### PR TITLE
Linter Rule: Refactor `erb-require-whitespace-inside-tags` to use `visitERBNode`

### DIFF
--- a/javascript/packages/linter/src/rules/erb-require-whitespace-inside-tags.ts
+++ b/javascript/packages/linter/src/rules/erb-require-whitespace-inside-tags.ts
@@ -1,20 +1,12 @@
-import type { ParseResult, Token, Node } from "@herb-tools/core"
-import { isERBNode } from "@herb-tools/core";
 import { ParserRule } from "../types.js"
-import type { LintOffense, LintContext } from "../types.js"
 import { BaseRuleVisitor } from "./rule-utils.js"
+
+import type { LintOffense, LintContext } from "../types.js"
+import type { ParseResult, Token, ERBNode } from "@herb-tools/core"
 
 class RequireWhitespaceInsideTags extends BaseRuleVisitor {
 
-  visitChildNodes(node: Node): void {
-    this.checkWhitespace(node)
-    super.visitChildNodes(node)
-  }
-
-  private checkWhitespace(node: Node): void {
-    if (!isERBNode(node)) {
-      return
-    }
+  visitERBNode(node: ERBNode): void {
     const openTag = node.tag_opening
     const closeTag = node.tag_closing
     const content = node.content


### PR DESCRIPTION
This pull request updates the `erb-require-whitespace-inside-tags` linter rule to use the new `visitERBNode` method in the visitor introduced in #569.