### PR TITLE
Parser: Fix `ConditionalElementMultipleTagsError` on valid templates

### DIFF
--- a/src/analyze_conditional_elements.c
+++ b/src/analyze_conditional_elements.c
@@ -225,9 +225,12 @@ static void rewrite_conditional_elements(hb_array_T* nodes, hb_array_T* document
     if (!is_simple_erb_conditional(open_node)) { continue; }
 
     hb_array_T* open_statements = get_erb_conditional_statements(open_node);
-    size_t open_tag_count = count_nodes_of_type(open_statements, AST_HTML_OPEN_TAG_NODE);
 
+    size_t open_tag_count = count_nodes_of_type(open_statements, AST_HTML_OPEN_TAG_NODE);
     if (open_tag_count < 2) { continue; }
+
+    size_t open_close_tag_count = count_nodes_of_type(open_statements, AST_HTML_CLOSE_TAG_NODE);
+    if (open_tag_count <= open_close_tag_count) { continue; }
 
     bool open_is_if;
     const char* open_condition = extract_condition_from_erb_content(open_node, &open_is_if);
@@ -242,9 +245,12 @@ static void rewrite_conditional_elements(hb_array_T* nodes, hb_array_T* document
       if (!is_simple_erb_conditional(close_node)) { continue; }
 
       hb_array_T* close_statements = get_erb_conditional_statements(close_node);
-      size_t close_tag_count = count_nodes_of_type(close_statements, AST_HTML_CLOSE_TAG_NODE);
 
+      size_t close_tag_count = count_nodes_of_type(close_statements, AST_HTML_CLOSE_TAG_NODE);
       if (close_tag_count < 2) { continue; }
+
+      size_t close_open_tag_count = count_nodes_of_type(close_statements, AST_HTML_OPEN_TAG_NODE);
+      if (close_tag_count <= close_open_tag_count) { continue; }
 
       bool close_is_if;
       const char* close_condition = extract_condition_from_erb_content(close_node, &close_is_if);

--- a/src/analyze_conditional_open_tags.c
+++ b/src/analyze_conditional_open_tags.c
@@ -79,12 +79,6 @@ static single_open_tag_result_T get_single_open_tag_from_statements(hb_array_T* 
 
     if (!node) { continue; }
 
-    if (node->type == AST_WHITESPACE_NODE) { continue; }
-    if (node->type == AST_HTML_CLOSE_TAG_NODE) { continue; }
-    if (node->type == AST_ERB_CONTENT_NODE) { continue; }
-    if (node->type == AST_HTML_ELEMENT_NODE) { continue; }
-    if (node->type == AST_ERB_BLOCK_NODE) { continue; }
-
     if (node->type == AST_HTML_TEXT_NODE) {
       AST_HTML_TEXT_NODE_T* text = (AST_HTML_TEXT_NODE_T*) node;
       bool whitespace_only = true;
@@ -125,8 +119,6 @@ static single_open_tag_result_T get_single_open_tag_from_statements(hb_array_T* 
 
       continue;
     }
-
-    return result;
   }
 
   if (tag_count != 1) {

--- a/test/analyze/conditional_element_test.rb
+++ b/test/analyze/conditional_element_test.rb
@@ -216,5 +216,93 @@ module Analyze
         <% end %>
       HTML
     end
+
+    test "complete elements inside matching if blocks should not trigger multiple tags error" do
+      assert_parsed_snapshot(<<~HTML)
+        <% if condition %>
+          <div>
+            <h2>Title</h2>
+            <p>Description</p>
+          </div>
+        <% end %>
+
+        <% if condition %>
+          <div>
+            <h2>Title</h2>
+            <p>Description</p>
+          </div>
+        <% end %>
+      HTML
+    end
+
+    test "complete elements with same condition in nested scope should not trigger error" do
+      assert_parsed_snapshot(<<~HTML)
+        <div>
+          <% if @is_owner %>
+            <div class="section">
+              <h2>Title</h2>
+              <p>Description</p>
+            </div>
+          <% end %>
+
+          <% if @is_owner %>
+            <div class="section">
+              <h2>Title</h2>
+              <p>Description</p>
+            </div>
+          <% end %>
+        </div>
+      HTML
+    end
+
+    test "matching unless blocks with balanced tags should not trigger error" do
+      assert_parsed_snapshot(<<~HTML)
+        <% unless hidden %>
+          <div>
+            <h2>Title</h2>
+          </div>
+        <% end %>
+        <% unless hidden %>
+          <div>
+            <span>Content</span>
+          </div>
+        <% end %>
+      HTML
+    end
+
+    test "if blocks with deeply nested balanced tags should not trigger error" do
+      assert_parsed_snapshot(<<~HTML)
+        <% if condition %>
+          <div>
+            <section>
+              <h1>Title</h1>
+              <p>Description</p>
+            </section>
+          </div>
+        <% end %>
+        <% if condition %>
+          <div>
+            <section>
+              <h1>Title</h1>
+              <p>Description</p>
+            </section>
+          </div>
+        <% end %>
+      HTML
+    end
+
+    test "actual unmatched multiple tags in matching conditionals" do
+      assert_parsed_snapshot(<<~HTML)
+        <% if condition %>
+          <div>
+          <span>
+        <% end %>
+          content
+        <% if condition %>
+          </span>
+          </div>
+        <% end %>
+      HTML
+    end
   end
 end

--- a/test/analyze/conditional_open_tag_test.rb
+++ b/test/analyze/conditional_open_tag_test.rb
@@ -307,5 +307,275 @@ module Analyze
         <% end %>
       HTML
     end
+
+    test "complete elements with erb if/end inside if/else branches (issue #1239)" do
+      assert_parsed_snapshot(<<~HTML)
+        <% if true %>
+          <div>
+            <div></div>
+            <% if true %><% end %>
+          </div>
+        <% else %>
+          <div></div>
+        <% end %>
+      HTML
+    end
+
+    test "nested if/else with complete elements and inner erb control flow (issue #1239)" do
+      assert_parsed_snapshot(<<~HTML)
+        <% if true %>
+          <% if true %>
+            <div>
+              <div></div>
+              <% if true %><% end %>
+            </div>
+          <% else %>
+            <div></div>
+          <% end %>
+        <% end %>
+      HTML
+    end
+
+    test "complete elements with erb while inside if/else branches" do
+      assert_parsed_snapshot(<<~HTML)
+        <% if condition %>
+          <div>
+            <span></span>
+            <% while x > 0 %>
+              <p><%= x %></p>
+            <% end %>
+          </div>
+        <% else %>
+          <div></div>
+        <% end %>
+      HTML
+    end
+
+    test "complete elements with erb each block inside if/else branches" do
+      assert_parsed_snapshot(<<~HTML)
+        <% if condition %>
+          <div>
+            <% items.each do |item| %>
+              <span><%= item %></span>
+            <% end %>
+          </div>
+        <% else %>
+          <div></div>
+        <% end %>
+      HTML
+    end
+
+    test "complete elements with erb unless inside if/else branches" do
+      assert_parsed_snapshot(<<~HTML)
+        <% if condition %>
+          <div>
+            <% unless hidden %>
+              <span>visible</span>
+            <% end %>
+          </div>
+        <% else %>
+          <div></div>
+        <% end %>
+      HTML
+    end
+
+    test "complete elements with erb begin/rescue inside if/else branches" do
+      assert_parsed_snapshot(<<~HTML)
+        <% if condition %>
+          <div>
+            <% begin %>
+              <span><%= dangerous_call %></span>
+            <% rescue %>
+              <span>error</span>
+            <% end %>
+          </div>
+        <% else %>
+          <div></div>
+        <% end %>
+      HTML
+    end
+
+    test "complete elements with erb case/when inside if/else branches" do
+      assert_parsed_snapshot(<<~HTML)
+        <% if condition %>
+          <div>
+            <% case status %>
+            <% when :active %>
+              <span>active</span>
+            <% when :inactive %>
+              <span>inactive</span>
+            <% end %>
+          </div>
+        <% else %>
+          <div></div>
+        <% end %>
+      HTML
+    end
+
+    test "erb if/end before complete element in branch" do
+      assert_parsed_snapshot(<<~HTML)
+        <% if condition %>
+          <% if setup %><% end %>
+          <div></div>
+        <% else %>
+          <div></div>
+        <% end %>
+      HTML
+    end
+
+    test "multiple erb control flow nodes with complete element in branch" do
+      assert_parsed_snapshot(<<~HTML)
+        <% if condition %>
+          <div>
+            <% if a %><% end %>
+            <% items.each do |item| %>
+              <span><%= item %></span>
+            <% end %>
+            <% if b %><% end %>
+          </div>
+        <% else %>
+          <div></div>
+        <% end %>
+      HTML
+    end
+
+    test "if/elsif/else with erb control flow in each branch" do
+      assert_parsed_snapshot(<<~HTML)
+        <% if a %>
+          <div>
+            <% if x %><% end %>
+          </div>
+        <% elsif b %>
+          <div>
+            <% items.each do |i| %><% end %>
+          </div>
+        <% else %>
+          <div>
+            <% while c %><% end %>
+          </div>
+        <% end %>
+      HTML
+    end
+
+    test "complete elements with erb until inside if/else branches" do
+      assert_parsed_snapshot(<<~HTML)
+        <% if condition %>
+          <div>
+            <% until done %>
+              <p>waiting</p>
+            <% end %>
+          </div>
+        <% else %>
+          <div></div>
+        <% end %>
+      HTML
+    end
+
+    test "complete elements with erb for inside if/else branches" do
+      assert_parsed_snapshot(<<~HTML)
+        <% if condition %>
+          <div>
+            <% for item in items %>
+              <span><%= item %></span>
+            <% end %>
+          </div>
+        <% else %>
+          <div></div>
+        <% end %>
+      HTML
+    end
+
+    test "complete elements with erb if/elsif/else inside if/else branches" do
+      assert_parsed_snapshot(<<~HTML)
+        <% if condition %>
+          <div>
+            <% if inner_a %>
+              <span>a</span>
+            <% elsif inner_b %>
+              <span>b</span>
+            <% else %>
+              <span>c</span>
+            <% end %>
+          </div>
+        <% else %>
+          <div></div>
+        <% end %>
+      HTML
+    end
+
+    test "erb block before complete element in branch" do
+      assert_parsed_snapshot(<<~HTML)
+        <% if condition %>
+          <% items.each do |item| %><% end %>
+          <div></div>
+        <% else %>
+          <div></div>
+        <% end %>
+      HTML
+    end
+
+    test "deeply nested erb control flow inside branch" do
+      assert_parsed_snapshot(<<~HTML)
+        <% if condition %>
+          <div>
+            <% items.each do |item| %>
+              <% if item.visible? %>
+                <span><%= item.name %></span>
+              <% end %>
+            <% end %>
+          </div>
+        <% else %>
+          <div></div>
+        <% end %>
+      HTML
+    end
+
+    test "html comment alongside complete element in branch" do
+      assert_parsed_snapshot(<<~HTML)
+        <% if condition %>
+          <!-- a comment -->
+          <div></div>
+        <% else %>
+          <div></div>
+        <% end %>
+      HTML
+    end
+
+    test "erb output tag alongside complete element in branch" do
+      assert_parsed_snapshot(<<~HTML)
+        <% if condition %>
+          <%= some_helper %>
+          <div></div>
+        <% else %>
+          <div></div>
+        <% end %>
+      HTML
+    end
+
+    test "both branches have erb control flow with complete elements" do
+      assert_parsed_snapshot(<<~HTML)
+        <% if condition %>
+          <div>
+            <% if inner %><% end %>
+          </div>
+        <% else %>
+          <div>
+            <% unless inner %><% end %>
+          </div>
+        <% end %>
+      HTML
+    end
+
+    test "unless/else with erb control flow inside branch" do
+      assert_parsed_snapshot(<<~HTML)
+        <% unless condition %>
+          <div>
+            <% if inner %><% end %>
+          </div>
+        <% else %>
+          <div></div>
+        <% end %>
+      HTML
+    end
   end
 end

--- a/test/snapshots/analyze/conditional_element_test/test_0016_complete_elements_inside_matching_if_blocks_should_not_trigger_multiple_tags_error_2104ef5d4d8c09c9bbed64a4bf2c7c31.txt
+++ b/test/snapshots/analyze/conditional_element_test/test_0016_complete_elements_inside_matching_if_blocks_should_not_trigger_multiple_tags_error_2104ef5d4d8c09c9bbed64a4bf2c7c31.txt
@@ -1,0 +1,220 @@
+---
+source: "Analyze::ConditionalElementTest#test_0016_complete elements inside matching if blocks should not trigger multiple tags error"
+input: |2-
+<% if condition %>
+  <div>
+    <h2>Title</h2>
+    <p>Description</p>
+  </div>
+<% end %>
+
+<% if condition %>
+  <div>
+    <h2>Title</h2>
+    <p>Description</p>
+  </div>
+<% end %>
+---
+@ DocumentNode (location: (1:0)-(14:0))
+└── children: (4 items)
+    ├── @ ERBIfNode (location: (1:0)-(6:9))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
+    │   ├── content: " if condition " (location: (1:2)-(1:16))
+    │   ├── tag_closing: "%>" (location: (1:16)-(1:18))
+    │   ├── then_keyword: ∅
+    │   ├── statements: (3 items)
+    │   │   ├── @ HTMLTextNode (location: (1:18)-(2:2))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ HTMLElementNode (location: (2:2)-(5:8))
+    │   │   │   ├── open_tag:
+    │   │   │   │   └── @ HTMLOpenTagNode (location: (2:2)-(2:7))
+    │   │   │   │       ├── tag_opening: "<" (location: (2:2)-(2:3))
+    │   │   │   │       ├── tag_name: "div" (location: (2:3)-(2:6))
+    │   │   │   │       ├── tag_closing: ">" (location: (2:6)-(2:7))
+    │   │   │   │       ├── children: []
+    │   │   │   │       └── is_void: false
+    │   │   │   │
+    │   │   │   ├── tag_name: "div" (location: (2:3)-(2:6))
+    │   │   │   ├── body: (5 items)
+    │   │   │   │   ├── @ HTMLTextNode (location: (2:7)-(3:4))
+    │   │   │   │   │   └── content: "\n    "
+    │   │   │   │   │
+    │   │   │   │   ├── @ HTMLElementNode (location: (3:4)-(3:18))
+    │   │   │   │   │   ├── open_tag:
+    │   │   │   │   │   │   └── @ HTMLOpenTagNode (location: (3:4)-(3:8))
+    │   │   │   │   │   │       ├── tag_opening: "<" (location: (3:4)-(3:5))
+    │   │   │   │   │   │       ├── tag_name: "h2" (location: (3:5)-(3:7))
+    │   │   │   │   │   │       ├── tag_closing: ">" (location: (3:7)-(3:8))
+    │   │   │   │   │   │       ├── children: []
+    │   │   │   │   │   │       └── is_void: false
+    │   │   │   │   │   │
+    │   │   │   │   │   ├── tag_name: "h2" (location: (3:5)-(3:7))
+    │   │   │   │   │   ├── body: (1 item)
+    │   │   │   │   │   │   └── @ HTMLTextNode (location: (3:8)-(3:13))
+    │   │   │   │   │   │       └── content: "Title"
+    │   │   │   │   │   │
+    │   │   │   │   │   ├── close_tag:
+    │   │   │   │   │   │   └── @ HTMLCloseTagNode (location: (3:13)-(3:18))
+    │   │   │   │   │   │       ├── tag_opening: "</" (location: (3:13)-(3:15))
+    │   │   │   │   │   │       ├── tag_name: "h2" (location: (3:15)-(3:17))
+    │   │   │   │   │   │       ├── children: []
+    │   │   │   │   │   │       └── tag_closing: ">" (location: (3:17)-(3:18))
+    │   │   │   │   │   │
+    │   │   │   │   │   ├── is_void: false
+    │   │   │   │   │   └── source: "HTML"
+    │   │   │   │   │
+    │   │   │   │   ├── @ HTMLTextNode (location: (3:18)-(4:4))
+    │   │   │   │   │   └── content: "\n    "
+    │   │   │   │   │
+    │   │   │   │   ├── @ HTMLElementNode (location: (4:4)-(4:22))
+    │   │   │   │   │   ├── open_tag:
+    │   │   │   │   │   │   └── @ HTMLOpenTagNode (location: (4:4)-(4:7))
+    │   │   │   │   │   │       ├── tag_opening: "<" (location: (4:4)-(4:5))
+    │   │   │   │   │   │       ├── tag_name: "p" (location: (4:5)-(4:6))
+    │   │   │   │   │   │       ├── tag_closing: ">" (location: (4:6)-(4:7))
+    │   │   │   │   │   │       ├── children: []
+    │   │   │   │   │   │       └── is_void: false
+    │   │   │   │   │   │
+    │   │   │   │   │   ├── tag_name: "p" (location: (4:5)-(4:6))
+    │   │   │   │   │   ├── body: (1 item)
+    │   │   │   │   │   │   └── @ HTMLTextNode (location: (4:7)-(4:18))
+    │   │   │   │   │   │       └── content: "Description"
+    │   │   │   │   │   │
+    │   │   │   │   │   ├── close_tag:
+    │   │   │   │   │   │   └── @ HTMLCloseTagNode (location: (4:18)-(4:22))
+    │   │   │   │   │   │       ├── tag_opening: "</" (location: (4:18)-(4:20))
+    │   │   │   │   │   │       ├── tag_name: "p" (location: (4:20)-(4:21))
+    │   │   │   │   │   │       ├── children: []
+    │   │   │   │   │   │       └── tag_closing: ">" (location: (4:21)-(4:22))
+    │   │   │   │   │   │
+    │   │   │   │   │   ├── is_void: false
+    │   │   │   │   │   └── source: "HTML"
+    │   │   │   │   │
+    │   │   │   │   └── @ HTMLTextNode (location: (4:22)-(5:2))
+    │   │   │   │       └── content: "\n  "
+    │   │   │   │
+    │   │   │   ├── close_tag:
+    │   │   │   │   └── @ HTMLCloseTagNode (location: (5:2)-(5:8))
+    │   │   │   │       ├── tag_opening: "</" (location: (5:2)-(5:4))
+    │   │   │   │       ├── tag_name: "div" (location: (5:4)-(5:7))
+    │   │   │   │       ├── children: []
+    │   │   │   │       └── tag_closing: ">" (location: (5:7)-(5:8))
+    │   │   │   │
+    │   │   │   ├── is_void: false
+    │   │   │   └── source: "HTML"
+    │   │   │
+    │   │   └── @ HTMLTextNode (location: (5:8)-(6:0))
+    │   │       └── content: "\n"
+    │   │
+    │   ├── subsequent: ∅
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (6:0)-(6:9))
+    │           ├── tag_opening: "<%" (location: (6:0)-(6:2))
+    │           ├── content: " end " (location: (6:2)-(6:7))
+    │           └── tag_closing: "%>" (location: (6:7)-(6:9))
+    │
+    │
+    ├── @ HTMLTextNode (location: (6:9)-(8:0))
+    │   └── content: "\n\n"
+    │
+    ├── @ ERBIfNode (location: (8:0)-(13:9))
+    │   ├── tag_opening: "<%" (location: (8:0)-(8:2))
+    │   ├── content: " if condition " (location: (8:2)-(8:16))
+    │   ├── tag_closing: "%>" (location: (8:16)-(8:18))
+    │   ├── then_keyword: ∅
+    │   ├── statements: (3 items)
+    │   │   ├── @ HTMLTextNode (location: (8:18)-(9:2))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ HTMLElementNode (location: (9:2)-(12:8))
+    │   │   │   ├── open_tag:
+    │   │   │   │   └── @ HTMLOpenTagNode (location: (9:2)-(9:7))
+    │   │   │   │       ├── tag_opening: "<" (location: (9:2)-(9:3))
+    │   │   │   │       ├── tag_name: "div" (location: (9:3)-(9:6))
+    │   │   │   │       ├── tag_closing: ">" (location: (9:6)-(9:7))
+    │   │   │   │       ├── children: []
+    │   │   │   │       └── is_void: false
+    │   │   │   │
+    │   │   │   ├── tag_name: "div" (location: (9:3)-(9:6))
+    │   │   │   ├── body: (5 items)
+    │   │   │   │   ├── @ HTMLTextNode (location: (9:7)-(10:4))
+    │   │   │   │   │   └── content: "\n    "
+    │   │   │   │   │
+    │   │   │   │   ├── @ HTMLElementNode (location: (10:4)-(10:18))
+    │   │   │   │   │   ├── open_tag:
+    │   │   │   │   │   │   └── @ HTMLOpenTagNode (location: (10:4)-(10:8))
+    │   │   │   │   │   │       ├── tag_opening: "<" (location: (10:4)-(10:5))
+    │   │   │   │   │   │       ├── tag_name: "h2" (location: (10:5)-(10:7))
+    │   │   │   │   │   │       ├── tag_closing: ">" (location: (10:7)-(10:8))
+    │   │   │   │   │   │       ├── children: []
+    │   │   │   │   │   │       └── is_void: false
+    │   │   │   │   │   │
+    │   │   │   │   │   ├── tag_name: "h2" (location: (10:5)-(10:7))
+    │   │   │   │   │   ├── body: (1 item)
+    │   │   │   │   │   │   └── @ HTMLTextNode (location: (10:8)-(10:13))
+    │   │   │   │   │   │       └── content: "Title"
+    │   │   │   │   │   │
+    │   │   │   │   │   ├── close_tag:
+    │   │   │   │   │   │   └── @ HTMLCloseTagNode (location: (10:13)-(10:18))
+    │   │   │   │   │   │       ├── tag_opening: "</" (location: (10:13)-(10:15))
+    │   │   │   │   │   │       ├── tag_name: "h2" (location: (10:15)-(10:17))
+    │   │   │   │   │   │       ├── children: []
+    │   │   │   │   │   │       └── tag_closing: ">" (location: (10:17)-(10:18))
+    │   │   │   │   │   │
+    │   │   │   │   │   ├── is_void: false
+    │   │   │   │   │   └── source: "HTML"
+    │   │   │   │   │
+    │   │   │   │   ├── @ HTMLTextNode (location: (10:18)-(11:4))
+    │   │   │   │   │   └── content: "\n    "
+    │   │   │   │   │
+    │   │   │   │   ├── @ HTMLElementNode (location: (11:4)-(11:22))
+    │   │   │   │   │   ├── open_tag:
+    │   │   │   │   │   │   └── @ HTMLOpenTagNode (location: (11:4)-(11:7))
+    │   │   │   │   │   │       ├── tag_opening: "<" (location: (11:4)-(11:5))
+    │   │   │   │   │   │       ├── tag_name: "p" (location: (11:5)-(11:6))
+    │   │   │   │   │   │       ├── tag_closing: ">" (location: (11:6)-(11:7))
+    │   │   │   │   │   │       ├── children: []
+    │   │   │   │   │   │       └── is_void: false
+    │   │   │   │   │   │
+    │   │   │   │   │   ├── tag_name: "p" (location: (11:5)-(11:6))
+    │   │   │   │   │   ├── body: (1 item)
+    │   │   │   │   │   │   └── @ HTMLTextNode (location: (11:7)-(11:18))
+    │   │   │   │   │   │       └── content: "Description"
+    │   │   │   │   │   │
+    │   │   │   │   │   ├── close_tag:
+    │   │   │   │   │   │   └── @ HTMLCloseTagNode (location: (11:18)-(11:22))
+    │   │   │   │   │   │       ├── tag_opening: "</" (location: (11:18)-(11:20))
+    │   │   │   │   │   │       ├── tag_name: "p" (location: (11:20)-(11:21))
+    │   │   │   │   │   │       ├── children: []
+    │   │   │   │   │   │       └── tag_closing: ">" (location: (11:21)-(11:22))
+    │   │   │   │   │   │
+    │   │   │   │   │   ├── is_void: false
+    │   │   │   │   │   └── source: "HTML"
+    │   │   │   │   │
+    │   │   │   │   └── @ HTMLTextNode (location: (11:22)-(12:2))
+    │   │   │   │       └── content: "\n  "
+    │   │   │   │
+    │   │   │   ├── close_tag:
+    │   │   │   │   └── @ HTMLCloseTagNode (location: (12:2)-(12:8))
+    │   │   │   │       ├── tag_opening: "</" (location: (12:2)-(12:4))
+    │   │   │   │       ├── tag_name: "div" (location: (12:4)-(12:7))
+    │   │   │   │       ├── children: []
+    │   │   │   │       └── tag_closing: ">" (location: (12:7)-(12:8))
+    │   │   │   │
+    │   │   │   ├── is_void: false
+    │   │   │   └── source: "HTML"
+    │   │   │
+    │   │   └── @ HTMLTextNode (location: (12:8)-(13:0))
+    │   │       └── content: "\n"
+    │   │
+    │   ├── subsequent: ∅
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (13:0)-(13:9))
+    │           ├── tag_opening: "<%" (location: (13:0)-(13:2))
+    │           ├── content: " end " (location: (13:2)-(13:7))
+    │           └── tag_closing: "%>" (location: (13:7)-(13:9))
+    │
+    │
+    └── @ HTMLTextNode (location: (13:9)-(14:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/conditional_element_test/test_0017_complete_elements_with_same_condition_in_nested_scope_should_not_trigger_error_ba0bfabc2444edf8d952b74db147ac7e.txt
+++ b/test/snapshots/analyze/conditional_element_test/test_0017_complete_elements_with_same_condition_in_nested_scope_should_not_trigger_error_ba0bfabc2444edf8d952b74db147ac7e.txt
@@ -1,0 +1,289 @@
+---
+source: "Analyze::ConditionalElementTest#test_0017_complete elements with same condition in nested scope should not trigger error"
+input: |2-
+<div>
+  <% if @is_owner %>
+    <div class="section">
+      <h2>Title</h2>
+      <p>Description</p>
+    </div>
+  <% end %>
+
+  <% if @is_owner %>
+    <div class="section">
+      <h2>Title</h2>
+      <p>Description</p>
+    </div>
+  <% end %>
+</div>
+---
+@ DocumentNode (location: (1:0)-(16:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(15:6))
+    │   ├── open_tag:
+    │   │   └── @ HTMLOpenTagNode (location: (1:0)-(1:5))
+    │   │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+    │   │       ├── tag_name: "div" (location: (1:1)-(1:4))
+    │   │       ├── tag_closing: ">" (location: (1:4)-(1:5))
+    │   │       ├── children: []
+    │   │       └── is_void: false
+    │   │
+    │   ├── tag_name: "div" (location: (1:1)-(1:4))
+    │   ├── body: (5 items)
+    │   │   ├── @ HTMLTextNode (location: (1:5)-(2:2))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ ERBIfNode (location: (2:2)-(7:11))
+    │   │   │   ├── tag_opening: "<%" (location: (2:2)-(2:4))
+    │   │   │   ├── content: " if @is_owner " (location: (2:4)-(2:18))
+    │   │   │   ├── tag_closing: "%>" (location: (2:18)-(2:20))
+    │   │   │   ├── then_keyword: ∅
+    │   │   │   ├── statements: (3 items)
+    │   │   │   │   ├── @ HTMLTextNode (location: (2:20)-(3:4))
+    │   │   │   │   │   └── content: "\n    "
+    │   │   │   │   │
+    │   │   │   │   ├── @ HTMLElementNode (location: (3:4)-(6:10))
+    │   │   │   │   │   ├── open_tag:
+    │   │   │   │   │   │   └── @ HTMLOpenTagNode (location: (3:4)-(3:25))
+    │   │   │   │   │   │       ├── tag_opening: "<" (location: (3:4)-(3:5))
+    │   │   │   │   │   │       ├── tag_name: "div" (location: (3:5)-(3:8))
+    │   │   │   │   │   │       ├── tag_closing: ">" (location: (3:24)-(3:25))
+    │   │   │   │   │   │       ├── children: (1 item)
+    │   │   │   │   │   │       │   └── @ HTMLAttributeNode (location: (3:9)-(3:24))
+    │   │   │   │   │   │       │       ├── name:
+    │   │   │   │   │   │       │       │   └── @ HTMLAttributeNameNode (location: (3:9)-(3:14))
+    │   │   │   │   │   │       │       │       └── children: (1 item)
+    │   │   │   │   │   │       │       │           └── @ LiteralNode (location: (3:9)-(3:14))
+    │   │   │   │   │   │       │       │               └── content: "class"
+    │   │   │   │   │   │       │       │
+    │   │   │   │   │   │       │       │
+    │   │   │   │   │   │       │       ├── equals: "=" (location: (3:14)-(3:15))
+    │   │   │   │   │   │       │       └── value:
+    │   │   │   │   │   │       │           └── @ HTMLAttributeValueNode (location: (3:15)-(3:24))
+    │   │   │   │   │   │       │               ├── open_quote: """ (location: (3:15)-(3:16))
+    │   │   │   │   │   │       │               ├── children: (1 item)
+    │   │   │   │   │   │       │               │   └── @ LiteralNode (location: (3:16)-(3:23))
+    │   │   │   │   │   │       │               │       └── content: "section"
+    │   │   │   │   │   │       │               │
+    │   │   │   │   │   │       │               ├── close_quote: """ (location: (3:23)-(3:24))
+    │   │   │   │   │   │       │               └── quoted: true
+    │   │   │   │   │   │       │
+    │   │   │   │   │   │       │
+    │   │   │   │   │   │       └── is_void: false
+    │   │   │   │   │   │
+    │   │   │   │   │   ├── tag_name: "div" (location: (3:5)-(3:8))
+    │   │   │   │   │   ├── body: (5 items)
+    │   │   │   │   │   │   ├── @ HTMLTextNode (location: (3:25)-(4:6))
+    │   │   │   │   │   │   │   └── content: "\n      "
+    │   │   │   │   │   │   │
+    │   │   │   │   │   │   ├── @ HTMLElementNode (location: (4:6)-(4:20))
+    │   │   │   │   │   │   │   ├── open_tag:
+    │   │   │   │   │   │   │   │   └── @ HTMLOpenTagNode (location: (4:6)-(4:10))
+    │   │   │   │   │   │   │   │       ├── tag_opening: "<" (location: (4:6)-(4:7))
+    │   │   │   │   │   │   │   │       ├── tag_name: "h2" (location: (4:7)-(4:9))
+    │   │   │   │   │   │   │   │       ├── tag_closing: ">" (location: (4:9)-(4:10))
+    │   │   │   │   │   │   │   │       ├── children: []
+    │   │   │   │   │   │   │   │       └── is_void: false
+    │   │   │   │   │   │   │   │
+    │   │   │   │   │   │   │   ├── tag_name: "h2" (location: (4:7)-(4:9))
+    │   │   │   │   │   │   │   ├── body: (1 item)
+    │   │   │   │   │   │   │   │   └── @ HTMLTextNode (location: (4:10)-(4:15))
+    │   │   │   │   │   │   │   │       └── content: "Title"
+    │   │   │   │   │   │   │   │
+    │   │   │   │   │   │   │   ├── close_tag:
+    │   │   │   │   │   │   │   │   └── @ HTMLCloseTagNode (location: (4:15)-(4:20))
+    │   │   │   │   │   │   │   │       ├── tag_opening: "</" (location: (4:15)-(4:17))
+    │   │   │   │   │   │   │   │       ├── tag_name: "h2" (location: (4:17)-(4:19))
+    │   │   │   │   │   │   │   │       ├── children: []
+    │   │   │   │   │   │   │   │       └── tag_closing: ">" (location: (4:19)-(4:20))
+    │   │   │   │   │   │   │   │
+    │   │   │   │   │   │   │   ├── is_void: false
+    │   │   │   │   │   │   │   └── source: "HTML"
+    │   │   │   │   │   │   │
+    │   │   │   │   │   │   ├── @ HTMLTextNode (location: (4:20)-(5:6))
+    │   │   │   │   │   │   │   └── content: "\n      "
+    │   │   │   │   │   │   │
+    │   │   │   │   │   │   ├── @ HTMLElementNode (location: (5:6)-(5:24))
+    │   │   │   │   │   │   │   ├── open_tag:
+    │   │   │   │   │   │   │   │   └── @ HTMLOpenTagNode (location: (5:6)-(5:9))
+    │   │   │   │   │   │   │   │       ├── tag_opening: "<" (location: (5:6)-(5:7))
+    │   │   │   │   │   │   │   │       ├── tag_name: "p" (location: (5:7)-(5:8))
+    │   │   │   │   │   │   │   │       ├── tag_closing: ">" (location: (5:8)-(5:9))
+    │   │   │   │   │   │   │   │       ├── children: []
+    │   │   │   │   │   │   │   │       └── is_void: false
+    │   │   │   │   │   │   │   │
+    │   │   │   │   │   │   │   ├── tag_name: "p" (location: (5:7)-(5:8))
+    │   │   │   │   │   │   │   ├── body: (1 item)
+    │   │   │   │   │   │   │   │   └── @ HTMLTextNode (location: (5:9)-(5:20))
+    │   │   │   │   │   │   │   │       └── content: "Description"
+    │   │   │   │   │   │   │   │
+    │   │   │   │   │   │   │   ├── close_tag:
+    │   │   │   │   │   │   │   │   └── @ HTMLCloseTagNode (location: (5:20)-(5:24))
+    │   │   │   │   │   │   │   │       ├── tag_opening: "</" (location: (5:20)-(5:22))
+    │   │   │   │   │   │   │   │       ├── tag_name: "p" (location: (5:22)-(5:23))
+    │   │   │   │   │   │   │   │       ├── children: []
+    │   │   │   │   │   │   │   │       └── tag_closing: ">" (location: (5:23)-(5:24))
+    │   │   │   │   │   │   │   │
+    │   │   │   │   │   │   │   ├── is_void: false
+    │   │   │   │   │   │   │   └── source: "HTML"
+    │   │   │   │   │   │   │
+    │   │   │   │   │   │   └── @ HTMLTextNode (location: (5:24)-(6:4))
+    │   │   │   │   │   │       └── content: "\n    "
+    │   │   │   │   │   │
+    │   │   │   │   │   ├── close_tag:
+    │   │   │   │   │   │   └── @ HTMLCloseTagNode (location: (6:4)-(6:10))
+    │   │   │   │   │   │       ├── tag_opening: "</" (location: (6:4)-(6:6))
+    │   │   │   │   │   │       ├── tag_name: "div" (location: (6:6)-(6:9))
+    │   │   │   │   │   │       ├── children: []
+    │   │   │   │   │   │       └── tag_closing: ">" (location: (6:9)-(6:10))
+    │   │   │   │   │   │
+    │   │   │   │   │   ├── is_void: false
+    │   │   │   │   │   └── source: "HTML"
+    │   │   │   │   │
+    │   │   │   │   └── @ HTMLTextNode (location: (6:10)-(7:2))
+    │   │   │   │       └── content: "\n  "
+    │   │   │   │
+    │   │   │   ├── subsequent: ∅
+    │   │   │   └── end_node:
+    │   │   │       └── @ ERBEndNode (location: (7:2)-(7:11))
+    │   │   │           ├── tag_opening: "<%" (location: (7:2)-(7:4))
+    │   │   │           ├── content: " end " (location: (7:4)-(7:9))
+    │   │   │           └── tag_closing: "%>" (location: (7:9)-(7:11))
+    │   │   │
+    │   │   │
+    │   │   ├── @ HTMLTextNode (location: (7:11)-(9:2))
+    │   │   │   └── content: "\n\n  "
+    │   │   │
+    │   │   ├── @ ERBIfNode (location: (9:2)-(14:11))
+    │   │   │   ├── tag_opening: "<%" (location: (9:2)-(9:4))
+    │   │   │   ├── content: " if @is_owner " (location: (9:4)-(9:18))
+    │   │   │   ├── tag_closing: "%>" (location: (9:18)-(9:20))
+    │   │   │   ├── then_keyword: ∅
+    │   │   │   ├── statements: (3 items)
+    │   │   │   │   ├── @ HTMLTextNode (location: (9:20)-(10:4))
+    │   │   │   │   │   └── content: "\n    "
+    │   │   │   │   │
+    │   │   │   │   ├── @ HTMLElementNode (location: (10:4)-(13:10))
+    │   │   │   │   │   ├── open_tag:
+    │   │   │   │   │   │   └── @ HTMLOpenTagNode (location: (10:4)-(10:25))
+    │   │   │   │   │   │       ├── tag_opening: "<" (location: (10:4)-(10:5))
+    │   │   │   │   │   │       ├── tag_name: "div" (location: (10:5)-(10:8))
+    │   │   │   │   │   │       ├── tag_closing: ">" (location: (10:24)-(10:25))
+    │   │   │   │   │   │       ├── children: (1 item)
+    │   │   │   │   │   │       │   └── @ HTMLAttributeNode (location: (10:9)-(10:24))
+    │   │   │   │   │   │       │       ├── name:
+    │   │   │   │   │   │       │       │   └── @ HTMLAttributeNameNode (location: (10:9)-(10:14))
+    │   │   │   │   │   │       │       │       └── children: (1 item)
+    │   │   │   │   │   │       │       │           └── @ LiteralNode (location: (10:9)-(10:14))
+    │   │   │   │   │   │       │       │               └── content: "class"
+    │   │   │   │   │   │       │       │
+    │   │   │   │   │   │       │       │
+    │   │   │   │   │   │       │       ├── equals: "=" (location: (10:14)-(10:15))
+    │   │   │   │   │   │       │       └── value:
+    │   │   │   │   │   │       │           └── @ HTMLAttributeValueNode (location: (10:15)-(10:24))
+    │   │   │   │   │   │       │               ├── open_quote: """ (location: (10:15)-(10:16))
+    │   │   │   │   │   │       │               ├── children: (1 item)
+    │   │   │   │   │   │       │               │   └── @ LiteralNode (location: (10:16)-(10:23))
+    │   │   │   │   │   │       │               │       └── content: "section"
+    │   │   │   │   │   │       │               │
+    │   │   │   │   │   │       │               ├── close_quote: """ (location: (10:23)-(10:24))
+    │   │   │   │   │   │       │               └── quoted: true
+    │   │   │   │   │   │       │
+    │   │   │   │   │   │       │
+    │   │   │   │   │   │       └── is_void: false
+    │   │   │   │   │   │
+    │   │   │   │   │   ├── tag_name: "div" (location: (10:5)-(10:8))
+    │   │   │   │   │   ├── body: (5 items)
+    │   │   │   │   │   │   ├── @ HTMLTextNode (location: (10:25)-(11:6))
+    │   │   │   │   │   │   │   └── content: "\n      "
+    │   │   │   │   │   │   │
+    │   │   │   │   │   │   ├── @ HTMLElementNode (location: (11:6)-(11:20))
+    │   │   │   │   │   │   │   ├── open_tag:
+    │   │   │   │   │   │   │   │   └── @ HTMLOpenTagNode (location: (11:6)-(11:10))
+    │   │   │   │   │   │   │   │       ├── tag_opening: "<" (location: (11:6)-(11:7))
+    │   │   │   │   │   │   │   │       ├── tag_name: "h2" (location: (11:7)-(11:9))
+    │   │   │   │   │   │   │   │       ├── tag_closing: ">" (location: (11:9)-(11:10))
+    │   │   │   │   │   │   │   │       ├── children: []
+    │   │   │   │   │   │   │   │       └── is_void: false
+    │   │   │   │   │   │   │   │
+    │   │   │   │   │   │   │   ├── tag_name: "h2" (location: (11:7)-(11:9))
+    │   │   │   │   │   │   │   ├── body: (1 item)
+    │   │   │   │   │   │   │   │   └── @ HTMLTextNode (location: (11:10)-(11:15))
+    │   │   │   │   │   │   │   │       └── content: "Title"
+    │   │   │   │   │   │   │   │
+    │   │   │   │   │   │   │   ├── close_tag:
+    │   │   │   │   │   │   │   │   └── @ HTMLCloseTagNode (location: (11:15)-(11:20))
+    │   │   │   │   │   │   │   │       ├── tag_opening: "</" (location: (11:15)-(11:17))
+    │   │   │   │   │   │   │   │       ├── tag_name: "h2" (location: (11:17)-(11:19))
+    │   │   │   │   │   │   │   │       ├── children: []
+    │   │   │   │   │   │   │   │       └── tag_closing: ">" (location: (11:19)-(11:20))
+    │   │   │   │   │   │   │   │
+    │   │   │   │   │   │   │   ├── is_void: false
+    │   │   │   │   │   │   │   └── source: "HTML"
+    │   │   │   │   │   │   │
+    │   │   │   │   │   │   ├── @ HTMLTextNode (location: (11:20)-(12:6))
+    │   │   │   │   │   │   │   └── content: "\n      "
+    │   │   │   │   │   │   │
+    │   │   │   │   │   │   ├── @ HTMLElementNode (location: (12:6)-(12:24))
+    │   │   │   │   │   │   │   ├── open_tag:
+    │   │   │   │   │   │   │   │   └── @ HTMLOpenTagNode (location: (12:6)-(12:9))
+    │   │   │   │   │   │   │   │       ├── tag_opening: "<" (location: (12:6)-(12:7))
+    │   │   │   │   │   │   │   │       ├── tag_name: "p" (location: (12:7)-(12:8))
+    │   │   │   │   │   │   │   │       ├── tag_closing: ">" (location: (12:8)-(12:9))
+    │   │   │   │   │   │   │   │       ├── children: []
+    │   │   │   │   │   │   │   │       └── is_void: false
+    │   │   │   │   │   │   │   │
+    │   │   │   │   │   │   │   ├── tag_name: "p" (location: (12:7)-(12:8))
+    │   │   │   │   │   │   │   ├── body: (1 item)
+    │   │   │   │   │   │   │   │   └── @ HTMLTextNode (location: (12:9)-(12:20))
+    │   │   │   │   │   │   │   │       └── content: "Description"
+    │   │   │   │   │   │   │   │
+    │   │   │   │   │   │   │   ├── close_tag:
+    │   │   │   │   │   │   │   │   └── @ HTMLCloseTagNode (location: (12:20)-(12:24))
+    │   │   │   │   │   │   │   │       ├── tag_opening: "</" (location: (12:20)-(12:22))
+    │   │   │   │   │   │   │   │       ├── tag_name: "p" (location: (12:22)-(12:23))
+    │   │   │   │   │   │   │   │       ├── children: []
+    │   │   │   │   │   │   │   │       └── tag_closing: ">" (location: (12:23)-(12:24))
+    │   │   │   │   │   │   │   │
+    │   │   │   │   │   │   │   ├── is_void: false
+    │   │   │   │   │   │   │   └── source: "HTML"
+    │   │   │   │   │   │   │
+    │   │   │   │   │   │   └── @ HTMLTextNode (location: (12:24)-(13:4))
+    │   │   │   │   │   │       └── content: "\n    "
+    │   │   │   │   │   │
+    │   │   │   │   │   ├── close_tag:
+    │   │   │   │   │   │   └── @ HTMLCloseTagNode (location: (13:4)-(13:10))
+    │   │   │   │   │   │       ├── tag_opening: "</" (location: (13:4)-(13:6))
+    │   │   │   │   │   │       ├── tag_name: "div" (location: (13:6)-(13:9))
+    │   │   │   │   │   │       ├── children: []
+    │   │   │   │   │   │       └── tag_closing: ">" (location: (13:9)-(13:10))
+    │   │   │   │   │   │
+    │   │   │   │   │   ├── is_void: false
+    │   │   │   │   │   └── source: "HTML"
+    │   │   │   │   │
+    │   │   │   │   └── @ HTMLTextNode (location: (13:10)-(14:2))
+    │   │   │   │       └── content: "\n  "
+    │   │   │   │
+    │   │   │   ├── subsequent: ∅
+    │   │   │   └── end_node:
+    │   │   │       └── @ ERBEndNode (location: (14:2)-(14:11))
+    │   │   │           ├── tag_opening: "<%" (location: (14:2)-(14:4))
+    │   │   │           ├── content: " end " (location: (14:4)-(14:9))
+    │   │   │           └── tag_closing: "%>" (location: (14:9)-(14:11))
+    │   │   │
+    │   │   │
+    │   │   └── @ HTMLTextNode (location: (14:11)-(15:0))
+    │   │       └── content: "\n"
+    │   │
+    │   ├── close_tag:
+    │   │   └── @ HTMLCloseTagNode (location: (15:0)-(15:6))
+    │   │       ├── tag_opening: "</" (location: (15:0)-(15:2))
+    │   │       ├── tag_name: "div" (location: (15:2)-(15:5))
+    │   │       ├── children: []
+    │   │       └── tag_closing: ">" (location: (15:5)-(15:6))
+    │   │
+    │   ├── is_void: false
+    │   └── source: "HTML"
+    │
+    └── @ HTMLTextNode (location: (15:6)-(16:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/conditional_element_test/test_0018_matching_unless_blocks_with_balanced_tags_should_not_trigger_error_83067234eac5e5f622f2b81840d4e25f.txt
+++ b/test/snapshots/analyze/conditional_element_test/test_0018_matching_unless_blocks_with_balanced_tags_should_not_trigger_error_83067234eac5e5f622f2b81840d4e25f.txt
@@ -1,0 +1,163 @@
+---
+source: "Analyze::ConditionalElementTest#test_0018_matching unless blocks with balanced tags should not trigger error"
+input: |2-
+<% unless hidden %>
+  <div>
+    <h2>Title</h2>
+  </div>
+<% end %>
+<% unless hidden %>
+  <div>
+    <span>Content</span>
+  </div>
+<% end %>
+---
+@ DocumentNode (location: (1:0)-(11:0))
+└── children: (4 items)
+    ├── @ ERBUnlessNode (location: (1:0)-(5:9))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
+    │   ├── content: " unless hidden " (location: (1:2)-(1:17))
+    │   ├── tag_closing: "%>" (location: (1:17)-(1:19))
+    │   ├── then_keyword: ∅
+    │   ├── statements: (3 items)
+    │   │   ├── @ HTMLTextNode (location: (1:19)-(2:2))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ HTMLElementNode (location: (2:2)-(4:8))
+    │   │   │   ├── open_tag:
+    │   │   │   │   └── @ HTMLOpenTagNode (location: (2:2)-(2:7))
+    │   │   │   │       ├── tag_opening: "<" (location: (2:2)-(2:3))
+    │   │   │   │       ├── tag_name: "div" (location: (2:3)-(2:6))
+    │   │   │   │       ├── tag_closing: ">" (location: (2:6)-(2:7))
+    │   │   │   │       ├── children: []
+    │   │   │   │       └── is_void: false
+    │   │   │   │
+    │   │   │   ├── tag_name: "div" (location: (2:3)-(2:6))
+    │   │   │   ├── body: (3 items)
+    │   │   │   │   ├── @ HTMLTextNode (location: (2:7)-(3:4))
+    │   │   │   │   │   └── content: "\n    "
+    │   │   │   │   │
+    │   │   │   │   ├── @ HTMLElementNode (location: (3:4)-(3:18))
+    │   │   │   │   │   ├── open_tag:
+    │   │   │   │   │   │   └── @ HTMLOpenTagNode (location: (3:4)-(3:8))
+    │   │   │   │   │   │       ├── tag_opening: "<" (location: (3:4)-(3:5))
+    │   │   │   │   │   │       ├── tag_name: "h2" (location: (3:5)-(3:7))
+    │   │   │   │   │   │       ├── tag_closing: ">" (location: (3:7)-(3:8))
+    │   │   │   │   │   │       ├── children: []
+    │   │   │   │   │   │       └── is_void: false
+    │   │   │   │   │   │
+    │   │   │   │   │   ├── tag_name: "h2" (location: (3:5)-(3:7))
+    │   │   │   │   │   ├── body: (1 item)
+    │   │   │   │   │   │   └── @ HTMLTextNode (location: (3:8)-(3:13))
+    │   │   │   │   │   │       └── content: "Title"
+    │   │   │   │   │   │
+    │   │   │   │   │   ├── close_tag:
+    │   │   │   │   │   │   └── @ HTMLCloseTagNode (location: (3:13)-(3:18))
+    │   │   │   │   │   │       ├── tag_opening: "</" (location: (3:13)-(3:15))
+    │   │   │   │   │   │       ├── tag_name: "h2" (location: (3:15)-(3:17))
+    │   │   │   │   │   │       ├── children: []
+    │   │   │   │   │   │       └── tag_closing: ">" (location: (3:17)-(3:18))
+    │   │   │   │   │   │
+    │   │   │   │   │   ├── is_void: false
+    │   │   │   │   │   └── source: "HTML"
+    │   │   │   │   │
+    │   │   │   │   └── @ HTMLTextNode (location: (3:18)-(4:2))
+    │   │   │   │       └── content: "\n  "
+    │   │   │   │
+    │   │   │   ├── close_tag:
+    │   │   │   │   └── @ HTMLCloseTagNode (location: (4:2)-(4:8))
+    │   │   │   │       ├── tag_opening: "</" (location: (4:2)-(4:4))
+    │   │   │   │       ├── tag_name: "div" (location: (4:4)-(4:7))
+    │   │   │   │       ├── children: []
+    │   │   │   │       └── tag_closing: ">" (location: (4:7)-(4:8))
+    │   │   │   │
+    │   │   │   ├── is_void: false
+    │   │   │   └── source: "HTML"
+    │   │   │
+    │   │   └── @ HTMLTextNode (location: (4:8)-(5:0))
+    │   │       └── content: "\n"
+    │   │
+    │   ├── else_clause: ∅
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (5:0)-(5:9))
+    │           ├── tag_opening: "<%" (location: (5:0)-(5:2))
+    │           ├── content: " end " (location: (5:2)-(5:7))
+    │           └── tag_closing: "%>" (location: (5:7)-(5:9))
+    │
+    │
+    ├── @ HTMLTextNode (location: (5:9)-(6:0))
+    │   └── content: "\n"
+    │
+    ├── @ ERBUnlessNode (location: (6:0)-(10:9))
+    │   ├── tag_opening: "<%" (location: (6:0)-(6:2))
+    │   ├── content: " unless hidden " (location: (6:2)-(6:17))
+    │   ├── tag_closing: "%>" (location: (6:17)-(6:19))
+    │   ├── then_keyword: ∅
+    │   ├── statements: (3 items)
+    │   │   ├── @ HTMLTextNode (location: (6:19)-(7:2))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ HTMLElementNode (location: (7:2)-(9:8))
+    │   │   │   ├── open_tag:
+    │   │   │   │   └── @ HTMLOpenTagNode (location: (7:2)-(7:7))
+    │   │   │   │       ├── tag_opening: "<" (location: (7:2)-(7:3))
+    │   │   │   │       ├── tag_name: "div" (location: (7:3)-(7:6))
+    │   │   │   │       ├── tag_closing: ">" (location: (7:6)-(7:7))
+    │   │   │   │       ├── children: []
+    │   │   │   │       └── is_void: false
+    │   │   │   │
+    │   │   │   ├── tag_name: "div" (location: (7:3)-(7:6))
+    │   │   │   ├── body: (3 items)
+    │   │   │   │   ├── @ HTMLTextNode (location: (7:7)-(8:4))
+    │   │   │   │   │   └── content: "\n    "
+    │   │   │   │   │
+    │   │   │   │   ├── @ HTMLElementNode (location: (8:4)-(8:24))
+    │   │   │   │   │   ├── open_tag:
+    │   │   │   │   │   │   └── @ HTMLOpenTagNode (location: (8:4)-(8:10))
+    │   │   │   │   │   │       ├── tag_opening: "<" (location: (8:4)-(8:5))
+    │   │   │   │   │   │       ├── tag_name: "span" (location: (8:5)-(8:9))
+    │   │   │   │   │   │       ├── tag_closing: ">" (location: (8:9)-(8:10))
+    │   │   │   │   │   │       ├── children: []
+    │   │   │   │   │   │       └── is_void: false
+    │   │   │   │   │   │
+    │   │   │   │   │   ├── tag_name: "span" (location: (8:5)-(8:9))
+    │   │   │   │   │   ├── body: (1 item)
+    │   │   │   │   │   │   └── @ HTMLTextNode (location: (8:10)-(8:17))
+    │   │   │   │   │   │       └── content: "Content"
+    │   │   │   │   │   │
+    │   │   │   │   │   ├── close_tag:
+    │   │   │   │   │   │   └── @ HTMLCloseTagNode (location: (8:17)-(8:24))
+    │   │   │   │   │   │       ├── tag_opening: "</" (location: (8:17)-(8:19))
+    │   │   │   │   │   │       ├── tag_name: "span" (location: (8:19)-(8:23))
+    │   │   │   │   │   │       ├── children: []
+    │   │   │   │   │   │       └── tag_closing: ">" (location: (8:23)-(8:24))
+    │   │   │   │   │   │
+    │   │   │   │   │   ├── is_void: false
+    │   │   │   │   │   └── source: "HTML"
+    │   │   │   │   │
+    │   │   │   │   └── @ HTMLTextNode (location: (8:24)-(9:2))
+    │   │   │   │       └── content: "\n  "
+    │   │   │   │
+    │   │   │   ├── close_tag:
+    │   │   │   │   └── @ HTMLCloseTagNode (location: (9:2)-(9:8))
+    │   │   │   │       ├── tag_opening: "</" (location: (9:2)-(9:4))
+    │   │   │   │       ├── tag_name: "div" (location: (9:4)-(9:7))
+    │   │   │   │       ├── children: []
+    │   │   │   │       └── tag_closing: ">" (location: (9:7)-(9:8))
+    │   │   │   │
+    │   │   │   ├── is_void: false
+    │   │   │   └── source: "HTML"
+    │   │   │
+    │   │   └── @ HTMLTextNode (location: (9:8)-(10:0))
+    │   │       └── content: "\n"
+    │   │
+    │   ├── else_clause: ∅
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (10:0)-(10:9))
+    │           ├── tag_opening: "<%" (location: (10:0)-(10:2))
+    │           ├── content: " end " (location: (10:2)-(10:7))
+    │           └── tag_closing: "%>" (location: (10:7)-(10:9))
+    │
+    │
+    └── @ HTMLTextNode (location: (10:9)-(11:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/conditional_element_test/test_0019_if_blocks_with_deeply_nested_balanced_tags_should_not_trigger_error_c561f325f0020a83663623adbcb78c81.txt
+++ b/test/snapshots/analyze/conditional_element_test/test_0019_if_blocks_with_deeply_nested_balanced_tags_should_not_trigger_error_c561f325f0020a83663623adbcb78c81.txt
@@ -1,0 +1,277 @@
+---
+source: "Analyze::ConditionalElementTest#test_0019_if blocks with deeply nested balanced tags should not trigger error"
+input: |2-
+<% if condition %>
+  <div>
+    <section>
+      <h1>Title</h1>
+      <p>Description</p>
+    </section>
+  </div>
+<% end %>
+<% if condition %>
+  <div>
+    <section>
+      <h1>Title</h1>
+      <p>Description</p>
+    </section>
+  </div>
+<% end %>
+---
+@ DocumentNode (location: (1:0)-(17:0))
+└── children: (4 items)
+    ├── @ ERBIfNode (location: (1:0)-(8:9))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
+    │   ├── content: " if condition " (location: (1:2)-(1:16))
+    │   ├── tag_closing: "%>" (location: (1:16)-(1:18))
+    │   ├── then_keyword: ∅
+    │   ├── statements: (3 items)
+    │   │   ├── @ HTMLTextNode (location: (1:18)-(2:2))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ HTMLElementNode (location: (2:2)-(7:8))
+    │   │   │   ├── open_tag:
+    │   │   │   │   └── @ HTMLOpenTagNode (location: (2:2)-(2:7))
+    │   │   │   │       ├── tag_opening: "<" (location: (2:2)-(2:3))
+    │   │   │   │       ├── tag_name: "div" (location: (2:3)-(2:6))
+    │   │   │   │       ├── tag_closing: ">" (location: (2:6)-(2:7))
+    │   │   │   │       ├── children: []
+    │   │   │   │       └── is_void: false
+    │   │   │   │
+    │   │   │   ├── tag_name: "div" (location: (2:3)-(2:6))
+    │   │   │   ├── body: (3 items)
+    │   │   │   │   ├── @ HTMLTextNode (location: (2:7)-(3:4))
+    │   │   │   │   │   └── content: "\n    "
+    │   │   │   │   │
+    │   │   │   │   ├── @ HTMLElementNode (location: (3:4)-(6:14))
+    │   │   │   │   │   ├── open_tag:
+    │   │   │   │   │   │   └── @ HTMLOpenTagNode (location: (3:4)-(3:13))
+    │   │   │   │   │   │       ├── tag_opening: "<" (location: (3:4)-(3:5))
+    │   │   │   │   │   │       ├── tag_name: "section" (location: (3:5)-(3:12))
+    │   │   │   │   │   │       ├── tag_closing: ">" (location: (3:12)-(3:13))
+    │   │   │   │   │   │       ├── children: []
+    │   │   │   │   │   │       └── is_void: false
+    │   │   │   │   │   │
+    │   │   │   │   │   ├── tag_name: "section" (location: (3:5)-(3:12))
+    │   │   │   │   │   ├── body: (5 items)
+    │   │   │   │   │   │   ├── @ HTMLTextNode (location: (3:13)-(4:6))
+    │   │   │   │   │   │   │   └── content: "\n      "
+    │   │   │   │   │   │   │
+    │   │   │   │   │   │   ├── @ HTMLElementNode (location: (4:6)-(4:20))
+    │   │   │   │   │   │   │   ├── open_tag:
+    │   │   │   │   │   │   │   │   └── @ HTMLOpenTagNode (location: (4:6)-(4:10))
+    │   │   │   │   │   │   │   │       ├── tag_opening: "<" (location: (4:6)-(4:7))
+    │   │   │   │   │   │   │   │       ├── tag_name: "h1" (location: (4:7)-(4:9))
+    │   │   │   │   │   │   │   │       ├── tag_closing: ">" (location: (4:9)-(4:10))
+    │   │   │   │   │   │   │   │       ├── children: []
+    │   │   │   │   │   │   │   │       └── is_void: false
+    │   │   │   │   │   │   │   │
+    │   │   │   │   │   │   │   ├── tag_name: "h1" (location: (4:7)-(4:9))
+    │   │   │   │   │   │   │   ├── body: (1 item)
+    │   │   │   │   │   │   │   │   └── @ HTMLTextNode (location: (4:10)-(4:15))
+    │   │   │   │   │   │   │   │       └── content: "Title"
+    │   │   │   │   │   │   │   │
+    │   │   │   │   │   │   │   ├── close_tag:
+    │   │   │   │   │   │   │   │   └── @ HTMLCloseTagNode (location: (4:15)-(4:20))
+    │   │   │   │   │   │   │   │       ├── tag_opening: "</" (location: (4:15)-(4:17))
+    │   │   │   │   │   │   │   │       ├── tag_name: "h1" (location: (4:17)-(4:19))
+    │   │   │   │   │   │   │   │       ├── children: []
+    │   │   │   │   │   │   │   │       └── tag_closing: ">" (location: (4:19)-(4:20))
+    │   │   │   │   │   │   │   │
+    │   │   │   │   │   │   │   ├── is_void: false
+    │   │   │   │   │   │   │   └── source: "HTML"
+    │   │   │   │   │   │   │
+    │   │   │   │   │   │   ├── @ HTMLTextNode (location: (4:20)-(5:6))
+    │   │   │   │   │   │   │   └── content: "\n      "
+    │   │   │   │   │   │   │
+    │   │   │   │   │   │   ├── @ HTMLElementNode (location: (5:6)-(5:24))
+    │   │   │   │   │   │   │   ├── open_tag:
+    │   │   │   │   │   │   │   │   └── @ HTMLOpenTagNode (location: (5:6)-(5:9))
+    │   │   │   │   │   │   │   │       ├── tag_opening: "<" (location: (5:6)-(5:7))
+    │   │   │   │   │   │   │   │       ├── tag_name: "p" (location: (5:7)-(5:8))
+    │   │   │   │   │   │   │   │       ├── tag_closing: ">" (location: (5:8)-(5:9))
+    │   │   │   │   │   │   │   │       ├── children: []
+    │   │   │   │   │   │   │   │       └── is_void: false
+    │   │   │   │   │   │   │   │
+    │   │   │   │   │   │   │   ├── tag_name: "p" (location: (5:7)-(5:8))
+    │   │   │   │   │   │   │   ├── body: (1 item)
+    │   │   │   │   │   │   │   │   └── @ HTMLTextNode (location: (5:9)-(5:20))
+    │   │   │   │   │   │   │   │       └── content: "Description"
+    │   │   │   │   │   │   │   │
+    │   │   │   │   │   │   │   ├── close_tag:
+    │   │   │   │   │   │   │   │   └── @ HTMLCloseTagNode (location: (5:20)-(5:24))
+    │   │   │   │   │   │   │   │       ├── tag_opening: "</" (location: (5:20)-(5:22))
+    │   │   │   │   │   │   │   │       ├── tag_name: "p" (location: (5:22)-(5:23))
+    │   │   │   │   │   │   │   │       ├── children: []
+    │   │   │   │   │   │   │   │       └── tag_closing: ">" (location: (5:23)-(5:24))
+    │   │   │   │   │   │   │   │
+    │   │   │   │   │   │   │   ├── is_void: false
+    │   │   │   │   │   │   │   └── source: "HTML"
+    │   │   │   │   │   │   │
+    │   │   │   │   │   │   └── @ HTMLTextNode (location: (5:24)-(6:4))
+    │   │   │   │   │   │       └── content: "\n    "
+    │   │   │   │   │   │
+    │   │   │   │   │   ├── close_tag:
+    │   │   │   │   │   │   └── @ HTMLCloseTagNode (location: (6:4)-(6:14))
+    │   │   │   │   │   │       ├── tag_opening: "</" (location: (6:4)-(6:6))
+    │   │   │   │   │   │       ├── tag_name: "section" (location: (6:6)-(6:13))
+    │   │   │   │   │   │       ├── children: []
+    │   │   │   │   │   │       └── tag_closing: ">" (location: (6:13)-(6:14))
+    │   │   │   │   │   │
+    │   │   │   │   │   ├── is_void: false
+    │   │   │   │   │   └── source: "HTML"
+    │   │   │   │   │
+    │   │   │   │   └── @ HTMLTextNode (location: (6:14)-(7:2))
+    │   │   │   │       └── content: "\n  "
+    │   │   │   │
+    │   │   │   ├── close_tag:
+    │   │   │   │   └── @ HTMLCloseTagNode (location: (7:2)-(7:8))
+    │   │   │   │       ├── tag_opening: "</" (location: (7:2)-(7:4))
+    │   │   │   │       ├── tag_name: "div" (location: (7:4)-(7:7))
+    │   │   │   │       ├── children: []
+    │   │   │   │       └── tag_closing: ">" (location: (7:7)-(7:8))
+    │   │   │   │
+    │   │   │   ├── is_void: false
+    │   │   │   └── source: "HTML"
+    │   │   │
+    │   │   └── @ HTMLTextNode (location: (7:8)-(8:0))
+    │   │       └── content: "\n"
+    │   │
+    │   ├── subsequent: ∅
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (8:0)-(8:9))
+    │           ├── tag_opening: "<%" (location: (8:0)-(8:2))
+    │           ├── content: " end " (location: (8:2)-(8:7))
+    │           └── tag_closing: "%>" (location: (8:7)-(8:9))
+    │
+    │
+    ├── @ HTMLTextNode (location: (8:9)-(9:0))
+    │   └── content: "\n"
+    │
+    ├── @ ERBIfNode (location: (9:0)-(16:9))
+    │   ├── tag_opening: "<%" (location: (9:0)-(9:2))
+    │   ├── content: " if condition " (location: (9:2)-(9:16))
+    │   ├── tag_closing: "%>" (location: (9:16)-(9:18))
+    │   ├── then_keyword: ∅
+    │   ├── statements: (3 items)
+    │   │   ├── @ HTMLTextNode (location: (9:18)-(10:2))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ HTMLElementNode (location: (10:2)-(15:8))
+    │   │   │   ├── open_tag:
+    │   │   │   │   └── @ HTMLOpenTagNode (location: (10:2)-(10:7))
+    │   │   │   │       ├── tag_opening: "<" (location: (10:2)-(10:3))
+    │   │   │   │       ├── tag_name: "div" (location: (10:3)-(10:6))
+    │   │   │   │       ├── tag_closing: ">" (location: (10:6)-(10:7))
+    │   │   │   │       ├── children: []
+    │   │   │   │       └── is_void: false
+    │   │   │   │
+    │   │   │   ├── tag_name: "div" (location: (10:3)-(10:6))
+    │   │   │   ├── body: (3 items)
+    │   │   │   │   ├── @ HTMLTextNode (location: (10:7)-(11:4))
+    │   │   │   │   │   └── content: "\n    "
+    │   │   │   │   │
+    │   │   │   │   ├── @ HTMLElementNode (location: (11:4)-(14:14))
+    │   │   │   │   │   ├── open_tag:
+    │   │   │   │   │   │   └── @ HTMLOpenTagNode (location: (11:4)-(11:13))
+    │   │   │   │   │   │       ├── tag_opening: "<" (location: (11:4)-(11:5))
+    │   │   │   │   │   │       ├── tag_name: "section" (location: (11:5)-(11:12))
+    │   │   │   │   │   │       ├── tag_closing: ">" (location: (11:12)-(11:13))
+    │   │   │   │   │   │       ├── children: []
+    │   │   │   │   │   │       └── is_void: false
+    │   │   │   │   │   │
+    │   │   │   │   │   ├── tag_name: "section" (location: (11:5)-(11:12))
+    │   │   │   │   │   ├── body: (5 items)
+    │   │   │   │   │   │   ├── @ HTMLTextNode (location: (11:13)-(12:6))
+    │   │   │   │   │   │   │   └── content: "\n      "
+    │   │   │   │   │   │   │
+    │   │   │   │   │   │   ├── @ HTMLElementNode (location: (12:6)-(12:20))
+    │   │   │   │   │   │   │   ├── open_tag:
+    │   │   │   │   │   │   │   │   └── @ HTMLOpenTagNode (location: (12:6)-(12:10))
+    │   │   │   │   │   │   │   │       ├── tag_opening: "<" (location: (12:6)-(12:7))
+    │   │   │   │   │   │   │   │       ├── tag_name: "h1" (location: (12:7)-(12:9))
+    │   │   │   │   │   │   │   │       ├── tag_closing: ">" (location: (12:9)-(12:10))
+    │   │   │   │   │   │   │   │       ├── children: []
+    │   │   │   │   │   │   │   │       └── is_void: false
+    │   │   │   │   │   │   │   │
+    │   │   │   │   │   │   │   ├── tag_name: "h1" (location: (12:7)-(12:9))
+    │   │   │   │   │   │   │   ├── body: (1 item)
+    │   │   │   │   │   │   │   │   └── @ HTMLTextNode (location: (12:10)-(12:15))
+    │   │   │   │   │   │   │   │       └── content: "Title"
+    │   │   │   │   │   │   │   │
+    │   │   │   │   │   │   │   ├── close_tag:
+    │   │   │   │   │   │   │   │   └── @ HTMLCloseTagNode (location: (12:15)-(12:20))
+    │   │   │   │   │   │   │   │       ├── tag_opening: "</" (location: (12:15)-(12:17))
+    │   │   │   │   │   │   │   │       ├── tag_name: "h1" (location: (12:17)-(12:19))
+    │   │   │   │   │   │   │   │       ├── children: []
+    │   │   │   │   │   │   │   │       └── tag_closing: ">" (location: (12:19)-(12:20))
+    │   │   │   │   │   │   │   │
+    │   │   │   │   │   │   │   ├── is_void: false
+    │   │   │   │   │   │   │   └── source: "HTML"
+    │   │   │   │   │   │   │
+    │   │   │   │   │   │   ├── @ HTMLTextNode (location: (12:20)-(13:6))
+    │   │   │   │   │   │   │   └── content: "\n      "
+    │   │   │   │   │   │   │
+    │   │   │   │   │   │   ├── @ HTMLElementNode (location: (13:6)-(13:24))
+    │   │   │   │   │   │   │   ├── open_tag:
+    │   │   │   │   │   │   │   │   └── @ HTMLOpenTagNode (location: (13:6)-(13:9))
+    │   │   │   │   │   │   │   │       ├── tag_opening: "<" (location: (13:6)-(13:7))
+    │   │   │   │   │   │   │   │       ├── tag_name: "p" (location: (13:7)-(13:8))
+    │   │   │   │   │   │   │   │       ├── tag_closing: ">" (location: (13:8)-(13:9))
+    │   │   │   │   │   │   │   │       ├── children: []
+    │   │   │   │   │   │   │   │       └── is_void: false
+    │   │   │   │   │   │   │   │
+    │   │   │   │   │   │   │   ├── tag_name: "p" (location: (13:7)-(13:8))
+    │   │   │   │   │   │   │   ├── body: (1 item)
+    │   │   │   │   │   │   │   │   └── @ HTMLTextNode (location: (13:9)-(13:20))
+    │   │   │   │   │   │   │   │       └── content: "Description"
+    │   │   │   │   │   │   │   │
+    │   │   │   │   │   │   │   ├── close_tag:
+    │   │   │   │   │   │   │   │   └── @ HTMLCloseTagNode (location: (13:20)-(13:24))
+    │   │   │   │   │   │   │   │       ├── tag_opening: "</" (location: (13:20)-(13:22))
+    │   │   │   │   │   │   │   │       ├── tag_name: "p" (location: (13:22)-(13:23))
+    │   │   │   │   │   │   │   │       ├── children: []
+    │   │   │   │   │   │   │   │       └── tag_closing: ">" (location: (13:23)-(13:24))
+    │   │   │   │   │   │   │   │
+    │   │   │   │   │   │   │   ├── is_void: false
+    │   │   │   │   │   │   │   └── source: "HTML"
+    │   │   │   │   │   │   │
+    │   │   │   │   │   │   └── @ HTMLTextNode (location: (13:24)-(14:4))
+    │   │   │   │   │   │       └── content: "\n    "
+    │   │   │   │   │   │
+    │   │   │   │   │   ├── close_tag:
+    │   │   │   │   │   │   └── @ HTMLCloseTagNode (location: (14:4)-(14:14))
+    │   │   │   │   │   │       ├── tag_opening: "</" (location: (14:4)-(14:6))
+    │   │   │   │   │   │       ├── tag_name: "section" (location: (14:6)-(14:13))
+    │   │   │   │   │   │       ├── children: []
+    │   │   │   │   │   │       └── tag_closing: ">" (location: (14:13)-(14:14))
+    │   │   │   │   │   │
+    │   │   │   │   │   ├── is_void: false
+    │   │   │   │   │   └── source: "HTML"
+    │   │   │   │   │
+    │   │   │   │   └── @ HTMLTextNode (location: (14:14)-(15:2))
+    │   │   │   │       └── content: "\n  "
+    │   │   │   │
+    │   │   │   ├── close_tag:
+    │   │   │   │   └── @ HTMLCloseTagNode (location: (15:2)-(15:8))
+    │   │   │   │       ├── tag_opening: "</" (location: (15:2)-(15:4))
+    │   │   │   │       ├── tag_name: "div" (location: (15:4)-(15:7))
+    │   │   │   │       ├── children: []
+    │   │   │   │       └── tag_closing: ">" (location: (15:7)-(15:8))
+    │   │   │   │
+    │   │   │   ├── is_void: false
+    │   │   │   └── source: "HTML"
+    │   │   │
+    │   │   └── @ HTMLTextNode (location: (15:8)-(16:0))
+    │   │       └── content: "\n"
+    │   │
+    │   ├── subsequent: ∅
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (16:0)-(16:9))
+    │           ├── tag_opening: "<%" (location: (16:0)-(16:2))
+    │           ├── content: " end " (location: (16:2)-(16:7))
+    │           └── tag_closing: "%>" (location: (16:7)-(16:9))
+    │
+    │
+    └── @ HTMLTextNode (location: (16:9)-(17:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/conditional_element_test/test_0020_actual_unmatched_multiple_tags_in_matching_conditionals_b038b6c3448e697c2a707d7930af5b6c.txt
+++ b/test/snapshots/analyze/conditional_element_test/test_0020_actual_unmatched_multiple_tags_in_matching_conditionals_b038b6c3448e697c2a707d7930af5b6c.txt
@@ -1,0 +1,118 @@
+---
+source: "Analyze::ConditionalElementTest#test_0020_actual unmatched multiple tags in matching conditionals"
+input: |2-
+<% if condition %>
+  <div>
+  <span>
+<% end %>
+  content
+<% if condition %>
+  </span>
+  </div>
+<% end %>
+---
+@ DocumentNode (location: (1:0)-(10:0))
+├── errors: (1 error)
+│   └── @ ConditionalElementMultipleTagsError (location: (1:0)-(4:9))
+│       ├── message: "Conditional element pattern detected at (1:0) but the conditional block contains multiple HTML tags. Each conditional element must wrap exactly one opening and one closing tag. Consider nesting the conditionals individually."
+│       ├── line: 1
+│       └── column: 0
+│
+└── children: (4 items)
+    ├── @ ERBIfNode (location: (1:0)-(4:9))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
+    │   ├── content: " if condition " (location: (1:2)-(1:16))
+    │   ├── tag_closing: "%>" (location: (1:16)-(1:18))
+    │   ├── then_keyword: ∅
+    │   ├── statements: (5 items)
+    │   │   ├── @ HTMLTextNode (location: (1:18)-(2:2))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ HTMLOpenTagNode (location: (2:2)-(2:7))
+    │   │   │   ├── errors: (1 error)
+    │   │   │   │   └── @ MissingClosingTagError (location: (2:2)-(2:7))
+    │   │   │   │       ├── message: "Opening tag `<div>` at (2:3) doesn't have a matching closing tag `</div>` in the same scope."
+    │   │   │   │       └── opening_tag: "div" (location: (2:3)-(2:6))
+    │   │   │   │
+    │   │   │   ├── tag_opening: "<" (location: (2:2)-(2:3))
+    │   │   │   ├── tag_name: "div" (location: (2:3)-(2:6))
+    │   │   │   ├── tag_closing: ">" (location: (2:6)-(2:7))
+    │   │   │   ├── children: []
+    │   │   │   └── is_void: false
+    │   │   │
+    │   │   ├── @ HTMLTextNode (location: (2:7)-(3:2))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ HTMLOpenTagNode (location: (3:2)-(3:8))
+    │   │   │   ├── errors: (1 error)
+    │   │   │   │   └── @ MissingClosingTagError (location: (3:2)-(3:8))
+    │   │   │   │       ├── message: "Opening tag `<span>` at (3:3) doesn't have a matching closing tag `</span>` in the same scope."
+    │   │   │   │       └── opening_tag: "span" (location: (3:3)-(3:7))
+    │   │   │   │
+    │   │   │   ├── tag_opening: "<" (location: (3:2)-(3:3))
+    │   │   │   ├── tag_name: "span" (location: (3:3)-(3:7))
+    │   │   │   ├── tag_closing: ">" (location: (3:7)-(3:8))
+    │   │   │   ├── children: []
+    │   │   │   └── is_void: false
+    │   │   │
+    │   │   └── @ HTMLTextNode (location: (3:8)-(4:0))
+    │   │       └── content: "\n"
+    │   │
+    │   ├── subsequent: ∅
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (4:0)-(4:9))
+    │           ├── tag_opening: "<%" (location: (4:0)-(4:2))
+    │           ├── content: " end " (location: (4:2)-(4:7))
+    │           └── tag_closing: "%>" (location: (4:7)-(4:9))
+    │
+    │
+    ├── @ HTMLTextNode (location: (4:9)-(6:0))
+    │   └── content: "\n  content\n"
+    │
+    ├── @ ERBIfNode (location: (6:0)-(9:9))
+    │   ├── tag_opening: "<%" (location: (6:0)-(6:2))
+    │   ├── content: " if condition " (location: (6:2)-(6:16))
+    │   ├── tag_closing: "%>" (location: (6:16)-(6:18))
+    │   ├── then_keyword: ∅
+    │   ├── statements: (5 items)
+    │   │   ├── @ HTMLTextNode (location: (6:18)-(7:2))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ HTMLCloseTagNode (location: (7:2)-(7:9))
+    │   │   │   ├── errors: (1 error)
+    │   │   │   │   └── @ MissingOpeningTagError (location: (7:2)-(7:9))
+    │   │   │   │       ├── message: "Found closing tag `</span>` at (7:4) without a matching opening tag in the same scope."
+    │   │   │   │       └── closing_tag: "span" (location: (7:4)-(7:8))
+    │   │   │   │
+    │   │   │   ├── tag_opening: "</" (location: (7:2)-(7:4))
+    │   │   │   ├── tag_name: "span" (location: (7:4)-(7:8))
+    │   │   │   ├── children: []
+    │   │   │   └── tag_closing: ">" (location: (7:8)-(7:9))
+    │   │   │
+    │   │   ├── @ HTMLTextNode (location: (7:9)-(8:2))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ HTMLCloseTagNode (location: (8:2)-(8:8))
+    │   │   │   ├── errors: (1 error)
+    │   │   │   │   └── @ MissingOpeningTagError (location: (8:2)-(8:8))
+    │   │   │   │       ├── message: "Found closing tag `</div>` at (8:4) without a matching opening tag in the same scope."
+    │   │   │   │       └── closing_tag: "div" (location: (8:4)-(8:7))
+    │   │   │   │
+    │   │   │   ├── tag_opening: "</" (location: (8:2)-(8:4))
+    │   │   │   ├── tag_name: "div" (location: (8:4)-(8:7))
+    │   │   │   ├── children: []
+    │   │   │   └── tag_closing: ">" (location: (8:7)-(8:8))
+    │   │   │
+    │   │   └── @ HTMLTextNode (location: (8:8)-(9:0))
+    │   │       └── content: "\n"
+    │   │
+    │   ├── subsequent: ∅
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (9:0)-(9:9))
+    │           ├── tag_opening: "<%" (location: (9:0)-(9:2))
+    │           ├── content: " end " (location: (9:2)-(9:7))
+    │           └── tag_closing: "%>" (location: (9:7)-(9:9))
+    │
+    │
+    └── @ HTMLTextNode (location: (9:9)-(10:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/conditional_open_tag_test/test_0022_complete_elements_with_erb_if_end_inside_if_else_branches_(issue_#1239)_af19edf9e21ef7ecdf4eadaa09979d59.txt
+++ b/test/snapshots/analyze/conditional_open_tag_test/test_0022_complete_elements_with_erb_if_end_inside_if_else_branches_(issue_#1239)_af19edf9e21ef7ecdf4eadaa09979d59.txt
@@ -1,0 +1,134 @@
+---
+source: "Analyze::ConditionalOpenTagTest#test_0022_complete elements with erb if/end inside if/else branches (issue #1239)"
+input: |2-
+<% if true %>
+  <div>
+    <div></div>
+    <% if true %><% end %>
+  </div>
+<% else %>
+  <div></div>
+<% end %>
+---
+@ DocumentNode (location: (1:0)-(9:0))
+└── children: (2 items)
+    ├── @ ERBIfNode (location: (1:0)-(8:9))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
+    │   ├── content: " if true " (location: (1:2)-(1:11))
+    │   ├── tag_closing: "%>" (location: (1:11)-(1:13))
+    │   ├── then_keyword: ∅
+    │   ├── statements: (3 items)
+    │   │   ├── @ HTMLTextNode (location: (1:13)-(2:2))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ HTMLElementNode (location: (2:2)-(5:8))
+    │   │   │   ├── open_tag:
+    │   │   │   │   └── @ HTMLOpenTagNode (location: (2:2)-(2:7))
+    │   │   │   │       ├── tag_opening: "<" (location: (2:2)-(2:3))
+    │   │   │   │       ├── tag_name: "div" (location: (2:3)-(2:6))
+    │   │   │   │       ├── tag_closing: ">" (location: (2:6)-(2:7))
+    │   │   │   │       ├── children: []
+    │   │   │   │       └── is_void: false
+    │   │   │   │
+    │   │   │   ├── tag_name: "div" (location: (2:3)-(2:6))
+    │   │   │   ├── body: (5 items)
+    │   │   │   │   ├── @ HTMLTextNode (location: (2:7)-(3:4))
+    │   │   │   │   │   └── content: "\n    "
+    │   │   │   │   │
+    │   │   │   │   ├── @ HTMLElementNode (location: (3:4)-(3:15))
+    │   │   │   │   │   ├── open_tag:
+    │   │   │   │   │   │   └── @ HTMLOpenTagNode (location: (3:4)-(3:9))
+    │   │   │   │   │   │       ├── tag_opening: "<" (location: (3:4)-(3:5))
+    │   │   │   │   │   │       ├── tag_name: "div" (location: (3:5)-(3:8))
+    │   │   │   │   │   │       ├── tag_closing: ">" (location: (3:8)-(3:9))
+    │   │   │   │   │   │       ├── children: []
+    │   │   │   │   │   │       └── is_void: false
+    │   │   │   │   │   │
+    │   │   │   │   │   ├── tag_name: "div" (location: (3:5)-(3:8))
+    │   │   │   │   │   ├── body: []
+    │   │   │   │   │   ├── close_tag:
+    │   │   │   │   │   │   └── @ HTMLCloseTagNode (location: (3:9)-(3:15))
+    │   │   │   │   │   │       ├── tag_opening: "</" (location: (3:9)-(3:11))
+    │   │   │   │   │   │       ├── tag_name: "div" (location: (3:11)-(3:14))
+    │   │   │   │   │   │       ├── children: []
+    │   │   │   │   │   │       └── tag_closing: ">" (location: (3:14)-(3:15))
+    │   │   │   │   │   │
+    │   │   │   │   │   ├── is_void: false
+    │   │   │   │   │   └── source: "HTML"
+    │   │   │   │   │
+    │   │   │   │   ├── @ HTMLTextNode (location: (3:15)-(4:4))
+    │   │   │   │   │   └── content: "\n    "
+    │   │   │   │   │
+    │   │   │   │   ├── @ ERBIfNode (location: (4:4)-(4:26))
+    │   │   │   │   │   ├── tag_opening: "<%" (location: (4:4)-(4:6))
+    │   │   │   │   │   ├── content: " if true " (location: (4:6)-(4:15))
+    │   │   │   │   │   ├── tag_closing: "%>" (location: (4:15)-(4:17))
+    │   │   │   │   │   ├── then_keyword: ∅
+    │   │   │   │   │   ├── statements: []
+    │   │   │   │   │   ├── subsequent: ∅
+    │   │   │   │   │   └── end_node:
+    │   │   │   │   │       └── @ ERBEndNode (location: (4:17)-(4:26))
+    │   │   │   │   │           ├── tag_opening: "<%" (location: (4:17)-(4:19))
+    │   │   │   │   │           ├── content: " end " (location: (4:19)-(4:24))
+    │   │   │   │   │           └── tag_closing: "%>" (location: (4:24)-(4:26))
+    │   │   │   │   │
+    │   │   │   │   │
+    │   │   │   │   └── @ HTMLTextNode (location: (4:26)-(5:2))
+    │   │   │   │       └── content: "\n  "
+    │   │   │   │
+    │   │   │   ├── close_tag:
+    │   │   │   │   └── @ HTMLCloseTagNode (location: (5:2)-(5:8))
+    │   │   │   │       ├── tag_opening: "</" (location: (5:2)-(5:4))
+    │   │   │   │       ├── tag_name: "div" (location: (5:4)-(5:7))
+    │   │   │   │       ├── children: []
+    │   │   │   │       └── tag_closing: ">" (location: (5:7)-(5:8))
+    │   │   │   │
+    │   │   │   ├── is_void: false
+    │   │   │   └── source: "HTML"
+    │   │   │
+    │   │   └── @ HTMLTextNode (location: (5:8)-(6:0))
+    │   │       └── content: "\n"
+    │   │
+    │   ├── subsequent:
+    │   │   └── @ ERBElseNode (location: (6:0)-(8:0))
+    │   │       ├── tag_opening: "<%" (location: (6:0)-(6:2))
+    │   │       ├── content: " else " (location: (6:2)-(6:8))
+    │   │       ├── tag_closing: "%>" (location: (6:8)-(6:10))
+    │   │       └── statements: (3 items)
+    │   │           ├── @ HTMLTextNode (location: (6:10)-(7:2))
+    │   │           │   └── content: "\n  "
+    │   │           │
+    │   │           ├── @ HTMLElementNode (location: (7:2)-(7:13))
+    │   │           │   ├── open_tag:
+    │   │           │   │   └── @ HTMLOpenTagNode (location: (7:2)-(7:7))
+    │   │           │   │       ├── tag_opening: "<" (location: (7:2)-(7:3))
+    │   │           │   │       ├── tag_name: "div" (location: (7:3)-(7:6))
+    │   │           │   │       ├── tag_closing: ">" (location: (7:6)-(7:7))
+    │   │           │   │       ├── children: []
+    │   │           │   │       └── is_void: false
+    │   │           │   │
+    │   │           │   ├── tag_name: "div" (location: (7:3)-(7:6))
+    │   │           │   ├── body: []
+    │   │           │   ├── close_tag:
+    │   │           │   │   └── @ HTMLCloseTagNode (location: (7:7)-(7:13))
+    │   │           │   │       ├── tag_opening: "</" (location: (7:7)-(7:9))
+    │   │           │   │       ├── tag_name: "div" (location: (7:9)-(7:12))
+    │   │           │   │       ├── children: []
+    │   │           │   │       └── tag_closing: ">" (location: (7:12)-(7:13))
+    │   │           │   │
+    │   │           │   ├── is_void: false
+    │   │           │   └── source: "HTML"
+    │   │           │
+    │   │           └── @ HTMLTextNode (location: (7:13)-(8:0))
+    │   │               └── content: "\n"
+    │   │
+    │   │
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (8:0)-(8:9))
+    │           ├── tag_opening: "<%" (location: (8:0)-(8:2))
+    │           ├── content: " end " (location: (8:2)-(8:7))
+    │           └── tag_closing: "%>" (location: (8:7)-(8:9))
+    │
+    │
+    └── @ HTMLTextNode (location: (8:9)-(9:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/conditional_open_tag_test/test_0023_nested_if_else_with_complete_elements_and_inner_erb_control_flow_(issue_#1239)_ca6e1999413421620d3db44672820407.txt
+++ b/test/snapshots/analyze/conditional_open_tag_test/test_0023_nested_if_else_with_complete_elements_and_inner_erb_control_flow_(issue_#1239)_ca6e1999413421620d3db44672820407.txt
@@ -1,0 +1,156 @@
+---
+source: "Analyze::ConditionalOpenTagTest#test_0023_nested if/else with complete elements and inner erb control flow (issue #1239)"
+input: |2-
+<% if true %>
+  <% if true %>
+    <div>
+      <div></div>
+      <% if true %><% end %>
+    </div>
+  <% else %>
+    <div></div>
+  <% end %>
+<% end %>
+---
+@ DocumentNode (location: (1:0)-(11:0))
+└── children: (2 items)
+    ├── @ ERBIfNode (location: (1:0)-(10:9))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
+    │   ├── content: " if true " (location: (1:2)-(1:11))
+    │   ├── tag_closing: "%>" (location: (1:11)-(1:13))
+    │   ├── then_keyword: ∅
+    │   ├── statements: (3 items)
+    │   │   ├── @ HTMLTextNode (location: (1:13)-(2:2))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ ERBIfNode (location: (2:2)-(9:11))
+    │   │   │   ├── tag_opening: "<%" (location: (2:2)-(2:4))
+    │   │   │   ├── content: " if true " (location: (2:4)-(2:13))
+    │   │   │   ├── tag_closing: "%>" (location: (2:13)-(2:15))
+    │   │   │   ├── then_keyword: ∅
+    │   │   │   ├── statements: (3 items)
+    │   │   │   │   ├── @ HTMLTextNode (location: (2:15)-(3:4))
+    │   │   │   │   │   └── content: "\n    "
+    │   │   │   │   │
+    │   │   │   │   ├── @ HTMLElementNode (location: (3:4)-(6:10))
+    │   │   │   │   │   ├── open_tag:
+    │   │   │   │   │   │   └── @ HTMLOpenTagNode (location: (3:4)-(3:9))
+    │   │   │   │   │   │       ├── tag_opening: "<" (location: (3:4)-(3:5))
+    │   │   │   │   │   │       ├── tag_name: "div" (location: (3:5)-(3:8))
+    │   │   │   │   │   │       ├── tag_closing: ">" (location: (3:8)-(3:9))
+    │   │   │   │   │   │       ├── children: []
+    │   │   │   │   │   │       └── is_void: false
+    │   │   │   │   │   │
+    │   │   │   │   │   ├── tag_name: "div" (location: (3:5)-(3:8))
+    │   │   │   │   │   ├── body: (5 items)
+    │   │   │   │   │   │   ├── @ HTMLTextNode (location: (3:9)-(4:6))
+    │   │   │   │   │   │   │   └── content: "\n      "
+    │   │   │   │   │   │   │
+    │   │   │   │   │   │   ├── @ HTMLElementNode (location: (4:6)-(4:17))
+    │   │   │   │   │   │   │   ├── open_tag:
+    │   │   │   │   │   │   │   │   └── @ HTMLOpenTagNode (location: (4:6)-(4:11))
+    │   │   │   │   │   │   │   │       ├── tag_opening: "<" (location: (4:6)-(4:7))
+    │   │   │   │   │   │   │   │       ├── tag_name: "div" (location: (4:7)-(4:10))
+    │   │   │   │   │   │   │   │       ├── tag_closing: ">" (location: (4:10)-(4:11))
+    │   │   │   │   │   │   │   │       ├── children: []
+    │   │   │   │   │   │   │   │       └── is_void: false
+    │   │   │   │   │   │   │   │
+    │   │   │   │   │   │   │   ├── tag_name: "div" (location: (4:7)-(4:10))
+    │   │   │   │   │   │   │   ├── body: []
+    │   │   │   │   │   │   │   ├── close_tag:
+    │   │   │   │   │   │   │   │   └── @ HTMLCloseTagNode (location: (4:11)-(4:17))
+    │   │   │   │   │   │   │   │       ├── tag_opening: "</" (location: (4:11)-(4:13))
+    │   │   │   │   │   │   │   │       ├── tag_name: "div" (location: (4:13)-(4:16))
+    │   │   │   │   │   │   │   │       ├── children: []
+    │   │   │   │   │   │   │   │       └── tag_closing: ">" (location: (4:16)-(4:17))
+    │   │   │   │   │   │   │   │
+    │   │   │   │   │   │   │   ├── is_void: false
+    │   │   │   │   │   │   │   └── source: "HTML"
+    │   │   │   │   │   │   │
+    │   │   │   │   │   │   ├── @ HTMLTextNode (location: (4:17)-(5:6))
+    │   │   │   │   │   │   │   └── content: "\n      "
+    │   │   │   │   │   │   │
+    │   │   │   │   │   │   ├── @ ERBIfNode (location: (5:6)-(5:28))
+    │   │   │   │   │   │   │   ├── tag_opening: "<%" (location: (5:6)-(5:8))
+    │   │   │   │   │   │   │   ├── content: " if true " (location: (5:8)-(5:17))
+    │   │   │   │   │   │   │   ├── tag_closing: "%>" (location: (5:17)-(5:19))
+    │   │   │   │   │   │   │   ├── then_keyword: ∅
+    │   │   │   │   │   │   │   ├── statements: []
+    │   │   │   │   │   │   │   ├── subsequent: ∅
+    │   │   │   │   │   │   │   └── end_node:
+    │   │   │   │   │   │   │       └── @ ERBEndNode (location: (5:19)-(5:28))
+    │   │   │   │   │   │   │           ├── tag_opening: "<%" (location: (5:19)-(5:21))
+    │   │   │   │   │   │   │           ├── content: " end " (location: (5:21)-(5:26))
+    │   │   │   │   │   │   │           └── tag_closing: "%>" (location: (5:26)-(5:28))
+    │   │   │   │   │   │   │
+    │   │   │   │   │   │   │
+    │   │   │   │   │   │   └── @ HTMLTextNode (location: (5:28)-(6:4))
+    │   │   │   │   │   │       └── content: "\n    "
+    │   │   │   │   │   │
+    │   │   │   │   │   ├── close_tag:
+    │   │   │   │   │   │   └── @ HTMLCloseTagNode (location: (6:4)-(6:10))
+    │   │   │   │   │   │       ├── tag_opening: "</" (location: (6:4)-(6:6))
+    │   │   │   │   │   │       ├── tag_name: "div" (location: (6:6)-(6:9))
+    │   │   │   │   │   │       ├── children: []
+    │   │   │   │   │   │       └── tag_closing: ">" (location: (6:9)-(6:10))
+    │   │   │   │   │   │
+    │   │   │   │   │   ├── is_void: false
+    │   │   │   │   │   └── source: "HTML"
+    │   │   │   │   │
+    │   │   │   │   └── @ HTMLTextNode (location: (6:10)-(7:2))
+    │   │   │   │       └── content: "\n  "
+    │   │   │   │
+    │   │   │   ├── subsequent:
+    │   │   │   │   └── @ ERBElseNode (location: (7:2)-(9:2))
+    │   │   │   │       ├── tag_opening: "<%" (location: (7:2)-(7:4))
+    │   │   │   │       ├── content: " else " (location: (7:4)-(7:10))
+    │   │   │   │       ├── tag_closing: "%>" (location: (7:10)-(7:12))
+    │   │   │   │       └── statements: (3 items)
+    │   │   │   │           ├── @ HTMLTextNode (location: (7:12)-(8:4))
+    │   │   │   │           │   └── content: "\n    "
+    │   │   │   │           │
+    │   │   │   │           ├── @ HTMLElementNode (location: (8:4)-(8:15))
+    │   │   │   │           │   ├── open_tag:
+    │   │   │   │           │   │   └── @ HTMLOpenTagNode (location: (8:4)-(8:9))
+    │   │   │   │           │   │       ├── tag_opening: "<" (location: (8:4)-(8:5))
+    │   │   │   │           │   │       ├── tag_name: "div" (location: (8:5)-(8:8))
+    │   │   │   │           │   │       ├── tag_closing: ">" (location: (8:8)-(8:9))
+    │   │   │   │           │   │       ├── children: []
+    │   │   │   │           │   │       └── is_void: false
+    │   │   │   │           │   │
+    │   │   │   │           │   ├── tag_name: "div" (location: (8:5)-(8:8))
+    │   │   │   │           │   ├── body: []
+    │   │   │   │           │   ├── close_tag:
+    │   │   │   │           │   │   └── @ HTMLCloseTagNode (location: (8:9)-(8:15))
+    │   │   │   │           │   │       ├── tag_opening: "</" (location: (8:9)-(8:11))
+    │   │   │   │           │   │       ├── tag_name: "div" (location: (8:11)-(8:14))
+    │   │   │   │           │   │       ├── children: []
+    │   │   │   │           │   │       └── tag_closing: ">" (location: (8:14)-(8:15))
+    │   │   │   │           │   │
+    │   │   │   │           │   ├── is_void: false
+    │   │   │   │           │   └── source: "HTML"
+    │   │   │   │           │
+    │   │   │   │           └── @ HTMLTextNode (location: (8:15)-(9:2))
+    │   │   │   │               └── content: "\n  "
+    │   │   │   │
+    │   │   │   │
+    │   │   │   └── end_node:
+    │   │   │       └── @ ERBEndNode (location: (9:2)-(9:11))
+    │   │   │           ├── tag_opening: "<%" (location: (9:2)-(9:4))
+    │   │   │           ├── content: " end " (location: (9:4)-(9:9))
+    │   │   │           └── tag_closing: "%>" (location: (9:9)-(9:11))
+    │   │   │
+    │   │   │
+    │   │   └── @ HTMLTextNode (location: (9:11)-(10:0))
+    │   │       └── content: "\n"
+    │   │
+    │   ├── subsequent: ∅
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (10:0)-(10:9))
+    │           ├── tag_opening: "<%" (location: (10:0)-(10:2))
+    │           ├── content: " end " (location: (10:2)-(10:7))
+    │           └── tag_closing: "%>" (location: (10:7)-(10:9))
+    │
+    │
+    └── @ HTMLTextNode (location: (10:9)-(11:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/conditional_open_tag_test/test_0024_complete_elements_with_erb_while_inside_if_else_branches_87fd82c369839dfadc71637a3dd1c55b.txt
+++ b/test/snapshots/analyze/conditional_open_tag_test/test_0024_complete_elements_with_erb_while_inside_if_else_branches_87fd82c369839dfadc71637a3dd1c55b.txt
@@ -1,0 +1,168 @@
+---
+source: "Analyze::ConditionalOpenTagTest#test_0024_complete elements with erb while inside if/else branches"
+input: |2-
+<% if condition %>
+  <div>
+    <span></span>
+    <% while x > 0 %>
+      <p><%= x %></p>
+    <% end %>
+  </div>
+<% else %>
+  <div></div>
+<% end %>
+---
+@ DocumentNode (location: (1:0)-(11:0))
+└── children: (2 items)
+    ├── @ ERBIfNode (location: (1:0)-(10:9))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
+    │   ├── content: " if condition " (location: (1:2)-(1:16))
+    │   ├── tag_closing: "%>" (location: (1:16)-(1:18))
+    │   ├── then_keyword: ∅
+    │   ├── statements: (3 items)
+    │   │   ├── @ HTMLTextNode (location: (1:18)-(2:2))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ HTMLElementNode (location: (2:2)-(7:8))
+    │   │   │   ├── open_tag:
+    │   │   │   │   └── @ HTMLOpenTagNode (location: (2:2)-(2:7))
+    │   │   │   │       ├── tag_opening: "<" (location: (2:2)-(2:3))
+    │   │   │   │       ├── tag_name: "div" (location: (2:3)-(2:6))
+    │   │   │   │       ├── tag_closing: ">" (location: (2:6)-(2:7))
+    │   │   │   │       ├── children: []
+    │   │   │   │       └── is_void: false
+    │   │   │   │
+    │   │   │   ├── tag_name: "div" (location: (2:3)-(2:6))
+    │   │   │   ├── body: (5 items)
+    │   │   │   │   ├── @ HTMLTextNode (location: (2:7)-(3:4))
+    │   │   │   │   │   └── content: "\n    "
+    │   │   │   │   │
+    │   │   │   │   ├── @ HTMLElementNode (location: (3:4)-(3:17))
+    │   │   │   │   │   ├── open_tag:
+    │   │   │   │   │   │   └── @ HTMLOpenTagNode (location: (3:4)-(3:10))
+    │   │   │   │   │   │       ├── tag_opening: "<" (location: (3:4)-(3:5))
+    │   │   │   │   │   │       ├── tag_name: "span" (location: (3:5)-(3:9))
+    │   │   │   │   │   │       ├── tag_closing: ">" (location: (3:9)-(3:10))
+    │   │   │   │   │   │       ├── children: []
+    │   │   │   │   │   │       └── is_void: false
+    │   │   │   │   │   │
+    │   │   │   │   │   ├── tag_name: "span" (location: (3:5)-(3:9))
+    │   │   │   │   │   ├── body: []
+    │   │   │   │   │   ├── close_tag:
+    │   │   │   │   │   │   └── @ HTMLCloseTagNode (location: (3:10)-(3:17))
+    │   │   │   │   │   │       ├── tag_opening: "</" (location: (3:10)-(3:12))
+    │   │   │   │   │   │       ├── tag_name: "span" (location: (3:12)-(3:16))
+    │   │   │   │   │   │       ├── children: []
+    │   │   │   │   │   │       └── tag_closing: ">" (location: (3:16)-(3:17))
+    │   │   │   │   │   │
+    │   │   │   │   │   ├── is_void: false
+    │   │   │   │   │   └── source: "HTML"
+    │   │   │   │   │
+    │   │   │   │   ├── @ HTMLTextNode (location: (3:17)-(4:4))
+    │   │   │   │   │   └── content: "\n    "
+    │   │   │   │   │
+    │   │   │   │   ├── @ ERBWhileNode (location: (4:4)-(6:13))
+    │   │   │   │   │   ├── tag_opening: "<%" (location: (4:4)-(4:6))
+    │   │   │   │   │   ├── content: " while x > 0 " (location: (4:6)-(4:19))
+    │   │   │   │   │   ├── tag_closing: "%>" (location: (4:19)-(4:21))
+    │   │   │   │   │   ├── statements: (3 items)
+    │   │   │   │   │   │   ├── @ HTMLTextNode (location: (4:21)-(5:6))
+    │   │   │   │   │   │   │   └── content: "\n      "
+    │   │   │   │   │   │   │
+    │   │   │   │   │   │   ├── @ HTMLElementNode (location: (5:6)-(5:21))
+    │   │   │   │   │   │   │   ├── open_tag:
+    │   │   │   │   │   │   │   │   └── @ HTMLOpenTagNode (location: (5:6)-(5:9))
+    │   │   │   │   │   │   │   │       ├── tag_opening: "<" (location: (5:6)-(5:7))
+    │   │   │   │   │   │   │   │       ├── tag_name: "p" (location: (5:7)-(5:8))
+    │   │   │   │   │   │   │   │       ├── tag_closing: ">" (location: (5:8)-(5:9))
+    │   │   │   │   │   │   │   │       ├── children: []
+    │   │   │   │   │   │   │   │       └── is_void: false
+    │   │   │   │   │   │   │   │
+    │   │   │   │   │   │   │   ├── tag_name: "p" (location: (5:7)-(5:8))
+    │   │   │   │   │   │   │   ├── body: (1 item)
+    │   │   │   │   │   │   │   │   └── @ ERBContentNode (location: (5:9)-(5:17))
+    │   │   │   │   │   │   │   │       ├── tag_opening: "<%=" (location: (5:9)-(5:12))
+    │   │   │   │   │   │   │   │       ├── content: " x " (location: (5:12)-(5:15))
+    │   │   │   │   │   │   │   │       ├── tag_closing: "%>" (location: (5:15)-(5:17))
+    │   │   │   │   │   │   │   │       ├── parsed: true
+    │   │   │   │   │   │   │   │       └── valid: true
+    │   │   │   │   │   │   │   │
+    │   │   │   │   │   │   │   ├── close_tag:
+    │   │   │   │   │   │   │   │   └── @ HTMLCloseTagNode (location: (5:17)-(5:21))
+    │   │   │   │   │   │   │   │       ├── tag_opening: "</" (location: (5:17)-(5:19))
+    │   │   │   │   │   │   │   │       ├── tag_name: "p" (location: (5:19)-(5:20))
+    │   │   │   │   │   │   │   │       ├── children: []
+    │   │   │   │   │   │   │   │       └── tag_closing: ">" (location: (5:20)-(5:21))
+    │   │   │   │   │   │   │   │
+    │   │   │   │   │   │   │   ├── is_void: false
+    │   │   │   │   │   │   │   └── source: "HTML"
+    │   │   │   │   │   │   │
+    │   │   │   │   │   │   └── @ HTMLTextNode (location: (5:21)-(6:4))
+    │   │   │   │   │   │       └── content: "\n    "
+    │   │   │   │   │   │
+    │   │   │   │   │   └── end_node:
+    │   │   │   │   │       └── @ ERBEndNode (location: (6:4)-(6:13))
+    │   │   │   │   │           ├── tag_opening: "<%" (location: (6:4)-(6:6))
+    │   │   │   │   │           ├── content: " end " (location: (6:6)-(6:11))
+    │   │   │   │   │           └── tag_closing: "%>" (location: (6:11)-(6:13))
+    │   │   │   │   │
+    │   │   │   │   │
+    │   │   │   │   └── @ HTMLTextNode (location: (6:13)-(7:2))
+    │   │   │   │       └── content: "\n  "
+    │   │   │   │
+    │   │   │   ├── close_tag:
+    │   │   │   │   └── @ HTMLCloseTagNode (location: (7:2)-(7:8))
+    │   │   │   │       ├── tag_opening: "</" (location: (7:2)-(7:4))
+    │   │   │   │       ├── tag_name: "div" (location: (7:4)-(7:7))
+    │   │   │   │       ├── children: []
+    │   │   │   │       └── tag_closing: ">" (location: (7:7)-(7:8))
+    │   │   │   │
+    │   │   │   ├── is_void: false
+    │   │   │   └── source: "HTML"
+    │   │   │
+    │   │   └── @ HTMLTextNode (location: (7:8)-(8:0))
+    │   │       └── content: "\n"
+    │   │
+    │   ├── subsequent:
+    │   │   └── @ ERBElseNode (location: (8:0)-(10:0))
+    │   │       ├── tag_opening: "<%" (location: (8:0)-(8:2))
+    │   │       ├── content: " else " (location: (8:2)-(8:8))
+    │   │       ├── tag_closing: "%>" (location: (8:8)-(8:10))
+    │   │       └── statements: (3 items)
+    │   │           ├── @ HTMLTextNode (location: (8:10)-(9:2))
+    │   │           │   └── content: "\n  "
+    │   │           │
+    │   │           ├── @ HTMLElementNode (location: (9:2)-(9:13))
+    │   │           │   ├── open_tag:
+    │   │           │   │   └── @ HTMLOpenTagNode (location: (9:2)-(9:7))
+    │   │           │   │       ├── tag_opening: "<" (location: (9:2)-(9:3))
+    │   │           │   │       ├── tag_name: "div" (location: (9:3)-(9:6))
+    │   │           │   │       ├── tag_closing: ">" (location: (9:6)-(9:7))
+    │   │           │   │       ├── children: []
+    │   │           │   │       └── is_void: false
+    │   │           │   │
+    │   │           │   ├── tag_name: "div" (location: (9:3)-(9:6))
+    │   │           │   ├── body: []
+    │   │           │   ├── close_tag:
+    │   │           │   │   └── @ HTMLCloseTagNode (location: (9:7)-(9:13))
+    │   │           │   │       ├── tag_opening: "</" (location: (9:7)-(9:9))
+    │   │           │   │       ├── tag_name: "div" (location: (9:9)-(9:12))
+    │   │           │   │       ├── children: []
+    │   │           │   │       └── tag_closing: ">" (location: (9:12)-(9:13))
+    │   │           │   │
+    │   │           │   ├── is_void: false
+    │   │           │   └── source: "HTML"
+    │   │           │
+    │   │           └── @ HTMLTextNode (location: (9:13)-(10:0))
+    │   │               └── content: "\n"
+    │   │
+    │   │
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (10:0)-(10:9))
+    │           ├── tag_opening: "<%" (location: (10:0)-(10:2))
+    │           ├── content: " end " (location: (10:2)-(10:7))
+    │           └── tag_closing: "%>" (location: (10:7)-(10:9))
+    │
+    │
+    └── @ HTMLTextNode (location: (10:9)-(11:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/conditional_open_tag_test/test_0025_complete_elements_with_erb_each_block_inside_if_else_branches_a37192548ff7379956420bc898a4fe34.txt
+++ b/test/snapshots/analyze/conditional_open_tag_test/test_0025_complete_elements_with_erb_each_block_inside_if_else_branches_a37192548ff7379956420bc898a4fe34.txt
@@ -1,0 +1,143 @@
+---
+source: "Analyze::ConditionalOpenTagTest#test_0025_complete elements with erb each block inside if/else branches"
+input: |2-
+<% if condition %>
+  <div>
+    <% items.each do |item| %>
+      <span><%= item %></span>
+    <% end %>
+  </div>
+<% else %>
+  <div></div>
+<% end %>
+---
+@ DocumentNode (location: (1:0)-(10:0))
+└── children: (2 items)
+    ├── @ ERBIfNode (location: (1:0)-(9:9))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
+    │   ├── content: " if condition " (location: (1:2)-(1:16))
+    │   ├── tag_closing: "%>" (location: (1:16)-(1:18))
+    │   ├── then_keyword: ∅
+    │   ├── statements: (3 items)
+    │   │   ├── @ HTMLTextNode (location: (1:18)-(2:2))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ HTMLElementNode (location: (2:2)-(6:8))
+    │   │   │   ├── open_tag:
+    │   │   │   │   └── @ HTMLOpenTagNode (location: (2:2)-(2:7))
+    │   │   │   │       ├── tag_opening: "<" (location: (2:2)-(2:3))
+    │   │   │   │       ├── tag_name: "div" (location: (2:3)-(2:6))
+    │   │   │   │       ├── tag_closing: ">" (location: (2:6)-(2:7))
+    │   │   │   │       ├── children: []
+    │   │   │   │       └── is_void: false
+    │   │   │   │
+    │   │   │   ├── tag_name: "div" (location: (2:3)-(2:6))
+    │   │   │   ├── body: (3 items)
+    │   │   │   │   ├── @ HTMLTextNode (location: (2:7)-(3:4))
+    │   │   │   │   │   └── content: "\n    "
+    │   │   │   │   │
+    │   │   │   │   ├── @ ERBBlockNode (location: (3:4)-(5:13))
+    │   │   │   │   │   ├── tag_opening: "<%" (location: (3:4)-(3:6))
+    │   │   │   │   │   ├── content: " items.each do |item| " (location: (3:6)-(3:28))
+    │   │   │   │   │   ├── tag_closing: "%>" (location: (3:28)-(3:30))
+    │   │   │   │   │   ├── body: (3 items)
+    │   │   │   │   │   │   ├── @ HTMLTextNode (location: (3:30)-(4:6))
+    │   │   │   │   │   │   │   └── content: "\n      "
+    │   │   │   │   │   │   │
+    │   │   │   │   │   │   ├── @ HTMLElementNode (location: (4:6)-(4:30))
+    │   │   │   │   │   │   │   ├── open_tag:
+    │   │   │   │   │   │   │   │   └── @ HTMLOpenTagNode (location: (4:6)-(4:12))
+    │   │   │   │   │   │   │   │       ├── tag_opening: "<" (location: (4:6)-(4:7))
+    │   │   │   │   │   │   │   │       ├── tag_name: "span" (location: (4:7)-(4:11))
+    │   │   │   │   │   │   │   │       ├── tag_closing: ">" (location: (4:11)-(4:12))
+    │   │   │   │   │   │   │   │       ├── children: []
+    │   │   │   │   │   │   │   │       └── is_void: false
+    │   │   │   │   │   │   │   │
+    │   │   │   │   │   │   │   ├── tag_name: "span" (location: (4:7)-(4:11))
+    │   │   │   │   │   │   │   ├── body: (1 item)
+    │   │   │   │   │   │   │   │   └── @ ERBContentNode (location: (4:12)-(4:23))
+    │   │   │   │   │   │   │   │       ├── tag_opening: "<%=" (location: (4:12)-(4:15))
+    │   │   │   │   │   │   │   │       ├── content: " item " (location: (4:15)-(4:21))
+    │   │   │   │   │   │   │   │       ├── tag_closing: "%>" (location: (4:21)-(4:23))
+    │   │   │   │   │   │   │   │       ├── parsed: true
+    │   │   │   │   │   │   │   │       └── valid: true
+    │   │   │   │   │   │   │   │
+    │   │   │   │   │   │   │   ├── close_tag:
+    │   │   │   │   │   │   │   │   └── @ HTMLCloseTagNode (location: (4:23)-(4:30))
+    │   │   │   │   │   │   │   │       ├── tag_opening: "</" (location: (4:23)-(4:25))
+    │   │   │   │   │   │   │   │       ├── tag_name: "span" (location: (4:25)-(4:29))
+    │   │   │   │   │   │   │   │       ├── children: []
+    │   │   │   │   │   │   │   │       └── tag_closing: ">" (location: (4:29)-(4:30))
+    │   │   │   │   │   │   │   │
+    │   │   │   │   │   │   │   ├── is_void: false
+    │   │   │   │   │   │   │   └── source: "HTML"
+    │   │   │   │   │   │   │
+    │   │   │   │   │   │   └── @ HTMLTextNode (location: (4:30)-(5:4))
+    │   │   │   │   │   │       └── content: "\n    "
+    │   │   │   │   │   │
+    │   │   │   │   │   └── end_node:
+    │   │   │   │   │       └── @ ERBEndNode (location: (5:4)-(5:13))
+    │   │   │   │   │           ├── tag_opening: "<%" (location: (5:4)-(5:6))
+    │   │   │   │   │           ├── content: " end " (location: (5:6)-(5:11))
+    │   │   │   │   │           └── tag_closing: "%>" (location: (5:11)-(5:13))
+    │   │   │   │   │
+    │   │   │   │   │
+    │   │   │   │   └── @ HTMLTextNode (location: (5:13)-(6:2))
+    │   │   │   │       └── content: "\n  "
+    │   │   │   │
+    │   │   │   ├── close_tag:
+    │   │   │   │   └── @ HTMLCloseTagNode (location: (6:2)-(6:8))
+    │   │   │   │       ├── tag_opening: "</" (location: (6:2)-(6:4))
+    │   │   │   │       ├── tag_name: "div" (location: (6:4)-(6:7))
+    │   │   │   │       ├── children: []
+    │   │   │   │       └── tag_closing: ">" (location: (6:7)-(6:8))
+    │   │   │   │
+    │   │   │   ├── is_void: false
+    │   │   │   └── source: "HTML"
+    │   │   │
+    │   │   └── @ HTMLTextNode (location: (6:8)-(7:0))
+    │   │       └── content: "\n"
+    │   │
+    │   ├── subsequent:
+    │   │   └── @ ERBElseNode (location: (7:0)-(9:0))
+    │   │       ├── tag_opening: "<%" (location: (7:0)-(7:2))
+    │   │       ├── content: " else " (location: (7:2)-(7:8))
+    │   │       ├── tag_closing: "%>" (location: (7:8)-(7:10))
+    │   │       └── statements: (3 items)
+    │   │           ├── @ HTMLTextNode (location: (7:10)-(8:2))
+    │   │           │   └── content: "\n  "
+    │   │           │
+    │   │           ├── @ HTMLElementNode (location: (8:2)-(8:13))
+    │   │           │   ├── open_tag:
+    │   │           │   │   └── @ HTMLOpenTagNode (location: (8:2)-(8:7))
+    │   │           │   │       ├── tag_opening: "<" (location: (8:2)-(8:3))
+    │   │           │   │       ├── tag_name: "div" (location: (8:3)-(8:6))
+    │   │           │   │       ├── tag_closing: ">" (location: (8:6)-(8:7))
+    │   │           │   │       ├── children: []
+    │   │           │   │       └── is_void: false
+    │   │           │   │
+    │   │           │   ├── tag_name: "div" (location: (8:3)-(8:6))
+    │   │           │   ├── body: []
+    │   │           │   ├── close_tag:
+    │   │           │   │   └── @ HTMLCloseTagNode (location: (8:7)-(8:13))
+    │   │           │   │       ├── tag_opening: "</" (location: (8:7)-(8:9))
+    │   │           │   │       ├── tag_name: "div" (location: (8:9)-(8:12))
+    │   │           │   │       ├── children: []
+    │   │           │   │       └── tag_closing: ">" (location: (8:12)-(8:13))
+    │   │           │   │
+    │   │           │   ├── is_void: false
+    │   │           │   └── source: "HTML"
+    │   │           │
+    │   │           └── @ HTMLTextNode (location: (8:13)-(9:0))
+    │   │               └── content: "\n"
+    │   │
+    │   │
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (9:0)-(9:9))
+    │           ├── tag_opening: "<%" (location: (9:0)-(9:2))
+    │           ├── content: " end " (location: (9:2)-(9:7))
+    │           └── tag_closing: "%>" (location: (9:7)-(9:9))
+    │
+    │
+    └── @ HTMLTextNode (location: (9:9)-(10:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/conditional_open_tag_test/test_0026_complete_elements_with_erb_unless_inside_if_else_branches_0abe4850497edd8ff7f1bcba027170a6.txt
+++ b/test/snapshots/analyze/conditional_open_tag_test/test_0026_complete_elements_with_erb_unless_inside_if_else_branches_0abe4850497edd8ff7f1bcba027170a6.txt
@@ -1,0 +1,141 @@
+---
+source: "Analyze::ConditionalOpenTagTest#test_0026_complete elements with erb unless inside if/else branches"
+input: |2-
+<% if condition %>
+  <div>
+    <% unless hidden %>
+      <span>visible</span>
+    <% end %>
+  </div>
+<% else %>
+  <div></div>
+<% end %>
+---
+@ DocumentNode (location: (1:0)-(10:0))
+└── children: (2 items)
+    ├── @ ERBIfNode (location: (1:0)-(9:9))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
+    │   ├── content: " if condition " (location: (1:2)-(1:16))
+    │   ├── tag_closing: "%>" (location: (1:16)-(1:18))
+    │   ├── then_keyword: ∅
+    │   ├── statements: (3 items)
+    │   │   ├── @ HTMLTextNode (location: (1:18)-(2:2))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ HTMLElementNode (location: (2:2)-(6:8))
+    │   │   │   ├── open_tag:
+    │   │   │   │   └── @ HTMLOpenTagNode (location: (2:2)-(2:7))
+    │   │   │   │       ├── tag_opening: "<" (location: (2:2)-(2:3))
+    │   │   │   │       ├── tag_name: "div" (location: (2:3)-(2:6))
+    │   │   │   │       ├── tag_closing: ">" (location: (2:6)-(2:7))
+    │   │   │   │       ├── children: []
+    │   │   │   │       └── is_void: false
+    │   │   │   │
+    │   │   │   ├── tag_name: "div" (location: (2:3)-(2:6))
+    │   │   │   ├── body: (3 items)
+    │   │   │   │   ├── @ HTMLTextNode (location: (2:7)-(3:4))
+    │   │   │   │   │   └── content: "\n    "
+    │   │   │   │   │
+    │   │   │   │   ├── @ ERBUnlessNode (location: (3:4)-(5:13))
+    │   │   │   │   │   ├── tag_opening: "<%" (location: (3:4)-(3:6))
+    │   │   │   │   │   ├── content: " unless hidden " (location: (3:6)-(3:21))
+    │   │   │   │   │   ├── tag_closing: "%>" (location: (3:21)-(3:23))
+    │   │   │   │   │   ├── then_keyword: ∅
+    │   │   │   │   │   ├── statements: (3 items)
+    │   │   │   │   │   │   ├── @ HTMLTextNode (location: (3:23)-(4:6))
+    │   │   │   │   │   │   │   └── content: "\n      "
+    │   │   │   │   │   │   │
+    │   │   │   │   │   │   ├── @ HTMLElementNode (location: (4:6)-(4:26))
+    │   │   │   │   │   │   │   ├── open_tag:
+    │   │   │   │   │   │   │   │   └── @ HTMLOpenTagNode (location: (4:6)-(4:12))
+    │   │   │   │   │   │   │   │       ├── tag_opening: "<" (location: (4:6)-(4:7))
+    │   │   │   │   │   │   │   │       ├── tag_name: "span" (location: (4:7)-(4:11))
+    │   │   │   │   │   │   │   │       ├── tag_closing: ">" (location: (4:11)-(4:12))
+    │   │   │   │   │   │   │   │       ├── children: []
+    │   │   │   │   │   │   │   │       └── is_void: false
+    │   │   │   │   │   │   │   │
+    │   │   │   │   │   │   │   ├── tag_name: "span" (location: (4:7)-(4:11))
+    │   │   │   │   │   │   │   ├── body: (1 item)
+    │   │   │   │   │   │   │   │   └── @ HTMLTextNode (location: (4:12)-(4:19))
+    │   │   │   │   │   │   │   │       └── content: "visible"
+    │   │   │   │   │   │   │   │
+    │   │   │   │   │   │   │   ├── close_tag:
+    │   │   │   │   │   │   │   │   └── @ HTMLCloseTagNode (location: (4:19)-(4:26))
+    │   │   │   │   │   │   │   │       ├── tag_opening: "</" (location: (4:19)-(4:21))
+    │   │   │   │   │   │   │   │       ├── tag_name: "span" (location: (4:21)-(4:25))
+    │   │   │   │   │   │   │   │       ├── children: []
+    │   │   │   │   │   │   │   │       └── tag_closing: ">" (location: (4:25)-(4:26))
+    │   │   │   │   │   │   │   │
+    │   │   │   │   │   │   │   ├── is_void: false
+    │   │   │   │   │   │   │   └── source: "HTML"
+    │   │   │   │   │   │   │
+    │   │   │   │   │   │   └── @ HTMLTextNode (location: (4:26)-(5:4))
+    │   │   │   │   │   │       └── content: "\n    "
+    │   │   │   │   │   │
+    │   │   │   │   │   ├── else_clause: ∅
+    │   │   │   │   │   └── end_node:
+    │   │   │   │   │       └── @ ERBEndNode (location: (5:4)-(5:13))
+    │   │   │   │   │           ├── tag_opening: "<%" (location: (5:4)-(5:6))
+    │   │   │   │   │           ├── content: " end " (location: (5:6)-(5:11))
+    │   │   │   │   │           └── tag_closing: "%>" (location: (5:11)-(5:13))
+    │   │   │   │   │
+    │   │   │   │   │
+    │   │   │   │   └── @ HTMLTextNode (location: (5:13)-(6:2))
+    │   │   │   │       └── content: "\n  "
+    │   │   │   │
+    │   │   │   ├── close_tag:
+    │   │   │   │   └── @ HTMLCloseTagNode (location: (6:2)-(6:8))
+    │   │   │   │       ├── tag_opening: "</" (location: (6:2)-(6:4))
+    │   │   │   │       ├── tag_name: "div" (location: (6:4)-(6:7))
+    │   │   │   │       ├── children: []
+    │   │   │   │       └── tag_closing: ">" (location: (6:7)-(6:8))
+    │   │   │   │
+    │   │   │   ├── is_void: false
+    │   │   │   └── source: "HTML"
+    │   │   │
+    │   │   └── @ HTMLTextNode (location: (6:8)-(7:0))
+    │   │       └── content: "\n"
+    │   │
+    │   ├── subsequent:
+    │   │   └── @ ERBElseNode (location: (7:0)-(9:0))
+    │   │       ├── tag_opening: "<%" (location: (7:0)-(7:2))
+    │   │       ├── content: " else " (location: (7:2)-(7:8))
+    │   │       ├── tag_closing: "%>" (location: (7:8)-(7:10))
+    │   │       └── statements: (3 items)
+    │   │           ├── @ HTMLTextNode (location: (7:10)-(8:2))
+    │   │           │   └── content: "\n  "
+    │   │           │
+    │   │           ├── @ HTMLElementNode (location: (8:2)-(8:13))
+    │   │           │   ├── open_tag:
+    │   │           │   │   └── @ HTMLOpenTagNode (location: (8:2)-(8:7))
+    │   │           │   │       ├── tag_opening: "<" (location: (8:2)-(8:3))
+    │   │           │   │       ├── tag_name: "div" (location: (8:3)-(8:6))
+    │   │           │   │       ├── tag_closing: ">" (location: (8:6)-(8:7))
+    │   │           │   │       ├── children: []
+    │   │           │   │       └── is_void: false
+    │   │           │   │
+    │   │           │   ├── tag_name: "div" (location: (8:3)-(8:6))
+    │   │           │   ├── body: []
+    │   │           │   ├── close_tag:
+    │   │           │   │   └── @ HTMLCloseTagNode (location: (8:7)-(8:13))
+    │   │           │   │       ├── tag_opening: "</" (location: (8:7)-(8:9))
+    │   │           │   │       ├── tag_name: "div" (location: (8:9)-(8:12))
+    │   │           │   │       ├── children: []
+    │   │           │   │       └── tag_closing: ">" (location: (8:12)-(8:13))
+    │   │           │   │
+    │   │           │   ├── is_void: false
+    │   │           │   └── source: "HTML"
+    │   │           │
+    │   │           └── @ HTMLTextNode (location: (8:13)-(9:0))
+    │   │               └── content: "\n"
+    │   │
+    │   │
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (9:0)-(9:9))
+    │           ├── tag_opening: "<%" (location: (9:0)-(9:2))
+    │           ├── content: " end " (location: (9:2)-(9:7))
+    │           └── tag_closing: "%>" (location: (9:7)-(9:9))
+    │
+    │
+    └── @ HTMLTextNode (location: (9:9)-(10:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/conditional_open_tag_test/test_0027_complete_elements_with_erb_begin_rescue_inside_if_else_branches_6b736ef8c0fd8abef22d95d6739f6acc.txt
+++ b/test/snapshots/analyze/conditional_open_tag_test/test_0027_complete_elements_with_erb_begin_rescue_inside_if_else_branches_6b736ef8c0fd8abef22d95d6739f6acc.txt
@@ -1,0 +1,185 @@
+---
+source: "Analyze::ConditionalOpenTagTest#test_0027_complete elements with erb begin/rescue inside if/else branches"
+input: |2-
+<% if condition %>
+  <div>
+    <% begin %>
+      <span><%= dangerous_call %></span>
+    <% rescue %>
+      <span>error</span>
+    <% end %>
+  </div>
+<% else %>
+  <div></div>
+<% end %>
+---
+@ DocumentNode (location: (1:0)-(12:0))
+└── children: (2 items)
+    ├── @ ERBIfNode (location: (1:0)-(11:9))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
+    │   ├── content: " if condition " (location: (1:2)-(1:16))
+    │   ├── tag_closing: "%>" (location: (1:16)-(1:18))
+    │   ├── then_keyword: ∅
+    │   ├── statements: (3 items)
+    │   │   ├── @ HTMLTextNode (location: (1:18)-(2:2))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ HTMLElementNode (location: (2:2)-(8:8))
+    │   │   │   ├── open_tag:
+    │   │   │   │   └── @ HTMLOpenTagNode (location: (2:2)-(2:7))
+    │   │   │   │       ├── tag_opening: "<" (location: (2:2)-(2:3))
+    │   │   │   │       ├── tag_name: "div" (location: (2:3)-(2:6))
+    │   │   │   │       ├── tag_closing: ">" (location: (2:6)-(2:7))
+    │   │   │   │       ├── children: []
+    │   │   │   │       └── is_void: false
+    │   │   │   │
+    │   │   │   ├── tag_name: "div" (location: (2:3)-(2:6))
+    │   │   │   ├── body: (3 items)
+    │   │   │   │   ├── @ HTMLTextNode (location: (2:7)-(3:4))
+    │   │   │   │   │   └── content: "\n    "
+    │   │   │   │   │
+    │   │   │   │   ├── @ ERBBeginNode (location: (3:4)-(7:13))
+    │   │   │   │   │   ├── tag_opening: "<%" (location: (3:4)-(3:6))
+    │   │   │   │   │   ├── content: " begin " (location: (3:6)-(3:13))
+    │   │   │   │   │   ├── tag_closing: "%>" (location: (3:13)-(3:15))
+    │   │   │   │   │   ├── statements: (3 items)
+    │   │   │   │   │   │   ├── @ HTMLTextNode (location: (3:15)-(4:6))
+    │   │   │   │   │   │   │   └── content: "\n      "
+    │   │   │   │   │   │   │
+    │   │   │   │   │   │   ├── @ HTMLElementNode (location: (4:6)-(4:40))
+    │   │   │   │   │   │   │   ├── open_tag:
+    │   │   │   │   │   │   │   │   └── @ HTMLOpenTagNode (location: (4:6)-(4:12))
+    │   │   │   │   │   │   │   │       ├── tag_opening: "<" (location: (4:6)-(4:7))
+    │   │   │   │   │   │   │   │       ├── tag_name: "span" (location: (4:7)-(4:11))
+    │   │   │   │   │   │   │   │       ├── tag_closing: ">" (location: (4:11)-(4:12))
+    │   │   │   │   │   │   │   │       ├── children: []
+    │   │   │   │   │   │   │   │       └── is_void: false
+    │   │   │   │   │   │   │   │
+    │   │   │   │   │   │   │   ├── tag_name: "span" (location: (4:7)-(4:11))
+    │   │   │   │   │   │   │   ├── body: (1 item)
+    │   │   │   │   │   │   │   │   └── @ ERBContentNode (location: (4:12)-(4:33))
+    │   │   │   │   │   │   │   │       ├── tag_opening: "<%=" (location: (4:12)-(4:15))
+    │   │   │   │   │   │   │   │       ├── content: " dangerous_call " (location: (4:15)-(4:31))
+    │   │   │   │   │   │   │   │       ├── tag_closing: "%>" (location: (4:31)-(4:33))
+    │   │   │   │   │   │   │   │       ├── parsed: true
+    │   │   │   │   │   │   │   │       └── valid: true
+    │   │   │   │   │   │   │   │
+    │   │   │   │   │   │   │   ├── close_tag:
+    │   │   │   │   │   │   │   │   └── @ HTMLCloseTagNode (location: (4:33)-(4:40))
+    │   │   │   │   │   │   │   │       ├── tag_opening: "</" (location: (4:33)-(4:35))
+    │   │   │   │   │   │   │   │       ├── tag_name: "span" (location: (4:35)-(4:39))
+    │   │   │   │   │   │   │   │       ├── children: []
+    │   │   │   │   │   │   │   │       └── tag_closing: ">" (location: (4:39)-(4:40))
+    │   │   │   │   │   │   │   │
+    │   │   │   │   │   │   │   ├── is_void: false
+    │   │   │   │   │   │   │   └── source: "HTML"
+    │   │   │   │   │   │   │
+    │   │   │   │   │   │   └── @ HTMLTextNode (location: (4:40)-(5:4))
+    │   │   │   │   │   │       └── content: "\n    "
+    │   │   │   │   │   │
+    │   │   │   │   │   ├── rescue_clause:
+    │   │   │   │   │   │   └── @ ERBRescueNode (location: (5:4)-(7:4))
+    │   │   │   │   │   │       ├── tag_opening: "<%" (location: (5:4)-(5:6))
+    │   │   │   │   │   │       ├── content: " rescue " (location: (5:6)-(5:14))
+    │   │   │   │   │   │       ├── tag_closing: "%>" (location: (5:14)-(5:16))
+    │   │   │   │   │   │       ├── statements: (3 items)
+    │   │   │   │   │   │       │   ├── @ HTMLTextNode (location: (5:16)-(6:6))
+    │   │   │   │   │   │       │   │   └── content: "\n      "
+    │   │   │   │   │   │       │   │
+    │   │   │   │   │   │       │   ├── @ HTMLElementNode (location: (6:6)-(6:24))
+    │   │   │   │   │   │       │   │   ├── open_tag:
+    │   │   │   │   │   │       │   │   │   └── @ HTMLOpenTagNode (location: (6:6)-(6:12))
+    │   │   │   │   │   │       │   │   │       ├── tag_opening: "<" (location: (6:6)-(6:7))
+    │   │   │   │   │   │       │   │   │       ├── tag_name: "span" (location: (6:7)-(6:11))
+    │   │   │   │   │   │       │   │   │       ├── tag_closing: ">" (location: (6:11)-(6:12))
+    │   │   │   │   │   │       │   │   │       ├── children: []
+    │   │   │   │   │   │       │   │   │       └── is_void: false
+    │   │   │   │   │   │       │   │   │
+    │   │   │   │   │   │       │   │   ├── tag_name: "span" (location: (6:7)-(6:11))
+    │   │   │   │   │   │       │   │   ├── body: (1 item)
+    │   │   │   │   │   │       │   │   │   └── @ HTMLTextNode (location: (6:12)-(6:17))
+    │   │   │   │   │   │       │   │   │       └── content: "error"
+    │   │   │   │   │   │       │   │   │
+    │   │   │   │   │   │       │   │   ├── close_tag:
+    │   │   │   │   │   │       │   │   │   └── @ HTMLCloseTagNode (location: (6:17)-(6:24))
+    │   │   │   │   │   │       │   │   │       ├── tag_opening: "</" (location: (6:17)-(6:19))
+    │   │   │   │   │   │       │   │   │       ├── tag_name: "span" (location: (6:19)-(6:23))
+    │   │   │   │   │   │       │   │   │       ├── children: []
+    │   │   │   │   │   │       │   │   │       └── tag_closing: ">" (location: (6:23)-(6:24))
+    │   │   │   │   │   │       │   │   │
+    │   │   │   │   │   │       │   │   ├── is_void: false
+    │   │   │   │   │   │       │   │   └── source: "HTML"
+    │   │   │   │   │   │       │   │
+    │   │   │   │   │   │       │   └── @ HTMLTextNode (location: (6:24)-(7:4))
+    │   │   │   │   │   │       │       └── content: "\n    "
+    │   │   │   │   │   │       │
+    │   │   │   │   │   │       └── subsequent: ∅
+    │   │   │   │   │   │
+    │   │   │   │   │   ├── else_clause: ∅
+    │   │   │   │   │   ├── ensure_clause: ∅
+    │   │   │   │   │   └── end_node:
+    │   │   │   │   │       └── @ ERBEndNode (location: (7:4)-(7:13))
+    │   │   │   │   │           ├── tag_opening: "<%" (location: (7:4)-(7:6))
+    │   │   │   │   │           ├── content: " end " (location: (7:6)-(7:11))
+    │   │   │   │   │           └── tag_closing: "%>" (location: (7:11)-(7:13))
+    │   │   │   │   │
+    │   │   │   │   │
+    │   │   │   │   └── @ HTMLTextNode (location: (7:13)-(8:2))
+    │   │   │   │       └── content: "\n  "
+    │   │   │   │
+    │   │   │   ├── close_tag:
+    │   │   │   │   └── @ HTMLCloseTagNode (location: (8:2)-(8:8))
+    │   │   │   │       ├── tag_opening: "</" (location: (8:2)-(8:4))
+    │   │   │   │       ├── tag_name: "div" (location: (8:4)-(8:7))
+    │   │   │   │       ├── children: []
+    │   │   │   │       └── tag_closing: ">" (location: (8:7)-(8:8))
+    │   │   │   │
+    │   │   │   ├── is_void: false
+    │   │   │   └── source: "HTML"
+    │   │   │
+    │   │   └── @ HTMLTextNode (location: (8:8)-(9:0))
+    │   │       └── content: "\n"
+    │   │
+    │   ├── subsequent:
+    │   │   └── @ ERBElseNode (location: (9:0)-(11:0))
+    │   │       ├── tag_opening: "<%" (location: (9:0)-(9:2))
+    │   │       ├── content: " else " (location: (9:2)-(9:8))
+    │   │       ├── tag_closing: "%>" (location: (9:8)-(9:10))
+    │   │       └── statements: (3 items)
+    │   │           ├── @ HTMLTextNode (location: (9:10)-(10:2))
+    │   │           │   └── content: "\n  "
+    │   │           │
+    │   │           ├── @ HTMLElementNode (location: (10:2)-(10:13))
+    │   │           │   ├── open_tag:
+    │   │           │   │   └── @ HTMLOpenTagNode (location: (10:2)-(10:7))
+    │   │           │   │       ├── tag_opening: "<" (location: (10:2)-(10:3))
+    │   │           │   │       ├── tag_name: "div" (location: (10:3)-(10:6))
+    │   │           │   │       ├── tag_closing: ">" (location: (10:6)-(10:7))
+    │   │           │   │       ├── children: []
+    │   │           │   │       └── is_void: false
+    │   │           │   │
+    │   │           │   ├── tag_name: "div" (location: (10:3)-(10:6))
+    │   │           │   ├── body: []
+    │   │           │   ├── close_tag:
+    │   │           │   │   └── @ HTMLCloseTagNode (location: (10:7)-(10:13))
+    │   │           │   │       ├── tag_opening: "</" (location: (10:7)-(10:9))
+    │   │           │   │       ├── tag_name: "div" (location: (10:9)-(10:12))
+    │   │           │   │       ├── children: []
+    │   │           │   │       └── tag_closing: ">" (location: (10:12)-(10:13))
+    │   │           │   │
+    │   │           │   ├── is_void: false
+    │   │           │   └── source: "HTML"
+    │   │           │
+    │   │           └── @ HTMLTextNode (location: (10:13)-(11:0))
+    │   │               └── content: "\n"
+    │   │
+    │   │
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (11:0)-(11:9))
+    │           ├── tag_opening: "<%" (location: (11:0)-(11:2))
+    │           ├── content: " end " (location: (11:2)-(11:7))
+    │           └── tag_closing: "%>" (location: (11:7)-(11:9))
+    │
+    │
+    └── @ HTMLTextNode (location: (11:9)-(12:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/conditional_open_tag_test/test_0028_complete_elements_with_erb_case_when_inside_if_else_branches_ce105fee5e83f6cc883189c02b181e43.txt
+++ b/test/snapshots/analyze/conditional_open_tag_test/test_0028_complete_elements_with_erb_case_when_inside_if_else_branches_ce105fee5e83f6cc883189c02b181e43.txt
@@ -1,0 +1,191 @@
+---
+source: "Analyze::ConditionalOpenTagTest#test_0028_complete elements with erb case/when inside if/else branches"
+input: |2-
+<% if condition %>
+  <div>
+    <% case status %>
+    <% when :active %>
+      <span>active</span>
+    <% when :inactive %>
+      <span>inactive</span>
+    <% end %>
+  </div>
+<% else %>
+  <div></div>
+<% end %>
+---
+@ DocumentNode (location: (1:0)-(13:0))
+└── children: (2 items)
+    ├── @ ERBIfNode (location: (1:0)-(12:9))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
+    │   ├── content: " if condition " (location: (1:2)-(1:16))
+    │   ├── tag_closing: "%>" (location: (1:16)-(1:18))
+    │   ├── then_keyword: ∅
+    │   ├── statements: (3 items)
+    │   │   ├── @ HTMLTextNode (location: (1:18)-(2:2))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ HTMLElementNode (location: (2:2)-(9:8))
+    │   │   │   ├── open_tag:
+    │   │   │   │   └── @ HTMLOpenTagNode (location: (2:2)-(2:7))
+    │   │   │   │       ├── tag_opening: "<" (location: (2:2)-(2:3))
+    │   │   │   │       ├── tag_name: "div" (location: (2:3)-(2:6))
+    │   │   │   │       ├── tag_closing: ">" (location: (2:6)-(2:7))
+    │   │   │   │       ├── children: []
+    │   │   │   │       └── is_void: false
+    │   │   │   │
+    │   │   │   ├── tag_name: "div" (location: (2:3)-(2:6))
+    │   │   │   ├── body: (3 items)
+    │   │   │   │   ├── @ HTMLTextNode (location: (2:7)-(3:4))
+    │   │   │   │   │   └── content: "\n    "
+    │   │   │   │   │
+    │   │   │   │   ├── @ ERBCaseNode (location: (3:4)-(8:13))
+    │   │   │   │   │   ├── tag_opening: "<%" (location: (3:4)-(3:6))
+    │   │   │   │   │   ├── content: " case status " (location: (3:6)-(3:19))
+    │   │   │   │   │   ├── tag_closing: "%>" (location: (3:19)-(3:21))
+    │   │   │   │   │   ├── children: (1 item)
+    │   │   │   │   │   │   └── @ HTMLTextNode (location: (3:21)-(4:4))
+    │   │   │   │   │   │       └── content: "\n    "
+    │   │   │   │   │   │
+    │   │   │   │   │   ├── conditions: (2 items)
+    │   │   │   │   │   │   ├── @ ERBWhenNode (location: (4:4)-(4:22))
+    │   │   │   │   │   │   │   ├── tag_opening: "<%" (location: (4:4)-(4:6))
+    │   │   │   │   │   │   │   ├── content: " when :active " (location: (4:6)-(4:20))
+    │   │   │   │   │   │   │   ├── tag_closing: "%>" (location: (4:20)-(4:22))
+    │   │   │   │   │   │   │   ├── then_keyword: ∅
+    │   │   │   │   │   │   │   └── statements: (3 items)
+    │   │   │   │   │   │   │       ├── @ HTMLTextNode (location: (4:22)-(5:6))
+    │   │   │   │   │   │   │       │   └── content: "\n      "
+    │   │   │   │   │   │   │       │
+    │   │   │   │   │   │   │       ├── @ HTMLElementNode (location: (5:6)-(5:25))
+    │   │   │   │   │   │   │       │   ├── open_tag:
+    │   │   │   │   │   │   │       │   │   └── @ HTMLOpenTagNode (location: (5:6)-(5:12))
+    │   │   │   │   │   │   │       │   │       ├── tag_opening: "<" (location: (5:6)-(5:7))
+    │   │   │   │   │   │   │       │   │       ├── tag_name: "span" (location: (5:7)-(5:11))
+    │   │   │   │   │   │   │       │   │       ├── tag_closing: ">" (location: (5:11)-(5:12))
+    │   │   │   │   │   │   │       │   │       ├── children: []
+    │   │   │   │   │   │   │       │   │       └── is_void: false
+    │   │   │   │   │   │   │       │   │
+    │   │   │   │   │   │   │       │   ├── tag_name: "span" (location: (5:7)-(5:11))
+    │   │   │   │   │   │   │       │   ├── body: (1 item)
+    │   │   │   │   │   │   │       │   │   └── @ HTMLTextNode (location: (5:12)-(5:18))
+    │   │   │   │   │   │   │       │   │       └── content: "active"
+    │   │   │   │   │   │   │       │   │
+    │   │   │   │   │   │   │       │   ├── close_tag:
+    │   │   │   │   │   │   │       │   │   └── @ HTMLCloseTagNode (location: (5:18)-(5:25))
+    │   │   │   │   │   │   │       │   │       ├── tag_opening: "</" (location: (5:18)-(5:20))
+    │   │   │   │   │   │   │       │   │       ├── tag_name: "span" (location: (5:20)-(5:24))
+    │   │   │   │   │   │   │       │   │       ├── children: []
+    │   │   │   │   │   │   │       │   │       └── tag_closing: ">" (location: (5:24)-(5:25))
+    │   │   │   │   │   │   │       │   │
+    │   │   │   │   │   │   │       │   ├── is_void: false
+    │   │   │   │   │   │   │       │   └── source: "HTML"
+    │   │   │   │   │   │   │       │
+    │   │   │   │   │   │   │       └── @ HTMLTextNode (location: (5:25)-(6:4))
+    │   │   │   │   │   │   │           └── content: "\n    "
+    │   │   │   │   │   │   │
+    │   │   │   │   │   │   │
+    │   │   │   │   │   │   └── @ ERBWhenNode (location: (6:4)-(6:24))
+    │   │   │   │   │   │       ├── tag_opening: "<%" (location: (6:4)-(6:6))
+    │   │   │   │   │   │       ├── content: " when :inactive " (location: (6:6)-(6:22))
+    │   │   │   │   │   │       ├── tag_closing: "%>" (location: (6:22)-(6:24))
+    │   │   │   │   │   │       ├── then_keyword: ∅
+    │   │   │   │   │   │       └── statements: (3 items)
+    │   │   │   │   │   │           ├── @ HTMLTextNode (location: (6:24)-(7:6))
+    │   │   │   │   │   │           │   └── content: "\n      "
+    │   │   │   │   │   │           │
+    │   │   │   │   │   │           ├── @ HTMLElementNode (location: (7:6)-(7:27))
+    │   │   │   │   │   │           │   ├── open_tag:
+    │   │   │   │   │   │           │   │   └── @ HTMLOpenTagNode (location: (7:6)-(7:12))
+    │   │   │   │   │   │           │   │       ├── tag_opening: "<" (location: (7:6)-(7:7))
+    │   │   │   │   │   │           │   │       ├── tag_name: "span" (location: (7:7)-(7:11))
+    │   │   │   │   │   │           │   │       ├── tag_closing: ">" (location: (7:11)-(7:12))
+    │   │   │   │   │   │           │   │       ├── children: []
+    │   │   │   │   │   │           │   │       └── is_void: false
+    │   │   │   │   │   │           │   │
+    │   │   │   │   │   │           │   ├── tag_name: "span" (location: (7:7)-(7:11))
+    │   │   │   │   │   │           │   ├── body: (1 item)
+    │   │   │   │   │   │           │   │   └── @ HTMLTextNode (location: (7:12)-(7:20))
+    │   │   │   │   │   │           │   │       └── content: "inactive"
+    │   │   │   │   │   │           │   │
+    │   │   │   │   │   │           │   ├── close_tag:
+    │   │   │   │   │   │           │   │   └── @ HTMLCloseTagNode (location: (7:20)-(7:27))
+    │   │   │   │   │   │           │   │       ├── tag_opening: "</" (location: (7:20)-(7:22))
+    │   │   │   │   │   │           │   │       ├── tag_name: "span" (location: (7:22)-(7:26))
+    │   │   │   │   │   │           │   │       ├── children: []
+    │   │   │   │   │   │           │   │       └── tag_closing: ">" (location: (7:26)-(7:27))
+    │   │   │   │   │   │           │   │
+    │   │   │   │   │   │           │   ├── is_void: false
+    │   │   │   │   │   │           │   └── source: "HTML"
+    │   │   │   │   │   │           │
+    │   │   │   │   │   │           └── @ HTMLTextNode (location: (7:27)-(8:4))
+    │   │   │   │   │   │               └── content: "\n    "
+    │   │   │   │   │   │
+    │   │   │   │   │   │
+    │   │   │   │   │   ├── else_clause: ∅
+    │   │   │   │   │   └── end_node:
+    │   │   │   │   │       └── @ ERBEndNode (location: (8:4)-(8:13))
+    │   │   │   │   │           ├── tag_opening: "<%" (location: (8:4)-(8:6))
+    │   │   │   │   │           ├── content: " end " (location: (8:6)-(8:11))
+    │   │   │   │   │           └── tag_closing: "%>" (location: (8:11)-(8:13))
+    │   │   │   │   │
+    │   │   │   │   │
+    │   │   │   │   └── @ HTMLTextNode (location: (8:13)-(9:2))
+    │   │   │   │       └── content: "\n  "
+    │   │   │   │
+    │   │   │   ├── close_tag:
+    │   │   │   │   └── @ HTMLCloseTagNode (location: (9:2)-(9:8))
+    │   │   │   │       ├── tag_opening: "</" (location: (9:2)-(9:4))
+    │   │   │   │       ├── tag_name: "div" (location: (9:4)-(9:7))
+    │   │   │   │       ├── children: []
+    │   │   │   │       └── tag_closing: ">" (location: (9:7)-(9:8))
+    │   │   │   │
+    │   │   │   ├── is_void: false
+    │   │   │   └── source: "HTML"
+    │   │   │
+    │   │   └── @ HTMLTextNode (location: (9:8)-(10:0))
+    │   │       └── content: "\n"
+    │   │
+    │   ├── subsequent:
+    │   │   └── @ ERBElseNode (location: (10:0)-(12:0))
+    │   │       ├── tag_opening: "<%" (location: (10:0)-(10:2))
+    │   │       ├── content: " else " (location: (10:2)-(10:8))
+    │   │       ├── tag_closing: "%>" (location: (10:8)-(10:10))
+    │   │       └── statements: (3 items)
+    │   │           ├── @ HTMLTextNode (location: (10:10)-(11:2))
+    │   │           │   └── content: "\n  "
+    │   │           │
+    │   │           ├── @ HTMLElementNode (location: (11:2)-(11:13))
+    │   │           │   ├── open_tag:
+    │   │           │   │   └── @ HTMLOpenTagNode (location: (11:2)-(11:7))
+    │   │           │   │       ├── tag_opening: "<" (location: (11:2)-(11:3))
+    │   │           │   │       ├── tag_name: "div" (location: (11:3)-(11:6))
+    │   │           │   │       ├── tag_closing: ">" (location: (11:6)-(11:7))
+    │   │           │   │       ├── children: []
+    │   │           │   │       └── is_void: false
+    │   │           │   │
+    │   │           │   ├── tag_name: "div" (location: (11:3)-(11:6))
+    │   │           │   ├── body: []
+    │   │           │   ├── close_tag:
+    │   │           │   │   └── @ HTMLCloseTagNode (location: (11:7)-(11:13))
+    │   │           │   │       ├── tag_opening: "</" (location: (11:7)-(11:9))
+    │   │           │   │       ├── tag_name: "div" (location: (11:9)-(11:12))
+    │   │           │   │       ├── children: []
+    │   │           │   │       └── tag_closing: ">" (location: (11:12)-(11:13))
+    │   │           │   │
+    │   │           │   ├── is_void: false
+    │   │           │   └── source: "HTML"
+    │   │           │
+    │   │           └── @ HTMLTextNode (location: (11:13)-(12:0))
+    │   │               └── content: "\n"
+    │   │
+    │   │
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (12:0)-(12:9))
+    │           ├── tag_opening: "<%" (location: (12:0)-(12:2))
+    │           ├── content: " end " (location: (12:2)-(12:7))
+    │           └── tag_closing: "%>" (location: (12:7)-(12:9))
+    │
+    │
+    └── @ HTMLTextNode (location: (12:9)-(13:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/conditional_open_tag_test/test_0029_erb_if_end_before_complete_element_in_branch_fcad290defd352b000e8e65a001eae20.txt
+++ b/test/snapshots/analyze/conditional_open_tag_test/test_0029_erb_if_end_before_complete_element_in_branch_fcad290defd352b000e8e65a001eae20.txt
@@ -1,0 +1,105 @@
+---
+source: "Analyze::ConditionalOpenTagTest#test_0029_erb if/end before complete element in branch"
+input: |2-
+<% if condition %>
+  <% if setup %><% end %>
+  <div></div>
+<% else %>
+  <div></div>
+<% end %>
+---
+@ DocumentNode (location: (1:0)-(7:0))
+└── children: (2 items)
+    ├── @ ERBIfNode (location: (1:0)-(6:9))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
+    │   ├── content: " if condition " (location: (1:2)-(1:16))
+    │   ├── tag_closing: "%>" (location: (1:16)-(1:18))
+    │   ├── then_keyword: ∅
+    │   ├── statements: (5 items)
+    │   │   ├── @ HTMLTextNode (location: (1:18)-(2:2))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ ERBIfNode (location: (2:2)-(2:25))
+    │   │   │   ├── tag_opening: "<%" (location: (2:2)-(2:4))
+    │   │   │   ├── content: " if setup " (location: (2:4)-(2:14))
+    │   │   │   ├── tag_closing: "%>" (location: (2:14)-(2:16))
+    │   │   │   ├── then_keyword: ∅
+    │   │   │   ├── statements: []
+    │   │   │   ├── subsequent: ∅
+    │   │   │   └── end_node:
+    │   │   │       └── @ ERBEndNode (location: (2:16)-(2:25))
+    │   │   │           ├── tag_opening: "<%" (location: (2:16)-(2:18))
+    │   │   │           ├── content: " end " (location: (2:18)-(2:23))
+    │   │   │           └── tag_closing: "%>" (location: (2:23)-(2:25))
+    │   │   │
+    │   │   │
+    │   │   ├── @ HTMLTextNode (location: (2:25)-(3:2))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ HTMLElementNode (location: (3:2)-(3:13))
+    │   │   │   ├── open_tag:
+    │   │   │   │   └── @ HTMLOpenTagNode (location: (3:2)-(3:7))
+    │   │   │   │       ├── tag_opening: "<" (location: (3:2)-(3:3))
+    │   │   │   │       ├── tag_name: "div" (location: (3:3)-(3:6))
+    │   │   │   │       ├── tag_closing: ">" (location: (3:6)-(3:7))
+    │   │   │   │       ├── children: []
+    │   │   │   │       └── is_void: false
+    │   │   │   │
+    │   │   │   ├── tag_name: "div" (location: (3:3)-(3:6))
+    │   │   │   ├── body: []
+    │   │   │   ├── close_tag:
+    │   │   │   │   └── @ HTMLCloseTagNode (location: (3:7)-(3:13))
+    │   │   │   │       ├── tag_opening: "</" (location: (3:7)-(3:9))
+    │   │   │   │       ├── tag_name: "div" (location: (3:9)-(3:12))
+    │   │   │   │       ├── children: []
+    │   │   │   │       └── tag_closing: ">" (location: (3:12)-(3:13))
+    │   │   │   │
+    │   │   │   ├── is_void: false
+    │   │   │   └── source: "HTML"
+    │   │   │
+    │   │   └── @ HTMLTextNode (location: (3:13)-(4:0))
+    │   │       └── content: "\n"
+    │   │
+    │   ├── subsequent:
+    │   │   └── @ ERBElseNode (location: (4:0)-(6:0))
+    │   │       ├── tag_opening: "<%" (location: (4:0)-(4:2))
+    │   │       ├── content: " else " (location: (4:2)-(4:8))
+    │   │       ├── tag_closing: "%>" (location: (4:8)-(4:10))
+    │   │       └── statements: (3 items)
+    │   │           ├── @ HTMLTextNode (location: (4:10)-(5:2))
+    │   │           │   └── content: "\n  "
+    │   │           │
+    │   │           ├── @ HTMLElementNode (location: (5:2)-(5:13))
+    │   │           │   ├── open_tag:
+    │   │           │   │   └── @ HTMLOpenTagNode (location: (5:2)-(5:7))
+    │   │           │   │       ├── tag_opening: "<" (location: (5:2)-(5:3))
+    │   │           │   │       ├── tag_name: "div" (location: (5:3)-(5:6))
+    │   │           │   │       ├── tag_closing: ">" (location: (5:6)-(5:7))
+    │   │           │   │       ├── children: []
+    │   │           │   │       └── is_void: false
+    │   │           │   │
+    │   │           │   ├── tag_name: "div" (location: (5:3)-(5:6))
+    │   │           │   ├── body: []
+    │   │           │   ├── close_tag:
+    │   │           │   │   └── @ HTMLCloseTagNode (location: (5:7)-(5:13))
+    │   │           │   │       ├── tag_opening: "</" (location: (5:7)-(5:9))
+    │   │           │   │       ├── tag_name: "div" (location: (5:9)-(5:12))
+    │   │           │   │       ├── children: []
+    │   │           │   │       └── tag_closing: ">" (location: (5:12)-(5:13))
+    │   │           │   │
+    │   │           │   ├── is_void: false
+    │   │           │   └── source: "HTML"
+    │   │           │
+    │   │           └── @ HTMLTextNode (location: (5:13)-(6:0))
+    │   │               └── content: "\n"
+    │   │
+    │   │
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (6:0)-(6:9))
+    │           ├── tag_opening: "<%" (location: (6:0)-(6:2))
+    │           ├── content: " end " (location: (6:2)-(6:7))
+    │           └── tag_closing: "%>" (location: (6:7)-(6:9))
+    │
+    │
+    └── @ HTMLTextNode (location: (6:9)-(7:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/conditional_open_tag_test/test_0030_multiple_erb_control_flow_nodes_with_complete_element_in_branch_23dee7c3c783818490db843c6b091023.txt
+++ b/test/snapshots/analyze/conditional_open_tag_test/test_0030_multiple_erb_control_flow_nodes_with_complete_element_in_branch_23dee7c3c783818490db843c6b091023.txt
@@ -1,0 +1,179 @@
+---
+source: "Analyze::ConditionalOpenTagTest#test_0030_multiple erb control flow nodes with complete element in branch"
+input: |2-
+<% if condition %>
+  <div>
+    <% if a %><% end %>
+    <% items.each do |item| %>
+      <span><%= item %></span>
+    <% end %>
+    <% if b %><% end %>
+  </div>
+<% else %>
+  <div></div>
+<% end %>
+---
+@ DocumentNode (location: (1:0)-(12:0))
+└── children: (2 items)
+    ├── @ ERBIfNode (location: (1:0)-(11:9))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
+    │   ├── content: " if condition " (location: (1:2)-(1:16))
+    │   ├── tag_closing: "%>" (location: (1:16)-(1:18))
+    │   ├── then_keyword: ∅
+    │   ├── statements: (3 items)
+    │   │   ├── @ HTMLTextNode (location: (1:18)-(2:2))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ HTMLElementNode (location: (2:2)-(8:8))
+    │   │   │   ├── open_tag:
+    │   │   │   │   └── @ HTMLOpenTagNode (location: (2:2)-(2:7))
+    │   │   │   │       ├── tag_opening: "<" (location: (2:2)-(2:3))
+    │   │   │   │       ├── tag_name: "div" (location: (2:3)-(2:6))
+    │   │   │   │       ├── tag_closing: ">" (location: (2:6)-(2:7))
+    │   │   │   │       ├── children: []
+    │   │   │   │       └── is_void: false
+    │   │   │   │
+    │   │   │   ├── tag_name: "div" (location: (2:3)-(2:6))
+    │   │   │   ├── body: (7 items)
+    │   │   │   │   ├── @ HTMLTextNode (location: (2:7)-(3:4))
+    │   │   │   │   │   └── content: "\n    "
+    │   │   │   │   │
+    │   │   │   │   ├── @ ERBIfNode (location: (3:4)-(3:23))
+    │   │   │   │   │   ├── tag_opening: "<%" (location: (3:4)-(3:6))
+    │   │   │   │   │   ├── content: " if a " (location: (3:6)-(3:12))
+    │   │   │   │   │   ├── tag_closing: "%>" (location: (3:12)-(3:14))
+    │   │   │   │   │   ├── then_keyword: ∅
+    │   │   │   │   │   ├── statements: []
+    │   │   │   │   │   ├── subsequent: ∅
+    │   │   │   │   │   └── end_node:
+    │   │   │   │   │       └── @ ERBEndNode (location: (3:14)-(3:23))
+    │   │   │   │   │           ├── tag_opening: "<%" (location: (3:14)-(3:16))
+    │   │   │   │   │           ├── content: " end " (location: (3:16)-(3:21))
+    │   │   │   │   │           └── tag_closing: "%>" (location: (3:21)-(3:23))
+    │   │   │   │   │
+    │   │   │   │   │
+    │   │   │   │   ├── @ HTMLTextNode (location: (3:23)-(4:4))
+    │   │   │   │   │   └── content: "\n    "
+    │   │   │   │   │
+    │   │   │   │   ├── @ ERBBlockNode (location: (4:4)-(6:13))
+    │   │   │   │   │   ├── tag_opening: "<%" (location: (4:4)-(4:6))
+    │   │   │   │   │   ├── content: " items.each do |item| " (location: (4:6)-(4:28))
+    │   │   │   │   │   ├── tag_closing: "%>" (location: (4:28)-(4:30))
+    │   │   │   │   │   ├── body: (3 items)
+    │   │   │   │   │   │   ├── @ HTMLTextNode (location: (4:30)-(5:6))
+    │   │   │   │   │   │   │   └── content: "\n      "
+    │   │   │   │   │   │   │
+    │   │   │   │   │   │   ├── @ HTMLElementNode (location: (5:6)-(5:30))
+    │   │   │   │   │   │   │   ├── open_tag:
+    │   │   │   │   │   │   │   │   └── @ HTMLOpenTagNode (location: (5:6)-(5:12))
+    │   │   │   │   │   │   │   │       ├── tag_opening: "<" (location: (5:6)-(5:7))
+    │   │   │   │   │   │   │   │       ├── tag_name: "span" (location: (5:7)-(5:11))
+    │   │   │   │   │   │   │   │       ├── tag_closing: ">" (location: (5:11)-(5:12))
+    │   │   │   │   │   │   │   │       ├── children: []
+    │   │   │   │   │   │   │   │       └── is_void: false
+    │   │   │   │   │   │   │   │
+    │   │   │   │   │   │   │   ├── tag_name: "span" (location: (5:7)-(5:11))
+    │   │   │   │   │   │   │   ├── body: (1 item)
+    │   │   │   │   │   │   │   │   └── @ ERBContentNode (location: (5:12)-(5:23))
+    │   │   │   │   │   │   │   │       ├── tag_opening: "<%=" (location: (5:12)-(5:15))
+    │   │   │   │   │   │   │   │       ├── content: " item " (location: (5:15)-(5:21))
+    │   │   │   │   │   │   │   │       ├── tag_closing: "%>" (location: (5:21)-(5:23))
+    │   │   │   │   │   │   │   │       ├── parsed: true
+    │   │   │   │   │   │   │   │       └── valid: true
+    │   │   │   │   │   │   │   │
+    │   │   │   │   │   │   │   ├── close_tag:
+    │   │   │   │   │   │   │   │   └── @ HTMLCloseTagNode (location: (5:23)-(5:30))
+    │   │   │   │   │   │   │   │       ├── tag_opening: "</" (location: (5:23)-(5:25))
+    │   │   │   │   │   │   │   │       ├── tag_name: "span" (location: (5:25)-(5:29))
+    │   │   │   │   │   │   │   │       ├── children: []
+    │   │   │   │   │   │   │   │       └── tag_closing: ">" (location: (5:29)-(5:30))
+    │   │   │   │   │   │   │   │
+    │   │   │   │   │   │   │   ├── is_void: false
+    │   │   │   │   │   │   │   └── source: "HTML"
+    │   │   │   │   │   │   │
+    │   │   │   │   │   │   └── @ HTMLTextNode (location: (5:30)-(6:4))
+    │   │   │   │   │   │       └── content: "\n    "
+    │   │   │   │   │   │
+    │   │   │   │   │   └── end_node:
+    │   │   │   │   │       └── @ ERBEndNode (location: (6:4)-(6:13))
+    │   │   │   │   │           ├── tag_opening: "<%" (location: (6:4)-(6:6))
+    │   │   │   │   │           ├── content: " end " (location: (6:6)-(6:11))
+    │   │   │   │   │           └── tag_closing: "%>" (location: (6:11)-(6:13))
+    │   │   │   │   │
+    │   │   │   │   │
+    │   │   │   │   ├── @ HTMLTextNode (location: (6:13)-(7:4))
+    │   │   │   │   │   └── content: "\n    "
+    │   │   │   │   │
+    │   │   │   │   ├── @ ERBIfNode (location: (7:4)-(7:23))
+    │   │   │   │   │   ├── tag_opening: "<%" (location: (7:4)-(7:6))
+    │   │   │   │   │   ├── content: " if b " (location: (7:6)-(7:12))
+    │   │   │   │   │   ├── tag_closing: "%>" (location: (7:12)-(7:14))
+    │   │   │   │   │   ├── then_keyword: ∅
+    │   │   │   │   │   ├── statements: []
+    │   │   │   │   │   ├── subsequent: ∅
+    │   │   │   │   │   └── end_node:
+    │   │   │   │   │       └── @ ERBEndNode (location: (7:14)-(7:23))
+    │   │   │   │   │           ├── tag_opening: "<%" (location: (7:14)-(7:16))
+    │   │   │   │   │           ├── content: " end " (location: (7:16)-(7:21))
+    │   │   │   │   │           └── tag_closing: "%>" (location: (7:21)-(7:23))
+    │   │   │   │   │
+    │   │   │   │   │
+    │   │   │   │   └── @ HTMLTextNode (location: (7:23)-(8:2))
+    │   │   │   │       └── content: "\n  "
+    │   │   │   │
+    │   │   │   ├── close_tag:
+    │   │   │   │   └── @ HTMLCloseTagNode (location: (8:2)-(8:8))
+    │   │   │   │       ├── tag_opening: "</" (location: (8:2)-(8:4))
+    │   │   │   │       ├── tag_name: "div" (location: (8:4)-(8:7))
+    │   │   │   │       ├── children: []
+    │   │   │   │       └── tag_closing: ">" (location: (8:7)-(8:8))
+    │   │   │   │
+    │   │   │   ├── is_void: false
+    │   │   │   └── source: "HTML"
+    │   │   │
+    │   │   └── @ HTMLTextNode (location: (8:8)-(9:0))
+    │   │       └── content: "\n"
+    │   │
+    │   ├── subsequent:
+    │   │   └── @ ERBElseNode (location: (9:0)-(11:0))
+    │   │       ├── tag_opening: "<%" (location: (9:0)-(9:2))
+    │   │       ├── content: " else " (location: (9:2)-(9:8))
+    │   │       ├── tag_closing: "%>" (location: (9:8)-(9:10))
+    │   │       └── statements: (3 items)
+    │   │           ├── @ HTMLTextNode (location: (9:10)-(10:2))
+    │   │           │   └── content: "\n  "
+    │   │           │
+    │   │           ├── @ HTMLElementNode (location: (10:2)-(10:13))
+    │   │           │   ├── open_tag:
+    │   │           │   │   └── @ HTMLOpenTagNode (location: (10:2)-(10:7))
+    │   │           │   │       ├── tag_opening: "<" (location: (10:2)-(10:3))
+    │   │           │   │       ├── tag_name: "div" (location: (10:3)-(10:6))
+    │   │           │   │       ├── tag_closing: ">" (location: (10:6)-(10:7))
+    │   │           │   │       ├── children: []
+    │   │           │   │       └── is_void: false
+    │   │           │   │
+    │   │           │   ├── tag_name: "div" (location: (10:3)-(10:6))
+    │   │           │   ├── body: []
+    │   │           │   ├── close_tag:
+    │   │           │   │   └── @ HTMLCloseTagNode (location: (10:7)-(10:13))
+    │   │           │   │       ├── tag_opening: "</" (location: (10:7)-(10:9))
+    │   │           │   │       ├── tag_name: "div" (location: (10:9)-(10:12))
+    │   │           │   │       ├── children: []
+    │   │           │   │       └── tag_closing: ">" (location: (10:12)-(10:13))
+    │   │           │   │
+    │   │           │   ├── is_void: false
+    │   │           │   └── source: "HTML"
+    │   │           │
+    │   │           └── @ HTMLTextNode (location: (10:13)-(11:0))
+    │   │               └── content: "\n"
+    │   │
+    │   │
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (11:0)-(11:9))
+    │           ├── tag_opening: "<%" (location: (11:0)-(11:2))
+    │           ├── content: " end " (location: (11:2)-(11:7))
+    │           └── tag_closing: "%>" (location: (11:7)-(11:9))
+    │
+    │
+    └── @ HTMLTextNode (location: (11:9)-(12:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/conditional_open_tag_test/test_0031_if_elsif_else_with_erb_control_flow_in_each_branch_efe905853a0f58b91dd869ad43a62b82.txt
+++ b/test/snapshots/analyze/conditional_open_tag_test/test_0031_if_elsif_else_with_erb_control_flow_in_each_branch_efe905853a0f58b91dd869ad43a62b82.txt
@@ -1,0 +1,187 @@
+---
+source: "Analyze::ConditionalOpenTagTest#test_0031_if/elsif/else with erb control flow in each branch"
+input: |2-
+<% if a %>
+  <div>
+    <% if x %><% end %>
+  </div>
+<% elsif b %>
+  <div>
+    <% items.each do |i| %><% end %>
+  </div>
+<% else %>
+  <div>
+    <% while c %><% end %>
+  </div>
+<% end %>
+---
+@ DocumentNode (location: (1:0)-(14:0))
+└── children: (2 items)
+    ├── @ ERBIfNode (location: (1:0)-(13:9))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
+    │   ├── content: " if a " (location: (1:2)-(1:8))
+    │   ├── tag_closing: "%>" (location: (1:8)-(1:10))
+    │   ├── then_keyword: ∅
+    │   ├── statements: (3 items)
+    │   │   ├── @ HTMLTextNode (location: (1:10)-(2:2))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ HTMLElementNode (location: (2:2)-(4:8))
+    │   │   │   ├── open_tag:
+    │   │   │   │   └── @ HTMLOpenTagNode (location: (2:2)-(2:7))
+    │   │   │   │       ├── tag_opening: "<" (location: (2:2)-(2:3))
+    │   │   │   │       ├── tag_name: "div" (location: (2:3)-(2:6))
+    │   │   │   │       ├── tag_closing: ">" (location: (2:6)-(2:7))
+    │   │   │   │       ├── children: []
+    │   │   │   │       └── is_void: false
+    │   │   │   │
+    │   │   │   ├── tag_name: "div" (location: (2:3)-(2:6))
+    │   │   │   ├── body: (3 items)
+    │   │   │   │   ├── @ HTMLTextNode (location: (2:7)-(3:4))
+    │   │   │   │   │   └── content: "\n    "
+    │   │   │   │   │
+    │   │   │   │   ├── @ ERBIfNode (location: (3:4)-(3:23))
+    │   │   │   │   │   ├── tag_opening: "<%" (location: (3:4)-(3:6))
+    │   │   │   │   │   ├── content: " if x " (location: (3:6)-(3:12))
+    │   │   │   │   │   ├── tag_closing: "%>" (location: (3:12)-(3:14))
+    │   │   │   │   │   ├── then_keyword: ∅
+    │   │   │   │   │   ├── statements: []
+    │   │   │   │   │   ├── subsequent: ∅
+    │   │   │   │   │   └── end_node:
+    │   │   │   │   │       └── @ ERBEndNode (location: (3:14)-(3:23))
+    │   │   │   │   │           ├── tag_opening: "<%" (location: (3:14)-(3:16))
+    │   │   │   │   │           ├── content: " end " (location: (3:16)-(3:21))
+    │   │   │   │   │           └── tag_closing: "%>" (location: (3:21)-(3:23))
+    │   │   │   │   │
+    │   │   │   │   │
+    │   │   │   │   └── @ HTMLTextNode (location: (3:23)-(4:2))
+    │   │   │   │       └── content: "\n  "
+    │   │   │   │
+    │   │   │   ├── close_tag:
+    │   │   │   │   └── @ HTMLCloseTagNode (location: (4:2)-(4:8))
+    │   │   │   │       ├── tag_opening: "</" (location: (4:2)-(4:4))
+    │   │   │   │       ├── tag_name: "div" (location: (4:4)-(4:7))
+    │   │   │   │       ├── children: []
+    │   │   │   │       └── tag_closing: ">" (location: (4:7)-(4:8))
+    │   │   │   │
+    │   │   │   ├── is_void: false
+    │   │   │   └── source: "HTML"
+    │   │   │
+    │   │   └── @ HTMLTextNode (location: (4:8)-(5:0))
+    │   │       └── content: "\n"
+    │   │
+    │   ├── subsequent:
+    │   │   └── @ ERBIfNode (location: (5:0)-(9:0))
+    │   │       ├── tag_opening: "<%" (location: (5:0)-(5:2))
+    │   │       ├── content: " elsif b " (location: (5:2)-(5:11))
+    │   │       ├── tag_closing: "%>" (location: (5:11)-(5:13))
+    │   │       ├── then_keyword: ∅
+    │   │       ├── statements: (3 items)
+    │   │       │   ├── @ HTMLTextNode (location: (5:13)-(6:2))
+    │   │       │   │   └── content: "\n  "
+    │   │       │   │
+    │   │       │   ├── @ HTMLElementNode (location: (6:2)-(8:8))
+    │   │       │   │   ├── open_tag:
+    │   │       │   │   │   └── @ HTMLOpenTagNode (location: (6:2)-(6:7))
+    │   │       │   │   │       ├── tag_opening: "<" (location: (6:2)-(6:3))
+    │   │       │   │   │       ├── tag_name: "div" (location: (6:3)-(6:6))
+    │   │       │   │   │       ├── tag_closing: ">" (location: (6:6)-(6:7))
+    │   │       │   │   │       ├── children: []
+    │   │       │   │   │       └── is_void: false
+    │   │       │   │   │
+    │   │       │   │   ├── tag_name: "div" (location: (6:3)-(6:6))
+    │   │       │   │   ├── body: (3 items)
+    │   │       │   │   │   ├── @ HTMLTextNode (location: (6:7)-(7:4))
+    │   │       │   │   │   │   └── content: "\n    "
+    │   │       │   │   │   │
+    │   │       │   │   │   ├── @ ERBBlockNode (location: (7:4)-(7:36))
+    │   │       │   │   │   │   ├── tag_opening: "<%" (location: (7:4)-(7:6))
+    │   │       │   │   │   │   ├── content: " items.each do |i| " (location: (7:6)-(7:25))
+    │   │       │   │   │   │   ├── tag_closing: "%>" (location: (7:25)-(7:27))
+    │   │       │   │   │   │   ├── body: []
+    │   │       │   │   │   │   └── end_node:
+    │   │       │   │   │   │       └── @ ERBEndNode (location: (7:27)-(7:36))
+    │   │       │   │   │   │           ├── tag_opening: "<%" (location: (7:27)-(7:29))
+    │   │       │   │   │   │           ├── content: " end " (location: (7:29)-(7:34))
+    │   │       │   │   │   │           └── tag_closing: "%>" (location: (7:34)-(7:36))
+    │   │       │   │   │   │
+    │   │       │   │   │   │
+    │   │       │   │   │   └── @ HTMLTextNode (location: (7:36)-(8:2))
+    │   │       │   │   │       └── content: "\n  "
+    │   │       │   │   │
+    │   │       │   │   ├── close_tag:
+    │   │       │   │   │   └── @ HTMLCloseTagNode (location: (8:2)-(8:8))
+    │   │       │   │   │       ├── tag_opening: "</" (location: (8:2)-(8:4))
+    │   │       │   │   │       ├── tag_name: "div" (location: (8:4)-(8:7))
+    │   │       │   │   │       ├── children: []
+    │   │       │   │   │       └── tag_closing: ">" (location: (8:7)-(8:8))
+    │   │       │   │   │
+    │   │       │   │   ├── is_void: false
+    │   │       │   │   └── source: "HTML"
+    │   │       │   │
+    │   │       │   └── @ HTMLTextNode (location: (8:8)-(9:0))
+    │   │       │       └── content: "\n"
+    │   │       │
+    │   │       ├── subsequent:
+    │   │       │   └── @ ERBElseNode (location: (9:0)-(13:0))
+    │   │       │       ├── tag_opening: "<%" (location: (9:0)-(9:2))
+    │   │       │       ├── content: " else " (location: (9:2)-(9:8))
+    │   │       │       ├── tag_closing: "%>" (location: (9:8)-(9:10))
+    │   │       │       └── statements: (3 items)
+    │   │       │           ├── @ HTMLTextNode (location: (9:10)-(10:2))
+    │   │       │           │   └── content: "\n  "
+    │   │       │           │
+    │   │       │           ├── @ HTMLElementNode (location: (10:2)-(12:8))
+    │   │       │           │   ├── open_tag:
+    │   │       │           │   │   └── @ HTMLOpenTagNode (location: (10:2)-(10:7))
+    │   │       │           │   │       ├── tag_opening: "<" (location: (10:2)-(10:3))
+    │   │       │           │   │       ├── tag_name: "div" (location: (10:3)-(10:6))
+    │   │       │           │   │       ├── tag_closing: ">" (location: (10:6)-(10:7))
+    │   │       │           │   │       ├── children: []
+    │   │       │           │   │       └── is_void: false
+    │   │       │           │   │
+    │   │       │           │   ├── tag_name: "div" (location: (10:3)-(10:6))
+    │   │       │           │   ├── body: (3 items)
+    │   │       │           │   │   ├── @ HTMLTextNode (location: (10:7)-(11:4))
+    │   │       │           │   │   │   └── content: "\n    "
+    │   │       │           │   │   │
+    │   │       │           │   │   ├── @ ERBWhileNode (location: (11:4)-(11:26))
+    │   │       │           │   │   │   ├── tag_opening: "<%" (location: (11:4)-(11:6))
+    │   │       │           │   │   │   ├── content: " while c " (location: (11:6)-(11:15))
+    │   │       │           │   │   │   ├── tag_closing: "%>" (location: (11:15)-(11:17))
+    │   │       │           │   │   │   ├── statements: []
+    │   │       │           │   │   │   └── end_node:
+    │   │       │           │   │   │       └── @ ERBEndNode (location: (11:17)-(11:26))
+    │   │       │           │   │   │           ├── tag_opening: "<%" (location: (11:17)-(11:19))
+    │   │       │           │   │   │           ├── content: " end " (location: (11:19)-(11:24))
+    │   │       │           │   │   │           └── tag_closing: "%>" (location: (11:24)-(11:26))
+    │   │       │           │   │   │
+    │   │       │           │   │   │
+    │   │       │           │   │   └── @ HTMLTextNode (location: (11:26)-(12:2))
+    │   │       │           │   │       └── content: "\n  "
+    │   │       │           │   │
+    │   │       │           │   ├── close_tag:
+    │   │       │           │   │   └── @ HTMLCloseTagNode (location: (12:2)-(12:8))
+    │   │       │           │   │       ├── tag_opening: "</" (location: (12:2)-(12:4))
+    │   │       │           │   │       ├── tag_name: "div" (location: (12:4)-(12:7))
+    │   │       │           │   │       ├── children: []
+    │   │       │           │   │       └── tag_closing: ">" (location: (12:7)-(12:8))
+    │   │       │           │   │
+    │   │       │           │   ├── is_void: false
+    │   │       │           │   └── source: "HTML"
+    │   │       │           │
+    │   │       │           └── @ HTMLTextNode (location: (12:8)-(13:0))
+    │   │       │               └── content: "\n"
+    │   │       │
+    │   │       │
+    │   │       └── end_node: ∅
+    │   │
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (13:0)-(13:9))
+    │           ├── tag_opening: "<%" (location: (13:0)-(13:2))
+    │           ├── content: " end " (location: (13:2)-(13:7))
+    │           └── tag_closing: "%>" (location: (13:7)-(13:9))
+    │
+    │
+    └── @ HTMLTextNode (location: (13:9)-(14:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/conditional_open_tag_test/test_0032_complete_elements_with_erb_until_inside_if_else_branches_bbea3fe4b96db51983920f77914675ea.txt
+++ b/test/snapshots/analyze/conditional_open_tag_test/test_0032_complete_elements_with_erb_until_inside_if_else_branches_bbea3fe4b96db51983920f77914675ea.txt
@@ -1,0 +1,139 @@
+---
+source: "Analyze::ConditionalOpenTagTest#test_0032_complete elements with erb until inside if/else branches"
+input: |2-
+<% if condition %>
+  <div>
+    <% until done %>
+      <p>waiting</p>
+    <% end %>
+  </div>
+<% else %>
+  <div></div>
+<% end %>
+---
+@ DocumentNode (location: (1:0)-(10:0))
+└── children: (2 items)
+    ├── @ ERBIfNode (location: (1:0)-(9:9))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
+    │   ├── content: " if condition " (location: (1:2)-(1:16))
+    │   ├── tag_closing: "%>" (location: (1:16)-(1:18))
+    │   ├── then_keyword: ∅
+    │   ├── statements: (3 items)
+    │   │   ├── @ HTMLTextNode (location: (1:18)-(2:2))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ HTMLElementNode (location: (2:2)-(6:8))
+    │   │   │   ├── open_tag:
+    │   │   │   │   └── @ HTMLOpenTagNode (location: (2:2)-(2:7))
+    │   │   │   │       ├── tag_opening: "<" (location: (2:2)-(2:3))
+    │   │   │   │       ├── tag_name: "div" (location: (2:3)-(2:6))
+    │   │   │   │       ├── tag_closing: ">" (location: (2:6)-(2:7))
+    │   │   │   │       ├── children: []
+    │   │   │   │       └── is_void: false
+    │   │   │   │
+    │   │   │   ├── tag_name: "div" (location: (2:3)-(2:6))
+    │   │   │   ├── body: (3 items)
+    │   │   │   │   ├── @ HTMLTextNode (location: (2:7)-(3:4))
+    │   │   │   │   │   └── content: "\n    "
+    │   │   │   │   │
+    │   │   │   │   ├── @ ERBUntilNode (location: (3:4)-(5:13))
+    │   │   │   │   │   ├── tag_opening: "<%" (location: (3:4)-(3:6))
+    │   │   │   │   │   ├── content: " until done " (location: (3:6)-(3:18))
+    │   │   │   │   │   ├── tag_closing: "%>" (location: (3:18)-(3:20))
+    │   │   │   │   │   ├── statements: (3 items)
+    │   │   │   │   │   │   ├── @ HTMLTextNode (location: (3:20)-(4:6))
+    │   │   │   │   │   │   │   └── content: "\n      "
+    │   │   │   │   │   │   │
+    │   │   │   │   │   │   ├── @ HTMLElementNode (location: (4:6)-(4:20))
+    │   │   │   │   │   │   │   ├── open_tag:
+    │   │   │   │   │   │   │   │   └── @ HTMLOpenTagNode (location: (4:6)-(4:9))
+    │   │   │   │   │   │   │   │       ├── tag_opening: "<" (location: (4:6)-(4:7))
+    │   │   │   │   │   │   │   │       ├── tag_name: "p" (location: (4:7)-(4:8))
+    │   │   │   │   │   │   │   │       ├── tag_closing: ">" (location: (4:8)-(4:9))
+    │   │   │   │   │   │   │   │       ├── children: []
+    │   │   │   │   │   │   │   │       └── is_void: false
+    │   │   │   │   │   │   │   │
+    │   │   │   │   │   │   │   ├── tag_name: "p" (location: (4:7)-(4:8))
+    │   │   │   │   │   │   │   ├── body: (1 item)
+    │   │   │   │   │   │   │   │   └── @ HTMLTextNode (location: (4:9)-(4:16))
+    │   │   │   │   │   │   │   │       └── content: "waiting"
+    │   │   │   │   │   │   │   │
+    │   │   │   │   │   │   │   ├── close_tag:
+    │   │   │   │   │   │   │   │   └── @ HTMLCloseTagNode (location: (4:16)-(4:20))
+    │   │   │   │   │   │   │   │       ├── tag_opening: "</" (location: (4:16)-(4:18))
+    │   │   │   │   │   │   │   │       ├── tag_name: "p" (location: (4:18)-(4:19))
+    │   │   │   │   │   │   │   │       ├── children: []
+    │   │   │   │   │   │   │   │       └── tag_closing: ">" (location: (4:19)-(4:20))
+    │   │   │   │   │   │   │   │
+    │   │   │   │   │   │   │   ├── is_void: false
+    │   │   │   │   │   │   │   └── source: "HTML"
+    │   │   │   │   │   │   │
+    │   │   │   │   │   │   └── @ HTMLTextNode (location: (4:20)-(5:4))
+    │   │   │   │   │   │       └── content: "\n    "
+    │   │   │   │   │   │
+    │   │   │   │   │   └── end_node:
+    │   │   │   │   │       └── @ ERBEndNode (location: (5:4)-(5:13))
+    │   │   │   │   │           ├── tag_opening: "<%" (location: (5:4)-(5:6))
+    │   │   │   │   │           ├── content: " end " (location: (5:6)-(5:11))
+    │   │   │   │   │           └── tag_closing: "%>" (location: (5:11)-(5:13))
+    │   │   │   │   │
+    │   │   │   │   │
+    │   │   │   │   └── @ HTMLTextNode (location: (5:13)-(6:2))
+    │   │   │   │       └── content: "\n  "
+    │   │   │   │
+    │   │   │   ├── close_tag:
+    │   │   │   │   └── @ HTMLCloseTagNode (location: (6:2)-(6:8))
+    │   │   │   │       ├── tag_opening: "</" (location: (6:2)-(6:4))
+    │   │   │   │       ├── tag_name: "div" (location: (6:4)-(6:7))
+    │   │   │   │       ├── children: []
+    │   │   │   │       └── tag_closing: ">" (location: (6:7)-(6:8))
+    │   │   │   │
+    │   │   │   ├── is_void: false
+    │   │   │   └── source: "HTML"
+    │   │   │
+    │   │   └── @ HTMLTextNode (location: (6:8)-(7:0))
+    │   │       └── content: "\n"
+    │   │
+    │   ├── subsequent:
+    │   │   └── @ ERBElseNode (location: (7:0)-(9:0))
+    │   │       ├── tag_opening: "<%" (location: (7:0)-(7:2))
+    │   │       ├── content: " else " (location: (7:2)-(7:8))
+    │   │       ├── tag_closing: "%>" (location: (7:8)-(7:10))
+    │   │       └── statements: (3 items)
+    │   │           ├── @ HTMLTextNode (location: (7:10)-(8:2))
+    │   │           │   └── content: "\n  "
+    │   │           │
+    │   │           ├── @ HTMLElementNode (location: (8:2)-(8:13))
+    │   │           │   ├── open_tag:
+    │   │           │   │   └── @ HTMLOpenTagNode (location: (8:2)-(8:7))
+    │   │           │   │       ├── tag_opening: "<" (location: (8:2)-(8:3))
+    │   │           │   │       ├── tag_name: "div" (location: (8:3)-(8:6))
+    │   │           │   │       ├── tag_closing: ">" (location: (8:6)-(8:7))
+    │   │           │   │       ├── children: []
+    │   │           │   │       └── is_void: false
+    │   │           │   │
+    │   │           │   ├── tag_name: "div" (location: (8:3)-(8:6))
+    │   │           │   ├── body: []
+    │   │           │   ├── close_tag:
+    │   │           │   │   └── @ HTMLCloseTagNode (location: (8:7)-(8:13))
+    │   │           │   │       ├── tag_opening: "</" (location: (8:7)-(8:9))
+    │   │           │   │       ├── tag_name: "div" (location: (8:9)-(8:12))
+    │   │           │   │       ├── children: []
+    │   │           │   │       └── tag_closing: ">" (location: (8:12)-(8:13))
+    │   │           │   │
+    │   │           │   ├── is_void: false
+    │   │           │   └── source: "HTML"
+    │   │           │
+    │   │           └── @ HTMLTextNode (location: (8:13)-(9:0))
+    │   │               └── content: "\n"
+    │   │
+    │   │
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (9:0)-(9:9))
+    │           ├── tag_opening: "<%" (location: (9:0)-(9:2))
+    │           ├── content: " end " (location: (9:2)-(9:7))
+    │           └── tag_closing: "%>" (location: (9:7)-(9:9))
+    │
+    │
+    └── @ HTMLTextNode (location: (9:9)-(10:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/conditional_open_tag_test/test_0033_complete_elements_with_erb_for_inside_if_else_branches_a7d393fb03c348db462ffbd498d9555e.txt
+++ b/test/snapshots/analyze/conditional_open_tag_test/test_0033_complete_elements_with_erb_for_inside_if_else_branches_a7d393fb03c348db462ffbd498d9555e.txt
@@ -1,0 +1,143 @@
+---
+source: "Analyze::ConditionalOpenTagTest#test_0033_complete elements with erb for inside if/else branches"
+input: |2-
+<% if condition %>
+  <div>
+    <% for item in items %>
+      <span><%= item %></span>
+    <% end %>
+  </div>
+<% else %>
+  <div></div>
+<% end %>
+---
+@ DocumentNode (location: (1:0)-(10:0))
+└── children: (2 items)
+    ├── @ ERBIfNode (location: (1:0)-(9:9))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
+    │   ├── content: " if condition " (location: (1:2)-(1:16))
+    │   ├── tag_closing: "%>" (location: (1:16)-(1:18))
+    │   ├── then_keyword: ∅
+    │   ├── statements: (3 items)
+    │   │   ├── @ HTMLTextNode (location: (1:18)-(2:2))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ HTMLElementNode (location: (2:2)-(6:8))
+    │   │   │   ├── open_tag:
+    │   │   │   │   └── @ HTMLOpenTagNode (location: (2:2)-(2:7))
+    │   │   │   │       ├── tag_opening: "<" (location: (2:2)-(2:3))
+    │   │   │   │       ├── tag_name: "div" (location: (2:3)-(2:6))
+    │   │   │   │       ├── tag_closing: ">" (location: (2:6)-(2:7))
+    │   │   │   │       ├── children: []
+    │   │   │   │       └── is_void: false
+    │   │   │   │
+    │   │   │   ├── tag_name: "div" (location: (2:3)-(2:6))
+    │   │   │   ├── body: (3 items)
+    │   │   │   │   ├── @ HTMLTextNode (location: (2:7)-(3:4))
+    │   │   │   │   │   └── content: "\n    "
+    │   │   │   │   │
+    │   │   │   │   ├── @ ERBForNode (location: (3:4)-(5:13))
+    │   │   │   │   │   ├── tag_opening: "<%" (location: (3:4)-(3:6))
+    │   │   │   │   │   ├── content: " for item in items " (location: (3:6)-(3:25))
+    │   │   │   │   │   ├── tag_closing: "%>" (location: (3:25)-(3:27))
+    │   │   │   │   │   ├── statements: (3 items)
+    │   │   │   │   │   │   ├── @ HTMLTextNode (location: (3:27)-(4:6))
+    │   │   │   │   │   │   │   └── content: "\n      "
+    │   │   │   │   │   │   │
+    │   │   │   │   │   │   ├── @ HTMLElementNode (location: (4:6)-(4:30))
+    │   │   │   │   │   │   │   ├── open_tag:
+    │   │   │   │   │   │   │   │   └── @ HTMLOpenTagNode (location: (4:6)-(4:12))
+    │   │   │   │   │   │   │   │       ├── tag_opening: "<" (location: (4:6)-(4:7))
+    │   │   │   │   │   │   │   │       ├── tag_name: "span" (location: (4:7)-(4:11))
+    │   │   │   │   │   │   │   │       ├── tag_closing: ">" (location: (4:11)-(4:12))
+    │   │   │   │   │   │   │   │       ├── children: []
+    │   │   │   │   │   │   │   │       └── is_void: false
+    │   │   │   │   │   │   │   │
+    │   │   │   │   │   │   │   ├── tag_name: "span" (location: (4:7)-(4:11))
+    │   │   │   │   │   │   │   ├── body: (1 item)
+    │   │   │   │   │   │   │   │   └── @ ERBContentNode (location: (4:12)-(4:23))
+    │   │   │   │   │   │   │   │       ├── tag_opening: "<%=" (location: (4:12)-(4:15))
+    │   │   │   │   │   │   │   │       ├── content: " item " (location: (4:15)-(4:21))
+    │   │   │   │   │   │   │   │       ├── tag_closing: "%>" (location: (4:21)-(4:23))
+    │   │   │   │   │   │   │   │       ├── parsed: true
+    │   │   │   │   │   │   │   │       └── valid: true
+    │   │   │   │   │   │   │   │
+    │   │   │   │   │   │   │   ├── close_tag:
+    │   │   │   │   │   │   │   │   └── @ HTMLCloseTagNode (location: (4:23)-(4:30))
+    │   │   │   │   │   │   │   │       ├── tag_opening: "</" (location: (4:23)-(4:25))
+    │   │   │   │   │   │   │   │       ├── tag_name: "span" (location: (4:25)-(4:29))
+    │   │   │   │   │   │   │   │       ├── children: []
+    │   │   │   │   │   │   │   │       └── tag_closing: ">" (location: (4:29)-(4:30))
+    │   │   │   │   │   │   │   │
+    │   │   │   │   │   │   │   ├── is_void: false
+    │   │   │   │   │   │   │   └── source: "HTML"
+    │   │   │   │   │   │   │
+    │   │   │   │   │   │   └── @ HTMLTextNode (location: (4:30)-(5:4))
+    │   │   │   │   │   │       └── content: "\n    "
+    │   │   │   │   │   │
+    │   │   │   │   │   └── end_node:
+    │   │   │   │   │       └── @ ERBEndNode (location: (5:4)-(5:13))
+    │   │   │   │   │           ├── tag_opening: "<%" (location: (5:4)-(5:6))
+    │   │   │   │   │           ├── content: " end " (location: (5:6)-(5:11))
+    │   │   │   │   │           └── tag_closing: "%>" (location: (5:11)-(5:13))
+    │   │   │   │   │
+    │   │   │   │   │
+    │   │   │   │   └── @ HTMLTextNode (location: (5:13)-(6:2))
+    │   │   │   │       └── content: "\n  "
+    │   │   │   │
+    │   │   │   ├── close_tag:
+    │   │   │   │   └── @ HTMLCloseTagNode (location: (6:2)-(6:8))
+    │   │   │   │       ├── tag_opening: "</" (location: (6:2)-(6:4))
+    │   │   │   │       ├── tag_name: "div" (location: (6:4)-(6:7))
+    │   │   │   │       ├── children: []
+    │   │   │   │       └── tag_closing: ">" (location: (6:7)-(6:8))
+    │   │   │   │
+    │   │   │   ├── is_void: false
+    │   │   │   └── source: "HTML"
+    │   │   │
+    │   │   └── @ HTMLTextNode (location: (6:8)-(7:0))
+    │   │       └── content: "\n"
+    │   │
+    │   ├── subsequent:
+    │   │   └── @ ERBElseNode (location: (7:0)-(9:0))
+    │   │       ├── tag_opening: "<%" (location: (7:0)-(7:2))
+    │   │       ├── content: " else " (location: (7:2)-(7:8))
+    │   │       ├── tag_closing: "%>" (location: (7:8)-(7:10))
+    │   │       └── statements: (3 items)
+    │   │           ├── @ HTMLTextNode (location: (7:10)-(8:2))
+    │   │           │   └── content: "\n  "
+    │   │           │
+    │   │           ├── @ HTMLElementNode (location: (8:2)-(8:13))
+    │   │           │   ├── open_tag:
+    │   │           │   │   └── @ HTMLOpenTagNode (location: (8:2)-(8:7))
+    │   │           │   │       ├── tag_opening: "<" (location: (8:2)-(8:3))
+    │   │           │   │       ├── tag_name: "div" (location: (8:3)-(8:6))
+    │   │           │   │       ├── tag_closing: ">" (location: (8:6)-(8:7))
+    │   │           │   │       ├── children: []
+    │   │           │   │       └── is_void: false
+    │   │           │   │
+    │   │           │   ├── tag_name: "div" (location: (8:3)-(8:6))
+    │   │           │   ├── body: []
+    │   │           │   ├── close_tag:
+    │   │           │   │   └── @ HTMLCloseTagNode (location: (8:7)-(8:13))
+    │   │           │   │       ├── tag_opening: "</" (location: (8:7)-(8:9))
+    │   │           │   │       ├── tag_name: "div" (location: (8:9)-(8:12))
+    │   │           │   │       ├── children: []
+    │   │           │   │       └── tag_closing: ">" (location: (8:12)-(8:13))
+    │   │           │   │
+    │   │           │   ├── is_void: false
+    │   │           │   └── source: "HTML"
+    │   │           │
+    │   │           └── @ HTMLTextNode (location: (8:13)-(9:0))
+    │   │               └── content: "\n"
+    │   │
+    │   │
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (9:0)-(9:9))
+    │           ├── tag_opening: "<%" (location: (9:0)-(9:2))
+    │           ├── content: " end " (location: (9:2)-(9:7))
+    │           └── tag_closing: "%>" (location: (9:7)-(9:9))
+    │
+    │
+    └── @ HTMLTextNode (location: (9:9)-(10:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/conditional_open_tag_test/test_0034_complete_elements_with_erb_if_elsif_else_inside_if_else_branches_82212a0cd1e638043885752f20166e1e.txt
+++ b/test/snapshots/analyze/conditional_open_tag_test/test_0034_complete_elements_with_erb_if_elsif_else_inside_if_else_branches_82212a0cd1e638043885752f20166e1e.txt
@@ -1,0 +1,220 @@
+---
+source: "Analyze::ConditionalOpenTagTest#test_0034_complete elements with erb if/elsif/else inside if/else branches"
+input: |2-
+<% if condition %>
+  <div>
+    <% if inner_a %>
+      <span>a</span>
+    <% elsif inner_b %>
+      <span>b</span>
+    <% else %>
+      <span>c</span>
+    <% end %>
+  </div>
+<% else %>
+  <div></div>
+<% end %>
+---
+@ DocumentNode (location: (1:0)-(14:0))
+└── children: (2 items)
+    ├── @ ERBIfNode (location: (1:0)-(13:9))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
+    │   ├── content: " if condition " (location: (1:2)-(1:16))
+    │   ├── tag_closing: "%>" (location: (1:16)-(1:18))
+    │   ├── then_keyword: ∅
+    │   ├── statements: (3 items)
+    │   │   ├── @ HTMLTextNode (location: (1:18)-(2:2))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ HTMLElementNode (location: (2:2)-(10:8))
+    │   │   │   ├── open_tag:
+    │   │   │   │   └── @ HTMLOpenTagNode (location: (2:2)-(2:7))
+    │   │   │   │       ├── tag_opening: "<" (location: (2:2)-(2:3))
+    │   │   │   │       ├── tag_name: "div" (location: (2:3)-(2:6))
+    │   │   │   │       ├── tag_closing: ">" (location: (2:6)-(2:7))
+    │   │   │   │       ├── children: []
+    │   │   │   │       └── is_void: false
+    │   │   │   │
+    │   │   │   ├── tag_name: "div" (location: (2:3)-(2:6))
+    │   │   │   ├── body: (3 items)
+    │   │   │   │   ├── @ HTMLTextNode (location: (2:7)-(3:4))
+    │   │   │   │   │   └── content: "\n    "
+    │   │   │   │   │
+    │   │   │   │   ├── @ ERBIfNode (location: (3:4)-(9:13))
+    │   │   │   │   │   ├── tag_opening: "<%" (location: (3:4)-(3:6))
+    │   │   │   │   │   ├── content: " if inner_a " (location: (3:6)-(3:18))
+    │   │   │   │   │   ├── tag_closing: "%>" (location: (3:18)-(3:20))
+    │   │   │   │   │   ├── then_keyword: ∅
+    │   │   │   │   │   ├── statements: (3 items)
+    │   │   │   │   │   │   ├── @ HTMLTextNode (location: (3:20)-(4:6))
+    │   │   │   │   │   │   │   └── content: "\n      "
+    │   │   │   │   │   │   │
+    │   │   │   │   │   │   ├── @ HTMLElementNode (location: (4:6)-(4:20))
+    │   │   │   │   │   │   │   ├── open_tag:
+    │   │   │   │   │   │   │   │   └── @ HTMLOpenTagNode (location: (4:6)-(4:12))
+    │   │   │   │   │   │   │   │       ├── tag_opening: "<" (location: (4:6)-(4:7))
+    │   │   │   │   │   │   │   │       ├── tag_name: "span" (location: (4:7)-(4:11))
+    │   │   │   │   │   │   │   │       ├── tag_closing: ">" (location: (4:11)-(4:12))
+    │   │   │   │   │   │   │   │       ├── children: []
+    │   │   │   │   │   │   │   │       └── is_void: false
+    │   │   │   │   │   │   │   │
+    │   │   │   │   │   │   │   ├── tag_name: "span" (location: (4:7)-(4:11))
+    │   │   │   │   │   │   │   ├── body: (1 item)
+    │   │   │   │   │   │   │   │   └── @ HTMLTextNode (location: (4:12)-(4:13))
+    │   │   │   │   │   │   │   │       └── content: "a"
+    │   │   │   │   │   │   │   │
+    │   │   │   │   │   │   │   ├── close_tag:
+    │   │   │   │   │   │   │   │   └── @ HTMLCloseTagNode (location: (4:13)-(4:20))
+    │   │   │   │   │   │   │   │       ├── tag_opening: "</" (location: (4:13)-(4:15))
+    │   │   │   │   │   │   │   │       ├── tag_name: "span" (location: (4:15)-(4:19))
+    │   │   │   │   │   │   │   │       ├── children: []
+    │   │   │   │   │   │   │   │       └── tag_closing: ">" (location: (4:19)-(4:20))
+    │   │   │   │   │   │   │   │
+    │   │   │   │   │   │   │   ├── is_void: false
+    │   │   │   │   │   │   │   └── source: "HTML"
+    │   │   │   │   │   │   │
+    │   │   │   │   │   │   └── @ HTMLTextNode (location: (4:20)-(5:4))
+    │   │   │   │   │   │       └── content: "\n    "
+    │   │   │   │   │   │
+    │   │   │   │   │   ├── subsequent:
+    │   │   │   │   │   │   └── @ ERBIfNode (location: (5:4)-(7:4))
+    │   │   │   │   │   │       ├── tag_opening: "<%" (location: (5:4)-(5:6))
+    │   │   │   │   │   │       ├── content: " elsif inner_b " (location: (5:6)-(5:21))
+    │   │   │   │   │   │       ├── tag_closing: "%>" (location: (5:21)-(5:23))
+    │   │   │   │   │   │       ├── then_keyword: ∅
+    │   │   │   │   │   │       ├── statements: (3 items)
+    │   │   │   │   │   │       │   ├── @ HTMLTextNode (location: (5:23)-(6:6))
+    │   │   │   │   │   │       │   │   └── content: "\n      "
+    │   │   │   │   │   │       │   │
+    │   │   │   │   │   │       │   ├── @ HTMLElementNode (location: (6:6)-(6:20))
+    │   │   │   │   │   │       │   │   ├── open_tag:
+    │   │   │   │   │   │       │   │   │   └── @ HTMLOpenTagNode (location: (6:6)-(6:12))
+    │   │   │   │   │   │       │   │   │       ├── tag_opening: "<" (location: (6:6)-(6:7))
+    │   │   │   │   │   │       │   │   │       ├── tag_name: "span" (location: (6:7)-(6:11))
+    │   │   │   │   │   │       │   │   │       ├── tag_closing: ">" (location: (6:11)-(6:12))
+    │   │   │   │   │   │       │   │   │       ├── children: []
+    │   │   │   │   │   │       │   │   │       └── is_void: false
+    │   │   │   │   │   │       │   │   │
+    │   │   │   │   │   │       │   │   ├── tag_name: "span" (location: (6:7)-(6:11))
+    │   │   │   │   │   │       │   │   ├── body: (1 item)
+    │   │   │   │   │   │       │   │   │   └── @ HTMLTextNode (location: (6:12)-(6:13))
+    │   │   │   │   │   │       │   │   │       └── content: "b"
+    │   │   │   │   │   │       │   │   │
+    │   │   │   │   │   │       │   │   ├── close_tag:
+    │   │   │   │   │   │       │   │   │   └── @ HTMLCloseTagNode (location: (6:13)-(6:20))
+    │   │   │   │   │   │       │   │   │       ├── tag_opening: "</" (location: (6:13)-(6:15))
+    │   │   │   │   │   │       │   │   │       ├── tag_name: "span" (location: (6:15)-(6:19))
+    │   │   │   │   │   │       │   │   │       ├── children: []
+    │   │   │   │   │   │       │   │   │       └── tag_closing: ">" (location: (6:19)-(6:20))
+    │   │   │   │   │   │       │   │   │
+    │   │   │   │   │   │       │   │   ├── is_void: false
+    │   │   │   │   │   │       │   │   └── source: "HTML"
+    │   │   │   │   │   │       │   │
+    │   │   │   │   │   │       │   └── @ HTMLTextNode (location: (6:20)-(7:4))
+    │   │   │   │   │   │       │       └── content: "\n    "
+    │   │   │   │   │   │       │
+    │   │   │   │   │   │       ├── subsequent:
+    │   │   │   │   │   │       │   └── @ ERBElseNode (location: (7:4)-(9:4))
+    │   │   │   │   │   │       │       ├── tag_opening: "<%" (location: (7:4)-(7:6))
+    │   │   │   │   │   │       │       ├── content: " else " (location: (7:6)-(7:12))
+    │   │   │   │   │   │       │       ├── tag_closing: "%>" (location: (7:12)-(7:14))
+    │   │   │   │   │   │       │       └── statements: (3 items)
+    │   │   │   │   │   │       │           ├── @ HTMLTextNode (location: (7:14)-(8:6))
+    │   │   │   │   │   │       │           │   └── content: "\n      "
+    │   │   │   │   │   │       │           │
+    │   │   │   │   │   │       │           ├── @ HTMLElementNode (location: (8:6)-(8:20))
+    │   │   │   │   │   │       │           │   ├── open_tag:
+    │   │   │   │   │   │       │           │   │   └── @ HTMLOpenTagNode (location: (8:6)-(8:12))
+    │   │   │   │   │   │       │           │   │       ├── tag_opening: "<" (location: (8:6)-(8:7))
+    │   │   │   │   │   │       │           │   │       ├── tag_name: "span" (location: (8:7)-(8:11))
+    │   │   │   │   │   │       │           │   │       ├── tag_closing: ">" (location: (8:11)-(8:12))
+    │   │   │   │   │   │       │           │   │       ├── children: []
+    │   │   │   │   │   │       │           │   │       └── is_void: false
+    │   │   │   │   │   │       │           │   │
+    │   │   │   │   │   │       │           │   ├── tag_name: "span" (location: (8:7)-(8:11))
+    │   │   │   │   │   │       │           │   ├── body: (1 item)
+    │   │   │   │   │   │       │           │   │   └── @ HTMLTextNode (location: (8:12)-(8:13))
+    │   │   │   │   │   │       │           │   │       └── content: "c"
+    │   │   │   │   │   │       │           │   │
+    │   │   │   │   │   │       │           │   ├── close_tag:
+    │   │   │   │   │   │       │           │   │   └── @ HTMLCloseTagNode (location: (8:13)-(8:20))
+    │   │   │   │   │   │       │           │   │       ├── tag_opening: "</" (location: (8:13)-(8:15))
+    │   │   │   │   │   │       │           │   │       ├── tag_name: "span" (location: (8:15)-(8:19))
+    │   │   │   │   │   │       │           │   │       ├── children: []
+    │   │   │   │   │   │       │           │   │       └── tag_closing: ">" (location: (8:19)-(8:20))
+    │   │   │   │   │   │       │           │   │
+    │   │   │   │   │   │       │           │   ├── is_void: false
+    │   │   │   │   │   │       │           │   └── source: "HTML"
+    │   │   │   │   │   │       │           │
+    │   │   │   │   │   │       │           └── @ HTMLTextNode (location: (8:20)-(9:4))
+    │   │   │   │   │   │       │               └── content: "\n    "
+    │   │   │   │   │   │       │
+    │   │   │   │   │   │       │
+    │   │   │   │   │   │       └── end_node: ∅
+    │   │   │   │   │   │
+    │   │   │   │   │   └── end_node:
+    │   │   │   │   │       └── @ ERBEndNode (location: (9:4)-(9:13))
+    │   │   │   │   │           ├── tag_opening: "<%" (location: (9:4)-(9:6))
+    │   │   │   │   │           ├── content: " end " (location: (9:6)-(9:11))
+    │   │   │   │   │           └── tag_closing: "%>" (location: (9:11)-(9:13))
+    │   │   │   │   │
+    │   │   │   │   │
+    │   │   │   │   └── @ HTMLTextNode (location: (9:13)-(10:2))
+    │   │   │   │       └── content: "\n  "
+    │   │   │   │
+    │   │   │   ├── close_tag:
+    │   │   │   │   └── @ HTMLCloseTagNode (location: (10:2)-(10:8))
+    │   │   │   │       ├── tag_opening: "</" (location: (10:2)-(10:4))
+    │   │   │   │       ├── tag_name: "div" (location: (10:4)-(10:7))
+    │   │   │   │       ├── children: []
+    │   │   │   │       └── tag_closing: ">" (location: (10:7)-(10:8))
+    │   │   │   │
+    │   │   │   ├── is_void: false
+    │   │   │   └── source: "HTML"
+    │   │   │
+    │   │   └── @ HTMLTextNode (location: (10:8)-(11:0))
+    │   │       └── content: "\n"
+    │   │
+    │   ├── subsequent:
+    │   │   └── @ ERBElseNode (location: (11:0)-(13:0))
+    │   │       ├── tag_opening: "<%" (location: (11:0)-(11:2))
+    │   │       ├── content: " else " (location: (11:2)-(11:8))
+    │   │       ├── tag_closing: "%>" (location: (11:8)-(11:10))
+    │   │       └── statements: (3 items)
+    │   │           ├── @ HTMLTextNode (location: (11:10)-(12:2))
+    │   │           │   └── content: "\n  "
+    │   │           │
+    │   │           ├── @ HTMLElementNode (location: (12:2)-(12:13))
+    │   │           │   ├── open_tag:
+    │   │           │   │   └── @ HTMLOpenTagNode (location: (12:2)-(12:7))
+    │   │           │   │       ├── tag_opening: "<" (location: (12:2)-(12:3))
+    │   │           │   │       ├── tag_name: "div" (location: (12:3)-(12:6))
+    │   │           │   │       ├── tag_closing: ">" (location: (12:6)-(12:7))
+    │   │           │   │       ├── children: []
+    │   │           │   │       └── is_void: false
+    │   │           │   │
+    │   │           │   ├── tag_name: "div" (location: (12:3)-(12:6))
+    │   │           │   ├── body: []
+    │   │           │   ├── close_tag:
+    │   │           │   │   └── @ HTMLCloseTagNode (location: (12:7)-(12:13))
+    │   │           │   │       ├── tag_opening: "</" (location: (12:7)-(12:9))
+    │   │           │   │       ├── tag_name: "div" (location: (12:9)-(12:12))
+    │   │           │   │       ├── children: []
+    │   │           │   │       └── tag_closing: ">" (location: (12:12)-(12:13))
+    │   │           │   │
+    │   │           │   ├── is_void: false
+    │   │           │   └── source: "HTML"
+    │   │           │
+    │   │           └── @ HTMLTextNode (location: (12:13)-(13:0))
+    │   │               └── content: "\n"
+    │   │
+    │   │
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (13:0)-(13:9))
+    │           ├── tag_opening: "<%" (location: (13:0)-(13:2))
+    │           ├── content: " end " (location: (13:2)-(13:7))
+    │           └── tag_closing: "%>" (location: (13:7)-(13:9))
+    │
+    │
+    └── @ HTMLTextNode (location: (13:9)-(14:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/conditional_open_tag_test/test_0035_erb_block_before_complete_element_in_branch_17f5e64425334e8aec464a95ea361aff.txt
+++ b/test/snapshots/analyze/conditional_open_tag_test/test_0035_erb_block_before_complete_element_in_branch_17f5e64425334e8aec464a95ea361aff.txt
@@ -1,0 +1,103 @@
+---
+source: "Analyze::ConditionalOpenTagTest#test_0035_erb block before complete element in branch"
+input: |2-
+<% if condition %>
+  <% items.each do |item| %><% end %>
+  <div></div>
+<% else %>
+  <div></div>
+<% end %>
+---
+@ DocumentNode (location: (1:0)-(7:0))
+└── children: (2 items)
+    ├── @ ERBIfNode (location: (1:0)-(6:9))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
+    │   ├── content: " if condition " (location: (1:2)-(1:16))
+    │   ├── tag_closing: "%>" (location: (1:16)-(1:18))
+    │   ├── then_keyword: ∅
+    │   ├── statements: (5 items)
+    │   │   ├── @ HTMLTextNode (location: (1:18)-(2:2))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ ERBBlockNode (location: (2:2)-(2:37))
+    │   │   │   ├── tag_opening: "<%" (location: (2:2)-(2:4))
+    │   │   │   ├── content: " items.each do |item| " (location: (2:4)-(2:26))
+    │   │   │   ├── tag_closing: "%>" (location: (2:26)-(2:28))
+    │   │   │   ├── body: []
+    │   │   │   └── end_node:
+    │   │   │       └── @ ERBEndNode (location: (2:28)-(2:37))
+    │   │   │           ├── tag_opening: "<%" (location: (2:28)-(2:30))
+    │   │   │           ├── content: " end " (location: (2:30)-(2:35))
+    │   │   │           └── tag_closing: "%>" (location: (2:35)-(2:37))
+    │   │   │
+    │   │   │
+    │   │   ├── @ HTMLTextNode (location: (2:37)-(3:2))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ HTMLElementNode (location: (3:2)-(3:13))
+    │   │   │   ├── open_tag:
+    │   │   │   │   └── @ HTMLOpenTagNode (location: (3:2)-(3:7))
+    │   │   │   │       ├── tag_opening: "<" (location: (3:2)-(3:3))
+    │   │   │   │       ├── tag_name: "div" (location: (3:3)-(3:6))
+    │   │   │   │       ├── tag_closing: ">" (location: (3:6)-(3:7))
+    │   │   │   │       ├── children: []
+    │   │   │   │       └── is_void: false
+    │   │   │   │
+    │   │   │   ├── tag_name: "div" (location: (3:3)-(3:6))
+    │   │   │   ├── body: []
+    │   │   │   ├── close_tag:
+    │   │   │   │   └── @ HTMLCloseTagNode (location: (3:7)-(3:13))
+    │   │   │   │       ├── tag_opening: "</" (location: (3:7)-(3:9))
+    │   │   │   │       ├── tag_name: "div" (location: (3:9)-(3:12))
+    │   │   │   │       ├── children: []
+    │   │   │   │       └── tag_closing: ">" (location: (3:12)-(3:13))
+    │   │   │   │
+    │   │   │   ├── is_void: false
+    │   │   │   └── source: "HTML"
+    │   │   │
+    │   │   └── @ HTMLTextNode (location: (3:13)-(4:0))
+    │   │       └── content: "\n"
+    │   │
+    │   ├── subsequent:
+    │   │   └── @ ERBElseNode (location: (4:0)-(6:0))
+    │   │       ├── tag_opening: "<%" (location: (4:0)-(4:2))
+    │   │       ├── content: " else " (location: (4:2)-(4:8))
+    │   │       ├── tag_closing: "%>" (location: (4:8)-(4:10))
+    │   │       └── statements: (3 items)
+    │   │           ├── @ HTMLTextNode (location: (4:10)-(5:2))
+    │   │           │   └── content: "\n  "
+    │   │           │
+    │   │           ├── @ HTMLElementNode (location: (5:2)-(5:13))
+    │   │           │   ├── open_tag:
+    │   │           │   │   └── @ HTMLOpenTagNode (location: (5:2)-(5:7))
+    │   │           │   │       ├── tag_opening: "<" (location: (5:2)-(5:3))
+    │   │           │   │       ├── tag_name: "div" (location: (5:3)-(5:6))
+    │   │           │   │       ├── tag_closing: ">" (location: (5:6)-(5:7))
+    │   │           │   │       ├── children: []
+    │   │           │   │       └── is_void: false
+    │   │           │   │
+    │   │           │   ├── tag_name: "div" (location: (5:3)-(5:6))
+    │   │           │   ├── body: []
+    │   │           │   ├── close_tag:
+    │   │           │   │   └── @ HTMLCloseTagNode (location: (5:7)-(5:13))
+    │   │           │   │       ├── tag_opening: "</" (location: (5:7)-(5:9))
+    │   │           │   │       ├── tag_name: "div" (location: (5:9)-(5:12))
+    │   │           │   │       ├── children: []
+    │   │           │   │       └── tag_closing: ">" (location: (5:12)-(5:13))
+    │   │           │   │
+    │   │           │   ├── is_void: false
+    │   │           │   └── source: "HTML"
+    │   │           │
+    │   │           └── @ HTMLTextNode (location: (5:13)-(6:0))
+    │   │               └── content: "\n"
+    │   │
+    │   │
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (6:0)-(6:9))
+    │           ├── tag_opening: "<%" (location: (6:0)-(6:2))
+    │           ├── content: " end " (location: (6:2)-(6:7))
+    │           └── tag_closing: "%>" (location: (6:7)-(6:9))
+    │
+    │
+    └── @ HTMLTextNode (location: (6:9)-(7:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/conditional_open_tag_test/test_0036_deeply_nested_erb_control_flow_inside_branch_b9dd98317ebc08c5e2d7df52e614250c.txt
+++ b/test/snapshots/analyze/conditional_open_tag_test/test_0036_deeply_nested_erb_control_flow_inside_branch_b9dd98317ebc08c5e2d7df52e614250c.txt
@@ -1,0 +1,165 @@
+---
+source: "Analyze::ConditionalOpenTagTest#test_0036_deeply nested erb control flow inside branch"
+input: |2-
+<% if condition %>
+  <div>
+    <% items.each do |item| %>
+      <% if item.visible? %>
+        <span><%= item.name %></span>
+      <% end %>
+    <% end %>
+  </div>
+<% else %>
+  <div></div>
+<% end %>
+---
+@ DocumentNode (location: (1:0)-(12:0))
+└── children: (2 items)
+    ├── @ ERBIfNode (location: (1:0)-(11:9))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
+    │   ├── content: " if condition " (location: (1:2)-(1:16))
+    │   ├── tag_closing: "%>" (location: (1:16)-(1:18))
+    │   ├── then_keyword: ∅
+    │   ├── statements: (3 items)
+    │   │   ├── @ HTMLTextNode (location: (1:18)-(2:2))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ HTMLElementNode (location: (2:2)-(8:8))
+    │   │   │   ├── open_tag:
+    │   │   │   │   └── @ HTMLOpenTagNode (location: (2:2)-(2:7))
+    │   │   │   │       ├── tag_opening: "<" (location: (2:2)-(2:3))
+    │   │   │   │       ├── tag_name: "div" (location: (2:3)-(2:6))
+    │   │   │   │       ├── tag_closing: ">" (location: (2:6)-(2:7))
+    │   │   │   │       ├── children: []
+    │   │   │   │       └── is_void: false
+    │   │   │   │
+    │   │   │   ├── tag_name: "div" (location: (2:3)-(2:6))
+    │   │   │   ├── body: (3 items)
+    │   │   │   │   ├── @ HTMLTextNode (location: (2:7)-(3:4))
+    │   │   │   │   │   └── content: "\n    "
+    │   │   │   │   │
+    │   │   │   │   ├── @ ERBBlockNode (location: (3:4)-(7:13))
+    │   │   │   │   │   ├── tag_opening: "<%" (location: (3:4)-(3:6))
+    │   │   │   │   │   ├── content: " items.each do |item| " (location: (3:6)-(3:28))
+    │   │   │   │   │   ├── tag_closing: "%>" (location: (3:28)-(3:30))
+    │   │   │   │   │   ├── body: (3 items)
+    │   │   │   │   │   │   ├── @ HTMLTextNode (location: (3:30)-(4:6))
+    │   │   │   │   │   │   │   └── content: "\n      "
+    │   │   │   │   │   │   │
+    │   │   │   │   │   │   ├── @ ERBIfNode (location: (4:6)-(6:15))
+    │   │   │   │   │   │   │   ├── tag_opening: "<%" (location: (4:6)-(4:8))
+    │   │   │   │   │   │   │   ├── content: " if item.visible? " (location: (4:8)-(4:26))
+    │   │   │   │   │   │   │   ├── tag_closing: "%>" (location: (4:26)-(4:28))
+    │   │   │   │   │   │   │   ├── then_keyword: ∅
+    │   │   │   │   │   │   │   ├── statements: (3 items)
+    │   │   │   │   │   │   │   │   ├── @ HTMLTextNode (location: (4:28)-(5:8))
+    │   │   │   │   │   │   │   │   │   └── content: "\n        "
+    │   │   │   │   │   │   │   │   │
+    │   │   │   │   │   │   │   │   ├── @ HTMLElementNode (location: (5:8)-(5:37))
+    │   │   │   │   │   │   │   │   │   ├── open_tag:
+    │   │   │   │   │   │   │   │   │   │   └── @ HTMLOpenTagNode (location: (5:8)-(5:14))
+    │   │   │   │   │   │   │   │   │   │       ├── tag_opening: "<" (location: (5:8)-(5:9))
+    │   │   │   │   │   │   │   │   │   │       ├── tag_name: "span" (location: (5:9)-(5:13))
+    │   │   │   │   │   │   │   │   │   │       ├── tag_closing: ">" (location: (5:13)-(5:14))
+    │   │   │   │   │   │   │   │   │   │       ├── children: []
+    │   │   │   │   │   │   │   │   │   │       └── is_void: false
+    │   │   │   │   │   │   │   │   │   │
+    │   │   │   │   │   │   │   │   │   ├── tag_name: "span" (location: (5:9)-(5:13))
+    │   │   │   │   │   │   │   │   │   ├── body: (1 item)
+    │   │   │   │   │   │   │   │   │   │   └── @ ERBContentNode (location: (5:14)-(5:30))
+    │   │   │   │   │   │   │   │   │   │       ├── tag_opening: "<%=" (location: (5:14)-(5:17))
+    │   │   │   │   │   │   │   │   │   │       ├── content: " item.name " (location: (5:17)-(5:28))
+    │   │   │   │   │   │   │   │   │   │       ├── tag_closing: "%>" (location: (5:28)-(5:30))
+    │   │   │   │   │   │   │   │   │   │       ├── parsed: true
+    │   │   │   │   │   │   │   │   │   │       └── valid: true
+    │   │   │   │   │   │   │   │   │   │
+    │   │   │   │   │   │   │   │   │   ├── close_tag:
+    │   │   │   │   │   │   │   │   │   │   └── @ HTMLCloseTagNode (location: (5:30)-(5:37))
+    │   │   │   │   │   │   │   │   │   │       ├── tag_opening: "</" (location: (5:30)-(5:32))
+    │   │   │   │   │   │   │   │   │   │       ├── tag_name: "span" (location: (5:32)-(5:36))
+    │   │   │   │   │   │   │   │   │   │       ├── children: []
+    │   │   │   │   │   │   │   │   │   │       └── tag_closing: ">" (location: (5:36)-(5:37))
+    │   │   │   │   │   │   │   │   │   │
+    │   │   │   │   │   │   │   │   │   ├── is_void: false
+    │   │   │   │   │   │   │   │   │   └── source: "HTML"
+    │   │   │   │   │   │   │   │   │
+    │   │   │   │   │   │   │   │   └── @ HTMLTextNode (location: (5:37)-(6:6))
+    │   │   │   │   │   │   │   │       └── content: "\n      "
+    │   │   │   │   │   │   │   │
+    │   │   │   │   │   │   │   ├── subsequent: ∅
+    │   │   │   │   │   │   │   └── end_node:
+    │   │   │   │   │   │   │       └── @ ERBEndNode (location: (6:6)-(6:15))
+    │   │   │   │   │   │   │           ├── tag_opening: "<%" (location: (6:6)-(6:8))
+    │   │   │   │   │   │   │           ├── content: " end " (location: (6:8)-(6:13))
+    │   │   │   │   │   │   │           └── tag_closing: "%>" (location: (6:13)-(6:15))
+    │   │   │   │   │   │   │
+    │   │   │   │   │   │   │
+    │   │   │   │   │   │   └── @ HTMLTextNode (location: (6:15)-(7:4))
+    │   │   │   │   │   │       └── content: "\n    "
+    │   │   │   │   │   │
+    │   │   │   │   │   └── end_node:
+    │   │   │   │   │       └── @ ERBEndNode (location: (7:4)-(7:13))
+    │   │   │   │   │           ├── tag_opening: "<%" (location: (7:4)-(7:6))
+    │   │   │   │   │           ├── content: " end " (location: (7:6)-(7:11))
+    │   │   │   │   │           └── tag_closing: "%>" (location: (7:11)-(7:13))
+    │   │   │   │   │
+    │   │   │   │   │
+    │   │   │   │   └── @ HTMLTextNode (location: (7:13)-(8:2))
+    │   │   │   │       └── content: "\n  "
+    │   │   │   │
+    │   │   │   ├── close_tag:
+    │   │   │   │   └── @ HTMLCloseTagNode (location: (8:2)-(8:8))
+    │   │   │   │       ├── tag_opening: "</" (location: (8:2)-(8:4))
+    │   │   │   │       ├── tag_name: "div" (location: (8:4)-(8:7))
+    │   │   │   │       ├── children: []
+    │   │   │   │       └── tag_closing: ">" (location: (8:7)-(8:8))
+    │   │   │   │
+    │   │   │   ├── is_void: false
+    │   │   │   └── source: "HTML"
+    │   │   │
+    │   │   └── @ HTMLTextNode (location: (8:8)-(9:0))
+    │   │       └── content: "\n"
+    │   │
+    │   ├── subsequent:
+    │   │   └── @ ERBElseNode (location: (9:0)-(11:0))
+    │   │       ├── tag_opening: "<%" (location: (9:0)-(9:2))
+    │   │       ├── content: " else " (location: (9:2)-(9:8))
+    │   │       ├── tag_closing: "%>" (location: (9:8)-(9:10))
+    │   │       └── statements: (3 items)
+    │   │           ├── @ HTMLTextNode (location: (9:10)-(10:2))
+    │   │           │   └── content: "\n  "
+    │   │           │
+    │   │           ├── @ HTMLElementNode (location: (10:2)-(10:13))
+    │   │           │   ├── open_tag:
+    │   │           │   │   └── @ HTMLOpenTagNode (location: (10:2)-(10:7))
+    │   │           │   │       ├── tag_opening: "<" (location: (10:2)-(10:3))
+    │   │           │   │       ├── tag_name: "div" (location: (10:3)-(10:6))
+    │   │           │   │       ├── tag_closing: ">" (location: (10:6)-(10:7))
+    │   │           │   │       ├── children: []
+    │   │           │   │       └── is_void: false
+    │   │           │   │
+    │   │           │   ├── tag_name: "div" (location: (10:3)-(10:6))
+    │   │           │   ├── body: []
+    │   │           │   ├── close_tag:
+    │   │           │   │   └── @ HTMLCloseTagNode (location: (10:7)-(10:13))
+    │   │           │   │       ├── tag_opening: "</" (location: (10:7)-(10:9))
+    │   │           │   │       ├── tag_name: "div" (location: (10:9)-(10:12))
+    │   │           │   │       ├── children: []
+    │   │           │   │       └── tag_closing: ">" (location: (10:12)-(10:13))
+    │   │           │   │
+    │   │           │   ├── is_void: false
+    │   │           │   └── source: "HTML"
+    │   │           │
+    │   │           └── @ HTMLTextNode (location: (10:13)-(11:0))
+    │   │               └── content: "\n"
+    │   │
+    │   │
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (11:0)-(11:9))
+    │           ├── tag_opening: "<%" (location: (11:0)-(11:2))
+    │           ├── content: " end " (location: (11:2)-(11:7))
+    │           └── tag_closing: "%>" (location: (11:7)-(11:9))
+    │
+    │
+    └── @ HTMLTextNode (location: (11:9)-(12:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/conditional_open_tag_test/test_0037_html_comment_alongside_complete_element_in_branch_e271ebf7ee2b6deb36b33344d46bbfb3.txt
+++ b/test/snapshots/analyze/conditional_open_tag_test/test_0037_html_comment_alongside_complete_element_in_branch_e271ebf7ee2b6deb36b33344d46bbfb3.txt
@@ -1,0 +1,99 @@
+---
+source: "Analyze::ConditionalOpenTagTest#test_0037_html comment alongside complete element in branch"
+input: |2-
+<% if condition %>
+  <!-- a comment -->
+  <div></div>
+<% else %>
+  <div></div>
+<% end %>
+---
+@ DocumentNode (location: (1:0)-(7:0))
+└── children: (2 items)
+    ├── @ ERBIfNode (location: (1:0)-(6:9))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
+    │   ├── content: " if condition " (location: (1:2)-(1:16))
+    │   ├── tag_closing: "%>" (location: (1:16)-(1:18))
+    │   ├── then_keyword: ∅
+    │   ├── statements: (5 items)
+    │   │   ├── @ HTMLTextNode (location: (1:18)-(2:2))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ HTMLCommentNode (location: (2:2)-(2:20))
+    │   │   │   ├── comment_start: "<!--" (location: (2:2)-(2:6))
+    │   │   │   ├── children: (1 item)
+    │   │   │   │   └── @ LiteralNode (location: (2:6)-(2:17))
+    │   │   │   │       └── content: " a comment "
+    │   │   │   │
+    │   │   │   └── comment_end: "-->" (location: (2:17)-(2:20))
+    │   │   │
+    │   │   ├── @ HTMLTextNode (location: (2:20)-(3:2))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ HTMLElementNode (location: (3:2)-(3:13))
+    │   │   │   ├── open_tag:
+    │   │   │   │   └── @ HTMLOpenTagNode (location: (3:2)-(3:7))
+    │   │   │   │       ├── tag_opening: "<" (location: (3:2)-(3:3))
+    │   │   │   │       ├── tag_name: "div" (location: (3:3)-(3:6))
+    │   │   │   │       ├── tag_closing: ">" (location: (3:6)-(3:7))
+    │   │   │   │       ├── children: []
+    │   │   │   │       └── is_void: false
+    │   │   │   │
+    │   │   │   ├── tag_name: "div" (location: (3:3)-(3:6))
+    │   │   │   ├── body: []
+    │   │   │   ├── close_tag:
+    │   │   │   │   └── @ HTMLCloseTagNode (location: (3:7)-(3:13))
+    │   │   │   │       ├── tag_opening: "</" (location: (3:7)-(3:9))
+    │   │   │   │       ├── tag_name: "div" (location: (3:9)-(3:12))
+    │   │   │   │       ├── children: []
+    │   │   │   │       └── tag_closing: ">" (location: (3:12)-(3:13))
+    │   │   │   │
+    │   │   │   ├── is_void: false
+    │   │   │   └── source: "HTML"
+    │   │   │
+    │   │   └── @ HTMLTextNode (location: (3:13)-(4:0))
+    │   │       └── content: "\n"
+    │   │
+    │   ├── subsequent:
+    │   │   └── @ ERBElseNode (location: (4:0)-(6:0))
+    │   │       ├── tag_opening: "<%" (location: (4:0)-(4:2))
+    │   │       ├── content: " else " (location: (4:2)-(4:8))
+    │   │       ├── tag_closing: "%>" (location: (4:8)-(4:10))
+    │   │       └── statements: (3 items)
+    │   │           ├── @ HTMLTextNode (location: (4:10)-(5:2))
+    │   │           │   └── content: "\n  "
+    │   │           │
+    │   │           ├── @ HTMLElementNode (location: (5:2)-(5:13))
+    │   │           │   ├── open_tag:
+    │   │           │   │   └── @ HTMLOpenTagNode (location: (5:2)-(5:7))
+    │   │           │   │       ├── tag_opening: "<" (location: (5:2)-(5:3))
+    │   │           │   │       ├── tag_name: "div" (location: (5:3)-(5:6))
+    │   │           │   │       ├── tag_closing: ">" (location: (5:6)-(5:7))
+    │   │           │   │       ├── children: []
+    │   │           │   │       └── is_void: false
+    │   │           │   │
+    │   │           │   ├── tag_name: "div" (location: (5:3)-(5:6))
+    │   │           │   ├── body: []
+    │   │           │   ├── close_tag:
+    │   │           │   │   └── @ HTMLCloseTagNode (location: (5:7)-(5:13))
+    │   │           │   │       ├── tag_opening: "</" (location: (5:7)-(5:9))
+    │   │           │   │       ├── tag_name: "div" (location: (5:9)-(5:12))
+    │   │           │   │       ├── children: []
+    │   │           │   │       └── tag_closing: ">" (location: (5:12)-(5:13))
+    │   │           │   │
+    │   │           │   ├── is_void: false
+    │   │           │   └── source: "HTML"
+    │   │           │
+    │   │           └── @ HTMLTextNode (location: (5:13)-(6:0))
+    │   │               └── content: "\n"
+    │   │
+    │   │
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (6:0)-(6:9))
+    │           ├── tag_opening: "<%" (location: (6:0)-(6:2))
+    │           ├── content: " end " (location: (6:2)-(6:7))
+    │           └── tag_closing: "%>" (location: (6:7)-(6:9))
+    │
+    │
+    └── @ HTMLTextNode (location: (6:9)-(7:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/conditional_open_tag_test/test_0038_erb_output_tag_alongside_complete_element_in_branch_81c49596fdcaa432e9b3ef127410a0a9.txt
+++ b/test/snapshots/analyze/conditional_open_tag_test/test_0038_erb_output_tag_alongside_complete_element_in_branch_81c49596fdcaa432e9b3ef127410a0a9.txt
@@ -1,0 +1,98 @@
+---
+source: "Analyze::ConditionalOpenTagTest#test_0038_erb output tag alongside complete element in branch"
+input: |2-
+<% if condition %>
+  <%= some_helper %>
+  <div></div>
+<% else %>
+  <div></div>
+<% end %>
+---
+@ DocumentNode (location: (1:0)-(7:0))
+└── children: (2 items)
+    ├── @ ERBIfNode (location: (1:0)-(6:9))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
+    │   ├── content: " if condition " (location: (1:2)-(1:16))
+    │   ├── tag_closing: "%>" (location: (1:16)-(1:18))
+    │   ├── then_keyword: ∅
+    │   ├── statements: (5 items)
+    │   │   ├── @ HTMLTextNode (location: (1:18)-(2:2))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ ERBContentNode (location: (2:2)-(2:20))
+    │   │   │   ├── tag_opening: "<%=" (location: (2:2)-(2:5))
+    │   │   │   ├── content: " some_helper " (location: (2:5)-(2:18))
+    │   │   │   ├── tag_closing: "%>" (location: (2:18)-(2:20))
+    │   │   │   ├── parsed: true
+    │   │   │   └── valid: true
+    │   │   │
+    │   │   ├── @ HTMLTextNode (location: (2:20)-(3:2))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ HTMLElementNode (location: (3:2)-(3:13))
+    │   │   │   ├── open_tag:
+    │   │   │   │   └── @ HTMLOpenTagNode (location: (3:2)-(3:7))
+    │   │   │   │       ├── tag_opening: "<" (location: (3:2)-(3:3))
+    │   │   │   │       ├── tag_name: "div" (location: (3:3)-(3:6))
+    │   │   │   │       ├── tag_closing: ">" (location: (3:6)-(3:7))
+    │   │   │   │       ├── children: []
+    │   │   │   │       └── is_void: false
+    │   │   │   │
+    │   │   │   ├── tag_name: "div" (location: (3:3)-(3:6))
+    │   │   │   ├── body: []
+    │   │   │   ├── close_tag:
+    │   │   │   │   └── @ HTMLCloseTagNode (location: (3:7)-(3:13))
+    │   │   │   │       ├── tag_opening: "</" (location: (3:7)-(3:9))
+    │   │   │   │       ├── tag_name: "div" (location: (3:9)-(3:12))
+    │   │   │   │       ├── children: []
+    │   │   │   │       └── tag_closing: ">" (location: (3:12)-(3:13))
+    │   │   │   │
+    │   │   │   ├── is_void: false
+    │   │   │   └── source: "HTML"
+    │   │   │
+    │   │   └── @ HTMLTextNode (location: (3:13)-(4:0))
+    │   │       └── content: "\n"
+    │   │
+    │   ├── subsequent:
+    │   │   └── @ ERBElseNode (location: (4:0)-(6:0))
+    │   │       ├── tag_opening: "<%" (location: (4:0)-(4:2))
+    │   │       ├── content: " else " (location: (4:2)-(4:8))
+    │   │       ├── tag_closing: "%>" (location: (4:8)-(4:10))
+    │   │       └── statements: (3 items)
+    │   │           ├── @ HTMLTextNode (location: (4:10)-(5:2))
+    │   │           │   └── content: "\n  "
+    │   │           │
+    │   │           ├── @ HTMLElementNode (location: (5:2)-(5:13))
+    │   │           │   ├── open_tag:
+    │   │           │   │   └── @ HTMLOpenTagNode (location: (5:2)-(5:7))
+    │   │           │   │       ├── tag_opening: "<" (location: (5:2)-(5:3))
+    │   │           │   │       ├── tag_name: "div" (location: (5:3)-(5:6))
+    │   │           │   │       ├── tag_closing: ">" (location: (5:6)-(5:7))
+    │   │           │   │       ├── children: []
+    │   │           │   │       └── is_void: false
+    │   │           │   │
+    │   │           │   ├── tag_name: "div" (location: (5:3)-(5:6))
+    │   │           │   ├── body: []
+    │   │           │   ├── close_tag:
+    │   │           │   │   └── @ HTMLCloseTagNode (location: (5:7)-(5:13))
+    │   │           │   │       ├── tag_opening: "</" (location: (5:7)-(5:9))
+    │   │           │   │       ├── tag_name: "div" (location: (5:9)-(5:12))
+    │   │           │   │       ├── children: []
+    │   │           │   │       └── tag_closing: ">" (location: (5:12)-(5:13))
+    │   │           │   │
+    │   │           │   ├── is_void: false
+    │   │           │   └── source: "HTML"
+    │   │           │
+    │   │           └── @ HTMLTextNode (location: (5:13)-(6:0))
+    │   │               └── content: "\n"
+    │   │
+    │   │
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (6:0)-(6:9))
+    │           ├── tag_opening: "<%" (location: (6:0)-(6:2))
+    │           ├── content: " end " (location: (6:2)-(6:7))
+    │           └── tag_closing: "%>" (location: (6:7)-(6:9))
+    │
+    │
+    └── @ HTMLTextNode (location: (6:9)-(7:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/conditional_open_tag_test/test_0039_both_branches_have_erb_control_flow_with_complete_elements_a46422346454f32f50ca01b5c4671ed6.txt
+++ b/test/snapshots/analyze/conditional_open_tag_test/test_0039_both_branches_have_erb_control_flow_with_complete_elements_a46422346454f32f50ca01b5c4671ed6.txt
@@ -1,0 +1,131 @@
+---
+source: "Analyze::ConditionalOpenTagTest#test_0039_both branches have erb control flow with complete elements"
+input: |2-
+<% if condition %>
+  <div>
+    <% if inner %><% end %>
+  </div>
+<% else %>
+  <div>
+    <% unless inner %><% end %>
+  </div>
+<% end %>
+---
+@ DocumentNode (location: (1:0)-(10:0))
+└── children: (2 items)
+    ├── @ ERBIfNode (location: (1:0)-(9:9))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
+    │   ├── content: " if condition " (location: (1:2)-(1:16))
+    │   ├── tag_closing: "%>" (location: (1:16)-(1:18))
+    │   ├── then_keyword: ∅
+    │   ├── statements: (3 items)
+    │   │   ├── @ HTMLTextNode (location: (1:18)-(2:2))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ HTMLElementNode (location: (2:2)-(4:8))
+    │   │   │   ├── open_tag:
+    │   │   │   │   └── @ HTMLOpenTagNode (location: (2:2)-(2:7))
+    │   │   │   │       ├── tag_opening: "<" (location: (2:2)-(2:3))
+    │   │   │   │       ├── tag_name: "div" (location: (2:3)-(2:6))
+    │   │   │   │       ├── tag_closing: ">" (location: (2:6)-(2:7))
+    │   │   │   │       ├── children: []
+    │   │   │   │       └── is_void: false
+    │   │   │   │
+    │   │   │   ├── tag_name: "div" (location: (2:3)-(2:6))
+    │   │   │   ├── body: (3 items)
+    │   │   │   │   ├── @ HTMLTextNode (location: (2:7)-(3:4))
+    │   │   │   │   │   └── content: "\n    "
+    │   │   │   │   │
+    │   │   │   │   ├── @ ERBIfNode (location: (3:4)-(3:27))
+    │   │   │   │   │   ├── tag_opening: "<%" (location: (3:4)-(3:6))
+    │   │   │   │   │   ├── content: " if inner " (location: (3:6)-(3:16))
+    │   │   │   │   │   ├── tag_closing: "%>" (location: (3:16)-(3:18))
+    │   │   │   │   │   ├── then_keyword: ∅
+    │   │   │   │   │   ├── statements: []
+    │   │   │   │   │   ├── subsequent: ∅
+    │   │   │   │   │   └── end_node:
+    │   │   │   │   │       └── @ ERBEndNode (location: (3:18)-(3:27))
+    │   │   │   │   │           ├── tag_opening: "<%" (location: (3:18)-(3:20))
+    │   │   │   │   │           ├── content: " end " (location: (3:20)-(3:25))
+    │   │   │   │   │           └── tag_closing: "%>" (location: (3:25)-(3:27))
+    │   │   │   │   │
+    │   │   │   │   │
+    │   │   │   │   └── @ HTMLTextNode (location: (3:27)-(4:2))
+    │   │   │   │       └── content: "\n  "
+    │   │   │   │
+    │   │   │   ├── close_tag:
+    │   │   │   │   └── @ HTMLCloseTagNode (location: (4:2)-(4:8))
+    │   │   │   │       ├── tag_opening: "</" (location: (4:2)-(4:4))
+    │   │   │   │       ├── tag_name: "div" (location: (4:4)-(4:7))
+    │   │   │   │       ├── children: []
+    │   │   │   │       └── tag_closing: ">" (location: (4:7)-(4:8))
+    │   │   │   │
+    │   │   │   ├── is_void: false
+    │   │   │   └── source: "HTML"
+    │   │   │
+    │   │   └── @ HTMLTextNode (location: (4:8)-(5:0))
+    │   │       └── content: "\n"
+    │   │
+    │   ├── subsequent:
+    │   │   └── @ ERBElseNode (location: (5:0)-(9:0))
+    │   │       ├── tag_opening: "<%" (location: (5:0)-(5:2))
+    │   │       ├── content: " else " (location: (5:2)-(5:8))
+    │   │       ├── tag_closing: "%>" (location: (5:8)-(5:10))
+    │   │       └── statements: (3 items)
+    │   │           ├── @ HTMLTextNode (location: (5:10)-(6:2))
+    │   │           │   └── content: "\n  "
+    │   │           │
+    │   │           ├── @ HTMLElementNode (location: (6:2)-(8:8))
+    │   │           │   ├── open_tag:
+    │   │           │   │   └── @ HTMLOpenTagNode (location: (6:2)-(6:7))
+    │   │           │   │       ├── tag_opening: "<" (location: (6:2)-(6:3))
+    │   │           │   │       ├── tag_name: "div" (location: (6:3)-(6:6))
+    │   │           │   │       ├── tag_closing: ">" (location: (6:6)-(6:7))
+    │   │           │   │       ├── children: []
+    │   │           │   │       └── is_void: false
+    │   │           │   │
+    │   │           │   ├── tag_name: "div" (location: (6:3)-(6:6))
+    │   │           │   ├── body: (3 items)
+    │   │           │   │   ├── @ HTMLTextNode (location: (6:7)-(7:4))
+    │   │           │   │   │   └── content: "\n    "
+    │   │           │   │   │
+    │   │           │   │   ├── @ ERBUnlessNode (location: (7:4)-(7:31))
+    │   │           │   │   │   ├── tag_opening: "<%" (location: (7:4)-(7:6))
+    │   │           │   │   │   ├── content: " unless inner " (location: (7:6)-(7:20))
+    │   │           │   │   │   ├── tag_closing: "%>" (location: (7:20)-(7:22))
+    │   │           │   │   │   ├── then_keyword: ∅
+    │   │           │   │   │   ├── statements: []
+    │   │           │   │   │   ├── else_clause: ∅
+    │   │           │   │   │   └── end_node:
+    │   │           │   │   │       └── @ ERBEndNode (location: (7:22)-(7:31))
+    │   │           │   │   │           ├── tag_opening: "<%" (location: (7:22)-(7:24))
+    │   │           │   │   │           ├── content: " end " (location: (7:24)-(7:29))
+    │   │           │   │   │           └── tag_closing: "%>" (location: (7:29)-(7:31))
+    │   │           │   │   │
+    │   │           │   │   │
+    │   │           │   │   └── @ HTMLTextNode (location: (7:31)-(8:2))
+    │   │           │   │       └── content: "\n  "
+    │   │           │   │
+    │   │           │   ├── close_tag:
+    │   │           │   │   └── @ HTMLCloseTagNode (location: (8:2)-(8:8))
+    │   │           │   │       ├── tag_opening: "</" (location: (8:2)-(8:4))
+    │   │           │   │       ├── tag_name: "div" (location: (8:4)-(8:7))
+    │   │           │   │       ├── children: []
+    │   │           │   │       └── tag_closing: ">" (location: (8:7)-(8:8))
+    │   │           │   │
+    │   │           │   ├── is_void: false
+    │   │           │   └── source: "HTML"
+    │   │           │
+    │   │           └── @ HTMLTextNode (location: (8:8)-(9:0))
+    │   │               └── content: "\n"
+    │   │
+    │   │
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (9:0)-(9:9))
+    │           ├── tag_opening: "<%" (location: (9:0)-(9:2))
+    │           ├── content: " end " (location: (9:2)-(9:7))
+    │           └── tag_closing: "%>" (location: (9:7)-(9:9))
+    │
+    │
+    └── @ HTMLTextNode (location: (9:9)-(10:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/conditional_open_tag_test/test_0040_unless_else_with_erb_control_flow_inside_branch_5bc080ab5a9fba89a77f29376af95077.txt
+++ b/test/snapshots/analyze/conditional_open_tag_test/test_0040_unless_else_with_erb_control_flow_inside_branch_5bc080ab5a9fba89a77f29376af95077.txt
@@ -1,0 +1,109 @@
+---
+source: "Analyze::ConditionalOpenTagTest#test_0040_unless/else with erb control flow inside branch"
+input: |2-
+<% unless condition %>
+  <div>
+    <% if inner %><% end %>
+  </div>
+<% else %>
+  <div></div>
+<% end %>
+---
+@ DocumentNode (location: (1:0)-(8:0))
+└── children: (2 items)
+    ├── @ ERBUnlessNode (location: (1:0)-(7:9))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
+    │   ├── content: " unless condition " (location: (1:2)-(1:20))
+    │   ├── tag_closing: "%>" (location: (1:20)-(1:22))
+    │   ├── then_keyword: ∅
+    │   ├── statements: (3 items)
+    │   │   ├── @ HTMLTextNode (location: (1:22)-(2:2))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ HTMLElementNode (location: (2:2)-(4:8))
+    │   │   │   ├── open_tag:
+    │   │   │   │   └── @ HTMLOpenTagNode (location: (2:2)-(2:7))
+    │   │   │   │       ├── tag_opening: "<" (location: (2:2)-(2:3))
+    │   │   │   │       ├── tag_name: "div" (location: (2:3)-(2:6))
+    │   │   │   │       ├── tag_closing: ">" (location: (2:6)-(2:7))
+    │   │   │   │       ├── children: []
+    │   │   │   │       └── is_void: false
+    │   │   │   │
+    │   │   │   ├── tag_name: "div" (location: (2:3)-(2:6))
+    │   │   │   ├── body: (3 items)
+    │   │   │   │   ├── @ HTMLTextNode (location: (2:7)-(3:4))
+    │   │   │   │   │   └── content: "\n    "
+    │   │   │   │   │
+    │   │   │   │   ├── @ ERBIfNode (location: (3:4)-(3:27))
+    │   │   │   │   │   ├── tag_opening: "<%" (location: (3:4)-(3:6))
+    │   │   │   │   │   ├── content: " if inner " (location: (3:6)-(3:16))
+    │   │   │   │   │   ├── tag_closing: "%>" (location: (3:16)-(3:18))
+    │   │   │   │   │   ├── then_keyword: ∅
+    │   │   │   │   │   ├── statements: []
+    │   │   │   │   │   ├── subsequent: ∅
+    │   │   │   │   │   └── end_node:
+    │   │   │   │   │       └── @ ERBEndNode (location: (3:18)-(3:27))
+    │   │   │   │   │           ├── tag_opening: "<%" (location: (3:18)-(3:20))
+    │   │   │   │   │           ├── content: " end " (location: (3:20)-(3:25))
+    │   │   │   │   │           └── tag_closing: "%>" (location: (3:25)-(3:27))
+    │   │   │   │   │
+    │   │   │   │   │
+    │   │   │   │   └── @ HTMLTextNode (location: (3:27)-(4:2))
+    │   │   │   │       └── content: "\n  "
+    │   │   │   │
+    │   │   │   ├── close_tag:
+    │   │   │   │   └── @ HTMLCloseTagNode (location: (4:2)-(4:8))
+    │   │   │   │       ├── tag_opening: "</" (location: (4:2)-(4:4))
+    │   │   │   │       ├── tag_name: "div" (location: (4:4)-(4:7))
+    │   │   │   │       ├── children: []
+    │   │   │   │       └── tag_closing: ">" (location: (4:7)-(4:8))
+    │   │   │   │
+    │   │   │   ├── is_void: false
+    │   │   │   └── source: "HTML"
+    │   │   │
+    │   │   └── @ HTMLTextNode (location: (4:8)-(5:0))
+    │   │       └── content: "\n"
+    │   │
+    │   ├── else_clause:
+    │   │   └── @ ERBElseNode (location: (5:0)-(7:0))
+    │   │       ├── tag_opening: "<%" (location: (5:0)-(5:2))
+    │   │       ├── content: " else " (location: (5:2)-(5:8))
+    │   │       ├── tag_closing: "%>" (location: (5:8)-(5:10))
+    │   │       └── statements: (3 items)
+    │   │           ├── @ HTMLTextNode (location: (5:10)-(6:2))
+    │   │           │   └── content: "\n  "
+    │   │           │
+    │   │           ├── @ HTMLElementNode (location: (6:2)-(6:13))
+    │   │           │   ├── open_tag:
+    │   │           │   │   └── @ HTMLOpenTagNode (location: (6:2)-(6:7))
+    │   │           │   │       ├── tag_opening: "<" (location: (6:2)-(6:3))
+    │   │           │   │       ├── tag_name: "div" (location: (6:3)-(6:6))
+    │   │           │   │       ├── tag_closing: ">" (location: (6:6)-(6:7))
+    │   │           │   │       ├── children: []
+    │   │           │   │       └── is_void: false
+    │   │           │   │
+    │   │           │   ├── tag_name: "div" (location: (6:3)-(6:6))
+    │   │           │   ├── body: []
+    │   │           │   ├── close_tag:
+    │   │           │   │   └── @ HTMLCloseTagNode (location: (6:7)-(6:13))
+    │   │           │   │       ├── tag_opening: "</" (location: (6:7)-(6:9))
+    │   │           │   │       ├── tag_name: "div" (location: (6:9)-(6:12))
+    │   │           │   │       ├── children: []
+    │   │           │   │       └── tag_closing: ">" (location: (6:12)-(6:13))
+    │   │           │   │
+    │   │           │   ├── is_void: false
+    │   │           │   └── source: "HTML"
+    │   │           │
+    │   │           └── @ HTMLTextNode (location: (6:13)-(7:0))
+    │   │               └── content: "\n"
+    │   │
+    │   │
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (7:0)-(7:9))
+    │           ├── tag_opening: "<%" (location: (7:0)-(7:2))
+    │           ├── content: " end " (location: (7:2)-(7:7))
+    │           └── tag_closing: "%>" (location: (7:7)-(7:9))
+    │
+    │
+    └── @ HTMLTextNode (location: (7:9)-(8:0))
+        └── content: "\n"


### PR DESCRIPTION
This pull request updates the conditional element analysis passes to no longer produce false `ConditionalElementMultipleTagsError` errors on valid templates containing complete HTML elements inside ERB control flow branches.

The following template now parses without any errors:
```html+erb
<% if true %>
  <% if true %>
    <div>
      <div></div>
      <% if true %><% end %>
    </div>
  <% else %>
    <div></div>
  <% end %>
<% end %>
```

Related #1153 
Related #1146
Related #1208

Resolves #1239