### PR TITLE
Increase initial buffer capacity to 8192

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -8,7 +8,7 @@
 #include "include/util.h"
 
 bool buffer_init(buffer_T* buffer) {
-  buffer->capacity = 1024;
+  buffer->capacity = 8192;
   buffer->length = 0;
   buffer->value = nullable_safe_malloc(buffer->capacity * sizeof(char));
 

--- a/test/c/test_buffer.c
+++ b/test/c/test_buffer.c
@@ -6,7 +6,7 @@ TEST(test_buffer_init)
   buffer_T buffer;
 
   ck_assert(buffer_init(&buffer));
-  ck_assert_int_eq(buffer.capacity, 1024);
+  ck_assert_int_eq(buffer.capacity, 8192);
   ck_assert_int_eq(buffer.length, 0);
   ck_assert_ptr_nonnull(buffer.value);
   ck_assert_str_eq(buffer.value, "");
@@ -63,7 +63,7 @@ TEST(test_buffer_increase_capacity)
   buffer_T buffer = buffer_new();
 
   const size_t initial_capacity = buffer.capacity;
-  ck_assert_int_ge(initial_capacity, 1024); // Ensure initial capacity is at least 1024
+  ck_assert_int_ge(initial_capacity, 8192); // Ensure initial capacity is at least 8192
 
   // Increase capacity by a small amount, should NOT trigger reallocation
   ck_assert(buffer_increase_capacity(&buffer, 100));
@@ -80,8 +80,8 @@ END
 TEST(test_buffer_reserve)
   buffer_T buffer = buffer_new();
 
-  ck_assert(buffer_reserve(&buffer, 2048)); // Ensure space for 4096 bytes
-  ck_assert_int_eq(buffer.capacity, 4096);
+  ck_assert(buffer_reserve(&buffer, 16384)); // Ensure space for 16384 bytes
+  ck_assert_int_eq(buffer.capacity, 32768);
 
   buffer_free(&buffer);
 END
@@ -97,7 +97,7 @@ TEST(test_buffer_clear)
 
   ck_assert_str_eq(buffer.value, "");
   ck_assert_int_eq(buffer.length, 0);
-  ck_assert_int_eq(buffer.capacity, 1024); // Capacity should remain unchanged
+  ck_assert_int_eq(buffer.capacity, 8192); // Capacity should remain unchanged
 
   buffer_free(&buffer);
 END
@@ -108,7 +108,7 @@ TEST(test_buffer_free)
 
   buffer_append(&buffer, "Test");
   ck_assert_int_eq(buffer.length, 4);
-  ck_assert_int_eq(buffer.capacity, 1024);
+  ck_assert_int_eq(buffer.capacity, 8192);
   buffer_free(&buffer);
 
   ck_assert_ptr_null(buffer.value);

--- a/test/libherb/buffer_test.rb
+++ b/test/libherb/buffer_test.rb
@@ -42,7 +42,7 @@ module LibHerb
       Herb::LibHerb::Buffer.with do |buffer|
         assert_equal "", buffer.read
         assert_equal 0, buffer.length
-        assert_equal 1024, buffer.capacity
+        assert_equal 8192, buffer.capacity
 
         string = "0123456789" * 64 # 640 bytes
 
@@ -50,20 +50,20 @@ module LibHerb
 
         assert_equal string, buffer.read
         assert_equal 640, buffer.length
-        assert_equal 1024, buffer.capacity # no realloc yet
+        assert_equal 8192, buffer.capacity # no realloc yet
 
         buffer.append(string)
 
         assert_equal "#{string}#{string}", buffer.read
         assert_equal 1280, buffer.length
-        assert_equal 2560, buffer.capacity # now it doubled
+        assert_equal 16384, buffer.capacity # now it doubled
       end
     end
 
     test "buffer length and capacity" do
       Herb::LibHerb::Buffer.with do |buffer|
         assert_equal buffer.length, 0
-        assert_equal buffer.capacity, 1024
+        assert_equal buffer.capacity, 8192
 
         assert buffer.capacity >= buffer.length, "Buffer capacity should be at least the length"
       end


### PR DESCRIPTION
This pull request updates the initial capacity of the `buffer_T` structure from `1024` to `8192`. This helps with the symptoms that surfaced in #103, but obviously doesn't solve them ultimately, just makes them less likely to show up.