### PR TITLE
Linter: Remove `no-title-attribute` and `navigation-has-label` from default rules

### DIFF
--- a/javascript/packages/linter/src/default-rules.ts
+++ b/javascript/packages/linter/src/default-rules.ts
@@ -19,7 +19,7 @@ import { HTMLAvoidBothDisabledAndAriaDisabledRule } from "./rules/html-avoid-bot
 import { HTMLBooleanAttributesNoValueRule } from "./rules/html-boolean-attributes-no-value.js"
 import { HTMLIframeHasTitleRule } from "./rules/html-iframe-has-title.js"
 import { HTMLImgRequireAltRule } from "./rules/html-img-require-alt.js"
-import { HTMLNavigationHasLabelRule } from "./rules/html-navigation-has-label.js"
+// import { HTMLNavigationHasLabelRule } from "./rules/html-navigation-has-label.js"
 import { HTMLNoAriaHiddenOnFocusableRule } from "./rules/html-no-aria-hidden-on-focusable.js"
 // import { HTMLNoBlockInsideInlineRule } from "./rules/html-no-block-inside-inline.js"
 import { HTMLNoDuplicateAttributesRule } from "./rules/html-no-duplicate-attributes.js"
@@ -28,7 +28,7 @@ import { HTMLNoEmptyHeadingsRule } from "./rules/html-no-empty-headings.js"
 import { HTMLNoNestedLinksRule } from "./rules/html-no-nested-links.js"
 import { HTMLNoPositiveTabIndexRule } from "./rules/html-no-positive-tab-index.js"
 import { HTMLNoSelfClosingRule } from "./rules/html-no-self-closing.js"
-import { HTMLNoTitleAttributeRule } from "./rules/html-no-title-attribute.js"
+// import { HTMLNoTitleAttributeRule } from "./rules/html-no-title-attribute.js"
 import { HTMLTagNameLowercaseRule } from "./rules/html-tag-name-lowercase.js"
 import { ParserNoErrorsRule } from "./rules/parser-no-errors.js"
 import { SVGTagNameCapitalizationRule } from "./rules/svg-tag-name-capitalization.js"
@@ -53,7 +53,7 @@ export const defaultRules: RuleClass[] = [
   HTMLBooleanAttributesNoValueRule,
   HTMLIframeHasTitleRule,
   HTMLImgRequireAltRule,
-  HTMLNavigationHasLabelRule,
+  // HTMLNavigationHasLabelRule,
   HTMLNoAriaHiddenOnFocusableRule,
   // HTMLNoBlockInsideInlineRule,
   HTMLNoDuplicateAttributesRule,
@@ -62,7 +62,7 @@ export const defaultRules: RuleClass[] = [
   HTMLNoNestedLinksRule,
   HTMLNoPositiveTabIndexRule,
   HTMLNoSelfClosingRule,
-  HTMLNoTitleAttributeRule,
+  // HTMLNoTitleAttributeRule,
   HTMLTagNameLowercaseRule,
   ParserNoErrorsRule,
   SVGTagNameCapitalizationRule,

--- a/javascript/packages/linter/test/__snapshots__/cli.test.ts.snap
+++ b/javascript/packages/linter/test/__snapshots__/cli.test.ts.snap
@@ -519,7 +519,7 @@ exports[`CLI Output Formatting > formats JSON output correctly for bad file 1`] 
   "summary": {
     "filesChecked": 1,
     "filesWithOffenses": 1,
-    "ruleCount": 31,
+    "ruleCount": 29,
     "totalErrors": 2,
     "totalOffenses": 2,
     "totalWarnings": 0,
@@ -537,7 +537,7 @@ exports[`CLI Output Formatting > formats JSON output correctly for clean file 1`
   "summary": {
     "filesChecked": 1,
     "filesWithOffenses": 0,
-    "ruleCount": 31,
+    "ruleCount": 29,
     "totalErrors": 0,
     "totalOffenses": 0,
     "totalWarnings": 0,
@@ -607,7 +607,7 @@ exports[`CLI Output Formatting > formats JSON output correctly for file with err
   "summary": {
     "filesChecked": 1,
     "filesWithOffenses": 1,
-    "ruleCount": 31,
+    "ruleCount": 29,
     "totalErrors": 3,
     "totalOffenses": 3,
     "totalWarnings": 0,


### PR DESCRIPTION
After some discussion and feedback from @brunoprietog in #414 this pull request removes the `html-no-title-attribute` and `html-navigation-has-label` linter rules from the default rules.

As soon as we have a better way and enabling/disabling and configuring linter rules we might be able to bring them back. But for now,  we keep them disabled as they cause more trouble than they help.