### PR TITLE
C: Implement rudimentary arena allocator `hb_arena.c`

### DIFF
--- a/javascript/packages/node/binding.gyp
+++ b/javascript/packages/node/binding.gyp
@@ -27,6 +27,7 @@
         "./extension/libherb/lexer_peek_helpers.c",
         "./extension/libherb/lexer.c",
         "./extension/libherb/location.c",
+        "./extension/libherb/hb_arena.c",
         "./extension/libherb/parser_helpers.c",
         "./extension/libherb/parser.c",
         "./extension/libherb/pretty_print.c",

--- a/src/hb_arena.c
+++ b/src/hb_arena.c
@@ -1,0 +1,57 @@
+#ifdef __linux__
+#define _GNU_SOURCE
+#endif
+#include "include/hb_arena.h"
+#include <stdbool.h>
+#include <sys/mman.h>
+
+#define KB(kb) (1024 * kb)
+#define MB(mb) (1024 * KB(mb))
+
+bool hb_arena_init(hb_arena_T* allocator, size_t size) {
+  allocator->memory = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+
+  if (allocator->memory == MAP_FAILED) {
+    allocator->memory = NULL;
+    allocator->position = 0;
+    allocator->capacity = 0;
+    return false;
+  }
+
+  allocator->position = 0;
+  allocator->capacity = size;
+  return true;
+}
+
+void* hb_arena_alloc(hb_arena_T* allocator, size_t size) {
+  size_t required_size = ((size + 7) / 8) * 8; // rounds up to the next 8 bytes
+
+  if (allocator->position + required_size > allocator->capacity) { return NULL; }
+
+  size_t offset = allocator->position;
+  void* ptr = &allocator->memory[offset];
+  allocator->position += required_size;
+
+  return ptr;
+}
+
+size_t hb_arena_position(hb_arena_T* allocator) {
+  return allocator->position;
+}
+
+void hb_arena_reset(hb_arena_T* allocator) {
+  allocator->position = 0;
+}
+
+void hb_arena_reset_to(hb_arena_T* allocator, size_t new_position) {
+  if (new_position <= allocator->capacity) { allocator->position = new_position; }
+}
+
+void hb_arena_free(hb_arena_T* allocator) {
+  if (allocator->memory != NULL) {
+    munmap(allocator->memory, allocator->capacity);
+    allocator->memory = NULL;
+    allocator->position = 0;
+    allocator->capacity = 0;
+  }
+}

--- a/src/include/hb_arena.h
+++ b/src/include/hb_arena.h
@@ -1,0 +1,20 @@
+#ifndef HERB_ARENA_H
+#define HERB_ARENA_H
+
+#include <stdbool.h>
+#include <stddef.h>
+
+typedef struct HB_ARENA_ALLOCATOR_STRUCT {
+  char* memory;
+  size_t capacity;
+  size_t position;
+} hb_arena_T;
+
+bool hb_arena_init(hb_arena_T* allocator, size_t size);
+void* hb_arena_alloc(hb_arena_T* allocator, size_t size);
+size_t hb_arena_position(hb_arena_T* allocator);
+void hb_arena_reset(hb_arena_T* allocator);
+void hb_arena_reset_to(hb_arena_T* allocator, size_t new_position);
+void hb_arena_free(hb_arena_T* allocator);
+
+#endif

--- a/test/c/main.c
+++ b/test/c/main.c
@@ -10,6 +10,7 @@ TCase *lex_tests(void);
 TCase *token_tests(void);
 TCase *util_tests(void);
 TCase *hb_string_tests(void);
+TCase *hb_arena_tests(void);
 
 Suite *herb_suite(void) {
   Suite *suite = suite_create("Herb Suite");
@@ -23,6 +24,7 @@ Suite *herb_suite(void) {
   suite_add_tcase(suite, token_tests());
   suite_add_tcase(suite, util_tests());
   suite_add_tcase(suite, hb_string_tests());
+  suite_add_tcase(suite, hb_arena_tests());
 
   return suite;
 }

--- a/test/c/test_hb_arena.c
+++ b/test/c/test_hb_arena.c
@@ -1,0 +1,57 @@
+#include "include/test.h"
+#include "../../src/include/hb_arena.h"
+
+// Test appending text to buffer
+TEST(test_arena_alloc)
+  hb_arena_T allocator;
+
+  hb_arena_init(&allocator, 1024);
+  ck_assert_int_eq(allocator.position, 0);
+  ck_assert_int_eq(allocator.capacity, 1024);
+
+  {
+    // Ensure memory is writable
+    char *memory = hb_arena_alloc(&allocator, 1);
+    *memory = 'a';
+  }
+
+  ck_assert(allocator.position % 8 == 0);
+  ck_assert_int_eq(allocator.position, 8);
+
+  char *memory = hb_arena_alloc(&allocator, allocator.capacity - allocator.position);
+  ck_assert_ptr_nonnull(memory);
+  ck_assert(allocator.position % 8 == 0);
+END
+
+TEST(test_arena_free)
+  hb_arena_T allocator;
+
+  {
+    hb_arena_init(&allocator, 1024);
+    hb_arena_free(&allocator);
+
+    ck_assert_ptr_null(allocator.memory);
+    ck_assert_int_eq(allocator.capacity, 0);
+    ck_assert_int_eq(allocator.position, 0);
+  }
+
+  {
+    hb_arena_init(&allocator, 1024);
+    hb_arena_free(&allocator);
+    hb_arena_free(&allocator);
+
+    ck_assert_ptr_null(allocator.memory);
+    ck_assert_int_eq(allocator.capacity, 0);
+    ck_assert_int_eq(allocator.position, 0);
+  }
+END
+
+
+TCase *hb_arena_tests(void) {
+  TCase *tags = tcase_create("arena");
+
+  tcase_add_test(tags, test_arena_alloc);
+  tcase_add_test(tags, test_arena_free);
+
+  return tags;
+}


### PR DESCRIPTION
This PR implements an arena allocator.

It provides an initial interface for performing allocations using the function `hb_arena_alloc(...)`.

## Implementation Details

All returned pointers **have an 8 byte alignment.** `malloc` on x64 machines returns 16 byte aligned memory [ref](https://refspecs.linuxbase.org/elf/x86_64-abi-0.99.pdf), but from everything I could find only 128bit integers and simd types really require 16 bytes. Since we don't use SIMD right now, I think we can go with 8 bytes.

We use [`mmap`](https://man7.org/linux/man-pages/man2/mmap.2.html) for allocating the memory which only allocates the memory when the page is actually written to on modern UNIX operating systems. This has the advantage that we can reservce e.g. 512mb of memory and the OS only really allocates the memory if we make our first write. 

## `mmap` example

```c
#include <string.h>
#include <stdlib.h>
#include <stddef.h>
#include <unistd.h>
#include <sys/mman.h>

#define KB(kb) (1024 * kb)
#define MB(mb) (1024 * KB(mb))

int main() {
  size_t memory_size = MB(512);
  char *memory = mmap(NULL, memory_size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);

  memset(memory, 0, MB(400));

  sleep(100);
}
```

Compile and start program

```bash
$ ./a.out &
$ vmmap $PID_SHOWN_IN_TERMINAL
```

```
...
                                 VIRTUAL   RESIDENT      DIRTY    SWAPPED ALLOCATION      BYTES DIRTY+SWAP          REGION
MALLOC ZONE                         SIZE       SIZE       SIZE       SIZE      COUNT  ALLOCATED  FRAG SIZE  % FRAG   COUNT
===========                      =======  =========  =========  =========  =========  =========  =========  ======  ======
DefaultMallocZone_0x104a5c000     524.5M     400.1M     400.1M         0K        185     512.0M         0K      0%      10
```

### Activity Manager View

<img width="1611" height="137" alt="memory_usage" src="https://github.com/user-attachments/assets/99f884e5-268d-4679-8e58-10fcf32ce92f" />
