### PR TITLE
Introduce `token_matches_any` and macros to simplify parser while loops

### DIFF
--- a/src/include/token_matchers.h
+++ b/src/include/token_matchers.h
@@ -1,0 +1,18 @@
+#ifndef ERBX_TOKEN_MATCHERS_H
+#define ERBX_TOKEN_MATCHERS_H
+
+#include "parser.h"
+#include "token.h"
+
+#include <stdarg.h>
+#include <stdbool.h>
+
+// This "TOKEN" is used to terminate the va_list arguments in the token_matches_any function
+#define TOKEN_SENTINEL 99999999
+
+bool token_matches_any(token_type_T current_token, token_type_T first_token, ...);
+
+#define token_is_any_of(parser, ...) (token_matches_any((parser)->current_token->type, __VA_ARGS__, TOKEN_SENTINEL))
+#define token_is_none_of(parser, ...) (!token_matches_any((parser)->current_token->type, __VA_ARGS__, TOKEN_SENTINEL))
+
+#endif

--- a/src/token_matchers.c
+++ b/src/token_matchers.c
@@ -1,0 +1,24 @@
+#include "include/token_matchers.h"
+#include "include/parser.h"
+#include "include/token.h"
+
+#include <stdarg.h>
+#include <stdbool.h>
+
+bool token_matches_any(token_type_T current_token, token_type_T first_token, ...) {
+  if (current_token == first_token) { return true; }
+
+  va_list tokens;
+  va_start(tokens, first_token);
+  token_type_T token;
+
+  while ((token = va_arg(tokens, token_type_T)) != TOKEN_SENTINEL) {
+    if (current_token == token) {
+      va_end(tokens);
+      return true;
+    }
+  }
+
+  va_end(tokens);
+  return false;
+}


### PR DESCRIPTION
This pull request introduces  the `token_matchers` utilities for matching token types. We can use these new utilities to simplify the logic in the parser while loops.

Key changes include:

* Added a new header file defining the `token_is_any_of` and `token_is_none_of` macros and a function for token matching the token type (`token_matches_any`).
* Implemented the `token_matches_any` function in `token_matchers.c` to check if the current token matches any in the provided list.
* Updated the parser to use the new `token_is_none_of` macro for improving the while loops.