### PR TITLE
Implement `free_analyzed_ruby` function

### DIFF
--- a/src/analyzed_ruby.c
+++ b/src/analyzed_ruby.c
@@ -34,5 +34,11 @@ analyzed_ruby_T* init_analyzed_ruby(char* source) {
 }
 
 void free_analyzed_ruby(analyzed_ruby_T* analyzed) {
-  // TODO
+  if (!analyzed) { return; }
+
+  if (analyzed->parsed && analyzed->root != NULL) { pm_node_destroy(&analyzed->parser, analyzed->root); }
+
+  pm_parser_free(&analyzed->parser);
+
+  free(analyzed);
 }

--- a/templates/src/ast_nodes.c.erb
+++ b/templates/src/ast_nodes.c.erb
@@ -116,7 +116,9 @@ static void ast_free_<%= node.human %>(<%= node.struct_type %>* <%= node.human %
     pm_node_destroy(NULL, <%= node.human %>-><%= field.name %>);
   }
   <%- when Herb::Template::AnalyzedRubyField -%>
-  // TODO: free
+  if (<%= node.human %>-><%= field.name %> != NULL) {
+    free_analyzed_ruby(<%= node.human %>-><%= field.name %>);
+  }
   <%- when Herb::Template::VoidPointerField -%>
   free(<%= node.human %>-><%= field.name %>);
   <%- when Herb::Template::BooleanField -%>


### PR DESCRIPTION
This pull request implements a proper cleanup procedure for `analyzed_ruby_T` structs by implementing the `free_analyzed_ruby` function in `src/analyzed_ruby.c` and calling it in the AST Node `free` function for Nodes with `Herb::Template::AnalyzedRubyField` fields (namely `ERBContentNode`).
