### PR TITLE
Fix parser to handle quotes around ERB output as text content

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -618,6 +618,7 @@ static void parser_parse_in_data_state(parser_T* parser, array_T* children, arra
           TOKEN_IDENTIFIER,
           TOKEN_NEWLINE,
           TOKEN_PERCENT,
+          TOKEN_QUOTE,
           TOKEN_SEMICOLON,
           TOKEN_SLASH,
           TOKEN_UNDERSCORE,

--- a/test/parser/erb_test.rb
+++ b/test/parser/erb_test.rb
@@ -81,5 +81,33 @@ module Parser
         %>
       HTML
     end
+
+    test "erb output wrapped in double quotes" do
+      assert_parsed_snapshot(<<~HTML)
+        "<%= value %>"
+      HTML
+    end
+
+    test "erb output wrapped in single quotes" do
+      assert_parsed_snapshot(<<~HTML)
+        '<%= value %>'
+      HTML
+    end
+
+    test "erb output wrapped in double quotes inside if" do
+      assert_parsed_snapshot(<<~HTML)
+        <% if true %>
+          "<%= value %>"
+        <% end %>
+      HTML
+    end
+
+    test "erb output wrapped in single quotes inside if" do
+      assert_parsed_snapshot(<<~HTML)
+        <% if true %>
+          '<%= value %>'
+        <% end %>
+      HTML
+    end
   end
 end

--- a/test/snapshots/parser/erb_test/test_0018_erb_output_wrapped_in_double_quotes_81968725d5b5d72882f6ae09a80071b7.txt
+++ b/test/snapshots/parser/erb_test/test_0018_erb_output_wrapped_in_double_quotes_81968725d5b5d72882f6ae09a80071b7.txt
@@ -1,0 +1,14 @@
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (3 items)
+    ├── @ HTMLTextNode (location: (1:0)-(1:1))
+    │   └── content: "\""
+    │
+    ├── @ ERBContentNode (location: (1:1)-(1:13))
+    │   ├── tag_opening: "<%=" (location: (1:1)-(1:4))
+    │   ├── content: " value " (location: (1:4)-(1:11))
+    │   ├── tag_closing: "%>" (location: (1:11)-(1:13))
+    │   ├── parsed: true
+    │   └── valid: true
+    │
+    └── @ HTMLTextNode (location: (1:13)-(2:0))
+        └── content: "\"\n"

--- a/test/snapshots/parser/erb_test/test_0019_erb_output_wrapped_in_single_quotes_aa9928aed6dc45d5fd983a3030e6c4ad.txt
+++ b/test/snapshots/parser/erb_test/test_0019_erb_output_wrapped_in_single_quotes_aa9928aed6dc45d5fd983a3030e6c4ad.txt
@@ -1,0 +1,14 @@
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (3 items)
+    ├── @ HTMLTextNode (location: (1:0)-(1:1))
+    │   └── content: "'"
+    │
+    ├── @ ERBContentNode (location: (1:1)-(1:13))
+    │   ├── tag_opening: "<%=" (location: (1:1)-(1:4))
+    │   ├── content: " value " (location: (1:4)-(1:11))
+    │   ├── tag_closing: "%>" (location: (1:11)-(1:13))
+    │   ├── parsed: true
+    │   └── valid: true
+    │
+    └── @ HTMLTextNode (location: (1:13)-(2:0))
+        └── content: "'\n"

--- a/test/snapshots/parser/erb_test/test_0020_erb_output_wrapped_in_double_quotes_inside_if_8194229e22f698062f184c58c874d6d1.txt
+++ b/test/snapshots/parser/erb_test/test_0020_erb_output_wrapped_in_double_quotes_inside_if_8194229e22f698062f184c58c874d6d1.txt
@@ -1,0 +1,30 @@
+@ DocumentNode (location: (1:0)-(4:0))
+└── children: (2 items)
+    ├── @ ERBIfNode (location: (1:0)-(3:9))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
+    │   ├── content: " if true " (location: (1:2)-(1:11))
+    │   ├── tag_closing: "%>" (location: (1:11)-(1:13))
+    │   ├── statements: (3 items)
+    │   │   ├── @ HTMLTextNode (location: (1:13)-(2:3))
+    │   │   │   └── content: "\n  \""
+    │   │   │
+    │   │   ├── @ ERBContentNode (location: (2:3)-(2:15))
+    │   │   │   ├── tag_opening: "<%=" (location: (2:3)-(2:6))
+    │   │   │   ├── content: " value " (location: (2:6)-(2:13))
+    │   │   │   ├── tag_closing: "%>" (location: (2:13)-(2:15))
+    │   │   │   ├── parsed: true
+    │   │   │   └── valid: true
+    │   │   │
+    │   │   └── @ HTMLTextNode (location: (2:15)-(3:0))
+    │   │       └── content: "\"\n"
+    │   │
+    │   ├── subsequent: ∅
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (3:0)-(3:9))
+    │           ├── tag_opening: "<%" (location: (3:0)-(3:2))
+    │           ├── content: " end " (location: (3:2)-(3:7))
+    │           └── tag_closing: "%>" (location: (3:7)-(3:9))
+    │
+    │
+    └── @ HTMLTextNode (location: (3:9)-(4:0))
+        └── content: "\n"

--- a/test/snapshots/parser/erb_test/test_0021_erb_output_wrapped_in_single_quotes_inside_if_5332acffecc53cb1b561a5e02e44e8fa.txt
+++ b/test/snapshots/parser/erb_test/test_0021_erb_output_wrapped_in_single_quotes_inside_if_5332acffecc53cb1b561a5e02e44e8fa.txt
@@ -1,0 +1,30 @@
+@ DocumentNode (location: (1:0)-(4:0))
+└── children: (2 items)
+    ├── @ ERBIfNode (location: (1:0)-(3:9))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
+    │   ├── content: " if true " (location: (1:2)-(1:11))
+    │   ├── tag_closing: "%>" (location: (1:11)-(1:13))
+    │   ├── statements: (3 items)
+    │   │   ├── @ HTMLTextNode (location: (1:13)-(2:3))
+    │   │   │   └── content: "\n  '"
+    │   │   │
+    │   │   ├── @ ERBContentNode (location: (2:3)-(2:15))
+    │   │   │   ├── tag_opening: "<%=" (location: (2:3)-(2:6))
+    │   │   │   ├── content: " value " (location: (2:6)-(2:13))
+    │   │   │   ├── tag_closing: "%>" (location: (2:13)-(2:15))
+    │   │   │   ├── parsed: true
+    │   │   │   └── valid: true
+    │   │   │
+    │   │   └── @ HTMLTextNode (location: (2:15)-(3:0))
+    │   │       └── content: "'\n"
+    │   │
+    │   ├── subsequent: ∅
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (3:0)-(3:9))
+    │           ├── tag_opening: "<%" (location: (3:0)-(3:2))
+    │           ├── content: " end " (location: (3:2)-(3:7))
+    │           └── tag_closing: "%>" (location: (3:7)-(3:9))
+    │
+    │
+    └── @ HTMLTextNode (location: (3:9)-(4:0))
+        └── content: "\n"


### PR DESCRIPTION
This pull request introduces support for parsing ERB tags wrapped in quotes (both single and double) by adding `TOKEN_QUOTE` to the list of token types in the `parser_parse_in_data_state` function.

So that we now can successfully parse documents like:

```html+erb
"<%= value %>"
```

Fixes #141