### PR TITLE
Printer: Add static `Printer.print()` method

### DIFF
--- a/javascript/packages/printer/src/printer.ts
+++ b/javascript/packages/printer/src/printer.ts
@@ -26,8 +26,22 @@ export abstract class Printer extends Visitor {
   protected context: PrintContext = new PrintContext()
 
   /**
+   * Static method to print a node without creating an instance
+   *
+   * @param node - The AST node to print
+   * @param options - Print options to control behavior
+   * @returns The printed string representation of the node
+   * @throws {Error} When node has parse errors and ignoreErrors is false
+   */
+  static print(node: Node, options: PrintOptions = DEFAULT_PRINT_OPTIONS): string {
+    const printer = new (this as any)()
+
+    return printer.print(node, options)
+  }
+
+  /**
    * Print a node to a string
-   * 
+   *
    * @param node - The AST node to print
    * @param options - Print options to control behavior
    * @returns The printed string representation of the node

--- a/javascript/packages/printer/test/identity-printer.test.ts
+++ b/javascript/packages/printer/test/identity-printer.test.ts
@@ -30,9 +30,36 @@ describe("IdentityPrinter", () => {
       expect(printer).toBeInstanceOf(IdentityPrinter)
     })
 
-    test("can be instantiated with options", () => {
-      const printer = new IdentityPrinter({ indentSize: 4 })
-      expect(printer).toBeInstanceOf(IdentityPrinter)
+    test("static print method works", () => {
+      const input = '<div>Hello World</div>'
+      const parseResult = Herb.parse(input, { track_whitespace: true })
+      expect(parseResult.value).toBeTruthy()
+
+      const output = IdentityPrinter.print(parseResult.value!)
+      expect(output).toBe(input)
+    })
+
+    test("static print method produces same output as instance method", () => {
+      const input = '<p class="paragraph">Test paragraph</p>'
+      const parseResult = Herb.parse(input, { track_whitespace: true })
+      expect(parseResult.value).toBeTruthy()
+
+      const printer = new IdentityPrinter()
+      const instanceOutput = printer.print(parseResult.value!)
+      const staticOutput = IdentityPrinter.print(parseResult.value!)
+
+      expect(staticOutput).toBe(instanceOutput)
+      expect(staticOutput).toBe(input)
+    })
+
+    test("static print method respects options", () => {
+      const input = '<div id="error">Error'
+      const parseResult = Herb.parse(input, { track_whitespace: true })
+
+      expect(() => IdentityPrinter.print(parseResult.value!)).toThrow()
+
+      const output = IdentityPrinter.print(parseResult.value!, { ignoreErrors: true })
+      expect(output).toBe(input)
     })
   })
 

--- a/javascript/packages/printer/test/static-print-method.test.ts
+++ b/javascript/packages/printer/test/static-print-method.test.ts
@@ -1,0 +1,129 @@
+import dedent from "dedent"
+import { describe, test, expect, beforeAll } from "vitest"
+
+import { Herb } from "@herb-tools/node-wasm"
+import { Printer, IdentityPrinter } from "../src/index.js"
+import type { HTMLTextNode } from "@herb-tools/core"
+
+class UppercasePrinter extends Printer {
+  visitHTMLTextNode(node: HTMLTextNode): void {
+    this.write(node.content.toUpperCase())
+  }
+}
+
+class NoAttributesPrinter extends Printer {
+  visitHTMLAttributeNode(): void {
+    // Skip attributes entirely
+  }
+
+  visitHTMLOpenTagNode(node: any): void {
+    if (node.tag_opening) {
+      this.context.write(node.tag_opening.value)
+    }
+
+    if (node.tag_name) {
+      this.context.write(node.tag_name.value)
+    }
+
+    // Skip child nodes (attributes and whitespace)
+
+    if (node.tag_closing) {
+      this.context.write(node.tag_closing.value)
+    }
+  }
+}
+
+describe("Static print method", () => {
+  beforeAll(async () => {
+    await Herb.load()
+  })
+
+  describe("IdentityPrinter static method", () => {
+    test("works without creating an instance", () => {
+      const input = '<div class="test">Hello World</div>'
+      const parseResult = Herb.parse(input, { track_whitespace: true })
+      expect(parseResult.value).toBeTruthy()
+
+      const output = IdentityPrinter.print(parseResult.value!)
+      expect(output).toBe(input)
+    })
+
+    test("handles complex HTML structures", () => {
+      const input = dedent`
+        <div>
+          <p>Paragraph</p>
+          <ul>
+            <li>Item 1</li>
+            <li>Item 2</li>
+          </ul>
+        </div>
+      `
+
+      const parseResult = Herb.parse(input, { track_whitespace: true })
+      expect(parseResult.value).toBeTruthy()
+
+      const output = IdentityPrinter.print(parseResult.value!)
+      expect(output).toBe(input)
+    })
+  })
+
+  describe("Custom printer static methods", () => {
+    test("UppercasePrinter static method works", () => {
+      const input = '<div>hello world</div>'
+      const parseResult = Herb.parse(input, { track_whitespace: true })
+      expect(parseResult.value).toBeTruthy()
+
+      const output = UppercasePrinter.print(parseResult.value!)
+      expect(output).toBe('<div>HELLO WORLD</div>')
+    })
+
+    test("NoAttributesPrinter static method works", () => {
+      const input = '<div class="container" id="main">Content</div>'
+      const parseResult = Herb.parse(input, { track_whitespace: true })
+      expect(parseResult.value).toBeTruthy()
+
+      const output = NoAttributesPrinter.print(parseResult.value!)
+      expect(output).toBe('<div>Content</div>')
+    })
+
+    test("custom printers produce same output with static and instance methods", () => {
+      const input = '<p class="text">hello</p>'
+      const parseResult = Herb.parse(input, { track_whitespace: true })
+      expect(parseResult.value).toBeTruthy()
+
+      const uppercaseInstance = new UppercasePrinter()
+      const uppercaseInstanceOutput = uppercaseInstance.print(parseResult.value!)
+      const uppercaseStaticOutput = UppercasePrinter.print(parseResult.value!)
+      expect(uppercaseStaticOutput).toBe(uppercaseInstanceOutput)
+      expect(uppercaseStaticOutput).toBe('<p class="text">HELLO</p>')
+
+      const noAttrInstance = new NoAttributesPrinter()
+      const noAttrInstanceOutput = noAttrInstance.print(parseResult.value!)
+      const noAttrStaticOutput = NoAttributesPrinter.print(parseResult.value!)
+      expect(noAttrStaticOutput).toBe(noAttrInstanceOutput)
+      expect(noAttrStaticOutput).toBe('<p>hello</p>')
+    })
+  })
+
+  describe("Options handling", () => {
+    test("static method respects print options", () => {
+      const input = '<div>Test'
+      const parseResult = Herb.parse(input, { track_whitespace: true })
+
+      expect(() => IdentityPrinter.print(parseResult.value!)).toThrow(/Cannot print the node/)
+
+      const output = IdentityPrinter.print(parseResult.value!, { ignoreErrors: true })
+      expect(output).toBe(input)
+    })
+
+    test("custom printer static method respects options", () => {
+      const input = '<p>error test'
+      const parseResult = Herb.parse(input, { track_whitespace: true })
+
+      expect(() => UppercasePrinter.print(parseResult.value!)).toThrow()
+
+      const output = UppercasePrinter.print(parseResult.value!, { ignoreErrors: true })
+      expect(output).toBe('<p>ERROR TEST')
+    })
+  })
+})


### PR DESCRIPTION
This pull request adds a new static `Printer.print()` method that allows a `Printer` to be called without creating an instance:

```ts
import { IdentityPrinter } from "@herb-tools/printer"

const result = Herb.parse("<div>Hello</div>", { track_whitespace: true })

IdentityPrinter.print(result.value)
// => "<div>Hello</div>"
```