### PR TITLE
Formatter: Preserve content in `white-space` significant elements

### DIFF
--- a/javascript/packages/core/src/ast-utils.ts
+++ b/javascript/packages/core/src/ast-utils.ts
@@ -14,7 +14,9 @@ import {
   HTMLElementNode,
   HTMLOpenTagNode,
   HTMLCloseTagNode,
+  HTMLAttributeNode,
   HTMLAttributeNameNode,
+  HTMLAttributeValueNode,
   HTMLCommentNode
 } from "./nodes.js"
 
@@ -24,8 +26,13 @@ import {
   isERBNode,
   isERBContentNode,
   isHTMLCommentNode,
+  isHTMLElementNode,
+  isHTMLOpenTagNode,
+  isHTMLAttributeNameNode,
+  isHTMLAttributeValueNode,
   areAllOfType,
-  filterLiteralNodes
+  filterLiteralNodes,
+  filterHTMLAttributeNodes
 } from "./node-type-guards.js"
 
 import type { Location } from "./location.js"
@@ -208,10 +215,26 @@ export function getCombinedAttributeName(attributeNameNode: HTMLAttributeNameNod
 }
 
 /**
- * Gets the tag name of an HTML element node
+ * Gets the tag name of an HTML element, open tag, or close tag node.
+ * Returns null if the node is null/undefined.
  */
-export function getTagName(node: HTMLElementNode | HTMLOpenTagNode | HTMLCloseTagNode): string {
-  return node.tag_name?.value ?? ""
+export function getTagName(node: HTMLElementNode | HTMLOpenTagNode | HTMLCloseTagNode): string
+export function getTagName(node: HTMLElementNode | HTMLOpenTagNode | HTMLCloseTagNode | null | undefined): string | null
+export function getTagName(node: HTMLElementNode | HTMLOpenTagNode | HTMLCloseTagNode | null | undefined): string | null {
+  if (!node) return null
+
+  return node.tag_name?.value ?? null
+}
+
+/**
+ * Gets the lowercased tag name of an HTML element, open tag, or close tag node.
+ * Similar to `Element.localName` in the DOM API.
+ * Returns null if the node is null/undefined.
+ */
+export function getTagLocalName(node: HTMLElementNode | HTMLOpenTagNode | HTMLCloseTagNode): string
+export function getTagLocalName(node: HTMLElementNode | HTMLOpenTagNode | HTMLCloseTagNode | null | undefined): string | null
+export function getTagLocalName(node: HTMLElementNode | HTMLOpenTagNode | HTMLCloseTagNode | null | undefined): string | null {
+  return getTagName(node)?.toLowerCase() ?? null
 }
 
 /**
@@ -220,6 +243,251 @@ export function getTagName(node: HTMLElementNode | HTMLOpenTagNode | HTMLCloseTa
 export function isCommentNode(node: Node): node is HTMLCommentNode | ERBCommentNode {
   return isHTMLCommentNode(node) || isERBCommentNode(node)
 }
+
+/**
+ * Gets the open tag node from an HTMLElementNode, handling both regular and conditional open tags.
+ * For conditional open tags, returns null.
+ * If given an HTMLOpenTagNode directly, returns it as-is.
+ */
+export function getOpenTag(node: HTMLElementNode | HTMLOpenTagNode | null | undefined): HTMLOpenTagNode | null {
+  if (!node) return null
+  if (isHTMLOpenTagNode(node)) return node
+  if (isHTMLElementNode(node)) return isHTMLOpenTagNode(node.open_tag) ? node.open_tag : null
+
+  return null
+}
+
+/**
+ * Gets attributes from an HTMLElementNode or HTMLOpenTagNode
+ */
+export function getAttributes(node: HTMLElementNode | HTMLOpenTagNode | null | undefined): HTMLAttributeNode[] {
+  const openTag = getOpenTag(node)
+
+  return openTag ? filterHTMLAttributeNodes(openTag.children) : []
+}
+
+/**
+ * Gets the attribute name from an HTMLAttributeNode (lowercased)
+ * Returns null if the attribute name contains dynamic content (ERB)
+ */
+export function getAttributeName(attributeNode: HTMLAttributeNode, lowercase = true): string | null {
+  if (!isHTMLAttributeNameNode(attributeNode.name)) return null
+
+  const staticName = getStaticAttributeName(attributeNode.name)
+
+  if (!lowercase) return staticName
+
+  return staticName ? staticName.toLowerCase() : null
+}
+
+/**
+ * Checks if an attribute value contains only static content (no ERB).
+ * Accepts an HTMLAttributeNode directly, or an element/open tag + attribute name.
+ * Returns false for null/undefined input.
+ */
+export function hasStaticAttributeValue(attributeNode: HTMLAttributeNode | null | undefined): boolean
+export function hasStaticAttributeValue(node: HTMLElementNode | HTMLOpenTagNode | null | undefined, attributeName: string): boolean
+export function hasStaticAttributeValue(nodeOrAttribute: HTMLAttributeNode | HTMLElementNode | HTMLOpenTagNode | null | undefined, attributeName?: string): boolean {
+  const attributeNode = attributeName
+    ? getAttribute(nodeOrAttribute as HTMLElementNode | HTMLOpenTagNode, attributeName)
+    : nodeOrAttribute as HTMLAttributeNode | null | undefined
+
+  if (!attributeNode?.value?.children) return false
+
+  return attributeNode.value.children.every(isLiteralNode)
+}
+
+/**
+ * Gets the static string value of an attribute (returns null if it contains ERB).
+ * Accepts an HTMLAttributeNode directly, or an element/open tag + attribute name.
+ * Returns null for null/undefined input.
+ */
+export function getStaticAttributeValue(attributeNode: HTMLAttributeNode | null | undefined): string | null
+export function getStaticAttributeValue(node: HTMLElementNode | HTMLOpenTagNode | null | undefined, attributeName: string): string | null
+export function getStaticAttributeValue(nodeOrAttribute: HTMLAttributeNode | HTMLElementNode | HTMLOpenTagNode | null | undefined, attributeName?: string): string | null {
+  const attributeNode = attributeName
+    ? getAttribute(nodeOrAttribute as HTMLElementNode | HTMLOpenTagNode, attributeName)
+    : nodeOrAttribute as HTMLAttributeNode | null | undefined
+
+  if (!attributeNode) return null
+  if (!hasStaticAttributeValue(attributeNode)) return null
+
+  const valueNode = attributeNode.value
+  if (!valueNode) return null
+
+  return filterLiteralNodes(valueNode.children).map(child => child.content).join("") || ""
+}
+
+/**
+ * Splits a space-separated attribute value into individual tokens.
+ * Accepts a string, or an element/open tag + attribute name to look up.
+ * Returns an empty array for null/undefined/empty input.
+ */
+export function getTokenList(value: string | null | undefined): string[]
+export function getTokenList(node: HTMLElementNode | HTMLOpenTagNode | null | undefined, attributeName: string): string[]
+export function getTokenList(valueOrNode: string | HTMLElementNode | HTMLOpenTagNode | null | undefined, attributeName?: string): string[] {
+  const value = attributeName
+    ? getStaticAttributeValue(valueOrNode as HTMLElementNode | HTMLOpenTagNode, attributeName)
+    : valueOrNode as string | null | undefined
+
+  if (!value) return []
+
+  return value.trim().split(/\s+/).filter(token => token.length > 0)
+}
+
+/**
+ * Finds an attribute by name in a list of attribute nodes
+ */
+export function findAttributeByName(attributes: Node[], attributeName: string): HTMLAttributeNode | null {
+  for (const attribute of filterHTMLAttributeNodes(attributes)) {
+    const name = getAttributeName(attribute)
+
+    if (name === attributeName.toLowerCase()) {
+      return attribute
+    }
+  }
+
+  return null
+}
+
+/**
+ * Gets a specific attribute from an HTMLElementNode or HTMLOpenTagNode by name
+ */
+export function getAttribute(node: HTMLElementNode | HTMLOpenTagNode | null | undefined, attributeName: string): HTMLAttributeNode | null {
+  const attributes = getAttributes(node)
+
+  return findAttributeByName(attributes, attributeName)
+}
+
+/**
+ * Checks if an element or open tag has a specific attribute
+ */
+export function hasAttribute(node: HTMLElementNode | HTMLOpenTagNode | null | undefined, attributeName: string): boolean {
+  if (!node) return false
+
+  return getAttribute(node, attributeName) !== null
+}
+
+/**
+ * Checks if an attribute has a dynamic (ERB-containing) name.
+ * Accepts an HTMLAttributeNode (wraps the core HTMLAttributeNameNode-level check).
+ */
+export function hasDynamicAttributeNameOnAttribute(attributeNode: HTMLAttributeNode): boolean {
+  if (!isHTMLAttributeNameNode(attributeNode.name)) return false
+
+  return hasDynamicAttributeName(attributeNode.name)
+}
+
+/**
+ * Gets the combined string representation of an attribute name (including ERB syntax).
+ * Accepts an HTMLAttributeNode (wraps the core HTMLAttributeNameNode-level check).
+ */
+export function getCombinedAttributeNameString(attributeNode: HTMLAttributeNode): string {
+  if (!isHTMLAttributeNameNode(attributeNode.name)) return ""
+
+  return getCombinedAttributeName(attributeNode.name)
+}
+
+/**
+ * Checks if an attribute value contains dynamic content (ERB)
+ */
+export function hasDynamicAttributeValue(attributeNode: HTMLAttributeNode): boolean {
+  if (!attributeNode.value?.children) return false
+
+  return attributeNode.value.children.some(isERBContentNode)
+}
+
+/**
+ * Gets the value nodes array from an attribute for dynamic inspection
+ */
+export function getAttributeValueNodes(attributeNode: HTMLAttributeNode): Node[] {
+  return attributeNode.value?.children || []
+}
+
+/**
+ * Checks if an attribute value contains any static content (for validation purposes)
+ */
+export function hasStaticAttributeValueContent(attributeNode: HTMLAttributeNode): boolean {
+  return hasStaticContent(getAttributeValueNodes(attributeNode))
+}
+
+/**
+ * Gets the static content of an attribute value (all literal parts combined).
+ * Unlike getStaticAttributeValue, this extracts only the static portions from mixed content.
+ * Returns the concatenated literal content, or null if no literal nodes exist.
+ */
+export function getStaticAttributeValueContent(attributeNode: HTMLAttributeNode): string | null {
+  return getStaticContentFromNodes(getAttributeValueNodes(attributeNode))
+}
+
+/**
+ * Gets the combined attribute value including both static text and ERB tag syntax.
+ * For ERB nodes, includes the full tag syntax (e.g., "<%= foo %>").
+ * Returns null if the attribute has no value.
+ */
+export function getAttributeValue(attributeNode: HTMLAttributeNode): string | null {
+  const valueNode = attributeNode.value
+  if (!valueNode) return null
+
+  if (valueNode.type !== "AST_HTML_ATTRIBUTE_VALUE_NODE" || !valueNode.children?.length) {
+    return null
+  }
+
+  let result = ""
+
+  for (const child of valueNode.children) {
+    if (isERBContentNode(child)) {
+      if (child.content) {
+        result += `${child.tag_opening?.value}${child.content.value}${child.tag_closing?.value}`
+      }
+    } else if (isLiteralNode(child)) {
+      result += child.content
+    }
+  }
+
+  return result
+}
+
+/**
+ * Checks if an attribute has a value node
+ */
+export function hasAttributeValue(attributeNode: HTMLAttributeNode): boolean {
+  return isHTMLAttributeValueNode(attributeNode.value)
+}
+
+/**
+ * Gets the quote type used for an attribute value
+ */
+export function getAttributeValueQuoteType(node: HTMLAttributeNode | HTMLAttributeValueNode): "single" | "double" | "none" | null {
+  const valueNode = isHTMLAttributeValueNode(node) ? node : node.value
+  if (!valueNode) return null
+
+  if (valueNode.quoted && valueNode.open_quote) {
+    return valueNode.open_quote.value === '"' ? "double" : "single"
+  }
+
+  return "none"
+}
+
+/**
+ * Checks if an attribute value is quoted
+ */
+export function isAttributeValueQuoted(attributeNode: HTMLAttributeNode): boolean {
+  if (!isHTMLAttributeValueNode(attributeNode.value)) return false
+
+  return !!attributeNode.value.quoted
+}
+
+/**
+ * Iterates over all attributes of an element or open tag node
+ */
+export function forEachAttribute(node: HTMLElementNode | HTMLOpenTagNode, callback: (attributeNode: HTMLAttributeNode) => void): void {
+  for (const attribute of getAttributes(node)) {
+    callback(attribute)
+  }
+}
+
+// --- Position Utilities ---
 
 /**
  * Compares two positions to determine if the first comes before the second

--- a/javascript/packages/formatter/src/format-helpers.ts
+++ b/javascript/packages/formatter/src/format-helpers.ts
@@ -1,4 +1,4 @@
-import { isNode, isERBNode, getTagName, isAnyOf, isERBControlFlowNode, hasERBOutput } from "@herb-tools/core"
+import { isNode, isERBNode, getTagName, isAnyOf, isERBControlFlowNode, hasERBOutput, getStaticAttributeValue, getTokenList } from "@herb-tools/core"
 import { Node, HTMLDoctypeNode, HTMLTextNode, HTMLElementNode, HTMLCommentNode, HTMLOpenTagNode, HTMLCloseTagNode, ERBIfNode, ERBContentNode, WhitespaceNode } from "@herb-tools/core"
 
 // --- Types ---
@@ -55,6 +55,22 @@ export const INLINE_ELEMENTS = new Set([
 
 export const CONTENT_PRESERVING_ELEMENTS = new Set([
   'script', 'style', 'pre', 'textarea'
+])
+
+// https://tailwindcss.com/docs/white-space
+export const WHITESPACE_PRESERVING_CLASSES = [
+  'whitespace-pre-line',
+  'whitespace-pre-wrap',
+  'whitespace-pre',
+  'whitespace-break-spaces',
+]
+
+// https://developer.mozilla.org/en-US/docs/Web/CSS/white-space
+export const WHITESPACE_PRESERVING_STYLE_VALUES = new Set([
+  'pre',
+  'pre-line',
+  'pre-wrap',
+  'break-spaces',
 ])
 
 export const SPACEABLE_CONTAINERS = new Set([
@@ -397,10 +413,31 @@ export function hasMixedTextAndInlineContent(children: Node[]): boolean {
   return (hasText && hasInlineElements) || (hasERBOutput(children) && hasText)
 }
 
+export function hasWhitespacePreservingStyle(element: HTMLElementNode): boolean {
+  if (getTokenList(element, "class").some(klass => WHITESPACE_PRESERVING_CLASSES.some(whitespace => klass.includes(whitespace)))) return true
+
+  const styleValue = getStaticAttributeValue(element, "style")
+  if (styleValue) {
+    const match = styleValue.match(/white-space\s*:\s*([^;!]+)/)
+
+    if (match) {
+      const value = match[1].trim().toLowerCase()
+      if (WHITESPACE_PRESERVING_STYLE_VALUES.has(value)) return true
+    }
+  }
+
+  return false
+}
+
 export function isContentPreserving(element: HTMLElementNode | HTMLOpenTagNode | HTMLCloseTagNode): boolean {
   const tagName = getTagName(element)
+  if (CONTENT_PRESERVING_ELEMENTS.has(tagName)) return true
 
-  return CONTENT_PRESERVING_ELEMENTS.has(tagName)
+  if (isNode(element, HTMLElementNode)) {
+    return hasWhitespacePreservingStyle(element)
+  }
+
+  return false
 }
 
 /**

--- a/javascript/packages/formatter/src/format-printer.ts
+++ b/javascript/packages/formatter/src/format-printer.ts
@@ -129,6 +129,7 @@ export class FormatPrinter extends Printer implements TextFlowDelegate, Attribut
   private lines: string[] = []
   private indentLevel: number = 0
   private inlineMode: boolean = false
+  private inContentPreservingContext: boolean = false
   private inConditionalOpenTagContext: boolean = false
   private elementStack: HTMLElementNode[] = []
   private elementFormattingAnalysis = new Map<HTMLElementNode, ElementFormattingAnalysis>()
@@ -282,6 +283,15 @@ export class FormatPrinter extends Printer implements TextFlowDelegate, Attribut
     this.indentLevel++
     const result = callback()
     this.indentLevel--
+
+    return result
+  }
+
+  private withContentPreserving<T>(callback: () => T): T {
+    const was = this.inContentPreservingContext
+    this.inContentPreservingContext = true
+    const result = callback()
+    this.inContentPreservingContext = was
 
     return result
   }
@@ -525,7 +535,7 @@ export class FormatPrinter extends Printer implements TextFlowDelegate, Attribut
   }
 
   visitHTMLElementBody(body: Node[], element: HTMLElementNode) {
-    if (isContentPreserving(element)) {
+    if (isContentPreserving(element) || this.inContentPreservingContext) {
       this.visitContentPreservingBody(element)
       return
     }
@@ -561,18 +571,20 @@ export class FormatPrinter extends Printer implements TextFlowDelegate, Attribut
   }
 
   private visitContentPreservingBody(element: HTMLElementNode) {
-    element.body.map(child => {
-      if (isNode(child, HTMLElementNode)) {
-        const wasInlineMode = this.inlineMode
-        this.inlineMode = true
+    this.withContentPreserving(() => {
+      element.body.map(child => {
+        if (isNode(child, HTMLElementNode)) {
+          const wasInlineMode = this.inlineMode
+          this.inlineMode = true
 
-        const formattedElement = this.capture(() => this.visit(child)).join("")
-        this.pushToLastLine(formattedElement)
+          const formattedElement = this.capture(() => this.visit(child)).join("")
+          this.pushToLastLine(formattedElement)
 
-        this.inlineMode = wasInlineMode
-      } else {
-        this.pushToLastLine(IdentityPrinter.print(child))
-      }
+          this.inlineMode = wasInlineMode
+        } else {
+          this.pushToLastLine(IdentityPrinter.print(child))
+        }
+      })
     })
   }
 

--- a/javascript/packages/formatter/test/html/inline-elements.test.ts
+++ b/javascript/packages/formatter/test/html/inline-elements.test.ts
@@ -213,17 +213,132 @@ describe("@herb-tools/formatter - inline elements", () => {
   })
 
   test("spaced ERB tags on separate line from block element preserves format", () => {
-    const source = dedent`
-      <div class="form-inputs">
-        <%= f.input :password, hint: false %> <%= f.input :password_confirmation %>
-      </div>
-    `
-    const result = formatter.format(source)
-    expect(result).toEqual(dedent`
+    expectFormattedToMatch(dedent`
       <div class="form-inputs">
         <%= f.input :password, hint: false %> <%= f.input :password_confirmation %>
       </div>
     `)
+  })
+
+  test("preserves content of element with whitespace-pre-line class (issue #1095)", () => {
+    expectFormattedToMatch(dedent`
+      <div>
+        <div>
+          <div>
+            <div>
+              <div>
+                <span class="truncate whitespace-pre-line"><%= option[:value] %></span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    `)
+  })
+
+  test("preserves content of element with whitespace-pre-line class and multiline body (issue #1095)", () => {
+    expectFormattedToMatch(dedent`
+      <div>
+        <div>
+          <div>
+            <div>
+              <div>
+                <span class="truncate whitespace-pre-line">
+                  <%= option[:value] %>
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    `)
+  })
+
+  test("preserves content of element with whitespace-pre class", () => {
+    expectFormattedToMatch(`<span class="whitespace-pre">  some   spaced   text  </span>`)
+  })
+
+  test("preserves content of element with whitespace-pre-wrap class", () => {
+    expectFormattedToMatch(`<span class="whitespace-pre-wrap">  some   spaced   text  </span>`)
+  })
+
+  test("preserves content of element with whitespace-break-spaces class", () => {
+    expectFormattedToMatch(`<span class="whitespace-break-spaces">  some   spaced   text  </span>`)
+  })
+
+  test("preserves content of element with inline style white-space: pre", () => {
+    expectFormattedToMatch(`<span style="white-space: pre">  some   spaced   text  </span>`)
+  })
+
+  test("preserves content of element with inline style white-space: pre-line", () => {
+    expectFormattedToMatch(`<span style="white-space: pre-line">  some   spaced   text  </span>`)
+  })
+
+  test("preserves content of element with inline style white-space:pre (no space)", () => {
+    expectFormattedToMatch(`<span style="white-space:pre">  some   spaced   text  </span>`)
+  })
+
+  test("does not treat whitespace-normal class as content preserving", () => {
+    expectFormattedToMatch(`<span class="whitespace-normal">some text</span>`)
+  })
+
+  test("does not treat whitespace-nowrap class as content preserving", () => {
+    expectFormattedToMatch(`<span class="whitespace-nowrap">some text</span>`)
+  })
+
+  test("does not treat inline style white-space: normal as content preserving", () => {
+    expectFormattedToMatch(`<span style="white-space: normal">some text</span>`)
+  })
+
+  test("does not treat inline style white-space: nowrap as content preserving", () => {
+    expectFormattedToMatch(`<span style="white-space: nowrap">some text</span>`)
+  })
+
+  test("preserves content with Tailwind responsive prefix md:whitespace-pre-line", () => {
+    expectFormattedToMatch(`<span class="md:whitespace-pre-line">  some   spaced   text  </span>`)
+  })
+
+  test("preserves content with Tailwind state prefix hover:whitespace-pre", () => {
+    expectFormattedToMatch(`<span class="hover:whitespace-pre">  some   spaced   text  </span>`)
+  })
+
+  test("preserves content with chained Tailwind prefix lg:hover:whitespace-pre-wrap", () => {
+    expectFormattedToMatch(`<span class="lg:hover:whitespace-pre-wrap">  some   spaced   text  </span>`)
+  })
+
+  test("preserves content with inline style white-space: pre !important", () => {
+    expectFormattedToMatch(`<span style="white-space: pre !important">  some   spaced   text  </span>`)
+  })
+
+  test("preserves content with white-space among other style properties", () => {
+    expectFormattedToMatch(`<span style="color: red; white-space: pre-wrap; font-size: 12px">  some   spaced   text  </span>`)
+  })
+
+  test("preserves content of block element with whitespace-preserving class", () => {
+    expectFormattedToMatch(dedent`
+      <div class="whitespace-pre">  some   spaced
+        text  with
+        newlines  </div>
+    `)
+  })
+
+  test("preserves content when whitespace-preserving class is among many classes", () => {
+    expectFormattedToMatch(`<span class="flex items-center whitespace-pre-line text-sm truncate">  some   spaced   text  </span>`)
+  })
+
+  test("preserves nested elements inside whitespace-preserving parent", () => {
+    expectFormattedToMatch(dedent`
+      <div class="whitespace-pre-line">
+        <span>  some   text  </span>
+        <strong>  more   text  </strong>
+      </div>
+    `)
+  })
+
+  test("preserves content with white-space as last style property without trailing semicolon", () => {
+    expectFormattedToMatch(`<span style="color: red; white-space: pre">  some   spaced   text  </span>`)
+    expectFormattedToMatch(`<span style="color: red; white-space: pre;">  some   spaced   text  </span>`)
+    expectFormattedToMatch(`<span style="white-space: pre; color: red; ">  some   spaced   text  </span>`)
   })
 
   test("preserves ERB interpolation in attributes", () => {

--- a/javascript/packages/linter/src/rules/erb-no-trailing-whitespace.ts
+++ b/javascript/packages/linter/src/rules/erb-no-trailing-whitespace.ts
@@ -1,6 +1,8 @@
-import { Location, isHTMLOpenTagNode, isHTMLTextNode, isLiteralNode, Visitor } from "@herb-tools/core"
-import { getTagName, findNodeAtPosition } from "./rule-utils.js"
+import { Location, Visitor } from "@herb-tools/core"
 import { ParserRule, Mutable, BaseAutofixContext } from "../types.js"
+
+import { isHTMLOpenTagNode, isHTMLTextNode, isLiteralNode, getTagLocalName } from "@herb-tools/core"
+import { findNodeAtPosition } from "./rule-utils.js"
 
 import type { UnboundLintOffense, LintOffense, LintContext, FullRuleConfig } from "../types.js"
 import type { HTMLElementNode, HTMLTextNode, LiteralNode, ParseResult, DocumentNode, ERBNode } from "@herb-tools/core"
@@ -33,7 +35,7 @@ class SkipZoneCollector extends Visitor {
 
   visitHTMLElementNode(node: HTMLElementNode): void {
     if (isHTMLOpenTagNode(node.open_tag)) {
-      const tagName = getTagName(node.open_tag)
+      const tagName = getTagLocalName(node.open_tag)
 
       if (tagName && this.SKIP_TAGS.has(tagName)) {
         this.skipZones.push({

--- a/javascript/packages/linter/src/rules/erb-prefer-image-tag-helper.ts
+++ b/javascript/packages/linter/src/rules/erb-prefer-image-tag-helper.ts
@@ -1,5 +1,6 @@
 import { ParserRule } from "../types.js"
-import { BaseRuleVisitor, getTagName, findAttributeByName, getAttributes } from "./rule-utils.js"
+import { BaseRuleVisitor } from "./rule-utils.js"
+import { findAttributeByName, getAttributes, getTagLocalName } from "@herb-tools/core"
 
 import { ERBToRubyStringPrinter } from "@herb-tools/printer"
 import { filterNodes, ERBContentNode, LiteralNode, isNode } from "@herb-tools/core"
@@ -14,7 +15,7 @@ class ERBPreferImageTagHelperVisitor extends BaseRuleVisitor {
   }
 
   private checkImgTag(openTag: HTMLOpenTagNode): void {
-    const tagName = getTagName(openTag)
+    const tagName = getTagLocalName(openTag)
 
     if (tagName !== "img") return
 

--- a/javascript/packages/linter/src/rules/html-allowed-script-type.ts
+++ b/javascript/packages/linter/src/rules/html-allowed-script-type.ts
@@ -1,6 +1,6 @@
 import { ParserRule } from "../types.js"
-import { BaseRuleVisitor, getAttribute, getStaticAttributeValue, hasAttributeValue } from "./rule-utils.js"
-import { getTagName } from "@herb-tools/core"
+import { BaseRuleVisitor } from "./rule-utils.js"
+import { getTagLocalName, getAttribute, getStaticAttributeValue, hasAttributeValue } from "@herb-tools/core"
 
 import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types.js"
 import type { HTMLAttributeNode, HTMLOpenTagNode, ParseResult } from "@herb-tools/core"
@@ -12,7 +12,7 @@ const ALLOW_BLANK = true
 
 class AllowedScriptTypeVisitor extends BaseRuleVisitor {
   visitHTMLOpenTagNode(node: HTMLOpenTagNode): void {
-    if (getTagName(node) === "script") {
+    if (getTagLocalName(node) === "script") {
       this.visitScriptNode(node)
     }
   }

--- a/javascript/packages/linter/src/rules/html-anchor-require-href.ts
+++ b/javascript/packages/linter/src/rules/html-anchor-require-href.ts
@@ -1,4 +1,5 @@
-import { BaseRuleVisitor, getTagName, getAttribute, getStaticAttributeValue } from "./rule-utils.js"
+import { BaseRuleVisitor } from "./rule-utils.js"
+import { getAttribute, getStaticAttributeValue, getTagLocalName } from "@herb-tools/core"
 
 import { ParserRule } from "../types.js"
 import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types.js"
@@ -11,7 +12,7 @@ class AnchorRequireHrefVisitor extends BaseRuleVisitor {
   }
 
   private checkATag(node: HTMLOpenTagNode): void {
-    const tagName = getTagName(node)
+    const tagName = getTagLocalName(node)
 
     if (tagName !== "a") {
       return

--- a/javascript/packages/linter/src/rules/html-aria-role-heading-requires-level.ts
+++ b/javascript/packages/linter/src/rules/html-aria-role-heading-requires-level.ts
@@ -1,5 +1,6 @@
 import { ParserRule } from "../types.js"
-import { AttributeVisitorMixin, getAttributeName, getAttributes, StaticAttributeStaticValueParams } from "./rule-utils.js"
+import { AttributeVisitorMixin, StaticAttributeStaticValueParams } from "./rule-utils.js"
+import { getAttributeName, getAttributes } from "@herb-tools/core"
 
 import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types.js"
 import type { ParseResult } from "@herb-tools/core"

--- a/javascript/packages/linter/src/rules/html-attribute-double-quotes.ts
+++ b/javascript/packages/linter/src/rules/html-attribute-double-quotes.ts
@@ -1,6 +1,6 @@
 import { ParserRule, BaseAutofixContext, Mutable } from "../types.js"
-import { AttributeVisitorMixin, StaticAttributeStaticValueParams, StaticAttributeDynamicValueParams, getAttributeValueQuoteType, hasAttributeValue } from "./rule-utils.js"
-import { filterLiteralNodes } from "@herb-tools/core"
+import { AttributeVisitorMixin, StaticAttributeStaticValueParams, StaticAttributeDynamicValueParams } from "./rule-utils.js"
+import { filterLiteralNodes, getAttributeValueQuoteType, hasAttributeValue } from "@herb-tools/core"
 
 import type { UnboundLintOffense, LintOffense, LintContext, FullRuleConfig } from "../types.js"
 import type { ParseResult, HTMLAttributeNode } from "@herb-tools/core"

--- a/javascript/packages/linter/src/rules/html-avoid-both-disabled-and-aria-disabled.ts
+++ b/javascript/packages/linter/src/rules/html-avoid-both-disabled-and-aria-disabled.ts
@@ -1,6 +1,6 @@
 import { ParserRule } from "../types.js"
-import { BaseRuleVisitor, getTagName, hasAttribute, getAttributes, findAttributeByName } from "./rule-utils.js"
-import { isHTMLAttributeValueNode, isERBContentNode } from "@herb-tools/core"
+import { BaseRuleVisitor } from "./rule-utils.js"
+import { isHTMLAttributeValueNode, isERBContentNode, getAttributes, findAttributeByName, hasAttribute, getTagLocalName } from "@herb-tools/core"
 
 import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types.js"
 import type { HTMLOpenTagNode, ParseResult } from "@herb-tools/core"
@@ -16,7 +16,7 @@ class AvoidBothDisabledAndAriaDisabledVisitor extends BaseRuleVisitor {
   }
 
   private checkElement(node: HTMLOpenTagNode): void {
-    const tagName = getTagName(node)
+    const tagName = getTagLocalName(node)
 
     if (!tagName || !ELEMENTS_WITH_NATIVE_DISABLED_ATTRIBUTE_SUPPORT.has(tagName)) {
       return

--- a/javascript/packages/linter/src/rules/html-body-only-elements.ts
+++ b/javascript/packages/linter/src/rules/html-body-only-elements.ts
@@ -1,5 +1,6 @@
 import { ParserRule } from "../types.js"
-import { BaseRuleVisitor, getTagName, isBodyOnlyTag } from "./rule-utils.js"
+import { BaseRuleVisitor, isBodyOnlyTag } from "./rule-utils.js"
+import { getTagLocalName } from "@herb-tools/core"
 
 import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types.js"
 import type { HTMLElementNode, ParseResult } from "@herb-tools/core"
@@ -8,7 +9,7 @@ class HTMLBodyOnlyElementsVisitor extends BaseRuleVisitor {
   private elementStack: string[] = []
 
   visitHTMLElementNode(node: HTMLElementNode): void {
-    const tagName = getTagName(node)?.toLowerCase()
+    const tagName = getTagLocalName(node)
     if (!tagName) return
 
     this.checkBodyOnlyElement(node, tagName)

--- a/javascript/packages/linter/src/rules/html-boolean-attributes-no-value.ts
+++ b/javascript/packages/linter/src/rules/html-boolean-attributes-no-value.ts
@@ -1,5 +1,6 @@
 import { ParserRule, BaseAutofixContext, Mutable } from "../types.js"
-import { AttributeVisitorMixin, StaticAttributeStaticValueParams, StaticAttributeDynamicValueParams, isBooleanAttribute, hasAttributeValue } from "./rule-utils.js"
+import { AttributeVisitorMixin, StaticAttributeStaticValueParams, StaticAttributeDynamicValueParams, isBooleanAttribute } from "./rule-utils.js"
+import { hasAttributeValue } from "@herb-tools/core"
 import { IdentityPrinter } from "@herb-tools/printer"
 
 import type { UnboundLintOffense, LintOffense, LintContext, FullRuleConfig } from "../types.js"

--- a/javascript/packages/linter/src/rules/html-head-only-elements.ts
+++ b/javascript/packages/linter/src/rules/html-head-only-elements.ts
@@ -1,5 +1,6 @@
 import { ParserRule } from "../types"
-import { BaseRuleVisitor, getTagName, isHeadOnlyTag, hasAttribute, getOpenTag } from "./rule-utils"
+import { BaseRuleVisitor, isHeadOnlyTag } from "./rule-utils"
+import { hasAttribute, getTagLocalName } from "@herb-tools/core"
 
 import type { ParseResult, HTMLElementNode } from "@herb-tools/core"
 import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types"
@@ -8,7 +9,7 @@ class HeadOnlyElementsVisitor extends BaseRuleVisitor {
   private elementStack: string[] = []
 
   visitHTMLElementNode(node: HTMLElementNode): void {
-    const tagName = getTagName(node)?.toLowerCase()
+    const tagName = getTagLocalName(node)
     if (!tagName) return
 
     this.checkHeadOnlyElement(node, tagName)
@@ -33,7 +34,7 @@ class HeadOnlyElementsVisitor extends BaseRuleVisitor {
   }
 
   private hasItempropAttribute(node: HTMLElementNode): boolean {
-    return hasAttribute(getOpenTag(node), "itemprop")
+    return hasAttribute(node, "itemprop")
   }
 
   private get insideHead(): boolean {

--- a/javascript/packages/linter/src/rules/html-iframe-has-title.ts
+++ b/javascript/packages/linter/src/rules/html-iframe-has-title.ts
@@ -1,5 +1,6 @@
 import { ParserRule } from "../types.js"
-import { BaseRuleVisitor, getTagName, getAttribute, getAttributeValue } from "./rule-utils.js"
+import { BaseRuleVisitor } from "./rule-utils.js"
+import { getStaticAttributeValue, getAttribute, getAttributeValue, getTagLocalName } from "@herb-tools/core"
 
 import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types.js"
 import type { HTMLOpenTagNode, ParseResult } from "@herb-tools/core"
@@ -11,18 +12,14 @@ class IframeHasTitleVisitor extends BaseRuleVisitor {
   }
 
   private checkIframeElement(node: HTMLOpenTagNode): void {
-    const tagName = getTagName(node)
+    const tagName = getTagLocalName(node)
 
     if (tagName !== "iframe") {
       return
     }
 
-    const ariaHiddenAttribute = getAttribute(node, "aria-hidden")
-    if (ariaHiddenAttribute) {
-      const ariaHiddenValue = getAttributeValue(ariaHiddenAttribute)
-      if (ariaHiddenValue === "true") {
-        return
-      }
+    if (getStaticAttributeValue(node, "aria-hidden") === "true") {
+      return
     }
 
     const attribute = getAttribute(node, "title")

--- a/javascript/packages/linter/src/rules/html-img-require-alt.ts
+++ b/javascript/packages/linter/src/rules/html-img-require-alt.ts
@@ -1,4 +1,5 @@
-import { BaseRuleVisitor, getTagName, hasAttribute } from "./rule-utils.js"
+import { BaseRuleVisitor } from "./rule-utils.js"
+import { hasAttribute, getTagLocalName } from "@herb-tools/core"
 
 import { ParserRule } from "../types.js"
 import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types.js"
@@ -11,7 +12,7 @@ class ImgRequireAltVisitor extends BaseRuleVisitor {
   }
 
   private checkImgTag(node: HTMLOpenTagNode): void {
-    const tagName = getTagName(node)
+    const tagName = getTagLocalName(node)
 
     if (tagName !== "img") {
       return

--- a/javascript/packages/linter/src/rules/html-input-require-autocomplete.ts
+++ b/javascript/packages/linter/src/rules/html-input-require-autocomplete.ts
@@ -1,5 +1,5 @@
-import { getTagName } from "@herb-tools/core"
-import { BaseRuleVisitor, getAttribute, getAttributeValue, getStaticAttributeValueContent } from "./rule-utils.js"
+import { getTagLocalName, getStaticAttributeValue, getAttribute, getAttributeValue } from "@herb-tools/core"
+import { BaseRuleVisitor } from "./rule-utils.js"
 import { ParserRule } from "../types.js"
 
 import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types.js"
@@ -30,10 +30,7 @@ class HTMLInputRequireAutocompleteVisitor extends BaseRuleVisitor {
   private checkInputTag(node: HTMLOpenTagNode): void {
     if (!this.isInputTag(node) || this.hasAutocomplete(node)) return
 
-    const typeAttribute = getAttribute(node, "type");
-    if (!typeAttribute) return
-
-    const typeValue = getStaticAttributeValueContent(typeAttribute)
+    const typeValue = getStaticAttributeValue(node, "type")
     if (!typeValue) return
 
     if (!this.HTML_INPUT_TYPES_REQUIRING_AUTOCOMPLETE.has(typeValue)) return
@@ -55,7 +52,7 @@ class HTMLInputRequireAutocompleteVisitor extends BaseRuleVisitor {
   }
 
   private isInputTag(node: HTMLOpenTagNode) {
-    const tagName = getTagName(node);
+    const tagName = getTagLocalName(node);
 
     if (tagName === "input") {
       return true

--- a/javascript/packages/linter/src/rules/html-navigation-has-label.ts
+++ b/javascript/packages/linter/src/rules/html-navigation-has-label.ts
@@ -1,5 +1,6 @@
 import { ParserRule } from "../types.js"
-import { BaseRuleVisitor, getTagName, hasAttribute, getAttributeValue, findAttributeByName, getAttributes } from "./rule-utils.js"
+import { BaseRuleVisitor } from "./rule-utils.js"
+import { hasAttribute, getAttributeValue, findAttributeByName, getAttributes, getTagLocalName } from "@herb-tools/core"
 
 import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types.js"
 import type { HTMLOpenTagNode, ParseResult } from "@herb-tools/core"
@@ -11,7 +12,7 @@ class NavigationHasLabelVisitor extends BaseRuleVisitor {
   }
 
   private checkNavigationElement(node: HTMLOpenTagNode): void {
-    const tagName = getTagName(node)
+    const tagName = getTagLocalName(node)
     const isNavElement = tagName === "nav"
     const hasNavigationRole = this.hasRoleNavigation(node)
 

--- a/javascript/packages/linter/src/rules/html-no-aria-hidden-on-body.ts
+++ b/javascript/packages/linter/src/rules/html-no-aria-hidden-on-body.ts
@@ -1,5 +1,6 @@
 import { ParserRule } from "../types.js"
-import { BaseRuleVisitor, getTagName, hasAttribute, getAttributeValue, findAttributeByName, getAttributes } from "./rule-utils.js"
+import { BaseRuleVisitor } from "./rule-utils.js"
+import { hasAttribute, getAttributeValue, findAttributeByName, getAttributes, getTagLocalName } from "@herb-tools/core"
 
 import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types.js"
 import type { HTMLOpenTagNode, ParseResult } from "@herb-tools/core"
@@ -11,7 +12,7 @@ class NoAriaHiddenBodyVisitor extends BaseRuleVisitor {
   }
 
   private checkAriaHiddenOnBody(node: HTMLOpenTagNode): void {
-    const tagName = getTagName(node)?.toLowerCase()
+    const tagName = getTagLocalName(node)
 
     if (tagName !== "body") return
 

--- a/javascript/packages/linter/src/rules/html-no-aria-hidden-on-focusable.ts
+++ b/javascript/packages/linter/src/rules/html-no-aria-hidden-on-focusable.ts
@@ -1,5 +1,6 @@
 import { ParserRule } from "../types.js"
-import { BaseRuleVisitor, getTagName, hasAttribute, getAttributeValue, findAttributeByName, getAttributes } from "./rule-utils.js"
+import { BaseRuleVisitor } from "./rule-utils.js"
+import { hasAttribute, getAttributeValue, findAttributeByName, getAttributes, getTagLocalName } from "@herb-tools/core"
 
 import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types.js"
 import type { HTMLOpenTagNode, ParseResult } from "@herb-tools/core"
@@ -37,7 +38,7 @@ class NoAriaHiddenOnFocusableVisitor extends BaseRuleVisitor {
   }
 
   private isFocusable(node: HTMLOpenTagNode): boolean {
-    const tagName = getTagName(node)
+    const tagName = getTagLocalName(node)
     if (!tagName) return false
 
     const tabIndexValue = this.getTabIndexValue(node)

--- a/javascript/packages/linter/src/rules/html-no-duplicate-attributes.ts
+++ b/javascript/packages/linter/src/rules/html-no-duplicate-attributes.ts
@@ -1,5 +1,6 @@
 import { ParserRule, BaseAutofixContext } from "../types.js"
-import { ControlFlowTrackingVisitor, ControlFlowType, getAttributeName } from "./rule-utils.js"
+import { ControlFlowTrackingVisitor, ControlFlowType } from "./rule-utils.js"
+import { getAttributeName } from "@herb-tools/core"
 
 import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types.js"
 import type { HTMLOpenTagNode, HTMLAttributeNode, ParseResult, Location } from "@herb-tools/core"

--- a/javascript/packages/linter/src/rules/html-no-duplicate-meta-names.ts
+++ b/javascript/packages/linter/src/rules/html-no-duplicate-meta-names.ts
@@ -1,5 +1,5 @@
-import { isHTMLElementNode, isHTMLOpenTagNode } from "@herb-tools/core"
-import { getTagName, getAttributeName, getAttributeValue, forEachAttribute } from "./rule-utils"
+import { isHTMLElementNode, isHTMLOpenTagNode, getAttributeName, getAttributeValue, forEachAttribute } from "@herb-tools/core"
+import { getTagLocalName } from "@herb-tools/core"
 
 import { ControlFlowTrackingVisitor, ControlFlowType } from "./rule-utils"
 import { ParserRule, BaseAutofixContext } from "../types"
@@ -30,7 +30,7 @@ class HTMLNoDuplicateMetaNamesVisitor extends ControlFlowTrackingVisitor<BaseAut
   private controlFlowMetas: MetaTag[] = []
 
   visitHTMLElementNode(node: HTMLElementNode): void {
-    const tagName = getTagName(node)?.toLowerCase()
+    const tagName = getTagLocalName(node)
     if (!tagName) return
 
     if (tagName === "head") {

--- a/javascript/packages/linter/src/rules/html-no-empty-headings.ts
+++ b/javascript/packages/linter/src/rules/html-no-empty-headings.ts
@@ -1,14 +1,15 @@
 import { ParserRule } from "../types.js"
-import { BaseRuleVisitor, getTagName, getAttributes, findAttributeByName, getAttributeValue, HEADING_TAGS, getOpenTag } from "./rule-utils.js"
-import { isLiteralNode, isHTMLTextNode, isHTMLElementNode, isERBOutputNode, isERBControlFlowNode } from "@herb-tools/core"
+import { BaseRuleVisitor, HEADING_TAGS } from "./rule-utils.js"
+import { getTagLocalName } from "@herb-tools/core"
+import { isLiteralNode, isHTMLTextNode, isHTMLElementNode, isERBOutputNode, isERBControlFlowNode, getStaticAttributeValue } from "@herb-tools/core"
 
 import type { Node } from "@herb-tools/core"
 import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types.js"
-import type { HTMLElementNode, HTMLOpenTagNode, ParseResult } from "@herb-tools/core"
+import type { HTMLElementNode, ParseResult } from "@herb-tools/core"
 
 class NoEmptyHeadingsVisitor extends BaseRuleVisitor {
   visitHTMLElementNode(node: HTMLElementNode): void {
-    const tagName = getTagName(node)?.toLowerCase()
+    const tagName = getTagLocalName(node)
     if (tagName === "template") return
 
     this.checkHeadingElement(node)
@@ -16,14 +17,11 @@ class NoEmptyHeadingsVisitor extends BaseRuleVisitor {
   }
 
   private checkHeadingElement(node: HTMLElementNode): void {
-    const openTag = getOpenTag(node)
-    if (!openTag) return
-
-    const tagName = getTagName(node)
+    const tagName = getTagLocalName(node)
     if (!tagName) return
 
     const isStandardHeading = HEADING_TAGS.has(tagName)
-    const isAriaHeading = this.hasHeadingRole(openTag)
+    const isAriaHeading = this.hasHeadingRole(node)
 
     if (!isStandardHeading && !isAriaHeading) {
       return
@@ -89,31 +87,13 @@ class NoEmptyHeadingsVisitor extends BaseRuleVisitor {
     return false
   }
 
-  private hasHeadingRole(node: HTMLOpenTagNode): boolean {
-    const attributes = getAttributes(node)
-    const roleAttribute = findAttributeByName(attributes, "role")
-
-    if (!roleAttribute) {
-      return false
-    }
-
-    const roleValue = getAttributeValue(roleAttribute)
-    return roleValue === "heading"
+  private hasHeadingRole(node: HTMLElementNode): boolean {
+    return getStaticAttributeValue(node, "role") === "heading"
   }
 
   private isElementAccessible(node: HTMLElementNode): boolean {
-    const openTag = getOpenTag(node)
-    if (!openTag) return true
-
-    const attributes = getAttributes(openTag)
-    const ariaHiddenAttribute = findAttributeByName(attributes, "aria-hidden")
-
-    if (ariaHiddenAttribute) {
-      const ariaHiddenValue = getAttributeValue(ariaHiddenAttribute)
-
-      if (ariaHiddenValue === "true") {
-        return false
-      }
+    if (getStaticAttributeValue(node, "aria-hidden") === "true") {
+      return false
     }
 
     if (!node.body || node.body.length === 0) {

--- a/javascript/packages/linter/src/rules/html-no-nested-links.ts
+++ b/javascript/packages/linter/src/rules/html-no-nested-links.ts
@@ -1,4 +1,5 @@
-import { BaseRuleVisitor, getTagName } from "./rule-utils.js"
+import { BaseRuleVisitor } from "./rule-utils.js"
+import { getTagLocalName } from "@herb-tools/core"
 import { ParserRule } from "../types.js"
 
 import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types.js"
@@ -29,7 +30,7 @@ class NestedLinkVisitor extends BaseRuleVisitor {
     switch (node.open_tag.type) {
       case "AST_HTML_OPEN_TAG_NODE": {
         const openTag = node.open_tag
-        const tagName = getTagName(openTag)
+        const tagName = getTagLocalName(openTag)
 
         if (tagName !== "a") {
           super.visitHTMLElementNode(node)
@@ -52,7 +53,7 @@ class NestedLinkVisitor extends BaseRuleVisitor {
 
   // Handle self-closing <a> tags (though they're not valid HTML, they might exist)
   visitHTMLOpenTagNode(node: HTMLOpenTagNode): void {
-    const tagName = getTagName(node)
+    const tagName = getTagLocalName(node)
 
     if (tagName === "a" && node.is_void) {
       this.checkNestedLink(node)

--- a/javascript/packages/linter/src/rules/html-no-self-closing.ts
+++ b/javascript/packages/linter/src/rules/html-no-self-closing.ts
@@ -1,6 +1,6 @@
 import { ParserRule, BaseAutofixContext, Mutable } from "../types.js"
 import { isVoidElement, findParent, BaseRuleVisitor } from "./rule-utils.js"
-import { getTagName, isWhitespaceNode, Location, HTMLCloseTagNode } from "@herb-tools/core"
+import { getTagName, getTagLocalName, isWhitespaceNode, Location, HTMLCloseTagNode } from "@herb-tools/core"
 
 import type { UnboundLintOffense, LintContext, LintOffense, FullRuleConfig } from "../types.js"
 import type { Node, HTMLOpenTagNode, HTMLElementNode, SerializedToken, ParseResult } from "@herb-tools/core"
@@ -13,7 +13,7 @@ interface NoSelfClosingAutofixContext extends BaseAutofixContext {
 
 class NoSelfClosingVisitor extends BaseRuleVisitor<NoSelfClosingAutofixContext> {
   visitHTMLElementNode(node: HTMLElementNode): void {
-    if (getTagName(node) === "svg") {
+    if (getTagLocalName(node) === "svg") {
       this.visit(node.open_tag)
     } else {
       this.visitChildNodes(node)

--- a/javascript/packages/linter/src/rules/html-no-title-attribute.ts
+++ b/javascript/packages/linter/src/rules/html-no-title-attribute.ts
@@ -1,5 +1,6 @@
 import { ParserRule } from "../types.js"
-import { BaseRuleVisitor, getTagName, hasAttribute } from "./rule-utils.js"
+import { BaseRuleVisitor } from "./rule-utils.js"
+import { hasAttribute, getTagLocalName } from "@herb-tools/core"
 
 import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types.js"
 import type { HTMLOpenTagNode, ParseResult } from "@herb-tools/core"
@@ -13,7 +14,7 @@ class NoTitleAttributeVisitor extends BaseRuleVisitor {
   }
 
   private checkTitleAttribute(node: HTMLOpenTagNode): void {
-    const tagName = getTagName(node)
+    const tagName = getTagLocalName(node)
 
     if (!tagName || this.ALLOWED_ELEMENTS_WITH_TITLE.has(tagName)) {
       return

--- a/javascript/packages/linter/src/rules/html-tag-name-lowercase.ts
+++ b/javascript/packages/linter/src/rules/html-tag-name-lowercase.ts
@@ -1,6 +1,6 @@
 import { ParserRule, BaseAutofixContext, Mutable } from "../types.js"
-import { BaseRuleVisitor, findParent, getOpenTag } from "./rule-utils.js"
-import { isNode, getTagName, HTMLOpenTagNode, isHTMLElementNode, isHTMLCloseTagNode } from "@herb-tools/core"
+import { BaseRuleVisitor, findParent } from "./rule-utils.js"
+import { isNode, getTagName, getTagLocalName, HTMLOpenTagNode, isHTMLElementNode, isHTMLCloseTagNode, getOpenTag } from "@herb-tools/core"
 
 import type { UnboundLintOffense, LintOffense, LintContext, FullRuleConfig } from "../types.js"
 import type { HTMLElementNode, HTMLCloseTagNode, ParseResult, XMLDeclarationNode, Node } from "@herb-tools/core"
@@ -26,7 +26,7 @@ class XMLDeclarationChecker extends BaseRuleVisitor {
 
 class TagNameLowercaseVisitor extends BaseRuleVisitor<TagNameAutofixContext> {
   visitHTMLElementNode(node: HTMLElementNode): void {
-    if (getTagName(node)?.toLowerCase() === "svg") {
+    if (getTagLocalName(node) === "svg") {
       this.checkTagName(getOpenTag(node))
 
       if (node.close_tag && isHTMLCloseTagNode(node.close_tag)) {

--- a/javascript/packages/linter/src/rules/rule-utils.ts
+++ b/javascript/packages/linter/src/rules/rule-utils.ts
@@ -2,27 +2,21 @@ import {
   Visitor,
   Location,
   Position,
-  getStaticAttributeName,
-  hasDynamicAttributeName as hasNodeDynamicAttributeName,
-  getCombinedAttributeName,
   hasERBOutput,
-  getStaticContentFromNodes,
-  hasStaticContent,
   isEffectivelyStatic,
-  isLiteralNode,
-  isERBContentNode,
-  isHTMLAttributeNode,
-  isHTMLAttributeValueNode,
-  isHTMLAttributeNameNode,
   getValidatableStaticContent,
-  filterLiteralNodes,
-  filterHTMLAttributeNodes,
+  getAttributeName,
+  getStaticAttributeValue,
+  hasDynamicAttributeNameOnAttribute as hasDynamicAttributeName,
+  getCombinedAttributeNameString,
+  getAttributeValueNodes,
+  getAttributeValue,
+  forEachAttribute,
 } from "@herb-tools/core"
 
 import type {
   HTMLAttributeNameNode,
   HTMLAttributeNode,
-  HTMLAttributeValueNode,
   HTMLElementNode,
   HTMLOpenTagNode,
   LexResult,
@@ -168,215 +162,6 @@ export abstract class ControlFlowTrackingVisitor<TAutofixContext extends BaseAut
   protected abstract onExitBranch(stateToRestore: TBranchState): void
 }
 
-/**
- * Gets attributes from an HTMLOpenTagNode
- */
-export function getAttributes(node: HTMLOpenTagNode): HTMLAttributeNode[] {
-  return node.children.filter(isHTMLAttributeNode)
-}
-
-/**
- * Gets the open tag node from an HTMLElementNode, handling both regular and conditional open tags.
- * For conditional open tags, returns null
- */
-export function getOpenTag(element: HTMLElementNode | null | undefined): HTMLOpenTagNode | null {
-  if (!element?.open_tag) return null
-
-  switch (element.open_tag.type) {
-    case "AST_HTML_OPEN_TAG_NODE": return element.open_tag
-    case "AST_HTML_CONDITIONAL_OPEN_TAG_NODE": return null
-    default: return null
-  }
-
-  return null
-}
-
-/**
- * Gets attributes from an element's open tag (handles both regular and conditional open tags)
- */
-export function getAttributesFromElement(element: HTMLElementNode | null | undefined): HTMLAttributeNode[] {
-  const openTag = getOpenTag(element)
-
-  return openTag ? getAttributes(openTag) : []
-}
-
-/**
- * Gets the tag name from an HTML tag node (lowercased)
- */
-export function getTagName(node: HTMLElementNode | HTMLOpenTagNode | null | undefined): string | null {
-  if (!node) return null
-
-  return node.tag_name?.value.toLowerCase() || null
-}
-
-/**
- * Gets the attribute name from an HTMLAttributeNode (lowercased)
- * Returns null if the attribute name contains dynamic content (ERB)
- */
-export function getAttributeName(attributeNode: HTMLAttributeNode, lowercase = true): string | null {
-  if (!isHTMLAttributeNameNode(attributeNode.name)) return null
-
-  const staticName = getStaticAttributeName(attributeNode.name)
-
-  if (!lowercase) return staticName
-
-  return staticName ? staticName.toLowerCase() : null
-}
-
-/**
- * Checks if an attribute has a dynamic (ERB-containing) name
- */
-export function hasDynamicAttributeName(attributeNode: HTMLAttributeNode): boolean {
-  if (!isHTMLAttributeNameNode(attributeNode.name)) return false
-
-  return hasNodeDynamicAttributeName(attributeNode.name)
-}
-
-/**
- * Gets the combined string representation of an attribute name (for debugging)
- * This includes both static content and ERB syntax
- */
-export function getCombinedAttributeNameString(attributeNode: HTMLAttributeNode): string {
-  if (!isHTMLAttributeNameNode(attributeNode.name)) return ""
-
-  return getCombinedAttributeName(attributeNode.name)
-}
-
-/**
- * Checks if an attribute value contains only static content (no ERB)
- */
-export function hasStaticAttributeValue(attributeNode: HTMLAttributeNode): boolean {
-  if (!attributeNode.value?.children) return false
-
-  return attributeNode.value.children.every(isLiteralNode)
-}
-
-/**
- * Checks if an attribute value contains dynamic content (ERB)
- */
-export function hasDynamicAttributeValue(attributeNode: HTMLAttributeNode): boolean {
-  if (!attributeNode.value?.children) return false
-
-  return attributeNode.value.children.some(isERBContentNode)
-}
-
-/**
- * Gets the static string value of an attribute (returns null if it contains ERB)
- */
-export function getStaticAttributeValue(attributeNode: HTMLAttributeNode): string | null {
-  if (!hasStaticAttributeValue(attributeNode)) return null
-
-  const valueNode = attributeNode.value
-  if (!valueNode) return null
-
-  return filterLiteralNodes(valueNode.children).map(child => child.content).join("") || ""
-}
-
-/**
- * Gets the value nodes array for dynamic inspection
- */
-export function getAttributeValueNodes(attributeNode: HTMLAttributeNode): Node[] {
-  return attributeNode.value ?.children || []
-}
-
-/**
- * Checks if an attribute value contains any static content (for validation purposes)
- */
-export function hasStaticAttributeValueContent(attributeNode: HTMLAttributeNode): boolean {
-  const valueNodes = getAttributeValueNodes(attributeNode)
-
-  return hasStaticContent(valueNodes)
-}
-
-/**
- * Gets the static content of an attribute value (all literal parts combined)
- * Returns the concatenated literal content, or null if no literal nodes exist
- */
-export function getStaticAttributeValueContent(attributeNode: HTMLAttributeNode): string | null {
-  const valueNodes = getAttributeValueNodes(attributeNode)
-
-  return getStaticContentFromNodes(valueNodes)
-}
-
-/**
- * Gets the attribute value content from an HTMLAttributeValueNode
- */
-export function getAttributeValue(attributeNode: HTMLAttributeNode): string | null {
-  const valueNode = attributeNode.value
-  if (!valueNode) return null
-
-  if (valueNode.type !== "AST_HTML_ATTRIBUTE_VALUE_NODE" || !valueNode.children?.length) {
-    return null
-  }
-
-  let result = ""
-
-  for (const child of valueNode.children) {
-    if (isERBContentNode(child)) {
-      if (child.content) {
-        result += `${child.tag_opening?.value}${child.content.value}${child.tag_closing?.value}`
-      }
-    } else if (isLiteralNode(child)) {
-      result += child.content
-    }
-  }
-
-  return result
-}
-
-/**
- * Checks if an attribute has a value
- */
-export function hasAttributeValue(attributeNode: HTMLAttributeNode): boolean {
-  return isHTMLAttributeValueNode(attributeNode.value)
-}
-
-/**
- * Gets the quote type used for an attribute value
- */
-export function getAttributeValueQuoteType(node: HTMLAttributeNode | HTMLAttributeValueNode): "single" | "double" | "none" | null {
-  const valueNode = isHTMLAttributeValueNode(node) ? node : node.value
-  if (!valueNode) return null
-
-  if (valueNode.quoted && valueNode.open_quote) {
-    return valueNode.open_quote.value === '"' ? "double" : "single"
-  }
-
-  return "none"
-}
-
-/**
- * Finds an attribute by name in a list of attributes
- */
-export function findAttributeByName(attributes: Node[], attributeName: string): HTMLAttributeNode | null {
-  for (const attribute of filterHTMLAttributeNodes(attributes)) {
-    const name = getAttributeName(attribute)
-
-    if (name === attributeName.toLowerCase()) {
-      return attribute
-    }
-  }
-
-  return null
-}
-
-/**
- * Checks if a tag has a specific attribute
- */
-export function hasAttribute(node: HTMLOpenTagNode | null | undefined, attributeName: string): boolean {
-  if (!node) return false
-
-  return getAttribute(node, attributeName) !== null
-}
-
-/**
- * Checks if a tag has a specific attribute
- */
-export function getAttribute(node: HTMLOpenTagNode, attributeName: string): HTMLAttributeNode | null {
-  const attributes = getAttributes(node)
-
-  return findAttributeByName(attributes, attributeName)
-}
 
 /**
  * Common HTML element categorization
@@ -709,24 +494,6 @@ export abstract class AttributeVisitorMixin<TAutofixContext extends BaseAutofixC
    */
   protected checkDynamicAttributeDynamicValue(_params: DynamicAttributeDynamicValueParams): void {
     // Default implementation does nothing
-  }
-}
-
-/**
- * Checks if an attribute value is quoted
- */
-export function isAttributeValueQuoted(attributeNode: HTMLAttributeNode): boolean {
-  if (!isHTMLAttributeValueNode(attributeNode.value)) return false
-
-  return !!attributeNode.value.quoted
-}
-
-/**
- * Iterates over all attributes of a tag node, calling the callback for each attribute
- */
-export function forEachAttribute(node: HTMLOpenTagNode, callback: (attributeNode: HTMLAttributeNode) => void): void {
-  for (const attribute of getAttributes(node)) {
-    callback(attribute)
   }
 }
 

--- a/javascript/packages/linter/src/rules/turbo-permanent-require-id.ts
+++ b/javascript/packages/linter/src/rules/turbo-permanent-require-id.ts
@@ -1,4 +1,5 @@
-import { BaseRuleVisitor, getAttribute } from "./rule-utils.js"
+import { BaseRuleVisitor } from "./rule-utils.js"
+import { getAttribute } from "@herb-tools/core"
 
 import { ParserRule } from "../types.js"
 import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types.js"

--- a/javascript/packages/stimulus-lint/src/rules/rule-utils.ts
+++ b/javascript/packages/stimulus-lint/src/rules/rule-utils.ts
@@ -1,15 +1,9 @@
-import {
-  BaseRuleVisitor,
-  AttributeVisitorMixin,
-  getAttributeName,
-  getStaticAttributeValue,
-  forEachAttribute,
-  ParserRule
-} from "@herb-tools/linter"
+import { DEFAULT_STIMULUS_LINT_CONTEXT } from "../types.js"
+import { BaseRuleVisitor, AttributeVisitorMixin, ParserRule } from "@herb-tools/linter"
+import { getAttributeName, getStaticAttributeValue, getTokenList, forEachAttribute, didyoumean } from "@herb-tools/core"
 
 import type { Project, RegisteredController } from "stimulus-parser"
 import type { ParseResult, HTMLOpenTagNode, Location } from "@herb-tools/core"
-import { DEFAULT_STIMULUS_LINT_CONTEXT } from "../types.js"
 import type { StimulusLintContext } from "../types.js"
 
 export * from "@herb-tools/linter"
@@ -49,7 +43,8 @@ export abstract class StimulusRuleVisitor extends BaseRuleVisitor {
    */
   protected validateControllerIdentifier(identifier: string, location: Location): boolean {
     if (!this.isControllerAvailable(identifier)) {
-      const suggestion = didyoumean(identifier, this.registeredControllerIdentifiers)
+      const match = didyoumean(identifier, this.registeredControllerIdentifiers, 2)
+      const suggestion = match ? ` Did you mean \`${match}\`?` : ""
 
       this.addOffense(
         `Unknown Stimulus controller \`${identifier}\`. Make sure the controller is defined in your project.${suggestion}`,
@@ -83,7 +78,7 @@ export abstract class StimulusRuleVisitor extends BaseRuleVisitor {
    * Get Stimulus controller identifiers from data-controller attribute
    */
   protected getControllerIdentifiers(value: string): string[] {
-    return value.split(/\s+/).filter(id => id.length > 0)
+    return getTokenList(value)
   }
 
   /**
@@ -119,7 +114,7 @@ export abstract class StimulusRuleVisitor extends BaseRuleVisitor {
 
       if (match && value) {
         const controller = match[1]
-        const targetNames = value.split(/\s+/).filter(t => t.length > 0)
+        const targetNames = getTokenList(value)
         targets.set(controller, targetNames)
       }
     }
@@ -186,7 +181,7 @@ export abstract class StimulusRuleVisitor extends BaseRuleVisitor {
 
       if (match && value) {
         const [, controller] = match
-        const outletNames = value.split(/\s+/).filter(o => o.length > 0)
+        const outletNames = getTokenList(value)
 
         outlets.set(controller, outletNames)
       }
@@ -217,50 +212,6 @@ export abstract class HerbParserRule extends ParserRule {
 
     return true
   }
-}
-
-export function getSuggestion(input: string, candidates: string[]): string | null {
-  for (const candidate of candidates) {
-    if (levenshteinDistance(input.toLowerCase(), candidate.toLowerCase()) <= 2) {
-      return candidate
-    }
-  }
-
-  return null
-}
-
-export function levenshteinDistance(a: string, b: string): number {
-  const matrix: number[][] = []
-
-  for (let i = 0; i <= b.length; i++) {
-    matrix[i] = [i]
-  }
-
-  for (let j = 0; j <= a.length; j++) {
-    matrix[0][j] = j
-  }
-
-  for (let i = 1; i <= b.length; i++) {
-    for (let j = 1; j <= a.length; j++) {
-      if (b.charAt(i - 1) === a.charAt(j - 1)) {
-        matrix[i][j] = matrix[i - 1][j - 1]
-      } else {
-        matrix[i][j] = Math.min(
-          matrix[i - 1][j - 1] + 1,
-          matrix[i][j - 1] + 1,
-          matrix[i - 1][j] + 1
-        )
-      }
-    }
-  }
-
-  return matrix[b.length][a.length]
-}
-
-export function didyoumean(input: string, candidates: string[]): string | null {
-  const suggestion = getSuggestion(input, candidates)
-
-  return suggestion ? ` Did you mean \`${suggestion}\`?` : ""
 }
 
 // [event->]controller#method[:options]

--- a/javascript/packages/stimulus-lint/src/rules/stimulus-data-action-valid.ts
+++ b/javascript/packages/stimulus-lint/src/rules/stimulus-data-action-valid.ts
@@ -1,4 +1,5 @@
-import { StimulusRuleVisitor, HerbParserRule, didyoumean, getAttribute, getStaticAttributeValue, hasStaticAttributeValue, parseActionDescriptor } from "./rule-utils.js"
+import { StimulusRuleVisitor, HerbParserRule, parseActionDescriptor } from "./rule-utils.js"
+import { getAttribute, getStaticAttributeValue, hasStaticAttributeValue, getTokenList, didyoumean } from "@herb-tools/core"
 
 import type { UnboundLintOffense, StimulusLintContext, FullRuleConfig } from "../types.js"
 import type { ParseResult, HTMLOpenTagNode, HTMLAttributeNode } from "@herb-tools/core"
@@ -23,7 +24,7 @@ class DataActionValidVisitor extends StimulusRuleVisitor {
   }
 
   private validateStaticActions(value: string, attributeNode: HTMLAttributeNode): void {
-    const actions = value.trim().split(/\s+/).filter(action => action.length > 0)
+    const actions = getTokenList(value)
 
     for (const action of actions) {
       const descriptor = parseActionDescriptor(action)
@@ -42,7 +43,8 @@ class DataActionValidVisitor extends StimulusRuleVisitor {
         const controller = this.stimulusProject.registeredControllers.find(controller => controller.identifier === descriptor.identifier)
 
         if (controller && controller.controllerDefinition.actionNames && !controller.controllerDefinition.actionNames.includes(descriptor.methodName)) {
-          const suggestion = didyoumean(descriptor.methodName, controller.controllerDefinition.actionNames)
+          const match = didyoumean(descriptor.methodName, controller.controllerDefinition.actionNames, 2)
+          const suggestion = match ? ` Did you mean \`${match}\`?` : ""
           this.addOffense(`Unknown action method \`${descriptor.methodName}\` on controller "${descriptor.identifier}".${suggestion}`, attributeNode.location)
         }
       }

--- a/javascript/packages/stimulus-lint/src/rules/stimulus-data-controller-valid.ts
+++ b/javascript/packages/stimulus-lint/src/rules/stimulus-data-controller-valid.ts
@@ -1,4 +1,5 @@
-import { StimulusRuleVisitor, HerbParserRule, getAttributeName, getAttributeValue, getStaticAttributeValue, hasStaticAttributeValue } from "./rule-utils.js"
+import { StimulusRuleVisitor, HerbParserRule } from "./rule-utils.js"
+import { getAttributeName, getStaticAttributeValue, hasStaticAttributeValue, getAttributeValue } from "@herb-tools/core"
 
 import type { UnboundLintOffense, StimulusLintContext, FullRuleConfig } from "../types.js"
 import type { ParseResult, HTMLAttributeNode } from "@herb-tools/core"

--- a/javascript/packages/stimulus-lint/src/rules/stimulus-data-target-valid.ts
+++ b/javascript/packages/stimulus-lint/src/rules/stimulus-data-target-valid.ts
@@ -1,4 +1,5 @@
-import { StimulusRuleVisitor, HerbParserRule, didyoumean, getStaticAttributeValue, hasStaticAttributeValue, getAttributeName } from "./rule-utils.js"
+import { StimulusRuleVisitor, HerbParserRule } from "./rule-utils.js"
+import { getStaticAttributeValue, hasStaticAttributeValue, getAttributeName, getTokenList, didyoumean } from "@herb-tools/core"
 
 import type { UnboundLintOffense, StimulusLintContext, FullRuleConfig } from "../types.js"
 import type { ParseResult, HTMLAttributeNode } from "@herb-tools/core"
@@ -27,14 +28,15 @@ class DataTargetValidVisitor extends StimulusRuleVisitor {
       return
     }
 
-    const targetNames = value.trim().split(/\s+/).filter((name: string) => name.length > 0)
+    const targetNames = getTokenList(value)
 
     for (const targetName of targetNames) {
       if (this.stimulusProject) {
         const controller = this.stimulusProject.registeredControllers.find(controller => controller.identifier === identifier)
 
         if (controller && controller.controllerDefinition.targetNames && !controller.controllerDefinition.targetNames.includes(targetName)) {
-          const suggestion = didyoumean(targetName, controller.controllerDefinition.targetNames)
+          const match = didyoumean(targetName, controller.controllerDefinition.targetNames, 2)
+          const suggestion = match ? ` Did you mean \`${match}\`?` : ""
           this.addOffense(`Unknown target \`${targetName}\` on controller \`${identifier}\`.${suggestion}`, attributeNode.location)
         }
       }

--- a/javascript/packages/stimulus-lint/src/rules/stimulus-data-value-valid.ts
+++ b/javascript/packages/stimulus-lint/src/rules/stimulus-data-value-valid.ts
@@ -1,12 +1,5 @@
-import {
-  StimulusRuleVisitor,
-  HerbParserRule,
-  didyoumean,
-  forEachAttribute,
-  getAttributeName,
-  getStaticAttributeValue,
-  hasStaticAttributeValue
-} from './rule-utils.js'
+import { StimulusRuleVisitor, HerbParserRule } from './rule-utils.js'
+import { getAttributeName, getStaticAttributeValue, hasStaticAttributeValue, forEachAttribute, didyoumean } from "@herb-tools/core"
 
 import type { UnboundLintOffense, StimulusLintContext, FullRuleConfig } from '../types.js'
 import type { ParseResult, HTMLOpenTagNode, HTMLAttributeNode } from '@herb-tools/core'
@@ -62,7 +55,8 @@ export class DataValueValidVisitor extends StimulusRuleVisitor {
         const valueDefinition = controller.controllerDefinition.values.find(value => value.name === valueName)
 
         if (!valueDefinition) {
-          const suggestion = didyoumean(valueName, controller.controllerDefinition.values.map((v: any) => v.name))
+          const match = didyoumean(valueName, controller.controllerDefinition.values.map((v: any) => v.name), 2)
+          const suggestion = match ? ` Did you mean \`${match}\`?` : ""
 
           this.addOffense(
             `Unknown value \`${valueName}\` on controller \`${identifier}\`.${suggestion}`,


### PR DESCRIPTION
This pull request updates the formatter to detect `white-space` significant elements by either looking at the `style` attribute and seeing if it includes the `white-space:` property with the relevant value, or if it includes one of the Tailwind whitespace-preserving classes.

Additionally, it moves some of the AST utils related to attributes from the linter package to `core` so we can also use them in the formatter.

Resolves #1095