### PR TITLE
Increase buffer capacity safely and handle overflow errors

### DIFF
--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -13,8 +13,11 @@ typedef struct BUFFER_STRUCT {
 bool buffer_init(buffer_T* buffer);
 buffer_T buffer_new(void);
 
-bool buffer_increase_capacity(buffer_T* buffer, size_t required_length);
-bool buffer_ensure_capacity(buffer_T* buffer, size_t min_capacity);
+bool buffer_increase_capacity(buffer_T* buffer, size_t additional_capacity);
+bool buffer_has_capacity(buffer_T* buffer, size_t required_length);
+bool buffer_expand_capacity(buffer_T* buffer);
+bool buffer_expand_if_needed(buffer_T* buffer, size_t required_length);
+bool buffer_resize(buffer_T* buffer, size_t new_capacity);
 
 void buffer_append(buffer_T* buffer, const char* text);
 void buffer_append_with_length(buffer_T* buffer, const char* text, size_t length);


### PR DESCRIPTION
This pull request refactors the buffer management system in `src/buffer.c` and updates its corresponding tests. The changes improve the clarity of function names, introduce new helper functions for managing buffer capacity, and enhance error handling.

Replaced `buffer_increase_capacity` with `buffer_expand_if_needed`, which dynamically adjusts buffer capacity based on required length. Introduced new helper functions `buffer_resize`, `buffer_expand_capacity`, and `buffer_has_capacity` for more modular buffer operations. Improved error handling by using `exit(1)` for critical failures.

Alternative to #118

Might close #103 
Might close #121 
