### PR TITLE
Linter: Access rule `type` from class instead of instance

### DIFF
--- a/javascript/packages/linter/src/linter.ts
+++ b/javascript/packages/linter/src/linter.ts
@@ -221,33 +221,39 @@ export class Linter {
     let ruleOffenses: UnboundLintOffense[]
 
     if (this.isLexerRuleClass(ruleClass)) {
-      if (rule.isEnabled) {
-        isEnabled = rule.isEnabled(lexResult, context)
+      const lexerRule = rule as LexerRule
+
+      if (lexerRule.isEnabled) {
+        isEnabled = lexerRule.isEnabled(lexResult, context)
       }
 
       if (isEnabled) {
-        ruleOffenses = (rule as LexerRule).check(lexResult, context)
+        ruleOffenses = lexerRule.check(lexResult, context)
       } else {
         ruleOffenses = []
       }
 
     } else if (this.isSourceRuleClass(ruleClass)) {
-      if (rule.isEnabled) {
-        isEnabled = rule.isEnabled(source, context)
+      const sourceRule = rule as SourceRule
+
+      if (sourceRule.isEnabled) {
+        isEnabled = sourceRule.isEnabled(source, context)
       }
 
       if (isEnabled) {
-        ruleOffenses = (rule as SourceRule).check(source, context)
+        ruleOffenses = sourceRule.check(source, context)
       } else {
         ruleOffenses = []
       }
     } else {
-      if (rule.isEnabled) {
-        isEnabled = rule.isEnabled(parseResult, context)
+      const parserRule = rule as ParserRule
+
+      if (parserRule.isEnabled) {
+        isEnabled = parserRule.isEnabled(parseResult, context)
       }
 
       if (isEnabled) {
-        ruleOffenses = (rule as ParserRule).check(parseResult, context)
+        ruleOffenses = parserRule.check(parseResult, context)
       } else {
         ruleOffenses = []
       }


### PR DESCRIPTION
This pull request refactors the linter by accessing the `static type` field directly on rule classes instead of instantiating rules and reading it from `rule.constructor`. 

The instance-level type guards (`isLexerRule`, `isSourceRule`, `isParserRule`) are replaced with class-level equivalents (`isLexerRuleClass`, `isSourceRuleClass`, `isParserRuleClass`) that take a `ruleClass` rather than a Rule instance. 

It also extracts a `findRuleClass(ruleName)` helper to deduplicate the six occurrences of `this.rules.find(rule => rule.ruleName === ...)`, and renames `RuleClass` local variables to `ruleClass` to follow camelCase conventions for non-type identifiers.

Follow up on #1268