### PR TITLE
Add `templates` generation to Makefile build process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ ifeq ($(os),Darwin)
   clang_tidy = $(llvm_path)/bin/clang-tidy
 endif
 
-all: prism $(exec) $(lib_name) $(static_lib_name) test wasm
+all: templates prism $(exec) $(lib_name) $(static_lib_name) test wasm
 
 $(exec): $(objects)
 	$(cc) $(objects) $(flags) $(ldflags) $(prism_ldflags) -o $(exec)
@@ -88,10 +88,10 @@ $(lib_name): $(objects)
 $(static_lib_name): $(objects)
 	ar rcs $(static_lib_name) $(objects)
 
-src/%.o: src/%.c
+src/%.o: src/%.c templates
 	$(cc) -c $(flags) -fPIC $< -o $@
 
-test/%.o: test/%.c
+test/%.o: test/%.c templates
 	$(cc) -c $(test_cflags) $(test_flags) $(prism_flags) $< -o $@
 
 test: $(test_objects) $(non_main_objects)
@@ -104,6 +104,9 @@ clean:
 
 bundle_install:
 	bundle install
+
+templates: bundle_install
+	bundle exec rake templates
 
 prism: bundle_install
 	cd $(prism_path) && ruby templates/template.rb && make static && cd -


### PR DESCRIPTION
While trying to set up the project locally I ran into an error when running `make all` after downloading it from GH

<img width="1526" height="456" alt="CleanShot 2025-08-23 at 17 38 59" src="https://github.com/user-attachments/assets/a0a4d990-23df-4aa4-abff-f47fe04305f1" />
> I first tried with `make all` and it also failed, the screenshot shows a later attempt


I needed to generate the templates it seems, otherwise I would get an error saying the files don't exist. This PR adds a step to the `Makefile` so that there isn't a second step needed. Replaces #421 