### PR TITLE
Parser: Add `XMLDeclarationNode` node

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -306,6 +306,18 @@ nodes:
         - name: tag_closing
           type: token
 
+    - name: XMLDeclarationNode
+      fields:
+        - name: tag_opening
+          type: token
+
+        - name: children
+          type: array
+          kind: Node
+
+        - name: tag_closing
+          type: token
+
     - name: WhitespaceNode
       fields:
         - name: value

--- a/javascript/packages/formatter/src/format-printer.ts
+++ b/javascript/packages/formatter/src/format-printer.ts
@@ -47,6 +47,7 @@ import {
   ERBUnlessNode,
   ERBYieldNode,
   ERBInNode,
+  XMLDeclarationNode,
   Token
 } from "@herb-tools/core"
 
@@ -1020,6 +1021,10 @@ export class FormatPrinter extends Printer {
   }
 
   visitHTMLDoctypeNode(node: HTMLDoctypeNode) {
+    this.push(this.indent + IdentityPrinter.print(node))
+  }
+
+  visitXMLDeclarationNode(node: XMLDeclarationNode) {
     this.push(this.indent + IdentityPrinter.print(node))
   }
 

--- a/javascript/packages/formatter/test/xml/xml.test.ts
+++ b/javascript/packages/formatter/test/xml/xml.test.ts
@@ -1,0 +1,724 @@
+import { describe, test, expect, beforeAll } from "vitest"
+import { Herb } from "@herb-tools/node-wasm"
+import { Formatter } from "../../src"
+
+import dedent from "dedent"
+
+let formatter: Formatter
+
+describe("XML", () => {
+  beforeAll(async () => {
+    await Herb.load()
+
+    formatter = new Formatter(Herb, {
+      indentWidth: 2,
+      maxLineLength: 80
+    })
+  })
+
+  test("basic XML declaration with library", () => {
+    const source = dedent`
+      <?xml version="1.0" encoding="UTF-8"?>
+      <library
+        xmlns="http://example.com/library">
+        <book>
+            <title>XML Basics</title>
+            <author>John Doe</author>
+        </book>
+        <book>
+            <title>Advanced XML</title>
+            <author>Jane Smith</author>
+        </book>
+      </library>
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <?xml version="1.0" encoding="UTF-8"?>
+
+      <library xmlns="http://example.com/library">
+        <book>
+          <title>XML Basics</title>
+          <author>John Doe</author>
+        </book>
+        <book>
+          <title>Advanced XML</title>
+          <author>Jane Smith</author>
+        </book>
+      </library>
+    `)
+  })
+
+  test("XML with namespaces", () => {
+    const source = dedent`
+      <?xml version="1.0" encoding="UTF-8"?>
+      <catalog
+        xmlns:bk="http://example.com/books"
+        xmlns:auth="http://example.com/authors">
+        <bk:book>
+            <bk:title>XML Basics</bk:title>
+            <auth:author>John Doe</auth:author>
+        </bk:book>
+        <bk:book>
+            <bk:title>Advanced XML</bk:title>
+            <auth:author>Jane Smith</auth:author>
+        </bk:book>
+      </catalog>
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <?xml version="1.0" encoding="UTF-8"?>
+
+      <catalog
+        xmlns:bk="http://example.com/books"
+        xmlns:auth="http://example.com/authors"
+      >
+        <bk:book>
+          <bk:title>XML Basics</bk:title>
+          <auth:author>John Doe</auth:author>
+        </bk:book>
+        <bk:book>
+          <bk:title>Advanced XML</bk:title>
+          <auth:author>Jane Smith</auth:author>
+        </bk:book>
+      </catalog>
+    `)
+  })
+
+  test("simple namespaced elements", () => {
+    const source = dedent`
+      <root xmlns:prefix="http://example.com/ns">
+        <prefix:child>Content</prefix:child>
+      </root>
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <root xmlns:prefix="http://example.com/ns">
+        <prefix:child>Content</prefix:child>
+      </root>
+    `)
+  })
+
+  test("XML declaration with ERB render calls", () => {
+    const source = dedent`
+      <?xml version="1.0" encoding="UTF-8"?>
+      <books>
+        <% @books.each do |book| %>
+          <%= render book %>
+        <% end %>
+      </books>
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <?xml version="1.0" encoding="UTF-8"?>
+
+      <books>
+        <% @books.each do |book| %>
+          <%= render book %>
+        <% end %>
+      </books>
+    `)
+  })
+
+  test("XML with ERB conditional logic", () => {
+    const source = dedent`
+      <?xml version="1.0"?>
+      <library>
+        <% if @featured_books.any? %>
+          <featured>
+            <% @featured_books.each do |book| %>
+              <book id="<%= book.id %>">
+                <title><%= book.title %></title>
+                <% if book.author %>
+                  <author><%= book.author.name %></author>
+                <% else %>
+                  <author>Unknown</author>
+                <% end %>
+              </book>
+            <% end %>
+          </featured>
+        <% end %>
+
+        <catalog>
+          <% @books.each do |book| %>
+            <% unless book.featured? %>
+              <book>
+                <title><%= book.title %></title>
+                <isbn><%= book.isbn %></isbn>
+              </book>
+            <% end %>
+          <% end %>
+        </catalog>
+      </library>
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <?xml version="1.0"?>
+
+      <library>
+        <% if @featured_books.any? %>
+          <featured>
+            <% @featured_books.each do |book| %>
+              <book id="<%= book.id %>">
+                <title><%= book.title %></title>
+                <% if book.author %>
+                  <author><%= book.author.name %></author>
+                <% else %>
+                  <author>Unknown</author>
+                <% end %>
+              </book>
+            <% end %>
+          </featured>
+        <% end %>
+
+        <catalog>
+          <% @books.each do |book| %>
+            <% unless book.featured? %>
+              <book>
+                <title><%= book.title %></title>
+                <isbn><%= book.isbn %></isbn>
+              </book>
+            <% end %>
+          <% end %>
+        </catalog>
+      </library>
+    `)
+  })
+
+  test("XML declaration with ERB case statement", () => {
+    const source = dedent`
+      <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+      <document>
+        <% case @document_type %>
+        <% when 'book' %>
+          <book>
+            <title><%= @title %></title>
+            <chapters>
+              <% @chapters.each do |chapter| %>
+                <chapter number="<%= chapter.number %>">
+                  <title><%= chapter.title %></title>
+                </chapter>
+              <% end %>
+            </chapters>
+          </book>
+        <% when 'article' %>
+          <article>
+            <headline><%= @headline %></headline>
+            <content><%= @content %></content>
+          </article>
+        <% else %>
+          <unknown-type>
+            <content><%= @content %></content>
+          </unknown-type>
+        <% end %>
+      </document>
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+      <document>
+        <% case @document_type %>
+        <% when 'book' %>
+          <book>
+            <title><%= @title %></title>
+            <chapters>
+              <% @chapters.each do |chapter| %>
+                <chapter number="<%= chapter.number %>">
+                  <title><%= chapter.title %></title>
+                </chapter>
+              <% end %>
+            </chapters>
+          </book>
+        <% when 'article' %>
+          <article>
+            <headline><%= @headline %></headline>
+            <content><%= @content %></content>
+          </article>
+        <% else %>
+          <unknown-type>
+            <content><%= @content %></content>
+          </unknown-type>
+        <% end %>
+      </document>
+    `)
+  })
+
+  test("XML with ERB partial rendering and complex logic", () => {
+    const source = dedent`
+      <?xml version="1.0"?>
+      <sitemap xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+        <% if @pages.present? %>
+          <% @pages.group_by(&:section).each do |section, pages| %>
+            <!-- Section: <%= section.humanize %> -->
+            <% pages.each do |page| %>
+              <url>
+                <loc><%= page_url(page) %></loc>
+                <% if page.updated_at %>
+                  <lastmod><%= page.updated_at.iso8601 %></lastmod>
+                <% end %>
+                <changefreq><%= page.change_frequency || 'monthly' %></changefreq>
+                <priority><%= page.priority || 0.5 %></priority>
+              </url>
+            <% end %>
+
+            <% if section.has_subsections? %>
+              <%= render 'sitemap_subsections', section: section %>
+            <% end %>
+          <% end %>
+        <% else %>
+          <!-- No pages available -->
+          <url>
+            <loc><%= root_url %></loc>
+            <changefreq>daily</changefreq>
+            <priority>1.0</priority>
+          </url>
+        <% end %>
+      </sitemap>
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <?xml version="1.0"?>
+
+      <sitemap xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+        <% if @pages.present? %>
+          <% @pages.group_by(&:section).each do |section, pages| %>
+            <!-- Section: <%= section.humanize %> -->
+            <% pages.each do |page| %>
+              <url>
+                <loc><%= page_url(page) %></loc>
+                <% if page.updated_at %>
+                  <lastmod><%= page.updated_at.iso8601 %></lastmod>
+                <% end %>
+                <changefreq><%= page.change_frequency || 'monthly' %></changefreq>
+                <priority><%= page.priority || 0.5 %></priority>
+              </url>
+            <% end %>
+
+            <% if section.has_subsections? %>
+              <%= render 'sitemap_subsections', section: section %>
+            <% end %>
+          <% end %>
+        <% else %>
+          <!-- No pages available -->
+          <url>
+            <loc><%= root_url %></loc>
+            <changefreq>daily</changefreq>
+            <priority>1.0</priority>
+          </url>
+        <% end %>
+      </sitemap>
+    `)
+  })
+
+  test("XML RSS feed with ERB logic", () => {
+    const source = dedent`
+      <?xml version="1.0" encoding="UTF-8"?>
+      <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+        <channel>
+          <title><%= @feed_title %></title>
+          <description><%= @feed_description %></description>
+          <link><%= @site_url %></link>
+          <atom:link href="<%= request.url %>" rel="self" type="application/rss+xml" />
+
+          <% @articles.limit(20).each do |article| %>
+            <item>
+              <title><%= article.title %></title>
+              <description><![CDATA[<%= article.excerpt %>]]></description>
+              <link><%= article_url(article) %></link>
+              <guid><%= article_url(article) %></guid>
+              <pubDate><%= article.published_at.rfc2822 %></pubDate>
+
+              <% if article.author.present? %>
+                <author><%= article.author.email %> (<%= article.author.name %>)</author>
+              <% end %>
+
+              <% article.categories.each do |category| %>
+                <category><%= category.name %></category>
+              <% end %>
+            </item>
+          <% end %>
+        </channel>
+      </rss>
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <?xml version="1.0" encoding="UTF-8"?>
+      <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+        <channel>
+          <title><%= @feed_title %></title>
+          <description><%= @feed_description %></description>
+          <link><%= @site_url %></link>
+          <atom:link href="<%= request.url %>" rel="self" type="application/rss+xml" />
+
+          <% @articles.limit(20).each do |article| %>
+            <item>
+              <title><%= article.title %></title>
+              <description><![CDATA[<%= article.excerpt %>]]></description>
+              <link><%= article_url(article) %></link>
+              <guid><%= article_url(article) %></guid>
+              <pubDate><%= article.published_at.rfc2822 %></pubDate>
+
+              <% if article.author.present? %>
+                <author><%= article.author.email %> (<%= article.author.name %>)</author>
+              <% end %>
+
+              <% article.categories.each do |category| %>
+                <category><%= category.name %></category>
+              <% end %>
+            </item>
+          <% end %>
+        </channel>
+      </rss>
+    `)
+  })
+
+  test("real-world XML ERB template with complex nested logic", () => {
+    const source = dedent`
+      <?xml version="1.0" encoding="UTF-8"?>
+      <Document>
+        <%= render layout: "mobile_ui/restaurant/meal_wrapper" do %>
+          <%= render partial: "mobile_ui/restaurant/nav_header" %>
+          <%= render partial: "mobile_ui/restaurant/page_title", locals: { title: "Confirm Your Order" } %>
+
+          <% unless order_items_missing %>
+            <% if customer_app_version.present? && customer_app_version >= AppVersion.new("2.3.1") %>
+              <%= render partial: "mobile_ui/restaurant/components/order_summary", locals: {
+                title: "Items in Your Order",
+                subtitle: "review items below",
+                order_items: order_items
+              } %>
+            <% end %>
+          <% end %>
+
+          <%= render partial: "mobile_ui/restaurant/components/payment_card", locals: {
+            message: "Please review your payment method and total",
+            show_total: true,
+          } %>
+
+          <%= render partial: "mobile_ui/restaurant/components/special_instructions" %>
+
+          <% if order_items_missing %>
+            <% if customer_app_version.present? && customer_app_version >= AppVersion.new("2.3.1") %>
+              <%= render partial: "mobile_ui/restaurant/components/order_summary", locals: {
+                title: "Missing Items - Please Add",
+                subtitle: "Select items from the menu to complete your order.",
+                order_items: order_items
+              } %>
+            <% end %>
+          <% end %>
+
+      <% gallery_images = restaurant_gallery_photos %>
+
+        <Section styleName="bg-surface p-6 rounded-lg shadow-sm">
+          <SectionHeader>
+            <Title xml:space="preserve">Upload a photo <Emphasis styleName="font-semibold" >showing your table setup</Emphasis> for verification.</Title>
+            <Description styleName="text-sm text-secondary">Our system will verify your table matches your reservation. This helps us ensure food safety and accurate delivery to the right location.</Description>
+          </SectionHeader>
+          <ImageGallery
+                    orientation="horizontal"
+                    containerClass="gap-3 pt-4 pr-4"
+                    styleName="flex flex-row overflow-scroll gap-3"
+                  >
+            <% gallery_images.each do |image| %>
+              <GalleryImage size="large" src="<%= image[:src]%>" alt="<%= image[:alt]%>" width="<%= image[:width]%>" height="<%= image[:height]%>"></GalleryImage>
+            <% end %>
+          </ImageGallery>
+        </Section>
+
+        <% end %>
+
+        <%= render partial: "mobile_ui/restaurant/toast_notifications"%>
+
+        <% unless defined?(order_confirmed) && order_confirmed == true %>
+          <% if order_items_missing %>
+            <% if customer_app_version.present? && customer_app_version >= AppVersion.new("2.3.1") %>
+              <%= render partial: "mobile_ui/restaurant/footers/action_footer", locals: {
+                action_type: "menu_browse",
+                primary_button_text: "Browse Menu"
+              } %>
+            <% end %>
+          <% elsif verification_photos_needed %>
+            <%= render partial: "mobile_ui/restaurant/footers/action_footer", locals: {
+              action_type: "camera",
+              primary_button_text: "Take Photo"
+            } %>
+          <% else %>
+            <%= render partial: "mobile_ui/restaurant/footers/checkout_footer", locals: {
+              primary_button_text: "Complete Order",
+              order_items: order_items,
+              enable_photos: true,
+              enable_payment: true,
+            } %>
+          <% end %>
+        <% end %>
+      </Document>
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <?xml version="1.0" encoding="UTF-8"?>
+
+      <Document>
+        <%= render layout: "mobile_ui/restaurant/meal_wrapper" do %>
+          <%= render partial: "mobile_ui/restaurant/nav_header" %>
+          <%= render partial: "mobile_ui/restaurant/page_title", locals: { title: "Confirm Your Order" } %>
+
+          <% unless order_items_missing %>
+            <% if customer_app_version.present? && customer_app_version >= AppVersion.new("2.3.1") %>
+              <%= render partial: "mobile_ui/restaurant/components/order_summary", locals: {
+                title: "Items in Your Order",
+                subtitle: "review items below",
+                order_items: order_items
+              } %>
+            <% end %>
+          <% end %>
+
+          <%= render partial: "mobile_ui/restaurant/components/payment_card", locals: {
+            message: "Please review your payment method and total",
+            show_total: true,
+          } %>
+
+          <%= render partial: "mobile_ui/restaurant/components/special_instructions" %>
+
+          <% if order_items_missing %>
+            <% if customer_app_version.present? && customer_app_version >= AppVersion.new("2.3.1") %>
+              <%= render partial: "mobile_ui/restaurant/components/order_summary", locals: {
+                title: "Missing Items - Please Add",
+                subtitle: "Select items from the menu to complete your order.",
+                order_items: order_items
+              } %>
+            <% end %>
+          <% end %>
+
+          <% gallery_images = restaurant_gallery_photos %>
+
+          <Section styleName="bg-surface p-6 rounded-lg shadow-sm">
+            <SectionHeader>
+              <Title xml:space="preserve">
+                Upload a photo
+                <Emphasis styleName="font-semibold">
+                  showing your table setup
+                </Emphasis>
+                for verification.
+              </Title>
+              <Description styleName="text-sm text-secondary">
+                Our system will verify your table matches your reservation. This helps
+                us ensure food safety and accurate delivery to the right location.
+              </Description>
+            </SectionHeader>
+            <ImageGallery
+              orientation="horizontal"
+              containerClass="gap-3 pt-4 pr-4"
+              styleName="flex flex-row overflow-scroll gap-3"
+            >
+              <% gallery_images.each do |image| %>
+                <GalleryImage
+                  size="large"
+                  src="<%= image[:src]%>"
+                  alt="<%= image[:alt]%>"
+                  width="<%= image[:width]%>"
+                  height="<%= image[:height]%>"
+                ></GalleryImage>
+              <% end %>
+            </ImageGallery>
+          </Section>
+        <% end %>
+
+        <%= render partial: "mobile_ui/restaurant/toast_notifications" %>
+
+        <% unless defined?(order_confirmed) && order_confirmed == true %>
+          <% if order_items_missing %>
+            <% if customer_app_version.present? && customer_app_version >= AppVersion.new("2.3.1") %>
+              <%= render partial: "mobile_ui/restaurant/footers/action_footer", locals: {
+                action_type: "menu_browse",
+                primary_button_text: "Browse Menu"
+              } %>
+            <% end %>
+          <% elsif verification_photos_needed %>
+            <%= render partial: "mobile_ui/restaurant/footers/action_footer", locals: {
+              action_type: "camera",
+              primary_button_text: "Take Photo"
+            } %>
+          <% else %>
+            <%= render partial: "mobile_ui/restaurant/footers/checkout_footer", locals: {
+              primary_button_text: "Complete Order",
+              order_items: order_items,
+              enable_photos: true,
+              enable_payment: true,
+            } %>
+          <% end %>
+        <% end %>
+      </Document>
+    `)
+  })
+
+  test("XML with complex ERB assignments and UI components", () => {
+    const source = dedent`
+      <?xml version="1.0" encoding="UTF-8"?>
+      <Screen>
+        <%= render layout: "mobile/app_layout" do %>
+          <% current_user_orders = @user.orders.active %>
+          <% notification_count = current_user_orders.unread.count %>
+
+          <%= render partial: "shared/navigation", locals: {
+            title: "My Orders",
+            badge_count: notification_count
+          } %>
+
+          <% if current_user_orders.any? %>
+            <ScrollView styleName="flex-1 bg-background">
+              <% current_user_orders.group_by(&:status).each do |status, orders| %>
+                <Section>
+                  <HeaderText><%= status.humanize %> Orders (<%= orders.count %>)</HeaderText>
+
+                  <% orders.each_with_index do |order, index| %>
+                    <% estimated_time = order.estimated_completion %>
+                    <% is_urgent = order.priority == 'high' %>
+
+                    <OrderCard
+                      id="<%= order.id %>"
+                      urgent="<%= is_urgent %>"
+                      estimatedTime="<%= estimated_time&.strftime('%I:%M %p') %>"
+                    >
+                      <% if order.items.present? %>
+                        <ItemsList>
+                          <% order.items.limit(3).each do |item| %>
+                            <Item
+                              name="<%= item.name %>"
+                              quantity="<%= item.quantity %>"
+                            />
+                          <% end %>
+
+                          <% if order.items.count > 3 %>
+                            <Item
+                              name="... and <%= pluralize(order.items.count - 3, 'more item') %>"
+                            />
+                          <% end %>
+                        </ItemsList>
+                      <% end %>
+
+                      <StatusBadge
+                        status="<%= order.status %>"
+                        color="<%= order.status_color %>"
+                      />
+
+                      <% case order.status %>
+                      <% when 'pending' %>
+                        <%= render partial: "orders/pending_actions", locals: { order: order } %>
+                      <% when 'in_progress' %>
+                        <%= render partial: "orders/progress_tracker", locals: {
+                          order: order,
+                          show_eta: true
+                        } %>
+                      <% when 'ready' %>
+                        <%= render partial: "orders/pickup_instructions", locals: { order: order } %>
+                      <% else %>
+                        <Text styleName="text-muted">
+                          Status: <%= order.status.humanize %>
+                        </Text>
+                      <% end %>
+                    </OrderCard>
+                  <% end %>
+                </Section>
+              <% end %>
+            </ScrollView>
+          <% else %>
+            <%= render partial: "shared/empty_state", locals: {
+              title: "No orders yet",
+              description: "When you place an order, it will appear here.",
+              action_text: "Browse Menu",
+              action_path: menu_path
+            } %>
+          <% end %>
+
+          <%= render partial: "shared/bottom_navigation" %>
+        <% end %>
+      </Screen>
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <?xml version="1.0" encoding="UTF-8"?>
+
+      <Screen>
+        <%= render layout: "mobile/app_layout" do %>
+          <% current_user_orders = @user.orders.active %>
+          <% notification_count = current_user_orders.unread.count %>
+
+          <%= render partial: "shared/navigation", locals: {
+            title: "My Orders",
+            badge_count: notification_count
+          } %>
+
+          <% if current_user_orders.any? %>
+            <ScrollView styleName="flex-1 bg-background">
+              <% current_user_orders.group_by(&:status).each do |status, orders| %>
+                <Section>
+                  <HeaderText>
+                    <%= status.humanize %> Orders (<%= orders.count %>)
+                  </HeaderText>
+
+                  <% orders.each_with_index do |order, index| %>
+                    <% estimated_time = order.estimated_completion %>
+                    <% is_urgent = order.priority == 'high' %>
+
+                    <OrderCard
+                      id="<%= order.id %>"
+                      urgent="<%= is_urgent %>"
+                      estimatedTime="<%= estimated_time&.strftime('%I:%M %p') %>"
+                    >
+                      <% if order.items.present? %>
+                        <ItemsList>
+                          <% order.items.limit(3).each do |item| %>
+                            <Item
+                              name="<%= item.name %>"
+                              quantity="<%= item.quantity %>"
+                            />
+                          <% end %>
+
+                          <% if order.items.count > 3 %>
+                            <Item
+                              name="... and <%= pluralize(order.items.count - 3, 'more item') %>"
+                            />
+                          <% end %>
+                        </ItemsList>
+                      <% end %>
+
+                      <StatusBadge
+                        status="<%= order.status %>"
+                        color="<%= order.status_color %>"
+                      />
+
+                      <% case order.status %>
+                      <% when 'pending' %>
+                        <%= render partial: "orders/pending_actions", locals: { order: order } %>
+                      <% when 'in_progress' %>
+                        <%= render partial: "orders/progress_tracker", locals: {
+                          order: order,
+                          show_eta: true
+                        } %>
+                      <% when 'ready' %>
+                        <%= render partial: "orders/pickup_instructions", locals: { order: order } %>
+                      <% else %>
+                        <Text styleName="text-muted">
+                          Status: <%= order.status.humanize %>
+                        </Text>
+                      <% end %>
+                    </OrderCard>
+                  <% end %>
+                </Section>
+              <% end %>
+            </ScrollView>
+          <% else %>
+            <%= render partial: "shared/empty_state", locals: {
+              title: "No orders yet",
+              description: "When you place an order, it will appear here.",
+              action_text: "Browse Menu",
+              action_path: menu_path
+            } %>
+          <% end %>
+
+          <%= render partial: "shared/bottom_navigation" %>
+        <% end %>
+      </Screen>
+    `)
+  })
+})

--- a/javascript/packages/printer/src/printer.ts
+++ b/javascript/packages/printer/src/printer.ts
@@ -191,6 +191,18 @@ export abstract class Printer extends Visitor {
     }
   }
 
+  visitXMLDeclarationNode(node: Nodes.XMLDeclarationNode): void {
+    if (node.tag_opening) {
+      this.context.write(node.tag_opening.value)
+    }
+
+    this.visitChildNodes(node)
+
+    if (node.tag_closing) {
+      this.context.write(node.tag_closing.value)
+    }
+  }
+
   visitERBContentNode(node: Nodes.ERBContentNode): void {
     this.printERBNode(node)
   }

--- a/javascript/packages/printer/test/nodes/x-m-l-declaration-node.test.ts
+++ b/javascript/packages/printer/test/nodes/x-m-l-declaration-node.test.ts
@@ -1,0 +1,88 @@
+import dedent from "dedent"
+import { describe, test, beforeAll } from "vitest"
+
+import { Herb } from "@herb-tools/node-wasm"
+import { XMLDeclarationNode, LiteralNode } from "@herb-tools/core"
+
+import { expectNodeToPrint, expectPrintRoundTrip, createLocation, createToken } from "../helpers/printer-test-helpers.js"
+
+describe("XMLDeclarationNode Printing", () => {
+  beforeAll(async () => {
+    await Herb.load()
+  })
+
+  test("can print basic XML declaration from node", () => {
+    const literalNode = LiteralNode.from({
+      type: "AST_LITERAL_NODE",
+      location: createLocation(),
+      errors: [],
+      content: " version=\"1.0\""
+    })
+
+    const node = XMLDeclarationNode.from({
+      type: "AST_XML_DECLARATION_NODE",
+      location: createLocation(),
+      errors: [],
+      tag_opening: createToken("TOKEN_XML_DECLARATION", "<?xml"),
+      children: [literalNode],
+      tag_closing: createToken("TOKEN_HTML_TAG_END", "?>")
+    })
+
+    expectNodeToPrint(node, "<?xml version=\"1.0\"?>")
+  })
+
+  test("can print XML declaration with encoding from node", () => {
+    const literalNode = LiteralNode.from({
+      type: "AST_LITERAL_NODE",
+      location: createLocation(),
+      errors: [],
+      content: " version=\"1.0\" encoding=\"UTF-8\""
+    })
+
+    const node = XMLDeclarationNode.from({
+      type: "AST_XML_DECLARATION_NODE",
+      location: createLocation(),
+      errors: [],
+      tag_opening: createToken("TOKEN_XML_DECLARATION", "<?xml"),
+      children: [literalNode],
+      tag_closing: createToken("TOKEN_HTML_TAG_END", "?>")
+    })
+
+    expectNodeToPrint(node, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>")
+  })
+
+  test("can print basic XML declaration from source", () => {
+    expectPrintRoundTrip("<?xml version=\"1.0\"?>")
+  })
+
+  test("can print XML declaration with encoding from source", () => {
+    expectPrintRoundTrip("<?xml version=\"1.0\" encoding=\"UTF-8\"?>")
+  })
+
+  test("can print XML declaration with encoding ISO-8859-1 from source", () => {
+    expectPrintRoundTrip("<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>")
+  })
+
+  test("can print XML declaration with standalone from source", () => {
+    expectPrintRoundTrip("<?xml version=\"1.0\" standalone=\"yes\"?>")
+  })
+
+  test("can print XML declaration with all attributes from source", () => {
+    expectPrintRoundTrip("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>")
+  })
+
+  test("can print XML declaration with spaces from source", () => {
+    expectPrintRoundTrip("<?xml  version = \"1.0\"  ?>")
+  })
+
+  test("can print XML declaration with single quotes from source", () => {
+    expectPrintRoundTrip("<?xml version='1.0' encoding='UTF-8'?>")
+  })
+
+  test("can print XML declaration followed by HTML from source", () => {
+    expectPrintRoundTrip(dedent`
+      <?xml version="1.0"?>
+      <html><body>Hello</body></html>
+    `)
+  })
+})

--- a/sig/herb/ast/nodes.rbs
+++ b/sig/herb/ast/nodes.rbs
@@ -317,6 +317,35 @@ module Herb
       def tree_inspect: (?Integer) -> String
     end
 
+    class XMLDeclarationNode < Node
+      attr_reader tag_opening: Herb::Token
+
+      attr_reader children: Array[Herb::AST::Node]
+
+      attr_reader tag_closing: Herb::Token
+
+      # : (String, Location, Array[Herb::Errors::Error], Herb::Token, Array[Herb::AST::Node], Herb::Token) -> void
+      def initialize: (String, Location, Array[Herb::Errors::Error], Herb::Token, Array[Herb::AST::Node], Herb::Token) -> void
+
+      # : () -> serialized_xml_declaration_node
+      def to_hash: () -> serialized_xml_declaration_node
+
+      # : (Visitor) -> void
+      def accept: (Visitor) -> void
+
+      # : () -> Array[Herb::AST::Node?]
+      def child_nodes: () -> Array[Herb::AST::Node?]
+
+      # : () -> Array[Herb::AST::Node]
+      def compact_child_nodes: () -> Array[Herb::AST::Node]
+
+      # : () -> String
+      def inspect: () -> String
+
+      # : (?Integer) -> String
+      def tree_inspect: (?Integer) -> String
+    end
+
     class WhitespaceNode < Node
       attr_reader value: Herb::Token
 

--- a/sig/herb/visitor.rbs
+++ b/sig/herb/visitor.rbs
@@ -44,6 +44,9 @@ module Herb
     # : (Herb::AST::HTMLDoctypeNode) -> void
     def visit_html_doctype_node: (Herb::AST::HTMLDoctypeNode) -> void
 
+    # : (Herb::AST::XMLDeclarationNode) -> void
+    def visit_xml_declaration_node: (Herb::AST::XMLDeclarationNode) -> void
+
     # : (Herb::AST::WhitespaceNode) -> void
     def visit_whitespace_node: (Herb::AST::WhitespaceNode) -> void
 

--- a/src/include/lexer_peek_helpers.h
+++ b/src/include/lexer_peek_helpers.h
@@ -21,6 +21,7 @@ typedef struct {
 
 char lexer_peek(const lexer_T* lexer, int offset);
 bool lexer_peek_for_doctype(const lexer_T* lexer, int offset);
+bool lexer_peek_for_xml_declaration(const lexer_T* lexer, int offset);
 
 bool lexer_peek_for_html_comment_start(const lexer_T* lexer, int offset);
 bool lexer_peek_for_html_comment_end(const lexer_T* lexer, int offset);

--- a/src/include/token_struct.h
+++ b/src/include/token_struct.h
@@ -11,6 +11,8 @@ typedef enum {
   TOKEN_IDENTIFIER,
 
   TOKEN_HTML_DOCTYPE, // <!DOCTYPE, <!doctype, <!DoCtYpE, <!dOcTyPe
+  TOKEN_XML_DECLARATION, // <?xml
+  TOKEN_XML_DECLARATION_END, // ?>
 
   TOKEN_HTML_TAG_START,       // <
   TOKEN_HTML_TAG_START_CLOSE, // </

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -290,6 +290,10 @@ token_T* lexer_next_token(lexer_T* lexer) {
         return lexer_advance_with_next(lexer, strlen("<!DOCTYPE"), TOKEN_HTML_DOCTYPE);
       }
 
+      if (lexer_peek_for_xml_declaration(lexer, 0)) {
+        return lexer_advance_with_next(lexer, strlen("<?xml"), TOKEN_XML_DECLARATION);
+      }
+
       if (isalnum(lexer_peek(lexer, 1))) { return lexer_advance_current(lexer, TOKEN_HTML_TAG_START); }
 
       if (lexer_peek_for_html_comment_start(lexer, 0)) {
@@ -306,6 +310,11 @@ token_T* lexer_next_token(lexer_T* lexer) {
     case '/': {
       token_T* token = lexer_match_and_advance(lexer, "/>", TOKEN_HTML_TAG_SELF_CLOSE);
       return token ? token : lexer_advance_current(lexer, TOKEN_SLASH);
+    }
+
+    case '?': {
+      token_T* token = lexer_match_and_advance(lexer, "?>", TOKEN_XML_DECLARATION_END);
+      return token ? token : lexer_advance_current(lexer, TOKEN_CHARACTER);
     }
 
     case '-': {

--- a/src/lexer_peek_helpers.c
+++ b/src/lexer_peek_helpers.c
@@ -33,6 +33,10 @@ bool lexer_peek_for_doctype(const lexer_T* lexer, const int offset) {
   return lexer_peek_for(lexer, offset, "<!DOCTYPE", true);
 }
 
+bool lexer_peek_for_xml_declaration(const lexer_T* lexer, const int offset) {
+  return lexer_peek_for(lexer, offset, "<?xml", true);
+}
+
 bool lexer_peek_for_html_comment_start(const lexer_T* lexer, const int offset) {
   return lexer_peek_for(lexer, offset, "<!--", false);
 }

--- a/src/token.c
+++ b/src/token.c
@@ -47,6 +47,8 @@ const char* token_type_to_string(const token_type_T type) {
     case TOKEN_NEWLINE: return "TOKEN_NEWLINE";
     case TOKEN_IDENTIFIER: return "TOKEN_IDENTIFIER";
     case TOKEN_HTML_DOCTYPE: return "TOKEN_HTML_DOCTYPE";
+    case TOKEN_XML_DECLARATION: return "TOKEN_XML_DECLARATION";
+    case TOKEN_XML_DECLARATION_END: return "TOKEN_XML_DECLARATION_END";
     case TOKEN_HTML_TAG_START: return "TOKEN_HTML_TAG_START";
     case TOKEN_HTML_TAG_END: return "TOKEN_HTML_TAG_END";
     case TOKEN_HTML_TAG_START_CLOSE: return "TOKEN_HTML_TAG_START_CLOSE";

--- a/test/lexer/xml_declaration_test.rb
+++ b/test/lexer/xml_declaration_test.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+module Lexer
+  class XMLDeclarationTest < Minitest::Spec
+    include SnapshotUtils
+
+    test "basic xml declaration" do
+      assert_lexed_snapshot("<?xml version=\"1.0\"?>")
+    end
+
+    test "xml declaration with encoding" do
+      assert_lexed_snapshot("<?xml version=\"1.0\" encoding=\"UTF-8\"?>")
+    end
+
+    test "xml declaration with encoding ISO-8859-1" do
+      assert_lexed_snapshot("<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>")
+    end
+
+    test "xml declaration with standalone" do
+      assert_lexed_snapshot("<?xml version=\"1.0\" standalone=\"yes\"?>")
+    end
+
+    test "xml declaration with all attributes" do
+      assert_lexed_snapshot("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>")
+    end
+
+    test "xml declaration case insensitive 1" do
+      assert_lexed_snapshot("<?xml version=\"1.0\"?>")
+    end
+
+    test "xml declaration case insensitive 2" do
+      assert_lexed_snapshot("<?XML version=\"1.0\"?>")
+    end
+
+    test "xml declaration case insensitive 3" do
+      assert_lexed_snapshot("<?Xml version=\"1.0\"?>")
+    end
+
+    test "xml declaration with spaces" do
+      assert_lexed_snapshot("<?xml  version = \"1.0\"  ?>")
+    end
+
+    test "xml declaration with newlines" do
+      assert_lexed_snapshot("<?xml version=\"1.0\"\n      encoding=\"UTF-8\"?>")
+    end
+
+    test "xml declaration with single quotes" do
+      assert_lexed_snapshot("<?xml version='1.0' encoding='UTF-8'?>")
+    end
+
+    test "xml declaration followed by html" do
+      assert_lexed_snapshot("<?xml version=\"1.0\"?>\n<html><body>Hello</body></html>")
+    end
+  end
+end

--- a/test/parser/xml_declaration_test.rb
+++ b/test/parser/xml_declaration_test.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+module Parser
+  class XMLDeclarationTest < Minitest::Spec
+    include SnapshotUtils
+
+    test "basic xml declaration" do
+      assert_parsed_snapshot("<?xml version=\"1.0\"?>")
+    end
+
+    test "xml declaration with encoding" do
+      assert_parsed_snapshot("<?xml version=\"1.0\" encoding=\"UTF-8\"?>")
+    end
+
+    test "xml declaration with encoding ISO-8859-1" do
+      assert_parsed_snapshot("<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>")
+    end
+
+    test "xml declaration with standalone" do
+      assert_parsed_snapshot("<?xml version=\"1.0\" standalone=\"yes\"?>")
+    end
+
+    test "xml declaration with all attributes" do
+      assert_parsed_snapshot("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>")
+    end
+
+    test "xml declaration case insensitive 1" do
+      assert_parsed_snapshot("<?xml version=\"1.0\"?>")
+    end
+
+    test "xml declaration case insensitive 2" do
+      assert_parsed_snapshot("<?XML version=\"1.0\"?>")
+    end
+
+    test "xml declaration case insensitive 3" do
+      assert_parsed_snapshot("<?Xml version=\"1.0\"?>")
+    end
+
+    test "xml declaration with spaces" do
+      assert_parsed_snapshot("<?xml  version = \"1.0\"  ?>")
+    end
+
+    test "xml declaration with newlines" do
+      assert_parsed_snapshot("<?xml version=\"1.0\"\n      encoding=\"UTF-8\"?>")
+    end
+
+    test "xml declaration with single quotes" do
+      assert_parsed_snapshot("<?xml version='1.0' encoding='UTF-8'?>")
+    end
+
+    test "xml declaration followed by html" do
+      assert_parsed_snapshot("<?xml version=\"1.0\"?>\n<html><body>Hello</body></html>")
+    end
+
+    test "two xml declarations" do
+      assert_parsed_snapshot("<?xml version=\"1.0\"?><?xml version=\"1.1\"?>")
+    end
+
+    test "xml declaration with erb content" do
+      assert_parsed_snapshot("<?xml version=\"<%= @version %>\" encoding=\"UTF-8\"?>")
+    end
+
+    test "xml declaration in html document" do
+      assert_parsed_snapshot("<!DOCTYPE html>\n<?xml version=\"1.0\"?>\n<html><body>Content</body></html>")
+    end
+  end
+end

--- a/test/snapshots/lexer/xml_declaration_test/test_0001_basic_xml_declaration_e4e345519e2b76863647d3351ace49e0.txt
+++ b/test/snapshots/lexer/xml_declaration_test/test_0001_basic_xml_declaration_e4e345519e2b76863647d3351ace49e0.txt
@@ -1,0 +1,11 @@
+#<Herb::Token type="TOKEN_XML_DECLARATION" value="<?xml" range=[0, 5] start=(1:0) end=(1:5)>
+#<Herb::Token type="TOKEN_WHITESPACE" value=" " range=[5, 6] start=(1:5) end=(1:6)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="version" range=[6, 13] start=(1:6) end=(1:13)>
+#<Herb::Token type="TOKEN_EQUALS" value="=" range=[13, 14] start=(1:13) end=(1:14)>
+#<Herb::Token type="TOKEN_QUOTE" value="\"" range=[14, 15] start=(1:14) end=(1:15)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="1" range=[15, 16] start=(1:15) end=(1:16)>
+#<Herb::Token type="TOKEN_CHARACTER" value="." range=[16, 17] start=(1:16) end=(1:17)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="0" range=[17, 18] start=(1:17) end=(1:18)>
+#<Herb::Token type="TOKEN_QUOTE" value="\"" range=[18, 19] start=(1:18) end=(1:19)>
+#<Herb::Token type="TOKEN_XML_DECLARATION_END" value="?>" range=[19, 21] start=(1:19) end=(1:21)>
+#<Herb::Token type="TOKEN_EOF" value="<EOF>" range=[21, 21] start=(1:21) end=(1:21)>

--- a/test/snapshots/lexer/xml_declaration_test/test_0002_xml_declaration_with_encoding_447d423b62bc6692ce2266e1dfb0a3b5.txt
+++ b/test/snapshots/lexer/xml_declaration_test/test_0002_xml_declaration_with_encoding_447d423b62bc6692ce2266e1dfb0a3b5.txt
@@ -1,0 +1,17 @@
+#<Herb::Token type="TOKEN_XML_DECLARATION" value="<?xml" range=[0, 5] start=(1:0) end=(1:5)>
+#<Herb::Token type="TOKEN_WHITESPACE" value=" " range=[5, 6] start=(1:5) end=(1:6)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="version" range=[6, 13] start=(1:6) end=(1:13)>
+#<Herb::Token type="TOKEN_EQUALS" value="=" range=[13, 14] start=(1:13) end=(1:14)>
+#<Herb::Token type="TOKEN_QUOTE" value="\"" range=[14, 15] start=(1:14) end=(1:15)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="1" range=[15, 16] start=(1:15) end=(1:16)>
+#<Herb::Token type="TOKEN_CHARACTER" value="." range=[16, 17] start=(1:16) end=(1:17)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="0" range=[17, 18] start=(1:17) end=(1:18)>
+#<Herb::Token type="TOKEN_QUOTE" value="\"" range=[18, 19] start=(1:18) end=(1:19)>
+#<Herb::Token type="TOKEN_WHITESPACE" value=" " range=[19, 20] start=(1:19) end=(1:20)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="encoding" range=[20, 28] start=(1:20) end=(1:28)>
+#<Herb::Token type="TOKEN_EQUALS" value="=" range=[28, 29] start=(1:28) end=(1:29)>
+#<Herb::Token type="TOKEN_QUOTE" value="\"" range=[29, 30] start=(1:29) end=(1:30)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="UTF-8" range=[30, 35] start=(1:30) end=(1:35)>
+#<Herb::Token type="TOKEN_QUOTE" value="\"" range=[35, 36] start=(1:35) end=(1:36)>
+#<Herb::Token type="TOKEN_XML_DECLARATION_END" value="?>" range=[36, 38] start=(1:36) end=(1:38)>
+#<Herb::Token type="TOKEN_EOF" value="<EOF>" range=[38, 38] start=(1:38) end=(1:38)>

--- a/test/snapshots/lexer/xml_declaration_test/test_0003_xml_declaration_with_encoding_ISO-8859-1_dd4263447c1fda5ed82c31b9d2f8f24c.txt
+++ b/test/snapshots/lexer/xml_declaration_test/test_0003_xml_declaration_with_encoding_ISO-8859-1_dd4263447c1fda5ed82c31b9d2f8f24c.txt
@@ -1,0 +1,17 @@
+#<Herb::Token type="TOKEN_XML_DECLARATION" value="<?xml" range=[0, 5] start=(1:0) end=(1:5)>
+#<Herb::Token type="TOKEN_WHITESPACE" value=" " range=[5, 6] start=(1:5) end=(1:6)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="version" range=[6, 13] start=(1:6) end=(1:13)>
+#<Herb::Token type="TOKEN_EQUALS" value="=" range=[13, 14] start=(1:13) end=(1:14)>
+#<Herb::Token type="TOKEN_QUOTE" value="\"" range=[14, 15] start=(1:14) end=(1:15)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="1" range=[15, 16] start=(1:15) end=(1:16)>
+#<Herb::Token type="TOKEN_CHARACTER" value="." range=[16, 17] start=(1:16) end=(1:17)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="0" range=[17, 18] start=(1:17) end=(1:18)>
+#<Herb::Token type="TOKEN_QUOTE" value="\"" range=[18, 19] start=(1:18) end=(1:19)>
+#<Herb::Token type="TOKEN_WHITESPACE" value=" " range=[19, 20] start=(1:19) end=(1:20)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="encoding" range=[20, 28] start=(1:20) end=(1:28)>
+#<Herb::Token type="TOKEN_EQUALS" value="=" range=[28, 29] start=(1:28) end=(1:29)>
+#<Herb::Token type="TOKEN_QUOTE" value="\"" range=[29, 30] start=(1:29) end=(1:30)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="ISO-8859-1" range=[30, 40] start=(1:30) end=(1:40)>
+#<Herb::Token type="TOKEN_QUOTE" value="\"" range=[40, 41] start=(1:40) end=(1:41)>
+#<Herb::Token type="TOKEN_XML_DECLARATION_END" value="?>" range=[41, 43] start=(1:41) end=(1:43)>
+#<Herb::Token type="TOKEN_EOF" value="<EOF>" range=[43, 43] start=(1:43) end=(1:43)>

--- a/test/snapshots/lexer/xml_declaration_test/test_0004_xml_declaration_with_standalone_5aa41195cf30adefdbca245f08726269.txt
+++ b/test/snapshots/lexer/xml_declaration_test/test_0004_xml_declaration_with_standalone_5aa41195cf30adefdbca245f08726269.txt
@@ -1,0 +1,17 @@
+#<Herb::Token type="TOKEN_XML_DECLARATION" value="<?xml" range=[0, 5] start=(1:0) end=(1:5)>
+#<Herb::Token type="TOKEN_WHITESPACE" value=" " range=[5, 6] start=(1:5) end=(1:6)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="version" range=[6, 13] start=(1:6) end=(1:13)>
+#<Herb::Token type="TOKEN_EQUALS" value="=" range=[13, 14] start=(1:13) end=(1:14)>
+#<Herb::Token type="TOKEN_QUOTE" value="\"" range=[14, 15] start=(1:14) end=(1:15)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="1" range=[15, 16] start=(1:15) end=(1:16)>
+#<Herb::Token type="TOKEN_CHARACTER" value="." range=[16, 17] start=(1:16) end=(1:17)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="0" range=[17, 18] start=(1:17) end=(1:18)>
+#<Herb::Token type="TOKEN_QUOTE" value="\"" range=[18, 19] start=(1:18) end=(1:19)>
+#<Herb::Token type="TOKEN_WHITESPACE" value=" " range=[19, 20] start=(1:19) end=(1:20)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="standalone" range=[20, 30] start=(1:20) end=(1:30)>
+#<Herb::Token type="TOKEN_EQUALS" value="=" range=[30, 31] start=(1:30) end=(1:31)>
+#<Herb::Token type="TOKEN_QUOTE" value="\"" range=[31, 32] start=(1:31) end=(1:32)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="yes" range=[32, 35] start=(1:32) end=(1:35)>
+#<Herb::Token type="TOKEN_QUOTE" value="\"" range=[35, 36] start=(1:35) end=(1:36)>
+#<Herb::Token type="TOKEN_XML_DECLARATION_END" value="?>" range=[36, 38] start=(1:36) end=(1:38)>
+#<Herb::Token type="TOKEN_EOF" value="<EOF>" range=[38, 38] start=(1:38) end=(1:38)>

--- a/test/snapshots/lexer/xml_declaration_test/test_0005_xml_declaration_with_all_attributes_3ef840d0361caa4801a5f9ec97056a2b.txt
+++ b/test/snapshots/lexer/xml_declaration_test/test_0005_xml_declaration_with_all_attributes_3ef840d0361caa4801a5f9ec97056a2b.txt
@@ -1,0 +1,23 @@
+#<Herb::Token type="TOKEN_XML_DECLARATION" value="<?xml" range=[0, 5] start=(1:0) end=(1:5)>
+#<Herb::Token type="TOKEN_WHITESPACE" value=" " range=[5, 6] start=(1:5) end=(1:6)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="version" range=[6, 13] start=(1:6) end=(1:13)>
+#<Herb::Token type="TOKEN_EQUALS" value="=" range=[13, 14] start=(1:13) end=(1:14)>
+#<Herb::Token type="TOKEN_QUOTE" value="\"" range=[14, 15] start=(1:14) end=(1:15)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="1" range=[15, 16] start=(1:15) end=(1:16)>
+#<Herb::Token type="TOKEN_CHARACTER" value="." range=[16, 17] start=(1:16) end=(1:17)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="0" range=[17, 18] start=(1:17) end=(1:18)>
+#<Herb::Token type="TOKEN_QUOTE" value="\"" range=[18, 19] start=(1:18) end=(1:19)>
+#<Herb::Token type="TOKEN_WHITESPACE" value=" " range=[19, 20] start=(1:19) end=(1:20)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="encoding" range=[20, 28] start=(1:20) end=(1:28)>
+#<Herb::Token type="TOKEN_EQUALS" value="=" range=[28, 29] start=(1:28) end=(1:29)>
+#<Herb::Token type="TOKEN_QUOTE" value="\"" range=[29, 30] start=(1:29) end=(1:30)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="UTF-8" range=[30, 35] start=(1:30) end=(1:35)>
+#<Herb::Token type="TOKEN_QUOTE" value="\"" range=[35, 36] start=(1:35) end=(1:36)>
+#<Herb::Token type="TOKEN_WHITESPACE" value=" " range=[36, 37] start=(1:36) end=(1:37)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="standalone" range=[37, 47] start=(1:37) end=(1:47)>
+#<Herb::Token type="TOKEN_EQUALS" value="=" range=[47, 48] start=(1:47) end=(1:48)>
+#<Herb::Token type="TOKEN_QUOTE" value="\"" range=[48, 49] start=(1:48) end=(1:49)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="yes" range=[49, 52] start=(1:49) end=(1:52)>
+#<Herb::Token type="TOKEN_QUOTE" value="\"" range=[52, 53] start=(1:52) end=(1:53)>
+#<Herb::Token type="TOKEN_XML_DECLARATION_END" value="?>" range=[53, 55] start=(1:53) end=(1:55)>
+#<Herb::Token type="TOKEN_EOF" value="<EOF>" range=[55, 55] start=(1:55) end=(1:55)>

--- a/test/snapshots/lexer/xml_declaration_test/test_0007_xml_declaration_case_insensitive_2_2c7827fc01b52f3dd103b842f07d2742.txt
+++ b/test/snapshots/lexer/xml_declaration_test/test_0007_xml_declaration_case_insensitive_2_2c7827fc01b52f3dd103b842f07d2742.txt
@@ -1,0 +1,11 @@
+#<Herb::Token type="TOKEN_XML_DECLARATION" value="<?XML" range=[0, 5] start=(1:0) end=(1:5)>
+#<Herb::Token type="TOKEN_WHITESPACE" value=" " range=[5, 6] start=(1:5) end=(1:6)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="version" range=[6, 13] start=(1:6) end=(1:13)>
+#<Herb::Token type="TOKEN_EQUALS" value="=" range=[13, 14] start=(1:13) end=(1:14)>
+#<Herb::Token type="TOKEN_QUOTE" value="\"" range=[14, 15] start=(1:14) end=(1:15)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="1" range=[15, 16] start=(1:15) end=(1:16)>
+#<Herb::Token type="TOKEN_CHARACTER" value="." range=[16, 17] start=(1:16) end=(1:17)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="0" range=[17, 18] start=(1:17) end=(1:18)>
+#<Herb::Token type="TOKEN_QUOTE" value="\"" range=[18, 19] start=(1:18) end=(1:19)>
+#<Herb::Token type="TOKEN_XML_DECLARATION_END" value="?>" range=[19, 21] start=(1:19) end=(1:21)>
+#<Herb::Token type="TOKEN_EOF" value="<EOF>" range=[21, 21] start=(1:21) end=(1:21)>

--- a/test/snapshots/lexer/xml_declaration_test/test_0008_xml_declaration_case_insensitive_3_19078f9a0d7c42b40a7aa66ccde337be.txt
+++ b/test/snapshots/lexer/xml_declaration_test/test_0008_xml_declaration_case_insensitive_3_19078f9a0d7c42b40a7aa66ccde337be.txt
@@ -1,0 +1,11 @@
+#<Herb::Token type="TOKEN_XML_DECLARATION" value="<?Xml" range=[0, 5] start=(1:0) end=(1:5)>
+#<Herb::Token type="TOKEN_WHITESPACE" value=" " range=[5, 6] start=(1:5) end=(1:6)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="version" range=[6, 13] start=(1:6) end=(1:13)>
+#<Herb::Token type="TOKEN_EQUALS" value="=" range=[13, 14] start=(1:13) end=(1:14)>
+#<Herb::Token type="TOKEN_QUOTE" value="\"" range=[14, 15] start=(1:14) end=(1:15)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="1" range=[15, 16] start=(1:15) end=(1:16)>
+#<Herb::Token type="TOKEN_CHARACTER" value="." range=[16, 17] start=(1:16) end=(1:17)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="0" range=[17, 18] start=(1:17) end=(1:18)>
+#<Herb::Token type="TOKEN_QUOTE" value="\"" range=[18, 19] start=(1:18) end=(1:19)>
+#<Herb::Token type="TOKEN_XML_DECLARATION_END" value="?>" range=[19, 21] start=(1:19) end=(1:21)>
+#<Herb::Token type="TOKEN_EOF" value="<EOF>" range=[21, 21] start=(1:21) end=(1:21)>

--- a/test/snapshots/lexer/xml_declaration_test/test_0009_xml_declaration_with_spaces_0f70f9dc3f7c17d88be358a804043833.txt
+++ b/test/snapshots/lexer/xml_declaration_test/test_0009_xml_declaration_with_spaces_0f70f9dc3f7c17d88be358a804043833.txt
@@ -1,0 +1,14 @@
+#<Herb::Token type="TOKEN_XML_DECLARATION" value="<?xml" range=[0, 5] start=(1:0) end=(1:5)>
+#<Herb::Token type="TOKEN_WHITESPACE" value="  " range=[5, 7] start=(1:5) end=(1:7)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="version" range=[7, 14] start=(1:7) end=(1:14)>
+#<Herb::Token type="TOKEN_WHITESPACE" value=" " range=[14, 15] start=(1:14) end=(1:15)>
+#<Herb::Token type="TOKEN_EQUALS" value="=" range=[15, 16] start=(1:15) end=(1:16)>
+#<Herb::Token type="TOKEN_WHITESPACE" value=" " range=[16, 17] start=(1:16) end=(1:17)>
+#<Herb::Token type="TOKEN_QUOTE" value="\"" range=[17, 18] start=(1:17) end=(1:18)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="1" range=[18, 19] start=(1:18) end=(1:19)>
+#<Herb::Token type="TOKEN_CHARACTER" value="." range=[19, 20] start=(1:19) end=(1:20)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="0" range=[20, 21] start=(1:20) end=(1:21)>
+#<Herb::Token type="TOKEN_QUOTE" value="\"" range=[21, 22] start=(1:21) end=(1:22)>
+#<Herb::Token type="TOKEN_WHITESPACE" value="  " range=[22, 24] start=(1:22) end=(1:24)>
+#<Herb::Token type="TOKEN_XML_DECLARATION_END" value="?>" range=[24, 26] start=(1:24) end=(1:26)>
+#<Herb::Token type="TOKEN_EOF" value="<EOF>" range=[26, 26] start=(1:26) end=(1:26)>

--- a/test/snapshots/lexer/xml_declaration_test/test_0010_xml_declaration_with_newlines_01fc1f4f0cc30f25fccc96fca16afed4.txt
+++ b/test/snapshots/lexer/xml_declaration_test/test_0010_xml_declaration_with_newlines_01fc1f4f0cc30f25fccc96fca16afed4.txt
@@ -1,0 +1,18 @@
+#<Herb::Token type="TOKEN_XML_DECLARATION" value="<?xml" range=[0, 5] start=(1:0) end=(1:5)>
+#<Herb::Token type="TOKEN_WHITESPACE" value=" " range=[5, 6] start=(1:5) end=(1:6)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="version" range=[6, 13] start=(1:6) end=(1:13)>
+#<Herb::Token type="TOKEN_EQUALS" value="=" range=[13, 14] start=(1:13) end=(1:14)>
+#<Herb::Token type="TOKEN_QUOTE" value="\"" range=[14, 15] start=(1:14) end=(1:15)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="1" range=[15, 16] start=(1:15) end=(1:16)>
+#<Herb::Token type="TOKEN_CHARACTER" value="." range=[16, 17] start=(1:16) end=(1:17)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="0" range=[17, 18] start=(1:17) end=(1:18)>
+#<Herb::Token type="TOKEN_QUOTE" value="\"" range=[18, 19] start=(1:18) end=(1:19)>
+#<Herb::Token type="TOKEN_NEWLINE" value="\n" range=[19, 20] start=(1:19) end=(2:0)>
+#<Herb::Token type="TOKEN_WHITESPACE" value="      " range=[20, 26] start=(2:0) end=(2:6)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="encoding" range=[26, 34] start=(2:6) end=(2:14)>
+#<Herb::Token type="TOKEN_EQUALS" value="=" range=[34, 35] start=(2:14) end=(2:15)>
+#<Herb::Token type="TOKEN_QUOTE" value="\"" range=[35, 36] start=(2:15) end=(2:16)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="UTF-8" range=[36, 41] start=(2:16) end=(2:21)>
+#<Herb::Token type="TOKEN_QUOTE" value="\"" range=[41, 42] start=(2:21) end=(2:22)>
+#<Herb::Token type="TOKEN_XML_DECLARATION_END" value="?>" range=[42, 44] start=(2:22) end=(2:24)>
+#<Herb::Token type="TOKEN_EOF" value="<EOF>" range=[44, 44] start=(2:24) end=(2:24)>

--- a/test/snapshots/lexer/xml_declaration_test/test_0011_xml_declaration_with_single_quotes_ee83d90fd5287d588959a3a5b611d6ce.txt
+++ b/test/snapshots/lexer/xml_declaration_test/test_0011_xml_declaration_with_single_quotes_ee83d90fd5287d588959a3a5b611d6ce.txt
@@ -1,0 +1,17 @@
+#<Herb::Token type="TOKEN_XML_DECLARATION" value="<?xml" range=[0, 5] start=(1:0) end=(1:5)>
+#<Herb::Token type="TOKEN_WHITESPACE" value=" " range=[5, 6] start=(1:5) end=(1:6)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="version" range=[6, 13] start=(1:6) end=(1:13)>
+#<Herb::Token type="TOKEN_EQUALS" value="=" range=[13, 14] start=(1:13) end=(1:14)>
+#<Herb::Token type="TOKEN_QUOTE" value="'" range=[14, 15] start=(1:14) end=(1:15)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="1" range=[15, 16] start=(1:15) end=(1:16)>
+#<Herb::Token type="TOKEN_CHARACTER" value="." range=[16, 17] start=(1:16) end=(1:17)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="0" range=[17, 18] start=(1:17) end=(1:18)>
+#<Herb::Token type="TOKEN_QUOTE" value="'" range=[18, 19] start=(1:18) end=(1:19)>
+#<Herb::Token type="TOKEN_WHITESPACE" value=" " range=[19, 20] start=(1:19) end=(1:20)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="encoding" range=[20, 28] start=(1:20) end=(1:28)>
+#<Herb::Token type="TOKEN_EQUALS" value="=" range=[28, 29] start=(1:28) end=(1:29)>
+#<Herb::Token type="TOKEN_QUOTE" value="'" range=[29, 30] start=(1:29) end=(1:30)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="UTF-8" range=[30, 35] start=(1:30) end=(1:35)>
+#<Herb::Token type="TOKEN_QUOTE" value="'" range=[35, 36] start=(1:35) end=(1:36)>
+#<Herb::Token type="TOKEN_XML_DECLARATION_END" value="?>" range=[36, 38] start=(1:36) end=(1:38)>
+#<Herb::Token type="TOKEN_EOF" value="<EOF>" range=[38, 38] start=(1:38) end=(1:38)>

--- a/test/snapshots/lexer/xml_declaration_test/test_0012_xml_declaration_followed_by_html_d3329c9fd9d81fa8c7e39656c4e48b5c.txt
+++ b/test/snapshots/lexer/xml_declaration_test/test_0012_xml_declaration_followed_by_html_d3329c9fd9d81fa8c7e39656c4e48b5c.txt
@@ -1,0 +1,25 @@
+#<Herb::Token type="TOKEN_XML_DECLARATION" value="<?xml" range=[0, 5] start=(1:0) end=(1:5)>
+#<Herb::Token type="TOKEN_WHITESPACE" value=" " range=[5, 6] start=(1:5) end=(1:6)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="version" range=[6, 13] start=(1:6) end=(1:13)>
+#<Herb::Token type="TOKEN_EQUALS" value="=" range=[13, 14] start=(1:13) end=(1:14)>
+#<Herb::Token type="TOKEN_QUOTE" value="\"" range=[14, 15] start=(1:14) end=(1:15)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="1" range=[15, 16] start=(1:15) end=(1:16)>
+#<Herb::Token type="TOKEN_CHARACTER" value="." range=[16, 17] start=(1:16) end=(1:17)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="0" range=[17, 18] start=(1:17) end=(1:18)>
+#<Herb::Token type="TOKEN_QUOTE" value="\"" range=[18, 19] start=(1:18) end=(1:19)>
+#<Herb::Token type="TOKEN_XML_DECLARATION_END" value="?>" range=[19, 21] start=(1:19) end=(1:21)>
+#<Herb::Token type="TOKEN_NEWLINE" value="\n" range=[21, 22] start=(1:21) end=(2:0)>
+#<Herb::Token type="TOKEN_HTML_TAG_START" value="<" range=[22, 23] start=(2:0) end=(2:1)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="html" range=[23, 27] start=(2:1) end=(2:5)>
+#<Herb::Token type="TOKEN_HTML_TAG_END" value=">" range=[27, 28] start=(2:5) end=(2:6)>
+#<Herb::Token type="TOKEN_HTML_TAG_START" value="<" range=[28, 29] start=(2:6) end=(2:7)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="body" range=[29, 33] start=(2:7) end=(2:11)>
+#<Herb::Token type="TOKEN_HTML_TAG_END" value=">" range=[33, 34] start=(2:11) end=(2:12)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="Hello" range=[34, 39] start=(2:12) end=(2:17)>
+#<Herb::Token type="TOKEN_HTML_TAG_START_CLOSE" value="</" range=[39, 41] start=(2:17) end=(2:19)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="body" range=[41, 45] start=(2:19) end=(2:23)>
+#<Herb::Token type="TOKEN_HTML_TAG_END" value=">" range=[45, 46] start=(2:23) end=(2:24)>
+#<Herb::Token type="TOKEN_HTML_TAG_START_CLOSE" value="</" range=[46, 48] start=(2:24) end=(2:26)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="html" range=[48, 52] start=(2:26) end=(2:30)>
+#<Herb::Token type="TOKEN_HTML_TAG_END" value=">" range=[52, 53] start=(2:30) end=(2:31)>
+#<Herb::Token type="TOKEN_EOF" value="<EOF>" range=[53, 53] start=(2:31) end=(2:31)>

--- a/test/snapshots/parser/xml_declaration_test/test_0001_basic_xml_declaration_e4e345519e2b76863647d3351ace49e0.txt
+++ b/test/snapshots/parser/xml_declaration_test/test_0001_basic_xml_declaration_e4e345519e2b76863647d3351ace49e0.txt
@@ -1,0 +1,9 @@
+@ DocumentNode (location: (1:0)-(1:21))
+└── children: (1 item)
+    └── @ XMLDeclarationNode (location: (1:0)-(1:21))
+        ├── tag_opening: "<?xml" (location: (1:0)-(1:5))
+        ├── children: (1 item)
+        │   └── @ LiteralNode (location: (1:5)-(1:19))
+        │       └── content: " version=\"1.0\""
+        │
+        └── tag_closing: "?>" (location: (1:19)-(1:21))

--- a/test/snapshots/parser/xml_declaration_test/test_0002_xml_declaration_with_encoding_447d423b62bc6692ce2266e1dfb0a3b5.txt
+++ b/test/snapshots/parser/xml_declaration_test/test_0002_xml_declaration_with_encoding_447d423b62bc6692ce2266e1dfb0a3b5.txt
@@ -1,0 +1,9 @@
+@ DocumentNode (location: (1:0)-(1:38))
+└── children: (1 item)
+    └── @ XMLDeclarationNode (location: (1:0)-(1:38))
+        ├── tag_opening: "<?xml" (location: (1:0)-(1:5))
+        ├── children: (1 item)
+        │   └── @ LiteralNode (location: (1:5)-(1:36))
+        │       └── content: " version=\"1.0\" encoding=\"UTF-8\""
+        │
+        └── tag_closing: "?>" (location: (1:36)-(1:38))

--- a/test/snapshots/parser/xml_declaration_test/test_0003_xml_declaration_with_encoding_ISO-8859-1_dd4263447c1fda5ed82c31b9d2f8f24c.txt
+++ b/test/snapshots/parser/xml_declaration_test/test_0003_xml_declaration_with_encoding_ISO-8859-1_dd4263447c1fda5ed82c31b9d2f8f24c.txt
@@ -1,0 +1,9 @@
+@ DocumentNode (location: (1:0)-(1:43))
+└── children: (1 item)
+    └── @ XMLDeclarationNode (location: (1:0)-(1:43))
+        ├── tag_opening: "<?xml" (location: (1:0)-(1:5))
+        ├── children: (1 item)
+        │   └── @ LiteralNode (location: (1:5)-(1:41))
+        │       └── content: " version=\"1.0\" encoding=\"ISO-8859-1\""
+        │
+        └── tag_closing: "?>" (location: (1:41)-(1:43))

--- a/test/snapshots/parser/xml_declaration_test/test_0004_xml_declaration_with_standalone_5aa41195cf30adefdbca245f08726269.txt
+++ b/test/snapshots/parser/xml_declaration_test/test_0004_xml_declaration_with_standalone_5aa41195cf30adefdbca245f08726269.txt
@@ -1,0 +1,9 @@
+@ DocumentNode (location: (1:0)-(1:38))
+└── children: (1 item)
+    └── @ XMLDeclarationNode (location: (1:0)-(1:38))
+        ├── tag_opening: "<?xml" (location: (1:0)-(1:5))
+        ├── children: (1 item)
+        │   └── @ LiteralNode (location: (1:5)-(1:36))
+        │       └── content: " version=\"1.0\" standalone=\"yes\""
+        │
+        └── tag_closing: "?>" (location: (1:36)-(1:38))

--- a/test/snapshots/parser/xml_declaration_test/test_0005_xml_declaration_with_all_attributes_3ef840d0361caa4801a5f9ec97056a2b.txt
+++ b/test/snapshots/parser/xml_declaration_test/test_0005_xml_declaration_with_all_attributes_3ef840d0361caa4801a5f9ec97056a2b.txt
@@ -1,0 +1,9 @@
+@ DocumentNode (location: (1:0)-(1:55))
+└── children: (1 item)
+    └── @ XMLDeclarationNode (location: (1:0)-(1:55))
+        ├── tag_opening: "<?xml" (location: (1:0)-(1:5))
+        ├── children: (1 item)
+        │   └── @ LiteralNode (location: (1:5)-(1:53))
+        │       └── content: " version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\""
+        │
+        └── tag_closing: "?>" (location: (1:53)-(1:55))

--- a/test/snapshots/parser/xml_declaration_test/test_0007_xml_declaration_case_insensitive_2_2c7827fc01b52f3dd103b842f07d2742.txt
+++ b/test/snapshots/parser/xml_declaration_test/test_0007_xml_declaration_case_insensitive_2_2c7827fc01b52f3dd103b842f07d2742.txt
@@ -1,0 +1,9 @@
+@ DocumentNode (location: (1:0)-(1:21))
+└── children: (1 item)
+    └── @ XMLDeclarationNode (location: (1:0)-(1:21))
+        ├── tag_opening: "<?XML" (location: (1:0)-(1:5))
+        ├── children: (1 item)
+        │   └── @ LiteralNode (location: (1:5)-(1:19))
+        │       └── content: " version=\"1.0\""
+        │
+        └── tag_closing: "?>" (location: (1:19)-(1:21))

--- a/test/snapshots/parser/xml_declaration_test/test_0008_xml_declaration_case_insensitive_3_19078f9a0d7c42b40a7aa66ccde337be.txt
+++ b/test/snapshots/parser/xml_declaration_test/test_0008_xml_declaration_case_insensitive_3_19078f9a0d7c42b40a7aa66ccde337be.txt
@@ -1,0 +1,9 @@
+@ DocumentNode (location: (1:0)-(1:21))
+└── children: (1 item)
+    └── @ XMLDeclarationNode (location: (1:0)-(1:21))
+        ├── tag_opening: "<?Xml" (location: (1:0)-(1:5))
+        ├── children: (1 item)
+        │   └── @ LiteralNode (location: (1:5)-(1:19))
+        │       └── content: " version=\"1.0\""
+        │
+        └── tag_closing: "?>" (location: (1:19)-(1:21))

--- a/test/snapshots/parser/xml_declaration_test/test_0009_xml_declaration_with_spaces_0f70f9dc3f7c17d88be358a804043833.txt
+++ b/test/snapshots/parser/xml_declaration_test/test_0009_xml_declaration_with_spaces_0f70f9dc3f7c17d88be358a804043833.txt
@@ -1,0 +1,9 @@
+@ DocumentNode (location: (1:0)-(1:26))
+└── children: (1 item)
+    └── @ XMLDeclarationNode (location: (1:0)-(1:26))
+        ├── tag_opening: "<?xml" (location: (1:0)-(1:5))
+        ├── children: (1 item)
+        │   └── @ LiteralNode (location: (1:5)-(1:24))
+        │       └── content: "  version = \"1.0\"  "
+        │
+        └── tag_closing: "?>" (location: (1:24)-(1:26))

--- a/test/snapshots/parser/xml_declaration_test/test_0010_xml_declaration_with_newlines_01fc1f4f0cc30f25fccc96fca16afed4.txt
+++ b/test/snapshots/parser/xml_declaration_test/test_0010_xml_declaration_with_newlines_01fc1f4f0cc30f25fccc96fca16afed4.txt
@@ -1,0 +1,9 @@
+@ DocumentNode (location: (1:0)-(2:24))
+└── children: (1 item)
+    └── @ XMLDeclarationNode (location: (1:0)-(2:24))
+        ├── tag_opening: "<?xml" (location: (1:0)-(1:5))
+        ├── children: (1 item)
+        │   └── @ LiteralNode (location: (1:5)-(2:22))
+        │       └── content: " version=\"1.0\"\n      encoding=\"UTF-8\""
+        │
+        └── tag_closing: "?>" (location: (2:22)-(2:24))

--- a/test/snapshots/parser/xml_declaration_test/test_0011_xml_declaration_with_single_quotes_ee83d90fd5287d588959a3a5b611d6ce.txt
+++ b/test/snapshots/parser/xml_declaration_test/test_0011_xml_declaration_with_single_quotes_ee83d90fd5287d588959a3a5b611d6ce.txt
@@ -1,0 +1,9 @@
+@ DocumentNode (location: (1:0)-(1:38))
+└── children: (1 item)
+    └── @ XMLDeclarationNode (location: (1:0)-(1:38))
+        ├── tag_opening: "<?xml" (location: (1:0)-(1:5))
+        ├── children: (1 item)
+        │   └── @ LiteralNode (location: (1:5)-(1:36))
+        │       └── content: " version='1.0' encoding='UTF-8'"
+        │
+        └── tag_closing: "?>" (location: (1:36)-(1:38))

--- a/test/snapshots/parser/xml_declaration_test/test_0012_xml_declaration_followed_by_html_d3329c9fd9d81fa8c7e39656c4e48b5c.txt
+++ b/test/snapshots/parser/xml_declaration_test/test_0012_xml_declaration_followed_by_html_d3329c9fd9d81fa8c7e39656c4e48b5c.txt
@@ -1,0 +1,55 @@
+@ DocumentNode (location: (1:0)-(2:31))
+└── children: (3 items)
+    ├── @ XMLDeclarationNode (location: (1:0)-(1:21))
+    │   ├── tag_opening: "<?xml" (location: (1:0)-(1:5))
+    │   ├── children: (1 item)
+    │   │   └── @ LiteralNode (location: (1:5)-(1:19))
+    │   │       └── content: " version=\"1.0\""
+    │   │
+    │   └── tag_closing: "?>" (location: (1:19)-(1:21))
+    │
+    ├── @ HTMLTextNode (location: (1:21)-(2:0))
+    │   └── content: "\n"
+    │
+    └── @ HTMLElementNode (location: (2:0)-(2:31))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (2:0)-(2:6))
+        │       ├── tag_opening: "<" (location: (2:0)-(2:1))
+        │       ├── tag_name: "html" (location: (2:1)-(2:5))
+        │       ├── tag_closing: ">" (location: (2:5)-(2:6))
+        │       ├── children: []
+        │       └── is_void: false
+        │
+        ├── tag_name: "html" (location: (2:1)-(2:5))
+        ├── body: (1 item)
+        │   └── @ HTMLElementNode (location: (2:6)-(2:24))
+        │       ├── open_tag:
+        │       │   └── @ HTMLOpenTagNode (location: (2:6)-(2:12))
+        │       │       ├── tag_opening: "<" (location: (2:6)-(2:7))
+        │       │       ├── tag_name: "body" (location: (2:7)-(2:11))
+        │       │       ├── tag_closing: ">" (location: (2:11)-(2:12))
+        │       │       ├── children: []
+        │       │       └── is_void: false
+        │       │
+        │       ├── tag_name: "body" (location: (2:7)-(2:11))
+        │       ├── body: (1 item)
+        │       │   └── @ HTMLTextNode (location: (2:12)-(2:17))
+        │       │       └── content: "Hello"
+        │       │
+        │       ├── close_tag:
+        │       │   └── @ HTMLCloseTagNode (location: (2:17)-(2:24))
+        │       │       ├── tag_opening: "</" (location: (2:17)-(2:19))
+        │       │       ├── tag_name: "body" (location: (2:19)-(2:23))
+        │       │       ├── children: []
+        │       │       └── tag_closing: ">" (location: (2:23)-(2:24))
+        │       │
+        │       └── is_void: false
+        │
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (2:24)-(2:31))
+        │       ├── tag_opening: "</" (location: (2:24)-(2:26))
+        │       ├── tag_name: "html" (location: (2:26)-(2:30))
+        │       ├── children: []
+        │       └── tag_closing: ">" (location: (2:30)-(2:31))
+        │
+        └── is_void: false

--- a/test/snapshots/parser/xml_declaration_test/test_0013_two_xml_declarations_aa9ca6f9069972c106bfcfe505a0a080.txt
+++ b/test/snapshots/parser/xml_declaration_test/test_0013_two_xml_declarations_aa9ca6f9069972c106bfcfe505a0a080.txt
@@ -1,0 +1,17 @@
+@ DocumentNode (location: (1:0)-(1:42))
+└── children: (2 items)
+    ├── @ XMLDeclarationNode (location: (1:0)-(1:21))
+    │   ├── tag_opening: "<?xml" (location: (1:0)-(1:5))
+    │   ├── children: (1 item)
+    │   │   └── @ LiteralNode (location: (1:5)-(1:19))
+    │   │       └── content: " version=\"1.0\""
+    │   │
+    │   └── tag_closing: "?>" (location: (1:19)-(1:21))
+    │
+    └── @ XMLDeclarationNode (location: (1:21)-(1:42))
+        ├── tag_opening: "<?xml" (location: (1:21)-(1:26))
+        ├── children: (1 item)
+        │   └── @ LiteralNode (location: (1:26)-(1:40))
+        │       └── content: " version=\"1.1\""
+        │
+        └── tag_closing: "?>" (location: (1:40)-(1:42))

--- a/test/snapshots/parser/xml_declaration_test/test_0014_xml_declaration_with_erb_content_7c2a2a608c90a24e12d1d51c9db4cec2.txt
+++ b/test/snapshots/parser/xml_declaration_test/test_0014_xml_declaration_with_erb_content_7c2a2a608c90a24e12d1d51c9db4cec2.txt
@@ -1,0 +1,19 @@
+@ DocumentNode (location: (1:0)-(1:50))
+└── children: (1 item)
+    └── @ XMLDeclarationNode (location: (1:0)-(1:50))
+        ├── tag_opening: "<?xml" (location: (1:0)-(1:5))
+        ├── children: (3 items)
+        │   ├── @ LiteralNode (location: (1:5)-(1:15))
+        │   │   └── content: " version=\""
+        │   │
+        │   ├── @ ERBContentNode (location: (1:15)-(1:30))
+        │   │   ├── tag_opening: "<%=" (location: (1:15)-(1:18))
+        │   │   ├── content: " @version " (location: (1:18)-(1:28))
+        │   │   ├── tag_closing: "%>" (location: (1:28)-(1:30))
+        │   │   ├── parsed: true
+        │   │   └── valid: true
+        │   │
+        │   └── @ LiteralNode (location: (1:30)-(1:48))
+        │       └── content: "\" encoding=\"UTF-8\""
+        │
+        └── tag_closing: "?>" (location: (1:48)-(1:50))

--- a/test/snapshots/parser/xml_declaration_test/test_0015_xml_declaration_in_html_document_b4aebebe021e8c204e11f2d48215323d.txt
+++ b/test/snapshots/parser/xml_declaration_test/test_0015_xml_declaration_in_html_document_b4aebebe021e8c204e11f2d48215323d.txt
@@ -1,0 +1,55 @@
+@ DocumentNode (location: (1:0)-(3:33))
+└── children: (3 items)
+    ├── @ HTMLDoctypeNode (location: (1:0)-(1:15))
+    │   ├── tag_opening: "<!DOCTYPE" (location: (1:0)-(1:9))
+    │   ├── children: (1 item)
+    │   │   └── @ LiteralNode (location: (1:9)-(1:14))
+    │   │       └── content: " html"
+    │   │
+    │   └── tag_closing: ">" (location: (1:14)-(1:15))
+    │
+    ├── @ HTMLTextNode (location: (1:15)-(3:0))
+    │   └── content: "\n<?xml version=\"1.0\"?>\n"
+    │
+    └── @ HTMLElementNode (location: (3:0)-(3:33))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (3:0)-(3:6))
+        │       ├── tag_opening: "<" (location: (3:0)-(3:1))
+        │       ├── tag_name: "html" (location: (3:1)-(3:5))
+        │       ├── tag_closing: ">" (location: (3:5)-(3:6))
+        │       ├── children: []
+        │       └── is_void: false
+        │
+        ├── tag_name: "html" (location: (3:1)-(3:5))
+        ├── body: (1 item)
+        │   └── @ HTMLElementNode (location: (3:6)-(3:26))
+        │       ├── open_tag:
+        │       │   └── @ HTMLOpenTagNode (location: (3:6)-(3:12))
+        │       │       ├── tag_opening: "<" (location: (3:6)-(3:7))
+        │       │       ├── tag_name: "body" (location: (3:7)-(3:11))
+        │       │       ├── tag_closing: ">" (location: (3:11)-(3:12))
+        │       │       ├── children: []
+        │       │       └── is_void: false
+        │       │
+        │       ├── tag_name: "body" (location: (3:7)-(3:11))
+        │       ├── body: (1 item)
+        │       │   └── @ HTMLTextNode (location: (3:12)-(3:19))
+        │       │       └── content: "Content"
+        │       │
+        │       ├── close_tag:
+        │       │   └── @ HTMLCloseTagNode (location: (3:19)-(3:26))
+        │       │       ├── tag_opening: "</" (location: (3:19)-(3:21))
+        │       │       ├── tag_name: "body" (location: (3:21)-(3:25))
+        │       │       ├── children: []
+        │       │       └── tag_closing: ">" (location: (3:25)-(3:26))
+        │       │
+        │       └── is_void: false
+        │
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (3:26)-(3:33))
+        │       ├── tag_opening: "</" (location: (3:26)-(3:28))
+        │       ├── tag_name: "html" (location: (3:28)-(3:32))
+        │       ├── children: []
+        │       └── tag_closing: ">" (location: (3:32)-(3:33))
+        │
+        └── is_void: false


### PR DESCRIPTION
This pull request adds support for parsing XML declarations, like:

```xml
<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
```

Which parses as:
```js
@ DocumentNode (location: (1:0)-(1:55))
├── errors: []
└── children: (1 item)
    └── @ XMLDeclarationNode (location: (1:0)-(1:55))
        ├── errors: []
        ├── tag_opening: "<?xml" (location: (1:0)-(1:5))
        ├── children: (1 item)
        │   └── @ LiteralNode (location: (1:5)-(1:53))
        │       ├── errors: []
        │       └── content: " version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\""
        │       
        │   
        └── tag_closing: "?>" (location: (1:53)-(1:55))
```
