### PR TITLE
Add `textDocument/rangeFormatting` support to language server

### DIFF
--- a/javascript/packages/language-server/src/server.ts
+++ b/javascript/packages/language-server/src/server.ts
@@ -8,6 +8,7 @@ import {
   InitializeResult,
   Connection,
   DocumentFormattingParams,
+  DocumentRangeFormattingParams,
 } from "vscode-languageserver/node"
 
 import { Service } from "./service"
@@ -32,6 +33,7 @@ export class Server {
         capabilities: {
           textDocumentSync: TextDocumentSyncKind.Incremental,
           documentFormattingProvider: true,
+          documentRangeFormattingProvider: true,
         },
       }
 
@@ -93,7 +95,7 @@ export class Server {
           await this.service.refreshConfig()
 
           const documents = this.service.documentService.getAll()
-          await Promise.all(documents.map(document => 
+          await Promise.all(documents.map(document =>
             this.service.diagnostics.refreshDocument(document)
           ))
         }
@@ -102,6 +104,10 @@ export class Server {
 
     this.connection.onDocumentFormatting((params: DocumentFormattingParams) => {
       return this.service.formatting.formatDocument(params)
+    })
+
+    this.connection.onDocumentRangeFormatting((params: DocumentRangeFormattingParams) => {
+      return this.service.formatting.formatRange(params)
     })
   }
 


### PR DESCRIPTION
This pull request implements the `textDocument/rangeFormatting` request in the language server, which allows to only format selected lines.

This also works when you have the formatter disabled globally but want to just format a selection by running the `Format Selection` command manually:

https://github.com/user-attachments/assets/2502ccb5-9986-4f7b-860d-1948bb90bcda

Resolves #317 