### PR TITLE
Ruby: Remove `tsort` from `Gemfile` since it's fixed in RBS

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem "prism", github: "ruby/prism", tag: "v1.9.0"
 gem "actionview", "~> 8.0"
 gem "digest", "~> 3.2"
 gem "erubi"
+gem "irb", "~> 1.16"
 gem "lz_string"
 gem "maxitest", "~> 6.0"
 gem "minitest-difftastic", "~> 0.2"
@@ -23,12 +24,3 @@ gem "sorbet"
 # TODO: Remove once https://github.com/ruby/rbs/pull/2850 is merged and released
 gem "rbs", github: "marcoroth/rbs", branch: "psych-load-unsafe-file"
 gem "steep", github: "soutaro/steep", branch: "master"
-
-# TODO: remove once it's fixed in RBS
-# ❯ bundle exec rbs-inline --opt-out --output=sig/ lib/
-# /Users/marcoroth/Development/herb/vendor/bundle/ruby/4.0.0/gems/rbs-3.10.0/lib/rbs.rb:11: warning: tsort was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 4.1.0
-# You can add tsort to your Gemfile or gemspec to silence this warning.
-# 🎉 Generated 0 RBS files under sig/
-gem "tsort", "~> 0.2.0"
-
-gem "irb", "~> 1.16"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -233,7 +233,6 @@ DEPENDENCIES
   rubocop (~> 1.71)
   sorbet
   steep!
-  tsort (~> 0.2.0)
 
 BUNDLED WITH
    2.7.2


### PR DESCRIPTION
Related: https://github.com/ruby/rbs/pull/2601
Related: https://github.com/ruby/webrick/pull/192