### PR TITLE
C: Use `hb_string_T` in `html_util.c` functions

### DIFF
--- a/src/html_util.c
+++ b/src/html_util.c
@@ -37,25 +37,22 @@ bool is_void_element(hb_string_T tag_name) {
  *
  * Example:
  * @code
- * char* tag = html_closing_tag_string("div");
- * if (tag) {
- *   printf("%s\n", tag); // Prints: </div>
- *   free(tag);
- * }
+ * hb_string_T tag = html_closing_tag_string(hb_string_from_c_string("div"));
+ *
+ * printf("%.*s\n", tag.length, tag.data); // Prints: </div>
+ * free(tag.data);
  * @endcode
  */
-char* html_closing_tag_string(const char* tag_name) {
-  if (tag_name == NULL) { return herb_strdup("</>"); }
-
+hb_string_T html_closing_tag_string(hb_string_T tag_name) {
   hb_buffer_T buffer;
-  hb_buffer_init(&buffer, strlen(tag_name) + 3);
+  hb_buffer_init(&buffer, tag_name.length + 3);
 
   hb_buffer_append_char(&buffer, '<');
   hb_buffer_append_char(&buffer, '/');
-  hb_buffer_append(&buffer, tag_name);
+  hb_buffer_append_string(&buffer, tag_name);
   hb_buffer_append_char(&buffer, '>');
 
-  return buffer.value;
+  return hb_string_from_c_string(buffer.value);
 }
 
 /**
@@ -67,24 +64,20 @@ char* html_closing_tag_string(const char* tag_name) {
  *
  * Example:
  * @code
- * char* tag = html_self_closing_tag_string("br");
- * if (tag) {
- *   printf("%s\n", tag); // Prints: <br />
- *   free(tag);
- * }
+ * hb_string_T tag = html_self_closing_tag_string(hb_string_from_c_string("br"));
+ * printf("%.*s\n", tag.length, tag.data); // Prints: <br />
+ * free(tag);
  * @endcode
  */
-char* html_self_closing_tag_string(const char* tag_name) {
-  if (tag_name == NULL) { return herb_strdup("< />"); }
-
+hb_string_T html_self_closing_tag_string(hb_string_T tag_name) {
   hb_buffer_T buffer;
-  hb_buffer_init(&buffer, strlen(tag_name) + 4);
+  hb_buffer_init(&buffer, tag_name.length + 4);
 
   hb_buffer_append_char(&buffer, '<');
-  hb_buffer_append(&buffer, tag_name);
+  hb_buffer_append_string(&buffer, tag_name);
   hb_buffer_append_char(&buffer, ' ');
   hb_buffer_append_char(&buffer, '/');
   hb_buffer_append_char(&buffer, '>');
 
-  return buffer.value;
+  return hb_string_from_c_string(buffer.value);
 }

--- a/src/include/html_util.h
+++ b/src/include/html_util.h
@@ -6,7 +6,7 @@
 
 bool is_void_element(hb_string_T tag_name);
 
-char* html_closing_tag_string(const char* tag_name);
-char* html_self_closing_tag_string(const char* tag_name);
+hb_string_T html_closing_tag_string(hb_string_T tag_name);
+hb_string_T html_self_closing_tag_string(hb_string_T tag_name);
 
 #endif

--- a/src/parser.c
+++ b/src/parser.c
@@ -11,6 +11,7 @@
 #include "include/util.h"
 #include "include/util/hb_array.h"
 #include "include/util/hb_buffer.h"
+#include "include/util/hb_string.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -859,20 +860,20 @@ static AST_HTML_CLOSE_TAG_NODE_T* parser_parse_html_close_tag(parser_T* parser) 
 
   if (tag_name != NULL && is_void_element(hb_string_from_c_string(tag_name->value))
       && parser_in_svg_context(parser) == false) {
-    char* expected = html_self_closing_tag_string(tag_name->value);
-    char* got = html_closing_tag_string(tag_name->value);
+    hb_string_T expected = html_self_closing_tag_string(hb_string_from_c_string(tag_name->value));
+    hb_string_T got = html_closing_tag_string(hb_string_from_c_string(tag_name->value));
 
     append_void_element_closing_tag_error(
       tag_name,
-      expected,
-      got,
+      expected.data,
+      got.data,
       tag_opening->location.start,
       tag_closing->location.end,
       errors
     );
 
-    free(expected);
-    free(got);
+    free(expected.data);
+    free(got.data);
   }
 
   AST_HTML_CLOSE_TAG_NODE_T* close_tag = ast_html_close_tag_node_init(

--- a/test/c/test_html_util.c
+++ b/test/c/test_html_util.c
@@ -1,26 +1,30 @@
-#include <stdio.h>
-#include "include/test.h"
 #include "../../src/include/herb.h"
 #include "../../src/include/html_util.h"
+#include "include/test.h"
+#include <stdio.h>
 
 TEST(html_util_html_closing_tag_string)
-  ck_assert_str_eq(html_closing_tag_string(NULL), "</>");
-  ck_assert_str_eq(html_closing_tag_string(""), "</>");
-  ck_assert_str_eq(html_closing_tag_string(" "), "</ >");
-  ck_assert_str_eq(html_closing_tag_string("div"), "</div>");
-  ck_assert_str_eq(html_closing_tag_string("somelongerstring"), "</somelongerstring>");
+  ck_assert(hb_string_equals(html_closing_tag_string((hb_string_T) { .data = NULL, .length = 0 }), hb_string_from_c_string("</>")));
+  ck_assert(hb_string_equals(html_closing_tag_string(hb_string_from_c_string("")), hb_string_from_c_string("</>")));
+  ck_assert(hb_string_equals(html_closing_tag_string(hb_string_from_c_string(" ")), hb_string_from_c_string("</ >")));
+  ck_assert(hb_string_equals(html_closing_tag_string(hb_string_from_c_string("div")), hb_string_from_c_string("</div>")));
+
+  ck_assert(hb_string_equals(
+    html_closing_tag_string(hb_string_from_c_string("somelongerstring")),
+    hb_string_from_c_string("</somelongerstring>")
+  ));
 END
 
 TEST(html_util_html_self_closing_tag_string)
-  ck_assert_str_eq(html_self_closing_tag_string(NULL), "< />");
-  ck_assert_str_eq(html_self_closing_tag_string(""), "< />");
-  ck_assert_str_eq(html_self_closing_tag_string(" "), "<  />");
-  ck_assert_str_eq(html_self_closing_tag_string("br"), "<br />");
-  ck_assert_str_eq(html_self_closing_tag_string("somelongerstring"), "<somelongerstring />");
+  ck_assert(hb_string_equals(html_self_closing_tag_string((hb_string_T) { .data = NULL, .length = 0 }), hb_string_from_c_string("< />")));
+  ck_assert(hb_string_equals(html_self_closing_tag_string(hb_string_from_c_string("")), hb_string_from_c_string("< />")));
+  ck_assert(hb_string_equals(html_self_closing_tag_string(hb_string_from_c_string(" ")), hb_string_from_c_string("<  />")));
+  ck_assert(hb_string_equals(html_self_closing_tag_string(hb_string_from_c_string("br")), hb_string_from_c_string("<br />")));
+  ck_assert(hb_string_equals(html_self_closing_tag_string(hb_string_from_c_string("somelongerstring")), hb_string_from_c_string("<somelongerstring />")));
 END
 
-TCase *html_util_tests(void) {
-  TCase *html_util = tcase_create("HTML Util");
+TCase* html_util_tests(void) {
+  TCase* html_util = tcase_create("HTML Util");
 
   tcase_add_test(html_util, html_util_html_closing_tag_string);
   tcase_add_test(html_util, html_util_html_closing_tag_string);


### PR DESCRIPTION
This PR changes all `html_util` functions to use `hb_string_T` instead of c strings. 

