### PR TITLE
C: Implement `realloc` for `hb_allocator_T`

### DIFF
--- a/src/include/util/hb_allocator.h
+++ b/src/include/util/hb_allocator.h
@@ -37,6 +37,7 @@ typedef struct {
 
 typedef struct hb_allocator {
   void* (*alloc)(struct hb_allocator* self, size_t size);
+  void* (*realloc)(struct hb_allocator* self, void* pointer, size_t old_size, size_t new_size);
   void (*dealloc)(struct hb_allocator* self, void* pointer);
   char* (*strdup)(struct hb_allocator* self, const char* string);
   char* (*strndup)(struct hb_allocator* self, const char* string, size_t length);
@@ -56,6 +57,10 @@ hb_allocator_tracking_stats_T* hb_allocator_tracking_stats(hb_allocator_T* alloc
 
 static inline void* hb_allocator_alloc(hb_allocator_T* allocator, size_t size) {
   return allocator->alloc(allocator, size);
+}
+
+static inline void* hb_allocator_realloc(hb_allocator_T* allocator, void* pointer, size_t old_size, size_t new_size) {
+  return allocator->realloc(allocator, pointer, old_size, new_size);
 }
 
 static inline void hb_allocator_dealloc(hb_allocator_T* allocator, void* pointer) {

--- a/src/util/hb_allocator.c
+++ b/src/util/hb_allocator.c
@@ -39,12 +39,17 @@ static char* malloc_strndup(hb_allocator_T* _self, const char* string, size_t le
   return copy;
 }
 
+static void* malloc_realloc(hb_allocator_T* _self, void* pointer, size_t _old_size, size_t new_size) {
+  return realloc(pointer, new_size);
+}
+
 static void malloc_destroy(hb_allocator_T* _self) {
 }
 
 hb_allocator_T hb_allocator_with_malloc(void) {
   return (hb_allocator_T) {
     .alloc = malloc_alloc,
+    .realloc = malloc_realloc,
     .dealloc = malloc_dealloc,
     .strdup = malloc_strdup,
     .strndup = malloc_strndup,
@@ -57,6 +62,18 @@ hb_allocator_T hb_allocator_with_malloc(void) {
 
 static void* arena_alloc(hb_allocator_T* self, size_t size) {
   return hb_arena_alloc((hb_arena_T*) self->context, size);
+}
+
+static void* arena_realloc(hb_allocator_T* self, void* pointer, size_t old_size, size_t new_size) {
+  if (!pointer) { return arena_alloc(self, new_size); }
+
+  void* new_pointer = hb_arena_alloc((hb_arena_T*) self->context, new_size);
+  if (!new_pointer) { return NULL; }
+
+  size_t copy_size = old_size < new_size ? old_size : new_size;
+  memcpy(new_pointer, pointer, copy_size);
+
+  return new_pointer;
 }
 
 static void arena_dealloc(hb_allocator_T* _self, void* _pointer) {
@@ -96,6 +113,7 @@ static void arena_destroy(hb_allocator_T* self) {
 hb_allocator_T hb_allocator_with_arena(hb_arena_T* arena) {
   return (hb_allocator_T) {
     .alloc = arena_alloc,
+    .realloc = arena_realloc,
     .dealloc = arena_dealloc,
     .strdup = arena_strdup,
     .strndup = arena_strndup,
@@ -207,6 +225,18 @@ static void* tracking_alloc(hb_allocator_T* self, size_t size) {
   return pointer;
 }
 
+static void* tracking_realloc(hb_allocator_T* self, void* pointer, size_t _old_size, size_t new_size) {
+  hb_allocator_tracking_stats_T* stats = (hb_allocator_tracking_stats_T*) self->context;
+
+  if (pointer) { tracking_unrecord(stats, pointer); }
+
+  void* new_pointer = realloc(pointer, new_size);
+
+  if (new_pointer) { tracking_record(stats, new_pointer, new_size); }
+
+  return new_pointer;
+}
+
 static void tracking_dealloc(hb_allocator_T* self, void* pointer) {
   hb_allocator_tracking_stats_T* stats = (hb_allocator_tracking_stats_T*) self->context;
   tracking_unrecord(stats, pointer);
@@ -256,6 +286,7 @@ hb_allocator_T hb_allocator_with_tracking(void) {
 
   return (hb_allocator_T) {
     .alloc = tracking_alloc,
+    .realloc = tracking_realloc,
     .dealloc = tracking_dealloc,
     .strdup = tracking_strdup,
     .strndup = tracking_strndup,

--- a/test/c/main.c
+++ b/test/c/main.c
@@ -1,6 +1,7 @@
 #include <check.h>
 #include <stdlib.h>
 
+TCase *hb_allocator_realloc_tests(void);
 TCase *hb_arena_tests(void);
 TCase *hb_array_tests(void);
 TCase *hb_narray_tests(void);
@@ -17,6 +18,7 @@ TCase *extract_tests(void);
 Suite *herb_suite(void) {
   Suite *suite = suite_create("Herb Suite");
 
+  suite_add_tcase(suite, hb_allocator_realloc_tests());
   suite_add_tcase(suite, hb_arena_tests());
   suite_add_tcase(suite, hb_array_tests());
   suite_add_tcase(suite, hb_narray_tests());

--- a/test/c/test_hb_allocator_realloc.c
+++ b/test/c/test_hb_allocator_realloc.c
@@ -1,0 +1,152 @@
+#include "include/test.h"
+#include "../../src/include/util/hb_allocator.h"
+
+#include <string.h>
+
+TEST(test_malloc_realloc_null_pointer)
+  hb_allocator_T allocator = hb_allocator_with_malloc();
+
+  void* pointer = hb_allocator_realloc(&allocator, NULL, 0, 64);
+  ck_assert_ptr_nonnull(pointer);
+
+  hb_allocator_dealloc(&allocator, pointer);
+END
+
+TEST(test_malloc_realloc_grow)
+  hb_allocator_T allocator = hb_allocator_with_malloc();
+
+  char* pointer = hb_allocator_alloc(&allocator, 16);
+  ck_assert_ptr_nonnull(pointer);
+  memcpy(pointer, "hello, world!!!", 16);
+
+  char* new_pointer = hb_allocator_realloc(&allocator, pointer, 16, 64);
+  ck_assert_ptr_nonnull(new_pointer);
+  ck_assert_int_eq(memcmp(new_pointer, "hello, world!!!", 16), 0);
+
+  hb_allocator_dealloc(&allocator, new_pointer);
+END
+
+TEST(test_malloc_realloc_shrink)
+  hb_allocator_T allocator = hb_allocator_with_malloc();
+
+  char* pointer = hb_allocator_alloc(&allocator, 64);
+  ck_assert_ptr_nonnull(pointer);
+  memcpy(pointer, "shrink me", 10);
+
+  char* new_pointer = hb_allocator_realloc(&allocator, pointer, 64, 16);
+  ck_assert_ptr_nonnull(new_pointer);
+  ck_assert_int_eq(memcmp(new_pointer, "shrink me", 10), 0);
+
+  hb_allocator_dealloc(&allocator, new_pointer);
+END
+
+TEST(test_arena_realloc_null_pointer)
+  hb_allocator_T allocator;
+  hb_allocator_init(&allocator, HB_ALLOCATOR_ARENA);
+
+  void* pointer = hb_allocator_realloc(&allocator, NULL, 0, 64);
+  ck_assert_ptr_nonnull(pointer);
+
+  hb_allocator_destroy(&allocator);
+END
+
+TEST(test_arena_realloc_grow)
+  hb_allocator_T allocator;
+  hb_allocator_init(&allocator, HB_ALLOCATOR_ARENA);
+
+  char* pointer = hb_allocator_alloc(&allocator, 16);
+  ck_assert_ptr_nonnull(pointer);
+  memcpy(pointer, "hello, world!!!", 16);
+
+  char* new_pointer = hb_allocator_realloc(&allocator, pointer, 16, 64);
+  ck_assert_ptr_nonnull(new_pointer);
+  ck_assert_ptr_ne(new_pointer, pointer);
+  ck_assert_int_eq(memcmp(new_pointer, "hello, world!!!", 16), 0);
+
+  hb_allocator_destroy(&allocator);
+END
+
+TEST(test_arena_realloc_shrink)
+  hb_allocator_T allocator;
+  hb_allocator_init(&allocator, HB_ALLOCATOR_ARENA);
+
+  char* pointer = hb_allocator_alloc(&allocator, 64);
+  ck_assert_ptr_nonnull(pointer);
+  memcpy(pointer, "shrink me", 10);
+
+  char* new_pointer = hb_allocator_realloc(&allocator, pointer, 64, 16);
+  ck_assert_ptr_nonnull(new_pointer);
+  ck_assert_int_eq(memcmp(new_pointer, "shrink me", 10), 0);
+
+  hb_allocator_destroy(&allocator);
+END
+
+TEST(test_arena_realloc_preserves_data_across_pages)
+  hb_allocator_T allocator;
+  hb_allocator_init_with_size(&allocator, HB_ALLOCATOR_ARENA, 64);
+
+  char* pointer = hb_allocator_alloc(&allocator, 32);
+  ck_assert_ptr_nonnull(pointer);
+  memset(pointer, 'A', 32);
+
+  char* new_pointer = hb_allocator_realloc(&allocator, pointer, 32, 128);
+  ck_assert_ptr_nonnull(new_pointer);
+
+  for (size_t i = 0; i < 32; i++) {
+    ck_assert_int_eq(new_pointer[i], 'A');
+  }
+
+  hb_allocator_destroy(&allocator);
+END
+
+TEST(test_tracking_realloc_null_pointer)
+  hb_allocator_T allocator = hb_allocator_with_tracking();
+
+  void* pointer = hb_allocator_realloc(&allocator, NULL, 0, 64);
+  ck_assert_ptr_nonnull(pointer);
+
+  hb_allocator_tracking_stats_T* stats = hb_allocator_tracking_stats(&allocator);
+  ck_assert_int_eq(stats->allocation_count, 1);
+  ck_assert_int_eq(stats->bytes_allocated, 64);
+
+  hb_allocator_dealloc(&allocator, pointer);
+  hb_allocator_destroy(&allocator);
+END
+
+TEST(test_tracking_realloc_grow)
+  hb_allocator_T allocator = hb_allocator_with_tracking();
+
+  char* pointer = hb_allocator_alloc(&allocator, 16);
+  memcpy(pointer, "hello, world!!!", 16);
+
+  char* new_pointer = hb_allocator_realloc(&allocator, pointer, 16, 64);
+  ck_assert_ptr_nonnull(new_pointer);
+  ck_assert_int_eq(memcmp(new_pointer, "hello, world!!!", 16), 0);
+
+  hb_allocator_tracking_stats_T* stats = hb_allocator_tracking_stats(&allocator);
+  ck_assert_int_eq(stats->allocation_count, 2);
+  ck_assert_int_eq(stats->deallocation_count, 1);
+  ck_assert_int_eq(stats->bytes_allocated, 16 + 64);
+  ck_assert_int_eq(stats->bytes_deallocated, 16);
+
+  hb_allocator_dealloc(&allocator, new_pointer);
+  hb_allocator_destroy(&allocator);
+END
+
+TCase *hb_allocator_realloc_tests(void) {
+  TCase *allocator = tcase_create("Herb Allocator");
+
+  tcase_add_test(allocator, test_malloc_realloc_null_pointer);
+  tcase_add_test(allocator, test_malloc_realloc_grow);
+  tcase_add_test(allocator, test_malloc_realloc_shrink);
+
+  tcase_add_test(allocator, test_arena_realloc_null_pointer);
+  tcase_add_test(allocator, test_arena_realloc_grow);
+  tcase_add_test(allocator, test_arena_realloc_shrink);
+  tcase_add_test(allocator, test_arena_realloc_preserves_data_across_pages);
+
+  tcase_add_test(allocator, test_tracking_realloc_null_pointer);
+  tcase_add_test(allocator, test_tracking_realloc_grow);
+
+  return allocator;
+}


### PR DESCRIPTION
This pull request adds `realloc` to the `hb_allocator_T` interface and implements all backend-specific `realloc` functions.

Currently, our `hb_array_T` and `hb_buffer_T` implementations use `realloc` for growing beyond their current capacity. In order to also migrate `hb_array` and `hb_buffer` to the allocator infrastructure we need a way to also support `realloc` in the interface.