### PR TITLE
C: Bump default buffer size to `4096`

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -8,7 +8,11 @@
 #include "include/util.h"
 
 bool buffer_init(buffer_T* buffer) {
-  buffer->capacity = 1024;
+  return buffer_init_with_capacity(buffer, 4096);
+}
+
+bool buffer_init_with_capacity(buffer_T* buffer, const size_t initial_capacity) {
+  buffer->capacity = initial_capacity;
   buffer->length = 0;
   buffer->value = nullable_safe_malloc((buffer->capacity + 1) * sizeof(char));
 
@@ -25,6 +29,12 @@ bool buffer_init(buffer_T* buffer) {
 buffer_T buffer_new(void) {
   buffer_T buffer;
   buffer_init(&buffer);
+  return buffer;
+}
+
+buffer_T buffer_new_with_capacity(const size_t initial_capacity) {
+  buffer_T buffer;
+  buffer_init_with_capacity(&buffer, initial_capacity);
   return buffer;
 }
 

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -11,7 +11,9 @@ typedef struct BUFFER_STRUCT {
 } buffer_T;
 
 bool buffer_init(buffer_T* buffer);
+bool buffer_init_with_capacity(buffer_T* buffer, size_t initial_capacity);
 buffer_T buffer_new(void);
+buffer_T buffer_new_with_capacity(size_t initial_capacity);
 
 bool buffer_increase_capacity(buffer_T* buffer, size_t additional_capacity);
 bool buffer_has_capacity(buffer_T* buffer, size_t required_length);


### PR DESCRIPTION
This pull request bumps the default buffer size in C from `1024` bytes to  `4096` bytes, since these buffers usually hold file contents.

Bumping the default buffer size requires fewer reallocations/resizings of the buffer, which is especially useful when working with bigger files. This should make it more reliable, since calling `realloc` in quick succession might fail in some scenarios.

Additionally, this pull request introduces two new methods `buffer_init_with_capacity` and `buffer_new_with_capacity` which can be used to create smaller/bigger buffers when needed.