### PR TITLE
Parser: Add support for `@` token in HTML attribute names

### DIFF
--- a/test/parser/attributes_test.rb
+++ b/test/parser/attributes_test.rb
@@ -65,5 +65,33 @@ module Parser
     test "complex attribute with dots and values" do
       assert_parsed_snapshot(%(<div x-transition.duration.500ms="fast" data-component.option="value"></div>))
     end
+
+    test "attributes starting with @ symbol" do
+      assert_parsed_snapshot(%(<div @click="handleClick" @keyup.enter="submit"></div>))
+    end
+
+    test "@ attributes with various patterns" do
+      assert_parsed_snapshot(%(<div @submit.prevent @change.debounce.100ms="update" @mouseover></div>))
+    end
+
+    test "standalone @ symbol in div tag" do
+      assert_parsed_snapshot(%(<div @></div>))
+    end
+
+    test "standalone @ symbol followed by whitesapce in div tag" do
+      assert_parsed_snapshot(%(<div @ ></div>))
+    end
+
+    test "standalone @ symbol followed by whitesapce and identifier in div tag" do
+      assert_parsed_snapshot(%(<div @ click></div>))
+    end
+
+    test "standalone @ symbol in div tag followed by attribute" do
+      assert_parsed_snapshot(%(<div @ data-attribute="test"></div>))
+    end
+
+    test "atttribute with @ prefix and now value" do
+      assert_parsed_snapshot(%(<div @click></div>))
+    end
   end
 end

--- a/test/snapshots/parser/attributes_test/test_0006_attribute_value_with_space_after_equal_sign_60301c34c290d45874e5f104c39feb48.txt
+++ b/test/snapshots/parser/attributes_test/test_0006_attribute_value_with_space_after_equal_sign_60301c34c290d45874e5f104c39feb48.txt
@@ -5,15 +5,15 @@
         │   └── @ HTMLOpenTagNode (location: (1:0)-(1:24))
         │       ├── errors: (2 errors)
         │       │   ├── @ UnexpectedError (location: (1:14)-(1:15))
-        │       │   │   ├── message: "Unexpected Token. Expected: `TOKEN_IDENTIFIER, TOKEN_ERB_START,TOKEN_WHITESPACE, or TOKEN_NEWLINE`, found: `TOKEN_QUOTE`."
+        │       │   │   ├── message: "Unexpected Token. Expected: `TOKEN_IDENTIFIER, TOKEN_AT, TOKEN_ERB_START,TOKEN_WHITESPACE, or TOKEN_NEWLINE`, found: `TOKEN_QUOTE`."
         │       │   │   ├── description: "Unexpected Token"
-        │       │   │   ├── expected: "TOKEN_IDENTIFIER, TOKEN_ERB_START,TOKEN_WHITESPACE, or TOKEN_NEWLINE"
+        │       │   │   ├── expected: "TOKEN_IDENTIFIER, TOKEN_AT, TOKEN_ERB_START,TOKEN_WHITESPACE, or TOKEN_NEWLINE"
         │       │   │   └── found: "TOKEN_QUOTE"
         │       │   │
         │       │   └── @ UnexpectedError (location: (1:20)-(1:21))
-        │       │       ├── message: "Unexpected Token. Expected: `TOKEN_IDENTIFIER, TOKEN_ERB_START,TOKEN_WHITESPACE, or TOKEN_NEWLINE`, found: `TOKEN_QUOTE`."
+        │       │       ├── message: "Unexpected Token. Expected: `TOKEN_IDENTIFIER, TOKEN_AT, TOKEN_ERB_START,TOKEN_WHITESPACE, or TOKEN_NEWLINE`, found: `TOKEN_QUOTE`."
         │       │       ├── description: "Unexpected Token"
-        │       │       ├── expected: "TOKEN_IDENTIFIER, TOKEN_ERB_START,TOKEN_WHITESPACE, or TOKEN_NEWLINE"
+        │       │       ├── expected: "TOKEN_IDENTIFIER, TOKEN_AT, TOKEN_ERB_START,TOKEN_WHITESPACE, or TOKEN_NEWLINE"
         │       │       └── found: "TOKEN_QUOTE"
         │       │
         │       ├── tag_opening: "<" (location: (1:0)-(1:1))

--- a/test/snapshots/parser/attributes_test/test_0016_attributes_starting_with_@_symbol_90ae5bd03544cde697c6898cc52d03a7.txt
+++ b/test/snapshots/parser/attributes_test/test_0016_attributes_starting_with_@_symbol_90ae5bd03544cde697c6898cc52d03a7.txt
@@ -1,0 +1,54 @@
+@ DocumentNode (location: (1:0)-(1:54))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:54))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:48))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "div" (location: (1:1)-(1:4))
+        │       ├── tag_closing: ">" (location: (1:47)-(1:48))
+        │       ├── children: (2 items)
+        │       │   ├── @ HTMLAttributeNode (location: (1:5)-(1:25))
+        │       │   │   ├── name:
+        │       │   │   │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:11))
+        │       │   │   │       └── name: "@click" (location: (1:5)-(1:11))
+        │       │   │   │
+        │       │   │   ├── equals: "=" (location: (1:11)-(1:12))
+        │       │   │   └── value:
+        │       │   │       └── @ HTMLAttributeValueNode (location: (1:12)-(1:25))
+        │       │   │           ├── open_quote: """ (location: (1:12)-(1:13))
+        │       │   │           ├── children: (1 item)
+        │       │   │           │   └── @ LiteralNode (location: (1:13)-(1:24))
+        │       │   │           │       └── content: "handleClick"
+        │       │   │           │
+        │       │   │           ├── close_quote: """ (location: (1:24)-(1:25))
+        │       │   │           └── quoted: true
+        │       │   │
+        │       │   │
+        │       │   └── @ HTMLAttributeNode (location: (1:26)-(1:47))
+        │       │       ├── name:
+        │       │       │   └── @ HTMLAttributeNameNode (location: (1:26)-(1:38))
+        │       │       │       └── name: "@keyup.enter" (location: (1:26)-(1:38))
+        │       │       │
+        │       │       ├── equals: "=" (location: (1:38)-(1:39))
+        │       │       └── value:
+        │       │           └── @ HTMLAttributeValueNode (location: (1:39)-(1:47))
+        │       │               ├── open_quote: """ (location: (1:39)-(1:40))
+        │       │               ├── children: (1 item)
+        │       │               │   └── @ LiteralNode (location: (1:40)-(1:46))
+        │       │               │       └── content: "submit"
+        │       │               │
+        │       │               ├── close_quote: """ (location: (1:46)-(1:47))
+        │       │               └── quoted: true
+        │       │
+        │       │
+        │       └── is_void: false
+        │
+        ├── tag_name: "div" (location: (1:1)-(1:4))
+        ├── body: []
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:48)-(1:54))
+        │       ├── tag_opening: "</" (location: (1:48)-(1:50))
+        │       ├── tag_name: "div" (location: (1:50)-(1:53))
+        │       └── tag_closing: ">" (location: (1:53)-(1:54))
+        │
+        └── is_void: false

--- a/test/snapshots/parser/attributes_test/test_0017_@_attributes_with_various_patterns_1c9d04c71dfedc10b544c42b3452367c.txt
+++ b/test/snapshots/parser/attributes_test/test_0017_@_attributes_with_various_patterns_1c9d04c71dfedc10b544c42b3452367c.txt
@@ -1,0 +1,53 @@
+@ DocumentNode (location: (1:0)-(1:70))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:70))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:64))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "div" (location: (1:1)-(1:4))
+        │       ├── tag_closing: ">" (location: (1:63)-(1:64))
+        │       ├── children: (3 items)
+        │       │   ├── @ HTMLAttributeNode (location: (1:5)-(1:20))
+        │       │   │   ├── name:
+        │       │   │   │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:20))
+        │       │   │   │       └── name: "@submit.prevent" (location: (1:5)-(1:20))
+        │       │   │   │
+        │       │   │   ├── equals: ∅
+        │       │   │   └── value: ∅
+        │       │   │
+        │       │   ├── @ HTMLAttributeNode (location: (1:21)-(1:52))
+        │       │   │   ├── name:
+        │       │   │   │   └── @ HTMLAttributeNameNode (location: (1:21)-(1:43))
+        │       │   │   │       └── name: "@change.debounce.100ms" (location: (1:21)-(1:43))
+        │       │   │   │
+        │       │   │   ├── equals: "=" (location: (1:43)-(1:44))
+        │       │   │   └── value:
+        │       │   │       └── @ HTMLAttributeValueNode (location: (1:44)-(1:52))
+        │       │   │           ├── open_quote: """ (location: (1:44)-(1:45))
+        │       │   │           ├── children: (1 item)
+        │       │   │           │   └── @ LiteralNode (location: (1:45)-(1:51))
+        │       │   │           │       └── content: "update"
+        │       │   │           │
+        │       │   │           ├── close_quote: """ (location: (1:51)-(1:52))
+        │       │   │           └── quoted: true
+        │       │   │
+        │       │   │
+        │       │   └── @ HTMLAttributeNode (location: (1:53)-(1:63))
+        │       │       ├── name:
+        │       │       │   └── @ HTMLAttributeNameNode (location: (1:53)-(1:63))
+        │       │       │       └── name: "@mouseover" (location: (1:53)-(1:63))
+        │       │       │
+        │       │       ├── equals: ∅
+        │       │       └── value: ∅
+        │       │
+        │       └── is_void: false
+        │
+        ├── tag_name: "div" (location: (1:1)-(1:4))
+        ├── body: []
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:64)-(1:70))
+        │       ├── tag_opening: "</" (location: (1:64)-(1:66))
+        │       ├── tag_name: "div" (location: (1:66)-(1:69))
+        │       └── tag_closing: ">" (location: (1:69)-(1:70))
+        │
+        └── is_void: false

--- a/test/snapshots/parser/attributes_test/test_0018_standalone_@_symbol_in_div_tag_0fac4a8abe9de4433967e825056a4635.txt
+++ b/test/snapshots/parser/attributes_test/test_0018_standalone_@_symbol_in_div_tag_0fac4a8abe9de4433967e825056a4635.txt
@@ -1,0 +1,34 @@
+@ DocumentNode (location: (1:0)-(1:13))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:13))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:7))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "div" (location: (1:1)-(1:4))
+        │       ├── tag_closing: ">" (location: (1:6)-(1:7))
+        │       ├── children: (1 item)
+        │       │   └── @ HTMLAttributeNode (location: (1:5)-(1:6))
+        │       │       ├── name:
+        │       │       │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:6))
+        │       │       │       ├── errors: (1 error)
+        │       │       │       │   └── @ UnexpectedTokenError (location: (1:6)-(1:7))
+        │       │       │       │       ├── message: "Found `TOKEN_HTML_TAG_END` when expecting `TOKEN_IDENTIFIER` at (1:6)."
+        │       │       │       │       ├── expected_type: "TOKEN_IDENTIFIER"
+        │       │       │       │       └── found: ">" (location: (1:6)-(1:7))
+        │       │       │       │
+        │       │       │       └── name: "@" (location: (1:5)-(1:6))
+        │       │       │
+        │       │       ├── equals: ∅
+        │       │       └── value: ∅
+        │       │
+        │       └── is_void: false
+        │
+        ├── tag_name: "div" (location: (1:1)-(1:4))
+        ├── body: []
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:7)-(1:13))
+        │       ├── tag_opening: "</" (location: (1:7)-(1:9))
+        │       ├── tag_name: "div" (location: (1:9)-(1:12))
+        │       └── tag_closing: ">" (location: (1:12)-(1:13))
+        │
+        └── is_void: false

--- a/test/snapshots/parser/attributes_test/test_0019_standalone_@_symbol_followed_by_whitesapce_in_div_tag_651fc560524277c36845d3e3e3cb01ae.txt
+++ b/test/snapshots/parser/attributes_test/test_0019_standalone_@_symbol_followed_by_whitesapce_in_div_tag_651fc560524277c36845d3e3e3cb01ae.txt
@@ -1,0 +1,34 @@
+@ DocumentNode (location: (1:0)-(1:14))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:14))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:8))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "div" (location: (1:1)-(1:4))
+        │       ├── tag_closing: ">" (location: (1:7)-(1:8))
+        │       ├── children: (1 item)
+        │       │   └── @ HTMLAttributeNode (location: (1:5)-(1:6))
+        │       │       ├── name:
+        │       │       │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:6))
+        │       │       │       ├── errors: (1 error)
+        │       │       │       │   └── @ UnexpectedTokenError (location: (1:6)-(1:7))
+        │       │       │       │       ├── message: "Found `TOKEN_WHITESPACE` when expecting `TOKEN_IDENTIFIER` at (1:6)."
+        │       │       │       │       ├── expected_type: "TOKEN_IDENTIFIER"
+        │       │       │       │       └── found: " " (location: (1:6)-(1:7))
+        │       │       │       │
+        │       │       │       └── name: "@" (location: (1:5)-(1:6))
+        │       │       │
+        │       │       ├── equals: ∅
+        │       │       └── value: ∅
+        │       │
+        │       └── is_void: false
+        │
+        ├── tag_name: "div" (location: (1:1)-(1:4))
+        ├── body: []
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:8)-(1:14))
+        │       ├── tag_opening: "</" (location: (1:8)-(1:10))
+        │       ├── tag_name: "div" (location: (1:10)-(1:13))
+        │       └── tag_closing: ">" (location: (1:13)-(1:14))
+        │
+        └── is_void: false

--- a/test/snapshots/parser/attributes_test/test_0020_standalone_@_symbol_followed_by_whitesapce_and_identifier_in_div_tag_1f97e198235e78d1a25174baf6e1973d.txt
+++ b/test/snapshots/parser/attributes_test/test_0020_standalone_@_symbol_followed_by_whitesapce_and_identifier_in_div_tag_1f97e198235e78d1a25174baf6e1973d.txt
@@ -1,0 +1,42 @@
+@ DocumentNode (location: (1:0)-(1:19))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:19))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:13))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "div" (location: (1:1)-(1:4))
+        │       ├── tag_closing: ">" (location: (1:12)-(1:13))
+        │       ├── children: (2 items)
+        │       │   ├── @ HTMLAttributeNode (location: (1:5)-(1:6))
+        │       │   │   ├── name:
+        │       │   │   │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:6))
+        │       │   │   │       ├── errors: (1 error)
+        │       │   │   │       │   └── @ UnexpectedTokenError (location: (1:6)-(1:7))
+        │       │   │   │       │       ├── message: "Found `TOKEN_WHITESPACE` when expecting `TOKEN_IDENTIFIER` at (1:6)."
+        │       │   │   │       │       ├── expected_type: "TOKEN_IDENTIFIER"
+        │       │   │   │       │       └── found: " " (location: (1:6)-(1:7))
+        │       │   │   │       │
+        │       │   │   │       └── name: "@" (location: (1:5)-(1:6))
+        │       │   │   │
+        │       │   │   ├── equals: ∅
+        │       │   │   └── value: ∅
+        │       │   │
+        │       │   └── @ HTMLAttributeNode (location: (1:7)-(1:12))
+        │       │       ├── name:
+        │       │       │   └── @ HTMLAttributeNameNode (location: (1:7)-(1:12))
+        │       │       │       └── name: "click" (location: (1:7)-(1:12))
+        │       │       │
+        │       │       ├── equals: ∅
+        │       │       └── value: ∅
+        │       │
+        │       └── is_void: false
+        │
+        ├── tag_name: "div" (location: (1:1)-(1:4))
+        ├── body: []
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:13)-(1:19))
+        │       ├── tag_opening: "</" (location: (1:13)-(1:15))
+        │       ├── tag_name: "div" (location: (1:15)-(1:18))
+        │       └── tag_closing: ">" (location: (1:18)-(1:19))
+        │
+        └── is_void: false

--- a/test/snapshots/parser/attributes_test/test_0021_standalone_@_symbol_in_div_tag_followed_by_attribute_b71e23ffa38851540e408d9383abd12c.txt
+++ b/test/snapshots/parser/attributes_test/test_0021_standalone_@_symbol_in_div_tag_followed_by_attribute_b71e23ffa38851540e408d9383abd12c.txt
@@ -1,0 +1,51 @@
+@ DocumentNode (location: (1:0)-(1:35))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:35))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:29))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "div" (location: (1:1)-(1:4))
+        │       ├── tag_closing: ">" (location: (1:28)-(1:29))
+        │       ├── children: (2 items)
+        │       │   ├── @ HTMLAttributeNode (location: (1:5)-(1:6))
+        │       │   │   ├── name:
+        │       │   │   │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:6))
+        │       │   │   │       ├── errors: (1 error)
+        │       │   │   │       │   └── @ UnexpectedTokenError (location: (1:6)-(1:7))
+        │       │   │   │       │       ├── message: "Found `TOKEN_WHITESPACE` when expecting `TOKEN_IDENTIFIER` at (1:6)."
+        │       │   │   │       │       ├── expected_type: "TOKEN_IDENTIFIER"
+        │       │   │   │       │       └── found: " " (location: (1:6)-(1:7))
+        │       │   │   │       │
+        │       │   │   │       └── name: "@" (location: (1:5)-(1:6))
+        │       │   │   │
+        │       │   │   ├── equals: ∅
+        │       │   │   └── value: ∅
+        │       │   │
+        │       │   └── @ HTMLAttributeNode (location: (1:7)-(1:28))
+        │       │       ├── name:
+        │       │       │   └── @ HTMLAttributeNameNode (location: (1:7)-(1:21))
+        │       │       │       └── name: "data-attribute" (location: (1:7)-(1:21))
+        │       │       │
+        │       │       ├── equals: "=" (location: (1:21)-(1:22))
+        │       │       └── value:
+        │       │           └── @ HTMLAttributeValueNode (location: (1:22)-(1:28))
+        │       │               ├── open_quote: """ (location: (1:22)-(1:23))
+        │       │               ├── children: (1 item)
+        │       │               │   └── @ LiteralNode (location: (1:23)-(1:27))
+        │       │               │       └── content: "test"
+        │       │               │
+        │       │               ├── close_quote: """ (location: (1:27)-(1:28))
+        │       │               └── quoted: true
+        │       │
+        │       │
+        │       └── is_void: false
+        │
+        ├── tag_name: "div" (location: (1:1)-(1:4))
+        ├── body: []
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:29)-(1:35))
+        │       ├── tag_opening: "</" (location: (1:29)-(1:31))
+        │       ├── tag_name: "div" (location: (1:31)-(1:34))
+        │       └── tag_closing: ">" (location: (1:34)-(1:35))
+        │
+        └── is_void: false

--- a/test/snapshots/parser/attributes_test/test_0022_atttribute_with_@_prefix_and_now_value_6583f84753df8346dcd916f07301fc6b.txt
+++ b/test/snapshots/parser/attributes_test/test_0022_atttribute_with_@_prefix_and_now_value_6583f84753df8346dcd916f07301fc6b.txt
@@ -1,0 +1,28 @@
+@ DocumentNode (location: (1:0)-(1:18))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:18))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:12))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "div" (location: (1:1)-(1:4))
+        │       ├── tag_closing: ">" (location: (1:11)-(1:12))
+        │       ├── children: (1 item)
+        │       │   └── @ HTMLAttributeNode (location: (1:5)-(1:11))
+        │       │       ├── name:
+        │       │       │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:11))
+        │       │       │       └── name: "@click" (location: (1:5)-(1:11))
+        │       │       │
+        │       │       ├── equals: ∅
+        │       │       └── value: ∅
+        │       │
+        │       └── is_void: false
+        │
+        ├── tag_name: "div" (location: (1:1)-(1:4))
+        ├── body: []
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:12)-(1:18))
+        │       ├── tag_opening: "</" (location: (1:12)-(1:14))
+        │       ├── tag_name: "div" (location: (1:14)-(1:17))
+        │       └── tag_closing: ">" (location: (1:17)-(1:18))
+        │
+        └── is_void: false

--- a/test/snapshots/parser/tags_test/test_0016_colon_inside_html_tag_b7b46dcd10fad620a00a95b27daab204.txt
+++ b/test/snapshots/parser/tags_test/test_0016_colon_inside_html_tag_b7b46dcd10fad620a00a95b27daab204.txt
@@ -5,9 +5,9 @@
         │   └── @ HTMLOpenTagNode (location: (1:0)-(1:16))
         │       ├── errors: (1 error)
         │       │   └── @ UnexpectedError (location: (1:5)-(1:6))
-        │       │       ├── message: "Unexpected Token. Expected: `TOKEN_IDENTIFIER, TOKEN_ERB_START,TOKEN_WHITESPACE, or TOKEN_NEWLINE`, found: `TOKEN_COLON`."
+        │       │       ├── message: "Unexpected Token. Expected: `TOKEN_IDENTIFIER, TOKEN_AT, TOKEN_ERB_START,TOKEN_WHITESPACE, or TOKEN_NEWLINE`, found: `TOKEN_COLON`."
         │       │       ├── description: "Unexpected Token"
-        │       │       ├── expected: "TOKEN_IDENTIFIER, TOKEN_ERB_START,TOKEN_WHITESPACE, or TOKEN_NEWLINE"
+        │       │       ├── expected: "TOKEN_IDENTIFIER, TOKEN_AT, TOKEN_ERB_START,TOKEN_WHITESPACE, or TOKEN_NEWLINE"
         │       │       └── found: "TOKEN_COLON"
         │       │
         │       ├── tag_opening: "<" (location: (1:0)-(1:1))


### PR DESCRIPTION
This pull request improves the way parser handles Alpine.js-like attributes where the attribute name starts with a `@` sign. 

Previously, the parser would fail to parse HTML templates containing attributes such as `@click`, `@keyup.enter`, or `@change.debounce.100ms`, which are commonly used in Alpine.js and Vue.js applications.

The pull request extends the existing attribute name parsing logic to recognize `@` tokens as valid starting characters for attribute names.