### PR TITLE
C: Remove unused functions from `hb_buffer.c`

### DIFF
--- a/src/include/util/hb_buffer.h
+++ b/src/include/util/hb_buffer.h
@@ -12,8 +12,6 @@ typedef struct HB_BUFFER_STRUCT {
 
 bool hb_buffer_init(hb_buffer_T* buffer, size_t capacity);
 
-bool hb_buffer_resize(hb_buffer_T* buffer, size_t new_capacity);
-
 void hb_buffer_append(hb_buffer_T* buffer, const char* text);
 void hb_buffer_append_with_length(hb_buffer_T* buffer, const char* text, size_t length);
 void hb_buffer_append_char(hb_buffer_T* buffer, char character);

--- a/src/util/hb_buffer.c
+++ b/src/util/hb_buffer.c
@@ -11,6 +11,32 @@ static bool hb_buffer_has_capacity(hb_buffer_T* buffer, const size_t required_le
 }
 
 /**
+ * Resizes the capacity of the buffer to the specified new capacity.
+ *
+ * @param buffer The buffer to resize
+ * @param new_capacity The new capacity to resize the buffer to
+ * @return true if capacity was resized, false if reallocation failed
+ */
+static bool hb_buffer_resize(hb_buffer_T* buffer, const size_t new_capacity) {
+  if (new_capacity + 1 >= SIZE_MAX) {
+    fprintf(stderr, "Error: Buffer capacity would overflow system limits.\n");
+    exit(1);
+  }
+
+  char* new_value = realloc(buffer->value, new_capacity + 1);
+
+  if (unlikely(new_value == NULL)) {
+    fprintf(stderr, "Error: Failed to resize buffer to %zu.\n", new_capacity);
+    exit(1);
+  }
+
+  buffer->value = new_value;
+  buffer->capacity = new_capacity;
+
+  return true;
+}
+
+/**
  * Expands the capacity of the buffer if needed to accommodate additional content.
  * This function is a convenience function that calls hb_buffer_has_capacity and
  * hb_buffer_expand_capacity.
@@ -64,32 +90,6 @@ size_t hb_buffer_capacity(const hb_buffer_T* buffer) {
 
 size_t hb_buffer_sizeof(void) {
   return sizeof(hb_buffer_T);
-}
-
-/**
- * Resizes the capacity of the buffer to the specified new capacity.
- *
- * @param buffer The buffer to resize
- * @param new_capacity The new capacity to resize the buffer to
- * @return true if capacity was resized, false if reallocation failed
- */
-bool hb_buffer_resize(hb_buffer_T* buffer, const size_t new_capacity) {
-  if (new_capacity + 1 >= SIZE_MAX) {
-    fprintf(stderr, "Error: Buffer capacity would overflow system limits.\n");
-    exit(1);
-  }
-
-  char* new_value = realloc(buffer->value, new_capacity + 1);
-
-  if (unlikely(new_value == NULL)) {
-    fprintf(stderr, "Error: Failed to resize buffer to %zu.\n", new_capacity);
-    exit(1);
-  }
-
-  buffer->value = new_value;
-  buffer->capacity = new_capacity;
-
-  return true;
 }
 
 /**

--- a/test/c/test_hb_buffer.c
+++ b/test/c/test_hb_buffer.c
@@ -81,25 +81,6 @@ TEST(test_hb_buffer_resizing_behavior)
   free(buffer.value);
 END
 
-// Test resizing buffer
-TEST(test_hb_buffer_resize)
-  hb_buffer_T buffer;
-  hb_buffer_init(&buffer, 1024);
-
-  ck_assert_int_eq(buffer.capacity, 1024);
-
-  ck_assert(hb_buffer_resize(&buffer, 2048));
-  ck_assert_int_eq(buffer.capacity, 2048);
-
-  ck_assert(hb_buffer_resize(&buffer, 4096));
-  ck_assert_int_eq(buffer.capacity, 4096);
-
-  ck_assert(hb_buffer_resize(&buffer, 8192));
-  ck_assert_int_eq(buffer.capacity, 8192);
-
-  free(buffer.value);
-END
-
 // Test clearing buffer without freeing memory
 TEST(test_hb_buffer_clear)
   hb_buffer_T buffer;
@@ -205,7 +186,6 @@ TCase *hb_buffer_tests(void) {
   tcase_add_test(buffer, test_hb_buffer_prepend);
   tcase_add_test(buffer, test_hb_buffer_concat);
   tcase_add_test(buffer, test_hb_buffer_resizing_behavior);
-  tcase_add_test(buffer, test_hb_buffer_resize);
   tcase_add_test(buffer, test_hb_buffer_clear);
   tcase_add_test(buffer, test_hb_buffer_free);
   tcase_add_test(buffer, test_buffer_utf8_integrity);


### PR DESCRIPTION
This PR removes buffer functions that aren't used (anymore) and makes functions required internally static.

## Removed functions

- buffer_new
- buffer_increase_capacity
- buffer_expand_capacity

## Made static

- buffer_resize
- buffer_has_capacity
- buffer_expand_if_needed
- buffer_append_repeated