### PR TITLE
Linter: Fix `html-no-empty-headings` to detect non-output ERB

### DIFF
--- a/javascript/packages/linter/src/rules/html-no-empty-headings.ts
+++ b/javascript/packages/linter/src/rules/html-no-empty-headings.ts
@@ -1,8 +1,8 @@
-import { BaseRuleVisitor, getTagName, getAttributes, findAttributeByName, getAttributeValue, HEADING_TAGS, getOpenTag } from "./rule-utils.js"
-import { isLiteralNode, isHTMLTextNode, isHTMLElementNode } from "@herb-tools/core"
-
 import { ParserRule } from "../types.js"
+import { BaseRuleVisitor, getTagName, getAttributes, findAttributeByName, getAttributeValue, HEADING_TAGS, getOpenTag } from "./rule-utils.js"
+import { isLiteralNode, isHTMLTextNode, isHTMLElementNode, isERBOutputNode, isERBControlFlowNode } from "@herb-tools/core"
 
+import type { Node } from "@herb-tools/core"
 import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types.js"
 import type { HTMLElementNode, HTMLOpenTagNode, ParseResult } from "@herb-tools/core"
 
@@ -46,26 +46,47 @@ class NoEmptyHeadingsVisitor extends BaseRuleVisitor {
       return true
     }
 
-    let hasAccessibleContent = false
+    return !this.hasAccessibleContent(node.body)
+  }
 
-    for (const child of node.body) {
-      if (isLiteralNode(child) || isHTMLTextNode(child)) {
+  private hasAccessibleContent(nodes: Node[]): boolean {
+    for (const child of nodes) {
+      if (isLiteralNode(child) || isHTMLTextNode(child)) {
         if (child.content.trim().length > 0) {
-          hasAccessibleContent = true
-          break
+          return true
         }
       } else if (isHTMLElementNode(child)) {
         if (this.isElementAccessible(child)) {
-          hasAccessibleContent = true
-          break
+          return true
         }
-      } else {
-        hasAccessibleContent = true
-        break
+      } else if (isERBOutputNode(child)) {
+        return true
+      } else if (isERBControlFlowNode(child)) {
+        if (this.hasAccessibleContentInControlFlow(child)) {
+          return true
+        }
       }
     }
 
-    return !hasAccessibleContent
+    return false
+  }
+
+  private hasAccessibleContentInControlFlow(node: Node): boolean {
+    const nodeWithStatements = node as { statements?: Node[], body?: Node[], subsequent?: Node }
+
+    if (nodeWithStatements.statements && this.hasAccessibleContent(nodeWithStatements.statements)) {
+      return true
+    }
+
+    if (nodeWithStatements.body && this.hasAccessibleContent(nodeWithStatements.body)) {
+      return true
+    }
+
+    if (nodeWithStatements.subsequent) {
+      return this.hasAccessibleContentInControlFlow(nodeWithStatements.subsequent)
+    }
+
+    return false
   }
 
   private hasHeadingRole(node: HTMLOpenTagNode): boolean {
@@ -99,22 +120,7 @@ class NoEmptyHeadingsVisitor extends BaseRuleVisitor {
       return false
     }
 
-    for (const child of node.body) {
-      if (isLiteralNode(child) || isHTMLTextNode(child)) {
-        if (child.content.trim().length > 0) {
-          return true
-        }
-      } else if (isHTMLElementNode(child)) {
-        if (this.isElementAccessible(child)) {
-          return true
-        }
-      } else {
-        // If there's any non-literal/non-text/non-element content (like ERB), consider it accessible
-        return true
-      }
-    }
-
-    return false
+    return this.hasAccessibleContent(node.body)
   }
 }
 

--- a/javascript/packages/linter/test/rules/html-no-empty-headings.test.ts
+++ b/javascript/packages/linter/test/rules/html-no-empty-headings.test.ts
@@ -161,4 +161,36 @@ describe("html-no-empty-headings", () => {
   test("passes for empty ARIA heading inside template tag", () => {
     expectNoOffenses('<template><div role="heading"></div></template>')
   })
+
+  test("fails for heading with only non-output ERB (issue #847)", () => {
+    expectError("Heading element `<h1>` must not be empty. Provide accessible text content for screen readers and SEO.")
+
+    assertOffenses('<h1><% title %></h1>')
+  })
+
+  test("fails for heading with non-output ERB and whitespace", () => {
+    expectError("Heading element `<h2>` must not be empty. Provide accessible text content for screen readers and SEO.")
+
+    assertOffenses('<h2> <% some_method %> </h2>')
+  })
+
+  test("passes for heading with ERB if containing output ERB", () => {
+    expectNoOffenses('<h1><% if show_title %><%= title %><% end %></h1>')
+  })
+
+  test("fails for heading with ERB if not containing any ERB output", () => {
+    expectError("Heading element `<h1>` must not be empty. Provide accessible text content for screen readers and SEO.")
+
+    assertOffenses('<h1><% if show_title %><% title %><% end %></h1>')
+  })
+
+  test("passes for heading with ERB block containing output", () => {
+    expectNoOffenses('<h1><% items.each do |item| %><%= item.name %><% end %></h1>')
+  })
+
+  test("fails for heading with only ERB comment", () => {
+    expectError("Heading element `<h1>` must not be empty. Provide accessible text content for screen readers and SEO.")
+
+    assertOffenses('<h1><%# this is a comment %></h1>')
+  })
 })


### PR DESCRIPTION
This pull request changes the `html-no-empty-headings` linter rule to  properly differentiate between ERB output tags (`<%= %>`) and non-output ERB tags (`<% %>`).

Previously, the rule treated all ERB content as accessible, so this template would not be flagged:

```html+erb
<h1><% title %></h1>
```

Now, only ERB output tags (`<%= %>` and `<%== %>`) are considered accessible content. Non-output ERB tags like `<% title %>` or `<%# comment %>` do not produce visible content and are correctly flagged as empty headings.

The rule also recursively checks ERB control flow nodes (`<% if %>`, `<% each %>`, etc.) to determine if any branch contains output ERB.

Resolves #847
