### PR TITLE
Parser: Fix `next` within `if` in single ERB tag

### DIFF
--- a/src/analyze.c
+++ b/src/analyze.c
@@ -280,6 +280,8 @@ static control_type_t detect_control_type(AST_ERB_CONTENT_NODE_T* erb_node) {
   if (has_ensure_node(ruby)) { return CONTROL_TYPE_ENSURE; }
   if (has_block_closing(ruby)) { return CONTROL_TYPE_BLOCK_CLOSE; }
 
+  if (ruby->unclosed_control_flow_count == 0 && !has_yield_node(ruby)) { return CONTROL_TYPE_UNKNOWN; }
+
   return find_earliest_control_keyword(root, ruby->parser.start);
 }
 

--- a/test/analyze/if_test.rb
+++ b/test/analyze/if_test.rb
@@ -166,5 +166,64 @@ module Analyze
         <% end %>
       HTML
     end
+
+    test "complete if/end in single ERB tag should not be ERBIfNode" do
+      assert_parsed_snapshot(<<~HTML)
+        <%
+          if false
+            next
+          end
+        %>
+      HTML
+    end
+
+    test "complete if/else/end in single ERB tag should not be ERBIfNode" do
+      assert_parsed_snapshot(<<~HTML)
+        <%
+          if condition
+            do_something
+          else
+            do_other
+          end
+        %>
+      HTML
+    end
+
+    test "complete if/elsif/else/end in single ERB tag should not be ERBIfNode" do
+      assert_parsed_snapshot(<<~HTML)
+        <%
+          if a
+            one
+          elsif b
+            two
+          else
+            three
+          end
+        %>
+      HTML
+    end
+
+    test "each block with complete if/end inside single ERB tag" do
+      assert_parsed_snapshot(<<~HTML)
+        <% [1,2,3].each do |i| %>
+          <%
+            if false
+              next
+            end
+          %>
+
+          <%= i %>
+        <% end %>
+      HTML
+    end
+
+    test "each block with inline guard clause should not be ERBIfNode" do
+      assert_parsed_snapshot(<<~HTML)
+        <% [1,2,3].each do |i| %>
+          <% next if false %>
+          <%= i %>
+        <% end %>
+      HTML
+    end
   end
 end

--- a/test/snapshots/analyze/if_test/test_0018_complete_if_end_in_single_ERB_tag_should_not_be_ERBIfNode_91e47fbc7a9db5760c1c1f48aad73d2a.txt
+++ b/test/snapshots/analyze/if_test/test_0018_complete_if_end_in_single_ERB_tag_should_not_be_ERBIfNode_91e47fbc7a9db5760c1c1f48aad73d2a.txt
@@ -1,0 +1,29 @@
+---
+source: "Analyze::IfTest#test_0018_complete if/end in single ERB tag should not be ERBIfNode"
+input: |2-
+<%
+  if false
+    next
+  end
+%>
+---
+@ DocumentNode (location: (1:0)-(6:0))
+└── children: (2 items)
+    ├── @ ERBContentNode (location: (1:0)-(5:2))
+    │   ├── errors: (1 error)
+    │   │   └── @ ERBControlFlowScopeError (location: (1:0)-(5:2))
+    │   │       ├── message: "`<% next %>` appears outside its control flow block. Keep ERB control flow statements together within the same HTML scope (tag, attribute, or content)."
+    │   │       └── keyword: "`<% next %>`"
+    │   │
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
+    │   ├── content: "
+    │     if false
+    │       next
+    │     end
+    │   " (location: (1:2)-(5:0))
+    │   ├── tag_closing: "%>" (location: (5:0)-(5:2))
+    │   ├── parsed: true
+    │   └── valid: false
+    │
+    └── @ HTMLTextNode (location: (5:2)-(6:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/if_test/test_0019_complete_if_else_end_in_single_ERB_tag_should_not_be_ERBIfNode_be60785f548cda1843f09c341e0eadb9.txt
+++ b/test/snapshots/analyze/if_test/test_0019_complete_if_else_end_in_single_ERB_tag_should_not_be_ERBIfNode_be60785f548cda1843f09c341e0eadb9.txt
@@ -1,0 +1,28 @@
+---
+source: "Analyze::IfTest#test_0019_complete if/else/end in single ERB tag should not be ERBIfNode"
+input: |2-
+<%
+  if condition
+    do_something
+  else
+    do_other
+  end
+%>
+---
+@ DocumentNode (location: (1:0)-(8:0))
+└── children: (2 items)
+    ├── @ ERBContentNode (location: (1:0)-(7:2))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
+    │   ├── content: "
+    │     if condition
+    │       do_something
+    │     else
+    │       do_other
+    │     end
+    │   " (location: (1:2)-(7:0))
+    │   ├── tag_closing: "%>" (location: (7:0)-(7:2))
+    │   ├── parsed: true
+    │   └── valid: true
+    │
+    └── @ HTMLTextNode (location: (7:2)-(8:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/if_test/test_0020_complete_if_elsif_else_end_in_single_ERB_tag_should_not_be_ERBIfNode_ec06261e4f13bb7a938c18780c1d9d9e.txt
+++ b/test/snapshots/analyze/if_test/test_0020_complete_if_elsif_else_end_in_single_ERB_tag_should_not_be_ERBIfNode_ec06261e4f13bb7a938c18780c1d9d9e.txt
@@ -1,0 +1,32 @@
+---
+source: "Analyze::IfTest#test_0020_complete if/elsif/else/end in single ERB tag should not be ERBIfNode"
+input: |2-
+<%
+  if a
+    one
+  elsif b
+    two
+  else
+    three
+  end
+%>
+---
+@ DocumentNode (location: (1:0)-(10:0))
+└── children: (2 items)
+    ├── @ ERBContentNode (location: (1:0)-(9:2))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
+    │   ├── content: "
+    │     if a
+    │       one
+    │     elsif b
+    │       two
+    │     else
+    │       three
+    │     end
+    │   " (location: (1:2)-(9:0))
+    │   ├── tag_closing: "%>" (location: (9:0)-(9:2))
+    │   ├── parsed: true
+    │   └── valid: true
+    │
+    └── @ HTMLTextNode (location: (9:2)-(10:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/if_test/test_0021_each_block_with_complete_if_end_inside_single_ERB_tag_6c79c199036b7027af1838f2983b96eb.txt
+++ b/test/snapshots/analyze/if_test/test_0021_each_block_with_complete_if_end_inside_single_ERB_tag_6c79c199036b7027af1838f2983b96eb.txt
@@ -1,0 +1,56 @@
+---
+source: "Analyze::IfTest#test_0021_each block with complete if/end inside single ERB tag"
+input: |2-
+<% [1,2,3].each do |i| %>
+  <%
+    if false
+      next
+    end
+  %>
+
+  <%= i %>
+<% end %>
+---
+@ DocumentNode (location: (1:0)-(10:0))
+└── children: (2 items)
+    ├── @ ERBBlockNode (location: (1:0)-(9:9))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
+    │   ├── content: " [1,2,3].each do |i| " (location: (1:2)-(1:23))
+    │   ├── tag_closing: "%>" (location: (1:23)-(1:25))
+    │   ├── body: (5 items)
+    │   │   ├── @ HTMLTextNode (location: (1:25)-(2:2))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ ERBContentNode (location: (2:2)-(6:4))
+    │   │   │   ├── tag_opening: "<%" (location: (2:2)-(2:4))
+    │   │   │   ├── content: "
+    │   │   │       if false
+    │   │   │         next
+    │   │   │       end
+    │   │   │     " (location: (2:4)-(6:2))
+    │   │   │   ├── tag_closing: "%>" (location: (6:2)-(6:4))
+    │   │   │   ├── parsed: true
+    │   │   │   └── valid: false
+    │   │   │
+    │   │   ├── @ HTMLTextNode (location: (6:4)-(8:2))
+    │   │   │   └── content: "\n\n  "
+    │   │   │
+    │   │   ├── @ ERBContentNode (location: (8:2)-(8:10))
+    │   │   │   ├── tag_opening: "<%=" (location: (8:2)-(8:5))
+    │   │   │   ├── content: " i " (location: (8:5)-(8:8))
+    │   │   │   ├── tag_closing: "%>" (location: (8:8)-(8:10))
+    │   │   │   ├── parsed: true
+    │   │   │   └── valid: true
+    │   │   │
+    │   │   └── @ HTMLTextNode (location: (8:10)-(9:0))
+    │   │       └── content: "\n"
+    │   │
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (9:0)-(9:9))
+    │           ├── tag_opening: "<%" (location: (9:0)-(9:2))
+    │           ├── content: " end " (location: (9:2)-(9:7))
+    │           └── tag_closing: "%>" (location: (9:7)-(9:9))
+    │
+    │
+    └── @ HTMLTextNode (location: (9:9)-(10:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/if_test/test_0022_each_block_with_inline_guard_clause_should_not_be_ERBIfNode_31f628430298e5de774756702da1c76b.txt
+++ b/test/snapshots/analyze/if_test/test_0022_each_block_with_inline_guard_clause_should_not_be_ERBIfNode_31f628430298e5de774756702da1c76b.txt
@@ -1,0 +1,47 @@
+---
+source: "Analyze::IfTest#test_0022_each block with inline guard clause should not be ERBIfNode"
+input: |2-
+<% [1,2,3].each do |i| %>
+  <% next if false %>
+  <%= i %>
+<% end %>
+---
+@ DocumentNode (location: (1:0)-(5:0))
+└── children: (2 items)
+    ├── @ ERBBlockNode (location: (1:0)-(4:9))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
+    │   ├── content: " [1,2,3].each do |i| " (location: (1:2)-(1:23))
+    │   ├── tag_closing: "%>" (location: (1:23)-(1:25))
+    │   ├── body: (5 items)
+    │   │   ├── @ HTMLTextNode (location: (1:25)-(2:2))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ ERBContentNode (location: (2:2)-(2:21))
+    │   │   │   ├── tag_opening: "<%" (location: (2:2)-(2:4))
+    │   │   │   ├── content: " next if false " (location: (2:4)-(2:19))
+    │   │   │   ├── tag_closing: "%>" (location: (2:19)-(2:21))
+    │   │   │   ├── parsed: true
+    │   │   │   └── valid: false
+    │   │   │
+    │   │   ├── @ HTMLTextNode (location: (2:21)-(3:2))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ ERBContentNode (location: (3:2)-(3:10))
+    │   │   │   ├── tag_opening: "<%=" (location: (3:2)-(3:5))
+    │   │   │   ├── content: " i " (location: (3:5)-(3:8))
+    │   │   │   ├── tag_closing: "%>" (location: (3:8)-(3:10))
+    │   │   │   ├── parsed: true
+    │   │   │   └── valid: true
+    │   │   │
+    │   │   └── @ HTMLTextNode (location: (3:10)-(4:0))
+    │   │       └── content: "\n"
+    │   │
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (4:0)-(4:9))
+    │           ├── tag_opening: "<%" (location: (4:0)-(4:2))
+    │           ├── content: " end " (location: (4:2)-(4:7))
+    │           └── tag_closing: "%>" (location: (4:7)-(4:9))
+    │
+    │
+    └── @ HTMLTextNode (location: (4:9)-(5:0))
+        └── content: "\n"


### PR DESCRIPTION
This pull request improves the parser to handle the case where a `next` is being used in an `if` inside a single `ERBContentNode`:

```erb
<%
  if false
    next
  end
%>
```

Resolves #1099