### PR TITLE
Parser: Use location-based detection for ERB control types

### DIFF
--- a/src/analyze_helpers.c
+++ b/src/analyze_helpers.c
@@ -110,11 +110,19 @@ bool search_block_nodes(const pm_node_t* node, void* data) {
   analyzed_ruby_T* analyzed = (analyzed_ruby_T*) data;
 
   if (node->type == PM_BLOCK_NODE) {
-    analyzed->has_block_node = true;
-    return true;
-  } else {
-    pm_visit_child_nodes(node, search_block_nodes, analyzed);
+    pm_block_node_t* block_node = (pm_block_node_t*) node;
+
+    size_t opening_length = block_node->opening_loc.end - block_node->opening_loc.start;
+
+    if ((opening_length == 2 && block_node->opening_loc.start[0] == 'd' && block_node->opening_loc.start[1] == 'o')
+        || (opening_length == 1 && block_node->opening_loc.start[0] == '{')) {
+      analyzed->has_block_node = true;
+
+      return true;
+    }
   }
+
+  pm_visit_child_nodes(node, search_block_nodes, analyzed);
 
   return false;
 }

--- a/test/analyze/block_test.rb
+++ b/test/analyze/block_test.rb
@@ -164,5 +164,35 @@ module Analyze
         <%= yield(:header) if content_for?(:header) %>
       HTML
     end
+
+    test "unclosed brace block should error" do
+      assert_parsed_snapshot(<<~HTML)
+        <% items.each { |item| %>
+          <%= item %>
+        <% } %>
+      HTML
+    end
+
+    test "unclosed brace block with end should error" do
+      assert_parsed_snapshot(<<~HTML)
+        <% items.each { |item| %>
+          <%= item %>
+        <% end %>
+      HTML
+    end
+
+    test "closed brace block in single tag is not a block" do
+      assert_parsed_snapshot(<<~HTML)
+        <% items.map { |item| item.name } %>
+      HTML
+    end
+
+    test "do/end block works as expected" do
+      assert_parsed_snapshot(<<~HTML)
+        <% items.each do |item| %>
+          <%= item %>
+        <% end %>
+      HTML
+    end
   end
 end

--- a/test/analyze/if_test.rb
+++ b/test/analyze/if_test.rb
@@ -134,6 +134,14 @@ module Analyze
       HTML
     end
 
+    test "if with yield in condition" do
+      assert_parsed_snapshot(<<~HTML)
+        <% if yield(:a) %>
+          content
+        <% end %>
+      HTML
+    end
+
     test "conditional attribute value" do
       skip
 

--- a/test/parser/erb_test.rb
+++ b/test/parser/erb_test.rb
@@ -258,5 +258,56 @@ module Parser
         more %> <% code %>
       HTML
     end
+
+    test "if/then/else with trimming and nested output tags (real-world RDoc example)" do
+      assert_parsed_snapshot(<<~'HTML')
+        <%- if @options.main_page and main_page = @files.find { |f| f.full_name == @options.main_page } then %>
+          <meta name="description" content="<%= h "#{@title}: #{excerpt(main_page.comment)}" %>">
+        <%- else %>
+          <meta name="description" content="Documentation for <%= h @title %>">
+        <%- end %>
+      HTML
+    end
+
+    test "if/elsif with block syntax in condition" do
+      assert_parsed_snapshot(<<~HTML)
+        <% if value %>
+
+        <% elsif items.any? { |item| item.true? } %>
+
+        <% end %>
+      HTML
+    end
+
+    test "if/elsif with symbol to proc in condition" do
+      assert_parsed_snapshot(<<~HTML)
+        <% if value %>
+
+        <% elsif items.any?(&:true?) %>
+
+        <% end %>
+      HTML
+    end
+
+    test "if/elsif/else with multiple block conditions and output (real-world form errors)" do
+      assert_parsed_snapshot(<<~HTML)
+        <% if f.object.errors.any? { |e| e.type == :blank } %>
+          Name is required.
+        <% elsif f.object.errors.any? { |e| e.type == :taken } %>
+          Coffee bag with this name and roast date already exists on this roaster.
+        <% else %>
+          <%= f.object.errors.first.message %>
+        <% end %>
+      HTML
+    end
+
+    test "if/elsif/else with assignment and block in condition" do
+      assert_parsed_snapshot(<<~HTML)
+        <% if something = @some.find { |t| t.id == 1 } %>
+        <% elsif other_condition %>
+        <% else %>
+        <% end %>
+      HTML
+    end
   end
 end

--- a/test/snapshots/analyze/block_test/test_0019_unclosed_brace_block_should_error_71c9c1b58aa58b284c179d494b481660.txt
+++ b/test/snapshots/analyze/block_test/test_0019_unclosed_brace_block_should_error_71c9c1b58aa58b284c179d494b481660.txt
@@ -1,0 +1,36 @@
+---
+source: "Analyze::BlockTest#test_0019_unclosed brace block should error"
+input: |2-
+<% items.each { |item| %>
+  <%= item %>
+<% } %>
+---
+@ DocumentNode (location: (1:0)-(4:0))
+└── children: (2 items)
+    ├── @ ERBBlockNode (location: (1:0)-(3:7))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
+    │   ├── content: " items.each { |item| " (location: (1:2)-(1:23))
+    │   ├── tag_closing: "%>" (location: (1:23)-(1:25))
+    │   ├── body: (3 items)
+    │   │   ├── @ HTMLTextNode (location: (1:25)-(2:2))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ ERBContentNode (location: (2:2)-(2:13))
+    │   │   │   ├── tag_opening: "<%=" (location: (2:2)-(2:5))
+    │   │   │   ├── content: " item " (location: (2:5)-(2:11))
+    │   │   │   ├── tag_closing: "%>" (location: (2:11)-(2:13))
+    │   │   │   ├── parsed: true
+    │   │   │   └── valid: true
+    │   │   │
+    │   │   └── @ HTMLTextNode (location: (2:13)-(3:0))
+    │   │       └── content: "\n"
+    │   │
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (3:0)-(3:7))
+    │           ├── tag_opening: "<%" (location: (3:0)-(3:2))
+    │           ├── content: " } " (location: (3:2)-(3:5))
+    │           └── tag_closing: "%>" (location: (3:5)-(3:7))
+    │
+    │
+    └── @ HTMLTextNode (location: (3:7)-(4:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/block_test/test_0020_unclosed_brace_block_with_end_should_error_ce5658e89dd99cb6740835d0d0666353.txt
+++ b/test/snapshots/analyze/block_test/test_0020_unclosed_brace_block_with_end_should_error_ce5658e89dd99cb6740835d0d0666353.txt
@@ -1,0 +1,55 @@
+---
+source: "Analyze::BlockTest#test_0020_unclosed brace block with end should error"
+input: |2-
+<% items.each { |item| %>
+  <%= item %>
+<% end %>
+---
+@ DocumentNode (location: (1:0)-(4:0))
+├── errors: (3 errors)
+│   ├── @ RubyParseError (location: (3:3)-(3:6))
+│   │   ├── message: "unexpected_token_ignore: unexpected 'end', ignoring it"
+│   │   ├── error_message: "unexpected 'end', ignoring it"
+│   │   ├── diagnostic_id: "unexpected_token_ignore"
+│   │   └── level: "syntax"
+│   │
+│   ├── @ RubyParseError (location: (3:9)-(4:0))
+│   │   ├── message: "unexpected_token_close_context: unexpected end-of-input, assuming it is closing the parent top level context"
+│   │   ├── error_message: "unexpected end-of-input, assuming it is closing the parent top level context"
+│   │   ├── diagnostic_id: "unexpected_token_close_context"
+│   │   └── level: "syntax"
+│   │
+│   └── @ RubyParseError (location: (4:0)-(4:0))
+│       ├── message: "block_term_brace: expected a block beginning with `{` to end with `}`"
+│       ├── error_message: "expected a block beginning with `{` to end with `}`"
+│       ├── diagnostic_id: "block_term_brace"
+│       └── level: "syntax"
+│
+└── children: (2 items)
+    ├── @ ERBBlockNode (location: (1:0)-(3:9))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
+    │   ├── content: " items.each { |item| " (location: (1:2)-(1:23))
+    │   ├── tag_closing: "%>" (location: (1:23)-(1:25))
+    │   ├── body: (3 items)
+    │   │   ├── @ HTMLTextNode (location: (1:25)-(2:2))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ ERBContentNode (location: (2:2)-(2:13))
+    │   │   │   ├── tag_opening: "<%=" (location: (2:2)-(2:5))
+    │   │   │   ├── content: " item " (location: (2:5)-(2:11))
+    │   │   │   ├── tag_closing: "%>" (location: (2:11)-(2:13))
+    │   │   │   ├── parsed: true
+    │   │   │   └── valid: true
+    │   │   │
+    │   │   └── @ HTMLTextNode (location: (2:13)-(3:0))
+    │   │       └── content: "\n"
+    │   │
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (3:0)-(3:9))
+    │           ├── tag_opening: "<%" (location: (3:0)-(3:2))
+    │           ├── content: " end " (location: (3:2)-(3:7))
+    │           └── tag_closing: "%>" (location: (3:7)-(3:9))
+    │
+    │
+    └── @ HTMLTextNode (location: (3:9)-(4:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/block_test/test_0021_closed_brace_block_in_single_tag_is_not_a_block_5795056538d87c6366da710856a9f7e2.txt
+++ b/test/snapshots/analyze/block_test/test_0021_closed_brace_block_in_single_tag_is_not_a_block_5795056538d87c6366da710856a9f7e2.txt
@@ -1,0 +1,16 @@
+---
+source: "Analyze::BlockTest#test_0021_closed brace block in single tag is not a block"
+input: |2-
+<% items.map { |item| item.name } %>
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ ERBContentNode (location: (1:0)-(1:36))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
+    │   ├── content: " items.map { |item| item.name } " (location: (1:2)-(1:34))
+    │   ├── tag_closing: "%>" (location: (1:34)-(1:36))
+    │   ├── parsed: true
+    │   └── valid: true
+    │
+    └── @ HTMLTextNode (location: (1:36)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/block_test/test_0022_do_end_block_works_as_expected_6af38da3c127d941bc2ca73254434f84.txt
+++ b/test/snapshots/analyze/block_test/test_0022_do_end_block_works_as_expected_6af38da3c127d941bc2ca73254434f84.txt
@@ -1,0 +1,36 @@
+---
+source: "Analyze::BlockTest#test_0022_do/end block works as expected"
+input: |2-
+<% items.each do |item| %>
+  <%= item %>
+<% end %>
+---
+@ DocumentNode (location: (1:0)-(4:0))
+└── children: (2 items)
+    ├── @ ERBBlockNode (location: (1:0)-(3:9))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
+    │   ├── content: " items.each do |item| " (location: (1:2)-(1:24))
+    │   ├── tag_closing: "%>" (location: (1:24)-(1:26))
+    │   ├── body: (3 items)
+    │   │   ├── @ HTMLTextNode (location: (1:26)-(2:2))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ ERBContentNode (location: (2:2)-(2:13))
+    │   │   │   ├── tag_opening: "<%=" (location: (2:2)-(2:5))
+    │   │   │   ├── content: " item " (location: (2:5)-(2:11))
+    │   │   │   ├── tag_closing: "%>" (location: (2:11)-(2:13))
+    │   │   │   ├── parsed: true
+    │   │   │   └── valid: true
+    │   │   │
+    │   │   └── @ HTMLTextNode (location: (2:13)-(3:0))
+    │   │       └── content: "\n"
+    │   │
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (3:0)-(3:9))
+    │           ├── tag_opening: "<%" (location: (3:0)-(3:2))
+    │           ├── content: " end " (location: (3:2)-(3:7))
+    │           └── tag_closing: "%>" (location: (3:7)-(3:9))
+    │
+    │
+    └── @ HTMLTextNode (location: (3:9)-(4:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/if_test/test_0014_if_with_yield_in_condition_4070aeafc603aa162d1c39baf6f6f451.txt
+++ b/test/snapshots/analyze/if_test/test_0014_if_with_yield_in_condition_4070aeafc603aa162d1c39baf6f6f451.txt
@@ -1,0 +1,27 @@
+---
+source: "Analyze::IfTest#test_0014_if with yield in condition"
+input: |2-
+<% if yield(:a) %>
+  content
+<% end %>
+---
+@ DocumentNode (location: (1:0)-(4:0))
+└── children: (2 items)
+    ├── @ ERBIfNode (location: (1:0)-(3:9))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
+    │   ├── content: " if yield(:a) " (location: (1:2)-(1:16))
+    │   ├── tag_closing: "%>" (location: (1:16)-(1:18))
+    │   ├── statements: (1 item)
+    │   │   └── @ HTMLTextNode (location: (1:18)-(3:0))
+    │   │       └── content: "\n  content\n"
+    │   │
+    │   ├── subsequent: ∅
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (3:0)-(3:9))
+    │           ├── tag_opening: "<%" (location: (3:0)-(3:2))
+    │           ├── content: " end " (location: (3:2)-(3:7))
+    │           └── tag_closing: "%>" (location: (3:7)-(3:9))
+    │
+    │
+    └── @ HTMLTextNode (location: (3:9)-(4:0))
+        └── content: "\n"

--- a/test/snapshots/parser/erb_test/test_0047_if_then_else_with_trimming_and_nested_output_tags_(real-world_RDoc_example)_6c3b80e7864615f8a75a7ec3f037b94f.txt
+++ b/test/snapshots/parser/erb_test/test_0047_if_then_else_with_trimming_and_nested_output_tags_(real-world_RDoc_example)_6c3b80e7864615f8a75a7ec3f037b94f.txt
@@ -1,0 +1,165 @@
+---
+source: "Parser::ERBTest#test_0047_if/then/else with trimming and nested output tags (real-world RDoc example)"
+input: |2-
+<%- if @options.main_page and main_page = @files.find { |f| f.full_name == @options.main_page } then %>
+  <meta name="description" content="<%= h "#{@title}: #{excerpt(main_page.comment)}" %>">
+<%- else %>
+  <meta name="description" content="Documentation for <%= h @title %>">
+<%- end %>
+---
+@ DocumentNode (location: (1:0)-(6:0))
+└── children: (2 items)
+    ├── @ ERBIfNode (location: (1:0)-(5:10))
+    │   ├── tag_opening: "<%-" (location: (1:0)-(1:3))
+    │   ├── content: " if @options.main_page and main_page = @files.find { |f| f.full_name == @options.main_page } then " (location: (1:3)-(1:101))
+    │   ├── tag_closing: "%>" (location: (1:101)-(1:103))
+    │   ├── statements: (3 items)
+    │   │   ├── @ HTMLTextNode (location: (1:103)-(2:2))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ HTMLElementNode (location: (2:2)-(2:89))
+    │   │   │   ├── open_tag:
+    │   │   │   │   └── @ HTMLOpenTagNode (location: (2:2)-(2:89))
+    │   │   │   │       ├── tag_opening: "<" (location: (2:2)-(2:3))
+    │   │   │   │       ├── tag_name: "meta" (location: (2:3)-(2:7))
+    │   │   │   │       ├── tag_closing: ">" (location: (2:88)-(2:89))
+    │   │   │   │       ├── children: (2 items)
+    │   │   │   │       │   ├── @ HTMLAttributeNode (location: (2:8)-(2:26))
+    │   │   │   │       │   │   ├── name:
+    │   │   │   │       │   │   │   └── @ HTMLAttributeNameNode (location: (2:8)-(2:12))
+    │   │   │   │       │   │   │       └── children: (1 item)
+    │   │   │   │       │   │   │           └── @ LiteralNode (location: (2:8)-(2:12))
+    │   │   │   │       │   │   │               └── content: "name"
+    │   │   │   │       │   │   │
+    │   │   │   │       │   │   │
+    │   │   │   │       │   │   ├── equals: "=" (location: (2:12)-(2:13))
+    │   │   │   │       │   │   └── value:
+    │   │   │   │       │   │       └── @ HTMLAttributeValueNode (location: (2:13)-(2:26))
+    │   │   │   │       │   │           ├── open_quote: """ (location: (2:13)-(2:14))
+    │   │   │   │       │   │           ├── children: (1 item)
+    │   │   │   │       │   │           │   └── @ LiteralNode (location: (2:14)-(2:25))
+    │   │   │   │       │   │           │       └── content: "description"
+    │   │   │   │       │   │           │
+    │   │   │   │       │   │           ├── close_quote: """ (location: (2:25)-(2:26))
+    │   │   │   │       │   │           └── quoted: true
+    │   │   │   │       │   │
+    │   │   │   │       │   │
+    │   │   │   │       │   └── @ HTMLAttributeNode (location: (2:27)-(2:88))
+    │   │   │   │       │       ├── name:
+    │   │   │   │       │       │   └── @ HTMLAttributeNameNode (location: (2:27)-(2:34))
+    │   │   │   │       │       │       └── children: (1 item)
+    │   │   │   │       │       │           └── @ LiteralNode (location: (2:27)-(2:34))
+    │   │   │   │       │       │               └── content: "content"
+    │   │   │   │       │       │
+    │   │   │   │       │       │
+    │   │   │   │       │       ├── equals: "=" (location: (2:34)-(2:35))
+    │   │   │   │       │       └── value:
+    │   │   │   │       │           └── @ HTMLAttributeValueNode (location: (2:35)-(2:88))
+    │   │   │   │       │               ├── open_quote: """ (location: (2:35)-(2:36))
+    │   │   │   │       │               ├── children: (1 item)
+    │   │   │   │       │               │   └── @ ERBContentNode (location: (2:36)-(2:87))
+    │   │   │   │       │               │       ├── tag_opening: "<%=" (location: (2:36)-(2:39))
+    │   │   │   │       │               │       ├── content: " h "#{@title}: #{excerpt(main_page.comment)}" " (location: (2:39)-(2:85))
+    │   │   │   │       │               │       ├── tag_closing: "%>" (location: (2:85)-(2:87))
+    │   │   │   │       │               │       ├── parsed: true
+    │   │   │   │       │               │       └── valid: true
+    │   │   │   │       │               │
+    │   │   │   │       │               ├── close_quote: """ (location: (2:87)-(2:88))
+    │   │   │   │       │               └── quoted: true
+    │   │   │   │       │
+    │   │   │   │       │
+    │   │   │   │       └── is_void: false
+    │   │   │   │
+    │   │   │   ├── tag_name: "meta" (location: (2:3)-(2:7))
+    │   │   │   ├── body: []
+    │   │   │   ├── close_tag: ∅
+    │   │   │   ├── is_void: true
+    │   │   │   └── source: "HTML"
+    │   │   │
+    │   │   └── @ HTMLTextNode (location: (2:89)-(3:0))
+    │   │       └── content: "\n"
+    │   │
+    │   ├── subsequent:
+    │   │   └── @ ERBElseNode (location: (3:0)-(5:0))
+    │   │       ├── tag_opening: "<%-" (location: (3:0)-(3:3))
+    │   │       ├── content: " else " (location: (3:3)-(3:9))
+    │   │       ├── tag_closing: "%>" (location: (3:9)-(3:11))
+    │   │       └── statements: (3 items)
+    │   │           ├── @ HTMLTextNode (location: (3:11)-(4:2))
+    │   │           │   └── content: "\n  "
+    │   │           │
+    │   │           ├── @ HTMLElementNode (location: (4:2)-(4:71))
+    │   │           │   ├── open_tag:
+    │   │           │   │   └── @ HTMLOpenTagNode (location: (4:2)-(4:71))
+    │   │           │   │       ├── tag_opening: "<" (location: (4:2)-(4:3))
+    │   │           │   │       ├── tag_name: "meta" (location: (4:3)-(4:7))
+    │   │           │   │       ├── tag_closing: ">" (location: (4:70)-(4:71))
+    │   │           │   │       ├── children: (2 items)
+    │   │           │   │       │   ├── @ HTMLAttributeNode (location: (4:8)-(4:26))
+    │   │           │   │       │   │   ├── name:
+    │   │           │   │       │   │   │   └── @ HTMLAttributeNameNode (location: (4:8)-(4:12))
+    │   │           │   │       │   │   │       └── children: (1 item)
+    │   │           │   │       │   │   │           └── @ LiteralNode (location: (4:8)-(4:12))
+    │   │           │   │       │   │   │               └── content: "name"
+    │   │           │   │       │   │   │
+    │   │           │   │       │   │   │
+    │   │           │   │       │   │   ├── equals: "=" (location: (4:12)-(4:13))
+    │   │           │   │       │   │   └── value:
+    │   │           │   │       │   │       └── @ HTMLAttributeValueNode (location: (4:13)-(4:26))
+    │   │           │   │       │   │           ├── open_quote: """ (location: (4:13)-(4:14))
+    │   │           │   │       │   │           ├── children: (1 item)
+    │   │           │   │       │   │           │   └── @ LiteralNode (location: (4:14)-(4:25))
+    │   │           │   │       │   │           │       └── content: "description"
+    │   │           │   │       │   │           │
+    │   │           │   │       │   │           ├── close_quote: """ (location: (4:25)-(4:26))
+    │   │           │   │       │   │           └── quoted: true
+    │   │           │   │       │   │
+    │   │           │   │       │   │
+    │   │           │   │       │   └── @ HTMLAttributeNode (location: (4:27)-(4:70))
+    │   │           │   │       │       ├── name:
+    │   │           │   │       │       │   └── @ HTMLAttributeNameNode (location: (4:27)-(4:34))
+    │   │           │   │       │       │       └── children: (1 item)
+    │   │           │   │       │       │           └── @ LiteralNode (location: (4:27)-(4:34))
+    │   │           │   │       │       │               └── content: "content"
+    │   │           │   │       │       │
+    │   │           │   │       │       │
+    │   │           │   │       │       ├── equals: "=" (location: (4:34)-(4:35))
+    │   │           │   │       │       └── value:
+    │   │           │   │       │           └── @ HTMLAttributeValueNode (location: (4:35)-(4:70))
+    │   │           │   │       │               ├── open_quote: """ (location: (4:35)-(4:36))
+    │   │           │   │       │               ├── children: (2 items)
+    │   │           │   │       │               │   ├── @ LiteralNode (location: (4:36)-(4:54))
+    │   │           │   │       │               │   │   └── content: "Documentation for "
+    │   │           │   │       │               │   │
+    │   │           │   │       │               │   └── @ ERBContentNode (location: (4:54)-(4:69))
+    │   │           │   │       │               │       ├── tag_opening: "<%=" (location: (4:54)-(4:57))
+    │   │           │   │       │               │       ├── content: " h @title " (location: (4:57)-(4:67))
+    │   │           │   │       │               │       ├── tag_closing: "%>" (location: (4:67)-(4:69))
+    │   │           │   │       │               │       ├── parsed: true
+    │   │           │   │       │               │       └── valid: true
+    │   │           │   │       │               │
+    │   │           │   │       │               ├── close_quote: """ (location: (4:69)-(4:70))
+    │   │           │   │       │               └── quoted: true
+    │   │           │   │       │
+    │   │           │   │       │
+    │   │           │   │       └── is_void: false
+    │   │           │   │
+    │   │           │   ├── tag_name: "meta" (location: (4:3)-(4:7))
+    │   │           │   ├── body: []
+    │   │           │   ├── close_tag: ∅
+    │   │           │   ├── is_void: true
+    │   │           │   └── source: "HTML"
+    │   │           │
+    │   │           └── @ HTMLTextNode (location: (4:71)-(5:0))
+    │   │               └── content: "\n"
+    │   │
+    │   │
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (5:0)-(5:10))
+    │           ├── tag_opening: "<%-" (location: (5:0)-(5:3))
+    │           ├── content: " end " (location: (5:3)-(5:8))
+    │           └── tag_closing: "%>" (location: (5:8)-(5:10))
+    │
+    │
+    └── @ HTMLTextNode (location: (5:10)-(6:0))
+        └── content: "\n"

--- a/test/snapshots/parser/erb_test/test_0048_if_elsif_with_block_syntax_in_condition_ba20822ea8182f5e4fb7bf8515cfa1a3.txt
+++ b/test/snapshots/parser/erb_test/test_0048_if_elsif_with_block_syntax_in_condition_ba20822ea8182f5e4fb7bf8515cfa1a3.txt
@@ -1,0 +1,40 @@
+---
+source: "Parser::ERBTest#test_0048_if/elsif with block syntax in condition"
+input: |2-
+<% if value %>
+
+<% elsif items.any? { |item| item.true? } %>
+
+<% end %>
+---
+@ DocumentNode (location: (1:0)-(6:0))
+└── children: (2 items)
+    ├── @ ERBIfNode (location: (1:0)-(5:9))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
+    │   ├── content: " if value " (location: (1:2)-(1:12))
+    │   ├── tag_closing: "%>" (location: (1:12)-(1:14))
+    │   ├── statements: (1 item)
+    │   │   └── @ HTMLTextNode (location: (1:14)-(3:0))
+    │   │       └── content: "\n\n"
+    │   │
+    │   ├── subsequent:
+    │   │   └── @ ERBIfNode (location: (3:0)-(5:0))
+    │   │       ├── tag_opening: "<%" (location: (3:0)-(3:2))
+    │   │       ├── content: " elsif items.any? { |item| item.true? } " (location: (3:2)-(3:42))
+    │   │       ├── tag_closing: "%>" (location: (3:42)-(3:44))
+    │   │       ├── statements: (1 item)
+    │   │       │   └── @ HTMLTextNode (location: (3:44)-(5:0))
+    │   │       │       └── content: "\n\n"
+    │   │       │
+    │   │       ├── subsequent: ∅
+    │   │       └── end_node: ∅
+    │   │
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (5:0)-(5:9))
+    │           ├── tag_opening: "<%" (location: (5:0)-(5:2))
+    │           ├── content: " end " (location: (5:2)-(5:7))
+    │           └── tag_closing: "%>" (location: (5:7)-(5:9))
+    │
+    │
+    └── @ HTMLTextNode (location: (5:9)-(6:0))
+        └── content: "\n"

--- a/test/snapshots/parser/erb_test/test_0049_if_elsif_with_symbol_to_proc_in_condition_6e7724ebffff1929458931e07e94b5fc.txt
+++ b/test/snapshots/parser/erb_test/test_0049_if_elsif_with_symbol_to_proc_in_condition_6e7724ebffff1929458931e07e94b5fc.txt
@@ -1,0 +1,40 @@
+---
+source: "Parser::ERBTest#test_0049_if/elsif with symbol to proc in condition"
+input: |2-
+<% if value %>
+
+<% elsif items.any?(&:true?) %>
+
+<% end %>
+---
+@ DocumentNode (location: (1:0)-(6:0))
+└── children: (2 items)
+    ├── @ ERBIfNode (location: (1:0)-(5:9))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
+    │   ├── content: " if value " (location: (1:2)-(1:12))
+    │   ├── tag_closing: "%>" (location: (1:12)-(1:14))
+    │   ├── statements: (1 item)
+    │   │   └── @ HTMLTextNode (location: (1:14)-(3:0))
+    │   │       └── content: "\n\n"
+    │   │
+    │   ├── subsequent:
+    │   │   └── @ ERBIfNode (location: (3:0)-(5:0))
+    │   │       ├── tag_opening: "<%" (location: (3:0)-(3:2))
+    │   │       ├── content: " elsif items.any?(&:true?) " (location: (3:2)-(3:29))
+    │   │       ├── tag_closing: "%>" (location: (3:29)-(3:31))
+    │   │       ├── statements: (1 item)
+    │   │       │   └── @ HTMLTextNode (location: (3:31)-(5:0))
+    │   │       │       └── content: "\n\n"
+    │   │       │
+    │   │       ├── subsequent: ∅
+    │   │       └── end_node: ∅
+    │   │
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (5:0)-(5:9))
+    │           ├── tag_opening: "<%" (location: (5:0)-(5:2))
+    │           ├── content: " end " (location: (5:2)-(5:7))
+    │           └── tag_closing: "%>" (location: (5:7)-(5:9))
+    │
+    │
+    └── @ HTMLTextNode (location: (5:9)-(6:0))
+        └── content: "\n"

--- a/test/snapshots/parser/erb_test/test_0050_if_elsif_else_with_multiple_block_conditions_and_output_(real-world_form_errors)_10f348784fe47c985ab245e92368d3b8.txt
+++ b/test/snapshots/parser/erb_test/test_0050_if_elsif_else_with_multiple_block_conditions_and_output_(real-world_form_errors)_10f348784fe47c985ab245e92368d3b8.txt
@@ -1,0 +1,61 @@
+---
+source: "Parser::ERBTest#test_0050_if/elsif/else with multiple block conditions and output (real-world form errors)"
+input: |2-
+<% if f.object.errors.any? { |e| e.type == :blank } %>
+  Name is required.
+<% elsif f.object.errors.any? { |e| e.type == :taken } %>
+  Coffee bag with this name and roast date already exists on this roaster.
+<% else %>
+  <%= f.object.errors.first.message %>
+<% end %>
+---
+@ DocumentNode (location: (1:0)-(8:0))
+└── children: (2 items)
+    ├── @ ERBIfNode (location: (1:0)-(7:9))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
+    │   ├── content: " if f.object.errors.any? { |e| e.type == :blank } " (location: (1:2)-(1:52))
+    │   ├── tag_closing: "%>" (location: (1:52)-(1:54))
+    │   ├── statements: (1 item)
+    │   │   └── @ HTMLTextNode (location: (1:54)-(3:0))
+    │   │       └── content: "\n  Name is required.\n"
+    │   │
+    │   ├── subsequent:
+    │   │   └── @ ERBIfNode (location: (3:0)-(5:0))
+    │   │       ├── tag_opening: "<%" (location: (3:0)-(3:2))
+    │   │       ├── content: " elsif f.object.errors.any? { |e| e.type == :taken } " (location: (3:2)-(3:55))
+    │   │       ├── tag_closing: "%>" (location: (3:55)-(3:57))
+    │   │       ├── statements: (1 item)
+    │   │       │   └── @ HTMLTextNode (location: (3:57)-(5:0))
+    │   │       │       └── content: "\n  Coffee bag with this name and roast date already exists on this roaster.\n"
+    │   │       │
+    │   │       ├── subsequent:
+    │   │       │   └── @ ERBElseNode (location: (5:0)-(7:0))
+    │   │       │       ├── tag_opening: "<%" (location: (5:0)-(5:2))
+    │   │       │       ├── content: " else " (location: (5:2)-(5:8))
+    │   │       │       ├── tag_closing: "%>" (location: (5:8)-(5:10))
+    │   │       │       └── statements: (3 items)
+    │   │       │           ├── @ HTMLTextNode (location: (5:10)-(6:2))
+    │   │       │           │   └── content: "\n  "
+    │   │       │           │
+    │   │       │           ├── @ ERBContentNode (location: (6:2)-(6:38))
+    │   │       │           │   ├── tag_opening: "<%=" (location: (6:2)-(6:5))
+    │   │       │           │   ├── content: " f.object.errors.first.message " (location: (6:5)-(6:36))
+    │   │       │           │   ├── tag_closing: "%>" (location: (6:36)-(6:38))
+    │   │       │           │   ├── parsed: true
+    │   │       │           │   └── valid: true
+    │   │       │           │
+    │   │       │           └── @ HTMLTextNode (location: (6:38)-(7:0))
+    │   │       │               └── content: "\n"
+    │   │       │
+    │   │       │
+    │   │       └── end_node: ∅
+    │   │
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (7:0)-(7:9))
+    │           ├── tag_opening: "<%" (location: (7:0)-(7:2))
+    │           ├── content: " end " (location: (7:2)-(7:7))
+    │           └── tag_closing: "%>" (location: (7:7)-(7:9))
+    │
+    │
+    └── @ HTMLTextNode (location: (7:9)-(8:0))
+        └── content: "\n"

--- a/test/snapshots/parser/erb_test/test_0051_if_elsif_else_with_assignment_and_block_in_condition_039c95173fbba491fbdcde41740cd7eb.txt
+++ b/test/snapshots/parser/erb_test/test_0051_if_elsif_else_with_assignment_and_block_in_condition_039c95173fbba491fbdcde41740cd7eb.txt
@@ -1,0 +1,48 @@
+---
+source: "Parser::ERBTest#test_0051_if/elsif/else with assignment and block in condition"
+input: |2-
+<% if something = @some.find { |t| t.id == 1 } %>
+<% elsif other_condition %>
+<% else %>
+<% end %>
+---
+@ DocumentNode (location: (1:0)-(5:0))
+└── children: (2 items)
+    ├── @ ERBIfNode (location: (1:0)-(4:9))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
+    │   ├── content: " if something = @some.find { |t| t.id == 1 } " (location: (1:2)-(1:47))
+    │   ├── tag_closing: "%>" (location: (1:47)-(1:49))
+    │   ├── statements: (1 item)
+    │   │   └── @ HTMLTextNode (location: (1:49)-(2:0))
+    │   │       └── content: "\n"
+    │   │
+    │   ├── subsequent:
+    │   │   └── @ ERBIfNode (location: (2:0)-(3:0))
+    │   │       ├── tag_opening: "<%" (location: (2:0)-(2:2))
+    │   │       ├── content: " elsif other_condition " (location: (2:2)-(2:25))
+    │   │       ├── tag_closing: "%>" (location: (2:25)-(2:27))
+    │   │       ├── statements: (1 item)
+    │   │       │   └── @ HTMLTextNode (location: (2:27)-(3:0))
+    │   │       │       └── content: "\n"
+    │   │       │
+    │   │       ├── subsequent:
+    │   │       │   └── @ ERBElseNode (location: (3:0)-(4:0))
+    │   │       │       ├── tag_opening: "<%" (location: (3:0)-(3:2))
+    │   │       │       ├── content: " else " (location: (3:2)-(3:8))
+    │   │       │       ├── tag_closing: "%>" (location: (3:8)-(3:10))
+    │   │       │       └── statements: (1 item)
+    │   │       │           └── @ HTMLTextNode (location: (3:10)-(4:0))
+    │   │       │               └── content: "\n"
+    │   │       │
+    │   │       │
+    │   │       └── end_node: ∅
+    │   │
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (4:0)-(4:9))
+    │           ├── tag_opening: "<%" (location: (4:0)-(4:2))
+    │           ├── content: " end " (location: (4:2)-(4:7))
+    │           └── tag_closing: "%>" (location: (4:7)-(4:9))
+    │
+    │
+    └── @ HTMLTextNode (location: (4:9)-(5:0))
+        └── content: "\n"


### PR DESCRIPTION
This commit improves the parser's control type detection by comparing keyword locations instead of relying solely on AST node structure.

This template:
```html+erb
<% if value %>
<% elsif items.any? { |item| item.true? } %>
<% end %>
```

Now gets correctly parsed as:
```js
@ DocumentNode (location: (1:0)-(3:9))
├── errors: []
└── children: (1 item)
    └── @ ERBIfNode (location: (1:0)-(3:9))
        ├── errors: []
        ├── tag_opening: "<%" (location: (1:0)-(1:2))
        ├── content: " if value " (location: (1:2)-(1:12))
        ├── tag_closing: "%>" (location: (1:12)-(1:14))
        ├── statements: (1 item)
        │   └── @ HTMLTextNode (location: (1:14)-(2:0))
        │       ├── errors: []
        │       └── content: "\n"
        │   
        ├── subsequent: 
        │   └── @ ERBIfNode (location: (2:0)-(3:0))
        │       ├── errors: []
        │       ├── tag_opening: "<%" (location: (2:0)-(2:2))
        │       ├── content: " elsif items.any? { |item| item.true? } " (location: (2:2)-(2:42))
        │       ├── tag_closing: "%>" (location: (2:42)-(2:44))
        │       ├── statements: (1 item)
        │       │   └── @ HTMLTextNode (location: (2:44)-(3:0))
        │       │       ├── errors: []
        │       │       └── content: "\n"
        │       │   
        │       ├── subsequent: ∅
        │       └── end_node: ∅
        │       
        └── end_node: 
            └── @ ERBEndNode (location: (3:0)-(3:9))
                ├── errors: []
                ├── tag_opening: "<%" (location: (3:0)-(3:2))
                ├── content: " end " (location: (3:2)-(3:7))
                └── tag_closing: "%>" (location: (3:7)-(3:9))
```

Previously the `elsif` was treated as `ERBBlockNode` causing the `<% end %>` to be consumed for the `ERBBlockNode`:
```js
@ DocumentNode (location: (1:0)-(3:9))
├── errors: []
└── children: (1 item)
    └── @ ERBIfNode (location: (1:0)-(3:9))
        ├── errors: (1 item)
        │   └── @ MissingERBEndTagError (location: (1:0)-(1:14))
        │       ├── message: "`<% if %>` started here but never closed with an end tag. The end tag may be in a different scope."
        │       └── keyword: "`<% if %>`"
        │   
        ├── tag_opening: "<%" (location: (1:0)-(1:2))
        ├── content: " if value " (location: (1:2)-(1:12))
        ├── tag_closing: "%>" (location: (1:12)-(1:14))
        ├── statements: (2 items)
        │   ├── @ HTMLTextNode (location: (1:14)-(2:0))
        │   │   ├── errors: []
        │   │   └── content: "\n"
        │   │   
        │   └── @ ERBBlockNode (location: (2:0)-(3:9))
        │       ├── errors: []
        │       ├── tag_opening: "<%" (location: (2:0)-(2:2))
        │       ├── content: " elsif items.any? { |item| item.true? } " (location: (2:2)-(2:42))
        │       ├── tag_closing: "%>" (location: (2:42)-(2:44))
        │       ├── body: (1 item)
        │       │   └── @ HTMLTextNode (location: (2:44)-(3:0))
        │       │       ├── errors: []
        │       │       └── content: "\n"
        │       │   
        │       └── end_node: 
        │           └── @ ERBEndNode (location: (3:0)-(3:9))
        │               ├── errors: []
        │               ├── tag_opening: "<%" (location: (3:0)-(3:2))
        │               ├── content: " end " (location: (3:2)-(3:7))
        │               └── tag_closing: "%>" (location: (3:7)-(3:9))
        │   
        ├── subsequent: ∅
        └── end_node: ∅
```


Resolves #857