### PR TITLE
Introduce `Location` for positional source spans

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -34,8 +34,8 @@ errors:
         arguments:
           - token_type_to_string(found->type)
           - token_type_to_string(expected_type)
-          - found->start->line
-          - found->start->column
+          - found->location->start->line
+          - found->location->start->column
 
       fields:
         - name: expected_type
@@ -49,8 +49,8 @@ errors:
         template: "Found closing tag `</%s>` at (%zu:%zu) without a matching opening tag."
         arguments:
           - closing_tag->value
-          - closing_tag->start->line
-          - closing_tag->start->column
+          - closing_tag->location->start->line
+          - closing_tag->location->start->column
 
       fields:
         - name: closing_tag
@@ -61,8 +61,8 @@ errors:
         template: "Opening tag `<%s>` at (%zu:%zu) doesn't have a matching closing tag `</%s>`."
         arguments:
           - opening_tag->value
-          - opening_tag->start->line
-          - opening_tag->start->column
+          - opening_tag->location->start->line
+          - opening_tag->location->start->column
           - opening_tag->value
 
       fields:
@@ -74,11 +74,11 @@ errors:
         template: "Opening tag `<%s>` at (%zu:%zu) closed with `</%s>` at (%zu:%zu)."
         arguments:
           - opening_tag->value
-          - opening_tag->start->line
-          - opening_tag->start->column
+          - opening_tag->location->start->line
+          - opening_tag->location->start->column
           - closing_tag->value
-          - closing_tag->start->line
-          - closing_tag->start->column
+          - closing_tag->location->start->line
+          - closing_tag->location->start->column
 
       fields:
         - name: opening_tag
@@ -93,8 +93,8 @@ errors:
         arguments:
           - opening_quote->value
           - closing_quote->value
-          - closing_quote->start->line
-          - closing_quote->start->column
+          - closing_quote->location->start->line
+          - closing_quote->location->start->column
 
       fields:
         - name: opening_quote
@@ -127,8 +127,8 @@ errors:
         template: "Tag `<%s>` opened at (%zu:%zu) was never closed before the end of document."
         arguments:
           - opening_tag->value
-          - opening_tag->start->line
-          - opening_tag->start->column
+          - opening_tag->location->start->line
+          - opening_tag->location->start->column
 
       fields:
         - name: opening_tag

--- a/ext/herb/extension_helpers.c
+++ b/ext/herb/extension_helpers.c
@@ -3,9 +3,10 @@
 #include "extension_helpers.h"
 #include "nodes.h"
 
-#include "../../src/include/ast_pretty_print.h"
 #include "../../src/include/herb.h"
 #include "../../src/include/io.h"
+#include "../../src/include/location.h"
+#include "../../src/include/position.h"
 #include "../../src/include/token.h"
 
 const char* check_string(VALUE value) {
@@ -31,6 +32,19 @@ VALUE rb_position_from_c_struct(position_T* position) {
   return rb_class_new_instance(2, args, Position);
 }
 
+VALUE rb_location_from_c_struct(location_T* location) {
+  if (!location) { return Qnil; }
+
+  VALUE args[2];
+  args[0] = rb_position_from_c_struct(location->start);
+  args[1] = rb_position_from_c_struct(location->end);
+
+  VALUE Herb = rb_define_module("Herb");
+  VALUE Location = rb_define_class_under(Herb, "Location", rb_cObject);
+
+  return rb_class_new_instance(2, args, Location);
+}
+
 VALUE rb_range_from_c_struct(range_T* range) {
   if (!range) { return Qnil; }
 
@@ -50,16 +64,15 @@ VALUE rb_token_from_c_struct(token_T* token) {
   VALUE value = token->value ? rb_str_new_cstr(token->value) : Qnil;
 
   VALUE range = rb_range_from_c_struct(token->range);
-  VALUE start = rb_position_from_c_struct(token->start);
-  VALUE end = rb_position_from_c_struct(token->end);
+  VALUE location = rb_location_from_c_struct(token->location);
   VALUE type = rb_str_new_cstr(token_type_to_string(token->type));
 
-  VALUE args[5] = { value, range, start, end, type };
+  VALUE args[4] = { value, range, location, type };
 
   VALUE Herb = rb_define_module("Herb");
   VALUE Token = rb_define_class_under(Herb, "Token", rb_cObject);
 
-  return rb_class_new_instance(5, args, Token);
+  return rb_class_new_instance(4, args, Token);
 }
 
 VALUE create_lex_result(array_T* tokens, VALUE source) {

--- a/ext/herb/extension_helpers.h
+++ b/ext/herb/extension_helpers.h
@@ -4,6 +4,7 @@
 #include <ruby.h>
 
 #include "../../src/include/herb.h"
+#include "../../src/include/location.h"
 #include "../../src/include/position.h"
 #include "../../src/include/range.h"
 #include "../../src/include/token.h"
@@ -12,6 +13,8 @@ const char* check_string(VALUE value);
 VALUE read_file_to_ruby_string(const char* file_path);
 
 VALUE rb_position_from_c_struct(position_T* position);
+VALUE rb_location_from_c_struct(location_T* location);
+
 VALUE rb_token_from_c_struct(token_T* token);
 VALUE rb_range_from_c_struct(range_T* range);
 

--- a/lib/herb.rb
+++ b/lib/herb.rb
@@ -2,6 +2,7 @@
 
 require_relative "herb/range"
 require_relative "herb/position"
+require_relative "herb/location"
 
 require_relative "herb/token"
 require_relative "herb/token_list"

--- a/lib/herb/ast/node.rb
+++ b/lib/herb/ast/node.rb
@@ -3,21 +3,18 @@
 module Herb
   module AST
     class Node
-      attr_reader :type, :start_position, :end_position, :errors
+      attr_reader :type, :location, :errors
 
-      # TODO: use a singe location
-      def initialize(type, start_position = nil, end_position = nil, errors = [])
+      def initialize(type, location, errors = [])
         @type = type
-        @start_position = start_position
-        @end_position = end_position
+        @location = location
         @errors = errors
       end
 
       def to_hash
         {
           type: type,
-          start_position: start_position&.to_hash,
-          end_position: end_position&.to_hash,
+          location: location&.to_hash,
           errors: errors.map(&:to_hash),
         }
       end

--- a/lib/herb/location.rb
+++ b/lib/herb/location.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Herb
+  class Location
+    attr_reader :start, :end
+
+    def initialize(start_position, end_position)
+      @start = start_position
+      @end = end_position
+    end
+
+    def self.from(start_line, start_column, end_line, end_column)
+      new(
+        Position.new(start_line, start_column),
+        Position.new(end_line, end_column)
+      )
+    end
+
+    def self.[](...)
+      from(...)
+    end
+
+    def to_hash
+      {
+        start: start,
+        end: self.end,
+      }
+    end
+
+    def to_json(*args)
+      to_hash.to_json(*args)
+    end
+
+    def tree_inspect
+      %((location: #{start.tree_inspect}-#{self.end.tree_inspect}))
+    end
+
+    def inspect
+      %(#<Herb::Location #{tree_inspect}>)
+    end
+  end
+end

--- a/lib/herb/position.rb
+++ b/lib/herb/position.rb
@@ -9,6 +9,14 @@ module Herb
       @column = column
     end
 
+    def self.[](...)
+      new(...)
+    end
+
+    def self.from(...)
+      new(...)
+    end
+
     def to_hash
       { line: line, column: column }
     end

--- a/lib/herb/range.rb
+++ b/lib/herb/range.rb
@@ -9,6 +9,14 @@ module Herb
       @to = to
     end
 
+    def self.[](...)
+      new(...)
+    end
+
+    def self.from(...)
+      new(...)
+    end
+
     def to_a
       [from, to]
     end

--- a/lib/herb/token.rb
+++ b/lib/herb/token.rb
@@ -2,14 +2,12 @@
 
 module Herb
   class Token
-    attr_reader :value, :range, :start_position, :end_position, :type
+    attr_reader :value, :range, :location, :type
 
-    # TODO: use a single location
-    def initialize(value, range, start_position, end_position, type)
+    def initialize(value, range, location, type)
       @value = value
       @range = range
-      @start_position = start_position
-      @end_position = end_position
+      @location = location
       @type = type
     end
 
@@ -17,8 +15,7 @@ module Herb
       {
         value: value,
         range: range&.to_a,
-        start_position: start_position&.to_hash,
-        end_position: end_position&.to_hash,
+        location: location&.to_hash,
         type: type,
       }
     end
@@ -28,12 +25,11 @@ module Herb
     end
 
     def tree_inspect
-      # TODO: use a single location
-      %("#{value}" (location: #{start_position.tree_inspect}-#{end_position.tree_inspect}))
+      %("#{value}" #{location.tree_inspect})
     end
 
     def inspect
-      %(#<Herb::Token type="#{type}" value=#{value.inspect} range=#{range.tree_inspect} start=#{start_position.tree_inspect} end=#{end_position.tree_inspect}>)
+      %(#<Herb::Token type="#{type}" value=#{value.inspect} range=#{range.tree_inspect} start=#{location.start.tree_inspect} end=#{location.end.tree_inspect}>)
     end
   end
 end

--- a/src/ast_node.c
+++ b/src/ast_node.c
@@ -15,8 +15,7 @@ void ast_node_init(AST_NODE_T* node, const ast_node_type_T type, position_T* sta
   if (!node) { return; }
 
   node->type = type;
-  node->start = position_copy(start);
-  node->end = position_copy(end);
+  node->location = location_init(position_copy(start), position_copy(end));
 
   if (errors == NULL) {
     node->errors = array_init(8);
@@ -28,7 +27,7 @@ void ast_node_init(AST_NODE_T* node, const ast_node_type_T type, position_T* sta
 AST_LITERAL_NODE_T* ast_literal_node_init_from_token(const token_T* token) {
   AST_LITERAL_NODE_T* literal = malloc(sizeof(AST_LITERAL_NODE_T));
 
-  ast_node_init(&literal->base, AST_LITERAL_NODE, token->start, token->end, NULL);
+  ast_node_init(&literal->base, AST_LITERAL_NODE, token->location->start, token->location->end, NULL);
 
   literal->content = herb_strdup(token->value);
 
@@ -52,23 +51,23 @@ void ast_node_append_error(const AST_NODE_T* node, ERROR_T* error) {
 }
 
 void ast_node_set_start(AST_NODE_T* node, position_T* position) {
-  if (node->start != NULL) { position_free(node->start); }
+  if (node->location->start != NULL) { position_free(node->location->start); }
 
-  node->start = position_copy(position);
+  node->location->start = position_copy(position);
 }
 
 void ast_node_set_end(AST_NODE_T* node, position_T* position) {
-  if (node->end != NULL) { position_free(node->end); }
+  if (node->location->end != NULL) { position_free(node->location->end); }
 
-  node->end = position_copy(position);
+  node->location->end = position_copy(position);
 }
 
 void ast_node_set_start_from_token(AST_NODE_T* node, const token_T* token) {
-  ast_node_set_start(node, token->start);
+  ast_node_set_start(node, token->location->start);
 }
 
 void ast_node_set_end_from_token(AST_NODE_T* node, const token_T* token) {
-  ast_node_set_end(node, token->end);
+  ast_node_set_end(node, token->location->end);
 }
 
 void ast_node_set_positions_from_token(AST_NODE_T* node, const token_T* token) {

--- a/src/include/location.h
+++ b/src/include/location.h
@@ -1,0 +1,25 @@
+#ifndef HERB_LOCATION_H
+#define HERB_LOCATION_H
+
+#include <stdlib.h>
+
+#include "position.h"
+
+typedef struct LOCATION_STRUCT {
+  position_T* start;
+  position_T* end;
+} location_T;
+
+location_T* location_init(position_T* start, position_T* end);
+location_T* location_from(size_t start_line, size_t start_column, size_t end_line, size_t end_column);
+
+position_T* location_start(location_T* location);
+position_T* location_end_(location_T* location);
+
+size_t location_sizeof(void);
+
+location_T* location_copy(location_T* location);
+
+void location_free(location_T* location);
+
+#endif

--- a/src/include/pretty_print.h
+++ b/src/include/pretty_print.h
@@ -3,6 +3,7 @@
 
 #include "ast_nodes.h"
 #include "buffer.h"
+#include "location.h"
 
 #include <stdbool.h>
 
@@ -14,11 +15,7 @@ void pretty_print_position_property(
   position_T* position, const char* name, size_t indent, size_t relative_indent, bool last_property, buffer_T* buffer
 );
 
-// TODO: replace pretty_print_positions with pretty_print_location
-//
-// void pretty_print_location(location_T* location, buffer_T* buffer);
-//
-void pretty_print_positions(position_T* start, position_T* end, buffer_T* buffer);
+void pretty_print_location(location_T* location, buffer_T* buffer);
 
 void pretty_print_property(
   const char* name, const char* value, size_t indent, size_t relative_indent, bool last_property, buffer_T* buffer

--- a/src/include/token.h
+++ b/src/include/token.h
@@ -2,6 +2,7 @@
 #define HERB_TOKEN_H
 
 #include "lexer_struct.h"
+#include "position.h"
 #include "token_struct.h"
 
 token_T* token_init(const char* value, token_type_T type, const lexer_T* lexer);
@@ -11,6 +12,9 @@ const char* token_type_to_string(token_type_T type);
 
 char* token_value(const token_T* token);
 int token_type(const token_T* token);
+
+position_T* token_start_position(token_T* token);
+position_T* token_end_position(token_T* token);
 
 size_t token_sizeof(void);
 

--- a/src/include/token_struct.h
+++ b/src/include/token_struct.h
@@ -1,7 +1,7 @@
 #ifndef HERB_TOKEN_STRUCT_H
 #define HERB_TOKEN_STRUCT_H
 
-#include "position.h"
+#include "location.h"
 #include "range.h"
 
 typedef enum {
@@ -44,8 +44,7 @@ typedef enum {
 typedef struct TOKEN_STRUCT {
   char* value;
   range_T* range;
-  position_T* start;
-  position_T* end;
+  location_T* location;
   token_type_T type;
 } token_T;
 

--- a/src/location.c
+++ b/src/location.c
@@ -1,0 +1,41 @@
+#include "include/location.h"
+#include "include/memory.h"
+#include "include/position.h"
+
+size_t location_sizeof(void) {
+  return sizeof(location_T);
+}
+
+location_T* location_init(position_T* start, position_T* end) {
+  location_T* location = safe_malloc(location_sizeof());
+
+  location->start = start;
+  location->end = end;
+
+  return location;
+}
+
+location_T* location_from(size_t start_line, size_t start_column, size_t end_line, size_t end_column) {
+  return location_init(position_init(start_line, start_column), position_init(end_line, end_column));
+}
+
+position_T* location_start(location_T* location) {
+  return location->start;
+}
+
+position_T* location_end(location_T* location) {
+  return location->end;
+}
+
+location_T* location_copy(location_T* location) {
+  if (location == NULL) { return NULL; }
+
+  return location_init(position_copy(location->start), position_copy(location->end));
+}
+
+void location_free(location_T* location) {
+  if (location->start != NULL) { position_free(location->start); }
+  if (location->end != NULL) { position_free(location->end); }
+
+  free(location);
+}

--- a/src/parser_helpers.c
+++ b/src/parser_helpers.c
@@ -57,7 +57,14 @@ bool parser_in_svg_context(const parser_T* parser) {
 void parser_append_unexpected_error(parser_T* parser, const char* description, const char* expected, array_T* errors) {
   token_T* token = parser_advance(parser);
 
-  append_unexpected_error(description, expected, token_type_to_string(token->type), token->start, token->end, errors);
+  append_unexpected_error(
+    description,
+    expected,
+    token_type_to_string(token->type),
+    token->location->start,
+    token->location->end,
+    errors
+  );
 
   token_free(token);
 }
@@ -66,8 +73,8 @@ void parser_append_unexpected_token_error(parser_T* parser, token_type_T expecte
   append_unexpected_token_error(
     expected_type,
     parser->current_token,
-    parser->current_token->start,
-    parser->current_token->end,
+    parser->current_token->location->start,
+    parser->current_token->location->end,
     errors
   );
 }
@@ -77,7 +84,8 @@ void parser_append_literal_node_from_buffer(
 ) {
   if (buffer_length(buffer) == 0) { return; }
 
-  AST_LITERAL_NODE_T* literal = ast_literal_node_init(buffer_value(buffer), start, parser->current_token->start, NULL);
+  AST_LITERAL_NODE_T* literal =
+    ast_literal_node_init(buffer_value(buffer), start, parser->current_token->location->start, NULL);
 
   if (children != NULL) { array_append(children, literal); }
   buffer_clear(buffer);
@@ -100,7 +108,7 @@ token_T* parser_consume_expected(parser_T* parser, const token_type_T expected_t
   if (token == NULL) {
     token = parser_advance(parser);
 
-    append_unexpected_token_error(expected_type, token, token->start, token->end, array);
+    append_unexpected_token_error(expected_type, token, token->location->start, token->location->end, array);
   }
 
   return token;
@@ -109,7 +117,12 @@ token_T* parser_consume_expected(parser_T* parser, const token_type_T expected_t
 AST_HTML_ELEMENT_NODE_T* parser_handle_missing_close_tag(
   AST_HTML_OPEN_TAG_NODE_T* open_tag, array_T* body, array_T* errors
 ) {
-  append_missing_closing_tag_error(open_tag->tag_name, open_tag->tag_name->start, open_tag->tag_name->end, errors);
+  append_missing_closing_tag_error(
+    open_tag->tag_name,
+    open_tag->tag_name->location->start,
+    open_tag->tag_name->location->end,
+    errors
+  );
 
   return ast_html_element_node_init(
     open_tag,
@@ -117,8 +130,8 @@ AST_HTML_ELEMENT_NODE_T* parser_handle_missing_close_tag(
     body,
     NULL,
     false,
-    open_tag->base.start,
-    open_tag->base.end,
+    open_tag->base.location->start,
+    open_tag->base.location->end,
     errors
   );
 }
@@ -130,8 +143,19 @@ void parser_handle_mismatched_tags(
     token_T* expected_tag = array_last(parser->open_tags_stack);
     token_T* actual_tag = close_tag->tag_name;
 
-    append_tag_names_mismatch_error(expected_tag, actual_tag, actual_tag->start, actual_tag->end, errors);
+    append_tag_names_mismatch_error(
+      expected_tag,
+      actual_tag,
+      actual_tag->location->start,
+      actual_tag->location->end,
+      errors
+    );
   } else {
-    append_missing_opening_tag_error(close_tag->tag_name, close_tag->tag_name->start, close_tag->tag_name->end, errors);
+    append_missing_opening_tag_error(
+      close_tag->tag_name,
+      close_tag->tag_name->location->start,
+      close_tag->tag_name->location->end,
+      errors
+    );
   }
 }

--- a/src/pretty_print.c
+++ b/src/pretty_print.c
@@ -111,23 +111,22 @@ void pretty_print_errors(
   }
 }
 
-// TODO: rename to pretty_print_location
-void pretty_print_positions(position_T* start, position_T* end, buffer_T* buffer) {
+void pretty_print_location(location_T* location, buffer_T* buffer) {
   buffer_append(buffer, "(location: (");
-  char location[128];
+  char location_string[128];
   sprintf(
-    location,
+    location_string,
     "%zu,%zu)-(%zu,%zu",
-    (start && start->line) ? start->line : 0,
-    (start && start->column) ? start->column : 0,
-    (end && end->line) ? end->line : 0,
-    (end && end->column) ? end->column : 0
+    (location->start && location->start->line) ? location->start->line : 0,
+    (location->start && location->start->column) ? location->start->column : 0,
+    (location->end && location->end->line) ? location->end->line : 0,
+    (location->end && location->end->column) ? location->end->column : 0
   );
-  buffer_append(buffer, location);
+  buffer_append(buffer, location_string);
   buffer_append(buffer, "))");
 }
 
-void pretty_print_positions_property(
+void pretty_print_position_property(
   position_T* position, const char* name, const size_t indent, const size_t relative_indent, const bool last_property,
   buffer_T* buffer
 ) {
@@ -166,7 +165,7 @@ void pretty_print_token_property(
     free(quoted);
 
     buffer_append(buffer, " ");
-    pretty_print_positions(token->start, token->end, buffer);
+    pretty_print_location(token->location, buffer);
   } else {
     buffer_append(buffer, "∅");
   }

--- a/templates/ext/herb/error_helpers.c.erb
+++ b/templates/ext/herb/error_helpers.c.erb
@@ -22,8 +22,7 @@ static VALUE rb_<%= error.human %>_from_c_struct(<%= error.struct_type %>* <%= e
   VALUE <%= error.name %> = rb_define_class_under(Errors, "<%= error.name %>", Error);
 
   VALUE type = rb_str_new_cstr(error_type_to_string(error));
-  VALUE start = rb_position_from_c_struct(error->start);
-  VALUE end = rb_position_from_c_struct(error->end);
+  VALUE location = rb_location_from_c_struct(error->location);
   VALUE message = rb_str_new_cstr(error->message);
 
   <%- error.fields.each do |field| -%>
@@ -42,17 +41,16 @@ static VALUE rb_<%= error.human %>_from_c_struct(<%= error.struct_type %>* <%= e
   <%- end -%>
   <%- end -%>
 
-  VALUE args[<%= 4 + error.fields.count %>] = {
+  VALUE args[<%= 3 + error.fields.count %>] = {
     type,
-    start,
-    end,
+    location,
     message<% if error.fields.any? %>,<% end %>
     <%- error.fields.each do |field| -%>
     <%= error.human %>_<%= field.name %><% if error.fields.last != field %>,<% end %>
     <%- end -%>
   };
 
-  return rb_class_new_instance(<%= 4 + error.fields.count %>, args, <%= error.name %>);
+  return rb_class_new_instance(<%= 3 + error.fields.count %>, args, <%= error.name %>);
 };
 
 <%- end -%>

--- a/templates/ext/herb/nodes.c.erb
+++ b/templates/ext/herb/nodes.c.erb
@@ -23,8 +23,7 @@ static VALUE rb_<%= node.human %>_from_c_struct(<%= node.struct_type %>* <%= nod
   VALUE <%= node.name %> = rb_define_class_under(AST, "<%= node.name %>", Node);
 
   VALUE type = rb_str_new_cstr(ast_node_type_to_string(node));
-  VALUE start = rb_position_from_c_struct(node->start);
-  VALUE end = rb_position_from_c_struct(node->end);
+  VALUE location = rb_location_from_c_struct(node->location);
   VALUE errors = rb_errors_array_from_c_array(node->errors);
 
   <%- node.fields.each do |field| -%>
@@ -45,17 +44,16 @@ static VALUE rb_<%= node.human %>_from_c_struct(<%= node.struct_type %>* <%= nod
   <%- end -%>
   <%- end -%>
 
-  VALUE args[<%= 4 + node.fields.count %>] = {
+  VALUE args[<%= 3 + node.fields.count %>] = {
     type,
-    start,
-    end,
+    location,
     errors<% if node.fields.any? %>,<% end %>
     <%- node.fields.each do |field| -%>
     <%= node.human %>_<%= field.name %><% if node.fields.last != field %>,<% end %>
     <%- end -%>
   };
 
-  return rb_class_new_instance(<%= 4 + node.fields.count %>, args, <%= node.name %>);
+  return rb_class_new_instance(<%= 3 + node.fields.count %>, args, <%= node.name %>);
 };
 
 <%- end -%>

--- a/templates/lib/herb/ast/nodes.rb.erb
+++ b/templates/lib/herb/ast/nodes.rb.erb
@@ -6,9 +6,8 @@ module Herb
       attr_reader :<%= field.name %>
       <%- end -%>
 
-      # TODO: use single location
-      def initialize(<%= ["type", "start_position", "end_position", "errors", *node.fields.map(&:name)].join(", ") %>)
-        super(type, start_position, end_position, errors)
+      def initialize(<%= ["type", "location", "errors", *node.fields.map(&:name)].join(", ") %>)
+        super(type, location, errors)
         <%- node.fields.each do |field| -%>
         @<%= field.name %> = <%= field.name %>
         <%- end -%>
@@ -30,7 +29,7 @@ module Herb
         output = +""
 
         output += "@ #{node_name} "
-        output += "(location: (#{start_position.line}:#{start_position.column})-(#{end_position.line}:#{end_position.column}))"
+        output += location.tree_inspect
         output += "\n"
 
         output += inspect_errors(prefix: "<%= node.fields.any? ? "│   " : "    " %>")

--- a/templates/lib/herb/errors.rb.erb
+++ b/templates/lib/herb/errors.rb.erb
@@ -1,5 +1,4 @@
-# TODO: use single location
-<%- base_arguments = ["type", "start_position", "end_position", "message"] -%>
+<%- base_arguments = ["type", "location", "message"] -%>
 module Herb
   module Errors
     class Error
@@ -16,8 +15,7 @@ module Herb
       def to_hash
         {
           type: type,
-          start_position: start_position&.to_hash,
-          end_position: end_position&.to_hash,
+          location: location&.to_hash,
           message: message,
         }
       end
@@ -60,7 +58,7 @@ module Herb
       def tree_inspect(indent = 0)
         output = +""
 
-        output += %(@ #{error_name} (location: #{start_position.tree_inspect}-#{end_position.tree_inspect})\n)
+        output += %(@ #{error_name} #{location.tree_inspect}\n)
         <%- symbol = error.fields.none? ? "└──" : "├──" -%>
         output += %(<%= symbol %> message: #{message.inspect}\n)
         <%- error.fields.each do |field| -%>

--- a/templates/src/ast_nodes.c.erb
+++ b/templates/src/ast_nodes.c.erb
@@ -70,8 +70,7 @@ void ast_free_base_node(AST_NODE_T* node) {
     array_free(&node->errors);
   }
 
-  if (node->start) { position_free(node->start); }
-  if (node->end) { position_free(node->end); }
+  if (node->location) { location_free(node->location); }
 
   free(node);
 }

--- a/templates/src/ast_pretty_print.c.erb
+++ b/templates/src/ast_pretty_print.c.erb
@@ -19,8 +19,7 @@ void ast_pretty_print_node(AST_NODE_T* node, const size_t indent, const size_t r
   buffer_append(buffer, ast_node_human_type(node));
   buffer_append(buffer, " ");
 
-  // TODO: update to use pretty_print_location
-  if (print_location) { pretty_print_positions(node->start, node->end, buffer); }
+  if (print_location) { pretty_print_location(node->location, buffer); }
 
   buffer_append(buffer, "\n");
 

--- a/templates/src/errors.c.erb
+++ b/templates/src/errors.c.erb
@@ -1,9 +1,10 @@
 #include "include/array.h"
-#include "include/position.h"
-#include "include/token.h"
 #include "include/errors.h"
-#include "include/util.h"
+#include "include/location.h"
+#include "include/position.h"
 #include "include/pretty_print.h"
+#include "include/token.h"
+#include "include/util.h"
 
 #include <stdio.h>
 #include <stdbool.h>
@@ -20,8 +21,7 @@ void error_init(ERROR_T* error, const error_type_T type, position_T* start, posi
   if (!error) { return; }
 
   error->type = type;
-  error->start = position_copy(start);
-  error->end = position_copy(end);
+  error->location = location_init(position_copy(start), position_copy(end));
 }
 <%- errors.each do |error| -%>
 <%- error_arguments = error.fields.any? ? error.fields.map { |field| [field.c_type, " ", field.name].join } : [] -%>
@@ -114,8 +114,7 @@ const char* error_human_type(ERROR_T* error) {
 void error_free_base_error(ERROR_T* error) {
   if (error == NULL) { return; }
 
-  if (error->start != NULL) { position_free(error->start); }
-  if (error->end != NULL) { position_free(error->end); }
+  if (error->location != NULL) { location_free(error->location); }
   if (error->message != NULL) { free(error->message); }
 
   free(error);
@@ -208,14 +207,14 @@ static void error_pretty_print_<%= error.human %>(<%= error.struct_type %>* erro
   buffer_append(buffer, error_human_type((ERROR_T*) error));
   buffer_append(buffer, " ");
 
-  pretty_print_positions(error->base.start, error->base.end, buffer);
+  pretty_print_location(error->base.location, buffer);
   buffer_append(buffer, "\n");
 
   pretty_print_quoted_property("message", error->base.message, indent, relative_indent, <%= error.fields.none? %>, buffer);
   <%- error.fields.each_with_index do |field, index| -%>
   <%- case field -%>
   <%- when Herb::Template::PositionField -%>
-  pretty_print_positions_property(error-><%= field.name %>, "<%= field.name %>", indent, relative_indent, <%= error.fields.length - 1 == index %>, buffer);
+  pretty_print_position_property(error-><%= field.name %>, "<%= field.name %>", indent, relative_indent, <%= error.fields.length - 1 == index %>, buffer);
   <%- when Herb::Template::TokenField -%>
   pretty_print_token_property(error-><%= field.name %>, "<%= field.name %>", indent, relative_indent, <%= error.fields.length - 1 == index %>, buffer);
   <%- when Herb::Template::TokenTypeField -%>

--- a/templates/src/include/ast_nodes.h.erb
+++ b/templates/src/include/ast_nodes.h.erb
@@ -6,8 +6,8 @@
 #include "array.h"
 #include "buffer.h"
 #include "position.h"
+#include "location.h"
 #include "token_struct.h"
-
 
 typedef enum {
 <%- nodes.each do |node| -%>
@@ -17,8 +17,7 @@ typedef enum {
 
 typedef struct AST_NODE_STRUCT {
   ast_node_type_T type;
-  position_T* start;
-  position_T* end;
+  location_T* location;
   // maybe a range too?
   array_T* errors;
 } AST_NODE_T;

--- a/templates/src/include/errors.h.erb
+++ b/templates/src/include/errors.h.erb
@@ -4,6 +4,7 @@
 #include "array.h"
 #include "buffer.h"
 #include "errors.h"
+#include "location.h"
 #include "position.h"
 #include "token.h"
 
@@ -15,8 +16,7 @@ typedef enum {
 
 typedef struct ERROR_STRUCT {
   error_type_T type;
-  position_T* start;
-  position_T* end;
+  location_T* location;
   char* message;
 } ERROR_T;
 

--- a/test/c/test_token.c
+++ b/test/c/test_token.c
@@ -25,7 +25,7 @@ TEST(test_token_to_json)
   herb_lex_json_to_buffer("hello", &output);
 
   const char* expected = "["
-  "{\"type\": \"TOKEN_IDENTIFIER\", \"value\": \"hello\", \"range\": [0 , 5], \"start\": {\"line\": 1, \"column\": 0}, \"end\": {\"line\": 1, \"column\": 0}}, "
+  "{\"type\": \"TOKEN_IDENTIFIER\", \"value\": \"hello\", \"range\": [0 , 5], \"start\": {\"line\": 1, \"column\": 0}, \"end\": {\"line\": 1, \"column\": 5}}, "
   "{\"type\": \"TOKEN_EOF\", \"value\": \"\", \"range\": [5 , 5], \"start\": {\"line\": 1, \"column\": 5}, \"end\": {\"line\": 1, \"column\": 5}}"
   "]";
 


### PR DESCRIPTION
This pull request introduces the new `Location` struct to complete our AST coordinate system. The `Location` represents a span in the source code using `start` and `end` `Position` structs, providing human-readable coordinates for tokens, AST Nodes and errors. This is continuing the work from #69.


#### Terminology Clarification
Our coordinate system now uses these terms:
* **Position** (as of #69) 
  A single point in the source code, defined by numeric line and column numbers. This represents exactly one character position in the source.
* **Range**
  A span of source code defined by two numeric offsets: from and to. These are character-based indices from the beginning of the file.
* **Location** (as of this PR #70)
  A higher-level construct that will contain a start position and an end position to represent a span of source code. This provides human-readable line/column coordinates for the beginning and end of syntax elements.


#### Key Changes

* Added a `Location` with `start` and `end` attributes.
* Added helper methods for Location creation and manipulation
* No breaking changes to existing Position or Range functionality
