### PR TITLE
Dev Tools: Allow to select editor from dropdown

### DIFF
--- a/javascript/packages/dev-tools/src/styles.css
+++ b/javascript/packages/dev-tools/src/styles.css
@@ -429,6 +429,85 @@
   background: #7c3aed;
 }
 
+.herb-editor-section {
+  padding: 16px 20px;
+  border-bottom: 1px solid #f3f4f6;
+  background: linear-gradient(135deg, #fafbfc 0%, #f8f9fa 100%);
+  position: relative;
+  overflow: hidden;
+}
+
+.herb-editor-section::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: linear-gradient(90deg, transparent, rgba(139, 92, 246, 0.2), transparent);
+}
+
+.herb-editor-label {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  cursor: default;
+}
+
+.herb-editor-text {
+  font-size: 12px;
+  font-weight: 600;
+  color: #6b7280;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.herb-editor-select {
+  width: 100%;
+  padding: 10px 36px 10px 12px;
+  background: white;
+  border: 1.5px solid #e5e7eb;
+  border-radius: 8px;
+  font-size: 13.5px;
+  font-weight: 500;
+  color: #1f2937;
+  cursor: pointer;
+  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+  font-family: "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  appearance: none;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+}
+
+.herb-editor-select option {
+  font-family: "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  font-size: 14px;
+  font-weight: 400;
+  padding: 8px 12px;
+}
+
+.herb-editor-select:hover {
+  border-color: #8b5cf6;
+  background-color: #fafafa;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.08), 0 0 0 1px rgba(139, 92, 246, 0.1);
+  transform: translateY(-1px);
+}
+
+.herb-editor-select:focus {
+  outline: none;
+  border-color: #8b5cf6;
+  background-color: white;
+  box-shadow: 0 0 0 3px rgba(139, 92, 246, 0.15), 0 2px 8px rgba(139, 92, 246, 0.1);
+  transform: translateY(-1px);
+}
+
+.herb-editor-select:active {
+  transform: translateY(0);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+}
+
 .herb-disable-all-section {
   padding: 16px 20px;
   border-top: 1px solid #f3f4f6;


### PR DESCRIPTION
This pull request updates the Herb Dev Tools to allow users to select their preferred editor. 

Tools like ReActionView can set a new `<meta name="herb-default-editor">` tag that will be used for the `auto` option, so you can use the new [`ActiveSupport::Editor` in Rails 8.1](https://github.com/rails/rails/blob/b22fd5a519f92e5c51c62e3b74b4407e492b89e2/activesupport/lib/active_support/editor.rb) or fallback to the `RAILS_EDITOR` or `EDITOR` environment variables (see accompanying pull request in ReActionView that sets this: https://github.com/marcoroth/reactionview/pull/51)

<img width="2296" height="1138" alt="CleanShot 2025-10-22 at 15 29 19@2x" src="https://github.com/user-attachments/assets/5219c85e-6150-4ae1-9a8f-59cd2ce4e75e" />

<img width="2296" height="1138" alt="CleanShot 2025-10-22 at 15 29 30@2x" src="https://github.com/user-attachments/assets/8bb91045-9fda-4f89-bb35-42b91287b87d" />


Resolves #599
Resolves #710
Resolves https://github.com/marcoroth/reactionview/issues/3