### PR TITLE
Printer: Also fully reconstruct whitespace in `HTMLCloseTag`

### DIFF
--- a/javascript/packages/printer/src/identity-printer.ts
+++ b/javascript/packages/printer/src/identity-printer.ts
@@ -1,4 +1,6 @@
 import { Printer } from "./printer.js"
+import { getNodesBeforePosition, getNodesAfterPosition } from "@herb-tools/core"
+
 import type * as Nodes from "@herb-tools/core"
 
 /**
@@ -47,7 +49,14 @@ export class IdentityPrinter extends Printer {
     }
 
     if (node.tag_name) {
+      const before = getNodesBeforePosition(node.children, node.tag_name.location.start, true)
+      const after = getNodesAfterPosition(node.children, node.tag_name.location.end)
+
+      this.visitAll(before)
       this.write(node.tag_name.value)
+      this.visitAll(after)
+    } else {
+      this.visitAll(node.children)
     }
 
     if (node.tag_closing) {

--- a/javascript/packages/printer/test/nodes/html-close-tag-node.test.ts
+++ b/javascript/packages/printer/test/nodes/html-close-tag-node.test.ts
@@ -1,4 +1,3 @@
-import dedent from "dedent"
 import { describe, test, beforeAll } from "vitest"
 
 import { Herb } from "@herb-tools/node-wasm"
@@ -25,12 +24,18 @@ describe("HTMLCloseTagNode Printing", () => {
   })
 
   test("can print from source", () => {
-    expectPrintRoundTrip(dedent`<a></a>`)
-    expectPrintRoundTrip(dedent`<custom-name></custom-name>`)
+    expectPrintRoundTrip(`<a></a>`)
+    expectPrintRoundTrip(`<custom-name></custom-name>`)
+    expectPrintRoundTrip(`<div></div     >`)
+    expectPrintRoundTrip(`<div></     div>`)
+    expectPrintRoundTrip(`<div></     div     >`)
   })
 
   test("can print from invalid source", () => {
-    expectPrintRoundTrip(dedent`</a>`, false)
-    expectPrintRoundTrip(dedent`</custom-name>`, false)
+    expectPrintRoundTrip(`</a>`, false)
+    expectPrintRoundTrip(`</custom-name>`, false)
+    expectPrintRoundTrip(`</div  >`, false)
+    expectPrintRoundTrip(`</  div>`, false)
+    expectPrintRoundTrip(`</  div  >`, false)
   })
 })


### PR DESCRIPTION
This pull request updates the `IdentityPrinter` to also reconstruct the whitespace in the `HTMLCloseTag`. 

The parser was already adding the `WhitespaceNode`s to the `children` array of the `HTMLCloseTag` (done in #396), but the `IdentityPrinter` wasn't accounting for them.

Now these templates can also be fully reconstructed using the `IdentityPrinter`:
```html
<div></   div>
<div></div   >
<div></   div   >
```

Additionally, this pull request also adds some more AST helpers to the `@herb-tools/core` package to select nodes before/after a certain `Location` or `Position`.