### PR TITLE
C: Implement page-based architecture for Arena Allocator

### DIFF
--- a/src/include/macros.h
+++ b/src/include/macros.h
@@ -5,6 +5,10 @@
 
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
 
+#define KB(kb) (1024 * kb)
+
+#define MB(mb) (1024 * KB(mb))
+
 #define unlikely(x) __builtin_expect(!!(x), 0)
 
 #endif

--- a/src/include/util/hb_arena.h
+++ b/src/include/util/hb_arena.h
@@ -4,15 +4,25 @@
 #include <stdbool.h>
 #include <stddef.h>
 
-typedef struct HB_ARENA_ALLOCATOR_STRUCT {
-  char* memory;
+typedef struct HB_ARENA_PAGE_STRUCT hb_arena_page_T;
+
+struct HB_ARENA_PAGE_STRUCT {
+  hb_arena_page_T* next;
   size_t capacity;
   size_t position;
+  char memory[];
+};
+
+typedef struct HB_ARENA_STRUCT {
+  hb_arena_page_T* head;
+  hb_arena_page_T* tail;
+  size_t default_page_size;
 } hb_arena_T;
 
-bool hb_arena_init(hb_arena_T* allocator, size_t size);
+bool hb_arena_init(hb_arena_T* allocator, size_t initial_size);
 void* hb_arena_alloc(hb_arena_T* allocator, size_t size);
 size_t hb_arena_position(hb_arena_T* allocator);
+size_t hb_arena_capacity(hb_arena_T* allocator);
 void hb_arena_reset(hb_arena_T* allocator);
 void hb_arena_reset_to(hb_arena_T* allocator, size_t new_position);
 void hb_arena_free(hb_arena_T* allocator);

--- a/src/util/hb_arena.c
+++ b/src/util/hb_arena.c
@@ -3,60 +3,179 @@
 #endif
 
 #include "../include/util/hb_arena.h"
+#include "../include/macros.h"
 
+#include <assert.h>
 #include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
 #include <sys/mman.h>
 
-#define KB(kb) (1024 * kb)
-#define MB(mb) (1024 * KB(mb))
+#define hb_arena_for_each_page(allocator, page)                                                                        \
+  for (hb_arena_page_T* page = (allocator)->head; page != NULL; page = page->next)
 
-bool hb_arena_init(hb_arena_T* allocator, size_t size) {
-  allocator->memory = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+static inline size_t hb_arena_align_size(size_t size, size_t alignment) {
+  assert(size <= SIZE_MAX - (alignment - 1));
 
-  if (allocator->memory == MAP_FAILED) {
-    allocator->memory = NULL;
-    allocator->position = 0;
-    allocator->capacity = 0;
+  return ((size + (alignment - 1)) / alignment) * alignment;
+}
 
-    return false;
+static inline bool hb_arena_page_has_capacity(hb_arena_page_T* page, size_t required_size) {
+  assert(page->position <= page->capacity);
+
+  return page->position + required_size <= page->capacity;
+}
+
+static inline void* hb_arena_page_alloc_from(hb_arena_page_T* page, size_t size) {
+  assert(size > 0);
+  assert(page->position + size <= page->capacity);
+
+  void* result = &page->memory[page->position];
+  page->position += size;
+
+  return result;
+}
+
+static inline void hb_arena_page_reset(hb_arena_page_T* page) {
+  page->position = 0;
+}
+
+static inline void hb_arena_reset_pages_after(hb_arena_page_T* start_page) {
+  for (hb_arena_page_T* page = start_page; page != NULL; page = page->next) {
+    hb_arena_page_reset(page);
   }
+}
 
-  allocator->position = 0;
-  allocator->capacity = size;
+static bool hb_arena_append_page(hb_arena_T* allocator, size_t minimum_size) {
+  assert(minimum_size > 0);
+
+  size_t page_size = MAX(allocator->default_page_size, minimum_size);
+
+  assert(page_size <= SIZE_MAX - sizeof(hb_arena_page_T));
+  size_t total_size = page_size + sizeof(hb_arena_page_T);
+
+  hb_arena_page_T* page = mmap(NULL, total_size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+
+  if (page == MAP_FAILED) { return false; }
+
+  *page = (hb_arena_page_T) { .next = NULL, .capacity = page_size, .position = 0 };
+
+  if (allocator->head == NULL) {
+    allocator->head = page;
+    allocator->tail = page;
+  } else {
+    hb_arena_page_T* last = allocator->head;
+
+    while (last->next != NULL) {
+      last = last->next;
+    }
+
+    last->next = page;
+    allocator->tail = page;
+  }
 
   return true;
 }
 
+bool hb_arena_init(hb_arena_T* allocator, size_t initial_size) {
+  assert(initial_size > 0);
+
+  allocator->head = NULL;
+  allocator->tail = NULL;
+  allocator->default_page_size = initial_size;
+
+  return hb_arena_append_page(allocator, initial_size);
+}
+
 void* hb_arena_alloc(hb_arena_T* allocator, size_t size) {
-  size_t required_size = ((size + 7) / 8) * 8; // rounds up to the next 8 bytes
+  assert(allocator->tail != NULL);
+  assert(size > 0);
 
-  if (allocator->position + required_size > allocator->capacity) { return NULL; }
+  size_t required_size = hb_arena_align_size(size, 8);
 
-  size_t offset = allocator->position;
-  void* ptr = &allocator->memory[offset];
-  allocator->position += required_size;
+  if (hb_arena_page_has_capacity(allocator->tail, required_size)) {
+    return hb_arena_page_alloc_from(allocator->tail, required_size);
+  }
 
-  return ptr;
+  for (hb_arena_page_T* page = allocator->tail->next; page != NULL; page = page->next) {
+    if (hb_arena_page_has_capacity(page, required_size)) {
+      allocator->tail = page;
+      return hb_arena_page_alloc_from(allocator->tail, required_size);
+    }
+  }
+
+  bool allocated = hb_arena_append_page(allocator, required_size);
+
+  if (!allocated) { return NULL; }
+
+  return hb_arena_page_alloc_from(allocator->tail, required_size);
 }
 
 size_t hb_arena_position(hb_arena_T* allocator) {
-  return allocator->position;
+  size_t total = 0;
+
+  hb_arena_for_each_page(allocator, page) {
+    total += page->position;
+  }
+
+  return total;
+}
+
+size_t hb_arena_capacity(hb_arena_T* allocator) {
+  size_t total = 0;
+
+  hb_arena_for_each_page(allocator, page) {
+    total += page->capacity;
+  }
+
+  return total;
 }
 
 void hb_arena_reset(hb_arena_T* allocator) {
-  allocator->position = 0;
+  hb_arena_for_each_page(allocator, page) {
+    hb_arena_page_reset(page);
+  }
+
+  allocator->tail = allocator->head;
 }
 
-void hb_arena_reset_to(hb_arena_T* allocator, size_t new_position) {
-  if (new_position <= allocator->capacity) { allocator->position = new_position; }
+void hb_arena_reset_to(hb_arena_T* allocator, size_t target_position) {
+  if (target_position == 0) {
+    hb_arena_reset(allocator);
+
+    return;
+  }
+
+  size_t accumulated = 0;
+
+  hb_arena_for_each_page(allocator, page) {
+    if (accumulated + page->capacity >= target_position) {
+      page->position = target_position - accumulated;
+      allocator->tail = page;
+
+      hb_arena_reset_pages_after(page->next);
+
+      return;
+    }
+
+    accumulated += page->capacity;
+    page->position = page->capacity;
+  }
 }
 
 void hb_arena_free(hb_arena_T* allocator) {
-  if (allocator->memory != NULL) {
-    munmap(allocator->memory, allocator->capacity);
+  if (allocator->head == NULL) { return; }
 
-    allocator->memory = NULL;
-    allocator->position = 0;
-    allocator->capacity = 0;
+  for (hb_arena_page_T* current = allocator->head; current != NULL;) {
+    hb_arena_page_T* next = current->next;
+    size_t total_size = sizeof(hb_arena_page_T) + current->capacity;
+
+    munmap(current, total_size);
+
+    current = next;
   }
+
+  allocator->head = NULL;
+  allocator->tail = NULL;
+  allocator->default_page_size = 0;
 }

--- a/test/c/test_hb_arena.c
+++ b/test/c/test_hb_arena.c
@@ -1,38 +1,251 @@
 #include "include/test.h"
 #include "../../src/include/util/hb_arena.h"
 
-// Test appending text to buffer
+#include <string.h>
+
+// Test basic allocation
 TEST(test_arena_alloc)
   hb_arena_T allocator;
 
   hb_arena_init(&allocator, 1024);
-  ck_assert_int_eq(allocator.position, 0);
-  ck_assert_int_eq(allocator.capacity, 1024);
+  ck_assert_ptr_nonnull(allocator.head);
+  ck_assert_ptr_eq(allocator.tail, allocator.head);
+  ck_assert_int_eq(allocator.default_page_size, 1024);
 
   {
-    // Ensure memory is writable
     char *memory = hb_arena_alloc(&allocator, 1);
+    ck_assert_ptr_nonnull(memory);
     *memory = 'a';
+    ck_assert_int_eq(*memory, 'a');
   }
 
-  ck_assert(allocator.position % 8 == 0);
-  ck_assert_int_eq(allocator.position, 8);
+  size_t pos = hb_arena_position(&allocator);
+  ck_assert(pos % 8 == 0);
+  ck_assert_int_eq(pos, 8);
 
-  char *memory = hb_arena_alloc(&allocator, allocator.capacity - allocator.position);
+  char *memory = hb_arena_alloc(&allocator, 100);
   ck_assert_ptr_nonnull(memory);
-  ck_assert(allocator.position % 8 == 0);
+  ck_assert(hb_arena_position(&allocator) % 8 == 0);
+
+  hb_arena_free(&allocator);
 END
 
+// Test page growth when allocation exceeds current page
+TEST(test_arena_page_growth)
+  hb_arena_T allocator;
+  hb_arena_init(&allocator, 64);
+
+  char *memory1 = hb_arena_alloc(&allocator, 32);
+  ck_assert_ptr_nonnull(memory1);
+  ck_assert_ptr_eq(allocator.tail, allocator.head);
+
+  char *memory2 = hb_arena_alloc(&allocator, 64);
+  ck_assert_ptr_nonnull(memory2);
+  ck_assert_ptr_ne(allocator.tail, allocator.head);
+  ck_assert_ptr_nonnull(allocator.head->next);
+
+  memset(memory1, 'A', 32);
+  memset(memory2, 'B', 64);
+  ck_assert_int_eq(memory1[0], 'A');
+  ck_assert_int_eq(memory2[0], 'B');
+
+  hb_arena_free(&allocator);
+END
+
+// Test large allocation that exceeds default page size
+TEST(test_arena_large_allocation)
+  hb_arena_T allocator;
+  hb_arena_init(&allocator, 1024);
+
+  char *large = hb_arena_alloc(&allocator, 8192);
+  ck_assert_ptr_nonnull(large);
+
+  memset(large, 'X', 8192);
+  ck_assert_int_eq(large[0], 'X');
+  ck_assert_int_eq(large[8191], 'X');
+
+  hb_arena_free(&allocator);
+END
+
+// Test reset functionality
+TEST(test_arena_reset)
+  hb_arena_T allocator;
+  hb_arena_init(&allocator, 1024);
+
+  char *memory1 = hb_arena_alloc(&allocator, 100);
+  strcpy(memory1, "first");
+  size_t position1 = hb_arena_position(&allocator);
+  ck_assert_int_eq(position1, 104);
+
+  hb_arena_reset(&allocator);
+  ck_assert_int_eq(hb_arena_position(&allocator), 0);
+  ck_assert_ptr_eq(allocator.tail, allocator.head);
+
+  char *memory2 = hb_arena_alloc(&allocator, 100);
+  ck_assert_ptr_nonnull(memory2);
+  strcpy(memory2, "second");
+  ck_assert_str_eq(memory2, "second");
+
+  hb_arena_free(&allocator);
+END
+
+// Test reset_to functionality
+TEST(test_arena_reset_to)
+  hb_arena_T allocator;
+  hb_arena_init(&allocator, 1024);
+
+  char *memory1 = hb_arena_alloc(&allocator, 100);
+  strcpy(memory1, "checkpoint1");
+  size_t checkpoint = hb_arena_position(&allocator);
+  ck_assert_int_eq(checkpoint, 104);
+
+  char *memory2 = hb_arena_alloc(&allocator, 100);
+  strcpy(memory2, "checkpoint2");
+  ck_assert_int_eq(hb_arena_position(&allocator), 208);
+
+  hb_arena_reset_to(&allocator, checkpoint);
+  ck_assert_int_eq(hb_arena_position(&allocator), checkpoint);
+
+  char *memory3 = hb_arena_alloc(&allocator, 50);
+  ck_assert_ptr_nonnull(memory3);
+  ck_assert_int_eq(hb_arena_position(&allocator), 160);
+
+  hb_arena_free(&allocator);
+END
+
+// Test reset_to with multiple pages
+TEST(test_arena_reset_to_multipage)
+  hb_arena_T allocator;
+  hb_arena_init(&allocator, 64);
+
+  hb_arena_alloc(&allocator, 32);
+  hb_arena_alloc(&allocator, 32);
+
+  size_t checkpoint = hb_arena_position(&allocator);
+
+  hb_arena_alloc(&allocator, 64);
+  ck_assert_ptr_nonnull(allocator.head->next);
+
+  hb_arena_reset_to(&allocator, checkpoint);
+  ck_assert_int_eq(hb_arena_position(&allocator), checkpoint);
+  ck_assert_ptr_eq(allocator.tail, allocator.head);
+
+  hb_arena_free(&allocator);
+END
+
+// Test position tracking across pages
+TEST(test_arena_position_multipage)
+  hb_arena_T allocator;
+  hb_arena_init(&allocator, 64);
+
+  ck_assert_int_eq(hb_arena_position(&allocator), 0);
+
+  hb_arena_alloc(&allocator, 32);
+  ck_assert_int_eq(hb_arena_position(&allocator), 32);
+
+  hb_arena_alloc(&allocator, 32);
+  ck_assert_int_eq(hb_arena_position(&allocator), 64);
+
+  hb_arena_alloc(&allocator, 64);
+  ck_assert_int_eq(hb_arena_position(&allocator), 128);
+
+  hb_arena_free(&allocator);
+END
+
+// Test capacity calculation
+TEST(test_arena_capacity)
+  hb_arena_T allocator;
+
+  hb_arena_init(&allocator, 1024);
+  ck_assert_int_eq(hb_arena_capacity(&allocator), 1024);
+
+  hb_arena_alloc(&allocator, 100);
+  ck_assert_int_eq(hb_arena_capacity(&allocator), 1024);
+
+  hb_arena_alloc(&allocator, 200);
+  ck_assert_int_eq(hb_arena_capacity(&allocator), 1024);
+
+  hb_arena_free(&allocator);
+END
+
+// Test capacity growth with multiple pages
+TEST(test_arena_capacity_multipage)
+  hb_arena_T allocator;
+  hb_arena_init(&allocator, 64);
+
+  size_t initial_capacity = hb_arena_capacity(&allocator);
+  ck_assert_int_eq(initial_capacity, 64);
+
+  hb_arena_alloc(&allocator, 32);
+  ck_assert_int_eq(hb_arena_capacity(&allocator), 64);
+
+  hb_arena_alloc(&allocator, 64);
+  size_t capacity_after_second_page = hb_arena_capacity(&allocator);
+  ck_assert_int_eq(capacity_after_second_page, 64 + 64);
+
+  hb_arena_alloc(&allocator, 64);
+  size_t capacity_after_third_page = hb_arena_capacity(&allocator);
+  ck_assert_int_eq(capacity_after_third_page, 64 + 64 + 64);
+
+  hb_arena_free(&allocator);
+END
+
+// Test capacity with large allocation
+TEST(test_arena_capacity_large_alloc)
+  hb_arena_T allocator;
+  hb_arena_init(&allocator, 64);
+
+  ck_assert_int_eq(hb_arena_capacity(&allocator), 64);
+
+  hb_arena_alloc(&allocator, 1024);
+  size_t new_capacity = hb_arena_capacity(&allocator);
+
+  ck_assert_int_eq(new_capacity, 1024 + 64);
+
+  hb_arena_free(&allocator);
+END
+
+// Test capacity doesn't change on reset
+TEST(test_arena_capacity_after_reset)
+  hb_arena_T allocator;
+  hb_arena_init(&allocator, 64);
+
+  hb_arena_alloc(&allocator, 64);
+  hb_arena_alloc(&allocator, 64);
+
+  size_t capacity_before_reset = hb_arena_capacity(&allocator);
+  ck_assert_int_eq(capacity_before_reset, 128);
+  ck_assert_int_eq(hb_arena_position(&allocator), 128);
+
+  hb_arena_reset(&allocator);
+  ck_assert_int_eq(hb_arena_capacity(&allocator), capacity_before_reset);
+
+  hb_arena_alloc(&allocator, 32);
+  size_t checkpoint = hb_arena_position(&allocator);
+  ck_assert_int_eq(checkpoint, 32);
+
+  hb_arena_alloc(&allocator, 24);
+  ck_assert_int_eq(hb_arena_position(&allocator), 56);
+
+  hb_arena_reset_to(&allocator, checkpoint);
+  ck_assert_int_eq(hb_arena_position(&allocator), checkpoint);
+  ck_assert_int_eq(hb_arena_capacity(&allocator), capacity_before_reset);
+
+  hb_arena_free(&allocator);
+END
+
+// Test free functionality
 TEST(test_arena_free)
   hb_arena_T allocator;
 
   {
     hb_arena_init(&allocator, 1024);
+    hb_arena_alloc(&allocator, 100);
     hb_arena_free(&allocator);
 
-    ck_assert_ptr_null(allocator.memory);
-    ck_assert_int_eq(allocator.capacity, 0);
-    ck_assert_int_eq(allocator.position, 0);
+    ck_assert_ptr_null(allocator.head);
+    ck_assert_ptr_null(allocator.tail);
+    ck_assert_int_eq(allocator.default_page_size, 0);
   }
 
   {
@@ -40,18 +253,122 @@ TEST(test_arena_free)
     hb_arena_free(&allocator);
     hb_arena_free(&allocator);
 
-    ck_assert_ptr_null(allocator.memory);
-    ck_assert_int_eq(allocator.capacity, 0);
-    ck_assert_int_eq(allocator.position, 0);
+    ck_assert_ptr_null(allocator.head);
+    ck_assert_ptr_null(allocator.tail);
+    ck_assert_int_eq(allocator.default_page_size, 0);
   }
 END
 
+// Test free with multiple pages
+TEST(test_arena_free_multipage)
+  hb_arena_T allocator;
+  hb_arena_init(&allocator, 64);
+
+  hb_arena_alloc(&allocator, 64);
+  hb_arena_alloc(&allocator, 64);
+  hb_arena_alloc(&allocator, 64);
+
+  ck_assert_ptr_nonnull(allocator.head->next);
+
+  hb_arena_free(&allocator);
+
+  ck_assert_ptr_null(allocator.head);
+  ck_assert_ptr_null(allocator.tail);
+  ck_assert_int_eq(allocator.default_page_size, 0);
+END
+
+// Test alignment
+TEST(test_arena_alignment)
+  hb_arena_T allocator;
+  hb_arena_init(&allocator, 1024);
+
+  for (size_t size = 1; size <= 17; size++) {
+    void *ptr = hb_arena_alloc(&allocator, size);
+    ck_assert_ptr_nonnull(ptr);
+    ck_assert_int_eq((uintptr_t)ptr % 8, 0);
+  }
+
+  hb_arena_free(&allocator);
+END
+
+// Test page reuse after reset_to
+TEST(test_arena_page_reuse_after_reset)
+  hb_arena_T allocator;
+  hb_arena_init(&allocator, 64);
+
+  hb_arena_alloc(&allocator, 32);
+  size_t checkpoint = hb_arena_position(&allocator);
+  ck_assert_int_eq(checkpoint, 32);
+
+  hb_arena_alloc(&allocator, 64);
+  hb_arena_alloc(&allocator, 64);
+
+  size_t capacity_with_three_pages = hb_arena_capacity(&allocator);
+  ck_assert_int_eq(capacity_with_three_pages, 192);
+
+  hb_arena_reset_to(&allocator, checkpoint);
+  ck_assert_int_eq(hb_arena_position(&allocator), checkpoint);
+  ck_assert_ptr_eq(allocator.tail, allocator.head);
+
+  char *memory = hb_arena_alloc(&allocator, 64);
+  ck_assert_ptr_nonnull(memory);
+  memset(memory, 'R', 64);
+  ck_assert_int_eq(memory[0], 'R');
+
+  size_t capacity_after_reuse = hb_arena_capacity(&allocator);
+  ck_assert_int_eq(capacity_after_reuse, capacity_with_three_pages);
+
+  hb_arena_free(&allocator);
+END
+
+// Test page reuse when next page is too small
+TEST(test_arena_page_reuse_when_next_page_is_too_small)
+  hb_arena_T allocator;
+  hb_arena_init(&allocator, 64);
+
+  hb_arena_alloc(&allocator, 32);
+  size_t checkpoint = hb_arena_position(&allocator);
+
+  hb_arena_alloc(&allocator, 16);
+  hb_arena_alloc(&allocator, 64);
+  hb_arena_alloc(&allocator, 100);
+
+  size_t total_capacity_before = hb_arena_capacity(&allocator);
+
+  hb_arena_reset_to(&allocator, checkpoint);
+
+  char *memory = hb_arena_alloc(&allocator, 80);
+  ck_assert_ptr_nonnull(memory);
+  memset(memory, 'X', 80);
+
+  size_t total_capacity_after = hb_arena_capacity(&allocator);
+  ck_assert_int_eq(total_capacity_after, total_capacity_before);
+
+  char *small = hb_arena_alloc(&allocator, 16);
+  ck_assert_ptr_nonnull(small);
+
+  hb_arena_free(&allocator);
+END
 
 TCase *hb_arena_tests(void) {
-  TCase *tags = tcase_create("arena");
+  TCase *arena = tcase_create("arena");
 
-  tcase_add_test(tags, test_arena_alloc);
-  tcase_add_test(tags, test_arena_free);
+  tcase_add_test(arena, test_arena_alloc);
+  tcase_add_test(arena, test_arena_page_growth);
+  tcase_add_test(arena, test_arena_large_allocation);
+  tcase_add_test(arena, test_arena_reset);
+  tcase_add_test(arena, test_arena_reset_to);
+  tcase_add_test(arena, test_arena_reset_to_multipage);
+  tcase_add_test(arena, test_arena_capacity);
+  tcase_add_test(arena, test_arena_capacity_multipage);
+  tcase_add_test(arena, test_arena_capacity_large_alloc);
+  tcase_add_test(arena, test_arena_capacity_after_reset);
+  tcase_add_test(arena, test_arena_position_multipage);
+  tcase_add_test(arena, test_arena_free);
+  tcase_add_test(arena, test_arena_free_multipage);
+  tcase_add_test(arena, test_arena_alignment);
+  tcase_add_test(arena, test_arena_page_reuse_after_reset);
+  tcase_add_test(arena, test_arena_page_reuse_when_next_page_is_too_small);
 
-  return tags;
+  return arena;
 }


### PR DESCRIPTION
This pull request refactors the `hb_arena_T` from a fixed-size design to a dynamically growing page-based implementation. The previous implementation had a hard capacity limit set at initialization. 

Instead of allocating one huge arena at initialization we now use a linked list of memory pages that grow automatically on demand. This allows us to start with a much smaller footprint and only allocate additional memory as actually needed, even though we are using `mmap`.  When the current page runs out of space, the allocator transparently allocates a new page and continues.

/cc @timkaechele 