### PR TITLE
Docs: Fix link for `html-no-self-closing` rule in README

### DIFF
--- a/javascript/packages/linter/docs/rules/README.md
+++ b/javascript/packages/linter/docs/rules/README.md
@@ -31,7 +31,7 @@ This page contains documentation for all Herb Linter rules.
 - [`html-no-empty-attributes`](./html-no-empty-attributes.md) - Attributes must not have empty values
 - [`html-no-nested-links`](./html-no-nested-links.md) - Prevents nested anchor tags
 - [`html-no-positive-tab-index`](./html-no-positive-tab-index.md) - Avoid positive `tabindex` values
-- [`html-no-self-closing`](./html-no-self-closing.md.md) - Disallow self closing tags
+- [`html-no-self-closing`](./html-no-self-closing.md) - Disallow self closing tags
 - [`html-no-title-attribute`](./html-no-title-attribute.md) - Avoid using the `title` attribute
 - [`html-tag-name-lowercase`](./html-tag-name-lowercase.md) - Enforces lowercase tag names in HTML
 - [`html-no-underscores-in-attribute-names`](./html-no-underscores-in-attribute-names.md) - Disallow underscores in HTML attribute names


### PR DESCRIPTION
This pull request makes a minor documentation fix to the Herb Linter rules list by correcting a broken link.

* Fixed the link for the `html-no-self-closing` rule in `README.md` by removing the duplicate `.md` extension.