### PR TITLE
Formatter: Preserve Unicode whitespace when formatting

### DIFF
--- a/javascript/packages/formatter/test/html/unicode-characters.test.ts
+++ b/javascript/packages/formatter/test/html/unicode-characters.test.ts
@@ -191,4 +191,60 @@ describe("Unicode character handling", () => {
       <%# ERB comment with — dash and 'apostrophe' %>
     `)
   })
+
+  test("Issue #930: Full-width ideographic space (U+3000) should be preserved", () => {
+    const source = '<p>a\u3000b</p>'
+    const result = formatter.format(source)
+
+    expect(result).toBe('<p>a\u3000b</p>')
+  })
+
+  test("Issue #930: Full-width space literal from playground should be preserved", () => {
+    const source = '<p>a　b</p>'
+    const result = formatter.format(source)
+
+    expect(result).toBe('<p>a　b</p>')
+  })
+
+  test("Non-breaking space (U+00A0) should be preserved", () => {
+    const source = '<p>a\u00A0b</p>'
+    const result = formatter.format(source)
+
+    expect(result).toBe('<p>a\u00A0b</p>')
+  })
+
+  test("Non-breaking space in text content should be preserved", () => {
+    const source = '<p>10\u00A0kg of weight</p>'
+    const result = formatter.format(source)
+
+    expect(result).toBe('<p>10\u00A0kg of weight</p>')
+  })
+
+  test("Full-width space in CJK text should be preserved", () => {
+    const source = '<p>日本語\u3000テスト</p>'
+    const result = formatter.format(source)
+
+    expect(result).toBe('<p>日本語\u3000テスト</p>')
+  })
+
+  test("Non-breaking space in attributes should be preserved", () => {
+    const source = '<div title="10\u00A0kg">Content</div>'
+    const result = formatter.format(source)
+
+    expect(result).toBe('<div title="10\u00A0kg">Content</div>')
+  })
+
+  test("Mixed NBSP and full-width space should all be preserved", () => {
+    const source = '<p>word1\u00A0word2\u3000word3</p>'
+    const result = formatter.format(source)
+
+    expect(result).toBe('<p>word1\u00A0word2\u3000word3</p>')
+  })
+
+  test("NBSP preserved while regular spaces get normalized", () => {
+    const source = '<p>word1   word2\u00A0word3   word4</p>'
+    const result = formatter.format(source)
+
+    expect(result).toBe('<p>word1 word2\u00A0word3 word4</p>')
+  })
 })


### PR DESCRIPTION
This pull request updates the formatter to use an ASCII-only whitespace pattern instead of the `\s` regex. This is in order to preserve Unicode whitespace characters like NBSP (U+00A0) and full-width ideographic space (U+3000) when formatting, as they have a meaning in a HTML text-content context.

JavaScript's `\s` regex matches all Unicode whitespace, which caused these meaningful characters to be normalized to regular ASCII spaces. This is problematic for Japanese typography where full-width space is used for readability and visual balance.

Fixes #930