### PR TITLE
Add `erbx_version()` in `erbx.c`

### DIFF
--- a/src/erbx.c
+++ b/src/erbx.c
@@ -3,6 +3,7 @@
 #include "include/lexer.h"
 #include "include/parser.h"
 #include "include/buffer.h"
+#include "include/version.h"
 
 #include <stdlib.h>
 
@@ -29,4 +30,8 @@ void erbx_compile_file(const char* filename, buffer* output) {
   char* source = erbx_read_file(filename);
   erbx_compile(source, output);
   free(source);
+}
+
+const char* erbx_version(void) {
+  return ERBX_VERSION;
 }

--- a/src/include/erbx.h
+++ b/src/include/erbx.h
@@ -5,5 +5,6 @@
 
 void erbx_compile(char* source, buffer* output);
 void erbx_compile_file(const char* filename, buffer* output);
+const char * erbx_version(void);
 
 #endif

--- a/src/include/version.h
+++ b/src/include/version.h
@@ -1,0 +1,6 @@
+#ifndef ERBX_VERSION_H
+#define ERBX_VERSION_H
+
+#define ERBX_VERSION "0.0.1"
+
+#endif

--- a/test/main.c
+++ b/test/main.c
@@ -3,12 +3,14 @@
 
 TCase *tags_tests(void);
 TCase *token_tests(void);
+TCase *erbx_tests(void);
 
 Suite *erbx_suite(void) {
   Suite *suite = suite_create("ERBX Suite");
 
   suite_add_tcase(suite, token_tests());
   suite_add_tcase(suite, tags_tests());
+  suite_add_tcase(suite, erbx_tests());
 
   return suite;
 }

--- a/test/test_erbx.c
+++ b/test/test_erbx.c
@@ -1,0 +1,14 @@
+#include "include/test.h"
+#include "../src/include/erbx.h"
+
+TEST(test_erbx_version)
+  ck_assert_str_eq(erbx_version(), "0.0.1");
+END
+
+TCase *erbx_tests(void) {
+  TCase *erbx = tcase_create("ERBX");
+
+  tcase_add_test(erbx, test_erbx_version);
+
+  return erbx;
+}


### PR DESCRIPTION
Add a `erbx_version()` function to `erbx.c` so the built library can expose its own version, this will also help with maintaining the language binding so they can rely on the version number from the C project.