### PR TITLE
Linter: Implement Autofix for `erb-right-trim` linter rule

### DIFF
--- a/javascript/packages/linter/src/rules/erb-right-trim.ts
+++ b/javascript/packages/linter/src/rules/erb-right-trim.ts
@@ -1,11 +1,15 @@
 import { BaseRuleVisitor } from "./rule-utils.js"
-import { ParserRule } from "../types.js"
+import { ParserRule, BaseAutofixContext, Mutable } from "../types.js"
 import { isERBOutputNode } from "@herb-tools/core"
 
 import type { LintOffense, LintContext } from "../types.js"
 import type { ERBNode, ParseResult } from "@herb-tools/core"
 
-class ERBRightTrimVisitor extends BaseRuleVisitor {
+interface ERBRightTrimAutofixContext extends BaseAutofixContext {
+  node: Mutable<ERBNode>
+}
+
+class ERBRightTrimVisitor extends BaseRuleVisitor<ERBRightTrimAutofixContext> {
   visitERBNode(node: ERBNode): void {
     if (!node.tag_opening) return
     if (!node.tag_closing) return
@@ -18,8 +22,10 @@ class ERBRightTrimVisitor extends BaseRuleVisitor {
 
     if (!isERBOutputNode(node)) {
       this.addOffense(
-        `Right-trimming with \`${trimClosing}\` has no effect on non-output ERB tags. Use \`%>\` instead`,
-        node.tag_closing.location
+        `Right-trimming with \`${trimClosing}\` has no effect on non-output ERB tags. Use \`%>\` instead.`,
+        node.tag_closing.location,
+        "error",
+        { node }
       )
 
       return
@@ -27,21 +33,46 @@ class ERBRightTrimVisitor extends BaseRuleVisitor {
 
     if (trimClosing === "=%>") {
       this.addOffense(
-        "Use `-%>` instead of `=%>` for right-trimming. The `=%>` syntax is obscure and not well-supported in most ERB engines",
-        node.tag_closing.location
+        "Use `-%>` instead of `=%>` for right-trimming. The `=%>` syntax is obscure and not well-supported in most ERB engines.",
+        node.tag_closing.location,
+        "error",
+        { node }
       )
     }
   }
 }
 
-export class ERBRightTrimRule extends ParserRule {
+export class ERBRightTrimRule extends ParserRule<ERBRightTrimAutofixContext> {
+  static autocorrectable = true
   name = "erb-right-trim"
 
-  check(result: ParseResult, context?: Partial<LintContext>): LintOffense[] {
+  check(result: ParseResult, context?: Partial<LintContext>): LintOffense<ERBRightTrimAutofixContext>[] {
     const visitor = new ERBRightTrimVisitor(this.name, context)
 
     visitor.visit(result.value)
 
     return visitor.offenses
+  }
+
+  autofix(offense: LintOffense<ERBRightTrimAutofixContext>, result: ParseResult, _context?: Partial<LintContext>): ParseResult | null {
+    if (!offense.autofixContext) return null
+
+    const { node } = offense.autofixContext
+
+    if (!node.tag_closing) return null
+
+    const closing = node.tag_closing
+
+    if (closing.value === "=%>") {
+      closing.value = "-%>"
+      return result
+    }
+
+    if (closing.value === "-%>") {
+      closing.value = "%>"
+      return result
+    }
+
+    return null
   }
 }

--- a/javascript/packages/linter/test/autofix/erb-right-trim.autofix.test.ts
+++ b/javascript/packages/linter/test/autofix/erb-right-trim.autofix.test.ts
@@ -1,0 +1,255 @@
+import dedent from "dedent"
+
+import { describe, test, expect, beforeAll } from "vitest"
+
+import { Herb } from "@herb-tools/node-wasm"
+import { Linter } from "../../src/linter.js"
+
+import { ERBRightTrimRule } from "../../src/rules/erb-right-trim.js"
+
+describe("erb-right-trim autofix", () => {
+  beforeAll(async () => {
+    await Herb.load()
+  })
+
+  test("when the erb tag close with %>", () => {
+    const input = dedent`
+      <h1>
+        <%= title %>
+      </h1>
+    `
+
+    const linter = new Linter(Herb, [ERBRightTrimRule])
+    const result = linter.autofix(input, { fileName: 'test.html.erb' })
+
+    expect(result.source).toBe(input)
+    expect(result.fixed).toHaveLength(0)
+    expect(result.unfixed).toHaveLength(0)
+  })
+
+  test("when output erb tag closes with -%>", () => {
+    const input = dedent`
+      <h1>
+        <%= title -%>
+      </h1>
+    `
+
+    const linter = new Linter(Herb, [ERBRightTrimRule])
+    const result = linter.autofix(input, { fileName: 'test.html.erb' })
+
+    expect(result.source).toBe(input)
+    expect(result.fixed).toHaveLength(0)
+    expect(result.unfixed).toHaveLength(0)
+  })
+
+  // TODO: figure out if this is actually right
+  test("when non-output tag uses -%>", () => {
+    const input = dedent`
+      <% if condition -%>
+        <p>Content</p>
+      <% elsif other_condition -%>
+        <p>Content</p>
+      <% elsif yet_another_condition -%>
+        <p>Content</p>
+      <% else -%>
+        <p>Content</p>
+      <% end -%>
+    `
+
+    const expected = dedent`
+      <% if condition %>
+        <p>Content</p>
+      <% elsif other_condition %>
+        <p>Content</p>
+      <% elsif yet_another_condition %>
+        <p>Content</p>
+      <% else %>
+        <p>Content</p>
+      <% end %>
+    `
+
+    const linter = new Linter(Herb, [ERBRightTrimRule])
+    const result = linter.autofix(input, { fileName: 'test.html.erb' })
+
+    expect(result.source).toBe(expected)
+    expect(result.fixed).toHaveLength(5)
+    expect(result.unfixed).toHaveLength(0)
+  })
+
+  test("when the erb tag close with =%>", () => {
+    const input = dedent`
+      <h1>
+        <%= title =%>
+      </h1>
+    `
+
+    const expected = dedent`
+      <h1>
+        <%= title -%>
+      </h1>
+    `
+
+    const linter = new Linter(Herb, [ERBRightTrimRule])
+    const result = linter.autofix(input, { fileName: 'test.html.erb' })
+
+    expect(result.source).toBe(expected)
+    expect(result.fixed).toHaveLength(1)
+    expect(result.unfixed).toHaveLength(0)
+  })
+
+  test("when an if block uses =%>", () => {
+    const input = dedent`
+      <% if condition =%>
+        <p>Content</p>
+      <% end =%>
+    `
+
+    const expected = dedent`
+      <% if condition -%>
+        <p>Content</p>
+      <% end -%>
+    `
+
+    const linter = new Linter(Herb, [ERBRightTrimRule])
+    const result = linter.autofix(input, { fileName: 'test.html.erb' })
+
+    expect(result.source).toBe(expected)
+    expect(result.fixed).toHaveLength(2)
+    expect(result.unfixed).toHaveLength(0)
+  })
+
+  test("when a loop uses =%>", () => {
+    const input = dedent`
+      <% items.each do |item| =%>
+        <li><%= item %></li>
+      <% end %>
+    `
+
+    const expected = dedent`
+      <% items.each do |item| -%>
+        <li><%= item %></li>
+      <% end %>
+    `
+
+    const linter = new Linter(Herb, [ERBRightTrimRule])
+    const result = linter.autofix(input, { fileName: 'test.html.erb' })
+
+    expect(result.source).toBe(expected)
+    expect(result.fixed).toHaveLength(1)
+    expect(result.unfixed).toHaveLength(0)
+  })
+
+  test("when multiple lines use =%>", () => {
+    const input = dedent`
+      <%= first =%>
+      <%= second =%>
+      <%= third =%>
+    `
+
+    const expected = dedent`
+      <%= first -%>
+      <%= second -%>
+      <%= third -%>
+    `
+
+    const linter = new Linter(Herb, [ERBRightTrimRule])
+    const result = linter.autofix(input, { fileName: 'test.html.erb' })
+
+    expect(result.source).toBe(expected)
+    expect(result.fixed).toHaveLength(3)
+    expect(result.unfixed).toHaveLength(0)
+  })
+
+  test("when mixed valid and invalid syntax is used", () => {
+    const input = dedent`
+      <%= valid %>
+      <%= invalid_trim =%>
+      <%= valid_trim -%>
+      <%= another_invalid =%>
+    `
+
+    const expected = dedent`
+      <%= valid %>
+      <%= invalid_trim -%>
+      <%= valid_trim -%>
+      <%= another_invalid -%>
+    `
+
+    const linter = new Linter(Herb, [ERBRightTrimRule])
+    const result = linter.autofix(input, { fileName: 'test.html.erb' })
+
+    expect(result.source).toBe(expected)
+    expect(result.fixed).toHaveLength(2)
+    expect(result.unfixed).toHaveLength(0)
+  })
+
+  test("when silent ERB uses =%>", () => {
+    const input = dedent`
+      <% silent_operation =%>
+    `
+
+    const expected = dedent`
+      <% silent_operation -%>
+    `
+
+    const linter = new Linter(Herb, [ERBRightTrimRule])
+    const result = linter.autofix(input, { fileName: 'test.html.erb' })
+
+    expect(result.source).toBe(expected)
+    expect(result.fixed).toHaveLength(1)
+    expect(result.unfixed).toHaveLength(0)
+  })
+
+  test("handles =%> in nested structures", () => {
+    const input = dedent`
+      <% if outer_condition =%>
+        <% if inner_condition =%>
+          <p>Nested content</p>
+        <% end %>
+      <% end %>
+    `
+
+    const expected = dedent`
+      <% if outer_condition -%>
+        <% if inner_condition -%>
+          <p>Nested content</p>
+        <% end %>
+      <% end %>
+    `
+
+    const linter = new Linter(Herb, [ERBRightTrimRule])
+    const result = linter.autofix(input, { fileName: 'test.html.erb' })
+
+    expect(result.source).toBe(expected)
+    expect(result.fixed).toHaveLength(2)
+    expect(result.unfixed).toHaveLength(0)
+  })
+
+  test("<%- with -%>", () => {
+    const input = dedent`
+      <%- something -%>
+    `
+
+    const linter = new Linter(Herb, [ERBRightTrimRule])
+    const result = linter.autofix(input, { fileName: 'test.html.erb' })
+
+    expect(result.source).toBe(input)
+    expect(result.fixed).toHaveLength(0)
+    expect(result.unfixed).toHaveLength(0)
+  })
+
+  test("<%- with -%> in if/end", () => {
+    const input = dedent`
+      <%- if true -%>
+        Something
+      <%- end -%>
+    `
+
+    const linter = new Linter(Herb, [ERBRightTrimRule])
+    const result = linter.autofix(input, { fileName: 'test.html.erb' })
+
+    expect(result.source).toBe(input)
+    expect(result.fixed).toHaveLength(0)
+    expect(result.unfixed).toHaveLength(0)
+  })
+})

--- a/javascript/packages/linter/test/rules/erb-right-trim.test.ts
+++ b/javascript/packages/linter/test/rules/erb-right-trim.test.ts
@@ -23,11 +23,11 @@ describe("ERBRightTrimRule", () => {
   })
 
   test("when non-output tag uses -%>", () => {
-    expectError("Right-trimming with `-%>` has no effect on non-output ERB tags. Use `%>` instead")
-    expectError("Right-trimming with `-%>` has no effect on non-output ERB tags. Use `%>` instead")
-    expectError("Right-trimming with `-%>` has no effect on non-output ERB tags. Use `%>` instead")
-    expectError("Right-trimming with `-%>` has no effect on non-output ERB tags. Use `%>` instead")
-    expectError("Right-trimming with `-%>` has no effect on non-output ERB tags. Use `%>` instead")
+    expectError("Right-trimming with `-%>` has no effect on non-output ERB tags. Use `%>` instead.")
+    expectError("Right-trimming with `-%>` has no effect on non-output ERB tags. Use `%>` instead.")
+    expectError("Right-trimming with `-%>` has no effect on non-output ERB tags. Use `%>` instead.")
+    expectError("Right-trimming with `-%>` has no effect on non-output ERB tags. Use `%>` instead.")
+    expectError("Right-trimming with `-%>` has no effect on non-output ERB tags. Use `%>` instead.")
 
     assertOffenses(dedent`
       <% if condition -%>
@@ -43,7 +43,7 @@ describe("ERBRightTrimRule", () => {
   })
 
   test("when the erb tag close with =%>", () => {
-    expectError("Use `-%>` instead of `=%>` for right-trimming. The `=%>` syntax is obscure and not well-supported in most ERB engines")
+    expectError("Use `-%>` instead of `=%>` for right-trimming. The `=%>` syntax is obscure and not well-supported in most ERB engines.")
 
     assertOffenses(dedent`
       <h1>
@@ -53,8 +53,8 @@ describe("ERBRightTrimRule", () => {
   })
 
   test("when an if block uses =%>", () => {
-    expectError("Right-trimming with `=%>` has no effect on non-output ERB tags. Use `%>` instead")
-    expectError("Right-trimming with `=%>` has no effect on non-output ERB tags. Use `%>` instead")
+    expectError("Right-trimming with `=%>` has no effect on non-output ERB tags. Use `%>` instead.")
+    expectError("Right-trimming with `=%>` has no effect on non-output ERB tags. Use `%>` instead.")
 
     assertOffenses(dedent`
       <% if condition =%>
@@ -64,7 +64,7 @@ describe("ERBRightTrimRule", () => {
   })
 
   test("when a loop uses =%>", () => {
-    expectError("Right-trimming with `=%>` has no effect on non-output ERB tags. Use `%>` instead")
+    expectError("Right-trimming with `=%>` has no effect on non-output ERB tags. Use `%>` instead.")
 
     assertOffenses(dedent`
       <% items.each do |item| =%>
@@ -74,9 +74,9 @@ describe("ERBRightTrimRule", () => {
   })
 
   test("when multiple lines use =%>", () => {
-    expectError("Use `-%>` instead of `=%>` for right-trimming. The `=%>` syntax is obscure and not well-supported in most ERB engines")
-    expectError("Use `-%>` instead of `=%>` for right-trimming. The `=%>` syntax is obscure and not well-supported in most ERB engines")
-    expectError("Use `-%>` instead of `=%>` for right-trimming. The `=%>` syntax is obscure and not well-supported in most ERB engines")
+    expectError("Use `-%>` instead of `=%>` for right-trimming. The `=%>` syntax is obscure and not well-supported in most ERB engines.")
+    expectError("Use `-%>` instead of `=%>` for right-trimming. The `=%>` syntax is obscure and not well-supported in most ERB engines.")
+    expectError("Use `-%>` instead of `=%>` for right-trimming. The `=%>` syntax is obscure and not well-supported in most ERB engines.")
 
     assertOffenses(dedent`
       <%= first =%>
@@ -86,8 +86,8 @@ describe("ERBRightTrimRule", () => {
   })
 
   test("when mixed valid and invalid syntax is used", () => {
-    expectError("Use `-%>` instead of `=%>` for right-trimming. The `=%>` syntax is obscure and not well-supported in most ERB engines")
-    expectError("Use `-%>` instead of `=%>` for right-trimming. The `=%>` syntax is obscure and not well-supported in most ERB engines")
+    expectError("Use `-%>` instead of `=%>` for right-trimming. The `=%>` syntax is obscure and not well-supported in most ERB engines.")
+    expectError("Use `-%>` instead of `=%>` for right-trimming. The `=%>` syntax is obscure and not well-supported in most ERB engines.")
 
     assertOffenses(dedent`
       <%= valid %>
@@ -98,7 +98,7 @@ describe("ERBRightTrimRule", () => {
   })
 
   test("when silent ERB uses =%>", () => {
-    expectError("Right-trimming with `=%>` has no effect on non-output ERB tags. Use `%>` instead")
+    expectError("Right-trimming with `=%>` has no effect on non-output ERB tags. Use `%>` instead.")
 
     assertOffenses(dedent`
       <% silent_operation =%>
@@ -106,8 +106,8 @@ describe("ERBRightTrimRule", () => {
   })
 
   test("handles =%> in nested structures", () => {
-    expectError("Right-trimming with `=%>` has no effect on non-output ERB tags. Use `%>` instead")
-    expectError("Right-trimming with `=%>` has no effect on non-output ERB tags. Use `%>` instead")
+    expectError("Right-trimming with `=%>` has no effect on non-output ERB tags. Use `%>` instead.")
+    expectError("Right-trimming with `=%>` has no effect on non-output ERB tags. Use `%>` instead.")
 
     assertOffenses(dedent`
       <% if outer_condition =%>


### PR DESCRIPTION
This pull request implements the autofix for the `erb-right-trim` linter rule, so the offenses can be autocorrect when running using the `--fix` mode.