### PR TITLE
Refactor Linter and Linter Rules

### DIFF
--- a/javascript/packages/linter/src/rules/html-attribute-double-quotes.ts
+++ b/javascript/packages/linter/src/rules/html-attribute-double-quotes.ts
@@ -1,65 +1,28 @@
-import type { HTMLOpenTagNode, HTMLSelfCloseTagNode, HTMLAttributeNode, HTMLAttributeNameNode, HTMLAttributeValueNode, LiteralNode } from "@herb-tools/core"
+import { AttributeVisitorMixin, getAttributeValueQuoteType, hasAttributeValue } from "./rule-utils.js"
+
 import type { Rule, LintMessage } from "../types.js"
+import type { Node, HTMLAttributeNode } from "@herb-tools/core"
+
+class AttributeDoubleQuotesVisitor extends AttributeVisitorMixin {
+  protected checkAttribute(attributeName: string, attributeValue: string | null, attributeNode: HTMLAttributeNode): void {
+    if (!hasAttributeValue(attributeNode)) return
+    if (getAttributeValueQuoteType(attributeNode) !== "single") return
+    if (attributeValue?.includes('"')) return // Single quotes acceptable when value contains double quotes
+
+    this.addMessage(
+      `Attribute \`${attributeName}\` uses single quotes. Prefer double quotes for HTML attribute values: \`${attributeName}="value"\`.`,
+      attributeNode.value!.location,
+      "warning"
+    )
+  }
+}
 
 export class HTMLAttributeDoubleQuotesRule implements Rule {
   name = "html-attribute-double-quotes"
-  description = "Prefer using double quotes (\") around HTML attribute values instead of single quotes (')"
 
-  check(node: HTMLOpenTagNode | HTMLSelfCloseTagNode): LintMessage[] {
-    const messages: LintMessage[] = []
-
-    // Only check nodes that can have attributes (opening and self-closing tags)
-    if (node.type !== "AST_HTML_OPEN_TAG_NODE" && node.type !== "AST_HTML_SELF_CLOSE_TAG_NODE") {
-      return messages
-    }
-
-    const attributes = node.type === "AST_HTML_SELF_CLOSE_TAG_NODE"
-      ? (node as HTMLSelfCloseTagNode).attributes
-      : (node as HTMLOpenTagNode).children
-
-    for (const child of attributes) {
-      if (child.type === "AST_HTML_ATTRIBUTE_NODE") {
-        const attributeNode = child as HTMLAttributeNode
-
-        // Check if this attribute has a value
-        if (attributeNode.value?.type === "AST_HTML_ATTRIBUTE_VALUE_NODE") {
-          const valueNode = attributeNode.value as HTMLAttributeValueNode
-
-          // If the value is quoted with single quotes, check if it contains double quotes
-          if (valueNode.quoted && valueNode.open_quote && valueNode.open_quote.value === "'" && valueNode.close_quote && valueNode.close_quote.value === "'") {
-            // Get the actual value content to check for double quotes
-            let valueContent = ""
-            if (valueNode.children && valueNode.children.length > 0) {
-              // Concatenate all text content from children
-              valueContent = valueNode.children
-                .filter(child => child.type === "AST_LITERAL_NODE")
-                .map(child => (child as LiteralNode).content)
-                .join("")
-            }
-
-            // Only report error if the value doesn't contain double quotes
-            // (single quotes are acceptable when the value contains double quotes)
-            if (!valueContent.includes('"')) {
-              let attributeName = "unknown"
-              if (attributeNode.name?.type === "AST_HTML_ATTRIBUTE_NAME_NODE") {
-                const nameNode = attributeNode.name as HTMLAttributeNameNode
-                if (nameNode.name) {
-                  attributeName = nameNode.name.value
-                }
-              }
-
-              messages.push({
-                rule: this.name,
-                message: `Attribute \`${attributeName}\` uses single quotes. Prefer double quotes for HTML attribute values: \`${attributeName}="value"\`.`,
-                location: valueNode.location,
-                severity: "error"
-              })
-            }
-          }
-        }
-      }
-    }
-
-    return messages
+  check(node: Node): LintMessage[] {
+    const visitor = new AttributeDoubleQuotesVisitor(this.name)
+    visitor.visit(node)
+    return visitor.messages
   }
 }

--- a/javascript/packages/linter/src/rules/html-attribute-values-require-quotes.ts
+++ b/javascript/packages/linter/src/rules/html-attribute-values-require-quotes.ts
@@ -1,51 +1,29 @@
-import type { HTMLOpenTagNode, HTMLSelfCloseTagNode, HTMLAttributeNode, HTMLAttributeNameNode, HTMLAttributeValueNode } from "@herb-tools/core"
+import { AttributeVisitorMixin } from "./rule-utils.js"
+
 import type { Rule, LintMessage } from "../types.js"
+import type { HTMLAttributeNode, HTMLAttributeValueNode, Node } from "@herb-tools/core"
+
+class AttributeValuesRequireQuotesVisitor extends AttributeVisitorMixin {
+  protected checkAttribute(attributeName: string, _attributeValue: string | null, attributeNode: HTMLAttributeNode): void {
+    if (attributeNode.value?.type !== "AST_HTML_ATTRIBUTE_VALUE_NODE") return
+
+    const valueNode = attributeNode.value as HTMLAttributeValueNode
+    if (valueNode.quoted) return
+
+    this.addMessage(
+      `Attribute value should be quoted: \`${attributeName}="value"\`. Always wrap attribute values in quotes.`,
+      valueNode.location,
+      "error"
+    )
+  }
+}
 
 export class HTMLAttributeValuesRequireQuotesRule implements Rule {
   name = "html-attribute-values-require-quotes"
-  description = "Always wrap HTML attribute values in quotes"
 
-  check(node: HTMLOpenTagNode | HTMLSelfCloseTagNode): LintMessage[] {
-    const messages: LintMessage[] = []
-
-    // Only check nodes that can have attributes (opening and self-closing tags)
-    if (node.type !== "AST_HTML_OPEN_TAG_NODE" && node.type !== "AST_HTML_SELF_CLOSE_TAG_NODE") {
-      return messages
-    }
-
-    const attributes = node.type === "AST_HTML_SELF_CLOSE_TAG_NODE"
-      ? (node as HTMLSelfCloseTagNode).attributes
-      : (node as HTMLOpenTagNode).children
-
-    for (const child of attributes) {
-      if (child.type === "AST_HTML_ATTRIBUTE_NODE") {
-        const attributeNode = child as HTMLAttributeNode
-
-        // Check if this attribute has a value
-        if (attributeNode.value?.type === "AST_HTML_ATTRIBUTE_VALUE_NODE") {
-          const valueNode = attributeNode.value as HTMLAttributeValueNode
-
-          // If the value is not quoted, report an error
-          if (!valueNode.quoted) {
-            let attributeName = "unknown"
-            if (attributeNode.name?.type === "AST_HTML_ATTRIBUTE_NAME_NODE") {
-              const nameNode = attributeNode.name as HTMLAttributeNameNode
-              if (nameNode.name) {
-                attributeName = nameNode.name.value
-              }
-            }
-
-            messages.push({
-              rule: this.name,
-              message: `Attribute value should be quoted: \`${attributeName}="value"\`. Always wrap attribute values in quotes.`,
-              location: valueNode.location,
-              severity: "error"
-            })
-          }
-        }
-      }
-    }
-
-    return messages
+  check(node: Node): LintMessage[] {
+    const visitor = new AttributeValuesRequireQuotesVisitor(this.name)
+    visitor.visit(node)
+    return visitor.messages
   }
 }

--- a/javascript/packages/linter/src/rules/html-boolean-attributes-no-value.ts
+++ b/javascript/packages/linter/src/rules/html-boolean-attributes-no-value.ts
@@ -1,57 +1,27 @@
-import type { HTMLOpenTagNode, HTMLSelfCloseTagNode, HTMLAttributeNode, HTMLAttributeNameNode, HTMLAttributeValueNode } from "@herb-tools/core"
+import { AttributeVisitorMixin, isBooleanAttribute, hasAttributeValue } from "./rule-utils.js"
+
 import type { Rule, LintMessage } from "../types.js"
+import type { HTMLAttributeNode, Node } from "@herb-tools/core"
+
+class BooleanAttributesNoValueVisitor extends AttributeVisitorMixin {
+  protected checkAttribute(attributeName: string, _attributeValue: string | null, attributeNode: HTMLAttributeNode): void {
+    if (!isBooleanAttribute(attributeName)) return
+    if (!hasAttributeValue(attributeNode)) return
+
+    this.addMessage(
+      `Boolean attribute \`${attributeName}\` should not have a value. Use \`${attributeName}\` instead of \`${attributeName}="${attributeName}"\`.`,
+      attributeNode.value!.location,
+      "error"
+    )
+  }
+}
 
 export class HTMLBooleanAttributesNoValueRule implements Rule {
   name = "html-boolean-attributes-no-value"
-  description = "Omit attribute values for boolean HTML attributes"
 
-  // List of known boolean attributes in HTML
-  private booleanAttributes = new Set([
-    "autofocus", "autoplay", "checked", "controls", "defer", "disabled", "hidden",
-    "loop", "multiple", "muted", "readonly", "required", "reversed", "selected",
-    "open", "default", "formnovalidate", "novalidate", "itemscope", "scoped",
-    "seamless", "allowfullscreen", "async", "compact", "declare", "nohref",
-    "noresize", "noshade", "nowrap", "sortable", "truespeed", "typemustmatch"
-  ])
-
-  check(node: HTMLOpenTagNode | HTMLSelfCloseTagNode): LintMessage[] {
-    const messages: LintMessage[] = []
-
-    // Only check nodes that can have attributes (opening and self-closing tags)
-    if (node.type !== "AST_HTML_OPEN_TAG_NODE" && node.type !== "AST_HTML_SELF_CLOSE_TAG_NODE") {
-      return messages
-    }
-
-    const attributes = node.type === "AST_HTML_SELF_CLOSE_TAG_NODE"
-      ? (node as HTMLSelfCloseTagNode).attributes
-      : (node as HTMLOpenTagNode).children
-
-    for (const child of attributes) {
-      if (child.type === "AST_HTML_ATTRIBUTE_NODE") {
-        const attributeNode = child as HTMLAttributeNode
-
-        if (attributeNode.name?.type === "AST_HTML_ATTRIBUTE_NAME_NODE") {
-          const nameNode = attributeNode.name as HTMLAttributeNameNode
-
-          if (nameNode.name) {
-            const attributeName = nameNode.name.value.toLowerCase()
-
-            // Check if this is a boolean attribute with a value
-            if (this.booleanAttributes.has(attributeName) && attributeNode.value?.type === "AST_HTML_ATTRIBUTE_VALUE_NODE") {
-              const valueNode = attributeNode.value as HTMLAttributeValueNode
-
-              messages.push({
-                rule: this.name,
-                message: `Boolean attribute \`${attributeName}\` should not have a value. Use \`${attributeName}\` instead of \`${attributeName}="${attributeName}"\`.`,
-                location: valueNode.location,
-                severity: "error"
-              })
-            }
-          }
-        }
-      }
-    }
-
-    return messages
+  check(node: Node): LintMessage[] {
+    const visitor = new BooleanAttributesNoValueVisitor(this.name)
+    visitor.visit(node)
+    return visitor.messages
   }
 }

--- a/javascript/packages/linter/src/rules/html-img-require-alt.ts
+++ b/javascript/packages/linter/src/rules/html-img-require-alt.ts
@@ -1,49 +1,42 @@
-import { HTMLOpenTagNode, HTMLSelfCloseTagNode, HTMLAttributeNode, HTMLAttributeNameNode } from "@herb-tools/core"
-import { Rule, LintMessage } from "../types.js"
+import { BaseRuleVisitor, getTagName, hasAttribute } from "./rule-utils.js"
+
+import type { Rule, LintMessage } from "../types.js"
+import type { HTMLOpenTagNode, HTMLSelfCloseTagNode, Node } from "@herb-tools/core"
+
+class ImgRequireAltVisitor extends BaseRuleVisitor {
+  visitHTMLOpenTagNode(node: HTMLOpenTagNode): void {
+    this.checkImgTag(node)
+    super.visitHTMLOpenTagNode(node)
+  }
+
+  visitHTMLSelfCloseTagNode(node: HTMLSelfCloseTagNode): void {
+    this.checkImgTag(node)
+    super.visitHTMLSelfCloseTagNode(node)
+  }
+
+  private checkImgTag(node: HTMLOpenTagNode | HTMLSelfCloseTagNode): void {
+    const tagName = getTagName(node)
+
+    if (tagName !== "img") {
+      return
+    }
+
+    if (!hasAttribute(node, "alt")) {
+      this.addMessage(
+        'Missing required `alt` attribute on `<img>` tag. Add `alt=""` for decorative images or `alt="description"` for informative images.',
+        node.tag_name!.location,
+        "error"
+      )
+    }
+  }
+}
 
 export class HTMLImgRequireAltRule implements Rule {
   name = "html-img-require-alt"
-  description = "Enforce that all <img> elements include an alt attribute"
 
-  check(node: HTMLOpenTagNode | HTMLSelfCloseTagNode): LintMessage[] {
-    const messages: LintMessage[] = []
-
-    // Only check img tags
-    if (!node.tag_name || node.tag_name.value.toLowerCase() !== "img") {
-      return messages
-    }
-
-    // Check if the img tag has an alt attribute
-    let hasAltAttribute = false
-
-    const attributes = node.type === "AST_HTML_SELF_CLOSE_TAG_NODE"
-      ? (node as HTMLSelfCloseTagNode).attributes
-      : (node as HTMLOpenTagNode).children
-
-    for (const child of attributes) {
-      if (child.type === "AST_HTML_ATTRIBUTE_NODE") {
-        const attributeNode = child as HTMLAttributeNode
-
-        if (attributeNode.name?.type === "AST_HTML_ATTRIBUTE_NAME_NODE") {
-          const nameNode = attributeNode.name as HTMLAttributeNameNode
-
-          if (nameNode.name && nameNode.name.value.toLowerCase() === "alt") {
-            hasAltAttribute = true
-            break
-          }
-        }
-      }
-    }
-
-    if (!hasAltAttribute) {
-      messages.push({
-        rule: this.name,
-        message: 'Missing required `alt` attribute on `<img>` tag. Add `alt=""` for decorative images or `alt="description"` for informative images.',
-        location: node.tag_name.location,
-        severity: "error"
-      })
-    }
-
-    return messages
+  check(node: Node): LintMessage[] {
+    const visitor = new ImgRequireAltVisitor(this.name)
+    visitor.visit(node)
+    return visitor.messages
   }
 }

--- a/javascript/packages/linter/src/rules/html-no-duplicate-attributes.ts
+++ b/javascript/packages/linter/src/rules/html-no-duplicate-attributes.ts
@@ -1,60 +1,59 @@
-import { HTMLOpenTagNode, HTMLCloseTagNode, HTMLSelfCloseTagNode, HTMLAttributeNode, HTMLAttributeNameNode } from "@herb-tools/core"
-import { Rule, LintMessage } from "../types.js"
+import { BaseRuleVisitor, forEachAttribute } from "./rule-utils.js"
+
+import type { Rule, LintMessage } from "../types.js"
+import type { HTMLOpenTagNode, HTMLSelfCloseTagNode, HTMLAttributeNameNode, Node } from "@herb-tools/core"
+
+class NoDuplicateAttributesVisitor extends BaseRuleVisitor {
+  visitHTMLOpenTagNode(node: HTMLOpenTagNode): void {
+    this.checkDuplicateAttributes(node)
+    super.visitHTMLOpenTagNode(node)
+  }
+
+  visitHTMLSelfCloseTagNode(node: HTMLSelfCloseTagNode): void {
+    this.checkDuplicateAttributes(node)
+    super.visitHTMLSelfCloseTagNode(node)
+  }
+
+  private checkDuplicateAttributes(node: HTMLOpenTagNode | HTMLSelfCloseTagNode): void {
+    const attributeNames = new Map<string, HTMLAttributeNameNode[]>()
+
+    forEachAttribute(node, (attributeNode) => {
+      if (attributeNode.name?.type !== "AST_HTML_ATTRIBUTE_NAME_NODE") return
+
+      const nameNode = attributeNode.name as HTMLAttributeNameNode
+      if (!nameNode.name) return
+
+      const attributeName = nameNode.name.value.toLowerCase() // HTML attributes are case-insensitive
+
+      if (!attributeNames.has(attributeName)) {
+        attributeNames.set(attributeName, [])
+      }
+
+      attributeNames.get(attributeName)!.push(nameNode)
+    })
+
+    for (const [attributeName, nameNodes] of attributeNames) {
+      if (nameNodes.length > 1) {
+        for (let i = 1; i < nameNodes.length; i++) {
+          const nameNode = nameNodes[i]
+
+          this.addMessage(
+            `Duplicate attribute \`${attributeName}\` found on tag. Remove the duplicate occurrence.`,
+            nameNode.location,
+            "error"
+          )
+        }
+      }
+    }
+  }
+}
 
 export class HTMLNoDuplicateAttributesRule implements Rule {
   name = "html-no-duplicate-attributes"
-  description = "Disallow having multiple attributes with the same name on a single HTML tag"
 
-  check(node: HTMLOpenTagNode | HTMLCloseTagNode | HTMLSelfCloseTagNode): LintMessage[] {
-    const messages: LintMessage[] = []
-
-    // Only check nodes that can have attributes (opening and self-closing tags)
-    if (node.type !== "AST_HTML_OPEN_TAG_NODE" && node.type !== "AST_HTML_SELF_CLOSE_TAG_NODE") {
-      return messages
-    }
-
-    // Collect all attribute names and their locations
-    const attributeNames = new Map<string, HTMLAttributeNameNode[]>()
-
-    const attributes = node.type === "AST_HTML_SELF_CLOSE_TAG_NODE"
-      ? (node as HTMLSelfCloseTagNode).attributes
-      : (node as HTMLOpenTagNode).children
-
-    for (const child of attributes) {
-      if (child.type === "AST_HTML_ATTRIBUTE_NODE") {
-        const attributeNode = child as HTMLAttributeNode
-
-        if (attributeNode.name?.type === "AST_HTML_ATTRIBUTE_NAME_NODE") {
-          const nameNode = attributeNode.name as HTMLAttributeNameNode
-
-          if (nameNode.name) {
-            const attributeName = nameNode.name.value.toLowerCase() // HTML attributes are case-insensitive
-
-            if (!attributeNames.has(attributeName)) {
-              attributeNames.set(attributeName, [])
-            }
-            attributeNames.get(attributeName)!.push(nameNode)
-          }
-        }
-      }
-    }
-
-    // Check for duplicates
-    for (const [attributeName, nameNodes] of attributeNames) {
-      if (nameNodes.length > 1) {
-        // Report error for all occurrences after the first
-        for (let i = 1; i < nameNodes.length; i++) {
-          const nameNode = nameNodes[i]
-          messages.push({
-            rule: this.name,
-            message: `Duplicate attribute \`${attributeName}\` found on tag. Remove the duplicate occurrence.`,
-            location: nameNode.location,
-            severity: "error"
-          })
-        }
-      }
-    }
-
-    return messages
+  check(node: Node): LintMessage[] {
+    const visitor = new NoDuplicateAttributesVisitor(this.name)
+    visitor.visit(node)
+    return visitor.messages
   }
 }

--- a/javascript/packages/linter/src/rules/html-no-nested-links.ts
+++ b/javascript/packages/linter/src/rules/html-no-nested-links.ts
@@ -1,64 +1,53 @@
-import { HTMLOpenTagNode, HTMLElementNode, Visitor, Node } from "@herb-tools/core"
-import { Rule, LintMessage } from "../types.js"
+import { BaseRuleVisitor, getTagName } from "./rule-utils.js"
 
-class NestedLinkVisitor extends Visitor {
+import type { Rule, LintMessage } from "../types.js"
+import type { HTMLOpenTagNode, HTMLElementNode, Node } from "@herb-tools/core"
+
+class NestedLinkVisitor extends BaseRuleVisitor {
   private linkStack: HTMLOpenTagNode[] = []
-  private messages: LintMessage[] = []
-  private ruleName: string
 
-  constructor(ruleName: string) {
-    super()
-    this.ruleName = ruleName
-  }
+  private checkNestedLink(openTag: HTMLOpenTagNode): boolean {
+    if (this.linkStack.length > 0) {
+      this.addMessage(
+        "Nested `<a>` elements are not allowed. Links cannot contain other links.",
+        openTag.tag_name!.location,
+        "error"
+      )
 
-  getMessages(): LintMessage[] {
-    return this.messages
+      return true
+    }
+
+    return false
   }
 
   visitHTMLElementNode(node: HTMLElementNode): void {
-    // Check if this is a link element
-    if (node.open_tag && node.open_tag.type === "AST_HTML_OPEN_TAG_NODE") {
-      const openTag = node.open_tag as HTMLOpenTagNode
-      if (openTag.tag_name?.value.toLowerCase() === "a") {
-        // If we're already inside a link, this is a nested link
-        if (this.linkStack.length > 0) {
-          this.messages.push({
-            rule: this.ruleName,
-            message: "Nested <a> elements are not allowed. Links cannot contain other links.",
-            location: openTag.tag_name.location,
-            severity: "error"
-          })
-        }
-
-        // Add this link to the stack
-        this.linkStack.push(openTag)
-
-        // Visit children
-        super.visitHTMLElementNode(node)
-
-        // Remove this link from the stack when done
-        this.linkStack.pop()
-      } else {
-        // Not a link, just continue traversing
-        super.visitHTMLElementNode(node)
-      }
-    } else {
-      // Not a proper element, just continue traversing
+    if (!node.open_tag || node.open_tag.type !== "AST_HTML_OPEN_TAG_NODE") {
       super.visitHTMLElementNode(node)
+      return
     }
+
+    const openTag = node.open_tag as HTMLOpenTagNode
+    const tagName = getTagName(openTag)
+
+    if (tagName !== "a") {
+      super.visitHTMLElementNode(node)
+      return
+    }
+
+    // If we're already inside a link, this is a nested link
+    this.checkNestedLink(openTag)
+
+    this.linkStack.push(openTag)
+    super.visitHTMLElementNode(node)
+    this.linkStack.pop()
   }
 
+  // Handle self-closing <a> tags (though they're not valid HTML, they might exist)
   visitHTMLOpenTagNode(node: HTMLOpenTagNode): void {
-    // Handle self-closing <a> tags (though they're not valid HTML, they might exist)
-    if (node.tag_name?.value.toLowerCase() === "a" && node.is_void) {
-      if (this.linkStack.length > 0) {
-        this.messages.push({
-          rule: this.ruleName,
-          message: "Nested <a> elements are not allowed. Links cannot contain other links.",
-          location: node.tag_name.location,
-          severity: "error"
-        })
-      }
+    const tagName = getTagName(node)
+
+    if (tagName === "a" && node.is_void) {
+      this.checkNestedLink(node)
     }
 
     super.visitHTMLOpenTagNode(node)
@@ -67,11 +56,10 @@ class NestedLinkVisitor extends Visitor {
 
 export class HTMLNoNestedLinksRule implements Rule {
   name = "html-no-nested-links"
-  description = "Disallow placing one <a> element inside another <a> element"
 
   check(node: Node): LintMessage[] {
     const visitor = new NestedLinkVisitor(this.name)
     visitor.visit(node)
-    return visitor.getMessages()
+    return visitor.messages
   }
 }

--- a/javascript/packages/linter/src/rules/html-tag-name-lowercase.ts
+++ b/javascript/packages/linter/src/rules/html-tag-name-lowercase.ts
@@ -1,29 +1,44 @@
-import { HTMLOpenTagNode, HTMLCloseTagNode, HTMLSelfCloseTagNode } from "@herb-tools/core"
-import { Rule, LintMessage } from "../types.js"
+import { BaseRuleVisitor } from "./rule-utils.js"
+
+import type { Rule, LintMessage } from "../types.js"
+import type { HTMLOpenTagNode, HTMLCloseTagNode, HTMLSelfCloseTagNode, Node } from "@herb-tools/core"
+
+class TagNameLowercaseVisitor extends BaseRuleVisitor {
+  visitHTMLOpenTagNode(node: HTMLOpenTagNode): void {
+    this.checkTagName(node)
+    super.visitHTMLOpenTagNode(node)
+  }
+
+  visitHTMLCloseTagNode(node: HTMLCloseTagNode): void {
+    this.checkTagName(node)
+    super.visitHTMLCloseTagNode(node)
+  }
+
+  visitHTMLSelfCloseTagNode(node: HTMLSelfCloseTagNode): void {
+    this.checkTagName(node)
+    super.visitHTMLSelfCloseTagNode(node)
+  }
+
+  private checkTagName(node: HTMLOpenTagNode | HTMLCloseTagNode | HTMLSelfCloseTagNode): void {
+    const tagName = node.tag_name?.value
+    if (!tagName) return
+
+    if (tagName !== tagName.toLowerCase()) {
+      this.addMessage(
+        `Tag name \`${tagName}\` should be lowercase. Use \`${tagName.toLowerCase()}\` instead.`,
+        node.tag_name!.location,
+        "error"
+      )
+    }
+  }
+}
 
 export class HTMLTagNameLowercaseRule implements Rule {
   name = "html-tag-name-lowercase"
-  description = "Enforce that all HTML tag names are written in lowercase"
 
-  check(node: HTMLOpenTagNode | HTMLCloseTagNode | HTMLSelfCloseTagNode): LintMessage[] {
-    const messages: LintMessage[] = []
-
-    if (!node.tag_name) {
-      return messages
-    }
-
-    const tagName = node.tag_name.value
-    const isLowercase = tagName === tagName.toLowerCase()
-
-    if (!isLowercase) {
-      messages.push({
-        rule: this.name,
-        message: `Tag name \`${tagName}\` should be lowercase. Use \`${tagName.toLowerCase()}\` instead.`,
-        location: node.tag_name.location,
-        severity: "error"
-      })
-    }
-
-    return messages
+  check(node: Node): LintMessage[] {
+    const visitor = new TagNameLowercaseVisitor(this.name)
+    visitor.visit(node)
+    return visitor.messages
   }
 }

--- a/javascript/packages/linter/src/rules/rule-utils.ts
+++ b/javascript/packages/linter/src/rules/rule-utils.ts
@@ -1,0 +1,249 @@
+import {
+  HTMLOpenTagNode,
+  HTMLSelfCloseTagNode,
+  HTMLAttributeNode,
+  HTMLAttributeNameNode,
+  HTMLAttributeValueNode,
+  LiteralNode,
+  Visitor,
+  Location
+} from "@herb-tools/core"
+
+import type { LintMessage } from "../types.js"
+
+/**
+ * Base visitor class that provides common functionality for rule visitors
+ */
+export abstract class BaseRuleVisitor extends Visitor {
+  public messages: LintMessage[] = []
+  protected ruleName: string
+
+  constructor(ruleName: string) {
+    super()
+
+    this.ruleName = ruleName
+  }
+
+  /**
+   * Helper method to create a lint message
+   */
+  protected createMessage(message: string, location: Location, severity: "error" | "warning" = "error"): LintMessage {
+    return {
+      rule: this.ruleName,
+      message,
+      location,
+      severity
+    }
+  }
+
+  /**
+   * Helper method to add a message to the messages array
+   */
+  protected addMessage(message: string, location: Location, severity: "error" | "warning" = "error"): void {
+    this.messages.push(this.createMessage(message, location, severity))
+  }
+}
+
+/**
+ * Gets attributes from either an HTMLOpenTagNode or HTMLSelfCloseTagNode
+ */
+export function getAttributes(node: HTMLOpenTagNode | HTMLSelfCloseTagNode): any[] {
+  return node.type === "AST_HTML_SELF_CLOSE_TAG_NODE"
+    ? (node as HTMLSelfCloseTagNode).attributes
+    : (node as HTMLOpenTagNode).children
+}
+
+/**
+ * Gets the tag name from an HTML tag node (lowercased)
+ */
+export function getTagName(node: HTMLOpenTagNode | HTMLSelfCloseTagNode): string | null {
+  return node.tag_name?.value.toLowerCase() || null
+}
+
+/**
+ * Gets the attribute name from an HTMLAttributeNode (lowercased)
+ */
+export function getAttributeName(attributeNode: HTMLAttributeNode): string | null {
+  if (attributeNode.name?.type === "AST_HTML_ATTRIBUTE_NAME_NODE") {
+    const nameNode = attributeNode.name as HTMLAttributeNameNode
+
+    return nameNode.name?.value.toLowerCase() || null
+  }
+
+  return null
+}
+
+/**
+ * Gets the attribute value content from an HTMLAttributeValueNode
+ */
+export function getAttributeValue(attributeNode: HTMLAttributeNode): string | null {
+  if (attributeNode.value?.type === "AST_HTML_ATTRIBUTE_VALUE_NODE") {
+    const valueNode = attributeNode.value as HTMLAttributeValueNode
+
+    if (valueNode.children && valueNode.children.length > 0) {
+      return valueNode.children
+        .filter(child => child.type === "AST_LITERAL_NODE")
+        .map(child => (child as LiteralNode).content)
+        .join("")
+    }
+  }
+
+  return null
+}
+
+/**
+ * Checks if an attribute has a value
+ */
+export function hasAttributeValue(attributeNode: HTMLAttributeNode): boolean {
+  return attributeNode.value?.type === "AST_HTML_ATTRIBUTE_VALUE_NODE"
+}
+
+/**
+ * Gets the quote type used for an attribute value
+ */
+export function getAttributeValueQuoteType(attributeNode: HTMLAttributeNode): "single" | "double" | "none" | null {
+  if (attributeNode.value?.type === "AST_HTML_ATTRIBUTE_VALUE_NODE") {
+    const valueNode = attributeNode.value as HTMLAttributeValueNode
+    if (valueNode.quoted && valueNode.open_quote) {
+      return valueNode.open_quote.value === '"' ? "double" : "single"
+    }
+
+    return "none"
+  }
+
+  return null
+}
+
+/**
+ * Finds an attribute by name in a list of attributes
+ */
+export function findAttributeByName(attributes: any[], attributeName: string): HTMLAttributeNode | null {
+  for (const child of attributes) {
+    if (child.type === "AST_HTML_ATTRIBUTE_NODE") {
+      const attributeNode = child as HTMLAttributeNode
+      const name = getAttributeName(attributeNode)
+      if (name === attributeName.toLowerCase()) {
+        return attributeNode
+      }
+    }
+  }
+  return null
+}
+
+/**
+ * Checks if a tag has a specific attribute
+ */
+export function hasAttribute(node: HTMLOpenTagNode | HTMLSelfCloseTagNode, attributeName: string): boolean {
+  const attributes = getAttributes(node)
+  return findAttributeByName(attributes, attributeName) !== null
+}
+
+/**
+ * Common HTML element categorization
+ */
+export const HTML_INLINE_ELEMENTS = new Set([
+  "a", "abbr", "acronym", "b", "bdo", "big", "br", "button", "cite", "code",
+  "dfn", "em", "i", "img", "input", "kbd", "label", "map", "object", "output",
+  "q", "samp", "script", "select", "small", "span", "strong", "sub", "sup",
+  "textarea", "time", "tt", "var"
+])
+
+export const HTML_BLOCK_ELEMENTS = new Set([
+  "address", "article", "aside", "blockquote", "canvas", "dd", "div", "dl",
+  "dt", "fieldset", "figcaption", "figure", "footer", "form", "h1", "h2",
+  "h3", "h4", "h5", "h6", "header", "hr", "li", "main", "nav", "noscript",
+  "ol", "p", "pre", "section", "table", "tfoot", "ul", "video"
+])
+
+export const HTML_BOOLEAN_ATTRIBUTES = new Set([
+  "autofocus", "autoplay", "checked", "controls", "defer", "disabled", "hidden",
+  "loop", "multiple", "muted", "readonly", "required", "reversed", "selected",
+  "open", "default", "formnovalidate", "novalidate", "itemscope", "scoped",
+  "seamless", "allowfullscreen", "async", "compact", "declare", "nohref",
+  "noresize", "noshade", "nowrap", "sortable", "truespeed", "typemustmatch"
+])
+
+/**
+ * Checks if an element is inline
+ */
+export function isInlineElement(tagName: string): boolean {
+  return HTML_INLINE_ELEMENTS.has(tagName.toLowerCase())
+}
+
+/**
+ * Checks if an element is block-level
+ */
+export function isBlockElement(tagName: string): boolean {
+  return HTML_BLOCK_ELEMENTS.has(tagName.toLowerCase())
+}
+
+/**
+ * Checks if an attribute is a boolean attribute
+ */
+export function isBooleanAttribute(attributeName: string): boolean {
+  return HTML_BOOLEAN_ATTRIBUTES.has(attributeName.toLowerCase())
+}
+
+/**
+ * Abstract base class for rules that need to check individual attributes on HTML tags
+ * Eliminates duplication of visitHTMLOpenTagNode/visitHTMLSelfCloseTagNode patterns
+ * and attribute iteration logic. Provides simplified interface with extracted attribute info.
+ */
+export abstract class AttributeVisitorMixin extends BaseRuleVisitor {
+  visitHTMLOpenTagNode(node: HTMLOpenTagNode): void {
+    this.checkAttributesOnNode(node)
+    super.visitHTMLOpenTagNode(node)
+  }
+
+  visitHTMLSelfCloseTagNode(node: HTMLSelfCloseTagNode): void {
+    this.checkAttributesOnNode(node)
+    super.visitHTMLSelfCloseTagNode(node)
+  }
+
+  private checkAttributesOnNode(node: HTMLOpenTagNode | HTMLSelfCloseTagNode): void {
+    forEachAttribute(node, (attributeNode) => {
+      const attributeName = getAttributeName(attributeNode)
+      const attributeValue = getAttributeValue(attributeNode)
+
+      if (attributeName) {
+        this.checkAttribute(attributeName, attributeValue, attributeNode, node)
+      }
+    })
+  }
+
+  protected abstract checkAttribute(
+    attributeName: string,
+    attributeValue: string | null,
+    attributeNode: HTMLAttributeNode,
+    parentNode: HTMLOpenTagNode | HTMLSelfCloseTagNode
+  ): void
+}
+
+/**
+ * Checks if an attribute value is quoted
+ */
+export function isAttributeValueQuoted(attributeNode: HTMLAttributeNode): boolean {
+  if (attributeNode.value?.type === "AST_HTML_ATTRIBUTE_VALUE_NODE") {
+    const valueNode = attributeNode.value as HTMLAttributeValueNode
+
+    return !!valueNode.quoted
+  }
+
+  return false
+}
+
+/**
+ * Iterates over all attributes of a tag node, calling the callback for each attribute
+ */
+export function forEachAttribute(
+  node: HTMLOpenTagNode | HTMLSelfCloseTagNode,
+  callback: (attributeNode: HTMLAttributeNode) => void
+): void {
+  const attributes = getAttributes(node)
+
+  for (const child of attributes) {
+    if (child.type === "AST_HTML_ATTRIBUTE_NODE") {
+      callback(child as HTMLAttributeNode)
+    }
+  }
+}

--- a/javascript/packages/linter/src/types.ts
+++ b/javascript/packages/linter/src/types.ts
@@ -1,4 +1,4 @@
-import { Location } from "@herb-tools/core"
+import { Location, Node } from "@herb-tools/core"
 
 export interface LintMessage {
   rule: string
@@ -15,6 +15,11 @@ export interface LintResult {
 
 export interface Rule {
   name: string
-  description: string
-  check(node: any): LintMessage[]
+  check(node: Node): LintMessage[]
 }
+
+/**
+ * Type representing a rule class constructor.
+ * The Linter accepts rule classes rather than instances for better performance and memory usage.
+ */
+export type RuleClass = new () => Rule

--- a/javascript/packages/linter/test/linter.test.ts
+++ b/javascript/packages/linter/test/linter.test.ts
@@ -19,8 +19,7 @@ describe("@herb-tools/linter", () => {
     })
 
     test("can be instantiated with custom rules", () => {
-      const rule = new HTMLTagNameLowercaseRule()
-      const linter = new Linter([rule])
+      const linter = new Linter([HTMLTagNameLowercaseRule])
       expect(linter).toBeInstanceOf(Linter)
     })
   })

--- a/javascript/packages/linter/test/rules/html-attribute-double-quotes.test.ts
+++ b/javascript/packages/linter/test/rules/html-attribute-double-quotes.test.ts
@@ -11,7 +11,7 @@ describe("html-attribute-double-quotes", () => {
   test("passes for double quoted attributes", () => {
     const html = '<input type="text" value="Username">'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLAttributeDoubleQuotesRule()])
+    const linter = new Linter([HTMLAttributeDoubleQuotesRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(0)
@@ -22,26 +22,26 @@ describe("html-attribute-double-quotes", () => {
   test("fails for single quoted attributes", () => {
     const html = "<input type='text' value='Username'>"
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLAttributeDoubleQuotesRule()])
+    const linter = new Linter([HTMLAttributeDoubleQuotesRule])
     const lintResult = linter.lint(result.value)
 
-    expect(lintResult.errors).toBe(2)
-    expect(lintResult.warnings).toBe(0)
+    expect(lintResult.errors).toBe(0)
+    expect(lintResult.warnings).toBe(2)
     expect(lintResult.messages).toHaveLength(2)
 
     expect(lintResult.messages[0].rule).toBe("html-attribute-double-quotes")
     expect(lintResult.messages[0].message).toBe('Attribute `type` uses single quotes. Prefer double quotes for HTML attribute values: `type="value"`.')
-    expect(lintResult.messages[0].severity).toBe("error")
+    expect(lintResult.messages[0].severity).toBe("warning")
 
     expect(lintResult.messages[1].rule).toBe("html-attribute-double-quotes")
     expect(lintResult.messages[1].message).toBe('Attribute `value` uses single quotes. Prefer double quotes for HTML attribute values: `value="value"`.')
-    expect(lintResult.messages[1].severity).toBe("error")
+    expect(lintResult.messages[1].severity).toBe("warning")
   })
 
   test("passes for mixed content with double quotes", () => {
     const html = '<a href="/profile" title="User Profile" data-controller="dropdown">Profile</a>'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLAttributeDoubleQuotesRule()])
+    const linter = new Linter([HTMLAttributeDoubleQuotesRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(0)
@@ -51,10 +51,11 @@ describe("html-attribute-double-quotes", () => {
   test("fails for mixed content with single quotes", () => {
     const html = "<a href='/profile' title='User Profile' data-controller='dropdown'>Profile</a>"
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLAttributeDoubleQuotesRule()])
+    const linter = new Linter([HTMLAttributeDoubleQuotesRule])
     const lintResult = linter.lint(result.value)
 
-    expect(lintResult.errors).toBe(3)
+    expect(lintResult.errors).toBe(0)
+    expect(lintResult.warnings).toBe(3)
     expect(lintResult.messages[0].message).toBe('Attribute `href` uses single quotes. Prefer double quotes for HTML attribute values: `href="value"`.')
     expect(lintResult.messages[1].message).toBe('Attribute `title` uses single quotes. Prefer double quotes for HTML attribute values: `title="value"`.')
     expect(lintResult.messages[2].message).toBe('Attribute `data-controller` uses single quotes. Prefer double quotes for HTML attribute values: `data-controller="value"`.')
@@ -63,7 +64,7 @@ describe("html-attribute-double-quotes", () => {
   test("passes for unquoted attributes (handled by other rule)", () => {
     const html = '<input type=text value=Username>'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLAttributeDoubleQuotesRule()])
+    const linter = new Linter([HTMLAttributeDoubleQuotesRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(0)
@@ -73,7 +74,7 @@ describe("html-attribute-double-quotes", () => {
   test("passes for attributes without values", () => {
     const html = '<input type="checkbox" checked disabled>'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLAttributeDoubleQuotesRule()])
+    const linter = new Linter([HTMLAttributeDoubleQuotesRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(0)
@@ -83,10 +84,11 @@ describe("html-attribute-double-quotes", () => {
   test("handles self-closing tags with single quotes", () => {
     const html = "<img src='/image.jpg' alt='Description' />"
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLAttributeDoubleQuotesRule()])
+    const linter = new Linter([HTMLAttributeDoubleQuotesRule])
     const lintResult = linter.lint(result.value)
 
-    expect(lintResult.errors).toBe(2)
+    expect(lintResult.errors).toBe(0)
+    expect(lintResult.warnings).toBe(2)
     expect(lintResult.messages[0].message).toBe('Attribute `src` uses single quotes. Prefer double quotes for HTML attribute values: `src="value"`.')
     expect(lintResult.messages[1].message).toBe('Attribute `alt` uses single quotes. Prefer double quotes for HTML attribute values: `alt="value"`.')
   })
@@ -94,10 +96,11 @@ describe("html-attribute-double-quotes", () => {
   test("handles ERB with single quoted attributes", () => {
     const html = "<div data-controller='<%= controller_name %>' data-action='click->toggle#action'>Content</div>"
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLAttributeDoubleQuotesRule()])
+    const linter = new Linter([HTMLAttributeDoubleQuotesRule])
     const lintResult = linter.lint(result.value)
 
-    expect(lintResult.errors).toBe(2)
+    expect(lintResult.errors).toBe(0)
+    expect(lintResult.warnings).toBe(2)
     expect(lintResult.messages[0].message).toBe('Attribute `data-controller` uses single quotes. Prefer double quotes for HTML attribute values: `data-controller="value"`.')
     expect(lintResult.messages[1].message).toBe('Attribute `data-action` uses single quotes. Prefer double quotes for HTML attribute values: `data-action="value"`.')
   })
@@ -105,7 +108,7 @@ describe("html-attribute-double-quotes", () => {
   test("allows single quotes when value contains double quotes", () => {
     const html = '<div id=\'"hello"\' class=\'Say "Hello" to the world\'></div>'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLAttributeDoubleQuotesRule()])
+    const linter = new Linter([HTMLAttributeDoubleQuotesRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(0)
@@ -116,10 +119,11 @@ describe("html-attribute-double-quotes", () => {
   test("still fails for single quotes when value has no double quotes", () => {
     const html = "<div id='hello' class='world'></div>"
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLAttributeDoubleQuotesRule()])
+    const linter = new Linter([HTMLAttributeDoubleQuotesRule])
     const lintResult = linter.lint(result.value)
 
-    expect(lintResult.errors).toBe(2)
+    expect(lintResult.errors).toBe(0)
+    expect(lintResult.warnings).toBe(2)
     expect(lintResult.messages[0].message).toBe('Attribute `id` uses single quotes. Prefer double quotes for HTML attribute values: `id="value"`.')
     expect(lintResult.messages[1].message).toBe('Attribute `class` uses single quotes. Prefer double quotes for HTML attribute values: `class="value"`.')
   })

--- a/javascript/packages/linter/test/rules/html-attribute-values-require-quotes.test.ts
+++ b/javascript/packages/linter/test/rules/html-attribute-values-require-quotes.test.ts
@@ -11,7 +11,7 @@ describe("html-attribute-values-require-quotes", () => {
   test("passes for quoted attribute values", () => {
     const html = '<div id="hello" class="container">'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLAttributeValuesRequireQuotesRule()])
+    const linter = new Linter([HTMLAttributeValuesRequireQuotesRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(0)
@@ -22,7 +22,7 @@ describe("html-attribute-values-require-quotes", () => {
   test("fails for unquoted attribute values", () => {
     const html = '<div id=hello class=container>'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLAttributeValuesRequireQuotesRule()])
+    const linter = new Linter([HTMLAttributeValuesRequireQuotesRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(2) // Both id and class are unquoted
@@ -37,7 +37,7 @@ describe("html-attribute-values-require-quotes", () => {
   test("passes for single-quoted values", () => {
     const html = "<div id='hello' class='container'>"
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLAttributeValuesRequireQuotesRule()])
+    const linter = new Linter([HTMLAttributeValuesRequireQuotesRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(0)
@@ -47,7 +47,7 @@ describe("html-attribute-values-require-quotes", () => {
   test("passes for boolean attributes without values", () => {
     const html = '<input type="text" disabled>'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLAttributeValuesRequireQuotesRule()])
+    const linter = new Linter([HTMLAttributeValuesRequireQuotesRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(0)
@@ -57,7 +57,7 @@ describe("html-attribute-values-require-quotes", () => {
   test("handles mixed quoted and unquoted", () => {
     const html = '<input type="text" name=username value="test">'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLAttributeValuesRequireQuotesRule()])
+    const linter = new Linter([HTMLAttributeValuesRequireQuotesRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(1) // Only name is unquoted
@@ -67,7 +67,7 @@ describe("html-attribute-values-require-quotes", () => {
   test("handles ERB in quoted attributes", () => {
     const html = '<div class="<%= classes %>" data-id="<%= item.id %>">'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLAttributeValuesRequireQuotesRule()])
+    const linter = new Linter([HTMLAttributeValuesRequireQuotesRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(0)
@@ -77,7 +77,7 @@ describe("html-attribute-values-require-quotes", () => {
   test("handles self-closing tags", () => {
     const html = '<img src=photo.jpg alt="Photo">'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLAttributeValuesRequireQuotesRule()])
+    const linter = new Linter([HTMLAttributeValuesRequireQuotesRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(1)
@@ -87,7 +87,7 @@ describe("html-attribute-values-require-quotes", () => {
   test("handles complex attribute values", () => {
     const html = '<a href="/profile" title=User\\ Profile>'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLAttributeValuesRequireQuotesRule()])
+    const linter = new Linter([HTMLAttributeValuesRequireQuotesRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(1)
@@ -97,7 +97,7 @@ describe("html-attribute-values-require-quotes", () => {
   test("ignores closing tags", () => {
     const html = '<div class="test"></div>'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLAttributeValuesRequireQuotesRule()])
+    const linter = new Linter([HTMLAttributeValuesRequireQuotesRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(0)

--- a/javascript/packages/linter/test/rules/html-boolean-attributes-no-value.test.ts
+++ b/javascript/packages/linter/test/rules/html-boolean-attributes-no-value.test.ts
@@ -11,7 +11,7 @@ describe("html-boolean-attributes-no-value", () => {
   test("passes for boolean attributes without values", () => {
     const html = '<input type="checkbox" checked disabled>'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLBooleanAttributesNoValueRule()])
+    const linter = new Linter([HTMLBooleanAttributesNoValueRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(0)
@@ -22,7 +22,7 @@ describe("html-boolean-attributes-no-value", () => {
   test("fails for boolean attributes with explicit values", () => {
     const html = '<input type="checkbox" checked="checked" disabled="disabled">'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLBooleanAttributesNoValueRule()])
+    const linter = new Linter([HTMLBooleanAttributesNoValueRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(2)
@@ -41,7 +41,7 @@ describe("html-boolean-attributes-no-value", () => {
   test("fails for boolean attributes with true/false values", () => {
     const html = '<button disabled="true">Submit</button>'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLBooleanAttributesNoValueRule()])
+    const linter = new Linter([HTMLBooleanAttributesNoValueRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(1)
@@ -51,7 +51,7 @@ describe("html-boolean-attributes-no-value", () => {
   test("passes for non-boolean attributes with values", () => {
     const html = '<input type="text" value="Username" name="user">'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLBooleanAttributesNoValueRule()])
+    const linter = new Linter([HTMLBooleanAttributesNoValueRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(0)
@@ -61,7 +61,7 @@ describe("html-boolean-attributes-no-value", () => {
   test("handles multiple boolean attributes", () => {
     const html = '<select multiple="multiple"><option selected="selected">Option 1</option></select>'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLBooleanAttributesNoValueRule()])
+    const linter = new Linter([HTMLBooleanAttributesNoValueRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(2)
@@ -72,7 +72,7 @@ describe("html-boolean-attributes-no-value", () => {
   test("handles self-closing tags with boolean attributes", () => {
     const html = '<input type="checkbox" checked="checked" required="true" />'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLBooleanAttributesNoValueRule()])
+    const linter = new Linter([HTMLBooleanAttributesNoValueRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(2)
@@ -83,7 +83,7 @@ describe("html-boolean-attributes-no-value", () => {
   test("handles case insensitive boolean attributes", () => {
     const html = '<input CHECKED="CHECKED" DISABLED="disabled">'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLBooleanAttributesNoValueRule()])
+    const linter = new Linter([HTMLBooleanAttributesNoValueRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(2)
@@ -94,7 +94,7 @@ describe("html-boolean-attributes-no-value", () => {
   test("passes for video controls", () => {
     const html = '<video controls>'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLBooleanAttributesNoValueRule()])
+    const linter = new Linter([HTMLBooleanAttributesNoValueRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(0)
@@ -104,7 +104,7 @@ describe("html-boolean-attributes-no-value", () => {
   test("fails for video controls with value", () => {
     const html = '<video controls="controls" autoplay="autoplay">'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLBooleanAttributesNoValueRule()])
+    const linter = new Linter([HTMLBooleanAttributesNoValueRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(2)
@@ -115,7 +115,7 @@ describe("html-boolean-attributes-no-value", () => {
   test("fails for boolean attribute with different value", () => {
     const html = '<video controls="something-else">'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLBooleanAttributesNoValueRule()])
+    const linter = new Linter([HTMLBooleanAttributesNoValueRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(1)
@@ -125,7 +125,7 @@ describe("html-boolean-attributes-no-value", () => {
   test("handles mixed boolean and regular attributes", () => {
     const html = '<form novalidate="novalidate" action="/submit" method="post">'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLBooleanAttributesNoValueRule()])
+    const linter = new Linter([HTMLBooleanAttributesNoValueRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(1)

--- a/javascript/packages/linter/test/rules/html-img-require-alt.test.ts
+++ b/javascript/packages/linter/test/rules/html-img-require-alt.test.ts
@@ -11,7 +11,7 @@ describe("html-img-require-alt", () => {
   test("passes for img with alt attribute", () => {
     const html = '<img src="/logo.png" alt="Company logo">'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLImgRequireAltRule()])
+    const linter = new Linter([HTMLImgRequireAltRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(0)
@@ -22,7 +22,7 @@ describe("html-img-require-alt", () => {
   test("passes for img with empty alt attribute", () => {
     const html = '<img src="/divider.png" alt="">'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLImgRequireAltRule()])
+    const linter = new Linter([HTMLImgRequireAltRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(0)
@@ -33,7 +33,7 @@ describe("html-img-require-alt", () => {
   test("fails for img without alt attribute", () => {
     const html = '<img src="/logo.png">'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLImgRequireAltRule()])
+    const linter = new Linter([HTMLImgRequireAltRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(1)
@@ -48,7 +48,7 @@ describe("html-img-require-alt", () => {
   test("fails for multiple img tags without alt", () => {
     const html = '<img src="/logo.png"><img src="/banner.jpg">'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLImgRequireAltRule()])
+    const linter = new Linter([HTMLImgRequireAltRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(2)
@@ -59,7 +59,7 @@ describe("html-img-require-alt", () => {
   test("handles mixed case img tags", () => {
     const html = '<IMG src="/logo.png">'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLImgRequireAltRule()])
+    const linter = new Linter([HTMLImgRequireAltRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(1)
@@ -69,7 +69,7 @@ describe("html-img-require-alt", () => {
   test("passes for img with ERB alt attribute", () => {
     const html = '<img src="/avatar.jpg" alt="<%= user.name %>\'s profile picture">'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLImgRequireAltRule()])
+    const linter = new Linter([HTMLImgRequireAltRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(0)
@@ -79,7 +79,7 @@ describe("html-img-require-alt", () => {
   test("ignores non-img tags", () => {
     const html = '<div src="/something.png"></div>'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLImgRequireAltRule()])
+    const linter = new Linter([HTMLImgRequireAltRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(0)
@@ -89,7 +89,7 @@ describe("html-img-require-alt", () => {
   test("handles self-closing img tags", () => {
     const html = '<img src="/logo.png" />'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLImgRequireAltRule()])
+    const linter = new Linter([HTMLImgRequireAltRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(1)
@@ -99,7 +99,7 @@ describe("html-img-require-alt", () => {
   test("passes for case-insensitive alt attribute", () => {
     const html = '<img src="/logo.png" ALT="Logo">'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLImgRequireAltRule()])
+    const linter = new Linter([HTMLImgRequireAltRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(0)

--- a/javascript/packages/linter/test/rules/html-no-block-inside-inline.test.ts
+++ b/javascript/packages/linter/test/rules/html-no-block-inside-inline.test.ts
@@ -11,7 +11,7 @@ describe("html-no-block-inside-inline", () => {
   test("passes for inline elements containing other inline elements", () => {
     const html = '<span>Hello <strong>World</strong></span>'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLNoBlockInsideInlineRule()])
+    const linter = new Linter([HTMLNoBlockInsideInlineRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(0)
@@ -22,7 +22,7 @@ describe("html-no-block-inside-inline", () => {
   test("passes for block elements containing block elements", () => {
     const html = '<div><p>Paragraph inside div (valid)</p></div>'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLNoBlockInsideInlineRule()])
+    const linter = new Linter([HTMLNoBlockInsideInlineRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(0)
@@ -33,7 +33,7 @@ describe("html-no-block-inside-inline", () => {
   test("fails for div inside span", () => {
     const html = '<span><div>Invalid block inside span</div></span>'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLNoBlockInsideInlineRule()])
+    const linter = new Linter([HTMLNoBlockInsideInlineRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(1)
@@ -48,7 +48,7 @@ describe("html-no-block-inside-inline", () => {
   test("fails for paragraph inside span", () => {
     const html = '<span><p>Paragraph inside span (invalid)</p></span>'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLNoBlockInsideInlineRule()])
+    const linter = new Linter([HTMLNoBlockInsideInlineRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(1)
@@ -61,7 +61,7 @@ describe("html-no-block-inside-inline", () => {
   test("fails for multiple block elements inside inline", () => {
     const html = '<span><div>First</div><p>Second</p></span>'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLNoBlockInsideInlineRule()])
+    const linter = new Linter([HTMLNoBlockInsideInlineRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(2)
@@ -72,7 +72,7 @@ describe("html-no-block-inside-inline", () => {
   test("fails for block inside anchor tag", () => {
     const html = '<a href="#"><div>Link with div</div></a>'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLNoBlockInsideInlineRule()])
+    const linter = new Linter([HTMLNoBlockInsideInlineRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(1)
@@ -82,7 +82,7 @@ describe("html-no-block-inside-inline", () => {
   test("fails for heading inside strong", () => {
     const html = '<strong><h1>Heading in strong</h1></strong>'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLNoBlockInsideInlineRule()])
+    const linter = new Linter([HTMLNoBlockInsideInlineRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(1)
@@ -92,7 +92,7 @@ describe("html-no-block-inside-inline", () => {
   test("fails for section inside em", () => {
     const html = '<em><section>Section in em</section></em>'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLNoBlockInsideInlineRule()])
+    const linter = new Linter([HTMLNoBlockInsideInlineRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(1)
@@ -102,7 +102,7 @@ describe("html-no-block-inside-inline", () => {
   test("passes for nested inline elements", () => {
     const html = '<span><a href="#"><em><strong>Valid nesting</strong></em></a></span>'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLNoBlockInsideInlineRule()])
+    const linter = new Linter([HTMLNoBlockInsideInlineRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(0)
@@ -112,7 +112,7 @@ describe("html-no-block-inside-inline", () => {
   test("fails for deeply nested block in inline", () => {
     const html = '<span><em><strong><div>Deeply nested div</div></strong></em></span>'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLNoBlockInsideInlineRule()])
+    const linter = new Linter([HTMLNoBlockInsideInlineRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(1)
@@ -122,7 +122,7 @@ describe("html-no-block-inside-inline", () => {
   test("passes for inline elements with text and inline children", () => {
     const html = '<span>Text before <code>code</code> text after</span>'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLNoBlockInsideInlineRule()])
+    const linter = new Linter([HTMLNoBlockInsideInlineRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(0)
@@ -132,7 +132,7 @@ describe("html-no-block-inside-inline", () => {
   test("fails for list inside inline element", () => {
     const html = '<span><ul><li>Item</li></ul></span>'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLNoBlockInsideInlineRule()])
+    const linter = new Linter([HTMLNoBlockInsideInlineRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(1)
@@ -142,7 +142,7 @@ describe("html-no-block-inside-inline", () => {
   test("handles ERB templates correctly", () => {
     const html = '<span><%= render partial: "some/partial" %></span>'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLNoBlockInsideInlineRule()])
+    const linter = new Linter([HTMLNoBlockInsideInlineRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(0)
@@ -152,7 +152,7 @@ describe("html-no-block-inside-inline", () => {
   test("fails for form inside button", () => {
     const html = '<button><form action="/submit">Submit</form></button>'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLNoBlockInsideInlineRule()])
+    const linter = new Linter([HTMLNoBlockInsideInlineRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(1)
@@ -162,7 +162,7 @@ describe("html-no-block-inside-inline", () => {
   test("fails for table inside label", () => {
     const html = '<label><table><tr><td>Cell</td></tr></table></label>'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLNoBlockInsideInlineRule()])
+    const linter = new Linter([HTMLNoBlockInsideInlineRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(1)
@@ -172,7 +172,7 @@ describe("html-no-block-inside-inline", () => {
   test("fails for custom elements inside inline elements", () => {
     const html = '<span><my-component>Custom content</my-component></span>'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLNoBlockInsideInlineRule()])
+    const linter = new Linter([HTMLNoBlockInsideInlineRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(1)
@@ -182,7 +182,7 @@ describe("html-no-block-inside-inline", () => {
   test("passes for block elements inside custom elements", () => {
     const html = '<my-inline-component><div>Block inside custom</div></my-inline-component>'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLNoBlockInsideInlineRule()])
+    const linter = new Linter([HTMLNoBlockInsideInlineRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(0)
@@ -198,7 +198,7 @@ describe("html-no-block-inside-inline", () => {
       </span>
     `
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLNoBlockInsideInlineRule()])
+    const linter = new Linter([HTMLNoBlockInsideInlineRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(3)
@@ -210,7 +210,7 @@ describe("html-no-block-inside-inline", () => {
   test("still fails for standard block elements after custom elements", () => {
     const html = '<span><my-component>Custom</my-component><div>Block div</div></span>'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLNoBlockInsideInlineRule()])
+    const linter = new Linter([HTMLNoBlockInsideInlineRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(2)
@@ -221,7 +221,7 @@ describe("html-no-block-inside-inline", () => {
   test("fails for nested custom elements inside inline", () => {
     const html = '<span><outer-component><inner-component><div>Content</div></inner-component></outer-component></span>'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLNoBlockInsideInlineRule()])
+    const linter = new Linter([HTMLNoBlockInsideInlineRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(1)
@@ -231,7 +231,7 @@ describe("html-no-block-inside-inline", () => {
   test("fails for single-word custom elements inside inline", () => {
     const html = '<span><customtag><div>Block inside unknown element</div></customtag></span>'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLNoBlockInsideInlineRule()])
+    const linter = new Linter([HTMLNoBlockInsideInlineRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(1)
@@ -241,7 +241,7 @@ describe("html-no-block-inside-inline", () => {
   test("fails for unknown elements inside inline but allows content inside unknown elements", () => {
     const html = '<span><unknownelement><randomtag><div>Block content</div></randomtag></unknownelement></span>'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLNoBlockInsideInlineRule()])
+    const linter = new Linter([HTMLNoBlockInsideInlineRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(1)
@@ -251,7 +251,7 @@ describe("html-no-block-inside-inline", () => {
   test("passes for custom elements at top level", () => {
     const html = '<my-component><div>Block inside custom</div></my-component>'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLNoBlockInsideInlineRule()])
+    const linter = new Linter([HTMLNoBlockInsideInlineRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(0)
@@ -261,7 +261,7 @@ describe("html-no-block-inside-inline", () => {
   test("fails for inline element containg erb node containing block node", () => {
     const html = '<span><% if true %><div>Not allowed</div><% end %></span>'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLNoBlockInsideInlineRule()])
+    const linter = new Linter([HTMLNoBlockInsideInlineRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(1)

--- a/javascript/packages/linter/test/rules/html-no-duplicate-attributes.test.ts
+++ b/javascript/packages/linter/test/rules/html-no-duplicate-attributes.test.ts
@@ -11,7 +11,7 @@ describe("html-no-duplicate-attributes", () => {
   test("passes for unique attributes", () => {
     const html = '<input type="text" name="username" id="user-id">'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLNoDuplicateAttributesRule()])
+    const linter = new Linter([HTMLNoDuplicateAttributesRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(0)
@@ -22,7 +22,7 @@ describe("html-no-duplicate-attributes", () => {
   test("fails for duplicate attributes", () => {
     const html = '<input type="text" type="password" name="username">'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLNoDuplicateAttributesRule()])
+    const linter = new Linter([HTMLNoDuplicateAttributesRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(1)
@@ -37,7 +37,7 @@ describe("html-no-duplicate-attributes", () => {
   test("fails for multiple duplicate attributes", () => {
     const html = '<button type="submit" type="button" class="btn" class="primary">'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLNoDuplicateAttributesRule()])
+    const linter = new Linter([HTMLNoDuplicateAttributesRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(2) // One for type, one for class
@@ -48,7 +48,7 @@ describe("html-no-duplicate-attributes", () => {
   test("handles case-insensitive duplicates", () => {
     const html = '<div Class="container" class="active">'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLNoDuplicateAttributesRule()])
+    const linter = new Linter([HTMLNoDuplicateAttributesRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(1)
@@ -58,7 +58,7 @@ describe("html-no-duplicate-attributes", () => {
   test("passes for different attributes", () => {
     const html = '<div class="container" id="main" data-value="test">'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLNoDuplicateAttributesRule()])
+    const linter = new Linter([HTMLNoDuplicateAttributesRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(0)
@@ -68,7 +68,7 @@ describe("html-no-duplicate-attributes", () => {
   test("handles self-closing tags", () => {
     const html = '<img src="/logo.png" src="/backup.png" alt="Logo">'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLNoDuplicateAttributesRule()])
+    const linter = new Linter([HTMLNoDuplicateAttributesRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(1)
@@ -78,7 +78,7 @@ describe("html-no-duplicate-attributes", () => {
   test("handles ERB templates with attributes", () => {
     const html = '<div class="<%= classes %>" data-id="<%= item.id %>">'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLNoDuplicateAttributesRule()])
+    const linter = new Linter([HTMLNoDuplicateAttributesRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(0)
@@ -88,7 +88,7 @@ describe("html-no-duplicate-attributes", () => {
   test("ignores closing tags", () => {
     const html = '<div class="test"></div>'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLNoDuplicateAttributesRule()])
+    const linter = new Linter([HTMLNoDuplicateAttributesRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(0)

--- a/javascript/packages/linter/test/rules/html-no-nested-links.test.ts
+++ b/javascript/packages/linter/test/rules/html-no-nested-links.test.ts
@@ -11,7 +11,7 @@ describe("html-no-nested-links", () => {
   test("passes for separate links", () => {
     const html = '<a href="/products">View products</a><a href="/about">About us</a>'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLNoNestedLinksRule()])
+    const linter = new Linter([HTMLNoNestedLinksRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(0)
@@ -22,7 +22,7 @@ describe("html-no-nested-links", () => {
   test("fails for directly nested links", () => {
     const html = '<a href="/products">View <a href="/special-offer">special offer</a></a>'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLNoNestedLinksRule()])
+    const linter = new Linter([HTMLNoNestedLinksRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(1)
@@ -30,24 +30,24 @@ describe("html-no-nested-links", () => {
     expect(lintResult.messages).toHaveLength(1)
 
     expect(lintResult.messages[0].rule).toBe("html-no-nested-links")
-    expect(lintResult.messages[0].message).toBe("Nested <a> elements are not allowed. Links cannot contain other links.")
+    expect(lintResult.messages[0].message).toBe("Nested `<a>` elements are not allowed. Links cannot contain other links.")
     expect(lintResult.messages[0].severity).toBe("error")
   })
 
   test("fails for indirectly nested links", () => {
     const html = '<a href="/main"><div><span><a href="/nested">Nested link</a></span></div></a>'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLNoNestedLinksRule()])
+    const linter = new Linter([HTMLNoNestedLinksRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(1)
-    expect(lintResult.messages[0].message).toBe("Nested <a> elements are not allowed. Links cannot contain other links.")
+    expect(lintResult.messages[0].message).toBe("Nested `<a>` elements are not allowed. Links cannot contain other links.")
   })
 
   test("passes for links in different containers", () => {
     const html = '<div><a href="/products">Products</a></div><div><a href="/special-offer">Special offer</a></div>'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLNoNestedLinksRule()])
+    const linter = new Linter([HTMLNoNestedLinksRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(0)
@@ -57,7 +57,7 @@ describe("html-no-nested-links", () => {
   test("fails for multiple levels of nesting", () => {
     const html = '<a href="/level1"><a href="/level2"><a href="/level3">Deep nesting</a></a></a>'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLNoNestedLinksRule()])
+    const linter = new Linter([HTMLNoNestedLinksRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(2) // Second and third links are nested
@@ -67,17 +67,17 @@ describe("html-no-nested-links", () => {
   test("handles mixed case anchor tags", () => {
     const html = '<a href="/main"><A href="/nested">Nested</A></a>'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLNoNestedLinksRule()])
+    const linter = new Linter([HTMLNoNestedLinksRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(1)
-    expect(lintResult.messages[0].message).toBe("Nested <a> elements are not allowed. Links cannot contain other links.")
+    expect(lintResult.messages[0].message).toBe("Nested `<a>` elements are not allowed. Links cannot contain other links.")
   })
 
   test("passes for links with complex content", () => {
     const html = '<a href="/profile"><img src="/avatar.jpg" alt="Avatar"><span>User Name</span></a>'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLNoNestedLinksRule()])
+    const linter = new Linter([HTMLNoNestedLinksRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(0)
@@ -87,7 +87,7 @@ describe("html-no-nested-links", () => {
   test("handles ERB templates with links", () => {
     const html = '<div><% items.each do |item| %><a href="<%= item.url %>"><%= item.name %></a><% end %></div>'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLNoNestedLinksRule()])
+    const linter = new Linter([HTMLNoNestedLinksRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(0)
@@ -97,7 +97,7 @@ describe("html-no-nested-links", () => {
   test("fails for nested links in ERB", () => {
     const html = '<%= link_to "Products", products_path do %><%= link_to "Special offer", offer_path %><% end %>'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLNoNestedLinksRule()])
+    const linter = new Linter([HTMLNoNestedLinksRule])
     const lintResult = linter.lint(result.value)
 
     // This test might not catch ERB helpers since they're not parsed as HTML elements

--- a/javascript/packages/linter/test/rules/html-tag-name-lowercase.test.ts
+++ b/javascript/packages/linter/test/rules/html-tag-name-lowercase.test.ts
@@ -11,7 +11,7 @@ describe("html-tag-name-lowercase", () => {
   test("passes for lowercase tag names", () => {
     const html = '<div class="container"><span>Hello</span></div>'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLTagNameLowercaseRule()])
+    const linter = new Linter([HTMLTagNameLowercaseRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(0)
@@ -22,7 +22,7 @@ describe("html-tag-name-lowercase", () => {
   test("fails for uppercase tag names", () => {
     const html = '<DIV class="container"><SPAN>Hello</SPAN></DIV>'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLTagNameLowercaseRule()])
+    const linter = new Linter([HTMLTagNameLowercaseRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(4) // DIV open, DIV close, SPAN open, SPAN close
@@ -37,7 +37,7 @@ describe("html-tag-name-lowercase", () => {
   test("fails for mixed case tag names", () => {
     const html = '<Div class="container"><Span>Hello</Span></Div>'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLTagNameLowercaseRule()])
+    const linter = new Linter([HTMLTagNameLowercaseRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(4)
@@ -50,7 +50,7 @@ describe("html-tag-name-lowercase", () => {
   test("handles self-closing tags", () => {
     const html = '<IMG src="photo.jpg" />'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLTagNameLowercaseRule()])
+    const linter = new Linter([HTMLTagNameLowercaseRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(1)
@@ -60,7 +60,7 @@ describe("html-tag-name-lowercase", () => {
   test("passes for valid self-closing tags", () => {
     const html = '<img src="photo.jpg" />'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLTagNameLowercaseRule()])
+    const linter = new Linter([HTMLTagNameLowercaseRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(0)
@@ -70,7 +70,7 @@ describe("html-tag-name-lowercase", () => {
   test.skip("handles ERB templates", () => {
     const html = '<div class="container"><%= content_tag(:DIV, "Hello world!") %></div>'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLTagNameLowercaseRule()])
+    const linter = new Linter([HTMLTagNameLowercaseRule])
     const lintResult = linter.lint(result.value)
 
     // Should only lint HTML tags, not Ruby code inside ERB
@@ -90,7 +90,7 @@ describe("html-tag-name-lowercase", () => {
       </article>
     `
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLTagNameLowercaseRule()])
+    const linter = new Linter([HTMLTagNameLowercaseRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(0)
@@ -109,7 +109,7 @@ describe("html-tag-name-lowercase", () => {
       </ARTICLE>
     `
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLTagNameLowercaseRule()])
+    const linter = new Linter([HTMLTagNameLowercaseRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(14)
@@ -124,7 +124,7 @@ describe("html-tag-name-lowercase", () => {
   test("handles empty tags", () => {
     const html = '<div></div>'
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLTagNameLowercaseRule()])
+    const linter = new Linter([HTMLTagNameLowercaseRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(0)
@@ -141,7 +141,7 @@ describe("html-tag-name-lowercase", () => {
       </div>
     `
     const result = Herb.parse(html)
-    const linter = new Linter([new HTMLTagNameLowercaseRule()])
+    const linter = new Linter([HTMLTagNameLowercaseRule])
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(0)


### PR DESCRIPTION
This pull request refactors the `Linter` class and all linting rules in the `@herb-tools/linter` package to simplify and improve their design. The changes focus on removing unnecessary code, introducing reusable utilities, and enhancing maintainability by adopting visitor-based patterns and removing direct dependencies on specific node types.