### PR TITLE
C: Remove superfluous `malloc` from `buffer_append_repeated`

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -185,8 +185,9 @@ void buffer_append_char(buffer_T* buffer, const char character) {
 }
 
 void buffer_append_repeated(buffer_T* buffer, const char character, size_t length) {
-  if (length == 0) { return; }
+  if (!buffer || length == 0) { return; }
   if (!buffer_expand_if_needed(buffer, length)) { return; }
+
   memset(buffer->value + buffer->length, character, length);
 
   buffer->length += length;


### PR DESCRIPTION
This MR removes the malloc/free combo from the `buffer_append_repeated` function.

Instead it expands the buffer to the required length and sets the memory directly using `memset`.
