### PR TITLE
Formatter: Try to persist `<%# herb:disable %>` nodes when formatting

### DIFF
--- a/javascript/packages/formatter/src/format-printer.ts
+++ b/javascript/packages/formatter/src/format-printer.ts
@@ -23,6 +23,7 @@ import {
   endsWithAlphanumeric,
   endsWithWhitespace,
   filterEmptyNodes,
+  filterEmptyNodesForHerbDisable,
   filterSignificantChildren,
   findPreviousMeaningfulSibling,
   hasComplexERBControlFlow,
@@ -30,10 +31,13 @@ import {
   hasMultilineTextContent,
   hasWhitespaceBetween,
   isBlockLevelNode,
+  isClosingPunctuation,
   isContentPreserving,
+  isHerbDisableComment,
   isInlineElement,
   isNonWhitespaceNode,
   isPureWhitespaceNode,
+  needsSpaceBetween,
   normalizeAndSplitWords,
   shouldAppendToLastLine,
   shouldPreserveUserSpacing,
@@ -764,11 +768,68 @@ export class FormatPrinter extends Printer {
 
     if (children.length === 0) return
 
+    let leadingHerbDisableComment: Node | null = null
+    let leadingHerbDisableIndex = -1
+    let firstWhitespaceIndex = -1
+    let remainingChildren = children
+
+    for (let i = 0; i < children.length; i++) {
+      const child = children[i]
+
+      if (isNode(child, WhitespaceNode) || isPureWhitespaceNode(child)) {
+        if (firstWhitespaceIndex < 0) {
+          firstWhitespaceIndex = i
+        }
+
+        continue
+      }
+
+      if (isNode(child, ERBContentNode) && isHerbDisableComment(child)) {
+        leadingHerbDisableComment = child
+        leadingHerbDisableIndex = i
+      }
+
+      break
+    }
+
+    if (leadingHerbDisableComment && leadingHerbDisableIndex >= 0) {
+      remainingChildren = children.filter((_, index) => {
+        if (index === leadingHerbDisableIndex) return false
+
+        if (firstWhitespaceIndex >= 0 && index === leadingHerbDisableIndex - 1) {
+          const child = children[index]
+
+          if (isNode(child, WhitespaceNode) || isPureWhitespaceNode(child)) {
+            return false
+          }
+        }
+
+        return true
+      })
+    }
+
+    if (leadingHerbDisableComment) {
+      const herbDisableString = this.capture(() => {
+        const savedIndentLevel = this.indentLevel
+        this.indentLevel = 0
+        this.inlineMode = true
+        this.visit(leadingHerbDisableComment)
+        this.inlineMode = false
+        this.indentLevel = savedIndentLevel
+      }).join("")
+
+      const hasLeadingWhitespace = firstWhitespaceIndex >= 0 && firstWhitespaceIndex < leadingHerbDisableIndex
+
+      this.pushToLastLine((hasLeadingWhitespace ? ' ' : '') + herbDisableString)
+    }
+
+    if (remainingChildren.length === 0) return
+
     this.withIndent(() => {
       if (hasTextFlow) {
-        this.visitTextFlowChildren(children)
+        this.visitTextFlowChildren(remainingChildren)
       } else {
-        this.visitElementChildren(body, element)
+        this.visitElementChildren(leadingHerbDisableComment ? remainingChildren : body, element)
       }
     })
   }
@@ -817,7 +878,44 @@ export class FormatPrinter extends Printer {
         }
       }
 
-      this.visit(child)
+      let hasTrailingHerbDisable = false
+
+      if (isNode(child, HTMLElementNode) && child.close_tag) {
+        for (let j = i + 1; j < body.length; j++) {
+          const nextChild = body[j]
+
+          if (isNode(nextChild, WhitespaceNode) || isPureWhitespaceNode(nextChild)) {
+            continue
+          }
+
+          if (isNode(nextChild, ERBContentNode) && isHerbDisableComment(nextChild)) {
+            hasTrailingHerbDisable = true
+
+            this.visit(child)
+
+            const herbDisableString = this.capture(() => {
+              const savedIndentLevel = this.indentLevel
+              this.indentLevel = 0
+              this.inlineMode = true
+              this.visit(nextChild)
+              this.inlineMode = false
+              this.indentLevel = savedIndentLevel
+            }).join("")
+
+            this.pushToLastLine(' ' + herbDisableString)
+
+            i = j
+
+            break
+          }
+
+          break
+        }
+      }
+
+      if (!hasTrailingHerbDisable) {
+        this.visit(child)
+      }
 
       if (isNonWhitespaceNode(child)) {
         lastWasMeaningful = true
@@ -1000,13 +1098,22 @@ export class FormatPrinter extends Printer {
       const startsWithSpace = content[0] === " "
       const before = startsWithSpace ? "" : " "
 
-      this.pushWithIndent(open + before + content.trimEnd() + ' ' + close)
+      if (this.inlineMode) {
+        this.push(open + before + content.trimEnd() + ' ' + close)
+      } else {
+        this.pushWithIndent(open + before + content.trimEnd() + ' ' + close)
+      }
 
       return
     }
 
     if (contentTrimmedLines.length === 1) {
-      this.pushWithIndent(open + ' ' + content.trim() + ' ' + close)
+      if (this.inlineMode) {
+        this.push(open + ' ' + content.trim() + ' ' + close)
+      } else {
+        this.pushWithIndent(open + ' ' + content.trim() + ' ' + close)
+      }
+
       return
     }
 
@@ -1260,6 +1367,22 @@ export class FormatPrinter extends Printer {
     if (!openTagInline) return false
     if (children.length === 0) return true
 
+    let hasLeadingHerbDisable = false
+
+    for (const child of node.body) {
+      if (isNode(child, WhitespaceNode) || isPureWhitespaceNode(child)) {
+        continue
+      }
+      if (isNode(child, ERBContentNode) && isHerbDisableComment(child)) {
+        hasLeadingHerbDisable = true
+      }
+      break
+    }
+
+    if (hasLeadingHerbDisable && !isInlineElement(tagName)) {
+      return false
+    }
+
     if (isInlineElement(tagName)) {
       const fullInlineResult = this.tryRenderInlineFull(node, tagName, filterNodes(node.open_tag?.children, HTMLAttributeNode), node.body)
 
@@ -1411,9 +1534,11 @@ export class FormatPrinter extends Printer {
       return `<${tagName}${attributesString}${isSelfClosing ? " />" : ">"}`
     }
 
+    const childrenToRender = this.getFilteredChildren(element.body)
+
     const childInline = this.tryRenderInlineFull(element, tagName,
       filterNodes(element.open_tag?.children, HTMLAttributeNode),
-      filterEmptyNodes(element.body)
+      childrenToRender
     )
 
     return childInline !== null ? childInline : ""
@@ -1454,7 +1579,7 @@ export class FormatPrinter extends Printer {
    */
   private buildAndWrapTextFlow(children: Node[]): void {
     const unitsWithNodes: ContentUnitWithNode[] = this.buildContentUnitsWithNodes(children)
-    const words: string[] = []
+    const words: Array<{ word: string, isHerbDisable: boolean }> = []
 
     for (const { unit, node } of unitsWithNodes) {
       if (unit.breaksFlow) {
@@ -1464,12 +1589,13 @@ export class FormatPrinter extends Printer {
           this.visit(node)
         }
       } else if (unit.isAtomic) {
-        words.push(unit.content)
+        words.push({ word: unit.content, isHerbDisable: unit.isHerbDisable || false })
       } else {
         const text = unit.content.replace(/\s+/g, ' ').trim()
 
         if (text) {
-          words.push(...text.split(' '))
+          const textWords = text.split(' ').map(w => ({ word: w, isHerbDisable: false }))
+          words.push(...textWords)
         }
       }
     }
@@ -1594,7 +1720,8 @@ export class FormatPrinter extends Printer {
    */
   private processInlineElement(result: ContentUnitWithNode[], children: Node[], child: HTMLElementNode, index: number, lastProcessedIndex: number): boolean {
     const tagName = getTagName(child)
-    const inlineContent = this.tryRenderInlineFull(child, tagName, filterNodes(child.open_tag?.children, HTMLAttributeNode), filterEmptyNodes(child.body))
+    const childrenToRender = this.getFilteredChildren(child.body)
+    const inlineContent = this.tryRenderInlineFull(child, tagName, filterNodes(child.open_tag?.children, HTMLAttributeNode), childrenToRender)
 
     if (inlineContent === null) {
       result.push({
@@ -1626,6 +1753,7 @@ export class FormatPrinter extends Printer {
    */
   private processERBContentNode(result: ContentUnitWithNode[], children: Node[], child: ERBContentNode, index: number, lastProcessedIndex: number): boolean {
     const erbContent = this.renderERBAsString(child)
+    const isHerbDisable = isHerbDisableComment(child)
 
     if (lastProcessedIndex >= 0) {
       const hasWhitespace = hasWhitespaceBetween(children, lastProcessedIndex, index) || this.lastUnitEndsWithWhitespace(result)
@@ -1636,7 +1764,7 @@ export class FormatPrinter extends Printer {
     }
 
     result.push({
-      unit: { content: erbContent, type: 'erb', isAtomic: true, breaksFlow: false },
+      unit: { content: erbContent, type: 'erb', isAtomic: true, breaksFlow: false, isHerbDisable },
       node: child
     })
 
@@ -1705,7 +1833,7 @@ export class FormatPrinter extends Printer {
   /**
    * Flush accumulated words to output with wrapping
    */
-  private flushWords(words: string[]): void {
+  private flushWords(words: Array<{ word: string, isHerbDisable: boolean }>): void {
     if (words.length > 0) {
       this.wrapAndPushWords(words)
       words.length = 0
@@ -1715,20 +1843,32 @@ export class FormatPrinter extends Printer {
   /**
    * Wrap words to fit within line length and push to output
    * Handles punctuation spacing intelligently
+   * Excludes herb:disable comments from line length calculations
    */
-  private wrapAndPushWords(words: string[]): void {
+  private wrapAndPushWords(words: Array<{ word: string, isHerbDisable: boolean }>): void {
     const wrapWidth = this.maxLineLength - this.indent.length
     const lines: string[] = []
     let currentLine = ""
+    let effectiveLength = 0
 
-    for (const word of words) {
+    for (const { word, isHerbDisable } of words) {
       const nextLine = buildLineWithWord(currentLine, word)
 
-      if (shouldWrapToNextLine(nextLine, currentLine, word, wrapWidth)) {
+      let nextEffectiveLength = effectiveLength
+
+      if (!isHerbDisable) {
+        const spaceBefore = currentLine && needsSpaceBetween(currentLine, word) ? 1 : 0
+        nextEffectiveLength = effectiveLength + spaceBefore + word.length
+      }
+
+      if (currentLine && !isClosingPunctuation(word) && nextEffectiveLength >= wrapWidth) {
         lines.push(this.indent + currentLine)
+
         currentLine = word
+        effectiveLength = isHerbDisable ? 0 : word.length
       } else {
         currentLine = nextLine
+        effectiveLength = nextEffectiveLength
       }
     }
 
@@ -1892,13 +2032,34 @@ export class FormatPrinter extends Printer {
   }
 
   /**
+   * Check if children contain a leading herb:disable comment (after optional whitespace)
+   */
+  private hasLeadingHerbDisable(children: Node[]): boolean {
+    for (const child of children) {
+      if (isNode(child, WhitespaceNode) || (isNode(child, HTMLTextNode) && child.content.trim() === "")) {
+        continue
+      }
+
+      return isNode(child, ERBContentNode) && isHerbDisableComment(child)
+    }
+
+    return false
+  }
+
+  /**
    * Try to render just the children inline (without tags)
    */
   private tryRenderChildrenInline(children: Node[]): string | null {
     let result = ""
     let hasInternalWhitespace = false
 
+    const hasHerbDisable = this.hasLeadingHerbDisable(children)
+    let addedLeadingSpace = false
+
     for (const child of children) {
+      const isWhitespace = isNode(child, WhitespaceNode) ||
+        (isNode(child, HTMLTextNode) && child.content.trim() === "")
+
       if (isNode(child, HTMLTextNode)) {
         const normalizedContent = child.content.replace(/\s+/g, ' ')
         const hasLeadingSpace = /^\s/.test(child.content)
@@ -1906,26 +2067,27 @@ export class FormatPrinter extends Printer {
         const trimmedContent = normalizedContent.trim()
 
         if (trimmedContent) {
-          let finalContent = trimmedContent
-
           if (hasLeadingSpace && result && !result.endsWith(' ')) {
-            finalContent = ' ' + finalContent
+            result += ' '
           }
+
+          result += trimmedContent
 
           if (hasTrailingSpace) {
-            finalContent = finalContent + ' '
-          }
-
-          result += finalContent
-        } else if (hasLeadingSpace || hasTrailingSpace) {
-          if (result && !result.endsWith(' ')) {
             result += ' '
-            hasInternalWhitespace = true
           }
+        } else if (isWhitespace) {
+          // Fall through to whitespace handling
+        } else {
+          continue
         }
+      }
 
-      } else if (isNode(child, WhitespaceNode)) {
-        if (result && !result.endsWith(' ')) {
+      if (isWhitespace && !result.endsWith(' ')) {
+        if (!result && hasHerbDisable && !addedLeadingSpace) {
+          result += ' '
+          addedLeadingSpace = true
+        } else if (result) {
           result += ' '
           hasInternalWhitespace = true
         }
@@ -1936,9 +2098,10 @@ export class FormatPrinter extends Printer {
           return null
         }
 
+        const childrenToRender = this.getFilteredChildren(child.body)
         const childInline = this.tryRenderInlineFull(child, tagName,
           filterNodes(child.open_tag?.children, HTMLAttributeNode),
-          filterEmptyNodes(child.body)
+          childrenToRender
         )
 
         if (!childInline) {
@@ -1946,19 +2109,20 @@ export class FormatPrinter extends Printer {
         }
 
         result += childInline
-      } else {
+      } else if (!isNode(child, HTMLTextNode) && !isWhitespace) {
         const wasInlineMode = this.inlineMode
         this.inlineMode = true
-
         const captured = this.capture(() => this.visit(child)).join("")
-
         this.inlineMode = wasInlineMode
-
         result += captured
       }
     }
 
-    return hasInternalWhitespace ? result : result.trim()
+    if (hasInternalWhitespace || (hasHerbDisable && result.startsWith(' '))) {
+      return result
+    }
+
+    return result.trim()
   }
 
   /**
@@ -1991,9 +2155,19 @@ export class FormatPrinter extends Printer {
     return `<${tagName}>${content}</${tagName}>`
   }
 
-  private renderElementInline(element: HTMLElementNode): string {
-    const children = filterEmptyNodes(element.body)
+  /**
+   * Get filtered children, using smart herb:disable filtering if needed
+   */
+  private getFilteredChildren(body: Node[]): Node[] {
+    const hasHerbDisable = body.some(child =>
+      isNode(child, ERBContentNode) && isHerbDisableComment(child)
+    )
 
+    return hasHerbDisable ? filterEmptyNodesForHerbDisable(body) : filterEmptyNodes(body)
+  }
+
+  private renderElementInline(element: HTMLElementNode): string {
+    const children = this.getFilteredChildren(element.body)
     return this.renderChildrenInline(children)
   }
 

--- a/javascript/packages/formatter/test/herb-disable-comment-formatting.test.ts
+++ b/javascript/packages/formatter/test/herb-disable-comment-formatting.test.ts
@@ -1,0 +1,327 @@
+import { describe, test, expect, beforeAll } from "vitest"
+import { Herb } from "@herb-tools/node-wasm"
+import { Formatter } from "../src"
+import dedent from "dedent"
+
+let formatter: Formatter
+
+describe("herb:disable comment formatting", () => {
+  beforeAll(async () => {
+    await Herb.load()
+
+    formatter = new Formatter(Herb, {
+      indentWidth: 2,
+      maxLineLength: 80,
+    })
+  })
+
+  test("should keep herb:disable comment inline after opening tag", () => {
+    const source = dedent`
+      <DIV> <%# herb:disable html-tag-name-lowercase %>
+        Dolores id occaecati ipsam. Eius blanditiis odio quas. Corrupti officia quasi sunt neque soluta veritatis. Sint esse nihil alias quia qui. Aut omnis quia ut dolores reiciendis. Numquam voluptate esse voluptas.
+      </DIV> <%# herb:disable html-tag-name-lowercase %>
+    `
+
+    const result = formatter.format(source)
+
+    expect(result).toBe(dedent`
+      <DIV> <%# herb:disable html-tag-name-lowercase %>
+        Dolores id occaecati ipsam. Eius blanditiis odio quas. Corrupti officia quasi
+        sunt neque soluta veritatis. Sint esse nihil alias quia qui. Aut omnis quia
+        ut dolores reiciendis. Numquam voluptate esse voluptas.
+      </DIV> <%# herb:disable html-tag-name-lowercase %>
+    `)
+  })
+
+  test("should keep herb:disable comment inline after opening tag nested in other element", () => {
+    const source = dedent`
+      <div>
+        <DIV> <%# herb:disable html-tag-name-lowercase %>
+          Dolores id occaecati ipsam. Eius blanditiis odio quas. Corrupti officia quasi sunt neque soluta veritatis. Sint esse nihil alias quia qui. Aut omnis quia ut dolores reiciendis. Numquam voluptate esse voluptas.
+        </DIV> <%# herb:disable html-tag-name-lowercase %>
+      </div>
+    `
+
+    const result = formatter.format(source)
+
+    expect(result).toBe(dedent`
+      <div>
+        <DIV> <%# herb:disable html-tag-name-lowercase %>
+          Dolores id occaecati ipsam. Eius blanditiis odio quas. Corrupti officia
+          quasi sunt neque soluta veritatis. Sint esse nihil alias quia qui. Aut
+          omnis quia ut dolores reiciendis. Numquam voluptate esse voluptas.
+        </DIV> <%# herb:disable html-tag-name-lowercase %>
+      </div>
+    `)
+  })
+
+  test("should keep herb:disable comment inline after closing tag", () => {
+    const source = dedent`
+      <DIV>
+        Some content here that needs formatting.
+      </DIV> <%# herb:disable html-tag-name-lowercase %>
+    `
+
+    const result = formatter.format(source)
+
+    expect(result).toBe(source)
+  })
+
+  test("should not count herb:disable comment length in line wrapping calculations", () => {
+    const source = dedent`
+      <DIV> <%# herb:disable html-tag-name-lowercase, some-super-long-rule-names-that-should-make-this-wrap-but-it-doesnt-because-its-a-herb-disable-comment %>
+        Short text here that should not wrap.
+      </DIV>
+    `
+
+    const result = formatter.format(source)
+
+    expect(result).toBe(source)
+  })
+
+  test("should treat herb:disable as 'invisible' for text flow wrapping", () => {
+    const source = dedent`
+      <p> <%# herb:disable some-rule %>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+      </p>
+    `
+
+    const result = formatter.format(source)
+
+    expect(result).toBe(dedent`
+      <p> <%# herb:disable some-rule %>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua.
+      </p>
+    `)
+  })
+
+  test("should handle herb:disable all comment", () => {
+    const source = dedent`
+      <SPAN> <%# herb:disable all %>
+        Some content that needs wrapping because it is quite long and exceeds the line length limit.
+      </SPAN>
+    `
+
+    const result = formatter.format(source)
+
+    expect(result).toBe(dedent`
+      <SPAN> <%# herb:disable all %>
+        Some content that needs wrapping because it is quite long and exceeds the
+        line length limit.
+      </SPAN>
+    `)
+  })
+
+  test("should handle multiple rule names in herb:disable comment", () => {
+    const source = dedent`
+      <DIV> <%# herb:disable rule-one, rule-two, rule-three %>
+        Text content here.
+      </DIV>
+    `
+
+    const result = formatter.format(source)
+
+    expect(result).toBe(source)
+  })
+
+  test("should preserve herb:disable comment whitespace and position", () => {
+    const source = dedent`
+      <DIV><%# herb:disable html-tag-name-lowercase %>
+        Content here.
+      </DIV>
+    `
+
+    const result = formatter.format(source)
+
+    expect(result).toBe(source)
+  })
+
+  test("should not treat regular ERB comments as herb:disable", () => {
+    const source = dedent`
+      <div> <%# just a regular comment %>
+        Some text that should wrap normally when it gets very long and exceeds the maximum line length limit.
+      </div>
+    `
+
+    const result = formatter.format(source)
+
+    expect(result).not.toBe(dedent`
+      <div> <%# just a regular comment %>
+        Some text that should wrap normally when it gets very long and exceeds the
+        maximum line length limit.
+      </div>
+    `)
+  })
+
+  test("should handle herb:disable in inline elements", () => {
+    const source = dedent`
+      <p>
+        Some text with <span> <%# herb:disable some-rule %>inline content</span> here.
+      </p>
+    `
+
+    const result = formatter.format(source)
+
+    expect(result).toBe(dedent`
+      <p>
+        Some text with <span> <%# herb:disable some-rule %>inline content</span>
+        here.
+      </p>
+    `)
+  })
+
+  test("should handle multiple herb:disable comments (opening and middle)", () => {
+    const source = dedent`
+      <DIV> <%# herb:disable html-tag-name-lowercase %>
+        Some content here.
+        <%# herb:disable another-rule %>
+        More content.
+      </DIV>
+    `
+
+    const result = formatter.format(source)
+
+    expect(result).toBe(dedent`
+      <DIV> <%# herb:disable html-tag-name-lowercase %>
+        Some content here. <%# herb:disable another-rule %> More content.
+      </DIV>
+    `)
+  })
+
+  test("should handle empty elements with herb:disable", () => {
+    const source = dedent`
+      <div> <%# herb:disable some-rule %>
+      </div>
+    `
+
+    const result = formatter.format(source)
+
+    expect(result).toBe(dedent`
+      <div> <%# herb:disable some-rule %>
+      </div>
+    `)
+  })
+
+  test("should handle herb:disable with ERB output tags", () => {
+    const source = dedent`
+      <div> <%# herb:disable some-rule %>
+        <%= content %>
+      </div>
+    `
+
+    const result = formatter.format(source)
+
+    expect(result).toBe(dedent`
+      <div> <%# herb:disable some-rule %>
+        <%= content %>
+      </div>
+    `)
+  })
+
+  test("should handle deeply nested herb:disable (3 levels)", () => {
+    const source = dedent`
+      <div>
+        <section>
+          <DIV> <%# herb:disable html-tag-name-lowercase %>
+            Content here.
+          </DIV>
+        </section>
+      </div>
+    `
+
+    const result = formatter.format(source)
+
+    expect(result).toBe(dedent`
+      <div>
+        <section>
+          <DIV> <%# herb:disable html-tag-name-lowercase %>
+            Content here.
+          </DIV>
+        </section>
+      </div>
+    `)
+  })
+
+  test("should handle very long herb:disable rule lists", () => {
+    const source = dedent`
+      <DIV> <%# herb:disable rule-one, rule-two, rule-three, rule-four, rule-five, rule-six, rule-seven %>
+        Content.
+      </DIV>
+    `
+
+    const result = formatter.format(source)
+
+    expect(result).toBe(source)
+  })
+
+  test("should handle herb:disable between sibling elements", () => {
+    const source = dedent`
+      <div>
+        <p>First paragraph</p>
+        <%# herb:disable some-rule %>
+        <p>Second paragraph</p>
+      </div>
+    `
+
+    const result = formatter.format(source)
+
+    expect(result).toBe(dedent`
+      <div>
+        <p>First paragraph</p> <%# herb:disable some-rule %>
+        <p>Second paragraph</p>
+      </div>
+    `)
+  })
+
+  test("should handle consecutive herb:disable comments", () => {
+    const source = dedent`
+      <DIV> <%# herb:disable rule-one %>
+      <%# herb:disable rule-two %>
+        Content here.
+      </DIV>
+    `
+
+    const result = formatter.format(source)
+
+    expect(result).toBe(dedent`
+      <DIV> <%# herb:disable rule-one %>
+        <%# herb:disable rule-two %> Content here.
+      </DIV>
+    `)
+  })
+
+  test("reproduces the exact issue from #738", () => {
+    const source = dedent`
+      <DIV> <%# herb:disable html-tag-name-lowercase %>
+        Dolores id occaecati ipsam. Eius blanditiis odio quas. Corrupti officia quasi sunt neque soluta veritatis. Sint esse nihil alias quia qui. Aut omnis quia ut dolores reiciendis. Numquam voluptate esse voluptas.
+      </DIV> <%# herb:disable html-tag-name-lowercase %>
+    `
+
+    const result = formatter.format(source)
+
+    const expectedOutput = dedent`
+      <DIV> <%# herb:disable html-tag-name-lowercase %>
+        Dolores id occaecati ipsam. Eius blanditiis odio quas. Corrupti officia quasi
+        sunt neque soluta veritatis. Sint esse nihil alias quia qui. Aut omnis quia
+        ut dolores reiciendis. Numquam voluptate esse voluptas.
+      </DIV> <%# herb:disable html-tag-name-lowercase %>
+    `
+
+    expect(result).toBe(expectedOutput)
+  })
+
+  test("handles erb if nodes", () => {
+    const source = dedent`
+      <%if valid?%> <%# herb:disable erb-require-whitespace-inside-tags %>
+        <%=content%> <%# herb:disable erb-require-whitespace-inside-tags %>
+      <%else%> <%# herb:disable erb-require-whitespace-inside-tags %>
+        <%=other_content%> <%# herb:disable erb-require-whitespace-inside-tags %>
+      <%end5> <%# herb:disable erb-require-whitespace-inside-tags %>
+    `
+
+    const result = formatter.format(source)
+
+    expect(result).toBe(source)
+  })
+})


### PR DESCRIPTION
This pull request introduces improved handling for `<%# herb:disable %>` comments in the formatter, ensuring that whitespace around the disable comments is preserved correctly and that they do not interfere with line wrapping or inline rendering and thus re-introduce linter offenses.

Resolves #738