### PR TITLE
Allow Colon `:` in HTML Attribute Names

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -805,6 +805,20 @@ static AST_HTML_OPEN_TAG_NODE_T* parser_parse_html_open_tag(parser_T* parser) {
       continue;
     }
 
+    if (parser->current_token->type == TOKEN_COLON) {
+      lexer_T lexer_copy = *parser->lexer;
+      token_T* next_token = lexer_next_token(&lexer_copy);
+
+      if (next_token && next_token->type == TOKEN_IDENTIFIER) {
+        token_free(next_token);
+        array_append(children, parser_parse_html_attribute(parser));
+
+        continue;
+      }
+
+      token_free(next_token);
+    }
+
     parser_append_unexpected_error(
       parser,
       "Unexpected Token",

--- a/test/parser/attributes_test.rb
+++ b/test/parser/attributes_test.rb
@@ -159,5 +159,37 @@ module Parser
     test "attribute with backtick containing HTML (invalid)" do
       assert_parsed_snapshot(%(<div data-template=`<span>Hello</span>`></div>))
     end
+
+    test "Vue-style directive attribute with value" do
+      assert_parsed_snapshot(%(<div :value="something"></div>))
+    end
+
+    test "Vue-style directive attributes multiple" do
+      assert_parsed_snapshot(%(<input :model="user" :disabled="isDisabled" :class="className"></input>))
+    end
+
+    test "Vue-style directive attribute without value" do
+      assert_parsed_snapshot(%(<div :disabled></div>))
+    end
+
+    test "Mixed Vue directives and regular attributes" do
+      assert_parsed_snapshot(%(<div id="app" :class="dynamicClass" data-test="static"></div>))
+    end
+
+    test "Standalone colon with space is invalid" do
+      assert_parsed_snapshot(%(<div : class="hello"></div>))
+    end
+
+    test "Colon immediately followed by attribute name is valid" do
+      assert_parsed_snapshot(%(<div :class="hello"></div>))
+    end
+
+    test "Double colon is invalid" do
+      assert_parsed_snapshot(%(<div ::value="hello"></div>))
+    end
+
+    test "Vue directive with namespace-like syntax" do
+      assert_parsed_snapshot(%(<div :v-model="user"></div>))
+    end
   end
 end

--- a/test/snapshots/parser/attributes_test/test_0038_Vue-style_directive_attribute_with_value_48a4fb492a8544d35ffb4d589f5a602c.txt
+++ b/test/snapshots/parser/attributes_test/test_0038_Vue-style_directive_attribute_with_value_48a4fb492a8544d35ffb4d589f5a602c.txt
@@ -1,0 +1,42 @@
+@ DocumentNode (location: (1:0)-(1:30))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:30))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:24))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "div" (location: (1:1)-(1:4))
+        │       ├── tag_closing: ">" (location: (1:23)-(1:24))
+        │       ├── children: (1 item)
+        │       │   └── @ HTMLAttributeNode (location: (1:5)-(1:23))
+        │       │       ├── name:
+        │       │       │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:11))
+        │       │       │       └── children: (1 item)
+        │       │       │           └── @ LiteralNode (location: (1:5)-(1:11))
+        │       │       │               └── content: ":value"
+        │       │       │
+        │       │       │
+        │       │       ├── equals: "=" (location: (1:11)-(1:12))
+        │       │       └── value:
+        │       │           └── @ HTMLAttributeValueNode (location: (1:12)-(1:23))
+        │       │               ├── open_quote: """ (location: (1:12)-(1:13))
+        │       │               ├── children: (1 item)
+        │       │               │   └── @ LiteralNode (location: (1:13)-(1:22))
+        │       │               │       └── content: "something"
+        │       │               │
+        │       │               ├── close_quote: """ (location: (1:22)-(1:23))
+        │       │               └── quoted: true
+        │       │
+        │       │
+        │       └── is_void: false
+        │
+        ├── tag_name: "div" (location: (1:1)-(1:4))
+        ├── body: []
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:24)-(1:30))
+        │       ├── tag_opening: "</" (location: (1:24)-(1:26))
+        │       ├── tag_name: "div" (location: (1:26)-(1:29))
+        │       ├── children: []
+        │       └── tag_closing: ">" (location: (1:29)-(1:30))
+        │
+        ├── is_void: false
+        └── source: "HTML"

--- a/test/snapshots/parser/attributes_test/test_0039_Vue-style_directive_attributes_multiple_4f1d1b98f3b9c869967323f090d9afee.txt
+++ b/test/snapshots/parser/attributes_test/test_0039_Vue-style_directive_attributes_multiple_4f1d1b98f3b9c869967323f090d9afee.txt
@@ -1,0 +1,89 @@
+@ DocumentNode (location: (1:0)-(1:71))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:63))
+    │   ├── open_tag:
+    │   │   └── @ HTMLOpenTagNode (location: (1:0)-(1:63))
+    │   │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+    │   │       ├── tag_name: "input" (location: (1:1)-(1:6))
+    │   │       ├── tag_closing: ">" (location: (1:62)-(1:63))
+    │   │       ├── children: (3 items)
+    │   │       │   ├── @ HTMLAttributeNode (location: (1:7)-(1:20))
+    │   │       │   │   ├── name:
+    │   │       │   │   │   └── @ HTMLAttributeNameNode (location: (1:7)-(1:13))
+    │   │       │   │   │       └── children: (1 item)
+    │   │       │   │   │           └── @ LiteralNode (location: (1:7)-(1:13))
+    │   │       │   │   │               └── content: ":model"
+    │   │       │   │   │
+    │   │       │   │   │
+    │   │       │   │   ├── equals: "=" (location: (1:13)-(1:14))
+    │   │       │   │   └── value:
+    │   │       │   │       └── @ HTMLAttributeValueNode (location: (1:14)-(1:20))
+    │   │       │   │           ├── open_quote: """ (location: (1:14)-(1:15))
+    │   │       │   │           ├── children: (1 item)
+    │   │       │   │           │   └── @ LiteralNode (location: (1:15)-(1:19))
+    │   │       │   │           │       └── content: "user"
+    │   │       │   │           │
+    │   │       │   │           ├── close_quote: """ (location: (1:19)-(1:20))
+    │   │       │   │           └── quoted: true
+    │   │       │   │
+    │   │       │   │
+    │   │       │   ├── @ HTMLAttributeNode (location: (1:21)-(1:43))
+    │   │       │   │   ├── name:
+    │   │       │   │   │   └── @ HTMLAttributeNameNode (location: (1:21)-(1:30))
+    │   │       │   │   │       └── children: (1 item)
+    │   │       │   │   │           └── @ LiteralNode (location: (1:21)-(1:30))
+    │   │       │   │   │               └── content: ":disabled"
+    │   │       │   │   │
+    │   │       │   │   │
+    │   │       │   │   ├── equals: "=" (location: (1:30)-(1:31))
+    │   │       │   │   └── value:
+    │   │       │   │       └── @ HTMLAttributeValueNode (location: (1:31)-(1:43))
+    │   │       │   │           ├── open_quote: """ (location: (1:31)-(1:32))
+    │   │       │   │           ├── children: (1 item)
+    │   │       │   │           │   └── @ LiteralNode (location: (1:32)-(1:42))
+    │   │       │   │           │       └── content: "isDisabled"
+    │   │       │   │           │
+    │   │       │   │           ├── close_quote: """ (location: (1:42)-(1:43))
+    │   │       │   │           └── quoted: true
+    │   │       │   │
+    │   │       │   │
+    │   │       │   └── @ HTMLAttributeNode (location: (1:44)-(1:62))
+    │   │       │       ├── name:
+    │   │       │       │   └── @ HTMLAttributeNameNode (location: (1:44)-(1:50))
+    │   │       │       │       └── children: (1 item)
+    │   │       │       │           └── @ LiteralNode (location: (1:44)-(1:50))
+    │   │       │       │               └── content: ":class"
+    │   │       │       │
+    │   │       │       │
+    │   │       │       ├── equals: "=" (location: (1:50)-(1:51))
+    │   │       │       └── value:
+    │   │       │           └── @ HTMLAttributeValueNode (location: (1:51)-(1:62))
+    │   │       │               ├── open_quote: """ (location: (1:51)-(1:52))
+    │   │       │               ├── children: (1 item)
+    │   │       │               │   └── @ LiteralNode (location: (1:52)-(1:61))
+    │   │       │               │       └── content: "className"
+    │   │       │               │
+    │   │       │               ├── close_quote: """ (location: (1:61)-(1:62))
+    │   │       │               └── quoted: true
+    │   │       │
+    │   │       │
+    │   │       └── is_void: false
+    │   │
+    │   ├── tag_name: "input" (location: (1:1)-(1:6))
+    │   ├── body: []
+    │   ├── close_tag: ∅
+    │   ├── is_void: true
+    │   └── source: "HTML"
+    │
+    └── @ HTMLCloseTagNode (location: (1:63)-(1:71))
+        ├── errors: (1 error)
+        │   └── @ VoidElementClosingTagError (location: (1:63)-(1:71))
+        │       ├── message: "`input` is a void element and should not be used as a closing tag. Use `<input>` or `<input />` instead of `</input>`."
+        │       ├── tag_name: "input" (location: (1:65)-(1:70))
+        │       ├── expected: "<input />"
+        │       └── found: "</input>"
+        │
+        ├── tag_opening: "</" (location: (1:63)-(1:65))
+        ├── tag_name: "input" (location: (1:65)-(1:70))
+        ├── children: []
+        └── tag_closing: ">" (location: (1:70)-(1:71))

--- a/test/snapshots/parser/attributes_test/test_0040_Vue-style_directive_attribute_without_value_14a36e2ed468092336d9f6080e939190.txt
+++ b/test/snapshots/parser/attributes_test/test_0040_Vue-style_directive_attribute_without_value_14a36e2ed468092336d9f6080e939190.txt
@@ -1,0 +1,33 @@
+@ DocumentNode (location: (1:0)-(1:21))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:21))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:15))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "div" (location: (1:1)-(1:4))
+        │       ├── tag_closing: ">" (location: (1:14)-(1:15))
+        │       ├── children: (1 item)
+        │       │   └── @ HTMLAttributeNode (location: (1:5)-(1:14))
+        │       │       ├── name:
+        │       │       │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:14))
+        │       │       │       └── children: (1 item)
+        │       │       │           └── @ LiteralNode (location: (1:5)-(1:14))
+        │       │       │               └── content: ":disabled"
+        │       │       │
+        │       │       │
+        │       │       ├── equals: ∅
+        │       │       └── value: ∅
+        │       │
+        │       └── is_void: false
+        │
+        ├── tag_name: "div" (location: (1:1)-(1:4))
+        ├── body: []
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:15)-(1:21))
+        │       ├── tag_opening: "</" (location: (1:15)-(1:17))
+        │       ├── tag_name: "div" (location: (1:17)-(1:20))
+        │       ├── children: []
+        │       └── tag_closing: ">" (location: (1:20)-(1:21))
+        │
+        ├── is_void: false
+        └── source: "HTML"

--- a/test/snapshots/parser/attributes_test/test_0041_Mixed_Vue_directives_and_regular_attributes_355d0da3aae174783058e2ccec41ac05.txt
+++ b/test/snapshots/parser/attributes_test/test_0041_Mixed_Vue_directives_and_regular_attributes_355d0da3aae174783058e2ccec41ac05.txt
@@ -1,0 +1,82 @@
+@ DocumentNode (location: (1:0)-(1:61))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:61))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:55))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "div" (location: (1:1)-(1:4))
+        │       ├── tag_closing: ">" (location: (1:54)-(1:55))
+        │       ├── children: (3 items)
+        │       │   ├── @ HTMLAttributeNode (location: (1:5)-(1:13))
+        │       │   │   ├── name:
+        │       │   │   │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:7))
+        │       │   │   │       └── children: (1 item)
+        │       │   │   │           └── @ LiteralNode (location: (1:5)-(1:7))
+        │       │   │   │               └── content: "id"
+        │       │   │   │
+        │       │   │   │
+        │       │   │   ├── equals: "=" (location: (1:7)-(1:8))
+        │       │   │   └── value:
+        │       │   │       └── @ HTMLAttributeValueNode (location: (1:8)-(1:13))
+        │       │   │           ├── open_quote: """ (location: (1:8)-(1:9))
+        │       │   │           ├── children: (1 item)
+        │       │   │           │   └── @ LiteralNode (location: (1:9)-(1:12))
+        │       │   │           │       └── content: "app"
+        │       │   │           │
+        │       │   │           ├── close_quote: """ (location: (1:12)-(1:13))
+        │       │   │           └── quoted: true
+        │       │   │
+        │       │   │
+        │       │   ├── @ HTMLAttributeNode (location: (1:14)-(1:35))
+        │       │   │   ├── name:
+        │       │   │   │   └── @ HTMLAttributeNameNode (location: (1:14)-(1:20))
+        │       │   │   │       └── children: (1 item)
+        │       │   │   │           └── @ LiteralNode (location: (1:14)-(1:20))
+        │       │   │   │               └── content: ":class"
+        │       │   │   │
+        │       │   │   │
+        │       │   │   ├── equals: "=" (location: (1:20)-(1:21))
+        │       │   │   └── value:
+        │       │   │       └── @ HTMLAttributeValueNode (location: (1:21)-(1:35))
+        │       │   │           ├── open_quote: """ (location: (1:21)-(1:22))
+        │       │   │           ├── children: (1 item)
+        │       │   │           │   └── @ LiteralNode (location: (1:22)-(1:34))
+        │       │   │           │       └── content: "dynamicClass"
+        │       │   │           │
+        │       │   │           ├── close_quote: """ (location: (1:34)-(1:35))
+        │       │   │           └── quoted: true
+        │       │   │
+        │       │   │
+        │       │   └── @ HTMLAttributeNode (location: (1:36)-(1:54))
+        │       │       ├── name:
+        │       │       │   └── @ HTMLAttributeNameNode (location: (1:36)-(1:45))
+        │       │       │       └── children: (1 item)
+        │       │       │           └── @ LiteralNode (location: (1:36)-(1:45))
+        │       │       │               └── content: "data-test"
+        │       │       │
+        │       │       │
+        │       │       ├── equals: "=" (location: (1:45)-(1:46))
+        │       │       └── value:
+        │       │           └── @ HTMLAttributeValueNode (location: (1:46)-(1:54))
+        │       │               ├── open_quote: """ (location: (1:46)-(1:47))
+        │       │               ├── children: (1 item)
+        │       │               │   └── @ LiteralNode (location: (1:47)-(1:53))
+        │       │               │       └── content: "static"
+        │       │               │
+        │       │               ├── close_quote: """ (location: (1:53)-(1:54))
+        │       │               └── quoted: true
+        │       │
+        │       │
+        │       └── is_void: false
+        │
+        ├── tag_name: "div" (location: (1:1)-(1:4))
+        ├── body: []
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:55)-(1:61))
+        │       ├── tag_opening: "</" (location: (1:55)-(1:57))
+        │       ├── tag_name: "div" (location: (1:57)-(1:60))
+        │       ├── children: []
+        │       └── tag_closing: ">" (location: (1:60)-(1:61))
+        │
+        ├── is_void: false
+        └── source: "HTML"

--- a/test/snapshots/parser/attributes_test/test_0042_Standalone_colon_with_space_is_invalid_c037b25064b31d22c6c195361999c5b8.txt
+++ b/test/snapshots/parser/attributes_test/test_0042_Standalone_colon_with_space_is_invalid_c037b25064b31d22c6c195361999c5b8.txt
@@ -1,0 +1,49 @@
+@ DocumentNode (location: (1:0)-(1:27))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:27))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:21))
+        │       ├── errors: (1 error)
+        │       │   └── @ UnexpectedError (location: (1:5)-(1:6))
+        │       │       ├── message: "Unexpected Token. Expected: `TOKEN_IDENTIFIER, TOKEN_AT, TOKEN_ERB_START,TOKEN_WHITESPACE, or TOKEN_NEWLINE`, found: `TOKEN_COLON`."
+        │       │       ├── description: "Unexpected Token"
+        │       │       ├── expected: "TOKEN_IDENTIFIER, TOKEN_AT, TOKEN_ERB_START,TOKEN_WHITESPACE, or TOKEN_NEWLINE"
+        │       │       └── found: "TOKEN_COLON"
+        │       │
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "div" (location: (1:1)-(1:4))
+        │       ├── tag_closing: ">" (location: (1:20)-(1:21))
+        │       ├── children: (1 item)
+        │       │   └── @ HTMLAttributeNode (location: (1:7)-(1:20))
+        │       │       ├── name:
+        │       │       │   └── @ HTMLAttributeNameNode (location: (1:7)-(1:12))
+        │       │       │       └── children: (1 item)
+        │       │       │           └── @ LiteralNode (location: (1:7)-(1:12))
+        │       │       │               └── content: "class"
+        │       │       │
+        │       │       │
+        │       │       ├── equals: "=" (location: (1:12)-(1:13))
+        │       │       └── value:
+        │       │           └── @ HTMLAttributeValueNode (location: (1:13)-(1:20))
+        │       │               ├── open_quote: """ (location: (1:13)-(1:14))
+        │       │               ├── children: (1 item)
+        │       │               │   └── @ LiteralNode (location: (1:14)-(1:19))
+        │       │               │       └── content: "hello"
+        │       │               │
+        │       │               ├── close_quote: """ (location: (1:19)-(1:20))
+        │       │               └── quoted: true
+        │       │
+        │       │
+        │       └── is_void: false
+        │
+        ├── tag_name: "div" (location: (1:1)-(1:4))
+        ├── body: []
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:21)-(1:27))
+        │       ├── tag_opening: "</" (location: (1:21)-(1:23))
+        │       ├── tag_name: "div" (location: (1:23)-(1:26))
+        │       ├── children: []
+        │       └── tag_closing: ">" (location: (1:26)-(1:27))
+        │
+        ├── is_void: false
+        └── source: "HTML"

--- a/test/snapshots/parser/attributes_test/test_0043_Colon_immediately_followed_by_attribute_name_is_valid_e30b590c384b162d5019345f8083bfdb.txt
+++ b/test/snapshots/parser/attributes_test/test_0043_Colon_immediately_followed_by_attribute_name_is_valid_e30b590c384b162d5019345f8083bfdb.txt
@@ -1,0 +1,42 @@
+@ DocumentNode (location: (1:0)-(1:26))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:26))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:20))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "div" (location: (1:1)-(1:4))
+        │       ├── tag_closing: ">" (location: (1:19)-(1:20))
+        │       ├── children: (1 item)
+        │       │   └── @ HTMLAttributeNode (location: (1:5)-(1:19))
+        │       │       ├── name:
+        │       │       │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:11))
+        │       │       │       └── children: (1 item)
+        │       │       │           └── @ LiteralNode (location: (1:5)-(1:11))
+        │       │       │               └── content: ":class"
+        │       │       │
+        │       │       │
+        │       │       ├── equals: "=" (location: (1:11)-(1:12))
+        │       │       └── value:
+        │       │           └── @ HTMLAttributeValueNode (location: (1:12)-(1:19))
+        │       │               ├── open_quote: """ (location: (1:12)-(1:13))
+        │       │               ├── children: (1 item)
+        │       │               │   └── @ LiteralNode (location: (1:13)-(1:18))
+        │       │               │       └── content: "hello"
+        │       │               │
+        │       │               ├── close_quote: """ (location: (1:18)-(1:19))
+        │       │               └── quoted: true
+        │       │
+        │       │
+        │       └── is_void: false
+        │
+        ├── tag_name: "div" (location: (1:1)-(1:4))
+        ├── body: []
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:20)-(1:26))
+        │       ├── tag_opening: "</" (location: (1:20)-(1:22))
+        │       ├── tag_name: "div" (location: (1:22)-(1:25))
+        │       ├── children: []
+        │       └── tag_closing: ">" (location: (1:25)-(1:26))
+        │
+        ├── is_void: false
+        └── source: "HTML"

--- a/test/snapshots/parser/attributes_test/test_0044_Double_colon_is_invalid_f2b2354b82896dec0458b506ae56eb58.txt
+++ b/test/snapshots/parser/attributes_test/test_0044_Double_colon_is_invalid_f2b2354b82896dec0458b506ae56eb58.txt
@@ -1,0 +1,49 @@
+@ DocumentNode (location: (1:0)-(1:27))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:27))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:21))
+        │       ├── errors: (1 error)
+        │       │   └── @ UnexpectedError (location: (1:5)-(1:6))
+        │       │       ├── message: "Unexpected Token. Expected: `TOKEN_IDENTIFIER, TOKEN_AT, TOKEN_ERB_START,TOKEN_WHITESPACE, or TOKEN_NEWLINE`, found: `TOKEN_COLON`."
+        │       │       ├── description: "Unexpected Token"
+        │       │       ├── expected: "TOKEN_IDENTIFIER, TOKEN_AT, TOKEN_ERB_START,TOKEN_WHITESPACE, or TOKEN_NEWLINE"
+        │       │       └── found: "TOKEN_COLON"
+        │       │
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "div" (location: (1:1)-(1:4))
+        │       ├── tag_closing: ">" (location: (1:20)-(1:21))
+        │       ├── children: (1 item)
+        │       │   └── @ HTMLAttributeNode (location: (1:6)-(1:20))
+        │       │       ├── name:
+        │       │       │   └── @ HTMLAttributeNameNode (location: (1:6)-(1:12))
+        │       │       │       └── children: (1 item)
+        │       │       │           └── @ LiteralNode (location: (1:6)-(1:12))
+        │       │       │               └── content: ":value"
+        │       │       │
+        │       │       │
+        │       │       ├── equals: "=" (location: (1:12)-(1:13))
+        │       │       └── value:
+        │       │           └── @ HTMLAttributeValueNode (location: (1:13)-(1:20))
+        │       │               ├── open_quote: """ (location: (1:13)-(1:14))
+        │       │               ├── children: (1 item)
+        │       │               │   └── @ LiteralNode (location: (1:14)-(1:19))
+        │       │               │       └── content: "hello"
+        │       │               │
+        │       │               ├── close_quote: """ (location: (1:19)-(1:20))
+        │       │               └── quoted: true
+        │       │
+        │       │
+        │       └── is_void: false
+        │
+        ├── tag_name: "div" (location: (1:1)-(1:4))
+        ├── body: []
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:21)-(1:27))
+        │       ├── tag_opening: "</" (location: (1:21)-(1:23))
+        │       ├── tag_name: "div" (location: (1:23)-(1:26))
+        │       ├── children: []
+        │       └── tag_closing: ">" (location: (1:26)-(1:27))
+        │
+        ├── is_void: false
+        └── source: "HTML"

--- a/test/snapshots/parser/attributes_test/test_0045_Vue_directive_with_namespace-like_syntax_e3d2d0afe1a0d7a4f71d0831ed0a9306.txt
+++ b/test/snapshots/parser/attributes_test/test_0045_Vue_directive_with_namespace-like_syntax_e3d2d0afe1a0d7a4f71d0831ed0a9306.txt
@@ -1,0 +1,42 @@
+@ DocumentNode (location: (1:0)-(1:27))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:27))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:21))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "div" (location: (1:1)-(1:4))
+        │       ├── tag_closing: ">" (location: (1:20)-(1:21))
+        │       ├── children: (1 item)
+        │       │   └── @ HTMLAttributeNode (location: (1:5)-(1:20))
+        │       │       ├── name:
+        │       │       │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:13))
+        │       │       │       └── children: (1 item)
+        │       │       │           └── @ LiteralNode (location: (1:5)-(1:13))
+        │       │       │               └── content: ":v-model"
+        │       │       │
+        │       │       │
+        │       │       ├── equals: "=" (location: (1:13)-(1:14))
+        │       │       └── value:
+        │       │           └── @ HTMLAttributeValueNode (location: (1:14)-(1:20))
+        │       │               ├── open_quote: """ (location: (1:14)-(1:15))
+        │       │               ├── children: (1 item)
+        │       │               │   └── @ LiteralNode (location: (1:15)-(1:19))
+        │       │               │       └── content: "user"
+        │       │               │
+        │       │               ├── close_quote: """ (location: (1:19)-(1:20))
+        │       │               └── quoted: true
+        │       │
+        │       │
+        │       └── is_void: false
+        │
+        ├── tag_name: "div" (location: (1:1)-(1:4))
+        ├── body: []
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:21)-(1:27))
+        │       ├── tag_opening: "</" (location: (1:21)-(1:23))
+        │       ├── tag_name: "div" (location: (1:23)-(1:26))
+        │       ├── children: []
+        │       └── tag_closing: ">" (location: (1:26)-(1:27))
+        │
+        ├── is_void: false
+        └── source: "HTML"


### PR DESCRIPTION
This pull request updates the parser to allow HTML Attributes to start with a colon, which is typical in the Vue.js style:

```html
<div :class="classes"></div>
```

Previously, this caused a syntax error: 
```js
@ UnexpectedError (location: (1:5)-(1:6))
├── message: "Unexpected Token. Expected: `TOKEN_IDENTIFIER, TOKEN_AT, TOKEN_ERB_START,TOKEN_WHITESPACE, or TOKEN_NEWLINE`, found: `TOKEN_COLON`."
├── description: "Unexpected Token"
├── expected: "TOKEN_IDENTIFIER, TOKEN_AT, TOKEN_ERB_START,TOKEN_WHITESPACE, or TOKEN_NEWLINE"
└── found: "TOKEN_COLON"
```

Now this parses as:

```js
@ HTMLAttributeNode (location: (1:5)-(1:21))
├── errors: []
├── name: 
│   └── @ HTMLAttributeNameNode (location: (1:5)-(1:11))
│       ├── errors: []
│       └── children: (1 item)
│           └── @ LiteralNode (location: (1:5)-(1:11))
│               ├── errors: []
│               └── content: ":class"
│                      
├── equals: "=" (location: (1:11)-(1:12))
└── value: 
    └── @ HTMLAttributeValueNode (location: (1:12)-(1:21))
        ├── errors: []
        ├── open_quote: """ (location: (1:12)-(1:13))
        ├── children: (1 item)
        │   └── @ LiteralNode (location: (1:13)-(1:20))
        │       ├── errors: []
        │       └── content: "classes"
        │       
        │   
        ├── close_quote: """ (location: (1:20)-(1:21))
        └── quoted: true
```