### PR TITLE
Rust: Vendor C sources for cargo publish

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -66,3 +66,11 @@ jobs:
       - name: Run Rust tests
         run: make test
         working-directory: rust
+
+      - name: Vendor C sources for packaging
+        run: make vendor
+        working-directory: rust
+
+      - name: Test cargo package
+        run: cargo package --allow-dirty
+        working-directory: rust

--- a/.gitignore
+++ b/.gitignore
@@ -134,6 +134,7 @@ java/.java_compiled
 
 # Rust Build Artifacts
 rust/target/
+rust/vendor/
 rust/Cargo.lock
 
 # NX Monorepo

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -9,6 +9,14 @@ license = "MIT"
 repository = "https://github.com/marcoroth/herb"
 keywords = ["erb", "html", "html+erb", "ruby", "rails"]
 categories = ["parser-implementations", "development-tools"]
+include = [
+  "src/**/*",
+  "vendor/**/*.c",
+  "vendor/**/*.h",
+  "build.rs",
+  "Cargo.toml",
+  "README.md"
+]
 
 [lib]
 name = "herb"

--- a/rust/Makefile
+++ b/rust/Makefile
@@ -5,7 +5,7 @@ BIN_NAME = herb-rust
 BIN_PATH = $(BUILD_DIR)/debug/$(BIN_NAME)
 RELEASE_BIN_PATH = $(BUILD_DIR)/release/$(BIN_NAME)
 
-.PHONY: all build release clean test cli help templates format
+.PHONY: all build release clean test cli help templates format vendor
 
 all: templates build
 
@@ -44,6 +44,18 @@ clean:
 	cargo clean
 	@echo "Cleaned Rust build artifacts"
 
+vendor:
+	@echo "Vendoring C sources into vendor/libherb..."
+	rm -rf vendor/
+	mkdir -p vendor/libherb/
+	mkdir -p vendor/prism/
+	cp -r ../src vendor/libherb/
+	@echo "Vendoring prism library..."
+	PRISM_PATH=$$(bundle show prism) && \
+	cp -r "$$PRISM_PATH/src" vendor/prism/ && \
+	cp -r "$$PRISM_PATH/include" vendor/prism/
+	@echo "Vendored C sources and prism successfully"
+
 help:
 	@echo "Herb Rust Build System"
 	@echo ""
@@ -55,6 +67,7 @@ help:
 	@echo "  cli        - Show CLI usage"
 	@echo "  test       - Run Rust tests"
 	@echo "  format     - Format Rust code with rustfmt"
+	@echo "  vendor     - Vendor C sources into vendor/"
 	@echo "  clean      - Remove build artifacts"
 	@echo "  help       - Show this help"
 	@echo ""

--- a/rust/README.md
+++ b/rust/README.md
@@ -19,7 +19,7 @@ make all          # Generate templates and build
 
 ## Usage
 
-### CLI
+### CLI (within the Herb repo)
 
 ```bash
 ./bin/herb-rust version
@@ -54,6 +54,17 @@ fn main() {
 ```bash
 cargo test
 ```
+
+## Publishing
+
+Before publishing to crates.io, vendor the C sources:
+
+```bash
+make vendor                        # Vendor C sources from ../src and prism
+cargo publish --allow-dirty        # Publish to crates.io
+```
+
+The `vendor/` directory is gitignored to avoid committing duplicate files. The `make vendor` task copies C sources from the parent directory into `vendor/libherb` and `vendor/prism` so the published crate is self-contained.
 
 ## Cleaning
 


### PR DESCRIPTION
In order the publish the Rust crate [`herb`](https://crates.io/crates/herb) on crates.io, I had to vendor the `*.c` and `*.h` files from both Herb and Prism. This pull request adds a script to set this up.