### PR TITLE
Parse ERB inside HTML Comments

### DIFF
--- a/test/parser/erb_test.rb
+++ b/test/parser/erb_test.rb
@@ -49,5 +49,9 @@ module Parser
     test "interpolate inside attribute value with static content around" do
       assert_parsed_snapshot(%(<h1 class="text-white <%= "bg-black" %> title"></h1>))
     end
+
+    test "interpolate inside comment" do
+      assert_parsed_snapshot(%(<!-- <%= "Comment" %> -->))
+    end
   end
 end

--- a/test/snapshots/parser/comments_test/test_0001_HTML_comment_with_padding_whitespace_9cb56068ef4732067422a670d943c08e.txt
+++ b/test/snapshots/parser/comments_test/test_0001_HTML_comment_with_padding_whitespace_9cb56068ef4732067422a670d943c08e.txt
@@ -2,6 +2,9 @@
 ├── name: ∅
 └── children: (1)
     @ Comment (location: (0,0)-(0,0))
-    ├── name: " Hello World "
-    └── children: []
+    ├── name: ∅
+    └── children: (1)
+        @ Literal (location: (0,0)-(0,0))
+        ├── name: " Hello World "
+        └── children: []
 

--- a/test/snapshots/parser/comments_test/test_0002_HTML_comment_with_no_whitespace_4644299a23e9ee76cdc970a26168b559.txt
+++ b/test/snapshots/parser/comments_test/test_0002_HTML_comment_with_no_whitespace_4644299a23e9ee76cdc970a26168b559.txt
@@ -2,6 +2,9 @@
 ├── name: ∅
 └── children: (1)
     @ Comment (location: (0,0)-(0,0))
-    ├── name: "Hello World"
-    └── children: []
+    ├── name: ∅
+    └── children: (1)
+        @ Literal (location: (0,0)-(0,0))
+        ├── name: "Hello World"
+        └── children: []
 

--- a/test/snapshots/parser/comments_test/test_0003_HTML_comment_followed_by_html_tag_573b93df7df7d12ef12722008abfc7ee.txt
+++ b/test/snapshots/parser/comments_test/test_0003_HTML_comment_followed_by_html_tag_573b93df7df7d12ef12722008abfc7ee.txt
@@ -2,8 +2,11 @@
 ├── name: ∅
 └── children: (2)
     @ Comment (location: (0,0)-(0,0))
-    ├── name: "Hello World"
-    └── children: []
+    ├── name: ∅
+    └── children: (1)
+        @ Literal (location: (0,0)-(0,0))
+        ├── name: "Hello World"
+        └── children: []
 
     @ Element (location: (0,0)-(0,0))
     ├── name: ∅

--- a/test/snapshots/parser/comments_test/test_0004_HTML_comment_followed_by_html_tag_with_nested_comment_f4042eb3e6a5d62fcc86e4162fe10cf2.txt
+++ b/test/snapshots/parser/comments_test/test_0004_HTML_comment_followed_by_html_tag_with_nested_comment_f4042eb3e6a5d62fcc86e4162fe10cf2.txt
@@ -6,8 +6,11 @@
     └── children: []
 
     @ Comment (location: (0,0)-(0,0))
-    ├── name: "Hello World"
-    └── children: []
+    ├── name: ∅
+    └── children: (1)
+        @ Literal (location: (0,0)-(0,0))
+        ├── name: "Hello World"
+        └── children: []
 
     @ TextContent (location: (0,0)-(0,0))
     ├── name: "\n        "
@@ -27,8 +30,11 @@
         ├── name: ∅
         └── children: (1)
             @ Comment (location: (0,0)-(0,0))
-            ├── name: " Hello World "
-            └── children: []
+            ├── name: ∅
+            └── children: (1)
+                @ Literal (location: (0,0)-(0,0))
+                ├── name: " Hello World "
+                └── children: []
 
         @ CloseTag (location: (0,0)-(0,0))
         ├── name: "h1"

--- a/test/snapshots/parser/erb_test/test_0012_interpolate_inside_comment_bfdabf4936ec72a10ffc2e12adfb446a.txt
+++ b/test/snapshots/parser/erb_test/test_0012_interpolate_inside_comment_bfdabf4936ec72a10ffc2e12adfb446a.txt
@@ -1,0 +1,18 @@
+@ DocumentNode (location: (0,0)-(0,0))
+├── name: ∅
+└── children: (1)
+    @ Comment (location: (0,0)-(0,0))
+    ├── name: ∅
+    └── children: (3)
+        @ Literal (location: (0,0)-(0,0))
+        ├── name: " "
+        └── children: []
+
+        @ ERBContent (location: (0,0)-(0,0))
+        ├── name: " "Comment" "
+        └── children: []
+
+        @ Literal (location: (0,0)-(0,0))
+        ├── name: " "
+        └── children: []
+


### PR DESCRIPTION
This pull request improves the parsing of ERB tags inside HTML comment nodes. Additionally, a new test case has been added to ensure the correct parsing of interpolated content within HTML comments.

We also changed the structure of the existing HTML comment nodes. The content of the HTML comment itself is now stored in the `childrens` array as literals or ERB Nodes.