### PR TITLE
Add `.envrc` file

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,5 @@
+export PATH="$PWD/javascript/packages/linter/bin:$PATH"
+export PATH="$PWD/javascript/packages/printer/bin:$PATH"
+export PATH="$PWD/javascript/packages/formatter/bin:$PATH"
+export PATH="$PWD/javascript/packages/language-server/bin:$PATH"
+export PATH="$PWD/javascript/packages/highlighter/bin:$PATH"


### PR DESCRIPTION
This pull request adds an `.envrc` file so that the `herb-lint`, `herb-formatter`, `herb-print`, `herb-highlight` and `herb-language-server` are available in the `PATH` within the `herb/` folder.