### PR TITLE
Engine: Ignore `<%graphql %>` tags when compiling templates

### DIFF
--- a/examples/graphql.html.erb
+++ b/examples/graphql.html.erb
@@ -1,0 +1,15 @@
+<%# app/views/products/product.html.erb %>
+<%graphql
+  fragment ProductFragment on Product {
+    id
+    title
+    description
+    price
+  }
+%>
+
+<article class="product">
+  <h1><%= product.title %></h1>
+  <p class="description"><%= product.description %></p>
+  <span class="price"><%= product.price %></span>
+</article>

--- a/lib/herb/ast/helpers.rb
+++ b/lib/herb/ast/helpers.rb
@@ -18,6 +18,11 @@ module Herb
       end
 
       #: (String) -> bool
+      def erb_graphql?(opening)
+        opening.start_with?("<%graphql")
+      end
+
+      #: (String) -> bool
       def erb_output?(opening)
         opening.include?("=")
       end

--- a/lib/herb/engine/compiler.rb
+++ b/lib/herb/engine/compiler.rb
@@ -319,6 +319,7 @@ module Herb
         opening = node.tag_opening.value
 
         return if !skip_comment_check && erb_comment?(opening)
+        return if erb_graphql?(opening)
 
         code = node.content.value.strip
 

--- a/sig/herb/ast/helpers.rbs
+++ b/sig/herb/ast/helpers.rbs
@@ -10,6 +10,9 @@ module Herb
       def erb_comment?: (String) -> bool
 
       # : (String) -> bool
+      def erb_graphql?: (String) -> bool
+
+      # : (String) -> bool
       def erb_output?: (String) -> bool
 
       # : (Herb::AST::ERBContentNode) -> bool

--- a/test/engine/evaluation_test.rb
+++ b/test/engine/evaluation_test.rb
@@ -452,5 +452,13 @@ module Engine
 
       assert_evaluated_snapshot(template, {}, { escape: false })
     end
+
+    test "graphql" do
+      template = File.read("examples/graphql.html.erb")
+      klass = Data.define(:title, :description, :price)
+      product = klass.new(title: "title", description: "Description", price: 42.00)
+
+      assert_evaluated_snapshot(template, { product: product }, { escape: false })
+    end
   end
 end

--- a/test/engine/graphql_test.rb
+++ b/test/engine/graphql_test.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+require_relative "../snapshot_utils"
+require_relative "../../lib/herb/engine"
+
+module Engine
+  class GraphQLTest < Minitest::Spec
+    include SnapshotUtils
+
+    test "graphql tag is omitted from compilation" do
+      template = <<~ERB
+        <%graphql
+          fragment HumanFragment on Human {
+            name
+            homePlanet
+          }
+        %>
+      ERB
+
+      assert_compiled_snapshot(template)
+    end
+
+    test "graphql tag inline is omitted from compilation" do
+      template = %(<%graphql query { users { id } } %>)
+
+      assert_compiled_snapshot(template)
+    end
+
+    test "graphql tag with surrounding html" do
+      template = <<~ERB
+        <div>
+          <%graphql
+            fragment UserFragment on User {
+              id
+              email
+            }
+          %>
+          <p>Hello <%= user.name %></p>
+        </div>
+      ERB
+
+      assert_compiled_snapshot(template)
+    end
+
+    test "graphql tag with comment and html" do
+      template = <<~ERB
+        <%# app/views/humans/human.html.erb %>
+        <%graphql
+          fragment HumanFragment on Human {
+            name
+            homePlanet
+          }
+        %>
+
+        <p><%= human.name %> lives on <%= human.home_planet %>.</p>
+      ERB
+
+      assert_compiled_snapshot(template)
+    end
+
+    test "graphql tag with query variables" do
+      template = <<~ERB
+        <%graphql
+          query Products($first: Int!) {
+            products(first: $first) {
+              nodes {
+                id
+                title
+              }
+            }
+          }
+        %>
+        <ul>
+          <% products.each do |product| %>
+            <li><%= product.title %></li>
+          <% end %>
+        </ul>
+      ERB
+
+      assert_compiled_snapshot(template)
+    end
+
+    test "graphql variable assignment is not omitted" do
+      template = %(<% graphql = "query" %>)
+
+      assert_compiled_snapshot(template)
+    end
+
+    test "graphql tag evaluated produces empty output" do
+      template = <<~ERB
+        <%graphql
+          fragment TestFragment on Test {
+            id
+          }
+        %>
+      ERB
+
+      assert_evaluated_snapshot(template)
+    end
+
+    test "graphql tag with html evaluated" do
+      template = <<~ERB
+        <%graphql
+          fragment UserFragment on User {
+            name
+          }
+        %>
+        <p>Hello World</p>
+      ERB
+
+      assert_evaluated_snapshot(template)
+    end
+  end
+end

--- a/test/snapshots/engine/evaluation_test/test_0034_graphql_7135798e54b37bd3100604be39e03425.txt
+++ b/test/snapshots/engine/evaluation_test/test_0034_graphql_7135798e54b37bd3100604be39e03425.txt
@@ -1,0 +1,12 @@
+---
+source: "Engine::EvaluationTest#test_0034_graphql"
+input: "{source: \"<%# app/views/products/product.html.erb %>\\n<%graphql\\n  fragment ProductFragment on Product {\\n    id\\n    title\\n    description\\n    price\\n  }\\n%>\\n\\n<article class=\\\"product\\\">\\n  <h1><%= product.title %></h1>\\n  <p class=\\\"description\\\"><%= product.description %></p>\\n  <span class=\\\"price\\\"><%= product.price %></span>\\n</article>\\n\", locals: {product: #<data title=\"title\", description=\"Description\", price=42.0>}, options: {escape: false}}"
+---
+
+
+
+<article class="product">
+  <h1>title</h1>
+  <p class="description">Description</p>
+  <span class="price">42.0</span>
+</article>

--- a/test/snapshots/engine/examples_compilation_test/test_0014_graphql_compilation_c61e4057efeb22889331fe18ef9e09b7.txt
+++ b/test/snapshots/engine/examples_compilation_test/test_0014_graphql_compilation_c61e4057efeb22889331fe18ef9e09b7.txt
@@ -1,0 +1,14 @@
+---
+source: "Engine::ExamplesCompilationTest#test_0014_graphql compilation"
+input: "{source: \"<%# app/views/products/product.html.erb %>\\n<%graphql\\n  fragment ProductFragment on Product {\\n    id\\n    title\\n    description\\n    price\\n  }\\n%>\\n\\n<article class=\\\"product\\\">\\n  <h1><%= product.title %></h1>\\n  <p class=\\\"description\\\"><%= product.description %></p>\\n  <span class=\\\"price\\\"><%= product.price %></span>\\n</article>\\n\", options: {escape: false}}"
+---
+_buf = ::String.new; _buf << '
+
+
+<article class="product">
+  <h1>'.freeze; _buf << (product.title).to_s; _buf << '</h1>
+  <p class="description">'.freeze; _buf << (product.description).to_s; _buf << '</p>
+  <span class="price">'.freeze; _buf << (product.price).to_s; _buf << '</span>
+</article>
+'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/examples_compilation_test/test_0015_if_else_compilation_1437d0425640509570342c24b30de571.txt
+++ b/test/snapshots/engine/examples_compilation_test/test_0015_if_else_compilation_1437d0425640509570342c24b30de571.txt
@@ -1,5 +1,5 @@
 ---
-source: "Engine::ExamplesCompilationTest#test_0014_if else compilation"
+source: "Engine::ExamplesCompilationTest#test_0015_if else compilation"
 input: "{source: \"<h1>\\n  <% if true %>\\n    <div>Text1</div>\\n  <% elsif false %>\\n    <div>Text2</div>\\n  <% else %>\\n    <div>Text3</div>\\n  <% end %>\\n</h1>\\n\", options: {escape: false}}"
 ---
 _buf = ::String.new; _buf << '<h1>

--- a/test/snapshots/engine/examples_compilation_test/test_0016_left_right_trim_compilation_0416edce0119986c84ba03c645b50717.txt
+++ b/test/snapshots/engine/examples_compilation_test/test_0016_left_right_trim_compilation_0416edce0119986c84ba03c645b50717.txt
@@ -1,5 +1,5 @@
 ---
-source: "Engine::ExamplesCompilationTest#test_0015_left right trim compilation"
+source: "Engine::ExamplesCompilationTest#test_0016_left right trim compilation"
 input: "{source: \"<%- if true -%>\\n  <h1>Content</h1>\\n<%- end -%>\\n\", options: {escape: false}}"
 ---
 _buf = ::String.new; if true 

--- a/test/snapshots/engine/examples_compilation_test/test_0017_left_trim_compilation_12bf92840853103be656f8d585205a84.txt
+++ b/test/snapshots/engine/examples_compilation_test/test_0017_left_trim_compilation_12bf92840853103be656f8d585205a84.txt
@@ -1,5 +1,5 @@
 ---
-source: "Engine::ExamplesCompilationTest#test_0016_left trim compilation"
+source: "Engine::ExamplesCompilationTest#test_0017_left trim compilation"
 input: "{source: \"<%- if true %>\\n  <h1>Content</h1>\\n<%- end %>\\n\", options: {escape: false}}"
 ---
 _buf = ::String.new; if true 

--- a/test/snapshots/engine/examples_compilation_test/test_0018_line_wrap_compilation_ba78b92bec7a4692a2043f2ba2ebe057.txt
+++ b/test/snapshots/engine/examples_compilation_test/test_0018_line_wrap_compilation_ba78b92bec7a4692a2043f2ba2ebe057.txt
@@ -1,5 +1,5 @@
 ---
-source: "Engine::ExamplesCompilationTest#test_0017_line wrap compilation"
+source: "Engine::ExamplesCompilationTest#test_0018_line wrap compilation"
 input: "{source: \"<div class=\\\"so many more classes that it has to line-wrap this line because there is so much text and that it actually covers up the diagnostic with the duplicate attribute\\\" class=\\\"violation\\\" data-class=\\\"this is another very long attribute value to see if it can still pinpoint the right location of the diagnostic\\\"></div>\\n\", options: {escape: false}}"
 ---
 _buf = ::String.new; _buf << '<div class="so many more classes that it has to line-wrap this line because there is so much text and that it actually covers up the diagnostic with the duplicate attribute" class="violation" data-class="this is another very long attribute value to see if it can still pinpoint the right location of the diagnostic"></div>

--- a/test/snapshots/engine/examples_compilation_test/test_0019_link_to_with_block_compilation_4ddb2a17755d3e775e3225970bc60a96.txt
+++ b/test/snapshots/engine/examples_compilation_test/test_0019_link_to_with_block_compilation_4ddb2a17755d3e775e3225970bc60a96.txt
@@ -1,5 +1,5 @@
 ---
-source: "Engine::ExamplesCompilationTest#test_0018_link to with block compilation"
+source: "Engine::ExamplesCompilationTest#test_0019_link to with block compilation"
 input: "{source: \"<%= link_to root_path do %>\\n  <div class=\\\"card\\\">\\n    Test\\n  </div>\\n<% end %>\\n\", options: {escape: false}}"
 ---
 _buf = ::String.new; _buf << link_to root_path do; _buf << '

--- a/test/snapshots/engine/examples_compilation_test/test_0020_nested_if_and_blocks_compilation_aa8aed9ef61b138a28efed42f4b72251.txt
+++ b/test/snapshots/engine/examples_compilation_test/test_0020_nested_if_and_blocks_compilation_aa8aed9ef61b138a28efed42f4b72251.txt
@@ -1,5 +1,5 @@
 ---
-source: "Engine::ExamplesCompilationTest#test_0019_nested if and blocks compilation"
+source: "Engine::ExamplesCompilationTest#test_0020_nested if and blocks compilation"
 input: "{source: \"<div id=\\\"output\\\">\\n  <%= tag.div class: \\\"div\\\" do %>\\n    <% if Date.today.friday? %>\\n      <h1>\\n        Happy\\n        <% current_hour = Time.now.hour %>\\n\\n        <% if current_hour < 12 %>\\n          <b>Early Friday</b>\\n        <% elsif current_hour >= 18 %>\\n          <b>Late Friday</b>\\n        <% else %>\\n          <b>Friday</b>\\n        <% end %>\\n      </h1>\\n    <% elsif Date.today.saturday? %>\\n      <h1>\\n        It's\\n        <b>Saturday</b>\\n        <%= \\\" - Time to relax!\\\" %>\\n      </h1>\\n    <% else %>\\n      <h1>\\n        Oh no, it's\\n        <b>Not Friday</b>\\n        <%= \\\" - Keep going!\\\" %>\\n      </h1>\\n    <% end %>\\n  <% end %>\\n</div>\\n\", options: {escape: false}}"
 ---
 _buf = ::String.new; _buf << '<div id="output">

--- a/test/snapshots/engine/examples_compilation_test/test_0021_right_trim_compilation_a702ca89e5a7ccec9e80bfc422053ffd.txt
+++ b/test/snapshots/engine/examples_compilation_test/test_0021_right_trim_compilation_a702ca89e5a7ccec9e80bfc422053ffd.txt
@@ -1,5 +1,5 @@
 ---
-source: "Engine::ExamplesCompilationTest#test_0020_right trim compilation"
+source: "Engine::ExamplesCompilationTest#test_0021_right trim compilation"
 input: "{source: \"<% if true -%>\\n  <h1>Content</h1>\\n<% end -%>\\n\", options: {escape: false}}"
 ---
 _buf = ::String.new; if true 

--- a/test/snapshots/engine/examples_compilation_test/test_0022_simple_block_compilation_1729fad3a77618acdc687c9fb671b75b.txt
+++ b/test/snapshots/engine/examples_compilation_test/test_0022_simple_block_compilation_1729fad3a77618acdc687c9fb671b75b.txt
@@ -1,5 +1,5 @@
 ---
-source: "Engine::ExamplesCompilationTest#test_0021_simple block compilation"
+source: "Engine::ExamplesCompilationTest#test_0022_simple block compilation"
 input: "{source: \"<% tag.div do %>\\n  <% if true %>\\n    Hello1\\n  <% else %>\\n    Hello2\\n  <% end %>\\n<% end %>\\n\", options: {escape: false}}"
 ---
 _buf = ::String.new; tag.div do 

--- a/test/snapshots/engine/examples_compilation_test/test_0023_simple_erb_compilation_d81de4ca83482c4836215ef7177d9eec.txt
+++ b/test/snapshots/engine/examples_compilation_test/test_0023_simple_erb_compilation_d81de4ca83482c4836215ef7177d9eec.txt
@@ -1,5 +1,5 @@
 ---
-source: "Engine::ExamplesCompilationTest#test_0022_simple erb compilation"
+source: "Engine::ExamplesCompilationTest#test_0023_simple erb compilation"
 input: "{source: \"<% title %>\\n\", options: {escape: false}}"
 ---
 _buf = ::String.new; title 

--- a/test/snapshots/engine/examples_compilation_test/test_0024_test_compilation_9c22f391d1d03fa66b3d18095354a236.txt
+++ b/test/snapshots/engine/examples_compilation_test/test_0024_test_compilation_9c22f391d1d03fa66b3d18095354a236.txt
@@ -1,5 +1,5 @@
 ---
-source: "Engine::ExamplesCompilationTest#test_0023_test compilation"
+source: "Engine::ExamplesCompilationTest#test_0024_test compilation"
 input: "{source: \"<input required />\\n\\n<h1 class=\\\"bg-gray-300 text-gray\\\" id='' data-controller=\\\"example\\\">\\n  Hello World <%= RUBY_VERSION %>\\n</h1>\\n\", options: {escape: false}}"
 ---
 _buf = ::String.new; _buf << '<input required />

--- a/test/snapshots/engine/examples_compilation_test/test_0025_until_compilation_0b1269c00fd15a74df125278ed6a9fc4.txt
+++ b/test/snapshots/engine/examples_compilation_test/test_0025_until_compilation_0b1269c00fd15a74df125278ed6a9fc4.txt
@@ -1,5 +1,5 @@
 ---
-source: "Engine::ExamplesCompilationTest#test_0024_until compilation"
+source: "Engine::ExamplesCompilationTest#test_0025_until compilation"
 input: "{source: \"<% i = 0 %>\\n\\n<% until i == 10 %>\\n  <b><%= i %></b> is less than 10\\n  <% i += 1 %>\\n<% end %>\\n\", options: {escape: false}}"
 ---
 _buf = ::String.new; i = 0 

--- a/test/snapshots/engine/examples_compilation_test/test_0026_utf8_compilation_45fa7aa654c0dc06d1a1b9504002dfba.txt
+++ b/test/snapshots/engine/examples_compilation_test/test_0026_utf8_compilation_45fa7aa654c0dc06d1a1b9504002dfba.txt
@@ -1,5 +1,5 @@
 ---
-source: "Engine::ExamplesCompilationTest#test_0025_utf8 compilation"
+source: "Engine::ExamplesCompilationTest#test_0026_utf8 compilation"
 input: "{source: \"Sitename • Title\\n\\n<% @title = \\\"Home\\\" %>\\n\\n<title><%= [@title, \\\"Sitename\\\"].compact.join(\\\" • \\\") %></title>\\n\", options: {escape: false}}"
 ---
 _buf = ::String.new; _buf << 'Sitename • Title

--- a/test/snapshots/engine/examples_compilation_test/test_0027_while_compilation_a705eb5ed83b4db368d7204baa136b36.txt
+++ b/test/snapshots/engine/examples_compilation_test/test_0027_while_compilation_a705eb5ed83b4db368d7204baa136b36.txt
@@ -1,5 +1,5 @@
 ---
-source: "Engine::ExamplesCompilationTest#test_0026_while compilation"
+source: "Engine::ExamplesCompilationTest#test_0027_while compilation"
 input: "{source: \"<% while i < 10 %>\\n  <b><%= i %></b> is less than 10\\n  <% i += 1 %>\\n<% end %>\\n\", options: {escape: false}}"
 ---
 _buf = ::String.new; while i < 10 

--- a/test/snapshots/engine/graph_ql_test/test_0001_graphql_tag_is_omitted_from_compilation_47490acff71eeb5f10202588769b41a9.txt
+++ b/test/snapshots/engine/graph_ql_test/test_0001_graphql_tag_is_omitted_from_compilation_47490acff71eeb5f10202588769b41a9.txt
@@ -1,0 +1,7 @@
+---
+source: "Engine::GraphQLTest#test_0001_graphql tag is omitted from compilation"
+input: "{source: \"<%graphql\\n  fragment HumanFragment on Human {\\n    name\\n    homePlanet\\n  }\\n%>\\n\", options: {}}"
+---
+_buf = ::String.new; _buf << '
+'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/graph_ql_test/test_0002_graphql_tag_inline_is_omitted_from_compilation_90aacd163bf59e73adcb6e1e07047072.txt
+++ b/test/snapshots/engine/graph_ql_test/test_0002_graphql_tag_inline_is_omitted_from_compilation_90aacd163bf59e73adcb6e1e07047072.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::GraphQLTest#test_0002_graphql tag inline is omitted from compilation"
+input: "{source: \"<%graphql query { users { id } } %>\", options: {}}"
+---
+_buf = ::String.new;
+_buf.to_s

--- a/test/snapshots/engine/graph_ql_test/test_0003_graphql_tag_with_surrounding_html_be45769f2a29cb99bc361c2aab0a4182.txt
+++ b/test/snapshots/engine/graph_ql_test/test_0003_graphql_tag_with_surrounding_html_be45769f2a29cb99bc361c2aab0a4182.txt
@@ -1,0 +1,10 @@
+---
+source: "Engine::GraphQLTest#test_0003_graphql tag with surrounding html"
+input: "{source: \"<div>\\n  <%graphql\\n    fragment UserFragment on User {\\n      id\\n      email\\n    }\\n  %>\\n  <p>Hello <%= user.name %></p>\\n</div>\\n\", options: {}}"
+---
+_buf = ::String.new; _buf << '<div>
+  
+  <p>Hello '.freeze; _buf << (user.name).to_s; _buf << '</p>
+</div>
+'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/graph_ql_test/test_0004_graphql_tag_with_comment_and_html_173ebe3413c7549d66739043f20b95af.txt
+++ b/test/snapshots/engine/graph_ql_test/test_0004_graphql_tag_with_comment_and_html_173ebe3413c7549d66739043f20b95af.txt
@@ -1,0 +1,10 @@
+---
+source: "Engine::GraphQLTest#test_0004_graphql tag with comment and html"
+input: "{source: \"<%# app/views/humans/human.html.erb %>\\n<%graphql\\n  fragment HumanFragment on Human {\\n    name\\n    homePlanet\\n  }\\n%>\\n\\n<p><%= human.name %> lives on <%= human.home_planet %>.</p>\\n\", options: {}}"
+---
+_buf = ::String.new; _buf << '
+
+
+<p>'.freeze; _buf << (human.name).to_s; _buf << ' lives on '.freeze; _buf << (human.home_planet).to_s; _buf << '.</p>
+'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/graph_ql_test/test_0005_graphql_tag_with_query_variables_14bbde4d098545604b9e13f62cbd3eaa.txt
+++ b/test/snapshots/engine/graph_ql_test/test_0005_graphql_tag_with_query_variables_14bbde4d098545604b9e13f62cbd3eaa.txt
@@ -1,0 +1,12 @@
+---
+source: "Engine::GraphQLTest#test_0005_graphql tag with query variables"
+input: "{source: \"<%graphql\\n  query Products($first: Int!) {\\n    products(first: $first) {\\n      nodes {\\n        id\\n        title\\n      }\\n    }\\n  }\\n%>\\n<ul>\\n  <% products.each do |product| %>\\n    <li><%= product.title %></li>\\n  <% end %>\\n</ul>\\n\", options: {}}"
+---
+_buf = ::String.new; _buf << '
+<ul>
+'.freeze;   products.each do |product| 
+ _buf << '    <li>'.freeze; _buf << (product.title).to_s; _buf << '</li>
+'.freeze;   end 
+ _buf << '</ul>
+'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/graph_ql_test/test_0006_graphql_variable_assignment_is_not_omitted_06942083656c0f05c0ae98ea47443697.txt
+++ b/test/snapshots/engine/graph_ql_test/test_0006_graphql_variable_assignment_is_not_omitted_06942083656c0f05c0ae98ea47443697.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::GraphQLTest#test_0006_graphql variable assignment is not omitted"
+input: "{source: \"<% graphql = \\\"query\\\" %>\", options: {}}"
+---
+_buf = ::String.new; graphql = "query" 
+_buf.to_s

--- a/test/snapshots/engine/graph_ql_test/test_0007_graphql_tag_evaluated_produces_empty_output_d30b72c8fb42d96edebf74a282fe742b.txt
+++ b/test/snapshots/engine/graph_ql_test/test_0007_graphql_tag_evaluated_produces_empty_output_d30b72c8fb42d96edebf74a282fe742b.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::GraphQLTest#test_0007_graphql tag evaluated produces empty output"
+input: "{source: \"<%graphql\\n  fragment TestFragment on Test {\\n    id\\n  }\\n%>\\n\", locals: {}, options: {}}"
+---
+

--- a/test/snapshots/engine/graph_ql_test/test_0008_graphql_tag_with_html_evaluated_647b7106649f1f0f3d3a7d3216737f61.txt
+++ b/test/snapshots/engine/graph_ql_test/test_0008_graphql_tag_with_html_evaluated_647b7106649f1f0f3d3a7d3216737f61.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::GraphQLTest#test_0008_graphql tag with html evaluated"
+input: "{source: \"<%graphql\\n  fragment UserFragment on User {\\n    name\\n  }\\n%>\\n<p>Hello World</p>\\n\", locals: {}, options: {}}"
+---
+
+<p>Hello World</p>


### PR DESCRIPTION
Follow up to: https://github.com/marcoroth/herb/pull/973

This pull request updates the `Herb::Engine` to not compile `<%graphql %>` tags when compiling HTML+ERB templates. This mirrors the behavior in `ErubiEnhancer` from the [`graphql-client`](https://github.com/github-community-projects/graphql-client/blob/ba1328fe77a35c3558758db2cbe302f50f64e283/lib/graphql/client/erubi_enhancer.rb#L17) gem.