### PR TITLE
docs: fix file name in Linter Custom Rules example code

### DIFF
--- a/javascript/packages/linter/README.md
+++ b/javascript/packages/linter/README.md
@@ -464,7 +464,7 @@ Custom rules must use the `.mjs` extension to avoid Node.js module type warnings
 ::: code-group
 
 
-```js [.herb/rules/no-inline-styles.mjs]
+```js [.herb/rules/no-div-tags.mjs]
 import { BaseRuleVisitor, ParserRule } from "@herb-tools/linter"
 
 class NoDivTagsVisitor extends BaseRuleVisitor {


### PR DESCRIPTION
The sample code showed duplicated file names, which was a bit confusing, so I fixed them. Thank you!

<img width="610" height="252" alt="image" src="https://github.com/user-attachments/assets/69478ff8-5dd7-4c06-bfe5-f190c16b2666" />
