### PR TITLE
Linter Rule: Fix false positive for `yield` in `erb-right-trim` rule

### DIFF
--- a/javascript/packages/core/src/ast-utils.ts
+++ b/javascript/packages/core/src/ast-utils.ts
@@ -1,6 +1,7 @@
 import {
   Node,
   LiteralNode,
+  ERBNode,
   ERBContentNode,
   ERBIfNode,
   ERBUnlessNode,
@@ -30,11 +31,17 @@ import {
 import type { Location } from "./location.js"
 import type { Position } from "./position.js"
 
+export type ERBOutputNode = ERBNode & {
+  tag_opening: {
+    value: "<%=" | "<%=="
+  }
+}
+
 /**
  * Checks if a node is an ERB output node (generates content: <%= %> or <%== %>)
  */
-export function isERBOutputNode(node: Node): node is ERBContentNode {
-  if (!isNode(node, ERBContentNode)) return false
+export function isERBOutputNode(node: Node): node is ERBOutputNode {
+  if (!isERBNode(node)) return false
   if (!node.tag_opening?.value) return false
 
   return ["<%=", "<%=="].includes(node.tag_opening?.value)

--- a/javascript/packages/linter/test/rules/erb-right-trim.test.ts
+++ b/javascript/packages/linter/test/rules/erb-right-trim.test.ts
@@ -131,4 +131,18 @@ describe("ERBRightTrimRule", () => {
       <%- end -%>
     `)
   })
+
+  test("passes for yield with -%>", () => {
+    expectNoOffenses(dedent`
+      <%= yield -%>
+    `)
+  })
+
+  test("passes for block with -%>", () => {
+    expectNoOffenses(dedent`
+      <%= content_for :content do -%>
+        Content
+      <%- end -%>
+    `)
+  })
 })


### PR DESCRIPTION
This pull request updates the `isERBOutputNode` helper in `@herb-tools/core` in order to detect a `<%= yield %>` node as an `ERBOutputNode`.

This change fixes the `erb-right-trim` rule to not report the following snippet as an offense:

```erb
<%= yield -%>
```

Resolves #643 