### PR TITLE
C: Use buffer in `escape_newlines` and `wrap_in_string`

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -37,17 +37,15 @@ char* escape_newlines(const char* input) {
 char* wrap_string(const char* input, const char character) {
   if (input == NULL) { return NULL; }
 
-  const size_t length = strlen(input);
-  char* wrapped = malloc(length + 3);
+  buffer_T buffer;
 
-  if (wrapped == NULL) { return NULL; }
+  buffer_init(&buffer, strlen(input) + 2);
 
-  wrapped[0] = character;
-  strcpy(wrapped + 1, input);
-  wrapped[length + 1] = character;
-  wrapped[length + 2] = '\0';
+  buffer_append_char(&buffer, character);
+  buffer_append(&buffer, input);
+  buffer_append_char(&buffer, character);
 
-  return wrapped;
+  return buffer.value;
 }
 
 char* quoted_string(const char* input) {


### PR DESCRIPTION
This Pr refactors the util functions `escape_newlines` and `wrap_in_string` to internally use buffer instead of manually allocating the memory and setting the null terminator.

