### PR TITLE
C: Add `free` calls to `prism` command

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -150,6 +150,10 @@ int main(const int argc, char* argv[]) {
 
     herb_parse_ruby_to_stdout(ruby_source);
 
+    free(ruby_source);
+    free(output.value);
+    free(source);
+
     return 0;
   }
 


### PR DESCRIPTION
**Rationale:**
While this is not really a memory leak (the OS will reclaim the memory since we `exit` right after), the missing `free`s are not that big of a deal. However, all other subcommands in `main.c` explicitly free the allocated memory, so I thought it'd be good to add some consistency here.