### PR TITLE
Parser: HTML tags treat as case-insensitive

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -1149,11 +1149,11 @@ static size_t find_matching_close_tag(hb_array_T* nodes, size_t start_idx, hb_st
     if (node->type == AST_HTML_OPEN_TAG_NODE) {
       AST_HTML_OPEN_TAG_NODE_T* open = (AST_HTML_OPEN_TAG_NODE_T*) node;
 
-      if (hb_string_equals(hb_string(open->tag_name->value), tag_name)) { depth++; }
+      if (hb_string_equals_case_insensitive(hb_string(open->tag_name->value), tag_name)) { depth++; }
     } else if (node->type == AST_HTML_CLOSE_TAG_NODE) {
       AST_HTML_CLOSE_TAG_NODE_T* close = (AST_HTML_CLOSE_TAG_NODE_T*) node;
 
-      if (hb_string_equals(hb_string(close->tag_name->value), tag_name)) {
+      if (hb_string_equals_case_insensitive(hb_string(close->tag_name->value), tag_name)) {
         if (depth == 0) { return i; }
         depth--;
       }

--- a/src/parser_helpers.c
+++ b/src/parser_helpers.c
@@ -24,7 +24,7 @@ bool parser_check_matching_tag(const parser_T* parser, hb_string_T tag_name) {
   token_T* top_token = hb_array_last(parser->open_tags_stack);
   if (top_token == NULL || top_token->value == NULL) { return false; };
 
-  return hb_string_equals(hb_string(top_token->value), tag_name);
+  return hb_string_equals_case_insensitive(hb_string(top_token->value), tag_name);
 }
 
 token_T* parser_pop_open_tag(const parser_T* parser) {
@@ -49,7 +49,7 @@ bool parser_in_svg_context(const parser_T* parser) {
 
     if (tag && tag->value) {
       hb_string_T tag_value_string = hb_string(tag->value);
-      if (hb_string_equals(tag_value_string, hb_string("svg"))) { return true; }
+      if (hb_string_equals_case_insensitive(tag_value_string, hb_string("svg"))) { return true; }
     }
   }
 
@@ -61,8 +61,8 @@ bool parser_in_svg_context(const parser_T* parser) {
 foreign_content_type_T parser_get_foreign_content_type(hb_string_T tag_name) {
   if (hb_string_is_empty(tag_name)) { return FOREIGN_CONTENT_UNKNOWN; }
 
-  if (hb_string_equals(tag_name, hb_string("script"))) { return FOREIGN_CONTENT_SCRIPT; }
-  if (hb_string_equals(tag_name, hb_string("style"))) { return FOREIGN_CONTENT_STYLE; }
+  if (hb_string_equals_case_insensitive(tag_name, hb_string("script"))) { return FOREIGN_CONTENT_SCRIPT; }
+  if (hb_string_equals_case_insensitive(tag_name, hb_string("style"))) { return FOREIGN_CONTENT_STYLE; }
 
   return FOREIGN_CONTENT_UNKNOWN;
 }
@@ -217,5 +217,5 @@ bool parser_is_expected_closing_tag_name(hb_string_T tag_name, foreign_content_t
 
   if (hb_string_is_empty(tag_name) || hb_string_is_empty(expected_tag_name)) { return false; }
 
-  return hb_string_equals(expected_tag_name, tag_name);
+  return hb_string_equals_case_insensitive(expected_tag_name, tag_name);
 }

--- a/test/parser/svg_test.rb
+++ b/test/parser/svg_test.rb
@@ -51,5 +51,13 @@ module Parser
         </svg>
       SVG
     end
+
+    test "case-insensitive svg with void element" do
+      assert_parsed_snapshot(<<~SVG)
+        <SVG>
+          <PATH />
+        </svg>
+      SVG
+    end
   end
 end

--- a/test/parser/tags_test.rb
+++ b/test/parser/tags_test.rb
@@ -293,5 +293,17 @@ module Parser
         >
       HTML
     end
+
+    test "case-insensitive empty tag" do
+      assert_parsed_snapshot("<SPAN></span>")
+    end
+
+    test "case-insensitive script tag" do
+      assert_parsed_snapshot(%(<SCRIPT>var x = 5;</script>))
+    end
+
+    test "case-insensitive style tag" do
+      assert_parsed_snapshot(%(<STYLE>.class { color: red; }</style>))
+    end
   end
 end

--- a/test/snapshots/parser/svg_test/test_0007_case-insensitive_svg_with_void_element_0cbbaf2331a0574a63f6444993bb175e.txt
+++ b/test/snapshots/parser/svg_test/test_0007_case-insensitive_svg_with_void_element_0cbbaf2331a0574a63f6444993bb175e.txt
@@ -1,0 +1,53 @@
+---
+source: "Parser::SVGTest#test_0007_case-insensitive svg with void element"
+input: |2-
+<SVG>
+  <PATH />
+</svg>
+---
+@ DocumentNode (location: (1:0)-(4:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(3:6))
+    │   ├── open_tag:
+    │   │   └── @ HTMLOpenTagNode (location: (1:0)-(1:5))
+    │   │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+    │   │       ├── tag_name: "SVG" (location: (1:1)-(1:4))
+    │   │       ├── tag_closing: ">" (location: (1:4)-(1:5))
+    │   │       ├── children: []
+    │   │       └── is_void: false
+    │   │
+    │   ├── tag_name: "SVG" (location: (1:1)-(1:4))
+    │   ├── body: (3 items)
+    │   │   ├── @ HTMLTextNode (location: (1:5)-(2:2))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ HTMLElementNode (location: (2:2)-(2:10))
+    │   │   │   ├── open_tag:
+    │   │   │   │   └── @ HTMLOpenTagNode (location: (2:2)-(2:10))
+    │   │   │   │       ├── tag_opening: "<" (location: (2:2)-(2:3))
+    │   │   │   │       ├── tag_name: "PATH" (location: (2:3)-(2:7))
+    │   │   │   │       ├── tag_closing: "/>" (location: (2:8)-(2:10))
+    │   │   │   │       ├── children: []
+    │   │   │   │       └── is_void: true
+    │   │   │   │
+    │   │   │   ├── tag_name: "PATH" (location: (2:3)-(2:7))
+    │   │   │   ├── body: []
+    │   │   │   ├── close_tag: ∅
+    │   │   │   ├── is_void: true
+    │   │   │   └── source: "HTML"
+    │   │   │
+    │   │   └── @ HTMLTextNode (location: (2:10)-(3:0))
+    │   │       └── content: "\n"
+    │   │
+    │   ├── close_tag:
+    │   │   └── @ HTMLCloseTagNode (location: (3:0)-(3:6))
+    │   │       ├── tag_opening: "</" (location: (3:0)-(3:2))
+    │   │       ├── tag_name: "svg" (location: (3:2)-(3:5))
+    │   │       ├── children: []
+    │   │       └── tag_closing: ">" (location: (3:5)-(3:6))
+    │   │
+    │   ├── is_void: false
+    │   └── source: "HTML"
+    │
+    └── @ HTMLTextNode (location: (3:6)-(4:0))
+        └── content: "\n"

--- a/test/snapshots/parser/tags_test/test_0052_case-insensitive_empty_tag_ce899a1d4aa2a1bf2060f8520dd19a18.txt
+++ b/test/snapshots/parser/tags_test/test_0052_case-insensitive_empty_tag_ce899a1d4aa2a1bf2060f8520dd19a18.txt
@@ -1,0 +1,26 @@
+---
+source: "Parser::TagsTest#test_0052_case-insensitive empty tag"
+input: "<SPAN></span>"
+---
+@ DocumentNode (location: (1:0)-(1:13))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:13))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:6))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "SPAN" (location: (1:1)-(1:5))
+        │       ├── tag_closing: ">" (location: (1:5)-(1:6))
+        │       ├── children: []
+        │       └── is_void: false
+        │
+        ├── tag_name: "SPAN" (location: (1:1)-(1:5))
+        ├── body: []
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:6)-(1:13))
+        │       ├── tag_opening: "</" (location: (1:6)-(1:8))
+        │       ├── tag_name: "span" (location: (1:8)-(1:12))
+        │       ├── children: []
+        │       └── tag_closing: ">" (location: (1:12)-(1:13))
+        │
+        ├── is_void: false
+        └── source: "HTML"

--- a/test/snapshots/parser/tags_test/test_0053_case-insensitive_script_tag_238d15df83823c7f5804fbb52e2c877d.txt
+++ b/test/snapshots/parser/tags_test/test_0053_case-insensitive_script_tag_238d15df83823c7f5804fbb52e2c877d.txt
@@ -1,0 +1,29 @@
+---
+source: "Parser::TagsTest#test_0053_case-insensitive script tag"
+input: "<SCRIPT>var x = 5;</script>"
+---
+@ DocumentNode (location: (1:0)-(1:27))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:27))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:8))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "SCRIPT" (location: (1:1)-(1:7))
+        │       ├── tag_closing: ">" (location: (1:7)-(1:8))
+        │       ├── children: []
+        │       └── is_void: false
+        │
+        ├── tag_name: "SCRIPT" (location: (1:1)-(1:7))
+        ├── body: (1 item)
+        │   └── @ LiteralNode (location: (1:8)-(1:18))
+        │       └── content: "var x = 5;"
+        │
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:18)-(1:27))
+        │       ├── tag_opening: "</" (location: (1:18)-(1:20))
+        │       ├── tag_name: "script" (location: (1:20)-(1:26))
+        │       ├── children: []
+        │       └── tag_closing: ">" (location: (1:26)-(1:27))
+        │
+        ├── is_void: false
+        └── source: "HTML"

--- a/test/snapshots/parser/tags_test/test_0054_case-insensitive_style_tag_bdefb7a6e5e31c0a121b7a2112469456.txt
+++ b/test/snapshots/parser/tags_test/test_0054_case-insensitive_style_tag_bdefb7a6e5e31c0a121b7a2112469456.txt
@@ -1,0 +1,29 @@
+---
+source: "Parser::TagsTest#test_0054_case-insensitive style tag"
+input: "<STYLE>.class { color: red; }</style>"
+---
+@ DocumentNode (location: (1:0)-(1:37))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:37))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:7))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "STYLE" (location: (1:1)-(1:6))
+        │       ├── tag_closing: ">" (location: (1:6)-(1:7))
+        │       ├── children: []
+        │       └── is_void: false
+        │
+        ├── tag_name: "STYLE" (location: (1:1)-(1:6))
+        ├── body: (1 item)
+        │   └── @ LiteralNode (location: (1:7)-(1:29))
+        │       └── content: ".class { color: red; }"
+        │
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:29)-(1:37))
+        │       ├── tag_opening: "</" (location: (1:29)-(1:31))
+        │       ├── tag_name: "style" (location: (1:31)-(1:36))
+        │       ├── children: []
+        │       └── tag_closing: ">" (location: (1:36)-(1:37))
+        │
+        ├── is_void: false
+        └── source: "HTML"


### PR DESCRIPTION
This pull request fixes https://github.com/marcoroth/herb/issues/956

HTML tags are handled case-insensitively across open/close matching, foreign content detection for script/style and SVG contexts, and the tests updated to cover mixed-case tags to ensure parsing.

Let me know if you see any improvements or have any suggestions!
