### PR TITLE
Add `lexer_error` to DRY up the error handling in the Lexer

### DIFF
--- a/src/lexer.c
+++ b/src/lexer.c
@@ -5,8 +5,8 @@
 
 #include <ctype.h>
 #include <stdio.h>
-#include <string.h>
 #include <stdnoreturn.h>
+#include <string.h>
 
 char* lexer_state_to_string(lexer_T* lexer) {
   switch (lexer->state) {
@@ -43,7 +43,12 @@ lexer_T* lexer_init(char* source) {
 }
 
 noreturn void lexer_error(lexer_T* lexer, const char* message) {
-  fprintf(stderr, "Lexer Error [character '%c', line %d, col %d]: %s\n", lexer->current_character, lexer->current_line, lexer->current_column, message);
+  fprintf(stderr,
+      "Lexer Error [character '%c', line %d, col %d]: %s\n",
+      lexer->current_character,
+      lexer->current_line,
+      lexer->current_column,
+      message);
   exit(1);
 }
 


### PR DESCRIPTION
This pull request improves error handling by introducing a new `lexer_error` function. This function standardizes error messages and replaces the previous `printf` and `exit` calls.