### PR TITLE
Formatter: Preserve user newlines for inline elements

### DIFF
--- a/javascript/packages/formatter/src/format-printer.ts
+++ b/javascript/packages/formatter/src/format-printer.ts
@@ -1295,11 +1295,7 @@ export class FormatPrinter extends Printer implements TextFlowDelegate, Attribut
       const contentStartsOnNewLine = startsOnNewLine || hasLeadingNewline
 
       if (contentStartsOnNewLine) {
-        const hasERBChildren = children.some(child => isERBNode(child))
-
-        if (hasERBChildren || hasMixedTextAndInlineContent(children)) {
-          return false
-        }
+        return false
       }
     }
 

--- a/javascript/packages/formatter/src/text-flow-analyzer.ts
+++ b/javascript/packages/formatter/src/text-flow-analyzer.ts
@@ -1,4 +1,4 @@
-import { isNode, getTagName } from "@herb-tools/core"
+import { isNode, getTagName, isERBCommentNode } from "@herb-tools/core"
 import { Node, HTMLTextNode, HTMLElementNode, ERBContentNode, WhitespaceNode } from "@herb-tools/core"
 
 import type { ContentUnitWithNode } from "./format-helpers.js"
@@ -189,6 +189,24 @@ export class TextFlowAnalyzer {
       unit: { content: erbContent, type: 'erb', isAtomic: true, breaksFlow: false, isHerbDisable: herbDisable },
       node: child
     })
+
+    if (isERBCommentNode(child) && !herbDisable) {
+      for (let j = index + 1; j < children.length; j++) {
+        const nextChild = children[j]
+        if (isNode(nextChild, WhitespaceNode)) continue
+        if (isPureWhitespaceNode(nextChild)) continue
+
+        const hasNewlineBefore = isNode(nextChild, HTMLTextNode) && /\n/.test(nextChild.content.split(/\S/)[0] || '')
+        if (nextChild.location.start.line > child.location.end.line || hasNewlineBefore) {
+          result.push({
+            unit: { content: '', type: 'text', isAtomic: false, breaksFlow: true },
+            node: null
+          })
+        }
+
+        break
+      }
+    }
 
     return false
   }

--- a/javascript/packages/formatter/src/text-flow-engine.ts
+++ b/javascript/packages/formatter/src/text-flow-engine.ts
@@ -297,7 +297,7 @@ export class TextFlowEngine {
       }
 
       if (currentLine && !isClosingPunctuation(word) && nextEffectiveLength > wrapWidth) {
-        lines.push(this.delegate.indent + currentLine.trimEnd())
+        lines.push(this.delegate.indent + currentLine.trim())
 
         currentLine = word
         effectiveLength = isHerbDisable ? 0 : word.length
@@ -308,7 +308,7 @@ export class TextFlowEngine {
     }
 
     if (currentLine) {
-      lines.push(this.delegate.indent + currentLine.trimEnd())
+      lines.push(this.delegate.indent + currentLine.trim())
     }
 
     lines.forEach(line => this.delegate.push(line))

--- a/javascript/packages/formatter/test/document-formatting.test.ts
+++ b/javascript/packages/formatter/test/document-formatting.test.ts
@@ -196,23 +196,13 @@ describe("Document-level formatting", () => {
   })
 
   test("handles ERB loops with proper spacing", () => {
-    const source = dedent`
+    expectFormattedToMatch(dedent`
       <% items = [1, 2, 3] %>
 
       <% items.each do |item| %>
         <div class="item">
           <span><%= item %></span>
         </div>
-      <% end %>
-
-      <div class="footer">Done</div>
-    `
-    const result = formatter.format(source)
-    expect(result).toEqual(dedent`
-      <% items = [1, 2, 3] %>
-
-      <% items.each do |item| %>
-        <div class="item"><span><%= item %></span></div>
       <% end %>
 
       <div class="footer">Done</div>

--- a/javascript/packages/formatter/test/erb/comment.test.ts
+++ b/javascript/packages/formatter/test/erb/comment.test.ts
@@ -324,4 +324,23 @@ describe("@herb-tools/formatter", () => {
     const result100 = formatter.format(source100)
     expect(result100).toEqual(source100)
   })
+
+  test("preserve newline after ERB comment", () => {
+    const source = dedent`
+      <div>
+        <%# just a regular comment %>
+        Some text that should wrap normally when it gets very long and exceeds the maximum line length limit.
+      </div>
+    `
+
+    const result = formatter.format(source)
+
+    expect(result).toBe(dedent`
+      <div>
+        <%# just a regular comment %>
+        Some text that should wrap normally when it gets very long and exceeds the
+        maximum line length limit.
+      </div>
+    `)
+  })
 })

--- a/javascript/packages/formatter/test/herb-disable-comment-formatting.test.ts
+++ b/javascript/packages/formatter/test/herb-disable-comment-formatting.test.ts
@@ -133,8 +133,9 @@ describe("herb:disable comment formatting", () => {
 
     const result = formatter.format(source)
 
-    expect(result).not.toBe(dedent`
-      <div> <%# just a regular comment %>
+    expect(result).toBe(dedent`
+      <div>
+        <%# just a regular comment %>
         Some text that should wrap normally when it gets very long and exceeds the
         maximum line length limit.
       </div>

--- a/javascript/packages/formatter/test/herb-formatter-ignore.test.ts
+++ b/javascript/packages/formatter/test/herb-formatter-ignore.test.ts
@@ -61,24 +61,34 @@ describe("herb:formatter ignore directive", () => {
     const source = dedent`
       <%# herb:formatter ignore some-rule %>
       <div>
-        <span>content</span>
+            <span>content</span>
       </div>
     `
 
     const result = formatter.format(source)
-    expect(result).not.toBe(source)
+    expect(result).toBe(dedent`
+      <%# herb:formatter ignore some-rule %>
+      <div>
+        <span>content</span>
+      </div>
+    `)
   })
 
   test("should not match herb:disable all", () => {
     const source = dedent`
       <%# herb:disable all %>
       <DIV>
-        <SPAN>content</SPAN>
+            <SPAN>content</SPAN>
       </DIV>
     `
 
     const result = formatter.format(source)
-    expect(result).not.toBe(source)
+    expect(result).toBe(dedent`
+      <%# herb:disable all %>
+      <DIV>
+        <SPAN>content</SPAN>
+      </DIV>
+    `)
   })
 
   test("should ignore formatting when directive is at end of file", () => {

--- a/javascript/packages/formatter/test/html/inline-elements.test.ts
+++ b/javascript/packages/formatter/test/html/inline-elements.test.ts
@@ -179,6 +179,18 @@ describe("@herb-tools/formatter - inline elements", () => {
     `)
   })
 
+  test("block element with inline child on separate line preserves format (issue #1181)", () => {
+    expectFormattedToMatch(dedent`
+      <div id="one" class="card">
+        <span>Hello</span>
+      </div>
+    `)
+  })
+
+  test("block element with inline child on same line stays inline (issue #1181)", () => {
+    expectFormattedToMatch(`<div id="one" class="card"><span>Hello</span></div>`)
+  })
+
   test("block element with ERB output child on separate line preserves format (issue #1181)", () => {
     expectFormattedToMatch(dedent`
       <div class="form-inputs">

--- a/javascript/packages/formatter/test/html/text-content.test.ts
+++ b/javascript/packages/formatter/test/html/text-content.test.ts
@@ -456,8 +456,8 @@ describe("@herb-tools/formatter", () => {
     `)
   })
 
-  test("inline bold with ERB collapses when alone but preserves when adjacent", () => {
-    const source = dedent`
+  test("inline bold with ERB preserves user newlines", () => {
+    expectFormattedToMatch(dedent`
       <p>
         <b><%= a_thing %> <%= another_thing %></b>
       </p>
@@ -470,20 +470,12 @@ describe("@herb-tools/formatter", () => {
         <b><%= a_thing %> <%= another_thing %></b>
         <b><%= a_thing %> <%= another_thing %></b>a
       </p>
-    `
+    `)
 
-    const result = formatter.format(source)
-    expect(result).toEqual(dedent`
+    expectFormattedToMatch(dedent`
       <p><b><%= a_thing %> <%= another_thing %></b></p>
 
-      <p>
-        <b><%= a_thing %> <%= another_thing %></b>a
-      </p>
-
-      <p>
-        <b><%= a_thing %> <%= another_thing %></b>
-        <b><%= a_thing %> <%= another_thing %></b>a
-      </p>
+      <p><b><%= a_thing %> <%= another_thing %></b>a</p>
     `)
   })
 })


### PR DESCRIPTION
Follow up on #1279 and #1295