### PR TITLE
CLI: `playground` command should open herb-tools.dev by default

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -93,8 +93,9 @@ Metrics/ParameterLists:
 
 Metrics/PerceivedComplexity:
   Exclude:
-    - lib/herb/project.rb
     - lib/herb/ast/nodes.rb
+    - lib/herb/cli.rb
+    - lib/herb/project.rb
     - test/snapshot_utils.rb
 
 Layout/LineLength:


### PR DESCRIPTION
This pull request updates the Ruby CLI so that the `playground` command uses the playground hosted on herb-tools.dev by default. It also adds a `--local` option to be able to open a file in the local playground.