### PR TITLE
Linter: Use `--generate-todo` to create a todo list for ignoring rules.

### DIFF
--- a/javascript/packages/linter/src/cli.ts
+++ b/javascript/packages/linter/src/cli.ts
@@ -141,7 +141,17 @@ export class CLI {
     const startTime = Date.now()
     const startDate = new Date()
 
-    let { pattern, formatOption, showTiming, theme, wrapLines, truncateLines, useGitHubActions, fix } = this.argumentParser.parse(process.argv)
+    let { 
+      pattern,
+      formatOption,
+      showTiming,
+      theme,
+      wrapLines,
+      truncateLines,
+      useGitHubActions,
+      fix,
+      generateTodo
+    } = this.argumentParser.parse(process.argv)
 
     this.determineProjectPath(pattern)
 
@@ -170,7 +180,8 @@ export class CLI {
       const context = {
         projectPath: this.projectPath,
         pattern,
-        fix
+        fix,
+        generateTodo
       }
 
       const results = await this.fileProcessor.processFiles(files, formatOption, context)

--- a/javascript/packages/linter/src/cli/argument-parser.ts
+++ b/javascript/packages/linter/src/cli/argument-parser.ts
@@ -22,7 +22,8 @@ export interface ParsedArguments {
   wrapLines: boolean
   truncateLines: boolean
   useGitHubActions: boolean
-  fix: boolean
+  fix: boolean,
+  generateTodo: boolean,
 }
 
 export class ArgumentParser {
@@ -48,6 +49,7 @@ export class ArgumentParser {
       --no-timing      hide timing information
       --no-wrap-lines  disable line wrapping
       --truncate-lines enable line truncation (mutually exclusive with line wrapping)
+      --generate-todo   generate a .herb-todo.yml file with current diagnostics
   `
 
   parse(argv: string[]): ParsedArguments {
@@ -66,7 +68,8 @@ export class ArgumentParser {
         "no-color": { type: "boolean" },
         "no-timing": { type: "boolean" },
         "no-wrap-lines": { type: "boolean" },
-        "truncate-lines": { type: "boolean" }
+        "truncate-lines": { type: "boolean" },
+        "generate-todo": { type: "boolean" },
       },
       allowPositionals: true
     })
@@ -125,11 +128,23 @@ export class ArgumentParser {
       process.exit(1)
     }
 
+    const generateTodo = values["generate-todo"] || false
+
     const theme = values.theme || DEFAULT_THEME
     const pattern = this.getFilePattern(positionals)
     const fix = values.fix || false
 
-    return { pattern, formatOption, showTiming, theme, wrapLines, truncateLines, useGitHubActions, fix }
+    return { 
+      pattern,
+      formatOption,
+      showTiming,
+      theme,
+      wrapLines,
+      truncateLines,
+      useGitHubActions,
+      fix,
+      generateTodo,
+    }
   }
 
   private getFilePattern(positionals: string[]): string {

--- a/javascript/packages/linter/src/linter-todo.ts
+++ b/javascript/packages/linter/src/linter-todo.ts
@@ -1,0 +1,119 @@
+import YAML from "yaml"
+import { existsSync, unlinkSync, readFileSync, writeFileSync } from "fs"
+import { join, relative, isAbsolute } from "path"
+
+import { LinterRule, LintOffense } from "./types"
+
+export interface TodoConfig {
+  excludes: {
+    [rule: LinterRule]: {
+      [filePath: string]: {
+        warning: number
+        error: number
+      }
+    }
+  }
+}
+
+export class LinterTodo {
+  private static readonly TODO_FILE = ".herb-todo.yml"
+  private todoConfig: TodoConfig | null = null
+  private readonly projectPath: string
+  private readonly todoPath: string
+
+  constructor(projectPath: string) {
+    this.projectPath = projectPath
+    this.todoPath = join(this.projectPath, LinterTodo.TODO_FILE)
+    this.loadTodoConfig()
+  }
+
+  clearTodoFile(): void {
+    if (!this.todoExists()) return
+    unlinkSync(this.todoPath)
+    this.loadTodoConfig()
+  }
+
+  generateTodoConfig(offenses: Record<string, LintOffense[]>): void {
+    const config: TodoConfig = { excludes: {} }
+    for (const filePath of Object.keys(offenses)) {
+      const fileOffenses = offenses[filePath]
+      const relativePath = isAbsolute(filePath) ? relative(this.projectPath, filePath) : filePath
+      for (const offense of fileOffenses) {
+        const ruleName = offense.rule
+        const ruleEntry = (config.excludes[ruleName] ??= {})
+        const ruleBaseline = (ruleEntry[relativePath] ??= { warning: 0, error: 0 })
+
+        if (offense.severity !== "warning" && offense.severity !== "error") {
+          continue
+        }
+
+        ruleBaseline[offense.severity]++
+      }
+    }
+    writeFileSync(this.todoPath, YAML.stringify(config))
+  }
+
+  filterOffenses(
+    offenses: LintOffense[],
+    filePath: string,
+  ): LintOffense[] {
+    if (!this.todoConfig) return offenses
+
+    const relativePath = isAbsolute(filePath) ? relative(this.projectPath, filePath): filePath
+    const filteredOffenses: LintOffense[] = []
+
+    const ruleOffensesCounts = new Map<LinterRule, { error: number; warning: number }>()
+
+    for (const offense of offenses) {
+      if (offense.severity !== "error" && offense.severity !== "warning") {
+        filteredOffenses.push(offense)
+        continue
+      }
+
+      const ruleEntry = this.todoConfig.excludes[offense.rule]
+      const ruleBaseline = ruleEntry ? ruleEntry[relativePath] : undefined
+
+      if (!ruleBaseline) {
+        filteredOffenses.push(offense)
+        continue
+      }
+
+      if (!ruleOffensesCounts.has(offense.rule)) {
+        ruleOffensesCounts.set(offense.rule, { error: 0, warning: 0 })
+      }
+
+      const ruleCounts = ruleOffensesCounts.get(offense.rule)!
+
+      if (ruleCounts[offense.severity] < ruleBaseline[offense.severity]) {
+        ruleCounts[offense.severity]++
+        continue
+      }
+
+      filteredOffenses.push(offense)
+    }
+
+    return filteredOffenses
+  }
+
+  private todoExists(): boolean {
+    return existsSync(this.todoPath)
+  }
+
+  private loadTodoConfig(): void {
+    if (!this.todoExists()) {
+      this.todoConfig = { excludes: {} }
+      return
+    }
+
+    try {
+      const content = readFileSync(this.todoPath, "utf8")
+      const parsed: TodoConfig = YAML.parse(content)
+      this.todoConfig = parsed
+    } catch {
+      console.log(
+        "Warning: Failed to load .herb-todo.yml. Ignoring todo configuration.",
+      )
+      this.todoConfig = { excludes: {} }
+    }
+  }
+}

--- a/javascript/packages/linter/src/types.ts
+++ b/javascript/packages/linter/src/types.ts
@@ -142,6 +142,7 @@ export interface LexerRuleConstructor {
  */
 export interface LintContext {
   fileName: string | undefined
+  generateTodo?: boolean
 }
 
 /**

--- a/javascript/packages/linter/test/linter-todo.test.ts
+++ b/javascript/packages/linter/test/linter-todo.test.ts
@@ -1,0 +1,175 @@
+import { beforeEach, afterEach, expect, describe, test } from "vitest"
+import { mkdtempSync, writeFileSync, rmSync, readFileSync } from "fs"
+import { join } from "path"
+import { tmpdir } from "os"
+import YAML from "yaml"
+
+import { LinterRule, LintOffense, LintSeverity } from "../src/types"
+import { LinterTodo } from "../src/linter-todo"
+import { Location } from "@herb-tools/core"
+
+describe("LinterTodo", () => {
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "herb-test-"))
+  })
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  const createOffense = (
+    rule: LinterRule,
+    severity: LintSeverity,
+  ): LintOffense =>
+    ({
+      rule,
+      message: "",
+      severity,
+      location: Location.from({
+        start: { line: 1, column: 1 },
+        end: { line: 1, column: 2 },
+      }),
+    }) as unknown as LintOffense
+
+  describe("#generateTodoConfig", () => {
+    test("generates a todo config with correct counts", () => {
+      const offenses: Record<string, LintOffense[]> = {
+        "src/test.html.erb": [
+          createOffense("rule1", "error"),
+          createOffense("rule1", "warning"),
+          createOffense("rule1", "warning"),
+          createOffense("rule2", "error"),
+        ],
+      }
+
+      const linterTodo = new LinterTodo(tmpDir)
+
+      linterTodo.generateTodoConfig(offenses)
+
+      const todoContent = YAML.parse(
+        readFileSync(join(tmpDir, ".herb-todo.yml"), "utf8"),
+      )
+      expect(todoContent).toEqual({
+        excludes: {
+          rule1: {
+            "src/test.html.erb": {
+              error: 1,
+              warning: 2,
+            },
+          },
+          rule2: {
+            "src/test.html.erb": {
+              error: 1,
+              warning: 0,
+            },
+          },
+        },
+      })
+    })
+  })
+
+  describe("#filterOffenses", () => {
+    test("ignores offenses within the allowed count", () => {
+      const todoConfig = {
+        excludes: {
+          rule1: {
+            "src/test.html.erb": {
+              error: 1,
+              warning: 2,
+            },
+          },
+        },
+      }
+      writeFileSync(join(tmpDir, ".herb-todo.yml"), YAML.stringify(todoConfig))
+
+      const linterTodo = new LinterTodo(tmpDir)
+
+      const offenses = [
+        createOffense("rule1", "error"),
+        createOffense("rule1", "warning"),
+        createOffense("rule1", "warning"),
+      ]
+
+      const remaining = linterTodo.filterOffenses(
+        offenses,
+        "src/test.html.erb",
+      )
+      expect(remaining).toHaveLength(0)
+    })
+
+    test("reports offenses exceeding the allowed count", () => {
+      const todoConfig = {
+        excludes: {
+          rule1: {
+            "src/test.html.erb": {
+              error: 1,
+              warning: 1,
+            },
+          },
+        },
+      }
+      writeFileSync(join(tmpDir, ".herb-todo.yml"), YAML.stringify(todoConfig))
+
+      const f = new LinterTodo(tmpDir)
+
+      const offenses = [
+        createOffense("rule1", "error"),
+        createOffense("rule1", "error"), // This exceeds the limit
+        createOffense("rule1", "warning"),
+        createOffense("rule1", "warning"), // This exceeds the limit
+      ]
+
+      const remaining = f.filterOffenses(offenses, "src/test.html.erb")
+      expect(remaining).toHaveLength(2)
+      expect(remaining[0].severity).toBe("error")
+      expect(remaining[1].severity).toBe("warning")
+    })
+
+    test("ignores info and hint severities when generating counts", () => {
+      const todoConfig = {
+        excludes: {
+          rule1: {
+            "src/test.html.erb": {
+              error: 1,
+              warning: 1,
+            },
+          },
+        },
+      }
+      writeFileSync(join(tmpDir, ".herb-todo.yml"), YAML.stringify(todoConfig))
+
+      const linterTodo = new LinterTodo(tmpDir)
+
+      const offenses = [
+        createOffense("rule1", "error"),
+        createOffense("rule1", "info"),
+        createOffense("rule1", "hint"),
+      ]
+
+      const remaining = linterTodo.filterOffenses(
+        offenses,
+        "src/test.html.erb",
+      )
+
+      expect(remaining).toHaveLength(2)
+      expect(remaining[0].severity).toBe("info")
+      expect(remaining[1].severity).toBe("hint")
+    })
+
+    test("returns all offenses when no todo config exists", () => {
+      const offenses = [
+        createOffense("rule1", "error"),
+        createOffense("rule1", "warning"),
+      ]
+
+      const linterTodo = new LinterTodo(tmpDir)
+      const remaining = linterTodo.filterOffenses(
+        offenses,
+        "src/test.html.erb",
+      )
+      expect(remaining).toEqual(offenses)
+    })
+  })
+})


### PR DESCRIPTION
Solves #667

Use `--generate-todo` to create a todo list that will ignore all the current offenses based on an offense count. Very similar of how [rubocop does](https://docs.rubocop.org/rubocop/configuration.html#automatically-generated-configuration). 

The implementation writes to a `.herb-todo.yml` file, that stores a map of all the files and rules with the counts of offenses and warnings. When the linter runs, reads from that file and ignore all ocurrences declarated as `exclude`.

The file is not dependant on a Herb Config file, because is autogenerated and can be very big, it should be consider as "private". 

The `--generate-todo` name comes from [standardrb recommendation on todo list.](https://github.com/standardrb/standard?tab=readme-ov-file#ignoring-every-violation-and-converting-them-into-a-todo-list)

Usage:

```bash
herb-lint --regenerate-todo <path> # Creates the file and show the offenses.
herb-lint <path> # Pass the linting without errors nor warnings.
```

## TODO

- [ ] Write documentation

