### PR TITLE
C: Implement Tracking Allocator and add `--leak-check` to `analyze`

### DIFF
--- a/ext/herb/extension.c
+++ b/ext/herb/extension.c
@@ -315,6 +315,98 @@ static VALUE Herb_arena_stats(int argc, VALUE* argv, VALUE self) {
   return hash;
 }
 
+static VALUE make_tracking_hash(hb_allocator_tracking_stats_T* stats) {
+  VALUE hash = rb_hash_new();
+  rb_hash_aset(hash, ID2SYM(rb_intern("allocations")), SIZET2NUM(stats->allocation_count));
+  rb_hash_aset(hash, ID2SYM(rb_intern("deallocations")), SIZET2NUM(stats->deallocation_count));
+  rb_hash_aset(hash, ID2SYM(rb_intern("bytes_allocated")), SIZET2NUM(stats->bytes_allocated));
+  rb_hash_aset(hash, ID2SYM(rb_intern("bytes_deallocated")), SIZET2NUM(stats->bytes_deallocated));
+  rb_hash_aset(hash, ID2SYM(rb_intern("untracked_deallocations")), SIZET2NUM(stats->untracked_deallocation_count));
+
+  VALUE leaks = rb_ary_new();
+  for (size_t i = 0; i < stats->buckets_capacity; i++) {
+    if (stats->buckets[i].pointer != NULL && stats->buckets[i].pointer != (void*) 1) {
+      rb_ary_push(leaks, SIZET2NUM(stats->buckets[i].size));
+    }
+  }
+  rb_hash_aset(hash, ID2SYM(rb_intern("leaks")), leaks);
+
+  VALUE untracked = rb_ary_new_capa((long) stats->untracked_pointers_size);
+  for (size_t i = 0; i < stats->untracked_pointers_size; i++) {
+    rb_ary_push(untracked, rb_sprintf("%p", stats->untracked_pointers[i]));
+  }
+  rb_hash_aset(hash, ID2SYM(rb_intern("untracked_pointers")), untracked);
+
+  return hash;
+}
+
+static VALUE Herb_leak_check(VALUE self, VALUE source) {
+  char* string = (char*) check_string(source);
+  VALUE result = rb_hash_new();
+
+  {
+    hb_allocator_T allocator;
+    if (!hb_allocator_init(&allocator, HB_ALLOCATOR_TRACKING)) { return Qnil; }
+
+    hb_array_T* tokens = herb_lex(string, &allocator);
+    if (tokens != NULL) { herb_free_tokens(&tokens, &allocator); }
+
+    hb_allocator_tracking_stats_T* stats = hb_allocator_tracking_stats(&allocator);
+    rb_hash_aset(result, ID2SYM(rb_intern("lex")), make_tracking_hash(stats));
+
+    hb_allocator_destroy(&allocator);
+  }
+
+  {
+    hb_allocator_T allocator;
+    if (!hb_allocator_init(&allocator, HB_ALLOCATOR_TRACKING)) { return Qnil; }
+
+    parser_options_T parser_options = HERB_DEFAULT_PARSER_OPTIONS;
+    AST_DOCUMENT_NODE_T* root = herb_parse(string, &parser_options, &allocator);
+    if (root != NULL) { ast_node_free((AST_NODE_T*) root, &allocator); }
+
+    hb_allocator_tracking_stats_T* stats = hb_allocator_tracking_stats(&allocator);
+    rb_hash_aset(result, ID2SYM(rb_intern("parse")), make_tracking_hash(stats));
+
+    hb_allocator_destroy(&allocator);
+  }
+
+  {
+    hb_buffer_T output;
+    if (!hb_buffer_init(&output, strlen(string))) { return Qnil; }
+
+    hb_allocator_T allocator;
+    if (!hb_allocator_init(&allocator, HB_ALLOCATOR_TRACKING)) { return Qnil; }
+
+    herb_extract_ruby_options_T extract_options = HERB_EXTRACT_RUBY_DEFAULT_OPTIONS;
+    herb_extract_ruby_to_buffer_with_options(string, &output, &extract_options, &allocator);
+
+    hb_allocator_tracking_stats_T* stats = hb_allocator_tracking_stats(&allocator);
+    rb_hash_aset(result, ID2SYM(rb_intern("extract_ruby")), make_tracking_hash(stats));
+
+    hb_allocator_destroy(&allocator);
+    free(output.value);
+  }
+
+  {
+    hb_buffer_T output;
+    if (!hb_buffer_init(&output, strlen(string))) { return Qnil; }
+
+    hb_allocator_T allocator;
+    if (!hb_allocator_init(&allocator, HB_ALLOCATOR_TRACKING)) { return Qnil; }
+
+    herb_extract_html_to_buffer(string, &output, &allocator);
+
+    hb_allocator_tracking_stats_T* stats = hb_allocator_tracking_stats(&allocator);
+    rb_hash_aset(result, ID2SYM(rb_intern("extract_html")), make_tracking_hash(stats));
+
+    hb_allocator_destroy(&allocator);
+    free(output.value);
+  }
+
+  return result;
+}
+
 static VALUE Herb_version(VALUE self) {
   VALUE gem_version = rb_const_get(self, rb_intern("VERSION"));
   VALUE libherb_version = rb_utf8_str_new_cstr(herb_version());
@@ -345,5 +437,6 @@ __attribute__((__visibility__("default"))) void Init_herb(void) {
   rb_define_singleton_method(mHerb, "extract_ruby", Herb_extract_ruby, -1);
   rb_define_singleton_method(mHerb, "extract_html", Herb_extract_html, 1);
   rb_define_singleton_method(mHerb, "arena_stats", Herb_arena_stats, -1);
+  rb_define_singleton_method(mHerb, "leak_check", Herb_leak_check, 1);
   rb_define_singleton_method(mHerb, "version", Herb_version, 0);
 }

--- a/lib/herb/cli.rb
+++ b/lib/herb/cli.rb
@@ -8,7 +8,7 @@ require "optparse"
 class Herb::CLI
   include Herb::Colors
 
-  attr_accessor :json, :silent, :log_file, :no_timing, :local, :escape, :no_escape, :freeze, :debug, :tool, :strict, :analyze, :track_whitespace, :verbose, :isolate, :arena_stats
+  attr_accessor :json, :silent, :log_file, :no_timing, :local, :escape, :no_escape, :freeze, :debug, :tool, :strict, :analyze, :track_whitespace, :verbose, :isolate, :arena_stats, :leak_check
 
   def initialize(args)
     @args = args
@@ -150,6 +150,7 @@ class Herb::CLI
                   project.isolate = isolate
                   project.validate_ruby = true
                   project.arena_stats = arena_stats
+                  project.leak_check = leak_check
                   has_issues = project.analyze!
                   exit(has_issues ? 1 : 0)
                 when "report"
@@ -303,6 +304,10 @@ class Herb::CLI
 
       parser.on("--arena-stats", "Print arena memory statistics (for lex/parse/analyze commands)") do
         self.arena_stats = true
+      end
+
+      parser.on("--leak-check", "Check for memory leaks in lex/parse/extract operations (for analyze command)") do
+        self.leak_check = true
       end
     end
   end

--- a/lib/herb/project.rb
+++ b/lib/herb/project.rb
@@ -12,7 +12,7 @@ module Herb
   class Project
     include Colors
 
-    attr_accessor :project_path, :output_file, :no_log_file, :no_timing, :silent, :verbose, :isolate, :validate_ruby, :file_paths, :arena_stats
+    attr_accessor :project_path, :output_file, :no_log_file, :no_timing, :silent, :verbose, :isolate, :validate_ruby, :file_paths, :arena_stats, :leak_check
 
     # Known error types that indicate issues in the user's template, not bugs in the parser.
     TEMPLATE_ERRORS = [
@@ -260,6 +260,10 @@ module Herb
           print_arena_summary(file_results)
         end
 
+        if leak_check
+          print_leak_check_summary(file_results)
+        end
+
         unless no_log_file
           puts "\n #{separator}"
           puts "\n #{dimmed("Results saved to #{output_file}")}"
@@ -345,6 +349,10 @@ module Herb
 
       if arena_stats
         result[:arena_stats] = capture_arena_stats(file_content)
+      end
+
+      if leak_check
+        result[:leak_check] = capture_leak_check(file_content)
       end
 
       Timeout.timeout(1) do
@@ -884,6 +892,90 @@ module Herb
         minutes = (seconds / 60).to_i
         remaining_seconds = seconds % 60
         "#{minutes}m #{remaining_seconds.round(2)}s"
+      end
+    end
+
+    def capture_leak_check(file_content)
+      Herb.leak_check(file_content)
+    rescue StandardError
+      { lex: { allocations: 0, deallocations: 0, bytes_allocated: 0, bytes_deallocated: 0 },
+        parse: { allocations: 0, deallocations: 0, bytes_allocated: 0, bytes_deallocated: 0 },
+        extract_ruby: { allocations: 0, deallocations: 0, bytes_allocated: 0, bytes_deallocated: 0 },
+        extract_html: { allocations: 0, deallocations: 0, bytes_allocated: 0, bytes_deallocated: 0 } }
+    end
+
+    def print_leak_check_summary(file_results)
+      leaky_files = file_results.filter_map { |result|
+        next unless result[:leak_check]
+
+        ops = result[:leak_check]
+        leaks = ops.select { |_op, stats| stats[:leaks]&.any? || stats[:allocations] != stats[:deallocations] || stats[:untracked_deallocations]&.positive? }
+        next if leaks.empty?
+
+        { file: result[:file_path], leaks: leaks, all: ops }
+      }
+
+      puts "\n #{separator}"
+      puts "\n"
+      puts " #{bold("Leak check:")}"
+
+      if leaky_files.empty?
+        puts ""
+        puts "  #{bold(green("✓"))} #{green("No leaks detected across all files.")}"
+        return
+      end
+
+      puts "  #{red("#{leaky_files.size} #{pluralize(leaky_files.size, "file")} with potential leaks:")}"
+      puts ""
+
+      leaky_files.each do |entry|
+        relative = relative_path(entry[:file])
+        puts "  #{cyan(relative)}:"
+
+        entry[:all].each do |op, stats|
+          leaks = stats[:leaks] || []
+          untracked_count = stats[:untracked_deallocations] || 0
+          untracked_ptrs = stats[:untracked_pointers] || []
+          leaked_bytes = stats[:bytes_allocated] - stats[:bytes_deallocated]
+
+          if leaks.any?
+            puts "    #{red("✗")} #{op}: #{stats[:allocations]} allocs, #{stats[:deallocations]} deallocs (#{bold(red("#{leaks.size} unfreed, #{format_bytes(leaked_bytes)}"))})"
+            leaks.each_with_index do |size, i|
+              puts "      #{dimmed("#{i + 1}.")} #{format_bytes(size)}"
+            end
+          elsif untracked_count.positive?
+            puts "    #{yellow("~")} #{op}: #{stats[:allocations]} allocs, #{stats[:deallocations]} deallocs"
+          else
+            puts "    #{green("✓")} #{op}: #{stats[:allocations]} allocs, #{stats[:deallocations]} deallocs"
+          end
+
+          next unless untracked_count.positive?
+
+          puts "      #{yellow("#{untracked_count} untracked #{pluralize(untracked_count, "deallocation")}")} #{dimmed("(freed through allocator but not allocated through it)")}"
+          untracked_ptrs.each_with_index do |ptr, i|
+            puts "      #{dimmed("#{i + 1}.")} #{ptr}"
+          end
+        end
+
+        puts ""
+      end
+
+      op_to_command = { lex: "lex", parse: "parse", extract_ruby: "ruby", extract_html: "html" }
+
+      commands = leaky_files.flat_map { |entry|
+        entry[:leaks].keys.map { |op| { command: op_to_command[op] || op.to_s, file: entry[:file] } }
+      }
+
+      puts "  #{dimmed("To debug, run the following from the herb repo root (build with `make` first):")}"
+      puts ""
+      puts "  #{dimmed("# macOS")}"
+      commands.each do |cmd|
+        puts "  leaks --atExit -- ./herb #{cmd[:command]} #{cmd[:file]}"
+      end
+      puts ""
+      puts "  #{dimmed("# Linux")}"
+      commands.each do |cmd|
+        puts "  valgrind --leak-check=full ./herb #{cmd[:command]} #{cmd[:file]}"
       end
     end
 

--- a/src/include/util/hb_allocator.h
+++ b/src/include/util/hb_allocator.h
@@ -13,7 +13,27 @@
 typedef enum {
   HB_ALLOCATOR_MALLOC,
   HB_ALLOCATOR_ARENA,
+  HB_ALLOCATOR_TRACKING,
 } hb_allocator_type_T;
+
+typedef struct {
+  void* pointer;
+  size_t size;
+} hb_allocator_tracking_entry_T;
+
+typedef struct {
+  size_t allocation_count;
+  size_t deallocation_count;
+  size_t untracked_deallocation_count;
+  size_t bytes_allocated;
+  size_t bytes_deallocated;
+  hb_allocator_tracking_entry_T* buckets;
+  size_t buckets_capacity;
+  size_t buckets_used;
+  void** untracked_pointers;
+  size_t untracked_pointers_size;
+  size_t untracked_pointers_capacity;
+} hb_allocator_tracking_stats_T;
 
 typedef struct hb_allocator {
   void* (*alloc)(struct hb_allocator* self, size_t size);
@@ -30,6 +50,9 @@ void hb_allocator_destroy(hb_allocator_T* allocator);
 
 hb_allocator_T hb_allocator_with_malloc(void);
 hb_allocator_T hb_allocator_with_arena(hb_arena_T* arena);
+hb_allocator_T hb_allocator_with_tracking(void);
+
+hb_allocator_tracking_stats_T* hb_allocator_tracking_stats(hb_allocator_T* allocator);
 
 static inline void* hb_allocator_alloc(hb_allocator_T* allocator, size_t size) {
   return allocator->alloc(allocator, size);

--- a/src/util/hb_allocator.c
+++ b/src/util/hb_allocator.c
@@ -1,6 +1,7 @@
 #include "../include/util/hb_allocator.h"
 #include "../include/util/hb_arena.h"
 
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -103,6 +104,170 @@ hb_allocator_T hb_allocator_with_arena(hb_arena_T* arena) {
   };
 }
 
+// --- Tracking backend ---
+
+#define TRACKING_INITIAL_CAPACITY 128
+#define TRACKING_TOMBSTONE ((void*) 1)
+
+static size_t tracking_probe(hb_allocator_tracking_stats_T* stats, void* pointer) {
+  size_t mask = stats->buckets_capacity - 1;
+  size_t index = ((size_t) pointer >> 4) & mask;
+
+  while (true) {
+    void* key = stats->buckets[index].pointer;
+    if (key == NULL || key == TRACKING_TOMBSTONE || key == pointer) { return index; }
+    index = (index + 1) & mask;
+  }
+}
+
+static void tracking_grow(hb_allocator_tracking_stats_T* stats) {
+  size_t old_capacity = stats->buckets_capacity;
+  hb_allocator_tracking_entry_T* old_buckets = stats->buckets;
+
+  size_t new_capacity = old_capacity ? old_capacity * 2 : TRACKING_INITIAL_CAPACITY;
+  stats->buckets = calloc(new_capacity, sizeof(hb_allocator_tracking_entry_T));
+  stats->buckets_capacity = new_capacity;
+  stats->buckets_used = 0;
+
+  for (size_t i = 0; i < old_capacity; i++) {
+    if (old_buckets[i].pointer != NULL && old_buckets[i].pointer != TRACKING_TOMBSTONE) {
+      size_t index = tracking_probe(stats, old_buckets[i].pointer);
+      stats->buckets[index] = old_buckets[i];
+      stats->buckets_used++;
+    }
+  }
+
+  free(old_buckets);
+}
+
+static void tracking_record(hb_allocator_tracking_stats_T* stats, void* pointer, size_t size) {
+  if (stats->buckets_used * 2 >= stats->buckets_capacity) { tracking_grow(stats); }
+
+  size_t index = tracking_probe(stats, pointer);
+  stats->buckets[index] = (hb_allocator_tracking_entry_T) { .pointer = pointer, .size = size };
+  stats->buckets_used++;
+  stats->allocation_count++;
+  stats->bytes_allocated += size;
+}
+
+static void tracking_record_untracked(hb_allocator_tracking_stats_T* stats, void* pointer) {
+  stats->untracked_deallocation_count++;
+
+  if (stats->untracked_pointers_size >= stats->untracked_pointers_capacity) {
+    size_t new_capacity = stats->untracked_pointers_capacity ? stats->untracked_pointers_capacity * 2 : 16;
+    void** new_pointers = realloc(stats->untracked_pointers, new_capacity * sizeof(void*));
+
+    if (!new_pointers) { return; }
+
+    stats->untracked_pointers = new_pointers;
+    stats->untracked_pointers_capacity = new_capacity;
+  }
+
+  stats->untracked_pointers[stats->untracked_pointers_size++] = pointer;
+}
+
+static void tracking_unrecord(hb_allocator_tracking_stats_T* stats, void* pointer) {
+  if (!stats->buckets_capacity) {
+    tracking_record_untracked(stats, pointer);
+
+    return;
+  }
+
+  size_t mask = stats->buckets_capacity - 1;
+  size_t index = ((size_t) pointer >> 4) & mask;
+
+  while (true) {
+    void* key = stats->buckets[index].pointer;
+
+    if (key == NULL) {
+      tracking_record_untracked(stats, pointer);
+
+      return;
+    }
+
+    if (key == pointer) {
+      stats->deallocation_count++;
+      stats->bytes_deallocated += stats->buckets[index].size;
+      stats->buckets[index].pointer = TRACKING_TOMBSTONE;
+      stats->buckets[index].size = 0;
+
+      return;
+    }
+
+    index = (index + 1) & mask;
+  }
+}
+
+static void* tracking_alloc(hb_allocator_T* self, size_t size) {
+  hb_allocator_tracking_stats_T* stats = (hb_allocator_tracking_stats_T*) self->context;
+  void* pointer = calloc(1, size);
+
+  if (pointer) { tracking_record(stats, pointer, size); }
+
+  return pointer;
+}
+
+static void tracking_dealloc(hb_allocator_T* self, void* pointer) {
+  hb_allocator_tracking_stats_T* stats = (hb_allocator_tracking_stats_T*) self->context;
+  tracking_unrecord(stats, pointer);
+  free(pointer);
+}
+
+static char* tracking_strdup(hb_allocator_T* self, const char* string) {
+  if (!string) { return NULL; }
+
+  hb_allocator_tracking_stats_T* stats = (hb_allocator_tracking_stats_T*) self->context;
+  size_t length = strlen(string);
+  char* copy = malloc(length + 1);
+  if (!copy) { return NULL; }
+
+  memcpy(copy, string, length + 1);
+  tracking_record(stats, copy, length + 1);
+
+  return copy;
+}
+
+static char* tracking_strndup(hb_allocator_T* self, const char* string, size_t length) {
+  if (!string) { return NULL; }
+
+  hb_allocator_tracking_stats_T* stats = (hb_allocator_tracking_stats_T*) self->context;
+  char* copy = malloc(length + 1);
+  if (!copy) { return NULL; }
+
+  memcpy(copy, string, length);
+  copy[length] = '\0';
+  tracking_record(stats, copy, length + 1);
+
+  return copy;
+}
+
+static void tracking_destroy(hb_allocator_T* self) {
+  hb_allocator_tracking_stats_T* stats = (hb_allocator_tracking_stats_T*) self->context;
+
+  free(stats->buckets);
+  free(stats->untracked_pointers);
+  free(stats);
+
+  self->context = NULL;
+}
+
+hb_allocator_T hb_allocator_with_tracking(void) {
+  hb_allocator_tracking_stats_T* stats = calloc(1, sizeof(hb_allocator_tracking_stats_T));
+
+  return (hb_allocator_T) {
+    .alloc = tracking_alloc,
+    .dealloc = tracking_dealloc,
+    .strdup = tracking_strdup,
+    .strndup = tracking_strndup,
+    .destroy = tracking_destroy,
+    .context = stats,
+  };
+}
+
+hb_allocator_tracking_stats_T* hb_allocator_tracking_stats(hb_allocator_T* allocator) {
+  return (hb_allocator_tracking_stats_T*) allocator->context;
+}
+
 // --- High-level API ---
 
 bool hb_allocator_init(hb_allocator_T* allocator, hb_allocator_type_T type) {
@@ -128,6 +293,11 @@ bool hb_allocator_init_with_size(hb_allocator_T* allocator, hb_allocator_type_T 
       }
 
       *allocator = hb_allocator_with_arena(arena);
+      return true;
+    }
+
+    case HB_ALLOCATOR_TRACKING: {
+      *allocator = hb_allocator_with_tracking();
       return true;
     }
 


### PR DESCRIPTION
This pull request implements a new `hb_alloctor_T` implementation that tracks allocations and checks if all allocations are also being freed again.

We also expose a new `--leak-check` CLI flag for the `analyze` subcommand so we can easily check a whole project if any of the files leak.

**`herb analyze ../rubyevents --leak-check`**

<img width="1900" height="882" alt="CleanShot 2026-03-05 at 08 40 16@2x" src="https://github.com/user-attachments/assets/3ed26685-dbf9-4661-8e55-2379a967779a" />


**With leaks:**

<img width="2844" height="1762" alt="CleanShot 2026-03-05 at 08 39 40@2x" src="https://github.com/user-attachments/assets/6b95f474-2479-4f8a-be1b-514847fbc86a" />


**Calling `delloc` on a pointer that wasn't allocated using our allocator:**

<img width="2812" height="1722" alt="CleanShot 2026-03-05 at 08 40 36@2x" src="https://github.com/user-attachments/assets/2190fefc-023b-4398-9d24-8193d6381646" />
