### PR TITLE
C: Implement `hb_string` struct

### DIFF
--- a/javascript/packages/node/binding.gyp
+++ b/javascript/packages/node/binding.gyp
@@ -32,6 +32,7 @@
         "./extension/libherb/pretty_print.c",
         "./extension/libherb/prism_helpers.c",
         "./extension/libherb/range.c",
+        "./extension/libherb/hb_string.c",
         "./extension/libherb/token_matchers.c",
         "./extension/libherb/token.c",
         "./extension/libherb/utf8.c",

--- a/src/hb_string.c
+++ b/src/hb_string.c
@@ -1,0 +1,48 @@
+#include "include/hb_string.h"
+
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+
+hb_string_T hb_string_from_c_string(const char* null_terminated_c_string) {
+  hb_string_T string;
+
+  string.data = (char*) null_terminated_c_string;
+  string.length = strlen(null_terminated_c_string);
+
+  return string;
+}
+
+bool hb_string_equals(hb_string_T a, hb_string_T b) {
+  if (a.length != b.length) { return false; }
+
+  return strncmp(a.data, b.data, a.length) == 0;
+}
+
+bool hb_string_equals_case_insensitive(hb_string_T a, hb_string_T b) {
+  if (a.length != b.length) { return false; }
+
+  return strncasecmp(a.data, b.data, a.length) == 0;
+}
+
+bool hb_string_starts_with(hb_string_T string, hb_string_T expected_prefix) {
+  if (hb_string_is_empty(string) || hb_string_is_empty(expected_prefix)) { return false; }
+  if (string.length < expected_prefix.length) { return false; }
+
+  return strncmp(string.data, expected_prefix.data, expected_prefix.length) == 0;
+}
+
+bool hb_string_is_empty(hb_string_T string) {
+  return string.length == 0;
+}
+
+char* hb_string_to_c_string(hb_string_T string) {
+  size_t string_length_in_bytes = sizeof(char) * (string.length);
+  char* buffer = malloc(string_length_in_bytes + sizeof(char) * 1);
+
+  if (!hb_string_is_empty(string)) { memcpy(buffer, string.data, string_length_in_bytes); }
+
+  buffer[string_length_in_bytes] = '\0';
+
+  return buffer;
+}

--- a/src/include/hb_string.h
+++ b/src/include/hb_string.h
@@ -1,0 +1,35 @@
+#ifndef HERB_STRING_H
+#define HERB_STRING_H
+
+#include <stdbool.h>
+#include <stddef.h>
+
+typedef struct STRING_STRUCT {
+  char* data;
+  size_t length;
+} hb_string_T;
+
+hb_string_T hb_string_from_c_string(const char* null_terminated_c_string);
+bool hb_string_equals(hb_string_T a, hb_string_T b);
+bool hb_string_equals_case_insensitive(hb_string_T a, hb_string_T b);
+bool hb_string_starts_with(hb_string_T string, hb_string_T expected_prefix);
+bool hb_string_is_empty(hb_string_T string);
+
+/**
+ * @brief Creates a null terminated c string version of the passed string
+ *
+ * @param string The string for which a c string version is to be created
+ * @return A heap allocated null terminated c string
+ *
+ * Example:
+ * @code
+ *
+ * hb_string_T string = hb_string_from_c_string("Hello, world");
+ * char* cstring = hb_string_to_c_string(string);
+ *
+ * free(cstring);
+ * @endcode
+ */
+char* hb_string_to_c_string(hb_string_T string);
+
+#endif

--- a/test/c/main.c
+++ b/test/c/main.c
@@ -9,6 +9,7 @@ TCase *io_tests(void);
 TCase *lex_tests(void);
 TCase *token_tests(void);
 TCase *util_tests(void);
+TCase *hb_string_tests(void);
 
 Suite *herb_suite(void) {
   Suite *suite = suite_create("Herb Suite");
@@ -21,6 +22,7 @@ Suite *herb_suite(void) {
   suite_add_tcase(suite, lex_tests());
   suite_add_tcase(suite, token_tests());
   suite_add_tcase(suite, util_tests());
+  suite_add_tcase(suite, hb_string_tests());
 
   return suite;
 }

--- a/test/c/test_hb_string.c
+++ b/test/c/test_hb_string.c
@@ -1,0 +1,133 @@
+#include "include/test.h"
+#include "../../src/include/hb_string.h"
+#include <string.h>
+
+TEST(hb_string_equals_tests)
+  {
+    hb_string_T a = hb_string_from_c_string("Hello, world.");
+    hb_string_T b = hb_string_from_c_string("Hello, world.");
+
+    ck_assert(hb_string_equals(a, b));
+  }
+
+  {
+    hb_string_T a = hb_string_from_c_string("Hello, world.");
+    hb_string_T b = hb_string_from_c_string("Hello, world. Longer text");
+
+    ck_assert(!hb_string_equals(a, b));
+  }
+
+  {
+    hb_string_T a = hb_string_from_c_string("Hello, world.");
+    hb_string_T b = hb_string_from_c_string("");
+
+    ck_assert(!hb_string_equals(a, b));
+  }
+END
+
+TEST(hb_string_equals_case_insensitive_tests)
+  {
+    hb_string_T a = hb_string_from_c_string("Hello, world.");
+    hb_string_T b = hb_string_from_c_string("Hello, World. Really?");
+
+    ck_assert(!hb_string_equals_case_insensitive(a, b));
+  }
+
+  {
+    hb_string_T a = hb_string_from_c_string("Hello, world.");
+    hb_string_T b = hb_string_from_c_string("Hello, World.");
+
+    ck_assert(hb_string_equals_case_insensitive(a, b));
+  }
+
+  {
+    hb_string_T a = hb_string_from_c_string("This.");
+    hb_string_T b = hb_string_from_c_string("That.");
+
+    ck_assert(!hb_string_equals_case_insensitive(a, b));
+  }
+END
+
+TEST(hb_string_is_empty_tests)
+  {
+    hb_string_T str = {
+      .length = 0,
+      .data = NULL
+    };
+
+    ck_assert(hb_string_is_empty(str));
+  }
+
+  {
+    hb_string_T str = hb_string_from_c_string("");
+
+    ck_assert(hb_string_is_empty(str));
+  }
+
+  {
+    hb_string_T str = hb_string_from_c_string("Content");
+
+    ck_assert(!hb_string_is_empty(str));
+  }
+END
+
+TEST(hb_string_starts_with_tests)
+  {
+    hb_string_T str = hb_string_from_c_string("This.");
+    hb_string_T prefix = {
+      .length = 0,
+      .data = NULL,
+    };
+
+    ck_assert(!hb_string_starts_with(str, prefix));
+  }
+
+  {
+    hb_string_T str = {
+      .length = 0,
+      .data = NULL,
+    };
+    hb_string_T prefix = hb_string_from_c_string("This.");
+
+    ck_assert(!hb_string_starts_with(str, prefix));
+  }
+
+  {
+    hb_string_T str = hb_string_from_c_string("Long text.");
+    hb_string_T prefix = hb_string_from_c_string("Long text.");
+
+    ck_assert(hb_string_starts_with(str, prefix));
+  }
+
+  {
+    hb_string_T str = hb_string_from_c_string("Long text.");
+    hb_string_T prefix = hb_string_from_c_string("Long");
+
+    ck_assert(hb_string_starts_with(str, prefix));
+  }
+
+  {
+    hb_string_T str = hb_string_from_c_string("Long text.");
+    hb_string_T prefix = hb_string_from_c_string("No");
+
+    ck_assert(!hb_string_starts_with(str, prefix));
+  }
+
+  {
+    hb_string_T str = hb_string_from_c_string("Long text.");
+    hb_string_T prefix = hb_string_from_c_string("This prefix is longer than the text");
+
+    ck_assert(!hb_string_starts_with(str, prefix));
+  }
+END
+
+TCase *hb_string_tests(void) {
+  TCase *tags = tcase_create("Str");
+
+  tcase_add_test(tags, hb_string_equals_tests);
+  tcase_add_test(tags, hb_string_equals_case_insensitive_tests);
+  tcase_add_test(tags, hb_string_is_empty_tests);
+  tcase_add_test(tags, hb_string_starts_with_tests);
+
+  return tags;
+}


### PR DESCRIPTION
Implement a string datastructure representing a string with a known limit, eliminating the need to always use null terminated strings.

This lays the groundwork for reducing the number of required allocations during parsing.

See #580 