### PR TITLE
C: Use `hb_string_T` in `parser_check_matching_tag` function

### DIFF
--- a/src/include/parser_helpers.h
+++ b/src/include/parser_helpers.h
@@ -9,7 +9,7 @@
 #include "util/hb_buffer.h"
 
 void parser_push_open_tag(const parser_T* parser, token_T* tag_name);
-bool parser_check_matching_tag(const parser_T* parser, const char* tag_name);
+bool parser_check_matching_tag(const parser_T* parser, hb_string_T tag_name);
 token_T* parser_pop_open_tag(const parser_T* parser);
 
 void parser_append_unexpected_error(

--- a/src/parser.c
+++ b/src/parser.c
@@ -936,7 +936,7 @@ static AST_HTML_ELEMENT_NODE_T* parser_parse_html_regular_element(
     close_tag = parser_parse_html_close_tag(parser);
   }
 
-  bool matches_stack = parser_check_matching_tag(parser, close_tag->tag_name->value);
+  bool matches_stack = parser_check_matching_tag(parser, hb_string_from_c_string(close_tag->tag_name->value));
 
   if (matches_stack) {
     token_T* popped_token = parser_pop_open_tag(parser);

--- a/src/parser_helpers.c
+++ b/src/parser_helpers.c
@@ -18,13 +18,13 @@ void parser_push_open_tag(const parser_T* parser, token_T* tag_name) {
   hb_array_push(parser->open_tags_stack, copy);
 }
 
-bool parser_check_matching_tag(const parser_T* parser, const char* tag_name) {
+bool parser_check_matching_tag(const parser_T* parser, hb_string_T tag_name) {
   if (hb_array_size(parser->open_tags_stack) == 0) { return false; }
 
   token_T* top_token = hb_array_last(parser->open_tags_stack);
   if (top_token == NULL || top_token->value == NULL) { return false; };
 
-  return (strcasecmp(top_token->value, tag_name) == 0);
+  return hb_string_equals(hb_string_from_c_string(top_token->value), tag_name);
 }
 
 token_T* parser_pop_open_tag(const parser_T* parser) {


### PR DESCRIPTION
This PR changes the interface and implementation of `parser_check_matching_tag` to make use of the new `hb_string_T` struct and accompanying functions.