### PR TITLE
Ruby: Don't run tests with forking threads by default

### DIFF
--- a/bin/test_debug
+++ b/bin/test_debug
@@ -4,6 +4,6 @@ set -e  # Exit on error
 
 make all
 ./run_herb_tests
-NO_TIMEOUT=true bundle exec rake test
+FORK_TESTS=true bundle exec rake test
 
 echo "Tests successful!"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,7 +9,11 @@ require "minitest/spec"
 
 require "active_support/core_ext/string/output_safety"
 
-require_relative "fork_helper" if ENV["NO_TIMEOUT"].nil?
+if ENV["FORK_TESTS"]
+  require_relative "fork_helper"
+else
+  puts "TIP: If a segfault in the native C extension crashes the test runner, run with FORK_TESTS=true to isolate each test in a forked process and identify which test causes the crash."
+end
 require_relative "snapshot_utils"
 
 Minitest::Spec::DSL.send(:alias_method, :test, :it)


### PR DESCRIPTION
This pull request updates the Ruby test suite to not require the `fork_helper` in a normal run. Initially, we added the forking helpers so we could isolate segfaults in the Parser/Ruby native extension when running the full test suite.

But this hasn't been happening a lot anymore, so the more than 2x slowdown is not worth to have on regular runs. 

Instead, we rename/flip the `NO_TIMEOUT` to `FORK_TESTS`. If we are not forking, we are now showing a message to remind people that they could be running the tests in forking mode by passing the new `FORK_TESTS` environment variable to isolate a potential crash/segfault in one of the tests.