### PR TITLE
C: Simplify `main.c`

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -11,6 +11,7 @@
 #include "include/util/hb_buffer.h"
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <time.h>
 
@@ -34,22 +35,22 @@ void print_time_diff(const struct timespec start, const struct timespec end, con
 
 int main(const int argc, char* argv[]) {
   if (argc < 2) {
-    printf("./herb [command] [options]\n\n");
+    puts("./herb [command] [options]\n");
 
-    printf("Herb 🌿 Powerful and seamless HTML-aware ERB parsing and tooling.\n\n");
+    puts("Herb 🌿 Powerful and seamless HTML-aware ERB parsing and tooling.\n");
 
-    printf("./herb lex [file]      -  Lex a file\n");
-    printf("./herb parse [file]    -  Parse a file\n");
-    printf("./herb ruby [file]     -  Extract Ruby from a file\n");
-    printf("./herb html [file]     -  Extract HTML from a file\n");
-    printf("./herb prism [file]    -  Extract Ruby from a file and parse the Ruby source with Prism\n");
+    puts("./herb lex [file]      -  Lex a file");
+    puts("./herb parse [file]    -  Parse a file");
+    puts("./herb ruby [file]     -  Extract Ruby from a file");
+    puts("./herb html [file]     -  Extract HTML from a file");
+    puts("./herb prism [file]    -  Extract Ruby from a file and parse the Ruby source with Prism");
 
-    return 1;
+    return EXIT_FAILURE;
   }
 
   if (argc < 3) {
-    printf("Please specify input file.\n");
-    return 1;
+    puts("Please specify input file.");
+    return EXIT_FAILURE;
   }
 
   hb_buffer_T output;
@@ -65,13 +66,13 @@ int main(const int argc, char* argv[]) {
     herb_lex_to_buffer(source, &output);
     clock_gettime(CLOCK_MONOTONIC, &end);
 
-    printf("%s\n", output.value);
+    puts(output.value);
     print_time_diff(start, end, "lexing");
 
     free(output.value);
     free(source);
 
-    return 0;
+    return EXIT_SUCCESS;
   }
 
   if (strcmp(argv[1], "parse") == 0) {
@@ -86,7 +87,7 @@ int main(const int argc, char* argv[]) {
 
     if (!silent) {
       ast_pretty_print_node((AST_NODE_T*) root, 0, 0, &output);
-      printf("%s\n", output.value);
+      puts(output.value);
 
       print_time_diff(start, end, "parsing");
     }
@@ -95,33 +96,33 @@ int main(const int argc, char* argv[]) {
     free(output.value);
     free(source);
 
-    return 0;
+    return EXIT_SUCCESS;
   }
 
   if (strcmp(argv[1], "ruby") == 0) {
     herb_extract_ruby_to_buffer(source, &output);
     clock_gettime(CLOCK_MONOTONIC, &end);
 
-    printf("%s\n", output.value);
+    puts(output.value);
     print_time_diff(start, end, "extracting Ruby");
 
     free(output.value);
     free(source);
 
-    return 0;
+    return EXIT_SUCCESS;
   }
 
   if (strcmp(argv[1], "html") == 0) {
     herb_extract_html_to_buffer(source, &output);
     clock_gettime(CLOCK_MONOTONIC, &end);
 
-    printf("%s\n", output.value);
+    puts(output.value);
     print_time_diff(start, end, "extracting HTML");
 
     free(output.value);
     free(source);
 
-    return 0;
+    return EXIT_SUCCESS;
   }
 
   if (strcmp(argv[1], "prism") == 0) {
@@ -136,9 +137,9 @@ int main(const int argc, char* argv[]) {
     free(output.value);
     free(source);
 
-    return 0;
+    return EXIT_SUCCESS;
   }
 
   printf("Unknown Command: %s\n", argv[1]);
-  return 1;
+  return EXIT_FAILURE;
 }


### PR DESCRIPTION
This PR updates `main.c` in the following ways:

1. Use `EXIT_SUCCESS` and `EXIT_FAILURE` from `stdlib.h`. These are generally preferred because they are more portable. While this probably isn't a concern for Herb — all targets use 0 for success and non-zero for failure — it is IMO more intent-revealing.
2. Use `puts` ([manpage](https://man7.org/linux/man-pages/man3/puts.3.html)) instead of `printf` in all cases where the former makes more sense, i.e. no format strings are used at all or trivial format strings are used (`printf("%s\n", some_var)` instead of `puts(some_var)`).