### PR TITLE
Linter Rule: Allow head-only elements on top level

### DIFF
--- a/javascript/packages/linter/src/rules/html-head-only-elements.ts
+++ b/javascript/packages/linter/src/rules/html-head-only-elements.ts
@@ -20,6 +20,7 @@ class HeadOnlyElementsVisitor extends BaseRuleVisitor {
 
   private checkHeadOnlyElement(node: HTMLElementNode, tagName: string): void {
     if (this.insideHead) return
+    if (!this.insideBody) return
     if (!isHeadOnlyTag(tagName)) return
     if (tagName === "title" && this.insideSVG) return
 
@@ -32,6 +33,10 @@ class HeadOnlyElementsVisitor extends BaseRuleVisitor {
 
   private get insideHead(): boolean {
     return this.elementStack.includes("head")
+  }
+
+  private get insideBody(): boolean {
+    return this.elementStack.includes("body")
   }
 
   private get insideSVG(): boolean {

--- a/javascript/packages/linter/test/rules/html-head-only-elements.test.ts
+++ b/javascript/packages/linter/test/rules/html-head-only-elements.test.ts
@@ -57,6 +57,28 @@ describe("html-head-only-elements", () => {
     `)
   })
 
+  test("passes for head-only elements on the top-level", () => {
+    expectNoOffenses(dedent`
+      <meta>
+      <link>
+      <base>
+      <title></title>
+      <style></style>
+    `)
+  })
+
+  test.todo("fails for head-only elements on the top-level when other body-elements are present", () => {
+    expectNoOffenses(dedent`
+      <meta>
+      <link>
+      <base>
+      <title></title>
+      <style></style>
+
+      <div></div>
+    `)
+  })
+
   test("fails when meta is in body", () => {
     expectError("Element `<meta>` must be placed inside the `<head>` tag.")
 
@@ -136,7 +158,8 @@ describe("html-head-only-elements", () => {
     `)
   })
 
-  test("fails when elements are outside html structure", () => {
+  // TODO: this should be handled in https://github.com/marcoroth/herb/issues/638
+  test.fails("fails when elements are outside html structure", () => {
     expectError("Element `<title>` must be placed inside the `<head>` tag.")
     expectError("Element `<meta>` must be placed inside the `<head>` tag.")
 


### PR DESCRIPTION
This pull request updates the `html-head-only-elements` linter rule to allow head-only elements on the top-level, like:

```html
<meta>
<link>
<base>
<title></title>
<style></style>
```

This is useful, when the content of `<head>` element in the layout is extracted to a partial, so that the partial itself doesn't contain the `<head>` element directly. This is now allowed.