### PR TITLE
Linter: Fix false positive in `erb-right-trim` when using `<%-`

### DIFF
--- a/javascript/packages/linter/src/rules/erb-right-trim.ts
+++ b/javascript/packages/linter/src/rules/erb-right-trim.ts
@@ -7,10 +7,13 @@ import type { ERBNode, ParseResult } from "@herb-tools/core"
 
 class ERBRightTrimVisitor extends BaseRuleVisitor {
   visitERBNode(node: ERBNode): void {
+    if (!node.tag_opening) return
     if (!node.tag_closing) return
 
+    const trimOpening = node.tag_opening.value
     const trimClosing = node.tag_closing.value
 
+    if (trimOpening === "<%-") return
     if (trimClosing !== "=%>" && trimClosing !== "-%>") return
 
     if (!isERBOutputNode(node)) {

--- a/javascript/packages/linter/test/rules/erb-right-trim.test.ts
+++ b/javascript/packages/linter/test/rules/erb-right-trim.test.ts
@@ -117,4 +117,18 @@ describe("ERBRightTrimRule", () => {
       <% end %>
     `)
   })
+
+  test("<%- with -%>", () => {
+    expectNoOffenses(dedent`
+      <%- something -%>
+    `)
+  })
+
+  test("<%- with -%> in if/end", () => {
+    expectNoOffenses(dedent`
+      <%- if true -%>
+        Something
+      <%- end -%>
+    `)
+  })
 })


### PR DESCRIPTION
This pull request resolves a false positive in the `erb-right-trim` linter rule when using `<%-` opening tag with a `-%>` closing tag.

This is now valid:
```erb
<%- if true -%>
  Something
<%- end -%>
```

Closes https://github.com/marcoroth/herb/issues/628