### PR TITLE
C: Remove unused `hb_buffer_free` function

### DIFF
--- a/src/include/util/hb_buffer.h
+++ b/src/include/util/hb_buffer.h
@@ -29,6 +29,5 @@ size_t hb_buffer_capacity(const hb_buffer_T* buffer);
 size_t hb_buffer_sizeof(void);
 
 void hb_buffer_clear(hb_buffer_T* buffer);
-void hb_buffer_free(hb_buffer_T** buffer);
 
 #endif

--- a/src/util/hb_buffer.c
+++ b/src/util/hb_buffer.c
@@ -192,12 +192,3 @@ void hb_buffer_clear(hb_buffer_T* buffer) {
   buffer->length = 0;
   buffer->value[0] = '\0';
 }
-
-void hb_buffer_free(hb_buffer_T** buffer) {
-  if (!buffer || !*buffer) { return; }
-
-  if ((*buffer)->value != NULL) { free((*buffer)->value); }
-
-  free(*buffer);
-  *buffer = NULL;
-}

--- a/test/c/test_hb_buffer.c
+++ b/test/c/test_hb_buffer.c
@@ -115,24 +115,6 @@ TEST(test_hb_buffer_clear)
   free(buffer.value);
 END
 
-// Test freeing buffer
-TEST(test_hb_buffer_free)
-  hb_buffer_T buffer;
-  hb_buffer_init(&buffer, 1024);
-
-  hb_buffer_append(&buffer, "Test");
-  ck_assert_int_eq(buffer.length, 4);
-  ck_assert_int_eq(buffer.capacity, 1024);
-  free(buffer.value);
-  buffer.value = NULL;
-  buffer.length = 0;
-  buffer.capacity = 0;
-
-  ck_assert_ptr_null(buffer.value);
-  ck_assert_int_eq(buffer.length, 0);
-  ck_assert_int_eq(buffer.capacity, 0);
-END
-
 // Test buffer UTF-8 integrity
 TEST(test_buffer_utf8_integrity)
   hb_buffer_T buffer;
@@ -201,7 +183,6 @@ TCase *hb_buffer_tests(void) {
   tcase_add_test(buffer, test_hb_buffer_append_string);
   tcase_add_test(buffer, test_hb_buffer_resizing_behavior);
   tcase_add_test(buffer, test_hb_buffer_clear);
-  tcase_add_test(buffer, test_hb_buffer_free);
   tcase_add_test(buffer, test_buffer_utf8_integrity);
   tcase_add_test(buffer, test_hb_buffer_append_utf8);
   tcase_add_test(buffer, test_hb_buffer_length_correctness);


### PR DESCRIPTION
This PR removes the unused `hb_buffer_free` function. 

It isn't actually used and promotes heap allocated buffers, instead of stack allocated buffers by taking a pointer to a buffer pointer.