### PR TITLE
Ruby: Add `arena_stats` kwarg and `--arena-stats` CLI flag

### DIFF
--- a/ext/herb/extension.c
+++ b/ext/herb/extension.c
@@ -1,6 +1,7 @@
 #include <ruby.h>
 
 #include "../../src/include/util/hb_allocator.h"
+#include "../../src/include/util/hb_arena_debug.h"
 
 #include "error_helpers.h"
 #include "extension.h"
@@ -80,8 +81,18 @@ static VALUE buffer_cleanup(VALUE arg) {
   return Qnil;
 }
 
-static VALUE Herb_lex(VALUE self, VALUE source) {
+static VALUE Herb_lex(int argc, VALUE* argv, VALUE self) {
+  VALUE source, options;
+  rb_scan_args(argc, argv, "1:", &source, &options);
+
   char* string = (char*) check_string(source);
+  bool print_arena_stats = false;
+
+  if (!NIL_P(options)) {
+    VALUE arena_stats = rb_hash_lookup(options, rb_utf8_str_new_cstr("arena_stats"));
+    if (NIL_P(arena_stats)) { arena_stats = rb_hash_lookup(options, ID2SYM(rb_intern("arena_stats"))); }
+    if (!NIL_P(arena_stats) && RTEST(arena_stats)) { print_arena_stats = true; }
+  }
 
   lex_args_T args = { 0 };
   args.source = source;
@@ -90,11 +101,23 @@ static VALUE Herb_lex(VALUE self, VALUE source) {
 
   args.tokens = herb_lex(string, &args.allocator);
 
+  if (print_arena_stats) { hb_arena_print_stats((hb_arena_T*) args.allocator.context); }
+
   return rb_ensure(lex_convert_body, (VALUE) &args, lex_cleanup, (VALUE) &args);
 }
 
-static VALUE Herb_lex_file(VALUE self, VALUE path) {
+static VALUE Herb_lex_file(int argc, VALUE* argv, VALUE self) {
+  VALUE path, options;
+  rb_scan_args(argc, argv, "1:", &path, &options);
+
   char* file_path = (char*) check_string(path);
+  bool print_arena_stats = false;
+
+  if (!NIL_P(options)) {
+    VALUE arena_stats = rb_hash_lookup(options, rb_utf8_str_new_cstr("arena_stats"));
+    if (NIL_P(arena_stats)) { arena_stats = rb_hash_lookup(options, ID2SYM(rb_intern("arena_stats"))); }
+    if (!NIL_P(arena_stats) && RTEST(arena_stats)) { print_arena_stats = true; }
+  }
 
   lex_args_T args = { 0 };
   args.source = read_file_to_ruby_string(file_path);
@@ -102,6 +125,8 @@ static VALUE Herb_lex_file(VALUE self, VALUE path) {
   if (!hb_allocator_init(&args.allocator, HB_ALLOCATOR_ARENA)) { return Qnil; }
 
   args.tokens = herb_lex_file(file_path, &args.allocator);
+
+  if (print_arena_stats) { hb_arena_print_stats((hb_arena_T*) args.allocator.context); }
 
   return rb_ensure(lex_convert_body, (VALUE) &args, lex_cleanup, (VALUE) &args);
 }
@@ -111,6 +136,7 @@ static VALUE Herb_parse(int argc, VALUE* argv, VALUE self) {
   rb_scan_args(argc, argv, "1:", &source, &options);
 
   char* string = (char*) check_string(source);
+  bool print_arena_stats = false;
 
   parser_options_T parser_options = HERB_DEFAULT_PARSER_OPTIONS;
 
@@ -126,6 +152,10 @@ static VALUE Herb_parse(int argc, VALUE* argv, VALUE self) {
     VALUE strict = rb_hash_lookup(options, rb_utf8_str_new_cstr("strict"));
     if (NIL_P(strict)) { strict = rb_hash_lookup(options, ID2SYM(rb_intern("strict"))); }
     if (!NIL_P(strict)) { parser_options.strict = RTEST(strict); }
+
+    VALUE arena_stats = rb_hash_lookup(options, rb_utf8_str_new_cstr("arena_stats"));
+    if (NIL_P(arena_stats)) { arena_stats = rb_hash_lookup(options, ID2SYM(rb_intern("arena_stats"))); }
+    if (!NIL_P(arena_stats) && RTEST(arena_stats)) { print_arena_stats = true; }
   }
 
   parse_args_T args = { 0 };
@@ -136,6 +166,8 @@ static VALUE Herb_parse(int argc, VALUE* argv, VALUE self) {
 
   args.root = herb_parse(string, &parser_options, &args.allocator);
 
+  if (print_arena_stats) { hb_arena_print_stats((hb_arena_T*) args.allocator.context); }
+
   return rb_ensure(parse_convert_body, (VALUE) &args, parse_cleanup, (VALUE) &args);
 }
 
@@ -144,6 +176,7 @@ static VALUE Herb_parse_file(int argc, VALUE* argv, VALUE self) {
   rb_scan_args(argc, argv, "1:", &path, &options);
 
   char* file_path = (char*) check_string(path);
+  bool print_arena_stats = false;
 
   VALUE source_value = read_file_to_ruby_string(file_path);
   char* string = (char*) check_string(source_value);
@@ -162,6 +195,10 @@ static VALUE Herb_parse_file(int argc, VALUE* argv, VALUE self) {
     VALUE strict = rb_hash_lookup(options, rb_utf8_str_new_cstr("strict"));
     if (NIL_P(strict)) { strict = rb_hash_lookup(options, ID2SYM(rb_intern("strict"))); }
     if (!NIL_P(strict)) { parser_options.strict = RTEST(strict); }
+
+    VALUE arena_stats = rb_hash_lookup(options, rb_utf8_str_new_cstr("arena_stats"));
+    if (NIL_P(arena_stats)) { arena_stats = rb_hash_lookup(options, ID2SYM(rb_intern("arena_stats"))); }
+    if (!NIL_P(arena_stats) && RTEST(arena_stats)) { print_arena_stats = true; }
   }
 
   parse_args_T args = { 0 };
@@ -171,6 +208,8 @@ static VALUE Herb_parse_file(int argc, VALUE* argv, VALUE self) {
   if (!hb_allocator_init(&args.allocator, HB_ALLOCATOR_ARENA)) { return Qnil; }
 
   args.root = herb_parse(string, &parser_options, &args.allocator);
+
+  if (print_arena_stats) { hb_arena_print_stats((hb_arena_T*) args.allocator.context); }
 
   return rb_ensure(parse_convert_body, (VALUE) &args, parse_cleanup, (VALUE) &args);
 }
@@ -256,9 +295,9 @@ __attribute__((__visibility__("default"))) void Init_herb(void) {
   rb_init_error_classes();
 
   rb_define_singleton_method(mHerb, "parse", Herb_parse, -1);
-  rb_define_singleton_method(mHerb, "lex", Herb_lex, 1);
+  rb_define_singleton_method(mHerb, "lex", Herb_lex, -1);
   rb_define_singleton_method(mHerb, "parse_file", Herb_parse_file, -1);
-  rb_define_singleton_method(mHerb, "lex_file", Herb_lex_file, 1);
+  rb_define_singleton_method(mHerb, "lex_file", Herb_lex_file, -1);
   rb_define_singleton_method(mHerb, "extract_ruby", Herb_extract_ruby, -1);
   rb_define_singleton_method(mHerb, "extract_html", Herb_extract_html, 1);
   rb_define_singleton_method(mHerb, "version", Herb_version, 0);

--- a/lib/herb/cli.rb
+++ b/lib/herb/cli.rb
@@ -8,7 +8,7 @@ require "optparse"
 class Herb::CLI
   include Herb::Colors
 
-  attr_accessor :json, :silent, :log_file, :no_timing, :local, :escape, :no_escape, :freeze, :debug, :tool, :strict, :analyze, :track_whitespace, :verbose, :isolate
+  attr_accessor :json, :silent, :log_file, :no_timing, :local, :escape, :no_escape, :freeze, :debug, :tool, :strict, :analyze, :track_whitespace, :verbose, :isolate, :arena_stats
 
   def initialize(args)
     @args = args
@@ -158,13 +158,13 @@ class Herb::CLI
                   show_config
                   exit(0)
                 when "parse"
-                  Herb.parse(file_content, strict: strict.nil? || strict, analyze: analyze.nil? || analyze, track_whitespace: track_whitespace || false)
+                  Herb.parse(file_content, strict: strict.nil? || strict, analyze: analyze.nil? || analyze, track_whitespace: track_whitespace || false, arena_stats: arena_stats)
                 when "compile"
                   compile_template
                 when "render"
                   render_template
                 when "lex"
-                  Herb.lex(file_content)
+                  Herb.lex(file_content, arena_stats: arena_stats)
                 when "ruby"
                   puts Herb.extract_ruby(file_content)
                   exit(0)
@@ -298,6 +298,10 @@ class Herb::CLI
 
       parser.on("--tool TOOL", "Show config for specific tool: linter, formatter (for config command)") do |t|
         self.tool = t.to_sym
+      end
+
+      parser.on("--arena-stats", "Print arena memory statistics (for lex/parse commands)") do
+        self.arena_stats = true
       end
     end
   end


### PR DESCRIPTION
```
❯ bundle exec exe/herb parse examples/test.html.erb --silent --arena-stats
╔════════════════════════════════════════════════════════════════════════════════════════════════════╗
║                                        ARENA MEMORY LAYOUT                                         ║
╠════════════════════════════════════════════════════════════════════════════════════════════════════╣
║  Statistics:                                                                                       ║
║    • Pages: 1                                                                                      ║
║    • Default Page Size: 16 KB                                                                      ║
║    • Total Capacity: 16 KB                                                                         ║
║    • Total Used: 7 KB                                                                              ║
║    • Total Available: 8 KB                                                                         ║
║    • Usage: 44.6%                                                                                  ║
║    • Allocations: 274                                                                              ║
║    • Fragmentation: 0 B                                                                            ║
╠════════════════════════════════════════════════════════════════════════════════════════════════════╣
║  Page 0 @ 0x104b2c000 ← CURRENT                                                                    ║
║    [████████████████████████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░]  7 KB / 16 KB (45%) ║
║    Unused: 8 KB (available for allocations)                                                        ║
║                                                                                                    ║
╚════════════════════════════════════════════════════════════════════════════════════════════════════╝
Success
```

```
irb(main):001> Herb.parse("<div></div>", arena_stats: true)
╔════════════════════════════════════════════════════════════════════════════════════════════════════╗
║                                        ARENA MEMORY LAYOUT                                         ║
╠════════════════════════════════════════════════════════════════════════════════════════════════════╣
║  Statistics:                                                                                       ║
║    • Pages: 1                                                                                      ║
║    • Default Page Size: 16 KB                                                                      ║
║    • Total Capacity: 16 KB                                                                         ║
║    • Total Used: 1 KB                                                                              ║
║    • Total Available: 14 KB                                                                        ║
║    • Usage: 8.0%                                                                                   ║
║    • Allocations: 48                                                                               ║
║    • Fragmentation: 0 B                                                                            ║
╠════════════════════════════════════════════════════════════════════════════════════════════════════╣
║  Page 0 @ 0x102f38000 ← CURRENT                                                                    ║
║    [█████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░]  1 KB / 16 KB (8%) ║
║    Unused: 14 KB (available for allocations)                                                       ║
║                                                                                                    ║
╚════════════════════════════════════════════════════════════════════════════════════════════════════╝
=>
#<Herb::ParseResult:0x0000000121ad6ef8 ...>
```