### PR TITLE
Parser: Prioritize blocks over `yield` in control flow detection

### DIFF
--- a/test/analyze/block_test.rb
+++ b/test/analyze/block_test.rb
@@ -200,5 +200,14 @@ module Analyze
         <% content = capture { yield } if block_given? %>
       HTML
     end
+
+    # https://github.com/marcoroth/herb/issues/1037
+    test "yield with fallback block" do
+      assert_parsed_snapshot(<<~HTML)
+        <%= yield(:sidebar).presence || capture do %>
+          default sidebar
+        <% end %>
+      HTML
+    end
   end
 end

--- a/test/snapshots/analyze/block_test/test_0024_yield_with_fallback_block_c429db364e7adb4c2132090dd601c906.txt
+++ b/test/snapshots/analyze/block_test/test_0024_yield_with_fallback_block_c429db364e7adb4c2132090dd601c906.txt
@@ -1,0 +1,26 @@
+---
+source: "Analyze::BlockTest#test_0024_yield with fallback block"
+input: |2-
+<%= yield(:sidebar).presence || capture do %>
+  default sidebar
+<% end %>
+---
+@ DocumentNode (location: (1:0)-(4:0))
+└── children: (2 items)
+    ├── @ ERBBlockNode (location: (1:0)-(3:9))
+    │   ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   ├── content: " yield(:sidebar).presence || capture do " (location: (1:3)-(1:43))
+    │   ├── tag_closing: "%>" (location: (1:43)-(1:45))
+    │   ├── body: (1 item)
+    │   │   └── @ HTMLTextNode (location: (1:45)-(3:0))
+    │   │       └── content: "\n  default sidebar\n"
+    │   │
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (3:0)-(3:9))
+    │           ├── tag_opening: "<%" (location: (3:0)-(3:2))
+    │           ├── content: " end " (location: (3:2)-(3:7))
+    │           └── tag_closing: "%>" (location: (3:7)-(3:9))
+    │
+    │
+    └── @ HTMLTextNode (location: (3:9)-(4:0))
+        └── content: "\n"


### PR DESCRIPTION
When an ERB tag contains both a `yield` and a block (e.g., `yield(:sidebar) || capture do`), the block should take precedence for control flow detection since it requires an `end` tag.

Previously, `yield` was selected because it appeared first in the expression, causing the `<% end %>` to be treated as orphaned.

Resolves #1037 