### PR TITLE
Linter: Account for `meta[media]` in `html-no-duplicate-meta-names` rule

### DIFF
--- a/javascript/packages/linter/src/rules/html-no-duplicate-meta-names.ts
+++ b/javascript/packages/linter/src/rules/html-no-duplicate-meta-names.ts
@@ -11,6 +11,7 @@ interface MetaTag {
   node: HTMLElementNode
   nameValue?: string
   httpEquivValue?: string
+  mediaValue?: string
 }
 
 interface ControlFlowState {
@@ -112,6 +113,8 @@ class HTMLNoDuplicateMetaNamesVisitor extends ControlFlowTrackingVisitor<BaseAut
           metaTag.nameValue = value
         } else if (name === "http-equiv" && value) {
           metaTag.httpEquivValue = value
+        } else if (name === "media" && value) {
+          metaTag.mediaValue = value
         }
       })
     }
@@ -155,6 +158,16 @@ class HTMLNoDuplicateMetaNamesVisitor extends ControlFlowTrackingVisitor<BaseAut
   }
 
   private areMetaTagsDuplicate(meta1: MetaTag, meta2: MetaTag): boolean {
+    if (meta1.mediaValue && meta2.mediaValue) {
+      if (meta1.mediaValue.toLowerCase() !== meta2.mediaValue.toLowerCase()) {
+        return false
+      }
+    }
+
+    if ((meta1.mediaValue && !meta2.mediaValue) || (!meta1.mediaValue && meta2.mediaValue)) {
+      return false
+    }
+
     if (meta1.nameValue && meta2.nameValue) {
       return meta1.nameValue.toLowerCase() === meta2.nameValue.toLowerCase()
     }

--- a/javascript/packages/linter/test/rules/html-no-duplicate-meta-names.test.ts
+++ b/javascript/packages/linter/test/rules/html-no-duplicate-meta-names.test.ts
@@ -549,4 +549,86 @@ describe("html-no-duplicate-meta-names", () => {
       </head>
     `)
   })
+
+  test("allows multiple theme-color meta tags with different media attributes", () => {
+    expectNoOffenses(dedent`
+      <html>
+        <head>
+          <meta
+            name="theme-color"
+            content="#ffffff"
+            media="(prefers-color-scheme: light)"
+          >
+          <meta
+            name="theme-color"
+            content="#212529"
+            media="(prefers-color-scheme: dark)"
+          >
+        </head>
+        <body>
+          <h1>Welcome</h1>
+        </body>
+      </html>
+    `)
+  })
+
+  test("allows multiple meta tags with same name but different media attributes", () => {
+    expectNoOffenses(dedent`
+      <head>
+        <meta name="viewport" content="width=device-width" media="screen">
+        <meta name="viewport" content="width=800" media="print">
+      </head>
+    `)
+  })
+
+  test("detects duplicate meta tags with same name and same media attribute", () => {
+    expectError('Duplicate `<meta>` tag with `name="theme-color"`. Meta names should be unique within the `<head>` section.')
+
+    assertOffenses(dedent`
+      <head>
+        <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)">
+        <meta name="theme-color" content="#000000" media="(prefers-color-scheme: light)">
+      </head>
+    `)
+  })
+
+  test("detects duplicate meta tags with same name and no media attribute", () => {
+    expectError('Duplicate `<meta>` tag with `name="theme-color"`. Meta names should be unique within the `<head>` section.')
+
+    assertOffenses(dedent`
+      <head>
+        <meta name="theme-color" content="#ffffff">
+        <meta name="theme-color" content="#000000">
+      </head>
+    `)
+  })
+
+  test("allows meta tag with media and another without media for same name", () => {
+    expectNoOffenses(dedent`
+      <head>
+        <meta name="theme-color" content="#ffffff">
+        <meta name="theme-color" content="#212529" media="(prefers-color-scheme: dark)">
+      </head>
+    `)
+  })
+
+  test("handles media attribute case insensitivity", () => {
+    expectError('Duplicate `<meta>` tag with `name="theme-color"`. Meta names should be unique within the `<head>` section.')
+
+    assertOffenses(dedent`
+      <head>
+        <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: LIGHT)">
+        <meta name="theme-color" content="#000000" media="(prefers-color-scheme: light)">
+      </head>
+    `)
+  })
+
+  test("allows different meta names with same media attribute", () => {
+    expectNoOffenses(dedent`
+      <head>
+        <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)">
+        <meta name="description" content="Light mode page" media="(prefers-color-scheme: light)">
+      </head>
+    `)
+  })
 })


### PR DESCRIPTION
This pull request updates the `html-no-duplicate-meta-names` linter rule to account for the `meta[media]` attribute.

A `<meta>` tag with the same `name` but different `media` values shouldn't be considered duplicate, this pull request updates that logic to allow this.

Resolves #957