### PR TITLE
C: Deprecate `hb_array_size`

### DIFF
--- a/ext/herb/extension_helpers.c
+++ b/ext/herb/extension_helpers.c
@@ -63,7 +63,7 @@ VALUE create_lex_result(hb_array_T* tokens, VALUE source) {
   VALUE warnings = rb_ary_new();
   VALUE errors = rb_ary_new();
 
-  for (size_t i = 0; i < hb_array_size(tokens); i++) {
+  for (size_t i = 0; i < tokens->size; i++) {
     token_T* token = hb_array_get(tokens, i);
     if (token != NULL) { rb_ary_push(value, rb_token_from_c_struct(token)); }
   }

--- a/java/extension_helpers.c
+++ b/java/extension_helpers.c
@@ -60,9 +60,9 @@ jobject CreateLexResult(JNIEnv* env, hb_array_T* tokens, jstring source) {
   jmethodID arrayListConstructor = (*env)->GetMethodID(env, arrayListClass, "<init>", "(I)V");
   jmethodID addMethod = (*env)->GetMethodID(env, arrayListClass, "add", "(Ljava/lang/Object;)Z");
 
-  jobject tokensList = (*env)->NewObject(env, arrayListClass, arrayListConstructor, (jint) hb_array_size(tokens));
+  jobject tokensList = (*env)->NewObject(env, arrayListClass, arrayListConstructor, (jint) tokens->size);
 
-  for (size_t i = 0; i < hb_array_size(tokens); i++) {
+  for (size_t i = 0; i < tokens->size; i++) {
     token_T* token = (token_T*) hb_array_get(tokens, i);
     jobject tokenObj = CreateToken(env, token);
     (*env)->CallBooleanMethod(env, tokensList, addMethod, tokenObj);
@@ -85,7 +85,7 @@ jobject CreateParseResult(JNIEnv* env, AST_DOCUMENT_NODE_T* root, jstring source
   jobject errorsList = (*env)->NewObject(env, arrayListClass, arrayListConstructor);
 
   if (root->base.errors) {
-    for (size_t i = 0; i < hb_array_size(root->base.errors); i++) {
+    for (size_t i = 0; i < root->base.errors->size; i++) {
       AST_NODE_T* error_node = (AST_NODE_T*) hb_array_get(root->base.errors, i);
       jobject errorObj = CreateErrorNode(env, error_node);
       (*env)->CallBooleanMethod(env, errorsList, addMethod, errorObj);

--- a/javascript/packages/node/extension/extension_helpers.cpp
+++ b/javascript/packages/node/extension/extension_helpers.cpp
@@ -153,7 +153,7 @@ napi_value CreateLexResult(napi_env env, hb_array_T* tokens, napi_value source) 
 
   // Add tokens to array
   if (tokens) {
-    for (size_t i = 0; i < hb_array_size(tokens); i++) {
+    for (size_t i = 0; i < tokens->size; i++) {
       token_T* token = (token_T*)hb_array_get(tokens, i);
       if (token) {
         napi_value token_obj = CreateToken(env, token);

--- a/src/analyze.c
+++ b/src/analyze.c
@@ -287,8 +287,8 @@ static AST_NODE_T* create_control_node(
 
   if (end_node) {
     end_position = end_node->base.location.end;
-  } else if (children && hb_array_size(children) > 0) {
-    AST_NODE_T* last_child = hb_array_get(children, hb_array_size(children) - 1);
+  } else if (children && children->size > 0) {
+    AST_NODE_T* last_child = hb_array_get(children, children->size - 1);
     end_position = last_child->location.end;
   } else if (subsequent) {
     end_position = subsequent->location.end;
@@ -329,7 +329,7 @@ static AST_NODE_T* create_control_node(
       hb_array_T* in_conditions = hb_array_init(8);
       hb_array_T* non_when_non_in_children = hb_array_init(8);
 
-      for (size_t i = 0; i < hb_array_size(children); i++) {
+      for (size_t i = 0; i < children->size; i++) {
         AST_NODE_T* child = hb_array_get(children, i);
 
         if (child && child->type == AST_ERB_WHEN_NODE) {
@@ -343,7 +343,7 @@ static AST_NODE_T* create_control_node(
 
       hb_array_free(&children);
 
-      if (hb_array_size(in_conditions) > 0) {
+      if (in_conditions->size > 0) {
         hb_array_free(&when_conditions);
 
         return (AST_NODE_T*) ast_erb_case_match_node_init(
@@ -539,7 +539,7 @@ static size_t process_control_structure(
     hb_array_T* in_conditions = hb_array_init(8);
     hb_array_T* non_when_non_in_children = hb_array_init(8);
 
-    while (index < hb_array_size(array)) {
+    while (index < array->size) {
       AST_NODE_T* next_node = hb_array_get(array, index);
 
       if (!next_node) { break; }
@@ -555,7 +555,7 @@ static size_t process_control_structure(
       index++;
     }
 
-    while (index < hb_array_size(array)) {
+    while (index < array->size) {
       AST_NODE_T* next_node = hb_array_get(array, index);
 
       if (!next_node) { break; }
@@ -627,7 +627,7 @@ static size_t process_control_structure(
 
     AST_ERB_ELSE_NODE_T* else_clause = NULL;
 
-    if (index < hb_array_size(array)) {
+    if (index < array->size) {
       AST_NODE_T* next_node = hb_array_get(array, index);
 
       if (next_node && next_node->type == AST_ERB_CONTENT_NODE) {
@@ -661,7 +661,7 @@ static size_t process_control_structure(
 
     AST_ERB_END_NODE_T* end_node = NULL;
 
-    if (index < hb_array_size(array)) {
+    if (index < array->size) {
       AST_NODE_T* potential_end = hb_array_get(array, index);
 
       if (potential_end && potential_end->type == AST_ERB_CONTENT_NODE) {
@@ -694,15 +694,15 @@ static size_t process_control_structure(
       end_position = end_node->base.location.end;
     } else if (else_clause) {
       end_position = else_clause->base.location.end;
-    } else if (hb_array_size(when_conditions) > 0) {
-      AST_NODE_T* last_when = hb_array_get(when_conditions, hb_array_size(when_conditions) - 1);
+    } else if (when_conditions->size > 0) {
+      AST_NODE_T* last_when = hb_array_get(when_conditions, when_conditions->size - 1);
       end_position = last_when->location.end;
-    } else if (hb_array_size(in_conditions) > 0) {
-      AST_NODE_T* last_in = hb_array_get(in_conditions, hb_array_size(in_conditions) - 1);
+    } else if (in_conditions->size > 0) {
+      AST_NODE_T* last_in = hb_array_get(in_conditions, in_conditions->size - 1);
       end_position = last_in->location.end;
     }
 
-    if (hb_array_size(in_conditions) > 0) {
+    if (in_conditions->size > 0) {
       hb_array_T* case_match_errors = erb_node->base.errors;
       erb_node->base.errors = NULL;
 
@@ -760,7 +760,7 @@ static size_t process_control_structure(
     AST_ERB_ELSE_NODE_T* else_clause = NULL;
     AST_ERB_ENSURE_NODE_T* ensure_clause = NULL;
 
-    if (index < hb_array_size(array)) {
+    if (index < array->size) {
       AST_NODE_T* next_node = hb_array_get(array, index);
 
       if (next_node && next_node->type == AST_ERB_CONTENT_NODE) {
@@ -775,7 +775,7 @@ static size_t process_control_structure(
       }
     }
 
-    if (index < hb_array_size(array)) {
+    if (index < array->size) {
       AST_NODE_T* next_node = hb_array_get(array, index);
 
       if (next_node && next_node->type == AST_ERB_CONTENT_NODE) {
@@ -807,7 +807,7 @@ static size_t process_control_structure(
       }
     }
 
-    if (index < hb_array_size(array)) {
+    if (index < array->size) {
       AST_NODE_T* next_node = hb_array_get(array, index);
 
       if (next_node && next_node->type == AST_ERB_CONTENT_NODE) {
@@ -819,7 +819,7 @@ static size_t process_control_structure(
 
           index++;
 
-          while (index < hb_array_size(array)) {
+          while (index < array->size) {
             AST_NODE_T* child = hb_array_get(array, index);
 
             if (!child) { break; }
@@ -855,7 +855,7 @@ static size_t process_control_structure(
 
     AST_ERB_END_NODE_T* end_node = NULL;
 
-    if (index < hb_array_size(array)) {
+    if (index < array->size) {
       AST_NODE_T* potential_end = hb_array_get(array, index);
 
       if (potential_end && potential_end->type == AST_ERB_CONTENT_NODE) {
@@ -922,7 +922,7 @@ static size_t process_control_structure(
 
     AST_ERB_END_NODE_T* end_node = NULL;
 
-    if (index < hb_array_size(array)) {
+    if (index < array->size) {
       AST_NODE_T* potential_close = hb_array_get(array, index);
 
       if (potential_close && potential_close->type == AST_ERB_CONTENT_NODE) {
@@ -954,8 +954,8 @@ static size_t process_control_structure(
 
     if (end_node) {
       end_position = end_node->base.location.end;
-    } else if (children && hb_array_size(children) > 0) {
-      AST_NODE_T* last_child = hb_array_get(children, hb_array_size(children) - 1);
+    } else if (children && children->size > 0) {
+      AST_NODE_T* last_child = hb_array_get(children, children->size - 1);
       end_position = last_child->location.end;
     }
 
@@ -984,7 +984,7 @@ static size_t process_control_structure(
   AST_NODE_T* subsequent = NULL;
   AST_ERB_END_NODE_T* end_node = NULL;
 
-  if (index < hb_array_size(array)) {
+  if (index < array->size) {
     AST_NODE_T* next_node = hb_array_get(array, index);
 
     if (next_node && next_node->type == AST_ERB_CONTENT_NODE) {
@@ -997,7 +997,7 @@ static size_t process_control_structure(
     }
   }
 
-  if (index < hb_array_size(array)) {
+  if (index < array->size) {
     AST_NODE_T* potential_end = hb_array_get(array, index);
 
     if (potential_end && potential_end->type == AST_ERB_CONTENT_NODE) {
@@ -1059,7 +1059,7 @@ static size_t process_subsequent_block(
     hb_array_free(&children);
   }
 
-  if (index < hb_array_size(array)) {
+  if (index < array->size) {
     AST_NODE_T* next_node = hb_array_get(array, index);
 
     if (next_node && next_node->type == AST_ERB_CONTENT_NODE) {
@@ -1117,7 +1117,7 @@ static size_t process_block_children(
   analyze_ruby_context_T* context,
   control_type_t parent_type
 ) {
-  while (index < hb_array_size(array)) {
+  while (index < array->size) {
     AST_NODE_T* child = hb_array_get(array, index);
 
     if (!child) { break; }
@@ -1139,7 +1139,7 @@ static size_t process_block_children(
       hb_array_T* temp_array = hb_array_init(1);
       size_t new_index = process_control_structure(node, array, index, temp_array, context, child_type);
 
-      if (hb_array_size(temp_array) > 0) { hb_array_append(children_array, hb_array_get(temp_array, 0)); }
+      if (temp_array->size > 0) { hb_array_append(children_array, hb_array_get(temp_array, 0)); }
 
       hb_array_free(&temp_array);
 
@@ -1155,10 +1155,10 @@ static size_t process_block_children(
 }
 
 hb_array_T* rewrite_node_array(AST_NODE_T* node, hb_array_T* array, analyze_ruby_context_T* context) {
-  hb_array_T* new_array = hb_array_init(hb_array_size(array));
+  hb_array_T* new_array = hb_array_init(array->size);
   size_t index = 0;
 
-  while (index < hb_array_size(array)) {
+  while (index < array->size) {
     AST_NODE_T* item = hb_array_get(array, index);
 
     if (!item) { break; }
@@ -1293,7 +1293,7 @@ static bool detect_invalid_erb_structures(const AST_NODE_T* node, void* data) {
     if (if_node->end_node == NULL) { check_erb_node_for_missing_end(node); }
 
     if (if_node->statements != NULL) {
-      for (size_t i = 0; i < hb_array_size(if_node->statements); i++) {
+      for (size_t i = 0; i < if_node->statements->size; i++) {
         AST_NODE_T* statement = (AST_NODE_T*) hb_array_get(if_node->statements, i);
 
         if (statement != NULL) { herb_visit_node(statement, detect_invalid_erb_structures, context); }
@@ -1325,7 +1325,7 @@ static bool detect_invalid_erb_structures(const AST_NODE_T* node, void* data) {
         const AST_ERB_IF_NODE_T* elsif_node = (const AST_ERB_IF_NODE_T*) subsequent;
 
         if (elsif_node->statements != NULL) {
-          for (size_t i = 0; i < hb_array_size(elsif_node->statements); i++) {
+          for (size_t i = 0; i < elsif_node->statements->size; i++) {
             AST_NODE_T* statement = (AST_NODE_T*) hb_array_get(elsif_node->statements, i);
 
             if (statement != NULL) { herb_visit_node(statement, detect_invalid_erb_structures, context); }
@@ -1337,7 +1337,7 @@ static bool detect_invalid_erb_structures(const AST_NODE_T* node, void* data) {
         const AST_ERB_ELSE_NODE_T* else_node = (const AST_ERB_ELSE_NODE_T*) subsequent;
 
         if (else_node->statements != NULL) {
-          for (size_t i = 0; i < hb_array_size(else_node->statements); i++) {
+          for (size_t i = 0; i < else_node->statements->size; i++) {
             AST_NODE_T* statement = (AST_NODE_T*) hb_array_get(else_node->statements, i);
 
             if (statement != NULL) { herb_visit_node(statement, detect_invalid_erb_structures, context); }

--- a/src/ast_node.c
+++ b/src/ast_node.c
@@ -41,7 +41,7 @@ ast_node_type_T ast_node_type(const AST_NODE_T* node) {
 }
 
 size_t ast_node_errors_count(const AST_NODE_T* node) {
-  return hb_array_size(node->errors);
+  return node->errors->size;
 }
 
 hb_array_T* ast_node_errors(const AST_NODE_T* node) {

--- a/src/extract.c
+++ b/src/extract.c
@@ -12,7 +12,7 @@ void herb_extract_ruby_to_buffer_with_semicolons(const char* source, hb_buffer_T
   bool skip_erb_content = false;
   bool is_comment_tag = false;
 
-  for (size_t i = 0; i < hb_array_size(tokens); i++) {
+  for (size_t i = 0; i < tokens->size; i++) {
     const token_T* token = hb_array_get(tokens, i);
 
     switch (token->type) {
@@ -79,7 +79,7 @@ void herb_extract_ruby_to_buffer_with_semicolons(const char* source, hb_buffer_T
         bool needs_semicolon = false;
         uint32_t current_line = token->location.end.line;
 
-        for (size_t j = i + 1; j < hb_array_size(tokens); j++) {
+        for (size_t j = i + 1; j < tokens->size; j++) {
           const token_T* next_token = hb_array_get(tokens, j);
 
           if (next_token->type == TOKEN_NEWLINE) { break; }
@@ -113,7 +113,7 @@ void herb_extract_ruby_to_buffer(const char* source, hb_buffer_T* output) {
   hb_array_T* tokens = herb_lex(source);
   bool skip_erb_content = false;
 
-  for (size_t i = 0; i < hb_array_size(tokens); i++) {
+  for (size_t i = 0; i < tokens->size; i++) {
     const token_T* token = hb_array_get(tokens, i);
 
     switch (token->type) {
@@ -160,7 +160,7 @@ void herb_extract_ruby_to_buffer(const char* source, hb_buffer_T* output) {
 void herb_extract_html_to_buffer(const char* source, hb_buffer_T* output) {
   hb_array_T* tokens = herb_lex(source);
 
-  for (size_t i = 0; i < hb_array_size(tokens); i++) {
+  for (size_t i = 0; i < tokens->size; i++) {
     const token_T* token = hb_array_get(tokens, i);
 
     switch (token->type) {

--- a/src/herb.c
+++ b/src/herb.c
@@ -58,7 +58,7 @@ hb_array_T* herb_lex_file(const char* path) {
 void herb_lex_to_buffer(const char* source, hb_buffer_T* output) {
   hb_array_T* tokens = herb_lex(source);
 
-  for (size_t i = 0; i < hb_array_size(tokens); i++) {
+  for (size_t i = 0; i < tokens->size; i++) {
     token_T* token = hb_array_get(tokens, i);
 
     hb_string_T type = token_to_string(token);
@@ -74,7 +74,7 @@ void herb_lex_to_buffer(const char* source, hb_buffer_T* output) {
 void herb_free_tokens(hb_array_T** tokens) {
   if (!tokens || !*tokens) { return; }
 
-  for (size_t i = 0; i < hb_array_size(*tokens); i++) {
+  for (size_t i = 0; i < (*tokens)->size; i++) {
     token_T* token = hb_array_get(*tokens, i);
     if (token) { token_free(token); }
   }

--- a/src/parser.c
+++ b/src/parser.c
@@ -1142,7 +1142,7 @@ static void parser_parse_in_data_state(parser_T* parser, hb_array_T* children, h
 static size_t find_matching_close_tag(hb_array_T* nodes, size_t start_idx, hb_string_T tag_name) {
   int depth = 0;
 
-  for (size_t i = start_idx + 1; i < hb_array_size(nodes); i++) {
+  for (size_t i = start_idx + 1; i < nodes->size; i++) {
     AST_NODE_T* node = (AST_NODE_T*) hb_array_get(nodes, i);
     if (node == NULL) { continue; }
 
@@ -1166,9 +1166,9 @@ static size_t find_matching_close_tag(hb_array_T* nodes, size_t start_idx, hb_st
 static hb_array_T* parser_build_elements_from_tags(hb_array_T* nodes, hb_array_T* errors);
 
 static hb_array_T* parser_build_elements_from_tags(hb_array_T* nodes, hb_array_T* errors) {
-  hb_array_T* result = hb_array_init(hb_array_size(nodes));
+  hb_array_T* result = hb_array_init(nodes->size);
 
-  for (size_t index = 0; index < hb_array_size(nodes); index++) {
+  for (size_t index = 0; index < nodes->size; index++) {
     AST_NODE_T* node = (AST_NODE_T*) hb_array_get(nodes, index);
     if (node == NULL) { continue; }
 
@@ -1179,7 +1179,7 @@ static hb_array_T* parser_build_elements_from_tags(hb_array_T* nodes, hb_array_T
       size_t close_index = find_matching_close_tag(nodes, index, tag_name);
 
       if (close_index == (size_t) -1) {
-        if (hb_array_size(open_tag->base.errors) == 0) {
+        if (open_tag->base.errors->size == 0) {
           append_missing_closing_tag_error(
             open_tag->tag_name,
             open_tag->base.location.start,
@@ -1223,7 +1223,7 @@ static hb_array_T* parser_build_elements_from_tags(hb_array_T* nodes, hb_array_T
       AST_HTML_CLOSE_TAG_NODE_T* close_tag = (AST_HTML_CLOSE_TAG_NODE_T*) node;
 
       if (!is_void_element(hb_string(close_tag->tag_name->value))) {
-        if (hb_array_size(close_tag->base.errors) == 0) {
+        if (close_tag->base.errors->size == 0) {
           append_missing_opening_tag_error(
             close_tag->tag_name,
             close_tag->base.location.start,
@@ -1297,7 +1297,7 @@ void herb_parser_deinit(parser_T* parser) {
 }
 
 void match_tags_in_node_array(hb_array_T* nodes, hb_array_T* errors) {
-  if (nodes == NULL || hb_array_size(nodes) == 0) { return; }
+  if (nodes == NULL || nodes->size == 0) { return; }
 
   hb_array_T* processed = parser_build_elements_from_tags(nodes, errors);
 

--- a/src/parser_helpers.c
+++ b/src/parser_helpers.c
@@ -19,7 +19,7 @@ void parser_push_open_tag(const parser_T* parser, token_T* tag_name) {
 }
 
 bool parser_check_matching_tag(const parser_T* parser, hb_string_T tag_name) {
-  if (hb_array_size(parser->open_tags_stack) == 0) { return false; }
+  if (parser->open_tags_stack->size == 0) { return false; }
 
   token_T* top_token = hb_array_last(parser->open_tags_stack);
   if (top_token == NULL || top_token->value == NULL) { return false; };
@@ -28,7 +28,7 @@ bool parser_check_matching_tag(const parser_T* parser, hb_string_T tag_name) {
 }
 
 token_T* parser_pop_open_tag(const parser_T* parser) {
-  if (hb_array_size(parser->open_tags_stack) == 0) { return NULL; }
+  if (parser->open_tags_stack->size == 0) { return NULL; }
 
   return hb_array_pop(parser->open_tags_stack);
 }
@@ -42,7 +42,7 @@ token_T* parser_pop_open_tag(const parser_T* parser) {
 bool parser_in_svg_context(const parser_T* parser) {
   if (!parser || !parser->open_tags_stack) { return false; }
 
-  size_t stack_size = hb_array_size(parser->open_tags_stack);
+  size_t stack_size = parser->open_tags_stack->size;
 
   for (size_t i = 0; i < stack_size; i++) {
     token_T* tag = (token_T*) hb_array_get(parser->open_tags_stack, i);
@@ -191,7 +191,7 @@ void parser_handle_mismatched_tags(
   const AST_HTML_CLOSE_TAG_NODE_T* close_tag,
   hb_array_T* errors
 ) {
-  if (hb_array_size(parser->open_tags_stack) > 0) {
+  if (parser->open_tags_stack->size > 0) {
     token_T* expected_tag = hb_array_last(parser->open_tags_stack);
     token_T* actual_tag = close_tag->tag_name;
 

--- a/src/pretty_print.c
+++ b/src/pretty_print.c
@@ -113,7 +113,7 @@ void pretty_print_array(
     return;
   }
 
-  if (hb_array_size(array) == 0) {
+  if (array->size == 0) {
     pretty_print_property(name, hb_string("[]"), indent, relative_indent, last_property, buffer);
 
     return;
@@ -124,17 +124,17 @@ void pretty_print_array(
   hb_buffer_append(buffer, "(");
 
   char count[16];
-  sprintf(count, "%zu", hb_array_size(array));
+  sprintf(count, "%zu", array->size);
   hb_buffer_append(buffer, count);
   hb_buffer_append(buffer, ")\n");
 
   if (indent < 20) {
-    for (size_t i = 0; i < hb_array_size(array); i++) {
+    for (size_t i = 0; i < array->size; i++) {
       AST_NODE_T* child = hb_array_get(array, i);
       pretty_print_indent(buffer, indent);
       pretty_print_indent(buffer, relative_indent + 1);
 
-      if (i == hb_array_size(array) - 1) {
+      if (i == array->size - 1) {
         hb_buffer_append(buffer, "└── ");
       } else {
         hb_buffer_append(buffer, "├── ");
@@ -142,7 +142,7 @@ void pretty_print_array(
 
       ast_pretty_print_node(child, indent + 1, relative_indent + 1, buffer);
 
-      if (i != hb_array_size(array) - 1) { pretty_print_newline(indent + 1, relative_indent, buffer); }
+      if (i != array->size - 1) { pretty_print_newline(indent + 1, relative_indent, buffer); }
     }
   }
   hb_buffer_append(buffer, "\n");
@@ -155,7 +155,7 @@ void pretty_print_errors(
   const bool last_property,
   hb_buffer_T* buffer
 ) {
-  if (node->errors != NULL && hb_array_size(node->errors) > 0) {
+  if (node->errors != NULL && node->errors->size > 0) {
     error_pretty_print_array("errors", node->errors, indent, relative_indent, last_property, buffer);
     hb_buffer_append(buffer, "\n");
   }

--- a/templates/ext/herb/error_helpers.c.erb
+++ b/templates/ext/herb/error_helpers.c.erb
@@ -71,7 +71,7 @@ VALUE rb_errors_array_from_c_array(hb_array_T* array) {
   VALUE rb_array = rb_ary_new();
 
   if (array) {
-    for (size_t i = 0; i < hb_array_size(array); i++) {
+    for (size_t i = 0; i < array->size; i++) {
       ERROR_T* child_node = (ERROR_T*) hb_array_get(array, i);
 
       if (child_node) {

--- a/templates/ext/herb/nodes.c.erb
+++ b/templates/ext/herb/nodes.c.erb
@@ -81,7 +81,7 @@ static VALUE rb_nodes_array_from_c_array(hb_array_T* array) {
   VALUE rb_array = rb_ary_new();
 
   if (array) {
-    for (size_t i = 0; i < hb_array_size(array); i++) {
+    for (size_t i = 0; i < array->size; i++) {
       AST_NODE_T* child_node = (AST_NODE_T*) hb_array_get(array, i);
 
       if (child_node) {

--- a/templates/java/error_helpers.c.erb
+++ b/templates/java/error_helpers.c.erb
@@ -46,7 +46,7 @@ jobject ErrorsArrayFromCArray(JNIEnv* env, hb_array_T* array) {
   jobject javaList = (*env)->NewObject(env, arrayListClass, arrayListConstructor, 0);
 
   if (array) {
-    for (size_t i = 0; i < hb_array_size(array); i++) {
+    for (size_t i = 0; i < array->size; i++) {
       ERROR_T* error = (ERROR_T*) hb_array_get(array, i);
 
       if (error) {

--- a/templates/java/nodes.c.erb
+++ b/templates/java/nodes.c.erb
@@ -75,9 +75,9 @@ jobject NodesArrayFromCArray(JNIEnv* env, hb_array_T* array) {
     return (*env)->NewObject(env, arrayListClass, arrayListConstructor, 0);
   }
 
-  jobject javaList = (*env)->NewObject(env, arrayListClass, arrayListConstructor, (jint) hb_array_size(array));
+  jobject javaList = (*env)->NewObject(env, arrayListClass, arrayListConstructor, (jint) array->size);
 
-  for (size_t i = 0; i < hb_array_size(array); i++) {
+  for (size_t i = 0; i < array->size; i++) {
     AST_NODE_T* child_node = (AST_NODE_T*) hb_array_get(array, i);
 
     if (child_node) {

--- a/templates/javascript/packages/node/extension/error_helpers.cpp.erb
+++ b/templates/javascript/packages/node/extension/error_helpers.cpp.erb
@@ -80,7 +80,7 @@ napi_value ErrorsArrayFromCArray(napi_env env, hb_array_T* array) {
   napi_create_array(env, &result);
 
   if (array) {
-    for (size_t i = 0; i < hb_array_size(array); i++) {
+    for (size_t i = 0; i < array->size; i++) {
       ERROR_T* error = (ERROR_T*) hb_array_get(array, i);
       if (error) {
         napi_value js_error = ErrorFromCStruct(env, error);

--- a/templates/javascript/packages/node/extension/nodes.cpp.erb
+++ b/templates/javascript/packages/node/extension/nodes.cpp.erb
@@ -78,7 +78,7 @@ napi_value NodesArrayFromCArray(napi_env env, hb_array_T* array) {
   napi_create_array(env, &result);
 
   if (array) {
-    for (size_t i = 0; i < hb_array_size(array); i++) {
+    for (size_t i = 0; i < array->size; i++) {
       AST_NODE_T* child_node = (AST_NODE_T*) hb_array_get(array, i);
       if (child_node) {
         napi_value js_child = NodeFromCStruct(env, child_node);

--- a/templates/rust/src/ast/nodes.rs.erb
+++ b/templates/rust/src/ast/nodes.rs.erb
@@ -51,7 +51,7 @@ unsafe fn convert_errors(errors_array: *mut hb_array_T) -> Vec<AnyError> {
     return Vec::new();
   }
 
-  let count = hb_array_size(errors_array);
+  let count = errors_array.size;
   let mut errors = Vec::with_capacity(count);
 
   for index in 0..count {
@@ -110,7 +110,7 @@ unsafe fn convert_children(children_array: *mut hb_array_T) -> Vec<AnyNode> {
     return Vec::new();
   }
 
-  let count = hb_array_size(children_array);
+  let count = children_array.size;
   let mut children = Vec::with_capacity(count);
 
   for index in 0..count {

--- a/templates/src/ast_nodes.c.erb
+++ b/templates/src/ast_nodes.c.erb
@@ -73,7 +73,7 @@ void ast_free_base_node(AST_NODE_T* node) {
   if (node == NULL) { return; }
 
   if (node->errors) {
-    for (size_t i = 0; i < hb_array_size(node->errors); i++) {
+    for (size_t i = 0; i < node->errors->size; i++) {
       ERROR_T* child = hb_array_get(node->errors, i);
       if (child != NULL) { error_free(child); }
     }
@@ -99,7 +99,7 @@ static void ast_free_<%= node.human %>(<%= node.struct_type %>* <%= node.human %
   ast_node_free((AST_NODE_T*) <%= node.human %>-><%= field.name %>);
   <%- when Herb::Template::ArrayField -%>
   if (<%= node.human %>-><%= field.name %> != NULL) {
-    for (size_t i = 0; i < hb_array_size(<%= node.human %>-><%= field.name %>); i++) {
+    for (size_t i = 0; i < <%= node.human %>-><%= field.name %>->size; i++) {
       AST_NODE_T* child = hb_array_get(<%= node.human %>-><%= field.name %>, i);
       if (child) { ast_node_free(child); }
     }

--- a/templates/src/errors.c.erb
+++ b/templates/src/errors.c.erb
@@ -167,7 +167,7 @@ void error_pretty_print_array(
     return;
   }
 
-  if (hb_array_size(array) == 0) {
+  if (array->size == 0) {
     pretty_print_property(hb_string(name), hb_string("[]"), indent, relative_indent, last_property, buffer);
 
     return;
@@ -178,17 +178,17 @@ void error_pretty_print_array(
   hb_buffer_append(buffer, "(");
 
   char count[16];
-  sprintf(count, "%zu", hb_array_size(array));
+  sprintf(count, "%zu", array->size);
   hb_buffer_append(buffer, count);
   hb_buffer_append(buffer, ")\n");
 
   if (indent < 20) {
-    for (size_t i = 0; i < hb_array_size(array); i++) {
+    for (size_t i = 0; i < array->size; i++) {
       ERROR_T* child = hb_array_get(array, i);
       pretty_print_indent(buffer, indent);
       pretty_print_indent(buffer, relative_indent + 1);
 
-      if (i == hb_array_size(array) - 1) {
+      if (i == array->size - 1) {
         hb_buffer_append(buffer, "└── ");
       } else {
         hb_buffer_append(buffer, "├── ");
@@ -196,7 +196,7 @@ void error_pretty_print_array(
 
       error_pretty_print(child, indent + 1, relative_indent + 1, buffer);
 
-      if (i != hb_array_size(array) - 1) { pretty_print_newline(indent + 1, relative_indent, buffer); }
+      if (i != array->size - 1) { pretty_print_newline(indent + 1, relative_indent, buffer); }
     }
   }
 }

--- a/templates/src/visitor.c.erb
+++ b/templates/src/visitor.c.erb
@@ -31,7 +31,7 @@ void herb_visit_child_nodes(const AST_NODE_T *node, bool (*visitor)(const AST_NO
 
       <%- when Herb::Template::ArrayField -%>
       if (<%= node.human %>-><%= field.name %> != NULL) {
-        for (size_t index = 0; index < hb_array_size(<%= node.human %>-><%= field.name %>); index++) {
+        for (size_t index = 0; index < <%= node.human %>-><%= field.name %>->size; index++) {
           herb_visit_node(hb_array_get(<%= node.human %>-><%= field.name %>, index), visitor, data);
         }
       }

--- a/templates/wasm/error_helpers.cpp.erb
+++ b/templates/wasm/error_helpers.cpp.erb
@@ -66,7 +66,7 @@ val ErrorsArrayFromCArray(hb_array_T* array) {
   val result = Array.new_();
 
   if (array) {
-    for (size_t i = 0; i < hb_array_size(array); i++) {
+    for (size_t i = 0; i < array->size; i++) {
       ERROR_T* error = (ERROR_T*)hb_array_get(array, i);
       if (error) {
         result.call<void>("push", ErrorFromCStruct(error));

--- a/templates/wasm/nodes.cpp.erb
+++ b/templates/wasm/nodes.cpp.erb
@@ -67,7 +67,7 @@ val NodesArrayFromCArray(hb_array_T* array) {
 
   val jsArray = val::array();
 
-  for (size_t i = 0; i < hb_array_size(array); i++) {
+  for (size_t i = 0; i < array->size; i++) {
     AST_NODE_T* child_node = (AST_NODE_T*) hb_array_get(array, i);
 
     if (child_node) {

--- a/wasm/extension_helpers.cpp
+++ b/wasm/extension_helpers.cpp
@@ -99,7 +99,7 @@ val CreateLexResult(hb_array_T* tokens, const std::string& source) {
   val warningsArray = Array.new_();
 
   if (tokens) {
-    for (size_t i = 0; i < hb_array_size(tokens); i++) {
+    for (size_t i = 0; i < tokens->size; i++) {
       token_T* token = (token_T*)hb_array_get(tokens, i);
       if (token) {
         tokensArray.call<void>("push", CreateToken(token));


### PR DESCRIPTION
This PR deprecates the `hb_array_size` function in favor of directly accessing `hb_array_T.size`