### PR TITLE
Formatter: Improve text content formatting and whitespace preservation

### DIFF
--- a/javascript/packages/formatter/test/erb/erb.test.ts
+++ b/javascript/packages/formatter/test/erb/erb.test.ts
@@ -294,7 +294,8 @@ describe("@herb-tools/formatter", () => {
       <p>
         This will be the all-in-one home for everything to do with
         <a href="https://hanamirb.org">Hanami</a>,
-        <a href="https://dry-rb.org">Dry</a> and <a href="https://rom-rb.org">Rom</a>.
+        <a href="https://dry-rb.org">Dry</a> and
+        <a href="https://rom-rb.org">Rom</a>.
       </p>
     `)
 
@@ -328,7 +329,7 @@ describe("@herb-tools/formatter", () => {
         Here is some text.
         <br />
         Tel:
-        <a href="#" style="color: #2f2f2b; font-size: 16px; text-decoration: none;" itemprop="telephone">08-123 456 78</a>
+        <a href="#" style="color: #2f2f2b; font-size: 16px; text-decoration: none;" itemprop="telephone"> 08-123 456 78 </a>
       </p>
     `)
 

--- a/javascript/packages/formatter/test/erb/if.test.ts
+++ b/javascript/packages/formatter/test/erb/if.test.ts
@@ -274,6 +274,27 @@ describe("@herb-tools/formatter", () => {
       expect(output).toEqual(expected)
     })
 
+    test("if/elsif/else inside <span>", () => {
+      const input = dedent`
+        <span>
+          <% if status == 'active' %>
+            Active
+          <% elsif status == 'pending' %>
+            Pending
+          <% else %>
+            Inactive
+          <% end %>
+        </span>
+      `
+
+      const expected = dedent`
+        <span><% if status == 'active' %>Active<% elsif status == 'pending' %>Pending<% else %>Inactive<% end %></span>
+      `
+
+      const output = formatter.format(input)
+      expect(output).toEqual(expected)
+    })
+
     test("if/elseif inside <span>", () => {
       const input = dedent`
         <span>

--- a/javascript/packages/formatter/test/html/tags.test.ts
+++ b/javascript/packages/formatter/test/html/tags.test.ts
@@ -86,21 +86,10 @@ describe("@herb-tools/formatter", () => {
     `
     const result = formatter.format(source)
     expect(result).toEqual(dedent`
-      One
-
-      <hr>
-
-      Two
-
-      <hr>
-
-      Three
-
-      <hr>
-
-      Four
-
-      <hr>
+      One<hr>
+      Two<hr>
+      Three<hr>
+      Four<hr>
     `)
   })
 

--- a/javascript/packages/formatter/test/html/text-content.test.ts
+++ b/javascript/packages/formatter/test/html/text-content.test.ts
@@ -167,4 +167,331 @@ describe("@herb-tools/formatter", () => {
     const result = formatter.format(source)
     expect(result).toEqual(source)
   })
+
+  test("period after ERB tag", () => {
+    const source = dedent`
+      Today is <%= Date.current %>.
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(source)
+  })
+
+  test("exclamation mark after ERB tag", () => {
+    const source = dedent`
+      Welcome <%= @user.name %>!
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(source)
+  })
+
+  test("question mark after ERB tag", () => {
+    const source = dedent`
+      Is this <%= @status %>?
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(source)
+  })
+
+  test("semicolon after ERB tag", () => {
+    const source = dedent`
+      First item: <%= @item %>;
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(source)
+  })
+
+  test("comma should not merge - maintains space", () => {
+    const source = dedent`
+      Hello <%= @first %>, how are you?
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(source)
+  })
+
+  test("colon after ERB with newline with <br>", () => {
+    const input = dedent`
+      <p>
+      <br>
+      <%= Date.current %>: Hello
+      </p>
+    `
+
+    const expected = dedent`
+      <p>
+        <br>
+        <%= Date.current %>: Hello
+      </p>
+    `
+
+    const result = formatter.format(input)
+    expect(result).toEqual(expected)
+  })
+
+  test("colon after ERB with newline with <hr>", () => {
+    const input = dedent`
+      <p>
+      <hr>
+      <%= Date.current %>: Hello
+      </p>
+    `
+
+    const expected = dedent`
+      <p>
+        <hr>
+        <%= Date.current %>: Hello
+      </p>
+    `
+
+    const result = formatter.format(input)
+    expect(result).toEqual(expected)
+  })
+
+  test("colon after ERB with newline (after <br>)", () => {
+    const result = formatter.format(dedent`
+      <html>
+      <head></head>
+      <body>
+      <div class="main">
+      <p>
+      <strong>Bold Heading:</strong><br>
+      <%= Date.current %>: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+      magna aliqua.
+      </p>
+      </div>
+      </body>
+      </html>
+    `)
+
+    expect(result).toEqual(dedent`
+      <html>
+        <head></head>
+        <body>
+          <div class="main">
+            <p>
+              <strong>Bold Heading:</strong><br>
+              <%= Date.current %>: Lorem ipsum dolor sit amet, consectetur adipiscing
+              elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+            </p>
+          </div>
+        </body>
+      </html>
+    `)
+  })
+
+  test("multiple inline elements with punctuation preserve spacing", () => {
+    const result = formatter.format(dedent`
+      <p>Visit <a href="/store">our store</a>; buy <strong>great products</strong>!</p>
+    `)
+
+    expect(result).toEqual(dedent`
+      <p>
+        Visit <a href="/store">our store</a>; buy <strong>great products</strong>!
+      </p>
+    `)
+  })
+
+  test("inline element at line end with punctuation on next line", () => {
+    const result = formatter.format(dedent`
+      <div>
+        Check <em>this</em>
+        : it works!
+      </div>
+    `)
+
+    expect(result).toEqual(dedent`
+      <div>Check <em>this</em> : it works!</div>
+    `)
+  })
+
+  test("ERB between inline elements with trailing punctuation", () => {
+    const result = formatter.format(dedent`
+      <p>Hello <strong>world</strong> <%= @greeting %>!</p>
+    `)
+
+    expect(result).toEqual(dedent`
+      <p>Hello <strong>world</strong> <%= @greeting %>!</p>
+    `)
+  })
+
+  test("semicolon after inline element in long text", () => {
+    const result = formatter.format(dedent`
+      <div>Download <a href="/app">the app</a>; install quickly; then restart your <strong>device</strong>.</div>
+    `)
+
+    expect(result).toEqual(dedent`
+      <div>
+        Download <a href="/app">the app</a>; install quickly; then restart your
+        <strong>device</strong>.
+      </div>
+    `)
+  })
+
+  test("exclamation after ERB following inline element", () => {
+    const result = formatter.format(dedent`
+      <p>See <strong>bold text</strong> <%= @value %>!</p>
+    `)
+
+    expect(result).toEqual(dedent`
+      <p>See <strong>bold text</strong> <%= @value %>!</p>
+    `)
+  })
+
+  test("question mark after nested inline elements", () => {
+    const result = formatter.format(dedent`
+      <div>Is <strong><em>this</em></strong> correct?</div>
+    `)
+
+    expect(result).toEqual(dedent`
+      <div>Is <strong><em>this</em></strong> correct?</div>
+    `)
+  })
+
+  test("long text with strong and em in between", () => {
+    const result = formatter.format(dedent`
+      <div>This is a super long text before the strong and em element to check if <strong><em>this</em></strong> works, even if there's a long text after the strong and em element!</div>
+    `)
+
+    expect(result).toEqual(dedent`
+      <div>
+        This is a super long text before the strong and em element to check if
+        <strong><em>this</em></strong> works, even if there's a long text after the
+        strong and em element!
+      </div>
+    `)
+  })
+
+  test("ERB block with non-output tag followed by text without space", () => {
+    const source = dedent`
+      <%= link_to "/" do %>
+        <% icon("icon") %>can not insert whitespace here
+      <% end %>
+    `
+
+    const result = formatter.format(source)
+    expect(result).toEqual(source)
+  })
+
+  test("text with hyphen before inline bold element preserves no-space boundary", () => {
+    const source = dedent`
+      <div>
+        This is a div where we still can assume that whitespace can be inserted-<b>infront or after of this bold you can not insert whitespace</b>. Next senctence.
+      </div>
+    `
+
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <div>
+        This is a div where we still can assume that whitespace can be
+        inserted-<b>infront or after of this bold you can not insert whitespace</b>.
+        Next senctence.
+      </div>
+    `)
+  })
+
+  // TODO: we need to wait for the parser to transform this as a HTMLElementNode
+  test("ERB block tag with inline content should stay on one line", () => {
+    const source = dedent`
+      <%= tag.span do %>This should stay on one line<% end %>
+    `
+
+    const result = formatter.format(source)
+    // TODO: expect(result).toEqual(source)
+
+    expect(result).toEqual(dedent`
+      <%= tag.span do %>
+        This should stay on one line
+      <% end %>
+    `)
+  })
+
+  test("multiline span with text collapses to inline with spaces", () => {
+    const source = dedent`
+      <span>
+        And on the other hand one can not remove whitespace entirely
+      </span>
+    `
+
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <span> And on the other hand one can not remove whitespace entirely </span>
+    `)
+  })
+
+  test("inline span with text content on single line preserves format", () => {
+    const source = dedent`
+      <span>And on the other hand one can not remove whitespace entirely</span>
+    `
+
+    const result = formatter.format(source)
+    expect(result).toEqual(source)
+  })
+
+  test("inline span with leading and trailing spaces preserves them", () => {
+    const source = dedent`
+      <span> And on the other hand one can not remove whitespace entirely </span>
+    `
+
+    const result = formatter.format(source)
+    expect(result).toEqual(source)
+  })
+
+  test("div with multiline text preserves leading and trailing whitespace", () => {
+    const source = dedent`
+      <div>
+        Here the whitespace will not be removed
+      </div>
+    `
+
+    const result = formatter.format(source)
+    expect(result).toEqual(source)
+  })
+
+  test("div with inline text content preserves format", () => {
+    const source = dedent`
+      <div>Here the whitespace will not be removed</div>
+    `
+
+    const result = formatter.format(source)
+    expect(result).toEqual(source)
+  })
+
+  test("div with leading and trailing spaces trims them for inline content", () => {
+    const source = dedent`
+      <div> Here the whitespace will not be removed </div>
+    `
+
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <div>Here the whitespace will not be removed</div>
+    `)
+  })
+
+  test("inline bold with ERB collapses when alone but preserves when adjacent", () => {
+    const source = dedent`
+      <p>
+        <b><%= a_thing %> <%= another_thing %></b>
+      </p>
+
+      <p>
+        <b><%= a_thing %> <%= another_thing %></b>a
+      </p>
+
+      <p>
+        <b><%= a_thing %> <%= another_thing %></b>
+        <b><%= a_thing %> <%= another_thing %></b>a
+      </p>
+    `
+
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <p><b><%= a_thing %> <%= another_thing %></b></p>
+
+      <p><b><%= a_thing %> <%= another_thing %></b>a</p>
+
+      <p>
+        <b><%= a_thing %> <%= another_thing %></b>
+        <b><%= a_thing %> <%= another_thing %></b>a
+      </p>
+    `)
+  })
 })


### PR DESCRIPTION
This pull request improves text content formatting by preserving leading and trailing whitespace for inline elements with text-only content, while ensuring block-level elements continue to have their whitespace normalized correctly.

**Input**
```erb
<span>
  And on the other hand one can not remove whitespace entirely
</span>
```

**Before**
```erb
<span>And on the other hand one can not remove whitespace entirely</span>
```


**After**
```erb
<span> And on the other hand one can not remove whitespace entirely </span>
```

---

**Input**
```erb
<html>
<head></head>
<body>
<div class="main">
<p>
<strong>Bold Heading:</strong><br>
<%= Date.current %>: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
magna aliqua.
</p>
</div>
</body>
</html>
```

**Before**
```erb
<html>
  <head></head>
  <body>
    <div class="main">
      <p>
        <strong>Bold Heading:</strong><br><%= Date.current %>
        : Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
        eiusmod tempor incididunt ut labore et dolore magna aliqua.
      </p>
    </div>
  </body>
</html>
```



**After**
```erb
<html>
  <head></head>
  <body>
    <div class="main">
      <p>
        <strong>Bold Heading:</strong><br>
        <%= Date.current %>: Lorem ipsum dolor sit amet, consectetur adipiscing
        elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
      </p>
    </div>
  </body>
</html>
```

Resolves https://github.com/marcoroth/herb/issues/609
Resolves https://github.com/marcoroth/herb/issues/806