### PR TITLE
C: Allow to control memory allocation strategy

### DIFF
--- a/javascript/packages/node/binding.gyp
+++ b/javascript/packages/node/binding.gyp
@@ -38,6 +38,7 @@
         "./extension/libherb/util/hb_array.c",
         "./extension/libherb/util/hb_buffer.c",
         "./extension/libherb/util/hb_string.c",
+        "./extension/libherb/util/hb_system.c",
         "./extension/libherb/visitor.c",
 
         # Prism main source files

--- a/src/include/util/hb_system.h
+++ b/src/include/util/hb_system.h
@@ -1,0 +1,9 @@
+#ifndef HERB_SYSTEM_H
+#define HERB_SYSTEM_H
+
+#include <stddef.h>
+
+void* hb_system_allocate_memory(size_t size);
+void hb_system_free_memory(void* ptr, size_t size);
+
+#endif

--- a/src/util/hb_system.c
+++ b/src/util/hb_system.c
@@ -1,0 +1,30 @@
+#include "../include/util/hb_system.h"
+
+#ifdef __linux__
+#define _GNU_SOURCE
+#endif
+
+#ifdef HB_USE_MALLOC
+#include <stdlib.h>
+#else
+#include <sys/mman.h>
+#endif
+
+void* hb_system_allocate_memory(size_t size) {
+#ifdef HB_USE_MALLOC
+  return malloc(size);
+#else
+  void* memory = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  if (memory == MAP_FAILED) { return NULL; }
+
+  return memory;
+#endif
+}
+
+void hb_system_free_memory(void* ptr, size_t size) {
+#ifdef HB_USE_MALLOC
+  free(ptr);
+#else
+  munmap(ptr, size);
+#endif
+}


### PR DESCRIPTION
This PR introduces a compile time flag that allows to use `malloc` instead of `mmap` to acquire memory for the arena. 