### PR TITLE
Add support for parsing HTML comments

### DIFF
--- a/test/parser/comments_test.rb
+++ b/test/parser/comments_test.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+module Parser
+  class CommentsTest < Minitest::Spec
+    include SnapshotUtils
+
+    test "HTML comment with padding whitespace" do
+      assert_parsed_snapshot(%(<!-- Hello World -->))
+    end
+
+    test "HTML comment with no whitespace" do
+      assert_parsed_snapshot(%(<!--Hello World-->))
+    end
+
+    test "HTML comment followed by html tag" do
+      assert_parsed_snapshot(%(<!--Hello World--><h1>Hello</h1>))
+    end
+
+    test "HTML comment followed by html tag with nested comment" do
+      assert_parsed_snapshot(%(
+        <!--Hello World-->
+        <h1><!-- Hello World --></h1>
+      ))
+    end
+  end
+end

--- a/test/snapshots/parser/comments_test/test_0001_HTML_comment_with_padding_whitespace_9cb56068ef4732067422a670d943c08e.txt
+++ b/test/snapshots/parser/comments_test/test_0001_HTML_comment_with_padding_whitespace_9cb56068ef4732067422a670d943c08e.txt
@@ -1,0 +1,7 @@
+@ DocumentNode (location: (0,0)-(0,0))
+├── name: ∅
+└── children: (1)
+    @ Comment (location: (0,0)-(0,0))
+    ├── name: " Hello World "
+    └── children: []
+

--- a/test/snapshots/parser/comments_test/test_0002_HTML_comment_with_no_whitespace_4644299a23e9ee76cdc970a26168b559.txt
+++ b/test/snapshots/parser/comments_test/test_0002_HTML_comment_with_no_whitespace_4644299a23e9ee76cdc970a26168b559.txt
@@ -1,0 +1,7 @@
+@ DocumentNode (location: (0,0)-(0,0))
+├── name: ∅
+└── children: (1)
+    @ Comment (location: (0,0)-(0,0))
+    ├── name: "Hello World"
+    └── children: []
+

--- a/test/snapshots/parser/comments_test/test_0003_HTML_comment_followed_by_html_tag_573b93df7df7d12ef12722008abfc7ee.txt
+++ b/test/snapshots/parser/comments_test/test_0003_HTML_comment_followed_by_html_tag_573b93df7df7d12ef12722008abfc7ee.txt
@@ -1,0 +1,28 @@
+@ DocumentNode (location: (0,0)-(0,0))
+├── name: ∅
+└── children: (2)
+    @ Comment (location: (0,0)-(0,0))
+    ├── name: "Hello World"
+    └── children: []
+
+    @ Element (location: (0,0)-(0,0))
+    ├── name: ∅
+    └── children: (3)
+        @ OpenTag (location: (0,0)-(0,0))
+        ├── name: "h1"
+        └── children: (1)
+            @ AttributeSet (location: (0,0)-(0,0))
+            ├── name: ∅
+            └── children: []
+
+        @ ElementBody (location: (0,0)-(0,0))
+        ├── name: ∅
+        └── children: (1)
+            @ TextContent (location: (0,0)-(0,0))
+            ├── name: "Hello"
+            └── children: []
+
+        @ CloseTag (location: (0,0)-(0,0))
+        ├── name: "h1"
+        └── children: []
+

--- a/test/snapshots/parser/comments_test/test_0004_HTML_comment_followed_by_html_tag_with_nested_comment_f4042eb3e6a5d62fcc86e4162fe10cf2.txt
+++ b/test/snapshots/parser/comments_test/test_0004_HTML_comment_followed_by_html_tag_with_nested_comment_f4042eb3e6a5d62fcc86e4162fe10cf2.txt
@@ -1,0 +1,40 @@
+@ DocumentNode (location: (0,0)-(0,0))
+├── name: ∅
+└── children: (5)
+    @ TextContent (location: (0,0)-(0,0))
+    ├── name: "\n        "
+    └── children: []
+
+    @ Comment (location: (0,0)-(0,0))
+    ├── name: "Hello World"
+    └── children: []
+
+    @ TextContent (location: (0,0)-(0,0))
+    ├── name: "\n        "
+    └── children: []
+
+    @ Element (location: (0,0)-(0,0))
+    ├── name: ∅
+    └── children: (3)
+        @ OpenTag (location: (0,0)-(0,0))
+        ├── name: "h1"
+        └── children: (1)
+            @ AttributeSet (location: (0,0)-(0,0))
+            ├── name: ∅
+            └── children: []
+
+        @ ElementBody (location: (0,0)-(0,0))
+        ├── name: ∅
+        └── children: (1)
+            @ Comment (location: (0,0)-(0,0))
+            ├── name: " Hello World "
+            └── children: []
+
+        @ CloseTag (location: (0,0)-(0,0))
+        ├── name: "h1"
+        └── children: []
+
+    @ TextContent (location: (0,0)-(0,0))
+    ├── name: "\n      "
+    └── children: []
+


### PR DESCRIPTION
This pull request introduces support for parsing HTML comments in the parser and includes corresponding tests and snapshots to verify the functionality. 