### PR TITLE
Integrate Herb Linter into playground

### DIFF
--- a/javascript/packages/linter/src/index.ts
+++ b/javascript/packages/linter/src/index.ts
@@ -1,4 +1,3 @@
 export * from "./linter.js"
 export * from "./rules/index.js"
 export * from "./types.js"
-export * from "./cli.js"

--- a/playground/index.html
+++ b/playground/index.html
@@ -99,10 +99,23 @@
               </div>
             </div>
 
-            <div
-              data-playground-target="position"
-              class="mt-2 font-mono whitespace-break-spaces text-right text-gray-400 text-[8pt]"
-            ></div>
+            <div class="mt-2 font-mono whitespace-break-spaces text-gray-400 text-[8pt] flex justify-between items-center">
+              <span data-playground-target="diagnosticStatus" class="hidden flex items-center gap-4">
+                <span class="flex items-center gap-1" title="Errors">
+                  <i class="fas fa-circle-xmark text-red-500 text-xs"></i>
+                  <span data-playground-target="errorCount">0</span>
+                </span>
+                <span class="flex items-center gap-1" title="Warnings">
+                  <i class="fas fa-triangle-exclamation text-yellow-500 text-xs"></i>
+                  <span data-playground-target="warningCount">0</span>
+                </span>
+                <span class="flex items-center gap-1" title="Info">
+                  <i class="fas fa-info-circle text-blue-500 text-xs"></i>
+                  <span data-playground-target="infoCount">0</span>
+                </span>
+              </span>
+              <div data-playground-target="position"></div>
+            </div>
 
             <div
               class="mt-2 outline outline-1 outline-gray-300 z-10 rounded-md overflow-hidden bg-gray-50 h-[30vh] md:h-[calc(100vh-110px)]"
@@ -197,7 +210,6 @@
               class="flex justify-between mt-2 font-mono whitespace-break-spaces text-gray-400 text-[8pt]"
             >
               <span data-playground-target="time"></span>
-
               <div data-playground-target="version" class=""></div>
             </div>
 

--- a/playground/package.json
+++ b/playground/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@alenaksu/json-viewer": "^2.0.1",
     "@herb-tools/browser": "0.3.1",
+    "@herb-tools/linter": "0.3.1",
     "@hotwired/stimulus": "^3.2.2",
     "dedent": "^1.6.0",
     "express": "^5.1.0",

--- a/playground/src/analyze.ts
+++ b/playground/src/analyze.ts
@@ -1,4 +1,6 @@
 import type { HerbBackend, ParseResult, LexResult } from "@herb-tools/core"
+import { Linter } from "@herb-tools/linter"
+import type { LintResult } from "@herb-tools/linter"
 
 async function safeExecute<T>(promise: Promise<T>): Promise<T> {
   try {
@@ -46,6 +48,16 @@ export async function analyze(herb: HerbBackend, source: string) {
     new Promise((resolve) => resolve(herb.version)),
   )
 
+  let lintResult: LintResult | null = null
+
+  if (parseResult && parseResult.value) {
+    const linter = new Linter()
+
+    lintResult = await safeExecute<LintResult>(
+      new Promise((resolve) => resolve(linter.lint(parseResult.value))),
+    )
+  }
+
   const endTime = performance.now()
 
   return {
@@ -57,6 +69,7 @@ export async function analyze(herb: HerbBackend, source: string) {
     ruby,
     html,
     version,
+    lintResult,
     duration: endTime - startTime,
   }
 }

--- a/playground/src/style.css
+++ b/playground/src/style.css
@@ -185,3 +185,36 @@ code.language-tree {
   border: 1px solid #ff9800;
   border-radius: 2px;
 }
+
+/* Tooltip styles */
+[title] {
+  position: relative;
+  cursor: help;
+}
+
+[title]:hover::after {
+  content: attr(title);
+  position: absolute;
+  bottom: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  background-color: #333;
+  color: white;
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 12px;
+  white-space: nowrap;
+  z-index: 1000;
+  margin-bottom: 5px;
+}
+
+[title]:hover::before {
+  content: '';
+  position: absolute;
+  bottom: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border: 5px solid transparent;
+  border-top-color: #333;
+  z-index: 1000;
+}


### PR DESCRIPTION
This pull request integrates the Herb Linter into the web-based playground, so you can inspect the linter rules.

It also adds a little section to show the number of error, warning, and info diagnostics on the top left:

![CleanShot 2025-07-01 at 02 31 19@2x](https://github.com/user-attachments/assets/5a8b2b21-b3ec-4ec1-a1be-b2a74deef137)
