### PR TITLE
C: Rename `parser_free` to `herb_parser_deinit`

### DIFF
--- a/src/herb.c
+++ b/src/herb.c
@@ -41,7 +41,7 @@ AST_DOCUMENT_NODE_T* herb_parse(const char* source, parser_options_T* options) {
 
   AST_DOCUMENT_NODE_T* document = herb_parser_parse(&parser);
 
-  parser_free(&parser);
+  herb_parser_deinit(&parser);
 
   return document;
 }

--- a/src/include/parser.h
+++ b/src/include/parser.h
@@ -36,6 +36,6 @@ AST_DOCUMENT_NODE_T* herb_parser_parse(parser_T* parser);
 
 size_t parser_sizeof(void);
 
-void parser_free(parser_T* parser);
+void herb_parser_deinit(parser_T* parser);
 
 #endif

--- a/src/parser.c
+++ b/src/parser.c
@@ -1233,7 +1233,7 @@ static void parser_consume_whitespace(parser_T* parser, hb_array_T* children) {
   }
 }
 
-void parser_free(parser_T* parser) {
+void herb_parser_deinit(parser_T* parser) {
   if (parser == NULL) { return; }
 
   if (parser->current_token != NULL) { token_free(parser->current_token); }


### PR DESCRIPTION
This PR namespaces the `parser_free` function and renames it to `parser_deinit`.

Follow up on #691 