### PR TITLE
Rename `message` to `offense` in Linter

### DIFF
--- a/javascript/packages/linter/src/cli.ts
+++ b/javascript/packages/linter/src/cli.ts
@@ -216,13 +216,13 @@ ${contextLines.trimEnd()}
         ruleCount = linter.getRuleCount()
       }
 
-      if (lintResult.messages.length === 0) {
+      if (lintResult.offenses.length === 0) {
         if (files.length === 1) {
           console.log(`${colorize("✓", "brightGreen")} ${colorize(filename, "cyan")} - ${colorize("No issues found", "green")}`)
         }
       } else {
         // Collect messages for later display
-        for (const message of lintResult.messages) {
+        for (const message of lintResult.offenses) {
           allMessages.push({ filename, message, content })
 
           const ruleData = ruleViolations.get(message.rule) || { count: 0, files: new Set() }
@@ -233,7 +233,7 @@ ${contextLines.trimEnd()}
 
         if (this.formatOption === 'simple') {
           console.log("")
-          this.displaySimpleFormat(filename, lintResult.messages)
+          this.displaySimpleFormat(filename, lintResult.offenses)
         }
 
         totalErrors += lintResult.errors
@@ -245,10 +245,10 @@ ${contextLines.trimEnd()}
     return { totalErrors, totalWarnings, filesWithIssues, ruleCount, allMessages, ruleViolations }
   }
 
-  private displaySimpleFormat(filename: string, messages: any[]): void {
+  private displaySimpleFormat(filename: string, offenses: any[]): void {
     console.log(`${colorize(filename, "cyan")}:`)
 
-    for (const message of messages) {
+    for (const message of offenses) {
       const isError = message.severity === "error"
       const severity = isError ? colorize("✗", "brightRed") : colorize("⚠", "brightYellow")
       const rule = colorize(`(${message.rule})`, "blue")

--- a/javascript/packages/linter/src/linter.ts
+++ b/javascript/packages/linter/src/linter.ts
@@ -1,10 +1,11 @@
 import { defaultRules } from "./default-rules.js"
+
 import type { RuleClass, LintResult, LintOffense } from "./types.js"
 import type { DocumentNode } from "@herb-tools/core"
 
 export class Linter {
   private rules: RuleClass[]
-  private messages: LintOffense[]
+  private offenses: LintOffense[]
 
   /**
    * Creates a new Linter instance.
@@ -12,7 +13,7 @@ export class Linter {
    */
   constructor(rules?: RuleClass[]) {
     this.rules = rules !== undefined ? rules : this.getDefaultRules()
-    this.messages = []
+    this.offenses = []
   }
 
   /**
@@ -28,20 +29,20 @@ export class Linter {
   }
 
   lint(document: DocumentNode): LintResult {
-    this.messages = []
+    this.offenses = []
 
     for (const Rule of this.rules) {
       const rule = new Rule()
-      const ruleMessages = rule.check(document)
+      const ruleOffenses = rule.check(document)
 
-      this.messages.push(...ruleMessages)
+      this.offenses.push(...ruleOffenses)
     }
 
-    const errors = this.messages.filter(message => message.severity === "error").length
-    const warnings = this.messages.filter(message => message.severity === "warning").length
+    const errors = this.offenses.filter(offense => offense.severity === "error").length
+    const warnings = this.offenses.filter(offense => offense.severity === "warning").length
 
     return {
-      messages: this.messages,
+      offenses: this.offenses,
       errors,
       warnings
     }

--- a/javascript/packages/linter/src/rules/erb-no-empty-tags.ts
+++ b/javascript/packages/linter/src/rules/erb-no-empty-tags.ts
@@ -10,7 +10,7 @@ class ERBNoEmptyTagsVisitor extends BaseRuleVisitor {
     if (!node.content) return
     if (node.content.value.trim().length > 0) return
 
-    this.addMessage(
+    this.addOffense(
       "ERB tag should not be empty. Remove empty ERB tags or add content.",
       node.location,
       "error"
@@ -26,6 +26,6 @@ export class ERBNoEmptyTagsRule implements Rule {
 
     visitor.visit(node)
 
-    return visitor.messages
+    return visitor.offenses
   }
 }

--- a/javascript/packages/linter/src/rules/erb-no-output-control-flow.ts
+++ b/javascript/packages/linter/src/rules/erb-no-output-control-flow.ts
@@ -1,16 +1,14 @@
-import { Visitor } from "@herb-tools/core"
-import type { Node, ERBIfNode, ERBUnlessNode, ERBElseNode, ERBEndNode } from "@herb-tools/core"
-import type { Rule, LintOffense } from "../types.js"
 import { BaseRuleVisitor } from "./rule-utils.js"
 
+import type { Node, ERBIfNode, ERBUnlessNode, ERBElseNode, ERBEndNode } from "@herb-tools/core"
+import type { Rule, LintOffense } from "../types.js"
 
 class NoOutputControlFlow extends BaseRuleVisitor {
-  
   visitERBIfNode(node: ERBIfNode): void {
     this.checkOutputControlFlow(node)
     this.visitChildNodes(node)
   }
-    
+
   visitERBUnlessNode(node: ERBUnlessNode): void {
     this.checkOutputControlFlow(node)
     this.visitChildNodes(node)
@@ -25,22 +23,22 @@ class NoOutputControlFlow extends BaseRuleVisitor {
     this.checkOutputControlFlow(node)
     this.visitChildNodes(node)
   }
-  
 
   private checkOutputControlFlow(controlBlock: ERBIfNode | ERBUnlessNode | ERBElseNode | ERBEndNode): void {
     const openTag = controlBlock.tag_opening;
     if (!openTag) {
       return
     }
+
     if (openTag.value === "<%="){
-      this.messages.push({
-        rule: this.ruleName,
-        message: `Control flow statements like \`${controlBlock.type}\` 
+      this.addOffense(
+        `Control flow statements like \`${controlBlock.type}\`
         should not be used with output tags. Use \`<% ${controlBlock.type} ... %>\` instead.`,
-        location: openTag.location,
-        severity: "error"
-      })
+        openTag.location,
+        "error"
+      )
     }
+
     return
   }
 
@@ -51,6 +49,6 @@ export class ERBNoOutputControlFlow implements Rule {
   check(node: Node): LintOffense[] {
     const visitor = new NoOutputControlFlow(this.name)
     visitor.visit(node)
-    return visitor.messages
+    return visitor.offenses
   }
 }

--- a/javascript/packages/linter/src/rules/html-anchor-require-href.ts
+++ b/javascript/packages/linter/src/rules/html-anchor-require-href.ts
@@ -17,7 +17,7 @@ class AnchorRechireHrefVisitor extends BaseRuleVisitor {
     }
 
     if (!hasAttribute(node, "href")) {
-      this.addMessage(
+      this.addOffense(
         "Add an `href` attribute to `<a>` to ensure it is focusable and accessible.",
         node.tag_name!.location,
         "error",
@@ -34,6 +34,6 @@ export class HTMLAnchorRequireHrefRule implements Rule {
 
     visitor.visit(node)
 
-    return visitor.messages
+    return visitor.offenses
   }
 }

--- a/javascript/packages/linter/src/rules/html-attribute-double-quotes.ts
+++ b/javascript/packages/linter/src/rules/html-attribute-double-quotes.ts
@@ -9,7 +9,7 @@ class AttributeDoubleQuotesVisitor extends AttributeVisitorMixin {
     if (getAttributeValueQuoteType(attributeNode) !== "single") return
     if (attributeValue?.includes('"')) return // Single quotes acceptable when value contains double quotes
 
-    this.addMessage(
+    this.addOffense(
       `Attribute \`${attributeName}\` uses single quotes. Prefer double quotes for HTML attribute values: \`${attributeName}="value"\`.`,
       attributeNode.value!.location,
       "warning"
@@ -23,6 +23,6 @@ export class HTMLAttributeDoubleQuotesRule implements Rule {
   check(node: Node): LintOffense[] {
     const visitor = new AttributeDoubleQuotesVisitor(this.name)
     visitor.visit(node)
-    return visitor.messages
+    return visitor.offenses
   }
 }

--- a/javascript/packages/linter/src/rules/html-attribute-values-require-quotes.ts
+++ b/javascript/packages/linter/src/rules/html-attribute-values-require-quotes.ts
@@ -10,7 +10,7 @@ class AttributeValuesRequireQuotesVisitor extends AttributeVisitorMixin {
     const valueNode = attributeNode.value as HTMLAttributeValueNode
     if (valueNode.quoted) return
 
-    this.addMessage(
+    this.addOffense(
       `Attribute value should be quoted: \`${attributeName}="value"\`. Always wrap attribute values in quotes.`,
       valueNode.location,
       "error"
@@ -24,6 +24,6 @@ export class HTMLAttributeValuesRequireQuotesRule implements Rule {
   check(node: Node): LintOffense[] {
     const visitor = new AttributeValuesRequireQuotesVisitor(this.name)
     visitor.visit(node)
-    return visitor.messages
+    return visitor.offenses
   }
 }

--- a/javascript/packages/linter/src/rules/html-boolean-attributes-no-value.ts
+++ b/javascript/packages/linter/src/rules/html-boolean-attributes-no-value.ts
@@ -8,7 +8,7 @@ class BooleanAttributesNoValueVisitor extends AttributeVisitorMixin {
     if (!isBooleanAttribute(attributeName)) return
     if (!hasAttributeValue(attributeNode)) return
 
-    this.addMessage(
+    this.addOffense(
       `Boolean attribute \`${attributeName}\` should not have a value. Use \`${attributeName}\` instead of \`${attributeName}="${attributeName}"\`.`,
       attributeNode.value!.location,
       "error"
@@ -22,6 +22,6 @@ export class HTMLBooleanAttributesNoValueRule implements Rule {
   check(node: Node): LintOffense[] {
     const visitor = new BooleanAttributesNoValueVisitor(this.name)
     visitor.visit(node)
-    return visitor.messages
+    return visitor.offenses
   }
 }

--- a/javascript/packages/linter/src/rules/html-img-require-alt.ts
+++ b/javascript/packages/linter/src/rules/html-img-require-alt.ts
@@ -22,7 +22,7 @@ class ImgRequireAltVisitor extends BaseRuleVisitor {
     }
 
     if (!hasAttribute(node, "alt")) {
-      this.addMessage(
+      this.addOffense(
         'Missing required `alt` attribute on `<img>` tag. Add `alt=""` for decorative images or `alt="description"` for informative images.',
         node.tag_name!.location,
         "error"
@@ -37,6 +37,6 @@ export class HTMLImgRequireAltRule implements Rule {
   check(node: Node): LintOffense[] {
     const visitor = new ImgRequireAltVisitor(this.name)
     visitor.visit(node)
-    return visitor.messages
+    return visitor.offenses
   }
 }

--- a/javascript/packages/linter/src/rules/html-no-block-inside-inline.ts
+++ b/javascript/packages/linter/src/rules/html-no-block-inside-inline.ts
@@ -22,7 +22,7 @@ class BlockInsideInlineVisitor extends BaseRuleVisitor {
     const parentInline = this.inlineStack[this.inlineStack.length - 1]
     const elementType = isBlock ? "Block-level" : "Unknown"
 
-    this.addMessage(
+    this.addOffense(
       `${elementType} element \`<${tagName}>\` cannot be placed inside inline element \`<${parentInline}>\`.`,
       openTag.tag_name!.location,
       "error"
@@ -79,6 +79,6 @@ export class HTMLNoBlockInsideInlineRule implements Rule {
   check(node: Node): LintOffense[] {
     const visitor = new BlockInsideInlineVisitor(this.name)
     visitor.visit(node)
-    return visitor.messages
+    return visitor.offenses
   }
 }

--- a/javascript/packages/linter/src/rules/html-no-duplicate-attributes.ts
+++ b/javascript/packages/linter/src/rules/html-no-duplicate-attributes.ts
@@ -37,7 +37,7 @@ class NoDuplicateAttributesVisitor extends BaseRuleVisitor {
         for (let i = 1; i < nameNodes.length; i++) {
           const nameNode = nameNodes[i]
 
-          this.addMessage(
+          this.addOffense(
             `Duplicate attribute \`${attributeName}\` found on tag. Remove the duplicate occurrence.`,
             nameNode.location,
             "error"
@@ -54,6 +54,6 @@ export class HTMLNoDuplicateAttributesRule implements Rule {
   check(node: Node): LintOffense[] {
     const visitor = new NoDuplicateAttributesVisitor(this.name)
     visitor.visit(node)
-    return visitor.messages
+    return visitor.offenses
   }
 }

--- a/javascript/packages/linter/src/rules/html-no-empty-headings.ts
+++ b/javascript/packages/linter/src/rules/html-no-empty-headings.ts
@@ -38,7 +38,7 @@ class NoEmptyHeadingsVisitor extends BaseRuleVisitor {
         ? `\`<${tagName}>\``
         : `\`<${tagName} role="heading">\``
 
-      this.addMessage(
+      this.addOffense(
         `Heading element ${elementDescription} must not be empty. Provide accessible text content for screen readers and SEO.`,
         node.location,
         "error"
@@ -65,7 +65,7 @@ class NoEmptyHeadingsVisitor extends BaseRuleVisitor {
       ? `\`<${tagName}>\``
       : `\`<${tagName} role="heading">\``
 
-    this.addMessage(
+    this.addOffense(
       `Heading element ${elementDescription} must not be empty. Provide accessible text content for screen readers and SEO.`,
       node.tag_name!.location,
       "error"
@@ -180,6 +180,6 @@ export class HTMLNoEmptyHeadingsRule implements Rule {
   check(node: Node): LintOffense[] {
     const visitor = new NoEmptyHeadingsVisitor(this.name)
     visitor.visit(node)
-    return visitor.messages
+    return visitor.offenses
   }
 }

--- a/javascript/packages/linter/src/rules/html-no-nested-links.ts
+++ b/javascript/packages/linter/src/rules/html-no-nested-links.ts
@@ -8,7 +8,7 @@ class NestedLinkVisitor extends BaseRuleVisitor {
 
   private checkNestedLink(openTag: HTMLOpenTagNode): boolean {
     if (this.linkStack.length > 0) {
-      this.addMessage(
+      this.addOffense(
         "Nested `<a>` elements are not allowed. Links cannot contain other links.",
         openTag.tag_name!.location,
         "error"
@@ -60,6 +60,6 @@ export class HTMLNoNestedLinksRule implements Rule {
   check(node: Node): LintOffense[] {
     const visitor = new NestedLinkVisitor(this.name)
     visitor.visit(node)
-    return visitor.messages
+    return visitor.offenses
   }
 }

--- a/javascript/packages/linter/src/rules/html-tag-name-lowercase.ts
+++ b/javascript/packages/linter/src/rules/html-tag-name-lowercase.ts
@@ -24,7 +24,7 @@ class TagNameLowercaseVisitor extends BaseRuleVisitor {
     if (!tagName) return
 
     if (tagName !== tagName.toLowerCase()) {
-      this.addMessage(
+      this.addOffense(
         `Tag name \`${tagName}\` should be lowercase. Use \`${tagName.toLowerCase()}\` instead.`,
         node.tag_name!.location,
         "error"
@@ -39,6 +39,6 @@ export class HTMLTagNameLowercaseRule implements Rule {
   check(node: Node): LintOffense[] {
     const visitor = new TagNameLowercaseVisitor(this.name)
     visitor.visit(node)
-    return visitor.messages
+    return visitor.offenses
   }
 }

--- a/javascript/packages/linter/src/rules/rule-utils.ts
+++ b/javascript/packages/linter/src/rules/rule-utils.ts
@@ -15,7 +15,7 @@ import type { LintOffense } from "../types.js"
  * Base visitor class that provides common functionality for rule visitors
  */
 export abstract class BaseRuleVisitor extends Visitor {
-  public messages: LintOffense[] = []
+  public offenses: LintOffense[] = []
   protected ruleName: string
 
   constructor(ruleName: string) {
@@ -25,9 +25,9 @@ export abstract class BaseRuleVisitor extends Visitor {
   }
 
   /**
-   * Helper method to create a lint message
+   * Helper method to create a lint offense
    */
-  protected createMessage(message: string, location: Location, severity: "error" | "warning" = "error"): LintOffense {
+  protected createOffense(message: string, location: Location, severity: "error" | "warning" = "error"): LintOffense {
     return {
       rule: this.ruleName,
       message,
@@ -37,10 +37,10 @@ export abstract class BaseRuleVisitor extends Visitor {
   }
 
   /**
-   * Helper method to add a message to the messages array
+   * Helper method to add an offense to the offenses array
    */
-  protected addMessage(message: string, location: Location, severity: "error" | "warning" = "error"): void {
-    this.messages.push(this.createMessage(message, location, severity))
+  protected addOffense(message: string, location: Location, severity: "error" | "warning" = "error"): void {
+    this.offenses.push(this.createOffense(message, location, severity))
   }
 }
 

--- a/javascript/packages/linter/src/types.ts
+++ b/javascript/packages/linter/src/types.ts
@@ -8,7 +8,7 @@ export interface LintOffense {
 }
 
 export interface LintResult {
-  messages: LintOffense[]
+  offenses: LintOffense[]
   errors: number
   warnings: number
 }

--- a/javascript/packages/linter/test/linter.test.ts
+++ b/javascript/packages/linter/test/linter.test.ts
@@ -31,10 +31,10 @@ describe("@herb-tools/linter", () => {
       const linter = new Linter()
       const lintResult = linter.lint(result.value)
 
-      expect(lintResult).toHaveProperty('messages')
+      expect(lintResult).toHaveProperty('offenses')
       expect(lintResult).toHaveProperty('errors')
       expect(lintResult).toHaveProperty('warnings')
-      expect(Array.isArray(lintResult.messages)).toBe(true)
+      expect(Array.isArray(lintResult.offenses)).toBe(true)
     })
 
     test("returns correct error and warning counts", () => {
@@ -45,9 +45,9 @@ describe("@herb-tools/linter", () => {
 
       expect(lintResult.errors).toBe(4)
       expect(lintResult.warnings).toBe(0)
-      expect(lintResult.messages).toHaveLength(4)
+      expect(lintResult.offenses).toHaveLength(4)
 
-      const allErrors = lintResult.messages.every(message => message.severity === "error")
+      const allErrors = lintResult.offenses.every(offense => offense.severity === "error")
       expect(allErrors).toBe(true)
     })
 
@@ -59,7 +59,7 @@ describe("@herb-tools/linter", () => {
 
       expect(lintResult.errors).toBe(0)
       expect(lintResult.warnings).toBe(0)
-      expect(lintResult.messages).toHaveLength(0)
+      expect(lintResult.offenses).toHaveLength(0)
     })
 
     test("processes complex ERB templates", () => {

--- a/javascript/packages/linter/test/rules/erb-no-empty-tags.test.ts
+++ b/javascript/packages/linter/test/rules/erb-no-empty-tags.test.ts
@@ -34,7 +34,7 @@ describe("ERBNoEmptyTagsRule", () => {
 
     expect(lintResult.errors).toBe(0)
     expect(lintResult.warnings).toBe(0)
-    expect(lintResult.messages).toHaveLength(0)
+    expect(lintResult.offenses).toHaveLength(0)
   })
 
   test("should report errors for completely empty ERB tags", () => {
@@ -50,9 +50,9 @@ describe("ERBNoEmptyTagsRule", () => {
 
     expect(lintResult.errors).toBe(2)
     expect(lintResult.warnings).toBe(0)
-    expect(lintResult.messages).toHaveLength(2)
-    expect(lintResult.messages[0].message).toBe("ERB tag should not be empty. Remove empty ERB tags or add content.")
-    expect(lintResult.messages[1].message).toBe("ERB tag should not be empty. Remove empty ERB tags or add content.")
+    expect(lintResult.offenses).toHaveLength(2)
+    expect(lintResult.offenses[0].message).toBe("ERB tag should not be empty. Remove empty ERB tags or add content.")
+    expect(lintResult.offenses[1].message).toBe("ERB tag should not be empty. Remove empty ERB tags or add content.")
   })
 
   test("should report errors for whitespace-only ERB tags", () => {
@@ -70,8 +70,8 @@ describe("ERBNoEmptyTagsRule", () => {
 
     expect(lintResult.errors).toBe(3)
     expect(lintResult.warnings).toBe(0)
-    expect(lintResult.messages).toHaveLength(3)
-    lintResult.messages.forEach(message => {
+    expect(lintResult.offenses).toHaveLength(3)
+    lintResult.offenses.forEach(message => {
       expect(message.message).toBe("ERB tag should not be empty. Remove empty ERB tags or add content.")
     })
   })
@@ -92,7 +92,7 @@ describe("ERBNoEmptyTagsRule", () => {
 
     expect(lintResult.errors).toBe(0)
     expect(lintResult.warnings).toBe(0)
-    expect(lintResult.messages).toHaveLength(0)
+    expect(lintResult.offenses).toHaveLength(0)
   })
 
   test("should handle mixed valid and invalid ERB tags", () => {
@@ -111,9 +111,9 @@ describe("ERBNoEmptyTagsRule", () => {
 
     expect(lintResult.errors).toBe(2)
     expect(lintResult.warnings).toBe(0)
-    expect(lintResult.messages).toHaveLength(2)
+    expect(lintResult.offenses).toHaveLength(2)
 
-    lintResult.messages.forEach(message => {
+    lintResult.offenses.forEach(message => {
       expect(message.message).toBe("ERB tag should not be empty. Remove empty ERB tags or add content.")
     })
   })
@@ -126,8 +126,8 @@ describe("ERBNoEmptyTagsRule", () => {
 
     expect(lintResult.errors).toBe(1)
     expect(lintResult.warnings).toBe(0)
-    expect(lintResult.messages).toHaveLength(1)
-    expect(lintResult.messages[0].message).toBe("ERB tag should not be empty. Remove empty ERB tags or add content.")
+    expect(lintResult.offenses).toHaveLength(1)
+    expect(lintResult.offenses[0].message).toBe("ERB tag should not be empty. Remove empty ERB tags or add content.")
   })
 
   test("should handle empty ERB tag in open tag", () => {
@@ -138,7 +138,7 @@ describe("ERBNoEmptyTagsRule", () => {
 
     expect(lintResult.errors).toBe(1)
     expect(lintResult.warnings).toBe(0)
-    expect(lintResult.messages).toHaveLength(1)
-    expect(lintResult.messages[0].message).toBe("ERB tag should not be empty. Remove empty ERB tags or add content.")
+    expect(lintResult.offenses).toHaveLength(1)
+    expect(lintResult.offenses[0].message).toBe("ERB tag should not be empty. Remove empty ERB tags or add content.")
   })
 })

--- a/javascript/packages/linter/test/rules/erb-no-output-control-flow.test.ts
+++ b/javascript/packages/linter/test/rules/erb-no-output-control-flow.test.ts
@@ -25,7 +25,7 @@ describe("erb-no-output-control-flow", () => {
     const lintResult = linter.lint(result.value)
     expect(lintResult.errors).toBe(0)
     expect(lintResult.warnings).toBe(0)
-    expect(lintResult.messages).toHaveLength(0)
+    expect(lintResult.offenses).toHaveLength(0)
   })
 
   it("should not allow if statments with output tags", () => {
@@ -40,7 +40,7 @@ describe("erb-no-output-control-flow", () => {
 
     expect(lintResult.errors).toBe(1)
     expect(lintResult.warnings).toBe(0)
-    expect(lintResult.messages).toHaveLength(1)
+    expect(lintResult.offenses).toHaveLength(1)
   })
   
   it("should not allow unless statements with output tags", () => {
@@ -55,7 +55,7 @@ describe("erb-no-output-control-flow", () => {
 
     expect(lintResult.errors).toBe(1)
     expect(lintResult.warnings).toBe(0)
-    expect(lintResult.messages).toHaveLength(1)
+    expect(lintResult.offenses).toHaveLength(1)
   })
 
   it("should not allow end statements with output tags", () => {
@@ -70,7 +70,7 @@ describe("erb-no-output-control-flow", () => {
 
     expect(lintResult.errors).toBe(1)
     expect(lintResult.warnings).toBe(0)
-    expect(lintResult.messages).toHaveLength(1)
+    expect(lintResult.offenses).toHaveLength(1)
   })
 
   it("should not allow nested control flow blocks with output tags", () => {
@@ -88,7 +88,7 @@ describe("erb-no-output-control-flow", () => {
 
     expect(lintResult.errors).toBe(1) 
     expect(lintResult.warnings).toBe(0)
-    expect(lintResult.messages).toHaveLength(1)
+    expect(lintResult.offenses).toHaveLength(1)
   })
 
   it('should show multiple errors for multiple output tags', () => {
@@ -107,7 +107,7 @@ describe("erb-no-output-control-flow", () => {
 
     expect(lintResult.errors).toBe(3) 
     expect(lintResult.warnings).toBe(0)
-    expect(lintResult.messages).toHaveLength(3)
+    expect(lintResult.offenses).toHaveLength(3)
   })
 
   it("should show an error for outputting control flow blocks with nested control flow blocks", () => {
@@ -124,6 +124,6 @@ describe("erb-no-output-control-flow", () => {
 
     expect(lintResult.errors).toBe(1) 
     expect(lintResult.warnings).toBe(0)
-    expect(lintResult.messages).toHaveLength(1)
+    expect(lintResult.offenses).toHaveLength(1)
   })
 })

--- a/javascript/packages/linter/test/rules/html-anchor-require-href-rule.test.ts
+++ b/javascript/packages/linter/test/rules/html-anchor-require-href-rule.test.ts
@@ -16,7 +16,7 @@ describe("html-anchor-require-href", () => {
 
     expect(lintResult.errors).toBe(0)
     expect(lintResult.warnings).toBe(0)
-    expect(lintResult.messages).toHaveLength(0)
+    expect(lintResult.offenses).toHaveLength(0)
   })
 
   test("fails for a without href attribute", () => {
@@ -27,13 +27,13 @@ describe("html-anchor-require-href", () => {
 
     expect(lintResult.errors).toBe(1)
     expect(lintResult.warnings).toBe(0)
-    expect(lintResult.messages).toHaveLength(1)
+    expect(lintResult.offenses).toHaveLength(1)
 
-    expect(lintResult.messages[0].rule).toBe("html-anchor-require-href")
-    expect(lintResult.messages[0].message).toBe(
+    expect(lintResult.offenses[0].rule).toBe("html-anchor-require-href")
+    expect(lintResult.offenses[0].message).toBe(
       "Add an `href` attribute to `<a>` to ensure it is focusable and accessible.",
     )
-    expect(lintResult.messages[0].severity).toBe("error")
+    expect(lintResult.offenses[0].severity).toBe("error")
   })
 
   test("fails for multiple a tags without href", () => {
@@ -44,7 +44,7 @@ describe("html-anchor-require-href", () => {
 
     expect(lintResult.errors).toBe(2)
     expect(lintResult.warnings).toBe(0)
-    expect(lintResult.messages).toHaveLength(2)
+    expect(lintResult.offenses).toHaveLength(2)
   })
 
   test("passes for img with ERB alt attribute", () => {
@@ -74,7 +74,7 @@ describe("html-anchor-require-href", () => {
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(1)
-    expect(lintResult.messages[0].message).toBe(
+    expect(lintResult.offenses[0].message).toBe(
       "Add an `href` attribute to `<a>` to ensure it is focusable and accessible.",
     )
   })

--- a/javascript/packages/linter/test/rules/html-attribute-double-quotes.test.ts
+++ b/javascript/packages/linter/test/rules/html-attribute-double-quotes.test.ts
@@ -16,7 +16,7 @@ describe("html-attribute-double-quotes", () => {
 
     expect(lintResult.errors).toBe(0)
     expect(lintResult.warnings).toBe(0)
-    expect(lintResult.messages).toHaveLength(0)
+    expect(lintResult.offenses).toHaveLength(0)
   })
 
   test("fails for single quoted attributes", () => {
@@ -27,15 +27,15 @@ describe("html-attribute-double-quotes", () => {
 
     expect(lintResult.errors).toBe(0)
     expect(lintResult.warnings).toBe(2)
-    expect(lintResult.messages).toHaveLength(2)
+    expect(lintResult.offenses).toHaveLength(2)
 
-    expect(lintResult.messages[0].rule).toBe("html-attribute-double-quotes")
-    expect(lintResult.messages[0].message).toBe('Attribute `type` uses single quotes. Prefer double quotes for HTML attribute values: `type="value"`.')
-    expect(lintResult.messages[0].severity).toBe("warning")
+    expect(lintResult.offenses[0].rule).toBe("html-attribute-double-quotes")
+    expect(lintResult.offenses[0].message).toBe('Attribute `type` uses single quotes. Prefer double quotes for HTML attribute values: `type="value"`.')
+    expect(lintResult.offenses[0].severity).toBe("warning")
 
-    expect(lintResult.messages[1].rule).toBe("html-attribute-double-quotes")
-    expect(lintResult.messages[1].message).toBe('Attribute `value` uses single quotes. Prefer double quotes for HTML attribute values: `value="value"`.')
-    expect(lintResult.messages[1].severity).toBe("warning")
+    expect(lintResult.offenses[1].rule).toBe("html-attribute-double-quotes")
+    expect(lintResult.offenses[1].message).toBe('Attribute `value` uses single quotes. Prefer double quotes for HTML attribute values: `value="value"`.')
+    expect(lintResult.offenses[1].severity).toBe("warning")
   })
 
   test("passes for mixed content with double quotes", () => {
@@ -56,9 +56,9 @@ describe("html-attribute-double-quotes", () => {
 
     expect(lintResult.errors).toBe(0)
     expect(lintResult.warnings).toBe(3)
-    expect(lintResult.messages[0].message).toBe('Attribute `href` uses single quotes. Prefer double quotes for HTML attribute values: `href="value"`.')
-    expect(lintResult.messages[1].message).toBe('Attribute `title` uses single quotes. Prefer double quotes for HTML attribute values: `title="value"`.')
-    expect(lintResult.messages[2].message).toBe('Attribute `data-controller` uses single quotes. Prefer double quotes for HTML attribute values: `data-controller="value"`.')
+    expect(lintResult.offenses[0].message).toBe('Attribute `href` uses single quotes. Prefer double quotes for HTML attribute values: `href="value"`.')
+    expect(lintResult.offenses[1].message).toBe('Attribute `title` uses single quotes. Prefer double quotes for HTML attribute values: `title="value"`.')
+    expect(lintResult.offenses[2].message).toBe('Attribute `data-controller` uses single quotes. Prefer double quotes for HTML attribute values: `data-controller="value"`.')
   })
 
   test("passes for unquoted attributes (handled by other rule)", () => {
@@ -89,8 +89,8 @@ describe("html-attribute-double-quotes", () => {
 
     expect(lintResult.errors).toBe(0)
     expect(lintResult.warnings).toBe(2)
-    expect(lintResult.messages[0].message).toBe('Attribute `src` uses single quotes. Prefer double quotes for HTML attribute values: `src="value"`.')
-    expect(lintResult.messages[1].message).toBe('Attribute `alt` uses single quotes. Prefer double quotes for HTML attribute values: `alt="value"`.')
+    expect(lintResult.offenses[0].message).toBe('Attribute `src` uses single quotes. Prefer double quotes for HTML attribute values: `src="value"`.')
+    expect(lintResult.offenses[1].message).toBe('Attribute `alt` uses single quotes. Prefer double quotes for HTML attribute values: `alt="value"`.')
   })
 
   test("handles ERB with single quoted attributes", () => {
@@ -101,8 +101,8 @@ describe("html-attribute-double-quotes", () => {
 
     expect(lintResult.errors).toBe(0)
     expect(lintResult.warnings).toBe(2)
-    expect(lintResult.messages[0].message).toBe('Attribute `data-controller` uses single quotes. Prefer double quotes for HTML attribute values: `data-controller="value"`.')
-    expect(lintResult.messages[1].message).toBe('Attribute `data-action` uses single quotes. Prefer double quotes for HTML attribute values: `data-action="value"`.')
+    expect(lintResult.offenses[0].message).toBe('Attribute `data-controller` uses single quotes. Prefer double quotes for HTML attribute values: `data-controller="value"`.')
+    expect(lintResult.offenses[1].message).toBe('Attribute `data-action` uses single quotes. Prefer double quotes for HTML attribute values: `data-action="value"`.')
   })
 
   test("allows single quotes when value contains double quotes", () => {
@@ -113,7 +113,7 @@ describe("html-attribute-double-quotes", () => {
 
     expect(lintResult.errors).toBe(0)
     expect(lintResult.warnings).toBe(0)
-    expect(lintResult.messages).toHaveLength(0)
+    expect(lintResult.offenses).toHaveLength(0)
   })
 
   test("still fails for single quotes when value has no double quotes", () => {
@@ -124,7 +124,7 @@ describe("html-attribute-double-quotes", () => {
 
     expect(lintResult.errors).toBe(0)
     expect(lintResult.warnings).toBe(2)
-    expect(lintResult.messages[0].message).toBe('Attribute `id` uses single quotes. Prefer double quotes for HTML attribute values: `id="value"`.')
-    expect(lintResult.messages[1].message).toBe('Attribute `class` uses single quotes. Prefer double quotes for HTML attribute values: `class="value"`.')
+    expect(lintResult.offenses[0].message).toBe('Attribute `id` uses single quotes. Prefer double quotes for HTML attribute values: `id="value"`.')
+    expect(lintResult.offenses[1].message).toBe('Attribute `class` uses single quotes. Prefer double quotes for HTML attribute values: `class="value"`.')
   })
 })

--- a/javascript/packages/linter/test/rules/html-attribute-values-require-quotes.test.ts
+++ b/javascript/packages/linter/test/rules/html-attribute-values-require-quotes.test.ts
@@ -16,7 +16,7 @@ describe("html-attribute-values-require-quotes", () => {
 
     expect(lintResult.errors).toBe(0)
     expect(lintResult.warnings).toBe(0)
-    expect(lintResult.messages).toHaveLength(0)
+    expect(lintResult.offenses).toHaveLength(0)
   })
 
   test("fails for unquoted attribute values", () => {
@@ -27,11 +27,11 @@ describe("html-attribute-values-require-quotes", () => {
 
     expect(lintResult.errors).toBe(2) // Both id and class are unquoted
     expect(lintResult.warnings).toBe(0)
-    expect(lintResult.messages).toHaveLength(2)
+    expect(lintResult.offenses).toHaveLength(2)
 
-    expect(lintResult.messages[0].rule).toBe("html-attribute-values-require-quotes")
-    expect(lintResult.messages[0].message).toBe('Attribute value should be quoted: `id="value"`. Always wrap attribute values in quotes.')
-    expect(lintResult.messages[0].severity).toBe("error")
+    expect(lintResult.offenses[0].rule).toBe("html-attribute-values-require-quotes")
+    expect(lintResult.offenses[0].message).toBe('Attribute value should be quoted: `id="value"`. Always wrap attribute values in quotes.')
+    expect(lintResult.offenses[0].severity).toBe("error")
   })
 
   test("passes for single-quoted values", () => {
@@ -61,7 +61,7 @@ describe("html-attribute-values-require-quotes", () => {
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(1) // Only name is unquoted
-    expect(lintResult.messages[0].message).toBe('Attribute value should be quoted: `name="value"`. Always wrap attribute values in quotes.')
+    expect(lintResult.offenses[0].message).toBe('Attribute value should be quoted: `name="value"`. Always wrap attribute values in quotes.')
   })
 
   test("handles ERB in quoted attributes", () => {
@@ -81,7 +81,7 @@ describe("html-attribute-values-require-quotes", () => {
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(1)
-    expect(lintResult.messages[0].message).toBe('Attribute value should be quoted: `src="value"`. Always wrap attribute values in quotes.')
+    expect(lintResult.offenses[0].message).toBe('Attribute value should be quoted: `src="value"`. Always wrap attribute values in quotes.')
   })
 
   test("handles complex attribute values", () => {
@@ -91,7 +91,7 @@ describe("html-attribute-values-require-quotes", () => {
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(1)
-    expect(lintResult.messages[0].message).toBe('Attribute value should be quoted: `title="value"`. Always wrap attribute values in quotes.')
+    expect(lintResult.offenses[0].message).toBe('Attribute value should be quoted: `title="value"`. Always wrap attribute values in quotes.')
   })
 
   test("ignores closing tags", () => {

--- a/javascript/packages/linter/test/rules/html-boolean-attributes-no-value.test.ts
+++ b/javascript/packages/linter/test/rules/html-boolean-attributes-no-value.test.ts
@@ -16,7 +16,7 @@ describe("html-boolean-attributes-no-value", () => {
 
     expect(lintResult.errors).toBe(0)
     expect(lintResult.warnings).toBe(0)
-    expect(lintResult.messages).toHaveLength(0)
+    expect(lintResult.offenses).toHaveLength(0)
   })
 
   test("fails for boolean attributes with explicit values", () => {
@@ -27,15 +27,15 @@ describe("html-boolean-attributes-no-value", () => {
 
     expect(lintResult.errors).toBe(2)
     expect(lintResult.warnings).toBe(0)
-    expect(lintResult.messages).toHaveLength(2)
+    expect(lintResult.offenses).toHaveLength(2)
 
-    expect(lintResult.messages[0].rule).toBe("html-boolean-attributes-no-value")
-    expect(lintResult.messages[0].message).toBe('Boolean attribute `checked` should not have a value. Use `checked` instead of `checked="checked"`.')
-    expect(lintResult.messages[0].severity).toBe("error")
+    expect(lintResult.offenses[0].rule).toBe("html-boolean-attributes-no-value")
+    expect(lintResult.offenses[0].message).toBe('Boolean attribute `checked` should not have a value. Use `checked` instead of `checked="checked"`.')
+    expect(lintResult.offenses[0].severity).toBe("error")
 
-    expect(lintResult.messages[1].rule).toBe("html-boolean-attributes-no-value")
-    expect(lintResult.messages[1].message).toBe('Boolean attribute `disabled` should not have a value. Use `disabled` instead of `disabled="disabled"`.')
-    expect(lintResult.messages[1].severity).toBe("error")
+    expect(lintResult.offenses[1].rule).toBe("html-boolean-attributes-no-value")
+    expect(lintResult.offenses[1].message).toBe('Boolean attribute `disabled` should not have a value. Use `disabled` instead of `disabled="disabled"`.')
+    expect(lintResult.offenses[1].severity).toBe("error")
   })
 
   test("fails for boolean attributes with true/false values", () => {
@@ -45,7 +45,7 @@ describe("html-boolean-attributes-no-value", () => {
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(1)
-    expect(lintResult.messages[0].message).toBe('Boolean attribute `disabled` should not have a value. Use `disabled` instead of `disabled="disabled"`.')
+    expect(lintResult.offenses[0].message).toBe('Boolean attribute `disabled` should not have a value. Use `disabled` instead of `disabled="disabled"`.')
   })
 
   test("passes for non-boolean attributes with values", () => {
@@ -65,8 +65,8 @@ describe("html-boolean-attributes-no-value", () => {
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(2)
-    expect(lintResult.messages[0].message).toBe('Boolean attribute `multiple` should not have a value. Use `multiple` instead of `multiple="multiple"`.')
-    expect(lintResult.messages[1].message).toBe('Boolean attribute `selected` should not have a value. Use `selected` instead of `selected="selected"`.')
+    expect(lintResult.offenses[0].message).toBe('Boolean attribute `multiple` should not have a value. Use `multiple` instead of `multiple="multiple"`.')
+    expect(lintResult.offenses[1].message).toBe('Boolean attribute `selected` should not have a value. Use `selected` instead of `selected="selected"`.')
   })
 
   test("handles self-closing tags with boolean attributes", () => {
@@ -76,8 +76,8 @@ describe("html-boolean-attributes-no-value", () => {
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(2)
-    expect(lintResult.messages[0].message).toBe('Boolean attribute `checked` should not have a value. Use `checked` instead of `checked="checked"`.')
-    expect(lintResult.messages[1].message).toBe('Boolean attribute `required` should not have a value. Use `required` instead of `required="required"`.')
+    expect(lintResult.offenses[0].message).toBe('Boolean attribute `checked` should not have a value. Use `checked` instead of `checked="checked"`.')
+    expect(lintResult.offenses[1].message).toBe('Boolean attribute `required` should not have a value. Use `required` instead of `required="required"`.')
   })
 
   test("handles case insensitive boolean attributes", () => {
@@ -87,8 +87,8 @@ describe("html-boolean-attributes-no-value", () => {
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(2)
-    expect(lintResult.messages[0].message).toBe('Boolean attribute `checked` should not have a value. Use `checked` instead of `checked="checked"`.')
-    expect(lintResult.messages[1].message).toBe('Boolean attribute `disabled` should not have a value. Use `disabled` instead of `disabled="disabled"`.')
+    expect(lintResult.offenses[0].message).toBe('Boolean attribute `checked` should not have a value. Use `checked` instead of `checked="checked"`.')
+    expect(lintResult.offenses[1].message).toBe('Boolean attribute `disabled` should not have a value. Use `disabled` instead of `disabled="disabled"`.')
   })
 
   test("passes for video controls", () => {
@@ -108,8 +108,8 @@ describe("html-boolean-attributes-no-value", () => {
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(2)
-    expect(lintResult.messages[0].message).toBe('Boolean attribute `controls` should not have a value. Use `controls` instead of `controls="controls"`.')
-    expect(lintResult.messages[1].message).toBe('Boolean attribute `autoplay` should not have a value. Use `autoplay` instead of `autoplay="autoplay"`.')
+    expect(lintResult.offenses[0].message).toBe('Boolean attribute `controls` should not have a value. Use `controls` instead of `controls="controls"`.')
+    expect(lintResult.offenses[1].message).toBe('Boolean attribute `autoplay` should not have a value. Use `autoplay` instead of `autoplay="autoplay"`.')
   })
 
   test("fails for boolean attribute with different value", () => {
@@ -119,7 +119,7 @@ describe("html-boolean-attributes-no-value", () => {
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(1)
-    expect(lintResult.messages[0].message).toBe('Boolean attribute `controls` should not have a value. Use `controls` instead of `controls="controls"`.')
+    expect(lintResult.offenses[0].message).toBe('Boolean attribute `controls` should not have a value. Use `controls` instead of `controls="controls"`.')
   })
 
   test("handles mixed boolean and regular attributes", () => {
@@ -129,6 +129,6 @@ describe("html-boolean-attributes-no-value", () => {
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(1)
-    expect(lintResult.messages[0].message).toBe('Boolean attribute `novalidate` should not have a value. Use `novalidate` instead of `novalidate="novalidate"`.')
+    expect(lintResult.offenses[0].message).toBe('Boolean attribute `novalidate` should not have a value. Use `novalidate` instead of `novalidate="novalidate"`.')
   })
 })

--- a/javascript/packages/linter/test/rules/html-img-require-alt.test.ts
+++ b/javascript/packages/linter/test/rules/html-img-require-alt.test.ts
@@ -16,7 +16,7 @@ describe("html-img-require-alt", () => {
 
     expect(lintResult.errors).toBe(0)
     expect(lintResult.warnings).toBe(0)
-    expect(lintResult.messages).toHaveLength(0)
+    expect(lintResult.offenses).toHaveLength(0)
   })
 
   test("passes for img with empty alt attribute", () => {
@@ -27,7 +27,7 @@ describe("html-img-require-alt", () => {
 
     expect(lintResult.errors).toBe(0)
     expect(lintResult.warnings).toBe(0)
-    expect(lintResult.messages).toHaveLength(0)
+    expect(lintResult.offenses).toHaveLength(0)
   })
 
   test("fails for img without alt attribute", () => {
@@ -38,11 +38,11 @@ describe("html-img-require-alt", () => {
 
     expect(lintResult.errors).toBe(1)
     expect(lintResult.warnings).toBe(0)
-    expect(lintResult.messages).toHaveLength(1)
+    expect(lintResult.offenses).toHaveLength(1)
 
-    expect(lintResult.messages[0].rule).toBe("html-img-require-alt")
-    expect(lintResult.messages[0].message).toBe('Missing required `alt` attribute on `<img>` tag. Add `alt=""` for decorative images or `alt="description"` for informative images.')
-    expect(lintResult.messages[0].severity).toBe("error")
+    expect(lintResult.offenses[0].rule).toBe("html-img-require-alt")
+    expect(lintResult.offenses[0].message).toBe('Missing required `alt` attribute on `<img>` tag. Add `alt=""` for decorative images or `alt="description"` for informative images.')
+    expect(lintResult.offenses[0].severity).toBe("error")
   })
 
   test("fails for multiple img tags without alt", () => {
@@ -53,7 +53,7 @@ describe("html-img-require-alt", () => {
 
     expect(lintResult.errors).toBe(2)
     expect(lintResult.warnings).toBe(0)
-    expect(lintResult.messages).toHaveLength(2)
+    expect(lintResult.offenses).toHaveLength(2)
   })
 
   test("handles mixed case img tags", () => {
@@ -63,7 +63,7 @@ describe("html-img-require-alt", () => {
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(1)
-    expect(lintResult.messages[0].message).toBe('Missing required `alt` attribute on `<img>` tag. Add `alt=""` for decorative images or `alt="description"` for informative images.')
+    expect(lintResult.offenses[0].message).toBe('Missing required `alt` attribute on `<img>` tag. Add `alt=""` for decorative images or `alt="description"` for informative images.')
   })
 
   test("passes for img with ERB alt attribute", () => {
@@ -93,7 +93,7 @@ describe("html-img-require-alt", () => {
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(1)
-    expect(lintResult.messages[0].message).toBe('Missing required `alt` attribute on `<img>` tag. Add `alt=""` for decorative images or `alt="description"` for informative images.')
+    expect(lintResult.offenses[0].message).toBe('Missing required `alt` attribute on `<img>` tag. Add `alt=""` for decorative images or `alt="description"` for informative images.')
   })
 
   test("passes for case-insensitive alt attribute", () => {

--- a/javascript/packages/linter/test/rules/html-no-block-inside-inline.test.ts
+++ b/javascript/packages/linter/test/rules/html-no-block-inside-inline.test.ts
@@ -16,7 +16,7 @@ describe("html-no-block-inside-inline", () => {
 
     expect(lintResult.errors).toBe(0)
     expect(lintResult.warnings).toBe(0)
-    expect(lintResult.messages).toHaveLength(0)
+    expect(lintResult.offenses).toHaveLength(0)
   })
 
   test("passes for block elements containing block elements", () => {
@@ -27,7 +27,7 @@ describe("html-no-block-inside-inline", () => {
 
     expect(lintResult.errors).toBe(0)
     expect(lintResult.warnings).toBe(0)
-    expect(lintResult.messages).toHaveLength(0)
+    expect(lintResult.offenses).toHaveLength(0)
   })
 
   test("fails for div inside span", () => {
@@ -38,11 +38,11 @@ describe("html-no-block-inside-inline", () => {
 
     expect(lintResult.errors).toBe(1)
     expect(lintResult.warnings).toBe(0)
-    expect(lintResult.messages).toHaveLength(1)
+    expect(lintResult.offenses).toHaveLength(1)
 
-    expect(lintResult.messages[0].rule).toBe("html-no-block-inside-inline")
-    expect(lintResult.messages[0].message).toBe('Block-level element `<div>` cannot be placed inside inline element `<span>`.')
-    expect(lintResult.messages[0].severity).toBe("error")
+    expect(lintResult.offenses[0].rule).toBe("html-no-block-inside-inline")
+    expect(lintResult.offenses[0].message).toBe('Block-level element `<div>` cannot be placed inside inline element `<span>`.')
+    expect(lintResult.offenses[0].severity).toBe("error")
   })
 
   test("fails for paragraph inside span", () => {
@@ -53,9 +53,9 @@ describe("html-no-block-inside-inline", () => {
 
     expect(lintResult.errors).toBe(1)
     expect(lintResult.warnings).toBe(0)
-    expect(lintResult.messages).toHaveLength(1)
+    expect(lintResult.offenses).toHaveLength(1)
 
-    expect(lintResult.messages[0].message).toBe('Block-level element `<p>` cannot be placed inside inline element `<span>`.')
+    expect(lintResult.offenses[0].message).toBe('Block-level element `<p>` cannot be placed inside inline element `<span>`.')
   })
 
   test("fails for multiple block elements inside inline", () => {
@@ -66,7 +66,7 @@ describe("html-no-block-inside-inline", () => {
 
     expect(lintResult.errors).toBe(2)
     expect(lintResult.warnings).toBe(0)
-    expect(lintResult.messages).toHaveLength(2)
+    expect(lintResult.offenses).toHaveLength(2)
   })
 
   test("fails for block inside anchor tag", () => {
@@ -76,7 +76,7 @@ describe("html-no-block-inside-inline", () => {
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(1)
-    expect(lintResult.messages[0].message).toBe('Block-level element `<div>` cannot be placed inside inline element `<a>`.')
+    expect(lintResult.offenses[0].message).toBe('Block-level element `<div>` cannot be placed inside inline element `<a>`.')
   })
 
   test("fails for heading inside strong", () => {
@@ -86,7 +86,7 @@ describe("html-no-block-inside-inline", () => {
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(1)
-    expect(lintResult.messages[0].message).toBe('Block-level element `<h1>` cannot be placed inside inline element `<strong>`.')
+    expect(lintResult.offenses[0].message).toBe('Block-level element `<h1>` cannot be placed inside inline element `<strong>`.')
   })
 
   test("fails for section inside em", () => {
@@ -96,7 +96,7 @@ describe("html-no-block-inside-inline", () => {
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(1)
-    expect(lintResult.messages[0].message).toBe('Block-level element `<section>` cannot be placed inside inline element `<em>`.')
+    expect(lintResult.offenses[0].message).toBe('Block-level element `<section>` cannot be placed inside inline element `<em>`.')
   })
 
   test("passes for nested inline elements", () => {
@@ -116,7 +116,7 @@ describe("html-no-block-inside-inline", () => {
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(1)
-    expect(lintResult.messages[0].message).toBe('Block-level element `<div>` cannot be placed inside inline element `<strong>`.')
+    expect(lintResult.offenses[0].message).toBe('Block-level element `<div>` cannot be placed inside inline element `<strong>`.')
   })
 
   test("passes for inline elements with text and inline children", () => {
@@ -136,7 +136,7 @@ describe("html-no-block-inside-inline", () => {
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(1)
-    expect(lintResult.messages[0].message).toBe('Block-level element `<ul>` cannot be placed inside inline element `<span>`.')
+    expect(lintResult.offenses[0].message).toBe('Block-level element `<ul>` cannot be placed inside inline element `<span>`.')
   })
 
   test("handles ERB templates correctly", () => {
@@ -156,7 +156,7 @@ describe("html-no-block-inside-inline", () => {
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(1)
-    expect(lintResult.messages[0].message).toBe('Block-level element `<form>` cannot be placed inside inline element `<button>`.')
+    expect(lintResult.offenses[0].message).toBe('Block-level element `<form>` cannot be placed inside inline element `<button>`.')
   })
 
   test("fails for table inside label", () => {
@@ -166,7 +166,7 @@ describe("html-no-block-inside-inline", () => {
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(1)
-    expect(lintResult.messages[0].message).toBe('Block-level element `<table>` cannot be placed inside inline element `<label>`.')
+    expect(lintResult.offenses[0].message).toBe('Block-level element `<table>` cannot be placed inside inline element `<label>`.')
   })
 
   test("fails for custom elements inside inline elements", () => {
@@ -176,7 +176,7 @@ describe("html-no-block-inside-inline", () => {
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(1)
-    expect(lintResult.messages[0].message).toBe('Unknown element `<my-component>` cannot be placed inside inline element `<span>`.')
+    expect(lintResult.offenses[0].message).toBe('Unknown element `<my-component>` cannot be placed inside inline element `<span>`.')
   })
 
   test("passes for block elements inside custom elements", () => {
@@ -202,9 +202,9 @@ describe("html-no-block-inside-inline", () => {
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(3)
-    expect(lintResult.messages[0].message).toBe('Unknown element `<x-button>` cannot be placed inside inline element `<span>`.')
-    expect(lintResult.messages[1].message).toBe('Unknown element `<app-icon>` cannot be placed inside inline element `<span>`.')
-    expect(lintResult.messages[2].message).toBe('Unknown element `<my-very-long-component-name>` cannot be placed inside inline element `<span>`.')
+    expect(lintResult.offenses[0].message).toBe('Unknown element `<x-button>` cannot be placed inside inline element `<span>`.')
+    expect(lintResult.offenses[1].message).toBe('Unknown element `<app-icon>` cannot be placed inside inline element `<span>`.')
+    expect(lintResult.offenses[2].message).toBe('Unknown element `<my-very-long-component-name>` cannot be placed inside inline element `<span>`.')
   })
 
   test("still fails for standard block elements after custom elements", () => {
@@ -214,8 +214,8 @@ describe("html-no-block-inside-inline", () => {
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(2)
-    expect(lintResult.messages[0].message).toBe('Unknown element `<my-component>` cannot be placed inside inline element `<span>`.')
-    expect(lintResult.messages[1].message).toBe('Block-level element `<div>` cannot be placed inside inline element `<span>`.')
+    expect(lintResult.offenses[0].message).toBe('Unknown element `<my-component>` cannot be placed inside inline element `<span>`.')
+    expect(lintResult.offenses[1].message).toBe('Block-level element `<div>` cannot be placed inside inline element `<span>`.')
   })
 
   test("fails for nested custom elements inside inline", () => {
@@ -225,7 +225,7 @@ describe("html-no-block-inside-inline", () => {
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(1)
-    expect(lintResult.messages[0].message).toBe('Unknown element `<outer-component>` cannot be placed inside inline element `<span>`.')
+    expect(lintResult.offenses[0].message).toBe('Unknown element `<outer-component>` cannot be placed inside inline element `<span>`.')
   })
 
   test("fails for single-word custom elements inside inline", () => {
@@ -235,7 +235,7 @@ describe("html-no-block-inside-inline", () => {
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(1)
-    expect(lintResult.messages[0].message).toBe('Unknown element `<customtag>` cannot be placed inside inline element `<span>`.')
+    expect(lintResult.offenses[0].message).toBe('Unknown element `<customtag>` cannot be placed inside inline element `<span>`.')
   })
 
   test("fails for unknown elements inside inline but allows content inside unknown elements", () => {
@@ -245,7 +245,7 @@ describe("html-no-block-inside-inline", () => {
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(1)
-    expect(lintResult.messages[0].message).toBe('Unknown element `<unknownelement>` cannot be placed inside inline element `<span>`.')
+    expect(lintResult.offenses[0].message).toBe('Unknown element `<unknownelement>` cannot be placed inside inline element `<span>`.')
   })
 
   test("passes for custom elements at top level", () => {
@@ -265,6 +265,6 @@ describe("html-no-block-inside-inline", () => {
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(1)
-    expect(lintResult.messages[0].message).toBe('Block-level element `<div>` cannot be placed inside inline element `<span>`.')
+    expect(lintResult.offenses[0].message).toBe('Block-level element `<div>` cannot be placed inside inline element `<span>`.')
   })
 })

--- a/javascript/packages/linter/test/rules/html-no-duplicate-attributes.test.ts
+++ b/javascript/packages/linter/test/rules/html-no-duplicate-attributes.test.ts
@@ -16,7 +16,7 @@ describe("html-no-duplicate-attributes", () => {
 
     expect(lintResult.errors).toBe(0)
     expect(lintResult.warnings).toBe(0)
-    expect(lintResult.messages).toHaveLength(0)
+    expect(lintResult.offenses).toHaveLength(0)
   })
 
   test("fails for duplicate attributes", () => {
@@ -27,11 +27,11 @@ describe("html-no-duplicate-attributes", () => {
 
     expect(lintResult.errors).toBe(1)
     expect(lintResult.warnings).toBe(0)
-    expect(lintResult.messages).toHaveLength(1)
+    expect(lintResult.offenses).toHaveLength(1)
 
-    expect(lintResult.messages[0].rule).toBe("html-no-duplicate-attributes")
-    expect(lintResult.messages[0].message).toBe('Duplicate attribute `type` found on tag. Remove the duplicate occurrence.')
-    expect(lintResult.messages[0].severity).toBe("error")
+    expect(lintResult.offenses[0].rule).toBe("html-no-duplicate-attributes")
+    expect(lintResult.offenses[0].message).toBe('Duplicate attribute `type` found on tag. Remove the duplicate occurrence.')
+    expect(lintResult.offenses[0].severity).toBe("error")
   })
 
   test("fails for multiple duplicate attributes", () => {
@@ -42,7 +42,7 @@ describe("html-no-duplicate-attributes", () => {
 
     expect(lintResult.errors).toBe(2) // One for type, one for class
     expect(lintResult.warnings).toBe(0)
-    expect(lintResult.messages).toHaveLength(2)
+    expect(lintResult.offenses).toHaveLength(2)
   })
 
   test("handles case-insensitive duplicates", () => {
@@ -52,7 +52,7 @@ describe("html-no-duplicate-attributes", () => {
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(1)
-    expect(lintResult.messages[0].message).toBe('Duplicate attribute `class` found on tag. Remove the duplicate occurrence.')
+    expect(lintResult.offenses[0].message).toBe('Duplicate attribute `class` found on tag. Remove the duplicate occurrence.')
   })
 
   test("passes for different attributes", () => {
@@ -72,7 +72,7 @@ describe("html-no-duplicate-attributes", () => {
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(1)
-    expect(lintResult.messages[0].message).toBe('Duplicate attribute `src` found on tag. Remove the duplicate occurrence.')
+    expect(lintResult.offenses[0].message).toBe('Duplicate attribute `src` found on tag. Remove the duplicate occurrence.')
   })
 
   test("handles ERB templates with attributes", () => {

--- a/javascript/packages/linter/test/rules/html-no-empty-headings.test.ts
+++ b/javascript/packages/linter/test/rules/html-no-empty-headings.test.ts
@@ -16,7 +16,7 @@ describe("html-no-empty-headings", () => {
 
     expect(lintResult.errors).toBe(0)
     expect(lintResult.warnings).toBe(0)
-    expect(lintResult.messages).toHaveLength(0)
+    expect(lintResult.offenses).toHaveLength(0)
   })
 
   test("passes for heading with nested elements", () => {
@@ -27,7 +27,7 @@ describe("html-no-empty-headings", () => {
 
     expect(lintResult.errors).toBe(0)
     expect(lintResult.warnings).toBe(0)
-    expect(lintResult.messages).toHaveLength(0)
+    expect(lintResult.offenses).toHaveLength(0)
   })
 
   test("passes for heading with ERB content", () => {
@@ -38,7 +38,7 @@ describe("html-no-empty-headings", () => {
 
     expect(lintResult.errors).toBe(0)
     expect(lintResult.warnings).toBe(0)
-    expect(lintResult.messages).toHaveLength(0)
+    expect(lintResult.offenses).toHaveLength(0)
   })
 
   test("fails for empty heading", () => {
@@ -49,11 +49,11 @@ describe("html-no-empty-headings", () => {
 
     expect(lintResult.errors).toBe(1)
     expect(lintResult.warnings).toBe(0)
-    expect(lintResult.messages).toHaveLength(1)
+    expect(lintResult.offenses).toHaveLength(1)
 
-    expect(lintResult.messages[0].rule).toBe("html-no-empty-headings")
-    expect(lintResult.messages[0].message).toBe("Heading element `<h1>` must not be empty. Provide accessible text content for screen readers and SEO.")
-    expect(lintResult.messages[0].severity).toBe("error")
+    expect(lintResult.offenses[0].rule).toBe("html-no-empty-headings")
+    expect(lintResult.offenses[0].message).toBe("Heading element `<h1>` must not be empty. Provide accessible text content for screen readers and SEO.")
+    expect(lintResult.offenses[0].severity).toBe("error")
   })
 
   test("fails for heading with only whitespace", () => {
@@ -64,10 +64,10 @@ describe("html-no-empty-headings", () => {
 
     expect(lintResult.errors).toBe(1)
     expect(lintResult.warnings).toBe(0)
-    expect(lintResult.messages).toHaveLength(1)
+    expect(lintResult.offenses).toHaveLength(1)
 
-    expect(lintResult.messages[0].rule).toBe("html-no-empty-headings")
-    expect(lintResult.messages[0].message).toBe("Heading element `<h2>` must not be empty. Provide accessible text content for screen readers and SEO.")
+    expect(lintResult.offenses[0].rule).toBe("html-no-empty-headings")
+    expect(lintResult.offenses[0].message).toBe("Heading element `<h2>` must not be empty. Provide accessible text content for screen readers and SEO.")
   })
 
   test("fails for self-closing heading", () => {
@@ -78,10 +78,10 @@ describe("html-no-empty-headings", () => {
 
     expect(lintResult.errors).toBe(1)
     expect(lintResult.warnings).toBe(0)
-    expect(lintResult.messages).toHaveLength(1)
+    expect(lintResult.offenses).toHaveLength(1)
 
-    expect(lintResult.messages[0].rule).toBe("html-no-empty-headings")
-    expect(lintResult.messages[0].message).toBe("Heading element `<h3>` must not be empty. Provide accessible text content for screen readers and SEO.")
+    expect(lintResult.offenses[0].rule).toBe("html-no-empty-headings")
+    expect(lintResult.offenses[0].message).toBe("Heading element `<h3>` must not be empty. Provide accessible text content for screen readers and SEO.")
   })
 
   test("handles all heading levels h1-h6", () => {
@@ -92,11 +92,11 @@ describe("html-no-empty-headings", () => {
 
     expect(lintResult.errors).toBe(6)
     expect(lintResult.warnings).toBe(0)
-    expect(lintResult.messages).toHaveLength(6)
+    expect(lintResult.offenses).toHaveLength(6)
 
-    expect(lintResult.messages[0].message).toBe("Heading element `<h1>` must not be empty. Provide accessible text content for screen readers and SEO.")
-    expect(lintResult.messages[1].message).toBe("Heading element `<h2>` must not be empty. Provide accessible text content for screen readers and SEO.")
-    expect(lintResult.messages[5].message).toBe("Heading element `<h6>` must not be empty. Provide accessible text content for screen readers and SEO.")
+    expect(lintResult.offenses[0].message).toBe("Heading element `<h1>` must not be empty. Provide accessible text content for screen readers and SEO.")
+    expect(lintResult.offenses[1].message).toBe("Heading element `<h2>` must not be empty. Provide accessible text content for screen readers and SEO.")
+    expect(lintResult.offenses[5].message).toBe("Heading element `<h6>` must not be empty. Provide accessible text content for screen readers and SEO.")
   })
 
   test("handles mixed case heading tags", () => {
@@ -106,7 +106,7 @@ describe("html-no-empty-headings", () => {
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(1)
-    expect(lintResult.messages[0].message).toBe("Heading element `<h1>` must not be empty. Provide accessible text content for screen readers and SEO.")
+    expect(lintResult.offenses[0].message).toBe("Heading element `<h1>` must not be empty. Provide accessible text content for screen readers and SEO.")
   })
 
   test("ignores non-heading tags", () => {
@@ -147,7 +147,7 @@ describe("html-no-empty-headings", () => {
 
     expect(lintResult.errors).toBe(2)
     expect(lintResult.warnings).toBe(0)
-    expect(lintResult.messages).toHaveLength(2)
+    expect(lintResult.offenses).toHaveLength(2)
   })
 
   test("passes for div with role='heading' and content", () => {
@@ -158,7 +158,7 @@ describe("html-no-empty-headings", () => {
 
     expect(lintResult.errors).toBe(0)
     expect(lintResult.warnings).toBe(0)
-    expect(lintResult.messages).toHaveLength(0)
+    expect(lintResult.offenses).toHaveLength(0)
   })
 
   test("fails for empty div with role='heading'", () => {
@@ -169,11 +169,11 @@ describe("html-no-empty-headings", () => {
 
     expect(lintResult.errors).toBe(1)
     expect(lintResult.warnings).toBe(0)
-    expect(lintResult.messages).toHaveLength(1)
+    expect(lintResult.offenses).toHaveLength(1)
 
-    expect(lintResult.messages[0].rule).toBe("html-no-empty-headings")
-    expect(lintResult.messages[0].message).toBe('Heading element `<div role="heading">` must not be empty. Provide accessible text content for screen readers and SEO.')
-    expect(lintResult.messages[0].severity).toBe("error")
+    expect(lintResult.offenses[0].rule).toBe("html-no-empty-headings")
+    expect(lintResult.offenses[0].message).toBe('Heading element `<div role="heading">` must not be empty. Provide accessible text content for screen readers and SEO.')
+    expect(lintResult.offenses[0].severity).toBe("error")
   })
 
   test("fails for div with role='heading' containing only whitespace", () => {
@@ -184,9 +184,9 @@ describe("html-no-empty-headings", () => {
 
     expect(lintResult.errors).toBe(1)
     expect(lintResult.warnings).toBe(0)
-    expect(lintResult.messages).toHaveLength(1)
+    expect(lintResult.offenses).toHaveLength(1)
 
-    expect(lintResult.messages[0].message).toBe('Heading element `<div role="heading">` must not be empty. Provide accessible text content for screen readers and SEO.')
+    expect(lintResult.offenses[0].message).toBe('Heading element `<div role="heading">` must not be empty. Provide accessible text content for screen readers and SEO.')
   })
 
   test("fails for self-closing div with role='heading'", () => {
@@ -197,9 +197,9 @@ describe("html-no-empty-headings", () => {
 
     expect(lintResult.errors).toBe(1)
     expect(lintResult.warnings).toBe(0)
-    expect(lintResult.messages).toHaveLength(1)
+    expect(lintResult.offenses).toHaveLength(1)
 
-    expect(lintResult.messages[0].message).toBe('Heading element `<div role="heading">` must not be empty. Provide accessible text content for screen readers and SEO.')
+    expect(lintResult.offenses[0].message).toBe('Heading element `<div role="heading">` must not be empty. Provide accessible text content for screen readers and SEO.')
   })
 
   test("ignores div without role='heading'", () => {
@@ -210,7 +210,7 @@ describe("html-no-empty-headings", () => {
 
     expect(lintResult.errors).toBe(0)
     expect(lintResult.warnings).toBe(0)
-    expect(lintResult.messages).toHaveLength(0)
+    expect(lintResult.offenses).toHaveLength(0)
   })
 
   test("handles mixed standard headings and ARIA headings", () => {
@@ -221,10 +221,10 @@ describe("html-no-empty-headings", () => {
 
     expect(lintResult.errors).toBe(2)
     expect(lintResult.warnings).toBe(0)
-    expect(lintResult.messages).toHaveLength(2)
+    expect(lintResult.offenses).toHaveLength(2)
 
-    expect(lintResult.messages[0].message).toBe("Heading element `<h1>` must not be empty. Provide accessible text content for screen readers and SEO.")
-    expect(lintResult.messages[1].message).toBe('Heading element `<div role="heading">` must not be empty. Provide accessible text content for screen readers and SEO.')
+    expect(lintResult.offenses[0].message).toBe("Heading element `<h1>` must not be empty. Provide accessible text content for screen readers and SEO.")
+    expect(lintResult.offenses[1].message).toBe('Heading element `<div role="heading">` must not be empty. Provide accessible text content for screen readers and SEO.')
   })
 
   test("fails for heading with only aria-hidden content", () => {
@@ -235,11 +235,11 @@ describe("html-no-empty-headings", () => {
 
     expect(lintResult.errors).toBe(1)
     expect(lintResult.warnings).toBe(0)
-    expect(lintResult.messages).toHaveLength(1)
+    expect(lintResult.offenses).toHaveLength(1)
 
-    expect(lintResult.messages[0].rule).toBe("html-no-empty-headings")
-    expect(lintResult.messages[0].message).toBe("Heading element `<h1>` must not be empty. Provide accessible text content for screen readers and SEO.")
-    expect(lintResult.messages[0].severity).toBe("error")
+    expect(lintResult.offenses[0].rule).toBe("html-no-empty-headings")
+    expect(lintResult.offenses[0].message).toBe("Heading element `<h1>` must not be empty. Provide accessible text content for screen readers and SEO.")
+    expect(lintResult.offenses[0].severity).toBe("error")
   })
 
   test("fails for heading with mixed accessible and inaccessible content", () => {
@@ -250,7 +250,7 @@ describe("html-no-empty-headings", () => {
 
     expect(lintResult.errors).toBe(1)
     expect(lintResult.warnings).toBe(0)
-    expect(lintResult.messages).toHaveLength(1)
+    expect(lintResult.offenses).toHaveLength(1)
   })
 
   test("passes for heading with mix of accessible and inaccessible content", () => {
@@ -261,7 +261,7 @@ describe("html-no-empty-headings", () => {
 
     expect(lintResult.errors).toBe(0)
     expect(lintResult.warnings).toBe(0)
-    expect(lintResult.messages).toHaveLength(0)
+    expect(lintResult.offenses).toHaveLength(0)
   })
 
   test("passes for heading itself with aria-hidden='true' but has content", () => {
@@ -272,7 +272,7 @@ describe("html-no-empty-headings", () => {
 
     expect(lintResult.errors).toBe(0)
     expect(lintResult.warnings).toBe(0)
-    expect(lintResult.messages).toHaveLength(0)
+    expect(lintResult.offenses).toHaveLength(0)
   })
 
   test("passes for heading itself with hidden attribute but has content", () => {
@@ -283,7 +283,7 @@ describe("html-no-empty-headings", () => {
 
     expect(lintResult.errors).toBe(0)
     expect(lintResult.warnings).toBe(0)
-    expect(lintResult.messages).toHaveLength(0)
+    expect(lintResult.offenses).toHaveLength(0)
   })
 
   test("passes for heading with nested span containing text", () => {
@@ -294,6 +294,6 @@ describe("html-no-empty-headings", () => {
 
     expect(lintResult.errors).toBe(0)
     expect(lintResult.warnings).toBe(0)
-    expect(lintResult.messages).toHaveLength(0)
+    expect(lintResult.offenses).toHaveLength(0)
   })
 })

--- a/javascript/packages/linter/test/rules/html-no-nested-links.test.ts
+++ b/javascript/packages/linter/test/rules/html-no-nested-links.test.ts
@@ -16,7 +16,7 @@ describe("html-no-nested-links", () => {
 
     expect(lintResult.errors).toBe(0)
     expect(lintResult.warnings).toBe(0)
-    expect(lintResult.messages).toHaveLength(0)
+    expect(lintResult.offenses).toHaveLength(0)
   })
 
   test("fails for directly nested links", () => {
@@ -27,11 +27,11 @@ describe("html-no-nested-links", () => {
 
     expect(lintResult.errors).toBe(1)
     expect(lintResult.warnings).toBe(0)
-    expect(lintResult.messages).toHaveLength(1)
+    expect(lintResult.offenses).toHaveLength(1)
 
-    expect(lintResult.messages[0].rule).toBe("html-no-nested-links")
-    expect(lintResult.messages[0].message).toBe("Nested `<a>` elements are not allowed. Links cannot contain other links.")
-    expect(lintResult.messages[0].severity).toBe("error")
+    expect(lintResult.offenses[0].rule).toBe("html-no-nested-links")
+    expect(lintResult.offenses[0].message).toBe("Nested `<a>` elements are not allowed. Links cannot contain other links.")
+    expect(lintResult.offenses[0].severity).toBe("error")
   })
 
   test("fails for indirectly nested links", () => {
@@ -41,7 +41,7 @@ describe("html-no-nested-links", () => {
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(1)
-    expect(lintResult.messages[0].message).toBe("Nested `<a>` elements are not allowed. Links cannot contain other links.")
+    expect(lintResult.offenses[0].message).toBe("Nested `<a>` elements are not allowed. Links cannot contain other links.")
   })
 
   test("passes for links in different containers", () => {
@@ -71,7 +71,7 @@ describe("html-no-nested-links", () => {
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(1)
-    expect(lintResult.messages[0].message).toBe("Nested `<a>` elements are not allowed. Links cannot contain other links.")
+    expect(lintResult.offenses[0].message).toBe("Nested `<a>` elements are not allowed. Links cannot contain other links.")
   })
 
   test("passes for links with complex content", () => {

--- a/javascript/packages/linter/test/rules/html-tag-name-lowercase.test.ts
+++ b/javascript/packages/linter/test/rules/html-tag-name-lowercase.test.ts
@@ -16,7 +16,7 @@ describe("html-tag-name-lowercase", () => {
 
     expect(lintResult.errors).toBe(0)
     expect(lintResult.warnings).toBe(0)
-    expect(lintResult.messages).toHaveLength(0)
+    expect(lintResult.offenses).toHaveLength(0)
   })
 
   test("fails for uppercase tag names", () => {
@@ -27,11 +27,11 @@ describe("html-tag-name-lowercase", () => {
 
     expect(lintResult.errors).toBe(4) // DIV open, DIV close, SPAN open, SPAN close
     expect(lintResult.warnings).toBe(0)
-    expect(lintResult.messages).toHaveLength(4)
+    expect(lintResult.offenses).toHaveLength(4)
 
-    expect(lintResult.messages[0].rule).toBe("html-tag-name-lowercase")
-    expect(lintResult.messages[0].message).toBe('Tag name `DIV` should be lowercase. Use `div` instead.')
-    expect(lintResult.messages[0].severity).toBe("error")
+    expect(lintResult.offenses[0].rule).toBe("html-tag-name-lowercase")
+    expect(lintResult.offenses[0].message).toBe('Tag name `DIV` should be lowercase. Use `div` instead.')
+    expect(lintResult.offenses[0].severity).toBe("error")
   })
 
   test("fails for mixed case tag names", () => {
@@ -42,9 +42,9 @@ describe("html-tag-name-lowercase", () => {
 
     expect(lintResult.errors).toBe(4)
     expect(lintResult.warnings).toBe(0)
-    expect(lintResult.messages).toHaveLength(4)
+    expect(lintResult.offenses).toHaveLength(4)
 
-    expect(lintResult.messages[0].message).toBe('Tag name `Div` should be lowercase. Use `div` instead.')
+    expect(lintResult.offenses[0].message).toBe('Tag name `Div` should be lowercase. Use `div` instead.')
   })
 
   test("handles self-closing tags", () => {
@@ -54,7 +54,7 @@ describe("html-tag-name-lowercase", () => {
     const lintResult = linter.lint(result.value)
 
     expect(lintResult.errors).toBe(1)
-    expect(lintResult.messages[0].message).toBe('Tag name `IMG` should be lowercase. Use `img` instead.')
+    expect(lintResult.offenses[0].message).toBe('Tag name `IMG` should be lowercase. Use `img` instead.')
   })
 
   test("passes for valid self-closing tags", () => {
@@ -115,7 +115,7 @@ describe("html-tag-name-lowercase", () => {
     expect(lintResult.errors).toBe(14)
     expect(lintResult.warnings).toBe(0)
 
-    const errorMessages = lintResult.messages.map(message => message.message)
+    const errorMessages = lintResult.offenses.map(message => message.message)
     expect(errorMessages.some(msg => msg.includes('ARTICLE'))).toBe(true)
     expect(errorMessages.some(msg => msg.includes('HEADER'))).toBe(true)
     expect(errorMessages.some(msg => msg.includes('H1'))).toBe(true)


### PR DESCRIPTION
Following up on #227, this pull request renames all properties and functions in the Linter from `message` to `offense`.