### PR TITLE
Parser: Mention `strict: false` in `OmittedClosingTagError` message

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -231,7 +231,7 @@ errors:
 
     - name: OmittedClosingTagError
       message:
-        template: "Element `<%s>` at (%u:%u) has its closing tag omitted. While valid HTML, consider adding an explicit `</%s>` closing tag at (%u:%u) for clarity."
+        template: "Element `<%s>` at (%u:%u) has its closing tag omitted. While valid HTML, consider adding an explicit `</%s>` closing tag at (%u:%u) for clarity, or set `strict: false` to allow this."
         arguments:
           - opening_tag->value
           - opening_tag->location.start.line

--- a/javascript/packages/linter/test/rules/parser-no-errors.test.ts
+++ b/javascript/packages/linter/test/rules/parser-no-errors.test.ts
@@ -27,7 +27,7 @@ describe("ParserNoErrorsRule", () => {
   })
 
   test("should report errors for unclosed elements", () => {
-    expectError("Element `<p>` at (2:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</p>` closing tag at (3:0) for clarity. (`OMITTED_CLOSING_TAG_ERROR`)")
+    expectError("Element `<p>` at (2:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</p>` closing tag at (3:0) for clarity, or set `strict: false` to allow this. (`OMITTED_CLOSING_TAG_ERROR`)")
 
     assertOffenses(dedent`
       <div>
@@ -61,7 +61,7 @@ describe("ParserNoErrorsRule", () => {
 
   test("should report multiple parser errors", () => {
     expectError("Opening tag `<h2>` at (1:1) doesn't have a matching closing tag `</h2>` in the same scope. (`MISSING_CLOSING_TAG_ERROR`)")
-    expectError("Element `<p>` at (2:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</p>` closing tag at (4:0) for clarity. (`OMITTED_CLOSING_TAG_ERROR`)")
+    expectError("Element `<p>` at (2:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</p>` closing tag at (4:0) for clarity, or set `strict: false` to allow this. (`OMITTED_CLOSING_TAG_ERROR`)")
     expectError("Found closing tag `</h3>` at (3:2) without a matching opening tag in the same scope. (`MISSING_OPENING_TAG_ERROR`)")
     expectError("Found closing tag `</div>` at (4:2) without a matching opening tag in the same scope. (`MISSING_OPENING_TAG_ERROR`)")
 

--- a/test/snapshots/parser/optional_closing_tags_test/test_0001_li_elements_with_implicit_closing_-_followed_by_another_li_7149f80676885ca7acc65ca43aa14a59.txt
+++ b/test/snapshots/parser/optional_closing_tags_test/test_0001_li_elements_with_implicit_closing_-_followed_by_another_li_7149f80676885ca7acc65ca43aa14a59.txt
@@ -25,7 +25,7 @@ input: |2-
     │   │   ├── @ HTMLElementNode (location: (2:2)-(3:2))
     │   │   │   ├── errors: (1 error)
     │   │   │   │   └── @ OmittedClosingTagError (location: (2:2)-(2:6))
-    │   │   │   │       ├── message: "Element `<li>` at (2:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</li>` closing tag at (3:2) for clarity."
+    │   │   │   │       ├── message: "Element `<li>` at (2:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</li>` closing tag at (3:2) for clarity, or set `strict: false` to allow this."
     │   │   │   │       ├── opening_tag: "li" (location: (2:3)-(2:5))
     │   │   │   │       └── insertion_point: (3:2)
     │   │   │   │
@@ -52,7 +52,7 @@ input: |2-
     │   │   └── @ HTMLElementNode (location: (3:2)-(4:0))
     │   │       ├── errors: (1 error)
     │   │       │   └── @ OmittedClosingTagError (location: (3:2)-(3:6))
-    │   │       │       ├── message: "Element `<li>` at (3:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</li>` closing tag at (4:0) for clarity."
+    │   │       │       ├── message: "Element `<li>` at (3:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</li>` closing tag at (4:0) for clarity, or set `strict: false` to allow this."
     │   │       │       ├── opening_tag: "li" (location: (3:3)-(3:5))
     │   │       │       └── insertion_point: (4:0)
     │   │       │

--- a/test/snapshots/parser/optional_closing_tags_test/test_0002_li_elements_with_implicit_closing_-_closed_by_parent_ff6e065993c9258e63ee145c02b79e63.txt
+++ b/test/snapshots/parser/optional_closing_tags_test/test_0002_li_elements_with_implicit_closing_-_closed_by_parent_ff6e065993c9258e63ee145c02b79e63.txt
@@ -24,7 +24,7 @@ input: |2-
     │   │   └── @ HTMLElementNode (location: (2:2)-(3:0))
     │   │       ├── errors: (1 error)
     │   │       │   └── @ OmittedClosingTagError (location: (2:2)-(2:6))
-    │   │       │       ├── message: "Element `<li>` at (2:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</li>` closing tag at (3:0) for clarity."
+    │   │       │       ├── message: "Element `<li>` at (2:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</li>` closing tag at (3:0) for clarity, or set `strict: false` to allow this."
     │   │       │       ├── opening_tag: "li" (location: (2:3)-(2:5))
     │   │       │       └── insertion_point: (3:0)
     │   │       │

--- a/test/snapshots/parser/optional_closing_tags_test/test_0004_li_elements_mixed_explicit_and_implicit_closing_53705a837c9604af23433b4d2711076a.txt
+++ b/test/snapshots/parser/optional_closing_tags_test/test_0004_li_elements_mixed_explicit_and_implicit_closing_53705a837c9604af23433b4d2711076a.txt
@@ -53,7 +53,7 @@ input: |2-
     │   │   ├── @ HTMLElementNode (location: (3:2)-(4:2))
     │   │   │   ├── errors: (1 error)
     │   │   │   │   └── @ OmittedClosingTagError (location: (3:2)-(3:6))
-    │   │   │   │       ├── message: "Element `<li>` at (3:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</li>` closing tag at (4:2) for clarity."
+    │   │   │   │       ├── message: "Element `<li>` at (3:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</li>` closing tag at (4:2) for clarity, or set `strict: false` to allow this."
     │   │   │   │       ├── opening_tag: "li" (location: (3:3)-(3:5))
     │   │   │   │       └── insertion_point: (4:2)
     │   │   │   │

--- a/test/snapshots/parser/optional_closing_tags_test/test_0005_nested_ul_with_implicit_li_closing_4c243bebe2fbd56431b4521f769cbfca.txt
+++ b/test/snapshots/parser/optional_closing_tags_test/test_0005_nested_ul_with_implicit_li_closing_4c243bebe2fbd56431b4521f769cbfca.txt
@@ -29,7 +29,7 @@ input: |2-
     │   │   ├── @ HTMLElementNode (location: (2:2)-(4:6))
     │   │   │   ├── errors: (1 error)
     │   │   │   │   └── @ OmittedClosingTagError (location: (2:2)-(2:6))
-    │   │   │   │       ├── message: "Element `<li>` at (2:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</li>` closing tag at (4:6) for clarity."
+    │   │   │   │       ├── message: "Element `<li>` at (2:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</li>` closing tag at (4:6) for clarity, or set `strict: false` to allow this."
     │   │   │   │       ├── opening_tag: "li" (location: (2:3)-(2:5))
     │   │   │   │       └── insertion_point: (4:6)
     │   │   │   │
@@ -71,7 +71,7 @@ input: |2-
     │   │   ├── @ HTMLElementNode (location: (4:6)-(5:6))
     │   │   │   ├── errors: (1 error)
     │   │   │   │   └── @ OmittedClosingTagError (location: (4:6)-(4:10))
-    │   │   │   │       ├── message: "Element `<li>` at (4:7) has its closing tag omitted. While valid HTML, consider adding an explicit `</li>` closing tag at (5:6) for clarity."
+    │   │   │   │       ├── message: "Element `<li>` at (4:7) has its closing tag omitted. While valid HTML, consider adding an explicit `</li>` closing tag at (5:6) for clarity, or set `strict: false` to allow this."
     │   │   │   │       ├── opening_tag: "li" (location: (4:7)-(4:9))
     │   │   │   │       └── insertion_point: (5:6)
     │   │   │   │
@@ -98,7 +98,7 @@ input: |2-
     │   │   ├── @ HTMLElementNode (location: (5:6)-(6:4))
     │   │   │   ├── errors: (1 error)
     │   │   │   │   └── @ OmittedClosingTagError (location: (5:6)-(5:10))
-    │   │   │   │       ├── message: "Element `<li>` at (5:7) has its closing tag omitted. While valid HTML, consider adding an explicit `</li>` closing tag at (6:4) for clarity."
+    │   │   │   │       ├── message: "Element `<li>` at (5:7) has its closing tag omitted. While valid HTML, consider adding an explicit `</li>` closing tag at (6:4) for clarity, or set `strict: false` to allow this."
     │   │   │   │       ├── opening_tag: "li" (location: (5:7)-(5:9))
     │   │   │   │       └── insertion_point: (6:4)
     │   │   │   │
@@ -139,7 +139,7 @@ input: |2-
     │   │   └── @ HTMLElementNode (location: (7:2)-(8:0))
     │   │       ├── errors: (1 error)
     │   │       │   └── @ OmittedClosingTagError (location: (7:2)-(7:6))
-    │   │       │       ├── message: "Element `<li>` at (7:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</li>` closing tag at (8:0) for clarity."
+    │   │       │       ├── message: "Element `<li>` at (7:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</li>` closing tag at (8:0) for clarity, or set `strict: false` to allow this."
     │   │       │       ├── opening_tag: "li" (location: (7:3)-(7:5))
     │   │       │       └── insertion_point: (8:0)
     │   │       │

--- a/test/snapshots/parser/optional_closing_tags_test/test_0006_ol_with_implicit_li_closing_554204d2abe9275ba8f549102487a9b5.txt
+++ b/test/snapshots/parser/optional_closing_tags_test/test_0006_ol_with_implicit_li_closing_554204d2abe9275ba8f549102487a9b5.txt
@@ -26,7 +26,7 @@ input: |2-
     │   │   ├── @ HTMLElementNode (location: (2:2)-(3:2))
     │   │   │   ├── errors: (1 error)
     │   │   │   │   └── @ OmittedClosingTagError (location: (2:2)-(2:6))
-    │   │   │   │       ├── message: "Element `<li>` at (2:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</li>` closing tag at (3:2) for clarity."
+    │   │   │   │       ├── message: "Element `<li>` at (2:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</li>` closing tag at (3:2) for clarity, or set `strict: false` to allow this."
     │   │   │   │       ├── opening_tag: "li" (location: (2:3)-(2:5))
     │   │   │   │       └── insertion_point: (3:2)
     │   │   │   │
@@ -53,7 +53,7 @@ input: |2-
     │   │   ├── @ HTMLElementNode (location: (3:2)-(4:2))
     │   │   │   ├── errors: (1 error)
     │   │   │   │   └── @ OmittedClosingTagError (location: (3:2)-(3:6))
-    │   │   │   │       ├── message: "Element `<li>` at (3:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</li>` closing tag at (4:2) for clarity."
+    │   │   │   │       ├── message: "Element `<li>` at (3:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</li>` closing tag at (4:2) for clarity, or set `strict: false` to allow this."
     │   │   │   │       ├── opening_tag: "li" (location: (3:3)-(3:5))
     │   │   │   │       └── insertion_point: (4:2)
     │   │   │   │
@@ -80,7 +80,7 @@ input: |2-
     │   │   └── @ HTMLElementNode (location: (4:2)-(5:0))
     │   │       ├── errors: (1 error)
     │   │       │   └── @ OmittedClosingTagError (location: (4:2)-(4:6))
-    │   │       │       ├── message: "Element `<li>` at (4:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</li>` closing tag at (5:0) for clarity."
+    │   │       │       ├── message: "Element `<li>` at (4:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</li>` closing tag at (5:0) for clarity, or set `strict: false` to allow this."
     │   │       │       ├── opening_tag: "li" (location: (4:3)-(4:5))
     │   │       │       └── insertion_point: (5:0)
     │   │       │

--- a/test/snapshots/parser/optional_closing_tags_test/test_0007_dt_elements_with_implicit_closing_-_followed_by_another_dt_319abaebd183c6a540902a26c80b4a2b.txt
+++ b/test/snapshots/parser/optional_closing_tags_test/test_0007_dt_elements_with_implicit_closing_-_followed_by_another_dt_319abaebd183c6a540902a26c80b4a2b.txt
@@ -25,7 +25,7 @@ input: |2-
     │   │   ├── @ HTMLElementNode (location: (2:2)-(3:2))
     │   │   │   ├── errors: (1 error)
     │   │   │   │   └── @ OmittedClosingTagError (location: (2:2)-(2:6))
-    │   │   │   │       ├── message: "Element `<dt>` at (2:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</dt>` closing tag at (3:2) for clarity."
+    │   │   │   │       ├── message: "Element `<dt>` at (2:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</dt>` closing tag at (3:2) for clarity, or set `strict: false` to allow this."
     │   │   │   │       ├── opening_tag: "dt" (location: (2:3)-(2:5))
     │   │   │   │       └── insertion_point: (3:2)
     │   │   │   │
@@ -52,7 +52,7 @@ input: |2-
     │   │   └── @ HTMLElementNode (location: (3:2)-(4:0))
     │   │       ├── errors: (1 error)
     │   │       │   └── @ OmittedClosingTagError (location: (3:2)-(3:6))
-    │   │       │       ├── message: "Element `<dt>` at (3:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</dt>` closing tag at (4:0) for clarity."
+    │   │       │       ├── message: "Element `<dt>` at (3:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</dt>` closing tag at (4:0) for clarity, or set `strict: false` to allow this."
     │   │       │       ├── opening_tag: "dt" (location: (3:3)-(3:5))
     │   │       │       └── insertion_point: (4:0)
     │   │       │

--- a/test/snapshots/parser/optional_closing_tags_test/test_0008_dt_element_implicitly_closed_by_dd_a2e1bde153e30ee6b7df2ef7af87344b.txt
+++ b/test/snapshots/parser/optional_closing_tags_test/test_0008_dt_element_implicitly_closed_by_dd_a2e1bde153e30ee6b7df2ef7af87344b.txt
@@ -25,7 +25,7 @@ input: |2-
     │   │   ├── @ HTMLElementNode (location: (2:2)-(3:2))
     │   │   │   ├── errors: (1 error)
     │   │   │   │   └── @ OmittedClosingTagError (location: (2:2)-(2:6))
-    │   │   │   │       ├── message: "Element `<dt>` at (2:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</dt>` closing tag at (3:2) for clarity."
+    │   │   │   │       ├── message: "Element `<dt>` at (2:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</dt>` closing tag at (3:2) for clarity, or set `strict: false` to allow this."
     │   │   │   │       ├── opening_tag: "dt" (location: (2:3)-(2:5))
     │   │   │   │       └── insertion_point: (3:2)
     │   │   │   │
@@ -52,7 +52,7 @@ input: |2-
     │   │   └── @ HTMLElementNode (location: (3:2)-(4:0))
     │   │       ├── errors: (1 error)
     │   │       │   └── @ OmittedClosingTagError (location: (3:2)-(3:6))
-    │   │       │       ├── message: "Element `<dd>` at (3:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</dd>` closing tag at (4:0) for clarity."
+    │   │       │       ├── message: "Element `<dd>` at (3:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</dd>` closing tag at (4:0) for clarity, or set `strict: false` to allow this."
     │   │       │       ├── opening_tag: "dd" (location: (3:3)-(3:5))
     │   │       │       └── insertion_point: (4:0)
     │   │       │

--- a/test/snapshots/parser/optional_closing_tags_test/test_0009_dd_elements_with_implicit_closing_-_followed_by_another_dd_99513a9929561722e33cf60b9534cf8f.txt
+++ b/test/snapshots/parser/optional_closing_tags_test/test_0009_dd_elements_with_implicit_closing_-_followed_by_another_dd_99513a9929561722e33cf60b9534cf8f.txt
@@ -25,7 +25,7 @@ input: |2-
     │   │   ├── @ HTMLElementNode (location: (2:2)-(3:2))
     │   │   │   ├── errors: (1 error)
     │   │   │   │   └── @ OmittedClosingTagError (location: (2:2)-(2:6))
-    │   │   │   │       ├── message: "Element `<dd>` at (2:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</dd>` closing tag at (3:2) for clarity."
+    │   │   │   │       ├── message: "Element `<dd>` at (2:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</dd>` closing tag at (3:2) for clarity, or set `strict: false` to allow this."
     │   │   │   │       ├── opening_tag: "dd" (location: (2:3)-(2:5))
     │   │   │   │       └── insertion_point: (3:2)
     │   │   │   │
@@ -52,7 +52,7 @@ input: |2-
     │   │   └── @ HTMLElementNode (location: (3:2)-(4:0))
     │   │       ├── errors: (1 error)
     │   │       │   └── @ OmittedClosingTagError (location: (3:2)-(3:6))
-    │   │       │       ├── message: "Element `<dd>` at (3:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</dd>` closing tag at (4:0) for clarity."
+    │   │       │       ├── message: "Element `<dd>` at (3:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</dd>` closing tag at (4:0) for clarity, or set `strict: false` to allow this."
     │   │       │       ├── opening_tag: "dd" (location: (3:3)-(3:5))
     │   │       │       └── insertion_point: (4:0)
     │   │       │

--- a/test/snapshots/parser/optional_closing_tags_test/test_0010_dd_element_implicitly_closed_by_dt_67bd268fe3348d8ac17eaf9c1acdba69.txt
+++ b/test/snapshots/parser/optional_closing_tags_test/test_0010_dd_element_implicitly_closed_by_dt_67bd268fe3348d8ac17eaf9c1acdba69.txt
@@ -25,7 +25,7 @@ input: |2-
     │   │   ├── @ HTMLElementNode (location: (2:2)-(3:2))
     │   │   │   ├── errors: (1 error)
     │   │   │   │   └── @ OmittedClosingTagError (location: (2:2)-(2:6))
-    │   │   │   │       ├── message: "Element `<dd>` at (2:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</dd>` closing tag at (3:2) for clarity."
+    │   │   │   │       ├── message: "Element `<dd>` at (2:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</dd>` closing tag at (3:2) for clarity, or set `strict: false` to allow this."
     │   │   │   │       ├── opening_tag: "dd" (location: (2:3)-(2:5))
     │   │   │   │       └── insertion_point: (3:2)
     │   │   │   │
@@ -52,7 +52,7 @@ input: |2-
     │   │   └── @ HTMLElementNode (location: (3:2)-(4:0))
     │   │       ├── errors: (1 error)
     │   │       │   └── @ OmittedClosingTagError (location: (3:2)-(3:6))
-    │   │       │       ├── message: "Element `<dt>` at (3:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</dt>` closing tag at (4:0) for clarity."
+    │   │       │       ├── message: "Element `<dt>` at (3:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</dt>` closing tag at (4:0) for clarity, or set `strict: false` to allow this."
     │   │       │       ├── opening_tag: "dt" (location: (3:3)-(3:5))
     │   │       │       └── insertion_point: (4:0)
     │   │       │

--- a/test/snapshots/parser/optional_closing_tags_test/test_0011_complete_definition_list_with_implicit_closing_5c3190dbb00c70ac5186de7d89723790.txt
+++ b/test/snapshots/parser/optional_closing_tags_test/test_0011_complete_definition_list_with_implicit_closing_5c3190dbb00c70ac5186de7d89723790.txt
@@ -27,7 +27,7 @@ input: |2-
     │   │   ├── @ HTMLElementNode (location: (2:2)-(3:2))
     │   │   │   ├── errors: (1 error)
     │   │   │   │   └── @ OmittedClosingTagError (location: (2:2)-(2:6))
-    │   │   │   │       ├── message: "Element `<dt>` at (2:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</dt>` closing tag at (3:2) for clarity."
+    │   │   │   │       ├── message: "Element `<dt>` at (2:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</dt>` closing tag at (3:2) for clarity, or set `strict: false` to allow this."
     │   │   │   │       ├── opening_tag: "dt" (location: (2:3)-(2:5))
     │   │   │   │       └── insertion_point: (3:2)
     │   │   │   │
@@ -54,7 +54,7 @@ input: |2-
     │   │   ├── @ HTMLElementNode (location: (3:2)-(4:2))
     │   │   │   ├── errors: (1 error)
     │   │   │   │   └── @ OmittedClosingTagError (location: (3:2)-(3:6))
-    │   │   │   │       ├── message: "Element `<dd>` at (3:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</dd>` closing tag at (4:2) for clarity."
+    │   │   │   │       ├── message: "Element `<dd>` at (3:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</dd>` closing tag at (4:2) for clarity, or set `strict: false` to allow this."
     │   │   │   │       ├── opening_tag: "dd" (location: (3:3)-(3:5))
     │   │   │   │       └── insertion_point: (4:2)
     │   │   │   │
@@ -81,7 +81,7 @@ input: |2-
     │   │   ├── @ HTMLElementNode (location: (4:2)-(5:2))
     │   │   │   ├── errors: (1 error)
     │   │   │   │   └── @ OmittedClosingTagError (location: (4:2)-(4:6))
-    │   │   │   │       ├── message: "Element `<dt>` at (4:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</dt>` closing tag at (5:2) for clarity."
+    │   │   │   │       ├── message: "Element `<dt>` at (4:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</dt>` closing tag at (5:2) for clarity, or set `strict: false` to allow this."
     │   │   │   │       ├── opening_tag: "dt" (location: (4:3)-(4:5))
     │   │   │   │       └── insertion_point: (5:2)
     │   │   │   │
@@ -108,7 +108,7 @@ input: |2-
     │   │   └── @ HTMLElementNode (location: (5:2)-(6:0))
     │   │       ├── errors: (1 error)
     │   │       │   └── @ OmittedClosingTagError (location: (5:2)-(5:6))
-    │   │       │       ├── message: "Element `<dd>` at (5:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</dd>` closing tag at (6:0) for clarity."
+    │   │       │       ├── message: "Element `<dd>` at (5:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</dd>` closing tag at (6:0) for clarity, or set `strict: false` to allow this."
     │   │       │       ├── opening_tag: "dd" (location: (5:3)-(5:5))
     │   │       │       └── insertion_point: (6:0)
     │   │       │

--- a/test/snapshots/parser/optional_closing_tags_test/test_0012_p_element_implicitly_closed_by_another_p_5a70fd0a73b3727f4881d9f3649f6987.txt
+++ b/test/snapshots/parser/optional_closing_tags_test/test_0012_p_element_implicitly_closed_by_another_p_5a70fd0a73b3727f4881d9f3649f6987.txt
@@ -25,7 +25,7 @@ input: |2-
     │   │   ├── @ HTMLElementNode (location: (2:2)-(3:2))
     │   │   │   ├── errors: (1 error)
     │   │   │   │   └── @ OmittedClosingTagError (location: (2:2)-(2:5))
-    │   │   │   │       ├── message: "Element `<p>` at (2:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</p>` closing tag at (3:2) for clarity."
+    │   │   │   │       ├── message: "Element `<p>` at (2:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</p>` closing tag at (3:2) for clarity, or set `strict: false` to allow this."
     │   │   │   │       ├── opening_tag: "p" (location: (2:3)-(2:4))
     │   │   │   │       └── insertion_point: (3:2)
     │   │   │   │
@@ -52,7 +52,7 @@ input: |2-
     │   │   └── @ HTMLElementNode (location: (3:2)-(4:0))
     │   │       ├── errors: (1 error)
     │   │       │   └── @ OmittedClosingTagError (location: (3:2)-(3:5))
-    │   │       │       ├── message: "Element `<p>` at (3:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</p>` closing tag at (4:0) for clarity."
+    │   │       │       ├── message: "Element `<p>` at (3:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</p>` closing tag at (4:0) for clarity, or set `strict: false` to allow this."
     │   │       │       ├── opening_tag: "p" (location: (3:3)-(3:4))
     │   │       │       └── insertion_point: (4:0)
     │   │       │

--- a/test/snapshots/parser/optional_closing_tags_test/test_0013_p_element_implicitly_closed_by_div_e1e1fbb1422c2a48338f9b1adb404c32.txt
+++ b/test/snapshots/parser/optional_closing_tags_test/test_0013_p_element_implicitly_closed_by_div_e1e1fbb1422c2a48338f9b1adb404c32.txt
@@ -25,7 +25,7 @@ input: |2-
     │   │   ├── @ HTMLElementNode (location: (2:2)-(3:2))
     │   │   │   ├── errors: (1 error)
     │   │   │   │   └── @ OmittedClosingTagError (location: (2:2)-(2:5))
-    │   │   │   │       ├── message: "Element `<p>` at (2:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</p>` closing tag at (3:2) for clarity."
+    │   │   │   │       ├── message: "Element `<p>` at (2:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</p>` closing tag at (3:2) for clarity, or set `strict: false` to allow this."
     │   │   │   │       ├── opening_tag: "p" (location: (2:3)-(2:4))
     │   │   │   │       └── insertion_point: (3:2)
     │   │   │   │

--- a/test/snapshots/parser/optional_closing_tags_test/test_0014_p_element_implicitly_closed_by_heading_4c78b28762598bb50a0a5955a8c48b67.txt
+++ b/test/snapshots/parser/optional_closing_tags_test/test_0014_p_element_implicitly_closed_by_heading_4c78b28762598bb50a0a5955a8c48b67.txt
@@ -25,7 +25,7 @@ input: |2-
     │   │   ├── @ HTMLElementNode (location: (2:2)-(3:2))
     │   │   │   ├── errors: (1 error)
     │   │   │   │   └── @ OmittedClosingTagError (location: (2:2)-(2:5))
-    │   │   │   │       ├── message: "Element `<p>` at (2:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</p>` closing tag at (3:2) for clarity."
+    │   │   │   │       ├── message: "Element `<p>` at (2:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</p>` closing tag at (3:2) for clarity, or set `strict: false` to allow this."
     │   │   │   │       ├── opening_tag: "p" (location: (2:3)-(2:4))
     │   │   │   │       └── insertion_point: (3:2)
     │   │   │   │

--- a/test/snapshots/parser/optional_closing_tags_test/test_0015_p_element_implicitly_closed_by_ul_851827341ce47057c353320afff7254b.txt
+++ b/test/snapshots/parser/optional_closing_tags_test/test_0015_p_element_implicitly_closed_by_ul_851827341ce47057c353320afff7254b.txt
@@ -25,7 +25,7 @@ input: |2-
     │   │   ├── @ HTMLElementNode (location: (2:2)-(3:2))
     │   │   │   ├── errors: (1 error)
     │   │   │   │   └── @ OmittedClosingTagError (location: (2:2)-(2:5))
-    │   │   │   │       ├── message: "Element `<p>` at (2:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</p>` closing tag at (3:2) for clarity."
+    │   │   │   │       ├── message: "Element `<p>` at (2:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</p>` closing tag at (3:2) for clarity, or set `strict: false` to allow this."
     │   │   │   │       ├── opening_tag: "p" (location: (2:3)-(2:4))
     │   │   │   │       └── insertion_point: (3:2)
     │   │   │   │

--- a/test/snapshots/parser/optional_closing_tags_test/test_0016_p_element_implicitly_closed_by_parent_64be247cea16025e9db03ac2b4a7d063.txt
+++ b/test/snapshots/parser/optional_closing_tags_test/test_0016_p_element_implicitly_closed_by_parent_64be247cea16025e9db03ac2b4a7d063.txt
@@ -24,7 +24,7 @@ input: |2-
     │   │   └── @ HTMLElementNode (location: (2:2)-(3:0))
     │   │       ├── errors: (1 error)
     │   │       │   └── @ OmittedClosingTagError (location: (2:2)-(2:5))
-    │   │       │       ├── message: "Element `<p>` at (2:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</p>` closing tag at (3:0) for clarity."
+    │   │       │       ├── message: "Element `<p>` at (2:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</p>` closing tag at (3:0) for clarity, or set `strict: false` to allow this."
     │   │       │       ├── opening_tag: "p" (location: (2:3)-(2:4))
     │   │       │       └── insertion_point: (3:0)
     │   │       │

--- a/test/snapshots/parser/optional_closing_tags_test/test_0017_rt_elements_with_implicit_closing_d614f2c2494d1e77bcdedaa4fa22a8cd.txt
+++ b/test/snapshots/parser/optional_closing_tags_test/test_0017_rt_elements_with_implicit_closing_d614f2c2494d1e77bcdedaa4fa22a8cd.txt
@@ -25,7 +25,7 @@ input: |2-
     │   │   ├── @ HTMLElementNode (location: (2:3)-(3:3))
     │   │   │   ├── errors: (1 error)
     │   │   │   │   └── @ OmittedClosingTagError (location: (2:3)-(2:7))
-    │   │   │   │       ├── message: "Element `<rt>` at (2:4) has its closing tag omitted. While valid HTML, consider adding an explicit `</rt>` closing tag at (3:3) for clarity."
+    │   │   │   │       ├── message: "Element `<rt>` at (2:4) has its closing tag omitted. While valid HTML, consider adding an explicit `</rt>` closing tag at (3:3) for clarity, or set `strict: false` to allow this."
     │   │   │   │       ├── opening_tag: "rt" (location: (2:4)-(2:6))
     │   │   │   │       └── insertion_point: (3:3)
     │   │   │   │
@@ -52,7 +52,7 @@ input: |2-
     │   │   └── @ HTMLElementNode (location: (3:3)-(4:0))
     │   │       ├── errors: (1 error)
     │   │       │   └── @ OmittedClosingTagError (location: (3:3)-(3:7))
-    │   │       │       ├── message: "Element `<rt>` at (3:4) has its closing tag omitted. While valid HTML, consider adding an explicit `</rt>` closing tag at (4:0) for clarity."
+    │   │       │       ├── message: "Element `<rt>` at (3:4) has its closing tag omitted. While valid HTML, consider adding an explicit `</rt>` closing tag at (4:0) for clarity, or set `strict: false` to allow this."
     │   │       │       ├── opening_tag: "rt" (location: (3:4)-(3:6))
     │   │       │       └── insertion_point: (4:0)
     │   │       │

--- a/test/snapshots/parser/optional_closing_tags_test/test_0018_rt_element_implicitly_closed_by_rp_3e12d24447db89a3069e350d8c48b642.txt
+++ b/test/snapshots/parser/optional_closing_tags_test/test_0018_rt_element_implicitly_closed_by_rp_3e12d24447db89a3069e350d8c48b642.txt
@@ -24,7 +24,7 @@ input: |2-
     │   │   ├── @ HTMLElementNode (location: (2:3)-(2:9))
     │   │   │   ├── errors: (1 error)
     │   │   │   │   └── @ OmittedClosingTagError (location: (2:3)-(2:7))
-    │   │   │   │       ├── message: "Element `<rt>` at (2:4) has its closing tag omitted. While valid HTML, consider adding an explicit `</rt>` closing tag at (2:9) for clarity."
+    │   │   │   │       ├── message: "Element `<rt>` at (2:4) has its closing tag omitted. While valid HTML, consider adding an explicit `</rt>` closing tag at (2:9) for clarity, or set `strict: false` to allow this."
     │   │   │   │       ├── opening_tag: "rt" (location: (2:4)-(2:6))
     │   │   │   │       └── insertion_point: (2:9)
     │   │   │   │

--- a/test/snapshots/parser/optional_closing_tags_test/test_0019_rp_elements_with_implicit_closing_813148a6e674d5df6e03874c894a85e7.txt
+++ b/test/snapshots/parser/optional_closing_tags_test/test_0019_rp_elements_with_implicit_closing_813148a6e674d5df6e03874c894a85e7.txt
@@ -24,7 +24,7 @@ input: |2-
     │   │   ├── @ HTMLElementNode (location: (2:3)-(2:8))
     │   │   │   ├── errors: (1 error)
     │   │   │   │   └── @ OmittedClosingTagError (location: (2:3)-(2:7))
-    │   │   │   │       ├── message: "Element `<rp>` at (2:4) has its closing tag omitted. While valid HTML, consider adding an explicit `</rp>` closing tag at (2:8) for clarity."
+    │   │   │   │       ├── message: "Element `<rp>` at (2:4) has its closing tag omitted. While valid HTML, consider adding an explicit `</rp>` closing tag at (2:8) for clarity, or set `strict: false` to allow this."
     │   │   │   │       ├── opening_tag: "rp" (location: (2:4)-(2:6))
     │   │   │   │       └── insertion_point: (2:8)
     │   │   │   │
@@ -51,7 +51,7 @@ input: |2-
     │   │   └── @ HTMLElementNode (location: (2:8)-(3:0))
     │   │       ├── errors: (1 error)
     │   │       │   └── @ OmittedClosingTagError (location: (2:8)-(2:12))
-    │   │       │       ├── message: "Element `<rp>` at (2:9) has its closing tag omitted. While valid HTML, consider adding an explicit `</rp>` closing tag at (3:0) for clarity."
+    │   │       │       ├── message: "Element `<rp>` at (2:9) has its closing tag omitted. While valid HTML, consider adding an explicit `</rp>` closing tag at (3:0) for clarity, or set `strict: false` to allow this."
     │   │       │       ├── opening_tag: "rp" (location: (2:9)-(2:11))
     │   │       │       └── insertion_point: (3:0)
     │   │       │

--- a/test/snapshots/parser/optional_closing_tags_test/test_0020_rp_element_implicitly_closed_by_rt_2e4361c4d2ed765e057a648a52aa6e1c.txt
+++ b/test/snapshots/parser/optional_closing_tags_test/test_0020_rp_element_implicitly_closed_by_rt_2e4361c4d2ed765e057a648a52aa6e1c.txt
@@ -24,7 +24,7 @@ input: |2-
     │   │   ├── @ HTMLElementNode (location: (2:3)-(2:8))
     │   │   │   ├── errors: (1 error)
     │   │   │   │   └── @ OmittedClosingTagError (location: (2:3)-(2:7))
-    │   │   │   │       ├── message: "Element `<rp>` at (2:4) has its closing tag omitted. While valid HTML, consider adding an explicit `</rp>` closing tag at (2:8) for clarity."
+    │   │   │   │       ├── message: "Element `<rp>` at (2:4) has its closing tag omitted. While valid HTML, consider adding an explicit `</rp>` closing tag at (2:8) for clarity, or set `strict: false` to allow this."
     │   │   │   │       ├── opening_tag: "rp" (location: (2:4)-(2:6))
     │   │   │   │       └── insertion_point: (2:8)
     │   │   │   │
@@ -51,7 +51,7 @@ input: |2-
     │   │   └── @ HTMLElementNode (location: (2:8)-(3:0))
     │   │       ├── errors: (1 error)
     │   │       │   └── @ OmittedClosingTagError (location: (2:8)-(2:12))
-    │   │       │       ├── message: "Element `<rt>` at (2:9) has its closing tag omitted. While valid HTML, consider adding an explicit `</rt>` closing tag at (3:0) for clarity."
+    │   │       │       ├── message: "Element `<rt>` at (2:9) has its closing tag omitted. While valid HTML, consider adding an explicit `</rt>` closing tag at (3:0) for clarity, or set `strict: false` to allow this."
     │   │       │       ├── opening_tag: "rt" (location: (2:9)-(2:11))
     │   │       │       └── insertion_point: (3:0)
     │   │       │

--- a/test/snapshots/parser/optional_closing_tags_test/test_0021_option_elements_with_implicit_closing_878a7fbfd8759ed3c47869cf1f5bcec9.txt
+++ b/test/snapshots/parser/optional_closing_tags_test/test_0021_option_elements_with_implicit_closing_878a7fbfd8759ed3c47869cf1f5bcec9.txt
@@ -26,7 +26,7 @@ input: |2-
     │   │   ├── @ HTMLElementNode (location: (2:2)-(3:2))
     │   │   │   ├── errors: (1 error)
     │   │   │   │   └── @ OmittedClosingTagError (location: (2:2)-(2:10))
-    │   │   │   │       ├── message: "Element `<option>` at (2:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</option>` closing tag at (3:2) for clarity."
+    │   │   │   │       ├── message: "Element `<option>` at (2:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</option>` closing tag at (3:2) for clarity, or set `strict: false` to allow this."
     │   │   │   │       ├── opening_tag: "option" (location: (2:3)-(2:9))
     │   │   │   │       └── insertion_point: (3:2)
     │   │   │   │
@@ -53,7 +53,7 @@ input: |2-
     │   │   ├── @ HTMLElementNode (location: (3:2)-(4:2))
     │   │   │   ├── errors: (1 error)
     │   │   │   │   └── @ OmittedClosingTagError (location: (3:2)-(3:10))
-    │   │   │   │       ├── message: "Element `<option>` at (3:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</option>` closing tag at (4:2) for clarity."
+    │   │   │   │       ├── message: "Element `<option>` at (3:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</option>` closing tag at (4:2) for clarity, or set `strict: false` to allow this."
     │   │   │   │       ├── opening_tag: "option" (location: (3:3)-(3:9))
     │   │   │   │       └── insertion_point: (4:2)
     │   │   │   │
@@ -80,7 +80,7 @@ input: |2-
     │   │   └── @ HTMLElementNode (location: (4:2)-(5:0))
     │   │       ├── errors: (1 error)
     │   │       │   └── @ OmittedClosingTagError (location: (4:2)-(4:10))
-    │   │       │       ├── message: "Element `<option>` at (4:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</option>` closing tag at (5:0) for clarity."
+    │   │       │       ├── message: "Element `<option>` at (4:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</option>` closing tag at (5:0) for clarity, or set `strict: false` to allow this."
     │   │       │       ├── opening_tag: "option" (location: (4:3)-(4:9))
     │   │       │       └── insertion_point: (5:0)
     │   │       │

--- a/test/snapshots/parser/optional_closing_tags_test/test_0022_option_element_implicitly_closed_by_optgroup_808eec7cab88028787060afce7e858d7.txt
+++ b/test/snapshots/parser/optional_closing_tags_test/test_0022_option_element_implicitly_closed_by_optgroup_808eec7cab88028787060afce7e858d7.txt
@@ -27,7 +27,7 @@ input: |2-
     │   │   ├── @ HTMLElementNode (location: (2:2)-(3:2))
     │   │   │   ├── errors: (1 error)
     │   │   │   │   └── @ OmittedClosingTagError (location: (2:2)-(2:10))
-    │   │   │   │       ├── message: "Element `<option>` at (2:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</option>` closing tag at (3:2) for clarity."
+    │   │   │   │       ├── message: "Element `<option>` at (2:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</option>` closing tag at (3:2) for clarity, or set `strict: false` to allow this."
     │   │   │   │       ├── opening_tag: "option" (location: (2:3)-(2:9))
     │   │   │   │       └── insertion_point: (3:2)
     │   │   │   │

--- a/test/snapshots/parser/optional_closing_tags_test/test_0023_optgroup_elements_with_implicit_closing_f252f3d3f1ced39d03b9102bbc2f080b.txt
+++ b/test/snapshots/parser/optional_closing_tags_test/test_0023_optgroup_elements_with_implicit_closing_f252f3d3f1ced39d03b9102bbc2f080b.txt
@@ -27,7 +27,7 @@ input: |2-
     │   │   ├── @ HTMLElementNode (location: (2:2)-(4:2))
     │   │   │   ├── errors: (1 error)
     │   │   │   │   └── @ OmittedClosingTagError (location: (2:2)-(2:28))
-    │   │   │   │       ├── message: "Element `<optgroup>` at (2:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</optgroup>` closing tag at (4:2) for clarity."
+    │   │   │   │       ├── message: "Element `<optgroup>` at (2:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</optgroup>` closing tag at (4:2) for clarity, or set `strict: false` to allow this."
     │   │   │   │       ├── opening_tag: "optgroup" (location: (2:3)-(2:11))
     │   │   │   │       └── insertion_point: (4:2)
     │   │   │   │
@@ -101,7 +101,7 @@ input: |2-
     │   │   └── @ HTMLElementNode (location: (4:2)-(6:0))
     │   │       ├── errors: (1 error)
     │   │       │   └── @ OmittedClosingTagError (location: (4:2)-(4:28))
-    │   │       │       ├── message: "Element `<optgroup>` at (4:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</optgroup>` closing tag at (6:0) for clarity."
+    │   │       │       ├── message: "Element `<optgroup>` at (4:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</optgroup>` closing tag at (6:0) for clarity, or set `strict: false` to allow this."
     │   │       │       ├── opening_tag: "optgroup" (location: (4:3)-(4:11))
     │   │       │       └── insertion_point: (6:0)
     │   │       │

--- a/test/snapshots/parser/optional_closing_tags_test/test_0024_thead_implicitly_closed_by_tbody_afb67a54b483387892d7f648689a2c67.txt
+++ b/test/snapshots/parser/optional_closing_tags_test/test_0024_thead_implicitly_closed_by_tbody_afb67a54b483387892d7f648689a2c67.txt
@@ -28,7 +28,7 @@ input: |2-
     │   │   ├── @ HTMLElementNode (location: (2:2)-(4:2))
     │   │   │   ├── errors: (1 error)
     │   │   │   │   └── @ OmittedClosingTagError (location: (2:2)-(2:9))
-    │   │   │   │       ├── message: "Element `<thead>` at (2:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</thead>` closing tag at (4:2) for clarity."
+    │   │   │   │       ├── message: "Element `<thead>` at (2:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</thead>` closing tag at (4:2) for clarity, or set `strict: false` to allow this."
     │   │   │   │       ├── opening_tag: "thead" (location: (2:3)-(2:8))
     │   │   │   │       └── insertion_point: (4:2)
     │   │   │   │

--- a/test/snapshots/parser/optional_closing_tags_test/test_0025_thead_implicitly_closed_by_tfoot_caa761c93baf4fbf46d4b5e4770500a4.txt
+++ b/test/snapshots/parser/optional_closing_tags_test/test_0025_thead_implicitly_closed_by_tfoot_caa761c93baf4fbf46d4b5e4770500a4.txt
@@ -28,7 +28,7 @@ input: |2-
     │   │   ├── @ HTMLElementNode (location: (2:2)-(4:2))
     │   │   │   ├── errors: (1 error)
     │   │   │   │   └── @ OmittedClosingTagError (location: (2:2)-(2:9))
-    │   │   │   │       ├── message: "Element `<thead>` at (2:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</thead>` closing tag at (4:2) for clarity."
+    │   │   │   │       ├── message: "Element `<thead>` at (2:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</thead>` closing tag at (4:2) for clarity, or set `strict: false` to allow this."
     │   │   │   │       ├── opening_tag: "thead" (location: (2:3)-(2:8))
     │   │   │   │       └── insertion_point: (4:2)
     │   │   │   │

--- a/test/snapshots/parser/optional_closing_tags_test/test_0026_tbody_elements_with_implicit_closing_3aa68a604806fa2801ad1bb22c1b2d68.txt
+++ b/test/snapshots/parser/optional_closing_tags_test/test_0026_tbody_elements_with_implicit_closing_3aa68a604806fa2801ad1bb22c1b2d68.txt
@@ -27,7 +27,7 @@ input: |2-
     │   │   ├── @ HTMLElementNode (location: (2:2)-(4:2))
     │   │   │   ├── errors: (1 error)
     │   │   │   │   └── @ OmittedClosingTagError (location: (2:2)-(2:9))
-    │   │   │   │       ├── message: "Element `<tbody>` at (2:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</tbody>` closing tag at (4:2) for clarity."
+    │   │   │   │       ├── message: "Element `<tbody>` at (2:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</tbody>` closing tag at (4:2) for clarity, or set `strict: false` to allow this."
     │   │   │   │       ├── opening_tag: "tbody" (location: (2:3)-(2:8))
     │   │   │   │       └── insertion_point: (4:2)
     │   │   │   │
@@ -102,7 +102,7 @@ input: |2-
     │   │   └── @ HTMLElementNode (location: (4:2)-(6:0))
     │   │       ├── errors: (1 error)
     │   │       │   └── @ OmittedClosingTagError (location: (4:2)-(4:9))
-    │   │       │       ├── message: "Element `<tbody>` at (4:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</tbody>` closing tag at (6:0) for clarity."
+    │   │       │       ├── message: "Element `<tbody>` at (4:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</tbody>` closing tag at (6:0) for clarity, or set `strict: false` to allow this."
     │   │       │       ├── opening_tag: "tbody" (location: (4:3)-(4:8))
     │   │       │       └── insertion_point: (6:0)
     │   │       │

--- a/test/snapshots/parser/optional_closing_tags_test/test_0027_tbody_implicitly_closed_by_tfoot_8ebe23933748b96ffdcd3739db450637.txt
+++ b/test/snapshots/parser/optional_closing_tags_test/test_0027_tbody_implicitly_closed_by_tfoot_8ebe23933748b96ffdcd3739db450637.txt
@@ -27,7 +27,7 @@ input: |2-
     │   │   ├── @ HTMLElementNode (location: (2:2)-(4:2))
     │   │   │   ├── errors: (1 error)
     │   │   │   │   └── @ OmittedClosingTagError (location: (2:2)-(2:9))
-    │   │   │   │       ├── message: "Element `<tbody>` at (2:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</tbody>` closing tag at (4:2) for clarity."
+    │   │   │   │       ├── message: "Element `<tbody>` at (2:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</tbody>` closing tag at (4:2) for clarity, or set `strict: false` to allow this."
     │   │   │   │       ├── opening_tag: "tbody" (location: (2:3)-(2:8))
     │   │   │   │       └── insertion_point: (4:2)
     │   │   │   │
@@ -102,7 +102,7 @@ input: |2-
     │   │   └── @ HTMLElementNode (location: (4:2)-(6:0))
     │   │       ├── errors: (1 error)
     │   │       │   └── @ OmittedClosingTagError (location: (4:2)-(4:9))
-    │   │       │       ├── message: "Element `<tfoot>` at (4:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</tfoot>` closing tag at (6:0) for clarity."
+    │   │       │       ├── message: "Element `<tfoot>` at (4:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</tfoot>` closing tag at (6:0) for clarity, or set `strict: false` to allow this."
     │   │       │       ├── opening_tag: "tfoot" (location: (4:3)-(4:8))
     │   │       │       └── insertion_point: (6:0)
     │   │       │

--- a/test/snapshots/parser/optional_closing_tags_test/test_0028_tr_elements_with_implicit_closing_cdb71cc4d48cde2a769c5510ed8446ff.txt
+++ b/test/snapshots/parser/optional_closing_tags_test/test_0028_tr_elements_with_implicit_closing_cdb71cc4d48cde2a769c5510ed8446ff.txt
@@ -25,7 +25,7 @@ input: |2-
     │   │   ├── @ HTMLElementNode (location: (2:2)-(3:2))
     │   │   │   ├── errors: (1 error)
     │   │   │   │   └── @ OmittedClosingTagError (location: (2:2)-(2:6))
-    │   │   │   │       ├── message: "Element `<tr>` at (2:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</tr>` closing tag at (3:2) for clarity."
+    │   │   │   │       ├── message: "Element `<tr>` at (2:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</tr>` closing tag at (3:2) for clarity, or set `strict: false` to allow this."
     │   │   │   │       ├── opening_tag: "tr" (location: (2:3)-(2:5))
     │   │   │   │       └── insertion_point: (3:2)
     │   │   │   │
@@ -76,7 +76,7 @@ input: |2-
     │   │   └── @ HTMLElementNode (location: (3:2)-(4:0))
     │   │       ├── errors: (1 error)
     │   │       │   └── @ OmittedClosingTagError (location: (3:2)-(3:6))
-    │   │       │       ├── message: "Element `<tr>` at (3:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</tr>` closing tag at (4:0) for clarity."
+    │   │       │       ├── message: "Element `<tr>` at (3:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</tr>` closing tag at (4:0) for clarity, or set `strict: false` to allow this."
     │   │       │       ├── opening_tag: "tr" (location: (3:3)-(3:5))
     │   │       │       └── insertion_point: (4:0)
     │   │       │

--- a/test/snapshots/parser/optional_closing_tags_test/test_0029_tr_implicitly_closed_by_parent_tbody_fee547d04eb05c4ec1857e203dbdaab4.txt
+++ b/test/snapshots/parser/optional_closing_tags_test/test_0029_tr_implicitly_closed_by_parent_tbody_fee547d04eb05c4ec1857e203dbdaab4.txt
@@ -40,7 +40,7 @@ input: |2-
     │   │   │   │   └── @ HTMLElementNode (location: (3:4)-(4:2))
     │   │   │   │       ├── errors: (1 error)
     │   │   │   │       │   └── @ OmittedClosingTagError (location: (3:4)-(3:8))
-    │   │   │   │       │       ├── message: "Element `<tr>` at (3:5) has its closing tag omitted. While valid HTML, consider adding an explicit `</tr>` closing tag at (4:2) for clarity."
+    │   │   │   │       │       ├── message: "Element `<tr>` at (3:5) has its closing tag omitted. While valid HTML, consider adding an explicit `</tr>` closing tag at (4:2) for clarity, or set `strict: false` to allow this."
     │   │   │   │       │       ├── opening_tag: "tr" (location: (3:5)-(3:7))
     │   │   │   │       │       └── insertion_point: (4:2)
     │   │   │   │       │

--- a/test/snapshots/parser/optional_closing_tags_test/test_0030_td_elements_with_implicit_closing_f5ae4c5705252d59a314c8ae67816575.txt
+++ b/test/snapshots/parser/optional_closing_tags_test/test_0030_td_elements_with_implicit_closing_f5ae4c5705252d59a314c8ae67816575.txt
@@ -41,7 +41,7 @@ input: |2-
     │   │   │   │   ├── @ HTMLElementNode (location: (3:4)-(4:4))
     │   │   │   │   │   ├── errors: (1 error)
     │   │   │   │   │   │   └── @ OmittedClosingTagError (location: (3:4)-(3:8))
-    │   │   │   │   │   │       ├── message: "Element `<td>` at (3:5) has its closing tag omitted. While valid HTML, consider adding an explicit `</td>` closing tag at (4:4) for clarity."
+    │   │   │   │   │   │       ├── message: "Element `<td>` at (3:5) has its closing tag omitted. While valid HTML, consider adding an explicit `</td>` closing tag at (4:4) for clarity, or set `strict: false` to allow this."
     │   │   │   │   │   │       ├── opening_tag: "td" (location: (3:5)-(3:7))
     │   │   │   │   │   │       └── insertion_point: (4:4)
     │   │   │   │   │   │
@@ -68,7 +68,7 @@ input: |2-
     │   │   │   │   └── @ HTMLElementNode (location: (4:4)-(5:2))
     │   │   │   │       ├── errors: (1 error)
     │   │   │   │       │   └── @ OmittedClosingTagError (location: (4:4)-(4:8))
-    │   │   │   │       │       ├── message: "Element `<td>` at (4:5) has its closing tag omitted. While valid HTML, consider adding an explicit `</td>` closing tag at (5:2) for clarity."
+    │   │   │   │       │       ├── message: "Element `<td>` at (4:5) has its closing tag omitted. While valid HTML, consider adding an explicit `</td>` closing tag at (5:2) for clarity, or set `strict: false` to allow this."
     │   │   │   │       │       ├── opening_tag: "td" (location: (4:5)-(4:7))
     │   │   │   │       │       └── insertion_point: (5:2)
     │   │   │   │       │

--- a/test/snapshots/parser/optional_closing_tags_test/test_0031_td_implicitly_closed_by_th_ec89f95bd12035697027c38068cfa428.txt
+++ b/test/snapshots/parser/optional_closing_tags_test/test_0031_td_implicitly_closed_by_th_ec89f95bd12035697027c38068cfa428.txt
@@ -41,7 +41,7 @@ input: |2-
     │   │   │   │   ├── @ HTMLElementNode (location: (3:4)-(4:4))
     │   │   │   │   │   ├── errors: (1 error)
     │   │   │   │   │   │   └── @ OmittedClosingTagError (location: (3:4)-(3:8))
-    │   │   │   │   │   │       ├── message: "Element `<td>` at (3:5) has its closing tag omitted. While valid HTML, consider adding an explicit `</td>` closing tag at (4:4) for clarity."
+    │   │   │   │   │   │       ├── message: "Element `<td>` at (3:5) has its closing tag omitted. While valid HTML, consider adding an explicit `</td>` closing tag at (4:4) for clarity, or set `strict: false` to allow this."
     │   │   │   │   │   │       ├── opening_tag: "td" (location: (3:5)-(3:7))
     │   │   │   │   │   │       └── insertion_point: (4:4)
     │   │   │   │   │   │
@@ -68,7 +68,7 @@ input: |2-
     │   │   │   │   └── @ HTMLElementNode (location: (4:4)-(5:2))
     │   │   │   │       ├── errors: (1 error)
     │   │   │   │       │   └── @ OmittedClosingTagError (location: (4:4)-(4:8))
-    │   │   │   │       │       ├── message: "Element `<th>` at (4:5) has its closing tag omitted. While valid HTML, consider adding an explicit `</th>` closing tag at (5:2) for clarity."
+    │   │   │   │       │       ├── message: "Element `<th>` at (4:5) has its closing tag omitted. While valid HTML, consider adding an explicit `</th>` closing tag at (5:2) for clarity, or set `strict: false` to allow this."
     │   │   │   │       │       ├── opening_tag: "th" (location: (4:5)-(4:7))
     │   │   │   │       │       └── insertion_point: (5:2)
     │   │   │   │       │

--- a/test/snapshots/parser/optional_closing_tags_test/test_0032_th_elements_with_implicit_closing_cdd30525f391c1287ea49a2778f82d14.txt
+++ b/test/snapshots/parser/optional_closing_tags_test/test_0032_th_elements_with_implicit_closing_cdd30525f391c1287ea49a2778f82d14.txt
@@ -41,7 +41,7 @@ input: |2-
     │   │   │   │   ├── @ HTMLElementNode (location: (3:4)-(4:4))
     │   │   │   │   │   ├── errors: (1 error)
     │   │   │   │   │   │   └── @ OmittedClosingTagError (location: (3:4)-(3:8))
-    │   │   │   │   │   │       ├── message: "Element `<th>` at (3:5) has its closing tag omitted. While valid HTML, consider adding an explicit `</th>` closing tag at (4:4) for clarity."
+    │   │   │   │   │   │       ├── message: "Element `<th>` at (3:5) has its closing tag omitted. While valid HTML, consider adding an explicit `</th>` closing tag at (4:4) for clarity, or set `strict: false` to allow this."
     │   │   │   │   │   │       ├── opening_tag: "th" (location: (3:5)-(3:7))
     │   │   │   │   │   │       └── insertion_point: (4:4)
     │   │   │   │   │   │
@@ -68,7 +68,7 @@ input: |2-
     │   │   │   │   └── @ HTMLElementNode (location: (4:4)-(5:2))
     │   │   │   │       ├── errors: (1 error)
     │   │   │   │       │   └── @ OmittedClosingTagError (location: (4:4)-(4:8))
-    │   │   │   │       │       ├── message: "Element `<th>` at (4:5) has its closing tag omitted. While valid HTML, consider adding an explicit `</th>` closing tag at (5:2) for clarity."
+    │   │   │   │       │       ├── message: "Element `<th>` at (4:5) has its closing tag omitted. While valid HTML, consider adding an explicit `</th>` closing tag at (5:2) for clarity, or set `strict: false` to allow this."
     │   │   │   │       │       ├── opening_tag: "th" (location: (4:5)-(4:7))
     │   │   │   │       │       └── insertion_point: (5:2)
     │   │   │   │       │

--- a/test/snapshots/parser/optional_closing_tags_test/test_0033_th_implicitly_closed_by_td_b250cdee25d2c4ecb1e31f6c690725bd.txt
+++ b/test/snapshots/parser/optional_closing_tags_test/test_0033_th_implicitly_closed_by_td_b250cdee25d2c4ecb1e31f6c690725bd.txt
@@ -41,7 +41,7 @@ input: |2-
     │   │   │   │   ├── @ HTMLElementNode (location: (3:4)-(4:4))
     │   │   │   │   │   ├── errors: (1 error)
     │   │   │   │   │   │   └── @ OmittedClosingTagError (location: (3:4)-(3:8))
-    │   │   │   │   │   │       ├── message: "Element `<th>` at (3:5) has its closing tag omitted. While valid HTML, consider adding an explicit `</th>` closing tag at (4:4) for clarity."
+    │   │   │   │   │   │       ├── message: "Element `<th>` at (3:5) has its closing tag omitted. While valid HTML, consider adding an explicit `</th>` closing tag at (4:4) for clarity, or set `strict: false` to allow this."
     │   │   │   │   │   │       ├── opening_tag: "th" (location: (3:5)-(3:7))
     │   │   │   │   │   │       └── insertion_point: (4:4)
     │   │   │   │   │   │
@@ -68,7 +68,7 @@ input: |2-
     │   │   │   │   └── @ HTMLElementNode (location: (4:4)-(5:2))
     │   │   │   │       ├── errors: (1 error)
     │   │   │   │       │   └── @ OmittedClosingTagError (location: (4:4)-(4:8))
-    │   │   │   │       │       ├── message: "Element `<td>` at (4:5) has its closing tag omitted. While valid HTML, consider adding an explicit `</td>` closing tag at (5:2) for clarity."
+    │   │   │   │       │       ├── message: "Element `<td>` at (4:5) has its closing tag omitted. While valid HTML, consider adding an explicit `</td>` closing tag at (5:2) for clarity, or set `strict: false` to allow this."
     │   │   │   │       │       ├── opening_tag: "td" (location: (4:5)-(4:7))
     │   │   │   │       │       └── insertion_point: (5:2)
     │   │   │   │       │

--- a/test/snapshots/parser/optional_closing_tags_test/test_0034_colgroup_implicitly_closed_by_thead_9299fb46f39328d204c32e39d0a2e492.txt
+++ b/test/snapshots/parser/optional_closing_tags_test/test_0034_colgroup_implicitly_closed_by_thead_9299fb46f39328d204c32e39d0a2e492.txt
@@ -28,7 +28,7 @@ input: |2-
     │   │   ├── @ HTMLElementNode (location: (2:2)-(4:2))
     │   │   │   ├── errors: (1 error)
     │   │   │   │   └── @ OmittedClosingTagError (location: (2:2)-(2:12))
-    │   │   │   │       ├── message: "Element `<colgroup>` at (2:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</colgroup>` closing tag at (4:2) for clarity."
+    │   │   │   │       ├── message: "Element `<colgroup>` at (2:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</colgroup>` closing tag at (4:2) for clarity, or set `strict: false` to allow this."
     │   │   │   │       ├── opening_tag: "colgroup" (location: (2:3)-(2:11))
     │   │   │   │       └── insertion_point: (4:2)
     │   │   │   │

--- a/test/snapshots/parser/optional_closing_tags_test/test_0035_colgroup_implicitly_closed_by_tbody_2b3abf5fe51eb17691489be27554b6c1.txt
+++ b/test/snapshots/parser/optional_closing_tags_test/test_0035_colgroup_implicitly_closed_by_tbody_2b3abf5fe51eb17691489be27554b6c1.txt
@@ -28,7 +28,7 @@ input: |2-
     │   │   ├── @ HTMLElementNode (location: (2:2)-(4:2))
     │   │   │   ├── errors: (1 error)
     │   │   │   │   └── @ OmittedClosingTagError (location: (2:2)-(2:12))
-    │   │   │   │       ├── message: "Element `<colgroup>` at (2:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</colgroup>` closing tag at (4:2) for clarity."
+    │   │   │   │       ├── message: "Element `<colgroup>` at (2:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</colgroup>` closing tag at (4:2) for clarity, or set `strict: false` to allow this."
     │   │   │   │       ├── opening_tag: "colgroup" (location: (2:3)-(2:11))
     │   │   │   │       └── insertion_point: (4:2)
     │   │   │   │

--- a/test/snapshots/parser/optional_closing_tags_test/test_0036_colgroup_implicitly_closed_by_tr_7f67b9a7f97b3f6f9701b94de0000053.txt
+++ b/test/snapshots/parser/optional_closing_tags_test/test_0036_colgroup_implicitly_closed_by_tr_7f67b9a7f97b3f6f9701b94de0000053.txt
@@ -26,7 +26,7 @@ input: |2-
     │   │   ├── @ HTMLElementNode (location: (2:2)-(4:2))
     │   │   │   ├── errors: (1 error)
     │   │   │   │   └── @ OmittedClosingTagError (location: (2:2)-(2:12))
-    │   │   │   │       ├── message: "Element `<colgroup>` at (2:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</colgroup>` closing tag at (4:2) for clarity."
+    │   │   │   │       ├── message: "Element `<colgroup>` at (2:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</colgroup>` closing tag at (4:2) for clarity, or set `strict: false` to allow this."
     │   │   │   │       ├── opening_tag: "colgroup" (location: (2:3)-(2:11))
     │   │   │   │       └── insertion_point: (4:2)
     │   │   │   │

--- a/test/snapshots/parser/optional_closing_tags_test/test_0037_complete_table_with_implicit_closing_tags_e61b0821c1ce3e0bb08b59210b6e178e.txt
+++ b/test/snapshots/parser/optional_closing_tags_test/test_0037_complete_table_with_implicit_closing_tags_e61b0821c1ce3e0bb08b59210b6e178e.txt
@@ -41,7 +41,7 @@ input: |2-
     │   │   ├── @ HTMLElementNode (location: (2:2)-(5:2))
     │   │   │   ├── errors: (1 error)
     │   │   │   │   └── @ OmittedClosingTagError (location: (2:2)-(2:12))
-    │   │   │   │       ├── message: "Element `<colgroup>` at (2:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</colgroup>` closing tag at (5:2) for clarity."
+    │   │   │   │       ├── message: "Element `<colgroup>` at (2:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</colgroup>` closing tag at (5:2) for clarity, or set `strict: false` to allow this."
     │   │   │   │       ├── opening_tag: "colgroup" (location: (2:3)-(2:11))
     │   │   │   │       └── insertion_point: (5:2)
     │   │   │   │
@@ -104,7 +104,7 @@ input: |2-
     │   │   ├── @ HTMLElementNode (location: (5:2)-(9:2))
     │   │   │   ├── errors: (1 error)
     │   │   │   │   └── @ OmittedClosingTagError (location: (5:2)-(5:9))
-    │   │   │   │       ├── message: "Element `<thead>` at (5:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</thead>` closing tag at (9:2) for clarity."
+    │   │   │   │       ├── message: "Element `<thead>` at (5:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</thead>` closing tag at (9:2) for clarity, or set `strict: false` to allow this."
     │   │   │   │       ├── opening_tag: "thead" (location: (5:3)-(5:8))
     │   │   │   │       └── insertion_point: (9:2)
     │   │   │   │
@@ -124,7 +124,7 @@ input: |2-
     │   │   │   │   └── @ HTMLElementNode (location: (6:4)-(9:2))
     │   │   │   │       ├── errors: (1 error)
     │   │   │   │       │   └── @ OmittedClosingTagError (location: (6:4)-(6:8))
-    │   │   │   │       │       ├── message: "Element `<tr>` at (6:5) has its closing tag omitted. While valid HTML, consider adding an explicit `</tr>` closing tag at (9:2) for clarity."
+    │   │   │   │       │       ├── message: "Element `<tr>` at (6:5) has its closing tag omitted. While valid HTML, consider adding an explicit `</tr>` closing tag at (9:2) for clarity, or set `strict: false` to allow this."
     │   │   │   │       │       ├── opening_tag: "tr" (location: (6:5)-(6:7))
     │   │   │   │       │       └── insertion_point: (9:2)
     │   │   │   │       │
@@ -144,7 +144,7 @@ input: |2-
     │   │   │   │       │   ├── @ HTMLElementNode (location: (7:6)-(8:6))
     │   │   │   │       │   │   ├── errors: (1 error)
     │   │   │   │       │   │   │   └── @ OmittedClosingTagError (location: (7:6)-(7:10))
-    │   │   │   │       │   │   │       ├── message: "Element `<th>` at (7:7) has its closing tag omitted. While valid HTML, consider adding an explicit `</th>` closing tag at (8:6) for clarity."
+    │   │   │   │       │   │   │       ├── message: "Element `<th>` at (7:7) has its closing tag omitted. While valid HTML, consider adding an explicit `</th>` closing tag at (8:6) for clarity, or set `strict: false` to allow this."
     │   │   │   │       │   │   │       ├── opening_tag: "th" (location: (7:7)-(7:9))
     │   │   │   │       │   │   │       └── insertion_point: (8:6)
     │   │   │   │       │   │   │
@@ -171,7 +171,7 @@ input: |2-
     │   │   │   │       │   └── @ HTMLElementNode (location: (8:6)-(9:2))
     │   │   │   │       │       ├── errors: (1 error)
     │   │   │   │       │       │   └── @ OmittedClosingTagError (location: (8:6)-(8:10))
-    │   │   │   │       │       │       ├── message: "Element `<th>` at (8:7) has its closing tag omitted. While valid HTML, consider adding an explicit `</th>` closing tag at (9:2) for clarity."
+    │   │   │   │       │       │       ├── message: "Element `<th>` at (8:7) has its closing tag omitted. While valid HTML, consider adding an explicit `</th>` closing tag at (9:2) for clarity, or set `strict: false` to allow this."
     │   │   │   │       │       │       ├── opening_tag: "th" (location: (8:7)-(8:9))
     │   │   │   │       │       │       └── insertion_point: (9:2)
     │   │   │   │       │       │
@@ -212,7 +212,7 @@ input: |2-
     │   │   ├── @ HTMLElementNode (location: (9:2)-(16:2))
     │   │   │   ├── errors: (1 error)
     │   │   │   │   └── @ OmittedClosingTagError (location: (9:2)-(9:9))
-    │   │   │   │       ├── message: "Element `<tbody>` at (9:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</tbody>` closing tag at (16:2) for clarity."
+    │   │   │   │       ├── message: "Element `<tbody>` at (9:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</tbody>` closing tag at (16:2) for clarity, or set `strict: false` to allow this."
     │   │   │   │       ├── opening_tag: "tbody" (location: (9:3)-(9:8))
     │   │   │   │       └── insertion_point: (16:2)
     │   │   │   │
@@ -232,7 +232,7 @@ input: |2-
     │   │   │   │   ├── @ HTMLElementNode (location: (10:4)-(13:4))
     │   │   │   │   │   ├── errors: (1 error)
     │   │   │   │   │   │   └── @ OmittedClosingTagError (location: (10:4)-(10:8))
-    │   │   │   │   │   │       ├── message: "Element `<tr>` at (10:5) has its closing tag omitted. While valid HTML, consider adding an explicit `</tr>` closing tag at (13:4) for clarity."
+    │   │   │   │   │   │       ├── message: "Element `<tr>` at (10:5) has its closing tag omitted. While valid HTML, consider adding an explicit `</tr>` closing tag at (13:4) for clarity, or set `strict: false` to allow this."
     │   │   │   │   │   │       ├── opening_tag: "tr" (location: (10:5)-(10:7))
     │   │   │   │   │   │       └── insertion_point: (13:4)
     │   │   │   │   │   │
@@ -252,7 +252,7 @@ input: |2-
     │   │   │   │   │   │   ├── @ HTMLElementNode (location: (11:6)-(12:6))
     │   │   │   │   │   │   │   ├── errors: (1 error)
     │   │   │   │   │   │   │   │   └── @ OmittedClosingTagError (location: (11:6)-(11:10))
-    │   │   │   │   │   │   │   │       ├── message: "Element `<td>` at (11:7) has its closing tag omitted. While valid HTML, consider adding an explicit `</td>` closing tag at (12:6) for clarity."
+    │   │   │   │   │   │   │   │       ├── message: "Element `<td>` at (11:7) has its closing tag omitted. While valid HTML, consider adding an explicit `</td>` closing tag at (12:6) for clarity, or set `strict: false` to allow this."
     │   │   │   │   │   │   │   │       ├── opening_tag: "td" (location: (11:7)-(11:9))
     │   │   │   │   │   │   │   │       └── insertion_point: (12:6)
     │   │   │   │   │   │   │   │
@@ -279,7 +279,7 @@ input: |2-
     │   │   │   │   │   │   └── @ HTMLElementNode (location: (12:6)-(13:4))
     │   │   │   │   │   │       ├── errors: (1 error)
     │   │   │   │   │   │       │   └── @ OmittedClosingTagError (location: (12:6)-(12:10))
-    │   │   │   │   │   │       │       ├── message: "Element `<td>` at (12:7) has its closing tag omitted. While valid HTML, consider adding an explicit `</td>` closing tag at (13:4) for clarity."
+    │   │   │   │   │   │       │       ├── message: "Element `<td>` at (12:7) has its closing tag omitted. While valid HTML, consider adding an explicit `</td>` closing tag at (13:4) for clarity, or set `strict: false` to allow this."
     │   │   │   │   │   │       │       ├── opening_tag: "td" (location: (12:7)-(12:9))
     │   │   │   │   │   │       │       └── insertion_point: (13:4)
     │   │   │   │   │   │       │
@@ -313,7 +313,7 @@ input: |2-
     │   │   │   │   └── @ HTMLElementNode (location: (13:4)-(16:2))
     │   │   │   │       ├── errors: (1 error)
     │   │   │   │       │   └── @ OmittedClosingTagError (location: (13:4)-(13:8))
-    │   │   │   │       │       ├── message: "Element `<tr>` at (13:5) has its closing tag omitted. While valid HTML, consider adding an explicit `</tr>` closing tag at (16:2) for clarity."
+    │   │   │   │       │       ├── message: "Element `<tr>` at (13:5) has its closing tag omitted. While valid HTML, consider adding an explicit `</tr>` closing tag at (16:2) for clarity, or set `strict: false` to allow this."
     │   │   │   │       │       ├── opening_tag: "tr" (location: (13:5)-(13:7))
     │   │   │   │       │       └── insertion_point: (16:2)
     │   │   │   │       │
@@ -333,7 +333,7 @@ input: |2-
     │   │   │   │       │   ├── @ HTMLElementNode (location: (14:6)-(15:6))
     │   │   │   │       │   │   ├── errors: (1 error)
     │   │   │   │       │   │   │   └── @ OmittedClosingTagError (location: (14:6)-(14:10))
-    │   │   │   │       │   │   │       ├── message: "Element `<td>` at (14:7) has its closing tag omitted. While valid HTML, consider adding an explicit `</td>` closing tag at (15:6) for clarity."
+    │   │   │   │       │   │   │       ├── message: "Element `<td>` at (14:7) has its closing tag omitted. While valid HTML, consider adding an explicit `</td>` closing tag at (15:6) for clarity, or set `strict: false` to allow this."
     │   │   │   │       │   │   │       ├── opening_tag: "td" (location: (14:7)-(14:9))
     │   │   │   │       │   │   │       └── insertion_point: (15:6)
     │   │   │   │       │   │   │
@@ -360,7 +360,7 @@ input: |2-
     │   │   │   │       │   └── @ HTMLElementNode (location: (15:6)-(16:2))
     │   │   │   │       │       ├── errors: (1 error)
     │   │   │   │       │       │   └── @ OmittedClosingTagError (location: (15:6)-(15:10))
-    │   │   │   │       │       │       ├── message: "Element `<td>` at (15:7) has its closing tag omitted. While valid HTML, consider adding an explicit `</td>` closing tag at (16:2) for clarity."
+    │   │   │   │       │       │       ├── message: "Element `<td>` at (15:7) has its closing tag omitted. While valid HTML, consider adding an explicit `</td>` closing tag at (16:2) for clarity, or set `strict: false` to allow this."
     │   │   │   │       │       │       ├── opening_tag: "td" (location: (15:7)-(15:9))
     │   │   │   │       │       │       └── insertion_point: (16:2)
     │   │   │   │       │       │
@@ -401,7 +401,7 @@ input: |2-
     │   │   └── @ HTMLElementNode (location: (16:2)-(20:0))
     │   │       ├── errors: (1 error)
     │   │       │   └── @ OmittedClosingTagError (location: (16:2)-(16:9))
-    │   │       │       ├── message: "Element `<tfoot>` at (16:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</tfoot>` closing tag at (20:0) for clarity."
+    │   │       │       ├── message: "Element `<tfoot>` at (16:3) has its closing tag omitted. While valid HTML, consider adding an explicit `</tfoot>` closing tag at (20:0) for clarity, or set `strict: false` to allow this."
     │   │       │       ├── opening_tag: "tfoot" (location: (16:3)-(16:8))
     │   │       │       └── insertion_point: (20:0)
     │   │       │
@@ -421,7 +421,7 @@ input: |2-
     │   │       │   └── @ HTMLElementNode (location: (17:4)-(20:0))
     │   │       │       ├── errors: (1 error)
     │   │       │       │   └── @ OmittedClosingTagError (location: (17:4)-(17:8))
-    │   │       │       │       ├── message: "Element `<tr>` at (17:5) has its closing tag omitted. While valid HTML, consider adding an explicit `</tr>` closing tag at (20:0) for clarity."
+    │   │       │       │       ├── message: "Element `<tr>` at (17:5) has its closing tag omitted. While valid HTML, consider adding an explicit `</tr>` closing tag at (20:0) for clarity, or set `strict: false` to allow this."
     │   │       │       │       ├── opening_tag: "tr" (location: (17:5)-(17:7))
     │   │       │       │       └── insertion_point: (20:0)
     │   │       │       │
@@ -441,7 +441,7 @@ input: |2-
     │   │       │       │   ├── @ HTMLElementNode (location: (18:6)-(19:6))
     │   │       │       │   │   ├── errors: (1 error)
     │   │       │       │   │   │   └── @ OmittedClosingTagError (location: (18:6)-(18:10))
-    │   │       │       │   │   │       ├── message: "Element `<td>` at (18:7) has its closing tag omitted. While valid HTML, consider adding an explicit `</td>` closing tag at (19:6) for clarity."
+    │   │       │       │   │   │       ├── message: "Element `<td>` at (18:7) has its closing tag omitted. While valid HTML, consider adding an explicit `</td>` closing tag at (19:6) for clarity, or set `strict: false` to allow this."
     │   │       │       │   │   │       ├── opening_tag: "td" (location: (18:7)-(18:9))
     │   │       │       │   │   │       └── insertion_point: (19:6)
     │   │       │       │   │   │
@@ -468,7 +468,7 @@ input: |2-
     │   │       │       │   └── @ HTMLElementNode (location: (19:6)-(20:0))
     │   │       │       │       ├── errors: (1 error)
     │   │       │       │       │   └── @ OmittedClosingTagError (location: (19:6)-(19:10))
-    │   │       │       │       │       ├── message: "Element `<td>` at (19:7) has its closing tag omitted. While valid HTML, consider adding an explicit `</td>` closing tag at (20:0) for clarity."
+    │   │       │       │       │       ├── message: "Element `<td>` at (19:7) has its closing tag omitted. While valid HTML, consider adding an explicit `</td>` closing tag at (20:0) for clarity, or set `strict: false` to allow this."
     │   │       │       │       │       ├── opening_tag: "td" (location: (19:7)-(19:9))
     │   │       │       │       │       └── insertion_point: (20:0)
     │   │       │       │       │

--- a/test/snapshots/parser/tags_test/test_0024_should_recover_from_multiple_out_of_order_closing_tags_d55597438f3e5bee8cd21841b672b31a.txt
+++ b/test/snapshots/parser/tags_test/test_0024_should_recover_from_multiple_out_of_order_closing_tags_d55597438f3e5bee8cd21841b672b31a.txt
@@ -42,7 +42,7 @@ input: |2-
     │   │   │   │   └── @ HTMLElementNode (location: (3:4)-(5:4))
     │   │   │   │       ├── errors: (1 error)
     │   │   │   │       │   └── @ OmittedClosingTagError (location: (3:4)-(3:7))
-    │   │   │   │       │       ├── message: "Element `<p>` at (3:5) has its closing tag omitted. While valid HTML, consider adding an explicit `</p>` closing tag at (5:4) for clarity."
+    │   │   │   │       │       ├── message: "Element `<p>` at (3:5) has its closing tag omitted. While valid HTML, consider adding an explicit `</p>` closing tag at (5:4) for clarity, or set `strict: false` to allow this."
     │   │   │   │       │       ├── opening_tag: "p" (location: (3:5)-(3:6))
     │   │   │   │       │       └── insertion_point: (5:4)
     │   │   │   │       │


### PR DESCRIPTION
```diff
- Element `<%s>` at (%u:%u) has its closing tag omitted. While valid HTML, consider adding an explicit `</%s>` closing tag at (%u:%u) for clarity.
+ Element `<%s>` at (%u:%u) has its closing tag omitted. While valid HTML, consider adding an explicit `</%s>` closing tag at (%u:%u) for clarity, or set `strict: false` to allow this.
```