### PR TITLE
Introduce project-specific linter configuration

### DIFF
--- a/javascript/packages/language-server/README.md
+++ b/javascript/packages/language-server/README.md
@@ -111,13 +111,31 @@ npx @herb-tools/language-server --stdio
 
 The language server can be configured using a `.herb-lsp/config.json` file in your project root. This file is automatically created when the language server starts if it doesn't exist.
 
+### Linter Configuration
+
+You can configure formatting behavior by adding a `linter` section to your config:
+
+```json
+{
+  "version": "0.7.5",
+  "createdAt": "2025-06-29T00:00:00.000Z",
+  "updatedAt": "2025-06-29T00:00:00.000Z",
+  "options": {
+    "linter": {
+      "enabled": true,
+      "excludedRules": ["parser-no-errors"]
+    }
+  }
+}
+```
+
 ### Formatter Configuration
 
 You can configure formatting behavior by adding a `formatter` section to your config:
 
 ```json
 {
-  "version": "0.3.1",
+  "version": "0.7.5",
   "createdAt": "2025-06-29T00:00:00.000Z",
   "updatedAt": "2025-06-29T00:00:00.000Z",
   "options": {

--- a/javascript/packages/language-server/src/config.ts
+++ b/javascript/packages/language-server/src/config.ts
@@ -1,4 +1,10 @@
+import type { RuleClass } from '@herb-tools/linter';
+
 export type HerbConfigOptions = {
+  linter?: {
+    enabled?: boolean;
+    excludedRules?: string[]
+  }
   formatter?: {
     enabled?: boolean
     include?: string[]

--- a/javascript/packages/language-server/src/service.ts
+++ b/javascript/packages/language-server/src/service.ts
@@ -28,7 +28,7 @@ export class Service {
     this.documentService = new DocumentService(this.connection)
     this.project = new Project(connection, this.settings.projectPath.replace("file://", ""))
     this.parserService = new ParserService()
-    this.linterService = new LinterService(this.settings)
+    this.linterService = new LinterService(this.connection, this.project, this.settings)
     this.formatting = new FormattingService(this.connection, this.documentService.documents, this.project, this.settings)
     this.codeActionService = new CodeActionService()
     this.diagnostics = new Diagnostics(this.connection, this.documentService, this.parserService, this.linterService)
@@ -41,6 +41,7 @@ export class Service {
 
   async init() {
     await this.project.initialize()
+    await this.linterService.initialize()
     await this.formatting.initialize()
 
     this.config = await Config.fromPathOrNew(this.project.projectPath)
@@ -64,6 +65,7 @@ export class Service {
 
   async refreshConfig() {
     this.config = await Config.fromPathOrNew(this.project.projectPath)
+    await this.linterService.refreshConfig();
     await this.formatting.refreshConfig()
   }
 }


### PR DESCRIPTION
Allows to define project-specific linter options in .herb-lsp/config.json.

ATTOW all maintainers of a project must use e.g. a vscode (fork) editor to share project specific linter settings via workspace settings. This PR adds the ability to configure linter settings in the config.json like for the formatter and prioritize these settings over editor specific configurations.