### PR TITLE
Ruby: Drop `rbs-inline` fork since it's now fixed upstream

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem "reline", "~> 0.6"
 gem "rubocop", "~> 1.71"
 
 group :development do
-  gem "rbs-inline", require: false, github: "marcoroth/rbs-inline", branch: "prism"
+  gem "rbs-inline", "~> 0.12"
   gem "sorbet"
   gem "steep", "~> 1.10"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,4 @@
 GIT
-  remote: https://github.com/marcoroth/rbs-inline.git
-  revision: 1e9266c0d6452faf30f13594f25e1548587f000d
-  branch: prism
-  specs:
-    rbs-inline (0.11.0)
-      prism (>= 0.29)
-      rbs (>= 3.5.0)
-
-GIT
   remote: https://github.com/ruby/prism.git
   revision: 2924f8f8832d57def7895cd7e2cc199ee58b3a3b
   tag: v1.6.0
@@ -123,8 +114,11 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
-    rbs (3.9.4)
+    rbs (3.9.5)
       logger
+    rbs-inline (0.12.0)
+      prism (>= 0.29)
+      rbs (>= 3.8.0)
     regexp_parser (2.11.2)
     reline (0.6.2)
       io-console (~> 0.5)
@@ -197,7 +191,7 @@ DEPENDENCIES
   rake (~> 13.2)
   rake-compiler (~> 1.3)
   rake-compiler-dock (~> 1.10)
-  rbs-inline!
+  rbs-inline (~> 0.12)
   reline (~> 0.6)
   rubocop (~> 1.71)
   sorbet


### PR DESCRIPTION
https://github.com/soutaro/rbs-inline/pull/207