### PR TITLE
Engine: Add support for customizing escape functions

### DIFF
--- a/Steepfile
+++ b/Steepfile
@@ -6,9 +6,10 @@ target :lib do
   check "lib"
 
   library "delegate"
+  library "digest"
   library "json"
-  library "tempfile"
   library "pathname"
+  library "tempfile"
 
   ignore "lib/herb/cli.rb"
   ignore "lib/herb/libherb.rb"

--- a/lib/herb/engine.rb
+++ b/lib/herb/engine.rb
@@ -43,7 +43,7 @@ module Herb
 
       @bufvar = properties[:bufvar] || properties[:outvar] || "_buf"
       @escape = properties.fetch(:escape) { properties.fetch(:escape_html, false) }
-      @escapefunc = properties[:escapefunc]
+      @escapefunc = properties.fetch(:escapefunc, @escape ? "__herb.h" : "::Herb::Engine.h")
       @src = properties[:src] || String.new
       @chain_appends = properties[:chain_appends]
       @buffer_on_stack = false
@@ -66,12 +66,6 @@ module Herb
         raise ArgumentError,
               "validation_mode must be one of :raise, :overlay, or :none, got #{@validation_mode.inspect}"
       end
-
-      @escapefunc ||= if @escape
-                        "__herb.h"
-                      else
-                        "::Herb::Engine.h"
-                      end
 
       @freeze = properties[:freeze]
       @freeze_template_literals = properties.fetch(:freeze_template_literals, true)

--- a/lib/herb/engine/compiler.rb
+++ b/lib/herb/engine/compiler.rb
@@ -10,6 +10,9 @@ module Herb
 
         @engine = engine
         @escape = options.fetch(:escape) { options.fetch(:escape_html, false) }
+        @attrfunc = options.fetch(:attrfunc, @escape ? "__herb.attr" : "::Herb::Engine.attr")
+        @jsfunc = options.fetch(:jsfunc, @escape ? "__herb.js" : "::Herb::Engine.js")
+        @cssfunc = options.fetch(:cssfunc, @escape ? "__herb.css" : "::Herb::Engine.css")
         @tokens = [] #: Array[untyped]
         @element_stack = [] #: Array[String]
         @context_stack = [:html_content]
@@ -294,11 +297,17 @@ module Herb
       def add_context_aware_expression(code, context)
         case context
         when :attribute_value
-          @engine.send(:with_buffer) { @engine.instance_variable_get(:@src) << " << ::Herb::Engine.attr((" << code << "))" }
+          @engine.send(:with_buffer) {
+            @engine.src << " << #{@attrfunc}((" << code << "))"
+          }
         when :script_content
-          @engine.send(:with_buffer) { @engine.instance_variable_get(:@src) << " << ::Herb::Engine.js((" << code << "))" }
+          @engine.send(:with_buffer) {
+            @engine.src << " << #{@jsfunc}((" << code << "))"
+          }
         when :style_content
-          @engine.send(:with_buffer) { @engine.instance_variable_get(:@src) << " << ::Herb::Engine.css((" << code << "))" }
+          @engine.send(:with_buffer) {
+            @engine.src << " << #{@cssfunc}((" << code << "))"
+          }
         else
           @engine.send(:add_expression_result_escaped, code)
         end

--- a/lib/herb/engine/parser_error_overlay.rb
+++ b/lib/herb/engine/parser_error_overlay.rb
@@ -529,7 +529,7 @@ module Herb
           HTML
         end
 
-        section_id = "suggestions-#{rand(1000)}"
+        section_id = "suggestions-#{Digest::MD5.hexdigest(suggestions.inspect)}"
 
         <<~HTML
           <div class="herb-section">

--- a/test/engine/escape_test.rb
+++ b/test/engine/escape_test.rb
@@ -1,0 +1,191 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+require_relative "../snapshot_utils"
+require_relative "../../lib/herb/engine"
+
+module Engine
+  class EscapeTest < Minitest::Spec
+    include SnapshotUtils
+
+    context "escape ERB output tag" do
+      template = %(<h1><%= value %></h1>)
+
+      test "default" do
+        assert_compiled_snapshot(template)
+      end
+
+      test "escape: true" do
+        assert_compiled_snapshot(template, escape: true)
+      end
+
+      test "custom escapefunc" do
+        assert_compiled_snapshot(template, escapefunc: "CustomEscape.h")
+      end
+
+      test "empty escapefunc" do
+        assert_compiled_snapshot(template, escapefunc: "")
+      end
+
+      test "escape: true and custom escapefunc" do
+        assert_compiled_snapshot(template, escape: true, escapefunc: "CustomEscape.h")
+      end
+
+      test "escape: true and empty escapefunc" do
+        assert_compiled_snapshot(template, escape: true, escapefunc: "")
+      end
+
+      test "escape: false and custom escapefunc" do
+        assert_compiled_snapshot(template, escape: false, escapefunc: "CustomEscape.h")
+      end
+
+      test "escape: false and empty escapefunc" do
+        assert_compiled_snapshot(template, escape: false, attrfunc: "")
+      end
+    end
+
+    context "escape ERB raw output tag" do
+      template = %(<h1><%== value %></h1>)
+
+      test "default" do
+        assert_compiled_snapshot(template)
+      end
+
+      test "escape: true" do
+        assert_compiled_snapshot(template, escape: true)
+      end
+
+      test "custom escapefunc" do
+        assert_compiled_snapshot(template, escapefunc: "CustomEscape.h")
+      end
+
+      test "empty escapefunc" do
+        assert_compiled_snapshot(template, escapefunc: "")
+      end
+
+      test "escape: true and custom escapefunc" do
+        assert_compiled_snapshot(template, escape: true, escapefunc: "CustomEscape.h")
+      end
+
+      test "escape: true and empty escapefunc" do
+        assert_compiled_snapshot(template, escape: true, escapefunc: "")
+      end
+
+      test "escape: false and custom escapefunc" do
+        assert_compiled_snapshot(template, escape: false, escapefunc: "CustomEscape.h")
+      end
+
+      test "escape: false and empty escapefunc" do
+        assert_compiled_snapshot(template, escape: false, escapefunc: "")
+      end
+    end
+
+    context "attributes" do
+      template = %(<div class="<%= value %>"></div>)
+
+      test "default" do
+        assert_compiled_snapshot(template)
+      end
+
+      test "escape: true" do
+        assert_compiled_snapshot(template, escape: true)
+      end
+
+      test "custom attrfunc" do
+        assert_compiled_snapshot(template, attrfunc: "CustomEscape.attribute")
+      end
+
+      test "empty attrfunc" do
+        assert_compiled_snapshot(template, attrfunc: "")
+      end
+
+      test "escape: true and custom attrfunc" do
+        assert_compiled_snapshot(template, escape: true, attrfunc: "CustomEscape.attribute")
+      end
+
+      test "escape: true and empty attrfunc" do
+        assert_compiled_snapshot(template, escape: true, attrfunc: "")
+      end
+
+      test "escape: false and custom attrfunc" do
+        assert_compiled_snapshot(template, escape: false, attrfunc: "CustomEscape.attribute")
+      end
+
+      test "escape: false and empty attrfunc" do
+        assert_compiled_snapshot(template, escape: false, attrfunc: "")
+      end
+    end
+
+    context "javascript" do
+      template = %(<script><%= value %></script>)
+
+      test "default" do
+        assert_compiled_snapshot(template)
+      end
+
+      test "escape: true" do
+        assert_compiled_snapshot(template, escape: true)
+      end
+
+      test "custom jsfunc" do
+        assert_compiled_snapshot(template, jsfunc: "CustomEscape.js")
+      end
+
+      test "empty jsfunc" do
+        assert_compiled_snapshot(template, jsfunc: "")
+      end
+
+      test "escape: true and custom jsfunc" do
+        assert_compiled_snapshot(template, escape: true, jsfunc: "CustomEscape.js")
+      end
+
+      test "escape: true and empty jsfunc" do
+        assert_compiled_snapshot(template, escape: true, jsfunc: "")
+      end
+
+      test "escape: false and custom jsfunc" do
+        assert_compiled_snapshot(template, escape: false, jsfunc: "CustomEscape.js")
+      end
+
+      test "escape: false and empty jsfunc" do
+        assert_compiled_snapshot(template, escape: false, jsfunc: "")
+      end
+    end
+
+    context "style" do
+      template = %(<style><%= value %></style>)
+
+      test "default" do
+        assert_compiled_snapshot(template)
+      end
+
+      test "escape: true" do
+        assert_compiled_snapshot(template, escape: true)
+      end
+
+      test "custom cssfunc" do
+        assert_compiled_snapshot(template, cssfunc: "CustomEscape.css")
+      end
+
+      test "empty cssfunc" do
+        assert_compiled_snapshot(template, cssfunc: "")
+      end
+
+      test "escape: true and custom cssfunc" do
+        assert_compiled_snapshot(template, escape: true, cssfunc: "CustomEscape.css")
+      end
+
+      test "escape: true and empty cssfunc" do
+        assert_compiled_snapshot(template, escape: true, cssfunc: "")
+      end
+
+      test "escape: false and custom cssfunc" do
+        assert_compiled_snapshot(template, escape: false, cssfunc: "CustomEscape.css")
+      end
+
+      test "escape: false and empty cssfunc" do
+        assert_compiled_snapshot(template, escape: false, cssfunc: "")
+      end
+    end
+  end
+end

--- a/test/snapshot_utils.rb
+++ b/test/snapshot_utils.rb
@@ -200,6 +200,7 @@ module SnapshotUtils
           .gsub(/([A-Z]+)([A-Z][a-z])/, '\1_\2')
           .gsub(/([a-z\d])([A-Z])/, '\1_\2')
           .tr("-", "_")
+          .tr(" ", "_")
           .downcase
   end
 end

--- a/test/snapshots/engine/escape_test/attributes/test_0001_default_82a7a92705ab6d35e9b98dcf832df658.txt
+++ b/test/snapshots/engine/escape_test/attributes/test_0001_default_82a7a92705ab6d35e9b98dcf832df658.txt
@@ -1,0 +1,3 @@
+_buf = ::String.new;
+ _buf << '<div class="'.freeze; _buf << ::Herb::Engine.attr((value)); _buf << '"></div>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/escape_test/attributes/test_0002_escape_true_bbb2f1b4762867f152a22fb91e012a4c.txt
+++ b/test/snapshots/engine/escape_test/attributes/test_0002_escape_true_bbb2f1b4762867f152a22fb91e012a4c.txt
@@ -1,0 +1,3 @@
+__herb = ::Herb::Engine; _buf = ::String.new;
+ _buf << '<div class="'.freeze; _buf << __herb.attr((value)); _buf << '"></div>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/escape_test/attributes/test_0003_custom_attrfunc_cf03e906f47d2afbb15fa203feeeb459.txt
+++ b/test/snapshots/engine/escape_test/attributes/test_0003_custom_attrfunc_cf03e906f47d2afbb15fa203feeeb459.txt
@@ -1,0 +1,3 @@
+_buf = ::String.new;
+ _buf << '<div class="'.freeze; _buf << CustomEscape.attribute((value)); _buf << '"></div>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/escape_test/attributes/test_0004_empty_attrfunc_d7d14e66fe9908f96175d0fc31e0dac1.txt
+++ b/test/snapshots/engine/escape_test/attributes/test_0004_empty_attrfunc_d7d14e66fe9908f96175d0fc31e0dac1.txt
@@ -1,0 +1,3 @@
+_buf = ::String.new;
+ _buf << '<div class="'.freeze; _buf << ((value)); _buf << '"></div>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/escape_test/attributes/test_0005_escape_true_and_custom_attrfunc_8f14421c2d93dcbfc8c32ebcd79e356c.txt
+++ b/test/snapshots/engine/escape_test/attributes/test_0005_escape_true_and_custom_attrfunc_8f14421c2d93dcbfc8c32ebcd79e356c.txt
@@ -1,0 +1,3 @@
+__herb = ::Herb::Engine; _buf = ::String.new;
+ _buf << '<div class="'.freeze; _buf << CustomEscape.attribute((value)); _buf << '"></div>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/escape_test/attributes/test_0006_escape_true_and_empty_attrfunc_b5195ed0791ce8b7fb7e9957385d0888.txt
+++ b/test/snapshots/engine/escape_test/attributes/test_0006_escape_true_and_empty_attrfunc_b5195ed0791ce8b7fb7e9957385d0888.txt
@@ -1,0 +1,3 @@
+__herb = ::Herb::Engine; _buf = ::String.new;
+ _buf << '<div class="'.freeze; _buf << ((value)); _buf << '"></div>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/escape_test/attributes/test_0007_escape_false_and_custom_attrfunc_60c2561eccf31fcc7be74358531d361a.txt
+++ b/test/snapshots/engine/escape_test/attributes/test_0007_escape_false_and_custom_attrfunc_60c2561eccf31fcc7be74358531d361a.txt
@@ -1,0 +1,3 @@
+_buf = ::String.new;
+ _buf << '<div class="'.freeze; _buf << CustomEscape.attribute((value)); _buf << '"></div>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/escape_test/attributes/test_0008_escape_false_and_empty_attrfunc_d36d73b6689a9ee6b1dd7429bacb5577.txt
+++ b/test/snapshots/engine/escape_test/attributes/test_0008_escape_false_and_empty_attrfunc_d36d73b6689a9ee6b1dd7429bacb5577.txt
@@ -1,0 +1,3 @@
+_buf = ::String.new;
+ _buf << '<div class="'.freeze; _buf << ((value)); _buf << '"></div>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/escape_test/escape_erb_output_tag/test_0001_default_4fb2161faf855683340cde061df50b63.txt
+++ b/test/snapshots/engine/escape_test/escape_erb_output_tag/test_0001_default_4fb2161faf855683340cde061df50b63.txt
@@ -1,0 +1,3 @@
+_buf = ::String.new;
+ _buf << '<h1>'.freeze; _buf << (value).to_s; _buf << '</h1>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/escape_test/escape_erb_output_tag/test_0002_escape_true_44fdc28505aff5a94a37c9368fc76e9d.txt
+++ b/test/snapshots/engine/escape_test/escape_erb_output_tag/test_0002_escape_true_44fdc28505aff5a94a37c9368fc76e9d.txt
@@ -1,0 +1,3 @@
+__herb = ::Herb::Engine; _buf = ::String.new;
+ _buf << '<h1>'.freeze; _buf << __herb.h((value)); _buf << '</h1>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/escape_test/escape_erb_output_tag/test_0003_custom_escapefunc_40f8668374512910499884ea2bd53300.txt
+++ b/test/snapshots/engine/escape_test/escape_erb_output_tag/test_0003_custom_escapefunc_40f8668374512910499884ea2bd53300.txt
@@ -1,0 +1,3 @@
+_buf = ::String.new;
+ _buf << '<h1>'.freeze; _buf << (value).to_s; _buf << '</h1>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/escape_test/escape_erb_output_tag/test_0004_empty_escapefunc_9e92c0a389c10a598f8ced575449686c.txt
+++ b/test/snapshots/engine/escape_test/escape_erb_output_tag/test_0004_empty_escapefunc_9e92c0a389c10a598f8ced575449686c.txt
@@ -1,0 +1,3 @@
+_buf = ::String.new;
+ _buf << '<h1>'.freeze; _buf << (value).to_s; _buf << '</h1>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/escape_test/escape_erb_output_tag/test_0005_escape_true_and_custom_escapefunc_3e35bb560dddb5f03f2d193e3e455d00.txt
+++ b/test/snapshots/engine/escape_test/escape_erb_output_tag/test_0005_escape_true_and_custom_escapefunc_3e35bb560dddb5f03f2d193e3e455d00.txt
@@ -1,0 +1,3 @@
+_buf = ::String.new;
+ _buf << '<h1>'.freeze; _buf << CustomEscape.h((value)); _buf << '</h1>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/escape_test/escape_erb_output_tag/test_0006_escape_true_and_empty_escapefunc_fd847a19c1f5170be7d9a8e865ff9fb3.txt
+++ b/test/snapshots/engine/escape_test/escape_erb_output_tag/test_0006_escape_true_and_empty_escapefunc_fd847a19c1f5170be7d9a8e865ff9fb3.txt
@@ -1,0 +1,3 @@
+_buf = ::String.new;
+ _buf << '<h1>'.freeze; _buf << ((value)); _buf << '</h1>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/escape_test/escape_erb_output_tag/test_0007_escape_false_and_custom_escapefunc_7683083386c679d64322db896966279d.txt
+++ b/test/snapshots/engine/escape_test/escape_erb_output_tag/test_0007_escape_false_and_custom_escapefunc_7683083386c679d64322db896966279d.txt
@@ -1,0 +1,3 @@
+_buf = ::String.new;
+ _buf << '<h1>'.freeze; _buf << (value).to_s; _buf << '</h1>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/escape_test/escape_erb_output_tag/test_0008_escape_false_and_empty_escapefunc_8588ecfab0b1fa69e732bbad0941ebf7.txt
+++ b/test/snapshots/engine/escape_test/escape_erb_output_tag/test_0008_escape_false_and_empty_escapefunc_8588ecfab0b1fa69e732bbad0941ebf7.txt
@@ -1,0 +1,3 @@
+_buf = ::String.new;
+ _buf << '<h1>'.freeze; _buf << (value).to_s; _buf << '</h1>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/escape_test/escape_erb_raw_output_tag/test_0001_default_f2be84eb0a72782680d35cf59765e9a8.txt
+++ b/test/snapshots/engine/escape_test/escape_erb_raw_output_tag/test_0001_default_f2be84eb0a72782680d35cf59765e9a8.txt
@@ -1,0 +1,3 @@
+_buf = ::String.new;
+ _buf << '<h1>'.freeze; _buf << ::Herb::Engine.h((value)); _buf << '</h1>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/escape_test/escape_erb_raw_output_tag/test_0002_escape_true_a71d7635b10408058ae5f6f8337d1e0c.txt
+++ b/test/snapshots/engine/escape_test/escape_erb_raw_output_tag/test_0002_escape_true_a71d7635b10408058ae5f6f8337d1e0c.txt
@@ -1,0 +1,3 @@
+__herb = ::Herb::Engine; _buf = ::String.new;
+ _buf << '<h1>'.freeze; _buf << (value).to_s; _buf << '</h1>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/escape_test/escape_erb_raw_output_tag/test_0003_custom_escapefunc_d8d378cd430fd52648905d31467fd15f.txt
+++ b/test/snapshots/engine/escape_test/escape_erb_raw_output_tag/test_0003_custom_escapefunc_d8d378cd430fd52648905d31467fd15f.txt
@@ -1,0 +1,3 @@
+_buf = ::String.new;
+ _buf << '<h1>'.freeze; _buf << CustomEscape.h((value)); _buf << '</h1>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/escape_test/escape_erb_raw_output_tag/test_0004_empty_escapefunc_6d8030e9f8e12e3a882ebc492e1efb1c.txt
+++ b/test/snapshots/engine/escape_test/escape_erb_raw_output_tag/test_0004_empty_escapefunc_6d8030e9f8e12e3a882ebc492e1efb1c.txt
@@ -1,0 +1,3 @@
+_buf = ::String.new;
+ _buf << '<h1>'.freeze; _buf << ((value)); _buf << '</h1>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/escape_test/escape_erb_raw_output_tag/test_0005_escape_true_and_custom_escapefunc_6549bbd875e087b9318ec6c35f61dd42.txt
+++ b/test/snapshots/engine/escape_test/escape_erb_raw_output_tag/test_0005_escape_true_and_custom_escapefunc_6549bbd875e087b9318ec6c35f61dd42.txt
@@ -1,0 +1,3 @@
+_buf = ::String.new;
+ _buf << '<h1>'.freeze; _buf << (value).to_s; _buf << '</h1>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/escape_test/escape_erb_raw_output_tag/test_0006_escape_true_and_empty_escapefunc_8d28173c3875daee25c08f28b41fa510.txt
+++ b/test/snapshots/engine/escape_test/escape_erb_raw_output_tag/test_0006_escape_true_and_empty_escapefunc_8d28173c3875daee25c08f28b41fa510.txt
@@ -1,0 +1,3 @@
+_buf = ::String.new;
+ _buf << '<h1>'.freeze; _buf << (value).to_s; _buf << '</h1>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/escape_test/escape_erb_raw_output_tag/test_0007_escape_false_and_custom_escapefunc_a0353f00c62b0daf50687e9c8d223391.txt
+++ b/test/snapshots/engine/escape_test/escape_erb_raw_output_tag/test_0007_escape_false_and_custom_escapefunc_a0353f00c62b0daf50687e9c8d223391.txt
@@ -1,0 +1,3 @@
+_buf = ::String.new;
+ _buf << '<h1>'.freeze; _buf << CustomEscape.h((value)); _buf << '</h1>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/escape_test/escape_erb_raw_output_tag/test_0008_escape_false_and_empty_escapefunc_f7d39b8a11a3022e2ef1a697e3c46888.txt
+++ b/test/snapshots/engine/escape_test/escape_erb_raw_output_tag/test_0008_escape_false_and_empty_escapefunc_f7d39b8a11a3022e2ef1a697e3c46888.txt
@@ -1,0 +1,3 @@
+_buf = ::String.new;
+ _buf << '<h1>'.freeze; _buf << ((value)); _buf << '</h1>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/escape_test/javascript/test_0001_default_b2330479d7cdc3d3bd870cbda6e5a13a.txt
+++ b/test/snapshots/engine/escape_test/javascript/test_0001_default_b2330479d7cdc3d3bd870cbda6e5a13a.txt
@@ -1,0 +1,3 @@
+_buf = ::String.new;
+ _buf << '<script>'.freeze; _buf << ::Herb::Engine.js((value)); _buf << '</script>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/escape_test/javascript/test_0002_escape_true_b20f9d8b8dcf7e533b68a6db0194bc75.txt
+++ b/test/snapshots/engine/escape_test/javascript/test_0002_escape_true_b20f9d8b8dcf7e533b68a6db0194bc75.txt
@@ -1,0 +1,3 @@
+__herb = ::Herb::Engine; _buf = ::String.new;
+ _buf << '<script>'.freeze; _buf << __herb.js((value)); _buf << '</script>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/escape_test/javascript/test_0003_custom_jsfunc_fff096d3faee3e5c8c1b1f5d09f407d1.txt
+++ b/test/snapshots/engine/escape_test/javascript/test_0003_custom_jsfunc_fff096d3faee3e5c8c1b1f5d09f407d1.txt
@@ -1,0 +1,3 @@
+_buf = ::String.new;
+ _buf << '<script>'.freeze; _buf << CustomEscape.js((value)); _buf << '</script>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/escape_test/javascript/test_0004_empty_jsfunc_33b8e30f7bf28e4f9dfc23d89e187438.txt
+++ b/test/snapshots/engine/escape_test/javascript/test_0004_empty_jsfunc_33b8e30f7bf28e4f9dfc23d89e187438.txt
@@ -1,0 +1,3 @@
+_buf = ::String.new;
+ _buf << '<script>'.freeze; _buf << ((value)); _buf << '</script>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/escape_test/javascript/test_0005_escape_true_and_custom_jsfunc_efcb50766c5a8f17b97cfd5ad4ca67cd.txt
+++ b/test/snapshots/engine/escape_test/javascript/test_0005_escape_true_and_custom_jsfunc_efcb50766c5a8f17b97cfd5ad4ca67cd.txt
@@ -1,0 +1,3 @@
+__herb = ::Herb::Engine; _buf = ::String.new;
+ _buf << '<script>'.freeze; _buf << CustomEscape.js((value)); _buf << '</script>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/escape_test/javascript/test_0006_escape_true_and_empty_jsfunc_96ece398c40750f59650d0c35f953dd9.txt
+++ b/test/snapshots/engine/escape_test/javascript/test_0006_escape_true_and_empty_jsfunc_96ece398c40750f59650d0c35f953dd9.txt
@@ -1,0 +1,3 @@
+__herb = ::Herb::Engine; _buf = ::String.new;
+ _buf << '<script>'.freeze; _buf << ((value)); _buf << '</script>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/escape_test/javascript/test_0007_escape_false_and_custom_jsfunc_f436b9a75e95db20869db3ea9fd57766.txt
+++ b/test/snapshots/engine/escape_test/javascript/test_0007_escape_false_and_custom_jsfunc_f436b9a75e95db20869db3ea9fd57766.txt
@@ -1,0 +1,3 @@
+_buf = ::String.new;
+ _buf << '<script>'.freeze; _buf << CustomEscape.js((value)); _buf << '</script>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/escape_test/javascript/test_0008_escape_false_and_empty_jsfunc_3d49d1a8bb960fe85c74d4deb4d3107f.txt
+++ b/test/snapshots/engine/escape_test/javascript/test_0008_escape_false_and_empty_jsfunc_3d49d1a8bb960fe85c74d4deb4d3107f.txt
@@ -1,0 +1,3 @@
+_buf = ::String.new;
+ _buf << '<script>'.freeze; _buf << ((value)); _buf << '</script>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/escape_test/style/test_0001_default_b2440242cdba618522e76914ac63a054.txt
+++ b/test/snapshots/engine/escape_test/style/test_0001_default_b2440242cdba618522e76914ac63a054.txt
@@ -1,0 +1,3 @@
+_buf = ::String.new;
+ _buf << '<style>'.freeze; _buf << ::Herb::Engine.css((value)); _buf << '</style>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/escape_test/style/test_0002_escape_true_4781fa0cc6abdaa0769dba2eb345e4cd.txt
+++ b/test/snapshots/engine/escape_test/style/test_0002_escape_true_4781fa0cc6abdaa0769dba2eb345e4cd.txt
@@ -1,0 +1,3 @@
+__herb = ::Herb::Engine; _buf = ::String.new;
+ _buf << '<style>'.freeze; _buf << __herb.css((value)); _buf << '</style>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/escape_test/style/test_0003_custom_cssfunc_bbd4d2d294779b5762d02b2e1c07fb11.txt
+++ b/test/snapshots/engine/escape_test/style/test_0003_custom_cssfunc_bbd4d2d294779b5762d02b2e1c07fb11.txt
@@ -1,0 +1,3 @@
+_buf = ::String.new;
+ _buf << '<style>'.freeze; _buf << CustomEscape.css((value)); _buf << '</style>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/escape_test/style/test_0004_empty_cssfunc_986ecd0589393eb937ceee2aa419f49e.txt
+++ b/test/snapshots/engine/escape_test/style/test_0004_empty_cssfunc_986ecd0589393eb937ceee2aa419f49e.txt
@@ -1,0 +1,3 @@
+_buf = ::String.new;
+ _buf << '<style>'.freeze; _buf << ((value)); _buf << '</style>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/escape_test/style/test_0005_escape_true_and_custom_cssfunc_cd5298d4aac80c862e718692bdf83eab.txt
+++ b/test/snapshots/engine/escape_test/style/test_0005_escape_true_and_custom_cssfunc_cd5298d4aac80c862e718692bdf83eab.txt
@@ -1,0 +1,3 @@
+__herb = ::Herb::Engine; _buf = ::String.new;
+ _buf << '<style>'.freeze; _buf << CustomEscape.css((value)); _buf << '</style>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/escape_test/style/test_0006_escape_true_and_empty_cssfunc_4d1ec0837eb25b77cd79886db2c4dee6.txt
+++ b/test/snapshots/engine/escape_test/style/test_0006_escape_true_and_empty_cssfunc_4d1ec0837eb25b77cd79886db2c4dee6.txt
@@ -1,0 +1,3 @@
+__herb = ::Herb::Engine; _buf = ::String.new;
+ _buf << '<style>'.freeze; _buf << ((value)); _buf << '</style>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/escape_test/style/test_0007_escape_false_and_custom_cssfunc_28db6ce107bc81f050f3de9a654f8fa5.txt
+++ b/test/snapshots/engine/escape_test/style/test_0007_escape_false_and_custom_cssfunc_28db6ce107bc81f050f3de9a654f8fa5.txt
@@ -1,0 +1,3 @@
+_buf = ::String.new;
+ _buf << '<style>'.freeze; _buf << CustomEscape.css((value)); _buf << '</style>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/escape_test/style/test_0008_escape_false_and_empty_cssfunc_3cb7a8609a8656ee321b953d5a5132f4.txt
+++ b/test/snapshots/engine/escape_test/style/test_0008_escape_false_and_empty_cssfunc_3cb7a8609a8656ee321b953d5a5132f4.txt
@@ -1,0 +1,3 @@
+_buf = ::String.new;
+ _buf << '<style>'.freeze; _buf << ((value)); _buf << '</style>'.freeze;
+_buf.to_s


### PR DESCRIPTION
This pull request updates the `Herb::Engine` to accept new `attrfunc`, `jsfunc`, and `cssfunc` options. 

This enables ReActionView (and Rails) to customize these escape functions (similar to how it's already customizing `escapefunc`) so that we can avoid the double escaping. 

Since ActionView uses `ActionView::OutputBuffer` instead of `String` it would end up be double-escaped if we didn't allow it to be customized and set to `""` (see https://github.com/marcoroth/reactionview/issues/12).

Enables https://github.com/marcoroth/reactionview/pull/53