### PR TITLE
C: Use Arena Allocator in `hb_string_to_c_string` function

### DIFF
--- a/src/include/util/hb_string.h
+++ b/src/include/util/hb_string.h
@@ -5,6 +5,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include "../hb_arena.h"
+
 typedef struct HB_STRING_STRUCT {
   char* data;
   uint32_t length;
@@ -17,21 +19,6 @@ bool hb_string_equals_case_insensitive(hb_string_T a, hb_string_T b);
 bool hb_string_starts_with(hb_string_T string, hb_string_T expected_prefix);
 bool hb_string_is_empty(hb_string_T string);
 
-/**
- * @brief Creates a null terminated c string version of the passed string
- *
- * @param string The string for which a c string version is to be created
- * @return A heap allocated null terminated c string
- *
- * Example:
- * @code
- *
- * hb_string_T string = hb_string_from_c_string("Hello, world");
- * char* cstring = hb_string_to_c_string(string);
- *
- * free(cstring);
- * @endcode
- */
-char* hb_string_to_c_string(hb_string_T string);
+char* hb_string_to_c_string(hb_arena_T* allocator, hb_string_T string);
 
 #endif

--- a/src/util/hb_string.c
+++ b/src/util/hb_string.c
@@ -51,9 +51,9 @@ bool hb_string_is_empty(hb_string_T string) {
   return string.length == 0;
 }
 
-char* hb_string_to_c_string(hb_string_T string) {
+char* hb_string_to_c_string(hb_arena_T* allocator, hb_string_T string) {
   size_t string_length_in_bytes = sizeof(char) * (string.length);
-  char* buffer = malloc(string_length_in_bytes + sizeof(char) * 1);
+  char* buffer = hb_arena_alloc(allocator, string_length_in_bytes + sizeof(char) * 1);
 
   if (!hb_string_is_empty(string)) { memcpy(buffer, string.data, string_length_in_bytes); }
 


### PR DESCRIPTION
This PR adds the new arena allocator to the `hb_string_to_c_string` that is the only hb_string function that needs to allocate memory.