### PR TITLE
Add `TOKEN_BACKTICK` to list of text content tokens

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -1121,6 +1121,7 @@ static void parser_parse_in_data_state(parser_T* parser, array_T* children, arra
           parser,
           TOKEN_AMPERSAND,
           TOKEN_AT,
+          TOKEN_BACKTICK,
           TOKEN_CHARACTER,
           TOKEN_COLON,
           TOKEN_DASH,


### PR DESCRIPTION
This seems to fix https://github.com/marcoroth/herb/issues/467 but I might be missing some other bits and bobs