### PR TITLE
Add printer version to CLI in formatter --version command

### DIFF
--- a/javascript/packages/formatter/src/cli.ts
+++ b/javascript/packages/formatter/src/cli.ts
@@ -6,7 +6,7 @@ import { join, resolve } from "path"
 import { Herb } from "@herb-tools/node-wasm"
 import { Formatter } from "./formatter.js"
 
-import { name, version } from "../package.json"
+import { name, version, dependencies } from "../package.json"
 
 const pluralize = (count: number, singular: string, plural: string = singular + 's'): string => {
   return count === 1 ? singular : plural
@@ -52,7 +52,9 @@ export class CLI {
 
       if (args.includes("--version") || args.includes("-v")) {
         console.log("Versions:")
-        console.log(`  ${name}@${version}, ${Herb.version}`.split(", ").join("\n  "))
+        console.log(`  ${name}@${version}`)
+        console.log(`  @herb-tools/printer@${dependencies['@herb-tools/printer']}`)
+        console.log(`  ${Herb.version}`.split(", ").join("\n  "))
 
         process.exit(0)
       }

--- a/javascript/packages/formatter/test/cli.test.ts
+++ b/javascript/packages/formatter/test/cli.test.ts
@@ -109,6 +109,7 @@ describe("CLI Binary", () => {
     expectExitCode(result, 0)
     expect(result.stdout).toContain("Versions:")
     expect(result.stdout).toContain("@herb-tools/formatter@")
+    expect(result.stdout).toContain("@herb-tools/printer@")
   })
 
   it("should show version when -v flag is provided", async () => {
@@ -117,6 +118,7 @@ describe("CLI Binary", () => {
     expectExitCode(result, 0)
     expect(result.stdout).toContain("Versions:")
     expect(result.stdout).toContain("@herb-tools/formatter@")
+    expect(result.stdout).toContain("@herb-tools/printer@")
   })
 
   it("should format HTML/ERB from stdin", async () => {


### PR DESCRIPTION
This resolves https://github.com/marcoroth/herb/issues/440. The output matches the example in the issue with additional `printer` version

```
$ npx @herb-tools/formatter --version
Versions:
  @herb-tools/formatter@0.6.1
  @herb-tools/printer@0.6.1
  @herb-tools/node-wasm@0.6.1
  @herb-tools/core@0.6.1
  libprism@1.4.0
  libherb@0.6.1 (WebAssembly)
```

Can also do this dynamically, but results in some duplicates like `@herb-tools/core@0.6.1`

```
$ npx @herb-tools/formatter --version
Versions:
  @herb-tools/formatter@0.6.1
  @herb-tools/core@0.6.1
  @herb-tools/printer@0.6.1
  @herb-tools/node-wasm@0.6.1
  @herb-tools/core@0.6.1
  libprism@1.4.0
  libherb@0.6.1 (WebAssembly)
```