### PR TITLE
Update CONTRIBUTING.md with template generation step

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,12 @@ git clone https://github.com/marcoroth/herb && cd herb/
 
 #### Build Herb
 
+First we will need to generate the templates
+
+```bash
+bundle exec rake template
+```
+
 We can now compile all source files in `src/` and generate the `herb` executable.
 
 ```bash


### PR DESCRIPTION
While trying to set up the project locally I ran into an error when running `make all` after downloading it from GH

<img width="1526" height="456" alt="CleanShot 2025-08-23 at 17 38 59" src="https://github.com/user-attachments/assets/a0a4d990-23df-4aa4-abff-f47fe04305f1" />
> I first tried with `make all` and it also failed, the screenshot shows a later attempt


I needed to generate the templates it seems, otherwise I would get an error saying the files don't exist. This PR adds instructions to generate templates before building.