### PR TITLE
C: Remove unnecessary `malloc` usage in errors and `hb_string`

### DIFF
--- a/src/analyze/conditional_elements.c
+++ b/src/analyze/conditional_elements.c
@@ -413,10 +413,9 @@ static void rewrite_conditional_elements(hb_array_T* nodes, hb_array_T* document
     position_T start_position = matched_open->open_conditional->location.start;
     position_T end_position = node->location.end;
     hb_array_T* errors = hb_array_init(8);
-    char* condition_copy = hb_string_to_c_string_using_malloc(hb_string(matched_open->condition));
 
     AST_HTML_CONDITIONAL_ELEMENT_NODE_T* conditional_element = ast_html_conditional_element_node_init(
-      condition_copy,
+      matched_open->condition,
       matched_open->open_conditional,
       matched_open->open_tag,
       body,
@@ -429,8 +428,6 @@ static void rewrite_conditional_elements(hb_array_T* nodes, hb_array_T* document
       errors,
       allocator
     );
-
-    free(condition_copy);
 
     for (size_t body_index = matched_open->open_index + 1; body_index < node_index; body_index++) {
       size_t* consumed_index = malloc(sizeof(size_t));

--- a/src/include/util/hb_string.h
+++ b/src/include/util/hb_string.h
@@ -22,8 +22,6 @@ hb_string_T hb_string_truncate(hb_string_T string, uint32_t max_length);
 
 hb_string_T hb_string_range(hb_string_T string, uint32_t from, uint32_t to);
 
-char* hb_string_to_c_string_using_malloc(hb_string_T string);
-
 char* hb_string_to_c_string(hb_arena_T* allocator, hb_string_T string);
 
 #endif

--- a/src/util/hb_string.c
+++ b/src/util/hb_string.c
@@ -62,19 +62,6 @@ hb_string_T hb_string_range(hb_string_T string, uint32_t from, uint32_t to) {
   return hb_string_truncate(hb_string_slice(string, from), to - from);
 }
 
-char* hb_string_to_c_string_using_malloc(hb_string_T string) {
-  size_t string_length_in_bytes = sizeof(char) * (string.length);
-  char* buffer = malloc(string_length_in_bytes + sizeof(char) * 1);
-
-  if (!buffer) { return NULL; }
-
-  if (!hb_string_is_empty(string)) { memcpy(buffer, string.data, string_length_in_bytes); }
-
-  buffer[string_length_in_bytes] = '\0';
-
-  return buffer;
-}
-
 char* hb_string_to_c_string(hb_arena_T* allocator, hb_string_T string) {
   size_t string_length_in_bytes = sizeof(char) * (string.length);
   char* buffer = hb_arena_alloc(allocator, string_length_in_bytes + sizeof(char) * 1);

--- a/templates/src/errors.c.erb
+++ b/templates/src/errors.c.erb
@@ -39,36 +39,29 @@ void error_init(ERROR_T* error, const error_type_T type, position_T start, posit
   <%- if error.message_arguments.any? -%>
   const char* message_template = "<%= error.message_template %>";
 
-  size_t message_size = <%= Herb::Template::PrintfMessageTemplate.estimate_buffer_size(error.message_template) %>;
-  char* message = (char*) malloc(message_size);
+  <%- error.message_arguments.each_with_index do |argument, i| -%>
+  <%- if error.message_template.scan(/%(?:zu|llu|lf|ld|[sdulf])/)[i] == "%s" -%>
+  char truncated_argument_<%= i %>[ERROR_MESSAGES_TRUNCATED_LENGTH + 1];
+  strncpy(truncated_argument_<%= i %>, <%= argument %>, ERROR_MESSAGES_TRUNCATED_LENGTH);
+  truncated_argument_<%= i %>[ERROR_MESSAGES_TRUNCATED_LENGTH] = '\0';
 
-  if (message) {
-    <%- error.message_arguments.each_with_index do |argument, i| -%>
-    <%- if error.message_template.scan(/%(?:zu|llu|lf|ld|[sdulf])/)[i] == "%s" -%>
-    char truncated_argument_<%= i %>[ERROR_MESSAGES_TRUNCATED_LENGTH + 1];
-    strncpy(truncated_argument_<%= i %>, <%= argument %>, ERROR_MESSAGES_TRUNCATED_LENGTH);
-    truncated_argument_<%= i %>[ERROR_MESSAGES_TRUNCATED_LENGTH] = '\0';
-
+  <%- end -%>
+  <%- end -%>
+  char message[<%= Herb::Template::PrintfMessageTemplate.estimate_buffer_size(error.message_template) %>];
+  snprintf(
+    message,
+    sizeof(message),
+    message_template,
+    <%- error.message_arguments.each_with_index do |argument, index| -%>
+    <%- if error.message_template.scan(/%(?:zu|llu|lf|ld|[sdulf])/)[index] == "%s" -%>
+    truncated_argument_<%= index %><% if index != error.message_arguments.length - 1 %>,<% end %>
+    <%- else -%>
+    <%= argument %><% if index != error.message_arguments.length - 1 %>,<% end %>
     <%- end -%>
     <%- end -%>
-    snprintf(
-      message,
-      message_size,
-      message_template,
-      <%- error.message_arguments.each_with_index do |argument, index| -%>
-      <%- if error.message_template.scan(/%(?:zu|llu|lf|ld|[sdulf])/)[index] == "%s" -%>
-      truncated_argument_<%= index %><% if index != error.message_arguments.length - 1 %>,<% end %>
-      <%- else -%>
-      <%= argument %><% if index != error.message_arguments.length - 1 %>,<% end %>
-      <%- end -%>
-      <%- end -%>
-    );
+  );
 
-    <%= error.human %>->base.message = hb_allocator_strdup(allocator, message);
-    free(message);
-  } else {
-    <%= error.human %>->base.message = hb_allocator_strdup(allocator, "<%= error.message_template %>");
-  }
+  <%= error.human %>->base.message = hb_allocator_strdup(allocator, message);
   <%- else -%>
   <%= error.human %>->base.message = hb_allocator_strdup(allocator, "<%= error.message_template %>");
   <%- end -%>


### PR DESCRIPTION
Follow up on #1306 