### PR TITLE
CI: Reorder build steps to fail fast on cheap checks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,14 +44,14 @@ jobs:
       - name: Render Templates
         run: bundle exec rake templates
 
-      - name: Compile Herb
-        run: bundle exec rake make
+      - name: RuboCop
+        run: bundle exec rubocop
 
-      - name: Compile Ruby extension
-        run: bundle exec rake compile
+      - name: clang-format version
+        run: clang-format-21 --version
 
-      - name: Run Ruby Tests
-        run: bundle exec rake test
+      - name: Lint
+        run: bin/lint
 
       - name: Steep
         run: bundle exec steep check
@@ -62,23 +62,23 @@ jobs:
       # - name: Sorbet
       #   run: bundle exec srb tc
 
-      - name: Run C tests
-        run: ./run_herb_tests
-
-      - name: Run valgrind on examples/
-        run: ./bin/valgrind_check_examples
-
-      - name: clang-format version
-        run: clang-format-21 --version
-
-      - name: Lint
-        run: bin/lint
-
       - name: clang-tidy version
         run: clang-tidy-21 --version
 
       - name: Tidy
         run: bin/tidy
 
-      - name: RuboCop
-        run: bundle exec rubocop
+      - name: Compile Herb
+        run: bundle exec rake make
+
+      - name: Compile Ruby extension
+        run: bundle exec rake compile
+
+      - name: Run Ruby Tests
+        run: bundle exec rake test
+
+      - name: Run C tests
+        run: ./run_herb_tests
+
+      - name: Run valgrind on examples/
+        run: ./bin/valgrind_check_examples


### PR DESCRIPTION
During my work on #1144 I noticed that CI runs some of the more expensive build steps before some of the faster lints. So this PR reorders them to an order that seems a bit more sensible to me.