### PR TITLE
C: Remove unused `html_util` functions

### DIFF
--- a/src/html_util.c
+++ b/src/html_util.c
@@ -23,54 +23,6 @@ bool is_void_element(const char* tag_name) {
   return false;
 }
 
-bool is_html4_void_element(const char* tag_name) {
-  if (tag_name == NULL) { return false; }
-
-  const char* html4_void_tags[] = {
-    "basefont", "bgsound", "command", "frame", "image", "keygen",
-  };
-
-  for (size_t i = 0; i < sizeof(html4_void_tags) / sizeof(char*); i++) {
-    if (strcasecmp(tag_name, html4_void_tags[i]) == 0) { return true; }
-  }
-
-  return false;
-}
-
-/**
- * @brief Creates an opening HTML tag string like "<tag_name>"
- *
- * @param tag_name The name of the HTML tag to be enclosed in a opening tag
- * @return A newly allocated string containing the opening tag, or NULL if memory allocation fails
- * @note The caller is responsible for freeing the returned string
- *
- * Example:
- * @code
- * char* tag = html_opening_tag_string("div");
- * if (tag) {
- *   printf("%s\n", tag); // Prints: <div>
- *   free(tag);
- * }
- * @endcode
- */
-char* html_opening_tag_string(const char* tag_name) {
-  if (tag_name == NULL) { return herb_strdup("<>"); }
-
-  size_t length = strlen(tag_name);
-  char* result = (char*) malloc(length + 3); // +3 for '<', '>', and '\0'
-
-  if (result == NULL) { return NULL; }
-
-  result[0] = '<';
-
-  memcpy(result + 1, tag_name, length);
-
-  result[length + 1] = '>';
-  result[length + 2] = '\0';
-
-  return result;
-}
-
 /**
  * @brief Creates a closing HTML tag string like "</tag_name>"
  *

--- a/src/include/html_util.h
+++ b/src/include/html_util.h
@@ -4,9 +4,7 @@
 #include <stdbool.h>
 
 bool is_void_element(const char* tag_name);
-bool is_html4_void_element(const char* tag_name);
 
-char* html_opening_tag_string(const char* tag_name);
 char* html_closing_tag_string(const char* tag_name);
 char* html_self_closing_tag_string(const char* tag_name);
 

--- a/test/c/test_html_util.c
+++ b/test/c/test_html_util.c
@@ -3,15 +3,6 @@
 #include "../../src/include/herb.h"
 #include "../../src/include/html_util.h"
 
-TEST(html_util_html_opening_tag_string)
-  ck_assert_str_eq(html_opening_tag_string(NULL), "<>");
-  ck_assert_str_eq(html_opening_tag_string(""), "<>");
-  ck_assert_str_eq(html_opening_tag_string(" "), "< >");
-  ck_assert_str_eq(html_opening_tag_string("br"), "<br>");
-  ck_assert_str_eq(html_opening_tag_string("div"), "<div>");
-  ck_assert_str_eq(html_opening_tag_string("somelongerstring"), "<somelongerstring>");
-END
-
 TEST(html_util_html_closing_tag_string)
   ck_assert_str_eq(html_closing_tag_string(NULL), "</>");
   ck_assert_str_eq(html_closing_tag_string(""), "</>");


### PR DESCRIPTION
This PR removes html_util functions that aren't used anymore.

## Removed functions

- is_html4_void_element
- html_opening_tag_string