### PR TITLE
Formatter: Refactor `visitHTMLElementNode` and extract helper methods

### DIFF
--- a/javascript/packages/printer/src/printer.ts
+++ b/javascript/packages/printer/src/printer.ts
@@ -3,10 +3,21 @@ import { PrintContext } from "./print-context.js"
 
 import type * as Nodes from "@herb-tools/core"
 
+/**
+ * Options for controlling the printing behavior
+ */
 export type PrintOptions = {
+  /**
+   * When true, allows printing nodes that have parse errors.
+   * When false (default), throws an error if attempting to print nodes with errors.
+   * @default false
+   */
   ignoreErrors: boolean
 }
 
+/**
+ * Default print options used when none are provided
+ */
 export const DEFAULT_PRINT_OPTIONS: PrintOptions = {
   ignoreErrors: false
 }
@@ -16,10 +27,15 @@ export abstract class Printer extends Visitor {
 
   /**
    * Print a node to a string
+   * 
+   * @param node - The AST node to print
+   * @param options - Print options to control behavior
+   * @returns The printed string representation of the node
+   * @throws {Error} When node has parse errors and ignoreErrors is false
    */
   print(node: Node, options: PrintOptions = DEFAULT_PRINT_OPTIONS): string {
     if (options.ignoreErrors === false && node.recursiveErrors().length > 0) {
-      throw new Error(`Cannot print the node (${node.type}) since it or any of it's children has parse errors. Either pass in a valid Node or call \`print()\` using \`print(node, { ignoreErrors: true })\``)
+      throw new Error(`Cannot print the node (${node.type}) since it or any of its children has parse errors. Either pass in a valid Node or call \`print()\` using \`print(node, { ignoreErrors: true })\``)
     }
 
     this.context.reset()

--- a/javascript/packages/printer/test/printer-options.test.ts
+++ b/javascript/packages/printer/test/printer-options.test.ts
@@ -28,7 +28,7 @@ describe("Printer Options", () => {
 
       expect(() => {
         printer.print(parseResult.value!)
-      }).toThrow("Cannot print the node (AST_DOCUMENT_NODE) since it or any of it's children has parse errors. Either pass in a valid Node or call `print()` using `print(node, { ignoreErrors: true })`")
+      }).toThrow("Cannot print the node (AST_DOCUMENT_NODE) since it or any of its children has parse errors. Either pass in a valid Node or call `print()` using `print(node, { ignoreErrors: true })`")
     })
 
     test("throws error when explicitly setting ignoreErrors to false", () => {
@@ -43,7 +43,7 @@ describe("Printer Options", () => {
 
       expect(() => {
         printer.print(parseResult.value!, options)
-      }).toThrow("Cannot print the node (AST_DOCUMENT_NODE) since it or any of it's children has parse errors. Either pass in a valid Node or call `print()` using `print(node, { ignoreErrors: true })`")
+      }).toThrow("Cannot print the node (AST_DOCUMENT_NODE) since it or any of its children has parse errors. Either pass in a valid Node or call `print()` using `print(node, { ignoreErrors: true })`")
     })
 
     test("prints nodes with errors when ignoreErrors is true", () => {
@@ -105,7 +105,7 @@ describe("Printer Options", () => {
 
           expect(() => {
             printer.print(parseResult.value!)
-          }).toThrow(`Cannot print the node (${expectedType}) since it or any of it's children has parse errors. Either pass in a valid Node or call \`print()\` using \`print(node, { ignoreErrors: true })\``)
+          }).toThrow(`Cannot print the node (${expectedType}) since it or any of its children has parse errors. Either pass in a valid Node or call \`print()\` using \`print(node, { ignoreErrors: true })\``)
         }
       })
     })


### PR DESCRIPTION
This pull request refactors the almost 400-line long `visitHTMLElementNode` visitor method in the Formatter by extracting helper methods.