### PR TITLE
Use zero-based columns in token positions

### DIFF
--- a/src/token.c
+++ b/src/token.c
@@ -18,7 +18,7 @@ token_T* token_init(const char* value, const token_type_T type, lexer_T* lexer) 
 
   if (type == TOKEN_NEWLINE) {
     lexer->current_line++;
-    lexer->current_column = 1;
+    lexer->current_column = 0;
   }
 
   if (value) {

--- a/test/snapshots/lexer/comments_test/test_0004_HTML_comment_followed_by_html_tag_with_nested_comment_f4042eb3e6a5d62fcc86e4162fe10cf2.txt
+++ b/test/snapshots/lexer/comments_test/test_0004_HTML_comment_followed_by_html_tag_with_nested_comment_f4042eb3e6a5d62fcc86e4162fe10cf2.txt
@@ -1,25 +1,25 @@
-#<Herb::Token type="TOKEN_NEWLINE" value="\n" range=[0, 1] start=(1:0) end=(2:1)>
-#<Herb::Token type="TOKEN_WHITESPACE" value="        " range=[1, 9] start=(2:1) end=(2:9)>
-#<Herb::Token type="TOKEN_HTML_COMMENT_START" value="<!--" range=[9, 13] start=(2:9) end=(2:13)>
-#<Herb::Token type="TOKEN_IDENTIFIER" value="Hello" range=[13, 18] start=(2:13) end=(2:18)>
-#<Herb::Token type="TOKEN_WHITESPACE" value=" " range=[18, 19] start=(2:18) end=(2:19)>
-#<Herb::Token type="TOKEN_IDENTIFIER" value="World" range=[19, 24] start=(2:19) end=(2:24)>
-#<Herb::Token type="TOKEN_HTML_COMMENT_END" value="-->" range=[24, 27] start=(2:24) end=(2:27)>
-#<Herb::Token type="TOKEN_NEWLINE" value="\n" range=[27, 28] start=(2:27) end=(3:1)>
-#<Herb::Token type="TOKEN_WHITESPACE" value="        " range=[28, 36] start=(3:1) end=(3:9)>
-#<Herb::Token type="TOKEN_HTML_TAG_START" value="<" range=[36, 37] start=(3:9) end=(3:10)>
-#<Herb::Token type="TOKEN_IDENTIFIER" value="h1" range=[37, 39] start=(3:10) end=(3:12)>
-#<Herb::Token type="TOKEN_HTML_TAG_END" value=">" range=[39, 40] start=(3:12) end=(3:13)>
-#<Herb::Token type="TOKEN_HTML_COMMENT_START" value="<!--" range=[40, 44] start=(3:13) end=(3:17)>
-#<Herb::Token type="TOKEN_WHITESPACE" value=" " range=[44, 45] start=(3:17) end=(3:18)>
-#<Herb::Token type="TOKEN_IDENTIFIER" value="Hello" range=[45, 50] start=(3:18) end=(3:23)>
-#<Herb::Token type="TOKEN_WHITESPACE" value=" " range=[50, 51] start=(3:23) end=(3:24)>
-#<Herb::Token type="TOKEN_IDENTIFIER" value="World" range=[51, 56] start=(3:24) end=(3:29)>
-#<Herb::Token type="TOKEN_WHITESPACE" value=" " range=[56, 57] start=(3:29) end=(3:30)>
-#<Herb::Token type="TOKEN_HTML_COMMENT_END" value="-->" range=[57, 60] start=(3:30) end=(3:33)>
-#<Herb::Token type="TOKEN_HTML_TAG_START_CLOSE" value="</" range=[60, 62] start=(3:33) end=(3:35)>
-#<Herb::Token type="TOKEN_IDENTIFIER" value="h1" range=[62, 64] start=(3:35) end=(3:37)>
-#<Herb::Token type="TOKEN_HTML_TAG_END" value=">" range=[64, 65] start=(3:37) end=(3:38)>
-#<Herb::Token type="TOKEN_NEWLINE" value="\n" range=[65, 66] start=(3:38) end=(4:1)>
-#<Herb::Token type="TOKEN_WHITESPACE" value="      " range=[66, 72] start=(4:1) end=(4:7)>
-#<Herb::Token type="TOKEN_EOF" value="<EOF>" range=[72, 72] start=(4:7) end=(4:7)>
+#<Herb::Token type="TOKEN_NEWLINE" value="\n" range=[0, 1] start=(1:0) end=(2:0)>
+#<Herb::Token type="TOKEN_WHITESPACE" value="        " range=[1, 9] start=(2:0) end=(2:8)>
+#<Herb::Token type="TOKEN_HTML_COMMENT_START" value="<!--" range=[9, 13] start=(2:8) end=(2:12)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="Hello" range=[13, 18] start=(2:12) end=(2:17)>
+#<Herb::Token type="TOKEN_WHITESPACE" value=" " range=[18, 19] start=(2:17) end=(2:18)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="World" range=[19, 24] start=(2:18) end=(2:23)>
+#<Herb::Token type="TOKEN_HTML_COMMENT_END" value="-->" range=[24, 27] start=(2:23) end=(2:26)>
+#<Herb::Token type="TOKEN_NEWLINE" value="\n" range=[27, 28] start=(2:26) end=(3:0)>
+#<Herb::Token type="TOKEN_WHITESPACE" value="        " range=[28, 36] start=(3:0) end=(3:8)>
+#<Herb::Token type="TOKEN_HTML_TAG_START" value="<" range=[36, 37] start=(3:8) end=(3:9)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="h1" range=[37, 39] start=(3:9) end=(3:11)>
+#<Herb::Token type="TOKEN_HTML_TAG_END" value=">" range=[39, 40] start=(3:11) end=(3:12)>
+#<Herb::Token type="TOKEN_HTML_COMMENT_START" value="<!--" range=[40, 44] start=(3:12) end=(3:16)>
+#<Herb::Token type="TOKEN_WHITESPACE" value=" " range=[44, 45] start=(3:16) end=(3:17)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="Hello" range=[45, 50] start=(3:17) end=(3:22)>
+#<Herb::Token type="TOKEN_WHITESPACE" value=" " range=[50, 51] start=(3:22) end=(3:23)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="World" range=[51, 56] start=(3:23) end=(3:28)>
+#<Herb::Token type="TOKEN_WHITESPACE" value=" " range=[56, 57] start=(3:28) end=(3:29)>
+#<Herb::Token type="TOKEN_HTML_COMMENT_END" value="-->" range=[57, 60] start=(3:29) end=(3:32)>
+#<Herb::Token type="TOKEN_HTML_TAG_START_CLOSE" value="</" range=[60, 62] start=(3:32) end=(3:34)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="h1" range=[62, 64] start=(3:34) end=(3:36)>
+#<Herb::Token type="TOKEN_HTML_TAG_END" value=">" range=[64, 65] start=(3:36) end=(3:37)>
+#<Herb::Token type="TOKEN_NEWLINE" value="\n" range=[65, 66] start=(3:37) end=(4:0)>
+#<Herb::Token type="TOKEN_WHITESPACE" value="      " range=[66, 72] start=(4:0) end=(4:6)>
+#<Herb::Token type="TOKEN_EOF" value="<EOF>" range=[72, 72] start=(4:6) end=(4:6)>

--- a/test/snapshots/lexer/newlines_test/test_0001_line_feed_68b329da9893e34099c7d8ad5cb9c940.txt
+++ b/test/snapshots/lexer/newlines_test/test_0001_line_feed_68b329da9893e34099c7d8ad5cb9c940.txt
@@ -1,2 +1,2 @@
-#<Herb::Token type="TOKEN_NEWLINE" value="\n" range=[0, 1] start=(1:0) end=(2:1)>
-#<Herb::Token type="TOKEN_EOF" value="<EOF>" range=[1, 1] start=(2:1) end=(2:1)>
+#<Herb::Token type="TOKEN_NEWLINE" value="\n" range=[0, 1] start=(1:0) end=(2:0)>
+#<Herb::Token type="TOKEN_EOF" value="<EOF>" range=[1, 1] start=(2:0) end=(2:0)>

--- a/test/snapshots/lexer/newlines_test/test_0002_carriage_return_dcb9be2f604e5df91deb9659bed4748d.txt
+++ b/test/snapshots/lexer/newlines_test/test_0002_carriage_return_dcb9be2f604e5df91deb9659bed4748d.txt
@@ -1,2 +1,2 @@
-#<Herb::Token type="TOKEN_NEWLINE" value="\r" range=[0, 1] start=(1:0) end=(2:1)>
-#<Herb::Token type="TOKEN_EOF" value="<EOF>" range=[1, 1] start=(2:1) end=(2:1)>
+#<Herb::Token type="TOKEN_NEWLINE" value="\r" range=[0, 1] start=(1:0) end=(2:0)>
+#<Herb::Token type="TOKEN_EOF" value="<EOF>" range=[1, 1] start=(2:0) end=(2:0)>

--- a/test/snapshots/lexer/newlines_test/test_0003_carriage_return_and_line_feed_81051bcc2cf1bedf378224b0a93e2877.txt
+++ b/test/snapshots/lexer/newlines_test/test_0003_carriage_return_and_line_feed_81051bcc2cf1bedf378224b0a93e2877.txt
@@ -1,2 +1,2 @@
-#<Herb::Token type="TOKEN_NEWLINE" value="\r\n" range=[0, 2] start=(1:0) end=(2:1)>
-#<Herb::Token type="TOKEN_EOF" value="<EOF>" range=[2, 2] start=(2:1) end=(2:1)>
+#<Herb::Token type="TOKEN_NEWLINE" value="\r\n" range=[0, 2] start=(1:0) end=(2:0)>
+#<Herb::Token type="TOKEN_EOF" value="<EOF>" range=[2, 2] start=(2:0) end=(2:0)>

--- a/test/snapshots/lexer/newlines_test/test_0004_two_newlines_e1c06d85ae7b8b032bef47e42e4c08f9.txt
+++ b/test/snapshots/lexer/newlines_test/test_0004_two_newlines_e1c06d85ae7b8b032bef47e42e4c08f9.txt
@@ -1,3 +1,3 @@
-#<Herb::Token type="TOKEN_NEWLINE" value="\n" range=[0, 1] start=(1:0) end=(2:1)>
-#<Herb::Token type="TOKEN_NEWLINE" value="\n" range=[1, 2] start=(2:1) end=(3:1)>
-#<Herb::Token type="TOKEN_EOF" value="<EOF>" range=[2, 2] start=(3:1) end=(3:1)>
+#<Herb::Token type="TOKEN_NEWLINE" value="\n" range=[0, 1] start=(1:0) end=(2:0)>
+#<Herb::Token type="TOKEN_NEWLINE" value="\n" range=[1, 2] start=(2:0) end=(3:0)>
+#<Herb::Token type="TOKEN_EOF" value="<EOF>" range=[2, 2] start=(3:0) end=(3:0)>

--- a/test/snapshots/lexer/newlines_test/test_0005_newline_after_space_d784fa8b6d98d27699781bd9a7cf19f0.txt
+++ b/test/snapshots/lexer/newlines_test/test_0005_newline_after_space_d784fa8b6d98d27699781bd9a7cf19f0.txt
@@ -1,3 +1,3 @@
 #<Herb::Token type="TOKEN_WHITESPACE" value=" " range=[0, 1] start=(1:0) end=(1:1)>
-#<Herb::Token type="TOKEN_NEWLINE" value="\n" range=[1, 2] start=(1:1) end=(2:1)>
-#<Herb::Token type="TOKEN_EOF" value="<EOF>" range=[2, 2] start=(2:1) end=(2:1)>
+#<Herb::Token type="TOKEN_NEWLINE" value="\n" range=[1, 2] start=(1:1) end=(2:0)>
+#<Herb::Token type="TOKEN_EOF" value="<EOF>" range=[2, 2] start=(2:0) end=(2:0)>

--- a/test/snapshots/lexer/newlines_test/test_0006_text_content_before_and_after_68423faee48fc1bab08291a512861446.txt
+++ b/test/snapshots/lexer/newlines_test/test_0006_text_content_before_and_after_68423faee48fc1bab08291a512861446.txt
@@ -1,5 +1,5 @@
 #<Herb::Token type="TOKEN_IDENTIFIER" value="Hello" range=[0, 5] start=(1:0) end=(1:5)>
-#<Herb::Token type="TOKEN_NEWLINE" value="\n" range=[5, 6] start=(1:5) end=(2:1)>
-#<Herb::Token type="TOKEN_NEWLINE" value="\n" range=[6, 7] start=(2:1) end=(3:1)>
-#<Herb::Token type="TOKEN_IDENTIFIER" value="World" range=[7, 12] start=(3:1) end=(3:6)>
-#<Herb::Token type="TOKEN_EOF" value="<EOF>" range=[12, 12] start=(3:6) end=(3:6)>
+#<Herb::Token type="TOKEN_NEWLINE" value="\n" range=[5, 6] start=(1:5) end=(2:0)>
+#<Herb::Token type="TOKEN_NEWLINE" value="\n" range=[6, 7] start=(2:0) end=(3:0)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="World" range=[7, 12] start=(3:0) end=(3:5)>
+#<Herb::Token type="TOKEN_EOF" value="<EOF>" range=[12, 12] start=(3:5) end=(3:5)>

--- a/test/snapshots/lexer/newlines_test/test_0007_newline_between_text_content_f41121a903eafadf258962abc57c8644.txt
+++ b/test/snapshots/lexer/newlines_test/test_0007_newline_between_text_content_f41121a903eafadf258962abc57c8644.txt
@@ -1,5 +1,5 @@
 #<Herb::Token type="TOKEN_IDENTIFIER" value="Hello" range=[0, 5] start=(1:0) end=(1:5)>
-#<Herb::Token type="TOKEN_NEWLINE" value="\n" range=[5, 6] start=(1:5) end=(2:1)>
-#<Herb::Token type="TOKEN_IDENTIFIER" value="World" range=[6, 11] start=(2:1) end=(2:6)>
-#<Herb::Token type="TOKEN_NEWLINE" value="\n" range=[11, 12] start=(2:6) end=(3:1)>
-#<Herb::Token type="TOKEN_EOF" value="<EOF>" range=[12, 12] start=(3:1) end=(3:1)>
+#<Herb::Token type="TOKEN_NEWLINE" value="\n" range=[5, 6] start=(1:5) end=(2:0)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="World" range=[6, 11] start=(2:0) end=(2:5)>
+#<Herb::Token type="TOKEN_NEWLINE" value="\n" range=[11, 12] start=(2:5) end=(3:0)>
+#<Herb::Token type="TOKEN_EOF" value="<EOF>" range=[12, 12] start=(3:0) end=(3:0)>

--- a/test/snapshots/lexer/newlines_test/test_0008_newline_between_html_elements_832f3c170675c57ee6c4b54c3dc60462.txt
+++ b/test/snapshots/lexer/newlines_test/test_0008_newline_between_html_elements_832f3c170675c57ee6c4b54c3dc60462.txt
@@ -7,15 +7,15 @@
 #<Herb::Token type="TOKEN_HTML_TAG_START_CLOSE" value="</" range=[11, 13] start=(1:11) end=(1:13)>
 #<Herb::Token type="TOKEN_IDENTIFIER" value="h1" range=[13, 15] start=(1:13) end=(1:15)>
 #<Herb::Token type="TOKEN_HTML_TAG_END" value=">" range=[15, 16] start=(1:15) end=(1:16)>
-#<Herb::Token type="TOKEN_NEWLINE" value="\n" range=[16, 17] start=(1:16) end=(2:1)>
-#<Herb::Token type="TOKEN_HTML_TAG_START" value="<" range=[17, 18] start=(2:1) end=(2:2)>
-#<Herb::Token type="TOKEN_IDENTIFIER" value="h2" range=[18, 20] start=(2:2) end=(2:4)>
-#<Herb::Token type="TOKEN_HTML_TAG_END" value=">" range=[20, 21] start=(2:4) end=(2:5)>
-#<Herb::Token type="TOKEN_IDENTIFIER" value="Title" range=[21, 26] start=(2:5) end=(2:10)>
-#<Herb::Token type="TOKEN_WHITESPACE" value=" " range=[26, 27] start=(2:10) end=(2:11)>
-#<Herb::Token type="TOKEN_IDENTIFIER" value="2" range=[27, 28] start=(2:11) end=(2:12)>
-#<Herb::Token type="TOKEN_HTML_TAG_START_CLOSE" value="</" range=[28, 30] start=(2:12) end=(2:14)>
-#<Herb::Token type="TOKEN_IDENTIFIER" value="h2" range=[30, 32] start=(2:14) end=(2:16)>
-#<Herb::Token type="TOKEN_HTML_TAG_END" value=">" range=[32, 33] start=(2:16) end=(2:17)>
-#<Herb::Token type="TOKEN_NEWLINE" value="\n" range=[33, 34] start=(2:17) end=(3:1)>
-#<Herb::Token type="TOKEN_EOF" value="<EOF>" range=[34, 34] start=(3:1) end=(3:1)>
+#<Herb::Token type="TOKEN_NEWLINE" value="\n" range=[16, 17] start=(1:16) end=(2:0)>
+#<Herb::Token type="TOKEN_HTML_TAG_START" value="<" range=[17, 18] start=(2:0) end=(2:1)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="h2" range=[18, 20] start=(2:1) end=(2:3)>
+#<Herb::Token type="TOKEN_HTML_TAG_END" value=">" range=[20, 21] start=(2:3) end=(2:4)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="Title" range=[21, 26] start=(2:4) end=(2:9)>
+#<Herb::Token type="TOKEN_WHITESPACE" value=" " range=[26, 27] start=(2:9) end=(2:10)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="2" range=[27, 28] start=(2:10) end=(2:11)>
+#<Herb::Token type="TOKEN_HTML_TAG_START_CLOSE" value="</" range=[28, 30] start=(2:11) end=(2:13)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="h2" range=[30, 32] start=(2:13) end=(2:15)>
+#<Herb::Token type="TOKEN_HTML_TAG_END" value=">" range=[32, 33] start=(2:15) end=(2:16)>
+#<Herb::Token type="TOKEN_NEWLINE" value="\n" range=[33, 34] start=(2:16) end=(3:0)>
+#<Herb::Token type="TOKEN_EOF" value="<EOF>" range=[34, 34] start=(3:0) end=(3:0)>

--- a/test/snapshots/lexer/newlines_test/test_0009_newlines_between_html_elements_abaab2c016a126725eb69381cc13978a.txt
+++ b/test/snapshots/lexer/newlines_test/test_0009_newlines_between_html_elements_abaab2c016a126725eb69381cc13978a.txt
@@ -7,16 +7,16 @@
 #<Herb::Token type="TOKEN_HTML_TAG_START_CLOSE" value="</" range=[11, 13] start=(1:11) end=(1:13)>
 #<Herb::Token type="TOKEN_IDENTIFIER" value="h1" range=[13, 15] start=(1:13) end=(1:15)>
 #<Herb::Token type="TOKEN_HTML_TAG_END" value=">" range=[15, 16] start=(1:15) end=(1:16)>
-#<Herb::Token type="TOKEN_NEWLINE" value="\n" range=[16, 17] start=(1:16) end=(2:1)>
-#<Herb::Token type="TOKEN_NEWLINE" value="\n" range=[17, 18] start=(2:1) end=(3:1)>
-#<Herb::Token type="TOKEN_HTML_TAG_START" value="<" range=[18, 19] start=(3:1) end=(3:2)>
-#<Herb::Token type="TOKEN_IDENTIFIER" value="h2" range=[19, 21] start=(3:2) end=(3:4)>
-#<Herb::Token type="TOKEN_HTML_TAG_END" value=">" range=[21, 22] start=(3:4) end=(3:5)>
-#<Herb::Token type="TOKEN_IDENTIFIER" value="Title" range=[22, 27] start=(3:5) end=(3:10)>
-#<Herb::Token type="TOKEN_WHITESPACE" value=" " range=[27, 28] start=(3:10) end=(3:11)>
-#<Herb::Token type="TOKEN_IDENTIFIER" value="2" range=[28, 29] start=(3:11) end=(3:12)>
-#<Herb::Token type="TOKEN_HTML_TAG_START_CLOSE" value="</" range=[29, 31] start=(3:12) end=(3:14)>
-#<Herb::Token type="TOKEN_IDENTIFIER" value="h2" range=[31, 33] start=(3:14) end=(3:16)>
-#<Herb::Token type="TOKEN_HTML_TAG_END" value=">" range=[33, 34] start=(3:16) end=(3:17)>
-#<Herb::Token type="TOKEN_NEWLINE" value="\n" range=[34, 35] start=(3:17) end=(4:1)>
-#<Herb::Token type="TOKEN_EOF" value="<EOF>" range=[35, 35] start=(4:1) end=(4:1)>
+#<Herb::Token type="TOKEN_NEWLINE" value="\n" range=[16, 17] start=(1:16) end=(2:0)>
+#<Herb::Token type="TOKEN_NEWLINE" value="\n" range=[17, 18] start=(2:0) end=(3:0)>
+#<Herb::Token type="TOKEN_HTML_TAG_START" value="<" range=[18, 19] start=(3:0) end=(3:1)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="h2" range=[19, 21] start=(3:1) end=(3:3)>
+#<Herb::Token type="TOKEN_HTML_TAG_END" value=">" range=[21, 22] start=(3:3) end=(3:4)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="Title" range=[22, 27] start=(3:4) end=(3:9)>
+#<Herb::Token type="TOKEN_WHITESPACE" value=" " range=[27, 28] start=(3:9) end=(3:10)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="2" range=[28, 29] start=(3:10) end=(3:11)>
+#<Herb::Token type="TOKEN_HTML_TAG_START_CLOSE" value="</" range=[29, 31] start=(3:11) end=(3:13)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="h2" range=[31, 33] start=(3:13) end=(3:15)>
+#<Herb::Token type="TOKEN_HTML_TAG_END" value=">" range=[33, 34] start=(3:15) end=(3:16)>
+#<Herb::Token type="TOKEN_NEWLINE" value="\n" range=[34, 35] start=(3:16) end=(4:0)>
+#<Herb::Token type="TOKEN_EOF" value="<EOF>" range=[35, 35] start=(4:0) end=(4:0)>

--- a/test/snapshots/lexer/newlines_test/test_0010_newline_inside_html_elements_5b50a444e2f5be5630be45cec35181eb.txt
+++ b/test/snapshots/lexer/newlines_test/test_0010_newline_inside_html_elements_5b50a444e2f5be5630be45cec35181eb.txt
@@ -1,14 +1,14 @@
 #<Herb::Token type="TOKEN_HTML_TAG_START" value="<" range=[0, 1] start=(1:0) end=(1:1)>
 #<Herb::Token type="TOKEN_IDENTIFIER" value="h1" range=[1, 3] start=(1:1) end=(1:3)>
 #<Herb::Token type="TOKEN_HTML_TAG_END" value=">" range=[3, 4] start=(1:3) end=(1:4)>
-#<Herb::Token type="TOKEN_NEWLINE" value="\n" range=[4, 5] start=(1:4) end=(2:1)>
-#<Herb::Token type="TOKEN_WHITESPACE" value="  " range=[5, 7] start=(2:1) end=(2:3)>
-#<Herb::Token type="TOKEN_IDENTIFIER" value="Title" range=[7, 12] start=(2:3) end=(2:8)>
-#<Herb::Token type="TOKEN_WHITESPACE" value=" " range=[12, 13] start=(2:8) end=(2:9)>
-#<Herb::Token type="TOKEN_IDENTIFIER" value="1" range=[13, 14] start=(2:9) end=(2:10)>
-#<Herb::Token type="TOKEN_NEWLINE" value="\n" range=[14, 15] start=(2:10) end=(3:1)>
-#<Herb::Token type="TOKEN_HTML_TAG_START_CLOSE" value="</" range=[15, 17] start=(3:1) end=(3:3)>
-#<Herb::Token type="TOKEN_IDENTIFIER" value="h1" range=[17, 19] start=(3:3) end=(3:5)>
-#<Herb::Token type="TOKEN_HTML_TAG_END" value=">" range=[19, 20] start=(3:5) end=(3:6)>
-#<Herb::Token type="TOKEN_NEWLINE" value="\n" range=[20, 21] start=(3:6) end=(4:1)>
-#<Herb::Token type="TOKEN_EOF" value="<EOF>" range=[21, 21] start=(4:1) end=(4:1)>
+#<Herb::Token type="TOKEN_NEWLINE" value="\n" range=[4, 5] start=(1:4) end=(2:0)>
+#<Herb::Token type="TOKEN_WHITESPACE" value="  " range=[5, 7] start=(2:0) end=(2:2)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="Title" range=[7, 12] start=(2:2) end=(2:7)>
+#<Herb::Token type="TOKEN_WHITESPACE" value=" " range=[12, 13] start=(2:7) end=(2:8)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="1" range=[13, 14] start=(2:8) end=(2:9)>
+#<Herb::Token type="TOKEN_NEWLINE" value="\n" range=[14, 15] start=(2:9) end=(3:0)>
+#<Herb::Token type="TOKEN_HTML_TAG_START_CLOSE" value="</" range=[15, 17] start=(3:0) end=(3:2)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="h1" range=[17, 19] start=(3:2) end=(3:4)>
+#<Herb::Token type="TOKEN_HTML_TAG_END" value=">" range=[19, 20] start=(3:4) end=(3:5)>
+#<Herb::Token type="TOKEN_NEWLINE" value="\n" range=[20, 21] start=(3:5) end=(4:0)>
+#<Herb::Token type="TOKEN_EOF" value="<EOF>" range=[21, 21] start=(4:0) end=(4:0)>

--- a/test/snapshots/lexer/token_test/test_0003_multiple_whitespace_with_newlines__ff50772e7d3bdf3652ee7b345823b611.txt
+++ b/test/snapshots/lexer/token_test/test_0003_multiple_whitespace_with_newlines__ff50772e7d3bdf3652ee7b345823b611.txt
@@ -1,7 +1,7 @@
 #<Herb::Token type="TOKEN_WHITESPACE" value=" " range=[0, 1] start=(1:0) end=(1:1)>
-#<Herb::Token type="TOKEN_NEWLINE" value="\n" range=[1, 2] start=(1:1) end=(2:1)>
-#<Herb::Token type="TOKEN_WHITESPACE" value="  " range=[2, 4] start=(2:1) end=(2:3)>
-#<Herb::Token type="TOKEN_NEWLINE" value="\n" range=[4, 5] start=(2:3) end=(3:1)>
-#<Herb::Token type="TOKEN_WHITESPACE" value="   " range=[5, 8] start=(3:1) end=(3:4)>
-#<Herb::Token type="TOKEN_NEWLINE" value="\n" range=[8, 9] start=(3:4) end=(4:1)>
-#<Herb::Token type="TOKEN_EOF" value="<EOF>" range=[9, 9] start=(4:1) end=(4:1)>
+#<Herb::Token type="TOKEN_NEWLINE" value="\n" range=[1, 2] start=(1:1) end=(2:0)>
+#<Herb::Token type="TOKEN_WHITESPACE" value="  " range=[2, 4] start=(2:0) end=(2:2)>
+#<Herb::Token type="TOKEN_NEWLINE" value="\n" range=[4, 5] start=(2:2) end=(3:0)>
+#<Herb::Token type="TOKEN_WHITESPACE" value="   " range=[5, 8] start=(3:0) end=(3:3)>
+#<Herb::Token type="TOKEN_NEWLINE" value="\n" range=[8, 9] start=(3:3) end=(4:0)>
+#<Herb::Token type="TOKEN_EOF" value="<EOF>" range=[9, 9] start=(4:0) end=(4:0)>

--- a/test/snapshots/lexer/token_test/test_0005_newline_68b329da9893e34099c7d8ad5cb9c940.txt
+++ b/test/snapshots/lexer/token_test/test_0005_newline_68b329da9893e34099c7d8ad5cb9c940.txt
@@ -1,2 +1,2 @@
-#<Herb::Token type="TOKEN_NEWLINE" value="\n" range=[0, 1] start=(1:0) end=(2:1)>
-#<Herb::Token type="TOKEN_EOF" value="<EOF>" range=[1, 1] start=(2:1) end=(2:1)>
+#<Herb::Token type="TOKEN_NEWLINE" value="\n" range=[0, 1] start=(1:0) end=(2:0)>
+#<Herb::Token type="TOKEN_EOF" value="<EOF>" range=[1, 1] start=(2:0) end=(2:0)>

--- a/test/snapshots/parser/comments_test/test_0004_HTML_comment_followed_by_html_tag_with_nested_comment_f4042eb3e6a5d62fcc86e4162fe10cf2.txt
+++ b/test/snapshots/parser/comments_test/test_0004_HTML_comment_followed_by_html_tag_with_nested_comment_f4042eb3e6a5d62fcc86e4162fe10cf2.txt
@@ -1,46 +1,46 @@
-@ DocumentNode (location: (1:0)-(4:7))
+@ DocumentNode (location: (1:0)-(4:6))
 └── children: (5 items)
-    ├── @ HTMLTextNode (location: (1:0)-(2:9))
+    ├── @ HTMLTextNode (location: (1:0)-(2:8))
     │   └── content: "\n        "
     │
-    ├── @ HTMLCommentNode (location: (2:9)-(2:27))
-    │   ├── comment_start: "<!--" (location: (2:9)-(2:13))
+    ├── @ HTMLCommentNode (location: (2:8)-(2:26))
+    │   ├── comment_start: "<!--" (location: (2:8)-(2:12))
     │   ├── children: (1 item)
-    │   │   └── @ LiteralNode (location: (2:13)-(2:24))
+    │   │   └── @ LiteralNode (location: (2:12)-(2:23))
     │   │       └── content: "Hello World"
     │   │
-    │   └── comment_end: "-->" (location: (2:24)-(2:27))
+    │   └── comment_end: "-->" (location: (2:23)-(2:26))
     │
-    ├── @ HTMLTextNode (location: (2:27)-(3:9))
+    ├── @ HTMLTextNode (location: (2:26)-(3:8))
     │   └── content: "\n        "
     │
-    ├── @ HTMLElementNode (location: (3:9)-(3:38))
+    ├── @ HTMLElementNode (location: (3:8)-(3:37))
     │   ├── open_tag:
-    │   │   └── @ HTMLOpenTagNode (location: (3:9)-(3:13))
-    │   │       ├── tag_opening: "<" (location: (3:9)-(3:10))
-    │   │       ├── tag_name: "h1" (location: (3:10)-(3:12))
+    │   │   └── @ HTMLOpenTagNode (location: (3:8)-(3:12))
+    │   │       ├── tag_opening: "<" (location: (3:8)-(3:9))
+    │   │       ├── tag_name: "h1" (location: (3:9)-(3:11))
     │   │       ├── attributes: []
-    │   │       ├── tag_closing: ">" (location: (3:12)-(3:13))
+    │   │       ├── tag_closing: ">" (location: (3:11)-(3:12))
     │   │       ├── children: []
     │   │       └── is_void: false
     │   │
-    │   ├── tag_name: "h1" (location: (3:10)-(3:12))
+    │   ├── tag_name: "h1" (location: (3:9)-(3:11))
     │   ├── body: (1 item)
-    │   │   └── @ HTMLCommentNode (location: (3:13)-(3:33))
-    │   │       ├── comment_start: "<!--" (location: (3:13)-(3:17))
+    │   │   └── @ HTMLCommentNode (location: (3:12)-(3:32))
+    │   │       ├── comment_start: "<!--" (location: (3:12)-(3:16))
     │   │       ├── children: (1 item)
-    │   │       │   └── @ LiteralNode (location: (3:17)-(3:30))
+    │   │       │   └── @ LiteralNode (location: (3:16)-(3:29))
     │   │       │       └── content: " Hello World "
     │   │       │
-    │   │       └── comment_end: "-->" (location: (3:30)-(3:33))
+    │   │       └── comment_end: "-->" (location: (3:29)-(3:32))
     │   │
     │   ├── close_tag:
-    │   │   └── @ HTMLCloseTagNode (location: (3:33)-(3:38))
-    │   │       ├── tag_opening: "</" (location: (3:33)-(3:35))
-    │   │       ├── tag_name: "h1" (location: (3:35)-(3:37))
-    │   │       └── tag_closing: ">" (location: (3:37)-(3:38))
+    │   │   └── @ HTMLCloseTagNode (location: (3:32)-(3:37))
+    │   │       ├── tag_opening: "</" (location: (3:32)-(3:34))
+    │   │       ├── tag_name: "h1" (location: (3:34)-(3:36))
+    │   │       └── tag_closing: ">" (location: (3:36)-(3:37))
     │   │
     │   └── is_void: false
     │
-    └── @ HTMLTextNode (location: (3:38)-(4:7))
+    └── @ HTMLTextNode (location: (3:37)-(4:6))
         └── content: "\n      "

--- a/test/snapshots/parser/newlines_test/test_0001_line_feed_68b329da9893e34099c7d8ad5cb9c940.txt
+++ b/test/snapshots/parser/newlines_test/test_0001_line_feed_68b329da9893e34099c7d8ad5cb9c940.txt
@@ -1,4 +1,4 @@
-@ DocumentNode (location: (1:0)-(2:1))
+@ DocumentNode (location: (1:0)-(2:0))
 └── children: (1 item)
-    └── @ HTMLTextNode (location: (1:0)-(2:1))
+    └── @ HTMLTextNode (location: (1:0)-(2:0))
         └── content: "\n"

--- a/test/snapshots/parser/newlines_test/test_0002_carriage_return_dcb9be2f604e5df91deb9659bed4748d.txt
+++ b/test/snapshots/parser/newlines_test/test_0002_carriage_return_dcb9be2f604e5df91deb9659bed4748d.txt
@@ -1,4 +1,4 @@
-@ DocumentNode (location: (1:0)-(2:1))
+@ DocumentNode (location: (1:0)-(2:0))
 └── children: (1 item)
-    └── @ HTMLTextNode (location: (1:0)-(2:1))
+    └── @ HTMLTextNode (location: (1:0)-(2:0))
         └── content: "\r"

--- a/test/snapshots/parser/newlines_test/test_0003_carriage_return_and_line_feed_81051bcc2cf1bedf378224b0a93e2877.txt
+++ b/test/snapshots/parser/newlines_test/test_0003_carriage_return_and_line_feed_81051bcc2cf1bedf378224b0a93e2877.txt
@@ -1,4 +1,4 @@
-@ DocumentNode (location: (1:0)-(2:1))
+@ DocumentNode (location: (1:0)-(2:0))
 └── children: (1 item)
-    └── @ HTMLTextNode (location: (1:0)-(2:1))
+    └── @ HTMLTextNode (location: (1:0)-(2:0))
         └── content: "\r\n"

--- a/test/snapshots/parser/newlines_test/test_0004_two_newlines_e1c06d85ae7b8b032bef47e42e4c08f9.txt
+++ b/test/snapshots/parser/newlines_test/test_0004_two_newlines_e1c06d85ae7b8b032bef47e42e4c08f9.txt
@@ -1,4 +1,4 @@
-@ DocumentNode (location: (1:0)-(3:1))
+@ DocumentNode (location: (1:0)-(3:0))
 └── children: (1 item)
-    └── @ HTMLTextNode (location: (1:0)-(3:1))
+    └── @ HTMLTextNode (location: (1:0)-(3:0))
         └── content: "\n\n"

--- a/test/snapshots/parser/newlines_test/test_0005_newline_after_space_d784fa8b6d98d27699781bd9a7cf19f0.txt
+++ b/test/snapshots/parser/newlines_test/test_0005_newline_after_space_d784fa8b6d98d27699781bd9a7cf19f0.txt
@@ -1,4 +1,4 @@
-@ DocumentNode (location: (1:0)-(2:1))
+@ DocumentNode (location: (1:0)-(2:0))
 └── children: (1 item)
-    └── @ HTMLTextNode (location: (1:0)-(2:1))
+    └── @ HTMLTextNode (location: (1:0)-(2:0))
         └── content: " \n"

--- a/test/snapshots/parser/newlines_test/test_0006_text_content_before_and_after_68423faee48fc1bab08291a512861446.txt
+++ b/test/snapshots/parser/newlines_test/test_0006_text_content_before_and_after_68423faee48fc1bab08291a512861446.txt
@@ -1,4 +1,4 @@
-@ DocumentNode (location: (1:0)-(3:6))
+@ DocumentNode (location: (1:0)-(3:5))
 └── children: (1 item)
-    └── @ HTMLTextNode (location: (1:0)-(3:6))
+    └── @ HTMLTextNode (location: (1:0)-(3:5))
         └── content: "Hello\n\nWorld"

--- a/test/snapshots/parser/newlines_test/test_0007_newline_between_text_content_f41121a903eafadf258962abc57c8644.txt
+++ b/test/snapshots/parser/newlines_test/test_0007_newline_between_text_content_f41121a903eafadf258962abc57c8644.txt
@@ -1,5 +1,5 @@
 #<Herb::Token type="TOKEN_IDENTIFIER" value="Hello" range=[0, 5] start=(1:0) end=(1:5)>
-#<Herb::Token type="TOKEN_NEWLINE" value="\n" range=[5, 6] start=(1:5) end=(2:1)>
-#<Herb::Token type="TOKEN_IDENTIFIER" value="World" range=[6, 11] start=(2:1) end=(2:6)>
-#<Herb::Token type="TOKEN_NEWLINE" value="\n" range=[11, 12] start=(2:6) end=(3:1)>
-#<Herb::Token type="TOKEN_EOF" value="<EOF>" range=[12, 12] start=(3:1) end=(3:1)>
+#<Herb::Token type="TOKEN_NEWLINE" value="\n" range=[5, 6] start=(1:5) end=(2:0)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="World" range=[6, 11] start=(2:0) end=(2:5)>
+#<Herb::Token type="TOKEN_NEWLINE" value="\n" range=[11, 12] start=(2:5) end=(3:0)>
+#<Herb::Token type="TOKEN_EOF" value="<EOF>" range=[12, 12] start=(3:0) end=(3:0)>

--- a/test/snapshots/parser/newlines_test/test_0008_newline_between_html_elements_832f3c170675c57ee6c4b54c3dc60462.txt
+++ b/test/snapshots/parser/newlines_test/test_0008_newline_between_html_elements_832f3c170675c57ee6c4b54c3dc60462.txt
@@ -1,4 +1,4 @@
-@ DocumentNode (location: (1:0)-(3:1))
+@ DocumentNode (location: (1:0)-(3:0))
 └── children: (4 items)
     ├── @ HTMLElementNode (location: (1:0)-(1:16))
     │   ├── open_tag:
@@ -23,31 +23,31 @@
     │   │
     │   └── is_void: false
     │
-    ├── @ HTMLTextNode (location: (1:16)-(2:1))
+    ├── @ HTMLTextNode (location: (1:16)-(2:0))
     │   └── content: "\n"
     │
-    ├── @ HTMLElementNode (location: (2:1)-(2:17))
+    ├── @ HTMLElementNode (location: (2:0)-(2:16))
     │   ├── open_tag:
-    │   │   └── @ HTMLOpenTagNode (location: (2:1)-(2:5))
-    │   │       ├── tag_opening: "<" (location: (2:1)-(2:2))
-    │   │       ├── tag_name: "h2" (location: (2:2)-(2:4))
+    │   │   └── @ HTMLOpenTagNode (location: (2:0)-(2:4))
+    │   │       ├── tag_opening: "<" (location: (2:0)-(2:1))
+    │   │       ├── tag_name: "h2" (location: (2:1)-(2:3))
     │   │       ├── attributes: []
-    │   │       ├── tag_closing: ">" (location: (2:4)-(2:5))
+    │   │       ├── tag_closing: ">" (location: (2:3)-(2:4))
     │   │       ├── children: []
     │   │       └── is_void: false
     │   │
-    │   ├── tag_name: "h2" (location: (2:2)-(2:4))
+    │   ├── tag_name: "h2" (location: (2:1)-(2:3))
     │   ├── body: (1 item)
-    │   │   └── @ HTMLTextNode (location: (2:5)-(2:12))
+    │   │   └── @ HTMLTextNode (location: (2:4)-(2:11))
     │   │       └── content: "Title 2"
     │   │
     │   ├── close_tag:
-    │   │   └── @ HTMLCloseTagNode (location: (2:12)-(2:17))
-    │   │       ├── tag_opening: "</" (location: (2:12)-(2:14))
-    │   │       ├── tag_name: "h2" (location: (2:14)-(2:16))
-    │   │       └── tag_closing: ">" (location: (2:16)-(2:17))
+    │   │   └── @ HTMLCloseTagNode (location: (2:11)-(2:16))
+    │   │       ├── tag_opening: "</" (location: (2:11)-(2:13))
+    │   │       ├── tag_name: "h2" (location: (2:13)-(2:15))
+    │   │       └── tag_closing: ">" (location: (2:15)-(2:16))
     │   │
     │   └── is_void: false
     │
-    └── @ HTMLTextNode (location: (2:17)-(3:1))
+    └── @ HTMLTextNode (location: (2:16)-(3:0))
         └── content: "\n"

--- a/test/snapshots/parser/newlines_test/test_0009_newlines_between_html_elements_abaab2c016a126725eb69381cc13978a.txt
+++ b/test/snapshots/parser/newlines_test/test_0009_newlines_between_html_elements_abaab2c016a126725eb69381cc13978a.txt
@@ -1,4 +1,4 @@
-@ DocumentNode (location: (1:0)-(4:1))
+@ DocumentNode (location: (1:0)-(4:0))
 └── children: (4 items)
     ├── @ HTMLElementNode (location: (1:0)-(1:16))
     │   ├── open_tag:
@@ -23,31 +23,31 @@
     │   │
     │   └── is_void: false
     │
-    ├── @ HTMLTextNode (location: (1:16)-(3:1))
+    ├── @ HTMLTextNode (location: (1:16)-(3:0))
     │   └── content: "\n\n"
     │
-    ├── @ HTMLElementNode (location: (3:1)-(3:17))
+    ├── @ HTMLElementNode (location: (3:0)-(3:16))
     │   ├── open_tag:
-    │   │   └── @ HTMLOpenTagNode (location: (3:1)-(3:5))
-    │   │       ├── tag_opening: "<" (location: (3:1)-(3:2))
-    │   │       ├── tag_name: "h2" (location: (3:2)-(3:4))
+    │   │   └── @ HTMLOpenTagNode (location: (3:0)-(3:4))
+    │   │       ├── tag_opening: "<" (location: (3:0)-(3:1))
+    │   │       ├── tag_name: "h2" (location: (3:1)-(3:3))
     │   │       ├── attributes: []
-    │   │       ├── tag_closing: ">" (location: (3:4)-(3:5))
+    │   │       ├── tag_closing: ">" (location: (3:3)-(3:4))
     │   │       ├── children: []
     │   │       └── is_void: false
     │   │
-    │   ├── tag_name: "h2" (location: (3:2)-(3:4))
+    │   ├── tag_name: "h2" (location: (3:1)-(3:3))
     │   ├── body: (1 item)
-    │   │   └── @ HTMLTextNode (location: (3:5)-(3:12))
+    │   │   └── @ HTMLTextNode (location: (3:4)-(3:11))
     │   │       └── content: "Title 2"
     │   │
     │   ├── close_tag:
-    │   │   └── @ HTMLCloseTagNode (location: (3:12)-(3:17))
-    │   │       ├── tag_opening: "</" (location: (3:12)-(3:14))
-    │   │       ├── tag_name: "h2" (location: (3:14)-(3:16))
-    │   │       └── tag_closing: ">" (location: (3:16)-(3:17))
+    │   │   └── @ HTMLCloseTagNode (location: (3:11)-(3:16))
+    │   │       ├── tag_opening: "</" (location: (3:11)-(3:13))
+    │   │       ├── tag_name: "h2" (location: (3:13)-(3:15))
+    │   │       └── tag_closing: ">" (location: (3:15)-(3:16))
     │   │
     │   └── is_void: false
     │
-    └── @ HTMLTextNode (location: (3:17)-(4:1))
+    └── @ HTMLTextNode (location: (3:16)-(4:0))
         └── content: "\n"

--- a/test/snapshots/parser/newlines_test/test_0010_newline_inside_html_elements_5b50a444e2f5be5630be45cec35181eb.txt
+++ b/test/snapshots/parser/newlines_test/test_0010_newline_inside_html_elements_5b50a444e2f5be5630be45cec35181eb.txt
@@ -1,6 +1,6 @@
-@ DocumentNode (location: (1:0)-(4:1))
+@ DocumentNode (location: (1:0)-(4:0))
 └── children: (2 items)
-    ├── @ HTMLElementNode (location: (1:0)-(3:6))
+    ├── @ HTMLElementNode (location: (1:0)-(3:5))
     │   ├── open_tag:
     │   │   └── @ HTMLOpenTagNode (location: (1:0)-(1:4))
     │   │       ├── tag_opening: "<" (location: (1:0)-(1:1))
@@ -12,16 +12,16 @@
     │   │
     │   ├── tag_name: "h1" (location: (1:1)-(1:3))
     │   ├── body: (1 item)
-    │   │   └── @ HTMLTextNode (location: (1:4)-(3:1))
+    │   │   └── @ HTMLTextNode (location: (1:4)-(3:0))
     │   │       └── content: "\n  Title 1\n"
     │   │
     │   ├── close_tag:
-    │   │   └── @ HTMLCloseTagNode (location: (3:1)-(3:6))
-    │   │       ├── tag_opening: "</" (location: (3:1)-(3:3))
-    │   │       ├── tag_name: "h1" (location: (3:3)-(3:5))
-    │   │       └── tag_closing: ">" (location: (3:5)-(3:6))
+    │   │   └── @ HTMLCloseTagNode (location: (3:0)-(3:5))
+    │   │       ├── tag_opening: "</" (location: (3:0)-(3:2))
+    │   │       ├── tag_name: "h1" (location: (3:2)-(3:4))
+    │   │       └── tag_closing: ">" (location: (3:4)-(3:5))
     │   │
     │   └── is_void: false
     │
-    └── @ HTMLTextNode (location: (3:6)-(4:1))
+    └── @ HTMLTextNode (location: (3:5)-(4:0))
         └── content: "\n"

--- a/test/snapshots/parser/svg_test/test_0002_svg_with_void_path_element_cf28475021c890620282e29c683e5d2c.txt
+++ b/test/snapshots/parser/svg_test/test_0002_svg_with_void_path_element_cf28475021c890620282e29c683e5d2c.txt
@@ -1,6 +1,6 @@
-@ DocumentNode (location: (1:0)-(4:1))
+@ DocumentNode (location: (1:0)-(4:0))
 └── children: (2 items)
-    ├── @ HTMLElementNode (location: (1:0)-(3:7))
+    ├── @ HTMLElementNode (location: (1:0)-(3:6))
     │   ├── open_tag:
     │   │   └── @ HTMLOpenTagNode (location: (1:0)-(1:5))
     │   │       ├── tag_opening: "<" (location: (1:0)-(1:1))
@@ -12,34 +12,34 @@
     │   │
     │   ├── tag_name: "svg" (location: (1:1)-(1:4))
     │   ├── body: (3 items)
-    │   │   ├── @ HTMLTextNode (location: (1:5)-(2:3))
+    │   │   ├── @ HTMLTextNode (location: (1:5)-(2:2))
     │   │   │   └── content: "\n  "
     │   │   │
-    │   │   ├── @ HTMLElementNode (location: (2:3)-(2:11))
+    │   │   ├── @ HTMLElementNode (location: (2:2)-(2:10))
     │   │   │   ├── open_tag:
-    │   │   │   │   └── @ HTMLOpenTagNode (location: (2:3)-(2:11))
-    │   │   │   │       ├── tag_opening: "<" (location: (2:3)-(2:4))
-    │   │   │   │       ├── tag_name: "path" (location: (2:4)-(2:8))
+    │   │   │   │   └── @ HTMLOpenTagNode (location: (2:2)-(2:10))
+    │   │   │   │       ├── tag_opening: "<" (location: (2:2)-(2:3))
+    │   │   │   │       ├── tag_name: "path" (location: (2:3)-(2:7))
     │   │   │   │       ├── attributes: []
-    │   │   │   │       ├── tag_closing: "/>" (location: (2:9)-(2:11))
+    │   │   │   │       ├── tag_closing: "/>" (location: (2:8)-(2:10))
     │   │   │   │       ├── children: []
     │   │   │   │       └── is_void: true
     │   │   │   │
-    │   │   │   ├── tag_name: "path" (location: (2:4)-(2:8))
+    │   │   │   ├── tag_name: "path" (location: (2:3)-(2:7))
     │   │   │   ├── body: []
     │   │   │   ├── close_tag: ∅
     │   │   │   └── is_void: true
     │   │   │
-    │   │   └── @ HTMLTextNode (location: (2:11)-(3:1))
+    │   │   └── @ HTMLTextNode (location: (2:10)-(3:0))
     │   │       └── content: "\n"
     │   │
     │   ├── close_tag:
-    │   │   └── @ HTMLCloseTagNode (location: (3:1)-(3:7))
-    │   │       ├── tag_opening: "</" (location: (3:1)-(3:3))
-    │   │       ├── tag_name: "svg" (location: (3:3)-(3:6))
-    │   │       └── tag_closing: ">" (location: (3:6)-(3:7))
+    │   │   └── @ HTMLCloseTagNode (location: (3:0)-(3:6))
+    │   │       ├── tag_opening: "</" (location: (3:0)-(3:2))
+    │   │       ├── tag_name: "svg" (location: (3:2)-(3:5))
+    │   │       └── tag_closing: ">" (location: (3:5)-(3:6))
     │   │
     │   └── is_void: false
     │
-    └── @ HTMLTextNode (location: (3:7)-(4:1))
+    └── @ HTMLTextNode (location: (3:6)-(4:0))
         └── content: "\n"

--- a/test/snapshots/parser/svg_test/test_0003_svg_with_non-void_path_element_f3bf2c27b88d669126ee1c419f491e08.txt
+++ b/test/snapshots/parser/svg_test/test_0003_svg_with_non-void_path_element_f3bf2c27b88d669126ee1c419f491e08.txt
@@ -1,6 +1,6 @@
-@ DocumentNode (location: (1:0)-(4:1))
+@ DocumentNode (location: (1:0)-(4:0))
 └── children: (2 items)
-    ├── @ HTMLElementNode (location: (1:0)-(3:7))
+    ├── @ HTMLElementNode (location: (1:0)-(3:6))
     │   ├── open_tag:
     │   │   └── @ HTMLOpenTagNode (location: (1:0)-(1:5))
     │   │       ├── tag_opening: "<" (location: (1:0)-(1:1))
@@ -12,39 +12,39 @@
     │   │
     │   ├── tag_name: "svg" (location: (1:1)-(1:4))
     │   ├── body: (3 items)
-    │   │   ├── @ HTMLTextNode (location: (1:5)-(2:3))
+    │   │   ├── @ HTMLTextNode (location: (1:5)-(2:2))
     │   │   │   └── content: "\n  "
     │   │   │
-    │   │   ├── @ HTMLElementNode (location: (2:3)-(2:16))
+    │   │   ├── @ HTMLElementNode (location: (2:2)-(2:15))
     │   │   │   ├── open_tag:
-    │   │   │   │   └── @ HTMLOpenTagNode (location: (2:3)-(2:9))
-    │   │   │   │       ├── tag_opening: "<" (location: (2:3)-(2:4))
-    │   │   │   │       ├── tag_name: "path" (location: (2:4)-(2:8))
+    │   │   │   │   └── @ HTMLOpenTagNode (location: (2:2)-(2:8))
+    │   │   │   │       ├── tag_opening: "<" (location: (2:2)-(2:3))
+    │   │   │   │       ├── tag_name: "path" (location: (2:3)-(2:7))
     │   │   │   │       ├── attributes: []
-    │   │   │   │       ├── tag_closing: ">" (location: (2:8)-(2:9))
+    │   │   │   │       ├── tag_closing: ">" (location: (2:7)-(2:8))
     │   │   │   │       ├── children: []
     │   │   │   │       └── is_void: false
     │   │   │   │
-    │   │   │   ├── tag_name: "path" (location: (2:4)-(2:8))
+    │   │   │   ├── tag_name: "path" (location: (2:3)-(2:7))
     │   │   │   ├── body: []
     │   │   │   ├── close_tag:
-    │   │   │   │   └── @ HTMLCloseTagNode (location: (2:9)-(2:16))
-    │   │   │   │       ├── tag_opening: "</" (location: (2:9)-(2:11))
-    │   │   │   │       ├── tag_name: "path" (location: (2:11)-(2:15))
-    │   │   │   │       └── tag_closing: ">" (location: (2:15)-(2:16))
+    │   │   │   │   └── @ HTMLCloseTagNode (location: (2:8)-(2:15))
+    │   │   │   │       ├── tag_opening: "</" (location: (2:8)-(2:10))
+    │   │   │   │       ├── tag_name: "path" (location: (2:10)-(2:14))
+    │   │   │   │       └── tag_closing: ">" (location: (2:14)-(2:15))
     │   │   │   │
     │   │   │   └── is_void: false
     │   │   │
-    │   │   └── @ HTMLTextNode (location: (2:16)-(3:1))
+    │   │   └── @ HTMLTextNode (location: (2:15)-(3:0))
     │   │       └── content: "\n"
     │   │
     │   ├── close_tag:
-    │   │   └── @ HTMLCloseTagNode (location: (3:1)-(3:7))
-    │   │       ├── tag_opening: "</" (location: (3:1)-(3:3))
-    │   │       ├── tag_name: "svg" (location: (3:3)-(3:6))
-    │   │       └── tag_closing: ">" (location: (3:6)-(3:7))
+    │   │   └── @ HTMLCloseTagNode (location: (3:0)-(3:6))
+    │   │       ├── tag_opening: "</" (location: (3:0)-(3:2))
+    │   │       ├── tag_name: "svg" (location: (3:2)-(3:5))
+    │   │       └── tag_closing: ">" (location: (3:5)-(3:6))
     │   │
     │   └── is_void: false
     │
-    └── @ HTMLTextNode (location: (3:7)-(4:1))
+    └── @ HTMLTextNode (location: (3:6)-(4:0))
         └── content: "\n"

--- a/test/snapshots/parser/svg_test/test_0004_svg_with_nested_void_path_element_da5904bd14662799ee327966686eafdf.txt
+++ b/test/snapshots/parser/svg_test/test_0004_svg_with_nested_void_path_element_da5904bd14662799ee327966686eafdf.txt
@@ -1,6 +1,6 @@
-@ DocumentNode (location: (1:0)-(6:1))
+@ DocumentNode (location: (1:0)-(6:0))
 └── children: (2 items)
-    ├── @ HTMLElementNode (location: (1:0)-(5:7))
+    ├── @ HTMLElementNode (location: (1:0)-(5:6))
     │   ├── open_tag:
     │   │   └── @ HTMLOpenTagNode (location: (1:0)-(1:5))
     │   │       ├── tag_opening: "<" (location: (1:0)-(1:1))
@@ -12,60 +12,60 @@
     │   │
     │   ├── tag_name: "svg" (location: (1:1)-(1:4))
     │   ├── body: (3 items)
-    │   │   ├── @ HTMLTextNode (location: (1:5)-(2:3))
+    │   │   ├── @ HTMLTextNode (location: (1:5)-(2:2))
     │   │   │   └── content: "\n  "
     │   │   │
-    │   │   ├── @ HTMLElementNode (location: (2:3)-(4:7))
+    │   │   ├── @ HTMLElementNode (location: (2:2)-(4:6))
     │   │   │   ├── open_tag:
-    │   │   │   │   └── @ HTMLOpenTagNode (location: (2:3)-(2:6))
-    │   │   │   │       ├── tag_opening: "<" (location: (2:3)-(2:4))
-    │   │   │   │       ├── tag_name: "g" (location: (2:4)-(2:5))
+    │   │   │   │   └── @ HTMLOpenTagNode (location: (2:2)-(2:5))
+    │   │   │   │       ├── tag_opening: "<" (location: (2:2)-(2:3))
+    │   │   │   │       ├── tag_name: "g" (location: (2:3)-(2:4))
     │   │   │   │       ├── attributes: []
-    │   │   │   │       ├── tag_closing: ">" (location: (2:5)-(2:6))
+    │   │   │   │       ├── tag_closing: ">" (location: (2:4)-(2:5))
     │   │   │   │       ├── children: []
     │   │   │   │       └── is_void: false
     │   │   │   │
-    │   │   │   ├── tag_name: "g" (location: (2:4)-(2:5))
+    │   │   │   ├── tag_name: "g" (location: (2:3)-(2:4))
     │   │   │   ├── body: (3 items)
-    │   │   │   │   ├── @ HTMLTextNode (location: (2:6)-(3:5))
+    │   │   │   │   ├── @ HTMLTextNode (location: (2:5)-(3:4))
     │   │   │   │   │   └── content: "\n    "
     │   │   │   │   │
-    │   │   │   │   ├── @ HTMLElementNode (location: (3:5)-(3:12))
+    │   │   │   │   ├── @ HTMLElementNode (location: (3:4)-(3:11))
     │   │   │   │   │   ├── open_tag:
-    │   │   │   │   │   │   └── @ HTMLOpenTagNode (location: (3:5)-(3:12))
-    │   │   │   │   │   │       ├── tag_opening: "<" (location: (3:5)-(3:6))
-    │   │   │   │   │   │       ├── tag_name: "path" (location: (3:6)-(3:10))
+    │   │   │   │   │   │   └── @ HTMLOpenTagNode (location: (3:4)-(3:11))
+    │   │   │   │   │   │       ├── tag_opening: "<" (location: (3:4)-(3:5))
+    │   │   │   │   │   │       ├── tag_name: "path" (location: (3:5)-(3:9))
     │   │   │   │   │   │       ├── attributes: []
-    │   │   │   │   │   │       ├── tag_closing: "/>" (location: (3:10)-(3:12))
+    │   │   │   │   │   │       ├── tag_closing: "/>" (location: (3:9)-(3:11))
     │   │   │   │   │   │       ├── children: []
     │   │   │   │   │   │       └── is_void: true
     │   │   │   │   │   │
-    │   │   │   │   │   ├── tag_name: "path" (location: (3:6)-(3:10))
+    │   │   │   │   │   ├── tag_name: "path" (location: (3:5)-(3:9))
     │   │   │   │   │   ├── body: []
     │   │   │   │   │   ├── close_tag: ∅
     │   │   │   │   │   └── is_void: true
     │   │   │   │   │
-    │   │   │   │   └── @ HTMLTextNode (location: (3:12)-(4:3))
+    │   │   │   │   └── @ HTMLTextNode (location: (3:11)-(4:2))
     │   │   │   │       └── content: "\n  "
     │   │   │   │
     │   │   │   ├── close_tag:
-    │   │   │   │   └── @ HTMLCloseTagNode (location: (4:3)-(4:7))
-    │   │   │   │       ├── tag_opening: "</" (location: (4:3)-(4:5))
-    │   │   │   │       ├── tag_name: "g" (location: (4:5)-(4:6))
-    │   │   │   │       └── tag_closing: ">" (location: (4:6)-(4:7))
+    │   │   │   │   └── @ HTMLCloseTagNode (location: (4:2)-(4:6))
+    │   │   │   │       ├── tag_opening: "</" (location: (4:2)-(4:4))
+    │   │   │   │       ├── tag_name: "g" (location: (4:4)-(4:5))
+    │   │   │   │       └── tag_closing: ">" (location: (4:5)-(4:6))
     │   │   │   │
     │   │   │   └── is_void: false
     │   │   │
-    │   │   └── @ HTMLTextNode (location: (4:7)-(5:1))
+    │   │   └── @ HTMLTextNode (location: (4:6)-(5:0))
     │   │       └── content: "\n"
     │   │
     │   ├── close_tag:
-    │   │   └── @ HTMLCloseTagNode (location: (5:1)-(5:7))
-    │   │       ├── tag_opening: "</" (location: (5:1)-(5:3))
-    │   │       ├── tag_name: "svg" (location: (5:3)-(5:6))
-    │   │       └── tag_closing: ">" (location: (5:6)-(5:7))
+    │   │   └── @ HTMLCloseTagNode (location: (5:0)-(5:6))
+    │   │       ├── tag_opening: "</" (location: (5:0)-(5:2))
+    │   │       ├── tag_name: "svg" (location: (5:2)-(5:5))
+    │   │       └── tag_closing: ">" (location: (5:5)-(5:6))
     │   │
     │   └── is_void: false
     │
-    └── @ HTMLTextNode (location: (5:7)-(6:1))
+    └── @ HTMLTextNode (location: (5:6)-(6:0))
         └── content: "\n"

--- a/test/snapshots/parser/svg_test/test_0005_HTML_void_can_be_non-void_within_svg_1072d4c2f81d845d5c1f0fd86e40e23b.txt
+++ b/test/snapshots/parser/svg_test/test_0005_HTML_void_can_be_non-void_within_svg_1072d4c2f81d845d5c1f0fd86e40e23b.txt
@@ -1,6 +1,6 @@
-@ DocumentNode (location: (1:0)-(4:1))
+@ DocumentNode (location: (1:0)-(4:0))
 └── children: (2 items)
-    ├── @ HTMLElementNode (location: (1:0)-(3:7))
+    ├── @ HTMLElementNode (location: (1:0)-(3:6))
     │   ├── open_tag:
     │   │   └── @ HTMLOpenTagNode (location: (1:0)-(1:5))
     │   │       ├── tag_opening: "<" (location: (1:0)-(1:1))
@@ -12,39 +12,39 @@
     │   │
     │   ├── tag_name: "svg" (location: (1:1)-(1:4))
     │   ├── body: (3 items)
-    │   │   ├── @ HTMLTextNode (location: (1:5)-(2:3))
+    │   │   ├── @ HTMLTextNode (location: (1:5)-(2:2))
     │   │   │   └── content: "\n  "
     │   │   │
-    │   │   ├── @ HTMLElementNode (location: (2:3)-(2:12))
+    │   │   ├── @ HTMLElementNode (location: (2:2)-(2:11))
     │   │   │   ├── open_tag:
-    │   │   │   │   └── @ HTMLOpenTagNode (location: (2:3)-(2:7))
-    │   │   │   │       ├── tag_opening: "<" (location: (2:3)-(2:4))
-    │   │   │   │       ├── tag_name: "br" (location: (2:4)-(2:6))
+    │   │   │   │   └── @ HTMLOpenTagNode (location: (2:2)-(2:6))
+    │   │   │   │       ├── tag_opening: "<" (location: (2:2)-(2:3))
+    │   │   │   │       ├── tag_name: "br" (location: (2:3)-(2:5))
     │   │   │   │       ├── attributes: []
-    │   │   │   │       ├── tag_closing: ">" (location: (2:6)-(2:7))
+    │   │   │   │       ├── tag_closing: ">" (location: (2:5)-(2:6))
     │   │   │   │       ├── children: []
     │   │   │   │       └── is_void: false
     │   │   │   │
-    │   │   │   ├── tag_name: "br" (location: (2:4)-(2:6))
+    │   │   │   ├── tag_name: "br" (location: (2:3)-(2:5))
     │   │   │   ├── body: []
     │   │   │   ├── close_tag:
-    │   │   │   │   └── @ HTMLCloseTagNode (location: (2:7)-(2:12))
-    │   │   │   │       ├── tag_opening: "</" (location: (2:7)-(2:9))
-    │   │   │   │       ├── tag_name: "br" (location: (2:9)-(2:11))
-    │   │   │   │       └── tag_closing: ">" (location: (2:11)-(2:12))
+    │   │   │   │   └── @ HTMLCloseTagNode (location: (2:6)-(2:11))
+    │   │   │   │       ├── tag_opening: "</" (location: (2:6)-(2:8))
+    │   │   │   │       ├── tag_name: "br" (location: (2:8)-(2:10))
+    │   │   │   │       └── tag_closing: ">" (location: (2:10)-(2:11))
     │   │   │   │
     │   │   │   └── is_void: false
     │   │   │
-    │   │   └── @ HTMLTextNode (location: (2:12)-(3:1))
+    │   │   └── @ HTMLTextNode (location: (2:11)-(3:0))
     │   │       └── content: "\n"
     │   │
     │   ├── close_tag:
-    │   │   └── @ HTMLCloseTagNode (location: (3:1)-(3:7))
-    │   │       ├── tag_opening: "</" (location: (3:1)-(3:3))
-    │   │       ├── tag_name: "svg" (location: (3:3)-(3:6))
-    │   │       └── tag_closing: ">" (location: (3:6)-(3:7))
+    │   │   └── @ HTMLCloseTagNode (location: (3:0)-(3:6))
+    │   │       ├── tag_opening: "</" (location: (3:0)-(3:2))
+    │   │       ├── tag_name: "svg" (location: (3:2)-(3:5))
+    │   │       └── tag_closing: ">" (location: (3:5)-(3:6))
     │   │
     │   └── is_void: false
     │
-    └── @ HTMLTextNode (location: (3:7)-(4:1))
+    └── @ HTMLTextNode (location: (3:6)-(4:0))
         └── content: "\n"

--- a/test/snapshots/parser/svg_test/test_0006_svg_unclosed_element_reports_an_error_e086a53256a215470da47ef3ee745599.txt
+++ b/test/snapshots/parser/svg_test/test_0006_svg_unclosed_element_reports_an_error_e086a53256a215470da47ef3ee745599.txt
@@ -1,10 +1,10 @@
-@ DocumentNode (location: (1:0)-(4:1))
+@ DocumentNode (location: (1:0)-(4:0))
 ├── errors: (2 errors)
-│   ├── @ UnclosedElementError (location: (4:1)-(4:1))
-│   │   ├── message: "Tag `<g>` opened at (2:4) was never closed before the end of document."
-│   │   └── opening_tag: "g" (location: (2:4)-(2:5))
+│   ├── @ UnclosedElementError (location: (4:0)-(4:0))
+│   │   ├── message: "Tag `<g>` opened at (2:3) was never closed before the end of document."
+│   │   └── opening_tag: "g" (location: (2:3)-(2:4))
 │   │
-│   └── @ UnclosedElementError (location: (4:1)-(4:1))
+│   └── @ UnclosedElementError (location: (4:0)-(4:0))
 │       ├── message: "Tag `<svg>` opened at (1:1) was never closed before the end of document."
 │       └── opening_tag: "svg" (location: (1:1)-(1:4))
 │
@@ -26,39 +26,39 @@
         │
         ├── tag_name: "svg" (location: (1:1)-(1:4))
         ├── body: (3 items)
-        │   ├── @ HTMLTextNode (location: (1:5)-(2:3))
+        │   ├── @ HTMLTextNode (location: (1:5)-(2:2))
         │   │   └── content: "\n  "
         │   │
-        │   ├── @ HTMLElementNode (location: (2:3)-(3:7))
+        │   ├── @ HTMLElementNode (location: (2:2)-(3:6))
         │   │   ├── errors: (1 error)
-        │   │   │   └── @ TagNamesMismatchError (location: (3:3)-(3:6))
-        │   │   │       ├── message: "Opening tag `<g>` at (2:4) closed with `</svg>` at (3:3)."
-        │   │   │       ├── opening_tag: "g" (location: (2:4)-(2:5))
-        │   │   │       └── closing_tag: "svg" (location: (3:3)-(3:6))
+        │   │   │   └── @ TagNamesMismatchError (location: (3:2)-(3:5))
+        │   │   │       ├── message: "Opening tag `<g>` at (2:3) closed with `</svg>` at (3:2)."
+        │   │   │       ├── opening_tag: "g" (location: (2:3)-(2:4))
+        │   │   │       └── closing_tag: "svg" (location: (3:2)-(3:5))
         │   │   │
         │   │   ├── open_tag:
-        │   │   │   └── @ HTMLOpenTagNode (location: (2:3)-(2:6))
-        │   │   │       ├── tag_opening: "<" (location: (2:3)-(2:4))
-        │   │   │       ├── tag_name: "g" (location: (2:4)-(2:5))
+        │   │   │   └── @ HTMLOpenTagNode (location: (2:2)-(2:5))
+        │   │   │       ├── tag_opening: "<" (location: (2:2)-(2:3))
+        │   │   │       ├── tag_name: "g" (location: (2:3)-(2:4))
         │   │   │       ├── attributes: []
-        │   │   │       ├── tag_closing: ">" (location: (2:5)-(2:6))
+        │   │   │       ├── tag_closing: ">" (location: (2:4)-(2:5))
         │   │   │       ├── children: []
         │   │   │       └── is_void: false
         │   │   │
-        │   │   ├── tag_name: "g" (location: (2:4)-(2:5))
+        │   │   ├── tag_name: "g" (location: (2:3)-(2:4))
         │   │   ├── body: (1 item)
-        │   │   │   └── @ HTMLTextNode (location: (2:6)-(3:1))
+        │   │   │   └── @ HTMLTextNode (location: (2:5)-(3:0))
         │   │   │       └── content: "\n"
         │   │   │
         │   │   ├── close_tag:
-        │   │   │   └── @ HTMLCloseTagNode (location: (3:1)-(3:7))
-        │   │   │       ├── tag_opening: "</" (location: (3:1)-(3:3))
-        │   │   │       ├── tag_name: "svg" (location: (3:3)-(3:6))
-        │   │   │       └── tag_closing: ">" (location: (3:6)-(3:7))
+        │   │   │   └── @ HTMLCloseTagNode (location: (3:0)-(3:6))
+        │   │   │       ├── tag_opening: "</" (location: (3:0)-(3:2))
+        │   │   │       ├── tag_name: "svg" (location: (3:2)-(3:5))
+        │   │   │       └── tag_closing: ">" (location: (3:5)-(3:6))
         │   │   │
         │   │   └── is_void: false
         │   │
-        │   └── @ HTMLTextNode (location: (3:7)-(4:1))
+        │   └── @ HTMLTextNode (location: (3:6)-(4:0))
         │       └── content: "\n"
         │
         ├── close_tag: ∅

--- a/test/snapshots/parser/tags_test/test_0003_empty_tag_with_newline_d07900ededde58845d8cc2ee728ace9f.txt
+++ b/test/snapshots/parser/tags_test/test_0003_empty_tag_with_newline_d07900ededde58845d8cc2ee728ace9f.txt
@@ -1,6 +1,6 @@
-@ DocumentNode (location: (1:0)-(2:8))
+@ DocumentNode (location: (1:0)-(2:7))
 └── children: (1 item)
-    └── @ HTMLElementNode (location: (1:0)-(2:8))
+    └── @ HTMLElementNode (location: (1:0)-(2:7))
         ├── open_tag:
         │   └── @ HTMLOpenTagNode (location: (1:0)-(1:6))
         │       ├── tag_opening: "<" (location: (1:0)-(1:1))
@@ -12,13 +12,13 @@
         │
         ├── tag_name: "span" (location: (1:1)-(1:5))
         ├── body: (1 item)
-        │   └── @ HTMLTextNode (location: (1:6)-(2:1))
+        │   └── @ HTMLTextNode (location: (1:6)-(2:0))
         │       └── content: "\n"
         │
         ├── close_tag:
-        │   └── @ HTMLCloseTagNode (location: (2:1)-(2:8))
-        │       ├── tag_opening: "</" (location: (2:1)-(2:3))
-        │       ├── tag_name: "span" (location: (2:3)-(2:7))
-        │       └── tag_closing: ">" (location: (2:7)-(2:8))
+        │   └── @ HTMLCloseTagNode (location: (2:0)-(2:7))
+        │       ├── tag_opening: "</" (location: (2:0)-(2:2))
+        │       ├── tag_name: "span" (location: (2:2)-(2:6))
+        │       └── tag_closing: ">" (location: (2:6)-(2:7))
         │
         └── is_void: false

--- a/test/snapshots/parser/tags_test/test_0023_should_recover_from_out_of_order_closing_tags_f273b8d48121740a82fdcc71150f3710.txt
+++ b/test/snapshots/parser/tags_test/test_0023_should_recover_from_out_of_order_closing_tags_f273b8d48121740a82fdcc71150f3710.txt
@@ -1,80 +1,80 @@
-@ DocumentNode (location: (1:0)-(7:7))
+@ DocumentNode (location: (1:0)-(7:6))
 ├── errors: (1 error)
-│   └── @ UnclosedElementError (location: (6:9)-(6:11))
-│       ├── message: "Tag `<main>` opened at (2:10) was never closed before the end of document."
-│       └── opening_tag: "main" (location: (2:10)-(2:14))
+│   └── @ UnclosedElementError (location: (6:8)-(6:10))
+│       ├── message: "Tag `<main>` opened at (2:9) was never closed before the end of document."
+│       └── opening_tag: "main" (location: (2:9)-(2:13))
 │
 └── children: (5 items)
-    ├── @ HTMLTextNode (location: (1:0)-(2:9))
+    ├── @ HTMLTextNode (location: (1:0)-(2:8))
     │   └── content: "\n        "
     │
-    ├── @ HTMLElementNode (location: (2:9)-(5:17))
+    ├── @ HTMLElementNode (location: (2:8)-(5:16))
     │   ├── open_tag:
-    │   │   └── @ HTMLOpenTagNode (location: (2:9)-(2:15))
-    │   │       ├── tag_opening: "<" (location: (2:9)-(2:10))
-    │   │       ├── tag_name: "main" (location: (2:10)-(2:14))
+    │   │   └── @ HTMLOpenTagNode (location: (2:8)-(2:14))
+    │   │       ├── tag_opening: "<" (location: (2:8)-(2:9))
+    │   │       ├── tag_name: "main" (location: (2:9)-(2:13))
     │   │       ├── attributes: []
-    │   │       ├── tag_closing: ">" (location: (2:14)-(2:15))
+    │   │       ├── tag_closing: ">" (location: (2:13)-(2:14))
     │   │       ├── children: []
     │   │       └── is_void: false
     │   │
-    │   ├── tag_name: "main" (location: (2:10)-(2:14))
+    │   ├── tag_name: "main" (location: (2:9)-(2:13))
     │   ├── body: (3 items)
-    │   │   ├── @ HTMLTextNode (location: (2:15)-(3:11))
+    │   │   ├── @ HTMLTextNode (location: (2:14)-(3:10))
     │   │   │   └── content: "\n          "
     │   │   │
-    │   │   ├── @ HTMLElementNode (location: (3:11)-(4:20))
+    │   │   ├── @ HTMLElementNode (location: (3:10)-(4:19))
     │   │   │   ├── errors: (1 error)
-    │   │   │   │   └── @ TagNamesMismatchError (location: (4:15)-(4:19))
-    │   │   │   │       ├── message: "Opening tag `<div>` at (3:12) closed with `</span>` at (4:15)."
-    │   │   │   │       ├── opening_tag: "div" (location: (3:12)-(3:15))
-    │   │   │   │       └── closing_tag: "span" (location: (4:15)-(4:19))
+    │   │   │   │   └── @ TagNamesMismatchError (location: (4:14)-(4:18))
+    │   │   │   │       ├── message: "Opening tag `<div>` at (3:11) closed with `</span>` at (4:14)."
+    │   │   │   │       ├── opening_tag: "div" (location: (3:11)-(3:14))
+    │   │   │   │       └── closing_tag: "span" (location: (4:14)-(4:18))
     │   │   │   │
     │   │   │   ├── open_tag:
-    │   │   │   │   └── @ HTMLOpenTagNode (location: (3:11)-(3:16))
-    │   │   │   │       ├── tag_opening: "<" (location: (3:11)-(3:12))
-    │   │   │   │       ├── tag_name: "div" (location: (3:12)-(3:15))
+    │   │   │   │   └── @ HTMLOpenTagNode (location: (3:10)-(3:15))
+    │   │   │   │       ├── tag_opening: "<" (location: (3:10)-(3:11))
+    │   │   │   │       ├── tag_name: "div" (location: (3:11)-(3:14))
     │   │   │   │       ├── attributes: []
-    │   │   │   │       ├── tag_closing: ">" (location: (3:15)-(3:16))
+    │   │   │   │       ├── tag_closing: ">" (location: (3:14)-(3:15))
     │   │   │   │       ├── children: []
     │   │   │   │       └── is_void: false
     │   │   │   │
-    │   │   │   ├── tag_name: "div" (location: (3:12)-(3:15))
+    │   │   │   ├── tag_name: "div" (location: (3:11)-(3:14))
     │   │   │   ├── body: (1 item)
-    │   │   │   │   └── @ HTMLTextNode (location: (3:16)-(4:13))
+    │   │   │   │   └── @ HTMLTextNode (location: (3:15)-(4:12))
     │   │   │   │       └── content: "\n            "
     │   │   │   │
     │   │   │   ├── close_tag:
-    │   │   │   │   └── @ HTMLCloseTagNode (location: (4:13)-(4:20))
-    │   │   │   │       ├── tag_opening: "</" (location: (4:13)-(4:15))
-    │   │   │   │       ├── tag_name: "span" (location: (4:15)-(4:19))
-    │   │   │   │       └── tag_closing: ">" (location: (4:19)-(4:20))
+    │   │   │   │   └── @ HTMLCloseTagNode (location: (4:12)-(4:19))
+    │   │   │   │       ├── tag_opening: "</" (location: (4:12)-(4:14))
+    │   │   │   │       ├── tag_name: "span" (location: (4:14)-(4:18))
+    │   │   │   │       └── tag_closing: ">" (location: (4:18)-(4:19))
     │   │   │   │
     │   │   │   └── is_void: false
     │   │   │
-    │   │   └── @ HTMLTextNode (location: (4:20)-(5:11))
+    │   │   └── @ HTMLTextNode (location: (4:19)-(5:10))
     │   │       └── content: "\n          "
     │   │
     │   ├── close_tag:
-    │   │   └── @ HTMLCloseTagNode (location: (5:11)-(5:17))
-    │   │       ├── tag_opening: "</" (location: (5:11)-(5:13))
-    │   │       ├── tag_name: "div" (location: (5:13)-(5:16))
-    │   │       └── tag_closing: ">" (location: (5:16)-(5:17))
+    │   │   └── @ HTMLCloseTagNode (location: (5:10)-(5:16))
+    │   │       ├── tag_opening: "</" (location: (5:10)-(5:12))
+    │   │       ├── tag_name: "div" (location: (5:12)-(5:15))
+    │   │       └── tag_closing: ">" (location: (5:15)-(5:16))
     │   │
     │   └── is_void: false
     │
-    ├── @ HTMLTextNode (location: (5:17)-(6:9))
+    ├── @ HTMLTextNode (location: (5:16)-(6:8))
     │   └── content: "\n        "
     │
-    ├── @ HTMLCloseTagNode (location: (6:9)-(6:16))
+    ├── @ HTMLCloseTagNode (location: (6:8)-(6:15))
     │   ├── errors: (1 error)
-    │   │   └── @ MissingOpeningTagError (location: (6:9)-(6:16))
-    │   │       ├── message: "Found closing tag `</main>` at (6:11) without a matching opening tag."
-    │   │       └── closing_tag: "main" (location: (6:11)-(6:15))
+    │   │   └── @ MissingOpeningTagError (location: (6:8)-(6:15))
+    │   │       ├── message: "Found closing tag `</main>` at (6:10) without a matching opening tag."
+    │   │       └── closing_tag: "main" (location: (6:10)-(6:14))
     │   │
-    │   ├── tag_opening: "</" (location: (6:9)-(6:11))
-    │   ├── tag_name: "main" (location: (6:11)-(6:15))
-    │   └── tag_closing: ">" (location: (6:15)-(6:16))
+    │   ├── tag_opening: "</" (location: (6:8)-(6:10))
+    │   ├── tag_name: "main" (location: (6:10)-(6:14))
+    │   └── tag_closing: ">" (location: (6:14)-(6:15))
     │
-    └── @ HTMLTextNode (location: (6:16)-(7:7))
+    └── @ HTMLTextNode (location: (6:15)-(7:6))
         └── content: "\n      "

--- a/test/snapshots/parser/tags_test/test_0025_should_recover_from_void_elements_used_as_closing_tag_8899d88bdd54fed8935467e2c9284fd1.txt
+++ b/test/snapshots/parser/tags_test/test_0025_should_recover_from_void_elements_used_as_closing_tag_8899d88bdd54fed8935467e2c9284fd1.txt
@@ -1,123 +1,123 @@
-@ DocumentNode (location: (1:0)-(9:7))
+@ DocumentNode (location: (1:0)-(9:6))
 └── children: (3 items)
-    ├── @ HTMLTextNode (location: (1:0)-(2:9))
+    ├── @ HTMLTextNode (location: (1:0)-(2:8))
     │   └── content: "\n        "
     │
-    ├── @ HTMLElementNode (location: (2:9)-(8:16))
+    ├── @ HTMLElementNode (location: (2:8)-(8:15))
     │   ├── open_tag:
-    │   │   └── @ HTMLOpenTagNode (location: (2:9)-(2:15))
-    │   │       ├── tag_opening: "<" (location: (2:9)-(2:10))
-    │   │       ├── tag_name: "main" (location: (2:10)-(2:14))
+    │   │   └── @ HTMLOpenTagNode (location: (2:8)-(2:14))
+    │   │       ├── tag_opening: "<" (location: (2:8)-(2:9))
+    │   │       ├── tag_name: "main" (location: (2:9)-(2:13))
     │   │       ├── attributes: []
-    │   │       ├── tag_closing: ">" (location: (2:14)-(2:15))
+    │   │       ├── tag_closing: ">" (location: (2:13)-(2:14))
     │   │       ├── children: []
     │   │       └── is_void: false
     │   │
-    │   ├── tag_name: "main" (location: (2:10)-(2:14))
+    │   ├── tag_name: "main" (location: (2:9)-(2:13))
     │   ├── body: (3 items)
-    │   │   ├── @ HTMLTextNode (location: (2:15)-(3:11))
+    │   │   ├── @ HTMLTextNode (location: (2:14)-(3:10))
     │   │   │   └── content: "\n          "
     │   │   │
-    │   │   ├── @ HTMLElementNode (location: (3:11)-(7:17))
+    │   │   ├── @ HTMLElementNode (location: (3:10)-(7:16))
     │   │   │   ├── open_tag:
-    │   │   │   │   └── @ HTMLOpenTagNode (location: (3:11)-(3:16))
-    │   │   │   │       ├── tag_opening: "<" (location: (3:11)-(3:12))
-    │   │   │   │       ├── tag_name: "div" (location: (3:12)-(3:15))
+    │   │   │   │   └── @ HTMLOpenTagNode (location: (3:10)-(3:15))
+    │   │   │   │       ├── tag_opening: "<" (location: (3:10)-(3:11))
+    │   │   │   │       ├── tag_name: "div" (location: (3:11)-(3:14))
     │   │   │   │       ├── attributes: []
-    │   │   │   │       ├── tag_closing: ">" (location: (3:15)-(3:16))
+    │   │   │   │       ├── tag_closing: ">" (location: (3:14)-(3:15))
     │   │   │   │       ├── children: []
     │   │   │   │       └── is_void: false
     │   │   │   │
-    │   │   │   ├── tag_name: "div" (location: (3:12)-(3:15))
+    │   │   │   ├── tag_name: "div" (location: (3:11)-(3:14))
     │   │   │   ├── body: (7 items)
-    │   │   │   │   ├── @ HTMLTextNode (location: (3:16)-(4:13))
+    │   │   │   │   ├── @ HTMLTextNode (location: (3:15)-(4:12))
     │   │   │   │   │   └── content: "\n            "
     │   │   │   │   │
-    │   │   │   │   ├── @ HTMLCloseTagNode (location: (4:13)-(4:18))
+    │   │   │   │   ├── @ HTMLCloseTagNode (location: (4:12)-(4:17))
     │   │   │   │   │   ├── errors: (1 error)
-    │   │   │   │   │   │   └── @ VoidElementClosingTagError (location: (4:13)-(4:18))
+    │   │   │   │   │   │   └── @ VoidElementClosingTagError (location: (4:12)-(4:17))
     │   │   │   │   │   │       ├── message: "`br` is a void element and should not be used as a closing tag. Use `<br>` or `<br />` instead of `</br>`."
-    │   │   │   │   │   │       ├── tag_name: "br" (location: (4:15)-(4:17))
+    │   │   │   │   │   │       ├── tag_name: "br" (location: (4:14)-(4:16))
     │   │   │   │   │   │       ├── expected: "<br />"
     │   │   │   │   │   │       └── found: "</br>"
     │   │   │   │   │   │
-    │   │   │   │   │   ├── tag_opening: "</" (location: (4:13)-(4:15))
-    │   │   │   │   │   ├── tag_name: "br" (location: (4:15)-(4:17))
-    │   │   │   │   │   └── tag_closing: ">" (location: (4:17)-(4:18))
+    │   │   │   │   │   ├── tag_opening: "</" (location: (4:12)-(4:14))
+    │   │   │   │   │   ├── tag_name: "br" (location: (4:14)-(4:16))
+    │   │   │   │   │   └── tag_closing: ">" (location: (4:16)-(4:17))
     │   │   │   │   │
-    │   │   │   │   ├── @ HTMLTextNode (location: (4:18)-(5:13))
+    │   │   │   │   ├── @ HTMLTextNode (location: (4:17)-(5:12))
     │   │   │   │   │   └── content: "\n            "
     │   │   │   │   │
-    │   │   │   │   ├── @ HTMLElementNode (location: (5:13)-(5:31))
+    │   │   │   │   ├── @ HTMLElementNode (location: (5:12)-(5:30))
     │   │   │   │   │   ├── open_tag:
-    │   │   │   │   │   │   └── @ HTMLOpenTagNode (location: (5:13)-(5:19))
-    │   │   │   │   │   │       ├── tag_opening: "<" (location: (5:13)-(5:14))
-    │   │   │   │   │   │       ├── tag_name: "span" (location: (5:14)-(5:18))
+    │   │   │   │   │   │   └── @ HTMLOpenTagNode (location: (5:12)-(5:18))
+    │   │   │   │   │   │       ├── tag_opening: "<" (location: (5:12)-(5:13))
+    │   │   │   │   │   │       ├── tag_name: "span" (location: (5:13)-(5:17))
     │   │   │   │   │   │       ├── attributes: []
-    │   │   │   │   │   │       ├── tag_closing: ">" (location: (5:18)-(5:19))
+    │   │   │   │   │   │       ├── tag_closing: ">" (location: (5:17)-(5:18))
     │   │   │   │   │   │       ├── children: []
     │   │   │   │   │   │       └── is_void: false
     │   │   │   │   │   │
-    │   │   │   │   │   ├── tag_name: "span" (location: (5:14)-(5:18))
+    │   │   │   │   │   ├── tag_name: "span" (location: (5:13)-(5:17))
     │   │   │   │   │   ├── body: (1 item)
-    │   │   │   │   │   │   └── @ HTMLTextNode (location: (5:19)-(5:24))
+    │   │   │   │   │   │   └── @ HTMLTextNode (location: (5:18)-(5:23))
     │   │   │   │   │   │       └── content: "Hello"
     │   │   │   │   │   │
     │   │   │   │   │   ├── close_tag:
-    │   │   │   │   │   │   └── @ HTMLCloseTagNode (location: (5:24)-(5:31))
-    │   │   │   │   │   │       ├── tag_opening: "</" (location: (5:24)-(5:26))
-    │   │   │   │   │   │       ├── tag_name: "span" (location: (5:26)-(5:30))
-    │   │   │   │   │   │       └── tag_closing: ">" (location: (5:30)-(5:31))
+    │   │   │   │   │   │   └── @ HTMLCloseTagNode (location: (5:23)-(5:30))
+    │   │   │   │   │   │       ├── tag_opening: "</" (location: (5:23)-(5:25))
+    │   │   │   │   │   │       ├── tag_name: "span" (location: (5:25)-(5:29))
+    │   │   │   │   │   │       └── tag_closing: ">" (location: (5:29)-(5:30))
     │   │   │   │   │   │
     │   │   │   │   │   └── is_void: false
     │   │   │   │   │
-    │   │   │   │   ├── @ HTMLTextNode (location: (5:31)-(6:13))
+    │   │   │   │   ├── @ HTMLTextNode (location: (5:30)-(6:12))
     │   │   │   │   │   └── content: "\n            "
     │   │   │   │   │
-    │   │   │   │   ├── @ HTMLElementNode (location: (6:13)-(6:25))
+    │   │   │   │   ├── @ HTMLElementNode (location: (6:12)-(6:24))
     │   │   │   │   │   ├── open_tag:
-    │   │   │   │   │   │   └── @ HTMLOpenTagNode (location: (6:13)-(6:16))
-    │   │   │   │   │   │       ├── tag_opening: "<" (location: (6:13)-(6:14))
-    │   │   │   │   │   │       ├── tag_name: "p" (location: (6:14)-(6:15))
+    │   │   │   │   │   │   └── @ HTMLOpenTagNode (location: (6:12)-(6:15))
+    │   │   │   │   │   │       ├── tag_opening: "<" (location: (6:12)-(6:13))
+    │   │   │   │   │   │       ├── tag_name: "p" (location: (6:13)-(6:14))
     │   │   │   │   │   │       ├── attributes: []
-    │   │   │   │   │   │       ├── tag_closing: ">" (location: (6:15)-(6:16))
+    │   │   │   │   │   │       ├── tag_closing: ">" (location: (6:14)-(6:15))
     │   │   │   │   │   │       ├── children: []
     │   │   │   │   │   │       └── is_void: false
     │   │   │   │   │   │
-    │   │   │   │   │   ├── tag_name: "p" (location: (6:14)-(6:15))
+    │   │   │   │   │   ├── tag_name: "p" (location: (6:13)-(6:14))
     │   │   │   │   │   ├── body: (1 item)
-    │   │   │   │   │   │   └── @ HTMLTextNode (location: (6:16)-(6:21))
+    │   │   │   │   │   │   └── @ HTMLTextNode (location: (6:15)-(6:20))
     │   │   │   │   │   │       └── content: "World"
     │   │   │   │   │   │
     │   │   │   │   │   ├── close_tag:
-    │   │   │   │   │   │   └── @ HTMLCloseTagNode (location: (6:21)-(6:25))
-    │   │   │   │   │   │       ├── tag_opening: "</" (location: (6:21)-(6:23))
-    │   │   │   │   │   │       ├── tag_name: "p" (location: (6:23)-(6:24))
-    │   │   │   │   │   │       └── tag_closing: ">" (location: (6:24)-(6:25))
+    │   │   │   │   │   │   └── @ HTMLCloseTagNode (location: (6:20)-(6:24))
+    │   │   │   │   │   │       ├── tag_opening: "</" (location: (6:20)-(6:22))
+    │   │   │   │   │   │       ├── tag_name: "p" (location: (6:22)-(6:23))
+    │   │   │   │   │   │       └── tag_closing: ">" (location: (6:23)-(6:24))
     │   │   │   │   │   │
     │   │   │   │   │   └── is_void: false
     │   │   │   │   │
-    │   │   │   │   └── @ HTMLTextNode (location: (6:25)-(7:11))
+    │   │   │   │   └── @ HTMLTextNode (location: (6:24)-(7:10))
     │   │   │   │       └── content: "\n          "
     │   │   │   │
     │   │   │   ├── close_tag:
-    │   │   │   │   └── @ HTMLCloseTagNode (location: (7:11)-(7:17))
-    │   │   │   │       ├── tag_opening: "</" (location: (7:11)-(7:13))
-    │   │   │   │       ├── tag_name: "div" (location: (7:13)-(7:16))
-    │   │   │   │       └── tag_closing: ">" (location: (7:16)-(7:17))
+    │   │   │   │   └── @ HTMLCloseTagNode (location: (7:10)-(7:16))
+    │   │   │   │       ├── tag_opening: "</" (location: (7:10)-(7:12))
+    │   │   │   │       ├── tag_name: "div" (location: (7:12)-(7:15))
+    │   │   │   │       └── tag_closing: ">" (location: (7:15)-(7:16))
     │   │   │   │
     │   │   │   └── is_void: false
     │   │   │
-    │   │   └── @ HTMLTextNode (location: (7:17)-(8:9))
+    │   │   └── @ HTMLTextNode (location: (7:16)-(8:8))
     │   │       └── content: "\n        "
     │   │
     │   ├── close_tag:
-    │   │   └── @ HTMLCloseTagNode (location: (8:9)-(8:16))
-    │   │       ├── tag_opening: "</" (location: (8:9)-(8:11))
-    │   │       ├── tag_name: "main" (location: (8:11)-(8:15))
-    │   │       └── tag_closing: ">" (location: (8:15)-(8:16))
+    │   │   └── @ HTMLCloseTagNode (location: (8:8)-(8:15))
+    │   │       ├── tag_opening: "</" (location: (8:8)-(8:10))
+    │   │       ├── tag_name: "main" (location: (8:10)-(8:14))
+    │   │       └── tag_closing: ">" (location: (8:14)-(8:15))
     │   │
     │   └── is_void: false
     │
-    └── @ HTMLTextNode (location: (8:16)-(9:7))
+    └── @ HTMLTextNode (location: (8:15)-(9:6))
         └── content: "\n      "


### PR DESCRIPTION
This pull request changes the columns in token positions to be zero-based throughout. The first line was already using a zero-based column, but any following line restarted at column 1, which made the column numbers inconsistent.

So, this pull request updates the columns to be zero-based for all lines, following the way [Prism](https://github.com/ruby/prism) is handling it. This is intentional, even when quite a few text editors are using 1-based column numbers.

Line numbers stay 1-based.