### PR TITLE
Formatter: Implement tag-specific attribute formatting

### DIFF
--- a/javascript/packages/formatter/src/printer.ts
+++ b/javascript/packages/formatter/src/printer.ts
@@ -57,6 +57,12 @@ type ERBNode =
 
 import type { FormatOptions } from "./options.js"
 
+// TODO: we can probably expand this list with more tags/attributes
+const FORMATTABLE_ATTRIBUTES: Record<string, string[]> = {
+  '*': ['class'],
+  'img': ['srcset', 'sizes']
+}
+
 /**
  * Printer traverses the Herb AST using the Visitor pattern
  * and emits a formatted string with proper indentation, line breaks, and attribute wrapping.
@@ -69,6 +75,7 @@ export class Printer extends Visitor {
   private indentLevel: number = 0
   private inlineMode: boolean = false
   private isInComplexNesting: boolean = false
+  private currentTagName: string = ""
 
   private static readonly INLINE_ELEMENTS = new Set([
     'a', 'abbr', 'acronym', 'b', 'bdo', 'big', 'br', 'cite', 'code',
@@ -196,22 +203,142 @@ export class Printer extends Visitor {
     indentLength: number,
     maxLineLength: number = this.maxLineLength,
     hasComplexERB: boolean = false,
-    nestingDepth: number = 0,
-    inlineNodesLength: number = 0
+    _nestingDepth: number = 0,
+    _inlineNodesLength: number = 0,
+    hasMultilineAttributes: boolean = false
   ): boolean {
-    if (hasComplexERB) return false
+    if (hasComplexERB || hasMultilineAttributes) return false
 
-    // Special case: no attributes at all, always inline if it fits
     if (totalAttributeCount === 0) {
       return inlineLength + indentLength <= maxLineLength
     }
 
-    const basicInlineCondition = totalAttributeCount <= 3 &&
-                                 inlineLength + indentLength <= maxLineLength
+    if (totalAttributeCount > 3 || inlineLength + indentLength > maxLineLength) {
+      return false
+    }
 
-    const erbInlineCondition = inlineNodesLength > 0 && totalAttributeCount <= 3
+    return true
+  }
 
-    return basicInlineCondition || erbInlineCondition
+  private hasMultilineAttributes(attributes: HTMLAttributeNode[]): boolean {
+    return attributes.some(attribute => {
+      if (attribute.value && (attribute.value instanceof HTMLAttributeValueNode || (attribute.value as any)?.type === 'AST_HTML_ATTRIBUTE_VALUE_NODE')) {
+        const attributeValue = attribute.value as HTMLAttributeValueNode
+
+        const content = attributeValue.children.map((child: Node) => {
+          if (child instanceof HTMLTextNode || (child as any).type === 'AST_HTML_TEXT_NODE' || child instanceof LiteralNode || (child as any).type === 'AST_LITERAL_NODE') {
+            return (child as HTMLTextNode | LiteralNode).content
+          } else if (child instanceof ERBContentNode || (child as any).type === 'AST_ERB_CONTENT_NODE') {
+            const erbAttribute = child as ERBContentNode
+
+            return erbAttribute.tag_opening!.value + erbAttribute.content!.value + erbAttribute.tag_closing!.value
+          }
+
+          return ""
+        }).join("")
+
+        if (/\r?\n/.test(content)) {
+          const name = (attribute.name as HTMLAttributeNameNode)!.name!.value ?? ""
+
+          if (name === 'class') {
+            const normalizedContent = content.replace(/\s+/g, ' ').trim()
+
+            return normalizedContent.length > 80
+          }
+
+          const lines = content.split(/\r?\n/)
+
+          if (lines.length > 1) {
+            return lines.slice(1).some(line => /^\s+/.test(line))
+          }
+        }
+      }
+
+      return false
+    })
+  }
+
+  private formatClassAttribute(content: string, name: string, equals: string, open_quote: string, close_quote: string): string {
+    const normalizedContent = content.replace(/\s+/g, ' ').trim()
+    const hasActualNewlines = /\r?\n/.test(content)
+
+    if (hasActualNewlines && normalizedContent.length > 80) {
+      const lines = content.split(/\r?\n/).map(line => line.trim()).filter(line => line)
+
+      if (lines.length > 1) {
+        return open_quote + this.formatMultilineAttributeValue(lines) + close_quote
+      }
+    }
+
+    const currentIndent = this.indentLevel * this.indentWidth
+    const attributeLine = `${name}${equals}${open_quote}${normalizedContent}${close_quote}`
+
+    if (currentIndent + attributeLine.length > this.maxLineLength && normalizedContent.length > 60) {
+      const classes = normalizedContent.split(' ')
+      const lines = this.breakTokensIntoLines(classes, currentIndent)
+
+      if (lines.length > 1) {
+        return open_quote + this.formatMultilineAttributeValue(lines) + close_quote
+      }
+    }
+
+    return open_quote + normalizedContent + close_quote
+  }
+
+  private isFormattableAttribute(attributeName: string, tagName: string): boolean {
+    const globalFormattable = FORMATTABLE_ATTRIBUTES['*'] || []
+    const tagSpecificFormattable = FORMATTABLE_ATTRIBUTES[tagName.toLowerCase()] || []
+
+    return globalFormattable.includes(attributeName) || tagSpecificFormattable.includes(attributeName)
+  }
+
+  private formatMultilineAttribute(content: string, name: string, equals: string, open_quote: string, close_quote: string): string {
+    if (name === 'srcset' || name === 'sizes') {
+      const normalizedContent = content.replace(/\s+/g, ' ').trim()
+
+      return open_quote + normalizedContent + close_quote
+    }
+
+    const lines = content.split('\n')
+
+    if (lines.length <= 1) {
+      return open_quote + content + close_quote
+    }
+
+    const formattedContent = this.formatMultilineAttributeValue(lines)
+
+    return open_quote + formattedContent + close_quote
+  }
+
+  private formatMultilineAttributeValue(lines: string[]): string {
+    const indent = " ".repeat((this.indentLevel + 1) * this.indentWidth)
+    const closeIndent = " ".repeat(this.indentLevel * this.indentWidth)
+
+    return "\n" + lines.map(line => indent + line).join("\n") + "\n" + closeIndent
+  }
+
+  private breakTokensIntoLines(tokens: string[], currentIndent: number, separator: string = ' '): string[] {
+    const lines: string[] = []
+    let currentLine = ''
+
+    for (const token of tokens) {
+      const testLine = currentLine ? currentLine + separator + token : token
+
+      if (testLine.length > (this.maxLineLength - currentIndent - 6)) {
+        if (currentLine) {
+          lines.push(currentLine)
+          currentLine = token
+        } else {
+          lines.push(token)
+        }
+      } else {
+        currentLine = testLine
+      }
+    }
+
+    if (currentLine) lines.push(currentLine)
+
+    return lines
   }
 
   /**
@@ -219,8 +346,8 @@ export class Printer extends Visitor {
    */
   private renderMultilineAttributes(
     tagName: string,
-    attributes: HTMLAttributeNode[],
-    inlineNodes: Node[] = [],
+    _attributes: HTMLAttributeNode[],
+    _inlineNodes: Node[] = [],
     allChildren: Node[] = [],
     isSelfClosing: boolean = false,
     isVoid: boolean = false,
@@ -230,7 +357,6 @@ export class Printer extends Visitor {
     this.push(indent + `<${tagName}`)
 
     this.withIndent(() => {
-      // Render children in order, handling both attributes and ERB nodes
       allChildren.forEach(child => {
         if (child instanceof HTMLAttributeNode || (child as any).type === 'AST_HTML_ATTRIBUTE_NODE') {
           this.push(this.indent() + this.renderAttribute(child as HTMLAttributeNode))
@@ -310,6 +436,7 @@ export class Printer extends Visitor {
     const tagName = open.tag_name?.value ?? ""
     const indent = this.indent()
 
+    this.currentTagName = tagName
 
     const attributes = this.extractAttributes(open.children)
     const inlineNodes = this.extractInlineNodes(open.children)
@@ -498,10 +625,9 @@ export class Printer extends Visitor {
       this.maxLineLength,
       hasComplexERB,
       nestingDepth,
-      inlineNodes.length
+      inlineNodes.length,
+      this.hasMultilineAttributes(attributes)
     )
-
-
 
     if (shouldKeepInline) {
       if (children.length === 0) {
@@ -632,17 +758,32 @@ export class Printer extends Visitor {
       }
 
       if (isInlineElement && children.length === 0) {
-        let result = `<${tagName}`
-        result += this.renderAttributesString(attributes)
-        if (isSelfClosing) {
-          result += " />"
-        } else if (node.is_void) {
-          result += ">"
-        } else {
-          result += `></${tagName}>`
+        const inline = this.renderInlineOpen(tagName, attributes, isSelfClosing, inlineNodes, open.children)
+        const totalAttributeCount = this.getTotalAttributeCount(attributes, inlineNodes)
+        const shouldKeepInline = this.shouldRenderInline(
+          totalAttributeCount,
+          inline.length,
+          indent.length,
+          this.maxLineLength,
+          false,
+          0,
+          inlineNodes.length,
+          this.hasMultilineAttributes(attributes)
+        )
+
+        if (shouldKeepInline) {
+          let result = `<${tagName}`
+          result += this.renderAttributesString(attributes)
+          if (isSelfClosing) {
+            result += " />"
+          } else if (node.is_void) {
+            result += ">"
+          } else {
+            result += `></${tagName}>`
+          }
+          this.push(indent + result)
+          return
         }
-        this.push(indent + result)
-        return
       }
 
       this.renderMultilineAttributes(tagName, attributes, inlineNodes, open.children, isSelfClosing, node.is_void, children.length > 0)
@@ -683,7 +824,8 @@ export class Printer extends Visitor {
       this.maxLineLength,
       false,
       0,
-      inlineNodes.length
+      inlineNodes.length,
+      this.hasMultilineAttributes(attributes)
     )
 
     if (shouldKeepInline) {
@@ -711,7 +853,8 @@ export class Printer extends Visitor {
       this.maxLineLength,
       false,
       0,
-      inlineNodes.length
+      inlineNodes.length,
+      this.hasMultilineAttributes(attributes)
     )
 
     if (shouldKeepInline) {
@@ -1359,7 +1502,15 @@ export class Printer extends Visitor {
         close_quote = '"'
       }
 
-      value = open_quote + content + close_quote
+      if (this.isFormattableAttribute(name, this.currentTagName)) {
+        if (name === 'class') {
+          value = this.formatClassAttribute(content, name, equals, open_quote, close_quote)
+        } else {
+          value = this.formatMultilineAttribute(content, name, equals, open_quote, close_quote)
+        }
+      } else {
+        value = open_quote + content + close_quote
+      }
     }
 
     return name + equals + value
@@ -1368,7 +1519,7 @@ export class Printer extends Visitor {
   /**
    * Try to render a complete element inline including opening tag, children, and closing tag
    */
-  private tryRenderInlineFull(node: HTMLElementNode, tagName: string, attributes: HTMLAttributeNode[], children: Node[]): string | null {
+  private tryRenderInlineFull(_node: HTMLElementNode, tagName: string, attributes: HTMLAttributeNode[], children: Node[]): string | null {
     let result = `<${tagName}`
 
     result += this.renderAttributesString(attributes)

--- a/javascript/packages/formatter/test/html/attribute-formatting.test.ts
+++ b/javascript/packages/formatter/test/html/attribute-formatting.test.ts
@@ -1,0 +1,315 @@
+import { describe, test, expect, beforeAll } from "vitest"
+import { Herb } from "@herb-tools/node-wasm"
+import { Formatter } from "../../src"
+import dedent from "dedent"
+
+let formatter: Formatter
+
+describe("Attribute formatting", () => {
+  beforeAll(async () => {
+    await Herb.load()
+
+    formatter = new Formatter(Herb, {
+      indentWidth: 2,
+      maxLineLength: 80
+    })
+  })
+
+  describe("Class attribute formatting", () => {
+    test("keeps short class lists inline", () => {
+      const source = `<div class="container flex items-center">Content</div>`
+
+      const result = formatter.format(source)
+
+      expect(result).toBe(dedent`
+        <div class="container flex items-center">
+          Content
+        </div>
+      `)
+    })
+
+    test("breaks long class lists into multiple lines", () => {
+      const source = `<div class="very-long-class-name another-very-long-class-name yet-another-extremely-long-class-name final-extremely-long-class-name">Content</div>`
+
+      const result = formatter.format(source)
+
+      expect(result).toBe(dedent`
+        <div
+          class="
+            very-long-class-name another-very-long-class-name
+            yet-another-extremely-long-class-name final-extremely-long-class-name
+          "
+        >
+          Content
+        </div>
+      `)
+    })
+
+    test("collapses multiline class attributes when they're short", () => {
+      const source = dedent`
+        <div class="container
+        flex items-center">Content</div>
+      `
+
+      const result = formatter.format(source)
+
+      expect(result).toBe(dedent`
+        <div class="container flex items-center">
+          Content
+        </div>
+      `)
+    })
+
+    test("preserves multiline structure for long class attributes", () => {
+      const source = dedent`
+        <div class="text-gray-700 bg-transparent hover:bg-gray-50 active:bg-gray-100 focus:bg-gray-50 focus:ring-gray-300 focus:ring-2
+        disabled:text-gray-300 disabled:bg-transparent disabled:border-gray-300 disabled:cursor-not-allowed">Content</div>
+      `
+
+      const result = formatter.format(source)
+
+      expect(result).toBe(dedent`
+        <div
+          class="
+            text-gray-700 bg-transparent hover:bg-gray-50 active:bg-gray-100 focus:bg-gray-50 focus:ring-gray-300 focus:ring-2
+            disabled:text-gray-300 disabled:bg-transparent disabled:border-gray-300 disabled:cursor-not-allowed
+          "
+        >
+          Content
+        </div>
+      `)
+    })
+
+    test("handles class attributes with ERB expressions", () => {
+      const source = `<div class="base-class <%= 'active' if active? %> <%= user_class %>">Content</div>`
+
+      const result = formatter.format(source)
+
+      expect(result).toBe(dedent`
+        <div class="base-class <%= 'active' if active? %> <%= user_class %>">
+          Content
+        </div>
+      `)
+    })
+  })
+
+  describe("Image srcset and sizes formatting", () => {
+    test("collapses multiline srcset to single line", () => {
+      const source = dedent`
+        <img srcset="image-480w.jpg 480w,
+                     image-800w.jpg 800w,
+                     image-1200w.jpg 1200w" alt="Image">
+      `
+
+      const result = formatter.format(source)
+
+      expect(result).toBe(dedent`
+        <img
+          srcset="image-480w.jpg 480w, image-800w.jpg 800w, image-1200w.jpg 1200w"
+          alt="Image"
+        >
+      `)
+    })
+
+    test("collapses multiline sizes to single line", () => {
+      const source = dedent`
+        <img sizes="(max-width: 600px) 480px,
+                    (max-width: 1000px) 800px,
+                    1200px" src="image.jpg" alt="Image">
+      `
+
+      const result = formatter.format(source)
+
+      expect(result).toBe(dedent`
+        <img
+          sizes="(max-width: 600px) 480px, (max-width: 1000px) 800px, 1200px"
+          src="image.jpg"
+          alt="Image"
+        >
+      `)
+    })
+
+    test("handles both srcset and sizes together", () => {
+      const source = dedent`
+        <img src="image.jpg"
+             srcset="image-480w.jpg 480w,
+                     image-800w.jpg 800w"
+             sizes="(max-width: 600px) 480px,
+                    800px"
+             alt="Responsive Image">
+      `
+
+      const result = formatter.format(source)
+
+      expect(result).toBe(dedent`
+        <img
+          src="image.jpg"
+          srcset="image-480w.jpg 480w, image-800w.jpg 800w"
+          sizes="(max-width: 600px) 480px, 800px"
+          alt="Responsive Image"
+        >
+      `)
+    })
+
+    test("srcset/sizes only format on img tags, not others", () => {
+      const source = `<source srcset="image-480w.webp 480w, image-800w.webp 800w" sizes="(max-width: 600px) 480px, 800px">`
+
+      const result = formatter.format(source)
+
+      expect(result).toBe(dedent`
+        <source
+          srcset="image-480w.webp 480w, image-800w.webp 800w"
+          sizes="(max-width: 600px) 480px, 800px"
+        >
+      `)
+    })
+  })
+
+  describe("Non-formattable attributes", () => {
+    test("preserves style attributes as-is", () => {
+      const source = dedent`
+        <div style="background: linear-gradient(45deg,
+                    red 0%,
+                    blue 100%);
+                    padding: 20px;">Content</div>
+      `
+
+      const result = formatter.format(source)
+
+      expect(result).toBe(dedent`
+        <div
+          style="background: linear-gradient(45deg,
+                    red 0%,
+                    blue 100%);
+                    padding: 20px;"
+        >
+          Content
+        </div>
+      `)
+    })
+
+    test("preserves data attributes as-is", () => {
+      const source = `<div data-config='{"key": "value", "nested": {"prop": "data"}}'>Content</div>`
+
+      const result = formatter.format(source)
+
+      expect(result).toBe(dedent`
+        <div data-config='{"key": "value", "nested": {"prop": "data"}}'>
+          Content
+        </div>
+      `)
+    })
+
+    test("preserves aria attributes as-is (except formattable ones)", () => {
+      const source = `<div aria-label="This is a long aria label that might wrap but should be preserved as-is">Content</div>`
+
+      const result = formatter.format(source)
+
+      expect(result).toBe(dedent`
+        <div
+          aria-label="This is a long aria label that might wrap but should be preserved as-is"
+        >
+          Content
+        </div>
+      `)
+    })
+
+    test("preserves href URLs as-is", () => {
+      const source = `<a href="https://example.com/very/long/path/with/many/segments?param1=value1&param2=value2&param3=value3">Link</a>`
+
+      const result = formatter.format(source)
+
+      expect(result).toBe(`<a href="https://example.com/very/long/path/with/many/segments?param1=value1&param2=value2&param3=value3">Link</a>`)
+    })
+  })
+
+  describe("Mixed attribute scenarios", () => {
+    test("handles mix of formattable and non-formattable attributes", () => {
+      const source = dedent`
+        <img src="image.jpg"
+             class="responsive-image border-2 border-gray-300 rounded-lg shadow-md hover:shadow-lg transition-shadow duration-300"
+             srcset="image-480w.jpg 480w,
+                     image-800w.jpg 800w,
+                     image-1200w.jpg 1200w"
+             alt="A beautiful responsive image with custom styling"
+             data-lazy="true"
+             style="max-width: 100%;
+                    height: auto;">
+      `
+
+      const result = formatter.format(source)
+
+      expect(result).toBe(dedent`
+        <img
+          src="image.jpg"
+          class="
+            responsive-image border-2 border-gray-300 rounded-lg shadow-md
+            hover:shadow-lg transition-shadow duration-300
+          "
+          srcset="image-480w.jpg 480w, image-800w.jpg 800w, image-1200w.jpg 1200w"
+          alt="A beautiful responsive image with custom styling"
+          data-lazy="true"
+          style="max-width: 100%;
+                    height: auto;"
+        >
+      `)
+    })
+
+    test("handles escaped newlines vs actual newlines correctly", () => {
+      const source = `<div class='Line 1\\nLine 2' data-content='Actual\\nNewline'>Content</div>`
+
+      const result = formatter.format(source)
+
+      expect(result).toBe(`<div class="Line 1\\nLine 2" data-content="Actual\\nNewline">
+  Content
+</div>`)
+    })
+
+    test("handles actual newlines in class vs data attributes differently", () => {
+      const source = dedent`
+        <div class='short
+        class' data-content='preserve
+        this
+        structure'>Content</div>
+      `
+
+      const result = formatter.format(source)
+
+      expect(result).toBe(dedent`
+        <div class="short class" data-content="preserve
+        this
+        structure">
+          Content
+        </div>
+      `)
+    })
+  })
+
+  describe("Quote handling with formatted attributes", () => {
+    test("maintains proper quote selection for formatted class attributes", () => {
+      const source = `<div class='container "special" formatting'>Content</div>`
+
+      const result = formatter.format(source)
+
+      expect(result).toBe(dedent`
+        <div class='container "special" formatting'>
+          Content
+        </div>
+      `)
+    })
+
+    test("maintains proper quote selection for formatted srcset", () => {
+      const source = `<img srcset='image-480w.jpg 480w, "special".jpg 800w' src="image.jpg" alt="Image">`
+
+      const result = formatter.format(source)
+
+      expect(result).toBe(dedent`
+        <img
+          srcset='image-480w.jpg 480w, "special".jpg 800w'
+          src="image.jpg"
+          alt="Image"
+        >
+      `)
+    })
+  })
+})

--- a/javascript/packages/formatter/test/html/quote-normalization.test.ts
+++ b/javascript/packages/formatter/test/html/quote-normalization.test.ts
@@ -273,6 +273,40 @@ describe("Quote normalization", () => {
       `)
     })
 
+    test("handles actual newline in attribute values", () => {
+      const source = dedent`
+        <div placeholder='Line 1
+          Line 2'>Text</div>
+      `
+
+      const result = formatter.format(source)
+
+      expect(result).toBe(dedent`
+        <div
+          placeholder="Line 1
+          Line 2"
+        >
+          Text
+        </div>
+      `)
+    })
+
+    test("handles actual newline in class attribute value", () => {
+      const source = dedent`
+        <div class='Line 1
+        Line 2'>
+        Text</div>
+      `
+
+      const result = formatter.format(source)
+
+      expect(result).toBe(dedent`
+        <div class="Line 1 Line 2">
+          Text
+        </div>
+      `)
+    })
+
     test("handles self-closing tags with mixed quotes", () => {
       const source = `<img src='image.jpg' alt="My Image" data-caption='The "best" photo' />`
 


### PR DESCRIPTION
This pull request improves the formatter by improving the way we format attribute values based on their semantic meaning and the HTML tag they belong to.

Previously, all attributes were either left as-is or formatted the same way. Now we have intelligent formatting that:
- Formats `class` attributes with multiline breaking for readability
- Normalizes `srcset` and `sizes` attributes on `img` tags by collapsing whitespace
- Preserves all other attributes exactly as-is to maintain their intended formatting (maybe we can expand the list of supported attributes in the future)

For example, an input like:

```html
<img class="very-long-class-name another-very-long-class-name yet-another-extremely-long-class-name"
     srcset="image-480w.jpg 480w,
             image-800w.jpg 800w,
             image-1200w.jpg 1200w"
     style="background: linear-gradient(45deg,
            red 0%,
            blue 100%);">
```

Before:
```html
<img class="very-long-class-name another-very-long-class-name yet-another-extremely-long-class-name" srcset="image-480w.jpg 480w,
             image-800w.jpg 800w,
             image-1200w.jpg 1200w" style="background: linear-gradient(45deg,
            red 0%,
            blue 100%);">
```

After:
```html
<img
  class="
    very-long-class-name another-very-long-class-name
    yet-another-extremely-long-class-name
  "
  srcset="image-480w.jpg 480w, image-800w.jpg 800w, image-1200w.jpg 1200w"
  style="background: linear-gradient(45deg,
            red 0%,
            blue 100%);"
>
```