### PR TITLE
C: Use `hb_string_T` in `parser_helpers.c` functions

### DIFF
--- a/src/include/parser_helpers.h
+++ b/src/include/parser_helpers.h
@@ -32,12 +32,12 @@ bool parser_in_svg_context(const parser_T* parser);
 
 foreign_content_type_T parser_get_foreign_content_type(hb_string_T tag_name);
 bool parser_is_foreign_content_tag(hb_string_T tag_name);
-const char* parser_get_foreign_content_closing_tag(foreign_content_type_T type);
+hb_string_T parser_get_foreign_content_closing_tag(foreign_content_type_T type);
 
 void parser_enter_foreign_content(parser_T* parser, foreign_content_type_T type);
 void parser_exit_foreign_content(parser_T* parser);
 
-bool parser_is_expected_closing_tag_name(const char* tag_name, foreign_content_type_T expected_type);
+bool parser_is_expected_closing_tag_name(hb_string_T tag_name, foreign_content_type_T expected_type);
 
 token_T* parser_advance(parser_T* parser);
 token_T* parser_consume_if_present(parser_T* parser, token_type_T type);

--- a/src/parser.c
+++ b/src/parser.c
@@ -1022,9 +1022,9 @@ static void parser_parse_foreign_content(parser_T* parser, hb_array_T* children,
   hb_buffer_T content;
   hb_buffer_init(&content, 1024);
   position_T start = parser->current_token->location.start;
-  const char* expected_closing_tag = parser_get_foreign_content_closing_tag(parser->foreign_content_type);
+  hb_string_T expected_closing_tag = parser_get_foreign_content_closing_tag(parser->foreign_content_type);
 
-  if (expected_closing_tag == NULL) {
+  if (hb_string_is_empty(expected_closing_tag)) {
     parser_exit_foreign_content(parser);
     free(content.value);
 
@@ -1050,7 +1050,8 @@ static void parser_parse_foreign_content(parser_T* parser, hb_array_T* children,
       bool is_potential_match = false;
 
       if (next_token && next_token->type == TOKEN_IDENTIFIER && next_token->value) {
-        is_potential_match = parser_is_expected_closing_tag_name(next_token->value, parser->foreign_content_type);
+        is_potential_match =
+          parser_is_expected_closing_tag_name(hb_string_from_c_string(next_token->value), parser->foreign_content_type);
       }
 
       lexer_restore_state(parser->lexer, saved_state);

--- a/src/parser_helpers.c
+++ b/src/parser_helpers.c
@@ -12,7 +12,6 @@
 #include "include/util/hb_string.h"
 
 #include <stdio.h>
-#include <strings.h>
 
 void parser_push_open_tag(const parser_T* parser, token_T* tag_name) {
   token_T* copy = token_copy(tag_name);
@@ -49,7 +48,8 @@ bool parser_in_svg_context(const parser_T* parser) {
     token_T* tag = (token_T*) hb_array_get(parser->open_tags_stack, i);
 
     if (tag && tag->value) {
-      if (strcasecmp(tag->value, "svg") == 0) { return true; }
+      hb_string_T tag_value_string = hb_string_from_c_string(tag->value);
+      if (hb_string_equals(tag_value_string, hb_string_from_c_string("svg"))) { return true; }
     }
   }
 
@@ -71,11 +71,11 @@ bool parser_is_foreign_content_tag(hb_string_T tag_name) {
   return parser_get_foreign_content_type(tag_name) != FOREIGN_CONTENT_UNKNOWN;
 }
 
-const char* parser_get_foreign_content_closing_tag(foreign_content_type_T type) {
+hb_string_T parser_get_foreign_content_closing_tag(foreign_content_type_T type) {
   switch (type) {
-    case FOREIGN_CONTENT_SCRIPT: return "script";
-    case FOREIGN_CONTENT_STYLE: return "style";
-    default: return NULL;
+    case FOREIGN_CONTENT_SCRIPT: return hb_string_from_c_string("script");
+    case FOREIGN_CONTENT_STYLE: return hb_string_from_c_string("style");
+    default: return hb_string_from_c_string("");
   }
 }
 
@@ -212,10 +212,10 @@ void parser_handle_mismatched_tags(
   }
 }
 
-bool parser_is_expected_closing_tag_name(const char* tag_name, foreign_content_type_T expected_type) {
-  const char* expected_tag_name = parser_get_foreign_content_closing_tag(expected_type);
+bool parser_is_expected_closing_tag_name(hb_string_T tag_name, foreign_content_type_T expected_type) {
+  hb_string_T expected_tag_name = parser_get_foreign_content_closing_tag(expected_type);
 
-  if (expected_tag_name == NULL || tag_name == NULL) { return false; }
+  if (hb_string_is_empty(tag_name) || hb_string_is_empty(expected_tag_name)) { return false; }
 
-  return strcmp(tag_name, expected_tag_name) == 0;
+  return hb_string_equals(expected_tag_name, tag_name);
 }


### PR DESCRIPTION
This PR refactors the `parser_get_foreign_content_closing_tag` and `parser_is_expected_closing_tag_name` to use `hb_string_T` instead of c strings.