### PR TITLE
Fix typo in pretty_print_analyzed_ruby method

### DIFF
--- a/src/analyze.c
+++ b/src/analyze.c
@@ -54,7 +54,7 @@ static bool analyze_erb_content(const AST_NODE_T* node, void* data) {
     if (strcmp(opening, "<%%") != 0 && strcmp(opening, "<%%=") != 0 && strcmp(opening, "<%#") != 0) {
       analyzed_ruby_T* analyzed = herb_analyze_ruby(erb_content_node->content->value);
 
-      if (false) { pretty_print_analyed_ruby(analyzed, erb_content_node->content->value); }
+      if (false) { pretty_print_analyzed_ruby(analyzed, erb_content_node->content->value); }
 
       erb_content_node->parsed = true;
       erb_content_node->valid = analyzed->valid;

--- a/src/include/pretty_print.h
+++ b/src/include/pretty_print.h
@@ -88,6 +88,6 @@ void pretty_print_array(
 
 void pretty_print_errors(AST_NODE_T* node, size_t indent, size_t relative_indent, bool last_property, buffer_T* buffer);
 
-void pretty_print_analyed_ruby(analyzed_ruby_T* analyzed, const char* source);
+void pretty_print_analyzed_ruby(analyzed_ruby_T* analyzed, const char* source);
 
 #endif

--- a/src/pretty_print.c
+++ b/src/pretty_print.c
@@ -254,7 +254,7 @@ void pretty_print_string_property(
   }
 }
 
-void pretty_print_analyed_ruby(analyzed_ruby_T* analyzed, const char* source) {
+void pretty_print_analyzed_ruby(analyzed_ruby_T* analyzed, const char* source) {
   printf(
     "------------------------\nanalyzed (%p)\n------------------------\n%s\n------------------------\n  if:     %i\n "
     " elsif:  %i\n  else:   %i\n  end:    %i\n  block:  %i\n  block_closing: %i\n  case:   %i\n  when:   %i\n  for:    "


### PR DESCRIPTION
This PR renames the `pretty_print_analyed_ruby` c method to `pretty_print_analyzed_ruby`. Fixing a typo in the process.