### PR TITLE
C: Add test for `herb_read_file`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ $(static_lib_name): $(objects)
 src/%.o: src/%.c templates
 	$(cc) -c $(flags) -fPIC $< -o $@
 
-test/%.o: test/%.c templates
+test/%.o: test/%.c templates prism
 	$(cc) -c $(test_cflags) $(test_flags) $(prism_flags) $< -o $@
 
 .PHONY: test

--- a/test/c/test_io.c
+++ b/test/c/test_io.c
@@ -11,6 +11,12 @@ void create_test_file(const char* filename, const char* content) {
   fclose(fp);
 }
 
+// Test that reading a non-existent file correctly exits
+// Note: Check verifies the exit code via tcase_add_exit_test, so no assertions.
+TEST(test_herb_read_file_nonexistent_exits)
+  herb_read_file("non_existent_file.txt");
+END
+
 // Test reading from a file
 TEST(test_herb_read_file)
   const char* filename = "test_herb_read_file.txt";
@@ -31,6 +37,7 @@ TCase* io_tests(void) {
   TCase* io = tcase_create("IO");
 
   tcase_add_test(io, test_herb_read_file);
+  tcase_add_exit_test(io, test_herb_read_file_nonexistent_exits, 1);
 
   return io;
 }


### PR DESCRIPTION
Document that the function exits when the filename is invalid.

**Rationale:**
I was originally a bit concerned when reading `main.c` that there was no `NULL` check around this line:

```c
char* source = herb_read_file(argv[2]);
```

However, `argv[2]` should never be empty due to this check:

```c
if (argc < 3) {
  printf("Please specify input file.\n");
  return 1;
}
```

This leaves the potential problem of non-existent files, which is handled directly inside `herb_read_file`. This behavior surprised me a little bit, so I thought it might be a good idea to document it with a test.