### PR TITLE
Add timing functionality to `herb analyze` command

### DIFF
--- a/lib/herb/cli.rb
+++ b/lib/herb/cli.rb
@@ -6,7 +6,7 @@
 require "optparse"
 
 class Herb::CLI
-  attr_accessor :json, :silent, :no_interactive, :no_log_file
+  attr_accessor :json, :silent, :no_interactive, :no_log_file, :no_timing
 
   def initialize(args)
     @args = args
@@ -109,6 +109,7 @@ class Herb::CLI
                   project = Herb::Project.new(directory)
                   project.no_interactive = no_interactive
                   project.no_log_file = no_log_file
+                  project.no_timing = no_timing
                   project.parse!
                   exit(0)
                 when "parse"
@@ -172,6 +173,10 @@ class Herb::CLI
 
       parser.on("--no-log-file", "Disable log file generation") do
         self.no_log_file = true
+      end
+
+      parser.on("--no-timing", "Disable timing output") do
+        self.no_timing = true
       end
     end
   end

--- a/lib/herb/project.rb
+++ b/lib/herb/project.rb
@@ -12,7 +12,7 @@ require "stringio"
 
 module Herb
   class Project
-    attr_accessor :project_path, :output_file, :no_interactive, :no_log_file
+    attr_accessor :project_path, :output_file, :no_interactive, :no_log_file, :no_timing
 
     def interactive?
       return false if no_interactive
@@ -46,6 +46,8 @@ module Herb
     end
 
     def parse!
+      start_time = Time.now unless no_timing
+
       log = if no_log_file
               StringIO.new
             else
@@ -355,6 +357,14 @@ module Herb
           end
         end
 
+        unless no_timing
+          end_time = Time.now
+          duration = end_time - start_time
+          timing_message = "\n⏱️ Total time: #{format_duration(duration)}"
+          log.puts timing_message
+          puts timing_message
+        end
+
         puts "\nResults saved to #{output_file}" unless no_log_file
       ensure
         log.close unless no_log_file
@@ -389,6 +399,18 @@ module Herb
       prefix = "--- #{text.upcase} "
 
       prefix + ("-" * (80 - prefix.length))
+    end
+
+    def format_duration(seconds)
+      if seconds < 1
+        "#{(seconds * 1000).round(2)}ms"
+      elsif seconds < 60
+        "#{seconds.round(2)}s"
+      else
+        minutes = (seconds / 60).to_i
+        remaining_seconds = seconds % 60
+        "#{minutes}m #{remaining_seconds.round(2)}s"
+      end
     end
   end
 end


### PR DESCRIPTION
This pull request adds timing to the `herb analyze` command to track total execution time. Additionally it also add a `--no-timing` option to disable timing output

```diff
Completed processing all files.
\--- SUMMARY --------------------------------------------------------------------
Total files: 145
✅ Successful: 144 (99.3%)
❌ Failed: 0 (0.0%)
⚠️  Parse errors: 1 (0.7%)
⏱️  Timed out: 0 (0.0%)

Files with parse errors:
  - app/views/contributions/index.html.erb
+
+⏱️  Total time: 535.81ms
```