### PR TITLE
Linter: Fix crash in `html-no-underscores-in-attribute-names` rule

### DIFF
--- a/javascript/packages/linter/src/rules/html-no-underscores-in-attribute-names.ts
+++ b/javascript/packages/linter/src/rules/html-no-underscores-in-attribute-names.ts
@@ -38,7 +38,7 @@ class HTMLNoUnderscoresInAttributeNamesVisitor extends AttributeVisitorMixin {
     if (attributeName.includes("_")) {
       this.addOffense(
         `Attribute \`${IdentityPrinter.print(attributeNode.name)}\` should not contain underscores. Use hyphens (-) instead.`,
-        attributeNode.value!.location,
+        attributeNode.name?.location ?? attributeNode.location,
         "warning"
       )
     }

--- a/javascript/packages/linter/test/rules/html-no-underscores-in-attribute-names.test.ts
+++ b/javascript/packages/linter/test/rules/html-no-underscores-in-attribute-names.test.ts
@@ -44,4 +44,20 @@ describe("html-no-underscores-in-attribute-names", () => {
       <div data-<%= key %>_test="value"></div>
     `)
   })
+
+  test("handles malformed attributes without crashing (issue #601)", () => {
+    expectWarning("Attribute `foo_bar` should not contain underscores. Use hyphens (-) instead.")
+
+    assertOffenses(dedent`
+      <input foo_bar=I18n.t('value')>
+    `)
+  })
+
+  test("handles malformed attributes without crashing - exact snippet from issue #601", () => {
+    expectWarning("Attribute `t('foo_bar')` should not contain underscores. Use hyphens (-) instead.")
+
+    assertOffenses(dedent`
+      <input title=I18n.t('foo_bar')>
+    `)
+  })
 })


### PR DESCRIPTION
Resolves #601 