### PR TITLE
Fix ternary operators being transformed into `ERBIfNode`

### DIFF
--- a/src/analyze_helpers.c
+++ b/src/analyze_helpers.c
@@ -89,11 +89,16 @@ bool search_if_nodes(const pm_node_t* node, void* data) {
   analyzed_ruby_T* analyzed = (analyzed_ruby_T*) data;
 
   if (node->type == PM_IF_NODE) {
-    analyzed->has_if_node = true;
-    return true;
-  } else {
-    pm_visit_child_nodes(node, search_if_nodes, analyzed);
+    const pm_if_node_t* if_node = (const pm_if_node_t*) node;
+
+    // Handle ternary
+    if (if_node->if_keyword_loc.start != NULL && if_node->if_keyword_loc.end != NULL) {
+      analyzed->has_if_node = true;
+      return true;
+    }
   }
+
+  pm_visit_child_nodes(node, search_if_nodes, analyzed);
 
   return false;
 }

--- a/test/analyze/ternary_test.rb
+++ b/test/analyze/ternary_test.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+module Analyze
+  class TernaryTest < Minitest::Spec
+    include SnapshotUtils
+
+    test "ternary operator in ERB output tag" do
+      assert_parsed_snapshot(<<~HTML)
+        <%= condition ? true_value : false_value %>
+      HTML
+    end
+
+    test "complex ternary operator with method calls" do
+      assert_parsed_snapshot(<<~HTML)
+        <%= @user.new_record? ? new_user_path(name: @user.name) : edit_user_path(@user, name: @user.name) %>
+      HTML
+    end
+
+    test "ternary operator in form_with" do
+      assert_parsed_snapshot(<<~HTML)
+        <%= form_with model: @post, url: @post.new_record? ? posts_path : post_path(@post) do |f| %>
+          Content
+        <% end %>
+      HTML
+    end
+
+    test "nested ternary operators" do
+      assert_parsed_snapshot(<<~HTML)
+        <%= status == :active ? "Active" : (status == :pending ? "Pending" : "Inactive") %>
+      HTML
+    end
+
+    test "ternary operator in attribute value" do
+      assert_parsed_snapshot(<<~HTML)
+        <div class="<%= active? ? 'active' : 'inactive' %>">Content</div>
+      HTML
+    end
+
+    test "multiple ternary operators in same ERB tag" do
+      assert_parsed_snapshot(<<~HTML)
+        <%= link_to (user.admin? ? "Admin" : "User"), (user.active? ? active_path : inactive_path) %>
+      HTML
+    end
+
+    test "ternary operator with blocks" do
+      assert_parsed_snapshot(<<~HTML)
+        <%= content_tag :div, class: (visible? ? "show" : "hide") do %>
+          Content
+        <% end %>
+      HTML
+    end
+
+    test "form_with helper with ternary in url parameter" do
+      assert_parsed_snapshot(<<~HTML)
+        <%= form_with model: @user, url: @user.new_record? ? users_path : user_path(@user), method: @user.new_record? ? :post : :patch do |form| %>
+          <%= form.text_field :name %>
+          <%= form.submit %>
+        <% end %>
+      HTML
+    end
+
+    test "content_tag with ternary for class attribute" do
+      assert_parsed_snapshot(<<~HTML)
+        <%= content_tag :div, "Hello World", class: current_user.admin? ? "admin-panel" : "user-panel" %>
+      HTML
+    end
+
+    test "content_tag with ternary for data attribute" do
+      assert_parsed_snapshot(<<~HTML)
+        <%= content_tag :button, "Click me",
+            data: {
+              action: @item.published? ? "unpublish" : "publish",
+              confirm: @item.published? ? "Are you sure you want to unpublish?" : "Are you sure you want to publish?"
+            } %>
+      HTML
+    end
+
+    test "form_with with complex ternary in multiple attributes" do
+      assert_parsed_snapshot(<<~HTML)
+        <%= form_with model: @article,
+                      url: @article.persisted? ? article_path(@article) : articles_path,
+                      html: { class: @article.draft? ? "draft-form" : "published-form" },
+                      local: @article.draft? ? true : false do |f| %>
+          <%= f.text_field :title %>
+        <% end %>
+      HTML
+    end
+
+    test "inline if modifier in ERB output tag" do
+      assert_parsed_snapshot(<<~HTML)
+        <%= render 'partial' if user_signed_in? %>
+      HTML
+    end
+
+    test "inline unless modifier in ERB output tag" do
+      assert_parsed_snapshot(<<~HTML)
+        <%= link_to "Home", root_path unless current_page?(root_path) %>
+      HTML
+    end
+  end
+end

--- a/test/snapshots/analyze/ternary_test/test_0001_ternary_operator_in_ERB_output_tag_487f1093637a362df78bafb89af97d09.txt
+++ b/test/snapshots/analyze/ternary_test/test_0001_ternary_operator_in_ERB_output_tag_487f1093637a362df78bafb89af97d09.txt
@@ -1,0 +1,11 @@
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ ERBContentNode (location: (1:0)-(1:43))
+    │   ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   ├── content: " condition ? true_value : false_value " (location: (1:3)-(1:41))
+    │   ├── tag_closing: "%>" (location: (1:41)-(1:43))
+    │   ├── parsed: true
+    │   └── valid: true
+    │
+    └── @ HTMLTextNode (location: (1:43)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/ternary_test/test_0002_complex_ternary_operator_with_method_calls_c9fd4eebccb37e967b174ccf1bde7bf2.txt
+++ b/test/snapshots/analyze/ternary_test/test_0002_complex_ternary_operator_with_method_calls_c9fd4eebccb37e967b174ccf1bde7bf2.txt
@@ -1,0 +1,11 @@
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ ERBContentNode (location: (1:0)-(1:100))
+    │   ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   ├── content: " @user.new_record? ? new_user_path(name: @user.name) : edit_user_path(@user, name: @user.name) " (location: (1:3)-(1:98))
+    │   ├── tag_closing: "%>" (location: (1:98)-(1:100))
+    │   ├── parsed: true
+    │   └── valid: true
+    │
+    └── @ HTMLTextNode (location: (1:100)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/ternary_test/test_0003_ternary_operator_in_form_with_3e5154d12d6259cc2ac2da74fc48e803.txt
+++ b/test/snapshots/analyze/ternary_test/test_0003_ternary_operator_in_form_with_3e5154d12d6259cc2ac2da74fc48e803.txt
@@ -1,0 +1,19 @@
+@ DocumentNode (location: (1:0)-(4:0))
+└── children: (2 items)
+    ├── @ ERBBlockNode (location: (1:0)-(3:9))
+    │   ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   ├── content: " form_with model: @post, url: @post.new_record? ? posts_path : post_path(@post) do |f| " (location: (1:3)-(1:90))
+    │   ├── tag_closing: "%>" (location: (1:90)-(1:92))
+    │   ├── body: (1 item)
+    │   │   └── @ HTMLTextNode (location: (1:92)-(3:0))
+    │   │       └── content: "\n  Content\n"
+    │   │
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (3:0)-(3:9))
+    │           ├── tag_opening: "<%" (location: (3:0)-(3:2))
+    │           ├── content: " end " (location: (3:2)-(3:7))
+    │           └── tag_closing: "%>" (location: (3:7)-(3:9))
+    │
+    │
+    └── @ HTMLTextNode (location: (3:9)-(4:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/ternary_test/test_0004_nested_ternary_operators_b02fe2f695043e3ef415f674581f8187.txt
+++ b/test/snapshots/analyze/ternary_test/test_0004_nested_ternary_operators_b02fe2f695043e3ef415f674581f8187.txt
@@ -1,0 +1,11 @@
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ ERBContentNode (location: (1:0)-(1:83))
+    │   ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   ├── content: " status == :active ? "Active" : (status == :pending ? "Pending" : "Inactive") " (location: (1:3)-(1:81))
+    │   ├── tag_closing: "%>" (location: (1:81)-(1:83))
+    │   ├── parsed: true
+    │   └── valid: true
+    │
+    └── @ HTMLTextNode (location: (1:83)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/ternary_test/test_0005_ternary_operator_in_attribute_value_d0b1eb0c3aae3bb30cf7891afdac44b8.txt
+++ b/test/snapshots/analyze/ternary_test/test_0005_ternary_operator_in_attribute_value_d0b1eb0c3aae3bb30cf7891afdac44b8.txt
@@ -1,0 +1,47 @@
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:65))
+    │   ├── open_tag:
+    │   │   └── @ HTMLOpenTagNode (location: (1:0)-(1:52))
+    │   │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+    │   │       ├── tag_name: "div" (location: (1:1)-(1:4))
+    │   │       ├── tag_closing: ">" (location: (1:51)-(1:52))
+    │   │       ├── children: (1 item)
+    │   │       │   └── @ HTMLAttributeNode (location: (1:5)-(1:51))
+    │   │       │       ├── name:
+    │   │       │       │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:10))
+    │   │       │       │       └── name: "class" (location: (1:5)-(1:10))
+    │   │       │       │
+    │   │       │       ├── equals: "=" (location: (1:10)-(1:11))
+    │   │       │       └── value:
+    │   │       │           └── @ HTMLAttributeValueNode (location: (1:11)-(1:51))
+    │   │       │               ├── open_quote: """ (location: (1:11)-(1:12))
+    │   │       │               ├── children: (1 item)
+    │   │       │               │   └── @ ERBContentNode (location: (1:12)-(1:50))
+    │   │       │               │       ├── tag_opening: "<%=" (location: (1:12)-(1:15))
+    │   │       │               │       ├── content: " active? ? 'active' : 'inactive' " (location: (1:15)-(1:48))
+    │   │       │               │       ├── tag_closing: "%>" (location: (1:48)-(1:50))
+    │   │       │               │       ├── parsed: true
+    │   │       │               │       └── valid: true
+    │   │       │               │
+    │   │       │               ├── close_quote: """ (location: (1:50)-(1:51))
+    │   │       │               └── quoted: true
+    │   │       │
+    │   │       │
+    │   │       └── is_void: false
+    │   │
+    │   ├── tag_name: "div" (location: (1:1)-(1:4))
+    │   ├── body: (1 item)
+    │   │   └── @ HTMLTextNode (location: (1:52)-(1:59))
+    │   │       └── content: "Content"
+    │   │
+    │   ├── close_tag:
+    │   │   └── @ HTMLCloseTagNode (location: (1:59)-(1:65))
+    │   │       ├── tag_opening: "</" (location: (1:59)-(1:61))
+    │   │       ├── tag_name: "div" (location: (1:61)-(1:64))
+    │   │       └── tag_closing: ">" (location: (1:64)-(1:65))
+    │   │
+    │   └── is_void: false
+    │
+    └── @ HTMLTextNode (location: (1:65)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/ternary_test/test_0006_multiple_ternary_operators_in_same_ERB_tag_7dd1d18fe401ed6c61c478be9ee5140f.txt
+++ b/test/snapshots/analyze/ternary_test/test_0006_multiple_ternary_operators_in_same_ERB_tag_7dd1d18fe401ed6c61c478be9ee5140f.txt
@@ -1,0 +1,11 @@
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ ERBContentNode (location: (1:0)-(1:93))
+    │   ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   ├── content: " link_to (user.admin? ? "Admin" : "User"), (user.active? ? active_path : inactive_path) " (location: (1:3)-(1:91))
+    │   ├── tag_closing: "%>" (location: (1:91)-(1:93))
+    │   ├── parsed: true
+    │   └── valid: true
+    │
+    └── @ HTMLTextNode (location: (1:93)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/ternary_test/test_0007_ternary_operator_with_blocks_a8c8a50604f8821739b2814b58b652f2.txt
+++ b/test/snapshots/analyze/ternary_test/test_0007_ternary_operator_with_blocks_a8c8a50604f8821739b2814b58b652f2.txt
@@ -1,0 +1,19 @@
+@ DocumentNode (location: (1:0)-(4:0))
+└── children: (2 items)
+    ├── @ ERBBlockNode (location: (1:0)-(3:9))
+    │   ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   ├── content: " content_tag :div, class: (visible? ? "show" : "hide") do " (location: (1:3)-(1:61))
+    │   ├── tag_closing: "%>" (location: (1:61)-(1:63))
+    │   ├── body: (1 item)
+    │   │   └── @ HTMLTextNode (location: (1:63)-(3:0))
+    │   │       └── content: "\n  Content\n"
+    │   │
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (3:0)-(3:9))
+    │           ├── tag_opening: "<%" (location: (3:0)-(3:2))
+    │           ├── content: " end " (location: (3:2)-(3:7))
+    │           └── tag_closing: "%>" (location: (3:7)-(3:9))
+    │
+    │
+    └── @ HTMLTextNode (location: (3:9)-(4:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/ternary_test/test_0008_form_with_helper_with_ternary_in_url_parameter_e554d08ac7e5da90cd046d79030c2a44.txt
+++ b/test/snapshots/analyze/ternary_test/test_0008_form_with_helper_with_ternary_in_url_parameter_e554d08ac7e5da90cd046d79030c2a44.txt
@@ -1,0 +1,39 @@
+@ DocumentNode (location: (1:0)-(5:0))
+└── children: (2 items)
+    ├── @ ERBBlockNode (location: (1:0)-(4:9))
+    │   ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   ├── content: " form_with model: @user, url: @user.new_record? ? users_path : user_path(@user), method: @user.new_record? ? :post : :patch do |form| " (location: (1:3)-(1:137))
+    │   ├── tag_closing: "%>" (location: (1:137)-(1:139))
+    │   ├── body: (5 items)
+    │   │   ├── @ HTMLTextNode (location: (1:139)-(2:2))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ ERBContentNode (location: (2:2)-(2:30))
+    │   │   │   ├── tag_opening: "<%=" (location: (2:2)-(2:5))
+    │   │   │   ├── content: " form.text_field :name " (location: (2:5)-(2:28))
+    │   │   │   ├── tag_closing: "%>" (location: (2:28)-(2:30))
+    │   │   │   ├── parsed: true
+    │   │   │   └── valid: true
+    │   │   │
+    │   │   ├── @ HTMLTextNode (location: (2:30)-(3:2))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ ERBContentNode (location: (3:2)-(3:20))
+    │   │   │   ├── tag_opening: "<%=" (location: (3:2)-(3:5))
+    │   │   │   ├── content: " form.submit " (location: (3:5)-(3:18))
+    │   │   │   ├── tag_closing: "%>" (location: (3:18)-(3:20))
+    │   │   │   ├── parsed: true
+    │   │   │   └── valid: true
+    │   │   │
+    │   │   └── @ HTMLTextNode (location: (3:20)-(4:0))
+    │   │       └── content: "\n"
+    │   │
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (4:0)-(4:9))
+    │           ├── tag_opening: "<%" (location: (4:0)-(4:2))
+    │           ├── content: " end " (location: (4:2)-(4:7))
+    │           └── tag_closing: "%>" (location: (4:7)-(4:9))
+    │
+    │
+    └── @ HTMLTextNode (location: (4:9)-(5:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/ternary_test/test_0009_content_tag_with_ternary_for_class_attribute_910f82cb9ee5855d1c51c08667ac90d5.txt
+++ b/test/snapshots/analyze/ternary_test/test_0009_content_tag_with_ternary_for_class_attribute_910f82cb9ee5855d1c51c08667ac90d5.txt
@@ -1,0 +1,11 @@
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ ERBContentNode (location: (1:0)-(1:97))
+    │   ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   ├── content: " content_tag :div, "Hello World", class: current_user.admin? ? "admin-panel" : "user-panel" " (location: (1:3)-(1:95))
+    │   ├── tag_closing: "%>" (location: (1:95)-(1:97))
+    │   ├── parsed: true
+    │   └── valid: true
+    │
+    └── @ HTMLTextNode (location: (1:97)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/ternary_test/test_0010_content_tag_with_ternary_for_data_attribute_6f00128b70c7d3176646995151ecfcaa.txt
+++ b/test/snapshots/analyze/ternary_test/test_0010_content_tag_with_ternary_for_data_attribute_6f00128b70c7d3176646995151ecfcaa.txt
@@ -1,0 +1,15 @@
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ ERBContentNode (location: (1:0)-(1:221))
+    │   ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   ├── content: " content_tag :button, "Click me",
+    │       data: {
+    │         action: @item.published? ? "unpublish" : "publish",
+    │         confirm: @item.published? ? "Are you sure you want to unpublish?" : "Are you sure you want to publish?"
+    │       } " (location: (1:3)-(1:219))
+    │   ├── tag_closing: "%>" (location: (1:219)-(1:221))
+    │   ├── parsed: true
+    │   └── valid: true
+    │
+    └── @ HTMLTextNode (location: (1:221)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/ternary_test/test_0011_form_with_with_complex_ternary_in_multiple_attributes_0db72f423bc1543d78016121e43409d3.txt
+++ b/test/snapshots/analyze/ternary_test/test_0011_form_with_with_complex_ternary_in_multiple_attributes_0db72f423bc1543d78016121e43409d3.txt
@@ -1,0 +1,32 @@
+@ DocumentNode (location: (1:0)-(4:0))
+└── children: (2 items)
+    ├── @ ERBBlockNode (location: (1:0)-(3:9))
+    │   ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   ├── content: " form_with model: @article,
+    │                 url: @article.persisted? ? article_path(@article) : articles_path,
+    │                 html: { class: @article.draft? ? "draft-form" : "published-form" },
+    │                 local: @article.draft? ? true : false do |f| " (location: (1:3)-(1:250))
+    │   ├── tag_closing: "%>" (location: (1:250)-(1:252))
+    │   ├── body: (3 items)
+    │   │   ├── @ HTMLTextNode (location: (1:252)-(2:2))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ ERBContentNode (location: (2:2)-(2:28))
+    │   │   │   ├── tag_opening: "<%=" (location: (2:2)-(2:5))
+    │   │   │   ├── content: " f.text_field :title " (location: (2:5)-(2:26))
+    │   │   │   ├── tag_closing: "%>" (location: (2:26)-(2:28))
+    │   │   │   ├── parsed: true
+    │   │   │   └── valid: true
+    │   │   │
+    │   │   └── @ HTMLTextNode (location: (2:28)-(3:0))
+    │   │       └── content: "\n"
+    │   │
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (3:0)-(3:9))
+    │           ├── tag_opening: "<%" (location: (3:0)-(3:2))
+    │           ├── content: " end " (location: (3:2)-(3:7))
+    │           └── tag_closing: "%>" (location: (3:7)-(3:9))
+    │
+    │
+    └── @ HTMLTextNode (location: (3:9)-(4:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/ternary_test/test_0012_inline_if_modifier_in_ERB_output_tag_b4d740369619f1d7bde41172ac6933e6.txt
+++ b/test/snapshots/analyze/ternary_test/test_0012_inline_if_modifier_in_ERB_output_tag_b4d740369619f1d7bde41172ac6933e6.txt
@@ -1,0 +1,11 @@
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ ERBContentNode (location: (1:0)-(1:42))
+    │   ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   ├── content: " render 'partial' if user_signed_in? " (location: (1:3)-(1:40))
+    │   ├── tag_closing: "%>" (location: (1:40)-(1:42))
+    │   ├── parsed: true
+    │   └── valid: true
+    │
+    └── @ HTMLTextNode (location: (1:42)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/ternary_test/test_0013_inline_unless_modifier_in_ERB_output_tag_982863841843053cc3728f62e00fa523.txt
+++ b/test/snapshots/analyze/ternary_test/test_0013_inline_unless_modifier_in_ERB_output_tag_982863841843053cc3728f62e00fa523.txt
@@ -1,0 +1,11 @@
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ ERBContentNode (location: (1:0)-(1:64))
+    │   ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   ├── content: " link_to "Home", root_path unless current_page?(root_path) " (location: (1:3)-(1:62))
+    │   ├── tag_closing: "%>" (location: (1:62)-(1:64))
+    │   ├── parsed: true
+    │   └── valid: true
+    │
+    └── @ HTMLTextNode (location: (1:64)-(2:0))
+        └── content: "\n"


### PR DESCRIPTION
This pull request fixes an issue where ternary operators in `ERBContentNode` were incorrectly transformed into `ERBIfNode` structures. The parser now properly distinguishes between ternary operators and regular if statements by checking if the `if_keyword_loc` is present in the Prism AST node.

```erb
<%= form_with model: @post, url: @post.new_record? ? posts_path : post_path(@post) do |f| %>
  Content
<% end %>
```

Now:
```js
@ DocumentNode (location: (1:0)-(4:0))
└── children: (2 items)
    ├── @ ERBBlockNode (location: (1:0)-(3:9))
    │   ├── tag_opening: "<%=" (location: (1:0)-(1:3))
    │   ├── content: " form_with model: @post, url: @post.new_record? ? posts_path : post_path(@post) do |f| " (location: (1:3)-(1:90))
    │   ├── tag_closing: "%>" (location: (1:90)-(1:92))
    │   ├── body: (1 item)
    │   │   └── @ HTMLTextNode (location: (1:92)-(3:0))
    │   │       └── content: "\n  Content\n"
    │   │
    │   └── end_node:
    │       └── @ ERBEndNode (location: (3:0)-(3:9))
    │           ├── tag_opening: "<%" (location: (3:0)-(3:2))
    │           ├── content: " end " (location: (3:2)-(3:7))
    │           └── tag_closing: "%>" (location: (3:7)-(3:9))
    │
    │
    └── @ HTMLTextNode (location: (3:9)-(4:0))
        └── content: "\n"
```

Before:
```js
@ DocumentNode (location: (1:0)-(3:9))
├── errors: []
└── children: (1 item)
    └── @ ERBIfNode (location: (1:0)-(3:9))
        ├── errors: []
        ├── tag_opening: "<%=" (location: (1:0)-(1:3))
        ├── content: " form_with model: @post, url: @post.new_record? ? posts_path : post_path(@post) do |f| " (location: (1:3)-(1:90))
        ├── tag_closing: "%>" (location: (1:90)-(1:92))
        ├── statements: (1 item)
        │   └── @ HTMLTextNode (location: (1:92)-(3:0))
        │       ├── errors: []
        │       └── content: "\n  Content\n"
        │       
        │   
        ├── subsequent: ∅
        └── end_node: 
            └── @ ERBEndNode (location: (3:0)-(3:9))
                ├── errors: []
                ├── tag_opening: "<%" (location: (3:0)-(3:2))
                ├── content: " end " (location: (3:2)-(3:7))
                └── tag_closing: "%>" (location: (3:7)-(3:9))
```

Resolves #217.