### PR TITLE
C: Use `hb_string_T` in `escape_newlines` implementation

### DIFF
--- a/src/include/util.h
+++ b/src/include/util.h
@@ -7,7 +7,7 @@
 
 int is_newline(int character);
 
-char* escape_newlines(const char* input);
+hb_string_T escape_newlines(hb_string_T input);
 hb_string_T quoted_string(hb_string_T input);
 char* herb_strdup(const char* s);
 

--- a/src/pretty_print.c
+++ b/src/pretty_print.c
@@ -235,19 +235,19 @@ void pretty_print_string_property(
   hb_buffer_T* buffer
 ) {
   const char* value = "∅";
-  char* escaped = NULL;
+  hb_string_T escaped = { .data = NULL, .length = 0 };
   hb_string_T quoted;
 
   if (string != NULL) {
-    escaped = escape_newlines(string);
-    quoted = quoted_string(hb_string(escaped));
+    escaped = escape_newlines(hb_string(string));
+    quoted = quoted_string(escaped);
     value = quoted.data;
   }
 
   pretty_print_property(name, value, indent, relative_indent, last_property, buffer);
 
   if (string != NULL) {
-    if (escaped != NULL) { free(escaped); }
+    if (!hb_string_is_empty(escaped)) { free(escaped.data); }
     if (!hb_string_is_empty(quoted)) { free(quoted.data); }
   }
 }

--- a/src/token.c
+++ b/src/token.c
@@ -89,22 +89,23 @@ const char* token_type_to_string(const token_type_T type) {
 
 char* token_to_string(const token_T* token) {
   const char* type_string = token_type_to_string(token->type);
-  const char* template = "#<Herb::Token type=\"%s\" value=\"%s\" range=[%u, %u] start=(%u:%u) end=(%u:%u)>";
+  const char* template = "#<Herb::Token type=\"%s\" value=\"%.*s\" range=[%u, %u] start=(%u:%u) end=(%u:%u)>";
 
   char* string = calloc(strlen(type_string) + strlen(template) + strlen(token->value) + 16, sizeof(char));
-  char* escaped;
+  hb_string_T escaped;
 
   if (token->type == TOKEN_EOF) {
-    escaped = herb_strdup("<EOF>");
+    escaped = hb_string(herb_strdup("<EOF>"));
   } else {
-    escaped = escape_newlines(token->value);
+    escaped = escape_newlines(hb_string(token->value));
   }
 
   sprintf(
     string,
     template,
     type_string,
-    escaped,
+    escaped.length,
+    escaped.data,
     token->range.from,
     token->range.to,
     token->location.start.line,
@@ -113,7 +114,7 @@ char* token_to_string(const token_T* token) {
     token->location.end.column
   );
 
-  free(escaped);
+  free(escaped.data);
 
   return string;
 }

--- a/src/util.c
+++ b/src/util.c
@@ -2,7 +2,6 @@
 #include "include/util/hb_buffer.h"
 #include "include/util/hb_string.h"
 
-#include <ctype.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -11,13 +10,13 @@ int is_newline(int character) {
   return character == '\n' || character == '\r';
 }
 
-char* escape_newlines(const char* input) {
+hb_string_T escape_newlines(hb_string_T input) {
   hb_buffer_T buffer;
 
-  hb_buffer_init(&buffer, strlen(input));
+  hb_buffer_init(&buffer, input.length);
 
-  for (size_t i = 0; i < strlen(input); ++i) {
-    switch (input[i]) {
+  for (size_t i = 0; i < input.length; ++i) {
+    switch (input.data[i]) {
       case '\n': {
         hb_buffer_append_char(&buffer, '\\');
         hb_buffer_append_char(&buffer, 'n');
@@ -27,12 +26,12 @@ char* escape_newlines(const char* input) {
         hb_buffer_append_char(&buffer, 'r');
       } break;
       default: {
-        hb_buffer_append_char(&buffer, input[i]);
+        hb_buffer_append_char(&buffer, input.data[i]);
       }
     }
   }
 
-  return buffer.value;
+  return hb_string(buffer.value);
 }
 
 static hb_string_T wrap_string(hb_string_T input, char character) {


### PR DESCRIPTION
This MR changes the `escape_newlines` function interface and implementationt to utilize `hb_string_T`.

