### PR TITLE
C: Optimize `hb_string()` to compute length at compile time

### DIFF
--- a/src/include/util/hb_string.h
+++ b/src/include/util/hb_string.h
@@ -15,12 +15,12 @@ typedef struct HB_STRING_STRUCT {
 #define HB_STRING_EMPTY ((hb_string_T){ .data = "", .length = 0 })
 #define HB_STRING_NULL  ((hb_string_T){ .data = NULL, .length = 0 })
 
-hb_string_T hb_string_from_cstr(const char* null_terminated_c_string);
+hb_string_T hb_string_from_c_string(const char* null_terminated_c_string);
 
 #define hb_string(string) \
   (__builtin_constant_p(string) \
     ? ((hb_string_T){ .data = (char*)(string), .length = (uint32_t)__builtin_strlen(string) }) \
-    : hb_string_from_cstr(string))
+    : hb_string_from_c_string(string))
 
 hb_string_T hb_string_slice(hb_string_T string, uint32_t offset);
 

--- a/src/util/hb_string.c
+++ b/src/util/hb_string.c
@@ -6,7 +6,7 @@
 #include <string.h>
 #include <strings.h>
 
-hb_string_T hb_string_from_cstr(const char* null_terminated_c_string) {
+hb_string_T hb_string_from_c_string(const char* null_terminated_c_string) {
   if (null_terminated_c_string == NULL) { return HB_STRING_NULL; }
 
   hb_string_T string;


### PR DESCRIPTION
This pull request converts the `hb_string()` function to a macro and renames the existing `hb_string` function to `hb_string_from_c_string`. 

We do this in order to optimize `hb_string()` calls with static string literals so that they have no runtime-overhead for converting a C-String to a `hb_string_T`.

This applies for calls like:
```c
hb_string("<%")
hb_string("%>")
```
For dynamic strings it will fallback to `hb_string_from_c_string()`:
```c
hb_string(variable)
hb_string(message)
```