### PR TITLE
Add `ERBNode` type and identification utilities

### DIFF
--- a/templates/javascript/packages/core/src/nodes.ts.erb
+++ b/templates/javascript/packages/core/src/nodes.ts.erb
@@ -21,11 +21,6 @@ export interface BaseNodeProps {
   errors: HerbError[]
 }
 
-export type NodeType =
-  <%- nodes.each_with_index.map do |node, index| -%>
-  | "<%= node.type %>"
-  <%- end -%>
-
 export abstract class Node implements BaseNodeProps {
   readonly type: NodeType
   readonly location: Location
@@ -348,8 +343,26 @@ export function fromSerializedNode(node: SerializedNode): Node {
   }
 }
 
+export type NodeType =
+  <%- nodes.each_with_index.map do |node, index| -%>
+  | "<%= node.type %>"
+  <%- end -%>
+
+export type ERBNodeType = Extract<NodeType, `AST_ERB_${string}`>;
+
 export type ERBNode =
   <%- nodes.each_with_index.map do |node, index| -%>
     <%- next unless node.name.start_with?("ERB") -%>
   | <%= node.name %>
   <%- end -%>
+
+export const ERBNodeClasses = [
+  <%- nodes.each_with_index.map do |node, index| -%>
+  <%- next unless node.name.start_with?("ERB") -%>
+  <%= node.name %>,
+  <%- end -%>
+]
+
+export function isERBNode(node: Node): node is ERBNode {
+  return ERBNodeClasses.some(NodeClass => node instanceof NodeClass);
+}


### PR DESCRIPTION
This pull request adds a `ERBNode` TypeScript type and introduces new types and utility functions to help identify and  reference to any ERB node in the AST.

- `ERBNodeType` subset of existing `NodeType`
- `ERBNodeClasses` array of all ERB AST Node classes
- `isERBNode(node: Node)` helper function to identify an ERB Node which also helps with type narrowing