### PR TITLE
VS Code: Only show `Report Issue` Code Action for Herb Diagnostics

### DIFF
--- a/javascript/packages/vscode/src/code-action-provider.ts
+++ b/javascript/packages/vscode/src/code-action-provider.ts
@@ -7,18 +7,13 @@ export class HerbCodeActionProvider implements vscode.CodeActionProvider {
     context: vscode.CodeActionContext,
     _token: vscode.CancellationToken
   ): vscode.CodeAction[] {
+    if (context.diagnostics.length === 0) {
+      return []
+    }
+
     const actions: vscode.CodeAction[] = []
 
-    if (!document.fileName.endsWith('.html.erb')) {
-      return actions
-    }
-
-    const diagnostics = context.diagnostics
-    if (diagnostics.length === 0) {
-      return actions
-    }
-
-    for (const diagnostic of diagnostics) {
+    for (const diagnostic of context.diagnostics) {
       const source = typeof diagnostic.source === 'string' ? diagnostic.source.trim() : undefined
 
       if (!source || !source.includes('Herb')) {


### PR DESCRIPTION
This pull request changes the VS Code Language Server client to only show the `Report Issue` Code Action when the `diagnostic.source` contains `"Herb"`. 

<img width="50%" height="188" alt="CleanShot 2025-10-20 at 16 31 49@2x" src="https://github.com/user-attachments/assets/0d155c93-2517-4083-9cd4-0241338d68cc" />

This makes it so the Code Action only shows up on diagnostics issued by the Herb Language Server.


Resolves https://github.com/marcoroth/herb/issues/308
Resolves https://github.com/marcoroth/herb/issues/699
