### PR TITLE
Memory management improvements in `analyze.c` and `extract.c`

### DIFF
--- a/src/extract.c
+++ b/src/extract.c
@@ -7,7 +7,7 @@
 #include <stdlib.h>
 
 void herb_extract_ruby_to_buffer_with_semicolons(const char* source, buffer_T* output) {
-  const array_T* tokens = herb_lex(source);
+  array_T* tokens = herb_lex(source);
   bool skip_erb_content = false;
 
   for (size_t i = 0; i < array_size(tokens); i++) {
@@ -49,10 +49,12 @@ void herb_extract_ruby_to_buffer_with_semicolons(const char* source, buffer_T* o
       }
     }
   }
+
+  herb_free_tokens(&tokens);
 }
 
 void herb_extract_ruby_to_buffer(const char* source, buffer_T* output) {
-  const array_T* tokens = herb_lex(source);
+  array_T* tokens = herb_lex(source);
   bool skip_erb_content = false;
 
   for (size_t i = 0; i < array_size(tokens); i++) {
@@ -93,10 +95,12 @@ void herb_extract_ruby_to_buffer(const char* source, buffer_T* output) {
       }
     }
   }
+
+  herb_free_tokens(&tokens);
 }
 
 void herb_extract_html_to_buffer(const char* source, buffer_T* output) {
-  const array_T* tokens = herb_lex(source);
+  array_T* tokens = herb_lex(source);
 
   for (size_t i = 0; i < array_size(tokens); i++) {
     const token_T* token = array_get(tokens, i);
@@ -108,6 +112,8 @@ void herb_extract_html_to_buffer(const char* source, buffer_T* output) {
       default: buffer_append(output, token->value);
     }
   }
+
+  herb_free_tokens(&tokens);
 }
 
 char* herb_extract_ruby_with_semicolons(const char* source) {


### PR DESCRIPTION
This pull request focuses on improving memory management and ensuring proper cleanup of dynamically allocated resources in `src/analyze.c` and `src/extract.c`. The changes add missing cleanup calls to prevent memory leaks.

