### PR TITLE
C: Implement `hb_string_slice` function

### DIFF
--- a/src/include/util/hb_string.h
+++ b/src/include/util/hb_string.h
@@ -11,6 +11,7 @@ typedef struct HB_STRING_STRUCT {
 } hb_string_T;
 
 hb_string_T hb_string_from_c_string(const char* null_terminated_c_string);
+hb_string_T hb_string_slice(hb_string_T string, uint32_t offset);
 bool hb_string_equals(hb_string_T a, hb_string_T b);
 bool hb_string_equals_case_insensitive(hb_string_T a, hb_string_T b);
 bool hb_string_starts_with(hb_string_T string, hb_string_T expected_prefix);

--- a/src/util/hb_string.c
+++ b/src/util/hb_string.c
@@ -13,6 +13,21 @@ hb_string_T hb_string_from_c_string(const char* null_terminated_c_string) {
   return string;
 }
 
+hb_string_T hb_string_slice(hb_string_T string, uint32_t offset) {
+  hb_string_T slice;
+  if (string.length < offset) {
+    slice.data = NULL;
+    slice.length = 0;
+
+    return slice;
+  }
+
+  slice.data = string.data + offset;
+  slice.length = string.length - offset;
+
+  return slice;
+}
+
 bool hb_string_equals(hb_string_T a, hb_string_T b) {
   if (a.length != b.length) { return false; }
 

--- a/test/c/test_hb_string.c
+++ b/test/c/test_hb_string.c
@@ -25,6 +25,41 @@ TEST(hb_string_equals_tests)
   }
 END
 
+TEST(hb_string_offset_based_slice_tests)
+  {
+    hb_string_T source = hb_string_from_c_string("01234");
+    hb_string_T expected_slice = hb_string_from_c_string("234");
+
+    hb_string_T slice = hb_string_slice(source, 2);
+
+    ck_assert(hb_string_equals(slice, expected_slice));
+  }
+
+  {
+    hb_string_T source = hb_string_from_c_string("01234");
+    hb_string_T expected_slice = hb_string_from_c_string("4");
+
+    hb_string_T slice = hb_string_slice(source, 4);
+
+    ck_assert(hb_string_equals(slice, expected_slice));
+  }
+
+  {
+    hb_string_T source = hb_string_from_c_string("01234");
+    hb_string_T slice = hb_string_slice(source, 5);
+
+    ck_assert(hb_string_is_empty(slice));
+  }
+
+  {
+    hb_string_T source = hb_string_from_c_string("01234");
+    hb_string_T slice = hb_string_slice(source, 6);
+
+    ck_assert(hb_string_is_empty(slice));
+  }
+END
+
+
 TEST(hb_string_equals_case_insensitive_tests)
   {
     hb_string_T a = hb_string_from_c_string("Hello, world.");
@@ -125,6 +160,7 @@ TCase *hb_string_tests(void) {
   TCase *tags = tcase_create("Herb String");
 
   tcase_add_test(tags, hb_string_equals_tests);
+  tcase_add_test(tags, hb_string_offset_based_slice_tests);
   tcase_add_test(tags, hb_string_equals_case_insensitive_tests);
   tcase_add_test(tags, hb_string_is_empty_tests);
   tcase_add_test(tags, hb_string_starts_with_tests);


### PR DESCRIPTION
This PR introduces a new function that allows to get a slice of a string.

![slice](https://github.com/user-attachments/assets/448e8319-aeef-4cd5-8176-bd9794f45c0c)
