### PR TITLE
Linter: Catch `<%# locals:() %>` in `erb-strict-locals-comment-syntax`

### DIFF
--- a/javascript/packages/linter/src/rules/erb-strict-locals-comment-syntax.ts
+++ b/javascript/packages/linter/src/rules/erb-strict-locals-comment-syntax.ts
@@ -7,7 +7,7 @@ import { hasBalancedParentheses, splitByTopLevelComma } from "./string-utils.js"
 import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types.js"
 import type { ParseResult, ERBContentNode } from "@herb-tools/core"
 
-export const STRICT_LOCALS_PATTERN = /^locals:\s*\([^)]*\)\s*$/
+export const STRICT_LOCALS_PATTERN = /^locals:\s+\([^)]*\)\s*$/
 
 function isValidStrictLocalsFormat(content: string): boolean {
   return STRICT_LOCALS_PATTERN.test(content)
@@ -47,6 +47,10 @@ function detectSingularLocal(content: string): boolean {
 
 function detectMissingColonBeforeParens(content: string): boolean {
   return /^locals\s+\(/.test(content)
+}
+
+function detectMissingSpaceAfterColon(content: string): boolean {
+  return /^locals:\(/.test(content)
 }
 
 function detectMissingParentheses(content: string): boolean {
@@ -237,6 +241,11 @@ class ERBStrictLocalsCommentSyntaxVisitor extends BaseRuleVisitor {
 
     if (detectMissingColonBeforeParens(commentContent)) {
       this.addOffense("Use `locals:` with a colon before the parentheses, not `locals (`.", node.location)
+      return
+    }
+
+    if (detectMissingSpaceAfterColon(commentContent)) {
+      this.addOffense("Missing space after `locals:`. Rails Strict Locals require a space after the colon: `<%# locals: (...) %>`.", node.location)
       return
     }
 

--- a/javascript/packages/linter/test/rules/erb-strict-locals-comment-syntax.test.ts
+++ b/javascript/packages/linter/test/rules/erb-strict-locals-comment-syntax.test.ts
@@ -72,6 +72,22 @@ describe("ERBStrictLocalsCommentSyntaxRule", () => {
     `)
   })
 
+  test("flags missing space after colon", () => {
+    expectError("Missing space after `locals:`. Rails Strict Locals require a space after the colon: `<%# locals: (...) %>`.")
+
+    assertOffenses(dedent`
+      <%# locals:() %>
+    `)
+  })
+
+  test("flags missing space after colon with locals", () => {
+    expectError("Missing space after `locals:`. Rails Strict Locals require a space after the colon: `<%# locals: (...) %>`.")
+
+    assertOffenses(dedent`
+      <%# locals:(title:) %>
+    `)
+  })
+
   test("flags missing parentheses around parameters", () => {
     expectError("Wrap parameters in parentheses: `locals: (name:)` or `locals: (name: default)`.")
 


### PR DESCRIPTION
This pull request updates the `erb-strict-locals-comment-syntax` linter rule to also catch this wrong syntax which doesn't work in Rails Strict locals: 

```erb
<%# locals:() %>
```