### PR TITLE
Lexer: Handle Memory Leak in `lexer_parse_erb_content`

### DIFF
--- a/src/lexer.c
+++ b/src/lexer.c
@@ -224,7 +224,11 @@ static token_T* lexer_parse_erb_content(lexer_T* lexer) {
 
   while (!lexer_peek_erb_end(lexer, 0)) {
     if (lexer_eof(lexer)) {
-      return token_init(buffer.value, TOKEN_ERROR, lexer); // Handle unexpected EOF
+      token_T* token = token_init(buffer.value, TOKEN_ERROR, lexer); // Handle unexpected EOF
+
+      free(buffer.value);
+
+      return token;
     }
 
     hb_buffer_append_char(&buffer, lexer->current_character);


### PR DESCRIPTION
As discovered by @timkaechele, this pull request fixes a memory leak in the `lexer_parse_erb_content` function when returning early in the `lexer_eof` case.