### PR TITLE
Core: Fix `TS2304: Cannot find name 'TextDecoder'` error

### DIFF
--- a/javascript/packages/core/tsconfig.json
+++ b/javascript/packages/core/tsconfig.json
@@ -5,7 +5,7 @@
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "lib": ["ES2022"],
+    "lib": ["ES2022", "dom"],
     "outDir": "./dist",
     "declaration": true,
     "declarationDir": "./dist/types",


### PR DESCRIPTION
Resolves #1167