### PR TITLE
C: Revert lazy array initialization and restore `hb_array_size()` usage

### DIFF
--- a/ext/herb/extension_helpers.c
+++ b/ext/herb/extension_helpers.c
@@ -63,7 +63,7 @@ VALUE create_lex_result(hb_array_T* tokens, VALUE source) {
   VALUE warnings = rb_ary_new();
   VALUE errors = rb_ary_new();
 
-  for (size_t i = 0; i < tokens->size; i++) {
+  for (size_t i = 0; i < hb_array_size(tokens); i++) {
     token_T* token = hb_array_get(tokens, i);
     if (token != NULL) { rb_ary_push(value, rb_token_from_c_struct(token)); }
   }

--- a/java/extension_helpers.c
+++ b/java/extension_helpers.c
@@ -60,9 +60,9 @@ jobject CreateLexResult(JNIEnv* env, hb_array_T* tokens, jstring source) {
   jmethodID arrayListConstructor = (*env)->GetMethodID(env, arrayListClass, "<init>", "(I)V");
   jmethodID addMethod = (*env)->GetMethodID(env, arrayListClass, "add", "(Ljava/lang/Object;)Z");
 
-  jobject tokensList = (*env)->NewObject(env, arrayListClass, arrayListConstructor, (jint) tokens->size);
+  jobject tokensList = (*env)->NewObject(env, arrayListClass, arrayListConstructor, (jint) hb_array_size(tokens));
 
-  for (size_t i = 0; i < tokens->size; i++) {
+  for (size_t i = 0; i < hb_array_size(tokens); i++) {
     token_T* token = (token_T*) hb_array_get(tokens, i);
     jobject tokenObj = CreateToken(env, token);
     (*env)->CallBooleanMethod(env, tokensList, addMethod, tokenObj);
@@ -85,7 +85,7 @@ jobject CreateParseResult(JNIEnv* env, AST_DOCUMENT_NODE_T* root, jstring source
   jobject errorsList = (*env)->NewObject(env, arrayListClass, arrayListConstructor);
 
   if (root->base.errors) {
-    for (size_t i = 0; i < root->base.errors->size; i++) {
+    for (size_t i = 0; i < hb_array_size(root->base.errors); i++) {
       AST_NODE_T* error_node = (AST_NODE_T*) hb_array_get(root->base.errors, i);
       jobject errorObj = CreateErrorNode(env, error_node);
       (*env)->CallBooleanMethod(env, errorsList, addMethod, errorObj);

--- a/javascript/packages/node/extension/extension_helpers.cpp
+++ b/javascript/packages/node/extension/extension_helpers.cpp
@@ -153,7 +153,7 @@ napi_value CreateLexResult(napi_env env, hb_array_T* tokens, napi_value source) 
 
   // Add tokens to array
   if (tokens) {
-    for (size_t i = 0; i < tokens->size; i++) {
+    for (size_t i = 0; i < hb_array_size(tokens); i++) {
       token_T* token = (token_T*)hb_array_get(tokens, i);
       if (token) {
         napi_value token_obj = CreateToken(env, token);

--- a/src/analyze.c
+++ b/src/analyze.c
@@ -308,7 +308,7 @@ static AST_NODE_T* create_control_node(
 
   if (end_node) {
     end_position = end_node->base.location.end;
-  } else if (children && children->size > 0) {
+  } else if (hb_array_size(children) > 0) {
     AST_NODE_T* last_child = hb_array_last(children);
     end_position = last_child->location.end;
   } else if (subsequent) {
@@ -350,7 +350,7 @@ static AST_NODE_T* create_control_node(
       hb_array_T* in_conditions = hb_array_init(8);
       hb_array_T* non_when_non_in_children = hb_array_init(8);
 
-      for (size_t i = 0; i < children->size; i++) {
+      for (size_t i = 0; i < hb_array_size(children); i++) {
         AST_NODE_T* child = hb_array_get(children, i);
 
         if (child && child->type == AST_ERB_WHEN_NODE) {
@@ -364,7 +364,7 @@ static AST_NODE_T* create_control_node(
 
       hb_array_free(&children);
 
-      if (in_conditions->size > 0) {
+      if (hb_array_size(in_conditions) > 0) {
         hb_array_free(&when_conditions);
 
         return (AST_NODE_T*) ast_erb_case_match_node_init(
@@ -560,7 +560,7 @@ static size_t process_control_structure(
     hb_array_T* in_conditions = hb_array_init(8);
     hb_array_T* non_when_non_in_children = hb_array_init(8);
 
-    while (index < array->size) {
+    while (index < hb_array_size(array)) {
       AST_NODE_T* next_node = hb_array_get(array, index);
 
       if (!next_node) { break; }
@@ -576,7 +576,7 @@ static size_t process_control_structure(
       index++;
     }
 
-    while (index < array->size) {
+    while (index < hb_array_size(array)) {
       AST_NODE_T* next_node = hb_array_get(array, index);
 
       if (!next_node) { break; }
@@ -648,7 +648,7 @@ static size_t process_control_structure(
 
     AST_ERB_ELSE_NODE_T* else_clause = NULL;
 
-    if (index < array->size) {
+    if (index < hb_array_size(array)) {
       AST_NODE_T* next_node = hb_array_get(array, index);
 
       if (next_node && next_node->type == AST_ERB_CONTENT_NODE) {
@@ -682,7 +682,7 @@ static size_t process_control_structure(
 
     AST_ERB_END_NODE_T* end_node = NULL;
 
-    if (index < array->size) {
+    if (index < hb_array_size(array)) {
       AST_NODE_T* potential_end = hb_array_get(array, index);
 
       if (potential_end && potential_end->type == AST_ERB_CONTENT_NODE) {
@@ -715,15 +715,15 @@ static size_t process_control_structure(
       end_position = end_node->base.location.end;
     } else if (else_clause) {
       end_position = else_clause->base.location.end;
-    } else if (when_conditions->size > 0) {
+    } else if (hb_array_size(when_conditions) > 0) {
       AST_NODE_T* last_when = hb_array_last(when_conditions);
       end_position = last_when->location.end;
-    } else if (in_conditions->size > 0) {
+    } else if (hb_array_size(in_conditions) > 0) {
       AST_NODE_T* last_in = hb_array_last(in_conditions);
       end_position = last_in->location.end;
     }
 
-    if (in_conditions->size > 0) {
+    if (hb_array_size(in_conditions) > 0) {
       hb_array_T* case_match_errors = erb_node->base.errors;
       erb_node->base.errors = NULL;
 
@@ -781,7 +781,7 @@ static size_t process_control_structure(
     AST_ERB_ELSE_NODE_T* else_clause = NULL;
     AST_ERB_ENSURE_NODE_T* ensure_clause = NULL;
 
-    if (index < array->size) {
+    if (index < hb_array_size(array)) {
       AST_NODE_T* next_node = hb_array_get(array, index);
 
       if (next_node && next_node->type == AST_ERB_CONTENT_NODE) {
@@ -796,7 +796,7 @@ static size_t process_control_structure(
       }
     }
 
-    if (index < array->size) {
+    if (index < hb_array_size(array)) {
       AST_NODE_T* next_node = hb_array_get(array, index);
 
       if (next_node && next_node->type == AST_ERB_CONTENT_NODE) {
@@ -828,7 +828,7 @@ static size_t process_control_structure(
       }
     }
 
-    if (index < array->size) {
+    if (index < hb_array_size(array)) {
       AST_NODE_T* next_node = hb_array_get(array, index);
 
       if (next_node && next_node->type == AST_ERB_CONTENT_NODE) {
@@ -840,7 +840,7 @@ static size_t process_control_structure(
 
           index++;
 
-          while (index < array->size) {
+          while (index < hb_array_size(array)) {
             AST_NODE_T* child = hb_array_get(array, index);
 
             if (!child) { break; }
@@ -876,7 +876,7 @@ static size_t process_control_structure(
 
     AST_ERB_END_NODE_T* end_node = NULL;
 
-    if (index < array->size) {
+    if (index < hb_array_size(array)) {
       AST_NODE_T* potential_end = hb_array_get(array, index);
 
       if (potential_end && potential_end->type == AST_ERB_CONTENT_NODE) {
@@ -943,7 +943,7 @@ static size_t process_control_structure(
 
     AST_ERB_END_NODE_T* end_node = NULL;
 
-    if (index < array->size) {
+    if (index < hb_array_size(array)) {
       AST_NODE_T* potential_close = hb_array_get(array, index);
 
       if (potential_close && potential_close->type == AST_ERB_CONTENT_NODE) {
@@ -975,7 +975,7 @@ static size_t process_control_structure(
 
     if (end_node) {
       end_position = end_node->base.location.end;
-    } else if (children && children->size > 0) {
+    } else if (hb_array_size(children) > 0) {
       AST_NODE_T* last_child = hb_array_last(children);
       end_position = last_child->location.end;
     }
@@ -1005,7 +1005,7 @@ static size_t process_control_structure(
   AST_NODE_T* subsequent = NULL;
   AST_ERB_END_NODE_T* end_node = NULL;
 
-  if (index < array->size) {
+  if (index < hb_array_size(array)) {
     AST_NODE_T* next_node = hb_array_get(array, index);
 
     if (next_node && next_node->type == AST_ERB_CONTENT_NODE) {
@@ -1018,7 +1018,7 @@ static size_t process_control_structure(
     }
   }
 
-  if (index < array->size) {
+  if (index < hb_array_size(array)) {
     AST_NODE_T* potential_end = hb_array_get(array, index);
 
     if (potential_end && potential_end->type == AST_ERB_CONTENT_NODE) {
@@ -1080,7 +1080,7 @@ static size_t process_subsequent_block(
     hb_array_free(&children);
   }
 
-  if (index < array->size) {
+  if (index < hb_array_size(array)) {
     AST_NODE_T* next_node = hb_array_get(array, index);
 
     if (next_node && next_node->type == AST_ERB_CONTENT_NODE) {
@@ -1138,7 +1138,7 @@ static size_t process_block_children(
   analyze_ruby_context_T* context,
   control_type_t parent_type
 ) {
-  while (index < array->size) {
+  while (index < hb_array_size(array)) {
     AST_NODE_T* child = hb_array_get(array, index);
 
     if (!child) { break; }
@@ -1160,7 +1160,7 @@ static size_t process_block_children(
       hb_array_T* temp_array = hb_array_init(1);
       size_t new_index = process_control_structure(node, array, index, temp_array, context, child_type);
 
-      if (temp_array->size > 0) { hb_array_append(children_array, hb_array_first(temp_array)); }
+      if (hb_array_size(temp_array) > 0) { hb_array_append(children_array, hb_array_first(temp_array)); }
 
       hb_array_free(&temp_array);
 
@@ -1176,10 +1176,10 @@ static size_t process_block_children(
 }
 
 hb_array_T* rewrite_node_array(AST_NODE_T* node, hb_array_T* array, analyze_ruby_context_T* context) {
-  hb_array_T* new_array = hb_array_init(array->size);
+  hb_array_T* new_array = hb_array_init(hb_array_size(array));
   size_t index = 0;
 
-  while (index < array->size) {
+  while (index < hb_array_size(array)) {
     AST_NODE_T* item = hb_array_get(array, index);
 
     if (!item) { break; }
@@ -1314,7 +1314,7 @@ static bool detect_invalid_erb_structures(const AST_NODE_T* node, void* data) {
     if (if_node->end_node == NULL) { check_erb_node_for_missing_end(node); }
 
     if (if_node->statements != NULL) {
-      for (size_t i = 0; i < if_node->statements->size; i++) {
+      for (size_t i = 0; i < hb_array_size(if_node->statements); i++) {
         AST_NODE_T* statement = (AST_NODE_T*) hb_array_get(if_node->statements, i);
 
         if (statement != NULL) { herb_visit_node(statement, detect_invalid_erb_structures, context); }
@@ -1346,7 +1346,7 @@ static bool detect_invalid_erb_structures(const AST_NODE_T* node, void* data) {
         const AST_ERB_IF_NODE_T* elsif_node = (const AST_ERB_IF_NODE_T*) subsequent;
 
         if (elsif_node->statements != NULL) {
-          for (size_t i = 0; i < elsif_node->statements->size; i++) {
+          for (size_t i = 0; i < hb_array_size(elsif_node->statements); i++) {
             AST_NODE_T* statement = (AST_NODE_T*) hb_array_get(elsif_node->statements, i);
 
             if (statement != NULL) { herb_visit_node(statement, detect_invalid_erb_structures, context); }
@@ -1358,7 +1358,7 @@ static bool detect_invalid_erb_structures(const AST_NODE_T* node, void* data) {
         const AST_ERB_ELSE_NODE_T* else_node = (const AST_ERB_ELSE_NODE_T*) subsequent;
 
         if (else_node->statements != NULL) {
-          for (size_t i = 0; i < else_node->statements->size; i++) {
+          for (size_t i = 0; i < hb_array_size(else_node->statements); i++) {
             AST_NODE_T* statement = (AST_NODE_T*) hb_array_get(else_node->statements, i);
 
             if (statement != NULL) { herb_visit_node(statement, detect_invalid_erb_structures, context); }

--- a/src/ast_node.c
+++ b/src/ast_node.c
@@ -43,7 +43,7 @@ ast_node_type_T ast_node_type(const AST_NODE_T* node) {
 }
 
 size_t ast_node_errors_count(const AST_NODE_T* node) {
-  return node->errors->size;
+  return hb_array_size(node->errors);
 }
 
 hb_array_T* ast_node_errors(const AST_NODE_T* node) {

--- a/src/extract.c
+++ b/src/extract.c
@@ -12,7 +12,7 @@ void herb_extract_ruby_to_buffer(const char* source, hb_buffer_T* output) {
   bool skip_erb_content = false;
   bool is_comment_tag = false;
 
-  for (size_t i = 0; i < tokens->size; i++) {
+  for (size_t i = 0; i < hb_array_size(tokens); i++) {
     const token_T* token = hb_array_get(tokens, i);
 
     switch (token->type) {
@@ -95,7 +95,7 @@ void herb_extract_ruby_to_buffer(const char* source, hb_buffer_T* output) {
 void herb_extract_html_to_buffer(const char* source, hb_buffer_T* output) {
   hb_array_T* tokens = herb_lex(source);
 
-  for (size_t i = 0; i < tokens->size; i++) {
+  for (size_t i = 0; i < hb_array_size(tokens); i++) {
     const token_T* token = hb_array_get(tokens, i);
 
     switch (token->type) {

--- a/src/herb.c
+++ b/src/herb.c
@@ -58,7 +58,7 @@ HERB_EXPORTED_FUNCTION hb_array_T* herb_lex_file(const char* path) {
 HERB_EXPORTED_FUNCTION void herb_lex_to_buffer(const char* source, hb_buffer_T* output) {
   hb_array_T* tokens = herb_lex(source);
 
-  for (size_t i = 0; i < tokens->size; i++) {
+  for (size_t i = 0; i < hb_array_size(tokens); i++) {
     token_T* token = hb_array_get(tokens, i);
 
     hb_string_T type = token_to_string(token);
@@ -74,7 +74,7 @@ HERB_EXPORTED_FUNCTION void herb_lex_to_buffer(const char* source, hb_buffer_T* 
 HERB_EXPORTED_FUNCTION void herb_free_tokens(hb_array_T** tokens) {
   if (!tokens || !*tokens) { return; }
 
-  for (size_t i = 0; i < (*tokens)->size; i++) {
+  for (size_t i = 0; i < hb_array_size(*tokens); i++) {
     token_T* token = hb_array_get(*tokens, i);
     if (token) { token_free(token); }
   }

--- a/src/include/util/hb_narray.h
+++ b/src/include/util/hb_narray.h
@@ -18,6 +18,7 @@ void hb_narray_init(hb_narray_T* array, size_t item_size, size_t initial_capacit
 void* hb_narray_get(const hb_narray_T* array, size_t index);
 void* hb_narray_first(hb_narray_T* array);
 void* hb_narray_last(hb_narray_T* array);
+size_t hb_narray_size(const hb_narray_T* array);
 
 void hb_narray_append(hb_narray_T* array, void* item);
 void hb_narray_remove(hb_narray_T* array, size_t index);

--- a/src/parser.c
+++ b/src/parser.c
@@ -314,7 +314,7 @@ static AST_HTML_ATTRIBUTE_NAME_NODE_T* parser_parse_html_attribute_name(parser_T
   position_T node_start = { 0 };
   position_T node_end = { 0 };
 
-  if (children->size > 0) {
+  if (hb_array_size(children) > 0) {
     AST_NODE_T* first_child = hb_array_first(children);
     AST_NODE_T* last_child = hb_array_last(children);
 
@@ -1144,7 +1144,7 @@ static void parser_parse_in_data_state(parser_T* parser, hb_array_T* children, h
 static size_t find_matching_close_tag(hb_array_T* nodes, size_t start_idx, hb_string_T tag_name) {
   int depth = 0;
 
-  for (size_t i = start_idx + 1; i < nodes->size; i++) {
+  for (size_t i = start_idx + 1; i < hb_array_size(nodes); i++) {
     AST_NODE_T* node = (AST_NODE_T*) hb_array_get(nodes, i);
     if (node == NULL) { continue; }
 
@@ -1168,9 +1168,9 @@ static size_t find_matching_close_tag(hb_array_T* nodes, size_t start_idx, hb_st
 static hb_array_T* parser_build_elements_from_tags(hb_array_T* nodes, hb_array_T* errors);
 
 static hb_array_T* parser_build_elements_from_tags(hb_array_T* nodes, hb_array_T* errors) {
-  hb_array_T* result = hb_array_init(nodes->size);
+  hb_array_T* result = hb_array_init(hb_array_size(nodes));
 
-  for (size_t index = 0; index < nodes->size; index++) {
+  for (size_t index = 0; index < hb_array_size(nodes); index++) {
     AST_NODE_T* node = (AST_NODE_T*) hb_array_get(nodes, index);
     if (node == NULL) { continue; }
 
@@ -1181,7 +1181,7 @@ static hb_array_T* parser_build_elements_from_tags(hb_array_T* nodes, hb_array_T
       size_t close_index = find_matching_close_tag(nodes, index, tag_name);
 
       if (close_index == (size_t) -1) {
-        if (open_tag->base.errors->size == 0) {
+        if (hb_array_size(open_tag->base.errors) == 0) {
           append_missing_closing_tag_error(
             open_tag->tag_name,
             open_tag->base.location.start,
@@ -1225,7 +1225,7 @@ static hb_array_T* parser_build_elements_from_tags(hb_array_T* nodes, hb_array_T
       AST_HTML_CLOSE_TAG_NODE_T* close_tag = (AST_HTML_CLOSE_TAG_NODE_T*) node;
 
       if (!is_void_element(hb_string(close_tag->tag_name->value))) {
-        if (close_tag->base.errors->size == 0) {
+        if (hb_array_size(close_tag->base.errors) == 0) {
           append_missing_opening_tag_error(
             close_tag->tag_name,
             close_tag->base.location.start,
@@ -1299,19 +1299,19 @@ void herb_parser_deinit(parser_T* parser) {
 }
 
 void match_tags_in_node_array(hb_array_T* nodes, hb_array_T* errors) {
-  if (nodes == NULL || nodes->size == 0) { return; }
+  if (nodes == NULL || hb_array_size(nodes) == 0) { return; }
 
   hb_array_T* processed = parser_build_elements_from_tags(nodes, errors);
 
   nodes->size = 0;
 
-  for (size_t i = 0; i < processed->size; i++) {
+  for (size_t i = 0; i < hb_array_size(processed); i++) {
     hb_array_append(nodes, hb_array_get(processed, i));
   }
 
   hb_array_free(&processed);
 
-  for (size_t i = 0; i < nodes->size; i++) {
+  for (size_t i = 0; i < hb_array_size(nodes); i++) {
     AST_NODE_T* node = (AST_NODE_T*) hb_array_get(nodes, i);
     if (node == NULL) { continue; }
 

--- a/src/parser_helpers.c
+++ b/src/parser_helpers.c
@@ -19,7 +19,7 @@ void parser_push_open_tag(const parser_T* parser, token_T* tag_name) {
 }
 
 bool parser_check_matching_tag(const parser_T* parser, hb_string_T tag_name) {
-  if (parser->open_tags_stack->size == 0) { return false; }
+  if (hb_array_size(parser->open_tags_stack) == 0) { return false; }
 
   token_T* top_token = hb_array_last(parser->open_tags_stack);
   if (top_token == NULL || top_token->value == NULL) { return false; };
@@ -28,7 +28,7 @@ bool parser_check_matching_tag(const parser_T* parser, hb_string_T tag_name) {
 }
 
 token_T* parser_pop_open_tag(const parser_T* parser) {
-  if (parser->open_tags_stack->size == 0) { return NULL; }
+  if (hb_array_size(parser->open_tags_stack) == 0) { return NULL; }
 
   return hb_array_pop(parser->open_tags_stack);
 }
@@ -42,7 +42,7 @@ token_T* parser_pop_open_tag(const parser_T* parser) {
 bool parser_in_svg_context(const parser_T* parser) {
   if (!parser || !parser->open_tags_stack) { return false; }
 
-  size_t stack_size = parser->open_tags_stack->size;
+  size_t stack_size = hb_array_size(parser->open_tags_stack);
 
   for (size_t i = 0; i < stack_size; i++) {
     token_T* tag = (token_T*) hb_array_get(parser->open_tags_stack, i);
@@ -191,7 +191,7 @@ void parser_handle_mismatched_tags(
   const AST_HTML_CLOSE_TAG_NODE_T* close_tag,
   hb_array_T* errors
 ) {
-  if (parser->open_tags_stack->size > 0) {
+  if (hb_array_size(parser->open_tags_stack) > 0) {
     token_T* expected_tag = hb_array_last(parser->open_tags_stack);
     token_T* actual_tag = close_tag->tag_name;
 

--- a/src/pretty_print.c
+++ b/src/pretty_print.c
@@ -113,7 +113,7 @@ void pretty_print_array(
     return;
   }
 
-  if (array->size == 0) {
+  if (hb_array_size(array) == 0) {
     pretty_print_property(name, hb_string("[]"), indent, relative_indent, last_property, buffer);
 
     return;
@@ -124,17 +124,17 @@ void pretty_print_array(
   hb_buffer_append(buffer, "(");
 
   char count[16];
-  sprintf(count, "%zu", array->size);
+  sprintf(count, "%zu", hb_array_size(array));
   hb_buffer_append(buffer, count);
   hb_buffer_append(buffer, ")\n");
 
   if (indent < 20) {
-    for (size_t i = 0; i < array->size; i++) {
+    for (size_t i = 0; i < hb_array_size(array); i++) {
       AST_NODE_T* child = hb_array_get(array, i);
       pretty_print_indent(buffer, indent);
       pretty_print_indent(buffer, relative_indent + 1);
 
-      if (i == array->size - 1) {
+      if (i == hb_array_size(array) - 1) {
         hb_buffer_append(buffer, "└── ");
       } else {
         hb_buffer_append(buffer, "├── ");
@@ -142,7 +142,7 @@ void pretty_print_array(
 
       ast_pretty_print_node(child, indent + 1, relative_indent + 1, buffer);
 
-      if (i != array->size - 1) { pretty_print_newline(indent + 1, relative_indent, buffer); }
+      if (i != hb_array_size(array) - 1) { pretty_print_newline(indent + 1, relative_indent, buffer); }
     }
   }
   hb_buffer_append(buffer, "\n");
@@ -155,7 +155,7 @@ void pretty_print_errors(
   const bool last_property,
   hb_buffer_T* buffer
 ) {
-  if (node->errors != NULL && node->errors->size > 0) {
+  if (hb_array_size(node->errors) > 0) {
     error_pretty_print_array("errors", node->errors, indent, relative_indent, last_property, buffer);
     hb_buffer_append(buffer, "\n");
   }

--- a/src/util/hb_array.c
+++ b/src/util/hb_array.c
@@ -116,6 +116,7 @@ void* hb_array_pop(hb_array_T* array) {
   return last_item;
 }
 
+// TODO: Remove this function once we fully migrate to hb_narray
 size_t hb_array_size(const hb_array_T* array) {
   if (array == NULL) { return 0; }
 

--- a/src/util/hb_narray.c
+++ b/src/util/hb_narray.c
@@ -73,3 +73,9 @@ void hb_narray_deinit(hb_narray_T* array) {
   array->size = 0;
   free(array->items);
 }
+
+size_t hb_narray_size(const hb_narray_T* array) {
+  if (array == NULL) { return 0; }
+
+  return array->size;
+}

--- a/templates/ext/herb/error_helpers.c.erb
+++ b/templates/ext/herb/error_helpers.c.erb
@@ -71,7 +71,7 @@ VALUE rb_errors_array_from_c_array(hb_array_T* array) {
   VALUE rb_array = rb_ary_new();
 
   if (array) {
-    for (size_t i = 0; i < array->size; i++) {
+    for (size_t i = 0; i < hb_array_size(array); i++) {
       ERROR_T* child_node = (ERROR_T*) hb_array_get(array, i);
 
       if (child_node) {

--- a/templates/ext/herb/nodes.c.erb
+++ b/templates/ext/herb/nodes.c.erb
@@ -81,7 +81,7 @@ static VALUE rb_nodes_array_from_c_array(hb_array_T* array) {
   VALUE rb_array = rb_ary_new();
 
   if (array) {
-    for (size_t i = 0; i < array->size; i++) {
+    for (size_t i = 0; i < hb_array_size(array); i++) {
       AST_NODE_T* child_node = (AST_NODE_T*) hb_array_get(array, i);
 
       if (child_node) {

--- a/templates/java/error_helpers.c.erb
+++ b/templates/java/error_helpers.c.erb
@@ -46,7 +46,7 @@ jobject ErrorsArrayFromCArray(JNIEnv* env, hb_array_T* array) {
   jobject javaList = (*env)->NewObject(env, arrayListClass, arrayListConstructor, 0);
 
   if (array) {
-    for (size_t i = 0; i < array->size; i++) {
+    for (size_t i = 0; i < hb_array_size(array); i++) {
       ERROR_T* error = (ERROR_T*) hb_array_get(array, i);
 
       if (error) {

--- a/templates/java/nodes.c.erb
+++ b/templates/java/nodes.c.erb
@@ -75,9 +75,9 @@ jobject NodesArrayFromCArray(JNIEnv* env, hb_array_T* array) {
     return (*env)->NewObject(env, arrayListClass, arrayListConstructor, 0);
   }
 
-  jobject javaList = (*env)->NewObject(env, arrayListClass, arrayListConstructor, (jint) array->size);
+  jobject javaList = (*env)->NewObject(env, arrayListClass, arrayListConstructor, (jint) hb_array_size(array));
 
-  for (size_t i = 0; i < array->size; i++) {
+  for (size_t i = 0; i < hb_array_size(array); i++) {
     AST_NODE_T* child_node = (AST_NODE_T*) hb_array_get(array, i);
 
     if (child_node) {

--- a/templates/javascript/packages/node/extension/error_helpers.cpp.erb
+++ b/templates/javascript/packages/node/extension/error_helpers.cpp.erb
@@ -80,7 +80,7 @@ napi_value ErrorsArrayFromCArray(napi_env env, hb_array_T* array) {
   napi_create_array(env, &result);
 
   if (array) {
-    for (size_t i = 0; i < array->size; i++) {
+    for (size_t i = 0; i < hb_array_size(array); i++) {
       ERROR_T* error = (ERROR_T*) hb_array_get(array, i);
       if (error) {
         napi_value js_error = ErrorFromCStruct(env, error);

--- a/templates/javascript/packages/node/extension/nodes.cpp.erb
+++ b/templates/javascript/packages/node/extension/nodes.cpp.erb
@@ -78,7 +78,7 @@ napi_value NodesArrayFromCArray(napi_env env, hb_array_T* array) {
   napi_create_array(env, &result);
 
   if (array) {
-    for (size_t i = 0; i < array->size; i++) {
+    for (size_t i = 0; i < hb_array_size(array); i++) {
       AST_NODE_T* child_node = (AST_NODE_T*) hb_array_get(array, i);
       if (child_node) {
         napi_value js_child = NodeFromCStruct(env, child_node);

--- a/templates/rust/src/ast/nodes.rs.erb
+++ b/templates/rust/src/ast/nodes.rs.erb
@@ -51,7 +51,7 @@ unsafe fn convert_errors(errors_array: *mut hb_array_T) -> Vec<AnyError> {
     return Vec::new();
   }
 
-  let count = (*errors_array).size;
+  let count = hb_array_size(errors_array);
   let mut errors = Vec::with_capacity(count);
 
   for index in 0..count {
@@ -110,7 +110,7 @@ unsafe fn convert_children(children_array: *mut hb_array_T) -> Vec<AnyNode> {
     return Vec::new();
   }
 
-  let count = (*children_array).size;
+  let count = hb_array_size(children_array);
   let mut children = Vec::with_capacity(count);
 
   for index in 0..count {

--- a/templates/src/ast_nodes.c.erb
+++ b/templates/src/ast_nodes.c.erb
@@ -27,11 +27,7 @@
   <%- when Herb::Template::NodeField -%>
   <%= node.human %>-><%= field.name %> = <%= field.name %>;
   <%- when Herb::Template::ArrayField -%>
-  if (<%= field.name %> == NULL) {
-    <%= node.human %>-><%= field.name %> = hb_array_init(8);
-  } else {
-    <%= node.human %>-><%= field.name %> = <%= field.name %>;
-  }
+  <%= node.human %>-><%= field.name %> = <%= field.name %>;
   <%- when Herb::Template::BooleanField -%>
   <%= node.human %>-><%= field.name %> = <%= field.name %>;
   <%- when Herb::Template::ElementSourceField -%>
@@ -77,7 +73,7 @@ void ast_free_base_node(AST_NODE_T* node) {
   if (node == NULL) { return; }
 
   if (node->errors) {
-    for (size_t i = 0; i < node->errors->size; i++) {
+    for (size_t i = 0; i < hb_array_size(node->errors); i++) {
       ERROR_T* child = hb_array_get(node->errors, i);
       if (child != NULL) { error_free(child); }
     }
@@ -103,7 +99,7 @@ static void ast_free_<%= node.human %>(<%= node.struct_type %>* <%= node.human %
   ast_node_free((AST_NODE_T*) <%= node.human %>-><%= field.name %>);
   <%- when Herb::Template::ArrayField -%>
   if (<%= node.human %>-><%= field.name %> != NULL) {
-    for (size_t i = 0; i < <%= node.human %>-><%= field.name %>->size; i++) {
+    for (size_t i = 0; i < hb_array_size(<%= node.human %>-><%= field.name %>); i++) {
       AST_NODE_T* child = hb_array_get(<%= node.human %>-><%= field.name %>, i);
       if (child) { ast_node_free(child); }
     }

--- a/templates/src/errors.c.erb
+++ b/templates/src/errors.c.erb
@@ -167,7 +167,7 @@ void error_pretty_print_array(
     return;
   }
 
-  if (array->size == 0) {
+  if (hb_array_size(array) == 0) {
     pretty_print_property(hb_string(name), hb_string("[]"), indent, relative_indent, last_property, buffer);
 
     return;
@@ -178,17 +178,17 @@ void error_pretty_print_array(
   hb_buffer_append(buffer, "(");
 
   char count[16];
-  sprintf(count, "%zu", array->size);
+  sprintf(count, "%zu", hb_array_size(array));
   hb_buffer_append(buffer, count);
   hb_buffer_append(buffer, ")\n");
 
   if (indent < 20) {
-    for (size_t i = 0; i < array->size; i++) {
+    for (size_t i = 0; i < hb_array_size(array); i++) {
       ERROR_T* child = hb_array_get(array, i);
       pretty_print_indent(buffer, indent);
       pretty_print_indent(buffer, relative_indent + 1);
 
-      if (i == array->size - 1) {
+      if (i == hb_array_size(array) - 1) {
         hb_buffer_append(buffer, "└── ");
       } else {
         hb_buffer_append(buffer, "├── ");
@@ -196,7 +196,7 @@ void error_pretty_print_array(
 
       error_pretty_print(child, indent + 1, relative_indent + 1, buffer);
 
-      if (i != array->size - 1) { pretty_print_newline(indent + 1, relative_indent, buffer); }
+      if (i != hb_array_size(array) - 1) { pretty_print_newline(indent + 1, relative_indent, buffer); }
     }
   }
 }

--- a/templates/src/visitor.c.erb
+++ b/templates/src/visitor.c.erb
@@ -31,7 +31,7 @@ void herb_visit_child_nodes(const AST_NODE_T *node, bool (*visitor)(const AST_NO
 
       <%- when Herb::Template::ArrayField -%>
       if (<%= node.human %>-><%= field.name %> != NULL) {
-        for (size_t index = 0; index < <%= node.human %>-><%= field.name %>->size; index++) {
+        for (size_t index = 0; index < hb_array_size(<%= node.human %>-><%= field.name %>); index++) {
           herb_visit_node(hb_array_get(<%= node.human %>-><%= field.name %>, index), visitor, data);
         }
       }

--- a/templates/wasm/error_helpers.cpp.erb
+++ b/templates/wasm/error_helpers.cpp.erb
@@ -66,7 +66,7 @@ val ErrorsArrayFromCArray(hb_array_T* array) {
   val result = Array.new_();
 
   if (array) {
-    for (size_t i = 0; i < array->size; i++) {
+    for (size_t i = 0; i < hb_array_size(array); i++) {
       ERROR_T* error = (ERROR_T*)hb_array_get(array, i);
       if (error) {
         result.call<void>("push", ErrorFromCStruct(error));

--- a/templates/wasm/nodes.cpp.erb
+++ b/templates/wasm/nodes.cpp.erb
@@ -67,7 +67,7 @@ val NodesArrayFromCArray(hb_array_T* array) {
 
   val jsArray = val::array();
 
-  for (size_t i = 0; i < array->size; i++) {
+  for (size_t i = 0; i < hb_array_size(array); i++) {
     AST_NODE_T* child_node = (AST_NODE_T*) hb_array_get(array, i);
 
     if (child_node) {

--- a/test/c/test_hb_array.c
+++ b/test/c/test_hb_array.c
@@ -90,6 +90,23 @@ TEST(test_hb_array_free)
   ck_assert_ptr_null(array);
 END
 
+// Test hb_array_size with NULL safety
+TEST(test_hb_array_size)
+  ck_assert_int_eq(hb_array_size(NULL), 0);
+
+  hb_array_T* array = hb_array_init(5);
+  ck_assert_int_eq(hb_array_size(array), 0);
+
+  size_t item1 = 42, item2 = 99;
+  hb_array_append(array, &item1);
+  ck_assert_int_eq(hb_array_size(array), 1);
+
+  hb_array_append(array, &item2);
+  ck_assert_int_eq(hb_array_size(array), 2);
+
+  hb_array_free(&array);
+END
+
 // Register test cases
 TCase *hb_array_tests(void) {
   TCase *array = tcase_create("Herb Array");
@@ -100,6 +117,7 @@ TCase *hb_array_tests(void) {
   tcase_add_test(array, test_hb_array_set);
   tcase_add_test(array, test_hb_array_remove);
   tcase_add_test(array, test_hb_array_free);
+  tcase_add_test(array, test_hb_array_size);
 
   return array;
 }

--- a/test/c/test_hb_narray.c
+++ b/test/c/test_hb_narray.c
@@ -138,6 +138,24 @@ TEST(test_hb_narray_remove)
   hb_narray_deinit(&array);
 END
 
+// Test hb_narray_size with NULL safety
+TEST(test_hb_narray_size)
+  ck_assert_int_eq(hb_narray_size(NULL), 0);
+
+  hb_narray_T array;
+  hb_narray_init(&array, sizeof(uint64_t), 5);
+  ck_assert_int_eq(hb_narray_size(&array), 0);
+
+  uint64_t item1 = 42, item2 = 99;
+  hb_narray_append(&array, &item1);
+  ck_assert_int_eq(hb_narray_size(&array), 1);
+
+  hb_narray_append(&array, &item2);
+  ck_assert_int_eq(hb_narray_size(&array), 2);
+
+  hb_narray_deinit(&array);
+END
+
 TCase *hb_narray_tests(void) {
   TCase *buffer = tcase_create("Herb (New) Array");
 
@@ -147,6 +165,7 @@ TCase *hb_narray_tests(void) {
   tcase_add_test(buffer, test_hb_narray_first_last);
   tcase_add_test(buffer, test_hb_narray_stack_behavior);
   tcase_add_test(buffer, test_hb_narray_remove);
+  tcase_add_test(buffer, test_hb_narray_size);
 
   return buffer;
 }

--- a/wasm/extension_helpers.cpp
+++ b/wasm/extension_helpers.cpp
@@ -99,7 +99,7 @@ val CreateLexResult(hb_array_T* tokens, const std::string& source) {
   val warningsArray = Array.new_();
 
   if (tokens) {
-    for (size_t i = 0; i < tokens->size; i++) {
+    for (size_t i = 0; i < hb_array_size(tokens); i++) {
       token_T* token = (token_T*)hb_array_get(tokens, i);
       if (token) {
         tokensArray.call<void>("push", CreateToken(token));


### PR DESCRIPTION
This pull request reverts #885 which caused memory issues in WebAssembly by always allocating arrays, even when `NULL` was passed.

The `hb_array_size()` function safely returns `0` for `NULL` arrays, eliminating the need for allocating arrays for all AST Nodes. This was causing the `"Cannot enlarge memory"` errors in WASM builds, as seen in #1016.

This pull request brings back `hb_array_size()` in places where we previously accessed `array->size` directly. With that, we don't need to allocate `array_init(8)` just so we can assume we always have a `size`. 

The problem is, even if we would use `array_init(0)` it would allocate memory that we are not going to need. So for now, I think it's better to be avoid allocating arrays and use `hb_array_size()` until we have fully integrated the new array implementation from #782. (/cc @timkaechele).

I also added a `hb_narray_size()` for API consistency that should help with the future array migration.

Resolves #1016
(Might also resolve https://github.com/marcoroth/herb/issues/993)