### PR TITLE
C: Use `uint32_t` for `length` member in `hb_string_T`  struct

### DIFF
--- a/src/include/util/hb_string.h
+++ b/src/include/util/hb_string.h
@@ -3,10 +3,11 @@
 
 #include <stdbool.h>
 #include <stddef.h>
+#include <stdint.h>
 
 typedef struct HB_STRING_STRUCT {
   char* data;
-  size_t length;
+  uint32_t length;
 } hb_string_T;
 
 hb_string_T hb_string_from_c_string(const char* null_terminated_c_string);

--- a/src/util/hb_string.c
+++ b/src/util/hb_string.c
@@ -8,7 +8,7 @@ hb_string_T hb_string_from_c_string(const char* null_terminated_c_string) {
   hb_string_T string;
 
   string.data = (char*) null_terminated_c_string;
-  string.length = strlen(null_terminated_c_string);
+  string.length = (uint32_t) strlen(null_terminated_c_string);
 
   return string;
 }


### PR DESCRIPTION
In line with the lexer/parser we are going to limit the string length to the range of `uint32_t` which is sufficient to hold 4 GB large strings.

Resolves #636 

