### PR TITLE
Formatter: Fix case where formatter would output `% %>`

### DIFF
--- a/javascript/packages/formatter/src/printer.ts
+++ b/javascript/packages/formatter/src/printer.ts
@@ -72,6 +72,7 @@ export class Printer extends Visitor {
 
   constructor(source: string, options: Required<FormatOptions>) {
     super()
+
     this.source = source
     this.indentWidth = options.indentWidth
     this.maxLineLength = options.maxLineLength
@@ -105,6 +106,7 @@ export class Printer extends Visitor {
     this.indentLevel++
     const result = callback()
     this.indentLevel--
+
     return result
   }
 
@@ -119,16 +121,9 @@ export class Printer extends Visitor {
     const indent = this.indent()
     const open = node.tag_opening?.value ?? ""
     const close = node.tag_closing?.value ?? ""
-    let inner: string
-    if (node.tag_opening && node.tag_closing) {
-      const [, openingEnd] = node.tag_opening.range.toArray()
-      const [closingStart] = node.tag_closing.range.toArray()
-      const rawInner = this.source.slice(openingEnd, closingStart)
-      inner = ` ${rawInner.trim()} `
-    } else {
-      const txt = node.content?.value ?? ""
-      inner = txt.trim() ? ` ${txt.trim()} ` : ""
-    }
+    const content = node.content?.value ?? ""
+    const inner = content.trim() ? ` ${content.trim()} ` : ""
+
     this.push(indent + open + inner + close)
   }
 

--- a/javascript/packages/formatter/test/erb/erb.test.ts
+++ b/javascript/packages/formatter/test/erb/erb.test.ts
@@ -69,4 +69,52 @@ describe("@herb-tools/formatter", () => {
       </div>
     `)
   })
+
+  test("should not add extra % to ERB closing tags with quoted strings", () => {
+    const input = dedent`
+      <div>
+        <%= link_to "Nederlands", url_for(locale: 'nl'), class: "px-4 py-2 hover:bg-slate-100 rounded block" %>
+        <%= link_to "Français", url_for(locale: 'fr'), class: "px-4 py-2 hover:bg-slate-100 rounded block" %>
+        <%= link_to "English", url_for(locale: 'en'), class: "px-4 py-2 hover:bg-slate-100 rounded block" %>
+      </div>
+    `
+
+    const result = formatter.format(input)
+    expect(result).toBe(input)
+  })
+
+  test("should handle complex ERB in layout files", () => {
+    const input = dedent`
+      <div class="container flex px-5 mx-auto mt-6">
+        <% if notice.present? %>
+          <div class="block">
+            <p class="inline-block px-5 py-2 mb-5 font-medium text-green-500 rounded bg-green-50" id="notice"><%= notice %></p>
+          </div>
+        <% end %>
+      </div>
+    `
+
+    const result = formatter.format(input)
+
+    expect(result).not.toContain("% %>")
+    expect(result).toContain("<% if notice.present? %>")
+    expect(result).toContain("<% end %>")
+    expect(result).toContain("<%= notice %>")
+  })
+
+  test("handles ERB tags ending with various patterns", () => {
+    const inputs = [
+      '<%= link_to "test" %>',
+      '<%= link_to "test", class: "btn" %>',
+      '<%= render "partial" %>',
+      '<% if something? %>',
+      '<%= tag.div("content") %>'
+    ]
+
+    inputs.forEach(input => {
+      const result = formatter.format(input)
+      expect(result).not.toContain("% %>")
+      expect(result).toBe(input)
+    })
+  })
 })


### PR DESCRIPTION
Resolves #277 