### PR TITLE
Remove `JSON` struct and instead pass `buffer_T` in

### DIFF
--- a/src/include/json.h
+++ b/src/include/json.h
@@ -3,28 +3,21 @@
 
 #include "buffer.h"
 
-typedef struct {
-  buffer_T buffer;
-} JSON;
+void json_start_root_object(buffer_T* json);
+void json_start_root_array(buffer_T* json);
 
-JSON* json_start_root_object(void);
-JSON* json_start_root_array(void);
+void json_escape_string(buffer_T* json, const char* string);
 
-void json_init(JSON* json);
-void json_free(JSON* json);
+void json_add_string(buffer_T* json, const char* key, const char* value);
+void json_add_int(buffer_T* json, const char* key, int value);
+void json_add_double(buffer_T* json, const char* key, double value);
+void json_add_bool(buffer_T* json, const char* key, int value);
 
-void json_escape_string(JSON* json, const char* string);
+void json_start_object(buffer_T* json, const char* key);
+void json_end_object(buffer_T* json);
 
-void json_add_string(JSON* json, const char* key, const char* value);
-void json_add_int(JSON* json, const char* key, int value);
-void json_add_double(JSON* json, const char* key, double value);
-void json_add_bool(JSON* json, const char* key, int value);
-
-JSON* json_start_object(JSON* parent, const char* key);
-void json_end_object(JSON* parent, JSON* object);
-
-JSON* json_start_array(JSON* parent, const char* key);
-void json_end_array(JSON* parent, JSON* array);
+void json_start_array(buffer_T* json, const char* key);
+void json_end_array(buffer_T* json);
 
 void json_double_to_string(double value, char* buffer);
 void json_int_to_string(int value, char* buffer);

--- a/test/c/test_json.c
+++ b/test/c/test_json.c
@@ -1,155 +1,195 @@
+#include <stdio.h>
+
 #include "include/test.h"
+#include "../../src/include/buffer.h"
 #include "../../src/include/json.h"
 
 TEST(test_json_escape_basic)
-  JSON* json = json_start_root_object();
-  json_add_string(json, "key", "value");
-  json_end_object(NULL, json);
+  buffer_T json = buffer_new();
 
-  ck_assert_str_eq(buffer_value(&json->buffer), "{\"key\": \"value\"}");
+  json_start_root_object(&json);
+  json_add_string(&json, "key", "value");
+  json_end_object(&json);
 
-  json_free(json);
+  ck_assert_str_eq(buffer_value(&json), "{\"key\": \"value\"}");
+
+  buffer_free(&json);
 END
 
 TEST(test_json_escape_quotes)
-  JSON* json = json_start_root_object();
-  json_add_string(json, "quote", "This is a \"quoted\" string");
-  json_end_object(NULL, json);
+  buffer_T json = buffer_new();
 
-  ck_assert_str_eq(buffer_value(&json->buffer), "{\"quote\": \"This is a \\\"quoted\\\" string\"}");
+  json_start_root_object(&json);
+  json_add_string(&json, "quote", "This is a \"quoted\" string");
+  json_end_object(&json);
 
-  json_free(json);
+  ck_assert_str_eq(buffer_value(&json), "{\"quote\": \"This is a \\\"quoted\\\" string\"}");
+
+  buffer_free(&json);
 END
 
 TEST(test_json_escape_backslash)
-  JSON* json = json_start_root_object();
-  json_add_string(json, "path", "C:\\Users\\Test");
-  json_end_object(NULL, json);
+  buffer_T json = buffer_new();
 
-  ck_assert_str_eq(buffer_value(&json->buffer), "{\"path\": \"C:\\\\Users\\\\Test\"}");
+  json_start_root_object(&json);
+  json_add_string(&json, "path", "C:\\Users\\Test");
+  json_end_object(&json);
 
-  json_free(json);
+  ck_assert_str_eq(buffer_value(&json), "{\"path\": \"C:\\\\Users\\\\Test\"}");
+
+  buffer_free(&json);
 END
 
 TEST(test_json_escape_newline)
-  JSON* json = json_start_root_object();
-  json_add_string(json, "text", "Line1\nLine2");
-  json_end_object(NULL, json);
+  buffer_T json = buffer_new();
 
-  ck_assert_str_eq(buffer_value(&json->buffer), "{\"text\": \"Line1\\nLine2\"}");
+  json_start_root_object(&json);
+  json_add_string(&json, "text", "Line1\nLine2");
+  json_end_object(&json);
 
-  json_free(json);
+  ck_assert_str_eq(buffer_value(&json), "{\"text\": \"Line1\\nLine2\"}");
+
+  buffer_free(&json);
 END
 
 TEST(test_json_escape_tab)
-  JSON* json = json_start_root_object();
-  json_add_string(json, "text", "Column1\tColumn2");
-  json_end_object(NULL, json);
+  buffer_T json = buffer_new();
 
-  ck_assert_str_eq(buffer_value(&json->buffer), "{\"text\": \"Column1\\tColumn2\"}");
+  json_start_root_object(&json);
+  json_add_string(&json, "text", "Column1\tColumn2");
+  json_end_object(&json);
 
-  json_free(json);
+  ck_assert_str_eq(buffer_value(&json), "{\"text\": \"Column1\\tColumn2\"}");
+
+  buffer_free(&json);
 END
 
 TEST(test_json_escape_mixed)
-  JSON* json = json_start_root_object();
-  json_add_string(json, "complex", "A \"quoted\" \\ path\nwith\ttabs.");
-  json_end_object(NULL, json);
+  buffer_T json = buffer_new();
 
-  ck_assert_str_eq(buffer_value(&json->buffer), "{\"complex\": \"A \\\"quoted\\\" \\\\ path\\nwith\\ttabs.\"}");
+  json_start_root_object(&json);
+  json_add_string(&json, "complex", "A \"quoted\" \\ path\nwith\ttabs.");
+  json_end_object(&json);
 
-  json_free(json);
+  ck_assert_str_eq(buffer_value(&json), "{\"complex\": \"A \\\"quoted\\\" \\\\ path\\nwith\\ttabs.\"}");
+
+  buffer_free(&json);
 END
 
 TEST(test_json_root_object)
-  JSON* json = json_start_root_object();
+  buffer_T json = buffer_new();
 
-  json_add_string(json, "name", "John");
-  json_add_int(json, "age", 20);
-  json_add_double(json, "score", 99.5);
-  json_add_bool(json, "active", 1);
+  json_start_root_object(&json);
 
-  JSON* address = json_start_object(json, "address");
-  json_add_string(address, "city", "Basel");
-  json_add_string(address, "country", "Switzerland");
-  json_end_object(json, address);
+  json_add_string(&json, "name", "John");
+  json_add_int(&json, "age", 20);
+  json_add_double(&json, "score", 99.5);
+  json_add_bool(&json, "active", 1);
 
-  JSON* languages = json_start_array(json, "languages");
-  json_add_string(languages, NULL, "Ruby");
-  json_add_string(languages, NULL, "C");
-  json_add_string(languages, NULL, "JavaScript");
-  json_end_array(json, languages);
+  buffer_T address = buffer_new();
+  json_start_object(&json, "address");
+  json_add_string(&address, "city", "Basel");
+  json_add_string(&address, "country", "Switzerland");
+  buffer_concat(&json, &address);
+  json_end_object(&json);
 
-  JSON* ratings = json_start_array(json, "ratings");
-  json_add_double(ratings, NULL, 4.5);
-  json_add_int(ratings, NULL, 3);
-  json_add_double(ratings, NULL, 5.0);
-  json_add_double(ratings, NULL, 3.8);
-  json_add_int(ratings, NULL, 5);
-  json_end_array(json, ratings);
+  buffer_T languages = buffer_new();
+  json_start_array(&json, "languages");
+  json_add_string(&languages, NULL, "Ruby");
+  json_add_string(&languages, NULL, "C");
+  json_add_string(&languages, NULL, "JavaScript");
+  buffer_concat(&json, &languages);
+  json_end_array(&json);
 
-  json_end_object(NULL, json);
+  buffer_T ratings = buffer_new();
+  json_start_array(&json, "ratings");
+  json_add_double(&ratings, NULL, 4.5);
+  json_add_int(&ratings, NULL, 3);
+  json_add_double(&ratings, NULL, 5.0);
+  json_add_double(&ratings, NULL, 3.8);
+  json_add_int(&ratings, NULL, 5);
+  buffer_concat(&json, &ratings);
+  json_end_array(&json);
 
-  ck_assert_str_eq(buffer_value(&json->buffer), "{\"name\": \"John\", \"age\": 20, \"score\": 99.50, \"active\": true, \"address\": {\"city\": \"Basel\", \"country\": \"Switzerland\"}, \"languages\": [\"Ruby\", \"C\", \"JavaScript\"], \"ratings\": [4.50, 3, 5.0, 3.79, 5]}");
+  json_end_object(&json);
 
-  json_free(json);
+  ck_assert_str_eq(buffer_value(&json), "{\"name\": \"John\", \"age\": 20, \"score\": 99.50, \"active\": true, \"address\": {\"city\": \"Basel\", \"country\": \"Switzerland\"}, \"languages\": [\"Ruby\", \"C\", \"JavaScript\"], \"ratings\": [4.50, 3, 5.0, 3.79, 5]}");
+
+  buffer_free(&json);
 END
 
 TEST(test_json_root_array)
-  JSON* json = json_start_root_array();
+  buffer_T json = buffer_new();
 
-  json_add_string(json, NULL, "Ruby");
-  json_add_string(json, NULL, "C");
-  json_add_string(json, NULL, "JavaScript");
-  json_add_int(json, NULL, 42);
-  json_add_double(json, NULL, 3.14159);
-  json_add_bool(json, NULL, 1);
-  json_add_bool(json, NULL, 0);
+  json_start_root_array(&json);
 
-  json_end_array(NULL, json);
+  json_add_string(&json, NULL, "Ruby");
+  json_add_string(&json, NULL, "C");
+  json_add_string(&json, NULL, "JavaScript");
+  json_add_int(&json, NULL, 42);
+  json_add_double(&json, NULL, 3.14159);
+  json_add_bool(&json, NULL, 1);
+  json_add_bool(&json, NULL, 0);
 
-  ck_assert_str_eq(buffer_value(&json->buffer), "[\"Ruby\", \"C\", \"JavaScript\", 42, 3.14, true, false]");
+  json_end_array(&json);
 
-  json_free(json);
+  ck_assert_str_eq(buffer_value(&json), "[\"Ruby\", \"C\", \"JavaScript\", 42, 3.14, true, false]");
+
+  buffer_free(&json);
 END
 
 TEST(test_json_append_array_to_object)
-  JSON* json = json_start_root_object();
+  buffer_T json = buffer_new();
 
-  JSON* object = json_start_object(json, "object");
-  json_add_string(object, "key", "value");
+  json_start_root_object(&json);
 
-  JSON* array = json_start_array(object, "array");
-  json_add_string(array, NULL, "One");
-  json_add_string(array, NULL, "Two");
-  json_end_array(object, array);
+  buffer_T object = buffer_new();
+  json_start_object(&json, "object");
+  json_add_string(&object, "key", "value");
 
-  json_end_object(json, object);
-  json_end_object(NULL, json);
+  buffer_T array = buffer_new();
+  json_start_array(&object, "array");
+  json_add_string(&array, NULL, "One");
+  json_add_string(&array, NULL, "Two");
 
-  ck_assert_str_eq(buffer_value(&json->buffer), "{\"object\": {\"key\": \"value\", \"array\": [\"One\", \"Two\"]}}");
+  buffer_concat(&object, &array);
+  json_end_array(&object);
 
-  json_free(json);
+  buffer_concat(&json, &object);
+  json_end_object(&json);
+
+  json_end_object(&json);
+
+  ck_assert_str_eq(buffer_value(&json), "{\"object\": {\"key\": \"value\", \"array\": [\"One\", \"Two\"]}}");
+
+  buffer_free(&json);
 END
 
 TEST(test_json_append_object_array)
-  JSON* json = json_start_root_object();
+  buffer_T json = buffer_new();
 
-  JSON* array = json_start_array(json, "array");
-  json_add_string(array, NULL, "One");
-  json_add_string(array, NULL, "Two");
+  json_start_root_object(&json);
 
-  JSON* object = json_start_object(array, NULL);
-  json_add_string(object, "key", "value");
-  json_end_object(array, object);
+  buffer_T array = buffer_new();
+  json_start_array(&json, "array");
+  json_add_string(&array, NULL, "One");
+  json_add_string(&array, NULL, "Two");
 
-  json_end_array(json, array);
+  buffer_T object = buffer_new();
+  json_start_object(&array, NULL);
+  json_add_string(&object, "key", "value");
 
-  json_end_object(NULL, json);
+  buffer_concat(&array, &object);
+  json_end_object(&array);
 
-  ck_assert_str_eq(buffer_value(&json->buffer), "{\"array\": [\"One\", \"Two\", {\"key\": \"value\"}]}");
+  buffer_concat(&json, &array);
+  json_end_array(&json);
 
-  json_free(json);
+  json_end_object(&json);
+
+  ck_assert_str_eq(buffer_value(&json), "{\"array\": [\"One\", \"Two\", {\"key\": \"value\"}]}");
+
+  buffer_free(&json);
 END
 
 TEST(test_json_double_to_string_precision)


### PR DESCRIPTION
This pull request refactors the `JSON` struct to use `buffer_T` directly and simplifying the interface. 

**Before:**
```c
JSON* json = json_start_root_object();

JSON* object = json_start_object(json, "object");
json_add_string(object, "key", "value");

JSON* array = json_start_array(object, "array");
json_add_string(array, NULL, "One");
json_add_string(array, NULL, "Two");
json_end_array(object, array);

json_end_object(json, object);
json_end_object(NULL, json);
```

**After:**
```c
buffer_T json = buffer_new();

json_start_root_object(&json);

buffer_T object = buffer_new();
json_start_object(&json, "object");
json_add_string(&object, "key", "value");

buffer_T array = buffer_new();
json_start_array(&object, "array");
json_add_string(&array, NULL, "One");
json_add_string(&array, NULL, "Two");

buffer_concat(&object, &array);
json_end_array(&object);

buffer_concat(&json, &object);
json_end_object(&json);

json_end_object(&json);
```

Ideally, we could simplify the interface later to something like:

```c
buffer_T json = json_start_root_object(&json);

buffer_T object = json_start_object(&json, "object");
json_add_string(&object, "key", "value");

buffer_T array = json_start_array(&object, "array");
json_add_string(&array, NULL, "One");
json_add_string(&array, NULL, "Two");
json_end_array(&object, &array);

json_end_array(&object, NULL);

json_end_object(&json, &object);
json_end_object(&json, NULL);
```
