### PR TITLE
Attach Location Information to AST Nodes

### DIFF
--- a/src/ast_node.c
+++ b/src/ast_node.c
@@ -1,5 +1,6 @@
 #include "include/ast_node.h"
 #include "include/buffer.h"
+#include "include/token_struct.h"
 #include "include/util.h"
 
 #include <stdio.h>
@@ -14,6 +15,8 @@ AST_NODE_T* ast_node_init(ast_node_type_T type) {
 
   node->type = type;
   node->children = array_init(ast_node_sizeof());
+  node->start = location_init(0, 0);
+  node->end = location_init(0, 0);
 
   return node;
 }
@@ -32,6 +35,26 @@ size_t ast_node_child_count(AST_NODE_T* node) {
 
 array_T* ast_node_children(AST_NODE_T* node) {
   return node->children;
+}
+
+void ast_node_set_start(AST_NODE_T* node, location_T* location) {
+  node->start = location;
+}
+void ast_node_set_end(AST_NODE_T* node, location_T* location) {
+  node->end = location;
+}
+
+void ast_node_set_start_from_token(AST_NODE_T* node, token_T* token) {
+  ast_node_set_start(node, token->start);
+}
+
+void ast_node_set_end_from_token(AST_NODE_T* node, token_T* token) {
+  ast_node_set_end(node, token->end);
+}
+
+void ast_node_set_locations_from_token(AST_NODE_T* node, token_T* token) {
+  ast_node_set_start_from_token(node, token);
+  ast_node_set_end_from_token(node, token);
 }
 
 char* ast_node_type_to_string(AST_NODE_T* node) {
@@ -135,7 +158,12 @@ void ast_node_pretty_print(AST_NODE_T* node, size_t indent, buffer_T* buffer) {
 
   buffer_append(buffer, "@ ");
   buffer_append(buffer, ast_node_human_type(node));
-  buffer_append(buffer, " (location: (0,0)-(0,0))\n");
+
+  buffer_append(buffer, " (location: (");
+  char location[64];
+  sprintf(location, "%zu,%zu)-(%zu,%zu", node->start->line, node->start->column, node->end->line, node->end->column);
+  buffer_append(buffer, location);
+  buffer_append(buffer, "))\n");
 
   buffer_append_whitespace(buffer, indent * 2);
   buffer_append(buffer, "├── ");

--- a/src/include/ast_node.h
+++ b/src/include/ast_node.h
@@ -3,6 +3,8 @@
 
 #include "array.h"
 #include "buffer.h"
+#include "location.h"
+#include "token_struct.h"
 
 typedef enum {
   AST_LITERAL_NODE,
@@ -61,6 +63,8 @@ typedef struct AST_NODE_STRUCT {
   array_T* children;
   char* name;
   struct AST_STRUCT* value;
+  location_T* start;
+  location_T* end;
   int data_type;
   int int_value;
 } AST_NODE_T;
@@ -74,6 +78,14 @@ size_t ast_node_child_count(AST_NODE_T* node);
 
 char* ast_node_type_to_string(AST_NODE_T* node);
 char* ast_node_name(AST_NODE_T* node);
+
+void ast_node_set_start(AST_NODE_T* node, location_T* location);
+void ast_node_set_end(AST_NODE_T* node, location_T* location);
+
+void ast_node_set_start_from_token(AST_NODE_T* node, token_T* token);
+void ast_node_set_end_from_token(AST_NODE_T* node, token_T* token);
+
+void ast_node_set_locations_from_token(AST_NODE_T* node, token_T* token);
 
 void ast_node_pretty_print(AST_NODE_T* node, size_t indent, buffer_T* buffer);
 

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -21,7 +21,7 @@ lexer_T* lexer_init(char* source) {
   lexer->source_length = strlen(source);
   lexer->current_position = 0;
   lexer->current_line = 1;
-  lexer->current_column = 1;
+  lexer->current_column = 0;
   lexer->current_character = source[0];
 
   return lexer;

--- a/src/parser.c
+++ b/src/parser.c
@@ -26,7 +26,7 @@ parser_T* parser_init(lexer_T* lexer) {
 
 static void parser_parse_in_data_state(parser_T* parser, AST_NODE_T* element);
 static AST_NODE_T* parser_parse_erb_tag(parser_T* parser, AST_NODE_T* element);
-static AST_NODE_T* parser_build_node(parser_T* parser, ast_node_type_T type, char* name, AST_NODE_T* element);
+static AST_NODE_T* parser_build_node(parser_T* parser, ast_node_type_T type, char* name, AST_NODE_T* node);
 
 static char* format_parser_error(const char* message, const char* expected, const char* got) {
   char* template = "[Parser]: Unexpected Token %s (expected '%s', got: '%s')";
@@ -43,10 +43,13 @@ static char* format_parser_error(const char* message, const char* expected, cons
 }
 
 static AST_NODE_T* parser_append_unexpected_token(
-  parser_T* parser, char* message, char* expected, char* actual, AST_NODE_T* node
+  parser_T* parser, location_T* start, location_T* end, char* message, char* expected, char* actual, AST_NODE_T* node
 ) {
   AST_NODE_T* unexpected_token = ast_node_init(AST_UNEXCPECTED_TOKEN_NODE);
   unexpected_token->name = escape_newlines(format_parser_error(message, expected, actual));
+  ast_node_set_start(unexpected_token, start);
+  ast_node_set_end(unexpected_token, end);
+
   array_append(node->children, unexpected_token);
 
   return unexpected_token;
@@ -57,6 +60,8 @@ static AST_NODE_T* parser_append_unexpected_token_from_token(parser_T* parser, t
 
   return parser_append_unexpected_token(
     parser,
+    token->start,
+    token->end,
     token->value,
     (char*) token_type_to_string(parser->current_token->type),
     (char*) token_type_to_string(type),
@@ -68,6 +73,8 @@ token_T* parser_consume(parser_T* parser, token_type_T type, AST_NODE_T* node) {
   if (parser->current_token->type != type) {
     parser_append_unexpected_token(
       parser,
+      parser->current_token->start,
+      parser->current_token->end,
       "in parser_consume",
       (char*) token_type_to_string(type),
       (char*) token_type_to_string(parser->current_token->type),
@@ -84,18 +91,51 @@ token_T* parser_consume(parser_T* parser, token_type_T type, AST_NODE_T* node) {
   return token;
 }
 
+static void parser_set_start_from_current_token(parser_T* parser, AST_NODE_T* node) {
+  ast_node_set_start(node, parser->current_token->start);
+}
+
+static void parser_set_end_from_current_token(parser_T* parser, AST_NODE_T* node) {
+  ast_node_set_end(node, parser->current_token->start);
+}
+
+static token_T* parser_consume_as_start_token(parser_T* parser, token_type_T type, AST_NODE_T* node) {
+  token_T* token = parser_consume(parser, type, node);
+  ast_node_set_start_from_token(node, token);
+  return token;
+}
+
+static token_T* parser_consume_as_end_token(parser_T* parser, token_type_T type, AST_NODE_T* node) {
+  token_T* token = parser_consume(parser, type, node);
+  ast_node_set_end_from_token(node, token);
+  return token;
+}
+
+static token_T* parser_consume_token_with_location(parser_T* parser, token_type_T type, AST_NODE_T* node) {
+  token_T* token = parser_consume(parser, type, node);
+  ast_node_set_locations_from_token(node, token);
+  return token;
+}
+
 static AST_NODE_T* parser_parse_html_comment(parser_T* parser, AST_NODE_T* element) {
   AST_NODE_T* comment_node = ast_node_init(AST_HTML_COMMENT_NODE);
 
-  parser_consume(parser, TOKEN_HTML_COMMENT_START, comment_node);
+  parser_consume_as_start_token(parser, TOKEN_HTML_COMMENT_START, comment_node);
+  location_T* start_location = parser->current_token->start;
+
   buffer_T comment = buffer_new();
 
   while (parser->current_token->type != TOKEN_EOF && parser->current_token->type != TOKEN_HTML_COMMENT_END) {
     switch (parser->current_token->type) {
       case TOKEN_ERB_START: {
-        parser_build_node(parser, AST_LITERAL_NODE, buffer_value(&comment), comment_node);
+        AST_NODE_T* literal = parser_build_node(parser, AST_LITERAL_NODE, buffer_value(&comment), comment_node);
+        literal->start = start_location;
+        literal->end = parser->current_token->start;
+
         comment = buffer_new();
         parser_parse_erb_tag(parser, comment_node);
+        start_location = parser->current_token->start;
+
         break;
       }
 
@@ -107,10 +147,13 @@ static AST_NODE_T* parser_parse_html_comment(parser_T* parser, AST_NODE_T* eleme
   }
 
   if (buffer_length(&comment) >= 0) {
-    parser_build_node(parser, AST_LITERAL_NODE, buffer_value(&comment), comment_node);
+    AST_NODE_T* literal = parser_build_node(parser, AST_LITERAL_NODE, buffer_value(&comment), comment_node);
+    literal->start = start_location;
+    literal->end = parser->current_token->start;
   }
 
-  parser_consume(parser, TOKEN_HTML_COMMENT_END, comment_node);
+  parser_consume_as_end_token(parser, TOKEN_HTML_COMMENT_END, comment_node);
+
   array_append(element->children, comment_node);
 
   return comment_node;
@@ -120,14 +163,14 @@ static AST_NODE_T* parser_parse_html_doctype(parser_T* parser, AST_NODE_T* eleme
   AST_NODE_T* doctype = ast_node_init(AST_HTML_DOCTYPE_NODE);
   buffer_T content = buffer_new();
 
-  parser_consume(parser, TOKEN_HTML_DOCTYPE, element);
+  parser_consume_as_start_token(parser, TOKEN_HTML_DOCTYPE, doctype);
 
   while (parser->current_token->type != TOKEN_EOF && parser->current_token->type != TOKEN_HTML_TAG_END) {
-    token_T* token = parser_consume(parser, parser->current_token->type, element);
+    token_T* token = parser_consume(parser, parser->current_token->type, doctype);
     buffer_append(&content, token->value);
   }
 
-  parser_consume(parser, TOKEN_HTML_TAG_END, element);
+  parser_consume_as_end_token(parser, TOKEN_HTML_TAG_END, doctype);
 
   doctype->name = buffer_value(&content);
 
@@ -139,6 +182,8 @@ static AST_NODE_T* parser_parse_html_doctype(parser_T* parser, AST_NODE_T* eleme
 static AST_NODE_T* parser_parse_text_content(parser_T* parser, AST_NODE_T* element) {
   AST_NODE_T* text_content_node = ast_node_init(AST_HTML_TEXT_NODE);
 
+  location_T* start_location = parser->current_token->start;
+
   buffer_T content = buffer_new();
 
   while (parser->current_token->type != TOKEN_EOF && parser->current_token->type != TOKEN_HTML_TAG_START
@@ -147,11 +192,15 @@ static AST_NODE_T* parser_parse_text_content(parser_T* parser, AST_NODE_T* eleme
     switch (parser->current_token->type) {
       case TOKEN_ERB_START: {
         if (buffer_length(&content) > 0) {
-          parser_build_node(parser, AST_HTML_TEXT_NODE, buffer_value(&content), element);
+          AST_NODE_T* text_content = parser_build_node(parser, AST_HTML_TEXT_NODE, buffer_value(&content), element);
           content = buffer_new();
+          text_content->start = start_location;
+          text_content->end = parser->current_token->start;
         }
 
         parser_parse_erb_tag(parser, element);
+
+        start_location = parser->current_token->start;
       } break;
 
       case TOKEN_IDENTIFIER: {
@@ -181,10 +230,15 @@ static AST_NODE_T* parser_parse_text_content(parser_T* parser, AST_NODE_T* eleme
       }
     }
   }
+
   if (buffer_length(&content) > 0) {
     text_content_node->name = buffer_value(&content);
+    text_content_node->start = start_location;
+    text_content_node->end = parser->current_token->start;
+
     array_append(element->children, text_content_node);
   } else {
+    // TODO: we shouldn't be interrupting the text_content parsing in the switch above
     // TODO: implement ast_node_free()
     // ast_node_free(text_content_node);
   }
@@ -198,7 +252,10 @@ static AST_NODE_T* parser_parse_html_attribute_name(parser_T* parser, AST_NODE_T
   if (parser->current_token->type != TOKEN_IDENTIFIER) {
     parser_append_unexpected_token_from_token(parser, TOKEN_IDENTIFIER, attribute_name);
   } else {
-    attribute_name->name = parser_consume(parser, TOKEN_IDENTIFIER, attribute)->value;
+    token_T* identifier = parser_consume_token_with_location(parser, TOKEN_IDENTIFIER, attribute_name);
+    attribute_name->name = identifier->value;
+    attribute->start = attribute_name->start;
+    attribute->end = attribute_name->end;
   }
 
   array_append(attribute->children, attribute_name);
@@ -206,17 +263,19 @@ static AST_NODE_T* parser_parse_html_attribute_name(parser_T* parser, AST_NODE_T
   return attribute_name;
 }
 
-static AST_NODE_T* parser_build_node(parser_T* parser, ast_node_type_T type, char* name, AST_NODE_T* element) {
+static AST_NODE_T* parser_build_node(parser_T* parser, ast_node_type_T type, char* name, AST_NODE_T* node) {
   AST_NODE_T* literal_node = ast_node_init(type);
 
   literal_node->name = name;
-  array_append(element->children, literal_node);
+  array_append(node->children, literal_node);
 
   return literal_node;
 }
 
 static AST_NODE_T* parser_parse_html_attribute_value(parser_T* parser, AST_NODE_T* attribute) {
   AST_NODE_T* attribute_value = ast_node_init(AST_HTML_ATTRIBUTE_VALUE_NODE);
+
+  parser_set_start_from_current_token(parser, attribute_value);
 
   switch (parser->current_token->type) {
     case TOKEN_ERB_START: {
@@ -228,15 +287,22 @@ static AST_NODE_T* parser_parse_html_attribute_value(parser_T* parser, AST_NODE_
       token_T* open_quote = parser_consume(parser, TOKEN_QUOTE, attribute_value);
       buffer_T buffer = buffer_new();
 
+      location_T* start_location = parser->current_token->start;
+
       while (parser->current_token->type != TOKEN_QUOTE && parser->current_token->type != TOKEN_EOF) {
         switch (parser->current_token->type) {
           case TOKEN_ERB_START: {
             if (buffer_length(&buffer) > 0) {
-              parser_build_node(parser, AST_LITERAL_NODE, buffer_value(&buffer), attribute_value);
+              AST_NODE_T* literal = parser_build_node(parser, AST_LITERAL_NODE, buffer_value(&buffer), attribute_value);
+              literal->start = start_location;
+              literal->end = parser->current_token->start;
+
               buffer = buffer_new();
             }
 
             parser_parse_erb_tag(parser, attribute_value);
+
+            start_location = parser->current_token->start;
           } break;
 
           default: {
@@ -247,7 +313,9 @@ static AST_NODE_T* parser_parse_html_attribute_value(parser_T* parser, AST_NODE_
       }
 
       if (buffer_length(&buffer) > 0) {
-        parser_build_node(parser, AST_LITERAL_NODE, buffer_value(&buffer), attribute_value);
+        AST_NODE_T* literal = parser_build_node(parser, AST_LITERAL_NODE, buffer_value(&buffer), attribute_value);
+        literal->start = start_location;
+        literal->end = parser->current_token->start;
       }
 
       token_T* close_quote = parser_consume(parser, TOKEN_QUOTE, attribute_value);
@@ -255,6 +323,8 @@ static AST_NODE_T* parser_parse_html_attribute_value(parser_T* parser, AST_NODE_
       if (strcmp(open_quote->value, close_quote->value) != 0) {
         parser_append_unexpected_token(
           parser,
+          close_quote->start,
+          close_quote->end,
           "Unexpected quote",
           open_quote->value,
           close_quote->value,
@@ -272,6 +342,8 @@ static AST_NODE_T* parser_parse_html_attribute_value(parser_T* parser, AST_NODE_
     default: parser_append_unexpected_token_from_token(parser, parser->current_token->type, attribute_value);
   }
 
+  parser_set_end_from_current_token(parser, attribute_value);
+
   array_append(attribute->children, attribute_value);
 
   return attribute_value;
@@ -287,7 +359,8 @@ static AST_NODE_T* parser_parse_html_attribute(parser_T* parser, AST_NODE_T* att
 
   if (parser->current_token->type == TOKEN_EQUALS) {
     parser_consume(parser, TOKEN_EQUALS, attribute);
-    parser_parse_html_attribute_value(parser, attribute);
+    AST_NODE_T* attribute_value = parser_parse_html_attribute_value(parser, attribute);
+    attribute->end = attribute_value->end;
   }
 
   array_append(attribute_list->children, attribute);
@@ -297,6 +370,7 @@ static AST_NODE_T* parser_parse_html_attribute(parser_T* parser, AST_NODE_T* att
 
 static AST_NODE_T* parser_parse_html_attribute_set(parser_T* parser) {
   AST_NODE_T* attribute_list = ast_node_init(AST_HTML_ATTRIBUTE_SET_NODE);
+  parser_set_start_from_current_token(parser, attribute_list);
 
   while (parser->current_token->type != TOKEN_HTML_TAG_END && parser->current_token->type != TOKEN_HTML_TAG_SELF_CLOSE
          && parser->current_token->type != TOKEN_EOF) {
@@ -308,31 +382,37 @@ static AST_NODE_T* parser_parse_html_attribute_set(parser_T* parser) {
     }
   }
 
+  parser_set_end_from_current_token(parser, attribute_list);
+
   return attribute_list;
 }
 
 static AST_NODE_T* parser_parse_html_open_tag(parser_T* parser, AST_NODE_T* element) {
-  parser_consume(parser, TOKEN_HTML_TAG_START, element);
-  token_T* tagName = parser_consume(parser, TOKEN_IDENTIFIER, element);
+  token_T* tag_start = parser_consume_as_start_token(parser, TOKEN_HTML_TAG_START, element);
+  token_T* tag_name = parser_consume(parser, TOKEN_IDENTIFIER, element);
 
   AST_NODE_T* attribute_list = parser_parse_html_attribute_set(parser);
 
   if (parser->current_token->type == TOKEN_HTML_TAG_END) {
     AST_NODE_T* open_tag = ast_node_init(AST_HTML_OPEN_TAG_NODE);
-    open_tag->name = tagName->value;
+    open_tag->name = tag_name->value;
+    open_tag->start = tag_start->start;
 
     array_append(element->children, open_tag);
     array_append(open_tag->children, attribute_list);
-    parser_consume(parser, TOKEN_HTML_TAG_END, open_tag);
+    token_T* tag_end = parser_consume_as_end_token(parser, TOKEN_HTML_TAG_END, open_tag);
+    element->end = tag_end->end;
 
     return open_tag;
   } else if (parser->current_token->type == TOKEN_HTML_TAG_SELF_CLOSE) {
     AST_NODE_T* self_close_tag = ast_node_init(AST_HTML_SELF_CLOSE_TAG_NODE);
-    self_close_tag->name = tagName->value;
+    self_close_tag->name = tag_name->value;
+    self_close_tag->start = tag_start->start;
 
     array_append(element->children, self_close_tag);
     array_append(self_close_tag->children, attribute_list);
-    parser_consume(parser, TOKEN_HTML_TAG_SELF_CLOSE, self_close_tag);
+    token_T* tag_end = parser_consume_as_end_token(parser, TOKEN_HTML_TAG_SELF_CLOSE, self_close_tag);
+    element->end = tag_end->end;
 
     return self_close_tag;
   } else {
@@ -342,9 +422,11 @@ static AST_NODE_T* parser_parse_html_open_tag(parser_T* parser, AST_NODE_T* elem
 
 static AST_NODE_T* parser_parse_html_element_body(parser_T* parser, AST_NODE_T* element) {
   AST_NODE_T* element_body = ast_node_init(AST_HTML_ELEMENT_BODY_NODE);
+  parser_set_start_from_current_token(parser, element_body);
 
   parser_parse_in_data_state(parser, element_body);
 
+  parser_set_end_from_current_token(parser, element_body);
   array_append(element->children, element_body);
 
   return element_body;
@@ -353,11 +435,12 @@ static AST_NODE_T* parser_parse_html_element_body(parser_T* parser, AST_NODE_T* 
 static AST_NODE_T* parser_parse_html_close_tag(parser_T* parser, AST_NODE_T* element) {
   AST_NODE_T* close_tag = ast_node_init(AST_HTML_CLOSE_TAG_NODE);
 
-  parser_consume(parser, TOKEN_HTML_TAG_START_CLOSE, close_tag);
+  parser_consume_as_start_token(parser, TOKEN_HTML_TAG_START_CLOSE, close_tag);
   close_tag->name = parser_consume(parser, TOKEN_IDENTIFIER, close_tag)->value;
-  parser_consume(parser, TOKEN_HTML_TAG_END, close_tag);
+  parser_consume_as_end_token(parser, TOKEN_HTML_TAG_END, close_tag);
 
   array_append(element->children, close_tag);
+  element->end = close_tag->end;
 
   return close_tag;
 }
@@ -372,7 +455,7 @@ static AST_NODE_T* parser_parse_html_element(parser_T* parser, AST_NODE_T* paren
   // open_tag->should_have_close_tag = is_void_element(open_tag->name);
 
   if (open_tag->type == AST_HTML_SELF_CLOSE_TAG_NODE || is_void_element(open_tag->name)) {
-    // no-op: since we don't expected a close tag
+    // no-op: since we don't expect a close tag
 
     // To make sure we always set it for the is_void_element cases
     open_tag->type = AST_HTML_SELF_CLOSE_TAG_NODE;
@@ -383,11 +466,21 @@ static AST_NODE_T* parser_parse_html_element(parser_T* parser, AST_NODE_T* paren
     AST_NODE_T* close_tag = parser_parse_html_close_tag(parser, element_node);
 
     if (strcasecmp(open_tag->name, close_tag->name) != 0) {
-      parser_append_unexpected_token(parser, "mismatched closing tag", open_tag->name, close_tag->name, element_node);
+      parser_append_unexpected_token(
+        parser,
+        close_tag->start,
+        close_tag->end,
+        "mismatched closing tag",
+        open_tag->name,
+        close_tag->name,
+        element_node
+      );
     }
   } else {
     parser_append_unexpected_token(
       parser,
+      open_tag->start,
+      open_tag->end,
       "open_tag type",
       "AST_HTML_OPEN_TAG_NODE, AST_HTML_SELF_CLOSE_TAG_NODE",
       open_tag->name,
@@ -401,12 +494,12 @@ static AST_NODE_T* parser_parse_html_element(parser_T* parser, AST_NODE_T* paren
 static AST_NODE_T* parser_parse_erb_tag(parser_T* parser, AST_NODE_T* element) {
   AST_NODE_T* erb_tag = ast_node_init(AST_ERB_CONTENT_NODE);
 
-  parser_consume(parser, TOKEN_ERB_START, element);
+  parser_consume_as_start_token(parser, TOKEN_ERB_START, erb_tag);
 
-  token_T* content = parser_consume(parser, TOKEN_ERB_CONTENT, element);
+  token_T* content = parser_consume(parser, TOKEN_ERB_CONTENT, erb_tag);
   erb_tag->name = content->value;
 
-  parser_consume(parser, TOKEN_ERB_END, element);
+  parser_consume_as_end_token(parser, TOKEN_ERB_END, erb_tag);
 
   array_append(element->children, erb_tag);
 
@@ -455,8 +548,11 @@ static void parser_parse_in_data_state(parser_T* parser, AST_NODE_T* element) {
 
 static AST_NODE_T* parser_parse_document(parser_T* parser) {
   AST_NODE_T* document_node = ast_node_init(AST_HTML_DOCUMENT_NODE);
+  parser_set_start_from_current_token(parser, document_node);
 
   parser_parse_in_data_state(parser, document_node);
+
+  parser_consume_as_end_token(parser, TOKEN_EOF, document_node);
 
   return document_node;
 }

--- a/test/snapshots/parser/attributes_test/test_0001_attributes_58a307bbb974b5a37bc8c4923f05efa0.txt
+++ b/test/snapshots/parser/attributes_test/test_0001_attributes_58a307bbb974b5a37bc8c4923f05efa0.txt
@@ -1,48 +1,48 @@
-@ DocumentNode (location: (0,0)-(0,0))
+@ DocumentNode (location: (1,0)-(1,44))
 ├── name: ∅
 └── children: (1)
-    @ Element (location: (0,0)-(0,0))
+    @ Element (location: (1,0)-(1,44))
     ├── name: ∅
     └── children: (3)
-        @ OpenTag (location: (0,0)-(0,0))
+        @ OpenTag (location: (1,0)-(1,38))
         ├── name: "div"
         └── children: (1)
-            @ AttributeSet (location: (0,0)-(0,0))
+            @ AttributeSet (location: (1,4)-(1,37))
             ├── name: ∅
             └── children: (2)
-                @ Attribute (location: (0,0)-(0,0))
+                @ Attribute (location: (1,5)-(1,15))
                 ├── name: ∅
                 └── children: (2)
-                    @ AttributeName (location: (0,0)-(0,0))
+                    @ AttributeName (location: (1,5)-(1,7))
                     ├── name: "id"
                     └── children: []
 
-                    @ AttributeValue (location: (0,0)-(0,0))
+                    @ AttributeValue (location: (1,8)-(1,15))
                     ├── name: "hello"
                     └── children: (1)
-                        @ Literal (location: (0,0)-(0,0))
+                        @ Literal (location: (1,9)-(1,14))
                         ├── name: "hello"
                         └── children: []
 
-                @ Attribute (location: (0,0)-(0,0))
+                @ Attribute (location: (1,16)-(1,37))
                 ├── name: ∅
                 └── children: (2)
-                    @ AttributeName (location: (0,0)-(0,0))
+                    @ AttributeName (location: (1,16)-(1,21))
                     ├── name: "class"
                     └── children: []
 
-                    @ AttributeValue (location: (0,0)-(0,0))
+                    @ AttributeValue (location: (1,22)-(1,37))
                     ├── name: "container p-3"
                     └── children: (1)
-                        @ Literal (location: (0,0)-(0,0))
+                        @ Literal (location: (1,23)-(1,36))
                         ├── name: "container p-3"
                         └── children: []
 
-        @ ElementBody (location: (0,0)-(0,0))
+        @ ElementBody (location: (1,38)-(1,38))
         ├── name: ∅
         └── children: []
 
-        @ CloseTag (location: (0,0)-(0,0))
+        @ CloseTag (location: (1,38)-(1,44))
         ├── name: "div"
         └── children: []
 

--- a/test/snapshots/parser/attributes_test/test_0002_duplicate_attributes_bf952621ac1542b125217fd3c3171e28.txt
+++ b/test/snapshots/parser/attributes_test/test_0002_duplicate_attributes_bf952621ac1542b125217fd3c3171e28.txt
@@ -1,48 +1,48 @@
-@ DocumentNode (location: (0,0)-(0,0))
+@ DocumentNode (location: (1,0)-(1,47))
 ├── name: ∅
 └── children: (1)
-    @ Element (location: (0,0)-(0,0))
+    @ Element (location: (1,0)-(1,47))
     ├── name: ∅
     └── children: (3)
-        @ OpenTag (location: (0,0)-(0,0))
+        @ OpenTag (location: (1,0)-(1,41))
         ├── name: "div"
         └── children: (1)
-            @ AttributeSet (location: (0,0)-(0,0))
+            @ AttributeSet (location: (1,4)-(1,40))
             ├── name: ∅
             └── children: (2)
-                @ Attribute (location: (0,0)-(0,0))
+                @ Attribute (location: (1,5)-(1,18))
                 ├── name: ∅
                 └── children: (2)
-                    @ AttributeName (location: (0,0)-(0,0))
+                    @ AttributeName (location: (1,5)-(1,10))
                     ├── name: "class"
                     └── children: []
 
-                    @ AttributeValue (location: (0,0)-(0,0))
+                    @ AttributeValue (location: (1,11)-(1,18))
                     ├── name: "hello"
                     └── children: (1)
-                        @ Literal (location: (0,0)-(0,0))
+                        @ Literal (location: (1,12)-(1,17))
                         ├── name: "hello"
                         └── children: []
 
-                @ Attribute (location: (0,0)-(0,0))
+                @ Attribute (location: (1,19)-(1,40))
                 ├── name: ∅
                 └── children: (2)
-                    @ AttributeName (location: (0,0)-(0,0))
+                    @ AttributeName (location: (1,19)-(1,24))
                     ├── name: "class"
                     └── children: []
 
-                    @ AttributeValue (location: (0,0)-(0,0))
+                    @ AttributeValue (location: (1,25)-(1,40))
                     ├── name: "container p-3"
                     └── children: (1)
-                        @ Literal (location: (0,0)-(0,0))
+                        @ Literal (location: (1,26)-(1,39))
                         ├── name: "container p-3"
                         └── children: []
 
-        @ ElementBody (location: (0,0)-(0,0))
+        @ ElementBody (location: (1,41)-(1,41))
         ├── name: ∅
         └── children: []
 
-        @ CloseTag (location: (0,0)-(0,0))
+        @ CloseTag (location: (1,41)-(1,47))
         ├── name: "div"
         └── children: []
 

--- a/test/snapshots/parser/attributes_test/test_0003_attribute_with_no_quotes_value_and_whitespace_and_self-closing_tag_fed80eb194a51acda7fe05820e850451.txt
+++ b/test/snapshots/parser/attributes_test/test_0003_attribute_with_no_quotes_value_and_whitespace_and_self-closing_tag_fed80eb194a51acda7fe05820e850451.txt
@@ -1,23 +1,23 @@
-@ DocumentNode (location: (0,0)-(0,0))
+@ DocumentNode (location: (1,0)-(1,19))
 ├── name: ∅
 └── children: (1)
-    @ Element (location: (0,0)-(0,0))
+    @ Element (location: (1,0)-(1,19))
     ├── name: ∅
     └── children: (1)
-        @ SelfCloseTag (location: (0,0)-(0,0))
+        @ SelfCloseTag (location: (1,0)-(1,19))
         ├── name: "img"
         └── children: (1)
-            @ AttributeSet (location: (0,0)-(0,0))
+            @ AttributeSet (location: (1,4)-(1,17))
             ├── name: ∅
             └── children: (1)
-                @ Attribute (location: (0,0)-(0,0))
+                @ Attribute (location: (1,5)-(1,16))
                 ├── name: ∅
                 └── children: (2)
-                    @ AttributeName (location: (0,0)-(0,0))
+                    @ AttributeName (location: (1,5)-(1,10))
                     ├── name: "value"
                     └── children: []
 
-                    @ AttributeValue (location: (0,0)-(0,0))
+                    @ AttributeValue (location: (1,11)-(1,16))
                     ├── name: "hello"
                     └── children: []
 

--- a/test/snapshots/parser/attributes_test/test_0004_attribute_with_no_quotes_value,_no_whitespace_and_self-closing_tag_82af2795699fe4f5b34f32ed1491228a.txt
+++ b/test/snapshots/parser/attributes_test/test_0004_attribute_with_no_quotes_value,_no_whitespace_and_self-closing_tag_82af2795699fe4f5b34f32ed1491228a.txt
@@ -1,23 +1,23 @@
-@ DocumentNode (location: (0,0)-(0,0))
+@ DocumentNode (location: (1,0)-(1,18))
 ├── name: ∅
 └── children: (1)
-    @ Element (location: (0,0)-(0,0))
+    @ Element (location: (1,0)-(1,18))
     ├── name: ∅
     └── children: (1)
-        @ SelfCloseTag (location: (0,0)-(0,0))
+        @ SelfCloseTag (location: (1,0)-(1,18))
         ├── name: "img"
         └── children: (1)
-            @ AttributeSet (location: (0,0)-(0,0))
+            @ AttributeSet (location: (1,4)-(1,16))
             ├── name: ∅
             └── children: (1)
-                @ Attribute (location: (0,0)-(0,0))
+                @ Attribute (location: (1,5)-(1,16))
                 ├── name: ∅
                 └── children: (2)
-                    @ AttributeName (location: (0,0)-(0,0))
+                    @ AttributeName (location: (1,5)-(1,10))
                     ├── name: "value"
                     └── children: []
 
-                    @ AttributeValue (location: (0,0)-(0,0))
+                    @ AttributeValue (location: (1,11)-(1,16))
                     ├── name: "hello"
                     └── children: []
 

--- a/test/snapshots/parser/attributes_test/test_0005_attribute_with_no_quotes_value,_no_whitespace,_and_non_self-closing_tag_f00fb4a0aa00f7c763be88670c0bc05d.txt
+++ b/test/snapshots/parser/attributes_test/test_0005_attribute_with_no_quotes_value,_no_whitespace,_and_non_self-closing_tag_f00fb4a0aa00f7c763be88670c0bc05d.txt
@@ -1,46 +1,46 @@
-@ DocumentNode (location: (0,0)-(0,0))
+@ DocumentNode (location: (1,0)-(1,17))
 ├── name: ∅
 └── children: (1)
-    @ Element (location: (0,0)-(0,0))
+    @ Element (location: (1,0)-(1,17))
     ├── name: ∅
     └── children: (4)
-        @ OpenTag (location: (0,0)-(0,0))
+        @ OpenTag (location: (1,0)-(1,17))
         ├── name: "div"
         └── children: (1)
-            @ AttributeSet (location: (0,0)-(0,0))
+            @ AttributeSet (location: (1,4)-(1,16))
             ├── name: ∅
             └── children: (1)
-                @ Attribute (location: (0,0)-(0,0))
+                @ Attribute (location: (1,5)-(1,16))
                 ├── name: ∅
                 └── children: (2)
-                    @ AttributeName (location: (0,0)-(0,0))
+                    @ AttributeName (location: (1,5)-(1,10))
                     ├── name: "value"
                     └── children: []
 
-                    @ AttributeValue (location: (0,0)-(0,0))
+                    @ AttributeValue (location: (1,11)-(1,16))
                     ├── name: "hello"
                     └── children: []
 
-        @ ElementBody (location: (0,0)-(0,0))
+        @ ElementBody (location: (1,17)-(1,17))
         ├── name: ∅
         └── children: []
 
-        @ CloseTag (location: (0,0)-(0,0))
+        @ CloseTag (location: (1,17)-(1,17))
         ├── name: ""
         └── children: (3)
-            @ UnexcpectedToken (location: (0,0)-(0,0))
+            @ UnexcpectedToken (location: (1,17)-(1,17))
             ├── name: "[Parser]: Unexpected Token in parser_consume (expected 'TOKEN_HTML_TAG_START_CLOSE', got: 'TOKEN_EOF')"
             └── children: []
 
-            @ UnexcpectedToken (location: (0,0)-(0,0))
+            @ UnexcpectedToken (location: (1,17)-(1,17))
             ├── name: "[Parser]: Unexpected Token in parser_consume (expected 'TOKEN_IDENTIFIER', got: 'TOKEN_EOF')"
             └── children: []
 
-            @ UnexcpectedToken (location: (0,0)-(0,0))
+            @ UnexcpectedToken (location: (1,17)-(1,17))
             ├── name: "[Parser]: Unexpected Token in parser_consume (expected 'TOKEN_HTML_TAG_END', got: 'TOKEN_EOF')"
             └── children: []
 
-        @ UnexcpectedToken (location: (0,0)-(0,0))
+        @ UnexcpectedToken (location: (1,17)-(1,17))
         ├── name: "[Parser]: Unexpected Token mismatched closing tag (expected 'div', got: '')"
         └── children: []
 

--- a/test/snapshots/parser/boolean_attributes_test/test_0001_boolean_attribute_a42f2f02865b5934ab801e14209484bb.txt
+++ b/test/snapshots/parser/boolean_attributes_test/test_0001_boolean_attribute_a42f2f02865b5934ab801e14209484bb.txt
@@ -1,19 +1,19 @@
-@ DocumentNode (location: (0,0)-(0,0))
+@ DocumentNode (location: (1,0)-(1,18))
 ├── name: ∅
 └── children: (1)
-    @ Element (location: (0,0)-(0,0))
+    @ Element (location: (1,0)-(1,18))
     ├── name: ∅
     └── children: (1)
-        @ SelfCloseTag (location: (0,0)-(0,0))
+        @ SelfCloseTag (location: (1,0)-(1,18))
         ├── name: "input"
         └── children: (1)
-            @ AttributeSet (location: (0,0)-(0,0))
+            @ AttributeSet (location: (1,6)-(1,16))
             ├── name: ∅
             └── children: (1)
-                @ Attribute (location: (0,0)-(0,0))
+                @ Attribute (location: (1,7)-(1,15))
                 ├── name: ∅
                 └── children: (1)
-                    @ AttributeName (location: (0,0)-(0,0))
+                    @ AttributeName (location: (1,7)-(1,15))
                     ├── name: "required"
                     └── children: []
 

--- a/test/snapshots/parser/boolean_attributes_test/test_0002_boolean_attribute_without_whitespace_eb449fdccded7b58eaadee0d6a709b70.txt
+++ b/test/snapshots/parser/boolean_attributes_test/test_0002_boolean_attribute_without_whitespace_eb449fdccded7b58eaadee0d6a709b70.txt
@@ -1,19 +1,19 @@
-@ DocumentNode (location: (0,0)-(0,0))
+@ DocumentNode (location: (1,0)-(1,17))
 ├── name: ∅
 └── children: (1)
-    @ Element (location: (0,0)-(0,0))
+    @ Element (location: (1,0)-(1,17))
     ├── name: ∅
     └── children: (1)
-        @ SelfCloseTag (location: (0,0)-(0,0))
+        @ SelfCloseTag (location: (1,0)-(1,17))
         ├── name: "input"
         └── children: (1)
-            @ AttributeSet (location: (0,0)-(0,0))
+            @ AttributeSet (location: (1,6)-(1,15))
             ├── name: ∅
             └── children: (1)
-                @ Attribute (location: (0,0)-(0,0))
+                @ Attribute (location: (1,7)-(1,15))
                 ├── name: ∅
                 └── children: (1)
-                    @ AttributeName (location: (0,0)-(0,0))
+                    @ AttributeName (location: (1,7)-(1,15))
                     ├── name: "required"
                     └── children: []
 

--- a/test/snapshots/parser/boolean_attributes_test/test_0003_boolean_attribute_without_whitespace_and_without_self-closing_tag_10073da0ec7061aa368fad226ff8dd33.txt
+++ b/test/snapshots/parser/boolean_attributes_test/test_0003_boolean_attribute_without_whitespace_and_without_self-closing_tag_10073da0ec7061aa368fad226ff8dd33.txt
@@ -1,19 +1,19 @@
-@ DocumentNode (location: (0,0)-(0,0))
+@ DocumentNode (location: (1,0)-(1,16))
 ├── name: ∅
 └── children: (1)
-    @ Element (location: (0,0)-(0,0))
+    @ Element (location: (1,0)-(1,16))
     ├── name: ∅
     └── children: (1)
-        @ SelfCloseTag (location: (0,0)-(0,0))
+        @ SelfCloseTag (location: (1,0)-(1,16))
         ├── name: "input"
         └── children: (1)
-            @ AttributeSet (location: (0,0)-(0,0))
+            @ AttributeSet (location: (1,6)-(1,15))
             ├── name: ∅
             └── children: (1)
-                @ Attribute (location: (0,0)-(0,0))
+                @ Attribute (location: (1,7)-(1,15))
                 ├── name: ∅
                 └── children: (1)
-                    @ AttributeName (location: (0,0)-(0,0))
+                    @ AttributeName (location: (1,7)-(1,15))
                     ├── name: "required"
                     └── children: []
 

--- a/test/snapshots/parser/boolean_attributes_test/test_0004_boolean_attribute_followed_by_regular_attribute_2f302cf3eda407efbc8e40d14cd26656.txt
+++ b/test/snapshots/parser/boolean_attributes_test/test_0004_boolean_attribute_followed_by_regular_attribute_2f302cf3eda407efbc8e40d14cd26656.txt
@@ -1,33 +1,33 @@
-@ DocumentNode (location: (0,0)-(0,0))
+@ DocumentNode (location: (1,0)-(1,28))
 ├── name: ∅
 └── children: (1)
-    @ Element (location: (0,0)-(0,0))
+    @ Element (location: (1,0)-(1,28))
     ├── name: ∅
     └── children: (1)
-        @ SelfCloseTag (location: (0,0)-(0,0))
+        @ SelfCloseTag (location: (1,0)-(1,28))
         ├── name: "input"
         └── children: (1)
-            @ AttributeSet (location: (0,0)-(0,0))
+            @ AttributeSet (location: (1,6)-(1,26))
             ├── name: ∅
             └── children: (2)
-                @ Attribute (location: (0,0)-(0,0))
+                @ Attribute (location: (1,7)-(1,15))
                 ├── name: ∅
                 └── children: (1)
-                    @ AttributeName (location: (0,0)-(0,0))
+                    @ AttributeName (location: (1,7)-(1,15))
                     ├── name: "required"
                     └── children: []
 
-                @ Attribute (location: (0,0)-(0,0))
+                @ Attribute (location: (1,16)-(1,26))
                 ├── name: ∅
                 └── children: (2)
-                    @ AttributeName (location: (0,0)-(0,0))
+                    @ AttributeName (location: (1,16)-(1,18))
                     ├── name: "id"
                     └── children: []
 
-                    @ AttributeValue (location: (0,0)-(0,0))
+                    @ AttributeValue (location: (1,19)-(1,26))
                     ├── name: "input"
                     └── children: (1)
-                        @ Literal (location: (0,0)-(0,0))
+                        @ Literal (location: (1,20)-(1,25))
                         ├── name: "input"
                         └── children: []
 

--- a/test/snapshots/parser/boolean_attributes_test/test_0005_boolean_attribute_after_regular_attribute_ac9036a484da8a6accae805201ef2dca.txt
+++ b/test/snapshots/parser/boolean_attributes_test/test_0005_boolean_attribute_after_regular_attribute_ac9036a484da8a6accae805201ef2dca.txt
@@ -1,33 +1,33 @@
-@ DocumentNode (location: (0,0)-(0,0))
+@ DocumentNode (location: (1,0)-(1,29))
 ├── name: ∅
 └── children: (1)
-    @ Element (location: (0,0)-(0,0))
+    @ Element (location: (1,0)-(1,29))
     ├── name: ∅
     └── children: (1)
-        @ SelfCloseTag (location: (0,0)-(0,0))
+        @ SelfCloseTag (location: (1,0)-(1,29))
         ├── name: "input"
         └── children: (1)
-            @ AttributeSet (location: (0,0)-(0,0))
+            @ AttributeSet (location: (1,6)-(1,27))
             ├── name: ∅
             └── children: (2)
-                @ Attribute (location: (0,0)-(0,0))
+                @ Attribute (location: (1,7)-(1,17))
                 ├── name: ∅
                 └── children: (2)
-                    @ AttributeName (location: (0,0)-(0,0))
+                    @ AttributeName (location: (1,7)-(1,9))
                     ├── name: "id"
                     └── children: []
 
-                    @ AttributeValue (location: (0,0)-(0,0))
+                    @ AttributeValue (location: (1,10)-(1,17))
                     ├── name: "input"
                     └── children: (1)
-                        @ Literal (location: (0,0)-(0,0))
+                        @ Literal (location: (1,11)-(1,16))
                         ├── name: "input"
                         └── children: []
 
-                @ Attribute (location: (0,0)-(0,0))
+                @ Attribute (location: (1,18)-(1,26))
                 ├── name: ∅
                 └── children: (1)
-                    @ AttributeName (location: (0,0)-(0,0))
+                    @ AttributeName (location: (1,18)-(1,26))
                     ├── name: "required"
                     └── children: []
 

--- a/test/snapshots/parser/boolean_attributes_test/test_0006_boolean_attribute_surounded_by_regular_attributes_d3642056798166a35948c97b38bde43d.txt
+++ b/test/snapshots/parser/boolean_attributes_test/test_0006_boolean_attribute_surounded_by_regular_attributes_d3642056798166a35948c97b38bde43d.txt
@@ -1,47 +1,47 @@
-@ DocumentNode (location: (0,0)-(0,0))
+@ DocumentNode (location: (1,0)-(1,42))
 ├── name: ∅
 └── children: (1)
-    @ Element (location: (0,0)-(0,0))
+    @ Element (location: (1,0)-(1,42))
     ├── name: ∅
     └── children: (1)
-        @ SelfCloseTag (location: (0,0)-(0,0))
+        @ SelfCloseTag (location: (1,0)-(1,42))
         ├── name: "input"
         └── children: (1)
-            @ AttributeSet (location: (0,0)-(0,0))
+            @ AttributeSet (location: (1,6)-(1,40))
             ├── name: ∅
             └── children: (3)
-                @ Attribute (location: (0,0)-(0,0))
+                @ Attribute (location: (1,7)-(1,22))
                 ├── name: ∅
                 └── children: (2)
-                    @ AttributeName (location: (0,0)-(0,0))
+                    @ AttributeName (location: (1,7)-(1,12))
                     ├── name: "class"
                     └── children: []
 
-                    @ AttributeValue (location: (0,0)-(0,0))
+                    @ AttributeValue (location: (1,13)-(1,22))
                     ├── name: "classes"
                     └── children: (1)
-                        @ Literal (location: (0,0)-(0,0))
+                        @ Literal (location: (1,14)-(1,21))
                         ├── name: "classes"
                         └── children: []
 
-                @ Attribute (location: (0,0)-(0,0))
+                @ Attribute (location: (1,23)-(1,31))
                 ├── name: ∅
                 └── children: (1)
-                    @ AttributeName (location: (0,0)-(0,0))
+                    @ AttributeName (location: (1,23)-(1,31))
                     ├── name: "required"
                     └── children: []
 
-                @ Attribute (location: (0,0)-(0,0))
+                @ Attribute (location: (1,32)-(1,40))
                 ├── name: ∅
                 └── children: (2)
-                    @ AttributeName (location: (0,0)-(0,0))
+                    @ AttributeName (location: (1,32)-(1,34))
                     ├── name: "id"
                     └── children: []
 
-                    @ AttributeValue (location: (0,0)-(0,0))
+                    @ AttributeValue (location: (1,35)-(1,40))
                     ├── name: "ids"
                     └── children: (1)
-                        @ Literal (location: (0,0)-(0,0))
+                        @ Literal (location: (1,36)-(1,39))
                         ├── name: "ids"
                         └── children: []
 

--- a/test/snapshots/parser/comments_test/test_0001_HTML_comment_with_padding_whitespace_9cb56068ef4732067422a670d943c08e.txt
+++ b/test/snapshots/parser/comments_test/test_0001_HTML_comment_with_padding_whitespace_9cb56068ef4732067422a670d943c08e.txt
@@ -1,10 +1,10 @@
-@ DocumentNode (location: (0,0)-(0,0))
+@ DocumentNode (location: (1,0)-(1,20))
 ├── name: ∅
 └── children: (1)
-    @ Comment (location: (0,0)-(0,0))
+    @ Comment (location: (1,0)-(1,20))
     ├── name: ∅
     └── children: (1)
-        @ Literal (location: (0,0)-(0,0))
+        @ Literal (location: (1,4)-(1,17))
         ├── name: " Hello World "
         └── children: []
 

--- a/test/snapshots/parser/comments_test/test_0002_HTML_comment_with_no_whitespace_4644299a23e9ee76cdc970a26168b559.txt
+++ b/test/snapshots/parser/comments_test/test_0002_HTML_comment_with_no_whitespace_4644299a23e9ee76cdc970a26168b559.txt
@@ -1,10 +1,10 @@
-@ DocumentNode (location: (0,0)-(0,0))
+@ DocumentNode (location: (1,0)-(1,18))
 ├── name: ∅
 └── children: (1)
-    @ Comment (location: (0,0)-(0,0))
+    @ Comment (location: (1,0)-(1,18))
     ├── name: ∅
     └── children: (1)
-        @ Literal (location: (0,0)-(0,0))
+        @ Literal (location: (1,4)-(1,15))
         ├── name: "Hello World"
         └── children: []
 

--- a/test/snapshots/parser/comments_test/test_0003_HTML_comment_followed_by_html_tag_573b93df7df7d12ef12722008abfc7ee.txt
+++ b/test/snapshots/parser/comments_test/test_0003_HTML_comment_followed_by_html_tag_573b93df7df7d12ef12722008abfc7ee.txt
@@ -1,31 +1,31 @@
-@ DocumentNode (location: (0,0)-(0,0))
+@ DocumentNode (location: (1,0)-(1,32))
 ├── name: ∅
 └── children: (2)
-    @ Comment (location: (0,0)-(0,0))
+    @ Comment (location: (1,0)-(1,18))
     ├── name: ∅
     └── children: (1)
-        @ Literal (location: (0,0)-(0,0))
+        @ Literal (location: (1,4)-(1,15))
         ├── name: "Hello World"
         └── children: []
 
-    @ Element (location: (0,0)-(0,0))
+    @ Element (location: (1,18)-(1,32))
     ├── name: ∅
     └── children: (3)
-        @ OpenTag (location: (0,0)-(0,0))
+        @ OpenTag (location: (1,18)-(1,22))
         ├── name: "h1"
         └── children: (1)
-            @ AttributeSet (location: (0,0)-(0,0))
+            @ AttributeSet (location: (1,21)-(1,21))
             ├── name: ∅
             └── children: []
 
-        @ ElementBody (location: (0,0)-(0,0))
+        @ ElementBody (location: (1,22)-(1,27))
         ├── name: ∅
         └── children: (1)
-            @ TextContent (location: (0,0)-(0,0))
+            @ TextContent (location: (1,22)-(1,27))
             ├── name: "Hello"
             └── children: []
 
-        @ CloseTag (location: (0,0)-(0,0))
+        @ CloseTag (location: (1,27)-(1,32))
         ├── name: "h1"
         └── children: []
 

--- a/test/snapshots/parser/comments_test/test_0004_HTML_comment_followed_by_html_tag_with_nested_comment_f4042eb3e6a5d62fcc86e4162fe10cf2.txt
+++ b/test/snapshots/parser/comments_test/test_0004_HTML_comment_followed_by_html_tag_with_nested_comment_f4042eb3e6a5d62fcc86e4162fe10cf2.txt
@@ -1,46 +1,46 @@
-@ DocumentNode (location: (0,0)-(0,0))
+@ DocumentNode (location: (1,0)-(4,7))
 ├── name: ∅
 └── children: (5)
-    @ TextContent (location: (0,0)-(0,0))
+    @ TextContent (location: (1,0)-(2,9))
     ├── name: "\n        "
     └── children: []
 
-    @ Comment (location: (0,0)-(0,0))
+    @ Comment (location: (2,9)-(2,27))
     ├── name: ∅
     └── children: (1)
-        @ Literal (location: (0,0)-(0,0))
+        @ Literal (location: (2,13)-(2,24))
         ├── name: "Hello World"
         └── children: []
 
-    @ TextContent (location: (0,0)-(0,0))
+    @ TextContent (location: (2,0)-(3,9))
     ├── name: "\n        "
     └── children: []
 
-    @ Element (location: (0,0)-(0,0))
+    @ Element (location: (3,9)-(3,38))
     ├── name: ∅
     └── children: (3)
-        @ OpenTag (location: (0,0)-(0,0))
+        @ OpenTag (location: (3,9)-(3,13))
         ├── name: "h1"
         └── children: (1)
-            @ AttributeSet (location: (0,0)-(0,0))
+            @ AttributeSet (location: (3,12)-(3,12))
             ├── name: ∅
             └── children: []
 
-        @ ElementBody (location: (0,0)-(0,0))
+        @ ElementBody (location: (3,13)-(3,33))
         ├── name: ∅
         └── children: (1)
-            @ Comment (location: (0,0)-(0,0))
+            @ Comment (location: (3,13)-(3,33))
             ├── name: ∅
             └── children: (1)
-                @ Literal (location: (0,0)-(0,0))
+                @ Literal (location: (3,17)-(3,30))
                 ├── name: " Hello World "
                 └── children: []
 
-        @ CloseTag (location: (0,0)-(0,0))
+        @ CloseTag (location: (3,33)-(3,38))
         ├── name: "h1"
         └── children: []
 
-    @ TextContent (location: (0,0)-(0,0))
+    @ TextContent (location: (3,0)-(4,7))
     ├── name: "\n      "
     └── children: []
 

--- a/test/snapshots/parser/doctype_test/test_0001_doctype_d50c7b32f19e4848938905f3dc675f44.txt
+++ b/test/snapshots/parser/doctype_test/test_0001_doctype_d50c7b32f19e4848938905f3dc675f44.txt
@@ -1,7 +1,7 @@
-@ DocumentNode (location: (0,0)-(0,0))
+@ DocumentNode (location: (1,0)-(1,10))
 ├── name: ∅
 └── children: (1)
-    @ Doctype (location: (0,0)-(0,0))
+    @ Doctype (location: (1,0)-(1,10))
     ├── name: ""
     └── children: []
 

--- a/test/snapshots/parser/doctype_test/test_0002_doctype_with_space_6bc67d7bee174842987d55662f6e3d1c.txt
+++ b/test/snapshots/parser/doctype_test/test_0002_doctype_with_space_6bc67d7bee174842987d55662f6e3d1c.txt
@@ -1,7 +1,7 @@
-@ DocumentNode (location: (0,0)-(0,0))
+@ DocumentNode (location: (1,0)-(1,11))
 ├── name: ∅
 └── children: (1)
-    @ Doctype (location: (0,0)-(0,0))
+    @ Doctype (location: (1,0)-(1,11))
     ├── name: " "
     └── children: []
 

--- a/test/snapshots/parser/doctype_test/test_0003_doctype_with_html_fe364450e1391215f596d043488f989f.txt
+++ b/test/snapshots/parser/doctype_test/test_0003_doctype_with_html_fe364450e1391215f596d043488f989f.txt
@@ -1,7 +1,7 @@
-@ DocumentNode (location: (0,0)-(0,0))
+@ DocumentNode (location: (1,0)-(1,15))
 ├── name: ∅
 └── children: (1)
-    @ Doctype (location: (0,0)-(0,0))
+    @ Doctype (location: (1,0)-(1,15))
     ├── name: " html"
     └── children: []
 

--- a/test/snapshots/parser/doctype_test/test_0004_two_doctypes_9b920c07c2b2e29b9dcf6cd03f842e08.txt
+++ b/test/snapshots/parser/doctype_test/test_0004_two_doctypes_9b920c07c2b2e29b9dcf6cd03f842e08.txt
@@ -1,11 +1,11 @@
-@ DocumentNode (location: (0,0)-(0,0))
+@ DocumentNode (location: (1,0)-(1,30))
 ├── name: ∅
 └── children: (2)
-    @ Doctype (location: (0,0)-(0,0))
+    @ Doctype (location: (1,0)-(1,15))
     ├── name: " html"
     └── children: []
 
-    @ Doctype (location: (0,0)-(0,0))
+    @ Doctype (location: (1,15)-(1,30))
     ├── name: " html"
     └── children: []
 

--- a/test/snapshots/parser/doctype_test/test_0005_html4_doctype_737d71ee3fb171f813731282cd802c3e.txt
+++ b/test/snapshots/parser/doctype_test/test_0005_html4_doctype_737d71ee3fb171f813731282cd802c3e.txt
@@ -1,7 +1,7 @@
-@ DocumentNode (location: (0,0)-(0,0))
+@ DocumentNode (location: (1,0)-(1,90))
 ├── name: ∅
 └── children: (1)
-    @ Doctype (location: (0,0)-(0,0))
+    @ Doctype (location: (1,0)-(1,90))
     ├── name: " HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd""
     └── children: []
 

--- a/test/snapshots/parser/doctype_test/test_0006_doctype_case_insensitivity_03935adb0833c1f800be8baa0a8aca3a.txt
+++ b/test/snapshots/parser/doctype_test/test_0006_doctype_case_insensitivity_03935adb0833c1f800be8baa0a8aca3a.txt
@@ -1,7 +1,7 @@
-@ DocumentNode (location: (0,0)-(0,0))
+@ DocumentNode (location: (1,0)-(1,10))
 ├── name: ∅
 └── children: (1)
-    @ Doctype (location: (0,0)-(0,0))
+    @ Doctype (location: (1,0)-(1,10))
     ├── name: ""
     └── children: []
 

--- a/test/snapshots/parser/doctype_test/test_0006_doctype_case_insensitivity_2f56dc84fb5f8e284f42eae7d1f1c597.txt
+++ b/test/snapshots/parser/doctype_test/test_0006_doctype_case_insensitivity_2f56dc84fb5f8e284f42eae7d1f1c597.txt
@@ -1,7 +1,7 @@
-@ DocumentNode (location: (0,0)-(0,0))
+@ DocumentNode (location: (1,0)-(1,10))
 ├── name: ∅
 └── children: (1)
-    @ Doctype (location: (0,0)-(0,0))
+    @ Doctype (location: (1,0)-(1,10))
     ├── name: ""
     └── children: []
 

--- a/test/snapshots/parser/doctype_test/test_0006_doctype_case_insensitivity_3e5902254c42ff2df6f6321086040dbe.txt
+++ b/test/snapshots/parser/doctype_test/test_0006_doctype_case_insensitivity_3e5902254c42ff2df6f6321086040dbe.txt
@@ -1,7 +1,7 @@
-@ DocumentNode (location: (0,0)-(0,0))
+@ DocumentNode (location: (1,0)-(1,10))
 ├── name: ∅
 └── children: (1)
-    @ Doctype (location: (0,0)-(0,0))
+    @ Doctype (location: (1,0)-(1,10))
     ├── name: ""
     └── children: []
 

--- a/test/snapshots/parser/doctype_test/test_0006_doctype_case_insensitivity_8bc9e797250fadb2f5af79f38cf7d74e.txt
+++ b/test/snapshots/parser/doctype_test/test_0006_doctype_case_insensitivity_8bc9e797250fadb2f5af79f38cf7d74e.txt
@@ -1,7 +1,7 @@
-@ DocumentNode (location: (0,0)-(0,0))
+@ DocumentNode (location: (1,0)-(1,10))
 ├── name: ∅
 └── children: (1)
-    @ Doctype (location: (0,0)-(0,0))
+    @ Doctype (location: (1,0)-(1,10))
     ├── name: ""
     └── children: []
 

--- a/test/snapshots/parser/doctype_test/test_0006_doctype_case_insensitivity_d1d92cd6681949b6e66a00ae3723d8db.txt
+++ b/test/snapshots/parser/doctype_test/test_0006_doctype_case_insensitivity_d1d92cd6681949b6e66a00ae3723d8db.txt
@@ -1,7 +1,7 @@
-@ DocumentNode (location: (0,0)-(0,0))
+@ DocumentNode (location: (1,0)-(1,10))
 ├── name: ∅
 └── children: (1)
-    @ Doctype (location: (0,0)-(0,0))
+    @ Doctype (location: (1,0)-(1,10))
     ├── name: ""
     └── children: []
 

--- a/test/snapshots/parser/erb_test/test_0001_interpolate_on_top_level_486c2e36d7c731369b8bc10cc66d671e.txt
+++ b/test/snapshots/parser/erb_test/test_0001_interpolate_on_top_level_486c2e36d7c731369b8bc10cc66d671e.txt
@@ -1,7 +1,7 @@
-@ DocumentNode (location: (0,0)-(0,0))
+@ DocumentNode (location: (1,0)-(1,12))
 ├── name: ∅
 └── children: (1)
-    @ ERBContent (location: (0,0)-(0,0))
+    @ ERBContent (location: (1,0)-(1,12))
     ├── name: " hello "
     └── children: []
 

--- a/test/snapshots/parser/erb_test/test_0002_interpolate_in_element_body_439bfe606142d918aa22c2f4185d92dc.txt
+++ b/test/snapshots/parser/erb_test/test_0002_interpolate_in_element_body_439bfe606142d918aa22c2f4185d92dc.txt
@@ -1,24 +1,24 @@
-@ DocumentNode (location: (0,0)-(0,0))
+@ DocumentNode (location: (1,0)-(1,21))
 ├── name: ∅
 └── children: (1)
-    @ Element (location: (0,0)-(0,0))
+    @ Element (location: (1,0)-(1,21))
     ├── name: ∅
     └── children: (3)
-        @ OpenTag (location: (0,0)-(0,0))
+        @ OpenTag (location: (1,0)-(1,4))
         ├── name: "h1"
         └── children: (1)
-            @ AttributeSet (location: (0,0)-(0,0))
+            @ AttributeSet (location: (1,3)-(1,3))
             ├── name: ∅
             └── children: []
 
-        @ ElementBody (location: (0,0)-(0,0))
+        @ ElementBody (location: (1,4)-(1,16))
         ├── name: ∅
         └── children: (1)
-            @ ERBContent (location: (0,0)-(0,0))
+            @ ERBContent (location: (1,4)-(1,16))
             ├── name: " hello "
             └── children: []
 
-        @ CloseTag (location: (0,0)-(0,0))
+        @ CloseTag (location: (1,16)-(1,21))
         ├── name: "h1"
         └── children: []
 

--- a/test/snapshots/parser/erb_test/test_0003_interpolate_in_element_body_followed_by_text_content_7508a1f47d3869a85e963b96503528a8.txt
+++ b/test/snapshots/parser/erb_test/test_0003_interpolate_in_element_body_followed_by_text_content_7508a1f47d3869a85e963b96503528a8.txt
@@ -1,28 +1,28 @@
-@ DocumentNode (location: (0,0)-(0,0))
+@ DocumentNode (location: (1,0)-(1,27))
 ├── name: ∅
 └── children: (1)
-    @ Element (location: (0,0)-(0,0))
+    @ Element (location: (1,0)-(1,27))
     ├── name: ∅
     └── children: (3)
-        @ OpenTag (location: (0,0)-(0,0))
+        @ OpenTag (location: (1,0)-(1,4))
         ├── name: "h1"
         └── children: (1)
-            @ AttributeSet (location: (0,0)-(0,0))
+            @ AttributeSet (location: (1,3)-(1,3))
             ├── name: ∅
             └── children: []
 
-        @ ElementBody (location: (0,0)-(0,0))
+        @ ElementBody (location: (1,4)-(1,22))
         ├── name: ∅
         └── children: (2)
-            @ ERBContent (location: (0,0)-(0,0))
+            @ ERBContent (location: (1,4)-(1,16))
             ├── name: " Hello "
             └── children: []
 
-            @ TextContent (location: (0,0)-(0,0))
+            @ TextContent (location: (1,16)-(1,22))
             ├── name: " World"
             └── children: []
 
-        @ CloseTag (location: (0,0)-(0,0))
+        @ CloseTag (location: (1,22)-(1,27))
         ├── name: "h1"
         └── children: []
 

--- a/test/snapshots/parser/erb_test/test_0004_interpolate_in_element_body_after_text_content_0a6d20b02f933f919dd2a5fc4993ff3a.txt
+++ b/test/snapshots/parser/erb_test/test_0004_interpolate_in_element_body_after_text_content_0a6d20b02f933f919dd2a5fc4993ff3a.txt
@@ -1,28 +1,28 @@
-@ DocumentNode (location: (0,0)-(0,0))
+@ DocumentNode (location: (1,0)-(1,27))
 ├── name: ∅
 └── children: (1)
-    @ Element (location: (0,0)-(0,0))
+    @ Element (location: (1,0)-(1,27))
     ├── name: ∅
     └── children: (3)
-        @ OpenTag (location: (0,0)-(0,0))
+        @ OpenTag (location: (1,0)-(1,4))
         ├── name: "h1"
         └── children: (1)
-            @ AttributeSet (location: (0,0)-(0,0))
+            @ AttributeSet (location: (1,3)-(1,3))
             ├── name: ∅
             └── children: []
 
-        @ ElementBody (location: (0,0)-(0,0))
+        @ ElementBody (location: (1,4)-(1,22))
         ├── name: ∅
         └── children: (2)
-            @ TextContent (location: (0,0)-(0,0))
+            @ TextContent (location: (1,4)-(1,10))
             ├── name: "Hello "
             └── children: []
 
-            @ ERBContent (location: (0,0)-(0,0))
+            @ ERBContent (location: (1,10)-(1,22))
             ├── name: " World "
             └── children: []
 
-        @ CloseTag (location: (0,0)-(0,0))
+        @ CloseTag (location: (1,22)-(1,27))
         ├── name: "h1"
         └── children: []
 

--- a/test/snapshots/parser/erb_test/test_0005_interpolate_in_element_body_surrounded_by_text_content_b2e0f59912288eae0790d132dc089534.txt
+++ b/test/snapshots/parser/erb_test/test_0005_interpolate_in_element_body_surrounded_by_text_content_b2e0f59912288eae0790d132dc089534.txt
@@ -1,32 +1,32 @@
-@ DocumentNode (location: (0,0)-(0,0))
+@ DocumentNode (location: (1,0)-(1,33))
 ├── name: ∅
 └── children: (1)
-    @ Element (location: (0,0)-(0,0))
+    @ Element (location: (1,0)-(1,33))
     ├── name: ∅
     └── children: (3)
-        @ OpenTag (location: (0,0)-(0,0))
+        @ OpenTag (location: (1,0)-(1,4))
         ├── name: "h1"
         └── children: (1)
-            @ AttributeSet (location: (0,0)-(0,0))
+            @ AttributeSet (location: (1,3)-(1,3))
             ├── name: ∅
             └── children: []
 
-        @ ElementBody (location: (0,0)-(0,0))
+        @ ElementBody (location: (1,4)-(1,28))
         ├── name: ∅
         └── children: (3)
-            @ TextContent (location: (0,0)-(0,0))
+            @ TextContent (location: (1,4)-(1,10))
             ├── name: "Hello "
             └── children: []
 
-            @ ERBContent (location: (0,0)-(0,0))
+            @ ERBContent (location: (1,10)-(1,22))
             ├── name: " World "
             └── children: []
 
-            @ TextContent (location: (0,0)-(0,0))
+            @ TextContent (location: (1,22)-(1,28))
             ├── name: " Hello"
             └── children: []
 
-        @ CloseTag (location: (0,0)-(0,0))
+        @ CloseTag (location: (1,28)-(1,33))
         ├── name: "h1"
         └── children: []
 

--- a/test/snapshots/parser/erb_test/test_0006_interpolate_inside_tag_eab2e64d663c26be3ae86f89610a672c.txt
+++ b/test/snapshots/parser/erb_test/test_0006_interpolate_inside_tag_eab2e64d663c26be3ae86f89610a672c.txt
@@ -1,24 +1,24 @@
-@ DocumentNode (location: (0,0)-(0,0))
+@ DocumentNode (location: (1,0)-(1,26))
 ├── name: ∅
 └── children: (1)
-    @ Element (location: (0,0)-(0,0))
+    @ Element (location: (1,0)-(1,26))
     ├── name: ∅
     └── children: (3)
-        @ OpenTag (location: (0,0)-(0,0))
+        @ OpenTag (location: (1,0)-(1,21))
         ├── name: "h1"
         └── children: (1)
-            @ AttributeSet (location: (0,0)-(0,0))
+            @ AttributeSet (location: (1,3)-(1,20))
             ├── name: ∅
             └── children: (1)
-                @ ERBContent (location: (0,0)-(0,0))
+                @ ERBContent (location: (1,4)-(1,20))
                 ├── name: " "id=test" "
                 └── children: []
 
-        @ ElementBody (location: (0,0)-(0,0))
+        @ ElementBody (location: (1,21)-(1,21))
         ├── name: ∅
         └── children: []
 
-        @ CloseTag (location: (0,0)-(0,0))
+        @ CloseTag (location: (1,21)-(1,26))
         ├── name: "h1"
         └── children: []
 

--- a/test/snapshots/parser/erb_test/test_0007_interpolate_inside_attribute_value_2e13bc9eabd550dcbe23f58ac7a01f99.txt
+++ b/test/snapshots/parser/erb_test/test_0007_interpolate_inside_attribute_value_2e13bc9eabd550dcbe23f58ac7a01f99.txt
@@ -1,34 +1,34 @@
-@ DocumentNode (location: (0,0)-(0,0))
+@ DocumentNode (location: (1,0)-(1,28))
 ├── name: ∅
 └── children: (1)
-    @ Element (location: (0,0)-(0,0))
+    @ Element (location: (1,0)-(1,28))
     ├── name: ∅
     └── children: (3)
-        @ OpenTag (location: (0,0)-(0,0))
+        @ OpenTag (location: (1,0)-(1,23))
         ├── name: "h1"
         └── children: (1)
-            @ AttributeSet (location: (0,0)-(0,0))
+            @ AttributeSet (location: (1,3)-(1,22))
             ├── name: ∅
             └── children: (1)
-                @ Attribute (location: (0,0)-(0,0))
+                @ Attribute (location: (1,4)-(1,22))
                 ├── name: ∅
                 └── children: (2)
-                    @ AttributeName (location: (0,0)-(0,0))
+                    @ AttributeName (location: (1,4)-(1,6))
                     ├── name: "id"
                     └── children: []
 
-                    @ AttributeValue (location: (0,0)-(0,0))
+                    @ AttributeValue (location: (1,7)-(1,22))
                     ├── name: ""
                     └── children: (1)
-                        @ ERBContent (location: (0,0)-(0,0))
+                        @ ERBContent (location: (1,8)-(1,21))
                         ├── name: " "test" "
                         └── children: []
 
-        @ ElementBody (location: (0,0)-(0,0))
+        @ ElementBody (location: (1,23)-(1,23))
         ├── name: ∅
         └── children: []
 
-        @ CloseTag (location: (0,0)-(0,0))
+        @ CloseTag (location: (1,23)-(1,28))
         ├── name: "h1"
         └── children: []
 

--- a/test/snapshots/parser/erb_test/test_0008_interpolate_after_attribute_name_871cced3d8488a845c21475c5f4a6bf1.txt
+++ b/test/snapshots/parser/erb_test/test_0008_interpolate_after_attribute_name_871cced3d8488a845c21475c5f4a6bf1.txt
@@ -1,34 +1,34 @@
-@ DocumentNode (location: (0,0)-(0,0))
+@ DocumentNode (location: (1,0)-(1,26))
 ├── name: ∅
 └── children: (1)
-    @ Element (location: (0,0)-(0,0))
+    @ Element (location: (1,0)-(1,26))
     ├── name: ∅
     └── children: (3)
-        @ OpenTag (location: (0,0)-(0,0))
+        @ OpenTag (location: (1,0)-(1,21))
         ├── name: "h1"
         └── children: (1)
-            @ AttributeSet (location: (0,0)-(0,0))
+            @ AttributeSet (location: (1,3)-(1,20))
             ├── name: ∅
             └── children: (1)
-                @ Attribute (location: (0,0)-(0,0))
+                @ Attribute (location: (1,4)-(1,20))
                 ├── name: ∅
                 └── children: (2)
-                    @ AttributeName (location: (0,0)-(0,0))
+                    @ AttributeName (location: (1,4)-(1,6))
                     ├── name: "id"
                     └── children: []
 
-                    @ AttributeValue (location: (0,0)-(0,0))
+                    @ AttributeValue (location: (1,7)-(1,20))
                     ├── name: ∅
                     └── children: (1)
-                        @ ERBContent (location: (0,0)-(0,0))
+                        @ ERBContent (location: (1,7)-(1,20))
                         ├── name: " "test" "
                         └── children: []
 
-        @ ElementBody (location: (0,0)-(0,0))
+        @ ElementBody (location: (1,21)-(1,21))
         ├── name: ∅
         └── children: []
 
-        @ CloseTag (location: (0,0)-(0,0))
+        @ CloseTag (location: (1,21)-(1,26))
         ├── name: "h1"
         └── children: []
 

--- a/test/snapshots/parser/erb_test/test_0009_interpolate_inside_attribute_value_with_static_content_before_47cae9bfcf12e434a763c78aad910e38.txt
+++ b/test/snapshots/parser/erb_test/test_0009_interpolate_inside_attribute_value_with_static_content_before_47cae9bfcf12e434a763c78aad910e38.txt
@@ -1,38 +1,38 @@
-@ DocumentNode (location: (0,0)-(0,0))
+@ DocumentNode (location: (1,0)-(1,46))
 ├── name: ∅
 └── children: (1)
-    @ Element (location: (0,0)-(0,0))
+    @ Element (location: (1,0)-(1,46))
     ├── name: ∅
     └── children: (3)
-        @ OpenTag (location: (0,0)-(0,0))
+        @ OpenTag (location: (1,0)-(1,41))
         ├── name: "h1"
         └── children: (1)
-            @ AttributeSet (location: (0,0)-(0,0))
+            @ AttributeSet (location: (1,3)-(1,40))
             ├── name: ∅
             └── children: (1)
-                @ Attribute (location: (0,0)-(0,0))
+                @ Attribute (location: (1,4)-(1,40))
                 ├── name: ∅
                 └── children: (2)
-                    @ AttributeName (location: (0,0)-(0,0))
+                    @ AttributeName (location: (1,4)-(1,9))
                     ├── name: "class"
                     └── children: []
 
-                    @ AttributeValue (location: (0,0)-(0,0))
+                    @ AttributeValue (location: (1,10)-(1,40))
                     ├── name: ""
                     └── children: (2)
-                        @ Literal (location: (0,0)-(0,0))
+                        @ Literal (location: (1,11)-(1,22))
                         ├── name: "text-white "
                         └── children: []
 
-                        @ ERBContent (location: (0,0)-(0,0))
+                        @ ERBContent (location: (1,22)-(1,39))
                         ├── name: " "bg-black" "
                         └── children: []
 
-        @ ElementBody (location: (0,0)-(0,0))
+        @ ElementBody (location: (1,41)-(1,41))
         ├── name: ∅
         └── children: []
 
-        @ CloseTag (location: (0,0)-(0,0))
+        @ CloseTag (location: (1,41)-(1,46))
         ├── name: "h1"
         └── children: []
 

--- a/test/snapshots/parser/erb_test/test_0010_interpolate_inside_attribute_value_with_static_content_after_c840a0e926fd1dd829420021b6f5da39.txt
+++ b/test/snapshots/parser/erb_test/test_0010_interpolate_inside_attribute_value_with_static_content_after_c840a0e926fd1dd829420021b6f5da39.txt
@@ -1,38 +1,38 @@
-@ DocumentNode (location: (0,0)-(0,0))
+@ DocumentNode (location: (1,0)-(1,46))
 ├── name: ∅
 └── children: (1)
-    @ Element (location: (0,0)-(0,0))
+    @ Element (location: (1,0)-(1,46))
     ├── name: ∅
     └── children: (3)
-        @ OpenTag (location: (0,0)-(0,0))
+        @ OpenTag (location: (1,0)-(1,41))
         ├── name: "h1"
         └── children: (1)
-            @ AttributeSet (location: (0,0)-(0,0))
+            @ AttributeSet (location: (1,3)-(1,40))
             ├── name: ∅
             └── children: (1)
-                @ Attribute (location: (0,0)-(0,0))
+                @ Attribute (location: (1,4)-(1,40))
                 ├── name: ∅
                 └── children: (2)
-                    @ AttributeName (location: (0,0)-(0,0))
+                    @ AttributeName (location: (1,4)-(1,9))
                     ├── name: "class"
                     └── children: []
 
-                    @ AttributeValue (location: (0,0)-(0,0))
+                    @ AttributeValue (location: (1,10)-(1,40))
                     ├── name: " text-white"
                     └── children: (2)
-                        @ ERBContent (location: (0,0)-(0,0))
+                        @ ERBContent (location: (1,11)-(1,28))
                         ├── name: " "bg-black" "
                         └── children: []
 
-                        @ Literal (location: (0,0)-(0,0))
+                        @ Literal (location: (1,28)-(1,39))
                         ├── name: " text-white"
                         └── children: []
 
-        @ ElementBody (location: (0,0)-(0,0))
+        @ ElementBody (location: (1,41)-(1,41))
         ├── name: ∅
         └── children: []
 
-        @ CloseTag (location: (0,0)-(0,0))
+        @ CloseTag (location: (1,41)-(1,46))
         ├── name: "h1"
         └── children: []
 

--- a/test/snapshots/parser/erb_test/test_0011_interpolate_inside_attribute_value_with_static_content_around_2d529a29e9c00085642b4f843fd79c5c.txt
+++ b/test/snapshots/parser/erb_test/test_0011_interpolate_inside_attribute_value_with_static_content_around_2d529a29e9c00085642b4f843fd79c5c.txt
@@ -1,42 +1,42 @@
-@ DocumentNode (location: (0,0)-(0,0))
+@ DocumentNode (location: (1,0)-(1,52))
 ├── name: ∅
 └── children: (1)
-    @ Element (location: (0,0)-(0,0))
+    @ Element (location: (1,0)-(1,52))
     ├── name: ∅
     └── children: (3)
-        @ OpenTag (location: (0,0)-(0,0))
+        @ OpenTag (location: (1,0)-(1,47))
         ├── name: "h1"
         └── children: (1)
-            @ AttributeSet (location: (0,0)-(0,0))
+            @ AttributeSet (location: (1,3)-(1,46))
             ├── name: ∅
             └── children: (1)
-                @ Attribute (location: (0,0)-(0,0))
+                @ Attribute (location: (1,4)-(1,46))
                 ├── name: ∅
                 └── children: (2)
-                    @ AttributeName (location: (0,0)-(0,0))
+                    @ AttributeName (location: (1,4)-(1,9))
                     ├── name: "class"
                     └── children: []
 
-                    @ AttributeValue (location: (0,0)-(0,0))
+                    @ AttributeValue (location: (1,10)-(1,46))
                     ├── name: " title"
                     └── children: (3)
-                        @ Literal (location: (0,0)-(0,0))
+                        @ Literal (location: (1,11)-(1,22))
                         ├── name: "text-white "
                         └── children: []
 
-                        @ ERBContent (location: (0,0)-(0,0))
+                        @ ERBContent (location: (1,22)-(1,39))
                         ├── name: " "bg-black" "
                         └── children: []
 
-                        @ Literal (location: (0,0)-(0,0))
+                        @ Literal (location: (1,39)-(1,45))
                         ├── name: " title"
                         └── children: []
 
-        @ ElementBody (location: (0,0)-(0,0))
+        @ ElementBody (location: (1,47)-(1,47))
         ├── name: ∅
         └── children: []
 
-        @ CloseTag (location: (0,0)-(0,0))
+        @ CloseTag (location: (1,47)-(1,52))
         ├── name: "h1"
         └── children: []
 

--- a/test/snapshots/parser/erb_test/test_0012_interpolate_inside_comment_bfdabf4936ec72a10ffc2e12adfb446a.txt
+++ b/test/snapshots/parser/erb_test/test_0012_interpolate_inside_comment_bfdabf4936ec72a10ffc2e12adfb446a.txt
@@ -1,18 +1,18 @@
-@ DocumentNode (location: (0,0)-(0,0))
+@ DocumentNode (location: (1,0)-(1,25))
 ├── name: ∅
 └── children: (1)
-    @ Comment (location: (0,0)-(0,0))
+    @ Comment (location: (1,0)-(1,25))
     ├── name: ∅
     └── children: (3)
-        @ Literal (location: (0,0)-(0,0))
+        @ Literal (location: (1,4)-(1,5))
         ├── name: " "
         └── children: []
 
-        @ ERBContent (location: (0,0)-(0,0))
+        @ ERBContent (location: (1,5)-(1,21))
         ├── name: " "Comment" "
         └── children: []
 
-        @ Literal (location: (0,0)-(0,0))
+        @ Literal (location: (1,21)-(1,22))
         ├── name: " "
         └── children: []
 

--- a/test/snapshots/parser/erb_test/test_0013_conditional_tags_53b63ea8caff68a33c4251d086ba42b9.txt
+++ b/test/snapshots/parser/erb_test/test_0013_conditional_tags_53b63ea8caff68a33c4251d086ba42b9.txt
@@ -1,74 +1,74 @@
-@ DocumentNode (location: (0,0)-(0,0))
+@ DocumentNode (location: (1,0)-(1,82))
 ├── name: ∅
 └── children: (1)
-    @ Element (location: (0,0)-(0,0))
+    @ Element (location: (1,0)-(1,82))
     ├── name: ∅
     └── children: (3)
-        @ OpenTag (location: (0,0)-(0,0))
+        @ OpenTag (location: (1,0)-(1,5))
         ├── name: "div"
         └── children: (1)
-            @ AttributeSet (location: (0,0)-(0,0))
+            @ AttributeSet (location: (1,4)-(1,4))
             ├── name: ∅
             └── children: []
 
-        @ ElementBody (location: (0,0)-(0,0))
+        @ ElementBody (location: (1,5)-(1,76))
         ├── name: ∅
         └── children: (5)
-            @ ERBContent (location: (0,0)-(0,0))
+            @ ERBContent (location: (1,5)-(1,19))
             ├── name: " if bold? "
             └── children: []
 
-            @ Element (location: (0,0)-(0,0))
+            @ Element (location: (1,19)-(1,38))
             ├── name: ∅
             └── children: (3)
-                @ OpenTag (location: (0,0)-(0,0))
+                @ OpenTag (location: (1,19)-(1,22))
                 ├── name: "b"
                 └── children: (1)
-                    @ AttributeSet (location: (0,0)-(0,0))
+                    @ AttributeSet (location: (1,21)-(1,21))
                     ├── name: ∅
                     └── children: []
 
-                @ ElementBody (location: (0,0)-(0,0))
+                @ ElementBody (location: (1,22)-(1,34))
                 ├── name: ∅
                 └── children: (1)
-                    @ ERBContent (location: (0,0)-(0,0))
+                    @ ERBContent (location: (1,22)-(1,34))
                     ├── name: " title "
                     └── children: []
 
-                @ CloseTag (location: (0,0)-(0,0))
+                @ CloseTag (location: (1,34)-(1,38))
                 ├── name: "b"
                 └── children: []
 
-            @ ERBContent (location: (0,0)-(0,0))
+            @ ERBContent (location: (1,38)-(1,48))
             ├── name: " else "
             └── children: []
 
-            @ Element (location: (0,0)-(0,0))
+            @ Element (location: (1,48)-(1,67))
             ├── name: ∅
             └── children: (3)
-                @ OpenTag (location: (0,0)-(0,0))
+                @ OpenTag (location: (1,48)-(1,51))
                 ├── name: "b"
                 └── children: (1)
-                    @ AttributeSet (location: (0,0)-(0,0))
+                    @ AttributeSet (location: (1,50)-(1,50))
                     ├── name: ∅
                     └── children: []
 
-                @ ElementBody (location: (0,0)-(0,0))
+                @ ElementBody (location: (1,51)-(1,63))
                 ├── name: ∅
                 └── children: (1)
-                    @ ERBContent (location: (0,0)-(0,0))
+                    @ ERBContent (location: (1,51)-(1,63))
                     ├── name: " title "
                     └── children: []
 
-                @ CloseTag (location: (0,0)-(0,0))
+                @ CloseTag (location: (1,63)-(1,67))
                 ├── name: "b"
                 └── children: []
 
-            @ ERBContent (location: (0,0)-(0,0))
+            @ ERBContent (location: (1,67)-(1,76))
             ├── name: " end "
             └── children: []
 
-        @ CloseTag (location: (0,0)-(0,0))
+        @ CloseTag (location: (1,76)-(1,82))
         ├── name: "div"
         └── children: []
 

--- a/test/snapshots/parser/erb_test/test_0014_conditional_attributes_a13d36a12e1c3d8ff1d625b0a32793fa.txt
+++ b/test/snapshots/parser/erb_test/test_0014_conditional_attributes_a13d36a12e1c3d8ff1d625b0a32793fa.txt
@@ -1,54 +1,54 @@
-@ DocumentNode (location: (0,0)-(0,0))
+@ DocumentNode (location: (1,0)-(1,75))
 ├── name: ∅
 └── children: (1)
-    @ Element (location: (0,0)-(0,0))
+    @ Element (location: (1,0)-(1,75))
     ├── name: ∅
     └── children: (3)
-        @ OpenTag (location: (0,0)-(0,0))
+        @ OpenTag (location: (1,0)-(1,69))
         ├── name: "div"
         └── children: (1)
-            @ AttributeSet (location: (0,0)-(0,0))
+            @ AttributeSet (location: (1,4)-(1,68))
             ├── name: ∅
             └── children: (5)
-                @ ERBContent (location: (0,0)-(0,0))
+                @ ERBContent (location: (1,5)-(1,18))
                 ├── name: " if odd? "
                 └── children: []
 
-                @ Attribute (location: (0,0)-(0,0))
+                @ Attribute (location: (1,19)-(1,32))
                 ├── name: ∅
                 └── children: (2)
-                    @ AttributeName (location: (0,0)-(0,0))
+                    @ AttributeName (location: (1,19)-(1,27))
                     ├── name: "data-odd"
                     └── children: []
 
-                    @ AttributeValue (location: (0,0)-(0,0))
+                    @ AttributeValue (location: (1,28)-(1,32))
                     ├── name: "true"
                     └── children: []
 
-                @ ERBContent (location: (0,0)-(0,0))
+                @ ERBContent (location: (1,33)-(1,43))
                 ├── name: " else "
                 └── children: []
 
-                @ Attribute (location: (0,0)-(0,0))
+                @ Attribute (location: (1,44)-(1,58))
                 ├── name: ∅
                 └── children: (2)
-                    @ AttributeName (location: (0,0)-(0,0))
+                    @ AttributeName (location: (1,44)-(1,52))
                     ├── name: "data-odd"
                     └── children: []
 
-                    @ AttributeValue (location: (0,0)-(0,0))
+                    @ AttributeValue (location: (1,53)-(1,58))
                     ├── name: "false"
                     └── children: []
 
-                @ ERBContent (location: (0,0)-(0,0))
+                @ ERBContent (location: (1,59)-(1,68))
                 ├── name: " end "
                 └── children: []
 
-        @ ElementBody (location: (0,0)-(0,0))
+        @ ElementBody (location: (1,69)-(1,69))
         ├── name: ∅
         └── children: []
 
-        @ CloseTag (location: (0,0)-(0,0))
+        @ CloseTag (location: (1,69)-(1,75))
         ├── name: "div"
         └── children: []
 

--- a/test/snapshots/parser/parser_test/test_0001_nil_560d7cfe153ff63e50fbb9a506bd32ba.txt
+++ b/test/snapshots/parser/parser_test/test_0001_nil_560d7cfe153ff63e50fbb9a506bd32ba.txt
@@ -1,4 +1,4 @@
-@ DocumentNode (location: (0,0)-(0,0))
+@ DocumentNode (location: (1,0)-(1,0))
 ├── name: ∅
 └── children: []
 

--- a/test/snapshots/parser/parser_test/test_0002_empty_file_d41d8cd98f00b204e9800998ecf8427e.txt
+++ b/test/snapshots/parser/parser_test/test_0002_empty_file_d41d8cd98f00b204e9800998ecf8427e.txt
@@ -1,4 +1,4 @@
-@ DocumentNode (location: (0,0)-(0,0))
+@ DocumentNode (location: (1,0)-(1,0))
 ├── name: ∅
 └── children: []
 

--- a/test/snapshots/parser/tags_test/test_0001_empty_tag_dfc9870d38d11e806e61bd5a448afc82.txt
+++ b/test/snapshots/parser/tags_test/test_0001_empty_tag_dfc9870d38d11e806e61bd5a448afc82.txt
@@ -1,21 +1,21 @@
-@ DocumentNode (location: (0,0)-(0,0))
+@ DocumentNode (location: (1,0)-(1,13))
 ├── name: ∅
 └── children: (1)
-    @ Element (location: (0,0)-(0,0))
+    @ Element (location: (1,0)-(1,13))
     ├── name: ∅
     └── children: (3)
-        @ OpenTag (location: (0,0)-(0,0))
+        @ OpenTag (location: (1,0)-(1,6))
         ├── name: "span"
         └── children: (1)
-            @ AttributeSet (location: (0,0)-(0,0))
+            @ AttributeSet (location: (1,5)-(1,5))
             ├── name: ∅
             └── children: []
 
-        @ ElementBody (location: (0,0)-(0,0))
+        @ ElementBody (location: (1,6)-(1,6))
         ├── name: ∅
         └── children: []
 
-        @ CloseTag (location: (0,0)-(0,0))
+        @ CloseTag (location: (1,6)-(1,13))
         ├── name: "span"
         └── children: []
 

--- a/test/snapshots/parser/tags_test/test_0002_empty_tag_with_whitespace_1e2608bc54aecef5ea56dede40640b51.txt
+++ b/test/snapshots/parser/tags_test/test_0002_empty_tag_with_whitespace_1e2608bc54aecef5ea56dede40640b51.txt
@@ -1,24 +1,24 @@
-@ DocumentNode (location: (0,0)-(0,0))
+@ DocumentNode (location: (1,0)-(1,14))
 ├── name: ∅
 └── children: (1)
-    @ Element (location: (0,0)-(0,0))
+    @ Element (location: (1,0)-(1,14))
     ├── name: ∅
     └── children: (3)
-        @ OpenTag (location: (0,0)-(0,0))
+        @ OpenTag (location: (1,0)-(1,6))
         ├── name: "span"
         └── children: (1)
-            @ AttributeSet (location: (0,0)-(0,0))
+            @ AttributeSet (location: (1,5)-(1,5))
             ├── name: ∅
             └── children: []
 
-        @ ElementBody (location: (0,0)-(0,0))
+        @ ElementBody (location: (1,6)-(1,7))
         ├── name: ∅
         └── children: (1)
-            @ TextContent (location: (0,0)-(0,0))
+            @ TextContent (location: (1,6)-(1,7))
             ├── name: " "
             └── children: []
 
-        @ CloseTag (location: (0,0)-(0,0))
+        @ CloseTag (location: (1,7)-(1,14))
         ├── name: "span"
         └── children: []
 

--- a/test/snapshots/parser/tags_test/test_0003_empty_tag_with_newline_d07900ededde58845d8cc2ee728ace9f.txt
+++ b/test/snapshots/parser/tags_test/test_0003_empty_tag_with_newline_d07900ededde58845d8cc2ee728ace9f.txt
@@ -1,24 +1,24 @@
-@ DocumentNode (location: (0,0)-(0,0))
+@ DocumentNode (location: (1,0)-(2,8))
 ├── name: ∅
 └── children: (1)
-    @ Element (location: (0,0)-(0,0))
+    @ Element (location: (1,0)-(2,8))
     ├── name: ∅
     └── children: (3)
-        @ OpenTag (location: (0,0)-(0,0))
+        @ OpenTag (location: (1,0)-(1,6))
         ├── name: "span"
         └── children: (1)
-            @ AttributeSet (location: (0,0)-(0,0))
+            @ AttributeSet (location: (1,5)-(1,5))
             ├── name: ∅
             └── children: []
 
-        @ ElementBody (location: (0,0)-(0,0))
+        @ ElementBody (location: (1,0)-(2,1))
         ├── name: ∅
         └── children: (1)
-            @ TextContent (location: (0,0)-(0,0))
+            @ TextContent (location: (1,0)-(2,1))
             ├── name: "\n"
             └── children: []
 
-        @ CloseTag (location: (0,0)-(0,0))
+        @ CloseTag (location: (2,1)-(2,8))
         ├── name: "span"
         └── children: []
 

--- a/test/snapshots/parser/tags_test/test_0004_br_tag_8b0f0ea73162b7552dda3c149b6c045d.txt
+++ b/test/snapshots/parser/tags_test/test_0004_br_tag_8b0f0ea73162b7552dda3c149b6c045d.txt
@@ -1,13 +1,13 @@
-@ DocumentNode (location: (0,0)-(0,0))
+@ DocumentNode (location: (1,0)-(1,4))
 ├── name: ∅
 └── children: (1)
-    @ Element (location: (0,0)-(0,0))
+    @ Element (location: (1,0)-(1,4))
     ├── name: ∅
     └── children: (1)
-        @ SelfCloseTag (location: (0,0)-(0,0))
+        @ SelfCloseTag (location: (1,0)-(1,4))
         ├── name: "br"
         └── children: (1)
-            @ AttributeSet (location: (0,0)-(0,0))
+            @ AttributeSet (location: (1,3)-(1,3))
             ├── name: ∅
             └── children: []
 

--- a/test/snapshots/parser/tags_test/test_0005_br_self-closing_tag_c5a0e9b5c299ec39a2fb26fa8b1c0dcf.txt
+++ b/test/snapshots/parser/tags_test/test_0005_br_self-closing_tag_c5a0e9b5c299ec39a2fb26fa8b1c0dcf.txt
@@ -1,13 +1,13 @@
-@ DocumentNode (location: (0,0)-(0,0))
+@ DocumentNode (location: (1,0)-(1,5))
 ├── name: ∅
 └── children: (1)
-    @ Element (location: (0,0)-(0,0))
+    @ Element (location: (1,0)-(1,5))
     ├── name: ∅
     └── children: (1)
-        @ SelfCloseTag (location: (0,0)-(0,0))
+        @ SelfCloseTag (location: (1,0)-(1,5))
         ├── name: "br"
         └── children: (1)
-            @ AttributeSet (location: (0,0)-(0,0))
+            @ AttributeSet (location: (1,3)-(1,3))
             ├── name: ∅
             └── children: []
 

--- a/test/snapshots/parser/tags_test/test_0006_basic_tag_c83301425b2ad1d496473a5ff3d9ecca.txt
+++ b/test/snapshots/parser/tags_test/test_0006_basic_tag_c83301425b2ad1d496473a5ff3d9ecca.txt
@@ -1,21 +1,21 @@
-@ DocumentNode (location: (0,0)-(0,0))
+@ DocumentNode (location: (1,0)-(1,13))
 ├── name: ∅
 └── children: (1)
-    @ Element (location: (0,0)-(0,0))
+    @ Element (location: (1,0)-(1,13))
     ├── name: ∅
     └── children: (3)
-        @ OpenTag (location: (0,0)-(0,0))
+        @ OpenTag (location: (1,0)-(1,6))
         ├── name: "html"
         └── children: (1)
-            @ AttributeSet (location: (0,0)-(0,0))
+            @ AttributeSet (location: (1,5)-(1,5))
             ├── name: ∅
             └── children: []
 
-        @ ElementBody (location: (0,0)-(0,0))
+        @ ElementBody (location: (1,6)-(1,6))
         ├── name: ∅
         └── children: []
 
-        @ CloseTag (location: (0,0)-(0,0))
+        @ CloseTag (location: (1,6)-(1,13))
         ├── name: "html"
         └── children: []
 

--- a/test/snapshots/parser/tags_test/test_0007_mismatched_closing_tag_7165dc23abec2b6bf23cbd14f51aa23b.txt
+++ b/test/snapshots/parser/tags_test/test_0007_mismatched_closing_tag_7165dc23abec2b6bf23cbd14f51aa23b.txt
@@ -1,25 +1,25 @@
-@ DocumentNode (location: (0,0)-(0,0))
+@ DocumentNode (location: (1,0)-(1,12))
 ├── name: ∅
 └── children: (1)
-    @ Element (location: (0,0)-(0,0))
+    @ Element (location: (1,0)-(1,12))
     ├── name: ∅
     └── children: (4)
-        @ OpenTag (location: (0,0)-(0,0))
+        @ OpenTag (location: (1,0)-(1,6))
         ├── name: "html"
         └── children: (1)
-            @ AttributeSet (location: (0,0)-(0,0))
+            @ AttributeSet (location: (1,5)-(1,5))
             ├── name: ∅
             └── children: []
 
-        @ ElementBody (location: (0,0)-(0,0))
+        @ ElementBody (location: (1,6)-(1,6))
         ├── name: ∅
         └── children: []
 
-        @ CloseTag (location: (0,0)-(0,0))
+        @ CloseTag (location: (1,6)-(1,12))
         ├── name: "div"
         └── children: []
 
-        @ UnexcpectedToken (location: (0,0)-(0,0))
+        @ UnexcpectedToken (location: (1,6)-(1,12))
         ├── name: "[Parser]: Unexpected Token mismatched closing tag (expected 'html', got: 'div')"
         └── children: []
 

--- a/test/snapshots/parser/tags_test/test_0008_nested_tags_f5b31fa25627c8dfbb3b8527c3cc2b02.txt
+++ b/test/snapshots/parser/tags_test/test_0008_nested_tags_f5b31fa25627c8dfbb3b8527c3cc2b02.txt
@@ -1,62 +1,62 @@
-@ DocumentNode (location: (0,0)-(0,0))
+@ DocumentNode (location: (1,0)-(1,43))
 ├── name: ∅
 └── children: (1)
-    @ Element (location: (0,0)-(0,0))
+    @ Element (location: (1,0)-(1,43))
     ├── name: ∅
     └── children: (3)
-        @ OpenTag (location: (0,0)-(0,0))
+        @ OpenTag (location: (1,0)-(1,5))
         ├── name: "div"
         └── children: (1)
-            @ AttributeSet (location: (0,0)-(0,0))
+            @ AttributeSet (location: (1,4)-(1,4))
             ├── name: ∅
             └── children: []
 
-        @ ElementBody (location: (0,0)-(0,0))
+        @ ElementBody (location: (1,5)-(1,37))
         ├── name: ∅
         └── children: (1)
-            @ Element (location: (0,0)-(0,0))
+            @ Element (location: (1,5)-(1,37))
             ├── name: ∅
             └── children: (3)
-                @ OpenTag (location: (0,0)-(0,0))
+                @ OpenTag (location: (1,5)-(1,9))
                 ├── name: "h1"
                 └── children: (1)
-                    @ AttributeSet (location: (0,0)-(0,0))
+                    @ AttributeSet (location: (1,8)-(1,8))
                     ├── name: ∅
                     └── children: []
 
-                @ ElementBody (location: (0,0)-(0,0))
+                @ ElementBody (location: (1,9)-(1,32))
                 ├── name: ∅
                 └── children: (2)
-                    @ TextContent (location: (0,0)-(0,0))
+                    @ TextContent (location: (1,9)-(1,14))
                     ├── name: "Hello"
                     └── children: []
 
-                    @ Element (location: (0,0)-(0,0))
+                    @ Element (location: (1,14)-(1,32))
                     ├── name: ∅
                     └── children: (3)
-                        @ OpenTag (location: (0,0)-(0,0))
+                        @ OpenTag (location: (1,14)-(1,20))
                         ├── name: "span"
                         └── children: (1)
-                            @ AttributeSet (location: (0,0)-(0,0))
+                            @ AttributeSet (location: (1,19)-(1,19))
                             ├── name: ∅
                             └── children: []
 
-                        @ ElementBody (location: (0,0)-(0,0))
+                        @ ElementBody (location: (1,20)-(1,25))
                         ├── name: ∅
                         └── children: (1)
-                            @ TextContent (location: (0,0)-(0,0))
+                            @ TextContent (location: (1,20)-(1,25))
                             ├── name: "World"
                             └── children: []
 
-                        @ CloseTag (location: (0,0)-(0,0))
+                        @ CloseTag (location: (1,25)-(1,32))
                         ├── name: "span"
                         └── children: []
 
-                @ CloseTag (location: (0,0)-(0,0))
+                @ CloseTag (location: (1,32)-(1,37))
                 ├── name: "h1"
                 └── children: []
 
-        @ CloseTag (location: (0,0)-(0,0))
+        @ CloseTag (location: (1,37)-(1,43))
         ├── name: "div"
         └── children: []
 

--- a/test/snapshots/parser/tags_test/test_0009_basic_void_tag_0a22925ab034fd09eb49cc4224720dcb.txt
+++ b/test/snapshots/parser/tags_test/test_0009_basic_void_tag_0a22925ab034fd09eb49cc4224720dcb.txt
@@ -1,13 +1,13 @@
-@ DocumentNode (location: (0,0)-(0,0))
+@ DocumentNode (location: (1,0)-(1,7))
 ├── name: ∅
 └── children: (1)
-    @ Element (location: (0,0)-(0,0))
+    @ Element (location: (1,0)-(1,7))
     ├── name: ∅
     └── children: (1)
-        @ SelfCloseTag (location: (0,0)-(0,0))
+        @ SelfCloseTag (location: (1,0)-(1,7))
         ├── name: "img"
         └── children: (1)
-            @ AttributeSet (location: (0,0)-(0,0))
+            @ AttributeSet (location: (1,4)-(1,5))
             ├── name: ∅
             └── children: []
 

--- a/test/snapshots/parser/tags_test/test_0010_basic_void_tag_without_whitespace_917eccff1c0d00dbdc9bbe20d07c939c.txt
+++ b/test/snapshots/parser/tags_test/test_0010_basic_void_tag_without_whitespace_917eccff1c0d00dbdc9bbe20d07c939c.txt
@@ -1,13 +1,13 @@
-@ DocumentNode (location: (0,0)-(0,0))
+@ DocumentNode (location: (1,0)-(1,6))
 ├── name: ∅
 └── children: (1)
-    @ Element (location: (0,0)-(0,0))
+    @ Element (location: (1,0)-(1,6))
     ├── name: ∅
     └── children: (1)
-        @ SelfCloseTag (location: (0,0)-(0,0))
+        @ SelfCloseTag (location: (1,0)-(1,6))
         ├── name: "img"
         └── children: (1)
-            @ AttributeSet (location: (0,0)-(0,0))
+            @ AttributeSet (location: (1,4)-(1,4))
             ├── name: ∅
             └── children: []
 

--- a/test/snapshots/parser/tags_test/test_0011_namespaced_tag_45f3ec5566563217212e18f9f9983f0a.txt
+++ b/test/snapshots/parser/tags_test/test_0011_namespaced_tag_45f3ec5566563217212e18f9f9983f0a.txt
@@ -1,21 +1,21 @@
-@ DocumentNode (location: (0,0)-(0,0))
+@ DocumentNode (location: (1,0)-(1,21))
 ├── name: ∅
 └── children: (1)
-    @ Element (location: (0,0)-(0,0))
+    @ Element (location: (1,0)-(1,21))
     ├── name: ∅
     └── children: (3)
-        @ OpenTag (location: (0,0)-(0,0))
+        @ OpenTag (location: (1,0)-(1,10))
         ├── name: "ns:table"
         └── children: (1)
-            @ AttributeSet (location: (0,0)-(0,0))
+            @ AttributeSet (location: (1,9)-(1,9))
             ├── name: ∅
             └── children: []
 
-        @ ElementBody (location: (0,0)-(0,0))
+        @ ElementBody (location: (1,10)-(1,10))
         ├── name: ∅
         └── children: []
 
-        @ CloseTag (location: (0,0)-(0,0))
+        @ CloseTag (location: (1,10)-(1,21))
         ├── name: "ns:table"
         └── children: []
 

--- a/test/snapshots/parser/tags_test/test_0012_colon_inside_html_tag_b7b46dcd10fad620a00a95b27daab204.txt
+++ b/test/snapshots/parser/tags_test/test_0012_colon_inside_html_tag_b7b46dcd10fad620a00a95b27daab204.txt
@@ -1,35 +1,35 @@
-@ DocumentNode (location: (0,0)-(0,0))
+@ DocumentNode (location: (1,0)-(1,22))
 ├── name: ∅
 └── children: (1)
-    @ Element (location: (0,0)-(0,0))
+    @ Element (location: (1,0)-(1,22))
     ├── name: ∅
     └── children: (3)
-        @ OpenTag (location: (0,0)-(0,0))
+        @ OpenTag (location: (1,0)-(1,16))
         ├── name: "div"
         └── children: (1)
-            @ AttributeSet (location: (0,0)-(0,0))
+            @ AttributeSet (location: (1,4)-(1,15))
             ├── name: ∅
             └── children: (2)
-                @ UnexcpectedToken (location: (0,0)-(0,0))
+                @ UnexcpectedToken (location: (1,5)-(1,6))
                 ├── name: "[Parser]: Unexpected Token : (expected 'TOKEN_WHITESPACE', got: 'TOKEN_COLON')"
                 └── children: []
 
-                @ Attribute (location: (0,0)-(0,0))
+                @ Attribute (location: (1,7)-(1,15))
                 ├── name: ∅
                 └── children: (2)
-                    @ AttributeName (location: (0,0)-(0,0))
+                    @ AttributeName (location: (1,7)-(1,12))
                     ├── name: "class"
                     └── children: []
 
-                    @ AttributeValue (location: (0,0)-(0,0))
+                    @ AttributeValue (location: (1,13)-(1,15))
                     ├── name: ""
                     └── children: []
 
-        @ ElementBody (location: (0,0)-(0,0))
+        @ ElementBody (location: (1,16)-(1,16))
         ├── name: ∅
         └── children: []
 
-        @ CloseTag (location: (0,0)-(0,0))
+        @ CloseTag (location: (1,16)-(1,22))
         ├── name: "div"
         └── children: []
 

--- a/test/snapshots/parser/text_content_test/test_0001_text_content_b10a8db164e0754105b7a99be72e3fe5.txt
+++ b/test/snapshots/parser/text_content_test/test_0001_text_content_b10a8db164e0754105b7a99be72e3fe5.txt
@@ -1,7 +1,7 @@
-@ DocumentNode (location: (0,0)-(0,0))
+@ DocumentNode (location: (1,0)-(1,11))
 ├── name: ∅
 └── children: (1)
-    @ TextContent (location: (0,0)-(0,0))
+    @ TextContent (location: (1,0)-(1,11))
     ├── name: "Hello World"
     └── children: []
 

--- a/test/snapshots/parser/text_content_test/test_0002_text_content_inside_tag_f797031f3210ce6494466d619610926c.txt
+++ b/test/snapshots/parser/text_content_test/test_0002_text_content_inside_tag_f797031f3210ce6494466d619610926c.txt
@@ -1,24 +1,24 @@
-@ DocumentNode (location: (0,0)-(0,0))
+@ DocumentNode (location: (1,0)-(1,20))
 ├── name: ∅
 └── children: (1)
-    @ Element (location: (0,0)-(0,0))
+    @ Element (location: (1,0)-(1,20))
     ├── name: ∅
     └── children: (3)
-        @ OpenTag (location: (0,0)-(0,0))
+        @ OpenTag (location: (1,0)-(1,4))
         ├── name: "h1"
         └── children: (1)
-            @ AttributeSet (location: (0,0)-(0,0))
+            @ AttributeSet (location: (1,3)-(1,3))
             ├── name: ∅
             └── children: []
 
-        @ ElementBody (location: (0,0)-(0,0))
+        @ ElementBody (location: (1,4)-(1,15))
         ├── name: ∅
         └── children: (1)
-            @ TextContent (location: (0,0)-(0,0))
+            @ TextContent (location: (1,4)-(1,15))
             ├── name: "Hello World"
             └── children: []
 
-        @ CloseTag (location: (0,0)-(0,0))
+        @ CloseTag (location: (1,15)-(1,20))
         ├── name: "h1"
         └── children: []
 

--- a/test/snapshots/parser/text_content_test/test_0003_text_content_with_tag_after_72f22f51d0be53cd7b1017d11f441721.txt
+++ b/test/snapshots/parser/text_content_test/test_0003_text_content_with_tag_after_72f22f51d0be53cd7b1017d11f441721.txt
@@ -1,28 +1,28 @@
-@ DocumentNode (location: (0,0)-(0,0))
+@ DocumentNode (location: (1,0)-(1,23))
 ├── name: ∅
 └── children: (2)
-    @ TextContent (location: (0,0)-(0,0))
+    @ TextContent (location: (1,0)-(1,5))
     ├── name: "Hello"
     └── children: []
 
-    @ Element (location: (0,0)-(0,0))
+    @ Element (location: (1,5)-(1,23))
     ├── name: ∅
     └── children: (3)
-        @ OpenTag (location: (0,0)-(0,0))
+        @ OpenTag (location: (1,5)-(1,11))
         ├── name: "span"
         └── children: (1)
-            @ AttributeSet (location: (0,0)-(0,0))
+            @ AttributeSet (location: (1,10)-(1,10))
             ├── name: ∅
             └── children: []
 
-        @ ElementBody (location: (0,0)-(0,0))
+        @ ElementBody (location: (1,11)-(1,16))
         ├── name: ∅
         └── children: (1)
-            @ TextContent (location: (0,0)-(0,0))
+            @ TextContent (location: (1,11)-(1,16))
             ├── name: "World"
             └── children: []
 
-        @ CloseTag (location: (0,0)-(0,0))
+        @ CloseTag (location: (1,16)-(1,23))
         ├── name: "span"
         └── children: []
 

--- a/test/snapshots/parser/text_content_test/test_0004_text_content_with_tag_before_75206a4d9262b9f527267fab91d7fac4.txt
+++ b/test/snapshots/parser/text_content_test/test_0004_text_content_with_tag_before_75206a4d9262b9f527267fab91d7fac4.txt
@@ -1,28 +1,28 @@
-@ DocumentNode (location: (0,0)-(0,0))
+@ DocumentNode (location: (1,0)-(1,23))
 ├── name: ∅
 └── children: (2)
-    @ Element (location: (0,0)-(0,0))
+    @ Element (location: (1,0)-(1,18))
     ├── name: ∅
     └── children: (3)
-        @ OpenTag (location: (0,0)-(0,0))
+        @ OpenTag (location: (1,0)-(1,6))
         ├── name: "span"
         └── children: (1)
-            @ AttributeSet (location: (0,0)-(0,0))
+            @ AttributeSet (location: (1,5)-(1,5))
             ├── name: ∅
             └── children: []
 
-        @ ElementBody (location: (0,0)-(0,0))
+        @ ElementBody (location: (1,6)-(1,11))
         ├── name: ∅
         └── children: (1)
-            @ TextContent (location: (0,0)-(0,0))
+            @ TextContent (location: (1,6)-(1,11))
             ├── name: "Hello"
             └── children: []
 
-        @ CloseTag (location: (0,0)-(0,0))
+        @ CloseTag (location: (1,11)-(1,18))
         ├── name: "span"
         └── children: []
 
-    @ TextContent (location: (0,0)-(0,0))
+    @ TextContent (location: (1,18)-(1,23))
     ├── name: "World"
     └── children: []
 

--- a/test/snapshots/parser/text_content_test/test_0005_text_content_with_tag_around_36c530447a30a5bccff1c61bc5e4465d.txt
+++ b/test/snapshots/parser/text_content_test/test_0005_text_content_with_tag_around_36c530447a30a5bccff1c61bc5e4465d.txt
@@ -1,29 +1,29 @@
-@ DocumentNode (location: (0,0)-(0,0))
+@ DocumentNode (location: (1,0)-(1,23))
 ├── name: ∅
 └── children: (3)
-    @ TextContent (location: (0,0)-(0,0))
+    @ TextContent (location: (1,0)-(1,5))
     ├── name: "Hello"
     └── children: []
 
-    @ Element (location: (0,0)-(0,0))
+    @ Element (location: (1,5)-(1,18))
     ├── name: ∅
     └── children: (3)
-        @ OpenTag (location: (0,0)-(0,0))
+        @ OpenTag (location: (1,5)-(1,11))
         ├── name: "span"
         └── children: (1)
-            @ AttributeSet (location: (0,0)-(0,0))
+            @ AttributeSet (location: (1,10)-(1,10))
             ├── name: ∅
             └── children: []
 
-        @ ElementBody (location: (0,0)-(0,0))
+        @ ElementBody (location: (1,11)-(1,11))
         ├── name: ∅
         └── children: []
 
-        @ CloseTag (location: (0,0)-(0,0))
+        @ CloseTag (location: (1,11)-(1,18))
         ├── name: "span"
         └── children: []
 
-    @ TextContent (location: (0,0)-(0,0))
+    @ TextContent (location: (1,18)-(1,23))
     ├── name: "World"
     └── children: []
 


### PR DESCRIPTION
This pull request adds location information to the AST nodes. This will allow for more precise error reporting and better debugging capabilities. 

### Summary

* Added `start` and `end` location fields to the `AST_NODE_T` struct.
* Updated `ast_node_init` function to initialize `start` and `end` locations to `(0,0)`.
* Added new functions to set start and end locations from tokens or directly from location values in `src/ast_node.c`.
* Modified parser functions to set start and end locations for nodes based on tokens. 
* Adjusted the lexer to start from column `0` instead of `1`.
* Enhanced the `ast_node_pretty_print` function to display the start and end locations of nodes.

