### PR TITLE
Improve parsing of attribute values with quotes

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -203,7 +203,11 @@ static AST_HTML_ATTRIBUTE_VALUE_NODE_T* parser_parse_quoted_html_attribute_value
   token_T* opening_quote = parser_consume_expected(parser, TOKEN_QUOTE, errors);
   position_T* start = position_copy(parser->current_token->location->start);
 
-  while (token_is_none_of(parser, TOKEN_QUOTE, TOKEN_EOF)) {
+  while (!token_is(parser, TOKEN_EOF)
+         && !(
+           token_is(parser, TOKEN_QUOTE) && opening_quote != NULL
+           && strcmp(parser->current_token->value, opening_quote->value) == 0
+         )) {
     if (token_is(parser, TOKEN_ERB_START)) {
       parser_append_literal_node_from_buffer(parser, &buffer, children, start);
 

--- a/test/parser/attributes_test.rb
+++ b/test/parser/attributes_test.rb
@@ -33,5 +33,29 @@ module Parser
     test "attribute value with exclamation point" do
       assert_parsed_snapshot(%(<input value="Hello!" />))
     end
+
+    test "style attribute with url" do
+      assert_parsed_snapshot(%(<div style="background-image: url('./images/image.png')"></div>))
+    end
+
+    test "double quotes inside single quotes" do
+      assert_parsed_snapshot(%(<div data-json='{"key": "value"}'></div>))
+    end
+
+    test "multiple nested quotes" do
+      assert_parsed_snapshot(%(<div title="She said 'Hello' and 'Goodbye'"></div>))
+    end
+
+    test "empty quoted attribute values" do
+      assert_parsed_snapshot(%(<input value="" placeholder='' />))
+    end
+
+    test "mixed quote types in multiple attributes" do
+      assert_parsed_snapshot(%(<input value="double quoted" placeholder='single quoted' />))
+    end
+
+    test "erb output with quotes" do
+      assert_parsed_snapshot(%(<div title="<%= "quoted string" %>"></div>))
+    end
   end
 end

--- a/test/snapshots/parser/attributes_test/test_0008_style_attribute_with_url_02762c59a138badb5bfea6b275ae6251.txt
+++ b/test/snapshots/parser/attributes_test/test_0008_style_attribute_with_url_02762c59a138badb5bfea6b275ae6251.txt
@@ -1,0 +1,37 @@
+@ DocumentNode (location: (1:0)-(1:63))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:63))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:57))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "div" (location: (1:1)-(1:4))
+        │       ├── tag_closing: ">" (location: (1:56)-(1:57))
+        │       ├── children: (1 item)
+        │       │   └── @ HTMLAttributeNode (location: (1:5)-(1:56))
+        │       │       ├── name:
+        │       │       │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:10))
+        │       │       │       └── name: "style" (location: (1:5)-(1:10))
+        │       │       │
+        │       │       ├── equals: "=" (location: (1:10)-(1:11))
+        │       │       └── value:
+        │       │           └── @ HTMLAttributeValueNode (location: (1:11)-(1:56))
+        │       │               ├── open_quote: """ (location: (1:11)-(1:12))
+        │       │               ├── children: (1 item)
+        │       │               │   └── @ LiteralNode (location: (1:12)-(1:55))
+        │       │               │       └── content: "background-image: url('./images/image.png')"
+        │       │               │
+        │       │               ├── close_quote: """ (location: (1:55)-(1:56))
+        │       │               └── quoted: true
+        │       │
+        │       │
+        │       └── is_void: false
+        │
+        ├── tag_name: "div" (location: (1:1)-(1:4))
+        ├── body: []
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:57)-(1:63))
+        │       ├── tag_opening: "</" (location: (1:57)-(1:59))
+        │       ├── tag_name: "div" (location: (1:59)-(1:62))
+        │       └── tag_closing: ">" (location: (1:62)-(1:63))
+        │
+        └── is_void: false

--- a/test/snapshots/parser/attributes_test/test_0009_double_quotes_inside_single_quotes_cbaae19549457c1f74162c0f28dbb022.txt
+++ b/test/snapshots/parser/attributes_test/test_0009_double_quotes_inside_single_quotes_cbaae19549457c1f74162c0f28dbb022.txt
@@ -1,0 +1,37 @@
+@ DocumentNode (location: (1:0)-(1:40))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:40))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:34))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "div" (location: (1:1)-(1:4))
+        │       ├── tag_closing: ">" (location: (1:33)-(1:34))
+        │       ├── children: (1 item)
+        │       │   └── @ HTMLAttributeNode (location: (1:5)-(1:33))
+        │       │       ├── name:
+        │       │       │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:14))
+        │       │       │       └── name: "data-json" (location: (1:5)-(1:14))
+        │       │       │
+        │       │       ├── equals: "=" (location: (1:14)-(1:15))
+        │       │       └── value:
+        │       │           └── @ HTMLAttributeValueNode (location: (1:15)-(1:33))
+        │       │               ├── open_quote: "'" (location: (1:15)-(1:16))
+        │       │               ├── children: (1 item)
+        │       │               │   └── @ LiteralNode (location: (1:16)-(1:32))
+        │       │               │       └── content: "{\"key\": \"value\"}"
+        │       │               │
+        │       │               ├── close_quote: "'" (location: (1:32)-(1:33))
+        │       │               └── quoted: true
+        │       │
+        │       │
+        │       └── is_void: false
+        │
+        ├── tag_name: "div" (location: (1:1)-(1:4))
+        ├── body: []
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:34)-(1:40))
+        │       ├── tag_opening: "</" (location: (1:34)-(1:36))
+        │       ├── tag_name: "div" (location: (1:36)-(1:39))
+        │       └── tag_closing: ">" (location: (1:39)-(1:40))
+        │
+        └── is_void: false

--- a/test/snapshots/parser/attributes_test/test_0010_multiple_nested_quotes_fbfe8fcce107a09add4af69465c4037d.txt
+++ b/test/snapshots/parser/attributes_test/test_0010_multiple_nested_quotes_fbfe8fcce107a09add4af69465c4037d.txt
@@ -1,0 +1,37 @@
+@ DocumentNode (location: (1:0)-(1:50))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:50))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:44))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "div" (location: (1:1)-(1:4))
+        │       ├── tag_closing: ">" (location: (1:43)-(1:44))
+        │       ├── children: (1 item)
+        │       │   └── @ HTMLAttributeNode (location: (1:5)-(1:43))
+        │       │       ├── name:
+        │       │       │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:10))
+        │       │       │       └── name: "title" (location: (1:5)-(1:10))
+        │       │       │
+        │       │       ├── equals: "=" (location: (1:10)-(1:11))
+        │       │       └── value:
+        │       │           └── @ HTMLAttributeValueNode (location: (1:11)-(1:43))
+        │       │               ├── open_quote: """ (location: (1:11)-(1:12))
+        │       │               ├── children: (1 item)
+        │       │               │   └── @ LiteralNode (location: (1:12)-(1:42))
+        │       │               │       └── content: "She said 'Hello' and 'Goodbye'"
+        │       │               │
+        │       │               ├── close_quote: """ (location: (1:42)-(1:43))
+        │       │               └── quoted: true
+        │       │
+        │       │
+        │       └── is_void: false
+        │
+        ├── tag_name: "div" (location: (1:1)-(1:4))
+        ├── body: []
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:44)-(1:50))
+        │       ├── tag_opening: "</" (location: (1:44)-(1:46))
+        │       ├── tag_name: "div" (location: (1:46)-(1:49))
+        │       └── tag_closing: ">" (location: (1:49)-(1:50))
+        │
+        └── is_void: false

--- a/test/snapshots/parser/attributes_test/test_0011_empty_quoted_attribute_values_8cbc6c3a58ce6e2fd57c03326bec1b73.txt
+++ b/test/snapshots/parser/attributes_test/test_0011_empty_quoted_attribute_values_8cbc6c3a58ce6e2fd57c03326bec1b73.txt
@@ -1,0 +1,43 @@
+@ DocumentNode (location: (1:0)-(1:33))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:33))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:33))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "input" (location: (1:1)-(1:6))
+        │       ├── tag_closing: "/>" (location: (1:31)-(1:33))
+        │       ├── children: (2 items)
+        │       │   ├── @ HTMLAttributeNode (location: (1:7)-(1:15))
+        │       │   │   ├── name:
+        │       │   │   │   └── @ HTMLAttributeNameNode (location: (1:7)-(1:12))
+        │       │   │   │       └── name: "value" (location: (1:7)-(1:12))
+        │       │   │   │
+        │       │   │   ├── equals: "=" (location: (1:12)-(1:13))
+        │       │   │   └── value:
+        │       │   │       └── @ HTMLAttributeValueNode (location: (1:13)-(1:15))
+        │       │   │           ├── open_quote: """ (location: (1:13)-(1:14))
+        │       │   │           ├── children: []
+        │       │   │           ├── close_quote: """ (location: (1:14)-(1:15))
+        │       │   │           └── quoted: true
+        │       │   │
+        │       │   │
+        │       │   └── @ HTMLAttributeNode (location: (1:16)-(1:30))
+        │       │       ├── name:
+        │       │       │   └── @ HTMLAttributeNameNode (location: (1:16)-(1:27))
+        │       │       │       └── name: "placeholder" (location: (1:16)-(1:27))
+        │       │       │
+        │       │       ├── equals: "=" (location: (1:27)-(1:28))
+        │       │       └── value:
+        │       │           └── @ HTMLAttributeValueNode (location: (1:28)-(1:30))
+        │       │               ├── open_quote: "'" (location: (1:28)-(1:29))
+        │       │               ├── children: []
+        │       │               ├── close_quote: "'" (location: (1:29)-(1:30))
+        │       │               └── quoted: true
+        │       │
+        │       │
+        │       └── is_void: true
+        │
+        ├── tag_name: "input" (location: (1:1)-(1:6))
+        ├── body: []
+        ├── close_tag: ∅
+        └── is_void: true

--- a/test/snapshots/parser/attributes_test/test_0012_mixed_quote_types_in_multiple_attributes_c8a24bb6a12da051002e130b8c94b4b4.txt
+++ b/test/snapshots/parser/attributes_test/test_0012_mixed_quote_types_in_multiple_attributes_c8a24bb6a12da051002e130b8c94b4b4.txt
@@ -1,0 +1,49 @@
+@ DocumentNode (location: (1:0)-(1:59))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:59))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:59))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "input" (location: (1:1)-(1:6))
+        │       ├── tag_closing: "/>" (location: (1:57)-(1:59))
+        │       ├── children: (2 items)
+        │       │   ├── @ HTMLAttributeNode (location: (1:7)-(1:28))
+        │       │   │   ├── name:
+        │       │   │   │   └── @ HTMLAttributeNameNode (location: (1:7)-(1:12))
+        │       │   │   │       └── name: "value" (location: (1:7)-(1:12))
+        │       │   │   │
+        │       │   │   ├── equals: "=" (location: (1:12)-(1:13))
+        │       │   │   └── value:
+        │       │   │       └── @ HTMLAttributeValueNode (location: (1:13)-(1:28))
+        │       │   │           ├── open_quote: """ (location: (1:13)-(1:14))
+        │       │   │           ├── children: (1 item)
+        │       │   │           │   └── @ LiteralNode (location: (1:14)-(1:27))
+        │       │   │           │       └── content: "double quoted"
+        │       │   │           │
+        │       │   │           ├── close_quote: """ (location: (1:27)-(1:28))
+        │       │   │           └── quoted: true
+        │       │   │
+        │       │   │
+        │       │   └── @ HTMLAttributeNode (location: (1:29)-(1:56))
+        │       │       ├── name:
+        │       │       │   └── @ HTMLAttributeNameNode (location: (1:29)-(1:40))
+        │       │       │       └── name: "placeholder" (location: (1:29)-(1:40))
+        │       │       │
+        │       │       ├── equals: "=" (location: (1:40)-(1:41))
+        │       │       └── value:
+        │       │           └── @ HTMLAttributeValueNode (location: (1:41)-(1:56))
+        │       │               ├── open_quote: "'" (location: (1:41)-(1:42))
+        │       │               ├── children: (1 item)
+        │       │               │   └── @ LiteralNode (location: (1:42)-(1:55))
+        │       │               │       └── content: "single quoted"
+        │       │               │
+        │       │               ├── close_quote: "'" (location: (1:55)-(1:56))
+        │       │               └── quoted: true
+        │       │
+        │       │
+        │       └── is_void: true
+        │
+        ├── tag_name: "input" (location: (1:1)-(1:6))
+        ├── body: []
+        ├── close_tag: ∅
+        └── is_void: true

--- a/test/snapshots/parser/attributes_test/test_0013_erb_output_with_quotes_fb1d0c6f864f1f46ac83f42d1250c9ad.txt
+++ b/test/snapshots/parser/attributes_test/test_0013_erb_output_with_quotes_fb1d0c6f864f1f46ac83f42d1250c9ad.txt
@@ -1,0 +1,41 @@
+@ DocumentNode (location: (1:0)-(1:42))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:42))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:36))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "div" (location: (1:1)-(1:4))
+        │       ├── tag_closing: ">" (location: (1:35)-(1:36))
+        │       ├── children: (1 item)
+        │       │   └── @ HTMLAttributeNode (location: (1:5)-(1:35))
+        │       │       ├── name:
+        │       │       │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:10))
+        │       │       │       └── name: "title" (location: (1:5)-(1:10))
+        │       │       │
+        │       │       ├── equals: "=" (location: (1:10)-(1:11))
+        │       │       └── value:
+        │       │           └── @ HTMLAttributeValueNode (location: (1:11)-(1:35))
+        │       │               ├── open_quote: """ (location: (1:11)-(1:12))
+        │       │               ├── children: (1 item)
+        │       │               │   └── @ ERBContentNode (location: (1:12)-(1:34))
+        │       │               │       ├── tag_opening: "<%=" (location: (1:12)-(1:15))
+        │       │               │       ├── content: " "quoted string" " (location: (1:15)-(1:32))
+        │       │               │       ├── tag_closing: "%>" (location: (1:32)-(1:34))
+        │       │               │       ├── parsed: true
+        │       │               │       └── valid: true
+        │       │               │
+        │       │               ├── close_quote: """ (location: (1:34)-(1:35))
+        │       │               └── quoted: true
+        │       │
+        │       │
+        │       └── is_void: false
+        │
+        ├── tag_name: "div" (location: (1:1)-(1:4))
+        ├── body: []
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:36)-(1:42))
+        │       ├── tag_opening: "</" (location: (1:36)-(1:38))
+        │       ├── tag_name: "div" (location: (1:38)-(1:41))
+        │       └── tag_closing: ">" (location: (1:41)-(1:42))
+        │
+        └── is_void: false


### PR DESCRIPTION
This pull request improves the parsing of quoted HTML attribute values and adds tests for various cases involving quotes in attribute values. 

Resolves #146