### PR TITLE
Core: Add short-hand to construct `Location`, `Position`, and `Range`

### DIFF
--- a/javascript/packages/core/src/location.ts
+++ b/javascript/packages/core/src/location.ts
@@ -10,11 +10,20 @@ export class Location {
   readonly start: Position
   readonly end: Position
 
-  static from(location: SerializedLocation) {
-    const start = Position.from(location.start)
-    const end = Position.from(location.end)
+  static from(location: SerializedLocation): Location
+  static from(line: number, column: number, endLine: number, endColumn: number): Location
+  static from(locationOrLine: SerializedLocation | number, column?: number, endLine?: number, endColumn?: number): Location {
+    if (typeof locationOrLine === "number") {
+      const start = Position.from(locationOrLine, column!)
+      const end = Position.from(endLine!, endColumn!)
 
-    return new Location(start, end)
+      return new Location(start, end)
+    } else {
+      const start = Position.from(locationOrLine.start)
+      const end = Position.from(locationOrLine.end)
+
+      return new Location(start, end)
+    }
   }
 
   static get zero() {

--- a/javascript/packages/core/src/position.ts
+++ b/javascript/packages/core/src/position.ts
@@ -7,8 +7,14 @@ export class Position {
   readonly line: number
   readonly column: number
 
-  static from(position: SerializedPosition) {
-    return new Position(position.line, position.column)
+  static from(position: SerializedPosition): Position
+  static from(line: number, column: number): Position
+  static from(positionOrLine: SerializedPosition | number, column?: number): Position {
+    if (typeof positionOrLine === "number") {
+      return new Position(positionOrLine, column!)
+    } else {
+      return new Position(positionOrLine.line, positionOrLine.column)
+    }
   }
 
   static get zero() {

--- a/javascript/packages/core/src/range.ts
+++ b/javascript/packages/core/src/range.ts
@@ -4,8 +4,14 @@ export class Range {
   readonly start: number
   readonly end: number
 
-  static from(range: SerializedRange) {
-    return new Range(range[0], range[1])
+  static from(range: SerializedRange): Range
+  static from(start: number, end: number): Range
+  static from(rangeOrStart: SerializedRange | number, end?: number): Range {
+    if (typeof rangeOrStart === "number") {
+      return new Range(rangeOrStart, end!)
+    } else {
+      return new Range(rangeOrStart[0], rangeOrStart[1])
+    }
   }
 
   static get zero() {

--- a/javascript/packages/core/test/ast-utils.test.ts
+++ b/javascript/packages/core/test/ast-utils.test.ts
@@ -17,30 +17,32 @@ import {
   hasStaticAttributeName,
   hasDynamicAttributeName,
   getStaticAttributeName,
-  getCombinedAttributeName
+  getCombinedAttributeName,
+  Location,
+  HTMLAttributeNameNode
 } from "../src"
 
-import type { Node, LiteralNode, ERBContentNode, HTMLAttributeNameNode } from "../src/nodes.js"
+import type { Node, LiteralNode, ERBContentNode } from "../src/nodes.js"
 
 describe("ast-utils", () => {
   const createLiteralNode = (content: string): LiteralNode => ({
     type: "AST_LITERAL_NODE",
     content,
-    location: { start: { line: 1, column: 1 }, end: { line: 1, column: 1 } }
+    location: Location.from(1, 1, 1, 1)
   })
 
   const createERBContentNode = (tagOpening: string, content: string = "", tagClosing: string = "%>"): ERBContentNode => ({
     type: "AST_ERB_CONTENT_NODE",
-    tag_opening: { type: "AST_TOKEN", value: tagOpening, location: { start: { line: 1, column: 1 }, end: { line: 1, column: 1 } } },
-    content: content ? { type: "AST_TOKEN", value: content, location: { start: { line: 1, column: 1 }, end: { line: 1, column: 1 } } } : undefined,
-    tag_closing: { type: "AST_TOKEN", value: tagClosing, location: { start: { line: 1, column: 1 }, end: { line: 1, column: 1 } } },
-    location: { start: { line: 1, column: 1 }, end: { line: 1, column: 1 } }
+    tag_opening: { type: "AST_TOKEN", value: tagOpening, location: Location.from(1, 1, 1, 1) },
+    content: content ? { type: "AST_TOKEN", value: content, location: Location.from(1, 1, 1, 1) } : undefined,
+    tag_closing: { type: "AST_TOKEN", value: tagClosing, location: Location.from(1, 1, 1, 1) },
+    location: Location.from(1, 1, 1, 1)
   })
 
   const createAttributeNameNode = (children: Node[]): HTMLAttributeNameNode => ({
     type: "AST_HTML_ATTRIBUTE_NAME_NODE",
     children,
-    location: { start: { line: 1, column: 1 }, end: { line: 1, column: 1 } }
+    location: Location.from(1, 1, 1, 1)
   })
 
   describe("isLiteralNode", () => {
@@ -321,7 +323,7 @@ describe("ast-utils", () => {
     test("handles unknown node types", () => {
       const unknownNode: Node = {
         type: "UNKNOWN_NODE" as any,
-        location: { start: { line: 1, column: 1 }, end: { line: 1, column: 1 } }
+        location: Location.from(1, 1, 1, 1)
       }
 
       const nodes = [createLiteralNode("test"), unknownNode]

--- a/javascript/packages/core/test/node-type-guards.test.ts
+++ b/javascript/packages/core/test/node-type-guards.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { Location } from '../src/location.js'
-import { Position } from '../src/position.js'
+
 import {
   DocumentNode,
   LiteralNode,
@@ -27,37 +27,30 @@ import {
 } from '../src/node-type-guards.js'
 
 describe('Node Type Guards', () => {
-  // Helper to create a basic location for nodes
-  const createLocation = () => new Location(
-    new Position(1, 1),
-    new Position(1, 2)
-  )
-
-  // Create sample nodes for testing
   const documentNode = new DocumentNode({
     type: 'AST_DOCUMENT_NODE',
-    location: createLocation(),
+    location: Location.zero,
     errors: [],
     children: []
   })
 
   const literalNode = new LiteralNode({
     type: 'AST_LITERAL_NODE',
-    location: createLocation(),
+    location: Location.zero,
     errors: [],
     content: 'test'
   })
 
   const htmlTextNode = new HTMLTextNode({
     type: 'AST_HTML_TEXT_NODE',
-    location: createLocation(),
+    location: Location.zero,
     errors: [],
     content: 'text'
   })
 
   const erbContentNode = new ERBContentNode({
     type: 'AST_ERB_CONTENT_NODE',
-    location: createLocation(),
+    location: Location.zero,
     errors: [],
     tag_opening: null,
     content: null,

--- a/javascript/packages/highlighter/test/syntax-renderer.test.ts
+++ b/javascript/packages/highlighter/test/syntax-renderer.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect, beforeEach } from "vitest"
 import { themes } from "../src/themes.js"
 
+import { Range } from "@herb-tools/core"
 import { Herb } from "@herb-tools/node-wasm"
 import { SyntaxRenderer } from "../src/syntax-renderer.js"
 
-// Helper function to strip ANSI color codes for testing
 function stripAnsiColors(text: string): string {
   return text.replace(/\x1b\[[0-9;]*m/g, '')
 }
@@ -34,7 +34,6 @@ describe("SyntaxRenderer", () => {
       await renderer.initialize()
       expect(renderer.initialized).toBe(true)
 
-      // Should not throw or cause issues
       await renderer.initialize()
       expect(renderer.initialized).toBe(true)
     })
@@ -52,7 +51,7 @@ describe("SyntaxRenderer", () => {
         isLoaded: false,
       }
       const uninitializedRenderer = new SyntaxRenderer(themes.onedark, uninitializedHerb as any)
-      // Don't initialize the renderer
+
       expect(() => uninitializedRenderer.highlight("<div>test</div>")).toThrow(
         "SyntaxRenderer must be initialized before use",
       )
@@ -136,7 +135,7 @@ describe("SyntaxRenderer", () => {
 
         const content = "<div>test</div>"
         const result = noColorRenderer.highlight(content)
-        // Should not contain ANSI escape codes
+
         expect(result).not.toMatch(/\x1b\\[[0-9;]*m/)
       } finally {
         if (originalNoColor === undefined) {
@@ -155,9 +154,9 @@ describe("SyntaxRenderer", () => {
         lex: () => ({
           errors: [],
           value: [
-            { type: "TOKEN_ERB_START", range: { start: 0, end: 2 } },
-            { type: "TOKEN_ERB_CONTENT", range: { start: 2, end: 12 } },
-            { type: "TOKEN_ERB_END", range: { start: 12, end: 14 } },
+            { type: "TOKEN_ERB_START", range: Range.from(0, 2) },
+            { type: "TOKEN_ERB_CONTENT", range: Range.from(2, 12) },
+            { type: "TOKEN_ERB_END", range: Range.from(12, 14) },
           ],
         }),
         isLoaded: true,
@@ -181,9 +180,9 @@ describe("SyntaxRenderer", () => {
         lex: () => ({
           errors: [],
           value: [
-            { type: "TOKEN_HTML_COMMENT_START", range: { start: 0, end: 4 } },
-            { type: "TOKEN_IDENTIFIER", range: { start: 4, end: 11 } },
-            { type: "TOKEN_HTML_COMMENT_END", range: { start: 11, end: 14 } },
+            { type: "TOKEN_HTML_COMMENT_START", range: Range.from(0, 4) },
+            { type: "TOKEN_IDENTIFIER", range: Range.from(4, 11) },
+            { type: "TOKEN_HTML_COMMENT_END", range: Range.from(11, 14) },
           ],
         }),
       }
@@ -206,11 +205,11 @@ describe("SyntaxRenderer", () => {
         lex: () => ({
           errors: [],
           value: [
-            { type: "TOKEN_HTML_COMMENT_START", range: { start: 0, end: 4 } },
-            { type: "TOKEN_ERB_START", range: { start: 5, end: 7 } },
-            { type: "TOKEN_ERB_CONTENT", range: { start: 7, end: 12 } },
-            { type: "TOKEN_ERB_END", range: { start: 12, end: 14 } },
-            { type: "TOKEN_HTML_COMMENT_END", range: { start: 15, end: 18 } },
+            { type: "TOKEN_HTML_COMMENT_START", range: Range.from(0, 4) },
+            { type: "TOKEN_ERB_START", range: Range.from(5, 7) },
+            { type: "TOKEN_ERB_CONTENT", range: Range.from(7, 12) },
+            { type: "TOKEN_ERB_END", range: Range.from(12, 14) },
+            { type: "TOKEN_HTML_COMMENT_END", range: Range.from(15, 18) },
           ],
         }),
       }

--- a/javascript/packages/linter/src/rules/rule-utils.ts
+++ b/javascript/packages/linter/src/rules/rule-utils.ts
@@ -582,10 +582,8 @@ export function createEndOfFileLocation(source: string): Location {
   const lastColumnNumber = lastLine.length
 
   const startColumn = lastColumnNumber > 0 ? lastColumnNumber - 1 : 0
-  const start = new Position(lastLineNumber, startColumn)
-  const end = new Position(lastLineNumber, lastColumnNumber)
 
-  return new Location(start, end)
+  return Location.from(lastLineNumber, startColumn, lastLineNumber, lastColumnNumber)
 }
 
 /**

--- a/javascript/packages/linter/test/linter.test.ts
+++ b/javascript/packages/linter/test/linter.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect, beforeAll } from "vitest"
 
 import { Herb } from "@herb-tools/node-wasm"
+import { Location } from "@herb-tools/core"
 import { Linter } from "../src/linter.js"
 
 import { HTMLTagNameLowercaseRule } from "../src/rules/html-tag-name-lowercase.js"
@@ -88,7 +89,7 @@ describe("@herb-tools/linter", () => {
       check(_result: ParseResult): LintOffense[] {
         return [{
           message: "Test offense",
-          location: { start: { line: 1, column: 1 }, end: { line: 1, column: 1 } },
+          location: Location.from(1, 1, 1, 1),
           severity: "error",
           rule: this.name,
           code: this.name,
@@ -107,7 +108,7 @@ describe("@herb-tools/linter", () => {
       check(_result: ParseResult): LintOffense[] {
         return [{
           message: "This should never appear",
-          location: { start: { line: 1, column: 1 }, end: { line: 1, column: 1 } },
+          location: Location.from(1, 1, 1, 1),
           severity: "error",
           rule: this.name,
           code: this.name,
@@ -126,7 +127,7 @@ describe("@herb-tools/linter", () => {
       check(_source: string): LintOffense[] {
         return [{
           message: "ERB file detected",
-          location: { start: { line: 1, column: 1 }, end: { line: 1, column: 1 } },
+          location: Location.from(1, 1, 1, 1),
           severity: "info",
           rule: this.name,
           code: this.name,
@@ -145,7 +146,7 @@ describe("@herb-tools/linter", () => {
       check(_result: ParseResult): LintOffense[] {
         return [{
           message: "Div found",
-          location: { start: { line: 1, column: 1 }, end: { line: 1, column: 1 } },
+          location: Location.from(1, 1, 1, 1),
           severity: "info",
           rule: this.name,
           code: this.name,

--- a/javascript/packages/printer/test/nodes/document-node.test.ts
+++ b/javascript/packages/printer/test/nodes/document-node.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, beforeAll } from "vitest"
 
 import { Herb } from "@herb-tools/node-wasm"
-import { DocumentNode } from "@herb-tools/core"
+import { DocumentNode, Location } from "@herb-tools/core"
 
 import { expectNodeToPrint, expectPrintRoundTrip } from "../helpers/printer-test-helpers.js"
 
@@ -13,7 +13,7 @@ describe("DocumentNode Printing", () => {
   test("can print from node", () => {
     const node = DocumentNode.from({
       type: "AST_DOCUMENT_NODE",
-      location: { start: { line: 1, column: 1 }, end: { line: 1, column: 1 } },
+      location: Location.from(1, 1, 1, 1),
       errors: [],
       children: []
     })


### PR DESCRIPTION
This pull request overloads the static `from` function for `Location`, `Position`, and `Range` so you can call it using a short-hand syntax:

```ts
// new - now supported
Range.from(0, 10)
Position.from(1, 5)
Location.from(0, 0, 0, 0)

// old - a lot more verbose 
Range.from([0, 10])
Position.from({ line: 1, column: 5 })
Location.from({ start: { line: 0, column: 0 }, end: { line: 0, column: 0 } })
```