### PR TITLE
Linter: Implement `erb-comment-syntax`  linter rule

### DIFF
--- a/javascript/packages/linter/docs/rules/README.md
+++ b/javascript/packages/linter/docs/rules/README.md
@@ -4,6 +4,7 @@ This page contains documentation for all Herb Linter rules.
 
 ## Available Rules
 
+- [`erb-comment-syntax`](./erb-comment-syntax.md) - Disallow Ruby comments immediately after ERB tags
 - [`erb-no-empty-tags`](./erb-no-empty-tags.md) - Disallow empty ERB tags
 - [`erb-no-output-control-flow`](./erb-no-output-control-flow.md) - Prevents outputting control flow blocks
 - [`erb-no-silent-tag-in-attribute-name`](./erb-no-silent-tag-in-attribute-name.md) - Disallow ERB silent tags in HTML attribute names

--- a/javascript/packages/linter/docs/rules/erb-comment-syntax.md
+++ b/javascript/packages/linter/docs/rules/erb-comment-syntax.md
@@ -1,0 +1,32 @@
+# Linter Rule: Disallow bad ERB comment syntax.
+
+## Rule: `erb-comment-syntax`
+
+Bad ERB comment syntax. Leaving a space between ERB tags and the Ruby comment character can cause parser errors.
+
+## Examples
+
+### ❌ Incorrect
+
+```erb
+<% # some bad ruby comment that should be changed to erb one line comment %>
+```
+
+### ✅ Correct
+
+```erb
+<% 
+ # some good multi line ruby comment
+ # some good multi line ruby comment
+ # some good multi line ruby comment
+ # some good multi line ruby comment
+%>
+<%# some good erb comment %>
+<% 
+ # some good ruby comment 
+%>
+```
+
+## Configuration
+
+This rule has no configuration options.

--- a/javascript/packages/linter/docs/rules/erb-comment-syntax.md
+++ b/javascript/packages/linter/docs/rules/erb-comment-syntax.md
@@ -1,32 +1,40 @@
-# Linter Rule: Disallow bad ERB comment syntax.
+# Linter Rule: Disallow Ruby comments immediately after ERB tags
 
-## Rule: `erb-comment-syntax`
+**Rule:** `erb-comment-syntax`
 
-Bad ERB comment syntax. Leaving a space between ERB tags and the Ruby comment character can cause parser errors.
+## Description
+
+Disallow ERB tags that start with `<% #` (with a space before the `#`). Use the ERB comment syntax `<%#` instead.
+
+## Rationale
+
+Ruby comments starting immediately after an ERB tag opening (e.g., `<% # comment %>`) can cause parsing issues in some contexts. The proper ERB comment syntax `<%# comment %>` is more reliable and explicitly designed for comments in templates.
+
+For multi-line comments or actual Ruby code with comments, ensure the content starts on a new line after the opening tag.
 
 ## Examples
 
-### ❌ Incorrect
+### ✅ Good
 
 ```erb
-<% # some bad ruby comment that should be changed to erb one line comment %>
-```
+<%# This is a proper ERB comment %>
 
-### ✅ Correct
-
-```erb
-<% 
- # some good multi line ruby comment
- # some good multi line ruby comment
- # some good multi line ruby comment
- # some good multi line ruby comment
+<%
+  # This is a proper ERB comment
 %>
-<%# some good erb comment %>
-<% 
- # some good ruby comment 
+
+<%
+  # Multi-line Ruby comment
+  # spanning multiple lines
 %>
 ```
 
-## Configuration
+### 🚫 Bad
 
-This rule has no configuration options.
+```erb
+<% # This should be an ERB comment %>
+
+<%= # This should also be an ERB comment %>
+
+<%== # This should also be an ERB comment %>
+```

--- a/javascript/packages/linter/src/default-rules.ts
+++ b/javascript/packages/linter/src/default-rules.ts
@@ -1,5 +1,6 @@
 import type { RuleClass } from "./types.js"
 
+import { ERBCommentSyntax } from "./rules/erb-comment-syntax.js";
 import { ERBNoEmptyTagsRule } from "./rules/erb-no-empty-tags.js"
 import { ERBNoOutputControlFlowRule } from "./rules/erb-no-output-control-flow.js"
 import { ERBNoSilentTagInAttributeNameRule } from "./rules/erb-no-silent-tag-in-attribute-name.js"
@@ -36,6 +37,7 @@ import { SVGTagNameCapitalizationRule } from "./rules/svg-tag-name-capitalizatio
 import { HTMLNoUnderscoresInAttributeNamesRule } from "./rules/html-no-underscores-in-attribute-names.js"
 
 export const defaultRules: RuleClass[] = [
+  ERBCommentSyntax,
   ERBNoEmptyTagsRule,
   ERBNoOutputControlFlowRule,
   ERBNoSilentTagInAttributeNameRule,

--- a/javascript/packages/linter/src/rules/erb-comment-syntax.ts
+++ b/javascript/packages/linter/src/rules/erb-comment-syntax.ts
@@ -1,0 +1,35 @@
+import { BaseRuleVisitor } from "./rule-utils.js";
+import { ParserRule } from "../types.js";
+import type { LintOffense, LintContext } from "../types.js";
+import type { ParseResult, ERBContentNode } from "@herb-tools/core";
+
+class ERBCommentSyntaxVisitor extends BaseRuleVisitor {
+  visitERBContentNode(node: ERBContentNode): void {
+    this.visitChildNodes(node);
+
+    if (!node.parsed) {
+      return;
+    }
+
+    if (node.content?.value.startsWith(" #")) {
+      const openingTag = node.tag_opening?.value;
+      const correctERBTag = openingTag === "<%=" ? "<%#=" : "<%#";
+      this.addOffense(
+        `Bad ERB comment syntax. Should be ${correctERBTag} without a space between.\nLeaving a space between ERB tags and the Ruby comment character can cause parser errors.`, 
+        node.location
+      );
+    }
+  }
+}
+
+export class ERBCommentSyntax extends ParserRule {
+  name = "erb-comment-syntax";
+
+  check(result: ParseResult, context?: Partial<LintContext>): LintOffense[] {
+    const visitor = new ERBCommentSyntaxVisitor(this.name, context);
+
+    visitor.visit(result.value)
+
+    return visitor.offenses
+  }
+}

--- a/javascript/packages/linter/src/rules/erb-comment-syntax.ts
+++ b/javascript/packages/linter/src/rules/erb-comment-syntax.ts
@@ -1,32 +1,27 @@
-import { BaseRuleVisitor } from "./rule-utils.js";
-import { ParserRule } from "../types.js";
-import type { LintOffense, LintContext } from "../types.js";
-import type { ParseResult, ERBContentNode } from "@herb-tools/core";
+import { BaseRuleVisitor } from "./rule-utils.js"
+import { ParserRule } from "../types.js"
+
+import type { LintOffense, LintContext } from "../types.js"
+import type { ParseResult, ERBContentNode } from "@herb-tools/core"
 
 class ERBCommentSyntaxVisitor extends BaseRuleVisitor {
   visitERBContentNode(node: ERBContentNode): void {
-    this.visitChildNodes(node);
-
-    if (!node.parsed) {
-      return;
-    }
-
     if (node.content?.value.startsWith(" #")) {
-      const openingTag = node.tag_opening?.value;
-      const correctERBTag = openingTag === "<%=" ? "<%#=" : "<%#";
+      const openingTag = node.tag_opening?.value
+
       this.addOffense(
-        `Bad ERB comment syntax. Should be ${correctERBTag} without a space between.\nLeaving a space between ERB tags and the Ruby comment character can cause parser errors.`, 
+        `Use \`<%#\` instead of \`${openingTag} #\`. Ruby comments immediately after ERB tags can cause parsing issues.`,
         node.location
-      );
+      )
     }
   }
 }
 
 export class ERBCommentSyntax extends ParserRule {
-  name = "erb-comment-syntax";
+  name = "erb-comment-syntax"
 
   check(result: ParseResult, context?: Partial<LintContext>): LintOffense[] {
-    const visitor = new ERBCommentSyntaxVisitor(this.name, context);
+    const visitor = new ERBCommentSyntaxVisitor(this.name, context)
 
     visitor.visit(result.value)
 

--- a/javascript/packages/linter/src/rules/index.ts
+++ b/javascript/packages/linter/src/rules/index.ts
@@ -1,4 +1,5 @@
 export * from "./rule-utils.js"
+export * from "./erb-comment-syntax.js"
 export * from "./erb-no-empty-tags.js"
 export * from "./erb-no-output-control-flow.js"
 export * from "./erb-no-silent-tag-in-attribute-name.js"

--- a/javascript/packages/linter/test/__snapshots__/cli.test.ts.snap
+++ b/javascript/packages/linter/test/__snapshots__/cli.test.ts.snap
@@ -561,7 +561,7 @@ exports[`CLI Output Formatting > formats JSON output correctly for bad file 1`] 
   "summary": {
     "filesChecked": 1,
     "filesWithOffenses": 1,
-    "ruleCount": 31,
+    "ruleCount": 32,
     "totalErrors": 2,
     "totalOffenses": 2,
     "totalWarnings": 0,
@@ -579,7 +579,7 @@ exports[`CLI Output Formatting > formats JSON output correctly for clean file 1`
   "summary": {
     "filesChecked": 1,
     "filesWithOffenses": 0,
-    "ruleCount": 31,
+    "ruleCount": 32,
     "totalErrors": 0,
     "totalOffenses": 0,
     "totalWarnings": 0,
@@ -649,7 +649,7 @@ exports[`CLI Output Formatting > formats JSON output correctly for file with err
   "summary": {
     "filesChecked": 1,
     "filesWithOffenses": 1,
-    "ruleCount": 31,
+    "ruleCount": 32,
     "totalErrors": 3,
     "totalOffenses": 3,
     "totalWarnings": 0,

--- a/javascript/packages/linter/test/rules/erb-comment-syntax.test.ts
+++ b/javascript/packages/linter/test/rules/erb-comment-syntax.test.ts
@@ -1,63 +1,75 @@
-import dedent from "dedent";
-import { describe, test, expect, beforeAll } from "vitest";
-import { Herb } from "@herb-tools/node-wasm";
-import { Linter } from "../../src/linter.js";
-import { ERBCommentSyntax } from "../../src/rules/erb-comment-syntax.js";
+import dedent from "dedent"
+import { describe, test, expect, beforeAll } from "vitest"
+import { Herb } from "@herb-tools/node-wasm"
+import { Linter } from "../../src/linter.js"
+import { ERBCommentSyntax } from "../../src/rules/erb-comment-syntax.js"
 
 describe("ERBCommentSyntax", () => {
   beforeAll(async () => {
-    await Herb.load();
-  });
+    await Herb.load()
+  })
 
   test("when the ERB comment syntax is correct", () => {
     const html = dedent`
       <%# good comment %>
-    `;
-    const linter = new Linter(Herb, [ERBCommentSyntax]);
-    const lintResult = linter.lint(html);
+    `
 
-    expect(lintResult.offenses).toHaveLength(0);
-  });
+    const linter = new Linter(Herb, [ERBCommentSyntax])
+    const lintResult = linter.lint(html)
+
+    expect(lintResult.offenses).toHaveLength(0)
+  })
 
   test("when the ERB multi-line comment syntax is correct", () => {
     const html = dedent`
       <%
         # good comment
       %>
-    `;
-    const linter = new Linter(Herb, [ERBCommentSyntax]);
-    const lintResult = linter.lint(html);
+    `
 
-    expect(lintResult.offenses).toHaveLength(0);
-  });
+    const linter = new Linter(Herb, [ERBCommentSyntax])
+    const lintResult = linter.lint(html)
+
+    expect(lintResult.offenses).toHaveLength(0)
+  })
+
+  test("when the ERB multi-line comment syntax is correct with multiple comment lines", () => {
+    const html = dedent`
+      <%
+        # good comment
+        # good comment
+      %>
+    `
+
+    const linter = new Linter(Herb, [ERBCommentSyntax])
+    const lintResult = linter.lint(html)
+
+    expect(lintResult.offenses).toHaveLength(0)
+  })
 
   test("when the ERB comment syntax is incorrect", () => {
     const html = dedent`
       <% # bad comment %>
-    `;
-    const linter = new Linter(Herb, [ERBCommentSyntax]);
-    const lintResult = linter.lint(html);
+    `
 
-    expect(lintResult.offenses).toHaveLength(1);
-    expect(lintResult.offenses[0].message).toContain(
-      "Bad ERB comment syntax. Should be <%# without a space between."
-    );
-  });
+    const linter = new Linter(Herb, [ERBCommentSyntax])
+    const lintResult = linter.lint(html)
+
+    expect(lintResult.offenses).toHaveLength(1)
+    expect(lintResult.offenses[0].message).toBe("Use `<%#` instead of `<% #`. Ruby comments immediately after ERB tags can cause parsing issues.")
+  })
 
   test("when the ERB comment syntax is incorrect multiple times in one file", () => {
     const html = dedent`
       <% # first bad comment %>
       <%= # second bad comment %>
-    `;
-    const linter = new Linter(Herb, [ERBCommentSyntax]);
-    const lintResult = linter.lint(html);
+    `
 
-    expect(lintResult.offenses).toHaveLength(2);
-    expect(lintResult.offenses[0].message).toContain(
-      "Bad ERB comment syntax. Should be <%# without a space between."
-    );
-    expect(lintResult.offenses[1].message).toContain(
-      "Bad ERB comment syntax. Should be <%#= without a space between."
-    );
-  });
-});
+    const linter = new Linter(Herb, [ERBCommentSyntax])
+    const lintResult = linter.lint(html)
+
+    expect(lintResult.offenses).toHaveLength(2)
+    expect(lintResult.offenses[0].message).toBe("Use `<%#` instead of `<% #`. Ruby comments immediately after ERB tags can cause parsing issues.")
+    expect(lintResult.offenses[1].message).toBe("Use `<%#` instead of `<%= #`. Ruby comments immediately after ERB tags can cause parsing issues.")
+  })
+})

--- a/javascript/packages/linter/test/rules/erb-comment-syntax.test.ts
+++ b/javascript/packages/linter/test/rules/erb-comment-syntax.test.ts
@@ -1,0 +1,63 @@
+import dedent from "dedent";
+import { describe, test, expect, beforeAll } from "vitest";
+import { Herb } from "@herb-tools/node-wasm";
+import { Linter } from "../../src/linter.js";
+import { ERBCommentSyntax } from "../../src/rules/erb-comment-syntax.js";
+
+describe("ERBCommentSyntax", () => {
+  beforeAll(async () => {
+    await Herb.load();
+  });
+
+  test("when the ERB comment syntax is correct", () => {
+    const html = dedent`
+      <%# good comment %>
+    `;
+    const linter = new Linter(Herb, [ERBCommentSyntax]);
+    const lintResult = linter.lint(html);
+
+    expect(lintResult.offenses).toHaveLength(0);
+  });
+
+  test("when the ERB multi-line comment syntax is correct", () => {
+    const html = dedent`
+      <%
+        # good comment
+      %>
+    `;
+    const linter = new Linter(Herb, [ERBCommentSyntax]);
+    const lintResult = linter.lint(html);
+
+    expect(lintResult.offenses).toHaveLength(0);
+  });
+
+  test("when the ERB comment syntax is incorrect", () => {
+    const html = dedent`
+      <% # bad comment %>
+    `;
+    const linter = new Linter(Herb, [ERBCommentSyntax]);
+    const lintResult = linter.lint(html);
+
+    expect(lintResult.offenses).toHaveLength(1);
+    expect(lintResult.offenses[0].message).toContain(
+      "Bad ERB comment syntax. Should be <%# without a space between."
+    );
+  });
+
+  test("when the ERB comment syntax is incorrect multiple times in one file", () => {
+    const html = dedent`
+      <% # first bad comment %>
+      <%= # second bad comment %>
+    `;
+    const linter = new Linter(Herb, [ERBCommentSyntax]);
+    const lintResult = linter.lint(html);
+
+    expect(lintResult.offenses).toHaveLength(2);
+    expect(lintResult.offenses[0].message).toContain(
+      "Bad ERB comment syntax. Should be <%# without a space between."
+    );
+    expect(lintResult.offenses[1].message).toContain(
+      "Bad ERB comment syntax. Should be <%#= without a space between."
+    );
+  });
+});

--- a/javascript/packages/vscode/package.json
+++ b/javascript/packages/vscode/package.json
@@ -61,6 +61,7 @@
           "items": {
             "type": "string",
             "enum": [
+              "erb-comment-syntax",
               "erb-no-empty-tags",
               "erb-no-output-control-flow",
               "erb-no-silent-tag-in-attribute-name",


### PR DESCRIPTION
Closes: #527 
Advances: https://github.com/marcoroth/herb/issues/537

This PR adds the rule `erb-comment-syntax`. It is the same rule implemented in [CommentSyntax](https://github.com/Shopify/erb_lint?tab=readme-ov-file#commentsyntax) of ERB Lint.

The rule itself avoid parsing errors in the action_view erb default parsing implementation.

Also the porting of ERB Lint rules to herb rules facilitates the adoption of Herb as a ERB Lint replacement.