### PR TITLE
VS Code Extension: Fix worker bundling for VSIX distribution

### DIFF
--- a/javascript/packages/vscode/esbuild.js
+++ b/javascript/packages/vscode/esbuild.js
@@ -43,17 +43,32 @@ async function main() {
       copy({
         assets: [
           { from: '../language-server/dist/herb-language-server.js', to: ['./'] },
-          { from: 'src/parse-worker.js', to: ['./'] },
         ],
       })
     ],
   })
 
+  const workerCtx = await esbuild.context({
+    entryPoints: ['src/parse-worker.js'],
+    bundle: true,
+    format: 'cjs',
+    minify: production,
+    sourcemap: !production,
+    sourcesContent: false,
+    platform: 'node',
+    outfile: 'dist/parse-worker.js',
+    external: [],
+    logLevel: 'silent',
+  })
+
   if (watch) {
     await ctx.watch()
+    await workerCtx.watch()
   } else {
     await ctx.rebuild()
+    await workerCtx.rebuild()
     await ctx.dispose()
+    await workerCtx.dispose()
   }
 }
 

--- a/javascript/packages/vscode/src/parse-worker.js
+++ b/javascript/packages/vscode/src/parse-worker.js
@@ -1,4 +1,6 @@
 const fs = require('fs');
+const { Herb } = require('@herb-tools/node-wasm');
+const { Linter } = require('@herb-tools/linter');
 
 (async () => {
   const file = process.argv[2];
@@ -21,9 +23,6 @@ const fs = require('fs');
     const originalConsoleError = console.error;
     console.log = () => {};
     console.error = () => {};
-
-    const { Herb } = await import('@herb-tools/node-wasm');
-    const { Linter } = await import('@herb-tools/linter');
 
     await Herb.load();
 
@@ -68,7 +67,6 @@ const fs = require('fs');
     };
 
     try {
-      const { Herb } = await import('@herb-tools/node-wasm');
       if (Herb && Herb.version) {
         result.version = Herb.version;
       }


### PR DESCRIPTION
The Herb version installed from the visual studio extension store would show all files as "parse errors". This pull request:

- replaces dynamic imports with static requires in parse-worker.js
- bundles worker separately with all dependencies using esbuild
- removes simple file copy in favor of proper bundling

This ensures the worker functions correctly when the extension is installed from a VSIX file.