### PR TITLE
`--exclude=@herb-tools/tailwind-class-sorter`

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,11 +40,11 @@
     "yeoman-generator": "^7.1.1"
   },
   "scripts": {
-    "dev": "nx run-many -t dev --all --parallel --exclude=herb-language-server",
-    "build": "nx run-many -t build --all --exclude=herb-language-server",
-    "build:affected": "nx affected -t build --exclude=herb-language-server",
-    "test": "nx run-many -t test --all --parallel --exclude=herb-language-server",
-    "test:affected": "nx affected -t test --exclude=herb-language-server",
+    "dev": "nx run-many -t dev --all --parallel --exclude=herb-language-server --exclude=@herb-tools/tailwind-class-sorter",
+    "build": "nx run-many -t build --all --exclude=herb-language-server --exclude=@herb-tools/tailwind-class-sorter",
+    "build:affected": "nx affected -t build --exclude=herb-language-server --exclude=@herb-tools/tailwind-class-sorter",
+    "test": "nx run-many -t test --all --parallel --exclude=herb-language-server --exclude=@herb-tools/tailwind-class-sorter",
+    "test:affected": "nx affected -t test --exclude=herb-language-server --exclude=@herb-tools/tailwind-class-sorter",
     "clean": "nx run-many -t clean --all --parallel && nx reset",
     "playground": "nx run playground:dev",
     "docs": "nx dev docs",


### PR DESCRIPTION
Ever since merging #355 the CI build on main has been flaky and hangs. This pull request excludes the new `@herb-tools/tailwind-class-sorter` package to see if that's actually causing the issue.