### PR TITLE
C: Make `is_newline` function legible

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -6,8 +6,8 @@
 #include <stdlib.h>
 #include <string.h>
 
-int is_newline(const int character) {
-  return character == 13 || character == 10;
+int is_newline(int character) {
+  return character == '\n' || character == '\r';
 }
 
 char* escape_newlines(const char* input) {


### PR DESCRIPTION
This PR is just a minor fix for a nitpick of mine. Instead of using the ascii codes in the `is_newline` function, we use the characters directly, making the function way more readable. 