### PR TITLE
Formatter: Fix ERB Tag spacing + more tests

### DIFF
--- a/javascript/packages/formatter/src/printer.ts
+++ b/javascript/packages/formatter/src/printer.ts
@@ -1070,12 +1070,7 @@ export class Printer extends Visitor {
   }
 
   visitERBBlockNode(node: ERBBlockNode): void {
-    const indent = this.indent()
-    const open = node.tag_opening?.value ?? ""
-    const content = node.content?.value ?? ""
-    const close = node.tag_closing?.value ?? ""
-
-    this.push(indent + open + content + close)
+    this.printERBNode(node)
 
     this.withIndent(() => {
       node.body.forEach(child => this.visit(child))
@@ -1088,12 +1083,7 @@ export class Printer extends Visitor {
 
   visitERBIfNode(node: ERBIfNode): void {
     if (this.inlineMode) {
-      const open = node.tag_opening?.value ?? ""
-      const content = node.content?.value ?? ""
-      const close = node.tag_closing?.value ?? ""
-      const inner = this.formatERBContent(content)
-
-      this.lines.push(open + inner + close)
+      this.printERBNode(node)
 
       node.statements.forEach((child, _index) => {
         this.lines.push(" ")
@@ -1156,12 +1146,7 @@ export class Printer extends Visitor {
   }
 
   visitERBCaseNode(node: ERBCaseNode): void {
-    const indent = this.indent()
-    const open = node.tag_opening?.value ?? ""
-    const content = node.content?.value ?? ""
-    const close = node.tag_closing?.value ?? ""
-
-    this.push(indent + open + content + close)
+    this.printERBNode(node)
 
     node.conditions.forEach(condition => this.visit(condition))
     if (node.else_clause) this.visit(node.else_clause)
@@ -1172,12 +1157,7 @@ export class Printer extends Visitor {
   }
 
   visitERBBeginNode(node: ERBBeginNode): void {
-    const indent = this.indent()
-    const open = node.tag_opening?.value ?? ""
-    const content = node.content?.value ?? ""
-    const close = node.tag_closing?.value ?? ""
-
-    this.push(indent + open + content + close)
+    this.printERBNode(node)
 
     this.withIndent(() => {
       node.statements.forEach(statement => this.visit(statement))
@@ -1222,12 +1202,7 @@ export class Printer extends Visitor {
 
   // TODO: don't use any
   private visitERBGeneric(node: any): void {
-    const indent = this.indent()
-    const open = node.tag_opening?.value ?? ""
-    const content = node.content?.value ?? ""
-    const close = node.tag_closing?.value ?? ""
-
-    this.push(indent + open + content + close)
+    this.printERBNode(node)
 
     this.withIndent(() => {
       const statements: any[] = node.statements ?? node.body ?? node.children ?? []

--- a/javascript/packages/formatter/test/erb-formatter/erb-formatter-fixtures.test.ts
+++ b/javascript/packages/formatter/test/erb-formatter/erb-formatter-fixtures.test.ts
@@ -273,7 +273,7 @@ describe("ERB Formatter Fixture Tests", () => {
       const result = formatter.format(source)
 
       expect(result).toBe(dedent`
-        <%foo.each do |bar|%>
+        <% foo.each do |bar| %>
           <p><%= baz %></p>
         <% end %>
       `)

--- a/javascript/packages/formatter/test/erb/begin.test.ts
+++ b/javascript/packages/formatter/test/erb/begin.test.ts
@@ -33,4 +33,161 @@ describe("@herb-tools/formatter", () => {
       <% end %>
     `)
   })
+
+  test("formats ERB begin with only rescue", () => {
+    const input = dedent`
+      <% begin %>
+      <%= risky_operation %>
+      <% rescue StandardError => e %>
+      <p>Error: <%= e.message %></p>
+      <% end %>
+    `
+
+    const expected = dedent`
+      <% begin %>
+        <%= risky_operation %>
+      <% rescue StandardError => e %>
+        <p>Error: <%= e.message %></p>
+      <% end %>
+    `
+
+    const output = formatter.format(input)
+    expect(output).toEqual(expected)
+  })
+
+  test("formats ERB begin with rescue and variables", () => {
+    const input = dedent`
+      <% begin %>
+      <%= dangerous_method %>
+      <% rescue => e %>
+      <p>Error: <%= e.message %></p>
+      <% end %>
+    `
+
+    const expected = dedent`
+      <% begin %>
+        <%= dangerous_method %>
+      <% rescue => e %>
+        <p>Error: <%= e.message %></p>
+      <% end %>
+    `
+
+    const output = formatter.format(input)
+    expect(output).toEqual(expected)
+  })
+
+  test("formats ERB begin with ensure only", () => {
+    const input = dedent`
+      <% begin %>
+      <%= some_operation %>
+      <% ensure %>
+      <%= cleanup_operation %>
+      <% end %>
+    `
+
+    const expected = dedent`
+      <% begin %>
+        <%= some_operation %>
+      <% ensure %>
+        <%= cleanup_operation %>
+      <% end %>
+    `
+
+    const output = formatter.format(input)
+    expect(output).toEqual(expected)
+  })
+
+  test("formats ERB begin with rescue/else/ensure", () => {
+    const input = dedent`
+      <% begin %>
+      <%= risky_operation %>
+      <% rescue StandardError => e %>
+      <p>Error occurred: <%= e.message %></p>
+      <% else %>
+      <p>No errors occurred</p>
+      <% ensure %>
+      <%= cleanup_operation %>
+      <% end %>
+    `
+
+    const expected = dedent`
+      <% begin %>
+        <%= risky_operation %>
+      <% rescue StandardError => e %>
+        <p>Error occurred: <%= e.message %></p>
+      <% else %>
+        <p>No errors occurred</p>
+      <% ensure %>
+        <%= cleanup_operation %>
+      <% end %>
+    `
+
+    const output = formatter.format(input)
+    expect(output).toEqual(expected)
+  })
+
+  test("formats ERB begin with typed rescue", () => {
+    const input = dedent`
+      <% begin %>
+      <%= dangerous_operation %>
+      <% rescue ArgumentError => e %>
+      <p>Argument error: <%= e.message %></p>
+      <% end %>
+    `
+
+    const expected = dedent`
+      <% begin %>
+        <%= dangerous_operation %>
+      <% rescue ArgumentError => e %>
+        <p>Argument error: <%= e.message %></p>
+      <% end %>
+    `
+
+    const output = formatter.format(input)
+    expect(output).toEqual(expected)
+  })
+
+  test("formats ERB begin with rescue and else only", () => {
+    const input = dedent`
+      <% begin %>
+      <%= operation %>
+      <% rescue %>
+      <p>Something went wrong</p>
+      <% else %>
+      <p>Everything went well</p>
+      <% end %>
+    `
+
+    const expected = dedent`
+      <% begin %>
+        <%= operation %>
+      <% rescue %>
+        <p>Something went wrong</p>
+      <% else %>
+        <p>Everything went well</p>
+      <% end %>
+    `
+
+    const output = formatter.format(input)
+    expect(output).toEqual(expected)
+  })
+
+  test("begin without surrounding spaces", () => {
+    const input = dedent`
+      <%begin%>
+      <%rescue%>
+      <%ensure%>
+      <%end%>
+    `
+
+    const expected = dedent`
+      <% begin %>
+      <% rescue %>
+      <% ensure %>
+      <% end %>
+    `
+
+    const output = formatter.format(input)
+    expect(output).toEqual(expected)
+  })
 })

--- a/javascript/packages/formatter/test/erb/case.test.ts
+++ b/javascript/packages/formatter/test/erb/case.test.ts
@@ -100,4 +100,46 @@ describe("@herb-tools/formatter", () => {
       <% end %>
     `)
   })
+
+  test("formats ERB case with when and no else", () => {
+    const input = dedent`
+      <% case user_type %>
+      <% when :admin %>
+      <p>Admin Panel</p>
+      <% when :user %>
+      <p>User Dashboard</p>
+      <% end %>
+    `
+
+    const expected = dedent`
+      <% case user_type %>
+      <% when :admin %>
+        <p>Admin Panel</p>
+      <% when :user %>
+        <p>User Dashboard</p>
+      <% end %>
+    `
+
+    const output = formatter.format(input)
+    expect(output).toEqual(expected)
+  })
+
+  test("case without surrounding spaces", () => {
+    const input = dedent`
+      <%case status%>
+      <%when "ok"%>
+      <%else%>
+      <%end%>
+    `
+
+    const expected = dedent`
+      <% case status %>
+      <% when "ok" %>
+      <% else %>
+      <% end %>
+    `
+
+    const output = formatter.format(input)
+    expect(output).toEqual(expected)
+  })
 })

--- a/javascript/packages/formatter/test/erb/for.test.ts
+++ b/javascript/packages/formatter/test/erb/for.test.ts
@@ -28,4 +28,82 @@ describe("@herb-tools/formatter", () => {
       <% end %>
     `)
   })
+
+  test("formats ERB for loop with multiple iterations", () => {
+    const input = dedent`
+      <% for user in @users %>
+      <div class="user">
+      <h3><%= user.name %></h3>
+      <p><%= user.email %></p>
+      </div>
+      <% end %>
+    `
+
+    const expected = dedent`
+      <% for user in @users %>
+        <div class="user">
+          <h3><%= user.name %></h3>
+          <p><%= user.email %></p>
+        </div>
+      <% end %>
+    `
+
+    const output = formatter.format(input)
+    expect(output).toEqual(expected)
+  })
+
+  test("formats ERB for loop with array range", () => {
+    const input = dedent`
+      <% for i in 1..5 %>
+      <span>Number <%= i %></span>
+      <% end %>
+    `
+
+    const expected = dedent`
+      <% for i in 1..5 %>
+        <span>Number <%= i %></span>
+      <% end %>
+    `
+
+    const output = formatter.format(input)
+    expect(output).toEqual(expected)
+  })
+
+  test("formats nested for loops", () => {
+    const input = dedent`
+      <% for category in categories %>
+      <h2><%= category.name %></h2>
+      <% for product in category.products %>
+      <p><%= product.name %> - $<%= product.price %></p>
+      <% end %>
+      <% end %>
+    `
+
+    const expected = dedent`
+      <% for category in categories %>
+        <h2><%= category.name %></h2>
+        <% for product in category.products %>
+          <p><%= product.name %> - $<%= product.price %></p>
+        <% end %>
+      <% end %>
+    `
+
+    const output = formatter.format(input)
+    expect(output).toEqual(expected)
+  })
+
+  test("for without surrounding spaces", () => {
+    const input = dedent`
+      <%for item in items%>
+      <%end%>
+    `
+
+    const expected = dedent`
+      <% for item in items %>
+      <% end %>
+    `
+
+    const output = formatter.format(input)
+    expect(output).toEqual(expected)
+  })
 })

--- a/javascript/packages/formatter/test/erb/if.test.ts
+++ b/javascript/packages/formatter/test/erb/if.test.ts
@@ -60,6 +60,56 @@ describe("@herb-tools/formatter", () => {
     expect(output).toEqual(expected)
   })
 
+  test("formats ERB if/elsif/else statement", () => {
+    const input = dedent`
+      <% if user.admin? %>
+      <p>Admin content</p>
+      <% elsif user.moderator? %>
+      <p>Moderator content</p>
+      <% elsif user.member? %>
+      <p>Member content</p>
+      <% else %>
+      <p>Guest content</p>
+      <% end %>
+    `
+
+    const expected = dedent`
+      <% if user.admin? %>
+        <p>Admin content</p>
+      <% elsif user.moderator? %>
+        <p>Moderator content</p>
+      <% elsif user.member? %>
+        <p>Member content</p>
+      <% else %>
+        <p>Guest content</p>
+      <% end %>
+    `
+
+    const output = formatter.format(input)
+    expect(output).toEqual(expected)
+  })
+
+  test("formats ERB if with only elsif", () => {
+    const input = dedent`
+      <% if condition_1 %>
+      <p>First condition</p>
+      <% elsif condition_2 %>
+      <p>Second condition</p>
+      <% end %>
+    `
+
+    const expected = dedent`
+      <% if condition_1 %>
+        <p>First condition</p>
+      <% elsif condition_2 %>
+        <p>Second condition</p>
+      <% end %>
+    `
+
+    const output = formatter.format(input)
+    expect(output).toEqual(expected)
+  })
+
   test("if without surrounding spaces", () => {
     const input = dedent`
       <%if user.admin?%>

--- a/javascript/packages/formatter/test/erb/until.test.ts
+++ b/javascript/packages/formatter/test/erb/until.test.ts
@@ -28,4 +28,65 @@ describe("@herb-tools/formatter", () => {
       <% end %>
     `)
   })
+
+  test("formats ERB until with complex condition", () => {
+    const input = dedent`
+      <% until queue.empty? || max_attempts_reached? %>
+      <p>Processing item: <%= queue.peek.name %></p>
+      <% process_queue_item %>
+      <% end %>
+    `
+
+    const expected = dedent`
+      <% until queue.empty? || max_attempts_reached? %>
+        <p>Processing item: <%= queue.peek.name %></p>
+        <% process_queue_item %>
+      <% end %>
+    `
+
+    const output = formatter.format(input)
+    expect(output).toEqual(expected)
+  })
+
+  test("formats nested until loops", () => {
+    const input = dedent`
+      <% until outer_condition_met? %>
+      <div>Outer loop iteration</div>
+      <% until inner_condition_met? %>
+      <span>Inner loop iteration</span>
+      <% inner_increment %>
+      <% end %>
+      <% outer_increment %>
+      <% end %>
+    `
+
+    const expected = dedent`
+      <% until outer_condition_met? %>
+        <div>Outer loop iteration</div>
+        <% until inner_condition_met? %>
+          <span>Inner loop iteration</span>
+          <% inner_increment %>
+        <% end %>
+        <% outer_increment %>
+      <% end %>
+    `
+
+    const output = formatter.format(input)
+    expect(output).toEqual(expected)
+  })
+
+  test("until without surrounding spaces", () => {
+    const input = dedent`
+      <%until condition%>
+      <%end%>
+    `
+
+    const expected = dedent`
+      <% until condition %>
+      <% end %>
+    `
+
+    const output = formatter.format(input)
+    expect(output).toEqual(expected)
+  })
 })

--- a/javascript/packages/formatter/test/erb/while.test.ts
+++ b/javascript/packages/formatter/test/erb/while.test.ts
@@ -28,4 +28,67 @@ describe("@herb-tools/formatter", () => {
       <% end %>
     `)
   })
+
+  test("formats ERB while with complex condition", () => {
+    const input = dedent`
+      <% while user.active? && user.posts.count < 10 %>
+      <p>Processing <%= user.name %></p>
+      <% user.process_next_post %>
+      <% end %>
+    `
+
+    const expected = dedent`
+      <% while user.active? && user.posts.count < 10 %>
+        <p>Processing <%= user.name %></p>
+        <% user.process_next_post %>
+      <% end %>
+    `
+
+    const output = formatter.format(input)
+    expect(output).toEqual(expected)
+  })
+
+  test("formats nested while loops", () => {
+    const input = dedent`
+      <% while i < 3 %>
+      <div>Outer: <%= i %></div>
+      <% j = 0 %>
+      <% while j < 2 %>
+      <span>Inner: <%= j %></span>
+      <% j += 1 %>
+      <% end %>
+      <% i += 1 %>
+      <% end %>
+    `
+
+    const expected = dedent`
+      <% while i < 3 %>
+        <div>Outer: <%= i %></div>
+        <% j = 0 %>
+        <% while j < 2 %>
+          <span>Inner: <%= j %></span>
+          <% j += 1 %>
+        <% end %>
+        <% i += 1 %>
+      <% end %>
+    `
+
+    const output = formatter.format(input)
+    expect(output).toEqual(expected)
+  })
+
+  test("while without surrounding spaces", () => {
+    const input = dedent`
+      <%while condition%>
+      <%end%>
+    `
+
+    const expected = dedent`
+      <% while condition %>
+      <% end %>
+    `
+
+    const output = formatter.format(input)
+    expect(output).toEqual(expected)
+  })
 })


### PR DESCRIPTION
This pull request refactors the printing of the ERB nodes to use the `this.printERBNode` function over the manual calls in the formatter. This now also more consistently adds whitespace around the Ruby content in ERB tags in all cases.

Previously this wasn't handled:

**Input:**
```erb
<%foo.each do |bar|%>
  <p><%=baz%></p>
<%end%>
```

**Before:**
```erb
<%foo.each do |bar|%>
  <p><%= baz %></p>
<% end %>
```


**After:**
```erb
<% foo.each do |bar| %>
  <p><%= baz %></p>
<% end %>
```

Additionally, it adds some more tests to avoid any regression.
        
          
        