### PR TITLE
C: Remove unused functions from token interface

### DIFF
--- a/src/include/token.h
+++ b/src/include/token.h
@@ -9,8 +9,6 @@ token_T* token_init(const char* value, token_type_T type, lexer_T* lexer);
 char* token_to_string(const token_T* token);
 const char* token_type_to_string(token_type_T type);
 
-size_t token_sizeof(void);
-
 token_T* token_copy(token_T* token);
 
 void token_free(token_T* token);

--- a/src/token.c
+++ b/src/token.c
@@ -9,12 +9,8 @@
 #include <stdlib.h>
 #include <string.h>
 
-size_t token_sizeof(void) {
-  return sizeof(struct TOKEN_STRUCT);
-}
-
 token_T* token_init(const char* value, const token_type_T type, lexer_T* lexer) {
-  token_T* token = calloc(1, token_sizeof());
+  token_T* token = calloc(1, sizeof(token_T));
 
   if (type == TOKEN_NEWLINE) {
     lexer->current_line++;
@@ -122,7 +118,7 @@ char* token_to_string(const token_T* token) {
 token_T* token_copy(token_T* token) {
   if (!token) { return NULL; }
 
-  token_T* new_token = calloc(1, token_sizeof());
+  token_T* new_token = calloc(1, sizeof(token_T));
 
   if (!new_token) { return NULL; }
 


### PR DESCRIPTION
This PR removes functions from the token implementation that were unused.

Removed functions:

- `token_value` function
- `token_type` function
- `token_sizeof` function

In the case of the `token_sizeof` function call sites were replaced with the more idiomatic `sizeof(token_T)`