### PR TITLE
Add `irb` to `Gemfile`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,3 +27,5 @@ gem "steep", "~> 1.10"
 # You can add tsort to your Gemfile or gemspec to silence this warning.
 # 🎉 Generated 0 RBS files under sig/
 gem "tsort", "~> 0.2.0"
+
+gem "irb", "~> 1.16"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,6 +40,7 @@ GEM
     connection_pool (3.0.2)
     crass (1.0.6)
     csv (3.3.5)
+    date (3.5.1)
     difftastic (0.8.0-aarch64-linux)
       pretty_please
     difftastic (0.8.0-arm64-darwin)
@@ -52,6 +53,7 @@ GEM
     dispersion (0.2.0)
       prism
     drb (2.2.3)
+    erb (6.0.1)
     erubi (1.13.1)
     ffi (1.17.3-aarch64-linux-gnu)
     ffi (1.17.3-aarch64-linux-musl)
@@ -63,6 +65,10 @@ GEM
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     io-console (0.8.2)
+    irb (1.16.0)
+      pp (>= 0.6.0)
+      rdoc (>= 4.0.0)
+      reline (>= 0.4.2)
     json (2.18.0)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
@@ -96,8 +102,14 @@ GEM
     parser (3.3.10.0)
       ast (~> 2.4.1)
       racc
+    pp (0.6.3)
+      prettyprint
     pretty_please (0.2.0)
       dispersion (~> 0.2)
+    prettyprint (0.2.0)
+    psych (5.3.1)
+      date
+      stringio
     racc (1.8.1)
     rails-dom-testing (2.3.0)
       activesupport (>= 5.0.0)
@@ -119,6 +131,10 @@ GEM
     rbs-inline (0.12.0)
       prism (>= 0.29)
       rbs (>= 3.8.0)
+    rdoc (7.0.3)
+      erb
+      psych (>= 4.0.0)
+      tsort
     regexp_parser (2.11.3)
     reline (0.6.3)
       io-console (~> 0.5)
@@ -160,6 +176,7 @@ GEM
       strscan (>= 1.0.0)
       terminal-table (>= 2, < 5)
       uri (>= 0.12.0)
+    stringio (3.2.0)
     strscan (3.1.6)
     terminal-table (4.0.0)
       unicode-display_width (>= 1.1.1, < 4)
@@ -187,6 +204,7 @@ DEPENDENCIES
   digest (~> 3.2)
   erubi
   herb!
+  irb (~> 1.16)
   lz_string
   maxitest (~> 6.0)
   minitest-difftastic (~> 0.2)


### PR DESCRIPTION
fixes #1034 .

Ruby 4.0 no longer includes `irb` by default, which causes `bundle console` to fail.