### PR TITLE
Rewriter: Implement Action View Tag Helpers <-> HTML rewriters

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -453,6 +453,7 @@ nodes:
             - HTMLCloseTagNode
             - HTMLOmittedCloseTagNode
             - HTMLVirtualCloseTagNode
+            - ERBEndNode
 
         - name: is_void
           type: boolean

--- a/javascript/packages/core/src/ast-utils.ts
+++ b/javascript/packages/core/src/ast-utils.ts
@@ -17,7 +17,8 @@ import {
   HTMLAttributeNode,
   HTMLAttributeNameNode,
   HTMLAttributeValueNode,
-  HTMLCommentNode
+  HTMLCommentNode,
+  WhitespaceNode
 } from "./nodes.js"
 
 import {
@@ -38,6 +39,9 @@ import {
 } from "./node-type-guards.js"
 
 import { Location } from "./location.js"
+import { Range } from "./range.js"
+import { Token } from "./token.js"
+
 import type { Position } from "./position.js"
 
 export type ERBOutputNode = ERBNode & {
@@ -854,5 +858,18 @@ export function createLiteral(content: string): LiteralNode {
     content,
     location: Location.zero,
     errors: [],
+  })
+}
+
+export function createSyntheticToken(value: string, type = "TOKEN_SYNTHETIC"): Token {
+  return new Token(value, Range.zero, Location.zero, type)
+}
+
+export function createWhitespaceNode(): WhitespaceNode {
+  return new WhitespaceNode({
+    type: "AST_WHITESPACE_NODE",
+    location: Location.zero,
+    errors: [],
+    value: createSyntheticToken(" "),
   })
 }

--- a/javascript/packages/language-server/src/comment_ast_utils.ts
+++ b/javascript/packages/language-server/src/comment_ast_utils.ts
@@ -1,7 +1,7 @@
 import { ParserService } from "./parser_service"
 import { LineContextCollector } from "./line_context_collector"
 
-import { HTMLCommentNode, Token, Location, Range } from "@herb-tools/core"
+import { HTMLCommentNode, Location, createSyntheticToken } from "@herb-tools/core"
 import { IdentityPrinter } from "@herb-tools/printer"
 
 import { isERBCommentNode, isLiteralNode, createLiteral } from "@herb-tools/core"
@@ -25,10 +25,6 @@ interface LineSegment {
   node?: ERBContentNode
 }
 
-export function createSyntheticToken(type: string, value: string): Token {
-  return new Token(value, Range.zero, Location.zero, type)
-}
-
 export function commentERBNode(node: ERBContentNode): void {
   const mutable = asMutable(node)
 
@@ -36,8 +32,8 @@ export function commentERBNode(node: ERBContentNode): void {
     const currentValue = mutable.tag_opening.value
 
     mutable.tag_opening = createSyntheticToken(
-      mutable.tag_opening.type,
-      currentValue.substring(0, 2) + "#" + currentValue.substring(2)
+      currentValue.substring(0, 2) + "#" + currentValue.substring(2),
+      mutable.tag_opening.type
     )
   }
 }
@@ -56,10 +52,10 @@ export function uncommentERBNode(node: ERBContentNode): void {
       contentValue.startsWith(" = ") ||
       contentValue.startsWith(" - ")
     ) {
-      mutable.tag_opening = createSyntheticToken(mutable.tag_opening.type, "<%")
-      mutable.content = createSyntheticToken(mutable.content!.type, contentValue.substring(1))
+      mutable.tag_opening = createSyntheticToken("<%", mutable.tag_opening.type)
+      mutable.content = createSyntheticToken(contentValue.substring(1), mutable.content!.type)
     } else {
-      mutable.tag_opening = createSyntheticToken(mutable.tag_opening.type, "<%")
+      mutable.tag_opening = createSyntheticToken("<%", mutable.tag_opening.type)
     }
   }
 }
@@ -158,9 +154,9 @@ export function commentLineContent(content: string, erbNodes: ERBContentNode[], 
         type: "AST_HTML_COMMENT_NODE",
         location: Location.zero,
         errors: [],
-        comment_start: createSyntheticToken("TOKEN_HTML_COMMENT_START", "<!--"),
+        comment_start: createSyntheticToken("<!--", "TOKEN_HTML_COMMENT_START"),
         children: [createLiteral(" "), ...(children.slice() as Node[]), createLiteral(" ")],
-        comment_end: createSyntheticToken("TOKEN_HTML_COMMENT_END", "-->"),
+        comment_end: createSyntheticToken("-->", "TOKEN_HTML_COMMENT_END"),
       })
 
       children.length = 0
@@ -173,9 +169,9 @@ export function commentLineContent(content: string, erbNodes: ERBContentNode[], 
         type: "AST_HTML_COMMENT_NODE",
         location: Location.zero,
         errors: [],
-        comment_start: createSyntheticToken("TOKEN_HTML_COMMENT_START", "<!--"),
+        comment_start: createSyntheticToken("<!--", "TOKEN_HTML_COMMENT_START"),
         children: [createLiteral(" "), ...(children.slice() as Node[]), createLiteral(" ")],
-        comment_end: createSyntheticToken("TOKEN_HTML_COMMENT_END", "-->"),
+        comment_end: createSyntheticToken("-->", "TOKEN_HTML_COMMENT_END"),
       })
 
       children.length = 0

--- a/javascript/packages/linter/src/rules/html-no-space-in-tag.ts
+++ b/javascript/packages/linter/src/rules/html-no-space-in-tag.ts
@@ -1,4 +1,4 @@
-import { Token, Location, WhitespaceNode } from "@herb-tools/core"
+import { Token, WhitespaceNode, createWhitespaceNode } from "@herb-tools/core"
 import { ParserRule, BaseAutofixContext } from "../types.js"
 
 import { findParent, BaseRuleVisitor } from "./rule-utils.js"
@@ -168,10 +168,7 @@ export class HTMLNoSpaceInTagRule extends ParserRule<HTMLNoSpaceInTagAutofixCont
     if (!node) return null
 
     if (isHTMLOpenTagNode(node)) {
-      const token = Token.from({ type: "TOKEN_WHITESPACE", value: " ", range: [0, 0], location: Location.zero })
-      const whitespace = new WhitespaceNode({ type: "AST_WHITESPACE_NODE", value: token, location: Location.zero, errors: [] })
-
-      node.children.push(whitespace)
+      node.children.push(createWhitespaceNode())
 
       return result
     }

--- a/javascript/packages/rewriter/src/built-ins/action-view-tag-helper-to-html.ts
+++ b/javascript/packages/rewriter/src/built-ins/action-view-tag-helper-to-html.ts
@@ -1,0 +1,162 @@
+import { Visitor, Location, HTMLOpenTagNode, HTMLCloseTagNode, HTMLElementNode, HTMLAttributeValueNode, WhitespaceNode, ERBContentNode } from "@herb-tools/core"
+import { isHTMLAttributeNode, isERBOpenTagNode, isRubyLiteralNode, isRubyHTMLAttributesSplatNode, createSyntheticToken } from "@herb-tools/core"
+
+import { ASTRewriter } from "../ast-rewriter.js"
+import { asMutable } from "../mutable.js"
+
+import type { RewriteContext } from "../context.js"
+import type { Node } from "@herb-tools/core"
+
+function createWhitespaceNode(): WhitespaceNode {
+  return new WhitespaceNode({
+    type: "AST_WHITESPACE_NODE",
+    location: Location.zero,
+    errors: [],
+    value: createSyntheticToken(" "),
+  })
+}
+
+class ActionViewTagHelperToHTMLVisitor extends Visitor {
+  visitHTMLElementNode(node: HTMLElementNode): void {
+    if (!node.element_source) {
+      this.visitChildNodes(node)
+      return
+    }
+
+    const openTag = node.open_tag
+
+    if (!isERBOpenTagNode(openTag)) {
+      this.visitChildNodes(node)
+      return
+    }
+
+    const tagName = openTag.tag_name
+
+    if (!tagName) {
+      this.visitChildNodes(node)
+      return
+    }
+
+    const htmlChildren: Node[] = []
+
+    for (const child of openTag.children) {
+      if (isRubyHTMLAttributesSplatNode(child)) {
+        htmlChildren.push(createWhitespaceNode())
+
+        htmlChildren.push(new ERBContentNode({
+          type: "AST_ERB_CONTENT_NODE",
+          location: Location.zero,
+          errors: [],
+          tag_opening: createSyntheticToken("<%="),
+          content: createSyntheticToken(` ${child.content} `),
+          tag_closing: createSyntheticToken("%>"),
+          parsed: false,
+          valid: true,
+        }))
+
+        continue
+      }
+
+      htmlChildren.push(createWhitespaceNode())
+
+      if (isHTMLAttributeNode(child)) {
+        if (child.equals && child.equals.value !== "=") {
+          asMutable(child).equals = createSyntheticToken("=")
+        }
+
+        if (child.value) {
+          this.transformAttributeValue(child.value)
+        }
+
+        htmlChildren.push(child)
+      }
+    }
+
+    const htmlOpenTag = new HTMLOpenTagNode({
+      type: "AST_HTML_OPEN_TAG_NODE",
+      location: openTag.location,
+      errors: [],
+      tag_opening: createSyntheticToken("<"),
+      tag_name: createSyntheticToken(tagName.value),
+      tag_closing: createSyntheticToken(node.is_void ? " />" : ">"),
+      children: htmlChildren,
+      is_void: node.is_void,
+    })
+
+    asMutable(node).open_tag = htmlOpenTag
+
+    if (node.is_void) {
+      asMutable(node).close_tag = null
+    } else if (node.close_tag) {
+      const htmlCloseTag = new HTMLCloseTagNode({
+        type: "AST_HTML_CLOSE_TAG_NODE",
+        location: node.close_tag.location,
+        errors: [],
+        tag_opening: createSyntheticToken("</"),
+        tag_name: createSyntheticToken(tagName.value),
+        children: [],
+        tag_closing: createSyntheticToken(">"),
+      })
+
+      asMutable(node).close_tag = htmlCloseTag
+    }
+
+    asMutable(node).element_source = "HTML"
+
+    if (node.body) {
+      for (const child of node.body) {
+        this.visit(child)
+      }
+    }
+  }
+
+  private transformAttributeValue(value: HTMLAttributeValueNode): void {
+    const mutableValue = asMutable(value)
+    const hasRubyLiteral = value.children.some(child => isRubyLiteralNode(child))
+
+    if (hasRubyLiteral) {
+      const newChildren: Node[] = value.children.map(child => {
+        if (isRubyLiteralNode(child)) {
+          return new ERBContentNode({
+            type: "AST_ERB_CONTENT_NODE",
+            location: child.location,
+            errors: [],
+            tag_opening: createSyntheticToken("<%="),
+            content: createSyntheticToken(` ${child.content} `),
+            tag_closing: createSyntheticToken("%>"),
+            parsed: false,
+            valid: true,
+          })
+        }
+
+        return child
+      })
+
+      mutableValue.children = newChildren
+
+      if (!value.quoted) {
+        mutableValue.quoted = true
+        mutableValue.open_quote = createSyntheticToken('"')
+        mutableValue.close_quote = createSyntheticToken('"')
+      }
+    }
+  }
+}
+
+export class ActionViewTagHelperToHTMLRewriter extends ASTRewriter {
+  get name(): string {
+    return "action-view-tag-helper-to-html"
+  }
+
+  get description(): string {
+    return "Converts ActionView tag helpers (tag.*, content_tag, link_to) to raw HTML elements"
+  }
+
+  rewrite<T extends Node>(node: T, _context: RewriteContext): T {
+    const visitor = new ActionViewTagHelperToHTMLVisitor()
+
+    visitor.visit(node)
+
+    return node
+  }
+}

--- a/javascript/packages/rewriter/src/built-ins/html-to-action-view-tag-helper.ts
+++ b/javascript/packages/rewriter/src/built-ins/html-to-action-view-tag-helper.ts
@@ -1,0 +1,229 @@
+import { Visitor, Location, ERBOpenTagNode, ERBEndNode, HTMLElementNode, HTMLVirtualCloseTagNode, createSyntheticToken } from "@herb-tools/core"
+import { getStaticAttributeName, isLiteralNode, isHTMLOpenTagNode, isHTMLTextNode, isHTMLAttributeNode, isERBContentNode, isWhitespaceNode } from "@herb-tools/core"
+
+import { ASTRewriter } from "../ast-rewriter.js"
+import { asMutable } from "../mutable.js"
+
+import type { RewriteContext } from "../context.js"
+import type { Node, HTMLCloseTagNode, HTMLAttributeValueNode } from "@herb-tools/core"
+
+function serializeAttributeValue(value: HTMLAttributeValueNode): string {
+  const hasERB = value.children.some(child => isERBContentNode(child))
+
+  if (hasERB && value.children.length === 1 && isERBContentNode(value.children[0])) {
+    return value.children[0].content?.value?.trim() ?? '""'
+  }
+
+  const parts: string[] = []
+
+  for (const child of value.children) {
+    if (isLiteralNode(child)) {
+      parts.push(child.content)
+    } else if (isERBContentNode(child)) {
+      parts.push(`#{${child.content?.value?.trim() ?? ""}}`)
+    }
+  }
+
+  return `"${parts.join("")}"`
+}
+
+function dashToUnderscore(string: string): string {
+  return string.replace(/-/g, "_")
+}
+
+interface SerializedAttributes {
+  attributes: string
+  href: string | null
+}
+
+function serializeAttributes(children: Node[], extractHref = false): SerializedAttributes {
+  const regular: string[] = []
+  const prefixed: Map<string, string[]> = new Map()
+
+  let href: string | null = null
+
+  for (const child of children) {
+    if (!isHTMLAttributeNode(child)) continue
+
+    const name = getStaticAttributeName(child.name!)
+    if (!name) continue
+
+    const value = child.value ? serializeAttributeValue(child.value) : "true"
+
+    if (extractHref && name === "href") {
+      href = value
+      continue
+    }
+
+    const dataMatch = name.match(/^(data|aria)-(.+)$/)
+
+    if (dataMatch) {
+      const [, prefix, rest] = dataMatch
+
+      if (!prefixed.has(prefix)) {
+        prefixed.set(prefix, [])
+      }
+
+      prefixed.get(prefix)!.push(`${dashToUnderscore(rest)}: ${value}`)
+    } else {
+      regular.push(`${name}: ${value}`)
+    }
+  }
+
+  const parts = [...regular]
+
+  for (const [prefix, entries] of prefixed) {
+    parts.push(`${prefix}: { ${entries.join(", ")} }`)
+  }
+
+  return { attributes: parts.join(", "), href }
+}
+
+function isTextOnlyBody(body: Node[]): boolean {
+  if (body.length !== 1 || !isHTMLTextNode(body[0])) return false
+
+  return !body[0].content.includes("\n")
+}
+
+class HTMLToActionViewTagHelperVisitor extends Visitor {
+  visitHTMLElementNode(node: HTMLElementNode): void {
+    const openTag = node.open_tag
+
+    if (!isHTMLOpenTagNode(openTag)) {
+      this.visitChildNodes(node)
+      return
+    }
+
+    const tagName = openTag.tag_name
+
+    if (!tagName) {
+      this.visitChildNodes(node)
+      return
+    }
+
+    if (node.body) {
+      for (const child of node.body) {
+        this.visit(child)
+      }
+    }
+
+    const isAnchor = tagName.value === "a"
+    const attributes = openTag.children.filter(child => !isWhitespaceNode(child))
+    const { attributes: attributesString, href } = serializeAttributes(attributes, isAnchor)
+    const hasBody = node.body && node.body.length > 0 && !node.is_void
+    const isInlineContent = hasBody && isTextOnlyBody(node.body)
+
+    let content: string
+    let elementSource: string
+
+    if (isAnchor) {
+      content = this.buildLinkToContent(node, attributesString, href, isInlineContent)
+      elementSource = "ActionView::Helpers::UrlHelper#link_to"
+    } else {
+      content = this.buildTagContent(tagName.value, node, attributesString, isInlineContent)
+      elementSource = "ActionView::Helpers::TagHelper#tag"
+    }
+
+    const erbOpenTag = new ERBOpenTagNode({
+      type: "AST_ERB_OPEN_TAG_NODE",
+      location: openTag.location,
+      errors: [],
+      tag_opening: createSyntheticToken("<%="),
+      content: createSyntheticToken(content),
+      tag_closing: createSyntheticToken("%>"),
+      tag_name: createSyntheticToken(isAnchor ? "a" : tagName.value),
+      children: [],
+    })
+
+    asMutable(node).open_tag = erbOpenTag
+    asMutable(node).element_source = elementSource
+
+    if (node.is_void) {
+      asMutable(node).close_tag = null
+    } else if (isInlineContent) {
+      asMutable(node).body = []
+
+      const virtualClose = new HTMLVirtualCloseTagNode({
+        type: "AST_HTML_VIRTUAL_CLOSE_TAG_NODE",
+        location: Location.zero,
+        errors: [],
+        tag_name: createSyntheticToken(tagName.value),
+      })
+
+      asMutable(node).close_tag = virtualClose
+    } else if (node.close_tag) {
+      const erbEnd = new ERBEndNode({
+        type: "AST_ERB_END_NODE",
+        location: node.close_tag.location,
+        errors: [],
+        tag_opening: createSyntheticToken("<%"),
+        content: createSyntheticToken(" end "),
+        tag_closing: createSyntheticToken("%>"),
+      })
+
+      asMutable(node).close_tag = erbEnd
+    }
+  }
+
+  private buildTagContent(tag: string, node: HTMLElementNode, attributes: string, isInlineContent: boolean): string {
+    if (node.is_void) {
+      return attributes
+        ? ` tag.${tag} ${attributes} `
+        : ` tag.${tag} `
+    }
+
+    if (isInlineContent && isHTMLTextNode(node.body[0])) {
+      const textContent = node.body[0].content
+
+      return attributes
+        ? ` tag.${tag} "${textContent}", ${attributes} `
+        : ` tag.${tag} "${textContent}" `
+    }
+
+    return attributes
+      ? ` tag.${tag} ${attributes} do `
+      : ` tag.${tag} do `
+  }
+
+  private buildLinkToContent(node: HTMLElementNode, attribute: string, href: string | null, isInlineContent: boolean): string {
+    const args: string[] = []
+
+    if (isInlineContent && isHTMLTextNode(node.body[0])) {
+      args.push(`"${node.body[0].content}"`)
+    }
+
+    if (href) {
+      args.push(href)
+    }
+
+    if (attribute) {
+      args.push(attribute)
+    }
+
+    const argString = args.join(", ")
+
+    if (isInlineContent) {
+      return argString ? ` link_to ${argString} ` : ` link_to `
+    }
+
+    return argString ? ` link_to ${argString} do ` : ` link_to do `
+  }
+}
+
+export class HTMLToActionViewTagHelperRewriter extends ASTRewriter {
+  get name(): string {
+    return "html-to-action-view-tag-helper"
+  }
+
+  get description(): string {
+    return "Converts raw HTML elements to ActionView tag helpers (tag.*)"
+  }
+
+  rewrite<T extends Node>(node: T, _context: RewriteContext): T {
+    const visitor = new HTMLToActionViewTagHelperVisitor()
+
+    visitor.visit(node)
+
+    return node
+  }
+}

--- a/javascript/packages/rewriter/src/built-ins/index.ts
+++ b/javascript/packages/rewriter/src/built-ins/index.ts
@@ -1,12 +1,15 @@
-import type { RewriterClass } from "../type-guards.js"
-
-export { TailwindClassSorterRewriter } from "./tailwind-class-sorter.js"
+import { ActionViewTagHelperToHTMLRewriter } from "./action-view-tag-helper-to-html.js"
+import { HTMLToActionViewTagHelperRewriter } from "./html-to-action-view-tag-helper.js"
 import { TailwindClassSorterRewriter } from "./tailwind-class-sorter.js"
+
+import type { RewriterClass } from "../type-guards.js"
 
 /**
  * All built-in rewriters available in the package
  */
 export const builtinRewriters: RewriterClass[] = [
+  ActionViewTagHelperToHTMLRewriter,
+  HTMLToActionViewTagHelperRewriter,
   TailwindClassSorterRewriter
 ]
 
@@ -31,3 +34,7 @@ export function getBuiltinRewriterNames(): string[] {
     return instance.name
   })
 }
+
+export { ActionViewTagHelperToHTMLRewriter } from "./action-view-tag-helper-to-html.js"
+export { HTMLToActionViewTagHelperRewriter } from "./html-to-action-view-tag-helper.js"
+export { TailwindClassSorterRewriter } from "./tailwind-class-sorter.js"

--- a/javascript/packages/rewriter/src/index.ts
+++ b/javascript/packages/rewriter/src/index.ts
@@ -1,4 +1,6 @@
 export { ASTRewriter } from "./ast-rewriter.js"
+export { ActionViewTagHelperToHTMLRewriter } from "./built-ins/action-view-tag-helper-to-html.js"
+export { HTMLToActionViewTagHelperRewriter } from "./built-ins/html-to-action-view-tag-helper.js"
 export { StringRewriter } from "./string-rewriter.js"
 
 export { asMutable } from "./mutable.js"

--- a/javascript/packages/rewriter/src/rewriter-factories.ts
+++ b/javascript/packages/rewriter/src/rewriter-factories.ts
@@ -1,4 +1,6 @@
 import { TailwindClassSorterRewriter } from "./built-ins/tailwind-class-sorter.js"
+import { ActionViewTagHelperToHTMLRewriter } from "./built-ins/action-view-tag-helper-to-html.js"
+import { HTMLToActionViewTagHelperRewriter } from "./built-ins/html-to-action-view-tag-helper.js"
 
 export interface TailwindClassSorterOptions {
   /**
@@ -34,4 +36,12 @@ export async function tailwindClassSorter(options: TailwindClassSorterOptions = 
   await rewriter.initialize({ baseDir })
 
   return rewriter
+}
+
+export function actionViewTagHelperToHTML(): ActionViewTagHelperToHTMLRewriter {
+  return new ActionViewTagHelperToHTMLRewriter()
+}
+
+export function htmlToActionViewTagHelper(): HTMLToActionViewTagHelperRewriter {
+  return new HTMLToActionViewTagHelperRewriter()
 }

--- a/javascript/packages/rewriter/test/action-view-tag-helper-to-html.test.ts
+++ b/javascript/packages/rewriter/test/action-view-tag-helper-to-html.test.ts
@@ -1,0 +1,212 @@
+import dedent from "dedent"
+import { describe, test, expect, beforeAll } from "vitest"
+
+import { Herb } from "@herb-tools/node-wasm"
+import { IdentityPrinter } from "@herb-tools/printer"
+import { ActionViewTagHelperToHTMLRewriter } from "@herb-tools/rewriter"
+
+import type { Node } from "@herb-tools/core"
+
+function transform(input: string): string {
+  const parseResult = Herb.parse(input, {
+    track_whitespace: true,
+    action_view_helpers: true,
+  })
+
+  if (parseResult.failed) {
+    throw new Error(
+      `Parser errors:\n${parseResult.recursiveErrors().map(e => `  - ${e.message}`).join("\n")}`
+    )
+  }
+
+  const rewriter = new ActionViewTagHelperToHTMLRewriter()
+  const node = rewriter.rewrite(parseResult.value as Node, { baseDir: process.cwd() })
+
+  return IdentityPrinter.print(node)
+}
+
+describe("ActionViewTagHelperToHTMLRewriter", () => {
+  beforeAll(async () => {
+    await Herb.load()
+  })
+
+  test("name and description", () => {
+    const rewriter = new ActionViewTagHelperToHTMLRewriter()
+    expect(rewriter.name).toBe("action-view-tag-helper-to-html")
+    expect(rewriter.description).toContain("ActionView")
+  })
+
+  describe("tag.* helpers", () => {
+    test("tag.div with block", () => {
+      const input = dedent`
+        <%= tag.div do %>
+          Content
+        <% end %>
+      `
+
+      const expected = dedent`
+        <div>
+          Content
+        </div>
+      `
+
+      expect(transform(input)).toBe(expected)
+    })
+
+    test("tag.div with content as argument", () => {
+      expect(transform('<%= tag.div "Content" %>')).toBe(
+        "<div>Content</div>"
+      )
+    })
+
+    test("tag.div with attributes", () => {
+      const input = dedent`
+        <%= tag.div class: "content" do %>
+          Content
+        <% end %>
+      `
+
+      const expected = dedent`
+        <div class="content">
+          Content
+        </div>
+      `
+
+      expect(transform(input)).toBe(expected)
+    })
+
+    test("tag.div with content as argument and attributes", () => {
+      expect(transform('<%= tag.div "Content", class: "content" %>')).toBe(
+        '<div class="content">Content</div>'
+      )
+    })
+
+    test("tag.div with multiple attributes", () => {
+      const input = dedent`
+        <%= tag.div class: "content", id: "main" do %>
+          Content
+        <% end %>
+      `
+
+      const expected = dedent`
+        <div class="content" id="main">
+          Content
+        </div>
+      `
+
+      expect(transform(input)).toBe(expected)
+    })
+
+    test("tag.div with data attributes in hash style", () => {
+      const input = dedent`
+        <%= tag.div data: { controller: "content" } do %>
+          Content
+        <% end %>
+      `
+
+      const expected = dedent`
+        <div data-controller="content">
+          Content
+        </div>
+      `
+
+      expect(transform(input)).toBe(expected)
+    })
+
+    test("tag.div with variable attribute value wraps in ERB", () => {
+      const input = dedent`
+        <%= tag.div class: class_name do %>
+          Content
+        <% end %>
+      `
+
+      const expected = dedent`
+        <div class="<%= class_name %>">
+          Content
+        </div>
+      `
+
+      expect(transform(input)).toBe(expected)
+    })
+
+    test("tag.div with data attribute ruby literal value", () => {
+      const input = dedent`
+        <%= tag.div data: { controller: "content", user_id: 123 } do %>
+          Content
+        <% end %>
+      `
+
+      const expected = dedent`
+        <div data-controller="content" data-user-id="<%= 123 %>">
+          Content
+        </div>
+      `
+
+      expect(transform(input)).toBe(expected)
+    })
+
+    test("tag.br void element", () => {
+      expect(transform("<%= tag.br %>")).toBe("<br />")
+    })
+
+    test("tag.hr void element with attributes", () => {
+      expect(transform('<%= tag.hr class: "divider" %>')).toBe(
+        '<hr class="divider" />'
+      )
+    })
+
+    test("tag.img void element with attributes", () => {
+      expect(transform('<%= tag.img src: "image.png", alt: "Photo" %>')).toBe(
+        '<img src="image.png" alt="Photo" />'
+      )
+    })
+
+    test("tag.div with splat attributes", () => {
+      const input = dedent`
+        <%= tag.div class: "content", **attributes do %>
+          Content
+        <% end %>
+      `
+
+      const expected = dedent`
+        <div class="content" <%= **attributes %>>
+          Content
+        </div>
+      `
+
+      expect(transform(input)).toBe(expected)
+    })
+  })
+
+  describe("nested helpers", () => {
+    test("nested tag helpers are also converted", () => {
+      const input = dedent`
+        <%= tag.div class: "outer" do %>
+          <%= tag.span "Inner" %>
+        <% end %>
+      `
+
+      const expected = dedent`
+        <div class="outer">
+          <span>Inner</span>
+        </div>
+      `
+
+      expect(transform(input)).toBe(expected)
+    })
+  })
+
+  describe("non-ActionView elements", () => {
+    test("regular HTML elements are not modified", () => {
+      expect(transform('<div class="content">Hello</div>')).toBe(
+        '<div class="content">Hello</div>'
+      )
+    })
+
+    test("regular ERB expressions are not modified", () => {
+      expect(transform("<%= some_method %>")).toBe(
+        "<%= some_method %>"
+      )
+    })
+  })
+})

--- a/javascript/packages/rewriter/test/html-to-action-view-tag-helper.test.ts
+++ b/javascript/packages/rewriter/test/html-to-action-view-tag-helper.test.ts
@@ -1,0 +1,265 @@
+import dedent from "dedent"
+import { describe, test, expect, beforeAll } from "vitest"
+
+import { Herb } from "@herb-tools/node-wasm"
+import { IdentityPrinter } from "@herb-tools/printer"
+import { HTMLToActionViewTagHelperRewriter } from "@herb-tools/rewriter"
+
+import type { Node } from "@herb-tools/core"
+
+function transform(input: string): string {
+  const parseResult = Herb.parse(input, { track_whitespace: true })
+
+  if (parseResult.failed) {
+    throw new Error(
+      `Parser errors:\n${parseResult.recursiveErrors().map(e => `  - ${e.message}`).join("\n")}`
+    )
+  }
+
+  const rewriter = new HTMLToActionViewTagHelperRewriter()
+  const node = rewriter.rewrite(parseResult.value as Node, { baseDir: process.cwd() })
+
+  return IdentityPrinter.print(node)
+}
+
+describe("HTMLToActionViewTagHelperRewriter", () => {
+  beforeAll(async () => {
+    await Herb.load()
+  })
+
+  test("name and description", () => {
+    const rewriter = new HTMLToActionViewTagHelperRewriter()
+    expect(rewriter.name).toBe("html-to-action-view-tag-helper")
+    expect(rewriter.description).toContain("ActionView")
+  })
+
+  describe("block form elements", () => {
+    test("div with body", () => {
+      const input = dedent`
+        <div>
+          Content
+        </div>
+      `
+
+      const expected = dedent`
+        <%= tag.div do %>
+          Content
+        <% end %>
+      `
+
+      expect(transform(input)).toBe(expected)
+    })
+
+    test("div with class attribute", () => {
+      const input = dedent`
+        <div class="content">
+          Content
+        </div>
+      `
+
+      const expected = dedent`
+        <%= tag.div class: "content" do %>
+          Content
+        <% end %>
+      `
+
+      expect(transform(input)).toBe(expected)
+    })
+
+    test("div with multiple attributes", () => {
+      const input = dedent`
+        <div class="content" id="main">
+          Content
+        </div>
+      `
+
+      const expected = dedent`
+        <%= tag.div class: "content", id: "main" do %>
+          Content
+        <% end %>
+      `
+
+      expect(transform(input)).toBe(expected)
+    })
+
+    test("div with data attributes grouped into hash", () => {
+      const input = dedent`
+        <div data-controller="content">
+          Content
+        </div>
+      `
+
+      const expected = dedent`
+        <%= tag.div data: { controller: "content" } do %>
+          Content
+        <% end %>
+      `
+
+      expect(transform(input)).toBe(expected)
+    })
+
+    test("div with multiple data attributes grouped into hash", () => {
+      const input = dedent`
+        <div data-controller="content" data-user-id="123">
+          Content
+        </div>
+      `
+
+      const expected = dedent`
+        <%= tag.div data: { controller: "content", user_id: "123" } do %>
+          Content
+        <% end %>
+      `
+
+      expect(transform(input)).toBe(expected)
+    })
+
+    test("div with mixed regular and data attributes", () => {
+      const input = dedent`
+        <div class="content" data-controller="hello">
+          Content
+        </div>
+      `
+
+      const expected = dedent`
+        <%= tag.div class: "content", data: { controller: "hello" } do %>
+          Content
+        <% end %>
+      `
+
+      expect(transform(input)).toBe(expected)
+    })
+
+    test("div with aria attributes grouped into hash", () => {
+      const input = dedent`
+        <div aria-label="Close" aria-hidden="true">
+          Content
+        </div>
+      `
+
+      const expected = dedent`
+        <%= tag.div aria: { label: "Close", hidden: "true" } do %>
+          Content
+        <% end %>
+      `
+
+      expect(transform(input)).toBe(expected)
+    })
+  })
+
+  describe("inline content form", () => {
+    test("div with text content only", () => {
+      expect(transform('<div>Content</div>')).toBe(
+        '<%= tag.div "Content" %>'
+      )
+    })
+
+    test("div with text content and attributes", () => {
+      expect(transform('<div class="content">Hello</div>')).toBe(
+        '<%= tag.div "Hello", class: "content" %>'
+      )
+    })
+
+    test("span with text content", () => {
+      expect(transform('<span>text</span>')).toBe(
+        '<%= tag.span "text" %>'
+      )
+    })
+  })
+
+  describe("void elements", () => {
+    test("br", () => {
+      expect(transform("<br>")).toBe("<%= tag.br %>")
+    })
+
+    test("br self-closing", () => {
+      expect(transform("<br />")).toBe("<%= tag.br %>")
+    })
+
+    test("hr with attributes", () => {
+      expect(transform('<hr class="divider">')).toBe(
+        '<%= tag.hr class: "divider" %>'
+      )
+    })
+
+    test("img with attributes", () => {
+      expect(transform('<img src="image.png" alt="Photo">')).toBe(
+        '<%= tag.img src: "image.png", alt: "Photo" %>'
+      )
+    })
+  })
+
+  describe("nested elements", () => {
+    test("nested elements are also converted", () => {
+      const input = dedent`
+        <div class="outer">
+          <span>Inner</span>
+        </div>
+      `
+
+      const expected = dedent`
+        <%= tag.div class: "outer" do %>
+          <%= tag.span "Inner" %>
+        <% end %>
+      `
+
+      expect(transform(input)).toBe(expected)
+    })
+  })
+
+  describe("link_to for anchor tags", () => {
+    test("simple link with text and href", () => {
+      expect(transform('<a href="/path">Click me</a>')).toBe(
+        '<%= link_to "Click me", "/path" %>'
+      )
+    })
+
+    test("link with href and class", () => {
+      expect(transform('<a href="/path" class="btn">Click</a>')).toBe(
+        '<%= link_to "Click", "/path", class: "btn" %>'
+      )
+    })
+
+    test("link with data attributes", () => {
+      expect(transform('<a href="/path" data-turbo-method="delete">Delete</a>')).toBe(
+        '<%= link_to "Delete", "/path", data: { turbo_method: "delete" } %>'
+      )
+    })
+
+    test("link with block content", () => {
+      const input = dedent`
+        <a href="/path" class="btn">
+          <span>Icon</span> Click
+        </a>
+      `
+
+      const expected = dedent`
+        <%= link_to "/path", class: "btn" do %>
+          <%= tag.span "Icon" %> Click
+        <% end %>
+      `
+
+      expect(transform(input)).toBe(expected)
+    })
+
+    test("link without href", () => {
+      expect(transform('<a class="btn">Click</a>')).toBe(
+        '<%= link_to "Click", class: "btn" %>'
+      )
+    })
+
+    test("link with ERB href", () => {
+      expect(transform('<a href="<%= user_path(@user) %>">Profile</a>')).toBe(
+        '<%= link_to "Profile", user_path(@user) %>'
+      )
+    })
+  })
+
+  describe("ERB in attribute values", () => {
+    test("single ERB expression becomes Ruby variable", () => {
+      expect(transform('<div class="<%= class_name %>">Content</div>')).toBe(
+        '<%= tag.div "Content", class: class_name %>'
+      )
+    })
+  })
+})

--- a/sig/herb/ast/nodes.rbs
+++ b/sig/herb/ast/nodes.rbs
@@ -243,7 +243,7 @@ module Herb
     # |  open_tag: (Herb::AST::HTMLOpenTagNode | Herb::AST::HTMLConditionalOpenTagNode | Herb::AST::ERBOpenTagNode)?,
     # |  tag_name: Herb::Token?,
     # |  body: Array[Herb::AST::Node],
-    # |  close_tag: (Herb::AST::HTMLCloseTagNode | Herb::AST::HTMLOmittedCloseTagNode | Herb::AST::HTMLVirtualCloseTagNode)?,
+    # |  close_tag: (Herb::AST::HTMLCloseTagNode | Herb::AST::HTMLOmittedCloseTagNode | Herb::AST::HTMLVirtualCloseTagNode | Herb::AST::ERBEndNode)?,
     # |  is_void: bool,
     # |  element_source: String?,
     # | }
@@ -256,14 +256,14 @@ module Herb
 
       attr_reader body: Array[Herb::AST::Node]
 
-      attr_reader close_tag: (Herb::AST::HTMLCloseTagNode | Herb::AST::HTMLOmittedCloseTagNode | Herb::AST::HTMLVirtualCloseTagNode)?
+      attr_reader close_tag: (Herb::AST::HTMLCloseTagNode | Herb::AST::HTMLOmittedCloseTagNode | Herb::AST::HTMLVirtualCloseTagNode | Herb::AST::ERBEndNode)?
 
       attr_reader is_void: bool
 
       attr_reader element_source: String?
 
-      # : (String, Location, Array[Herb::Errors::Error], (Herb::AST::HTMLOpenTagNode | Herb::AST::HTMLConditionalOpenTagNode | Herb::AST::ERBOpenTagNode), Herb::Token, Array[Herb::AST::Node], (Herb::AST::HTMLCloseTagNode | Herb::AST::HTMLOmittedCloseTagNode | Herb::AST::HTMLVirtualCloseTagNode), bool, String) -> void
-      def initialize: (String, Location, Array[Herb::Errors::Error], Herb::AST::HTMLOpenTagNode | Herb::AST::HTMLConditionalOpenTagNode | Herb::AST::ERBOpenTagNode, Herb::Token, Array[Herb::AST::Node], Herb::AST::HTMLCloseTagNode | Herb::AST::HTMLOmittedCloseTagNode | Herb::AST::HTMLVirtualCloseTagNode, bool, String) -> void
+      # : (String, Location, Array[Herb::Errors::Error], (Herb::AST::HTMLOpenTagNode | Herb::AST::HTMLConditionalOpenTagNode | Herb::AST::ERBOpenTagNode), Herb::Token, Array[Herb::AST::Node], (Herb::AST::HTMLCloseTagNode | Herb::AST::HTMLOmittedCloseTagNode | Herb::AST::HTMLVirtualCloseTagNode | Herb::AST::ERBEndNode), bool, String) -> void
+      def initialize: (String, Location, Array[Herb::Errors::Error], Herb::AST::HTMLOpenTagNode | Herb::AST::HTMLConditionalOpenTagNode | Herb::AST::ERBOpenTagNode, Herb::Token, Array[Herb::AST::Node], Herb::AST::HTMLCloseTagNode | Herb::AST::HTMLOmittedCloseTagNode | Herb::AST::HTMLVirtualCloseTagNode | Herb::AST::ERBEndNode, bool, String) -> void
 
       # : () -> serialized_html_element_node
       def to_hash: () -> serialized_html_element_node


### PR DESCRIPTION
This pull request implements two new built-in rewriters `action-view-tag-helper-to-html` and `html-to-action-view-tag-helper` using the infrastructure implemented in #1347.

This allows us to rewrite an Action View Tag Helper like:
```html+erb
<%= tag.div class: classes, data: { controller: "hello" } do %>
  Content
<% end %>
```
to HTML:
```html+erb
<div class="<%= classes %>" data-controller="hello">
  Content
</div>
```

and back!