### PR TITLE
Parser: Add support for `TOKEN_NBSP` in HTML content

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -630,6 +630,7 @@ static void parser_parse_in_data_state(parser_T* parser, array_T* children, arra
           TOKEN_EQUALS,
           TOKEN_EXCLAMATION,
           TOKEN_IDENTIFIER,
+          TOKEN_NBSP,
           TOKEN_NEWLINE,
           TOKEN_PERCENT,
           TOKEN_QUOTE,
@@ -645,8 +646,8 @@ static void parser_parse_in_data_state(parser_T* parser, array_T* children, arra
     parser_append_unexpected_error(
       parser,
       "Unexpected token",
-      "TOKEN_ERB_START, TOKEN_HTML_DOCTYPE, TOKEN_HTML_COMMENT_START, TOKEN_IDENTIFIER, TOKEN_WHITESPACE, or "
-      "TOKEN_NEWLINE",
+      "TOKEN_ERB_START, TOKEN_HTML_DOCTYPE, TOKEN_HTML_COMMENT_START, TOKEN_IDENTIFIER, TOKEN_WHITESPACE, "
+      "TOKEN_NBSP, or TOKEN_NEWLINE",
       errors
     );
   }

--- a/test/parser/text_content_test.rb
+++ b/test/parser/text_content_test.rb
@@ -105,5 +105,21 @@ module Parser
     test "emoji as only content" do
       assert_parsed_snapshot("<b>🌿</b>")
     end
+
+    test "non-breaking space (U+00A0) as only content" do
+      assert_parsed_snapshot("<b> </b>")
+    end
+
+    test "non-breaking space mixed with ERB - issue 310" do
+      assert_parsed_snapshot("<p><%= hello %> !</p>")
+    end
+
+    test "multiple non-breaking spaces in text" do
+      assert_parsed_snapshot("<p>Hello   World</p>")
+    end
+
+    test "non-breaking space in attribute value" do
+      assert_parsed_snapshot('<div title="Hello World">Content</div>')
+    end
   end
 end

--- a/test/snapshots/parser/tags_test/test_0027_stray_closing_tag_with_whitespace_0ee4b96cac701f87a8b6cb0cf5ad48bc.txt
+++ b/test/snapshots/parser/tags_test/test_0027_stray_closing_tag_with_whitespace_0ee4b96cac701f87a8b6cb0cf5ad48bc.txt
@@ -1,9 +1,9 @@
 @ DocumentNode (location: (1:0)-(1:24))
 ├── errors: (1 error)
 │   └── @ UnexpectedError (location: (1:16)-(1:17))
-│       ├── message: "Unexpected token. Expected: `TOKEN_ERB_START, TOKEN_HTML_DOCTYPE, TOKEN_HTML_COMMENT_START, TOKEN_IDENTIFIER, TOKEN_WHITESPACE, or TOKEN_NEWLINE`, found: `TOKEN_LT`."
+│       ├── message: "Unexpected token. Expected: `TOKEN_ERB_START, TOKEN_HTML_DOCTYPE, TOKEN_HTML_COMMENT_START, TOKEN_IDENTIFIER, TOKEN_WHITESPACE, TOKEN_NBSP, or TOKEN_NEWLINE`, found: `TOKEN_LT`."
 │       ├── description: "Unexpected token"
-│       ├── expected: "TOKEN_ERB_START, TOKEN_HTML_DOCTYPE, TOKEN_HTML_COMMENT_START, TOKEN_IDENTIFIER, TOKEN_WHITESPACE, or TOKEN_NEWLINE"
+│       ├── expected: "TOKEN_ERB_START, TOKEN_HTML_DOCTYPE, TOKEN_HTML_COMMENT_START, TOKEN_IDENTIFIER, TOKEN_WHITESPACE, TOKEN_NBSP, or TOKEN_NEWLINE"
 │       └── found: "TOKEN_LT"
 │
 └── children: (2 items)

--- a/test/snapshots/parser/text_content_test/test_0024_non-breaking_space_(U+00A0)_as_only_content_171ed99b0854aa35f50c3371b07fffcc.txt
+++ b/test/snapshots/parser/text_content_test/test_0024_non-breaking_space_(U+00A0)_as_only_content_171ed99b0854aa35f50c3371b07fffcc.txt
@@ -1,0 +1,23 @@
+@ DocumentNode (location: (1:0)-(1:8))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:8))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:3))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "b" (location: (1:1)-(1:2))
+        │       ├── tag_closing: ">" (location: (1:2)-(1:3))
+        │       ├── children: []
+        │       └── is_void: false
+        │
+        ├── tag_name: "b" (location: (1:1)-(1:2))
+        ├── body: (1 item)
+        │   └── @ HTMLTextNode (location: (1:3)-(1:4))
+        │       └── content: " "
+        │
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:4)-(1:8))
+        │       ├── tag_opening: "</" (location: (1:4)-(1:6))
+        │       ├── tag_name: "b" (location: (1:6)-(1:7))
+        │       └── tag_closing: ">" (location: (1:7)-(1:8))
+        │
+        └── is_void: false

--- a/test/snapshots/parser/text_content_test/test_0025_non-breaking_space_mixed_with_ERB_-_issue_310_1f905e5ab087b22e76444d7e98132e6d.txt
+++ b/test/snapshots/parser/text_content_test/test_0025_non-breaking_space_mixed_with_ERB_-_issue_310_1f905e5ab087b22e76444d7e98132e6d.txt
@@ -1,0 +1,30 @@
+@ DocumentNode (location: (1:0)-(1:21))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:21))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:3))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "p" (location: (1:1)-(1:2))
+        │       ├── tag_closing: ">" (location: (1:2)-(1:3))
+        │       ├── children: []
+        │       └── is_void: false
+        │
+        ├── tag_name: "p" (location: (1:1)-(1:2))
+        ├── body: (2 items)
+        │   ├── @ ERBContentNode (location: (1:3)-(1:15))
+        │   │   ├── tag_opening: "<%=" (location: (1:3)-(1:6))
+        │   │   ├── content: " hello " (location: (1:6)-(1:13))
+        │   │   ├── tag_closing: "%>" (location: (1:13)-(1:15))
+        │   │   ├── parsed: true
+        │   │   └── valid: true
+        │   │
+        │   └── @ HTMLTextNode (location: (1:15)-(1:17))
+        │       └── content: " !"
+        │
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:17)-(1:21))
+        │       ├── tag_opening: "</" (location: (1:17)-(1:19))
+        │       ├── tag_name: "p" (location: (1:19)-(1:20))
+        │       └── tag_closing: ">" (location: (1:20)-(1:21))
+        │
+        └── is_void: false

--- a/test/snapshots/parser/text_content_test/test_0026_multiple_non-breaking_spaces_in_text_7a2675aa6ba4cdbc5080233628d5e45e.txt
+++ b/test/snapshots/parser/text_content_test/test_0026_multiple_non-breaking_spaces_in_text_7a2675aa6ba4cdbc5080233628d5e45e.txt
@@ -1,0 +1,23 @@
+@ DocumentNode (location: (1:0)-(1:20))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:20))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:3))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "p" (location: (1:1)-(1:2))
+        │       ├── tag_closing: ">" (location: (1:2)-(1:3))
+        │       ├── children: []
+        │       └── is_void: false
+        │
+        ├── tag_name: "p" (location: (1:1)-(1:2))
+        ├── body: (1 item)
+        │   └── @ HTMLTextNode (location: (1:3)-(1:16))
+        │       └── content: "Hello   World"
+        │
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:16)-(1:20))
+        │       ├── tag_opening: "</" (location: (1:16)-(1:18))
+        │       ├── tag_name: "p" (location: (1:18)-(1:19))
+        │       └── tag_closing: ">" (location: (1:19)-(1:20))
+        │
+        └── is_void: false

--- a/test/snapshots/parser/text_content_test/test_0027_non-breaking_space_in_attribute_value_4ef6c07c78dcc312066ef682f96c0253.txt
+++ b/test/snapshots/parser/text_content_test/test_0027_non-breaking_space_in_attribute_value_4ef6c07c78dcc312066ef682f96c0253.txt
@@ -1,0 +1,40 @@
+@ DocumentNode (location: (1:0)-(1:38))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:38))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:25))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "div" (location: (1:1)-(1:4))
+        │       ├── tag_closing: ">" (location: (1:24)-(1:25))
+        │       ├── children: (1 item)
+        │       │   └── @ HTMLAttributeNode (location: (1:5)-(1:24))
+        │       │       ├── name:
+        │       │       │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:10))
+        │       │       │       └── name: "title" (location: (1:5)-(1:10))
+        │       │       │
+        │       │       ├── equals: "=" (location: (1:10)-(1:11))
+        │       │       └── value:
+        │       │           └── @ HTMLAttributeValueNode (location: (1:11)-(1:24))
+        │       │               ├── open_quote: """ (location: (1:11)-(1:12))
+        │       │               ├── children: (1 item)
+        │       │               │   └── @ LiteralNode (location: (1:12)-(1:23))
+        │       │               │       └── content: "Hello World"
+        │       │               │
+        │       │               ├── close_quote: """ (location: (1:23)-(1:24))
+        │       │               └── quoted: true
+        │       │
+        │       │
+        │       └── is_void: false
+        │
+        ├── tag_name: "div" (location: (1:1)-(1:4))
+        ├── body: (1 item)
+        │   └── @ HTMLTextNode (location: (1:25)-(1:32))
+        │       └── content: "Content"
+        │
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:32)-(1:38))
+        │       ├── tag_opening: "</" (location: (1:32)-(1:34))
+        │       ├── tag_name: "div" (location: (1:34)-(1:37))
+        │       └── tag_closing: ">" (location: (1:37)-(1:38))
+        │
+        └── is_void: false


### PR DESCRIPTION
This pull requst adds support for non-breaking space (U+00A0) characters in HTML content. Previously they were not recognized as valid text content, causing unexpected token errors.

Fixes #310