### PR TITLE
Parser: Add support for `TOKEN_AT` in HTML content

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -624,6 +624,7 @@ static void parser_parse_in_data_state(parser_T* parser, array_T* children, arra
     if (token_is_any_of(
           parser,
           TOKEN_AMPERSAND,
+          TOKEN_AT,
           TOKEN_CHARACTER,
           TOKEN_COLON,
           TOKEN_DASH,
@@ -647,7 +648,7 @@ static void parser_parse_in_data_state(parser_T* parser, array_T* children, arra
       parser,
       "Unexpected token",
       "TOKEN_ERB_START, TOKEN_HTML_DOCTYPE, TOKEN_HTML_COMMENT_START, TOKEN_IDENTIFIER, TOKEN_WHITESPACE, "
-      "TOKEN_NBSP, or TOKEN_NEWLINE",
+      "TOKEN_NBSP, TOKEN_AT, or TOKEN_NEWLINE",
       errors
     );
   }

--- a/test/parser/text_content_test.rb
+++ b/test/parser/text_content_test.rb
@@ -121,5 +121,25 @@ module Parser
     test "non-breaking space in attribute value" do
       assert_parsed_snapshot('<div title="Hello World">Content</div>')
     end
+
+    test "at symbol (@) in text content - issue 285" do
+      assert_parsed_snapshot("<p>Did we get it wrong? Respond with <em>@reverse</em> to remove the receipt.</p>")
+    end
+
+    test "at symbol at beginning of text" do
+      assert_parsed_snapshot("<span>@username</span>")
+    end
+
+    test "multiple at symbols in text" do
+      assert_parsed_snapshot("<p>Email me @john@example.com</p>")
+    end
+
+    test "at symbol mixed with ERB" do
+      assert_parsed_snapshot("<p>Contact <%= user.name %> @support</p>")
+    end
+
+    test "at symbol in attribute value" do
+      assert_parsed_snapshot('<a href="mailto:support@example.com">Contact @support</a>')
+    end
   end
 end

--- a/test/snapshots/parser/tags_test/test_0027_stray_closing_tag_with_whitespace_0ee4b96cac701f87a8b6cb0cf5ad48bc.txt
+++ b/test/snapshots/parser/tags_test/test_0027_stray_closing_tag_with_whitespace_0ee4b96cac701f87a8b6cb0cf5ad48bc.txt
@@ -1,9 +1,9 @@
 @ DocumentNode (location: (1:0)-(1:24))
 ├── errors: (1 error)
 │   └── @ UnexpectedError (location: (1:16)-(1:17))
-│       ├── message: "Unexpected token. Expected: `TOKEN_ERB_START, TOKEN_HTML_DOCTYPE, TOKEN_HTML_COMMENT_START, TOKEN_IDENTIFIER, TOKEN_WHITESPACE, TOKEN_NBSP, or TOKEN_NEWLINE`, found: `TOKEN_LT`."
+│       ├── message: "Unexpected token. Expected: `TOKEN_ERB_START, TOKEN_HTML_DOCTYPE, TOKEN_HTML_COMMENT_START, TOKEN_IDENTIFIER, TOKEN_WHITESPACE, TOKEN_NBSP, TOKEN_AT, or TOKE`, found: `TOKEN_LT`."
 │       ├── description: "Unexpected token"
-│       ├── expected: "TOKEN_ERB_START, TOKEN_HTML_DOCTYPE, TOKEN_HTML_COMMENT_START, TOKEN_IDENTIFIER, TOKEN_WHITESPACE, TOKEN_NBSP, or TOKEN_NEWLINE"
+│       ├── expected: "TOKEN_ERB_START, TOKEN_HTML_DOCTYPE, TOKEN_HTML_COMMENT_START, TOKEN_IDENTIFIER, TOKEN_WHITESPACE, TOKEN_NBSP, TOKEN_AT, or TOKEN_NEWLINE"
 │       └── found: "TOKEN_LT"
 │
 └── children: (2 items)

--- a/test/snapshots/parser/text_content_test/test_0028_at_symbol_(@)_in_text_content_-_issue_285_b4af64f3ea734ed4c7510e7e5738841a.txt
+++ b/test/snapshots/parser/text_content_test/test_0028_at_symbol_(@)_in_text_content_-_issue_285_b4af64f3ea734ed4c7510e7e5738841a.txt
@@ -1,0 +1,48 @@
+@ DocumentNode (location: (1:0)-(1:81))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:81))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:3))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "p" (location: (1:1)-(1:2))
+        │       ├── tag_closing: ">" (location: (1:2)-(1:3))
+        │       ├── children: []
+        │       └── is_void: false
+        │
+        ├── tag_name: "p" (location: (1:1)-(1:2))
+        ├── body: (3 items)
+        │   ├── @ HTMLTextNode (location: (1:3)-(1:37))
+        │   │   └── content: "Did we get it wrong? Respond with "
+        │   │
+        │   ├── @ HTMLElementNode (location: (1:37)-(1:54))
+        │   │   ├── open_tag:
+        │   │   │   └── @ HTMLOpenTagNode (location: (1:37)-(1:41))
+        │   │   │       ├── tag_opening: "<" (location: (1:37)-(1:38))
+        │   │   │       ├── tag_name: "em" (location: (1:38)-(1:40))
+        │   │   │       ├── tag_closing: ">" (location: (1:40)-(1:41))
+        │   │   │       ├── children: []
+        │   │   │       └── is_void: false
+        │   │   │
+        │   │   ├── tag_name: "em" (location: (1:38)-(1:40))
+        │   │   ├── body: (1 item)
+        │   │   │   └── @ HTMLTextNode (location: (1:41)-(1:49))
+        │   │   │       └── content: "@reverse"
+        │   │   │
+        │   │   ├── close_tag:
+        │   │   │   └── @ HTMLCloseTagNode (location: (1:49)-(1:54))
+        │   │   │       ├── tag_opening: "</" (location: (1:49)-(1:51))
+        │   │   │       ├── tag_name: "em" (location: (1:51)-(1:53))
+        │   │   │       └── tag_closing: ">" (location: (1:53)-(1:54))
+        │   │   │
+        │   │   └── is_void: false
+        │   │
+        │   └── @ HTMLTextNode (location: (1:54)-(1:77))
+        │       └── content: " to remove the receipt."
+        │
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:77)-(1:81))
+        │       ├── tag_opening: "</" (location: (1:77)-(1:79))
+        │       ├── tag_name: "p" (location: (1:79)-(1:80))
+        │       └── tag_closing: ">" (location: (1:80)-(1:81))
+        │
+        └── is_void: false

--- a/test/snapshots/parser/text_content_test/test_0029_at_symbol_at_beginning_of_text_b0241d43408d1826ae74f1bbec2e6413.txt
+++ b/test/snapshots/parser/text_content_test/test_0029_at_symbol_at_beginning_of_text_b0241d43408d1826ae74f1bbec2e6413.txt
@@ -1,0 +1,23 @@
+@ DocumentNode (location: (1:0)-(1:22))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:22))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:6))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "span" (location: (1:1)-(1:5))
+        │       ├── tag_closing: ">" (location: (1:5)-(1:6))
+        │       ├── children: []
+        │       └── is_void: false
+        │
+        ├── tag_name: "span" (location: (1:1)-(1:5))
+        ├── body: (1 item)
+        │   └── @ HTMLTextNode (location: (1:6)-(1:15))
+        │       └── content: "@username"
+        │
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:15)-(1:22))
+        │       ├── tag_opening: "</" (location: (1:15)-(1:17))
+        │       ├── tag_name: "span" (location: (1:17)-(1:21))
+        │       └── tag_closing: ">" (location: (1:21)-(1:22))
+        │
+        └── is_void: false

--- a/test/snapshots/parser/text_content_test/test_0030_multiple_at_symbols_in_text_33e06a6d495e2d066b5a1a7be86f91c1.txt
+++ b/test/snapshots/parser/text_content_test/test_0030_multiple_at_symbols_in_text_33e06a6d495e2d066b5a1a7be86f91c1.txt
@@ -1,0 +1,23 @@
+@ DocumentNode (location: (1:0)-(1:33))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:33))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:3))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "p" (location: (1:1)-(1:2))
+        │       ├── tag_closing: ">" (location: (1:2)-(1:3))
+        │       ├── children: []
+        │       └── is_void: false
+        │
+        ├── tag_name: "p" (location: (1:1)-(1:2))
+        ├── body: (1 item)
+        │   └── @ HTMLTextNode (location: (1:3)-(1:29))
+        │       └── content: "Email me @john@example.com"
+        │
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:29)-(1:33))
+        │       ├── tag_opening: "</" (location: (1:29)-(1:31))
+        │       ├── tag_name: "p" (location: (1:31)-(1:32))
+        │       └── tag_closing: ">" (location: (1:32)-(1:33))
+        │
+        └── is_void: false

--- a/test/snapshots/parser/text_content_test/test_0031_at_symbol_mixed_with_ERB_a4b70c6afcd72595d84b1468a8b61d3a.txt
+++ b/test/snapshots/parser/text_content_test/test_0031_at_symbol_mixed_with_ERB_a4b70c6afcd72595d84b1468a8b61d3a.txt
@@ -1,0 +1,33 @@
+@ DocumentNode (location: (1:0)-(1:40))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:40))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:3))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "p" (location: (1:1)-(1:2))
+        │       ├── tag_closing: ">" (location: (1:2)-(1:3))
+        │       ├── children: []
+        │       └── is_void: false
+        │
+        ├── tag_name: "p" (location: (1:1)-(1:2))
+        ├── body: (3 items)
+        │   ├── @ HTMLTextNode (location: (1:3)-(1:11))
+        │   │   └── content: "Contact "
+        │   │
+        │   ├── @ ERBContentNode (location: (1:11)-(1:27))
+        │   │   ├── tag_opening: "<%=" (location: (1:11)-(1:14))
+        │   │   ├── content: " user.name " (location: (1:14)-(1:25))
+        │   │   ├── tag_closing: "%>" (location: (1:25)-(1:27))
+        │   │   ├── parsed: true
+        │   │   └── valid: true
+        │   │
+        │   └── @ HTMLTextNode (location: (1:27)-(1:36))
+        │       └── content: " @support"
+        │
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:36)-(1:40))
+        │       ├── tag_opening: "</" (location: (1:36)-(1:38))
+        │       ├── tag_name: "p" (location: (1:38)-(1:39))
+        │       └── tag_closing: ">" (location: (1:39)-(1:40))
+        │
+        └── is_void: false

--- a/test/snapshots/parser/text_content_test/test_0032_at_symbol_in_attribute_value_e5290cd6e77d3872131d3aa211bea034.txt
+++ b/test/snapshots/parser/text_content_test/test_0032_at_symbol_in_attribute_value_e5290cd6e77d3872131d3aa211bea034.txt
@@ -1,0 +1,40 @@
+@ DocumentNode (location: (1:0)-(1:57))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:57))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:37))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "a" (location: (1:1)-(1:2))
+        │       ├── tag_closing: ">" (location: (1:36)-(1:37))
+        │       ├── children: (1 item)
+        │       │   └── @ HTMLAttributeNode (location: (1:3)-(1:36))
+        │       │       ├── name:
+        │       │       │   └── @ HTMLAttributeNameNode (location: (1:3)-(1:7))
+        │       │       │       └── name: "href" (location: (1:3)-(1:7))
+        │       │       │
+        │       │       ├── equals: "=" (location: (1:7)-(1:8))
+        │       │       └── value:
+        │       │           └── @ HTMLAttributeValueNode (location: (1:8)-(1:36))
+        │       │               ├── open_quote: """ (location: (1:8)-(1:9))
+        │       │               ├── children: (1 item)
+        │       │               │   └── @ LiteralNode (location: (1:9)-(1:35))
+        │       │               │       └── content: "mailto:support@example.com"
+        │       │               │
+        │       │               ├── close_quote: """ (location: (1:35)-(1:36))
+        │       │               └── quoted: true
+        │       │
+        │       │
+        │       └── is_void: false
+        │
+        ├── tag_name: "a" (location: (1:1)-(1:2))
+        ├── body: (1 item)
+        │   └── @ HTMLTextNode (location: (1:37)-(1:53))
+        │       └── content: "Contact @support"
+        │
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:53)-(1:57))
+        │       ├── tag_opening: "</" (location: (1:53)-(1:55))
+        │       ├── tag_name: "a" (location: (1:55)-(1:56))
+        │       └── tag_closing: ">" (location: (1:56)-(1:57))
+        │
+        └── is_void: false


### PR DESCRIPTION
This pull requst adds support for the `@` character in HTML content. Previously it wasn't recognized as valid text content, causing unexpected token errors.

**Example**

```html
<span>@username</span>
```

**Before**
```js
@ DocumentNode (location: (1:0)-(1:22))
├── errors: []
└── children: (1 item)
    └── @ HTMLElementNode (location: (1:0)-(1:22))
        ├── errors: (1 item)
        │   └── @ UnexpectedError (location: (1:6)-(1:7))
        │       ├── message: "Unexpected token. Expected: `TOKEN_ERB_START, TOKEN_HTML_DOCTYPE, TOKEN_HTML_COMMENT_START, TOKEN_IDENTIFIER, TOKEN_WHITESPACE, TOKEN_NBSP, or TOKEN_NEWLINE`, found: `TOKEN_AT`."
        │       ├── description: "Unexpected token"
        │       ├── expected: "TOKEN_ERB_START, TOKEN_HTML_DOCTYPE, TOKEN_HTML_COMMENT_START, TOKEN_IDENTIFIER, TOKEN_WHITESPACE, TOKEN_NBSP, or TOKEN_NEWLINE"
        │       └── found: "TOKEN_AT"
        │       
        │   
        ├── open_tag: 
        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:6))
        │       ├── errors: []
        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
        │       ├── tag_name: "span" (location: (1:1)-(1:5))
        │       ├── tag_closing: ">" (location: (1:5)-(1:6))
        │       ├── children: []
        │       └── is_void: false
        │       
        ├── tag_name: "span" (location: (1:1)-(1:5))
        ├── body: (1 item)
        │   └── @ HTMLTextNode (location: (1:7)-(1:15))
        │       ├── errors: []
        │       └── content: "username"
        │       
        │   
        ├── close_tag: 
        │   └── @ HTMLCloseTagNode (location: (1:15)-(1:22))
        │       ├── errors: []
        │       ├── tag_opening: "</" (location: (1:15)-(1:17))
        │       ├── tag_name: "span" (location: (1:17)-(1:21))
        │       └── tag_closing: ">" (location: (1:21)-(1:22))
        │       
        └── is_void: false   
```

**After**

```js
@ DocumentNode (location: (1:0)-(1:22))
├── errors: []
└── children: (1 item)
    └── @ HTMLElementNode (location: (1:0)-(1:22))
        ├── errors: []
        ├── open_tag: 
        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:6))
        │       ├── errors: []
        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
        │       ├── tag_name: "span" (location: (1:1)-(1:5))
        │       ├── tag_closing: ">" (location: (1:5)-(1:6))
        │       ├── children: []
        │       └── is_void: false
        │       
        ├── tag_name: "span" (location: (1:1)-(1:5))
        ├── body: (1 item)
        │   └── @ HTMLTextNode (location: (1:6)-(1:15))
        │       ├── errors: []
        │       └── content: "@username"
        │       
        │   
        ├── close_tag: 
        │   └── @ HTMLCloseTagNode (location: (1:15)-(1:22))
        │       ├── errors: []
        │       ├── tag_opening: "</" (location: (1:15)-(1:17))
        │       ├── tag_name: "span" (location: (1:17)-(1:21))
        │       └── tag_closing: ">" (location: (1:21)-(1:22))
        │       
        └── is_void: false
```

Fixes #285