### PR TITLE
Show total number of issues in Herb Lint CLI

### DIFF
--- a/javascript/packages/linter/src/cli.ts
+++ b/javascript/packages/linter/src/cli.ts
@@ -330,8 +330,10 @@ ${contextLines.trimEnd()}
       // Add total count and file count
       let detailText = ""
 
+      const totalIssues = totalErrors + totalWarnings
+
       if (filesWithIssues > 0) {
-        detailText = `across ${filesWithIssues} ${this.pluralize(filesWithIssues, "file")}`
+        detailText = `${totalIssues} ${this.pluralize(totalIssues, "issue")} across ${filesWithIssues} ${this.pluralize(filesWithIssues, "file")}`
       }
 
       issuesSummary += ` ${colorize(colorize(`(${detailText})`, "gray"), "dim")}`
@@ -365,13 +367,13 @@ ${contextLines.trimEnd()}
       await Herb.load()
 
       const pattern = this.getFilePattern(positionals)
-      
+
       // Validate that we have a proper file pattern
       if (positionals.length === 0) {
         console.error("Please specify input file.")
         process.exit(1)
       }
-      
+
       const files = await glob(pattern)
 
       if (files.length === 0) {

--- a/javascript/packages/linter/test/__snapshots__/cli.test.ts.snap
+++ b/javascript/packages/linter/test/__snapshots__/cli.test.ts.snap
@@ -42,7 +42,7 @@ test/fixtures/test-file-with-errors.html.erb:3:3
 
 
  Checked     1 file
- Issues      3 errors | 0 warnings (across 1 file)"
+ Issues      3 errors | 0 warnings (3 issues across 1 file)"
 `;
 
 exports[`CLI Output Formatting > formats simple output correctly 1`] = `
@@ -52,7 +52,7 @@ exports[`CLI Output Formatting > formats simple output correctly 1`] = `
 
 
  Checked     1 file
- Issues      2 errors | 0 warnings (across 1 file)"
+ Issues      2 errors | 0 warnings (2 issues across 1 file)"
 `;
 
 exports[`CLI Output Formatting > formats success output correctly 1`] = `
@@ -86,5 +86,5 @@ test/fixtures/bad-file.html.erb:1:16
 
 
  Checked     1 file
- Issues      2 errors | 0 warnings (across 1 file)"
+ Issues      2 errors | 0 warnings (2 issues across 1 file)"
 `;


### PR DESCRIPTION
This pull request shows the total number of issues (error count + warnings count) in the summary of the lint run.

```diff
  ❯ bin/herb-lint test/fixtures/

  [...]

  Checked     4 files
  Files       3 with issues | 1 clean (4 total)
- Issues      7 errors | 0 warnings (across 3 files)
+ Issues      7 errors | 0 warnings (7 issues across 3 files)
  Start at    03:45:41
  Duration    33ms (8 rules)
```