### PR TITLE
C: Migrate `hb_narray` to use new allocator system

### DIFF
--- a/src/include/util/hb_narray.h
+++ b/src/include/util/hb_narray.h
@@ -5,15 +5,18 @@
 #include <stdlib.h>
 #include <stdbool.h>
 
+#include "hb_allocator.h"
+
 typedef struct HB_NARRAY_STRUCT {
+  hb_allocator_T *allocator;
   uint8_t* items;
   size_t item_size;
   size_t size;
   size_t capacity;
 } hb_narray_T;
 
-bool hb_narray_init(hb_narray_T* array, size_t item_size, size_t initial_capacity);
-#define hb_narray_pointer_init(array, initial_capacity) (hb_narray_init(array, sizeof(void*), initial_capacity))
+bool hb_narray_init(hb_narray_T* array, size_t item_size, size_t initial_capacity, hb_allocator_T* allocator);
+#define hb_narray_pointer_init(array, initial_capacity, allocator) (hb_narray_init(array, sizeof(void*), initial_capacity, allocator))
 
 void* hb_narray_get(const hb_narray_T* array, size_t index);
 void* hb_narray_first(hb_narray_T* array);

--- a/src/util/hb_narray.c
+++ b/src/util/hb_narray.c
@@ -4,13 +4,14 @@
 #include <stdbool.h>
 #include <string.h>
 
-bool hb_narray_init(hb_narray_T* array, size_t item_size, size_t initial_capacity) {
+bool hb_narray_init(hb_narray_T* array, size_t item_size, size_t initial_capacity, hb_allocator_T* allocator) {
   assert(initial_capacity != 0);
 
+  array->allocator = allocator;
   array->item_size = item_size;
   array->capacity = initial_capacity;
   array->size = 0;
-  array->items = malloc(array->capacity * array->item_size);
+  array->items = hb_allocator_alloc(array->allocator, array->capacity * array->item_size);
 
   if (!array->items) { return false; }
 
@@ -20,7 +21,12 @@ bool hb_narray_init(hb_narray_T* array, size_t item_size, size_t initial_capacit
 bool hb_narray_append(hb_narray_T* array, void* item) {
   if (array->size + 1 > array->capacity) {
     size_t new_capacity = array->capacity * 2;
-    void* new_buffer = realloc(array->items, new_capacity * array->item_size);
+    void* new_buffer = hb_allocator_realloc(
+      array->allocator,
+      array->items,
+      array->capacity * array->item_size,
+      new_capacity * array->item_size
+    );
 
     if (!new_buffer) { return false; }
 
@@ -80,7 +86,7 @@ void hb_narray_deinit(hb_narray_T* array) {
   array->item_size = 0;
   array->capacity = 0;
   array->size = 0;
-  free(array->items);
+  hb_allocator_dealloc(array->allocator, array->items);
 }
 
 size_t hb_narray_size(const hb_narray_T* array) {

--- a/test/c/test_hb_narray.c
+++ b/test/c/test_hb_narray.c
@@ -3,8 +3,10 @@
 
 TEST(test_hb_narray_init)
   hb_narray_T array;
+  hb_allocator_T allocator;
+  hb_allocator_init(&allocator, HB_ALLOCATOR_MALLOC);
 
-  ck_assert(hb_narray_init(&array, sizeof(uint64_t), 1024));
+  ck_assert(hb_narray_init(&array, sizeof(uint64_t), 1024, &allocator));
 
   ck_assert_int_eq(array.item_size, sizeof(uint64_t));
   ck_assert_int_eq(array.capacity, 1024);
@@ -17,7 +19,10 @@ END
 TEST(test_hb_narray_pointer_init)
   hb_narray_T array;
 
-  ck_assert(hb_narray_pointer_init(&array, 1024));
+  hb_allocator_T allocator;
+  hb_allocator_init(&allocator, HB_ALLOCATOR_MALLOC);
+
+  ck_assert(hb_narray_pointer_init(&array, 1024, &allocator));
 
   ck_assert_int_eq(array.item_size, sizeof(void *));
   ck_assert_int_eq(array.capacity, 1024);
@@ -30,7 +35,10 @@ END
 TEST(test_hb_narray_append)
   hb_narray_T array;
 
-  ck_assert(hb_narray_init(&array, sizeof(uint64_t), 2));
+  hb_allocator_T allocator;
+  hb_allocator_init(&allocator, HB_ALLOCATOR_MALLOC);
+
+  ck_assert(hb_narray_init(&array, sizeof(uint64_t), 2, &allocator));
 
   uint64_t number = 1;
   ck_assert(hb_narray_append(&array, &number));
@@ -55,8 +63,10 @@ END
 
 TEST(test_hb_narray_first_last)
   hb_narray_T array;
+  hb_allocator_T allocator;
+  hb_allocator_init(&allocator, HB_ALLOCATOR_MALLOC);
 
-  hb_narray_init(&array, sizeof(uint64_t), 2);
+  hb_narray_init(&array, sizeof(uint64_t), 2, &allocator);
 
   ck_assert_ptr_null(hb_narray_first(&array));
   ck_assert_ptr_null(hb_narray_last(&array));
@@ -78,8 +88,10 @@ END
 
 TEST(test_hb_narray_stack_behavior)
   hb_narray_T array;
+  hb_allocator_T allocator;
+  hb_allocator_init(&allocator, HB_ALLOCATOR_MALLOC);
 
-  hb_narray_init(&array, sizeof(uint64_t), 2);
+  hb_narray_init(&array, sizeof(uint64_t), 2, &allocator);
 
   for(uint64_t i = 0; i < 4; i++) {
     hb_narray_push(&array, &i);
@@ -110,8 +122,10 @@ END
 
 TEST(test_hb_narray_remove)
   hb_narray_T array;
+  hb_allocator_T allocator;
+  hb_allocator_init(&allocator, HB_ALLOCATOR_MALLOC);
 
-  hb_narray_init(&array, sizeof(uint64_t), 2);
+  hb_narray_init(&array, sizeof(uint64_t), 2, &allocator);
 
   for(uint64_t i = 0; i < 4; i++) {
     hb_narray_push(&array, &i);
@@ -141,9 +155,11 @@ END
 // Test hb_narray_size with NULL safety
 TEST(test_hb_narray_size)
   ck_assert_int_eq(hb_narray_size(NULL), 0);
+  hb_allocator_T allocator;
+  hb_allocator_init(&allocator, HB_ALLOCATOR_MALLOC);
 
   hb_narray_T array;
-  hb_narray_init(&array, sizeof(uint64_t), 5);
+  hb_narray_init(&array, sizeof(uint64_t), 5, &allocator);
   ck_assert_int_eq(hb_narray_size(&array), 0);
 
   uint64_t item1 = 42, item2 = 99;
@@ -158,8 +174,10 @@ END
 
 TEST(test_hb_narray_init_returns_bool)
   hb_narray_T array;
+  hb_allocator_T allocator;
+  hb_allocator_init(&allocator, HB_ALLOCATOR_MALLOC);
 
-  ck_assert(hb_narray_init(&array, sizeof(uint64_t), 4));
+  ck_assert(hb_narray_init(&array, sizeof(uint64_t), 4, &allocator));
   ck_assert_ptr_nonnull(array.items);
   ck_assert_int_eq(array.size, 0);
   ck_assert_int_eq(array.capacity, 4);
@@ -169,8 +187,10 @@ END
 
 TEST(test_hb_narray_append_returns_bool)
   hb_narray_T array;
+  hb_allocator_T allocator;
+  hb_allocator_init(&allocator, HB_ALLOCATOR_MALLOC);
 
-  ck_assert(hb_narray_init(&array, sizeof(uint64_t), 2));
+  ck_assert(hb_narray_init(&array, sizeof(uint64_t), 2, &allocator));
 
   uint64_t number = 42;
   ck_assert(hb_narray_append(&array, &number));


### PR DESCRIPTION
This MR migrates the `hb_narray` implementation to use the `hb_allocator` interface for allocating memory. 

Related #1323 and #1326