### PR TITLE
Add `Diagnostics` interface and rename other to `MonacoDiagnostic`

### DIFF
--- a/javascript/packages/core/src/diagnostic.ts
+++ b/javascript/packages/core/src/diagnostic.ts
@@ -1,0 +1,78 @@
+import { Location, SerializedLocation } from "./location.js"
+
+export type DiagnosticSeverity = "error" | "warning" | "info" | "hint"
+
+/**
+ * Base interface for all diagnostic information in Herb tooling.
+ * This includes parser errors, lexer errors, lint offenses, and any other
+ * issues that need to be reported to users.
+ */
+export interface Diagnostic {
+  /**
+   * The diagnostic message describing the issue
+   */
+  message: string
+
+  /**
+   * The location in the source where this diagnostic applies
+   */
+  location: Location
+
+  /**
+   * The severity level of the diagnostic
+   */
+  severity: DiagnosticSeverity
+
+  /**
+   * Optional diagnostic code for categorization (e.g., "E0001", "W0042")
+   */
+  code?: string
+
+  /**
+   * Optional source that generated this diagnostic (e.g., "parser", "linter", "lexer")
+   */
+  source?: string
+}
+
+/**
+ * Serialized form of a Diagnostic for JSON representation
+ */
+export interface SerializedDiagnostic {
+  message: string
+  location: SerializedLocation
+  severity: DiagnosticSeverity
+  code?: string
+  source?: string
+}
+
+export type MonacoSeverity = "error" | "warning" | "info"
+
+/**
+ * Monaco/VSCode-compatible diagnostic format for editor integration
+ */
+export type MonacoDiagnostic = {
+  line: number
+  column: number
+  endLine: number
+  endColumn: number
+  message: string
+  severity: MonacoSeverity
+}
+
+/**
+ * Converts a Diagnostic to Monaco/VSCode-compatible MonacoDiagnostic format
+ */
+export function toMonacoDiagnostic(diagnostic: Diagnostic): MonacoDiagnostic {
+  const { message, location } = diagnostic
+
+  const severity: MonacoSeverity = diagnostic.severity === "hint" ? "info" : diagnostic.severity
+
+  return {
+    line: location.start.line,
+    column: location.start.column,
+    endLine: location.end.line,
+    endColumn: location.end.column,
+    message,
+    severity
+  }
+}

--- a/javascript/packages/core/src/index.ts
+++ b/javascript/packages/core/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./backend.js"
+export * from "./diagnostic.js"
 export * from "./errors.js"
 export * from "./herb-backend.js"
 export * from "./lex-result.js"

--- a/javascript/packages/linter/src/rules/rule-utils.ts
+++ b/javascript/packages/linter/src/rules/rule-utils.ts
@@ -6,10 +6,10 @@ import {
   HTMLAttributeValueNode,
   LiteralNode,
   Visitor,
-  Location
+  Location,
 } from "@herb-tools/core"
 
-import type { LintOffense } from "../types.js"
+import type { LintOffense, LintSeverity } from "../types.js"
 
 /**
  * Base visitor class that provides common functionality for rule visitors
@@ -27,7 +27,7 @@ export abstract class BaseRuleVisitor extends Visitor {
   /**
    * Helper method to create a lint offense
    */
-  protected createOffense(message: string, location: Location, severity: "error" | "warning" = "error"): LintOffense {
+  protected createOffense(message: string, location: Location, severity: LintSeverity = "error"): LintOffense {
     return {
       rule: this.ruleName,
       message,
@@ -39,7 +39,7 @@ export abstract class BaseRuleVisitor extends Visitor {
   /**
    * Helper method to add an offense to the offenses array
    */
-  protected addOffense(message: string, location: Location, severity: "error" | "warning" = "error"): void {
+  protected addOffense(message: string, location: Location, severity: LintSeverity = "error"): void {
     this.offenses.push(this.createOffense(message, location, severity))
   }
 }

--- a/javascript/packages/linter/src/types.ts
+++ b/javascript/packages/linter/src/types.ts
@@ -1,10 +1,10 @@
-import { Location, Node } from "@herb-tools/core"
+import { Node, Diagnostic } from "@herb-tools/core"
 
-export interface LintOffense {
+export type LintSeverity = "error" | "warning"
+
+export interface LintOffense extends Diagnostic {
   rule: string
-  message: string
-  location: Location
-  severity: "error" | "warning"
+  severity: LintSeverity
 }
 
 export interface LintResult {

--- a/playground/src/controllers/playground_controller.js
+++ b/playground/src/controllers/playground_controller.js
@@ -310,19 +310,19 @@ export default class extends Controller {
 
     if (result.parseResult) {
       const errors = result.parseResult.recursiveErrors()
-      allDiagnostics.push(...errors.flatMap((error) => error.toDiagnostics()))
+      allDiagnostics.push(...errors.map((error) => error.toMonacoDiagnostic()))
     }
 
-    if (result.lintResult && result.lintResult.messages) {
-      const lintDiagnostics = result.lintResult.messages.map((message) => ({
-        severity: message.severity,
-        message: message.message,
-        line: message.location.start.line,
-        column: message.location.start.column,
-        endLine: message.location.end.line,
-        endColumn: message.location.end.column,
+    if (result.lintResult && result.lintResult.offenses) {
+      const lintDiagnostics = result.lintResult.offenses.map((offense) => ({
+        severity: offense.severity,
+        message: offense.message,
+        line: offense.location.start.line,
+        column: offense.location.start.column,
+        endLine: offense.location.end.line,
+        endColumn: offense.location.end.column,
         source: "Herb Linter ",
-        code: message.rule,
+        code: offense.rule,
       }))
 
       allDiagnostics.push(...lintDiagnostics)

--- a/templates/javascript/packages/core/src/errors.ts.erb
+++ b/templates/javascript/packages/core/src/errors.ts.erb
@@ -1,14 +1,6 @@
 import { Location, SerializedLocation } from "./location.js"
 import { Token, SerializedToken } from "./token.js"
-
-type HerbDiagnostic = {
-  line: number
-  column: number
-  endLine: number
-  endColumn: number
-  message: string
-  severity: "error" | "warning" | "info"
-}
+import { Diagnostic, MonacoDiagnostic } from "./diagnostic.js"
 
 export type HerbErrorType =
   <%- errors.each_with_index.map do |error, index| -%>
@@ -23,10 +15,16 @@ export interface SerializedHerbError {
   location: SerializedLocation
 }
 
-export abstract class HerbError {
+export abstract class HerbError implements Diagnostic {
   readonly type: string
   readonly message: string
   readonly location: Location
+  readonly severity: "error" | "warning" | "info" | "hint" = "error"
+  readonly source: string = "parser"
+
+  get code(): string {
+    return this.type
+  }
 
   static from(error: SerializedHerbError): HerbError {
     return fromSerializedError(error)
@@ -147,40 +145,15 @@ export class <%= error.name %> extends HerbError {
     };
   }
 
-  toDiagnostics(): HerbDiagnostic[] {
-    const diagnostics: HerbDiagnostic[] = [
-      {
-        line: this.location.start.line,
-        column: this.location.start.column,
-        endLine: this.location.end.line,
-        endColumn: this.location.end.column,
-        message: this.message,
-        severity: 'error'
-      }
-    ]
-
-    <%- error.fields.each do |field| -%>
-    <%- case field -%>
-    <%- when Herb::Template::TokenField -%>
-    if (this.<%= field.name %>) {
-      diagnostics.push({
-        line: this.<%= field.name %>.location.start.line,
-        column: this.<%= field.name %>.location.start.column,
-        endLine: this.<%= field.name %>.location.end.line,
-        endColumn: this.<%= field.name %>.location.end.column,
-        message: `<%= field.name %> "${(this.<%= field.name %>.value)}" is here`,
-        severity: 'info'
-      })
+  toMonacoDiagnostic(): MonacoDiagnostic {
+    return {
+      line: this.location.start.line,
+      column: this.location.start.column,
+      endLine: this.location.end.line,
+      endColumn: this.location.end.column,
+      message: this.message,
+      severity: 'error'
     }
-
-    <%- when Herb::Template::StringField, Herb::Template::TokenTypeField -%>
-    // no-op for <%= field.name %>
-    <%- else -%>
-    <%- raise "Unhandled Type: #{field.class}" %>
-    <%- end -%>
-    <%- end -%>
-
-    return diagnostics
   }
 
   treeInspect(): string {


### PR DESCRIPTION
This pull request introduces a new `Diagnostics` interface which will be used to represent errors, warnings, info messages, lint offenses, and anything else that could be shown in the editor as a "Diagnostic".

Previously we had a `HerbDiagnostic` type, which we used to convert "errors" to "diagnostics" so they would be compatible with the Monaco editor in the playground.

Now we renamed that `HerbDiagnostic` type to `MonacoDiagnostic` so it's clear what this one is used for. With that, we also introduced a new `toMonacoDiagnostic(diagnostic: Diagnostic): MonacoDiagnostic` utility function to convert any `Diagnostic` to a `MonacoDiagnostic`.

There are probably also some refactoring opportunities to make use of these new types in the Language Server.