### PR TITLE
Lexer: Add support for `<%graphql %>` tags

### DIFF
--- a/src/analyze.c
+++ b/src/analyze.c
@@ -56,7 +56,8 @@ static bool analyze_erb_content(const AST_NODE_T* node, void* data) {
 
     const char* opening = erb_content_node->tag_opening->value;
 
-    if (strcmp(opening, "<%%") != 0 && strcmp(opening, "<%%=") != 0 && strcmp(opening, "<%#") != 0) {
+    if (strcmp(opening, "<%%") != 0 && strcmp(opening, "<%%=") != 0 && strcmp(opening, "<%#") != 0
+        && strcmp(opening, "<%graphql") != 0) {
       analyzed_ruby_T* analyzed = herb_analyze_ruby(hb_string(erb_content_node->content->value));
 
       erb_content_node->parsed = true;

--- a/src/extract.c
+++ b/src/extract.c
@@ -25,7 +25,8 @@ void herb_extract_ruby_to_buffer(const char* source, hb_buffer_T* output) {
         if (strcmp(token->value, "<%#") == 0) {
           skip_erb_content = true;
           is_comment_tag = true;
-        } else if (strcmp(token->value, "<%%") == 0 || strcmp(token->value, "<%%=") == 0) {
+        } else if (strcmp(token->value, "<%%") == 0 || strcmp(token->value, "<%%=") == 0
+                   || strcmp(token->value, "<%graphql") == 0) {
           skip_erb_content = true;
           is_comment_tag = false;
         } else {

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -185,8 +185,8 @@ static token_T* lexer_parse_identifier(lexer_T* lexer) {
 // ===== ERB Parsing
 
 static token_T* lexer_parse_erb_open(lexer_T* lexer) {
-  hb_string_T erb_patterns[] = { hb_string("<%=="), hb_string("<%%="), hb_string("<%="), hb_string("<%#"),
-                                 hb_string("<%-"),  hb_string("<%%"),  hb_string("<%") };
+  hb_string_T erb_patterns[] = { hb_string("<%=="), hb_string("<%%="), hb_string("<%="),       hb_string("<%#"),
+                                 hb_string("<%-"),  hb_string("<%%"),  hb_string("<%graphql"), hb_string("<%") };
 
   lexer->state = STATE_ERB_CONTENT;
 

--- a/test/parser/graphql_test.rb
+++ b/test/parser/graphql_test.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+module Parser
+  class GraphQLTest < Minitest::Spec
+    include SnapshotUtils
+
+    test "graphql tag" do
+      assert_parsed_snapshot(<<~HTML)
+        <%graphql
+          fragment HumanFragment on Human {
+            name
+            homePlanet
+          }
+        %>
+      HTML
+    end
+
+    test "graphql tag with comment and html" do
+      assert_parsed_snapshot(<<~HTML)
+        <%# app/views/humans/human.html.erb %>
+        <%graphql
+          fragment HumanFragment on Human {
+            name
+            homePlanet
+          }
+        %>
+
+        <p><%= human.name %> lives on <%= human.home_planet %>.</p>
+      HTML
+    end
+
+    test "graphql tag inline" do
+      assert_parsed_snapshot(%(<%graphql query { users { id } } %>))
+    end
+
+    test "graphql tag with query variables" do
+      assert_parsed_snapshot(<<~HTML)
+        <%graphql
+          query Products($first: Int!) {
+            products(first: $first) {
+              nodes {
+                id
+                title
+              }
+            }
+          }
+        %>
+      HTML
+    end
+
+    test "erb tag with graphql variable is not a graphql tag" do
+      assert_parsed_snapshot(%(<% graphql = "query" %>))
+    end
+  end
+end

--- a/test/snapshots/parser/graph_ql_test/test_0001_graphql_tag_0067daf23c850dd1c9945d5805db8158.txt
+++ b/test/snapshots/parser/graph_ql_test/test_0001_graphql_tag_0067daf23c850dd1c9945d5805db8158.txt
@@ -1,0 +1,26 @@
+---
+source: "Parser::GraphQLTest#test_0001_graphql tag"
+input: |2-
+<%graphql
+  fragment HumanFragment on Human {
+    name
+    homePlanet
+  }
+%>
+---
+@ DocumentNode (location: (1:0)-(7:0))
+└── children: (2 items)
+    ├── @ ERBContentNode (location: (1:0)-(6:2))
+    │   ├── tag_opening: "<%graphql" (location: (1:0)-(1:9))
+    │   ├── content: "
+    │     fragment HumanFragment on Human {
+    │       name
+    │       homePlanet
+    │     }
+    │   " (location: (1:9)-(6:0))
+    │   ├── tag_closing: "%>" (location: (6:0)-(6:2))
+    │   ├── parsed: false
+    │   └── valid: true
+    │
+    └── @ HTMLTextNode (location: (6:2)-(7:0))
+        └── content: "\n"

--- a/test/snapshots/parser/graph_ql_test/test_0002_graphql_tag_with_comment_and_html_0cd544e338da709b3343e75d9fdd4be8.txt
+++ b/test/snapshots/parser/graph_ql_test/test_0002_graphql_tag_with_comment_and_html_0cd544e338da709b3343e75d9fdd4be8.txt
@@ -1,0 +1,83 @@
+---
+source: "Parser::GraphQLTest#test_0002_graphql tag with comment and html"
+input: |2-
+<%# app/views/humans/human.html.erb %>
+<%graphql
+  fragment HumanFragment on Human {
+    name
+    homePlanet
+  }
+%>
+
+<p><%= human.name %> lives on <%= human.home_planet %>.</p>
+---
+@ DocumentNode (location: (1:0)-(10:0))
+└── children: (6 items)
+    ├── @ ERBContentNode (location: (1:0)-(1:38))
+    │   ├── tag_opening: "<%#" (location: (1:0)-(1:3))
+    │   ├── content: " app/views/humans/human.html.erb " (location: (1:3)-(1:36))
+    │   ├── tag_closing: "%>" (location: (1:36)-(1:38))
+    │   ├── parsed: false
+    │   └── valid: true
+    │
+    ├── @ HTMLTextNode (location: (1:38)-(2:0))
+    │   └── content: "\n"
+    │
+    ├── @ ERBContentNode (location: (2:0)-(7:2))
+    │   ├── tag_opening: "<%graphql" (location: (2:0)-(2:9))
+    │   ├── content: "
+    │     fragment HumanFragment on Human {
+    │       name
+    │       homePlanet
+    │     }
+    │   " (location: (2:9)-(7:0))
+    │   ├── tag_closing: "%>" (location: (7:0)-(7:2))
+    │   ├── parsed: false
+    │   └── valid: true
+    │
+    ├── @ HTMLTextNode (location: (7:2)-(9:0))
+    │   └── content: "\n\n"
+    │
+    ├── @ HTMLElementNode (location: (9:0)-(9:59))
+    │   ├── open_tag:
+    │   │   └── @ HTMLOpenTagNode (location: (9:0)-(9:3))
+    │   │       ├── tag_opening: "<" (location: (9:0)-(9:1))
+    │   │       ├── tag_name: "p" (location: (9:1)-(9:2))
+    │   │       ├── tag_closing: ">" (location: (9:2)-(9:3))
+    │   │       ├── children: []
+    │   │       └── is_void: false
+    │   │
+    │   ├── tag_name: "p" (location: (9:1)-(9:2))
+    │   ├── body: (4 items)
+    │   │   ├── @ ERBContentNode (location: (9:3)-(9:20))
+    │   │   │   ├── tag_opening: "<%=" (location: (9:3)-(9:6))
+    │   │   │   ├── content: " human.name " (location: (9:6)-(9:18))
+    │   │   │   ├── tag_closing: "%>" (location: (9:18)-(9:20))
+    │   │   │   ├── parsed: true
+    │   │   │   └── valid: true
+    │   │   │
+    │   │   ├── @ HTMLTextNode (location: (9:20)-(9:30))
+    │   │   │   └── content: " lives on "
+    │   │   │
+    │   │   ├── @ ERBContentNode (location: (9:30)-(9:54))
+    │   │   │   ├── tag_opening: "<%=" (location: (9:30)-(9:33))
+    │   │   │   ├── content: " human.home_planet " (location: (9:33)-(9:52))
+    │   │   │   ├── tag_closing: "%>" (location: (9:52)-(9:54))
+    │   │   │   ├── parsed: true
+    │   │   │   └── valid: true
+    │   │   │
+    │   │   └── @ HTMLTextNode (location: (9:54)-(9:55))
+    │   │       └── content: "."
+    │   │
+    │   ├── close_tag:
+    │   │   └── @ HTMLCloseTagNode (location: (9:55)-(9:59))
+    │   │       ├── tag_opening: "</" (location: (9:55)-(9:57))
+    │   │       ├── tag_name: "p" (location: (9:57)-(9:58))
+    │   │       ├── children: []
+    │   │       └── tag_closing: ">" (location: (9:58)-(9:59))
+    │   │
+    │   ├── is_void: false
+    │   └── source: "HTML"
+    │
+    └── @ HTMLTextNode (location: (9:59)-(10:0))
+        └── content: "\n"

--- a/test/snapshots/parser/graph_ql_test/test_0003_graphql_tag_inline_cd5722662613dd0339e7a219da5487ba.txt
+++ b/test/snapshots/parser/graph_ql_test/test_0003_graphql_tag_inline_cd5722662613dd0339e7a219da5487ba.txt
@@ -1,0 +1,12 @@
+---
+source: "Parser::GraphQLTest#test_0003_graphql tag inline"
+input: "<%graphql query { users { id } } %>"
+---
+@ DocumentNode (location: (1:0)-(1:35))
+└── children: (1 item)
+    └── @ ERBContentNode (location: (1:0)-(1:35))
+        ├── tag_opening: "<%graphql" (location: (1:0)-(1:9))
+        ├── content: " query { users { id } } " (location: (1:9)-(1:33))
+        ├── tag_closing: "%>" (location: (1:33)-(1:35))
+        ├── parsed: false
+        └── valid: true

--- a/test/snapshots/parser/graph_ql_test/test_0004_graphql_tag_with_query_variables_d644d55920fd0ae38acbd96a2481de7f.txt
+++ b/test/snapshots/parser/graph_ql_test/test_0004_graphql_tag_with_query_variables_d644d55920fd0ae38acbd96a2481de7f.txt
@@ -1,0 +1,34 @@
+---
+source: "Parser::GraphQLTest#test_0004_graphql tag with query variables"
+input: |2-
+<%graphql
+  query Products($first: Int!) {
+    products(first: $first) {
+      nodes {
+        id
+        title
+      }
+    }
+  }
+%>
+---
+@ DocumentNode (location: (1:0)-(11:0))
+└── children: (2 items)
+    ├── @ ERBContentNode (location: (1:0)-(10:2))
+    │   ├── tag_opening: "<%graphql" (location: (1:0)-(1:9))
+    │   ├── content: "
+    │     query Products($first: Int!) {
+    │       products(first: $first) {
+    │         nodes {
+    │           id
+    │           title
+    │         }
+    │       }
+    │     }
+    │   " (location: (1:9)-(10:0))
+    │   ├── tag_closing: "%>" (location: (10:0)-(10:2))
+    │   ├── parsed: false
+    │   └── valid: true
+    │
+    └── @ HTMLTextNode (location: (10:2)-(11:0))
+        └── content: "\n"

--- a/test/snapshots/parser/graph_ql_test/test_0005_erb_tag_with_graphql_variable_is_not_a_graphql_tag_3da8d4028f50f9de93b9bcda2947b05d.txt
+++ b/test/snapshots/parser/graph_ql_test/test_0005_erb_tag_with_graphql_variable_is_not_a_graphql_tag_3da8d4028f50f9de93b9bcda2947b05d.txt
@@ -1,0 +1,12 @@
+---
+source: "Parser::GraphQLTest#test_0005_erb tag with graphql variable is not a graphql tag"
+input: "<% graphql = \"query\" %>"
+---
+@ DocumentNode (location: (1:0)-(1:23))
+└── children: (1 item)
+    └── @ ERBContentNode (location: (1:0)-(1:23))
+        ├── tag_opening: "<%" (location: (1:0)-(1:2))
+        ├── content: " graphql = "query" " (location: (1:2)-(1:21))
+        ├── tag_closing: "%>" (location: (1:21)-(1:23))
+        ├── parsed: true
+        └── valid: true


### PR DESCRIPTION
This pull request updates the lexer to support detecting `<%grapqhl` as a valid ERB tag opening. That way, we can treat them differently and don't their content as Ruby code and parse them using Prism.

The [`graphql-client`](https://github.com/github-community-projects/graphql-client?tab=readme-ov-file#rails-erb-integration) gem exposes an ERB extension that allows to use custom `<%grapqhl %>` tags in ERB files.

```html+erb
<%# app/views/humans/human.html.erb %>
<%graphql
  fragment HumanFragment on Human {
    name
    homePlanet
  }
%>

<p><%= human.name %> lives on <%= human.home_planet %>.</p>
```

With this pull request, the example from #972 now gets parsed with a `"<%graphql"` as the `tag_opening` and with no Ruby parse errors:

```js
@ DocumentNode (location: (1:0)-(15:2))
└── children: (1 item)
    └── @ ERBContentNode (location: (1:0)-(15:2))
        ├── tag_opening: "<%graphql" (location: (1:0)-(1:9))
        ├── content: "
          fragment Comment on Comment {
            ... on PullRequestReviewComment {
              pullRequest {
                id
                repository {
                  name
                  owner {
                    login
                  }
                }
              }
            }
          }
        " (location: (1:9)-(15:0))
        ├── tag_closing: "%>" (location: (15:0)-(15:2))
        ├── parsed: false
        └── valid: true
```


At runtime, these tags are [getting converted to ERB comments](https://github.com/github-community-projects/graphql-client/blob/ba1328fe77a35c3558758db2cbe302f50f64e283/lib/graphql/client/erubi_enhancer.rb#L17).  In the future, we might also want to update the `Herb::Engine` to skip these tags from being compiled.

Resolves #972 