### PR TITLE
Playground: Add selected tab as part of URL

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -167,7 +167,7 @@
 
                 <button
                   data-playground-target="viewerButton"
-                  data-viewer="pretty"
+                  data-viewer="parse"
                   data-action="click->playground#selectViewer"
                   class="text-gray-900 dark:text-gray-100 bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700 rounded-md px-3 py-1.5 text-sm font-medium data-[active=true]:!bg-green-600 data-[active=true]:hover:!bg-green-700 data-[active=true]:!text-white"
                   data-active="true"
@@ -246,8 +246,8 @@
             <div class="mt-2">
               <pre
                 style="white-space: pre; line-height: 1.3"
-                data-viewer-target="pretty"
-                data-playground-target="prettyViewer"
+                data-viewer-target="parse"
+                data-playground-target="parseViewer"
                 data-action="click->playground#shrinkViewer"
                 class="w-full p-3 mb-3 rounded overflow-auto font-mono bg-[#282c34] text-[#dcdfe4] highlight h-[50vh] md:h-[calc(100vh-110px)] overflow-scroll"
               ></pre>


### PR DESCRIPTION
This pull request updates the playground to store the currently selected tab in the URL as a query parameter.

For example, `playground/?tab=ruby` opens with the Ruby tab selected, while `playground/?tab=html` shows the HTML output. The `parse` tab remains the default with no URL parameter needed.

Additionally, the `pretty` tab has been renamed to `parse` to better reflect its purpose of showing the parsed syntax tree.