### PR TITLE
Refactor Ruby extension to reuse constants

### DIFF
--- a/ext/herb/extension.c
+++ b/ext/herb/extension.c
@@ -1,10 +1,20 @@
 #include <ruby.h>
 
 #include "error_helpers.h"
+#include "extension.h"
 #include "extension_helpers.h"
 #include "nodes.h"
 
 #include "../../src/include/analyze.h"
+
+VALUE mHerb;
+VALUE cPosition;
+VALUE cLocation;
+VALUE cRange;
+VALUE cToken;
+VALUE cResult;
+VALUE cLexResult;
+VALUE cParseResult;
 
 static VALUE Herb_lex(VALUE self, VALUE source) {
   char* string = (char*) check_string(source);
@@ -112,14 +122,21 @@ static VALUE Herb_version(VALUE self) {
 }
 
 void Init_herb(void) {
-  VALUE Herb = rb_define_module("Herb");
+  mHerb = rb_define_module("Herb");
+  cPosition = rb_define_class_under(mHerb, "Position", rb_cObject);
+  cLocation = rb_define_class_under(mHerb, "Location", rb_cObject);
+  cRange = rb_define_class_under(mHerb, "Range", rb_cObject);
+  cToken = rb_define_class_under(mHerb, "Token", rb_cObject);
+  cResult = rb_define_class_under(mHerb, "Result", rb_cObject);
+  cLexResult = rb_define_class_under(mHerb, "LexResult", cResult);
+  cParseResult = rb_define_class_under(mHerb, "ParseResult", cResult);
 
-  rb_define_singleton_method(Herb, "parse", Herb_parse, 1);
-  rb_define_singleton_method(Herb, "lex", Herb_lex, 1);
-  rb_define_singleton_method(Herb, "parse_file", Herb_parse_file, 1);
-  rb_define_singleton_method(Herb, "lex_file", Herb_lex_file, 1);
-  rb_define_singleton_method(Herb, "lex_to_json", Herb_lex_to_json, 1);
-  rb_define_singleton_method(Herb, "extract_ruby", Herb_extract_ruby, 1);
-  rb_define_singleton_method(Herb, "extract_html", Herb_extract_html, 1);
-  rb_define_singleton_method(Herb, "version", Herb_version, 0);
+  rb_define_singleton_method(mHerb, "parse", Herb_parse, 1);
+  rb_define_singleton_method(mHerb, "lex", Herb_lex, 1);
+  rb_define_singleton_method(mHerb, "parse_file", Herb_parse_file, 1);
+  rb_define_singleton_method(mHerb, "lex_file", Herb_lex_file, 1);
+  rb_define_singleton_method(mHerb, "lex_to_json", Herb_lex_to_json, 1);
+  rb_define_singleton_method(mHerb, "extract_ruby", Herb_extract_ruby, 1);
+  rb_define_singleton_method(mHerb, "extract_html", Herb_extract_html, 1);
+  rb_define_singleton_method(mHerb, "version", Herb_version, 0);
 }

--- a/ext/herb/extension.h
+++ b/ext/herb/extension.h
@@ -3,4 +3,13 @@
 
 void Init_herb(void);
 
+extern VALUE mHerb;
+extern VALUE cPosition;
+extern VALUE cLocation;
+extern VALUE cRange;
+extern VALUE cToken;
+extern VALUE cResult;
+extern VALUE cLexResult;
+extern VALUE cParseResult;
+
 #endif

--- a/ext/herb/extension_helpers.c
+++ b/ext/herb/extension_helpers.c
@@ -1,5 +1,6 @@
 #include <ruby.h>
 
+#include "extension.h"
 #include "extension_helpers.h"
 #include "nodes.h"
 
@@ -26,10 +27,7 @@ VALUE rb_position_from_c_struct(position_T* position) {
   args[0] = SIZET2NUM(position->line);
   args[1] = SIZET2NUM(position->column);
 
-  VALUE Herb = rb_define_module("Herb");
-  VALUE Position = rb_define_class_under(Herb, "Position", rb_cObject);
-
-  return rb_class_new_instance(2, args, Position);
+  return rb_class_new_instance(2, args, cPosition);
 }
 
 VALUE rb_location_from_c_struct(location_T* location) {
@@ -39,10 +37,7 @@ VALUE rb_location_from_c_struct(location_T* location) {
   args[0] = rb_position_from_c_struct(location->start);
   args[1] = rb_position_from_c_struct(location->end);
 
-  VALUE Herb = rb_define_module("Herb");
-  VALUE Location = rb_define_class_under(Herb, "Location", rb_cObject);
-
-  return rb_class_new_instance(2, args, Location);
+  return rb_class_new_instance(2, args, cLocation);
 }
 
 VALUE rb_range_from_c_struct(range_T* range) {
@@ -52,10 +47,7 @@ VALUE rb_range_from_c_struct(range_T* range) {
   args[0] = SIZET2NUM(range->from);
   args[1] = SIZET2NUM(range->to);
 
-  VALUE Herb = rb_define_module("Herb");
-  VALUE Range = rb_define_class_under(Herb, "Range", rb_cObject);
-
-  return rb_class_new_instance(2, args, Range);
+  return rb_class_new_instance(2, args, cRange);
 }
 
 VALUE rb_token_from_c_struct(token_T* token) {
@@ -69,10 +61,7 @@ VALUE rb_token_from_c_struct(token_T* token) {
 
   VALUE args[4] = { value, range, location, type };
 
-  VALUE Herb = rb_define_module("Herb");
-  VALUE Token = rb_define_class_under(Herb, "Token", rb_cObject);
-
-  return rb_class_new_instance(4, args, Token);
+  return rb_class_new_instance(4, args, cToken);
 }
 
 VALUE create_lex_result(array_T* tokens, VALUE source) {
@@ -85,13 +74,9 @@ VALUE create_lex_result(array_T* tokens, VALUE source) {
     if (token != NULL) { rb_ary_push(value, rb_token_from_c_struct(token)); }
   }
 
-  VALUE Herb = rb_define_module("Herb");
-  VALUE Result = rb_define_class_under(Herb, "Result", rb_cObject);
-  VALUE LexResult = rb_define_class_under(Herb, "LexResult", Result);
-
   VALUE args[4] = { value, source, warnings, errors };
 
-  return rb_class_new_instance(4, args, LexResult);
+  return rb_class_new_instance(4, args, cLexResult);
 }
 
 VALUE create_parse_result(AST_DOCUMENT_NODE_T* root, VALUE source) {
@@ -99,13 +84,9 @@ VALUE create_parse_result(AST_DOCUMENT_NODE_T* root, VALUE source) {
   VALUE warnings = rb_ary_new();
   VALUE errors = rb_ary_new();
 
-  VALUE Herb = rb_define_module("Herb");
-  VALUE Result = rb_define_class_under(Herb, "Result", rb_cObject);
-  VALUE ParseResult = rb_define_class_under(Herb, "ParseResult", Result);
-
   VALUE args[4] = { value, source, warnings, errors };
 
-  return rb_class_new_instance(4, args, ParseResult);
+  return rb_class_new_instance(4, args, cParseResult);
 }
 
 VALUE read_file_to_ruby_string(const char* file_path) {


### PR DESCRIPTION
This pull request refactors the `Herb` Ruby C extension to centralize the definitions of module and class constants. This reduces redundancy and any issues that might arise from redefining the constants on every call.


