### PR TITLE
Add `assert_lexed_snapshot` and use it in lexer tests

### DIFF
--- a/lib/erbx/lex_result.rb
+++ b/lib/erbx/lex_result.rb
@@ -13,5 +13,9 @@ module ERBX
     def initialize(pointer)
       @array = LibERBX::Array.new(pointer, LibERBX::Token)
     end
+
+    def inspect
+      @array.items.map(&:inspect).join("\n")
+    end
   end
 end

--- a/lib/erbx/liberbx/token.rb
+++ b/lib/erbx/liberbx/token.rb
@@ -2,6 +2,7 @@
 
 module ERBX
   module LibERBX
+    attach_function :token_to_string, [:pointer], :string
     attach_function :token_type_to_string, [:int], :pointer
     attach_function :token_value, [:pointer], :pointer
     attach_function :token_type, [:pointer], :int
@@ -26,7 +27,7 @@ module ERBX
       end
 
       def inspect
-        %(#<#{self.class} type="#{type}" value="#{value}">)
+        LibERBX.token_to_string(pointer).force_encoding("utf-8")
       end
     end
   end

--- a/test/lexer/attributes_test.rb
+++ b/test/lexer/attributes_test.rb
@@ -4,398 +4,84 @@ require_relative "../test_helper"
 
 module Lexer
   class AttributesTest < Minitest::Spec
+    include SnapshotUtils
+
     test "attribute value double quotes" do
-      result = ERBX.lex(%(<img value="hello world" />))
-
-      expected = %w[
-        TOKEN_HTML_TAG_START
-        TOKEN_IDENTIFIER
-        TOKEN_WHITESPACE
-        TOKEN_IDENTIFIER
-        TOKEN_EQUALS
-        TOKEN_QUOTE
-        TOKEN_IDENTIFIER
-        TOKEN_WHITESPACE
-        TOKEN_IDENTIFIER
-        TOKEN_QUOTE
-        TOKEN_WHITESPACE
-        TOKEN_HTML_TAG_SELF_CLOSE
-        TOKEN_EOF
-      ]
-
-      assert_equal expected, result.array.items.map(&:type)
+      assert_lexed_snapshot(%(<img value="hello world" />))
     end
 
     test "attribute value single quotes" do
-      result = ERBX.lex(%(<img value='hello world' />))
-
-      expected = %w[
-        TOKEN_HTML_TAG_START
-        TOKEN_IDENTIFIER
-        TOKEN_WHITESPACE
-        TOKEN_IDENTIFIER
-        TOKEN_EQUALS
-        TOKEN_QUOTE
-        TOKEN_IDENTIFIER
-        TOKEN_WHITESPACE
-        TOKEN_IDENTIFIER
-        TOKEN_QUOTE
-        TOKEN_WHITESPACE
-        TOKEN_HTML_TAG_SELF_CLOSE
-        TOKEN_EOF
-      ]
-
-      assert_equal expected, result.array.items.map(&:type)
+      assert_lexed_snapshot(%(<img value='hello world' />))
     end
 
     test "attribute value empty double quotes with whitespace" do
-      result = ERBX.lex(%(<img value="" />))
-
-      expected = %w[
-        TOKEN_HTML_TAG_START
-        TOKEN_IDENTIFIER
-        TOKEN_WHITESPACE
-        TOKEN_IDENTIFIER
-        TOKEN_EQUALS
-        TOKEN_QUOTE
-        TOKEN_QUOTE
-        TOKEN_WHITESPACE
-        TOKEN_HTML_TAG_SELF_CLOSE
-        TOKEN_EOF
-      ]
-
-      assert_equal expected, result.array.items.map(&:type)
+      assert_lexed_snapshot(%(<img value="" />))
     end
 
     test "attribute value empty double quotes without whitespace" do
-      result = ERBX.lex(%(<img value=""/>))
-
-      expected = %w[
-        TOKEN_HTML_TAG_START
-        TOKEN_IDENTIFIER
-        TOKEN_WHITESPACE
-        TOKEN_IDENTIFIER
-        TOKEN_EQUALS
-        TOKEN_QUOTE
-        TOKEN_QUOTE
-        TOKEN_HTML_TAG_SELF_CLOSE
-        TOKEN_EOF
-      ]
-
-      assert_equal expected, result.array.items.map(&:type)
+      assert_lexed_snapshot(%(<img value=""/>))
     end
 
     test "attribute value empty single quotes with whitespace" do
-      result = ERBX.lex("<img value='' />")
-
-      expected = %w[
-        TOKEN_HTML_TAG_START
-        TOKEN_IDENTIFIER
-        TOKEN_WHITESPACE
-        TOKEN_IDENTIFIER
-        TOKEN_EQUALS
-        TOKEN_QUOTE
-        TOKEN_QUOTE
-        TOKEN_WHITESPACE
-        TOKEN_HTML_TAG_SELF_CLOSE
-        TOKEN_EOF
-      ]
-
-      assert_equal expected, result.array.items.map(&:type)
+      assert_lexed_snapshot("<img value='' />")
     end
 
     test "attribute value empty single quotes without whitespace" do
-      result = ERBX.lex("<img value=''/>")
-
-      expected = %w[
-        TOKEN_HTML_TAG_START
-        TOKEN_IDENTIFIER
-        TOKEN_WHITESPACE
-        TOKEN_IDENTIFIER
-        TOKEN_EQUALS
-        TOKEN_QUOTE
-        TOKEN_QUOTE
-        TOKEN_HTML_TAG_SELF_CLOSE
-        TOKEN_EOF
-      ]
-
-      assert_equal expected, result.array.items.map(&:type)
+      assert_lexed_snapshot("<img value=''/>")
     end
 
-    test "attribute value single quotes with />" do
-      result = ERBX.lex("<img value='/>'/>")
-
-      expected = %w[
-        TOKEN_HTML_TAG_START
-        TOKEN_IDENTIFIER
-        TOKEN_WHITESPACE
-        TOKEN_IDENTIFIER
-        TOKEN_EQUALS
-        TOKEN_QUOTE
-        TOKEN_HTML_TAG_SELF_CLOSE
-        TOKEN_QUOTE
-        TOKEN_HTML_TAG_SELF_CLOSE
-        TOKEN_EOF
-      ]
-
-      assert_equal expected, result.array.items.map(&:type)
+    test "attribute value single quotes with slash gt" do
+      assert_lexed_snapshot("<img value='/>'/>")
     end
 
-    test "attribute value double quotes with />" do
-      result = ERBX.lex(%(<img value="/>"/>))
-
+    test "attribute value double quotes with slash gt" do
       # `>` is not valid as an attribute value, it should be &lt; which is why we parse it as TOKEN_HTML_TAG_END
-      expected = %w[
-        TOKEN_HTML_TAG_START
-        TOKEN_IDENTIFIER
-        TOKEN_WHITESPACE
-        TOKEN_IDENTIFIER
-        TOKEN_EQUALS
-        TOKEN_QUOTE
-        TOKEN_HTML_TAG_SELF_CLOSE
-        TOKEN_QUOTE
-        TOKEN_HTML_TAG_SELF_CLOSE
-        TOKEN_EOF
-      ]
-
-      assert_equal expected, result.array.items.map(&:type)
+      assert_lexed_snapshot(%(<img value="/>"/>))
     end
 
     test "attribute value single quotes with > value" do
-      result = ERBX.lex(%(<img value='>'/>))
-
       # `>` is not valid as an attribute value, it should be &lt; which is why we parse it as TOKEN_HTML_TAG_END
-      expected = %w[
-        TOKEN_HTML_TAG_START
-        TOKEN_IDENTIFIER
-        TOKEN_WHITESPACE
-        TOKEN_IDENTIFIER
-        TOKEN_EQUALS
-        TOKEN_QUOTE
-        TOKEN_HTML_TAG_END
-        TOKEN_QUOTE
-        TOKEN_HTML_TAG_SELF_CLOSE
-        TOKEN_EOF
-      ]
-
-      assert_equal expected, result.array.items.map(&:type)
+      assert_lexed_snapshot(%(<img value='>'/>))
     end
 
-    test "attribute value double quotes with /" do
-      result = ERBX.lex(%(<img value="/"/>))
-
-      expected = %w[
-        TOKEN_HTML_TAG_START
-        TOKEN_IDENTIFIER
-        TOKEN_WHITESPACE
-        TOKEN_IDENTIFIER
-        TOKEN_EQUALS
-        TOKEN_QUOTE
-        TOKEN_SLASH
-        TOKEN_QUOTE
-        TOKEN_HTML_TAG_SELF_CLOSE
-        TOKEN_EOF
-      ]
-
-      assert_equal expected, result.array.items.map(&:type)
+    test "attribute value double quotes with slash" do
+      assert_lexed_snapshot(%(<img value="/"/>))
     end
 
     test "attribute value double quotes with > value" do
-      result = ERBX.lex(%(<img value=">"/>))
-
-      # `>` is not valid as an attribute value, it should be &lt; which is why we parse it as TOKEN_HTML_TAG_END
-      expected = %w[
-        TOKEN_HTML_TAG_START
-        TOKEN_IDENTIFIER
-        TOKEN_WHITESPACE
-        TOKEN_IDENTIFIER
-        TOKEN_EQUALS
-        TOKEN_QUOTE
-        TOKEN_HTML_TAG_END
-        TOKEN_QUOTE
-        TOKEN_HTML_TAG_SELF_CLOSE
-        TOKEN_EOF
-      ]
-
-      assert_equal expected, result.array.items.map(&:type)
+      assert_lexed_snapshot(%(<img value=">"/>))
     end
 
-    test "attribute value single quotes with / value" do
-      result = ERBX.lex(%(<img value='>'/>))
-
-      expected = %w[
-        TOKEN_HTML_TAG_START
-        TOKEN_IDENTIFIER
-        TOKEN_WHITESPACE
-        TOKEN_IDENTIFIER
-        TOKEN_EQUALS
-        TOKEN_QUOTE
-        TOKEN_HTML_TAG_END
-        TOKEN_QUOTE
-        TOKEN_HTML_TAG_SELF_CLOSE
-        TOKEN_EOF
-      ]
-
-      assert_equal expected, result.array.items.map(&:type)
+    test "attribute value single quotes with slash value" do
+      assert_lexed_snapshot(%(<img value='>'/>))
     end
 
-    test "attribute value double quotes with / value" do
-      result = ERBX.lex(%(<img value=">"/>))
-
-      expected = %w[
-        TOKEN_HTML_TAG_START
-        TOKEN_IDENTIFIER
-        TOKEN_WHITESPACE
-        TOKEN_IDENTIFIER
-        TOKEN_EQUALS
-        TOKEN_QUOTE
-        TOKEN_HTML_TAG_END
-        TOKEN_QUOTE
-        TOKEN_HTML_TAG_SELF_CLOSE
-        TOKEN_EOF
-      ]
-
-      assert_equal expected, result.array.items.map(&:type)
+    test "attribute value double quotes with slash value" do
+      assert_lexed_snapshot(%(<img value=">"/>))
     end
 
     test "attribute value double quotes with single quote value" do
-      result = ERBX.lex(%(<img value="''"/>))
-
-      expected = %w[
-        TOKEN_HTML_TAG_START
-        TOKEN_IDENTIFIER
-        TOKEN_WHITESPACE
-        TOKEN_IDENTIFIER
-        TOKEN_EQUALS
-        TOKEN_QUOTE
-        TOKEN_QUOTE
-        TOKEN_QUOTE
-        TOKEN_QUOTE
-        TOKEN_HTML_TAG_SELF_CLOSE
-        TOKEN_EOF
-      ]
-
-      assert_equal expected, result.array.items.map(&:type)
+      assert_lexed_snapshot(%(<img value="''"/>))
     end
 
     test "attribute value single quotes with double quote value" do
-      result = ERBX.lex(%(<img value='""'/>))
-
-      expected = %w[
-        TOKEN_HTML_TAG_START
-        TOKEN_IDENTIFIER
-        TOKEN_WHITESPACE
-        TOKEN_IDENTIFIER
-        TOKEN_EQUALS
-        TOKEN_QUOTE
-        TOKEN_QUOTE
-        TOKEN_QUOTE
-        TOKEN_QUOTE
-        TOKEN_HTML_TAG_SELF_CLOSE
-        TOKEN_EOF
-      ]
-
-      assert_equal expected, result.array.items.map(&:type)
+      assert_lexed_snapshot(%(<img value='""'/>))
     end
 
     test "attribute value empty quotes followed by another attribute" do
-      result = ERBX.lex(%(<img value="" required />))
-
-      expected = %w[
-        TOKEN_HTML_TAG_START
-        TOKEN_IDENTIFIER
-        TOKEN_WHITESPACE
-        TOKEN_IDENTIFIER
-        TOKEN_EQUALS
-        TOKEN_QUOTE
-        TOKEN_QUOTE
-        TOKEN_WHITESPACE
-        TOKEN_IDENTIFIER
-        TOKEN_WHITESPACE
-        TOKEN_HTML_TAG_SELF_CLOSE
-        TOKEN_EOF
-      ]
-
-      assert_equal expected, result.array.items.map(&:type)
+      assert_lexed_snapshot(%(<img value="" required />))
     end
 
     test "attribute value with a period" do
-      result = ERBX.lex(%(<div value="hello. world."></div>))
-
-      expected = %w[
-        TOKEN_HTML_TAG_START
-        TOKEN_IDENTIFIER
-        TOKEN_WHITESPACE
-        TOKEN_IDENTIFIER
-        TOKEN_EQUALS
-        TOKEN_QUOTE
-        TOKEN_IDENTIFIER
-        TOKEN_CHARACTER
-        TOKEN_WHITESPACE
-        TOKEN_IDENTIFIER
-        TOKEN_CHARACTER
-        TOKEN_QUOTE
-        TOKEN_HTML_TAG_END
-        TOKEN_HTML_TAG_START_CLOSE
-        TOKEN_IDENTIFIER
-        TOKEN_HTML_TAG_END
-        TOKEN_EOF
-      ]
-
-      assert_equal expected, result.array.items.map(&:type)
+      assert_lexed_snapshot(%(<div value="hello. world."></div>))
     end
 
     test "attribute value with a slash" do
-      result = ERBX.lex(%(<div value="hello/ world/"></div>))
-
-      expected = %w[
-        TOKEN_HTML_TAG_START
-        TOKEN_IDENTIFIER
-        TOKEN_WHITESPACE
-        TOKEN_IDENTIFIER
-        TOKEN_EQUALS
-        TOKEN_QUOTE
-        TOKEN_IDENTIFIER
-        TOKEN_SLASH
-        TOKEN_WHITESPACE
-        TOKEN_IDENTIFIER
-        TOKEN_SLASH
-        TOKEN_QUOTE
-        TOKEN_HTML_TAG_END
-        TOKEN_HTML_TAG_START_CLOSE
-        TOKEN_IDENTIFIER
-        TOKEN_HTML_TAG_END
-        TOKEN_EOF
-      ]
-
-      assert_equal expected, result.array.items.map(&:type)
+      assert_lexed_snapshot(%(<div value="hello/ world/"></div>))
     end
 
     test "attribute value with an URL" do
-      result = ERBX.lex(%(<a href="https://example.com"></div>))
-
-      expected = %w[
-        TOKEN_HTML_TAG_START
-        TOKEN_IDENTIFIER
-        TOKEN_WHITESPACE
-        TOKEN_IDENTIFIER
-        TOKEN_EQUALS
-        TOKEN_QUOTE
-        TOKEN_IDENTIFIER
-        TOKEN_SLASH
-        TOKEN_SLASH
-        TOKEN_IDENTIFIER
-        TOKEN_CHARACTER
-        TOKEN_IDENTIFIER
-        TOKEN_QUOTE
-        TOKEN_HTML_TAG_END
-        TOKEN_HTML_TAG_START_CLOSE
-        TOKEN_IDENTIFIER
-        TOKEN_HTML_TAG_END
-        TOKEN_EOF
-      ]
-
-      assert_equal expected, result.array.items.map(&:type)
+      assert_lexed_snapshot(%(<a href="https://example.com"></div>))
     end
   end
 end

--- a/test/lexer/boolean_attributes_test.rb
+++ b/test/lexer/boolean_attributes_test.rb
@@ -4,65 +4,22 @@ require_relative "../test_helper"
 
 module Lexer
   class BooleanAttributesTest < Minitest::Spec
+    include SnapshotUtils
+
     test "boolean attribute" do
-      result = ERBX.lex("<img required />")
-
-      expected = %w[
-        TOKEN_HTML_TAG_START
-        TOKEN_IDENTIFIER
-        TOKEN_WHITESPACE
-        TOKEN_IDENTIFIER
-        TOKEN_WHITESPACE
-        TOKEN_HTML_TAG_SELF_CLOSE
-        TOKEN_EOF
-      ]
-
-      assert_equal expected, result.array.items.map(&:type)
+      assert_lexed_snapshot("<img required />")
     end
 
     test "boolean attribute without whitespace and with self-closing tag" do
-      result = ERBX.lex("<img required/>")
-
-      expected = %w[
-        TOKEN_HTML_TAG_START
-        TOKEN_IDENTIFIER
-        TOKEN_WHITESPACE
-        TOKEN_IDENTIFIER
-        TOKEN_HTML_TAG_SELF_CLOSE
-        TOKEN_EOF
-      ]
-
-      assert_equal expected, result.array.items.map(&:type)
+      assert_lexed_snapshot("<img required/>")
     end
 
     test "boolean attribute without whitespace and without self-closing tag" do
-      result = ERBX.lex("<img required>")
-
-      expected = %w[
-        TOKEN_HTML_TAG_START
-        TOKEN_IDENTIFIER
-        TOKEN_WHITESPACE
-        TOKEN_IDENTIFIER
-        TOKEN_HTML_TAG_END
-        TOKEN_EOF
-      ]
-
-      assert_equal expected, result.array.items.map(&:type)
+      assert_lexed_snapshot("<img required>")
     end
 
     test "boolean attribute without whitespace" do
-      result = ERBX.lex("<img required/>")
-
-      expected = %w[
-        TOKEN_HTML_TAG_START
-        TOKEN_IDENTIFIER
-        TOKEN_WHITESPACE
-        TOKEN_IDENTIFIER
-        TOKEN_HTML_TAG_SELF_CLOSE
-        TOKEN_EOF
-      ]
-
-      assert_equal expected, result.array.items.map(&:type)
+      assert_lexed_snapshot("<img required/>")
     end
   end
 end

--- a/test/lexer/comments_test.rb
+++ b/test/lexer/comments_test.rb
@@ -4,102 +4,25 @@ require_relative "../test_helper"
 
 module Lexer
   class CommentsTest < Minitest::Spec
+    include SnapshotUtils
+
     test "HTML comment with padding whitespace" do
-      result = ERBX.lex(%(<!-- Hello World -->))
-
-      expected = %w[
-        TOKEN_HTML_COMMENT_START
-        TOKEN_WHITESPACE
-        TOKEN_IDENTIFIER
-        TOKEN_WHITESPACE
-        TOKEN_IDENTIFIER
-        TOKEN_WHITESPACE
-        TOKEN_HTML_COMMENT_END
-        TOKEN_EOF
-      ]
-
-      assert_equal expected, result.array.items.map(&:type)
+      assert_lexed_snapshot(%(<!-- Hello World -->))
     end
 
     test "HTML comment with no whitespace" do
-      result = ERBX.lex(%(<!--Hello World-->))
-
-      expected = %w[
-        TOKEN_HTML_COMMENT_START
-        TOKEN_IDENTIFIER
-        TOKEN_WHITESPACE
-        TOKEN_IDENTIFIER
-        TOKEN_HTML_COMMENT_END
-        TOKEN_EOF
-      ]
-
-      assert_equal expected, result.array.items.map(&:type)
+      assert_lexed_snapshot(%(<!--Hello World-->))
     end
 
     test "HTML comment followed by html tag" do
-      result = ERBX.lex(%(<!--Hello World--><h1>Hello</h1>))
-
-      expected = %w[
-        TOKEN_HTML_COMMENT_START
-        TOKEN_IDENTIFIER
-        TOKEN_WHITESPACE
-        TOKEN_IDENTIFIER
-        TOKEN_HTML_COMMENT_END
-
-        TOKEN_HTML_TAG_START
-        TOKEN_IDENTIFIER
-        TOKEN_HTML_TAG_END
-        TOKEN_IDENTIFIER
-        TOKEN_HTML_TAG_START_CLOSE
-        TOKEN_IDENTIFIER
-        TOKEN_HTML_TAG_END
-        TOKEN_EOF
-      ]
-
-      assert_equal expected, result.array.items.map(&:type)
+      assert_lexed_snapshot(%(<!--Hello World--><h1>Hello</h1>))
     end
 
     test "HTML comment followed by html tag with nested comment" do
-      result = ERBX.lex(%(
+      assert_lexed_snapshot(%(
         <!--Hello World-->
         <h1><!-- Hello World --></h1>
       ))
-
-      expected = %w[
-        TOKEN_NEWLINE
-        TOKEN_WHITESPACE
-
-        TOKEN_HTML_COMMENT_START
-        TOKEN_IDENTIFIER
-        TOKEN_WHITESPACE
-        TOKEN_IDENTIFIER
-        TOKEN_HTML_COMMENT_END
-
-        TOKEN_NEWLINE
-
-        TOKEN_WHITESPACE
-        TOKEN_HTML_TAG_START
-        TOKEN_IDENTIFIER
-        TOKEN_HTML_TAG_END
-
-        TOKEN_HTML_COMMENT_START
-        TOKEN_WHITESPACE
-        TOKEN_IDENTIFIER
-        TOKEN_WHITESPACE
-        TOKEN_IDENTIFIER
-        TOKEN_WHITESPACE
-        TOKEN_HTML_COMMENT_END
-
-        TOKEN_HTML_TAG_START_CLOSE
-        TOKEN_IDENTIFIER
-        TOKEN_HTML_TAG_END
-        TOKEN_NEWLINE
-        TOKEN_WHITESPACE
-        TOKEN_EOF
-      ]
-
-      assert_equal expected, result.array.items.map(&:type)
-      assert_equal [8, 1, 8, 1, 1, 1, 6], result.array.items.select { |token| token.type == "TOKEN_WHITESPACE" }.map(&:value).map(&:length)
     end
   end
 end

--- a/test/lexer/doctype_test.rb
+++ b/test/lexer/doctype_test.rb
@@ -4,114 +4,28 @@ require_relative "../test_helper"
 
 module Lexer
   class DoctypeTest < Minitest::Spec
+    include SnapshotUtils
+
     test "doctype" do
-      result = ERBX.lex("<!DOCTYPE>")
-
-      expected = %w[
-        TOKEN_HTML_DOCTYPE
-        TOKEN_HTML_TAG_END
-        TOKEN_EOF
-      ]
-
-      assert_equal expected, result.array.items.map(&:type)
+      assert_lexed_snapshot("<!DOCTYPE>")
     end
 
     test "doctype with space" do
-      result = ERBX.lex("<!DOCTYPE >")
-
-      expected = %w[
-        TOKEN_HTML_DOCTYPE
-        TOKEN_WHITESPACE
-        TOKEN_HTML_TAG_END
-        TOKEN_EOF
-      ]
-
-      assert_equal expected, result.array.items.map(&:type)
+      assert_lexed_snapshot("<!DOCTYPE >")
     end
 
     test "doctype with html" do
-      result = ERBX.lex("<!DOCTYPE html>")
-
-      expected = %w[
-        TOKEN_HTML_DOCTYPE
-        TOKEN_WHITESPACE
-        TOKEN_IDENTIFIER
-        TOKEN_HTML_TAG_END
-        TOKEN_EOF
-      ]
-
-      assert_equal expected, result.array.items.map(&:type)
+      assert_lexed_snapshot("<!DOCTYPE html>")
     end
 
     test "html4 doctype" do
-      result = ERBX.lex(%(<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">))
-
-      expected = %w[
-        TOKEN_HTML_DOCTYPE
-        TOKEN_WHITESPACE
-        TOKEN_IDENTIFIER
-        TOKEN_WHITESPACE
-        TOKEN_IDENTIFIER
-        TOKEN_WHITESPACE
-
-        TOKEN_QUOTE
-        TOKEN_DASH
-        TOKEN_SLASH
-        TOKEN_SLASH
-        TOKEN_IDENTIFIER
-        TOKEN_SLASH
-        TOKEN_SLASH
-        TOKEN_IDENTIFIER
-        TOKEN_WHITESPACE
-        TOKEN_IDENTIFIER
-        TOKEN_WHITESPACE
-        TOKEN_IDENTIFIER
-        TOKEN_CHARACTER
-        TOKEN_IDENTIFIER
-        TOKEN_SLASH
-        TOKEN_SLASH
-        TOKEN_IDENTIFIER
-        TOKEN_QUOTE
-
-        TOKEN_WHITESPACE
-
-        TOKEN_QUOTE
-        TOKEN_IDENTIFIER
-        TOKEN_SLASH
-        TOKEN_SLASH
-        TOKEN_IDENTIFIER
-        TOKEN_CHARACTER
-        TOKEN_IDENTIFIER
-        TOKEN_CHARACTER
-        TOKEN_IDENTIFIER
-        TOKEN_SLASH
-        TOKEN_IDENTIFIER
-        TOKEN_SLASH
-        TOKEN_IDENTIFIER
-        TOKEN_SLASH
-        TOKEN_IDENTIFIER
-        TOKEN_CHARACTER
-        TOKEN_IDENTIFIER
-        TOKEN_QUOTE
-
-        TOKEN_HTML_TAG_END
-        TOKEN_EOF
-      ]
-
-      assert_equal expected, result.array.items.map(&:type)
+      assert_lexed_snapshot(%(<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">))
     end
 
     test "doctype case insensitivity" do
-      doctypes = ["<!DOCTYPE>", "<!doctype>", "<!DoCtYpE>", "<!dOcTyPe>"]
-
-      expected = %w[
-        TOKEN_HTML_DOCTYPE
-        TOKEN_HTML_TAG_END
-        TOKEN_EOF
-      ]
-
+      doctypes = ["<!doctype>", "<!DoCtYpE>", "<!dOcTyPe>"]
       doctypes.each do |doctype|
-        assert_equal expected, ERBX.lex(doctype).array.items.map(&:type), "#{doctype} didn't match"
+        assert_lexed_snapshot(doctype)
       end
     end
   end

--- a/test/lexer/erb_test.rb
+++ b/test/lexer/erb_test.rb
@@ -4,196 +4,46 @@ require_relative "../test_helper"
 
 module Lexer
   class ERBTest < Minitest::Spec
+    include SnapshotUtils
+
     test "erb <% %>" do
-      result = ERBX.lex(%(<% 'hello world' %>))
-
-      expected = %w[
-        TOKEN_ERB_START
-        TOKEN_ERB_CONTENT
-        TOKEN_ERB_END
-        TOKEN_EOF
-      ]
-
-      assert_equal expected, result.array.items.map(&:type)
-      assert_equal "<%", result.array.items.find { |token| token.type == "TOKEN_ERB_START" }&.value
-      assert_equal "%>", result.array.items.find { |token| token.type == "TOKEN_ERB_END" }&.value
+      assert_lexed_snapshot(%(<% 'hello world' %>))
     end
 
     test "erb <%= %>" do
-      result = ERBX.lex(%(<%= "hello world" %>))
-
-      expected = %w[
-        TOKEN_ERB_START
-        TOKEN_ERB_CONTENT
-        TOKEN_ERB_END
-        TOKEN_EOF
-      ]
-
-      assert_equal expected, result.array.items.map(&:type)
-      assert_equal "<%=", result.array.items.find { |token| token.type == "TOKEN_ERB_START" }&.value
-      assert_equal "%>", result.array.items.find { |token| token.type == "TOKEN_ERB_END" }&.value
+      assert_lexed_snapshot(%(<%= "hello world" %>))
     end
 
     test "erb <%- %>" do
-      result = ERBX.lex(%(<%- "Test" %>))
-
-      expected = %w[
-        TOKEN_ERB_START
-        TOKEN_ERB_CONTENT
-        TOKEN_ERB_END
-        TOKEN_EOF
-      ]
-
-      assert_equal expected, result.array.items.map(&:type)
-      assert_equal "<%-", result.array.items.find { |token| token.type == "TOKEN_ERB_START" }&.value
-      assert_equal "%>", result.array.items.find { |token| token.type == "TOKEN_ERB_END" }&.value
+      assert_lexed_snapshot(%(<%- "Test" %>))
     end
 
     test "erb <%- -%>" do
-      result = ERBX.lex(%(<%- "Test" -%>))
-
-      expected = %w[
-        TOKEN_ERB_START
-        TOKEN_ERB_CONTENT
-        TOKEN_ERB_END
-        TOKEN_EOF
-      ]
-
-      assert_equal expected, result.array.items.map(&:type)
-      assert_equal "<%-", result.array.items.find { |token| token.type == "TOKEN_ERB_START" }&.value
-      assert_equal "-%>", result.array.items.find { |token| token.type == "TOKEN_ERB_END" }&.value
+      assert_lexed_snapshot(%(<%- "Test" -%>))
     end
 
     test "erb <%# %>" do
-      result = ERBX.lex(%(<%# "Test" %>))
-
-      expected = %w[
-        TOKEN_ERB_START
-        TOKEN_ERB_CONTENT
-        TOKEN_ERB_END
-        TOKEN_EOF
-      ]
-
-      assert_equal expected, result.array.items.map(&:type)
-      assert_equal "<%#", result.array.items.find { |token| token.type == "TOKEN_ERB_START" }&.value
-      assert_equal "%>", result.array.items.find { |token| token.type == "TOKEN_ERB_END" }&.value
+      assert_lexed_snapshot(%(<%# "Test" %>))
     end
 
     test "erb <%% %%>" do
-      result = ERBX.lex(%(<%% "Test" %%>))
-
-      expected = %w[
-        TOKEN_ERB_START
-        TOKEN_ERB_CONTENT
-        TOKEN_ERB_END
-        TOKEN_EOF
-      ]
-
-      assert_equal expected, result.array.items.map(&:type)
-      assert_equal "<%%", result.array.items.find { |token| token.type == "TOKEN_ERB_START" }&.value
-      assert_equal "%%>", result.array.items.find { |token| token.type == "TOKEN_ERB_END" }&.value
+      assert_lexed_snapshot(%(<%% "Test" %%>))
     end
 
     test "erb output inside HTML attribute value" do
-      result = ERBX.lex(%(<article id="<%= dom_id(article) %>"></article>))
-
-      expected = %w[
-        TOKEN_HTML_TAG_START
-        TOKEN_IDENTIFIER
-        TOKEN_WHITESPACE
-        TOKEN_IDENTIFIER
-        TOKEN_EQUALS
-        TOKEN_QUOTE
-        TOKEN_ERB_START
-        TOKEN_ERB_CONTENT
-        TOKEN_ERB_END
-        TOKEN_QUOTE
-        TOKEN_HTML_TAG_END
-        TOKEN_HTML_TAG_START_CLOSE
-        TOKEN_IDENTIFIER
-        TOKEN_HTML_TAG_END
-        TOKEN_EOF
-      ]
-
-      assert_equal expected, result.array.items.map(&:type)
+      assert_lexed_snapshot(%(<article id="<%= dom_id(article) %>"></article>))
     end
 
     test "erb output inside HTML attribute value with value before" do
-      result = ERBX.lex(%(<div class="bg-black <%= "text-white" %>"></div>))
-
-      expected = %w[
-        TOKEN_HTML_TAG_START
-        TOKEN_IDENTIFIER
-        TOKEN_WHITESPACE
-        TOKEN_IDENTIFIER
-        TOKEN_EQUALS
-        TOKEN_QUOTE
-        TOKEN_IDENTIFIER
-        TOKEN_WHITESPACE
-        TOKEN_ERB_START
-        TOKEN_ERB_CONTENT
-        TOKEN_ERB_END
-        TOKEN_QUOTE
-        TOKEN_HTML_TAG_END
-        TOKEN_HTML_TAG_START_CLOSE
-        TOKEN_IDENTIFIER
-        TOKEN_HTML_TAG_END
-        TOKEN_EOF
-      ]
-
-      assert_equal expected, result.array.items.map(&:type)
+      assert_lexed_snapshot(%(<div class="bg-black <%= "text-white" %>"></div>))
     end
 
     test "erb output inside HTML attribute value with value before and after" do
-      result = ERBX.lex(%(<div class="bg-black <%= "text-white" %>"></div>))
-
-      expected = %w[
-        TOKEN_HTML_TAG_START
-        TOKEN_IDENTIFIER
-        TOKEN_WHITESPACE
-        TOKEN_IDENTIFIER
-        TOKEN_EQUALS
-        TOKEN_QUOTE
-        TOKEN_IDENTIFIER
-        TOKEN_WHITESPACE
-        TOKEN_ERB_START
-        TOKEN_ERB_CONTENT
-        TOKEN_ERB_END
-        TOKEN_QUOTE
-        TOKEN_HTML_TAG_END
-        TOKEN_HTML_TAG_START_CLOSE
-        TOKEN_IDENTIFIER
-        TOKEN_HTML_TAG_END
-        TOKEN_EOF
-      ]
-
-      assert_equal expected, result.array.items.map(&:type)
+      assert_lexed_snapshot(%(<div class="bg-black <%= "text-white" %>"></div>))
     end
 
     test "erb output inside HTML attribute value with value and after" do
-      result = ERBX.lex(%(<div class="bg-black <%= "text-white" %>"></div>))
-
-      expected = %w[
-        TOKEN_HTML_TAG_START
-        TOKEN_IDENTIFIER
-        TOKEN_WHITESPACE
-        TOKEN_IDENTIFIER
-        TOKEN_EQUALS
-        TOKEN_QUOTE
-        TOKEN_IDENTIFIER
-        TOKEN_WHITESPACE
-        TOKEN_ERB_START
-        TOKEN_ERB_CONTENT
-        TOKEN_ERB_END
-        TOKEN_QUOTE
-        TOKEN_HTML_TAG_END
-        TOKEN_HTML_TAG_START_CLOSE
-        TOKEN_IDENTIFIER
-        TOKEN_HTML_TAG_END
-        TOKEN_EOF
-      ]
-
-      assert_equal expected, result.array.items.map(&:type)
+      assert_lexed_snapshot(%(<div class="bg-black <%= "text-white" %>"></div>))
     end
   end
 end

--- a/test/lexer/html_entities_test.rb
+++ b/test/lexer/html_entities_test.rb
@@ -4,93 +4,34 @@ require_relative "../test_helper"
 
 module Lexer
   class HTMLEntitiesTest < Minitest::Spec
+    include SnapshotUtils
+
     test "&lt;" do
-      result = ERBX.lex("&lt;")
-
-      expected = %w[
-        TOKEN_AMPERSAND
-        TOKEN_IDENTIFIER
-        TOKEN_SEMICOLON
-        TOKEN_EOF
-      ]
-
-      assert_equal expected, result.array.items.map(&:type)
+      assert_lexed_snapshot("&lt;")
     end
 
     test "&gt;" do
-      result = ERBX.lex("&gt;")
-
-      expected = %w[
-        TOKEN_AMPERSAND
-        TOKEN_IDENTIFIER
-        TOKEN_SEMICOLON
-        TOKEN_EOF
-      ]
-
-      assert_equal expected, result.array.items.map(&:type)
+      assert_lexed_snapshot("&gt;")
     end
 
     test "&nbsp;" do
-      result = ERBX.lex("&nbsp;")
-
-      expected = %w[
-        TOKEN_AMPERSAND
-        TOKEN_IDENTIFIER
-        TOKEN_SEMICOLON
-        TOKEN_EOF
-      ]
-
-      assert_equal expected, result.array.items.map(&:type)
+      assert_lexed_snapshot("&nbsp;")
     end
 
     test "&quot;" do
-      result = ERBX.lex("&quot;")
-
-      expected = %w[
-        TOKEN_AMPERSAND
-        TOKEN_IDENTIFIER
-        TOKEN_SEMICOLON
-        TOKEN_EOF
-      ]
-
-      assert_equal expected, result.array.items.map(&:type)
+      assert_lexed_snapshot("&quot;")
     end
 
     test "&apos;" do
-      result = ERBX.lex("&apos;")
-
-      expected = %w[
-        TOKEN_AMPERSAND
-        TOKEN_IDENTIFIER
-        TOKEN_SEMICOLON
-        TOKEN_EOF
-      ]
-
-      assert_equal expected, result.array.items.map(&:type)
+      assert_lexed_snapshot("&apos;")
     end
 
     test "ampersand" do
-      result = ERBX.lex("&amp;")
-
-      expected = %w[
-        TOKEN_AMPERSAND
-        TOKEN_IDENTIFIER
-        TOKEN_SEMICOLON
-        TOKEN_EOF
-      ]
-
-      assert_equal expected, result.array.items.map(&:type)
+      assert_lexed_snapshot("&amp;")
     end
 
     test "literal ampersand" do
-      result = ERBX.lex("&")
-
-      expected = %w[
-        TOKEN_AMPERSAND
-        TOKEN_EOF
-      ]
-
-      assert_equal expected, result.array.items.map(&:type)
+      assert_lexed_snapshot("&")
     end
   end
 end

--- a/test/lexer/lexer_test.rb
+++ b/test/lexer/lexer_test.rb
@@ -4,24 +4,14 @@ require_relative "../test_helper"
 
 module Lexer
   class LexerTest < Minitest::Spec
+    include SnapshotUtils
+
     test "nil" do
-      result = ERBX.lex(nil)
-
-      expected = %w[
-        TOKEN_EOF
-      ]
-
-      assert_equal expected, result.array.items.map(&:type)
+      assert_lexed_snapshot(nil)
     end
 
     test "empty file" do
-      result = ERBX.lex("")
-
-      expected = %w[
-        TOKEN_EOF
-      ]
-
-      assert_equal expected, result.array.items.map(&:type)
+      assert_lexed_snapshot("")
     end
   end
 end

--- a/test/lexer/tags_test.rb
+++ b/test/lexer/tags_test.rb
@@ -4,194 +4,46 @@ require_relative "../test_helper"
 
 module Lexer
   class TagsTest < Minitest::Spec
+    include SnapshotUtils
+
     test "basic tag" do
-      result = ERBX.lex("<html></html>")
-
-      expected = %w[
-        TOKEN_HTML_TAG_START
-        TOKEN_IDENTIFIER
-        TOKEN_HTML_TAG_END
-        TOKEN_HTML_TAG_START_CLOSE
-        TOKEN_IDENTIFIER
-        TOKEN_HTML_TAG_END
-        TOKEN_EOF
-      ]
-
-      assert_equal expected, result.array.items.map(&:type)
+      assert_lexed_snapshot("<html></html>")
     end
 
     test "basic void tag" do
-      result = ERBX.lex("<img />")
-
-      expected = %w[
-        TOKEN_HTML_TAG_START
-        TOKEN_IDENTIFIER
-        TOKEN_WHITESPACE
-        TOKEN_HTML_TAG_SELF_CLOSE
-        TOKEN_EOF
-      ]
-
-      assert_equal expected, result.array.items.map(&:type)
+      assert_lexed_snapshot("<img />")
     end
 
     test "basic void tag without whitespace" do
-      result = ERBX.lex("<img/>")
-
-      expected = %w[
-        TOKEN_HTML_TAG_START
-        TOKEN_IDENTIFIER
-        TOKEN_HTML_TAG_SELF_CLOSE
-        TOKEN_EOF
-      ]
-
-      assert_equal expected, result.array.items.map(&:type)
+      assert_lexed_snapshot("<img/>")
     end
 
     test "namespaced tag" do
-      result = ERBX.lex("<ns:table></ns:table>")
-
-      expected = %w[
-        TOKEN_HTML_TAG_START
-        TOKEN_IDENTIFIER
-        TOKEN_HTML_TAG_END
-        TOKEN_HTML_TAG_START_CLOSE
-        TOKEN_IDENTIFIER
-        TOKEN_HTML_TAG_END
-        TOKEN_EOF
-      ]
-
-      assert_equal expected, result.array.items.map(&:type)
+      assert_lexed_snapshot("<ns:table></ns:table>")
     end
 
     test "colon inside html " do
-      result = ERBX.lex(%(<div : class=""></div>))
-
-      expected = %w[
-        TOKEN_HTML_TAG_START
-        TOKEN_IDENTIFIER
-        TOKEN_WHITESPACE
-        TOKEN_COLON
-        TOKEN_WHITESPACE
-        TOKEN_IDENTIFIER
-        TOKEN_EQUALS
-        TOKEN_QUOTE
-        TOKEN_QUOTE
-        TOKEN_HTML_TAG_END
-        TOKEN_HTML_TAG_START_CLOSE
-        TOKEN_IDENTIFIER
-        TOKEN_HTML_TAG_END
-        TOKEN_EOF
-      ]
-
-      assert_equal expected, result.array.items.map(&:type)
+      assert_lexed_snapshot(%(<div : class=""></div>))
     end
 
     test "text content" do
-      result = ERBX.lex("<h1>Hello World</h1>")
-
-      expected = %w[
-        TOKEN_HTML_TAG_START
-        TOKEN_IDENTIFIER
-        TOKEN_HTML_TAG_END
-        TOKEN_IDENTIFIER
-        TOKEN_WHITESPACE
-        TOKEN_IDENTIFIER
-        TOKEN_HTML_TAG_START_CLOSE
-        TOKEN_IDENTIFIER
-        TOKEN_HTML_TAG_END
-        TOKEN_EOF
-      ]
-
-      assert_equal expected, result.array.items.map(&:type)
+      assert_lexed_snapshot("<h1>Hello World</h1>")
     end
 
     test "attribute with no quotes value and whitespace and self-closing tag" do
-      result = ERBX.lex("<img value=hello />")
-
-      expected = %w[
-        TOKEN_HTML_TAG_START
-        TOKEN_IDENTIFIER
-        TOKEN_WHITESPACE
-        TOKEN_IDENTIFIER
-        TOKEN_EQUALS
-        TOKEN_IDENTIFIER
-        TOKEN_WHITESPACE
-        TOKEN_HTML_TAG_SELF_CLOSE
-        TOKEN_EOF
-      ]
-
-      assert_equal expected, result.array.items.map(&:type)
+      assert_lexed_snapshot("<img value=hello />")
     end
 
     test "attribute with no quotes value, no whitespace and self-closing tag" do
-      result = ERBX.lex("<img value=hello/>")
-
-      expected = %w[
-        TOKEN_HTML_TAG_START
-        TOKEN_IDENTIFIER
-        TOKEN_WHITESPACE
-        TOKEN_IDENTIFIER
-        TOKEN_EQUALS
-        TOKEN_IDENTIFIER
-        TOKEN_HTML_TAG_SELF_CLOSE
-        TOKEN_EOF
-      ]
-
-      assert_equal expected, result.array.items.map(&:type)
+      assert_lexed_snapshot("<img value=hello/>")
     end
 
     test "attribute with no quotes value, no whitespace, and non self-closing tag" do
-      result = ERBX.lex("<div value=hello>")
-
-      expected = %w[
-        TOKEN_HTML_TAG_START
-        TOKEN_IDENTIFIER
-        TOKEN_WHITESPACE
-        TOKEN_IDENTIFIER
-        TOKEN_EQUALS
-        TOKEN_IDENTIFIER
-        TOKEN_HTML_TAG_END
-        TOKEN_EOF
-      ]
-
-      assert_equal expected, result.array.items.map(&:type)
+      assert_lexed_snapshot("<div value=hello>")
     end
 
     test "link tag" do
-      result = ERBX.lex(%(<link href="https://mywebsite.com/style.css" rel="stylesheet">))
-
-      expected = %w[
-        TOKEN_HTML_TAG_START
-        TOKEN_IDENTIFIER
-        TOKEN_WHITESPACE
-
-        TOKEN_IDENTIFIER
-        TOKEN_EQUALS
-        TOKEN_QUOTE
-        TOKEN_IDENTIFIER
-        TOKEN_SLASH
-        TOKEN_SLASH
-        TOKEN_IDENTIFIER
-        TOKEN_CHARACTER
-        TOKEN_IDENTIFIER
-        TOKEN_SLASH
-        TOKEN_IDENTIFIER
-        TOKEN_CHARACTER
-        TOKEN_IDENTIFIER
-        TOKEN_QUOTE
-        TOKEN_WHITESPACE
-
-        TOKEN_IDENTIFIER
-        TOKEN_EQUALS
-        TOKEN_QUOTE
-        TOKEN_IDENTIFIER
-        TOKEN_QUOTE
-
-        TOKEN_HTML_TAG_END
-        TOKEN_EOF
-      ]
-
-      assert_equal expected, result.array.items.map(&:type)
+      assert_lexed_snapshot(%(<link href="https://mywebsite.com/style.css" rel="stylesheet">))
     end
   end
 end

--- a/test/lexer/text_content_test.rb
+++ b/test/lexer/text_content_test.rb
@@ -4,44 +4,14 @@ require_relative "../test_helper"
 
 module Lexer
   class TextContentTest < Minitest::Spec
+    include SnapshotUtils
+
     test "text content" do
-      result = ERBX.lex("<h1>Some Text</h1>")
-
-      expected = %w[
-        TOKEN_HTML_TAG_START
-        TOKEN_IDENTIFIER
-        TOKEN_HTML_TAG_END
-        TOKEN_IDENTIFIER
-        TOKEN_WHITESPACE
-        TOKEN_IDENTIFIER
-        TOKEN_HTML_TAG_START_CLOSE
-        TOKEN_IDENTIFIER
-        TOKEN_HTML_TAG_END
-        TOKEN_EOF
-      ]
-
-      assert_equal expected, result.array.items.map(&:type)
+      assert_lexed_snapshot("<h1>Some Text</h1>")
     end
 
     test "text content with period" do
-      result = ERBX.lex("<h1>Some. Text.</h1>")
-
-      expected = %w[
-        TOKEN_HTML_TAG_START
-        TOKEN_IDENTIFIER
-        TOKEN_HTML_TAG_END
-        TOKEN_IDENTIFIER
-        TOKEN_CHARACTER
-        TOKEN_WHITESPACE
-        TOKEN_IDENTIFIER
-        TOKEN_CHARACTER
-        TOKEN_HTML_TAG_START_CLOSE
-        TOKEN_IDENTIFIER
-        TOKEN_HTML_TAG_END
-        TOKEN_EOF
-      ]
-
-      assert_equal expected, result.array.items.map(&:type)
+      assert_lexed_snapshot("<h1>Some. Text.</h1>")
     end
   end
 end

--- a/test/lexer/token_test.rb
+++ b/test/lexer/token_test.rb
@@ -4,210 +4,74 @@ require_relative "../test_helper"
 
 module Lexer
   class TokenTest < Minitest::Spec
+    include SnapshotUtils
+
     test "whitespace" do
-      result = ERBX.lex(" ")
-
-      expected = %w[
-        TOKEN_WHITESPACE
-        TOKEN_EOF
-      ]
-
-      assert_equal expected, result.array.items.map(&:type)
+      assert_lexed_snapshot(" ")
     end
 
     test "multiple whitespace" do
-      result = ERBX.lex("    ")
-
-      expected = %w[
-        TOKEN_WHITESPACE
-        TOKEN_EOF
-      ]
-
-      assert_equal expected, result.array.items.map(&:type)
-      assert_equal ["    ", ""], result.array.items.map(&:value)
+      assert_lexed_snapshot("    ")
     end
 
     test "multiple whitespace with newliens " do
-      result = ERBX.lex(" \n  \n   \n")
-
-      expected = %w[
-        TOKEN_WHITESPACE
-        TOKEN_NEWLINE
-        TOKEN_WHITESPACE
-        TOKEN_NEWLINE
-        TOKEN_WHITESPACE
-        TOKEN_NEWLINE
-        TOKEN_EOF
-      ]
-
-      assert_equal expected, result.array.items.map(&:type)
+      assert_lexed_snapshot(" \n  \n   \n")
     end
 
     test "non-breaking space" do
-      result = ERBX.lex(" ")
-
-      expected = %w[
-        TOKEN_NBSP
-        TOKEN_EOF
-      ]
-
-      assert_equal expected, result.array.items.map(&:type)
+      assert_lexed_snapshot(" ")
     end
 
     test "newline" do
-      result = ERBX.lex("\n")
-
-      expected = %w[
-        TOKEN_NEWLINE
-        TOKEN_EOF
-      ]
-
-      assert_equal expected, result.array.items.map(&:type)
+      assert_lexed_snapshot("\n")
     end
 
     test "!" do
-      result = ERBX.lex("!")
-
-      expected = %w[
-        TOKEN_EXCLAMATION
-        TOKEN_EOF
-      ]
-
-      assert_equal expected, result.array.items.map(&:type)
+      assert_lexed_snapshot("!")
     end
 
     test "slash" do
-      result = ERBX.lex("/")
-
-      expected = %w[
-        TOKEN_SLASH
-        TOKEN_EOF
-      ]
-
-      assert_equal expected, result.array.items.map(&:type)
+      assert_lexed_snapshot("/")
     end
 
     test "dash" do
-      result = ERBX.lex("-")
-
-      expected = %w[
-        TOKEN_DASH
-        TOKEN_EOF
-      ]
-
-      assert_equal expected, result.array.items.map(&:type)
+      assert_lexed_snapshot("-")
     end
 
     test "underscore" do
-      result = ERBX.lex("_")
-
-      expected = %w[
-        TOKEN_UNDERSCORE
-        TOKEN_EOF
-      ]
-
-      assert_equal expected, result.array.items.map(&:type)
+      assert_lexed_snapshot("_")
     end
 
     test "percent" do
-      result = ERBX.lex("%")
-
-      expected = %w[
-        TOKEN_PERCENT
-        TOKEN_EOF
-      ]
-
-      assert_equal expected, result.array.items.map(&:type)
+      assert_lexed_snapshot("%")
     end
 
     test "colon" do
-      result = ERBX.lex(":")
-
-      expected = %w[
-        TOKEN_COLON
-        TOKEN_EOF
-      ]
-
-      assert_equal expected, result.array.items.map(&:type)
+      assert_lexed_snapshot(":")
     end
 
-    test "colon" do
-      result = ERBX.lex("=")
-
-      expected = %w[
-        TOKEN_EQUALS
-        TOKEN_EOF
-      ]
-
-      assert_equal expected, result.array.items.map(&:type)
+    test "equals" do
+      assert_lexed_snapshot("=")
     end
 
     test "double quote" do
-      result = ERBX.lex(%("))
-
-      expected = %w[
-        TOKEN_QUOTE
-        TOKEN_EOF
-      ]
-
-      assert_equal expected, result.array.items.map(&:type)
+      assert_lexed_snapshot(%("))
     end
 
     test "single quote" do
-      result = ERBX.lex(%('))
-
-      expected = %w[
-        TOKEN_QUOTE
-        TOKEN_EOF
-      ]
-
-      assert_equal expected, result.array.items.map(&:type)
+      assert_lexed_snapshot(%('))
     end
 
     test "less than signs" do
-      result = ERBX.lex("<<<<")
-
-      expected = %w[
-        TOKEN_LT
-        TOKEN_LT
-        TOKEN_LT
-        TOKEN_LT
-        TOKEN_EOF
-      ]
-
-      assert_equal expected, result.array.items.map(&:type)
+      assert_lexed_snapshot("<<<<")
     end
 
     test "greater than signs" do
-      result = ERBX.lex(">>>>")
-
-      expected = %w[
-        TOKEN_HTML_TAG_END
-        TOKEN_HTML_TAG_END
-        TOKEN_HTML_TAG_END
-        TOKEN_HTML_TAG_END
-        TOKEN_EOF
-      ]
-
-      assert_equal expected, result.array.items.map(&:type)
+      assert_lexed_snapshot(">>>>")
     end
 
     test "LT, GT and PERCENT signs" do
-      result = ERBX.lex(%(< % % >))
-
-      expected = %w[
-        TOKEN_LT
-        TOKEN_WHITESPACE
-        TOKEN_PERCENT
-        TOKEN_WHITESPACE
-        TOKEN_PERCENT
-        TOKEN_WHITESPACE
-        TOKEN_HTML_TAG_END
-        TOKEN_EOF
-      ]
-
-      assert_equal expected, result.array.items.map(&:type)
-      assert_equal ["<", " ", "%", " ", "%", " ", ">", ""], result.array.items.map(&:value)
+      assert_lexed_snapshot(%(< % % >))
     end
   end
 end

--- a/test/snapshot_utils.rb
+++ b/test/snapshot_utils.rb
@@ -9,6 +9,13 @@ def ask?(prompt = "")
 end
 
 module SnapshotUtils
+  def assert_lexed_snapshot(source)
+    result = ERBX.lex(source)
+    expected = result.inspect
+
+    assert_snapshot_matches(expected, source)
+  end
+
   def assert_parsed_snapshot(source)
     parsed = ERBX.parse(source)
     expected = parsed.root_node.inspect

--- a/test/snapshots/lexer/attributes_test/test_0001_attribute_value_double_quotes_24d3faf147396fd00701c040dd088d1c.txt
+++ b/test/snapshots/lexer/attributes_test/test_0001_attribute_value_double_quotes_24d3faf147396fd00701c040dd088d1c.txt
@@ -1,0 +1,13 @@
+#<Token type=TOKEN_HTML_TAG_START value='<' range=[0, 1] start=1:0 end=1:1>
+#<Token type=TOKEN_IDENTIFIER value='img' range=[1, 4] start=1:1 end=1:4>
+#<Token type=TOKEN_WHITESPACE value=' ' range=[4, 5] start=1:4 end=1:5>
+#<Token type=TOKEN_IDENTIFIER value='value' range=[5, 10] start=1:5 end=1:10>
+#<Token type=TOKEN_EQUALS value='=' range=[10, 11] start=1:10 end=1:11>
+#<Token type=TOKEN_QUOTE value='"' range=[11, 12] start=1:11 end=1:12>
+#<Token type=TOKEN_IDENTIFIER value='hello' range=[12, 17] start=1:12 end=1:17>
+#<Token type=TOKEN_WHITESPACE value=' ' range=[17, 18] start=1:17 end=1:18>
+#<Token type=TOKEN_IDENTIFIER value='world' range=[18, 23] start=1:18 end=1:23>
+#<Token type=TOKEN_QUOTE value='"' range=[23, 24] start=1:23 end=1:24>
+#<Token type=TOKEN_WHITESPACE value=' ' range=[24, 25] start=1:24 end=1:25>
+#<Token type=TOKEN_HTML_TAG_SELF_CLOSE value='/>' range=[25, 27] start=1:25 end=1:27>
+#<Token type=TOKEN_EOF value='' range=[27, 27] start=1:27 end=1:27>

--- a/test/snapshots/lexer/attributes_test/test_0002_attribute_value_single_quotes_8b3b7fed8756aacca4ddc48cda37862c.txt
+++ b/test/snapshots/lexer/attributes_test/test_0002_attribute_value_single_quotes_8b3b7fed8756aacca4ddc48cda37862c.txt
@@ -1,0 +1,13 @@
+#<Token type=TOKEN_HTML_TAG_START value='<' range=[0, 1] start=1:0 end=1:1>
+#<Token type=TOKEN_IDENTIFIER value='img' range=[1, 4] start=1:1 end=1:4>
+#<Token type=TOKEN_WHITESPACE value=' ' range=[4, 5] start=1:4 end=1:5>
+#<Token type=TOKEN_IDENTIFIER value='value' range=[5, 10] start=1:5 end=1:10>
+#<Token type=TOKEN_EQUALS value='=' range=[10, 11] start=1:10 end=1:11>
+#<Token type=TOKEN_QUOTE value=''' range=[11, 12] start=1:11 end=1:12>
+#<Token type=TOKEN_IDENTIFIER value='hello' range=[12, 17] start=1:12 end=1:17>
+#<Token type=TOKEN_WHITESPACE value=' ' range=[17, 18] start=1:17 end=1:18>
+#<Token type=TOKEN_IDENTIFIER value='world' range=[18, 23] start=1:18 end=1:23>
+#<Token type=TOKEN_QUOTE value=''' range=[23, 24] start=1:23 end=1:24>
+#<Token type=TOKEN_WHITESPACE value=' ' range=[24, 25] start=1:24 end=1:25>
+#<Token type=TOKEN_HTML_TAG_SELF_CLOSE value='/>' range=[25, 27] start=1:25 end=1:27>
+#<Token type=TOKEN_EOF value='' range=[27, 27] start=1:27 end=1:27>

--- a/test/snapshots/lexer/attributes_test/test_0003_attribute_value_empty_double_quotes_with_whitespace_aa45c5ab55dcf5752db629787123d549.txt
+++ b/test/snapshots/lexer/attributes_test/test_0003_attribute_value_empty_double_quotes_with_whitespace_aa45c5ab55dcf5752db629787123d549.txt
@@ -1,0 +1,10 @@
+#<Token type=TOKEN_HTML_TAG_START value='<' range=[0, 1] start=1:0 end=1:1>
+#<Token type=TOKEN_IDENTIFIER value='img' range=[1, 4] start=1:1 end=1:4>
+#<Token type=TOKEN_WHITESPACE value=' ' range=[4, 5] start=1:4 end=1:5>
+#<Token type=TOKEN_IDENTIFIER value='value' range=[5, 10] start=1:5 end=1:10>
+#<Token type=TOKEN_EQUALS value='=' range=[10, 11] start=1:10 end=1:11>
+#<Token type=TOKEN_QUOTE value='"' range=[11, 12] start=1:11 end=1:12>
+#<Token type=TOKEN_QUOTE value='"' range=[12, 13] start=1:12 end=1:13>
+#<Token type=TOKEN_WHITESPACE value=' ' range=[13, 14] start=1:13 end=1:14>
+#<Token type=TOKEN_HTML_TAG_SELF_CLOSE value='/>' range=[14, 16] start=1:14 end=1:16>
+#<Token type=TOKEN_EOF value='' range=[16, 16] start=1:16 end=1:16>

--- a/test/snapshots/lexer/attributes_test/test_0004_attribute_value_empty_double_quotes_without_whitespace_dc0893bda6faff8ecc29985263b68f44.txt
+++ b/test/snapshots/lexer/attributes_test/test_0004_attribute_value_empty_double_quotes_without_whitespace_dc0893bda6faff8ecc29985263b68f44.txt
@@ -1,0 +1,9 @@
+#<Token type=TOKEN_HTML_TAG_START value='<' range=[0, 1] start=1:0 end=1:1>
+#<Token type=TOKEN_IDENTIFIER value='img' range=[1, 4] start=1:1 end=1:4>
+#<Token type=TOKEN_WHITESPACE value=' ' range=[4, 5] start=1:4 end=1:5>
+#<Token type=TOKEN_IDENTIFIER value='value' range=[5, 10] start=1:5 end=1:10>
+#<Token type=TOKEN_EQUALS value='=' range=[10, 11] start=1:10 end=1:11>
+#<Token type=TOKEN_QUOTE value='"' range=[11, 12] start=1:11 end=1:12>
+#<Token type=TOKEN_QUOTE value='"' range=[12, 13] start=1:12 end=1:13>
+#<Token type=TOKEN_HTML_TAG_SELF_CLOSE value='/>' range=[13, 15] start=1:13 end=1:15>
+#<Token type=TOKEN_EOF value='' range=[15, 15] start=1:15 end=1:15>

--- a/test/snapshots/lexer/attributes_test/test_0005_attribute_value_empty_single_quotes_with_whitespace_2e5584859fa6a3d0830bbc5ad9020767.txt
+++ b/test/snapshots/lexer/attributes_test/test_0005_attribute_value_empty_single_quotes_with_whitespace_2e5584859fa6a3d0830bbc5ad9020767.txt
@@ -1,0 +1,10 @@
+#<Token type=TOKEN_HTML_TAG_START value='<' range=[0, 1] start=1:0 end=1:1>
+#<Token type=TOKEN_IDENTIFIER value='img' range=[1, 4] start=1:1 end=1:4>
+#<Token type=TOKEN_WHITESPACE value=' ' range=[4, 5] start=1:4 end=1:5>
+#<Token type=TOKEN_IDENTIFIER value='value' range=[5, 10] start=1:5 end=1:10>
+#<Token type=TOKEN_EQUALS value='=' range=[10, 11] start=1:10 end=1:11>
+#<Token type=TOKEN_QUOTE value=''' range=[11, 12] start=1:11 end=1:12>
+#<Token type=TOKEN_QUOTE value=''' range=[12, 13] start=1:12 end=1:13>
+#<Token type=TOKEN_WHITESPACE value=' ' range=[13, 14] start=1:13 end=1:14>
+#<Token type=TOKEN_HTML_TAG_SELF_CLOSE value='/>' range=[14, 16] start=1:14 end=1:16>
+#<Token type=TOKEN_EOF value='' range=[16, 16] start=1:16 end=1:16>

--- a/test/snapshots/lexer/attributes_test/test_0006_attribute_value_empty_single_quotes_without_whitespace_ec5b4690851677e250ac5506d70c355f.txt
+++ b/test/snapshots/lexer/attributes_test/test_0006_attribute_value_empty_single_quotes_without_whitespace_ec5b4690851677e250ac5506d70c355f.txt
@@ -1,0 +1,9 @@
+#<Token type=TOKEN_HTML_TAG_START value='<' range=[0, 1] start=1:0 end=1:1>
+#<Token type=TOKEN_IDENTIFIER value='img' range=[1, 4] start=1:1 end=1:4>
+#<Token type=TOKEN_WHITESPACE value=' ' range=[4, 5] start=1:4 end=1:5>
+#<Token type=TOKEN_IDENTIFIER value='value' range=[5, 10] start=1:5 end=1:10>
+#<Token type=TOKEN_EQUALS value='=' range=[10, 11] start=1:10 end=1:11>
+#<Token type=TOKEN_QUOTE value=''' range=[11, 12] start=1:11 end=1:12>
+#<Token type=TOKEN_QUOTE value=''' range=[12, 13] start=1:12 end=1:13>
+#<Token type=TOKEN_HTML_TAG_SELF_CLOSE value='/>' range=[13, 15] start=1:13 end=1:15>
+#<Token type=TOKEN_EOF value='' range=[15, 15] start=1:15 end=1:15>

--- a/test/snapshots/lexer/attributes_test/test_0007_attribute_value_single_quotes_with_slash_gt_ea0ed04bb6803d8a6cb24afe526c5a4a.txt
+++ b/test/snapshots/lexer/attributes_test/test_0007_attribute_value_single_quotes_with_slash_gt_ea0ed04bb6803d8a6cb24afe526c5a4a.txt
@@ -1,0 +1,10 @@
+#<Token type=TOKEN_HTML_TAG_START value='<' range=[0, 1] start=1:0 end=1:1>
+#<Token type=TOKEN_IDENTIFIER value='img' range=[1, 4] start=1:1 end=1:4>
+#<Token type=TOKEN_WHITESPACE value=' ' range=[4, 5] start=1:4 end=1:5>
+#<Token type=TOKEN_IDENTIFIER value='value' range=[5, 10] start=1:5 end=1:10>
+#<Token type=TOKEN_EQUALS value='=' range=[10, 11] start=1:10 end=1:11>
+#<Token type=TOKEN_QUOTE value=''' range=[11, 12] start=1:11 end=1:12>
+#<Token type=TOKEN_HTML_TAG_SELF_CLOSE value='/>' range=[12, 14] start=1:12 end=1:14>
+#<Token type=TOKEN_QUOTE value=''' range=[14, 15] start=1:14 end=1:15>
+#<Token type=TOKEN_HTML_TAG_SELF_CLOSE value='/>' range=[15, 17] start=1:15 end=1:17>
+#<Token type=TOKEN_EOF value='' range=[17, 17] start=1:17 end=1:17>

--- a/test/snapshots/lexer/attributes_test/test_0008_attribute_value_double_quotes_with_slash_gt_f890220bd65269c4616e9ce562492257.txt
+++ b/test/snapshots/lexer/attributes_test/test_0008_attribute_value_double_quotes_with_slash_gt_f890220bd65269c4616e9ce562492257.txt
@@ -1,0 +1,10 @@
+#<Token type=TOKEN_HTML_TAG_START value='<' range=[0, 1] start=1:0 end=1:1>
+#<Token type=TOKEN_IDENTIFIER value='img' range=[1, 4] start=1:1 end=1:4>
+#<Token type=TOKEN_WHITESPACE value=' ' range=[4, 5] start=1:4 end=1:5>
+#<Token type=TOKEN_IDENTIFIER value='value' range=[5, 10] start=1:5 end=1:10>
+#<Token type=TOKEN_EQUALS value='=' range=[10, 11] start=1:10 end=1:11>
+#<Token type=TOKEN_QUOTE value='"' range=[11, 12] start=1:11 end=1:12>
+#<Token type=TOKEN_HTML_TAG_SELF_CLOSE value='/>' range=[12, 14] start=1:12 end=1:14>
+#<Token type=TOKEN_QUOTE value='"' range=[14, 15] start=1:14 end=1:15>
+#<Token type=TOKEN_HTML_TAG_SELF_CLOSE value='/>' range=[15, 17] start=1:15 end=1:17>
+#<Token type=TOKEN_EOF value='' range=[17, 17] start=1:17 end=1:17>

--- a/test/snapshots/lexer/attributes_test/test_0009_attribute_value_single_quotes_with_>_value_2e196056650e47d46886938eb88136f7.txt
+++ b/test/snapshots/lexer/attributes_test/test_0009_attribute_value_single_quotes_with_>_value_2e196056650e47d46886938eb88136f7.txt
@@ -1,0 +1,10 @@
+#<Token type=TOKEN_HTML_TAG_START value='<' range=[0, 1] start=1:0 end=1:1>
+#<Token type=TOKEN_IDENTIFIER value='img' range=[1, 4] start=1:1 end=1:4>
+#<Token type=TOKEN_WHITESPACE value=' ' range=[4, 5] start=1:4 end=1:5>
+#<Token type=TOKEN_IDENTIFIER value='value' range=[5, 10] start=1:5 end=1:10>
+#<Token type=TOKEN_EQUALS value='=' range=[10, 11] start=1:10 end=1:11>
+#<Token type=TOKEN_QUOTE value=''' range=[11, 12] start=1:11 end=1:12>
+#<Token type=TOKEN_HTML_TAG_END value='>' range=[12, 13] start=1:12 end=1:13>
+#<Token type=TOKEN_QUOTE value=''' range=[13, 14] start=1:13 end=1:14>
+#<Token type=TOKEN_HTML_TAG_SELF_CLOSE value='/>' range=[14, 16] start=1:14 end=1:16>
+#<Token type=TOKEN_EOF value='' range=[16, 16] start=1:16 end=1:16>

--- a/test/snapshots/lexer/attributes_test/test_0010_attribute_value_double_quotes_with_slash_98c2bda4f37e2def75e128c157a85691.txt
+++ b/test/snapshots/lexer/attributes_test/test_0010_attribute_value_double_quotes_with_slash_98c2bda4f37e2def75e128c157a85691.txt
@@ -1,0 +1,10 @@
+#<Token type=TOKEN_HTML_TAG_START value='<' range=[0, 1] start=1:0 end=1:1>
+#<Token type=TOKEN_IDENTIFIER value='img' range=[1, 4] start=1:1 end=1:4>
+#<Token type=TOKEN_WHITESPACE value=' ' range=[4, 5] start=1:4 end=1:5>
+#<Token type=TOKEN_IDENTIFIER value='value' range=[5, 10] start=1:5 end=1:10>
+#<Token type=TOKEN_EQUALS value='=' range=[10, 11] start=1:10 end=1:11>
+#<Token type=TOKEN_QUOTE value='"' range=[11, 12] start=1:11 end=1:12>
+#<Token type=TOKEN_SLASH value='/' range=[12, 13] start=1:12 end=1:13>
+#<Token type=TOKEN_QUOTE value='"' range=[13, 14] start=1:13 end=1:14>
+#<Token type=TOKEN_HTML_TAG_SELF_CLOSE value='/>' range=[14, 16] start=1:14 end=1:16>
+#<Token type=TOKEN_EOF value='' range=[16, 16] start=1:16 end=1:16>

--- a/test/snapshots/lexer/attributes_test/test_0013_attribute_value_double_quotes_with_slash_value_bf55684b694d2aa471b24fa539546339.txt
+++ b/test/snapshots/lexer/attributes_test/test_0013_attribute_value_double_quotes_with_slash_value_bf55684b694d2aa471b24fa539546339.txt
@@ -1,0 +1,10 @@
+#<Token type=TOKEN_HTML_TAG_START value='<' range=[0, 1] start=1:0 end=1:1>
+#<Token type=TOKEN_IDENTIFIER value='img' range=[1, 4] start=1:1 end=1:4>
+#<Token type=TOKEN_WHITESPACE value=' ' range=[4, 5] start=1:4 end=1:5>
+#<Token type=TOKEN_IDENTIFIER value='value' range=[5, 10] start=1:5 end=1:10>
+#<Token type=TOKEN_EQUALS value='=' range=[10, 11] start=1:10 end=1:11>
+#<Token type=TOKEN_QUOTE value='"' range=[11, 12] start=1:11 end=1:12>
+#<Token type=TOKEN_HTML_TAG_END value='>' range=[12, 13] start=1:12 end=1:13>
+#<Token type=TOKEN_QUOTE value='"' range=[13, 14] start=1:13 end=1:14>
+#<Token type=TOKEN_HTML_TAG_SELF_CLOSE value='/>' range=[14, 16] start=1:14 end=1:16>
+#<Token type=TOKEN_EOF value='' range=[16, 16] start=1:16 end=1:16>

--- a/test/snapshots/lexer/attributes_test/test_0014_attribute_value_double_quotes_with_single_quote_value_bd2cc15e28c80a4cfdafb4467f6f0555.txt
+++ b/test/snapshots/lexer/attributes_test/test_0014_attribute_value_double_quotes_with_single_quote_value_bd2cc15e28c80a4cfdafb4467f6f0555.txt
@@ -1,0 +1,11 @@
+#<Token type=TOKEN_HTML_TAG_START value='<' range=[0, 1] start=1:0 end=1:1>
+#<Token type=TOKEN_IDENTIFIER value='img' range=[1, 4] start=1:1 end=1:4>
+#<Token type=TOKEN_WHITESPACE value=' ' range=[4, 5] start=1:4 end=1:5>
+#<Token type=TOKEN_IDENTIFIER value='value' range=[5, 10] start=1:5 end=1:10>
+#<Token type=TOKEN_EQUALS value='=' range=[10, 11] start=1:10 end=1:11>
+#<Token type=TOKEN_QUOTE value='"' range=[11, 12] start=1:11 end=1:12>
+#<Token type=TOKEN_QUOTE value=''' range=[12, 13] start=1:12 end=1:13>
+#<Token type=TOKEN_QUOTE value=''' range=[13, 14] start=1:13 end=1:14>
+#<Token type=TOKEN_QUOTE value='"' range=[14, 15] start=1:14 end=1:15>
+#<Token type=TOKEN_HTML_TAG_SELF_CLOSE value='/>' range=[15, 17] start=1:15 end=1:17>
+#<Token type=TOKEN_EOF value='' range=[17, 17] start=1:17 end=1:17>

--- a/test/snapshots/lexer/attributes_test/test_0015_attribute_value_single_quotes_with_double_quote_value_3b99fbfb2dbe3aba937cc20311e7d331.txt
+++ b/test/snapshots/lexer/attributes_test/test_0015_attribute_value_single_quotes_with_double_quote_value_3b99fbfb2dbe3aba937cc20311e7d331.txt
@@ -1,0 +1,11 @@
+#<Token type=TOKEN_HTML_TAG_START value='<' range=[0, 1] start=1:0 end=1:1>
+#<Token type=TOKEN_IDENTIFIER value='img' range=[1, 4] start=1:1 end=1:4>
+#<Token type=TOKEN_WHITESPACE value=' ' range=[4, 5] start=1:4 end=1:5>
+#<Token type=TOKEN_IDENTIFIER value='value' range=[5, 10] start=1:5 end=1:10>
+#<Token type=TOKEN_EQUALS value='=' range=[10, 11] start=1:10 end=1:11>
+#<Token type=TOKEN_QUOTE value=''' range=[11, 12] start=1:11 end=1:12>
+#<Token type=TOKEN_QUOTE value='"' range=[12, 13] start=1:12 end=1:13>
+#<Token type=TOKEN_QUOTE value='"' range=[13, 14] start=1:13 end=1:14>
+#<Token type=TOKEN_QUOTE value=''' range=[14, 15] start=1:14 end=1:15>
+#<Token type=TOKEN_HTML_TAG_SELF_CLOSE value='/>' range=[15, 17] start=1:15 end=1:17>
+#<Token type=TOKEN_EOF value='' range=[17, 17] start=1:17 end=1:17>

--- a/test/snapshots/lexer/attributes_test/test_0016_attribute_value_empty_quotes_followed_by_another_attribute_f25f6219b2cf10d288d83c451540e958.txt
+++ b/test/snapshots/lexer/attributes_test/test_0016_attribute_value_empty_quotes_followed_by_another_attribute_f25f6219b2cf10d288d83c451540e958.txt
@@ -1,0 +1,12 @@
+#<Token type=TOKEN_HTML_TAG_START value='<' range=[0, 1] start=1:0 end=1:1>
+#<Token type=TOKEN_IDENTIFIER value='img' range=[1, 4] start=1:1 end=1:4>
+#<Token type=TOKEN_WHITESPACE value=' ' range=[4, 5] start=1:4 end=1:5>
+#<Token type=TOKEN_IDENTIFIER value='value' range=[5, 10] start=1:5 end=1:10>
+#<Token type=TOKEN_EQUALS value='=' range=[10, 11] start=1:10 end=1:11>
+#<Token type=TOKEN_QUOTE value='"' range=[11, 12] start=1:11 end=1:12>
+#<Token type=TOKEN_QUOTE value='"' range=[12, 13] start=1:12 end=1:13>
+#<Token type=TOKEN_WHITESPACE value=' ' range=[13, 14] start=1:13 end=1:14>
+#<Token type=TOKEN_IDENTIFIER value='required' range=[14, 22] start=1:14 end=1:22>
+#<Token type=TOKEN_WHITESPACE value=' ' range=[22, 23] start=1:22 end=1:23>
+#<Token type=TOKEN_HTML_TAG_SELF_CLOSE value='/>' range=[23, 25] start=1:23 end=1:25>
+#<Token type=TOKEN_EOF value='' range=[25, 25] start=1:25 end=1:25>

--- a/test/snapshots/lexer/attributes_test/test_0017_attribute_value_with_a_period_ce133d95b3be56c458be6147bbb4418b.txt
+++ b/test/snapshots/lexer/attributes_test/test_0017_attribute_value_with_a_period_ce133d95b3be56c458be6147bbb4418b.txt
@@ -1,0 +1,17 @@
+#<Token type=TOKEN_HTML_TAG_START value='<' range=[0, 1] start=1:0 end=1:1>
+#<Token type=TOKEN_IDENTIFIER value='div' range=[1, 4] start=1:1 end=1:4>
+#<Token type=TOKEN_WHITESPACE value=' ' range=[4, 5] start=1:4 end=1:5>
+#<Token type=TOKEN_IDENTIFIER value='value' range=[5, 10] start=1:5 end=1:10>
+#<Token type=TOKEN_EQUALS value='=' range=[10, 11] start=1:10 end=1:11>
+#<Token type=TOKEN_QUOTE value='"' range=[11, 12] start=1:11 end=1:12>
+#<Token type=TOKEN_IDENTIFIER value='hello' range=[12, 17] start=1:12 end=1:17>
+#<Token type=TOKEN_CHARACTER value='.' range=[17, 18] start=1:17 end=1:18>
+#<Token type=TOKEN_WHITESPACE value=' ' range=[18, 19] start=1:18 end=1:19>
+#<Token type=TOKEN_IDENTIFIER value='world' range=[19, 24] start=1:19 end=1:24>
+#<Token type=TOKEN_CHARACTER value='.' range=[24, 25] start=1:24 end=1:25>
+#<Token type=TOKEN_QUOTE value='"' range=[25, 26] start=1:25 end=1:26>
+#<Token type=TOKEN_HTML_TAG_END value='>' range=[26, 27] start=1:26 end=1:27>
+#<Token type=TOKEN_HTML_TAG_START_CLOSE value='</' range=[27, 29] start=1:27 end=1:29>
+#<Token type=TOKEN_IDENTIFIER value='div' range=[29, 32] start=1:29 end=1:32>
+#<Token type=TOKEN_HTML_TAG_END value='>' range=[32, 33] start=1:32 end=1:33>
+#<Token type=TOKEN_EOF value='' range=[33, 33] start=1:33 end=1:33>

--- a/test/snapshots/lexer/attributes_test/test_0018_attribute_value_with_a_slash_6db33df13355465e338194afbebd9174.txt
+++ b/test/snapshots/lexer/attributes_test/test_0018_attribute_value_with_a_slash_6db33df13355465e338194afbebd9174.txt
@@ -1,0 +1,17 @@
+#<Token type=TOKEN_HTML_TAG_START value='<' range=[0, 1] start=1:0 end=1:1>
+#<Token type=TOKEN_IDENTIFIER value='div' range=[1, 4] start=1:1 end=1:4>
+#<Token type=TOKEN_WHITESPACE value=' ' range=[4, 5] start=1:4 end=1:5>
+#<Token type=TOKEN_IDENTIFIER value='value' range=[5, 10] start=1:5 end=1:10>
+#<Token type=TOKEN_EQUALS value='=' range=[10, 11] start=1:10 end=1:11>
+#<Token type=TOKEN_QUOTE value='"' range=[11, 12] start=1:11 end=1:12>
+#<Token type=TOKEN_IDENTIFIER value='hello' range=[12, 17] start=1:12 end=1:17>
+#<Token type=TOKEN_SLASH value='/' range=[17, 18] start=1:17 end=1:18>
+#<Token type=TOKEN_WHITESPACE value=' ' range=[18, 19] start=1:18 end=1:19>
+#<Token type=TOKEN_IDENTIFIER value='world' range=[19, 24] start=1:19 end=1:24>
+#<Token type=TOKEN_SLASH value='/' range=[24, 25] start=1:24 end=1:25>
+#<Token type=TOKEN_QUOTE value='"' range=[25, 26] start=1:25 end=1:26>
+#<Token type=TOKEN_HTML_TAG_END value='>' range=[26, 27] start=1:26 end=1:27>
+#<Token type=TOKEN_HTML_TAG_START_CLOSE value='</' range=[27, 29] start=1:27 end=1:29>
+#<Token type=TOKEN_IDENTIFIER value='div' range=[29, 32] start=1:29 end=1:32>
+#<Token type=TOKEN_HTML_TAG_END value='>' range=[32, 33] start=1:32 end=1:33>
+#<Token type=TOKEN_EOF value='' range=[33, 33] start=1:33 end=1:33>

--- a/test/snapshots/lexer/attributes_test/test_0019_attribute_value_with_an_URL_0d5203d491fd23e18ad9d18972871f99.txt
+++ b/test/snapshots/lexer/attributes_test/test_0019_attribute_value_with_an_URL_0d5203d491fd23e18ad9d18972871f99.txt
@@ -1,0 +1,18 @@
+#<Token type=TOKEN_HTML_TAG_START value='<' range=[0, 1] start=1:0 end=1:1>
+#<Token type=TOKEN_IDENTIFIER value='a' range=[1, 2] start=1:1 end=1:2>
+#<Token type=TOKEN_WHITESPACE value=' ' range=[2, 3] start=1:2 end=1:3>
+#<Token type=TOKEN_IDENTIFIER value='href' range=[3, 7] start=1:3 end=1:7>
+#<Token type=TOKEN_EQUALS value='=' range=[7, 8] start=1:7 end=1:8>
+#<Token type=TOKEN_QUOTE value='"' range=[8, 9] start=1:8 end=1:9>
+#<Token type=TOKEN_IDENTIFIER value='https:' range=[9, 15] start=1:9 end=1:15>
+#<Token type=TOKEN_SLASH value='/' range=[15, 16] start=1:15 end=1:16>
+#<Token type=TOKEN_SLASH value='/' range=[16, 17] start=1:16 end=1:17>
+#<Token type=TOKEN_IDENTIFIER value='example' range=[17, 24] start=1:17 end=1:24>
+#<Token type=TOKEN_CHARACTER value='.' range=[24, 25] start=1:24 end=1:25>
+#<Token type=TOKEN_IDENTIFIER value='com' range=[25, 28] start=1:25 end=1:28>
+#<Token type=TOKEN_QUOTE value='"' range=[28, 29] start=1:28 end=1:29>
+#<Token type=TOKEN_HTML_TAG_END value='>' range=[29, 30] start=1:29 end=1:30>
+#<Token type=TOKEN_HTML_TAG_START_CLOSE value='</' range=[30, 32] start=1:30 end=1:32>
+#<Token type=TOKEN_IDENTIFIER value='div' range=[32, 35] start=1:32 end=1:35>
+#<Token type=TOKEN_HTML_TAG_END value='>' range=[35, 36] start=1:35 end=1:36>
+#<Token type=TOKEN_EOF value='' range=[36, 36] start=1:36 end=1:36>

--- a/test/snapshots/lexer/boolean_attributes_test/test_0001_boolean_attribute_bb7e4ba2925fabbda530de889e749a52.txt
+++ b/test/snapshots/lexer/boolean_attributes_test/test_0001_boolean_attribute_bb7e4ba2925fabbda530de889e749a52.txt
@@ -1,0 +1,7 @@
+#<Token type=TOKEN_HTML_TAG_START value='<' range=[0, 1] start=1:0 end=1:1>
+#<Token type=TOKEN_IDENTIFIER value='img' range=[1, 4] start=1:1 end=1:4>
+#<Token type=TOKEN_WHITESPACE value=' ' range=[4, 5] start=1:4 end=1:5>
+#<Token type=TOKEN_IDENTIFIER value='required' range=[5, 13] start=1:5 end=1:13>
+#<Token type=TOKEN_WHITESPACE value=' ' range=[13, 14] start=1:13 end=1:14>
+#<Token type=TOKEN_HTML_TAG_SELF_CLOSE value='/>' range=[14, 16] start=1:14 end=1:16>
+#<Token type=TOKEN_EOF value='' range=[16, 16] start=1:16 end=1:16>

--- a/test/snapshots/lexer/boolean_attributes_test/test_0002_boolean_attribute_without_whitespace_and_with_self-closing_tag_c6b0a14a338dd8edc4a12c0d19e7f542.txt
+++ b/test/snapshots/lexer/boolean_attributes_test/test_0002_boolean_attribute_without_whitespace_and_with_self-closing_tag_c6b0a14a338dd8edc4a12c0d19e7f542.txt
@@ -1,0 +1,6 @@
+#<Token type=TOKEN_HTML_TAG_START value='<' range=[0, 1] start=1:0 end=1:1>
+#<Token type=TOKEN_IDENTIFIER value='img' range=[1, 4] start=1:1 end=1:4>
+#<Token type=TOKEN_WHITESPACE value=' ' range=[4, 5] start=1:4 end=1:5>
+#<Token type=TOKEN_IDENTIFIER value='required' range=[5, 13] start=1:5 end=1:13>
+#<Token type=TOKEN_HTML_TAG_SELF_CLOSE value='/>' range=[13, 15] start=1:13 end=1:15>
+#<Token type=TOKEN_EOF value='' range=[15, 15] start=1:15 end=1:15>

--- a/test/snapshots/lexer/boolean_attributes_test/test_0003_boolean_attribute_without_whitespace_and_without_self-closing_tag_64b6a6bf9a284ab86a9db5974b31b466.txt
+++ b/test/snapshots/lexer/boolean_attributes_test/test_0003_boolean_attribute_without_whitespace_and_without_self-closing_tag_64b6a6bf9a284ab86a9db5974b31b466.txt
@@ -1,0 +1,6 @@
+#<Token type=TOKEN_HTML_TAG_START value='<' range=[0, 1] start=1:0 end=1:1>
+#<Token type=TOKEN_IDENTIFIER value='img' range=[1, 4] start=1:1 end=1:4>
+#<Token type=TOKEN_WHITESPACE value=' ' range=[4, 5] start=1:4 end=1:5>
+#<Token type=TOKEN_IDENTIFIER value='required' range=[5, 13] start=1:5 end=1:13>
+#<Token type=TOKEN_HTML_TAG_END value='>' range=[13, 14] start=1:13 end=1:14>
+#<Token type=TOKEN_EOF value='' range=[14, 14] start=1:14 end=1:14>

--- a/test/snapshots/lexer/comments_test/test_0001_HTML_comment_with_padding_whitespace_9cb56068ef4732067422a670d943c08e.txt
+++ b/test/snapshots/lexer/comments_test/test_0001_HTML_comment_with_padding_whitespace_9cb56068ef4732067422a670d943c08e.txt
@@ -1,0 +1,8 @@
+#<Token type=TOKEN_HTML_COMMENT_START value='<!--' range=[0, 4] start=1:0 end=1:4>
+#<Token type=TOKEN_WHITESPACE value=' ' range=[4, 5] start=1:4 end=1:5>
+#<Token type=TOKEN_IDENTIFIER value='Hello' range=[5, 10] start=1:5 end=1:10>
+#<Token type=TOKEN_WHITESPACE value=' ' range=[10, 11] start=1:10 end=1:11>
+#<Token type=TOKEN_IDENTIFIER value='World' range=[11, 16] start=1:11 end=1:16>
+#<Token type=TOKEN_WHITESPACE value=' ' range=[16, 17] start=1:16 end=1:17>
+#<Token type=TOKEN_HTML_COMMENT_END value='-->' range=[17, 20] start=1:17 end=1:20>
+#<Token type=TOKEN_EOF value='' range=[20, 20] start=1:20 end=1:20>

--- a/test/snapshots/lexer/comments_test/test_0002_HTML_comment_with_no_whitespace_4644299a23e9ee76cdc970a26168b559.txt
+++ b/test/snapshots/lexer/comments_test/test_0002_HTML_comment_with_no_whitespace_4644299a23e9ee76cdc970a26168b559.txt
@@ -1,0 +1,6 @@
+#<Token type=TOKEN_HTML_COMMENT_START value='<!--' range=[0, 4] start=1:0 end=1:4>
+#<Token type=TOKEN_IDENTIFIER value='Hello' range=[4, 9] start=1:4 end=1:9>
+#<Token type=TOKEN_WHITESPACE value=' ' range=[9, 10] start=1:9 end=1:10>
+#<Token type=TOKEN_IDENTIFIER value='World' range=[10, 15] start=1:10 end=1:15>
+#<Token type=TOKEN_HTML_COMMENT_END value='-->' range=[15, 18] start=1:15 end=1:18>
+#<Token type=TOKEN_EOF value='' range=[18, 18] start=1:18 end=1:18>

--- a/test/snapshots/lexer/comments_test/test_0003_HTML_comment_followed_by_html_tag_573b93df7df7d12ef12722008abfc7ee.txt
+++ b/test/snapshots/lexer/comments_test/test_0003_HTML_comment_followed_by_html_tag_573b93df7df7d12ef12722008abfc7ee.txt
@@ -1,0 +1,13 @@
+#<Token type=TOKEN_HTML_COMMENT_START value='<!--' range=[0, 4] start=1:0 end=1:4>
+#<Token type=TOKEN_IDENTIFIER value='Hello' range=[4, 9] start=1:4 end=1:9>
+#<Token type=TOKEN_WHITESPACE value=' ' range=[9, 10] start=1:9 end=1:10>
+#<Token type=TOKEN_IDENTIFIER value='World' range=[10, 15] start=1:10 end=1:15>
+#<Token type=TOKEN_HTML_COMMENT_END value='-->' range=[15, 18] start=1:15 end=1:18>
+#<Token type=TOKEN_HTML_TAG_START value='<' range=[18, 19] start=1:18 end=1:19>
+#<Token type=TOKEN_IDENTIFIER value='h1' range=[19, 21] start=1:19 end=1:21>
+#<Token type=TOKEN_HTML_TAG_END value='>' range=[21, 22] start=1:21 end=1:22>
+#<Token type=TOKEN_IDENTIFIER value='Hello' range=[22, 27] start=1:22 end=1:27>
+#<Token type=TOKEN_HTML_TAG_START_CLOSE value='</' range=[27, 29] start=1:27 end=1:29>
+#<Token type=TOKEN_IDENTIFIER value='h1' range=[29, 31] start=1:29 end=1:31>
+#<Token type=TOKEN_HTML_TAG_END value='>' range=[31, 32] start=1:31 end=1:32>
+#<Token type=TOKEN_EOF value='' range=[32, 32] start=1:32 end=1:32>

--- a/test/snapshots/lexer/comments_test/test_0004_HTML_comment_followed_by_html_tag_with_nested_comment_f4042eb3e6a5d62fcc86e4162fe10cf2.txt
+++ b/test/snapshots/lexer/comments_test/test_0004_HTML_comment_followed_by_html_tag_with_nested_comment_f4042eb3e6a5d62fcc86e4162fe10cf2.txt
@@ -1,0 +1,25 @@
+#<Token type=TOKEN_NEWLINE value='\n' range=[0, 1] start=1:0 end=2:1>
+#<Token type=TOKEN_WHITESPACE value='        ' range=[1, 9] start=2:1 end=2:9>
+#<Token type=TOKEN_HTML_COMMENT_START value='<!--' range=[9, 13] start=2:9 end=2:13>
+#<Token type=TOKEN_IDENTIFIER value='Hello' range=[13, 18] start=2:13 end=2:18>
+#<Token type=TOKEN_WHITESPACE value=' ' range=[18, 19] start=2:18 end=2:19>
+#<Token type=TOKEN_IDENTIFIER value='World' range=[19, 24] start=2:19 end=2:24>
+#<Token type=TOKEN_HTML_COMMENT_END value='-->' range=[24, 27] start=2:24 end=2:27>
+#<Token type=TOKEN_NEWLINE value='\n' range=[27, 28] start=2:0 end=3:1>
+#<Token type=TOKEN_WHITESPACE value='        ' range=[28, 36] start=3:1 end=3:9>
+#<Token type=TOKEN_HTML_TAG_START value='<' range=[36, 37] start=3:9 end=3:10>
+#<Token type=TOKEN_IDENTIFIER value='h1' range=[37, 39] start=3:10 end=3:12>
+#<Token type=TOKEN_HTML_TAG_END value='>' range=[39, 40] start=3:12 end=3:13>
+#<Token type=TOKEN_HTML_COMMENT_START value='<!--' range=[40, 44] start=3:13 end=3:17>
+#<Token type=TOKEN_WHITESPACE value=' ' range=[44, 45] start=3:17 end=3:18>
+#<Token type=TOKEN_IDENTIFIER value='Hello' range=[45, 50] start=3:18 end=3:23>
+#<Token type=TOKEN_WHITESPACE value=' ' range=[50, 51] start=3:23 end=3:24>
+#<Token type=TOKEN_IDENTIFIER value='World' range=[51, 56] start=3:24 end=3:29>
+#<Token type=TOKEN_WHITESPACE value=' ' range=[56, 57] start=3:29 end=3:30>
+#<Token type=TOKEN_HTML_COMMENT_END value='-->' range=[57, 60] start=3:30 end=3:33>
+#<Token type=TOKEN_HTML_TAG_START_CLOSE value='</' range=[60, 62] start=3:33 end=3:35>
+#<Token type=TOKEN_IDENTIFIER value='h1' range=[62, 64] start=3:35 end=3:37>
+#<Token type=TOKEN_HTML_TAG_END value='>' range=[64, 65] start=3:37 end=3:38>
+#<Token type=TOKEN_NEWLINE value='\n' range=[65, 66] start=3:0 end=4:1>
+#<Token type=TOKEN_WHITESPACE value='      ' range=[66, 72] start=4:1 end=4:7>
+#<Token type=TOKEN_EOF value='' range=[72, 72] start=4:7 end=4:7>

--- a/test/snapshots/lexer/doctype_test/test_0001_doctype_d50c7b32f19e4848938905f3dc675f44.txt
+++ b/test/snapshots/lexer/doctype_test/test_0001_doctype_d50c7b32f19e4848938905f3dc675f44.txt
@@ -1,0 +1,3 @@
+#<Token type=TOKEN_HTML_DOCTYPE value='<!DOCTYPE' range=[0, 9] start=1:0 end=1:9>
+#<Token type=TOKEN_HTML_TAG_END value='>' range=[9, 10] start=1:9 end=1:10>
+#<Token type=TOKEN_EOF value='' range=[10, 10] start=1:10 end=1:10>

--- a/test/snapshots/lexer/doctype_test/test_0002_doctype_with_space_6bc67d7bee174842987d55662f6e3d1c.txt
+++ b/test/snapshots/lexer/doctype_test/test_0002_doctype_with_space_6bc67d7bee174842987d55662f6e3d1c.txt
@@ -1,0 +1,4 @@
+#<Token type=TOKEN_HTML_DOCTYPE value='<!DOCTYPE' range=[0, 9] start=1:0 end=1:9>
+#<Token type=TOKEN_WHITESPACE value=' ' range=[9, 10] start=1:9 end=1:10>
+#<Token type=TOKEN_HTML_TAG_END value='>' range=[10, 11] start=1:10 end=1:11>
+#<Token type=TOKEN_EOF value='' range=[11, 11] start=1:11 end=1:11>

--- a/test/snapshots/lexer/doctype_test/test_0003_doctype_with_html_fe364450e1391215f596d043488f989f.txt
+++ b/test/snapshots/lexer/doctype_test/test_0003_doctype_with_html_fe364450e1391215f596d043488f989f.txt
@@ -1,0 +1,5 @@
+#<Token type=TOKEN_HTML_DOCTYPE value='<!DOCTYPE' range=[0, 9] start=1:0 end=1:9>
+#<Token type=TOKEN_WHITESPACE value=' ' range=[9, 10] start=1:9 end=1:10>
+#<Token type=TOKEN_IDENTIFIER value='html' range=[10, 14] start=1:10 end=1:14>
+#<Token type=TOKEN_HTML_TAG_END value='>' range=[14, 15] start=1:14 end=1:15>
+#<Token type=TOKEN_EOF value='' range=[15, 15] start=1:15 end=1:15>

--- a/test/snapshots/lexer/doctype_test/test_0004_html4_doctype_737d71ee3fb171f813731282cd802c3e.txt
+++ b/test/snapshots/lexer/doctype_test/test_0004_html4_doctype_737d71ee3fb171f813731282cd802c3e.txt
@@ -1,0 +1,45 @@
+#<Token type=TOKEN_HTML_DOCTYPE value='<!DOCTYPE' range=[0, 9] start=1:0 end=1:9>
+#<Token type=TOKEN_WHITESPACE value=' ' range=[9, 10] start=1:9 end=1:10>
+#<Token type=TOKEN_IDENTIFIER value='HTML' range=[10, 14] start=1:10 end=1:14>
+#<Token type=TOKEN_WHITESPACE value=' ' range=[14, 15] start=1:14 end=1:15>
+#<Token type=TOKEN_IDENTIFIER value='PUBLIC' range=[15, 21] start=1:15 end=1:21>
+#<Token type=TOKEN_WHITESPACE value=' ' range=[21, 22] start=1:21 end=1:22>
+#<Token type=TOKEN_QUOTE value='"' range=[22, 23] start=1:22 end=1:23>
+#<Token type=TOKEN_DASH value='-' range=[23, 24] start=1:23 end=1:24>
+#<Token type=TOKEN_SLASH value='/' range=[24, 25] start=1:24 end=1:25>
+#<Token type=TOKEN_SLASH value='/' range=[25, 26] start=1:25 end=1:26>
+#<Token type=TOKEN_IDENTIFIER value='W3C' range=[26, 29] start=1:26 end=1:29>
+#<Token type=TOKEN_SLASH value='/' range=[29, 30] start=1:29 end=1:30>
+#<Token type=TOKEN_SLASH value='/' range=[30, 31] start=1:30 end=1:31>
+#<Token type=TOKEN_IDENTIFIER value='DTD' range=[31, 34] start=1:31 end=1:34>
+#<Token type=TOKEN_WHITESPACE value=' ' range=[34, 35] start=1:34 end=1:35>
+#<Token type=TOKEN_IDENTIFIER value='HTML' range=[35, 39] start=1:35 end=1:39>
+#<Token type=TOKEN_WHITESPACE value=' ' range=[39, 40] start=1:39 end=1:40>
+#<Token type=TOKEN_IDENTIFIER value='4' range=[40, 41] start=1:40 end=1:41>
+#<Token type=TOKEN_CHARACTER value='.' range=[41, 42] start=1:41 end=1:42>
+#<Token type=TOKEN_IDENTIFIER value='01' range=[42, 44] start=1:42 end=1:44>
+#<Token type=TOKEN_SLASH value='/' range=[44, 45] start=1:44 end=1:45>
+#<Token type=TOKEN_SLASH value='/' range=[45, 46] start=1:45 end=1:46>
+#<Token type=TOKEN_IDENTIFIER value='EN' range=[46, 48] start=1:46 end=1:48>
+#<Token type=TOKEN_QUOTE value='"' range=[48, 49] start=1:48 end=1:49>
+#<Token type=TOKEN_WHITESPACE value=' ' range=[49, 50] start=1:49 end=1:50>
+#<Token type=TOKEN_QUOTE value='"' range=[50, 51] start=1:50 end=1:51>
+#<Token type=TOKEN_IDENTIFIER value='http:' range=[51, 56] start=1:51 end=1:56>
+#<Token type=TOKEN_SLASH value='/' range=[56, 57] start=1:56 end=1:57>
+#<Token type=TOKEN_SLASH value='/' range=[57, 58] start=1:57 end=1:58>
+#<Token type=TOKEN_IDENTIFIER value='www' range=[58, 61] start=1:58 end=1:61>
+#<Token type=TOKEN_CHARACTER value='.' range=[61, 62] start=1:61 end=1:62>
+#<Token type=TOKEN_IDENTIFIER value='w3' range=[62, 64] start=1:62 end=1:64>
+#<Token type=TOKEN_CHARACTER value='.' range=[64, 65] start=1:64 end=1:65>
+#<Token type=TOKEN_IDENTIFIER value='org' range=[65, 68] start=1:65 end=1:68>
+#<Token type=TOKEN_SLASH value='/' range=[68, 69] start=1:68 end=1:69>
+#<Token type=TOKEN_IDENTIFIER value='TR' range=[69, 71] start=1:69 end=1:71>
+#<Token type=TOKEN_SLASH value='/' range=[71, 72] start=1:71 end=1:72>
+#<Token type=TOKEN_IDENTIFIER value='html4' range=[72, 77] start=1:72 end=1:77>
+#<Token type=TOKEN_SLASH value='/' range=[77, 78] start=1:77 end=1:78>
+#<Token type=TOKEN_IDENTIFIER value='strict' range=[78, 84] start=1:78 end=1:84>
+#<Token type=TOKEN_CHARACTER value='.' range=[84, 85] start=1:84 end=1:85>
+#<Token type=TOKEN_IDENTIFIER value='dtd' range=[85, 88] start=1:85 end=1:88>
+#<Token type=TOKEN_QUOTE value='"' range=[88, 89] start=1:88 end=1:89>
+#<Token type=TOKEN_HTML_TAG_END value='>' range=[89, 90] start=1:89 end=1:90>
+#<Token type=TOKEN_EOF value='' range=[90, 90] start=1:90 end=1:90>

--- a/test/snapshots/lexer/doctype_test/test_0005_doctype_case_insensitivity_2f56dc84fb5f8e284f42eae7d1f1c597.txt
+++ b/test/snapshots/lexer/doctype_test/test_0005_doctype_case_insensitivity_2f56dc84fb5f8e284f42eae7d1f1c597.txt
@@ -1,0 +1,3 @@
+#<Token type=TOKEN_HTML_DOCTYPE value='<!DOCTYPE' range=[0, 9] start=1:0 end=1:9>
+#<Token type=TOKEN_HTML_TAG_END value='>' range=[9, 10] start=1:9 end=1:10>
+#<Token type=TOKEN_EOF value='' range=[10, 10] start=1:10 end=1:10>

--- a/test/snapshots/lexer/doctype_test/test_0005_doctype_case_insensitivity_3e5902254c42ff2df6f6321086040dbe.txt
+++ b/test/snapshots/lexer/doctype_test/test_0005_doctype_case_insensitivity_3e5902254c42ff2df6f6321086040dbe.txt
@@ -1,0 +1,3 @@
+#<Token type=TOKEN_HTML_DOCTYPE value='<!DOCTYPE' range=[0, 9] start=1:0 end=1:9>
+#<Token type=TOKEN_HTML_TAG_END value='>' range=[9, 10] start=1:9 end=1:10>
+#<Token type=TOKEN_EOF value='' range=[10, 10] start=1:10 end=1:10>

--- a/test/snapshots/lexer/doctype_test/test_0005_doctype_case_insensitivity_8bc9e797250fadb2f5af79f38cf7d74e.txt
+++ b/test/snapshots/lexer/doctype_test/test_0005_doctype_case_insensitivity_8bc9e797250fadb2f5af79f38cf7d74e.txt
@@ -1,0 +1,3 @@
+#<Token type=TOKEN_HTML_DOCTYPE value='<!DOCTYPE' range=[0, 9] start=1:0 end=1:9>
+#<Token type=TOKEN_HTML_TAG_END value='>' range=[9, 10] start=1:9 end=1:10>
+#<Token type=TOKEN_EOF value='' range=[10, 10] start=1:10 end=1:10>

--- a/test/snapshots/lexer/erb_test/test_0001_erb_<%_%>_e97ed3ba194342cfe8febc1a40a3d603.txt
+++ b/test/snapshots/lexer/erb_test/test_0001_erb_<%_%>_e97ed3ba194342cfe8febc1a40a3d603.txt
@@ -1,0 +1,4 @@
+#<Token type=TOKEN_ERB_START value='<%' range=[0, 2] start=1:0 end=1:2>
+#<Token type=TOKEN_ERB_CONTENT value=' 'hello world' ' range=[2, 17] start=1:2 end=1:17>
+#<Token type=TOKEN_ERB_END value='%>' range=[17, 19] start=1:17 end=1:19>
+#<Token type=TOKEN_EOF value='' range=[19, 19] start=1:19 end=1:19>

--- a/test/snapshots/lexer/erb_test/test_0002_erb_<%=_%>_2d5c53c5a986076f8a5df2585ce5aa74.txt
+++ b/test/snapshots/lexer/erb_test/test_0002_erb_<%=_%>_2d5c53c5a986076f8a5df2585ce5aa74.txt
@@ -1,0 +1,4 @@
+#<Token type=TOKEN_ERB_START value='<%=' range=[0, 3] start=1:0 end=1:3>
+#<Token type=TOKEN_ERB_CONTENT value=' "hello world" ' range=[3, 18] start=1:3 end=1:18>
+#<Token type=TOKEN_ERB_END value='%>' range=[18, 20] start=1:18 end=1:20>
+#<Token type=TOKEN_EOF value='' range=[20, 20] start=1:20 end=1:20>

--- a/test/snapshots/lexer/erb_test/test_0003_erb_<%-_%>_b305aff64a566ea549c116aacb0ce86c.txt
+++ b/test/snapshots/lexer/erb_test/test_0003_erb_<%-_%>_b305aff64a566ea549c116aacb0ce86c.txt
@@ -1,0 +1,4 @@
+#<Token type=TOKEN_ERB_START value='<%-' range=[0, 3] start=1:0 end=1:3>
+#<Token type=TOKEN_ERB_CONTENT value=' "Test" ' range=[3, 11] start=1:3 end=1:11>
+#<Token type=TOKEN_ERB_END value='%>' range=[11, 13] start=1:11 end=1:13>
+#<Token type=TOKEN_EOF value='' range=[13, 13] start=1:13 end=1:13>

--- a/test/snapshots/lexer/erb_test/test_0004_erb_<%-_-%>_34d2696185efe003bf3f2c2dddb924e3.txt
+++ b/test/snapshots/lexer/erb_test/test_0004_erb_<%-_-%>_34d2696185efe003bf3f2c2dddb924e3.txt
@@ -1,0 +1,4 @@
+#<Token type=TOKEN_ERB_START value='<%-' range=[0, 3] start=1:0 end=1:3>
+#<Token type=TOKEN_ERB_CONTENT value=' "Test" ' range=[3, 11] start=1:3 end=1:11>
+#<Token type=TOKEN_ERB_END value='-%>' range=[11, 14] start=1:11 end=1:14>
+#<Token type=TOKEN_EOF value='' range=[14, 14] start=1:14 end=1:14>

--- a/test/snapshots/lexer/erb_test/test_0005_erb_<%#_%>_d59bec1a45925c1618c6d42541cb652b.txt
+++ b/test/snapshots/lexer/erb_test/test_0005_erb_<%#_%>_d59bec1a45925c1618c6d42541cb652b.txt
@@ -1,0 +1,4 @@
+#<Token type=TOKEN_ERB_START value='<%#' range=[0, 3] start=1:0 end=1:3>
+#<Token type=TOKEN_ERB_CONTENT value=' "Test" ' range=[3, 11] start=1:3 end=1:11>
+#<Token type=TOKEN_ERB_END value='%>' range=[11, 13] start=1:11 end=1:13>
+#<Token type=TOKEN_EOF value='' range=[13, 13] start=1:13 end=1:13>

--- a/test/snapshots/lexer/erb_test/test_0006_erb_<%%_%%>_5856d025d70301b0cc95e2287a1d324f.txt
+++ b/test/snapshots/lexer/erb_test/test_0006_erb_<%%_%%>_5856d025d70301b0cc95e2287a1d324f.txt
@@ -1,0 +1,4 @@
+#<Token type=TOKEN_ERB_START value='<%%' range=[0, 3] start=1:0 end=1:3>
+#<Token type=TOKEN_ERB_CONTENT value=' "Test" ' range=[3, 11] start=1:3 end=1:11>
+#<Token type=TOKEN_ERB_END value='%%>' range=[11, 14] start=1:11 end=1:14>
+#<Token type=TOKEN_EOF value='' range=[14, 14] start=1:14 end=1:14>

--- a/test/snapshots/lexer/erb_test/test_0007_erb_output_inside_HTML_attribute_value_91d881ce0dd66286e4866c07a91e025c.txt
+++ b/test/snapshots/lexer/erb_test/test_0007_erb_output_inside_HTML_attribute_value_91d881ce0dd66286e4866c07a91e025c.txt
@@ -1,0 +1,15 @@
+#<Token type=TOKEN_HTML_TAG_START value='<' range=[0, 1] start=1:0 end=1:1>
+#<Token type=TOKEN_IDENTIFIER value='article' range=[1, 8] start=1:1 end=1:8>
+#<Token type=TOKEN_WHITESPACE value=' ' range=[8, 9] start=1:8 end=1:9>
+#<Token type=TOKEN_IDENTIFIER value='id' range=[9, 11] start=1:9 end=1:11>
+#<Token type=TOKEN_EQUALS value='=' range=[11, 12] start=1:11 end=1:12>
+#<Token type=TOKEN_QUOTE value='"' range=[12, 13] start=1:12 end=1:13>
+#<Token type=TOKEN_ERB_START value='<%=' range=[13, 16] start=1:13 end=1:16>
+#<Token type=TOKEN_ERB_CONTENT value=' dom_id(article) ' range=[16, 33] start=1:16 end=1:33>
+#<Token type=TOKEN_ERB_END value='%>' range=[33, 35] start=1:33 end=1:35>
+#<Token type=TOKEN_QUOTE value='"' range=[35, 36] start=1:35 end=1:36>
+#<Token type=TOKEN_HTML_TAG_END value='>' range=[36, 37] start=1:36 end=1:37>
+#<Token type=TOKEN_HTML_TAG_START_CLOSE value='</' range=[37, 39] start=1:37 end=1:39>
+#<Token type=TOKEN_IDENTIFIER value='article' range=[39, 46] start=1:39 end=1:46>
+#<Token type=TOKEN_HTML_TAG_END value='>' range=[46, 47] start=1:46 end=1:47>
+#<Token type=TOKEN_EOF value='' range=[47, 47] start=1:47 end=1:47>

--- a/test/snapshots/lexer/erb_test/test_0010_erb_output_inside_HTML_attribute_value_with_value_and_after_e474134558bf8ffccb829ba880271d99.txt
+++ b/test/snapshots/lexer/erb_test/test_0010_erb_output_inside_HTML_attribute_value_with_value_and_after_e474134558bf8ffccb829ba880271d99.txt
@@ -1,0 +1,17 @@
+#<Token type=TOKEN_HTML_TAG_START value='<' range=[0, 1] start=1:0 end=1:1>
+#<Token type=TOKEN_IDENTIFIER value='div' range=[1, 4] start=1:1 end=1:4>
+#<Token type=TOKEN_WHITESPACE value=' ' range=[4, 5] start=1:4 end=1:5>
+#<Token type=TOKEN_IDENTIFIER value='class' range=[5, 10] start=1:5 end=1:10>
+#<Token type=TOKEN_EQUALS value='=' range=[10, 11] start=1:10 end=1:11>
+#<Token type=TOKEN_QUOTE value='"' range=[11, 12] start=1:11 end=1:12>
+#<Token type=TOKEN_IDENTIFIER value='bg-black' range=[12, 20] start=1:12 end=1:20>
+#<Token type=TOKEN_WHITESPACE value=' ' range=[20, 21] start=1:20 end=1:21>
+#<Token type=TOKEN_ERB_START value='<%=' range=[21, 24] start=1:21 end=1:24>
+#<Token type=TOKEN_ERB_CONTENT value=' "text-white" ' range=[24, 38] start=1:24 end=1:38>
+#<Token type=TOKEN_ERB_END value='%>' range=[38, 40] start=1:38 end=1:40>
+#<Token type=TOKEN_QUOTE value='"' range=[40, 41] start=1:40 end=1:41>
+#<Token type=TOKEN_HTML_TAG_END value='>' range=[41, 42] start=1:41 end=1:42>
+#<Token type=TOKEN_HTML_TAG_START_CLOSE value='</' range=[42, 44] start=1:42 end=1:44>
+#<Token type=TOKEN_IDENTIFIER value='div' range=[44, 47] start=1:44 end=1:47>
+#<Token type=TOKEN_HTML_TAG_END value='>' range=[47, 48] start=1:47 end=1:48>
+#<Token type=TOKEN_EOF value='' range=[48, 48] start=1:48 end=1:48>

--- a/test/snapshots/lexer/html_entities_test/test_0001_&lt;_87acb03b9542ddbc824f5bbd080a5cd4.txt
+++ b/test/snapshots/lexer/html_entities_test/test_0001_&lt;_87acb03b9542ddbc824f5bbd080a5cd4.txt
@@ -1,0 +1,4 @@
+#<Token type=TOKEN_AMPERSAND value='&' range=[0, 1] start=1:0 end=1:1>
+#<Token type=TOKEN_IDENTIFIER value='lt' range=[1, 3] start=1:1 end=1:3>
+#<Token type=TOKEN_SEMICOLON value=';' range=[3, 4] start=1:3 end=1:4>
+#<Token type=TOKEN_EOF value='' range=[4, 4] start=1:4 end=1:4>

--- a/test/snapshots/lexer/html_entities_test/test_0002_&gt;_58ba3bb1a1772a74392e5e86bd2be4b7.txt
+++ b/test/snapshots/lexer/html_entities_test/test_0002_&gt;_58ba3bb1a1772a74392e5e86bd2be4b7.txt
@@ -1,0 +1,4 @@
+#<Token type=TOKEN_AMPERSAND value='&' range=[0, 1] start=1:0 end=1:1>
+#<Token type=TOKEN_IDENTIFIER value='gt' range=[1, 3] start=1:1 end=1:3>
+#<Token type=TOKEN_SEMICOLON value=';' range=[3, 4] start=1:3 end=1:4>
+#<Token type=TOKEN_EOF value='' range=[4, 4] start=1:4 end=1:4>

--- a/test/snapshots/lexer/html_entities_test/test_0003_&nbsp;_cc7819055cde3194bb3b136bad5cf58d.txt
+++ b/test/snapshots/lexer/html_entities_test/test_0003_&nbsp;_cc7819055cde3194bb3b136bad5cf58d.txt
@@ -1,0 +1,4 @@
+#<Token type=TOKEN_AMPERSAND value='&' range=[0, 1] start=1:0 end=1:1>
+#<Token type=TOKEN_IDENTIFIER value='nbsp' range=[1, 5] start=1:1 end=1:5>
+#<Token type=TOKEN_SEMICOLON value=';' range=[5, 6] start=1:5 end=1:6>
+#<Token type=TOKEN_EOF value='' range=[6, 6] start=1:6 end=1:6>

--- a/test/snapshots/lexer/html_entities_test/test_0004_&quot;_eb6439de53405a48b124e7cf89ba71d3.txt
+++ b/test/snapshots/lexer/html_entities_test/test_0004_&quot;_eb6439de53405a48b124e7cf89ba71d3.txt
@@ -1,0 +1,4 @@
+#<Token type=TOKEN_AMPERSAND value='&' range=[0, 1] start=1:0 end=1:1>
+#<Token type=TOKEN_IDENTIFIER value='quot' range=[1, 5] start=1:1 end=1:5>
+#<Token type=TOKEN_SEMICOLON value=';' range=[5, 6] start=1:5 end=1:6>
+#<Token type=TOKEN_EOF value='' range=[6, 6] start=1:6 end=1:6>

--- a/test/snapshots/lexer/html_entities_test/test_0005_&apos;_e38c1fb206aebfcf7289482b93815826.txt
+++ b/test/snapshots/lexer/html_entities_test/test_0005_&apos;_e38c1fb206aebfcf7289482b93815826.txt
@@ -1,0 +1,4 @@
+#<Token type=TOKEN_AMPERSAND value='&' range=[0, 1] start=1:0 end=1:1>
+#<Token type=TOKEN_IDENTIFIER value='apos' range=[1, 5] start=1:1 end=1:5>
+#<Token type=TOKEN_SEMICOLON value=';' range=[5, 6] start=1:5 end=1:6>
+#<Token type=TOKEN_EOF value='' range=[6, 6] start=1:6 end=1:6>

--- a/test/snapshots/lexer/html_entities_test/test_0006_ampersand_c2249209343ab488c055da76368f04a0.txt
+++ b/test/snapshots/lexer/html_entities_test/test_0006_ampersand_c2249209343ab488c055da76368f04a0.txt
@@ -1,0 +1,4 @@
+#<Token type=TOKEN_AMPERSAND value='&' range=[0, 1] start=1:0 end=1:1>
+#<Token type=TOKEN_IDENTIFIER value='amp' range=[1, 4] start=1:1 end=1:4>
+#<Token type=TOKEN_SEMICOLON value=';' range=[4, 5] start=1:4 end=1:5>
+#<Token type=TOKEN_EOF value='' range=[5, 5] start=1:5 end=1:5>

--- a/test/snapshots/lexer/html_entities_test/test_0007_literal_ampersand_6cff047854f19ac2aa52aac51bf3af4a.txt
+++ b/test/snapshots/lexer/html_entities_test/test_0007_literal_ampersand_6cff047854f19ac2aa52aac51bf3af4a.txt
@@ -1,0 +1,2 @@
+#<Token type=TOKEN_AMPERSAND value='&' range=[0, 1] start=1:0 end=1:1>
+#<Token type=TOKEN_EOF value='' range=[1, 1] start=1:1 end=1:1>

--- a/test/snapshots/lexer/lexer_test/test_0001_nil_560d7cfe153ff63e50fbb9a506bd32ba.txt
+++ b/test/snapshots/lexer/lexer_test/test_0001_nil_560d7cfe153ff63e50fbb9a506bd32ba.txt
@@ -1,0 +1,1 @@
+#<Token type=TOKEN_EOF value='' range=[0, 0] start=1:0 end=1:0>

--- a/test/snapshots/lexer/lexer_test/test_0002_empty_file_d41d8cd98f00b204e9800998ecf8427e.txt
+++ b/test/snapshots/lexer/lexer_test/test_0002_empty_file_d41d8cd98f00b204e9800998ecf8427e.txt
@@ -1,0 +1,1 @@
+#<Token type=TOKEN_EOF value='' range=[0, 0] start=1:0 end=1:0>

--- a/test/snapshots/lexer/tags_test/test_0001_basic_tag_c83301425b2ad1d496473a5ff3d9ecca.txt
+++ b/test/snapshots/lexer/tags_test/test_0001_basic_tag_c83301425b2ad1d496473a5ff3d9ecca.txt
@@ -1,0 +1,7 @@
+#<Token type=TOKEN_HTML_TAG_START value='<' range=[0, 1] start=1:0 end=1:1>
+#<Token type=TOKEN_IDENTIFIER value='html' range=[1, 5] start=1:1 end=1:5>
+#<Token type=TOKEN_HTML_TAG_END value='>' range=[5, 6] start=1:5 end=1:6>
+#<Token type=TOKEN_HTML_TAG_START_CLOSE value='</' range=[6, 8] start=1:6 end=1:8>
+#<Token type=TOKEN_IDENTIFIER value='html' range=[8, 12] start=1:8 end=1:12>
+#<Token type=TOKEN_HTML_TAG_END value='>' range=[12, 13] start=1:12 end=1:13>
+#<Token type=TOKEN_EOF value='' range=[13, 13] start=1:13 end=1:13>

--- a/test/snapshots/lexer/tags_test/test_0002_basic_void_tag_0a22925ab034fd09eb49cc4224720dcb.txt
+++ b/test/snapshots/lexer/tags_test/test_0002_basic_void_tag_0a22925ab034fd09eb49cc4224720dcb.txt
@@ -1,0 +1,5 @@
+#<Token type=TOKEN_HTML_TAG_START value='<' range=[0, 1] start=1:0 end=1:1>
+#<Token type=TOKEN_IDENTIFIER value='img' range=[1, 4] start=1:1 end=1:4>
+#<Token type=TOKEN_WHITESPACE value=' ' range=[4, 5] start=1:4 end=1:5>
+#<Token type=TOKEN_HTML_TAG_SELF_CLOSE value='/>' range=[5, 7] start=1:5 end=1:7>
+#<Token type=TOKEN_EOF value='' range=[7, 7] start=1:7 end=1:7>

--- a/test/snapshots/lexer/tags_test/test_0003_basic_void_tag_without_whitespace_917eccff1c0d00dbdc9bbe20d07c939c.txt
+++ b/test/snapshots/lexer/tags_test/test_0003_basic_void_tag_without_whitespace_917eccff1c0d00dbdc9bbe20d07c939c.txt
@@ -1,0 +1,4 @@
+#<Token type=TOKEN_HTML_TAG_START value='<' range=[0, 1] start=1:0 end=1:1>
+#<Token type=TOKEN_IDENTIFIER value='img' range=[1, 4] start=1:1 end=1:4>
+#<Token type=TOKEN_HTML_TAG_SELF_CLOSE value='/>' range=[4, 6] start=1:4 end=1:6>
+#<Token type=TOKEN_EOF value='' range=[6, 6] start=1:6 end=1:6>

--- a/test/snapshots/lexer/tags_test/test_0004_namespaced_tag_45f3ec5566563217212e18f9f9983f0a.txt
+++ b/test/snapshots/lexer/tags_test/test_0004_namespaced_tag_45f3ec5566563217212e18f9f9983f0a.txt
@@ -1,0 +1,7 @@
+#<Token type=TOKEN_HTML_TAG_START value='<' range=[0, 1] start=1:0 end=1:1>
+#<Token type=TOKEN_IDENTIFIER value='ns:table' range=[1, 9] start=1:1 end=1:9>
+#<Token type=TOKEN_HTML_TAG_END value='>' range=[9, 10] start=1:9 end=1:10>
+#<Token type=TOKEN_HTML_TAG_START_CLOSE value='</' range=[10, 12] start=1:10 end=1:12>
+#<Token type=TOKEN_IDENTIFIER value='ns:table' range=[12, 20] start=1:12 end=1:20>
+#<Token type=TOKEN_HTML_TAG_END value='>' range=[20, 21] start=1:20 end=1:21>
+#<Token type=TOKEN_EOF value='' range=[21, 21] start=1:21 end=1:21>

--- a/test/snapshots/lexer/tags_test/test_0005_colon_inside_html__b7b46dcd10fad620a00a95b27daab204.txt
+++ b/test/snapshots/lexer/tags_test/test_0005_colon_inside_html__b7b46dcd10fad620a00a95b27daab204.txt
@@ -1,0 +1,14 @@
+#<Token type=TOKEN_HTML_TAG_START value='<' range=[0, 1] start=1:0 end=1:1>
+#<Token type=TOKEN_IDENTIFIER value='div' range=[1, 4] start=1:1 end=1:4>
+#<Token type=TOKEN_WHITESPACE value=' ' range=[4, 5] start=1:4 end=1:5>
+#<Token type=TOKEN_COLON value=':' range=[5, 6] start=1:5 end=1:6>
+#<Token type=TOKEN_WHITESPACE value=' ' range=[6, 7] start=1:6 end=1:7>
+#<Token type=TOKEN_IDENTIFIER value='class' range=[7, 12] start=1:7 end=1:12>
+#<Token type=TOKEN_EQUALS value='=' range=[12, 13] start=1:12 end=1:13>
+#<Token type=TOKEN_QUOTE value='"' range=[13, 14] start=1:13 end=1:14>
+#<Token type=TOKEN_QUOTE value='"' range=[14, 15] start=1:14 end=1:15>
+#<Token type=TOKEN_HTML_TAG_END value='>' range=[15, 16] start=1:15 end=1:16>
+#<Token type=TOKEN_HTML_TAG_START_CLOSE value='</' range=[16, 18] start=1:16 end=1:18>
+#<Token type=TOKEN_IDENTIFIER value='div' range=[18, 21] start=1:18 end=1:21>
+#<Token type=TOKEN_HTML_TAG_END value='>' range=[21, 22] start=1:21 end=1:22>
+#<Token type=TOKEN_EOF value='' range=[22, 22] start=1:22 end=1:22>

--- a/test/snapshots/lexer/tags_test/test_0006_text_content_f797031f3210ce6494466d619610926c.txt
+++ b/test/snapshots/lexer/tags_test/test_0006_text_content_f797031f3210ce6494466d619610926c.txt
@@ -1,0 +1,10 @@
+#<Token type=TOKEN_HTML_TAG_START value='<' range=[0, 1] start=1:0 end=1:1>
+#<Token type=TOKEN_IDENTIFIER value='h1' range=[1, 3] start=1:1 end=1:3>
+#<Token type=TOKEN_HTML_TAG_END value='>' range=[3, 4] start=1:3 end=1:4>
+#<Token type=TOKEN_IDENTIFIER value='Hello' range=[4, 9] start=1:4 end=1:9>
+#<Token type=TOKEN_WHITESPACE value=' ' range=[9, 10] start=1:9 end=1:10>
+#<Token type=TOKEN_IDENTIFIER value='World' range=[10, 15] start=1:10 end=1:15>
+#<Token type=TOKEN_HTML_TAG_START_CLOSE value='</' range=[15, 17] start=1:15 end=1:17>
+#<Token type=TOKEN_IDENTIFIER value='h1' range=[17, 19] start=1:17 end=1:19>
+#<Token type=TOKEN_HTML_TAG_END value='>' range=[19, 20] start=1:19 end=1:20>
+#<Token type=TOKEN_EOF value='' range=[20, 20] start=1:20 end=1:20>

--- a/test/snapshots/lexer/tags_test/test_0007_attribute_with_no_quotes_value_and_whitespace_and_self-closing_tag_fed80eb194a51acda7fe05820e850451.txt
+++ b/test/snapshots/lexer/tags_test/test_0007_attribute_with_no_quotes_value_and_whitespace_and_self-closing_tag_fed80eb194a51acda7fe05820e850451.txt
@@ -1,0 +1,9 @@
+#<Token type=TOKEN_HTML_TAG_START value='<' range=[0, 1] start=1:0 end=1:1>
+#<Token type=TOKEN_IDENTIFIER value='img' range=[1, 4] start=1:1 end=1:4>
+#<Token type=TOKEN_WHITESPACE value=' ' range=[4, 5] start=1:4 end=1:5>
+#<Token type=TOKEN_IDENTIFIER value='value' range=[5, 10] start=1:5 end=1:10>
+#<Token type=TOKEN_EQUALS value='=' range=[10, 11] start=1:10 end=1:11>
+#<Token type=TOKEN_IDENTIFIER value='hello' range=[11, 16] start=1:11 end=1:16>
+#<Token type=TOKEN_WHITESPACE value=' ' range=[16, 17] start=1:16 end=1:17>
+#<Token type=TOKEN_HTML_TAG_SELF_CLOSE value='/>' range=[17, 19] start=1:17 end=1:19>
+#<Token type=TOKEN_EOF value='' range=[19, 19] start=1:19 end=1:19>

--- a/test/snapshots/lexer/tags_test/test_0008_attribute_with_no_quotes_value,_no_whitespace_and_self-closing_tag_82af2795699fe4f5b34f32ed1491228a.txt
+++ b/test/snapshots/lexer/tags_test/test_0008_attribute_with_no_quotes_value,_no_whitespace_and_self-closing_tag_82af2795699fe4f5b34f32ed1491228a.txt
@@ -1,0 +1,8 @@
+#<Token type=TOKEN_HTML_TAG_START value='<' range=[0, 1] start=1:0 end=1:1>
+#<Token type=TOKEN_IDENTIFIER value='img' range=[1, 4] start=1:1 end=1:4>
+#<Token type=TOKEN_WHITESPACE value=' ' range=[4, 5] start=1:4 end=1:5>
+#<Token type=TOKEN_IDENTIFIER value='value' range=[5, 10] start=1:5 end=1:10>
+#<Token type=TOKEN_EQUALS value='=' range=[10, 11] start=1:10 end=1:11>
+#<Token type=TOKEN_IDENTIFIER value='hello' range=[11, 16] start=1:11 end=1:16>
+#<Token type=TOKEN_HTML_TAG_SELF_CLOSE value='/>' range=[16, 18] start=1:16 end=1:18>
+#<Token type=TOKEN_EOF value='' range=[18, 18] start=1:18 end=1:18>

--- a/test/snapshots/lexer/tags_test/test_0009_attribute_with_no_quotes_value,_no_whitespace,_and_non_self-closing_tag_f00fb4a0aa00f7c763be88670c0bc05d.txt
+++ b/test/snapshots/lexer/tags_test/test_0009_attribute_with_no_quotes_value,_no_whitespace,_and_non_self-closing_tag_f00fb4a0aa00f7c763be88670c0bc05d.txt
@@ -1,0 +1,8 @@
+#<Token type=TOKEN_HTML_TAG_START value='<' range=[0, 1] start=1:0 end=1:1>
+#<Token type=TOKEN_IDENTIFIER value='div' range=[1, 4] start=1:1 end=1:4>
+#<Token type=TOKEN_WHITESPACE value=' ' range=[4, 5] start=1:4 end=1:5>
+#<Token type=TOKEN_IDENTIFIER value='value' range=[5, 10] start=1:5 end=1:10>
+#<Token type=TOKEN_EQUALS value='=' range=[10, 11] start=1:10 end=1:11>
+#<Token type=TOKEN_IDENTIFIER value='hello' range=[11, 16] start=1:11 end=1:16>
+#<Token type=TOKEN_HTML_TAG_END value='>' range=[16, 17] start=1:16 end=1:17>
+#<Token type=TOKEN_EOF value='' range=[17, 17] start=1:17 end=1:17>

--- a/test/snapshots/lexer/tags_test/test_0010_link_tag_aab5814bdfc527d6d55d8957f089b911.txt
+++ b/test/snapshots/lexer/tags_test/test_0010_link_tag_aab5814bdfc527d6d55d8957f089b911.txt
@@ -1,0 +1,25 @@
+#<Token type=TOKEN_HTML_TAG_START value='<' range=[0, 1] start=1:0 end=1:1>
+#<Token type=TOKEN_IDENTIFIER value='link' range=[1, 5] start=1:1 end=1:5>
+#<Token type=TOKEN_WHITESPACE value=' ' range=[5, 6] start=1:5 end=1:6>
+#<Token type=TOKEN_IDENTIFIER value='href' range=[6, 10] start=1:6 end=1:10>
+#<Token type=TOKEN_EQUALS value='=' range=[10, 11] start=1:10 end=1:11>
+#<Token type=TOKEN_QUOTE value='"' range=[11, 12] start=1:11 end=1:12>
+#<Token type=TOKEN_IDENTIFIER value='https:' range=[12, 18] start=1:12 end=1:18>
+#<Token type=TOKEN_SLASH value='/' range=[18, 19] start=1:18 end=1:19>
+#<Token type=TOKEN_SLASH value='/' range=[19, 20] start=1:19 end=1:20>
+#<Token type=TOKEN_IDENTIFIER value='mywebsite' range=[20, 29] start=1:20 end=1:29>
+#<Token type=TOKEN_CHARACTER value='.' range=[29, 30] start=1:29 end=1:30>
+#<Token type=TOKEN_IDENTIFIER value='com' range=[30, 33] start=1:30 end=1:33>
+#<Token type=TOKEN_SLASH value='/' range=[33, 34] start=1:33 end=1:34>
+#<Token type=TOKEN_IDENTIFIER value='style' range=[34, 39] start=1:34 end=1:39>
+#<Token type=TOKEN_CHARACTER value='.' range=[39, 40] start=1:39 end=1:40>
+#<Token type=TOKEN_IDENTIFIER value='css' range=[40, 43] start=1:40 end=1:43>
+#<Token type=TOKEN_QUOTE value='"' range=[43, 44] start=1:43 end=1:44>
+#<Token type=TOKEN_WHITESPACE value=' ' range=[44, 45] start=1:44 end=1:45>
+#<Token type=TOKEN_IDENTIFIER value='rel' range=[45, 48] start=1:45 end=1:48>
+#<Token type=TOKEN_EQUALS value='=' range=[48, 49] start=1:48 end=1:49>
+#<Token type=TOKEN_QUOTE value='"' range=[49, 50] start=1:49 end=1:50>
+#<Token type=TOKEN_IDENTIFIER value='stylesheet' range=[50, 60] start=1:50 end=1:60>
+#<Token type=TOKEN_QUOTE value='"' range=[60, 61] start=1:60 end=1:61>
+#<Token type=TOKEN_HTML_TAG_END value='>' range=[61, 62] start=1:61 end=1:62>
+#<Token type=TOKEN_EOF value='' range=[62, 62] start=1:62 end=1:62>

--- a/test/snapshots/lexer/text_content_test/test_0001_text_content_4dc7bb0f7aaadf0c36061e92ff8d581b.txt
+++ b/test/snapshots/lexer/text_content_test/test_0001_text_content_4dc7bb0f7aaadf0c36061e92ff8d581b.txt
@@ -1,0 +1,10 @@
+#<Token type=TOKEN_HTML_TAG_START value='<' range=[0, 1] start=1:0 end=1:1>
+#<Token type=TOKEN_IDENTIFIER value='h1' range=[1, 3] start=1:1 end=1:3>
+#<Token type=TOKEN_HTML_TAG_END value='>' range=[3, 4] start=1:3 end=1:4>
+#<Token type=TOKEN_IDENTIFIER value='Some' range=[4, 8] start=1:4 end=1:8>
+#<Token type=TOKEN_WHITESPACE value=' ' range=[8, 9] start=1:8 end=1:9>
+#<Token type=TOKEN_IDENTIFIER value='Text' range=[9, 13] start=1:9 end=1:13>
+#<Token type=TOKEN_HTML_TAG_START_CLOSE value='</' range=[13, 15] start=1:13 end=1:15>
+#<Token type=TOKEN_IDENTIFIER value='h1' range=[15, 17] start=1:15 end=1:17>
+#<Token type=TOKEN_HTML_TAG_END value='>' range=[17, 18] start=1:17 end=1:18>
+#<Token type=TOKEN_EOF value='' range=[18, 18] start=1:18 end=1:18>

--- a/test/snapshots/lexer/text_content_test/test_0002_text_content_with_period_d654eb23e13156b3de00db20412d10d4.txt
+++ b/test/snapshots/lexer/text_content_test/test_0002_text_content_with_period_d654eb23e13156b3de00db20412d10d4.txt
@@ -1,0 +1,12 @@
+#<Token type=TOKEN_HTML_TAG_START value='<' range=[0, 1] start=1:0 end=1:1>
+#<Token type=TOKEN_IDENTIFIER value='h1' range=[1, 3] start=1:1 end=1:3>
+#<Token type=TOKEN_HTML_TAG_END value='>' range=[3, 4] start=1:3 end=1:4>
+#<Token type=TOKEN_IDENTIFIER value='Some' range=[4, 8] start=1:4 end=1:8>
+#<Token type=TOKEN_CHARACTER value='.' range=[8, 9] start=1:8 end=1:9>
+#<Token type=TOKEN_WHITESPACE value=' ' range=[9, 10] start=1:9 end=1:10>
+#<Token type=TOKEN_IDENTIFIER value='Text' range=[10, 14] start=1:10 end=1:14>
+#<Token type=TOKEN_CHARACTER value='.' range=[14, 15] start=1:14 end=1:15>
+#<Token type=TOKEN_HTML_TAG_START_CLOSE value='</' range=[15, 17] start=1:15 end=1:17>
+#<Token type=TOKEN_IDENTIFIER value='h1' range=[17, 19] start=1:17 end=1:19>
+#<Token type=TOKEN_HTML_TAG_END value='>' range=[19, 20] start=1:19 end=1:20>
+#<Token type=TOKEN_EOF value='' range=[20, 20] start=1:20 end=1:20>

--- a/test/snapshots/lexer/token_test/test_0001_whitespace_7215ee9c7d9dc229d2921a40e899ec5f.txt
+++ b/test/snapshots/lexer/token_test/test_0001_whitespace_7215ee9c7d9dc229d2921a40e899ec5f.txt
@@ -1,0 +1,2 @@
+#<Token type=TOKEN_WHITESPACE value=' ' range=[0, 1] start=1:0 end=1:1>
+#<Token type=TOKEN_EOF value='' range=[1, 1] start=1:1 end=1:1>

--- a/test/snapshots/lexer/token_test/test_0002_multiple_whitespace_0cf31b2c283ce3431794586df7b0996d.txt
+++ b/test/snapshots/lexer/token_test/test_0002_multiple_whitespace_0cf31b2c283ce3431794586df7b0996d.txt
@@ -1,0 +1,2 @@
+#<Token type=TOKEN_WHITESPACE value='    ' range=[0, 4] start=1:0 end=1:4>
+#<Token type=TOKEN_EOF value='' range=[4, 4] start=1:4 end=1:4>

--- a/test/snapshots/lexer/token_test/test_0003_multiple_whitespace_with_newliens__ff50772e7d3bdf3652ee7b345823b611.txt
+++ b/test/snapshots/lexer/token_test/test_0003_multiple_whitespace_with_newliens__ff50772e7d3bdf3652ee7b345823b611.txt
@@ -1,0 +1,7 @@
+#<Token type=TOKEN_WHITESPACE value=' ' range=[0, 1] start=1:0 end=1:1>
+#<Token type=TOKEN_NEWLINE value='\n' range=[1, 2] start=1:0 end=2:1>
+#<Token type=TOKEN_WHITESPACE value='  ' range=[2, 4] start=2:1 end=2:3>
+#<Token type=TOKEN_NEWLINE value='\n' range=[4, 5] start=2:0 end=3:1>
+#<Token type=TOKEN_WHITESPACE value='   ' range=[5, 8] start=3:1 end=3:4>
+#<Token type=TOKEN_NEWLINE value='\n' range=[8, 9] start=3:0 end=4:1>
+#<Token type=TOKEN_EOF value='' range=[9, 9] start=4:1 end=4:1>

--- a/test/snapshots/lexer/token_test/test_0004_non-breaking_space_8df6fbcc43d31d99e5112eb009ed8a2d.txt
+++ b/test/snapshots/lexer/token_test/test_0004_non-breaking_space_8df6fbcc43d31d99e5112eb009ed8a2d.txt
@@ -1,0 +1,2 @@
+#<Token type=TOKEN_NBSP value=' ' range=[0, 2] start=1:0 end=1:2>
+#<Token type=TOKEN_EOF value='' range=[2, 2] start=1:2 end=1:2>

--- a/test/snapshots/lexer/token_test/test_0005_newline_68b329da9893e34099c7d8ad5cb9c940.txt
+++ b/test/snapshots/lexer/token_test/test_0005_newline_68b329da9893e34099c7d8ad5cb9c940.txt
@@ -1,0 +1,2 @@
+#<Token type=TOKEN_NEWLINE value='\n' range=[0, 1] start=1:0 end=2:1>
+#<Token type=TOKEN_EOF value='' range=[1, 1] start=2:1 end=2:1>

--- a/test/snapshots/lexer/token_test/test_0006_!_9033e0e305f247c0c3c80d0c7848c8b3.txt
+++ b/test/snapshots/lexer/token_test/test_0006_!_9033e0e305f247c0c3c80d0c7848c8b3.txt
@@ -1,0 +1,2 @@
+#<Token type=TOKEN_EXCLAMATION value='!' range=[0, 1] start=1:0 end=1:1>
+#<Token type=TOKEN_EOF value='' range=[1, 1] start=1:1 end=1:1>

--- a/test/snapshots/lexer/token_test/test_0007_slash_6666cd76f96956469e7be39d750cc7d9.txt
+++ b/test/snapshots/lexer/token_test/test_0007_slash_6666cd76f96956469e7be39d750cc7d9.txt
@@ -1,0 +1,2 @@
+#<Token type=TOKEN_SLASH value='/' range=[0, 1] start=1:0 end=1:1>
+#<Token type=TOKEN_EOF value='' range=[1, 1] start=1:1 end=1:1>

--- a/test/snapshots/lexer/token_test/test_0008_dash_336d5ebc5436534e61d16e63ddfca327.txt
+++ b/test/snapshots/lexer/token_test/test_0008_dash_336d5ebc5436534e61d16e63ddfca327.txt
@@ -1,0 +1,2 @@
+#<Token type=TOKEN_DASH value='-' range=[0, 1] start=1:0 end=1:1>
+#<Token type=TOKEN_EOF value='' range=[1, 1] start=1:1 end=1:1>

--- a/test/snapshots/lexer/token_test/test_0009_underscore_b14a7b8059d9c055954c92674ce60032.txt
+++ b/test/snapshots/lexer/token_test/test_0009_underscore_b14a7b8059d9c055954c92674ce60032.txt
@@ -1,0 +1,2 @@
+#<Token type=TOKEN_UNDERSCORE value='_' range=[0, 1] start=1:0 end=1:1>
+#<Token type=TOKEN_EOF value='' range=[1, 1] start=1:1 end=1:1>

--- a/test/snapshots/lexer/token_test/test_0010_percent_0bcef9c45bd8a48eda1b26eb0c61c869.txt
+++ b/test/snapshots/lexer/token_test/test_0010_percent_0bcef9c45bd8a48eda1b26eb0c61c869.txt
@@ -1,0 +1,2 @@
+#<Token type=TOKEN_PERCENT value='%' range=[0, 1] start=1:0 end=1:1>
+#<Token type=TOKEN_EOF value='' range=[1, 1] start=1:1 end=1:1>

--- a/test/snapshots/lexer/token_test/test_0011_colon_853ae90f0351324bd73ea615e6487517.txt
+++ b/test/snapshots/lexer/token_test/test_0011_colon_853ae90f0351324bd73ea615e6487517.txt
@@ -1,0 +1,2 @@
+#<Token type=TOKEN_COLON value=':' range=[0, 1] start=1:0 end=1:1>
+#<Token type=TOKEN_EOF value='' range=[1, 1] start=1:1 end=1:1>

--- a/test/snapshots/lexer/token_test/test_0012_equals_43ec3e5dee6e706af7766fffea512721.txt
+++ b/test/snapshots/lexer/token_test/test_0012_equals_43ec3e5dee6e706af7766fffea512721.txt
@@ -1,0 +1,2 @@
+#<Token type=TOKEN_EQUALS value='=' range=[0, 1] start=1:0 end=1:1>
+#<Token type=TOKEN_EOF value='' range=[1, 1] start=1:1 end=1:1>

--- a/test/snapshots/lexer/token_test/test_0013_double_quote_b15835f133ff2e27c7cb28117bfae8f4.txt
+++ b/test/snapshots/lexer/token_test/test_0013_double_quote_b15835f133ff2e27c7cb28117bfae8f4.txt
@@ -1,0 +1,2 @@
+#<Token type=TOKEN_QUOTE value='"' range=[0, 1] start=1:0 end=1:1>
+#<Token type=TOKEN_EOF value='' range=[1, 1] start=1:1 end=1:1>

--- a/test/snapshots/lexer/token_test/test_0014_single_quote_3590cb8af0bbb9e78c343b52b93773c9.txt
+++ b/test/snapshots/lexer/token_test/test_0014_single_quote_3590cb8af0bbb9e78c343b52b93773c9.txt
@@ -1,0 +1,2 @@
+#<Token type=TOKEN_QUOTE value=''' range=[0, 1] start=1:0 end=1:1>
+#<Token type=TOKEN_EOF value='' range=[1, 1] start=1:1 end=1:1>

--- a/test/snapshots/lexer/token_test/test_0015_less_than_signs_83699a49d8884e65d9291885a6448e44.txt
+++ b/test/snapshots/lexer/token_test/test_0015_less_than_signs_83699a49d8884e65d9291885a6448e44.txt
@@ -1,0 +1,5 @@
+#<Token type=TOKEN_LT value='<' range=[0, 1] start=1:0 end=1:1>
+#<Token type=TOKEN_LT value='<' range=[1, 2] start=1:1 end=1:2>
+#<Token type=TOKEN_LT value='<' range=[2, 3] start=1:2 end=1:3>
+#<Token type=TOKEN_LT value='<' range=[3, 4] start=1:3 end=1:4>
+#<Token type=TOKEN_EOF value='' range=[4, 4] start=1:4 end=1:4>

--- a/test/snapshots/lexer/token_test/test_0016_greater_than_signs_4a8c3066e1720f3068d5559fc41acb0c.txt
+++ b/test/snapshots/lexer/token_test/test_0016_greater_than_signs_4a8c3066e1720f3068d5559fc41acb0c.txt
@@ -1,0 +1,5 @@
+#<Token type=TOKEN_HTML_TAG_END value='>' range=[0, 1] start=1:0 end=1:1>
+#<Token type=TOKEN_HTML_TAG_END value='>' range=[1, 2] start=1:1 end=1:2>
+#<Token type=TOKEN_HTML_TAG_END value='>' range=[2, 3] start=1:2 end=1:3>
+#<Token type=TOKEN_HTML_TAG_END value='>' range=[3, 4] start=1:3 end=1:4>
+#<Token type=TOKEN_EOF value='' range=[4, 4] start=1:4 end=1:4>

--- a/test/snapshots/lexer/token_test/test_0017_LT,_GT_and_PERCENT_signs_6f6dcf1103a1b99a952c36d32a89a2ec.txt
+++ b/test/snapshots/lexer/token_test/test_0017_LT,_GT_and_PERCENT_signs_6f6dcf1103a1b99a952c36d32a89a2ec.txt
@@ -1,0 +1,8 @@
+#<Token type=TOKEN_LT value='<' range=[0, 1] start=1:0 end=1:1>
+#<Token type=TOKEN_WHITESPACE value=' ' range=[1, 2] start=1:1 end=1:2>
+#<Token type=TOKEN_PERCENT value='%' range=[2, 3] start=1:2 end=1:3>
+#<Token type=TOKEN_WHITESPACE value=' ' range=[3, 4] start=1:3 end=1:4>
+#<Token type=TOKEN_PERCENT value='%' range=[4, 5] start=1:4 end=1:5>
+#<Token type=TOKEN_WHITESPACE value=' ' range=[5, 6] start=1:5 end=1:6>
+#<Token type=TOKEN_HTML_TAG_END value='>' range=[6, 7] start=1:6 end=1:7>
+#<Token type=TOKEN_EOF value='' range=[7, 7] start=1:7 end=1:7>


### PR DESCRIPTION
This pull request adds a new `assert_lexed_snapshot` method to the `SnapshotUtils` and converts all lexer tests to use snapshots as well.

Additionally, the `ERBX::LibERBX::LexResult` and `ERBX::LibERBX::Token` now use the `token_to_string` function which the shared library exposes.