### PR TITLE
Exclude `main.c` from WebAssembly builds

### DIFF
--- a/wasm/Makefile
+++ b/wasm/Makefile
@@ -7,7 +7,7 @@ NODE_BUILD_DIR = ../javascript/packages/node-wasm/build/
 NODE_WASM_OUTPUT = $(NODE_BUILD_DIR)libherb.js
 
 CPP_SOURCES = $(wildcard *.cpp)
-C_SOURCES = $(wildcard ../src/*.c) $(wildcard ../src/**/*.c)
+C_SOURCES = $(filter-out ../src/main.c, $(wildcard ../src/*.c)) $(wildcard ../src/**/*.c)
 
 PRISM_PATH = $(shell cd .. && bundle show prism)
 PRISM_MAIN_SOURCES = $(wildcard $(PRISM_PATH)/src/*.c)


### PR DESCRIPTION
This pull request removes the `src/main.c` file from the WebAssembly builds, since everytime you imported the library it would `console.log` the arguments/output from the C-CLI which is in `main.c`:

```
❯ yarn test
yarn run v1.22.22
$ vitest run

 RUN  v3.1.4 /Users/marcoroth/Development/herb-linter/javascript/packages/browser

stdout | test/browser.test.ts > @herb-tools/browser
./herb [command] [options]
stdout | test/browser.test.ts > @herb-tools/browser

stdout | test/browser.test.ts > @herb-tools/browser
Herb 🌿 Powerful and seamless HTML-aware ERB parsing and tooling.
stdout | test/browser.test.ts > @herb-tools/browser

stdout | test/browser.test.ts > @herb-tools/browser
./herb lex [file]      -  Lex a file
stdout | test/browser.test.ts > @herb-tools/browser
./herb lex_json [file] -  Lex a file and return the result as json.
stdout | test/browser.test.ts > @herb-tools/browser
./herb parse [file]    -  Parse a file
stdout | test/browser.test.ts > @herb-tools/browser
./herb ruby [file]     -  Extract Ruby from a file
stdout | test/browser.test.ts > @herb-tools/browser
./herb html [file]     -  Extract HTML from a file
stdout | test/browser.test.ts > @herb-tools/browser
./herb prism [file]    -  Extract Ruby from a file and parse the Ruby source with Prism
stdout | test/visitor.test.ts > Visitor
./herb [command] [options]
stdout | test/visitor.test.ts > Visitor
```

