### PR TITLE
C: Fix `KB` macro argument warning

### DIFF
--- a/src/include/macros.h
+++ b/src/include/macros.h
@@ -5,7 +5,7 @@
 
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
 
-#define KB(kb) (1024 * kb)
+#define KB(kb) (1024 * (kb))
 
 #define MB(mb) (1024 * KB(mb))
 


### PR DESCRIPTION
```
warning: macro argument should be enclosed in parentheses [bugprone-macro-parentheses]
    8 | #define KB(kb) (1024 * kb)
      |                        ^
      |                        ( )
```

Closes #684