### PR TITLE
Language Server: Fix `case` with `then` being marked as unnecessary

### DIFF
--- a/javascript/packages/language-server/src/diagnostics.ts
+++ b/javascript/packages/language-server/src/diagnostics.ts
@@ -185,7 +185,10 @@ export class UnreachableCodeCollector extends Visitor {
   }
 
   visitERBWhenNode(node: ERBWhenNode): void {
-    this.checkEmptyStatements(node, node.statements, "when")
+    if (!node.then_keyword) {
+      this.checkEmptyStatements(node, node.statements, "when")
+    }
+
     this.visitChildNodes(node)
   }
 
@@ -210,7 +213,10 @@ export class UnreachableCodeCollector extends Visitor {
   }
 
   visitERBInNode(node: ERBInNode): void {
-    this.checkEmptyStatements(node, node.statements, "in")
+    if (!node.then_keyword) {
+      this.checkEmptyStatements(node, node.statements, "in")
+    }
+
     this.visitChildNodes(node)
   }
 


### PR DESCRIPTION
With the help of #1078, we can now track the `then` keyword and can fix #1061 where we previously marked `case` with `then` keywords as unnecessary.

**Before:**

<img width="1390" height="320" alt="CleanShot 2026-01-17 at 23 58 28@2x" src="https://github.com/user-attachments/assets/61739452-6712-4ec5-9d32-70640a224d49" />



**After:**

<img width="1390" height="320" alt="CleanShot 2026-01-17 at 23 58 00@2x" src="https://github.com/user-attachments/assets/ef8bf96f-554e-42bf-8235-6ad755cddf94" />


We assume that when the `then` keyword is present that the branch is not unnecessary. This approach is not 100% correct, but it should solve most cases and the issue outlined in #1061. 

I think we should avoid using `then` in ERB files, since this behavior is really unpredictable and ambiguous. This is also why I opened a proposal for the linter rule in #1077.

