### PR TITLE
Parser: Add support for parsing CDATA nodes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -74,6 +74,7 @@ Metrics/ClassLength:
   Exclude:
     - lib/herb/cli.rb
     - lib/herb/project.rb
+    - lib/herb/visitor.rb
     - test/**/*_test.rb
 
 Metrics/BlockLength:

--- a/config.yml
+++ b/config.yml
@@ -318,6 +318,18 @@ nodes:
         - name: tag_closing
           type: token
 
+    - name: CDATANode
+      fields:
+        - name: tag_opening
+          type: token
+
+        - name: children
+          type: array
+          kind: Node
+
+        - name: tag_closing
+          type: token
+
     - name: WhitespaceNode
       fields:
         - name: value

--- a/javascript/packages/formatter/src/format-printer.ts
+++ b/javascript/packages/formatter/src/format-printer.ts
@@ -48,6 +48,7 @@ import {
   ERBYieldNode,
   ERBInNode,
   XMLDeclarationNode,
+  CDATANode,
   Token
 } from "@herb-tools/core"
 
@@ -1025,6 +1026,10 @@ export class FormatPrinter extends Printer {
   }
 
   visitXMLDeclarationNode(node: XMLDeclarationNode) {
+    this.push(this.indent + IdentityPrinter.print(node))
+  }
+
+  visitCDATANode(node: CDATANode) {
     this.push(this.indent + IdentityPrinter.print(node))
   }
 

--- a/javascript/packages/printer/src/printer.ts
+++ b/javascript/packages/printer/src/printer.ts
@@ -203,6 +203,18 @@ export abstract class Printer extends Visitor {
     }
   }
 
+  visitCDATANode(node: Nodes.CDATANode): void {
+    if (node.tag_opening) {
+      this.context.write(node.tag_opening.value)
+    }
+
+    this.visitChildNodes(node)
+
+    if (node.tag_closing) {
+      this.context.write(node.tag_closing.value)
+    }
+  }
+
   visitERBContentNode(node: Nodes.ERBContentNode): void {
     this.printERBNode(node)
   }

--- a/javascript/packages/printer/test/nodes/c-d-a-t-a-node.test.ts
+++ b/javascript/packages/printer/test/nodes/c-d-a-t-a-node.test.ts
@@ -1,0 +1,147 @@
+import dedent from "dedent"
+import { describe, test, beforeAll } from "vitest"
+
+import { Herb } from "@herb-tools/node-wasm"
+import { CDATANode, LiteralNode } from "@herb-tools/core"
+
+import { expectNodeToPrint, expectPrintRoundTrip, createLocation, createToken } from "../helpers/printer-test-helpers.js"
+
+describe("CDATANode Printing", () => {
+  beforeAll(async () => {
+    await Herb.load()
+  })
+
+  test("can print empty CDATA section from node", () => {
+    const node = CDATANode.from({
+      type: "AST_CDATA_NODE",
+      location: createLocation(),
+      errors: [],
+      tag_opening: createToken("TOKEN_CDATA_START", "<![CDATA["),
+      children: [],
+      tag_closing: createToken("TOKEN_CDATA_END", "]]>")
+    })
+
+    expectNodeToPrint(node, "<![CDATA[]]>")
+  })
+
+  test("can print CDATA with text content from node", () => {
+    const literalNode = LiteralNode.from({
+      type: "AST_LITERAL_NODE",
+      location: createLocation(),
+      errors: [],
+      content: "Hello World"
+    })
+
+    const node = CDATANode.from({
+      type: "AST_CDATA_NODE",
+      location: createLocation(),
+      errors: [],
+      tag_opening: createToken("TOKEN_CDATA_START", "<![CDATA["),
+      children: [literalNode],
+      tag_closing: createToken("TOKEN_CDATA_END", "]]>")
+    })
+
+    expectNodeToPrint(node, "<![CDATA[Hello World]]>")
+  })
+
+  test("can print CDATA with XML-like content from node", () => {
+    const literalNode = LiteralNode.from({
+      type: "AST_LITERAL_NODE",
+      location: createLocation(),
+      errors: [],
+      content: "<sender>John Smith</sender>"
+    })
+
+    const node = CDATANode.from({
+      type: "AST_CDATA_NODE",
+      location: createLocation(),
+      errors: [],
+      tag_opening: createToken("TOKEN_CDATA_START", "<![CDATA["),
+      children: [literalNode],
+      tag_closing: createToken("TOKEN_CDATA_END", "]]>")
+    })
+
+    expectNodeToPrint(node, "<![CDATA[<sender>John Smith</sender>]]>")
+  })
+
+  test("can print empty CDATA section from source", () => {
+    expectPrintRoundTrip("<![CDATA[]]>")
+  })
+
+  test("can print CDATA with text content from source", () => {
+    expectPrintRoundTrip("<![CDATA[Hello World]]>")
+  })
+
+  test("can print CDATA with XML-like content from source", () => {
+    expectPrintRoundTrip("<![CDATA[<sender>John Smith</sender>]]>")
+  })
+
+  test("can print CDATA with special characters from source", () => {
+    expectPrintRoundTrip("<![CDATA[&lt; &gt; &amp; &#240;]]>")
+  })
+
+  test("can print CDATA with escaped characters from source", () => {
+    expectPrintRoundTrip("<![CDATA[<html>&amp; &lt;div&gt;</html>]]>")
+  })
+
+  test("can print CDATA with newlines from source", () => {
+    expectPrintRoundTrip(dedent`
+      <![CDATA[
+        Line 1
+        Line 2
+        Line 3
+      ]]>
+    `)
+  })
+
+  test("can print CDATA in XML document from source", () => {
+    expectPrintRoundTrip(dedent`
+      <?xml version="1.0"?>
+      <root>
+        <data><![CDATA[Some data here]]></data>
+      </root>
+    `)
+  })
+
+  test("can print CDATA with ERB content from source", () => {
+    expectPrintRoundTrip("<![CDATA[<%= @variable %>]]>")
+  })
+
+  test("can print CDATA with complex ERB from source", () => {
+    expectPrintRoundTrip(dedent`
+      <![CDATA[
+        <% if @condition %>
+          <%= @content %>
+        <% end %>
+      ]]>
+    `)
+  })
+
+  test("can print multiple CDATA sections from source", () => {
+    expectPrintRoundTrip("<![CDATA[First]]><![CDATA[Second]]>")
+  })
+
+  test("can print CDATA with brackets from source", () => {
+    expectPrintRoundTrip("<![CDATA[{[()]}]]>")
+  })
+
+  test("can print CDATA with spaces from source", () => {
+    expectPrintRoundTrip("<![CDATA[   ]]>")
+  })
+
+  test("can print CDATA followed by HTML from source", () => {
+    expectPrintRoundTrip("<![CDATA[Data]]><div>HTML</div>")
+  })
+
+  test("can print CDATA in RSS feed context from source", () => {
+    expectPrintRoundTrip(dedent`
+      <rss version="2.0">
+        <channel>
+          <item>
+            <description><![CDATA[<%= article.excerpt %>]]></description>
+          </item>
+        </channel>
+      </rss>
+    `)
+  })
+})

--- a/sig/herb/ast/nodes.rbs
+++ b/sig/herb/ast/nodes.rbs
@@ -346,6 +346,35 @@ module Herb
       def tree_inspect: (?Integer) -> String
     end
 
+    class CDATANode < Node
+      attr_reader tag_opening: Herb::Token
+
+      attr_reader children: Array[Herb::AST::Node]
+
+      attr_reader tag_closing: Herb::Token
+
+      # : (String, Location, Array[Herb::Errors::Error], Herb::Token, Array[Herb::AST::Node], Herb::Token) -> void
+      def initialize: (String, Location, Array[Herb::Errors::Error], Herb::Token, Array[Herb::AST::Node], Herb::Token) -> void
+
+      # : () -> serialized_cdata_node
+      def to_hash: () -> serialized_cdata_node
+
+      # : (Visitor) -> void
+      def accept: (Visitor) -> void
+
+      # : () -> Array[Herb::AST::Node?]
+      def child_nodes: () -> Array[Herb::AST::Node?]
+
+      # : () -> Array[Herb::AST::Node]
+      def compact_child_nodes: () -> Array[Herb::AST::Node]
+
+      # : () -> String
+      def inspect: () -> String
+
+      # : (?Integer) -> String
+      def tree_inspect: (?Integer) -> String
+    end
+
     class WhitespaceNode < Node
       attr_reader value: Herb::Token
 

--- a/sig/herb/visitor.rbs
+++ b/sig/herb/visitor.rbs
@@ -47,6 +47,9 @@ module Herb
     # : (Herb::AST::XMLDeclarationNode) -> void
     def visit_xml_declaration_node: (Herb::AST::XMLDeclarationNode) -> void
 
+    # : (Herb::AST::CDATANode) -> void
+    def visit_cdata_node: (Herb::AST::CDATANode) -> void
+
     # : (Herb::AST::WhitespaceNode) -> void
     def visit_whitespace_node: (Herb::AST::WhitespaceNode) -> void
 

--- a/src/include/lexer_peek_helpers.h
+++ b/src/include/lexer_peek_helpers.h
@@ -22,6 +22,8 @@ typedef struct {
 char lexer_peek(const lexer_T* lexer, int offset);
 bool lexer_peek_for_doctype(const lexer_T* lexer, int offset);
 bool lexer_peek_for_xml_declaration(const lexer_T* lexer, int offset);
+bool lexer_peek_for_cdata_start(const lexer_T* lexer, int offset);
+bool lexer_peek_for_cdata_end(const lexer_T* lexer, int offset);
 
 bool lexer_peek_for_html_comment_start(const lexer_T* lexer, int offset);
 bool lexer_peek_for_html_comment_end(const lexer_T* lexer, int offset);

--- a/src/include/token_struct.h
+++ b/src/include/token_struct.h
@@ -13,6 +13,8 @@ typedef enum {
   TOKEN_HTML_DOCTYPE,        // <!DOCTYPE, <!doctype, <!DoCtYpE, <!dOcTyPe
   TOKEN_XML_DECLARATION,     // <?xml
   TOKEN_XML_DECLARATION_END, // ?>
+  TOKEN_CDATA_START,         // <![CDATA[
+  TOKEN_CDATA_END,           // ]]>
 
   TOKEN_HTML_TAG_START,       // <
   TOKEN_HTML_TAG_START_CLOSE, // </

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -294,6 +294,10 @@ token_T* lexer_next_token(lexer_T* lexer) {
         return lexer_advance_with_next(lexer, strlen("<?xml"), TOKEN_XML_DECLARATION);
       }
 
+      if (lexer_peek_for_cdata_start(lexer, 0)) {
+        return lexer_advance_with_next(lexer, strlen("<![CDATA["), TOKEN_CDATA_START);
+      }
+
       if (isalnum(lexer_peek(lexer, 1))) { return lexer_advance_current(lexer, TOKEN_HTML_TAG_START); }
 
       if (lexer_peek_for_html_comment_start(lexer, 0)) {
@@ -320,6 +324,11 @@ token_T* lexer_next_token(lexer_T* lexer) {
     case '-': {
       token_T* token = lexer_match_and_advance(lexer, "-->", TOKEN_HTML_COMMENT_END);
       return token ? token : lexer_advance_current(lexer, TOKEN_DASH);
+    }
+
+    case ']': {
+      token_T* token = lexer_match_and_advance(lexer, "]]>", TOKEN_CDATA_END);
+      return token ? token : lexer_advance_current(lexer, TOKEN_CHARACTER);
     }
 
     case '>': return lexer_advance_current(lexer, TOKEN_HTML_TAG_END);

--- a/src/lexer_peek_helpers.c
+++ b/src/lexer_peek_helpers.c
@@ -37,6 +37,14 @@ bool lexer_peek_for_xml_declaration(const lexer_T* lexer, const int offset) {
   return lexer_peek_for(lexer, offset, "<?xml", true);
 }
 
+bool lexer_peek_for_cdata_start(const lexer_T* lexer, const int offset) {
+  return lexer_peek_for(lexer, offset, "<![CDATA[", false);
+}
+
+bool lexer_peek_for_cdata_end(const lexer_T* lexer, const int offset) {
+  return lexer_peek_for(lexer, offset, "]]>", false);
+}
+
 bool lexer_peek_for_html_comment_start(const lexer_T* lexer, const int offset) {
   return lexer_peek_for(lexer, offset, "<!--", false);
 }

--- a/src/token.c
+++ b/src/token.c
@@ -49,6 +49,8 @@ const char* token_type_to_string(const token_type_T type) {
     case TOKEN_HTML_DOCTYPE: return "TOKEN_HTML_DOCTYPE";
     case TOKEN_XML_DECLARATION: return "TOKEN_XML_DECLARATION";
     case TOKEN_XML_DECLARATION_END: return "TOKEN_XML_DECLARATION_END";
+    case TOKEN_CDATA_START: return "TOKEN_CDATA_START";
+    case TOKEN_CDATA_END: return "TOKEN_CDATA_END";
     case TOKEN_HTML_TAG_START: return "TOKEN_HTML_TAG_START";
     case TOKEN_HTML_TAG_END: return "TOKEN_HTML_TAG_END";
     case TOKEN_HTML_TAG_START_CLOSE: return "TOKEN_HTML_TAG_START_CLOSE";

--- a/test/lexer/cdata_test.rb
+++ b/test/lexer/cdata_test.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+module Lexer
+  class CDATATest < Minitest::Spec
+    include SnapshotUtils
+
+    test "basic CDATA section" do
+      assert_lexed_snapshot("<![CDATA[]]>")
+    end
+
+    test "CDATA with text content" do
+      assert_lexed_snapshot("<![CDATA[Hello World]]>")
+    end
+
+    test "CDATA with XML-like content" do
+      assert_lexed_snapshot("<![CDATA[<sender>John Smith</sender>]]>")
+    end
+
+    test "CDATA with special characters" do
+      assert_lexed_snapshot("<![CDATA[&lt; &gt; &amp; &#240;]]>")
+    end
+
+    test "CDATA with escaped characters that are not interpreted" do
+      assert_lexed_snapshot("<![CDATA[<html>&amp; &lt;div&gt;</html>]]>")
+    end
+
+    test "CDATA with newlines" do
+      assert_lexed_snapshot(<<~XML)
+        <![CDATA[
+          Line 1
+          Line 2
+          Line 3
+        ]]>
+      XML
+    end
+
+    test "CDATA in XML document" do
+      assert_lexed_snapshot(<<~XML)
+        <?xml version="1.0"?>
+        <root>
+          <data><![CDATA[Some data here]]></data>
+        </root>
+      XML
+    end
+
+    test "CDATA with ERB content" do
+      assert_lexed_snapshot("<![CDATA[<%= @variable %>]]>")
+    end
+
+    test "CDATA with complex ERB" do
+      assert_lexed_snapshot(<<~XML)
+        <![CDATA[
+          <% if @condition %>
+            <%= @content %>
+          <% end %>
+        ]]>
+      XML
+    end
+
+    test "Multiple CDATA sections" do
+      assert_lexed_snapshot("<![CDATA[First]]><![CDATA[Second]]>")
+    end
+
+    test "CDATA with ]] inside (workaround pattern)" do
+      assert_lexed_snapshot("<![CDATA[Content with ]]]]><![CDATA[> inside]]>")
+    end
+
+    test "CDATA in HTML comment context" do
+      assert_lexed_snapshot("<!-- Before --><![CDATA[Data]]><!-- After -->")
+    end
+
+    test "CDATA with various brackets" do
+      assert_lexed_snapshot("<![CDATA[{[()]}]]>")
+    end
+
+    test "Empty CDATA with spaces" do
+      assert_lexed_snapshot("<![CDATA[   ]]>")
+    end
+
+    test "CDATA followed by HTML" do
+      assert_lexed_snapshot("<![CDATA[Data]]><div>HTML</div>")
+    end
+  end
+end

--- a/test/parser/cdata_test.rb
+++ b/test/parser/cdata_test.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+module Parser
+  class CDATATest < Minitest::Spec
+    include SnapshotUtils
+
+    test "basic CDATA section" do
+      assert_parsed_snapshot("<![CDATA[]]>")
+    end
+
+    test "CDATA with text content" do
+      assert_parsed_snapshot("<![CDATA[Hello World]]>")
+    end
+
+    test "CDATA with XML-like content" do
+      assert_parsed_snapshot("<![CDATA[<sender>John Smith</sender>]]>")
+    end
+
+    test "CDATA with special characters" do
+      assert_parsed_snapshot("<![CDATA[&lt; &gt; &amp; &#240;]]>")
+    end
+
+    test "CDATA with escaped characters that are not interpreted" do
+      assert_parsed_snapshot("<![CDATA[<html>&amp; &lt;div&gt;</html>]]>")
+    end
+
+    test "CDATA with newlines" do
+      assert_parsed_snapshot(<<~XML)
+        <![CDATA[
+          Line 1
+          Line 2
+          Line 3
+        ]]>
+      XML
+    end
+
+    test "CDATA in XML document" do
+      assert_parsed_snapshot(<<~XML)
+        <?xml version="1.0"?>
+        <root>
+          <data><![CDATA[Some data here]]></data>
+        </root>
+      XML
+    end
+
+    test "CDATA with ERB content" do
+      assert_parsed_snapshot("<![CDATA[<%= @variable %>]]>")
+    end
+
+    test "CDATA with complex ERB" do
+      assert_parsed_snapshot(<<~XML)
+        <![CDATA[
+          <% if @condition %>
+            <%= @content %>
+          <% end %>
+        ]]>
+      XML
+    end
+
+    test "Multiple CDATA sections" do
+      assert_parsed_snapshot("<![CDATA[First]]><![CDATA[Second]]>")
+    end
+
+    test "CDATA with ]] inside (workaround pattern)" do
+      assert_parsed_snapshot("<![CDATA[Content with ]]]]><![CDATA[> inside]]>")
+    end
+
+    test "CDATA in HTML comment context" do
+      assert_parsed_snapshot("<!-- Before --><![CDATA[Data]]><!-- After -->")
+    end
+
+    test "CDATA with various brackets" do
+      assert_parsed_snapshot("<![CDATA[{[()]}]]>")
+    end
+
+    test "Empty CDATA with spaces" do
+      assert_parsed_snapshot("<![CDATA[   ]]>")
+    end
+
+    test "CDATA followed by HTML" do
+      assert_parsed_snapshot("<![CDATA[Data]]><div>HTML</div>")
+    end
+
+    test "CDATA in complex document structure" do
+      assert_parsed_snapshot(<<~HTML)
+        <!DOCTYPE html>
+        <html>
+          <head>
+            <script>
+              <![CDATA[
+                function test() {
+                  if (x < 5 && y > 3) {
+                    return true;
+                  }
+                }
+              ]]>
+            </script>
+          </head>
+          <body>
+            <div><![CDATA[<%= render partial: 'test' %>]]></div>
+          </body>
+        </html>
+      HTML
+    end
+
+    test "CDATA with ERB loop" do
+      assert_parsed_snapshot(<<~XML)
+        <![CDATA[
+          <% @items.each do |item| %>
+            <item><%= item.name %></item>
+          <% end %>
+        ]]>
+      XML
+    end
+
+    test "nested CDATA workaround" do
+      assert_parsed_snapshot("<![CDATA[Outer start <![CDATA[fake nested]]]]><![CDATA[> Outer end]]>")
+    end
+  end
+end

--- a/test/snapshots/lexer/cdata_test/test_0001_basic_CDATA_section_c25ae454841778f175fd05bfcdda8b42.txt
+++ b/test/snapshots/lexer/cdata_test/test_0001_basic_CDATA_section_c25ae454841778f175fd05bfcdda8b42.txt
@@ -1,0 +1,3 @@
+#<Herb::Token type="TOKEN_CDATA_START" value="<![CDATA[" range=[0, 9] start=(1:0) end=(1:9)>
+#<Herb::Token type="TOKEN_CDATA_END" value="]]>" range=[9, 12] start=(1:9) end=(1:12)>
+#<Herb::Token type="TOKEN_EOF" value="<EOF>" range=[12, 12] start=(1:12) end=(1:12)>

--- a/test/snapshots/lexer/cdata_test/test_0002_CDATA_with_text_content_7f9125f551bc58d3dbfe940ac096a78c.txt
+++ b/test/snapshots/lexer/cdata_test/test_0002_CDATA_with_text_content_7f9125f551bc58d3dbfe940ac096a78c.txt
@@ -1,0 +1,6 @@
+#<Herb::Token type="TOKEN_CDATA_START" value="<![CDATA[" range=[0, 9] start=(1:0) end=(1:9)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="Hello" range=[9, 14] start=(1:9) end=(1:14)>
+#<Herb::Token type="TOKEN_WHITESPACE" value=" " range=[14, 15] start=(1:14) end=(1:15)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="World" range=[15, 20] start=(1:15) end=(1:20)>
+#<Herb::Token type="TOKEN_CDATA_END" value="]]>" range=[20, 23] start=(1:20) end=(1:23)>
+#<Herb::Token type="TOKEN_EOF" value="<EOF>" range=[23, 23] start=(1:23) end=(1:23)>

--- a/test/snapshots/lexer/cdata_test/test_0003_CDATA_with_XML-like_content_4a372fc4422be677973351bc351746ff.txt
+++ b/test/snapshots/lexer/cdata_test/test_0003_CDATA_with_XML-like_content_4a372fc4422be677973351bc351746ff.txt
@@ -1,0 +1,12 @@
+#<Herb::Token type="TOKEN_CDATA_START" value="<![CDATA[" range=[0, 9] start=(1:0) end=(1:9)>
+#<Herb::Token type="TOKEN_HTML_TAG_START" value="<" range=[9, 10] start=(1:9) end=(1:10)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="sender" range=[10, 16] start=(1:10) end=(1:16)>
+#<Herb::Token type="TOKEN_HTML_TAG_END" value=">" range=[16, 17] start=(1:16) end=(1:17)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="John" range=[17, 21] start=(1:17) end=(1:21)>
+#<Herb::Token type="TOKEN_WHITESPACE" value=" " range=[21, 22] start=(1:21) end=(1:22)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="Smith" range=[22, 27] start=(1:22) end=(1:27)>
+#<Herb::Token type="TOKEN_HTML_TAG_START_CLOSE" value="</" range=[27, 29] start=(1:27) end=(1:29)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="sender" range=[29, 35] start=(1:29) end=(1:35)>
+#<Herb::Token type="TOKEN_HTML_TAG_END" value=">" range=[35, 36] start=(1:35) end=(1:36)>
+#<Herb::Token type="TOKEN_CDATA_END" value="]]>" range=[36, 39] start=(1:36) end=(1:39)>
+#<Herb::Token type="TOKEN_EOF" value="<EOF>" range=[39, 39] start=(1:39) end=(1:39)>

--- a/test/snapshots/lexer/cdata_test/test_0004_CDATA_with_special_characters_8c3ab9c7c35d3cc83316278049f22d3e.txt
+++ b/test/snapshots/lexer/cdata_test/test_0004_CDATA_with_special_characters_8c3ab9c7c35d3cc83316278049f22d3e.txt
@@ -1,0 +1,19 @@
+#<Herb::Token type="TOKEN_CDATA_START" value="<![CDATA[" range=[0, 9] start=(1:0) end=(1:9)>
+#<Herb::Token type="TOKEN_AMPERSAND" value="&" range=[9, 10] start=(1:9) end=(1:10)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="lt" range=[10, 12] start=(1:10) end=(1:12)>
+#<Herb::Token type="TOKEN_SEMICOLON" value=";" range=[12, 13] start=(1:12) end=(1:13)>
+#<Herb::Token type="TOKEN_WHITESPACE" value=" " range=[13, 14] start=(1:13) end=(1:14)>
+#<Herb::Token type="TOKEN_AMPERSAND" value="&" range=[14, 15] start=(1:14) end=(1:15)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="gt" range=[15, 17] start=(1:15) end=(1:17)>
+#<Herb::Token type="TOKEN_SEMICOLON" value=";" range=[17, 18] start=(1:17) end=(1:18)>
+#<Herb::Token type="TOKEN_WHITESPACE" value=" " range=[18, 19] start=(1:18) end=(1:19)>
+#<Herb::Token type="TOKEN_AMPERSAND" value="&" range=[19, 20] start=(1:19) end=(1:20)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="amp" range=[20, 23] start=(1:20) end=(1:23)>
+#<Herb::Token type="TOKEN_SEMICOLON" value=";" range=[23, 24] start=(1:23) end=(1:24)>
+#<Herb::Token type="TOKEN_WHITESPACE" value=" " range=[24, 25] start=(1:24) end=(1:25)>
+#<Herb::Token type="TOKEN_AMPERSAND" value="&" range=[25, 26] start=(1:25) end=(1:26)>
+#<Herb::Token type="TOKEN_CHARACTER" value="#" range=[26, 27] start=(1:26) end=(1:27)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="240" range=[27, 30] start=(1:27) end=(1:30)>
+#<Herb::Token type="TOKEN_SEMICOLON" value=";" range=[30, 31] start=(1:30) end=(1:31)>
+#<Herb::Token type="TOKEN_CDATA_END" value="]]>" range=[31, 34] start=(1:31) end=(1:34)>
+#<Herb::Token type="TOKEN_EOF" value="<EOF>" range=[34, 34] start=(1:34) end=(1:34)>

--- a/test/snapshots/lexer/cdata_test/test_0005_CDATA_with_escaped_characters_that_are_not_interpreted_745d1382f26e84d827b38cdf475d33e3.txt
+++ b/test/snapshots/lexer/cdata_test/test_0005_CDATA_with_escaped_characters_that_are_not_interpreted_745d1382f26e84d827b38cdf475d33e3.txt
@@ -1,0 +1,20 @@
+#<Herb::Token type="TOKEN_CDATA_START" value="<![CDATA[" range=[0, 9] start=(1:0) end=(1:9)>
+#<Herb::Token type="TOKEN_HTML_TAG_START" value="<" range=[9, 10] start=(1:9) end=(1:10)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="html" range=[10, 14] start=(1:10) end=(1:14)>
+#<Herb::Token type="TOKEN_HTML_TAG_END" value=">" range=[14, 15] start=(1:14) end=(1:15)>
+#<Herb::Token type="TOKEN_AMPERSAND" value="&" range=[15, 16] start=(1:15) end=(1:16)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="amp" range=[16, 19] start=(1:16) end=(1:19)>
+#<Herb::Token type="TOKEN_SEMICOLON" value=";" range=[19, 20] start=(1:19) end=(1:20)>
+#<Herb::Token type="TOKEN_WHITESPACE" value=" " range=[20, 21] start=(1:20) end=(1:21)>
+#<Herb::Token type="TOKEN_AMPERSAND" value="&" range=[21, 22] start=(1:21) end=(1:22)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="lt" range=[22, 24] start=(1:22) end=(1:24)>
+#<Herb::Token type="TOKEN_SEMICOLON" value=";" range=[24, 25] start=(1:24) end=(1:25)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="div" range=[25, 28] start=(1:25) end=(1:28)>
+#<Herb::Token type="TOKEN_AMPERSAND" value="&" range=[28, 29] start=(1:28) end=(1:29)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="gt" range=[29, 31] start=(1:29) end=(1:31)>
+#<Herb::Token type="TOKEN_SEMICOLON" value=";" range=[31, 32] start=(1:31) end=(1:32)>
+#<Herb::Token type="TOKEN_HTML_TAG_START_CLOSE" value="</" range=[32, 34] start=(1:32) end=(1:34)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="html" range=[34, 38] start=(1:34) end=(1:38)>
+#<Herb::Token type="TOKEN_HTML_TAG_END" value=">" range=[38, 39] start=(1:38) end=(1:39)>
+#<Herb::Token type="TOKEN_CDATA_END" value="]]>" range=[39, 42] start=(1:39) end=(1:42)>
+#<Herb::Token type="TOKEN_EOF" value="<EOF>" range=[42, 42] start=(1:42) end=(1:42)>

--- a/test/snapshots/lexer/cdata_test/test_0006_CDATA_with_newlines_fde68cdcd0102d806db2e3c69fa5e5cf.txt
+++ b/test/snapshots/lexer/cdata_test/test_0006_CDATA_with_newlines_fde68cdcd0102d806db2e3c69fa5e5cf.txt
@@ -1,0 +1,20 @@
+#<Herb::Token type="TOKEN_CDATA_START" value="<![CDATA[" range=[0, 9] start=(1:0) end=(1:9)>
+#<Herb::Token type="TOKEN_NEWLINE" value="\n" range=[9, 10] start=(1:9) end=(2:0)>
+#<Herb::Token type="TOKEN_WHITESPACE" value="  " range=[10, 12] start=(2:0) end=(2:2)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="Line" range=[12, 16] start=(2:2) end=(2:6)>
+#<Herb::Token type="TOKEN_WHITESPACE" value=" " range=[16, 17] start=(2:6) end=(2:7)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="1" range=[17, 18] start=(2:7) end=(2:8)>
+#<Herb::Token type="TOKEN_NEWLINE" value="\n" range=[18, 19] start=(2:8) end=(3:0)>
+#<Herb::Token type="TOKEN_WHITESPACE" value="  " range=[19, 21] start=(3:0) end=(3:2)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="Line" range=[21, 25] start=(3:2) end=(3:6)>
+#<Herb::Token type="TOKEN_WHITESPACE" value=" " range=[25, 26] start=(3:6) end=(3:7)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="2" range=[26, 27] start=(3:7) end=(3:8)>
+#<Herb::Token type="TOKEN_NEWLINE" value="\n" range=[27, 28] start=(3:8) end=(4:0)>
+#<Herb::Token type="TOKEN_WHITESPACE" value="  " range=[28, 30] start=(4:0) end=(4:2)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="Line" range=[30, 34] start=(4:2) end=(4:6)>
+#<Herb::Token type="TOKEN_WHITESPACE" value=" " range=[34, 35] start=(4:6) end=(4:7)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="3" range=[35, 36] start=(4:7) end=(4:8)>
+#<Herb::Token type="TOKEN_NEWLINE" value="\n" range=[36, 37] start=(4:8) end=(5:0)>
+#<Herb::Token type="TOKEN_CDATA_END" value="]]>" range=[37, 40] start=(5:0) end=(5:3)>
+#<Herb::Token type="TOKEN_NEWLINE" value="\n" range=[40, 41] start=(5:3) end=(6:0)>
+#<Herb::Token type="TOKEN_EOF" value="<EOF>" range=[41, 41] start=(6:0) end=(6:0)>

--- a/test/snapshots/lexer/cdata_test/test_0007_CDATA_in_XML_document_a80d5f083429384bc29f1c2a6bc80bf1.txt
+++ b/test/snapshots/lexer/cdata_test/test_0007_CDATA_in_XML_document_a80d5f083429384bc29f1c2a6bc80bf1.txt
@@ -1,0 +1,35 @@
+#<Herb::Token type="TOKEN_XML_DECLARATION" value="<?xml" range=[0, 5] start=(1:0) end=(1:5)>
+#<Herb::Token type="TOKEN_WHITESPACE" value=" " range=[5, 6] start=(1:5) end=(1:6)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="version" range=[6, 13] start=(1:6) end=(1:13)>
+#<Herb::Token type="TOKEN_EQUALS" value="=" range=[13, 14] start=(1:13) end=(1:14)>
+#<Herb::Token type="TOKEN_QUOTE" value="\"" range=[14, 15] start=(1:14) end=(1:15)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="1" range=[15, 16] start=(1:15) end=(1:16)>
+#<Herb::Token type="TOKEN_CHARACTER" value="." range=[16, 17] start=(1:16) end=(1:17)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="0" range=[17, 18] start=(1:17) end=(1:18)>
+#<Herb::Token type="TOKEN_QUOTE" value="\"" range=[18, 19] start=(1:18) end=(1:19)>
+#<Herb::Token type="TOKEN_XML_DECLARATION_END" value="?>" range=[19, 21] start=(1:19) end=(1:21)>
+#<Herb::Token type="TOKEN_NEWLINE" value="\n" range=[21, 22] start=(1:21) end=(2:0)>
+#<Herb::Token type="TOKEN_HTML_TAG_START" value="<" range=[22, 23] start=(2:0) end=(2:1)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="root" range=[23, 27] start=(2:1) end=(2:5)>
+#<Herb::Token type="TOKEN_HTML_TAG_END" value=">" range=[27, 28] start=(2:5) end=(2:6)>
+#<Herb::Token type="TOKEN_NEWLINE" value="\n" range=[28, 29] start=(2:6) end=(3:0)>
+#<Herb::Token type="TOKEN_WHITESPACE" value="  " range=[29, 31] start=(3:0) end=(3:2)>
+#<Herb::Token type="TOKEN_HTML_TAG_START" value="<" range=[31, 32] start=(3:2) end=(3:3)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="data" range=[32, 36] start=(3:3) end=(3:7)>
+#<Herb::Token type="TOKEN_HTML_TAG_END" value=">" range=[36, 37] start=(3:7) end=(3:8)>
+#<Herb::Token type="TOKEN_CDATA_START" value="<![CDATA[" range=[37, 46] start=(3:8) end=(3:17)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="Some" range=[46, 50] start=(3:17) end=(3:21)>
+#<Herb::Token type="TOKEN_WHITESPACE" value=" " range=[50, 51] start=(3:21) end=(3:22)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="data" range=[51, 55] start=(3:22) end=(3:26)>
+#<Herb::Token type="TOKEN_WHITESPACE" value=" " range=[55, 56] start=(3:26) end=(3:27)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="here" range=[56, 60] start=(3:27) end=(3:31)>
+#<Herb::Token type="TOKEN_CDATA_END" value="]]>" range=[60, 63] start=(3:31) end=(3:34)>
+#<Herb::Token type="TOKEN_HTML_TAG_START_CLOSE" value="</" range=[63, 65] start=(3:34) end=(3:36)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="data" range=[65, 69] start=(3:36) end=(3:40)>
+#<Herb::Token type="TOKEN_HTML_TAG_END" value=">" range=[69, 70] start=(3:40) end=(3:41)>
+#<Herb::Token type="TOKEN_NEWLINE" value="\n" range=[70, 71] start=(3:41) end=(4:0)>
+#<Herb::Token type="TOKEN_HTML_TAG_START_CLOSE" value="</" range=[71, 73] start=(4:0) end=(4:2)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="root" range=[73, 77] start=(4:2) end=(4:6)>
+#<Herb::Token type="TOKEN_HTML_TAG_END" value=">" range=[77, 78] start=(4:6) end=(4:7)>
+#<Herb::Token type="TOKEN_NEWLINE" value="\n" range=[78, 79] start=(4:7) end=(5:0)>
+#<Herb::Token type="TOKEN_EOF" value="<EOF>" range=[79, 79] start=(5:0) end=(5:0)>

--- a/test/snapshots/lexer/cdata_test/test_0008_CDATA_with_ERB_content_9884f8776402de7d7296618307ccd714.txt
+++ b/test/snapshots/lexer/cdata_test/test_0008_CDATA_with_ERB_content_9884f8776402de7d7296618307ccd714.txt
@@ -1,0 +1,6 @@
+#<Herb::Token type="TOKEN_CDATA_START" value="<![CDATA[" range=[0, 9] start=(1:0) end=(1:9)>
+#<Herb::Token type="TOKEN_ERB_START" value="<%=" range=[9, 12] start=(1:9) end=(1:12)>
+#<Herb::Token type="TOKEN_ERB_CONTENT" value=" @variable " range=[12, 23] start=(1:12) end=(1:23)>
+#<Herb::Token type="TOKEN_ERB_END" value="%>" range=[23, 25] start=(1:23) end=(1:25)>
+#<Herb::Token type="TOKEN_CDATA_END" value="]]>" range=[25, 28] start=(1:25) end=(1:28)>
+#<Herb::Token type="TOKEN_EOF" value="<EOF>" range=[28, 28] start=(1:28) end=(1:28)>

--- a/test/snapshots/lexer/cdata_test/test_0009_CDATA_with_complex_ERB_2c2d90415d057b7acbff8136b9e5e8bf.txt
+++ b/test/snapshots/lexer/cdata_test/test_0009_CDATA_with_complex_ERB_2c2d90415d057b7acbff8136b9e5e8bf.txt
@@ -1,0 +1,20 @@
+#<Herb::Token type="TOKEN_CDATA_START" value="<![CDATA[" range=[0, 9] start=(1:0) end=(1:9)>
+#<Herb::Token type="TOKEN_NEWLINE" value="\n" range=[9, 10] start=(1:9) end=(2:0)>
+#<Herb::Token type="TOKEN_WHITESPACE" value="  " range=[10, 12] start=(2:0) end=(2:2)>
+#<Herb::Token type="TOKEN_ERB_START" value="<%" range=[12, 14] start=(2:2) end=(2:4)>
+#<Herb::Token type="TOKEN_ERB_CONTENT" value=" if @condition " range=[14, 29] start=(2:4) end=(2:19)>
+#<Herb::Token type="TOKEN_ERB_END" value="%>" range=[29, 31] start=(2:19) end=(2:21)>
+#<Herb::Token type="TOKEN_NEWLINE" value="\n" range=[31, 32] start=(2:21) end=(3:0)>
+#<Herb::Token type="TOKEN_WHITESPACE" value="    " range=[32, 36] start=(3:0) end=(3:4)>
+#<Herb::Token type="TOKEN_ERB_START" value="<%=" range=[36, 39] start=(3:4) end=(3:7)>
+#<Herb::Token type="TOKEN_ERB_CONTENT" value=" @content " range=[39, 49] start=(3:7) end=(3:17)>
+#<Herb::Token type="TOKEN_ERB_END" value="%>" range=[49, 51] start=(3:17) end=(3:19)>
+#<Herb::Token type="TOKEN_NEWLINE" value="\n" range=[51, 52] start=(3:19) end=(4:0)>
+#<Herb::Token type="TOKEN_WHITESPACE" value="  " range=[52, 54] start=(4:0) end=(4:2)>
+#<Herb::Token type="TOKEN_ERB_START" value="<%" range=[54, 56] start=(4:2) end=(4:4)>
+#<Herb::Token type="TOKEN_ERB_CONTENT" value=" end " range=[56, 61] start=(4:4) end=(4:9)>
+#<Herb::Token type="TOKEN_ERB_END" value="%>" range=[61, 63] start=(4:9) end=(4:11)>
+#<Herb::Token type="TOKEN_NEWLINE" value="\n" range=[63, 64] start=(4:11) end=(5:0)>
+#<Herb::Token type="TOKEN_CDATA_END" value="]]>" range=[64, 67] start=(5:0) end=(5:3)>
+#<Herb::Token type="TOKEN_NEWLINE" value="\n" range=[67, 68] start=(5:3) end=(6:0)>
+#<Herb::Token type="TOKEN_EOF" value="<EOF>" range=[68, 68] start=(6:0) end=(6:0)>

--- a/test/snapshots/lexer/cdata_test/test_0010_Multiple_CDATA_sections_0550f12e814e4f157f6d0c72afe7b323.txt
+++ b/test/snapshots/lexer/cdata_test/test_0010_Multiple_CDATA_sections_0550f12e814e4f157f6d0c72afe7b323.txt
@@ -1,0 +1,7 @@
+#<Herb::Token type="TOKEN_CDATA_START" value="<![CDATA[" range=[0, 9] start=(1:0) end=(1:9)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="First" range=[9, 14] start=(1:9) end=(1:14)>
+#<Herb::Token type="TOKEN_CDATA_END" value="]]>" range=[14, 17] start=(1:14) end=(1:17)>
+#<Herb::Token type="TOKEN_CDATA_START" value="<![CDATA[" range=[17, 26] start=(1:17) end=(1:26)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="Second" range=[26, 32] start=(1:26) end=(1:32)>
+#<Herb::Token type="TOKEN_CDATA_END" value="]]>" range=[32, 35] start=(1:32) end=(1:35)>
+#<Herb::Token type="TOKEN_EOF" value="<EOF>" range=[35, 35] start=(1:35) end=(1:35)>

--- a/test/snapshots/lexer/cdata_test/test_0011_CDATA_with_]]_inside_(workaround_pattern)_4f9dc3882e1e756e56efaf4dc1561c12.txt
+++ b/test/snapshots/lexer/cdata_test/test_0011_CDATA_with_]]_inside_(workaround_pattern)_4f9dc3882e1e756e56efaf4dc1561c12.txt
@@ -1,0 +1,14 @@
+#<Herb::Token type="TOKEN_CDATA_START" value="<![CDATA[" range=[0, 9] start=(1:0) end=(1:9)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="Content" range=[9, 16] start=(1:9) end=(1:16)>
+#<Herb::Token type="TOKEN_WHITESPACE" value=" " range=[16, 17] start=(1:16) end=(1:17)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="with" range=[17, 21] start=(1:17) end=(1:21)>
+#<Herb::Token type="TOKEN_WHITESPACE" value=" " range=[21, 22] start=(1:21) end=(1:22)>
+#<Herb::Token type="TOKEN_CHARACTER" value="]" range=[22, 23] start=(1:22) end=(1:23)>
+#<Herb::Token type="TOKEN_CHARACTER" value="]" range=[23, 24] start=(1:23) end=(1:24)>
+#<Herb::Token type="TOKEN_CDATA_END" value="]]>" range=[24, 27] start=(1:24) end=(1:27)>
+#<Herb::Token type="TOKEN_CDATA_START" value="<![CDATA[" range=[27, 36] start=(1:27) end=(1:36)>
+#<Herb::Token type="TOKEN_HTML_TAG_END" value=">" range=[36, 37] start=(1:36) end=(1:37)>
+#<Herb::Token type="TOKEN_WHITESPACE" value=" " range=[37, 38] start=(1:37) end=(1:38)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="inside" range=[38, 44] start=(1:38) end=(1:44)>
+#<Herb::Token type="TOKEN_CDATA_END" value="]]>" range=[44, 47] start=(1:44) end=(1:47)>
+#<Herb::Token type="TOKEN_EOF" value="<EOF>" range=[47, 47] start=(1:47) end=(1:47)>

--- a/test/snapshots/lexer/cdata_test/test_0012_CDATA_in_HTML_comment_context_1c8a6d998d9daa0bbe631c88cd6098e0.txt
+++ b/test/snapshots/lexer/cdata_test/test_0012_CDATA_in_HTML_comment_context_1c8a6d998d9daa0bbe631c88cd6098e0.txt
@@ -1,0 +1,14 @@
+#<Herb::Token type="TOKEN_HTML_COMMENT_START" value="<!--" range=[0, 4] start=(1:0) end=(1:4)>
+#<Herb::Token type="TOKEN_WHITESPACE" value=" " range=[4, 5] start=(1:4) end=(1:5)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="Before" range=[5, 11] start=(1:5) end=(1:11)>
+#<Herb::Token type="TOKEN_WHITESPACE" value=" " range=[11, 12] start=(1:11) end=(1:12)>
+#<Herb::Token type="TOKEN_HTML_COMMENT_END" value="-->" range=[12, 15] start=(1:12) end=(1:15)>
+#<Herb::Token type="TOKEN_CDATA_START" value="<![CDATA[" range=[15, 24] start=(1:15) end=(1:24)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="Data" range=[24, 28] start=(1:24) end=(1:28)>
+#<Herb::Token type="TOKEN_CDATA_END" value="]]>" range=[28, 31] start=(1:28) end=(1:31)>
+#<Herb::Token type="TOKEN_HTML_COMMENT_START" value="<!--" range=[31, 35] start=(1:31) end=(1:35)>
+#<Herb::Token type="TOKEN_WHITESPACE" value=" " range=[35, 36] start=(1:35) end=(1:36)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="After" range=[36, 41] start=(1:36) end=(1:41)>
+#<Herb::Token type="TOKEN_WHITESPACE" value=" " range=[41, 42] start=(1:41) end=(1:42)>
+#<Herb::Token type="TOKEN_HTML_COMMENT_END" value="-->" range=[42, 45] start=(1:42) end=(1:45)>
+#<Herb::Token type="TOKEN_EOF" value="<EOF>" range=[45, 45] start=(1:45) end=(1:45)>

--- a/test/snapshots/lexer/cdata_test/test_0013_CDATA_with_various_brackets_8684c648c8855fc8d36e691241c500b6.txt
+++ b/test/snapshots/lexer/cdata_test/test_0013_CDATA_with_various_brackets_8684c648c8855fc8d36e691241c500b6.txt
@@ -1,0 +1,9 @@
+#<Herb::Token type="TOKEN_CDATA_START" value="<![CDATA[" range=[0, 9] start=(1:0) end=(1:9)>
+#<Herb::Token type="TOKEN_CHARACTER" value="{" range=[9, 10] start=(1:9) end=(1:10)>
+#<Herb::Token type="TOKEN_CHARACTER" value="[" range=[10, 11] start=(1:10) end=(1:11)>
+#<Herb::Token type="TOKEN_CHARACTER" value="(" range=[11, 12] start=(1:11) end=(1:12)>
+#<Herb::Token type="TOKEN_CHARACTER" value=")" range=[12, 13] start=(1:12) end=(1:13)>
+#<Herb::Token type="TOKEN_CHARACTER" value="]" range=[13, 14] start=(1:13) end=(1:14)>
+#<Herb::Token type="TOKEN_CHARACTER" value="}" range=[14, 15] start=(1:14) end=(1:15)>
+#<Herb::Token type="TOKEN_CDATA_END" value="]]>" range=[15, 18] start=(1:15) end=(1:18)>
+#<Herb::Token type="TOKEN_EOF" value="<EOF>" range=[18, 18] start=(1:18) end=(1:18)>

--- a/test/snapshots/lexer/cdata_test/test_0014_Empty_CDATA_with_spaces_d7f7e4ef752a4dac58a4b97b06b627c1.txt
+++ b/test/snapshots/lexer/cdata_test/test_0014_Empty_CDATA_with_spaces_d7f7e4ef752a4dac58a4b97b06b627c1.txt
@@ -1,0 +1,4 @@
+#<Herb::Token type="TOKEN_CDATA_START" value="<![CDATA[" range=[0, 9] start=(1:0) end=(1:9)>
+#<Herb::Token type="TOKEN_WHITESPACE" value="   " range=[9, 12] start=(1:9) end=(1:12)>
+#<Herb::Token type="TOKEN_CDATA_END" value="]]>" range=[12, 15] start=(1:12) end=(1:15)>
+#<Herb::Token type="TOKEN_EOF" value="<EOF>" range=[15, 15] start=(1:15) end=(1:15)>

--- a/test/snapshots/lexer/cdata_test/test_0015_CDATA_followed_by_HTML_37ac0c068811ca1c4a498dbf50d1fe06.txt
+++ b/test/snapshots/lexer/cdata_test/test_0015_CDATA_followed_by_HTML_37ac0c068811ca1c4a498dbf50d1fe06.txt
@@ -1,0 +1,11 @@
+#<Herb::Token type="TOKEN_CDATA_START" value="<![CDATA[" range=[0, 9] start=(1:0) end=(1:9)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="Data" range=[9, 13] start=(1:9) end=(1:13)>
+#<Herb::Token type="TOKEN_CDATA_END" value="]]>" range=[13, 16] start=(1:13) end=(1:16)>
+#<Herb::Token type="TOKEN_HTML_TAG_START" value="<" range=[16, 17] start=(1:16) end=(1:17)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="div" range=[17, 20] start=(1:17) end=(1:20)>
+#<Herb::Token type="TOKEN_HTML_TAG_END" value=">" range=[20, 21] start=(1:20) end=(1:21)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="HTML" range=[21, 25] start=(1:21) end=(1:25)>
+#<Herb::Token type="TOKEN_HTML_TAG_START_CLOSE" value="</" range=[25, 27] start=(1:25) end=(1:27)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="div" range=[27, 30] start=(1:27) end=(1:30)>
+#<Herb::Token type="TOKEN_HTML_TAG_END" value=">" range=[30, 31] start=(1:30) end=(1:31)>
+#<Herb::Token type="TOKEN_EOF" value="<EOF>" range=[31, 31] start=(1:31) end=(1:31)>

--- a/test/snapshots/parser/cdata_test/test_0001_basic_CDATA_section_c25ae454841778f175fd05bfcdda8b42.txt
+++ b/test/snapshots/parser/cdata_test/test_0001_basic_CDATA_section_c25ae454841778f175fd05bfcdda8b42.txt
@@ -1,0 +1,6 @@
+@ DocumentNode (location: (1:0)-(1:12))
+└── children: (1 item)
+    └── @ CDATANode (location: (1:0)-(1:12))
+        ├── tag_opening: "<![CDATA[" (location: (1:0)-(1:9))
+        ├── children: []
+        └── tag_closing: "]]>" (location: (1:9)-(1:12))

--- a/test/snapshots/parser/cdata_test/test_0002_CDATA_with_text_content_7f9125f551bc58d3dbfe940ac096a78c.txt
+++ b/test/snapshots/parser/cdata_test/test_0002_CDATA_with_text_content_7f9125f551bc58d3dbfe940ac096a78c.txt
@@ -1,0 +1,9 @@
+@ DocumentNode (location: (1:0)-(1:23))
+└── children: (1 item)
+    └── @ CDATANode (location: (1:0)-(1:23))
+        ├── tag_opening: "<![CDATA[" (location: (1:0)-(1:9))
+        ├── children: (1 item)
+        │   └── @ LiteralNode (location: (1:9)-(1:20))
+        │       └── content: "Hello World"
+        │
+        └── tag_closing: "]]>" (location: (1:20)-(1:23))

--- a/test/snapshots/parser/cdata_test/test_0003_CDATA_with_XML-like_content_4a372fc4422be677973351bc351746ff.txt
+++ b/test/snapshots/parser/cdata_test/test_0003_CDATA_with_XML-like_content_4a372fc4422be677973351bc351746ff.txt
@@ -1,0 +1,9 @@
+@ DocumentNode (location: (1:0)-(1:39))
+└── children: (1 item)
+    └── @ CDATANode (location: (1:0)-(1:39))
+        ├── tag_opening: "<![CDATA[" (location: (1:0)-(1:9))
+        ├── children: (1 item)
+        │   └── @ LiteralNode (location: (1:9)-(1:36))
+        │       └── content: "<sender>John Smith</sender>"
+        │
+        └── tag_closing: "]]>" (location: (1:36)-(1:39))

--- a/test/snapshots/parser/cdata_test/test_0004_CDATA_with_special_characters_8c3ab9c7c35d3cc83316278049f22d3e.txt
+++ b/test/snapshots/parser/cdata_test/test_0004_CDATA_with_special_characters_8c3ab9c7c35d3cc83316278049f22d3e.txt
@@ -1,0 +1,9 @@
+@ DocumentNode (location: (1:0)-(1:34))
+└── children: (1 item)
+    └── @ CDATANode (location: (1:0)-(1:34))
+        ├── tag_opening: "<![CDATA[" (location: (1:0)-(1:9))
+        ├── children: (1 item)
+        │   └── @ LiteralNode (location: (1:9)-(1:31))
+        │       └── content: "&lt; &gt; &amp; &#240;"
+        │
+        └── tag_closing: "]]>" (location: (1:31)-(1:34))

--- a/test/snapshots/parser/cdata_test/test_0005_CDATA_with_escaped_characters_that_are_not_interpreted_745d1382f26e84d827b38cdf475d33e3.txt
+++ b/test/snapshots/parser/cdata_test/test_0005_CDATA_with_escaped_characters_that_are_not_interpreted_745d1382f26e84d827b38cdf475d33e3.txt
@@ -1,0 +1,9 @@
+@ DocumentNode (location: (1:0)-(1:42))
+└── children: (1 item)
+    └── @ CDATANode (location: (1:0)-(1:42))
+        ├── tag_opening: "<![CDATA[" (location: (1:0)-(1:9))
+        ├── children: (1 item)
+        │   └── @ LiteralNode (location: (1:9)-(1:39))
+        │       └── content: "<html>&amp; &lt;div&gt;</html>"
+        │
+        └── tag_closing: "]]>" (location: (1:39)-(1:42))

--- a/test/snapshots/parser/cdata_test/test_0006_CDATA_with_newlines_fde68cdcd0102d806db2e3c69fa5e5cf.txt
+++ b/test/snapshots/parser/cdata_test/test_0006_CDATA_with_newlines_fde68cdcd0102d806db2e3c69fa5e5cf.txt
@@ -1,0 +1,12 @@
+@ DocumentNode (location: (1:0)-(6:0))
+└── children: (2 items)
+    ├── @ CDATANode (location: (1:0)-(5:3))
+    │   ├── tag_opening: "<![CDATA[" (location: (1:0)-(1:9))
+    │   ├── children: (1 item)
+    │   │   └── @ LiteralNode (location: (1:9)-(5:0))
+    │   │       └── content: "\n  Line 1\n  Line 2\n  Line 3\n"
+    │   │
+    │   └── tag_closing: "]]>" (location: (5:0)-(5:3))
+    │
+    └── @ HTMLTextNode (location: (5:3)-(6:0))
+        └── content: "\n"

--- a/test/snapshots/parser/cdata_test/test_0007_CDATA_in_XML_document_a80d5f083429384bc29f1c2a6bc80bf1.txt
+++ b/test/snapshots/parser/cdata_test/test_0007_CDATA_in_XML_document_a80d5f083429384bc29f1c2a6bc80bf1.txt
@@ -1,0 +1,69 @@
+@ DocumentNode (location: (1:0)-(5:0))
+└── children: (4 items)
+    ├── @ XMLDeclarationNode (location: (1:0)-(1:21))
+    │   ├── tag_opening: "<?xml" (location: (1:0)-(1:5))
+    │   ├── children: (1 item)
+    │   │   └── @ LiteralNode (location: (1:5)-(1:19))
+    │   │       └── content: " version=\"1.0\""
+    │   │
+    │   └── tag_closing: "?>" (location: (1:19)-(1:21))
+    │
+    ├── @ HTMLTextNode (location: (1:21)-(2:0))
+    │   └── content: "\n"
+    │
+    ├── @ HTMLElementNode (location: (2:0)-(4:7))
+    │   ├── open_tag:
+    │   │   └── @ HTMLOpenTagNode (location: (2:0)-(2:6))
+    │   │       ├── tag_opening: "<" (location: (2:0)-(2:1))
+    │   │       ├── tag_name: "root" (location: (2:1)-(2:5))
+    │   │       ├── tag_closing: ">" (location: (2:5)-(2:6))
+    │   │       ├── children: []
+    │   │       └── is_void: false
+    │   │
+    │   ├── tag_name: "root" (location: (2:1)-(2:5))
+    │   ├── body: (3 items)
+    │   │   ├── @ HTMLTextNode (location: (2:6)-(3:2))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ HTMLElementNode (location: (3:2)-(3:41))
+    │   │   │   ├── open_tag:
+    │   │   │   │   └── @ HTMLOpenTagNode (location: (3:2)-(3:8))
+    │   │   │   │       ├── tag_opening: "<" (location: (3:2)-(3:3))
+    │   │   │   │       ├── tag_name: "data" (location: (3:3)-(3:7))
+    │   │   │   │       ├── tag_closing: ">" (location: (3:7)-(3:8))
+    │   │   │   │       ├── children: []
+    │   │   │   │       └── is_void: false
+    │   │   │   │
+    │   │   │   ├── tag_name: "data" (location: (3:3)-(3:7))
+    │   │   │   ├── body: (1 item)
+    │   │   │   │   └── @ CDATANode (location: (3:8)-(3:34))
+    │   │   │   │       ├── tag_opening: "<![CDATA[" (location: (3:8)-(3:17))
+    │   │   │   │       ├── children: (1 item)
+    │   │   │   │       │   └── @ LiteralNode (location: (3:17)-(3:31))
+    │   │   │   │       │       └── content: "Some data here"
+    │   │   │   │       │
+    │   │   │   │       └── tag_closing: "]]>" (location: (3:31)-(3:34))
+    │   │   │   │
+    │   │   │   ├── close_tag:
+    │   │   │   │   └── @ HTMLCloseTagNode (location: (3:34)-(3:41))
+    │   │   │   │       ├── tag_opening: "</" (location: (3:34)-(3:36))
+    │   │   │   │       ├── tag_name: "data" (location: (3:36)-(3:40))
+    │   │   │   │       ├── children: []
+    │   │   │   │       └── tag_closing: ">" (location: (3:40)-(3:41))
+    │   │   │   │
+    │   │   │   └── is_void: false
+    │   │   │
+    │   │   └── @ HTMLTextNode (location: (3:41)-(4:0))
+    │   │       └── content: "\n"
+    │   │
+    │   ├── close_tag:
+    │   │   └── @ HTMLCloseTagNode (location: (4:0)-(4:7))
+    │   │       ├── tag_opening: "</" (location: (4:0)-(4:2))
+    │   │       ├── tag_name: "root" (location: (4:2)-(4:6))
+    │   │       ├── children: []
+    │   │       └── tag_closing: ">" (location: (4:6)-(4:7))
+    │   │
+    │   └── is_void: false
+    │
+    └── @ HTMLTextNode (location: (4:7)-(5:0))
+        └── content: "\n"

--- a/test/snapshots/parser/cdata_test/test_0008_CDATA_with_ERB_content_9884f8776402de7d7296618307ccd714.txt
+++ b/test/snapshots/parser/cdata_test/test_0008_CDATA_with_ERB_content_9884f8776402de7d7296618307ccd714.txt
@@ -1,0 +1,13 @@
+@ DocumentNode (location: (1:0)-(1:28))
+└── children: (1 item)
+    └── @ CDATANode (location: (1:0)-(1:28))
+        ├── tag_opening: "<![CDATA[" (location: (1:0)-(1:9))
+        ├── children: (1 item)
+        │   └── @ ERBContentNode (location: (1:9)-(1:25))
+        │       ├── tag_opening: "<%=" (location: (1:9)-(1:12))
+        │       ├── content: " @variable " (location: (1:12)-(1:23))
+        │       ├── tag_closing: "%>" (location: (1:23)-(1:25))
+        │       ├── parsed: true
+        │       └── valid: true
+        │
+        └── tag_closing: "]]>" (location: (1:25)-(1:28))

--- a/test/snapshots/parser/cdata_test/test_0009_CDATA_with_complex_ERB_2c2d90415d057b7acbff8136b9e5e8bf.txt
+++ b/test/snapshots/parser/cdata_test/test_0009_CDATA_with_complex_ERB_2c2d90415d057b7acbff8136b9e5e8bf.txt
@@ -1,0 +1,42 @@
+@ DocumentNode (location: (1:0)-(6:0))
+└── children: (2 items)
+    ├── @ CDATANode (location: (1:0)-(5:3))
+    │   ├── tag_opening: "<![CDATA[" (location: (1:0)-(1:9))
+    │   ├── children: (7 items)
+    │   │   ├── @ LiteralNode (location: (1:9)-(2:2))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ ERBContentNode (location: (2:2)-(2:21))
+    │   │   │   ├── tag_opening: "<%" (location: (2:2)-(2:4))
+    │   │   │   ├── content: " if @condition " (location: (2:4)-(2:19))
+    │   │   │   ├── tag_closing: "%>" (location: (2:19)-(2:21))
+    │   │   │   ├── parsed: true
+    │   │   │   └── valid: false
+    │   │   │
+    │   │   ├── @ LiteralNode (location: (2:21)-(3:4))
+    │   │   │   └── content: "\n    "
+    │   │   │
+    │   │   ├── @ ERBContentNode (location: (3:4)-(3:19))
+    │   │   │   ├── tag_opening: "<%=" (location: (3:4)-(3:7))
+    │   │   │   ├── content: " @content " (location: (3:7)-(3:17))
+    │   │   │   ├── tag_closing: "%>" (location: (3:17)-(3:19))
+    │   │   │   ├── parsed: true
+    │   │   │   └── valid: true
+    │   │   │
+    │   │   ├── @ LiteralNode (location: (3:19)-(4:2))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ ERBContentNode (location: (4:2)-(4:11))
+    │   │   │   ├── tag_opening: "<%" (location: (4:2)-(4:4))
+    │   │   │   ├── content: " end " (location: (4:4)-(4:9))
+    │   │   │   ├── tag_closing: "%>" (location: (4:9)-(4:11))
+    │   │   │   ├── parsed: true
+    │   │   │   └── valid: false
+    │   │   │
+    │   │   └── @ LiteralNode (location: (4:11)-(5:0))
+    │   │       └── content: "\n"
+    │   │
+    │   └── tag_closing: "]]>" (location: (5:0)-(5:3))
+    │
+    └── @ HTMLTextNode (location: (5:3)-(6:0))
+        └── content: "\n"

--- a/test/snapshots/parser/cdata_test/test_0010_Multiple_CDATA_sections_0550f12e814e4f157f6d0c72afe7b323.txt
+++ b/test/snapshots/parser/cdata_test/test_0010_Multiple_CDATA_sections_0550f12e814e4f157f6d0c72afe7b323.txt
@@ -1,0 +1,17 @@
+@ DocumentNode (location: (1:0)-(1:35))
+└── children: (2 items)
+    ├── @ CDATANode (location: (1:0)-(1:17))
+    │   ├── tag_opening: "<![CDATA[" (location: (1:0)-(1:9))
+    │   ├── children: (1 item)
+    │   │   └── @ LiteralNode (location: (1:9)-(1:14))
+    │   │       └── content: "First"
+    │   │
+    │   └── tag_closing: "]]>" (location: (1:14)-(1:17))
+    │
+    └── @ CDATANode (location: (1:17)-(1:35))
+        ├── tag_opening: "<![CDATA[" (location: (1:17)-(1:26))
+        ├── children: (1 item)
+        │   └── @ LiteralNode (location: (1:26)-(1:32))
+        │       └── content: "Second"
+        │
+        └── tag_closing: "]]>" (location: (1:32)-(1:35))

--- a/test/snapshots/parser/cdata_test/test_0011_CDATA_with_]]_inside_(workaround_pattern)_4f9dc3882e1e756e56efaf4dc1561c12.txt
+++ b/test/snapshots/parser/cdata_test/test_0011_CDATA_with_]]_inside_(workaround_pattern)_4f9dc3882e1e756e56efaf4dc1561c12.txt
@@ -1,0 +1,17 @@
+@ DocumentNode (location: (1:0)-(1:47))
+└── children: (2 items)
+    ├── @ CDATANode (location: (1:0)-(1:27))
+    │   ├── tag_opening: "<![CDATA[" (location: (1:0)-(1:9))
+    │   ├── children: (1 item)
+    │   │   └── @ LiteralNode (location: (1:9)-(1:24))
+    │   │       └── content: "Content with ]]"
+    │   │
+    │   └── tag_closing: "]]>" (location: (1:24)-(1:27))
+    │
+    └── @ CDATANode (location: (1:27)-(1:47))
+        ├── tag_opening: "<![CDATA[" (location: (1:27)-(1:36))
+        ├── children: (1 item)
+        │   └── @ LiteralNode (location: (1:36)-(1:44))
+        │       └── content: "> inside"
+        │
+        └── tag_closing: "]]>" (location: (1:44)-(1:47))

--- a/test/snapshots/parser/cdata_test/test_0012_CDATA_in_HTML_comment_context_1c8a6d998d9daa0bbe631c88cd6098e0.txt
+++ b/test/snapshots/parser/cdata_test/test_0012_CDATA_in_HTML_comment_context_1c8a6d998d9daa0bbe631c88cd6098e0.txt
@@ -1,0 +1,25 @@
+@ DocumentNode (location: (1:0)-(1:45))
+└── children: (3 items)
+    ├── @ HTMLCommentNode (location: (1:0)-(1:15))
+    │   ├── comment_start: "<!--" (location: (1:0)-(1:4))
+    │   ├── children: (1 item)
+    │   │   └── @ LiteralNode (location: (1:4)-(1:12))
+    │   │       └── content: " Before "
+    │   │
+    │   └── comment_end: "-->" (location: (1:12)-(1:15))
+    │
+    ├── @ CDATANode (location: (1:15)-(1:31))
+    │   ├── tag_opening: "<![CDATA[" (location: (1:15)-(1:24))
+    │   ├── children: (1 item)
+    │   │   └── @ LiteralNode (location: (1:24)-(1:28))
+    │   │       └── content: "Data"
+    │   │
+    │   └── tag_closing: "]]>" (location: (1:28)-(1:31))
+    │
+    └── @ HTMLCommentNode (location: (1:31)-(1:45))
+        ├── comment_start: "<!--" (location: (1:31)-(1:35))
+        ├── children: (1 item)
+        │   └── @ LiteralNode (location: (1:35)-(1:42))
+        │       └── content: " After "
+        │
+        └── comment_end: "-->" (location: (1:42)-(1:45))

--- a/test/snapshots/parser/cdata_test/test_0013_CDATA_with_various_brackets_8684c648c8855fc8d36e691241c500b6.txt
+++ b/test/snapshots/parser/cdata_test/test_0013_CDATA_with_various_brackets_8684c648c8855fc8d36e691241c500b6.txt
@@ -1,0 +1,9 @@
+@ DocumentNode (location: (1:0)-(1:18))
+└── children: (1 item)
+    └── @ CDATANode (location: (1:0)-(1:18))
+        ├── tag_opening: "<![CDATA[" (location: (1:0)-(1:9))
+        ├── children: (1 item)
+        │   └── @ LiteralNode (location: (1:9)-(1:15))
+        │       └── content: "{[()]}"
+        │
+        └── tag_closing: "]]>" (location: (1:15)-(1:18))

--- a/test/snapshots/parser/cdata_test/test_0014_Empty_CDATA_with_spaces_d7f7e4ef752a4dac58a4b97b06b627c1.txt
+++ b/test/snapshots/parser/cdata_test/test_0014_Empty_CDATA_with_spaces_d7f7e4ef752a4dac58a4b97b06b627c1.txt
@@ -1,0 +1,9 @@
+@ DocumentNode (location: (1:0)-(1:15))
+└── children: (1 item)
+    └── @ CDATANode (location: (1:0)-(1:15))
+        ├── tag_opening: "<![CDATA[" (location: (1:0)-(1:9))
+        ├── children: (1 item)
+        │   └── @ LiteralNode (location: (1:9)-(1:12))
+        │       └── content: "   "
+        │
+        └── tag_closing: "]]>" (location: (1:12)-(1:15))

--- a/test/snapshots/parser/cdata_test/test_0015_CDATA_followed_by_HTML_37ac0c068811ca1c4a498dbf50d1fe06.txt
+++ b/test/snapshots/parser/cdata_test/test_0015_CDATA_followed_by_HTML_37ac0c068811ca1c4a498dbf50d1fe06.txt
@@ -1,0 +1,32 @@
+@ DocumentNode (location: (1:0)-(1:31))
+└── children: (2 items)
+    ├── @ CDATANode (location: (1:0)-(1:16))
+    │   ├── tag_opening: "<![CDATA[" (location: (1:0)-(1:9))
+    │   ├── children: (1 item)
+    │   │   └── @ LiteralNode (location: (1:9)-(1:13))
+    │   │       └── content: "Data"
+    │   │
+    │   └── tag_closing: "]]>" (location: (1:13)-(1:16))
+    │
+    └── @ HTMLElementNode (location: (1:16)-(1:31))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:16)-(1:21))
+        │       ├── tag_opening: "<" (location: (1:16)-(1:17))
+        │       ├── tag_name: "div" (location: (1:17)-(1:20))
+        │       ├── tag_closing: ">" (location: (1:20)-(1:21))
+        │       ├── children: []
+        │       └── is_void: false
+        │
+        ├── tag_name: "div" (location: (1:17)-(1:20))
+        ├── body: (1 item)
+        │   └── @ HTMLTextNode (location: (1:21)-(1:25))
+        │       └── content: "HTML"
+        │
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:25)-(1:31))
+        │       ├── tag_opening: "</" (location: (1:25)-(1:27))
+        │       ├── tag_name: "div" (location: (1:27)-(1:30))
+        │       ├── children: []
+        │       └── tag_closing: ">" (location: (1:30)-(1:31))
+        │
+        └── is_void: false

--- a/test/snapshots/parser/cdata_test/test_0016_CDATA_in_complex_document_structure_61eadd3877dc3642e8e24238fddc9b34.txt
+++ b/test/snapshots/parser/cdata_test/test_0016_CDATA_in_complex_document_structure_61eadd3877dc3642e8e24238fddc9b34.txt
@@ -1,0 +1,151 @@
+@ DocumentNode (location: (1:0)-(18:0))
+└── children: (4 items)
+    ├── @ HTMLDoctypeNode (location: (1:0)-(1:15))
+    │   ├── tag_opening: "<!DOCTYPE" (location: (1:0)-(1:9))
+    │   ├── children: (1 item)
+    │   │   └── @ LiteralNode (location: (1:9)-(1:14))
+    │   │       └── content: " html"
+    │   │
+    │   └── tag_closing: ">" (location: (1:14)-(1:15))
+    │
+    ├── @ HTMLTextNode (location: (1:15)-(2:0))
+    │   └── content: "\n"
+    │
+    ├── @ HTMLElementNode (location: (2:0)-(17:7))
+    │   ├── open_tag:
+    │   │   └── @ HTMLOpenTagNode (location: (2:0)-(2:6))
+    │   │       ├── tag_opening: "<" (location: (2:0)-(2:1))
+    │   │       ├── tag_name: "html" (location: (2:1)-(2:5))
+    │   │       ├── tag_closing: ">" (location: (2:5)-(2:6))
+    │   │       ├── children: []
+    │   │       └── is_void: false
+    │   │
+    │   ├── tag_name: "html" (location: (2:1)-(2:5))
+    │   ├── body: (5 items)
+    │   │   ├── @ HTMLTextNode (location: (2:6)-(3:2))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ HTMLElementNode (location: (3:2)-(13:9))
+    │   │   │   ├── open_tag:
+    │   │   │   │   └── @ HTMLOpenTagNode (location: (3:2)-(3:8))
+    │   │   │   │       ├── tag_opening: "<" (location: (3:2)-(3:3))
+    │   │   │   │       ├── tag_name: "head" (location: (3:3)-(3:7))
+    │   │   │   │       ├── tag_closing: ">" (location: (3:7)-(3:8))
+    │   │   │   │       ├── children: []
+    │   │   │   │       └── is_void: false
+    │   │   │   │
+    │   │   │   ├── tag_name: "head" (location: (3:3)-(3:7))
+    │   │   │   ├── body: (3 items)
+    │   │   │   │   ├── @ HTMLTextNode (location: (3:8)-(4:4))
+    │   │   │   │   │   └── content: "\n    "
+    │   │   │   │   │
+    │   │   │   │   ├── @ HTMLElementNode (location: (4:4)-(12:13))
+    │   │   │   │   │   ├── open_tag:
+    │   │   │   │   │   │   └── @ HTMLOpenTagNode (location: (4:4)-(4:12))
+    │   │   │   │   │   │       ├── tag_opening: "<" (location: (4:4)-(4:5))
+    │   │   │   │   │   │       ├── tag_name: "script" (location: (4:5)-(4:11))
+    │   │   │   │   │   │       ├── tag_closing: ">" (location: (4:11)-(4:12))
+    │   │   │   │   │   │       ├── children: []
+    │   │   │   │   │   │       └── is_void: false
+    │   │   │   │   │   │
+    │   │   │   │   │   ├── tag_name: "script" (location: (4:5)-(4:11))
+    │   │   │   │   │   ├── body: (1 item)
+    │   │   │   │   │   │   └── @ LiteralNode (location: (4:12)-(12:4))
+    │   │   │   │   │   │       └── content: "\n      <![CDATA[\n        function test() {\n          if (x < 5 && y > 3) {\n            return true;\n          }\n        }\n      ]]>\n    "
+    │   │   │   │   │   │
+    │   │   │   │   │   ├── close_tag:
+    │   │   │   │   │   │   └── @ HTMLCloseTagNode (location: (12:4)-(12:13))
+    │   │   │   │   │   │       ├── tag_opening: "</" (location: (12:4)-(12:6))
+    │   │   │   │   │   │       ├── tag_name: "script" (location: (12:6)-(12:12))
+    │   │   │   │   │   │       ├── children: []
+    │   │   │   │   │   │       └── tag_closing: ">" (location: (12:12)-(12:13))
+    │   │   │   │   │   │
+    │   │   │   │   │   └── is_void: false
+    │   │   │   │   │
+    │   │   │   │   └── @ HTMLTextNode (location: (12:13)-(13:2))
+    │   │   │   │       └── content: "\n  "
+    │   │   │   │
+    │   │   │   ├── close_tag:
+    │   │   │   │   └── @ HTMLCloseTagNode (location: (13:2)-(13:9))
+    │   │   │   │       ├── tag_opening: "</" (location: (13:2)-(13:4))
+    │   │   │   │       ├── tag_name: "head" (location: (13:4)-(13:8))
+    │   │   │   │       ├── children: []
+    │   │   │   │       └── tag_closing: ">" (location: (13:8)-(13:9))
+    │   │   │   │
+    │   │   │   └── is_void: false
+    │   │   │
+    │   │   ├── @ HTMLTextNode (location: (13:9)-(14:2))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ HTMLElementNode (location: (14:2)-(16:9))
+    │   │   │   ├── open_tag:
+    │   │   │   │   └── @ HTMLOpenTagNode (location: (14:2)-(14:8))
+    │   │   │   │       ├── tag_opening: "<" (location: (14:2)-(14:3))
+    │   │   │   │       ├── tag_name: "body" (location: (14:3)-(14:7))
+    │   │   │   │       ├── tag_closing: ">" (location: (14:7)-(14:8))
+    │   │   │   │       ├── children: []
+    │   │   │   │       └── is_void: false
+    │   │   │   │
+    │   │   │   ├── tag_name: "body" (location: (14:3)-(14:7))
+    │   │   │   ├── body: (3 items)
+    │   │   │   │   ├── @ HTMLTextNode (location: (14:8)-(15:4))
+    │   │   │   │   │   └── content: "\n    "
+    │   │   │   │   │
+    │   │   │   │   ├── @ HTMLElementNode (location: (15:4)-(15:56))
+    │   │   │   │   │   ├── open_tag:
+    │   │   │   │   │   │   └── @ HTMLOpenTagNode (location: (15:4)-(15:9))
+    │   │   │   │   │   │       ├── tag_opening: "<" (location: (15:4)-(15:5))
+    │   │   │   │   │   │       ├── tag_name: "div" (location: (15:5)-(15:8))
+    │   │   │   │   │   │       ├── tag_closing: ">" (location: (15:8)-(15:9))
+    │   │   │   │   │   │       ├── children: []
+    │   │   │   │   │   │       └── is_void: false
+    │   │   │   │   │   │
+    │   │   │   │   │   ├── tag_name: "div" (location: (15:5)-(15:8))
+    │   │   │   │   │   ├── body: (1 item)
+    │   │   │   │   │   │   └── @ CDATANode (location: (15:9)-(15:50))
+    │   │   │   │   │   │       ├── tag_opening: "<![CDATA[" (location: (15:9)-(15:18))
+    │   │   │   │   │   │       ├── children: (1 item)
+    │   │   │   │   │   │       │   └── @ ERBContentNode (location: (15:18)-(15:47))
+    │   │   │   │   │   │       │       ├── tag_opening: "<%=" (location: (15:18)-(15:21))
+    │   │   │   │   │   │       │       ├── content: " render partial: 'test' " (location: (15:21)-(15:45))
+    │   │   │   │   │   │       │       ├── tag_closing: "%>" (location: (15:45)-(15:47))
+    │   │   │   │   │   │       │       ├── parsed: true
+    │   │   │   │   │   │       │       └── valid: true
+    │   │   │   │   │   │       │
+    │   │   │   │   │   │       └── tag_closing: "]]>" (location: (15:47)-(15:50))
+    │   │   │   │   │   │
+    │   │   │   │   │   ├── close_tag:
+    │   │   │   │   │   │   └── @ HTMLCloseTagNode (location: (15:50)-(15:56))
+    │   │   │   │   │   │       ├── tag_opening: "</" (location: (15:50)-(15:52))
+    │   │   │   │   │   │       ├── tag_name: "div" (location: (15:52)-(15:55))
+    │   │   │   │   │   │       ├── children: []
+    │   │   │   │   │   │       └── tag_closing: ">" (location: (15:55)-(15:56))
+    │   │   │   │   │   │
+    │   │   │   │   │   └── is_void: false
+    │   │   │   │   │
+    │   │   │   │   └── @ HTMLTextNode (location: (15:56)-(16:2))
+    │   │   │   │       └── content: "\n  "
+    │   │   │   │
+    │   │   │   ├── close_tag:
+    │   │   │   │   └── @ HTMLCloseTagNode (location: (16:2)-(16:9))
+    │   │   │   │       ├── tag_opening: "</" (location: (16:2)-(16:4))
+    │   │   │   │       ├── tag_name: "body" (location: (16:4)-(16:8))
+    │   │   │   │       ├── children: []
+    │   │   │   │       └── tag_closing: ">" (location: (16:8)-(16:9))
+    │   │   │   │
+    │   │   │   └── is_void: false
+    │   │   │
+    │   │   └── @ HTMLTextNode (location: (16:9)-(17:0))
+    │   │       └── content: "\n"
+    │   │
+    │   ├── close_tag:
+    │   │   └── @ HTMLCloseTagNode (location: (17:0)-(17:7))
+    │   │       ├── tag_opening: "</" (location: (17:0)-(17:2))
+    │   │       ├── tag_name: "html" (location: (17:2)-(17:6))
+    │   │       ├── children: []
+    │   │       └── tag_closing: ">" (location: (17:6)-(17:7))
+    │   │
+    │   └── is_void: false
+    │
+    └── @ HTMLTextNode (location: (17:7)-(18:0))
+        └── content: "\n"

--- a/test/snapshots/parser/cdata_test/test_0017_CDATA_with_ERB_loop_e0b9e9e369a74b4d48962fb7540684ff.txt
+++ b/test/snapshots/parser/cdata_test/test_0017_CDATA_with_ERB_loop_e0b9e9e369a74b4d48962fb7540684ff.txt
@@ -1,0 +1,42 @@
+@ DocumentNode (location: (1:0)-(6:0))
+└── children: (2 items)
+    ├── @ CDATANode (location: (1:0)-(5:3))
+    │   ├── tag_opening: "<![CDATA[" (location: (1:0)-(1:9))
+    │   ├── children: (7 items)
+    │   │   ├── @ LiteralNode (location: (1:9)-(2:2))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ ERBContentNode (location: (2:2)-(2:29))
+    │   │   │   ├── tag_opening: "<%" (location: (2:2)-(2:4))
+    │   │   │   ├── content: " @items.each do |item| " (location: (2:4)-(2:27))
+    │   │   │   ├── tag_closing: "%>" (location: (2:27)-(2:29))
+    │   │   │   ├── parsed: true
+    │   │   │   └── valid: false
+    │   │   │
+    │   │   ├── @ LiteralNode (location: (2:29)-(3:10))
+    │   │   │   └── content: "\n    <item>"
+    │   │   │
+    │   │   ├── @ ERBContentNode (location: (3:10)-(3:26))
+    │   │   │   ├── tag_opening: "<%=" (location: (3:10)-(3:13))
+    │   │   │   ├── content: " item.name " (location: (3:13)-(3:24))
+    │   │   │   ├── tag_closing: "%>" (location: (3:24)-(3:26))
+    │   │   │   ├── parsed: true
+    │   │   │   └── valid: true
+    │   │   │
+    │   │   ├── @ LiteralNode (location: (3:26)-(4:2))
+    │   │   │   └── content: "</item>\n  "
+    │   │   │
+    │   │   ├── @ ERBContentNode (location: (4:2)-(4:11))
+    │   │   │   ├── tag_opening: "<%" (location: (4:2)-(4:4))
+    │   │   │   ├── content: " end " (location: (4:4)-(4:9))
+    │   │   │   ├── tag_closing: "%>" (location: (4:9)-(4:11))
+    │   │   │   ├── parsed: true
+    │   │   │   └── valid: false
+    │   │   │
+    │   │   └── @ LiteralNode (location: (4:11)-(5:0))
+    │   │       └── content: "\n"
+    │   │
+    │   └── tag_closing: "]]>" (location: (5:0)-(5:3))
+    │
+    └── @ HTMLTextNode (location: (5:3)-(6:0))
+        └── content: "\n"

--- a/test/snapshots/parser/cdata_test/test_0018_nested_CDATA_workaround_2ec87bf5c1413bcb7f9a5f7a2569a50c.txt
+++ b/test/snapshots/parser/cdata_test/test_0018_nested_CDATA_workaround_2ec87bf5c1413bcb7f9a5f7a2569a50c.txt
@@ -1,0 +1,17 @@
+@ DocumentNode (location: (1:0)-(1:69))
+└── children: (2 items)
+    ├── @ CDATANode (location: (1:0)-(1:46))
+    │   ├── tag_opening: "<![CDATA[" (location: (1:0)-(1:9))
+    │   ├── children: (1 item)
+    │   │   └── @ LiteralNode (location: (1:9)-(1:43))
+    │   │       └── content: "Outer start <![CDATA[fake nested]]"
+    │   │
+    │   └── tag_closing: "]]>" (location: (1:43)-(1:46))
+    │
+    └── @ CDATANode (location: (1:46)-(1:69))
+        ├── tag_opening: "<![CDATA[" (location: (1:46)-(1:55))
+        ├── children: (1 item)
+        │   └── @ LiteralNode (location: (1:55)-(1:66))
+        │       └── content: "> Outer end"
+        │
+        └── tag_closing: "]]>" (location: (1:66)-(1:69))


### PR DESCRIPTION
This pull request adds support for parsing CDATA nodes, like:

```xml
<![CDATA[Hello World]]>
```

Which parses as:
```js
@ DocumentNode (location: (1:0)-(1:23))
├── errors: []
└── children: (1 item)
    └── @ CDATANode (location: (1:0)-(1:23))
        ├── errors: []
        ├── tag_opening: "<![CDATA[" (location: (1:0)-(1:9))
        ├── children: (1 item)
        │   └── @ LiteralNode (location: (1:9)-(1:20))
        │       ├── errors: []
        │       └── content: "Hello World"
        │       
        │   
        └── tag_closing: "]]>" (location: (1:20)-(1:23))
```

Resolves #425
