### PR TITLE
C: Implement merging arena pages

### DIFF
--- a/src/util/hb_arena.c
+++ b/src/util/hb_arena.c
@@ -116,6 +116,11 @@ void* hb_arena_alloc(hb_arena_T* allocator, size_t size) {
     }
   }
 
+  size_t page_size = MAX(allocator->default_page_size, required_size);
+  bool allocated = hb_arena_append_page(allocator, page_size);
+
+  if (!allocated) { return NULL; }
+
   return hb_arena_page_alloc(allocator->tail, required_size);
 }
 
@@ -141,6 +146,7 @@ size_t hb_arena_capacity(hb_arena_T* allocator) {
 
 void hb_arena_reset(hb_arena_T* allocator) {
   hb_arena_reset_to(allocator, 0);
+  allocator->allocation_count = 0;
 }
 
 void hb_arena_reset_to(hb_arena_T* allocator, size_t target_position) {
@@ -158,9 +164,12 @@ void hb_arena_reset_to(hb_arena_T* allocator, size_t target_position) {
     current_page = current_page->next;
   }
 
+  if (current_page == NULL) { return; }
+
+  allocator->tail = current_page;
+
   if (current_page->next != NULL) {
     size_t freed_size = hb_arena_page_free(current_page->next);
-    allocator->tail = current_page;
     current_page->next = NULL;
 
     hb_arena_append_page(allocator, freed_size);

--- a/test/c/test_hb_arena.c
+++ b/test/c/test_hb_arena.c
@@ -354,6 +354,42 @@ TEST(test_arena_page_reuse_when_next_page_is_too_small)
   hb_arena_free(&allocator);
 END
 
+// Test reset_to with gap from page fragmentation (position != capacity)
+TEST(test_arena_reset_to_with_page_gap)
+  hb_arena_T allocator;
+  hb_arena_init(&allocator, 4096);
+
+  char *mem1 = hb_arena_alloc(&allocator, 100);
+  ck_assert_ptr_nonnull(mem1);
+  memset(mem1, 'A', 100);
+  ck_assert_int_eq(hb_arena_position(&allocator), 104);
+
+  char *mem2 = hb_arena_alloc(&allocator, 4000);
+  ck_assert_ptr_nonnull(mem2);
+  memset(mem2, 'B', 4000);
+
+  ck_assert_int_eq(allocator.head->position, 104);
+  ck_assert_int_eq(allocator.head->capacity, 4096);
+  ck_assert_ptr_ne(allocator.tail, allocator.head);
+
+  size_t checkpoint = hb_arena_position(&allocator);
+  ck_assert_int_eq(checkpoint, 4104);
+
+  char *mem3 = hb_arena_alloc(&allocator, 64);
+  ck_assert_ptr_nonnull(mem3);
+  memset(mem3, 'C', 64);
+
+  hb_arena_reset_to(&allocator, checkpoint);
+
+  ck_assert_int_eq(allocator.head->position, 104);
+  ck_assert_int_eq(hb_arena_position(&allocator), checkpoint);
+
+  ck_assert_int_eq(mem1[0], 'A');
+  ck_assert_int_eq(mem1[99], 'A');
+
+  hb_arena_free(&allocator);
+END
+
 TCase *hb_arena_tests(void) {
   TCase *arena = tcase_create("arena");
 
@@ -373,6 +409,7 @@ TCase *hb_arena_tests(void) {
   tcase_add_test(arena, test_arena_alignment);
   tcase_add_test(arena, test_arena_page_reuse_after_reset);
   tcase_add_test(arena, test_arena_page_reuse_when_next_page_is_too_small);
+  tcase_add_test(arena, test_arena_reset_to_with_page_gap);
 
   return arena;
 }


### PR DESCRIPTION
Based on the arena pages proposed in #708 by @marcoroth, this PR builds on the concept and adds a more refined reset behavior that merges obsolete pages into one big page.

This has the advantage that we won't have a bunch of small pages, and instead have more contiguous memory available.

## How it works

```
# Initial state
| Page 1 (4kb) | - next > | Page 2 (4kb) | - next > | Page 1 (16kb) | 

# reset to  4kb
| Page 1 (4kb) | - next > | Page 2 (24kb) |

# reset to 0kb
| Page 1 (4kb) | - next > | Page 2 (24kb) |
```

For now the first page is never deallocated and merged into a bigger page for two reasons:

1. It's an edge case that needs to be handled.
2. If the allocation of a new arena page fails at least you still have the first page. 🤷‍♂️ 

Related: #1155