### PR TITLE
Formatter: Improve HTML comment formatting with ERB content

### DIFF
--- a/javascript/packages/formatter/test/html/comments.test.ts
+++ b/javascript/packages/formatter/test/html/comments.test.ts
@@ -47,4 +47,146 @@ describe("@herb-tools/formatter", () => {
       <%# ERB Comment %>
     `)
   })
+
+  test("HTML comment with ERB content inside", () => {
+    const source = dedent`
+      <div>
+        <!-- <%= hello world %> -->
+      </div>
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <div>
+        <!-- <%= hello world %> -->
+      </div>
+    `)
+  })
+
+  test("HTML comment with multiple ERB tags inside", () => {
+    const source = dedent`
+      <!-- <%= user.name %> - <%= user.email %> -->
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <!-- <%= user.name %> - <%= user.email %> -->
+    `)
+  })
+
+  test("HTML comment with ERB and text mixed", () => {
+    const source = dedent`
+      <!-- User: <%= @user.name %> (ID: <%= @user.id %>) -->
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <!-- User: <%= @user.name %> (ID: <%= @user.id %>) -->
+    `)
+  })
+
+  test("multi-line HTML comment with ERB content", () => {
+    const source = dedent`
+      <!--
+        TODO: Fix this <%= bug_type %>
+        Assigned to: <%= developer.name %>
+        Due: <%= deadline.strftime('%Y-%m-%d') %>
+      -->
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <!--
+        TODO: Fix this <%= bug_type %>
+        Assigned to: <%= developer.name %>
+        Due: <%= deadline.strftime('%Y-%m-%d') %>
+      -->
+    `)
+  })
+
+  test("multi-line HTML comment with ERB if", () => {
+    const source = dedent`
+      <!--
+        <% if Rails.env.development? %>
+          Debug info: <%= current_user&.email %>
+        <% end %>
+      -->
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <!--
+        <% if Rails.env.development? %>
+          Debug info: <%= current_user&.email %>
+        <% end %>
+      -->
+    `)
+  })
+
+  test.todo("indents multi-line HTML comment with ERB if", () => {
+    const source = dedent`
+      <!--
+      <% if Rails.env.development? %>
+      Debug info: <%= current_user&.email %>
+      <% end %>
+      -->
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <!--
+        <% if Rails.env.development? %>
+          Debug info: <%= current_user&.email %>
+        <% end %>
+      -->
+    `)
+  })
+
+  test("HTML comment spanning multiple lines with inline ERB", () => {
+    const source = dedent`
+      <!-- Status: <%= status %> |
+           Updated: <%= updated_at %> |
+           Version: <%= version %> -->
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <!--
+        Status: <%= status %> |
+        Updated: <%= updated_at %> |
+        Version: <%= version %>
+      -->
+    `)
+  })
+
+  test("multi-line HTML comment with ERB gets indented", () => {
+    const source = dedent`
+      <!--
+      Status: <%= status %> |
+      Updated: <%= updated_at %> |
+      Version: <%= version %>
+      -->
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <!--
+        Status: <%= status %> |
+        Updated: <%= updated_at %> |
+        Version: <%= version %>
+      -->
+    `)
+  })
+
+  test("multi-line HTML comment gets indented", () => {
+    const source = dedent`
+      <!--
+      Comment
+      on
+      multiple
+      lines
+      -->
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <!--
+        Comment
+        on
+        multiple
+        lines
+      -->
+    `)
+  })
 })


### PR DESCRIPTION
This pull request improves the way the formatter handles HTML comments containing ERB expressions and multi-line content. Previously, comments with ERB tags were not properly formatted and could lose/duplicate content. The formatter now correctly preserves ERB expressions within comments while applying indentation to multi-line comments.

**Before:**
```erb
<!-- <%= user.name %>-<%= user.email %> -->
<!--TODO: Fix this <%= bug %>
Assigned to: <%= dev %>-->
```

**After:**
```erb
<!-- <%= user.name %> - <%= user.email %> -->

<!--
  TODO: Fix this <%= bug %>
  Assigned to: <%= dev %>
-->
```

Also fixes the issue #395:

**Input:**
```erb
<div>
  <!-- <%= hello world %> -->
</div>
```

**Before:**
```erb
<div>
  <%= hello world %>
  <!-- <%= hello world %> -->
</div>
```

**After:**
```erb
<div>
  <!-- <%= hello world %> -->
</div>
```