### PR TITLE
Engine: Fix ERB expression compilation when code contains a heredoc

### DIFF
--- a/lib/herb/engine.rb
+++ b/lib/herb/engine.rb
@@ -213,13 +213,17 @@ module Herb
 
     def add_expression_result(code)
       with_buffer {
-        @src << " << (" << code << comment_aware_newline(code) << ").to_s"
+        @src << " << (" << code
+        @src << "\n" if heredoc?(code)
+        @src << comment_aware_newline(code) << ").to_s"
       }
     end
 
     def add_expression_result_escaped(code)
       with_buffer {
-        @src << " << " << @escapefunc << "((" << code << comment_aware_newline(code) << "))"
+        @src << " << " << @escapefunc << "((" << code
+        @src << "\n" if heredoc?(code)
+        @src << comment_aware_newline(code) << "))"
       }
     end
 
@@ -245,6 +249,10 @@ module Herb
 
     def comment_aware_newline(code)
       code.include?("#") ? "\n" : ""
+    end
+
+    def heredoc?(code)
+      code.match?(/<<[~-]?\s*['"`]?\w/)
     end
 
     def add_postamble(postamble)

--- a/sig/herb/engine.rbs
+++ b/sig/herb/engine.rbs
@@ -53,6 +53,8 @@ module Herb
 
     def comment_aware_newline: (untyped code) -> untyped
 
+    def heredoc?: (untyped code) -> untyped
+
     def add_postamble: (untyped postamble) -> untyped
 
     def with_buffer: () ?{ (?) -> untyped } -> untyped

--- a/test/engine/engine_test.rb
+++ b/test/engine/engine_test.rb
@@ -164,5 +164,18 @@ module Engine
 
       assert_compiled_snapshot(template, escape: false)
     end
+
+    test "heredoc with trailing arguments compiles to valid Ruby" do
+      template = <<~ERB
+        <%= method_call <<~GRAPHQL, variables
+          query {
+            field
+          }
+        GRAPHQL
+        %>
+      ERB
+
+      assert_compiled_snapshot(template)
+    end
   end
 end

--- a/test/snapshots/engine/engine_test/test_0018_heredoc_with_trailing_arguments_compiles_to_valid_Ruby_46fb4e6ec5bd55cc1041f3f88ad9508c.txt
+++ b/test/snapshots/engine/engine_test/test_0018_heredoc_with_trailing_arguments_compiles_to_valid_Ruby_46fb4e6ec5bd55cc1041f3f88ad9508c.txt
@@ -1,0 +1,12 @@
+---
+source: "Engine::EngineTest#test_0018_heredoc with trailing arguments compiles to valid Ruby"
+input: "{source: \"<%= method_call <<~GRAPHQL, variables\\n  query {\\n    field\\n  }\\nGRAPHQL\\n%>\\n\", options: {}}"
+---
+_buf = ::String.new; _buf << (method_call <<~GRAPHQL, variables
+  query {
+    field
+  }
+GRAPHQL
+).to_s; _buf << '
+'.freeze;
+_buf.to_s


### PR DESCRIPTION
When an ERB output tag contains a heredoc (e.g. `<%= method_call <<~GRAPHQL, variables %>`), the closing parenthesis in the compiled Ruby must appear on its own line after the heredoc terminator. Without this, the compiled Ruby is syntactically invalid.

This is a sibling commit of https://github.com/marcoroth/reactionview/pull/78