### PR TITLE
Formatter: Improve `tailwind-class-sorter` rewriter experience

### DIFF
--- a/javascript/packages/language-server/src/service.ts
+++ b/javascript/packages/language-server/src/service.ts
@@ -93,6 +93,7 @@ export class Service {
 
   async refresh() {
     await this.project.refresh()
+    await this.formattingService.refreshConfig(this.config)
     await this.diagnostics.refreshAllDocuments()
   }
 

--- a/javascript/packages/language-server/src/settings.ts
+++ b/javascript/packages/language-server/src/settings.ts
@@ -39,6 +39,7 @@ export class Settings {
   hasConfigurationCapability = false
   hasWorkspaceFolderCapability = false
   hasDiagnosticRelatedInformationCapability = false
+  hasShowDocumentCapability = false
 
   params: InitializeParams
   capabilities: ClientCapabilities
@@ -50,6 +51,7 @@ export class Settings {
     this.connection = connection
 
     this.hasConfigurationCapability = !!(this.capabilities.workspace && !!this.capabilities.workspace.configuration)
+    this.hasShowDocumentCapability = !!(this.capabilities.window?.showDocument)
 
     this.hasWorkspaceFolderCapability = !!(
       this.capabilities.workspace && !!this.capabilities.workspace.workspaceFolders

--- a/javascript/packages/rewriter/package.json
+++ b/javascript/packages/rewriter/package.json
@@ -39,6 +39,7 @@
   },
   "dependencies": {
     "@herb-tools/core": "0.7.5",
+    "@herb-tools/tailwind-class-sorter": "0.7.5",
     "glob": "^11.0.3"
   },
   "devDependencies": {

--- a/javascript/packages/rewriter/src/built-ins/tailwind-class-sorter.ts
+++ b/javascript/packages/rewriter/src/built-ins/tailwind-class-sorter.ts
@@ -243,9 +243,25 @@ export class TailwindClassSorterRewriter extends ASTRewriter {
   }
 
   async initialize(context: RewriteContext): Promise<void> {
-    this.sorter = await TailwindClassSorter.fromConfig({
-      baseDir: context.baseDir
-    })
+    try {
+      this.sorter = await TailwindClassSorter.fromConfig({
+        baseDir: context.baseDir
+      })
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error)
+
+      if (errorMessage.includes('Cannot find module') || errorMessage.includes('ENOENT')) {
+        throw new Error(
+          `Tailwind CSS is not installed in this project. ` +
+          `To use the Tailwind class sorter, install Tailwind CSS itself using: npm install -D tailwindcss, ` +
+          `or remove the "tailwind-class-sorter" rewriter from your .herb.yml config file.\n` +
+          `If "tailwindcss" is already part of your package.json, make sure your NPM dependencies are installed.\n` +
+          `Original error: ${errorMessage}.`
+        )
+      }
+
+      throw error
+    }
   }
 
   rewrite<T extends Node>(node: T, _context: RewriteContext): T {

--- a/javascript/packages/vscode/src/client.ts
+++ b/javascript/packages/vscode/src/client.ts
@@ -83,6 +83,7 @@ export class Client {
             indentWidth: projectConfig.formatter?.indentWidth ?? 2,
             maxLineLength: projectConfig.formatter?.maxLineLength ?? 80,
             exclude: projectConfig.formatter?.exclude,
+            rewriter: projectConfig.formatter?.rewriter,
           },
           trace: {
             server: vscodeConfig.get('trace.server', 'verbose'),
@@ -175,6 +176,7 @@ export class Client {
             indentWidth: projectConfig.formatter?.indentWidth ?? 2,
             maxLineLength: projectConfig.formatter?.maxLineLength ?? 80,
             exclude: projectConfig.formatter?.exclude,
+            rewriter: projectConfig.formatter?.rewriter,
           },
           trace: {
             server: vscodeConfig.get('trace.server', 'verbose'), // Trace is always from VS Code

--- a/yarn.lock
+++ b/yarn.lock
@@ -4276,7 +4276,7 @@ esbuild-plugin-copy@^2.1.1:
     fs-extra "^10.0.1"
     globby "^11.0.3"
 
-esbuild@^0.25.0, esbuild@^0.25.11, esbuild@~0.25.0:
+esbuild@^0.25.0, esbuild@~0.25.0:
   version "0.25.11"
   resolved "https://registry.npmjs.org/esbuild/-/esbuild-0.25.11.tgz"
   integrity sha512-KohQwyzrKTQmhXDW1PjCv3Tyspn9n5GcY2RTDqeORIdIJY8yKIF7sTSopFmn/wpMPW4rdPXI0UE5LJLuq3bx0Q==


### PR DESCRIPTION
If the project you are trying to format a file in doesn't use `tailwindcss` but has the `tailwind-class-sorter` rewriter for the formatter enabled, we show a better warning now:

<img width="1356" height="580" alt="CleanShot 2025-11-12 at 02 52 34@2x" src="https://github.com/user-attachments/assets/4ca81ac0-d14f-4584-ad49-a5b94cc15d52" />

<img width="3456" height="866" alt="CleanShot 2025-11-12 at 03 33 21@2x" src="https://github.com/user-attachments/assets/5a62edc3-7f1a-4283-8496-36a74b132d5d" />
