### PR TITLE
Linter: Allow a new `LintContext` to be passed to linter rules

### DIFF
--- a/javascript/packages/language-server/src/linter_service.ts
+++ b/javascript/packages/language-server/src/linter_service.ts
@@ -29,7 +29,7 @@ export class LinterService {
       return { diagnostics: [] }
     }
 
-    const lintResult = this.linter.lint(textDocument.getText())
+    const lintResult = this.linter.lint(textDocument.getText(), { fileName: textDocument.uri })
     const diagnostics: Diagnostic[] = []
 
     lintResult.offenses.forEach(offense => {

--- a/javascript/packages/linter/generators/linter-rule/generators/app/templates/rule.ts.ejs
+++ b/javascript/packages/linter/generators/linter-rule/generators/app/templates/rule.ts.ejs
@@ -11,7 +11,7 @@
 
 import { BaseRuleVisitor } from "./rule-utils.js"
 import { ParserRule } from "../types.js"
-import type { LintOffense } from "../types.js"
+import type { LintOffense, LintContext } from "../types.js"
 import type { Node, HTMLElementNode, ERBContentNode } from "@herb-tools/core"
 
 class <%= visitorClassName %> extends BaseRuleVisitor {
@@ -31,8 +31,8 @@ class <%= visitorClassName %> extends BaseRuleVisitor {
 export class <%= ruleClassName %> extends ParserRule {
   name = "<%= ruleName %>"
 
-  check(node: Node): LintOffense[] {
-    const visitor = new <%= visitorClassName %>(this.name)
+  check(node: Node, context?: Partial<LintContext>): LintOffense[] {
+    const visitor = new <%= visitorClassName %>(this.name, context)
 
     visitor.visit(node)
 

--- a/javascript/packages/linter/src/cli/file-processor.ts
+++ b/javascript/packages/linter/src/cli/file-processor.ts
@@ -53,7 +53,7 @@ export class FileProcessor {
         this.linter = new Linter(Herb)
       }
 
-      const lintResult = this.linter.lint(content)
+      const lintResult = this.linter.lint(content, { fileName: filename })
 
       if (ruleCount === 0) {
         ruleCount = this.linter.getRuleCount()

--- a/javascript/packages/linter/src/linter.ts
+++ b/javascript/packages/linter/src/linter.ts
@@ -1,6 +1,6 @@
 import { defaultRules } from "./default-rules.js"
 
-import type { RuleClass, Rule, ParserRule, LexerRule, SourceRule, LintResult, LintOffense } from "./types.js"
+import type { RuleClass, Rule, ParserRule, LexerRule, SourceRule, LintResult, LintOffense, LintContext } from "./types.js"
 import type { HerbBackend } from "@herb-tools/core"
 
 export class Linter {
@@ -48,8 +48,9 @@ export class Linter {
   /**
    * Lint source code using Parser/AST, Lexer, and Source rules.
    * @param source - The source code to lint
+   * @param context - Optional context for linting (e.g., fileName for distinguishing files vs snippets)
    */
-  lint(source: string): LintResult {
+  lint(source: string, context?: Partial<LintContext>): LintResult {
     this.offenses = []
 
     const parseResult = this.herb.parse(source)
@@ -61,11 +62,11 @@ export class Linter {
       let ruleOffenses: LintOffense[]
 
       if (this.isLexerRule(rule)) {
-        ruleOffenses = (rule as LexerRule).check(lexResult)
+        ruleOffenses = (rule as LexerRule).check(lexResult, context)
       } else if (this.isSourceRule(rule)) {
-        ruleOffenses = (rule as SourceRule).check(source)
+        ruleOffenses = (rule as SourceRule).check(source, context)
       } else {
-        ruleOffenses = (rule as ParserRule).check(parseResult.value)
+        ruleOffenses = (rule as ParserRule).check(parseResult.value, context)
       }
 
       this.offenses.push(...ruleOffenses)

--- a/javascript/packages/linter/src/rules/erb-no-empty-tags.ts
+++ b/javascript/packages/linter/src/rules/erb-no-empty-tags.ts
@@ -1,7 +1,7 @@
 import { BaseRuleVisitor } from "./rule-utils.js"
 
 import { ParserRule } from "../types.js"
-import type { LintOffense } from "../types.js"
+import type { LintOffense, LintContext } from "../types.js"
 import type { Node, ERBContentNode } from "@herb-tools/core"
 
 class ERBNoEmptyTagsVisitor extends BaseRuleVisitor {
@@ -25,8 +25,8 @@ class ERBNoEmptyTagsVisitor extends BaseRuleVisitor {
 export class ERBNoEmptyTagsRule extends ParserRule {
   name = "erb-no-empty-tags"
 
-  check(node: Node): LintOffense[] {
-    const visitor = new ERBNoEmptyTagsVisitor(this.name)
+  check(node: Node, context?: Partial<LintContext>): LintOffense[] {
+    const visitor = new ERBNoEmptyTagsVisitor(this.name, context)
 
     visitor.visit(node)
 

--- a/javascript/packages/linter/src/rules/erb-no-output-control-flow.ts
+++ b/javascript/packages/linter/src/rules/erb-no-output-control-flow.ts
@@ -2,7 +2,7 @@ import { BaseRuleVisitor } from "./rule-utils.js"
 
 import type { Node, ERBIfNode, ERBUnlessNode, ERBElseNode, ERBEndNode } from "@herb-tools/core"
 import { ParserRule } from "../types.js"
-import type { LintOffense } from "../types.js"
+import type { LintOffense, LintContext } from "../types.js"
 
 class ERBNoOutputControlFlowRuleVisitor extends BaseRuleVisitor {
   visitERBIfNode(node: ERBIfNode): void {
@@ -53,8 +53,8 @@ class ERBNoOutputControlFlowRuleVisitor extends BaseRuleVisitor {
 export class ERBNoOutputControlFlowRule extends ParserRule {
   name = "erb-no-output-control-flow"
 
-  check(node: Node): LintOffense[] {
-    const visitor = new ERBNoOutputControlFlowRuleVisitor(this.name)
+  check(node: Node, context?: Partial<LintContext>): LintOffense[] {
+    const visitor = new ERBNoOutputControlFlowRuleVisitor(this.name, context)
 
     visitor.visit(node)
 

--- a/javascript/packages/linter/src/rules/erb-prefer-image-tag-helper.ts
+++ b/javascript/packages/linter/src/rules/erb-prefer-image-tag-helper.ts
@@ -1,7 +1,7 @@
 import { BaseRuleVisitor, getTagName, findAttributeByName, getAttributes } from "./rule-utils.js"
 
 import { ParserRule } from "../types.js"
-import type { LintOffense } from "../types.js"
+import type { LintOffense, LintContext } from "../types.js"
 import type { HTMLOpenTagNode, HTMLSelfCloseTagNode, HTMLAttributeValueNode, ERBContentNode, LiteralNode, Node } from "@herb-tools/core"
 
 class ERBPreferImageTagHelperVisitor extends BaseRuleVisitor {
@@ -116,8 +116,8 @@ class ERBPreferImageTagHelperVisitor extends BaseRuleVisitor {
 export class ERBPreferImageTagHelperRule extends ParserRule {
   name = "erb-prefer-image-tag-helper"
 
-  check(node: Node): LintOffense[] {
-    const visitor = new ERBPreferImageTagHelperVisitor(this.name)
+  check(node: Node, context?: Partial<LintContext>): LintOffense[] {
+    const visitor = new ERBPreferImageTagHelperVisitor(this.name, context)
     visitor.visit(node)
     return visitor.offenses
   }

--- a/javascript/packages/linter/src/rules/erb-require-whitespace-inside-tags.ts
+++ b/javascript/packages/linter/src/rules/erb-require-whitespace-inside-tags.ts
@@ -1,7 +1,7 @@
 import type { Node, Token } from "@herb-tools/core"
 import { isERBNode } from "@herb-tools/core";
 import { ParserRule } from "../types.js"
-import type { LintOffense } from "../types.js"
+import type { LintOffense, LintContext } from "../types.js"
 import { BaseRuleVisitor } from "./rule-utils.js"
 
 class RequireWhitespaceInsideTags extends BaseRuleVisitor {
@@ -85,8 +85,8 @@ class RequireWhitespaceInsideTags extends BaseRuleVisitor {
 export class ERBRequireWhitespaceRule extends ParserRule {
   name = "erb-require-whitespace-inside-tags"
 
-  check(node: Node): LintOffense[] {
-    const visitor = new RequireWhitespaceInsideTags(this.name)
+  check(node: Node, context?: Partial<LintContext>): LintOffense[] {
+    const visitor = new RequireWhitespaceInsideTags(this.name, context)
     visitor.visit(node)
     return visitor.offenses
   }

--- a/javascript/packages/linter/src/rules/erb-requires-trailing-newline.ts
+++ b/javascript/packages/linter/src/rules/erb-requires-trailing-newline.ts
@@ -1,11 +1,12 @@
 import { BaseSourceRuleVisitor, createEndOfFileLocation } from "./rule-utils.js"
 import { SourceRule } from "../types.js"
-import type { LintOffense } from "../types.js"
+import type { LintOffense, LintContext } from "../types.js"
 
 class ERBRequiresTrailingNewlineVisitor extends BaseSourceRuleVisitor {
   protected visitSource(source: string): void {
     if (source.length === 0) return
     if (source.endsWith('\n')) return
+    if (!this.context.fileName) return
 
     this.addOffense(
       "File must end with trailing newline",
@@ -18,8 +19,8 @@ class ERBRequiresTrailingNewlineVisitor extends BaseSourceRuleVisitor {
 export class ERBRequiresTrailingNewlineRule extends SourceRule {
   name = "erb-requires-trailing-newline"
 
-  check(source: string): LintOffense[] {
-    const visitor = new ERBRequiresTrailingNewlineVisitor(this.name)
+  check(source: string, context?: Partial<LintContext>): LintOffense[] {
+    const visitor = new ERBRequiresTrailingNewlineVisitor(this.name, context)
     visitor.visit(source)
     return visitor.offenses
   }

--- a/javascript/packages/linter/src/rules/html-anchor-require-href.ts
+++ b/javascript/packages/linter/src/rules/html-anchor-require-href.ts
@@ -1,7 +1,7 @@
 import { BaseRuleVisitor, getTagName, hasAttribute } from "./rule-utils.js"
 
 import { ParserRule } from "../types.js"
-import type { LintOffense } from "../types.js"
+import type { LintOffense, LintContext } from "../types.js"
 import type { HTMLOpenTagNode, Node } from "@herb-tools/core"
 
 class AnchorRechireHrefVisitor extends BaseRuleVisitor {
@@ -30,8 +30,8 @@ class AnchorRechireHrefVisitor extends BaseRuleVisitor {
 export class HTMLAnchorRequireHrefRule extends ParserRule {
   name = "html-anchor-require-href"
 
-  check(node: Node): LintOffense[] {
-    const visitor = new AnchorRechireHrefVisitor(this.name)
+  check(node: Node, context?: Partial<LintContext>): LintOffense[] {
+    const visitor = new AnchorRechireHrefVisitor(this.name, context)
 
     visitor.visit(node)
 

--- a/javascript/packages/linter/src/rules/html-aria-attribute-must-be-valid.ts
+++ b/javascript/packages/linter/src/rules/html-aria-attribute-must-be-valid.ts
@@ -3,7 +3,7 @@ import {
   AttributeVisitorMixin,
 } from "./rule-utils.js";
 import { ParserRule } from "../types.js";
-import type { LintOffense } from "../types.js";
+import type { LintOffense, LintContext } from "../types.js";
 import type {
   HTMLAttributeNode,
   HTMLOpenTagNode,
@@ -34,8 +34,8 @@ class AriaAttributeMustBeValid extends AttributeVisitorMixin {
 export class HTMLAriaAttributeMustBeValid extends ParserRule {
   name = "html-aria-attribute-must-be-valid";
 
-  check(node: Node): LintOffense[] {
-    const visitor = new AriaAttributeMustBeValid(this.name);
+  check(node: Node, context?: Partial<LintContext>): LintOffense[] {
+    const visitor = new AriaAttributeMustBeValid(this.name, context);
     visitor.visit(node);
     return visitor.offenses;
   }

--- a/javascript/packages/linter/src/rules/html-aria-level-must-be-valid.ts
+++ b/javascript/packages/linter/src/rules/html-aria-level-must-be-valid.ts
@@ -1,7 +1,7 @@
 import { AttributeVisitorMixin } from "./rule-utils.js"
 import { ParserRule } from "../types.js"
 
-import type { LintOffense } from "../types.js"
+import type { LintOffense, LintContext } from "../types.js"
 import type { Node, HTMLAttributeNode, HTMLOpenTagNode, HTMLSelfCloseTagNode } from "@herb-tools/core"
 
 class HTMLAriaLevelMustBeValidVisitor extends AttributeVisitorMixin {
@@ -24,8 +24,8 @@ class HTMLAriaLevelMustBeValidVisitor extends AttributeVisitorMixin {
 export class HTMLAriaLevelMustBeValidRule extends ParserRule {
   name = "html-aria-level-must-be-valid"
 
-  check(node: Node): LintOffense[] {
-    const visitor = new HTMLAriaLevelMustBeValidVisitor(this.name)
+  check(node: Node, context?: Partial<LintContext>): LintOffense[] {
+    const visitor = new HTMLAriaLevelMustBeValidVisitor(this.name, context)
 
     visitor.visit(node)
 

--- a/javascript/packages/linter/src/rules/html-aria-role-heading-requires-level.ts
+++ b/javascript/packages/linter/src/rules/html-aria-role-heading-requires-level.ts
@@ -1,7 +1,7 @@
 import { AttributeVisitorMixin, getAttributeName, getAttributes } from "./rule-utils.js"
 
 import { ParserRule } from "../types.js"
-import type { LintOffense } from "../types.js"
+import type { LintOffense, LintContext } from "../types.js"
 import type { Node, HTMLAttributeNode, HTMLOpenTagNode, HTMLSelfCloseTagNode } from "@herb-tools/core"
 
 class AriaRoleHeadingRequiresLevel extends AttributeVisitorMixin {
@@ -37,8 +37,8 @@ class AriaRoleHeadingRequiresLevel extends AttributeVisitorMixin {
 export class HTMLAriaRoleHeadingRequiresLevelRule extends ParserRule {
   name = "html-aria-role-heading-requires-level"
 
-  check(node: Node): LintOffense[] {
-    const visitor = new AriaRoleHeadingRequiresLevel(this.name)
+  check(node: Node, context?: Partial<LintContext>): LintOffense[] {
+    const visitor = new AriaRoleHeadingRequiresLevel(this.name, context)
     visitor.visit(node)
     return visitor.offenses
   }

--- a/javascript/packages/linter/src/rules/html-aria-role-must-be-valid.ts
+++ b/javascript/packages/linter/src/rules/html-aria-role-must-be-valid.ts
@@ -1,7 +1,7 @@
 import { AttributeVisitorMixin, VALID_ARIA_ROLES } from "./rule-utils.js"
 
 import { ParserRule } from "../types.js"
-import type { LintOffense } from "../types.js"
+import type { LintOffense, LintContext } from "../types.js"
 import type { Node, HTMLAttributeNode } from "@herb-tools/core"
 
 class AriaRoleMustBeValid extends AttributeVisitorMixin {
@@ -21,8 +21,8 @@ class AriaRoleMustBeValid extends AttributeVisitorMixin {
 export class HTMLAriaRoleMustBeValidRule extends ParserRule {
   name = "html-aria-role-must-be-valid"
 
-  check(node: Node): LintOffense[] {
-    const visitor = new AriaRoleMustBeValid(this.name)
+  check(node: Node, context?: Partial<LintContext>): LintOffense[] {
+    const visitor = new AriaRoleMustBeValid(this.name, context)
 
     visitor.visit(node)
 

--- a/javascript/packages/linter/src/rules/html-attribute-double-quotes.ts
+++ b/javascript/packages/linter/src/rules/html-attribute-double-quotes.ts
@@ -1,7 +1,7 @@
 import { AttributeVisitorMixin, getAttributeValueQuoteType, hasAttributeValue } from "./rule-utils.js"
 
 import { ParserRule } from "../types.js"
-import type { LintOffense } from "../types.js"
+import type { LintOffense, LintContext } from "../types.js"
 import type { Node, HTMLAttributeNode } from "@herb-tools/core"
 
 class AttributeDoubleQuotesVisitor extends AttributeVisitorMixin {
@@ -21,8 +21,8 @@ class AttributeDoubleQuotesVisitor extends AttributeVisitorMixin {
 export class HTMLAttributeDoubleQuotesRule extends ParserRule {
   name = "html-attribute-double-quotes"
 
-  check(node: Node): LintOffense[] {
-    const visitor = new AttributeDoubleQuotesVisitor(this.name)
+  check(node: Node, context?: Partial<LintContext>): LintOffense[] {
+    const visitor = new AttributeDoubleQuotesVisitor(this.name, context)
     visitor.visit(node)
     return visitor.offenses
   }

--- a/javascript/packages/linter/src/rules/html-attribute-values-require-quotes.ts
+++ b/javascript/packages/linter/src/rules/html-attribute-values-require-quotes.ts
@@ -1,7 +1,7 @@
 import { AttributeVisitorMixin } from "./rule-utils.js"
 
 import { ParserRule } from "../types.js"
-import type { LintOffense } from "../types.js"
+import type { LintOffense, LintContext } from "../types.js"
 import type { HTMLAttributeNode, HTMLAttributeValueNode, Node } from "@herb-tools/core"
 
 class AttributeValuesRequireQuotesVisitor extends AttributeVisitorMixin {
@@ -23,8 +23,8 @@ class AttributeValuesRequireQuotesVisitor extends AttributeVisitorMixin {
 export class HTMLAttributeValuesRequireQuotesRule extends ParserRule {
   name = "html-attribute-values-require-quotes"
 
-  check(node: Node): LintOffense[] {
-    const visitor = new AttributeValuesRequireQuotesVisitor(this.name)
+  check(node: Node, context?: Partial<LintContext>): LintOffense[] {
+    const visitor = new AttributeValuesRequireQuotesVisitor(this.name, context)
     visitor.visit(node)
     return visitor.offenses
   }

--- a/javascript/packages/linter/src/rules/html-boolean-attributes-no-value.ts
+++ b/javascript/packages/linter/src/rules/html-boolean-attributes-no-value.ts
@@ -1,7 +1,7 @@
 import { AttributeVisitorMixin, isBooleanAttribute, hasAttributeValue } from "./rule-utils.js"
 
 import { ParserRule } from "../types.js"
-import type { LintOffense } from "../types.js"
+import type { LintOffense, LintContext } from "../types.js"
 import type { HTMLAttributeNode, Node } from "@herb-tools/core"
 
 class BooleanAttributesNoValueVisitor extends AttributeVisitorMixin {
@@ -20,8 +20,8 @@ class BooleanAttributesNoValueVisitor extends AttributeVisitorMixin {
 export class HTMLBooleanAttributesNoValueRule extends ParserRule {
   name = "html-boolean-attributes-no-value"
 
-  check(node: Node): LintOffense[] {
-    const visitor = new BooleanAttributesNoValueVisitor(this.name)
+  check(node: Node, context?: Partial<LintContext>): LintOffense[] {
+    const visitor = new BooleanAttributesNoValueVisitor(this.name, context)
     visitor.visit(node)
     return visitor.offenses
   }

--- a/javascript/packages/linter/src/rules/html-img-require-alt.ts
+++ b/javascript/packages/linter/src/rules/html-img-require-alt.ts
@@ -1,7 +1,7 @@
 import { BaseRuleVisitor, getTagName, hasAttribute } from "./rule-utils.js"
 
 import { ParserRule } from "../types.js"
-import type { LintOffense } from "../types.js"
+import type { LintOffense, LintContext } from "../types.js"
 import type { HTMLOpenTagNode, HTMLSelfCloseTagNode, Node } from "@herb-tools/core"
 
 class ImgRequireAltVisitor extends BaseRuleVisitor {
@@ -35,8 +35,8 @@ class ImgRequireAltVisitor extends BaseRuleVisitor {
 export class HTMLImgRequireAltRule extends ParserRule {
   name = "html-img-require-alt"
 
-  check(node: Node): LintOffense[] {
-    const visitor = new ImgRequireAltVisitor(this.name)
+  check(node: Node, context?: Partial<LintContext>): LintOffense[] {
+    const visitor = new ImgRequireAltVisitor(this.name, context)
     visitor.visit(node)
     return visitor.offenses
   }

--- a/javascript/packages/linter/src/rules/html-no-block-inside-inline.ts
+++ b/javascript/packages/linter/src/rules/html-no-block-inside-inline.ts
@@ -1,7 +1,7 @@
 import { BaseRuleVisitor, isInlineElement, isBlockElement } from "./rule-utils.js"
 
 import { ParserRule } from "../types.js"
-import type { LintOffense } from "../types.js"
+import type { LintOffense, LintContext } from "../types.js"
 import type { HTMLOpenTagNode, HTMLElementNode, Node } from "@herb-tools/core"
 
 class BlockInsideInlineVisitor extends BaseRuleVisitor {
@@ -77,8 +77,8 @@ class BlockInsideInlineVisitor extends BaseRuleVisitor {
 export class HTMLNoBlockInsideInlineRule extends ParserRule {
   name = "html-no-block-inside-inline"
 
-  check(node: Node): LintOffense[] {
-    const visitor = new BlockInsideInlineVisitor(this.name)
+  check(node: Node, context?: Partial<LintContext>): LintOffense[] {
+    const visitor = new BlockInsideInlineVisitor(this.name, context)
     visitor.visit(node)
     return visitor.offenses
   }

--- a/javascript/packages/linter/src/rules/html-no-duplicate-attributes.ts
+++ b/javascript/packages/linter/src/rules/html-no-duplicate-attributes.ts
@@ -1,7 +1,7 @@
 import { BaseRuleVisitor, forEachAttribute } from "./rule-utils.js"
 
 import { ParserRule } from "../types.js"
-import type { LintOffense } from "../types.js"
+import type { LintOffense, LintContext } from "../types.js"
 import type { HTMLOpenTagNode, HTMLSelfCloseTagNode, HTMLAttributeNameNode, Node } from "@herb-tools/core"
 
 class NoDuplicateAttributesVisitor extends BaseRuleVisitor {
@@ -52,8 +52,8 @@ class NoDuplicateAttributesVisitor extends BaseRuleVisitor {
 export class HTMLNoDuplicateAttributesRule extends ParserRule {
   name = "html-no-duplicate-attributes"
 
-  check(node: Node): LintOffense[] {
-    const visitor = new NoDuplicateAttributesVisitor(this.name)
+  check(node: Node, context?: Partial<LintContext>): LintOffense[] {
+    const visitor = new NoDuplicateAttributesVisitor(this.name, context)
     visitor.visit(node)
     return visitor.offenses
   }

--- a/javascript/packages/linter/src/rules/html-no-duplicate-ids.ts
+++ b/javascript/packages/linter/src/rules/html-no-duplicate-ids.ts
@@ -1,7 +1,7 @@
 import { AttributeVisitorMixin } from "./rule-utils"
 import { ParserRule } from "../types"
 import type { Node } from "@herb-tools/core"
-import type { LintOffense } from "../types"
+import type { LintOffense, LintContext } from "../types"
 
 class NoDuplicateIdsVisitor extends AttributeVisitorMixin {
   private documentIds: Set<string> = new Set<string>()
@@ -29,8 +29,8 @@ class NoDuplicateIdsVisitor extends AttributeVisitorMixin {
 export class HTMLNoDuplicateIdsRule extends ParserRule {
   name = "html-no-duplicate-ids"
 
-  check(node: Node): LintOffense[] {
-    const visitor = new NoDuplicateIdsVisitor(this.name)
+  check(node: Node, context?: Partial<LintContext>): LintOffense[] {
+    const visitor = new NoDuplicateIdsVisitor(this.name, context)
 
     visitor.visit(node)
 

--- a/javascript/packages/linter/src/rules/html-no-empty-headings.ts
+++ b/javascript/packages/linter/src/rules/html-no-empty-headings.ts
@@ -1,7 +1,7 @@
 import { BaseRuleVisitor, getTagName, getAttributes, findAttributeByName, getAttributeValue, HEADING_TAGS } from "./rule-utils.js"
 
 import { ParserRule } from "../types.js"
-import type { LintOffense } from "../types.js"
+import type { LintOffense, LintContext } from "../types.js"
 import type { HTMLElementNode, HTMLOpenTagNode, HTMLSelfCloseTagNode, Node, LiteralNode, HTMLTextNode } from "@herb-tools/core"
 
 class NoEmptyHeadingsVisitor extends BaseRuleVisitor {
@@ -178,8 +178,8 @@ class NoEmptyHeadingsVisitor extends BaseRuleVisitor {
 export class HTMLNoEmptyHeadingsRule extends ParserRule {
   name = "html-no-empty-headings"
 
-  check(node: Node): LintOffense[] {
-    const visitor = new NoEmptyHeadingsVisitor(this.name)
+  check(node: Node, context?: Partial<LintContext>): LintOffense[] {
+    const visitor = new NoEmptyHeadingsVisitor(this.name, context)
     visitor.visit(node)
     return visitor.offenses
   }

--- a/javascript/packages/linter/src/rules/html-no-nested-links.ts
+++ b/javascript/packages/linter/src/rules/html-no-nested-links.ts
@@ -1,7 +1,7 @@
 import { BaseRuleVisitor, getTagName } from "./rule-utils.js"
 
 import { ParserRule } from "../types.js"
-import type { LintOffense } from "../types.js"
+import type { LintOffense, LintContext } from "../types.js"
 import type { HTMLOpenTagNode, HTMLElementNode, Node } from "@herb-tools/core"
 
 class NestedLinkVisitor extends BaseRuleVisitor {
@@ -58,8 +58,8 @@ class NestedLinkVisitor extends BaseRuleVisitor {
 export class HTMLNoNestedLinksRule extends ParserRule {
   name = "html-no-nested-links"
 
-  check(node: Node): LintOffense[] {
-    const visitor = new NestedLinkVisitor(this.name)
+  check(node: Node, context?: Partial<LintContext>): LintOffense[] {
+    const visitor = new NestedLinkVisitor(this.name, context)
     visitor.visit(node)
     return visitor.offenses
   }

--- a/javascript/packages/linter/src/rules/html-tag-name-lowercase.ts
+++ b/javascript/packages/linter/src/rules/html-tag-name-lowercase.ts
@@ -1,7 +1,7 @@
 import { BaseRuleVisitor } from "./rule-utils.js"
 
 import { ParserRule } from "../types.js"
-import type { LintOffense } from "../types.js"
+import type { LintOffense, LintContext } from "../types.js"
 import type { HTMLElementNode, HTMLOpenTagNode, HTMLCloseTagNode, HTMLSelfCloseTagNode, Node } from "@herb-tools/core"
 
 class TagNameLowercaseVisitor extends BaseRuleVisitor {
@@ -58,8 +58,8 @@ class TagNameLowercaseVisitor extends BaseRuleVisitor {
 export class HTMLTagNameLowercaseRule extends ParserRule {
   name = "html-tag-name-lowercase"
 
-  check(node: Node): LintOffense[] {
-    const visitor = new TagNameLowercaseVisitor(this.name)
+  check(node: Node, context?: Partial<LintContext>): LintOffense[] {
+    const visitor = new TagNameLowercaseVisitor(this.name, context)
     visitor.visit(node)
     return visitor.offenses
   }

--- a/javascript/packages/linter/src/rules/rule-utils.ts
+++ b/javascript/packages/linter/src/rules/rule-utils.ts
@@ -15,7 +15,8 @@ import type {
   LexResult,
   Token
 } from "@herb-tools/core"
-import type { LintOffense, LintSeverity, } from "../types.js"
+import type { LintOffense, LintSeverity, LintContext } from "../types.js"
+import { DEFAULT_LINT_CONTEXT } from "../types.js"
 
 /**
  * Base visitor class that provides common functionality for rule visitors
@@ -23,11 +24,13 @@ import type { LintOffense, LintSeverity, } from "../types.js"
 export abstract class BaseRuleVisitor extends Visitor {
   public readonly offenses: LintOffense[] = []
   protected ruleName: string
+  protected context: LintContext
 
-  constructor(ruleName: string) {
+  constructor(ruleName: string, context?: Partial<LintContext>) {
     super()
 
     this.ruleName = ruleName
+    this.context = { ...DEFAULT_LINT_CONTEXT, ...context }
   }
 
   /**
@@ -345,6 +348,10 @@ export function isBooleanAttribute(attributeName: string): boolean {
  * and attribute iteration logic. Provides simplified interface with extracted attribute info.
  */
 export abstract class AttributeVisitorMixin extends BaseRuleVisitor {
+  constructor(ruleName: string, context?: Partial<LintContext>) {
+    super(ruleName, context)
+  }
+
   visitHTMLOpenTagNode(node: HTMLOpenTagNode): void {
     this.checkAttributesOnNode(node)
     super.visitHTMLOpenTagNode(node)
@@ -409,9 +416,11 @@ export function forEachAttribute(
 export abstract class BaseLexerRuleVisitor {
   public readonly offenses: LintOffense[] = []
   protected ruleName: string
+  protected context: LintContext
 
-  constructor(ruleName: string) {
+  constructor(ruleName: string, context?: Partial<LintContext>) {
     this.ruleName = ruleName
+    this.context = { ...DEFAULT_LINT_CONTEXT, ...context }
   }
 
   /**
@@ -469,9 +478,11 @@ export abstract class BaseLexerRuleVisitor {
 export abstract class BaseSourceRuleVisitor {
   public readonly offenses: LintOffense[] = []
   protected ruleName: string
+  protected context: LintContext
 
-  constructor(ruleName: string) {
+  constructor(ruleName: string, context?: Partial<LintContext>) {
     this.ruleName = ruleName
+    this.context = { ...DEFAULT_LINT_CONTEXT, ...context }
   }
 
   /**

--- a/javascript/packages/linter/src/rules/svg-tag-name-capitalization.ts
+++ b/javascript/packages/linter/src/rules/svg-tag-name-capitalization.ts
@@ -1,7 +1,7 @@
 import { BaseRuleVisitor, SVG_CAMEL_CASE_ELEMENTS, SVG_LOWERCASE_TO_CAMELCASE } from "./rule-utils.js"
 
 import { ParserRule } from "../types.js"
-import type { LintOffense } from "../types.js"
+import type { LintOffense, LintContext } from "../types.js"
 import type { HTMLElementNode, HTMLOpenTagNode, HTMLCloseTagNode, HTMLSelfCloseTagNode, Node } from "@herb-tools/core"
 
 class SVGTagNameCapitalizationVisitor extends BaseRuleVisitor {
@@ -66,8 +66,8 @@ class SVGTagNameCapitalizationVisitor extends BaseRuleVisitor {
 export class SVGTagNameCapitalizationRule extends ParserRule {
   name = "svg-tag-name-capitalization"
 
-  check(node: Node): LintOffense[] {
-    const visitor = new SVGTagNameCapitalizationVisitor(this.name)
+  check(node: Node, context?: Partial<LintContext>): LintOffense[] {
+    const visitor = new SVGTagNameCapitalizationVisitor(this.name, context)
     visitor.visit(node)
     return visitor.offenses
   }

--- a/javascript/packages/linter/src/types.ts
+++ b/javascript/packages/linter/src/types.ts
@@ -23,13 +23,13 @@ export interface LintResult {
 export abstract class ParserRule {
   static type = "parser" as const
   abstract name: string
-  abstract check(node: Node): LintOffense[]
+  abstract check(node: Node, context?: Partial<LintContext>): LintOffense[]
 }
 
 export abstract class LexerRule {
   static type = "lexer" as const
   abstract name: string
-  abstract check(lexResult: LexResult): LintOffense[]
+  abstract check(lexResult: LexResult, context?: Partial<LintContext>): LintOffense[]
 }
 
 export interface LexerRuleConstructor {
@@ -37,10 +37,25 @@ export interface LexerRuleConstructor {
   new (): LexerRule
 }
 
+/**
+ * Complete lint context with all properties defined.
+ * Use Partial<LintContext> when passing context to rules.
+ */
+export interface LintContext {
+  fileName: string | undefined
+}
+
+/**
+ * Default context object with all keys defined but set to undefined
+ */
+export const DEFAULT_LINT_CONTEXT: LintContext = {
+  fileName: undefined
+} as const
+
 export abstract class SourceRule {
   static type = "source" as const
   abstract name: string
-  abstract check(source: string): LintOffense[]
+  abstract check(source: string, context?: Partial<LintContext>): LintOffense[]
 }
 
 export interface SourceRuleConstructor {

--- a/javascript/packages/linter/test/cli.test.ts
+++ b/javascript/packages/linter/test/cli.test.ts
@@ -80,4 +80,12 @@ describe("CLI Output Formatting", () => {
     const wrappedLines = lines.filter(line => line.match(/^\s+│\s/))
     expect(wrappedLines.length).toBeGreaterThan(0)
   })
+
+  test("correctly passes filename context for file-specific rules", () => {
+    const { output, exitCode } = runLinter("no-trailing-newline.html.erb", "--simple", "--no-wrap-lines")
+
+    expect(output).toContain("erb-requires-trailing-newline")
+    expect(output).toContain("File must end with trailing newline")
+    expect(exitCode).toBe(1)
+  })
 })

--- a/javascript/packages/linter/test/fixtures/no-trailing-newline.html.erb
+++ b/javascript/packages/linter/test/fixtures/no-trailing-newline.html.erb
@@ -1,0 +1,1 @@
+<div>No trailing newline</div>

--- a/javascript/packages/linter/test/rules/erb-requires-trailing-newline.test.ts
+++ b/javascript/packages/linter/test/rules/erb-requires-trailing-newline.test.ts
@@ -58,7 +58,7 @@ describe("ERBRequiresTrailingNewlineRule", () => {
     `
 
     const linter = new Linter(Herb, [ERBRequiresTrailingNewlineRule])
-    const lintResult = linter.lint(html)
+    const lintResult = linter.lint(html, { fileName: "test.html.erb" })
 
     expect(lintResult.errors).toBe(1)
     expect(lintResult.warnings).toBe(0)
@@ -70,7 +70,7 @@ describe("ERBRequiresTrailingNewlineRule", () => {
   test("should report errors for single line files without newline", () => {
     const html = `<%= render partial: "header" %>`
     const linter = new Linter(Herb, [ERBRequiresTrailingNewlineRule])
-    const lintResult = linter.lint(html)
+    const lintResult = linter.lint(html, { fileName: "test.html.erb" })
 
     expect(lintResult.errors).toBe(1)
     expect(lintResult.warnings).toBe(0)
@@ -90,7 +90,7 @@ describe("ERBRequiresTrailingNewlineRule", () => {
     `
 
     const linter = new Linter(Herb, [ERBRequiresTrailingNewlineRule])
-    const lintResult = linter.lint(html)
+    const lintResult = linter.lint(html, { fileName: "test.html.erb" })
 
     expect(lintResult.errors).toBe(1)
     expect(lintResult.warnings).toBe(0)
@@ -120,7 +120,7 @@ describe("ERBRequiresTrailingNewlineRule", () => {
   test("should handle ERB-only template without trailing newline", () => {
     const html = `<%= hello world %>`
     const linter = new Linter(Herb, [ERBRequiresTrailingNewlineRule])
-    const lintResult = linter.lint(html)
+    const lintResult = linter.lint(html, { fileName: "test.html.erb" })
 
     expect(lintResult.errors).toBe(1)
     expect(lintResult.warnings).toBe(0)
@@ -152,7 +152,7 @@ describe("ERBRequiresTrailingNewlineRule", () => {
   test("should flag empty file with whitespace", () => {
     const html = ` `
     const linter = new Linter(Herb, [ERBRequiresTrailingNewlineRule])
-    const lintResult = linter.lint(html)
+    const lintResult = linter.lint(html, { fileName: "test.html.erb" })
 
     expect(lintResult.errors).toBe(1)
     expect(lintResult.warnings).toBe(0)

--- a/javascript/packages/linter/test/rules/erb-requires-trailing-newline.test.ts
+++ b/javascript/packages/linter/test/rules/erb-requires-trailing-newline.test.ts
@@ -160,4 +160,66 @@ describe("ERBRequiresTrailingNewlineRule", () => {
     expect(lintResult.offenses[0].rule).toBe("erb-requires-trailing-newline")
     expect(lintResult.offenses[0].message).toBe("File must end with trailing newline")
   })
+
+  test("should not flag snippets without trailing newline (fileName: null)", () => {
+    const html = dedent`
+      <h1>
+        <%= title %>
+      </h1>
+    `
+
+    const linter = new Linter(Herb, [ERBRequiresTrailingNewlineRule])
+    const lintResult = linter.lint(html, { fileName: null })
+
+    expect(lintResult.errors).toBe(0)
+    expect(lintResult.warnings).toBe(0)
+    expect(lintResult.offenses).toHaveLength(0)
+  })
+
+  test("should not flag single line snippets without trailing newline (fileName: null)", () => {
+    const html = `<%= render partial: "header" %>`
+    const linter = new Linter(Herb, [ERBRequiresTrailingNewlineRule])
+    const lintResult = linter.lint(html, { fileName: null })
+
+    expect(lintResult.errors).toBe(0)
+    expect(lintResult.warnings).toBe(0)
+    expect(lintResult.offenses).toHaveLength(0)
+  })
+
+  test("should not flag single line snippets without trailing newline (fileName: undefined)", () => {
+    const html = `<%= render partial: "header" %>`
+    const linter = new Linter(Herb, [ERBRequiresTrailingNewlineRule])
+    const lintResult = linter.lint(html, { fileName: undefined })
+
+    expect(lintResult.errors).toBe(0)
+    expect(lintResult.warnings).toBe(0)
+    expect(lintResult.offenses).toHaveLength(0)
+  })
+
+  test("should not flag single line snippets without trailing newline with no context", () => {
+    const html = `<%= render partial: "header" %>`
+    const linter = new Linter(Herb, [ERBRequiresTrailingNewlineRule])
+    const lintResult = linter.lint(html)
+
+    expect(lintResult.errors).toBe(0)
+    expect(lintResult.warnings).toBe(0)
+    expect(lintResult.offenses).toHaveLength(0)
+  })
+
+  test("should flag files without trailing newline when fileName is provided", () => {
+    const html = dedent`
+      <h1>
+        <%= title %>
+      </h1>
+    `
+
+    const linter = new Linter(Herb, [ERBRequiresTrailingNewlineRule])
+    const lintResult = linter.lint(html, { fileName: "template.html.erb" })
+
+    expect(lintResult.errors).toBe(1)
+    expect(lintResult.warnings).toBe(0)
+    expect(lintResult.offenses).toHaveLength(1)
+    expect(lintResult.offenses[0].rule).toBe("erb-requires-trailing-newline")
+    expect(lintResult.offenses[0].message).toBe("File must end with trailing newline")
+  })
 })

--- a/javascript/packages/vscode/src/parse-worker.js
+++ b/javascript/packages/vscode/src/parse-worker.js
@@ -37,7 +37,7 @@ const { Linter } = require('@herb-tools/linter');
     if (parseErrors === 0 && linterEnabled) {
       try {
         const linter = new Linter(Herb);
-        const lintResult = linter.lint(content);
+        const lintResult = linter.lint(content, { fileName: file });
 
         lintOffenses = lintResult.offenses || [];
       } catch (lintError) {


### PR DESCRIPTION
This pull request adds a context to the linter rule to be able to distinguish between file linting and snippet linting. Rules can now access filename information through a shared context object, enabling different behavior for actual files versus code snippets used in documentation or testing.

We added this functionality so we could remove the `erb-requires-trailing-newline` offenses in all the code snippets in the docs, that weren't really valid since the snippets in markdown aren't really files. By not passing a filename we now assume that this comes from stdin or a snippet and therefore don't the `erb-requires-trailing-newline` rule in that case.

This change also allows us to pass around context in the future to build more sophisticated rules.