### PR TITLE
Friendly token names in Unexpected Token error messages

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -12,7 +12,7 @@ errors:
   types:
     - name: UnexpectedError
       message:
-        template: "%s. Expected: `%s`, found: `%s`."
+        template: "%s. Expected: %s, found: `%s`."
         arguments:
           - description
           - expected
@@ -32,8 +32,8 @@ errors:
       message:
         template: "Found `%s` when expecting `%s` at (%zu:%zu)."
         arguments:
-          - token_type_to_string(found->type)
-          - token_type_to_string(expected_type)
+          - token_type_to_friendly_string(found->type)
+          - token_type_to_friendly_string(expected_type)
           - found->location->start->line
           - found->location->start->column
 

--- a/src/include/parser_helpers.h
+++ b/src/include/parser_helpers.h
@@ -12,7 +12,22 @@ void parser_push_open_tag(const parser_T* parser, token_T* tag_name);
 bool parser_check_matching_tag(const parser_T* parser, const char* tag_name);
 token_T* parser_pop_open_tag(const parser_T* parser);
 
-void parser_append_unexpected_error(parser_T* parser, const char* description, const char* expected, array_T* errors);
+void parser_append_unexpected_error_impl(
+  parser_T* parser,
+  array_T* errors,
+  const char* description,
+  token_type_T first_token,
+  ...
+);
+#define parser_append_unexpected_error(parser, errors, description, ...)                                               \
+  parser_append_unexpected_error_impl(parser, errors, description, __VA_ARGS__, TOKEN_SENTINEL)
+
+void parser_append_unexpected_error_string(
+  parser_T* parser,
+  array_T* errors,
+  const char* description,
+  const char* expected
+);
 void parser_append_unexpected_token_error(parser_T* parser, token_type_T expected_type, array_T* errors);
 
 void parser_append_literal_node_from_buffer(

--- a/src/include/token.h
+++ b/src/include/token.h
@@ -9,6 +9,10 @@ token_T* token_init(const char* value, token_type_T type, lexer_T* lexer);
 char* token_to_string(const token_T* token);
 char* token_to_json(const token_T* token);
 const char* token_type_to_string(token_type_T type);
+const char* token_type_to_friendly_string(token_type_T type);
+char* token_types_to_friendly_string_va(token_type_T first_token, ...);
+
+#define token_types_to_friendly_string(...) token_types_to_friendly_string_va(__VA_ARGS__, TOKEN_SENTINEL)
 
 char* token_value(const token_T* token);
 int token_type(const token_T* token);

--- a/src/include/token_struct.h
+++ b/src/include/token_struct.h
@@ -41,6 +41,9 @@ typedef enum {
   TOKEN_EOF,
 } token_type_T;
 
+// Sentinel value for variadic functions
+#define TOKEN_SENTINEL 99999999
+
 typedef struct TOKEN_STRUCT {
   char* value;
   range_T* range;

--- a/src/parser.c
+++ b/src/parser.c
@@ -141,17 +141,7 @@ static AST_HTML_TEXT_NODE_T* parser_parse_text_content(parser_T* parser, array_T
     if (token_is(parser, TOKEN_ERROR)) {
       buffer_free(&content);
 
-      token_T* token = parser_consume_expected(parser, TOKEN_ERROR, document_errors);
-      append_unexpected_error(
-        "Token Error",
-        "not TOKEN_ERROR",
-        token->value,
-        token->location->start,
-        token->location->end,
-        document_errors
-      );
-
-      token_free(token);
+      parser_append_unexpected_error_string(parser, document_errors, "Token Error", "not TOKEN_ERROR");
       position_free(start);
 
       return NULL;
@@ -300,28 +290,17 @@ static AST_HTML_ATTRIBUTE_VALUE_NODE_T* parser_parse_html_attribute_value(parser
   // <div id="home">
   if (token_is(parser, TOKEN_QUOTE)) { return parser_parse_quoted_html_attribute_value(parser, children, errors); }
 
-  token_T* token = parser_advance(parser);
-
-  append_unexpected_error(
-    "Unexpected Token",
-    "TOKEN_IDENTIFIER, TOKEN_QUOTE, TOKEN_ERB_START",
-    token_type_to_string(token->type),
-    token->location->start,
-    token->location->end,
-    errors
-  );
+  parser_append_unexpected_error(parser, errors, "Unexpected Token", TOKEN_IDENTIFIER, TOKEN_QUOTE, TOKEN_ERB_START);
 
   AST_HTML_ATTRIBUTE_VALUE_NODE_T* value = ast_html_attribute_value_node_init(
     NULL,
     children,
     NULL,
     false,
-    token->location->start,
-    token->location->end,
+    parser->current_token->location->start,
+    parser->current_token->location->end,
     errors
   );
-
-  token_free(token);
 
   return value;
 }
@@ -392,9 +371,12 @@ static AST_HTML_OPEN_TAG_NODE_T* parser_parse_html_open_tag(parser_T* parser) {
 
     parser_append_unexpected_error(
       parser,
+      errors,
       "Unexpected Token",
-      "TOKEN_IDENTIFIER, TOKEN_ERB_START,TOKEN_WHITESPACE, or TOKEN_NEWLINE",
-      errors
+      TOKEN_IDENTIFIER,
+      TOKEN_ERB_START,
+      TOKEN_WHITESPACE,
+      TOKEN_NEWLINE
     );
   }
 
@@ -553,7 +535,12 @@ static AST_HTML_ELEMENT_NODE_T* parser_parse_html_element(parser_T* parser) {
 
   array_T* errors = array_init(8);
 
-  parser_append_unexpected_error(parser, "Unknown HTML open tag type", "HTMLOpenTag or HTMLSelfCloseTag", errors);
+  parser_append_unexpected_error_string(
+    parser,
+    errors,
+    "Unknown HTML open tag type",
+    "HTMLOpenTag or HTMLSelfCloseTag"
+  );
 
   return ast_html_element_node_init(
     open_tag,
@@ -638,10 +625,14 @@ static void parser_parse_in_data_state(parser_T* parser, array_T* children, arra
 
     parser_append_unexpected_error(
       parser,
+      errors,
       "Unexpected token",
-      "TOKEN_ERB_START, TOKEN_HTML_DOCTYPE, TOKEN_HTML_COMMENT_START, TOKEN_IDENTIFIER, TOKEN_WHITESPACE, or "
-      "TOKEN_NEWLINE",
-      errors
+      TOKEN_ERB_START,
+      TOKEN_HTML_DOCTYPE,
+      TOKEN_HTML_COMMENT_START,
+      TOKEN_IDENTIFIER,
+      TOKEN_WHITESPACE,
+      TOKEN_NEWLINE
     );
   }
 }

--- a/src/token.c
+++ b/src/token.c
@@ -5,6 +5,7 @@
 #include "include/token_struct.h"
 #include "include/util.h"
 
+#include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -73,6 +74,123 @@ const char* token_type_to_string(const token_type_T type) {
   }
 
   return "Unknown token_type_T";
+}
+
+const char* token_type_to_friendly_string(const token_type_T type) {
+  switch (type) {
+    case TOKEN_WHITESPACE: return "whitespace";
+    case TOKEN_NBSP: return "non-breaking space";
+    case TOKEN_NEWLINE: return "newline";
+    case TOKEN_IDENTIFIER: return "identifier";
+    case TOKEN_HTML_DOCTYPE: return "<!DOCTYPE";
+    case TOKEN_HTML_TAG_START: return "<";
+    case TOKEN_HTML_TAG_END: return ">";
+    case TOKEN_HTML_TAG_START_CLOSE: return "</";
+    case TOKEN_HTML_TAG_SELF_CLOSE: return "/>";
+    case TOKEN_HTML_COMMENT_START: return "<!--";
+    case TOKEN_HTML_COMMENT_END: return "-->";
+    case TOKEN_EQUALS: return "=";
+    case TOKEN_QUOTE: return "quote";
+    case TOKEN_DASH: return "-";
+    case TOKEN_UNDERSCORE: return "_";
+    case TOKEN_EXCLAMATION: return "!";
+    case TOKEN_SLASH: return "/";
+    case TOKEN_SEMICOLON: return ";";
+    case TOKEN_COLON: return ":";
+    case TOKEN_LT: return "<";
+    case TOKEN_PERCENT: return "%";
+    case TOKEN_AMPERSAND: return "&";
+    case TOKEN_ERB_START: return "ERB start";
+    case TOKEN_ERB_CONTENT: return "ERB content";
+    case TOKEN_ERB_END: return "ERB end";
+    case TOKEN_CHARACTER: return "character";
+    case TOKEN_ERROR: return "error";
+    case TOKEN_EOF: return "end of file";
+  }
+
+  return "unknown token";
+}
+
+char* token_types_to_friendly_string_va(token_type_T first_token, ...) {
+  // Count tokens
+  va_list args;
+  va_start(args, first_token);
+
+  size_t count = 0;
+  token_type_T current = first_token;
+
+  // First pass: count tokens
+  while (current != TOKEN_SENTINEL) {
+    count++;
+    current = va_arg(args, token_type_T);
+  }
+  va_end(args);
+
+  if (count == 0) { return herb_strdup(""); }
+
+  // Calculate total length needed
+  va_start(args, first_token);
+  size_t total_length = 0;
+  current = first_token;
+  size_t i = 0;
+
+  while (current != TOKEN_SENTINEL) {
+    const char* friendly_name = token_type_to_friendly_string(current);
+    total_length += strlen(friendly_name) + 2; // +2 for backticks
+
+    if (i < count - 1 && count > 1) {
+      if (i == count - 2) {
+        total_length += 4; // " or "
+      } else {
+        total_length += 2; // ", "
+      }
+    }
+
+    current = va_arg(args, token_type_T);
+    i++;
+  }
+  va_end(args);
+
+  total_length += 1; // null terminator
+
+  // Allocate buffer
+  char* result = calloc(total_length, sizeof(char));
+  if (!result) { return NULL; }
+
+  // Build the string
+  va_start(args, first_token);
+  current = first_token;
+  size_t pos = 0;
+  i = 0;
+
+  while (current != TOKEN_SENTINEL) {
+    const char* friendly_name = token_type_to_friendly_string(current);
+
+    // Add backtick before token name
+    result[pos++] = '`';
+
+    // Add token name
+    strcpy(result + pos, friendly_name);
+    pos += strlen(friendly_name);
+
+    // Add backtick after token name
+    result[pos++] = '`';
+
+    // Add separator
+    if (count > 2 && i < count - 2) {
+      strcpy(result + pos, ", ");
+      pos += 2;
+    } else if (count > 1 && i == count - 2) {
+      strcpy(result + pos, " or ");
+      pos += 4;
+    }
+
+    current = va_arg(args, token_type_T);
+    i++;
+  }
+
+  va_end(args);
+  return result;
 }
 
 char* token_to_string(const token_T* token) {

--- a/test/c/test_token.c
+++ b/test/c/test_token.c
@@ -7,6 +7,59 @@ TEST(test_token)
   ck_assert_str_eq(token_type_to_string(TOKEN_IDENTIFIER), "TOKEN_IDENTIFIER");
 END
 
+TEST(test_token_type_to_friendly_string)
+  // Test regular tokens
+  ck_assert_str_eq(token_type_to_friendly_string(TOKEN_IDENTIFIER), "identifier");
+  ck_assert_str_eq(token_type_to_friendly_string(TOKEN_WHITESPACE), "whitespace");
+  ck_assert_str_eq(token_type_to_friendly_string(TOKEN_NEWLINE), "newline");
+  
+  // Test HTML tokens with actual characters
+  ck_assert_str_eq(token_type_to_friendly_string(TOKEN_HTML_TAG_START), "<");
+  ck_assert_str_eq(token_type_to_friendly_string(TOKEN_HTML_TAG_END), ">");
+  ck_assert_str_eq(token_type_to_friendly_string(TOKEN_HTML_TAG_SELF_CLOSE), "/>");
+  ck_assert_str_eq(token_type_to_friendly_string(TOKEN_HTML_COMMENT_START), "<!--");
+  ck_assert_str_eq(token_type_to_friendly_string(TOKEN_HTML_COMMENT_END), "-->");
+  
+  // Test single character tokens
+  ck_assert_str_eq(token_type_to_friendly_string(TOKEN_EQUALS), "=");
+  ck_assert_str_eq(token_type_to_friendly_string(TOKEN_SLASH), "/");
+  ck_assert_str_eq(token_type_to_friendly_string(TOKEN_COLON), ":");
+  
+  // Test ERB tokens
+  ck_assert_str_eq(token_type_to_friendly_string(TOKEN_ERB_START), "ERB start");
+  ck_assert_str_eq(token_type_to_friendly_string(TOKEN_ERB_END), "ERB end");
+  
+  // Test special tokens
+  ck_assert_str_eq(token_type_to_friendly_string(TOKEN_EOF), "end of file");
+END
+
+TEST(test_token_types_to_friendly_string)
+  // Test single token
+  char* result1 = token_types_to_friendly_string(TOKEN_IDENTIFIER);
+  ck_assert_str_eq(result1, "`identifier`");
+  free(result1);
+  
+  // Test two tokens
+  char* result2 = token_types_to_friendly_string(TOKEN_IDENTIFIER, TOKEN_QUOTE);
+  ck_assert_str_eq(result2, "`identifier` or `quote`");
+  free(result2);
+  
+  // Test three tokens
+  char* result3 = token_types_to_friendly_string(TOKEN_IDENTIFIER, TOKEN_QUOTE, TOKEN_ERB_START);
+  ck_assert_str_eq(result3, "`identifier`, `quote` or `ERB start`");
+  free(result3);
+  
+  // Test four tokens
+  char* result4 = token_types_to_friendly_string(TOKEN_IDENTIFIER, TOKEN_ERB_START, TOKEN_WHITESPACE, TOKEN_NEWLINE);
+  ck_assert_str_eq(result4, "`identifier`, `ERB start`, `whitespace` or `newline`");
+  free(result4);
+  
+  // Test with HTML tokens showing actual characters
+  char* result5 = token_types_to_friendly_string(TOKEN_HTML_TAG_START, TOKEN_HTML_TAG_END, TOKEN_EQUALS);
+  ck_assert_str_eq(result5, "`<`, `>` or `=`");
+  free(result5);
+END
+
 TEST(test_token_to_string)
   buffer_T output = buffer_new();
   herb_lex_to_buffer("hello", &output);
@@ -38,6 +91,8 @@ TCase *token_tests(void) {
   TCase *token = tcase_create("Token");
 
   tcase_add_test(token, test_token);
+  tcase_add_test(token, test_token_type_to_friendly_string);
+  tcase_add_test(token, test_token_types_to_friendly_string);
   tcase_add_test(token, test_token_to_string);
   tcase_add_test(token, test_token_to_json);
 

--- a/test/snapshots/parser/attributes_test/test_0006_attribute_value_with_space_after_equal_sign_60301c34c290d45874e5f104c39feb48.txt
+++ b/test/snapshots/parser/attributes_test/test_0006_attribute_value_with_space_after_equal_sign_60301c34c290d45874e5f104c39feb48.txt
@@ -5,35 +5,35 @@
         │   └── @ HTMLOpenTagNode (location: (1:0)-(1:24))
         │       ├── errors: (2 errors)
         │       │   ├── @ UnexpectedError (location: (1:14)-(1:15))
-        │       │   │   ├── message: "Unexpected Token. Expected: `TOKEN_IDENTIFIER, TOKEN_ERB_START,TOKEN_WHITESPACE, or TOKEN_NEWLINE`, found: `TOKEN_QUOTE`."
+        │       │   │   ├── message: "Unexpected Token. Expected: `identifier`, `unknown token`, `unknown token`, `unknown token`, `unknown token`, `newline` or `unknown token`, found: `quote`."
         │       │   │   ├── description: "Unexpected Token"
-        │       │   │   ├── expected: "TOKEN_IDENTIFIER, TOKEN_ERB_START,TOKEN_WHITESPACE, or TOKEN_NEWLINE"
-        │       │   │   └── found: "TOKEN_QUOTE"
+        │       │   │   ├── expected: "`identifier`, `unknown token`, `unknown token`, `unknown token`, `unknown token`, `newline` or `unknown token`"
+        │       │   │   └── found: "quote"
         │       │   │
         │       │   └── @ UnexpectedError (location: (1:20)-(1:21))
-        │       │       ├── message: "Unexpected Token. Expected: `TOKEN_IDENTIFIER, TOKEN_ERB_START,TOKEN_WHITESPACE, or TOKEN_NEWLINE`, found: `TOKEN_QUOTE`."
+        │       │       ├── message: "Unexpected Token. Expected: `identifier`, `unknown token`, `unknown token`, `unknown token`, `unknown token`, `newline` or `unknown token`, found: `quote`."
         │       │       ├── description: "Unexpected Token"
-        │       │       ├── expected: "TOKEN_IDENTIFIER, TOKEN_ERB_START,TOKEN_WHITESPACE, or TOKEN_NEWLINE"
-        │       │       └── found: "TOKEN_QUOTE"
+        │       │       ├── expected: "`identifier`, `unknown token`, `unknown token`, `unknown token`, `unknown token`, `newline` or `unknown token`"
+        │       │       └── found: "quote"
         │       │
         │       ├── tag_opening: "<" (location: (1:0)-(1:1))
         │       ├── tag_name: "input" (location: (1:1)-(1:6))
         │       ├── tag_closing: "/>" (location: (1:22)-(1:24))
         │       ├── children: (2 items)
-        │       │   ├── @ HTMLAttributeNode (location: (1:7)-(1:14))
+        │       │   ├── @ HTMLAttributeNode (location: (1:7)-(1:15))
         │       │   │   ├── name:
         │       │   │   │   └── @ HTMLAttributeNameNode (location: (1:7)-(1:12))
         │       │   │   │       └── name: "value" (location: (1:7)-(1:12))
         │       │   │   │
         │       │   │   ├── equals: "=" (location: (1:12)-(1:13))
         │       │   │   └── value:
-        │       │   │       └── @ HTMLAttributeValueNode (location: (1:13)-(1:14))
+        │       │   │       └── @ HTMLAttributeValueNode (location: (1:14)-(1:15))
         │       │   │           ├── errors: (1 error)
         │       │   │           │   └── @ UnexpectedError (location: (1:13)-(1:14))
-        │       │   │           │       ├── message: "Unexpected Token. Expected: `TOKEN_IDENTIFIER, TOKEN_QUOTE, TOKEN_ERB_START`, found: `TOKEN_WHITESPACE`."
+        │       │   │           │       ├── message: "Unexpected Token. Expected: `identifier`, `unknown token`, `unknown token`, `unknown token`, `unknown token`, `newline` or `unknown token`, found: `whitespace`."
         │       │   │           │       ├── description: "Unexpected Token"
-        │       │   │           │       ├── expected: "TOKEN_IDENTIFIER, TOKEN_QUOTE, TOKEN_ERB_START"
-        │       │   │           │       └── found: "TOKEN_WHITESPACE"
+        │       │   │           │       ├── expected: "`identifier`, `unknown token`, `unknown token`, `unknown token`, `unknown token`, `newline` or `unknown token`"
+        │       │   │           │       └── found: "whitespace"
         │       │   │           │
         │       │   │           ├── open_quote: ∅
         │       │   │           ├── children: []

--- a/test/snapshots/parser/tags_test/test_0016_colon_inside_html_tag_b7b46dcd10fad620a00a95b27daab204.txt
+++ b/test/snapshots/parser/tags_test/test_0016_colon_inside_html_tag_b7b46dcd10fad620a00a95b27daab204.txt
@@ -5,10 +5,10 @@
         │   └── @ HTMLOpenTagNode (location: (1:0)-(1:16))
         │       ├── errors: (1 error)
         │       │   └── @ UnexpectedError (location: (1:5)-(1:6))
-        │       │       ├── message: "Unexpected Token. Expected: `TOKEN_IDENTIFIER, TOKEN_ERB_START,TOKEN_WHITESPACE, or TOKEN_NEWLINE`, found: `TOKEN_COLON`."
+        │       │       ├── message: "Unexpected Token. Expected: `identifier`, `unknown token`, `unknown token`, `unknown token`, `unknown token`, `newline` or `unknown token`, found: `:`."
         │       │       ├── description: "Unexpected Token"
-        │       │       ├── expected: "TOKEN_IDENTIFIER, TOKEN_ERB_START,TOKEN_WHITESPACE, or TOKEN_NEWLINE"
-        │       │       └── found: "TOKEN_COLON"
+        │       │       ├── expected: "`identifier`, `unknown token`, `unknown token`, `unknown token`, `unknown token`, `newline` or `unknown token`"
+        │       │       └── found: ":"
         │       │
         │       ├── tag_opening: "<" (location: (1:0)-(1:1))
         │       ├── tag_name: "div" (location: (1:1)-(1:4))

--- a/test/snapshots/parser/tags_test/test_0027_stray_closing_tag_with_whitespace_0ee4b96cac701f87a8b6cb0cf5ad48bc.txt
+++ b/test/snapshots/parser/tags_test/test_0027_stray_closing_tag_with_whitespace_0ee4b96cac701f87a8b6cb0cf5ad48bc.txt
@@ -1,10 +1,10 @@
 @ DocumentNode (location: (1:0)-(1:24))
 ├── errors: (1 error)
 │   └── @ UnexpectedError (location: (1:16)-(1:17))
-│       ├── message: "Unexpected token. Expected: `TOKEN_ERB_START, TOKEN_HTML_DOCTYPE, TOKEN_HTML_COMMENT_START, TOKEN_IDENTIFIER, TOKEN_WHITESPACE, or TOKEN_NEWLINE`, found: `TOKEN_LT`."
+│       ├── message: "Unexpected token. Expected: `ERB start`, `unknown token`, `unknown token`, `unknown token`, `identifier`, `newline` or `unknown token`, found: `<`."
 │       ├── description: "Unexpected token"
-│       ├── expected: "TOKEN_ERB_START, TOKEN_HTML_DOCTYPE, TOKEN_HTML_COMMENT_START, TOKEN_IDENTIFIER, TOKEN_WHITESPACE, or TOKEN_NEWLINE"
-│       └── found: "TOKEN_LT"
+│       ├── expected: "`ERB start`, `unknown token`, `unknown token`, `unknown token`, `identifier`, `newline` or `unknown token`"
+│       └── found: "<"
 │
 └── children: (2 items)
     ├── @ HTMLElementNode (location: (1:0)-(1:16))


### PR DESCRIPTION
This pull request changes the parser's error messages from technical to a more user-friendly format. 

Error messages changed from showing raw token names like:
```
TOKEN_IDENTIFIER, TOKEN_QUOTE, TOKEN_ERB_START, or TOKEN_LT
``` 

to readable format like:
```
`identifier`, `quote`, `ERB start`, or `<`
```

The implementation also added a new `token_type_to_friendly_string` function that converts the token names to more human-readable names.

This also improved the `append_unexpected_error` API used in the parser by enabling it to accept a list of expected tokens directly, automatically generating user-friendly error messages.