### PR TITLE
Fix how to instantiate specific rules in the Javascript customization example

### DIFF
--- a/javascript/packages/linter/README.md
+++ b/javascript/packages/linter/README.md
@@ -25,9 +25,7 @@ By default, all rules are enabled. You can customize the rules by passing a cust
 import { Linter, HTMLTagNameLowercaseRule } from "@herb-tools/linter"
 
 // Only run specific rules
-const linter = new Linter([
-  new HTMLTagNameLowercaseRule()
-])
+const linter = new Linter([HTMLTagNameLowercaseRule])
 
 // Run with no rules (disabled)
 const linter = new Linter([])


### PR DESCRIPTION
This PR corrects how rules are passed to the Linter in the JavaScript customization example.

