### PR TITLE
Linter: Implement `erb-no-conditional-html-element` rule

### DIFF
--- a/javascript/packages/linter/docs/rules/README.md
+++ b/javascript/packages/linter/docs/rules/README.md
@@ -6,6 +6,7 @@ This page contains documentation for all Herb Linter rules.
 
 - [`erb-comment-syntax`](./erb-comment-syntax.md) - Disallow Ruby comments immediately after ERB tags
 - [`erb-no-case-node-children`](./erb-no-case-node-children.md) - Don't use `children` for `case/when` and `case/in` nodes
+- [`erb-no-conditional-html-element`](./erb-no-conditional-html-element.md) - Disallow conditional HTML elements
 - [`erb-no-empty-tags`](./erb-no-empty-tags.md) - Disallow empty ERB tags
 - [`erb-no-extra-newline`](./erb-no-extra-newline.md) - Disallow extra newlines.
 - [`erb-no-extra-whitespace-inside-tags`](./erb-no-extra-whitespace-inside-tags.md) - Disallow multiple consecutive spaces inside ERB tags

--- a/javascript/packages/linter/docs/rules/erb-no-conditional-html-element.md
+++ b/javascript/packages/linter/docs/rules/erb-no-conditional-html-element.md
@@ -1,0 +1,90 @@
+# Linter Rule: Disallow conditional HTML elements
+
+**Rule:** `erb-no-conditional-html-element`
+
+## Description
+
+Disallow the pattern of opening an HTML tag in one conditional block and closing it in another conditional block with the same condition. This creates a "conditional element" where the element's existence depends on a runtime condition.
+
+## Rationale
+
+This pattern is difficult to read, maintain, and reason about. It can lead to confusion when trying to understand the document structure, and it makes the template harder to format, lint, and analyze. The opening and closing tags are visually separated, making it non-obvious that they form a matched pair.
+
+Instead, prefer using `capture` blocks with `content_tag` helpers, which make the conditional wrapping explicit and keeps the logic together.
+
+## Examples
+
+### ✅ Good
+
+Using a `capture` block to conditionally wrap content:
+
+```erb
+<% content = capture do %>
+  <div>Content</div>
+<% end %>
+
+<% if wrap_in_dialog? %>
+  <dialog><%= content %></dialog>
+<% else %>
+  <%= content %>
+<% end %>
+```
+
+```erb
+<% content = capture do %>
+  <div>Content</div>
+<% end %>
+
+<%= wrap_in_dialog? ? content_tag(:dialog, content) : content %>
+```
+
+Complete elements within conditional branches:
+
+```erb
+<% if some_condition %>
+  <div class="a">Content</div>
+<% else %>
+  <div class="b">Content</div>
+<% end %>
+```
+
+### 🚫 Bad
+
+Opening and closing tags in separate conditional blocks:
+
+```erb
+<% if wrap_in_dialog? %>
+  <dialog>
+<% end %>
+
+<div>Stuff</div>
+
+<% if wrap_in_dialog? %>
+  </dialog>
+<% end %>
+```
+
+```erb
+<% if @with_icon %>
+  <div class="icon">
+<% end %>
+  <span>Hello</span>
+<% if @with_icon %>
+  </div>
+<% end %>
+```
+
+```erb
+<% if @with_icon %>
+  <div class="icon">
+<% else %>
+  <div class="no-icon">
+<% end %>
+
+  <span>Hello</span>
+</div>
+```
+
+## References
+
+\-

--- a/javascript/packages/linter/src/rules.ts
+++ b/javascript/packages/linter/src/rules.ts
@@ -2,6 +2,7 @@ import type { RuleClass } from "./types.js"
 
 import { ERBCommentSyntax } from "./rules/erb-comment-syntax.js";
 import { ERBNoCaseNodeChildrenRule } from "./rules/erb-no-case-node-children.js"
+import { ERBNoConditionalHTMLElementRule } from "./rules/erb-no-conditional-html-element.js"
 import { ERBNoEmptyTagsRule } from "./rules/erb-no-empty-tags.js"
 import { ERBNoExtraNewLineRule } from "./rules/erb-no-extra-newline.js"
 import { ERBNoExtraWhitespaceRule } from "./rules/erb-no-extra-whitespace-inside-tags.js"
@@ -60,6 +61,7 @@ import { ParserNoErrorsRule } from "./rules/parser-no-errors.js"
 export const rules: RuleClass[] = [
   ERBCommentSyntax,
   ERBNoCaseNodeChildrenRule,
+  ERBNoConditionalHTMLElementRule,
   ERBNoEmptyTagsRule,
   ERBNoExtraNewLineRule,
   ERBNoExtraWhitespaceRule,

--- a/javascript/packages/linter/src/rules/erb-no-conditional-html-element.ts
+++ b/javascript/packages/linter/src/rules/erb-no-conditional-html-element.ts
@@ -1,0 +1,53 @@
+import dedent from "dedent"
+
+import { ParserRule } from "../types.js"
+import { BaseRuleVisitor } from "./rule-utils.js"
+
+import type { ParseResult, HTMLConditionalElementNode } from "@herb-tools/core"
+import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types.js"
+
+class ERBNoConditionalHTMLElementRuleVisitor extends BaseRuleVisitor {
+  visitHTMLConditionalElementNode(node: HTMLConditionalElementNode): void {
+    const tagName = node.tag_name?.value || "element"
+    const condition = node.condition || "condition"
+
+    const suggestion = dedent`
+      Consider using a \`capture\` block instead:
+
+        <% content = capture do %>
+          ... your content here ...
+        <% end %>
+
+        <%= ${condition} ? content_tag(:${tagName}, content) : content %>
+    `
+
+    this.addOffense(
+      dedent`
+        Avoid opening and closing \`<${tagName}>\` tags in separate conditional blocks with the same condition. \
+        This pattern is difficult to read and maintain. ${suggestion}
+      `,
+      node.location,
+    )
+
+    this.visitChildNodes(node)
+  }
+}
+
+export class ERBNoConditionalHTMLElementRule extends ParserRule {
+  name = "erb-no-conditional-html-element"
+
+  get defaultConfig(): FullRuleConfig {
+    return {
+      enabled: true,
+      severity: "error"
+    }
+  }
+
+  check(result: ParseResult, context?: Partial<LintContext>): UnboundLintOffense[] {
+    const visitor = new ERBNoConditionalHTMLElementRuleVisitor(this.name, context)
+
+    visitor.visit(result.value)
+
+    return visitor.offenses
+  }
+}

--- a/javascript/packages/linter/test/__snapshots__/cli.test.ts.snap
+++ b/javascript/packages/linter/test/__snapshots__/cli.test.ts.snap
@@ -765,7 +765,7 @@ exports[`CLI Output Formatting > formats JSON output correctly for bad file 1`] 
   "summary": {
     "filesChecked": 1,
     "filesWithOffenses": 1,
-    "ruleCount": 47,
+    "ruleCount": 48,
     "totalErrors": 2,
     "totalHints": 0,
     "totalIgnored": 0,
@@ -786,7 +786,7 @@ exports[`CLI Output Formatting > formats JSON output correctly for clean file 1`
   "summary": {
     "filesChecked": 1,
     "filesWithOffenses": 0,
-    "ruleCount": 47,
+    "ruleCount": 48,
     "totalErrors": 0,
     "totalHints": 0,
     "totalIgnored": 0,
@@ -859,7 +859,7 @@ exports[`CLI Output Formatting > formats JSON output correctly for file with err
   "summary": {
     "filesChecked": 1,
     "filesWithOffenses": 1,
-    "ruleCount": 47,
+    "ruleCount": 48,
     "totalErrors": 3,
     "totalHints": 0,
     "totalIgnored": 0,

--- a/javascript/packages/linter/test/rules/erb-no-conditional-html-element.test.ts
+++ b/javascript/packages/linter/test/rules/erb-no-conditional-html-element.test.ts
@@ -1,0 +1,288 @@
+import { describe, it } from "vitest"
+import dedent from "dedent";
+
+import { ERBNoConditionalHTMLElementRule } from "../../src/rules/erb-no-conditional-html-element.js";
+import { createLinterTest } from "../helpers/linter-test-helper.js"
+
+const { expectNoOffenses, expectError, assertOffenses } = createLinterTest(ERBNoConditionalHTMLElementRule)
+
+describe("erb-no-conditional-html-element", () => {
+  describe("valid cases - no conditional elements", () => {
+    it("should allow normal if statements", () => {
+      const html = dedent`
+        <% if true %>
+          <div>Text1</div>
+        <% end %>
+      `
+
+      expectNoOffenses(html)
+    })
+
+    it("should allow if/else with complete elements in each branch", () => {
+      const html = dedent`
+        <% if some_condition %>
+          <div class="a">Content</div>
+        <% else %>
+          <div class="b">Content</div>
+        <% end %>
+      `
+
+      expectNoOffenses(html)
+    })
+
+    it("should allow conditional classes using ternary", () => {
+      const html = dedent`
+        <div class="<%= some_condition ? "a" : "b" %>">
+          Content
+        </div>
+      `
+
+      expectNoOffenses(html)
+    })
+
+    it("should allow using capture block pattern", () => {
+      const html = dedent`
+        <% content = capture do %>
+          <div>Stuff</div>
+        <% end %>
+
+        <%= wrap_in_dialog? ? content_tag(:dialog, content) : content %>
+      `
+
+      expectNoOffenses(html)
+    })
+
+    it("should allow unless with complete element", () => {
+      const html = dedent`
+        <% unless hide_icon? %>
+          <div class="icon">
+            <span>Icon</span>
+          </div>
+        <% end %>
+      `
+
+      expectNoOffenses(html)
+    })
+  })
+
+  describe("GitHub issue #84 - opening/closing element in separate contexts", () => {
+    it("should report conditional element with if blocks", () => {
+      const html = dedent`
+        <% if @with_icon %>
+          <h1>
+        <% end %>
+
+          Content
+
+        <% if @with_icon %>
+          </h1>
+        <% end %>
+      `
+
+      expectError(dedent`
+        Avoid opening and closing \`<h1>\` tags in separate conditional blocks with the same condition. This pattern is difficult to read and maintain. Consider using a \`capture\` block instead:
+
+        <% content = capture do %>
+          ... your content here ...
+        <% end %>
+
+        <%= @with_icon ? content_tag(:h1, content) : content %>
+      `)
+      assertOffenses(html)
+    })
+  })
+
+  describe("GitHub issue #399 - formatter issue with conditional tags", () => {
+    it("should report conditional dialog element", () => {
+      const html = dedent`
+        <% if wrap_in_dialog? %>
+          <dialog>
+        <% end %>
+
+        <div>Stuff</div>
+
+        <% if wrap_in_dialog? %>
+          </dialog>
+        <% end %>
+      `
+
+      expectError(dedent`
+        Avoid opening and closing \`<dialog>\` tags in separate conditional blocks with the same condition. This pattern is difficult to read and maintain. Consider using a \`capture\` block instead:
+
+        <% content = capture do %>
+          ... your content here ...
+        <% end %>
+
+        <%= wrap_in_dialog? ? content_tag(:dialog, content) : content %>
+      `)
+      assertOffenses(html)
+    })
+  })
+
+  describe("GitHub issue #856 - incorrect MissingClosingTagError", () => {
+    it("should report conditional div element (primer/view_components example)", () => {
+      const html = dedent`
+        <% if @with_icon %>
+          <div class="icon">
+        <% end %>
+        <span>Content</span>
+        <% if @with_icon %>
+          </div>
+        <% end %>
+      `
+
+      expectError(dedent`
+        Avoid opening and closing \`<div>\` tags in separate conditional blocks with the same condition. This pattern is difficult to read and maintain. Consider using a \`capture\` block instead:
+
+        <% content = capture do %>
+          ... your content here ...
+        <% end %>
+
+        <%= @with_icon ? content_tag(:div, content) : content %>
+      `)
+      assertOffenses(html)
+    })
+  })
+
+  describe("GitHub issue #1033 - question about conditional wrapping", () => {
+    it("should report conditional div wrapper", () => {
+      const html = dedent`
+        <% if wrap_in_div %>
+          <div>
+        <% end %>
+        <p>My text here.</p>
+        <% if wrap_in_div %>
+          </div>
+        <% end %>
+      `
+
+      expectError(dedent`
+        Avoid opening and closing \`<div>\` tags in separate conditional blocks with the same condition. This pattern is difficult to read and maintain. Consider using a \`capture\` block instead:
+
+        <% content = capture do %>
+          ... your content here ...
+        <% end %>
+
+        <%= wrap_in_div ? content_tag(:div, content) : content %>
+      `)
+      assertOffenses(html)
+    })
+  })
+
+  describe("GitHub issue #779 - conditional HTML open tag in if/else", () => {
+    it("should report conditional div with attributes in if/else", () => {
+      const html = dedent`
+        <% if @show_wrapper %>
+          <div class="wrapper">
+        <% end %>
+        <span>Content</span>
+        <% if @show_wrapper %>
+          </div>
+        <% end %>
+      `
+
+      expectError(dedent`
+        Avoid opening and closing \`<div>\` tags in separate conditional blocks with the same condition. This pattern is difficult to read and maintain. Consider using a \`capture\` block instead:
+
+        <% content = capture do %>
+          ... your content here ...
+        <% end %>
+
+        <%= @show_wrapper ? content_tag(:div, content) : content %>
+      `)
+      assertOffenses(html)
+    })
+  })
+
+  describe("unless conditionals", () => {
+    it("should report conditional element with unless blocks", () => {
+      const html = dedent`
+        <% unless hide_wrapper? %>
+          <section>
+        <% end %>
+        <article>Main content</article>
+        <% unless hide_wrapper? %>
+          </section>
+        <% end %>
+      `
+
+      expectError(dedent`
+        Avoid opening and closing \`<section>\` tags in separate conditional blocks with the same condition. This pattern is difficult to read and maintain. Consider using a \`capture\` block instead:
+
+        <% content = capture do %>
+          ... your content here ...
+        <% end %>
+
+        <%= hide_wrapper? ? content_tag(:section, content) : content %>
+      `)
+      assertOffenses(html)
+    })
+  })
+
+  describe("nested conditional elements", () => {
+    it("should report multiple nested conditional elements", () => {
+      const html = dedent`
+        <% if @outer %>
+          <div class="outer">
+        <% end %>
+        <% if @inner %>
+          <span class="inner">
+        <% end %>
+        Content
+        <% if @inner %>
+          </span>
+        <% end %>
+        <% if @outer %>
+          </div>
+        <% end %>
+      `
+
+      expectError(dedent`
+        Avoid opening and closing \`<div>\` tags in separate conditional blocks with the same condition. This pattern is difficult to read and maintain. Consider using a \`capture\` block instead:
+
+        <% content = capture do %>
+          ... your content here ...
+        <% end %>
+
+        <%= @outer ? content_tag(:div, content) : content %>
+      `)
+      expectError(dedent`
+        Avoid opening and closing \`<span>\` tags in separate conditional blocks with the same condition. This pattern is difficult to read and maintain. Consider using a \`capture\` block instead:
+
+        <% content = capture do %>
+          ... your content here ...
+        <% end %>
+
+        <%= @inner ? content_tag(:span, content) : content %>
+      `)
+      assertOffenses(html)
+    })
+  })
+
+  describe("conditional element with body content", () => {
+    it("should report conditional element containing other elements", () => {
+      const html = dedent`
+        <% if @use_wrapper %>
+          <main>
+        <% end %>
+        <header>Header</header>
+        <section>Content</section>
+        <footer>Footer</footer>
+        <% if @use_wrapper %>
+          </main>
+        <% end %>
+      `
+
+      expectError(dedent`
+        Avoid opening and closing \`<main>\` tags in separate conditional blocks with the same condition. This pattern is difficult to read and maintain. Consider using a \`capture\` block instead:
+
+        <% content = capture do %>
+          ... your content here ...
+        <% end %>
+
+        <%= @use_wrapper ? content_tag(:main, content) : content %>
+      `)
+      assertOffenses(html)
+    })
+  })
+})


### PR DESCRIPTION
This pull request adds a new linter rule `erb-no-conditional-html-element` which disallows the use of `HTMLConditionalElementNode` in templates.

The following snippet:

```html+erb
<% if @with_icon %>
  <div class="icon">
<% end %>

  <span>Content</span>

<% if @with_icon %>
  </div>
<% end %>
```

Now fails with:
```
Avoid opening and closing `<div>` tags in separate conditional blocks with the same condition. This pattern is difficult to read and maintain. Consider using a `capture` block instead: <% content = capture do %> ... your content here ... <% end %> <%= @with_icon ? content_tag(:div, content) : content %>
```


This is a follow up on #1146 as it introduced the new `HTMLConditionalElementNode`.