### PR TITLE
Release `herb` gem via trusted publishing

### DIFF
--- a/.github/workflows/build-gems.yml
+++ b/.github/workflows/build-gems.yml
@@ -107,7 +107,6 @@ jobs:
     needs: build
     timeout-minutes: 30
     runs-on: ubuntu-latest
-    environment: deployment
     permissions:
       contents: write
       id-token: write


### PR DESCRIPTION
Following up on our discussion. This should do it. What is also needed is:

- add deployment env to your repo settings
- configure truste publidhing in rubygems

Please note I do not have a way to test it. I made it based on my: https://github.com/karafka/rdkafka-ruby/blob/main/.github/workflows/push_linux_x86_64_gnu.yml