### PR TITLE
Engine: Don't compile `<% # comments %>`

### DIFF
--- a/lib/herb/ast/helpers.rb
+++ b/lib/herb/ast/helpers.rb
@@ -21,6 +21,17 @@ module Herb
       def erb_output?(opening)
         opening.include?("=")
       end
+
+      #: (Herb::AST::ERBContentNode) -> bool
+      def inline_ruby_comment?(node)
+        return false unless node.is_a?(Herb::AST::ERBContentNode)
+        return false if erb_comment?(node.tag_opening&.value || "")
+
+        content = node.content&.value || ""
+        stripped = content.lstrip
+
+        stripped.start_with?("#") && node.location.start.line == node.location.end.line
+      end
     end
   end
 end

--- a/lib/herb/engine/compiler.rb
+++ b/lib/herb/engine/compiler.rb
@@ -162,6 +162,8 @@ module Herb
       end
 
       def visit_erb_content_node(node)
+        return if inline_ruby_comment?(node)
+
         process_erb_tag(node)
       end
 

--- a/sig/herb/ast/helpers.rbs
+++ b/sig/herb/ast/helpers.rbs
@@ -11,6 +11,9 @@ module Herb
 
       # : (String) -> bool
       def erb_output?: (String) -> bool
+
+      # : (Herb::AST::ERBContentNode) -> bool
+      def inline_ruby_comment?: (Herb::AST::ERBContentNode) -> bool
     end
   end
 end

--- a/test/engine/erb_comments_test.rb
+++ b/test/engine/erb_comments_test.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+require_relative "../snapshot_utils"
+require_relative "../../lib/herb/engine"
+
+module Engine
+  class ERBCommentsTest < Minitest::Spec
+    include SnapshotUtils
+
+    test "inline ruby comment on same line" do
+      template = %(<% if true %><% # Comment here %><% end %>)
+
+      assert_compiled_snapshot(template)
+    end
+
+    test "inline ruby comment with newline" do
+      template = "<% if true %><% # Comment here %>\n<% end %>"
+
+      assert_compiled_snapshot(template)
+    end
+
+    test "inline ruby comment between code" do
+      template = %(<% if true %><% # Comment here %><%= "hello" %><% end %>)
+
+      assert_compiled_snapshot(template)
+    end
+
+    test "inline ruby comment before and between code" do
+      template = %(<% # Comment here %><% if true %><% # Comment here %><%= "hello" %><% end %>)
+
+      assert_compiled_snapshot(template)
+    end
+
+    test "inline ruby comment with spaces" do
+      template = %(<%  # Comment %> <% code = "test" %><%= code %>)
+
+      assert_compiled_snapshot(template)
+    end
+
+    test "inline ruby comment multiline" do
+      template = "<% # Comment\nmore %> <% code = \"test\" %><%= code %>"
+
+      assert_compiled_snapshot(template)
+    end
+
+    test "evaluation: inline ruby comment on same line" do
+      template = %(<% if true %><% # Comment here %><% end %>)
+
+      assert_evaluated_snapshot(template)
+    end
+
+    test "evaluation: inline ruby comment with newline" do
+      template = "<% if true %><% # Comment here %>\n<% end %>"
+
+      assert_evaluated_snapshot(template)
+    end
+
+    test "evaluation: inline ruby comment between code" do
+      template = %(<% if true %><% # Comment here %><%= "hello" %><% end %>)
+
+      assert_evaluated_snapshot(template)
+    end
+
+    test "evaluation: inline ruby comment before and between code" do
+      template = %(<% # Comment here %><% if true %><% # Comment here %><%= "hello" %><% end %>)
+
+      assert_evaluated_snapshot(template)
+    end
+
+    test "evaluation: inline ruby comment with spaces" do
+      template = %(<%  # Comment %> <% code = "test" %><%= code %>)
+
+      assert_evaluated_snapshot(template)
+    end
+
+    test "evaluation: inline ruby comment multiline" do
+      template = "<% # Comment\nmore %> <% code = \"test\" %><%= code %>"
+
+      assert_evaluated_snapshot(template, { more: "ignored" })
+    end
+  end
+end

--- a/test/engine/evaluation_test.rb
+++ b/test/engine/evaluation_test.rb
@@ -398,5 +398,41 @@ module Engine
 
       assert_evaluated_snapshot(template, {}, { escape: false })
     end
+
+    test "inline ruby comment on same line" do
+      template = %(<% if true %><% # Comment here %><% end %>)
+
+      assert_evaluated_snapshot(template, {}, { escape: false })
+    end
+
+    test "inline ruby comment with newline" do
+      template = "<% if true %><% # Comment here %>\n<% end %>"
+
+      assert_evaluated_snapshot(template, {}, { escape: false })
+    end
+
+    test "inline ruby comment between code" do
+      template = %(<% if true %><% # Comment here %><%= "hello" %><% end %>)
+
+      assert_evaluated_snapshot(template, {}, { escape: false })
+    end
+
+    test "inline ruby comment before and between code" do
+      template = %(<% # Comment here %><% if true %><% # Comment here %><%= "hello" %><% end %>)
+
+      assert_evaluated_snapshot(template, {}, { escape: false })
+    end
+
+    test "inline ruby comment with spaces" do
+      template = %(<%  # Comment %> <% code = "test" %><%= code %>)
+
+      assert_evaluated_snapshot(template, {}, { escape: false })
+    end
+
+    test "inline ruby comment multiline" do
+      template = "<% # Comment\nmore %> <% code = \"test\" %><%= code %>"
+
+      assert_evaluated_snapshot(template, { more: "ignored" }, { escape: false })
+    end
   end
 end

--- a/test/snapshots/engine/erb_comments_test/test_0001_inline_ruby_comment_on_same_line_ece56a54ce9835acc67012583c42fc01.txt
+++ b/test/snapshots/engine/erb_comments_test/test_0001_inline_ruby_comment_on_same_line_ece56a54ce9835acc67012583c42fc01.txt
@@ -1,0 +1,7 @@
+---
+source: "Engine::ERBCommentsTest#test_0001_inline ruby comment on same line"
+input: "{source: \"<% if true %><% # Comment here %><% end %>\", options: {}}"
+---
+_buf = ::String.new;
+ if true; end;
+_buf.to_s

--- a/test/snapshots/engine/erb_comments_test/test_0002_inline_ruby_comment_with_newline_32dd50121c8e2af22b8a7e5efd92940f.txt
+++ b/test/snapshots/engine/erb_comments_test/test_0002_inline_ruby_comment_with_newline_32dd50121c8e2af22b8a7e5efd92940f.txt
@@ -1,0 +1,8 @@
+---
+source: "Engine::ERBCommentsTest#test_0002_inline ruby comment with newline"
+input: "{source: \"<% if true %><% # Comment here %>\\n<% end %>\", options: {}}"
+---
+_buf = ::String.new;
+ if true; _buf << '
+'.freeze; end;
+_buf.to_s

--- a/test/snapshots/engine/erb_comments_test/test_0003_inline_ruby_comment_between_code_987d6e126382f02311aa0c1a0e0007bc.txt
+++ b/test/snapshots/engine/erb_comments_test/test_0003_inline_ruby_comment_between_code_987d6e126382f02311aa0c1a0e0007bc.txt
@@ -1,0 +1,7 @@
+---
+source: "Engine::ERBCommentsTest#test_0003_inline ruby comment between code"
+input: "{source: \"<% if true %><% # Comment here %><%= \\\"hello\\\" %><% end %>\", options: {}}"
+---
+_buf = ::String.new;
+ if true; _buf << ("hello").to_s; end;
+_buf.to_s

--- a/test/snapshots/engine/erb_comments_test/test_0004_inline_ruby_comment_before_and_between_code_d6e28172fd69bf4538744950bffb2848.txt
+++ b/test/snapshots/engine/erb_comments_test/test_0004_inline_ruby_comment_before_and_between_code_d6e28172fd69bf4538744950bffb2848.txt
@@ -1,0 +1,7 @@
+---
+source: "Engine::ERBCommentsTest#test_0004_inline ruby comment before and between code"
+input: "{source: \"<% # Comment here %><% if true %><% # Comment here %><%= \\\"hello\\\" %><% end %>\", options: {}}"
+---
+_buf = ::String.new;
+ if true; _buf << ("hello").to_s; end;
+_buf.to_s

--- a/test/snapshots/engine/erb_comments_test/test_0005_inline_ruby_comment_with_spaces_a1f69e41bb63eacbc881533c704e17a4.txt
+++ b/test/snapshots/engine/erb_comments_test/test_0005_inline_ruby_comment_with_spaces_a1f69e41bb63eacbc881533c704e17a4.txt
@@ -1,0 +1,7 @@
+---
+source: "Engine::ERBCommentsTest#test_0005_inline ruby comment with spaces"
+input: "{source: \"<%  # Comment %> <% code = \\\"test\\\" %><%= code %>\", options: {}}"
+---
+_buf = ::String.new;
+ _buf << ' '.freeze; code = "test"; _buf << (code).to_s;
+_buf.to_s

--- a/test/snapshots/engine/erb_comments_test/test_0006_inline_ruby_comment_multiline_1dc1e842d2fb5a2484c2e2fa0eca3678.txt
+++ b/test/snapshots/engine/erb_comments_test/test_0006_inline_ruby_comment_multiline_1dc1e842d2fb5a2484c2e2fa0eca3678.txt
@@ -1,0 +1,9 @@
+---
+source: "Engine::ERBCommentsTest#test_0006_inline ruby comment multiline"
+input: "{source: \"<% # Comment\\nmore %> <% code = \\\"test\\\" %><%= code %>\", options: {}}"
+---
+_buf = ::String.new;
+ # Comment
+more
+ _buf << ' '.freeze; code = "test"; _buf << (code).to_s;
+_buf.to_s

--- a/test/snapshots/engine/erb_comments_test/test_0007_evaluation_inline_ruby_comment_on_same_line_da1ad954cfb3b204db6e91dd6fa35de7.txt
+++ b/test/snapshots/engine/erb_comments_test/test_0007_evaluation_inline_ruby_comment_on_same_line_da1ad954cfb3b204db6e91dd6fa35de7.txt
@@ -1,0 +1,4 @@
+---
+source: "Engine::ERBCommentsTest#test_0007_evaluation: inline ruby comment on same line"
+input: "{source: \"<% if true %><% # Comment here %><% end %>\", locals: {}, options: {}}"
+---

--- a/test/snapshots/engine/erb_comments_test/test_0008_evaluation_inline_ruby_comment_with_newline_3519273b500925a720622d82288e0a31.txt
+++ b/test/snapshots/engine/erb_comments_test/test_0008_evaluation_inline_ruby_comment_with_newline_3519273b500925a720622d82288e0a31.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::ERBCommentsTest#test_0008_evaluation: inline ruby comment with newline"
+input: "{source: \"<% if true %><% # Comment here %>\\n<% end %>\", locals: {}, options: {}}"
+---
+

--- a/test/snapshots/engine/erb_comments_test/test_0009_evaluation_inline_ruby_comment_between_code_2788ca7a784e1295299a8d85ec9e396d.txt
+++ b/test/snapshots/engine/erb_comments_test/test_0009_evaluation_inline_ruby_comment_between_code_2788ca7a784e1295299a8d85ec9e396d.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::ERBCommentsTest#test_0009_evaluation: inline ruby comment between code"
+input: "{source: \"<% if true %><% # Comment here %><%= \\\"hello\\\" %><% end %>\", locals: {}, options: {}}"
+---
+hello

--- a/test/snapshots/engine/erb_comments_test/test_0010_evaluation_inline_ruby_comment_before_and_between_code_13d746f9eef6690df9a609b4349a5189.txt
+++ b/test/snapshots/engine/erb_comments_test/test_0010_evaluation_inline_ruby_comment_before_and_between_code_13d746f9eef6690df9a609b4349a5189.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::ERBCommentsTest#test_0010_evaluation: inline ruby comment before and between code"
+input: "{source: \"<% # Comment here %><% if true %><% # Comment here %><%= \\\"hello\\\" %><% end %>\", locals: {}, options: {}}"
+---
+hello

--- a/test/snapshots/engine/erb_comments_test/test_0011_evaluation_inline_ruby_comment_with_spaces_403e802d2a1c4f738b359fc3eee74053.txt
+++ b/test/snapshots/engine/erb_comments_test/test_0011_evaluation_inline_ruby_comment_with_spaces_403e802d2a1c4f738b359fc3eee74053.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::ERBCommentsTest#test_0011_evaluation: inline ruby comment with spaces"
+input: "{source: \"<%  # Comment %> <% code = \\\"test\\\" %><%= code %>\", locals: {}, options: {}}"
+---
+ test

--- a/test/snapshots/engine/erb_comments_test/test_0012_evaluation_inline_ruby_comment_multiline_c4d3ea038c11a5575430ca4b14abff47.txt
+++ b/test/snapshots/engine/erb_comments_test/test_0012_evaluation_inline_ruby_comment_multiline_c4d3ea038c11a5575430ca4b14abff47.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::ERBCommentsTest#test_0012_evaluation: inline ruby comment multiline"
+input: "{source: \"<% # Comment\\nmore %> <% code = \\\"test\\\" %><%= code %>\", locals: {more: \"ignored\"}, options: {}}"
+---
+ test

--- a/test/snapshots/engine/evaluation_test/test_0025_inline_ruby_comment_on_same_line_ad303bca1e8d22f5b16ec13f3c664241.txt
+++ b/test/snapshots/engine/evaluation_test/test_0025_inline_ruby_comment_on_same_line_ad303bca1e8d22f5b16ec13f3c664241.txt
@@ -1,0 +1,4 @@
+---
+source: "Engine::EvaluationTest#test_0025_inline ruby comment on same line"
+input: "{source: \"<% if true %><% # Comment here %><% end %>\", locals: {}, options: {escape: false}}"
+---

--- a/test/snapshots/engine/evaluation_test/test_0026_inline_ruby_comment_with_newline_9abf0cb2099f40dfd7f4dfd3bfe1cc76.txt
+++ b/test/snapshots/engine/evaluation_test/test_0026_inline_ruby_comment_with_newline_9abf0cb2099f40dfd7f4dfd3bfe1cc76.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::EvaluationTest#test_0026_inline ruby comment with newline"
+input: "{source: \"<% if true %><% # Comment here %>\\n<% end %>\", locals: {}, options: {escape: false}}"
+---
+

--- a/test/snapshots/engine/evaluation_test/test_0027_inline_ruby_comment_between_code_846a700430f96166237a051e3fca1bed.txt
+++ b/test/snapshots/engine/evaluation_test/test_0027_inline_ruby_comment_between_code_846a700430f96166237a051e3fca1bed.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::EvaluationTest#test_0027_inline ruby comment between code"
+input: "{source: \"<% if true %><% # Comment here %><%= \\\"hello\\\" %><% end %>\", locals: {}, options: {escape: false}}"
+---
+hello

--- a/test/snapshots/engine/evaluation_test/test_0028_inline_ruby_comment_before_and_between_code_033a23daedac7be2427e58914b665c0f.txt
+++ b/test/snapshots/engine/evaluation_test/test_0028_inline_ruby_comment_before_and_between_code_033a23daedac7be2427e58914b665c0f.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::EvaluationTest#test_0028_inline ruby comment before and between code"
+input: "{source: \"<% # Comment here %><% if true %><% # Comment here %><%= \\\"hello\\\" %><% end %>\", locals: {}, options: {escape: false}}"
+---
+hello

--- a/test/snapshots/engine/evaluation_test/test_0029_inline_ruby_comment_with_spaces_c05d8f81793b59bea0ce93cf959bcfbe.txt
+++ b/test/snapshots/engine/evaluation_test/test_0029_inline_ruby_comment_with_spaces_c05d8f81793b59bea0ce93cf959bcfbe.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::EvaluationTest#test_0029_inline ruby comment with spaces"
+input: "{source: \"<%  # Comment %> <% code = \\\"test\\\" %><%= code %>\", locals: {}, options: {escape: false}}"
+---
+ test

--- a/test/snapshots/engine/evaluation_test/test_0030_inline_ruby_comment_multiline_d65c4c66f63611e90c0ea96b74af1ce4.txt
+++ b/test/snapshots/engine/evaluation_test/test_0030_inline_ruby_comment_multiline_d65c4c66f63611e90c0ea96b74af1ce4.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::EvaluationTest#test_0030_inline ruby comment multiline"
+input: "{source: \"<% # Comment\\nmore %> <% code = \\\"test\\\" %><%= code %>\", locals: {more: \"ignored\"}, options: {escape: false}}"
+---
+ test

--- a/test/snapshots/engine/examples_compilation_test/test_0009_comment_before_content_compilation_2b3c4e3c244db77468813a7472298e82.txt
+++ b/test/snapshots/engine/examples_compilation_test/test_0009_comment_before_content_compilation_2b3c4e3c244db77468813a7472298e82.txt
@@ -3,7 +3,6 @@ source: "Engine::ExamplesCompilationTest#test_0009_comment before content compil
 input: "{source: \"<% # This file contains a comment before other content %>\\n<div>Hey there</div>\\n\", options: {escape: false}}"
 ---
 _buf = ::String.new;
- # This file contains a comment before other content
  _buf << '
 <div>Hey there</div>
 '.freeze;


### PR DESCRIPTION
Follow up to #825.

This pull request improves the engine by not compiling `<% # coments %>` comments as part of the template. Outputting `# coments` could lead to some cases, where the template could be compiled but couldn't be rendered, because it would comment out important pieces of the template.

```erb
<% if true %><% # comment %><%= "Hello World" %><% end %>
```

**Before**

`exe/herb compile test.html.erb`
```ruby
__herb = ::Herb::Engine; _buf = ::String.new;
 if true; # comment
 _buf << __herb.h(("Hello World")); end; _buf << '
'.freeze;
_buf.to_s
```


**After**

`exe/herb compile test.html.erb`
```ruby
__herb = ::Herb::Engine; _buf = ::String.new;
 if true; _buf << __herb.h(("Hello World")); end; _buf << '
'.freeze;
_buf.to_s
```


### For reference

`bin/erubi-compile test.html.erb`
```ruby
__erubi = ::Erubi; _buf = ::String.new; if true ; # comment ; _buf << __erubi.h(( "Hello World" )); end ; _buf << '
'.freeze;
_buf.to_s
```

`bin/erubi-render test.html.erb`
```
bin/erubi-render:117:in 'Kernel#eval': (eval at bin/erubi-render:117):2: syntax errors found (SyntaxError)
  1 | __erubi = ::Erubi; _buf = ::String.new; if true ; # comment ; _buf << __erubi.h(( "Hello World" )); end ; _buf << '
> 2 | '.freeze;
    | ^ unterminated string meets end of file
  3 | _buf.to_s
> 4 |
    | ^ expected an `end` to close the conditional clause

    | ^ unexpected end-of-input, assuming it is closing the parent top level context

        from bin/erubi-render:117:in 'ErubiRenderer#render_template'
        from bin/erubi-render:31:in 'ErubiRenderer#run'
        from bin/erubi-render:152:in '<main>'
```

`exe/herb render test.html.erb`
```
Hello World
```

