### PR TITLE
Formatter: Improve whitespace formatting on the root-level

### DIFF
--- a/javascript/packages/formatter/src/format-helpers.ts
+++ b/javascript/packages/formatter/src/format-helpers.ts
@@ -235,6 +235,12 @@ export function buildLineWithWord(currentLine: string, word: string): string {
     return currentLine.endsWith(' ') ? currentLine : `${currentLine} `
   }
 
+  if (isClosingPunctuation(word)) {
+    currentLine = currentLine.trimEnd()
+
+    return `${currentLine}${word}`
+  }
+
   return needsSpaceBetween(currentLine, word) ? `${currentLine} ${word}` : `${currentLine}${word}`
 }
 

--- a/javascript/packages/formatter/test/erb/erb.test.ts
+++ b/javascript/packages/formatter/test/erb/erb.test.ts
@@ -367,9 +367,9 @@ describe("@herb-tools/formatter", () => {
     expect(result).toBe(dedent`
        <p>
          Visit
-         <a href="/products">our amazing product catalog with hundreds of items</a> or
-         <a href="/support">contact our customer support team</a> for assistance with
-         your order.
+         <a href="/products">our amazing product catalog with hundreds of items</a>
+         or <a href="/support">contact our customer support team</a> for assistance
+         with your order.
        </p>
      `)
   })
@@ -478,18 +478,6 @@ describe("@herb-tools/formatter", () => {
          <a href="https://example.com/very/long/path/to/documentation/page/so/long/that/it/should/break/the/content/of/the/tag">our comprehensive documentation</a>
          or contact support.
        </p>
-     `)
-  })
-
-  test("https://github.com/marcoroth/herb/issues/469#issue-3379906221", () => {
-    const input = dedent`
-       <%= @user.translated_greeting %>,<br>
-     `
-
-    const result = formatter.format(input)
-
-    expect(result).toBe(dedent`
-       <%= @user.translated_greeting %>,<br>
      `)
   })
 

--- a/javascript/packages/formatter/test/html/inline-elements.test.ts
+++ b/javascript/packages/formatter/test/html/inline-elements.test.ts
@@ -197,7 +197,7 @@ describe("@herb-tools/formatter - inline elements", () => {
     `)
   })
 
-  test("TODO", () => {
+  test("Element with ERB interpolation in text content", () => {
     const source = dedent`
       <h2 class="title">Posts (<%= @posts.count %>)</h2>
     `

--- a/javascript/packages/formatter/test/html/tags.test.ts
+++ b/javascript/packages/formatter/test/html/tags.test.ts
@@ -45,4 +45,83 @@ describe("@herb-tools/formatter", () => {
       <div id="hello"></div>
     `)
   })
+
+  test("<br>", () => {
+    const source = dedent`
+      One<br> Two<br> Three<br> Four<br>
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      One<br>
+      Two<br>
+      Three<br>
+      Four<br>
+    `)
+  })
+
+  test("<br> in <p>", () => {
+    const source = dedent`
+      <p>
+        One<br> Two<br> Three<br> Four<br>
+      </p>
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <p>
+        One
+        <br>
+        Two
+        <br>
+        Three
+        <br>
+        Four
+        <br>
+      </p>
+    `)
+  })
+
+  test("<hr>", () => {
+    const source = dedent`
+      One<hr> Two<hr> Three<hr> Four<hr>
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      One
+
+      <hr>
+
+      Two
+
+      <hr>
+
+      Three
+
+      <hr>
+
+      Four
+
+      <hr>
+    `)
+  })
+
+  test("<hr> in <p>", () => {
+    const source = dedent`
+      <p>
+        One<hr> Two<hr> Three<hr> Four<hr>
+      </p>
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <p>
+        One
+        <hr>
+        Two
+        <hr>
+        Three
+        <hr>
+        Four
+        <hr>
+      </p>
+    `)
+  })
 })

--- a/javascript/packages/formatter/test/html/text-content.test.ts
+++ b/javascript/packages/formatter/test/html/text-content.test.ts
@@ -140,7 +140,7 @@ describe("@herb-tools/formatter", () => {
     `)
   })
 
-  test("TODO", () => {
+  test("Block element nested inside inline context", () => {
     const source = dedent`
       <h1><div><b>hello</b></div></h1>
     `
@@ -150,5 +150,21 @@ describe("@herb-tools/formatter", () => {
         <div><b>hello</b></div>
       </h1>
     `)
+  })
+
+  test("root-level text with ERB interpolation", () => {
+    const source = dedent`
+      Hello, <%= @name %>, it is <%= @time %>.
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(source)
+  })
+
+  test("text with ERB interpolation inside element", () => {
+    const source = dedent`
+      <div>Hello, <%= @name %>, it is <%= @time %>.</div>
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(source)
   })
 })


### PR DESCRIPTION
**Input:**
```erb
Hello, <%= @name %>, it is <%= @time %>.
```

**Output (now)**
```erb
Hello, <%= @name %>, it is <%= @time %>.
```

**Before:**
```erb
Hello,<%= @name %>, it is<%= @time %>.
```




Resolves #727