### PR TITLE
Add `--no-log-file` option to `herb analyze` command

### DIFF
--- a/lib/herb/cli.rb
+++ b/lib/herb/cli.rb
@@ -6,7 +6,7 @@
 require "optparse"
 
 class Herb::CLI
-  attr_accessor :json, :silent, :no_interactive
+  attr_accessor :json, :silent, :no_interactive, :no_log_file
 
   def initialize(args)
     @args = args
@@ -108,6 +108,7 @@ class Herb::CLI
                 when "analyze"
                   project = Herb::Project.new(directory)
                   project.no_interactive = no_interactive
+                  project.no_log_file = no_log_file
                   project.parse!
                   exit(0)
                 when "parse"
@@ -167,6 +168,10 @@ class Herb::CLI
 
       parser.on("-n", "--non-interactive", "Disable interactive output (progress bars, terminal clearing)") do
         self.no_interactive = true
+      end
+
+      parser.on("--no-log-file", "Disable log file generation") do
+        self.no_log_file = true
       end
     end
   end

--- a/lib/herb/project.rb
+++ b/lib/herb/project.rb
@@ -8,10 +8,11 @@ require "timeout"
 require "tempfile"
 require "pathname"
 require "English"
+require "stringio"
 
 module Herb
   class Project
-    attr_accessor :project_path, :output_file, :no_interactive
+    attr_accessor :project_path, :output_file, :no_interactive, :no_log_file
 
     def interactive?
       return false if no_interactive
@@ -45,7 +46,13 @@ module Herb
     end
 
     def parse!
-      File.open(output_file, "w") do |log|
+      if no_log_file
+        log = StringIO.new
+      else
+        log = File.open(output_file, "w")
+      end
+
+      begin
         log.puts heading("METADATA")
         log.puts "Herb Version: #{Herb.version}"
         log.puts "Reported at: #{Time.now.strftime("%Y-%m-%dT%H:%M:%S")}\n\n"
@@ -60,7 +67,7 @@ module Herb
           message = "No .html.erb files found using #{full_path_glob}"
           log.puts message
           puts message
-          next
+          return
         end
 
         print "\e[H\e[2J" if interactive?
@@ -348,7 +355,9 @@ module Herb
           end
         end
 
-        puts "\nResults saved to #{output_file}"
+        puts "\nResults saved to #{output_file}" unless no_log_file
+      ensure
+        log.close unless no_log_file
       end
     end
 


### PR DESCRIPTION
This pull request adds the `--no-log-file` option which allows users to run `herb analyze` without generating a log file. This is especially useful for larger projects with a lot of files. 

When enabled, log output is discarded using `StringIO` instead of writing to disk.