### PR TITLE
CLI: Bring Formatter and Linter CLI behavior closer together

### DIFF
--- a/javascript/packages/formatter/test/cli.test.ts
+++ b/javascript/packages/formatter/test/cli.test.ts
@@ -396,4 +396,257 @@ describe("CLI Binary", () => {
     const formattedLines = lines.slice(2) // Skip experimental preview lines
     expect(formattedLines.join('\n')).toBe('\n')
   })
+
+  describe("Glob Pattern Support", () => {
+    beforeEach(async () => {
+      await mkdir("test-fixtures", { recursive: true })
+      await mkdir("test-fixtures/nested", { recursive: true })
+    })
+
+    afterEach(async () => {
+      await rm("test-fixtures", { recursive: true }).catch(() => {})
+    })
+
+    it("should format single .xml.erb file", async () => {
+      const content = '<?xml version="1.0"?>\n<root><% if true %><item/><% end %></root>'
+      const expectedContent = dedent`
+        <?xml version="1.0"?>
+
+        <root>
+          <% if true %>
+            <item />
+          <% end %>
+        </root>
+      `
+
+      await writeFile("test-fixtures/test.xml.erb", content)
+      const result = await execBinary(["test-fixtures/test.xml.erb"])
+
+      expectExitCode(result, 0)
+      expect(result.stdout).toContain("Formatted: test-fixtures/test.xml.erb")
+
+      const actualContent = await readFile("test-fixtures/test.xml.erb", "utf-8")
+      expect(actualContent.trim()).toBe(expectedContent)
+    })
+
+    it("should handle glob pattern for .xml.erb files", async () => {
+      const content1 = '<?xml version="1.0"?><root><item/></root>'
+      const content2 = '<?xml version="1.0"?><config><setting/></config>'
+
+      await writeFile("test-fixtures/file1.xml.erb", content1)
+      await writeFile("test-fixtures/file2.xml.erb", content2)
+      await writeFile("test-fixtures/ignored.html.erb", "<div></div>")
+
+      const result = await execBinary(["test-fixtures/*.xml.erb"])
+
+      expectExitCode(result, 0)
+      expect(result.stdout).toContain("Formatted: test-fixtures/file1.xml.erb")
+      expect(result.stdout).toContain("Formatted: test-fixtures/file2.xml.erb")
+      expect(result.stdout).not.toContain("ignored.html.erb")
+      expect(result.stdout).toContain("Checked 2 files, formatted 2 files")
+    })
+
+    it("should handle recursive glob pattern", async () => {
+      const content = '<?xml version="1.0"?><root><item/></root>'
+
+      await writeFile("test-fixtures/top.xml.erb", content)
+      await writeFile("test-fixtures/nested/deep.xml.erb", content)
+
+      const result = await execBinary(["test-fixtures/**/*.xml.erb"])
+
+      expectExitCode(result, 0)
+      expect(result.stdout).toContain("Formatted: test-fixtures/top.xml.erb")
+      expect(result.stdout).toContain("Formatted: test-fixtures/nested/deep.xml.erb")
+      expect(result.stdout).toContain("Checked 2 files, formatted 2 files")
+    })
+
+    it("should handle mixed file extensions with glob", async () => {
+      const xmlContent = '<?xml version="1.0"?><root><item/></root>'
+      const htmlContent = '<div><p></p></div>'
+
+      await writeFile("test-fixtures/file.xml.erb", xmlContent)
+      await writeFile("test-fixtures/file.html.erb", htmlContent)
+
+      const result = await execBinary(["test-fixtures/*.erb"])
+
+      expectExitCode(result, 0)
+      expect(result.stdout).toContain("Formatted: test-fixtures/file.xml.erb")
+      expect(result.stdout).toContain("Formatted: test-fixtures/file.html.erb")
+      expect(result.stdout).toContain("Checked 2 files, formatted 2 files")
+    })
+
+    it("should handle glob with --check mode", async () => {
+      const wellFormattedContent = dedent`
+        <?xml version="1.0"?>
+
+        <root>
+          <% if true %>
+            <item />
+          <% end %>
+        </root>
+      `
+      const poorlyFormattedContent = '<?xml version="1.0"?><root><% if true %><item/><% end %></root>'
+
+      await writeFile("test-fixtures/good.xml.erb", wellFormattedContent + '\n')
+      await writeFile("test-fixtures/bad.xml.erb", poorlyFormattedContent)
+
+      const result = await execBinary(["--check", "test-fixtures/*.xml.erb"])
+
+      expectExitCode(result, 1)
+      expect(result.stdout).toContain("The following")
+      expect(result.stdout).toContain("not formatted")
+      expect(result.stdout).toContain("bad.xml.erb")
+      expect(result.stdout).not.toContain("good.xml.erb")
+      expect(result.stdout).toContain("Checked 2 files, found 1 unformatted file")
+    })
+
+    it("should handle no files matching glob pattern", async () => {
+      const result = await execBinary(["test-fixtures/*.nonexistent"])
+
+      expectExitCode(result, 0)
+      expect(result.stdout).toContain("No files found matching pattern")
+      expect(result.stdout).toContain("test-fixtures/*.nonexistent")
+    })
+
+    it("should error for non-existent specific file", async () => {
+      const result = await execBinary(["test-fixtures/nonexistent.xml.erb"])
+
+      expectExitCode(result, 1)
+      expect(result.stderr).toContain("Error: Cannot access 'test-fixtures/nonexistent.xml.erb'")
+    })
+
+    it("should handle relative path glob patterns", async () => {
+      const content = '<?xml version="1.0"?><root><item/></root>'
+
+      await writeFile("test-fixtures/test.xml.erb", content)
+
+      const result = await execBinary(["./test-fixtures/*.xml.erb"])
+
+      expectExitCode(result, 0)
+      expect(result.stdout).toContain("Formatted: test-fixtures/test.xml.erb")
+      expect(result.stdout).toContain("Checked 1 file, formatted 1 file")
+    })
+  })
+
+  describe("Advanced CLI Patterns", () => {
+    beforeEach(async () => {
+      await mkdir("test-advanced", { recursive: true })
+      await mkdir("test-advanced/sub1", { recursive: true })
+      await mkdir("test-advanced/sub2", { recursive: true })
+    })
+
+    afterEach(async () => {
+      await rm("test-advanced", { recursive: true }).catch(() => {})
+    })
+
+    it("should handle complex nested glob patterns", async () => {
+      const content = '<?xml version="1.0"?><root><item/></root>'
+
+      await writeFile("test-advanced/root.xml.erb", content)
+      await writeFile("test-advanced/sub1/file1.xml.erb", content)
+      await writeFile("test-advanced/sub1/file2.xml.erb", content)
+      await writeFile("test-advanced/sub2/file3.xml.erb", content)
+      await writeFile("test-advanced/sub2/ignore.html.erb", "<div></div>")
+
+      const result = await execBinary(["test-advanced/**/file*.xml.erb"])
+
+      expectExitCode(result, 0)
+      expect(result.stdout).toContain("Formatted: test-advanced/sub1/file1.xml.erb")
+      expect(result.stdout).toContain("Formatted: test-advanced/sub1/file2.xml.erb")
+      expect(result.stdout).toContain("Formatted: test-advanced/sub2/file3.xml.erb")
+      expect(result.stdout).not.toContain("root.xml.erb")
+      expect(result.stdout).not.toContain("ignore.html.erb")
+      expect(result.stdout).toContain("Checked 3 files, formatted 3 files")
+    })
+
+    it("should handle brace expansion patterns", async () => {
+      const content = '<?xml version="1.0"?><root><item/></root>'
+
+      await writeFile("test-advanced/config.xml.erb", content)
+      await writeFile("test-advanced/manifest.xml.erb", content)
+      await writeFile("test-advanced/other.erb", content)
+
+      const result = await execBinary(["test-advanced/{config,manifest}.xml.erb"])
+
+      expectExitCode(result, 0)
+      expect(result.stdout).toContain("Formatted: test-advanced/config.xml.erb")
+      expect(result.stdout).toContain("Formatted: test-advanced/manifest.xml.erb")
+      expect(result.stdout).not.toContain("other.erb")
+      expect(result.stdout).toContain("Checked 2 files, formatted 2 files")
+    })
+
+    it("should handle directory argument with mixed file types", async () => {
+      const xmlContent = '<?xml version="1.0"?><root><item/></root>'
+      const htmlContent = '<div><p></p></div>'
+
+      await writeFile("test-advanced/file.xml.erb", xmlContent)
+      await writeFile("test-advanced/page.html.erb", htmlContent)
+      await writeFile("test-advanced/readme.txt", "plain text")
+
+      const result = await execBinary(["test-advanced/"])
+
+      expectExitCode(result, 0)
+      expect(result.stdout).toContain("Formatted: test-advanced/page.html.erb")
+      expect(result.stdout).not.toContain("file.xml.erb") // Only .html.erb by default for directories
+      expect(result.stdout).not.toContain("readme.txt")
+      expect(result.stdout).toContain("Checked 1 file, formatted 1 file")
+    })
+
+    it("should handle empty directory gracefully", async () => {
+      const result = await execBinary(["test-advanced/"])
+
+      expectExitCode(result, 0)
+      expect(result.stdout).toContain("No files found matching pattern")
+      expect(result.stdout).toContain("test-advanced/**/*.html.erb")
+    })
+
+    it("should handle mixed file arguments", async () => {
+      const xmlContent = '<?xml version="1.0"?><root><item/></root>'
+      const htmlContent = '<div><p></p></div>'
+
+      await writeFile("test-advanced/specific.xml.erb", xmlContent)
+      await writeFile("test-advanced/another.html.erb", htmlContent)
+
+      const result1 = await execBinary(["test-advanced/specific.xml.erb"])
+      expectExitCode(result1, 0)
+      expect(result1.stdout).toContain("Formatted: test-advanced/specific.xml.erb")
+
+      const result2 = await execBinary(["test-advanced/another.html.erb"])
+      expectExitCode(result2, 0)
+      expect(result2.stdout).toContain("Formatted: test-advanced/another.html.erb")
+    })
+
+    it("should preserve glob patterns in error messages", async () => {
+      const result = await execBinary(["test-advanced/non-existent-*.xml.erb"])
+
+      expectExitCode(result, 0)
+      expect(result.stdout).toContain("No files found matching pattern")
+      expect(result.stdout).toContain("test-advanced/non-existent-*.xml.erb")
+    })
+
+    it("should handle check mode with complex patterns", async () => {
+      const formattedContent = dedent`
+        <?xml version="1.0"?>
+
+        <root>
+          <item />
+        </root>
+      `
+      const unformattedContent = '<?xml version="1.0"?><root><item/></root>'
+
+      await writeFile("test-advanced/good1.xml.erb", formattedContent + '\n')
+      await writeFile("test-advanced/good2.xml.erb", formattedContent + '\n')
+      await writeFile("test-advanced/sub1/bad.xml.erb", unformattedContent)
+
+      const result = await execBinary(["--check", "test-advanced/**/*.xml.erb"])
+
+      expectExitCode(result, 1)
+      expect(result.stdout).toContain("The following")
+      expect(result.stdout).toContain("not formatted")
+      expect(result.stdout).toContain("bad.xml.erb")
+      expect(result.stdout).not.toContain("good1.xml.erb")
+      expect(result.stdout).not.toContain("good2.xml.erb")
+      expect(result.stdout).toContain("Checked 3 files, found 1 unformatted file")
+    })
+  })
 })

--- a/javascript/packages/formatter/test/fixtures/config.xml.erb
+++ b/javascript/packages/formatter/test/fixtures/config.xml.erb
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <settings>
+    <% if Rails.env.production? %>
+      <env>production</env>
+      <debug>false</debug>
+    <% else %>
+      <env>development</env>
+      <debug>true</debug>
+    <% end %>
+  </settings>
+  <database>
+    <host><%= database_host %></host>
+    <port><%= database_port || 5432 %></port>
+  </database>
+</configuration>

--- a/javascript/packages/formatter/test/fixtures/example.xml.erb
+++ b/javascript/packages/formatter/test/fixtures/example.xml.erb
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title><%= @title %></title>
+    <description><%= @description %></description>
+    <% @items.each do |item| %>
+    <item>
+      <title><%= item.title %></title>
+      <description><%= item.content %></description>
+    </item>
+    <% end %>
+  </channel>
+</rss>

--- a/javascript/packages/formatter/test/fixtures/nested/manifest.xml.erb
+++ b/javascript/packages/formatter/test/fixtures/nested/manifest.xml.erb
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+  <application>
+    <activity android:name="MainActivity">
+      <% permissions.each do |permission| %>
+        <uses-permission android:name="<%= permission %>" />
+      <% end %>
+    </activity>
+  </application>
+</manifest>

--- a/javascript/packages/formatter/test/xml-erb-integration.test.ts
+++ b/javascript/packages/formatter/test/xml-erb-integration.test.ts
@@ -1,0 +1,253 @@
+import { describe, test, expect, beforeAll } from "vitest"
+import { Herb } from "@herb-tools/node-wasm"
+import { Formatter } from "../src"
+
+import dedent from "dedent"
+
+let formatter: Formatter
+
+describe("XML ERB Integration", () => {
+  beforeAll(async () => {
+    await Herb.load()
+
+    formatter = new Formatter(Herb, {
+      indentWidth: 2,
+      maxLineLength: 80
+    })
+  })
+
+  test("XML RSS feed with ERB", () => {
+    const source = dedent`
+      <?xml version="1.0" encoding="UTF-8"?>
+      <rss version="2.0">
+        <channel>
+          <title><%= @title %></title>
+          <description><%= @description %></description>
+          <% @items.each do |item| %>
+          <item>
+            <title><%= item.title %></title>
+            <description><%= item.content %></description>
+          </item>
+          <% end %>
+        </channel>
+      </rss>
+    `
+
+    const expected = dedent`
+      <?xml version="1.0" encoding="UTF-8"?>
+
+      <rss version="2.0">
+        <channel>
+          <title><%= @title %></title>
+          <description><%= @description %></description>
+          <% @items.each do |item| %>
+            <item>
+              <title><%= item.title %></title>
+              <description><%= item.content %></description>
+            </item>
+          <% end %>
+        </channel>
+      </rss>
+    `
+
+    const result = formatter.format(source)
+    expect(result.trim()).toEqual(expected)
+  })
+
+  test("XML configuration with conditional ERB", () => {
+    const source = dedent`
+      <?xml version="1.0" encoding="UTF-8"?>
+      <configuration>
+        <settings>
+          <% if Rails.env.production? %>
+            <env>production</env>
+            <debug>false</debug>
+          <% else %>
+            <env>development</env>
+            <debug>true</debug>
+          <% end %>
+        </settings>
+        <database>
+          <host><%= database_host %></host>
+          <port><%= database_port || 5432 %></port>
+        </database>
+      </configuration>
+    `
+
+    const expected = dedent`
+      <?xml version="1.0" encoding="UTF-8"?>
+
+      <configuration>
+        <settings>
+          <% if Rails.env.production? %>
+            <env>production</env>
+            <debug>false</debug>
+          <% else %>
+            <env>development</env>
+            <debug>true</debug>
+          <% end %>
+        </settings>
+        <database>
+          <host><%= database_host %></host>
+          <port><%= database_port || 5432 %></port>
+        </database>
+      </configuration>
+    `
+
+    const result = formatter.format(source)
+    expect(result.trim()).toEqual(expected)
+  })
+
+  test("Android manifest XML with ERB loops", () => {
+    const source = dedent`
+      <?xml version="1.0" encoding="UTF-8"?>
+      <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+        <application android:name="MainActivity">
+          <% permissions.each do |permission| %>
+            <uses-permission android:name="<%= permission %>" />
+          <% end %>
+          <% features.each_with_index do |feature, index| %>
+            <uses-feature
+              android:name="<%= feature.name %>"
+              android:required="<%= feature.required %>"
+              android:glEsVersion="<%= feature.gl_version if feature.gl_version %>"
+            />
+          <% end %>
+        </application>
+      </manifest>
+    `
+
+    const expected = dedent`
+      <?xml version="1.0" encoding="UTF-8"?>
+
+      <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+        <application android:name="MainActivity">
+          <% permissions.each do |permission| %>
+            <uses-permission android:name="<%= permission %>" />
+          <% end %>
+          <% features.each_with_index do |feature, index| %>
+            <uses-feature
+              android:name="<%= feature.name %>"
+              android:required="<%= feature.required %>"
+              android:glEsVersion="<%= feature.gl_version if feature.gl_version %>"
+            />
+          <% end %>
+        </application>
+      </manifest>
+    `
+
+    const result = formatter.format(source)
+    expect(result.trim()).toEqual(expected)
+  })
+
+  test("XML with mixed content and ERB", () => {
+    const source = dedent`
+      <?xml version="1.0" encoding="UTF-8"?>
+      <document>
+        <header>
+          <title>Document Title</title>
+        </header>
+        <content>
+          <% if @show_intro %>
+            <introduction>
+              <p>This is an introduction paragraph.</p>
+            </introduction>
+          <% end %>
+          <main>
+            <% @sections.each do |section| %>
+              <section id="<%= section.id %>">
+                <h2><%= section.title %></h2>
+                <% section.paragraphs.each do |p| %>
+                  <p><%= p %></p>
+                <% end %>
+              </section>
+            <% end %>
+          </main>
+        </content>
+      </document>
+    `
+
+    const expected = dedent`
+      <?xml version="1.0" encoding="UTF-8"?>
+
+      <document>
+        <header>
+          <title>Document Title</title>
+        </header>
+        <content>
+          <% if @show_intro %>
+            <introduction>
+              <p>This is an introduction paragraph.</p>
+            </introduction>
+          <% end %>
+          <main>
+            <% @sections.each do |section| %>
+              <section id="<%= section.id %>">
+                <h2><%= section.title %></h2>
+                <% section.paragraphs.each do |p| %>
+                  <p><%= p %></p>
+                <% end %>
+              </section>
+            <% end %>
+          </main>
+        </content>
+      </document>
+    `
+
+    const result = formatter.format(source)
+    expect(result.trim()).toEqual(expected)
+  })
+
+  test("Compact XML gets properly formatted", () => {
+    const source = '<?xml version="1.0"?><root><% if true %><item/><% end %></root>'
+
+    const expected = dedent`
+      <?xml version="1.0"?>
+
+      <root>
+        <% if true %>
+          <item />
+        <% end %>
+      </root>
+    `
+
+    const result = formatter.format(source)
+    expect(result.trim()).toEqual(expected)
+  })
+
+  test.skip("XML with CDATA and ERB", () => {
+    const source = dedent`
+      <?xml version="1.0" encoding="UTF-8"?>
+      <document>
+        <script>
+          <![CDATA[
+            <% if @include_analytics %>
+              function trackEvent(name) {
+                analytics.track(name);
+              }
+            <% end %>
+          ]]>
+        </script>
+      </document>
+    `
+
+    const expected = dedent`
+      <?xml version="1.0" encoding="UTF-8"?>
+
+      <document>
+        <script>
+          <![CDATA[
+            <% if @include_analytics %>
+              function trackEvent(name) {
+                analytics.track(name);
+              }
+            <% end %>
+          ]]>
+        </script>
+      </document>
+    `
+
+    const result = formatter.format(source)
+    expect(result.trim()).toEqual(expected)
+  })
+})

--- a/javascript/packages/linter/src/cli/argument-parser.ts
+++ b/javascript/packages/linter/src/cli/argument-parser.ts
@@ -114,11 +114,6 @@ export class ArgumentParser {
     const theme = values.theme || DEFAULT_THEME
     const pattern = this.getFilePattern(positionals)
 
-    if (positionals.length === 0) {
-      console.error("Please specify input file.")
-      process.exit(1)
-    }
-
     return { pattern, formatOption, showTiming, theme, wrapLines, truncateLines }
   }
 

--- a/javascript/packages/linter/test/xml-erb-linting.test.ts
+++ b/javascript/packages/linter/test/xml-erb-linting.test.ts
@@ -1,0 +1,186 @@
+import { describe, test, expect, beforeAll } from "vitest"
+import { Herb } from "@herb-tools/node-wasm"
+import { Linter } from "../src"
+import dedent from "dedent"
+
+let linter: Linter
+
+describe("XML+ERB Linting", () => {
+  beforeAll(async () => {
+    await Herb.load()
+    linter = new Linter(Herb)
+  })
+
+  test("should lint valid XML ERB without errors", () => {
+    const source = dedent`
+      <?xml version="1.0" encoding="UTF-8"?>
+      <rss version="2.0">
+        <channel>
+          <title><%= @title %></title>
+          <description><%= @description %></description>
+          <% @items.each do |item| %>
+            <item>
+              <title><%= item.title %></title>
+              <description><%= item.content %></description>
+            </item>
+          <% end %>
+        </channel>
+      </rss>
+    ` + '\n'
+
+    const result = linter.lint(source, { fileName: "test.xml.erb" })
+    expect(result.offenses).toHaveLength(0)
+  })
+
+  test("should detect ERB whitespace issues in XML", () => {
+    const source = dedent`
+      <?xml version="1.0" encoding="UTF-8"?>
+      <config>
+        <setting><%=value%></setting>
+        <debug><%=debug_mode %></debug>
+      </config>
+    ` + '\n'
+
+    const result = linter.lint(source, { fileName: "config.xml.erb" })
+
+
+    const whitespaceErrors = result.offenses.filter(offense =>
+      offense.code === "erb-require-whitespace-inside-tags"
+    )
+    expect(whitespaceErrors.length).toBeGreaterThanOrEqual(2)
+  })
+
+  test("should detect self-closing tags in XML (which are different from HTML)", () => {
+    const source = dedent`
+      <?xml version="1.0" encoding="UTF-8"?>
+      <manifest>
+        <application>
+          <% permissions.each do |perm| %>
+            <uses-permission android:name="<%= perm %>" />
+          <% end %>
+        </application>
+      </manifest>
+    ` + '\n'
+
+    const result = linter.lint(source, { fileName: "manifest.xml.erb" })
+
+    // In XML context, self-closing tags are normal, but linter treats as HTML
+    const selfClosingErrors = result.offenses.filter(offense =>
+      offense.code === "html-no-self-closing"
+    )
+    expect(selfClosingErrors.length).toBeGreaterThanOrEqual(1)
+  })
+
+  test.todo("should handle XML with CDATA sections", () => {
+    const source = dedent`
+      <?xml version="1.0" encoding="UTF-8"?>
+      <document>
+        <script>
+          <![CDATA[
+            <% if @analytics_enabled %>
+              function track() { analytics.track(); }
+            <% end %>
+          ]]>
+        </script>
+      </document>
+    ` + '\n'
+
+    const result = linter.lint(source, { fileName: "document.xml.erb" })
+    expect(result.offenses).toEqual(expect.any(Array))
+  })
+
+  test("should handle self-closing XML tags appropriately", () => {
+    const source = dedent`
+      <?xml version="1.0" encoding="UTF-8"?>
+      <manifest>
+        <uses-permission android:name="CAMERA" />
+        <uses-feature android:name="camera" android:required="true" />
+      </manifest>
+    ` + '\n'
+
+    const result = linter.lint(source, { fileName: "manifest.xml.erb" })
+
+    const selfClosingErrors = result.offenses.filter(offense =>
+      offense.code === "html-no-self-closing"
+    )
+
+    expect(selfClosingErrors.length).toBeGreaterThanOrEqual(0)
+  })
+
+  test("should lint Android manifest XML ERB", () => {
+    const source = dedent`
+      <?xml version="1.0" encoding="UTF-8"?>
+      <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+        <application android:name="MainActivity">
+          <% @permissions.each do |permission| %>
+            <uses-permission android:name="<%= permission %>" />
+          <% end %>
+          <% @features.each do |feature| %>
+            <uses-feature
+              android:name="<%= feature.name %>"
+              android:required="<%= feature.required %>" />
+          <% end %>
+        </application>
+      </manifest>
+    ` + '\n'
+
+    const result = linter.lint(source, { fileName: "AndroidManifest.xml.erb" })
+    expect(result.offenses).toEqual(expect.any(Array))
+
+    const parserErrors = result.offenses.filter(offense => offense.code === "parser-no-errors")
+    expect(parserErrors).toHaveLength(0)
+  })
+
+  test("should lint RSS feed XML ERB", () => {
+    const source = dedent`
+      <?xml version="1.0" encoding="UTF-8"?>
+      <rss version="2.0">
+        <channel>
+          <title><%= @feed_title %></title>
+          <link><%= @site_url %></link>
+          <description><%= @feed_description %></description>
+          <language><%= @language || 'en-us' %></language>
+          <lastBuildDate><%= @last_updated.rfc822 %></lastBuildDate>
+
+          <% @articles.each do |article| %>
+            <item>
+              <title><%= article.title %></title>
+              <link><%= article_url(article) %></link>
+              <guid><%= article_url(article) %></guid>
+              <pubDate><%= article.published_at.rfc822 %></pubDate>
+              <description><![CDATA[<%= article.summary %>]]></description>
+            </item>
+          <% end %>
+        </channel>
+      </rss>
+    ` + '\n'
+
+    const result = linter.lint(source, { fileName: "feed.xml.erb" })
+    expect(result.offenses).toEqual(expect.any(Array))
+
+    const parserErrors = result.offenses.filter(offense => offense.code === "parser-no-errors")
+    expect(parserErrors.length).toBeGreaterThanOrEqual(0)
+  })
+
+  test("should handle XML sitemap ERB", () => {
+    const source = dedent`
+      <?xml version="1.0" encoding="UTF-8"?>
+      <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+        <% @pages.each do |page| %>
+          <url>
+            <loc><%= page.canonical_url %></loc>
+            <lastmod><%= page.updated_at.iso8601 %></lastmod>
+            <changefreq><%= page.change_frequency %></changefreq>
+            <priority><%= page.priority %></priority>
+          </url>
+        <% end %>
+      </urlset>
+    ` + '\n'
+
+    const result = linter.lint(source, { fileName: "sitemap.xml.erb" })
+    expect(result.offenses).toEqual(expect.any(Array))
+
+    const parserErrors = result.offenses.filter(offense => offense.code === "parser-no-errors")
+    expect(parserErrors).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
This pull request updates the CLIs of both the formatter and linter to work the same way when passing passed arguments, especially in the way they handle files, paths, globs, or no arguments.


```bash
herb-lint                      # => "./**.html.erb"
herb-lint template.html.erb    # => "template.html.erb"
herb-lint app/                 # => "app/**.html.erb"
herb-lint "app/**.html.erb"    # => "app/**.html.erb"

herb-format                    # => "./**.html.erb"
herb-format template.html.erb  # => "template.html.erb"
herb-format app/               # => "app/**.html.erb"
herb-format "app/**.html.erb"  # => "app/**.html.erb"
```
