### PR TITLE
Printer: Introduce `ERBToRubyStringPrinter` to convert ERB to Ruby

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -222,7 +222,6 @@ nodes:
         - name: tag_closing
           type: token
 
-
     - name: HTMLElementNode
       fields:
         - name: open_tag
@@ -262,7 +261,11 @@ nodes:
       fields:
         - name: children
           type: array
-          kind: Node # LiteralNode or ERBContentNode
+          kind: Node
+          # kind:
+          #   - LiteralNode
+          #   - ERBContentNode
+          #   - WhitespaceNode
 
     - name: HTMLAttributeNode
       fields:
@@ -401,7 +404,10 @@ nodes:
 
         - name: subsequent
           type: node
-          #kind: ERBIfNode # or ERBElseNode
+          kind: Node
+          # kind:
+          #   - ERBIfNode
+          #   - ERBElseNode
 
         - name: end_node
           type: node

--- a/javascript/packages/formatter/src/format-printer.ts
+++ b/javascript/packages/formatter/src/format-printer.ts
@@ -490,21 +490,16 @@ export class FormatPrinter extends Printer {
   }
 
   private getAttributeValue(attribute: HTMLAttributeNode): string {
-    if (attribute.value && isNode(attribute.value, HTMLAttributeValueNode)) {
-      const content = attribute.value.children.map(child => {
-        if (isNode(child, HTMLTextNode)) {
-          return child.content
-        }
-        return IdentityPrinter.print(child)
-      }).join('')
-      return content
+    if (isNode(attribute.value, HTMLAttributeValueNode)) {
+      return attribute.value.children.map(child => isNode(child, HTMLTextNode) ? child.content : IdentityPrinter.print(child)).join('')
     }
+
     return ''
   }
 
   private hasMultilineAttributes(attributes: HTMLAttributeNode[]): boolean {
     return attributes.some(attribute => {
-      if (attribute.value && isNode(attribute.value, HTMLAttributeValueNode)) {
+      if (isNode(attribute.value, HTMLAttributeValueNode)) {
         const content = getCombinedStringFromNodes(attribute.value.children)
 
         if (/\r?\n/.test(content)) {
@@ -1523,7 +1518,7 @@ export class FormatPrinter extends Printer {
 
     let value = ""
 
-    if (attribute.value && isNode(attribute.value, HTMLAttributeValueNode)) {
+    if (isNode(attribute.value, HTMLAttributeValueNode)) {
       const attributeValue = attribute.value
 
       let open_quote = attributeValue.open_quote?.value ?? ""

--- a/javascript/packages/linter/package.json
+++ b/javascript/packages/linter/package.json
@@ -36,6 +36,7 @@
     "@herb-tools/core": "0.6.0",
     "@herb-tools/highlighter": "0.6.0",
     "@herb-tools/node-wasm": "0.6.0",
+    "@herb-tools/printer": "0.6.0",
     "glob": "^11.0.3"
   },
   "files": [

--- a/javascript/packages/linter/test/rules/erb-prefer-image-tag-helper.test.ts
+++ b/javascript/packages/linter/test/rules/erb-prefer-image-tag-helper.test.ts
@@ -11,7 +11,7 @@ describe("erb-prefer-image-tag-helper", () => {
 
   test("passes for regular img tags without ERB", () => {
     const html = '<img src="/logo.png" alt="Company logo">'
-    
+
     const linter = new Linter(Herb, [ERBPreferImageTagHelperRule])
     const lintResult = linter.lint(html)
 
@@ -22,7 +22,7 @@ describe("erb-prefer-image-tag-helper", () => {
 
   test("passes for image_tag helper usage", () => {
     const html = '<%= image_tag "logo.png", alt: "Company logo", class: "logo" %>'
-    
+
     const linter = new Linter(Herb, [ERBPreferImageTagHelperRule])
     const lintResult = linter.lint(html)
 
@@ -33,7 +33,7 @@ describe("erb-prefer-image-tag-helper", () => {
 
   test("fails for img with image_path helper", () => {
     const html = '<img src="<%= image_path("logo.png") %>" alt="Logo">'
-    
+
     const linter = new Linter(Herb, [ERBPreferImageTagHelperRule])
     const lintResult = linter.lint(html)
 
@@ -48,7 +48,7 @@ describe("erb-prefer-image-tag-helper", () => {
 
   test("fails for img with asset_path helper", () => {
     const html = '<img src="<%= asset_path("banner.jpg") %>" alt="Banner">'
-    
+
     const linter = new Linter(Herb, [ERBPreferImageTagHelperRule])
     const lintResult = linter.lint(html)
 
@@ -63,7 +63,7 @@ describe("erb-prefer-image-tag-helper", () => {
 
   test("handles self-closing img tags with image_path", () => {
     const html = '<img src="<%= image_path("logo.png") %>" alt="Logo" />'
-    
+
     const linter = new Linter(Herb, [ERBPreferImageTagHelperRule])
     const lintResult = linter.lint(html)
 
@@ -77,7 +77,7 @@ describe("erb-prefer-image-tag-helper", () => {
 
   test("ignores non-img tags with image_path", () => {
     const html = '<div data-background="<%= image_path("bg.jpg") %>">Content</div>'
-    
+
     const linter = new Linter(Herb, [ERBPreferImageTagHelperRule])
     const lintResult = linter.lint(html)
 
@@ -88,7 +88,7 @@ describe("erb-prefer-image-tag-helper", () => {
 
   test("fails for img with Rails URL helpers", () => {
     const html = '<img src="<%= Rails.application.routes.url_helpers.root_url %>/icon.png" alt="Logo">'
-    
+
     const linter = new Linter(Herb, [ERBPreferImageTagHelperRule])
     const lintResult = linter.lint(html)
 
@@ -103,7 +103,7 @@ describe("erb-prefer-image-tag-helper", () => {
 
   test("fails for img with root_url helper", () => {
     const html = '<img src="<%= root_url %>/banner.jpg" alt="Banner">'
-    
+
     const linter = new Linter(Herb, [ERBPreferImageTagHelperRule])
     const lintResult = linter.lint(html)
 
@@ -118,7 +118,7 @@ describe("erb-prefer-image-tag-helper", () => {
 
   test("fails for img with custom path helpers", () => {
     const html = '<img src="<%= admin_path %>/icon.png" alt="Admin icon">'
-    
+
     const linter = new Linter(Herb, [ERBPreferImageTagHelperRule])
     const lintResult = linter.lint(html)
 
@@ -133,7 +133,7 @@ describe("erb-prefer-image-tag-helper", () => {
 
   test("fails for img with dynamic user avatar URL", () => {
     const html = '<img src="<%= user.avatar.url %>" alt="User avatar">'
-    
+
     const linter = new Linter(Herb, [ERBPreferImageTagHelperRule])
     const lintResult = linter.lint(html)
 
@@ -148,7 +148,7 @@ describe("erb-prefer-image-tag-helper", () => {
 
   test("fails for img with dynamic product image", () => {
     const html = '<img src="<%= product.image %>" alt="Product image">'
-    
+
     const linter = new Linter(Herb, [ERBPreferImageTagHelperRule])
     const lintResult = linter.lint(html)
 
@@ -163,7 +163,7 @@ describe("erb-prefer-image-tag-helper", () => {
 
   test("fails for img with any ERB expression", () => {
     const html = '<img src="<%= @company.logo_path %>" alt="Company logo">'
-    
+
     const linter = new Linter(Herb, [ERBPreferImageTagHelperRule])
     const lintResult = linter.lint(html)
 
@@ -178,7 +178,7 @@ describe("erb-prefer-image-tag-helper", () => {
 
   test("fails for img with multiple ERB expressions", () => {
     const html = '<img src="<%= base_url %><%= image_path("logo.png") %>" alt="Logo">'
-    
+
     const linter = new Linter(Herb, [ERBPreferImageTagHelperRule])
     const lintResult = linter.lint(html)
 
@@ -193,7 +193,7 @@ describe("erb-prefer-image-tag-helper", () => {
 
   test("fails for img with ERB expression containing string literal", () => {
     const html = '<img src="<%= root_path %><%= "icon.png" %>" alt="Icon">'
-    
+
     const linter = new Linter(Herb, [ERBPreferImageTagHelperRule])
     const lintResult = linter.lint(html)
 
@@ -208,7 +208,7 @@ describe("erb-prefer-image-tag-helper", () => {
 
   test("fails for img with ERB expression containing string literal followed by another ERB tag", () => {
     const html = '<img src="<%= root_path %>/assets/<%= "icon.png" %>" alt="Icon">'
-    
+
     const linter = new Linter(Herb, [ERBPreferImageTagHelperRule])
     const lintResult = linter.lint(html)
 
@@ -223,7 +223,7 @@ describe("erb-prefer-image-tag-helper", () => {
 
   test("shouldn't flag empty src attribute", () => {
     const html = '<img src="" alt="Empty"><img src="    " alt="Empty">'
-    
+
     const linter = new Linter(Herb, [ERBPreferImageTagHelperRule])
     const lintResult = linter.lint(html)
 
@@ -240,7 +240,84 @@ describe("erb-prefer-image-tag-helper", () => {
         <img src="logo.png" alt="Relative path">
       </div>
     `
-    
+
+    const linter = new Linter(Herb, [ERBPreferImageTagHelperRule])
+    const lintResult = linter.lint(html)
+
+    expect(lintResult.errors).toBe(0)
+    expect(lintResult.warnings).toBe(0)
+    expect(lintResult.offenses).toHaveLength(0)
+  })
+
+  test("passes for data URIs with embedded ERB content", () => {
+    const html = '<img src="data:image/png;base64,<%= base64_encoded_logo_image %>" alt="Logo">'
+
+    const linter = new Linter(Herb, [ERBPreferImageTagHelperRule])
+    const lintResult = linter.lint(html)
+
+    expect(lintResult.errors).toBe(0)
+    expect(lintResult.warnings).toBe(0)
+    expect(lintResult.offenses).toHaveLength(0)
+  })
+
+  test("passes for mixed static and ERB content in src", () => {
+    const html = '<img src="https://example.com/<%= user.id %>/avatar.png" alt="User avatar">'
+
+    const linter = new Linter(Herb, [ERBPreferImageTagHelperRule])
+    const lintResult = linter.lint(html)
+
+    expect(lintResult.errors).toBe(0)
+    expect(lintResult.warnings).toBe(0)
+    expect(lintResult.offenses).toHaveLength(0)
+  })
+
+  test("passes for data URI with SVG and embedded ERB", () => {
+    const html = '<img src="data:image/svg+xml,<svg><text><%= user_name %></text></svg>" alt="SVG">'
+
+    const linter = new Linter(Herb, [ERBPreferImageTagHelperRule])
+    const lintResult = linter.lint(html)
+
+    expect(lintResult.errors).toBe(0)
+    expect(lintResult.warnings).toBe(0)
+    expect(lintResult.offenses).toHaveLength(0)
+  })
+
+  test("passes for data URI with PNG", () => {
+    const html = '<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO2W2n8AAAAASUVORK5CYII=" alt="1x1 transparent image">'
+
+    const linter = new Linter(Herb, [ERBPreferImageTagHelperRule])
+    const lintResult = linter.lint(html)
+
+    expect(lintResult.errors).toBe(0)
+    expect(lintResult.warnings).toBe(0)
+    expect(lintResult.offenses).toHaveLength(0)
+  })
+
+  test("passes for data URI with PNG with ERB", () => {
+    const html = '<img src="data:image/png;base64,<%= File.read("image.png").to_base64 %>" alt="1x1 transparent image">'
+
+    const linter = new Linter(Herb, [ERBPreferImageTagHelperRule])
+    const lintResult = linter.lint(html)
+
+    expect(lintResult.errors).toBe(0)
+    expect(lintResult.warnings).toBe(0)
+    expect(lintResult.offenses).toHaveLength(0)
+  })
+
+  test("passes for img with only https URL", () => {
+    const html = '<img src="https://example.com/image.jpg" alt="External image">'
+
+    const linter = new Linter(Herb, [ERBPreferImageTagHelperRule])
+    const lintResult = linter.lint(html)
+
+    expect(lintResult.errors).toBe(0)
+    expect(lintResult.warnings).toBe(0)
+    expect(lintResult.offenses).toHaveLength(0)
+  })
+
+  test("passes for img with only http URL", () => {
+    const html = '<img src="http://example.com/image.jpg" alt="External image">'
+
     const linter = new Linter(Herb, [ERBPreferImageTagHelperRule])
     const lintResult = linter.lint(html)
 

--- a/javascript/packages/printer/src/erb-to-ruby-string-printer.ts
+++ b/javascript/packages/printer/src/erb-to-ruby-string-printer.ts
@@ -1,0 +1,309 @@
+import { IdentityPrinter } from "./identity-printer.js"
+import { PrintOptions, DEFAULT_PRINT_OPTIONS } from "./printer.js"
+import { isERBOutputNode, filterNodes, ERBContentNode, } from "@herb-tools/core"
+
+import { HTMLTextNode, ERBIfNode, ERBElseNode, ERBUnlessNode, Node, HTMLAttributeValueNode } from "@herb-tools/core"
+
+export interface ERBToRubyStringOptions extends PrintOptions {
+  /**
+   * Whether to force wrapping the output in double quotes even for single ERB nodes
+   * @default false
+   */
+  forceQuotes?: boolean
+}
+
+export const DEFAULT_ERB_TO_RUBY_STRING_OPTIONS: ERBToRubyStringOptions = {
+  ...DEFAULT_PRINT_OPTIONS,
+  forceQuotes: false
+}
+
+/**
+ * ERBToRubyStringPrinter - Converts ERB snippets to Ruby strings with interpolation
+ *
+ * This printer transforms ERB templates into Ruby strings by:
+ * - Converting literal text to string content
+ * - Converting <%= %> tags to #{} interpolation
+ * - Converting simple if/else blocks to ternary operators
+ * - Ignoring <% %> tags (they don't produce output)
+ *
+ * Examples:
+ * - `hello world <%= hello %>` => `"hello world #{hello}"`
+ * - `hello world <% hello %>` => `"hello world "`
+ * - `Welcome <%= user.name %>!` => `"Welcome #{user.name}!"`
+ * - `<% if logged_in? %>Welcome<% else %>Login<% end %>` => `"logged_in? ? "Welcome" : "Login"`
+ * - `<% if logged_in? %>Welcome<% else %>Login<% end %>!` => `"#{logged_in? ? "Welcome" : "Login"}!"`
+ */
+export class ERBToRubyStringPrinter extends IdentityPrinter {
+
+  // TODO: cleanup `.type === "AST_*" checks`
+  static print(node: Node, options: Partial<ERBToRubyStringOptions> = DEFAULT_ERB_TO_RUBY_STRING_OPTIONS): string {
+    const erbNodes = filterNodes([node], ERBContentNode)
+
+    if (erbNodes.length === 1 && isERBOutputNode(erbNodes[0]) && !options.forceQuotes) {
+      return (erbNodes[0].content?.value || "").trim()
+    }
+
+    if ('children' in node && Array.isArray(node.children)) {
+      const childErbNodes = filterNodes(node.children, ERBContentNode)
+      const hasOnlyERBContent = node.children.length > 0 && node.children.length === childErbNodes.length
+
+      if (hasOnlyERBContent && childErbNodes.length === 1 && isERBOutputNode(childErbNodes[0]) && !options.forceQuotes) {
+        return (childErbNodes[0].content?.value || "").trim()
+      }
+
+      if (node.children.length === 1 && node.children[0].type === "AST_ERB_IF_NODE" && !options.forceQuotes) {
+        const ifNode = node.children[0] as ERBIfNode
+        const printer = new ERBToRubyStringPrinter()
+
+        if (printer.canConvertToTernary(ifNode)) {
+          printer.convertToTernaryWithoutWrapper(ifNode)
+          return printer.context.getOutput()
+        }
+      }
+
+      if (node.children.length === 1 && node.children[0].type === "AST_ERB_UNLESS_NODE" && !options.forceQuotes) {
+        const unlessNode = node.children[0] as ERBUnlessNode
+        const printer = new ERBToRubyStringPrinter()
+
+        if (printer.canConvertUnlessToTernary(unlessNode)) {
+          printer.convertUnlessToTernaryWithoutWrapper(unlessNode)
+          return printer.context.getOutput()
+        }
+      }
+    }
+
+    const printer = new ERBToRubyStringPrinter()
+
+    printer.context.write('"')
+
+    printer.visit(node)
+
+    printer.context.write('"')
+
+    return printer.context.getOutput()
+  }
+
+  visitHTMLTextNode(node: HTMLTextNode) {
+    if (node.content) {
+      const escapedContent = node.content.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
+      this.context.write(escapedContent)
+    }
+  }
+
+  visitERBContentNode(node: ERBContentNode) {
+    if (isERBOutputNode(node)) {
+      this.context.write("#{")
+
+      if (node.content?.value) {
+        this.context.write(node.content.value.trim())
+      }
+
+      this.context.write("}")
+    }
+  }
+
+  visitERBIfNode(node: ERBIfNode) {
+    if (this.canConvertToTernary(node)) {
+      this.convertToTernary(node)
+    }
+  }
+
+  visitERBUnlessNode(node: ERBUnlessNode) {
+    if (this.canConvertUnlessToTernary(node)) {
+      this.convertUnlessToTernary(node)
+    }
+  }
+
+  visitHTMLAttributeValueNode(node: HTMLAttributeValueNode) {
+    this.visitChildNodes(node)
+  }
+
+  private canConvertToTernary(node: ERBIfNode): boolean {
+    if (node.subsequent && node.subsequent.type !== "AST_ERB_ELSE_NODE") {
+      return false
+    }
+
+    const ifOnlyText = node.statements ? node.statements.every(statement => statement.type === "AST_HTML_TEXT_NODE") : true
+    if (!ifOnlyText) return false
+
+    if (node.subsequent && node.subsequent.type === "AST_ERB_ELSE_NODE") {
+      return (node.subsequent as ERBElseNode).statements
+        ? (node.subsequent as ERBElseNode).statements.every(statement => statement.type === "AST_HTML_TEXT_NODE")
+        : true
+    }
+
+    return true
+  }
+
+  private convertToTernary(node: ERBIfNode) {
+    this.context.write("#{")
+
+    if (node.content?.value) {
+      const condition = node.content.value.trim()
+      const cleanCondition = condition.replace(/^if\s+/, '')
+      const needsParentheses = cleanCondition.includes(' ')
+
+      if (needsParentheses) {
+        this.context.write("(")
+      }
+
+      this.context.write(cleanCondition)
+
+      if (needsParentheses) {
+        this.context.write(")")
+      }
+    }
+
+    this.context.write(" ? ")
+    this.context.write('"')
+
+    if (node.statements) {
+      node.statements.forEach(statement => this.visit(statement))
+    }
+
+    this.context.write('"')
+    this.context.write(" : ")
+    this.context.write('"')
+
+    if (node.subsequent && node.subsequent.type === "AST_ERB_ELSE_NODE" && (node.subsequent as ERBElseNode).statements) {
+      (node.subsequent as ERBElseNode).statements.forEach(statement => this.visit(statement))
+    }
+
+    this.context.write('"')
+    this.context.write("}")
+  }
+
+  private convertToTernaryWithoutWrapper(node: ERBIfNode) {
+    if (node.subsequent && node.subsequent.type !== "AST_ERB_ELSE_NODE") {
+      return false
+    }
+
+    if (node.content?.value) {
+      const condition = node.content.value.trim()
+      const cleanCondition = condition.replace(/^if\s+/, '')
+      const needsParentheses = cleanCondition.includes(' ')
+
+      if (needsParentheses) {
+        this.context.write("(")
+      }
+
+      this.context.write(cleanCondition)
+
+      if (needsParentheses) {
+        this.context.write(")")
+      }
+    }
+
+    this.context.write(" ? ")
+    this.context.write('"')
+
+    if (node.statements) {
+      node.statements.forEach(statement => this.visit(statement))
+    }
+
+    this.context.write('"')
+    this.context.write(" : ")
+    this.context.write('"')
+
+    if (node.subsequent && node.subsequent.type === "AST_ERB_ELSE_NODE" && (node.subsequent as ERBElseNode).statements) {
+      (node.subsequent as ERBElseNode).statements.forEach(statement => this.visit(statement))
+    }
+
+    this.context.write('"')
+  }
+
+  private canConvertUnlessToTernary(node: ERBUnlessNode): boolean {
+    const unlessOnlyText = node.statements ? node.statements.every(statement => statement.type === "AST_HTML_TEXT_NODE") : true
+
+    if (!unlessOnlyText) return false
+
+    if (node.else_clause && node.else_clause.type === "AST_ERB_ELSE_NODE") {
+      return node.else_clause.statements
+        ? node.else_clause.statements.every(statement => statement.type === "AST_HTML_TEXT_NODE")
+        : true
+    }
+
+    return true
+  }
+
+  private convertUnlessToTernary(node: ERBUnlessNode) {
+    this.context.write("#{")
+
+    if (node.content?.value) {
+      const condition = node.content.value.trim()
+      const cleanCondition = condition.replace(/^unless\s+/, '')
+      const needsParentheses = cleanCondition.includes(' ')
+
+      this.context.write("!(")
+
+      if (needsParentheses) {
+        this.context.write("(")
+      }
+
+      this.context.write(cleanCondition)
+
+      if (needsParentheses) {
+        this.context.write(")")
+      }
+
+      this.context.write(")")
+    }
+
+    this.context.write(" ? ")
+    this.context.write('"')
+
+    if (node.statements) {
+      node.statements.forEach(statement => this.visit(statement))
+    }
+
+    this.context.write('"')
+    this.context.write(" : ")
+    this.context.write('"')
+
+    if (node.else_clause && node.else_clause.type === "AST_ERB_ELSE_NODE") {
+      node.else_clause.statements.forEach(statement => this.visit(statement))
+    }
+
+    this.context.write('"')
+    this.context.write("}")
+  }
+
+  private convertUnlessToTernaryWithoutWrapper(node: ERBUnlessNode) {
+    if (node.content?.value) {
+      const condition = node.content.value.trim()
+      const cleanCondition = condition.replace(/^unless\s+/, '')
+      const needsParentheses = cleanCondition.includes(' ')
+
+      this.context.write("!(")
+
+      if (needsParentheses) {
+        this.context.write("(")
+      }
+
+      this.context.write(cleanCondition)
+
+      if (needsParentheses) {
+        this.context.write(")")
+      }
+
+      this.context.write(")")
+    }
+
+    this.context.write(" ? ")
+    this.context.write('"')
+
+    if (node.statements) {
+      node.statements.forEach(statement => this.visit(statement))
+    }
+
+    this.context.write('"')
+    this.context.write(" : ")
+    this.context.write('"')
+
+    if (node.else_clause && node.else_clause.type === "AST_ERB_ELSE_NODE") {
+      node.else_clause.statements.forEach(statement => this.visit(statement))
+    }
+
+    this.context.write('"')
+  }
+}

--- a/javascript/packages/printer/src/index.ts
+++ b/javascript/packages/printer/src/index.ts
@@ -1,4 +1,5 @@
 export { IdentityPrinter } from "./identity-printer.js"
+export { ERBToRubyStringPrinter } from "./erb-to-ruby-string-printer.js"
 export { PrintContext } from "./print-context.js"
 export { Printer, DEFAULT_PRINT_OPTIONS } from "./printer.js"
 export type { PrintOptions } from "./printer.js"

--- a/javascript/packages/printer/test/erb-to-ruby-string-printer.test.ts
+++ b/javascript/packages/printer/test/erb-to-ruby-string-printer.test.ts
@@ -1,0 +1,262 @@
+import { describe, test, expect, beforeAll } from "vitest"
+import { Herb } from "@herb-tools/node-wasm"
+import { ERBToRubyStringPrinter } from "../src/erb-to-ruby-string-printer.js"
+
+describe("ERBToRubyStringPrinter", () => {
+  beforeAll(async () => {
+    await Herb.load()
+  })
+
+  test("converts simple text to Ruby string", () => {
+    const erb = `hello world`
+    const parseResult = Herb.parse(erb)
+    const result = ERBToRubyStringPrinter.print(parseResult.value)
+
+    expect(result).toBe(`"hello world"`)
+  })
+
+  test("converts single ERB output tag to raw Ruby code", () => {
+    const erb = `<%= hello %>`
+    const parseResult = Herb.parse(erb)
+    const result = ERBToRubyStringPrinter.print(parseResult.value)
+
+    expect(result).toBe(`hello`)
+  })
+
+  test("converts single ERB silent tag", () => {
+    const erb = `<% hello %>`
+    const parseResult = Herb.parse(erb)
+    const result = ERBToRubyStringPrinter.print(parseResult.value)
+
+    expect(result).toBe(`""`)
+  })
+
+  test("converts ERB output tag to interpolation", () => {
+    const erb = `hello world <%= hello %>`
+    const parseResult = Herb.parse(erb)
+    const result = ERBToRubyStringPrinter.print(parseResult.value)
+
+    expect(result).toBe(`"hello world #{hello}"`)
+  })
+
+  test("converts simple if/else to ternary without quotes", () => {
+    const erb = `<% if true %> hello <% else %> world <% end %>`
+    const parseResult = Herb.parse(erb)
+    const result = ERBToRubyStringPrinter.print(parseResult.value)
+
+    expect(result).toBe(`true ? " hello " : " world "`)
+  })
+
+  test("ignores ERB silent tags", () => {
+    const erb = `hello world <% hello %>`
+    const parseResult = Herb.parse(erb)
+    const result = ERBToRubyStringPrinter.print(parseResult.value)
+
+    expect(result).toBe(`"hello world "`)
+  })
+
+  test("handles mixed ERB output and silent tags", () => {
+    const erb = `Welcome <%= user.name %><% puts "debug" %>!`
+    const parseResult = Herb.parse(erb)
+    const result = ERBToRubyStringPrinter.print(parseResult.value)
+
+    expect(result).toBe(`"Welcome #{user.name}!"`)
+  })
+
+  test("handles multiple ERB output tags", () => {
+    const erb = `Hello <%= first_name %> <%= last_name %>`
+    const parseResult = Herb.parse(erb)
+    const result = ERBToRubyStringPrinter.print(parseResult.value)
+
+    expect(result).toBe(`"Hello #{first_name} #{last_name}"`)
+  })
+
+  test("handles complex ERB expressions", () => {
+    const erb = `Price: $<%= product.price.round(2) %>`
+    const parseResult = Herb.parse(erb)
+    const result = ERBToRubyStringPrinter.print(parseResult.value)
+
+    expect(result).toBe(`"Price: $#{product.price.round(2)}"`)
+  })
+
+  test("handles ERB with HTML", () => {
+    const erb = `<p>Welcome <%= user.name %>!</p>`
+    const parseResult = Herb.parse(erb)
+    const result = ERBToRubyStringPrinter.print(parseResult.value)
+
+    expect(result).toBe(`"<p>Welcome #{user.name}!</p>"`)
+  })
+
+  test("handles empty ERB tags", () => {
+    const erb = `text <%= %> more text`
+    const parseResult = Herb.parse(erb)
+    const result = ERBToRubyStringPrinter.print(parseResult.value)
+
+    expect(result).toBe(`"text #{} more text"`)
+  })
+
+  test("handles ERB with special characters", () => {
+    const erb = `Quote: "<%= message %>"`
+    const parseResult = Herb.parse(erb)
+    const result = ERBToRubyStringPrinter.print(parseResult.value)
+
+    expect(result).toBe(`"Quote: \\"#{message}\\""`)
+  })
+
+  test("handles only ERB output tag", () => {
+    const erb = `<%= user.name %>`
+    const parseResult = Herb.parse(erb)
+    const result = ERBToRubyStringPrinter.print(parseResult.value)
+
+    expect(result).toBe(`user.name`)
+  })
+
+  test("handles only ERB silent tag", () => {
+    const erb = `<% puts "hello" %>`
+    const parseResult = Herb.parse(erb)
+    const result = ERBToRubyStringPrinter.print(parseResult.value)
+
+    expect(result).toBe(`""`)
+  })
+
+  test("handles ERB with whitespace", () => {
+    const erb = `Start <%= value %> End`
+    const parseResult = Herb.parse(erb)
+    const result = ERBToRubyStringPrinter.print(parseResult.value)
+
+    expect(result).toBe(`"Start #{value} End"`)
+  })
+
+  test("converts simple if/else to ternary operator", () => {
+    const erb = `<% if user.logged_in? %>Welcome<% else %>Please login<% end %>`
+    const parseResult = Herb.parse(erb)
+    const result = ERBToRubyStringPrinter.print(parseResult.value)
+
+    expect(result).toBe(`user.logged_in? ? \"Welcome\" : \"Please login\"`)
+  })
+
+  test("converts if/else with mixed content to ternary", () => {
+    const erb = `Hello <% if premium? %>Premium User<% else %>Guest<% end %>!`
+    const parseResult = Herb.parse(erb)
+    const result = ERBToRubyStringPrinter.print(parseResult.value)
+
+    expect(result).toBe(`"Hello #{premium? ? \"Premium User\" : \"Guest\"}!"`)
+  })
+
+  test("ignores if without else", () => {
+    const erb = `<% if admin? %>Admin Panel<% end %>`
+    const parseResult = Herb.parse(erb)
+    const result = ERBToRubyStringPrinter.print(parseResult.value)
+
+    expect(result).toBe(`admin? ? "Admin Panel" : ""`)
+  })
+
+  test("handles if/else with special characters", () => {
+    const erb = `<% if active? %>Status: "active"<% else %>Status: "inactive"<% end %>`
+    const parseResult = Herb.parse(erb)
+    const result = ERBToRubyStringPrinter.print(parseResult.value)
+
+    expect(result).toBe(`active? ? \"Status: \\\"active\\\"\" : \"Status: \\\"inactive\\\"\"`)
+  })
+
+  test("handles empty if/else branches", () => {
+    const erb = `<% if condition? %><% else %>Empty<% end %>`
+    const parseResult = Herb.parse(erb)
+    const result = ERBToRubyStringPrinter.print(parseResult.value)
+
+    expect(result).toBe(`condition? ? \"\" : \"Empty\"`)
+  })
+
+  test("adds parentheses for complex conditions with spaces", () => {
+    const erb = `<% if user && user.active? %>Active<% else %>Inactive<% end %>`
+    const parseResult = Herb.parse(erb)
+    const result = ERBToRubyStringPrinter.print(parseResult.value)
+
+    expect(result).toBe(`(user && user.active?) ? \"Active\" : \"Inactive\"`)
+  })
+
+  test("adds parentheses for complex conditions with spaces", () => {
+    const erb = `<% if user && user.active? %>Active<% else %>Inactive<% end %>`
+    const parseResult = Herb.parse(erb)
+    const result = ERBToRubyStringPrinter.print(parseResult.value, { forceQuotes: true})
+
+    expect(result).toBe(`"#{(user && user.active?) ? \"Active\" : \"Inactive\"}"`)
+  })
+
+  test("no parentheses for simple method calls", () => {
+    const erb = `<% if logged_in? %>Welcome<% else %>Login<% end %>`
+    const parseResult = Herb.parse(erb)
+    const result = ERBToRubyStringPrinter.print(parseResult.value)
+
+    expect(result).toBe(`logged_in? ? \"Welcome\" : \"Login\"`)
+  })
+
+  test("no parentheses for simple method calls with force", () => {
+    const erb = `<% if logged_in? %>Welcome<% else %>Login<% end %>`
+    const parseResult = Herb.parse(erb)
+    const result = ERBToRubyStringPrinter.print(parseResult.value, { forceQuotes: true})
+
+    expect(result).toBe(`"#{logged_in? ? \"Welcome\" : \"Login\"}"`)
+  })
+
+  test("does not convert if/elsif/else to ternary", () => {
+    const erb = `<% if admin? %>Admin<% elsif user? %>User<% else %>Guest<% end %>`
+    const parseResult = Herb.parse(erb)
+    const result = ERBToRubyStringPrinter.print(parseResult.value)
+
+    expect(result).toBe(`""`)
+  })
+
+  test("erb, static, erb with string", () => {
+    const erb = `<%= root_path %>/assets/<%= "icon.png" %>`
+    const parseResult = Herb.parse(erb)
+    const result = ERBToRubyStringPrinter.print(parseResult.value)
+
+    expect(result).toBe(`"#{root_path}/assets/#{"icon.png"}"`)
+  })
+
+  test("handles HTML attribute value node without double quotes", () => {
+    const erb = `<img src="<%= root_url %>/banner.jpg" />`
+    const parseResult = Herb.parse(erb)
+
+    const imgElement = parseResult.value.children[0]
+    const srcAttr = imgElement.open_tag.children.find(child =>
+      child.type === "AST_HTML_ATTRIBUTE_NODE"
+    )
+
+    const result = ERBToRubyStringPrinter.print(srcAttr.value)
+    expect(result).toBe(`"#{root_url}/banner.jpg"`)
+  })
+
+  test("converts simple unless to ternary without quotes", () => {
+    const erb = `<% unless logged_in? %>Please login<% end %>`
+    const parseResult = Herb.parse(erb)
+    const result = ERBToRubyStringPrinter.print(parseResult.value)
+
+    expect(result).toBe(`!(logged_in?) ? "Please login" : ""`)
+  })
+
+  test("converts unless without else to ternary", () => {
+    const erb = `<% unless admin? %>Restricted Access<% end %>`
+    const parseResult = Herb.parse(erb)
+    const result = ERBToRubyStringPrinter.print(parseResult.value)
+
+    expect(result).toBe(`!(admin?) ? "Restricted Access" : ""`)
+  })
+
+  test("converts unless with mixed content to ternary", () => {
+    const erb = `Status: <% unless active? %>Inactive<% end %>`
+    const parseResult = Herb.parse(erb)
+    const result = ERBToRubyStringPrinter.print(parseResult.value)
+
+    expect(result).toBe(`"Status: #{!(active?) ? "Inactive" : ""}"`)
+  })
+
+  test("adds parentheses for complex unless conditions", () => {
+    const erb = `<% unless user && user.active? %>Please activate<% end %>`
+    const parseResult = Herb.parse(erb)
+    const result = ERBToRubyStringPrinter.print(parseResult.value)
+
+    expect(result).toBe(`!((user && user.active?)) ? "Please activate" : ""`)
+  })
+})

--- a/templates/javascript/packages/core/src/node-type-guards.ts.erb
+++ b/templates/javascript/packages/core/src/node-type-guards.ts.erb
@@ -21,7 +21,7 @@ import {
  * Checks if a node is a <%= node.name %>
  */
 export function is<%= node.name %>(node: Node): node is <%= node.name %> {
-  return node instanceof <%= node.name %> || (node as any).type === "<%= node.type %>"
+  return node instanceof <%= node.name %> || node.type === "<%= node.type %>" || (node.constructor as any).type === "<%= node.type %>"
 }
 
 <%- end -%>
@@ -71,7 +71,7 @@ export const NODE_TYPE_GUARDS = new Map<new (...args: any[]) => Node, (node: Nod
  *   // node is HTMLTextNode
  * }
  */
-export const AST_TYPE_GUARDS = new Map<string, (node: Node) => boolean>([
+export const AST_TYPE_GUARDS = new Map<NodeType, (node: Node) => boolean>([
 <%- nodes.each_with_index do |node, index| -%>
   ["<%= node.type %>", is<%= node.name %>],
 <%- end -%>
@@ -246,19 +246,21 @@ export function filterNodes(
  */
 
 export function isNode<T extends NodeType>(
-  node: Node,
+  node: Node | null | undefined,
   type: T
 ): node is NodeTypeToClass[T]
 
 export function isNode<T extends new (...args: any[]) => Node>(
-  node: Node,
+  node: Node | null | undefined,
   type: T
 ): node is ClassToInstance<T>
 
 export function isNode(
-  node: Node,
+  node: Node | null | undefined,
   type: NodeType | (new (...args: any[]) => Node)
 ): boolean {
+  if (!node) return false
+
   if (typeof type === 'string') {
     const guard = AST_TYPE_GUARDS.get(type)
 

--- a/templates/javascript/packages/core/src/nodes.ts.erb
+++ b/templates/javascript/packages/core/src/nodes.ts.erb
@@ -30,6 +30,10 @@ export abstract class Node implements BaseNodeProps {
     return fromSerializedNode(node)
   }
 
+  static get type(): NodeType {
+    throw new Error("AST_NODE")
+  }
+
   constructor(type: NodeType, location: Location, errors: HerbError[]) {
     this.type = type
     this.location = location
@@ -46,6 +50,14 @@ export abstract class Node implements BaseNodeProps {
 
   inspect(): string {
     return this.treeInspect(0)
+  }
+
+  is<T extends Node>(nodeClass: { new(...args: any[]): T; prototype: T, type: NodeType }): this is T {
+    return this.type === nodeClass.type
+  }
+
+  isOfType<T extends Node>(type: NodeType): this is T {
+    return this.type === type
   }
 
   get isSingleLine(): boolean {
@@ -201,6 +213,10 @@ export class <%= node.name %> extends Node {
   <% raise "Unhandled class #{field.class}" %>
   <%- end -%>
   <%- end -%>
+
+  static get type(): NodeType {
+    return "<%= node.type %>"
+  }
 
   static from(data: Serialized<%= node.name %>): <%= node.name %> {
     return new <%= node.name %>({


### PR DESCRIPTION
This pull request introduces a new `ERBToRubyStringPrinter` that converts simple ERB expressions to a Ruby expression that outputs a String.

| In | Out |
| --- | --- |
| `hello world <%= hello %>` | `"hello world #{hello}"` |
| `hello world <% hello %>` | `"hello world "` |
| `Welcome <%= user.name %>!` | `"Welcome #{user.name}!"` |
| `<% if logged_in? %>Welcome<% else %>Login<% end %>` | `logged_in? ? "Welcome" : "Login"` |
| `<% if logged_in? %>Welcome<% else %>Login<% end %>!` | `"#{logged_in? ? "Welcome" : "Login"}!"` |

API:
```ts
import { ERBToRubyStringPrinter } from "@herb-tools/printer"

const result = Herb.parse("Hello <%= name %>!")

ERBToRubyStringPrinter.print(result)
// => "Hello #{name}!"
```

This pull request also refactors the `erb-prefer-image-tag-helper` linter rule to use this new printer to show better linter offense messages.

For a document like this:
```erb
<img src="<%= root_path %>/assets/<%= "icon.png" %>" alt="Icon">
```

It will now say:

```
Prefer `image_tag` helper over manual `<img>` with dynamic ERB expressions. 
Use `<%= image_tag "#{root_path}/assets/#{"icon.png"}", alt: "..." %>` instead.
```