### PR TITLE
Dev Tools: Avoid overriding non-static position when attaching herb overlay

### DIFF
--- a/javascript/packages/dev-tools/src/herb-overlay.ts
+++ b/javascript/packages/dev-tools/src/herb-overlay.ts
@@ -537,7 +537,9 @@ export class HerbOverlay {
 
       parent.setAttribute('data-herb-debug-attached-outline-type', type);
 
-      parent.style.position = 'relative';
+      if (window.getComputedStyle(parent).position === 'static') {
+        parent.style.position = 'relative';
+      }
       label.style.position = 'absolute';
       label.style.top = '0';
       label.style.left = '0';
@@ -546,7 +548,9 @@ export class HerbOverlay {
       return;
     }
 
-    element.style.position = 'relative';
+    if (window.getComputedStyle(element).position === 'static') {
+      element.style.position = 'relative';
+    }
     element.appendChild(label);
   }
 


### PR DESCRIPTION
When showing the Herb overlay:

- For non-static positions (absolute, fixed, sticky, relative), the existing position value should be respected.
- Non-static elements already serve as the positioning context for absolutely positioned children, so overriding them is unnecessary.

Thank you.
