### PR TITLE
Engine: Add `AutoCloseOmittedTagsVisitor`

### DIFF
--- a/Yerbafile
+++ b/Yerbafile
@@ -81,6 +81,7 @@ rules:
           order:
             - name
             - type
+            - writable
             - kind
 
       - quote_style:

--- a/config.yml
+++ b/config.yml
@@ -634,6 +634,7 @@ nodes:
 
         - name: "close_tag"
           type: "node"
+          writable: true
           kind:
             - "HTMLCloseTagNode"
             - "HTMLOmittedCloseTagNode"

--- a/docs/docs/projects/engine.md
+++ b/docs/docs/projects/engine.md
@@ -73,8 +73,65 @@ Controls how the engine presents validation results:
 - **`:overlay`** — Renders errors as in-browser overlay (used by [ReActionView](https://github.com/marcoroth/reactionview) in development)
 - **`:none`** — Skips validation entirely
 
+## Transform Visitors
+
+The `visitors` option accepts [visitors](/bindings/ruby/reference#visitors) that run over the AST before compilation. Transform visitors rewrite the AST, which changes what the compiler emits.
+
+Herb ships the following transform visitors:
+
+| Visitor | Description |
+|---|---|
+| `AutoCloseOmittedTagsVisitor` | Replaces omitted closing tags with explicit ones |
+
+Transform visitors are not loaded when you `require "herb"`. Require the ones you want and pass them to the engine:
+
+```ruby
+require "herb/engine/auto_close_omitted_tags_visitor"
+
+Herb::Engine.new(source, visitors: [Herb::Engine::AutoCloseOmittedTagsVisitor.new])
+```
+
+Your own visitors are passed the same way. See [Visitors](/bindings/ruby/reference#visitors) for how to write one.
+
+### AutoCloseOmittedTagsVisitor
+
+Makes sure the compiled output always contains a closing tag, even when the template omits it.
+
+Given this template:
+
+```html+erb
+<ul>
+  <li>List Item 1
+  <li>List Item 2
+</ul>
+```
+
+The engine renders:
+
+```html
+<ul>
+  <li>List Item 1
+  </li><li>List Item 2
+</li></ul>
+```
+
+The closing tag is inserted where the parser determined the element ends, which keeps the surrounding whitespace (and therefore the rendering of `inline-block` elements) identical to the template without the visitor.
+
 ## ReActionView Integration
 
 [ReActionView](https://github.com/marcoroth/reactionview) registers `Herb::Engine` as the template handler for `.html.erb` and `.html.herb` files in Rails. It uses `validation_mode: :overlay` so validation errors appear as in-browser overlays during development instead of raising exceptions.
 
 Validator settings from `.herb.yml` are respected automatically — no ReActionView-specific configuration needed.
+
+ReActionView also lets you run transform visitors on every template it compiles, through `config.transform_visitors`:
+
+```ruby
+# config/initializers/reactionview.rb
+require "herb/engine/auto_close_omitted_tags_visitor"
+
+ReActionView.configure do |config|
+  config.transform_visitors = [
+    Herb::Engine::AutoCloseOmittedTagsVisitor.new
+  ]
+end
+```

--- a/lib/herb/ast/helpers.rb
+++ b/lib/herb/ast/helpers.rb
@@ -27,11 +27,18 @@ module Herb
         opening.include?("=")
       end
 
+      #: (Herb::AST::Node?) -> Herb::AST::HTMLOmittedCloseTagNode?
+      def omitted_close_tag(node)
+        return nil unless node.is_a?(Herb::AST::HTMLElementNode)
+
+        close_tag = node.close_tag
+
+        close_tag if close_tag.is_a?(Herb::AST::HTMLOmittedCloseTagNode)
+      end
+
       #: (Herb::AST::Node?) -> bool
       def omitted_close_tag?(node)
-        return false unless node.is_a?(Herb::AST::HTMLElementNode)
-
-        node.close_tag.is_a?(Herb::AST::HTMLOmittedCloseTagNode)
+        !omitted_close_tag(node).nil?
       end
 
       #: (Herb::AST::ERBContentNode) -> bool

--- a/lib/herb/ast/helpers.rb
+++ b/lib/herb/ast/helpers.rb
@@ -27,6 +27,13 @@ module Herb
         opening.include?("=")
       end
 
+      #: (Herb::AST::Node?) -> bool
+      def omitted_close_tag?(node)
+        return false unless node.is_a?(Herb::AST::HTMLElementNode)
+
+        node.close_tag.is_a?(Herb::AST::HTMLOmittedCloseTagNode)
+      end
+
       #: (Herb::AST::ERBContentNode) -> bool
       def inline_ruby_comment?(node)
         return false unless node.is_a?(Herb::AST::ERBContentNode)

--- a/lib/herb/engine/auto_close_omitted_tags_visitor.rb
+++ b/lib/herb/engine/auto_close_omitted_tags_visitor.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+# typed: false
+
+require_relative "../../herb"
+
+module Herb
+  class Engine
+    # Replaces omitted closing tags with explicit ones, so that the compiled output always
+    # contains a closing tag, even when the template omits it.
+    #
+    # This visitor is not loaded by default. Require it explicitly and pass it to the engine:
+    #
+    #     require "herb/engine/auto_close_omitted_tags_visitor"
+    #
+    #     Herb::Engine.new(source, visitors: [Herb::Engine::AutoCloseOmittedTagsVisitor.new])
+    #
+    class AutoCloseOmittedTagsVisitor < Herb::Visitor
+      #: (Herb::AST::HTMLElementNode) -> void
+      def visit_html_element_node(node)
+        close_tag = node.close_tag
+
+        node.close_tag = explicit_close_tag(close_tag) if omitted_close_tag?(node) && close_tag.tag_name
+
+        super
+      end
+
+      #: () -> String
+      def inspect
+        "#<#{self.class.name}>"
+      end
+
+      private
+
+      #: (Herb::AST::HTMLOmittedCloseTagNode) -> Herb::AST::HTMLCloseTagNode
+      def explicit_close_tag(omitted_close_tag)
+        Herb::AST::HTMLCloseTagNode.new(
+          "HTMLCloseTagNode",
+          omitted_close_tag.location,
+          [],
+          token("</", "TOKEN_HTML_TAG_START_CLOSE", omitted_close_tag.location),
+          omitted_close_tag.tag_name,
+          [],
+          token(">", "TOKEN_HTML_TAG_END", omitted_close_tag.location)
+        )
+      end
+
+      #: (String, String, Herb::Location?) -> Herb::Token
+      def token(value, type, location)
+        Herb::Token.new(value.dup, Herb::Range.from(0, 0), location || Herb::Location.from(0, 0, 0, 0), type)
+      end
+    end
+  end
+end

--- a/lib/herb/engine/auto_close_omitted_tags_visitor.rb
+++ b/lib/herb/engine/auto_close_omitted_tags_visitor.rb
@@ -17,9 +17,10 @@ module Herb
     class AutoCloseOmittedTagsVisitor < Herb::Visitor
       #: (Herb::AST::HTMLElementNode) -> void
       def visit_html_element_node(node)
-        close_tag = node.close_tag
+        omitted = omitted_close_tag(node)
+        tag_name = omitted&.tag_name
 
-        node.close_tag = explicit_close_tag(close_tag) if omitted_close_tag?(node) && close_tag.tag_name
+        node.close_tag = explicit_close_tag(tag_name, omitted.location) if omitted && tag_name
 
         super
       end
@@ -31,22 +32,22 @@ module Herb
 
       private
 
-      #: (Herb::AST::HTMLOmittedCloseTagNode) -> Herb::AST::HTMLCloseTagNode
-      def explicit_close_tag(omitted_close_tag)
+      #: (Herb::Token, Herb::Location) -> Herb::AST::HTMLCloseTagNode
+      def explicit_close_tag(tag_name, location)
         Herb::AST::HTMLCloseTagNode.new(
           "HTMLCloseTagNode",
-          omitted_close_tag.location,
+          location,
           [],
-          token("</", "TOKEN_HTML_TAG_START_CLOSE", omitted_close_tag.location),
-          omitted_close_tag.tag_name,
+          token("</", "TOKEN_HTML_TAG_START_CLOSE", location),
+          tag_name,
           [],
-          token(">", "TOKEN_HTML_TAG_END", omitted_close_tag.location)
+          token(">", "TOKEN_HTML_TAG_END", location)
         )
       end
 
-      #: (String, String, Herb::Location?) -> Herb::Token
+      #: (String, String, Herb::Location) -> Herb::Token
       def token(value, type, location)
-        Herb::Token.new(value.dup, Herb::Range.from(0, 0), location || Herb::Location.from(0, 0, 0, 0), type)
+        Herb::Token.new(value.dup, Herb::Range.from(0, 0), location, type)
       end
     end
   end

--- a/sig/herb/ast/helpers.rbs
+++ b/sig/herb/ast/helpers.rbs
@@ -15,6 +15,9 @@ module Herb
       # : (String) -> bool
       def erb_output?: (String) -> bool
 
+      # : (Herb::AST::Node?) -> bool
+      def omitted_close_tag?: (Herb::AST::Node?) -> bool
+
       # : (Herb::AST::ERBContentNode) -> bool
       def inline_ruby_comment?: (Herb::AST::ERBContentNode) -> bool
     end

--- a/sig/herb/ast/helpers.rbs
+++ b/sig/herb/ast/helpers.rbs
@@ -15,6 +15,9 @@ module Herb
       # : (String) -> bool
       def erb_output?: (String) -> bool
 
+      # : (Herb::AST::Node?) -> Herb::AST::HTMLOmittedCloseTagNode?
+      def omitted_close_tag: (Herb::AST::Node?) -> Herb::AST::HTMLOmittedCloseTagNode?
+
       # : (Herb::AST::Node?) -> bool
       def omitted_close_tag?: (Herb::AST::Node?) -> bool
 

--- a/sig/herb/ast/nodes.rbs
+++ b/sig/herb/ast/nodes.rbs
@@ -265,7 +265,7 @@ module Herb
 
       attr_reader body: Array[Herb::AST::Node]
 
-      attr_reader close_tag: (Herb::AST::HTMLCloseTagNode | Herb::AST::HTMLOmittedCloseTagNode | Herb::AST::HTMLVirtualCloseTagNode | Herb::AST::ERBEndNode)?
+      attr_accessor close_tag: (Herb::AST::HTMLCloseTagNode | Herb::AST::HTMLOmittedCloseTagNode | Herb::AST::HTMLVirtualCloseTagNode | Herb::AST::ERBEndNode)?
 
       attr_reader is_void: bool
 

--- a/sig/herb/engine/auto_close_omitted_tags_visitor.rbs
+++ b/sig/herb/engine/auto_close_omitted_tags_visitor.rbs
@@ -19,11 +19,11 @@ module Herb
 
       private
 
-      # : (Herb::AST::HTMLOmittedCloseTagNode) -> Herb::AST::HTMLCloseTagNode
-      def explicit_close_tag: (Herb::AST::HTMLOmittedCloseTagNode) -> Herb::AST::HTMLCloseTagNode
+      # : (Herb::Token, Herb::Location) -> Herb::AST::HTMLCloseTagNode
+      def explicit_close_tag: (Herb::Token, Herb::Location) -> Herb::AST::HTMLCloseTagNode
 
-      # : (String, String, Herb::Location?) -> Herb::Token
-      def token: (String, String, Herb::Location?) -> Herb::Token
+      # : (String, String, Herb::Location) -> Herb::Token
+      def token: (String, String, Herb::Location) -> Herb::Token
     end
   end
 end

--- a/sig/herb/engine/auto_close_omitted_tags_visitor.rbs
+++ b/sig/herb/engine/auto_close_omitted_tags_visitor.rbs
@@ -1,0 +1,29 @@
+# Generated from lib/herb/engine/auto_close_omitted_tags_visitor.rb with RBS::Inline
+
+module Herb
+  class Engine
+    # Replaces omitted closing tags with explicit ones, so that the compiled output always
+    # contains a closing tag, even when the template omits it.
+    #
+    # This visitor is not loaded by default. Require it explicitly and pass it to the engine:
+    #
+    #     require "herb/engine/auto_close_omitted_tags_visitor"
+    #
+    #     Herb::Engine.new(source, visitors: [Herb::Engine::AutoCloseOmittedTagsVisitor.new])
+    class AutoCloseOmittedTagsVisitor < Herb::Visitor
+      # : (Herb::AST::HTMLElementNode) -> void
+      def visit_html_element_node: (Herb::AST::HTMLElementNode) -> void
+
+      # : () -> String
+      def inspect: () -> String
+
+      private
+
+      # : (Herb::AST::HTMLOmittedCloseTagNode) -> Herb::AST::HTMLCloseTagNode
+      def explicit_close_tag: (Herb::AST::HTMLOmittedCloseTagNode) -> Herb::AST::HTMLCloseTagNode
+
+      # : (String, String, Herb::Location?) -> Herb::Token
+      def token: (String, String, Herb::Location?) -> Herb::Token
+    end
+  end
+end

--- a/templates/lib/herb/ast/nodes.rb.erb
+++ b/templates/lib/herb/ast/nodes.rb.erb
@@ -14,7 +14,7 @@ module Herb
 
       <%- node.fields.each do |field| -%>
       <%- is_nilable = !%w[Array[Herb::AST::Node] Array[Herb::AST::ERBWhenNode] Array[Herb::AST::ERBInNode] bool nil].include?(field.ruby_type) -%>
-      attr_reader :<%= field.name %> #: <%= field.ruby_type %><%= if is_nilable then "?" end %>
+      <%= field.writable? ? "attr_accessor" : "attr_reader" %> :<%= field.name %> #: <%= field.ruby_type %><%= if is_nilable then "?" end %>
       <%- end -%>
 
       #: (<%= ["String", "Location", "Array[Herb::Errors::Error]", *node.fields.map(&:ruby_type)].join(", ") %>) -> void

--- a/templates/template.rb
+++ b/templates/template.rb
@@ -25,6 +25,10 @@ module Herb
         @options = options
       end
 
+      def writable?
+        options.fetch(:writable, false)
+      end
+
       def always_invisible?
         ALWAYS_INVISIBLE_FIELD_CLASSES.include?(self.class.name.split("::").last)
       end
@@ -412,7 +416,7 @@ module Herb
           type = field_type_for(field.fetch("type"))
           kind = normalize_kind(field.fetch("kind", nil), type, @name, field_name)
 
-          type.new(name: field_name, kind: kind)
+          type.new(name: field_name, kind: kind, writable: field.fetch("writable", false))
         end
       end
 

--- a/test/engine/auto_close_omitted_tags_visitor_test.rb
+++ b/test/engine/auto_close_omitted_tags_visitor_test.rb
@@ -1,0 +1,347 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+require_relative "../snapshot_utils"
+require_relative "../../lib/herb/engine"
+require_relative "../../lib/herb/engine/auto_close_omitted_tags_visitor"
+
+module Engine
+  class AutoCloseOmittedTagsVisitorTest < Minitest::Spec
+    include SnapshotUtils
+
+    def auto_close_options
+      {
+        escape: false,
+        parser_options: { strict: false },
+        visitors: [Herb::Engine::AutoCloseOmittedTagsVisitor.new],
+      }
+    end
+
+    test "visitor is not loaded when only requiring herb" do
+      load_path = $LOAD_PATH.map { |path| "-I#{path}" }.join(" ")
+      output = `#{Gem.ruby} #{load_path} -e 'require "herb"; print defined?(Herb::Engine::AutoCloseOmittedTagsVisitor).inspect' 2>&1`
+
+      assert_equal "nil", output
+    end
+
+    test "p element without closing tag - compilation" do
+      template = "<p>Hello World"
+
+      assert_compiled_snapshot(template, auto_close_options)
+    end
+
+    test "p element without closing tag - render" do
+      template = "<p>Hello World"
+
+      assert_evaluated_snapshot(template, {}, auto_close_options)
+    end
+
+    test "multiple p elements without closing tags - compilation" do
+      template = "<p>First<p>Second<p>Third"
+
+      assert_compiled_snapshot(template, auto_close_options)
+    end
+
+    test "multiple p elements without closing tags - render" do
+      template = "<p>First<p>Second<p>Third"
+
+      assert_evaluated_snapshot(template, {}, auto_close_options)
+    end
+
+    test "li elements without closing tags - compilation" do
+      template = "<ul><li>One<li>Two</ul>"
+
+      assert_compiled_snapshot(template, auto_close_options)
+    end
+
+    test "li elements without closing tags - render" do
+      template = "<ul><li>One<li>Two</ul>"
+
+      assert_evaluated_snapshot(template, {}, auto_close_options)
+    end
+
+    test "dt and dd elements without closing tags - compilation" do
+      template = "<dl><dt>Term<dd>Definition</dl>"
+
+      assert_compiled_snapshot(template, auto_close_options)
+    end
+
+    test "dt and dd elements without closing tags - render" do
+      template = "<dl><dt>Term<dd>Definition</dl>"
+
+      assert_evaluated_snapshot(template, {}, auto_close_options)
+    end
+
+    test "option elements without closing tags - compilation" do
+      template = '<select><option value="1">One<option value="2">Two</select>'
+
+      assert_compiled_snapshot(template, auto_close_options)
+    end
+
+    test "option elements without closing tags - render" do
+      template = '<select><option value="1">One<option value="2">Two</select>'
+
+      assert_evaluated_snapshot(template, {}, auto_close_options)
+    end
+
+    test "tr and td elements without closing tags - compilation" do
+      template = "<table><tr><td>A<td>B<tr><td>C<td>D</table>"
+
+      assert_compiled_snapshot(template, auto_close_options)
+    end
+
+    test "tr and td elements without closing tags - render" do
+      template = "<table><tr><td>A<td>B<tr><td>C<td>D</table>"
+
+      assert_evaluated_snapshot(template, {}, auto_close_options)
+    end
+
+    test "thead tbody tfoot without closing tags - compilation" do
+      template = "<table><thead><tr><th>H<tbody><tr><td>B<tfoot><tr><td>F</table>"
+
+      assert_compiled_snapshot(template, auto_close_options)
+    end
+
+    test "thead tbody tfoot without closing tags - render" do
+      template = "<table><thead><tr><th>H<tbody><tr><td>B<tfoot><tr><td>F</table>"
+
+      assert_evaluated_snapshot(template, {}, auto_close_options)
+    end
+
+    test "rt and rp elements without closing tags - compilation" do
+      template = "<ruby>Base<rp>(<rt>annotation<rp>)</ruby>"
+
+      assert_compiled_snapshot(template, auto_close_options)
+    end
+
+    test "rt and rp elements without closing tags - render" do
+      template = "<ruby>Base<rp>(<rt>annotation<rp>)</ruby>"
+
+      assert_evaluated_snapshot(template, {}, auto_close_options)
+    end
+
+    test "erb expression in p element - compilation" do
+      template = "<p><%= message %>"
+
+      assert_compiled_snapshot(template, auto_close_options)
+    end
+
+    test "erb expression in p element - render" do
+      template = "<p><%= message %>"
+
+      assert_evaluated_snapshot(template, { message: "Hello" }, auto_close_options)
+    end
+
+    test "erb loop with li elements - compilation" do
+      template = "<ul><% items.each do |item| %><li><%= item %><% end %></ul>"
+
+      assert_compiled_snapshot(template, auto_close_options)
+    end
+
+    test "erb loop with li elements - render" do
+      template = "<ul><% items.each do |item| %><li><%= item %><% end %></ul>"
+
+      assert_evaluated_snapshot(template, { items: ["A", "B", "C"] }, auto_close_options)
+    end
+
+    test "mixed explicit and omitted closing tags - compilation" do
+      template = "<ul><li>One</li><li>Two<li>Three</li></ul>"
+
+      assert_compiled_snapshot(template, auto_close_options)
+    end
+
+    test "mixed explicit and omitted closing tags - render" do
+      template = "<ul><li>One</li><li>Two<li>Three</li></ul>"
+
+      assert_evaluated_snapshot(template, {}, auto_close_options)
+    end
+
+    test "complex navigation with optional closing tags - compilation" do
+      template = <<~ERB
+        <nav>
+          <ul>
+            <% items.each do |item| %>
+              <li><a href="<%= item[:url] %>"><%= item[:name] %></a>
+            <% end %>
+          </ul>
+        </nav>
+      ERB
+
+      assert_compiled_snapshot(template, auto_close_options)
+    end
+
+    test "complex navigation with optional closing tags - render" do
+      template = <<~ERB
+        <nav>
+          <ul>
+            <% items.each do |item| %>
+              <li><a href="<%= item[:url] %>"><%= item[:name] %></a>
+            <% end %>
+          </ul>
+        </nav>
+      ERB
+
+      items = [
+        { name: "Home", url: "/" },
+        { name: "About", url: "/about" }
+      ]
+
+      assert_evaluated_snapshot(template, { items: items }, auto_close_options)
+    end
+
+    test "complex table with optional closing tags - compilation" do
+      template = <<~ERB
+        <table>
+          <thead>
+            <tr>
+              <th>Name
+              <th>Age
+          <tbody>
+            <% users.each do |user| %>
+              <tr>
+                <td><%= user[:name] %>
+                <td><%= user[:age] %>
+            <% end %>
+        </table>
+      ERB
+
+      assert_compiled_snapshot(template, auto_close_options)
+    end
+
+    test "complex table with optional closing tags - render" do
+      template = <<~ERB
+        <table>
+          <thead>
+            <tr>
+              <th>Name
+              <th>Age
+          <tbody>
+            <% users.each do |user| %>
+              <tr>
+                <td><%= user[:name] %>
+                <td><%= user[:age] %>
+            <% end %>
+        </table>
+      ERB
+
+      users = [
+        { name: "Alice", age: 30 },
+        { name: "Bob", age: 25 }
+      ]
+
+      assert_evaluated_snapshot(template, { users: users }, auto_close_options)
+    end
+
+    test "GitHub issue #965 - inline-block li elements - closing tag position preserves no-whitespace behavior - compilation" do
+      template = <<~ERB
+        <ul>
+          <li style="display: inline-block">Foo
+          <li style="display: inline-block">Bar
+        </ul>
+      ERB
+
+      assert_compiled_snapshot(template, auto_close_options)
+    end
+
+    test "inline-block li elements - closing tag position preserves no-whitespace behavior - render" do
+      template = <<~ERB
+        <ul>
+          <li style="display: inline-block">Foo
+          <li style="display: inline-block">Bar
+        </ul>
+      ERB
+
+      assert_evaluated_snapshot(template, {}, auto_close_options)
+    end
+
+    test "inline-block li elements - single line maintains no whitespace - compilation" do
+      template = '<ul><li style="display: inline-block">Foo<li style="display: inline-block">Bar</ul>'
+
+      assert_compiled_snapshot(template, auto_close_options)
+    end
+
+    test "inline-block li elements - single line maintains no whitespace - render" do
+      template = '<ul><li style="display: inline-block">Foo<li style="display: inline-block">Bar</ul>'
+
+      assert_evaluated_snapshot(template, {}, auto_close_options)
+    end
+
+    test "inline-block with erb - closing tag inserted at correct position - compilation" do
+      template = <<~ERB
+        <ul>
+          <% items.each do |item| %>
+            <li style="display: inline-block"><%= item %>
+          <% end %>
+        </ul>
+      ERB
+
+      assert_compiled_snapshot(template, auto_close_options)
+    end
+
+    test "inline-block with erb - closing tag inserted at correct position - render" do
+      template = <<~ERB
+        <ul>
+          <% items.each do |item| %>
+            <li style="display: inline-block"><%= item %>
+          <% end %>
+        </ul>
+      ERB
+
+      assert_evaluated_snapshot(template, { items: ["A", "B", "C"] }, auto_close_options)
+    end
+
+    test "p elements on separate lines - whitespace preserved between elements - render" do
+      template = "<p>First\n<p>Second"
+
+      assert_evaluated_snapshot(template, {}, auto_close_options)
+    end
+
+    test "closing tag inserted immediately after content - no trailing whitespace added" do
+      engine = Herb::Engine.new("<p>Text", auto_close_options)
+
+      assert_equal "<p>Text</p>", eval(engine.src)
+    end
+
+    test "without the visitor the omitted closing tag is not emitted" do
+      template = "<ul><li>One<li>Two</ul>"
+
+      engine = Herb::Engine.new(template, escape: false, parser_options: { strict: false })
+
+      assert_equal "<ul><li>One<li>Two</ul>", eval(engine.src)
+    end
+
+    test "explicit closing tags are left untouched" do
+      template = "<ul><li>One</li><li>Two</li></ul>"
+
+      engine = Herb::Engine.new(template, auto_close_options)
+
+      assert_equal template, eval(engine.src)
+    end
+
+    test "void elements are not given a closing tag" do
+      template = "<div><br><img src=\"a.png\"></div>"
+
+      engine = Herb::Engine.new(template, auto_close_options)
+
+      assert_equal template, eval(engine.src)
+    end
+
+    test "the visitor replaces the omitted close tag node in the AST" do
+      result = Herb.parse("<ul><li>One<li>Two</ul>", strict: false)
+
+      result.value.accept(Herb::Engine::AutoCloseOmittedTagsVisitor.new)
+
+      close_tags = []
+
+      collect = lambda do |node|
+        close_tags << node.close_tag if node.is_a?(Herb::AST::HTMLElementNode)
+        node.compact_child_nodes.each { |child| collect.call(child) }
+      end
+
+      collect.call(result.value)
+
+      assert_empty close_tags.compact.grep(Herb::AST::HTMLOmittedCloseTagNode)
+      assert_equal(2, close_tags.compact.grep(Herb::AST::HTMLCloseTagNode).count { |node| node.tag_name.value == "li" })
+    end
+  end
+end

--- a/test/snapshots/engine/auto_close_omitted_tags_visitor_test/test_0002_p_element_without_closing_tag_-_compilation_6a863f0d0a26c21376cd031ebe84ae31.txt
+++ b/test/snapshots/engine/auto_close_omitted_tags_visitor_test/test_0002_p_element_without_closing_tag_-_compilation_6a863f0d0a26c21376cd031ebe84ae31.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::AutoCloseOmittedTagsVisitorTest#test_0002_p element without closing tag - compilation"
+input: "{source: \"<p>Hello World\", options: {escape: false, parser_options: {strict: false}, visitors: [#<Herb::Engine::AutoCloseOmittedTagsVisitor>]}}"
+---
+_buf = ::String.new; _buf << '<p>Hello World</p>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/auto_close_omitted_tags_visitor_test/test_0003_p_element_without_closing_tag_-_render_e07dab1168265a26f91fbb5294f15c1c.txt
+++ b/test/snapshots/engine/auto_close_omitted_tags_visitor_test/test_0003_p_element_without_closing_tag_-_render_e07dab1168265a26f91fbb5294f15c1c.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::AutoCloseOmittedTagsVisitorTest#test_0003_p element without closing tag - render"
+input: "{source: \"<p>Hello World\", locals: {}, options: {escape: false, parser_options: {strict: false}, visitors: [#<Herb::Engine::AutoCloseOmittedTagsVisitor>]}}"
+---
+<p>Hello World</p>

--- a/test/snapshots/engine/auto_close_omitted_tags_visitor_test/test_0004_multiple_p_elements_without_closing_tags_-_compilation_23d7528cd6ecedb68b362f0ce9d1fec8.txt
+++ b/test/snapshots/engine/auto_close_omitted_tags_visitor_test/test_0004_multiple_p_elements_without_closing_tags_-_compilation_23d7528cd6ecedb68b362f0ce9d1fec8.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::AutoCloseOmittedTagsVisitorTest#test_0004_multiple p elements without closing tags - compilation"
+input: "{source: \"<p>First<p>Second<p>Third\", options: {escape: false, parser_options: {strict: false}, visitors: [#<Herb::Engine::AutoCloseOmittedTagsVisitor>]}}"
+---
+_buf = ::String.new; _buf << '<p>First</p><p>Second</p><p>Third</p>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/auto_close_omitted_tags_visitor_test/test_0005_multiple_p_elements_without_closing_tags_-_render_d3108544c029cf7efbfcacba87e4f78f.txt
+++ b/test/snapshots/engine/auto_close_omitted_tags_visitor_test/test_0005_multiple_p_elements_without_closing_tags_-_render_d3108544c029cf7efbfcacba87e4f78f.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::AutoCloseOmittedTagsVisitorTest#test_0005_multiple p elements without closing tags - render"
+input: "{source: \"<p>First<p>Second<p>Third\", locals: {}, options: {escape: false, parser_options: {strict: false}, visitors: [#<Herb::Engine::AutoCloseOmittedTagsVisitor>]}}"
+---
+<p>First</p><p>Second</p><p>Third</p>

--- a/test/snapshots/engine/auto_close_omitted_tags_visitor_test/test_0006_li_elements_without_closing_tags_-_compilation_049c66e512493a9948e7c1a986afec41.txt
+++ b/test/snapshots/engine/auto_close_omitted_tags_visitor_test/test_0006_li_elements_without_closing_tags_-_compilation_049c66e512493a9948e7c1a986afec41.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::AutoCloseOmittedTagsVisitorTest#test_0006_li elements without closing tags - compilation"
+input: "{source: \"<ul><li>One<li>Two</ul>\", options: {escape: false, parser_options: {strict: false}, visitors: [#<Herb::Engine::AutoCloseOmittedTagsVisitor>]}}"
+---
+_buf = ::String.new; _buf << '<ul><li>One</li><li>Two</li></ul>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/auto_close_omitted_tags_visitor_test/test_0007_li_elements_without_closing_tags_-_render_e3ae6ef5921ad61dbd373321a3a92e80.txt
+++ b/test/snapshots/engine/auto_close_omitted_tags_visitor_test/test_0007_li_elements_without_closing_tags_-_render_e3ae6ef5921ad61dbd373321a3a92e80.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::AutoCloseOmittedTagsVisitorTest#test_0007_li elements without closing tags - render"
+input: "{source: \"<ul><li>One<li>Two</ul>\", locals: {}, options: {escape: false, parser_options: {strict: false}, visitors: [#<Herb::Engine::AutoCloseOmittedTagsVisitor>]}}"
+---
+<ul><li>One</li><li>Two</li></ul>

--- a/test/snapshots/engine/auto_close_omitted_tags_visitor_test/test_0008_dt_and_dd_elements_without_closing_tags_-_compilation_8289ddae45916091bcafa955293682c4.txt
+++ b/test/snapshots/engine/auto_close_omitted_tags_visitor_test/test_0008_dt_and_dd_elements_without_closing_tags_-_compilation_8289ddae45916091bcafa955293682c4.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::AutoCloseOmittedTagsVisitorTest#test_0008_dt and dd elements without closing tags - compilation"
+input: "{source: \"<dl><dt>Term<dd>Definition</dl>\", options: {escape: false, parser_options: {strict: false}, visitors: [#<Herb::Engine::AutoCloseOmittedTagsVisitor>]}}"
+---
+_buf = ::String.new; _buf << '<dl><dt>Term</dt><dd>Definition</dd></dl>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/auto_close_omitted_tags_visitor_test/test_0009_dt_and_dd_elements_without_closing_tags_-_render_74ff23b0aafca7ba0417999ac459fbbb.txt
+++ b/test/snapshots/engine/auto_close_omitted_tags_visitor_test/test_0009_dt_and_dd_elements_without_closing_tags_-_render_74ff23b0aafca7ba0417999ac459fbbb.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::AutoCloseOmittedTagsVisitorTest#test_0009_dt and dd elements without closing tags - render"
+input: "{source: \"<dl><dt>Term<dd>Definition</dl>\", locals: {}, options: {escape: false, parser_options: {strict: false}, visitors: [#<Herb::Engine::AutoCloseOmittedTagsVisitor>]}}"
+---
+<dl><dt>Term</dt><dd>Definition</dd></dl>

--- a/test/snapshots/engine/auto_close_omitted_tags_visitor_test/test_0010_option_elements_without_closing_tags_-_compilation_ff23ffb54a4096b92ecc3324ad7cfb87.txt
+++ b/test/snapshots/engine/auto_close_omitted_tags_visitor_test/test_0010_option_elements_without_closing_tags_-_compilation_ff23ffb54a4096b92ecc3324ad7cfb87.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::AutoCloseOmittedTagsVisitorTest#test_0010_option elements without closing tags - compilation"
+input: "{source: \"<select><option value=\\\"1\\\">One<option value=\\\"2\\\">Two</select>\", options: {escape: false, parser_options: {strict: false}, visitors: [#<Herb::Engine::AutoCloseOmittedTagsVisitor>]}}"
+---
+_buf = ::String.new; _buf << '<select><option value="1">One</option><option value="2">Two</option></select>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/auto_close_omitted_tags_visitor_test/test_0011_option_elements_without_closing_tags_-_render_d64e1b8816bbeb43cef05e670a10b872.txt
+++ b/test/snapshots/engine/auto_close_omitted_tags_visitor_test/test_0011_option_elements_without_closing_tags_-_render_d64e1b8816bbeb43cef05e670a10b872.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::AutoCloseOmittedTagsVisitorTest#test_0011_option elements without closing tags - render"
+input: "{source: \"<select><option value=\\\"1\\\">One<option value=\\\"2\\\">Two</select>\", locals: {}, options: {escape: false, parser_options: {strict: false}, visitors: [#<Herb::Engine::AutoCloseOmittedTagsVisitor>]}}"
+---
+<select><option value="1">One</option><option value="2">Two</option></select>

--- a/test/snapshots/engine/auto_close_omitted_tags_visitor_test/test_0012_tr_and_td_elements_without_closing_tags_-_compilation_e29f840e1f5c8a05228443d1e0e37a39.txt
+++ b/test/snapshots/engine/auto_close_omitted_tags_visitor_test/test_0012_tr_and_td_elements_without_closing_tags_-_compilation_e29f840e1f5c8a05228443d1e0e37a39.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::AutoCloseOmittedTagsVisitorTest#test_0012_tr and td elements without closing tags - compilation"
+input: "{source: \"<table><tr><td>A<td>B<tr><td>C<td>D</table>\", options: {escape: false, parser_options: {strict: false}, visitors: [#<Herb::Engine::AutoCloseOmittedTagsVisitor>]}}"
+---
+_buf = ::String.new; _buf << '<table><tr><td>A</td><td>B</td></tr><tr><td>C</td><td>D</td></tr></table>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/auto_close_omitted_tags_visitor_test/test_0013_tr_and_td_elements_without_closing_tags_-_render_2587f930c6ceb1b39aa491434c7a2cfc.txt
+++ b/test/snapshots/engine/auto_close_omitted_tags_visitor_test/test_0013_tr_and_td_elements_without_closing_tags_-_render_2587f930c6ceb1b39aa491434c7a2cfc.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::AutoCloseOmittedTagsVisitorTest#test_0013_tr and td elements without closing tags - render"
+input: "{source: \"<table><tr><td>A<td>B<tr><td>C<td>D</table>\", locals: {}, options: {escape: false, parser_options: {strict: false}, visitors: [#<Herb::Engine::AutoCloseOmittedTagsVisitor>]}}"
+---
+<table><tr><td>A</td><td>B</td></tr><tr><td>C</td><td>D</td></tr></table>

--- a/test/snapshots/engine/auto_close_omitted_tags_visitor_test/test_0014_thead_tbody_tfoot_without_closing_tags_-_compilation_3740825b372b408fd9df432afcd0fe7a.txt
+++ b/test/snapshots/engine/auto_close_omitted_tags_visitor_test/test_0014_thead_tbody_tfoot_without_closing_tags_-_compilation_3740825b372b408fd9df432afcd0fe7a.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::AutoCloseOmittedTagsVisitorTest#test_0014_thead tbody tfoot without closing tags - compilation"
+input: "{source: \"<table><thead><tr><th>H<tbody><tr><td>B<tfoot><tr><td>F</table>\", options: {escape: false, parser_options: {strict: false}, visitors: [#<Herb::Engine::AutoCloseOmittedTagsVisitor>]}}"
+---
+_buf = ::String.new; _buf << '<table><thead><tr><th>H</th></tr></thead><tbody><tr><td>B</td></tr></tbody><tfoot><tr><td>F</td></tr></tfoot></table>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/auto_close_omitted_tags_visitor_test/test_0015_thead_tbody_tfoot_without_closing_tags_-_render_9d4edbd0d7e7590b1ef833b38618b562.txt
+++ b/test/snapshots/engine/auto_close_omitted_tags_visitor_test/test_0015_thead_tbody_tfoot_without_closing_tags_-_render_9d4edbd0d7e7590b1ef833b38618b562.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::AutoCloseOmittedTagsVisitorTest#test_0015_thead tbody tfoot without closing tags - render"
+input: "{source: \"<table><thead><tr><th>H<tbody><tr><td>B<tfoot><tr><td>F</table>\", locals: {}, options: {escape: false, parser_options: {strict: false}, visitors: [#<Herb::Engine::AutoCloseOmittedTagsVisitor>]}}"
+---
+<table><thead><tr><th>H</th></tr></thead><tbody><tr><td>B</td></tr></tbody><tfoot><tr><td>F</td></tr></tfoot></table>

--- a/test/snapshots/engine/auto_close_omitted_tags_visitor_test/test_0016_rt_and_rp_elements_without_closing_tags_-_compilation_a06106ac4d5dfbc0f227b69078bbd1ec.txt
+++ b/test/snapshots/engine/auto_close_omitted_tags_visitor_test/test_0016_rt_and_rp_elements_without_closing_tags_-_compilation_a06106ac4d5dfbc0f227b69078bbd1ec.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::AutoCloseOmittedTagsVisitorTest#test_0016_rt and rp elements without closing tags - compilation"
+input: "{source: \"<ruby>Base<rp>(<rt>annotation<rp>)</ruby>\", options: {escape: false, parser_options: {strict: false}, visitors: [#<Herb::Engine::AutoCloseOmittedTagsVisitor>]}}"
+---
+_buf = ::String.new; _buf << '<ruby>Base<rp>(</rp><rt>annotation</rt><rp>)</rp></ruby>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/auto_close_omitted_tags_visitor_test/test_0017_rt_and_rp_elements_without_closing_tags_-_render_e20b7c17c05d5ebdc93f59d93a10c2ee.txt
+++ b/test/snapshots/engine/auto_close_omitted_tags_visitor_test/test_0017_rt_and_rp_elements_without_closing_tags_-_render_e20b7c17c05d5ebdc93f59d93a10c2ee.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::AutoCloseOmittedTagsVisitorTest#test_0017_rt and rp elements without closing tags - render"
+input: "{source: \"<ruby>Base<rp>(<rt>annotation<rp>)</ruby>\", locals: {}, options: {escape: false, parser_options: {strict: false}, visitors: [#<Herb::Engine::AutoCloseOmittedTagsVisitor>]}}"
+---
+<ruby>Base<rp>(</rp><rt>annotation</rt><rp>)</rp></ruby>

--- a/test/snapshots/engine/auto_close_omitted_tags_visitor_test/test_0018_erb_expression_in_p_element_-_compilation_d1787839d0dfc407e49cadcc1b43e078.txt
+++ b/test/snapshots/engine/auto_close_omitted_tags_visitor_test/test_0018_erb_expression_in_p_element_-_compilation_d1787839d0dfc407e49cadcc1b43e078.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::AutoCloseOmittedTagsVisitorTest#test_0018_erb expression in p element - compilation"
+input: "{source: \"<p><%= message %>\", options: {escape: false, parser_options: {strict: false}, visitors: [#<Herb::Engine::AutoCloseOmittedTagsVisitor>]}}"
+---
+_buf = ::String.new; _buf << '<p>'.freeze; _buf << (message).to_s; _buf << '</p>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/auto_close_omitted_tags_visitor_test/test_0019_erb_expression_in_p_element_-_render_a1c8cab88af2ff345f3924d691a3c994.txt
+++ b/test/snapshots/engine/auto_close_omitted_tags_visitor_test/test_0019_erb_expression_in_p_element_-_render_a1c8cab88af2ff345f3924d691a3c994.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::AutoCloseOmittedTagsVisitorTest#test_0019_erb expression in p element - render"
+input: "{source: \"<p><%= message %>\", locals: {message: \"Hello\"}, options: {escape: false, parser_options: {strict: false}, visitors: [#<Herb::Engine::AutoCloseOmittedTagsVisitor>]}}"
+---
+<p>Hello</p>

--- a/test/snapshots/engine/auto_close_omitted_tags_visitor_test/test_0020_erb_loop_with_li_elements_-_compilation_838aedacfbad28cc96a71fefc48eb27a.txt
+++ b/test/snapshots/engine/auto_close_omitted_tags_visitor_test/test_0020_erb_loop_with_li_elements_-_compilation_838aedacfbad28cc96a71fefc48eb27a.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::AutoCloseOmittedTagsVisitorTest#test_0020_erb loop with li elements - compilation"
+input: "{source: \"<ul><% items.each do |item| %><li><%= item %><% end %></ul>\", options: {escape: false, parser_options: {strict: false}, visitors: [#<Herb::Engine::AutoCloseOmittedTagsVisitor>]}}"
+---
+_buf = ::String.new; _buf << '<ul>'.freeze; items.each do |item|; _buf << '<li>'.freeze; _buf << (item).to_s; _buf << '</li>'.freeze; end; _buf << '</ul>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/auto_close_omitted_tags_visitor_test/test_0021_erb_loop_with_li_elements_-_render_d326a541536415325c3ba67fc71c7d13.txt
+++ b/test/snapshots/engine/auto_close_omitted_tags_visitor_test/test_0021_erb_loop_with_li_elements_-_render_d326a541536415325c3ba67fc71c7d13.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::AutoCloseOmittedTagsVisitorTest#test_0021_erb loop with li elements - render"
+input: "{source: \"<ul><% items.each do |item| %><li><%= item %><% end %></ul>\", locals: {items: [\"A\", \"B\", \"C\"]}, options: {escape: false, parser_options: {strict: false}, visitors: [#<Herb::Engine::AutoCloseOmittedTagsVisitor>]}}"
+---
+<ul><li>A</li><li>B</li><li>C</li></ul>

--- a/test/snapshots/engine/auto_close_omitted_tags_visitor_test/test_0022_mixed_explicit_and_omitted_closing_tags_-_compilation_512dec0622aee05559bec8d4284968ea.txt
+++ b/test/snapshots/engine/auto_close_omitted_tags_visitor_test/test_0022_mixed_explicit_and_omitted_closing_tags_-_compilation_512dec0622aee05559bec8d4284968ea.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::AutoCloseOmittedTagsVisitorTest#test_0022_mixed explicit and omitted closing tags - compilation"
+input: "{source: \"<ul><li>One</li><li>Two<li>Three</li></ul>\", options: {escape: false, parser_options: {strict: false}, visitors: [#<Herb::Engine::AutoCloseOmittedTagsVisitor>]}}"
+---
+_buf = ::String.new; _buf << '<ul><li>One</li><li>Two</li><li>Three</li></ul>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/auto_close_omitted_tags_visitor_test/test_0023_mixed_explicit_and_omitted_closing_tags_-_render_18ad27e990dfd538089895a304e10010.txt
+++ b/test/snapshots/engine/auto_close_omitted_tags_visitor_test/test_0023_mixed_explicit_and_omitted_closing_tags_-_render_18ad27e990dfd538089895a304e10010.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::AutoCloseOmittedTagsVisitorTest#test_0023_mixed explicit and omitted closing tags - render"
+input: "{source: \"<ul><li>One</li><li>Two<li>Three</li></ul>\", locals: {}, options: {escape: false, parser_options: {strict: false}, visitors: [#<Herb::Engine::AutoCloseOmittedTagsVisitor>]}}"
+---
+<ul><li>One</li><li>Two</li><li>Three</li></ul>

--- a/test/snapshots/engine/auto_close_omitted_tags_visitor_test/test_0024_complex_navigation_with_optional_closing_tags_-_compilation_c8c5122d6cd0a905d13fec9613e3a65c.txt
+++ b/test/snapshots/engine/auto_close_omitted_tags_visitor_test/test_0024_complex_navigation_with_optional_closing_tags_-_compilation_c8c5122d6cd0a905d13fec9613e3a65c.txt
@@ -1,0 +1,13 @@
+---
+source: "Engine::AutoCloseOmittedTagsVisitorTest#test_0024_complex navigation with optional closing tags - compilation"
+input: "{source: \"<nav>\\n  <ul>\\n    <% items.each do |item| %>\\n      <li><a href=\\\"<%= item[:url] %>\\\"><%= item[:name] %></a>\\n    <% end %>\\n  </ul>\\n</nav>\\n\", options: {escape: false, parser_options: {strict: false}, visitors: [#<Herb::Engine::AutoCloseOmittedTagsVisitor>]}}"
+---
+_buf = ::String.new; _buf << '<nav>
+  <ul>
+'.freeze;     items.each do |item| 
+ _buf << '      <li><a href="'.freeze; _buf << ::Herb::Engine.attr((item[:url])); _buf << '">'.freeze; _buf << (item[:name]).to_s; _buf << '</a>
+    </li>'.freeze; end; _buf << '
+  </ul>
+</nav>
+'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/auto_close_omitted_tags_visitor_test/test_0025_complex_navigation_with_optional_closing_tags_-_render_8a8ce2bc98468cf8befc4a6ef9da53b5.txt
+++ b/test/snapshots/engine/auto_close_omitted_tags_visitor_test/test_0025_complex_navigation_with_optional_closing_tags_-_render_8a8ce2bc98468cf8befc4a6ef9da53b5.txt
@@ -1,0 +1,11 @@
+---
+source: "Engine::AutoCloseOmittedTagsVisitorTest#test_0025_complex navigation with optional closing tags - render"
+input: "{source: \"<nav>\\n  <ul>\\n    <% items.each do |item| %>\\n      <li><a href=\\\"<%= item[:url] %>\\\"><%= item[:name] %></a>\\n    <% end %>\\n  </ul>\\n</nav>\\n\", locals: {items: [{name: \"Home\", url: \"/\"}, {name: \"About\", url: \"/about\"}]}, options: {escape: false, parser_options: {strict: false}, visitors: [#<Herb::Engine::AutoCloseOmittedTagsVisitor>]}}"
+---
+<nav>
+  <ul>
+      <li><a href="/">Home</a>
+    </li>      <li><a href="/about">About</a>
+    </li>
+  </ul>
+</nav>

--- a/test/snapshots/engine/auto_close_omitted_tags_visitor_test/test_0026_complex_table_with_optional_closing_tags_-_compilation_1dc5040c3b0cb5247ad180558e28dea1.txt
+++ b/test/snapshots/engine/auto_close_omitted_tags_visitor_test/test_0026_complex_table_with_optional_closing_tags_-_compilation_1dc5040c3b0cb5247ad180558e28dea1.txt
@@ -1,0 +1,18 @@
+---
+source: "Engine::AutoCloseOmittedTagsVisitorTest#test_0026_complex table with optional closing tags - compilation"
+input: "{source: \"<table>\\n  <thead>\\n    <tr>\\n      <th>Name\\n      <th>Age\\n  <tbody>\\n    <% users.each do |user| %>\\n      <tr>\\n        <td><%= user[:name] %>\\n        <td><%= user[:age] %>\\n    <% end %>\\n</table>\\n\", options: {escape: false, parser_options: {strict: false}, visitors: [#<Herb::Engine::AutoCloseOmittedTagsVisitor>]}}"
+---
+_buf = ::String.new; _buf << '<table>
+  <thead>
+    <tr>
+      <th>Name
+      </th><th>Age
+  </th></tr></thead><tbody>
+'.freeze;     users.each do |user| 
+ _buf << '      <tr>
+        <td>'.freeze; _buf << (user[:name]).to_s; _buf << '
+        </td><td>'.freeze; _buf << (user[:age]).to_s; _buf << '
+    </td></tr>'.freeze; end; _buf << '
+</tbody></table>
+'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/auto_close_omitted_tags_visitor_test/test_0027_complex_table_with_optional_closing_tags_-_render_08ac25c128182e9bb480d25b7482c719.txt
+++ b/test/snapshots/engine/auto_close_omitted_tags_visitor_test/test_0027_complex_table_with_optional_closing_tags_-_render_08ac25c128182e9bb480d25b7482c719.txt
@@ -1,0 +1,18 @@
+---
+source: "Engine::AutoCloseOmittedTagsVisitorTest#test_0027_complex table with optional closing tags - render"
+input: "{source: \"<table>\\n  <thead>\\n    <tr>\\n      <th>Name\\n      <th>Age\\n  <tbody>\\n    <% users.each do |user| %>\\n      <tr>\\n        <td><%= user[:name] %>\\n        <td><%= user[:age] %>\\n    <% end %>\\n</table>\\n\", locals: {users: [{name: \"Alice\", age: 30}, {name: \"Bob\", age: 25}]}, options: {escape: false, parser_options: {strict: false}, visitors: [#<Herb::Engine::AutoCloseOmittedTagsVisitor>]}}"
+---
+<table>
+  <thead>
+    <tr>
+      <th>Name
+      </th><th>Age
+  </th></tr></thead><tbody>
+      <tr>
+        <td>Alice
+        </td><td>30
+    </td></tr>      <tr>
+        <td>Bob
+        </td><td>25
+    </td></tr>
+</tbody></table>

--- a/test/snapshots/engine/auto_close_omitted_tags_visitor_test/test_0028_GitHub_issue_#965_-_inline-block_li_elements_-_closing_tag_position_preserves_no-whitespace_behavior_-_compilation_ed316c5ddd8f09fe23899cf4c6acdd2e.txt
+++ b/test/snapshots/engine/auto_close_omitted_tags_visitor_test/test_0028_GitHub_issue_#965_-_inline-block_li_elements_-_closing_tag_position_preserves_no-whitespace_behavior_-_compilation_ed316c5ddd8f09fe23899cf4c6acdd2e.txt
@@ -1,0 +1,10 @@
+---
+source: "Engine::AutoCloseOmittedTagsVisitorTest#test_0028_GitHub issue #965 - inline-block li elements - closing tag position preserves no-whitespace behavior - compilation"
+input: "{source: \"<ul>\\n  <li style=\\\"display: inline-block\\\">Foo\\n  <li style=\\\"display: inline-block\\\">Bar\\n</ul>\\n\", options: {escape: false, parser_options: {strict: false}, visitors: [#<Herb::Engine::AutoCloseOmittedTagsVisitor>]}}"
+---
+_buf = ::String.new; _buf << '<ul>
+  <li style="display: inline-block">Foo
+  </li><li style="display: inline-block">Bar
+</li></ul>
+'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/auto_close_omitted_tags_visitor_test/test_0029_inline-block_li_elements_-_closing_tag_position_preserves_no-whitespace_behavior_-_render_415b7cd6ecf2f0b21855625eb83eed0e.txt
+++ b/test/snapshots/engine/auto_close_omitted_tags_visitor_test/test_0029_inline-block_li_elements_-_closing_tag_position_preserves_no-whitespace_behavior_-_render_415b7cd6ecf2f0b21855625eb83eed0e.txt
@@ -1,0 +1,8 @@
+---
+source: "Engine::AutoCloseOmittedTagsVisitorTest#test_0029_inline-block li elements - closing tag position preserves no-whitespace behavior - render"
+input: "{source: \"<ul>\\n  <li style=\\\"display: inline-block\\\">Foo\\n  <li style=\\\"display: inline-block\\\">Bar\\n</ul>\\n\", locals: {}, options: {escape: false, parser_options: {strict: false}, visitors: [#<Herb::Engine::AutoCloseOmittedTagsVisitor>]}}"
+---
+<ul>
+  <li style="display: inline-block">Foo
+  </li><li style="display: inline-block">Bar
+</li></ul>

--- a/test/snapshots/engine/auto_close_omitted_tags_visitor_test/test_0030_inline-block_li_elements_-_single_line_maintains_no_whitespace_-_compilation_47529653e7b16587cbfac3d94454d26b.txt
+++ b/test/snapshots/engine/auto_close_omitted_tags_visitor_test/test_0030_inline-block_li_elements_-_single_line_maintains_no_whitespace_-_compilation_47529653e7b16587cbfac3d94454d26b.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::AutoCloseOmittedTagsVisitorTest#test_0030_inline-block li elements - single line maintains no whitespace - compilation"
+input: "{source: \"<ul><li style=\\\"display: inline-block\\\">Foo<li style=\\\"display: inline-block\\\">Bar</ul>\", options: {escape: false, parser_options: {strict: false}, visitors: [#<Herb::Engine::AutoCloseOmittedTagsVisitor>]}}"
+---
+_buf = ::String.new; _buf << '<ul><li style="display: inline-block">Foo</li><li style="display: inline-block">Bar</li></ul>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/auto_close_omitted_tags_visitor_test/test_0031_inline-block_li_elements_-_single_line_maintains_no_whitespace_-_render_4fbd6dbfd714ad93271bc1f78d62deee.txt
+++ b/test/snapshots/engine/auto_close_omitted_tags_visitor_test/test_0031_inline-block_li_elements_-_single_line_maintains_no_whitespace_-_render_4fbd6dbfd714ad93271bc1f78d62deee.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::AutoCloseOmittedTagsVisitorTest#test_0031_inline-block li elements - single line maintains no whitespace - render"
+input: "{source: \"<ul><li style=\\\"display: inline-block\\\">Foo<li style=\\\"display: inline-block\\\">Bar</ul>\", locals: {}, options: {escape: false, parser_options: {strict: false}, visitors: [#<Herb::Engine::AutoCloseOmittedTagsVisitor>]}}"
+---
+<ul><li style="display: inline-block">Foo</li><li style="display: inline-block">Bar</li></ul>

--- a/test/snapshots/engine/auto_close_omitted_tags_visitor_test/test_0032_inline-block_with_erb_-_closing_tag_inserted_at_correct_position_-_compilation_1460e1effbf92ffd95a008b77821d3d6.txt
+++ b/test/snapshots/engine/auto_close_omitted_tags_visitor_test/test_0032_inline-block_with_erb_-_closing_tag_inserted_at_correct_position_-_compilation_1460e1effbf92ffd95a008b77821d3d6.txt
@@ -1,0 +1,11 @@
+---
+source: "Engine::AutoCloseOmittedTagsVisitorTest#test_0032_inline-block with erb - closing tag inserted at correct position - compilation"
+input: "{source: \"<ul>\\n  <% items.each do |item| %>\\n    <li style=\\\"display: inline-block\\\"><%= item %>\\n  <% end %>\\n</ul>\\n\", options: {escape: false, parser_options: {strict: false}, visitors: [#<Herb::Engine::AutoCloseOmittedTagsVisitor>]}}"
+---
+_buf = ::String.new; _buf << '<ul>
+'.freeze;   items.each do |item| 
+ _buf << '    <li style="display: inline-block">'.freeze; _buf << (item).to_s; _buf << '
+  </li>'.freeze; end; _buf << '
+</ul>
+'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/auto_close_omitted_tags_visitor_test/test_0033_inline-block_with_erb_-_closing_tag_inserted_at_correct_position_-_render_e8b30365b991b9b99f20b157d553fc73.txt
+++ b/test/snapshots/engine/auto_close_omitted_tags_visitor_test/test_0033_inline-block_with_erb_-_closing_tag_inserted_at_correct_position_-_render_e8b30365b991b9b99f20b157d553fc73.txt
@@ -1,0 +1,10 @@
+---
+source: "Engine::AutoCloseOmittedTagsVisitorTest#test_0033_inline-block with erb - closing tag inserted at correct position - render"
+input: "{source: \"<ul>\\n  <% items.each do |item| %>\\n    <li style=\\\"display: inline-block\\\"><%= item %>\\n  <% end %>\\n</ul>\\n\", locals: {items: [\"A\", \"B\", \"C\"]}, options: {escape: false, parser_options: {strict: false}, visitors: [#<Herb::Engine::AutoCloseOmittedTagsVisitor>]}}"
+---
+<ul>
+    <li style="display: inline-block">A
+  </li>    <li style="display: inline-block">B
+  </li>    <li style="display: inline-block">C
+  </li>
+</ul>

--- a/test/snapshots/engine/auto_close_omitted_tags_visitor_test/test_0034_p_elements_on_separate_lines_-_whitespace_preserved_between_elements_-_render_aa4f60e1bda4021e09969611897316bb.txt
+++ b/test/snapshots/engine/auto_close_omitted_tags_visitor_test/test_0034_p_elements_on_separate_lines_-_whitespace_preserved_between_elements_-_render_aa4f60e1bda4021e09969611897316bb.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::AutoCloseOmittedTagsVisitorTest#test_0034_p elements on separate lines - whitespace preserved between elements - render"
+input: "{source: \"<p>First\\n<p>Second\", locals: {}, options: {escape: false, parser_options: {strict: false}, visitors: [#<Herb::Engine::AutoCloseOmittedTagsVisitor>]}}"
+---
+<p>First
+</p><p>Second</p>


### PR DESCRIPTION
This pull request updates the `Herb::Engine` to have the ability to automatically close omitted HTML closing tags when compiling and rendering templates by introducing a new `Herb::Engine::AutoCloseOmittedTagsVisitor`.

While you are able to omit certain HTML closing tags according to the spec, it can be a bit misleading and confusing to do so. That's why Herb encourages to always close all HTML elements, even if they could be omitted.

This new visitor now allows the templates to remain as they are, but to make sure that the rendered output of the engine is always "fully conforming" to have a closing tag in the rendered output.

For example, this template:

```html+erb
<ul>
  <li>List Item 1
  <li>List Item 2
</ul>
```

Compiled with the visitor:

```ruby
require "herb/engine/auto_close_omitted_tags_visitor"

Herb::Engine.new(template, visitors: [Herb::Engine::AutoCloseOmittedTagsVisitor.new]).src
```

Gets compiled as:

```ruby
_buf = ::String.new; _buf << '<ul>
  <li>List Item 1
  </li><li>List Item 2
</li></ul>
'.freeze;
_buf.to_s
```

And rendered as:

```html
<ul>
  <li>List Item 1
  </li><li>List Item 2
</li></ul>
```

#### Why a visitor and not an engine option

The previous version of this pull request added an `auto_close_omitted_tags` option to `Herb::Engine`, which meant threading a flag from the engine into the compiler and teaching `Herb::Engine::Compiler#visit_html_omitted_close_tag_node` to emit the tag itself.

`Herb::Engine` already has a `visitors` option for visitors that run over the AST before compilation, and ReActionView exposes it as `config.transform_visitors`, so a visitor slots into the place where this kind of behavior is meant to live and composes with any other visitor you want to run:

```ruby
# config/initializers/reactionview.rb
require "herb/engine/auto_close_omitted_tags_visitor"

ReActionView.configure do |config|
  config.transform_visitors = [
    Herb::Engine::AutoCloseOmittedTagsVisitor.new
  ]
end
```

Builds on top of #1173.
