### PR TITLE
Formatter: Fix inline element and ERB conditional attributes formatting

### DIFF
--- a/javascript/packages/formatter/test/cli.test.ts
+++ b/javascript/packages/formatter/test/cli.test.ts
@@ -1,3 +1,4 @@
+import dedent from "dedent"
 import { describe, it, expect, beforeEach, afterEach } from "vitest"
 import { spawn } from "child_process"
 import { writeFile, unlink, mkdir, rm, readFile } from "fs/promises"
@@ -141,10 +142,12 @@ describe("CLI Binary", () => {
       expect(result.stdout).toContain('Formatted: test-format.html.erb')
 
       const formattedContent = await readFile(testFile, 'utf-8')
-      expect(formattedContent).toContain('<div class="container">')
-      expect(formattedContent).toContain('  <%= "Hello" %>')
-      expect(formattedContent).toContain('  <p>World</p>')
-      expect(formattedContent).toContain('</div>')
+      expect(formattedContent).toBe(dedent`
+        <div class="container">
+          <%= "Hello" %>
+          <p>World</p>
+        </div>
+      ` + '\n')
     } finally {
       await unlink(testFile).catch(() => {})
     }
@@ -303,7 +306,7 @@ describe("CLI Binary", () => {
 
   it("should pass --check when file is already formatted", async () => {
     const testFile = "test-formatted.html.erb"
-    const input = '<div><p>Already formatted</p></div>\n'
+    const input = '<div>\n  <p>Already formatted</p>\n</div>\n'
 
     await writeFile(testFile, input)
 
@@ -338,7 +341,7 @@ describe("CLI Binary", () => {
     const formattedFile = join("test-dir", "formatted.html.erb")
     const unformattedFile = join("test-dir", "unformatted.html.erb")
 
-    await writeFile(formattedFile, '<div><p>Formatted</p></div>\n')
+    await writeFile(formattedFile, '<div>\n  <p>Formatted</p>\n</div>\n')
     await writeFile(unformattedFile, '<div><p>   Unformatted   </p></div>')
 
     try {

--- a/javascript/packages/formatter/test/document-formatting.test.ts
+++ b/javascript/packages/formatter/test/document-formatting.test.ts
@@ -86,7 +86,9 @@ describe("Document-level formatting", () => {
         <span>Welcome <%= user.name %></span>
       <% end %>
 
-      <main><p>Main content</p></main>
+      <main>
+        <p>Main content</p>
+      </main>
     `)
   })
 
@@ -158,14 +160,8 @@ describe("Document-level formatting", () => {
         </head>
         <body>
           <% if user_data %>
-            <h1>
-              Welcome
-              <%= user_data[:name] %>
-            </h1>
-            <p>
-              Age:
-              <%= user_data[:age] %>
-            </p>
+            <h1>Welcome <%= user_data[:name] %></h1>
+            <p>Age: <%= user_data[:age] %></p>
           <% end %>
           <footer>
             <p>&copy; 2024</p>
@@ -249,5 +245,223 @@ describe("Document-level formatting", () => {
 
       <footer>Footer</footer>
     `)
+  })
+
+  test("splits mixed content with nested block elements properly", () => {
+    const source = dedent`
+      <div>hello <div>complex <span>nested</span> content</div> world</div>
+    `
+
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <div>
+        hello
+        <div>complex <span>nested</span> content</div>
+        world
+      </div>
+    `)
+  })
+
+  test("handles mixed content in paragraph with block elements", () => {
+    const source = dedent`
+      <p>hello <div>complex <span>nested</span> content</div> world</p>
+    `
+
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <p>
+        hello
+        <div>complex <span>nested</span> content</div>
+        world
+      </p>
+    `)
+  })
+
+  test("formats nested paragraph in div with mixed content", () => {
+    const source = dedent`
+      <div>hello <p>complex <span>nested</span> content</p> world</div>
+    `
+
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <div>
+        hello
+        <p>complex <span>nested</span> content</p>
+        world
+      </div>
+    `)
+  })
+
+  test("preserves inline elements while splitting long mixed content", () => {
+    const source = dedent`
+      <p>hello <b>complex <span>nested</span> content</b> world</p>
+    `
+
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <p>
+        hello <b>complex <span>nested</span> content</b> world
+      </p>
+    `)
+  })
+
+  test("formats HTML elements with ERB conditionals inline when total attributes <= 3", () => {
+    const source = dedent`
+      <span <% if true %> class="one" <% end %> another="attribute" final="one">Content</span>
+    `
+
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <span <% if true %> class="one" <% end %> another="attribute" final="one">
+        Content
+      </span>
+    `)
+  })
+
+  test("formats regular HTML elements in multiline when attributes > 3", () => {
+    const source = dedent`
+      <div id="element" class="bg-gray-300" another="attribute" final="one">Content</div>
+    `
+
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <div
+        id="element"
+        class="bg-gray-300"
+        another="attribute"
+        final="one"
+      >
+        Content
+      </div>
+    `)
+  })
+
+  test("formats HTML elements with ERB conditionals in multiline when total attributes > 3", () => {
+    const source = dedent`
+      <div <% if disabled? %> disabled <% end %> id="element" class="bg-gray-300" another="attribute" final="one">Content</div>
+    `
+
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <div
+        <% if disabled? %>
+          disabled
+        <% end %>
+        id="element"
+        class="bg-gray-300"
+        another="attribute"
+        final="one"
+      >
+        Content
+      </div>
+    `)
+  })
+
+  test("formats self-closing tags with ERB conditionals in multiline when total attributes > 3", () => {
+    const source = dedent`
+      <input <% if disabled? %> disabled <% end %> id="element" class="bg-gray-300" another="attribute" final="one" />
+    `
+
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <input
+        <% if disabled? %>
+          disabled
+        <% end %>
+        id="element"
+        class="bg-gray-300"
+        another="attribute"
+        final="one"
+      />
+    `)
+  })
+
+  test("keeps self-closing tags with ERB conditionals inline when total attributes <= 3", () => {
+    const source = dedent`
+      <input <% if disabled? %> disabled <% end %> id="element" />
+    `
+
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <input <% if disabled? %> disabled <% end %> id="element" />
+    `)
+  })
+
+  test("formats void elements with ERB conditionals in multiline when total attributes > 3", () => {
+    const source = dedent`
+      <input <% if disabled? %> disabled <% end %> id="element" class="bg-gray-300" another="attribute" final="one">
+    `
+
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <input
+        <% if disabled? %>
+          disabled
+        <% end %>
+        id="element"
+        class="bg-gray-300"
+        another="attribute"
+        final="one"
+      >
+    `)
+  })
+
+  test("keeps void elements with ERB conditionals inline when total attributes <= 3", () => {
+    const source = dedent`
+      <input <% if disabled? %> disabled <% end %> id="element">
+    `
+
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <input <% if disabled? %> disabled <% end %> id="element">
+    `)
+  })
+
+  test("handles multiple ERB conditionals with attributes correctly", () => {
+    const source = dedent`
+      <div <% if disabled? %> disabled <% end %> <% if hidden? %> hidden <% end %> id="element" class="test">Content</div>
+    `
+
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <div
+        <% if disabled? %>
+          disabled
+        <% end %>
+        <% if hidden? %>
+          hidden
+        <% end %>
+        id="element"
+        class="test"
+      >
+        Content
+      </div>
+    `)
+  })
+
+  test("keeps simple ERB conditionals with few attributes inline", () => {
+    const source = dedent`
+      <span <% if active? %> class="active" <% end %>>Text</span>
+    `
+
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <span <% if active? %> class="active" <% end %>>
+        Text
+      </span>
+    `)
+  })
+
+  test("preserves inline opening tag for block elements with few attributes", () => {
+    const source = dedent`
+      <div class="flex flex-col">
+        <h3 class="line-clamp-1">
+          <pre>Content</pre>
+        </h3>
+      </div>
+    `
+
+    const result = formatter.format(source)
+    expect(result).toEqual(source)
   })
 })

--- a/javascript/packages/formatter/test/erb/whitespace-formatting.test.ts
+++ b/javascript/packages/formatter/test/erb/whitespace-formatting.test.ts
@@ -19,7 +19,7 @@ describe("ERB whitespace formatting", () => {
   describe("regression tests for whitespace formatting fix", () => {
     test("formats the original problematic snippet correctly", () => {
       const source = dedent`
-        <a href=""
+        <a href="/path"
           <% if disabled%>
             class="disabled"
           <%end%>
@@ -28,6 +28,17 @@ describe("ERB whitespace formatting", () => {
         </a>
       `
       const result = formatter.format(source)
+
+      expect(result).toBe(dedent`
+        <a
+          href="/path"
+          <% if disabled %>
+            class="disabled"
+          <% end %>
+        >
+          Text
+        </a>
+      `)
 
       expect(result).toContain('<% if disabled %>')
       expect(result).toContain('<% end %>')

--- a/javascript/packages/formatter/test/html/inline-elements.test.ts
+++ b/javascript/packages/formatter/test/html/inline-elements.test.ts
@@ -1,0 +1,211 @@
+import { describe, test, expect, beforeAll } from "vitest"
+import { Herb } from "@herb-tools/node-wasm"
+import { Formatter } from "../../src"
+
+import dedent from "dedent"
+
+let formatter: Formatter
+
+describe("@herb-tools/formatter - inline elements", () => {
+  beforeAll(async () => {
+    await Herb.load()
+
+    formatter = new Formatter(Herb, {
+      indentWidth: 2,
+      maxLineLength: 80
+    })
+  })
+
+  test("preserves inline elements in text flow (issue #251)", () => {
+    const source = dedent`
+      <p>Em<em>pha</em>sis</p>
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <p>Em<em>pha</em>sis</p>
+    `)
+  })
+
+  test("preserves strong elements inline", () => {
+    const source = dedent`
+      <p>This is <strong>important</strong> text.</p>
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <p>This is <strong>important</strong> text.</p>
+    `)
+  })
+
+  test("preserves span elements inline", () => {
+    const source = dedent`
+      <div>Some <span>inline</span> content</div>
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <div>Some <span>inline</span> content</div>
+    `)
+  })
+
+  test("preserves links with attributes inline", () => {
+    const source = dedent`
+      <p>A <a href="/link">link</a> in text</p>
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <p>A <a href="/link">link</a> in text</p>
+    `)
+  })
+
+  test("preserves multiple inline elements", () => {
+    const source = dedent`
+      <p>This has <em>emphasis</em> and <strong>strong</strong> text.</p>
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <p>This has <em>emphasis</em> and <strong>strong</strong> text.</p>
+    `)
+  })
+
+  test("preserves nested inline elements", () => {
+    const source = dedent`
+      <p>This is <strong>very <em>important</em></strong> text.</p>
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <p>This is <strong>very <em>important</em></strong> text.</p>
+    `)
+  })
+
+  test("preserves code elements inline", () => {
+    const source = dedent`
+      <p>Use the <code>foo()</code> function.</p>
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <p>Use the <code>foo()</code> function.</p>
+    `)
+  })
+
+  test("preserves abbr elements inline", () => {
+    const source = dedent`
+      <p>The <abbr title="World Health Organization">WHO</abbr> was founded in 1948.</p>
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <p>
+        The <abbr title="World Health Organization">WHO</abbr> was founded in 1948.
+      </p>
+    `)
+  })
+
+  test("preserves del and ins elements inline", () => {
+    const source = dedent`
+      <p>The price is <del>$50</del> <ins>$40</ins>.</p>
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <p>The price is <del>$50</del> <ins>$40</ins>.</p>
+    `)
+  })
+
+  test("correctly handles block elements in text flow", () => {
+    const source = dedent`
+      <div>Text before <div>block element</div> text after</div>
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <div>
+        Text before
+        <div>block element</div>
+        text after
+      </div>
+    `)
+  })
+
+  test("preserves inline elements with multiple attributes", () => {
+    const source = dedent`
+      <p>Visit <a href="/page" class="link" target="_blank">our page</a> today.</p>
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <p>Visit <a href="/page" class="link" target="_blank">our page</a> today.</p>
+    `)
+  })
+
+  test("normalizes malformed closing tag placement", () => {
+    const source = dedent`
+      <p>
+        Em<em>pha</em>sis</p>
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <p>Em<em>pha</em>sis</p>
+    `)
+  })
+
+  test("normalizes malformed closing tag placement", () => {
+    const source = dedent`
+      <p>
+        Em<em>pha</em>sis
+        </p>
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <p>Em<em>pha</em>sis</p>
+    `)
+  })
+
+  test("normalizes malformed closing tag placement", () => {
+    const source = dedent`
+      <p>
+                  Test
+        </p>
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <p>
+        Test
+      </p>
+    `)
+  })
+
+  test("normalizes malformed closing tag placement", () => {
+    const source = dedent`
+      <p>
+                  Test
+        </p>
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <p>
+        Test
+      </p>
+    `)
+  })
+
+  test("normalizes malformed closing tag placement", () => {
+    const source = dedent`
+      <p>
+        Test</p>
+
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <p>
+        Test
+      </p>
+    `)
+  })
+
+  test("TODO", () => {
+    const source = dedent`
+      <h2 class="title">Posts (<%= @posts.count %>)</h2>
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <h2 class="title">
+        Posts (<%= @posts.count %>)
+      </h2>
+    `)
+  })
+})

--- a/javascript/packages/formatter/test/html/text-content.test.ts
+++ b/javascript/packages/formatter/test/html/text-content.test.ts
@@ -98,7 +98,11 @@ describe("@herb-tools/formatter", () => {
     `
     const result = formatter.format(source)
     expect(result).toEqual(dedent`
-      <div>Simple <section>nested</section> content</div>
+      <div>
+        Simple
+        <section>nested</section>
+        content
+      </div>
     `)
   })
 
@@ -110,11 +114,7 @@ describe("@herb-tools/formatter", () => {
     expect(result).toEqual(dedent`
       <p>
         hello
-        <div>
-          complex
-          <span>nested</span>
-          content
-        </div>
+        <div>complex <span>nested</span> content</div>
         world
       </p>
     `)


### PR DESCRIPTION
This pull request improves the formatter by addressing two critical formatting issues. First, it resolves the problem described in issue #251 where inline elements within text flow were being unnecessarily broken across multiple lines, disrupting the visual presentation of content like `Em<em>pha</em>sis`. 

The formatter now correctly identifies text flow contexts and preserves inline elements on the same line as their surrounding text.

Second, it fixes spacing issues with ERB conditional attributes in HTML tags. Previously, ERB conditionals like `<span<% if condition %>class="active"<% end %>></span>` were being formatted with double spaces between ERB tag closings and attributes. 

The root cause was that ERB control flow nodes in HTML tag contexts were not being processed in inline mode, causing improper spacing logic to be applied.