### PR TITLE
Dev Tools: Ensure Herb overlay label is visible in overflow-clipped elements

### DIFF
--- a/javascript/packages/dev-tools/src/herb-overlay.ts
+++ b/javascript/packages/dev-tools/src/herb-overlay.ts
@@ -548,7 +548,7 @@ export class HerbOverlay {
       return;
     }
 
-    if (element.localName === 'html') {
+    if (element.localName === 'html' || window.getComputedStyle(element).overflowY !== 'visible') {
       label.style.top = '0';
     }
     


### PR DESCRIPTION
Previously handled only the html element, but labels can be clipped whenever overflow is not visible.

Relates to #1000