### PR TITLE
Linter: Rename `erb-require-trailing-newline` linter rule

### DIFF
--- a/docs/.vitepress/transformers/herb-linter-transformer.mts
+++ b/docs/.vitepress/transformers/herb-linter-transformer.mts
@@ -21,9 +21,9 @@ function createCustomTwoslashFunction(optionse) {
   return (code, lang, options) => {
     let fileName = undefined
 
-    // kinda of a hack to make sure we pass a `fileName` for the `erb-requires-trailing-newline` rule
+    // kind of a hack to make sure we pass a `fileName` for the `erb-require-trailing-newline` rule
     if (code.includes('▌')) {
-      fileName = "erb-requires-trailing-newline.html.erb"
+      fileName = "erb-require-trailing-newline.html.erb"
     }
 
     if (!lang || !['erb', 'html'].includes(lang)) {

--- a/javascript/packages/linter/README.md
+++ b/javascript/packages/linter/README.md
@@ -250,7 +250,7 @@ npx @herb-tools/linter template.html.erb --json
         "end": { "line": 1, "column": 22 }
       },
       "severity": "error",
-      "code": "erb-requires-trailing-newline",
+      "code": "erb-require-trailing-newline",
       "source": "Herb Linter"
     }
   ],

--- a/javascript/packages/linter/docs/rules/README.md
+++ b/javascript/packages/linter/docs/rules/README.md
@@ -12,7 +12,7 @@ This page contains documentation for all Herb Linter rules.
 - [`erb-no-silent-tag-in-attribute-name`](./erb-no-silent-tag-in-attribute-name.md) - Disallow ERB silent tags in HTML attribute names
 - [`erb-prefer-image-tag-helper`](./erb-prefer-image-tag-helper.md) - Prefer `image_tag` helper over `<img>` with ERB expressions
 - [`erb-require-whitespace-inside-tags`](./erb-require-whitespace-inside-tags.md) - Requires whitespace around ERB tags
-- [`erb-requires-trailing-newline`](./erb-requires-trailing-newline.md) - Enforces that all HTML+ERB template files end with exactly one trailing newline character.
+- [`erb-require-trailing-newline`](./erb-require-trailing-newline.md) - Enforces that all HTML+ERB template files end with exactly one trailing newline character.
 - [`erb-right-trim`](./erb-right-trim.md) - Enforce consistent right-trimming syntax.
 - [`html-anchor-require-href`](./html-anchor-require-href.md) - Requires an href attribute on anchor tags
 - [`html-aria-attribute-must-be-valid`](./html-aria-attribute-must-be-valid.md) - Disallow invalid or unknown `aria-*` attributes.

--- a/javascript/packages/linter/docs/rules/erb-require-trailing-newline.md
+++ b/javascript/packages/linter/docs/rules/erb-require-trailing-newline.md
@@ -1,6 +1,6 @@
 # Linter Rule: Enforce trailing newline
 
-**Rule:** `erb-requires-trailing-newline`
+**Rule:** `erb-require-trailing-newline`
 
 ## Description
 

--- a/javascript/packages/linter/src/default-rules.ts
+++ b/javascript/packages/linter/src/default-rules.ts
@@ -7,7 +7,7 @@ import { ERBNoExtraNewLineRule } from "./rules/erb-no-extra-newline.js"
 import { ERBNoOutputControlFlowRule } from "./rules/erb-no-output-control-flow.js"
 import { ERBNoSilentTagInAttributeNameRule } from "./rules/erb-no-silent-tag-in-attribute-name.js"
 import { ERBPreferImageTagHelperRule } from "./rules/erb-prefer-image-tag-helper.js"
-import { ERBRequiresTrailingNewlineRule } from "./rules/erb-requires-trailing-newline.js"
+import { ERBRequireTrailingNewlineRule } from "./rules/erb-require-trailing-newline.js"
 import { ERBRequireWhitespaceRule } from "./rules/erb-require-whitespace-inside-tags.js"
 import { ERBRightTrimRule } from "./rules/erb-right-trim.js"
 
@@ -55,7 +55,7 @@ export const defaultRules: RuleClass[] = [
   ERBNoOutputControlFlowRule,
   ERBNoSilentTagInAttributeNameRule,
   ERBPreferImageTagHelperRule,
-  ERBRequiresTrailingNewlineRule,
+  ERBRequireTrailingNewlineRule,
   ERBRequireWhitespaceRule,
   ERBRightTrimRule,
 

--- a/javascript/packages/linter/src/rules/erb-require-trailing-newline.ts
+++ b/javascript/packages/linter/src/rules/erb-require-trailing-newline.ts
@@ -3,7 +3,7 @@ import { BaseSourceRuleVisitor, createEndOfFileLocation } from "./rule-utils.js"
 
 import type { LintOffense, LintContext } from "../types.js"
 
-class ERBRequiresTrailingNewlineVisitor extends BaseSourceRuleVisitor {
+class ERBRequireTrailingNewlineVisitor extends BaseSourceRuleVisitor {
   protected visitSource(source: string): void {
     if (source.length === 0) return
     if (!this.context.fileName) return
@@ -24,12 +24,12 @@ class ERBRequiresTrailingNewlineVisitor extends BaseSourceRuleVisitor {
   }
 }
 
-export class ERBRequiresTrailingNewlineRule extends SourceRule {
+export class ERBRequireTrailingNewlineRule extends SourceRule {
   static autocorrectable = true
-  name = "erb-requires-trailing-newline"
+  name = "erb-require-trailing-newline"
 
   check(source: string, context?: Partial<LintContext>): LintOffense[] {
-    const visitor = new ERBRequiresTrailingNewlineVisitor(this.name, context)
+    const visitor = new ERBRequireTrailingNewlineVisitor(this.name, context)
 
     visitor.visit(source)
 

--- a/javascript/packages/linter/src/rules/index.ts
+++ b/javascript/packages/linter/src/rules/index.ts
@@ -7,7 +7,7 @@ export * from "./erb-no-extra-newline.js"
 export * from "./erb-no-output-control-flow.js"
 export * from "./erb-no-silent-tag-in-attribute-name.js"
 export * from "./erb-prefer-image-tag-helper.js"
-export * from "./erb-requires-trailing-newline.js"
+export * from "./erb-require-trailing-newline.js"
 export * from "./erb-right-trim.js"
 
 export * from "./html-anchor-require-href.js"

--- a/javascript/packages/linter/test/__snapshots__/cli.test.ts.snap
+++ b/javascript/packages/linter/test/__snapshots__/cli.test.ts.snap
@@ -56,9 +56,9 @@ test/fixtures/test-file-with-errors.html.erb:2:22
 `;
 
 exports[`CLI Output Formatting > GitHub Actions format includes rule codes 1`] = `
-"::error file=test/fixtures/no-trailing-newline.html.erb,line=1,col=29,title=erb-requires-trailing-newline • @herb-tools/linter@0.7.5::File must end with trailing newline. [erb-requires-trailing-newline]%0A%0A%0Atest/fixtures/no-trailing-newline.html.erb:1:29%0A%0A  →   1 │ <div>No trailing newline</div>%0A        │                              ~%0A
+"::error file=test/fixtures/no-trailing-newline.html.erb,line=1,col=29,title=erb-require-trailing-newline • @herb-tools/linter@0.7.5::File must end with trailing newline. [erb-require-trailing-newline]%0A%0A%0Atest/fixtures/no-trailing-newline.html.erb:1:29%0A%0A  →   1 │ <div>No trailing newline</div>%0A        │                              ~%0A
 
-[error] File must end with trailing newline. [Correctable] (erb-requires-trailing-newline)
+[error] File must end with trailing newline. [Correctable] (erb-require-trailing-newline)
 
 test/fixtures/no-trailing-newline.html.erb:1:29
 
@@ -66,7 +66,7 @@ test/fixtures/no-trailing-newline.html.erb:1:29
         │                              ~
 
  Rule offenses:
-  erb-requires-trailing-newline (1 offense in 1 file)
+  erb-require-trailing-newline (1 offense in 1 file)
 
 
  Summary:

--- a/javascript/packages/linter/test/autofix/erb-require-trailing-newline.autofix.test.ts
+++ b/javascript/packages/linter/test/autofix/erb-require-trailing-newline.autofix.test.ts
@@ -2,9 +2,9 @@ import dedent from "dedent"
 import { describe, test, expect, beforeAll } from "vitest"
 import { Herb } from "@herb-tools/node-wasm"
 import { Linter } from "../../src/linter.js"
-import { ERBRequiresTrailingNewlineRule } from "../../src/rules/erb-requires-trailing-newline.js"
+import { ERBRequireTrailingNewlineRule } from "../../src/rules/erb-require-trailing-newline.js"
 
-describe("erb-requires-trailing-newline autofix", () => {
+describe("erb-require-trailing-newline autofix", () => {
   beforeAll(async () => {
     await Herb.load()
   })
@@ -13,7 +13,7 @@ describe("erb-requires-trailing-newline autofix", () => {
     const input = '<div>Hello World</div>'
     const expected = '<div>Hello World</div>\n'
 
-    const linter = new Linter(Herb, [ERBRequiresTrailingNewlineRule])
+    const linter = new Linter(Herb, [ERBRequireTrailingNewlineRule])
     const result = linter.autofix(input, { fileName: 'test.html.erb' })
 
     expect(result.source).toBe(expected)
@@ -25,7 +25,7 @@ describe("erb-requires-trailing-newline autofix", () => {
     const input = '<div>Hello World</div>\n'
     const expected = '<div>Hello World</div>\n'
 
-    const linter = new Linter(Herb, [ERBRequiresTrailingNewlineRule])
+    const linter = new Linter(Herb, [ERBRequireTrailingNewlineRule])
     const result = linter.autofix(input, { fileName: 'test.html.erb' })
 
     expect(result.source).toBe(expected)
@@ -44,7 +44,7 @@ describe("erb-requires-trailing-newline autofix", () => {
       </div>
     ` + '\n'
 
-    const linter = new Linter(Herb, [ERBRequiresTrailingNewlineRule])
+    const linter = new Linter(Herb, [ERBRequireTrailingNewlineRule])
     const result = linter.autofix(input, { fileName: 'test.html.erb' })
 
     expect(result.source).toBe(expected)
@@ -55,7 +55,7 @@ describe("erb-requires-trailing-newline autofix", () => {
     const input = '<div><%= content %></div>'
     const expected = '<div><%= content %></div>\n'
 
-    const linter = new Linter(Herb, [ERBRequiresTrailingNewlineRule])
+    const linter = new Linter(Herb, [ERBRequireTrailingNewlineRule])
     const result = linter.autofix(input, { fileName: 'test.html.erb' })
 
     expect(result.source).toBe(expected)
@@ -66,7 +66,7 @@ describe("erb-requires-trailing-newline autofix", () => {
     const input = ''
     const expected = ''
 
-    const linter = new Linter(Herb, [ERBRequiresTrailingNewlineRule])
+    const linter = new Linter(Herb, [ERBRequireTrailingNewlineRule])
     const result = linter.autofix(input, { fileName: 'test.html.erb' })
 
     expect(result.source).toBe(expected)
@@ -77,7 +77,7 @@ describe("erb-requires-trailing-newline autofix", () => {
     const input = '<div>Hello</div>\n\n'
     const expected = '<div>Hello</div>\n'
 
-    const linter = new Linter(Herb, [ERBRequiresTrailingNewlineRule])
+    const linter = new Linter(Herb, [ERBRequireTrailingNewlineRule])
     const result = linter.autofix(input, { fileName: 'test.html.erb' })
 
     expect(result.source).toBe(expected)
@@ -89,7 +89,7 @@ describe("erb-requires-trailing-newline autofix", () => {
     const input = '<div>Hello</div>\n\n\n\n\n\n'
     const expected = '<div>Hello</div>\n'
 
-    const linter = new Linter(Herb, [ERBRequiresTrailingNewlineRule])
+    const linter = new Linter(Herb, [ERBRequireTrailingNewlineRule])
     const result = linter.autofix(input, { fileName: 'test.html.erb' })
 
     expect(result.source).toBe(expected)

--- a/javascript/packages/linter/test/cli.test.ts
+++ b/javascript/packages/linter/test/cli.test.ts
@@ -105,7 +105,7 @@ describe("CLI Output Formatting", () => {
   test("correctly passes filename context for file-specific rules", () => {
     const { output, exitCode } = runLinter("no-trailing-newline.html.erb", "--simple", "--no-wrap-lines")
 
-    expect(output).toContain("erb-requires-trailing-newline")
+    expect(output).toContain("erb-require-trailing-newline")
     expect(output).toContain("File must end with trailing newline")
     expect(exitCode).toBe(1)
   })

--- a/javascript/packages/linter/test/rules/erb-require-trailing-newline.test.ts
+++ b/javascript/packages/linter/test/rules/erb-require-trailing-newline.test.ts
@@ -2,12 +2,12 @@ import dedent from "dedent"
 
 import { describe, test } from "vitest"
 
-import { ERBRequiresTrailingNewlineRule } from "../../src/rules/erb-requires-trailing-newline.js"
+import { ERBRequireTrailingNewlineRule } from "../../src/rules/erb-require-trailing-newline.js"
 import { createLinterTest } from "../helpers/linter-test-helper.js"
 
-const { expectNoOffenses, expectError, assertOffenses } = createLinterTest(ERBRequiresTrailingNewlineRule)
+const { expectNoOffenses, expectError, assertOffenses } = createLinterTest(ERBRequireTrailingNewlineRule)
 
-describe("ERBRequiresTrailingNewlineRule", () => {
+describe("ERBRequireTrailingNewlineRule", () => {
   test("should not report errors for files ending with a trailing newline", () => {
     const html = dedent`
       <h1>

--- a/javascript/packages/vscode/package.json
+++ b/javascript/packages/vscode/package.json
@@ -69,7 +69,7 @@
               "erb-no-silent-tag-in-attribute-name",
               "erb-prefer-image-tag-helper",
               "erb-require-whitespace-inside-tags",
-              "erb-requires-trailing-newline",
+              "erb-require-trailing-newline",
               "erb-right-trim",
               "html-anchor-require-href",
               "html-aria-attribute-must-be-valid",


### PR DESCRIPTION
This pull request renames the `erb-requires-trailing-newline` linter rule to `erb-require-trailing-newline` to be more in line with the other `erb-require-whitespace-inside-tags` linter rule name.