### PR TITLE
C: Remove old `visit` subcommand

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -61,24 +61,6 @@ int main(const int argc, char* argv[]) {
   struct timespec start, end;
   clock_gettime(CLOCK_MONOTONIC, &start);
 
-  if (strcmp(argv[1], "visit") == 0) {
-    AST_DOCUMENT_NODE_T* root = herb_parse(source, NULL);
-    clock_gettime(CLOCK_MONOTONIC, &end);
-
-    herb_analyze_parse_tree(root, source);
-
-    ast_pretty_print_node((AST_NODE_T*) root, 0, 0, &output);
-    printf("%s\n", output.value);
-
-    print_time_diff(start, end, "visiting");
-
-    ast_node_free((AST_NODE_T*) root);
-    free(output.value);
-    free(source);
-
-    return 0;
-  }
-
   if (strcmp(argv[1], "lex") == 0) {
     herb_lex_to_buffer(source, &output);
     clock_gettime(CLOCK_MONOTONIC, &end);


### PR DESCRIPTION
**Rationale:**
While reading `main.c` I noticed a subcommand called `visit`, which was not documented in `herb`'s help:

```c
    printf("./herb lex [file]      -  Lex a file\n");
    printf("./herb parse [file]    -  Parse a file\n");
    printf("./herb ruby [file]     -  Extract Ruby from a file\n");
    printf("./herb html [file]     -  Extract HTML from a file\n");
    printf("./herb prism [file]    -  Extract Ruby from a file and parse the Ruby source with Prism\n");
```

@marcoroth clarified that this is a leftover from the early days of Herb, so this PR removes the subcommand.