### PR TITLE
C: Inline `size_t_to_string` function

### DIFF
--- a/src/include/util.h
+++ b/src/include/util.h
@@ -11,6 +11,4 @@ char* quoted_string(const char* input);
 char* wrap_string(const char* input, char character);
 char* herb_strdup(const char* s);
 
-char* size_t_to_string(size_t value);
-
 #endif

--- a/src/pretty_print.c
+++ b/src/pretty_print.c
@@ -90,10 +90,12 @@ void pretty_print_size_t_property(
   hb_buffer_T* buffer
 ) {
   pretty_print_label(name, indent, relative_indent, last_property, buffer);
-  char* string = size_t_to_string(value);
-  hb_buffer_append(buffer, string);
+
+  char size_string[21];
+  snprintf(size_string, 21, "%zu", value);
+
+  hb_buffer_append(buffer, size_string);
   hb_buffer_append(buffer, "\n");
-  free(string);
 }
 
 void pretty_print_array(

--- a/src/util.c
+++ b/src/util.c
@@ -60,10 +60,3 @@ char* herb_strdup(const char* s) {
 
   return copy;
 }
-
-char* size_t_to_string(const size_t value) {
-  char* buffer = malloc(21);
-  snprintf(buffer, 21, "%zu", value);
-
-  return buffer;
-}


### PR DESCRIPTION
This PR removes the `size_t_to_string`  function and replaces its only usages the function body.

## Reasoning

- `size_t_to_string` is only used in one place
- it is rather trivial
- if we would migrate it to use the arena allocator we would need to pass an explicit arena allocator to the pretty print function
- Using a stack allocated char array has better cache locality