### PR TITLE
Linter: Standardize terminology to use `offens` consistently

### DIFF
--- a/javascript/packages/linter/README.md
+++ b/javascript/packages/linter/README.md
@@ -33,7 +33,7 @@ npx @herb-tools/linter template.html.erb --json
 Example output:
 ```json
 {
-  "diagnostics": [
+  "offenses": [
     {
       "filename": "template.html.erb",
       "message": "File must end with trailing newline",
@@ -48,10 +48,10 @@ Example output:
   ],
   "summary": {
     "filesChecked": 1,
-    "filesWithViolations": 1,
+    "filesWithOffenses": 1,
     "totalErrors": 1,
     "totalWarnings": 0,
-    "totalViolations": 1,
+    "totalOffenses": 1,
     "ruleCount": 21
   },
   "timing": {
@@ -65,11 +65,11 @@ Example output:
 ```
 
 JSON output fields:
-- `diagnostics`: Array of linting violations with location and severity
+- `offenses`: Array of linting offenses with location and severity
 - `summary`: Statistics about the linting run (null on errors)
 - `timing`: Timing information with ISO timestamp (null with `--no-timing`)
 - `completed`: Whether the linter ran successfully on files
-- `clean`: Whether there were no violations (null when `completed=false`)
+- `clean`: Whether there were no offenses (null when `completed=false`)
 - `message`: Error or informational message (null on success)
 
 ### Language Server Integration

--- a/javascript/packages/linter/src/cli/file-processor.ts
+++ b/javascript/packages/linter/src/cli/file-processor.ts
@@ -8,17 +8,17 @@ import type { FormatOption } from "./argument-parser.js"
 
 export interface ProcessedFile {
   filename: string
-  diagnostic: Diagnostic
+  offense: Diagnostic
   content: string
 }
 
 export interface ProcessingResult {
   totalErrors: number
   totalWarnings: number
-  filesWithIssues: number
+  filesWithOffenses: number
   ruleCount: number
-  allDiagnostics: ProcessedFile[]
-  ruleViolations: Map<string, { count: number, files: Set<string> }>
+  allOffenses: ProcessedFile[]
+  ruleOffenses: Map<string, { count: number, files: Set<string> }>
 }
 
 export class FileProcessor {
@@ -27,10 +27,10 @@ export class FileProcessor {
   async processFiles(files: string[], formatOption: FormatOption = 'detailed'): Promise<ProcessingResult> {
     let totalErrors = 0
     let totalWarnings = 0
-    let filesWithIssues = 0
+    let filesWithOffenses = 0
     let ruleCount = 0
-    const allDiagnostics: ProcessedFile[] = []
-    const ruleViolations = new Map<string, { count: number, files: Set<string> }>()
+    const allOffenses: ProcessedFile[] = []
+    const ruleOffenses = new Map<string, { count: number, files: Set<string> }>()
 
     for (const filename of files) {
       const filePath = resolve(filename)
@@ -47,13 +47,13 @@ export class FileProcessor {
           }
         }
 
-        // Add parse errors to diagnostics for JSON output
+        // Add parse errors to offenses for JSON output
         for (const error of parseResult.errors) {
-          allDiagnostics.push({ filename, diagnostic: error, content })
+          allOffenses.push({ filename, offense: error, content })
         }
 
         totalErrors++
-        filesWithIssues++
+        filesWithOffenses++
         continue
       }
 
@@ -73,20 +73,20 @@ export class FileProcessor {
         }
       } else {
         for (const offense of lintResult.offenses) {
-          allDiagnostics.push({ filename, diagnostic: offense, content })
+          allOffenses.push({ filename, offense: offense, content })
 
-          const ruleData = ruleViolations.get(offense.rule) || { count: 0, files: new Set() }
+          const ruleData = ruleOffenses.get(offense.rule) || { count: 0, files: new Set() }
           ruleData.count++
           ruleData.files.add(filename)
-          ruleViolations.set(offense.rule, ruleData)
+          ruleOffenses.set(offense.rule, ruleData)
         }
 
         totalErrors += lintResult.errors
         totalWarnings += lintResult.warnings
-        filesWithIssues++
+        filesWithOffenses++
       }
     }
 
-    return { totalErrors, totalWarnings, filesWithIssues, ruleCount, allDiagnostics, ruleViolations }
+    return { totalErrors, totalWarnings, filesWithOffenses, ruleCount, allOffenses, ruleOffenses }
   }
 }

--- a/javascript/packages/linter/src/cli/formatters/base-formatter.ts
+++ b/javascript/packages/linter/src/cli/formatters/base-formatter.ts
@@ -3,9 +3,9 @@ import type { ProcessedFile } from "../file-processor.js"
 
 export abstract class BaseFormatter {
   abstract format(
-    allDiagnostics: ProcessedFile[],
+    allOffenses: ProcessedFile[],
     isSingleFile?: boolean
   ): Promise<void>
 
-  abstract formatFile(filename: string, diagnostics: Diagnostic[]): void
+  abstract formatFile(filename: string, offenses: Diagnostic[]): void
 }

--- a/javascript/packages/linter/src/cli/formatters/detailed-formatter.ts
+++ b/javascript/packages/linter/src/cli/formatters/detailed-formatter.ts
@@ -18,8 +18,8 @@ export class DetailedFormatter extends BaseFormatter {
     this.truncateLines = truncateLines
   }
 
-  async format(allDiagnostics: ProcessedFile[], isSingleFile: boolean = false): Promise<void> {
-    if (allDiagnostics.length === 0) return
+  async format(allOffenses: ProcessedFile[], isSingleFile: boolean = false): Promise<void> {
+    if (allOffenses.length === 0) return
 
     if (!this.highlighter) {
       this.highlighter = new Highlighter(this.theme)
@@ -28,8 +28,8 @@ export class DetailedFormatter extends BaseFormatter {
 
     if (isSingleFile) {
       // For single file, use inline diagnostics with syntax highlighting
-      const { filename, content } = allDiagnostics[0]
-      const diagnostics = allDiagnostics.map(item => item.diagnostic)
+      const { filename, content } = allOffenses[0]
+      const diagnostics = allOffenses.map(item => item.offense)
 
       const highlighted = this.highlighter.highlight(filename, content, {
         diagnostics: diagnostics,
@@ -42,11 +42,11 @@ export class DetailedFormatter extends BaseFormatter {
       console.log(`\n${highlighted}`)
     } else {
       // For multiple files, show individual diagnostics with syntax highlighting
-      const totalMessageCount = allDiagnostics.length
+      const totalMessageCount = allOffenses.length
 
-      for (let i = 0; i < allDiagnostics.length; i++) {
-        const { filename, diagnostic, content } = allDiagnostics[i]
-        const formatted = this.highlighter.highlightDiagnostic(filename, diagnostic, content, { 
+      for (let i = 0; i < allOffenses.length; i++) {
+        const { filename, offense, content } = allOffenses[i]
+        const formatted = this.highlighter.highlightDiagnostic(filename, offense, content, { 
           contextLines: 2, 
           wrapLines: this.wrapLines,
           truncateLines: this.truncateLines
@@ -67,7 +67,7 @@ export class DetailedFormatter extends BaseFormatter {
     }
   }
 
-  formatFile(_filename: string, _diagnostics: Diagnostic[]): void {
+  formatFile(_filename: string, _offenses: Diagnostic[]): void {
     // Not used in detailed formatter
     throw new Error("formatFile is not implemented for DetailedFormatter")
   }

--- a/javascript/packages/linter/src/cli/formatters/json-formatter.ts
+++ b/javascript/packages/linter/src/cli/formatters/json-formatter.ts
@@ -3,16 +3,16 @@ import { BaseFormatter } from "./base-formatter.js"
 import type { Diagnostic, SerializedDiagnostic } from "@herb-tools/core"
 import type { ProcessedFile } from "../file-processor.js"
 
-interface JSONDiagnostic extends SerializedDiagnostic {
+interface JSONOffense extends SerializedDiagnostic {
   filename: string
 }
 
 interface JSONSummary {
   filesChecked: number
-  filesWithViolations: number
+  filesWithOffenses: number
   totalErrors: number
   totalWarnings: number
-  totalViolations: number
+  totalOffenses: number
   ruleCount: number
 }
 
@@ -22,7 +22,7 @@ interface JSONTiming {
 }
 
 export interface JSONOutput {
-  diagnostics: JSONDiagnostic[]
+  offenses: JSONOffense[]
   summary: JSONSummary | null
   timing: JSONTiming | null
   completed: boolean
@@ -34,7 +34,7 @@ interface JSONFormatOptions {
   files: string[]
   totalErrors: number
   totalWarnings: number
-  filesWithIssues: number
+  filesWithOffenses: number
   ruleCount: number
   startTime: number
   startDate: Date
@@ -42,49 +42,49 @@ interface JSONFormatOptions {
 }
 
 export class JSONFormatter extends BaseFormatter {
-  async format(allDiagnostics: ProcessedFile[]): Promise<void> {
-    const jsonDiagnostics: JSONDiagnostic[] = allDiagnostics.map(({ filename, diagnostic }) => ({
+  async format(allOffenses: ProcessedFile[]): Promise<void> {
+    const jsonOffenses: JSONOffense[] = allOffenses.map(({ filename, offense }) => ({
       filename,
-      message: diagnostic.message,
-      location: diagnostic.location.toJSON(),
-      severity: diagnostic.severity,
-      code: diagnostic.code,
-      source: diagnostic.source
+      message: offense.message,
+      location: offense.location.toJSON(),
+      severity: offense.severity,
+      code: offense.code,
+      source: offense.source
     }))
 
     const output: JSONOutput = {
-      diagnostics: jsonDiagnostics,
+      offenses: jsonOffenses,
       summary: null,
       timing: null,
       completed: true,
-      clean: jsonDiagnostics.length === 0,
+      clean: jsonOffenses.length === 0,
       message: null
     }
 
     console.log(JSON.stringify(output, null, 2))
   }
 
-  async formatWithSummary(allDiagnostics: ProcessedFile[], options: JSONFormatOptions): Promise<void> {
-    const jsonDiagnostics: JSONDiagnostic[] = allDiagnostics.map(({ filename, diagnostic }) => ({
+  async formatWithSummary(allOffenses: ProcessedFile[], options: JSONFormatOptions): Promise<void> {
+    const jsonOffenses: JSONOffense[] = allOffenses.map(({ filename, offense }) => ({
       filename,
-      message: diagnostic.message,
-      location: diagnostic.location.toJSON(),
-      severity: diagnostic.severity,
-      code: diagnostic.code,
-      source: diagnostic.source
+      message: offense.message,
+      location: offense.location.toJSON(),
+      severity: offense.severity,
+      code: offense.code,
+      source: offense.source
     }))
 
     const summary: JSONSummary = {
       filesChecked: options.files.length,
-      filesWithViolations: options.filesWithIssues,
+      filesWithOffenses: options.filesWithOffenses,
       totalErrors: options.totalErrors,
       totalWarnings: options.totalWarnings,
-      totalViolations: options.totalErrors + options.totalWarnings,
+      totalOffenses: options.totalErrors + options.totalWarnings,
       ruleCount: options.ruleCount
     }
 
     const output: JSONOutput = {
-      diagnostics: jsonDiagnostics,
+      offenses: jsonOffenses,
       summary,
       timing: null,
       completed: true,
@@ -101,7 +101,7 @@ export class JSONFormatter extends BaseFormatter {
     console.log(JSON.stringify(output, null, 2))
   }
 
-  formatFile(_filename: string, _diagnostics: Diagnostic[]): void {
+  formatFile(_filename: string, _offenses: Diagnostic[]): void {
     // Not used in JSON formatter, everything is handled in format()
   }
 }

--- a/javascript/packages/linter/src/cli/formatters/simple-formatter.ts
+++ b/javascript/packages/linter/src/cli/formatters/simple-formatter.ts
@@ -6,34 +6,34 @@ import type { Diagnostic } from "@herb-tools/core"
 import type { ProcessedFile } from "../file-processor.js"
 
 export class SimpleFormatter extends BaseFormatter {
-  async format(allDiagnostics: ProcessedFile[]): Promise<void> {
-    if (allDiagnostics.length === 0) return
+  async format(allOffenses: ProcessedFile[]): Promise<void> {
+    if (allOffenses.length === 0) return
 
-    const groupedDiagnostics = new Map<string, Diagnostic[]>()
+    const groupedOffenses = new Map<string, Diagnostic[]>()
 
-    for (const { filename, diagnostic } of allDiagnostics) {
-      const diagnostics = groupedDiagnostics.get(filename) || []
-      diagnostics.push(diagnostic)
-      groupedDiagnostics.set(filename, diagnostics)
+    for (const { filename, offense } of allOffenses) {
+      const offenses = groupedOffenses.get(filename) || []
+      offenses.push(offense)
+      groupedOffenses.set(filename, offenses)
     }
 
-    for (const [filename, diagnostics] of groupedDiagnostics) {
+    for (const [filename, offenses] of groupedOffenses) {
       console.log("")
-      this.formatFile(filename, diagnostics)
+      this.formatFile(filename, offenses)
     }
   }
 
-  formatFile(filename: string, diagnostics: Diagnostic[]): void {
+  formatFile(filename: string, offenses: Diagnostic[]): void {
     console.log(`${colorize(filename, "cyan")}:`)
 
-    for (const diagnostic of diagnostics) {
-      const isError = diagnostic.severity === "error"
+    for (const offense of offenses) {
+      const isError = offense.severity === "error"
       const severity = isError ? colorize("✗", "brightRed") : colorize("⚠", "brightYellow")
-      const rule = colorize(`(${diagnostic.code})`, "blue")
-      const locationString = `${diagnostic.location.start.line}:${diagnostic.location.start.column}`
+      const rule = colorize(`(${offense.code})`, "blue")
+      const locationString = `${offense.location.start.line}:${offense.location.start.column}`
       const paddedLocation = locationString.padEnd(4) // Pad to 4 characters for alignment
 
-      console.log(`  ${colorize(paddedLocation, "gray")} ${severity} ${diagnostic.message} ${rule}`)
+      console.log(`  ${colorize(paddedLocation, "gray")} ${severity} ${offense.message} ${rule}`)
     }
     console.log("")
   }

--- a/javascript/packages/linter/src/cli/output-manager.ts
+++ b/javascript/packages/linter/src/cli/output-manager.ts
@@ -26,24 +26,24 @@ export class OutputManager {
    * Output successful lint results
    */
   async outputResults(results: LintResults, options: OutputOptions): Promise<void> {
-    const { allDiagnostics, files, totalErrors, totalWarnings, filesWithIssues, ruleCount, ruleViolations } = results
+    const { allOffenses, files, totalErrors, totalWarnings, filesWithOffenses, ruleCount, ruleOffenses } = results
 
     if (options.formatOption === "json") {
       const output: JSONOutput = {
-        diagnostics: allDiagnostics.map(({ filename, diagnostic }) => ({
+        offenses: allOffenses.map(({ filename, offense }) => ({
           filename,
-          message: diagnostic.message,
-          location: diagnostic.location.toJSON(),
-          severity: diagnostic.severity,
-          code: diagnostic.code,
-          source: diagnostic.source
+          message: offense.message,
+          location: offense.location.toJSON(),
+          severity: offense.severity,
+          code: offense.code,
+          source: offense.source
         })),
         summary: {
           filesChecked: files.length,
-          filesWithViolations: filesWithIssues,
+          filesWithOffenses,
           totalErrors,
           totalWarnings,
-          totalViolations: totalErrors + totalWarnings,
+          totalOffenses: totalErrors + totalWarnings,
           ruleCount
         },
         timing: null,
@@ -64,19 +64,19 @@ export class OutputManager {
         ? new SimpleFormatter()
         : new DetailedFormatter(options.theme, options.wrapLines, options.truncateLines)
 
-      await formatter.format(allDiagnostics, files.length === 1)
+      await formatter.format(allOffenses, files.length === 1)
 
-      this.summaryReporter.displayMostViolatedRules(ruleViolations)
+      this.summaryReporter.displayMostViolatedRules(ruleOffenses)
       this.summaryReporter.displaySummary({
         files,
         totalErrors,
         totalWarnings,
-        filesWithViolations: filesWithIssues,
+        filesWithOffenses,
         ruleCount,
         startTime: options.startTime,
         startDate: options.startDate,
         showTiming: options.showTiming,
-        ruleViolations
+        ruleOffenses
       })
     }
   }
@@ -87,13 +87,13 @@ export class OutputManager {
   outputInfo(message: string, options: OutputOptions): void {
     if (options.formatOption === "json") {
       const output: JSONOutput = {
-        diagnostics: [],
+        offenses: [],
         summary: {
           filesChecked: 0,
-          filesWithViolations: 0,
+          filesWithOffenses: 0,
           totalErrors: 0,
           totalWarnings: 0,
-          totalViolations: 0,
+          totalOffenses: 0,
           ruleCount: 0
         },
         timing: null,
@@ -120,7 +120,7 @@ export class OutputManager {
   outputError(message: string, options: OutputOptions): void {
     if (options.formatOption === "json") {
       const output: JSONOutput = {
-        diagnostics: [],
+        offenses: [],
         summary: null,
         timing: null,
         completed: false,

--- a/javascript/packages/linter/src/cli/summary-reporter.ts
+++ b/javascript/packages/linter/src/cli/summary-reporter.ts
@@ -4,12 +4,12 @@ export interface SummaryData {
   files: string[]
   totalErrors: number
   totalWarnings: number
-  filesWithViolations: number
+  filesWithOffenses: number
   ruleCount: number
   startTime: number
   startDate: Date
   showTiming: boolean
-  ruleViolations: Map<string, { count: number, files: Set<string> }>
+  ruleOffenses: Map<string, { count: number, files: Set<string> }>
 }
 
 export class SummaryReporter {
@@ -18,13 +18,13 @@ export class SummaryReporter {
   }
 
   displaySummary(data: SummaryData): void {
-    const { files, totalErrors, totalWarnings, filesWithViolations, ruleCount, startTime, startDate, showTiming } = data
+    const { files, totalErrors, totalWarnings, filesWithOffenses, ruleCount, startTime, startDate, showTiming } = data
 
     console.log("\n")
     console.log(` ${colorize("Summary:", "bold")}`)
 
     // Calculate padding for alignment
-    const labelWidth = 12 // Width for the longest label "Violations"
+    const labelWidth = 12 // Width for the longest label "Offenses"
     const pad = (label: string) => label.padEnd(labelWidth)
 
     // Checked summary
@@ -33,13 +33,13 @@ export class SummaryReporter {
     // Files summary (for multiple files)
     if (files.length > 1) {
       const filesChecked = files.length
-      const filesClean = filesChecked - filesWithViolations
+      const filesClean = filesChecked - filesWithOffenses
 
       let filesSummary = ""
       let shouldDim = false
 
-      if (filesWithViolations > 0) {
-        filesSummary = `${colorize(colorize(`${filesWithViolations} with violations`, "brightRed"), "bold")} | ${colorize(colorize(`${filesClean} clean`, "green"), "bold")} ${colorize(colorize(`(${filesChecked} total)`, "gray"), "dim")}`
+      if (filesWithOffenses > 0) {
+        filesSummary = `${colorize(colorize(`${filesWithOffenses} with offenses`, "brightRed"), "bold")} | ${colorize(colorize(`${filesClean} clean`, "green"), "bold")} ${colorize(colorize(`(${filesChecked} total)`, "gray"), "dim")}`
       } else {
         filesSummary = `${colorize(colorize(`${filesChecked} clean`, "green"), "bold")} ${colorize(colorize(`(${filesChecked} total)`, "gray"), "dim")}`
         shouldDim = true
@@ -52,8 +52,8 @@ export class SummaryReporter {
       }
     }
 
-    // Violations summary with file count
-    let violationsSummary = ""
+    // Offenses summary with file count
+    let offensesSummary = ""
     const parts = []
 
     // Build the main part with errors and warnings
@@ -69,22 +69,22 @@ export class SummaryReporter {
     }
 
     if (parts.length === 0) {
-      violationsSummary = colorize(colorize("0 violations", "green"), "bold")
+      offensesSummary = colorize(colorize("0 offenses", "green"), "bold")
     } else {
-      violationsSummary = parts.join(" | ")
+      offensesSummary = parts.join(" | ")
       // Add total count and file count
       let detailText = ""
 
-      const totalViolations = totalErrors + totalWarnings
+      const totalOffenses = totalErrors + totalWarnings
 
-      if (filesWithViolations > 0) {
-        detailText = `${totalViolations} ${this.pluralize(totalViolations, "violation")} across ${filesWithViolations} ${this.pluralize(filesWithViolations, "file")}`
+      if (filesWithOffenses > 0) {
+        detailText = `${totalOffenses} ${this.pluralize(totalOffenses, "offense")} across ${filesWithOffenses} ${this.pluralize(filesWithOffenses, "file")}`
       }
 
-      violationsSummary += ` ${colorize(colorize(`(${detailText})`, "gray"), "dim")}`
+      offensesSummary += ` ${colorize(colorize(`(${detailText})`, "gray"), "dim")}`
     }
 
-    console.log(`  ${colorize(pad("Violations"), "gray")} ${violationsSummary}`)
+    console.log(`  ${colorize(pad("Offenses"), "gray")} ${offensesSummary}`)
 
     // Timing information (if enabled)
     if (showTiming) {
@@ -96,32 +96,32 @@ export class SummaryReporter {
     }
 
     // Success message for all files clean
-    if (filesWithViolations === 0 && files.length > 1) {
+    if (filesWithOffenses === 0 && files.length > 1) {
       console.log("")
       console.log(` ${colorize("✓", "brightGreen")} ${colorize("All files are clean!", "green")}`)
     }
   }
 
-  displayMostViolatedRules(ruleViolations: Map<string, { count: number, files: Set<string> }>, limit: number = 5): void {
-    if (ruleViolations.size === 0) return
+  displayMostViolatedRules(ruleOffenses: Map<string, { count: number, files: Set<string> }>, limit: number = 5): void {
+    if (ruleOffenses.size === 0) return
 
-    const allRules = Array.from(ruleViolations.entries()).sort((a, b) => b[1].count - a[1].count)
+    const allRules = Array.from(ruleOffenses.entries()).sort((a, b) => b[1].count - a[1].count)
     const displayedRules = allRules.slice(0, limit)
     const remainingRules = allRules.slice(limit)
 
-    const title = ruleViolations.size <= limit ? "Rule violations:" : "Most violated rules:"
+    const title = ruleOffenses.size <= limit ? "Rule offenses:" : "Most frequent rule offenses:"
     console.log(` ${colorize(title, "bold")}`)
 
     for (const [rule, data] of displayedRules) {
       const fileCount = data.files.size
-      const countText = `(${data.count} ${this.pluralize(data.count, "violation")} in ${fileCount} ${this.pluralize(fileCount, "file")})`
+      const countText = `(${data.count} ${this.pluralize(data.count, "offense")} in ${fileCount} ${this.pluralize(fileCount, "file")})`
       console.log(`  ${colorize(rule, "gray")} ${colorize(colorize(countText, "gray"), "dim")}`)
     }
 
     if (remainingRules.length > 0) {
-      const remainingViolationCount = remainingRules.reduce((sum, [_, data]) => sum + data.count, 0)
+      const remainingOffenseCount = remainingRules.reduce((sum, [_, data]) => sum + data.count, 0)
       const remainingRuleCount = remainingRules.length
-      console.log(colorize(colorize(`\n  ...and ${remainingRuleCount} more ${this.pluralize(remainingRuleCount, "rule")} with ${remainingViolationCount} ${this.pluralize(remainingViolationCount, "violation")}`, "gray"), "dim"))
+      console.log(colorize(colorize(`\n  ...and ${remainingRuleCount} more ${this.pluralize(remainingRuleCount, "rule")} with ${remainingOffenseCount} ${this.pluralize(remainingOffenseCount, "offense")}`, "gray"), "dim"))
     }
   }
 }

--- a/javascript/packages/linter/src/rules/html-no-block-inside-inline.ts
+++ b/javascript/packages/linter/src/rules/html-no-block-inside-inline.ts
@@ -19,7 +19,7 @@ class BlockInsideInlineVisitor extends BaseRuleVisitor {
     return { isInline, isBlock, isUnknown }
   }
 
-  private addViolationMessage(tagName: string, isBlock: boolean, openTag: HTMLOpenTagNode): void {
+  private addOffenseMessage(tagName: string, isBlock: boolean, openTag: HTMLOpenTagNode): void {
     const parentInline = this.inlineStack[this.inlineStack.length - 1]
     const elementType = isBlock ? "Block-level" : "Unknown"
 
@@ -62,7 +62,7 @@ class BlockInsideInlineVisitor extends BaseRuleVisitor {
     const { isInline, isBlock, isUnknown } = this.getElementType(tagName)
 
     if ((isBlock || isUnknown) && this.inlineStack.length > 0) {
-      this.addViolationMessage(tagName, isBlock, openTag)
+      this.addOffenseMessage(tagName, isBlock, openTag)
     }
 
     if (isInline) {

--- a/javascript/packages/linter/test/__snapshots__/cli.test.ts.snap
+++ b/javascript/packages/linter/test/__snapshots__/cli.test.ts.snap
@@ -1,9 +1,9 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`CLI Output Formatting > displays most violated rules with multiple violations 1`] = `
+exports[`CLI Output Formatting > displays most violated rules with multiple offenses 1`] = `
 "[error] Add an \`href\` attribute to \`<a>\` to ensure it is focusable and accessible. (html-anchor-require-href)
 
-test/fixtures/multiple-rule-violations.html.erb:5:3
+test/fixtures/multiple-rule-offenses.html.erb:5:3
 
       3 │ <div id=test1 class='' data-value=bar>
       4 │   <img />
@@ -17,7 +17,7 @@ test/fixtures/multiple-rule-violations.html.erb:5:3
 
 [error] Add an \`href\` attribute to \`<a>\` to ensure it is focusable and accessible. (html-anchor-require-href)
 
-test/fixtures/multiple-rule-violations.html.erb:10:1
+test/fixtures/multiple-rule-offenses.html.erb:10:1
 
       8 │ <h1></h1>
       9 │ 
@@ -31,7 +31,7 @@ test/fixtures/multiple-rule-violations.html.erb:10:1
 
 [error] Add an \`href\` attribute to \`<a>\` to ensure it is focusable and accessible. (html-anchor-require-href)
 
-test/fixtures/multiple-rule-violations.html.erb:10:4
+test/fixtures/multiple-rule-offenses.html.erb:10:4
 
       8 │ <h1></h1>
       9 │ 
@@ -45,9 +45,9 @@ test/fixtures/multiple-rule-violations.html.erb:10:4
 
 [warning] Attribute \`class\` uses single quotes. Prefer double quotes for HTML attribute values: \`class="value"\`. (html-attribute-double-quotes)
 
-test/fixtures/multiple-rule-violations.html.erb:3:20
+test/fixtures/multiple-rule-offenses.html.erb:3:20
 
-      1 │ <!-- Multiple violations of same rules to test "Most violated rules" display -->
+      1 │ <!-- Multiple offenses of same rules to test "Most frequent rule offenses" display -->
       2 │ 
   →   3 │ <div id=test1 class='' data-value=bar>
         │                     ~~
@@ -59,9 +59,9 @@ test/fixtures/multiple-rule-violations.html.erb:3:20
 
 [error] Attribute value should be quoted: \`id="value"\`. Always wrap attribute values in quotes. (html-attribute-values-require-quotes)
 
-test/fixtures/multiple-rule-violations.html.erb:3:8
+test/fixtures/multiple-rule-offenses.html.erb:3:8
 
-      1 │ <!-- Multiple violations of same rules to test "Most violated rules" display -->
+      1 │ <!-- Multiple offenses of same rules to test "Most frequent rule offenses" display -->
       2 │ 
   →   3 │ <div id=test1 class='' data-value=bar>
         │         ~~~~~
@@ -73,9 +73,9 @@ test/fixtures/multiple-rule-violations.html.erb:3:8
 
 [error] Attribute value should be quoted: \`data-value="value"\`. Always wrap attribute values in quotes. (html-attribute-values-require-quotes)
 
-test/fixtures/multiple-rule-violations.html.erb:3:34
+test/fixtures/multiple-rule-offenses.html.erb:3:34
 
-      1 │ <!-- Multiple violations of same rules to test "Most violated rules" display -->
+      1 │ <!-- Multiple offenses of same rules to test "Most frequent rule offenses" display -->
       2 │ 
   →   3 │ <div id=test1 class='' data-value=bar>
         │                                   ~~~
@@ -87,7 +87,7 @@ test/fixtures/multiple-rule-violations.html.erb:3:34
 
 [error] Missing required \`alt\` attribute on \`<img>\` tag. Add \`alt=""\` for decorative images or \`alt="description"\` for informative images. (html-img-require-alt)
 
-test/fixtures/multiple-rule-violations.html.erb:4:3
+test/fixtures/multiple-rule-offenses.html.erb:4:3
 
       2 │ 
       3 │ <div id=test1 class='' data-value=bar>
@@ -101,7 +101,7 @@ test/fixtures/multiple-rule-violations.html.erb:4:3
 
 [error] Duplicate attribute \`class\` found on tag. Remove the duplicate occurrence. (html-no-duplicate-attributes)
 
-test/fixtures/multiple-rule-violations.html.erb:5:14
+test/fixtures/multiple-rule-offenses.html.erb:5:14
 
       3 │ <div id=test1 class='' data-value=bar>
       4 │   <img />
@@ -115,7 +115,7 @@ test/fixtures/multiple-rule-violations.html.erb:5:14
 
 [error] Heading element \`<h1>\` must not be empty. Provide accessible text content for screen readers and SEO. (html-no-empty-headings)
 
-test/fixtures/multiple-rule-violations.html.erb:8:0
+test/fixtures/multiple-rule-offenses.html.erb:8:0
 
       6 │ </div>
       7 │ 
@@ -129,7 +129,7 @@ test/fixtures/multiple-rule-violations.html.erb:8:0
 
 [error] Nested \`<a>\` elements are not allowed. Links cannot contain other links. (html-no-nested-links)
 
-test/fixtures/multiple-rule-violations.html.erb:10:4
+test/fixtures/multiple-rule-offenses.html.erb:10:4
 
       8 │ <h1></h1>
       9 │ 
@@ -138,27 +138,27 @@ test/fixtures/multiple-rule-violations.html.erb:10:4
      11 │ 
      12 │ <div id="duplicate"></div>
 
- Most violated rules:
-  html-anchor-require-href (3 violations in 1 file)
-  html-attribute-values-require-quotes (2 violations in 1 file)
-  html-attribute-double-quotes (1 violation in 1 file)
-  html-img-require-alt (1 violation in 1 file)
-  html-no-duplicate-attributes (1 violation in 1 file)
+ Most frequent rule offenses:
+  html-anchor-require-href (3 offenses in 1 file)
+  html-attribute-values-require-quotes (2 offenses in 1 file)
+  html-attribute-double-quotes (1 offense in 1 file)
+  html-img-require-alt (1 offense in 1 file)
+  html-no-duplicate-attributes (1 offense in 1 file)
 
-  ...and 2 more rules with 2 violations
+  ...and 2 more rules with 2 offenses
 
 
  Summary:
   Checked      1 file
-  Violations   9 errors | 1 warning (10 violations across 1 file)"
+  Offenses     9 errors | 1 warning (10 offenses across 1 file)"
 `;
 
-exports[`CLI Output Formatting > displays rule violations when showing all rules 1`] = `
+exports[`CLI Output Formatting > displays rule offenses when showing all rules 1`] = `
 "[error] Attribute value should be quoted: \`id="value"\`. Always wrap attribute values in quotes. (html-attribute-values-require-quotes)
 
-test/fixtures/few-rule-violations.html.erb:2:8
+test/fixtures/few-rule-offenses.html.erb:2:8
 
-      1 │ <!-- Just a few different rule violations to test "Rule violations:" vs "Most violated rules:" -->
+      1 │ <!-- Just a few different rule offenses to test "Rule offenses:" vs "Most frequent rule offenses:" -->
   →   2 │ <div id=test class=foo>
         │         ~~~~
       3 │   <img src=image.jpg>
@@ -169,9 +169,9 @@ test/fixtures/few-rule-violations.html.erb:2:8
 
 [error] Attribute value should be quoted: \`class="value"\`. Always wrap attribute values in quotes. (html-attribute-values-require-quotes)
 
-test/fixtures/few-rule-violations.html.erb:2:19
+test/fixtures/few-rule-offenses.html.erb:2:19
 
-      1 │ <!-- Just a few different rule violations to test "Rule violations:" vs "Most violated rules:" -->
+      1 │ <!-- Just a few different rule offenses to test "Rule offenses:" vs "Most frequent rule offenses:" -->
   →   2 │ <div id=test class=foo>
         │                    ~~~
       3 │   <img src=image.jpg>
@@ -182,9 +182,9 @@ test/fixtures/few-rule-violations.html.erb:2:19
 
 [error] Attribute value should be quoted: \`src="value"\`. Always wrap attribute values in quotes. (html-attribute-values-require-quotes)
 
-test/fixtures/few-rule-violations.html.erb:3:11
+test/fixtures/few-rule-offenses.html.erb:3:11
 
-      1 │ <!-- Just a few different rule violations to test "Rule violations:" vs "Most violated rules:" -->
+      1 │ <!-- Just a few different rule offenses to test "Rule offenses:" vs "Most frequent rule offenses:" -->
       2 │ <div id=test class=foo>
   →   3 │   <img src=image.jpg>
         │            ~~~~~
@@ -196,9 +196,9 @@ test/fixtures/few-rule-violations.html.erb:3:11
 
 [error] Missing required \`alt\` attribute on \`<img>\` tag. Add \`alt=""\` for decorative images or \`alt="description"\` for informative images. (html-img-require-alt)
 
-test/fixtures/few-rule-violations.html.erb:3:3
+test/fixtures/few-rule-offenses.html.erb:3:3
 
-      1 │ <!-- Just a few different rule violations to test "Rule violations:" vs "Most violated rules:" -->
+      1 │ <!-- Just a few different rule offenses to test "Rule offenses:" vs "Most frequent rule offenses:" -->
       2 │ <div id=test class=foo>
   →   3 │   <img src=image.jpg>
         │    ~~~
@@ -210,7 +210,7 @@ test/fixtures/few-rule-violations.html.erb:3:3
 
 [error] Duplicate ID \`duplicate\` found. IDs must be unique within a document. (html-no-duplicate-ids)
 
-test/fixtures/few-rule-violations.html.erb:9:5
+test/fixtures/few-rule-offenses.html.erb:9:5
 
       7 │ 
       8 │ <div id="duplicate"></div>
@@ -223,7 +223,7 @@ test/fixtures/few-rule-violations.html.erb:9:5
 
 [error] Heading element \`<h1>\` must not be empty. Provide accessible text content for screen readers and SEO. (html-no-empty-headings)
 
-test/fixtures/few-rule-violations.html.erb:6:0
+test/fixtures/few-rule-offenses.html.erb:6:0
 
       4 │ </div>
       5 │ 
@@ -237,26 +237,167 @@ test/fixtures/few-rule-violations.html.erb:6:0
 
 [error] Unexpected Token. Expected: \`TOKEN_IDENTIFIER, TOKEN_AT, TOKEN_ERB_START,TOKEN_WHITESPACE, or TOKEN_NEWLINE\`, found: \`TOKEN_CHARACTER\`. (\`UNEXPECTED_ERROR\`) (parser-no-errors)
 
-test/fixtures/few-rule-violations.html.erb:3:16
+test/fixtures/few-rule-offenses.html.erb:3:16
 
-      1 │ <!-- Just a few different rule violations to test "Rule violations:" vs "Most violated rules:" -->
+      1 │ <!-- Just a few different rule offenses to test "Rule offenses:" vs "Most frequent rule offenses:" -->
       2 │ <div id=test class=foo>
   →   3 │   <img src=image.jpg>
         │                 ~
       4 │ </div>
       5 │
 
- Rule violations:
-  html-attribute-values-require-quotes (3 violations in 1 file)
-  html-img-require-alt (1 violation in 1 file)
-  html-no-duplicate-ids (1 violation in 1 file)
-  html-no-empty-headings (1 violation in 1 file)
-  parser-no-errors (1 violation in 1 file)
+ Rule offenses:
+  html-attribute-values-require-quotes (3 offenses in 1 file)
+  html-img-require-alt (1 offense in 1 file)
+  html-no-duplicate-ids (1 offense in 1 file)
+  html-no-empty-headings (1 offense in 1 file)
+  parser-no-errors (1 offense in 1 file)
 
 
  Summary:
   Checked      1 file
-  Violations   7 errors | 0 warnings (7 violations across 1 file)"
+  Offenses     7 errors | 0 warnings (7 offenses across 1 file)"
+`;
+
+exports[`CLI Output Formatting > formats JSON output correctly for bad file 1`] = `
+{
+  "clean": false,
+  "completed": true,
+  "message": null,
+  "offenses": [
+    {
+      "code": "html-tag-name-lowercase",
+      "filename": "test/fixtures/bad-file.html.erb",
+      "location": {
+        "end": {
+          "column": 5,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "message": "Opening tag name \`SPAN\` should be lowercase. Use \`span\` instead.",
+      "severity": "error",
+      "source": "Herb Linter",
+    },
+    {
+      "code": "html-tag-name-lowercase",
+      "filename": "test/fixtures/bad-file.html.erb",
+      "location": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "message": "Closing tag name \`SPAN\` should be lowercase. Use \`span\` instead.",
+      "severity": "error",
+      "source": "Herb Linter",
+    },
+  ],
+  "summary": {
+    "filesChecked": 1,
+    "filesWithOffenses": 1,
+    "ruleCount": 21,
+    "totalErrors": 2,
+    "totalOffenses": 2,
+    "totalWarnings": 0,
+  },
+  "timing": null,
+}
+`;
+
+exports[`CLI Output Formatting > formats JSON output correctly for clean file 1`] = `
+{
+  "clean": true,
+  "completed": true,
+  "message": null,
+  "offenses": [],
+  "summary": {
+    "filesChecked": 1,
+    "filesWithOffenses": 0,
+    "ruleCount": 21,
+    "totalErrors": 0,
+    "totalOffenses": 0,
+    "totalWarnings": 0,
+  },
+  "timing": null,
+}
+`;
+
+exports[`CLI Output Formatting > formats JSON output correctly for file with errors 1`] = `
+{
+  "clean": false,
+  "completed": true,
+  "message": null,
+  "offenses": [
+    {
+      "code": "html-img-require-alt",
+      "filename": "test/fixtures/test-file-with-errors.html.erb",
+      "location": {
+        "end": {
+          "column": 6,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "message": "Missing required \`alt\` attribute on \`<img>\` tag. Add \`alt=""\` for decorative images or \`alt="description"\` for informative images.",
+      "severity": "error",
+      "source": "Herb Linter",
+    },
+    {
+      "code": "html-tag-name-lowercase",
+      "filename": "test/fixtures/test-file-with-errors.html.erb",
+      "location": {
+        "end": {
+          "column": 7,
+          "line": 2,
+        },
+        "start": {
+          "column": 3,
+          "line": 2,
+        },
+      },
+      "message": "Opening tag name \`SPAN\` should be lowercase. Use \`span\` instead.",
+      "severity": "error",
+      "source": "Herb Linter",
+    },
+    {
+      "code": "html-tag-name-lowercase",
+      "filename": "test/fixtures/test-file-with-errors.html.erb",
+      "location": {
+        "end": {
+          "column": 26,
+          "line": 2,
+        },
+        "start": {
+          "column": 22,
+          "line": 2,
+        },
+      },
+      "message": "Closing tag name \`SPAN\` should be lowercase. Use \`span\` instead.",
+      "severity": "error",
+      "source": "Herb Linter",
+    },
+  ],
+  "summary": {
+    "filesChecked": 1,
+    "filesWithOffenses": 1,
+    "ruleCount": 21,
+    "totalErrors": 3,
+    "totalOffenses": 3,
+    "totalWarnings": 0,
+  },
+  "timing": null,
+}
 `;
 
 exports[`CLI Output Formatting > formats detailed error output correctly 1`] = `
@@ -297,14 +438,14 @@ test/fixtures/test-file-with-errors.html.erb:2:22
       3 │   <img src="test.jpg">
       4 │ </div>
 
- Rule violations:
-  html-tag-name-lowercase (2 violations in 1 file)
-  html-img-require-alt (1 violation in 1 file)
+ Rule offenses:
+  html-tag-name-lowercase (2 offenses in 1 file)
+  html-img-require-alt (1 offense in 1 file)
 
 
  Summary:
   Checked      1 file
-  Violations   3 errors | 0 warnings (3 violations across 1 file)"
+  Offenses     3 errors | 0 warnings (3 offenses across 1 file)"
 `;
 
 exports[`CLI Output Formatting > formats simple output correctly 1`] = `
@@ -312,13 +453,13 @@ exports[`CLI Output Formatting > formats simple output correctly 1`] = `
   2:3  ✗ Opening tag name \`SPAN\` should be lowercase. Use \`span\` instead. (html-tag-name-lowercase)
   2:22 ✗ Closing tag name \`SPAN\` should be lowercase. Use \`span\` instead. (html-tag-name-lowercase)
 
- Rule violations:
-  html-tag-name-lowercase (2 violations in 1 file)
+ Rule offenses:
+  html-tag-name-lowercase (2 offenses in 1 file)
 
 
  Summary:
   Checked      1 file
-  Violations   2 errors | 0 warnings (2 violations across 1 file)"
+  Offenses     2 errors | 0 warnings (2 offenses across 1 file)"
 `;
 
 exports[`CLI Output Formatting > formats simple output for bad-file correctly 1`] = `
@@ -326,13 +467,13 @@ exports[`CLI Output Formatting > formats simple output for bad-file correctly 1`
   1:1  ✗ Opening tag name \`SPAN\` should be lowercase. Use \`span\` instead. (html-tag-name-lowercase)
   1:16 ✗ Closing tag name \`SPAN\` should be lowercase. Use \`span\` instead. (html-tag-name-lowercase)
 
- Rule violations:
-  html-tag-name-lowercase (2 violations in 1 file)
+ Rule offenses:
+  html-tag-name-lowercase (2 offenses in 1 file)
 
 
  Summary:
   Checked      1 file
-  Violations   2 errors | 0 warnings (2 violations across 1 file)"
+  Offenses     2 errors | 0 warnings (2 offenses across 1 file)"
 `;
 
 exports[`CLI Output Formatting > formats success output correctly 1`] = `
@@ -341,7 +482,7 @@ exports[`CLI Output Formatting > formats success output correctly 1`] = `
 
  Summary:
   Checked      1 file
-  Violations   0 violations"
+  Offenses     0 offenses"
 `;
 
 exports[`CLI Output Formatting > handles multiple errors correctly 1`] = `
@@ -364,11 +505,11 @@ test/fixtures/bad-file.html.erb:1:16
         │                 ~~~~
       2 │
 
- Rule violations:
-  html-tag-name-lowercase (2 violations in 1 file)
+ Rule offenses:
+  html-tag-name-lowercase (2 offenses in 1 file)
 
 
  Summary:
   Checked      1 file
-  Violations   2 errors | 0 warnings (2 violations across 1 file)"
+  Offenses     2 errors | 0 warnings (2 offenses across 1 file)"
 `;

--- a/javascript/packages/linter/test/cli.test.ts
+++ b/javascript/packages/linter/test/cli.test.ts
@@ -57,15 +57,15 @@ describe("CLI Output Formatting", () => {
     expect(exitCode).toBe(1)
   })
 
-  test("displays most violated rules with multiple violations", () => {
-    const { output, exitCode } = runLinter("multiple-rule-violations.html.erb", "--no-wrap-lines")
+  test("displays most violated rules with multiple offenses", () => {
+    const { output, exitCode } = runLinter("multiple-rule-offenses.html.erb", "--no-wrap-lines")
 
     expect(output).toMatchSnapshot()
     expect(exitCode).toBe(1)
   })
 
-  test("displays rule violations when showing all rules", () => {
-    const { output, exitCode } = runLinter("few-rule-violations.html.erb", "--no-wrap-lines")
+  test("displays rule offenses when showing all rules", () => {
+    const { output, exitCode } = runLinter("few-rule-offenses.html.erb", "--no-wrap-lines")
 
     expect(output).toMatchSnapshot()
     expect(exitCode).toBe(1)
@@ -86,6 +86,30 @@ describe("CLI Output Formatting", () => {
 
     expect(output).toContain("erb-requires-trailing-newline")
     expect(output).toContain("File must end with trailing newline")
+    expect(exitCode).toBe(1)
+  })
+
+  test("formats JSON output correctly for file with errors", () => {
+    const { output, exitCode } = runLinter("test-file-with-errors.html.erb", "--json")
+    
+    const json = JSON.parse(output)
+    expect(json).toMatchSnapshot()
+    expect(exitCode).toBe(1)
+  })
+
+  test("formats JSON output correctly for clean file", () => {
+    const { output, exitCode } = runLinter("clean-file.html.erb", "--json")
+    
+    const json = JSON.parse(output)
+    expect(json).toMatchSnapshot()
+    expect(exitCode).toBe(0)
+  })
+
+  test("formats JSON output correctly for bad file", () => {
+    const { output, exitCode } = runLinter("bad-file.html.erb", "--json")
+    
+    const json = JSON.parse(output)
+    expect(json).toMatchSnapshot()
     expect(exitCode).toBe(1)
   })
 })

--- a/javascript/packages/linter/test/fixtures/few-rule-offenses.html.erb
+++ b/javascript/packages/linter/test/fixtures/few-rule-offenses.html.erb
@@ -1,4 +1,4 @@
-<!-- Just a few different rule violations to test "Rule violations:" vs "Most violated rules:" -->
+<!-- Just a few different rule offenses to test "Rule offenses:" vs "Most frequent rule offenses:" -->
 <div id=test class=foo>
   <img src=image.jpg>
 </div>

--- a/javascript/packages/linter/test/fixtures/multiple-rule-offenses.html.erb
+++ b/javascript/packages/linter/test/fixtures/multiple-rule-offenses.html.erb
@@ -1,4 +1,4 @@
-<!-- Multiple violations of same rules to test "Most violated rules" display -->
+<!-- Multiple offenses of same rules to test "Most frequent rule offenses" display -->
 
 <div id=test1 class='' data-value=bar>
   <img />

--- a/javascript/packages/linter/test/rules/erb-require-whitespace-inside-tags.test.ts
+++ b/javascript/packages/linter/test/rules/erb-require-whitespace-inside-tags.test.ts
@@ -81,7 +81,7 @@ describe("erb-require-whitespace-inside-tags", () => {
     expect(lintResult.offenses[0].message).toMatch(/Add whitespace before/i)
   })
 
-  it("should report multiple errors for multiple violations", () => {
+  it("should report multiple errors for multiple offenses", () => {
     const html = dedent`
       <%=user.name%>
       <%if admin%>


### PR DESCRIPTION
This pull request standardizes all terminology throughout the linter to use `offense`/`offenses` instead of the mixed usage of `violation`, `diagnostic`, and `offense` terms.