### PR TITLE
C: Use `hb_string_T` in `element_source_to_string` function

### DIFF
--- a/src/element_source.c
+++ b/src/element_source.c
@@ -1,11 +1,12 @@
 #include "include/element_source.h"
+#include "include/util/hb_string.h"
 
-const char* element_source_to_string(element_source_t source) {
+hb_string_T element_source_to_string(element_source_t source) {
   switch (source) {
-    case ELEMENT_SOURCE_HTML: return "HTML";
-    case ELEMENT_SOURCE_ACTIONVIEW: return "ActionView";
-    case ELEMENT_SOURCE_HAML: return "Haml";
-    case ELEMENT_SOURCE_SLIM: return "Slim";
-    default: return "Unknown";
+    case ELEMENT_SOURCE_HTML: return hb_string("HTML");
+    case ELEMENT_SOURCE_ACTIONVIEW: return hb_string("ActionView");
+    case ELEMENT_SOURCE_HAML: return hb_string("Haml");
+    case ELEMENT_SOURCE_SLIM: return hb_string("Slim");
+    default: return hb_string("Unknown");
   }
 }

--- a/src/include/element_source.h
+++ b/src/include/element_source.h
@@ -1,6 +1,8 @@
 #ifndef HERB_ELEMENT_SOURCE_H
 #define HERB_ELEMENT_SOURCE_H
 
+#include "util/hb_string.h"
+
 typedef enum {
   ELEMENT_SOURCE_HTML,
   ELEMENT_SOURCE_ACTIONVIEW,
@@ -8,6 +10,6 @@ typedef enum {
   ELEMENT_SOURCE_SLIM
 } element_source_t;
 
-const char* element_source_to_string(element_source_t source);
+hb_string_T element_source_to_string(element_source_t source);
 
 #endif

--- a/templates/ext/herb/nodes.c.erb
+++ b/templates/ext/herb/nodes.c.erb
@@ -39,7 +39,11 @@ static VALUE rb_<%= node.human %>_from_c_struct(<%= node.struct_type %>* <%= nod
   <%- when Herb::Template::ArrayField -%>
   VALUE <%= node.human %>_<%= field.name %> = rb_nodes_array_from_c_array(<%= node.human %>-><%= field.name %>);
   <%- when Herb::Template::ElementSourceField -%>
-  VALUE <%= node.human %>_<%= field.name %> = rb_utf8_str_new_cstr(element_source_to_string(<%= node.human %>-><%= field.name %>));
+  VALUE <%= node.human %>_<%= field.name %>;
+  {
+    hb_string_T element_source_string = element_source_to_string(<%= node.human %>-><%= field.name %>);
+    <%= node.human %>_<%= field.name %> = rb_utf8_str_new(element_source_string.data, element_source_string.length);
+  }
   <%- else -%>
   /* <%= field.inspect %> */
   VALUE <%= node.human %>_<%= field.name %> = Qnil;

--- a/templates/javascript/packages/node/extension/nodes.cpp.erb
+++ b/templates/javascript/packages/node/extension/nodes.cpp.erb
@@ -58,7 +58,7 @@ napi_value <%= node.human %>NodeFromCStruct(napi_env env, <%= node.struct_type %
   napi_set_named_property(env, result, "<%= field.name %>", <%= field.name %>);
 
   <%- when Herb::Template::ElementSourceField -%>
-  napi_value <%= field.name %> = CreateString(env, element_source_to_string(<%= node.human %>-><%= field.name %>));
+  napi_value <%= field.name %> = CreateStringFromHbString(env, element_source_to_string(<%= node.human %>-><%= field.name %>));
   napi_set_named_property(env, result, "<%= field.name %>", <%= field.name %>);
 
   <%- else -%>

--- a/templates/src/ast_pretty_print.c.erb
+++ b/templates/src/ast_pretty_print.c.erb
@@ -39,7 +39,7 @@ void ast_pretty_print_node(AST_NODE_T* node, const size_t indent, const size_t r
       <%- when Herb::Template::BooleanField -%>
       pretty_print_boolean_property(hb_string("<%= field.name %>"), <%= node.human %>-><%= field.name %>, indent, relative_indent, <%= last %>, buffer);
       <%- when Herb::Template::ElementSourceField -%>
-      pretty_print_string_property(hb_string(element_source_to_string(<%= node.human %>-><%= field.name %>)), hb_string("<%= field.name %>"), indent, relative_indent, <%= last %>, buffer);
+      pretty_print_string_property(element_source_to_string(<%= node.human %>-><%= field.name %>), hb_string("<%= field.name %>"), indent, relative_indent, <%= last %>, buffer);
       <%- when Herb::Template::StringField -%>
       pretty_print_string_property(hb_string(<%= node.human %>-><%= field.name %>), hb_string("<%= field.name %>"), indent, relative_indent, <%= last %>, buffer);
       <%- when Herb::Template::PrismNodeField -%>

--- a/templates/wasm/nodes.cpp.erb
+++ b/templates/wasm/nodes.cpp.erb
@@ -38,7 +38,7 @@ val <%= node.name %>FromCStruct(<%= node.struct_type %>* <%= node.human %>) {
   <%- when Herb::Template::ArrayField -%>
   result.set("<%= field.name %>", NodesArrayFromCArray(<%= node.human %>-><%= field.name %>));
   <%- when Herb::Template::ElementSourceField -%>
-  result.set("<%= field.name %>", CreateString(element_source_to_string(<%= node.human %>-><%= field.name %>)));
+  result.set("<%= field.name %>", CreateStringFromHbString(element_source_to_string(<%= node.human %>-><%= field.name %>)));
   <%- else -%>
   result.set("<%= field.name %>", val::null());
   <%- end -%>


### PR DESCRIPTION
This PR starts using the `hb_string_T` for strings when returning the element source string.