### PR TITLE
WASM: Build Optimizations

### DIFF
--- a/wasm/Makefile
+++ b/wasm/Makefile
@@ -7,7 +7,7 @@ NODE_BUILD_DIR = ../javascript/packages/node-wasm/build/
 NODE_WASM_OUTPUT = $(NODE_BUILD_DIR)libherb.js
 
 CPP_SOURCES = $(wildcard *.cpp)
-C_SOURCES = $(filter-out ../src/main.c, $(wildcard ../src/*.c)) $(wildcard ../src/**/*.c)
+C_SOURCES = $(filter-out ../src/main.c ../src/ruby_parser.c, $(wildcard ../src/*.c)) $(wildcard ../src/**/*.c)
 
 PRISM_PATH = $(shell cd .. && bundle show prism)
 PRISM_MAIN_SOURCES = $(wildcard $(PRISM_PATH)/src/*.c)
@@ -26,8 +26,11 @@ INCLUDE_DIR = ../include
 PRISM_INCLUDE = $(PRISM_PATH)/include
 PRISM_SRC = $(PRISM_PATH)/src
 PRISM_UTIL = $(PRISM_PATH)/src/util
+PRISM_EXCLUDE_FLAGS = -DPRISM_EXCLUDE_PRETTYPRINT -DPRISM_EXCLUDE_JSON -DPRISM_EXCLUDE_PACK
 
-CFLAGS = -I$(INCLUDE_DIR) -I$(PRISM_INCLUDE) -I$(PRISM_SRC) -I$(PRISM_UTIL) -DPRISM_STATIC=1 -DPRISM_EXPORT_SYMBOLS=static
+OPT_FLAGS = -Oz -g0 -flto -fdata-sections -ffunction-sections
+
+CFLAGS = -I$(INCLUDE_DIR) -I$(PRISM_INCLUDE) -I$(PRISM_SRC) -I$(PRISM_UTIL) -DPRISM_STATIC=1 -DPRISM_EXPORT_SYMBOLS=static $(PRISM_EXCLUDE_FLAGS) $(OPT_FLAGS)
 WASM_FLAGS = -s WASM=1 \
              -s SINGLE_FILE=1 \
              -s EXPORT_ES6=1 \
@@ -35,6 +38,7 @@ WASM_FLAGS = -s WASM=1 \
              -s EXPORT_NAME="Herb" \
              -s ALLOW_MEMORY_GROWTH=1 \
              -s ERROR_ON_UNDEFINED_SYMBOLS=0 \
+             -flto \
              --bind
 
 all: $(BROWSER_WASM_OUTPUT) $(NODE_WASM_OUTPUT)


### PR DESCRIPTION
This pull request applies size optimizations to the WebAssembly build, inspired by https://github.com/ruby/prism/pull/3824.

The WASM bindings don't use Prism's prettyprint, JSON serialization, or pack parsing features, so we can exclude these features by defining `PRISM_EXCLUDE_PRETTYPRINT`, `PRISM_EXCLUDE_JSON`, and `PRISM_EXCLUDE_PACK`.

Added `-Oz` (optimize for size), `-g0` (strip debug info), `-flto` (link-time optimization), and `-fdata-sections -ffunction-sections` (enable dead code elimination) to produce smaller output.

Excluded `ruby_parser.c` from the WASM build since it's only used for CLI debugging.

**Results**

|  Build  | Before | After |  Reduction  |
| --- | --- | --- | --- |
| Browser | 905K   | 365K  | -540K (~60%) |
| Node | 907K   | 365K  | -542K (~60%) |


<details>
<summary>Details</summary>

**Before:**
```
ls -lh javascript/packages/browser/build/libherb.js javascript/packages/node-wasm/build/libherb.js
-rw-r--r--@ 1 marcoroth  staff   905K Jan 17 11:17 javascript/packages/browser/build/libherb.js
-rw-r--r--@ 1 marcoroth  staff   907K Jan 17 11:17 javascript/packages/node-wasm/build/libherb.js
```

**After:**
```
ls -lh javascript/packages/browser/build/libherb.js javascript/packages/node-wasm/build/libherb.js
-rw-r--r--@ 1 marcoroth  staff   365K Jan 17 11:18 javascript/packages/browser/build/libherb.js
-rw-r--r--@ 1 marcoroth  staff   365K Jan 17 11:18 javascript/packages/node-wasm/build/libherb.js
```

</details>