### PR TITLE
Linter: Move `path` to CLI-only bundle

### DIFF
--- a/javascript/packages/linter/src/cli/file-url.ts
+++ b/javascript/packages/linter/src/cli/file-url.ts
@@ -1,0 +1,6 @@
+import { resolve } from "node:path"
+
+export function fileUrl(filePath: string): string {
+  const absolutePath = resolve(filePath)
+  return `file://${absolutePath}`
+}

--- a/javascript/packages/linter/src/cli/formatters/detailed-formatter.ts
+++ b/javascript/packages/linter/src/cli/formatters/detailed-formatter.ts
@@ -2,7 +2,8 @@ import { colorize, Highlighter, type ThemeInput, DEFAULT_THEME } from "@herb-too
 
 import { BaseFormatter } from "./base-formatter.js"
 import { LineWrapper } from "@herb-tools/highlighter"
-import { ruleDocumentationUrl, fileUrl } from "../../urls.js"
+import { ruleDocumentationUrl } from "../../urls.js"
+import { fileUrl } from "../file-url.js"
 
 import type { Diagnostic } from "@herb-tools/core"
 import type { ProcessedFile } from "../file-processor.js"

--- a/javascript/packages/linter/src/cli/formatters/simple-formatter.ts
+++ b/javascript/packages/linter/src/cli/formatters/simple-formatter.ts
@@ -1,7 +1,8 @@
 import { colorize, hyperlink, TextFormatter } from "@herb-tools/highlighter"
 
 import { BaseFormatter } from "./base-formatter.js"
-import { ruleDocumentationUrl, fileUrl } from "../../urls.js"
+import { ruleDocumentationUrl } from "../../urls.js"
+import { fileUrl } from "../file-url.js"
 
 import type { Diagnostic } from "@herb-tools/core"
 import type { ProcessedFile } from "../file-processor.js"

--- a/javascript/packages/linter/src/urls.ts
+++ b/javascript/packages/linter/src/urls.ts
@@ -1,12 +1,5 @@
-import { resolve } from "node:path"
-
 const DOCS_BASE_URL = "https://herb-tools.dev/linter/rules"
 
 export function ruleDocumentationUrl(ruleId: string): string {
   return `${DOCS_BASE_URL}/${ruleId}`
-}
-
-export function fileUrl(filePath: string): string {
-  const absolutePath = resolve(filePath)
-  return `file://${absolutePath}`
 }


### PR DESCRIPTION
This pull request moves the `fileUrl` helpers to a new file `src/cli/file-url.ts` in the linter package, so that the import to `"node:path"` is only within the CLI and not leaking to the web/browser bundle of the linter.