### PR TITLE
Playground: Ensure `track_whitespace` parser option persists

### DIFF
--- a/playground/src/controllers/playground_controller.js
+++ b/playground/src/controllers/playground_controller.js
@@ -1020,7 +1020,7 @@ export default class extends Controller {
   }
 
   getOptionsFromURL() {
-    const urlParams = new URLSearchParams(window.location.search)
+    const urlParams = new URLSearchParams(window.parent.location.search)
     const optionsString = urlParams.get('options')
 
     if (optionsString) {
@@ -1035,7 +1035,7 @@ export default class extends Controller {
   }
 
   setOptionsInURL(options) {
-    const url = new URL(window.location)
+    const url = new URL(window.parent.location)
 
     const nonDefaultOptions = {}
 
@@ -1051,11 +1051,11 @@ export default class extends Controller {
       url.searchParams.delete('options')
     }
 
-    window.history.replaceState({}, '', url)
+    window.parent.history.replaceState({}, '', url)
   }
 
   setPrinterOptionsInURL(printerOptions) {
-    const url = new URL(window.location)
+    const url = new URL(window.parent.location)
 
     const nonDefaultPrinterOptions = {}
 
@@ -1071,11 +1071,11 @@ export default class extends Controller {
       url.searchParams.delete('printerOptions')
     }
 
-    window.history.replaceState({}, '', url)
+    window.parent.history.replaceState({}, '', url)
   }
 
   getPrinterOptionsFromURL() {
-    const urlParams = new URLSearchParams(window.location.search)
+    const urlParams = new URLSearchParams(window.parent.location.search)
     const printerOptionsString = urlParams.get('printerOptions')
 
     if (printerOptionsString) {


### PR DESCRIPTION
This pull request updates the `playground_controller` to make sure we don't loose the `track_whitespace` on the deployed version at: https://herb-tools.dev/playground

Since that one is embedded in an `<iframe>` we have to set the params on `window.parent`. When running the playground locally `window.parent` will refer to itself when there is no parent.