### PR TITLE
Remove unused argument in `LinterService.lintDocument`

### DIFF
--- a/javascript/packages/language-server/src/diagnostics.ts
+++ b/javascript/packages/language-server/src/diagnostics.ts
@@ -26,7 +26,7 @@ export class Diagnostics {
 
   async validate(textDocument: TextDocument) {
     const parseResult = this.parserService.parseDocument(textDocument)
-    const lintResult = await this.linterService.lintDocument(parseResult.document, textDocument)
+    const lintResult = await this.linterService.lintDocument(textDocument)
 
     const allDiagnostics = [
       ...parseResult.diagnostics,

--- a/javascript/packages/language-server/src/linter_service.ts
+++ b/javascript/packages/language-server/src/linter_service.ts
@@ -5,8 +5,6 @@ import { Herb } from "@herb-tools/node-wasm"
 
 import { Settings } from "./settings"
 
-import type { DocumentNode } from "@herb-tools/node-wasm"
-
 export interface LintServiceResult {
   diagnostics: Diagnostic[]
 }
@@ -21,7 +19,7 @@ export class LinterService {
     this.linter = new Linter(Herb)
   }
 
-  async lintDocument(document: DocumentNode, textDocument: TextDocument): Promise<LintServiceResult> {
+  async lintDocument(textDocument: TextDocument): Promise<LintServiceResult> {
     const settings = await this.settings.getDocumentSettings(textDocument.uri)
     const linterEnabled = settings?.linter?.enabled ?? true
 

--- a/javascript/packages/language-server/test/linter_service.test.ts
+++ b/javascript/packages/language-server/test/linter_service.test.ts
@@ -36,11 +36,9 @@ describe("LinterService", () => {
       settings.getDocumentSettings = vi.fn().mockResolvedValue(null)
 
       const linterService = new LinterService(settings)
-      const parseResult = Herb.parse("<div>Test</div>\n")
-      const document = parseResult.value
       const textDocument = createTestDocument("<div>Test</div>\n")
 
-      const result = await linterService.lintDocument(document, textDocument)
+      const result = await linterService.lintDocument(textDocument)
 
       expect(result).toBeDefined()
       expect(result.diagnostics).toEqual([])
@@ -54,11 +52,9 @@ describe("LinterService", () => {
       })
 
       const linterService = new LinterService(settings)
-      const parseResult = Herb.parse("<div>Test</div>\n")
-      const document = parseResult.value
       const textDocument = createTestDocument("<div>Test</div>\n")
 
-      const result = await linterService.lintDocument(document, textDocument)
+      const result = await linterService.lintDocument(textDocument)
 
       expect(result).toBeDefined()
       expect(result.diagnostics).toBeDefined()
@@ -71,11 +67,9 @@ describe("LinterService", () => {
       })
 
       const linterService = new LinterService(settings)
-      const parseResult = Herb.parse("<DIV>Test</DIV>\n")
-      const document = parseResult.value
       const textDocument = createTestDocument("<DIV>Test</DIV>\n")
 
-      const result = await linterService.lintDocument(document, textDocument)
+      const result = await linterService.lintDocument(textDocument)
 
       expect(result.diagnostics).toEqual([])
     })
@@ -87,11 +81,9 @@ describe("LinterService", () => {
       })
 
       const linterService = new LinterService(settings)
-      const parseResult = Herb.parse("<DIV><SPAN>Hello</SPAN></DIV>")
-      const document = parseResult.value
       const textDocument = createTestDocument("<DIV><SPAN>Hello</SPAN></DIV>")
 
-      const result = await linterService.lintDocument(document, textDocument)
+      const result = await linterService.lintDocument(textDocument)
 
       expect(result.diagnostics.length).toBeGreaterThan(0)
     })
@@ -101,11 +93,9 @@ describe("LinterService", () => {
       settings.hasConfigurationCapability = false
 
       const linterService = new LinterService(settings)
-      const parseResult = Herb.parse("<DIV>Test</DIV>")
-      const document = parseResult.value
       const textDocument = createTestDocument("<DIV>Test</DIV>")
 
-      const result = await linterService.lintDocument(document, textDocument)
+      const result = await linterService.lintDocument(textDocument)
 
       expect(result.diagnostics.length).toBeGreaterThan(0)
     })


### PR DESCRIPTION
This pull request refactors the `LinterService.lintDocument()` function and removes the now unused `DocumentNode` argument.