### PR TITLE
Parser: Allow `TOKEN_BACKSLASH` in HTML Text Content

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -1110,6 +1110,7 @@ static void parser_parse_in_data_state(parser_T* parser, hb_array_T* children, h
           parser,
           TOKEN_AMPERSAND,
           TOKEN_AT,
+          TOKEN_BACKSLASH,
           TOKEN_BACKTICK,
           TOKEN_CHARACTER,
           TOKEN_COLON,
@@ -1134,7 +1135,7 @@ static void parser_parse_in_data_state(parser_T* parser, hb_array_T* children, h
       parser,
       "Unexpected token",
       "TOKEN_ERB_START, TOKEN_HTML_DOCTYPE, TOKEN_HTML_COMMENT_START, TOKEN_IDENTIFIER, TOKEN_WHITESPACE, "
-      "TOKEN_NBSP, TOKEN_AT, or TOKEN_NEWLINE",
+      "TOKEN_NBSP, TOKEN_AT, TOKEN_BACKSLASH, or TOKEN_NEWLINE",
       errors
     );
   }

--- a/test/parser/text_content_test.rb
+++ b/test/parser/text_content_test.rb
@@ -145,5 +145,16 @@ module Parser
     test "backtick with HTML tags - issue 467" do
       assert_parsed_snapshot("a `<b></b>` c")
     end
+
+    test "backslash-prefixed text stays literal - issue 635" do
+      assert_parsed_snapshot("<p>\\Asome-regexp\\z</p>")
+    end
+
+    # https://github.com/lobsters/lobsters/blob/75f9a53077d5aeaeadbb8271def0479dd8fcd761/app/views/domains/edit.html.erb#L11
+    test "backslash-prefixed text - issue 633" do
+      assert_parsed_snapshot <<~HTML
+        <p class="help">Regexp with captures, must consume whole string like: <kbd>\\Ahttps?://github.com/+([^/]+).*\\z</kbd></p>
+      HTML
+    end
   end
 end

--- a/test/snapshots/parser/script_style_test/test_0035_script_tag_with_escaped_quotes_in_strings_3217a5ed01ac8ce6c44f9e106f9b4017.txt
+++ b/test/snapshots/parser/script_style_test/test_0035_script_tag_with_escaped_quotes_in_strings_3217a5ed01ac8ce6c44f9e106f9b4017.txt
@@ -1,11 +1,4 @@
 @ DocumentNode (location: (1:0)-(1:59))
-├── errors: (1 error)
-│   └── @ UnexpectedError (location: (1:36)-(1:37))
-│       ├── message: "Unexpected token. Expected: `TOKEN_ERB_START, TOKEN_HTML_DOCTYPE, TOKEN_HTML_COMMENT_START, TOKEN_IDENTIFIER, TOKEN_WHITESPACE, TOKEN_NBSP, TOKEN_AT, or TOKE`, found: `TOKEN_BACKSLASH`."
-│       ├── description: "Unexpected token"
-│       ├── expected: "TOKEN_ERB_START, TOKEN_HTML_DOCTYPE, TOKEN_HTML_COMMENT_START, TOKEN_IDENTIFIER, TOKEN_WHITESPACE, TOKEN_NBSP, TOKEN_AT, or TOKEN_NEWLINE"
-│       └── found: "TOKEN_BACKSLASH"
-│
 └── children: (3 items)
     ├── @ HTMLElementNode (location: (1:0)-(1:36))
     │   ├── open_tag:
@@ -31,8 +24,8 @@
     │   ├── is_void: false
     │   └── source: "HTML"
     │
-    ├── @ HTMLTextNode (location: (1:37)-(1:50))
-    │   └── content: "\" yesterday\";"
+    ├── @ HTMLTextNode (location: (1:36)-(1:50))
+    │   └── content: "\\\" yesterday\";"
     │
     └── @ HTMLCloseTagNode (location: (1:50)-(1:59))
         ├── errors: (1 error)

--- a/test/snapshots/parser/tags_test/test_0027_stray_closing_tag_with_whitespace_0ee4b96cac701f87a8b6cb0cf5ad48bc.txt
+++ b/test/snapshots/parser/tags_test/test_0027_stray_closing_tag_with_whitespace_0ee4b96cac701f87a8b6cb0cf5ad48bc.txt
@@ -1,9 +1,9 @@
 @ DocumentNode (location: (1:0)-(1:24))
 ├── errors: (1 error)
 │   └── @ UnexpectedError (location: (1:16)-(1:17))
-│       ├── message: "Unexpected token. Expected: `TOKEN_ERB_START, TOKEN_HTML_DOCTYPE, TOKEN_HTML_COMMENT_START, TOKEN_IDENTIFIER, TOKEN_WHITESPACE, TOKEN_NBSP, TOKEN_AT, or TOKE`, found: `TOKEN_LT`."
+│       ├── message: "Unexpected token. Expected: `TOKEN_ERB_START, TOKEN_HTML_DOCTYPE, TOKEN_HTML_COMMENT_START, TOKEN_IDENTIFIER, TOKEN_WHITESPACE, TOKEN_NBSP, TOKEN_AT, TOKEN_B`, found: `TOKEN_LT`."
 │       ├── description: "Unexpected token"
-│       ├── expected: "TOKEN_ERB_START, TOKEN_HTML_DOCTYPE, TOKEN_HTML_COMMENT_START, TOKEN_IDENTIFIER, TOKEN_WHITESPACE, TOKEN_NBSP, TOKEN_AT, or TOKEN_NEWLINE"
+│       ├── expected: "TOKEN_ERB_START, TOKEN_HTML_DOCTYPE, TOKEN_HTML_COMMENT_START, TOKEN_IDENTIFIER, TOKEN_WHITESPACE, TOKEN_NBSP, TOKEN_AT, TOKEN_BACKSLASH, or TOKEN_NEWLINE"
 │       └── found: "TOKEN_LT"
 │
 └── children: (2 items)

--- a/test/snapshots/parser/text_content_test/test_0034_backslash-prefixed_text_stays_literal_-_issue_635_816fd02d8670264d606d92812679f159.txt
+++ b/test/snapshots/parser/text_content_test/test_0034_backslash-prefixed_text_stays_literal_-_issue_635_816fd02d8670264d606d92812679f159.txt
@@ -1,0 +1,25 @@
+@ DocumentNode (location: (1:0)-(1:22))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:22))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:3))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "p" (location: (1:1)-(1:2))
+        │       ├── tag_closing: ">" (location: (1:2)-(1:3))
+        │       ├── children: []
+        │       └── is_void: false
+        │
+        ├── tag_name: "p" (location: (1:1)-(1:2))
+        ├── body: (1 item)
+        │   └── @ HTMLTextNode (location: (1:3)-(1:18))
+        │       └── content: "\\Asome-regexp\\z"
+        │
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:18)-(1:22))
+        │       ├── tag_opening: "</" (location: (1:18)-(1:20))
+        │       ├── tag_name: "p" (location: (1:20)-(1:21))
+        │       ├── children: []
+        │       └── tag_closing: ">" (location: (1:21)-(1:22))
+        │
+        ├── is_void: false
+        └── source: "HTML"

--- a/test/snapshots/parser/text_content_test/test_0035_backslash-prefixed_text_-_issue_633_fd1ab6af93689cddc537bac4cbdaefde.txt
+++ b/test/snapshots/parser/text_content_test/test_0035_backslash-prefixed_text_-_issue_633_fd1ab6af93689cddc537bac4cbdaefde.txt
@@ -1,0 +1,72 @@
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:119))
+    │   ├── open_tag:
+    │   │   └── @ HTMLOpenTagNode (location: (1:0)-(1:16))
+    │   │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+    │   │       ├── tag_name: "p" (location: (1:1)-(1:2))
+    │   │       ├── tag_closing: ">" (location: (1:15)-(1:16))
+    │   │       ├── children: (1 item)
+    │   │       │   └── @ HTMLAttributeNode (location: (1:3)-(1:15))
+    │   │       │       ├── name:
+    │   │       │       │   └── @ HTMLAttributeNameNode (location: (1:3)-(1:8))
+    │   │       │       │       └── children: (1 item)
+    │   │       │       │           └── @ LiteralNode (location: (1:3)-(1:8))
+    │   │       │       │               └── content: "class"
+    │   │       │       │
+    │   │       │       │
+    │   │       │       ├── equals: "=" (location: (1:8)-(1:9))
+    │   │       │       └── value:
+    │   │       │           └── @ HTMLAttributeValueNode (location: (1:9)-(1:15))
+    │   │       │               ├── open_quote: """ (location: (1:9)-(1:10))
+    │   │       │               ├── children: (1 item)
+    │   │       │               │   └── @ LiteralNode (location: (1:10)-(1:14))
+    │   │       │               │       └── content: "help"
+    │   │       │               │
+    │   │       │               ├── close_quote: """ (location: (1:14)-(1:15))
+    │   │       │               └── quoted: true
+    │   │       │
+    │   │       │
+    │   │       └── is_void: false
+    │   │
+    │   ├── tag_name: "p" (location: (1:1)-(1:2))
+    │   ├── body: (2 items)
+    │   │   ├── @ HTMLTextNode (location: (1:16)-(1:70))
+    │   │   │   └── content: "Regexp with captures, must consume whole string like: "
+    │   │   │
+    │   │   └── @ HTMLElementNode (location: (1:70)-(1:115))
+    │   │       ├── open_tag:
+    │   │       │   └── @ HTMLOpenTagNode (location: (1:70)-(1:75))
+    │   │       │       ├── tag_opening: "<" (location: (1:70)-(1:71))
+    │   │       │       ├── tag_name: "kbd" (location: (1:71)-(1:74))
+    │   │       │       ├── tag_closing: ">" (location: (1:74)-(1:75))
+    │   │       │       ├── children: []
+    │   │       │       └── is_void: false
+    │   │       │
+    │   │       ├── tag_name: "kbd" (location: (1:71)-(1:74))
+    │   │       ├── body: (1 item)
+    │   │       │   └── @ HTMLTextNode (location: (1:75)-(1:109))
+    │   │       │       └── content: "\\Ahttps?://github.com/+([^/]+).*\\z"
+    │   │       │
+    │   │       ├── close_tag:
+    │   │       │   └── @ HTMLCloseTagNode (location: (1:109)-(1:115))
+    │   │       │       ├── tag_opening: "</" (location: (1:109)-(1:111))
+    │   │       │       ├── tag_name: "kbd" (location: (1:111)-(1:114))
+    │   │       │       ├── children: []
+    │   │       │       └── tag_closing: ">" (location: (1:114)-(1:115))
+    │   │       │
+    │   │       ├── is_void: false
+    │   │       └── source: "HTML"
+    │   │
+    │   ├── close_tag:
+    │   │   └── @ HTMLCloseTagNode (location: (1:115)-(1:119))
+    │   │       ├── tag_opening: "</" (location: (1:115)-(1:117))
+    │   │       ├── tag_name: "p" (location: (1:117)-(1:118))
+    │   │       ├── children: []
+    │   │       └── tag_closing: ">" (location: (1:118)-(1:119))
+    │   │
+    │   ├── is_void: false
+    │   └── source: "HTML"
+    │
+    └── @ HTMLTextNode (location: (1:119)-(2:0))
+        └── content: "\n"


### PR DESCRIPTION
This pull request updates the parser to allow backslashes in the HTML Text Content. Previously, a document like this failed to parse:

```html
<p>\Asome-regexp\z</p>
```

With an error like:

```
Unexpected token. Expected: `TOKEN_ERB_START, TOKEN_HTML_DOCTYPE, TOKEN_HTML_COMMENT_START, TOKEN_IDENTIFIER, TOKEN_WHITESPACE, TOKEN_NBSP, TOKEN_AT, or TOKE`, found: `TOKEN_BACKSLASH`. 
```

Resolves #633 
Resolves #635 