### PR TITLE
C: Use `hb_string_T` in `herb_analyze` function

### DIFF
--- a/src/analyze.c
+++ b/src/analyze.c
@@ -11,6 +11,7 @@
 #include "include/token_struct.h"
 #include "include/util.h"
 #include "include/util/hb_array.h"
+#include "include/util/hb_string.h"
 #include "include/visitor.h"
 
 #include <prism.h>
@@ -19,7 +20,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-static analyzed_ruby_T* herb_analyze_ruby(char* source) {
+static analyzed_ruby_T* herb_analyze_ruby(hb_string_T source) {
   analyzed_ruby_T* analyzed = init_analyzed_ruby(source);
 
   pm_visit_node(analyzed->root, search_if_nodes, analyzed);
@@ -52,7 +53,7 @@ static bool analyze_erb_content(const AST_NODE_T* node, void* data) {
     const char* opening = erb_content_node->tag_opening->value;
 
     if (strcmp(opening, "<%%") != 0 && strcmp(opening, "<%%=") != 0 && strcmp(opening, "<%#") != 0) {
-      analyzed_ruby_T* analyzed = herb_analyze_ruby(erb_content_node->content->value);
+      analyzed_ruby_T* analyzed = herb_analyze_ruby(hb_string_from_c_string(erb_content_node->content->value));
 
       if (false) { pretty_print_analyzed_ruby(analyzed, erb_content_node->content->value); }
 

--- a/src/analyzed_ruby.c
+++ b/src/analyzed_ruby.c
@@ -1,12 +1,13 @@
 #include "include/analyzed_ruby.h"
+#include "include/util/hb_string.h"
 
 #include <prism.h>
 #include <string.h>
 
-analyzed_ruby_T* init_analyzed_ruby(char* source) {
+analyzed_ruby_T* init_analyzed_ruby(hb_string_T source) {
   analyzed_ruby_T* analyzed = malloc(sizeof(analyzed_ruby_T));
 
-  pm_parser_init(&analyzed->parser, (const uint8_t*) source, strlen(source), NULL);
+  pm_parser_init(&analyzed->parser, (const uint8_t*) source.data, source.length, NULL);
 
   analyzed->root = pm_parse(&analyzed->parser);
   analyzed->valid = (analyzed->parser.error_list.size == 0);

--- a/src/include/analyzed_ruby.h
+++ b/src/include/analyzed_ruby.h
@@ -2,6 +2,7 @@
 #define HERB_ANALYZED_RUBY_H
 
 #include "util/hb_array.h"
+#include "util/hb_string.h"
 
 #include <prism.h>
 
@@ -30,7 +31,7 @@ typedef struct ANALYZED_RUBY_STRUCT {
   bool has_yield_node;
 } analyzed_ruby_T;
 
-analyzed_ruby_T* init_analyzed_ruby(char* source);
+analyzed_ruby_T* init_analyzed_ruby(hb_string_T source);
 void free_analyzed_ruby(analyzed_ruby_T* analyzed);
 
 #endif


### PR DESCRIPTION
This PR starts using the `hb_string_T` in the interface of `herb_analyze`.  

This is a side effect free refactor, that makes the switch to `hb_string_T` based token values easier later on.