### PR TITLE
Parser: Fix exponential recursion in two-pass HTML tag matching

### DIFF
--- a/templates/src/parser_match_tags.c.erb
+++ b/templates/src/parser_match_tags.c.erb
@@ -11,13 +11,20 @@ bool match_tags_visitor(const AST_NODE_T* node, void* data) {
   switch (node->type) {
     <%- nodes.each do |node| -%>
     <%- array_fields = node.fields.select { |f| f.is_a?(Herb::Template::ArrayField) && f.name != "errors" } -%>
-    <%- if array_fields.any? -%>
+    <%- single_node_fields = node.fields.select { |f| f.is_a?(Herb::Template::NodeField) } -%>
+
+    <%- if array_fields.any? || single_node_fields.any? -%>
     case <%= node.type %>: {
       const <%= node.struct_type %>* <%= node.human %> = (const <%= node.struct_type %>*) node;
 
       <%- array_fields.each do |field| -%>
       if (<%= node.human %>-><%= field.name %> != NULL) {
         match_tags_in_node_array(<%= node.human %>-><%= field.name %>, errors);
+      }
+      <%- end -%>
+      <%- single_node_fields.each do |field| -%>
+      if (<%= node.human %>-><%= field.name %> != NULL) {
+        herb_visit_node((AST_NODE_T*) <%= node.human %>-><%= field.name %>, match_tags_visitor, errors);
       }
       <%- end -%>
     } break;
@@ -27,5 +34,5 @@ bool match_tags_visitor(const AST_NODE_T* node, void* data) {
     default: break;
   }
 
-  return true;
+  return false;
 }


### PR DESCRIPTION
This pull request fixes a critical performance regression in the two-pass tag matching algorithm introduced in #795.

Documents that previously parsed in ~75ms were taking ~11 seconds (and in some cases didn't even complete in a reasonable timeframe, see #828).

The `match_tags_visitor` function was causing double recursion by manually processing array fields through calls to `match_tags_in_node_array()`, but then returning `true` which instructed `herb_visit_node` to also automatically traverse those same children a second time.

This created an exponential explosion where each level of nesting squared the number of visits.

Resolves #828

