### PR TITLE
Linter: Fix `--version` flag for CLI

### DIFF
--- a/javascript/packages/linter/src/cli.ts
+++ b/javascript/packages/linter/src/cli.ts
@@ -6,6 +6,7 @@ import { dirname, resolve, relative } from "path"
 import { ArgumentParser, type FormatOption } from "./cli/argument-parser.js"
 import { FileProcessor } from "./cli/file-processor.js"
 import { OutputManager } from "./cli/output-manager.js"
+import { dependencies, name, version } from "../package.json"
 
 export * from "./cli/index.js"
 
@@ -132,6 +133,18 @@ export class CLI {
   }
 
   async run() {
+    const args = process.argv.slice(2);
+
+    if (args.includes("--version") || args.includes("-v")) {
+      console.log("Versions:")
+      console.log(`  ${name}@${version}`)
+      console.log(
+        `  @herb-tools/printer@${dependencies["@herb-tools/printer"]}`,
+      )
+      console.log(`  ${version}`.split(", ").join("\n  "))
+
+      process.exit(0)
+    }
     const startTime = Date.now()
     const startDate = new Date()
 

--- a/javascript/packages/linter/src/cli.ts
+++ b/javascript/packages/linter/src/cli.ts
@@ -6,7 +6,6 @@ import { dirname, resolve, relative } from "path"
 import { ArgumentParser, type FormatOption } from "./cli/argument-parser.js"
 import { FileProcessor } from "./cli/file-processor.js"
 import { OutputManager } from "./cli/output-manager.js"
-import { dependencies, name, version } from "../package.json"
 
 export * from "./cli/index.js"
 
@@ -125,7 +124,7 @@ export class CLI {
   }
 
   protected async beforeProcess(): Promise<void> {
-    await Herb.load()
+    // Hook for subclasses to add custom output before processing
   }
 
   protected async afterProcess(_results: any, _outputOptions: any): Promise<void> {
@@ -133,18 +132,8 @@ export class CLI {
   }
 
   async run() {
-    const args = process.argv.slice(2);
+    await Herb.load()
 
-    if (args.includes("--version") || args.includes("-v")) {
-      console.log("Versions:")
-      console.log(`  ${name}@${version}`)
-      console.log(
-        `  @herb-tools/printer@${dependencies["@herb-tools/printer"]}`,
-      )
-      console.log(`  ${version}`.split(", ").join("\n  "))
-
-      process.exit(0)
-    }
     const startTime = Date.now()
     const startDate = new Date()
 

--- a/javascript/packages/linter/src/cli/argument-parser.ts
+++ b/javascript/packages/linter/src/cli/argument-parser.ts
@@ -9,7 +9,7 @@ import { Herb } from "@herb-tools/node-wasm"
 import { THEME_NAMES, DEFAULT_THEME } from "@herb-tools/highlighter"
 import type { ThemeInput } from "@herb-tools/highlighter"
 
-import { name, version } from "../../package.json"
+import { name, version, dependencies } from "../../package.json"
 
 export type FormatOption = "simple" | "detailed" | "json"
 
@@ -74,7 +74,9 @@ export class ArgumentParser {
 
     if (values.version) {
       console.log("Versions:")
-      console.log(`  ${name}@${version}, ${Herb.version}`.split(", ").join("\n  "))
+      console.log(`  ${name}@${version}`)
+      console.log(`  @herb-tools/printer@${dependencies["@herb-tools/printer"]}`)
+      console.log(`  ${Herb.version}`.split(", ").join("\n  "))
       process.exit(0)
     }
 


### PR DESCRIPTION
Check first if the user just wants to see the version of their linter. If so, print and exit.

Closes #437 