### PR TITLE
Rename `LintMessage` type to `LintOffense`

### DIFF
--- a/javascript/packages/linter/generators/linter-rule/generators/app/templates/rule.ts.ejs
+++ b/javascript/packages/linter/generators/linter-rule/generators/app/templates/rule.ts.ejs
@@ -1,6 +1,6 @@
 import { BaseRuleVisitor } from "./rule-utils.js"
 
-import type { Rule, LintMessage } from "../types.js"
+import type { Rule, LintOffense } from "../types.js"
 import type { Node, HTMLElementNode, ERBContentNode } from "@herb-tools/core"
 
 class <%= visitorClassName %> extends BaseRuleVisitor {
@@ -20,7 +20,7 @@ class <%= visitorClassName %> extends BaseRuleVisitor {
 export class <%= ruleClassName %> implements Rule {
   name = "<%= ruleName %>"
 
-  check(node: Node): LintMessage[] {
+  check(node: Node): LintOffense[] {
     const visitor = new <%= visitorClassName %>(this.name)
 
     visitor.visit(node)

--- a/javascript/packages/linter/src/linter.ts
+++ b/javascript/packages/linter/src/linter.ts
@@ -1,10 +1,10 @@
 import { defaultRules } from "./default-rules.js"
-import type { RuleClass, LintResult, LintMessage } from "./types.js"
+import type { RuleClass, LintResult, LintOffense } from "./types.js"
 import type { DocumentNode } from "@herb-tools/core"
 
 export class Linter {
   private rules: RuleClass[]
-  private messages: LintMessage[]
+  private messages: LintOffense[]
 
   /**
    * Creates a new Linter instance.

--- a/javascript/packages/linter/src/rules/erb-no-empty-tags.ts
+++ b/javascript/packages/linter/src/rules/erb-no-empty-tags.ts
@@ -1,6 +1,6 @@
 import { BaseRuleVisitor } from "./rule-utils.js"
 
-import type { Rule, LintMessage } from "../types.js"
+import type { Rule, LintOffense } from "../types.js"
 import type { Node, ERBContentNode } from "@herb-tools/core"
 
 class ERBNoEmptyTagsVisitor extends BaseRuleVisitor {
@@ -21,7 +21,7 @@ class ERBNoEmptyTagsVisitor extends BaseRuleVisitor {
 export class ERBNoEmptyTagsRule implements Rule {
   name = "erb-no-empty-tags"
 
-  check(node: Node): LintMessage[] {
+  check(node: Node): LintOffense[] {
     const visitor = new ERBNoEmptyTagsVisitor(this.name)
 
     visitor.visit(node)

--- a/javascript/packages/linter/src/rules/erb-no-output-control-flow.ts
+++ b/javascript/packages/linter/src/rules/erb-no-output-control-flow.ts
@@ -1,6 +1,6 @@
 import { Visitor } from "@herb-tools/core"
 import type { Node, ERBIfNode, ERBUnlessNode, ERBElseNode, ERBEndNode } from "@herb-tools/core"
-import type { Rule, LintMessage } from "../types.js"
+import type { Rule, LintOffense } from "../types.js"
 import { BaseRuleVisitor } from "./rule-utils.js"
 
 
@@ -48,7 +48,7 @@ class NoOutputControlFlow extends BaseRuleVisitor {
 
 export class ERBNoOutputControlFlow implements Rule {
   name = "erb-no-output-control-flow"
-  check(node: Node): LintMessage[] {
+  check(node: Node): LintOffense[] {
     const visitor = new NoOutputControlFlow(this.name)
     visitor.visit(node)
     return visitor.messages

--- a/javascript/packages/linter/src/rules/html-anchor-require-href.ts
+++ b/javascript/packages/linter/src/rules/html-anchor-require-href.ts
@@ -1,6 +1,6 @@
 import { BaseRuleVisitor, getTagName, hasAttribute } from "./rule-utils.js"
 
-import { Rule, LintMessage } from "../types.js"
+import { Rule, LintOffense } from "../types.js"
 import type { HTMLOpenTagNode, Node } from "@herb-tools/core"
 
 class AnchorRechireHrefVisitor extends BaseRuleVisitor {
@@ -29,7 +29,7 @@ class AnchorRechireHrefVisitor extends BaseRuleVisitor {
 export class HTMLAnchorRequireHrefRule implements Rule {
   name = "html-anchor-require-href"
 
-  check(node: Node): LintMessage[] {
+  check(node: Node): LintOffense[] {
     const visitor = new AnchorRechireHrefVisitor(this.name)
 
     visitor.visit(node)

--- a/javascript/packages/linter/src/rules/html-attribute-double-quotes.ts
+++ b/javascript/packages/linter/src/rules/html-attribute-double-quotes.ts
@@ -1,6 +1,6 @@
 import { AttributeVisitorMixin, getAttributeValueQuoteType, hasAttributeValue } from "./rule-utils.js"
 
-import type { Rule, LintMessage } from "../types.js"
+import type { Rule, LintOffense } from "../types.js"
 import type { Node, HTMLAttributeNode } from "@herb-tools/core"
 
 class AttributeDoubleQuotesVisitor extends AttributeVisitorMixin {
@@ -20,7 +20,7 @@ class AttributeDoubleQuotesVisitor extends AttributeVisitorMixin {
 export class HTMLAttributeDoubleQuotesRule implements Rule {
   name = "html-attribute-double-quotes"
 
-  check(node: Node): LintMessage[] {
+  check(node: Node): LintOffense[] {
     const visitor = new AttributeDoubleQuotesVisitor(this.name)
     visitor.visit(node)
     return visitor.messages

--- a/javascript/packages/linter/src/rules/html-attribute-values-require-quotes.ts
+++ b/javascript/packages/linter/src/rules/html-attribute-values-require-quotes.ts
@@ -1,6 +1,6 @@
 import { AttributeVisitorMixin } from "./rule-utils.js"
 
-import type { Rule, LintMessage } from "../types.js"
+import type { Rule, LintOffense } from "../types.js"
 import type { HTMLAttributeNode, HTMLAttributeValueNode, Node } from "@herb-tools/core"
 
 class AttributeValuesRequireQuotesVisitor extends AttributeVisitorMixin {
@@ -21,7 +21,7 @@ class AttributeValuesRequireQuotesVisitor extends AttributeVisitorMixin {
 export class HTMLAttributeValuesRequireQuotesRule implements Rule {
   name = "html-attribute-values-require-quotes"
 
-  check(node: Node): LintMessage[] {
+  check(node: Node): LintOffense[] {
     const visitor = new AttributeValuesRequireQuotesVisitor(this.name)
     visitor.visit(node)
     return visitor.messages

--- a/javascript/packages/linter/src/rules/html-boolean-attributes-no-value.ts
+++ b/javascript/packages/linter/src/rules/html-boolean-attributes-no-value.ts
@@ -1,6 +1,6 @@
 import { AttributeVisitorMixin, isBooleanAttribute, hasAttributeValue } from "./rule-utils.js"
 
-import type { Rule, LintMessage } from "../types.js"
+import type { Rule, LintOffense } from "../types.js"
 import type { HTMLAttributeNode, Node } from "@herb-tools/core"
 
 class BooleanAttributesNoValueVisitor extends AttributeVisitorMixin {
@@ -19,7 +19,7 @@ class BooleanAttributesNoValueVisitor extends AttributeVisitorMixin {
 export class HTMLBooleanAttributesNoValueRule implements Rule {
   name = "html-boolean-attributes-no-value"
 
-  check(node: Node): LintMessage[] {
+  check(node: Node): LintOffense[] {
     const visitor = new BooleanAttributesNoValueVisitor(this.name)
     visitor.visit(node)
     return visitor.messages

--- a/javascript/packages/linter/src/rules/html-img-require-alt.ts
+++ b/javascript/packages/linter/src/rules/html-img-require-alt.ts
@@ -1,6 +1,6 @@
 import { BaseRuleVisitor, getTagName, hasAttribute } from "./rule-utils.js"
 
-import type { Rule, LintMessage } from "../types.js"
+import type { Rule, LintOffense } from "../types.js"
 import type { HTMLOpenTagNode, HTMLSelfCloseTagNode, Node } from "@herb-tools/core"
 
 class ImgRequireAltVisitor extends BaseRuleVisitor {
@@ -34,7 +34,7 @@ class ImgRequireAltVisitor extends BaseRuleVisitor {
 export class HTMLImgRequireAltRule implements Rule {
   name = "html-img-require-alt"
 
-  check(node: Node): LintMessage[] {
+  check(node: Node): LintOffense[] {
     const visitor = new ImgRequireAltVisitor(this.name)
     visitor.visit(node)
     return visitor.messages

--- a/javascript/packages/linter/src/rules/html-no-block-inside-inline.ts
+++ b/javascript/packages/linter/src/rules/html-no-block-inside-inline.ts
@@ -1,6 +1,6 @@
 import { BaseRuleVisitor, isInlineElement, isBlockElement } from "./rule-utils.js"
 
-import type { Rule, LintMessage } from "../types.js"
+import type { Rule, LintOffense } from "../types.js"
 import type { HTMLOpenTagNode, HTMLElementNode, Node } from "@herb-tools/core"
 
 class BlockInsideInlineVisitor extends BaseRuleVisitor {
@@ -76,7 +76,7 @@ class BlockInsideInlineVisitor extends BaseRuleVisitor {
 export class HTMLNoBlockInsideInlineRule implements Rule {
   name = "html-no-block-inside-inline"
 
-  check(node: Node): LintMessage[] {
+  check(node: Node): LintOffense[] {
     const visitor = new BlockInsideInlineVisitor(this.name)
     visitor.visit(node)
     return visitor.messages

--- a/javascript/packages/linter/src/rules/html-no-duplicate-attributes.ts
+++ b/javascript/packages/linter/src/rules/html-no-duplicate-attributes.ts
@@ -1,6 +1,6 @@
 import { BaseRuleVisitor, forEachAttribute } from "./rule-utils.js"
 
-import type { Rule, LintMessage } from "../types.js"
+import type { Rule, LintOffense } from "../types.js"
 import type { HTMLOpenTagNode, HTMLSelfCloseTagNode, HTMLAttributeNameNode, Node } from "@herb-tools/core"
 
 class NoDuplicateAttributesVisitor extends BaseRuleVisitor {
@@ -51,7 +51,7 @@ class NoDuplicateAttributesVisitor extends BaseRuleVisitor {
 export class HTMLNoDuplicateAttributesRule implements Rule {
   name = "html-no-duplicate-attributes"
 
-  check(node: Node): LintMessage[] {
+  check(node: Node): LintOffense[] {
     const visitor = new NoDuplicateAttributesVisitor(this.name)
     visitor.visit(node)
     return visitor.messages

--- a/javascript/packages/linter/src/rules/html-no-empty-headings.ts
+++ b/javascript/packages/linter/src/rules/html-no-empty-headings.ts
@@ -1,6 +1,6 @@
 import { BaseRuleVisitor, getTagName, getAttributes, findAttributeByName, getAttributeValue, HEADING_TAGS } from "./rule-utils.js"
 
-import type { Rule, LintMessage } from "../types.js"
+import type { Rule, LintOffense } from "../types.js"
 import type { HTMLElementNode, HTMLOpenTagNode, HTMLSelfCloseTagNode, Node, LiteralNode, HTMLTextNode } from "@herb-tools/core"
 
 class NoEmptyHeadingsVisitor extends BaseRuleVisitor {
@@ -177,7 +177,7 @@ class NoEmptyHeadingsVisitor extends BaseRuleVisitor {
 export class HTMLNoEmptyHeadingsRule implements Rule {
   name = "html-no-empty-headings"
 
-  check(node: Node): LintMessage[] {
+  check(node: Node): LintOffense[] {
     const visitor = new NoEmptyHeadingsVisitor(this.name)
     visitor.visit(node)
     return visitor.messages

--- a/javascript/packages/linter/src/rules/html-no-nested-links.ts
+++ b/javascript/packages/linter/src/rules/html-no-nested-links.ts
@@ -1,6 +1,6 @@
 import { BaseRuleVisitor, getTagName } from "./rule-utils.js"
 
-import type { Rule, LintMessage } from "../types.js"
+import type { Rule, LintOffense } from "../types.js"
 import type { HTMLOpenTagNode, HTMLElementNode, Node } from "@herb-tools/core"
 
 class NestedLinkVisitor extends BaseRuleVisitor {
@@ -57,7 +57,7 @@ class NestedLinkVisitor extends BaseRuleVisitor {
 export class HTMLNoNestedLinksRule implements Rule {
   name = "html-no-nested-links"
 
-  check(node: Node): LintMessage[] {
+  check(node: Node): LintOffense[] {
     const visitor = new NestedLinkVisitor(this.name)
     visitor.visit(node)
     return visitor.messages

--- a/javascript/packages/linter/src/rules/html-tag-name-lowercase.ts
+++ b/javascript/packages/linter/src/rules/html-tag-name-lowercase.ts
@@ -1,6 +1,6 @@
 import { BaseRuleVisitor } from "./rule-utils.js"
 
-import type { Rule, LintMessage } from "../types.js"
+import type { Rule, LintOffense } from "../types.js"
 import type { HTMLOpenTagNode, HTMLCloseTagNode, HTMLSelfCloseTagNode, Node } from "@herb-tools/core"
 
 class TagNameLowercaseVisitor extends BaseRuleVisitor {
@@ -36,7 +36,7 @@ class TagNameLowercaseVisitor extends BaseRuleVisitor {
 export class HTMLTagNameLowercaseRule implements Rule {
   name = "html-tag-name-lowercase"
 
-  check(node: Node): LintMessage[] {
+  check(node: Node): LintOffense[] {
     const visitor = new TagNameLowercaseVisitor(this.name)
     visitor.visit(node)
     return visitor.messages

--- a/javascript/packages/linter/src/rules/rule-utils.ts
+++ b/javascript/packages/linter/src/rules/rule-utils.ts
@@ -9,13 +9,13 @@ import {
   Location
 } from "@herb-tools/core"
 
-import type { LintMessage } from "../types.js"
+import type { LintOffense } from "../types.js"
 
 /**
  * Base visitor class that provides common functionality for rule visitors
  */
 export abstract class BaseRuleVisitor extends Visitor {
-  public messages: LintMessage[] = []
+  public messages: LintOffense[] = []
   protected ruleName: string
 
   constructor(ruleName: string) {
@@ -27,7 +27,7 @@ export abstract class BaseRuleVisitor extends Visitor {
   /**
    * Helper method to create a lint message
    */
-  protected createMessage(message: string, location: Location, severity: "error" | "warning" = "error"): LintMessage {
+  protected createMessage(message: string, location: Location, severity: "error" | "warning" = "error"): LintOffense {
     return {
       rule: this.ruleName,
       message,

--- a/javascript/packages/linter/src/types.ts
+++ b/javascript/packages/linter/src/types.ts
@@ -1,6 +1,6 @@
 import { Location, Node } from "@herb-tools/core"
 
-export interface LintMessage {
+export interface LintOffense {
   rule: string
   message: string
   location: Location
@@ -8,14 +8,14 @@ export interface LintMessage {
 }
 
 export interface LintResult {
-  messages: LintMessage[]
+  messages: LintOffense[]
   errors: number
   warnings: number
 }
 
 export interface Rule {
   name: string
-  check(node: Node): LintMessage[]
+  check(node: Node): LintOffense[]
 }
 
 /**


### PR DESCRIPTION
This pull request renames the `LintMessage` type to `LintOffense` and applies the change across all relevant files. This is mostly for establishing a more commonly known and referred to term. It also prepares it so we could implement #226.