### PR TITLE
Engine: Ensure Engine produces valid Ruby in test suite

### DIFF
--- a/lib/herb/engine/compiler.rb
+++ b/lib/herb/engine/compiler.rb
@@ -22,7 +22,7 @@ module Herb
       def generate_output
         optimized_tokens = optimize_tokens(@tokens)
 
-        optimized_tokens.each do |type, value, context|
+        optimized_tokens.each do |type, value, context, escaped|
           case type
           when :text
             @engine.send(:add_text, value)
@@ -48,6 +48,8 @@ module Herb
           when :expr_block_escaped
             indicator = @escape ? "=" : "=="
             @engine.send(:add_expression_block, indicator, value)
+          when :expr_block_end
+            @engine.send(:add_expression_block_end, value, escaped: escaped)
           end
         end
       end
@@ -281,12 +283,30 @@ module Herb
                      end
 
           visit_all(node.body)
-          visit(node.end_node)
+          visit_erb_block_end_node(node.end_node, escaped: should_escape)
         else
           visit_erb_control_node(node) do
             visit_all(node.body)
             visit(node.end_node)
           end
+        end
+      end
+
+      def visit_erb_block_end_node(node, escaped: false)
+        has_left_trim = node.tag_opening.value.start_with?("<%-")
+
+        remove_trailing_whitespace_from_last_token! if has_left_trim
+
+        code = node.content.value.strip
+
+        if at_line_start?
+          lspace = extract_and_remove_lspace!
+          rspace = " \n"
+
+          @tokens << [:expr_block_end, "#{lspace}#{code}#{rspace}", current_context, escaped]
+          @trim_next_whitespace = true
+        else
+          @tokens << [:expr_block_end, code, current_context, escaped]
         end
       end
 
@@ -394,7 +414,7 @@ module Herb
         current_text = ""
         current_context = nil
 
-        compacted.each do |type, value, context|
+        compacted.each do |type, value, context, escaped|
           if type == :text
             current_text += value
             current_context ||= context
@@ -406,7 +426,7 @@ module Herb
               current_context = nil
             end
 
-            optimized << [type, value, context]
+            optimized << [type, value, context, escaped]
           end
         end
 

--- a/sig/herb/engine.rbs
+++ b/sig/herb/engine.rbs
@@ -51,7 +51,11 @@ module Herb
 
     def add_expression_block_result_escaped: (untyped code) -> untyped
 
-    def comment_aware_newline: (untyped code) -> untyped
+    def add_expression_block_end: (untyped code, ?escaped: untyped) -> untyped
+
+    def trailing_newline: (untyped code) -> untyped
+
+    def comment?: (untyped code) -> untyped
 
     def heredoc?: (untyped code) -> untyped
 

--- a/sig/herb/engine/compiler.rbs
+++ b/sig/herb/engine/compiler.rbs
@@ -77,6 +77,8 @@ module Herb
 
       def visit_erb_block_node: (untyped node) -> untyped
 
+      def visit_erb_block_end_node: (untyped node, ?escaped: untyped) -> untyped
+
       def visit_erb_control_with_parts: (untyped node, *untyped parts) -> untyped
 
       private

--- a/test/snapshot_utils.rb
+++ b/test/snapshot_utils.rb
@@ -36,6 +36,7 @@ module SnapshotUtils
 
   def assert_compiled_snapshot(source, options = {}, **kwargs)
     require_relative "../lib/herb/engine"
+    require "prism"
 
     enforce_erubi_equality = kwargs.delete(:enforce_erubi_equality) || false
     engine_options = options.merge(kwargs)
@@ -45,6 +46,18 @@ module SnapshotUtils
 
     snapshot_key = { source: source, options: engine_options }.to_s
     assert_snapshot_matches(expected, snapshot_key)
+
+    prism_result = Prism.parse(engine.src)
+    syntax_errors = prism_result.errors.reject { |e| e.type == :invalid_yield }
+
+    assert syntax_errors.empty?, <<~MESSAGE
+      Compiled output is not valid Ruby:
+
+      #{syntax_errors.map { |e| "  - #{e.message} (line #{e.location.start_line})" }.join("\n")}
+
+      Compiled source:
+      #{engine.src}
+    MESSAGE
 
     if should_compare_with_erubi? || enforce_erubi_equality
       compare_with_erubi_compiled(source, engine.src, engine_options, enforce_equality: enforce_erubi_equality)

--- a/test/snapshots/engine/debug_mode_test/test_0016_block_expressions_get_debug_spans_c71ab7a64204c499e9b116ffc3fbf03d.txt
+++ b/test/snapshots/engine/debug_mode_test/test_0016_block_expressions_get_debug_spans_c71ab7a64204c499e9b116ffc3fbf03d.txt
@@ -2,7 +2,7 @@
 source: "Engine::DebugModeTest#test_0016_block expressions get debug spans"
 input: "{source: \"<%= content_for :sidebar do %>\\n  <div>Sidebar content</div>\\n<% end %>\\n\", options: {debug: true, filename: \"test.html.erb\"}}"
 ---
-_buf = ::String.new; _buf << content_for :sidebar do; _buf << '
+_buf = ::String.new; _buf << (content_for :sidebar do; _buf << '
   <div>Sidebar content</div>
-'.freeze; end 
+'.freeze; end )
 _buf.to_s

--- a/test/snapshots/engine/debug_mode_test/test_0017_render_block_expressions_get_outline_boundaries_a8600827a6adf41bc60a28a65a7ebe50.txt
+++ b/test/snapshots/engine/debug_mode_test/test_0017_render_block_expressions_get_outline_boundaries_a8600827a6adf41bc60a28a65a7ebe50.txt
@@ -2,7 +2,7 @@
 source: "Engine::DebugModeTest#test_0017_render block expressions get outline boundaries"
 input: "{source: \"<%= render \\\"layout\\\" do %>\\n  <div>Block content</div>\\n<% end %>\\n\", options: {debug: true, filename: \"test.html.erb\"}}"
 ---
-_buf = ::String.new; _buf << render "layout" do; _buf << '
+_buf = ::String.new; _buf << (render "layout" do; _buf << '
   <div>Block content</div>
-'.freeze; end 
+'.freeze; end )
 _buf.to_s

--- a/test/snapshots/engine/debug_mode_test/test_0025_turbo_frame_tag_does_NOT_get_erb-output_outline_type_6441400221f6c4babe86ffc5da0cd758.txt
+++ b/test/snapshots/engine/debug_mode_test/test_0025_turbo_frame_tag_does_NOT_get_erb-output_outline_type_6441400221f6c4babe86ffc5da0cd758.txt
@@ -2,5 +2,5 @@
 source: "Engine::DebugModeTest#test_0025_turbo_frame_tag does NOT get erb-output outline type"
 input: "{source: \"<%= turbo_frame_tag \\\"posts\\\" do %><p>Content</p><% end %>\", options: {debug: true, filename: \"test.html.erb\"}}"
 ---
-_buf = ::String.new; _buf << turbo_frame_tag "posts" do; _buf << '<p>Content</p>'.freeze; end;
+_buf = ::String.new; _buf << (turbo_frame_tag "posts" do; _buf << '<p>Content</p>'.freeze; end);
 _buf.to_s

--- a/test/snapshots/engine/debug_mode_test/test_0026_content_for_with_block_does_NOT_get_erb-output_outline_type_1d1f4277e9176d7fdfd12943bfdca2fe.txt
+++ b/test/snapshots/engine/debug_mode_test/test_0026_content_for_with_block_does_NOT_get_erb-output_outline_type_1d1f4277e9176d7fdfd12943bfdca2fe.txt
@@ -2,5 +2,5 @@
 source: "Engine::DebugModeTest#test_0026_content_for with block does NOT get erb-output outline type"
 input: "{source: \"<%= content_for :sidebar do %><div>Sidebar content</div><% end %>\", options: {debug: true, filename: \"test.html.erb\"}}"
 ---
-_buf = ::String.new; _buf << content_for :sidebar do; _buf << '<div>Sidebar content</div>'.freeze; end;
+_buf = ::String.new; _buf << (content_for :sidebar do; _buf << '<div>Sidebar content</div>'.freeze; end);
 _buf.to_s

--- a/test/snapshots/engine/debug_mode_test/test_0027_content_tag_with_block_does_NOT_get_erb-output_outline_type_085c2022e3fc5db7ee51f4bdb45e58cc.txt
+++ b/test/snapshots/engine/debug_mode_test/test_0027_content_tag_with_block_does_NOT_get_erb-output_outline_type_085c2022e3fc5db7ee51f4bdb45e58cc.txt
@@ -2,5 +2,5 @@
 source: "Engine::DebugModeTest#test_0027_content_tag with block does NOT get erb-output outline type"
 input: "{source: \"<%= content_tag :div, class: \\\"wrapper\\\" do %>Content<% end %>\", options: {debug: true, filename: \"test.html.erb\"}}"
 ---
-_buf = ::String.new; _buf << content_tag :div, class: "wrapper" do; _buf << 'Content'.freeze; end;
+_buf = ::String.new; _buf << (content_tag :div, class: "wrapper" do; _buf << 'Content'.freeze; end);
 _buf.to_s

--- a/test/snapshots/engine/debug_mode_test/test_0028_link_to_with_block_does_NOT_get_erb-output_outline_type_25a2a32341c4efbd5fc67fcaccc65e04.txt
+++ b/test/snapshots/engine/debug_mode_test/test_0028_link_to_with_block_does_NOT_get_erb-output_outline_type_25a2a32341c4efbd5fc67fcaccc65e04.txt
@@ -2,5 +2,5 @@
 source: "Engine::DebugModeTest#test_0028_link_to with block does NOT get erb-output outline type"
 input: "{source: \"<%= link_to \\\"/users\\\" do %>View Users<% end %>\", options: {debug: true, filename: \"test.html.erb\"}}"
 ---
-_buf = ::String.new; _buf << link_to "/users" do; _buf << 'View Users'.freeze; end;
+_buf = ::String.new; _buf << (link_to "/users" do; _buf << 'View Users'.freeze; end);
 _buf.to_s

--- a/test/snapshots/engine/debug_mode_test/test_0029_tag_helper_with_block_does_NOT_get_erb-output_outline_type_d94d55997ab20001501c4d8811a7bb88.txt
+++ b/test/snapshots/engine/debug_mode_test/test_0029_tag_helper_with_block_does_NOT_get_erb-output_outline_type_d94d55997ab20001501c4d8811a7bb88.txt
@@ -2,5 +2,5 @@
 source: "Engine::DebugModeTest#test_0029_tag helper with block does NOT get erb-output outline type"
 input: "{source: \"<%= tag.div class: \\\"container\\\" do %>Content<% end %>\", options: {debug: true, filename: \"test.html.erb\"}}"
 ---
-_buf = ::String.new; _buf << tag.div class: "container" do; _buf << 'Content'.freeze; end;
+_buf = ::String.new; _buf << (tag.div class: "container" do; _buf << 'Content'.freeze; end);
 _buf.to_s

--- a/test/snapshots/engine/debug_mode_test/test_0030_form_with_block_does_NOT_get_erb-output_outline_type_93a0348e20c77450c6d171153f72e728.txt
+++ b/test/snapshots/engine/debug_mode_test/test_0030_form_with_block_does_NOT_get_erb-output_outline_type_93a0348e20c77450c6d171153f72e728.txt
@@ -2,5 +2,5 @@
 source: "Engine::DebugModeTest#test_0030_form_with block does NOT get erb-output outline type"
 input: "{source: \"<%= form_with model: @user do |f| %>Form content<% end %>\", options: {debug: true, filename: \"test.html.erb\"}}"
 ---
-_buf = ::String.new; _buf << form_with model: @user do |f|; _buf << 'Form content'.freeze; end;
+_buf = ::String.new; _buf << (form_with model: @user do |f|; _buf << 'Form content'.freeze; end);
 _buf.to_s

--- a/test/snapshots/engine/debug_mode_test/test_0037_non_HTML-element_top-level_node_should_be_wrapped_in_type=view_div_a5de27451c9360545052120fb160f115.txt
+++ b/test/snapshots/engine/debug_mode_test/test_0037_non_HTML-element_top-level_node_should_be_wrapped_in_type=view_div_a5de27451c9360545052120fb160f115.txt
@@ -2,7 +2,7 @@
 source: "Engine::DebugModeTest#test_0037_non HTML-element top-level node should be wrapped in type=view div"
 input: "{source: \"<%= content_tag :div do %>\\n  Content\\n<% end %>\\n\", options: {debug: true, filename: \"test.html.erb\"}}"
 ---
-_buf = ::String.new; _buf << content_tag :div do; _buf << '
+_buf = ::String.new; _buf << (content_tag :div do; _buf << '
   Content
-'.freeze; end 
+'.freeze; end )
 _buf.to_s

--- a/test/snapshots/engine/debug_mode_test/test_0046_javascript_tag_content_erb_expressions_do_NOT_get_debug_spans_a98f57bcf7299e63c0fed690e6457510.txt
+++ b/test/snapshots/engine/debug_mode_test/test_0046_javascript_tag_content_erb_expressions_do_NOT_get_debug_spans_a98f57bcf7299e63c0fed690e6457510.txt
@@ -2,8 +2,8 @@
 source: "Engine::DebugModeTest#test_0046_javascript_tag content erb expressions do NOT get debug spans"
 input: "{source: \"<%= javascript_tag do %>\\n  var userId = <%= @user.id %>;\\n  var name = \\\"<%= @user.name %>\\\";\\n<% end %>\\n\", options: {debug: true}}"
 ---
-_buf = ::String.new; _buf << javascript_tag do; _buf << '
+_buf = ::String.new; _buf << (javascript_tag do; _buf << '
   var userId = '.freeze; _buf << (@user.id).to_s; _buf << ';
   var name = "'.freeze; _buf << (@user.name).to_s; _buf << '";
-'.freeze; end 
+'.freeze; end )
 _buf.to_s

--- a/test/snapshots/engine/engine_block_test/test_0001_erb_block_expressions_generate_correct_code_without_parentheses_f1ec47d1e1a09d1114d928c64d54de58.txt
+++ b/test/snapshots/engine/engine_block_test/test_0001_erb_block_expressions_generate_correct_code_without_parentheses_f1ec47d1e1a09d1114d928c64d54de58.txt
@@ -2,5 +2,5 @@
 source: "Engine::EngineBlockTest#test_0001_erb block expressions generate correct code without parentheses"
 input: "{source: \"<%= link_to \\\"/path\\\", class: \\\"btn\\\" do %>Click me<% end %>\", options: {}}"
 ---
-_buf = ::String.new; _buf << link_to "/path", class: "btn" do; _buf << 'Click me'.freeze; end;
+_buf = ::String.new; _buf << (link_to "/path", class: "btn" do; _buf << 'Click me'.freeze; end);
 _buf.to_s

--- a/test/snapshots/engine/engine_block_test/test_0002_erb_block_expressions_with_escaping_7296abe3ce9cad7a56f653b0669c8e0a.txt
+++ b/test/snapshots/engine/engine_block_test/test_0002_erb_block_expressions_with_escaping_7296abe3ce9cad7a56f653b0669c8e0a.txt
@@ -2,5 +2,5 @@
 source: "Engine::EngineBlockTest#test_0002_erb block expressions with escaping"
 input: "{source: \"<%== form_for @user do %>Form content<% end %>\", options: {escape: false}}"
 ---
-_buf = ::String.new; _buf << ::Herb::Engine.h(form_for @user do); _buf << 'Form content'.freeze; end;
+_buf = ::String.new; _buf << ::Herb::Engine.h((form_for @user do; _buf << 'Form content'.freeze; end));
 _buf.to_s

--- a/test/snapshots/engine/engine_erubi_compat_test/test_0011_handles_custom_preamble_and_postamble_3b55a12762518f8786870b322ca30296.txt
+++ b/test/snapshots/engine/engine_erubi_compat_test/test_0011_handles_custom_preamble_and_postamble_3b55a12762518f8786870b322ca30296.txt
@@ -2,5 +2,5 @@
 source: "Engine::EngineErubiCompatTest#test_0011_handles custom preamble and postamble"
 input: "{source: \"<div>Test</div>\", options: {preamble: \"@buf = []\", postamble: \"@buf.join\"}}"
 ---
-@buf = [] _buf << '<div>Test</div>'.freeze;
+@buf = [];  _buf << '<div>Test</div>'.freeze;
 @buf.join

--- a/test/snapshots/engine/examples_compilation_test/test_0021_link_to_with_block_compilation_4ddb2a17755d3e775e3225970bc60a96.txt
+++ b/test/snapshots/engine/examples_compilation_test/test_0021_link_to_with_block_compilation_4ddb2a17755d3e775e3225970bc60a96.txt
@@ -2,9 +2,9 @@
 source: "Engine::ExamplesCompilationTest#test_0021_link to with block compilation"
 input: "{source: \"<%= link_to root_path do %>\\n  <div class=\\\"card\\\">\\n    Test\\n  </div>\\n<% end %>\\n\", options: {escape: false}}"
 ---
-_buf = ::String.new; _buf << link_to root_path do; _buf << '
+_buf = ::String.new; _buf << (link_to root_path do; _buf << '
   <div class="card">
     Test
   </div>
-'.freeze; end 
+'.freeze; end )
 _buf.to_s

--- a/test/snapshots/engine/examples_compilation_test/test_0022_nested_if_and_blocks_compilation_aa8aed9ef61b138a28efed42f4b72251.txt
+++ b/test/snapshots/engine/examples_compilation_test/test_0022_nested_if_and_blocks_compilation_aa8aed9ef61b138a28efed42f4b72251.txt
@@ -3,7 +3,7 @@ source: "Engine::ExamplesCompilationTest#test_0022_nested if and blocks compilat
 input: "{source: \"<div id=\\\"output\\\">\\n  <%= tag.div class: \\\"div\\\" do %>\\n    <% if Date.today.friday? %>\\n      <h1>\\n        Happy\\n        <% current_hour = Time.now.hour %>\\n\\n        <% if current_hour < 12 %>\\n          <b>Early Friday</b>\\n        <% elsif current_hour >= 18 %>\\n          <b>Late Friday</b>\\n        <% else %>\\n          <b>Friday</b>\\n        <% end %>\\n      </h1>\\n    <% elsif Date.today.saturday? %>\\n      <h1>\\n        It's\\n        <b>Saturday</b>\\n        <%= \\\" - Time to relax!\\\" %>\\n      </h1>\\n    <% else %>\\n      <h1>\\n        Oh no, it's\\n        <b>Not Friday</b>\\n        <%= \\\" - Keep going!\\\" %>\\n      </h1>\\n    <% end %>\\n  <% end %>\\n</div>\\n\", options: {escape: false}}"
 ---
 _buf = ::String.new; _buf << '<div id="output">
-  '.freeze; _buf << tag.div class: "div" do; _buf << '
+  '.freeze; _buf << (tag.div class: "div" do; _buf << '
 '.freeze;     if Date.today.friday? 
  _buf << '      <h1>
         Happy
@@ -29,8 +29,7 @@ _buf = ::String.new; _buf << '<div id="output">
         <b>Not Friday</b>
         '.freeze; _buf << (" - Keep going!").to_s; _buf << '
       </h1>
-'.freeze;     end 
-   end 
+'.freeze;     end    end )
  _buf << '</div>
 '.freeze;
 _buf.to_s


### PR DESCRIPTION
Inspired by https://github.com/marcoroth/reactionview/pull/78#discussion_r2825149213

This pull request updates our `assert_compiled_snapshot` assertion helper to make sure the compiled snapshot is valid Ruby by passing the engine output to Prism and checking for syntax errors.