### PR TITLE
Handle empty attribute case for `html-aria-level-must-be-valid` rule

### DIFF
--- a/javascript/packages/linter/src/rules/html-aria-level-must-be-valid.ts
+++ b/javascript/packages/linter/src/rules/html-aria-level-must-be-valid.ts
@@ -7,8 +7,16 @@ import type { Node, HTMLAttributeNode, HTMLOpenTagNode, HTMLSelfCloseTagNode } f
 class HTMLAriaLevelMustBeValidVisitor extends AttributeVisitorMixin {
   protected checkAttribute(attributeName: string, attributeValue: string | null, attributeNode: HTMLAttributeNode, _parentNode: HTMLOpenTagNode | HTMLSelfCloseTagNode): void {
     if (attributeName !== "aria-level") return
-    if (attributeValue === null) return
-    if (attributeValue.includes("<%")) return
+    if (attributeValue !== null && attributeValue.includes("<%")) return
+
+    if (attributeValue === null || attributeValue === "") {
+      this.addOffense(
+        `The \`aria-level\` attribute must be an integer between 1 and 6, got an empty value.`,
+        attributeNode.location,
+      )
+
+      return
+    }
 
     const number = parseInt(attributeValue)
 

--- a/javascript/packages/linter/test/rules/html-aria-level-must-be-valid.test.ts
+++ b/javascript/packages/linter/test/rules/html-aria-level-must-be-valid.test.ts
@@ -175,4 +175,20 @@ describe("HTMLAriaLevelMustBeValidRule", () => {
     expect(lintResult.warnings).toBe(0)
     expect(lintResult.offenses).toHaveLength(0)
   })
+
+  test("flags empty aria-level attribute", () => {
+    const html = dedent`
+      <div role="heading" aria-level="">Empty value</div>
+    `
+    const linter = new Linter(Herb, [HTMLAriaLevelMustBeValidRule])
+    const lintResult = linter.lint(html)
+
+    expect(lintResult.errors).toBe(1)
+    expect(lintResult.warnings).toBe(0)
+    expect(lintResult.offenses).toHaveLength(1)
+    expect(lintResult.offenses[0].code).toBe("html-aria-level-must-be-valid")
+    expect(lintResult.offenses[0].message).toBe(
+      'The `aria-level` attribute must be an integer between 1 and 6, got an empty value.',
+    )
+  })
 })


### PR DESCRIPTION
This pull request improves the `html-aria-level-must-be-valid` linter rule introduced in #338 to also flag empty `aria-level` attributes.

After this change, it will now also flag this snippet:
```html
<div role="heading" aria-level="">Empty value</div>
```
