### PR TITLE
Document an additional behavior of erb-right-trim

### DIFF
--- a/javascript/packages/linter/docs/rules/erb-right-trim.md
+++ b/javascript/packages/linter/docs/rules/erb-right-trim.md
@@ -6,6 +6,8 @@
 
 This rule enforces the use of `-%>` for right-trimming ERB output tags (like `<%= %>`) instead of `=%>`.
 
+Additionally, this rule enforces the use of `%>` instead of `-%>` or `=%>` when right-trimming has no effect.
+
 ## Rationale
 
 While `=%>` can be used for right-trimming whitespace in some ERB engines (like Erubi), it is an obscure and not well-defined syntax that lacks consistent support across most ERB implementations.
@@ -26,6 +28,8 @@ The `-%>` syntax is the standard, well-documented approach for right-trimming th
 <% items.each do |item| %>
   <li><%= item -%></li>
 <% end %>
+
+<%# locals: () %>
 ```
 
 ### 🚫 Bad
@@ -45,6 +49,8 @@ The `-%>` syntax is the standard, well-documented approach for right-trimming th
 <% items.each do |item| =%>
   <li><%= item %></li>
 <% end %>
+
+<%# locals: () -%>
 ```
 
 ## References


### PR DESCRIPTION
erb-right-trim flagged a number of instances where we're using `-%>` when we should be using `%>`. In fixing them, I'd like to be able to link my team to the herb docs where they can read more about the change, but the page doesn't currently mention this behavior of this linter. Seems worth mentioning.

Incidentally, this is the tweak I wanted to make when I noticed https://github.com/marcoroth/herb/issues/716 🙂 