### PR TITLE
Any element within `<svg>` can be void or non-void

### DIFF
--- a/src/ast_node.c
+++ b/src/ast_node.c
@@ -75,3 +75,7 @@ void ast_node_set_locations_from_token(AST_NODE_T* node, const token_T* token) {
   ast_node_set_start_from_token(node, token);
   ast_node_set_end_from_token(node, token);
 }
+
+bool ast_node_is(const AST_NODE_T* node, const ast_node_type_T type) {
+  return node->type == type;
+}

--- a/src/include/ast_node.h
+++ b/src/include/ast_node.h
@@ -30,4 +30,6 @@ void ast_node_set_end_from_token(AST_NODE_T* node, const token_T* token);
 
 void ast_node_set_locations_from_token(AST_NODE_T* node, const token_T* token);
 
+bool ast_node_is(const AST_NODE_T* node, ast_node_type_T type);
+
 #endif

--- a/src/include/parser_helpers.h
+++ b/src/include/parser_helpers.h
@@ -19,6 +19,8 @@ void parser_append_literal_node_from_buffer(
   const parser_T* parser, buffer_T* buffer, array_T* children, location_T* start_location
 );
 
+bool parser_in_svg_context(const parser_T* parser);
+
 token_T* parser_advance(parser_T* parser);
 token_T* parser_consume_if_present(parser_T* parser, token_type_T type);
 token_T* parser_consume_expected(parser_T* parser, token_type_T type, array_T* array);

--- a/src/parser_helpers.c
+++ b/src/parser_helpers.c
@@ -32,6 +32,28 @@ token_T* parser_pop_open_tag(const parser_T* parser) {
   return array_pop(parser->open_tags_stack);
 }
 
+/**
+ * Checks if any element in the open tags stack is an SVG element.
+ *
+ * @param parser The parser containing the open tags stack.
+ * @return true if an SVG tag is found in the stack, false otherwise.
+ */
+bool parser_in_svg_context(const parser_T* parser) {
+  if (!parser || !parser->open_tags_stack) { return false; }
+
+  size_t stack_size = array_size(parser->open_tags_stack);
+
+  for (size_t i = 0; i < stack_size; i++) {
+    token_T* tag = (token_T*) array_get(parser->open_tags_stack, i);
+
+    if (tag && tag->value) {
+      if (strcasecmp(tag->value, "svg") == 0) { return true; }
+    }
+  }
+
+  return false;
+}
+
 void parser_append_unexpected_error(parser_T* parser, const char* description, const char* expected, array_T* errors) {
   token_T* token = parser_advance(parser);
 

--- a/test/parser/svg_test.rb
+++ b/test/parser/svg_test.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+module Parser
+  class SVGTest < Minitest::Spec
+    include SnapshotUtils
+
+    test "svg" do
+      assert_parsed_snapshot("<svg></svg>")
+    end
+
+    test "svg with void path element" do
+      assert_parsed_snapshot(<<~SVG)
+        <svg>
+          <path />
+        </svg>
+      SVG
+    end
+
+    test "svg with non-void path element" do
+      assert_parsed_snapshot(<<~SVG)
+        <svg>
+          <path></path>
+        </svg>
+      SVG
+    end
+
+    test "svg with nested void path element" do
+      assert_parsed_snapshot(<<~SVG)
+        <svg>
+          <g>
+            <path/>
+          </g>
+        </svg>
+      SVG
+    end
+
+    test "HTML void can be non-void within svg" do
+      assert_parsed_snapshot(<<~SVG)
+        <svg>
+          <br></br>
+        </svg>
+      SVG
+    end
+
+    test "svg unclosed element reports an error" do
+      assert_parsed_snapshot(<<~SVG)
+        <svg>
+          <g>
+        </svg>
+      SVG
+    end
+  end
+end

--- a/test/snapshots/parser/svg_test/test_0001_svg_7b56e1eab00ec8000da9331a4888cb35.txt
+++ b/test/snapshots/parser/svg_test/test_0001_svg_7b56e1eab00ec8000da9331a4888cb35.txt
@@ -1,0 +1,21 @@
+@ DocumentNode (location: (1:0)-(1:11))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:11))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:5))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "svg" (location: (1:1)-(1:4))
+        │       ├── attributes: []
+        │       ├── tag_closing: ">" (location: (1:4)-(1:5))
+        │       ├── children: []
+        │       └── is_void: false
+        │
+        ├── tag_name: "svg" (location: (1:1)-(1:4))
+        ├── body: []
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:5)-(1:11))
+        │       ├── tag_opening: "</" (location: (1:5)-(1:7))
+        │       ├── tag_name: "svg" (location: (1:7)-(1:10))
+        │       └── tag_closing: ">" (location: (1:10)-(1:11))
+        │
+        └── is_void: false

--- a/test/snapshots/parser/svg_test/test_0002_svg_with_void_path_element_cf28475021c890620282e29c683e5d2c.txt
+++ b/test/snapshots/parser/svg_test/test_0002_svg_with_void_path_element_cf28475021c890620282e29c683e5d2c.txt
@@ -1,0 +1,45 @@
+@ DocumentNode (location: (1:0)-(4:1))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(3:7))
+    │   ├── open_tag:
+    │   │   └── @ HTMLOpenTagNode (location: (1:0)-(1:5))
+    │   │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+    │   │       ├── tag_name: "svg" (location: (1:1)-(1:4))
+    │   │       ├── attributes: []
+    │   │       ├── tag_closing: ">" (location: (1:4)-(1:5))
+    │   │       ├── children: []
+    │   │       └── is_void: false
+    │   │
+    │   ├── tag_name: "svg" (location: (1:1)-(1:4))
+    │   ├── body: (3 items)
+    │   │   ├── @ HTMLTextNode (location: (1:0)-(2:3))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ HTMLElementNode (location: (2:3)-(2:11))
+    │   │   │   ├── open_tag:
+    │   │   │   │   └── @ HTMLOpenTagNode (location: (2:3)-(2:11))
+    │   │   │   │       ├── tag_opening: "<" (location: (2:3)-(2:4))
+    │   │   │   │       ├── tag_name: "path" (location: (2:4)-(2:8))
+    │   │   │   │       ├── attributes: []
+    │   │   │   │       ├── tag_closing: "/>" (location: (2:9)-(2:11))
+    │   │   │   │       ├── children: []
+    │   │   │   │       └── is_void: true
+    │   │   │   │
+    │   │   │   ├── tag_name: "path" (location: (2:4)-(2:8))
+    │   │   │   ├── body: []
+    │   │   │   ├── close_tag: ∅
+    │   │   │   └── is_void: true
+    │   │   │
+    │   │   └── @ HTMLTextNode (location: (2:0)-(3:1))
+    │   │       └── content: "\n"
+    │   │
+    │   ├── close_tag:
+    │   │   └── @ HTMLCloseTagNode (location: (3:1)-(3:7))
+    │   │       ├── tag_opening: "</" (location: (3:1)-(3:3))
+    │   │       ├── tag_name: "svg" (location: (3:3)-(3:6))
+    │   │       └── tag_closing: ">" (location: (3:6)-(3:7))
+    │   │
+    │   └── is_void: false
+    │
+    └── @ HTMLTextNode (location: (3:0)-(4:1))
+        └── content: "\n"

--- a/test/snapshots/parser/svg_test/test_0003_svg_with_non-void_path_element_f3bf2c27b88d669126ee1c419f491e08.txt
+++ b/test/snapshots/parser/svg_test/test_0003_svg_with_non-void_path_element_f3bf2c27b88d669126ee1c419f491e08.txt
@@ -1,0 +1,50 @@
+@ DocumentNode (location: (1:0)-(4:1))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(3:7))
+    │   ├── open_tag:
+    │   │   └── @ HTMLOpenTagNode (location: (1:0)-(1:5))
+    │   │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+    │   │       ├── tag_name: "svg" (location: (1:1)-(1:4))
+    │   │       ├── attributes: []
+    │   │       ├── tag_closing: ">" (location: (1:4)-(1:5))
+    │   │       ├── children: []
+    │   │       └── is_void: false
+    │   │
+    │   ├── tag_name: "svg" (location: (1:1)-(1:4))
+    │   ├── body: (3 items)
+    │   │   ├── @ HTMLTextNode (location: (1:0)-(2:3))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ HTMLElementNode (location: (2:3)-(2:16))
+    │   │   │   ├── open_tag:
+    │   │   │   │   └── @ HTMLOpenTagNode (location: (2:3)-(2:9))
+    │   │   │   │       ├── tag_opening: "<" (location: (2:3)-(2:4))
+    │   │   │   │       ├── tag_name: "path" (location: (2:4)-(2:8))
+    │   │   │   │       ├── attributes: []
+    │   │   │   │       ├── tag_closing: ">" (location: (2:8)-(2:9))
+    │   │   │   │       ├── children: []
+    │   │   │   │       └── is_void: false
+    │   │   │   │
+    │   │   │   ├── tag_name: "path" (location: (2:4)-(2:8))
+    │   │   │   ├── body: []
+    │   │   │   ├── close_tag:
+    │   │   │   │   └── @ HTMLCloseTagNode (location: (2:9)-(2:16))
+    │   │   │   │       ├── tag_opening: "</" (location: (2:9)-(2:11))
+    │   │   │   │       ├── tag_name: "path" (location: (2:11)-(2:15))
+    │   │   │   │       └── tag_closing: ">" (location: (2:15)-(2:16))
+    │   │   │   │
+    │   │   │   └── is_void: false
+    │   │   │
+    │   │   └── @ HTMLTextNode (location: (2:0)-(3:1))
+    │   │       └── content: "\n"
+    │   │
+    │   ├── close_tag:
+    │   │   └── @ HTMLCloseTagNode (location: (3:1)-(3:7))
+    │   │       ├── tag_opening: "</" (location: (3:1)-(3:3))
+    │   │       ├── tag_name: "svg" (location: (3:3)-(3:6))
+    │   │       └── tag_closing: ">" (location: (3:6)-(3:7))
+    │   │
+    │   └── is_void: false
+    │
+    └── @ HTMLTextNode (location: (3:0)-(4:1))
+        └── content: "\n"

--- a/test/snapshots/parser/svg_test/test_0004_svg_with_nested_void_path_element_da5904bd14662799ee327966686eafdf.txt
+++ b/test/snapshots/parser/svg_test/test_0004_svg_with_nested_void_path_element_da5904bd14662799ee327966686eafdf.txt
@@ -1,0 +1,71 @@
+@ DocumentNode (location: (1:0)-(6:1))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(5:7))
+    │   ├── open_tag:
+    │   │   └── @ HTMLOpenTagNode (location: (1:0)-(1:5))
+    │   │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+    │   │       ├── tag_name: "svg" (location: (1:1)-(1:4))
+    │   │       ├── attributes: []
+    │   │       ├── tag_closing: ">" (location: (1:4)-(1:5))
+    │   │       ├── children: []
+    │   │       └── is_void: false
+    │   │
+    │   ├── tag_name: "svg" (location: (1:1)-(1:4))
+    │   ├── body: (3 items)
+    │   │   ├── @ HTMLTextNode (location: (1:0)-(2:3))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ HTMLElementNode (location: (2:3)-(4:7))
+    │   │   │   ├── open_tag:
+    │   │   │   │   └── @ HTMLOpenTagNode (location: (2:3)-(2:6))
+    │   │   │   │       ├── tag_opening: "<" (location: (2:3)-(2:4))
+    │   │   │   │       ├── tag_name: "g" (location: (2:4)-(2:5))
+    │   │   │   │       ├── attributes: []
+    │   │   │   │       ├── tag_closing: ">" (location: (2:5)-(2:6))
+    │   │   │   │       ├── children: []
+    │   │   │   │       └── is_void: false
+    │   │   │   │
+    │   │   │   ├── tag_name: "g" (location: (2:4)-(2:5))
+    │   │   │   ├── body: (3 items)
+    │   │   │   │   ├── @ HTMLTextNode (location: (2:0)-(3:5))
+    │   │   │   │   │   └── content: "\n    "
+    │   │   │   │   │
+    │   │   │   │   ├── @ HTMLElementNode (location: (3:5)-(3:12))
+    │   │   │   │   │   ├── open_tag:
+    │   │   │   │   │   │   └── @ HTMLOpenTagNode (location: (3:5)-(3:12))
+    │   │   │   │   │   │       ├── tag_opening: "<" (location: (3:5)-(3:6))
+    │   │   │   │   │   │       ├── tag_name: "path" (location: (3:6)-(3:10))
+    │   │   │   │   │   │       ├── attributes: []
+    │   │   │   │   │   │       ├── tag_closing: "/>" (location: (3:10)-(3:12))
+    │   │   │   │   │   │       ├── children: []
+    │   │   │   │   │   │       └── is_void: true
+    │   │   │   │   │   │
+    │   │   │   │   │   ├── tag_name: "path" (location: (3:6)-(3:10))
+    │   │   │   │   │   ├── body: []
+    │   │   │   │   │   ├── close_tag: ∅
+    │   │   │   │   │   └── is_void: true
+    │   │   │   │   │
+    │   │   │   │   └── @ HTMLTextNode (location: (3:0)-(4:3))
+    │   │   │   │       └── content: "\n  "
+    │   │   │   │
+    │   │   │   ├── close_tag:
+    │   │   │   │   └── @ HTMLCloseTagNode (location: (4:3)-(4:7))
+    │   │   │   │       ├── tag_opening: "</" (location: (4:3)-(4:5))
+    │   │   │   │       ├── tag_name: "g" (location: (4:5)-(4:6))
+    │   │   │   │       └── tag_closing: ">" (location: (4:6)-(4:7))
+    │   │   │   │
+    │   │   │   └── is_void: false
+    │   │   │
+    │   │   └── @ HTMLTextNode (location: (4:0)-(5:1))
+    │   │       └── content: "\n"
+    │   │
+    │   ├── close_tag:
+    │   │   └── @ HTMLCloseTagNode (location: (5:1)-(5:7))
+    │   │       ├── tag_opening: "</" (location: (5:1)-(5:3))
+    │   │       ├── tag_name: "svg" (location: (5:3)-(5:6))
+    │   │       └── tag_closing: ">" (location: (5:6)-(5:7))
+    │   │
+    │   └── is_void: false
+    │
+    └── @ HTMLTextNode (location: (5:0)-(6:1))
+        └── content: "\n"

--- a/test/snapshots/parser/svg_test/test_0005_HTML_void_can_be_non-void_within_svg_1072d4c2f81d845d5c1f0fd86e40e23b.txt
+++ b/test/snapshots/parser/svg_test/test_0005_HTML_void_can_be_non-void_within_svg_1072d4c2f81d845d5c1f0fd86e40e23b.txt
@@ -1,0 +1,50 @@
+@ DocumentNode (location: (1:0)-(4:1))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(3:7))
+    │   ├── open_tag:
+    │   │   └── @ HTMLOpenTagNode (location: (1:0)-(1:5))
+    │   │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+    │   │       ├── tag_name: "svg" (location: (1:1)-(1:4))
+    │   │       ├── attributes: []
+    │   │       ├── tag_closing: ">" (location: (1:4)-(1:5))
+    │   │       ├── children: []
+    │   │       └── is_void: false
+    │   │
+    │   ├── tag_name: "svg" (location: (1:1)-(1:4))
+    │   ├── body: (3 items)
+    │   │   ├── @ HTMLTextNode (location: (1:0)-(2:3))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ HTMLElementNode (location: (2:3)-(2:12))
+    │   │   │   ├── open_tag:
+    │   │   │   │   └── @ HTMLOpenTagNode (location: (2:3)-(2:7))
+    │   │   │   │       ├── tag_opening: "<" (location: (2:3)-(2:4))
+    │   │   │   │       ├── tag_name: "br" (location: (2:4)-(2:6))
+    │   │   │   │       ├── attributes: []
+    │   │   │   │       ├── tag_closing: ">" (location: (2:6)-(2:7))
+    │   │   │   │       ├── children: []
+    │   │   │   │       └── is_void: false
+    │   │   │   │
+    │   │   │   ├── tag_name: "br" (location: (2:4)-(2:6))
+    │   │   │   ├── body: []
+    │   │   │   ├── close_tag:
+    │   │   │   │   └── @ HTMLCloseTagNode (location: (2:7)-(2:12))
+    │   │   │   │       ├── tag_opening: "</" (location: (2:7)-(2:9))
+    │   │   │   │       ├── tag_name: "br" (location: (2:9)-(2:11))
+    │   │   │   │       └── tag_closing: ">" (location: (2:11)-(2:12))
+    │   │   │   │
+    │   │   │   └── is_void: false
+    │   │   │
+    │   │   └── @ HTMLTextNode (location: (2:0)-(3:1))
+    │   │       └── content: "\n"
+    │   │
+    │   ├── close_tag:
+    │   │   └── @ HTMLCloseTagNode (location: (3:1)-(3:7))
+    │   │       ├── tag_opening: "</" (location: (3:1)-(3:3))
+    │   │       ├── tag_name: "svg" (location: (3:3)-(3:6))
+    │   │       └── tag_closing: ">" (location: (3:6)-(3:7))
+    │   │
+    │   └── is_void: false
+    │
+    └── @ HTMLTextNode (location: (3:0)-(4:1))
+        └── content: "\n"

--- a/test/snapshots/parser/svg_test/test_0006_svg_unclosed_element_reports_an_error_e086a53256a215470da47ef3ee745599.txt
+++ b/test/snapshots/parser/svg_test/test_0006_svg_unclosed_element_reports_an_error_e086a53256a215470da47ef3ee745599.txt
@@ -1,0 +1,65 @@
+@ DocumentNode (location: (1:0)-(4:1))
+├── errors: (2 errors)
+│   ├── @ UnclosedElementError (location: (4:1)-(4:1))
+│   │   ├── message: "Tag `<g>` opened at (2:4) was never closed before the end of document."
+│   │   └── opening_tag: "g" (location: (2:4)-(2:5))
+│   │
+│   └── @ UnclosedElementError (location: (4:1)-(4:1))
+│       ├── message: "Tag `<svg>` opened at (1:1) was never closed before the end of document."
+│       └── opening_tag: "svg" (location: (1:1)-(1:4))
+│
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:5))
+        ├── errors: (1 error)
+        │   └── @ MissingClosingTagError (location: (1:1)-(1:4))
+        │       ├── message: "Opening tag `<svg>` at (1:1) doesn't have a matching closing tag `</svg>`."
+        │       └── opening_tag: "svg" (location: (1:1)-(1:4))
+        │
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:5))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "svg" (location: (1:1)-(1:4))
+        │       ├── attributes: []
+        │       ├── tag_closing: ">" (location: (1:4)-(1:5))
+        │       ├── children: []
+        │       └── is_void: false
+        │
+        ├── tag_name: "svg" (location: (1:1)-(1:4))
+        ├── body: (3 items)
+        │   ├── @ HTMLTextNode (location: (1:0)-(2:3))
+        │   │   └── content: "\n  "
+        │   │
+        │   ├── @ HTMLElementNode (location: (2:3)-(3:7))
+        │   │   ├── errors: (1 error)
+        │   │   │   └── @ TagNamesMismatchError (location: (3:3)-(3:6))
+        │   │   │       ├── message: "Opening tag `<g>` at (2:4) closed with `</svg>` at (3:3)."
+        │   │   │       ├── opening_tag: "g" (location: (2:4)-(2:5))
+        │   │   │       └── closing_tag: "svg" (location: (3:3)-(3:6))
+        │   │   │
+        │   │   ├── open_tag:
+        │   │   │   └── @ HTMLOpenTagNode (location: (2:3)-(2:6))
+        │   │   │       ├── tag_opening: "<" (location: (2:3)-(2:4))
+        │   │   │       ├── tag_name: "g" (location: (2:4)-(2:5))
+        │   │   │       ├── attributes: []
+        │   │   │       ├── tag_closing: ">" (location: (2:5)-(2:6))
+        │   │   │       ├── children: []
+        │   │   │       └── is_void: false
+        │   │   │
+        │   │   ├── tag_name: "g" (location: (2:4)-(2:5))
+        │   │   ├── body: (1 item)
+        │   │   │   └── @ HTMLTextNode (location: (2:0)-(3:1))
+        │   │   │       └── content: "\n"
+        │   │   │
+        │   │   ├── close_tag:
+        │   │   │   └── @ HTMLCloseTagNode (location: (3:1)-(3:7))
+        │   │   │       ├── tag_opening: "</" (location: (3:1)-(3:3))
+        │   │   │       ├── tag_name: "svg" (location: (3:3)-(3:6))
+        │   │   │       └── tag_closing: ">" (location: (3:6)-(3:7))
+        │   │   │
+        │   │   └── is_void: false
+        │   │
+        │   └── @ HTMLTextNode (location: (3:0)-(4:1))
+        │       └── content: "\n"
+        │
+        ├── close_tag: ∅
+        └── is_void: false


### PR DESCRIPTION
This pull request enhances the parsing of HTML elements inside an `<svg>` element. Within an SVG context, any tag name can be a regular element (with opening and closing tag) or a self-closing element. But all elements have to be closed.

**Valid:**
```svg
<svg>
  <path></path>
</svg>
```

**Valid:**
```svg
<svg>
  <path />
</svg>
```

**Invalid:**
```html
<svg>
  <path>
</svg>
```

This technically even applies to tag names that are void elements in the HTML context:

**Valid (in SVG):**
```svg
<svg>
  <br></br>
</svg>
```

**Invalid (in HTML):**
```html
<br></br>
```