### PR TITLE
C: Use `uint32_t` in `utf8.c`

### DIFF
--- a/src/include/utf8.h
+++ b/src/include/utf8.h
@@ -2,10 +2,11 @@
 #define HERB_UTF8_H
 
 #include <stdbool.h>
+#include <stdint.h>
 #include <stdlib.h>
 
-int utf8_char_byte_length(unsigned char first_byte);
-int utf8_sequence_length(const char* str, size_t position, size_t max_length);
+uint32_t utf8_char_byte_length(unsigned char first_byte);
+uint32_t utf8_sequence_length(const char* str, size_t position, size_t max_length);
 bool utf8_is_valid_continuation_byte(unsigned char byte);
 
 #endif

--- a/src/utf8.c
+++ b/src/utf8.c
@@ -5,7 +5,7 @@
 //   110xxxxx = 2 bytes
 //   1110xxxx = 3 bytes
 //   11110xxx = 4 bytes
-int utf8_char_byte_length(unsigned char first_byte) {
+uint32_t utf8_char_byte_length(unsigned char first_byte) {
   if ((first_byte & 0x80) == 0) {
     return 1;
   } else if ((first_byte & 0xE0) == 0xC0) {
@@ -24,18 +24,18 @@ bool utf8_is_valid_continuation_byte(unsigned char byte) {
   return (byte & 0xC0) == 0x80;
 }
 
-int utf8_sequence_length(const char* str, size_t position, size_t max_length) {
+uint32_t utf8_sequence_length(const char* str, size_t position, size_t max_length) {
   if (position >= max_length) { return 0; }
 
   unsigned char first_byte = (unsigned char) str[position];
-  int expected_length = utf8_char_byte_length(first_byte);
+  uint32_t expected_length = utf8_char_byte_length(first_byte);
 
   if (position + expected_length > max_length) {
     return 1; // Not enough bytes, treat as single byte
   }
 
   if (expected_length > 1) {
-    for (int i = 1; i < expected_length; i++) {
+    for (uint32_t i = 1; i < expected_length; i++) {
       if (!utf8_is_valid_continuation_byte((unsigned char) str[position + i])) {
         return 1; // Invalid continuation byte, treat first byte as single byte
       }


### PR DESCRIPTION
This PR makes all utf8 apis use `uint32_t` instead of the more generic `int`