### PR TITLE
Bump Prism to `v1.5.2`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ If you encounter any issues when following along with this file please dont hesi
 - [**Clang 19**](https://clang.llvm.org): The compiler used to build this project.
 - [**Clang Format 19**](https://clang.llvm.org/docs/ClangFormat.html): For formatting the project.
 - [**Clang Tidy 19**](https://clang.llvm.org/extra/clang-tidy/): For linting the project.
-- [**Prism Ruby Parser v1.5.1**](https://github.com/ruby/prism/releases/tag/v1.5.1): We use Prism for Parsing the Ruby Source Code in the HTML+ERB files.
+- [**Prism Ruby Parser v1.5.2**](https://github.com/ruby/prism/releases/tag/v1.5.2): We use Prism for Parsing the Ruby Source Code in the HTML+ERB files.
 - [**Ruby**](https://www.ruby-lang.org/en/): We need Ruby as a dependency for `bundler`.
 - [**Bundler**](https://bundler.io): We are using `bundler` to build [`prism`](https://github.com/ruby/prism) from source so we can build `herb` against it.
 - [**Emscripten**](https://emscripten.org): For the WebAssembly build of `libherb` so it can be used in the browser using the [`@herb-tools/browser`](https://github.com/marcoroth/herb/blob/main/javascript/packages/browser) package.

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "prism", github: "ruby/prism", tag: "v1.5.1"
+gem "prism", github: "ruby/prism", tag: "v1.5.2"
 
 gem "actionview", "~> 8.0"
 gem "lz_string"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/ruby/prism.git
-  revision: 23f16d31a7c57c4b927e1e3ec8f1281b45e7cb9f
-  tag: v1.5.1
+  revision: 983ecaf4790a536ad26ff444ec962887ea2aa6ba
+  tag: v1.5.2
   specs:
-    prism (1.5.1)
+    prism (1.5.2)
 
 PATH
   remote: .

--- a/javascript/packages/browser/test/browser.test.ts
+++ b/javascript/packages/browser/test/browser.test.ts
@@ -17,7 +17,7 @@ describe("@herb-tools/browser", () => {
   test("version() returns a string", async () => {
     const version = Herb.version
     expect(typeof version).toBe("string")
-    expect(version).toBe("@herb-tools/browser@0.7.5, @herb-tools/core@0.7.5, libprism@1.5.1, libherb@0.7.5 (WebAssembly)")
+    expect(version).toBe("@herb-tools/browser@0.7.5, @herb-tools/core@0.7.5, libprism@1.5.2, libherb@0.7.5 (WebAssembly)")
   })
 
   test("parse() can process a simple template", async () => {

--- a/javascript/packages/node-wasm/test/node-wasm.test.ts
+++ b/javascript/packages/node-wasm/test/node-wasm.test.ts
@@ -17,7 +17,7 @@ describe("@herb-tools/node-wasm", () => {
   test("version() returns a string", async () => {
     const version = Herb.version
     expect(typeof version).toBe("string")
-    expect(version).toBe("@herb-tools/node-wasm@0.7.5, @herb-tools/core@0.7.5, libprism@1.5.1, libherb@0.7.5 (WebAssembly)")
+    expect(version).toBe("@herb-tools/node-wasm@0.7.5, @herb-tools/core@0.7.5, libprism@1.5.2, libherb@0.7.5 (WebAssembly)")
   })
 
   test("parse() can process a simple template", async () => {

--- a/javascript/packages/node/test/node.test.ts
+++ b/javascript/packages/node/test/node.test.ts
@@ -17,7 +17,7 @@ describe("@herb-tools/node", () => {
   test("version() returns a string", async () => {
     const version = Herb.version
     expect(typeof version).toBe("string")
-    expect(version).toBe("@herb-tools/node@0.7.5, @herb-tools/core@0.7.5, libprism@1.5.1, libherb@0.7.5 (Node.js C++ native extension)")
+    expect(version).toBe("@herb-tools/node@0.7.5, @herb-tools/core@0.7.5, libprism@1.5.2, libherb@0.7.5 (Node.js C++ native extension)")
   })
 
   test("parse() can process a simple template", async () => {

--- a/test/herb_test.rb
+++ b/test/herb_test.rb
@@ -4,6 +4,6 @@ require_relative "test_helper"
 
 class HerbTest < Minitest::Spec
   test "version" do
-    assert_equal "herb gem v0.7.5, libprism v1.5.1, libherb v0.7.5 (Ruby C native extension)", Herb.version
+    assert_equal "herb gem v0.7.5, libprism v1.5.2, libherb v0.7.5 (Ruby C native extension)", Herb.version
   end
 end


### PR DESCRIPTION
This pull request updates Prism to [`v1.5.2`](https://github.com/ruby/prism/releases/tag/v1.5.2).