### PR TITLE
Formatter: Keep simple element children inline instead of splitting them up

### DIFF
--- a/javascript/packages/formatter/src/cli.ts
+++ b/javascript/packages/formatter/src/cli.ts
@@ -105,13 +105,16 @@ export class CLI {
               try {
                 const source = readFileSync(filePath, "utf-8")
                 const result = formatter.format(source)
-                if (result !== source) {
+                const output = result.endsWith('\n') ? result : result + '\n'
+
+                if (output !== source) {
                   if (isCheckMode) {
                     unformattedFiles.push(filePath)
                   } else {
-                    writeFileSync(filePath, result, "utf-8")
+                    writeFileSync(filePath, output, "utf-8")
                     console.log(`Formatted: ${filePath}`)
                   }
+
                   formattedCount++
                 }
               } catch (error) {
@@ -134,13 +137,14 @@ export class CLI {
           } else {
             const source = readFileSync(file, "utf-8")
             const result = formatter.format(source)
+            const output = result.endsWith('\n') ? result : result + '\n'
 
-            if (result !== source) {
+            if (output !== source) {
               if (isCheckMode) {
                 console.log(`File is not formatted: ${file}`)
                 process.exit(1)
               } else {
-                writeFileSync(file, result, "utf-8")
+                writeFileSync(file, output, "utf-8")
                 console.log(`Formatted: ${file}`)
               }
             } else if (isCheckMode) {
@@ -169,12 +173,13 @@ export class CLI {
           try {
             const source = readFileSync(filePath, "utf-8")
             const result = formatter.format(source)
+            const output = result.endsWith('\n') ? result : result + '\n'
 
-            if (result !== source) {
+            if (output !== source) {
               if (isCheckMode) {
                 unformattedFiles.push(filePath)
               } else {
-                writeFileSync(filePath, result, "utf-8")
+                writeFileSync(filePath, output, "utf-8")
                 console.log(`Formatted: ${filePath}`)
               }
               formattedCount++

--- a/javascript/packages/formatter/src/printer.ts
+++ b/javascript/packages/formatter/src/printer.ts
@@ -178,6 +178,20 @@ export class Printer extends Visitor {
         return
       }
 
+      if (children.length === 1) {
+        const child = children[0]
+
+        if (child instanceof HTMLTextNode || (child as any).type === 'AST_HTML_TEXT_NODE') {
+          const textContent = (child as HTMLTextNode).content.trim()
+          const singleLine = `<${tagName}>${textContent}</${tagName}>`
+
+          if (!textContent.includes('\n') && (indent.length + singleLine.length) <= this.maxLineLength) {
+            this.push(indent + singleLine)
+            return
+          }
+        }
+      }
+
       this.push(indent + `<${tagName}>`)
 
       this.withIndent(() => {

--- a/javascript/packages/formatter/src/printer.ts
+++ b/javascript/packages/formatter/src/printer.ts
@@ -259,7 +259,6 @@ export class Printer extends Visitor {
     )
 
     const shouldKeepInline = (attributes.length <= 3 &&
-                            !hasEmptyValue &&
                             inline.length + indent.length <= this.maxLineLength) ||
                             (inlineNodes.length > 0 && !hasERBControlFlow)
 
@@ -399,7 +398,6 @@ export class Printer extends Visitor {
       (singleAttribute.value as any)?.children.length === 0
 
     const shouldKeepInline = attributes.length <= 3 &&
-                            !hasEmptyValue &&
                             inline.length + indent.length <= this.maxLineLength
 
     if (shouldKeepInline) {

--- a/javascript/packages/formatter/test/cli.test.ts
+++ b/javascript/packages/formatter/test/cli.test.ts
@@ -183,7 +183,7 @@ describe("CLI Binary", () => {
 
   it("should only show formatted message when file changes", async () => {
     const testFile = "test-unchanged.html.erb"
-    const input = '<div>Already formatted</div>'
+    const input = '<div>Already formatted</div>\n'
 
     await writeFile(testFile, input)
 
@@ -202,7 +202,7 @@ describe("CLI Binary", () => {
 
   it("should show formatted message when file changes", async () => {
     const testFile = "test-changed.html.erb"
-    const input = '<div><p>Unformatted</p></div>'
+    const input = '<div><p>   Unformatted   </p></div>'
 
     await writeFile(testFile, input)
 
@@ -236,7 +236,7 @@ describe("CLI Binary", () => {
   it("should handle directory with files", async () => {
     await mkdir("test-dir", { recursive: true })
     const testFile = join("test-dir", "test.html.erb")
-    const input = '<div><p>Test</p></div>'
+    const input = '<div><p>   Test   </p></div>'
 
     await writeFile(testFile, input)
 
@@ -303,7 +303,7 @@ describe("CLI Binary", () => {
 
   it("should pass --check when file is already formatted", async () => {
     const testFile = "test-formatted.html.erb"
-    const input = '<div>\n  <p>Already formatted</p>\n</div>'
+    const input = '<div><p>Already formatted</p></div>\n'
 
     await writeFile(testFile, input)
 
@@ -319,7 +319,7 @@ describe("CLI Binary", () => {
 
   it("should fail --check when file is not formatted", async () => {
     const testFile = "test-unformatted.html.erb"
-    const input = '<div><p>Not formatted</p></div>'
+    const input = '<div><p>   Not formatted   </p></div>'
 
     await writeFile(testFile, input)
 
@@ -338,8 +338,8 @@ describe("CLI Binary", () => {
     const formattedFile = join("test-dir", "formatted.html.erb")
     const unformattedFile = join("test-dir", "unformatted.html.erb")
 
-    await writeFile(formattedFile, '<div>\n  <p>Formatted</p>\n</div>')
-    await writeFile(unformattedFile, '<div   ><p>Unformatted</p></div>')
+    await writeFile(formattedFile, '<div><p>Formatted</p></div>\n')
+    await writeFile(unformattedFile, '<div><p>   Unformatted   </p></div>')
 
     try {
       const result = await execBinary(["--check", "test-dir"])

--- a/javascript/packages/formatter/test/cli.test.ts
+++ b/javascript/packages/formatter/test/cli.test.ts
@@ -143,9 +143,7 @@ describe("CLI Binary", () => {
       const formattedContent = await readFile(testFile, 'utf-8')
       expect(formattedContent).toContain('<div class="container">')
       expect(formattedContent).toContain('  <%= "Hello" %>')
-      expect(formattedContent).toContain('  <p>')
-      expect(formattedContent).toContain('    World')
-      expect(formattedContent).toContain('  </p>')
+      expect(formattedContent).toContain('  <p>World</p>')
       expect(formattedContent).toContain('</div>')
     } finally {
       await unlink(testFile).catch(() => {})
@@ -185,7 +183,7 @@ describe("CLI Binary", () => {
 
   it("should only show formatted message when file changes", async () => {
     const testFile = "test-unchanged.html.erb"
-    const input = '<div>\n  Already formatted\n</div>'
+    const input = '<div>Already formatted</div>'
 
     await writeFile(testFile, input)
 
@@ -305,7 +303,7 @@ describe("CLI Binary", () => {
 
   it("should pass --check when file is already formatted", async () => {
     const testFile = "test-formatted.html.erb"
-    const input = '<div>\n  <p>\n    Already formatted\n  </p>\n</div>'
+    const input = '<div>\n  <p>Already formatted</p>\n</div>'
 
     await writeFile(testFile, input)
 
@@ -340,8 +338,8 @@ describe("CLI Binary", () => {
     const formattedFile = join("test-dir", "formatted.html.erb")
     const unformattedFile = join("test-dir", "unformatted.html.erb")
 
-    await writeFile(formattedFile, '<div>\n  <p>\n    Formatted\n  </p>\n</div>')
-    await writeFile(unformattedFile, '<div><p>Unformatted</p></div>')
+    await writeFile(formattedFile, '<div>\n  <p>Formatted</p>\n</div>')
+    await writeFile(unformattedFile, '<div   ><p>Unformatted</p></div>')
 
     try {
       const result = await execBinary(["--check", "test-dir"])
@@ -363,11 +361,11 @@ describe("CLI Binary", () => {
     expectExitCode(result, 0)
     expect(result.stdout.endsWith('\n')).toBe(true)
     expect(result.stdout).toContain("⚠️  Experimental Preview")
-    expect(result.stdout).toContain('<div>\n  Hello\n</div>')
+    expect(result.stdout).toContain('<div>Hello</div>')
 
     const lines = result.stdout.split('\n')
     const formattedLines = lines.slice(2) // Skip experimental preview lines
-    expect(formattedLines.join('\n')).toBe('<div>\n  Hello\n</div>\n')
+    expect(formattedLines.join('\n')).toBe('<div>Hello</div>\n')
   })
 
   it("CLI should preserve existing trailing newline", async () => {
@@ -377,11 +375,11 @@ describe("CLI Binary", () => {
     expectExitCode(result, 0)
     expect(result.stdout.endsWith('\n')).toBe(true)
     expect(result.stdout).toContain("⚠️  Experimental Preview")
-    expect(result.stdout).toContain('<div>\n  Hello\n</div>')
+    expect(result.stdout).toContain('<div>Hello</div>')
 
     const lines = result.stdout.split('\n')
     const formattedLines = lines.slice(2) // Skip experimental preview lines
-    expect(formattedLines.join('\n')).toBe('<div>\n  Hello\n</div>\n')
+    expect(formattedLines.join('\n')).toBe('<div>Hello</div>\n')
   })
 
   it("CLI should add trailing newline to empty input", async () => {

--- a/javascript/packages/formatter/test/erb/erb.test.ts
+++ b/javascript/packages/formatter/test/erb/erb.test.ts
@@ -17,12 +17,10 @@ describe("@herb-tools/formatter", () => {
   })
 
   test("formats simple HTML with ERB content", () => {
-    const source = '<div><%= "Hello" %></div>'
+    const source = '<div><%= "Hello" %> World</div>'
     const result = formatter.format(source)
     expect(result).toEqual(dedent`
-      <div>
-        <%= "Hello" %>
-      </div>
+      <div><%= "Hello" %> World</div>
     `)
   })
 
@@ -50,6 +48,24 @@ describe("@herb-tools/formatter", () => {
             <span>NO</span>
           <% end %>
         <% end %>
+      </div>
+    `)
+  })
+
+  test("preserves ERB within HTML attributes and content", () => {
+    const source = dedent`
+      <div>
+        <h1 class="<%= classes %>">
+          <%= title %>
+        </h1>
+      </div>
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <div>
+        <h1 class="<%= classes %>">
+          <%= title %>
+        </h1>
       </div>
     `)
   })

--- a/javascript/packages/formatter/test/erb/erb.test.ts
+++ b/javascript/packages/formatter/test/erb/erb.test.ts
@@ -45,13 +45,9 @@ describe("@herb-tools/formatter", () => {
       <div id="output">
         <%= tag.div class: "div" do %>
           <% if true %>
-            <span>
-              OK
-            </span>
+            <span>OK</span>
           <% else %>
-            <span>
-              NO
-            </span>
+            <span>NO</span>
           <% end %>
         <% end %>
       </div>

--- a/javascript/packages/formatter/test/erb/for.test.ts
+++ b/javascript/packages/formatter/test/erb/for.test.ts
@@ -24,9 +24,7 @@ describe("@herb-tools/formatter", () => {
 
     expect(result).toEqual(dedent`
       <% for item in list %>
-        <li>
-          <%= item.name %>
-        </li>
+        <li><%= item.name %></li>
       <% end %>
     `)
   })

--- a/javascript/packages/formatter/test/erb/until.test.ts
+++ b/javascript/packages/formatter/test/erb/until.test.ts
@@ -23,9 +23,7 @@ describe("@herb-tools/formatter", () => {
     const result = formatter.format(source)
     expect(result).toEqual(dedent`
       <% until i == 3 %>
-        <b>
-          <%= i %>
-        </b>
+        <b><%= i %></b>
         <% i += 1 %>
       <% end %>
     `)

--- a/javascript/packages/formatter/test/erb/while.test.ts
+++ b/javascript/packages/formatter/test/erb/while.test.ts
@@ -23,9 +23,7 @@ describe("@herb-tools/formatter", () => {
     const result = formatter.format(source)
     expect(result).toEqual(dedent`
       <% while i < 3 %>
-        <b>
-          <%= i %>
-        </b>
+        <b><%= i %></b>
         <% i += 1 %>
       <% end %>
     `)

--- a/javascript/packages/formatter/test/html/attributes.test.ts
+++ b/javascript/packages/formatter/test/html/attributes.test.ts
@@ -61,14 +61,37 @@ describe("@herb-tools/formatter", () => {
     `)
   })
 
-  test("formats tags with empty attribute values", () => {
+  test("keeps empty attribute values inline when ≤3 attributes", () => {
     const source = dedent`
       <div id=""></div>
     `
     const result = formatter.format(source)
     expect(result).toEqual(dedent`
+      <div id=""></div>
+    `)
+  })
+
+  test("keeps multiple empty attributes inline when <= 3 attributes", () => {
+    const source = dedent`
+      <div id="" class="" data-value=""></div>
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <div id="" class="" data-value=""></div>
+    `)
+  })
+
+  test("splits multiple empty attributes inline when > 3 attributes", () => {
+    const source = dedent`
+      <div id="" class="" data-value="" another-value=""></div>
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
       <div
         id=""
+        class=""
+        data-value=""
+        another-value=""
       ></div>
     `)
   })

--- a/javascript/packages/formatter/test/html/text-content.test.ts
+++ b/javascript/packages/formatter/test/html/text-content.test.ts
@@ -32,8 +32,42 @@ describe("@herb-tools/formatter", () => {
     `
     const result = formatter.format(source)
     expect(result).toEqual(dedent`
+      <div>Hello</div>
+    `)
+  })
+
+  test("short text content stays inline", () => {
+    const source = dedent`
+      <h1>hello</h1>
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <h1>hello</h1>
+    `)
+  })
+
+  test("long text content splits across lines", () => {
+    const source = dedent`
+      <h1>This is a very long text that should probably be split across multiple lines because it exceeds the max line length</h1>
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <h1>
+        This is a very long text that should probably be split across multiple lines
+        because it exceeds the max line length
+      </h1>
+    `)
+  })
+
+  test("multiline text content splits across lines", () => {
+    const source = dedent`
+      <div>Multi
+      line</div>
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
       <div>
-        Hello
+        Multi line
       </div>
     `)
   })

--- a/javascript/packages/formatter/test/html/text-content.test.ts
+++ b/javascript/packages/formatter/test/html/text-content.test.ts
@@ -71,4 +71,76 @@ describe("@herb-tools/formatter", () => {
       </div>
     `)
   })
+
+  test("mixed inline content stays inline", () => {
+    const source = dedent`
+      <p>hello <b>bold</b> world</p>
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <p>hello <b>bold</b> world</p>
+    `)
+  })
+
+  test("simple mixed content with multiple elements stays inline", () => {
+    const source = dedent`
+      <p>A <b>bold</b> and <i>italic</i> text</p>
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <p>A <b>bold</b> and <i>italic</i> text</p>
+    `)
+  })
+
+  test("any tag can be inline when content is simple", () => {
+    const source = dedent`
+      <div>Simple <section>nested</section> content</div>
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <div>Simple <section>nested</section> content</div>
+    `)
+  })
+
+  test("mixed content with nested elements splits when too deep", () => {
+    const source = dedent`
+      <p>hello <div>complex <span>nested</span> content</div> world</p>
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <p>
+        hello
+        <div>
+          complex
+          <span>nested</span>
+          content
+        </div>
+        world
+      </p>
+    `)
+  })
+
+  test("single level nesting stays inline", () => {
+    const source = dedent`
+      <h1><b>hello</b></h1>
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <h1><b>hello</b></h1>
+    `)
+  })
+
+  test("deep nesting splits across lines", () => {
+    const source = dedent`
+      <h1><b><i>hello</i></b></h1>
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <h1>
+        <b>
+          <i>hello</i>
+        </b>
+      </h1>
+    `)
+  })
 })

--- a/javascript/packages/formatter/test/options.test.ts
+++ b/javascript/packages/formatter/test/options.test.ts
@@ -18,11 +18,14 @@ describe("@herb-tools/formatter", () => {
 
   test("respects indentWidth option", () => {
     const source = dedent`
-      <div><%= "World" %></div>
+      <div><b><i>Hello</i></b> <%= "World" %></div>
     `
     const result = formatter.format(source, { indentWidth: 4 })
     expect(result).toEqual(dedent`
       <div>
+          <b>
+              <i>Hello</i>
+          </b>
           <%= "World" %>
       </div>
     `)


### PR DESCRIPTION
This pull request improves the formatter to make smarter decisions when inlining/splitting the line based on content complexity and nesting depth.

**Simple elements now stay inline**

  Before:
```html
  <h1>
    hello
  </h1>

  <div>
    Hello World
  </div>

  <p>
    Simple text
  </p>
```

  After:
```html
  <h1>hello</h1>

  <div>Hello World</div>

  <p>Simple text</p>
```

**Mixed content with inline elements stays inline**

  Before:
```html
  <p>
    hello
    <b>
      bold
    </b>
     world
  </p>

  <div>
    Text with
    <strong>
      strong
    </strong>
     and
    <em>
      emphasis
    </em>
  </div>
```

  After:
```html
  <p>hello <b>bold</b> world</p>

  <div>Text with <strong>strong</strong> and <em>emphasis</em></div>
```

**Deep nesting (2+ levels) splits appropriately**

  Before:
```html
  <h1>
    <b>
      <i>
        hello
      </i>
    </b>
  </h1>
```

After:
```html
  <h1>
    <b>
      <i>hello</i>
    </b>
  </h1>
```

**Any tag can be inline-friendly based on content complexity**

  Before:
```html
  <section>
    <article>
      Simple content
    </article>
  </section>
```

  After:
```html
  <section><article>Simple content</article></section>
```