### PR TITLE
Upgrade Prism to v1.4.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "prism", github: "ruby/prism", tag: "v1.3.0"
+gem "prism", github: "ruby/prism", tag: "v1.4.0"
 
 gem "lz_string"
 gem "maxitest"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/ruby/prism.git
-  revision: 01843caefd06828190161826575822c30466d95c
-  tag: v1.3.0
+  revision: 266f83de6a2b0c1557404dde33ad3d41ceba7043
+  tag: v1.4.0
   specs:
-    prism (1.3.0)
+    prism (1.4.0)
 
 PATH
   remote: .


### PR DESCRIPTION
Prism v1.4.0 just released: https://github.com/ruby/prism/releases/tag/v1.4.0

So this pull request updates Prism to v1.4.0.