### PR TITLE
VS Code: Add `Shopify.ruby-lsp` to `extensionDependencies`

### DIFF
--- a/javascript/packages/vscode/package.json
+++ b/javascript/packages/vscode/package.json
@@ -14,6 +14,9 @@
   "engines": {
     "vscode": "^1.43.0"
   },
+  "extensionDependencies": [
+    "Shopify.ruby-lsp"
+  ],
   "categories": [
     "Programming Languages",
     "Linters",


### PR DESCRIPTION
The Herb Visual Studio Code Extension relies on the fact that a grammar definition for `HTML+ERB` is available. Otherwise, the Herb Visual Studio Code extension won't work.

This pull request adds `Shopify.ruby-lsp` to `extensionDependencies` to ensure that grammar is always available.