### PR TITLE
Ruby CLI: Squelch Processing output when silent is passed in

### DIFF
--- a/lib/herb/cli.rb
+++ b/lib/herb/cli.rb
@@ -110,6 +110,7 @@ class Herb::CLI
                   project.no_interactive = no_interactive
                   project.no_log_file = no_log_file
                   project.no_timing = no_timing
+                  project.silent = silent
                   has_issues = project.parse!
                   exit(has_issues ? 1 : 0)
                 when "parse"

--- a/lib/herb/project.rb
+++ b/lib/herb/project.rb
@@ -12,7 +12,7 @@ require "stringio"
 
 module Herb
   class Project
-    attr_accessor :project_path, :output_file, :no_interactive, :no_log_file, :no_timing
+    attr_accessor :project_path, :output_file, :no_interactive, :no_log_file, :no_timing, :silent
 
     def interactive?
       return false if no_interactive
@@ -106,7 +106,7 @@ module Herb
           else
             relative_path = file_path.sub("#{project_path}/", "")
           end
-          puts "Processing [#{index + 1}/#{files.count}]: #{relative_path}"
+          puts "Processing [#{index + 1}/#{files.count}]: #{relative_path}" unless silent
 
           if interactive?
             if failed_files.any?
@@ -240,7 +240,7 @@ module Herb
           puts "Completed processing all files."
           print "\e[H\e[2J"
         else
-          puts "Completed processing all files."
+          puts "Completed processing all files." unless silent
         end
 
         log.puts ""


### PR DESCRIPTION
Fixes #347


### Without `silent` flag:
```
ruby -I lib exe/herb analyze examples --no-log-file --non-interactive
Processing [1/16]: attributes_with_empty_value.html.erb
Processing [2/16]: begin.html.erb
Processing [3/16]: block.html.erb
Processing [4/16]: case_when.html.erb
Processing [5/16]: comment.html.erb
Processing [6/16]: doctype.html.erb
Processing [7/16]: erb.html.erb
Processing [8/16]: for.html.erb
Processing [9/16]: if_else.html.erb
Processing [10/16]: line-wrap.html.erb
Processing [11/16]: nested_if_and_blocks.html.erb
Processing [12/16]: simple_block.html.erb
Processing [13/16]: simple_erb.html.erb
Processing [14/16]: test.html.erb
Processing [15/16]: until.html.erb
Processing [16/16]: while.html.erb
Completed processing all files.
--- SUMMARY --------------------------------------------------------------------
Total files: 16
✅ Successful: 16 (100.0%)
❌ Failed: 0 (0.0%)
⚠️ Parse errors: 0 (0.0%)
⏱️ Timed out: 0 (0.0%)

⏱️ Total time: 31.9ms
```


### With `silent` flag:

```bash
ruby -I lib exe/herb analyze examples --no-log-file --non-interactive --silent
--- SUMMARY --------------------------------------------------------------------
Total files: 16
✅ Successful: 16 (100.0%)
❌ Failed: 0 (0.0%)
⚠️ Parse errors: 0 (0.0%)
⏱️ Timed out: 0 (0.0%)

⏱️ Total time: 35.15ms
```