### PR TITLE
Free C Structs after creating Lex and Parse Results

### DIFF
--- a/ext/herb/extension.c
+++ b/ext/herb/extension.c
@@ -11,7 +11,11 @@ static VALUE Herb_lex(VALUE self, VALUE source) {
 
   array_T* tokens = herb_lex(string);
 
-  return create_lex_result(tokens, source);
+  VALUE result = create_lex_result(tokens, source);
+
+  herb_free_tokens(&tokens);
+
+  return result;
 }
 
 static VALUE Herb_lex_file(VALUE self, VALUE path) {
@@ -19,8 +23,11 @@ static VALUE Herb_lex_file(VALUE self, VALUE path) {
   array_T* tokens = herb_lex_file(file_path);
 
   VALUE source_value = read_file_to_ruby_string(file_path);
+  VALUE result = create_lex_result(tokens, source_value);
 
-  return create_lex_result(tokens, source_value);
+  herb_free_tokens(&tokens);
+
+  return result;
 }
 
 static VALUE Herb_parse(VALUE self, VALUE source) {
@@ -30,7 +37,11 @@ static VALUE Herb_parse(VALUE self, VALUE source) {
 
   herb_analyze_parse_tree(root, string);
 
-  return create_parse_result(root, source);
+  VALUE result = create_parse_result(root, source);
+
+  ast_node_free((AST_NODE_T*) root);
+
+  return result;
 }
 
 static VALUE Herb_parse_file(VALUE self, VALUE path) {
@@ -41,7 +52,11 @@ static VALUE Herb_parse_file(VALUE self, VALUE path) {
 
   AST_DOCUMENT_NODE_T* root = herb_parse(string);
 
-  return create_parse_result(root, source_value);
+  VALUE result = create_parse_result(root, source_value);
+
+  ast_node_free((AST_NODE_T*) root);
+
+  return result;
 }
 
 static VALUE Herb_lex_to_json(VALUE self, VALUE source) {

--- a/ext/herb/extension_helpers.c
+++ b/ext/herb/extension_helpers.c
@@ -89,8 +89,8 @@ VALUE create_lex_result(array_T* tokens, VALUE source) {
   VALUE Result = rb_define_class_under(Herb, "Result", rb_cObject);
   VALUE LexResult = rb_define_class_under(Herb, "LexResult", Result);
 
-  herb_free_tokens(&tokens);
   VALUE args[4] = { value, source, warnings, errors };
+
   return rb_class_new_instance(4, args, LexResult);
 }
 
@@ -104,6 +104,7 @@ VALUE create_parse_result(AST_DOCUMENT_NODE_T* root, VALUE source) {
   VALUE ParseResult = rb_define_class_under(Herb, "ParseResult", Result);
 
   VALUE args[4] = { value, source, warnings, errors };
+
   return rb_class_new_instance(4, args, ParseResult);
 }
 

--- a/javascript/packages/node/extension/extension_helpers.cpp
+++ b/javascript/packages/node/extension/extension_helpers.cpp
@@ -148,7 +148,9 @@ napi_value ReadFileToString(napi_env env, const char* file_path) {
   }
 
   napi_value result = CreateString(env, content);
+
   free(content);
+
   return result;
 }
 
@@ -175,9 +177,6 @@ napi_value CreateLexResult(napi_env env, array_T* tokens, napi_value source) {
   napi_set_named_property(env, result, "source", source);
   napi_set_named_property(env, result, "warnings", warnings_array);
   napi_set_named_property(env, result, "errors", errors_array);
-
-  // Free tokens after creating JS objects
-  herb_free_tokens(&tokens);
 
   return result;
 }

--- a/javascript/packages/node/extension/herb.cpp
+++ b/javascript/packages/node/extension/herb.cpp
@@ -34,7 +34,9 @@ napi_value Herb_lex(napi_env env, napi_callback_info info) {
   array_T* tokens = herb_lex(string);
   napi_value result = CreateLexResult(env, tokens, args[0]);
 
+  herb_free_tokens(&tokens);
   free(string);
+
   return result;
 }
 
@@ -55,7 +57,9 @@ napi_value Herb_lex_file(napi_env env, napi_callback_info info) {
   napi_value source_value = ReadFileToString(env, file_path);
   napi_value result = CreateLexResult(env, tokens, source_value);
 
+  herb_free_tokens(&tokens);
   free(file_path);
+
   return result;
 }
 
@@ -76,7 +80,9 @@ napi_value Herb_parse(napi_env env, napi_callback_info info) {
   herb_analyze_parse_tree(root, string);
   napi_value result = CreateParseResult(env, root, args[0]);
 
+  ast_node_free((AST_NODE_T *) root);
   free(string);
+
   return result;
 }
 
@@ -104,8 +110,10 @@ napi_value Herb_parse_file(napi_env env, napi_callback_info info) {
   AST_DOCUMENT_NODE_T* root = herb_parse(string);
   napi_value result = CreateParseResult(env, root, source_value);
 
+  ast_node_free((AST_NODE_T *) root);
   free(file_path);
   free(string);
+
   return result;
 }
 
@@ -136,6 +144,7 @@ napi_value Herb_lex_to_json(napi_env env, napi_callback_info info) {
 
   buffer_free(&output);
   free(string);
+
   return result;
 }
 

--- a/wasm/extension_helpers.cpp
+++ b/wasm/extension_helpers.cpp
@@ -113,8 +113,6 @@ val CreateLexResult(array_T* tokens, const std::string& source) {
   result.set("warnings", warningsArray);
   result.set("errors", errorsArray);
 
-  herb_free_tokens(&tokens);
-
   return result;
 }
 

--- a/wasm/herb-wasm.cpp
+++ b/wasm/herb-wasm.cpp
@@ -29,6 +29,8 @@ val Herb_lex(const std::string& source) {
 
   val result = CreateLexResult(tokens, source);
 
+  herb_free_tokens(&tokens);
+
   return result;
 }
 
@@ -37,7 +39,11 @@ val Herb_parse(const std::string& source) {
 
   herb_analyze_parse_tree(root, source.c_str());
 
-  return CreateParseResult(root, source);
+  val result = CreateParseResult(root, source);
+
+  ast_node_free((AST_NODE_T *) root);
+
+  return result;
 }
 
 std::string Herb_extract_ruby(const std::string& source) {


### PR DESCRIPTION
This pull request improves the memory management in all language-bindings by adding explicit calls to free allocated resources after creating the `LexResult` and `ParseResult` objects. 

There's a good chance that this is part of the reason why we are seeing the issues in #103.