### PR TITLE
Language Server: Add `excludedRules` configuration

### DIFF
--- a/javascript/packages/language-server/README.md
+++ b/javascript/packages/language-server/README.md
@@ -50,7 +50,8 @@ After installing the Herb Language Server (see below) and [Sublime LSP](http://l
       "selector": "text.html.ruby | text.html.rails",
       "settings": {
         "languageServerHerb.linter": {
-          "enabled": true
+          "enabled": true,
+          "excludedRules": ["parser-no-errors"]
         }
       },
       "initializationOptions": {

--- a/javascript/packages/language-server/package.json
+++ b/javascript/packages/language-server/package.json
@@ -34,9 +34,8 @@
     "clean": "rimraf dist",
     "build": "yarn clean && tsc -b && rollup -c",
     "dev": "tsc -b -w",
-    "test": "vitest",
-    "test:run": "vitest run",
-    "prepublishOnly": "yarn clean && yarn build && yarn test:run"
+    "test": "vitest run",
+    "prepublishOnly": "yarn clean && yarn build && yarn test"
   },
   "files": [
     "package.json",

--- a/javascript/packages/language-server/src/settings.ts
+++ b/javascript/packages/language-server/src/settings.ts
@@ -7,6 +7,7 @@ export interface HerbSettings {
   }
   linter?: {
     enabled?: boolean
+    excludedRules?: string[]
   }
   formatter?: {
     enabled?: boolean
@@ -21,7 +22,8 @@ export class Settings {
   // but could happen with other clients.
   defaultSettings: HerbSettings = {
     linter: {
-      enabled: true
+      enabled: true,
+      excludedRules: ["parser-no-errors"] // Default exclusion since parser errors are handled by ParserService
     },
     formatter: {
       enabled: false,

--- a/javascript/packages/vscode/README.md
+++ b/javascript/packages/vscode/README.md
@@ -16,6 +16,29 @@ Install the [Herb LSP extension](https://marketplace.visualstudio.com/items?item
 
 If you are looking to use Herb in another editor, check out the instructions on the [editor integrations](https://herb-tools.dev/integrations/editors) page.
 
+## Configuration
+
+### Linter Settings
+
+You can configure the linter behavior through VS Code settings:
+
+* `languageServerHerb.linter.enabled` (boolean, default: `true`) - Enable/disable the linter
+* `languageServerHerb.linter.excludedRules` (string[], default: `["parser-no-errors"]`) - Array of linter rule names to exclude from diagnostics
+
+#### Example configuration in `settings.json`:
+
+```json
+{
+  "languageServerHerb.linter.enabled": true,
+  "languageServerHerb.linter.excludedRules": [
+    "parser-no-errors",
+    "html-tag-name-lowercase"
+  ]
+}
+```
+
+**Note:** The `parser-no-errors` rule is excluded by default to prevent duplicate error reporting, since parser errors are already displayed through the language server's built-in diagnostics.
+
 ## Functionality
 
 #### Diagnostics

--- a/javascript/packages/vscode/package.json
+++ b/javascript/packages/vscode/package.json
@@ -54,6 +54,43 @@
           "description": "Enable/disable the Herb Linter. The linter provides comprehensive HTML+ERB validation, enforces best practices, and catches common errors with a set of configurable rules, like proper tag nesting, required attributes, and ERB usage patterns.",
           "markdownDescription": "Enable/disable the [Herb Linter](https://herb-tools.dev/projects/linter). The linter provides comprehensive HTML+ERB validation, enforces best practices, and catches common errors with a set of configurable [rules](https://herb-tools.dev/linter/rules/), like proper tag nesting, required attributes, and ERB usage patterns."
         },
+        "languageServerHerb.linter.excludedRules": {
+          "title": "Herb Linter Excluded Rules",
+          "scope": "window",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "erb-no-empty-tags",
+              "erb-no-output-control-flow",
+              "erb-prefer-image-tag-helper",
+              "erb-require-whitespace-inside-tags",
+              "erb-requires-trailing-newline",
+              "html-anchor-require-href",
+              "html-aria-attribute-must-be-valid",
+              "html-aria-level-must-be-valid",
+              "html-aria-role-heading-requires-level",
+              "html-aria-role-must-be-valid",
+              "html-attribute-double-quotes",
+              "html-attribute-values-require-quotes",
+              "html-boolean-attributes-no-value",
+              "html-img-require-alt",
+              "html-no-block-inside-inline",
+              "html-no-duplicate-attributes",
+              "html-no-duplicate-ids",
+              "html-no-empty-headings",
+              "html-no-nested-links",
+              "html-tag-name-lowercase",
+              "parser-no-errors",
+              "svg-tag-name-capitalization"
+            ]
+          },
+          "default": [
+            "parser-no-errors"
+          ],
+          "description": "Array of linter rule names to exclude from diagnostics. The 'parser-no-errors' rule is excluded by default to prevent duplicate error reporting since parser errors are already displayed through the language server's built-in diagnostics.",
+          "markdownDescription": "Array of linter rule names to exclude from diagnostics. The `parser-no-errors` rule is excluded by default to prevent duplicate error reporting since parser errors are already displayed through the language server's built-in diagnostics. See all available [rules](https://herb-tools.dev/linter/rules/)."
+        },
         "languageServerHerb.formatter.enabled": {
           "scope": "resource",
           "type": "boolean",

--- a/javascript/packages/vscode/scripts/sync-defaults.js
+++ b/javascript/packages/vscode/scripts/sync-defaults.js
@@ -9,20 +9,83 @@ const { defaultFormatOptions } = require('@herb-tools/formatter');
 const packageJsonPath = path.join(__dirname, '..', 'package.json');
 const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
 
-// Update the VS Code settings defaults to match formatter defaults
-const formattingConfig = packageJson.contributes.configuration.properties;
+// Extract linter rule names from the linter package
+function extractLinterRuleNames() {
+  const rulesDir = path.join(__dirname, '..', '..', 'linter', 'src', 'rules');
+  const ruleNames = [];
 
-if (formattingConfig['languageServerHerb.formatting.indentWidth']) {
-  formattingConfig['languageServerHerb.formatting.indentWidth'].default = defaultFormatOptions.indentWidth;
+  const files = fs.readdirSync(rulesDir);
+
+  for (const file of files) {
+    if (file.endsWith('.ts') && file !== 'index.ts' && file !== 'rule-utils.ts') {
+      const filePath = path.join(rulesDir, file);
+      const content = fs.readFileSync(filePath, 'utf8');
+
+      // Look for name = "rule-name" pattern
+      const match = content.match(/name\s*=\s*["']([^"']+)["']/);
+      if (match) {
+        ruleNames.push(match[1]);
+      }
+    }
+  }
+
+  return ruleNames.sort();
 }
 
-if (formattingConfig['languageServerHerb.formatting.maxLineLength']) {
-  formattingConfig['languageServerHerb.formatting.maxLineLength'].default = defaultFormatOptions.maxLineLength;
+// Import default settings from language-server
+let languageServerDefaults;
+try {
+  const settingsPath = path.join(__dirname, '..', '..', 'language-server', 'dist', 'settings.js');
+  // Note: This would require the language-server to be built first
+  // For now, we'll use hardcoded defaults that match the settings.ts file
+  languageServerDefaults = {
+    linter: {
+      enabled: true,
+      excludedRules: ["parser-no-errors"]
+    }
+  };
+} catch (e) {
+  // Fallback defaults if we can't import from language-server
+  languageServerDefaults = {
+    linter: {
+      enabled: true,
+      excludedRules: ["parser-no-errors"]
+    }
+  };
+}
+
+// Extract available linter rule names
+const availableRuleNames = extractLinterRuleNames();
+
+// Update the VS Code settings defaults to match language server and formatter defaults
+const config = packageJson.contributes.configuration.properties;
+
+// Sync formatter defaults
+if (config['languageServerHerb.formatter.indentWidth']) {
+  config['languageServerHerb.formatter.indentWidth'].default = defaultFormatOptions.indentWidth;
+}
+
+if (config['languageServerHerb.formatter.maxLineLength']) {
+  config['languageServerHerb.formatter.maxLineLength'].default = defaultFormatOptions.maxLineLength;
+}
+
+// Sync linter defaults
+if (config['languageServerHerb.linter.enabled']) {
+  config['languageServerHerb.linter.enabled'].default = languageServerDefaults.linter.enabled;
+}
+
+if (config['languageServerHerb.linter.excludedRules']) {
+  config['languageServerHerb.linter.excludedRules'].default = languageServerDefaults.linter.excludedRules;
+  // Update the enum with all available rule names for autocomplete
+  config['languageServerHerb.linter.excludedRules'].items.enum = availableRuleNames;
 }
 
 // Write the updated package.json
 fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2) + '\n');
 
-console.log(`Updated VS Code settings defaults to match formatter defaults:`);
+console.log(`Updated VS Code settings defaults to match language server and formatter defaults:`);
 console.log(`  indentWidth: ${defaultFormatOptions.indentWidth}`);
 console.log(`  maxLineLength: ${defaultFormatOptions.maxLineLength}`);
+console.log(`  linter.enabled: ${languageServerDefaults.linter.enabled}`);
+console.log(`  linter.excludedRules: ${JSON.stringify(languageServerDefaults.linter.excludedRules)}`);
+console.log(`  available linter rules: ${availableRuleNames.length} rules found for autocomplete`);


### PR DESCRIPTION
This pull request adds configurable `excludedRules` support to the language server and VSCode extension.

Since #362 introduced the `parser-no-errors` rule we now have two ways of surfacing the parser errors in the language server.

The language server now allows to configure which linter rules to exclude from diagnostics. The `parser-no-errors` rule is set as the default to prevent duplicate parsers errors. But this change now also allows users to exclude other linter rules they might want to disable (just in the language server for now).


https://github.com/user-attachments/assets/1cf108b4-856e-4a96-b372-4a4e1f678a6d

