### PR TITLE
Refactor Parser `while` loops to not use `switch/case` statements

### DIFF
--- a/src/include/token_matchers.h
+++ b/src/include/token_matchers.h
@@ -10,6 +10,9 @@
 // This "TOKEN" is used to terminate the va_list arguments in the token_matches_any function
 #define TOKEN_SENTINEL 99999999
 
+bool token_is(parser_T* parser, token_type_T expected_type);
+bool token_is_not(parser_T* parser, token_type_T type);
+
 bool token_matches_any(token_type_T current_token, token_type_T first_token, ...);
 
 #define token_is_any_of(parser, ...) (token_matches_any((parser)->current_token->type, __VA_ARGS__, TOKEN_SENTINEL))

--- a/src/token_matchers.c
+++ b/src/token_matchers.c
@@ -5,6 +5,14 @@
 #include <stdarg.h>
 #include <stdbool.h>
 
+bool token_is(parser_T* parser, token_type_T expected_type) {
+  return parser->current_token->type == expected_type;
+}
+
+bool token_is_not(parser_T* parser, token_type_T type) {
+  return parser->current_token->type != type;
+}
+
 bool token_matches_any(token_type_T current_token, token_type_T first_token, ...) {
   if (current_token == first_token) { return true; }
 


### PR DESCRIPTION
This pull request refactors the parser `while` loops to use simple `if` statements using the new `token_is` function instead of the `switch/case` statements.
 
To help with that, we added two new `token_matchers` helper functions: `token_is` and `token_is_not`.

We also simplified the initialization of unexpected token nodes by extracting the `parser_init_unexpected_token` function form `parser_parse_in_data_state` and using it in place of the old `parser_init_unexpected_token_from_current_token` function.