### PR TITLE
C: Compile with `-fvisibility=hidden` flag

### DIFF
--- a/ext/herb/extconf.rb
+++ b/ext/herb/extconf.rb
@@ -24,7 +24,8 @@ $INCFLAGS << " -I#{include_path}"
 $INCFLAGS << " -I#{prism_src_path}"
 $INCFLAGS << " -I#{prism_src_path}/util"
 
-$CFLAGS << " -DPRISM_EXPORT_SYMBOLS=static "
+$CFLAGS << " -DPRISM_EXPORT_SYMBOLS=static"
+$CFLAGS << " -fvisibility=hidden"
 
 herb_src_files = Dir.glob("#{$srcdir}/../../src/**/*.c").map { |file| file.delete_prefix("../../../../ext/herb/") }.sort
 

--- a/ext/herb/extension.c
+++ b/ext/herb/extension.c
@@ -124,7 +124,7 @@ static VALUE Herb_version(VALUE self) {
   return rb_funcall(rb_mKernel, rb_intern("sprintf"), 4, format_string, gem_version, libprism_version, libherb_version);
 }
 
-void Init_herb(void) {
+__attribute__((visibility("default"))) void Init_herb(void) {
   mHerb = rb_define_module("Herb");
   cPosition = rb_define_class_under(mHerb, "Position", rb_cObject);
   cLocation = rb_define_class_under(mHerb, "Location", rb_cObject);


### PR DESCRIPTION
This PR starts compiling the ruby herb gem c dependencies with `-fvisibility=hidden`.

This addresses a criticial bug that lead to crashes when the ruby gem ran in an environment that already had harfbuzz loaded. Both define a function called `hb_buffer_append`, which resulted in conflicts.

With this fix we only expose the init function required by the ruby runtime in the DLL/SO. 

This PR addresses the issues reported in https://github.com/marcoroth/herb/issues/905

## Before

![Bildschirmfoto_2025-11-19_um_00 09 11](https://github.com/user-attachments/assets/387d11b5-a62d-4548-9a38-7bfbd6ba808a)

## After

![Bildschirmfoto_2025-11-19_um_00 19 23](https://github.com/user-attachments/assets/5acfa368-351a-47a1-8b7e-20ac8351896f)

