### PR TITLE
Parser: Fix `<div foo=>bar</div>` skipping over the closing bracket from the opening div

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -555,14 +555,12 @@ static AST_HTML_ATTRIBUTE_VALUE_NODE_T* parser_parse_html_attribute_value(parser
     return value;
   }
 
-  token_T* token = parser_advance(parser);
-
   append_unexpected_error(
     "Unexpected Token",
     "TOKEN_IDENTIFIER, TOKEN_QUOTE, TOKEN_ERB_START",
-    token_type_to_string(token->type),
-    token->location->start,
-    token->location->end,
+    token_type_to_string(parser->current_token->type),
+    parser->current_token->location->start,
+    parser->current_token->location->end,
     errors
   );
 
@@ -571,12 +569,10 @@ static AST_HTML_ATTRIBUTE_VALUE_NODE_T* parser_parse_html_attribute_value(parser
     children,
     NULL,
     false,
-    token->location->start,
-    token->location->end,
+    parser->current_token->location->start,
+    parser->current_token->location->end,
     errors
   );
-
-  token_free(token);
 
   return value;
 }

--- a/test/parser/attributes_test.rb
+++ b/test/parser/attributes_test.rb
@@ -191,5 +191,9 @@ module Parser
     test "Vue directive with namespace-like syntax" do
       assert_parsed_snapshot(%(<div :v-model="user"></div>))
     end
+
+    test "Empty attribute value with closing bracket immediatly following it" do
+      assert_parsed_snapshot(%(<div attribute-name=>div-content</div>))
+    end
   end
 end

--- a/test/snapshots/parser/attributes_test/test_0046_Empty_attribute_value_with_closing_bracket_immediatly_following_it_56df6b7e184a50db1eac62508206a332.txt
+++ b/test/snapshots/parser/attributes_test/test_0046_Empty_attribute_value_with_closing_bracket_immediatly_following_it_56df6b7e184a50db1eac62508206a332.txt
@@ -1,0 +1,49 @@
+@ DocumentNode (location: (1:0)-(1:38))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:38))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:21))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "div" (location: (1:1)-(1:4))
+        │       ├── tag_closing: ">" (location: (1:20)-(1:21))
+        │       ├── children: (1 item)
+        │       │   └── @ HTMLAttributeNode (location: (1:5)-(1:21))
+        │       │       ├── name:
+        │       │       │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:19))
+        │       │       │       └── children: (1 item)
+        │       │       │           └── @ LiteralNode (location: (1:5)-(1:19))
+        │       │       │               └── content: "attribute-name"
+        │       │       │
+        │       │       │
+        │       │       ├── equals: "=" (location: (1:19)-(1:20))
+        │       │       └── value:
+        │       │           └── @ HTMLAttributeValueNode (location: (1:20)-(1:21))
+        │       │               ├── errors: (1 error)
+        │       │               │   └── @ UnexpectedError (location: (1:20)-(1:21))
+        │       │               │       ├── message: "Unexpected Token. Expected: `TOKEN_IDENTIFIER, TOKEN_QUOTE, TOKEN_ERB_START`, found: `TOKEN_HTML_TAG_END`."
+        │       │               │       ├── description: "Unexpected Token"
+        │       │               │       ├── expected: "TOKEN_IDENTIFIER, TOKEN_QUOTE, TOKEN_ERB_START"
+        │       │               │       └── found: "TOKEN_HTML_TAG_END"
+        │       │               │
+        │       │               ├── open_quote: ∅
+        │       │               ├── children: []
+        │       │               ├── close_quote: ∅
+        │       │               └── quoted: false
+        │       │
+        │       │
+        │       └── is_void: false
+        │
+        ├── tag_name: "div" (location: (1:1)-(1:4))
+        ├── body: (1 item)
+        │   └── @ HTMLTextNode (location: (1:21)-(1:32))
+        │       └── content: "div-content"
+        │
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:32)-(1:38))
+        │       ├── tag_opening: "</" (location: (1:32)-(1:34))
+        │       ├── tag_name: "div" (location: (1:34)-(1:37))
+        │       ├── children: []
+        │       └── tag_closing: ">" (location: (1:37)-(1:38))
+        │
+        ├── is_void: false
+        └── source: "HTML"


### PR DESCRIPTION
`parser_advance` consumes the `TOKEN_HTML_TAG_END`, which ends up not closing the opening tag.

Snapshot diff (most notably, only a single `HTMLAttributeNode` and `HTMLCloseTagNode` now appears):

<details><summary>Diff</summary>
<p>

```patch
diff --git a/test/snapshots/parser/attributes_test/test_0046_Empty_attribute_value_with_closing_bracket_immediatly_following_it_56df6b7e184a50db1eac62508206a332.txt b/test/snapshots/parser/attributes_test/test_0046_Empty_attribute_value_with_closing_bracket_immediatly_following_it_56df6b7e184a50db1eac62508206a332.txt
index 41997bb..0f1e93e 100644
--- a/test/snapshots/parser/attributes_test/test_0046_Empty_attribute_value_with_closing_bracket_immediatly_following_it_56df6b7e184a50db1eac62508206a332.txt
+++ b/test/snapshots/parser/attributes_test/test_0046_Empty_attribute_value_with_closing_bracket_immediatly_following_it_56df6b7e184a50db1eac62508206a332.txt
@@ -1,61 +1,49 @@
 @ DocumentNode (location: (1:0)-(1:38))
-├── errors: (1 error)
-│   └── @ UnclosedElementError (location: (1:38)-(1:38))
-│       ├── message: "Tag `<div>` opened at (1:1) was never closed before the end of document."
-│       └── opening_tag: "div" (location: (1:1)-(1:4))
-│
 └── children: (1 item)
     └── @ HTMLElementNode (location: (1:0)-(1:38))
-        ├── errors: (1 error)
-        │   └── @ MissingClosingTagError (location: (1:1)-(1:4))
-        │       ├── message: "Opening tag `<div>` at (1:1) doesn't have a matching closing tag `</div>`."
-        │       └── opening_tag: "div" (location: (1:1)-(1:4))
-        │
         ├── open_tag:
-        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:38))
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:21))
         │       ├── tag_opening: "<" (location: (1:0)-(1:1))
         │       ├── tag_name: "div" (location: (1:1)-(1:4))
-        │       ├── tag_closing: ">" (location: (1:37)-(1:38))
-        │       ├── children: (2 items)
-        │       │   ├── @ HTMLAttributeNode (location: (1:5)-(1:21))
-        │       │   │   ├── name:
-        │       │   │   │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:19))
-        │       │   │   │       └── children: (1 item)
-        │       │   │   │           └── @ LiteralNode (location: (1:5)-(1:19))
-        │       │   │   │               └── content: "attribute-name"
-        │       │   │   │
-        │       │   │   │
-        │       │   │   ├── equals: "=" (location: (1:19)-(1:20))
-        │       │   │   └── value:
-        │       │   │       └── @ HTMLAttributeValueNode (location: (1:20)-(1:21))
-        │       │   │           ├── errors: (1 error)
-        │       │   │           │   └── @ UnexpectedError (location: (1:20)-(1:21))
-        │       │   │           │       ├── message: "Unexpected Token. Expected: `TOKEN_IDENTIFIER, TOKEN_QUOTE, TOKEN_ERB_START`, found: `TOKEN_HTML_TAG_END`."
-        │       │   │           │       ├── description: "Unexpected Token"
-        │       │   │           │       ├── expected: "TOKEN_IDENTIFIER, TOKEN_QUOTE, TOKEN_ERB_START"
-        │       │   │           │       └── found: "TOKEN_HTML_TAG_END"
-        │       │   │           │
-        │       │   │           ├── open_quote: ∅
-        │       │   │           ├── children: []
-        │       │   │           ├── close_quote: ∅
-        │       │   │           └── quoted: false
-        │       │   │
-        │       │   │
-        │       │   └── @ HTMLAttributeNode (location: (1:21)-(1:37))
+        │       ├── tag_closing: ">" (location: (1:20)-(1:21))
+        │       ├── children: (1 item)
+        │       │   └── @ HTMLAttributeNode (location: (1:5)-(1:21))
         │       │       ├── name:
-        │       │       │   └── @ HTMLAttributeNameNode (location: (1:21)-(1:37))
+        │       │       │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:19))
         │       │       │       └── children: (1 item)
-        │       │       │           └── @ LiteralNode (location: (1:21)-(1:37))
-        │       │       │               └── content: "div-content</div"
+        │       │       │           └── @ LiteralNode (location: (1:5)-(1:19))
+        │       │       │               └── content: "attribute-name"
         │       │       │
         │       │       │
-        │       │       ├── equals: ∅
-        │       │       └── value: ∅
+        │       │       ├── equals: "=" (location: (1:19)-(1:20))
+        │       │       └── value:
+        │       │           └── @ HTMLAttributeValueNode (location: (1:20)-(1:21))
+        │       │               ├── errors: (1 error)
+        │       │               │   └── @ UnexpectedError (location: (1:20)-(1:21))
+        │       │               │       ├── message: "Unexpected Token. Expected: `TOKEN_IDENTIFIER, TOKEN_QUOTE, TOKEN_ERB_START`, found: `TOKEN_HTML_TAG_END`."
+        │       │               │       ├── description: "Unexpected Token"
+        │       │               │       ├── expected: "TOKEN_IDENTIFIER, TOKEN_QUOTE, TOKEN_ERB_START"
+        │       │               │       └── found: "TOKEN_HTML_TAG_END"
+        │       │               │
+        │       │               ├── open_quote: ∅
+        │       │               ├── children: []
+        │       │               ├── close_quote: ∅
+        │       │               └── quoted: false
+        │       │
         │       │
         │       └── is_void: false
         │
         ├── tag_name: "div" (location: (1:1)-(1:4))
-        ├── body: []
-        ├── close_tag: ∅
+        ├── body: (1 item)
+        │   └── @ HTMLTextNode (location: (1:21)-(1:32))
+        │       └── content: "div-content"
+        │
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:32)-(1:38))
+        │       ├── tag_opening: "</" (location: (1:32)-(1:34))
+        │       ├── tag_name: "div" (location: (1:34)-(1:37))
+        │       ├── children: []
+        │       └── tag_closing: ">" (location: (1:37)-(1:38))
+        │
         ├── is_void: false
         └── source: "HTML"
\ No newline at end of file
```

</p>
</details> 