### PR TITLE
C: Use buffer for string operations in `html_utils.c`

### DIFF
--- a/src/html_util.c
+++ b/src/html_util.c
@@ -43,20 +43,16 @@ bool is_void_element(const char* tag_name) {
 char* html_closing_tag_string(const char* tag_name) {
   if (tag_name == NULL) { return herb_strdup("</>"); }
 
-  size_t length = strlen(tag_name);
-  char* result = (char*) malloc(length + 4); // +4 for '<', '/', '>', and '\0'
 
-  if (result == NULL) { return NULL; }
+  buffer_T buffer;
+  buffer_init(&buffer, strlen(tag_name) + 3);
 
-  result[0] = '<';
-  result[1] = '/';
+  buffer_append_char(&buffer, '<');
+  buffer_append_char(&buffer, '/');
+  buffer_append(&buffer, tag_name);
+  buffer_append_char(&buffer, '>');
 
-  memcpy(result + 2, tag_name, length);
-
-  result[length + 2] = '>';
-  result[length + 3] = '\0';
-
-  return result;
+  return buffer.value;
 }
 
 /**


### PR DESCRIPTION
This PR changes the implementation of the html_utils `html_self_closing_tag_string` and `html_closing_tag_string`.

Instead of directly using malloc to allocate the string we instead use the buffer, which not only performs bounds checks, but also encapsulates any low level memory operations. 