### PR TITLE
Rename to violations in Herb Lint CLI and show violated rule names

### DIFF
--- a/javascript/packages/linter/test/__snapshots__/cli.test.ts.snap
+++ b/javascript/packages/linter/test/__snapshots__/cli.test.ts.snap
@@ -1,5 +1,197 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`CLI Output Formatting > displays most violated rules with multiple violations 1`] = `
+"[error] Duplicate attribute \`class\` found on tag. Remove the duplicate occurrence. (html-no-duplicate-attributes)
+
+test/fixtures/multiple-rule-violations.html.erb:5:14
+
+      3 │ <div id=test1 class='' data-value=bar>
+      4 │   <img />
+  →   5 │   <a class="" class="">Link 1</a>
+        │               ~~~~~
+      6 │ </div>
+      7 │
+
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯  [1/7] ⎯⎯⎯⎯
+
+
+[error] Missing required \`alt\` attribute on \`<img>\` tag. Add \`alt=""\` for decorative images or \`alt="description"\` for informative images. (html-img-require-alt)
+
+test/fixtures/multiple-rule-violations.html.erb:4:3
+
+      2 │ 
+      3 │ <div id=test1 class='' data-value=bar>
+  →   4 │   <img />
+        │    ~~~
+      5 │   <a class="" class="">Link 1</a>
+      6 │ </div>
+
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯  [2/7] ⎯⎯⎯⎯
+
+
+[error] Attribute value should be quoted: \`id="value"\`. Always wrap attribute values in quotes. (html-attribute-values-require-quotes)
+
+test/fixtures/multiple-rule-violations.html.erb:3:8
+
+      1 │ <!-- Multiple violations of same rules to test "Most violated rules" display -->
+      2 │ 
+  →   3 │ <div id=test1 class='' data-value=bar>
+        │         ~~~~~
+      4 │   <img />
+      5 │   <a class="" class="">Link 1</a>
+
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯  [3/7] ⎯⎯⎯⎯
+
+
+[error] Attribute value should be quoted: \`data-value="value"\`. Always wrap attribute values in quotes. (html-attribute-values-require-quotes)
+
+test/fixtures/multiple-rule-violations.html.erb:3:34
+
+      1 │ <!-- Multiple violations of same rules to test "Most violated rules" display -->
+      2 │ 
+  →   3 │ <div id=test1 class='' data-value=bar>
+        │                                   ~~~
+      4 │   <img />
+      5 │   <a class="" class="">Link 1</a>
+
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯  [4/7] ⎯⎯⎯⎯
+
+
+[error] Nested \`<a>\` elements are not allowed. Links cannot contain other links. (html-no-nested-links)
+
+test/fixtures/multiple-rule-violations.html.erb:10:4
+
+      8 │ <h1></h1>
+      9 │ 
+  →  10 │ <a><a>Nested</a></a>
+        │     ~
+     11 │ 
+     12 │ <div id="duplicate"></div>
+
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯  [5/7] ⎯⎯⎯⎯
+
+
+[warning] Attribute \`class\` uses single quotes. Prefer double quotes for HTML attribute values: \`class="value"\`. (html-attribute-double-quotes)
+
+test/fixtures/multiple-rule-violations.html.erb:3:20
+
+      1 │ <!-- Multiple violations of same rules to test "Most violated rules" display -->
+      2 │ 
+  →   3 │ <div id=test1 class='' data-value=bar>
+        │                     ~~
+      4 │   <img />
+      5 │   <a class="" class="">Link 1</a>
+
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯  [6/7] ⎯⎯⎯⎯
+
+
+[error] Heading element \`<h1>\` must not be empty. Provide accessible text content for screen readers and SEO. (html-no-empty-headings)
+
+test/fixtures/multiple-rule-violations.html.erb:8:0
+
+      6 │ </div>
+      7 │ 
+  →   8 │ <h1></h1>
+        │ ~~~~~~~~~
+      9 │ 
+     10 │ <a><a>Nested</a></a>
+
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯  [7/7] ⎯⎯⎯⎯
+
+ Most violated rules:
+  html-attribute-values-require-quotes (2 violations in 1 file)
+  html-no-duplicate-attributes (1 violation in 1 file)
+  html-img-require-alt (1 violation in 1 file)
+  html-no-nested-links (1 violation in 1 file)
+  html-attribute-double-quotes (1 violation in 1 file)
+
+  ...and 1 more rule with 1 violation
+
+
+ Summary:
+  Checked      1 file
+  Violations   6 errors | 1 warning (7 violations across 1 file)"
+`;
+
+exports[`CLI Output Formatting > displays rule violations when showing all rules 1`] = `
+"[error] Missing required \`alt\` attribute on \`<img>\` tag. Add \`alt=""\` for decorative images or \`alt="description"\` for informative images. (html-img-require-alt)
+
+test/fixtures/few-rule-violations.html.erb:3:3
+
+      1 │ <!-- Just a few different rule violations to test "Rule violations:" vs "Most violated rules:" -->
+      2 │ <div id=test class=foo>
+  →   3 │   <img src=image.jpg>
+        │    ~~~
+      4 │ </div>
+      5 │
+
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯  [1/5] ⎯⎯⎯⎯
+
+
+[error] Attribute value should be quoted: \`id="value"\`. Always wrap attribute values in quotes. (html-attribute-values-require-quotes)
+
+test/fixtures/few-rule-violations.html.erb:2:8
+
+      1 │ <!-- Just a few different rule violations to test "Rule violations:" vs "Most violated rules:" -->
+  →   2 │ <div id=test class=foo>
+        │         ~~~~
+      3 │   <img src=image.jpg>
+      4 │ </div>
+
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯  [2/5] ⎯⎯⎯⎯
+
+
+[error] Attribute value should be quoted: \`class="value"\`. Always wrap attribute values in quotes. (html-attribute-values-require-quotes)
+
+test/fixtures/few-rule-violations.html.erb:2:19
+
+      1 │ <!-- Just a few different rule violations to test "Rule violations:" vs "Most violated rules:" -->
+  →   2 │ <div id=test class=foo>
+        │                    ~~~
+      3 │   <img src=image.jpg>
+      4 │ </div>
+
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯  [3/5] ⎯⎯⎯⎯
+
+
+[error] Attribute value should be quoted: \`src="value"\`. Always wrap attribute values in quotes. (html-attribute-values-require-quotes)
+
+test/fixtures/few-rule-violations.html.erb:3:11
+
+      1 │ <!-- Just a few different rule violations to test "Rule violations:" vs "Most violated rules:" -->
+      2 │ <div id=test class=foo>
+  →   3 │   <img src=image.jpg>
+        │            ~~~~~
+      4 │ </div>
+      5 │
+
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯  [4/5] ⎯⎯⎯⎯
+
+
+[error] Heading element \`<h1>\` must not be empty. Provide accessible text content for screen readers and SEO. (html-no-empty-headings)
+
+test/fixtures/few-rule-violations.html.erb:6:0
+
+      4 │ </div>
+      5 │ 
+  →   6 │ <h1></h1>
+        │ ~~~~~~~~~
+      7 │ 
+      8 │ <div id="duplicate"></div>
+
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯  [5/5] ⎯⎯⎯⎯
+
+ Rule violations:
+  html-attribute-values-require-quotes (3 violations in 1 file)
+  html-img-require-alt (1 violation in 1 file)
+  html-no-empty-headings (1 violation in 1 file)
+
+
+ Summary:
+  Checked      1 file
+  Violations   5 errors | 0 warnings (5 violations across 1 file)"
+`;
+
 exports[`CLI Output Formatting > formats detailed error output correctly 1`] = `
 "[error] Tag name \`SPAN\` should be lowercase. Use \`span\` instead. (html-tag-name-lowercase)
 
@@ -40,9 +232,14 @@ test/fixtures/test-file-with-errors.html.erb:3:3
 
 ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯  [3/3] ⎯⎯⎯⎯
 
+ Rule violations:
+  html-tag-name-lowercase (2 violations in 1 file)
+  html-img-require-alt (1 violation in 1 file)
 
- Checked     1 file
- Issues      3 errors | 0 warnings (3 issues across 1 file)"
+
+ Summary:
+  Checked      1 file
+  Violations   3 errors | 0 warnings (3 violations across 1 file)"
 `;
 
 exports[`CLI Output Formatting > formats simple output correctly 1`] = `
@@ -50,16 +247,22 @@ exports[`CLI Output Formatting > formats simple output correctly 1`] = `
   2:3  ✗ Tag name \`SPAN\` should be lowercase. Use \`span\` instead. (html-tag-name-lowercase)
   2:22 ✗ Tag name \`SPAN\` should be lowercase. Use \`span\` instead. (html-tag-name-lowercase)
 
+ Rule violations:
+  html-tag-name-lowercase (2 violations in 1 file)
 
- Checked     1 file
- Issues      2 errors | 0 warnings (2 issues across 1 file)"
+
+ Summary:
+  Checked      1 file
+  Violations   2 errors | 0 warnings (2 violations across 1 file)"
 `;
 
 exports[`CLI Output Formatting > formats success output correctly 1`] = `
 "✓ test/fixtures/clean-file.html.erb - No issues found
 
- Checked     1 file
- Issues      0 issues"
+
+ Summary:
+  Checked      1 file
+  Violations   0 violations"
 `;
 
 exports[`CLI Output Formatting > handles multiple errors correctly 1`] = `
@@ -84,7 +287,11 @@ test/fixtures/bad-file.html.erb:1:16
 
 ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯  [2/2] ⎯⎯⎯⎯
 
+ Rule violations:
+  html-tag-name-lowercase (2 violations in 1 file)
 
- Checked     1 file
- Issues      2 errors | 0 warnings (2 issues across 1 file)"
+
+ Summary:
+  Checked      1 file
+  Violations   2 errors | 0 warnings (2 violations across 1 file)"
 `;

--- a/javascript/packages/linter/test/cli.test.ts
+++ b/javascript/packages/linter/test/cli.test.ts
@@ -49,4 +49,18 @@ describe("CLI Output Formatting", () => {
     expect(output).toMatchSnapshot()
     expect(exitCode).toBe(1)
   })
+
+  test("displays most violated rules with multiple violations", () => {
+    const { output, exitCode } = runLinter("multiple-rule-violations.html.erb")
+
+    expect(output).toMatchSnapshot()
+    expect(exitCode).toBe(1)
+  })
+
+  test("displays rule violations when showing all rules", () => {
+    const { output, exitCode } = runLinter("few-rule-violations.html.erb")
+
+    expect(output).toMatchSnapshot()
+    expect(exitCode).toBe(1)
+  })
 })

--- a/javascript/packages/linter/test/fixtures/few-rule-violations.html.erb
+++ b/javascript/packages/linter/test/fixtures/few-rule-violations.html.erb
@@ -1,0 +1,9 @@
+<!-- Just a few different rule violations to test "Rule violations:" vs "Most violated rules:" -->
+<div id=test class=foo>
+  <img src=image.jpg>
+</div>
+
+<h1></h1>
+
+<div id="duplicate"></div>
+<div id="duplicate"></div>

--- a/javascript/packages/linter/test/fixtures/multiple-rule-violations.html.erb
+++ b/javascript/packages/linter/test/fixtures/multiple-rule-violations.html.erb
@@ -1,0 +1,12 @@
+<!-- Multiple violations of same rules to test "Most violated rules" display -->
+
+<div id=test1 class='' data-value=bar>
+  <img />
+  <a class="" class="">Link 1</a>
+</div>
+
+<h1></h1>
+
+<a><a>Nested</a></a>
+
+<div id="duplicate"></div>


### PR DESCRIPTION
This pull request renames "Issues" to "Violations" in the Herb Lint CLI. It now also lists the rule names of the violated rules. If there are more than 5 violated rules it will show the "Most violated rules" including a summary of how many more there were:

Rule violations:

![CleanShot 2025-07-01 at 11 32 40@2x](https://github.com/user-attachments/assets/52513e56-6cac-423f-b90d-c5b252dc6330)


Most violated rules:

![CleanShot 2025-07-01 at 11 31 39@2x](https://github.com/user-attachments/assets/59fd36e8-e82e-4549-b4b4-93913004a48d)
