### PR TITLE
Add Prism version to `version` methods

### DIFF
--- a/ext/herb/extension.c
+++ b/ext/herb/extension.c
@@ -86,9 +86,10 @@ static VALUE Herb_extract_html(VALUE self, VALUE source) {
 static VALUE Herb_version(VALUE self) {
   VALUE gem_version = rb_const_get(self, rb_intern("VERSION"));
   VALUE libherb_version = rb_str_new_cstr(herb_version());
-  VALUE format_string = rb_str_new_cstr("herb gem v%s, libherb v%s (Ruby C native extension)");
+  VALUE libprism_version = rb_str_new_cstr(herb_prism_version());
+  VALUE format_string = rb_str_new_cstr("herb gem v%s, libprism v%s, libherb v%s (Ruby C native extension)");
 
-  return rb_funcall(rb_mKernel, rb_intern("sprintf"), 3, format_string, gem_version, libherb_version);
+  return rb_funcall(rb_mKernel, rb_intern("sprintf"), 4, format_string, gem_version, libprism_version, libherb_version);
 }
 
 void Init_herb(void) {

--- a/javascript/packages/node/extension/herb.cpp
+++ b/javascript/packages/node/extension/herb.cpp
@@ -198,10 +198,11 @@ napi_value Herb_extract_html(napi_env env, napi_callback_info info) {
 }
 
 napi_value Herb_version(napi_env env, napi_callback_info info) {
-  const char* native_version = herb_version();
+  const char* libherb_version = herb_version();
+  const char* libprism_version = herb_prism_version();
 
   char version_buf[256];
-  snprintf(version_buf, sizeof(version_buf), "libherb@%s (Node.js C++ native extension)", native_version);
+  snprintf(version_buf, sizeof(version_buf), "libprism@%s, libherb@%s (Node.js C++ native extension)", libprism_version, libherb_version);
 
   napi_value result;
   napi_create_string_utf8(env, version_buf, NAPI_AUTO_LENGTH, &result);

--- a/src/herb.c
+++ b/src/herb.c
@@ -8,6 +8,7 @@
 #include "include/token.h"
 #include "include/version.h"
 
+#include <prism.h>
 #include <stdlib.h>
 
 array_T* herb_lex(const char* source) {
@@ -95,4 +96,8 @@ void herb_free_tokens(array_T** tokens) {
 
 const char* herb_version(void) {
   return HERB_VERSION;
+}
+
+const char* herb_prism_version(void) {
+  return PRISM_VERSION;
 }

--- a/src/include/herb.h
+++ b/src/include/herb.h
@@ -14,10 +14,15 @@ extern "C" {
 
 void herb_lex_to_buffer(const char* source, buffer_T* output);
 void herb_lex_json_to_buffer(const char* source, buffer_T* output);
+
 array_T* herb_lex(const char* source);
 array_T* herb_lex_file(const char* path);
+
 AST_DOCUMENT_NODE_T* herb_parse(const char* source);
+
 const char* herb_version(void);
+const char* herb_prism_version(void);
+
 void herb_free_tokens(array_T** tokens);
 
 #ifdef __cplusplus

--- a/wasm/herb-wasm.cpp
+++ b/wasm/herb-wasm.cpp
@@ -56,8 +56,10 @@ std::string Herb_extract_html(const std::string& source) {
 }
 
 std::string Herb_version() {
-  const char* native_version = herb_version();
-  std::string version = std::string("libherb@") + native_version + " (WebAssembly)";
+  const char* libherb_version = herb_version();
+  const char* libprism_version = herb_prism_version();
+
+  std::string version = std::string("libprism@") + libprism_version + ", libherb@" + libherb_version + " (WebAssembly)";
   return version;
 }
 


### PR DESCRIPTION
Following up on https://github.com/marcoroth/herb/pull/81, I think it's useful to know which bundled Prism version Herb ships with, so this pull request adds the Prism version to all `Herb.version` methods in both Ruby and JavaScript.

This depends on the Prism build settings from #80.