### PR TITLE
Linter: Use `--github` by default in GitHub Actions

### DIFF
--- a/javascript/packages/linter/README.md
+++ b/javascript/packages/linter/README.md
@@ -123,6 +123,7 @@ npx @herb-tools/linter template.html.erb --json
 npx @herb-tools/linter template.html.erb --format json
 
 # Use GitHub Actions output format
+# (This format is selected automatically when the GITHUB_ACTIONS environment variable is set)
 npx @herb-tools/linter template.html.erb --github
 # or
 npx @herb-tools/linter template.html.erb --format github
@@ -157,10 +158,14 @@ npx @herb-tools/linter --version
 
 #### GitHub Actions Output Format
 
-The linter supports GitHub Actions annotation format with the `--github` flag, which outputs errors and warnings in a format that GitHub Actions can parse to create inline annotations in pull requests:
+The linter supports GitHub Actions annotation format with the `--github` flag, which outputs errors and warnings in a format that GitHub Actions can parse to create inline annotations in pull requests.
+
+::: tip Tip: Running in GitHub Actions
+When the `GITHUB_ACTIONS` environment variable is set (as in GitHub Actions), this format is enabled by default, so the `--github` flag is optional.
+:::
 
 ```bash
-npx @herb-tools/linter "**/*.html.erb" --github
+npx @herb-tools/linter --github
 ```
 
 Example output:
@@ -181,7 +186,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
-      - run: npx @herb-tools/linter "**/*.html.erb" --github
+      - run: npx @herb-tools/linter
 ```
 
 #### JSON Output Format
@@ -232,11 +237,11 @@ npx @herb-tools/linter template.html.erb --json
 
 JSON output fields:
 - `offenses`: Array of linting offenses with location and severity
-- `summary`: Statistics about the linting run (null on errors)
-- `timing`: Timing information with ISO timestamp (null with `--no-timing`)
+- `summary`: Statistics about the linting run (`null` on errors)
+- `timing`: Timing information with ISO timestamp (`null` with `--no-timing`)
 - `completed`: Whether the linter ran successfully on files
-- `clean`: Whether there were no offenses (null when `completed=false`)
-- `message`: Error or informational message (null on success)
+- `clean`: Whether there were no offenses (`null` when `completed=false`)
+- `message`: Error or informational message (`null` on success)
 
 ### Language Server Integration
 

--- a/javascript/packages/linter/src/cli/argument-parser.ts
+++ b/javascript/packages/linter/src/cli/argument-parser.ts
@@ -34,7 +34,7 @@ export class ArgumentParser {
     Options:
       -h, --help       show help
       -v, --version    show version
-      --format         output format (simple|detailed|json|github) [default: detailed]
+      --format         output format (simple|detailed|json|github) [default: detailed, github in GitHub Actions]
       --simple         use simple output format (shortcut for --format simple)
       --json           use JSON output format (shortcut for --format json)
       --github         use GitHub Actions output format (shortcut for --format github)
@@ -75,7 +75,9 @@ export class ArgumentParser {
       process.exit(0)
     }
 
-    let formatOption: FormatOption = "detailed"
+    const isGitHubActions = process.env.GITHUB_ACTIONS === "true"
+
+    let formatOption: FormatOption = isGitHubActions ? "github" : "detailed"
     if (values.format && (values.format === "detailed" || values.format === "simple" || values.format === "json" || values.format === "github")) {
       formatOption = values.format
     }

--- a/javascript/packages/linter/test/__snapshots__/cli.test.ts.snap
+++ b/javascript/packages/linter/test/__snapshots__/cli.test.ts.snap
@@ -559,3 +559,11 @@ test/fixtures/bad-file.html.erb:1:16
   Checked      1 file
   Offenses     2 errors | 0 warnings (2 offenses across 1 file)"
 `;
+
+exports[`CLI Output Formatting > uses GitHub Actions format by default when GITHUB_ACTIONS is true 1`] = `
+"::error file=test/fixtures/test-file-with-errors.html.erb,line=3,col=3::Missing required \`alt\` attribute on \`<img>\` tag. Add \`alt=""\` for decorative images or \`alt="description"\` for informative images. [html-img-require-alt]
+
+::error file=test/fixtures/test-file-with-errors.html.erb,line=2,col=3::Opening tag name \`<SPAN>\` should be lowercase. Use \`<span>\` instead. [html-tag-name-lowercase]
+
+::error file=test/fixtures/test-file-with-errors.html.erb,line=2,col=22::Closing tag name \`</SPAN>\` should be lowercase. Use \`</span>\` instead. [html-tag-name-lowercase]"
+`;

--- a/javascript/packages/linter/test/cli.test.ts
+++ b/javascript/packages/linter/test/cli.test.ts
@@ -6,14 +6,18 @@ describe("CLI Output Formatting", () => {
     await Herb.load()
   })
 
-  function runLinter(fixture: string, ...args: string[]): { output: string, exitCode: number } {
+  function runLinter(fixture: string, ...args: (string | Record<string, string>)[]): { output: string, exitCode: number } {
     try {
       const { execSync } = require("child_process")
-      const allArgs = [...args, "--no-timing"].join(' ')
+      let env: Record<string, string> = {}
+      if (typeof args[args.length - 1] === "object") {
+        env = args.pop() as Record<string, string>
+      }
+      const allArgs = [...(args as string[]), "--no-timing"].join(' ')
 
       const output = execSync(`bin/herb-lint test/fixtures/${fixture} ${allArgs}`, {
         encoding: "utf-8",
-        env: { ...process.env, NO_COLOR: "1" }
+        env: { ...process.env, NO_COLOR: "1", ...env }
       })
 
       return { output: output.trim(), exitCode: 0 }
@@ -136,6 +140,13 @@ describe("CLI Output Formatting", () => {
 
   test("formats GitHub Actions output with --format=github option", () => {
     const { output, exitCode } = runLinter("test-file-simple.html.erb", "--format=github")
+
+    expect(output).toMatchSnapshot()
+    expect(exitCode).toBe(1)
+  })
+
+  test("uses GitHub Actions format by default when GITHUB_ACTIONS is true", () => {
+    const { output, exitCode } = runLinter("test-file-with-errors.html.erb", { GITHUB_ACTIONS: "true" })
 
     expect(output).toMatchSnapshot()
     expect(exitCode).toBe(1)


### PR DESCRIPTION
This pull request updates the linter to automatically select the `--format=github` option when running the linter in GitHub Actions (`GITHUB_ACTIONS=true` variable set) unless specified otherwise.