### PR TITLE
Change LLVM detection on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,13 +67,16 @@ ifeq ($(os),Linux)
 endif
 
 ifeq ($(os),Darwin)
-  brew_prefix := $(shell brew --prefix check)
-  test_cflags = $(test_flags) -I$(brew_prefix)/include
-  test_ldflags = -L$(brew_prefix)/lib -lcheck -lm $(prism_ldflags)
-  llvm_path = $(shell brew --prefix llvm@21)
-  cc = $(llvm_path)/bin/clang
-  clang_format = $(llvm_path)/bin/clang-format
-  clang_tidy = $(llvm_path)/bin/clang-tidy
+  llvm_version := 21
+  llvm_prefix ?= $(shell brew --prefix llvm@$(llvm_version))
+  check_prefix ?= $(shell brew --prefix check)
+
+  cc ?= $(llvm_prefix)/bin/clang
+  clang_format ?= $(llvm_prefix)/bin/clang-format
+  clang_tidy ?= $(llvm_prefix)/bin/clang-tidy
+
+  test_cflags = $(test_flags) -I$(check_prefix)/include
+  test_ldflags = -L$(check_prefix)/lib -lcheck -lm $(prism_ldflags)
 endif
 
 all: templates prism $(exec) $(lib_name) $(static_lib_name) test wasm clangd_config


### PR DESCRIPTION
This PR changes how `clang`, `clang-tidy`, etc., are detected on macOS without requiring any changes for current users.

**Rationale:** 
Not everyone uses Homebrew in this way. I personally only use it for application formulae and kegs, and manage my dev dependencies with Nix flakes (which is also what motivated #1120). 

**Proposed solution:** 
Use the Homebrew prefix by default on macOS, as it's a sensible choice. Users who install `clang` and friends some other way can probably figure out how to override the values as required for their environment (either by exporting environment variables or directly in the `make` invocation).

**Verification:** 
I temporarily added the following task to the `Makefile`:

```make
debug_cc:
	@echo "os:            $(os)"
	@echo "cc:            $(cc)"
	@echo "clang_format:  $(clang_format)"
	@echo "clang_tidy:    $(clang_tidy)"
	@echo "test_cflags:   $(test_cflags)"
	@echo "test_ldflags:  $(test_ldflags)"
```

I ran this before and after making the changes in this PR, the generated output was identical for the Homebrew use case:

```sh
❯ diff -s cc.old.txt cc.new.txt
Files cc.old.txt and cc.new.txt are identical
```

**Notes:**
1. The `debug_cc` target could be generally useful, also for Linux users. If you want, I can add it to either this PR or separately.
2. It's a sort of convention in `Makefile`s to call the variables `CC`, `CFLAGS`, etc. This is primarily because they can be overridden from the environment, and lower-case environment variables look a bit odd. However, I decided not to change this in this PR, as it's not really related to the problem I'm trying to solve here.