### PR TITLE
Linter: Add JSON output format

### DIFF
--- a/javascript/packages/linter/README.md
+++ b/javascript/packages/linter/README.md
@@ -11,7 +11,66 @@ The Herb Linter provides comprehensive HTML+ERB validation with a set of configu
 ### Command Line
 ```bash
 npx @herb-tools/linter template.html.erb
+
+# Use simple output format
+npx @herb-tools/linter template.html.erb --simple
+
+# Use JSON output format
+npx @herb-tools/linter template.html.erb --json
+
+# Disable timing information
+npx @herb-tools/linter template.html.erb --no-timing
 ```
+
+#### JSON Output Format
+
+The linter supports structured JSON output with the `--json` flag, useful for programmatic consumption:
+
+```bash
+npx @herb-tools/linter template.html.erb --json
+```
+
+Example output:
+```json
+{
+  "diagnostics": [
+    {
+      "filename": "template.html.erb",
+      "message": "File must end with trailing newline",
+      "location": {
+        "start": { "line": 1, "column": 21 },
+        "end": { "line": 1, "column": 22 }
+      },
+      "severity": "error",
+      "code": "erb-requires-trailing-newline",
+      "source": "Herb Linter"
+    }
+  ],
+  "summary": {
+    "filesChecked": 1,
+    "filesWithViolations": 1,
+    "totalErrors": 1,
+    "totalWarnings": 0,
+    "totalViolations": 1,
+    "ruleCount": 21
+  },
+  "timing": {
+    "startTime": "2025-08-14T16:00:48.845Z",
+    "duration": 27
+  },
+  "completed": true,
+  "clean": false,
+  "message": null
+}
+```
+
+JSON output fields:
+- `diagnostics`: Array of linting violations with location and severity
+- `summary`: Statistics about the linting run (null on errors)
+- `timing`: Timing information with ISO timestamp (null with `--no-timing`)
+- `completed`: Whether the linter ran successfully on files
+- `clean`: Whether there were no violations (null when `completed=false`)
+- `message`: Error or informational message (null on success)
 
 ### Language Server Integration
 

--- a/javascript/packages/linter/src/cli.ts
+++ b/javascript/packages/linter/src/cli.ts
@@ -1,14 +1,41 @@
 import { glob } from "glob"
 import { Herb } from "@herb-tools/node-wasm"
-import { ArgumentParser } from "./cli/argument-parser.js"
+import { ArgumentParser, type FormatOption } from "./cli/argument-parser.js"
 import { FileProcessor } from "./cli/file-processor.js"
-import { SimpleFormatter, DetailedFormatter } from "./cli/formatters/index.js"
-import { SummaryReporter } from "./cli/summary-reporter.js"
+import { OutputManager } from "./cli/output-manager.js"
 
 export class CLI {
   private argumentParser = new ArgumentParser()
   private fileProcessor = new FileProcessor()
-  private summaryReporter = new SummaryReporter()
+  private outputManager = new OutputManager()
+
+  private exitWithError(message: string, formatOption: FormatOption, exitCode: number = 1) {
+    this.outputManager.outputError(message, { 
+      formatOption, 
+      theme: 'auto', 
+      wrapLines: false, 
+      truncateLines: false, 
+      showTiming: false, 
+      startTime: 0, 
+      startDate: new Date() 
+    })
+    process.exit(exitCode)
+  }
+
+  private exitWithInfo(message: string, formatOption: FormatOption, exitCode: number = 0, timingData?: { startTime: number, startDate: Date, showTiming: boolean }) {
+    const outputOptions = {
+      formatOption,
+      theme: 'auto' as const,
+      wrapLines: false,
+      truncateLines: false,
+      showTiming: timingData?.showTiming ?? false,
+      startTime: timingData?.startTime ?? Date.now(),
+      startDate: timingData?.startDate ?? new Date()
+    }
+    
+    this.outputManager.outputInfo(message, outputOptions)
+    process.exit(exitCode)
+  }
 
   async run() {
     const startTime = Date.now()
@@ -16,45 +43,35 @@ export class CLI {
 
     const { pattern, formatOption, showTiming, theme, wrapLines, truncateLines } = this.argumentParser.parse(process.argv)
 
+    const outputOptions = {
+      formatOption,
+      theme,
+      wrapLines,
+      truncateLines,
+      showTiming,
+      startTime,
+      startDate
+    }
+
     try {
       await Herb.load()
 
       const files = await glob(pattern)
 
       if (files.length === 0) {
-        console.log(`No files found matching pattern: ${pattern}`)
-        process.exit(0)
+        this.exitWithInfo(`No files found matching pattern: ${pattern}`, formatOption, 0, { startTime, startDate, showTiming })
       }
 
-      const results = await this.fileProcessor.processFiles(files)
-      const { totalErrors, totalWarnings, filesWithIssues, ruleCount, allDiagnostics, ruleViolations } = results
+      const results = await this.fileProcessor.processFiles(files, formatOption)
+      
+      await this.outputManager.outputResults({ ...results, files }, outputOptions)
 
-      const formatter = formatOption === 'simple'
-        ? new SimpleFormatter()
-        : new DetailedFormatter(theme, wrapLines, truncateLines)
-
-      await formatter.format(allDiagnostics, files.length === 1)
-
-      this.summaryReporter.displayMostViolatedRules(ruleViolations)
-      this.summaryReporter.displaySummary({
-        files,
-        totalErrors,
-        totalWarnings,
-        filesWithViolations: filesWithIssues,
-        ruleCount,
-        startTime,
-        startDate,
-        showTiming,
-        ruleViolations
-      })
-
-      if (totalErrors > 0) {
+      if (results.totalErrors > 0) {
         process.exit(1)
       }
 
     } catch (error) {
-      console.error(`Error:`, error)
-      process.exit(1)
+      this.exitWithError(`Error: ${error}`, formatOption)
     }
   }
 }

--- a/javascript/packages/linter/src/cli/argument-parser.ts
+++ b/javascript/packages/linter/src/cli/argument-parser.ts
@@ -11,9 +11,11 @@ import type { ThemeInput } from "@herb-tools/highlighter"
 
 import { name, version } from "../../package.json"
 
+export type FormatOption = "simple" | "detailed" | "json"
+
 export interface ParsedArguments {
   pattern: string
-  formatOption: 'simple' | 'detailed'
+  formatOption: FormatOption
   showTiming: boolean
   theme: ThemeInput
   wrapLines: boolean
@@ -32,9 +34,10 @@ export class ArgumentParser {
     Options:
       -h, --help       show help
       -v, --version    show version
-      --format         output format (simple|detailed) [default: detailed]
+      --format         output format (simple|detailed|json) [default: detailed]
       --simple         use simple output format (shortcut for --format simple)
-      --theme          syntax highlighting theme (${THEME_NAMES.join('|')}) or path to custom theme file [default: ${DEFAULT_THEME}]
+      --json           use JSON output format (shortcut for --format json)
+      --theme          syntax highlighting theme (${THEME_NAMES.join("|")}) or path to custom theme file [default: ${DEFAULT_THEME}]
       --no-color       disable colored output
       --no-timing      hide timing information
       --no-wrap-lines  disable line wrapping
@@ -45,15 +48,16 @@ export class ArgumentParser {
     const { values, positionals } = parseArgs({
       args: argv.slice(2),
       options: {
-        help: { type: 'boolean', short: 'h' },
-        version: { type: 'boolean', short: 'v' },
-        format: { type: 'string' },
-        simple: { type: 'boolean' },
-        theme: { type: 'string' },
-        'no-color': { type: 'boolean' },
-        'no-timing': { type: 'boolean' },
-        'no-wrap-lines': { type: 'boolean' },
-        'truncate-lines': { type: 'boolean' }
+        help: { type: "boolean", short: "h" },
+        version: { type: "boolean", short: "v" },
+        format: { type: "string" },
+        simple: { type: "boolean" },
+        json: { type: "boolean" },
+        theme: { type: "string" },
+        "no-color": { type: "boolean" },
+        "no-timing": { type: "boolean" },
+        "no-wrap-lines": { type: "boolean" },
+        "truncate-lines": { type: "boolean" }
       },
       allowPositionals: true
     })
@@ -69,8 +73,8 @@ export class ArgumentParser {
       process.exit(0)
     }
 
-    let formatOption: 'simple' | 'detailed' = 'detailed'
-    if (values.format && (values.format === "detailed" || values.format === "simple")) {
+    let formatOption: FormatOption = "detailed"
+    if (values.format && (values.format === "detailed" || values.format === "simple" || values.format === "json")) {
       formatOption = values.format
     }
 
@@ -78,21 +82,25 @@ export class ArgumentParser {
       formatOption = "simple"
     }
 
-    if (values['no-color']) {
+    if (values.json) {
+      formatOption = "json"
+    }
+
+    if (values["no-color"]) {
       process.env.NO_COLOR = "1"
     }
 
-    const showTiming = !values['no-timing']
+    const showTiming = !values["no-timing"]
 
-    let wrapLines = !values['no-wrap-lines']
+    let wrapLines = !values["no-wrap-lines"]
     let truncateLines = false
 
-    if (values['truncate-lines']) {
+    if (values["truncate-lines"]) {
       truncateLines = true
       wrapLines = false
     }
 
-    if (!values['no-wrap-lines'] && values['truncate-lines']) {
+    if (!values["no-wrap-lines"] && values["truncate-lines"]) {
       console.error("Error: Line wrapping and --truncate-lines cannot be used together. Use --no-wrap-lines with --truncate-lines.")
       process.exit(1)
     }

--- a/javascript/packages/linter/src/cli/formatters/index.ts
+++ b/javascript/packages/linter/src/cli/formatters/index.ts
@@ -1,3 +1,4 @@
 export { BaseFormatter } from "./base-formatter.js"
 export { SimpleFormatter } from "./simple-formatter.js"
 export { DetailedFormatter } from "./detailed-formatter.js"
+export { JSONFormatter, type JSONOutput } from "./json-formatter.js"

--- a/javascript/packages/linter/src/cli/formatters/json-formatter.ts
+++ b/javascript/packages/linter/src/cli/formatters/json-formatter.ts
@@ -1,0 +1,107 @@
+import { BaseFormatter } from "./base-formatter.js"
+
+import type { Diagnostic, SerializedDiagnostic } from "@herb-tools/core"
+import type { ProcessedFile } from "../file-processor.js"
+
+interface JSONDiagnostic extends SerializedDiagnostic {
+  filename: string
+}
+
+interface JSONSummary {
+  filesChecked: number
+  filesWithViolations: number
+  totalErrors: number
+  totalWarnings: number
+  totalViolations: number
+  ruleCount: number
+}
+
+interface JSONTiming {
+  startTime: string
+  duration: number
+}
+
+export interface JSONOutput {
+  diagnostics: JSONDiagnostic[]
+  summary: JSONSummary | null
+  timing: JSONTiming | null
+  completed: boolean
+  clean: boolean | null
+  message: string | null
+}
+
+interface JSONFormatOptions {
+  files: string[]
+  totalErrors: number
+  totalWarnings: number
+  filesWithIssues: number
+  ruleCount: number
+  startTime: number
+  startDate: Date
+  showTiming: boolean
+}
+
+export class JSONFormatter extends BaseFormatter {
+  async format(allDiagnostics: ProcessedFile[]): Promise<void> {
+    const jsonDiagnostics: JSONDiagnostic[] = allDiagnostics.map(({ filename, diagnostic }) => ({
+      filename,
+      message: diagnostic.message,
+      location: diagnostic.location.toJSON(),
+      severity: diagnostic.severity,
+      code: diagnostic.code,
+      source: diagnostic.source
+    }))
+
+    const output: JSONOutput = {
+      diagnostics: jsonDiagnostics,
+      summary: null,
+      timing: null,
+      completed: true,
+      clean: jsonDiagnostics.length === 0,
+      message: null
+    }
+
+    console.log(JSON.stringify(output, null, 2))
+  }
+
+  async formatWithSummary(allDiagnostics: ProcessedFile[], options: JSONFormatOptions): Promise<void> {
+    const jsonDiagnostics: JSONDiagnostic[] = allDiagnostics.map(({ filename, diagnostic }) => ({
+      filename,
+      message: diagnostic.message,
+      location: diagnostic.location.toJSON(),
+      severity: diagnostic.severity,
+      code: diagnostic.code,
+      source: diagnostic.source
+    }))
+
+    const summary: JSONSummary = {
+      filesChecked: options.files.length,
+      filesWithViolations: options.filesWithIssues,
+      totalErrors: options.totalErrors,
+      totalWarnings: options.totalWarnings,
+      totalViolations: options.totalErrors + options.totalWarnings,
+      ruleCount: options.ruleCount
+    }
+
+    const output: JSONOutput = {
+      diagnostics: jsonDiagnostics,
+      summary,
+      timing: null,
+      completed: true,
+      clean: options.totalErrors === 0 && options.totalWarnings === 0,
+      message: null
+    }
+
+    const duration = Date.now() - options.startTime
+    output.timing = options.showTiming ? {
+      startTime: options.startDate.toISOString(),
+      duration: duration
+    } : null
+
+    console.log(JSON.stringify(output, null, 2))
+  }
+
+  formatFile(_filename: string, _diagnostics: Diagnostic[]): void {
+    // Not used in JSON formatter, everything is handled in format()
+  }
+}

--- a/javascript/packages/linter/src/cli/output-manager.ts
+++ b/javascript/packages/linter/src/cli/output-manager.ts
@@ -1,0 +1,136 @@
+import { SummaryReporter } from "./summary-reporter.js"
+import { SimpleFormatter, DetailedFormatter, type JSONOutput } from "./formatters/index.js"
+
+import type { ThemeInput } from "@herb-tools/highlighter"
+import type { FormatOption } from "./argument-parser.js"
+import type { ProcessingResult } from "./file-processor.js"
+
+interface OutputOptions {
+  formatOption: FormatOption
+  theme: ThemeInput
+  wrapLines: boolean
+  truncateLines: boolean
+  showTiming: boolean
+  startTime: number
+  startDate: Date
+}
+
+interface LintResults extends ProcessingResult {
+  files: string[]
+}
+
+export class OutputManager {
+  private summaryReporter = new SummaryReporter()
+
+  /**
+   * Output successful lint results
+   */
+  async outputResults(results: LintResults, options: OutputOptions): Promise<void> {
+    const { allDiagnostics, files, totalErrors, totalWarnings, filesWithIssues, ruleCount, ruleViolations } = results
+
+    if (options.formatOption === "json") {
+      const output: JSONOutput = {
+        diagnostics: allDiagnostics.map(({ filename, diagnostic }) => ({
+          filename,
+          message: diagnostic.message,
+          location: diagnostic.location.toJSON(),
+          severity: diagnostic.severity,
+          code: diagnostic.code,
+          source: diagnostic.source
+        })),
+        summary: {
+          filesChecked: files.length,
+          filesWithViolations: filesWithIssues,
+          totalErrors,
+          totalWarnings,
+          totalViolations: totalErrors + totalWarnings,
+          ruleCount
+        },
+        timing: null,
+        completed: true,
+        clean: totalErrors === 0 && totalWarnings === 0,
+        message: null
+      }
+
+      const duration = Date.now() - options.startTime
+      output.timing = options.showTiming ? {
+        startTime: options.startDate.toISOString(),
+        duration: duration
+      } : null
+
+      console.log(JSON.stringify(output, null, 2))
+    } else {
+      const formatter = options.formatOption === "simple"
+        ? new SimpleFormatter()
+        : new DetailedFormatter(options.theme, options.wrapLines, options.truncateLines)
+
+      await formatter.format(allDiagnostics, files.length === 1)
+
+      this.summaryReporter.displayMostViolatedRules(ruleViolations)
+      this.summaryReporter.displaySummary({
+        files,
+        totalErrors,
+        totalWarnings,
+        filesWithViolations: filesWithIssues,
+        ruleCount,
+        startTime: options.startTime,
+        startDate: options.startDate,
+        showTiming: options.showTiming,
+        ruleViolations
+      })
+    }
+  }
+
+  /**
+   * Output informational message (like "no files found")
+   */
+  outputInfo(message: string, options: OutputOptions): void {
+    if (options.formatOption === "json") {
+      const output: JSONOutput = {
+        diagnostics: [],
+        summary: {
+          filesChecked: 0,
+          filesWithViolations: 0,
+          totalErrors: 0,
+          totalWarnings: 0,
+          totalViolations: 0,
+          ruleCount: 0
+        },
+        timing: null,
+        completed: false,
+        clean: null,
+        message
+      }
+
+      const duration = Date.now() - options.startTime
+      output.timing = options.showTiming ? {
+        startTime: options.startDate.toISOString(),
+        duration: duration
+      } : null
+
+      console.log(JSON.stringify(output, null, 2))
+    } else {
+      console.log(message)
+    }
+  }
+
+  /**
+   * Output error message
+   */
+  outputError(message: string, options: OutputOptions): void {
+    if (options.formatOption === "json") {
+      const output: JSONOutput = {
+        diagnostics: [],
+        summary: null,
+        timing: null,
+        completed: false,
+        clean: null,
+        message
+      }
+
+      console.log(JSON.stringify(output, null, 2))
+    } else {
+      console.error(message)
+    }
+  }
+}


### PR DESCRIPTION
This pull request adds a new JSON flag to the linter CLI for structured JSON output. The implementation includes the new `--json` flag (shorthand for `--format=json`) and consistent JSON structure across all scenarios (success, errors, no files, no folder).

```bash
$ herb-lint file.html.erb --json
{
  "offenses": [
    {
      "filename": "template.html.erb",
      "message": "File must end with trailing newline",
      "location": {
        "start": { "line": 1, "column": 21 },
        "end": { "line": 1, "column": 22 }
      },
      "severity": "error",
      "code": "erb-requires-trailing-newline",
      "source": "Herb Linter"
    }
  ],
  "summary": {
    "filesChecked": 1,
    "filesWithOffenses": 1,
    "totalErrors": 1,
    "totalWarnings": 0,
    "totalOffenses": 1,
    "ruleCount": 21
  },
  "timing": {
    "startTime": "2025-08-14T16:00:48.845Z",
    "duration": 27
  },
  "completed": true,
  "clean": false,
  "message": null
}
```

```bash
$ herb-lint clean.html.erb --json
{
  "offenses": [],
  "summary": {...},
  "timing": {...},
  "completed": true,
  "clean": true,
  "message": null
}
```

```bash
$ herb-lint nonexistent --json
{
  "offenses": [],
  "summary": {...},
  "timing": {...},
  "completed": false,
  "clean": null,
  "message": "No files found matching pattern: nonexistent"
}
```

The implementation also refactors the CLI architecture with a new `OutputManager` class for better managemnet of the different output modes.

Resolves #354 

/cc @asilano