### PR TITLE
Parser: Fix parsing boolean attributes with `track_whitespace`

### DIFF
--- a/javascript/packages/linter/test/rules/html-no-empty-headings.test.ts
+++ b/javascript/packages/linter/test/rules/html-no-empty-headings.test.ts
@@ -10,7 +10,7 @@ describe("html-no-empty-headings", () => {
 
   test("passes for heading with text content", () => {
     const html = '<h1>Heading Content</h1>'
-    
+
     const linter = new Linter(Herb, [HTMLNoEmptyHeadingsRule])
     const lintResult = linter.lint(html)
 
@@ -21,7 +21,7 @@ describe("html-no-empty-headings", () => {
 
   test("passes for heading with nested elements", () => {
     const html = '<h2><span>Text</span></h2>'
-    
+
     const linter = new Linter(Herb, [HTMLNoEmptyHeadingsRule])
     const lintResult = linter.lint(html)
 
@@ -32,7 +32,7 @@ describe("html-no-empty-headings", () => {
 
   test("passes for heading with ERB content", () => {
     const html = '<h3><%= title %></h3>'
-    
+
     const linter = new Linter(Herb, [HTMLNoEmptyHeadingsRule])
     const lintResult = linter.lint(html)
 
@@ -43,7 +43,7 @@ describe("html-no-empty-headings", () => {
 
   test("fails for empty heading", () => {
     const html = '<h1></h1>'
-    
+
     const linter = new Linter(Herb, [HTMLNoEmptyHeadingsRule])
     const lintResult = linter.lint(html)
 
@@ -58,7 +58,7 @@ describe("html-no-empty-headings", () => {
 
   test("fails for heading with only whitespace", () => {
     const html = '<h2>   \n\t  </h2>'
-    
+
     const linter = new Linter(Herb, [HTMLNoEmptyHeadingsRule])
     const lintResult = linter.lint(html)
 
@@ -72,7 +72,7 @@ describe("html-no-empty-headings", () => {
 
   test("fails for self-closing heading", () => {
     const html = '<h3 />'
-    
+
     const linter = new Linter(Herb, [HTMLNoEmptyHeadingsRule])
     const lintResult = linter.lint(html)
 
@@ -86,7 +86,7 @@ describe("html-no-empty-headings", () => {
 
   test("handles all heading levels h1-h6", () => {
     const html = '<h1></h1><h2></h2><h3></h3><h4></h4><h5></h5><h6></h6>'
-    
+
     const linter = new Linter(Herb, [HTMLNoEmptyHeadingsRule])
     const lintResult = linter.lint(html)
 
@@ -101,7 +101,7 @@ describe("html-no-empty-headings", () => {
 
   test("handles mixed case heading tags", () => {
     const html = '<H1></H1>'
-    
+
     const linter = new Linter(Herb, [HTMLNoEmptyHeadingsRule])
     const lintResult = linter.lint(html)
 
@@ -111,7 +111,7 @@ describe("html-no-empty-headings", () => {
 
   test("ignores non-heading tags", () => {
     const html = '<div></div><p></p>'
-    
+
     const linter = new Linter(Herb, [HTMLNoEmptyHeadingsRule])
     const lintResult = linter.lint(html)
 
@@ -121,7 +121,7 @@ describe("html-no-empty-headings", () => {
 
   test("passes for headings with mixed content", () => {
     const html = '<h1>Welcome <%= user.name %>!</h1>'
-    
+
     const linter = new Linter(Herb, [HTMLNoEmptyHeadingsRule])
     const lintResult = linter.lint(html)
 
@@ -131,7 +131,7 @@ describe("html-no-empty-headings", () => {
 
   test("passes for heading with only ERB", () => {
     const html = '<h1><%= page.title %></h1>'
-    
+
     const linter = new Linter(Herb, [HTMLNoEmptyHeadingsRule])
     const lintResult = linter.lint(html)
 
@@ -141,7 +141,7 @@ describe("html-no-empty-headings", () => {
 
   test("handles multiple empty headings", () => {
     const html = '<h1></h1><h2>Valid</h2><h3></h3>'
-    
+
     const linter = new Linter(Herb, [HTMLNoEmptyHeadingsRule])
     const lintResult = linter.lint(html)
 
@@ -152,7 +152,7 @@ describe("html-no-empty-headings", () => {
 
   test("passes for div with role='heading' and content", () => {
     const html = '<div role="heading" aria-level="1">Heading Content</div>'
-    
+
     const linter = new Linter(Herb, [HTMLNoEmptyHeadingsRule])
     const lintResult = linter.lint(html)
 
@@ -163,7 +163,7 @@ describe("html-no-empty-headings", () => {
 
   test("fails for empty div with role='heading'", () => {
     const html = '<div role="heading" aria-level="1"></div>'
-    
+
     const linter = new Linter(Herb, [HTMLNoEmptyHeadingsRule])
     const lintResult = linter.lint(html)
 
@@ -178,7 +178,7 @@ describe("html-no-empty-headings", () => {
 
   test("fails for div with role='heading' containing only whitespace", () => {
     const html = '<div role="heading" aria-level="2">   </div>'
-    
+
     const linter = new Linter(Herb, [HTMLNoEmptyHeadingsRule])
     const lintResult = linter.lint(html)
 
@@ -191,7 +191,7 @@ describe("html-no-empty-headings", () => {
 
   test("fails for self-closing div with role='heading'", () => {
     const html = '<div role="heading" aria-level="3" />'
-    
+
     const linter = new Linter(Herb, [HTMLNoEmptyHeadingsRule])
     const lintResult = linter.lint(html)
 
@@ -204,7 +204,7 @@ describe("html-no-empty-headings", () => {
 
   test("ignores div without role='heading'", () => {
     const html = '<div></div><div role="button">Button</div>'
-    
+
     const linter = new Linter(Herb, [HTMLNoEmptyHeadingsRule])
     const lintResult = linter.lint(html)
 
@@ -215,7 +215,7 @@ describe("html-no-empty-headings", () => {
 
   test("handles mixed standard headings and ARIA headings", () => {
     const html = '<h1></h1><div role="heading">Valid</div><h2>Valid</h2><div role="heading"></div>'
-    
+
     const linter = new Linter(Herb, [HTMLNoEmptyHeadingsRule])
     const lintResult = linter.lint(html)
 
@@ -229,7 +229,7 @@ describe("html-no-empty-headings", () => {
 
   test("fails for heading with only aria-hidden content", () => {
     const html = '<h1><span aria-hidden="true">Inaccessible text</span></h1>'
-    
+
     const linter = new Linter(Herb, [HTMLNoEmptyHeadingsRule])
     const lintResult = linter.lint(html)
 
@@ -244,7 +244,7 @@ describe("html-no-empty-headings", () => {
 
   test("fails for heading with mixed accessible and inaccessible content", () => {
     const html = '<h2><span aria-hidden="true">Hidden</span><span aria-hidden="true">Also hidden</span></h2>'
-    
+
     const linter = new Linter(Herb, [HTMLNoEmptyHeadingsRule])
     const lintResult = linter.lint(html)
 
@@ -255,7 +255,7 @@ describe("html-no-empty-headings", () => {
 
   test("passes for heading with mix of accessible and inaccessible content", () => {
     const html = '<h3>Visible text<span aria-hidden="true">Hidden text</span></h3>'
-    
+
     const linter = new Linter(Herb, [HTMLNoEmptyHeadingsRule])
     const lintResult = linter.lint(html)
 
@@ -266,7 +266,7 @@ describe("html-no-empty-headings", () => {
 
   test("passes for heading itself with aria-hidden='true' but has content", () => {
     const html = '<h1 aria-hidden="true">Heading Content</h1>'
-    
+
     const linter = new Linter(Herb, [HTMLNoEmptyHeadingsRule])
     const lintResult = linter.lint(html)
 
@@ -277,7 +277,7 @@ describe("html-no-empty-headings", () => {
 
   test("passes for heading itself with hidden attribute but has content", () => {
     const html = '<h2 hidden>Heading Content</h2>'
-    
+
     const linter = new Linter(Herb, [HTMLNoEmptyHeadingsRule])
     const lintResult = linter.lint(html)
 
@@ -288,7 +288,18 @@ describe("html-no-empty-headings", () => {
 
   test("passes for heading with nested span containing text", () => {
     const html = '<h3><span>Text</span></h3>'
-    
+
+    const linter = new Linter(Herb, [HTMLNoEmptyHeadingsRule])
+    const lintResult = linter.lint(html)
+
+    expect(lintResult.errors).toBe(0)
+    expect(lintResult.warnings).toBe(0)
+    expect(lintResult.offenses).toHaveLength(0)
+  })
+
+  test("passes for heading with nested span containing text", () => {
+    const html = '<h2 class="class" data-turbo-temporary><%= content %></h2>'
+
     const linter = new Linter(Herb, [HTMLNoEmptyHeadingsRule])
     const lintResult = linter.lint(html)
 

--- a/javascript/packages/linter/test/rules/parser-no-errors.test.ts
+++ b/javascript/packages/linter/test/rules/parser-no-errors.test.ts
@@ -205,4 +205,17 @@ describe("ParserNoErrorsRule", () => {
     expect(lintResult.offenses[2].message).toBe("Opening tag `<h2>` at (1:1) doesn't have a matching closing tag `</h2>`. (`MISSING_CLOSING_TAG_ERROR`)")
     expect(lintResult.offenses[3].message).toBe("Opening tag `<h2>` at (1:25) doesn't have a matching closing tag `</h2>`. (`MISSING_CLOSING_TAG_ERROR`)")
   })
+
+  test("html element ending with boolean attribute followed by ERB tag", () => {
+    const html = dedent`
+      <link crossorigin>
+      <%= hello %>
+    `
+
+    const linter = new Linter(Herb, [ParserNoErrorsRule ])
+    const lintResult = linter.lint(html)
+
+    expect(lintResult.errors).toBe(0)
+    expect(lintResult.offenses).toHaveLength(0)
+  })
 })

--- a/src/lexer_peek_helpers.c
+++ b/src/lexer_peek_helpers.c
@@ -77,6 +77,7 @@ bool lexer_peek_for_token_type_after_whitespace(lexer_T* lexer, token_type_T tok
   size_t saved_line = lexer->current_line;
   size_t saved_column = lexer->current_column;
   char saved_character = lexer->current_character;
+  lexer_state_T saved_state = lexer->state;
 
   token_T* token = lexer_next_token(lexer);
 
@@ -93,6 +94,7 @@ bool lexer_peek_for_token_type_after_whitespace(lexer_T* lexer, token_type_T tok
   lexer->current_line = saved_line;
   lexer->current_column = saved_column;
   lexer->current_character = saved_character;
+  lexer->state = saved_state;
 
   return result;
 }

--- a/test/parser/boolean_attributes_test.rb
+++ b/test/parser/boolean_attributes_test.rb
@@ -37,5 +37,13 @@ module Parser
     test "boolean attribute on void element followed by ERB tag with track_whitespace" do
       assert_parsed_snapshot(%(<link crossorigin><%= hello %>), track_whitespace: true)
     end
+
+    test "boolean attribute on void element followed by ERB tag with track_whitespace" do
+      assert_parsed_snapshot(<<~HTML, track_whitespace: true)
+        <div id="test" hidden>
+          <%= "hi" %>
+        </div>
+      HTML
+    end
   end
 end

--- a/test/parser/boolean_attributes_test.rb
+++ b/test/parser/boolean_attributes_test.rb
@@ -29,5 +29,13 @@ module Parser
     test "boolean attribute surrounded by regular attributes" do
       assert_parsed_snapshot(%(<input class="classes" required id="ids"/>))
     end
+
+    test "boolean attribute on void element followed by newline and ERB tag with track_whitespace" do
+      assert_parsed_snapshot(%(<link crossorigin>\n<%= hello %>), track_whitespace: true)
+    end
+
+    test "boolean attribute on void element followed by ERB tag with track_whitespace" do
+      assert_parsed_snapshot(%(<link crossorigin><%= hello %>), track_whitespace: true)
+    end
   end
 end

--- a/test/snapshots/parser/boolean_attributes_test/test_0007_boolean_attribute_on_void_element_followed_by_newline_and_ERB_tag_with_track_whitespace_865f46b916df0289c3b60c880f529e8b-b26dbda6d8a652930695c93bd07179f4.txt
+++ b/test/snapshots/parser/boolean_attributes_test/test_0007_boolean_attribute_on_void_element_followed_by_newline_and_ERB_tag_with_track_whitespace_865f46b916df0289c3b60c880f529e8b-b26dbda6d8a652930695c93bd07179f4.txt
@@ -1,0 +1,40 @@
+@ DocumentNode (location: (1:0)-(2:12))
+└── children: (3 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:18))
+    │   ├── open_tag:
+    │   │   └── @ HTMLOpenTagNode (location: (1:0)-(1:18))
+    │   │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+    │   │       ├── tag_name: "link" (location: (1:1)-(1:5))
+    │   │       ├── tag_closing: ">" (location: (1:17)-(1:18))
+    │   │       ├── children: (2 items)
+    │   │       │   ├── @ WhitespaceNode (location: (1:5)-(1:6))
+    │   │       │   │   └── value: " " (location: (1:5)-(1:6))
+    │   │       │   │
+    │   │       │   └── @ HTMLAttributeNode (location: (1:6)-(1:17))
+    │   │       │       ├── name:
+    │   │       │       │   └── @ HTMLAttributeNameNode (location: (1:6)-(1:17))
+    │   │       │       │       └── children: (1 item)
+    │   │       │       │           └── @ LiteralNode (location: (1:6)-(1:17))
+    │   │       │       │               └── content: "crossorigin"
+    │   │       │       │
+    │   │       │       │
+    │   │       │       ├── equals: ∅
+    │   │       │       └── value: ∅
+    │   │       │
+    │   │       └── is_void: false
+    │   │
+    │   ├── tag_name: "link" (location: (1:1)-(1:5))
+    │   ├── body: []
+    │   ├── close_tag: ∅
+    │   ├── is_void: true
+    │   └── source: "HTML"
+    │
+    ├── @ HTMLTextNode (location: (2:3)-(2:0))
+    │   └── content: "\n"
+    │
+    └── @ ERBContentNode (location: (2:0)-(2:12))
+        ├── tag_opening: "<%=" (location: (2:0)-(2:3))
+        ├── content: " hello " (location: (2:3)-(2:10))
+        ├── tag_closing: "%>" (location: (2:10)-(2:12))
+        ├── parsed: true
+        └── valid: true

--- a/test/snapshots/parser/boolean_attributes_test/test_0008_boolean_attribute_on_void_element_followed_by_ERB_tag_with_track_whitespace_7a98c943c925e6943aaa2bec978901a9-b26dbda6d8a652930695c93bd07179f4.txt
+++ b/test/snapshots/parser/boolean_attributes_test/test_0008_boolean_attribute_on_void_element_followed_by_ERB_tag_with_track_whitespace_7a98c943c925e6943aaa2bec978901a9-b26dbda6d8a652930695c93bd07179f4.txt
@@ -1,0 +1,37 @@
+@ DocumentNode (location: (1:0)-(1:30))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:18))
+    │   ├── open_tag:
+    │   │   └── @ HTMLOpenTagNode (location: (1:0)-(1:18))
+    │   │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+    │   │       ├── tag_name: "link" (location: (1:1)-(1:5))
+    │   │       ├── tag_closing: ">" (location: (1:17)-(1:18))
+    │   │       ├── children: (2 items)
+    │   │       │   ├── @ WhitespaceNode (location: (1:5)-(1:6))
+    │   │       │   │   └── value: " " (location: (1:5)-(1:6))
+    │   │       │   │
+    │   │       │   └── @ HTMLAttributeNode (location: (1:6)-(1:17))
+    │   │       │       ├── name:
+    │   │       │       │   └── @ HTMLAttributeNameNode (location: (1:6)-(1:17))
+    │   │       │       │       └── children: (1 item)
+    │   │       │       │           └── @ LiteralNode (location: (1:6)-(1:17))
+    │   │       │       │               └── content: "crossorigin"
+    │   │       │       │
+    │   │       │       │
+    │   │       │       ├── equals: ∅
+    │   │       │       └── value: ∅
+    │   │       │
+    │   │       └── is_void: false
+    │   │
+    │   ├── tag_name: "link" (location: (1:1)-(1:5))
+    │   ├── body: []
+    │   ├── close_tag: ∅
+    │   ├── is_void: true
+    │   └── source: "HTML"
+    │
+    └── @ ERBContentNode (location: (1:21)-(1:30))
+        ├── tag_opening: "<%=" (location: (1:21)-(1:21))
+        ├── content: " hello " (location: (1:21)-(1:28))
+        ├── tag_closing: "%>" (location: (1:28)-(1:30))
+        ├── parsed: true
+        └── valid: true

--- a/test/snapshots/parser/boolean_attributes_test/test_0009_boolean_attribute_on_void_element_followed_by_ERB_tag_with_track_whitespace_1d3295149578acc142f855bb3b75b3ec-b26dbda6d8a652930695c93bd07179f4.txt
+++ b/test/snapshots/parser/boolean_attributes_test/test_0009_boolean_attribute_on_void_element_followed_by_ERB_tag_with_track_whitespace_1d3295149578acc142f855bb3b75b3ec-b26dbda6d8a652930695c93bd07179f4.txt
@@ -1,0 +1,75 @@
+@ DocumentNode (location: (1:0)-(4:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(3:6))
+    │   ├── open_tag:
+    │   │   └── @ HTMLOpenTagNode (location: (1:0)-(1:22))
+    │   │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+    │   │       ├── tag_name: "div" (location: (1:1)-(1:4))
+    │   │       ├── tag_closing: ">" (location: (1:21)-(1:22))
+    │   │       ├── children: (4 items)
+    │   │       │   ├── @ WhitespaceNode (location: (1:4)-(1:5))
+    │   │       │   │   └── value: " " (location: (1:4)-(1:5))
+    │   │       │   │
+    │   │       │   ├── @ HTMLAttributeNode (location: (1:5)-(1:14))
+    │   │       │   │   ├── name:
+    │   │       │   │   │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:7))
+    │   │       │   │   │       └── children: (1 item)
+    │   │       │   │   │           └── @ LiteralNode (location: (1:5)-(1:7))
+    │   │       │   │   │               └── content: "id"
+    │   │       │   │   │
+    │   │       │   │   │
+    │   │       │   │   ├── equals: "=" (location: (1:7)-(1:8))
+    │   │       │   │   └── value:
+    │   │       │   │       └── @ HTMLAttributeValueNode (location: (1:8)-(1:14))
+    │   │       │   │           ├── open_quote: """ (location: (1:8)-(1:9))
+    │   │       │   │           ├── children: (1 item)
+    │   │       │   │           │   └── @ LiteralNode (location: (1:9)-(1:13))
+    │   │       │   │           │       └── content: "test"
+    │   │       │   │           │
+    │   │       │   │           ├── close_quote: """ (location: (1:13)-(1:14))
+    │   │       │   │           └── quoted: true
+    │   │       │   │
+    │   │       │   │
+    │   │       │   ├── @ WhitespaceNode (location: (1:14)-(1:15))
+    │   │       │   │   └── value: " " (location: (1:14)-(1:15))
+    │   │       │   │
+    │   │       │   └── @ HTMLAttributeNode (location: (1:15)-(1:21))
+    │   │       │       ├── name:
+    │   │       │       │   └── @ HTMLAttributeNameNode (location: (1:15)-(1:21))
+    │   │       │       │       └── children: (1 item)
+    │   │       │       │           └── @ LiteralNode (location: (1:15)-(1:21))
+    │   │       │       │               └── content: "hidden"
+    │   │       │       │
+    │   │       │       │
+    │   │       │       ├── equals: ∅
+    │   │       │       └── value: ∅
+    │   │       │
+    │   │       └── is_void: false
+    │   │
+    │   ├── tag_name: "div" (location: (1:1)-(1:4))
+    │   ├── body: (3 items)
+    │   │   ├── @ HTMLTextNode (location: (2:5)-(2:2))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ ERBContentNode (location: (2:2)-(2:13))
+    │   │   │   ├── tag_opening: "<%=" (location: (2:2)-(2:5))
+    │   │   │   ├── content: " "hi" " (location: (2:5)-(2:11))
+    │   │   │   ├── tag_closing: "%>" (location: (2:11)-(2:13))
+    │   │   │   ├── parsed: true
+    │   │   │   └── valid: true
+    │   │   │
+    │   │   └── @ HTMLTextNode (location: (2:13)-(3:0))
+    │   │       └── content: "\n"
+    │   │
+    │   ├── close_tag:
+    │   │   └── @ HTMLCloseTagNode (location: (3:0)-(3:6))
+    │   │       ├── tag_opening: "</" (location: (3:0)-(3:2))
+    │   │       ├── tag_name: "div" (location: (3:2)-(3:5))
+    │   │       ├── children: []
+    │   │       └── tag_closing: ">" (location: (3:5)-(3:6))
+    │   │
+    │   ├── is_void: false
+    │   └── source: "HTML"
+    │
+    └── @ HTMLTextNode (location: (3:6)-(4:0))
+        └── content: "\n"


### PR DESCRIPTION
This pull request updates the parser to fix a bug where an HTML element with a boolean attribute as the final attribute would cause a parser error when the `track_whitespace` parser option is set.

This snippet parses fine using `track_whitespace: false`
```html+erb
<input required><%= content %>
```

But with `track_whitespace: true` it would fail with:
```
Unexpected token. Expected: `TOKEN_ERB_START, TOKEN_HTML_DOCTYPE, TOKEN_HTML_COMMENT_START, TOKEN_IDENTIFIER, TOKEN_WHITESPACE, TOKEN_NBSP, TOKEN_AT, or TOKE`, found: `TOKEN_ERB_CONTENT`. Line 1:19

Unexpected token. Expected: `TOKEN_ERB_START, TOKEN_HTML_DOCTYPE, TOKEN_HTML_COMMENT_START, TOKEN_IDENTIFIER, TOKEN_WHITESPACE, TOKEN_NBSP, TOKEN_AT, or TOKE`, found: `TOKEN_ERB_END`. Line 1:28
```

Resolves #471 
Resolves #525 
Resolves #558 