### PR TITLE
Parser: Analyze `case` statements with `yield` as `ERBCaseNode`

### DIFF
--- a/src/analyze.c
+++ b/src/analyze.c
@@ -96,12 +96,8 @@ static control_type_t detect_control_type(AST_ERB_CONTENT_NODE_T* erb_node) {
 
   if (!ruby) { return CONTROL_TYPE_UNKNOWN; }
 
-  if (ruby->valid) {
-    if (has_yield_node(ruby)) { return CONTROL_TYPE_YIELD; }
-    return CONTROL_TYPE_UNKNOWN;
-  }
+  if (ruby->valid) { return CONTROL_TYPE_UNKNOWN; }
 
-  if (has_yield_node(ruby)) { return CONTROL_TYPE_YIELD; }
   if (has_block_node(ruby)) { return CONTROL_TYPE_BLOCK; }
   if (has_if_node(ruby)) { return CONTROL_TYPE_IF; }
   if (has_elsif_node(ruby)) { return CONTROL_TYPE_ELSIF; }
@@ -119,6 +115,7 @@ static control_type_t detect_control_type(AST_ERB_CONTENT_NODE_T* erb_node) {
   if (has_until_node(ruby)) { return CONTROL_TYPE_UNTIL; }
   if (has_for_node(ruby)) { return CONTROL_TYPE_FOR; }
   if (has_block_closing(ruby)) { return CONTROL_TYPE_BLOCK_CLOSE; }
+  if (has_yield_node(ruby)) { return CONTROL_TYPE_YIELD; }
 
   return CONTROL_TYPE_UNKNOWN;
 }

--- a/test/analyze/case_test.rb
+++ b/test/analyze/case_test.rb
@@ -154,5 +154,14 @@ module Analyze
         <% end %>
       HTML
     end
+
+    test "case with yield" do
+      assert_parsed_snapshot(<<~HTML)
+        <% case yield(:a) %>
+        <% when 'a' %>
+          aaa
+        <% end %>
+      HTML
+    end
   end
 end

--- a/test/snapshots/analyze/case_test/test_0013_case_with_yield_dc59b65969b8ef95076abc05c3907392.txt
+++ b/test/snapshots/analyze/case_test/test_0013_case_with_yield_dc59b65969b8ef95076abc05c3907392.txt
@@ -1,0 +1,30 @@
+@ DocumentNode (location: (1:0)-(5:0))
+└── children: (2 items)
+    ├── @ ERBCaseNode (location: (1:0)-(4:9))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
+    │   ├── content: " case yield(:a) " (location: (1:2)-(1:18))
+    │   ├── tag_closing: "%>" (location: (1:18)-(1:20))
+    │   ├── children: (1 item)
+    │   │   └── @ HTMLTextNode (location: (1:20)-(2:0))
+    │   │       └── content: "\n"
+    │   │
+    │   ├── conditions: (1 item)
+    │   │   └── @ ERBWhenNode (location: (2:0)-(2:14))
+    │   │       ├── tag_opening: "<%" (location: (2:0)-(2:2))
+    │   │       ├── content: " when 'a' " (location: (2:2)-(2:12))
+    │   │       ├── tag_closing: "%>" (location: (2:12)-(2:14))
+    │   │       └── statements: (1 item)
+    │   │           └── @ HTMLTextNode (location: (2:14)-(4:0))
+    │   │               └── content: "\n  aaa\n"
+    │   │
+    │   │
+    │   ├── else_clause: ∅
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (4:0)-(4:9))
+    │           ├── tag_opening: "<%" (location: (4:0)-(4:2))
+    │           ├── content: " end " (location: (4:2)-(4:7))
+    │           └── tag_closing: "%>" (location: (4:7)-(4:9))
+    │
+    │
+    └── @ HTMLTextNode (location: (4:9)-(5:0))
+        └── content: "\n"


### PR DESCRIPTION
This pull request updates the parser to analyze `yield`  inside `case` nodes as `ERBCaseNode` instead of `ERBYieldNode`.

The following templates:
```html+erb
<% case yield(:a) %>
<% when 'a' %>
  aaa
<% end %>
```

Gets now parsed as:
```js
@ DocumentNode (location: (1:0)-(5:0))
└── children: (2 items)
    ├── @ ERBCaseNode (location: (1:0)-(4:9))
    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
    │   ├── content: " case yield(:a) " (location: (1:2)-(1:18))
    │   ├── tag_closing: "%>" (location: (1:18)-(1:20))
    │   ├── children: (1 item)
    │   │   └── @ HTMLTextNode (location: (1:20)-(2:0))
    │   │       └── content: "\n"
    │   │
    │   ├── conditions: (1 item)
    │   │   └── @ ERBWhenNode (location: (2:0)-(2:14))
    │   │       ├── tag_opening: "<%" (location: (2:0)-(2:2))
    │   │       ├── content: " when 'a' " (location: (2:2)-(2:12))
    │   │       ├── tag_closing: "%>" (location: (2:12)-(2:14))
    │   │       └── statements: (1 item)
    │   │           └── @ HTMLTextNode (location: (2:14)-(4:0))
    │   │               └── content: "\n  aaa\n"
    │   │
    │   │
    │   ├── else_clause: ∅
    │   └── end_node:
    │       └── @ ERBEndNode (location: (4:0)-(4:9))
    │           ├── tag_opening: "<%" (location: (4:0)-(4:2))
    │           ├── content: " end " (location: (4:2)-(4:7))
    │           └── tag_closing: "%>" (location: (4:7)-(4:9))
    │
    │
    └── @ HTMLTextNode (location: (4:9)-(5:0))
        └── content: "\n"
```

Previously it was parsed as:

```js
@ DocumentNode (location: (1:0)-(5:0))
└── children: (6 items)
    ├── @ ERBYieldNode (location: (1:0)-(1:20))
    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
    │   ├── content: " case yield(:a) " (location: (1:2)-(1:18))
    │   └── tag_closing: "%>" (location: (1:18)-(1:20))
    │
    ├── @ HTMLTextNode (location: (1:20)-(2:0))
    │   └── content: "\n"
    │
    ├── @ ERBContentNode (location: (2:0)-(2:14))
    │   ├── tag_opening: "<%" (location: (2:0)-(2:2))
    │   ├── content: " when 'a' " (location: (2:2)-(2:12))
    │   ├── tag_closing: "%>" (location: (2:12)-(2:14))
    │   ├── parsed: true
    │   └── valid: false
    │
    ├── @ HTMLTextNode (location: (2:14)-(4:0))
    │   └── content: "\n  aaa\n"
    │
    ├── @ ERBContentNode (location: (4:0)-(4:9))
    │   ├── tag_opening: "<%" (location: (4:0)-(4:2))
    │   ├── content: " end " (location: (4:2)-(4:7))
    │   ├── tag_closing: "%>" (location: (4:7)-(4:9))
    │   ├── parsed: true
    │   └── valid: false
    │
    └── @ HTMLTextNode (location: (4:9)-(5:0))
        └── content: "\n"
```

Resolves https://github.com/marcoroth/herb/issues/561