### PR TITLE
Parser: Don't treat backslash as escape character in attribute values

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -485,28 +485,6 @@ static AST_HTML_ATTRIBUTE_VALUE_NODE_T* parser_parse_quoted_html_attribute_value
       continue;
     }
 
-    if (token_is(parser, TOKEN_BACKSLASH)) {
-      lexer_state_snapshot_T saved_state = lexer_save_state(parser->lexer);
-
-      token_T* next_token = lexer_next_token(parser->lexer);
-
-      if (next_token && next_token->type == TOKEN_QUOTE && opening_quote != NULL
-          && string_equals(next_token->value, opening_quote->value)) {
-        hb_buffer_append(&buffer, parser->current_token->value);
-        hb_buffer_append(&buffer, next_token->value);
-
-        token_free(parser->current_token);
-        token_free(next_token);
-
-        parser->current_token = lexer_next_token(parser->lexer);
-        continue;
-      } else {
-        lexer_restore_state(parser->lexer, saved_state);
-
-        if (next_token) { token_free(next_token); }
-      }
-    }
-
     hb_buffer_append(&buffer, parser->current_token->value);
     token_free(parser->current_token);
 
@@ -523,7 +501,7 @@ static AST_HTML_ATTRIBUTE_VALUE_NODE_T* parser_parse_quoted_html_attribute_value
     if (token_is(parser, TOKEN_IDENTIFIER) || token_is(parser, TOKEN_CHARACTER)) {
       append_unexpected_error(
         "Unescaped quote character in attribute value",
-        "escaped quote (\\') or different quote style (\")",
+        "HTML entity (&apos;/&quot;) or different quote style",
         opening_quote->value,
         potential_closing->location.start,
         potential_closing->location.end,

--- a/test/parser/attributes_test.rb
+++ b/test/parser/attributes_test.rb
@@ -509,5 +509,9 @@ module Parser
     test "attribute with equals followed by closing tag" do
       assert_parsed_snapshot("<div class=</div>")
     end
+
+    test "issue #1211: attribute value with backslash" do
+      assert_parsed_snapshot('<button data-shortcut="S,s,\">S \</button>')
+    end
   end
 end

--- a/test/snapshots/parser/attributes_test/test_0018_apostrophe_inside_single_quotes_e431474b58446f910c9425491add27a0.txt
+++ b/test/snapshots/parser/attributes_test/test_0018_apostrophe_inside_single_quotes_e431474b58446f910c9425491add27a0.txt
@@ -24,9 +24,9 @@ input: "<div data-msg='Don't worry'>Text</div>"
         │       │           └── @ HTMLAttributeValueNode (location: (1:14)-(1:27))
         │       │               ├── errors: (1 error)
         │       │               │   └── @ UnexpectedError (location: (1:18)-(1:19))
-        │       │               │       ├── message: "Unescaped quote character in attribute value. Expected: `escaped quote (\\') or different quote style (\")`, found: `'`."
+        │       │               │       ├── message: "Unescaped quote character in attribute value. Expected: `HTML entity (&apos;/&quot;) or different quote style`, found: `'`."
         │       │               │       ├── description: "Unescaped quote character in attribute value"
-        │       │               │       ├── expected: "escaped quote (\\') or different quote style (\")"
+        │       │               │       ├── expected: "HTML entity (&apos;/&quot;) or different quote style"
         │       │               │       └── found: "'"
         │       │               │
         │       │               ├── open_quote: "'" (location: (1:14)-(1:15))

--- a/test/snapshots/parser/attributes_test/test_0019_escaped_apostrophe_inside_single_quotes_73b1e8ba6af89da5d178df9a5b3781fc.txt
+++ b/test/snapshots/parser/attributes_test/test_0019_escaped_apostrophe_inside_single_quotes_73b1e8ba6af89da5d178df9a5b3781fc.txt
@@ -22,6 +22,13 @@ input: "<div data-msg='Don\\'t worry'>Text</div>"
         │       │       ├── equals: "=" (location: (1:13)-(1:14))
         │       │       └── value:
         │       │           └── @ HTMLAttributeValueNode (location: (1:14)-(1:28))
+        │       │               ├── errors: (1 error)
+        │       │               │   └── @ UnexpectedError (location: (1:19)-(1:20))
+        │       │               │       ├── message: "Unescaped quote character in attribute value. Expected: `HTML entity (&apos;/&quot;) or different quote style`, found: `'`."
+        │       │               │       ├── description: "Unescaped quote character in attribute value"
+        │       │               │       ├── expected: "HTML entity (&apos;/&quot;) or different quote style"
+        │       │               │       └── found: "'"
+        │       │               │
         │       │               ├── open_quote: "'" (location: (1:14)-(1:15))
         │       │               ├── children: (1 item)
         │       │               │   └── @ LiteralNode (location: (1:15)-(1:27))

--- a/test/snapshots/parser/attributes_test/test_0020_escaped_double_quote_inside_double_quotes_1ad5f48462c267e84580003c8ac9abac.txt
+++ b/test/snapshots/parser/attributes_test/test_0020_escaped_double_quote_inside_double_quotes_1ad5f48462c267e84580003c8ac9abac.txt
@@ -7,11 +7,18 @@ input: "<div data-msg=\"She said \\\"Hello\\\"\">Text</div>"
     └── @ HTMLElementNode (location: (1:0)-(1:45))
         ├── open_tag:
         │   └── @ HTMLOpenTagNode (location: (1:0)-(1:35))
+        │       ├── errors: (1 error)
+        │       │   └── @ UnexpectedError (location: (1:33)-(1:34))
+        │       │       ├── message: "Unexpected Token. Expected: `TOKEN_IDENTIFIER, TOKEN_AT, TOKEN_ERB_START,TOKEN_WHITESPACE, or TOKEN_NEWLINE`, found: `TOKEN_QUOTE`."
+        │       │       ├── description: "Unexpected Token"
+        │       │       ├── expected: "TOKEN_IDENTIFIER, TOKEN_AT, TOKEN_ERB_START,TOKEN_WHITESPACE, or TOKEN_NEWLINE"
+        │       │       └── found: "TOKEN_QUOTE"
+        │       │
         │       ├── tag_opening: "<" (location: (1:0)-(1:1))
         │       ├── tag_name: "div" (location: (1:1)-(1:4))
         │       ├── tag_closing: ">" (location: (1:34)-(1:35))
         │       ├── children: (1 item)
-        │       │   └── @ HTMLAttributeNode (location: (1:5)-(1:34))
+        │       │   └── @ HTMLAttributeNode (location: (1:5)-(1:33))
         │       │       ├── name:
         │       │       │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:13))
         │       │       │       └── children: (1 item)
@@ -21,13 +28,20 @@ input: "<div data-msg=\"She said \\\"Hello\\\"\">Text</div>"
         │       │       │
         │       │       ├── equals: "=" (location: (1:13)-(1:14))
         │       │       └── value:
-        │       │           └── @ HTMLAttributeValueNode (location: (1:14)-(1:34))
+        │       │           └── @ HTMLAttributeValueNode (location: (1:14)-(1:33))
+        │       │               ├── errors: (1 error)
+        │       │               │   └── @ UnexpectedError (location: (1:25)-(1:26))
+        │       │               │       ├── message: "Unescaped quote character in attribute value. Expected: `HTML entity (&apos;/&quot;) or different quote style`, found: `\"`."
+        │       │               │       ├── description: "Unescaped quote character in attribute value"
+        │       │               │       ├── expected: "HTML entity (&apos;/&quot;) or different quote style"
+        │       │               │       └── found: "\""
+        │       │               │
         │       │               ├── open_quote: """ (location: (1:14)-(1:15))
         │       │               ├── children: (1 item)
-        │       │               │   └── @ LiteralNode (location: (1:15)-(1:33))
-        │       │               │       └── content: "She said \\\"Hello\\\""
+        │       │               │   └── @ LiteralNode (location: (1:15)-(1:32))
+        │       │               │       └── content: "She said \\\"Hello\\"
         │       │               │
-        │       │               ├── close_quote: """ (location: (1:33)-(1:34))
+        │       │               ├── close_quote: """ (location: (1:32)-(1:33))
         │       │               └── quoted: true
         │       │
         │       │

--- a/test/snapshots/parser/attributes_test/test_0121_issue_#1211_attribute_value_with_backslash_0218028fb9f838a63686f64070e12379.txt
+++ b/test/snapshots/parser/attributes_test/test_0121_issue_#1211_attribute_value_with_backslash_0218028fb9f838a63686f64070e12379.txt
@@ -1,0 +1,49 @@
+---
+source: "Parser::AttributesTest#test_0121_issue #1211: attribute value with backslash"
+input: "<button data-shortcut=\"S,s,\\\">S \\</button>"
+---
+@ DocumentNode (location: (1:0)-(1:42))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:42))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:30))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "button" (location: (1:1)-(1:7))
+        │       ├── tag_closing: ">" (location: (1:29)-(1:30))
+        │       ├── children: (1 item)
+        │       │   └── @ HTMLAttributeNode (location: (1:8)-(1:29))
+        │       │       ├── name:
+        │       │       │   └── @ HTMLAttributeNameNode (location: (1:8)-(1:21))
+        │       │       │       └── children: (1 item)
+        │       │       │           └── @ LiteralNode (location: (1:8)-(1:21))
+        │       │       │               └── content: "data-shortcut"
+        │       │       │
+        │       │       │
+        │       │       ├── equals: "=" (location: (1:21)-(1:22))
+        │       │       └── value:
+        │       │           └── @ HTMLAttributeValueNode (location: (1:22)-(1:29))
+        │       │               ├── open_quote: """ (location: (1:22)-(1:23))
+        │       │               ├── children: (1 item)
+        │       │               │   └── @ LiteralNode (location: (1:23)-(1:28))
+        │       │               │       └── content: "S,s,\\"
+        │       │               │
+        │       │               ├── close_quote: """ (location: (1:28)-(1:29))
+        │       │               └── quoted: true
+        │       │
+        │       │
+        │       └── is_void: false
+        │
+        ├── tag_name: "button" (location: (1:1)-(1:7))
+        ├── body: (1 item)
+        │   └── @ HTMLTextNode (location: (1:30)-(1:33))
+        │       └── content: "S \\"
+        │
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:33)-(1:42))
+        │       ├── tag_opening: "</" (location: (1:33)-(1:35))
+        │       ├── tag_name: "button" (location: (1:35)-(1:41))
+        │       ├── children: []
+        │       └── tag_closing: ">" (location: (1:41)-(1:42))
+        │
+        ├── is_void: false
+        └── source: "HTML"


### PR DESCRIPTION
This pull request updates the parser to treat backslash as a literal character in HTML attribute values instead of an escape character.

The HTML spec does not define backslash as an escape character in attribute values. To include quote characters in attribute values, the spec recommends using HTML character references (e.g. `&quot;` or `&apos;`) or using a different quote style.

See: https://html.spec.whatwg.org/multipage/syntax.html#attributes-2

The following snippet: 
```html
<button data-shortcut="S,s,\">S \</button>
```

Now parses as:
```js
@ DocumentNode (location: (1:0)-(1:42))
└── children: (3 items)
    ├── @ HTMLOpenTagNode (location: (1:0)-(1:30))
    │   ├── tag_opening: "<" (location: (1:0)-(1:1))
    │   ├── tag_name: "button" (location: (1:1)-(1:7))
    │   ├── tag_closing: ">" (location: (1:29)-(1:30))
    │   ├── children: (1 item)
    │   │   └── @ HTMLAttributeNode (location: (1:8)-(1:29))
    │   │       ├── name: 
    │   │       │   └── @ HTMLAttributeNameNode (location: (1:8)-(1:21))
    │   │       │       └── children: (1 item)
    │   │       │           └── @ LiteralNode (location: (1:8)-(1:21))
    │   │       │               └── content: "data-shortcut"
    │   │       │               
    │   │       ├── equals: "=" (location: (1:21)-(1:22))
    │   │       └── value: 
    │   │           └── @ HTMLAttributeValueNode (location: (1:22)-(1:29))
    │   │               ├── open_quote: """ (location: (1:22)-(1:23))
    │   │               ├── children: (1 item)
    │   │               │   └── @ LiteralNode (location: (1:23)-(1:28))
    │   │               │       └── content: "S,s,\\"
    │   │               │   
    │   │               ├── close_quote: """ (location: (1:28)-(1:29))
    │   │               └── quoted: true
    │   │               
    │   └── is_void: false
    │   
    ├── @ HTMLTextNode (location: (1:30)-(1:33))
    │   └── content: "S \\"
    │   
    └── @ HTMLCloseTagNode (location: (1:33)-(1:42))
        ├── tag_opening: "</" (location: (1:33)-(1:35))
        ├── tag_name: "button" (location: (1:35)-(1:41))
        └── tag_closing: ">" (location: (1:41)-(1:42))
```

Resolves #1211 