### PR TITLE
Formatter: Improve ERB Comment Rendering

### DIFF
--- a/javascript/packages/formatter/src/format-printer.ts
+++ b/javascript/packages/formatter/src/format-printer.ts
@@ -235,6 +235,15 @@ export class FormatPrinter extends Printer {
     this.lines.push(line)
   }
 
+  /**
+   * @deprecated refactor to use @herb-tools/printer infrastructre (or rework printer use push and this.lines)
+   */
+  private pushWithIndent(line: string) {
+    const indent = line.trim() === "" ? "" : this.indent
+
+    this.push(indent + line)
+  }
+
   private withIndent<T>(callback: () => T): T {
     this.indentLevel++
     const result = callback()
@@ -620,12 +629,12 @@ export class FormatPrinter extends Printer {
    * Render multiline attributes for a tag
    */
   private renderMultilineAttributes(tagName: string, allChildren: Node[] = [], isSelfClosing: boolean = false,) {
-    this.push(this.indent + `<${tagName}`)
+    this.pushWithIndent(`<${tagName}`)
 
     this.withIndent(() => {
       allChildren.forEach(child => {
         if (isNode(child, HTMLAttributeNode)) {
-          this.push(this.indent + this.renderAttribute(child))
+          this.pushWithIndent(this.renderAttribute(child))
         } else if (!isNode(child, WhitespaceNode)) {
           this.visit(child)
         }
@@ -633,9 +642,9 @@ export class FormatPrinter extends Printer {
     })
 
     if (isSelfClosing) {
-      this.push(this.indent + "/>")
+      this.pushWithIndent("/>")
     } else {
-      this.push(this.indent + ">")
+      this.pushWithIndent(">")
     }
   }
 
@@ -887,7 +896,7 @@ export class FormatPrinter extends Printer {
     if (this.currentElement && closeTagInline) {
       this.pushToLastLine(closingTag)
     } else {
-      this.push(this.indent + closingTag)
+      this.pushWithIndent(closingTag)
     }
   }
 
@@ -927,15 +936,15 @@ export class FormatPrinter extends Printer {
   }
 
   visitHTMLAttributeNode(node: HTMLAttributeNode) {
-    this.push(this.indent + this.renderAttribute(node))
+    this.pushWithIndent(this.renderAttribute(node))
   }
 
   visitHTMLAttributeNameNode(node: HTMLAttributeNameNode) {
-    this.push(this.indent + getCombinedAttributeName(node))
+    this.pushWithIndent(getCombinedAttributeName(node))
   }
 
   visitHTMLAttributeValueNode(node: HTMLAttributeValueNode) {
-    this.push(this.indent + IdentityPrinter.print(node))
+    this.pushWithIndent(IdentityPrinter.print(node))
   }
 
   // TODO: rework
@@ -999,7 +1008,7 @@ export class FormatPrinter extends Printer {
       inner = ""
     }
 
-    this.push(this.indent + open + inner + close)
+    this.pushWithIndent(open + inner + close)
   }
 
   visitERBCommentNode(node: ERBContentNode) {
@@ -1014,41 +1023,38 @@ export class FormatPrinter extends Printer {
       const startsWithSpace = content[0] === " "
       const before = startsWithSpace ? "" : " "
 
-      this.push(this.indent + open + before + content.trimEnd() + ' ' + close)
+      this.pushWithIndent(open + before + content.trimEnd() + ' ' + close)
 
       return
     }
 
     if (contentTrimmedLines.length === 1) {
-      this.push(this.indent + open + ' ' + content.trim() + ' ' + close)
+      this.pushWithIndent(open + ' ' + content.trim() + ' ' + close)
       return
     }
 
     const firstLineEmpty = contentLines[0].trim() === ""
     const dedentedContent = dedent(firstLineEmpty ? content : content.trimStart())
 
-    this.push(this.indent + open)
+    this.pushWithIndent(open)
 
     this.withIndent(() => {
-      dedentedContent.split("\n").forEach(line => {
-        const indent = line.trim() === "" ? "" : this.indent
-        this.push(indent + line)
-      })
+      dedentedContent.split("\n").forEach(line => this.pushWithIndent(line))
     })
 
-    this.push(this.indent + close)
+    this.pushWithIndent(close)
   }
 
   visitHTMLDoctypeNode(node: HTMLDoctypeNode) {
-    this.push(this.indent + IdentityPrinter.print(node))
+    this.pushWithIndent(IdentityPrinter.print(node))
   }
 
   visitXMLDeclarationNode(node: XMLDeclarationNode) {
-    this.push(this.indent + IdentityPrinter.print(node))
+    this.pushWithIndent(IdentityPrinter.print(node))
   }
 
   visitCDATANode(node: CDATANode) {
-    this.push(this.indent + IdentityPrinter.print(node))
+    this.pushWithIndent(IdentityPrinter.print(node))
   }
 
   visitERBContentNode(node: ERBContentNode) {
@@ -1397,7 +1403,7 @@ export class FormatPrinter extends Printer {
             }
           } else {
             if (currentLineContent.trim()) {
-              this.push(this.indent + currentLineContent.trim())
+              this.pushWithIndent(currentLineContent.trim())
               currentLineContent = ""
             }
 
@@ -1405,7 +1411,7 @@ export class FormatPrinter extends Printer {
           }
         } else {
           if (currentLineContent.trim()) {
-            this.push(this.indent + currentLineContent.trim())
+            this.pushWithIndent(currentLineContent.trim())
             currentLineContent = ""
           }
 
@@ -1436,7 +1442,7 @@ export class FormatPrinter extends Printer {
         }
       } else {
         if (currentLineContent.trim()) {
-          this.push(this.indent + currentLineContent.trim())
+          this.pushWithIndent(currentLineContent.trim())
           currentLineContent = ""
         }
 

--- a/javascript/packages/formatter/src/format-printer.ts
+++ b/javascript/packages/formatter/src/format-printer.ts
@@ -1030,7 +1030,10 @@ export class FormatPrinter extends Printer {
     this.push(this.indent + open)
 
     this.withIndent(() => {
-      dedentedContent.split("\n").forEach(line => this.push(this.indent + line))
+      dedentedContent.split("\n").forEach(line => {
+        const indent = line.trim() === "" ? "" : this.indent
+        this.push(indent + line)
+      })
     })
 
     this.push(this.indent + close)

--- a/javascript/packages/formatter/test/erb-formatter/erb-formatter-fixtures.test.ts
+++ b/javascript/packages/formatter/test/erb-formatter/erb-formatter-fixtures.test.ts
@@ -194,7 +194,23 @@ describe("ERB Formatter Fixture Tests", () => {
               hey
           hey
         %>
+      `
 
+      const result = formatter.format(source)
+
+      expect(result).toBe(dedent`
+        <%#
+          This fails
+          hey
+            hey
+              hey
+          hey
+        %>
+      `)
+    })
+
+    test("comments.html.erb - handles various comment formats", () => {
+      const source = dedent`
         <%#
             This fails
             hey
@@ -202,7 +218,23 @@ describe("ERB Formatter Fixture Tests", () => {
                 hey
             hey
         %>
+      `
 
+      const result = formatter.format(source)
+
+      expect(result).toBe(dedent`
+        <%#
+          This fails
+          hey
+            hey
+              hey
+          hey
+        %>
+      `)
+    })
+
+    test("comments.html.erb - handles various comment formats", () => {
+      const source = dedent`
         <%# This fails
           This fails
           hey
@@ -217,25 +249,10 @@ describe("ERB Formatter Fixture Tests", () => {
       expect(result).toBe(dedent`
         <%#
           This fails
-          hey
-          hey
-          hey
-          hey
-        %>
-
-        <%#
           This fails
           hey
-          hey
-          hey
-          hey
-        %>
-
-        <%#
-          This fails
-          hey
-          hey
-          hey
+            hey
+              hey
           hey
         %>
       `)

--- a/javascript/packages/formatter/test/erb/comment.test.ts
+++ b/javascript/packages/formatter/test/erb/comment.test.ts
@@ -43,6 +43,276 @@ describe("@herb-tools/formatter", () => {
     `)
   })
 
+  test("formats multi-line ERB comment with first comment line on same line", () => {
+    const source = dedent`
+      <%# hello
+        this is a
+        multi-line ERB
+        comment
+      %>
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <%#
+        hello
+        this is a
+        multi-line ERB
+        comment
+      %>
+    `)
+  })
+
+  test("formats multi-line ERB comment with first comment line on same line", () => {
+    const source = dedent`
+      <%#   hello
+        this is a
+        multi-line ERB
+        comment
+      %>
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <%#
+        hello
+        this is a
+        multi-line ERB
+        comment
+      %>
+    `)
+  })
+
+  test("ERB Comment not trim left", () => {
+    const source = dedent`
+      <%#       content %>
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <%#       content %>
+    `)
+  })
+
+  test("multiple ERB Comments not trim left", () => {
+    const source = dedent`
+      <%# level 1 %>
+      <%#   level 2 %>
+      <%#     level 3 %>
+      <%#       level 4 %>
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <%# level 1 %>
+
+      <%#   level 2 %>
+
+      <%#     level 3 %>
+
+      <%#       level 4 %>
+    `)
+  })
+
+  test("ERB Comment trim right", () => {
+    const source = dedent`
+      <%# level 1       %>
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <%# level 1 %>
+    `)
+  })
+
+  test("multiple ERB Comments trim right", () => {
+    const source = dedent`
+      <%# level 1       %>
+      <%# level 2     %>
+      <%# level 3   %>
+      <%# level 4 %>
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <%# level 1 %>
+
+      <%# level 2 %>
+
+      <%# level 3 %>
+
+      <%# level 4 %>
+    `)
+  })
+
+  test("ERB Comment not trim left but trim tright", () => {
+    const source = dedent`
+      <%#       content                   %>
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <%#       content %>
+    `)
+  })
+
+  test("spacing around", () => {
+    const source = dedent`
+      <%#comment%>
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <%# comment %>
+    `)
+  })
+
+  test("formats multi-line ERB comment with one line on first line", () => {
+    const source = dedent`
+      <%# hello
+      %>
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <%# hello %>
+    `)
+  })
+
+  test("formats multi-line ERB comment with one line on second line", () => {
+    const source = dedent`
+      <%#
+        hello
+      %>
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <%# hello %>
+    `)
+  })
+
+  test("formats multi-line ERB comment with one line on second line indented", () => {
+    const source = dedent`
+      <%#
+             hello
+      %>
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <%# hello %>
+    `)
+  })
+
+  test("formats multi-line ERB comment with one line on second line not indented", () => {
+    const source = dedent`
+      <%#
+      hello
+      %>
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <%# hello %>
+    `)
+  })
+
+  test("formats multi-line ERB comment", () => {
+    const source = dedent`
+      <%#
+      line 1
+      line 2
+            %>
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <%#
+        line 1
+        line 2
+      %>
+    `)
+  })
+
+  test("formats multi-line ERB comment", () => {
+    const source = dedent`
+      <%#
+      line 1
+      line 2 %>
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <%#
+        line 1
+        line 2
+      %>
+    `)
+  })
+
+  test("empty ERB comment", () => {
+    const source = dedent`
+      <%#          %>
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <%# %>
+    `)
+  })
+
+  test("empty multi-line ERB comment", () => {
+    const source = dedent`
+      <%#
+
+      %>
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <%#  %>
+    `)
+  })
+
+  test("formats multi-line ERB comment", () => {
+    const source = dedent`
+      <%# Non-link tag that stands for skipped pages...
+        - available local variables
+          current_page:  a page object for the currently displayed page
+          total_pages:   total number of pages
+          per_page:      number of items to fetch per page
+          remote:        data-remote
+      -%>
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <%#
+        Non-link tag that stands for skipped pages...
+        - available local variables
+          current_page:  a page object for the currently displayed page
+          total_pages:   total number of pages
+          per_page:      number of items to fetch per page
+          remote:        data-remote
+      -%>
+    `)
+  })
+
+  test("formats multi-line ERB comment with newlines", () => {
+    const source = dedent`
+      <%# this is the first line
+
+
+        this is the second line
+
+
+
+
+        this is the last line
+
+
+      -%>
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <%#
+        this is the first line
+        ${''}
+        ${''}
+        this is the second line
+        ${''}
+        ${''}
+        ${''}
+        ${''}
+        this is the last line
+      -%>
+    `)
+  })
+
   test("handles long ERB comments that exceed maxLineLength", () => {
     const source = '<%# herb lsp herb lsp herb lsp herb lsp herb lsp herb lsp herb lsp herb lsp herb lsp herb lsp herb lsp herb lsp herb lsp herb lsp %>'
 

--- a/javascript/packages/formatter/test/erb/comment.test.ts
+++ b/javascript/packages/formatter/test/erb/comment.test.ts
@@ -285,29 +285,29 @@ describe("@herb-tools/formatter", () => {
   test("formats multi-line ERB comment with newlines", () => {
     const source = dedent`
       <%# this is the first line
-
+        ${'' /* this is the add trailing whitespace */}
 
         this is the second line
 
-
+        ${'' /* this is the add trailing whitespace */}
 
 
         this is the last line
 
-
+        ${'' /* this is the add trailing whitespace */}
       -%>
     `
     const result = formatter.format(source)
     expect(result).toEqual(dedent`
       <%#
         this is the first line
-        ${''}
-        ${''}
+
+
         this is the second line
-        ${''}
-        ${''}
-        ${''}
-        ${''}
+
+
+
+
         this is the last line
       -%>
     `)


### PR DESCRIPTION
This pull request improves the way the formatter renders ERB Comments. It also solves the issue surfaced in #436 where the formatter duplicated the first line if it was on the same line as `<%#`.