### PR TITLE
Fix error in language server when linter settings are not provided

### DIFF
--- a/javascript/packages/language-server/package.json
+++ b/javascript/packages/language-server/package.json
@@ -34,8 +34,9 @@
     "clean": "rimraf dist",
     "build": "yarn clean && tsc -b && rollup -c",
     "dev": "tsc -b -w",
-    "test": "echo 'TODO: add tests'",
-    "prepublishOnly": "yarn clean && yarn build && yarn test"
+    "test": "vitest",
+    "test:run": "vitest run",
+    "prepublishOnly": "yarn clean && yarn build && yarn test:run"
   },
   "files": [
     "package.json",
@@ -51,5 +52,8 @@
     "dedent": "^1.6.0",
     "vscode-languageserver": "^9.0.1",
     "vscode-languageserver-textdocument": "^1.0.12"
+  },
+  "devDependencies": {
+    "vitest": "^1.0.0"
   }
 }

--- a/javascript/packages/language-server/src/linter_service.ts
+++ b/javascript/packages/language-server/src/linter_service.ts
@@ -22,7 +22,7 @@ export class LinterService {
 
   async lintDocument(document: DocumentNode, textDocument: TextDocument): Promise<LintServiceResult> {
     const settings = await this.settings.getDocumentSettings(textDocument.uri)
-    const linterEnabled = settings.linter?.enabled ?? true
+    const linterEnabled = settings?.linter?.enabled ?? true
 
     if (!linterEnabled) {
       return { diagnostics: [] }

--- a/javascript/packages/language-server/src/settings.ts
+++ b/javascript/packages/language-server/src/settings.ts
@@ -20,6 +20,9 @@ export class Settings {
   // Please note that this is not the case when using this server with the client provided in this example
   // but could happen with other clients.
   defaultSettings: HerbSettings = {
+    linter: {
+      enabled: true
+    },
     formatter: {
       enabled: false,
       indentWidth: defaultFormatOptions.indentWidth,

--- a/javascript/packages/language-server/test/linter_service.test.ts
+++ b/javascript/packages/language-server/test/linter_service.test.ts
@@ -1,0 +1,113 @@
+import { describe, test, expect, vi, beforeAll } from "vitest"
+
+import { TextDocument } from "vscode-languageserver-textdocument"
+
+import { LinterService } from "../src/linter_service"
+import { Settings } from "../src/settings"
+import { Herb } from "@herb-tools/node-wasm"
+
+import type { Connection, InitializeParams } from "vscode-languageserver/node"
+
+describe("LinterService", () => {
+  beforeAll(async () => {
+    await Herb.load()
+  })
+
+  const mockConnection = {
+    workspace: {
+      getConfiguration: vi.fn()
+    }
+  } as unknown as Connection
+
+  const mockParams: InitializeParams = {
+    processId: null,
+    rootUri: null,
+    capabilities: {},
+    workspaceFolders: null
+  }
+
+  const createTestDocument = (content: string) => {
+    return TextDocument.create("file:///test.html.erb", "erb", 1, content)
+  }
+
+  describe("lintDocument", () => {
+    test("handles null settings gracefully", async () => {
+      const settings = new Settings(mockParams, mockConnection)
+      settings.getDocumentSettings = vi.fn().mockResolvedValue(null)
+
+      const linterService = new LinterService(settings)
+      const parseResult = Herb.parse("<div>Test</div>")
+      const document = parseResult.value
+      const textDocument = createTestDocument("<div>Test</div>")
+
+      const result = await linterService.lintDocument(document, textDocument)
+
+      expect(result).toBeDefined()
+      expect(result.diagnostics).toEqual([])
+    })
+
+    test("handles undefined linter settings", async () => {
+      const settings = new Settings(mockParams, mockConnection)
+      settings.getDocumentSettings = vi.fn().mockResolvedValue({
+        formatter: { enabled: true }
+        // linter is undefined
+      })
+
+      const linterService = new LinterService(settings)
+      const parseResult = Herb.parse("<div>Test</div>")
+      const document = parseResult.value
+      const textDocument = createTestDocument("<div>Test</div>")
+
+      const result = await linterService.lintDocument(document, textDocument)
+
+      expect(result).toBeDefined()
+      expect(result.diagnostics).toBeDefined()
+    })
+
+    test("respects linter.enabled = false", async () => {
+      const settings = new Settings(mockParams, mockConnection)
+      settings.getDocumentSettings = vi.fn().mockResolvedValue({
+        linter: { enabled: false }
+      })
+
+      const linterService = new LinterService(settings)
+      const parseResult = Herb.parse("<DIV>Test</DIV>")
+      const document = parseResult.value
+      const textDocument = createTestDocument("<DIV>Test</DIV>")
+
+      const result = await linterService.lintDocument(document, textDocument)
+
+      expect(result.diagnostics).toEqual([])
+    })
+
+    test("lints when linter.enabled = true", async () => {
+      const settings = new Settings(mockParams, mockConnection)
+      settings.getDocumentSettings = vi.fn().mockResolvedValue({
+        linter: { enabled: true }
+      })
+
+      const linterService = new LinterService(settings)
+      const parseResult = Herb.parse("<DIV><SPAN>Hello</SPAN></DIV>")
+      const document = parseResult.value
+      const textDocument = createTestDocument("<DIV><SPAN>Hello</SPAN></DIV>")
+
+      const result = await linterService.lintDocument(document, textDocument)
+
+      expect(result.diagnostics.length).toBeGreaterThan(0)
+    })
+
+    test("uses default settings when no configuration is provided", async () => {
+      const settings = new Settings(mockParams, mockConnection)
+      settings.hasConfigurationCapability = false
+
+      const linterService = new LinterService(settings)
+      const parseResult = Herb.parse("<DIV>Test</DIV>")
+      const document = parseResult.value
+      const textDocument = createTestDocument("<DIV>Test</DIV>")
+
+      const result = await linterService.lintDocument(document, textDocument)
+
+      expect(result.diagnostics.length).toBeGreaterThan(0)
+    })
+  })
+})

--- a/javascript/packages/language-server/test/settings.test.ts
+++ b/javascript/packages/language-server/test/settings.test.ts
@@ -1,0 +1,94 @@
+import { describe, test, expect, vi } from "vitest"
+import { Settings } from "../src/settings"
+import type { Connection, InitializeParams } from "vscode-languageserver/node"
+
+describe("Settings", () => {
+  const mockConnection = {
+    workspace: {
+      getConfiguration: vi.fn()
+    }
+  } as unknown as Connection
+
+  const mockParams: InitializeParams = {
+    processId: null,
+    rootUri: null,
+    capabilities: {},
+    workspaceFolders: null
+  }
+
+  describe("defaultSettings", () => {
+    test("includes linter configuration with enabled: true", () => {
+      const settings = new Settings(mockParams, mockConnection)
+
+      expect(settings.defaultSettings).toBeDefined()
+      expect(settings.defaultSettings.linter).toBeDefined()
+      expect(settings.defaultSettings.linter?.enabled).toBe(true)
+    })
+
+    test("includes formatter configuration", () => {
+      const settings = new Settings(mockParams, mockConnection)
+
+      expect(settings.defaultSettings.formatter).toBeDefined()
+      expect(settings.defaultSettings.formatter?.enabled).toBe(false)
+      expect(settings.defaultSettings.formatter?.indentWidth).toBeDefined()
+      expect(settings.defaultSettings.formatter?.maxLineLength).toBeDefined()
+    })
+  })
+
+  describe("getDocumentSettings", () => {
+    test("returns defaultSettings when hasConfigurationCapability is false", async () => {
+      const settings = new Settings(mockParams, mockConnection)
+      settings.hasConfigurationCapability = false
+
+      const result = await settings.getDocumentSettings("file:///test.html.erb")
+
+      expect(result).toEqual(settings.defaultSettings)
+      expect(result.linter?.enabled).toBe(true)
+    })
+
+    test("returns workspace configuration when hasConfigurationCapability is true", async () => {
+      const paramsWithConfig: InitializeParams = {
+        ...mockParams,
+        capabilities: {
+          workspace: {
+            configuration: true
+          }
+        }
+      }
+
+      const customSettings = {
+        linter: { enabled: false },
+        formatter: { enabled: true }
+      }
+
+      mockConnection.workspace.getConfiguration = vi.fn().mockResolvedValue(customSettings)
+
+      const settings = new Settings(paramsWithConfig, mockConnection)
+      const result = await settings.getDocumentSettings("file:///test.erb")
+
+      expect(result).toEqual(customSettings)
+      expect(mockConnection.workspace.getConfiguration).toHaveBeenCalledWith({
+        scopeUri: "file:///test.erb",
+        section: "languageServerHerb"
+      })
+    })
+
+    test("handles null settings gracefully", async () => {
+      const paramsWithConfig: InitializeParams = {
+        ...mockParams,
+        capabilities: {
+          workspace: {
+            configuration: true
+          }
+        }
+      }
+
+      mockConnection.workspace.getConfiguration = vi.fn().mockResolvedValue(null)
+
+      const settings = new Settings(paramsWithConfig, mockConnection)
+      const result = await settings.getDocumentSettings("file:///test.erb")
+
+      expect(result).toBeNull()
+    })
+  })
+})


### PR DESCRIPTION
Add default linter configuration to prevent TypeError when clients like Helix don't provide settings configuration. This ensures the language server works out of the box without requiring a `.herb-lsp/config.json` file.

Fixes #244