### PR TITLE
Fix `erb-require-whitespace-inside-tags` rule for comment tags

### DIFF
--- a/javascript/packages/linter/test/rules/erb-require-whitespace-inside-tags.test.ts
+++ b/javascript/packages/linter/test/rules/erb-require-whitespace-inside-tags.test.ts
@@ -141,4 +141,81 @@ describe("erb-require-whitespace-inside-tags", () => {
     expect(lintResult.errors).toBe(0)
     expect(lintResult.offenses).toHaveLength(0)
   })
+
+  it("should require whitespace after # in ERB comment tags", () => {
+    const html = dedent`
+      <%# This is a comment %>
+      <%#This is a comment without spaces%>
+      <%# %>
+    `
+    const result = Herb.parse(html)
+    const linter = new Linter([ERBRequireWhitespaceRule])
+    const lintResult = linter.lint(result.value)
+
+    expect(lintResult.errors).toBe(2)
+    expect(lintResult.offenses).toHaveLength(2)
+
+    expect(lintResult.offenses[0].message).toBe("Add whitespace after `<%#`.")
+    expect(lintResult.offenses[1].message).toBe("Add whitespace before `%>`.")
+  })
+
+  it("should not report ERB comment tags with equals signs", () => {
+    const html = dedent`
+      <%#= link_to "New watch list", new_watch_list_path, class: "btn btn-ghost" %>
+    `
+    const result = Herb.parse(html)
+    const linter = new Linter([ERBRequireWhitespaceRule])
+    const lintResult = linter.lint(result.value)
+
+    expect(lintResult.errors).toBe(0)
+    expect(lintResult.offenses).toHaveLength(0)
+  })
+
+  it("should report ERB comment tags with equals sign and no space after", () => {
+    const html = dedent`
+      <%#=link_to "New watch list", new_watch_list_path, class: "btn btn-ghost"%>
+    `
+    const result = Herb.parse(html)
+    const linter = new Linter([ERBRequireWhitespaceRule])
+    const lintResult = linter.lint(result.value)
+
+    expect(lintResult.errors).toBe(2)
+    expect(lintResult.offenses).toHaveLength(2)
+
+    expect(lintResult.offenses[0].message).toBe("Add whitespace after `<%#=`.")
+    expect(lintResult.offenses[1].message).toBe("Add whitespace before `%>`.")
+  })
+
+  it("should not report ERB comment tags with equals followed by space", () => {
+    const html = dedent`
+      <%# = link_to "New watch list", new_watch_list_path, class: "btn btn-ghost" %>
+    `
+    const result = Herb.parse(html)
+    const linter = new Linter([ERBRequireWhitespaceRule])
+    const lintResult = linter.lint(result.value)
+
+    expect(lintResult.errors).toBe(0)
+    expect(lintResult.offenses).toHaveLength(0)
+  })
+
+  it("should handle multi-line ERB comment tags", () => {
+    const html = dedent`
+      <%#
+        This is a multi-line comment
+        with multiple lines
+      %>
+
+      <%#=
+        link_to "New watch list",
+        new_watch_list_path,
+        class: "btn btn-ghost"
+      %>
+    `
+    const result = Herb.parse(html)
+    const linter = new Linter([ERBRequireWhitespaceRule])
+    const lintResult = linter.lint(result.value)
+
+    expect(lintResult.errors).toBe(0)
+    expect(lintResult.offenses).toHaveLength(0)
+  })
 })

--- a/test/parser/erb_test.rb
+++ b/test/parser/erb_test.rb
@@ -82,7 +82,6 @@ module Parser
       HTML
     end
 
-
     test "erb output wrapped in double quotes" do
       assert_parsed_snapshot(<<~HTML)
         "<%= value %>"

--- a/test/parser/erb_test.rb
+++ b/test/parser/erb_test.rb
@@ -82,6 +82,7 @@ module Parser
       HTML
     end
 
+
     test "erb output wrapped in double quotes" do
       assert_parsed_snapshot(<<~HTML)
         "<%= value %>"
@@ -144,6 +145,24 @@ module Parser
         <%#
           This is a comment
           across multiple lines
+        %>
+      HTML
+    end
+
+    test "erb comment with equals sign" do
+      assert_parsed_snapshot(%(<%#= link_to "New watch list", new_watch_list_path, class: "btn btn-ghost" %>))
+    end
+
+    test "erb comment with equals sign without spaces" do
+      assert_parsed_snapshot(%(<%#=link_to "New watch list", new_watch_list_path, class: "btn btn-ghost"%>))
+    end
+
+    test "multi-line erb comment with equals sign" do
+      assert_parsed_snapshot(<<~HTML)
+        <%#=
+          link_to "New watch list",
+          new_watch_list_path,
+          class: "btn btn-ghost"
         %>
       HTML
     end

--- a/test/snapshots/parser/erb_test/test_0026_erb_comment_with_equals_sign_312beb21c876bb87e5bbb8c9288a5bd1.txt
+++ b/test/snapshots/parser/erb_test/test_0026_erb_comment_with_equals_sign_312beb21c876bb87e5bbb8c9288a5bd1.txt
@@ -1,0 +1,8 @@
+@ DocumentNode (location: (1:0)-(1:77))
+└── children: (1 item)
+    └── @ ERBContentNode (location: (1:0)-(1:77))
+        ├── tag_opening: "<%#" (location: (1:0)-(1:3))
+        ├── content: "= link_to "New watch list", new_watch_list_path, class: "btn btn-ghost" " (location: (1:3)-(1:75))
+        ├── tag_closing: "%>" (location: (1:75)-(1:77))
+        ├── parsed: true
+        └── valid: false

--- a/test/snapshots/parser/erb_test/test_0027_erb_comment_with_equals_sign_without_spaces_be2c65ad965090f17c18896f988e85a9.txt
+++ b/test/snapshots/parser/erb_test/test_0027_erb_comment_with_equals_sign_without_spaces_be2c65ad965090f17c18896f988e85a9.txt
@@ -1,0 +1,8 @@
+@ DocumentNode (location: (1:0)-(1:75))
+└── children: (1 item)
+    └── @ ERBContentNode (location: (1:0)-(1:75))
+        ├── tag_opening: "<%#" (location: (1:0)-(1:3))
+        ├── content: "=link_to "New watch list", new_watch_list_path, class: "btn btn-ghost"" (location: (1:3)-(1:73))
+        ├── tag_closing: "%>" (location: (1:73)-(1:75))
+        ├── parsed: true
+        └── valid: false

--- a/test/snapshots/parser/erb_test/test_0028_multi-line_erb_comment_with_equals_sign_bb3c3c1637a687e1d87a90a893fa09fd.txt
+++ b/test/snapshots/parser/erb_test/test_0028_multi-line_erb_comment_with_equals_sign_bb3c3c1637a687e1d87a90a893fa09fd.txt
@@ -1,0 +1,15 @@
+@ DocumentNode (location: (1:0)-(6:0))
+└── children: (2 items)
+    ├── @ ERBContentNode (location: (1:0)-(5:2))
+    │   ├── tag_opening: "<%#" (location: (1:0)-(1:3))
+    │   ├── content: "=
+    │     link_to "New watch list",
+    │     new_watch_list_path,
+    │     class: "btn btn-ghost"
+    │   " (location: (1:3)-(5:0))
+    │   ├── tag_closing: "%>" (location: (5:0)-(5:2))
+    │   ├── parsed: true
+    │   └── valid: false
+    │
+    └── @ HTMLTextNode (location: (5:2)-(6:0))
+        └── content: "\n"


### PR DESCRIPTION
This pull request updates the `erb-require-whitespace-inside-tags` rule to properly check whitespace after the `#` in ERB comment tags.

- `<%# comment %>` requires space after `#`
- `<%#= comment %>` requires space after `=`
- `<%#comment %>` and `<%#=comment %>` are flagged as offenses

Fixes #297