### PR TITLE
Formatter: Preserve newlines between top-level nodes

### DIFF
--- a/javascript/packages/formatter/src/printer.ts
+++ b/javascript/packages/formatter/src/printer.ts
@@ -130,6 +130,9 @@ export class Printer extends Visitor {
   // --- Visitor methods ---
 
   visitDocumentNode(node: DocumentNode): void {
+    let lastWasMeaningful = false
+    let hasHandledSpacing = false
+
     for (let i = 0; i < node.children.length; i++) {
       const child = node.children[i]
 
@@ -145,13 +148,23 @@ export class Printer extends Visitor {
 
           if (hasPrevNonWhitespace && hasNextNonWhitespace && hasMultipleNewlines) {
             this.push("")
+            hasHandledSpacing = true
           }
 
           continue
         }
       }
 
+      if (this.isNonWhitespaceNode(child) && lastWasMeaningful && !hasHandledSpacing) {
+        this.push("")
+      }
+
       this.visit(child)
+
+      if (this.isNonWhitespaceNode(child)) {
+        lastWasMeaningful = true
+        hasHandledSpacing = false
+      }
     }
   }
 

--- a/javascript/packages/formatter/test/document-formatting.test.ts
+++ b/javascript/packages/formatter/test/document-formatting.test.ts
@@ -106,7 +106,7 @@ describe("Document-level formatting", () => {
     `)
   })
 
-  test("does not add extra newlines when no blank lines exist", () => {
+  test("adds newlines between top-level elements when none exist", () => {
     const source = dedent`
       <% title = "Test" %>
       <div><%= title %></div>
@@ -114,6 +114,7 @@ describe("Document-level formatting", () => {
     const result = formatter.format(source)
     expect(result).toEqual(dedent`
       <% title = "Test" %>
+
       <div><%= title %></div>
     `)
   })
@@ -144,9 +145,11 @@ describe("Document-level formatting", () => {
     const result = formatter.format(source)
     expect(result).toEqual(dedent`
       <% page_title = "User Profile" %>
+
       <% user_data = { name: "John", age: 30 } %>
 
       <!DOCTYPE html>
+
       <html>
         <head>
           <title>
@@ -219,6 +222,32 @@ describe("Document-level formatting", () => {
       <div class="footer">
         Done
       </div>
+    `)
+  })
+
+  test("adds newlines between adjacent ERB and HTML with no spacing", () => {
+    const source = `<% user = current_user %><div>Hello</div><% if user %><span>Welcome</span><% end %>`
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <% user = current_user %>
+
+      <div>Hello</div>
+
+      <% if user %>
+        <span>Welcome</span>
+      <% end %>
+    `)
+  })
+
+  test("handles single line with multiple elements", () => {
+    const source = `<h1>Title</h1><p>Content</p><footer>Footer</footer>`
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <h1>Title</h1>
+
+      <p>Content</p>
+
+      <footer>Footer</footer>
     `)
   })
 })

--- a/javascript/packages/formatter/test/html/comments.test.ts
+++ b/javascript/packages/formatter/test/html/comments.test.ts
@@ -43,6 +43,7 @@ describe("@herb-tools/formatter", () => {
     const result = formatter.format(source)
     expect(result).toEqual(dedent`
       <!-- HTML Comment -->
+
       <%# ERB Comment %>
     `)
   })


### PR DESCRIPTION
This pull request improves the way the formatter handles top-level node spacing by preserving intentional blank lines between meaningful elements in ERB templates.

**Before:**
```erb
<% array = ["One", "Two", "Three"] %>
<ul>
  <% array.each do |item| %>
    <li><%= item %></li>
  <% end %>
</ul>
```

**After:**
```erb
<% array = ["One", "Two", "Three"] %>

<ul>
  <% array.each do |item| %>
    <li><%= item %></li>
  <% end %>
</ul>
```

This ensures proper visual separation between logical sections while still applying consistent formatting to individual elements.

Touches on #261, but doesn't fully resolve it.