### PR TITLE
Formatter: Support formatting `case`/`in` statements

### DIFF
--- a/javascript/packages/formatter/src/printer.ts
+++ b/javascript/packages/formatter/src/printer.ts
@@ -137,6 +137,7 @@ export class Printer extends Visitor {
       node instanceof ERBUnlessNode || (node as any).type === 'AST_ERB_UNLESS_NODE' ||
       node instanceof ERBBlockNode || (node as any).type === 'AST_ERB_BLOCK_NODE' ||
       node instanceof ERBCaseNode || (node as any).type === 'AST_ERB_CASE_NODE' ||
+      node instanceof ERBCaseMatchNode || (node as any).type === 'AST_ERB_CASE_MATCH_NODE' ||
       node instanceof ERBWhileNode || (node as any).type === 'AST_ERB_WHILE_NODE' ||
       node instanceof ERBForNode || (node as any).type === 'AST_ERB_FOR_NODE'
   }
@@ -895,10 +896,19 @@ export class Printer extends Visitor {
 
   visitERBInNode(node: ERBInNode): void {
     this.printERBNode(node)
+
+    this.withIndent(() => {
+      node.statements.forEach(stmt => this.visit(stmt))
+    })
   }
 
   visitERBCaseMatchNode(node: ERBCaseMatchNode): void {
     this.printERBNode(node)
+
+    node.conditions.forEach(condition => this.visit(condition))
+
+    if (node.else_clause) this.visit(node.else_clause)
+    if (node.end_node) this.visit(node.end_node)
   }
 
   visitERBBlockNode(node: ERBBlockNode): void {

--- a/javascript/packages/formatter/test/erb/case.test.ts
+++ b/javascript/packages/formatter/test/erb/case.test.ts
@@ -51,4 +51,53 @@ describe("@herb-tools/formatter", () => {
       </div>
     `)
   })
+
+  test("formats ERB case/in statements", () => {
+    const source = dedent`
+      <% case { hash: { nested: '4' } } %>
+            <% in { hash: { nested: } } %>
+      <span>there</span>
+              <% in { another: } %>
+      <span>there</span>
+      <% in { yet_another: { nested: } } %>
+             <span>hi</span>
+            <% else %>
+      <span>there</span>
+        <% end %>
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <% case { hash: { nested: '4' } } %>
+      <% in { hash: { nested: } } %>
+        <span>there</span>
+      <% in { another: } %>
+        <span>there</span>
+      <% in { yet_another: { nested: } } %>
+        <span>hi</span>
+      <% else %>
+        <span>there</span>
+      <% end %>
+    `)
+  })
+
+  test("formats ERB case/in/else statements", () => {
+    const source = dedent`
+      <% case { hash: { nested: '4' } } %>
+            <% in { hash: { nested: } } %>
+            2
+              <% else %>
+              3
+
+      <% end %>
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <% case { hash: { nested: '4' } } %>
+      <% in { hash: { nested: } } %>
+        2
+      <% else %>
+        3
+      <% end %>
+    `)
+  })
 })


### PR DESCRIPTION
This pull request adds support for formatting `case/in` statements.

Previously it would only format the `case` line and omit all `in` nodes. Now an input like:

```erb
     <% case { hash: { nested: '4' } } %>
            <% in { hash: { nested: } } %>
      <span>there</span>
              <% in { another: } %>
      <span>there</span>
      <% in { yet_another: { nested: } } %>
             <span>hi</span>
            <% else %>
      <span>there</span>
        <% end %>
```

Will now format as:

```erb
<% case { hash: { nested: '4' } } %>
<% in { hash: { nested: } } %>
  <span>there</span>
<% in { another: } %>
  <span>there</span>
<% in { yet_another: { nested: } } %>
  <span>hi</span>
<% else %>
  <span>there</span>
<% end %>
```