### PR TITLE
Language Server: Implement Disable Linter Rule Code Actions

### DIFF
--- a/javascript/packages/language-server/src/code_action_service.ts
+++ b/javascript/packages/language-server/src/code_action_service.ts
@@ -1,0 +1,122 @@
+import { CodeAction, CodeActionKind, Diagnostic, Range, TextEdit, WorkspaceEdit } from "vscode-languageserver/node"
+
+export class CodeActionService {
+  createCodeActions(uri: string, diagnostics: Diagnostic[], documentText: string): CodeAction[] {
+    const actions: CodeAction[] = []
+
+    for (const diagnostic of diagnostics) {
+      if (diagnostic.source === "Herb Linter " && diagnostic.data?.rule) {
+        const ruleName = diagnostic.data.rule as string
+
+        const disableLineAction = this.createDisableLineAction(
+          uri,
+          diagnostic,
+          ruleName,
+          documentText
+        )
+
+        if (disableLineAction) {
+          actions.push(disableLineAction)
+        }
+
+        const disableAllAction = this.createDisableAllAction(
+          uri,
+          diagnostic,
+          documentText
+        )
+
+        if (disableAllAction) {
+          actions.push(disableAllAction)
+        }
+      }
+    }
+
+    return actions
+  }
+
+  private createDisableLineAction(uri: string, diagnostic: Diagnostic, ruleName: string, documentText: string): CodeAction | null {
+    const line = diagnostic.range.start.line
+    const edit = this.createDisableCommentEdit(uri, line, ruleName, documentText)
+
+    if (!edit) return null
+
+    const action: CodeAction = {
+      title: `Herb: Disable \`${ruleName}\` for this line`,
+      kind: CodeActionKind.QuickFix,
+      diagnostics: [diagnostic],
+      edit,
+    }
+
+    return action
+  }
+
+  private createDisableAllAction(uri: string, diagnostic: Diagnostic, documentText: string): CodeAction | null {
+    const line = diagnostic.range.start.line
+    const edit = this.createDisableCommentEdit(uri, line, "all", documentText)
+
+    if (!edit) return null
+
+    const action: CodeAction = {
+      title: "Herb: Disable all linter rules for this line",
+      kind: CodeActionKind.QuickFix,
+      diagnostics: [diagnostic],
+      edit,
+    }
+
+    return action
+  }
+
+  private createDisableCommentEdit(uri: string, line: number, ruleName: string, documentText: string): WorkspaceEdit | null {
+    const lines = documentText.split("\n")
+
+    if (line >= lines.length) return null
+
+    const lineText = lines[line]
+    const existingDisableMatch = lineText.match(/<%#\s*herb:disable\s+(.+?)\s*%>/)
+
+    let textEdit: TextEdit
+
+    if (existingDisableMatch) {
+      const existingRules = existingDisableMatch[1].split(",").map(r => r.trim())
+
+      if (existingRules.includes("all") || ruleName === "all") {
+        if (existingRules.includes("all")) {
+          return null
+        }
+
+        textEdit = TextEdit.replace(
+          Range.create(line, 0, line, lineText.length),
+          lineText.replace(/<%#\s*herb:disable\s+.+?\s*%>/, "<%# herb:disable all %>")
+        )
+      } else {
+        if (existingRules.includes(ruleName)) {
+          return null
+        }
+
+        const newRules = [...existingRules, ruleName].join(", ")
+
+        textEdit = TextEdit.replace(
+          Range.create(line, 0, line, lineText.length),
+          lineText.replace(/<%#\s*herb:disable\s+.+?\s*%>/, `<%# herb:disable ${newRules} %>`)
+        )
+      }
+    } else {
+      const disableComment = ruleName === "all"
+        ? " <%# herb:disable all %>"
+        : ` <%# herb:disable ${ruleName} %>`
+
+      textEdit = TextEdit.replace(
+        Range.create(line, 0, line, lineText.length),
+        lineText + disableComment
+      )
+    }
+
+    const workspaceEdit: WorkspaceEdit = {
+      changes: {
+        [uri]: [textEdit]
+      }
+    }
+
+    return workspaceEdit
+  }
+}

--- a/javascript/packages/language-server/src/server.ts
+++ b/javascript/packages/language-server/src/server.ts
@@ -9,6 +9,7 @@ import {
   Connection,
   DocumentFormattingParams,
   DocumentRangeFormattingParams,
+  CodeActionParams,
 } from "vscode-languageserver/node"
 
 import { Service } from "./service"
@@ -36,6 +37,7 @@ export class Server {
           textDocumentSync: TextDocumentSyncKind.Incremental,
           documentFormattingProvider: true,
           documentRangeFormattingProvider: true,
+          codeActionProvider: true,
         },
       }
 
@@ -110,6 +112,23 @@ export class Server {
 
     this.connection.onDocumentRangeFormatting((params: DocumentRangeFormattingParams) => {
       return this.service.formatting.formatRange(params)
+    })
+
+    this.connection.onCodeAction((params: CodeActionParams) => {
+      const document = this.service.documentService.get(params.textDocument.uri)
+
+      if (!document) {
+        return []
+      }
+
+      const diagnostics = params.context.diagnostics
+      const documentText = document.getText()
+
+      return this.service.codeActionService.createCodeActions(
+        params.textDocument.uri,
+        diagnostics,
+        documentText
+      )
     })
   }
 

--- a/javascript/packages/language-server/src/service.ts
+++ b/javascript/packages/language-server/src/service.ts
@@ -8,6 +8,7 @@ import { LinterService } from "./linter_service"
 import { Config } from "./config"
 import { Project } from "./project"
 import { FormattingService } from "./formatting_service"
+import { CodeActionService } from "./code_action_service"
 
 export class Service {
   connection: Connection
@@ -19,6 +20,7 @@ export class Service {
   project: Project
   config?: Config
   formatting: FormattingService
+  codeActionService: CodeActionService
 
   constructor(connection: Connection, params: InitializeParams) {
     this.connection = connection
@@ -28,6 +30,7 @@ export class Service {
     this.parserService = new ParserService()
     this.linterService = new LinterService(this.settings)
     this.formatting = new FormattingService(this.connection, this.documentService.documents, this.project, this.settings)
+    this.codeActionService = new CodeActionService()
     this.diagnostics = new Diagnostics(this.connection, this.documentService, this.parserService, this.linterService)
 
     // Initialize global settings from initialization options


### PR DESCRIPTION
This pull request adds two new Code Actions for the Herb Language Server to able to ignore linter offenses by inserting a `<%# herb:disable ... %>` comment. Either by disabling the exact offending rule or by ignoring all rules.


https://github.com/user-attachments/assets/f3ebc29f-a5a2-4783-9e0a-7731a2f6546b

Resolves #664 