### PR TITLE
Add `range`, `start` and `end` locations to `token_T`

### DIFF
--- a/src/erbx.c
+++ b/src/erbx.c
@@ -1,6 +1,7 @@
 #include "include/erbx.h"
 #include "include/io.h"
 #include "include/lexer.h"
+#include "include/token.h"
 #include "include/parser.h"
 #include "include/buffer.h"
 #include "include/version.h"

--- a/src/include/lexer.h
+++ b/src/include/lexer.h
@@ -1,30 +1,10 @@
 #ifndef ERBX_LEXER_H
 #define ERBX_LEXER_H
 
-#include "token.h"
 #include <stdlib.h>
 
-typedef struct LEXER_STRUCT {
-  char* source;
-  size_t source_length;
-  char current_character;
-  unsigned int current_position;
-  enum {
-    STATE_NONE,
-    STATE_SINGLE_QUOTE,
-    STATE_DOUBLE_QUOTE,
-    STATE_START_TAG_START,
-    STATE_END_TAG_START,
-    STATE_END_TAG_END,
-    STATE_TAG_ATTRIBUTES,
-    STATE_ATTRIBUTE_START,
-    STATE_ATTRIBUTE_VALUE_START,
-    STATE_ATTRIBUTE_VALUE,
-    STATE_ATTRIBUTE_VALUE_END,
-    STATE_ELEMENT_CHILDREN,
-    STATE_ERB_OPEN,
-  } state;
-} lexer_T;
+#include "lexer_struct.h"
+#include "token_struct.h"
 
 lexer_T* lexer_init(char* src);
 
@@ -34,7 +14,6 @@ char lexer_peek(lexer_T* lexer, int offset);
 char lexer_backtrack(lexer_T* lexer, int offset);
 
 token_T* lexer_advance_current(lexer_T* lexer, int type);
-token_T* lexer_advance_with(lexer_T* lexer, token_T* token);
 token_T* lexer_next_token(lexer_T* lexer);
 token_T* lexer_parse_attribute_name(lexer_T* lexer);
 token_T* lexer_parse_attribute_value(lexer_T* lexer);

--- a/src/include/lexer_struct.h
+++ b/src/include/lexer_struct.h
@@ -1,0 +1,30 @@
+#ifndef ERBX_LEXER_STRUCT_H
+#define ERBX_LEXER_STRUCT_H
+
+#include <stdlib.h>
+
+typedef struct LEXER_STRUCT {
+  char* source;
+  size_t source_length;
+  char current_character;
+  unsigned int current_position;
+  unsigned int current_line;
+  unsigned int current_column;
+  enum {
+    STATE_NONE,
+    STATE_SINGLE_QUOTE,
+    STATE_DOUBLE_QUOTE,
+    STATE_START_TAG_START,
+    STATE_END_TAG_START,
+    STATE_END_TAG_END,
+    STATE_TAG_ATTRIBUTES,
+    STATE_ATTRIBUTE_START,
+    STATE_ATTRIBUTE_VALUE_START,
+    STATE_ATTRIBUTE_VALUE,
+    STATE_ATTRIBUTE_VALUE_END,
+    STATE_ELEMENT_CHILDREN,
+    STATE_ERB_OPEN,
+  } state;
+} lexer_T;
+
+#endif

--- a/src/include/location.h
+++ b/src/include/location.h
@@ -1,0 +1,20 @@
+#ifndef ERBX_LOCATION_H
+#define ERBX_LOCATION_H
+
+#include <stdlib.h>
+
+typedef struct LOCATION_STRUCT {
+  int line;
+  int column;
+} location_T;
+
+location_T* location_init(int line, int column);
+
+int location_line(location_T* location);
+int location_column(location_T* location);
+
+size_t location_sizeof(void);
+
+void location_free(location_T* location);
+
+#endif

--- a/src/include/range.h
+++ b/src/include/range.h
@@ -1,0 +1,18 @@
+#ifndef ERBX_RANGE_H
+#define ERBX_RANGE_H
+
+#include <stdlib.h>
+
+typedef struct RANGE_STRUCT {
+  int start;
+  int end;
+} range_T;
+
+range_T* range_init(int start, int end);
+
+int range_start(range_T* range);
+int range_end(range_T* range);
+
+size_t range_sizeof(void);
+
+#endif

--- a/src/include/token.h
+++ b/src/include/token.h
@@ -3,31 +3,10 @@
 
 #include <stdlib.h>
 
-typedef struct TOKEN_STRUCT {
-  char* value;
-  enum {
-    TOKEN_ATTRIBUTE_NAME,
-    TOKEN_ATTRIBUTE_VALUE,
-    TOKEN_DOUBLE_QUOTE,
-    TOKEN_END_TAG_END,
-    TOKEN_END_TAG_START,
-    TOKEN_EOF,
-    TOKEN_EQUALS,
-    TOKEN_ID,
-    TOKEN_NEWLINE,
-    TOKEN_SINGLE_QUOTE,
-    TOKEN_SPACE,
-    TOKEN_START_TAG_END_VOID,
-    TOKEN_START_TAG_END,
-    TOKEN_START_TAG_START,
-    TOKEN_TAG_END,
-    TOKEN_TAG_NAME,
-    TOKEN_TEXT_CONTENT,
-    TOKEN_WHITESPACE,
-  } type;
-} token_T;
+#include "lexer_struct.h"
+#include "token_struct.h"
 
-token_T* token_init(char* value, int type);
+token_T* token_init(char* value, int type, lexer_T* lexer);
 char* token_to_string(token_T* token);
 const char* token_type_to_string(int type);
 

--- a/src/include/token_struct.h
+++ b/src/include/token_struct.h
@@ -1,0 +1,36 @@
+#ifndef ERBX_TOKEN_STRUCT_H
+#define ERBX_TOKEN_STRUCT_H
+
+#include <stdlib.h>
+
+#include "location.h"
+#include "range.h"
+
+typedef struct TOKEN_STRUCT {
+  char* value;
+  range_T* range;
+  location_T* start;
+  location_T* end;
+  enum {
+    TOKEN_ATTRIBUTE_NAME,
+    TOKEN_ATTRIBUTE_VALUE,
+    TOKEN_DOUBLE_QUOTE,
+    TOKEN_END_TAG_END,
+    TOKEN_END_TAG_START,
+    TOKEN_EOF,
+    TOKEN_EQUALS,
+    TOKEN_ID,
+    TOKEN_NEWLINE,
+    TOKEN_SINGLE_QUOTE,
+    TOKEN_SPACE,
+    TOKEN_START_TAG_END_VOID,
+    TOKEN_START_TAG_END,
+    TOKEN_START_TAG_START,
+    TOKEN_TAG_END,
+    TOKEN_TAG_NAME,
+    TOKEN_TEXT_CONTENT,
+    TOKEN_WHITESPACE,
+  } type;
+} token_T;
+
+#endif

--- a/src/include/util.h
+++ b/src/include/util.h
@@ -1,0 +1,13 @@
+#ifndef ERBX_UTIL_H
+#define ERBX_UTIL_H
+
+int iswhitespace(int character);
+int isnewline(int character);
+
+int count_in_string(const char *string, char character);
+int count_newlines(const char *string);
+
+char* replace_char(char *string, char find, char replace);
+char* escape_newlines(const char* input);
+
+#endif

--- a/src/location.c
+++ b/src/location.c
@@ -1,0 +1,25 @@
+#include "include/location.h"
+
+size_t location_sizeof(void) {
+  return sizeof(location_T);
+}
+
+location_T* location_init(int line, int column) {
+  location_T* location = (location_T*) malloc(location_sizeof());
+  location->line = line;
+  location->column = column;
+
+  return location;
+}
+
+int location_line(location_T* location) {
+  return location->line;
+}
+
+int location_column(location_T* location) {
+  return location->column;
+}
+
+void location_free(location_T* location) {
+  free(location);
+}

--- a/src/parser.c
+++ b/src/parser.c
@@ -1,5 +1,6 @@
 #include "include/ast.h"
 #include "include/parser.h"
+#include "include/token.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/range.c
+++ b/src/range.c
@@ -1,0 +1,22 @@
+#include "include/range.h"
+
+size_t range_sizeof(void) {
+  return sizeof(range_T);
+}
+
+range_T* range_init(int start, int end) {
+  range_T* range = calloc(1, range_sizeof());
+
+  range->start = start;
+  range->end = end;
+
+  return range;
+}
+
+int range_start(range_T* range) {
+  return range->start;
+}
+
+int range_end(range_T* range) {
+  return range->end;
+}

--- a/src/util.c
+++ b/src/util.c
@@ -1,0 +1,62 @@
+#include <stdlib.h>
+#include <string.h>
+
+#include "include/util.h"
+
+int iswhitespace(int character) {
+  return character == ' ' || character == '\t';
+}
+
+int isnewline(int character) {
+  return character == 13 || character == 10;
+}
+
+int count_in_string(const char *string, char character) {
+  int count = 0;
+
+  while (*string != '\0') {
+    if (*string == character) {
+      count++;
+    }
+
+    string++;
+  }
+
+  return count;
+}
+
+int count_newlines(const char *string) {
+  return count_in_string(string, '\n');
+}
+
+char* replace_char(char *string, char find, char replace) {
+  while (*string != '\0') {
+    if (*string == find) {
+      *string = replace;
+    }
+
+    string++;
+  }
+
+  return string;
+}
+
+char* escape_newlines(const char* input) {
+  char* output = (char*) calloc(strlen(input) * 2 + 1, sizeof(char));
+  char* orig_output = output;
+
+  while (*input) {
+    if (*input == '\n') {
+      *output++ = '\\';
+      *output++ = 'n';
+    } else {
+      *output++ = *input;
+    }
+
+    input++;
+  }
+
+  *output = '\0';
+
+  return orig_output;
+}

--- a/test/test_tags.c
+++ b/test/test_tags.c
@@ -7,7 +7,7 @@ TEST(test_empty_file)
 
   erbx_compile(html, &output);
 
-  ck_assert_str_eq(output.value, "<type='TOKEN_EOF', int_type='5', value=''>\n");
+  ck_assert_str_eq(output.value, "#<Token type=TOKEN_EOF value='' range=[0, 0] start=1:0 end=1:0>\n");
 
   buffer_free(&output);
 END
@@ -20,13 +20,13 @@ TEST(test_basic_tag)
 
   ck_assert_str_eq(
     output.value,
-    "<type='TOKEN_START_TAG_START', int_type='13', value='<'>\n"
-    "<type='TOKEN_TAG_NAME', int_type='15', value='html'>\n"
-    "<type='TOKEN_START_TAG_END', int_type='12', value='>'>\n"
-    "<type='TOKEN_END_TAG_START', int_type='4', value='</'>\n"
-    "<type='TOKEN_TAG_NAME', int_type='15', value='html'>\n"
-    "<type='TOKEN_END_TAG_END', int_type='3', value='>'>\n"
-    "<type='TOKEN_EOF', int_type='5', value=''>\n"
+    "#<Token type=TOKEN_START_TAG_START value='<' range=[0, 1] start=1:0 end=1:1>\n"
+    "#<Token type=TOKEN_TAG_NAME value='html' range=[1, 5] start=1:1 end=1:5>\n"
+    "#<Token type=TOKEN_START_TAG_END value='>' range=[5, 6] start=1:5 end=1:6>\n"
+    "#<Token type=TOKEN_END_TAG_START value='</' range=[6, 8] start=1:6 end=1:8>\n"
+    "#<Token type=TOKEN_TAG_NAME value='html' range=[8, 12] start=1:8 end=1:12>\n"
+    "#<Token type=TOKEN_END_TAG_END value='>' range=[12, 13] start=1:12 end=1:13>\n"
+    "#<Token type=TOKEN_EOF value='' range=[13, 13] start=1:13 end=1:13>\n"
   );
 
   buffer_free(&output);
@@ -40,10 +40,10 @@ TEST(test_basic_void_tag)
 
   ck_assert_str_eq(
     output.value,
-    "<type='TOKEN_START_TAG_START', int_type='13', value='<'>\n"
-    "<type='TOKEN_TAG_NAME', int_type='15', value='img'>\n"
-    "<type='TOKEN_START_TAG_END_VOID', int_type='11', value='/>'>\n"
-    "<type='TOKEN_EOF', int_type='5', value=''>\n"
+    "#<Token type=TOKEN_START_TAG_START value='<' range=[0, 1] start=1:0 end=1:1>\n"
+    "#<Token type=TOKEN_TAG_NAME value='img' range=[1, 4] start=1:1 end=1:4>\n"
+    "#<Token type=TOKEN_START_TAG_END_VOID value='/>' range=[5, 7] start=1:5 end=1:7>\n"
+    "#<Token type=TOKEN_EOF value='' range=[7, 7] start=1:7 end=1:7>\n"
   );
 
   buffer_free(&output);
@@ -57,13 +57,13 @@ TEST(test_namespaced_tag)
 
   ck_assert_str_eq(
     output.value,
-    "<type='TOKEN_START_TAG_START', int_type='13', value='<'>\n"
-    "<type='TOKEN_TAG_NAME', int_type='15', value='ns:table'>\n"
-    "<type='TOKEN_START_TAG_END', int_type='12', value='>'>\n"
-    "<type='TOKEN_END_TAG_START', int_type='4', value='</'>\n"
-    "<type='TOKEN_TAG_NAME', int_type='15', value='ns:table'>\n"
-    "<type='TOKEN_END_TAG_END', int_type='3', value='>'>\n"
-    "<type='TOKEN_EOF', int_type='5', value=''>\n"
+    "#<Token type=TOKEN_START_TAG_START value='<' range=[0, 1] start=1:0 end=1:1>\n"
+    "#<Token type=TOKEN_TAG_NAME value='ns:table' range=[1, 9] start=1:1 end=1:9>\n"
+    "#<Token type=TOKEN_START_TAG_END value='>' range=[9, 10] start=1:9 end=1:10>\n"
+    "#<Token type=TOKEN_END_TAG_START value='</' range=[10, 12] start=1:10 end=1:12>\n"
+    "#<Token type=TOKEN_TAG_NAME value='ns:table' range=[12, 20] start=1:12 end=1:20>\n"
+    "#<Token type=TOKEN_END_TAG_END value='>' range=[20, 21] start=1:20 end=1:21>\n"
+    "#<Token type=TOKEN_EOF value='' range=[21, 21] start=1:21 end=1:21>\n"
   );
 
   buffer_free(&output);
@@ -77,14 +77,14 @@ TEST(test_text_content)
 
   ck_assert_str_eq(
     output.value,
-    "<type='TOKEN_START_TAG_START', int_type='13', value='<'>\n"
-    "<type='TOKEN_TAG_NAME', int_type='15', value='h1'>\n"
-    "<type='TOKEN_START_TAG_END', int_type='12', value='>'>\n"
-    "<type='TOKEN_TEXT_CONTENT', int_type='16', value='Hello World'>\n"
-    "<type='TOKEN_END_TAG_START', int_type='4', value='</'>\n"
-    "<type='TOKEN_TAG_NAME', int_type='15', value='h1'>\n"
-    "<type='TOKEN_END_TAG_END', int_type='3', value='>'>\n"
-    "<type='TOKEN_EOF', int_type='5', value=''>\n"
+    "#<Token type=TOKEN_START_TAG_START value='<' range=[0, 1] start=1:0 end=1:1>\n"
+    "#<Token type=TOKEN_TAG_NAME value='h1' range=[1, 3] start=1:1 end=1:3>\n"
+    "#<Token type=TOKEN_START_TAG_END value='>' range=[3, 4] start=1:3 end=1:4>\n"
+    "#<Token type=TOKEN_TEXT_CONTENT value='Hello World' range=[4, 15] start=1:4 end=1:15>\n"
+    "#<Token type=TOKEN_END_TAG_START value='</' range=[15, 17] start=1:15 end=1:17>\n"
+    "#<Token type=TOKEN_TAG_NAME value='h1' range=[17, 19] start=1:17 end=1:19>\n"
+    "#<Token type=TOKEN_END_TAG_END value='>' range=[19, 20] start=1:19 end=1:20>\n"
+    "#<Token type=TOKEN_EOF value='' range=[20, 20] start=1:20 end=1:20>\n"
   );
 
   buffer_free(&output);
@@ -98,15 +98,15 @@ TEST(test_attribute_value_double_quotes)
 
   ck_assert_str_eq(
     output.value,
-    "<type='TOKEN_START_TAG_START', int_type='13', value='<'>\n"
-    "<type='TOKEN_TAG_NAME', int_type='15', value='img'>\n"
-    "<type='TOKEN_ATTRIBUTE_NAME', int_type='0', value='value'>\n"
-    "<type='TOKEN_EQUALS', int_type='6', value='='>\n"
-    "<type='TOKEN_DOUBLE_QUOTE', int_type='2', value='\"'>\n"
-    "<type='TOKEN_ATTRIBUTE_VALUE', int_type='1', value='hello world'>\n"
-    "<type='TOKEN_DOUBLE_QUOTE', int_type='2', value='\"'>\n"
-    "<type='TOKEN_START_TAG_END_VOID', int_type='11', value='/>'>\n"
-    "<type='TOKEN_EOF', int_type='5', value=''>\n"
+    "#<Token type=TOKEN_START_TAG_START value='<' range=[0, 1] start=1:0 end=1:1>\n"
+    "#<Token type=TOKEN_TAG_NAME value='img' range=[1, 4] start=1:1 end=1:4>\n"
+    "#<Token type=TOKEN_ATTRIBUTE_NAME value='value' range=[5, 10] start=1:5 end=1:10>\n"
+    "#<Token type=TOKEN_EQUALS value='=' range=[10, 11] start=1:10 end=1:11>\n"
+    "#<Token type=TOKEN_DOUBLE_QUOTE value='\"' range=[11, 12] start=1:11 end=1:12>\n"
+    "#<Token type=TOKEN_ATTRIBUTE_VALUE value='hello world' range=[12, 23] start=1:12 end=1:23>\n"
+    "#<Token type=TOKEN_DOUBLE_QUOTE value='\"' range=[23, 24] start=1:23 end=1:24>\n"
+    "#<Token type=TOKEN_START_TAG_END_VOID value='/>' range=[25, 27] start=1:25 end=1:27>\n"
+    "#<Token type=TOKEN_EOF value='' range=[27, 27] start=1:27 end=1:27>\n"
   );
 
   buffer_free(&output);
@@ -120,15 +120,15 @@ TEST(test_attribute_value_single_quotes)
 
   ck_assert_str_eq(
     output.value,
-    "<type='TOKEN_START_TAG_START', int_type='13', value='<'>\n"
-    "<type='TOKEN_TAG_NAME', int_type='15', value='img'>\n"
-    "<type='TOKEN_ATTRIBUTE_NAME', int_type='0', value='value'>\n"
-    "<type='TOKEN_EQUALS', int_type='6', value='='>\n"
-    "<type='TOKEN_SINGLE_QUOTE', int_type='9', value='''>\n"
-    "<type='TOKEN_ATTRIBUTE_VALUE', int_type='1', value='hello world'>\n"
-    "<type='TOKEN_SINGLE_QUOTE', int_type='9', value='''>\n"
-    "<type='TOKEN_START_TAG_END_VOID', int_type='11', value='/>'>\n"
-    "<type='TOKEN_EOF', int_type='5', value=''>\n"
+    "#<Token type=TOKEN_START_TAG_START value='<' range=[0, 1] start=1:0 end=1:1>\n"
+    "#<Token type=TOKEN_TAG_NAME value='img' range=[1, 4] start=1:1 end=1:4>\n"
+    "#<Token type=TOKEN_ATTRIBUTE_NAME value='value' range=[5, 10] start=1:5 end=1:10>\n"
+    "#<Token type=TOKEN_EQUALS value='=' range=[10, 11] start=1:10 end=1:11>\n"
+    "#<Token type=TOKEN_SINGLE_QUOTE value=''' range=[11, 12] start=1:11 end=1:12>\n"
+    "#<Token type=TOKEN_ATTRIBUTE_VALUE value='hello world' range=[12, 23] start=1:12 end=1:23>\n"
+    "#<Token type=TOKEN_SINGLE_QUOTE value=''' range=[23, 24] start=1:23 end=1:24>\n"
+    "#<Token type=TOKEN_START_TAG_END_VOID value='/>' range=[25, 27] start=1:25 end=1:27>\n"
+    "#<Token type=TOKEN_EOF value='' range=[27, 27] start=1:27 end=1:27>\n"
   );
 
   buffer_free(&output);
@@ -142,13 +142,13 @@ END
 //
 //   ck_assert_str_eq(
 //     output.value,
-//     "<type='TOKEN_START_TAG_START', int_type='13', value='<'>\n"
-//     "<type='TOKEN_TAG_NAME', int_type='15', value='img'>\n"
-//     "<type='TOKEN_ATTRIBUTE_NAME', int_type='0', value='value'>\n"
-//     "<type='TOKEN_EQUALS', int_type='6', value='='>\n"
-//     "<type='TOKEN_ATTRIBUTE_VALUE', int_type='1', value='hello'>\n"
-//     "<type='TOKEN_START_TAG_END_VOID', int_type='11', value='/>'>\n"
-//     "<type='TOKEN_EOF', int_type='5', value=''>\n"
+//     "#<Token type=TOKEN_START_TAG_START value='<' range=[0, 1] start=1:0 end=1:1>\n"
+//     "#<Token type=TOKEN_TAG_NAME value='img' range=[1, 4] start=1:1 end=1:4>\n"
+//     "#<Token type=TOKEN_ATTRIBUTE_NAME value='value' range=[5, 10] start=1:5 end=1:10>\n"
+//     "#<Token type=TOKEN_EQUALS value='=' range=[10, 11] start=1:10 end=1:11>\n"
+//     "#<Token type=TOKEN_ATTRIBUTE_VALUE value='hello' range=[11, 17] start=1:11 end=1:17>\n"
+//     "#<Token type=TOKEN_START_TAG_END_VOID value='/>' range=[17, 19] start=1:17 end=1:19>\n"
+//     "#<Token type=TOKEN_EOF value='' range=[19, 19] start=1:19 end=1:19>\n"
 //   );
 //
 //   buffer_free(&output);
@@ -162,15 +162,15 @@ TEST(test_attribute_value_empty_double_quotes)
 
   ck_assert_str_eq(
     output.value,
-    "<type='TOKEN_START_TAG_START', int_type='13', value='<'>\n"
-    "<type='TOKEN_TAG_NAME', int_type='15', value='img'>\n"
-    "<type='TOKEN_ATTRIBUTE_NAME', int_type='0', value='value'>\n"
-    "<type='TOKEN_EQUALS', int_type='6', value='='>\n"
-    "<type='TOKEN_DOUBLE_QUOTE', int_type='2', value='\"'>\n"
-    "<type='TOKEN_ATTRIBUTE_VALUE', int_type='1', value=''>\n"
-    "<type='TOKEN_DOUBLE_QUOTE', int_type='2', value='\"'>\n"
-    "<type='TOKEN_START_TAG_END_VOID', int_type='11', value='/>'>\n"
-    "<type='TOKEN_EOF', int_type='5', value=''>\n"
+    "#<Token type=TOKEN_START_TAG_START value='<' range=[0, 1] start=1:0 end=1:1>\n"
+    "#<Token type=TOKEN_TAG_NAME value='img' range=[1, 4] start=1:1 end=1:4>\n"
+    "#<Token type=TOKEN_ATTRIBUTE_NAME value='value' range=[5, 10] start=1:5 end=1:10>\n"
+    "#<Token type=TOKEN_EQUALS value='=' range=[10, 11] start=1:10 end=1:11>\n"
+    "#<Token type=TOKEN_DOUBLE_QUOTE value='\"' range=[11, 12] start=1:11 end=1:12>\n"
+    "#<Token type=TOKEN_ATTRIBUTE_VALUE value='' range=[12, 12] start=1:12 end=1:12>\n"
+    "#<Token type=TOKEN_DOUBLE_QUOTE value='\"' range=[12, 13] start=1:12 end=1:13>\n"
+    "#<Token type=TOKEN_START_TAG_END_VOID value='/>' range=[14, 16] start=1:14 end=1:16>\n"
+    "#<Token type=TOKEN_EOF value='' range=[16, 16] start=1:16 end=1:16>\n"
   );
 
   buffer_free(&output);
@@ -184,15 +184,15 @@ TEST(test_attribute_value_empty_single_quotes)
 
   ck_assert_str_eq(
     output.value,
-    "<type='TOKEN_START_TAG_START', int_type='13', value='<'>\n"
-    "<type='TOKEN_TAG_NAME', int_type='15', value='img'>\n"
-    "<type='TOKEN_ATTRIBUTE_NAME', int_type='0', value='value'>\n"
-    "<type='TOKEN_EQUALS', int_type='6', value='='>\n"
-    "<type='TOKEN_SINGLE_QUOTE', int_type='9', value='''>\n"
-    "<type='TOKEN_ATTRIBUTE_VALUE', int_type='1', value=''>\n"
-    "<type='TOKEN_SINGLE_QUOTE', int_type='9', value='''>\n"
-    "<type='TOKEN_START_TAG_END_VOID', int_type='11', value='/>'>\n"
-    "<type='TOKEN_EOF', int_type='5', value=''>\n"
+    "#<Token type=TOKEN_START_TAG_START value='<' range=[0, 1] start=1:0 end=1:1>\n"
+    "#<Token type=TOKEN_TAG_NAME value='img' range=[1, 4] start=1:1 end=1:4>\n"
+    "#<Token type=TOKEN_ATTRIBUTE_NAME value='value' range=[5, 10] start=1:5 end=1:10>\n"
+    "#<Token type=TOKEN_EQUALS value='=' range=[10, 11] start=1:10 end=1:11>\n"
+    "#<Token type=TOKEN_SINGLE_QUOTE value=''' range=[11, 12] start=1:11 end=1:12>\n"
+    "#<Token type=TOKEN_ATTRIBUTE_VALUE value='' range=[12, 12] start=1:12 end=1:12>\n"
+    "#<Token type=TOKEN_SINGLE_QUOTE value=''' range=[12, 13] start=1:12 end=1:13>\n"
+    "#<Token type=TOKEN_START_TAG_END_VOID value='/>' range=[14, 16] start=1:14 end=1:16>\n"
+    "#<Token type=TOKEN_EOF value='' range=[16, 16] start=1:16 end=1:16>\n"
   );
 
   buffer_free(&output);
@@ -206,11 +206,11 @@ TEST(test_boolean_attribute)
 
   ck_assert_str_eq(
     output.value,
-    "<type='TOKEN_START_TAG_START', int_type='13', value='<'>\n"
-    "<type='TOKEN_TAG_NAME', int_type='15', value='img'>\n"
-    "<type='TOKEN_ATTRIBUTE_NAME', int_type='0', value='required'>\n"
-    "<type='TOKEN_START_TAG_END_VOID', int_type='11', value='/>'>\n"
-    "<type='TOKEN_EOF', int_type='5', value=''>\n"
+    "#<Token type=TOKEN_START_TAG_START value='<' range=[0, 1] start=1:0 end=1:1>\n"
+    "#<Token type=TOKEN_TAG_NAME value='img' range=[1, 4] start=1:1 end=1:4>\n"
+    "#<Token type=TOKEN_ATTRIBUTE_NAME value='required' range=[5, 13] start=1:5 end=1:13>\n"
+    "#<Token type=TOKEN_START_TAG_END_VOID value='/>' range=[14, 16] start=1:14 end=1:16>\n"
+    "#<Token type=TOKEN_EOF value='' range=[16, 16] start=1:16 end=1:16>\n"
   );
 
   buffer_free(&output);


### PR DESCRIPTION
This pull request adds `range.c` and `location.c` for tracking the ranges and locations of a token in a source document. 

Additionally, it adds `range`, `start` and `end` fields to the `token_T` struct for tracking that information on each token.