### PR TITLE
C: Favor explicit buffer capacity over default capacity

### DIFF
--- a/bin/leaks_parse
+++ b/bin/leaks_parse
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ -z "$1" ]; then
-  echo "Usage: $0 <file>"
+  echo "Usage: $0 <file_or_directory>"
   exit 1
 fi
 
@@ -10,4 +10,13 @@ if [[ "$(uname)" != "Darwin" ]]; then
   exit 0
 fi
 
-leaks --atExit -- ./herb parse "$1"
+TARGET="$1"
+
+if [ -d "$TARGET" ]; then
+  while IFS= read -r -d '' file; do
+    echo "Checking $file for leaks..."
+    leaks --atExit -- ./herb parse "$file" --silent || exit 1
+  done < <(find "$TARGET" -name "*.html.erb" -type f -print0)
+else
+  leaks --atExit -- ./herb parse "$TARGET" --silent
+fi

--- a/ext/herb/extension.c
+++ b/ext/herb/extension.c
@@ -89,13 +89,13 @@ static VALUE Herb_lex_to_json(VALUE self, VALUE source) {
   char* string = (char*) check_string(source);
   buffer_T output;
 
-  if (!buffer_init(&output)) { return Qnil; }
+  if (!buffer_init(&output, 4096)) { return Qnil; }
 
   herb_lex_json_to_buffer(string, &output);
 
   VALUE result = rb_str_new(output.value, output.length);
 
-  buffer_free(&output);
+  free(output.value);
 
   return result;
 }
@@ -104,12 +104,12 @@ static VALUE Herb_extract_ruby(VALUE self, VALUE source) {
   char* string = (char*) check_string(source);
   buffer_T output;
 
-  if (!buffer_init(&output)) { return Qnil; }
+  if (!buffer_init(&output, strlen(string))) { return Qnil; }
 
   herb_extract_ruby_to_buffer(string, &output);
 
   VALUE result = rb_utf8_str_new_cstr(output.value);
-  buffer_free(&output);
+  free(output.value);
 
   return result;
 }
@@ -118,12 +118,12 @@ static VALUE Herb_extract_html(VALUE self, VALUE source) {
   char* string = (char*) check_string(source);
   buffer_T output;
 
-  if (!buffer_init(&output)) { return Qnil; }
+  if (!buffer_init(&output, strlen(string))) { return Qnil; }
 
   herb_extract_html_to_buffer(string, &output);
 
   VALUE result = rb_utf8_str_new_cstr(output.value);
-  buffer_free(&output);
+  free(output.value);
 
   return result;
 }

--- a/javascript/packages/node/extension/herb.cpp
+++ b/javascript/packages/node/extension/herb.cpp
@@ -156,7 +156,7 @@ napi_value Herb_lex_to_json(napi_env env, napi_callback_info info) {
   if (!string) { return nullptr; }
 
   buffer_T output;
-  if (!buffer_init(&output)) {
+  if (!buffer_init(&output, 4096)) {
     free(string);
     napi_throw_error(env, nullptr, "Failed to initialize buffer");
     return nullptr;
@@ -167,7 +167,7 @@ napi_value Herb_lex_to_json(napi_env env, napi_callback_info info) {
   napi_value result;
   napi_create_string_utf8(env, output.value, output.length, &result);
 
-  buffer_free(&output);
+  free(output.value);
   free(string);
 
   return result;
@@ -187,7 +187,7 @@ napi_value Herb_extract_ruby(napi_env env, napi_callback_info info) {
   if (!string) { return nullptr; }
 
   buffer_T output;
-  if (!buffer_init(&output)) {
+  if (!buffer_init(&output, strlen(string))) {
     free(string);
     napi_throw_error(env, nullptr, "Failed to initialize buffer");
     return nullptr;
@@ -198,7 +198,7 @@ napi_value Herb_extract_ruby(napi_env env, napi_callback_info info) {
   napi_value result;
   napi_create_string_utf8(env, output.value, NAPI_AUTO_LENGTH, &result);
 
-  buffer_free(&output);
+  free(output.value);
   free(string);
   return result;
 }
@@ -217,7 +217,7 @@ napi_value Herb_extract_html(napi_env env, napi_callback_info info) {
   if (!string) { return nullptr; }
 
   buffer_T output;
-  if (!buffer_init(&output)) {
+  if (!buffer_init(&output, strlen(string))) {
     free(string);
     napi_throw_error(env, nullptr, "Failed to initialize buffer");
     return nullptr;
@@ -228,7 +228,7 @@ napi_value Herb_extract_html(napi_env env, napi_callback_info info) {
   napi_value result;
   napi_create_string_utf8(env, output.value, NAPI_AUTO_LENGTH, &result);
 
-  buffer_free(&output);
+  free(output.value);
   free(string);
   return result;
 }

--- a/src/analyze.c
+++ b/src/analyze.c
@@ -1072,6 +1072,8 @@ void herb_analyze_parse_tree(AST_DOCUMENT_NODE_T* document, const char* source) 
 void herb_analyze_parse_errors(AST_DOCUMENT_NODE_T* document, const char* source) {
   char* extracted_ruby = herb_extract_ruby_with_semicolons(source);
 
+  if (!extracted_ruby) { return; }
+
   pm_parser_t parser;
   pm_options_t options = { 0, .partial_script = true };
   pm_parser_init(&parser, (const uint8_t*) extracted_ruby, strlen(extracted_ruby), &options);

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -7,8 +7,8 @@
 #include "include/memory.h"
 #include "include/util.h"
 
-bool buffer_init(buffer_T* buffer) {
-  buffer->capacity = 1024;
+bool buffer_init(buffer_T* buffer, const size_t capacity) {
+  buffer->capacity = capacity;
   buffer->length = 0;
   buffer->value = nullable_safe_malloc((buffer->capacity + 1) * sizeof(char));
 
@@ -22,9 +22,14 @@ bool buffer_init(buffer_T* buffer) {
   return true;
 }
 
-buffer_T buffer_new(void) {
-  buffer_T buffer;
-  buffer_init(&buffer);
+buffer_T* buffer_new(const size_t capacity) {
+  buffer_T* buffer = safe_malloc(sizeof(buffer_T));
+
+  if (!buffer_init(buffer, capacity)) {
+    free(buffer);
+    return NULL;
+  }
+
   return buffer;
 }
 
@@ -231,11 +236,11 @@ void buffer_clear(buffer_T* buffer) {
   buffer->value[0] = '\0';
 }
 
-void buffer_free(buffer_T* buffer) {
-  if (!buffer) { return; }
+void buffer_free(buffer_T** buffer) {
+  if (!buffer || !*buffer) { return; }
 
-  if (buffer->value != NULL) { free(buffer->value); }
+  if ((*buffer)->value != NULL) { free((*buffer)->value); }
 
-  buffer->value = NULL;
-  buffer->length = buffer->capacity = 0;
+  free(*buffer);
+  *buffer = NULL;
 }

--- a/src/extract.c
+++ b/src/extract.c
@@ -5,6 +5,7 @@
 #include "include/lexer.h"
 
 #include <stdlib.h>
+#include <string.h>
 
 void herb_extract_ruby_to_buffer_with_semicolons(const char* source, buffer_T* output) {
   array_T* tokens = herb_lex(source);
@@ -121,8 +122,10 @@ void herb_extract_html_to_buffer(const char* source, buffer_T* output) {
 }
 
 char* herb_extract_ruby_with_semicolons(const char* source) {
+  if (!source) { return NULL; }
+
   buffer_T output;
-  buffer_init(&output);
+  buffer_init(&output, strlen(source));
 
   herb_extract_ruby_to_buffer_with_semicolons(source, &output);
 
@@ -130,8 +133,10 @@ char* herb_extract_ruby_with_semicolons(const char* source) {
 }
 
 char* herb_extract(const char* source, const herb_extract_language_T language) {
+  if (!source) { return NULL; }
+
   buffer_T output;
-  buffer_init(&output);
+  buffer_init(&output, strlen(source));
 
   switch (language) {
     case HERB_EXTRACT_LANGUAGE_RUBY: herb_extract_ruby_to_buffer(source, &output); break;

--- a/src/herb.c
+++ b/src/herb.c
@@ -28,6 +28,8 @@ array_T* herb_lex(const char* source) {
 }
 
 AST_DOCUMENT_NODE_T* herb_parse(const char* source, parser_options_T* options) {
+  if (!source) { source = ""; }
+
   lexer_T* lexer = lexer_init(source);
   parser_T* parser = herb_parser_init(lexer, options);
 
@@ -66,7 +68,8 @@ void herb_lex_to_buffer(const char* source, buffer_T* output) {
 void herb_lex_json_to_buffer(const char* source, buffer_T* output) {
   array_T* tokens = herb_lex(source);
 
-  buffer_T json = buffer_new();
+  buffer_T json;
+  buffer_init(&json, 4096);
   json_start_root_array(&json);
 
   for (size_t i = 0; i < array_size(tokens); i++) {
@@ -79,7 +82,7 @@ void herb_lex_json_to_buffer(const char* source, buffer_T* output) {
   json_end_array(&json);
   buffer_concat(output, &json);
 
-  buffer_free(&json);
+  free(json.value);
   herb_free_tokens(&tokens);
 }
 

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -10,8 +10,8 @@ typedef struct BUFFER_STRUCT {
   size_t capacity;
 } buffer_T;
 
-bool buffer_init(buffer_T* buffer);
-buffer_T buffer_new(void);
+bool buffer_init(buffer_T* buffer, size_t capacity);
+buffer_T* buffer_new(size_t capacity);
 
 bool buffer_increase_capacity(buffer_T* buffer, size_t additional_capacity);
 bool buffer_has_capacity(buffer_T* buffer, size_t required_length);
@@ -34,6 +34,6 @@ size_t buffer_capacity(const buffer_T* buffer);
 size_t buffer_sizeof(void);
 
 void buffer_clear(buffer_T* buffer);
-void buffer_free(buffer_T* buffer);
+void buffer_free(buffer_T** buffer);
 
 #endif

--- a/src/io.c
+++ b/src/io.c
@@ -8,6 +8,8 @@
 #define FILE_READ_CHUNK 4096
 
 char* herb_read_file(const char* filename) {
+  if (!filename) { return NULL; }
+
   FILE* fp = fopen(filename, "rb");
 
   if (fp == NULL) {
@@ -15,7 +17,8 @@ char* herb_read_file(const char* filename) {
     exit(1);
   }
 
-  buffer_T buffer = buffer_new();
+  buffer_T buffer;
+  buffer_init(&buffer, 4096);
 
   char chunk[FILE_READ_CHUNK];
   size_t bytes_read;

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -174,7 +174,8 @@ static token_T* lexer_match_and_advance(lexer_T* lexer, const char* value, const
 // ===== Specialized Parsers
 
 static token_T* lexer_parse_whitespace(lexer_T* lexer) {
-  buffer_T buffer = buffer_new();
+  buffer_T buffer;
+  buffer_init(&buffer, 128);
 
   while (isspace(lexer->current_character) && lexer->current_character != '\n' && lexer->current_character != '\r'
          && !lexer_eof(lexer)) {
@@ -184,13 +185,14 @@ static token_T* lexer_parse_whitespace(lexer_T* lexer) {
 
   token_T* token = token_init(buffer.value, TOKEN_WHITESPACE, lexer);
 
-  buffer_free(&buffer);
+  free(buffer.value);
 
   return token;
 }
 
 static token_T* lexer_parse_identifier(lexer_T* lexer) {
-  buffer_T buffer = buffer_new();
+  buffer_T buffer;
+  buffer_init(&buffer, 128);
 
   while ((isalnum(lexer->current_character) || lexer->current_character == '-' || lexer->current_character == '_'
           || lexer->current_character == ':')
@@ -202,7 +204,7 @@ static token_T* lexer_parse_identifier(lexer_T* lexer) {
 
   token_T* token = token_init(buffer.value, TOKEN_IDENTIFIER, lexer);
 
-  buffer_free(&buffer);
+  free(buffer.value);
 
   return token;
 }
@@ -223,7 +225,8 @@ static token_T* lexer_parse_erb_open(lexer_T* lexer) {
 }
 
 static token_T* lexer_parse_erb_content(lexer_T* lexer) {
-  buffer_T buffer = buffer_new();
+  buffer_T buffer;
+  buffer_init(&buffer, 1024);
 
   while (!lexer_peek_erb_end(lexer, 0)) {
     if (lexer_eof(lexer)) {
@@ -247,7 +250,7 @@ static token_T* lexer_parse_erb_content(lexer_T* lexer) {
 
   token_T* token = token_init(buffer.value, TOKEN_ERB_CONTENT, lexer);
 
-  buffer_free(&buffer);
+  free(buffer.value);
 
   return token;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -55,7 +55,7 @@ int main(const int argc, char* argv[]) {
 
   buffer_T output;
 
-  if (!buffer_init(&output)) { return 1; }
+  if (!buffer_init(&output, 4096)) { return 1; }
 
   char* source = herb_read_file(argv[2]);
 
@@ -74,7 +74,7 @@ int main(const int argc, char* argv[]) {
     print_time_diff(start, end, "visiting");
 
     ast_node_free((AST_NODE_T*) root);
-    buffer_free(&output);
+    free(output.value);
     free(source);
 
     return 0;
@@ -87,7 +87,7 @@ int main(const int argc, char* argv[]) {
     printf("%s\n", output.value);
     print_time_diff(start, end, "lexing");
 
-    buffer_free(&output);
+    free(output.value);
     free(source);
 
     return 0;
@@ -98,7 +98,7 @@ int main(const int argc, char* argv[]) {
 
     printf("%s\n", output.value);
 
-    buffer_free(&output);
+    free(output.value);
     free(source);
 
     return 0;
@@ -108,13 +108,18 @@ int main(const int argc, char* argv[]) {
     AST_DOCUMENT_NODE_T* root = herb_parse(source, NULL);
     clock_gettime(CLOCK_MONOTONIC, &end);
 
-    ast_pretty_print_node((AST_NODE_T*) root, 0, 0, &output);
-    printf("%s\n", output.value);
+    int silent = 0;
+    if (argc > 3 && strcmp(argv[3], "--silent") == 0) { silent = 1; }
 
-    print_time_diff(start, end, "parsing");
+    if (!silent) {
+      ast_pretty_print_node((AST_NODE_T*) root, 0, 0, &output);
+      printf("%s\n", output.value);
+
+      print_time_diff(start, end, "parsing");
+    }
 
     ast_node_free((AST_NODE_T*) root);
-    buffer_free(&output);
+    free(output.value);
     free(source);
 
     return 0;
@@ -127,7 +132,7 @@ int main(const int argc, char* argv[]) {
     printf("%s\n", output.value);
     print_time_diff(start, end, "extracting Ruby");
 
-    buffer_free(&output);
+    free(output.value);
     free(source);
 
     return 0;
@@ -140,7 +145,7 @@ int main(const int argc, char* argv[]) {
     printf("%s\n", output.value);
     print_time_diff(start, end, "extracting HTML");
 
-    buffer_free(&output);
+    free(output.value);
     free(source);
 
     return 0;

--- a/src/token.c
+++ b/src/token.c
@@ -120,34 +120,38 @@ char* token_to_string(const token_T* token) {
 }
 
 char* token_to_json(const token_T* token) {
-  buffer_T json = buffer_new();
+  buffer_T json;
+  buffer_init(&json, 512);
 
   json_start_root_object(&json);
   json_add_string(&json, "type", token_type_to_string(token->type));
   json_add_string(&json, "value", token->value);
 
-  buffer_T range = buffer_new();
+  buffer_T range;
+  buffer_init(&range, 128);
   json_start_array(&json, "range");
   json_add_size_t(&range, NULL, token->range.from);
   json_add_size_t(&range, NULL, token->range.to);
   buffer_concat(&json, &range);
-  buffer_free(&range);
+  free(range.value);
   json_end_array(&json);
 
-  buffer_T start = buffer_new();
+  buffer_T start;
+  buffer_init(&start, 128);
   json_start_object(&json, "start");
   json_add_size_t(&start, "line", token->location.start.line);
   json_add_size_t(&start, "column", token->location.start.column);
   buffer_concat(&json, &start);
-  buffer_free(&start);
+  free(start.value);
   json_end_object(&json);
 
-  buffer_T end = buffer_new();
+  buffer_T end;
+  buffer_init(&end, 128);
   json_start_object(&json, "end");
   json_add_size_t(&end, "line", token->location.end.line);
   json_add_size_t(&end, "column", token->location.end.column);
   buffer_concat(&json, &end);
-  buffer_free(&end);
+  free(end.value);
   json_end_object(&json);
 
   json_end_object(&json);

--- a/test/c/test_json.c
+++ b/test/c/test_json.c
@@ -5,7 +5,8 @@
 #include "../../src/include/json.h"
 
 TEST(test_json_escape_basic)
-  buffer_T json = buffer_new();
+  buffer_T json;
+  buffer_init(&json, 1024);
 
   json_start_root_object(&json);
   json_add_string(&json, "key", "value");
@@ -13,11 +14,12 @@ TEST(test_json_escape_basic)
 
   ck_assert_str_eq(buffer_value(&json), "{\"key\": \"value\"}");
 
-  buffer_free(&json);
+  free(json.value);
 END
 
 TEST(test_json_escape_quotes)
-  buffer_T json = buffer_new();
+  buffer_T json;
+  buffer_init(&json, 1024);
 
   json_start_root_object(&json);
   json_add_string(&json, "quote", "This is a \"quoted\" string");
@@ -25,11 +27,12 @@ TEST(test_json_escape_quotes)
 
   ck_assert_str_eq(buffer_value(&json), "{\"quote\": \"This is a \\\"quoted\\\" string\"}");
 
-  buffer_free(&json);
+  free(json.value);
 END
 
 TEST(test_json_escape_backslash)
-  buffer_T json = buffer_new();
+  buffer_T json;
+  buffer_init(&json, 1024);
 
   json_start_root_object(&json);
   json_add_string(&json, "path", "C:\\Users\\Test");
@@ -37,11 +40,12 @@ TEST(test_json_escape_backslash)
 
   ck_assert_str_eq(buffer_value(&json), "{\"path\": \"C:\\\\Users\\\\Test\"}");
 
-  buffer_free(&json);
+  free(json.value);
 END
 
 TEST(test_json_escape_newline)
-  buffer_T json = buffer_new();
+  buffer_T json;
+  buffer_init(&json, 1024);
 
   json_start_root_object(&json);
   json_add_string(&json, "text", "Line1\nLine2");
@@ -49,11 +53,12 @@ TEST(test_json_escape_newline)
 
   ck_assert_str_eq(buffer_value(&json), "{\"text\": \"Line1\\nLine2\"}");
 
-  buffer_free(&json);
+  free(json.value);
 END
 
 TEST(test_json_escape_tab)
-  buffer_T json = buffer_new();
+  buffer_T json;
+  buffer_init(&json, 1024);
 
   json_start_root_object(&json);
   json_add_string(&json, "text", "Column1\tColumn2");
@@ -61,11 +66,12 @@ TEST(test_json_escape_tab)
 
   ck_assert_str_eq(buffer_value(&json), "{\"text\": \"Column1\\tColumn2\"}");
 
-  buffer_free(&json);
+  free(json.value);
 END
 
 TEST(test_json_escape_mixed)
-  buffer_T json = buffer_new();
+  buffer_T json;
+  buffer_init(&json, 1024);
 
   json_start_root_object(&json);
   json_add_string(&json, "complex", "A \"quoted\" \\ path\nwith\ttabs.");
@@ -73,11 +79,12 @@ TEST(test_json_escape_mixed)
 
   ck_assert_str_eq(buffer_value(&json), "{\"complex\": \"A \\\"quoted\\\" \\\\ path\\nwith\\ttabs.\"}");
 
-  buffer_free(&json);
+  free(json.value);
 END
 
 TEST(test_json_root_object)
-  buffer_T json = buffer_new();
+  buffer_T json;
+  buffer_init(&json, 1024);
 
   json_start_root_object(&json);
 
@@ -86,14 +93,16 @@ TEST(test_json_root_object)
   json_add_double(&json, "score", 99.5);
   json_add_bool(&json, "active", 1);
 
-  buffer_T address = buffer_new();
+  buffer_T address;
+  buffer_init(&address, 1024);
   json_start_object(&json, "address");
   json_add_string(&address, "city", "Basel");
   json_add_string(&address, "country", "Switzerland");
   buffer_concat(&json, &address);
   json_end_object(&json);
 
-  buffer_T languages = buffer_new();
+  buffer_T languages;
+  buffer_init(&languages, 1024);
   json_start_array(&json, "languages");
   json_add_string(&languages, NULL, "Ruby");
   json_add_string(&languages, NULL, "C");
@@ -101,7 +110,8 @@ TEST(test_json_root_object)
   buffer_concat(&json, &languages);
   json_end_array(&json);
 
-  buffer_T ratings = buffer_new();
+  buffer_T ratings;
+  buffer_init(&ratings, 1024);
   json_start_array(&json, "ratings");
   json_add_double(&ratings, NULL, 4.5);
   json_add_int(&ratings, NULL, 3);
@@ -115,11 +125,15 @@ TEST(test_json_root_object)
 
   ck_assert_str_eq(buffer_value(&json), "{\"name\": \"John\", \"age\": 20, \"score\": 99.50, \"active\": true, \"address\": {\"city\": \"Basel\", \"country\": \"Switzerland\"}, \"languages\": [\"Ruby\", \"C\", \"JavaScript\"], \"ratings\": [4.50, 3, 5.0, 3.79, 5]}");
 
-  buffer_free(&json);
+  free(address.value);
+  free(languages.value);
+  free(ratings.value);
+  free(json.value);
 END
 
 TEST(test_json_root_array)
-  buffer_T json = buffer_new();
+  buffer_T json;
+  buffer_init(&json, 1024);
 
   json_start_root_array(&json);
 
@@ -135,19 +149,22 @@ TEST(test_json_root_array)
 
   ck_assert_str_eq(buffer_value(&json), "[\"Ruby\", \"C\", \"JavaScript\", 42, 3.14, true, false]");
 
-  buffer_free(&json);
+  free(json.value);
 END
 
 TEST(test_json_append_array_to_object)
-  buffer_T json = buffer_new();
+  buffer_T json;
+  buffer_init(&json, 1024);
 
   json_start_root_object(&json);
 
-  buffer_T object = buffer_new();
+  buffer_T object;
+  buffer_init(&object, 1024);
   json_start_object(&json, "object");
   json_add_string(&object, "key", "value");
 
-  buffer_T array = buffer_new();
+  buffer_T array;
+  buffer_init(&array, 1024);
   json_start_array(&object, "array");
   json_add_string(&array, NULL, "One");
   json_add_string(&array, NULL, "Two");
@@ -162,20 +179,25 @@ TEST(test_json_append_array_to_object)
 
   ck_assert_str_eq(buffer_value(&json), "{\"object\": {\"key\": \"value\", \"array\": [\"One\", \"Two\"]}}");
 
-  buffer_free(&json);
+  free(array.value);
+  free(object.value);
+  free(json.value);
 END
 
 TEST(test_json_append_object_array)
-  buffer_T json = buffer_new();
+  buffer_T json;
+  buffer_init(&json, 1024);
 
   json_start_root_object(&json);
 
-  buffer_T array = buffer_new();
+  buffer_T array;
+  buffer_init(&array, 1024);
   json_start_array(&json, "array");
   json_add_string(&array, NULL, "One");
   json_add_string(&array, NULL, "Two");
 
-  buffer_T object = buffer_new();
+  buffer_T object;
+  buffer_init(&object, 1024);
   json_start_object(&array, NULL);
   json_add_string(&object, "key", "value");
 
@@ -189,7 +211,9 @@ TEST(test_json_append_object_array)
 
   ck_assert_str_eq(buffer_value(&json), "{\"array\": [\"One\", \"Two\", {\"key\": \"value\"}]}");
 
-  buffer_free(&json);
+  free(object.value);
+  free(array.value);
+  free(json.value);
 END
 
 TEST(test_json_double_to_string_precision)
@@ -248,16 +272,18 @@ TEST(test_json_int_to_string_min_max)
 END
 
 TEST(test_json_add_size_t_basic)
-  buffer_T json = buffer_new();
+  buffer_T json;
+  buffer_init(&json, 1024);
 
   json_add_size_t(&json, "size", 42);
   ck_assert_str_eq(buffer_value(&json), "\"size\": 42");
 
-  buffer_free(&json);
+  free(json.value);
 END
 
 TEST(test_json_add_size_t_large_number)
-  buffer_T json = buffer_new();
+  buffer_T json;
+  buffer_init(&json, 1024);
 
   json_add_size_t(&json, "size", 9876543210UL);
   ck_assert_str_eq(buffer_value(&json), "\"size\": 9876543210");
@@ -266,11 +292,12 @@ TEST(test_json_add_size_t_large_number)
   json_add_size_t(&json, "size", SIZE_MAX);
   ck_assert_str_eq(buffer_value(&json), "\"size\": 18446744073709551615");
 
-  buffer_free(&json);
+  free(json.value);
 END
 
 TEST(test_json_add_size_t_in_array)
-  buffer_T json = buffer_new();
+  buffer_T json;
+  buffer_init(&json, 1024);
 
   json_add_size_t(&json, NULL, 1024);
   json_add_size_t(&json, NULL, 2048);
@@ -278,7 +305,7 @@ TEST(test_json_add_size_t_in_array)
 
   ck_assert_str_eq(buffer_value(&json), "1024, 2048, 4096");
 
-  buffer_free(&json);
+  free(json.value);
 END
 
 

--- a/test/c/test_lex.c
+++ b/test/c/test_lex.c
@@ -3,18 +3,20 @@
 
 TEST(herb_lex_to_buffer_empty_file)
   char* html = "";
-  buffer_T output = buffer_new();
+  buffer_T output;
+  buffer_init(&output, 1024);
 
   herb_lex_to_buffer(html, &output);
 
   ck_assert_str_eq(output.value, "#<Herb::Token type=\"TOKEN_EOF\" value=\"<EOF>\" range=[0, 0] start=(1:0) end=(1:0)>\n");
 
-  buffer_free(&output);
+  free(output.value);
 END
 
 TEST(herb_lex_to_buffer_basic_tag)
   char* html = "<html></html>";
-  buffer_T output = buffer_new();
+  buffer_T output;
+  buffer_init(&output, 1024);
 
   herb_lex_to_buffer(html, &output);
 
@@ -29,7 +31,7 @@ TEST(herb_lex_to_buffer_basic_tag)
     "#<Herb::Token type=\"TOKEN_EOF\" value=\"<EOF>\" range=[13, 13] start=(1:13) end=(1:13)>\n"
   );
 
-  buffer_free(&output);
+  free(output.value);
 END
 
 TCase *lex_tests(void) {

--- a/test/c/test_token.c
+++ b/test/c/test_token.c
@@ -8,7 +8,8 @@ TEST(test_token)
 END
 
 TEST(test_token_to_string)
-  buffer_T output = buffer_new();
+  buffer_T output;
+  buffer_init(&output, 1024);
   herb_lex_to_buffer("hello", &output);
 
   ck_assert_str_eq(
@@ -17,11 +18,12 @@ TEST(test_token_to_string)
     "#<Herb::Token type=\"TOKEN_EOF\" value=\"<EOF>\" range=[5, 5] start=(1:5) end=(1:5)>\n"
   );
 
-  buffer_free(&output);
+  free(output.value);
 END
 
 TEST(test_token_to_json)
-  buffer_T output = buffer_new();
+  buffer_T output;
+  buffer_init(&output, 1024);
   herb_lex_json_to_buffer("hello", &output);
 
   const char* expected = "["
@@ -31,7 +33,7 @@ TEST(test_token_to_json)
 
   ck_assert_str_eq(output.value, expected);
 
-  buffer_free(&output);
+  free(output.value);
 END
 
 TCase *token_tests(void) {

--- a/wasm/herb-wasm.cpp
+++ b/wasm/herb-wasm.cpp
@@ -61,19 +61,21 @@ val Herb_parse(const std::string& source, val options) {
 
 std::string Herb_extract_ruby(const std::string& source) {
   buffer_T output;
-  buffer_init(&output);
+  buffer_init(&output, source.length());
+
   herb_extract_ruby_to_buffer(source.c_str(), &output);
   std::string result(buffer_value(&output));
-  buffer_free(&output);
+  free(output.value);
   return result;
 }
 
 std::string Herb_extract_html(const std::string& source) {
   buffer_T output;
-  buffer_init(&output);
+  buffer_init(&output, source.length());
+
   herb_extract_html_to_buffer(source.c_str(), &output);
   std::string result(buffer_value(&output));
-  buffer_free(&output);
+  free(output.value);
   return result;
 }
 


### PR DESCRIPTION
This pull request is an alternative to #579 and reworks the buffer to not have a default capacity anymore, but instead, let the caller decide how big the initial buffer capacity should be. 

This also allows callers to request enough capacity upfront if they know the approximate or exact buffer buffer length, which then doesn't need any buffer capacity expansions at a later point, thus removing the need to reallocate.

Closes #579 
