### PR TITLE
Add `buffer.c` helper functions and make API more constant

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -4,9 +4,9 @@
 
 #include "include/buffer.h"
 
-void init_buffer(buffer* buffer) {
+void buffer_init(buffer_T* buffer) {
   buffer->capacity = 1024;
-  buffer->size = 0;
+  buffer->length = 0;
   buffer->value = malloc(buffer->capacity * sizeof(char));
 
   if (buffer->value) {
@@ -14,11 +14,27 @@ void init_buffer(buffer* buffer) {
   }
 }
 
-void buffer_append(buffer* buffer, const char* text) {
+char* buffer_value(buffer_T* buffer) {
+  return buffer->value;
+}
+
+size_t buffer_length(buffer_T* buffer) {
+  return buffer->length;
+}
+
+size_t buffer_capacity(buffer_T* buffer) {
+  return buffer->capacity;
+}
+
+size_t buffer_sizeof(void) {
+  return sizeof(buffer_T);
+}
+
+void buffer_append(buffer_T* buffer, const char* text) {
   size_t text_length = strlen(text);
 
-  if (buffer->size + text_length >= buffer->capacity) {
-    size_t new_capacity = (buffer->size + text_length) * 2;
+  if (buffer->length + text_length >= buffer->capacity) {
+    size_t new_capacity = (buffer->length + text_length) * 2;
     char* new_buffer = realloc(buffer->value, new_capacity);
 
     if (new_buffer) {
@@ -30,47 +46,47 @@ void buffer_append(buffer* buffer, const char* text) {
     }
   }
 
-  strcat(buffer->value + buffer->size, text);
-  buffer->size += text_length;
+  strcat(buffer->value + buffer->length, text);
+  buffer->length += text_length;
 }
 
-void buffer_prepend(buffer* buffer, const char* text) {
+void buffer_prepend(buffer_T* buffer, const char* text) {
   if (text == NULL || text[0] == '\0') return;
 
   size_t text_length = strlen(text);
-  size_t new_size = buffer->size + text_length;
+  size_t new_length = buffer->length + text_length;
 
-  if (new_size >= buffer->capacity) {
-    size_t new_capacity = new_size * 2;
+  if (new_length >= buffer->capacity) {
+    size_t new_capacity = new_length * 2;
     buffer->value = realloc(buffer->value, new_capacity);
     buffer->capacity = new_capacity;
   }
 
-  memmove(buffer->value + text_length, buffer->value, buffer->size + 1);
+  memmove(buffer->value + text_length, buffer->value, buffer->length + 1);
   memcpy(buffer->value, text, text_length);
 
-  buffer->size = new_size;
-  buffer->value[buffer->size] = '\0';
+  buffer->length = new_length;
+  buffer->value[buffer->length] = '\0';
 }
 
-void buffer_concat(buffer* destination, buffer* source) {
-  if (source->size == 0) return;
+void buffer_concat(buffer_T* destination, buffer_T* source) {
+  if (source->length == 0) return;
 
-  size_t new_size = destination->size + source->size;
+  size_t new_length = destination->length + source->length;
 
-  if (new_size >= destination->capacity) {
-    size_t new_capacity = new_size * 2;
+  if (new_length >= destination->capacity) {
+    size_t new_capacity = new_length * 2;
     destination->value = realloc(destination->value, new_capacity);
     destination->capacity = new_capacity;
   }
 
-  strcat(destination->value + destination->size, source->value);
+  strcat(destination->value + destination->length, source->value);
 
-  destination->size = new_size;
+  destination->length = new_length;
 }
 
-void buffer_free(buffer* buffer) {
+void buffer_free(buffer_T* buffer) {
   free(buffer->value);
   buffer->value = NULL;
-  buffer->size = buffer->capacity = 0;
+  buffer->length = buffer->capacity = 0;
 }

--- a/src/erbx.c
+++ b/src/erbx.c
@@ -7,11 +7,11 @@
 
 #include <stdlib.h>
 
-void erbx_compile(char* source, buffer* output) {
+void erbx_compile(char* source, buffer_T* output) {
   lexer_T* lexer = init_lexer(source);
   token_T* token = 0;
 
-  init_buffer(output);
+  buffer_init(output);
 
   while ((token = lexer_next_token(lexer))->type != TOKEN_EOF) {
     buffer_append(output, token_to_string(token));
@@ -26,7 +26,7 @@ void erbx_compile(char* source, buffer* output) {
   // printf("%zu\n", root->children->size);
 }
 
-void erbx_compile_file(const char* filename, buffer* output) {
+void erbx_compile_file(const char* filename, buffer_T* output) {
   char* source = erbx_read_file(filename);
   erbx_compile(source, output);
   free(source);

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -3,16 +3,22 @@
 
 #include <stdlib.h>
 
-typedef struct {
+typedef struct BUFFER_STRUCT {
   char* value;
-  size_t size;
+  size_t length;
   size_t capacity;
-} buffer;
+} buffer_T;
 
-void init_buffer(buffer* buffer);
-void buffer_append(buffer* buffer, const char* text);
-void buffer_prepend(buffer* buffer, const char* text);
-void buffer_concat(buffer* destination, buffer* source);
-void buffer_free(buffer* buffer);
+void buffer_init(buffer_T* buffer);
+void buffer_append(buffer_T* buffer, const char* text);
+void buffer_prepend(buffer_T* buffer, const char* text);
+void buffer_concat(buffer_T* destination, buffer_T* source);
+void buffer_free(buffer_T* buffer);
+
+char* buffer_value(buffer_T* buffer);
+
+size_t buffer_length(buffer_T* buffer);
+size_t buffer_capacity(buffer_T* buffer);
+size_t buffer_sizeof(void);
 
 #endif

--- a/src/include/erbx.h
+++ b/src/include/erbx.h
@@ -3,8 +3,8 @@
 
 #include "buffer.h"
 
-void erbx_compile(char* source, buffer* output);
-void erbx_compile_file(const char* filename, buffer* output);
+void erbx_compile(char* source, buffer_T* output);
+void erbx_compile_file(const char* filename, buffer_T* output);
 const char * erbx_version(void);
 
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -10,7 +10,7 @@ int main(int argc, char* argv[]) {
     return 1;
   }
 
-  buffer output;
+  buffer_T output;
 
   erbx_compile_file(argv[1], &output);
 

--- a/test/test_tags.c
+++ b/test/test_tags.c
@@ -3,7 +3,7 @@
 
 TEST(test_empty_file)
   char* html = "";
-  buffer output;
+  buffer_T output;
 
   erbx_compile(html, &output);
 
@@ -14,7 +14,7 @@ END
 
 TEST(test_basic_tag)
   char* html = "<html></html>";
-  buffer output;
+  buffer_T output;
 
   erbx_compile(html, &output);
 
@@ -34,7 +34,7 @@ END
 
 TEST(test_basic_void_tag)
   char* html = "<img />";
-  buffer output;
+  buffer_T output;
 
   erbx_compile(html, &output);
 
@@ -51,7 +51,7 @@ END
 
 TEST(test_namespaced_tag)
   char* html = "<ns:table></ns:table>";
-  buffer output;
+  buffer_T output;
 
   erbx_compile(html, &output);
 
@@ -71,7 +71,7 @@ END
 
 TEST(test_text_content)
   char* html = "<h1>Hello World</h1>";
-  buffer output;
+  buffer_T output;
 
   erbx_compile(html, &output);
 
@@ -92,7 +92,7 @@ END
 
 TEST(test_attribute_value_double_quotes)
   char* html = "<img value=\"hello world\" />";
-  buffer output;
+  buffer_T output;
 
   erbx_compile(html, &output);
 
@@ -114,7 +114,7 @@ END
 
 TEST(test_attribute_value_single_quotes)
   char* html = "<img value='hello world' />";
-  buffer output;
+  buffer_T output;
 
   erbx_compile(html, &output);
 
@@ -136,7 +136,7 @@ END
 
 // TEST(test_attribute_value_no_quotes)
 //   char* html = "<img value=hello />";
-//   buffer output;
+//   buffer_T output;
 //
 //   erbx_compile(html, &output);
 //
@@ -156,7 +156,7 @@ END
 
 TEST(test_attribute_value_empty_double_quotes)
   char* html = "<img value=\"\" />";
-  buffer output;
+  buffer_T output;
 
   erbx_compile(html, &output);
 
@@ -178,7 +178,7 @@ END
 
 TEST(test_attribute_value_empty_single_quotes)
   char* html = "<img value='' />";
-  buffer output;
+  buffer_T output;
 
   erbx_compile(html, &output);
 
@@ -200,7 +200,7 @@ END
 
 TEST(test_boolean_attribute)
   char* html = "<img required />";
-  buffer output;
+  buffer_T output;
 
   erbx_compile(html, &output);
 


### PR DESCRIPTION
This pull request makes `buffer.c` more consistent by:

* naming the buffer struct in `buffer.h` `BUFFER_STRUCT`
* renaming `init_buffer` to `buffer_init` 
* renaming `buffer->size` to `buffer->length`
* renaming `buffer` to `buffer_T`
* adding and exposing `buffer_value`, `buffer_length`, `buffer_capacity` and `buffer_sizeof` helper functions so we can call them from the language bindings later