### PR TITLE
Parser: Make `parser_options` parameter `const` in `herb_parse`

### DIFF
--- a/rust/src/herb.rs
+++ b/rust/src/herb.rs
@@ -53,12 +53,12 @@ pub fn parse_with_options(source: &str, options: &ParserOptions) -> Result<Parse
   unsafe {
     let c_source = CString::new(source).map_err(|e| e.to_string())?;
 
-    let mut c_parser_options = crate::bindings::parser_options_T {
+    let c_parser_options = crate::bindings::parser_options_T {
       track_whitespace: options.track_whitespace,
       analyze: options.analyze,
     };
 
-    let ast = crate::ffi::herb_parse(c_source.as_ptr(), &mut c_parser_options);
+    let ast = crate::ffi::herb_parse(c_source.as_ptr(), &c_parser_options);
 
     if ast.is_null() {
       return Err("Failed to parse source".to_string());

--- a/src/herb.c
+++ b/src/herb.c
@@ -27,7 +27,7 @@ HERB_EXPORTED_FUNCTION hb_array_T* herb_lex(const char* source) {
   return tokens;
 }
 
-HERB_EXPORTED_FUNCTION AST_DOCUMENT_NODE_T* herb_parse(const char* source, parser_options_T* options) {
+HERB_EXPORTED_FUNCTION AST_DOCUMENT_NODE_T* herb_parse(const char* source, const parser_options_T* options) {
   if (!source) { source = ""; }
 
   lexer_T lexer = { 0 };

--- a/src/include/herb.h
+++ b/src/include/herb.h
@@ -19,7 +19,7 @@ HERB_EXPORTED_FUNCTION void herb_lex_to_buffer(const char* source, hb_buffer_T* 
 HERB_EXPORTED_FUNCTION hb_array_T* herb_lex(const char* source);
 HERB_EXPORTED_FUNCTION hb_array_T* herb_lex_file(const char* path);
 
-HERB_EXPORTED_FUNCTION AST_DOCUMENT_NODE_T* herb_parse(const char* source, parser_options_T* options);
+HERB_EXPORTED_FUNCTION AST_DOCUMENT_NODE_T* herb_parse(const char* source, const parser_options_T* options);
 
 HERB_EXPORTED_FUNCTION const char* herb_version(void);
 HERB_EXPORTED_FUNCTION const char* herb_prism_version(void);


### PR DESCRIPTION
As discussed in https://github.com/marcoroth/herb/pull/1144#discussion_r2793475975, we can make the options argument `const` since herb_parse is not modifying it. This also allows us to change the Rust bindings from `&mut` to `&`.