### PR TITLE
Implement `Herb::Visitor` in Ruby gem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,6 +93,7 @@ javascript/packages/node/extension/nodes.cpp
 javascript/packages/node/extension/nodes.h
 lib/herb/ast/nodes.rb
 lib/herb/errors.rb
+lib/herb/visitor.rb
 sig/serialized_ast_nodes.rbs
 sig/serialized_ast_errors.rbs
 src/ast_nodes.c

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -111,6 +111,10 @@ Layout/EmptyLinesAroundModuleBody:
     - lib/herb/ast/nodes.rb
     - lib/herb/errors.rb
 
+Layout/EmptyLinesAroundClassBody:
+  Exclude:
+    - lib/herb/visitor.rb
+
 Layout/FirstHashElementIndentation:
   EnforcedStyle: consistent
 

--- a/lib/herb.rb
+++ b/lib/herb.rb
@@ -24,6 +24,8 @@ require_relative "herb/project"
 
 require_relative "herb/version"
 
+require_relative "herb/visitor"
+
 begin
   major, minor, _patch = RUBY_VERSION.split(".") #: [String, String, String]
   require_relative "herb/#{major}.#{minor}/herb"

--- a/lib/herb/ast/node.rb
+++ b/lib/herb/ast/node.rb
@@ -75,6 +75,18 @@ module Herb
       def tree_inspect(_indent = 0)
         raise NotImplementedError
       end
+
+      #: (Visitor) -> void
+      def accept(_visitor)
+        raise NoMethodError, "undefined method `accept' for #{inspect}"
+      end
+
+      #: () -> Array[Herb::AST::Node]
+      def child_nodes
+        raise NoMethodError, "undefined method `child_nodes' for #{inspect}"
+      end
+
+      alias deconstruct child_nodes
     end
   end
 end

--- a/lib/herb/parse_result.rb
+++ b/lib/herb/parse_result.rb
@@ -26,5 +26,10 @@ module Herb
     def pretty_errors
       JSON.pretty_generate(errors + value.errors)
     end
+
+    #: (Visitor) -> void
+    def visit(visitor)
+      value.accept(visitor)
+    end
   end
 end

--- a/sig/herb/ast/node.rbs
+++ b/sig/herb/ast/node.rbs
@@ -32,6 +32,14 @@ module Herb
 
       # : (?Integer) -> String
       def tree_inspect: (?Integer) -> String
+
+      # : (Visitor) -> void
+      def accept: (Visitor) -> void
+
+      # : () -> Array[Herb::AST::Node]
+      def child_nodes: () -> Array[Herb::AST::Node]
+
+      alias deconstruct child_nodes
     end
   end
 end

--- a/sig/herb/ast/nodes.rbs
+++ b/sig/herb/ast/nodes.rbs
@@ -11,6 +11,12 @@ module Herb
       # : () -> serialized_document_node
       def to_hash: () -> serialized_document_node
 
+      # : (Visitor) -> void
+      def accept: (Visitor) -> void
+
+      # : () -> Array[Herb::AST::Node?]
+      def child_nodes: () -> Array[Herb::AST::Node?]
+
       # : () -> String
       def inspect: () -> String
 
@@ -26,6 +32,12 @@ module Herb
 
       # : () -> serialized_literal_node
       def to_hash: () -> serialized_literal_node
+
+      # : (Visitor) -> void
+      def accept: (Visitor) -> void
+
+      # : () -> Array[Herb::AST::Node?]
+      def child_nodes: () -> Array[Herb::AST::Node?]
 
       # : () -> String
       def inspect: () -> String
@@ -51,6 +63,12 @@ module Herb
       # : () -> serialized_html_open_tag_node
       def to_hash: () -> serialized_html_open_tag_node
 
+      # : (Visitor) -> void
+      def accept: (Visitor) -> void
+
+      # : () -> Array[Herb::AST::Node?]
+      def child_nodes: () -> Array[Herb::AST::Node?]
+
       # : () -> String
       def inspect: () -> String
 
@@ -70,6 +88,12 @@ module Herb
 
       # : () -> serialized_html_close_tag_node
       def to_hash: () -> serialized_html_close_tag_node
+
+      # : (Visitor) -> void
+      def accept: (Visitor) -> void
+
+      # : () -> Array[Herb::AST::Node?]
+      def child_nodes: () -> Array[Herb::AST::Node?]
 
       # : () -> String
       def inspect: () -> String
@@ -95,6 +119,12 @@ module Herb
       # : () -> serialized_html_self_close_tag_node
       def to_hash: () -> serialized_html_self_close_tag_node
 
+      # : (Visitor) -> void
+      def accept: (Visitor) -> void
+
+      # : () -> Array[Herb::AST::Node?]
+      def child_nodes: () -> Array[Herb::AST::Node?]
+
       # : () -> String
       def inspect: () -> String
 
@@ -119,6 +149,12 @@ module Herb
       # : () -> serialized_html_element_node
       def to_hash: () -> serialized_html_element_node
 
+      # : (Visitor) -> void
+      def accept: (Visitor) -> void
+
+      # : () -> Array[Herb::AST::Node?]
+      def child_nodes: () -> Array[Herb::AST::Node?]
+
       # : () -> String
       def inspect: () -> String
 
@@ -141,6 +177,12 @@ module Herb
       # : () -> serialized_html_attribute_value_node
       def to_hash: () -> serialized_html_attribute_value_node
 
+      # : (Visitor) -> void
+      def accept: (Visitor) -> void
+
+      # : () -> Array[Herb::AST::Node?]
+      def child_nodes: () -> Array[Herb::AST::Node?]
+
       # : () -> String
       def inspect: () -> String
 
@@ -156,6 +198,12 @@ module Herb
 
       # : () -> serialized_html_attribute_name_node
       def to_hash: () -> serialized_html_attribute_name_node
+
+      # : (Visitor) -> void
+      def accept: (Visitor) -> void
+
+      # : () -> Array[Herb::AST::Node?]
+      def child_nodes: () -> Array[Herb::AST::Node?]
 
       # : () -> String
       def inspect: () -> String
@@ -177,6 +225,12 @@ module Herb
       # : () -> serialized_html_attribute_node
       def to_hash: () -> serialized_html_attribute_node
 
+      # : (Visitor) -> void
+      def accept: (Visitor) -> void
+
+      # : () -> Array[Herb::AST::Node?]
+      def child_nodes: () -> Array[Herb::AST::Node?]
+
       # : () -> String
       def inspect: () -> String
 
@@ -192,6 +246,12 @@ module Herb
 
       # : () -> serialized_html_text_node
       def to_hash: () -> serialized_html_text_node
+
+      # : (Visitor) -> void
+      def accept: (Visitor) -> void
+
+      # : () -> Array[Herb::AST::Node?]
+      def child_nodes: () -> Array[Herb::AST::Node?]
 
       # : () -> String
       def inspect: () -> String
@@ -213,6 +273,12 @@ module Herb
       # : () -> serialized_html_comment_node
       def to_hash: () -> serialized_html_comment_node
 
+      # : (Visitor) -> void
+      def accept: (Visitor) -> void
+
+      # : () -> Array[Herb::AST::Node?]
+      def child_nodes: () -> Array[Herb::AST::Node?]
+
       # : () -> String
       def inspect: () -> String
 
@@ -233,6 +299,12 @@ module Herb
       # : () -> serialized_html_doctype_node
       def to_hash: () -> serialized_html_doctype_node
 
+      # : (Visitor) -> void
+      def accept: (Visitor) -> void
+
+      # : () -> Array[Herb::AST::Node?]
+      def child_nodes: () -> Array[Herb::AST::Node?]
+
       # : () -> String
       def inspect: () -> String
 
@@ -248,6 +320,12 @@ module Herb
 
       # : () -> serialized_whitespace_node
       def to_hash: () -> serialized_whitespace_node
+
+      # : (Visitor) -> void
+      def accept: (Visitor) -> void
+
+      # : () -> Array[Herb::AST::Node?]
+      def child_nodes: () -> Array[Herb::AST::Node?]
 
       # : () -> String
       def inspect: () -> String
@@ -275,6 +353,12 @@ module Herb
       # : () -> serialized_erb_content_node
       def to_hash: () -> serialized_erb_content_node
 
+      # : (Visitor) -> void
+      def accept: (Visitor) -> void
+
+      # : () -> Array[Herb::AST::Node?]
+      def child_nodes: () -> Array[Herb::AST::Node?]
+
       # : () -> String
       def inspect: () -> String
 
@@ -294,6 +378,12 @@ module Herb
 
       # : () -> serialized_erb_end_node
       def to_hash: () -> serialized_erb_end_node
+
+      # : (Visitor) -> void
+      def accept: (Visitor) -> void
+
+      # : () -> Array[Herb::AST::Node?]
+      def child_nodes: () -> Array[Herb::AST::Node?]
 
       # : () -> String
       def inspect: () -> String
@@ -316,6 +406,12 @@ module Herb
 
       # : () -> serialized_erb_else_node
       def to_hash: () -> serialized_erb_else_node
+
+      # : (Visitor) -> void
+      def accept: (Visitor) -> void
+
+      # : () -> Array[Herb::AST::Node?]
+      def child_nodes: () -> Array[Herb::AST::Node?]
 
       # : () -> String
       def inspect: () -> String
@@ -343,6 +439,12 @@ module Herb
       # : () -> serialized_erb_if_node
       def to_hash: () -> serialized_erb_if_node
 
+      # : (Visitor) -> void
+      def accept: (Visitor) -> void
+
+      # : () -> Array[Herb::AST::Node?]
+      def child_nodes: () -> Array[Herb::AST::Node?]
+
       # : () -> String
       def inspect: () -> String
 
@@ -367,6 +469,12 @@ module Herb
       # : () -> serialized_erb_block_node
       def to_hash: () -> serialized_erb_block_node
 
+      # : (Visitor) -> void
+      def accept: (Visitor) -> void
+
+      # : () -> Array[Herb::AST::Node?]
+      def child_nodes: () -> Array[Herb::AST::Node?]
+
       # : () -> String
       def inspect: () -> String
 
@@ -388,6 +496,12 @@ module Herb
 
       # : () -> serialized_erb_when_node
       def to_hash: () -> serialized_erb_when_node
+
+      # : (Visitor) -> void
+      def accept: (Visitor) -> void
+
+      # : () -> Array[Herb::AST::Node?]
+      def child_nodes: () -> Array[Herb::AST::Node?]
 
       # : () -> String
       def inspect: () -> String
@@ -417,6 +531,12 @@ module Herb
       # : () -> serialized_erb_case_node
       def to_hash: () -> serialized_erb_case_node
 
+      # : (Visitor) -> void
+      def accept: (Visitor) -> void
+
+      # : () -> Array[Herb::AST::Node?]
+      def child_nodes: () -> Array[Herb::AST::Node?]
+
       # : () -> String
       def inspect: () -> String
 
@@ -445,6 +565,12 @@ module Herb
       # : () -> serialized_erb_case_match_node
       def to_hash: () -> serialized_erb_case_match_node
 
+      # : (Visitor) -> void
+      def accept: (Visitor) -> void
+
+      # : () -> Array[Herb::AST::Node?]
+      def child_nodes: () -> Array[Herb::AST::Node?]
+
       # : () -> String
       def inspect: () -> String
 
@@ -468,6 +594,12 @@ module Herb
 
       # : () -> serialized_erb_while_node
       def to_hash: () -> serialized_erb_while_node
+
+      # : (Visitor) -> void
+      def accept: (Visitor) -> void
+
+      # : () -> Array[Herb::AST::Node?]
+      def child_nodes: () -> Array[Herb::AST::Node?]
 
       # : () -> String
       def inspect: () -> String
@@ -493,6 +625,12 @@ module Herb
       # : () -> serialized_erb_until_node
       def to_hash: () -> serialized_erb_until_node
 
+      # : (Visitor) -> void
+      def accept: (Visitor) -> void
+
+      # : () -> Array[Herb::AST::Node?]
+      def child_nodes: () -> Array[Herb::AST::Node?]
+
       # : () -> String
       def inspect: () -> String
 
@@ -516,6 +654,12 @@ module Herb
 
       # : () -> serialized_erb_for_node
       def to_hash: () -> serialized_erb_for_node
+
+      # : (Visitor) -> void
+      def accept: (Visitor) -> void
+
+      # : () -> Array[Herb::AST::Node?]
+      def child_nodes: () -> Array[Herb::AST::Node?]
 
       # : () -> String
       def inspect: () -> String
@@ -541,6 +685,12 @@ module Herb
       # : () -> serialized_erb_rescue_node
       def to_hash: () -> serialized_erb_rescue_node
 
+      # : (Visitor) -> void
+      def accept: (Visitor) -> void
+
+      # : () -> Array[Herb::AST::Node?]
+      def child_nodes: () -> Array[Herb::AST::Node?]
+
       # : () -> String
       def inspect: () -> String
 
@@ -562,6 +712,12 @@ module Herb
 
       # : () -> serialized_erb_ensure_node
       def to_hash: () -> serialized_erb_ensure_node
+
+      # : (Visitor) -> void
+      def accept: (Visitor) -> void
+
+      # : () -> Array[Herb::AST::Node?]
+      def child_nodes: () -> Array[Herb::AST::Node?]
 
       # : () -> String
       def inspect: () -> String
@@ -593,6 +749,12 @@ module Herb
       # : () -> serialized_erb_begin_node
       def to_hash: () -> serialized_erb_begin_node
 
+      # : (Visitor) -> void
+      def accept: (Visitor) -> void
+
+      # : () -> Array[Herb::AST::Node?]
+      def child_nodes: () -> Array[Herb::AST::Node?]
+
       # : () -> String
       def inspect: () -> String
 
@@ -619,6 +781,12 @@ module Herb
       # : () -> serialized_erb_unless_node
       def to_hash: () -> serialized_erb_unless_node
 
+      # : (Visitor) -> void
+      def accept: (Visitor) -> void
+
+      # : () -> Array[Herb::AST::Node?]
+      def child_nodes: () -> Array[Herb::AST::Node?]
+
       # : () -> String
       def inspect: () -> String
 
@@ -638,6 +806,12 @@ module Herb
 
       # : () -> serialized_erb_yield_node
       def to_hash: () -> serialized_erb_yield_node
+
+      # : (Visitor) -> void
+      def accept: (Visitor) -> void
+
+      # : () -> Array[Herb::AST::Node?]
+      def child_nodes: () -> Array[Herb::AST::Node?]
 
       # : () -> String
       def inspect: () -> String
@@ -660,6 +834,12 @@ module Herb
 
       # : () -> serialized_erb_in_node
       def to_hash: () -> serialized_erb_in_node
+
+      # : (Visitor) -> void
+      def accept: (Visitor) -> void
+
+      # : () -> Array[Herb::AST::Node?]
+      def child_nodes: () -> Array[Herb::AST::Node?]
 
       # : () -> String
       def inspect: () -> String

--- a/sig/herb/parse_result.rbs
+++ b/sig/herb/parse_result.rbs
@@ -15,5 +15,8 @@ module Herb
 
     # : () -> String
     def pretty_errors: () -> String
+
+    # : (Visitor) -> void
+    def visit: (Visitor) -> void
   end
 end

--- a/sig/herb/visitor.rbs
+++ b/sig/herb/visitor.rbs
@@ -11,64 +11,94 @@ module Herb
     # : (Herb::AST::Node) -> void
     def visit_child_nodes: (Herb::AST::Node) -> void
 
-    alias visit_document_node visit_child_nodes
+    # : (Herb::AST::DocumentNode) -> void
+    def visit_document_node: (Herb::AST::DocumentNode) -> void
 
-    alias visit_literal_node visit_child_nodes
+    # : (Herb::AST::LiteralNode) -> void
+    def visit_literal_node: (Herb::AST::LiteralNode) -> void
 
-    alias visit_html_open_tag_node visit_child_nodes
+    # : (Herb::AST::HTMLOpenTagNode) -> void
+    def visit_html_open_tag_node: (Herb::AST::HTMLOpenTagNode) -> void
 
-    alias visit_html_close_tag_node visit_child_nodes
+    # : (Herb::AST::HTMLCloseTagNode) -> void
+    def visit_html_close_tag_node: (Herb::AST::HTMLCloseTagNode) -> void
 
-    alias visit_html_self_close_tag_node visit_child_nodes
+    # : (Herb::AST::HTMLSelfCloseTagNode) -> void
+    def visit_html_self_close_tag_node: (Herb::AST::HTMLSelfCloseTagNode) -> void
 
-    alias visit_html_element_node visit_child_nodes
+    # : (Herb::AST::HTMLElementNode) -> void
+    def visit_html_element_node: (Herb::AST::HTMLElementNode) -> void
 
-    alias visit_html_attribute_value_node visit_child_nodes
+    # : (Herb::AST::HTMLAttributeValueNode) -> void
+    def visit_html_attribute_value_node: (Herb::AST::HTMLAttributeValueNode) -> void
 
-    alias visit_html_attribute_name_node visit_child_nodes
+    # : (Herb::AST::HTMLAttributeNameNode) -> void
+    def visit_html_attribute_name_node: (Herb::AST::HTMLAttributeNameNode) -> void
 
-    alias visit_html_attribute_node visit_child_nodes
+    # : (Herb::AST::HTMLAttributeNode) -> void
+    def visit_html_attribute_node: (Herb::AST::HTMLAttributeNode) -> void
 
-    alias visit_html_text_node visit_child_nodes
+    # : (Herb::AST::HTMLTextNode) -> void
+    def visit_html_text_node: (Herb::AST::HTMLTextNode) -> void
 
-    alias visit_html_comment_node visit_child_nodes
+    # : (Herb::AST::HTMLCommentNode) -> void
+    def visit_html_comment_node: (Herb::AST::HTMLCommentNode) -> void
 
-    alias visit_html_doctype_node visit_child_nodes
+    # : (Herb::AST::HTMLDoctypeNode) -> void
+    def visit_html_doctype_node: (Herb::AST::HTMLDoctypeNode) -> void
 
-    alias visit_whitespace_node visit_child_nodes
+    # : (Herb::AST::WhitespaceNode) -> void
+    def visit_whitespace_node: (Herb::AST::WhitespaceNode) -> void
 
-    alias visit_erb_content_node visit_child_nodes
+    # : (Herb::AST::ERBContentNode) -> void
+    def visit_erb_content_node: (Herb::AST::ERBContentNode) -> void
 
-    alias visit_erb_end_node visit_child_nodes
+    # : (Herb::AST::ERBEndNode) -> void
+    def visit_erb_end_node: (Herb::AST::ERBEndNode) -> void
 
-    alias visit_erb_else_node visit_child_nodes
+    # : (Herb::AST::ERBElseNode) -> void
+    def visit_erb_else_node: (Herb::AST::ERBElseNode) -> void
 
-    alias visit_erb_if_node visit_child_nodes
+    # : (Herb::AST::ERBIfNode) -> void
+    def visit_erb_if_node: (Herb::AST::ERBIfNode) -> void
 
-    alias visit_erb_block_node visit_child_nodes
+    # : (Herb::AST::ERBBlockNode) -> void
+    def visit_erb_block_node: (Herb::AST::ERBBlockNode) -> void
 
-    alias visit_erb_when_node visit_child_nodes
+    # : (Herb::AST::ERBWhenNode) -> void
+    def visit_erb_when_node: (Herb::AST::ERBWhenNode) -> void
 
-    alias visit_erb_case_node visit_child_nodes
+    # : (Herb::AST::ERBCaseNode) -> void
+    def visit_erb_case_node: (Herb::AST::ERBCaseNode) -> void
 
-    alias visit_erb_case_match_node visit_child_nodes
+    # : (Herb::AST::ERBCaseMatchNode) -> void
+    def visit_erb_case_match_node: (Herb::AST::ERBCaseMatchNode) -> void
 
-    alias visit_erb_while_node visit_child_nodes
+    # : (Herb::AST::ERBWhileNode) -> void
+    def visit_erb_while_node: (Herb::AST::ERBWhileNode) -> void
 
-    alias visit_erb_until_node visit_child_nodes
+    # : (Herb::AST::ERBUntilNode) -> void
+    def visit_erb_until_node: (Herb::AST::ERBUntilNode) -> void
 
-    alias visit_erb_for_node visit_child_nodes
+    # : (Herb::AST::ERBForNode) -> void
+    def visit_erb_for_node: (Herb::AST::ERBForNode) -> void
 
-    alias visit_erb_rescue_node visit_child_nodes
+    # : (Herb::AST::ERBRescueNode) -> void
+    def visit_erb_rescue_node: (Herb::AST::ERBRescueNode) -> void
 
-    alias visit_erb_ensure_node visit_child_nodes
+    # : (Herb::AST::ERBEnsureNode) -> void
+    def visit_erb_ensure_node: (Herb::AST::ERBEnsureNode) -> void
 
-    alias visit_erb_begin_node visit_child_nodes
+    # : (Herb::AST::ERBBeginNode) -> void
+    def visit_erb_begin_node: (Herb::AST::ERBBeginNode) -> void
 
-    alias visit_erb_unless_node visit_child_nodes
+    # : (Herb::AST::ERBUnlessNode) -> void
+    def visit_erb_unless_node: (Herb::AST::ERBUnlessNode) -> void
 
-    alias visit_erb_yield_node visit_child_nodes
+    # : (Herb::AST::ERBYieldNode) -> void
+    def visit_erb_yield_node: (Herb::AST::ERBYieldNode) -> void
 
-    alias visit_erb_in_node visit_child_nodes
+    # : (Herb::AST::ERBInNode) -> void
+    def visit_erb_in_node: (Herb::AST::ERBInNode) -> void
   end
 end

--- a/sig/herb/visitor.rbs
+++ b/sig/herb/visitor.rbs
@@ -1,0 +1,74 @@
+# Generated from lib/herb/visitor.rb with RBS::Inline
+
+module Herb
+  class Visitor
+    # : (Herb::AST::Node) -> void
+    def visit: (Herb::AST::Node) -> void
+
+    # : (Array[Herb::AST::Node]) -> void
+    def visit_all: (Array[Herb::AST::Node]) -> void
+
+    # : (Herb::AST::Node) -> void
+    def visit_child_nodes: (Herb::AST::Node) -> void
+
+    alias visit_document_node visit_child_nodes
+
+    alias visit_literal_node visit_child_nodes
+
+    alias visit_html_open_tag_node visit_child_nodes
+
+    alias visit_html_close_tag_node visit_child_nodes
+
+    alias visit_html_self_close_tag_node visit_child_nodes
+
+    alias visit_html_element_node visit_child_nodes
+
+    alias visit_html_attribute_value_node visit_child_nodes
+
+    alias visit_html_attribute_name_node visit_child_nodes
+
+    alias visit_html_attribute_node visit_child_nodes
+
+    alias visit_html_text_node visit_child_nodes
+
+    alias visit_html_comment_node visit_child_nodes
+
+    alias visit_html_doctype_node visit_child_nodes
+
+    alias visit_whitespace_node visit_child_nodes
+
+    alias visit_erb_content_node visit_child_nodes
+
+    alias visit_erb_end_node visit_child_nodes
+
+    alias visit_erb_else_node visit_child_nodes
+
+    alias visit_erb_if_node visit_child_nodes
+
+    alias visit_erb_block_node visit_child_nodes
+
+    alias visit_erb_when_node visit_child_nodes
+
+    alias visit_erb_case_node visit_child_nodes
+
+    alias visit_erb_case_match_node visit_child_nodes
+
+    alias visit_erb_while_node visit_child_nodes
+
+    alias visit_erb_until_node visit_child_nodes
+
+    alias visit_erb_for_node visit_child_nodes
+
+    alias visit_erb_rescue_node visit_child_nodes
+
+    alias visit_erb_ensure_node visit_child_nodes
+
+    alias visit_erb_begin_node visit_child_nodes
+
+    alias visit_erb_unless_node visit_child_nodes
+
+    alias visit_erb_yield_node visit_child_nodes
+
+    alias visit_erb_in_node visit_child_nodes
+  end
+end

--- a/templates/lib/herb/ast/nodes.rb.erb
+++ b/templates/lib/herb/ast/nodes.rb.erb
@@ -27,6 +27,24 @@ module Herb
         }) #: Herb::serialized_<%= node.human %>
       end
 
+      #: (Visitor) -> void
+      def accept(visitor)
+        visitor.visit_<%= node.human %>(self)
+      end
+
+      #: () -> Array[Herb::AST::Node?]
+      def child_nodes
+        [<%= node.fields.map { |field|
+          if field.is_a?(Herb::Template::NodeField)
+            field.name
+          elsif field.is_a?(Herb::Template::ArrayField) && field.specific_kind.end_with?("Node")
+            "*#{field.name}"
+          else
+            nil
+          end
+        }.compact.join(", ") %>]
+      end
+
       #: () -> String
       def inspect
         tree_inspect.rstrip.gsub(/\s+$/, "")

--- a/templates/lib/herb/visitor.rb.erb
+++ b/templates/lib/herb/visitor.rb.erb
@@ -16,7 +16,11 @@ module Herb
     end
 
     <%- nodes.each do |node| -%>
-    alias visit_<%= node.human %> visit_child_nodes
+    #: (Herb::AST::<%= node.name %>) -> void
+    def visit_<%= node.human %>(node)
+      visit_child_nodes(node)
+    end
+
     <%- end -%>
   end
 end

--- a/templates/lib/herb/visitor.rb.erb
+++ b/templates/lib/herb/visitor.rb.erb
@@ -1,0 +1,22 @@
+module Herb
+  class Visitor
+    #: (Herb::AST::Node) -> void
+    def visit(node)
+      node&.accept(self)
+    end
+
+    #: (Array[Herb::AST::Node]) -> void
+    def visit_all(nodes)
+      nodes.each { |node| node&.accept(self) }
+    end
+
+    #: (Herb::AST::Node) -> void
+    def visit_child_nodes(node)
+      node.child_nodes.each { |node| node.accept(self) }
+    end
+
+    <%- nodes.each do |node| -%>
+    alias visit_<%= node.human %> visit_child_nodes
+    <%- end -%>
+  end
+end

--- a/test/visitor_test.rb
+++ b/test/visitor_test.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+class VisitorTest < Minitest::Spec
+  class VisitedNodesVisitor < Herb::Visitor
+    attr_reader :visited_nodes
+
+    def initialize
+      super
+      @visited_nodes = []
+    end
+
+    def visit_child_nodes(node)
+      @visited_nodes << node
+      super
+    end
+  end
+
+  test "visitor" do
+    visitor = VisitedNodesVisitor.new
+
+    result = Herb.parse(%(<p id="greeting">Hello <%= user.name %></p>))
+    result.visit(visitor)
+
+    expected_nodes = [
+      "Herb::AST::DocumentNode",
+      "Herb::AST::HTMLElementNode",
+      "Herb::AST::HTMLOpenTagNode",
+      "Herb::AST::HTMLAttributeNode",
+      "Herb::AST::HTMLAttributeNameNode",
+      "Herb::AST::HTMLAttributeValueNode",
+      "Herb::AST::LiteralNode",
+      "Herb::AST::HTMLTextNode",
+      "Herb::AST::ERBContentNode",
+      "Herb::AST::HTMLCloseTagNode"
+    ]
+
+    assert_equal expected_nodes, visitor.visited_nodes.map(&:class).map(&:to_s)
+  end
+end


### PR DESCRIPTION
This pull request introduces a `Herb::Visitor` class to the ruby gem, enabling traversal of the AST by writing a visitor class that inherits from `Herb::Visitor`.

```ruby
class TextNodeVisitor < Herb::Visitor
  def visit_html_text_node(node)
    puts "HTML TextNode #{node.content}"
  end
end

visitor = TextNodeVisitor.new

result = Herb.parse("<p>Hello <%= user.name %></p>")
result.visit(visitor)
```