### PR TITLE
C: Add `compile_flags.txt`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -156,3 +156,6 @@ docs/docs/public/c-reference
 
 # NPM
 **/node_modules/**/*
+
+# Clangd config
+compile_flags.txt

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ ifeq ($(os),Darwin)
   clang_tidy = $(llvm_path)/bin/clang-tidy
 endif
 
-all: templates prism $(exec) $(lib_name) $(static_lib_name) test wasm
+all: templates prism $(exec) $(lib_name) $(static_lib_name) test wasm clangd_config
 
 $(exec): $(objects)
 	$(cc) $(objects) $(flags) $(ldflags) $(prism_ldflags) -o $(exec)
@@ -121,6 +121,9 @@ lint:
 
 tidy:
 	$(clang_tidy) $(project_files) -- $(flags)
+
+clangd_config:
+	@echo "$(flags) $(test_cflags)" | tr ' ' '\n' | sort -u > compile_flags.txt
 
 wasm:
 	cd wasm && make


### PR DESCRIPTION
This PR adds a compile flags configuration [[ref](https://clangd.llvm.org/installation#compile_flagstxt)] for clangd. 

This way C files using prism are actually correctly resolved.