### PR TITLE
Formatter: Respect Outlook Conditional HTML Comments

### DIFF
--- a/javascript/packages/formatter/src/format-printer.ts
+++ b/javascript/packages/formatter/src/format-printer.ts
@@ -1179,9 +1179,9 @@ export class FormatPrinter extends Printer {
         }
       }).join("")
 
-      const isConditionalComment = /^\[if\s*[^\]]*\]>/.test(inner.trim())
+      const trimmedInner = inner.trim()
 
-      if (isConditionalComment) {
+      if (trimmedInner.startsWith('[if ') && trimmedInner.endsWith('<![endif]')) {
         this.pushWithIndent(open + inner + close)
 
         return

--- a/javascript/packages/formatter/test/html/outlook-conditional-comments.test.ts
+++ b/javascript/packages/formatter/test/html/outlook-conditional-comments.test.ts
@@ -48,4 +48,18 @@ describe("Outlook conditional comments", () => {
     const result = formatter.format(source)
     expect(result).toEqual(source)
   })
+
+  test("handles conditional comment with ERB interpolation", () => {
+    const source = dedent`
+      <!--[if mso]>
+      <table width="<%= width %>" cellpadding="0" cellspacing="0">
+        <tr>
+          <td><%= content %></td>
+        </tr>
+      </table>
+      <![endif]-->
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(source)
+  })
 })


### PR DESCRIPTION
**Input**
```html+erb
<!--[if mso]>
<center>
<![endif]-->
```

**Before**
```html+erb
<!--
  [if mso]>
  <center>
  <![endif]
-->
```

**After**
```html+erb
<!--[if mso]>
<center>
<![endif]-->
```

Resolves #877 