### PR TITLE
Playground: Add Copy Buttons for editor and result and add overlays

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -88,6 +88,15 @@
 
               <div class="flex gap-3 mt-2 lg:mt-0">
                 <button
+                  data-action="click->playground#copyEditorContent"
+                  class="text-gray-900 dark:text-gray-100 bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700 rounded-md px-3 py-1.5 text-sm font-medium"
+                >
+                  <i class="fas fa-copy"></i>
+                  <i class="fas fa-circle-check text-green-600 hidden ease-in duration-300"></i>
+                  <span class="ml-1">Copy</span>
+                </button>
+
+                <button
                   data-action="click->playground#share"
                   id="copy-share-url"
                   class="text-gray-900 dark:text-gray-100 bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700 rounded-md px-3 py-1.5 text-sm font-medium"
@@ -168,9 +177,17 @@
           <div class="mt-6" data-contoller="output">
             <div class="lg:flex justify-between">
               <div
-                class="text-gray-900 dark:text-gray-100 rounded-md px-0 py-1.5 text-sm font-medium"
+                class="text-gray-900 dark:text-gray-100 rounded-md px-0 py-1.5 text-sm font-medium flex items-center gap-3"
               >
-                Herb Result
+                <span>Herb Result</span>
+                <button
+                  data-action="click->playground#copyViewerContent"
+                  class="text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 text-sm"
+                  title="Copy current panel content"
+                >
+                  <i class="fas fa-copy"></i>
+                  <i class="fas fa-circle-check text-green-600 hidden ease-in duration-300"></i>
+                </button>
               </div>
 
               <div class="mt-1 md:mt-0 md:flex gap-3">
@@ -295,13 +312,12 @@
                 class="hidden w-full p-3 mb-3 rounded overflow-auto font-mono bg-[#282c34] text-[#dcdfe4] highlight h-[50vh] md:h-[calc(100vh-110px)] overflow-scroll"
               ></pre>
 
-              <pre
-                style="white-space: pre; line-height: 1.3"
+              <div
                 data-viewer-target="format"
                 data-playground-target="formatViewer"
                 data-action="click->playground#shrinkViewer"
-                class="hidden w-full p-3 mb-3 rounded overflow-auto font-mono bg-[#282c34] text-[#dcdfe4] highlight h-[50vh] md:h-[calc(100vh-110px)] overflow-scroll"
-              ></pre>
+                class="hidden w-full mb-3 rounded overflow-auto bg-[#282c34] h-[50vh] md:h-[calc(100vh-110px)] overflow-scroll"
+              ></div>
 
               <pre
                 style="white-space: pre; line-height: 1.3"
@@ -315,11 +331,19 @@
                 data-viewer-target="diagnostics"
                 data-playground-target="linterViewer"
                 data-action="click->playground#shrinkViewer"
-                class="hidden w-full p-3 mb-3 rounded overflow-auto bg-[#282c34] text-[#dcdfe4] h-[50vh] md:h-[calc(100vh-110px)] overflow-scroll"
+                class="hidden w-full mb-3 rounded overflow-auto bg-[#282c34] text-[#dcdfe4] h-[50vh] md:h-[calc(100vh-110px)] overflow-scroll"
               >
-                <div data-playground-target="linterContent">
-                  <div class="text-center text-gray-500 dark:text-gray-400 py-8">
-                    No diagnostics to display
+                <div data-playground-target="linterContent" class="h-full p-3">
+                  <div class="relative h-full overflow-hidden">
+                    <div class="absolute inset-0 flex items-center justify-center z-10">
+                      <div class="bg-gray-700 border border-gray-500 rounded-lg p-6 text-center">
+                        <i class="fas fa-circle-check text-green-400 text-2xl mb-3"></i>
+                        <h3 class="text-lg font-semibold text-gray-100 mb-2">No Issues Found</h3>
+                        <p class="text-gray-300 text-sm">
+                          No diagnostics to display
+                        </p>
+                      </div>
+                    </div>
                   </div>
                 </div>
               </div>

--- a/playground/index.html
+++ b/playground/index.html
@@ -317,7 +317,36 @@
                 data-playground-target="formatViewer"
                 data-action="click->playground#shrinkViewer"
                 class="hidden w-full mb-3 rounded overflow-auto bg-[#282c34] h-[50vh] md:h-[calc(100vh-110px)] overflow-scroll"
-              ></div>
+              >
+                <pre 
+                  data-playground-target="formatSuccess"
+                  class="w-full h-full p-3 m-0 rounded overflow-auto font-mono bg-[#282c34] text-[#dcdfe4] language-html highlight"
+                  style="white-space: pre; line-height: 1.3"
+                ></pre>
+
+                <div data-playground-target="formatError" class="hidden relative h-full overflow-hidden">
+                  <pre 
+                    class="absolute inset-0 blur-md opacity-30 overflow-auto p-3 m-0 font-mono text-[#dcdfe4] language-html" 
+                    style="white-space: pre; line-height: 1.3"
+                  ></pre>
+                  <div class="absolute inset-0 bg-gray-800/70 backdrop-blur-md flex items-center justify-center z-10 rounded">
+                    <div class="bg-gray-700 border border-gray-500 rounded-lg p-6 text-center">
+                      <i class="fas fa-exclamation-triangle text-yellow-400 text-2xl mb-3"></i>
+                      <h3 class="text-lg font-semibold text-gray-100 mb-2">Formatting Unavailable</h3>
+                      <p class="text-gray-300 text-sm">
+                        Cannot format code due to syntax errors.
+                      </p>
+                      <p class="text-gray-300 text-sm mt-2">
+                        Fix errors in
+                        <button class="text-blue-400 hover:text-blue-300 underline" onclick="this.closest('[data-controller*=playground]').querySelector('[data-playground-target=diagnosticStatus]').click()">
+                          Diagnostics
+                        </button>
+                        tab first.
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
 
               <pre
                 style="white-space: pre; line-height: 1.3"
@@ -329,12 +358,12 @@
 
               <div
                 data-viewer-target="diagnostics"
-                data-playground-target="linterViewer"
+                data-playground-target="diagnosticsViewer"
                 data-action="click->playground#shrinkViewer"
                 class="hidden w-full mb-3 rounded overflow-auto bg-[#282c34] text-[#dcdfe4] h-[50vh] md:h-[calc(100vh-110px)] overflow-scroll"
               >
-                <div data-playground-target="linterContent" class="h-full p-3">
-                  <div class="relative h-full overflow-hidden">
+                <div data-playground-target="diagnosticsContent" class="h-full p-3">
+                  <div data-playground-target="noDiagnostics" class="relative h-full overflow-hidden">
                     <div class="absolute inset-0 flex items-center justify-center z-10">
                       <div class="bg-gray-700 border border-gray-500 rounded-lg p-6 text-center">
                         <i class="fas fa-circle-check text-green-400 text-2xl mb-3"></i>
@@ -344,6 +373,9 @@
                         </p>
                       </div>
                     </div>
+                  </div>
+
+                  <div data-playground-target="diagnosticsList" class="hidden">
                   </div>
                 </div>
               </div>

--- a/playground/src/controllers/playground_controller.js
+++ b/playground/src/controllers/playground_controller.js
@@ -75,6 +75,10 @@ export default class extends Controller {
       document.documentElement.classList.add('dark')
     }
 
+    document.querySelectorAll('.fa-circle-check').forEach(icon => {
+      icon.style.display = 'none'
+    })
+
     this.restoreInput()
     this.restoreActiveTab()
     this.restoreParserOptions()
@@ -213,6 +217,126 @@ export default class extends Controller {
       button.querySelector(".fa-circle-xmark").classList.add("hidden")
       button.querySelector(".fa-circle-check").classList.add("hidden")
     }, 1000)
+  }
+
+  async copyEditorContent(event) {
+    const button = this.getClosestButton(event.target)
+    const content = this.editor ? this.editor.getValue() : this.inputTarget.value
+
+    try {
+      await navigator.clipboard.writeText(content)
+      this.showCopySuccessFixed(button)
+    } catch (error) {
+      console.error('Failed to copy editor content:', error)
+    }
+  }
+
+  async copyViewerContent(event) {
+    const button = this.getClosestButton(event.target)
+    const activeViewer = this.activeViewerButton.dataset.viewer
+    let content = ''
+
+    switch(activeViewer) {
+      case 'parse':
+        content = this.parseViewerTarget.textContent
+        break
+      case 'lex':
+        content = this.lexViewerTarget.textContent
+        break
+      case 'ruby':
+        content = this.rubyViewerTarget.textContent
+        break
+      case 'html':
+        content = this.htmlViewerTarget.textContent
+        break
+      case 'format':
+        const formatPre = this.formatViewerTarget.querySelector('pre')
+        content = formatPre ? formatPre.textContent : ''
+        break
+      case 'diagnostics':
+        content = this.getDiagnosticsAsText()
+        break
+    }
+
+    if (content) {
+      try {
+        await navigator.clipboard.writeText(content)
+        this.showCopySuccessFixed(button)
+      } catch (error) {
+        console.error('Failed to copy viewer content:', error)
+      }
+    }
+  }
+
+  showCopySuccessFixed(button) {
+    const allIcons = button.querySelectorAll('svg, i')
+
+    let copyIcon = null
+    let checkIcon = null
+
+    allIcons.forEach(icon => {
+      if (icon.classList.contains('fa-copy')) {
+        copyIcon = icon
+      } else if (icon.classList.contains('fa-circle-check')) {
+        checkIcon = icon
+      }
+    })
+
+    if (!copyIcon || !checkIcon) {
+      console.error('Icons not found', { copyIcon, checkIcon })
+      return
+    }
+
+    if (this.copyTimeout) {
+      clearTimeout(this.copyTimeout)
+    }
+
+    copyIcon.style.display = 'none'
+    checkIcon.style.display = 'inline-block'
+
+    this.copyTimeout = setTimeout(() => {
+      copyIcon.style.display = 'inline-block'
+      checkIcon.style.display = 'none'
+      this.copyTimeout = null
+    }, 1000)
+  }
+
+  showCopySuccess(button) {
+    const copyIcon = button.querySelector('.fa-copy, svg.fa-copy')
+    const checkIcon = button.querySelector('.fa-circle-check, svg.fa-circle-check')
+
+    if (!copyIcon || !checkIcon) return
+
+    if (this.copyTimeout) {
+      clearTimeout(this.copyTimeout)
+    }
+
+    checkIcon.classList.add('hidden')
+    checkIcon.classList.remove('hidden')
+    copyIcon.classList.add('hidden')
+
+    this.copyTimeout = setTimeout(() => {
+      copyIcon.classList.remove('hidden')
+      checkIcon.classList.add('hidden')
+      this.copyTimeout = null
+    }, 1000)
+  }
+
+  getDiagnosticsAsText() {
+    const diagnosticItems = this.linterContentTarget.querySelectorAll('.diagnostic-item')
+
+    if (diagnosticItems.length === 0) {
+      return 'No diagnostics to display'
+    }
+
+    let text = 'Diagnostics:\n\n'
+    diagnosticItems.forEach(item => {
+      const message = item.querySelector('.text-sm.font-medium').textContent.trim()
+      const location = item.querySelector('.text-xs.text-gray-400').textContent.trim()
+      text += `• ${message}\n  ${location}\n\n`
+    })
+
+    return text
   }
 
   restoreInput() {
@@ -449,7 +573,7 @@ export default class extends Controller {
     }
 
     // Filter out parser-no-errors diagnostics for both editor and status display
-    const filteredDiagnosticsForEditor = allDiagnostics.filter(diagnostic => 
+    const filteredDiagnosticsForEditor = allDiagnostics.filter(diagnostic =>
       diagnostic.code !== 'parser-no-errors'
     )
 
@@ -549,10 +673,50 @@ export default class extends Controller {
     }
 
     if (this.hasFormatViewerTarget) {
-      this.formatViewerTarget.classList.add("language-html")
-      this.formatViewerTarget.textContent = result.formatted
+      // Check if there are any errors that would prevent proper formatting
+      const hasErrors = filteredDiagnosticsForEditor.some(diagnostic => diagnostic.severity === "error")
 
-      Prism.highlightElement(this.formatViewerTarget)
+      if (hasErrors) {
+        // Show overlay with blurred formatted content
+        this.formatViewerTarget.innerHTML = `
+          <div class="relative h-full overflow-hidden">
+            <pre class="absolute inset-0 blur-md opacity-30 overflow-auto p-3 m-0 font-mono text-[#dcdfe4] language-html" style="white-space: pre; line-height: 1.3">${this.escapeHtml(result.formatted || 'No formatted output available')}</pre>
+            <div class="absolute inset-0 bg-gray-800/70 backdrop-blur-md flex items-center justify-center z-10 rounded">
+              <div class="bg-gray-700 border border-gray-500 rounded-lg p-6 text-center">
+                <i class="fas fa-exclamation-triangle text-yellow-400 text-2xl mb-3"></i>
+                <h3 class="text-lg font-semibold text-gray-100 mb-2">Formatting Unavailable</h3>
+                <p class="text-gray-300 text-sm">
+                  Cannot format code due to syntax errors.
+                </p>
+                <p class="text-gray-300 text-sm mt-2">
+                  Fix errors in
+                  <button class="text-blue-400 hover:text-blue-300 underline" onclick="this.closest('[data-controller*=playground]').querySelector('[data-playground-target=diagnosticStatus]').click()">
+                    Diagnostics
+                  </button>
+                  tab first.
+                </p>
+              </div>
+            </div>
+          </div>
+        `
+
+        // Apply syntax highlighting to the blurred pre
+        const blurredPre = this.formatViewerTarget.querySelector('pre.language-html')
+        if (blurredPre) {
+          Prism.highlightElement(blurredPre)
+        }
+      } else {
+        // Show normal formatted content in a pre element
+        this.formatViewerTarget.innerHTML = ''
+
+        const pre = document.createElement('pre')
+        pre.className = 'w-full h-full p-3 m-0 rounded overflow-auto font-mono bg-[#282c34] text-[#dcdfe4] language-html highlight'
+        pre.style.cssText = 'white-space: pre; line-height: 1.3'
+        pre.textContent = result.formatted || 'No formatted output available'
+
+        this.formatViewerTarget.appendChild(pre)
+        Prism.highlightElement(pre)
+      }
     }
 
     if (this.hasRubyViewerTarget) {
@@ -658,14 +822,22 @@ export default class extends Controller {
 
   updateLinterViewer(diagnostics) {
     // Filter out parser-no-errors diagnostics
-    const filteredDiagnostics = diagnostics.filter(diagnostic => 
+    const filteredDiagnostics = diagnostics.filter(diagnostic =>
       diagnostic.code !== 'parser-no-errors'
     )
 
     if (filteredDiagnostics.length === 0) {
       this.linterContentTarget.innerHTML = `
-        <div class="text-center text-gray-400 py-8">
-          No diagnostics to display
+        <div class="relative h-full overflow-hidden">
+          <div class="absolute inset-0 flex items-center justify-center z-10">
+            <div class="bg-gray-700 border border-gray-500 rounded-lg p-6 text-center">
+              <i class="fas fa-circle-check text-green-400 text-2xl mb-3"></i>
+              <h3 class="text-lg font-semibold text-gray-100 mb-2">No Issues Found</h3>
+              <p class="text-gray-300 text-sm">
+                No diagnostics to display
+              </p>
+            </div>
+          </div>
         </div>
       `
       return
@@ -676,7 +848,7 @@ export default class extends Controller {
         const lineA = a.line || a.startLineNumber || 1
         const lineB = b.line || b.startLineNumber || 1
         if (lineA !== lineB) return lineA - lineB
-        
+
         const colA = a.column || a.startColumn || 0
         const colB = b.column || b.startColumn || 0
         return colA - colB
@@ -710,7 +882,7 @@ export default class extends Controller {
         const endColumn = (diagnostic.endColumn || diagnostic.endColumn || diagnostic.column || 0) + 1
 
         groupHtml += `
-          <div 
+          <div
             class="p-3 border rounded-lg cursor-pointer bg-gray-700 hover:border-gray-400 border-gray-500 diagnostic-item transition-colors duration-150"
             data-diagnostic-index="${index}"
             data-start-line="${startLine}"
@@ -753,7 +925,7 @@ export default class extends Controller {
     )
 
     html += renderDiagnosticGroup(
-      'Warnings', 
+      'Warnings',
       diagnosticsByType.warning,
       'fas fa-triangle-exclamation text-yellow-400',
       'text-yellow-400'
@@ -762,7 +934,7 @@ export default class extends Controller {
     html += renderDiagnosticGroup(
       'Info',
       diagnosticsByType.info,
-      'fas fa-info-circle text-blue-400', 
+      'fas fa-info-circle text-blue-400',
       'text-blue-400'
     )
 


### PR DESCRIPTION
This pull request adds two new buttons to to copy the content of the editor (on the left side) and to copy the result of the current tab (on the right side).


https://github.com/user-attachments/assets/d9e56a46-1a72-451a-841a-a848a6045aad


Additionally we have two new overlays to show that the formatter isn't formatting when there are errors in the document:

<img width="3396" height="1724" alt="CleanShot 2025-08-21 at 12 55 42@2x" src="https://github.com/user-attachments/assets/9085aa9d-1661-4da4-8fda-10e9260f5c85" />

And if there are now diagnostics we show that too:


<img width="3396" height="1724" alt="CleanShot 2025-08-21 at 12 56 02@2x" src="https://github.com/user-attachments/assets/21aaba5f-d67e-41ea-b349-3e8f074cebaf" />
