### PR TITLE
C: Rename `hb_string_from_c_string` to `hb_string`

### DIFF
--- a/src/analyze.c
+++ b/src/analyze.c
@@ -53,7 +53,7 @@ static bool analyze_erb_content(const AST_NODE_T* node, void* data) {
     const char* opening = erb_content_node->tag_opening->value;
 
     if (strcmp(opening, "<%%") != 0 && strcmp(opening, "<%%=") != 0 && strcmp(opening, "<%#") != 0) {
-      analyzed_ruby_T* analyzed = herb_analyze_ruby(hb_string_from_c_string(erb_content_node->content->value));
+      analyzed_ruby_T* analyzed = herb_analyze_ruby(hb_string(erb_content_node->content->value));
 
       erb_content_node->parsed = true;
       erb_content_node->valid = analyzed->valid;

--- a/src/html_util.c
+++ b/src/html_util.c
@@ -14,11 +14,9 @@ bool is_void_element(hb_string_T tag_name) {
   if (hb_string_is_empty(tag_name)) { return false; }
 
   hb_string_T void_tags[14] = {
-    hb_string_from_c_string("area"),  hb_string_from_c_string("base"),  hb_string_from_c_string("br"),
-    hb_string_from_c_string("col"),   hb_string_from_c_string("embed"), hb_string_from_c_string("hr"),
-    hb_string_from_c_string("img"),   hb_string_from_c_string("input"), hb_string_from_c_string("link"),
-    hb_string_from_c_string("meta"),  hb_string_from_c_string("param"), hb_string_from_c_string("source"),
-    hb_string_from_c_string("track"), hb_string_from_c_string("wbr"),
+    hb_string("area"),  hb_string("base"),   hb_string("br"),    hb_string("col"),  hb_string("embed"),
+    hb_string("hr"),    hb_string("img"),    hb_string("input"), hb_string("link"), hb_string("meta"),
+    hb_string("param"), hb_string("source"), hb_string("track"), hb_string("wbr"),
   };
 
   for (size_t i = 0; i < 14; i++) {
@@ -37,7 +35,7 @@ bool is_void_element(hb_string_T tag_name) {
  *
  * Example:
  * @code
- * hb_string_T tag = html_closing_tag_string(hb_string_from_c_string("div"));
+ * hb_string_T tag = html_closing_tag_string(hb_string("div"));
  *
  * printf("%.*s\n", tag.length, tag.data); // Prints: </div>
  * free(tag.data);
@@ -52,7 +50,7 @@ hb_string_T html_closing_tag_string(hb_string_T tag_name) {
   hb_buffer_append_string(&buffer, tag_name);
   hb_buffer_append_char(&buffer, '>');
 
-  return hb_string_from_c_string(buffer.value);
+  return hb_string(buffer.value);
 }
 
 /**
@@ -64,7 +62,7 @@ hb_string_T html_closing_tag_string(hb_string_T tag_name) {
  *
  * Example:
  * @code
- * hb_string_T tag = html_self_closing_tag_string(hb_string_from_c_string("br"));
+ * hb_string_T tag = html_self_closing_tag_string(hb_string("br"));
  * printf("%.*s\n", tag.length, tag.data); // Prints: <br />
  * free(tag);
  * @endcode
@@ -79,5 +77,5 @@ hb_string_T html_self_closing_tag_string(hb_string_T tag_name) {
   hb_buffer_append_char(&buffer, '/');
   hb_buffer_append_char(&buffer, '>');
 
-  return hb_string_from_c_string(buffer.value);
+  return hb_string(buffer.value);
 }

--- a/src/include/util/hb_string.h
+++ b/src/include/util/hb_string.h
@@ -12,7 +12,7 @@ typedef struct HB_STRING_STRUCT {
   uint32_t length;
 } hb_string_T;
 
-hb_string_T hb_string_from_c_string(const char* null_terminated_c_string);
+hb_string_T hb_string(const char* null_terminated_c_string);
 hb_string_T hb_string_slice(hb_string_T string, uint32_t offset);
 bool hb_string_equals(hb_string_T a, hb_string_T b);
 bool hb_string_equals_case_insensitive(hb_string_T a, hb_string_T b);

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -33,9 +33,9 @@ static bool lexer_stalled(lexer_T* lexer) {
 
 void lexer_init(lexer_T* lexer, const char* source) {
   if (source != NULL) {
-    lexer->source = hb_string_from_c_string(source);
+    lexer->source = hb_string(source);
   } else {
-    lexer->source = hb_string_from_c_string("");
+    lexer->source = hb_string("");
   }
 
   lexer->current_character = lexer->source.data[0];

--- a/src/lexer_peek_helpers.c
+++ b/src/lexer_peek_helpers.c
@@ -28,43 +28,43 @@ bool lexer_peek_for(const lexer_T* lexer, uint32_t offset, hb_string_T pattern, 
 }
 
 bool lexer_peek_for_doctype(const lexer_T* lexer, uint32_t offset) {
-  return lexer_peek_for(lexer, offset, hb_string_from_c_string("<!DOCTYPE"), true);
+  return lexer_peek_for(lexer, offset, hb_string("<!DOCTYPE"), true);
 }
 
 bool lexer_peek_for_xml_declaration(const lexer_T* lexer, uint32_t offset) {
-  return lexer_peek_for(lexer, offset, hb_string_from_c_string("<?xml"), true);
+  return lexer_peek_for(lexer, offset, hb_string("<?xml"), true);
 }
 
 bool lexer_peek_for_cdata_start(const lexer_T* lexer, uint32_t offset) {
-  return lexer_peek_for(lexer, offset, hb_string_from_c_string("<![CDATA["), false);
+  return lexer_peek_for(lexer, offset, hb_string("<![CDATA["), false);
 }
 
 bool lexer_peek_for_cdata_end(const lexer_T* lexer, uint32_t offset) {
-  return lexer_peek_for(lexer, offset, hb_string_from_c_string("]]>"), false);
+  return lexer_peek_for(lexer, offset, hb_string("]]>"), false);
 }
 
 bool lexer_peek_for_html_comment_start(const lexer_T* lexer, uint32_t offset) {
-  return lexer_peek_for(lexer, offset, hb_string_from_c_string("<!--"), false);
+  return lexer_peek_for(lexer, offset, hb_string("<!--"), false);
 }
 
 bool lexer_peek_for_html_comment_end(const lexer_T* lexer, uint32_t offset) {
-  return lexer_peek_for(lexer, offset, hb_string_from_c_string("-->"), false);
+  return lexer_peek_for(lexer, offset, hb_string("-->"), false);
 }
 
 bool lexer_peek_erb_close_tag(const lexer_T* lexer, uint32_t offset) {
-  return lexer_peek_for(lexer, offset, hb_string_from_c_string("%>"), false);
+  return lexer_peek_for(lexer, offset, hb_string("%>"), false);
 }
 
 bool lexer_peek_erb_dash_close_tag(const lexer_T* lexer, uint32_t offset) {
-  return lexer_peek_for(lexer, offset, hb_string_from_c_string("-%>"), false);
+  return lexer_peek_for(lexer, offset, hb_string("-%>"), false);
 }
 
 bool lexer_peek_erb_percent_close_tag(const lexer_T* lexer, uint32_t offset) {
-  return lexer_peek_for(lexer, offset, hb_string_from_c_string("%%>"), false);
+  return lexer_peek_for(lexer, offset, hb_string("%%>"), false);
 }
 
 bool lexer_peek_erb_equals_close_tag(const lexer_T* lexer, uint32_t offset) {
-  return lexer_peek_for(lexer, offset, hb_string_from_c_string("=%>"), false);
+  return lexer_peek_for(lexer, offset, hb_string("=%>"), false);
 }
 
 bool lexer_peek_erb_end(const lexer_T* lexer, uint32_t offset) {

--- a/src/parser.c
+++ b/src/parser.c
@@ -858,10 +858,9 @@ static AST_HTML_CLOSE_TAG_NODE_T* parser_parse_html_close_tag(parser_T* parser) 
 
   token_T* tag_closing = parser_consume_expected(parser, TOKEN_HTML_TAG_END, errors);
 
-  if (tag_name != NULL && is_void_element(hb_string_from_c_string(tag_name->value))
-      && parser_in_svg_context(parser) == false) {
-    hb_string_T expected = html_self_closing_tag_string(hb_string_from_c_string(tag_name->value));
-    hb_string_T got = html_closing_tag_string(hb_string_from_c_string(tag_name->value));
+  if (tag_name != NULL && is_void_element(hb_string(tag_name->value)) && parser_in_svg_context(parser) == false) {
+    hb_string_T expected = html_self_closing_tag_string(hb_string(tag_name->value));
+    hb_string_T got = html_closing_tag_string(hb_string(tag_name->value));
 
     append_void_element_closing_tag_error(
       tag_name,
@@ -920,9 +919,8 @@ static AST_HTML_ELEMENT_NODE_T* parser_parse_html_regular_element(
 
   parser_push_open_tag(parser, open_tag->tag_name);
 
-  if (open_tag->tag_name->value && parser_is_foreign_content_tag(hb_string_from_c_string(open_tag->tag_name->value))) {
-    foreign_content_type_T content_type =
-      parser_get_foreign_content_type(hb_string_from_c_string(open_tag->tag_name->value));
+  if (open_tag->tag_name->value && parser_is_foreign_content_tag(hb_string(open_tag->tag_name->value))) {
+    foreign_content_type_T content_type = parser_get_foreign_content_type(hb_string(open_tag->tag_name->value));
     parser_enter_foreign_content(parser, content_type);
     parser_parse_foreign_content(parser, body, errors);
   } else {
@@ -933,13 +931,13 @@ static AST_HTML_ELEMENT_NODE_T* parser_parse_html_regular_element(
 
   AST_HTML_CLOSE_TAG_NODE_T* close_tag = parser_parse_html_close_tag(parser);
 
-  if (parser_in_svg_context(parser) == false && is_void_element(hb_string_from_c_string(close_tag->tag_name->value))) {
+  if (parser_in_svg_context(parser) == false && is_void_element(hb_string(close_tag->tag_name->value))) {
     hb_array_push(body, close_tag);
     parser_parse_in_data_state(parser, body, errors);
     close_tag = parser_parse_html_close_tag(parser);
   }
 
-  bool matches_stack = parser_check_matching_tag(parser, hb_string_from_c_string(close_tag->tag_name->value));
+  bool matches_stack = parser_check_matching_tag(parser, hb_string(close_tag->tag_name->value));
 
   if (matches_stack) {
     token_T* popped_token = parser_pop_open_tag(parser);
@@ -968,8 +966,7 @@ static AST_HTML_ELEMENT_NODE_T* parser_parse_html_element(parser_T* parser) {
   if (open_tag->is_void) { return parser_parse_html_self_closing_element(parser, open_tag); }
 
   // <tag>, in void element list, and not in inside an <svg> element
-  if (!open_tag->is_void && is_void_element(hb_string_from_c_string(open_tag->tag_name->value))
-      && !parser_in_svg_context(parser)) {
+  if (!open_tag->is_void && is_void_element(hb_string(open_tag->tag_name->value)) && !parser_in_svg_context(parser)) {
     return parser_parse_html_self_closing_element(parser, open_tag);
   }
 
@@ -1052,7 +1049,7 @@ static void parser_parse_foreign_content(parser_T* parser, hb_array_T* children,
 
       if (next_token && next_token->type == TOKEN_IDENTIFIER && next_token->value) {
         is_potential_match =
-          parser_is_expected_closing_tag_name(hb_string_from_c_string(next_token->value), parser->foreign_content_type);
+          parser_is_expected_closing_tag_name(hb_string(next_token->value), parser->foreign_content_type);
       }
 
       lexer_restore_state(parser->lexer, saved_state);
@@ -1174,7 +1171,7 @@ static void parser_parse_stray_closing_tags(parser_T* parser, hb_array_T* childr
 
     AST_HTML_CLOSE_TAG_NODE_T* close_tag = parser_parse_html_close_tag(parser);
 
-    if (!is_void_element(hb_string_from_c_string(close_tag->tag_name->value))) {
+    if (!is_void_element(hb_string(close_tag->tag_name->value))) {
       append_missing_opening_tag_error(
         close_tag->tag_name,
         close_tag->base.location.start,

--- a/src/parser_helpers.c
+++ b/src/parser_helpers.c
@@ -24,7 +24,7 @@ bool parser_check_matching_tag(const parser_T* parser, hb_string_T tag_name) {
   token_T* top_token = hb_array_last(parser->open_tags_stack);
   if (top_token == NULL || top_token->value == NULL) { return false; };
 
-  return hb_string_equals(hb_string_from_c_string(top_token->value), tag_name);
+  return hb_string_equals(hb_string(top_token->value), tag_name);
 }
 
 token_T* parser_pop_open_tag(const parser_T* parser) {
@@ -48,8 +48,8 @@ bool parser_in_svg_context(const parser_T* parser) {
     token_T* tag = (token_T*) hb_array_get(parser->open_tags_stack, i);
 
     if (tag && tag->value) {
-      hb_string_T tag_value_string = hb_string_from_c_string(tag->value);
-      if (hb_string_equals(tag_value_string, hb_string_from_c_string("svg"))) { return true; }
+      hb_string_T tag_value_string = hb_string(tag->value);
+      if (hb_string_equals(tag_value_string, hb_string("svg"))) { return true; }
     }
   }
 
@@ -61,8 +61,8 @@ bool parser_in_svg_context(const parser_T* parser) {
 foreign_content_type_T parser_get_foreign_content_type(hb_string_T tag_name) {
   if (hb_string_is_empty(tag_name)) { return FOREIGN_CONTENT_UNKNOWN; }
 
-  if (hb_string_equals(tag_name, hb_string_from_c_string("script"))) { return FOREIGN_CONTENT_SCRIPT; }
-  if (hb_string_equals(tag_name, hb_string_from_c_string("style"))) { return FOREIGN_CONTENT_STYLE; }
+  if (hb_string_equals(tag_name, hb_string("script"))) { return FOREIGN_CONTENT_SCRIPT; }
+  if (hb_string_equals(tag_name, hb_string("style"))) { return FOREIGN_CONTENT_STYLE; }
 
   return FOREIGN_CONTENT_UNKNOWN;
 }
@@ -73,9 +73,9 @@ bool parser_is_foreign_content_tag(hb_string_T tag_name) {
 
 hb_string_T parser_get_foreign_content_closing_tag(foreign_content_type_T type) {
   switch (type) {
-    case FOREIGN_CONTENT_SCRIPT: return hb_string_from_c_string("script");
-    case FOREIGN_CONTENT_STYLE: return hb_string_from_c_string("style");
-    default: return hb_string_from_c_string("");
+    case FOREIGN_CONTENT_SCRIPT: return hb_string("script");
+    case FOREIGN_CONTENT_STYLE: return hb_string("style");
+    default: return hb_string("");
   }
 }
 

--- a/src/pretty_print.c
+++ b/src/pretty_print.c
@@ -53,7 +53,7 @@ void pretty_print_quoted_property(
   const bool last_property,
   hb_buffer_T* buffer
 ) {
-  hb_string_T quoted = quoted_string(hb_string_from_c_string(value));
+  hb_string_T quoted = quoted_string(hb_string(value));
   pretty_print_property(name, quoted.data, indent, relative_indent, last_property, buffer);
   free(quoted.data);
 }
@@ -213,7 +213,7 @@ void pretty_print_token_property(
   pretty_print_label(name, indent, relative_indent, last_property, buffer);
 
   if (token != NULL && token->value != NULL) {
-    hb_string_T quoted = quoted_string(hb_string_from_c_string(token->value));
+    hb_string_T quoted = quoted_string(hb_string(token->value));
     hb_buffer_append_string(buffer, quoted);
     free(quoted.data);
 
@@ -240,7 +240,7 @@ void pretty_print_string_property(
 
   if (string != NULL) {
     escaped = escape_newlines(string);
-    quoted = quoted_string(hb_string_from_c_string(escaped));
+    quoted = quoted_string(hb_string(escaped));
     value = quoted.data;
   }
 

--- a/src/util.c
+++ b/src/util.c
@@ -44,7 +44,7 @@ static hb_string_T wrap_string(hb_string_T input, char character) {
   hb_buffer_append_string(&buffer, input);
   hb_buffer_append_char(&buffer, character);
 
-  return hb_string_from_c_string(buffer.value);
+  return hb_string(buffer.value);
 }
 
 hb_string_T quoted_string(hb_string_T input) {

--- a/src/util/hb_string.c
+++ b/src/util/hb_string.c
@@ -4,7 +4,7 @@
 #include <string.h>
 #include <strings.h>
 
-hb_string_T hb_string_from_c_string(const char* null_terminated_c_string) {
+hb_string_T hb_string(const char* null_terminated_c_string) {
   hb_string_T string;
 
   string.data = (char*) null_terminated_c_string;

--- a/test/c/test_hb_buffer.c
+++ b/test/c/test_hb_buffer.c
@@ -68,7 +68,7 @@ TEST(test_hb_buffer_append_string)
   hb_buffer_T buffer;
   hb_buffer_init(&buffer, 1);
 
-  hb_buffer_append_string(&buffer, hb_string_from_c_string("Hello, world"));
+  hb_buffer_append_string(&buffer, hb_string("Hello, world"));
 
   ck_assert_str_eq(buffer.value, "Hello, world");
   ck_assert_int_eq(buffer.length, 12);

--- a/test/c/test_hb_string.c
+++ b/test/c/test_hb_string.c
@@ -4,22 +4,22 @@
 
 TEST(hb_string_equals_tests)
   {
-    hb_string_T a = hb_string_from_c_string("Hello, world.");
-    hb_string_T b = hb_string_from_c_string("Hello, world.");
+    hb_string_T a = hb_string("Hello, world.");
+    hb_string_T b = hb_string("Hello, world.");
 
     ck_assert(hb_string_equals(a, b));
   }
 
   {
-    hb_string_T a = hb_string_from_c_string("Hello, world.");
-    hb_string_T b = hb_string_from_c_string("Hello, world. Longer text");
+    hb_string_T a = hb_string("Hello, world.");
+    hb_string_T b = hb_string("Hello, world. Longer text");
 
     ck_assert(!hb_string_equals(a, b));
   }
 
   {
-    hb_string_T a = hb_string_from_c_string("Hello, world.");
-    hb_string_T b = hb_string_from_c_string("");
+    hb_string_T a = hb_string("Hello, world.");
+    hb_string_T b = hb_string("");
 
     ck_assert(!hb_string_equals(a, b));
   }
@@ -27,8 +27,8 @@ END
 
 TEST(hb_string_offset_based_slice_tests)
   {
-    hb_string_T source = hb_string_from_c_string("01234");
-    hb_string_T expected_slice = hb_string_from_c_string("234");
+    hb_string_T source = hb_string("01234");
+    hb_string_T expected_slice = hb_string("234");
 
     hb_string_T slice = hb_string_slice(source, 2);
 
@@ -36,8 +36,8 @@ TEST(hb_string_offset_based_slice_tests)
   }
 
   {
-    hb_string_T source = hb_string_from_c_string("01234");
-    hb_string_T expected_slice = hb_string_from_c_string("4");
+    hb_string_T source = hb_string("01234");
+    hb_string_T expected_slice = hb_string("4");
 
     hb_string_T slice = hb_string_slice(source, 4);
 
@@ -45,14 +45,14 @@ TEST(hb_string_offset_based_slice_tests)
   }
 
   {
-    hb_string_T source = hb_string_from_c_string("01234");
+    hb_string_T source = hb_string("01234");
     hb_string_T slice = hb_string_slice(source, 5);
 
     ck_assert(hb_string_is_empty(slice));
   }
 
   {
-    hb_string_T source = hb_string_from_c_string("01234");
+    hb_string_T source = hb_string("01234");
     hb_string_T slice = hb_string_slice(source, 6);
 
     ck_assert(hb_string_is_empty(slice));
@@ -62,22 +62,22 @@ END
 
 TEST(hb_string_equals_case_insensitive_tests)
   {
-    hb_string_T a = hb_string_from_c_string("Hello, world.");
-    hb_string_T b = hb_string_from_c_string("Hello, World. Really?");
+    hb_string_T a = hb_string("Hello, world.");
+    hb_string_T b = hb_string("Hello, World. Really?");
 
     ck_assert(!hb_string_equals_case_insensitive(a, b));
   }
 
   {
-    hb_string_T a = hb_string_from_c_string("Hello, world.");
-    hb_string_T b = hb_string_from_c_string("Hello, World.");
+    hb_string_T a = hb_string("Hello, world.");
+    hb_string_T b = hb_string("Hello, World.");
 
     ck_assert(hb_string_equals_case_insensitive(a, b));
   }
 
   {
-    hb_string_T a = hb_string_from_c_string("This.");
-    hb_string_T b = hb_string_from_c_string("That.");
+    hb_string_T a = hb_string("This.");
+    hb_string_T b = hb_string("That.");
 
     ck_assert(!hb_string_equals_case_insensitive(a, b));
   }
@@ -94,13 +94,13 @@ TEST(hb_string_is_empty_tests)
   }
 
   {
-    hb_string_T str = hb_string_from_c_string("");
+    hb_string_T str = hb_string("");
 
     ck_assert(hb_string_is_empty(str));
   }
 
   {
-    hb_string_T str = hb_string_from_c_string("Content");
+    hb_string_T str = hb_string("Content");
 
     ck_assert(!hb_string_is_empty(str));
   }
@@ -108,7 +108,7 @@ END
 
 TEST(hb_string_starts_with_tests)
   {
-    hb_string_T str = hb_string_from_c_string("This.");
+    hb_string_T str = hb_string("This.");
     hb_string_T prefix = {
       .length = 0,
       .data = NULL,
@@ -122,35 +122,35 @@ TEST(hb_string_starts_with_tests)
       .length = 0,
       .data = NULL,
     };
-    hb_string_T prefix = hb_string_from_c_string("This.");
+    hb_string_T prefix = hb_string("This.");
 
     ck_assert(!hb_string_starts_with(str, prefix));
   }
 
   {
-    hb_string_T str = hb_string_from_c_string("Long text.");
-    hb_string_T prefix = hb_string_from_c_string("Long text.");
+    hb_string_T str = hb_string("Long text.");
+    hb_string_T prefix = hb_string("Long text.");
 
     ck_assert(hb_string_starts_with(str, prefix));
   }
 
   {
-    hb_string_T str = hb_string_from_c_string("Long text.");
-    hb_string_T prefix = hb_string_from_c_string("Long");
+    hb_string_T str = hb_string("Long text.");
+    hb_string_T prefix = hb_string("Long");
 
     ck_assert(hb_string_starts_with(str, prefix));
   }
 
   {
-    hb_string_T str = hb_string_from_c_string("Long text.");
-    hb_string_T prefix = hb_string_from_c_string("No");
+    hb_string_T str = hb_string("Long text.");
+    hb_string_T prefix = hb_string("No");
 
     ck_assert(!hb_string_starts_with(str, prefix));
   }
 
   {
-    hb_string_T str = hb_string_from_c_string("Long text.");
-    hb_string_T prefix = hb_string_from_c_string("This prefix is longer than the text");
+    hb_string_T str = hb_string("Long text.");
+    hb_string_T prefix = hb_string("This prefix is longer than the text");
 
     ck_assert(!hb_string_starts_with(str, prefix));
   }

--- a/test/c/test_html_util.c
+++ b/test/c/test_html_util.c
@@ -4,23 +4,23 @@
 #include <stdio.h>
 
 TEST(html_util_html_closing_tag_string)
-  ck_assert(hb_string_equals(html_closing_tag_string((hb_string_T) { .data = NULL, .length = 0 }), hb_string_from_c_string("</>")));
-  ck_assert(hb_string_equals(html_closing_tag_string(hb_string_from_c_string("")), hb_string_from_c_string("</>")));
-  ck_assert(hb_string_equals(html_closing_tag_string(hb_string_from_c_string(" ")), hb_string_from_c_string("</ >")));
-  ck_assert(hb_string_equals(html_closing_tag_string(hb_string_from_c_string("div")), hb_string_from_c_string("</div>")));
+  ck_assert(hb_string_equals(html_closing_tag_string((hb_string_T) { .data = NULL, .length = 0 }), hb_string("</>")));
+  ck_assert(hb_string_equals(html_closing_tag_string(hb_string("")), hb_string("</>")));
+  ck_assert(hb_string_equals(html_closing_tag_string(hb_string(" ")), hb_string("</ >")));
+  ck_assert(hb_string_equals(html_closing_tag_string(hb_string("div")), hb_string("</div>")));
 
   ck_assert(hb_string_equals(
-    html_closing_tag_string(hb_string_from_c_string("somelongerstring")),
-    hb_string_from_c_string("</somelongerstring>")
+    html_closing_tag_string(hb_string("somelongerstring")),
+    hb_string("</somelongerstring>")
   ));
 END
 
 TEST(html_util_html_self_closing_tag_string)
-  ck_assert(hb_string_equals(html_self_closing_tag_string((hb_string_T) { .data = NULL, .length = 0 }), hb_string_from_c_string("< />")));
-  ck_assert(hb_string_equals(html_self_closing_tag_string(hb_string_from_c_string("")), hb_string_from_c_string("< />")));
-  ck_assert(hb_string_equals(html_self_closing_tag_string(hb_string_from_c_string(" ")), hb_string_from_c_string("<  />")));
-  ck_assert(hb_string_equals(html_self_closing_tag_string(hb_string_from_c_string("br")), hb_string_from_c_string("<br />")));
-  ck_assert(hb_string_equals(html_self_closing_tag_string(hb_string_from_c_string("somelongerstring")), hb_string_from_c_string("<somelongerstring />")));
+  ck_assert(hb_string_equals(html_self_closing_tag_string((hb_string_T) { .data = NULL, .length = 0 }), hb_string("< />")));
+  ck_assert(hb_string_equals(html_self_closing_tag_string(hb_string("")), hb_string("< />")));
+  ck_assert(hb_string_equals(html_self_closing_tag_string(hb_string(" ")), hb_string("<  />")));
+  ck_assert(hb_string_equals(html_self_closing_tag_string(hb_string("br")), hb_string("<br />")));
+  ck_assert(hb_string_equals(html_self_closing_tag_string(hb_string("somelongerstring")), hb_string("<somelongerstring />")));
 END
 
 TCase* html_util_tests(void) {


### PR DESCRIPTION
This pull request renames the `hb_string_from_c_string` function to just `hb_string` which makes it a bit easier and more natural to read.