### PR TITLE
Refactor Lexer Peek Helpers with `lexer_peek_for()`

### DIFF
--- a/src/lexer_peek_helpers.c
+++ b/src/lexer_peek_helpers.c
@@ -13,36 +13,42 @@ char lexer_peek(lexer_T* lexer, int offset) {
   return lexer->source[MIN(lexer->current_position + offset, lexer->source_length)];
 }
 
+bool lexer_peek_for(lexer_T* lexer, int offset, const char* pattern, bool case_insensitive) {
+  for (int index = 0; pattern[index]; index++) {
+    char character = lexer_peek(lexer, offset + index);
+
+    if (case_insensitive) {
+      if (tolower(character) != tolower(pattern[index])) return false;
+    } else {
+      if (character != pattern[index]) return false;
+    }
+  }
+
+  return true;
+}
+
 bool lexer_peek_for_doctype(lexer_T* lexer, int offset) {
-  return (lexer_peek(lexer, offset) == '<' && lexer_peek(lexer, offset + 1) == '!' &&
-          tolower(lexer_peek(lexer, offset + 2)) == 'd' && tolower(lexer_peek(lexer, offset + 3)) == 'o' &&
-          tolower(lexer_peek(lexer, offset + 4)) == 'c' && tolower(lexer_peek(lexer, offset + 5)) == 't' &&
-          tolower(lexer_peek(lexer, offset + 6)) == 'y' && tolower(lexer_peek(lexer, offset + 7)) == 'p' &&
-          tolower(lexer_peek(lexer, offset + 8)) == 'e');
+  return lexer_peek_for(lexer, offset, "<!DOCTYPE", true);
 }
 
 bool lexer_peek_for_html_comment_start(lexer_T* lexer, int offset) {
-  return (lexer_peek(lexer, offset) == '<' && lexer_peek(lexer, offset + 1) == '!' &&
-          lexer_peek(lexer, offset + 2) == '-' && lexer_peek(lexer, offset + 3) == '-');
+  return lexer_peek_for(lexer, offset, "<!--", true);
 }
 
 bool lexer_peek_for_html_comment_end(lexer_T* lexer, int offset) {
-  return (
-      lexer_peek(lexer, offset) == '-' && lexer_peek(lexer, offset + 1) == '-' && lexer_peek(lexer, offset + 2) == '>');
+  return lexer_peek_for(lexer, offset, "-->", true);
 }
 
 bool lexer_peek_erb_close_tag(lexer_T* lexer, int offset) {
-  return (lexer_peek(lexer, offset + 0) == '%' && lexer_peek(lexer, offset + 1) == '>');
+  return lexer_peek_for(lexer, offset, "%>", true);
 }
 
 bool lexer_peek_erb_dash_close_tag(lexer_T* lexer, int offset) {
-  return (lexer_peek(lexer, offset + 0) == '-' && lexer_peek(lexer, offset + 1) == '%' &&
-          lexer_peek(lexer, offset + 2) == '>');
+  return lexer_peek_for(lexer, offset, "-%>", true);
 }
 
 bool lexer_peek_erb_percent_close_tag(lexer_T* lexer, int offset) {
-  return (lexer_peek(lexer, offset + 0) == '%' && lexer_peek(lexer, offset + 1) == '%' &&
-          lexer_peek(lexer, offset + 2) == '>');
+  return lexer_peek_for(lexer, offset, "%%>", true);
 }
 
 bool lexer_peek_erb_end(lexer_T* lexer, int offset) {


### PR DESCRIPTION
This pull request introduces a new helper function to simplify and consolidate pattern-matching operations in the lexer. The most important changes include adding the `lexer_peek_for` function and refactoring existing functions to use this new helper.