### PR TITLE
Linter: Update `html-anchor-require-href` with `erblint-github` insights

### DIFF
--- a/javascript/packages/linter/docs/rules/html-anchor-require-href.md
+++ b/javascript/packages/linter/docs/rules/html-anchor-require-href.md
@@ -4,11 +4,11 @@
 
 ## Description
 
-Disallow the use of anchor tags without an `href` attribute in HTML templates. Use if you want to perform an action without having the user navigated to a new URL.
+An `<a>` element that has an `href` attribute represents a hyperlink (a hypertext anchor) labeled by its contents. Links should go somewhere. If you want to perform an action without navigating the user to a new URL, use a `<button>` instead.
 
 ## Rationale
 
-Anchor tags without href are unfocusable if user is using keyboard navigation, or is unseen by screen readers.
+Anchor tags without an `href` attribute are not focusable via keyboard navigation and are not visible to screen readers. This makes them inaccessible to users who rely on assistive technologies.
 
 ## Examples
 
@@ -21,12 +21,21 @@ Anchor tags without href are unfocusable if user is using keyboard navigation, o
 ### 🚫 Bad
 
 ```erb
+<a>Go to Page</a>
+```
+
+```erb
 <a data-action="click->doSomething">I'm a fake link</a>
 ```
 
 ## References
 
-* https://marcysutton.com/links-vs-buttons-in-modern-web-applications
-* https://a11y-101.com/design/button-vs-link
-* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/button_role
-* https://www.scottohara.me/blog/2021/05/28/disabled-links.html#w3c/html-aria#305
+* [MDN: The Anchor element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a)
+* [HTML Spec: The `a` element](https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element)
+* [WAI-ARIA 1.2: `link` role](https://www.w3.org/TR/wai-aria-1.2/#link)
+* [Primer: Links](https://primer.style/design/accessibility/links)
+* [Links vs. Buttons in Modern Web Applications](https://marcysutton.com/links-vs-buttons-in-modern-web-applications)
+* [Button vs. Link](https://a11y-101.com/design/button-vs-link)
+* [MDN: ARIA button role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/button_role)
+* [Disabled Links](https://www.scottohara.me/blog/2021/05/28/disabled-links.html)
+* [`erblint-github`: `LinkHasHref`](https://github.com/github/erblint-github/blob/main/docs/rules/accessibility/link-has-href.md)

--- a/javascript/packages/linter/src/rules/html-anchor-require-href.ts
+++ b/javascript/packages/linter/src/rules/html-anchor-require-href.ts
@@ -1,10 +1,10 @@
-import { BaseRuleVisitor, getTagName, hasAttribute } from "./rule-utils.js"
+import { BaseRuleVisitor, getTagName, getAttribute, getStaticAttributeValue } from "./rule-utils.js"
 
 import { ParserRule } from "../types.js"
 import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types.js"
 import type { HTMLOpenTagNode, ParseResult } from "@herb-tools/core"
 
-class AnchorRechireHrefVisitor extends BaseRuleVisitor {
+class AnchorRequireHrefVisitor extends BaseRuleVisitor {
   visitHTMLOpenTagNode(node: HTMLOpenTagNode): void {
     this.checkATag(node)
     super.visitHTMLOpenTagNode(node)
@@ -17,9 +17,21 @@ class AnchorRechireHrefVisitor extends BaseRuleVisitor {
       return
     }
 
-    if (!hasAttribute(node, "href")) {
+    const hrefAttribute = getAttribute(node, "href")
+
+    if (!hrefAttribute) {
       this.addOffense(
-        "Add an `href` attribute to `<a>` to ensure it is focusable and accessible.",
+        "Add an `href` attribute to `<a>` to ensure it is focusable and accessible. Links should go somewhere, you probably want to use a `<button>` instead.",
+        node.tag_name!.location,
+      )
+      return
+    }
+
+    const hrefValue = getStaticAttributeValue(hrefAttribute)
+
+    if (hrefValue === "#") {
+      this.addOffense(
+        "Add an `href` attribute to `<a>` to ensure it is focusable and accessible. Links should go somewhere, you probably want to use a `<button>` instead.",
         node.tag_name!.location,
       )
     }
@@ -37,7 +49,7 @@ export class HTMLAnchorRequireHrefRule extends ParserRule {
   }
 
   check(result: ParseResult, context?: Partial<LintContext>): UnboundLintOffense[] {
-    const visitor = new AnchorRechireHrefVisitor(this.name, context)
+    const visitor = new AnchorRequireHrefVisitor(this.name, context)
 
     visitor.visit(result.value)
 

--- a/javascript/packages/linter/test/__snapshots__/cli.test.ts.snap
+++ b/javascript/packages/linter/test/__snapshots__/cli.test.ts.snap
@@ -288,7 +288,7 @@ test/fixtures/parser-errors.html.erb:2:16
 `;
 
 exports[`CLI Output Formatting > displays most violated rules with multiple offenses 1`] = `
-"[error] Add an \`href\` attribute to \`<a>\` to ensure it is focusable and accessible. (html-anchor-require-href)
+"[error] Add an \`href\` attribute to \`<a>\` to ensure it is focusable and accessible. Links should go somewhere, you probably want to use a \`<button>\` instead. (html-anchor-require-href)
 
 test/fixtures/multiple-rule-offenses.html.erb:5:3
 
@@ -302,7 +302,7 @@ test/fixtures/multiple-rule-offenses.html.erb:5:3
 
 ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯  [1/14] ⎯⎯⎯⎯
 
-[error] Add an \`href\` attribute to \`<a>\` to ensure it is focusable and accessible. (html-anchor-require-href)
+[error] Add an \`href\` attribute to \`<a>\` to ensure it is focusable and accessible. Links should go somewhere, you probably want to use a \`<button>\` instead. (html-anchor-require-href)
 
 test/fixtures/multiple-rule-offenses.html.erb:10:1
 
@@ -316,7 +316,7 @@ test/fixtures/multiple-rule-offenses.html.erb:10:1
 
 ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯  [2/14] ⎯⎯⎯⎯
 
-[error] Add an \`href\` attribute to \`<a>\` to ensure it is focusable and accessible. (html-anchor-require-href)
+[error] Add an \`href\` attribute to \`<a>\` to ensure it is focusable and accessible. Links should go somewhere, you probably want to use a \`<button>\` instead. (html-anchor-require-href)
 
 test/fixtures/multiple-rule-offenses.html.erb:10:4
 

--- a/javascript/packages/linter/test/rules/html-anchor-require-href-rule.test.ts
+++ b/javascript/packages/linter/test/rules/html-anchor-require-href-rule.test.ts
@@ -4,26 +4,70 @@ import { createLinterTest } from "../helpers/linter-test-helper.js"
 
 const { expectNoOffenses, expectError, assertOffenses } = createLinterTest(HTMLAnchorRequireHrefRule)
 
+const MESSAGE = "Add an `href` attribute to `<a>` to ensure it is focusable and accessible. Links should go somewhere, you probably want to use a `<button>` instead."
+
 describe("html-anchor-require-href", () => {
   test("passes for a with href attribute", () => {
     expectNoOffenses('<a href="http://example.com">My link</a>')
   })
 
   test("fails for a without href attribute", () => {
-    expectError("Add an `href` attribute to `<a>` to ensure it is focusable and accessible.")
+    expectError(MESSAGE)
 
     assertOffenses("<a>My link</a>")
   })
 
   test("fails for multiple a tags without href", () => {
-    expectError("Add an `href` attribute to `<a>` to ensure it is focusable and accessible.")
-    expectError("Add an `href` attribute to `<a>` to ensure it is focusable and accessible.")
+    expectError(MESSAGE)
+    expectError(MESSAGE)
 
     assertOffenses("<a>My link</a><a>My other link</a>")
   })
 
-  test("passes for img with ERB alt attribute", () => {
+  test("fails for a with href='#'", () => {
+    expectError(MESSAGE)
+
+    assertOffenses('<a href="#">My link</a>')
+  })
+
+  test("fails for a with name attribute and no href", () => {
+    expectError(MESSAGE)
+
+    assertOffenses('<a name="section1"></a>')
+  })
+
+  test("fails for a with id attribute and no href", () => {
+    expectError(MESSAGE)
+
+    assertOffenses('<a id="content">anchor target</a>')
+  })
+
+  test("passes for a with ERB href attribute", () => {
     expectNoOffenses('<a href="<%= user.home_page_url %>">My Link</a>')
+  })
+
+  test("passes for a with fragment href", () => {
+    expectNoOffenses('<a href="#section">Jump to section</a>')
+  })
+
+  test("passes for a with empty href", () => {
+    expectNoOffenses('<a href="">Self link</a>')
+  })
+
+  test("passes for a with both name and href", () => {
+    expectNoOffenses('<a name="top" href="http://example.com">My link</a>')
+  })
+
+  test("fails for a with other attributes but no href", () => {
+    expectError(MESSAGE)
+
+    assertOffenses('<a class="btn">My link</a>')
+  })
+
+  test("fails for a with href='#' and other attributes", () => {
+    expectError(MESSAGE)
+
+    assertOffenses('<a href="#" data-action="click->doSomething">My link</a>')
   })
 
   test("ignores non-a tags", () => {
@@ -31,7 +75,7 @@ describe("html-anchor-require-href", () => {
   })
 
   test("handles mixed case a tags", () => {
-    expectError("Add an `href` attribute to `<a>` to ensure it is focusable and accessible.")
+    expectError(MESSAGE)
 
     assertOffenses("<A>My link</A>")
   })


### PR DESCRIPTION
This pull request updates the `html-anchor-require-href` rule with the findings from the [`GitHub::Accessibility::LinkHasHref`](https://github.com/github/erblint-github/blob/main/lib/erblint-github/linters/github/accessibility/link_has_href.rb) rule from [`erblint-github`](https://github.com/github/erblint-github).


Resolves #1221 