### PR TITLE
Upgrade Prism to v1.9.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ If you encounter any issues when following along with this file please don't hes
 - [**Clang 21**](https://clang.llvm.org): The compiler used to build this project.
 - [**Clang Format 21**](https://clang.llvm.org/docs/ClangFormat.html): For formatting the project.
 - [**Clang Tidy 21**](https://clang.llvm.org/extra/clang-tidy/): For linting the project.
-- [**Prism Ruby Parser v1.8.0**](https://github.com/ruby/prism/releases/tag/v1.8.0): We use Prism for Parsing the Ruby Source Code in the HTML+ERB files.
+- [**Prism Ruby Parser v1.9.0**](https://github.com/ruby/prism/releases/tag/v1.9.0): We use Prism for Parsing the Ruby Source Code in the HTML+ERB files.
 - [**Ruby**](https://www.ruby-lang.org/en/): We need Ruby as a dependency for `bundler`.
 - [**Bundler**](https://bundler.io): We are using `bundler` to build [`prism`](https://github.com/ruby/prism) from source so we can build `herb` against it.
 - [**Emscripten**](https://emscripten.org): For the WebAssembly build of `libherb` so it can be used in the browser using the [`@herb-tools/browser`](https://github.com/marcoroth/herb/blob/main/javascript/packages/browser) package.

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "prism", github: "ruby/prism", tag: "v1.8.0"
+gem "prism", github: "ruby/prism", tag: "v1.9.0"
 
 gem "actionview", "~> 8.0"
 gem "digest", "~> 3.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/ruby/prism.git
-  revision: 90c05789e4f90dec600d7748a002058046852370
-  tag: v1.8.0
+  revision: c0e37816e97e23e92524a4070e1b99a4025bc63f
+  tag: v1.9.0
   specs:
-    prism (1.8.0)
+    prism (1.9.0)
 
 PATH
   remote: .
@@ -13,13 +13,13 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    actionview (8.1.1)
-      activesupport (= 8.1.1)
+    actionview (8.1.2)
+      activesupport (= 8.1.2)
       builder (~> 3.1)
       erubi (~> 1.11)
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
-    activesupport (8.1.1)
+    activesupport (8.1.2)
       base64
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.3.1)
@@ -72,7 +72,8 @@ GEM
     json (2.18.0)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
-    listen (3.9.0)
+    listen (3.10.0)
+      logger
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     logger (1.7.0)
@@ -99,7 +100,7 @@ GEM
     nokogiri (1.19.0-x86_64-linux-musl)
       racc (~> 1.4)
     parallel (1.27.0)
-    parser (3.3.10.0)
+    parser (3.3.10.1)
       ast (~> 2.4.1)
       racc
     pp (0.6.3)
@@ -110,7 +111,7 @@ GEM
     psych (5.3.1)
       date
       stringio
-    racc (1.8.0)
+    racc (1.8.1)
     rails-dom-testing (2.3.0)
       activesupport (>= 5.0.0)
       minitest
@@ -126,19 +127,19 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
-    rbs (3.10.0)
+    rbs (3.10.2)
       logger
     rbs-inline (0.12.0)
       prism (>= 0.29)
       rbs (>= 3.8.0)
-    rdoc (7.0.3)
+    rdoc (7.1.0)
       erb
       psych (>= 4.0.0)
       tsort
     regexp_parser (2.11.3)
     reline (0.6.3)
       io-console (~> 0.5)
-    rubocop (1.82.1)
+    rubocop (1.84.0)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
@@ -146,7 +147,7 @@ GEM
       parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 2.9.3, < 3.0)
-      rubocop-ast (>= 1.48.0, < 2.0)
+      rubocop-ast (>= 1.49.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 4.0)
     rubocop-ast (1.49.0)
@@ -154,11 +155,11 @@ GEM
       prism (~> 1.7)
     ruby-progressbar (1.13.0)
     securerandom (0.4.1)
-    sorbet (0.6.12872)
-      sorbet-static (= 0.6.12872)
-    sorbet-static (0.6.12872-aarch64-linux)
-    sorbet-static (0.6.12872-universal-darwin)
-    sorbet-static (0.6.12872-x86_64-linux)
+    sorbet (0.6.12903)
+      sorbet-static (= 0.6.12903)
+    sorbet-static (0.6.12903-aarch64-linux)
+    sorbet-static (0.6.12903-universal-darwin)
+    sorbet-static (0.6.12903-x86_64-linux)
     steep (1.10.0)
       activesupport (>= 5.1)
       concurrent-ruby (>= 1.1.10)
@@ -177,7 +178,7 @@ GEM
       terminal-table (>= 2, < 5)
       uri (>= 0.12.0)
     stringio (3.2.0)
-    strscan (3.1.6)
+    strscan (3.1.7)
     terminal-table (4.0.0)
       unicode-display_width (>= 1.1.1, < 4)
     tsort (0.2.0)

--- a/docs/docs/bindings/java/reference.md
+++ b/docs/docs/bindings/java/reference.md
@@ -185,7 +185,7 @@ Returns the full version information including Herb, Prism, and JNI details:
 import org.herb.Herb;
 
 System.out.println(Herb.version());
-// Output: "herb java v0.8.9, libprism v1.8.0, libherb v0.8.9 (Java JNI)"
+// Output: "herb java v0.8.9, libprism v1.9.0, libherb v0.8.9 (Java JNI)"
 ```
 :::
 
@@ -211,7 +211,7 @@ Returns the Prism parser version:
 import org.herb.Herb;
 
 System.out.println(Herb.prismVersion());
-// Output: "1.8.0"
+// Output: "1.9.0"
 ```
 :::
 

--- a/docs/docs/bindings/rust/reference.md
+++ b/docs/docs/bindings/rust/reference.md
@@ -229,7 +229,7 @@ Returns the full version information including Herb, Prism, and FFI details:
 use herb::version;
 
 println!("{}", version());
-// Output: "herb rust v0.8.9, libprism v1.8.0, libherb v0.8.9 (Rust FFI)"
+// Output: "herb rust v0.8.9, libprism v1.9.0, libherb v0.8.9 (Rust FFI)"
 ```
 :::
 
@@ -255,7 +255,7 @@ Returns the Prism parser version:
 use herb::prism_version;
 
 println!("{}", prism_version());
-// Output: "1.8.0"
+// Output: "1.9.0"
 ```
 :::
 

--- a/javascript/packages/browser/test/browser.test.ts
+++ b/javascript/packages/browser/test/browser.test.ts
@@ -17,7 +17,7 @@ describe("@herb-tools/browser", () => {
   test("version() returns a string", async () => {
     const version = Herb.version
     expect(typeof version).toBe("string")
-    expect(version).toBe("@herb-tools/browser@0.8.9, @herb-tools/core@0.8.9, libprism@1.8.0, libherb@0.8.9 (WebAssembly)")
+    expect(version).toBe("@herb-tools/browser@0.8.9, @herb-tools/core@0.8.9, libprism@1.9.0, libherb@0.8.9 (WebAssembly)")
   })
 
   test("parse() can process a simple template", async () => {

--- a/javascript/packages/node-wasm/test/node-wasm.test.ts
+++ b/javascript/packages/node-wasm/test/node-wasm.test.ts
@@ -20,7 +20,7 @@ describe("@herb-tools/node-wasm", () => {
   test("version() returns a string", async () => {
     const version = Herb.version
     expect(typeof version).toBe("string")
-    expect(version).toBe("@herb-tools/node-wasm@0.8.9, @herb-tools/core@0.8.9, libprism@1.8.0, libherb@0.8.9 (WebAssembly)")
+    expect(version).toBe("@herb-tools/node-wasm@0.8.9, @herb-tools/core@0.8.9, libprism@1.9.0, libherb@0.8.9 (WebAssembly)")
   })
 
   test("parse() can process a simple template", async () => {

--- a/javascript/packages/node/test/node.test.ts
+++ b/javascript/packages/node/test/node.test.ts
@@ -18,7 +18,7 @@ describe("@herb-tools/node", () => {
   test("version() returns a string", async () => {
     const version = Herb.version
     expect(typeof version).toBe("string")
-    expect(version).toBe("@herb-tools/node@0.8.9, @herb-tools/core@0.8.9, libprism@1.8.0, libherb@0.8.9 (Node.js C++ native extension)")
+    expect(version).toBe("@herb-tools/node@0.8.9, @herb-tools/core@0.8.9, libprism@1.9.0, libherb@0.8.9 (Node.js C++ native extension)")
   })
 
   test("parse() can process a simple template", async () => {

--- a/rust/tests/cli_commands_test.rs
+++ b/rust/tests/cli_commands_test.rs
@@ -4,7 +4,7 @@ use herb::{extract_html, extract_ruby, version};
 fn test_version_functions() {
   assert_eq!(
     version(),
-    "herb rust v0.8.9, libprism v1.8.0, libherb v0.8.9 (Rust FFI)"
+    "herb rust v0.8.9, libprism v1.9.0, libherb v0.8.9 (Rust FFI)"
   );
 }
 

--- a/rust/tests/snapshots/snapshot_test__prism_version_output.snap
+++ b/rust/tests/snapshots/snapshot_test__prism_version_output.snap
@@ -2,4 +2,4 @@
 source: tests/snapshot_test.rs
 expression: output
 ---
-1.8.0
+1.9.0

--- a/rust/tests/snapshots/snapshot_test__version_output.snap
+++ b/rust/tests/snapshots/snapshot_test__version_output.snap
@@ -2,4 +2,4 @@
 source: tests/snapshot_test.rs
 expression: output
 ---
-herb rust v0.8.9, libprism v1.8.0, libherb v0.8.9 (Rust FFI)
+herb rust v0.8.9, libprism v1.9.0, libherb v0.8.9 (Rust FFI)

--- a/test/herb_test.rb
+++ b/test/herb_test.rb
@@ -4,6 +4,6 @@ require_relative "test_helper"
 
 class HerbTest < Minitest::Spec
   test "version" do
-    assert_equal "herb gem v0.8.9, libprism v1.8.0, libherb v0.8.9 (Ruby C native extension)", Herb.version
+    assert_equal "herb gem v0.8.9, libprism v1.9.0, libherb v0.8.9 (Ruby C native extension)", Herb.version
   end
 end


### PR DESCRIPTION
https://github.com/ruby/prism/releases/tag/v1.9.0