### PR TITLE
Add `bundle exec` to rake tasks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,7 +103,7 @@ Finished lexing in:
 We use `rake` and `rake-compiler` to compile the Ruby extension. Running rake will generate the needed templates, run make, build the needed artifacts, and run the Ruby tests.
 
 ```bash
-rake
+bundle exec rake
 ```
 
 If `rake` was successful you can use `bundle console` to interact with `Herb`:
@@ -131,7 +131,7 @@ make test && ./run_herb_tests
 #### For the Ruby Tests
 
 ```bash
-rake test
+bundle exec rake test
 ```
 
 ### Clean

--- a/bin/integration
+++ b/bin/integration
@@ -2,8 +2,9 @@
 
 set -e  # Exit on error
 
-rake clean
-rake
+bundle exec rake clean
+bundle install
+bundle exec rake
 
 ./run_herb_tests
 


### PR DESCRIPTION
Fixes  #447

Also adds `bundle install` between the `clean` task and the `rake` task because `clean` removes the prism path and rake fails because of it.

**Without `bundle install`:**
```bash
bin/integration
rm -f herb run_herb_tests build/libherb.bundle  ext/herb/build/libherb.bundle
rm -rf src/analyze.o src/analyze_helpers.o src/analyzed_ruby.o src/array.o src/ast_node.o src/ast_nodes.o src/ast_pretty_print.o src/buffer.o src/errors.o src/extract.o src/herb.o src/html_util.o src/io.o src/json.o src/lexer.o src/lexer_peek_helpers.o src/location.o src/main.o src/memory.o src/parser.o src/parser_helpers.o src/position.o src/pretty_print.o src/prism_helpers.o src/range.o src/ruby_parser.o src/token.o src/token_matchers.o src/utf8.o src/util.o src/visitor.o test/c/main.o test/c/test_array.o test/c/test_buffer.o test/c/test_herb.o test/c/test_html_util.o test/c/test_io.o test/c/test_json.o test/c/test_lex.o test/c/test_token.o test/c/test_util.o  lib/herb/*.bundle tmp
rm -rf /Users/miguel/code/herb/vendor/bundle/ruby/3.4.0/bundler/gems/prism-266f83de6a2b
https://github.com/ruby/prism.git (at v1.4.0@266f83d) is not yet checked out. Run `bundle install` first.
```