### PR TITLE
C: Introduce String data structure

### DIFF
--- a/ext/herb/extension.c
+++ b/ext/herb/extension.c
@@ -18,6 +18,9 @@ VALUE cParseResult;
 
 static VALUE Herb_lex(VALUE self, VALUE source) {
   char* string = (char*) check_string(source);
+  if (NIL_P(source)) {
+    string = "";
+  }
 
   array_T* tokens = herb_lex(string);
 
@@ -45,6 +48,10 @@ static VALUE Herb_parse(int argc, VALUE* argv, VALUE self) {
   rb_scan_args(argc, argv, "1:", &source, &options);
 
   char* string = (char*) check_string(source);
+
+  if (NIL_P(source)) {
+    string = "";
+  }
 
   parser_options_T* parser_options = NULL;
   parser_options_T opts = { 0 };

--- a/src/herb.c
+++ b/src/herb.c
@@ -28,12 +28,12 @@ array_T* herb_lex(const char* source) {
 }
 
 AST_DOCUMENT_NODE_T* herb_parse(const char* source, parser_options_T* options) {
-  lexer_T* lexer = lexer_init(source);
-  parser_T* parser = herb_parser_init(&lexer, options);
+  lexer_T lexer = { 0 };
+  lexer_init(&lexer, source);
+  parser_T parser = { 0 };
+  herb_parser_init(&parser, &lexer, options);
 
-  AST_DOCUMENT_NODE_T* document = herb_parser_parse(parser);
-
-  parser_free(parser);
+  AST_DOCUMENT_NODE_T* document = herb_parser_parse(&parser);
 
   return document;
 }

--- a/src/herb.c
+++ b/src/herb.c
@@ -12,24 +12,24 @@
 #include <stdlib.h>
 
 array_T* herb_lex(const char* source) {
-  lexer_T* lexer = lexer_init(source);
+  lexer_T lexer = { 0 };
+  lexer_init(&lexer, source);
+
   token_T* token = NULL;
   array_T* tokens = array_init(128);
 
-  while ((token = lexer_next_token(lexer))->type != TOKEN_EOF) {
+  while ((token = lexer_next_token(&lexer))->type != TOKEN_EOF) {
     array_append(tokens, token);
   }
 
   array_append(tokens, token);
-
-  lexer_free(lexer);
 
   return tokens;
 }
 
 AST_DOCUMENT_NODE_T* herb_parse(const char* source, parser_options_T* options) {
   lexer_T* lexer = lexer_init(source);
-  parser_T* parser = herb_parser_init(lexer, options);
+  parser_T* parser = herb_parser_init(&lexer, options);
 
   AST_DOCUMENT_NODE_T* document = herb_parser_parse(parser);
 

--- a/src/herb.c
+++ b/src/herb.c
@@ -5,6 +5,7 @@
 #include "include/json.h"
 #include "include/lexer.h"
 #include "include/parser.h"
+#include "include/str.h"
 #include "include/token.h"
 #include "include/version.h"
 
@@ -12,8 +13,10 @@
 #include <stdlib.h>
 
 array_T* herb_lex(const char* source) {
+  str_T source_str = { .data = (char*) source, .length = strlen(source) };
+
   lexer_T lexer = { 0 };
-  lexer_init(&lexer, source);
+  lexer_init(&lexer, source_str);
 
   token_T* token = NULL;
   array_T* tokens = array_init(128);
@@ -28,8 +31,11 @@ array_T* herb_lex(const char* source) {
 }
 
 AST_DOCUMENT_NODE_T* herb_parse(const char* source, parser_options_T* options) {
+  str_T source_string = { .data = (char*) source, .length = strlen(source) };
+
   lexer_T lexer = { 0 };
-  lexer_init(&lexer, source);
+  lexer_init(&lexer, source_string);
+
   parser_T parser = { 0 };
   herb_parser_init(&parser, &lexer, options);
 

--- a/src/include/lexer.h
+++ b/src/include/lexer.h
@@ -4,10 +4,8 @@
 #include "lexer_struct.h"
 #include "token_struct.h"
 
-lexer_T* lexer_init(const char* source);
+void lexer_init(lexer_T* lexer, const char* source);
 token_T* lexer_next_token(lexer_T* lexer);
 token_T* lexer_error(lexer_T* lexer, const char* message);
-
-void lexer_free(lexer_T* lexer);
 
 #endif

--- a/src/include/lexer.h
+++ b/src/include/lexer.h
@@ -2,9 +2,10 @@
 #define HERB_LEXER_H
 
 #include "lexer_struct.h"
+#include "str.h"
 #include "token_struct.h"
 
-void lexer_init(lexer_T* lexer, const char* source);
+void lexer_init(lexer_T* lexer, str_T source);
 token_T* lexer_next_token(lexer_T* lexer);
 token_T* lexer_error(lexer_T* lexer, const char* message);
 

--- a/src/include/lexer_struct.h
+++ b/src/include/lexer_struct.h
@@ -1,6 +1,7 @@
 #ifndef HERB_LEXER_STRUCT_H
 #define HERB_LEXER_STRUCT_H
 
+#include "str.h"
 #include <stdbool.h>
 #include <stdlib.h>
 
@@ -11,8 +12,7 @@ typedef enum {
 } lexer_state_T;
 
 typedef struct LEXER_STRUCT {
-  const char* source;
-  size_t source_length;
+  str_T source;
 
   size_t current_line;
   size_t current_column;

--- a/src/include/parser.h
+++ b/src/include/parser.h
@@ -28,7 +28,7 @@ typedef struct PARSER_STRUCT {
   parser_options_T* options;
 } parser_T;
 
-parser_T* herb_parser_init(lexer_T* lexer, parser_options_T* options);
+void herb_parser_init(parser_T* parser, lexer_T* lexer, parser_options_T* options);
 
 AST_DOCUMENT_NODE_T* herb_parser_parse(parser_T* parser);
 

--- a/src/include/str.h
+++ b/src/include/str.h
@@ -1,0 +1,11 @@
+#ifndef HERB_STRING_H
+#define HERB_STRING_H
+
+#include <stdlib.h>
+
+typedef struct STRING_STRUCT {
+  char* data;
+  size_t length;
+} str_T;
+
+#endif

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -9,10 +9,6 @@
 
 #define LEXER_STALL_LIMIT 5
 
-static size_t lexer_sizeof(void) {
-  return sizeof(struct LEXER_STRUCT);
-}
-
 static bool lexer_eof(const lexer_T* lexer) {
   return lexer->current_character == '\0' || lexer->stalled;
 }
@@ -34,10 +30,8 @@ static bool lexer_stalled(lexer_T* lexer) {
   return lexer->stalled;
 }
 
-lexer_T* lexer_init(const char* source) {
+void lexer_init(lexer_T* lexer, const char* source) {
   if (source == NULL) { source = ""; }
-
-  lexer_T* lexer = calloc(1, lexer_sizeof());
 
   lexer->state = STATE_DATA;
 
@@ -56,8 +50,6 @@ lexer_T* lexer_init(const char* source) {
   lexer->stall_counter = 0;
   lexer->last_position = 0;
   lexer->stalled = false;
-
-  return lexer;
 }
 
 token_T* lexer_error(lexer_T* lexer, const char* message) {
@@ -352,10 +344,4 @@ token_T* lexer_next_token(lexer_T* lexer) {
       return lexer_advance_utf8_character(lexer, TOKEN_CHARACTER);
     }
   }
-}
-
-void lexer_free(lexer_T* lexer) {
-  if (lexer == NULL) { return; }
-
-  free(lexer);
 }

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -31,7 +31,6 @@ static bool lexer_stalled(lexer_T* lexer) {
 }
 
 void lexer_init(lexer_T* lexer, const char* source) {
-  if (source == NULL) { source = ""; }
 
   lexer->state = STATE_DATA;
 

--- a/src/lexer_peek_helpers.c
+++ b/src/lexer_peek_helpers.c
@@ -8,11 +8,11 @@
 #include <stdbool.h>
 
 char lexer_backtrack(const lexer_T* lexer, const int offset) {
-  return lexer->source[MAX(lexer->current_position - offset, 0)];
+  return lexer->source.data[MAX(lexer->current_position - offset, 0)];
 }
 
 char lexer_peek(const lexer_T* lexer, const int offset) {
-  return lexer->source[MIN(lexer->current_position + offset, lexer->source_length)];
+  return lexer->source.data[MIN(lexer->current_position + offset, lexer->source.length)];
 }
 
 bool lexer_peek_for(const lexer_T* lexer, const int offset, const char* pattern, const bool case_insensitive) {

--- a/src/parser.c
+++ b/src/parser.c
@@ -1257,7 +1257,6 @@ static void parser_consume_whitespace(parser_T* parser, array_T* children) {
 void parser_free(parser_T* parser) {
   if (parser == NULL) { return; }
 
-  if (parser->lexer != NULL) { lexer_free(parser->lexer); }
   if (parser->current_token != NULL) { token_free(parser->current_token); }
   if (parser->open_tags_stack != NULL) { array_free(&parser->open_tags_stack); }
   if (parser->options != NULL) { free(parser->options); }

--- a/src/parser.c
+++ b/src/parser.c
@@ -31,9 +31,7 @@ size_t parser_sizeof(void) {
   return sizeof(struct PARSER_STRUCT);
 }
 
-parser_T* herb_parser_init(lexer_T* lexer, parser_options_T* options) {
-  parser_T* parser = calloc(1, parser_sizeof());
-
+void herb_parser_init(parser_T* parser, lexer_T* lexer, parser_options_T* options) {
   parser->lexer = lexer;
   parser->current_token = lexer_next_token(lexer);
   parser->open_tags_stack = array_init(16);
@@ -46,8 +44,6 @@ parser_T* herb_parser_init(lexer_T* lexer, parser_options_T* options) {
   } else {
     parser->options = NULL;
   }
-
-  return parser;
 }
 
 static AST_CDATA_NODE_T* parser_parse_cdata(parser_T* parser) {


### PR DESCRIPTION
Introduce a new c struct for representing a string with a known length without an explicit `\0` terminator.

This eliminates the need to do string copies when creating tokens, because there's no need to store a new `\0` terminator.

## Goal 

```c
str_t slice = {
  .data = &lexer->source.data[lexer->previous_position],
  .length = lexer->current_position - lexer->previous_position
}
token_init(&token, slice, ...)
```