### PR TITLE
C: Migrate `hb_array` to use `hb_allocator_T` infrastructure

### DIFF
--- a/src/analyze/analyze.c
+++ b/src/analyze/analyze.c
@@ -287,9 +287,9 @@ static size_t process_case_structure(
   AST_ERB_CONTENT_NODE_T* erb_node = get_erb_content_at(array, index);
   if (!erb_node) { return index; }
 
-  hb_array_T* when_conditions = hb_array_init(8);
-  hb_array_T* in_conditions = hb_array_init(8);
-  hb_array_T* non_when_non_in_children = hb_array_init(8);
+  hb_array_T* when_conditions = hb_array_init(8, allocator);
+  hb_array_T* in_conditions = hb_array_init(8, allocator);
+  hb_array_T* non_when_non_in_children = hb_array_init(8, allocator);
 
   analyzed_ruby_T* analyzed = erb_node->analyzed_ruby;
   bool has_inline_when = has_case_node(analyzed) && has_when_node(analyzed);
@@ -309,7 +309,7 @@ static size_t process_case_structure(
   // Create a synthetic when/in node for inline when/in (e.g., <% case variable when "a" %>),
   if (has_inline_when || has_inline_in) {
     hb_array_T* statements = non_when_non_in_children;
-    non_when_non_in_children = hb_array_init(8);
+    non_when_non_in_children = hb_array_init(8, allocator);
 
     position_T start_position =
       erb_node->tag_closing ? erb_node->tag_closing->location.end : erb_node->content->location.end;
@@ -329,7 +329,7 @@ static size_t process_case_structure(
         statements,
         start_position,
         end_position,
-        hb_array_init(0),
+        hb_array_init(0, allocator),
         allocator
       );
 
@@ -343,7 +343,7 @@ static size_t process_case_structure(
         statements,
         start_position,
         end_position,
-        hb_array_init(0),
+        hb_array_init(0, allocator),
         allocator
       );
 
@@ -367,7 +367,7 @@ static size_t process_case_structure(
     control_type_t next_type = detect_control_type(next_erb);
 
     if (next_type == CONTROL_TYPE_WHEN || next_type == CONTROL_TYPE_IN) {
-      hb_array_T* statements = hb_array_init(8);
+      hb_array_T* statements = hb_array_init(8, allocator);
       index++;
       index = process_block_children(node, array, index, statements, context, next_type);
 
@@ -422,7 +422,7 @@ static size_t process_case_structure(
   AST_ERB_CONTENT_NODE_T* next_erb = NULL;
 
   if (peek_control_type(array, index, &next_type, &next_erb) && next_type == CONTROL_TYPE_ELSE) {
-    hb_array_T* else_children = hb_array_init(8);
+    hb_array_T* else_children = hb_array_init(8, allocator);
     index++;
 
     index = process_block_children(node, array, index, else_children, context, CONTROL_TYPE_CASE);
@@ -518,7 +518,7 @@ static size_t process_begin_structure(
   hb_allocator_T* allocator = context->allocator;
   AST_ERB_CONTENT_NODE_T* erb_node = get_erb_content_at(array, index);
   if (!erb_node) { return index; }
-  hb_array_T* children = hb_array_init(8);
+  hb_array_T* children = hb_array_init(8, allocator);
 
   index++;
   index = process_block_children(node, array, index, children, context, CONTROL_TYPE_BEGIN);
@@ -537,7 +537,7 @@ static size_t process_begin_structure(
   }
 
   if (peek_control_type(array, index, &next_type, &next_erb) && next_type == CONTROL_TYPE_ELSE) {
-    hb_array_T* else_children = hb_array_init(8);
+    hb_array_T* else_children = hb_array_init(8, allocator);
     index++;
 
     index = process_block_children(node, array, index, else_children, context, CONTROL_TYPE_BEGIN);
@@ -560,7 +560,7 @@ static size_t process_begin_structure(
   }
 
   if (peek_control_type(array, index, &next_type, &next_erb) && next_type == CONTROL_TYPE_ENSURE) {
-    hb_array_T* ensure_children = hb_array_init(8);
+    hb_array_T* ensure_children = hb_array_init(8, allocator);
     index++;
 
     const control_type_t ensure_stop[] = { CONTROL_TYPE_END };
@@ -635,7 +635,7 @@ static size_t process_generic_structure(
   hb_allocator_T* allocator = context->allocator;
   AST_ERB_CONTENT_NODE_T* erb_node = get_erb_content_at(array, index);
   if (!erb_node) { return index; }
-  hb_array_T* children = hb_array_init(8);
+  hb_array_T* children = hb_array_init(8, allocator);
 
   index++;
   index = process_block_children(node, array, index, children, context, initial_type);
@@ -690,7 +690,7 @@ static size_t process_subsequent_block(
   if (!erb_node) { return index; }
 
   control_type_t type = detect_control_type(erb_node);
-  hb_array_T* children = hb_array_init(8);
+  hb_array_T* children = hb_array_init(8, allocator);
 
   index++;
 
@@ -772,7 +772,7 @@ static size_t process_block_children(
     if (is_terminator_type(parent_type, child_type)) { break; }
 
     if (is_compound_control_type(child_type)) {
-      hb_array_T* temp_array = hb_array_init(1);
+      hb_array_T* temp_array = hb_array_init(1, context->allocator);
       size_t new_index = process_control_structure(node, array, index, temp_array, context, child_type);
 
       if (hb_array_size(temp_array) > 0) { hb_array_append(children_array, hb_array_first(temp_array)); }
@@ -792,7 +792,7 @@ static size_t process_block_children(
 
 hb_array_T* rewrite_node_array(AST_NODE_T* node, hb_array_T* array, analyze_ruby_context_T* context) {
   hb_allocator_T* allocator = context->allocator;
-  hb_array_T* new_array = hb_array_init(hb_array_size(array));
+  hb_array_T* new_array = hb_array_init(hb_array_size(array), allocator);
   size_t index = 0;
 
   while (index < hb_array_size(array)) {
@@ -847,7 +847,7 @@ void herb_analyze_parse_tree(
   analyze_ruby_context_T context = {
     .document = document,
     .parent = NULL,
-    .ruby_context_stack = hb_array_init(8),
+    .ruby_context_stack = hb_array_init(8, allocator),
     .allocator = allocator,
   };
 

--- a/src/analyze/conditional_elements.c
+++ b/src/analyze/conditional_elements.c
@@ -241,7 +241,7 @@ static void rewrite_conditional_elements(hb_array_T* nodes, hb_array_T* document
     }
   }
 
-  hb_array_T* open_stack = hb_array_init(8);
+  hb_array_T* open_stack = hb_array_init(8, allocator);
 
   for (size_t node_index = 0; node_index < hb_array_size(nodes); node_index++) {
     AST_NODE_T* node = (AST_NODE_T*) hb_array_get(nodes, node_index);
@@ -271,7 +271,7 @@ static void rewrite_conditional_elements(hb_array_T* nodes, hb_array_T* document
     }
   }
 
-  hb_array_T* consumed_indices = hb_array_init(8);
+  hb_array_T* consumed_indices = hb_array_init(8, allocator);
 
   for (size_t node_index = 0; node_index < hb_array_size(nodes); node_index++) {
     AST_NODE_T* node = (AST_NODE_T*) hb_array_get(nodes, node_index);
@@ -345,7 +345,7 @@ static void rewrite_conditional_elements(hb_array_T* nodes, hb_array_T* document
 
     if (!matched_open) { continue; }
 
-    hb_array_T* body = hb_array_init(8);
+    hb_array_T* body = hb_array_init(8, allocator);
 
     for (size_t body_index = matched_open->open_index + 1; body_index < node_index; body_index++) {
       AST_NODE_T* body_node = (AST_NODE_T*) hb_array_get(nodes, body_index);
@@ -355,7 +355,7 @@ static void rewrite_conditional_elements(hb_array_T* nodes, hb_array_T* document
 
     position_T start_position = matched_open->open_conditional->location.start;
     position_T end_position = node->location.end;
-    hb_array_T* errors = hb_array_init(8);
+    hb_array_T* errors = hb_array_init(0, allocator);
 
     AST_HTML_CONDITIONAL_ELEMENT_NODE_T* conditional_element = ast_html_conditional_element_node_init(
       matched_open->condition,
@@ -406,7 +406,7 @@ static void rewrite_conditional_elements(hb_array_T* nodes, hb_array_T* document
   hb_array_free(&open_stack);
 
   if (hb_array_size(consumed_indices) > 0) {
-    hb_array_T* new_nodes = hb_array_init(hb_array_size(nodes));
+    hb_array_T* new_nodes = hb_array_init(hb_array_size(nodes), allocator);
 
     for (size_t node_index = 0; node_index < hb_array_size(nodes); node_index++) {
       bool consumed = false;

--- a/src/analyze/conditional_open_tags.c
+++ b/src/analyze/conditional_open_tags.c
@@ -265,7 +265,7 @@ static void add_multiple_tags_error_to_erb_node(
     allocator
   );
 
-  if (!erb_node->errors) { erb_node->errors = hb_array_init(1); }
+  if (!erb_node->errors) { erb_node->errors = hb_array_init(0, allocator); }
 
   hb_array_append(erb_node->errors, error);
 }
@@ -340,7 +340,7 @@ static void rewrite_conditional_open_tags(hb_array_T* nodes, hb_array_T* documen
 
   if (!nodes || hb_array_size(nodes) == 0) { return; }
 
-  hb_array_T* consumed_indices = hb_array_init(8);
+  hb_array_T* consumed_indices = hb_array_init(8, allocator);
 
   for (size_t i = 0; i < hb_array_size(nodes); i++) {
     AST_NODE_T* node = (AST_NODE_T*) hb_array_get(nodes, i);
@@ -379,7 +379,7 @@ static void rewrite_conditional_open_tags(hb_array_T* nodes, hb_array_T* documen
 
     if (close_index == (size_t) -1 || !close_tag) { continue; }
 
-    hb_array_T* body = hb_array_init(8);
+    hb_array_T* body = hb_array_init(8, allocator);
 
     for (size_t j = i + 1; j < close_index; j++) {
       AST_NODE_T* body_node = (AST_NODE_T*) hb_array_get(nodes, j);
@@ -389,7 +389,7 @@ static void rewrite_conditional_open_tags(hb_array_T* nodes, hb_array_T* documen
     position_T start_position = conditional_node->location.start;
     position_T end_position = close_tag->base.location.end;
 
-    hb_array_T* conditional_open_tag_errors = hb_array_init(1);
+    hb_array_T* conditional_open_tag_errors = hb_array_init(0, allocator);
 
     AST_HTML_CONDITIONAL_OPEN_TAG_NODE_T* conditional_open_tag = ast_html_conditional_open_tag_node_init(
       conditional_node,
@@ -401,7 +401,7 @@ static void rewrite_conditional_open_tags(hb_array_T* nodes, hb_array_T* documen
       allocator
     );
 
-    hb_array_T* element_errors = hb_array_init(1);
+    hb_array_T* element_errors = hb_array_init(0, allocator);
 
     AST_HTML_ELEMENT_NODE_T* element = ast_html_element_node_init(
       (AST_NODE_T*) conditional_open_tag,
@@ -429,7 +429,7 @@ static void rewrite_conditional_open_tags(hb_array_T* nodes, hb_array_T* documen
   }
 
   if (hb_array_size(consumed_indices) > 0) {
-    hb_array_T* new_nodes = hb_array_init(hb_array_size(nodes));
+    hb_array_T* new_nodes = hb_array_init(hb_array_size(nodes), allocator);
 
     for (size_t i = 0; i < hb_array_size(nodes); i++) {
       bool consumed = false;

--- a/src/ast_node.c
+++ b/src/ast_node.c
@@ -15,7 +15,14 @@ size_t ast_node_sizeof(void) {
   return sizeof(struct AST_NODE_STRUCT);
 }
 
-void ast_node_init(AST_NODE_T* node, const ast_node_type_T type, position_T start, position_T end, hb_array_T* errors) {
+void ast_node_init(
+  AST_NODE_T* node,
+  const ast_node_type_T type,
+  position_T start,
+  position_T end,
+  hb_array_T* errors,
+  hb_allocator_T* allocator
+) {
   if (!node) { return; }
 
   node->type = type;
@@ -23,7 +30,7 @@ void ast_node_init(AST_NODE_T* node, const ast_node_type_T type, position_T star
   node->location.end = end;
 
   if (errors == NULL) {
-    node->errors = hb_array_init(8);
+    node->errors = hb_array_init(0, allocator);
   } else {
     node->errors = errors;
   }
@@ -34,7 +41,7 @@ AST_LITERAL_NODE_T* ast_literal_node_init_from_token(const token_T* token, hb_al
 
   if (!literal) { return NULL; }
 
-  ast_node_init(&literal->base, AST_LITERAL_NODE, token->location.start, token->location.end, NULL);
+  ast_node_init(&literal->base, AST_LITERAL_NODE, token->location.start, token->location.end, NULL, allocator);
 
   literal->content = hb_string_copy(token->value, allocator);
 

--- a/src/herb.c
+++ b/src/herb.c
@@ -17,7 +17,7 @@ HERB_EXPORTED_FUNCTION hb_array_T* herb_lex(const char* source, hb_allocator_T* 
   lexer_init(&lexer, source, allocator);
 
   token_T* token = NULL;
-  hb_array_T* tokens = hb_array_init(128);
+  hb_array_T* tokens = hb_array_init(128, allocator);
 
   while ((token = lexer_next_token(&lexer))->type != TOKEN_EOF) {
     hb_array_append(tokens, token);

--- a/src/include/ast_node.h
+++ b/src/include/ast_node.h
@@ -7,7 +7,14 @@
 #include "token_struct.h"
 #include "util/hb_allocator.h"
 
-void ast_node_init(AST_NODE_T* node, ast_node_type_T type, position_T start, position_T end, hb_array_T* errors);
+void ast_node_init(
+  AST_NODE_T* node,
+  ast_node_type_T type,
+  position_T start,
+  position_T end,
+  hb_array_T* errors,
+  hb_allocator_T* allocator
+);
 void ast_node_free(AST_NODE_T* node, hb_allocator_T* allocator);
 
 AST_LITERAL_NODE_T* ast_literal_node_init_from_token(const token_T* token, hb_allocator_T* allocator);

--- a/src/include/util/hb_array.h
+++ b/src/include/util/hb_array.h
@@ -4,13 +4,16 @@
 #include <stdbool.h>
 #include <stdlib.h>
 
+struct hb_allocator;
+
 typedef struct HB_ARRAY_STRUCT {
   void** items;
   size_t size;
   size_t capacity;
+  struct hb_allocator* allocator;
 } hb_array_T;
 
-hb_array_T* hb_array_init(size_t capacity);
+hb_array_T* hb_array_init(size_t capacity, struct hb_allocator* allocator);
 
 void* hb_array_get(const hb_array_T* array, size_t index);
 void* hb_array_first(hb_array_T* array);

--- a/src/parser.c
+++ b/src/parser.c
@@ -43,7 +43,7 @@ void herb_parser_init(parser_T* parser, lexer_T* lexer, parser_options_T options
   parser->allocator = lexer->allocator;
   parser->lexer = lexer;
   parser->current_token = lexer_next_token(lexer);
-  parser->open_tags_stack = hb_array_init(16);
+  parser->open_tags_stack = hb_array_init(16, parser->allocator);
   parser->state = PARSER_STATE_DATA;
   parser->foreign_content_type = FOREIGN_CONTENT_UNKNOWN;
   parser->options = options;
@@ -52,8 +52,8 @@ void herb_parser_init(parser_T* parser, lexer_T* lexer, parser_options_T options
 }
 
 static AST_CDATA_NODE_T* parser_parse_cdata(parser_T* parser) {
-  hb_array_T* errors = hb_array_init(8);
-  hb_array_T* children = hb_array_init(8);
+  hb_array_T* errors = hb_array_init(8, parser->allocator);
+  hb_array_T* children = hb_array_init(8, parser->allocator);
   hb_buffer_T content;
   hb_buffer_init(&content, 128);
 
@@ -95,8 +95,8 @@ static AST_CDATA_NODE_T* parser_parse_cdata(parser_T* parser) {
 }
 
 static AST_HTML_COMMENT_NODE_T* parser_parse_html_comment(parser_T* parser) {
-  hb_array_T* errors = hb_array_init(8);
-  hb_array_T* children = hb_array_init(8);
+  hb_array_T* errors = hb_array_init(8, parser->allocator);
+  hb_array_T* children = hb_array_init(8, parser->allocator);
   token_T* comment_start = parser_consume_expected(parser, TOKEN_HTML_COMMENT_START, errors);
   position_T start = parser->current_token->location.start;
 
@@ -155,8 +155,8 @@ static AST_HTML_COMMENT_NODE_T* parser_parse_html_comment(parser_T* parser) {
 }
 
 static AST_HTML_DOCTYPE_NODE_T* parser_parse_html_doctype(parser_T* parser) {
-  hb_array_T* errors = hb_array_init(8);
-  hb_array_T* children = hb_array_init(8);
+  hb_array_T* errors = hb_array_init(8, parser->allocator);
+  hb_array_T* children = hb_array_init(8, parser->allocator);
   hb_buffer_T content;
   hb_buffer_init(&content, 64);
 
@@ -201,8 +201,8 @@ static AST_HTML_DOCTYPE_NODE_T* parser_parse_html_doctype(parser_T* parser) {
 }
 
 static AST_XML_DECLARATION_NODE_T* parser_parse_xml_declaration(parser_T* parser) {
-  hb_array_T* errors = hb_array_init(8);
-  hb_array_T* children = hb_array_init(8);
+  hb_array_T* errors = hb_array_init(8, parser->allocator);
+  hb_array_T* children = hb_array_init(8, parser->allocator);
   hb_buffer_T content;
   hb_buffer_init(&content, 64);
 
@@ -301,7 +301,7 @@ static AST_HTML_TEXT_NODE_T* parser_parse_text_content(parser_T* parser, hb_arra
     token_free(token, parser->allocator);
   }
 
-  hb_array_T* errors = hb_array_init(8);
+  hb_array_T* errors = hb_array_init(8, parser->allocator);
 
   AST_HTML_TEXT_NODE_T* text_node = NULL;
 
@@ -320,8 +320,8 @@ static AST_HTML_TEXT_NODE_T* parser_parse_text_content(parser_T* parser, hb_arra
 }
 
 static AST_HTML_ATTRIBUTE_NAME_NODE_T* parser_parse_html_attribute_name(parser_T* parser) {
-  hb_array_T* errors = hb_array_init(8);
-  hb_array_T* children = hb_array_init(8);
+  hb_array_T* errors = hb_array_init(8, parser->allocator);
+  hb_array_T* children = hb_array_init(8, parser->allocator);
   hb_buffer_T buffer;
   hb_buffer_init(&buffer, 128);
   position_T start = parser->current_token->location.start;
@@ -597,8 +597,8 @@ static AST_HTML_ATTRIBUTE_VALUE_NODE_T* parser_parse_quoted_html_attribute_value
 }
 
 static AST_HTML_ATTRIBUTE_VALUE_NODE_T* parser_parse_html_attribute_value(parser_T* parser) {
-  hb_array_T* children = hb_array_init(8);
-  hb_array_T* errors = hb_array_init(8);
+  hb_array_T* children = hb_array_init(8, parser->allocator);
+  hb_array_T* errors = hb_array_init(8, parser->allocator);
 
   // <div id=<%= "home" %>>
   if (token_is(parser, TOKEN_ERB_START)) {
@@ -800,7 +800,7 @@ static AST_HTML_ATTRIBUTE_NODE_T* parser_parse_html_attribute(parser_T* parser) 
 
     // <div class= >
     if (token_is(parser, TOKEN_HTML_TAG_END) || token_is(parser, TOKEN_HTML_TAG_SELF_CLOSE)) {
-      hb_array_T* errors = hb_array_init(8);
+      hb_array_T* errors = hb_array_init(8, parser->allocator);
       hb_string_T attribute_name_string = hb_string("unknown");
 
       if (hb_array_size(attribute_name->children) > 0) {
@@ -819,7 +819,7 @@ static AST_HTML_ATTRIBUTE_NODE_T* parser_parse_html_attribute(parser_T* parser) 
 
       AST_HTML_ATTRIBUTE_VALUE_NODE_T* empty_value = ast_html_attribute_value_node_init(
         NULL,
-        hb_array_init(8),
+        hb_array_init(8, parser->allocator),
         NULL,
         false,
         equals->location.end,
@@ -992,8 +992,8 @@ static void parser_handle_whitespace_in_open_tag(parser_T* parser, hb_array_T* c
 }
 
 static AST_HTML_OPEN_TAG_NODE_T* parser_parse_html_open_tag(parser_T* parser) {
-  hb_array_T* errors = hb_array_init(8);
-  hb_array_T* children = hb_array_init(8);
+  hb_array_T* errors = hb_array_init(8, parser->allocator);
+  hb_array_T* children = hb_array_init(8, parser->allocator);
 
   token_T* tag_start = parser_consume_expected(parser, TOKEN_HTML_TAG_START, errors);
   token_T* tag_name = parser_consume_expected(parser, TOKEN_IDENTIFIER, errors);
@@ -1166,8 +1166,8 @@ static AST_HTML_OPEN_TAG_NODE_T* parser_parse_html_open_tag(parser_T* parser) {
 }
 
 static AST_HTML_CLOSE_TAG_NODE_T* parser_parse_html_close_tag(parser_T* parser) {
-  hb_array_T* errors = hb_array_init(8);
-  hb_array_T* children = hb_array_init(8);
+  hb_array_T* errors = hb_array_init(8, parser->allocator);
+  hb_array_T* children = hb_array_init(8, parser->allocator);
 
   token_T* tag_opening = parser_consume_expected(parser, TOKEN_HTML_TAG_START_CLOSE, errors);
 
@@ -1251,8 +1251,8 @@ static AST_HTML_ELEMENT_NODE_T* parser_parse_html_regular_element(
   parser_T* parser,
   AST_HTML_OPEN_TAG_NODE_T* open_tag
 ) {
-  hb_array_T* errors = hb_array_init(8);
-  hb_array_T* body = hb_array_init(8);
+  hb_array_T* errors = hb_array_init(8, parser->allocator);
+  hb_array_T* body = hb_array_init(8, parser->allocator);
 
   parser_push_open_tag(parser, open_tag->tag_name);
 
@@ -1342,7 +1342,7 @@ static AST_NODE_T* parser_parse_html_element(parser_T* parser) {
 }
 
 static AST_ERB_CONTENT_NODE_T* parser_parse_erb_tag(parser_T* parser) {
-  hb_array_T* errors = hb_array_init(8);
+  hb_array_T* errors = hb_array_init(8, parser->allocator);
 
   token_T* opening_tag = parser_consume_expected(parser, TOKEN_ERB_START, errors);
   token_T* content = parser_consume_expected(parser, TOKEN_ERB_CONTENT, errors);
@@ -1616,7 +1616,7 @@ static hb_array_T* parser_build_elements_from_tags(
   hb_allocator_T* allocator
 ) {
   bool strict = options ? options->strict : false;
-  hb_array_T* result = hb_array_init(hb_array_size(nodes));
+  hb_array_T* result = hb_array_init(hb_array_size(nodes), allocator);
 
   for (size_t index = 0; index < hb_array_size(nodes); index++) {
     AST_NODE_T* node = (AST_NODE_T*) hb_array_get(nodes, index);
@@ -1632,7 +1632,7 @@ static hb_array_T* parser_build_elements_from_tags(
         size_t implicit_close_index = find_implicit_close_index(nodes, index, tag_name);
 
         if (implicit_close_index != (size_t) -1 && implicit_close_index > index + 1) {
-          hb_array_T* body = hb_array_init(implicit_close_index - index - 1);
+          hb_array_T* body = hb_array_init(implicit_close_index - index - 1, allocator);
 
           for (size_t j = index + 1; j < implicit_close_index; j++) {
             hb_array_append(body, hb_array_get(nodes, j));
@@ -1648,7 +1648,7 @@ static hb_array_T* parser_build_elements_from_tags(
             if (last_body_node != NULL) { end_position = last_body_node->location.end; }
           }
 
-          hb_array_T* element_errors = hb_array_init(8);
+          hb_array_T* element_errors = hb_array_init(8, allocator);
 
           if (strict) {
             append_omitted_closing_tag_error(
@@ -1665,7 +1665,7 @@ static hb_array_T* parser_build_elements_from_tags(
             open_tag->tag_name,
             end_position,
             end_position,
-            hb_array_init(8),
+            hb_array_init(8, allocator),
             allocator
           );
 
@@ -1701,7 +1701,7 @@ static hb_array_T* parser_build_elements_from_tags(
       } else {
         AST_HTML_CLOSE_TAG_NODE_T* close_tag = (AST_HTML_CLOSE_TAG_NODE_T*) hb_array_get(nodes, close_index);
 
-        hb_array_T* body = hb_array_init(close_index - index - 1);
+        hb_array_T* body = hb_array_init(close_index - index - 1, allocator);
 
         for (size_t j = index + 1; j < close_index; j++) {
           hb_array_append(body, hb_array_get(nodes, j));
@@ -1710,7 +1710,7 @@ static hb_array_T* parser_build_elements_from_tags(
         hb_array_T* processed_body = parser_build_elements_from_tags(body, errors, options, allocator);
         hb_array_free(&body);
 
-        hb_array_T* element_errors = hb_array_init(8);
+        hb_array_T* element_errors = hb_array_init(8, allocator);
 
         AST_HTML_ELEMENT_NODE_T* element = ast_html_element_node_init(
           (AST_NODE_T*) open_tag,
@@ -1754,8 +1754,8 @@ static hb_array_T* parser_build_elements_from_tags(
 }
 
 static AST_DOCUMENT_NODE_T* parser_parse_document(parser_T* parser) {
-  hb_array_T* children = hb_array_init(8);
-  hb_array_T* errors = hb_array_init(8);
+  hb_array_T* children = hb_array_init(8, parser->allocator);
+  hb_array_T* errors = hb_array_init(8, parser->allocator);
   position_T start = parser->current_token->location.start;
 
   parser_parse_in_data_state(parser, children, errors);
@@ -1776,7 +1776,7 @@ AST_DOCUMENT_NODE_T* herb_parser_parse(parser_T* parser) {
 
 static void parser_handle_whitespace(parser_T* parser, token_T* whitespace_token, hb_array_T* children) {
   if (parser->options.track_whitespace) {
-    hb_array_T* errors = hb_array_init(8);
+    hb_array_T* errors = hb_array_init(8, parser->allocator);
     AST_WHITESPACE_NODE_T* whitespace_node = ast_whitespace_node_init(
       whitespace_token,
       whitespace_token->location.start,

--- a/src/util/hb_array.c
+++ b/src/util/hb_array.c
@@ -2,24 +2,31 @@
 #include <stdio.h>
 
 #include "../include/macros.h"
+#include "../include/util/hb_allocator.h"
 #include "../include/util/hb_array.h"
 
 size_t hb_array_sizeof(void) {
   return sizeof(hb_array_T);
 }
 
-hb_array_T* hb_array_init(const size_t capacity) {
-  hb_array_T* array = malloc(hb_array_sizeof());
+hb_array_T* hb_array_init(const size_t capacity, hb_allocator_T* allocator) {
+  hb_array_T* array = hb_allocator_alloc(allocator, hb_array_sizeof());
 
   if (!array) { return NULL; }
 
   array->size = 0;
   array->capacity = capacity;
-  array->items = malloc(capacity * sizeof(void*));
+  array->allocator = allocator;
 
-  if (!array->items) {
-    free(array);
-    return NULL;
+  if (capacity == 0) {
+    array->items = NULL;
+  } else {
+    array->items = hb_allocator_alloc(allocator, capacity * sizeof(void*));
+
+    if (!array->items) {
+      hb_allocator_dealloc(allocator, array);
+      return NULL;
+    }
   }
 
   return array;
@@ -47,12 +54,13 @@ bool hb_array_append(hb_array_T* array, void* item) {
       return false;
     }
 
+    size_t old_size_bytes = array->capacity * sizeof(void*);
     size_t new_size_bytes = new_capacity * sizeof(void*);
-    void* new_items = realloc(array->items, new_size_bytes);
+    void** new_items = hb_allocator_realloc(array->allocator, array->items, old_size_bytes, new_size_bytes);
 
     if (unlikely(new_items == NULL)) { return false; }
 
-    array->items = (void**) new_items;
+    array->items = new_items;
     array->capacity = new_capacity;
   }
 
@@ -136,8 +144,9 @@ size_t hb_array_capacity(const hb_array_T* array) {
 void hb_array_free(hb_array_T** array) {
   if (!array || !*array) { return; }
 
-  free((*array)->items);
-  free(*array);
+  hb_allocator_T* allocator = (*array)->allocator;
+  hb_allocator_dealloc(allocator, (*array)->items);
+  hb_allocator_dealloc(allocator, *array);
 
   *array = NULL;
 }

--- a/templates/src/ast_nodes.c.erb
+++ b/templates/src/ast_nodes.c.erb
@@ -22,7 +22,7 @@
 
   if (!<%= node.human %>) { return NULL; }
 
-  ast_node_init(&<%= node.human %>->base, <%= node.type %>, start_position, end_position, errors);
+  ast_node_init(&<%= node.human %>->base, <%= node.type %>, start_position, end_position, errors, allocator);
 
   <%- node.fields.each do |field| -%>
   <%- case field -%>

--- a/test/c/test_hb_array.c
+++ b/test/c/test_hb_array.c
@@ -1,9 +1,17 @@
 #include "include/test.h"
+#include "../../src/include/util/hb_allocator.h"
 #include "../../src/include/util/hb_array.h"
+
+static hb_allocator_T test_allocator;
+
+static void setup(void) {
+  test_allocator = hb_allocator_with_malloc();
+}
 
 // Test array initialization
 TEST(test_hb_array_init)
-  hb_array_T* array = hb_array_init(10);
+  setup();
+  hb_array_T* array = hb_array_init(10, &test_allocator);
 
   ck_assert_ptr_nonnull(array);
   ck_assert_int_eq(array->size, 0);
@@ -15,7 +23,8 @@ END
 
 // Test array appending
 TEST(test_hb_array_append)
-  hb_array_T* array = hb_array_init(2);
+  setup();
+  hb_array_T* array = hb_array_init(2, &test_allocator);
 
   size_t item1 = 42, item2 = 99, item3 = 100;
   hb_array_append(array, &item1);
@@ -36,7 +45,8 @@ END
 
 // Test getting elements
 TEST(test_hb_array_get)
-  hb_array_T* array = hb_array_init(3);
+  setup();
+  hb_array_T* array = hb_array_init(3, &test_allocator);
 
   size_t item1 = 42, item2 = 99;
   hb_array_append(array, &item1);
@@ -51,7 +61,8 @@ END
 
 // Test setting elements
 TEST(test_hb_array_set)
-  hb_array_T* array = hb_array_init(3);
+  setup();
+  hb_array_T* array = hb_array_init(3, &test_allocator);
 
   size_t item1 = 42, item2 = 99;
   hb_array_append(array, &item1);
@@ -67,7 +78,8 @@ END
 
 // Test removing elements
 TEST(test_hb_array_remove)
-  hb_array_T* array = hb_array_init(3);
+  setup();
+  hb_array_T* array = hb_array_init(3, &test_allocator);
 
   size_t item1 = 42, item2 = 99, item3 = 100;
   hb_array_append(array, &item1);
@@ -84,7 +96,8 @@ END
 
 // Test freeing the array
 TEST(test_hb_array_free)
-  hb_array_T* array = hb_array_init(5);
+  setup();
+  hb_array_T* array = hb_array_init(5, &test_allocator);
   hb_array_free(&array);
 
   ck_assert_ptr_null(array);
@@ -92,9 +105,10 @@ END
 
 // Test hb_array_size with NULL safety
 TEST(test_hb_array_size)
+  setup();
   ck_assert_int_eq(hb_array_size(NULL), 0);
 
-  hb_array_T* array = hb_array_init(5);
+  hb_array_T* array = hb_array_init(5, &test_allocator);
   ck_assert_int_eq(hb_array_size(array), 0);
 
   size_t item1 = 42, item2 = 99;


### PR DESCRIPTION
With the new `hb_allocator_realloc` implemented in #1322 we can now port `hb_array` to use the `hb_allocator_T` infrastructure.

Resolves #1291