### PR TITLE
Formatter: Fix ERB content deletion during line wrapping

### DIFF
--- a/javascript/packages/formatter/src/printer.ts
+++ b/javascript/packages/formatter/src/printer.ts
@@ -1333,6 +1333,8 @@ export class Printer extends Visitor {
           currentLineContent += erbContent
 
           if ((indent.length + currentLineContent.length) > Math.max(this.maxLineLength, 120)) {
+            this.lines = oldLines
+            this.inlineMode = oldInlineMode
             this.visitTextFlowChildrenMultiline(children)
 
             return

--- a/javascript/packages/formatter/test/erb/erb.test.ts
+++ b/javascript/packages/formatter/test/erb/erb.test.ts
@@ -117,4 +117,45 @@ describe("@herb-tools/formatter", () => {
       expect(result).toBe(input)
     })
   })
+
+  test("preserves ERB content with HTML entities when line wrapping occurs", () => {
+    const input = dedent`
+      <h3>
+        <%= link_to "Start", start_path %>&rsquo;s overview of <%= link_to "Section", section_path %>, <%= link_to "End", end_path %>.
+      </h3>
+    `
+
+    const result = formatter.format(input)
+
+    expect(result).toBe(dedent`
+      <h3>
+        <%= link_to "Start", start_path %>
+        &rsquo;s overview of
+        <%= link_to "Section", section_path %>
+        ,
+        <%= link_to "End", end_path %>
+        .
+      </h3>
+    `)
+  })
+
+  test("preserves complex ERB expressions when exceeding line length", () => {
+    const input = dedent`
+      <p class="info-text">
+        For assistance, contact us at <%= config.phone_number %> or <%= mail_to(config.support_email, class: "email-link") %> if you need help with your account.
+      </p>
+    `
+
+    const result = formatter.format(input)
+
+    expect(result).toBe(dedent`
+      <p class="info-text">
+        For assistance, contact us at
+        <%= config.phone_number %>
+        or
+        <%= mail_to(config.support_email, class: "email-link") %>
+        if you need help with your account.
+      </p>
+    `)
+  })
 })


### PR DESCRIPTION
This pull request improves the formatter to prevent ERB content from being deleted when line wrapping occurs in text flow contexts.

Previously, when processing ERB tags that exceeded line length limits, the context restoration could happen after multiline formatting, causing the generated output to be discarded and resulting in empty HTML tags.

The fix ensures that context restoration occurs before calling `visitTextFlowChildrenMultiline` preserving the content.

Input:
```erb
<h3>
  <%= link_to "Start", start_path %>&rsquo;s overview of <%= link_to "Section", section_path %>, <%= link_to "End", end_path %>.
</h3>
```

Before:
```erb
<h3>
</h3>
```

After:
```erb
<h3>
  <%= link_to "Start", start_path %>&rsquo;s overview of <%= link_to "Section", section_path %>
  , <%= link_to "End", end_path %>.
</h3>
```
(for this ^ we still need to improve the over-agressive formatting, since this is now also causing a space betweeen the "Section" and the "," in the rendered HTML)

Resolves #351 