### PR TITLE
Implement `erb-no-silent-tag-in-attribute-name` linter rule

### DIFF
--- a/javascript/packages/linter/docs/rules/README.md
+++ b/javascript/packages/linter/docs/rules/README.md
@@ -6,6 +6,7 @@ This page contains documentation for all Herb Linter rules.
 
 - [`erb-no-empty-tags`](./erb-no-empty-tags.md) - Disallow empty ERB tags
 - [`erb-no-output-control-flow`](./erb-no-output-control-flow.md) - Prevents outputting control flow blocks
+- [`erb-no-silent-tag-in-attribute-name`](./erb-no-silent-tag-in-attribute-name.md) - Disallow ERB silent tags in HTML attribute names
 - [`erb-prefer-image-tag-helper`](./erb-prefer-image-tag-helper.md) - Prefer `image_tag` helper over `<img>` with ERB expressions
 - [`erb-require-whitespace-inside-tags`](./erb-require-whitespace-inside-tags.md) - Requires whitespace around ERB tags
 - [`erb-requires-trailing-newline`](./erb-requires-trailing-newline.md) - Enforces that all HTML+ERB template files end with exactly one trailing newline character.

--- a/javascript/packages/linter/docs/rules/erb-no-silent-tag-in-attribute-name.md
+++ b/javascript/packages/linter/docs/rules/erb-no-silent-tag-in-attribute-name.md
@@ -1,0 +1,34 @@
+# Linter Rule: Disallow ERB silent tags in HTML attribute names
+
+**Rule:** `erb-no-silent-tag-in-attribute-name`
+
+## Description
+
+Disallow the use of ERB silent tags (`<% ... %>`) inside HTML attribute names. These tags introduce Ruby logic that does not output anything, and placing them in attribute names leads to malformed HTML or completely unpredictable rendering.
+
+## Rationale
+
+HTML attribute names, ideally, must be valid, statically defined strings. Placing ERB silent tags (`<% ... %>`) that don't output anything inside attribute names might result in invalid HTML and is confusing. These cases are rarely intentional and almost always indicate a mistake or misuse of ERB templating.
+
+## Examples
+
+### ✅ Good
+
+```erb
+<div data-<%= key %>-target="value"></div>
+<div <%= data_attributes_for(user) %>></div>
+```
+
+### 🚫 Bad
+
+```erb
+<div data-<% key %>-id="value"></div>
+
+<div data-<%# key %>-id="thing"></div>
+
+<div data-<%- key -%>-id="thing"></div>
+```
+
+## References
+
+\-

--- a/javascript/packages/linter/src/default-rules.ts
+++ b/javascript/packages/linter/src/default-rules.ts
@@ -2,6 +2,7 @@ import type { RuleClass } from "./types.js"
 
 import { ERBNoEmptyTagsRule } from "./rules/erb-no-empty-tags.js"
 import { ERBNoOutputControlFlowRule } from "./rules/erb-no-output-control-flow.js"
+import { ERBNoSilentTagInAttributeNameRule } from "./rules/erb-no-silent-tag-in-attribute-name.js"
 import { ERBPreferImageTagHelperRule } from "./rules/erb-prefer-image-tag-helper.js"
 import { ERBRequiresTrailingNewlineRule } from "./rules/erb-requires-trailing-newline.js"
 import { ERBRequireWhitespaceRule } from "./rules/erb-require-whitespace-inside-tags.js"
@@ -28,6 +29,7 @@ import { SVGTagNameCapitalizationRule } from "./rules/svg-tag-name-capitalizatio
 export const defaultRules: RuleClass[] = [
   ERBNoEmptyTagsRule,
   ERBNoOutputControlFlowRule,
+  ERBNoSilentTagInAttributeNameRule,
   ERBPreferImageTagHelperRule,
   ERBRequiresTrailingNewlineRule,
   ERBRequireWhitespaceRule,

--- a/javascript/packages/linter/src/rules/erb-no-silent-tag-in-attribute-name.ts
+++ b/javascript/packages/linter/src/rules/erb-no-silent-tag-in-attribute-name.ts
@@ -1,0 +1,40 @@
+import { ParserRule } from "../types.js"
+import { BaseRuleVisitor } from "./rule-utils.js"
+import { filterERBContentNodes } from "@herb-tools/core"
+
+import type { LintOffense, LintContext } from "../types.js"
+import type { ParseResult, HTMLAttributeNameNode, ERBContentNode } from "@herb-tools/core"
+
+class ERBNoSilentTagInAttributeNameVisitor extends BaseRuleVisitor {
+  visitHTMLAttributeNameNode(node: HTMLAttributeNameNode): void {
+    const erbNodes = filterERBContentNodes(node.children)
+    const silentNodes = erbNodes.filter(this.isSilentERBTag)
+
+    for (const node of silentNodes) {
+      this.addOffense(
+        `Remove silent ERB tag from HTML attribute name. Silent ERB tags (\`${node.tag_opening?.value}\`) do not output content and should not be used in attribute names.`,
+        node.location,
+        "error"
+      )
+    }
+  }
+
+  // TODO: might be worth to extract
+  private isSilentERBTag(node: ERBContentNode): boolean {
+    const silentTags = ["<%", "<%-", "<%#"]
+
+    return silentTags.includes(node.tag_opening?.value || "")
+  }
+}
+
+export class ERBNoSilentTagInAttributeNameRule extends ParserRule {
+  name = "erb-no-silent-tag-in-attribute-name"
+
+  check(result: ParseResult, context?: Partial<LintContext>): LintOffense[] {
+    const visitor = new ERBNoSilentTagInAttributeNameVisitor(this.name, context)
+
+    visitor.visit(result.value)
+
+    return visitor.offenses
+  }
+}

--- a/javascript/packages/linter/src/rules/index.ts
+++ b/javascript/packages/linter/src/rules/index.ts
@@ -1,5 +1,6 @@
 export * from "./erb-no-empty-tags.js"
 export * from "./erb-no-output-control-flow.js"
+export * from "./erb-no-silent-tag-in-attribute-name.js"
 export * from "./erb-prefer-image-tag-helper.js"
 export * from "./erb-requires-trailing-newline.js"
 export * from "./html-anchor-require-href.js"

--- a/javascript/packages/linter/test/__snapshots__/cli.test.ts.snap
+++ b/javascript/packages/linter/test/__snapshots__/cli.test.ts.snap
@@ -349,7 +349,7 @@ exports[`CLI Output Formatting > formats JSON output correctly for bad file 1`] 
   "summary": {
     "filesChecked": 1,
     "filesWithOffenses": 1,
-    "ruleCount": 23,
+    "ruleCount": 24,
     "totalErrors": 2,
     "totalOffenses": 2,
     "totalWarnings": 0,
@@ -367,7 +367,7 @@ exports[`CLI Output Formatting > formats JSON output correctly for clean file 1`
   "summary": {
     "filesChecked": 1,
     "filesWithOffenses": 0,
-    "ruleCount": 23,
+    "ruleCount": 24,
     "totalErrors": 0,
     "totalOffenses": 0,
     "totalWarnings": 0,
@@ -437,7 +437,7 @@ exports[`CLI Output Formatting > formats JSON output correctly for file with err
   "summary": {
     "filesChecked": 1,
     "filesWithOffenses": 1,
-    "ruleCount": 23,
+    "ruleCount": 24,
     "totalErrors": 3,
     "totalOffenses": 3,
     "totalWarnings": 0,

--- a/javascript/packages/linter/test/rules/erb-no-silent-tag-in-attribute-name.test.ts
+++ b/javascript/packages/linter/test/rules/erb-no-silent-tag-in-attribute-name.test.ts
@@ -1,0 +1,149 @@
+import dedent from "dedent"
+
+import { describe, test, expect, beforeAll } from "vitest"
+import { Herb } from "@herb-tools/node-wasm"
+import { Linter } from "../../src/linter.js"
+
+import { ERBNoSilentTagInAttributeNameRule } from "../../src/rules/erb-no-silent-tag-in-attribute-name.js"
+
+describe("ERBNoSilentTagInAttributeNameRule", () => {
+  beforeAll(async () => {
+    await Herb.load()
+  })
+
+  test("valid attributes with output ERB tags", () => {
+    const html = dedent`
+      <div data-<%= key %>-target="value"></div>
+      <div <%= data_attributes_for(user) %>></div>
+      <input data-<%= user.id %>-field="text">
+    `
+
+    const linter = new Linter(Herb, [ERBNoSilentTagInAttributeNameRule])
+    const lintResult = linter.lint(html)
+
+    expect(lintResult.errors).toBe(0)
+    expect(lintResult.warnings).toBe(0)
+    expect(lintResult.offenses).toHaveLength(0)
+  })
+
+  test("valid static attribute names", () => {
+    const html = dedent`
+      <div class="container"></div>
+      <img src="/logo.png" alt="Logo">
+      <input type="text" data-target="value">
+    `
+    const linter = new Linter(Herb, [ERBNoSilentTagInAttributeNameRule])
+    const lintResult = linter.lint(html)
+
+    expect(lintResult.errors).toBe(0)
+    expect(lintResult.warnings).toBe(0)
+    expect(lintResult.offenses).toHaveLength(0)
+  })
+
+  test("valid conditional attributes with ERB control flow", () => {
+    const html = dedent`
+      <div <% if valid? %>data-valid="true"<% else %>data-valid="false"<% end %>></div>
+      <span <% if user.admin? %>class="admin"<% end %>></span>
+      <input <% unless disabled %>enabled="true"<% end %>>
+    `
+    const linter = new Linter(Herb, [ERBNoSilentTagInAttributeNameRule])
+    const lintResult = linter.lint(html)
+
+    expect(lintResult.errors).toBe(0)
+    expect(lintResult.warnings).toBe(0)
+    expect(lintResult.offenses).toHaveLength(0)
+  })
+
+  test("invalid attribute with silent ERB tag", () => {
+    const html = dedent`
+      <div data-<% key %>-target="value"></div>
+    `
+    const linter = new Linter(Herb, [ERBNoSilentTagInAttributeNameRule])
+    const lintResult = linter.lint(html)
+
+    expect(lintResult.errors).toBe(1)
+    expect(lintResult.warnings).toBe(0)
+    expect(lintResult.offenses).toHaveLength(1)
+    expect(lintResult.offenses[0].code).toBe("erb-no-silent-tag-in-attribute-name")
+    expect(lintResult.offenses[0].message).toBe("Remove silent ERB tag from HTML attribute name. Silent ERB tags (`<%`) do not output content and should not be used in attribute names.")
+  })
+
+  test("invalid attribute with trimming silent ERB tag", () => {
+    const html = dedent`
+      <div data-<%- key -%>-id="thing"></div>
+    `
+    const linter = new Linter(Herb, [ERBNoSilentTagInAttributeNameRule])
+    const lintResult = linter.lint(html)
+
+    expect(lintResult.errors).toBe(1)
+    expect(lintResult.warnings).toBe(0)
+    expect(lintResult.offenses).toHaveLength(1)
+    expect(lintResult.offenses[0].code).toBe("erb-no-silent-tag-in-attribute-name")
+    expect(lintResult.offenses[0].message).toBe("Remove silent ERB tag from HTML attribute name. Silent ERB tags (`<%-`) do not output content and should not be used in attribute names.")
+  })
+
+  test("invalid attribute with comment ERB tag", () => {
+    const html = dedent`
+      <div data-<%# comment %>-target="value"></div>
+    `
+    const linter = new Linter(Herb, [ERBNoSilentTagInAttributeNameRule])
+    const lintResult = linter.lint(html)
+
+    expect(lintResult.errors).toBe(1)
+    expect(lintResult.warnings).toBe(0)
+    expect(lintResult.offenses).toHaveLength(1)
+    expect(lintResult.offenses[0].code).toBe("erb-no-silent-tag-in-attribute-name")
+    expect(lintResult.offenses[0].message).toBe("Remove silent ERB tag from HTML attribute name. Silent ERB tags (`<%#`) do not output content and should not be used in attribute names.")
+  })
+
+  test("multiple invalid attributes in same element", () => {
+    const html = dedent`
+      <div data-<% key %>-target="value" id-<% another %>-suffix="test"></div>
+    `
+    const linter = new Linter(Herb, [ERBNoSilentTagInAttributeNameRule])
+    const lintResult = linter.lint(html)
+
+    expect(lintResult.errors).toBe(2)
+    expect(lintResult.warnings).toBe(0)
+    expect(lintResult.offenses).toHaveLength(2)
+    expect(lintResult.offenses[0].message).toBe("Remove silent ERB tag from HTML attribute name. Silent ERB tags (`<%`) do not output content and should not be used in attribute names.")
+    expect(lintResult.offenses[1].message).toBe("Remove silent ERB tag from HTML attribute name. Silent ERB tags (`<%`) do not output content and should not be used in attribute names.")
+  })
+
+  test("mixed valid and invalid ERB tags in different attributes", () => {
+    const html = dedent`
+      <div
+        data-<%= valid_key %>-target="value"
+        prefix-<% invalid_key %>-id="test"
+        class="<%= valid_class %>"
+      ></div>
+    `
+    const linter = new Linter(Herb, [ERBNoSilentTagInAttributeNameRule])
+    const lintResult = linter.lint(html)
+
+    expect(lintResult.errors).toBe(1)
+    expect(lintResult.warnings).toBe(0)
+    expect(lintResult.offenses).toHaveLength(1)
+    expect(lintResult.offenses[0].code).toBe("erb-no-silent-tag-in-attribute-name")
+    expect(lintResult.offenses[0].message).toBe("Remove silent ERB tag from HTML attribute name. Silent ERB tags (`<%`) do not output content and should not be used in attribute names.")
+  })
+
+  test("nested HTML elements with various ERB patterns", () => {
+    const html = dedent`
+      <form>
+        <input data-<%= user.id %>-field="text">
+        <button data-<% collection %>-list="options"></button>
+        <select prefix-<%# comment %>-suffix="value"></select>
+      </form>
+    `
+    const linter = new Linter(Herb, [ERBNoSilentTagInAttributeNameRule])
+    const lintResult = linter.lint(html)
+
+    expect(lintResult.errors).toBe(2)
+    expect(lintResult.warnings).toBe(0)
+    expect(lintResult.offenses).toHaveLength(2)
+
+    expect(lintResult.offenses[0].message).toBe("Remove silent ERB tag from HTML attribute name. Silent ERB tags (`<%`) do not output content and should not be used in attribute names.")
+    expect(lintResult.offenses[1].message).toBe("Remove silent ERB tag from HTML attribute name. Silent ERB tags (`<%#`) do not output content and should not be used in attribute names.")
+  })
+})


### PR DESCRIPTION
This pull request adds a new linter rule that disallows the use of silent ERB tags in HTML attribute names:

```erb
<div data-<% key %>-id="value"></div>
```

Resolves #409 