### PR TITLE
Herb: Expose `Herb.parse_puby` to parse Ruby with Prism

### DIFF
--- a/java/herb_jni.c
+++ b/java/herb_jni.c
@@ -185,6 +185,35 @@ Java_org_herb_Herb_extractRuby(JNIEnv* env, jclass clazz, jstring source, jobjec
   return result;
 }
 
+JNIEXPORT jbyteArray JNICALL
+Java_org_herb_Herb_parseRuby(JNIEnv* env, jclass clazz, jstring source) {
+  const char* src = (*env)->GetStringUTFChars(env, source, 0);
+  size_t src_len = strlen(src);
+
+  herb_ruby_parse_result_T* parse_result = herb_parse_ruby(src, src_len);
+
+  if (!parse_result) {
+    (*env)->ReleaseStringUTFChars(env, source, src);
+    return NULL;
+  }
+
+  pm_buffer_t buffer = { 0 };
+  pm_serialize(&parse_result->parser, parse_result->root, &buffer);
+
+  jbyteArray result = NULL;
+
+  if (buffer.length > 0) {
+    result = (*env)->NewByteArray(env, (jsize) buffer.length);
+    (*env)->SetByteArrayRegion(env, result, 0, (jsize) buffer.length, (const jbyte*) buffer.value);
+  }
+
+  pm_buffer_free(&buffer);
+  herb_free_ruby_parse_result(parse_result);
+  (*env)->ReleaseStringUTFChars(env, source, src);
+
+  return result;
+}
+
 JNIEXPORT jstring JNICALL
 Java_org_herb_Herb_extractHTML(JNIEnv* env, jclass clazz, jstring source) {
   const char* src = (*env)->GetStringUTFChars(env, source, 0);

--- a/java/herb_jni.h
+++ b/java/herb_jni.h
@@ -13,6 +13,7 @@ JNIEXPORT jobject JNICALL Java_org_herb_Herb_parse(JNIEnv*, jclass, jstring, job
 JNIEXPORT jobject JNICALL Java_org_herb_Herb_lex(JNIEnv*, jclass, jstring);
 JNIEXPORT jstring JNICALL Java_org_herb_Herb_extractRuby(JNIEnv*, jclass, jstring, jobject);
 JNIEXPORT jstring JNICALL Java_org_herb_Herb_extractHTML(JNIEnv*, jclass, jstring);
+JNIEXPORT jbyteArray JNICALL Java_org_herb_Herb_parseRuby(JNIEnv*, jclass, jstring);
 
 #ifdef __cplusplus
 }

--- a/java/org/herb/Herb.java
+++ b/java/org/herb/Herb.java
@@ -20,6 +20,7 @@ public class Herb {
   public static native LexResult lex(String source);
   public static native String extractRuby(String source, ExtractRubyOptions options);
   public static native String extractHTML(String source);
+  public static native byte[] parseRuby(String source);
 
   public static ParseResult parse(String source) {
     return parse(source, null);

--- a/java/org/herb/HerbTest.java
+++ b/java/org/herb/HerbTest.java
@@ -148,6 +148,22 @@ public class HerbTest {
   }
 
   @Test
+  void testParseRuby() {
+    byte[] result = Herb.parseRuby("link_to('Home', root_path)");
+
+    assertNotNull(result);
+    assertTrue(result.length > 0);
+  }
+
+  @Test
+  void testParseRubyEmpty() {
+    byte[] result = Herb.parseRuby("");
+
+    assertNotNull(result);
+    assertTrue(result.length > 0);
+  }
+
+  @Test
   void testParserOptionsAnalyze() {
     String source = "<% if true %><div></div><% end %>";
 

--- a/javascript/packages/core/src/backend.ts
+++ b/javascript/packages/core/src/backend.ts
@@ -11,6 +11,8 @@ interface LibHerbBackendFunctions {
   extractRuby: (source: string, options?: ExtractRubyOptions) => string
   extractHTML: (source: string) => string
 
+  parseRuby: (source: string) => Uint8Array | null
+
   version: () => string
 }
 
@@ -21,6 +23,7 @@ const expectedFunctions = [
   "lex",
   "extractRuby",
   "extractHTML",
+  "parseRuby",
   "version",
 ] as const
 

--- a/javascript/packages/core/src/herb-backend.ts
+++ b/javascript/packages/core/src/herb-backend.ts
@@ -5,10 +5,12 @@ import { LexResult } from "./lex-result.js"
 import { ParseResult } from "./parse-result.js"
 import { DEFAULT_PARSER_OPTIONS } from "./parser-options.js"
 import { DEFAULT_EXTRACT_RUBY_OPTIONS } from "./extract-ruby-options.js"
+import { deserializePrismParseResult } from "./prism/index.js"
 
 import type { LibHerbBackend, BackendPromise } from "./backend.js"
 import type { ParseOptions } from "./parser-options.js"
 import type { ExtractRubyOptions } from "./extract-ruby-options.js"
+import type { PrismParseResult } from "./prism/index.js"
 
 /**
  * The main Herb parser interface, providing methods to lex and parse input.
@@ -95,6 +97,24 @@ export abstract class HerbBackend {
     const mergedOptions = { ...DEFAULT_EXTRACT_RUBY_OPTIONS, ...options }
 
     return this.backend.extractRuby(ensureString(source), mergedOptions)
+  }
+
+  /**
+   * Parses a Ruby source string using Prism via the libherb backend.
+   * @param source - The Ruby source code to parse.
+   * @returns A Prism ParseResult containing the AST.
+   * @throws Error if the backend is not loaded.
+   */
+  parseRuby(source: string): PrismParseResult {
+    this.ensureBackend()
+
+    const bytes = this.backend.parseRuby(ensureString(source))
+
+    if (!bytes) {
+      throw new Error("Failed to parse Ruby source")
+    }
+
+    return deserializePrismParseResult(bytes, source)
   }
 
   /**

--- a/javascript/packages/node-wasm/test/__snapshots__/parse-ruby.test.ts.snap
+++ b/javascript/packages/node-wasm/test/__snapshots__/parse-ruby.test.ts.snap
@@ -1,0 +1,136 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`parseRuby > parseRuby() parses a class definition 1`] = `
+"@ ProgramNode (location: (1:0)-(1:14))
+├── locals: []
+└── statements:
+    └── @ StatementsNode (location: (1:0)-(1:14))
+        └── body: (1 item)
+            └── @ ClassNode (location: (1:0)-(1:14))
+                ├── locals: []
+                ├── classKeywordLoc: (location: (1:0)-(1:5))
+                ├── constantPath:
+                │   └── @ ConstantReadNode (location: (1:6)-(1:9))
+                │       └── name: "Foo"
+                ├── inheritanceOperatorLoc: ∅
+                ├── superclass: ∅
+                ├── body: ∅
+                ├── endKeywordLoc: (location: (1:11)-(1:14))
+                └── name: "Foo"
+"
+`;
+
+exports[`parseRuby > parseRuby() parses a method definition 1`] = `
+"@ ProgramNode (location: (1:0)-(3:3))
+├── locals: []
+└── statements:
+    └── @ StatementsNode (location: (1:0)-(3:3))
+        └── body: (1 item)
+            └── @ DefNode (location: (1:0)-(3:3))
+                ├── name: "greet"
+                ├── nameLoc: (location: (1:4)-(1:9))
+                ├── receiver: ∅
+                ├── parameters:
+                │   └── @ ParametersNode (location: (1:10)-(1:14))
+                │       ├── requireds: (1 item)
+                │       │   └── @ RequiredParameterNode (location: (1:10)-(1:14))
+                │       │       └── name: "name"
+                │       ├── optionals: []
+                │       ├── rest: ∅
+                │       ├── posts: []
+                │       ├── keywords: []
+                │       ├── keywordRest: ∅
+                │       └── block: ∅
+                ├── body:
+                │   └── @ StatementsNode (location: (2:2)-(2:19))
+                │       └── body: (1 item)
+                │           └── @ InterpolatedStringNode (location: (2:2)-(2:19))
+                │               ├── openingLoc: (location: (2:2)-(2:3))
+                │               ├── parts: (3 items)
+                │               │   ├── @ StringNode (location: (2:3)-(2:10))
+                │               │   │   ├── openingLoc: ∅
+                │               │   │   ├── contentLoc: (location: (2:3)-(2:10))
+                │               │   │   ├── closingLoc: ∅
+                │               │   │   └── unescaped: "Hello, "
+                │               │   ├── @ EmbeddedStatementsNode (location: (2:10)-(2:17))
+                │               │   │   ├── openingLoc: (location: (2:10)-(2:12))
+                │               │   │   ├── statements:
+                │               │   │   │   └── @ StatementsNode (location: (2:12)-(2:16))
+                │               │   │   │       └── body: (1 item)
+                │               │   │   │           └── @ LocalVariableReadNode (location: (2:12)-(2:16))
+                │               │   │   │               ├── name: "name"
+                │               │   │   │               └── depth: 0
+                │               │   │   └── closingLoc: (location: (2:16)-(2:17))
+                │               │   └── @ StringNode (location: (2:17)-(2:18))
+                │               │       ├── openingLoc: ∅
+                │               │       ├── contentLoc: (location: (2:17)-(2:18))
+                │               │       ├── closingLoc: ∅
+                │               │       └── unescaped: "!"
+                │               └── closingLoc: (location: (2:18)-(2:19))
+                ├── locals: (1 item)
+                │   └── name
+                ├── defKeywordLoc: (location: (1:0)-(1:3))
+                ├── operatorLoc: ∅
+                ├── lparenLoc: (location: (1:9)-(1:10))
+                ├── rparenLoc: (location: (1:14)-(1:15))
+                ├── equalLoc: ∅
+                └── endKeywordLoc: (location: (3:0)-(3:3))
+"
+`;
+
+exports[`parseRuby > parseRuby() parses a simple expression 1`] = `
+"@ ProgramNode (location: (1:0)-(1:5))
+├── locals: []
+└── statements:
+    └── @ StatementsNode (location: (1:0)-(1:5))
+        └── body: (1 item)
+            └── @ CallNode (location: (1:0)-(1:5))
+                ├── receiver:
+                │   └── @ IntegerNode (location: (1:0)-(1:1))
+                │       └── value: 1
+                ├── callOperatorLoc: ∅
+                ├── name: "+"
+                ├── messageLoc: (location: (1:2)-(1:3))
+                ├── openingLoc: ∅
+                ├── arguments_:
+                │   └── @ ArgumentsNode (location: (1:4)-(1:5))
+                │       └── arguments_: (1 item)
+                │           └── @ IntegerNode (location: (1:4)-(1:5))
+                │               └── value: 2
+                ├── closingLoc: ∅
+                ├── equalLoc: ∅
+                └── block: ∅
+"
+`;
+
+exports[`parseRuby > parseRuby() parses raw Ruby, not ERB 1`] = `
+"@ ProgramNode (location: (1:0)-(1:9))
+├── locals: (1 item)
+│   └── x
+└── statements:
+    └── @ StatementsNode (location: (1:0)-(1:9))
+        └── body: (1 item)
+            └── @ LocalVariableWriteNode (location: (1:0)-(1:9))
+                ├── name: "x"
+                ├── depth: 0
+                ├── nameLoc: (location: (1:0)-(1:1))
+                ├── value:
+                │   └── @ CallNode (location: (1:4)-(1:9))
+                │       ├── receiver:
+                │       │   └── @ IntegerNode (location: (1:4)-(1:5))
+                │       │       └── value: 1
+                │       ├── callOperatorLoc: ∅
+                │       ├── name: "+"
+                │       ├── messageLoc: (location: (1:6)-(1:7))
+                │       ├── openingLoc: ∅
+                │       ├── arguments_:
+                │       │   └── @ ArgumentsNode (location: (1:8)-(1:9))
+                │       │       └── arguments_: (1 item)
+                │       │           └── @ IntegerNode (location: (1:8)-(1:9))
+                │       │               └── value: 2
+                │       ├── closingLoc: ∅
+                │       ├── equalLoc: ∅
+                │       └── block: ∅
+                └── operatorLoc: (location: (1:2)-(1:3))
+"
+`;

--- a/javascript/packages/node-wasm/test/parse-ruby.test.ts
+++ b/javascript/packages/node-wasm/test/parse-ruby.test.ts
@@ -1,0 +1,32 @@
+import { describe, test, expect, beforeAll } from "vitest"
+import { Herb, inspectPrismNode } from "../src"
+
+describe("parseRuby", () => {
+  beforeAll(async () => {
+    await Herb.load()
+  })
+
+  test("parseRuby() parses a simple expression", () => {
+    const source = "1 + 2"
+    const result = Herb.parseRuby(source)
+    expect(inspectPrismNode(result.value, source)).toMatchSnapshot()
+  })
+
+  test("parseRuby() parses a class definition", () => {
+    const source = "class Foo; end"
+    const result = Herb.parseRuby(source)
+    expect(inspectPrismNode(result.value, source)).toMatchSnapshot()
+  })
+
+  test("parseRuby() parses a method definition", () => {
+    const source = 'def greet(name)\n  "Hello, #{name}!"\nend'
+    const result = Herb.parseRuby(source)
+    expect(inspectPrismNode(result.value, source)).toMatchSnapshot()
+  })
+
+  test("parseRuby() parses raw Ruby, not ERB", () => {
+    const source = "x = 1 + 2"
+    const result = Herb.parseRuby(source)
+    expect(inspectPrismNode(result.value, source)).toMatchSnapshot()
+  })
+})

--- a/javascript/packages/node/extension/herb.cpp
+++ b/javascript/packages/node/extension/herb.cpp
@@ -285,6 +285,43 @@ napi_value Herb_extract_html(napi_env env, napi_callback_info info) {
   return result;
 }
 
+napi_value Herb_parse_ruby(napi_env env, napi_callback_info info) {
+  size_t argc = 1;
+  napi_value args[1];
+  napi_get_cb_info(env, info, &argc, args, nullptr, nullptr);
+
+  if (argc < 1) {
+    napi_throw_error(env, nullptr, "Wrong number of arguments");
+    return nullptr;
+  }
+
+  char* string = CheckString(env, args[0]);
+  if (!string) { return nullptr; }
+
+  herb_ruby_parse_result_T* parse_result = herb_parse_ruby(string, strlen(string));
+
+  if (!parse_result) {
+    free(string);
+    return nullptr;
+  }
+
+  pm_buffer_t buffer = { 0 };
+  pm_serialize(&parse_result->parser, parse_result->root, &buffer);
+
+  napi_value result = nullptr;
+
+  if (buffer.length > 0) {
+    void* data;
+    napi_create_buffer_copy(env, buffer.length, buffer.value, &data, &result);
+  }
+
+  pm_buffer_free(&buffer);
+  herb_free_ruby_parse_result(parse_result);
+  free(string);
+
+  return result;
+}
+
 napi_value Herb_version(napi_env env, napi_callback_info info) {
   const char* libherb_version = herb_version();
   const char* libprism_version = herb_prism_version();
@@ -305,6 +342,7 @@ napi_value Init(napi_env env, napi_value exports) {
     { "extractRuby", nullptr, Herb_extract_ruby, nullptr, nullptr, nullptr, napi_default, nullptr },
     { "extractHTML", nullptr, Herb_extract_html, nullptr, nullptr, nullptr, napi_default, nullptr },
     { "version", nullptr, Herb_version, nullptr, nullptr, nullptr, napi_default, nullptr },
+    { "parseRuby", nullptr, Herb_parse_ruby, nullptr, nullptr, nullptr, napi_default, nullptr },
   };
 
   napi_define_properties(env, exports, sizeof(descriptors) / sizeof(descriptors[0]), descriptors);

--- a/javascript/packages/node/test/__snapshots__/parse-ruby.test.ts.snap
+++ b/javascript/packages/node/test/__snapshots__/parse-ruby.test.ts.snap
@@ -1,0 +1,136 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`parseRuby > parseRuby() parses a class definition 1`] = `
+"@ ProgramNode (location: (1:0)-(1:14))
+├── locals: []
+└── statements:
+    └── @ StatementsNode (location: (1:0)-(1:14))
+        └── body: (1 item)
+            └── @ ClassNode (location: (1:0)-(1:14))
+                ├── locals: []
+                ├── classKeywordLoc: (location: (1:0)-(1:5))
+                ├── constantPath:
+                │   └── @ ConstantReadNode (location: (1:6)-(1:9))
+                │       └── name: "Foo"
+                ├── inheritanceOperatorLoc: ∅
+                ├── superclass: ∅
+                ├── body: ∅
+                ├── endKeywordLoc: (location: (1:11)-(1:14))
+                └── name: "Foo"
+"
+`;
+
+exports[`parseRuby > parseRuby() parses a method definition 1`] = `
+"@ ProgramNode (location: (1:0)-(3:3))
+├── locals: []
+└── statements:
+    └── @ StatementsNode (location: (1:0)-(3:3))
+        └── body: (1 item)
+            └── @ DefNode (location: (1:0)-(3:3))
+                ├── name: "greet"
+                ├── nameLoc: (location: (1:4)-(1:9))
+                ├── receiver: ∅
+                ├── parameters:
+                │   └── @ ParametersNode (location: (1:10)-(1:14))
+                │       ├── requireds: (1 item)
+                │       │   └── @ RequiredParameterNode (location: (1:10)-(1:14))
+                │       │       └── name: "name"
+                │       ├── optionals: []
+                │       ├── rest: ∅
+                │       ├── posts: []
+                │       ├── keywords: []
+                │       ├── keywordRest: ∅
+                │       └── block: ∅
+                ├── body:
+                │   └── @ StatementsNode (location: (2:2)-(2:19))
+                │       └── body: (1 item)
+                │           └── @ InterpolatedStringNode (location: (2:2)-(2:19))
+                │               ├── openingLoc: (location: (2:2)-(2:3))
+                │               ├── parts: (3 items)
+                │               │   ├── @ StringNode (location: (2:3)-(2:10))
+                │               │   │   ├── openingLoc: ∅
+                │               │   │   ├── contentLoc: (location: (2:3)-(2:10))
+                │               │   │   ├── closingLoc: ∅
+                │               │   │   └── unescaped: "Hello, "
+                │               │   ├── @ EmbeddedStatementsNode (location: (2:10)-(2:17))
+                │               │   │   ├── openingLoc: (location: (2:10)-(2:12))
+                │               │   │   ├── statements:
+                │               │   │   │   └── @ StatementsNode (location: (2:12)-(2:16))
+                │               │   │   │       └── body: (1 item)
+                │               │   │   │           └── @ LocalVariableReadNode (location: (2:12)-(2:16))
+                │               │   │   │               ├── name: "name"
+                │               │   │   │               └── depth: 0
+                │               │   │   └── closingLoc: (location: (2:16)-(2:17))
+                │               │   └── @ StringNode (location: (2:17)-(2:18))
+                │               │       ├── openingLoc: ∅
+                │               │       ├── contentLoc: (location: (2:17)-(2:18))
+                │               │       ├── closingLoc: ∅
+                │               │       └── unescaped: "!"
+                │               └── closingLoc: (location: (2:18)-(2:19))
+                ├── locals: (1 item)
+                │   └── name
+                ├── defKeywordLoc: (location: (1:0)-(1:3))
+                ├── operatorLoc: ∅
+                ├── lparenLoc: (location: (1:9)-(1:10))
+                ├── rparenLoc: (location: (1:14)-(1:15))
+                ├── equalLoc: ∅
+                └── endKeywordLoc: (location: (3:0)-(3:3))
+"
+`;
+
+exports[`parseRuby > parseRuby() parses a simple expression 1`] = `
+"@ ProgramNode (location: (1:0)-(1:5))
+├── locals: []
+└── statements:
+    └── @ StatementsNode (location: (1:0)-(1:5))
+        └── body: (1 item)
+            └── @ CallNode (location: (1:0)-(1:5))
+                ├── receiver:
+                │   └── @ IntegerNode (location: (1:0)-(1:1))
+                │       └── value: 1
+                ├── callOperatorLoc: ∅
+                ├── name: "+"
+                ├── messageLoc: (location: (1:2)-(1:3))
+                ├── openingLoc: ∅
+                ├── arguments_:
+                │   └── @ ArgumentsNode (location: (1:4)-(1:5))
+                │       └── arguments_: (1 item)
+                │           └── @ IntegerNode (location: (1:4)-(1:5))
+                │               └── value: 2
+                ├── closingLoc: ∅
+                ├── equalLoc: ∅
+                └── block: ∅
+"
+`;
+
+exports[`parseRuby > parseRuby() parses raw Ruby, not ERB 1`] = `
+"@ ProgramNode (location: (1:0)-(1:9))
+├── locals: (1 item)
+│   └── x
+└── statements:
+    └── @ StatementsNode (location: (1:0)-(1:9))
+        └── body: (1 item)
+            └── @ LocalVariableWriteNode (location: (1:0)-(1:9))
+                ├── name: "x"
+                ├── depth: 0
+                ├── nameLoc: (location: (1:0)-(1:1))
+                ├── value:
+                │   └── @ CallNode (location: (1:4)-(1:9))
+                │       ├── receiver:
+                │       │   └── @ IntegerNode (location: (1:4)-(1:5))
+                │       │       └── value: 1
+                │       ├── callOperatorLoc: ∅
+                │       ├── name: "+"
+                │       ├── messageLoc: (location: (1:6)-(1:7))
+                │       ├── openingLoc: ∅
+                │       ├── arguments_:
+                │       │   └── @ ArgumentsNode (location: (1:8)-(1:9))
+                │       │       └── arguments_: (1 item)
+                │       │           └── @ IntegerNode (location: (1:8)-(1:9))
+                │       │               └── value: 2
+                │       ├── closingLoc: ∅
+                │       ├── equalLoc: ∅
+                │       └── block: ∅
+                └── operatorLoc: (location: (1:2)-(1:3))
+"
+`;

--- a/javascript/packages/node/test/parse-ruby.test.ts
+++ b/javascript/packages/node/test/parse-ruby.test.ts
@@ -1,0 +1,32 @@
+import { describe, test, expect, beforeAll } from "vitest"
+import { Herb, inspectPrismNode } from "../src/index.ts"
+
+describe("parseRuby", () => {
+  beforeAll(async () => {
+    await Herb.load()
+  })
+
+  test("parseRuby() parses a simple expression", () => {
+    const source = "1 + 2"
+    const result = Herb.parseRuby(source)
+    expect(inspectPrismNode(result.value, source)).toMatchSnapshot()
+  })
+
+  test("parseRuby() parses a class definition", () => {
+    const source = "class Foo; end"
+    const result = Herb.parseRuby(source)
+    expect(inspectPrismNode(result.value, source)).toMatchSnapshot()
+  })
+
+  test("parseRuby() parses a method definition", () => {
+    const source = 'def greet(name)\n  "Hello, #{name}!"\nend'
+    const result = Herb.parseRuby(source)
+    expect(inspectPrismNode(result.value, source)).toMatchSnapshot()
+  })
+
+  test("parseRuby() parses raw Ruby, not ERB", () => {
+    const source = "x = 1 + 2"
+    const result = Herb.parseRuby(source)
+    expect(inspectPrismNode(result.value, source)).toMatchSnapshot()
+  })
+})

--- a/lib/herb.rb
+++ b/lib/herb.rb
@@ -77,6 +77,13 @@ module Herb
       parse(File.read(path), **options)
     end
 
+    #: (String source) -> Prism::ParseResult
+    def parse_ruby(source)
+      require "prism"
+
+      Prism.parse(source)
+    end
+
     def configuration(project_path = nil)
       @configuration ||= Configuration.load(project_path)
     end

--- a/rust/src/ffi.rs
+++ b/rust/src/ffi.rs
@@ -1,5 +1,5 @@
 pub use crate::bindings::{
   ast_node_free, hb_allocator_T, hb_allocator_destroy, hb_allocator_init, hb_array_get, hb_array_size, hb_buffer_free, hb_buffer_init, hb_buffer_value,
-  hb_string_T, herb_extract, herb_extract_ruby_to_buffer_with_options, herb_free_tokens, herb_lex, herb_parse, herb_prism_version, herb_version,
-  token_type_to_string, HB_ALLOCATOR_ARENA,
+  hb_string_T, herb_extract, herb_extract_ruby_to_buffer_with_options, herb_free_ruby_parse_result, herb_free_tokens, herb_lex, herb_parse, herb_parse_ruby,
+  herb_prism_version, herb_version, pm_buffer_free, pm_buffer_t, pm_prettyprint, token_type_to_string, HB_ALLOCATOR_ARENA,
 };

--- a/rust/src/herb.rs
+++ b/rust/src/herb.rs
@@ -66,15 +66,15 @@ pub fn lex(source: &str) -> Result<LexResult, String> {
     let mut tokens = Vec::with_capacity(array_size);
 
     for index in 0..array_size {
-      let token_ptr = crate::ffi::hb_array_get(c_tokens, index) as *const token_T;
+      let token_pointer = crate::ffi::hb_array_get(c_tokens, index) as *const token_T;
 
-      if !token_ptr.is_null() {
-        tokens.push(token_from_c(token_ptr));
+      if !token_pointer.is_null() {
+        tokens.push(token_from_c(token_pointer));
       }
     }
 
-    let mut c_tokens_ptr = c_tokens;
-    crate::ffi::herb_free_tokens(&mut c_tokens_ptr as *mut *mut hb_array_T, &mut allocator);
+    let mut c_tokens_pointer = c_tokens;
+    crate::ffi::herb_free_tokens(&mut c_tokens_pointer as *mut *mut hb_array_T, &mut allocator);
     crate::ffi::hb_allocator_destroy(&mut allocator);
 
     Ok(LexResult::new(tokens))
@@ -124,6 +124,59 @@ pub fn parse_with_options(source: &str, options: &ParserOptions) -> Result<Parse
     crate::ffi::hb_allocator_destroy(&mut allocator);
 
     Ok(result)
+  }
+}
+
+pub struct RubyParseResult {
+  pointer: *mut crate::bindings::herb_ruby_parse_result_T,
+  _source: CString,
+}
+
+impl RubyParseResult {
+  pub fn prettyprint(&self) -> String {
+    unsafe {
+      let mut buffer: crate::ffi::pm_buffer_t = std::mem::zeroed();
+
+      crate::ffi::pm_prettyprint(&mut buffer, &(*self.pointer).parser, (*self.pointer).root);
+
+      let output = if !buffer.value.is_null() && buffer.length > 0 {
+        let slice = std::slice::from_raw_parts(buffer.value as *const u8, buffer.length);
+        String::from_utf8_lossy(slice).into_owned()
+      } else {
+        String::new()
+      };
+
+      crate::ffi::pm_buffer_free(&mut buffer);
+
+      crate::nodes::prettify_prism_tree(&output)
+    }
+  }
+}
+
+impl Drop for RubyParseResult {
+  fn drop(&mut self) {
+    if !self.pointer.is_null() {
+      unsafe {
+        crate::ffi::herb_free_ruby_parse_result(self.pointer);
+      }
+    }
+  }
+}
+
+pub fn parse_ruby(source: &str) -> Result<RubyParseResult, String> {
+  let c_source = CString::new(source).map_err(|e| e.to_string())?;
+
+  unsafe {
+    let result = crate::ffi::herb_parse_ruby(c_source.as_ptr(), source.len());
+
+    if result.is_null() {
+      return Err("Failed to parse Ruby source".to_string());
+    }
+
+    Ok(RubyParseResult {
+      pointer: result,
+      _source: c_source,
+    })
   }
 }
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -16,8 +16,8 @@ pub mod visitor;
 
 pub use errors::{AnyError, ErrorNode, ErrorType};
 pub use herb::{
-  extract_html, extract_ruby, extract_ruby_with_options, herb_version, lex, parse, parse_with_options, prism_version, version, ExtractRubyOptions,
-  ParserOptions,
+  extract_html, extract_ruby, extract_ruby_with_options, herb_version, lex, parse, parse_ruby, parse_with_options, prism_version, version, ExtractRubyOptions,
+  ParserOptions, RubyParseResult,
 };
 pub use lex_result::LexResult;
 pub use location::Location;

--- a/rust/tests/parse_ruby_test.rs
+++ b/rust/tests/parse_ruby_test.rs
@@ -1,0 +1,20 @@
+use herb::parse_ruby;
+use insta::assert_snapshot;
+
+#[test]
+fn test_parse_ruby_class() {
+  let result = parse_ruby("class Foo; end").unwrap();
+  assert_snapshot!(result.prettyprint());
+}
+
+#[test]
+fn test_parse_ruby_method_definition() {
+  let result = parse_ruby("def greet(name)\n  \"Hello, #{name}!\"\nend").unwrap();
+  assert_snapshot!(result.prettyprint());
+}
+
+#[test]
+fn test_parse_ruby_simple_expression() {
+  let result = parse_ruby("1 + 2").unwrap();
+  assert_snapshot!(result.prettyprint());
+}

--- a/rust/tests/snapshots/parse_ruby_test__parse_ruby_class.snap
+++ b/rust/tests/snapshots/parse_ruby_test__parse_ruby_class.snap
@@ -1,0 +1,20 @@
+---
+source: tests/parse_ruby_test.rs
+expression: result.prettyprint()
+---
+@ ProgramNode (location: (0,0)-(0,14))
+├── locals: []
+└── statements:
+    @ StatementsNode (location: (0,0)-(0,14))
+    └── body: (length: 1)
+        └── @ ClassNode (location: (0,0)-(0,14))
+            ├── locals: []
+            ├── class_keyword_loc: (0,0)-(0,5) = "class"
+            ├── constant_path:
+            │   @ ConstantReadNode (location: (0,6)-(0,9))
+            │   └── name: :Foo
+            ├── inheritance_operator_loc: nil
+            ├── superclass: nil
+            ├── body: nil
+            ├── end_keyword_loc: (0,11)-(0,14) = "end"
+            └── name: :Foo

--- a/rust/tests/snapshots/parse_ruby_test__parse_ruby_method_definition.snap
+++ b/rust/tests/snapshots/parse_ruby_test__parse_ruby_method_definition.snap
@@ -1,0 +1,61 @@
+---
+source: tests/parse_ruby_test.rs
+expression: result.prettyprint()
+---
+@ ProgramNode (location: (0,0)-(2,3))
+├── locals: []
+└── statements:
+    @ StatementsNode (location: (0,0)-(2,3))
+    └── body: (length: 1)
+        └── @ DefNode (location: (0,0)-(2,3))
+            ├── name: :greet
+            ├── name_loc: (0,4)-(0,9) = "greet"
+            ├── receiver: nil
+            ├── parameters:
+            │   @ ParametersNode (location: (0,10)-(0,14))
+            │   ├── requireds: (length: 1)
+            │   │   └── @ RequiredParameterNode (location: (0,10)-(0,14))
+            │   │       ├── ParameterFlags: nil
+            │   │       └── name: :name
+            │   ├── optionals: (length: 0)
+            │   ├── rest: nil
+            │   ├── posts: (length: 0)
+            │   ├── keywords: (length: 0)
+            │   ├── keyword_rest: nil
+            │   ├── block: nil
+            ├── body:
+            │   @ StatementsNode (location: (1,2)-(1,19))
+            │   └── body: (length: 1)
+            │       └── @ InterpolatedStringNode (location: (1,2)-(1,19))
+            │           ├── InterpolatedStringNodeFlags: nil
+            │           ├── opening_loc: (1,2)-(1,3) = "\""
+            │           ├── parts: (length: 3)
+            │           │   ├── @ StringNode (location: (1,3)-(1,10))
+            │           │   │   ├── StringFlags: frozen
+            │           │   │   ├── opening_loc: nil
+            │           │   │   ├── content_loc: (1,3)-(1,10) = "Hello, "
+            │           │   │   ├── closing_loc: nil
+            │           │   │   ├── unescaped: "Hello, "
+            │           │   ├── @ EmbeddedStatementsNode (location: (1,10)-(1,17))
+            │           │   │   ├── opening_loc: (1,10)-(1,12) = "\#{"
+            │           │   │   ├── statements:
+            │           │   │   │   @ StatementsNode (location: (1,12)-(1,16))
+            │           │   │   │   └── body: (length: 1)
+            │           │   │   │       └── @ LocalVariableReadNode (location: (1,12)-(1,16))
+            │           │   │   │           ├── name: :name
+            │           │   │   │           └── depth: 0
+            │           │   │   └── closing_loc: (1,16)-(1,17) = "}"
+            │           │   └── @ StringNode (location: (1,17)-(1,18))
+            │           │       ├── StringFlags: frozen
+            │           │       ├── opening_loc: nil
+            │           │       ├── content_loc: (1,17)-(1,18) = "!"
+            │           │       ├── closing_loc: nil
+            │           │       └── unescaped: "!"
+            │           └── closing_loc: (1,18)-(1,19) = "\""
+            ├── locals: [:name]
+            ├── def_keyword_loc: (0,0)-(0,3) = "def"
+            ├── operator_loc: nil
+            ├── lparen_loc: (0,9)-(0,10) = "("
+            ├── rparen_loc: (0,14)-(0,15) = ")"
+            ├── equal_loc: nil
+            └── end_keyword_loc: (2,0)-(2,3) = "end"

--- a/rust/tests/snapshots/parse_ruby_test__parse_ruby_simple_expression.snap
+++ b/rust/tests/snapshots/parse_ruby_test__parse_ruby_simple_expression.snap
@@ -1,0 +1,29 @@
+---
+source: tests/parse_ruby_test.rs
+expression: result.prettyprint()
+---
+@ ProgramNode (location: (0,0)-(0,5))
+├── locals: []
+└── statements:
+    @ StatementsNode (location: (0,0)-(0,5))
+    └── body: (length: 1)
+        └── @ CallNode (location: (0,0)-(0,5))
+            ├── CallNodeFlags: nil
+            ├── receiver:
+            │   @ IntegerNode (location: (0,0)-(0,1))
+            │   ├── IntegerBaseFlags: decimal
+            │   ├── value: 1
+            ├── call_operator_loc: nil
+            ├── name: :+
+            ├── message_loc: (0,2)-(0,3) = "+"
+            ├── opening_loc: nil
+            ├── arguments:
+            │   @ ArgumentsNode (location: (0,4)-(0,5))
+            │   ├── ArgumentsNodeFlags: nil
+            │   └── arguments: (length: 1)
+            │       └── @ IntegerNode (location: (0,4)-(0,5))
+            │           ├── IntegerBaseFlags: decimal
+            │           └── value: 2
+            ├── closing_loc: nil
+            ├── equal_loc: nil
+            └── block: nil

--- a/sig/herb.rbs
+++ b/sig/herb.rbs
@@ -7,6 +7,9 @@ module Herb
   # : (String path, ?track_whitespace: bool, ?analyze: bool, ?strict: bool, ?arena_stats: bool) -> ParseResult
   def self.parse_file: (String path, ?track_whitespace: bool, ?analyze: bool, ?strict: bool, ?arena_stats: bool) -> ParseResult
 
+  # : (String source) -> Prism::ParseResult
+  def self.parse_ruby: (String source) -> Prism::ParseResult
+
   def self.configuration: (?untyped project_path) -> untyped
 
   def self.configure: (?untyped project_path) -> untyped

--- a/src/herb.c
+++ b/src/herb.c
@@ -10,6 +10,7 @@
 
 #include <prism.h>
 #include <stdlib.h>
+#include <string.h>
 
 HERB_EXPORTED_FUNCTION hb_array_T* herb_lex(const char* source, hb_allocator_T* allocator) {
   if (!source) { source = ""; }
@@ -82,4 +83,27 @@ HERB_EXPORTED_FUNCTION const char* herb_version(void) {
 
 HERB_EXPORTED_FUNCTION const char* herb_prism_version(void) {
   return PRISM_VERSION;
+}
+
+HERB_EXPORTED_FUNCTION herb_ruby_parse_result_T* herb_parse_ruby(const char* source, size_t length) {
+  if (!source) { return NULL; }
+
+  herb_ruby_parse_result_T* result = malloc(sizeof(herb_ruby_parse_result_T));
+  if (!result) { return NULL; }
+
+  memset(&result->options, 0, sizeof(pm_options_t));
+  pm_parser_init(&result->parser, (const uint8_t*) source, length, &result->options);
+  result->root = pm_parse(&result->parser);
+
+  return result;
+}
+
+HERB_EXPORTED_FUNCTION void herb_free_ruby_parse_result(herb_ruby_parse_result_T* result) {
+  if (!result) { return; }
+
+  if (result->root) { pm_node_destroy(&result->parser, result->root); }
+
+  pm_parser_free(&result->parser);
+  pm_options_free(&result->options);
+  free(result);
 }

--- a/src/include/herb.h
+++ b/src/include/herb.h
@@ -9,6 +9,8 @@
 #include "util/hb_array.h"
 #include "util/hb_buffer.h"
 
+#include <prism.h>
+#include <stdbool.h>
 #include <stdint.h>
 
 #ifdef __cplusplus
@@ -26,6 +28,14 @@ HERB_EXPORTED_FUNCTION AST_DOCUMENT_NODE_T* herb_parse(
 HERB_EXPORTED_FUNCTION const char* herb_version(void);
 HERB_EXPORTED_FUNCTION const char* herb_prism_version(void);
 
+typedef struct {
+  pm_parser_t parser;
+  pm_node_t* root;
+  pm_options_t options;
+} herb_ruby_parse_result_T;
+
+HERB_EXPORTED_FUNCTION herb_ruby_parse_result_T* herb_parse_ruby(const char* source, size_t length);
+HERB_EXPORTED_FUNCTION void herb_free_ruby_parse_result(herb_ruby_parse_result_T* result);
 HERB_EXPORTED_FUNCTION void herb_free_tokens(hb_array_T** tokens, hb_allocator_T* allocator);
 
 #ifdef __cplusplus

--- a/templates/rust/src/nodes.rs.erb
+++ b/templates/rust/src/nodes.rs.erb
@@ -3,7 +3,7 @@ use crate::{Location, Token};
 use crate::union_types::*;
 use colored::*;
 
-fn prettify_prism_tree(input: &str) -> String {
+pub(crate) fn prettify_prism_tree(input: &str) -> String {
   let input = input.replace("+-- ", "├── ").replace("|   ", "│   ");
   let lines: Vec<&str> = input.lines().collect();
   let mut result: Vec<String> = lines.iter().map(|l| l.to_string()).collect();

--- a/test/parser/parse_ruby_test.rb
+++ b/test/parser/parse_ruby_test.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+module Parser
+  class ParseRubyTest < Minitest::Spec
+    include SnapshotUtils
+
+    test "parse_ruby simple expression" do
+      assert_parsed_ruby_snapshot("1 + 2")
+    end
+
+    test "parse_ruby class definition" do
+      assert_parsed_ruby_snapshot("class Foo; end")
+    end
+
+    test "parse_ruby method definition" do
+      assert_parsed_ruby_snapshot("def greet(name)\n  \"Hello, \#{name}!\"\nend")
+    end
+
+    test "parse_ruby variable assignment" do
+      assert_parsed_ruby_snapshot("x = 1 + 2")
+    end
+
+    private
+
+    def assert_parsed_ruby_snapshot(source)
+      result = Herb.parse_ruby(source)
+      assert_instance_of ::Prism::ParseResult, result
+      assert_equal 0, result.errors.length
+
+      assert_snapshot_matches(result.value.inspect, source)
+    end
+  end
+end

--- a/test/snapshots/parser/parse_ruby_test/test_0001_parse_ruby_simple_expression_45459934a386946e6f76a32587aac2d3.txt
+++ b/test/snapshots/parser/parse_ruby_test/test_0001_parse_ruby_simple_expression_45459934a386946e6f76a32587aac2d3.txt
@@ -1,0 +1,31 @@
+---
+source: "Parser::ParseRubyTest#test_0001_parse_ruby simple expression"
+input: "1 + 2"
+---
+@ ProgramNode (location: (1,0)-(1,5))
+├── flags: ∅
+├── locals: []
+└── statements:
+    @ StatementsNode (location: (1,0)-(1,5))
+    ├── flags: ∅
+    └── body: (length: 1)
+        └── @ CallNode (location: (1,0)-(1,5))
+            ├── flags: newline
+            ├── receiver:
+            │   @ IntegerNode (location: (1,0)-(1,1))
+            │   ├── flags: static_literal, decimal
+            │   └── value: 1
+            ├── call_operator_loc: ∅
+            ├── name: :+
+            ├── message_loc: (1,2)-(1,3) = "+"
+            ├── opening_loc: ∅
+            ├── arguments:
+            │   @ ArgumentsNode (location: (1,4)-(1,5))
+            │   ├── flags: ∅
+            │   └── arguments: (length: 1)
+            │       └── @ IntegerNode (location: (1,4)-(1,5))
+            │           ├── flags: static_literal, decimal
+            │           └── value: 2
+            ├── closing_loc: ∅
+            ├── equal_loc: ∅
+            └── block: ∅

--- a/test/snapshots/parser/parse_ruby_test/test_0002_parse_ruby_class_definition_82384b5bd5f438b22c983816ce7cb6b7.txt
+++ b/test/snapshots/parser/parse_ruby_test/test_0002_parse_ruby_class_definition_82384b5bd5f438b22c983816ce7cb6b7.txt
@@ -1,0 +1,24 @@
+---
+source: "Parser::ParseRubyTest#test_0002_parse_ruby class definition"
+input: "class Foo; end"
+---
+@ ProgramNode (location: (1,0)-(1,14))
+├── flags: ∅
+├── locals: []
+└── statements:
+    @ StatementsNode (location: (1,0)-(1,14))
+    ├── flags: ∅
+    └── body: (length: 1)
+        └── @ ClassNode (location: (1,0)-(1,14))
+            ├── flags: newline
+            ├── locals: []
+            ├── class_keyword_loc: (1,0)-(1,5) = "class"
+            ├── constant_path:
+            │   @ ConstantReadNode (location: (1,6)-(1,9))
+            │   ├── flags: ∅
+            │   └── name: :Foo
+            ├── inheritance_operator_loc: ∅
+            ├── superclass: ∅
+            ├── body: ∅
+            ├── end_keyword_loc: (1,11)-(1,14) = "end"
+            └── name: :Foo

--- a/test/snapshots/parser/parse_ruby_test/test_0003_parse_ruby_method_definition_463db44fc7d04313b9a4423336b03815.txt
+++ b/test/snapshots/parser/parse_ruby_test/test_0003_parse_ruby_method_definition_463db44fc7d04313b9a4423336b03815.txt
@@ -1,0 +1,72 @@
+---
+source: "Parser::ParseRubyTest#test_0003_parse_ruby method definition"
+input: |2-
+def greet(name)
+  "Hello, #{name}!"
+end
+---
+@ ProgramNode (location: (1,0)-(3,3))
+├── flags: ∅
+├── locals: []
+└── statements:
+    @ StatementsNode (location: (1,0)-(3,3))
+    ├── flags: ∅
+    └── body: (length: 1)
+        └── @ DefNode (location: (1,0)-(3,3))
+            ├── flags: newline
+            ├── name: :greet
+            ├── name_loc: (1,4)-(1,9) = "greet"
+            ├── receiver: ∅
+            ├── parameters:
+            │   @ ParametersNode (location: (1,10)-(1,14))
+            │   ├── flags: ∅
+            │   ├── requireds: (length: 1)
+            │   │   └── @ RequiredParameterNode (location: (1,10)-(1,14))
+            │   │       ├── flags: ∅
+            │   │       └── name: :name
+            │   ├── optionals: (length: 0)
+            │   ├── rest: ∅
+            │   ├── posts: (length: 0)
+            │   ├── keywords: (length: 0)
+            │   ├── keyword_rest: ∅
+            │   └── block: ∅
+            ├── body:
+            │   @ StatementsNode (location: (2,2)-(2,19))
+            │   ├── flags: ∅
+            │   └── body: (length: 1)
+            │       └── @ InterpolatedStringNode (location: (2,2)-(2,19))
+            │           ├── flags: newline
+            │           ├── opening_loc: (2,2)-(2,3) = "\""
+            │           ├── parts: (length: 3)
+            │           │   ├── @ StringNode (location: (2,3)-(2,10))
+            │           │   │   ├── flags: static_literal, frozen
+            │           │   │   ├── opening_loc: ∅
+            │           │   │   ├── content_loc: (2,3)-(2,10) = "Hello, "
+            │           │   │   ├── closing_loc: ∅
+            │           │   │   └── unescaped: "Hello, "
+            │           │   ├── @ EmbeddedStatementsNode (location: (2,10)-(2,17))
+            │           │   │   ├── flags: ∅
+            │           │   │   ├── opening_loc: (2,10)-(2,12) = "\#{"
+            │           │   │   ├── statements:
+            │           │   │   │   @ StatementsNode (location: (2,12)-(2,16))
+            │           │   │   │   ├── flags: ∅
+            │           │   │   │   └── body: (length: 1)
+            │           │   │   │       └── @ LocalVariableReadNode (location: (2,12)-(2,16))
+            │           │   │   │           ├── flags: ∅
+            │           │   │   │           ├── name: :name
+            │           │   │   │           └── depth: 0
+            │           │   │   └── closing_loc: (2,16)-(2,17) = "}"
+            │           │   └── @ StringNode (location: (2,17)-(2,18))
+            │           │       ├── flags: static_literal, frozen
+            │           │       ├── opening_loc: ∅
+            │           │       ├── content_loc: (2,17)-(2,18) = "!"
+            │           │       ├── closing_loc: ∅
+            │           │       └── unescaped: "!"
+            │           └── closing_loc: (2,18)-(2,19) = "\""
+            ├── locals: [:name]
+            ├── def_keyword_loc: (1,0)-(1,3) = "def"
+            ├── operator_loc: ∅
+            ├── lparen_loc: (1,9)-(1,10) = "("
+            ├── rparen_loc: (1,14)-(1,15) = ")"
+            ├── equal_loc: ∅
+            └── end_keyword_loc: (3,0)-(3,3) = "end"

--- a/test/snapshots/parser/parse_ruby_test/test_0004_parse_ruby_variable_assignment_6f141f5f5180a5d7dfe267e0cc564935.txt
+++ b/test/snapshots/parser/parse_ruby_test/test_0004_parse_ruby_variable_assignment_6f141f5f5180a5d7dfe267e0cc564935.txt
@@ -1,0 +1,38 @@
+---
+source: "Parser::ParseRubyTest#test_0004_parse_ruby variable assignment"
+input: "x = 1 + 2"
+---
+@ ProgramNode (location: (1,0)-(1,9))
+├── flags: ∅
+├── locals: [:x]
+└── statements:
+    @ StatementsNode (location: (1,0)-(1,9))
+    ├── flags: ∅
+    └── body: (length: 1)
+        └── @ LocalVariableWriteNode (location: (1,0)-(1,9))
+            ├── flags: newline
+            ├── name: :x
+            ├── depth: 0
+            ├── name_loc: (1,0)-(1,1) = "x"
+            ├── value:
+            │   @ CallNode (location: (1,4)-(1,9))
+            │   ├── flags: ∅
+            │   ├── receiver:
+            │   │   @ IntegerNode (location: (1,4)-(1,5))
+            │   │   ├── flags: static_literal, decimal
+            │   │   └── value: 1
+            │   ├── call_operator_loc: ∅
+            │   ├── name: :+
+            │   ├── message_loc: (1,6)-(1,7) = "+"
+            │   ├── opening_loc: ∅
+            │   ├── arguments:
+            │   │   @ ArgumentsNode (location: (1,8)-(1,9))
+            │   │   ├── flags: ∅
+            │   │   └── arguments: (length: 1)
+            │   │       └── @ IntegerNode (location: (1,8)-(1,9))
+            │   │           ├── flags: static_literal, decimal
+            │   │           └── value: 2
+            │   ├── closing_loc: ∅
+            │   ├── equal_loc: ∅
+            │   └── block: ∅
+            └── operator_loc: (1,2)-(1,3) = "="

--- a/wasm/herb-wasm.cpp
+++ b/wasm/herb-wasm.cpp
@@ -140,6 +140,27 @@ std::string Herb_extract_html(const std::string& source) {
   return result;
 }
 
+val Herb_parse_ruby(const std::string& source) {
+  herb_ruby_parse_result_T* parse_result = herb_parse_ruby(source.c_str(), source.length());
+
+  if (!parse_result) { return val::null(); }
+
+  pm_buffer_t buffer = { 0 };
+  pm_serialize(&parse_result->parser, parse_result->root, &buffer);
+
+  val result = val::null();
+
+  if (buffer.length > 0) {
+    result = val(typed_memory_view(buffer.length, (const uint8_t*) buffer.value));
+    result = val::global("Uint8Array").new_(result);
+  }
+
+  pm_buffer_free(&buffer);
+  herb_free_ruby_parse_result(parse_result);
+
+  return result;
+}
+
 std::string Herb_version() {
   const char* libherb_version = herb_version();
   const char* libprism_version = herb_prism_version();
@@ -154,4 +175,5 @@ EMSCRIPTEN_BINDINGS(herb_module) {
   function("extractRuby", &Herb_extract_ruby);
   function("extractHTML", &Herb_extract_html);
   function("version", &Herb_version);
+  function("parseRuby", &Herb_parse_ruby);
 }


### PR DESCRIPTION
This pull request adds a new `Herb.parse_ruby` API in all language bindings that can be used to parse Ruby with Prism ad-hoc from wherever `Herb` is available too.

This uses the same underlying architecture used in #1350, but allows to get a full Prism ParseResult back without any HTML or ERB involvement.

```
irb(main):001> Herb.parse_ruby("Greeter.salute('Herb')")
=>
#<Prism::ParseResult:0x000000011ced9118
 @comments=[],
 @data_loc=nil,
 @errors=[],
 @magic_comments=[],
 @source=#<Prism::ASCIISource:0x0000000101487720 @offsets=[0], @source="Greeter.salute('Herb')", @start_line=1>,
 @value=
  @ ProgramNode (location: (1,0)-(1,22))
  ├── flags: ∅
  ├── locals: []
  └── statements:
      @ StatementsNode (location: (1,0)-(1,22))
      ├── flags: ∅
      └── body: (length: 1)
          └── @ CallNode (location: (1,0)-(1,22))
              ├── flags: newline
              ├── receiver:
              │   @ ConstantReadNode (location: (1,0)-(1,7))
              │   ├── flags: ∅
              │   └── name: :Greeter
              ├── call_operator_loc: (1,7)-(1,8) = "."
              ├── name: :salute
              ├── message_loc: (1,8)-(1,14) = "salute"
              ├── opening_loc: (1,14)-(1,15) = "("
              ├── arguments:
              │   @ ArgumentsNode (location: (1,15)-(1,21))
              │   ├── flags: ∅
              │   └── arguments: (length: 1)
              │       └── @ StringNode (location: (1,15)-(1,21))
              │           ├── flags: ∅
              │           ├── opening_loc: (1,15)-(1,16) = "'"
              │           ├── content_loc: (1,16)-(1,20) = "Herb"
              │           ├── closing_loc: (1,20)-(1,21) = "'"
              │           └── unescaped: "Herb"
              ├── closing_loc: (1,21)-(1,22) = ")"
              ├── equal_loc: ∅
              └── block: ∅,
 @warnings=[]>
```