### PR TITLE
Improve range formatting to preserve minimum indentation

### DIFF
--- a/javascript/packages/language-server/test/formatting_service.test.ts
+++ b/javascript/packages/language-server/test/formatting_service.test.ts
@@ -373,5 +373,48 @@ describe('FormattingService', () => {
 
       expect(result).toBeDefined()
     })
+
+    it('should calculate minimum indentation across all selected lines', async () => {
+      const input = dedent`
+        <div>
+          <div>
+            <div>
+              <p>some <%= formatted %> text, that needs <% needs %> <% to_be_formatted %> without being reset to the <b><i>start of the line</i></b>.</p>
+            </div>
+          </div>
+        </div>
+      `
+
+      const document = TextDocument.create('file:///test/file.erb', 'erb', 1, input)
+      vi.mocked(documents.get).mockReturnValue(document)
+
+      const range: Range = {
+        start: Position.create(3, 0),
+        end: Position.create(3, 150)
+      }
+
+      const params: DocumentRangeFormattingParams = {
+        textDocument: { uri: 'file:///test/file.erb' },
+        range,
+        options: { tabSize: 2, insertSpaces: true }
+      }
+
+      const result = await formattingService.formatRange(params)
+
+      expect(result[0].newText).toBe(
+        '      <p>\n' +
+        '        some\n' +
+        '        <%= formatted %>\n' +
+        '        text, that needs\n' +
+        '        <% needs %>\n' +
+        '        <% to_be_formatted %>\n' +
+        '        without being reset to the\n' +
+        '        <b>\n' +
+        '          <i>start of the line</i>\n' +
+        '        </b>\n' +
+        '        .\n' +
+        '      </p>\n'
+      )
+    })
   })
 })


### PR DESCRIPTION
This pull request improves the range formatting functionality introduced in #319 by calculating the minimum indentation across all selected lines, then stripping the minimum indentation before formatting (to prevent over-indenting) and then re-applying the minimum indentation to all formatted lines so it stays in-place and doesn't get dedented all the way to the beginning of the line.

**Before:**

https://github.com/user-attachments/assets/d5aea24d-9090-447c-aff8-a3ae17f767b6





**After:**


https://github.com/user-attachments/assets/21001f36-f337-49fa-847e-2f59cbd1bfc1

/cc @excid3