### PR TITLE
Support `-v` and `--version` in Ruby CLI

### DIFF
--- a/lib/herb/cli.rb
+++ b/lib/herb/cli.rb
@@ -128,11 +128,10 @@ class Herb::CLI
                     puts "This command can currently only be run within the herb repo itself"
                     exit(1)
                   end
-                when "help", "-h", "--help"
+                when "help"
                   help
-                when "version", "-v", "--version"
-                  puts Herb.version
-                  exit(0)
+                when "version"
+                  print_version
                 when String
                   puts "Unknown command: '#{@command}'"
                   puts
@@ -146,6 +145,10 @@ class Herb::CLI
   def option_parser
     @option_parser ||= OptionParser.new do |parser|
       parser.banner = ""
+
+      parser.on_tail("-v", "--version", "Show the version") do
+        print_version
+      end
 
       parser.on_tail("-h", "--help", "Show this message") do
         help
@@ -164,5 +167,12 @@ class Herb::CLI
 
   def options
     option_parser.parse!(@args)
+  end
+
+  private
+
+  def print_version
+    puts Herb.version
+    exit(0)
   end
 end


### PR DESCRIPTION
Prior to this, only `herb version` worked. Now with this pull request you can also use `herb -v` and `herb --version` to get the version information:

```sh
❯ ./exe/herb version
herb gem v0.2.0, libprism v1.4.0, libherb v0.2.0 (Ruby C native extension)

❯ ./exe/herb -v
herb gem v0.2.0, libprism v1.4.0, libherb v0.2.0 (Ruby C native extension)

❯ ./exe/herb --version
herb gem v0.2.0, libprism v1.4.0, libherb v0.2.0 (Ruby C native extension)

```
Closes https://github.com/marcoroth/herb/issues/123