### PR TITLE
Update Linux Instructions: Add LLVM Repository for Clang 21

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,6 @@ Before installing the dependencies, you need to add the LLVM repository and GPG 
 
 ```bash
 wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-sudo add-apt-repository "deb http://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-19 main"
 sudo add-apt-repository "deb http://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-21 main"
 sudo apt update
 ```


### PR DESCRIPTION
Adds steps to CONTRIBUTING.md for adding the LLVM repository and GPG key before installing Clang 21 and related tools on Linux.