### PR TITLE
C: Also call `analyze` in C-CLI `parse` command

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -106,6 +106,9 @@ int main(const int argc, char* argv[]) {
 
   if (strcmp(argv[1], "parse") == 0) {
     AST_DOCUMENT_NODE_T* root = herb_parse(source, NULL);
+
+    herb_analyze_parse_tree(root, source);
+
     clock_gettime(CLOCK_MONOTONIC, &end);
 
     ast_pretty_print_node((AST_NODE_T*) root, 0, 0, &output);


### PR DESCRIPTION
This pull request updates the C-CLI to also call `herb_analyze_parse_tree` in the `parse` command, so that the `ERBContentNodes` also get analyzed in a HTML+ERB document.

AS discussed in https://github.com/marcoroth/herb/issues/406#issuecomment-3350166452