### PR TITLE
C: Remove unused functions from `util.c`

### DIFF
--- a/src/include/util.h
+++ b/src/include/util.h
@@ -4,20 +4,11 @@
 #include <stdbool.h>
 #include <stdlib.h>
 
-int is_whitespace(int character);
 int is_newline(int character);
 
-int count_in_string(const char* string, char character);
-int count_newlines(const char* string);
-
-char* replace_char(char* string, char find, char replace);
 char* escape_newlines(const char* input);
 char* quoted_string(const char* input);
 char* wrap_string(const char* input, char character);
-
-bool string_blank(const char* input);
-bool string_present(const char* input);
-
 char* herb_strdup(const char* s);
 
 char* size_t_to_string(size_t value);

--- a/src/util.c
+++ b/src/util.c
@@ -5,53 +5,8 @@
 #include <stdlib.h>
 #include <string.h>
 
-int is_whitespace(const int character) {
-  return character == ' ' || character == '\t';
-}
-
 int is_newline(const int character) {
   return character == 13 || character == 10;
-}
-
-int count_in_string(const char* string, const char character) {
-  int count = 0;
-
-  while (*string != '\0') {
-    if (*string == character) { count++; }
-
-    string++;
-  }
-
-  return count;
-}
-
-int count_newlines(const char* string) {
-  int count = 0;
-
-  while (*string) {
-    if (*string == '\r') {
-      count++;
-      if (*(string + 1) == '\n') { string++; }
-    } else if (*string == '\n') {
-      count++;
-    }
-
-    string++;
-  }
-
-  return count;
-}
-
-char* replace_char(char* string, const char find, const char replace) {
-  char* original_string = string;
-
-  while (*string != '\0') {
-    if (*string == find) { *string = replace; }
-
-    string++;
-  }
-
-  return original_string;
 }
 
 char* escape_newlines(const char* input) {
@@ -95,22 +50,6 @@ char* wrap_string(const char* input, const char character) {
 
 char* quoted_string(const char* input) {
   return wrap_string(input, '"');
-}
-
-// Check if a string is blank (NULL, empty, or only contains whitespace)
-bool string_blank(const char* input) {
-  if (input == NULL || input[0] == '\0') { return true; }
-
-  for (const char* p = input; *p != '\0'; p++) {
-    if (!isspace(*p)) { return false; }
-  }
-
-  return true;
-}
-
-// Check if a string is present (not blank)
-bool string_present(const char* input) {
-  return !string_blank(input);
 }
 
 char* herb_strdup(const char* s) {

--- a/test/c/test_util.c
+++ b/test/c/test_util.c
@@ -3,16 +3,6 @@
 #include "../../src/include/herb.h"
 #include "../../src/include/util.h"
 
-TEST(util_count_newlines)
-  ck_assert_int_eq(count_newlines("\n"), 1);
-  ck_assert_int_eq(count_newlines("\n\n"), 2);
-
-  ck_assert_int_eq(count_newlines("\r"), 1);
-  ck_assert_int_eq(count_newlines("\r\r"), 2);
-
-  ck_assert_int_eq(count_newlines("\r\n"), 1);
-  ck_assert_int_eq(count_newlines("\r\n\r\n"), 2);
-END
 
 TEST(util_is_newline)
   ck_assert_int_eq(is_newline('\n'), 1);
@@ -22,20 +12,10 @@ TEST(util_is_newline)
   ck_assert_int_eq(is_newline('a'), 0);
 END
 
-TEST(util_replace_char_returns_original)
-  char str[] = "abca";
-  char *returned = replace_char(str, 'a', 'x');
-
-  ck_assert_ptr_eq(returned, str);
-  ck_assert_str_eq(str, "xbcx");
-END
-
 TCase *util_tests(void) {
   TCase *util = tcase_create("Util");
 
-  tcase_add_test(util, util_count_newlines);
   tcase_add_test(util, util_is_newline);
-  tcase_add_test(util, util_replace_char_returns_original);
 
   return util;
 }


### PR DESCRIPTION
This MR removes functions from util.c that aren't used in the code base anymore.

## Removed functions

- is_whitespace
- count_in_string
- count_newlines
- replace_char
- string_blank
- string_present