### PR TITLE
docs: add documentation for using Herb in Sublime Text via Sublime LSP

### DIFF
--- a/docs/.vitepress/config/theme.mts
+++ b/docs/.vitepress/config/theme.mts
@@ -93,6 +93,7 @@ export function createThemeConfig() {
             { text: "Helix", link: "/integrations/editors/helix" },
             { text: "Neovim", link: "/integrations/editors/neovim" },
             { text: "RubyMine", link: "/integrations/editors/rubymine" },
+            { text: "Sublime Text", link: "/integrations/editors/sublime" },
             { text: "Vim", link: "/integrations/editors/vim" },
             { text: "Visual Studio Code", link: "/integrations/editors/vscode" },
             { text: "Zed", link: "/integrations/editors/zed" },

--- a/docs/docs/integrations/editors.md
+++ b/docs/docs/integrations/editors.md
@@ -9,6 +9,7 @@ The Herb Language Server provides intelligent language features for HTML+ERB fil
 - **[Cursor](/integrations/editors/cursor)** - Available through the Open VSX Registry
 - **[Helix](/integrations/editors/helix)** - Terminal-based modal editor with built-in LSP support
 - **[Neovim](/integrations/editors/neovim)** - LSP configuration with multiple setup options
+- **[Sublime Text](/integrations/editors/sublime)** - LSP configuration using Sublime LSP
 - **[Vim](/integrations/editors/vim)** - Traditional Vim integration
 - **[Visual Studio Code](/integrations/editors/vscode)** - Full-featured extension available on the Visual Studio Marketplace
 - **[Zed](/integrations/editors/zed)** - Built into the official Ruby extension

--- a/docs/docs/integrations/editors/sublime.md
+++ b/docs/docs/integrations/editors/sublime.md
@@ -1,0 +1,74 @@
+# Using Herb with Sublime Text
+
+Configure the Herb Language Server with Sublime Text (via [Sublime LSP](https://lsp.sublimetext.io)) for HTML+ERB development.
+
+![Herb with Sublime Text](/herb-sublime.png)
+
+## Installation
+
+*These instructions assume that you have already installed [Sublime LSP](https://lsp.sublimetext.io)*
+
+### Manual Configuration
+
+First, install the Herb Language Server globally:
+
+:::code-group
+
+```bash [npm]
+npm install -g @herb-tools/language-server
+```
+
+```bash [yarn]
+yarn global add @herb-tools/language-server
+```
+
+```bash [pnpm]
+pnpm add -g @herb-tools/language-server
+```
+
+```bash [bun]
+bun add -g @herb-tools/language-server
+```
+:::
+
+Then add the `herb` client via the `LSP` package preferences:
+
+```json
+// LSP.sublime-settings
+{
+  "clients": {
+    "herb": {
+      "enabled": true,
+      "command": [
+        "herb-language-server",
+        "--stdio"
+      ],
+      "selector": "text.html.ruby | text.html.rails",
+      "settings": {
+        "languageServerHerb.linter": {
+          "enabled": true
+        }
+      },
+      "initializationOptions": {
+        "enabledFeatures": {
+          "diagnostics": true,
+        },
+        "experimentalFeaturesEnabled": true
+      }
+    }
+  },
+}
+```
+
+## Troubleshooting
+
+Ensure the language server is in your PATH:
+```bash
+which herb-language-server
+```
+
+Check your LSP client's documentation for debugging commands.
+
+## Other editors
+
+If you are looking to use Herb in another editor, check out the instructions on the [editor integrations page](/integrations/editors).

--- a/javascript/packages/language-server/README.md
+++ b/javascript/packages/language-server/README.md
@@ -33,6 +33,37 @@ require('lspconfig')
 vim.lsp.enable('herb_ls')
 ```
 
+#### Sublime Text (using Sublime LSP)
+
+After installing the Herb Language Server (see below) and [Sublime LSP](http://lsp.sublimetext.io), update the preferences for the `LSP` package:
+
+```json
+// LSP.sublime-settings
+{
+  "clients": {
+    "herb": {
+      "enabled": true,
+      "command": [
+        "herb-language-server",
+        "--stdio"
+      ],
+      "selector": "text.html.ruby | text.html.rails",
+      "settings": {
+        "languageServerHerb.linter": {
+          "enabled": true
+        }
+      },
+      "initializationOptions": {
+        "enabledFeatures": {
+          "diagnostics": true,
+        },
+        "experimentalFeaturesEnabled": true
+      }
+    }
+  },
+}
+```
+
 #### Manual Installation
 
 You can use the language server in any editor that supports the [Language Server Protocol](https://microsoft.github.io/language-server-protocol/).


### PR DESCRIPTION
Just what the title says! Uses the logo from https://github.com/marcoroth/herb/commit/be53b87d2ab98b604704a7ec35862d260a07a548