### PR TITLE
Parser: Allow inline `case/when` and `case/in` in strict mode

### DIFF
--- a/bin/force_update_snapshots
+++ b/bin/force_update_snapshots
@@ -2,7 +2,7 @@
 
 set -e  # Exit on error
 
-FORCE_UPDATE_SNAPSHOTS=true bundle exec rake test
+FORCE_UPDATE_SNAPSHOTS=true bundle exec rake test:all
 
 echo ""
 echo "Force updated snapshots!"

--- a/config.yml
+++ b/config.yml
@@ -164,7 +164,7 @@ errors:
 
     - name: ERBCaseWithConditionsError
       message:
-        template: "A `case` statement with `when`/`in` in a single ERB tag cannot be formatted. Use separate tags for `case` and its conditions."
+        template: "A `case` statement with `when`/`in` conditions in a single ERB tag cannot be reliably parsed, compiled, and formatted. Use separate ERB tags for `case` and its conditions (e.g., `<% case x %>` followed by `<% when y %>`)."
         arguments: []
 
       fields: []

--- a/lib/herb/engine/compiler.rb
+++ b/lib/herb/engine/compiler.rb
@@ -194,7 +194,9 @@ module Herb
       end
 
       def visit_erb_control_node(node, &_block)
-        apply_trim(node, node.content.value.strip)
+        if node.content
+          apply_trim(node, node.content.value.strip)
+        end
 
         yield if block_given?
       end

--- a/src/analyze/helpers.c
+++ b/src/analyze/helpers.c
@@ -6,79 +6,84 @@
 #include "../include/util/string.h"
 
 bool has_if_node(analyzed_ruby_T* analyzed) {
-  return analyzed->if_node_count > 0;
+  return analyzed && analyzed->if_node_count > 0;
 }
 
 bool has_elsif_node(analyzed_ruby_T* analyzed) {
-  return analyzed->elsif_node_count > 0;
+  return analyzed && analyzed->elsif_node_count > 0;
 }
 
 bool has_else_node(analyzed_ruby_T* analyzed) {
-  return analyzed->else_node_count > 0;
+  return analyzed && analyzed->else_node_count > 0;
 }
 
 bool has_end(analyzed_ruby_T* analyzed) {
-  return analyzed->end_count > 0;
+  return analyzed && analyzed->end_count > 0;
 }
 
 bool has_block_node(analyzed_ruby_T* analyzed) {
-  return analyzed->block_node_count > 0;
+  return analyzed && analyzed->block_node_count > 0;
 }
 
 bool has_block_closing(analyzed_ruby_T* analyzed) {
-  return analyzed->block_closing_count > 0;
+  return analyzed && analyzed->block_closing_count > 0;
 }
 
 bool has_case_node(analyzed_ruby_T* analyzed) {
-  return analyzed->case_node_count > 0;
+  return analyzed && analyzed->case_node_count > 0;
 }
 
 bool has_case_match_node(analyzed_ruby_T* analyzed) {
-  return analyzed->case_match_node_count > 0;
+  return analyzed && analyzed->case_match_node_count > 0;
 }
 
 bool has_when_node(analyzed_ruby_T* analyzed) {
-  return analyzed->when_node_count > 0;
+  return analyzed && analyzed->when_node_count > 0;
 }
 
 bool has_in_node(analyzed_ruby_T* analyzed) {
-  return analyzed->in_node_count > 0;
+  return analyzed && analyzed->in_node_count > 0;
 }
 
 bool has_for_node(analyzed_ruby_T* analyzed) {
-  return analyzed->for_node_count > 0;
+  return analyzed && analyzed->for_node_count > 0;
 }
 
 bool has_while_node(analyzed_ruby_T* analyzed) {
-  return analyzed->while_node_count > 0;
+  return analyzed && analyzed->while_node_count > 0;
 }
 
 bool has_until_node(analyzed_ruby_T* analyzed) {
-  return analyzed->until_node_count > 0;
+  return analyzed && analyzed->until_node_count > 0;
 }
 
 bool has_begin_node(analyzed_ruby_T* analyzed) {
-  return analyzed->begin_node_count > 0;
+  return analyzed && analyzed->begin_node_count > 0;
 }
 
 bool has_rescue_node(analyzed_ruby_T* analyzed) {
-  return analyzed->rescue_node_count > 0;
+  return analyzed && analyzed->rescue_node_count > 0;
 }
 
 bool has_ensure_node(analyzed_ruby_T* analyzed) {
-  return analyzed->ensure_node_count > 0;
+  return analyzed && analyzed->ensure_node_count > 0;
 }
 
 bool has_unless_node(analyzed_ruby_T* analyzed) {
-  return analyzed->unless_node_count > 0;
+  return analyzed && analyzed->unless_node_count > 0;
 }
 
 bool has_yield_node(analyzed_ruby_T* analyzed) {
-  return analyzed->yield_node_count > 0;
+  return analyzed && analyzed->yield_node_count > 0;
 }
 
 bool has_then_keyword(analyzed_ruby_T* analyzed) {
-  return analyzed->then_keyword_count > 0;
+  return analyzed && analyzed->then_keyword_count > 0;
+}
+
+bool has_inline_case_condition(analyzed_ruby_T* analyzed) {
+  return (has_case_node(analyzed) && has_when_node(analyzed))
+      || (has_case_match_node(analyzed) && has_in_node(analyzed));
 }
 
 bool has_error_message(analyzed_ruby_T* analyzed, const char* message) {

--- a/src/herb.c
+++ b/src/herb.c
@@ -44,7 +44,7 @@ HERB_EXPORTED_FUNCTION AST_DOCUMENT_NODE_T* herb_parse(const char* source, const
 
   herb_parser_deinit(&parser);
 
-  if (parser_options.analyze) { herb_analyze_parse_tree(document, source, parser_options.strict); }
+  if (parser_options.analyze) { herb_analyze_parse_tree(document, source, &parser_options); }
 
   return document;
 }

--- a/src/include/analyze/analyze.h
+++ b/src/include/analyze/analyze.h
@@ -3,6 +3,7 @@
 
 #include "analyzed_ruby.h"
 #include "../ast_nodes.h"
+#include "../parser.h"
 #include "../util/hb_array.h"
 
 typedef struct ANALYZE_RUBY_CONTEXT_STRUCT {
@@ -39,7 +40,7 @@ typedef struct {
 } invalid_erb_context_T;
 
 void herb_analyze_parse_errors(AST_DOCUMENT_NODE_T* document, const char* source);
-void herb_analyze_parse_tree(AST_DOCUMENT_NODE_T* document, const char* source, bool strict);
+void herb_analyze_parse_tree(AST_DOCUMENT_NODE_T* document, const char* source, const parser_options_T* options);
 
 hb_array_T* rewrite_node_array(AST_NODE_T* node, hb_array_T* array, analyze_ruby_context_T* context);
 bool transform_erb_nodes(const AST_NODE_T* node, void* data);

--- a/src/include/analyze/helpers.h
+++ b/src/include/analyze/helpers.h
@@ -26,6 +26,7 @@ bool has_ensure_node(analyzed_ruby_T* analyzed);
 bool has_unless_node(analyzed_ruby_T* analyzed);
 bool has_yield_node(analyzed_ruby_T* analyzed);
 bool has_then_keyword(analyzed_ruby_T* analyzed);
+bool has_inline_case_condition(analyzed_ruby_T* analyzed);
 
 bool has_error_message(analyzed_ruby_T* anlayzed, const char* message);
 

--- a/src/include/parser.h
+++ b/src/include/parser.h
@@ -23,7 +23,7 @@ typedef struct PARSER_OPTIONS_STRUCT {
 
 typedef struct MATCH_TAGS_CONTEXT_STRUCT {
   hb_array_T* errors;
-  bool strict;
+  const parser_options_T* options;
 } match_tags_context_T;
 
 extern const parser_options_T HERB_DEFAULT_PARSER_OPTIONS;
@@ -45,10 +45,10 @@ void herb_parser_init(parser_T* parser, lexer_T* lexer, parser_options_T options
 
 AST_DOCUMENT_NODE_T* herb_parser_parse(parser_T* parser);
 
-void herb_parser_match_html_tags_post_analyze(AST_DOCUMENT_NODE_T* document, bool strict);
+void herb_parser_match_html_tags_post_analyze(AST_DOCUMENT_NODE_T* document, const parser_options_T* options);
 void herb_parser_deinit(parser_T* parser);
 
-void match_tags_in_node_array(hb_array_T* nodes, hb_array_T* errors, bool strict);
+void match_tags_in_node_array(hb_array_T* nodes, hb_array_T* errors, const parser_options_T* options);
 bool match_tags_visitor(const AST_NODE_T* node, void* data);
 
 #endif

--- a/templates/src/parser_match_tags.c.erb
+++ b/templates/src/parser_match_tags.c.erb
@@ -25,7 +25,7 @@ bool match_tags_visitor(const AST_NODE_T* node, void* data) {
 
       <%- array_fields.each do |field| -%>
       if (<%= node.human %>-><%= field.name %> != NULL) {
-        match_tags_in_node_array(<%= node.human %>-><%= field.name %>, context->errors, context->strict);
+        match_tags_in_node_array(<%= node.human %>-><%= field.name %>, context->errors, context->options);
       }
       <%- end -%>
       <%- single_node_fields.each do |field| -%>

--- a/test/engine/evaluation/case_test.rb
+++ b/test/engine/evaluation/case_test.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require_relative "../../test_helper"
+require_relative "../../snapshot_utils"
+require_relative "../../../lib/herb/engine"
+
+module Engine
+  class CaseTest < Minitest::Spec
+    include SnapshotUtils
+
+    test "case when in same ERB tag" do
+      template = <<~ERB
+        <% case status when "pending" %>
+          <span>Pending</span>
+        <% when "approved" %>
+          <span>Approved</span>
+        <% else %>
+          <span>Unknown</span>
+        <% end %>
+      ERB
+
+      error = assert_raises(Herb::Engine::CompilationError) do
+        Herb::Engine.new(template, strict: true)
+      end
+
+      assert_includes error.message, "ERBCaseWithConditions"
+
+      assert_evaluated_snapshot(template, { status: "pending" }, { escape: false, strict: false })
+      assert_evaluated_snapshot(template, { status: "approved" }, { escape: false, strict: false })
+      assert_evaluated_snapshot(template, { status: "other" }, { escape: false, strict: false })
+    end
+
+    test "case in pattern in same ERB tag" do
+      template = <<~ERB
+        <% case count in 1 %>
+          <span>One</span>
+        <% in 2 %>
+          <span>Two</span>
+        <% else %>
+          <span>Other</span>
+        <% end %>
+      ERB
+
+      error = assert_raises(Herb::Engine::CompilationError) do
+        Herb::Engine.new(template, strict: true)
+      end
+
+      assert_includes error.message, "ERBCaseWithConditions"
+    end
+
+    test "case when on newline in same ERB tag" do
+      template = <<~ERB
+        <% case status
+           when "pending" %>
+          <span>Pending</span>
+        <% when "approved" %>
+          <span>Approved</span>
+        <% end %>
+      ERB
+
+      error = assert_raises(Herb::Engine::CompilationError) do
+        Herb::Engine.new(template, strict: true)
+      end
+
+      assert_includes error.message, "ERBCaseWithConditions"
+
+      assert_evaluated_snapshot(template, { status: "pending" }, { escape: false, strict: false })
+      assert_evaluated_snapshot(template, { status: "approved" }, { escape: false, strict: false })
+    end
+
+    test "case in on newline in same ERB tag" do
+      template = <<~ERB
+        <% case count
+           in 1 %>
+          <span>One</span>
+        <% in 2 %>
+          <span>Two</span>
+        <% end %>
+      ERB
+
+      error = assert_raises(Herb::Engine::CompilationError) do
+        Herb::Engine.new(template, strict: true)
+      end
+
+      assert_includes error.message, "ERBCaseWithConditions"
+
+      assert_evaluated_snapshot(template, { count: 1 }, { escape: false, strict: false })
+      assert_evaluated_snapshot(template, { count: 2 }, { escape: false, strict: false })
+    end
+  end
+end

--- a/test/engine/evaluation/heredoc_test.rb
+++ b/test/engine/evaluation/heredoc_test.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require_relative "../../test_helper"
+require_relative "../../snapshot_utils"
+require_relative "../../../lib/herb/engine"
+
+module Engine
+  class HeredocTest < Minitest::Spec
+    include SnapshotUtils
+
+    test "heredoc in code tag" do
+      template = <<~ERB
+        <%
+          text = <<~TEXT
+            Hello, world!
+          TEXT
+        %>
+        <%= text %>
+      ERB
+
+      assert_evaluated_snapshot(template, {}, { escape: false })
+    end
+  end
+end

--- a/test/engine/evaluation_test.rb
+++ b/test/engine/evaluation_test.rb
@@ -484,18 +484,5 @@ module Engine
 
       assert_evaluated_snapshot(template, { some_condition: false }, { escape: false })
     end
-
-    test "heredoc in code tag" do
-      template = <<~ERB
-        <%
-          text = <<~TEXT
-            Hello, world!
-          TEXT
-        %>
-        <%= text %>
-      ERB
-
-      assert_evaluated_snapshot(template, {}, { escape: false })
-    end
   end
 end

--- a/test/parser/multiple_control_flow_test.rb
+++ b/test/parser/multiple_control_flow_test.rb
@@ -363,23 +363,57 @@ module Parser
     end
 
     test "case and when in same ERB tag" do
-      assert_parsed_snapshot(<<~ERB)
+      template = <<~ERB
         <% case variable when "a" %>
           A
         <% when "b" %>
           B
         <% end %>
       ERB
+
+      assert_parsed_snapshot(template, strict: true)
+      assert_parsed_snapshot(template, strict: false)
     end
 
     test "case in pattern in same ERB tag" do
-      assert_parsed_snapshot(<<~ERB)
+      template = <<~ERB
         <% case value in 1 %>
           One
         <% in 2 %>
           Two
         <% end %>
       ERB
+
+      assert_parsed_snapshot(template, strict: true)
+      assert_parsed_snapshot(template, strict: false)
+    end
+
+    test "case and when on newline in same ERB tag" do
+      template = <<~ERB
+        <% case variable
+           when "a" %>
+          A
+        <% when "b" %>
+          B
+        <% end %>
+      ERB
+
+      assert_parsed_snapshot(template, strict: true)
+      assert_parsed_snapshot(template, strict: false)
+    end
+
+    test "case in pattern on newline in same ERB tag" do
+      template = <<~ERB
+        <% case value
+           in 1 %>
+          One
+        <% in 2 %>
+          Two
+        <% end %>
+      ERB
+
+      assert_parsed_snapshot(template, strict: true)
+      assert_parsed_snapshot(template, strict: false)
     end
   end
 end

--- a/test/snapshots/engine/case_test/test_0001_case_when_in_same_ERB_tag_23aed430da2e0530eba76d6ff44d4f48.txt
+++ b/test/snapshots/engine/case_test/test_0001_case_when_in_same_ERB_tag_23aed430da2e0530eba76d6ff44d4f48.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::CaseTest#test_0001_case when in same ERB tag"
+input: "{source: \"<% case status when \\\"pending\\\" %>\\n  <span>Pending</span>\\n<% when \\\"approved\\\" %>\\n  <span>Approved</span>\\n<% else %>\\n  <span>Unknown</span>\\n<% end %>\\n\", locals: {status: \"pending\"}, options: {escape: false, strict: false}}"
+---
+  <span>Pending</span>

--- a/test/snapshots/engine/case_test/test_0001_case_when_in_same_ERB_tag_6ca15c3a9293976c06d3d4e1421980f9.txt
+++ b/test/snapshots/engine/case_test/test_0001_case_when_in_same_ERB_tag_6ca15c3a9293976c06d3d4e1421980f9.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::CaseTest#test_0001_case when in same ERB tag"
+input: "{source: \"<% case status when \\\"pending\\\" %>\\n  <span>Pending</span>\\n<% when \\\"approved\\\" %>\\n  <span>Approved</span>\\n<% else %>\\n  <span>Unknown</span>\\n<% end %>\\n\", locals: {status: \"approved\"}, options: {escape: false, strict: false}}"
+---
+  <span>Approved</span>

--- a/test/snapshots/engine/case_test/test_0001_case_when_in_same_ERB_tag_9b671780f0459813359368a1df6afaff.txt
+++ b/test/snapshots/engine/case_test/test_0001_case_when_in_same_ERB_tag_9b671780f0459813359368a1df6afaff.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::CaseTest#test_0001_case when in same ERB tag"
+input: "{source: \"<% case status when \\\"pending\\\" %>\\n  <span>Pending</span>\\n<% when \\\"approved\\\" %>\\n  <span>Approved</span>\\n<% else %>\\n  <span>Unknown</span>\\n<% end %>\\n\", locals: {status: \"other\"}, options: {escape: false, strict: false}}"
+---
+  <span>Unknown</span>

--- a/test/snapshots/engine/case_test/test_0003_case_when_on_newline_in_same_ERB_tag_811ef7173169870133e367deaede4fe4.txt
+++ b/test/snapshots/engine/case_test/test_0003_case_when_on_newline_in_same_ERB_tag_811ef7173169870133e367deaede4fe4.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::CaseTest#test_0003_case when on newline in same ERB tag"
+input: "{source: \"<% case status\\n   when \\\"pending\\\" %>\\n  <span>Pending</span>\\n<% when \\\"approved\\\" %>\\n  <span>Approved</span>\\n<% end %>\\n\", locals: {status: \"approved\"}, options: {escape: false, strict: false}}"
+---
+  <span>Approved</span>

--- a/test/snapshots/engine/case_test/test_0003_case_when_on_newline_in_same_ERB_tag_ab777e9f2c3de2a5939a0bc885c8d74c.txt
+++ b/test/snapshots/engine/case_test/test_0003_case_when_on_newline_in_same_ERB_tag_ab777e9f2c3de2a5939a0bc885c8d74c.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::CaseTest#test_0003_case when on newline in same ERB tag"
+input: "{source: \"<% case status\\n   when \\\"pending\\\" %>\\n  <span>Pending</span>\\n<% when \\\"approved\\\" %>\\n  <span>Approved</span>\\n<% end %>\\n\", locals: {status: \"pending\"}, options: {escape: false, strict: false}}"
+---
+  <span>Pending</span>

--- a/test/snapshots/engine/case_test/test_0004_case_in_on_newline_in_same_ERB_tag_0a592ed5a885b7022e49432c323b8991.txt
+++ b/test/snapshots/engine/case_test/test_0004_case_in_on_newline_in_same_ERB_tag_0a592ed5a885b7022e49432c323b8991.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::CaseTest#test_0004_case in on newline in same ERB tag"
+input: "{source: \"<% case count\\n   in 1 %>\\n  <span>One</span>\\n<% in 2 %>\\n  <span>Two</span>\\n<% end %>\\n\", locals: {count: 1}, options: {escape: false, strict: false}}"
+---
+  <span>One</span>

--- a/test/snapshots/engine/case_test/test_0004_case_in_on_newline_in_same_ERB_tag_efdcbb5c5c9196a57d4695520c828efc.txt
+++ b/test/snapshots/engine/case_test/test_0004_case_in_on_newline_in_same_ERB_tag_efdcbb5c5c9196a57d4695520c828efc.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::CaseTest#test_0004_case in on newline in same ERB tag"
+input: "{source: \"<% case count\\n   in 1 %>\\n  <span>One</span>\\n<% in 2 %>\\n  <span>Two</span>\\n<% end %>\\n\", locals: {count: 2}, options: {escape: false, strict: false}}"
+---
+  <span>Two</span>

--- a/test/snapshots/engine/heredoc_test/test_0001_heredoc_in_code_tag_89436ef132cfca5077afe91beb8082b8.txt
+++ b/test/snapshots/engine/heredoc_test/test_0001_heredoc_in_code_tag_89436ef132cfca5077afe91beb8082b8.txt
@@ -1,5 +1,5 @@
 ---
-source: "Engine::EvaluationTest#test_0039_heredoc in code tag"
+source: "Engine::HeredocTest#test_0001_heredoc in code tag"
 input: "{source: \"<%\\n  text = <<~TEXT\\n    Hello, world!\\n  TEXT\\n%>\\n<%= text %>\\n\", locals: {}, options: {escape: false}}"
 ---
 Hello, world!

--- a/test/snapshots/parser/multiple_control_flow_test/test_0041_case_and_when_in_same_ERB_tag_82797abe9bddf29a367f8ebcc420eaba-08996694f7ff1e6e34277dc32f646630.txt
+++ b/test/snapshots/parser/multiple_control_flow_test/test_0041_case_and_when_in_same_ERB_tag_82797abe9bddf29a367f8ebcc420eaba-08996694f7ff1e6e34277dc32f646630.txt
@@ -6,22 +6,30 @@ input: |2-
 <% when "b" %>
   B
 <% end %>
+options: {strict: true}
 ---
 @ DocumentNode (location: (1:0)-(6:0))
 └── children: (2 items)
     ├── @ ERBCaseNode (location: (1:0)-(5:9))
     │   ├── errors: (1 error)
     │   │   └── @ ERBCaseWithConditionsError (location: (1:0)-(1:28))
-    │   │       └── message: "A `case` statement with `when`/`in` in a single ERB tag cannot be formatted. Use separate tags for `case` and its conditions."
+    │   │       └── message: "A `case` statement with `when`/`in` conditions in a single ERB tag cannot be reliably parsed, compiled, and formatted. Use separate ERB tags for `case` and its conditions (e.g., `<% case x %>` followed by `<% when y %>`)."
     │   │
     │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
     │   ├── content: " case variable when "a" " (location: (1:2)-(1:26))
     │   ├── tag_closing: "%>" (location: (1:26)-(1:28))
-    │   ├── children: (1 item)
-    │   │   └── @ HTMLTextNode (location: (1:28)-(3:0))
-    │   │       └── content: "\n  A\n"
-    │   │
-    │   ├── conditions: (1 item)
+    │   ├── children: []
+    │   ├── conditions: (2 items)
+    │   │   ├── @ ERBWhenNode (location: (1:28)-(3:0))
+    │   │   │   ├── tag_opening: ∅
+    │   │   │   ├── content: ∅
+    │   │   │   ├── tag_closing: ∅
+    │   │   │   ├── then_keyword: ∅
+    │   │   │   └── statements: (1 item)
+    │   │   │       └── @ HTMLTextNode (location: (1:28)-(3:0))
+    │   │   │           └── content: "\n  A\n"
+    │   │   │
+    │   │   │
     │   │   └── @ ERBWhenNode (location: (3:0)-(3:14))
     │   │       ├── tag_opening: "<%" (location: (3:0)-(3:2))
     │   │       ├── content: " when "b" " (location: (3:2)-(3:12))

--- a/test/snapshots/parser/multiple_control_flow_test/test_0041_case_and_when_in_same_ERB_tag_82797abe9bddf29a367f8ebcc420eaba-2ffd01e26b8c99a6c7a6dad67c9489dc.txt
+++ b/test/snapshots/parser/multiple_control_flow_test/test_0041_case_and_when_in_same_ERB_tag_82797abe9bddf29a367f8ebcc420eaba-2ffd01e26b8c99a6c7a6dad67c9489dc.txt
@@ -1,0 +1,48 @@
+---
+source: "Parser::MultipleControlFlowTest#test_0041_case and when in same ERB tag"
+input: |2-
+<% case variable when "a" %>
+  A
+<% when "b" %>
+  B
+<% end %>
+options: {strict: false}
+---
+@ DocumentNode (location: (1:0)-(6:0))
+└── children: (2 items)
+    ├── @ ERBCaseNode (location: (1:0)-(5:9))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
+    │   ├── content: " case variable when "a" " (location: (1:2)-(1:26))
+    │   ├── tag_closing: "%>" (location: (1:26)-(1:28))
+    │   ├── children: []
+    │   ├── conditions: (2 items)
+    │   │   ├── @ ERBWhenNode (location: (1:28)-(3:0))
+    │   │   │   ├── tag_opening: ∅
+    │   │   │   ├── content: ∅
+    │   │   │   ├── tag_closing: ∅
+    │   │   │   ├── then_keyword: ∅
+    │   │   │   └── statements: (1 item)
+    │   │   │       └── @ HTMLTextNode (location: (1:28)-(3:0))
+    │   │   │           └── content: "\n  A\n"
+    │   │   │
+    │   │   │
+    │   │   └── @ ERBWhenNode (location: (3:0)-(3:14))
+    │   │       ├── tag_opening: "<%" (location: (3:0)-(3:2))
+    │   │       ├── content: " when "b" " (location: (3:2)-(3:12))
+    │   │       ├── tag_closing: "%>" (location: (3:12)-(3:14))
+    │   │       ├── then_keyword: ∅
+    │   │       └── statements: (1 item)
+    │   │           └── @ HTMLTextNode (location: (3:14)-(5:0))
+    │   │               └── content: "\n  B\n"
+    │   │
+    │   │
+    │   ├── else_clause: ∅
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (5:0)-(5:9))
+    │           ├── tag_opening: "<%" (location: (5:0)-(5:2))
+    │           ├── content: " end " (location: (5:2)-(5:7))
+    │           └── tag_closing: "%>" (location: (5:7)-(5:9))
+    │
+    │
+    └── @ HTMLTextNode (location: (5:9)-(6:0))
+        └── content: "\n"

--- a/test/snapshots/parser/multiple_control_flow_test/test_0042_case_in_pattern_in_same_ERB_tag_5655a054015224a72ca2f5d378f9b966-08996694f7ff1e6e34277dc32f646630.txt
+++ b/test/snapshots/parser/multiple_control_flow_test/test_0042_case_in_pattern_in_same_ERB_tag_5655a054015224a72ca2f5d378f9b966-08996694f7ff1e6e34277dc32f646630.txt
@@ -1,0 +1,52 @@
+---
+source: "Parser::MultipleControlFlowTest#test_0042_case in pattern in same ERB tag"
+input: |2-
+<% case value in 1 %>
+  One
+<% in 2 %>
+  Two
+<% end %>
+options: {strict: true}
+---
+@ DocumentNode (location: (1:0)-(6:0))
+└── children: (2 items)
+    ├── @ ERBCaseMatchNode (location: (1:0)-(5:9))
+    │   ├── errors: (1 error)
+    │   │   └── @ ERBCaseWithConditionsError (location: (1:0)-(1:21))
+    │   │       └── message: "A `case` statement with `when`/`in` conditions in a single ERB tag cannot be reliably parsed, compiled, and formatted. Use separate ERB tags for `case` and its conditions (e.g., `<% case x %>` followed by `<% when y %>`)."
+    │   │
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
+    │   ├── content: " case value in 1 " (location: (1:2)-(1:19))
+    │   ├── tag_closing: "%>" (location: (1:19)-(1:21))
+    │   ├── children: []
+    │   ├── conditions: (2 items)
+    │   │   ├── @ ERBInNode (location: (1:21)-(3:0))
+    │   │   │   ├── tag_opening: ∅
+    │   │   │   ├── content: ∅
+    │   │   │   ├── tag_closing: ∅
+    │   │   │   ├── then_keyword: ∅
+    │   │   │   └── statements: (1 item)
+    │   │   │       └── @ HTMLTextNode (location: (1:21)-(3:0))
+    │   │   │           └── content: "\n  One\n"
+    │   │   │
+    │   │   │
+    │   │   └── @ ERBInNode (location: (3:0)-(3:10))
+    │   │       ├── tag_opening: "<%" (location: (3:0)-(3:2))
+    │   │       ├── content: " in 2 " (location: (3:2)-(3:8))
+    │   │       ├── tag_closing: "%>" (location: (3:8)-(3:10))
+    │   │       ├── then_keyword: ∅
+    │   │       └── statements: (1 item)
+    │   │           └── @ HTMLTextNode (location: (3:10)-(5:0))
+    │   │               └── content: "\n  Two\n"
+    │   │
+    │   │
+    │   ├── else_clause: ∅
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (5:0)-(5:9))
+    │           ├── tag_opening: "<%" (location: (5:0)-(5:2))
+    │           ├── content: " end " (location: (5:2)-(5:7))
+    │           └── tag_closing: "%>" (location: (5:7)-(5:9))
+    │
+    │
+    └── @ HTMLTextNode (location: (5:9)-(6:0))
+        └── content: "\n"

--- a/test/snapshots/parser/multiple_control_flow_test/test_0042_case_in_pattern_in_same_ERB_tag_5655a054015224a72ca2f5d378f9b966-2ffd01e26b8c99a6c7a6dad67c9489dc.txt
+++ b/test/snapshots/parser/multiple_control_flow_test/test_0042_case_in_pattern_in_same_ERB_tag_5655a054015224a72ca2f5d378f9b966-2ffd01e26b8c99a6c7a6dad67c9489dc.txt
@@ -6,22 +6,26 @@ input: |2-
 <% in 2 %>
   Two
 <% end %>
+options: {strict: false}
 ---
 @ DocumentNode (location: (1:0)-(6:0))
 └── children: (2 items)
     ├── @ ERBCaseMatchNode (location: (1:0)-(5:9))
-    │   ├── errors: (1 error)
-    │   │   └── @ ERBCaseWithConditionsError (location: (1:0)-(1:21))
-    │   │       └── message: "A `case` statement with `when`/`in` in a single ERB tag cannot be formatted. Use separate tags for `case` and its conditions."
-    │   │
     │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
     │   ├── content: " case value in 1 " (location: (1:2)-(1:19))
     │   ├── tag_closing: "%>" (location: (1:19)-(1:21))
-    │   ├── children: (1 item)
-    │   │   └── @ HTMLTextNode (location: (1:21)-(3:0))
-    │   │       └── content: "\n  One\n"
-    │   │
-    │   ├── conditions: (1 item)
+    │   ├── children: []
+    │   ├── conditions: (2 items)
+    │   │   ├── @ ERBInNode (location: (1:21)-(3:0))
+    │   │   │   ├── tag_opening: ∅
+    │   │   │   ├── content: ∅
+    │   │   │   ├── tag_closing: ∅
+    │   │   │   ├── then_keyword: ∅
+    │   │   │   └── statements: (1 item)
+    │   │   │       └── @ HTMLTextNode (location: (1:21)-(3:0))
+    │   │   │           └── content: "\n  One\n"
+    │   │   │
+    │   │   │
     │   │   └── @ ERBInNode (location: (3:0)-(3:10))
     │   │       ├── tag_opening: "<%" (location: (3:0)-(3:2))
     │   │       ├── content: " in 2 " (location: (3:2)-(3:8))

--- a/test/snapshots/parser/multiple_control_flow_test/test_0043_case_and_when_on_newline_in_same_ERB_tag_0560399f6147186ba24ad4f6c9f5df6f-08996694f7ff1e6e34277dc32f646630.txt
+++ b/test/snapshots/parser/multiple_control_flow_test/test_0043_case_and_when_on_newline_in_same_ERB_tag_0560399f6147186ba24ad4f6c9f5df6f-08996694f7ff1e6e34277dc32f646630.txt
@@ -1,0 +1,54 @@
+---
+source: "Parser::MultipleControlFlowTest#test_0043_case and when on newline in same ERB tag"
+input: |2-
+<% case variable
+   when "a" %>
+  A
+<% when "b" %>
+  B
+<% end %>
+options: {strict: true}
+---
+@ DocumentNode (location: (1:0)-(7:0))
+└── children: (2 items)
+    ├── @ ERBCaseNode (location: (1:0)-(6:9))
+    │   ├── errors: (1 error)
+    │   │   └── @ ERBCaseWithConditionsError (location: (1:0)-(2:14))
+    │   │       └── message: "A `case` statement with `when`/`in` conditions in a single ERB tag cannot be reliably parsed, compiled, and formatted. Use separate ERB tags for `case` and its conditions (e.g., `<% case x %>` followed by `<% when y %>`)."
+    │   │
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
+    │   ├── content: " case variable
+    │      when "a" " (location: (1:2)-(2:12))
+    │   ├── tag_closing: "%>" (location: (2:12)-(2:14))
+    │   ├── children: []
+    │   ├── conditions: (2 items)
+    │   │   ├── @ ERBWhenNode (location: (2:14)-(4:0))
+    │   │   │   ├── tag_opening: ∅
+    │   │   │   ├── content: ∅
+    │   │   │   ├── tag_closing: ∅
+    │   │   │   ├── then_keyword: ∅
+    │   │   │   └── statements: (1 item)
+    │   │   │       └── @ HTMLTextNode (location: (2:14)-(4:0))
+    │   │   │           └── content: "\n  A\n"
+    │   │   │
+    │   │   │
+    │   │   └── @ ERBWhenNode (location: (4:0)-(4:14))
+    │   │       ├── tag_opening: "<%" (location: (4:0)-(4:2))
+    │   │       ├── content: " when "b" " (location: (4:2)-(4:12))
+    │   │       ├── tag_closing: "%>" (location: (4:12)-(4:14))
+    │   │       ├── then_keyword: ∅
+    │   │       └── statements: (1 item)
+    │   │           └── @ HTMLTextNode (location: (4:14)-(6:0))
+    │   │               └── content: "\n  B\n"
+    │   │
+    │   │
+    │   ├── else_clause: ∅
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (6:0)-(6:9))
+    │           ├── tag_opening: "<%" (location: (6:0)-(6:2))
+    │           ├── content: " end " (location: (6:2)-(6:7))
+    │           └── tag_closing: "%>" (location: (6:7)-(6:9))
+    │
+    │
+    └── @ HTMLTextNode (location: (6:9)-(7:0))
+        └── content: "\n"

--- a/test/snapshots/parser/multiple_control_flow_test/test_0043_case_and_when_on_newline_in_same_ERB_tag_0560399f6147186ba24ad4f6c9f5df6f-2ffd01e26b8c99a6c7a6dad67c9489dc.txt
+++ b/test/snapshots/parser/multiple_control_flow_test/test_0043_case_and_when_on_newline_in_same_ERB_tag_0560399f6147186ba24ad4f6c9f5df6f-2ffd01e26b8c99a6c7a6dad67c9489dc.txt
@@ -1,0 +1,50 @@
+---
+source: "Parser::MultipleControlFlowTest#test_0043_case and when on newline in same ERB tag"
+input: |2-
+<% case variable
+   when "a" %>
+  A
+<% when "b" %>
+  B
+<% end %>
+options: {strict: false}
+---
+@ DocumentNode (location: (1:0)-(7:0))
+└── children: (2 items)
+    ├── @ ERBCaseNode (location: (1:0)-(6:9))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
+    │   ├── content: " case variable
+    │      when "a" " (location: (1:2)-(2:12))
+    │   ├── tag_closing: "%>" (location: (2:12)-(2:14))
+    │   ├── children: []
+    │   ├── conditions: (2 items)
+    │   │   ├── @ ERBWhenNode (location: (2:14)-(4:0))
+    │   │   │   ├── tag_opening: ∅
+    │   │   │   ├── content: ∅
+    │   │   │   ├── tag_closing: ∅
+    │   │   │   ├── then_keyword: ∅
+    │   │   │   └── statements: (1 item)
+    │   │   │       └── @ HTMLTextNode (location: (2:14)-(4:0))
+    │   │   │           └── content: "\n  A\n"
+    │   │   │
+    │   │   │
+    │   │   └── @ ERBWhenNode (location: (4:0)-(4:14))
+    │   │       ├── tag_opening: "<%" (location: (4:0)-(4:2))
+    │   │       ├── content: " when "b" " (location: (4:2)-(4:12))
+    │   │       ├── tag_closing: "%>" (location: (4:12)-(4:14))
+    │   │       ├── then_keyword: ∅
+    │   │       └── statements: (1 item)
+    │   │           └── @ HTMLTextNode (location: (4:14)-(6:0))
+    │   │               └── content: "\n  B\n"
+    │   │
+    │   │
+    │   ├── else_clause: ∅
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (6:0)-(6:9))
+    │           ├── tag_opening: "<%" (location: (6:0)-(6:2))
+    │           ├── content: " end " (location: (6:2)-(6:7))
+    │           └── tag_closing: "%>" (location: (6:7)-(6:9))
+    │
+    │
+    └── @ HTMLTextNode (location: (6:9)-(7:0))
+        └── content: "\n"

--- a/test/snapshots/parser/multiple_control_flow_test/test_0044_case_in_pattern_on_newline_in_same_ERB_tag_469f7105ed227c9918b8e8e22644591c-08996694f7ff1e6e34277dc32f646630.txt
+++ b/test/snapshots/parser/multiple_control_flow_test/test_0044_case_in_pattern_on_newline_in_same_ERB_tag_469f7105ed227c9918b8e8e22644591c-08996694f7ff1e6e34277dc32f646630.txt
@@ -1,0 +1,54 @@
+---
+source: "Parser::MultipleControlFlowTest#test_0044_case in pattern on newline in same ERB tag"
+input: |2-
+<% case value
+   in 1 %>
+  One
+<% in 2 %>
+  Two
+<% end %>
+options: {strict: true}
+---
+@ DocumentNode (location: (1:0)-(7:0))
+└── children: (2 items)
+    ├── @ ERBCaseMatchNode (location: (1:0)-(6:9))
+    │   ├── errors: (1 error)
+    │   │   └── @ ERBCaseWithConditionsError (location: (1:0)-(2:10))
+    │   │       └── message: "A `case` statement with `when`/`in` conditions in a single ERB tag cannot be reliably parsed, compiled, and formatted. Use separate ERB tags for `case` and its conditions (e.g., `<% case x %>` followed by `<% when y %>`)."
+    │   │
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
+    │   ├── content: " case value
+    │      in 1 " (location: (1:2)-(2:8))
+    │   ├── tag_closing: "%>" (location: (2:8)-(2:10))
+    │   ├── children: []
+    │   ├── conditions: (2 items)
+    │   │   ├── @ ERBInNode (location: (2:10)-(4:0))
+    │   │   │   ├── tag_opening: ∅
+    │   │   │   ├── content: ∅
+    │   │   │   ├── tag_closing: ∅
+    │   │   │   ├── then_keyword: ∅
+    │   │   │   └── statements: (1 item)
+    │   │   │       └── @ HTMLTextNode (location: (2:10)-(4:0))
+    │   │   │           └── content: "\n  One\n"
+    │   │   │
+    │   │   │
+    │   │   └── @ ERBInNode (location: (4:0)-(4:10))
+    │   │       ├── tag_opening: "<%" (location: (4:0)-(4:2))
+    │   │       ├── content: " in 2 " (location: (4:2)-(4:8))
+    │   │       ├── tag_closing: "%>" (location: (4:8)-(4:10))
+    │   │       ├── then_keyword: ∅
+    │   │       └── statements: (1 item)
+    │   │           └── @ HTMLTextNode (location: (4:10)-(6:0))
+    │   │               └── content: "\n  Two\n"
+    │   │
+    │   │
+    │   ├── else_clause: ∅
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (6:0)-(6:9))
+    │           ├── tag_opening: "<%" (location: (6:0)-(6:2))
+    │           ├── content: " end " (location: (6:2)-(6:7))
+    │           └── tag_closing: "%>" (location: (6:7)-(6:9))
+    │
+    │
+    └── @ HTMLTextNode (location: (6:9)-(7:0))
+        └── content: "\n"

--- a/test/snapshots/parser/multiple_control_flow_test/test_0044_case_in_pattern_on_newline_in_same_ERB_tag_469f7105ed227c9918b8e8e22644591c-2ffd01e26b8c99a6c7a6dad67c9489dc.txt
+++ b/test/snapshots/parser/multiple_control_flow_test/test_0044_case_in_pattern_on_newline_in_same_ERB_tag_469f7105ed227c9918b8e8e22644591c-2ffd01e26b8c99a6c7a6dad67c9489dc.txt
@@ -1,0 +1,50 @@
+---
+source: "Parser::MultipleControlFlowTest#test_0044_case in pattern on newline in same ERB tag"
+input: |2-
+<% case value
+   in 1 %>
+  One
+<% in 2 %>
+  Two
+<% end %>
+options: {strict: false}
+---
+@ DocumentNode (location: (1:0)-(7:0))
+└── children: (2 items)
+    ├── @ ERBCaseMatchNode (location: (1:0)-(6:9))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
+    │   ├── content: " case value
+    │      in 1 " (location: (1:2)-(2:8))
+    │   ├── tag_closing: "%>" (location: (2:8)-(2:10))
+    │   ├── children: []
+    │   ├── conditions: (2 items)
+    │   │   ├── @ ERBInNode (location: (2:10)-(4:0))
+    │   │   │   ├── tag_opening: ∅
+    │   │   │   ├── content: ∅
+    │   │   │   ├── tag_closing: ∅
+    │   │   │   ├── then_keyword: ∅
+    │   │   │   └── statements: (1 item)
+    │   │   │       └── @ HTMLTextNode (location: (2:10)-(4:0))
+    │   │   │           └── content: "\n  One\n"
+    │   │   │
+    │   │   │
+    │   │   └── @ ERBInNode (location: (4:0)-(4:10))
+    │   │       ├── tag_opening: "<%" (location: (4:0)-(4:2))
+    │   │       ├── content: " in 2 " (location: (4:2)-(4:8))
+    │   │       ├── tag_closing: "%>" (location: (4:8)-(4:10))
+    │   │       ├── then_keyword: ∅
+    │   │       └── statements: (1 item)
+    │   │           └── @ HTMLTextNode (location: (4:10)-(6:0))
+    │   │               └── content: "\n  Two\n"
+    │   │
+    │   │
+    │   ├── else_clause: ∅
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (6:0)-(6:9))
+    │           ├── tag_opening: "<%" (location: (6:0)-(6:2))
+    │           ├── content: " end " (location: (6:2)-(6:7))
+    │           └── tag_closing: "%>" (location: (6:7)-(6:9))
+    │
+    │
+    └── @ HTMLTextNode (location: (6:9)-(7:0))
+        └── content: "\n"


### PR DESCRIPTION
This pull request updates the parser to provide backwards compatibility for `<% case @foo when :bar %>` (`case/when` or `case/in` in a single ERB tag) by gating the `ERBCaseWithConditionsError` behind strict mode. 

This syntax is valid Erubi and, for backwards compatibility reasons, we should also make this also work in Herb. With this change, non-strict now mode accepts this syntax and now correctly compiles it by splitting a the single ERB Node into multiple AST nodes by creating a new synthetic `ERBWhenNode` or  `ERBCaseInNode` node.

The following template:

```html+erb
<% case count
   in 1 %>
  One
<% in 2 %>
  Two
<% end %>
```

Now gets parsed as this in non-strict mode:

```js
@ DocumentNode (location: (1:0)-(7:0))
└── children: (2 items)
    ├── @ ERBCaseMatchNode (location: (1:0)-(6:9))
    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
    │   ├── content: " case count
    │      in 1 " (location: (1:2)-(2:8))
    │   ├── tag_closing: "%>" (location: (2:8)-(2:10))
    │   ├── children: []
    │   ├── conditions: (2 items)
    │   │   ├── @ ERBInNode (location: (2:10)-(4:0))
    │   │   │   ├── tag_opening: ∅
    │   │   │   ├── content: ∅
    │   │   │   ├── tag_closing: ∅
    │   │   │   ├── then_keyword: ∅
    │   │   │   └── statements: (1 item)
    │   │   │       └── @ HTMLTextNode (location: (2:10)-(4:0))
    │   │   │           └── content: "\n  One\n"
    │   │   │
    │   │   └── @ ERBInNode (location: (4:0)-(4:10))
    │   │       ├── tag_opening: "<%" (location: (4:0)-(4:2))
    │   │       ├── content: " in 2 " (location: (4:2)-(4:8))
    │   │       ├── tag_closing: "%>" (location: (4:8)-(4:10))
    │   │       ├── then_keyword: ∅
    │   │       └── statements: (1 item)
    │   │           └── @ HTMLTextNode (location: (4:10)-(6:0))
    │   │               └── content: "\n  Two\n"
    │   │
    │   ├── else_clause: ∅
    │   └── end_node:
    │       └── @ ERBEndNode (location: (6:0)-(6:9))
    │           ├── tag_opening: "<%" (location: (6:0)-(6:2))
    │           ├── content: " end " (location: (6:2)-(6:7))
    │           └── tag_closing: "%>" (location: (6:7)-(6:9))
    │
    └── @ HTMLTextNode (location: (6:9)-(7:0))
        └── content: "\n"
```

In strict mode it will still produce a `ERBCaseWithConditionsError`.

Before this change, it was parsed as:
```js
@ DocumentNode (location: (1:0)-(7:0))
└── children: (2 items)
    ├── @ ERBCaseMatchNode (location: (1:0)-(6:9))
    │   ├── errors: (1 error)
    │   │   └── @ ERBCaseWithConditionsError (location: (1:0)-(2:10))
    │   │       └── message: "A `case` statement with `when`/`in` in a single ERB tag cannot be formatted. Use separate tags for `case` and its conditions."
    │   │
    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
    │   ├── content: " case count
    │      in 1 " (location: (1:2)-(2:8))
    │   ├── tag_closing: "%>" (location: (2:8)-(2:10))
    │   ├── children: (1 item)
    │   │   └── @ HTMLTextNode (location: (2:10)-(4:0))
    │   │       └── content: "\n  One\n"
    │   │
    │   ├── conditions: (1 item)
    │   │   └── @ ERBInNode (location: (4:0)-(4:10))
    │   │       ├── tag_opening: "<%" (location: (4:0)-(4:2))
    │   │       ├── content: " in 2 " (location: (4:2)-(4:8))
    │   │       ├── tag_closing: "%>" (location: (4:8)-(4:10))
    │   │       ├── then_keyword: ∅
    │   │       └── statements: (1 item)
    │   │           └── @ HTMLTextNode (location: (4:10)-(6:0))
    │   │               └── content: "\n  Two\n"
    │   │
    │   ├── else_clause: ∅
    │   └── end_node:
    │       └── @ ERBEndNode (location: (6:0)-(6:9))
    │           ├── tag_opening: "<%" (location: (6:0)-(6:2))
    │           ├── content: " end " (location: (6:2)-(6:7))
    │           └── tag_closing: "%>" (location: (6:7)-(6:9))
    │
    └── @ HTMLTextNode (location: (6:9)-(7:0))
        └── content: "\n"
```

Resolves #1252
Related #1112