### PR TITLE
WASM: Upgrade to C++17 for Embind compatibility

### DIFF
--- a/wasm/Makefile
+++ b/wasm/Makefile
@@ -49,7 +49,7 @@ $(OBJ_DIR)/herb/%.o: ../src/%.c | $(OBJ_DIR)
 
 $(OBJ_DIR)/%.o: %.cpp | $(OBJ_DIR)
 	@mkdir -p $(@D)
-	em++ -std=c++11 -c $< -o $@ $(CFLAGS)
+	em++ -std=c++17 -c $< -o $@ $(CFLAGS)
 
 $(OBJ_DIR)/prism/%.o: $(PRISM_PATH)/src/%.c | $(OBJ_DIR)
 	@mkdir -p $(@D)


### PR DESCRIPTION
This pull request updates the `-std` argument to `em++` from `c++11` to `-std=c++17` in `wasm/Makefile`.

Starting with Emscripten 4.0.20, Embind requires C++17 or newer. Building with older Emscripten versions (< 4.0.20) still works since C++17 should be backward compatible with C++11.

See: https://github.com/emscripten-core/emscripten/blob/main/ChangeLog.md#4020---111825

Related https://github.com/emscripten-core/emscripten/issues/24850
Related https://github.com/emscripten-core/emscripten/pull/25773

Resolves https://github.com/marcoroth/herb/issues/1015