### PR TITLE
Add percentage to `herb analyze` CLI output

### DIFF
--- a/lib/herb/project.rb
+++ b/lib/herb/project.rb
@@ -221,10 +221,10 @@ module Herb
         summary = [
           heading("Summary"),
           "Total files: #{files.count}",
-          "✅ Successful: #{successful_files.count}",
-          "❌ Failed: #{failed_files.count}",
-          "⚠️ Parse errors: #{error_files.count}",
-          "⏱️ Timed out: #{timeout_files.count}"
+          "✅ Successful: #{successful_files.count} (#{percentage(successful_files.count, files.count)}%)",
+          "❌ Failed: #{failed_files.count} (#{percentage(failed_files.count, files.count)}%)",
+          "⚠️ Parse errors: #{error_files.count} (#{percentage(error_files.count, files.count)}%)",
+          "⏱️ Timed out: #{timeout_files.count} (#{percentage(timeout_files.count, files.count)}%)"
         ]
 
         summary.each do |line|
@@ -350,6 +350,12 @@ module Herb
 
       # Format as [███████▋       ] 42% (123/292)
       "[#{completed}#{partial}#{remaining}] #{percentage}% (#{current}/#{total})"
+    end
+
+    def percentage(part, total)
+      return 0.0 if total.zero?
+
+      ((part.to_f / total) * 100).round(1)
     end
 
     def heading(text)


### PR DESCRIPTION
This pull request improves the output of the `herb analyze` CLI command by adding a percentage for each status.

![CleanShot 2025-06-06 at 23 04 19@2x](https://github.com/user-attachments/assets/a9d97a51-5298-40a3-bfc8-6fcf90884be9)


/cc @dennispaagman