### PR TITLE
Parser: Namespace Parser C functions

### DIFF
--- a/src/herb.c
+++ b/src/herb.c
@@ -29,9 +29,9 @@ array_T* herb_lex(const char* source) {
 
 AST_DOCUMENT_NODE_T* herb_parse(const char* source, parser_options_T* options) {
   lexer_T* lexer = lexer_init(source);
-  parser_T* parser = parser_init(lexer, options);
+  parser_T* parser = herb_parser_init(lexer, options);
 
-  AST_DOCUMENT_NODE_T* document = parser_parse(parser);
+  AST_DOCUMENT_NODE_T* document = herb_parser_parse(parser);
 
   parser_free(parser);
 

--- a/src/include/parser.h
+++ b/src/include/parser.h
@@ -28,9 +28,9 @@ typedef struct PARSER_STRUCT {
   parser_options_T* options;
 } parser_T;
 
-parser_T* parser_init(lexer_T* lexer, parser_options_T* options);
+parser_T* herb_parser_init(lexer_T* lexer, parser_options_T* options);
 
-AST_DOCUMENT_NODE_T* parser_parse(parser_T* parser);
+AST_DOCUMENT_NODE_T* herb_parser_parse(parser_T* parser);
 
 size_t parser_sizeof(void);
 

--- a/src/parser.c
+++ b/src/parser.c
@@ -31,7 +31,7 @@ size_t parser_sizeof(void) {
   return sizeof(struct PARSER_STRUCT);
 }
 
-parser_T* parser_init(lexer_T* lexer, parser_options_T* options) {
+parser_T* herb_parser_init(lexer_T* lexer, parser_options_T* options) {
   parser_T* parser = calloc(1, parser_sizeof());
 
   parser->lexer = lexer;
@@ -1223,7 +1223,7 @@ static AST_DOCUMENT_NODE_T* parser_parse_document(parser_T* parser) {
   return document_node;
 }
 
-AST_DOCUMENT_NODE_T* parser_parse(parser_T* parser) {
+AST_DOCUMENT_NODE_T* herb_parser_parse(parser_T* parser) {
   return parser_parse_document(parser);
 }
 


### PR DESCRIPTION
As painstakingly worked out with @marcoroth during Kaigi on Rails, macOS 26 Tahoe introduces a function named `parser_init` that can clobber the Herb function with the same name. Precompiled gems no longer crash on macOS 26 after this change to ensure the Herb functions will not be clobbered by the OS functions.


Resolves https://github.com/marcoroth/herb/issues/484
Resolves https://github.com/marcoroth/reactionview/issues/13
