### PR TITLE
Parser: Don't treat guard clauses as `ERBIfNode` or `ERBUnlessNode`

### DIFF
--- a/javascript/packages/formatter/test/erb/if.test.ts
+++ b/javascript/packages/formatter/test/erb/if.test.ts
@@ -126,4 +126,133 @@ describe("@herb-tools/formatter", () => {
     const output = formatter.format(input)
     expect(output).toEqual(expected)
   })
+
+  describe("guard clauses (modifier if)", () => {
+    test("does not indent content after 'next if' guard clause", () => {
+      const input = dedent`
+        <% [1,2].each do |value| %>
+        <% next if false %>
+        <div></div>
+        <% end %>
+      `
+
+      const expected = dedent`
+        <% [1,2].each do |value| %>
+          <% next if false %>
+          <div></div>
+        <% end %>
+      `
+
+      const output = formatter.format(input)
+      expect(output).toEqual(expected)
+    })
+
+    test("does not indent content after 'return if' guard clause", () => {
+      const input = dedent`
+        <% (1..10).each do %>
+        <% return if condition %>
+        <div>Content</div>
+        <p>More content</p>
+        <% end %>
+      `
+
+      const expected = dedent`
+        <% (1..10).each do %>
+          <% return if condition %>
+          <div>Content</div>
+
+          <p>More content</p>
+        <% end %>
+      `
+
+      const output = formatter.format(input)
+      expect(output).toEqual(expected)
+    })
+
+    test("does not indent content after 'break if' guard clause", () => {
+      const input = dedent`
+        <% loop do %>
+        <% break if done %>
+        <div>Loop content</div>
+        <% end %>
+      `
+
+      const expected = dedent`
+        <% loop do %>
+          <% break if done %>
+          <div>Loop content</div>
+        <% end %>
+      `
+
+      const output = formatter.format(input)
+      expect(output).toEqual(expected)
+    })
+
+    test("handles multiple guard clauses in sequence", () => {
+      const input = dedent`
+        <% items.each do |item| %>
+        <% next if item.nil? %>
+        <% next if item.hidden? %>
+        <div><%= item.name %></div>
+        <% end %>
+      `
+
+      const expected = dedent`
+        <% items.each do |item| %>
+          <% next if item.nil? %>
+          <% next if item.hidden? %>
+          <div><%= item.name %></div>
+        <% end %>
+      `
+
+      const output = formatter.format(input)
+      expect(output).toEqual(expected)
+    })
+
+    test("handles guard clause with unless modifier", () => {
+      const input = dedent`
+        <% items.each do |item| %>
+        <% next unless item.visible? %>
+        <div><%= item.name %></div>
+        <% end %>
+      `
+
+      const expected = dedent`
+        <% items.each do |item| %>
+          <% next unless item.visible? %>
+          <div><%= item.name %></div>
+        <% end %>
+      `
+
+      const output = formatter.format(input)
+      expect(output).toEqual(expected)
+    })
+
+    test("distinguishes between block if and modifier if", () => {
+      const input = dedent`
+        <% items.each do |item| %>
+        <% next if item.skip? %>
+        <% if item.special? %>
+        <div class="special"><%= item.name %></div>
+        <% else %>
+        <div><%= item.name %></div>
+        <% end %>
+        <% end %>
+      `
+
+      const expected = dedent`
+        <% items.each do |item| %>
+          <% next if item.skip? %>
+          <% if item.special? %>
+            <div class="special"><%= item.name %></div>
+          <% else %>
+            <div><%= item.name %></div>
+          <% end %>
+        <% end %>
+      `
+
+      const output = formatter.format(input)
+      expect(output).toEqual(expected)
+    })
+  })
 })

--- a/javascript/packages/formatter/test/erb/unless.test.ts
+++ b/javascript/packages/formatter/test/erb/unless.test.ts
@@ -119,4 +119,189 @@ describe("@herb-tools/formatter", () => {
     const output = formatter.format(input)
     expect(output).toEqual(expected)
   })
+
+  describe("guard clauses (modifier unless)", () => {
+    test("does not indent content after 'next unless' guard clause", () => {
+      const input = dedent`
+        <% items.each do |item| %>
+        <% next unless item.visible? %>
+        <div><%= item.name %></div>
+        <% end %>
+      `
+
+      const expected = dedent`
+        <% items.each do |item| %>
+          <% next unless item.visible? %>
+          <div><%= item.name %></div>
+        <% end %>
+      `
+
+      const output = formatter.format(input)
+      expect(output).toEqual(expected)
+    })
+
+    test("does not indent content after 'return unless' guard clause", () => {
+      const input = dedent`
+        <% [1, 2].each do %>
+        <% return unless @content.present? %>
+        <div class="content">
+        <%= @content %>
+        </div>
+        <% end %>
+      `
+
+      const expected = dedent`
+        <% [1, 2].each do %>
+          <% return unless @content.present? %>
+          <div class="content"><%= @content %></div>
+        <% end %>
+      `
+
+      const output = formatter.format(input)
+      expect(output).toEqual(expected)
+    })
+
+    test("does not indent content after 'break unless' guard clause", () => {
+      const input = dedent`
+        <% loop do %>
+        <% break unless continue_processing? %>
+        <div>Processing...</div>
+        <% end %>
+      `
+
+      const expected = dedent`
+        <% loop do %>
+          <% break unless continue_processing? %>
+          <div>Processing...</div>
+        <% end %>
+      `
+
+      const output = formatter.format(input)
+      expect(output).toEqual(expected)
+    })
+
+    test("handles multiple unless guard clauses in sequence", () => {
+      const input = dedent`
+        <% items.each do |item| %>
+        <% next unless item %>
+        <% next unless item.active? %>
+        <% next unless item.published? %>
+        <article>
+        <h2><%= item.title %></h2>
+        <p><%= item.description %></p>
+        </article>
+        <% end %>
+      `
+
+      const expected = dedent`
+        <% items.each do |item| %>
+          <% next unless item %>
+          <% next unless item.active? %>
+          <% next unless item.published? %>
+          <article>
+            <h2><%= item.title %></h2>
+            <p><%= item.description %></p>
+          </article>
+        <% end %>
+      `
+
+      const output = formatter.format(input)
+      expect(output).toEqual(expected)
+    })
+
+    test("distinguishes between block unless and modifier unless", () => {
+      const input = dedent`
+        <% items.each do |item| %>
+        <% next unless item.visible? %>
+        <% unless item.featured? %>
+        <div class="regular">
+        <%= item.name %>
+        </div>
+        <% else %>
+        <div class="featured">
+        <%= item.name %>
+        </div>
+        <% end %>
+        <% end %>
+      `
+
+      const expected = dedent`
+        <% items.each do |item| %>
+          <% next unless item.visible? %>
+          <% unless item.featured? %>
+            <div class="regular"><%= item.name %></div>
+          <% else %>
+            <div class="featured"><%= item.name %></div>
+          <% end %>
+        <% end %>
+      `
+
+      const output = formatter.format(input)
+      expect(output).toEqual(expected)
+    })
+
+    test("handles mixed if and unless modifiers", () => {
+      const input = dedent`
+        <% products.each do |product| %>
+        <% next if product.discontinued? %>
+        <% next unless product.in_stock? %>
+        <% next if product.price > budget %>
+        <% next unless product.available_in_region? %>
+        <div class="product">
+        <h3><%= product.name %></h3>
+        <span class="price">$<%= product.price %></span>
+        </div>
+        <% end %>
+      `
+
+      const expected = dedent`
+        <% products.each do |product| %>
+          <% next if product.discontinued? %>
+          <% next unless product.in_stock? %>
+          <% next if product.price > budget %>
+          <% next unless product.available_in_region? %>
+          <div class="product">
+            <h3><%= product.name %></h3>
+            <span class="price">$<%= product.price %></span>
+          </div>
+        <% end %>
+      `
+
+      const output = formatter.format(input)
+      expect(output).toEqual(expected)
+    })
+
+    test("handles guard clauses in nested blocks", () => {
+      const input = dedent`
+        <% categories.each do |category| %>
+        <% next unless category.active? %>
+        <section>
+        <h2><%= category.name %></h2>
+        <% category.items.each do |item| %>
+        <% next if item.hidden? %>
+        <% next unless item.published? %>
+        <div><%= item.title %></div>
+        <% end %>
+        </section>
+        <% end %>
+      `
+
+      const expected = dedent`
+        <% categories.each do |category| %>
+          <% next unless category.active? %>
+          <section>
+            <h2><%= category.name %></h2>
+            <% category.items.each do |item| %>
+              <% next if item.hidden? %>
+              <% next unless item.published? %>
+              <div><%= item.title %></div>
+            <% end %>
+          </section>
+        <% end %>
+      `
+
+      const output = formatter.format(input)
+      expect(output).toEqual(expected)
+    })
+  })
 })

--- a/src/analyze_helpers.c
+++ b/src/analyze_helpers.c
@@ -91,9 +91,12 @@ bool search_if_nodes(const pm_node_t* node, void* data) {
   if (node->type == PM_IF_NODE) {
     const pm_if_node_t* if_node = (const pm_if_node_t*) node;
 
-    // Handle ternary
-    if (if_node->if_keyword_loc.start != NULL && if_node->if_keyword_loc.end != NULL) {
+    bool has_if_keyword = if_node->if_keyword_loc.start != NULL && if_node->if_keyword_loc.end != NULL;
+    bool has_end_keyword = if_node->end_keyword_loc.start != NULL && if_node->end_keyword_loc.end != NULL;
+
+    if (has_if_keyword && has_end_keyword) {
       analyzed->has_if_node = true;
+
       return true;
     }
   }
@@ -198,11 +201,19 @@ bool search_unless_nodes(const pm_node_t* node, void* data) {
   analyzed_ruby_T* analyzed = (analyzed_ruby_T*) data;
 
   if (node->type == PM_UNLESS_NODE) {
-    analyzed->has_unless_node = true;
-    return true;
-  } else {
-    pm_visit_child_nodes(node, search_unless_nodes, analyzed);
+    const pm_unless_node_t* unless_node = (const pm_unless_node_t*) node;
+
+    bool has_if_keyword = unless_node->keyword_loc.start != NULL && unless_node->keyword_loc.end != NULL;
+    bool has_end_keyword = unless_node->end_keyword_loc.start != NULL && unless_node->end_keyword_loc.end != NULL;
+
+    if (has_if_keyword && has_end_keyword) {
+      analyzed->has_unless_node = true;
+
+      return true;
+    }
   }
+
+  pm_visit_child_nodes(node, search_unless_nodes, analyzed);
 
   return false;
 }

--- a/test/analyze/if_test.rb
+++ b/test/analyze/if_test.rb
@@ -93,5 +93,32 @@ module Analyze
         <h1 class="<% if bold? %>bold<% else %>normal<% end %>"></h1>
       HTML
     end
+
+    test "guard clause with if modifier should not be parsed as ERBIfNode" do
+      assert_parsed_snapshot(<<~HTML)
+        <% [1,2].each do |value| %>
+          <% next if false %>
+          <div></div>
+        <% end %>
+      HTML
+    end
+
+    test "guard clause with return if modifier" do
+      assert_parsed_snapshot(<<~HTML)
+        <% def some_method %>
+          <% return if true %>
+          <div>This won't render</div>
+        <% end %>
+      HTML
+    end
+
+    test "guard clause with break if modifier" do
+      assert_parsed_snapshot(<<~HTML)
+        <% loop do %>
+          <% break if condition %>
+          <div>Loop content</div>
+        <% end %>
+      HTML
+    end
   end
 end

--- a/test/analyze/unless_test.rb
+++ b/test/analyze/unless_test.rb
@@ -65,5 +65,56 @@ module Analyze
         <% end %>
       HTML
     end
+
+    test "guard clause with unless modifier should not be parsed as ERBUnlessNode" do
+      assert_parsed_snapshot(<<~HTML)
+        <% items.each do |item| %>
+          <% next unless item.visible? %>
+          <div><%= item.name %></div>
+        <% end %>
+      HTML
+    end
+
+    test "guard clause with return unless modifier" do
+      assert_parsed_snapshot(<<~HTML)
+        <% def some_method %>
+          <% return unless condition %>
+          <div>This will render</div>
+        <% end %>
+      HTML
+    end
+
+    test "guard clause with break unless modifier" do
+      assert_parsed_snapshot(<<~HTML)
+        <% loop do %>
+          <% break unless continue? %>
+          <div>Loop content</div>
+        <% end %>
+      HTML
+    end
+
+    test "multiple unless guard clauses" do
+      assert_parsed_snapshot(<<~HTML)
+        <% items.each do |item| %>
+          <% next unless item %>
+          <% next unless item.active? %>
+          <% next unless item.published? %>
+          <div><%= item.title %></div>
+        <% end %>
+      HTML
+    end
+
+    test "distinguishes between block unless and modifier unless" do
+      assert_parsed_snapshot(<<~HTML)
+        <% items.each do |item| %>
+          <% next unless item.visible? %>
+          <% unless item.special? %>
+            <div class="normal"><%= item.name %></div>
+          <% else %>
+            <div class="special"><%= item.name %></div>
+          <% end %>
+        <% end %>
+      HTML
+    end
   end
 end

--- a/test/snapshots/analyze/if_test/test_0010_guard_clause_with_if_modifier_should_not_be_parsed_as_ERBIfNode_84c50d0087a29c69bf5125ce6ec79f86.txt
+++ b/test/snapshots/analyze/if_test/test_0010_guard_clause_with_if_modifier_should_not_be_parsed_as_ERBIfNode_84c50d0087a29c69bf5125ce6ec79f86.txt
@@ -1,0 +1,53 @@
+@ DocumentNode (location: (1:0)-(5:0))
+└── children: (2 items)
+    ├── @ ERBBlockNode (location: (1:0)-(4:9))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
+    │   ├── content: " [1,2].each do |value| " (location: (1:2)-(1:25))
+    │   ├── tag_closing: "%>" (location: (1:25)-(1:27))
+    │   ├── body: (5 items)
+    │   │   ├── @ HTMLTextNode (location: (1:27)-(2:2))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ ERBContentNode (location: (2:2)-(2:21))
+    │   │   │   ├── tag_opening: "<%" (location: (2:2)-(2:4))
+    │   │   │   ├── content: " next if false " (location: (2:4)-(2:19))
+    │   │   │   ├── tag_closing: "%>" (location: (2:19)-(2:21))
+    │   │   │   ├── parsed: true
+    │   │   │   └── valid: false
+    │   │   │
+    │   │   ├── @ HTMLTextNode (location: (2:21)-(3:2))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ HTMLElementNode (location: (3:2)-(3:13))
+    │   │   │   ├── open_tag:
+    │   │   │   │   └── @ HTMLOpenTagNode (location: (3:2)-(3:7))
+    │   │   │   │       ├── tag_opening: "<" (location: (3:2)-(3:3))
+    │   │   │   │       ├── tag_name: "div" (location: (3:3)-(3:6))
+    │   │   │   │       ├── tag_closing: ">" (location: (3:6)-(3:7))
+    │   │   │   │       ├── children: []
+    │   │   │   │       └── is_void: false
+    │   │   │   │
+    │   │   │   ├── tag_name: "div" (location: (3:3)-(3:6))
+    │   │   │   ├── body: []
+    │   │   │   ├── close_tag:
+    │   │   │   │   └── @ HTMLCloseTagNode (location: (3:7)-(3:13))
+    │   │   │   │       ├── tag_opening: "</" (location: (3:7)-(3:9))
+    │   │   │   │       ├── tag_name: "div" (location: (3:9)-(3:12))
+    │   │   │   │       ├── children: []
+    │   │   │   │       └── tag_closing: ">" (location: (3:12)-(3:13))
+    │   │   │   │
+    │   │   │   ├── is_void: false
+    │   │   │   └── source: "HTML"
+    │   │   │
+    │   │   └── @ HTMLTextNode (location: (3:13)-(4:0))
+    │   │       └── content: "\n"
+    │   │
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (4:0)-(4:9))
+    │           ├── tag_opening: "<%" (location: (4:0)-(4:2))
+    │           ├── content: " end " (location: (4:2)-(4:7))
+    │           └── tag_closing: "%>" (location: (4:7)-(4:9))
+    │
+    │
+    └── @ HTMLTextNode (location: (4:9)-(5:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/if_test/test_0011_guard_clause_with_return_if_modifier_6a92e7d29b0b8ff99771a96e90f4ac10.txt
+++ b/test/snapshots/analyze/if_test/test_0011_guard_clause_with_return_if_modifier_6a92e7d29b0b8ff99771a96e90f4ac10.txt
@@ -1,0 +1,58 @@
+@ DocumentNode (location: (1:0)-(5:0))
+└── children: (8 items)
+    ├── @ ERBContentNode (location: (1:0)-(1:21))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
+    │   ├── content: " def some_method " (location: (1:2)-(1:19))
+    │   ├── tag_closing: "%>" (location: (1:19)-(1:21))
+    │   ├── parsed: true
+    │   └── valid: false
+    │
+    ├── @ HTMLTextNode (location: (1:21)-(2:2))
+    │   └── content: "\n  "
+    │
+    ├── @ ERBContentNode (location: (2:2)-(2:22))
+    │   ├── tag_opening: "<%" (location: (2:2)-(2:4))
+    │   ├── content: " return if true " (location: (2:4)-(2:20))
+    │   ├── tag_closing: "%>" (location: (2:20)-(2:22))
+    │   ├── parsed: true
+    │   └── valid: true
+    │
+    ├── @ HTMLTextNode (location: (2:22)-(3:2))
+    │   └── content: "\n  "
+    │
+    ├── @ HTMLElementNode (location: (3:2)-(3:30))
+    │   ├── open_tag:
+    │   │   └── @ HTMLOpenTagNode (location: (3:2)-(3:7))
+    │   │       ├── tag_opening: "<" (location: (3:2)-(3:3))
+    │   │       ├── tag_name: "div" (location: (3:3)-(3:6))
+    │   │       ├── tag_closing: ">" (location: (3:6)-(3:7))
+    │   │       ├── children: []
+    │   │       └── is_void: false
+    │   │
+    │   ├── tag_name: "div" (location: (3:3)-(3:6))
+    │   ├── body: (1 item)
+    │   │   └── @ HTMLTextNode (location: (3:7)-(3:24))
+    │   │       └── content: "This won't render"
+    │   │
+    │   ├── close_tag:
+    │   │   └── @ HTMLCloseTagNode (location: (3:24)-(3:30))
+    │   │       ├── tag_opening: "</" (location: (3:24)-(3:26))
+    │   │       ├── tag_name: "div" (location: (3:26)-(3:29))
+    │   │       ├── children: []
+    │   │       └── tag_closing: ">" (location: (3:29)-(3:30))
+    │   │
+    │   ├── is_void: false
+    │   └── source: "HTML"
+    │
+    ├── @ HTMLTextNode (location: (3:30)-(4:0))
+    │   └── content: "\n"
+    │
+    ├── @ ERBContentNode (location: (4:0)-(4:9))
+    │   ├── tag_opening: "<%" (location: (4:0)-(4:2))
+    │   ├── content: " end " (location: (4:2)-(4:7))
+    │   ├── tag_closing: "%>" (location: (4:7)-(4:9))
+    │   ├── parsed: true
+    │   └── valid: false
+    │
+    └── @ HTMLTextNode (location: (4:9)-(5:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/if_test/test_0012_guard_clause_with_break_if_modifier_41f095a3d010c4b7e9a38aa708b9054d.txt
+++ b/test/snapshots/analyze/if_test/test_0012_guard_clause_with_break_if_modifier_41f095a3d010c4b7e9a38aa708b9054d.txt
@@ -1,0 +1,56 @@
+@ DocumentNode (location: (1:0)-(5:0))
+└── children: (2 items)
+    ├── @ ERBBlockNode (location: (1:0)-(4:9))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
+    │   ├── content: " loop do " (location: (1:2)-(1:11))
+    │   ├── tag_closing: "%>" (location: (1:11)-(1:13))
+    │   ├── body: (5 items)
+    │   │   ├── @ HTMLTextNode (location: (1:13)-(2:2))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ ERBContentNode (location: (2:2)-(2:26))
+    │   │   │   ├── tag_opening: "<%" (location: (2:2)-(2:4))
+    │   │   │   ├── content: " break if condition " (location: (2:4)-(2:24))
+    │   │   │   ├── tag_closing: "%>" (location: (2:24)-(2:26))
+    │   │   │   ├── parsed: true
+    │   │   │   └── valid: false
+    │   │   │
+    │   │   ├── @ HTMLTextNode (location: (2:26)-(3:2))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ HTMLElementNode (location: (3:2)-(3:25))
+    │   │   │   ├── open_tag:
+    │   │   │   │   └── @ HTMLOpenTagNode (location: (3:2)-(3:7))
+    │   │   │   │       ├── tag_opening: "<" (location: (3:2)-(3:3))
+    │   │   │   │       ├── tag_name: "div" (location: (3:3)-(3:6))
+    │   │   │   │       ├── tag_closing: ">" (location: (3:6)-(3:7))
+    │   │   │   │       ├── children: []
+    │   │   │   │       └── is_void: false
+    │   │   │   │
+    │   │   │   ├── tag_name: "div" (location: (3:3)-(3:6))
+    │   │   │   ├── body: (1 item)
+    │   │   │   │   └── @ HTMLTextNode (location: (3:7)-(3:19))
+    │   │   │   │       └── content: "Loop content"
+    │   │   │   │
+    │   │   │   ├── close_tag:
+    │   │   │   │   └── @ HTMLCloseTagNode (location: (3:19)-(3:25))
+    │   │   │   │       ├── tag_opening: "</" (location: (3:19)-(3:21))
+    │   │   │   │       ├── tag_name: "div" (location: (3:21)-(3:24))
+    │   │   │   │       ├── children: []
+    │   │   │   │       └── tag_closing: ">" (location: (3:24)-(3:25))
+    │   │   │   │
+    │   │   │   ├── is_void: false
+    │   │   │   └── source: "HTML"
+    │   │   │
+    │   │   └── @ HTMLTextNode (location: (3:25)-(4:0))
+    │   │       └── content: "\n"
+    │   │
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (4:0)-(4:9))
+    │           ├── tag_opening: "<%" (location: (4:0)-(4:2))
+    │           ├── content: " end " (location: (4:2)-(4:7))
+    │           └── tag_closing: "%>" (location: (4:7)-(4:9))
+    │
+    │
+    └── @ HTMLTextNode (location: (4:9)-(5:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/unless_test/test_0007_guard_clause_with_unless_modifier_should_not_be_parsed_as_ERBUnlessNode_647968bffc9de35b805b872472b322b7.txt
+++ b/test/snapshots/analyze/unless_test/test_0007_guard_clause_with_unless_modifier_should_not_be_parsed_as_ERBUnlessNode_647968bffc9de35b805b872472b322b7.txt
@@ -1,0 +1,60 @@
+@ DocumentNode (location: (1:0)-(5:0))
+└── children: (2 items)
+    ├── @ ERBBlockNode (location: (1:0)-(4:9))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
+    │   ├── content: " items.each do |item| " (location: (1:2)-(1:24))
+    │   ├── tag_closing: "%>" (location: (1:24)-(1:26))
+    │   ├── body: (5 items)
+    │   │   ├── @ HTMLTextNode (location: (1:26)-(2:2))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ ERBContentNode (location: (2:2)-(2:33))
+    │   │   │   ├── tag_opening: "<%" (location: (2:2)-(2:4))
+    │   │   │   ├── content: " next unless item.visible? " (location: (2:4)-(2:31))
+    │   │   │   ├── tag_closing: "%>" (location: (2:31)-(2:33))
+    │   │   │   ├── parsed: true
+    │   │   │   └── valid: false
+    │   │   │
+    │   │   ├── @ HTMLTextNode (location: (2:33)-(3:2))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ HTMLElementNode (location: (3:2)-(3:29))
+    │   │   │   ├── open_tag:
+    │   │   │   │   └── @ HTMLOpenTagNode (location: (3:2)-(3:7))
+    │   │   │   │       ├── tag_opening: "<" (location: (3:2)-(3:3))
+    │   │   │   │       ├── tag_name: "div" (location: (3:3)-(3:6))
+    │   │   │   │       ├── tag_closing: ">" (location: (3:6)-(3:7))
+    │   │   │   │       ├── children: []
+    │   │   │   │       └── is_void: false
+    │   │   │   │
+    │   │   │   ├── tag_name: "div" (location: (3:3)-(3:6))
+    │   │   │   ├── body: (1 item)
+    │   │   │   │   └── @ ERBContentNode (location: (3:7)-(3:23))
+    │   │   │   │       ├── tag_opening: "<%=" (location: (3:7)-(3:10))
+    │   │   │   │       ├── content: " item.name " (location: (3:10)-(3:21))
+    │   │   │   │       ├── tag_closing: "%>" (location: (3:21)-(3:23))
+    │   │   │   │       ├── parsed: true
+    │   │   │   │       └── valid: true
+    │   │   │   │
+    │   │   │   ├── close_tag:
+    │   │   │   │   └── @ HTMLCloseTagNode (location: (3:23)-(3:29))
+    │   │   │   │       ├── tag_opening: "</" (location: (3:23)-(3:25))
+    │   │   │   │       ├── tag_name: "div" (location: (3:25)-(3:28))
+    │   │   │   │       ├── children: []
+    │   │   │   │       └── tag_closing: ">" (location: (3:28)-(3:29))
+    │   │   │   │
+    │   │   │   ├── is_void: false
+    │   │   │   └── source: "HTML"
+    │   │   │
+    │   │   └── @ HTMLTextNode (location: (3:29)-(4:0))
+    │   │       └── content: "\n"
+    │   │
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (4:0)-(4:9))
+    │           ├── tag_opening: "<%" (location: (4:0)-(4:2))
+    │           ├── content: " end " (location: (4:2)-(4:7))
+    │           └── tag_closing: "%>" (location: (4:7)-(4:9))
+    │
+    │
+    └── @ HTMLTextNode (location: (4:9)-(5:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/unless_test/test_0008_guard_clause_with_return_unless_modifier_650bfc3134fa92038c335f96f9047860.txt
+++ b/test/snapshots/analyze/unless_test/test_0008_guard_clause_with_return_unless_modifier_650bfc3134fa92038c335f96f9047860.txt
@@ -1,0 +1,58 @@
+@ DocumentNode (location: (1:0)-(5:0))
+└── children: (8 items)
+    ├── @ ERBContentNode (location: (1:0)-(1:21))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
+    │   ├── content: " def some_method " (location: (1:2)-(1:19))
+    │   ├── tag_closing: "%>" (location: (1:19)-(1:21))
+    │   ├── parsed: true
+    │   └── valid: false
+    │
+    ├── @ HTMLTextNode (location: (1:21)-(2:2))
+    │   └── content: "\n  "
+    │
+    ├── @ ERBContentNode (location: (2:2)-(2:31))
+    │   ├── tag_opening: "<%" (location: (2:2)-(2:4))
+    │   ├── content: " return unless condition " (location: (2:4)-(2:29))
+    │   ├── tag_closing: "%>" (location: (2:29)-(2:31))
+    │   ├── parsed: true
+    │   └── valid: true
+    │
+    ├── @ HTMLTextNode (location: (2:31)-(3:2))
+    │   └── content: "\n  "
+    │
+    ├── @ HTMLElementNode (location: (3:2)-(3:29))
+    │   ├── open_tag:
+    │   │   └── @ HTMLOpenTagNode (location: (3:2)-(3:7))
+    │   │       ├── tag_opening: "<" (location: (3:2)-(3:3))
+    │   │       ├── tag_name: "div" (location: (3:3)-(3:6))
+    │   │       ├── tag_closing: ">" (location: (3:6)-(3:7))
+    │   │       ├── children: []
+    │   │       └── is_void: false
+    │   │
+    │   ├── tag_name: "div" (location: (3:3)-(3:6))
+    │   ├── body: (1 item)
+    │   │   └── @ HTMLTextNode (location: (3:7)-(3:23))
+    │   │       └── content: "This will render"
+    │   │
+    │   ├── close_tag:
+    │   │   └── @ HTMLCloseTagNode (location: (3:23)-(3:29))
+    │   │       ├── tag_opening: "</" (location: (3:23)-(3:25))
+    │   │       ├── tag_name: "div" (location: (3:25)-(3:28))
+    │   │       ├── children: []
+    │   │       └── tag_closing: ">" (location: (3:28)-(3:29))
+    │   │
+    │   ├── is_void: false
+    │   └── source: "HTML"
+    │
+    ├── @ HTMLTextNode (location: (3:29)-(4:0))
+    │   └── content: "\n"
+    │
+    ├── @ ERBContentNode (location: (4:0)-(4:9))
+    │   ├── tag_opening: "<%" (location: (4:0)-(4:2))
+    │   ├── content: " end " (location: (4:2)-(4:7))
+    │   ├── tag_closing: "%>" (location: (4:7)-(4:9))
+    │   ├── parsed: true
+    │   └── valid: false
+    │
+    └── @ HTMLTextNode (location: (4:9)-(5:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/unless_test/test_0009_guard_clause_with_break_unless_modifier_5ae9786a5b6893828c737287cffd216f.txt
+++ b/test/snapshots/analyze/unless_test/test_0009_guard_clause_with_break_unless_modifier_5ae9786a5b6893828c737287cffd216f.txt
@@ -1,0 +1,56 @@
+@ DocumentNode (location: (1:0)-(5:0))
+└── children: (2 items)
+    ├── @ ERBBlockNode (location: (1:0)-(4:9))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
+    │   ├── content: " loop do " (location: (1:2)-(1:11))
+    │   ├── tag_closing: "%>" (location: (1:11)-(1:13))
+    │   ├── body: (5 items)
+    │   │   ├── @ HTMLTextNode (location: (1:13)-(2:2))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ ERBContentNode (location: (2:2)-(2:30))
+    │   │   │   ├── tag_opening: "<%" (location: (2:2)-(2:4))
+    │   │   │   ├── content: " break unless continue? " (location: (2:4)-(2:28))
+    │   │   │   ├── tag_closing: "%>" (location: (2:28)-(2:30))
+    │   │   │   ├── parsed: true
+    │   │   │   └── valid: false
+    │   │   │
+    │   │   ├── @ HTMLTextNode (location: (2:30)-(3:2))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ HTMLElementNode (location: (3:2)-(3:25))
+    │   │   │   ├── open_tag:
+    │   │   │   │   └── @ HTMLOpenTagNode (location: (3:2)-(3:7))
+    │   │   │   │       ├── tag_opening: "<" (location: (3:2)-(3:3))
+    │   │   │   │       ├── tag_name: "div" (location: (3:3)-(3:6))
+    │   │   │   │       ├── tag_closing: ">" (location: (3:6)-(3:7))
+    │   │   │   │       ├── children: []
+    │   │   │   │       └── is_void: false
+    │   │   │   │
+    │   │   │   ├── tag_name: "div" (location: (3:3)-(3:6))
+    │   │   │   ├── body: (1 item)
+    │   │   │   │   └── @ HTMLTextNode (location: (3:7)-(3:19))
+    │   │   │   │       └── content: "Loop content"
+    │   │   │   │
+    │   │   │   ├── close_tag:
+    │   │   │   │   └── @ HTMLCloseTagNode (location: (3:19)-(3:25))
+    │   │   │   │       ├── tag_opening: "</" (location: (3:19)-(3:21))
+    │   │   │   │       ├── tag_name: "div" (location: (3:21)-(3:24))
+    │   │   │   │       ├── children: []
+    │   │   │   │       └── tag_closing: ">" (location: (3:24)-(3:25))
+    │   │   │   │
+    │   │   │   ├── is_void: false
+    │   │   │   └── source: "HTML"
+    │   │   │
+    │   │   └── @ HTMLTextNode (location: (3:25)-(4:0))
+    │   │       └── content: "\n"
+    │   │
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (4:0)-(4:9))
+    │           ├── tag_opening: "<%" (location: (4:0)-(4:2))
+    │           ├── content: " end " (location: (4:2)-(4:7))
+    │           └── tag_closing: "%>" (location: (4:7)-(4:9))
+    │
+    │
+    └── @ HTMLTextNode (location: (4:9)-(5:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/unless_test/test_0010_multiple_unless_guard_clauses_80edd1ae63fb2cd18f33418d1ef308c1.txt
+++ b/test/snapshots/analyze/unless_test/test_0010_multiple_unless_guard_clauses_80edd1ae63fb2cd18f33418d1ef308c1.txt
@@ -1,0 +1,80 @@
+@ DocumentNode (location: (1:0)-(7:0))
+└── children: (2 items)
+    ├── @ ERBBlockNode (location: (1:0)-(6:9))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
+    │   ├── content: " items.each do |item| " (location: (1:2)-(1:24))
+    │   ├── tag_closing: "%>" (location: (1:24)-(1:26))
+    │   ├── body: (9 items)
+    │   │   ├── @ HTMLTextNode (location: (1:26)-(2:2))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ ERBContentNode (location: (2:2)-(2:24))
+    │   │   │   ├── tag_opening: "<%" (location: (2:2)-(2:4))
+    │   │   │   ├── content: " next unless item " (location: (2:4)-(2:22))
+    │   │   │   ├── tag_closing: "%>" (location: (2:22)-(2:24))
+    │   │   │   ├── parsed: true
+    │   │   │   └── valid: false
+    │   │   │
+    │   │   ├── @ HTMLTextNode (location: (2:24)-(3:2))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ ERBContentNode (location: (3:2)-(3:32))
+    │   │   │   ├── tag_opening: "<%" (location: (3:2)-(3:4))
+    │   │   │   ├── content: " next unless item.active? " (location: (3:4)-(3:30))
+    │   │   │   ├── tag_closing: "%>" (location: (3:30)-(3:32))
+    │   │   │   ├── parsed: true
+    │   │   │   └── valid: false
+    │   │   │
+    │   │   ├── @ HTMLTextNode (location: (3:32)-(4:2))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ ERBContentNode (location: (4:2)-(4:35))
+    │   │   │   ├── tag_opening: "<%" (location: (4:2)-(4:4))
+    │   │   │   ├── content: " next unless item.published? " (location: (4:4)-(4:33))
+    │   │   │   ├── tag_closing: "%>" (location: (4:33)-(4:35))
+    │   │   │   ├── parsed: true
+    │   │   │   └── valid: false
+    │   │   │
+    │   │   ├── @ HTMLTextNode (location: (4:35)-(5:2))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ HTMLElementNode (location: (5:2)-(5:30))
+    │   │   │   ├── open_tag:
+    │   │   │   │   └── @ HTMLOpenTagNode (location: (5:2)-(5:7))
+    │   │   │   │       ├── tag_opening: "<" (location: (5:2)-(5:3))
+    │   │   │   │       ├── tag_name: "div" (location: (5:3)-(5:6))
+    │   │   │   │       ├── tag_closing: ">" (location: (5:6)-(5:7))
+    │   │   │   │       ├── children: []
+    │   │   │   │       └── is_void: false
+    │   │   │   │
+    │   │   │   ├── tag_name: "div" (location: (5:3)-(5:6))
+    │   │   │   ├── body: (1 item)
+    │   │   │   │   └── @ ERBContentNode (location: (5:7)-(5:24))
+    │   │   │   │       ├── tag_opening: "<%=" (location: (5:7)-(5:10))
+    │   │   │   │       ├── content: " item.title " (location: (5:10)-(5:22))
+    │   │   │   │       ├── tag_closing: "%>" (location: (5:22)-(5:24))
+    │   │   │   │       ├── parsed: true
+    │   │   │   │       └── valid: true
+    │   │   │   │
+    │   │   │   ├── close_tag:
+    │   │   │   │   └── @ HTMLCloseTagNode (location: (5:24)-(5:30))
+    │   │   │   │       ├── tag_opening: "</" (location: (5:24)-(5:26))
+    │   │   │   │       ├── tag_name: "div" (location: (5:26)-(5:29))
+    │   │   │   │       ├── children: []
+    │   │   │   │       └── tag_closing: ">" (location: (5:29)-(5:30))
+    │   │   │   │
+    │   │   │   ├── is_void: false
+    │   │   │   └── source: "HTML"
+    │   │   │
+    │   │   └── @ HTMLTextNode (location: (5:30)-(6:0))
+    │   │       └── content: "\n"
+    │   │
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (6:0)-(6:9))
+    │           ├── tag_opening: "<%" (location: (6:0)-(6:2))
+    │           ├── content: " end " (location: (6:2)-(6:7))
+    │           └── tag_closing: "%>" (location: (6:7)-(6:9))
+    │
+    │
+    └── @ HTMLTextNode (location: (6:9)-(7:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/unless_test/test_0011_distinguishes_between_block_unless_and_modifier_unless_4ca85acaceb3fb39b75797c6a07e7437.txt
+++ b/test/snapshots/analyze/unless_test/test_0011_distinguishes_between_block_unless_and_modifier_unless_4ca85acaceb3fb39b75797c6a07e7437.txt
@@ -1,0 +1,159 @@
+@ DocumentNode (location: (1:0)-(9:0))
+└── children: (2 items)
+    ├── @ ERBBlockNode (location: (1:0)-(8:9))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
+    │   ├── content: " items.each do |item| " (location: (1:2)-(1:24))
+    │   ├── tag_closing: "%>" (location: (1:24)-(1:26))
+    │   ├── body: (5 items)
+    │   │   ├── @ HTMLTextNode (location: (1:26)-(2:2))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ ERBContentNode (location: (2:2)-(2:33))
+    │   │   │   ├── tag_opening: "<%" (location: (2:2)-(2:4))
+    │   │   │   ├── content: " next unless item.visible? " (location: (2:4)-(2:31))
+    │   │   │   ├── tag_closing: "%>" (location: (2:31)-(2:33))
+    │   │   │   ├── parsed: true
+    │   │   │   └── valid: false
+    │   │   │
+    │   │   ├── @ HTMLTextNode (location: (2:33)-(3:2))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ ERBUnlessNode (location: (3:2)-(7:11))
+    │   │   │   ├── tag_opening: "<%" (location: (3:2)-(3:4))
+    │   │   │   ├── content: " unless item.special? " (location: (3:4)-(3:26))
+    │   │   │   ├── tag_closing: "%>" (location: (3:26)-(3:28))
+    │   │   │   ├── statements: (3 items)
+    │   │   │   │   ├── @ HTMLTextNode (location: (3:28)-(4:4))
+    │   │   │   │   │   └── content: "\n    "
+    │   │   │   │   │
+    │   │   │   │   ├── @ HTMLElementNode (location: (4:4)-(4:46))
+    │   │   │   │   │   ├── open_tag:
+    │   │   │   │   │   │   └── @ HTMLOpenTagNode (location: (4:4)-(4:24))
+    │   │   │   │   │   │       ├── tag_opening: "<" (location: (4:4)-(4:5))
+    │   │   │   │   │   │       ├── tag_name: "div" (location: (4:5)-(4:8))
+    │   │   │   │   │   │       ├── tag_closing: ">" (location: (4:23)-(4:24))
+    │   │   │   │   │   │       ├── children: (1 item)
+    │   │   │   │   │   │       │   └── @ HTMLAttributeNode (location: (4:9)-(4:23))
+    │   │   │   │   │   │       │       ├── name:
+    │   │   │   │   │   │       │       │   └── @ HTMLAttributeNameNode (location: (4:9)-(4:14))
+    │   │   │   │   │   │       │       │       └── children: (1 item)
+    │   │   │   │   │   │       │       │           └── @ LiteralNode (location: (4:9)-(4:14))
+    │   │   │   │   │   │       │       │               └── content: "class"
+    │   │   │   │   │   │       │       │
+    │   │   │   │   │   │       │       │
+    │   │   │   │   │   │       │       ├── equals: "=" (location: (4:14)-(4:15))
+    │   │   │   │   │   │       │       └── value:
+    │   │   │   │   │   │       │           └── @ HTMLAttributeValueNode (location: (4:15)-(4:23))
+    │   │   │   │   │   │       │               ├── open_quote: """ (location: (4:15)-(4:16))
+    │   │   │   │   │   │       │               ├── children: (1 item)
+    │   │   │   │   │   │       │               │   └── @ LiteralNode (location: (4:16)-(4:22))
+    │   │   │   │   │   │       │               │       └── content: "normal"
+    │   │   │   │   │   │       │               │
+    │   │   │   │   │   │       │               ├── close_quote: """ (location: (4:22)-(4:23))
+    │   │   │   │   │   │       │               └── quoted: true
+    │   │   │   │   │   │       │
+    │   │   │   │   │   │       │
+    │   │   │   │   │   │       └── is_void: false
+    │   │   │   │   │   │
+    │   │   │   │   │   ├── tag_name: "div" (location: (4:5)-(4:8))
+    │   │   │   │   │   ├── body: (1 item)
+    │   │   │   │   │   │   └── @ ERBContentNode (location: (4:24)-(4:40))
+    │   │   │   │   │   │       ├── tag_opening: "<%=" (location: (4:24)-(4:27))
+    │   │   │   │   │   │       ├── content: " item.name " (location: (4:27)-(4:38))
+    │   │   │   │   │   │       ├── tag_closing: "%>" (location: (4:38)-(4:40))
+    │   │   │   │   │   │       ├── parsed: true
+    │   │   │   │   │   │       └── valid: true
+    │   │   │   │   │   │
+    │   │   │   │   │   ├── close_tag:
+    │   │   │   │   │   │   └── @ HTMLCloseTagNode (location: (4:40)-(4:46))
+    │   │   │   │   │   │       ├── tag_opening: "</" (location: (4:40)-(4:42))
+    │   │   │   │   │   │       ├── tag_name: "div" (location: (4:42)-(4:45))
+    │   │   │   │   │   │       ├── children: []
+    │   │   │   │   │   │       └── tag_closing: ">" (location: (4:45)-(4:46))
+    │   │   │   │   │   │
+    │   │   │   │   │   ├── is_void: false
+    │   │   │   │   │   └── source: "HTML"
+    │   │   │   │   │
+    │   │   │   │   └── @ HTMLTextNode (location: (4:46)-(5:2))
+    │   │   │   │       └── content: "\n  "
+    │   │   │   │
+    │   │   │   ├── else_clause:
+    │   │   │   │   └── @ ERBElseNode (location: (5:2)-(7:2))
+    │   │   │   │       ├── tag_opening: "<%" (location: (5:2)-(5:4))
+    │   │   │   │       ├── content: " else " (location: (5:4)-(5:10))
+    │   │   │   │       ├── tag_closing: "%>" (location: (5:10)-(5:12))
+    │   │   │   │       └── statements: (3 items)
+    │   │   │   │           ├── @ HTMLTextNode (location: (5:12)-(6:4))
+    │   │   │   │           │   └── content: "\n    "
+    │   │   │   │           │
+    │   │   │   │           ├── @ HTMLElementNode (location: (6:4)-(6:47))
+    │   │   │   │           │   ├── open_tag:
+    │   │   │   │           │   │   └── @ HTMLOpenTagNode (location: (6:4)-(6:25))
+    │   │   │   │           │   │       ├── tag_opening: "<" (location: (6:4)-(6:5))
+    │   │   │   │           │   │       ├── tag_name: "div" (location: (6:5)-(6:8))
+    │   │   │   │           │   │       ├── tag_closing: ">" (location: (6:24)-(6:25))
+    │   │   │   │           │   │       ├── children: (1 item)
+    │   │   │   │           │   │       │   └── @ HTMLAttributeNode (location: (6:9)-(6:24))
+    │   │   │   │           │   │       │       ├── name:
+    │   │   │   │           │   │       │       │   └── @ HTMLAttributeNameNode (location: (6:9)-(6:14))
+    │   │   │   │           │   │       │       │       └── children: (1 item)
+    │   │   │   │           │   │       │       │           └── @ LiteralNode (location: (6:9)-(6:14))
+    │   │   │   │           │   │       │       │               └── content: "class"
+    │   │   │   │           │   │       │       │
+    │   │   │   │           │   │       │       │
+    │   │   │   │           │   │       │       ├── equals: "=" (location: (6:14)-(6:15))
+    │   │   │   │           │   │       │       └── value:
+    │   │   │   │           │   │       │           └── @ HTMLAttributeValueNode (location: (6:15)-(6:24))
+    │   │   │   │           │   │       │               ├── open_quote: """ (location: (6:15)-(6:16))
+    │   │   │   │           │   │       │               ├── children: (1 item)
+    │   │   │   │           │   │       │               │   └── @ LiteralNode (location: (6:16)-(6:23))
+    │   │   │   │           │   │       │               │       └── content: "special"
+    │   │   │   │           │   │       │               │
+    │   │   │   │           │   │       │               ├── close_quote: """ (location: (6:23)-(6:24))
+    │   │   │   │           │   │       │               └── quoted: true
+    │   │   │   │           │   │       │
+    │   │   │   │           │   │       │
+    │   │   │   │           │   │       └── is_void: false
+    │   │   │   │           │   │
+    │   │   │   │           │   ├── tag_name: "div" (location: (6:5)-(6:8))
+    │   │   │   │           │   ├── body: (1 item)
+    │   │   │   │           │   │   └── @ ERBContentNode (location: (6:25)-(6:41))
+    │   │   │   │           │   │       ├── tag_opening: "<%=" (location: (6:25)-(6:28))
+    │   │   │   │           │   │       ├── content: " item.name " (location: (6:28)-(6:39))
+    │   │   │   │           │   │       ├── tag_closing: "%>" (location: (6:39)-(6:41))
+    │   │   │   │           │   │       ├── parsed: true
+    │   │   │   │           │   │       └── valid: true
+    │   │   │   │           │   │
+    │   │   │   │           │   ├── close_tag:
+    │   │   │   │           │   │   └── @ HTMLCloseTagNode (location: (6:41)-(6:47))
+    │   │   │   │           │   │       ├── tag_opening: "</" (location: (6:41)-(6:43))
+    │   │   │   │           │   │       ├── tag_name: "div" (location: (6:43)-(6:46))
+    │   │   │   │           │   │       ├── children: []
+    │   │   │   │           │   │       └── tag_closing: ">" (location: (6:46)-(6:47))
+    │   │   │   │           │   │
+    │   │   │   │           │   ├── is_void: false
+    │   │   │   │           │   └── source: "HTML"
+    │   │   │   │           │
+    │   │   │   │           └── @ HTMLTextNode (location: (6:47)-(7:2))
+    │   │   │   │               └── content: "\n  "
+    │   │   │   │
+    │   │   │   │
+    │   │   │   └── end_node:
+    │   │   │       └── @ ERBEndNode (location: (7:2)-(7:11))
+    │   │   │           ├── tag_opening: "<%" (location: (7:2)-(7:4))
+    │   │   │           ├── content: " end " (location: (7:4)-(7:9))
+    │   │   │           └── tag_closing: "%>" (location: (7:9)-(7:11))
+    │   │   │
+    │   │   │
+    │   │   └── @ HTMLTextNode (location: (7:11)-(8:0))
+    │   │       └── content: "\n"
+    │   │
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (8:0)-(8:9))
+    │           ├── tag_opening: "<%" (location: (8:0)-(8:2))
+    │           ├── content: " end " (location: (8:2)-(8:7))
+    │           └── tag_closing: "%>" (location: (8:7)-(8:9))
+    │
+    │
+    └── @ HTMLTextNode (location: (8:9)-(9:0))
+        └── content: "\n"


### PR DESCRIPTION
This pull request updates the parser and the analyzer to only transform an `ERBContentNode` node to an `ERBIfNode` or `ERBUnlessNode` when it has both `if/unless` and `end` keywords.

Guard clauses or ternaries shouldn't be treated as `ERBIfNode` or `ERBUnlessNode`. We might want to revisit this when we expose the actual prism nodes for each `ERBContentNode`, but for the sake of parsing/formatting we shouldn't treat those  `ERBIfNode` or `ERBUnlessNode` nodes for now.

Resolves #505 