### PR TITLE
C: Make `hb_buffer_append_char` thread-safe

### DIFF
--- a/rust/Makefile
+++ b/rust/Makefile
@@ -26,7 +26,7 @@ cli: build
 	@./bin/$(BIN_NAME) || true
 
 test: build
-	NO_COLOR=1 cargo +stable test --verbose -- --test-threads=1
+	NO_COLOR=1 cargo +stable test --verbose
 
 format:
 	cargo +nightly fmt

--- a/src/util/hb_buffer.c
+++ b/src/util/hb_buffer.c
@@ -142,7 +142,7 @@ void hb_buffer_append_string(hb_buffer_T* buffer, hb_string_T string) {
 }
 
 void hb_buffer_append_char(hb_buffer_T* buffer, const char character) {
-  static char string[2];
+  char string[2];
 
   string[0] = character;
   string[1] = '\0';


### PR DESCRIPTION
This pull request replaces the `static` temporary buffer in `hb_buffer_append_char` with a stack-allocated buffer so parallel calls no longer share mutable state and could corrupt appended output.

Before, it corrupted data like this on rare occasions:

```
  left: "<piv>\n                            \n    <p>                </p>\n           \n</div>"
 right: "<div>\n                            \n    <p>                </p>\n           \n</div>"
```

This was only noticeable in the Cargo tests, since they run so fast in parallel and quick succession that it could happen occasionally.