### PR TITLE
Linter: Allow nested parens in `erb-strict-locals-comment-syntax` rule

### DIFF
--- a/javascript/packages/linter/src/rules/erb-strict-locals-comment-syntax.ts
+++ b/javascript/packages/linter/src/rules/erb-strict-locals-comment-syntax.ts
@@ -7,7 +7,7 @@ import { hasBalancedParentheses, splitByTopLevelComma } from "./string-utils.js"
 import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types.js"
 import type { ParseResult, ERBContentNode } from "@herb-tools/core"
 
-export const STRICT_LOCALS_PATTERN = /^locals:\s+\([^)]*\)\s*$/
+export const STRICT_LOCALS_PATTERN = /^locals:\s+\(.*\)\s*$/s
 
 function isValidStrictLocalsFormat(content: string): boolean {
   return STRICT_LOCALS_PATTERN.test(content)

--- a/javascript/packages/linter/test/rules/erb-strict-locals-comment-syntax.test.ts
+++ b/javascript/packages/linter/test/rules/erb-strict-locals-comment-syntax.test.ts
@@ -30,6 +30,12 @@ describe("ERBStrictLocalsCommentSyntaxRule", () => {
     expectNoOffenses(`<%# locals: (callback: -> { nil }) %>`)
   })
 
+  test("allows i18n method calls with parentheses as default values", () => {
+    expectNoOffenses(`<%# locals: (title: t("translation_key_for.title"), message:) %>`)
+    expectNoOffenses(`<%# locals: (label: I18n.t("key"), value:) %>`)
+    expectNoOffenses(`<%# locals: (a: foo(bar(baz())), b:) %>`)
+  })
+
   test("allows double-splat for optional keyword arguments", () => {
     expectNoOffenses(`<%# locals: (message: "Hello", **attributes) %>`)
     expectNoOffenses(`<%# locals: (**options) %>`)


### PR DESCRIPTION
Fixes #1119