### PR TITLE
Update all HTML+ERB globs to include Action View Variants

### DIFF
--- a/javascript/packages/formatter/src/cli.ts
+++ b/javascript/packages/formatter/src/cli.ts
@@ -19,8 +19,8 @@ export class CLI {
     Usage: herb-format [file|directory|glob-pattern] [options]
 
     Arguments:
-      file|directory|glob-pattern   File to format, directory to format all **/*.html.erb files within,
-                                    glob pattern to match files, or '-' for stdin (omit to format all **/*.html.erb files in current directory)
+      file|directory|glob-pattern   File to format, directory to format all **/*.html{+*,}.erb files within,
+                                    glob pattern to match files, or '-' for stdin (omit to format all **/*.html{+*,}.erb files in current directory)
 
     Options:
       -c, --check                     check if files are formatted without modifying them
@@ -30,15 +30,15 @@ export class CLI {
       --max-line-length <number>      maximum line length before wrapping (default: 80)
 
     Examples:
-      herb-format                            # Format all **/*.html.erb files in current directory
-      herb-format index.html.erb             # Format and write single file
-      herb-format templates/index.html.erb   # Format and write single file
-      herb-format templates/                 # Format and **/*.html.erb within the given directory
-      herb-format "templates/**/*.html.erb"  # Format all .html.erb files in templates directory using glob pattern
-      herb-format "**/*.html.erb"            # Format all .html.erb files using glob pattern
-      herb-format "**/*.xml.erb"             # Format all .xml.erb files using glob pattern
-      herb-format --check                    # Check if all **/*.html.erb files are formatted
-      herb-format --check templates/         # Check if all **/*.html.erb files in templates/ are formatted
+      herb-format                                 # Format all **/*.html{+*,}.erb files in current directory
+      herb-format index.html.erb                  # Format and write single file
+      herb-format templates/index.html.erb        # Format and write single file
+      herb-format templates/                      # Format and **/*.html{+*,}.erb within the given directory
+      herb-format "templates/**/*.html{+*,}.erb"  # Format all .html{+*,}.erb files in templates directory using glob pattern
+      herb-format "**/*.html{+*,}.erb"            # Format all .html{+*,}.erb files using glob pattern
+      herb-format "**/*.xml.erb"                  # Format all .xml.erb files using glob pattern
+      herb-format --check                         # Check if all **/*.html{+*,}.erb files are formatted
+      herb-format --check templates/              # Check if all **/*.html{+*,}.erb files in templates/ are formatted
       herb-format --indent-width 4           # Format with 4-space indentation
       herb-format --max-line-length 100      # Format with 100-character line limit
       cat template.html.erb | herb-format    # Format from stdin to stdout
@@ -162,7 +162,7 @@ export class CLI {
         }
 
         if (isDirectory) {
-          pattern = join(file, "**/*.html.erb")
+          pattern = join(file, "**/*.html{+*,}.erb")
         } else if (isFile) {
           const source = readFileSync(file, "utf-8")
           const result = formatter.format(source)
@@ -245,10 +245,10 @@ export class CLI {
           process.exit(1)
         }
       } else {
-        const files = await glob("**/*.html.erb")
+        const files = await glob("**/*.html{+*,}.erb")
 
         if (files.length === 0) {
-          console.log(`No files found matching pattern: ${resolve("**/*.html.erb")}`)
+          console.log(`No files found matching pattern: ${resolve("**/*.html{+*,}.erb")}`)
 
           process.exit(0)
         }

--- a/javascript/packages/formatter/test/cli.test.ts
+++ b/javascript/packages/formatter/test/cli.test.ts
@@ -201,7 +201,7 @@ describe("CLI Binary", () => {
       expectExitCode(result, 0)
       expect(result.stderr).toContain("⚠️  Experimental Preview")
       expect(result.stdout).toContain("No files found matching pattern:")
-      expect(result.stdout).toContain("test-empty-dir/**/*.html.erb")
+      expect(result.stdout).toContain("test-empty-dir/**/*.html{+*,}.erb")
     } finally {
       await rm("test-empty-dir", { recursive: true }).catch(() => {})
     }
@@ -253,7 +253,7 @@ describe("CLI Binary", () => {
 
       expectExitCode(result, 0)
       expect(result.stdout).toContain("No files found matching pattern:")
-      expect(result.stdout).toContain("test-dir/**/*.html.erb")
+      expect(result.stdout).toContain("test-dir/**/*.html{+*,}.erb")
     } finally {
       await rm("test-dir", { recursive: true }).catch(() => {})
     }
@@ -642,7 +642,7 @@ describe("CLI Binary", () => {
 
       expectExitCode(result, 0)
       expect(result.stdout).toContain("No files found matching pattern")
-      expect(result.stdout).toContain("test-advanced/**/*.html.erb")
+      expect(result.stdout).toContain("test-advanced/**/*.html{+*,}.erb")
     })
 
     it("should handle mixed file arguments", async () => {

--- a/javascript/packages/language-server/src/server.ts
+++ b/javascript/packages/language-server/src/server.ts
@@ -62,7 +62,7 @@ export class Server {
 
       this.connection.client.register(DidChangeWatchedFilesNotification.type, {
         watchers: [
-          { globPattern: `**/**/*.html.erb` },
+          { globPattern: `**/**/*.html{+*,}.erb` },
           { globPattern: `**/**/.herb-lsp/config.json` },
         ],
       })

--- a/javascript/packages/linter/README.md
+++ b/javascript/packages/linter/README.md
@@ -67,7 +67,7 @@ After installing as a dev dependency, add a lint NPM script to your `package.jso
 ```json
 {
   "scripts": {
-    "herb:lint": "herb-lint '**/*.html.erb'"
+    "herb:lint": "herb-lint '**/*.html{+*,}.erb'"
   }
 }
 ```
@@ -101,7 +101,7 @@ bun run herb:lint
 Basic usage:
 ```bash
 npx @herb-tools/linter template.html.erb
-npx @herb-tools/linter "**/*.html.erb"
+npx @herb-tools/linter "**/*.html{+*,}.erb"
 npx @herb-tools/linter app/
 ```
 

--- a/javascript/packages/linter/src/cli.ts
+++ b/javascript/packages/linter/src/cli.ts
@@ -105,7 +105,7 @@ export class CLI {
 
   protected adjustPattern(pattern: string | undefined): string {
     if (!pattern) {
-      return '**/*.html.erb'
+      return '**/*.html{+*,}.erb'
     }
 
     const resolvedPattern = resolve(pattern)
@@ -114,7 +114,7 @@ export class CLI {
       const stats = statSync(resolvedPattern)
 
       if (stats.isDirectory()) {
-        return '**/*.html.erb'
+        return '**/*.html{+*,}.erb'
       } else if (stats.isFile()) {
         return relative(this.projectPath, resolvedPattern)
       }

--- a/javascript/packages/linter/src/cli/argument-parser.ts
+++ b/javascript/packages/linter/src/cli/argument-parser.ts
@@ -29,8 +29,8 @@ export class ArgumentParser {
 
     Arguments:
       file             Single file to lint
-      glob-pattern     Files to lint (defaults to **/*.html.erb)
-      directory        Directory to lint (automatically appends **/*.html.erb)
+      glob-pattern     Files to lint (defaults to **/*.html{+*,}.erb)
+      directory        Directory to lint (automatically appends **/*.html{+*,}.erb)
 
     Options:
       -h, --help       show help
@@ -128,12 +128,12 @@ export class ArgumentParser {
   }
 
   private getFilePattern(positionals: string[]): string {
-    let pattern = positionals.length > 0 ? positionals[0] : "**/*.html.erb"
+    let pattern = positionals.length > 0 ? positionals[0] : "**/*.html{+*,}.erb"
 
     try {
       const stat = statSync(pattern)
       if (stat.isDirectory()) {
-        pattern = join(pattern, "**/*.html.erb")
+        pattern = join(pattern, "**/*.html{+*,}.erb")
       }
     } catch {
       // Not a file/directory, treat as glob pattern

--- a/javascript/packages/printer/src/cli.ts
+++ b/javascript/packages/printer/src/cli.ts
@@ -74,7 +74,7 @@ export class CLI {
         -o, --output <file>          Output file path (defaults to stdout)
         --verify                     Verify that output matches input exactly
         --stats                      Show parsing and printing statistics
-        --glob                       Treat input as glob pattern (default: **/*.html.erb)
+        --glob                       Treat input as glob pattern (default: **/*.html{+*,}.erb)
         -h, --help                   Show this help message
 
       Examples:
@@ -84,11 +84,11 @@ export class CLI {
         herb-print input.html.erb --stats
 
         # Glob patterns (batch verification)
-        herb-print --glob --verify                    # All .html.erb files
-        herb-print "app/views/**/*.html.erb" --glob --verify --stats
+        herb-print --glob --verify                         # All .html{+*,}.erb files
+        herb-print "app/views/**/*.html{+*,}.erb" --glob --verify --stats
         herb-print "*.erb" --glob --verify
-        herb-print "/path/to/templates" --glob --verify    # Directory (auto-appends /**/*.html.erb)
-        herb-print "/path/to/templates/**/*.html.erb" --glob --verify
+        herb-print "/path/to/templates" --glob --verify    # Directory (auto-appends /**/*.html{+*,}.erb)
+        herb-print "/path/to/templates/**/*.html{+*,}.erb" --glob --verify
 
         # The --verify flag is useful to test parser fidelity:
         herb-print input.html.erb --verify
@@ -108,7 +108,7 @@ export class CLI {
       await Herb.load()
 
       if (options.glob) {
-        const pattern = options.input || "**/*.html.erb"
+        const pattern = options.input || "**/*.html{+*,}.erb"
         const files = await glob(pattern)
 
         if (files.length === 0) {

--- a/javascript/packages/vscode/src/extension.ts
+++ b/javascript/packages/vscode/src/extension.ts
@@ -64,7 +64,7 @@ export async function activate(context: vscode.ExtensionContext) {
   )
 
   // Set up file watcher for HTML+ERB files
-  const fileWatcher = vscode.workspace.createFileSystemWatcher('**/*.html.erb')
+  const fileWatcher = vscode.workspace.createFileSystemWatcher('**/*.html{+*,}.erb')
 
   fileWatcher.onDidChange(async (uri) => {
     console.log(`File changed: ${uri.fsPath}`)
@@ -94,7 +94,7 @@ async function runAutoAnalysis() {
     return
   }
 
-  const erbFiles = await vscode.workspace.findFiles('**/*.html.erb')
+  const erbFiles = await vscode.workspace.findFiles('**/*.html{+*,}.erb')
   if (erbFiles.length === 0) {
     return
   }

--- a/javascript/packages/vscode/src/herb-analysis-provider.ts
+++ b/javascript/packages/vscode/src/herb-analysis-provider.ts
@@ -46,7 +46,7 @@ export class HerbAnalysisProvider implements TreeDataProvider<TreeNode> {
   }
 
   async analyzeProject(): Promise<void> {
-    const uris = await workspace.findFiles('**/*.html.erb')
+    const uris = await workspace.findFiles('**/*.html{+*,}.erb')
 
     this.lastAnalysisTime = new Date()
 

--- a/lib/herb/project.rb
+++ b/lib/herb/project.rb
@@ -30,7 +30,7 @@ module Herb
     end
 
     def glob
-      "**/*.html.erb"
+      "**/*.html{+*,}.erb"
     end
 
     def full_path_glob


### PR DESCRIPTION
As discovered in https://github.com/kaigionrails/conference-app/pull/601, we didn't include templates that had an Action View Variant in the filename (like `index.html+mobile.erb`).

This pull request now updates all file globs Herb uses to also detect all Action View Variants.

Thanks to @nissyi-gh and @unasuke for the help! 🙏🏼 