### PR TITLE
Linter: Show highlighted offense preview in GitHub Actions annotations

### DIFF
--- a/javascript/packages/linter/src/cli.ts
+++ b/javascript/packages/linter/src/cli.ts
@@ -16,6 +16,7 @@ export class CLI {
       wrapLines: false, 
       truncateLines: false, 
       showTiming: false, 
+      useGitHubActions: false,
       startTime: 0, 
       startDate: new Date() 
     })
@@ -29,6 +30,7 @@ export class CLI {
       wrapLines: false,
       truncateLines: false,
       showTiming: timingData?.showTiming ?? false,
+      useGitHubActions: false,
       startTime: timingData?.startTime ?? Date.now(),
       startDate: timingData?.startDate ?? new Date()
     }
@@ -41,7 +43,7 @@ export class CLI {
     const startTime = Date.now()
     const startDate = new Date()
 
-    const { pattern, formatOption, showTiming, theme, wrapLines, truncateLines } = this.argumentParser.parse(process.argv)
+    const { pattern, formatOption, showTiming, theme, wrapLines, truncateLines, useGitHubActions } = this.argumentParser.parse(process.argv)
 
     const outputOptions = {
       formatOption,
@@ -49,6 +51,7 @@ export class CLI {
       wrapLines,
       truncateLines,
       showTiming,
+      useGitHubActions,
       startTime,
       startDate
     }

--- a/javascript/packages/linter/src/cli/file-processor.ts
+++ b/javascript/packages/linter/src/cli/file-processor.ts
@@ -39,7 +39,7 @@ export class FileProcessor {
       const parseResult = Herb.parse(content)
 
       if (parseResult.errors.length > 0) {
-        if (formatOption !== 'json' && formatOption !== 'github') {
+        if (formatOption !== 'json') {
           console.error(`${colorize(filename, "cyan")} - ${colorize("Parse errors:", "brightRed")}`)
 
           for (const error of parseResult.errors) {
@@ -47,7 +47,6 @@ export class FileProcessor {
           }
         }
 
-        // Add parse errors to offenses for JSON output
         for (const error of parseResult.errors) {
           allOffenses.push({ filename, offense: error, content })
         }
@@ -68,7 +67,7 @@ export class FileProcessor {
       }
 
       if (lintResult.offenses.length === 0) {
-        if (files.length === 1 && formatOption !== 'json' && formatOption !== 'github') {
+        if (files.length === 1 && formatOption !== 'json') {
           console.log(`${colorize("✓", "brightGreen")} ${colorize(filename, "cyan")} - ${colorize("No issues found", "green")}`)
         }
       } else {

--- a/javascript/packages/linter/src/cli/formatters/github-actions-formatter.ts
+++ b/javascript/packages/linter/src/cli/formatters/github-actions-formatter.ts
@@ -1,10 +1,24 @@
+import { Highlighter } from "@herb-tools/highlighter"
+
 import { BaseFormatter } from "./base-formatter.js"
+import { name, version } from "../../../package.json"
 
 import type { Diagnostic } from "@herb-tools/core"
 import type { ProcessedFile } from "../file-processor.js"
 
 // https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands
 export class GitHubActionsFormatter extends BaseFormatter {
+  private highlighter: Highlighter
+  private wrapLines: boolean
+  private truncateLines: boolean
+
+  constructor(wrapLines: boolean = true, truncateLines: boolean = false) {
+    super()
+    this.wrapLines = wrapLines
+    this.truncateLines = truncateLines
+    this.highlighter = new Highlighter()
+  }
+
   private static readonly MESSAGE_ESCAPE_MAP: Record<string, string> = {
     '%': '%25',
     '\n': '%0A',
@@ -19,13 +33,39 @@ export class GitHubActionsFormatter extends BaseFormatter {
     ',': '%2C'
   }
 
-  async format(allDiagnostics: ProcessedFile[]): Promise<void> {
-    for (const { filename, offense } of allDiagnostics) {
-      this.formatDiagnostic(filename, offense)
+  async format(allDiagnostics: ProcessedFile[], _isSingleFile: boolean = false): Promise<void> {
+    await this.formatAnnotations(allDiagnostics)
+  }
+
+  async formatAnnotations(allDiagnostics: ProcessedFile[]): Promise<void> {
+    if (allDiagnostics.length === 0) return
+
+    if (!this.highlighter.initialized) {
+      await this.highlighter.initialize()
     }
 
-    if (allDiagnostics.length > 0) {
-      console.log()
+    for (const { filename, offense, content } of allDiagnostics) {
+      const originalNoColor = process.env.NO_COLOR
+      process.env.NO_COLOR = "1"
+
+      let plainCodePreview = ""
+      try {
+        const formatted = this.highlighter.highlightDiagnostic(filename, offense, content, {
+          contextLines: 2,
+          wrapLines: this.wrapLines,
+          truncateLines: this.truncateLines
+        })
+
+        plainCodePreview = formatted.split('\n').slice(1).join('\n')
+      } finally {
+        if (originalNoColor === undefined) {
+          delete process.env.NO_COLOR
+        } else {
+          process.env.NO_COLOR = originalNoColor
+        }
+      }
+
+      this.formatDiagnostic(filename, offense, plainCodePreview)
     }
   }
 
@@ -36,22 +76,35 @@ export class GitHubActionsFormatter extends BaseFormatter {
   }
 
   // GitHub Actions annotation format:
-  // ::{level} file={file},line={line},col={col}::{message}
+  // ::{level} file={file},line={line},col={col},title={title}::{message}
   //
-  private formatDiagnostic(filename: string, diagnostic: Diagnostic): void {
+  private formatDiagnostic(filename: string, diagnostic: Diagnostic, codePreview: string = ""): void {
     const level = diagnostic.severity === "error" ? "error" : "warning"
     const { line, column } = diagnostic.location.start
 
     const escapedFilename = this.escapeParam(filename)
-    const message = this.escapeMessage(diagnostic.message)
-
-    let fullMessage = message
+    let message = diagnostic.message
 
     if (diagnostic.code) {
-      fullMessage += ` [${diagnostic.code}]`
+      message += ` [${diagnostic.code}]`
     }
 
-    console.log(`\n::${level} file=${escapedFilename},line=${line},col=${column}::${fullMessage}`)
+    if (codePreview) {
+      message += "\n\n" + codePreview
+    }
+
+    const escapedMessage = this.escapeMessage(message)
+
+    let annotations = `file=${escapedFilename},line=${line},col=${column}`
+
+    if (diagnostic.code) {
+      const title = `${diagnostic.code} • ${name}@${version}`
+      const escapedTitle = this.escapeParam(title)
+
+      annotations += `,title=${escapedTitle}`
+    }
+
+    console.log(`\n::${level} ${annotations}::${escapedMessage}`)
   }
 
   private escapeMessage(string: string): string {

--- a/javascript/packages/linter/src/cli/index.ts
+++ b/javascript/packages/linter/src/cli/index.ts
@@ -1,4 +1,5 @@
 export { ArgumentParser } from "./argument-parser.js"
 export { FileProcessor } from "./file-processor.js"
 export { SummaryReporter } from "./summary-reporter.js"
+
 export * from "./formatters/index.js"

--- a/javascript/packages/linter/src/cli/summary-reporter.ts
+++ b/javascript/packages/linter/src/cli/summary-reporter.ts
@@ -23,14 +23,11 @@ export class SummaryReporter {
     console.log("\n")
     console.log(` ${colorize("Summary:", "bold")}`)
 
-    // Calculate padding for alignment
-    const labelWidth = 12 // Width for the longest label "Offenses"
+    const labelWidth = 12
     const pad = (label: string) => label.padEnd(labelWidth)
 
-    // Checked summary
     console.log(`  ${colorize(pad("Checked"), "gray")} ${colorize(`${files.length} ${this.pluralize(files.length, "file")}`, "cyan")}`)
 
-    // Files summary (for multiple files)
     if (files.length > 1) {
       const filesChecked = files.length
       const filesClean = filesChecked - filesWithOffenses
@@ -52,11 +49,9 @@ export class SummaryReporter {
       }
     }
 
-    // Offenses summary with file count
     let offensesSummary = ""
     const parts = []
 
-    // Build the main part with errors and warnings
     if (totalErrors > 0) {
       parts.push(colorize(colorize(`${totalErrors} ${this.pluralize(totalErrors, "error")}`, "brightRed"), "bold"))
     }
@@ -64,7 +59,6 @@ export class SummaryReporter {
     if (totalWarnings > 0) {
       parts.push(colorize(colorize(`${totalWarnings} ${this.pluralize(totalWarnings, "warning")}`, "brightYellow"), "bold"))
     } else if (totalErrors > 0) {
-      // Show 0 warnings when there are errors but no warnings
       parts.push(colorize(colorize(`${totalWarnings} ${this.pluralize(totalWarnings, "warning")}`, "green"), "bold"))
     }
 
@@ -72,7 +66,7 @@ export class SummaryReporter {
       offensesSummary = colorize(colorize("0 offenses", "green"), "bold")
     } else {
       offensesSummary = parts.join(" | ")
-      // Add total count and file count
+
       let detailText = ""
 
       const totalOffenses = totalErrors + totalWarnings
@@ -86,16 +80,14 @@ export class SummaryReporter {
 
     console.log(`  ${colorize(pad("Offenses"), "gray")} ${offensesSummary}`)
 
-    // Timing information (if enabled)
     if (showTiming) {
       const duration = Date.now() - startTime
-      const timeString = startDate.toTimeString().split(' ')[0] // HH:MM:SS format
+      const timeString = startDate.toTimeString().split(' ')[0]
 
       console.log(`  ${colorize(pad("Start at"), "gray")} ${colorize(timeString, "cyan")}`)
       console.log(`  ${colorize(pad("Duration"), "gray")} ${colorize(`${duration}ms`, "cyan")} ${colorize(colorize(`(${ruleCount} ${this.pluralize(ruleCount, "rule")})`, "gray"), "dim")}`)
     }
 
-    // Success message for all files clean
     if (filesWithOffenses === 0 && files.length > 1) {
       console.log("")
       console.log(` ${colorize("✓", "brightGreen")} ${colorize("All files are clean!", "green")}`)

--- a/javascript/packages/linter/test/__snapshots__/cli.test.ts.snap
+++ b/javascript/packages/linter/test/__snapshots__/cli.test.ts.snap
@@ -1,14 +1,77 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`CLI Output Formatting > GitHub Actions format escapes special characters in messages 1`] = `
-"::error file=test/fixtures/test-file-with-errors.html.erb,line=3,col=3::Missing required \`alt\` attribute on \`<img>\` tag. Add \`alt=""\` for decorative images or \`alt="description"\` for informative images. [html-img-require-alt]
+"::error file=test/fixtures/test-file-with-errors.html.erb,line=3,col=3,title=html-img-require-alt • @herb-tools/linter@0.6.1::Missing required \`alt\` attribute on \`<img>\` tag. Add \`alt=""\` for decorative images or \`alt="description"\` for informative images. [html-img-require-alt]%0A%0A%0Atest/fixtures/test-file-with-errors.html.erb:3:3%0A%0A      1 │ <div>%0A      2 │   <SPAN>Test content</SPAN>%0A  →   3 │   <img src="test.jpg">%0A        │    ~~~%0A      4 │ </div>%0A      5 │%0A
 
-::error file=test/fixtures/test-file-with-errors.html.erb,line=2,col=3::Opening tag name \`<SPAN>\` should be lowercase. Use \`<span>\` instead. [html-tag-name-lowercase]
+::error file=test/fixtures/test-file-with-errors.html.erb,line=2,col=3,title=html-tag-name-lowercase • @herb-tools/linter@0.6.1::Opening tag name \`<SPAN>\` should be lowercase. Use \`<span>\` instead. [html-tag-name-lowercase]%0A%0A%0Atest/fixtures/test-file-with-errors.html.erb:2:3%0A%0A      1 │ <div>%0A  →   2 │   <SPAN>Test content</SPAN>%0A        │    ~~~~%0A      3 │   <img src="test.jpg">%0A      4 │ </div>%0A
 
-::error file=test/fixtures/test-file-with-errors.html.erb,line=2,col=22::Closing tag name \`</SPAN>\` should be lowercase. Use \`</span>\` instead. [html-tag-name-lowercase]"
+::error file=test/fixtures/test-file-with-errors.html.erb,line=2,col=22,title=html-tag-name-lowercase • @herb-tools/linter@0.6.1::Closing tag name \`</SPAN>\` should be lowercase. Use \`</span>\` instead. [html-tag-name-lowercase]%0A%0A%0Atest/fixtures/test-file-with-errors.html.erb:2:22%0A%0A      1 │ <div>%0A  →   2 │   <SPAN>Test content</SPAN>%0A        │                       ~~~~%0A      3 │   <img src="test.jpg">%0A      4 │ </div>%0A
+
+[error] Missing required \`alt\` attribute on \`<img>\` tag. Add \`alt=""\` for decorative images or \`alt="description"\` for informative images. (html-img-require-alt)
+
+test/fixtures/test-file-with-errors.html.erb:3:3
+
+      1 │ <div>
+      2 │   <SPAN>Test content</SPAN>
+  →   3 │   <img src="test.jpg">
+        │    ~~~
+      4 │ </div>
+      5 │
+
+
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯  [1/3] ⎯⎯⎯⎯
+
+[error] Opening tag name \`<SPAN>\` should be lowercase. Use \`<span>\` instead. (html-tag-name-lowercase)
+
+test/fixtures/test-file-with-errors.html.erb:2:3
+
+      1 │ <div>
+  →   2 │   <SPAN>Test content</SPAN>
+        │    ~~~~
+      3 │   <img src="test.jpg">
+      4 │ </div>
+
+
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯  [2/3] ⎯⎯⎯⎯
+
+[error] Closing tag name \`</SPAN>\` should be lowercase. Use \`</span>\` instead. (html-tag-name-lowercase)
+
+test/fixtures/test-file-with-errors.html.erb:2:22
+
+      1 │ <div>
+  →   2 │   <SPAN>Test content</SPAN>
+        │                       ~~~~
+      3 │   <img src="test.jpg">
+      4 │ </div>
+
+ Rule offenses:
+  html-tag-name-lowercase (2 offenses in 1 file)
+  html-img-require-alt (1 offense in 1 file)
+
+
+ Summary:
+  Checked      1 file
+  Offenses     3 errors | 0 warnings (3 offenses across 1 file)"
 `;
 
-exports[`CLI Output Formatting > GitHub Actions format includes rule codes 1`] = `"::error file=test/fixtures/no-trailing-newline.html.erb,line=1,col=29::File must end with trailing newline [erb-requires-trailing-newline]"`;
+exports[`CLI Output Formatting > GitHub Actions format includes rule codes 1`] = `
+"::error file=test/fixtures/no-trailing-newline.html.erb,line=1,col=29,title=erb-requires-trailing-newline • @herb-tools/linter@0.6.1::File must end with trailing newline [erb-requires-trailing-newline]%0A%0A%0Atest/fixtures/no-trailing-newline.html.erb:1:29%0A%0A  →   1 │ <div>No trailing newline</div>%0A        │                              ~%0A
+
+[error] File must end with trailing newline (erb-requires-trailing-newline)
+
+test/fixtures/no-trailing-newline.html.erb:1:29
+
+  →   1 │ <div>No trailing newline</div>
+        │                              ~
+
+ Rule offenses:
+  erb-requires-trailing-newline (1 offense in 1 file)
+
+
+ Summary:
+  Checked      1 file
+  Offenses     1 error | 0 warnings (1 offense across 1 file)"
+`;
 
 exports[`CLI Output Formatting > displays most violated rules with multiple offenses 1`] = `
 "[error] Add an \`href\` attribute to \`<a>\` to ensure it is focusable and accessible. (html-anchor-require-href)
@@ -284,25 +347,132 @@ test/fixtures/few-rule-offenses.html.erb:3:16
 `;
 
 exports[`CLI Output Formatting > formats GitHub Actions output correctly for bad file 1`] = `
-"::error file=test/fixtures/bad-file.html.erb,line=1,col=1::Opening tag name \`<SPAN>\` should be lowercase. Use \`<span>\` instead. [html-tag-name-lowercase]
+"::error file=test/fixtures/bad-file.html.erb,line=1,col=1,title=html-tag-name-lowercase • @herb-tools/linter@0.6.1::Opening tag name \`<SPAN>\` should be lowercase. Use \`<span>\` instead. [html-tag-name-lowercase]%0A%0A%0Atest/fixtures/bad-file.html.erb:1:1%0A%0A  →   1 │ <SPAN>Bad file</SPAN>%0A        │  ~~~~%0A      2 │%0A
 
-::error file=test/fixtures/bad-file.html.erb,line=1,col=16::Closing tag name \`</SPAN>\` should be lowercase. Use \`</span>\` instead. [html-tag-name-lowercase]"
+::error file=test/fixtures/bad-file.html.erb,line=1,col=16,title=html-tag-name-lowercase • @herb-tools/linter@0.6.1::Closing tag name \`</SPAN>\` should be lowercase. Use \`</span>\` instead. [html-tag-name-lowercase]%0A%0A%0Atest/fixtures/bad-file.html.erb:1:16%0A%0A  →   1 │ <SPAN>Bad file</SPAN>%0A        │                 ~~~~%0A      2 │%0A
+
+[error] Opening tag name \`<SPAN>\` should be lowercase. Use \`<span>\` instead. (html-tag-name-lowercase)
+
+test/fixtures/bad-file.html.erb:1:1
+
+  →   1 │ <SPAN>Bad file</SPAN>
+        │  ~~~~
+      2 │
+
+
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯  [1/2] ⎯⎯⎯⎯
+
+[error] Closing tag name \`</SPAN>\` should be lowercase. Use \`</span>\` instead. (html-tag-name-lowercase)
+
+test/fixtures/bad-file.html.erb:1:16
+
+  →   1 │ <SPAN>Bad file</SPAN>
+        │                 ~~~~
+      2 │
+
+ Rule offenses:
+  html-tag-name-lowercase (2 offenses in 1 file)
+
+
+ Summary:
+  Checked      1 file
+  Offenses     2 errors | 0 warnings (2 offenses across 1 file)"
 `;
 
-exports[`CLI Output Formatting > formats GitHub Actions output correctly for clean file 1`] = `""`;
+exports[`CLI Output Formatting > formats GitHub Actions output correctly for clean file 1`] = `
+"✓ test/fixtures/clean-file.html.erb - No issues found
+
+
+ Summary:
+  Checked      1 file
+  Offenses     0 offenses"
+`;
 
 exports[`CLI Output Formatting > formats GitHub Actions output correctly for file with errors 1`] = `
-"::error file=test/fixtures/test-file-with-errors.html.erb,line=3,col=3::Missing required \`alt\` attribute on \`<img>\` tag. Add \`alt=""\` for decorative images or \`alt="description"\` for informative images. [html-img-require-alt]
+"::error file=test/fixtures/test-file-with-errors.html.erb,line=3,col=3,title=html-img-require-alt • @herb-tools/linter@0.6.1::Missing required \`alt\` attribute on \`<img>\` tag. Add \`alt=""\` for decorative images or \`alt="description"\` for informative images. [html-img-require-alt]%0A%0A%0Atest/fixtures/test-file-with-errors.html.erb:3:3%0A%0A      1 │ <div>%0A      2 │   <SPAN>Test content</SPAN>%0A  →   3 │   <img src="test.jpg">%0A        │    ~~~%0A      4 │ </div>%0A      5 │%0A
 
-::error file=test/fixtures/test-file-with-errors.html.erb,line=2,col=3::Opening tag name \`<SPAN>\` should be lowercase. Use \`<span>\` instead. [html-tag-name-lowercase]
+::error file=test/fixtures/test-file-with-errors.html.erb,line=2,col=3,title=html-tag-name-lowercase • @herb-tools/linter@0.6.1::Opening tag name \`<SPAN>\` should be lowercase. Use \`<span>\` instead. [html-tag-name-lowercase]%0A%0A%0Atest/fixtures/test-file-with-errors.html.erb:2:3%0A%0A      1 │ <div>%0A  →   2 │   <SPAN>Test content</SPAN>%0A        │    ~~~~%0A      3 │   <img src="test.jpg">%0A      4 │ </div>%0A
 
-::error file=test/fixtures/test-file-with-errors.html.erb,line=2,col=22::Closing tag name \`</SPAN>\` should be lowercase. Use \`</span>\` instead. [html-tag-name-lowercase]"
+::error file=test/fixtures/test-file-with-errors.html.erb,line=2,col=22,title=html-tag-name-lowercase • @herb-tools/linter@0.6.1::Closing tag name \`</SPAN>\` should be lowercase. Use \`</span>\` instead. [html-tag-name-lowercase]%0A%0A%0Atest/fixtures/test-file-with-errors.html.erb:2:22%0A%0A      1 │ <div>%0A  →   2 │   <SPAN>Test content</SPAN>%0A        │                       ~~~~%0A      3 │   <img src="test.jpg">%0A      4 │ </div>%0A
+
+[error] Missing required \`alt\` attribute on \`<img>\` tag. Add \`alt=""\` for decorative images or \`alt="description"\` for informative images. (html-img-require-alt)
+
+test/fixtures/test-file-with-errors.html.erb:3:3
+
+      1 │ <div>
+      2 │   <SPAN>Test content</SPAN>
+  →   3 │   <img src="test.jpg">
+        │    ~~~
+      4 │ </div>
+      5 │
+
+
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯  [1/3] ⎯⎯⎯⎯
+
+[error] Opening tag name \`<SPAN>\` should be lowercase. Use \`<span>\` instead. (html-tag-name-lowercase)
+
+test/fixtures/test-file-with-errors.html.erb:2:3
+
+      1 │ <div>
+  →   2 │   <SPAN>Test content</SPAN>
+        │    ~~~~
+      3 │   <img src="test.jpg">
+      4 │ </div>
+
+
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯  [2/3] ⎯⎯⎯⎯
+
+[error] Closing tag name \`</SPAN>\` should be lowercase. Use \`</span>\` instead. (html-tag-name-lowercase)
+
+test/fixtures/test-file-with-errors.html.erb:2:22
+
+      1 │ <div>
+  →   2 │   <SPAN>Test content</SPAN>
+        │                       ~~~~
+      3 │   <img src="test.jpg">
+      4 │ </div>
+
+ Rule offenses:
+  html-tag-name-lowercase (2 offenses in 1 file)
+  html-img-require-alt (1 offense in 1 file)
+
+
+ Summary:
+  Checked      1 file
+  Offenses     3 errors | 0 warnings (3 offenses across 1 file)"
 `;
 
 exports[`CLI Output Formatting > formats GitHub Actions output with --format=github option 1`] = `
-"::error file=test/fixtures/test-file-simple.html.erb,line=2,col=3::Opening tag name \`<SPAN>\` should be lowercase. Use \`<span>\` instead. [html-tag-name-lowercase]
+"[error] Opening tag name \`<SPAN>\` should be lowercase. Use \`<span>\` instead. (html-tag-name-lowercase)
 
-::error file=test/fixtures/test-file-simple.html.erb,line=2,col=22::Closing tag name \`</SPAN>\` should be lowercase. Use \`</span>\` instead. [html-tag-name-lowercase]"
+test/fixtures/test-file-simple.html.erb:2:3
+
+      1 │ <div>
+  →   2 │   <SPAN>Test content</SPAN>
+        │    ~~~~
+      3 │ </div>
+      4 │
+
+
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯  [1/2] ⎯⎯⎯⎯
+
+[error] Closing tag name \`</SPAN>\` should be lowercase. Use \`</span>\` instead. (html-tag-name-lowercase)
+
+test/fixtures/test-file-simple.html.erb:2:22
+
+      1 │ <div>
+  →   2 │   <SPAN>Test content</SPAN>
+        │                       ~~~~
+      3 │ </div>
+      4 │
+
+ Rule offenses:
+  html-tag-name-lowercase (2 offenses in 1 file)
+
+
+ Summary:
+  Checked      1 file
+  Offenses     2 errors | 0 warnings (2 offenses across 1 file)"
 `;
 
 exports[`CLI Output Formatting > formats JSON output correctly for bad file 1`] = `
@@ -561,9 +731,55 @@ test/fixtures/bad-file.html.erb:1:16
 `;
 
 exports[`CLI Output Formatting > uses GitHub Actions format by default when GITHUB_ACTIONS is true 1`] = `
-"::error file=test/fixtures/test-file-with-errors.html.erb,line=3,col=3::Missing required \`alt\` attribute on \`<img>\` tag. Add \`alt=""\` for decorative images or \`alt="description"\` for informative images. [html-img-require-alt]
+"::error file=test/fixtures/test-file-with-errors.html.erb,line=3,col=3,title=html-img-require-alt • @herb-tools/linter@0.6.1::Missing required \`alt\` attribute on \`<img>\` tag. Add \`alt=""\` for decorative images or \`alt="description"\` for informative images. [html-img-require-alt]%0A%0A%0Atest/fixtures/test-file-with-errors.html.erb:3:3%0A%0A      1 │ <div>%0A      2 │   <SPAN>Test content</SPAN>%0A  →   3 │   <img src="test.jpg">%0A        │    ~~~%0A      4 │ </div>%0A      5 │%0A
 
-::error file=test/fixtures/test-file-with-errors.html.erb,line=2,col=3::Opening tag name \`<SPAN>\` should be lowercase. Use \`<span>\` instead. [html-tag-name-lowercase]
+::error file=test/fixtures/test-file-with-errors.html.erb,line=2,col=3,title=html-tag-name-lowercase • @herb-tools/linter@0.6.1::Opening tag name \`<SPAN>\` should be lowercase. Use \`<span>\` instead. [html-tag-name-lowercase]%0A%0A%0Atest/fixtures/test-file-with-errors.html.erb:2:3%0A%0A      1 │ <div>%0A  →   2 │   <SPAN>Test content</SPAN>%0A        │    ~~~~%0A      3 │   <img src="test.jpg">%0A      4 │ </div>%0A
 
-::error file=test/fixtures/test-file-with-errors.html.erb,line=2,col=22::Closing tag name \`</SPAN>\` should be lowercase. Use \`</span>\` instead. [html-tag-name-lowercase]"
+::error file=test/fixtures/test-file-with-errors.html.erb,line=2,col=22,title=html-tag-name-lowercase • @herb-tools/linter@0.6.1::Closing tag name \`</SPAN>\` should be lowercase. Use \`</span>\` instead. [html-tag-name-lowercase]%0A%0A%0Atest/fixtures/test-file-with-errors.html.erb:2:22%0A%0A      1 │ <div>%0A  →   2 │   <SPAN>Test content</SPAN>%0A        │                       ~~~~%0A      3 │   <img src="test.jpg">%0A      4 │ </div>%0A
+
+[error] Missing required \`alt\` attribute on \`<img>\` tag. Add \`alt=""\` for decorative images or \`alt="description"\` for informative images. (html-img-require-alt)
+
+test/fixtures/test-file-with-errors.html.erb:3:3
+
+      1 │ <div>
+      2 │   <SPAN>Test content</SPAN>
+  →   3 │   <img src="test.jpg">
+        │    ~~~
+      4 │ </div>
+      5 │
+
+
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯  [1/3] ⎯⎯⎯⎯
+
+[error] Opening tag name \`<SPAN>\` should be lowercase. Use \`<span>\` instead. (html-tag-name-lowercase)
+
+test/fixtures/test-file-with-errors.html.erb:2:3
+
+      1 │ <div>
+  →   2 │   <SPAN>Test content</SPAN>
+        │    ~~~~
+      3 │   <img src="test.jpg">
+      4 │ </div>
+
+
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯  [2/3] ⎯⎯⎯⎯
+
+[error] Closing tag name \`</SPAN>\` should be lowercase. Use \`</span>\` instead. (html-tag-name-lowercase)
+
+test/fixtures/test-file-with-errors.html.erb:2:22
+
+      1 │ <div>
+  →   2 │   <SPAN>Test content</SPAN>
+        │                       ~~~~
+      3 │   <img src="test.jpg">
+      4 │ </div>
+
+ Rule offenses:
+  html-tag-name-lowercase (2 offenses in 1 file)
+  html-img-require-alt (1 offense in 1 file)
+
+
+ Summary:
+  Checked      1 file
+  Offenses     3 errors | 0 warnings (3 offenses across 1 file)"
 `;

--- a/javascript/packages/linter/test/formatters/github-actions-formatter.test.ts
+++ b/javascript/packages/linter/test/formatters/github-actions-formatter.test.ts
@@ -1,14 +1,16 @@
 import { describe, test, expect, vi, beforeEach, afterEach } from "vitest"
 import { GitHubActionsFormatter } from "../../src/cli/formatters/github-actions-formatter.js"
+import { name, version } from "../../package.json"
 import type { ProcessedFile } from "../../src/cli/file-processor.js"
 import type { Diagnostic } from "@herb-tools/core"
 
 describe("GitHubActionsFormatter", () => {
   let formatter: GitHubActionsFormatter
   let consoleLogSpy: ReturnType<typeof vi.spyOn>
+  const linterTitle = `${name}@${version}`
 
   beforeEach(() => {
-    formatter = new GitHubActionsFormatter()
+    formatter = new GitHubActionsFormatter(true, false)
     consoleLogSpy = vi.spyOn(console, "log").mockImplementation()
   })
 
@@ -45,9 +47,8 @@ describe("GitHubActionsFormatter", () => {
     await formatter.format(files)
 
     expect(consoleLogSpy).toHaveBeenCalledWith(
-      "\n::error file=test.html.erb,line=10,col=5::Test error message [test-rule]"
+      `\n::error file=test.html.erb,line=10,col=5,title=test-rule • ${linterTitle}::Test error message [test-rule]%0A%0A%0Atest.html.erb:10:5%0A%0A%0A`
     )
-    expect(consoleLogSpy).toHaveBeenCalledWith() // Final newline
   })
 
   test("formats warning diagnostics correctly", async () => {
@@ -60,7 +61,7 @@ describe("GitHubActionsFormatter", () => {
     await formatter.format(files)
 
     expect(consoleLogSpy).toHaveBeenCalledWith(
-      "\n::warning file=test.html.erb,line=10,col=5::Test error message [test-rule]"
+      `\n::warning file=test.html.erb,line=10,col=5,title=test-rule • ${linterTitle}::Test error message [test-rule]%0A%0A%0Atest.html.erb:10:5%0A%0A%0A`
     )
   })
 
@@ -74,7 +75,7 @@ describe("GitHubActionsFormatter", () => {
     await formatter.format(files)
 
     expect(consoleLogSpy).toHaveBeenCalledWith(
-      "\n::error file=test.html.erb,line=10,col=5::Error: 100%25 failure rate [test-rule]"
+      `\n::error file=test.html.erb,line=10,col=5,title=test-rule • ${linterTitle}::Error: 100%25 failure rate [test-rule]%0A%0A%0Atest.html.erb:10:5%0A%0A%0A`
     )
   })
 
@@ -88,7 +89,7 @@ describe("GitHubActionsFormatter", () => {
     await formatter.format(files)
 
     expect(consoleLogSpy).toHaveBeenCalledWith(
-      "\n::error file=test.html.erb,line=10,col=5::Error on line 1%0AContinued on line 2 [test-rule]"
+      `\n::error file=test.html.erb,line=10,col=5,title=test-rule • ${linterTitle}::Error on line 1%0AContinued on line 2 [test-rule]%0A%0AContinued on line 2 (test-rule)%0A%0Atest.html.erb:10:5%0A%0A%0A`
     )
   })
 
@@ -102,7 +103,7 @@ describe("GitHubActionsFormatter", () => {
     await formatter.format(files)
 
     expect(consoleLogSpy).toHaveBeenCalledWith(
-      "\n::error file=test.html.erb,line=10,col=5::Error%0DMessage [test-rule]"
+      `\n::error file=test.html.erb,line=10,col=5,title=test-rule • ${linterTitle}::Error%0DMessage [test-rule]%0A%0A%0Atest.html.erb:10:5%0A%0A%0A`
     )
   })
 
@@ -134,12 +135,11 @@ describe("GitHubActionsFormatter", () => {
     await formatter.format(files)
 
     expect(consoleLogSpy).toHaveBeenCalledWith(
-      "\n::error file=test1.html.erb,line=10,col=5::Error 1 [test-rule]"
+      `\n::error file=test1.html.erb,line=10,col=5,title=test-rule • ${linterTitle}::Error 1 [test-rule]%0A%0A%0Atest1.html.erb:10:5%0A%0A%0A`
     )
     expect(consoleLogSpy).toHaveBeenCalledWith(
-      "\n::warning file=test2.html.erb,line=5,col=10::Error 2 [test-rule]"
+      `\n::warning file=test2.html.erb,line=5,col=10,title=test-rule • ${linterTitle}::Error 2 [test-rule]%0A%0A%0Atest2.html.erb:5:10%0A%0A%0A`
     )
-    expect(consoleLogSpy).toHaveBeenCalledWith() // Final newline
   })
 
   test("handles diagnostics without code", async () => {
@@ -152,7 +152,7 @@ describe("GitHubActionsFormatter", () => {
     await formatter.format(files)
 
     expect(consoleLogSpy).toHaveBeenCalledWith(
-      "\n::error file=test.html.erb,line=10,col=5::Test error message"
+      "\n::error file=test.html.erb,line=10,col=5::Test error message%0A%0A%0Atest.html.erb:10:5%0A%0A%0A"
     )
   })
 
@@ -171,10 +171,10 @@ describe("GitHubActionsFormatter", () => {
     formatter.formatFile("test.html.erb", diagnostics)
 
     expect(consoleLogSpy).toHaveBeenCalledWith(
-      "\n::error file=test.html.erb,line=10,col=5::Error 1 [test-rule]"
+      `\n::error file=test.html.erb,line=10,col=5,title=test-rule • ${linterTitle}::Error 1 [test-rule]`
     )
     expect(consoleLogSpy).toHaveBeenCalledWith(
-      "\n::warning file=test.html.erb,line=10,col=5::Error 2 [test-rule]"
+      `\n::warning file=test.html.erb,line=10,col=5,title=test-rule • ${linterTitle}::Error 2 [test-rule]`
     )
   })
 
@@ -188,7 +188,7 @@ describe("GitHubActionsFormatter", () => {
     await formatter.format(files)
 
     expect(consoleLogSpy).toHaveBeenCalledWith(
-      "\n::error file=test%3Afile%2Cname%25.html.erb,line=10,col=5::Test error [test-rule]"
+      `\n::error file=test%3Afile%2Cname%25.html.erb,line=10,col=5,title=test-rule • ${linterTitle}::Test error [test-rule]%0A%0A%0Atest:file,name%25.html.erb:10:5%0A%0A%0A`
     )
   })
 
@@ -204,7 +204,7 @@ describe("GitHubActionsFormatter", () => {
     await formatter.format(files)
 
     expect(consoleLogSpy).toHaveBeenCalledWith(
-      "\n::error file=path%3Awith%2Cspecial%25chars%0Aand%0Dnewlines.erb,line=10,col=5::Error: 50%25 failure%0AOn multiple%0Dlines [test-rule]"
+      `\n::error file=path%3Awith%2Cspecial%25chars%0Aand%0Dnewlines.erb,line=10,col=5,title=test-rule • ${linterTitle}::Error: 50%25 failure%0AOn multiple%0Dlines [test-rule]%0A%0AOn multiple%0Dlines (test-rule)%0A%0Apath:with,special%25chars%0Aand%0Dnewlines.erb:10:5%0A%0A%0A`
     )
   })
 })


### PR DESCRIPTION
This pull request updates the linter CLI to output the highlighted part of the code in GitHub Actions annotation.


<img width="2744" height="926" alt="CleanShot 2025-08-27 at 00 39 24@2x" src="https://github.com/user-attachments/assets/2e4b58e9-373c-4a4b-9f1c-ac5edb76d51e" />
