### PR TITLE
Formatter: Fix Bug where `case` children were lost

### DIFF
--- a/javascript/packages/formatter/src/format-printer.ts
+++ b/javascript/packages/formatter/src/format-printer.ts
@@ -1058,6 +1058,8 @@ export class FormatPrinter extends Printer {
 
   visitERBCaseMatchNode(node: ERBCaseMatchNode) {
     this.printERBNode(node)
+
+    this.withIndent(() => this.visitAll(node.children))
     this.visitAll(node.conditions)
 
     if (node.else_clause) this.visit(node.else_clause)
@@ -1137,6 +1139,8 @@ export class FormatPrinter extends Printer {
 
   visitERBCaseNode(node: ERBCaseNode) {
     this.printERBNode(node)
+
+    this.withIndent(() => this.visitAll(node.children))
     this.visitAll(node.conditions)
 
     if (node.else_clause) this.visit(node.else_clause)

--- a/javascript/packages/formatter/test/erb-formatter/erb-formatter-compat.test.ts
+++ b/javascript/packages/formatter/test/erb-formatter/erb-formatter-compat.test.ts
@@ -306,6 +306,7 @@ describe("ERB Formatter Compatibility Tests", () => {
       expect(result).toBe(dedent`
         <% case status
            when 'active' %>
+          <span class="badge-active">Active</span>
         <% when 'inactive' %>
           <span class="badge-inactive">Inactive</span>
         <% else %>

--- a/javascript/packages/formatter/test/erb/case.test.ts
+++ b/javascript/packages/formatter/test/erb/case.test.ts
@@ -142,4 +142,36 @@ describe("@herb-tools/formatter", () => {
     const output = formatter.format(input)
     expect(output).toEqual(expected)
   })
+
+  test("case/when with children", () => {
+    const input = dedent`
+      <% case variable %>
+        <h1>Children</h1>
+      <% when Integer %>
+        <h1>Integer</h1>
+      <% when String %>
+        <h1>String</h1>
+      <% else %>
+        <h1>else</h1>
+      <% end %>
+    `
+
+    const output = formatter.format(input)
+    expect(output).toEqual(input)
+  })
+
+  test("case/in with children", () => {
+    const input = dedent`
+      <% case { hash: { nested: '4' } } %>
+        <span>children</span>
+      <% in { hash: { nested: } } %>
+        <span>nested</span>
+      <% else %>
+        <span>else</span>
+      <% end %>
+    `
+
+    const output = formatter.format(input)
+    expect(output).toEqual(input)
+  })
 })


### PR DESCRIPTION
This pull request fixes a bug in the formatter where it would drop the children of `case/when` and `case/in` statements.


```html+erb
<% case variable %>
  <h1>Children</h1>
<% else %>
  <h1>else</h1>
<% end %>
```

was formatted as:
```html+erb
<% case variable %>
<% else %>
  <h1>else</h1>
<% end %>
```

Now they are being preserved:
```html+erb
<% case variable %>
  <h1>Children</h1>
<% else %>
  <h1>else</h1>
<% end %>
```
