### PR TITLE
Introduce `buffer.c` to compile output into buffer instead of stdout

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -1,0 +1,76 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "include/buffer.h"
+
+void init_buffer(buffer* buffer) {
+  buffer->capacity = 1024;
+  buffer->size = 0;
+  buffer->value = malloc(buffer->capacity * sizeof(char));
+
+  if (buffer->value) {
+    buffer->value[0] = '\0';
+  }
+}
+
+void buffer_append(buffer* buffer, const char* text) {
+  size_t text_length = strlen(text);
+
+  if (buffer->size + text_length >= buffer->capacity) {
+    size_t new_capacity = (buffer->size + text_length) * 2;
+    char* new_buffer = realloc(buffer->value, new_capacity);
+
+    if (new_buffer) {
+      buffer->value = new_buffer;
+      buffer->capacity = new_capacity;
+    } else {
+      printf("Couldn't allocate memory for new_buffer in buffer_append");
+      return;
+    }
+  }
+
+  strcat(buffer->value + buffer->size, text);
+  buffer->size += text_length;
+}
+
+void buffer_prepend(buffer* buffer, const char* text) {
+  if (text == NULL || text[0] == '\0') return;
+
+  size_t text_length = strlen(text);
+  size_t new_size = buffer->size + text_length;
+
+  if (new_size >= buffer->capacity) {
+    size_t new_capacity = new_size * 2;
+    buffer->value = realloc(buffer->value, new_capacity);
+    buffer->capacity = new_capacity;
+  }
+
+  memmove(buffer->value + text_length, buffer->value, buffer->size + 1);
+  memcpy(buffer->value, text, text_length);
+
+  buffer->size = new_size;
+  buffer->value[buffer->size] = '\0';
+}
+
+void buffer_concat(buffer* destination, buffer* source) {
+  if (source->size == 0) return;
+
+  size_t new_size = destination->size + source->size;
+
+  if (new_size >= destination->capacity) {
+    size_t new_capacity = new_size * 2;
+    destination->value = realloc(destination->value, new_capacity);
+    destination->capacity = new_capacity;
+  }
+
+  strcat(destination->value + destination->size, source->value);
+
+  destination->size = new_size;
+}
+
+void buffer_free(buffer* buffer) {
+  free(buffer->value);
+  buffer->value = NULL;
+  buffer->size = buffer->capacity = 0;
+}

--- a/src/erbx.c
+++ b/src/erbx.c
@@ -2,25 +2,31 @@
 #include "include/io.h"
 #include "include/lexer.h"
 #include "include/parser.h"
+#include "include/buffer.h"
 
 #include <stdlib.h>
 
-void erbx_compile(char* source) {
+void erbx_compile(char* source, buffer* output) {
   lexer_T* lexer = init_lexer(source);
   token_T* token = 0;
 
+  init_buffer(output);
+
   while ((token = lexer_next_token(lexer))->type != TOKEN_EOF) {
-    printf("%s\n", token_to_string(token));
+    buffer_append(output, token_to_string(token));
+    buffer_append(output, "\n");
   }
-  printf("%s\n", token_to_string(token));
+
+  buffer_append(output, token_to_string(token));
+  buffer_append(output, "\n");
 
   // parser_T* parser = init_parser(lexer);
   // AST_T* root = parser_parse(parser);
   // printf("%zu\n", root->children->size);
 }
 
-void erbx_compile_file(const char* filename) {
+void erbx_compile_file(const char* filename, buffer* output) {
   char* source = erbx_read_file(filename);
-  erbx_compile(source);
+  erbx_compile(source, output);
   free(source);
 }

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -1,0 +1,18 @@
+#ifndef ERBX_BUFFER_H
+#define ERBX_BUFFER_H
+
+#include <stdlib.h>
+
+typedef struct {
+  char* value;
+  size_t size;
+  size_t capacity;
+} buffer;
+
+void init_buffer(buffer* buffer);
+void buffer_append(buffer* buffer, const char* text);
+void buffer_prepend(buffer* buffer, const char* text);
+void buffer_concat(buffer* destination, buffer* source);
+void buffer_free(buffer* buffer);
+
+#endif

--- a/src/include/erbx.h
+++ b/src/include/erbx.h
@@ -1,7 +1,9 @@
 #ifndef ERBX_H
 #define ERBX_H
 
-void erbx_compile(char* source);
-void erbx_compile_file(const char* filename);
+#include "buffer.h"
+
+void erbx_compile(char* source, buffer* output);
+void erbx_compile_file(const char* filename, buffer* output);
 
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -1,4 +1,5 @@
 #include "include/erbx.h"
+#include "include/buffer.h"
 
 #include <stdio.h>
 
@@ -9,7 +10,13 @@ int main(int argc, char* argv[]) {
     return 1;
   }
 
-  erbx_compile_file(argv[1]);
+  buffer output;
+
+  erbx_compile_file(argv[1], &output);
+
+  printf("%s", output.value);
+
+  buffer_free(&output);
 
   return 0;
 }

--- a/test/test_tags.c
+++ b/test/test_tags.c
@@ -3,8 +3,11 @@
 
 TEST(test_basic_tag)
   char* html = "";
+  buffer output;
 
-  erbx_compile(html);
+  erbx_compile(html, &output);
+
+  buffer_free(&output);
 END
 
 TCase *tags_tests(void) {


### PR DESCRIPTION
This pull request adds a `buffer.c` file to compile the output into buffer instead of stdout.