### PR TITLE
Add support for `.envrc.local`

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -6,3 +6,5 @@ export PATH="$PWD/javascript/packages/highlighter/bin:$PATH"
 export PATH="$PWD/javascript/packages/stimulus-lint/bin:$PATH"
 export PATH="$PWD/java/bin:$PATH"
 export PATH="$PWD/rust/bin:$PATH"
+
+source_env_if_exists .envrc.local

--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,6 @@ docs/docs/public/c-reference
 
 # Clangd config
 compile_flags.txt
+
+# Local .envrc overrides
+.envrc.local


### PR DESCRIPTION
I think that when including an `.envrc` in a repository, it's a good practice to also [conditionally source](https://direnv.net/man/direnv-stdlib.1.html#codesourceenvifexists-ltfilenamegtcode) another `.envrc` file so users can customize their environment without having to worry about accidentally committing changes. I needed this today so figured I'll open a PR.