### PR TITLE
Implement `Herb::Node#compact_child_nodes`

### DIFF
--- a/lib/herb/ast/node.rb
+++ b/lib/herb/ast/node.rb
@@ -81,12 +81,17 @@ module Herb
         raise NoMethodError, "undefined method `accept' for #{inspect}"
       end
 
-      #: () -> Array[Herb::AST::Node]
+      #: () -> Array[Herb::AST::Node?]
       def child_nodes
         raise NoMethodError, "undefined method `child_nodes' for #{inspect}"
       end
 
       alias deconstruct child_nodes
+
+      #: () -> Array[Herb::AST::Node]
+      def compact_child_nodes
+        child_nodes.compact
+      end
     end
   end
 end

--- a/sig/herb/ast/node.rbs
+++ b/sig/herb/ast/node.rbs
@@ -36,10 +36,13 @@ module Herb
       # : (Visitor) -> void
       def accept: (Visitor) -> void
 
-      # : () -> Array[Herb::AST::Node]
-      def child_nodes: () -> Array[Herb::AST::Node]
+      # : () -> Array[Herb::AST::Node?]
+      def child_nodes: () -> Array[Herb::AST::Node?]
 
       alias deconstruct child_nodes
+
+      # : () -> Array[Herb::AST::Node]
+      def compact_child_nodes: () -> Array[Herb::AST::Node]
     end
   end
 end

--- a/sig/herb/ast/nodes.rbs
+++ b/sig/herb/ast/nodes.rbs
@@ -17,6 +17,9 @@ module Herb
       # : () -> Array[Herb::AST::Node?]
       def child_nodes: () -> Array[Herb::AST::Node?]
 
+      # : () -> Array[Herb::AST::Node]
+      def compact_child_nodes: () -> Array[Herb::AST::Node]
+
       # : () -> String
       def inspect: () -> String
 
@@ -38,6 +41,9 @@ module Herb
 
       # : () -> Array[Herb::AST::Node?]
       def child_nodes: () -> Array[Herb::AST::Node?]
+
+      # : () -> Array[Herb::AST::Node]
+      def compact_child_nodes: () -> Array[Herb::AST::Node]
 
       # : () -> String
       def inspect: () -> String
@@ -69,6 +75,9 @@ module Herb
       # : () -> Array[Herb::AST::Node?]
       def child_nodes: () -> Array[Herb::AST::Node?]
 
+      # : () -> Array[Herb::AST::Node]
+      def compact_child_nodes: () -> Array[Herb::AST::Node]
+
       # : () -> String
       def inspect: () -> String
 
@@ -94,6 +103,9 @@ module Herb
 
       # : () -> Array[Herb::AST::Node?]
       def child_nodes: () -> Array[Herb::AST::Node?]
+
+      # : () -> Array[Herb::AST::Node]
+      def compact_child_nodes: () -> Array[Herb::AST::Node]
 
       # : () -> String
       def inspect: () -> String
@@ -125,6 +137,9 @@ module Herb
       # : () -> Array[Herb::AST::Node?]
       def child_nodes: () -> Array[Herb::AST::Node?]
 
+      # : () -> Array[Herb::AST::Node]
+      def compact_child_nodes: () -> Array[Herb::AST::Node]
+
       # : () -> String
       def inspect: () -> String
 
@@ -155,6 +170,9 @@ module Herb
       # : () -> Array[Herb::AST::Node?]
       def child_nodes: () -> Array[Herb::AST::Node?]
 
+      # : () -> Array[Herb::AST::Node]
+      def compact_child_nodes: () -> Array[Herb::AST::Node]
+
       # : () -> String
       def inspect: () -> String
 
@@ -183,6 +201,9 @@ module Herb
       # : () -> Array[Herb::AST::Node?]
       def child_nodes: () -> Array[Herb::AST::Node?]
 
+      # : () -> Array[Herb::AST::Node]
+      def compact_child_nodes: () -> Array[Herb::AST::Node]
+
       # : () -> String
       def inspect: () -> String
 
@@ -204,6 +225,9 @@ module Herb
 
       # : () -> Array[Herb::AST::Node?]
       def child_nodes: () -> Array[Herb::AST::Node?]
+
+      # : () -> Array[Herb::AST::Node]
+      def compact_child_nodes: () -> Array[Herb::AST::Node]
 
       # : () -> String
       def inspect: () -> String
@@ -231,6 +255,9 @@ module Herb
       # : () -> Array[Herb::AST::Node?]
       def child_nodes: () -> Array[Herb::AST::Node?]
 
+      # : () -> Array[Herb::AST::Node]
+      def compact_child_nodes: () -> Array[Herb::AST::Node]
+
       # : () -> String
       def inspect: () -> String
 
@@ -252,6 +279,9 @@ module Herb
 
       # : () -> Array[Herb::AST::Node?]
       def child_nodes: () -> Array[Herb::AST::Node?]
+
+      # : () -> Array[Herb::AST::Node]
+      def compact_child_nodes: () -> Array[Herb::AST::Node]
 
       # : () -> String
       def inspect: () -> String
@@ -279,6 +309,9 @@ module Herb
       # : () -> Array[Herb::AST::Node?]
       def child_nodes: () -> Array[Herb::AST::Node?]
 
+      # : () -> Array[Herb::AST::Node]
+      def compact_child_nodes: () -> Array[Herb::AST::Node]
+
       # : () -> String
       def inspect: () -> String
 
@@ -305,6 +338,9 @@ module Herb
       # : () -> Array[Herb::AST::Node?]
       def child_nodes: () -> Array[Herb::AST::Node?]
 
+      # : () -> Array[Herb::AST::Node]
+      def compact_child_nodes: () -> Array[Herb::AST::Node]
+
       # : () -> String
       def inspect: () -> String
 
@@ -326,6 +362,9 @@ module Herb
 
       # : () -> Array[Herb::AST::Node?]
       def child_nodes: () -> Array[Herb::AST::Node?]
+
+      # : () -> Array[Herb::AST::Node]
+      def compact_child_nodes: () -> Array[Herb::AST::Node]
 
       # : () -> String
       def inspect: () -> String
@@ -359,6 +398,9 @@ module Herb
       # : () -> Array[Herb::AST::Node?]
       def child_nodes: () -> Array[Herb::AST::Node?]
 
+      # : () -> Array[Herb::AST::Node]
+      def compact_child_nodes: () -> Array[Herb::AST::Node]
+
       # : () -> String
       def inspect: () -> String
 
@@ -384,6 +426,9 @@ module Herb
 
       # : () -> Array[Herb::AST::Node?]
       def child_nodes: () -> Array[Herb::AST::Node?]
+
+      # : () -> Array[Herb::AST::Node]
+      def compact_child_nodes: () -> Array[Herb::AST::Node]
 
       # : () -> String
       def inspect: () -> String
@@ -412,6 +457,9 @@ module Herb
 
       # : () -> Array[Herb::AST::Node?]
       def child_nodes: () -> Array[Herb::AST::Node?]
+
+      # : () -> Array[Herb::AST::Node]
+      def compact_child_nodes: () -> Array[Herb::AST::Node]
 
       # : () -> String
       def inspect: () -> String
@@ -445,6 +493,9 @@ module Herb
       # : () -> Array[Herb::AST::Node?]
       def child_nodes: () -> Array[Herb::AST::Node?]
 
+      # : () -> Array[Herb::AST::Node]
+      def compact_child_nodes: () -> Array[Herb::AST::Node]
+
       # : () -> String
       def inspect: () -> String
 
@@ -475,6 +526,9 @@ module Herb
       # : () -> Array[Herb::AST::Node?]
       def child_nodes: () -> Array[Herb::AST::Node?]
 
+      # : () -> Array[Herb::AST::Node]
+      def compact_child_nodes: () -> Array[Herb::AST::Node]
+
       # : () -> String
       def inspect: () -> String
 
@@ -502,6 +556,9 @@ module Herb
 
       # : () -> Array[Herb::AST::Node?]
       def child_nodes: () -> Array[Herb::AST::Node?]
+
+      # : () -> Array[Herb::AST::Node]
+      def compact_child_nodes: () -> Array[Herb::AST::Node]
 
       # : () -> String
       def inspect: () -> String
@@ -537,6 +594,9 @@ module Herb
       # : () -> Array[Herb::AST::Node?]
       def child_nodes: () -> Array[Herb::AST::Node?]
 
+      # : () -> Array[Herb::AST::Node]
+      def compact_child_nodes: () -> Array[Herb::AST::Node]
+
       # : () -> String
       def inspect: () -> String
 
@@ -571,6 +631,9 @@ module Herb
       # : () -> Array[Herb::AST::Node?]
       def child_nodes: () -> Array[Herb::AST::Node?]
 
+      # : () -> Array[Herb::AST::Node]
+      def compact_child_nodes: () -> Array[Herb::AST::Node]
+
       # : () -> String
       def inspect: () -> String
 
@@ -600,6 +663,9 @@ module Herb
 
       # : () -> Array[Herb::AST::Node?]
       def child_nodes: () -> Array[Herb::AST::Node?]
+
+      # : () -> Array[Herb::AST::Node]
+      def compact_child_nodes: () -> Array[Herb::AST::Node]
 
       # : () -> String
       def inspect: () -> String
@@ -631,6 +697,9 @@ module Herb
       # : () -> Array[Herb::AST::Node?]
       def child_nodes: () -> Array[Herb::AST::Node?]
 
+      # : () -> Array[Herb::AST::Node]
+      def compact_child_nodes: () -> Array[Herb::AST::Node]
+
       # : () -> String
       def inspect: () -> String
 
@@ -660,6 +729,9 @@ module Herb
 
       # : () -> Array[Herb::AST::Node?]
       def child_nodes: () -> Array[Herb::AST::Node?]
+
+      # : () -> Array[Herb::AST::Node]
+      def compact_child_nodes: () -> Array[Herb::AST::Node]
 
       # : () -> String
       def inspect: () -> String
@@ -691,6 +763,9 @@ module Herb
       # : () -> Array[Herb::AST::Node?]
       def child_nodes: () -> Array[Herb::AST::Node?]
 
+      # : () -> Array[Herb::AST::Node]
+      def compact_child_nodes: () -> Array[Herb::AST::Node]
+
       # : () -> String
       def inspect: () -> String
 
@@ -718,6 +793,9 @@ module Herb
 
       # : () -> Array[Herb::AST::Node?]
       def child_nodes: () -> Array[Herb::AST::Node?]
+
+      # : () -> Array[Herb::AST::Node]
+      def compact_child_nodes: () -> Array[Herb::AST::Node]
 
       # : () -> String
       def inspect: () -> String
@@ -755,6 +833,9 @@ module Herb
       # : () -> Array[Herb::AST::Node?]
       def child_nodes: () -> Array[Herb::AST::Node?]
 
+      # : () -> Array[Herb::AST::Node]
+      def compact_child_nodes: () -> Array[Herb::AST::Node]
+
       # : () -> String
       def inspect: () -> String
 
@@ -787,6 +868,9 @@ module Herb
       # : () -> Array[Herb::AST::Node?]
       def child_nodes: () -> Array[Herb::AST::Node?]
 
+      # : () -> Array[Herb::AST::Node]
+      def compact_child_nodes: () -> Array[Herb::AST::Node]
+
       # : () -> String
       def inspect: () -> String
 
@@ -812,6 +896,9 @@ module Herb
 
       # : () -> Array[Herb::AST::Node?]
       def child_nodes: () -> Array[Herb::AST::Node?]
+
+      # : () -> Array[Herb::AST::Node]
+      def compact_child_nodes: () -> Array[Herb::AST::Node]
 
       # : () -> String
       def inspect: () -> String
@@ -840,6 +927,9 @@ module Herb
 
       # : () -> Array[Herb::AST::Node?]
       def child_nodes: () -> Array[Herb::AST::Node?]
+
+      # : () -> Array[Herb::AST::Node]
+      def compact_child_nodes: () -> Array[Herb::AST::Node]
 
       # : () -> String
       def inspect: () -> String

--- a/templates/lib/herb/ast/nodes.rb.erb
+++ b/templates/lib/herb/ast/nodes.rb.erb
@@ -45,6 +45,11 @@ module Herb
         }.compact.join(", ") %>]
       end
 
+      #: () -> Array[Herb::AST::Node]
+      def compact_child_nodes
+        child_nodes.compact
+      end
+
       #: () -> String
       def inspect
         tree_inspect.rstrip.gsub(/\s+$/, "")

--- a/templates/lib/herb/visitor.rb.erb
+++ b/templates/lib/herb/visitor.rb.erb
@@ -12,7 +12,7 @@ module Herb
 
     #: (Herb::AST::Node) -> void
     def visit_child_nodes(node)
-      node.child_nodes.each { |node| node.accept(self) }
+      node.compact_child_nodes.each { |node| node.accept(self) }
     end
 
     <%- nodes.each do |node| -%>

--- a/test/visitor_test.rb
+++ b/test/visitor_test.rb
@@ -38,4 +38,20 @@ class VisitorTest < Minitest::Spec
 
     assert_equal expected_nodes, visitor.visited_nodes.map(&:class).map(&:to_s)
   end
+
+  test "document with nil in child_nodes" do
+    visitor = VisitedNodesVisitor.new
+
+    result = Herb.parse(%(<p>Hello))
+    result.visit(visitor)
+
+    expected_nodes = [
+      "Herb::AST::DocumentNode",
+      "Herb::AST::HTMLElementNode",
+      "Herb::AST::HTMLOpenTagNode",
+      "Herb::AST::HTMLTextNode"
+    ]
+
+    assert_equal expected_nodes, visitor.visited_nodes.map(&:class).map(&:to_s)
+  end
 end


### PR DESCRIPTION
This pull request introduces changes to improve the handling of `nil` values in `child_nodes` when traversing a tree using a Visitor. The `compact_child_nodes` method filters out `nil` values so that the visitor can call that method without having to handle nil values there.

Previously this would fail with something like:

```
NoMethodError: undefined method 'accept' for nil
    lib/herb/visitor.rb:21:in 'block in Herb::Visitor#visit_child_nodes'
    lib/herb/visitor.rb:21:in 'Array#each'
    lib/herb/visitor.rb:21:in 'Herb::Visitor#visit_child_nodes'
    test/visitor_test.rb:16:in 'VisitorTest::VisitedNodesVisitor#visit_child_nodes'
    lib/herb/visitor.rb:51:in 'Herb::Visitor#visit_html_element_node'
    lib/herb/ast/nodes.rb:344:in 'Herb::AST::HTMLElementNode#accept'
    lib/herb/visitor.rb:21:in 'block in Herb::Visitor#visit_child_nodes'
    lib/herb/visitor.rb:21:in 'Array#each'
    lib/herb/visitor.rb:21:in 'Herb::Visitor#visit_child_nodes'
    test/visitor_test.rb:16:in 'VisitorTest::VisitedNodesVisitor#visit_child_nodes'
    lib/herb/visitor.rb:26:in 'Herb::Visitor#visit_document_node'
    lib/herb/ast/nodes.rb:27:in 'Herb::AST::DocumentNode#accept'
    lib/herb/parse_result.rb:32:in 'Herb::ParseResult#visit'
    test/visitor_test.rb:46:in 'block in <class:VisitorTest>'
```