### PR TITLE
Remove `HTMLSelfCloseTagNode`

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -222,23 +222,6 @@ nodes:
         - name: tag_closing
           type: token
 
-    - name: HTMLSelfCloseTagNode
-      fields:
-        - name: tag_opening
-          type: token
-
-        - name: tag_name
-          type: token
-
-        - name: attributes
-          type: array
-          kind: HTMLAttributeNode
-
-        - name: tag_closing
-          type: token
-
-        - name: is_void
-          type: boolean
 
     - name: HTMLElementNode
       fields:

--- a/javascript/packages/formatter/src/printer.ts
+++ b/javascript/packages/formatter/src/printer.ts
@@ -5,7 +5,6 @@ import {
   DocumentNode,
   HTMLOpenTagNode,
   HTMLCloseTagNode,
-  HTMLSelfCloseTagNode,
   HTMLElementNode,
   HTMLAttributeNode,
   HTMLAttributeValueNode,
@@ -828,34 +827,6 @@ export class Printer extends Visitor {
     this.renderMultilineAttributes(tagName, attributes, inlineNodes, node.children, false, node.is_void, false)
   }
 
-  visitHTMLSelfCloseTagNode(node: HTMLSelfCloseTagNode): void {
-    const tagName = node.tag_name?.value ?? ""
-    const indent = this.indent()
-
-    const attributes = this.extractAttributes(node.attributes)
-    const inlineNodes = this.extractInlineNodes(node.attributes)
-
-    const inline = this.renderInlineOpen(tagName, attributes, true, inlineNodes, node.attributes)
-    const totalAttributeCount = this.getTotalAttributeCount(attributes, inlineNodes)
-    const shouldKeepInline = this.shouldRenderInline(
-      totalAttributeCount,
-      inline.length,
-      indent.length,
-      this.maxLineLength,
-      false,
-      0,
-      inlineNodes.length,
-      this.hasMultilineAttributes(attributes)
-    )
-
-    if (shouldKeepInline) {
-      this.push(indent + inline)
-
-      return
-    }
-
-    this.renderMultilineAttributes(tagName, attributes, inlineNodes, node.attributes, true, false, false)
-  }
 
   visitHTMLCloseTagNode(node: HTMLCloseTagNode): void {
     const indent = this.indent()

--- a/javascript/packages/linter/src/rules/erb-prefer-image-tag-helper.ts
+++ b/javascript/packages/linter/src/rules/erb-prefer-image-tag-helper.ts
@@ -2,7 +2,7 @@ import { BaseRuleVisitor, getTagName, findAttributeByName, getAttributes } from 
 
 import { ParserRule } from "../types.js"
 import type { LintOffense, LintContext } from "../types.js"
-import type { HTMLOpenTagNode, HTMLSelfCloseTagNode, HTMLAttributeValueNode, ERBContentNode, LiteralNode, ParseResult } from "@herb-tools/core"
+import type { HTMLOpenTagNode, HTMLAttributeValueNode, ERBContentNode, LiteralNode, ParseResult } from "@herb-tools/core"
 
 class ERBPreferImageTagHelperVisitor extends BaseRuleVisitor {
   visitHTMLOpenTagNode(node: HTMLOpenTagNode): void {
@@ -10,12 +10,7 @@ class ERBPreferImageTagHelperVisitor extends BaseRuleVisitor {
     super.visitHTMLOpenTagNode(node)
   }
 
-  visitHTMLSelfCloseTagNode(node: HTMLSelfCloseTagNode): void {
-    this.checkImgTag(node)
-    super.visitHTMLSelfCloseTagNode(node)
-  }
-
-  private checkImgTag(node: HTMLOpenTagNode | HTMLSelfCloseTagNode): void {
+  private checkImgTag(node: HTMLOpenTagNode): void {
     const tagName = getTagName(node)
 
     if (tagName !== "img") {

--- a/javascript/packages/linter/src/rules/html-img-require-alt.ts
+++ b/javascript/packages/linter/src/rules/html-img-require-alt.ts
@@ -2,7 +2,7 @@ import { BaseRuleVisitor, getTagName, hasAttribute } from "./rule-utils.js"
 
 import { ParserRule } from "../types.js"
 import type { LintOffense, LintContext } from "../types.js"
-import type { HTMLOpenTagNode, HTMLSelfCloseTagNode, ParseResult } from "@herb-tools/core"
+import type { HTMLOpenTagNode, ParseResult } from "@herb-tools/core"
 
 class ImgRequireAltVisitor extends BaseRuleVisitor {
   visitHTMLOpenTagNode(node: HTMLOpenTagNode): void {
@@ -10,12 +10,7 @@ class ImgRequireAltVisitor extends BaseRuleVisitor {
     super.visitHTMLOpenTagNode(node)
   }
 
-  visitHTMLSelfCloseTagNode(node: HTMLSelfCloseTagNode): void {
-    this.checkImgTag(node)
-    super.visitHTMLSelfCloseTagNode(node)
-  }
-
-  private checkImgTag(node: HTMLOpenTagNode | HTMLSelfCloseTagNode): void {
+  private checkImgTag(node: HTMLOpenTagNode): void {
     const tagName = getTagName(node)
 
     if (tagName !== "img") {

--- a/javascript/packages/linter/src/rules/html-no-duplicate-attributes.ts
+++ b/javascript/packages/linter/src/rules/html-no-duplicate-attributes.ts
@@ -2,7 +2,7 @@ import { ParserRule } from "../types.js"
 import { AttributeVisitorMixin, StaticAttributeStaticValueParams, StaticAttributeDynamicValueParams } from "./rule-utils.js"
 
 import type { LintOffense, LintContext } from "../types.js"
-import type { HTMLOpenTagNode, HTMLSelfCloseTagNode, HTMLAttributeNode, ParseResult } from "@herb-tools/core"
+import type { HTMLOpenTagNode, HTMLAttributeNode, ParseResult } from "@herb-tools/core"
 
 class NoDuplicateAttributesVisitor extends AttributeVisitorMixin {
   private attributeNames = new Map<string, HTMLAttributeNode[]>()
@@ -13,11 +13,6 @@ class NoDuplicateAttributesVisitor extends AttributeVisitorMixin {
     this.reportDuplicates()
   }
 
-  visitHTMLSelfCloseTagNode(node: HTMLSelfCloseTagNode): void {
-    this.attributeNames.clear()
-    super.visitHTMLSelfCloseTagNode(node)
-    this.reportDuplicates()
-  }
 
   protected checkStaticAttributeStaticValue({ attributeName, attributeNode }: StaticAttributeStaticValueParams): void {
     this.trackAttributeName(attributeName, attributeNode)

--- a/javascript/packages/linter/src/rules/html-no-empty-headings.ts
+++ b/javascript/packages/linter/src/rules/html-no-empty-headings.ts
@@ -2,7 +2,7 @@ import { BaseRuleVisitor, getTagName, getAttributes, findAttributeByName, getAtt
 
 import { ParserRule } from "../types.js"
 import type { LintOffense, LintContext } from "../types.js"
-import type { HTMLElementNode, HTMLOpenTagNode, HTMLSelfCloseTagNode, ParseResult, LiteralNode, HTMLTextNode } from "@herb-tools/core"
+import type { HTMLElementNode, HTMLOpenTagNode, ParseResult, LiteralNode, HTMLTextNode } from "@herb-tools/core"
 
 class NoEmptyHeadingsVisitor extends BaseRuleVisitor {
   visitHTMLElementNode(node: HTMLElementNode): void {
@@ -10,10 +10,6 @@ class NoEmptyHeadingsVisitor extends BaseRuleVisitor {
     super.visitHTMLElementNode(node)
   }
 
-  visitHTMLSelfCloseTagNode(node: HTMLSelfCloseTagNode): void {
-    this.checkSelfClosingHeading(node)
-    super.visitHTMLSelfCloseTagNode(node)
-  }
 
   private checkHeadingElement(node: HTMLElementNode): void {
     if (!node.open_tag || node.open_tag.type !== "AST_HTML_OPEN_TAG_NODE") {
@@ -47,31 +43,6 @@ class NoEmptyHeadingsVisitor extends BaseRuleVisitor {
     }
   }
 
-  private checkSelfClosingHeading(node: HTMLSelfCloseTagNode): void {
-    const tagName = getTagName(node)
-    if (!tagName) {
-      return
-    }
-
-    // Check if it's a standard heading tag (h1-h6) or has role="heading"
-    const isStandardHeading = HEADING_TAGS.has(tagName)
-    const isAriaHeading = this.hasHeadingRole(node)
-
-    if (!isStandardHeading && !isAriaHeading) {
-      return
-    }
-
-    // Self-closing headings are always empty
-    const elementDescription = isStandardHeading
-      ? `\`<${tagName}>\``
-      : `\`<${tagName} role="heading">\``
-
-    this.addOffense(
-      `Heading element ${elementDescription} must not be empty. Provide accessible text content for screen readers and SEO.`,
-      node.tag_name!.location,
-      "error"
-    )
-  }
 
   private isEmptyHeading(node: HTMLElementNode): boolean {
     if (!node.body || node.body.length === 0) {
@@ -114,7 +85,7 @@ class NoEmptyHeadingsVisitor extends BaseRuleVisitor {
     return !hasAccessibleContent
   }
 
-  private hasHeadingRole(node: HTMLOpenTagNode | HTMLSelfCloseTagNode): boolean {
+  private hasHeadingRole(node: HTMLOpenTagNode): boolean {
     const attributes = getAttributes(node)
     const roleAttribute = findAttributeByName(attributes, "role")
 

--- a/javascript/packages/linter/src/rules/html-tag-name-lowercase.ts
+++ b/javascript/packages/linter/src/rules/html-tag-name-lowercase.ts
@@ -2,7 +2,7 @@ import { BaseRuleVisitor } from "./rule-utils.js"
 
 import { ParserRule } from "../types.js"
 import type { LintOffense, LintContext } from "../types.js"
-import type { HTMLElementNode, HTMLOpenTagNode, HTMLCloseTagNode, HTMLSelfCloseTagNode, ParseResult } from "@herb-tools/core"
+import type { HTMLElementNode, HTMLOpenTagNode, HTMLCloseTagNode, ParseResult } from "@herb-tools/core"
 
 class TagNameLowercaseVisitor extends BaseRuleVisitor {
   visitHTMLElementNode(node: HTMLElementNode): void {
@@ -27,12 +27,7 @@ class TagNameLowercaseVisitor extends BaseRuleVisitor {
     }
   }
 
-  visitHTMLSelfCloseTagNode(node: HTMLSelfCloseTagNode): void {
-    this.checkTagName(node)
-    this.visitChildNodes(node)
-  }
-
-  private checkTagName(node: HTMLOpenTagNode | HTMLCloseTagNode | HTMLSelfCloseTagNode): void {
+  private checkTagName(node: HTMLOpenTagNode | HTMLCloseTagNode): void {
     const tagName = node.tag_name?.value
 
     if (!tagName) return
@@ -44,7 +39,6 @@ class TagNameLowercaseVisitor extends BaseRuleVisitor {
 
       if (node.type == "AST_HTML_OPEN_TAG_NODE") type = "Opening"
       if (node.type == "AST_HTML_CLOSE_TAG_NODE") type = "Closing"
-      if (node.type == "AST_HTML_SELF_CLOSE_TAG_NODE") type = "Self-closing"
 
       this.addOffense(
         `${type} tag name \`${tagName}\` should be lowercase. Use \`${lowercaseTagName}\` instead.`,

--- a/javascript/packages/linter/src/rules/rule-utils.ts
+++ b/javascript/packages/linter/src/rules/rule-utils.ts
@@ -18,7 +18,6 @@ import type {
   HTMLAttributeNode,
   HTMLAttributeValueNode,
   HTMLOpenTagNode,
-  HTMLSelfCloseTagNode,
   LiteralNode,
   LexResult,
   Token,
@@ -67,20 +66,16 @@ export abstract class BaseRuleVisitor extends Visitor {
 }
 
 /**
- * Gets attributes from either an HTMLOpenTagNode or HTMLSelfCloseTagNode
+ * Gets attributes from an HTMLOpenTagNode
  */
-export function getAttributes(node: HTMLOpenTagNode | HTMLSelfCloseTagNode): HTMLAttributeNode[] {
-  const nodes = node.type === "AST_HTML_SELF_CLOSE_TAG_NODE"
-    ? (node as HTMLSelfCloseTagNode).attributes
-    : (node as HTMLOpenTagNode).children
-
-  return nodes.filter(node => node.type === "AST_HTML_ATTRIBUTE_NODE")
+export function getAttributes(node: HTMLOpenTagNode): HTMLAttributeNode[] {
+  return node.children.filter(node => node.type === "AST_HTML_ATTRIBUTE_NODE") as HTMLAttributeNode[]
 }
 
 /**
  * Gets the tag name from an HTML tag node (lowercased)
  */
-export function getTagName(node: HTMLOpenTagNode | HTMLSelfCloseTagNode): string | null {
+export function getTagName(node: HTMLOpenTagNode): string | null {
   return node.tag_name?.value.toLowerCase() || null
 }
 
@@ -282,7 +277,7 @@ export function findAttributeByName(attributes: Node[], attributeName: string): 
 /**
  * Checks if a tag has a specific attribute
  */
-export function hasAttribute(node: HTMLOpenTagNode | HTMLSelfCloseTagNode, attributeName: string): boolean {
+export function hasAttribute(node: HTMLOpenTagNode, attributeName: string): boolean {
   const attributes = getAttributes(node)
 
   return findAttributeByName(attributes, attributeName) !== null
@@ -382,14 +377,14 @@ export interface StaticAttributeStaticValueParams {
   attributeName: string
   attributeValue: string
   attributeNode: HTMLAttributeNode
-  parentNode: HTMLOpenTagNode | HTMLSelfCloseTagNode
+  parentNode: HTMLOpenTagNode
 }
 
 export interface StaticAttributeDynamicValueParams {
   attributeName: string
   valueNodes: Node[]
   attributeNode: HTMLAttributeNode
-  parentNode: HTMLOpenTagNode | HTMLSelfCloseTagNode
+  parentNode: HTMLOpenTagNode
   combinedValue?: string | null
 }
 
@@ -397,7 +392,7 @@ export interface DynamicAttributeStaticValueParams {
   nameNodes: Node[]
   attributeValue: string
   attributeNode: HTMLAttributeNode
-  parentNode: HTMLOpenTagNode | HTMLSelfCloseTagNode
+  parentNode: HTMLOpenTagNode
   combinedName?: string
 }
 
@@ -405,7 +400,7 @@ export interface DynamicAttributeDynamicValueParams {
   nameNodes: Node[]
   valueNodes: Node[]
   attributeNode: HTMLAttributeNode
-  parentNode: HTMLOpenTagNode | HTMLSelfCloseTagNode
+  parentNode: HTMLOpenTagNode
   combinedName?: string
   combinedValue?: string | null
 }
@@ -518,13 +513,7 @@ export abstract class AttributeVisitorMixin extends BaseRuleVisitor {
     super.visitHTMLOpenTagNode(node)
   }
 
-  visitHTMLSelfCloseTagNode(node: HTMLSelfCloseTagNode): void {
-    this.checkAttributesOnNode(node)
-    super.visitHTMLSelfCloseTagNode(node)
-  }
-
-
-  private checkAttributesOnNode(node: HTMLOpenTagNode | HTMLSelfCloseTagNode): void {
+  private checkAttributesOnNode(node: HTMLOpenTagNode): void {
     forEachAttribute(node, (attributeNode) => {
       const staticAttributeName = getAttributeName(attributeNode)
       const isDynamicName = hasDynamicAttributeName(attributeNode)
@@ -611,7 +600,7 @@ export function isAttributeValueQuoted(attributeNode: HTMLAttributeNode): boolea
  * Iterates over all attributes of a tag node, calling the callback for each attribute
  */
 export function forEachAttribute(
-  node: HTMLOpenTagNode | HTMLSelfCloseTagNode,
+  node: HTMLOpenTagNode,
   callback: (attributeNode: HTMLAttributeNode) => void
 ): void {
   const attributes = getAttributes(node)

--- a/javascript/packages/linter/src/rules/svg-tag-name-capitalization.ts
+++ b/javascript/packages/linter/src/rules/svg-tag-name-capitalization.ts
@@ -2,7 +2,7 @@ import { BaseRuleVisitor, SVG_CAMEL_CASE_ELEMENTS, SVG_LOWERCASE_TO_CAMELCASE } 
 
 import { ParserRule } from "../types.js"
 import type { LintOffense, LintContext } from "../types.js"
-import type { HTMLElementNode, HTMLOpenTagNode, HTMLCloseTagNode, HTMLSelfCloseTagNode, ParseResult } from "@herb-tools/core"
+import type { HTMLElementNode, HTMLOpenTagNode, HTMLCloseTagNode, ParseResult } from "@herb-tools/core"
 
 class SVGTagNameCapitalizationVisitor extends BaseRuleVisitor {
   private insideSVG = false
@@ -30,14 +30,8 @@ class SVGTagNameCapitalizationVisitor extends BaseRuleVisitor {
     this.visitChildNodes(node)
   }
 
-  visitHTMLSelfCloseTagNode(node: HTMLSelfCloseTagNode): void {
-    if (this.insideSVG) {
-      this.checkTagName(node)
-    }
-    this.visitChildNodes(node)
-  }
 
-  private checkTagName(node: HTMLOpenTagNode | HTMLCloseTagNode | HTMLSelfCloseTagNode): void {
+  private checkTagName(node: HTMLOpenTagNode | HTMLCloseTagNode): void {
     const tagName = node.tag_name?.value
 
     if (!tagName) return
@@ -52,7 +46,6 @@ class SVGTagNameCapitalizationVisitor extends BaseRuleVisitor {
 
       if (node.type == "AST_HTML_OPEN_TAG_NODE") type = "Opening"
       if (node.type == "AST_HTML_CLOSE_TAG_NODE") type = "Closing"
-      if (node.type == "AST_HTML_SELF_CLOSE_TAG_NODE") type = "Self-closing"
 
       this.addOffense(
         `${type} SVG tag name \`${tagName}\` should use proper capitalization. Use \`${correctCamelCase}\` instead.`,

--- a/sig/herb/ast/nodes.rbs
+++ b/sig/herb/ast/nodes.rbs
@@ -116,39 +116,6 @@ module Herb
       def tree_inspect: (?Integer) -> String
     end
 
-    class HTMLSelfCloseTagNode < Node
-      attr_reader tag_opening: Herb::Token
-
-      attr_reader tag_name: Herb::Token
-
-      attr_reader attributes: Array[Herb::AST::HTMLAttributeNode]
-
-      attr_reader tag_closing: Herb::Token
-
-      attr_reader is_void: bool
-
-      # : (String, Location, Array[Herb::Errors::Error], Herb::Token, Herb::Token, Array[Herb::AST::HTMLAttributeNode], Herb::Token, bool) -> void
-      def initialize: (String, Location, Array[Herb::Errors::Error], Herb::Token, Herb::Token, Array[Herb::AST::HTMLAttributeNode], Herb::Token, bool) -> void
-
-      # : () -> serialized_html_self_close_tag_node
-      def to_hash: () -> serialized_html_self_close_tag_node
-
-      # : (Visitor) -> void
-      def accept: (Visitor) -> void
-
-      # : () -> Array[Herb::AST::Node?]
-      def child_nodes: () -> Array[Herb::AST::Node?]
-
-      # : () -> Array[Herb::AST::Node]
-      def compact_child_nodes: () -> Array[Herb::AST::Node]
-
-      # : () -> String
-      def inspect: () -> String
-
-      # : (?Integer) -> String
-      def tree_inspect: (?Integer) -> String
-    end
-
     class HTMLElementNode < Node
       attr_reader open_tag: Herb::AST::HTMLOpenTagNode
 

--- a/sig/herb/visitor.rbs
+++ b/sig/herb/visitor.rbs
@@ -23,9 +23,6 @@ module Herb
     # : (Herb::AST::HTMLCloseTagNode) -> void
     def visit_html_close_tag_node: (Herb::AST::HTMLCloseTagNode) -> void
 
-    # : (Herb::AST::HTMLSelfCloseTagNode) -> void
-    def visit_html_self_close_tag_node: (Herb::AST::HTMLSelfCloseTagNode) -> void
-
     # : (Herb::AST::HTMLElementNode) -> void
     def visit_html_element_node: (Herb::AST::HTMLElementNode) -> void
 

--- a/src/parser.c
+++ b/src/parser.c
@@ -877,9 +877,7 @@ static AST_HTML_ELEMENT_NODE_T* parser_parse_html_element(parser_T* parser) {
   AST_HTML_OPEN_TAG_NODE_T* open_tag = parser_parse_html_open_tag(parser);
 
   // <tag />
-  if (open_tag->is_void || ast_node_is((AST_NODE_T*) open_tag, AST_HTML_SELF_CLOSE_TAG_NODE)) {
-    return parser_parse_html_self_closing_element(parser, open_tag);
-  }
+  if (open_tag->is_void) { return parser_parse_html_self_closing_element(parser, open_tag); }
 
   // <tag>, in void element list, and not in inside an <svg> element
   if (!open_tag->is_void && is_void_element(open_tag->tag_name->value) && !parser_in_svg_context(parser)) {


### PR DESCRIPTION
This pull request removes the `HTMLSelfCloseTagNode` since it was unused in the project. The `HTMLOpenTagNode` has a `is_void` field that handles this.