### PR TITLE
Printer: Implement Indentation Printer

### DIFF
--- a/javascript/packages/printer/src/indent-printer.ts
+++ b/javascript/packages/printer/src/indent-printer.ts
@@ -1,0 +1,313 @@
+import { IdentityPrinter } from "./identity-printer.js"
+
+import type * as Nodes from "@herb-tools/core"
+
+/**
+ * IndentPrinter - Re-indentation printer that preserves content but adjusts indentation
+ *
+ * Extends IdentityPrinter to preserve all content as-is while replacing
+ * leading whitespace on each line with the correct indentation based on
+ * the AST nesting depth.
+ */
+export class IndentPrinter extends IdentityPrinter {
+  protected indentLevel: number = 0
+  protected indentWidth: number
+  private pendingIndent: boolean = false
+
+  constructor(indentWidth: number = 2) {
+    super()
+
+    this.indentWidth = indentWidth
+  }
+
+  protected get indent(): string {
+    return " ".repeat(this.indentLevel * this.indentWidth)
+  }
+
+  protected write(content: string): void {
+    if (this.pendingIndent && content.length > 0) {
+      this.pendingIndent = false
+      this.context.write(this.indent + content)
+    } else {
+      this.context.write(content)
+    }
+  }
+
+  visitLiteralNode(node: Nodes.LiteralNode): void {
+    this.writeWithIndent(node.content)
+  }
+
+  visitHTMLTextNode(node: Nodes.HTMLTextNode): void {
+    this.writeWithIndent(node.content)
+  }
+
+  visitHTMLElementNode(node: Nodes.HTMLElementNode): void {
+    const tagName = node.tag_name?.value
+
+    if (tagName) {
+      this.context.enterTag(tagName)
+    }
+
+    if (node.open_tag) {
+      this.visit(node.open_tag)
+    }
+
+    if (node.body) {
+      this.indentLevel++
+      node.body.forEach(child => this.visit(child))
+      this.indentLevel--
+    }
+
+    if (node.close_tag) {
+      this.visit(node.close_tag)
+    }
+
+    if (tagName) {
+      this.context.exitTag()
+    }
+  }
+
+  visitERBIfNode(node: Nodes.ERBIfNode): void {
+    this.printERBNode(node)
+
+    if (node.statements) {
+      this.indentLevel++
+      node.statements.forEach(statement => this.visit(statement))
+      this.indentLevel--
+    }
+
+    if (node.subsequent) {
+      this.visit(node.subsequent)
+    }
+
+    if (node.end_node) {
+      this.visit(node.end_node)
+    }
+  }
+
+  visitERBElseNode(node: Nodes.ERBElseNode): void {
+    this.printERBNode(node)
+
+    if (node.statements) {
+      this.indentLevel++
+      node.statements.forEach(statement => this.visit(statement))
+      this.indentLevel--
+    }
+  }
+
+  visitERBBlockNode(node: Nodes.ERBBlockNode): void {
+    this.printERBNode(node)
+
+    if (node.body) {
+      this.indentLevel++
+      node.body.forEach(child => this.visit(child))
+      this.indentLevel--
+    }
+
+    if (node.end_node) {
+      this.visit(node.end_node)
+    }
+  }
+
+  visitERBCaseNode(node: Nodes.ERBCaseNode): void {
+    this.printERBNode(node)
+
+    if (node.children) {
+      this.indentLevel++
+      node.children.forEach(child => this.visit(child))
+      this.indentLevel--
+    }
+
+    if (node.conditions) {
+      this.indentLevel++
+      node.conditions.forEach(condition => this.visit(condition))
+      this.indentLevel--
+    }
+
+    if (node.else_clause) {
+      this.indentLevel++
+      this.visit(node.else_clause)
+      this.indentLevel--
+    }
+
+    if (node.end_node) {
+      this.visit(node.end_node)
+    }
+  }
+
+  visitERBWhenNode(node: Nodes.ERBWhenNode): void {
+    this.printERBNode(node)
+
+    if (node.statements) {
+      this.indentLevel++
+      node.statements.forEach(statement => this.visit(statement))
+      this.indentLevel--
+    }
+  }
+
+  visitERBWhileNode(node: Nodes.ERBWhileNode): void {
+    this.printERBNode(node)
+
+    if (node.statements) {
+      this.indentLevel++
+      node.statements.forEach(statement => this.visit(statement))
+      this.indentLevel--
+    }
+
+    if (node.end_node) {
+      this.visit(node.end_node)
+    }
+  }
+
+  visitERBUntilNode(node: Nodes.ERBUntilNode): void {
+    this.printERBNode(node)
+
+    if (node.statements) {
+      this.indentLevel++
+      node.statements.forEach(statement => this.visit(statement))
+      this.indentLevel--
+    }
+
+    if (node.end_node) {
+      this.visit(node.end_node)
+    }
+  }
+
+  visitERBForNode(node: Nodes.ERBForNode): void {
+    this.printERBNode(node)
+
+    if (node.statements) {
+      this.indentLevel++
+      node.statements.forEach(statement => this.visit(statement))
+      this.indentLevel--
+    }
+
+    if (node.end_node) {
+      this.visit(node.end_node)
+    }
+  }
+
+  visitERBBeginNode(node: Nodes.ERBBeginNode): void {
+    this.printERBNode(node)
+
+    if (node.statements) {
+      this.indentLevel++
+      node.statements.forEach(statement => this.visit(statement))
+      this.indentLevel--
+    }
+
+    if (node.rescue_clause) {
+      this.visit(node.rescue_clause)
+    }
+
+    if (node.else_clause) {
+      this.visit(node.else_clause)
+    }
+
+    if (node.ensure_clause) {
+      this.visit(node.ensure_clause)
+    }
+
+    if (node.end_node) {
+      this.visit(node.end_node)
+    }
+  }
+
+  visitERBRescueNode(node: Nodes.ERBRescueNode): void {
+    this.printERBNode(node)
+
+    if (node.statements) {
+      this.indentLevel++
+      node.statements.forEach(statement => this.visit(statement))
+      this.indentLevel--
+    }
+
+    if (node.subsequent) {
+      this.visit(node.subsequent)
+    }
+  }
+
+  visitERBEnsureNode(node: Nodes.ERBEnsureNode): void {
+    this.printERBNode(node)
+
+    if (node.statements) {
+      this.indentLevel++
+      node.statements.forEach(statement => this.visit(statement))
+      this.indentLevel--
+    }
+  }
+
+  visitERBUnlessNode(node: Nodes.ERBUnlessNode): void {
+    this.printERBNode(node)
+
+    if (node.statements) {
+      this.indentLevel++
+      node.statements.forEach(statement => this.visit(statement))
+      this.indentLevel--
+    }
+
+    if (node.else_clause) {
+      this.visit(node.else_clause)
+    }
+
+    if (node.end_node) {
+      this.visit(node.end_node)
+    }
+  }
+
+  /**
+   * Write content, replacing leading whitespace on each line with the current indent.
+   *
+   * Uses a pendingIndent mechanism: when content ends with a newline followed by
+   * whitespace-only, sets pendingIndent=true instead of writing the indent immediately.
+   * The indent is then applied at the correct level when the next node writes content
+   * (via the overridden write() method).
+   */
+  protected writeWithIndent(content: string): void {
+    if (!content.includes("\n")) {
+      if (this.pendingIndent) {
+        this.pendingIndent = false
+
+        const trimmed = content.replace(/^[ \t]+/, "")
+
+        if (trimmed.length > 0) {
+          this.context.write(this.indent + trimmed)
+        }
+      } else {
+        this.context.write(content)
+      }
+
+      return
+    }
+
+    const lines = content.split("\n")
+    const lastIndex = lines.length - 1
+
+    for (let i = 0; i < lines.length; i++) {
+      if (i > 0) {
+        this.context.write("\n")
+      }
+
+      const line = lines[i]
+      const trimmed = line.replace(/^[ \t]+/, "")
+
+      if (i === 0) {
+        if (this.pendingIndent) {
+          this.pendingIndent = false
+
+          if (trimmed.length > 0) {
+            this.context.write(this.indent + trimmed)
+          }
+        } else {
+          this.context.write(line)
+        }
+      } else if (i === lastIndex && trimmed.length === 0) {
+        this.pendingIndent = true
+      } else if (trimmed.length === 0) {
+        // Middle whitespace-only line: write nothing (newline already written above)
+      } else {
+        this.context.write(this.indent + trimmed)
+      }
+    }
+  }
+}

--- a/javascript/packages/printer/src/index.ts
+++ b/javascript/packages/printer/src/index.ts
@@ -1,4 +1,5 @@
 export { IdentityPrinter } from "./identity-printer.js"
+export { IndentPrinter } from "./indent-printer.js"
 export { ERBToRubyStringPrinter } from "./erb-to-ruby-string-printer.js"
 export { PrintContext } from "./print-context.js"
 export { Printer, DEFAULT_PRINT_OPTIONS } from "./printer.js"

--- a/javascript/packages/printer/test/indent-printer.test.ts
+++ b/javascript/packages/printer/test/indent-printer.test.ts
@@ -1,0 +1,244 @@
+import dedent from "dedent"
+import { describe, test, expect, beforeAll } from "vitest"
+
+import { Herb } from "@herb-tools/node-wasm"
+import { IndentPrinter } from "../src/index.js"
+
+describe("IndentPrinter", () => {
+  beforeAll(async () => {
+    await Herb.load()
+  })
+
+  function printIndented(input: string, indentWidth: number = 2): string {
+    const parseResult = Herb.parse(input, { track_whitespace: true })
+    expect(parseResult.value).toBeTruthy()
+
+    const printer = new IndentPrinter(indentWidth)
+    return printer.print(parseResult.value!)
+  }
+
+  describe("Basic functionality", () => {
+    test("is defined", () => {
+      expect(IndentPrinter).toBeDefined()
+    })
+
+    test("can be instantiated", () => {
+      const printer = new IndentPrinter()
+      expect(printer).toBeInstanceOf(IndentPrinter)
+    })
+
+    test("static print method works", () => {
+      const input = "<div>Hello World</div>"
+      const parseResult = Herb.parse(input, { track_whitespace: true })
+      expect(parseResult.value).toBeTruthy()
+
+      const output = IndentPrinter.print(parseResult.value!)
+      expect(output).toBe(input)
+    })
+  })
+
+  describe("Flat elements", () => {
+    test("flat element prints unchanged", () => {
+      const input = "<div>Hello</div>"
+      expect(printIndented(input)).toBe("<div>Hello</div>")
+    })
+
+    test("self-closing element prints unchanged", () => {
+      const input = "<br />"
+      expect(printIndented(input)).toBe("<br />")
+    })
+  })
+
+  describe("Nested elements", () => {
+    test("nested elements get re-indented based on depth", () => {
+      const input = dedent`
+        <div>
+            <p>
+                Hello
+            </p>
+        </div>
+      `
+
+      const expected = dedent`
+        <div>
+          <p>
+            Hello
+          </p>
+        </div>
+      `
+
+      expect(printIndented(input)).toBe(expected)
+    })
+
+    test("deeply nested elements", () => {
+      const input = dedent`
+        <div>
+              <ul>
+                    <li>
+                          Hello
+                    </li>
+              </ul>
+        </div>
+      `
+
+      const expected = dedent`
+        <div>
+          <ul>
+            <li>
+              Hello
+            </li>
+          </ul>
+        </div>
+      `
+
+      expect(printIndented(input)).toBe(expected)
+    })
+  })
+
+  describe("indentWidth option", () => {
+    test("indentWidth of 4 spaces", () => {
+      const input = dedent`
+        <div>
+          <p>
+            Hello
+          </p>
+        </div>
+      `
+
+      const expected = dedent`
+        <div>
+            <p>
+                Hello
+            </p>
+        </div>
+      `
+
+      expect(printIndented(input, 4)).toBe(expected)
+    })
+  })
+
+  describe("Whitespace-only lines", () => {
+    test("whitespace-only lines become empty", () => {
+      const input = "<div>\n   \n  <p>Hello</p>\n</div>"
+
+      const expected = dedent`
+        <div>
+
+          <p>Hello</p>
+        </div>
+      `
+
+      expect(printIndented(input)).toBe(expected)
+    })
+  })
+
+  describe("Preserves attributes and tag structure", () => {
+    test("preserves attributes", () => {
+      const input = dedent`
+        <div class="container" id="main">
+              <p>Hello</p>
+        </div>
+      `
+
+      const expected = dedent`
+        <div class="container" id="main">
+          <p>Hello</p>
+        </div>
+      `
+
+      expect(printIndented(input)).toBe(expected)
+    })
+  })
+
+  describe("ERB block structures", () => {
+    test("ERB if/else indents each branch", () => {
+      const input = dedent`
+        <% if true %>
+              <p>Yes</p>
+        <% else %>
+              <p>No</p>
+        <% end %>
+      `
+
+      const expected = dedent`
+        <% if true %>
+          <p>Yes</p>
+        <% else %>
+          <p>No</p>
+        <% end %>
+      `
+
+      expect(printIndented(input)).toBe(expected)
+    })
+
+    test("ERB each block indents body", () => {
+      const input = dedent`
+        <% items.each do |item| %>
+              <p><%= item %></p>
+        <% end %>
+      `
+
+      const expected = dedent`
+        <% items.each do |item| %>
+          <p><%= item %></p>
+        <% end %>
+      `
+
+      expect(printIndented(input)).toBe(expected)
+    })
+
+    test("ERB unless indents body", () => {
+      const input = dedent`
+        <% unless false %>
+              <p>Hello</p>
+        <% end %>
+      `
+
+      const expected = dedent`
+        <% unless false %>
+          <p>Hello</p>
+        <% end %>
+      `
+
+      expect(printIndented(input)).toBe(expected)
+    })
+  })
+
+  describe("Mixed HTML + ERB", () => {
+    test("HTML with ERB content inside", () => {
+      const input = dedent`
+        <div>
+              <% if true %>
+                    <p>Hello</p>
+              <% end %>
+        </div>
+      `
+
+      const expected = dedent`
+        <div>
+          <% if true %>
+            <p>Hello</p>
+          <% end %>
+        </div>
+      `
+
+      expect(printIndented(input)).toBe(expected)
+    })
+
+    test("ERB expression in element", () => {
+      const input = dedent`
+        <div>
+              <%= @name %>
+        </div>
+      `
+
+      const expected = dedent`
+        <div>
+          <%= @name %>
+        </div>
+      `
+
+      expect(printIndented(input)).toBe(expected)
+    })
+  })
+})


### PR DESCRIPTION
This pull request implements a new `IndentPrinter` class in the `@herb-tools/printer` package that can be used to print an AST and preserve all content as-is while replacing leading whitespace on each line with the correct indentation based on the AST nesting depth.

Example:

```html
<div>
      <ul>
            <li>
                  Hello
            </li>
      </ul>
</div>
```

Becomes:
```html
<div>
  <ul>
    <li>
      Hello
    </li>
  </ul>
</div>
```

This is going to be useful when changing the nodes hierarchy in the AST and want the indentation to be reflected based on that transformation without needing to fully format it. Especially for things like the autofix for the `erb-no-duplicate-branch-elements` linter rule in #1301.