### PR TITLE
Parser: Fix analysis of nested `case/when` and `case/in` parsing

### DIFF
--- a/src/analyze.c
+++ b/src/analyze.c
@@ -435,24 +435,7 @@ static size_t process_control_structure(
         array_T* when_statements = array_init(8);
         index++;
 
-        while (index < array_size(array)) {
-          AST_NODE_T* child = array_get(array, index);
-
-          if (!child) { break; }
-
-          if (child->type == AST_ERB_CONTENT_NODE) {
-            AST_ERB_CONTENT_NODE_T* child_erb = (AST_ERB_CONTENT_NODE_T*) child;
-            control_type_t child_type = detect_control_type(child_erb);
-
-            if (child_type == CONTROL_TYPE_WHEN || child_type == CONTROL_TYPE_IN || child_type == CONTROL_TYPE_ELSE
-                || child_type == CONTROL_TYPE_END) {
-              break;
-            }
-          }
-
-          array_append(when_statements, child);
-          index++;
-        }
+        index = process_block_children(node, array, index, when_statements, context, CONTROL_TYPE_WHEN);
 
         AST_ERB_WHEN_NODE_T* when_node = ast_erb_when_node_init(
           erb_content->tag_opening,
@@ -471,24 +454,7 @@ static size_t process_control_structure(
         array_T* in_statements = array_init(8);
         index++;
 
-        while (index < array_size(array)) {
-          AST_NODE_T* child = array_get(array, index);
-
-          if (!child) { break; }
-
-          if (child->type == AST_ERB_CONTENT_NODE) {
-            AST_ERB_CONTENT_NODE_T* child_erb = (AST_ERB_CONTENT_NODE_T*) child;
-            control_type_t child_type = detect_control_type(child_erb);
-
-            if (child_type == CONTROL_TYPE_IN || child_type == CONTROL_TYPE_WHEN || child_type == CONTROL_TYPE_ELSE
-                || child_type == CONTROL_TYPE_END) {
-              break;
-            }
-          }
-
-          array_append(in_statements, child);
-          index++;
-        }
+        index = process_block_children(node, array, index, in_statements, context, CONTROL_TYPE_IN);
 
         AST_ERB_IN_NODE_T* in_node = ast_erb_in_node_init(
           erb_content->tag_opening,

--- a/test/analyze/case_in_test.rb
+++ b/test/analyze/case_in_test.rb
@@ -92,5 +92,41 @@ module Analyze
         <% end %>
       HTML
     end
+
+    test "case in with block inside in clause" do
+      assert_parsed_snapshot(<<~HTML)
+        <% case result %>
+        <% in { status: :success } %>
+          <%= content_tag(:div) do %>
+            Success!
+          <% end %>
+        <% end %>
+      HTML
+    end
+
+    test "case in with multiple blocks in in clause" do
+      assert_parsed_snapshot(<<~HTML)
+        <% case data %>
+        <% in { type: :alert } %>
+          <%= content_tag(:div) do %>
+            Alert
+          <% end %>
+          <%= content_tag(:span) do %>
+            Icon
+          <% end %>
+        <% end %>
+      HTML
+    end
+
+    test "case in with if statement inside in clause" do
+      assert_parsed_snapshot(<<~HTML)
+        <% case value %>
+        <% in [Integer] %>
+          <% if positive? %>
+            Positive
+          <% end %>
+        <% end %>
+      HTML
+    end
   end
 end

--- a/test/analyze/case_test.rb
+++ b/test/analyze/case_test.rb
@@ -90,5 +90,69 @@ module Analyze
         <% end %>
       HTML
     end
+
+    test "case with block inside when" do
+      assert_parsed_snapshot(<<~HTML)
+        <% case 1 %>
+        <% when 1 %>
+          <%= content_tag(:p) do %>
+            Yep
+          <% end %>
+        <% end %>
+      HTML
+    end
+
+    test "case with multiple blocks in when" do
+      assert_parsed_snapshot(<<~HTML)
+        <% case status %>
+        <% when :active %>
+          <%= content_tag(:div) do %>
+            Active
+          <% end %>
+          <%= content_tag(:span) do %>
+            Badge
+          <% end %>
+        <% end %>
+      HTML
+    end
+
+    test "case with nested blocks in when" do
+      assert_parsed_snapshot(<<~HTML)
+        <% case level %>
+        <% when 1 %>
+          <%= content_tag(:div) do %>
+            <%= content_tag(:p) do %>
+              Nested
+            <% end %>
+          <% end %>
+        <% end %>
+      HTML
+    end
+
+    test "case with block in multiple when clauses" do
+      assert_parsed_snapshot(<<~HTML)
+        <% case type %>
+        <% when :a %>
+          <%= form_for(obj) do |f| %>
+            Form A
+          <% end %>
+        <% when :b %>
+          <%= form_for(obj) do |f| %>
+            Form B
+          <% end %>
+        <% end %>
+      HTML
+    end
+
+    test "case with if statement inside when" do
+      assert_parsed_snapshot(<<~HTML)
+        <% case status %>
+        <% when :active %>
+          <% if admin? %>
+            Admin view
+          <% end %>
+        <% end %>
+      HTML
+    end
   end
 end

--- a/test/snapshots/analyze/case_in_test/test_0008_case_in_with_block_inside_in_clause_a5d7393ef0ab780cd777fd4d09413ac8.txt
+++ b/test/snapshots/analyze/case_in_test/test_0008_case_in_with_block_inside_in_clause_a5d7393ef0ab780cd777fd4d09413ac8.txt
@@ -1,0 +1,48 @@
+@ DocumentNode (location: (1:0)-(7:0))
+└── children: (2 items)
+    ├── @ ERBCaseMatchNode (location: (1:0)-(6:9))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
+    │   ├── content: " case result " (location: (1:2)-(1:15))
+    │   ├── tag_closing: "%>" (location: (1:15)-(1:17))
+    │   ├── children: (1 item)
+    │   │   └── @ HTMLTextNode (location: (1:17)-(2:0))
+    │   │       └── content: "\n"
+    │   │
+    │   ├── conditions: (1 item)
+    │   │   └── @ ERBInNode (location: (2:0)-(2:29))
+    │   │       ├── tag_opening: "<%" (location: (2:0)-(2:2))
+    │   │       ├── content: " in { status: :success } " (location: (2:2)-(2:27))
+    │   │       ├── tag_closing: "%>" (location: (2:27)-(2:29))
+    │   │       └── statements: (3 items)
+    │   │           ├── @ HTMLTextNode (location: (2:29)-(3:2))
+    │   │           │   └── content: "\n  "
+    │   │           │
+    │   │           ├── @ ERBBlockNode (location: (3:2)-(5:11))
+    │   │           │   ├── tag_opening: "<%=" (location: (3:2)-(3:5))
+    │   │           │   ├── content: " content_tag(:div) do " (location: (3:5)-(3:27))
+    │   │           │   ├── tag_closing: "%>" (location: (3:27)-(3:29))
+    │   │           │   ├── body: (1 item)
+    │   │           │   │   └── @ HTMLTextNode (location: (3:29)-(5:2))
+    │   │           │   │       └── content: "\n    Success!\n  "
+    │   │           │   │
+    │   │           │   └── end_node:
+    │   │           │       └── @ ERBEndNode (location: (5:2)-(5:11))
+    │   │           │           ├── tag_opening: "<%" (location: (5:2)-(5:4))
+    │   │           │           ├── content: " end " (location: (5:4)-(5:9))
+    │   │           │           └── tag_closing: "%>" (location: (5:9)-(5:11))
+    │   │           │
+    │   │           │
+    │   │           └── @ HTMLTextNode (location: (5:11)-(6:0))
+    │   │               └── content: "\n"
+    │   │
+    │   │
+    │   ├── else_clause: ∅
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (6:0)-(6:9))
+    │           ├── tag_opening: "<%" (location: (6:0)-(6:2))
+    │           ├── content: " end " (location: (6:2)-(6:7))
+    │           └── tag_closing: "%>" (location: (6:7)-(6:9))
+    │
+    │
+    └── @ HTMLTextNode (location: (6:9)-(7:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/case_in_test/test_0009_case_in_with_multiple_blocks_in_in_clause_8cdfe954fcb68cf29f71d5c05893547c.txt
+++ b/test/snapshots/analyze/case_in_test/test_0009_case_in_with_multiple_blocks_in_in_clause_8cdfe954fcb68cf29f71d5c05893547c.txt
@@ -1,0 +1,66 @@
+@ DocumentNode (location: (1:0)-(10:0))
+└── children: (2 items)
+    ├── @ ERBCaseMatchNode (location: (1:0)-(9:9))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
+    │   ├── content: " case data " (location: (1:2)-(1:13))
+    │   ├── tag_closing: "%>" (location: (1:13)-(1:15))
+    │   ├── children: (1 item)
+    │   │   └── @ HTMLTextNode (location: (1:15)-(2:0))
+    │   │       └── content: "\n"
+    │   │
+    │   ├── conditions: (1 item)
+    │   │   └── @ ERBInNode (location: (2:0)-(2:25))
+    │   │       ├── tag_opening: "<%" (location: (2:0)-(2:2))
+    │   │       ├── content: " in { type: :alert } " (location: (2:2)-(2:23))
+    │   │       ├── tag_closing: "%>" (location: (2:23)-(2:25))
+    │   │       └── statements: (5 items)
+    │   │           ├── @ HTMLTextNode (location: (2:25)-(3:2))
+    │   │           │   └── content: "\n  "
+    │   │           │
+    │   │           ├── @ ERBBlockNode (location: (3:2)-(5:11))
+    │   │           │   ├── tag_opening: "<%=" (location: (3:2)-(3:5))
+    │   │           │   ├── content: " content_tag(:div) do " (location: (3:5)-(3:27))
+    │   │           │   ├── tag_closing: "%>" (location: (3:27)-(3:29))
+    │   │           │   ├── body: (1 item)
+    │   │           │   │   └── @ HTMLTextNode (location: (3:29)-(5:2))
+    │   │           │   │       └── content: "\n    Alert\n  "
+    │   │           │   │
+    │   │           │   └── end_node:
+    │   │           │       └── @ ERBEndNode (location: (5:2)-(5:11))
+    │   │           │           ├── tag_opening: "<%" (location: (5:2)-(5:4))
+    │   │           │           ├── content: " end " (location: (5:4)-(5:9))
+    │   │           │           └── tag_closing: "%>" (location: (5:9)-(5:11))
+    │   │           │
+    │   │           │
+    │   │           ├── @ HTMLTextNode (location: (5:11)-(6:2))
+    │   │           │   └── content: "\n  "
+    │   │           │
+    │   │           ├── @ ERBBlockNode (location: (6:2)-(8:11))
+    │   │           │   ├── tag_opening: "<%=" (location: (6:2)-(6:5))
+    │   │           │   ├── content: " content_tag(:span) do " (location: (6:5)-(6:28))
+    │   │           │   ├── tag_closing: "%>" (location: (6:28)-(6:30))
+    │   │           │   ├── body: (1 item)
+    │   │           │   │   └── @ HTMLTextNode (location: (6:30)-(8:2))
+    │   │           │   │       └── content: "\n    Icon\n  "
+    │   │           │   │
+    │   │           │   └── end_node:
+    │   │           │       └── @ ERBEndNode (location: (8:2)-(8:11))
+    │   │           │           ├── tag_opening: "<%" (location: (8:2)-(8:4))
+    │   │           │           ├── content: " end " (location: (8:4)-(8:9))
+    │   │           │           └── tag_closing: "%>" (location: (8:9)-(8:11))
+    │   │           │
+    │   │           │
+    │   │           └── @ HTMLTextNode (location: (8:11)-(9:0))
+    │   │               └── content: "\n"
+    │   │
+    │   │
+    │   ├── else_clause: ∅
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (9:0)-(9:9))
+    │           ├── tag_opening: "<%" (location: (9:0)-(9:2))
+    │           ├── content: " end " (location: (9:2)-(9:7))
+    │           └── tag_closing: "%>" (location: (9:7)-(9:9))
+    │
+    │
+    └── @ HTMLTextNode (location: (9:9)-(10:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/case_in_test/test_0010_case_in_with_if_statement_inside_in_clause_51fcf7566215a5284ae1ee34c920837e.txt
+++ b/test/snapshots/analyze/case_in_test/test_0010_case_in_with_if_statement_inside_in_clause_51fcf7566215a5284ae1ee34c920837e.txt
@@ -1,0 +1,49 @@
+@ DocumentNode (location: (1:0)-(7:0))
+└── children: (2 items)
+    ├── @ ERBCaseMatchNode (location: (1:0)-(6:9))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
+    │   ├── content: " case value " (location: (1:2)-(1:14))
+    │   ├── tag_closing: "%>" (location: (1:14)-(1:16))
+    │   ├── children: (1 item)
+    │   │   └── @ HTMLTextNode (location: (1:16)-(2:0))
+    │   │       └── content: "\n"
+    │   │
+    │   ├── conditions: (1 item)
+    │   │   └── @ ERBInNode (location: (2:0)-(2:18))
+    │   │       ├── tag_opening: "<%" (location: (2:0)-(2:2))
+    │   │       ├── content: " in [Integer] " (location: (2:2)-(2:16))
+    │   │       ├── tag_closing: "%>" (location: (2:16)-(2:18))
+    │   │       └── statements: (3 items)
+    │   │           ├── @ HTMLTextNode (location: (2:18)-(3:2))
+    │   │           │   └── content: "\n  "
+    │   │           │
+    │   │           ├── @ ERBIfNode (location: (3:2)-(5:11))
+    │   │           │   ├── tag_opening: "<%" (location: (3:2)-(3:4))
+    │   │           │   ├── content: " if positive? " (location: (3:4)-(3:18))
+    │   │           │   ├── tag_closing: "%>" (location: (3:18)-(3:20))
+    │   │           │   ├── statements: (1 item)
+    │   │           │   │   └── @ HTMLTextNode (location: (3:20)-(5:2))
+    │   │           │   │       └── content: "\n    Positive\n  "
+    │   │           │   │
+    │   │           │   ├── subsequent: ∅
+    │   │           │   └── end_node:
+    │   │           │       └── @ ERBEndNode (location: (5:2)-(5:11))
+    │   │           │           ├── tag_opening: "<%" (location: (5:2)-(5:4))
+    │   │           │           ├── content: " end " (location: (5:4)-(5:9))
+    │   │           │           └── tag_closing: "%>" (location: (5:9)-(5:11))
+    │   │           │
+    │   │           │
+    │   │           └── @ HTMLTextNode (location: (5:11)-(6:0))
+    │   │               └── content: "\n"
+    │   │
+    │   │
+    │   ├── else_clause: ∅
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (6:0)-(6:9))
+    │           ├── tag_opening: "<%" (location: (6:0)-(6:2))
+    │           ├── content: " end " (location: (6:2)-(6:7))
+    │           └── tag_closing: "%>" (location: (6:7)-(6:9))
+    │
+    │
+    └── @ HTMLTextNode (location: (6:9)-(7:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/case_test/test_0008_case_with_block_inside_when_adb20c2773fe1206d2b47123f8001e22.txt
+++ b/test/snapshots/analyze/case_test/test_0008_case_with_block_inside_when_adb20c2773fe1206d2b47123f8001e22.txt
@@ -1,0 +1,48 @@
+@ DocumentNode (location: (1:0)-(7:0))
+└── children: (2 items)
+    ├── @ ERBCaseNode (location: (1:0)-(6:9))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
+    │   ├── content: " case 1 " (location: (1:2)-(1:10))
+    │   ├── tag_closing: "%>" (location: (1:10)-(1:12))
+    │   ├── children: (1 item)
+    │   │   └── @ HTMLTextNode (location: (1:12)-(2:0))
+    │   │       └── content: "\n"
+    │   │
+    │   ├── conditions: (1 item)
+    │   │   └── @ ERBWhenNode (location: (2:0)-(2:12))
+    │   │       ├── tag_opening: "<%" (location: (2:0)-(2:2))
+    │   │       ├── content: " when 1 " (location: (2:2)-(2:10))
+    │   │       ├── tag_closing: "%>" (location: (2:10)-(2:12))
+    │   │       └── statements: (3 items)
+    │   │           ├── @ HTMLTextNode (location: (2:12)-(3:2))
+    │   │           │   └── content: "\n  "
+    │   │           │
+    │   │           ├── @ ERBBlockNode (location: (3:2)-(5:11))
+    │   │           │   ├── tag_opening: "<%=" (location: (3:2)-(3:5))
+    │   │           │   ├── content: " content_tag(:p) do " (location: (3:5)-(3:25))
+    │   │           │   ├── tag_closing: "%>" (location: (3:25)-(3:27))
+    │   │           │   ├── body: (1 item)
+    │   │           │   │   └── @ HTMLTextNode (location: (3:27)-(5:2))
+    │   │           │   │       └── content: "\n    Yep\n  "
+    │   │           │   │
+    │   │           │   └── end_node:
+    │   │           │       └── @ ERBEndNode (location: (5:2)-(5:11))
+    │   │           │           ├── tag_opening: "<%" (location: (5:2)-(5:4))
+    │   │           │           ├── content: " end " (location: (5:4)-(5:9))
+    │   │           │           └── tag_closing: "%>" (location: (5:9)-(5:11))
+    │   │           │
+    │   │           │
+    │   │           └── @ HTMLTextNode (location: (5:11)-(6:0))
+    │   │               └── content: "\n"
+    │   │
+    │   │
+    │   ├── else_clause: ∅
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (6:0)-(6:9))
+    │           ├── tag_opening: "<%" (location: (6:0)-(6:2))
+    │           ├── content: " end " (location: (6:2)-(6:7))
+    │           └── tag_closing: "%>" (location: (6:7)-(6:9))
+    │
+    │
+    └── @ HTMLTextNode (location: (6:9)-(7:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/case_test/test_0009_case_with_multiple_blocks_in_when_05f7d387314a95620a58ddc7f7d31b7b.txt
+++ b/test/snapshots/analyze/case_test/test_0009_case_with_multiple_blocks_in_when_05f7d387314a95620a58ddc7f7d31b7b.txt
@@ -1,0 +1,66 @@
+@ DocumentNode (location: (1:0)-(10:0))
+└── children: (2 items)
+    ├── @ ERBCaseNode (location: (1:0)-(9:9))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
+    │   ├── content: " case status " (location: (1:2)-(1:15))
+    │   ├── tag_closing: "%>" (location: (1:15)-(1:17))
+    │   ├── children: (1 item)
+    │   │   └── @ HTMLTextNode (location: (1:17)-(2:0))
+    │   │       └── content: "\n"
+    │   │
+    │   ├── conditions: (1 item)
+    │   │   └── @ ERBWhenNode (location: (2:0)-(2:18))
+    │   │       ├── tag_opening: "<%" (location: (2:0)-(2:2))
+    │   │       ├── content: " when :active " (location: (2:2)-(2:16))
+    │   │       ├── tag_closing: "%>" (location: (2:16)-(2:18))
+    │   │       └── statements: (5 items)
+    │   │           ├── @ HTMLTextNode (location: (2:18)-(3:2))
+    │   │           │   └── content: "\n  "
+    │   │           │
+    │   │           ├── @ ERBBlockNode (location: (3:2)-(5:11))
+    │   │           │   ├── tag_opening: "<%=" (location: (3:2)-(3:5))
+    │   │           │   ├── content: " content_tag(:div) do " (location: (3:5)-(3:27))
+    │   │           │   ├── tag_closing: "%>" (location: (3:27)-(3:29))
+    │   │           │   ├── body: (1 item)
+    │   │           │   │   └── @ HTMLTextNode (location: (3:29)-(5:2))
+    │   │           │   │       └── content: "\n    Active\n  "
+    │   │           │   │
+    │   │           │   └── end_node:
+    │   │           │       └── @ ERBEndNode (location: (5:2)-(5:11))
+    │   │           │           ├── tag_opening: "<%" (location: (5:2)-(5:4))
+    │   │           │           ├── content: " end " (location: (5:4)-(5:9))
+    │   │           │           └── tag_closing: "%>" (location: (5:9)-(5:11))
+    │   │           │
+    │   │           │
+    │   │           ├── @ HTMLTextNode (location: (5:11)-(6:2))
+    │   │           │   └── content: "\n  "
+    │   │           │
+    │   │           ├── @ ERBBlockNode (location: (6:2)-(8:11))
+    │   │           │   ├── tag_opening: "<%=" (location: (6:2)-(6:5))
+    │   │           │   ├── content: " content_tag(:span) do " (location: (6:5)-(6:28))
+    │   │           │   ├── tag_closing: "%>" (location: (6:28)-(6:30))
+    │   │           │   ├── body: (1 item)
+    │   │           │   │   └── @ HTMLTextNode (location: (6:30)-(8:2))
+    │   │           │   │       └── content: "\n    Badge\n  "
+    │   │           │   │
+    │   │           │   └── end_node:
+    │   │           │       └── @ ERBEndNode (location: (8:2)-(8:11))
+    │   │           │           ├── tag_opening: "<%" (location: (8:2)-(8:4))
+    │   │           │           ├── content: " end " (location: (8:4)-(8:9))
+    │   │           │           └── tag_closing: "%>" (location: (8:9)-(8:11))
+    │   │           │
+    │   │           │
+    │   │           └── @ HTMLTextNode (location: (8:11)-(9:0))
+    │   │               └── content: "\n"
+    │   │
+    │   │
+    │   ├── else_clause: ∅
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (9:0)-(9:9))
+    │           ├── tag_opening: "<%" (location: (9:0)-(9:2))
+    │           ├── content: " end " (location: (9:2)-(9:7))
+    │           └── tag_closing: "%>" (location: (9:7)-(9:9))
+    │
+    │
+    └── @ HTMLTextNode (location: (9:9)-(10:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/case_test/test_0010_case_with_nested_blocks_in_when_6e70c1bf60788969969296d35c409a47.txt
+++ b/test/snapshots/analyze/case_test/test_0010_case_with_nested_blocks_in_when_6e70c1bf60788969969296d35c409a47.txt
@@ -1,0 +1,66 @@
+@ DocumentNode (location: (1:0)-(9:0))
+└── children: (2 items)
+    ├── @ ERBCaseNode (location: (1:0)-(8:9))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
+    │   ├── content: " case level " (location: (1:2)-(1:14))
+    │   ├── tag_closing: "%>" (location: (1:14)-(1:16))
+    │   ├── children: (1 item)
+    │   │   └── @ HTMLTextNode (location: (1:16)-(2:0))
+    │   │       └── content: "\n"
+    │   │
+    │   ├── conditions: (1 item)
+    │   │   └── @ ERBWhenNode (location: (2:0)-(2:12))
+    │   │       ├── tag_opening: "<%" (location: (2:0)-(2:2))
+    │   │       ├── content: " when 1 " (location: (2:2)-(2:10))
+    │   │       ├── tag_closing: "%>" (location: (2:10)-(2:12))
+    │   │       └── statements: (3 items)
+    │   │           ├── @ HTMLTextNode (location: (2:12)-(3:2))
+    │   │           │   └── content: "\n  "
+    │   │           │
+    │   │           ├── @ ERBBlockNode (location: (3:2)-(7:11))
+    │   │           │   ├── tag_opening: "<%=" (location: (3:2)-(3:5))
+    │   │           │   ├── content: " content_tag(:div) do " (location: (3:5)-(3:27))
+    │   │           │   ├── tag_closing: "%>" (location: (3:27)-(3:29))
+    │   │           │   ├── body: (3 items)
+    │   │           │   │   ├── @ HTMLTextNode (location: (3:29)-(4:4))
+    │   │           │   │   │   └── content: "\n    "
+    │   │           │   │   │
+    │   │           │   │   ├── @ ERBBlockNode (location: (4:4)-(6:13))
+    │   │           │   │   │   ├── tag_opening: "<%=" (location: (4:4)-(4:7))
+    │   │           │   │   │   ├── content: " content_tag(:p) do " (location: (4:7)-(4:27))
+    │   │           │   │   │   ├── tag_closing: "%>" (location: (4:27)-(4:29))
+    │   │           │   │   │   ├── body: (1 item)
+    │   │           │   │   │   │   └── @ HTMLTextNode (location: (4:29)-(6:4))
+    │   │           │   │   │   │       └── content: "\n      Nested\n    "
+    │   │           │   │   │   │
+    │   │           │   │   │   └── end_node:
+    │   │           │   │   │       └── @ ERBEndNode (location: (6:4)-(6:13))
+    │   │           │   │   │           ├── tag_opening: "<%" (location: (6:4)-(6:6))
+    │   │           │   │   │           ├── content: " end " (location: (6:6)-(6:11))
+    │   │           │   │   │           └── tag_closing: "%>" (location: (6:11)-(6:13))
+    │   │           │   │   │
+    │   │           │   │   │
+    │   │           │   │   └── @ HTMLTextNode (location: (6:13)-(7:2))
+    │   │           │   │       └── content: "\n  "
+    │   │           │   │
+    │   │           │   └── end_node:
+    │   │           │       └── @ ERBEndNode (location: (7:2)-(7:11))
+    │   │           │           ├── tag_opening: "<%" (location: (7:2)-(7:4))
+    │   │           │           ├── content: " end " (location: (7:4)-(7:9))
+    │   │           │           └── tag_closing: "%>" (location: (7:9)-(7:11))
+    │   │           │
+    │   │           │
+    │   │           └── @ HTMLTextNode (location: (7:11)-(8:0))
+    │   │               └── content: "\n"
+    │   │
+    │   │
+    │   ├── else_clause: ∅
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (8:0)-(8:9))
+    │           ├── tag_opening: "<%" (location: (8:0)-(8:2))
+    │           ├── content: " end " (location: (8:2)-(8:7))
+    │           └── tag_closing: "%>" (location: (8:7)-(8:9))
+    │
+    │
+    └── @ HTMLTextNode (location: (8:9)-(9:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/case_test/test_0011_case_with_block_in_multiple_when_clauses_3f35d3ebf6ea6eaf8e7b9bc7f8393a0f.txt
+++ b/test/snapshots/analyze/case_test/test_0011_case_with_block_in_multiple_when_clauses_3f35d3ebf6ea6eaf8e7b9bc7f8393a0f.txt
@@ -1,0 +1,75 @@
+@ DocumentNode (location: (1:0)-(11:0))
+└── children: (2 items)
+    ├── @ ERBCaseNode (location: (1:0)-(10:9))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
+    │   ├── content: " case type " (location: (1:2)-(1:13))
+    │   ├── tag_closing: "%>" (location: (1:13)-(1:15))
+    │   ├── children: (1 item)
+    │   │   └── @ HTMLTextNode (location: (1:15)-(2:0))
+    │   │       └── content: "\n"
+    │   │
+    │   ├── conditions: (2 items)
+    │   │   ├── @ ERBWhenNode (location: (2:0)-(2:13))
+    │   │   │   ├── tag_opening: "<%" (location: (2:0)-(2:2))
+    │   │   │   ├── content: " when :a " (location: (2:2)-(2:11))
+    │   │   │   ├── tag_closing: "%>" (location: (2:11)-(2:13))
+    │   │   │   └── statements: (3 items)
+    │   │   │       ├── @ HTMLTextNode (location: (2:13)-(3:2))
+    │   │   │       │   └── content: "\n  "
+    │   │   │       │
+    │   │   │       ├── @ ERBBlockNode (location: (3:2)-(5:11))
+    │   │   │       │   ├── tag_opening: "<%=" (location: (3:2)-(3:5))
+    │   │   │       │   ├── content: " form_for(obj) do |f| " (location: (3:5)-(3:27))
+    │   │   │       │   ├── tag_closing: "%>" (location: (3:27)-(3:29))
+    │   │   │       │   ├── body: (1 item)
+    │   │   │       │   │   └── @ HTMLTextNode (location: (3:29)-(5:2))
+    │   │   │       │   │       └── content: "\n    Form A\n  "
+    │   │   │       │   │
+    │   │   │       │   └── end_node:
+    │   │   │       │       └── @ ERBEndNode (location: (5:2)-(5:11))
+    │   │   │       │           ├── tag_opening: "<%" (location: (5:2)-(5:4))
+    │   │   │       │           ├── content: " end " (location: (5:4)-(5:9))
+    │   │   │       │           └── tag_closing: "%>" (location: (5:9)-(5:11))
+    │   │   │       │
+    │   │   │       │
+    │   │   │       └── @ HTMLTextNode (location: (5:11)-(6:0))
+    │   │   │           └── content: "\n"
+    │   │   │
+    │   │   │
+    │   │   └── @ ERBWhenNode (location: (6:0)-(6:13))
+    │   │       ├── tag_opening: "<%" (location: (6:0)-(6:2))
+    │   │       ├── content: " when :b " (location: (6:2)-(6:11))
+    │   │       ├── tag_closing: "%>" (location: (6:11)-(6:13))
+    │   │       └── statements: (3 items)
+    │   │           ├── @ HTMLTextNode (location: (6:13)-(7:2))
+    │   │           │   └── content: "\n  "
+    │   │           │
+    │   │           ├── @ ERBBlockNode (location: (7:2)-(9:11))
+    │   │           │   ├── tag_opening: "<%=" (location: (7:2)-(7:5))
+    │   │           │   ├── content: " form_for(obj) do |f| " (location: (7:5)-(7:27))
+    │   │           │   ├── tag_closing: "%>" (location: (7:27)-(7:29))
+    │   │           │   ├── body: (1 item)
+    │   │           │   │   └── @ HTMLTextNode (location: (7:29)-(9:2))
+    │   │           │   │       └── content: "\n    Form B\n  "
+    │   │           │   │
+    │   │           │   └── end_node:
+    │   │           │       └── @ ERBEndNode (location: (9:2)-(9:11))
+    │   │           │           ├── tag_opening: "<%" (location: (9:2)-(9:4))
+    │   │           │           ├── content: " end " (location: (9:4)-(9:9))
+    │   │           │           └── tag_closing: "%>" (location: (9:9)-(9:11))
+    │   │           │
+    │   │           │
+    │   │           └── @ HTMLTextNode (location: (9:11)-(10:0))
+    │   │               └── content: "\n"
+    │   │
+    │   │
+    │   ├── else_clause: ∅
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (10:0)-(10:9))
+    │           ├── tag_opening: "<%" (location: (10:0)-(10:2))
+    │           ├── content: " end " (location: (10:2)-(10:7))
+    │           └── tag_closing: "%>" (location: (10:7)-(10:9))
+    │
+    │
+    └── @ HTMLTextNode (location: (10:9)-(11:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/case_test/test_0012_case_with_if_statement_inside_when_ccc0bd511203c41d9274ccc360e736c2.txt
+++ b/test/snapshots/analyze/case_test/test_0012_case_with_if_statement_inside_when_ccc0bd511203c41d9274ccc360e736c2.txt
@@ -1,0 +1,49 @@
+@ DocumentNode (location: (1:0)-(7:0))
+└── children: (2 items)
+    ├── @ ERBCaseNode (location: (1:0)-(6:9))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
+    │   ├── content: " case status " (location: (1:2)-(1:15))
+    │   ├── tag_closing: "%>" (location: (1:15)-(1:17))
+    │   ├── children: (1 item)
+    │   │   └── @ HTMLTextNode (location: (1:17)-(2:0))
+    │   │       └── content: "\n"
+    │   │
+    │   ├── conditions: (1 item)
+    │   │   └── @ ERBWhenNode (location: (2:0)-(2:18))
+    │   │       ├── tag_opening: "<%" (location: (2:0)-(2:2))
+    │   │       ├── content: " when :active " (location: (2:2)-(2:16))
+    │   │       ├── tag_closing: "%>" (location: (2:16)-(2:18))
+    │   │       └── statements: (3 items)
+    │   │           ├── @ HTMLTextNode (location: (2:18)-(3:2))
+    │   │           │   └── content: "\n  "
+    │   │           │
+    │   │           ├── @ ERBIfNode (location: (3:2)-(5:11))
+    │   │           │   ├── tag_opening: "<%" (location: (3:2)-(3:4))
+    │   │           │   ├── content: " if admin? " (location: (3:4)-(3:15))
+    │   │           │   ├── tag_closing: "%>" (location: (3:15)-(3:17))
+    │   │           │   ├── statements: (1 item)
+    │   │           │   │   └── @ HTMLTextNode (location: (3:17)-(5:2))
+    │   │           │   │       └── content: "\n    Admin view\n  "
+    │   │           │   │
+    │   │           │   ├── subsequent: ∅
+    │   │           │   └── end_node:
+    │   │           │       └── @ ERBEndNode (location: (5:2)-(5:11))
+    │   │           │           ├── tag_opening: "<%" (location: (5:2)-(5:4))
+    │   │           │           ├── content: " end " (location: (5:4)-(5:9))
+    │   │           │           └── tag_closing: "%>" (location: (5:9)-(5:11))
+    │   │           │
+    │   │           │
+    │   │           └── @ HTMLTextNode (location: (5:11)-(6:0))
+    │   │               └── content: "\n"
+    │   │
+    │   │
+    │   ├── else_clause: ∅
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (6:0)-(6:9))
+    │           ├── tag_opening: "<%" (location: (6:0)-(6:2))
+    │           ├── content: " end " (location: (6:2)-(6:7))
+    │           └── tag_closing: "%>" (location: (6:7)-(6:9))
+    │
+    │
+    └── @ HTMLTextNode (location: (6:9)-(7:0))
+        └── content: "\n"


### PR DESCRIPTION
This pull request updates the parser to fix the analysis of nested control flow structures within `case/when` and `case/in` statements.

The following kind templates now have the properly nested structure:

```html+erb
<% case 1 %>
<% when 1 %>
  <%= content_tag(:p) do %>
    Yep
  <% end %>
<% end %>
```

Resolves https://github.com/marcoroth/herb/issues/540