### PR TITLE
Linter: `html-no-duplicate-attributes` respect ERB Control Flow

### DIFF
--- a/javascript/packages/linter/src/rules/html-no-duplicate-attributes.ts
+++ b/javascript/packages/linter/src/rules/html-no-duplicate-attributes.ts
@@ -113,7 +113,10 @@ class NoDuplicateAttributesVisitor extends ControlFlowTrackingVisitor<
 
     if (this.tagAttributes.has(identifier)) {
       this.addDuplicateAttributeOffense(identifier, attributeNode.name!.location)
+      return
     }
+
+    this.addLoopWillDuplicateOffense(identifier, attributeNode.name!.location)
   }
 
   private handleConditionalAttribute(identifier: string, attributeNode: HTMLAttributeNode): void {
@@ -125,22 +128,34 @@ class NoDuplicateAttributesVisitor extends ControlFlowTrackingVisitor<
     if (this.tagAttributes.has(identifier)) {
       this.addDuplicateAttributeOffense(identifier, attributeNode.name!.location)
     }
+
+    this.controlFlowAttributes.add(identifier)
   }
 
   private addDuplicateAttributeOffense(identifier: string, location: Location): void {
-    this.addOffense(`Duplicate attribute \`${identifier}\` found on tag. Remove the duplicate occurrence.`, location)
+    this.addOffense(
+      `Duplicate attribute \`${identifier}\`. Browsers only use the first occurrence and ignore duplicate attributes. Remove the duplicate or merge the values.`,
+      location,
+    )
   }
 
   private addSameLoopIterationOffense(identifier: string, location: Location): void {
     this.addOffense(
-      `Duplicate attribute \`${identifier}\` found within the same loop iteration. Attributes must be unique within the same loop iteration.`,
+      `Duplicate attribute \`${identifier}\` in same loop iteration. Each iteration will produce an element with duplicate attributes. Remove one or merge the values.`,
+      location,
+    )
+  }
+
+  private addLoopWillDuplicateOffense(identifier: string, location: Location): void {
+    this.addOffense(
+      `Attribute \`${identifier}\` inside loop will appear multiple times on this element. Use a dynamic attribute name like \`${identifier}-<%= index %>\` or move the attribute outside the loop.`,
       location,
     )
   }
 
   private addSameBranchOffense(identifier: string, location: Location): void {
     this.addOffense(
-      `Duplicate attribute \`${identifier}\` found within the same control flow branch. Attributes must be unique within the same control flow branch.`,
+      `Duplicate attribute \`${identifier}\` in same branch. This branch will produce an element with duplicate attributes. Remove one or merge the values.`,
       location,
     )
   }

--- a/javascript/packages/linter/test/__snapshots__/cli.test.ts.snap
+++ b/javascript/packages/linter/test/__snapshots__/cli.test.ts.snap
@@ -386,7 +386,7 @@ test/fixtures/multiple-rule-offenses.html.erb:4:3
 
 ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯  [7/14] ⎯⎯⎯⎯
 
-[error] Duplicate attribute \`class\` found on tag. Remove the duplicate occurrence. (html-no-duplicate-attributes)
+[error] Duplicate attribute \`class\`. Browsers only use the first occurrence and ignore duplicate attributes. Remove the duplicate or merge the values. (html-no-duplicate-attributes)
 
 test/fixtures/multiple-rule-offenses.html.erb:5:14
 

--- a/javascript/packages/linter/test/rules/html-no-duplicate-attributes.test.ts
+++ b/javascript/packages/linter/test/rules/html-no-duplicate-attributes.test.ts
@@ -11,18 +11,18 @@ describe("html-no-duplicate-attributes", () => {
   })
 
   test("fails for duplicate attributes", () => {
-    expectError('Duplicate attribute `type` found on tag. Remove the duplicate occurrence.')
+    expectError("Duplicate attribute `type`. Browsers only use the first occurrence and ignore duplicate attributes. Remove the duplicate or merge the values.")
     assertOffenses(`<input type="text" type="password" name="username">`)
   })
 
   test("fails for multiple duplicate attributes", () => {
-    expectError('Duplicate attribute `type` found on tag. Remove the duplicate occurrence.')
-    expectError('Duplicate attribute `class` found on tag. Remove the duplicate occurrence.')
+    expectError("Duplicate attribute `type`. Browsers only use the first occurrence and ignore duplicate attributes. Remove the duplicate or merge the values.")
+    expectError("Duplicate attribute `class`. Browsers only use the first occurrence and ignore duplicate attributes. Remove the duplicate or merge the values.")
     assertOffenses(`<button type="submit" type="button" class="btn" class="primary"></button>`)
   })
 
   test("handles case-insensitive duplicates", () => {
-    expectError('Duplicate attribute `class` found on tag. Remove the duplicate occurrence.')
+    expectError("Duplicate attribute `class`. Browsers only use the first occurrence and ignore duplicate attributes. Remove the duplicate or merge the values.")
     assertOffenses(`<div Class="container" class="active"></div>`)
   })
 
@@ -31,7 +31,7 @@ describe("html-no-duplicate-attributes", () => {
   })
 
   test("handles self-closing tags", () => {
-    expectError('Duplicate attribute `src` found on tag. Remove the duplicate occurrence.')
+    expectError("Duplicate attribute `src`. Browsers only use the first occurrence and ignore duplicate attributes. Remove the duplicate or merge the values.")
     assertOffenses(`<img src="/logo.png" src="/backup.png" alt="Logo">`)
   })
 
@@ -56,11 +56,11 @@ describe("html-no-duplicate-attributes", () => {
   })
 
   test("fails when ERB control flow adds duplicate attributes on the same tag", () => {
-    expectError("Duplicate attribute `class` found on tag. Remove the duplicate occurrence.")
+    expectError("Duplicate attribute `class`. Browsers only use the first occurrence and ignore duplicate attributes. Remove the duplicate or merge the values.")
     assertOffenses(dedent`
-      <div 
+      <div
         class="base"
-        
+
         <% if active? %>
           class="active"
         <% end %>
@@ -69,8 +69,8 @@ describe("html-no-duplicate-attributes", () => {
   })
 
   test("fails when attribute outside control flow and different branches create duplicates", () => {
-    expectError("Duplicate attribute `class` found on tag. Remove the duplicate occurrence.")
-    expectError("Duplicate attribute `class` found on tag. Remove the duplicate occurrence.")
+    expectError("Duplicate attribute `class`. Browsers only use the first occurrence and ignore duplicate attributes. Remove the duplicate or merge the values.")
+    expectError("Duplicate attribute `class`. Browsers only use the first occurrence and ignore duplicate attributes. Remove the duplicate or merge the values.")
     assertOffenses(dedent`
       <div
         class="base"
@@ -85,9 +85,7 @@ describe("html-no-duplicate-attributes", () => {
   })
 
   test("fails for duplicate attributes within the same control flow branch", () => {
-    expectError(
-      "Duplicate attribute `class` found within the same control flow branch. Attributes must be unique within the same control flow branch.",
-    )
+    expectError("Duplicate attribute `class` in same branch. This branch will produce an element with duplicate attributes. Remove one or merge the values.")
     assertOffenses(dedent`
       <div
         <% if condition %>
@@ -99,9 +97,9 @@ describe("html-no-duplicate-attributes", () => {
   })
 
   test("fails for duplicate attributes within the same loop iteration", () => {
-    expectError(
-      "Duplicate attribute `class` found within the same loop iteration. Attributes must be unique within the same loop iteration.",
-    )
+    expectError("Attribute `class` inside loop will appear multiple times on this element. Use a dynamic attribute name like `class-<%= index %>` or move the attribute outside the loop.")
+    expectError("Duplicate attribute `class` in same loop iteration. Each iteration will produce an element with duplicate attributes. Remove one or merge the values.")
+
     assertOffenses(dedent`
       <div
         <% while condition %>
@@ -113,9 +111,9 @@ describe("html-no-duplicate-attributes", () => {
   })
 
   test("fails for duplicate attributes with attribute outside control flow and mutually exclusive case/when branches", () => {
-    expectError("Duplicate attribute `class` found on tag. Remove the duplicate occurrence.")
-    expectError("Duplicate attribute `class` found on tag. Remove the duplicate occurrence.")
-    expectError("Duplicate attribute `class` found on tag. Remove the duplicate occurrence.")
+    expectError("Duplicate attribute `class`. Browsers only use the first occurrence and ignore duplicate attributes. Remove the duplicate or merge the values.")
+    expectError("Duplicate attribute `class`. Browsers only use the first occurrence and ignore duplicate attributes. Remove the duplicate or merge the values.")
+    expectError("Duplicate attribute `class`. Browsers only use the first occurrence and ignore duplicate attributes. Remove the duplicate or merge the values.")
     assertOffenses(dedent`
       <div
         class="base"
@@ -127,6 +125,168 @@ describe("html-no-duplicate-attributes", () => {
           class="status-inactive"
         <% else %>
           class="status-other"
+        <% end %>
+      ></div>
+    `)
+  })
+
+  test("fails when attribute appears after control flow that contained same attribute", () => {
+    expectError("Duplicate attribute `class`. Browsers only use the first occurrence and ignore duplicate attributes. Remove the duplicate or merge the values.")
+
+    assertOffenses(dedent`
+      <div
+        <% if active? %>
+          class="active"
+        <% end %>
+        class="base"
+      ></div>
+    `)
+  })
+
+  test("fails when attribute appears after if/else control flow", () => {
+    expectError("Duplicate attribute `class`. Browsers only use the first occurrence and ignore duplicate attributes. Remove the duplicate or merge the values.")
+
+    assertOffenses(dedent`
+      <div
+        <% if active? %>
+          class="active"
+        <% else %>
+          class="inactive"
+        <% end %>
+        class="base"
+      ></div>
+    `)
+  })
+
+  test("passes for different attributes in control flow branches", () => {
+    expectNoOffenses(dedent`
+      <div
+        <% if active? %>
+          class="active"
+        <% else %>
+          id="inactive"
+        <% end %>
+      ></div>
+    `)
+  })
+
+  test("fails for nested control flow with duplicate in inner branch", () => {
+    expectError("Duplicate attribute `class` in same branch. This branch will produce an element with duplicate attributes. Remove one or merge the values.")
+
+    assertOffenses(dedent`
+      <div
+        <% if outer %>
+          <% if inner %>
+            class="one"
+            class="two"
+          <% end %>
+        <% end %>
+      ></div>
+    `)
+  })
+
+  test("fails when outer attribute conflicts with nested control flow attribute", () => {
+    expectError("Duplicate attribute `class`. Browsers only use the first occurrence and ignore duplicate attributes. Remove the duplicate or merge the values.")
+
+    assertOffenses(dedent`
+      <div
+        class="base"
+        <% if outer %>
+          <% if inner %>
+            class="nested"
+          <% end %>
+        <% end %>
+      ></div>
+    `)
+  })
+
+  test("passes for unless control flow with unique attributes per branch", () => {
+    expectNoOffenses(dedent`
+      <div
+        <% unless disabled? %>
+          class="enabled"
+        <% else %>
+          class="disabled"
+        <% end %>
+      ></div>
+    `)
+  })
+
+  test("fails for for loop with duplicate attributes", () => {
+    expectError("Attribute `data-index` inside loop will appear multiple times on this element. Use a dynamic attribute name like `data-index-<%= index %>` or move the attribute outside the loop.")
+    expectError("Duplicate attribute `data-index` in same loop iteration. Each iteration will produce an element with duplicate attributes. Remove one or merge the values.")
+
+    assertOffenses(dedent`
+      <div
+        <% for item in @items %>
+          data-index="1"
+          data-index="2"
+        <% end %>
+      ></div>
+    `)
+  })
+
+  test("fails for static attribute name in loop", () => {
+    expectError("Attribute `data-id` inside loop will appear multiple times on this element. Use a dynamic attribute name like `data-id-<%= index %>` or move the attribute outside the loop.")
+
+    assertOffenses(dedent`
+      <div
+        <% for item in @items %>
+          data-id="<%= item.id %>"
+        <% end %>
+      ></div>
+    `)
+  })
+
+  test("passes for dynamic attribute name in loop", () => {
+    expectNoOffenses(dedent`
+      <div
+        <% @items.each_with_index do |item, i| %>
+          data-id-<%= i %>="value"
+        <% end %>
+      ></div>
+    `)
+  })
+
+  test.fails("fails for static attribute name in each loop", () => {
+    assertOffenses(dedent`
+      <div
+        <% @items.each do |i| %>
+          data-id="<%= i %>"
+        <% end %>
+      ></div>
+    `)
+  })
+
+  test.fails("fails for static attribute name in each_with_index loop", () => {
+    assertOffenses(dedent`
+      <div
+        <% @items.each_with_index do |item, i| %>
+          data-id="<%= i %>"
+        <% end %>
+      ></div>
+    `)
+  })
+
+  test.fails("fails for static attribute name in times loop", () => {
+    assertOffenses(dedent`
+      <div
+        <% 10.times do |i| %>
+          data-id="<%= i %>"
+        <% end %>
+      ></div>
+    `)
+  })
+
+  test("fails when attribute before loop conflicts with attribute inside loop", () => {
+    expectError("Duplicate attribute `class`. Browsers only use the first occurrence and ignore duplicate attributes. Remove the duplicate or merge the values.")
+
+    assertOffenses(dedent`
+      <div
+        class="base"
+
+        <% @items.each do |item| %>
+          class="item"
         <% end %>
       ></div>
     `)


### PR DESCRIPTION
Resolves https://github.com/marcoroth/herb/issues/458

This implements detection of duplicate attributes in control flow by leveraging the ControlFlowTrackingVisitor introduced in #444.

The intended behavior is described in the test cases, so suggestions for improvement are welcome!