### PR TITLE
Formatter: Add spaces in `ERBContentNode` within HTML attributes

### DIFF
--- a/javascript/packages/formatter/src/format-printer.ts
+++ b/javascript/packages/formatter/src/format-printer.ts
@@ -1572,7 +1572,7 @@ export class FormatPrinter extends Printer {
 
           return child.content
         } else if (isNode(child, ERBContentNode)) {
-          return IdentityPrinter.print(child)
+          return this.reconstructERBNode(child, true)
         } else {
           const printed = IdentityPrinter.print(child)
 

--- a/javascript/packages/formatter/test/html/attributes.test.ts
+++ b/javascript/packages/formatter/test/html/attributes.test.ts
@@ -255,4 +255,24 @@ describe("@herb-tools/formatter", () => {
       <input type="text" value="<%= @user.name %>">
     `)
   })
+
+  test("formats ERB tags in attribute values with proper whitespace (issue #482)", () => {
+    const source = dedent`
+      <a href="<%=""%>"></a>
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <a href="<%= "" %>"></a>
+    `)
+  })
+
+  test("formats ERB tags in attribute values with content", () => {
+    const source = dedent`
+      <a href="<%=@post.url%>"></a>
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <a href="<%= @post.url %>"></a>
+    `)
+  })
 })

--- a/javascript/packages/formatter/test/xml/xml.test.ts
+++ b/javascript/packages/formatter/test/xml/xml.test.ts
@@ -513,10 +513,10 @@ describe("XML", () => {
               <% gallery_images.each do |image| %>
                 <GalleryImage
                   size="large"
-                  src="<%= image[:src]%>"
-                  alt="<%= image[:alt]%>"
-                  width="<%= image[:width]%>"
-                  height="<%= image[:height]%>"
+                  src="<%= image[:src] %>"
+                  alt="<%= image[:alt] %>"
+                  width="<%= image[:width] %>"
+                  height="<%= image[:height] %>"
                 ></GalleryImage>
               <% end %>
             </ImageGallery>


### PR DESCRIPTION
This pull request updates the formatter to also add surrounding spaces for `ERBContentNode` nodes within HTML attribute values when formatting HTML+ERB documents.

Resolves https://github.com/marcoroth/herb/issues/482