### PR TITLE
Rewriter: Preserve interpolated ERB class names in tailwind rewriter

### DIFF
--- a/javascript/packages/rewriter/src/built-ins/tailwind-class-sorter.ts
+++ b/javascript/packages/rewriter/src/built-ins/tailwind-class-sorter.ts
@@ -203,6 +203,8 @@ class ClassAttributeSorter extends Visitor {
           startNewGroup = false
         } else if (previousNode && !isLiteralNode(previousNode)) {
           startNewGroup = true
+        } else if (currentGroup.every(member => this.isWhitespaceLiteral(member))) {
+          startNewGroup = true
         }
 
       } else {
@@ -294,10 +296,37 @@ class ClassAttributeSorter extends Visitor {
 
   private formatNodes(nodes: Node[], isNested: boolean): Node[] {
     if (nodes.length === 0) return nodes
-    if (nodes.every(n => this.isWhitespaceLiteral(n))) return nodes
+    if (nodes.every(child => this.isWhitespaceLiteral(child))) return nodes
 
     const splitNodes = this.splitLiteralsAtWhitespace(nodes)
     const groups = this.groupNodesByClass(splitNodes)
+    const groupPrecedingWhitespace = new Map<Node[], Node[]>()
+    const nodePrecedingWhitespace = new Map<Node, Node[]>()
+
+    for (let i = 1; i < groups.length; i++) {
+      if (!this.isWhitespaceGroup(groups[i]) && this.isWhitespaceGroup(groups[i - 1])) {
+        groupPrecedingWhitespace.set(groups[i], groups[i - 1])
+
+        for (const node of groups[i]) {
+          if (!isLiteralNode(node)) {
+            nodePrecedingWhitespace.set(node, groups[i - 1])
+          }
+        }
+      }
+    }
+
+    let leadingWhitespace: Node[] | null = null
+    let trailingWhitespace: Node[] | null = null
+
+    if (isNested && groups.length > 0) {
+      if (this.isWhitespaceGroup(groups[0])) {
+        leadingWhitespace = groups[0]
+      }
+      if (groups.length > 1 && this.isWhitespaceGroup(groups[groups.length - 1])) {
+        trailingWhitespace = groups[groups.length - 1]
+      }
+    }
+
     const { staticClasses, interpolationGroups, standaloneERBNodes } = this.categorizeGroups(groups)
 
     const allStaticContent = staticClasses.join(" ")
@@ -324,7 +353,8 @@ class ClassAttributeSorter extends Visitor {
 
     for (const group of interpolationGroups) {
       if (parts.length > 0) {
-        parts.push(this.spaceLiteral)
+        const whitespace = groupPrecedingWhitespace.get(group)
+        parts.push(...(whitespace ?? [this.spaceLiteral]))
       }
 
       parts.push(...this.trimGroupWhitespace(group))
@@ -332,13 +362,16 @@ class ClassAttributeSorter extends Visitor {
 
     for (const node of standaloneERBNodes) {
       if (parts.length > 0) {
-        parts.push(this.spaceLiteral)
+        const whitespace = nodePrecedingWhitespace.get(node)
+        parts.push(...(whitespace ?? [this.spaceLiteral]))
       }
       parts.push(node)
     }
 
     if (isNested && parts.length > 0) {
-      return [this.spaceLiteral, ...parts, this.spaceLiteral]
+      const leading = leadingWhitespace ?? [this.spaceLiteral]
+      const trailing = trailingWhitespace ?? [this.spaceLiteral]
+      return [...leading, ...parts, ...trailing]
     }
 
     return parts

--- a/javascript/packages/rewriter/test/built-ins/tailwind-class-sorter.test.ts
+++ b/javascript/packages/rewriter/test/built-ins/tailwind-class-sorter.test.ts
@@ -334,7 +334,74 @@ describe("tailwind-class-sorter", () => {
             rounded">
           </div>
         `,
-        `<div class="rounded px-4 <% if valid? %> bg-green-500 font-bold text-green-800 <% else %> bg-red-500 font-bold text-red-800 <% end %>">\n</div>`
+        dedent`
+          <div class="rounded px-4
+            <% if valid? %>
+              bg-green-500 font-bold text-green-800
+            <% else %>
+              bg-red-500 font-bold text-red-800
+            <% end %>">
+          </div>
+        `
+      )
+    })
+
+    test("sorts multiline conditional with classes before and after", async () => {
+      await expectTransform(
+        dedent`
+          <div class="px-4 text-white
+            <% if valid? %>
+              font-bold text-green-800 bg-green-500
+            <% else %>
+              font-bold bg-red-500 text-red-800
+            <% end %>
+            rounded bg-blue-500">
+          </div>
+        `,
+        dedent`
+          <div class="rounded bg-blue-500 px-4 text-white
+            <% if valid? %>
+              bg-green-500 font-bold text-green-800
+            <% else %>
+              bg-red-500 font-bold text-red-800
+            <% end %>">
+          </div>
+        `
+      )
+    })
+
+    test("sorts multiline template with two conditional blocks and classes between", async () => {
+      await expectTransform(
+        dedent`
+          <div class="px-4 text-white
+            <% if valid? %>
+              font-bold text-green-800 bg-green-500
+            <% else %>
+              font-bold bg-red-500 text-red-800
+            <% end %>
+            rounded bg-blue-500
+            <% if highlighted? %>
+              border-2 border-blue-500
+            <% else %>
+              border border-gray-300
+            <% end %>
+            py-2 mt-4">
+          </div>
+        `,
+        dedent`
+          <div class="mt-4 rounded bg-blue-500 px-4 py-2 text-white
+            <% if valid? %>
+              bg-green-500 font-bold text-green-800
+            <% else %>
+              bg-red-500 font-bold text-red-800
+            <% end %>
+            <% if highlighted? %>
+              border-2 border-blue-500
+            <% else %>
+              border border-gray-300
+            <% end %>">
+          </div>
+        `
       )
     })
 

--- a/javascript/packages/rewriter/test/rewrite.test.ts
+++ b/javascript/packages/rewriter/test/rewrite.test.ts
@@ -129,7 +129,15 @@ describe("rewrite", () => {
         </div>
       `
 
-      const expected = `<div class="rounded px-4 <% if valid? %> bg-green-500 font-bold text-green-800 <% else %> bg-red-500 font-bold text-red-800 <% end %>">\n</div>`
+      const expected = dedent`
+        <div class="rounded px-4
+          <% if valid? %>
+            bg-green-500 font-bold text-green-800
+          <% else %>
+            bg-red-500 font-bold text-red-800
+          <% end %>">
+        </div>
+      `
       const output = rewriteString(Herb, template, [sorter])
 
       expect(output).toBe(expected)


### PR DESCRIPTION
The `tailwind-class-sorter` was silently corrupting class names in attributes when ERB was used for interpolating class names. For example:

**Input:**
```html
<div class="foo-<%= bar %>-100">
```

**Output:**
```html
<div class="foo--100 <%= bar %>">
```

This happened because the sorter separated all literal nodes from ERB nodes and joined them together, losing the ERB's position within the class name.

This pull request adds detection for string interpolation patterns and skips sorting when they're found:

  - Case 1: `literal → ERB → literal` with no whitespace at boundaries
    e.g., `foo-<%= bar %>-100`

  - Case 2: ERB at start followed by literal without leading whitespace
    e.g., `<%= prefix %>-blue-500`

  - Case 3: Literal ending with hyphen followed by ERB at end
    e.g., `bg-<%= suffix %>`

When interpolation is detected, sorting is skipped for that attribute value to prevent silent corruption. Classes inside nested conditionals are still sorted correctly.

Resolves #879