### PR TITLE
Clean URLs: (remove .html postfix from the links)

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -146,6 +146,7 @@ export default defineConfig({
     ['meta', { property: 'og:url', content: 'https://herb-tools.dev' }],
     ['meta', { property: 'og:type', content: 'website' }],
   ],
+  cleanUrls: true,
   // base: "/herb/",
   markdown,
   vite,


### PR DESCRIPTION
This PR enables VitePress option to [generate clean](https://vitepress.dev/guide/routing#generating-clean-url), beautiful links without the `.html` postfix.

❌ Before:
https://herb-tools.dev/bindings/javascript/reference.html

✅ After:
https://herb-tools.dev/bindings/javascript/reference
