### PR TITLE
Parser: Support Foreign Content for `<style>` and `<script>`

### DIFF
--- a/src/include/parser.h
+++ b/src/include/parser.h
@@ -5,10 +5,22 @@
 #include "ast_node.h"
 #include "lexer.h"
 
+typedef enum {
+  FOREIGN_CONTENT_UNKNOWN = 0,
+  FOREIGN_CONTENT_SCRIPT,
+  FOREIGN_CONTENT_STYLE,
+  // FOREIGN_CONTENT_RUBY,
+  // FOREIGN_CONTENT_TEMPLATE
+} foreign_content_type_T;
+
+typedef enum { PARSER_STATE_DATA, PARSER_STATE_FOREIGN_CONTENT } parser_state_T;
+
 typedef struct PARSER_STRUCT {
   lexer_T* lexer;
   token_T* current_token;
   array_T* open_tags_stack;
+  parser_state_T state;
+  foreign_content_type_T foreign_content_type;
 } parser_T;
 
 parser_T* parser_init(lexer_T* lexer);

--- a/src/include/parser_helpers.h
+++ b/src/include/parser_helpers.h
@@ -24,6 +24,15 @@ void parser_append_literal_node_from_buffer(
 
 bool parser_in_svg_context(const parser_T* parser);
 
+foreign_content_type_T parser_get_foreign_content_type(const char* tag_name);
+bool parser_is_foreign_content_tag(const char* tag_name);
+const char* parser_get_foreign_content_closing_tag(foreign_content_type_T type);
+
+void parser_enter_foreign_content(parser_T* parser, foreign_content_type_T type);
+void parser_exit_foreign_content(parser_T* parser);
+
+bool parser_is_expected_closing_tag_name(const char* tag_name, foreign_content_type_T expected_type);
+
 token_T* parser_advance(parser_T* parser);
 token_T* parser_consume_if_present(parser_T* parser, token_type_T type);
 token_T* parser_consume_expected(parser_T* parser, token_type_T type, array_T* array);

--- a/src/include/token_struct.h
+++ b/src/include/token_struct.h
@@ -28,6 +28,7 @@ typedef enum {
   TOKEN_SLASH,       // /
   TOKEN_EQUALS,      // =
   TOKEN_QUOTE,       // ", '
+  TOKEN_BACKTICK,    // `
   TOKEN_DASH,        // -
   TOKEN_UNDERSCORE,  // _
   TOKEN_EXCLAMATION, // !

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -325,6 +325,7 @@ token_T* lexer_next_token(lexer_T* lexer) {
 
     case '"':
     case '\'': return lexer_advance_current(lexer, TOKEN_QUOTE);
+    case '`': return lexer_advance_current(lexer, TOKEN_BACKTICK);
 
     default: {
       if (isalnum(lexer->current_character)) { return lexer_parse_identifier(lexer); }

--- a/src/token.c
+++ b/src/token.c
@@ -55,6 +55,7 @@ const char* token_type_to_string(const token_type_T type) {
     case TOKEN_HTML_COMMENT_END: return "TOKEN_HTML_COMMENT_END";
     case TOKEN_EQUALS: return "TOKEN_EQUALS";
     case TOKEN_QUOTE: return "TOKEN_QUOTE";
+    case TOKEN_BACKTICK: return "TOKEN_BACKTICK";
     case TOKEN_DASH: return "TOKEN_DASH";
     case TOKEN_UNDERSCORE: return "TOKEN_UNDERSCORE";
     case TOKEN_EXCLAMATION: return "TOKEN_EXCLAMATION";

--- a/test/parser/attributes_test.rb
+++ b/test/parser/attributes_test.rb
@@ -123,5 +123,25 @@ module Parser
     test "atttribute with @ prefix and now value" do
       assert_parsed_snapshot(%(<div @click></div>))
     end
+
+    test "attribute with backtick quotes (invalid)" do
+      assert_parsed_snapshot(%(<div class=`hello`></div>))
+    end
+
+    test "attribute with backtick quotes and whitespace (invalid)" do
+      assert_parsed_snapshot(%(<div class=`hello world`></div>))
+    end
+
+    test "multiple attributes with mixed quotes including backticks (invalid)" do
+      assert_parsed_snapshot(%(<div class="valid" id=`invalid` data-test='also-valid'></div>))
+    end
+
+    test "self-closing tag with backtick attribute (invalid)" do
+      assert_parsed_snapshot(%(<img src=`image.jpg` />))
+    end
+
+    test "attribute with backtick containing HTML (invalid)" do
+      assert_parsed_snapshot(%(<div data-template=`<span>Hello</span>`></div>))
+    end
   end
 end

--- a/test/parser/script_style_test.rb
+++ b/test/parser/script_style_test.rb
@@ -1,0 +1,412 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+module Parser
+  class ScriptStyleTest < Minitest::Spec
+    include SnapshotUtils
+
+    test "script tag with less than comparison" do
+      assert_parsed_snapshot(%(<script>if (x < 10) { console.log("less"); }</script>))
+    end
+
+    test "script tag with greater than comparison" do
+      assert_parsed_snapshot(%(<script>if (x > 10) { console.log("greater"); }</script>))
+    end
+
+    test "script tag with HTML in string literal" do
+      assert_parsed_snapshot(%(<script>var html = "<div class='test'>content</div>";</script>))
+    end
+
+    test "script tag with HTML in comment" do
+      assert_parsed_snapshot(%(<script>// <div> should be ignored in comment</script>))
+    end
+
+    test "script tag with multiline comment containing HTML" do
+      assert_parsed_snapshot(<<~HTML)
+        <script>
+          /*
+           * <div>This is in a comment</div>
+           * <span>Also ignored</span>
+           */
+          console.log("test");
+        </script>
+      HTML
+    end
+
+    test "script tag with ERB-like content in string" do
+      assert_parsed_snapshot(%(<script>console.log("<%");</script>))
+    end
+
+    test "script tag with incomplete ERB-like content" do
+      assert_parsed_snapshot(%(<script>console.log("<%= incomplete");</script>))
+    end
+
+    test "script tag with closing script tag in string" do
+      assert_parsed_snapshot(%(<script>var s = "</script>";</script>))
+    end
+
+    test "script tag with escaped closing tag in string" do
+      assert_parsed_snapshot(%(<script>var s = "<\\/script>";</script>))
+    end
+
+    test "script tag with actual ERB interpolation" do
+      assert_parsed_snapshot(%(<script>var userId = <%= @user.id %>;</script>))
+    end
+
+    test "script tag with multiple ERB interpolations" do
+      assert_parsed_snapshot(<<~HTML)
+        <script>
+          var config = {
+            userId: <%= @user.id %>,
+            userName: "<%= @user.name %>",
+            isAdmin: <%= @user.admin? %>
+          };
+        </script>
+      HTML
+    end
+
+    test "script tag with complex JavaScript including comparisons and HTML strings" do
+      assert_parsed_snapshot(<<~HTML)
+        <script>
+          function test() {
+            if (x < 10 && y > 5) {
+              return "<div>" + content + "</div>";
+            }
+            // <span>Comment with HTML</span>
+            var template = `<ul>${items.map(i => `<li>${i}</li>`).join('')}</ul>`;
+          }
+        </script>
+      HTML
+    end
+
+    test "style tag with child selector" do
+      assert_parsed_snapshot(%(<style>.parent > .child { color: red; }</style>))
+    end
+
+    test "style tag with attribute selector containing HTML" do
+      assert_parsed_snapshot(%(<style>input[placeholder="<enter text>"] { color: blue; }</style>))
+    end
+
+    test "style tag with content property containing HTML" do
+      assert_parsed_snapshot(%(<style>.icon::before { content: "<span>★</span>"; }</style>))
+    end
+
+    test "style tag with ERB interpolation" do
+      assert_parsed_snapshot(%(<style>.user-<%= @user.id %> { color: <%= @theme_color %>; }</style>))
+    end
+
+    test "style tag with complex CSS including HTML-like content" do
+      assert_parsed_snapshot(<<~HTML)
+        <style>
+          /* <div>Comment with HTML</div> */
+          .tooltip::after {
+            content: "<div class='arrow'></div>";
+          }
+          .container > .item:first-child {
+            background: url("data:image/svg+xml,<svg><rect/></svg>");
+          }
+        </style>
+      HTML
+    end
+
+    test "nested script tags (inner in string)" do
+      assert_parsed_snapshot(<<~HTML)
+        <script>
+          document.write('<script src="other.js"><' + '/script>');
+        </script>
+      HTML
+    end
+
+    test "script tag with regex containing angle brackets" do
+      assert_parsed_snapshot(%(<script>var regex = /<[^>]+>/g;</script>))
+    end
+
+    test "style tag with media query and nested selectors" do
+      assert_parsed_snapshot(<<~HTML)
+        <style>
+          @media (max-width: 768px) {
+            .nav > ul > li {
+              display: block;
+            }
+          }
+        </style>
+      HTML
+    end
+
+    test "script tag with template literals containing HTML" do
+      assert_parsed_snapshot(<<~HTML)
+        <script>
+          const template = `
+            <div class="container">
+              <h1>${title}</h1>
+              <p>${content}</p>
+            </div>
+          `;
+        </script>
+      HTML
+    end
+
+    test "script tag with JSX-like syntax" do
+      assert_parsed_snapshot(<<~HTML)
+        <script>
+          const element = (
+            <div className="greeting">
+              <h1>Hello, {name}!</h1>
+            </div>
+          );
+        </script>
+      HTML
+    end
+
+    test "empty script and style tags" do
+      assert_parsed_snapshot(%(<script></script><style></style>))
+    end
+
+    test "script tag followed by style tag with complex content" do
+      assert_parsed_snapshot(<<~HTML)
+        <script>
+          if (window.width < 768) {
+            document.body.className = "mobile";
+          }
+        </script>
+        <style>
+          .mobile > .header {
+            font-size: 14px;
+          }
+        </style>
+      HTML
+    end
+
+    test "script tag with minified JavaScript containing many angle brackets" do
+      assert_parsed_snapshot(%(<script>!function(){for(var i=0;i<10;i++)if(arr[i]>5&&arr[i]<15)console.log("<item>"+arr[i]+"</item>")}();</script>))
+    end
+
+    test "script tag with JSON containing HTML" do
+      assert_parsed_snapshot(<<~HTML)
+        <script>
+          var data = {
+            "template": "<div class='widget'>{{content}}</div>",
+            "items": ["<span>A</span>", "<span>B</span>"]
+          };
+        </script>
+      HTML
+    end
+
+    test "style tag with CSS custom properties and calc" do
+      assert_parsed_snapshot(<<~HTML)
+        <style>
+          :root {
+            --arrow: "<";
+            --content: ">";
+          }
+          .element {
+            width: calc(100% - 20px);
+          }
+        </style>
+      HTML
+    end
+
+    test "script tag with incomplete ERB tag at end" do
+      assert_parsed_snapshot(%(<script>console.log("test"); <%</script>))
+    end
+
+    test "script tag with only ERB-like characters" do
+      assert_parsed_snapshot(%(<script>var s = "<%"; var e = "%>";</script>))
+    end
+
+    test "real world example - Google Analytics" do
+      assert_parsed_snapshot(<<~HTML)
+        <script>
+          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+          (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+          m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+          })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+        </script>
+      HTML
+    end
+
+    test "real world example - Klaviyo script from issue 271" do
+      assert_parsed_snapshot(<<~HTML)
+        <script>
+          // prettier-ignore
+          !function(){if(!window.klaviyo){window._klOnsite=window._klOnsite||[];try{window.klaviyo=new Proxy({},{get:function(n,i){return"push"===i?function(){var n;(n=window._klOnsite).push.apply(n,arguments)}:function(){for(var n=arguments.length,o=new Array(n),w=0;w<n;w++)o[w]=arguments[w];var t="function"==typeof o[o.length-1]?o.pop():void 0,e=new Promise((function(n){window._klOnsite.push([i].concat(o,[function(i){t&&t(i),n(i)}]))}));return e}}})}catch(n){window.klaviyo=window.klaviyo||[],window.klaviyo.push=function(){var n;(n=window._klOnsite).push.apply(n,arguments)}}}}();
+        </script>
+      HTML
+    end
+
+    test "script tag with single quote strings containing closing tags" do
+      assert_parsed_snapshot(%(<script>var s1 = '</script>'; var s2 = '</style>';</script>))
+    end
+
+    test "script tag with double quote strings containing closing tags" do
+      assert_parsed_snapshot(%(<script>var s1 = "</script>"; var s2 = "</style>";</script>))
+    end
+
+    test "script tag with template literals containing closing tags" do
+      assert_parsed_snapshot(%(<script>var template = `</script>`;</script>))
+    end
+
+    test "script tag with escaped quotes in strings" do
+      assert_parsed_snapshot(%(<script>var s = "He said \\"</script>\\" yesterday";</script>))
+    end
+
+    test "style tag with quotes containing HTML-like content" do
+      assert_parsed_snapshot(%(<style>.icon::before { content: "</style>"; }</style>))
+    end
+
+    test "script tag with mixed quote types and closing tags" do
+      assert_parsed_snapshot(<<~HTML)
+        <script>
+          var single = '</script>';
+          var double = "</script>";
+          console.log("All strings parsed correctly");
+        </script>
+      HTML
+    end
+
+    test "script tag with ERB inside string literals (ERB always processed)" do
+      assert_parsed_snapshot(<<~HTML)
+        <script>
+          var message = "<%= @greeting %>";
+          var template = '<%= @template %>';
+          var config = `<%= @config %>`;
+        </script>
+      HTML
+    end
+
+    test "script tag with ERB outside vs inside strings" do
+      assert_parsed_snapshot(<<~HTML)
+        <script>
+          var outside = <%= @value %>;
+          var inside = "<%= @value %>";
+          var mixed = "Hello " + <%= @name %> + " world";
+        </script>
+      HTML
+    end
+
+    test "script tag with ERB in double quotes" do
+      assert_parsed_snapshot(%(<script>var msg = "Hello <%= @user.name %> world";</script>))
+    end
+
+    test "script tag with ERB in single quotes" do
+      assert_parsed_snapshot(%(<script>var msg = 'Hello <%= @user.name %> world';</script>))
+    end
+
+    test "script tag with ERB in template literals" do
+      assert_parsed_snapshot(%(<script>var msg = `Hello <%= @user.name %> world`;</script>))
+    end
+
+    test "script tag with multiple ERB tags in one string" do
+      assert_parsed_snapshot(%(<script>var info = "User <%= @user.id %>: <%= @user.name %>";</script>))
+    end
+
+    test "script tag with ERB in different quote types same line" do
+      assert_parsed_snapshot(%(<script>var a = "ERB: <%= @a %>"; var b = 'ERB: <%= @b %>';</script>))
+    end
+
+    test "style tag with ERB in CSS strings" do
+      assert_parsed_snapshot(<<~HTML)
+        <style>
+          .dynamic::before {
+            content: "Generated: <%= @timestamp %>";
+            background: url('<%= @image_path %>');
+          }
+        </style>
+      HTML
+    end
+
+    test "script tag with closing tag in single-line comment" do
+      assert_parsed_snapshot(<<~HTML)
+        <script>
+          // </script>
+        </script>
+      HTML
+    end
+
+    test "script tag with closing tag in multi-line comment" do
+      assert_parsed_snapshot(<<~HTML)
+        <script>
+          /* </script> */
+        </script>
+      HTML
+    end
+
+    test "script tag with closing tag in complex multi-line comment" do
+      assert_parsed_snapshot(<<~HTML)
+        <script>
+          /*
+           * This is a comment with </script> inside
+           * and some more content </style>
+           */
+          console.log("actual code");
+        </script>
+      HTML
+    end
+
+    test "script tag with mixed comments and strings" do
+      assert_parsed_snapshot(<<~HTML)
+        <script>
+          // Comment with </script>
+          var str = "String with </script>";
+          /* Multi-line comment
+             with </script> inside */
+          var another = 'Single quote </script>';
+        </script>
+      HTML
+    end
+
+    test "script tag with nested comment markers" do
+      assert_parsed_snapshot(<<~HTML)
+        <script>
+          // First comment // with nested comment marker
+          /* Outer comment /* with nested comment marker */ still in comment */
+          console.log("done");
+        </script>
+      HTML
+    end
+
+    test "script tag with ERB in comments" do
+      assert_parsed_snapshot(<<~HTML)
+        <script>
+          // ERB in comment: <%= @value %>
+          /* Multi-line ERB: <%= @data %> */
+          var result = <%= @actual_erb %>;
+        </script>
+      HTML
+    end
+
+    test "script tag with complex multi-line comment containing closing tag" do
+      assert_parsed_snapshot(<<~HTML)
+        <script>
+          /*
+           * </script>
+           */
+        </script>
+      HTML
+    end
+
+    test "script tag with template literal containing closing tag (multiline)" do
+      assert_parsed_snapshot(<<~HTML)
+        <script>
+          `</script>`
+        </script>
+      HTML
+    end
+
+    test "script tag with closing tag on comment line" do
+      assert_parsed_snapshot(<<~HTML)
+        <div>Before</div>
+
+        <script>
+          // </script>
+
+        <div>After</div>
+      HTML
+    end
+
+    test "script tag with closing div tag in string" do
+      assert_parsed_snapshot(%(<script>var s = "</div>";</script>))
+    end
+  end
+end

--- a/test/parser/tags_test.rb
+++ b/test/parser/tags_test.rb
@@ -163,22 +163,18 @@ module Parser
     end
 
     test "script tag with nested div" do
-      skip
       assert_parsed_snapshot(%(<script><div>var x = 5;</div></script>))
     end
 
     test "script tag with JavaScript greater than comparison" do
-      skip
       assert_parsed_snapshot(%(<script>if (something > 3) { alert("hello"); }</script>))
     end
 
     test "script tag with JavaScript less than comparison" do
-      skip
       assert_parsed_snapshot(%(<script>if (count < 10) { return true; }</script>))
     end
 
     test "script tag with HTML-like string literals" do
-      skip
       assert_parsed_snapshot(%(<script>var html = "<div class='test'>content</div>";</script>))
     end
 
@@ -193,12 +189,10 @@ module Parser
     end
 
     test "style tag with nested div and CSS selectors" do
-      skip
       assert_parsed_snapshot(%(<style><div>.class { color: red; }</div></style>))
     end
 
     test "style tag with CSS greater than selector" do
-      skip
       assert_parsed_snapshot(%(<style>.parent > .child { margin: 0; }</style>))
     end
 
@@ -218,12 +212,10 @@ module Parser
     end
 
     test "script tag with ERB interpolation" do
-      skip
       assert_parsed_snapshot(%(<script>var userId = <%= current_user.id %>; if (userId > 0) { login(); }</script>))
     end
 
     test "style tag with ERB interpolation" do
-      skip
       assert_parsed_snapshot(%(<style>.user-<%= user.id %> > .content { color: <%= theme_color %>; }</style>))
     end
 

--- a/test/snapshots/parser/attributes_test/test_0029_attribute_with_backtick_quotes_(invalid)_8718691f5760feaae83ee2b77c476b95.txt
+++ b/test/snapshots/parser/attributes_test/test_0029_attribute_with_backtick_quotes_(invalid)_8718691f5760feaae83ee2b77c476b95.txt
@@ -1,0 +1,56 @@
+@ DocumentNode (location: (1:0)-(1:25))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:25))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:19))
+        │       ├── errors: (1 error)
+        │       │   └── @ UnexpectedError (location: (1:17)-(1:18))
+        │       │       ├── message: "Unexpected Token. Expected: `TOKEN_IDENTIFIER, TOKEN_AT, TOKEN_ERB_START,TOKEN_WHITESPACE, or TOKEN_NEWLINE`, found: `TOKEN_BACKTICK`."
+        │       │       ├── description: "Unexpected Token"
+        │       │       ├── expected: "TOKEN_IDENTIFIER, TOKEN_AT, TOKEN_ERB_START,TOKEN_WHITESPACE, or TOKEN_NEWLINE"
+        │       │       └── found: "TOKEN_BACKTICK"
+        │       │
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "div" (location: (1:1)-(1:4))
+        │       ├── tag_closing: ">" (location: (1:18)-(1:19))
+        │       ├── children: (2 items)
+        │       │   ├── @ HTMLAttributeNode (location: (1:5)-(1:12))
+        │       │   │   ├── name:
+        │       │   │   │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:10))
+        │       │   │   │       └── name: "class" (location: (1:5)-(1:10))
+        │       │   │   │
+        │       │   │   ├── equals: "=" (location: (1:10)-(1:11))
+        │       │   │   └── value:
+        │       │   │       └── @ HTMLAttributeValueNode (location: (1:11)-(1:12))
+        │       │   │           ├── errors: (1 error)
+        │       │   │           │   └── @ UnexpectedError (location: (1:11)-(1:12))
+        │       │   │           │       ├── message: "Invalid quote character for HTML attribute. Expected: `single quote (') or double quote (\")`, found: `backtick (`)`."
+        │       │   │           │       ├── description: "Invalid quote character for HTML attribute"
+        │       │   │           │       ├── expected: "single quote (') or double quote (\")"
+        │       │   │           │       └── found: "backtick (`)"
+        │       │   │           │
+        │       │   │           ├── open_quote: ∅
+        │       │   │           ├── children: []
+        │       │   │           ├── close_quote: ∅
+        │       │   │           └── quoted: false
+        │       │   │
+        │       │   │
+        │       │   └── @ HTMLAttributeNode (location: (1:12)-(1:17))
+        │       │       ├── name:
+        │       │       │   └── @ HTMLAttributeNameNode (location: (1:12)-(1:17))
+        │       │       │       └── name: "hello" (location: (1:12)-(1:17))
+        │       │       │
+        │       │       ├── equals: ∅
+        │       │       └── value: ∅
+        │       │
+        │       └── is_void: false
+        │
+        ├── tag_name: "div" (location: (1:1)-(1:4))
+        ├── body: []
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:19)-(1:25))
+        │       ├── tag_opening: "</" (location: (1:19)-(1:21))
+        │       ├── tag_name: "div" (location: (1:21)-(1:24))
+        │       └── tag_closing: ">" (location: (1:24)-(1:25))
+        │
+        └── is_void: false

--- a/test/snapshots/parser/attributes_test/test_0030_attribute_with_backtick_quotes_and_whitespace_(invalid)_237e4c11b70033b3f49f29b7e3c9cb70.txt
+++ b/test/snapshots/parser/attributes_test/test_0030_attribute_with_backtick_quotes_and_whitespace_(invalid)_237e4c11b70033b3f49f29b7e3c9cb70.txt
@@ -1,0 +1,64 @@
+@ DocumentNode (location: (1:0)-(1:31))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:31))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:25))
+        │       ├── errors: (1 error)
+        │       │   └── @ UnexpectedError (location: (1:23)-(1:24))
+        │       │       ├── message: "Unexpected Token. Expected: `TOKEN_IDENTIFIER, TOKEN_AT, TOKEN_ERB_START,TOKEN_WHITESPACE, or TOKEN_NEWLINE`, found: `TOKEN_BACKTICK`."
+        │       │       ├── description: "Unexpected Token"
+        │       │       ├── expected: "TOKEN_IDENTIFIER, TOKEN_AT, TOKEN_ERB_START,TOKEN_WHITESPACE, or TOKEN_NEWLINE"
+        │       │       └── found: "TOKEN_BACKTICK"
+        │       │
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "div" (location: (1:1)-(1:4))
+        │       ├── tag_closing: ">" (location: (1:24)-(1:25))
+        │       ├── children: (3 items)
+        │       │   ├── @ HTMLAttributeNode (location: (1:5)-(1:12))
+        │       │   │   ├── name:
+        │       │   │   │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:10))
+        │       │   │   │       └── name: "class" (location: (1:5)-(1:10))
+        │       │   │   │
+        │       │   │   ├── equals: "=" (location: (1:10)-(1:11))
+        │       │   │   └── value:
+        │       │   │       └── @ HTMLAttributeValueNode (location: (1:11)-(1:12))
+        │       │   │           ├── errors: (1 error)
+        │       │   │           │   └── @ UnexpectedError (location: (1:11)-(1:12))
+        │       │   │           │       ├── message: "Invalid quote character for HTML attribute. Expected: `single quote (') or double quote (\")`, found: `backtick (`)`."
+        │       │   │           │       ├── description: "Invalid quote character for HTML attribute"
+        │       │   │           │       ├── expected: "single quote (') or double quote (\")"
+        │       │   │           │       └── found: "backtick (`)"
+        │       │   │           │
+        │       │   │           ├── open_quote: ∅
+        │       │   │           ├── children: []
+        │       │   │           ├── close_quote: ∅
+        │       │   │           └── quoted: false
+        │       │   │
+        │       │   │
+        │       │   ├── @ HTMLAttributeNode (location: (1:12)-(1:17))
+        │       │   │   ├── name:
+        │       │   │   │   └── @ HTMLAttributeNameNode (location: (1:12)-(1:17))
+        │       │   │   │       └── name: "hello" (location: (1:12)-(1:17))
+        │       │   │   │
+        │       │   │   ├── equals: ∅
+        │       │   │   └── value: ∅
+        │       │   │
+        │       │   └── @ HTMLAttributeNode (location: (1:18)-(1:23))
+        │       │       ├── name:
+        │       │       │   └── @ HTMLAttributeNameNode (location: (1:18)-(1:23))
+        │       │       │       └── name: "world" (location: (1:18)-(1:23))
+        │       │       │
+        │       │       ├── equals: ∅
+        │       │       └── value: ∅
+        │       │
+        │       └── is_void: false
+        │
+        ├── tag_name: "div" (location: (1:1)-(1:4))
+        ├── body: []
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:25)-(1:31))
+        │       ├── tag_opening: "</" (location: (1:25)-(1:27))
+        │       ├── tag_name: "div" (location: (1:27)-(1:30))
+        │       └── tag_closing: ">" (location: (1:30)-(1:31))
+        │
+        └── is_void: false

--- a/test/snapshots/parser/attributes_test/test_0031_multiple_attributes_with_mixed_quotes_including_backticks_(invalid)_5eb53ae0e5d34773abdd248e275f8c51.txt
+++ b/test/snapshots/parser/attributes_test/test_0031_multiple_attributes_with_mixed_quotes_including_backticks_(invalid)_5eb53ae0e5d34773abdd248e275f8c51.txt
@@ -1,0 +1,90 @@
+@ DocumentNode (location: (1:0)-(1:61))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:61))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:55))
+        │       ├── errors: (1 error)
+        │       │   └── @ UnexpectedError (location: (1:30)-(1:31))
+        │       │       ├── message: "Unexpected Token. Expected: `TOKEN_IDENTIFIER, TOKEN_AT, TOKEN_ERB_START,TOKEN_WHITESPACE, or TOKEN_NEWLINE`, found: `TOKEN_BACKTICK`."
+        │       │       ├── description: "Unexpected Token"
+        │       │       ├── expected: "TOKEN_IDENTIFIER, TOKEN_AT, TOKEN_ERB_START,TOKEN_WHITESPACE, or TOKEN_NEWLINE"
+        │       │       └── found: "TOKEN_BACKTICK"
+        │       │
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "div" (location: (1:1)-(1:4))
+        │       ├── tag_closing: ">" (location: (1:54)-(1:55))
+        │       ├── children: (4 items)
+        │       │   ├── @ HTMLAttributeNode (location: (1:5)-(1:18))
+        │       │   │   ├── name:
+        │       │   │   │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:10))
+        │       │   │   │       └── name: "class" (location: (1:5)-(1:10))
+        │       │   │   │
+        │       │   │   ├── equals: "=" (location: (1:10)-(1:11))
+        │       │   │   └── value:
+        │       │   │       └── @ HTMLAttributeValueNode (location: (1:11)-(1:18))
+        │       │   │           ├── open_quote: """ (location: (1:11)-(1:12))
+        │       │   │           ├── children: (1 item)
+        │       │   │           │   └── @ LiteralNode (location: (1:12)-(1:17))
+        │       │   │           │       └── content: "valid"
+        │       │   │           │
+        │       │   │           ├── close_quote: """ (location: (1:17)-(1:18))
+        │       │   │           └── quoted: true
+        │       │   │
+        │       │   │
+        │       │   ├── @ HTMLAttributeNode (location: (1:19)-(1:23))
+        │       │   │   ├── name:
+        │       │   │   │   └── @ HTMLAttributeNameNode (location: (1:19)-(1:21))
+        │       │   │   │       └── name: "id" (location: (1:19)-(1:21))
+        │       │   │   │
+        │       │   │   ├── equals: "=" (location: (1:21)-(1:22))
+        │       │   │   └── value:
+        │       │   │       └── @ HTMLAttributeValueNode (location: (1:22)-(1:23))
+        │       │   │           ├── errors: (1 error)
+        │       │   │           │   └── @ UnexpectedError (location: (1:22)-(1:23))
+        │       │   │           │       ├── message: "Invalid quote character for HTML attribute. Expected: `single quote (') or double quote (\")`, found: `backtick (`)`."
+        │       │   │           │       ├── description: "Invalid quote character for HTML attribute"
+        │       │   │           │       ├── expected: "single quote (') or double quote (\")"
+        │       │   │           │       └── found: "backtick (`)"
+        │       │   │           │
+        │       │   │           ├── open_quote: ∅
+        │       │   │           ├── children: []
+        │       │   │           ├── close_quote: ∅
+        │       │   │           └── quoted: false
+        │       │   │
+        │       │   │
+        │       │   ├── @ HTMLAttributeNode (location: (1:23)-(1:30))
+        │       │   │   ├── name:
+        │       │   │   │   └── @ HTMLAttributeNameNode (location: (1:23)-(1:30))
+        │       │   │   │       └── name: "invalid" (location: (1:23)-(1:30))
+        │       │   │   │
+        │       │   │   ├── equals: ∅
+        │       │   │   └── value: ∅
+        │       │   │
+        │       │   └── @ HTMLAttributeNode (location: (1:32)-(1:54))
+        │       │       ├── name:
+        │       │       │   └── @ HTMLAttributeNameNode (location: (1:32)-(1:41))
+        │       │       │       └── name: "data-test" (location: (1:32)-(1:41))
+        │       │       │
+        │       │       ├── equals: "=" (location: (1:41)-(1:42))
+        │       │       └── value:
+        │       │           └── @ HTMLAttributeValueNode (location: (1:42)-(1:54))
+        │       │               ├── open_quote: "'" (location: (1:42)-(1:43))
+        │       │               ├── children: (1 item)
+        │       │               │   └── @ LiteralNode (location: (1:43)-(1:53))
+        │       │               │       └── content: "also-valid"
+        │       │               │
+        │       │               ├── close_quote: "'" (location: (1:53)-(1:54))
+        │       │               └── quoted: true
+        │       │
+        │       │
+        │       └── is_void: false
+        │
+        ├── tag_name: "div" (location: (1:1)-(1:4))
+        ├── body: []
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:55)-(1:61))
+        │       ├── tag_opening: "</" (location: (1:55)-(1:57))
+        │       ├── tag_name: "div" (location: (1:57)-(1:60))
+        │       └── tag_closing: ">" (location: (1:60)-(1:61))
+        │
+        └── is_void: false

--- a/test/snapshots/parser/attributes_test/test_0032_self-closing_tag_with_backtick_attribute_(invalid)_0545b512ba1dfae2fd7c90ec643b4cca.txt
+++ b/test/snapshots/parser/attributes_test/test_0032_self-closing_tag_with_backtick_attribute_(invalid)_0545b512ba1dfae2fd7c90ec643b4cca.txt
@@ -1,0 +1,51 @@
+@ DocumentNode (location: (1:0)-(1:23))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:23))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:23))
+        │       ├── errors: (1 error)
+        │       │   └── @ UnexpectedError (location: (1:19)-(1:20))
+        │       │       ├── message: "Unexpected Token. Expected: `TOKEN_IDENTIFIER, TOKEN_AT, TOKEN_ERB_START,TOKEN_WHITESPACE, or TOKEN_NEWLINE`, found: `TOKEN_BACKTICK`."
+        │       │       ├── description: "Unexpected Token"
+        │       │       ├── expected: "TOKEN_IDENTIFIER, TOKEN_AT, TOKEN_ERB_START,TOKEN_WHITESPACE, or TOKEN_NEWLINE"
+        │       │       └── found: "TOKEN_BACKTICK"
+        │       │
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "img" (location: (1:1)-(1:4))
+        │       ├── tag_closing: "/>" (location: (1:21)-(1:23))
+        │       ├── children: (2 items)
+        │       │   ├── @ HTMLAttributeNode (location: (1:5)-(1:10))
+        │       │   │   ├── name:
+        │       │   │   │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:8))
+        │       │   │   │       └── name: "src" (location: (1:5)-(1:8))
+        │       │   │   │
+        │       │   │   ├── equals: "=" (location: (1:8)-(1:9))
+        │       │   │   └── value:
+        │       │   │       └── @ HTMLAttributeValueNode (location: (1:9)-(1:10))
+        │       │   │           ├── errors: (1 error)
+        │       │   │           │   └── @ UnexpectedError (location: (1:9)-(1:10))
+        │       │   │           │       ├── message: "Invalid quote character for HTML attribute. Expected: `single quote (') or double quote (\")`, found: `backtick (`)`."
+        │       │   │           │       ├── description: "Invalid quote character for HTML attribute"
+        │       │   │           │       ├── expected: "single quote (') or double quote (\")"
+        │       │   │           │       └── found: "backtick (`)"
+        │       │   │           │
+        │       │   │           ├── open_quote: ∅
+        │       │   │           ├── children: []
+        │       │   │           ├── close_quote: ∅
+        │       │   │           └── quoted: false
+        │       │   │
+        │       │   │
+        │       │   └── @ HTMLAttributeNode (location: (1:10)-(1:19))
+        │       │       ├── name:
+        │       │       │   └── @ HTMLAttributeNameNode (location: (1:10)-(1:19))
+        │       │       │       └── name: "image.jpg" (location: (1:10)-(1:19))
+        │       │       │
+        │       │       ├── equals: ∅
+        │       │       └── value: ∅
+        │       │
+        │       └── is_void: true
+        │
+        ├── tag_name: "img" (location: (1:1)-(1:4))
+        ├── body: []
+        ├── close_tag: ∅
+        └── is_void: true

--- a/test/snapshots/parser/attributes_test/test_0033_attribute_with_backtick_containing_HTML_(invalid)_542130e358dadabeb4a1629bc9bcf4f3.txt
+++ b/test/snapshots/parser/attributes_test/test_0033_attribute_with_backtick_containing_HTML_(invalid)_542130e358dadabeb4a1629bc9bcf4f3.txt
@@ -1,0 +1,92 @@
+@ DocumentNode (location: (1:0)-(1:46))
+├── errors: (3 errors)
+│   ├── @ UnexpectedError (location: (1:38)-(1:39))
+│   │   ├── message: "Unexpected token. Expected: `TOKEN_ERB_START, TOKEN_HTML_DOCTYPE, TOKEN_HTML_COMMENT_START, TOKEN_IDENTIFIER, TOKEN_WHITESPACE, TOKEN_NBSP, TOKEN_AT, or TOKE`, found: `TOKEN_BACKTICK`."
+│   │   ├── description: "Unexpected token"
+│   │   ├── expected: "TOKEN_ERB_START, TOKEN_HTML_DOCTYPE, TOKEN_HTML_COMMENT_START, TOKEN_IDENTIFIER, TOKEN_WHITESPACE, TOKEN_NBSP, TOKEN_AT, or TOKEN_NEWLINE"
+│   │   └── found: "TOKEN_BACKTICK"
+│   │
+│   ├── @ UnexpectedError (location: (1:39)-(1:40))
+│   │   ├── message: "Unexpected token. Expected: `TOKEN_ERB_START, TOKEN_HTML_DOCTYPE, TOKEN_HTML_COMMENT_START, TOKEN_IDENTIFIER, TOKEN_WHITESPACE, TOKEN_NBSP, TOKEN_AT, or TOKE`, found: `TOKEN_HTML_TAG_END`."
+│   │   ├── description: "Unexpected token"
+│   │   ├── expected: "TOKEN_ERB_START, TOKEN_HTML_DOCTYPE, TOKEN_HTML_COMMENT_START, TOKEN_IDENTIFIER, TOKEN_WHITESPACE, TOKEN_NBSP, TOKEN_AT, or TOKEN_NEWLINE"
+│   │   └── found: "TOKEN_HTML_TAG_END"
+│   │
+│   └── @ UnclosedElementError (location: (1:40)-(1:42))
+│       ├── message: "Tag `<div>` opened at (1:1) was never closed before the end of document."
+│       └── opening_tag: "div" (location: (1:1)-(1:4))
+│
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:38))
+    │   ├── errors: (1 error)
+    │   │   └── @ TagNamesMismatchError (location: (1:33)-(1:37))
+    │   │       ├── message: "Opening tag `<div>` at (1:1) closed with `</span>` at (1:33)."
+    │   │       ├── opening_tag: "div" (location: (1:1)-(1:4))
+    │   │       └── closing_tag: "span" (location: (1:33)-(1:37))
+    │   │
+    │   ├── open_tag:
+    │   │   └── @ HTMLOpenTagNode (location: (1:0)-(1:26))
+    │   │       ├── errors: (1 error)
+    │   │       │   └── @ UnexpectedError (location: (1:20)-(1:21))
+    │   │       │       ├── message: "Unexpected Token. Expected: `TOKEN_IDENTIFIER, TOKEN_AT, TOKEN_ERB_START,TOKEN_WHITESPACE, or TOKEN_NEWLINE`, found: `TOKEN_HTML_TAG_START`."
+    │   │       │       ├── description: "Unexpected Token"
+    │   │       │       ├── expected: "TOKEN_IDENTIFIER, TOKEN_AT, TOKEN_ERB_START,TOKEN_WHITESPACE, or TOKEN_NEWLINE"
+    │   │       │       └── found: "TOKEN_HTML_TAG_START"
+    │   │       │
+    │   │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+    │   │       ├── tag_name: "div" (location: (1:1)-(1:4))
+    │   │       ├── tag_closing: ">" (location: (1:25)-(1:26))
+    │   │       ├── children: (2 items)
+    │   │       │   ├── @ HTMLAttributeNode (location: (1:5)-(1:20))
+    │   │       │   │   ├── name:
+    │   │       │   │   │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:18))
+    │   │       │   │   │       └── name: "data-template" (location: (1:5)-(1:18))
+    │   │       │   │   │
+    │   │       │   │   ├── equals: "=" (location: (1:18)-(1:19))
+    │   │       │   │   └── value:
+    │   │       │   │       └── @ HTMLAttributeValueNode (location: (1:19)-(1:20))
+    │   │       │   │           ├── errors: (1 error)
+    │   │       │   │           │   └── @ UnexpectedError (location: (1:19)-(1:20))
+    │   │       │   │           │       ├── message: "Invalid quote character for HTML attribute. Expected: `single quote (') or double quote (\")`, found: `backtick (`)`."
+    │   │       │   │           │       ├── description: "Invalid quote character for HTML attribute"
+    │   │       │   │           │       ├── expected: "single quote (') or double quote (\")"
+    │   │       │   │           │       └── found: "backtick (`)"
+    │   │       │   │           │
+    │   │       │   │           ├── open_quote: ∅
+    │   │       │   │           ├── children: []
+    │   │       │   │           ├── close_quote: ∅
+    │   │       │   │           └── quoted: false
+    │   │       │   │
+    │   │       │   │
+    │   │       │   └── @ HTMLAttributeNode (location: (1:21)-(1:25))
+    │   │       │       ├── name:
+    │   │       │       │   └── @ HTMLAttributeNameNode (location: (1:21)-(1:25))
+    │   │       │       │       └── name: "span" (location: (1:21)-(1:25))
+    │   │       │       │
+    │   │       │       ├── equals: ∅
+    │   │       │       └── value: ∅
+    │   │       │
+    │   │       └── is_void: false
+    │   │
+    │   ├── tag_name: "div" (location: (1:1)-(1:4))
+    │   ├── body: (1 item)
+    │   │   └── @ HTMLTextNode (location: (1:26)-(1:31))
+    │   │       └── content: "Hello"
+    │   │
+    │   ├── close_tag:
+    │   │   └── @ HTMLCloseTagNode (location: (1:31)-(1:38))
+    │   │       ├── tag_opening: "</" (location: (1:31)-(1:33))
+    │   │       ├── tag_name: "span" (location: (1:33)-(1:37))
+    │   │       └── tag_closing: ">" (location: (1:37)-(1:38))
+    │   │
+    │   └── is_void: false
+    │
+    └── @ HTMLCloseTagNode (location: (1:40)-(1:46))
+        ├── errors: (1 error)
+        │   └── @ MissingOpeningTagError (location: (1:40)-(1:46))
+        │       ├── message: "Found closing tag `</div>` at (1:42) without a matching opening tag."
+        │       └── closing_tag: "div" (location: (1:42)-(1:45))
+        │
+        ├── tag_opening: "</" (location: (1:40)-(1:42))
+        ├── tag_name: "div" (location: (1:42)-(1:45))
+        └── tag_closing: ">" (location: (1:45)-(1:46))

--- a/test/snapshots/parser/script_style_test/test_0001_script_tag_with_less_than_comparison_986012b1810325f86cbfc83a34165cf6.txt
+++ b/test/snapshots/parser/script_style_test/test_0001_script_tag_with_less_than_comparison_986012b1810325f86cbfc83a34165cf6.txt
@@ -1,0 +1,23 @@
+@ DocumentNode (location: (1:0)-(1:53))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:53))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:8))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "script" (location: (1:1)-(1:7))
+        │       ├── tag_closing: ">" (location: (1:7)-(1:8))
+        │       ├── children: []
+        │       └── is_void: false
+        │
+        ├── tag_name: "script" (location: (1:1)-(1:7))
+        ├── body: (1 item)
+        │   └── @ LiteralNode (location: (1:8)-(1:44))
+        │       └── content: "if (x < 10) { console.log(\"less\"); }"
+        │
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:44)-(1:53))
+        │       ├── tag_opening: "</" (location: (1:44)-(1:46))
+        │       ├── tag_name: "script" (location: (1:46)-(1:52))
+        │       └── tag_closing: ">" (location: (1:52)-(1:53))
+        │
+        └── is_void: false

--- a/test/snapshots/parser/script_style_test/test_0002_script_tag_with_greater_than_comparison_c91f3c6a114f0255015282bad4fd59b6.txt
+++ b/test/snapshots/parser/script_style_test/test_0002_script_tag_with_greater_than_comparison_c91f3c6a114f0255015282bad4fd59b6.txt
@@ -1,0 +1,23 @@
+@ DocumentNode (location: (1:0)-(1:56))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:56))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:8))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "script" (location: (1:1)-(1:7))
+        │       ├── tag_closing: ">" (location: (1:7)-(1:8))
+        │       ├── children: []
+        │       └── is_void: false
+        │
+        ├── tag_name: "script" (location: (1:1)-(1:7))
+        ├── body: (1 item)
+        │   └── @ LiteralNode (location: (1:8)-(1:47))
+        │       └── content: "if (x > 10) { console.log(\"greater\"); }"
+        │
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:47)-(1:56))
+        │       ├── tag_opening: "</" (location: (1:47)-(1:49))
+        │       ├── tag_name: "script" (location: (1:49)-(1:55))
+        │       └── tag_closing: ">" (location: (1:55)-(1:56))
+        │
+        └── is_void: false

--- a/test/snapshots/parser/script_style_test/test_0003_script_tag_with_HTML_in_string_literal_9287823706422dd5f10c14109bd0bc25.txt
+++ b/test/snapshots/parser/script_style_test/test_0003_script_tag_with_HTML_in_string_literal_9287823706422dd5f10c14109bd0bc25.txt
@@ -1,0 +1,23 @@
+@ DocumentNode (location: (1:0)-(1:62))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:62))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:8))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "script" (location: (1:1)-(1:7))
+        │       ├── tag_closing: ">" (location: (1:7)-(1:8))
+        │       ├── children: []
+        │       └── is_void: false
+        │
+        ├── tag_name: "script" (location: (1:1)-(1:7))
+        ├── body: (1 item)
+        │   └── @ LiteralNode (location: (1:8)-(1:53))
+        │       └── content: "var html = \"<div class='test'>content</div>\";"
+        │
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:53)-(1:62))
+        │       ├── tag_opening: "</" (location: (1:53)-(1:55))
+        │       ├── tag_name: "script" (location: (1:55)-(1:61))
+        │       └── tag_closing: ">" (location: (1:61)-(1:62))
+        │
+        └── is_void: false

--- a/test/snapshots/parser/script_style_test/test_0004_script_tag_with_HTML_in_comment_22b0049eb8bc227ece2a9f520a4e4ec3.txt
+++ b/test/snapshots/parser/script_style_test/test_0004_script_tag_with_HTML_in_comment_22b0049eb8bc227ece2a9f520a4e4ec3.txt
@@ -1,0 +1,23 @@
+@ DocumentNode (location: (1:0)-(1:54))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:54))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:8))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "script" (location: (1:1)-(1:7))
+        │       ├── tag_closing: ">" (location: (1:7)-(1:8))
+        │       ├── children: []
+        │       └── is_void: false
+        │
+        ├── tag_name: "script" (location: (1:1)-(1:7))
+        ├── body: (1 item)
+        │   └── @ LiteralNode (location: (1:8)-(1:45))
+        │       └── content: "// <div> should be ignored in comment"
+        │
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:45)-(1:54))
+        │       ├── tag_opening: "</" (location: (1:45)-(1:47))
+        │       ├── tag_name: "script" (location: (1:47)-(1:53))
+        │       └── tag_closing: ">" (location: (1:53)-(1:54))
+        │
+        └── is_void: false

--- a/test/snapshots/parser/script_style_test/test_0005_script_tag_with_multiline_comment_containing_HTML_5c0e9eb44b2e454a0cf0f8d3eb15000a.txt
+++ b/test/snapshots/parser/script_style_test/test_0005_script_tag_with_multiline_comment_containing_HTML_5c0e9eb44b2e454a0cf0f8d3eb15000a.txt
@@ -1,0 +1,26 @@
+@ DocumentNode (location: (1:0)-(8:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(7:9))
+    │   ├── open_tag:
+    │   │   └── @ HTMLOpenTagNode (location: (1:0)-(1:8))
+    │   │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+    │   │       ├── tag_name: "script" (location: (1:1)-(1:7))
+    │   │       ├── tag_closing: ">" (location: (1:7)-(1:8))
+    │   │       ├── children: []
+    │   │       └── is_void: false
+    │   │
+    │   ├── tag_name: "script" (location: (1:1)-(1:7))
+    │   ├── body: (1 item)
+    │   │   └── @ LiteralNode (location: (1:8)-(7:0))
+    │   │       └── content: "\n  /*\n   * <div>This is in a comment</div>\n   * <span>Also ignored</span>\n   */\n  console.log(\"test\");\n"
+    │   │
+    │   ├── close_tag:
+    │   │   └── @ HTMLCloseTagNode (location: (7:0)-(7:9))
+    │   │       ├── tag_opening: "</" (location: (7:0)-(7:2))
+    │   │       ├── tag_name: "script" (location: (7:2)-(7:8))
+    │   │       └── tag_closing: ">" (location: (7:8)-(7:9))
+    │   │
+    │   └── is_void: false
+    │
+    └── @ HTMLTextNode (location: (7:9)-(8:0))
+        └── content: "\n"

--- a/test/snapshots/parser/script_style_test/test_0006_script_tag_with_ERB-like_content_in_string_b1ffbf793264421bcbb1b9d6087f10b2.txt
+++ b/test/snapshots/parser/script_style_test/test_0006_script_tag_with_ERB-like_content_in_string_b1ffbf793264421bcbb1b9d6087f10b2.txt
@@ -1,0 +1,46 @@
+@ DocumentNode (location: (1:0)-(1:35))
+├── errors: (1 error)
+│   └── @ UnclosedElementError (location: (1:35)-(1:35))
+│       ├── message: "Tag `<script>` opened at (1:1) was never closed before the end of document."
+│       └── opening_tag: "script" (location: (1:1)-(1:7))
+│
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:8))
+        ├── errors: (1 error)
+        │   └── @ MissingClosingTagError (location: (1:1)-(1:7))
+        │       ├── message: "Opening tag `<script>` at (1:1) doesn't have a matching closing tag `</script>`."
+        │       └── opening_tag: "script" (location: (1:1)-(1:7))
+        │
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:8))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "script" (location: (1:1)-(1:7))
+        │       ├── tag_closing: ">" (location: (1:7)-(1:8))
+        │       ├── children: []
+        │       └── is_void: false
+        │
+        ├── tag_name: "script" (location: (1:1)-(1:7))
+        ├── body: (2 items)
+        │   ├── @ LiteralNode (location: (1:8)-(1:21))
+        │   │   └── content: "console.log(\""
+        │   │
+        │   └── @ ERBContentNode (location: (1:21)-(1:35))
+        │       ├── errors: (2 errors)
+        │       │   ├── @ UnexpectedTokenError (location: (1:23)-(1:35))
+        │       │   │   ├── message: "Found `TOKEN_ERROR` when expecting `TOKEN_ERB_CONTENT` at (1:23)."
+        │       │   │   ├── expected_type: "TOKEN_ERB_CONTENT"
+        │       │   │   └── found: "");</script>" (location: (1:23)-(1:35))
+        │       │   │
+        │       │   └── @ UnexpectedTokenError (location: (1:35)-(1:35))
+        │       │       ├── message: "Found `TOKEN_EOF` when expecting `TOKEN_ERB_END` at (1:35)."
+        │       │       ├── expected_type: "TOKEN_ERB_END"
+        │       │       └── found: "" (location: (1:35)-(1:35))
+        │       │
+        │       ├── tag_opening: "<%" (location: (1:21)-(1:23))
+        │       ├── content: "");</script>" (location: (1:23)-(1:35))
+        │       ├── tag_closing: "" (location: (1:35)-(1:35))
+        │       ├── parsed: true
+        │       └── valid: false
+        │
+        ├── close_tag: ∅
+        └── is_void: false

--- a/test/snapshots/parser/script_style_test/test_0007_script_tag_with_incomplete_ERB-like_content_c3dcacbbac9dfaafc8298a1e8b6df38b.txt
+++ b/test/snapshots/parser/script_style_test/test_0007_script_tag_with_incomplete_ERB-like_content_c3dcacbbac9dfaafc8298a1e8b6df38b.txt
@@ -1,0 +1,46 @@
+@ DocumentNode (location: (1:0)-(1:47))
+├── errors: (1 error)
+│   └── @ UnclosedElementError (location: (1:47)-(1:47))
+│       ├── message: "Tag `<script>` opened at (1:1) was never closed before the end of document."
+│       └── opening_tag: "script" (location: (1:1)-(1:7))
+│
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:8))
+        ├── errors: (1 error)
+        │   └── @ MissingClosingTagError (location: (1:1)-(1:7))
+        │       ├── message: "Opening tag `<script>` at (1:1) doesn't have a matching closing tag `</script>`."
+        │       └── opening_tag: "script" (location: (1:1)-(1:7))
+        │
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:8))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "script" (location: (1:1)-(1:7))
+        │       ├── tag_closing: ">" (location: (1:7)-(1:8))
+        │       ├── children: []
+        │       └── is_void: false
+        │
+        ├── tag_name: "script" (location: (1:1)-(1:7))
+        ├── body: (2 items)
+        │   ├── @ LiteralNode (location: (1:8)-(1:21))
+        │   │   └── content: "console.log(\""
+        │   │
+        │   └── @ ERBContentNode (location: (1:21)-(1:47))
+        │       ├── errors: (2 errors)
+        │       │   ├── @ UnexpectedTokenError (location: (1:24)-(1:47))
+        │       │   │   ├── message: "Found `TOKEN_ERROR` when expecting `TOKEN_ERB_CONTENT` at (1:24)."
+        │       │   │   ├── expected_type: "TOKEN_ERB_CONTENT"
+        │       │   │   └── found: " incomplete");</script>" (location: (1:24)-(1:47))
+        │       │   │
+        │       │   └── @ UnexpectedTokenError (location: (1:47)-(1:47))
+        │       │       ├── message: "Found `TOKEN_EOF` when expecting `TOKEN_ERB_END` at (1:47)."
+        │       │       ├── expected_type: "TOKEN_ERB_END"
+        │       │       └── found: "" (location: (1:47)-(1:47))
+        │       │
+        │       ├── tag_opening: "<%=" (location: (1:21)-(1:24))
+        │       ├── content: " incomplete");</script>" (location: (1:24)-(1:47))
+        │       ├── tag_closing: "" (location: (1:47)-(1:47))
+        │       ├── parsed: true
+        │       └── valid: false
+        │
+        ├── close_tag: ∅
+        └── is_void: false

--- a/test/snapshots/parser/script_style_test/test_0008_script_tag_with_closing_script_tag_in_string_4d120bcac86583501954aa7c7d1b54f8.txt
+++ b/test/snapshots/parser/script_style_test/test_0008_script_tag_with_closing_script_tag_in_string_4d120bcac86583501954aa7c7d1b54f8.txt
@@ -1,0 +1,36 @@
+@ DocumentNode (location: (1:0)-(1:37))
+└── children: (3 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:26))
+    │   ├── open_tag:
+    │   │   └── @ HTMLOpenTagNode (location: (1:0)-(1:8))
+    │   │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+    │   │       ├── tag_name: "script" (location: (1:1)-(1:7))
+    │   │       ├── tag_closing: ">" (location: (1:7)-(1:8))
+    │   │       ├── children: []
+    │   │       └── is_void: false
+    │   │
+    │   ├── tag_name: "script" (location: (1:1)-(1:7))
+    │   ├── body: (1 item)
+    │   │   └── @ LiteralNode (location: (1:8)-(1:17))
+    │   │       └── content: "var s = \""
+    │   │
+    │   ├── close_tag:
+    │   │   └── @ HTMLCloseTagNode (location: (1:17)-(1:26))
+    │   │       ├── tag_opening: "</" (location: (1:17)-(1:19))
+    │   │       ├── tag_name: "script" (location: (1:19)-(1:25))
+    │   │       └── tag_closing: ">" (location: (1:25)-(1:26))
+    │   │
+    │   └── is_void: false
+    │
+    ├── @ HTMLTextNode (location: (1:26)-(1:28))
+    │   └── content: "\";"
+    │
+    └── @ HTMLCloseTagNode (location: (1:28)-(1:37))
+        ├── errors: (1 error)
+        │   └── @ MissingOpeningTagError (location: (1:28)-(1:37))
+        │       ├── message: "Found closing tag `</script>` at (1:30) without a matching opening tag."
+        │       └── closing_tag: "script" (location: (1:30)-(1:36))
+        │
+        ├── tag_opening: "</" (location: (1:28)-(1:30))
+        ├── tag_name: "script" (location: (1:30)-(1:36))
+        └── tag_closing: ">" (location: (1:36)-(1:37))

--- a/test/snapshots/parser/script_style_test/test_0009_script_tag_with_escaped_closing_tag_in_string_ccf8337d19aea0367aac410fe8cb6b02.txt
+++ b/test/snapshots/parser/script_style_test/test_0009_script_tag_with_escaped_closing_tag_in_string_ccf8337d19aea0367aac410fe8cb6b02.txt
@@ -1,0 +1,23 @@
+@ DocumentNode (location: (1:0)-(1:38))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:38))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:8))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "script" (location: (1:1)-(1:7))
+        │       ├── tag_closing: ">" (location: (1:7)-(1:8))
+        │       ├── children: []
+        │       └── is_void: false
+        │
+        ├── tag_name: "script" (location: (1:1)-(1:7))
+        ├── body: (1 item)
+        │   └── @ LiteralNode (location: (1:8)-(1:29))
+        │       └── content: "var s = \"<\\/script>\";"
+        │
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:29)-(1:38))
+        │       ├── tag_opening: "</" (location: (1:29)-(1:31))
+        │       ├── tag_name: "script" (location: (1:31)-(1:37))
+        │       └── tag_closing: ">" (location: (1:37)-(1:38))
+        │
+        └── is_void: false

--- a/test/snapshots/parser/script_style_test/test_0010_script_tag_with_actual_ERB_interpolation_d091c43ef237db588be6adf2a4f24b61.txt
+++ b/test/snapshots/parser/script_style_test/test_0010_script_tag_with_actual_ERB_interpolation_d091c43ef237db588be6adf2a4f24b61.txt
@@ -1,0 +1,33 @@
+@ DocumentNode (location: (1:0)-(1:46))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:46))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:8))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "script" (location: (1:1)-(1:7))
+        │       ├── tag_closing: ">" (location: (1:7)-(1:8))
+        │       ├── children: []
+        │       └── is_void: false
+        │
+        ├── tag_name: "script" (location: (1:1)-(1:7))
+        ├── body: (3 items)
+        │   ├── @ LiteralNode (location: (1:8)-(1:21))
+        │   │   └── content: "var userId = "
+        │   │
+        │   ├── @ ERBContentNode (location: (1:21)-(1:36))
+        │   │   ├── tag_opening: "<%=" (location: (1:21)-(1:24))
+        │   │   ├── content: " @user.id " (location: (1:24)-(1:34))
+        │   │   ├── tag_closing: "%>" (location: (1:34)-(1:36))
+        │   │   ├── parsed: true
+        │   │   └── valid: true
+        │   │
+        │   └── @ LiteralNode (location: (1:36)-(1:37))
+        │       └── content: ";"
+        │
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:37)-(1:46))
+        │       ├── tag_opening: "</" (location: (1:37)-(1:39))
+        │       ├── tag_name: "script" (location: (1:39)-(1:45))
+        │       └── tag_closing: ">" (location: (1:45)-(1:46))
+        │
+        └── is_void: false

--- a/test/snapshots/parser/script_style_test/test_0011_script_tag_with_multiple_ERB_interpolations_1c032866b0f442a891b17fca46aefe9e.txt
+++ b/test/snapshots/parser/script_style_test/test_0011_script_tag_with_multiple_ERB_interpolations_1c032866b0f442a891b17fca46aefe9e.txt
@@ -1,0 +1,56 @@
+@ DocumentNode (location: (1:0)-(8:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(7:9))
+    │   ├── open_tag:
+    │   │   └── @ HTMLOpenTagNode (location: (1:0)-(1:8))
+    │   │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+    │   │       ├── tag_name: "script" (location: (1:1)-(1:7))
+    │   │       ├── tag_closing: ">" (location: (1:7)-(1:8))
+    │   │       ├── children: []
+    │   │       └── is_void: false
+    │   │
+    │   ├── tag_name: "script" (location: (1:1)-(1:7))
+    │   ├── body: (7 items)
+    │   │   ├── @ LiteralNode (location: (1:8)-(3:12))
+    │   │   │   └── content: "\n  var config = {\n    userId: "
+    │   │   │
+    │   │   ├── @ ERBContentNode (location: (3:12)-(3:27))
+    │   │   │   ├── tag_opening: "<%=" (location: (3:12)-(3:15))
+    │   │   │   ├── content: " @user.id " (location: (3:15)-(3:25))
+    │   │   │   ├── tag_closing: "%>" (location: (3:25)-(3:27))
+    │   │   │   ├── parsed: true
+    │   │   │   └── valid: true
+    │   │   │
+    │   │   ├── @ LiteralNode (location: (3:27)-(4:15))
+    │   │   │   └── content: ",\n    userName: \""
+    │   │   │
+    │   │   ├── @ ERBContentNode (location: (4:15)-(4:32))
+    │   │   │   ├── tag_opening: "<%=" (location: (4:15)-(4:18))
+    │   │   │   ├── content: " @user.name " (location: (4:18)-(4:30))
+    │   │   │   ├── tag_closing: "%>" (location: (4:30)-(4:32))
+    │   │   │   ├── parsed: true
+    │   │   │   └── valid: true
+    │   │   │
+    │   │   ├── @ LiteralNode (location: (4:32)-(5:13))
+    │   │   │   └── content: "\",\n    isAdmin: "
+    │   │   │
+    │   │   ├── @ ERBContentNode (location: (5:13)-(5:32))
+    │   │   │   ├── tag_opening: "<%=" (location: (5:13)-(5:16))
+    │   │   │   ├── content: " @user.admin? " (location: (5:16)-(5:30))
+    │   │   │   ├── tag_closing: "%>" (location: (5:30)-(5:32))
+    │   │   │   ├── parsed: true
+    │   │   │   └── valid: true
+    │   │   │
+    │   │   └── @ LiteralNode (location: (5:32)-(7:0))
+    │   │       └── content: "\n  };\n"
+    │   │
+    │   ├── close_tag:
+    │   │   └── @ HTMLCloseTagNode (location: (7:0)-(7:9))
+    │   │       ├── tag_opening: "</" (location: (7:0)-(7:2))
+    │   │       ├── tag_name: "script" (location: (7:2)-(7:8))
+    │   │       └── tag_closing: ">" (location: (7:8)-(7:9))
+    │   │
+    │   └── is_void: false
+    │
+    └── @ HTMLTextNode (location: (7:9)-(8:0))
+        └── content: "\n"

--- a/test/snapshots/parser/script_style_test/test_0012_script_tag_with_complex_JavaScript_including_comparisons_and_HTML_strings_b1151f65233be7cb601bd69e7e414a79.txt
+++ b/test/snapshots/parser/script_style_test/test_0012_script_tag_with_complex_JavaScript_including_comparisons_and_HTML_strings_b1151f65233be7cb601bd69e7e414a79.txt
@@ -1,0 +1,26 @@
+@ DocumentNode (location: (1:0)-(10:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(9:9))
+    │   ├── open_tag:
+    │   │   └── @ HTMLOpenTagNode (location: (1:0)-(1:8))
+    │   │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+    │   │       ├── tag_name: "script" (location: (1:1)-(1:7))
+    │   │       ├── tag_closing: ">" (location: (1:7)-(1:8))
+    │   │       ├── children: []
+    │   │       └── is_void: false
+    │   │
+    │   ├── tag_name: "script" (location: (1:1)-(1:7))
+    │   ├── body: (1 item)
+    │   │   └── @ LiteralNode (location: (1:8)-(9:0))
+    │   │       └── content: "\n  function test() {\n    if (x < 10 && y > 5) {\n      return \"<div>\" + content + \"</div>\";\n    }\n    // <span>Comment with HTML</span>\n    var template = `<ul>${items.map(i => `<li>${i}</li>`).join('')}</ul>`;\n  }\n"
+    │   │
+    │   ├── close_tag:
+    │   │   └── @ HTMLCloseTagNode (location: (9:0)-(9:9))
+    │   │       ├── tag_opening: "</" (location: (9:0)-(9:2))
+    │   │       ├── tag_name: "script" (location: (9:2)-(9:8))
+    │   │       └── tag_closing: ">" (location: (9:8)-(9:9))
+    │   │
+    │   └── is_void: false
+    │
+    └── @ HTMLTextNode (location: (9:9)-(10:0))
+        └── content: "\n"

--- a/test/snapshots/parser/script_style_test/test_0013_style_tag_with_child_selector_3675980b06d0732a42d3e3d4da50428f.txt
+++ b/test/snapshots/parser/script_style_test/test_0013_style_tag_with_child_selector_3675980b06d0732a42d3e3d4da50428f.txt
@@ -1,0 +1,23 @@
+@ DocumentNode (location: (1:0)-(1:47))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:47))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:7))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "style" (location: (1:1)-(1:6))
+        │       ├── tag_closing: ">" (location: (1:6)-(1:7))
+        │       ├── children: []
+        │       └── is_void: false
+        │
+        ├── tag_name: "style" (location: (1:1)-(1:6))
+        ├── body: (1 item)
+        │   └── @ LiteralNode (location: (1:7)-(1:39))
+        │       └── content: ".parent > .child { color: red; }"
+        │
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:39)-(1:47))
+        │       ├── tag_opening: "</" (location: (1:39)-(1:41))
+        │       ├── tag_name: "style" (location: (1:41)-(1:46))
+        │       └── tag_closing: ">" (location: (1:46)-(1:47))
+        │
+        └── is_void: false

--- a/test/snapshots/parser/script_style_test/test_0014_style_tag_with_attribute_selector_containing_HTML_6024cebc93b5103ba789a52ba13c2f01.txt
+++ b/test/snapshots/parser/script_style_test/test_0014_style_tag_with_attribute_selector_containing_HTML_6024cebc93b5103ba789a52ba13c2f01.txt
@@ -1,0 +1,23 @@
+@ DocumentNode (location: (1:0)-(1:65))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:65))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:7))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "style" (location: (1:1)-(1:6))
+        │       ├── tag_closing: ">" (location: (1:6)-(1:7))
+        │       ├── children: []
+        │       └── is_void: false
+        │
+        ├── tag_name: "style" (location: (1:1)-(1:6))
+        ├── body: (1 item)
+        │   └── @ LiteralNode (location: (1:7)-(1:57))
+        │       └── content: "input[placeholder=\"<enter text>\"] { color: blue; }"
+        │
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:57)-(1:65))
+        │       ├── tag_opening: "</" (location: (1:57)-(1:59))
+        │       ├── tag_name: "style" (location: (1:59)-(1:64))
+        │       └── tag_closing: ">" (location: (1:64)-(1:65))
+        │
+        └── is_void: false

--- a/test/snapshots/parser/script_style_test/test_0015_style_tag_with_content_property_containing_HTML_aa75bbfce10aaa99576a8041bc62e42a.txt
+++ b/test/snapshots/parser/script_style_test/test_0015_style_tag_with_content_property_containing_HTML_aa75bbfce10aaa99576a8041bc62e42a.txt
@@ -1,0 +1,23 @@
+@ DocumentNode (location: (1:0)-(1:59))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:59))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:7))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "style" (location: (1:1)-(1:6))
+        │       ├── tag_closing: ">" (location: (1:6)-(1:7))
+        │       ├── children: []
+        │       └── is_void: false
+        │
+        ├── tag_name: "style" (location: (1:1)-(1:6))
+        ├── body: (1 item)
+        │   └── @ LiteralNode (location: (1:7)-(1:51))
+        │       └── content: ".icon::before { content: \"<span>★</span>\"; }"
+        │
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:51)-(1:59))
+        │       ├── tag_opening: "</" (location: (1:51)-(1:53))
+        │       ├── tag_name: "style" (location: (1:53)-(1:58))
+        │       └── tag_closing: ">" (location: (1:58)-(1:59))
+        │
+        └── is_void: false

--- a/test/snapshots/parser/script_style_test/test_0016_style_tag_with_ERB_interpolation_e7608ec944a2eed2de2082144b6ccbff.txt
+++ b/test/snapshots/parser/script_style_test/test_0016_style_tag_with_ERB_interpolation_e7608ec944a2eed2de2082144b6ccbff.txt
@@ -1,0 +1,43 @@
+@ DocumentNode (location: (1:0)-(1:68))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:68))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:7))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "style" (location: (1:1)-(1:6))
+        │       ├── tag_closing: ">" (location: (1:6)-(1:7))
+        │       ├── children: []
+        │       └── is_void: false
+        │
+        ├── tag_name: "style" (location: (1:1)-(1:6))
+        ├── body: (5 items)
+        │   ├── @ LiteralNode (location: (1:7)-(1:13))
+        │   │   └── content: ".user-"
+        │   │
+        │   ├── @ ERBContentNode (location: (1:13)-(1:28))
+        │   │   ├── tag_opening: "<%=" (location: (1:13)-(1:16))
+        │   │   ├── content: " @user.id " (location: (1:16)-(1:26))
+        │   │   ├── tag_closing: "%>" (location: (1:26)-(1:28))
+        │   │   ├── parsed: true
+        │   │   └── valid: true
+        │   │
+        │   ├── @ LiteralNode (location: (1:28)-(1:38))
+        │   │   └── content: " { color: "
+        │   │
+        │   ├── @ ERBContentNode (location: (1:38)-(1:57))
+        │   │   ├── tag_opening: "<%=" (location: (1:38)-(1:41))
+        │   │   ├── content: " @theme_color " (location: (1:41)-(1:55))
+        │   │   ├── tag_closing: "%>" (location: (1:55)-(1:57))
+        │   │   ├── parsed: true
+        │   │   └── valid: true
+        │   │
+        │   └── @ LiteralNode (location: (1:57)-(1:60))
+        │       └── content: "; }"
+        │
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:60)-(1:68))
+        │       ├── tag_opening: "</" (location: (1:60)-(1:62))
+        │       ├── tag_name: "style" (location: (1:62)-(1:67))
+        │       └── tag_closing: ">" (location: (1:67)-(1:68))
+        │
+        └── is_void: false

--- a/test/snapshots/parser/script_style_test/test_0017_style_tag_with_complex_CSS_including_HTML-like_content_2029b62a2d67c13cdb6a6109966d1952.txt
+++ b/test/snapshots/parser/script_style_test/test_0017_style_tag_with_complex_CSS_including_HTML-like_content_2029b62a2d67c13cdb6a6109966d1952.txt
@@ -1,0 +1,26 @@
+@ DocumentNode (location: (1:0)-(10:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(9:8))
+    │   ├── open_tag:
+    │   │   └── @ HTMLOpenTagNode (location: (1:0)-(1:7))
+    │   │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+    │   │       ├── tag_name: "style" (location: (1:1)-(1:6))
+    │   │       ├── tag_closing: ">" (location: (1:6)-(1:7))
+    │   │       ├── children: []
+    │   │       └── is_void: false
+    │   │
+    │   ├── tag_name: "style" (location: (1:1)-(1:6))
+    │   ├── body: (1 item)
+    │   │   └── @ LiteralNode (location: (1:7)-(9:0))
+    │   │       └── content: "\n  /* <div>Comment with HTML</div> */\n  .tooltip::after {\n    content: \"<div class='arrow'></div>\";\n  }\n  .container > .item:first-child {\n    background: url(\"data:image/svg+xml,<svg><rect/></svg>\");\n  }\n"
+    │   │
+    │   ├── close_tag:
+    │   │   └── @ HTMLCloseTagNode (location: (9:0)-(9:8))
+    │   │       ├── tag_opening: "</" (location: (9:0)-(9:2))
+    │   │       ├── tag_name: "style" (location: (9:2)-(9:7))
+    │   │       └── tag_closing: ">" (location: (9:7)-(9:8))
+    │   │
+    │   └── is_void: false
+    │
+    └── @ HTMLTextNode (location: (9:8)-(10:0))
+        └── content: "\n"

--- a/test/snapshots/parser/script_style_test/test_0018_nested_script_tags_(inner_in_string)_52a2de99ba9b0a7cc84920e0376f62d5.txt
+++ b/test/snapshots/parser/script_style_test/test_0018_nested_script_tags_(inner_in_string)_52a2de99ba9b0a7cc84920e0376f62d5.txt
@@ -1,0 +1,26 @@
+@ DocumentNode (location: (1:0)-(4:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(3:9))
+    │   ├── open_tag:
+    │   │   └── @ HTMLOpenTagNode (location: (1:0)-(1:8))
+    │   │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+    │   │       ├── tag_name: "script" (location: (1:1)-(1:7))
+    │   │       ├── tag_closing: ">" (location: (1:7)-(1:8))
+    │   │       ├── children: []
+    │   │       └── is_void: false
+    │   │
+    │   ├── tag_name: "script" (location: (1:1)-(1:7))
+    │   ├── body: (1 item)
+    │   │   └── @ LiteralNode (location: (1:8)-(3:0))
+    │   │       └── content: "\n  document.write('<script src=\"other.js\"><' + '/script>');\n"
+    │   │
+    │   ├── close_tag:
+    │   │   └── @ HTMLCloseTagNode (location: (3:0)-(3:9))
+    │   │       ├── tag_opening: "</" (location: (3:0)-(3:2))
+    │   │       ├── tag_name: "script" (location: (3:2)-(3:8))
+    │   │       └── tag_closing: ">" (location: (3:8)-(3:9))
+    │   │
+    │   └── is_void: false
+    │
+    └── @ HTMLTextNode (location: (3:9)-(4:0))
+        └── content: "\n"

--- a/test/snapshots/parser/script_style_test/test_0019_script_tag_with_regex_containing_angle_brackets_76ffe5ab074bc06a6215d144ba302d68.txt
+++ b/test/snapshots/parser/script_style_test/test_0019_script_tag_with_regex_containing_angle_brackets_76ffe5ab074bc06a6215d144ba302d68.txt
@@ -1,0 +1,23 @@
+@ DocumentNode (location: (1:0)-(1:40))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:40))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:8))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "script" (location: (1:1)-(1:7))
+        │       ├── tag_closing: ">" (location: (1:7)-(1:8))
+        │       ├── children: []
+        │       └── is_void: false
+        │
+        ├── tag_name: "script" (location: (1:1)-(1:7))
+        ├── body: (1 item)
+        │   └── @ LiteralNode (location: (1:8)-(1:31))
+        │       └── content: "var regex = /<[^>]+>/g;"
+        │
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:31)-(1:40))
+        │       ├── tag_opening: "</" (location: (1:31)-(1:33))
+        │       ├── tag_name: "script" (location: (1:33)-(1:39))
+        │       └── tag_closing: ">" (location: (1:39)-(1:40))
+        │
+        └── is_void: false

--- a/test/snapshots/parser/script_style_test/test_0020_style_tag_with_media_query_and_nested_selectors_85e3c3a8a155fa6bba717f6f71bd20d9.txt
+++ b/test/snapshots/parser/script_style_test/test_0020_style_tag_with_media_query_and_nested_selectors_85e3c3a8a155fa6bba717f6f71bd20d9.txt
@@ -1,0 +1,26 @@
+@ DocumentNode (location: (1:0)-(8:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(7:8))
+    │   ├── open_tag:
+    │   │   └── @ HTMLOpenTagNode (location: (1:0)-(1:7))
+    │   │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+    │   │       ├── tag_name: "style" (location: (1:1)-(1:6))
+    │   │       ├── tag_closing: ">" (location: (1:6)-(1:7))
+    │   │       ├── children: []
+    │   │       └── is_void: false
+    │   │
+    │   ├── tag_name: "style" (location: (1:1)-(1:6))
+    │   ├── body: (1 item)
+    │   │   └── @ LiteralNode (location: (1:7)-(7:0))
+    │   │       └── content: "\n  @media (max-width: 768px) {\n    .nav > ul > li {\n      display: block;\n    }\n  }\n"
+    │   │
+    │   ├── close_tag:
+    │   │   └── @ HTMLCloseTagNode (location: (7:0)-(7:8))
+    │   │       ├── tag_opening: "</" (location: (7:0)-(7:2))
+    │   │       ├── tag_name: "style" (location: (7:2)-(7:7))
+    │   │       └── tag_closing: ">" (location: (7:7)-(7:8))
+    │   │
+    │   └── is_void: false
+    │
+    └── @ HTMLTextNode (location: (7:8)-(8:0))
+        └── content: "\n"

--- a/test/snapshots/parser/script_style_test/test_0021_script_tag_with_template_literals_containing_HTML_c96ddb0da7bec2ac0fb9f59040acf0b9.txt
+++ b/test/snapshots/parser/script_style_test/test_0021_script_tag_with_template_literals_containing_HTML_c96ddb0da7bec2ac0fb9f59040acf0b9.txt
@@ -1,0 +1,26 @@
+@ DocumentNode (location: (1:0)-(9:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(8:9))
+    │   ├── open_tag:
+    │   │   └── @ HTMLOpenTagNode (location: (1:0)-(1:8))
+    │   │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+    │   │       ├── tag_name: "script" (location: (1:1)-(1:7))
+    │   │       ├── tag_closing: ">" (location: (1:7)-(1:8))
+    │   │       ├── children: []
+    │   │       └── is_void: false
+    │   │
+    │   ├── tag_name: "script" (location: (1:1)-(1:7))
+    │   ├── body: (1 item)
+    │   │   └── @ LiteralNode (location: (1:8)-(8:0))
+    │   │       └── content: "\n  const template = `\n    <div class=\"container\">\n      <h1>${title}</h1>\n      <p>${content}</p>\n    </div>\n  `;\n"
+    │   │
+    │   ├── close_tag:
+    │   │   └── @ HTMLCloseTagNode (location: (8:0)-(8:9))
+    │   │       ├── tag_opening: "</" (location: (8:0)-(8:2))
+    │   │       ├── tag_name: "script" (location: (8:2)-(8:8))
+    │   │       └── tag_closing: ">" (location: (8:8)-(8:9))
+    │   │
+    │   └── is_void: false
+    │
+    └── @ HTMLTextNode (location: (8:9)-(9:0))
+        └── content: "\n"

--- a/test/snapshots/parser/script_style_test/test_0022_script_tag_with_JSX-like_syntax_2dbf7fd3cfd4a7582954347fc9098b10.txt
+++ b/test/snapshots/parser/script_style_test/test_0022_script_tag_with_JSX-like_syntax_2dbf7fd3cfd4a7582954347fc9098b10.txt
@@ -1,0 +1,26 @@
+@ DocumentNode (location: (1:0)-(8:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(7:9))
+    │   ├── open_tag:
+    │   │   └── @ HTMLOpenTagNode (location: (1:0)-(1:8))
+    │   │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+    │   │       ├── tag_name: "script" (location: (1:1)-(1:7))
+    │   │       ├── tag_closing: ">" (location: (1:7)-(1:8))
+    │   │       ├── children: []
+    │   │       └── is_void: false
+    │   │
+    │   ├── tag_name: "script" (location: (1:1)-(1:7))
+    │   ├── body: (1 item)
+    │   │   └── @ LiteralNode (location: (1:8)-(7:0))
+    │   │       └── content: "\n  const element = (\n    <div className=\"greeting\">\n      <h1>Hello, {name}!</h1>\n    </div>\n  );\n"
+    │   │
+    │   ├── close_tag:
+    │   │   └── @ HTMLCloseTagNode (location: (7:0)-(7:9))
+    │   │       ├── tag_opening: "</" (location: (7:0)-(7:2))
+    │   │       ├── tag_name: "script" (location: (7:2)-(7:8))
+    │   │       └── tag_closing: ">" (location: (7:8)-(7:9))
+    │   │
+    │   └── is_void: false
+    │
+    └── @ HTMLTextNode (location: (7:9)-(8:0))
+        └── content: "\n"

--- a/test/snapshots/parser/script_style_test/test_0023_empty_script_and_style_tags_90e333bda009d6740ab8a936de1f6121.txt
+++ b/test/snapshots/parser/script_style_test/test_0023_empty_script_and_style_tags_90e333bda009d6740ab8a936de1f6121.txt
@@ -1,0 +1,39 @@
+@ DocumentNode (location: (1:0)-(1:32))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:17))
+    │   ├── open_tag:
+    │   │   └── @ HTMLOpenTagNode (location: (1:0)-(1:8))
+    │   │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+    │   │       ├── tag_name: "script" (location: (1:1)-(1:7))
+    │   │       ├── tag_closing: ">" (location: (1:7)-(1:8))
+    │   │       ├── children: []
+    │   │       └── is_void: false
+    │   │
+    │   ├── tag_name: "script" (location: (1:1)-(1:7))
+    │   ├── body: []
+    │   ├── close_tag:
+    │   │   └── @ HTMLCloseTagNode (location: (1:8)-(1:17))
+    │   │       ├── tag_opening: "</" (location: (1:8)-(1:10))
+    │   │       ├── tag_name: "script" (location: (1:10)-(1:16))
+    │   │       └── tag_closing: ">" (location: (1:16)-(1:17))
+    │   │
+    │   └── is_void: false
+    │
+    └── @ HTMLElementNode (location: (1:17)-(1:32))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:17)-(1:24))
+        │       ├── tag_opening: "<" (location: (1:17)-(1:18))
+        │       ├── tag_name: "style" (location: (1:18)-(1:23))
+        │       ├── tag_closing: ">" (location: (1:23)-(1:24))
+        │       ├── children: []
+        │       └── is_void: false
+        │
+        ├── tag_name: "style" (location: (1:18)-(1:23))
+        ├── body: []
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:24)-(1:32))
+        │       ├── tag_opening: "</" (location: (1:24)-(1:26))
+        │       ├── tag_name: "style" (location: (1:26)-(1:31))
+        │       └── tag_closing: ">" (location: (1:31)-(1:32))
+        │
+        └── is_void: false

--- a/test/snapshots/parser/script_style_test/test_0024_script_tag_followed_by_style_tag_with_complex_content_d81018eb4e7c7c6fc05c8b35a8cfd494.txt
+++ b/test/snapshots/parser/script_style_test/test_0024_script_tag_followed_by_style_tag_with_complex_content_d81018eb4e7c7c6fc05c8b35a8cfd494.txt
@@ -1,0 +1,51 @@
+@ DocumentNode (location: (1:0)-(11:0))
+└── children: (4 items)
+    ├── @ HTMLElementNode (location: (1:0)-(5:9))
+    │   ├── open_tag:
+    │   │   └── @ HTMLOpenTagNode (location: (1:0)-(1:8))
+    │   │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+    │   │       ├── tag_name: "script" (location: (1:1)-(1:7))
+    │   │       ├── tag_closing: ">" (location: (1:7)-(1:8))
+    │   │       ├── children: []
+    │   │       └── is_void: false
+    │   │
+    │   ├── tag_name: "script" (location: (1:1)-(1:7))
+    │   ├── body: (1 item)
+    │   │   └── @ LiteralNode (location: (1:8)-(5:0))
+    │   │       └── content: "\n  if (window.width < 768) {\n    document.body.className = \"mobile\";\n  }\n"
+    │   │
+    │   ├── close_tag:
+    │   │   └── @ HTMLCloseTagNode (location: (5:0)-(5:9))
+    │   │       ├── tag_opening: "</" (location: (5:0)-(5:2))
+    │   │       ├── tag_name: "script" (location: (5:2)-(5:8))
+    │   │       └── tag_closing: ">" (location: (5:8)-(5:9))
+    │   │
+    │   └── is_void: false
+    │
+    ├── @ HTMLTextNode (location: (5:9)-(6:0))
+    │   └── content: "\n"
+    │
+    ├── @ HTMLElementNode (location: (6:0)-(10:8))
+    │   ├── open_tag:
+    │   │   └── @ HTMLOpenTagNode (location: (6:0)-(6:7))
+    │   │       ├── tag_opening: "<" (location: (6:0)-(6:1))
+    │   │       ├── tag_name: "style" (location: (6:1)-(6:6))
+    │   │       ├── tag_closing: ">" (location: (6:6)-(6:7))
+    │   │       ├── children: []
+    │   │       └── is_void: false
+    │   │
+    │   ├── tag_name: "style" (location: (6:1)-(6:6))
+    │   ├── body: (1 item)
+    │   │   └── @ LiteralNode (location: (6:7)-(10:0))
+    │   │       └── content: "\n  .mobile > .header {\n    font-size: 14px;\n  }\n"
+    │   │
+    │   ├── close_tag:
+    │   │   └── @ HTMLCloseTagNode (location: (10:0)-(10:8))
+    │   │       ├── tag_opening: "</" (location: (10:0)-(10:2))
+    │   │       ├── tag_name: "style" (location: (10:2)-(10:7))
+    │   │       └── tag_closing: ">" (location: (10:7)-(10:8))
+    │   │
+    │   └── is_void: false
+    │
+    └── @ HTMLTextNode (location: (10:8)-(11:0))
+        └── content: "\n"

--- a/test/snapshots/parser/script_style_test/test_0025_script_tag_with_minified_JavaScript_containing_many_angle_brackets_d4a0cc7e0c3d0525fa86d830732dd9c6.txt
+++ b/test/snapshots/parser/script_style_test/test_0025_script_tag_with_minified_JavaScript_containing_many_angle_brackets_d4a0cc7e0c3d0525fa86d830732dd9c6.txt
@@ -1,0 +1,23 @@
+@ DocumentNode (location: (1:0)-(1:115))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:115))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:8))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "script" (location: (1:1)-(1:7))
+        │       ├── tag_closing: ">" (location: (1:7)-(1:8))
+        │       ├── children: []
+        │       └── is_void: false
+        │
+        ├── tag_name: "script" (location: (1:1)-(1:7))
+        ├── body: (1 item)
+        │   └── @ LiteralNode (location: (1:8)-(1:106))
+        │       └── content: "!function(){for(var i=0;i<10;i++)if(arr[i]>5&&arr[i]<15)console.log(\"<item>\"+arr[i]+\"</item>\")}();"
+        │
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:106)-(1:115))
+        │       ├── tag_opening: "</" (location: (1:106)-(1:108))
+        │       ├── tag_name: "script" (location: (1:108)-(1:114))
+        │       └── tag_closing: ">" (location: (1:114)-(1:115))
+        │
+        └── is_void: false

--- a/test/snapshots/parser/script_style_test/test_0026_script_tag_with_JSON_containing_HTML_2696010b25079cee665dad541e6a3c9f.txt
+++ b/test/snapshots/parser/script_style_test/test_0026_script_tag_with_JSON_containing_HTML_2696010b25079cee665dad541e6a3c9f.txt
@@ -1,0 +1,26 @@
+@ DocumentNode (location: (1:0)-(7:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(6:9))
+    │   ├── open_tag:
+    │   │   └── @ HTMLOpenTagNode (location: (1:0)-(1:8))
+    │   │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+    │   │       ├── tag_name: "script" (location: (1:1)-(1:7))
+    │   │       ├── tag_closing: ">" (location: (1:7)-(1:8))
+    │   │       ├── children: []
+    │   │       └── is_void: false
+    │   │
+    │   ├── tag_name: "script" (location: (1:1)-(1:7))
+    │   ├── body: (1 item)
+    │   │   └── @ LiteralNode (location: (1:8)-(6:0))
+    │   │       └── content: "\n  var data = {\n    \"template\": \"<div class='widget'>{{content}}</div>\",\n    \"items\": [\"<span>A</span>\", \"<span>B</span>\"]\n  };\n"
+    │   │
+    │   ├── close_tag:
+    │   │   └── @ HTMLCloseTagNode (location: (6:0)-(6:9))
+    │   │       ├── tag_opening: "</" (location: (6:0)-(6:2))
+    │   │       ├── tag_name: "script" (location: (6:2)-(6:8))
+    │   │       └── tag_closing: ">" (location: (6:8)-(6:9))
+    │   │
+    │   └── is_void: false
+    │
+    └── @ HTMLTextNode (location: (6:9)-(7:0))
+        └── content: "\n"

--- a/test/snapshots/parser/script_style_test/test_0027_style_tag_with_CSS_custom_properties_and_calc_5b9a8e819022c7cd704610880a30afd3.txt
+++ b/test/snapshots/parser/script_style_test/test_0027_style_tag_with_CSS_custom_properties_and_calc_5b9a8e819022c7cd704610880a30afd3.txt
@@ -1,0 +1,26 @@
+@ DocumentNode (location: (1:0)-(10:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(9:8))
+    │   ├── open_tag:
+    │   │   └── @ HTMLOpenTagNode (location: (1:0)-(1:7))
+    │   │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+    │   │       ├── tag_name: "style" (location: (1:1)-(1:6))
+    │   │       ├── tag_closing: ">" (location: (1:6)-(1:7))
+    │   │       ├── children: []
+    │   │       └── is_void: false
+    │   │
+    │   ├── tag_name: "style" (location: (1:1)-(1:6))
+    │   ├── body: (1 item)
+    │   │   └── @ LiteralNode (location: (1:7)-(9:0))
+    │   │       └── content: "\n  :root {\n    --arrow: \"<\";\n    --content: \">\";\n  }\n  .element {\n    width: calc(100% - 20px);\n  }\n"
+    │   │
+    │   ├── close_tag:
+    │   │   └── @ HTMLCloseTagNode (location: (9:0)-(9:8))
+    │   │       ├── tag_opening: "</" (location: (9:0)-(9:2))
+    │   │       ├── tag_name: "style" (location: (9:2)-(9:7))
+    │   │       └── tag_closing: ">" (location: (9:7)-(9:8))
+    │   │
+    │   └── is_void: false
+    │
+    └── @ HTMLTextNode (location: (9:8)-(10:0))
+        └── content: "\n"

--- a/test/snapshots/parser/script_style_test/test_0028_script_tag_with_incomplete_ERB_tag_at_end_1ccec9a4a170634bddb31f9c22d0fbc5.txt
+++ b/test/snapshots/parser/script_style_test/test_0028_script_tag_with_incomplete_ERB_tag_at_end_1ccec9a4a170634bddb31f9c22d0fbc5.txt
@@ -1,0 +1,46 @@
+@ DocumentNode (location: (1:0)-(1:40))
+├── errors: (1 error)
+│   └── @ UnclosedElementError (location: (1:40)-(1:40))
+│       ├── message: "Tag `<script>` opened at (1:1) was never closed before the end of document."
+│       └── opening_tag: "script" (location: (1:1)-(1:7))
+│
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:8))
+        ├── errors: (1 error)
+        │   └── @ MissingClosingTagError (location: (1:1)-(1:7))
+        │       ├── message: "Opening tag `<script>` at (1:1) doesn't have a matching closing tag `</script>`."
+        │       └── opening_tag: "script" (location: (1:1)-(1:7))
+        │
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:8))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "script" (location: (1:1)-(1:7))
+        │       ├── tag_closing: ">" (location: (1:7)-(1:8))
+        │       ├── children: []
+        │       └── is_void: false
+        │
+        ├── tag_name: "script" (location: (1:1)-(1:7))
+        ├── body: (2 items)
+        │   ├── @ LiteralNode (location: (1:8)-(1:29))
+        │   │   └── content: "console.log(\"test\"); "
+        │   │
+        │   └── @ ERBContentNode (location: (1:29)-(1:40))
+        │       ├── errors: (2 errors)
+        │       │   ├── @ UnexpectedTokenError (location: (1:31)-(1:40))
+        │       │   │   ├── message: "Found `TOKEN_ERROR` when expecting `TOKEN_ERB_CONTENT` at (1:31)."
+        │       │   │   ├── expected_type: "TOKEN_ERB_CONTENT"
+        │       │   │   └── found: "</script>" (location: (1:31)-(1:40))
+        │       │   │
+        │       │   └── @ UnexpectedTokenError (location: (1:40)-(1:40))
+        │       │       ├── message: "Found `TOKEN_EOF` when expecting `TOKEN_ERB_END` at (1:40)."
+        │       │       ├── expected_type: "TOKEN_ERB_END"
+        │       │       └── found: "" (location: (1:40)-(1:40))
+        │       │
+        │       ├── tag_opening: "<%" (location: (1:29)-(1:31))
+        │       ├── content: "</script>" (location: (1:31)-(1:40))
+        │       ├── tag_closing: "" (location: (1:40)-(1:40))
+        │       ├── parsed: true
+        │       └── valid: false
+        │
+        ├── close_tag: ∅
+        └── is_void: false

--- a/test/snapshots/parser/script_style_test/test_0029_script_tag_with_only_ERB-like_characters_adba6c52b9f376024caae0fb1a7c3804.txt
+++ b/test/snapshots/parser/script_style_test/test_0029_script_tag_with_only_ERB-like_characters_adba6c52b9f376024caae0fb1a7c3804.txt
@@ -1,0 +1,33 @@
+@ DocumentNode (location: (1:0)-(1:44))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:44))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:8))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "script" (location: (1:1)-(1:7))
+        │       ├── tag_closing: ">" (location: (1:7)-(1:8))
+        │       ├── children: []
+        │       └── is_void: false
+        │
+        ├── tag_name: "script" (location: (1:1)-(1:7))
+        ├── body: (3 items)
+        │   ├── @ LiteralNode (location: (1:8)-(1:17))
+        │   │   └── content: "var s = \""
+        │   │
+        │   ├── @ ERBContentNode (location: (1:17)-(1:33))
+        │   │   ├── tag_opening: "<%" (location: (1:17)-(1:19))
+        │   │   ├── content: ""; var e = "" (location: (1:19)-(1:31))
+        │   │   ├── tag_closing: "%>" (location: (1:31)-(1:33))
+        │   │   ├── parsed: true
+        │   │   └── valid: true
+        │   │
+        │   └── @ LiteralNode (location: (1:33)-(1:35))
+        │       └── content: "\";"
+        │
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:35)-(1:44))
+        │       ├── tag_opening: "</" (location: (1:35)-(1:37))
+        │       ├── tag_name: "script" (location: (1:37)-(1:43))
+        │       └── tag_closing: ">" (location: (1:43)-(1:44))
+        │
+        └── is_void: false

--- a/test/snapshots/parser/script_style_test/test_0030_real_world_example_-_Google_Analytics_bbdcf8626f2d4ba86e193cf8a0898cd4.txt
+++ b/test/snapshots/parser/script_style_test/test_0030_real_world_example_-_Google_Analytics_bbdcf8626f2d4ba86e193cf8a0898cd4.txt
@@ -1,0 +1,26 @@
+@ DocumentNode (location: (1:0)-(7:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(6:9))
+    │   ├── open_tag:
+    │   │   └── @ HTMLOpenTagNode (location: (1:0)-(1:8))
+    │   │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+    │   │       ├── tag_name: "script" (location: (1:1)-(1:7))
+    │   │       ├── tag_closing: ">" (location: (1:7)-(1:8))
+    │   │       ├── children: []
+    │   │       └── is_void: false
+    │   │
+    │   ├── tag_name: "script" (location: (1:1)-(1:7))
+    │   ├── body: (1 item)
+    │   │   └── @ LiteralNode (location: (1:8)-(6:0))
+    │   │       └── content: "\n  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){\n  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),\n  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)\n  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');\n"
+    │   │
+    │   ├── close_tag:
+    │   │   └── @ HTMLCloseTagNode (location: (6:0)-(6:9))
+    │   │       ├── tag_opening: "</" (location: (6:0)-(6:2))
+    │   │       ├── tag_name: "script" (location: (6:2)-(6:8))
+    │   │       └── tag_closing: ">" (location: (6:8)-(6:9))
+    │   │
+    │   └── is_void: false
+    │
+    └── @ HTMLTextNode (location: (6:9)-(7:0))
+        └── content: "\n"

--- a/test/snapshots/parser/script_style_test/test_0031_real_world_example_-_Klaviyo_script_from_issue_271_a44d9ed4b4dc95089740ac1df66eb9af.txt
+++ b/test/snapshots/parser/script_style_test/test_0031_real_world_example_-_Klaviyo_script_from_issue_271_a44d9ed4b4dc95089740ac1df66eb9af.txt
@@ -1,0 +1,26 @@
+@ DocumentNode (location: (1:0)-(5:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(4:9))
+    │   ├── open_tag:
+    │   │   └── @ HTMLOpenTagNode (location: (1:0)-(1:8))
+    │   │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+    │   │       ├── tag_name: "script" (location: (1:1)-(1:7))
+    │   │       ├── tag_closing: ">" (location: (1:7)-(1:8))
+    │   │       ├── children: []
+    │   │       └── is_void: false
+    │   │
+    │   ├── tag_name: "script" (location: (1:1)-(1:7))
+    │   ├── body: (1 item)
+    │   │   └── @ LiteralNode (location: (1:8)-(4:0))
+    │   │       └── content: "\n  // prettier-ignore\n  !function(){if(!window.klaviyo){window._klOnsite=window._klOnsite||[];try{window.klaviyo=new Proxy({},{get:function(n,i){return\"push\"===i?function(){var n;(n=window._klOnsite).push.apply(n,arguments)}:function(){for(var n=arguments.length,o=new Array(n),w=0;w<n;w++)o[w]=arguments[w];var t=\"function\"==typeof o[o.length-1]?o.pop():void 0,e=new Promise((function(n){window._klOnsite.push([i].concat(o,[function(i){t&&t(i),n(i)}]))}));return e}}})}catch(n){window.klaviyo=window.klaviyo||[],window.klaviyo.push=function(){var n;(n=window._klOnsite).push.apply(n,arguments)}}}}();\n"
+    │   │
+    │   ├── close_tag:
+    │   │   └── @ HTMLCloseTagNode (location: (4:0)-(4:9))
+    │   │       ├── tag_opening: "</" (location: (4:0)-(4:2))
+    │   │       ├── tag_name: "script" (location: (4:2)-(4:8))
+    │   │       └── tag_closing: ">" (location: (4:8)-(4:9))
+    │   │
+    │   └── is_void: false
+    │
+    └── @ HTMLTextNode (location: (4:9)-(5:0))
+        └── content: "\n"

--- a/test/snapshots/parser/script_style_test/test_0032_script_tag_with_single_quote_strings_containing_closing_tags_ffab60cb04f4e44e1ee7ed24d4ac9563.txt
+++ b/test/snapshots/parser/script_style_test/test_0032_script_tag_with_single_quote_strings_containing_closing_tags_ffab60cb04f4e44e1ee7ed24d4ac9563.txt
@@ -1,0 +1,49 @@
+@ DocumentNode (location: (1:0)-(1:59))
+└── children: (5 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:27))
+    │   ├── open_tag:
+    │   │   └── @ HTMLOpenTagNode (location: (1:0)-(1:8))
+    │   │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+    │   │       ├── tag_name: "script" (location: (1:1)-(1:7))
+    │   │       ├── tag_closing: ">" (location: (1:7)-(1:8))
+    │   │       ├── children: []
+    │   │       └── is_void: false
+    │   │
+    │   ├── tag_name: "script" (location: (1:1)-(1:7))
+    │   ├── body: (1 item)
+    │   │   └── @ LiteralNode (location: (1:8)-(1:18))
+    │   │       └── content: "var s1 = '"
+    │   │
+    │   ├── close_tag:
+    │   │   └── @ HTMLCloseTagNode (location: (1:18)-(1:27))
+    │   │       ├── tag_opening: "</" (location: (1:18)-(1:20))
+    │   │       ├── tag_name: "script" (location: (1:20)-(1:26))
+    │   │       └── tag_closing: ">" (location: (1:26)-(1:27))
+    │   │
+    │   └── is_void: false
+    │
+    ├── @ HTMLTextNode (location: (1:27)-(1:40))
+    │   └── content: "'; var s2 = '"
+    │
+    ├── @ HTMLCloseTagNode (location: (1:40)-(1:48))
+    │   ├── errors: (1 error)
+    │   │   └── @ MissingOpeningTagError (location: (1:40)-(1:48))
+    │   │       ├── message: "Found closing tag `</style>` at (1:42) without a matching opening tag."
+    │   │       └── closing_tag: "style" (location: (1:42)-(1:47))
+    │   │
+    │   ├── tag_opening: "</" (location: (1:40)-(1:42))
+    │   ├── tag_name: "style" (location: (1:42)-(1:47))
+    │   └── tag_closing: ">" (location: (1:47)-(1:48))
+    │
+    ├── @ HTMLTextNode (location: (1:48)-(1:50))
+    │   └── content: "';"
+    │
+    └── @ HTMLCloseTagNode (location: (1:50)-(1:59))
+        ├── errors: (1 error)
+        │   └── @ MissingOpeningTagError (location: (1:50)-(1:59))
+        │       ├── message: "Found closing tag `</script>` at (1:52) without a matching opening tag."
+        │       └── closing_tag: "script" (location: (1:52)-(1:58))
+        │
+        ├── tag_opening: "</" (location: (1:50)-(1:52))
+        ├── tag_name: "script" (location: (1:52)-(1:58))
+        └── tag_closing: ">" (location: (1:58)-(1:59))

--- a/test/snapshots/parser/script_style_test/test_0033_script_tag_with_double_quote_strings_containing_closing_tags_34e16086c329d845a1defbf80502a3a7.txt
+++ b/test/snapshots/parser/script_style_test/test_0033_script_tag_with_double_quote_strings_containing_closing_tags_34e16086c329d845a1defbf80502a3a7.txt
@@ -1,0 +1,49 @@
+@ DocumentNode (location: (1:0)-(1:59))
+└── children: (5 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:27))
+    │   ├── open_tag:
+    │   │   └── @ HTMLOpenTagNode (location: (1:0)-(1:8))
+    │   │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+    │   │       ├── tag_name: "script" (location: (1:1)-(1:7))
+    │   │       ├── tag_closing: ">" (location: (1:7)-(1:8))
+    │   │       ├── children: []
+    │   │       └── is_void: false
+    │   │
+    │   ├── tag_name: "script" (location: (1:1)-(1:7))
+    │   ├── body: (1 item)
+    │   │   └── @ LiteralNode (location: (1:8)-(1:18))
+    │   │       └── content: "var s1 = \""
+    │   │
+    │   ├── close_tag:
+    │   │   └── @ HTMLCloseTagNode (location: (1:18)-(1:27))
+    │   │       ├── tag_opening: "</" (location: (1:18)-(1:20))
+    │   │       ├── tag_name: "script" (location: (1:20)-(1:26))
+    │   │       └── tag_closing: ">" (location: (1:26)-(1:27))
+    │   │
+    │   └── is_void: false
+    │
+    ├── @ HTMLTextNode (location: (1:27)-(1:40))
+    │   └── content: "\"; var s2 = \""
+    │
+    ├── @ HTMLCloseTagNode (location: (1:40)-(1:48))
+    │   ├── errors: (1 error)
+    │   │   └── @ MissingOpeningTagError (location: (1:40)-(1:48))
+    │   │       ├── message: "Found closing tag `</style>` at (1:42) without a matching opening tag."
+    │   │       └── closing_tag: "style" (location: (1:42)-(1:47))
+    │   │
+    │   ├── tag_opening: "</" (location: (1:40)-(1:42))
+    │   ├── tag_name: "style" (location: (1:42)-(1:47))
+    │   └── tag_closing: ">" (location: (1:47)-(1:48))
+    │
+    ├── @ HTMLTextNode (location: (1:48)-(1:50))
+    │   └── content: "\";"
+    │
+    └── @ HTMLCloseTagNode (location: (1:50)-(1:59))
+        ├── errors: (1 error)
+        │   └── @ MissingOpeningTagError (location: (1:50)-(1:59))
+        │       ├── message: "Found closing tag `</script>` at (1:52) without a matching opening tag."
+        │       └── closing_tag: "script" (location: (1:52)-(1:58))
+        │
+        ├── tag_opening: "</" (location: (1:50)-(1:52))
+        ├── tag_name: "script" (location: (1:52)-(1:58))
+        └── tag_closing: ">" (location: (1:58)-(1:59))

--- a/test/snapshots/parser/script_style_test/test_0034_script_tag_with_template_literals_containing_closing_tags_6bcbe820b5902dfe97a869593621bebf.txt
+++ b/test/snapshots/parser/script_style_test/test_0034_script_tag_with_template_literals_containing_closing_tags_6bcbe820b5902dfe97a869593621bebf.txt
@@ -1,0 +1,43 @@
+@ DocumentNode (location: (1:0)-(1:44))
+├── errors: (1 error)
+│   └── @ UnexpectedError (location: (1:33)-(1:34))
+│       ├── message: "Unexpected token. Expected: `TOKEN_ERB_START, TOKEN_HTML_DOCTYPE, TOKEN_HTML_COMMENT_START, TOKEN_IDENTIFIER, TOKEN_WHITESPACE, TOKEN_NBSP, TOKEN_AT, or TOKE`, found: `TOKEN_BACKTICK`."
+│       ├── description: "Unexpected token"
+│       ├── expected: "TOKEN_ERB_START, TOKEN_HTML_DOCTYPE, TOKEN_HTML_COMMENT_START, TOKEN_IDENTIFIER, TOKEN_WHITESPACE, TOKEN_NBSP, TOKEN_AT, or TOKEN_NEWLINE"
+│       └── found: "TOKEN_BACKTICK"
+│
+└── children: (3 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:33))
+    │   ├── open_tag:
+    │   │   └── @ HTMLOpenTagNode (location: (1:0)-(1:8))
+    │   │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+    │   │       ├── tag_name: "script" (location: (1:1)-(1:7))
+    │   │       ├── tag_closing: ">" (location: (1:7)-(1:8))
+    │   │       ├── children: []
+    │   │       └── is_void: false
+    │   │
+    │   ├── tag_name: "script" (location: (1:1)-(1:7))
+    │   ├── body: (1 item)
+    │   │   └── @ LiteralNode (location: (1:8)-(1:24))
+    │   │       └── content: "var template = `"
+    │   │
+    │   ├── close_tag:
+    │   │   └── @ HTMLCloseTagNode (location: (1:24)-(1:33))
+    │   │       ├── tag_opening: "</" (location: (1:24)-(1:26))
+    │   │       ├── tag_name: "script" (location: (1:26)-(1:32))
+    │   │       └── tag_closing: ">" (location: (1:32)-(1:33))
+    │   │
+    │   └── is_void: false
+    │
+    ├── @ HTMLTextNode (location: (1:34)-(1:35))
+    │   └── content: ";"
+    │
+    └── @ HTMLCloseTagNode (location: (1:35)-(1:44))
+        ├── errors: (1 error)
+        │   └── @ MissingOpeningTagError (location: (1:35)-(1:44))
+        │       ├── message: "Found closing tag `</script>` at (1:37) without a matching opening tag."
+        │       └── closing_tag: "script" (location: (1:37)-(1:43))
+        │
+        ├── tag_opening: "</" (location: (1:35)-(1:37))
+        ├── tag_name: "script" (location: (1:37)-(1:43))
+        └── tag_closing: ">" (location: (1:43)-(1:44))

--- a/test/snapshots/parser/script_style_test/test_0035_script_tag_with_escaped_quotes_in_strings_3217a5ed01ac8ce6c44f9e106f9b4017.txt
+++ b/test/snapshots/parser/script_style_test/test_0035_script_tag_with_escaped_quotes_in_strings_3217a5ed01ac8ce6c44f9e106f9b4017.txt
@@ -1,0 +1,36 @@
+@ DocumentNode (location: (1:0)-(1:59))
+└── children: (3 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:36))
+    │   ├── open_tag:
+    │   │   └── @ HTMLOpenTagNode (location: (1:0)-(1:8))
+    │   │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+    │   │       ├── tag_name: "script" (location: (1:1)-(1:7))
+    │   │       ├── tag_closing: ">" (location: (1:7)-(1:8))
+    │   │       ├── children: []
+    │   │       └── is_void: false
+    │   │
+    │   ├── tag_name: "script" (location: (1:1)-(1:7))
+    │   ├── body: (1 item)
+    │   │   └── @ LiteralNode (location: (1:8)-(1:27))
+    │   │       └── content: "var s = \"He said \\\""
+    │   │
+    │   ├── close_tag:
+    │   │   └── @ HTMLCloseTagNode (location: (1:27)-(1:36))
+    │   │       ├── tag_opening: "</" (location: (1:27)-(1:29))
+    │   │       ├── tag_name: "script" (location: (1:29)-(1:35))
+    │   │       └── tag_closing: ">" (location: (1:35)-(1:36))
+    │   │
+    │   └── is_void: false
+    │
+    ├── @ HTMLTextNode (location: (1:36)-(1:50))
+    │   └── content: "\\\" yesterday\";"
+    │
+    └── @ HTMLCloseTagNode (location: (1:50)-(1:59))
+        ├── errors: (1 error)
+        │   └── @ MissingOpeningTagError (location: (1:50)-(1:59))
+        │       ├── message: "Found closing tag `</script>` at (1:52) without a matching opening tag."
+        │       └── closing_tag: "script" (location: (1:52)-(1:58))
+        │
+        ├── tag_opening: "</" (location: (1:50)-(1:52))
+        ├── tag_name: "script" (location: (1:52)-(1:58))
+        └── tag_closing: ">" (location: (1:58)-(1:59))

--- a/test/snapshots/parser/script_style_test/test_0036_style_tag_with_quotes_containing_HTML-like_content_e270b9ac006614d91dd6f0ac8fa94fa0.txt
+++ b/test/snapshots/parser/script_style_test/test_0036_style_tag_with_quotes_containing_HTML-like_content_e270b9ac006614d91dd6f0ac8fa94fa0.txt
@@ -1,0 +1,36 @@
+@ DocumentNode (location: (1:0)-(1:53))
+└── children: (3 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:41))
+    │   ├── open_tag:
+    │   │   └── @ HTMLOpenTagNode (location: (1:0)-(1:7))
+    │   │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+    │   │       ├── tag_name: "style" (location: (1:1)-(1:6))
+    │   │       ├── tag_closing: ">" (location: (1:6)-(1:7))
+    │   │       ├── children: []
+    │   │       └── is_void: false
+    │   │
+    │   ├── tag_name: "style" (location: (1:1)-(1:6))
+    │   ├── body: (1 item)
+    │   │   └── @ LiteralNode (location: (1:7)-(1:33))
+    │   │       └── content: ".icon::before { content: \""
+    │   │
+    │   ├── close_tag:
+    │   │   └── @ HTMLCloseTagNode (location: (1:33)-(1:41))
+    │   │       ├── tag_opening: "</" (location: (1:33)-(1:35))
+    │   │       ├── tag_name: "style" (location: (1:35)-(1:40))
+    │   │       └── tag_closing: ">" (location: (1:40)-(1:41))
+    │   │
+    │   └── is_void: false
+    │
+    ├── @ HTMLTextNode (location: (1:41)-(1:45))
+    │   └── content: "\"; }"
+    │
+    └── @ HTMLCloseTagNode (location: (1:45)-(1:53))
+        ├── errors: (1 error)
+        │   └── @ MissingOpeningTagError (location: (1:45)-(1:53))
+        │       ├── message: "Found closing tag `</style>` at (1:47) without a matching opening tag."
+        │       └── closing_tag: "style" (location: (1:47)-(1:52))
+        │
+        ├── tag_opening: "</" (location: (1:45)-(1:47))
+        ├── tag_name: "style" (location: (1:47)-(1:52))
+        └── tag_closing: ">" (location: (1:52)-(1:53))

--- a/test/snapshots/parser/script_style_test/test_0037_script_tag_with_mixed_quote_types_and_closing_tags_13c557e6f9f1cb452509b1e1750ede1d.txt
+++ b/test/snapshots/parser/script_style_test/test_0037_script_tag_with_mixed_quote_types_and_closing_tags_13c557e6f9f1cb452509b1e1750ede1d.txt
@@ -1,0 +1,52 @@
+@ DocumentNode (location: (1:0)-(6:0))
+└── children: (6 items)
+    ├── @ HTMLElementNode (location: (1:0)-(2:25))
+    │   ├── open_tag:
+    │   │   └── @ HTMLOpenTagNode (location: (1:0)-(1:8))
+    │   │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+    │   │       ├── tag_name: "script" (location: (1:1)-(1:7))
+    │   │       ├── tag_closing: ">" (location: (1:7)-(1:8))
+    │   │       ├── children: []
+    │   │       └── is_void: false
+    │   │
+    │   ├── tag_name: "script" (location: (1:1)-(1:7))
+    │   ├── body: (1 item)
+    │   │   └── @ LiteralNode (location: (1:8)-(2:16))
+    │   │       └── content: "\n  var single = '"
+    │   │
+    │   ├── close_tag:
+    │   │   └── @ HTMLCloseTagNode (location: (2:16)-(2:25))
+    │   │       ├── tag_opening: "</" (location: (2:16)-(2:18))
+    │   │       ├── tag_name: "script" (location: (2:18)-(2:24))
+    │   │       └── tag_closing: ">" (location: (2:24)-(2:25))
+    │   │
+    │   └── is_void: false
+    │
+    ├── @ HTMLTextNode (location: (2:25)-(3:16))
+    │   └── content: "';\n  var double = \""
+    │
+    ├── @ HTMLCloseTagNode (location: (3:16)-(3:25))
+    │   ├── errors: (1 error)
+    │   │   └── @ MissingOpeningTagError (location: (3:16)-(3:25))
+    │   │       ├── message: "Found closing tag `</script>` at (3:18) without a matching opening tag."
+    │   │       └── closing_tag: "script" (location: (3:18)-(3:24))
+    │   │
+    │   ├── tag_opening: "</" (location: (3:16)-(3:18))
+    │   ├── tag_name: "script" (location: (3:18)-(3:24))
+    │   └── tag_closing: ">" (location: (3:24)-(3:25))
+    │
+    ├── @ HTMLTextNode (location: (3:25)-(5:0))
+    │   └── content: "\";\n  console.log(\"All strings parsed correctly\");\n"
+    │
+    ├── @ HTMLCloseTagNode (location: (5:0)-(5:9))
+    │   ├── errors: (1 error)
+    │   │   └── @ MissingOpeningTagError (location: (5:0)-(5:9))
+    │   │       ├── message: "Found closing tag `</script>` at (5:2) without a matching opening tag."
+    │   │       └── closing_tag: "script" (location: (5:2)-(5:8))
+    │   │
+    │   ├── tag_opening: "</" (location: (5:0)-(5:2))
+    │   ├── tag_name: "script" (location: (5:2)-(5:8))
+    │   └── tag_closing: ">" (location: (5:8)-(5:9))
+    │
+    └── @ HTMLTextNode (location: (5:9)-(6:0))
+        └── content: "\n"

--- a/test/snapshots/parser/script_style_test/test_0038_script_tag_with_ERB_inside_string_literals_(ERB_always_processed)_b67f69c998376fb2dc4d376e22d717a6.txt
+++ b/test/snapshots/parser/script_style_test/test_0038_script_tag_with_ERB_inside_string_literals_(ERB_always_processed)_b67f69c998376fb2dc4d376e22d717a6.txt
@@ -1,0 +1,56 @@
+@ DocumentNode (location: (1:0)-(6:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(5:9))
+    │   ├── open_tag:
+    │   │   └── @ HTMLOpenTagNode (location: (1:0)-(1:8))
+    │   │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+    │   │       ├── tag_name: "script" (location: (1:1)-(1:7))
+    │   │       ├── tag_closing: ">" (location: (1:7)-(1:8))
+    │   │       ├── children: []
+    │   │       └── is_void: false
+    │   │
+    │   ├── tag_name: "script" (location: (1:1)-(1:7))
+    │   ├── body: (7 items)
+    │   │   ├── @ LiteralNode (location: (1:8)-(2:17))
+    │   │   │   └── content: "\n  var message = \""
+    │   │   │
+    │   │   ├── @ ERBContentNode (location: (2:17)-(2:33))
+    │   │   │   ├── tag_opening: "<%=" (location: (2:17)-(2:20))
+    │   │   │   ├── content: " @greeting " (location: (2:20)-(2:31))
+    │   │   │   ├── tag_closing: "%>" (location: (2:31)-(2:33))
+    │   │   │   ├── parsed: true
+    │   │   │   └── valid: true
+    │   │   │
+    │   │   ├── @ LiteralNode (location: (2:33)-(3:18))
+    │   │   │   └── content: "\";\n  var template = '"
+    │   │   │
+    │   │   ├── @ ERBContentNode (location: (3:18)-(3:34))
+    │   │   │   ├── tag_opening: "<%=" (location: (3:18)-(3:21))
+    │   │   │   ├── content: " @template " (location: (3:21)-(3:32))
+    │   │   │   ├── tag_closing: "%>" (location: (3:32)-(3:34))
+    │   │   │   ├── parsed: true
+    │   │   │   └── valid: true
+    │   │   │
+    │   │   ├── @ LiteralNode (location: (3:34)-(4:16))
+    │   │   │   └── content: "';\n  var config = `"
+    │   │   │
+    │   │   ├── @ ERBContentNode (location: (4:16)-(4:30))
+    │   │   │   ├── tag_opening: "<%=" (location: (4:16)-(4:19))
+    │   │   │   ├── content: " @config " (location: (4:19)-(4:28))
+    │   │   │   ├── tag_closing: "%>" (location: (4:28)-(4:30))
+    │   │   │   ├── parsed: true
+    │   │   │   └── valid: true
+    │   │   │
+    │   │   └── @ LiteralNode (location: (4:30)-(5:0))
+    │   │       └── content: "`;\n"
+    │   │
+    │   ├── close_tag:
+    │   │   └── @ HTMLCloseTagNode (location: (5:0)-(5:9))
+    │   │       ├── tag_opening: "</" (location: (5:0)-(5:2))
+    │   │       ├── tag_name: "script" (location: (5:2)-(5:8))
+    │   │       └── tag_closing: ">" (location: (5:8)-(5:9))
+    │   │
+    │   └── is_void: false
+    │
+    └── @ HTMLTextNode (location: (5:9)-(6:0))
+        └── content: "\n"

--- a/test/snapshots/parser/script_style_test/test_0039_script_tag_with_ERB_outside_vs_inside_strings_e40c255ffc82b3e1425a4dc9931950fb.txt
+++ b/test/snapshots/parser/script_style_test/test_0039_script_tag_with_ERB_outside_vs_inside_strings_e40c255ffc82b3e1425a4dc9931950fb.txt
@@ -1,0 +1,56 @@
+@ DocumentNode (location: (1:0)-(6:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(5:9))
+    │   ├── open_tag:
+    │   │   └── @ HTMLOpenTagNode (location: (1:0)-(1:8))
+    │   │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+    │   │       ├── tag_name: "script" (location: (1:1)-(1:7))
+    │   │       ├── tag_closing: ">" (location: (1:7)-(1:8))
+    │   │       ├── children: []
+    │   │       └── is_void: false
+    │   │
+    │   ├── tag_name: "script" (location: (1:1)-(1:7))
+    │   ├── body: (7 items)
+    │   │   ├── @ LiteralNode (location: (1:8)-(2:16))
+    │   │   │   └── content: "\n  var outside = "
+    │   │   │
+    │   │   ├── @ ERBContentNode (location: (2:16)-(2:29))
+    │   │   │   ├── tag_opening: "<%=" (location: (2:16)-(2:19))
+    │   │   │   ├── content: " @value " (location: (2:19)-(2:27))
+    │   │   │   ├── tag_closing: "%>" (location: (2:27)-(2:29))
+    │   │   │   ├── parsed: true
+    │   │   │   └── valid: true
+    │   │   │
+    │   │   ├── @ LiteralNode (location: (2:29)-(3:16))
+    │   │   │   └── content: ";\n  var inside = \""
+    │   │   │
+    │   │   ├── @ ERBContentNode (location: (3:16)-(3:29))
+    │   │   │   ├── tag_opening: "<%=" (location: (3:16)-(3:19))
+    │   │   │   ├── content: " @value " (location: (3:19)-(3:27))
+    │   │   │   ├── tag_closing: "%>" (location: (3:27)-(3:29))
+    │   │   │   ├── parsed: true
+    │   │   │   └── valid: true
+    │   │   │
+    │   │   ├── @ LiteralNode (location: (3:29)-(4:25))
+    │   │   │   └── content: "\";\n  var mixed = \"Hello \" + "
+    │   │   │
+    │   │   ├── @ ERBContentNode (location: (4:25)-(4:37))
+    │   │   │   ├── tag_opening: "<%=" (location: (4:25)-(4:28))
+    │   │   │   ├── content: " @name " (location: (4:28)-(4:35))
+    │   │   │   ├── tag_closing: "%>" (location: (4:35)-(4:37))
+    │   │   │   ├── parsed: true
+    │   │   │   └── valid: true
+    │   │   │
+    │   │   └── @ LiteralNode (location: (4:37)-(5:0))
+    │   │       └── content: " + \" world\";\n"
+    │   │
+    │   ├── close_tag:
+    │   │   └── @ HTMLCloseTagNode (location: (5:0)-(5:9))
+    │   │       ├── tag_opening: "</" (location: (5:0)-(5:2))
+    │   │       ├── tag_name: "script" (location: (5:2)-(5:8))
+    │   │       └── tag_closing: ">" (location: (5:8)-(5:9))
+    │   │
+    │   └── is_void: false
+    │
+    └── @ HTMLTextNode (location: (5:9)-(6:0))
+        └── content: "\n"

--- a/test/snapshots/parser/script_style_test/test_0040_script_tag_with_ERB_in_double_quotes_2c6059f094bb5e1ee9bda67bc46c8733.txt
+++ b/test/snapshots/parser/script_style_test/test_0040_script_tag_with_ERB_in_double_quotes_2c6059f094bb5e1ee9bda67bc46c8733.txt
@@ -1,0 +1,33 @@
+@ DocumentNode (location: (1:0)-(1:59))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:59))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:8))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "script" (location: (1:1)-(1:7))
+        │       ├── tag_closing: ">" (location: (1:7)-(1:8))
+        │       ├── children: []
+        │       └── is_void: false
+        │
+        ├── tag_name: "script" (location: (1:1)-(1:7))
+        ├── body: (3 items)
+        │   ├── @ LiteralNode (location: (1:8)-(1:25))
+        │   │   └── content: "var msg = \"Hello "
+        │   │
+        │   ├── @ ERBContentNode (location: (1:25)-(1:42))
+        │   │   ├── tag_opening: "<%=" (location: (1:25)-(1:28))
+        │   │   ├── content: " @user.name " (location: (1:28)-(1:40))
+        │   │   ├── tag_closing: "%>" (location: (1:40)-(1:42))
+        │   │   ├── parsed: true
+        │   │   └── valid: true
+        │   │
+        │   └── @ LiteralNode (location: (1:42)-(1:50))
+        │       └── content: " world\";"
+        │
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:50)-(1:59))
+        │       ├── tag_opening: "</" (location: (1:50)-(1:52))
+        │       ├── tag_name: "script" (location: (1:52)-(1:58))
+        │       └── tag_closing: ">" (location: (1:58)-(1:59))
+        │
+        └── is_void: false

--- a/test/snapshots/parser/script_style_test/test_0041_script_tag_with_ERB_in_single_quotes_d59cd4bf09cc0b041c800441470bd40b.txt
+++ b/test/snapshots/parser/script_style_test/test_0041_script_tag_with_ERB_in_single_quotes_d59cd4bf09cc0b041c800441470bd40b.txt
@@ -1,0 +1,33 @@
+@ DocumentNode (location: (1:0)-(1:59))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:59))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:8))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "script" (location: (1:1)-(1:7))
+        │       ├── tag_closing: ">" (location: (1:7)-(1:8))
+        │       ├── children: []
+        │       └── is_void: false
+        │
+        ├── tag_name: "script" (location: (1:1)-(1:7))
+        ├── body: (3 items)
+        │   ├── @ LiteralNode (location: (1:8)-(1:25))
+        │   │   └── content: "var msg = 'Hello "
+        │   │
+        │   ├── @ ERBContentNode (location: (1:25)-(1:42))
+        │   │   ├── tag_opening: "<%=" (location: (1:25)-(1:28))
+        │   │   ├── content: " @user.name " (location: (1:28)-(1:40))
+        │   │   ├── tag_closing: "%>" (location: (1:40)-(1:42))
+        │   │   ├── parsed: true
+        │   │   └── valid: true
+        │   │
+        │   └── @ LiteralNode (location: (1:42)-(1:50))
+        │       └── content: " world';"
+        │
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:50)-(1:59))
+        │       ├── tag_opening: "</" (location: (1:50)-(1:52))
+        │       ├── tag_name: "script" (location: (1:52)-(1:58))
+        │       └── tag_closing: ">" (location: (1:58)-(1:59))
+        │
+        └── is_void: false

--- a/test/snapshots/parser/script_style_test/test_0042_script_tag_with_ERB_in_template_literals_1bf37f10e055cd40a4029b93ebf85e4c.txt
+++ b/test/snapshots/parser/script_style_test/test_0042_script_tag_with_ERB_in_template_literals_1bf37f10e055cd40a4029b93ebf85e4c.txt
@@ -1,0 +1,33 @@
+@ DocumentNode (location: (1:0)-(1:59))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:59))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:8))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "script" (location: (1:1)-(1:7))
+        │       ├── tag_closing: ">" (location: (1:7)-(1:8))
+        │       ├── children: []
+        │       └── is_void: false
+        │
+        ├── tag_name: "script" (location: (1:1)-(1:7))
+        ├── body: (3 items)
+        │   ├── @ LiteralNode (location: (1:8)-(1:25))
+        │   │   └── content: "var msg = `Hello "
+        │   │
+        │   ├── @ ERBContentNode (location: (1:25)-(1:42))
+        │   │   ├── tag_opening: "<%=" (location: (1:25)-(1:28))
+        │   │   ├── content: " @user.name " (location: (1:28)-(1:40))
+        │   │   ├── tag_closing: "%>" (location: (1:40)-(1:42))
+        │   │   ├── parsed: true
+        │   │   └── valid: true
+        │   │
+        │   └── @ LiteralNode (location: (1:42)-(1:50))
+        │       └── content: " world`;"
+        │
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:50)-(1:59))
+        │       ├── tag_opening: "</" (location: (1:50)-(1:52))
+        │       ├── tag_name: "script" (location: (1:52)-(1:58))
+        │       └── tag_closing: ">" (location: (1:58)-(1:59))
+        │
+        └── is_void: false

--- a/test/snapshots/parser/script_style_test/test_0043_script_tag_with_multiple_ERB_tags_in_one_string_c10abf5afe91f2c24667c89a1a2da782.txt
+++ b/test/snapshots/parser/script_style_test/test_0043_script_tag_with_multiple_ERB_tags_in_one_string_c10abf5afe91f2c24667c89a1a2da782.txt
@@ -1,0 +1,43 @@
+@ DocumentNode (location: (1:0)-(1:70))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:70))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:8))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "script" (location: (1:1)-(1:7))
+        │       ├── tag_closing: ">" (location: (1:7)-(1:8))
+        │       ├── children: []
+        │       └── is_void: false
+        │
+        ├── tag_name: "script" (location: (1:1)-(1:7))
+        ├── body: (5 items)
+        │   ├── @ LiteralNode (location: (1:8)-(1:25))
+        │   │   └── content: "var info = \"User "
+        │   │
+        │   ├── @ ERBContentNode (location: (1:25)-(1:40))
+        │   │   ├── tag_opening: "<%=" (location: (1:25)-(1:28))
+        │   │   ├── content: " @user.id " (location: (1:28)-(1:38))
+        │   │   ├── tag_closing: "%>" (location: (1:38)-(1:40))
+        │   │   ├── parsed: true
+        │   │   └── valid: true
+        │   │
+        │   ├── @ LiteralNode (location: (1:40)-(1:42))
+        │   │   └── content: ": "
+        │   │
+        │   ├── @ ERBContentNode (location: (1:42)-(1:59))
+        │   │   ├── tag_opening: "<%=" (location: (1:42)-(1:45))
+        │   │   ├── content: " @user.name " (location: (1:45)-(1:57))
+        │   │   ├── tag_closing: "%>" (location: (1:57)-(1:59))
+        │   │   ├── parsed: true
+        │   │   └── valid: true
+        │   │
+        │   └── @ LiteralNode (location: (1:59)-(1:61))
+        │       └── content: "\";"
+        │
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:61)-(1:70))
+        │       ├── tag_opening: "</" (location: (1:61)-(1:63))
+        │       ├── tag_name: "script" (location: (1:63)-(1:69))
+        │       └── tag_closing: ">" (location: (1:69)-(1:70))
+        │
+        └── is_void: false

--- a/test/snapshots/parser/script_style_test/test_0044_script_tag_with_ERB_in_different_quote_types_same_line_9ee69c6b662e77ee693b096f74ddc97b.txt
+++ b/test/snapshots/parser/script_style_test/test_0044_script_tag_with_ERB_in_different_quote_types_same_line_9ee69c6b662e77ee693b096f74ddc97b.txt
@@ -1,0 +1,43 @@
+@ DocumentNode (location: (1:0)-(1:68))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:68))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:8))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "script" (location: (1:1)-(1:7))
+        │       ├── tag_closing: ">" (location: (1:7)-(1:8))
+        │       ├── children: []
+        │       └── is_void: false
+        │
+        ├── tag_name: "script" (location: (1:1)-(1:7))
+        ├── body: (5 items)
+        │   ├── @ LiteralNode (location: (1:8)-(1:22))
+        │   │   └── content: "var a = \"ERB: "
+        │   │
+        │   ├── @ ERBContentNode (location: (1:22)-(1:31))
+        │   │   ├── tag_opening: "<%=" (location: (1:22)-(1:25))
+        │   │   ├── content: " @a " (location: (1:25)-(1:29))
+        │   │   ├── tag_closing: "%>" (location: (1:29)-(1:31))
+        │   │   ├── parsed: true
+        │   │   └── valid: true
+        │   │
+        │   ├── @ LiteralNode (location: (1:31)-(1:48))
+        │   │   └── content: "\"; var b = 'ERB: "
+        │   │
+        │   ├── @ ERBContentNode (location: (1:48)-(1:57))
+        │   │   ├── tag_opening: "<%=" (location: (1:48)-(1:51))
+        │   │   ├── content: " @b " (location: (1:51)-(1:55))
+        │   │   ├── tag_closing: "%>" (location: (1:55)-(1:57))
+        │   │   ├── parsed: true
+        │   │   └── valid: true
+        │   │
+        │   └── @ LiteralNode (location: (1:57)-(1:59))
+        │       └── content: "';"
+        │
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:59)-(1:68))
+        │       ├── tag_opening: "</" (location: (1:59)-(1:61))
+        │       ├── tag_name: "script" (location: (1:61)-(1:67))
+        │       └── tag_closing: ">" (location: (1:67)-(1:68))
+        │
+        └── is_void: false

--- a/test/snapshots/parser/script_style_test/test_0045_style_tag_with_ERB_in_CSS_strings_a74d4a4f4488689aceb2070a2901e6d2.txt
+++ b/test/snapshots/parser/script_style_test/test_0045_style_tag_with_ERB_in_CSS_strings_a74d4a4f4488689aceb2070a2901e6d2.txt
@@ -1,0 +1,46 @@
+@ DocumentNode (location: (1:0)-(7:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(6:8))
+    │   ├── open_tag:
+    │   │   └── @ HTMLOpenTagNode (location: (1:0)-(1:7))
+    │   │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+    │   │       ├── tag_name: "style" (location: (1:1)-(1:6))
+    │   │       ├── tag_closing: ">" (location: (1:6)-(1:7))
+    │   │       ├── children: []
+    │   │       └── is_void: false
+    │   │
+    │   ├── tag_name: "style" (location: (1:1)-(1:6))
+    │   ├── body: (5 items)
+    │   │   ├── @ LiteralNode (location: (1:7)-(3:25))
+    │   │   │   └── content: "\n  .dynamic::before {\n    content: \"Generated: "
+    │   │   │
+    │   │   ├── @ ERBContentNode (location: (3:25)-(3:42))
+    │   │   │   ├── tag_opening: "<%=" (location: (3:25)-(3:28))
+    │   │   │   ├── content: " @timestamp " (location: (3:28)-(3:40))
+    │   │   │   ├── tag_closing: "%>" (location: (3:40)-(3:42))
+    │   │   │   ├── parsed: true
+    │   │   │   └── valid: true
+    │   │   │
+    │   │   ├── @ LiteralNode (location: (3:42)-(4:21))
+    │   │   │   └── content: "\";\n    background: url('"
+    │   │   │
+    │   │   ├── @ ERBContentNode (location: (4:21)-(4:39))
+    │   │   │   ├── tag_opening: "<%=" (location: (4:21)-(4:24))
+    │   │   │   ├── content: " @image_path " (location: (4:24)-(4:37))
+    │   │   │   ├── tag_closing: "%>" (location: (4:37)-(4:39))
+    │   │   │   ├── parsed: true
+    │   │   │   └── valid: true
+    │   │   │
+    │   │   └── @ LiteralNode (location: (4:39)-(6:0))
+    │   │       └── content: "');\n  }\n"
+    │   │
+    │   ├── close_tag:
+    │   │   └── @ HTMLCloseTagNode (location: (6:0)-(6:8))
+    │   │       ├── tag_opening: "</" (location: (6:0)-(6:2))
+    │   │       ├── tag_name: "style" (location: (6:2)-(6:7))
+    │   │       └── tag_closing: ">" (location: (6:7)-(6:8))
+    │   │
+    │   └── is_void: false
+    │
+    └── @ HTMLTextNode (location: (6:8)-(7:0))
+        └── content: "\n"

--- a/test/snapshots/parser/script_style_test/test_0046_script_tag_with_closing_tag_in_single-line_comment_6cfabe5d024715f9a1a359ead2336bde.txt
+++ b/test/snapshots/parser/script_style_test/test_0046_script_tag_with_closing_tag_in_single-line_comment_6cfabe5d024715f9a1a359ead2336bde.txt
@@ -1,0 +1,39 @@
+@ DocumentNode (location: (1:0)-(4:0))
+└── children: (4 items)
+    ├── @ HTMLElementNode (location: (1:0)-(2:14))
+    │   ├── open_tag:
+    │   │   └── @ HTMLOpenTagNode (location: (1:0)-(1:8))
+    │   │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+    │   │       ├── tag_name: "script" (location: (1:1)-(1:7))
+    │   │       ├── tag_closing: ">" (location: (1:7)-(1:8))
+    │   │       ├── children: []
+    │   │       └── is_void: false
+    │   │
+    │   ├── tag_name: "script" (location: (1:1)-(1:7))
+    │   ├── body: (1 item)
+    │   │   └── @ LiteralNode (location: (1:8)-(2:5))
+    │   │       └── content: "\n  // "
+    │   │
+    │   ├── close_tag:
+    │   │   └── @ HTMLCloseTagNode (location: (2:5)-(2:14))
+    │   │       ├── tag_opening: "</" (location: (2:5)-(2:7))
+    │   │       ├── tag_name: "script" (location: (2:7)-(2:13))
+    │   │       └── tag_closing: ">" (location: (2:13)-(2:14))
+    │   │
+    │   └── is_void: false
+    │
+    ├── @ HTMLTextNode (location: (2:14)-(3:0))
+    │   └── content: "\n"
+    │
+    ├── @ HTMLCloseTagNode (location: (3:0)-(3:9))
+    │   ├── errors: (1 error)
+    │   │   └── @ MissingOpeningTagError (location: (3:0)-(3:9))
+    │   │       ├── message: "Found closing tag `</script>` at (3:2) without a matching opening tag."
+    │   │       └── closing_tag: "script" (location: (3:2)-(3:8))
+    │   │
+    │   ├── tag_opening: "</" (location: (3:0)-(3:2))
+    │   ├── tag_name: "script" (location: (3:2)-(3:8))
+    │   └── tag_closing: ">" (location: (3:8)-(3:9))
+    │
+    └── @ HTMLTextNode (location: (3:9)-(4:0))
+        └── content: "\n"

--- a/test/snapshots/parser/script_style_test/test_0047_script_tag_with_closing_tag_in_multi-line_comment_f31fa6a4dd0f181740b8650c7c0eadba.txt
+++ b/test/snapshots/parser/script_style_test/test_0047_script_tag_with_closing_tag_in_multi-line_comment_f31fa6a4dd0f181740b8650c7c0eadba.txt
@@ -1,0 +1,39 @@
+@ DocumentNode (location: (1:0)-(4:0))
+└── children: (4 items)
+    ├── @ HTMLElementNode (location: (1:0)-(2:14))
+    │   ├── open_tag:
+    │   │   └── @ HTMLOpenTagNode (location: (1:0)-(1:8))
+    │   │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+    │   │       ├── tag_name: "script" (location: (1:1)-(1:7))
+    │   │       ├── tag_closing: ">" (location: (1:7)-(1:8))
+    │   │       ├── children: []
+    │   │       └── is_void: false
+    │   │
+    │   ├── tag_name: "script" (location: (1:1)-(1:7))
+    │   ├── body: (1 item)
+    │   │   └── @ LiteralNode (location: (1:8)-(2:5))
+    │   │       └── content: "\n  /* "
+    │   │
+    │   ├── close_tag:
+    │   │   └── @ HTMLCloseTagNode (location: (2:5)-(2:14))
+    │   │       ├── tag_opening: "</" (location: (2:5)-(2:7))
+    │   │       ├── tag_name: "script" (location: (2:7)-(2:13))
+    │   │       └── tag_closing: ">" (location: (2:13)-(2:14))
+    │   │
+    │   └── is_void: false
+    │
+    ├── @ HTMLTextNode (location: (2:14)-(3:0))
+    │   └── content: " */\n"
+    │
+    ├── @ HTMLCloseTagNode (location: (3:0)-(3:9))
+    │   ├── errors: (1 error)
+    │   │   └── @ MissingOpeningTagError (location: (3:0)-(3:9))
+    │   │       ├── message: "Found closing tag `</script>` at (3:2) without a matching opening tag."
+    │   │       └── closing_tag: "script" (location: (3:2)-(3:8))
+    │   │
+    │   ├── tag_opening: "</" (location: (3:0)-(3:2))
+    │   ├── tag_name: "script" (location: (3:2)-(3:8))
+    │   └── tag_closing: ">" (location: (3:8)-(3:9))
+    │
+    └── @ HTMLTextNode (location: (3:9)-(4:0))
+        └── content: "\n"

--- a/test/snapshots/parser/script_style_test/test_0048_script_tag_with_closing_tag_in_complex_multi-line_comment_740adce7cfe9c265534de5ed0019592a.txt
+++ b/test/snapshots/parser/script_style_test/test_0048_script_tag_with_closing_tag_in_complex_multi-line_comment_740adce7cfe9c265534de5ed0019592a.txt
@@ -1,0 +1,52 @@
+@ DocumentNode (location: (1:0)-(8:0))
+└── children: (6 items)
+    ├── @ HTMLElementNode (location: (1:0)-(3:37))
+    │   ├── open_tag:
+    │   │   └── @ HTMLOpenTagNode (location: (1:0)-(1:8))
+    │   │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+    │   │       ├── tag_name: "script" (location: (1:1)-(1:7))
+    │   │       ├── tag_closing: ">" (location: (1:7)-(1:8))
+    │   │       ├── children: []
+    │   │       └── is_void: false
+    │   │
+    │   ├── tag_name: "script" (location: (1:1)-(1:7))
+    │   ├── body: (1 item)
+    │   │   └── @ LiteralNode (location: (1:8)-(3:28))
+    │   │       └── content: "\n  /*\n   * This is a comment with "
+    │   │
+    │   ├── close_tag:
+    │   │   └── @ HTMLCloseTagNode (location: (3:28)-(3:37))
+    │   │       ├── tag_opening: "</" (location: (3:28)-(3:30))
+    │   │       ├── tag_name: "script" (location: (3:30)-(3:36))
+    │   │       └── tag_closing: ">" (location: (3:36)-(3:37))
+    │   │
+    │   └── is_void: false
+    │
+    ├── @ HTMLTextNode (location: (3:37)-(4:27))
+    │   └── content: " inside\n   * and some more content "
+    │
+    ├── @ HTMLCloseTagNode (location: (4:27)-(4:35))
+    │   ├── errors: (1 error)
+    │   │   └── @ MissingOpeningTagError (location: (4:27)-(4:35))
+    │   │       ├── message: "Found closing tag `</style>` at (4:29) without a matching opening tag."
+    │   │       └── closing_tag: "style" (location: (4:29)-(4:34))
+    │   │
+    │   ├── tag_opening: "</" (location: (4:27)-(4:29))
+    │   ├── tag_name: "style" (location: (4:29)-(4:34))
+    │   └── tag_closing: ">" (location: (4:34)-(4:35))
+    │
+    ├── @ HTMLTextNode (location: (4:35)-(7:0))
+    │   └── content: "\n   */\n  console.log(\"actual code\");\n"
+    │
+    ├── @ HTMLCloseTagNode (location: (7:0)-(7:9))
+    │   ├── errors: (1 error)
+    │   │   └── @ MissingOpeningTagError (location: (7:0)-(7:9))
+    │   │       ├── message: "Found closing tag `</script>` at (7:2) without a matching opening tag."
+    │   │       └── closing_tag: "script" (location: (7:2)-(7:8))
+    │   │
+    │   ├── tag_opening: "</" (location: (7:0)-(7:2))
+    │   ├── tag_name: "script" (location: (7:2)-(7:8))
+    │   └── tag_closing: ">" (location: (7:8)-(7:9))
+    │
+    └── @ HTMLTextNode (location: (7:9)-(8:0))
+        └── content: "\n"

--- a/test/snapshots/parser/script_style_test/test_0049_script_tag_with_mixed_comments_and_strings_dd4ddc45ba4f6eac82de8f8d0c4f8430.txt
+++ b/test/snapshots/parser/script_style_test/test_0049_script_tag_with_mixed_comments_and_strings_dd4ddc45ba4f6eac82de8f8d0c4f8430.txt
@@ -1,0 +1,78 @@
+@ DocumentNode (location: (1:0)-(8:0))
+└── children: (10 items)
+    ├── @ HTMLElementNode (location: (1:0)-(2:27))
+    │   ├── open_tag:
+    │   │   └── @ HTMLOpenTagNode (location: (1:0)-(1:8))
+    │   │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+    │   │       ├── tag_name: "script" (location: (1:1)-(1:7))
+    │   │       ├── tag_closing: ">" (location: (1:7)-(1:8))
+    │   │       ├── children: []
+    │   │       └── is_void: false
+    │   │
+    │   ├── tag_name: "script" (location: (1:1)-(1:7))
+    │   ├── body: (1 item)
+    │   │   └── @ LiteralNode (location: (1:8)-(2:18))
+    │   │       └── content: "\n  // Comment with "
+    │   │
+    │   ├── close_tag:
+    │   │   └── @ HTMLCloseTagNode (location: (2:18)-(2:27))
+    │   │       ├── tag_opening: "</" (location: (2:18)-(2:20))
+    │   │       ├── tag_name: "script" (location: (2:20)-(2:26))
+    │   │       └── tag_closing: ">" (location: (2:26)-(2:27))
+    │   │
+    │   └── is_void: false
+    │
+    ├── @ HTMLTextNode (location: (2:27)-(3:25))
+    │   └── content: "\n  var str = \"String with "
+    │
+    ├── @ HTMLCloseTagNode (location: (3:25)-(3:34))
+    │   ├── errors: (1 error)
+    │   │   └── @ MissingOpeningTagError (location: (3:25)-(3:34))
+    │   │       ├── message: "Found closing tag `</script>` at (3:27) without a matching opening tag."
+    │   │       └── closing_tag: "script" (location: (3:27)-(3:33))
+    │   │
+    │   ├── tag_opening: "</" (location: (3:25)-(3:27))
+    │   ├── tag_name: "script" (location: (3:27)-(3:33))
+    │   └── tag_closing: ">" (location: (3:33)-(3:34))
+    │
+    ├── @ HTMLTextNode (location: (3:34)-(5:10))
+    │   └── content: "\";\n  /* Multi-line comment\n     with "
+    │
+    ├── @ HTMLCloseTagNode (location: (5:10)-(5:19))
+    │   ├── errors: (1 error)
+    │   │   └── @ MissingOpeningTagError (location: (5:10)-(5:19))
+    │   │       ├── message: "Found closing tag `</script>` at (5:12) without a matching opening tag."
+    │   │       └── closing_tag: "script" (location: (5:12)-(5:18))
+    │   │
+    │   ├── tag_opening: "</" (location: (5:10)-(5:12))
+    │   ├── tag_name: "script" (location: (5:12)-(5:18))
+    │   └── tag_closing: ">" (location: (5:18)-(5:19))
+    │
+    ├── @ HTMLTextNode (location: (5:19)-(6:30))
+    │   └── content: " inside */\n  var another = 'Single quote "
+    │
+    ├── @ HTMLCloseTagNode (location: (6:30)-(6:39))
+    │   ├── errors: (1 error)
+    │   │   └── @ MissingOpeningTagError (location: (6:30)-(6:39))
+    │   │       ├── message: "Found closing tag `</script>` at (6:32) without a matching opening tag."
+    │   │       └── closing_tag: "script" (location: (6:32)-(6:38))
+    │   │
+    │   ├── tag_opening: "</" (location: (6:30)-(6:32))
+    │   ├── tag_name: "script" (location: (6:32)-(6:38))
+    │   └── tag_closing: ">" (location: (6:38)-(6:39))
+    │
+    ├── @ HTMLTextNode (location: (6:39)-(7:0))
+    │   └── content: "';\n"
+    │
+    ├── @ HTMLCloseTagNode (location: (7:0)-(7:9))
+    │   ├── errors: (1 error)
+    │   │   └── @ MissingOpeningTagError (location: (7:0)-(7:9))
+    │   │       ├── message: "Found closing tag `</script>` at (7:2) without a matching opening tag."
+    │   │       └── closing_tag: "script" (location: (7:2)-(7:8))
+    │   │
+    │   ├── tag_opening: "</" (location: (7:0)-(7:2))
+    │   ├── tag_name: "script" (location: (7:2)-(7:8))
+    │   └── tag_closing: ">" (location: (7:8)-(7:9))
+    │
+    └── @ HTMLTextNode (location: (7:9)-(8:0))
+        └── content: "\n"

--- a/test/snapshots/parser/script_style_test/test_0050_script_tag_with_nested_comment_markers_a4df6fe19ac8d1b0a34db42d412a673e.txt
+++ b/test/snapshots/parser/script_style_test/test_0050_script_tag_with_nested_comment_markers_a4df6fe19ac8d1b0a34db42d412a673e.txt
@@ -1,0 +1,26 @@
+@ DocumentNode (location: (1:0)-(6:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(5:9))
+    │   ├── open_tag:
+    │   │   └── @ HTMLOpenTagNode (location: (1:0)-(1:8))
+    │   │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+    │   │       ├── tag_name: "script" (location: (1:1)-(1:7))
+    │   │       ├── tag_closing: ">" (location: (1:7)-(1:8))
+    │   │       ├── children: []
+    │   │       └── is_void: false
+    │   │
+    │   ├── tag_name: "script" (location: (1:1)-(1:7))
+    │   ├── body: (1 item)
+    │   │   └── @ LiteralNode (location: (1:8)-(5:0))
+    │   │       └── content: "\n  // First comment // with nested comment marker\n  /* Outer comment /* with nested comment marker */ still in comment */\n  console.log(\"done\");\n"
+    │   │
+    │   ├── close_tag:
+    │   │   └── @ HTMLCloseTagNode (location: (5:0)-(5:9))
+    │   │       ├── tag_opening: "</" (location: (5:0)-(5:2))
+    │   │       ├── tag_name: "script" (location: (5:2)-(5:8))
+    │   │       └── tag_closing: ">" (location: (5:8)-(5:9))
+    │   │
+    │   └── is_void: false
+    │
+    └── @ HTMLTextNode (location: (5:9)-(6:0))
+        └── content: "\n"

--- a/test/snapshots/parser/script_style_test/test_0051_script_tag_with_ERB_in_comments_231feb7c74575ff4cfc97fdfbdb892f6.txt
+++ b/test/snapshots/parser/script_style_test/test_0051_script_tag_with_ERB_in_comments_231feb7c74575ff4cfc97fdfbdb892f6.txt
@@ -1,0 +1,56 @@
+@ DocumentNode (location: (1:0)-(6:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(5:9))
+    │   ├── open_tag:
+    │   │   └── @ HTMLOpenTagNode (location: (1:0)-(1:8))
+    │   │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+    │   │       ├── tag_name: "script" (location: (1:1)-(1:7))
+    │   │       ├── tag_closing: ">" (location: (1:7)-(1:8))
+    │   │       ├── children: []
+    │   │       └── is_void: false
+    │   │
+    │   ├── tag_name: "script" (location: (1:1)-(1:7))
+    │   ├── body: (7 items)
+    │   │   ├── @ LiteralNode (location: (1:8)-(2:21))
+    │   │   │   └── content: "\n  // ERB in comment: "
+    │   │   │
+    │   │   ├── @ ERBContentNode (location: (2:21)-(2:34))
+    │   │   │   ├── tag_opening: "<%=" (location: (2:21)-(2:24))
+    │   │   │   ├── content: " @value " (location: (2:24)-(2:32))
+    │   │   │   ├── tag_closing: "%>" (location: (2:32)-(2:34))
+    │   │   │   ├── parsed: true
+    │   │   │   └── valid: true
+    │   │   │
+    │   │   ├── @ LiteralNode (location: (2:34)-(3:21))
+    │   │   │   └── content: "\n  /* Multi-line ERB: "
+    │   │   │
+    │   │   ├── @ ERBContentNode (location: (3:21)-(3:33))
+    │   │   │   ├── tag_opening: "<%=" (location: (3:21)-(3:24))
+    │   │   │   ├── content: " @data " (location: (3:24)-(3:31))
+    │   │   │   ├── tag_closing: "%>" (location: (3:31)-(3:33))
+    │   │   │   ├── parsed: true
+    │   │   │   └── valid: true
+    │   │   │
+    │   │   ├── @ LiteralNode (location: (3:33)-(4:15))
+    │   │   │   └── content: " */\n  var result = "
+    │   │   │
+    │   │   ├── @ ERBContentNode (location: (4:15)-(4:33))
+    │   │   │   ├── tag_opening: "<%=" (location: (4:15)-(4:18))
+    │   │   │   ├── content: " @actual_erb " (location: (4:18)-(4:31))
+    │   │   │   ├── tag_closing: "%>" (location: (4:31)-(4:33))
+    │   │   │   ├── parsed: true
+    │   │   │   └── valid: true
+    │   │   │
+    │   │   └── @ LiteralNode (location: (4:33)-(5:0))
+    │   │       └── content: ";\n"
+    │   │
+    │   ├── close_tag:
+    │   │   └── @ HTMLCloseTagNode (location: (5:0)-(5:9))
+    │   │       ├── tag_opening: "</" (location: (5:0)-(5:2))
+    │   │       ├── tag_name: "script" (location: (5:2)-(5:8))
+    │   │       └── tag_closing: ">" (location: (5:8)-(5:9))
+    │   │
+    │   └── is_void: false
+    │
+    └── @ HTMLTextNode (location: (5:9)-(6:0))
+        └── content: "\n"

--- a/test/snapshots/parser/script_style_test/test_0052_script_tag_with_complex_multi-line_comment_containing_closing_tag_baba657d4b37767ec99d327b6dec635a.txt
+++ b/test/snapshots/parser/script_style_test/test_0052_script_tag_with_complex_multi-line_comment_containing_closing_tag_baba657d4b37767ec99d327b6dec635a.txt
@@ -1,0 +1,39 @@
+@ DocumentNode (location: (1:0)-(6:0))
+└── children: (4 items)
+    ├── @ HTMLElementNode (location: (1:0)-(3:14))
+    │   ├── open_tag:
+    │   │   └── @ HTMLOpenTagNode (location: (1:0)-(1:8))
+    │   │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+    │   │       ├── tag_name: "script" (location: (1:1)-(1:7))
+    │   │       ├── tag_closing: ">" (location: (1:7)-(1:8))
+    │   │       ├── children: []
+    │   │       └── is_void: false
+    │   │
+    │   ├── tag_name: "script" (location: (1:1)-(1:7))
+    │   ├── body: (1 item)
+    │   │   └── @ LiteralNode (location: (1:8)-(3:5))
+    │   │       └── content: "\n  /*\n   * "
+    │   │
+    │   ├── close_tag:
+    │   │   └── @ HTMLCloseTagNode (location: (3:5)-(3:14))
+    │   │       ├── tag_opening: "</" (location: (3:5)-(3:7))
+    │   │       ├── tag_name: "script" (location: (3:7)-(3:13))
+    │   │       └── tag_closing: ">" (location: (3:13)-(3:14))
+    │   │
+    │   └── is_void: false
+    │
+    ├── @ HTMLTextNode (location: (3:14)-(5:0))
+    │   └── content: "\n   */\n"
+    │
+    ├── @ HTMLCloseTagNode (location: (5:0)-(5:9))
+    │   ├── errors: (1 error)
+    │   │   └── @ MissingOpeningTagError (location: (5:0)-(5:9))
+    │   │       ├── message: "Found closing tag `</script>` at (5:2) without a matching opening tag."
+    │   │       └── closing_tag: "script" (location: (5:2)-(5:8))
+    │   │
+    │   ├── tag_opening: "</" (location: (5:0)-(5:2))
+    │   ├── tag_name: "script" (location: (5:2)-(5:8))
+    │   └── tag_closing: ">" (location: (5:8)-(5:9))
+    │
+    └── @ HTMLTextNode (location: (5:9)-(6:0))
+        └── content: "\n"

--- a/test/snapshots/parser/script_style_test/test_0053_script_tag_with_template_literal_containing_closing_tag_(multiline)_372da24666282e3c531de3c5a8de44ca.txt
+++ b/test/snapshots/parser/script_style_test/test_0053_script_tag_with_template_literal_containing_closing_tag_(multiline)_372da24666282e3c531de3c5a8de44ca.txt
@@ -1,0 +1,46 @@
+@ DocumentNode (location: (1:0)-(4:0))
+├── errors: (1 error)
+│   └── @ UnexpectedError (location: (2:12)-(2:13))
+│       ├── message: "Unexpected token. Expected: `TOKEN_ERB_START, TOKEN_HTML_DOCTYPE, TOKEN_HTML_COMMENT_START, TOKEN_IDENTIFIER, TOKEN_WHITESPACE, TOKEN_NBSP, TOKEN_AT, or TOKE`, found: `TOKEN_BACKTICK`."
+│       ├── description: "Unexpected token"
+│       ├── expected: "TOKEN_ERB_START, TOKEN_HTML_DOCTYPE, TOKEN_HTML_COMMENT_START, TOKEN_IDENTIFIER, TOKEN_WHITESPACE, TOKEN_NBSP, TOKEN_AT, or TOKEN_NEWLINE"
+│       └── found: "TOKEN_BACKTICK"
+│
+└── children: (4 items)
+    ├── @ HTMLElementNode (location: (1:0)-(2:12))
+    │   ├── open_tag:
+    │   │   └── @ HTMLOpenTagNode (location: (1:0)-(1:8))
+    │   │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+    │   │       ├── tag_name: "script" (location: (1:1)-(1:7))
+    │   │       ├── tag_closing: ">" (location: (1:7)-(1:8))
+    │   │       ├── children: []
+    │   │       └── is_void: false
+    │   │
+    │   ├── tag_name: "script" (location: (1:1)-(1:7))
+    │   ├── body: (1 item)
+    │   │   └── @ LiteralNode (location: (1:8)-(2:3))
+    │   │       └── content: "\n  `"
+    │   │
+    │   ├── close_tag:
+    │   │   └── @ HTMLCloseTagNode (location: (2:3)-(2:12))
+    │   │       ├── tag_opening: "</" (location: (2:3)-(2:5))
+    │   │       ├── tag_name: "script" (location: (2:5)-(2:11))
+    │   │       └── tag_closing: ">" (location: (2:11)-(2:12))
+    │   │
+    │   └── is_void: false
+    │
+    ├── @ HTMLTextNode (location: (2:13)-(3:0))
+    │   └── content: "\n"
+    │
+    ├── @ HTMLCloseTagNode (location: (3:0)-(3:9))
+    │   ├── errors: (1 error)
+    │   │   └── @ MissingOpeningTagError (location: (3:0)-(3:9))
+    │   │       ├── message: "Found closing tag `</script>` at (3:2) without a matching opening tag."
+    │   │       └── closing_tag: "script" (location: (3:2)-(3:8))
+    │   │
+    │   ├── tag_opening: "</" (location: (3:0)-(3:2))
+    │   ├── tag_name: "script" (location: (3:2)-(3:8))
+    │   └── tag_closing: ">" (location: (3:8)-(3:9))
+    │
+    └── @ HTMLTextNode (location: (3:9)-(4:0))
+        └── content: "\n"

--- a/test/snapshots/parser/script_style_test/test_0054_script_tag_with_closing_tag_on_comment_line_b0c5fd685fa4dd26975b5ddf24ca007d.txt
+++ b/test/snapshots/parser/script_style_test/test_0054_script_tag_with_closing_tag_on_comment_line_b0c5fd685fa4dd26975b5ddf24ca007d.txt
@@ -1,0 +1,76 @@
+@ DocumentNode (location: (1:0)-(7:0))
+└── children: (6 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:17))
+    │   ├── open_tag:
+    │   │   └── @ HTMLOpenTagNode (location: (1:0)-(1:5))
+    │   │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+    │   │       ├── tag_name: "div" (location: (1:1)-(1:4))
+    │   │       ├── tag_closing: ">" (location: (1:4)-(1:5))
+    │   │       ├── children: []
+    │   │       └── is_void: false
+    │   │
+    │   ├── tag_name: "div" (location: (1:1)-(1:4))
+    │   ├── body: (1 item)
+    │   │   └── @ HTMLTextNode (location: (1:5)-(1:11))
+    │   │       └── content: "Before"
+    │   │
+    │   ├── close_tag:
+    │   │   └── @ HTMLCloseTagNode (location: (1:11)-(1:17))
+    │   │       ├── tag_opening: "</" (location: (1:11)-(1:13))
+    │   │       ├── tag_name: "div" (location: (1:13)-(1:16))
+    │   │       └── tag_closing: ">" (location: (1:16)-(1:17))
+    │   │
+    │   └── is_void: false
+    │
+    ├── @ HTMLTextNode (location: (1:17)-(3:0))
+    │   └── content: "\n\n"
+    │
+    ├── @ HTMLElementNode (location: (3:0)-(4:14))
+    │   ├── open_tag:
+    │   │   └── @ HTMLOpenTagNode (location: (3:0)-(3:8))
+    │   │       ├── tag_opening: "<" (location: (3:0)-(3:1))
+    │   │       ├── tag_name: "script" (location: (3:1)-(3:7))
+    │   │       ├── tag_closing: ">" (location: (3:7)-(3:8))
+    │   │       ├── children: []
+    │   │       └── is_void: false
+    │   │
+    │   ├── tag_name: "script" (location: (3:1)-(3:7))
+    │   ├── body: (1 item)
+    │   │   └── @ LiteralNode (location: (3:8)-(4:5))
+    │   │       └── content: "\n  // "
+    │   │
+    │   ├── close_tag:
+    │   │   └── @ HTMLCloseTagNode (location: (4:5)-(4:14))
+    │   │       ├── tag_opening: "</" (location: (4:5)-(4:7))
+    │   │       ├── tag_name: "script" (location: (4:7)-(4:13))
+    │   │       └── tag_closing: ">" (location: (4:13)-(4:14))
+    │   │
+    │   └── is_void: false
+    │
+    ├── @ HTMLTextNode (location: (4:14)-(6:0))
+    │   └── content: "\n\n"
+    │
+    ├── @ HTMLElementNode (location: (6:0)-(6:16))
+    │   ├── open_tag:
+    │   │   └── @ HTMLOpenTagNode (location: (6:0)-(6:5))
+    │   │       ├── tag_opening: "<" (location: (6:0)-(6:1))
+    │   │       ├── tag_name: "div" (location: (6:1)-(6:4))
+    │   │       ├── tag_closing: ">" (location: (6:4)-(6:5))
+    │   │       ├── children: []
+    │   │       └── is_void: false
+    │   │
+    │   ├── tag_name: "div" (location: (6:1)-(6:4))
+    │   ├── body: (1 item)
+    │   │   └── @ HTMLTextNode (location: (6:5)-(6:10))
+    │   │       └── content: "After"
+    │   │
+    │   ├── close_tag:
+    │   │   └── @ HTMLCloseTagNode (location: (6:10)-(6:16))
+    │   │       ├── tag_opening: "</" (location: (6:10)-(6:12))
+    │   │       ├── tag_name: "div" (location: (6:12)-(6:15))
+    │   │       └── tag_closing: ">" (location: (6:15)-(6:16))
+    │   │
+    │   └── is_void: false
+    │
+    └── @ HTMLTextNode (location: (6:16)-(7:0))
+        └── content: "\n"

--- a/test/snapshots/parser/script_style_test/test_0055_script_tag_with_closing_div_tag_in_string_01f7309c0ef4f1977a6265ed3ae833e1.txt
+++ b/test/snapshots/parser/script_style_test/test_0055_script_tag_with_closing_div_tag_in_string_01f7309c0ef4f1977a6265ed3ae833e1.txt
@@ -1,0 +1,23 @@
+@ DocumentNode (location: (1:0)-(1:34))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:34))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:8))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "script" (location: (1:1)-(1:7))
+        │       ├── tag_closing: ">" (location: (1:7)-(1:8))
+        │       ├── children: []
+        │       └── is_void: false
+        │
+        ├── tag_name: "script" (location: (1:1)-(1:7))
+        ├── body: (1 item)
+        │   └── @ LiteralNode (location: (1:8)-(1:25))
+        │       └── content: "var s = \"</div>\";"
+        │
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:25)-(1:34))
+        │       ├── tag_opening: "</" (location: (1:25)-(1:27))
+        │       ├── tag_name: "script" (location: (1:27)-(1:33))
+        │       └── tag_closing: ">" (location: (1:33)-(1:34))
+        │
+        └── is_void: false

--- a/test/snapshots/parser/tags_test/test_0028_script_tag_with_nested_div_40b4741e518839bafbaaa187c5a57d50.txt
+++ b/test/snapshots/parser/tags_test/test_0028_script_tag_with_nested_div_40b4741e518839bafbaaa187c5a57d50.txt
@@ -1,0 +1,23 @@
+@ DocumentNode (location: (1:0)-(1:38))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:38))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:8))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "script" (location: (1:1)-(1:7))
+        │       ├── tag_closing: ">" (location: (1:7)-(1:8))
+        │       ├── children: []
+        │       └── is_void: false
+        │
+        ├── tag_name: "script" (location: (1:1)-(1:7))
+        ├── body: (1 item)
+        │   └── @ LiteralNode (location: (1:8)-(1:29))
+        │       └── content: "<div>var x = 5;</div>"
+        │
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:29)-(1:38))
+        │       ├── tag_opening: "</" (location: (1:29)-(1:31))
+        │       ├── tag_name: "script" (location: (1:31)-(1:37))
+        │       └── tag_closing: ">" (location: (1:37)-(1:38))
+        │
+        └── is_void: false

--- a/test/snapshots/parser/tags_test/test_0029_script_tag_with_JavaScript_greater_than_comparison_e217953abdc486dffee56f0400c66822.txt
+++ b/test/snapshots/parser/tags_test/test_0029_script_tag_with_JavaScript_greater_than_comparison_e217953abdc486dffee56f0400c66822.txt
@@ -1,0 +1,23 @@
+@ DocumentNode (location: (1:0)-(1:55))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:55))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:8))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "script" (location: (1:1)-(1:7))
+        │       ├── tag_closing: ">" (location: (1:7)-(1:8))
+        │       ├── children: []
+        │       └── is_void: false
+        │
+        ├── tag_name: "script" (location: (1:1)-(1:7))
+        ├── body: (1 item)
+        │   └── @ LiteralNode (location: (1:8)-(1:46))
+        │       └── content: "if (something > 3) { alert(\"hello\"); }"
+        │
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:46)-(1:55))
+        │       ├── tag_opening: "</" (location: (1:46)-(1:48))
+        │       ├── tag_name: "script" (location: (1:48)-(1:54))
+        │       └── tag_closing: ">" (location: (1:54)-(1:55))
+        │
+        └── is_void: false

--- a/test/snapshots/parser/tags_test/test_0030_script_tag_with_JavaScript_less_than_comparison_e15b637d8eae8240a61a21ab4fd07798.txt
+++ b/test/snapshots/parser/tags_test/test_0030_script_tag_with_JavaScript_less_than_comparison_e15b637d8eae8240a61a21ab4fd07798.txt
@@ -1,0 +1,23 @@
+@ DocumentNode (location: (1:0)-(1:49))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:49))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:8))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "script" (location: (1:1)-(1:7))
+        │       ├── tag_closing: ">" (location: (1:7)-(1:8))
+        │       ├── children: []
+        │       └── is_void: false
+        │
+        ├── tag_name: "script" (location: (1:1)-(1:7))
+        ├── body: (1 item)
+        │   └── @ LiteralNode (location: (1:8)-(1:40))
+        │       └── content: "if (count < 10) { return true; }"
+        │
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:40)-(1:49))
+        │       ├── tag_opening: "</" (location: (1:40)-(1:42))
+        │       ├── tag_name: "script" (location: (1:42)-(1:48))
+        │       └── tag_closing: ">" (location: (1:48)-(1:49))
+        │
+        └── is_void: false

--- a/test/snapshots/parser/tags_test/test_0031_script_tag_with_HTML-like_string_literals_9287823706422dd5f10c14109bd0bc25.txt
+++ b/test/snapshots/parser/tags_test/test_0031_script_tag_with_HTML-like_string_literals_9287823706422dd5f10c14109bd0bc25.txt
@@ -1,0 +1,23 @@
+@ DocumentNode (location: (1:0)-(1:62))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:62))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:8))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "script" (location: (1:1)-(1:7))
+        │       ├── tag_closing: ">" (location: (1:7)-(1:8))
+        │       ├── children: []
+        │       └── is_void: false
+        │
+        ├── tag_name: "script" (location: (1:1)-(1:7))
+        ├── body: (1 item)
+        │   └── @ LiteralNode (location: (1:8)-(1:53))
+        │       └── content: "var html = \"<div class='test'>content</div>\";"
+        │
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:53)-(1:62))
+        │       ├── tag_opening: "</" (location: (1:53)-(1:55))
+        │       ├── tag_name: "script" (location: (1:55)-(1:61))
+        │       └── tag_closing: ">" (location: (1:61)-(1:62))
+        │
+        └── is_void: false

--- a/test/snapshots/parser/tags_test/test_0034_style_tag_with_nested_div_and_CSS_selectors_78cfabdfd368bd486b01a414bd09cead.txt
+++ b/test/snapshots/parser/tags_test/test_0034_style_tag_with_nested_div_and_CSS_selectors_78cfabdfd368bd486b01a414bd09cead.txt
@@ -1,0 +1,23 @@
+@ DocumentNode (location: (1:0)-(1:48))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:48))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:7))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "style" (location: (1:1)-(1:6))
+        │       ├── tag_closing: ">" (location: (1:6)-(1:7))
+        │       ├── children: []
+        │       └── is_void: false
+        │
+        ├── tag_name: "style" (location: (1:1)-(1:6))
+        ├── body: (1 item)
+        │   └── @ LiteralNode (location: (1:7)-(1:40))
+        │       └── content: "<div>.class { color: red; }</div>"
+        │
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:40)-(1:48))
+        │       ├── tag_opening: "</" (location: (1:40)-(1:42))
+        │       ├── tag_name: "style" (location: (1:42)-(1:47))
+        │       └── tag_closing: ">" (location: (1:47)-(1:48))
+        │
+        └── is_void: false

--- a/test/snapshots/parser/tags_test/test_0035_style_tag_with_CSS_greater_than_selector_aeb1512ea553ab369a3129d25e6677b6.txt
+++ b/test/snapshots/parser/tags_test/test_0035_style_tag_with_CSS_greater_than_selector_aeb1512ea553ab369a3129d25e6677b6.txt
@@ -1,0 +1,23 @@
+@ DocumentNode (location: (1:0)-(1:46))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:46))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:7))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "style" (location: (1:1)-(1:6))
+        │       ├── tag_closing: ">" (location: (1:6)-(1:7))
+        │       ├── children: []
+        │       └── is_void: false
+        │
+        ├── tag_name: "style" (location: (1:1)-(1:6))
+        ├── body: (1 item)
+        │   └── @ LiteralNode (location: (1:7)-(1:38))
+        │       └── content: ".parent > .child { margin: 0; }"
+        │
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:38)-(1:46))
+        │       ├── tag_opening: "</" (location: (1:38)-(1:40))
+        │       ├── tag_name: "style" (location: (1:40)-(1:45))
+        │       └── tag_closing: ">" (location: (1:45)-(1:46))
+        │
+        └── is_void: false

--- a/test/snapshots/parser/tags_test/test_0039_script_tag_with_ERB_interpolation_7d12ef54ba3782ad4d601e7610c7946a.txt
+++ b/test/snapshots/parser/tags_test/test_0039_script_tag_with_ERB_interpolation_7d12ef54ba3782ad4d601e7610c7946a.txt
@@ -1,0 +1,33 @@
+@ DocumentNode (location: (1:0)-(1:82))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:82))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:8))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "script" (location: (1:1)-(1:7))
+        │       ├── tag_closing: ">" (location: (1:7)-(1:8))
+        │       ├── children: []
+        │       └── is_void: false
+        │
+        ├── tag_name: "script" (location: (1:1)-(1:7))
+        ├── body: (3 items)
+        │   ├── @ LiteralNode (location: (1:8)-(1:21))
+        │   │   └── content: "var userId = "
+        │   │
+        │   ├── @ ERBContentNode (location: (1:21)-(1:43))
+        │   │   ├── tag_opening: "<%=" (location: (1:21)-(1:24))
+        │   │   ├── content: " current_user.id " (location: (1:24)-(1:41))
+        │   │   ├── tag_closing: "%>" (location: (1:41)-(1:43))
+        │   │   ├── parsed: true
+        │   │   └── valid: true
+        │   │
+        │   └── @ LiteralNode (location: (1:43)-(1:73))
+        │       └── content: "; if (userId > 0) { login(); }"
+        │
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:73)-(1:82))
+        │       ├── tag_opening: "</" (location: (1:73)-(1:75))
+        │       ├── tag_name: "script" (location: (1:75)-(1:81))
+        │       └── tag_closing: ">" (location: (1:81)-(1:82))
+        │
+        └── is_void: false

--- a/test/snapshots/parser/tags_test/test_0040_style_tag_with_ERB_interpolation_bba0dcc89d67e474bb211be3f0d2409c.txt
+++ b/test/snapshots/parser/tags_test/test_0040_style_tag_with_ERB_interpolation_bba0dcc89d67e474bb211be3f0d2409c.txt
@@ -1,0 +1,43 @@
+@ DocumentNode (location: (1:0)-(1:77))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:77))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:7))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "style" (location: (1:1)-(1:6))
+        │       ├── tag_closing: ">" (location: (1:6)-(1:7))
+        │       ├── children: []
+        │       └── is_void: false
+        │
+        ├── tag_name: "style" (location: (1:1)-(1:6))
+        ├── body: (5 items)
+        │   ├── @ LiteralNode (location: (1:7)-(1:13))
+        │   │   └── content: ".user-"
+        │   │
+        │   ├── @ ERBContentNode (location: (1:13)-(1:27))
+        │   │   ├── tag_opening: "<%=" (location: (1:13)-(1:16))
+        │   │   ├── content: " user.id " (location: (1:16)-(1:25))
+        │   │   ├── tag_closing: "%>" (location: (1:25)-(1:27))
+        │   │   ├── parsed: true
+        │   │   └── valid: true
+        │   │
+        │   ├── @ LiteralNode (location: (1:27)-(1:48))
+        │   │   └── content: " > .content { color: "
+        │   │
+        │   ├── @ ERBContentNode (location: (1:48)-(1:66))
+        │   │   ├── tag_opening: "<%=" (location: (1:48)-(1:51))
+        │   │   ├── content: " theme_color " (location: (1:51)-(1:64))
+        │   │   ├── tag_closing: "%>" (location: (1:64)-(1:66))
+        │   │   ├── parsed: true
+        │   │   └── valid: true
+        │   │
+        │   └── @ LiteralNode (location: (1:66)-(1:69))
+        │       └── content: "; }"
+        │
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:69)-(1:77))
+        │       ├── tag_opening: "</" (location: (1:69)-(1:71))
+        │       ├── tag_name: "style" (location: (1:71)-(1:76))
+        │       └── tag_closing: ">" (location: (1:76)-(1:77))
+        │
+        └── is_void: false


### PR DESCRIPTION
This pull request improves the way the parser handles foreign content within `<script>` and `<style>` tags by treating their content as text content rather than attempting to parse them as HTML. 

The parser previously struggled with common JavaScript and CSS patterns. For example, when encountering JavaScript code like `if (x<10) { console.log("test"); }`, the parser would incorrectly interpret the less-than operator as the start of an HTML tag, leading to parsing errors. 

Similarly, CSS content could also confuse the parser, especially since you are allow to put any content in CSS comments. 

The new implementation introduces an enum-based type system for foreign content, with dedicated handling for script and style elements. When the parser encounters these tags, it switches to a special foreign content parsing mode where all tokens are consumed as literal text until the matching closing tag is found. 

This approach correctly preserves the original content while still supporting ERB interpolation within these sections. The parser now produces a clean AST. 

**Input (from #269)**
```erb
<script>
  // <div> should be ignored
</script>
```

**Before**
```js
@ DocumentNode (location: (1:0)-(3:9))
├── errors: (2 items)
│   ├── @ UnclosedElementError (location: (3:9)-(3:9))
│   │   ├── message: "Tag `<div>` opened at (2:6) was never closed before the end of document."
│   │   └── opening_tag: "div" (location: (2:6)-(2:9))
│   │   
│   └── @ UnclosedElementError (location: (3:9)-(3:9))
│       ├── message: "Tag `<script>` opened at (1:1) was never closed before the end of document."
│       └── opening_tag: "script" (location: (1:1)-(1:7))
│       
│   
└── children: (1 item)
    └── @ HTMLElementNode (location: (1:0)-(1:8))
        ├── errors: (1 item)
        │   └── @ MissingClosingTagError (location: (1:1)-(1:7))
        │       ├── message: "Opening tag `<script>` at (1:1) doesn't have a matching closing tag `</script>`."
        │       └── opening_tag: "script" (location: (1:1)-(1:7))
        │       
        │   
        ├── open_tag: 
        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:8))
        │       ├── errors: []
        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
        │       ├── tag_name: "script" (location: (1:1)-(1:7))
        │       ├── tag_closing: ">" (location: (1:7)-(1:8))
        │       ├── children: []
        │       └── is_void: false
        │       
        ├── tag_name: "script" (location: (1:1)-(1:7))
        ├── body: (2 items)
        │   ├── @ HTMLTextNode (location: (1:8)-(2:5))
        │   │   ├── errors: []
        │   │   └── content: "\n  // "
        │   │   
        │   └── @ HTMLElementNode (location: (2:5)-(3:9))
        │       ├── errors: (1 item)
        │       │   └── @ TagNamesMismatchError (location: (3:2)-(3:8))
        │       │       ├── message: "Opening tag `<div>` at (2:6) closed with `</script>` at (3:2)."
        │       │       ├── opening_tag: "div" (location: (2:6)-(2:9))
        │       │       └── closing_tag: "script" (location: (3:2)-(3:8))
        │       │       
        │       │   
        │       ├── open_tag: 
        │       │   └── @ HTMLOpenTagNode (location: (2:5)-(2:10))
        │       │       ├── errors: []
        │       │       ├── tag_opening: "<" (location: (2:5)-(2:6))
        │       │       ├── tag_name: "div" (location: (2:6)-(2:9))
        │       │       ├── tag_closing: ">" (location: (2:9)-(2:10))
        │       │       ├── children: []
        │       │       └── is_void: false
        │       │       
        │       ├── tag_name: "div" (location: (2:6)-(2:9))
        │       ├── body: (1 item)
        │       │   └── @ HTMLTextNode (location: (2:10)-(3:0))
        │       │       ├── errors: []
        │       │       └── content: " should be ignored\n"
        │       │       
        │       │   
        │       ├── close_tag: 
        │       │   └── @ HTMLCloseTagNode (location: (3:0)-(3:9))
        │       │       ├── errors: []
        │       │       ├── tag_opening: "</" (location: (3:0)-(3:2))
        │       │       ├── tag_name: "script" (location: (3:2)-(3:8))
        │       │       └── tag_closing: ">" (location: (3:8)-(3:9))
        │       │       
        │       └── is_void: false
        │       
        │   
        ├── close_tag: ∅
        └── is_void: false
```

**After**
```js
@ DocumentNode (location: (1:0)-(4:0))
└── children: (2 items)
    ├── @ HTMLElementNode (location: (1:0)-(3:9))
    │   ├── open_tag:
    │   │   └── @ HTMLOpenTagNode (location: (1:0)-(1:8))
    │   │       ├── tag_opening: "<" (location: (1:0)-(1:1))
    │   │       ├── tag_name: "script" (location: (1:1)-(1:7))
    │   │       ├── tag_closing: ">" (location: (1:7)-(1:8))
    │   │       ├── children: []
    │   │       └── is_void: false
    │   │
    │   ├── tag_name: "script" (location: (1:1)-(1:7))
    │   ├── body: (1 item)
    │   │   └── @ LiteralNode (location: (1:8)-(3:0))
    │   │       └── content: "\n  // <div> should be ignored\n"
    │   │
    │   ├── close_tag:
    │   │   └── @ HTMLCloseTagNode (location: (3:0)-(3:9))
    │   │       ├── tag_opening: "</" (location: (3:0)-(3:2))
    │   │       ├── tag_name: "script" (location: (3:2)-(3:8))
    │   │       └── tag_closing: ">" (location: (3:8)-(3:9))
    │   │
    │   └── is_void: false
    │
    └── @ HTMLTextNode (location: (3:9)-(4:0))
        └── content: "\n"
```

Resolves https://github.com/marcoroth/herb/issues/269
Resolves https://github.com/marcoroth/herb/issues/271