### PR TITLE
Linter: Don't lint files with parser errors

### DIFF
--- a/javascript/packages/linter/src/linter.ts
+++ b/javascript/packages/linter/src/linter.ts
@@ -55,6 +55,7 @@ export class Linter {
 
     const parseResult = this.herb.parse(source, { track_whitespace: true })
     const lexResult = this.herb.lex(source)
+    const hasParserErrors = parseResult.recursiveErrors().length > 0
 
     for (const RuleClass of this.rules) {
       const rule = new RuleClass()
@@ -84,6 +85,12 @@ export class Linter {
           ruleOffenses = []
         }
       } else {
+        if (hasParserErrors && rule.name !== "parser-no-errors") {
+          ruleOffenses = []
+
+          continue
+        }
+
         if (rule.isEnabled) {
           isEnabled = rule.isEnabled(parseResult, context)
         }

--- a/javascript/packages/linter/test/__snapshots__/cli.test.ts.snap
+++ b/javascript/packages/linter/test/__snapshots__/cli.test.ts.snap
@@ -73,6 +73,26 @@ test/fixtures/no-trailing-newline.html.erb:1:29
   Offenses     1 error | 0 warnings (1 offense across 1 file)"
 `;
 
+exports[`CLI Output Formatting > diplays only parsers errors if one is present 1`] = `
+"[error] Unexpected Token. Expected: \`TOKEN_IDENTIFIER, TOKEN_AT, TOKEN_ERB_START,TOKEN_WHITESPACE, or TOKEN_NEWLINE\`, found: \`TOKEN_CHARACTER\`. (\`UNEXPECTED_ERROR\`) (parser-no-errors)
+
+test/fixtures/parser-errors.html.erb:2:16
+
+      1 │ <div id=test class=foo>
+  →   2 │   <img src=image.jpg>
+        │                 ~
+      3 │ </div>
+      4 │
+
+ Rule offenses:
+  parser-no-errors (1 offense in 1 file)
+
+
+ Summary:
+  Checked      1 file
+  Offenses     1 error | 0 warnings (1 offense across 1 file)"
+`;
+
 exports[`CLI Output Formatting > displays most violated rules with multiple offenses 1`] = `
 "[error] Add an \`href\` attribute to \`<a>\` to ensure it is focusable and accessible. (html-anchor-require-href)
 
@@ -290,11 +310,11 @@ test/fixtures/few-rule-offenses.html.erb:2:8
       1 │ <!-- Just a few different rule offenses to test "Rule offenses:" vs "Most frequent rule offenses:" -->
   →   2 │ <div id=test class=foo>
         │         ~~~~
-      3 │   <img src=image.jpg>
+      3 │   <img src=image>
       4 │ </div>
 
 
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯  [1/7] ⎯⎯⎯⎯
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯  [1/6] ⎯⎯⎯⎯
 
 [error] Attribute value should be quoted: \`class="foo"\`. Always wrap attribute values in quotes. (html-attribute-values-require-quotes)
 
@@ -303,11 +323,11 @@ test/fixtures/few-rule-offenses.html.erb:2:19
       1 │ <!-- Just a few different rule offenses to test "Rule offenses:" vs "Most frequent rule offenses:" -->
   →   2 │ <div id=test class=foo>
         │                    ~~~
-      3 │   <img src=image.jpg>
+      3 │   <img src=image>
       4 │ </div>
 
 
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯  [2/7] ⎯⎯⎯⎯
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯  [2/6] ⎯⎯⎯⎯
 
 [error] Attribute value should be quoted: \`src="image"\`. Always wrap attribute values in quotes. (html-attribute-values-require-quotes)
 
@@ -315,13 +335,13 @@ test/fixtures/few-rule-offenses.html.erb:3:11
 
       1 │ <!-- Just a few different rule offenses to test "Rule offenses:" vs "Most frequent rule offenses:" -->
       2 │ <div id=test class=foo>
-  →   3 │   <img src=image.jpg>
+  →   3 │   <img src=image>
         │            ~~~~~
       4 │ </div>
       5 │
 
 
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯  [3/7] ⎯⎯⎯⎯
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯  [3/6] ⎯⎯⎯⎯
 
 [error] Missing required \`alt\` attribute on \`<img>\` tag. Add \`alt=""\` for decorative images or \`alt="description"\` for informative images. (html-img-require-alt)
 
@@ -329,13 +349,13 @@ test/fixtures/few-rule-offenses.html.erb:3:3
 
       1 │ <!-- Just a few different rule offenses to test "Rule offenses:" vs "Most frequent rule offenses:" -->
       2 │ <div id=test class=foo>
-  →   3 │   <img src=image.jpg>
+  →   3 │   <img src=image>
         │    ~~~
       4 │ </div>
       5 │
 
 
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯  [4/7] ⎯⎯⎯⎯
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯  [4/6] ⎯⎯⎯⎯
 
 [error] Duplicate ID \`duplicate\` found. IDs must be unique within a document. (html-no-duplicate-ids)
 
@@ -348,7 +368,7 @@ test/fixtures/few-rule-offenses.html.erb:9:5
      10 │
 
 
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯  [5/7] ⎯⎯⎯⎯
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯  [5/6] ⎯⎯⎯⎯
 
 [error] Heading element \`<h1>\` must not be empty. Provide accessible text content for screen readers and SEO. (html-no-empty-headings)
 
@@ -361,31 +381,16 @@ test/fixtures/few-rule-offenses.html.erb:6:0
       7 │ 
       8 │ <div id="duplicate"></div>
 
-
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯  [6/7] ⎯⎯⎯⎯
-
-[error] Unexpected Token. Expected: \`TOKEN_IDENTIFIER, TOKEN_AT, TOKEN_ERB_START,TOKEN_WHITESPACE, or TOKEN_NEWLINE\`, found: \`TOKEN_CHARACTER\`. (\`UNEXPECTED_ERROR\`) (parser-no-errors)
-
-test/fixtures/few-rule-offenses.html.erb:3:16
-
-      1 │ <!-- Just a few different rule offenses to test "Rule offenses:" vs "Most frequent rule offenses:" -->
-      2 │ <div id=test class=foo>
-  →   3 │   <img src=image.jpg>
-        │                 ~
-      4 │ </div>
-      5 │
-
  Rule offenses:
   html-attribute-values-require-quotes (3 offenses in 1 file)
   html-img-require-alt (1 offense in 1 file)
   html-no-duplicate-ids (1 offense in 1 file)
   html-no-empty-headings (1 offense in 1 file)
-  parser-no-errors (1 offense in 1 file)
 
 
  Summary:
   Checked      1 file
-  Offenses     7 errors | 0 warnings (7 offenses across 1 file)"
+  Offenses     6 errors | 0 warnings (6 offenses across 1 file)"
 `;
 
 exports[`CLI Output Formatting > formats GitHub Actions output correctly for bad file 1`] = `

--- a/javascript/packages/linter/test/cli.test.ts
+++ b/javascript/packages/linter/test/cli.test.ts
@@ -85,6 +85,13 @@ describe("CLI Output Formatting", () => {
     expect(exitCode).toBe(1)
   })
 
+  test("diplays only parsers errors if one is present", () => {
+    const { output, exitCode } = runLinter("parser-errors.html.erb", "--no-wrap-lines")
+
+    expect(output).toMatchSnapshot()
+    expect(exitCode).toBe(1)
+  })
+
   test("enables line wrapping by default", () => {
     const { output } = runLinter("long-line.html.erb")
 

--- a/javascript/packages/linter/test/fixtures/few-rule-offenses.html.erb
+++ b/javascript/packages/linter/test/fixtures/few-rule-offenses.html.erb
@@ -1,6 +1,6 @@
 <!-- Just a few different rule offenses to test "Rule offenses:" vs "Most frequent rule offenses:" -->
 <div id=test class=foo>
-  <img src=image.jpg>
+  <img src=image>
 </div>
 
 <h1></h1>

--- a/javascript/packages/linter/test/fixtures/parser-errors.html.erb
+++ b/javascript/packages/linter/test/fixtures/parser-errors.html.erb
@@ -1,0 +1,3 @@
+<div id=test class=foo>
+  <img src=image.jpg>
+</div>

--- a/javascript/packages/linter/test/rules/erb-no-empty-tags.test.ts
+++ b/javascript/packages/linter/test/rules/erb-no-empty-tags.test.ts
@@ -27,13 +27,13 @@ describe("ERBNoEmptyTagsRule", () => {
   test("should not report errors for incomplete erb tags", () => {
     expectNoOffenses(dedent`
       <%
-    `)
+    `, { allowInvalidSyntax: true })
   })
 
   test("should not report errors for incomplete erb output tags", () => {
     expectNoOffenses(dedent`
       <%=
-    `)
+    `, { allowInvalidSyntax: true })
   })
 
   test("should report errors for completely empty ERB tags", () => {

--- a/javascript/packages/linter/test/rules/erb-right-trim.test.ts
+++ b/javascript/packages/linter/test/rules/erb-right-trim.test.ts
@@ -48,6 +48,7 @@ describe("ERBRightTrimRule", () => {
     assertOffenses(dedent`
       <h1>
         <%= title =%>
+      </h1>
     `)
   })
 

--- a/javascript/packages/linter/test/rules/html-attribute-values-require-quotes.test.ts
+++ b/javascript/packages/linter/test/rules/html-attribute-values-require-quotes.test.ts
@@ -6,45 +6,45 @@ const { expectNoOffenses, expectError, assertOffenses } = createLinterTest(HTMLA
 
 describe("html-attribute-values-require-quotes", () => {
   test("passes for quoted attribute values", () => {
-    expectNoOffenses(`<div id="hello" class="container">`)
+    expectNoOffenses(`<div id="hello" class="container"></div>`)
   })
 
   test("fails for unquoted attribute values", () => {
     expectError('Attribute value should be quoted: `id="hello"`. Always wrap attribute values in quotes.')
     expectError('Attribute value should be quoted: `class="container"`. Always wrap attribute values in quotes.')
-    assertOffenses(`<div id=hello class=container>`)
+    assertOffenses(`<div id=hello class=container></div>`)
   })
 
   test("passes for single-quoted values", () => {
-    expectNoOffenses(`<div id='hello' class='container'>`)
+    expectNoOffenses(`<div id='hello' class='container'></div>`)
   })
 
   test("passes for boolean attributes without values", () => {
-    expectNoOffenses(`<input type="text" disabled>`)
+    expectNoOffenses(`<input type="text" disabled />`)
   })
 
   test("handles mixed quoted and unquoted", () => {
     expectError('Attribute value should be quoted: `name="username"`. Always wrap attribute values in quotes.')
-    assertOffenses(`<input type="text" name=username value="test">`)
+    assertOffenses(`<input type="text" name=username value="test" />`)
   })
 
   test("handles ERB in quoted attributes", () => {
-    expectNoOffenses(`<div class="<%= classes %>" data-id="<%= item.id %>">`)
+    expectNoOffenses(`<div class="<%= classes %>" data-id="<%= item.id %>"></div>`)
   })
 
   test("handles ERB in unquoted attributes", () => {
     expectError('Attribute value should be quoted: `class="<%= classes %>"`. Always wrap attribute values in quotes.')
-    assertOffenses(`<div class=<%= classes %>`)
+    assertOffenses(`<div class=<%= classes %>></div>`)
   })
 
   test("handles self-closing tags", () => {
     expectError('Attribute value should be quoted: `src="photo"`. Always wrap attribute values in quotes.')
-    assertOffenses(`<img src=photo.jpg alt="Photo">`)
+    assertOffenses(`<img src=photo alt="Photo" />`)
   })
 
   test("handles complex attribute values", () => {
     expectError('Attribute value should be quoted: `title="User"`. Always wrap attribute values in quotes.')
-    assertOffenses(`<a href="/profile" title=User\\ Profile>`)
+    assertOffenses(`<a href="/profile" title=User></a>`)
   })
 
   test("ignores closing tags", () => {

--- a/javascript/packages/linter/test/rules/html-boolean-attributes-no-value.test.ts
+++ b/javascript/packages/linter/test/rules/html-boolean-attributes-no-value.test.ts
@@ -48,26 +48,26 @@ describe("html-boolean-attributes-no-value", () => {
   })
 
   test("passes for video controls", () => {
-    expectNoOffenses('<video controls>')
+    expectNoOffenses('<video controls></video>')
   })
 
   test("fails for video controls with value", () => {
     expectError('Boolean attribute `controls` should not have a value. Use `controls` instead of `controls="controls"`.')
     expectError('Boolean attribute `autoplay` should not have a value. Use `autoplay` instead of `autoplay="autoplay"`.')
 
-    assertOffenses('<video controls="controls" autoplay="autoplay">')
+    assertOffenses('<video controls="controls" autoplay="autoplay"></video>')
   })
 
   test("fails for boolean attribute with different value", () => {
     expectError('Boolean attribute `controls` should not have a value. Use `controls` instead of `controls="something-else"`.')
 
-    assertOffenses('<video controls="something-else">')
+    assertOffenses('<video controls="something-else"></video>')
   })
 
   test("handles mixed boolean and regular attributes", () => {
     expectError('Boolean attribute `novalidate` should not have a value. Use `novalidate` instead of `novalidate="novalidate"`.')
 
-    assertOffenses('<form novalidate="novalidate" action="/submit" method="post">')
+    assertOffenses('<form novalidate="novalidate" action="/submit" method="post"></form>')
   })
 
   test("fails for boolean attributes with ERB output value", () => {

--- a/javascript/packages/linter/test/rules/html-iframe-has-title.test.ts
+++ b/javascript/packages/linter/test/rules/html-iframe-has-title.test.ts
@@ -38,7 +38,7 @@ describe("html-iframe-has-title", () => {
   })
 
   test("ignores frame elements (different tag)", () => {
-    expectNoOffenses(`<frame src="https://example.com">`)
+    expectNoOffenses(`<frame src="https://example.com"></frame>`)
   })
 
   test("handles mixed case iframe tag", () => {

--- a/javascript/packages/linter/test/rules/html-no-duplicate-attributes.test.ts
+++ b/javascript/packages/linter/test/rules/html-no-duplicate-attributes.test.ts
@@ -17,16 +17,16 @@ describe("html-no-duplicate-attributes", () => {
   test("fails for multiple duplicate attributes", () => {
     expectError('Duplicate attribute `type` found on tag. Remove the duplicate occurrence.')
     expectError('Duplicate attribute `class` found on tag. Remove the duplicate occurrence.')
-    assertOffenses(`<button type="submit" type="button" class="btn" class="primary">`)
+    assertOffenses(`<button type="submit" type="button" class="btn" class="primary"></button>`)
   })
 
   test("handles case-insensitive duplicates", () => {
     expectError('Duplicate attribute `class` found on tag. Remove the duplicate occurrence.')
-    assertOffenses(`<div Class="container" class="active">`)
+    assertOffenses(`<div Class="container" class="active"></div>`)
   })
 
   test("passes for different attributes", () => {
-    expectNoOffenses(`<div class="container" id="main" data-value="test">`)
+    expectNoOffenses(`<div class="container" id="main" data-value="test"></div>`)
   })
 
   test("handles self-closing tags", () => {
@@ -35,7 +35,7 @@ describe("html-no-duplicate-attributes", () => {
   })
 
   test("handles ERB templates with attributes", () => {
-    expectNoOffenses(`<div class="<%= classes %>" data-id="<%= item.id %>">`)
+    expectNoOffenses(`<div class="<%= classes %>" data-id="<%= item.id %>"></div>`)
   })
 
   test("ignores closing tags", () => {

--- a/javascript/packages/linter/test/rules/html-no-underscores-in-attribute-names.test.ts
+++ b/javascript/packages/linter/test/rules/html-no-underscores-in-attribute-names.test.ts
@@ -46,18 +46,10 @@ describe("html-no-underscores-in-attribute-names", () => {
   })
 
   test("handles malformed attributes without crashing (issue #601)", () => {
-    expectWarning("Attribute `foo_bar` should not contain underscores. Use hyphens (-) instead.")
-
-    assertOffenses(dedent`
-      <input foo_bar=I18n.t('value')>
-    `)
+    expectNoOffenses(`<input foo_bar=I18n.t('value')>`, { allowInvalidSyntax: true })
   })
 
   test("handles malformed attributes without crashing - exact snippet from issue #601", () => {
-    expectWarning("Attribute `t('foo_bar')` should not contain underscores. Use hyphens (-) instead.")
-
-    assertOffenses(dedent`
-      <input title=I18n.t('foo_bar')>
-    `)
+    expectNoOffenses(`<input title=I18n.t('foo_bar')>`, { allowInvalidSyntax: true })
   })
 })


### PR DESCRIPTION
This pull request updates the linter to not lint files with syntax errors. This is to avoid false positives that might occur when trying to lint a file that isn't properly parsed, which could also lead to a "parser error" and "lint offense" diagnostic in the LSP.

Additionally, it updates the Linter test helpers to make sure all test cases have valid syntax too. Since we have the `no-parser-errors` rule we will still catch syntax errors, invalid syntax, and parser errors with that rule in real applications.