### PR TITLE
Linter: Add support for `--fix-unsafely` flag

### DIFF
--- a/javascript/packages/linter/README.md
+++ b/javascript/packages/linter/README.md
@@ -214,6 +214,32 @@ linter:
 
 The CLI flag takes precedence over the configuration file.
 
+**Autofix:**
+
+Automatically fix auto-correctable offenses:
+```bash
+npx @herb-tools/linter --fix
+```
+
+Also apply unsafe auto-fixes (implies `--fix`):
+```bash
+npx @herb-tools/linter --fix-unsafely
+```
+
+The `--fix` flag automatically corrects offenses that have safe, deterministic fixes (like formatting issues). The `--fix-unsafely` flag additionally applies fixes that may change code behavior or require manual review after application.
+
+**Safe fixes** (`--fix`):
+- Formatting corrections (whitespace, quotes, trailing newlines)
+- Syntax normalization (tag casing, attribute formatting)
+
+**Unsafe fixes** (`--fix-unsafely`):
+- Changes that may alter runtime behavior
+- Insertions that require manual completion (e.g., adding empty strict locals declarations)
+
+::: warning
+Always review changes made by `--fix-unsafely` before committing. These fixes are intentionally separated because they may require additional manual adjustments.
+:::
+
 **Help and Version:**
 ```bash
 # Show help

--- a/javascript/packages/linter/docs/rules/erb-strict-locals-required.md
+++ b/javascript/packages/linter/docs/rules/erb-strict-locals-required.md
@@ -36,6 +36,26 @@ linter:
       enabled: true
 ```
 
+## Autofix
+
+This rule supports **unsafe autofix** via `--fix-unsafely`. When applied, it inserts an empty strict locals declaration at the top of the file:
+
+```erb
+<%# locals: () %>
+```
+
+This is considered "unsafe" because:
+- It changes the partial's behavior (strict mode will now error on undeclared locals)
+- You may need to manually add the actual local variables your partial uses
+
+To apply the autofix:
+
+```bash
+herb-lint --fix-unsafely _partial.html.erb
+```
+
+After the autofix runs, review the file and update the locals declaration to include any variables your partial expects.
+
 ## Examples
 
 ### ✅ Good

--- a/javascript/packages/linter/src/cli.ts
+++ b/javascript/packages/linter/src/cli.ts
@@ -135,7 +135,7 @@ export class CLI {
     const startTime = Date.now()
     const startDate = new Date()
 
-    let { patterns, configFile, formatOption, showTiming, theme, wrapLines, truncateLines, useGitHubActions, fix, ignoreDisableComments, force, init, loadCustomRules, failLevel } = this.argumentParser.parse(process.argv)
+    let { patterns, configFile, formatOption, showTiming, theme, wrapLines, truncateLines, useGitHubActions, fix, fixUnsafe, ignoreDisableComments, force, init, loadCustomRules, failLevel } = this.argumentParser.parse(process.argv)
 
     this.determineProjectPath(patterns)
 
@@ -239,6 +239,7 @@ export class CLI {
         projectPath: this.projectPath,
         pattern: patterns.join(' '),
         fix,
+        fixUnsafe,
         ignoreDisableComments,
         linterConfig,
         config: processingConfig,

--- a/javascript/packages/linter/src/cli/argument-parser.ts
+++ b/javascript/packages/linter/src/cli/argument-parser.ts
@@ -21,6 +21,7 @@ export interface ParsedArguments {
   truncateLines: boolean
   useGitHubActions: boolean
   fix: boolean
+  fixUnsafe: boolean
   ignoreDisableComments: boolean
   force: boolean
   init: boolean
@@ -43,6 +44,7 @@ export class ArgumentParser {
       -c, --config-file <path>      explicitly specify path to .herb.yml config file
       --force                       force linting even if disabled in .herb.yml
       --fix                         automatically fix auto-correctable offenses
+      --fix-unsafely                also apply unsafe auto-fixes (implies --fix)
       --ignore-disable-comments     report offenses even when suppressed with <%# herb:disable %> comments
       --fail-level <severity>       exit with error code when diagnostics of this severity or higher are present (error|warning|info|hint) [default: error]
       --format                      output format (simple|detailed|json) [default: detailed]
@@ -68,6 +70,7 @@ export class ArgumentParser {
         "config-file": { type: "string", short: "c" },
         force: { type: "boolean" },
         fix: { type: "boolean" },
+        "fix-unsafely": { type: "boolean" },
         "ignore-disable-comments": { type: "boolean" },
         "fail-level": { type: "string" },
         format: { type: "string" },
@@ -141,7 +144,8 @@ export class ArgumentParser {
 
     const theme = values.theme || DEFAULT_THEME
     const patterns = this.getFilePatterns(positionals)
-    const fix = values.fix || false
+    const fixUnsafe = values["fix-unsafely"] || false
+    const fix = values.fix || fixUnsafe  // --fix-unsafely implies --fix
     const force = !!values.force
     const ignoreDisableComments = values["ignore-disable-comments"] || false
     const configFile = values["config-file"]
@@ -159,7 +163,7 @@ export class ArgumentParser {
       }
     }
 
-    return { patterns, configFile, formatOption, showTiming, theme, wrapLines, truncateLines, useGitHubActions, fix, ignoreDisableComments, force, init, loadCustomRules, failLevel }
+    return { patterns, configFile, formatOption, showTiming, theme, wrapLines, truncateLines, useGitHubActions, fix, fixUnsafe, ignoreDisableComments, force, init, loadCustomRules, failLevel }
   }
 
   private getFilePatterns(positionals: string[]): string[] {

--- a/javascript/packages/linter/src/cli/file-processor.ts
+++ b/javascript/packages/linter/src/cli/file-processor.ts
@@ -22,6 +22,7 @@ export interface ProcessingContext {
   projectPath?: string
   pattern?: string
   fix?: boolean
+  fixUnsafe?: boolean
   ignoreDisableComments?: boolean
   linterConfig?: HerbConfigOptions['linter']
   config?: Config
@@ -138,7 +139,7 @@ export class FileProcessor {
         const autofixResult = this.linter.autofix(content, {
           fileName: filename,
           ignoreDisableComments: context?.ignoreDisableComments
-        })
+        }, undefined, { includeUnsafe: context?.fixUnsafe })
 
         if (autofixResult.fixed.length > 0) {
           writeFileSync(filePath, autofixResult.source, "utf-8")

--- a/javascript/packages/linter/src/linter.ts
+++ b/javascript/packages/linter/src/linter.ts
@@ -459,9 +459,12 @@ export class Linter {
    * @param source - The source code to fix
    * @param context - Optional context for linting (e.g., fileName)
    * @param offensesToFix - Optional array of specific offenses to fix. If not provided, all fixable offenses will be fixed.
+   * @param options - Options for autofix behavior
+   * @param options.includeUnsafe - If true, also apply unsafe fixes (rules with unsafeAutocorrectable = true)
    * @returns AutofixResult containing the corrected source and lists of fixed/unfixed offenses
    */
-  autofix(source: string, context?: Partial<LintContext>, offensesToFix?: LintOffense[]): AutofixResult {
+  autofix(source: string, context?: Partial<LintContext>, offensesToFix?: LintOffense[], options?: { includeUnsafe?: boolean }): AutofixResult {
+    const includeUnsafe = options?.includeUnsafe ?? false
     const lintResult = offensesToFix ? { offenses: offensesToFix } : this.lint(source, context)
 
     const parserOffenses: LintOffense[] = []
@@ -503,8 +506,15 @@ export class Linter {
         }
 
         const rule = new RuleClass() as ParserRule
+        const isUnsafe = (RuleClass as any).unsafeAutocorrectable === true
 
         if (!rule.autofix) {
+          unfixed.push(offense)
+
+          continue
+        }
+
+        if (isUnsafe && !includeUnsafe) {
           unfixed.push(offense)
 
           continue
@@ -562,8 +572,14 @@ export class Linter {
         }
 
         const rule = new RuleClass() as SourceRule
+        const isUnsafe = (RuleClass as any).unsafeAutocorrectable === true
 
         if (!rule.autofix) {
+          unfixed.push(offense)
+          continue
+        }
+
+        if (isUnsafe && !includeUnsafe) {
           unfixed.push(offense)
           continue
         }

--- a/javascript/packages/linter/src/rules/erb-strict-locals-required.ts
+++ b/javascript/packages/linter/src/rules/erb-strict-locals-required.ts
@@ -4,7 +4,7 @@ import { BaseSourceRuleVisitor } from "./rule-utils.js"
 
 import { isPartialFile } from "./file-utils.js"
 
-import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types.js"
+import type { UnboundLintOffense, LintOffense, LintContext, FullRuleConfig } from "../types.js"
 
 function hasStrictLocals(source: string): boolean {
   return source.includes("<%# locals:") || source.includes("<%#locals:")
@@ -28,6 +28,7 @@ class ERBStrictLocalsRequiredVisitor extends BaseSourceRuleVisitor {
 }
 
 export class ERBStrictLocalsRequiredRule extends SourceRule {
+  static unsafeAutocorrectable = true
   name = "erb-strict-locals-required"
 
   get defaultConfig(): FullRuleConfig {
@@ -43,5 +44,9 @@ export class ERBStrictLocalsRequiredRule extends SourceRule {
     visitor.visit(source)
 
     return visitor.offenses
+  }
+
+  autofix(_offense: LintOffense, source: string, _context?: Partial<LintContext>): string | null {
+    return `<%# locals: () %>\n\n${source}`
   }
 }

--- a/javascript/packages/linter/src/types.ts
+++ b/javascript/packages/linter/src/types.ts
@@ -85,6 +85,8 @@ export abstract class ParserRule<TAutofixContext extends BaseAutofixContext = Ba
   static type = "parser" as const
   /** Indicates whether this rule supports autofix. Defaults to false. */
   static autocorrectable = false
+  /** Indicates whether this rule supports unsafe autofix (requires --fix-unsafely). Defaults to false. */
+  static unsafeAutocorrectable = false
   abstract name: string
 
   get defaultConfig(): FullRuleConfig {
@@ -119,6 +121,8 @@ export abstract class LexerRule<TAutofixContext extends BaseAutofixContext = Bas
   static type = "lexer" as const
   /** Indicates whether this rule supports autofix. Defaults to false. */
   static autocorrectable = false
+  /** Indicates whether this rule supports unsafe autofix (requires --fix-unsafely). Defaults to false. */
+  static unsafeAutocorrectable = false
   abstract name: string
 
   get defaultConfig(): FullRuleConfig {
@@ -176,6 +180,8 @@ export abstract class SourceRule<TAutofixContext extends BaseAutofixContext = Ba
   static type = "source" as const
   /** Indicates whether this rule supports autofix. Defaults to false. */
   static autocorrectable = false
+  /** Indicates whether this rule supports unsafe autofix (requires --fix-unsafely). Defaults to false. */
+  static unsafeAutocorrectable = false
   abstract name: string
 
   get defaultConfig(): FullRuleConfig {

--- a/javascript/packages/linter/test/autofix/erb-strict-locals-required.autofix.test.ts
+++ b/javascript/packages/linter/test/autofix/erb-strict-locals-required.autofix.test.ts
@@ -1,0 +1,76 @@
+import dedent from "dedent"
+import { describe, test, expect, beforeAll } from "vitest"
+import { Herb } from "@herb-tools/node-wasm"
+import { Linter } from "../../src/linter.js"
+import { ERBStrictLocalsRequiredRule } from "../../src/rules/erb-strict-locals-required.js"
+
+describe("erb-strict-locals-required autofix", () => {
+  beforeAll(async () => {
+    await Herb.load()
+  })
+
+  test("does not apply unsafe fix by default", () => {
+    const input = '<div>Content</div>'
+
+    const linter = new Linter(Herb, [ERBStrictLocalsRequiredRule])
+    const result = linter.autofix(input, { fileName: '_partial.html.erb' })
+
+    expect(result.source).toBe(input)
+    expect(result.fixed).toHaveLength(0)
+    expect(result.unfixed).toHaveLength(1)
+  })
+
+  test("adds empty strict locals declaration with --fix-unsafely", () => {
+    const input = '<div>Content</div>'
+    const expected = '<%# locals: () %>\n\n<div>Content</div>'
+
+    const linter = new Linter(Herb, [ERBStrictLocalsRequiredRule])
+    const result = linter.autofix(input, { fileName: '_partial.html.erb' }, undefined, { includeUnsafe: true })
+
+    expect(result.source).toBe(expected)
+    expect(result.fixed).toHaveLength(1)
+    expect(result.unfixed).toHaveLength(0)
+  })
+
+  test("does not modify files that already have strict locals", () => {
+    const input = dedent`
+      <%# locals: (user:) %>
+      <div><%= user.name %></div>
+    `
+
+    const linter = new Linter(Herb, [ERBStrictLocalsRequiredRule])
+    const result = linter.autofix(input, { fileName: '_partial.html.erb' }, undefined, { includeUnsafe: true })
+
+    expect(result.source).toBe(input)
+    expect(result.fixed).toHaveLength(0)
+    expect(result.unfixed).toHaveLength(0)
+  })
+
+  test("does not modify non-partial files", () => {
+    const input = '<div>Content</div>'
+
+    const linter = new Linter(Herb, [ERBStrictLocalsRequiredRule])
+    const result = linter.autofix(input, { fileName: 'show.html.erb' }, undefined, { includeUnsafe: true })
+
+    expect(result.source).toBe(input)
+    expect(result.fixed).toHaveLength(0)
+    expect(result.unfixed).toHaveLength(0)
+  })
+
+  test("handles multi-line files", () => {
+    const input = dedent`
+      <div class="card">
+        <h2>Title</h2>
+        <p>Content</p>
+      </div>
+    `
+
+    const expected = `<%# locals: () %>\n\n${input}`
+
+    const linter = new Linter(Herb, [ERBStrictLocalsRequiredRule])
+    const result = linter.autofix(input, { fileName: '_card.html.erb' }, undefined, { includeUnsafe: true })
+
+    expect(result.source).toBe(expected)
+    expect(result.fixed).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
This pull request adds a new `--fix-unsafely` flag for the linter CLI and for rules to declare that they are unsafe to auto-fix. 

Additionally, this introduces an autofix action for the `erb-strict-locals-required` rule (implemented in #1070) which is being marked as unsafe to auto-fix, since adding the `<%# locals: () %>` (without adding the proper locals) might break the signature of some partials.

https://github.com/user-attachments/assets/2608c0c2-24a4-4c6b-9453-40eb214f9512


