### PR TITLE
Rewriter: Fix single-arg `link_to` in Action View rewriter

### DIFF
--- a/javascript/packages/rewriter/src/built-ins/action-view-tag-helper-to-html.ts
+++ b/javascript/packages/rewriter/src/built-ins/action-view-tag-helper-to-html.ts
@@ -104,9 +104,23 @@ class ActionViewTagHelperToHTMLVisitor extends Visitor {
     asMutable(node).element_source = "HTML"
 
     if (node.body) {
-      for (const child of node.body) {
+      asMutable(node).body = node.body.map(child => {
+        if (isRubyLiteralNode(child)) {
+          return new ERBContentNode({
+            type: "AST_ERB_CONTENT_NODE",
+            location: child.location,
+            errors: [],
+            tag_opening: createSyntheticToken("<%="),
+            content: createSyntheticToken(` ${child.content} `),
+            tag_closing: createSyntheticToken("%>"),
+            parsed: false,
+            valid: true,
+          })
+        }
+
         this.visit(child)
-      }
+        return child
+      })
     }
   }
 

--- a/javascript/packages/rewriter/test/action-view-tag-helper-to-html.test.ts
+++ b/javascript/packages/rewriter/test/action-view-tag-helper-to-html.test.ts
@@ -196,6 +196,26 @@ describe("ActionViewTagHelperToHTMLRewriter", () => {
     })
   })
 
+  describe("link_to helpers", () => {
+    test("link_to with path only", () => {
+      expect(transform("<%= link_to root_path %>")).toBe(
+        '<a href="<%= root_path %>"><%= root_path.to_s %></a>'
+      )
+    })
+
+    test("link_to with model", () => {
+      expect(transform("<%= link_to @profile %>")).toBe(
+        '<a href="<%= url_for(@profile) %>"><%= @profile.to_s %></a>'
+      )
+    })
+
+    test("link_to with :back", () => {
+      expect(transform('<%= link_to "Back", :back %>')).toBe(
+        '<a href="<%= url_for(:back) %>">Back</a>'
+      )
+    })
+  })
+
   describe("non-ActionView elements", () => {
     test("regular HTML elements are not modified", () => {
       expect(transform('<div class="content">Hello</div>')).toBe(


### PR DESCRIPTION
This pull request fixes the case transforming `<%= link_to root_path %>` to HTML using the `action-view-tag-helper-to-html` rewriter.

Follow up on #1348 
