### PR TITLE
Mark certain targets as `.PHONY` in Makefile

### DIFF
--- a/src/project.json
+++ b/src/project.json
@@ -9,7 +9,7 @@
       "options": {
         "commands": [
           "bundle install",
-          "make"
+          "make templates prism build/libherb.a"
         ],
       },
       "inputs": ["{projectRoot}/**/*"],


### PR DESCRIPTION
To quote the [fine manual](https://www.gnu.org/software/make/manual/html_node/Phony-Targets.html):

> A phony target is one that is not really the name of a file; rather it is just a name for a recipe to be executed when you make an explicit request. There are two reasons to use a phony target: to avoid a conflict with a file of the same name, and to improve performance.

Note: While you can also declare all `.PHONY` targets in a list, I've found that individual declarations work better for larger Makefiles like this one, since they require less vertical scanning.