### PR TITLE
Allow HTML Attribute Names to have a period in the attribute name

### DIFF
--- a/test/parser/attributes_test.rb
+++ b/test/parser/attributes_test.rb
@@ -57,5 +57,13 @@ module Parser
     test "erb output with quotes" do
       assert_parsed_snapshot(%(<div title="<%= "quoted string" %>"></div>))
     end
+
+    test "attributes with dots in name" do
+      assert_parsed_snapshot(%(<div x-transition.duration.500ms x-show="visible" x-cloak></div>))
+    end
+
+    test "complex attribute with dots and values" do
+      assert_parsed_snapshot(%(<div x-transition.duration.500ms="fast" data-component.option="value"></div>))
+    end
   end
 end

--- a/test/snapshots/parser/attributes_test/test_0014_attributes_with_dots_in_name_89984a18a28d8c5c73db29753dc762c2.txt
+++ b/test/snapshots/parser/attributes_test/test_0014_attributes_with_dots_in_name_89984a18a28d8c5c73db29753dc762c2.txt
@@ -1,0 +1,53 @@
+@ DocumentNode (location: (1:0)-(1:64))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:64))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:58))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "div" (location: (1:1)-(1:4))
+        │       ├── tag_closing: ">" (location: (1:57)-(1:58))
+        │       ├── children: (3 items)
+        │       │   ├── @ HTMLAttributeNode (location: (1:5)-(1:32))
+        │       │   │   ├── name:
+        │       │   │   │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:32))
+        │       │   │   │       └── name: "x-transition.duration.500ms" (location: (1:5)-(1:32))
+        │       │   │   │
+        │       │   │   ├── equals: ∅
+        │       │   │   └── value: ∅
+        │       │   │
+        │       │   ├── @ HTMLAttributeNode (location: (1:33)-(1:49))
+        │       │   │   ├── name:
+        │       │   │   │   └── @ HTMLAttributeNameNode (location: (1:33)-(1:39))
+        │       │   │   │       └── name: "x-show" (location: (1:33)-(1:39))
+        │       │   │   │
+        │       │   │   ├── equals: "=" (location: (1:39)-(1:40))
+        │       │   │   └── value:
+        │       │   │       └── @ HTMLAttributeValueNode (location: (1:40)-(1:49))
+        │       │   │           ├── open_quote: """ (location: (1:40)-(1:41))
+        │       │   │           ├── children: (1 item)
+        │       │   │           │   └── @ LiteralNode (location: (1:41)-(1:48))
+        │       │   │           │       └── content: "visible"
+        │       │   │           │
+        │       │   │           ├── close_quote: """ (location: (1:48)-(1:49))
+        │       │   │           └── quoted: true
+        │       │   │
+        │       │   │
+        │       │   └── @ HTMLAttributeNode (location: (1:50)-(1:57))
+        │       │       ├── name:
+        │       │       │   └── @ HTMLAttributeNameNode (location: (1:50)-(1:57))
+        │       │       │       └── name: "x-cloak" (location: (1:50)-(1:57))
+        │       │       │
+        │       │       ├── equals: ∅
+        │       │       └── value: ∅
+        │       │
+        │       └── is_void: false
+        │
+        ├── tag_name: "div" (location: (1:1)-(1:4))
+        ├── body: []
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:58)-(1:64))
+        │       ├── tag_opening: "</" (location: (1:58)-(1:60))
+        │       ├── tag_name: "div" (location: (1:60)-(1:63))
+        │       └── tag_closing: ">" (location: (1:63)-(1:64))
+        │
+        └── is_void: false

--- a/test/snapshots/parser/attributes_test/test_0015_complex_attribute_with_dots_and_values_d5cd679cddf6b4eae3a0c22c008acaae.txt
+++ b/test/snapshots/parser/attributes_test/test_0015_complex_attribute_with_dots_and_values_d5cd679cddf6b4eae3a0c22c008acaae.txt
@@ -1,0 +1,54 @@
+@ DocumentNode (location: (1:0)-(1:76))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:76))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:70))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "div" (location: (1:1)-(1:4))
+        │       ├── tag_closing: ">" (location: (1:69)-(1:70))
+        │       ├── children: (2 items)
+        │       │   ├── @ HTMLAttributeNode (location: (1:5)-(1:39))
+        │       │   │   ├── name:
+        │       │   │   │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:32))
+        │       │   │   │       └── name: "x-transition.duration.500ms" (location: (1:5)-(1:32))
+        │       │   │   │
+        │       │   │   ├── equals: "=" (location: (1:32)-(1:33))
+        │       │   │   └── value:
+        │       │   │       └── @ HTMLAttributeValueNode (location: (1:33)-(1:39))
+        │       │   │           ├── open_quote: """ (location: (1:33)-(1:34))
+        │       │   │           ├── children: (1 item)
+        │       │   │           │   └── @ LiteralNode (location: (1:34)-(1:38))
+        │       │   │           │       └── content: "fast"
+        │       │   │           │
+        │       │   │           ├── close_quote: """ (location: (1:38)-(1:39))
+        │       │   │           └── quoted: true
+        │       │   │
+        │       │   │
+        │       │   └── @ HTMLAttributeNode (location: (1:40)-(1:69))
+        │       │       ├── name:
+        │       │       │   └── @ HTMLAttributeNameNode (location: (1:40)-(1:61))
+        │       │       │       └── name: "data-component.option" (location: (1:40)-(1:61))
+        │       │       │
+        │       │       ├── equals: "=" (location: (1:61)-(1:62))
+        │       │       └── value:
+        │       │           └── @ HTMLAttributeValueNode (location: (1:62)-(1:69))
+        │       │               ├── open_quote: """ (location: (1:62)-(1:63))
+        │       │               ├── children: (1 item)
+        │       │               │   └── @ LiteralNode (location: (1:63)-(1:68))
+        │       │               │       └── content: "value"
+        │       │               │
+        │       │               ├── close_quote: """ (location: (1:68)-(1:69))
+        │       │               └── quoted: true
+        │       │
+        │       │
+        │       └── is_void: false
+        │
+        ├── tag_name: "div" (location: (1:1)-(1:4))
+        ├── body: []
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:70)-(1:76))
+        │       ├── tag_opening: "</" (location: (1:70)-(1:72))
+        │       ├── tag_name: "div" (location: (1:72)-(1:75))
+        │       └── tag_closing: ">" (location: (1:75)-(1:76))
+        │
+        └── is_void: false


### PR DESCRIPTION
This pull request adds support for parsing a period in HTML attribute names. So we can now properly parse snippets like this: 

```erb
<div x-transition.duration.500ms></div>
```

Technically this is not fully compliant HTML5, but popular frameworks like Alpine.js leverage this syntax and it mostly seem to work in browsers.

But even if we wouldn't want to allow this kind of syntax, we'd still need to parse it this way so we could write linter rules to help people avoid this kind of syntax if strict HTML5-compliance is required.

Resolves https://github.com/marcoroth/herb/issues/287