### PR TITLE
Add `visitNode` and `visitERBNode` methods to improve `erb-right-trim`

### DIFF
--- a/javascript/packages/linter/docs/rules/README.md
+++ b/javascript/packages/linter/docs/rules/README.md
@@ -11,7 +11,7 @@ This page contains documentation for all Herb Linter rules.
 - [`erb-prefer-image-tag-helper`](./erb-prefer-image-tag-helper.md) - Prefer `image_tag` helper over `<img>` with ERB expressions
 - [`erb-require-whitespace-inside-tags`](./erb-require-whitespace-inside-tags.md) - Requires whitespace around ERB tags
 - [`erb-requires-trailing-newline`](./erb-requires-trailing-newline.md) - Enforces that all HTML+ERB template files end with exactly one trailing newline character.
-- [`erb-right-trim`](./erb-right-trim.md) - Enforces trimming with `-`
+- [`erb-right-trim`](./erb-right-trim.md) - Enforce consistent right-trimming syntax.
 - [`html-anchor-require-href`](./html-anchor-require-href.md) - Requires an href attribute on anchor tags
 - [`html-aria-attribute-must-be-valid`](./html-aria-attribute-must-be-valid.md) - Disallow invalid or unknown `aria-*` attributes.
 - [`html-aria-label-is-well-formatted`](./html-aria-label-is-well-formatted.md) - `aria-label` must be well-formatted

--- a/javascript/packages/linter/docs/rules/erb-right-trim.md
+++ b/javascript/packages/linter/docs/rules/erb-right-trim.md
@@ -1,23 +1,57 @@
-# Linter Rule: Enforces trimming with -
+# Linter Rule: Enforce consistent right-trimming syntax
 
-**Rule:**: `erb-right-trim`
+**Rule:** `erb-right-trim`
 
-Trimming at the right of an ERB tag can be done with either =%&gt; or -%&gt;, this linter enforces "-" as the default trimming style.
+## Description
+
+This rule enforces the use of `-%>` for right-trimming ERB output tags (like `<%= %>`) instead of `=%>`. It also warns when right-trimming syntax (`-%>` or `=%>`) is used on non-output ERB tags (like `<% %>`, `<% if %>`, etc.) where it has no effect.
+
+## Rationale
+
+While `=%>` can be used for right-trimming whitespace in some ERB engines (like Erubi), it is an obscure and not well-defined syntax that lacks consistent support across most ERB implementations. The `-%>` syntax is the standard, well-documented approach for right-trimming that is universally supported and consistent with left-trimming syntax (`<%-`).
+
+Additionally, right-trimming syntax only has an effect on ERB output tags (`<%=` and `<%==`). Using `-%>` or `=%>` on non-output ERB tags (control flow like `<% if %>`, `<% each %>`, etc.) has no effect and is misleading.
+
+Using `-%>` for output tags ensures compatibility across different ERB engines, improves code clarity, and aligns with established Rails and ERB conventions.
 
 ## Examples
 
-### ❌ Incorrect
-
-```erb
-<%= title =%>
-```
-
-### ✅ Correct
+### ✅ Good
 
 ```erb
 <%= title -%>
+
+<% if true %>
+  <h1>Content</h1>
+<% end %>
+
+<% items.each do |item| %>
+  <li><%= item -%></li>
+<% end %>
 ```
 
-## Configuration
+### 🚫 Bad
 
-This rule has no configuration options.
+```erb
+<%= title =%>
+
+
+<% title =%>
+
+
+<% title -%>
+
+
+<% if true -%>
+  <h1>Content</h1>
+<% end %>
+
+
+<% items.each do |item| =%>
+  <li><%= item %></li>
+<% end %>
+```
+
+## References
+
+- [Inspiration: ERB Lint `RightTrim` rule](https://github.com/Shopify/erb_lint/blob/main/README.md#righttrim)

--- a/javascript/packages/linter/src/rules/rule-utils.ts
+++ b/javascript/packages/linter/src/rules/rule-utils.ts
@@ -13,7 +13,7 @@ import {
 } from "@herb-tools/core"
 
 import type {
-  ERBNode,
+  ERBContentNode,
   HTMLAttributeNameNode,
   HTMLAttributeNode,
   HTMLAttributeValueNode,
@@ -300,7 +300,7 @@ export function getAttributeValue(attributeNode: HTMLAttributeNode): string | nu
   for (const child of valueNode.children) {
     switch (child.type) {
       case "AST_ERB_CONTENT_NODE": {
-        const erbNode = child as ERBNode
+        const erbNode = child as ERBContentNode
 
         if (erbNode.content) {
           result += `${erbNode.tag_opening?.value}${erbNode.content.value}${erbNode.tag_closing?.value}`

--- a/javascript/packages/linter/test/rules/erb-right-trim.test.ts
+++ b/javascript/packages/linter/test/rules/erb-right-trim.test.ts
@@ -46,6 +46,102 @@ describe("ERBRightTrimRule", () => {
     expect(lintResult.warnings).toBe(0)
     expect(lintResult.offenses).toHaveLength(1)
     expect(lintResult.offenses[0].code).toBe("erb-right-trim")
-    expect(lintResult.offenses[0].message).toBe("Prefer -%> instead of =%> for trimming on the right")
+    expect(lintResult.offenses[0].message).toBe("Use `-%>` instead of `=%>` for right-trimming. The `=%>` syntax is obscure and not well-supported in most ERB engines")
+  })
+
+  test("when an if block uses =%>", () => {
+    const html = dedent`
+      <% if condition =%>
+        <p>Content</p>
+      <% end %>
+    `
+    const linter = new Linter(Herb, [ERBRightTrimRule])
+    const lintResult = linter.lint(html)
+
+    expect(lintResult.errors).toBe(1)
+    expect(lintResult.warnings).toBe(0)
+    expect(lintResult.offenses).toHaveLength(1)
+    expect(lintResult.offenses[0].code).toBe("erb-right-trim")
+    expect(lintResult.offenses[0].message).toBe("Right-trimming with `=%>` has no effect on non-output ERB tags. Use `%>` instead")
+  })
+
+  test("when an if-else block uses =%>", () => {
+    const html = dedent`
+      <% if condition =%>
+        <p>True branch</p>
+      <% else =%>
+        <p>False branch</p>
+      <% end %>
+    `
+    const linter = new Linter(Herb, [ERBRightTrimRule])
+    const lintResult = linter.lint(html)
+
+    expect(lintResult.errors).toBe(2)
+    expect(lintResult.warnings).toBe(0)
+    expect(lintResult.offenses).toHaveLength(2)
+    expect(lintResult.offenses[0].code).toBe("erb-right-trim")
+
+    expect(lintResult.offenses[0].message).toBe("Right-trimming with `=%>` has no effect on non-output ERB tags. Use `%>` instead")
+    expect(lintResult.offenses[1].message).toBe("Right-trimming with `=%>` has no effect on non-output ERB tags. Use `%>` instead")
+  })
+
+  test("when each block uses =%>", () => {
+    const html = dedent`
+      <% items.each do |item| =%>
+        <li><%= item %></li>
+      <% end %>
+    `
+    const linter = new Linter(Herb, [ERBRightTrimRule])
+    const lintResult = linter.lint(html)
+
+    expect(lintResult.errors).toBe(1)
+    expect(lintResult.warnings).toBe(0)
+    expect(lintResult.offenses).toHaveLength(1)
+    expect(lintResult.offenses[0].code).toBe("erb-right-trim")
+    expect(lintResult.offenses[0].message).toBe("Right-trimming with `=%>` has no effect on non-output ERB tags. Use `%>` instead")
+  })
+
+  test("when non-output tag uses -%>", () => {
+    const html = dedent`
+      <% if condition -%>
+        <p>Content</p>
+      <% elsif other_condition -%>
+        <p>Content</p>
+      <% elsif yet_another_condition -%>
+        <p>Content</p>
+      <% else -%>
+        <p>Content</p>
+      <% end -%>
+    `
+    const linter = new Linter(Herb, [ERBRightTrimRule])
+    const lintResult = linter.lint(html)
+
+    expect(lintResult.errors).toBe(5)
+    expect(lintResult.warnings).toBe(0)
+    expect(lintResult.offenses).toHaveLength(5)
+
+    expect(lintResult.offenses[0].code).toBe("erb-right-trim")
+    expect(lintResult.offenses[0].message).toBe("Right-trimming with `-%>` has no effect on non-output ERB tags. Use `%>` instead")
+    expect(lintResult.offenses[1].message).toBe("Right-trimming with `-%>` has no effect on non-output ERB tags. Use `%>` instead")
+    expect(lintResult.offenses[2].message).toBe("Right-trimming with `-%>` has no effect on non-output ERB tags. Use `%>` instead")
+    expect(lintResult.offenses[3].message).toBe("Right-trimming with `-%>` has no effect on non-output ERB tags. Use `%>` instead")
+    expect(lintResult.offenses[4].message).toBe("Right-trimming with `-%>` has no effect on non-output ERB tags. Use `%>` instead")
+  })
+
+  test("when multiple non-output tags use trimming", () => {
+    const html = dedent`
+      <% items.each do |item| -%>
+        <li><%= item %></li>
+      <% end -%>
+    `
+    const linter = new Linter(Herb, [ERBRightTrimRule])
+    const lintResult = linter.lint(html)
+
+    expect(lintResult.errors).toBe(2)
+    expect(lintResult.warnings).toBe(0)
+    expect(lintResult.offenses).toHaveLength(2)
+
+    expect(lintResult.offenses[0].message).toBe("Right-trimming with `-%>` has no effect on non-output ERB tags. Use `%>` instead")
+    expect(lintResult.offenses[1].message).toBe("Right-trimming with `-%>` has no effect on non-output ERB tags. Use `%>` instead")
   })
 })

--- a/templates/javascript/packages/core/src/visitor.ts.erb
+++ b/templates/javascript/packages/core/src/visitor.ts.erb
@@ -1,11 +1,27 @@
 import {
   Node,
+  ERBNode,
   <%- nodes.each do |node| -%>
   <%= node.name %>,
   <%- end -%>
 } from "./nodes.js"
 
-export class Visitor {
+/**
+ * Interface that enforces all node visit methods are implemented
+ * This ensures that any class implementing IVisitor must have a visit method for every node type
+ */
+export interface IVisitor {
+  visit(node: Node | null | undefined): void
+  visitAll(nodes: (Node | null | undefined)[]): void
+  visitChildNodes(node: Node): void
+  <%- nodes.each do |node| -%>
+  visit<%= node.name %>(node: <%= node.name %>): void
+  <%- end -%>
+  visitNode(node: Node): void
+  visitERBNode(node: ERBNode): void
+}
+
+export class Visitor implements IVisitor {
   visit(node: Node | null | undefined): void {
     if (!node) return
 
@@ -20,8 +36,20 @@ export class Visitor {
     node.compactChildNodes().forEach(node => node.accept(this))
   }
 
+  visitNode(_node: Node): void {
+    // Default implementation does nothing
+  }
+
+  visitERBNode(_node: ERBNode): void {
+    // Default implementation does nothing
+  }
+
   <%- nodes.each do |node| -%>
   visit<%= node.name %>(node: <%= node.name %>): void {
+    this.visitNode(node)
+    <%- if node.name.start_with?("ERB") -%>
+    this.visitERBNode(node)
+    <%- end -%>
     this.visitChildNodes(node)
   }
 


### PR DESCRIPTION
This pull request introduces two new methods `visitNode(node: Node)` and `visitERBNode(node: ERBNode)` in the JavaScript visitor that allows to visit any node, or visit any ERB node. This is useful and allows us to improve the `erb-right-trim` introduced in #556.

This now updates the `erb-right-trim` to also handle cases where the right trimming is used when it has no effect (like on non-outputting ERB Nodes like `<%`).

/cc @domingo2000