### PR TITLE
Use `*_init()` convention for initialize functions

### DIFF
--- a/src/ast.c
+++ b/src/ast.c
@@ -2,10 +2,10 @@
 
 #include <stdlib.h>
 
-AST_T* init_ast(int type) {
+AST_T* ast_init(int type) {
   AST_T* ast = calloc(1, sizeof(struct AST_STRUCT));
   ast->type = type;
-  ast->children = init_list(sizeof(struct AST_STRUCT));
+  ast->children = list_init(sizeof(struct AST_STRUCT));
 
   return ast;
 }

--- a/src/erbx.c
+++ b/src/erbx.c
@@ -8,7 +8,7 @@
 #include <stdlib.h>
 
 void erbx_compile(char* source, buffer_T* output) {
-  lexer_T* lexer = init_lexer(source);
+  lexer_T* lexer = lexer_init(source);
   token_T* token = 0;
 
   buffer_init(output);
@@ -21,7 +21,7 @@ void erbx_compile(char* source, buffer_T* output) {
   buffer_append(output, token_to_string(token));
   buffer_append(output, "\n");
 
-  // parser_T* parser = init_parser(lexer);
+  // parser_T* parser = parser_init(lexer);
   // AST_T* root = parser_parse(parser);
   // printf("%zu\n", root->children->size);
 }

--- a/src/include/ast.h
+++ b/src/include/ast.h
@@ -24,6 +24,6 @@ typedef struct AST_STRUCT {
   int int_value;
 } AST_T;
 
-AST_T* init_ast(int type);
+AST_T* ast_init(int type);
 
 #endif

--- a/src/include/lexer.h
+++ b/src/include/lexer.h
@@ -26,7 +26,7 @@ typedef struct LEXER_STRUCT {
   } state;
 } lexer_T;
 
-lexer_T* init_lexer(char* src);
+lexer_T* lexer_init(char* src);
 
 void lexer_skip_whitespace(lexer_T* lexer);
 void lexer_advance(lexer_T* lexer);

--- a/src/include/list.h
+++ b/src/include/list.h
@@ -9,7 +9,7 @@ typedef struct LIST_STRUCT {
   size_t item_size;
 } list_T;
 
-list_T* init_list(size_t item_size);
+list_T* list_init(size_t item_size);
 void list_push(list_T* list, void* item);
 
 #endif

--- a/src/include/parser.h
+++ b/src/include/parser.h
@@ -9,7 +9,7 @@ typedef struct PARSER_STRUCT {
   token_T* token;
 } parser_T;
 
-parser_T* init_parser(lexer_T* lexer);
+parser_T* parser_init(lexer_T* lexer);
 token_T* parser_consume(parser_T* parser, int type);
 AST_T* parser_parse(parser_T* parser);
 

--- a/src/include/token.h
+++ b/src/include/token.h
@@ -25,7 +25,7 @@ typedef struct TOKEN_STRUCT {
   } type;
 } token_T;
 
-token_T* init_token(char* value, int type);
+token_T* token_init(char* value, int type);
 char* token_to_string(token_T* token);
 const char* token_type_to_string(int type);
 

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -5,7 +5,7 @@
 #include <stdlib.h>
 #include <ctype.h>
 
-lexer_T* init_lexer(char* source) {
+lexer_T* lexer_init(char* source) {
   lexer_T* lexer = calloc(1, sizeof(struct LEXER_STRUCT));
 
   lexer->state = STATE_NONE;
@@ -51,7 +51,7 @@ token_T* lexer_advance_current(lexer_T* lexer, int type) {
   value[0] = lexer->current_character;
   value[1] = '\0';
 
-  token_T* token = init_token(value, type);
+  token_T* token = token_init(value, type);
   lexer_advance(lexer);
 
   return token;
@@ -70,7 +70,7 @@ token_T* lexer_parse_newline(lexer_T* lexer) {
 
   lexer_advance(lexer);
 
-  return init_token(value, TOKEN_NEWLINE);
+  return token_init(value, TOKEN_NEWLINE);
 }
 
 token_T* lexer_parse_whitespace(lexer_T* lexer) {
@@ -82,7 +82,7 @@ token_T* lexer_parse_whitespace(lexer_T* lexer) {
     lexer_advance(lexer);
   }
 
-  return init_token(value, TOKEN_WHITESPACE);
+  return token_init(value, TOKEN_WHITESPACE);
 }
 
 token_T* lexer_parse_tag_name(lexer_T* lexer) {
@@ -94,7 +94,7 @@ token_T* lexer_parse_tag_name(lexer_T* lexer) {
     lexer_advance(lexer);
   }
 
-  return init_token(value, TOKEN_TAG_NAME);
+  return token_init(value, TOKEN_TAG_NAME);
 }
 
 token_T* lexer_parse_attribute_name(lexer_T* lexer) {
@@ -115,7 +115,7 @@ token_T* lexer_parse_attribute_name(lexer_T* lexer) {
     lexer->state = STATE_ATTRIBUTE_START;
   }
 
-  return init_token(value, TOKEN_ATTRIBUTE_NAME);
+  return token_init(value, TOKEN_ATTRIBUTE_NAME);
 }
 
 token_T* lexer_parse_attribute_value(lexer_T* lexer) {
@@ -128,7 +128,7 @@ token_T* lexer_parse_attribute_value(lexer_T* lexer) {
     lexer_advance(lexer);
   }
 
-  return init_token(value, TOKEN_ATTRIBUTE_VALUE);
+  return token_init(value, TOKEN_ATTRIBUTE_VALUE);
 }
 
 token_T* lexer_parse_text_content(lexer_T* lexer) {
@@ -140,7 +140,7 @@ token_T* lexer_parse_text_content(lexer_T* lexer) {
     lexer_advance(lexer);
   }
 
-  return init_token(value, TOKEN_TEXT_CONTENT);
+  return token_init(value, TOKEN_TEXT_CONTENT);
 }
 
 token_T* lexer_next_token(lexer_T* lexer) {
@@ -159,11 +159,11 @@ token_T* lexer_next_token(lexer_T* lexer) {
           case '<': {
             if (lexer_peek(lexer, 1) == '/') {
               lexer->state = STATE_START_TAG_START;
-              return lexer_advance_with(lexer, lexer_advance_with(lexer, init_token("</", TOKEN_END_TAG_START)));
+              return lexer_advance_with(lexer, lexer_advance_with(lexer, token_init("</", TOKEN_END_TAG_START)));
             }
 
             lexer->state = STATE_START_TAG_START;
-            return lexer_advance_with(lexer, init_token("<", TOKEN_START_TAG_START));
+            return lexer_advance_with(lexer, token_init("<", TOKEN_START_TAG_START));
           } break;
 
 
@@ -224,7 +224,7 @@ token_T* lexer_next_token(lexer_T* lexer) {
           case '/': {
             if (lexer_peek(lexer, 1) == '>') {
               lexer->state = STATE_NONE;
-              return lexer_advance_with(lexer, lexer_advance_with(lexer, init_token("/>", TOKEN_START_TAG_END_VOID)));
+              return lexer_advance_with(lexer, lexer_advance_with(lexer, token_init("/>", TOKEN_START_TAG_END_VOID)));
             } else {
               // TODO: raise
             }
@@ -245,10 +245,10 @@ token_T* lexer_next_token(lexer_T* lexer) {
         if (lexer->current_character == '<') {
           if (lexer_peek(lexer, 1) == '/') {
             lexer->state = STATE_END_TAG_START;
-            return lexer_advance_with(lexer, lexer_advance_with(lexer, init_token("</", TOKEN_END_TAG_START)));
+            return lexer_advance_with(lexer, lexer_advance_with(lexer, token_init("</", TOKEN_END_TAG_START)));
           } else {
             lexer->state = STATE_START_TAG_START;
-            return lexer_advance_with(lexer, init_token("<", TOKEN_START_TAG_START));
+            return lexer_advance_with(lexer, token_init("<", TOKEN_START_TAG_START));
           }
         } else {
           return lexer_parse_text_content(lexer);
@@ -273,7 +273,7 @@ token_T* lexer_next_token(lexer_T* lexer) {
       case STATE_ATTRIBUTE_VALUE: {
         if (lexer->current_character == '"' || lexer->current_character == '\'') {
           lexer->state = STATE_ATTRIBUTE_VALUE_END;
-          return init_token("\0", TOKEN_ATTRIBUTE_VALUE);
+          return token_init("\0", TOKEN_ATTRIBUTE_VALUE);
         }
 
         if (isalpha(lexer->current_character) || iswhitespace(lexer->current_character)) {
@@ -301,7 +301,7 @@ token_T* lexer_next_token(lexer_T* lexer) {
           }
         }
 
-        return init_token(0, TOKEN_ATTRIBUTE_VALUE);
+        return token_init(0, TOKEN_ATTRIBUTE_VALUE);
       } break;
       default: {
         if (iswhitespace(lexer->current_character) || isnewline(lexer->current_character)) {
@@ -311,5 +311,5 @@ token_T* lexer_next_token(lexer_T* lexer) {
     }
   }
 
-  return init_token("\0", TOKEN_EOF);
+  return token_init("\0", TOKEN_EOF);
 }

--- a/src/list.c
+++ b/src/list.c
@@ -1,6 +1,6 @@
 #include "include/list.h"
 
-list_T* init_list(size_t item_size) {
+list_T* list_init(size_t item_size) {
   list_T* list = calloc(1, sizeof(struct LIST_STRUCT));
   list->size = 0;
   list->item_size = item_size;

--- a/src/parser.c
+++ b/src/parser.c
@@ -5,7 +5,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-parser_T* init_parser(lexer_T* lexer) {
+parser_T* parser_init(lexer_T* lexer) {
   parser_T * parser = calloc(1, sizeof(struct PARSER_STRUCT));
   parser->lexer = lexer;
   parser->token = lexer_next_token(lexer);
@@ -31,5 +31,5 @@ AST_T* parser_parse(parser_T* parser) {
     }
   }
 
-  return init_ast(AST_NOOP);
+  return ast_init(AST_NOOP);
 }

--- a/src/token.c
+++ b/src/token.c
@@ -4,7 +4,7 @@
 #include <string.h>
 #include <stdio.h>
 
-token_T* init_token(char* value, int type) {
+token_T* token_init(char* value, int type) {
   token_T* token = calloc(1, sizeof(struct TOKEN_STRUCT));
   token->value = value;
   token->type = type;


### PR DESCRIPTION
This pull request unifies the convention from `init_*()` to `*_init()` for initializing "objects" throughout the codebase.