### PR TITLE
Ruby: Fix native extension loading for new RubyGems (Ruby 4.1+)

### DIFF
--- a/lib/herb.rb
+++ b/lib/herb.rb
@@ -35,12 +35,12 @@ begin
   major, minor, _patch = RUBY_VERSION.split(".") #: [String, String, String]
 
   if RUBY_PATCHLEVEL == -1
-    require_relative "herb/herb"
+    require "herb/herb"
   else
     begin
-      require_relative "herb/#{major}.#{minor}/herb"
+      require "herb/#{major}.#{minor}/herb"
     rescue LoadError
-      require_relative "herb/herb"
+      require "herb/herb"
     end
   end
 rescue LoadError => e


### PR DESCRIPTION
This pull request changes the native extension loading from `require_relative` to `require` to ensure compatibility with the latest RubyGems, which no longer installs native extensions into the gem's `lib/` directory by default. See https://github.com/ruby/rubygems/pull/9240.

Using `require` resolves the extension through `$LOAD_PATH`, which RubyGems populates with both the `lib/` and extension directories, so this works on both old and new versions of RubyGems.

Resolves #1244 
