### PR TITLE
C: Add default language case in `herb_extract`

### DIFF
--- a/src/extract.c
+++ b/src/extract.c
@@ -4,6 +4,7 @@
 #include "include/util/hb_array.h"
 #include "include/util/hb_buffer.h"
 
+#include <assert.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -129,6 +130,7 @@ char* herb_extract(const char* source, const herb_extract_language_T language) {
   switch (language) {
     case HERB_EXTRACT_LANGUAGE_RUBY: herb_extract_ruby_to_buffer(source, &output); break;
     case HERB_EXTRACT_LANGUAGE_HTML: herb_extract_html_to_buffer(source, &output); break;
+    default: assert(0 && "invalid extract language");
   }
 
   return output.value;


### PR DESCRIPTION
This is admittedly a rather defensive code change, but my previous work on parsers has taught me that exhaustive `switch` cases are generally a GoodIdea™. 

**Rationale:** 
So far, the `switch` in `herb_extract` only considers the two obvious cases, `HERB_EXTRACT_LANGUAGE_RUBY` and `HERB_EXTRACT_LANGUAGE_HTML`. In case the language type is invalid, we'd just silently return an empty string. I'd posit that failing an assertion and being made aware of this in development is a better approach.