### PR TITLE
Implement more efficient buffer resizing

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -114,7 +114,15 @@ bool buffer_expand_capacity(buffer_T* buffer) {
 bool buffer_expand_if_needed(buffer_T* buffer, const size_t required_length) {
   if (buffer_has_capacity(buffer, required_length)) { return true; }
 
-  return buffer_resize(buffer, buffer->capacity + (required_length * 2));
+  bool fits_in_doubled_buffer = required_length < buffer->capacity;
+  size_t new_capacity = 0;
+  if (fits_in_doubled_buffer) {
+    new_capacity = buffer->capacity * 2;
+  } else {
+    new_capacity = buffer->capacity + required_length * 2;
+  }
+
+  return buffer_resize(buffer, new_capacity);
 }
 
 /**

--- a/test/c/test_buffer.c
+++ b/test/c/test_buffer.c
@@ -113,6 +113,20 @@ TEST(test_buffer_expand_if_needed)
   buffer_free(&buffer);
 END
 
+TEST(test_buffer_expand_if_needed_with_nearly_full_buffer)
+  buffer_T buffer = buffer_new();
+
+  ck_assert_int_eq(buffer.capacity, 1024);
+
+  buffer_append_repeated(&buffer, ' ', 1023);
+  ck_assert_int_eq(buffer.capacity, 1024);
+
+  ck_assert(buffer_expand_if_needed(&buffer, 2));
+  ck_assert_int_eq(buffer.capacity, 2048);
+
+  buffer_free(&buffer);
+END
+
 // Test resizing buffer
 TEST(test_buffer_resize)
   buffer_T buffer = buffer_new();
@@ -229,6 +243,7 @@ TCase *buffer_tests(void) {
   tcase_add_test(buffer, test_buffer_increase_capacity);
   tcase_add_test(buffer, test_buffer_expand_capacity);
   tcase_add_test(buffer, test_buffer_expand_if_needed);
+  tcase_add_test(buffer, test_buffer_expand_if_needed_with_nearly_full_buffer);
   tcase_add_test(buffer, test_buffer_resize);
   tcase_add_test(buffer, test_buffer_clear);
   tcase_add_test(buffer, test_buffer_free);


### PR DESCRIPTION
## Problem

If the buffer is nearly full even one extra character can trigger an expansion of the buffer. Since the buffer only grows by two characters at a time, this can lead to frequent resizing.

### Visualization

![buffer_problem](https://github.com/user-attachments/assets/11658cf7-1ab5-41fe-8a75-fc6eaddfb80a)

## How the problem is addressed

Rather than just checking the required length, we test whether doubling the current capacity will be enough. If it is, we expand to the doubled capacity. If not, we double the required length itself and resize the buffer to that size.

## Performance impact

Lexing a  [real world html page](https://shop.herthabsc.com)

Before: ~88.255ms

After: ~79.208ms

Parsing showed no significant performance impact though