### PR TITLE
C: Return `hb_string_T` from `token_to_string` function

### DIFF
--- a/src/herb.c
+++ b/src/herb.c
@@ -61,9 +61,9 @@ void herb_lex_to_buffer(const char* source, hb_buffer_T* output) {
   for (size_t i = 0; i < hb_array_size(tokens); i++) {
     token_T* token = hb_array_get(tokens, i);
 
-    char* type = token_to_string(token);
-    hb_buffer_append(output, type);
-    free(type);
+    hb_string_T type = token_to_string(token);
+    hb_buffer_append_string(output, type);
+    free(type.data);
 
     hb_buffer_append(output, "\n");
   }

--- a/src/include/token.h
+++ b/src/include/token.h
@@ -4,9 +4,10 @@
 #include "lexer_struct.h"
 #include "position.h"
 #include "token_struct.h"
+#include "util/hb_string.h"
 
 token_T* token_init(const char* value, token_type_T type, lexer_T* lexer);
-char* token_to_string(const token_T* token);
+hb_string_T token_to_string(const token_T* token);
 const char* token_type_to_string(token_type_T type);
 
 token_T* token_copy(token_T* token);

--- a/src/token.c
+++ b/src/token.c
@@ -83,7 +83,7 @@ const char* token_type_to_string(const token_type_T type) {
   return "Unknown token_type_T";
 }
 
-char* token_to_string(const token_T* token) {
+hb_string_T token_to_string(const token_T* token) {
   const char* type_string = token_type_to_string(token->type);
   const char* template = "#<Herb::Token type=\"%s\" value=\"%.*s\" range=[%u, %u] start=(%u:%u) end=(%u:%u)>";
 
@@ -112,7 +112,7 @@ char* token_to_string(const token_T* token) {
 
   free(escaped.data);
 
-  return string;
+  return hb_string(string);
 }
 
 token_T* token_copy(token_T* token) {


### PR DESCRIPTION
This PR changes the return type of the token to string method so that it returns an `hb_string_T` instead of a raw `char *`.