### PR TITLE
Language Server: Implement Hover Provider for Action View Helpers

### DIFF
--- a/javascript/packages/language-server/src/action_view_helpers.ts
+++ b/javascript/packages/language-server/src/action_view_helpers.ts
@@ -1,0 +1,23 @@
+export interface ActionViewHelperInfo {
+  signature: string
+  documentationURL: string
+}
+
+export const ACTION_VIEW_HELPERS: Record<string, ActionViewHelperInfo> = {
+  "ActionView::Helpers::TagHelper#tag": {
+    signature: "tag.<tag name>(optional content, options)",
+    documentationURL: "https://api.rubyonrails.org/classes/ActionView/Helpers/TagHelper.html#method-i-tag",
+  },
+  "ActionView::Helpers::TagHelper#content_tag": {
+    signature: "content_tag(name, content_or_options_with_block = nil, options = nil, escape = true, &block)",
+    documentationURL: "https://api.rubyonrails.org/classes/ActionView/Helpers/TagHelper.html#method-i-content_tag",
+  },
+  "ActionView::Helpers::UrlHelper#link_to": {
+    signature: "link_to(name = nil, options = nil, html_options = nil, &block)",
+    documentationURL: "https://api.rubyonrails.org/classes/ActionView/Helpers/UrlHelper.html#method-i-link_to",
+  },
+  "Turbo::FramesHelper#turbo_frame_tag": {
+    signature: "turbo_frame_tag(*ids, src: nil, target: nil, **attributes, &block)",
+    documentationURL: "https://www.rubydoc.info/github/hotwired/turbo-rails/Turbo/FramesHelper:turbo_frame_tag",
+  },
+}

--- a/javascript/packages/language-server/src/document_highlight_service.ts
+++ b/javascript/packages/language-server/src/document_highlight_service.ts
@@ -5,7 +5,7 @@ import { Visitor } from "@herb-tools/core"
 import { ParserService } from "./parser_service"
 
 import { isERBIfNode, isERBElseNode, isHTMLOpenTagNode } from "@herb-tools/core"
-import { erbTagToRange, tokenToRange, nodeToRange, openTagRanges } from "./range_utils"
+import { erbTagToRange, tokenToRange, nodeToRange, openTagRanges, isPositionInRange, rangeSize } from "./range_utils"
 
 import type {
   Node,
@@ -245,10 +245,10 @@ export class DocumentHighlightService {
     let bestSize = Infinity
 
     for (const group of collector.groups) {
-      const matchingRange = group.find(range => this.isPositionInRange(position, range))
+      const matchingRange = group.find(range => isPositionInRange(position, range))
 
       if (matchingRange) {
-        const size = this.rangeSize(matchingRange)
+        const size = rangeSize(matchingRange)
 
         if (size < bestSize) {
           bestSize = size
@@ -264,27 +264,4 @@ export class DocumentHighlightService {
     return []
   }
 
-  private rangeSize(range: Range): number {
-    if (range.start.line === range.end.line) {
-      return range.end.character - range.start.character
-    }
-
-    return (range.end.line - range.start.line) * 10000 + range.end.character
-  }
-
-  private isPositionInRange(position: Position, range: Range): boolean {
-    if (position.line < range.start.line || position.line > range.end.line) {
-      return false
-    }
-
-    if (position.line === range.start.line && position.character < range.start.character) {
-      return false
-    }
-
-    if (position.line === range.end.line && position.character > range.end.character) {
-      return false
-    }
-
-    return true
-  }
 }

--- a/javascript/packages/language-server/src/hover_service.ts
+++ b/javascript/packages/language-server/src/hover_service.ts
@@ -1,0 +1,90 @@
+import { Hover, MarkupKind, Position } from "vscode-languageserver/node"
+import { TextDocument } from "vscode-languageserver-textdocument"
+
+import { Visitor } from "@herb-tools/node-wasm"
+import { IdentityPrinter } from "@herb-tools/printer"
+import { ActionViewTagHelperToHTMLRewriter } from "@herb-tools/rewriter"
+import { isERBOpenTagNode } from "@herb-tools/core"
+import { ParserService } from "./parser_service"
+import { nodeToRange, isPositionInRange, rangeSize } from "./range_utils"
+import { ACTION_VIEW_HELPERS } from "./action_view_helpers"
+
+import type { Node, HTMLElementNode } from "@herb-tools/core"
+import type { Range } from "vscode-languageserver/node"
+
+class ActionViewElementCollector extends Visitor {
+  public elements: { node: HTMLElementNode; range: Range }[] = []
+
+  visitHTMLElementNode(node: HTMLElementNode): void {
+    if (node.element_source && node.element_source !== "HTML" && isERBOpenTagNode(node.open_tag)) {
+      this.elements.push({
+        node,
+        range: nodeToRange(node),
+      })
+    }
+
+    this.visitChildNodes(node)
+  }
+}
+
+export class HoverService {
+  private parserService: ParserService
+
+  constructor(parserService: ParserService) {
+    this.parserService = parserService
+  }
+
+  getHover(textDocument: TextDocument, position: Position): Hover | null {
+    const parseResult = this.parserService.parseContent(textDocument.getText(), {
+      action_view_helpers: true,
+      track_whitespace: true,
+    })
+
+    const collector = new ActionViewElementCollector()
+    collector.visit(parseResult.value)
+
+    let bestElement: { node: HTMLElementNode; range: Range } | null = null
+    let bestSize = Infinity
+
+    for (const element of collector.elements) {
+      if (isPositionInRange(position, element.range)) {
+        const size = rangeSize(element.range)
+
+        if (size < bestSize) {
+          bestSize = size
+          bestElement = element
+        }
+      }
+    }
+
+    if (!bestElement) {
+      return null
+    }
+
+    const elementSource = bestElement.node.element_source
+    const rewriter = new ActionViewTagHelperToHTMLRewriter()
+    const rewrittenNode = rewriter.rewrite(bestElement.node as Node, { baseDir: process.cwd() })
+    const htmlOutput = IdentityPrinter.print(rewrittenNode)
+    const helper = ACTION_VIEW_HELPERS[elementSource]
+    const parts: string[] = []
+
+    if (helper) {
+      parts.push(`\`\`\`ruby\n${helper.signature}\n\`\`\``)
+    }
+
+    parts.push(`**HTML equivalent**\n\`\`\`erb\n${htmlOutput.trim()}\n\`\`\``)
+
+    if (helper) {
+      parts.push(`[${elementSource}](${helper.documentationURL})`)
+    }
+
+    return {
+      contents: {
+        kind: MarkupKind.Markdown,
+        value: parts.join("\n\n"),
+      },
+      range: bestElement.range,
+    }
+  }
+
+}

--- a/javascript/packages/language-server/src/parser_service.ts
+++ b/javascript/packages/language-server/src/parser_service.ts
@@ -2,7 +2,7 @@ import { Diagnostic, DiagnosticSeverity } from "vscode-languageserver/node"
 import { TextDocument } from "vscode-languageserver-textdocument"
 import { Herb, Visitor } from "@herb-tools/node-wasm"
 
-import type { Node, HerbError, DocumentNode, ParseResult } from "@herb-tools/node-wasm"
+import type { Node, HerbError, DocumentNode, ParseResult, ParseOptions } from "@herb-tools/node-wasm"
 
 import { lspRangeFromLocation } from "./range_utils"
 
@@ -52,7 +52,7 @@ export class ParserService {
     }
   }
 
-  parseContent(content: string, options?: { track_whitespace?: boolean }): ParseResult {
+  parseContent(content: string, options?: ParseOptions): ParseResult {
     return Herb.parse(content, options)
   }
 }

--- a/javascript/packages/language-server/src/range_utils.ts
+++ b/javascript/packages/language-server/src/range_utils.ts
@@ -48,6 +48,30 @@ export function openTagRanges(tag: HTMLOpenTagNode): (Range | null)[] {
   return ranges
 }
 
+export function isPositionInRange(position: Position, range: Range): boolean {
+  if (position.line < range.start.line || position.line > range.end.line) {
+    return false
+  }
+
+  if (position.line === range.start.line && position.character < range.start.character) {
+    return false
+  }
+
+  if (position.line === range.end.line && position.character > range.end.character) {
+    return false
+  }
+
+  return true
+}
+
+export function rangeSize(range: Range): number {
+  if (range.start.line === range.end.line) {
+    return range.end.character - range.start.character
+  }
+
+  return (range.end.line - range.start.line) * 10000 + range.end.character
+}
+
 /**
  * Returns a Range that spans the entire document
  */

--- a/javascript/packages/language-server/src/server.ts
+++ b/javascript/packages/language-server/src/server.ts
@@ -14,6 +14,7 @@ import {
   CodeActionKind,
   FoldingRangeParams,
   DocumentHighlightParams,
+  HoverParams,
   TextDocumentIdentifier,
   Range,
 } from "vscode-languageserver/node"
@@ -59,6 +60,7 @@ export class Server {
           },
           foldingRangeProvider: true,
           documentHighlightProvider: true,
+          hoverProvider: true,
         },
       }
 
@@ -169,6 +171,14 @@ export class Server {
       if (!document) return []
 
       return this.service.documentHighlightService.getDocumentHighlights(document, params.position)
+    })
+
+    this.connection.onHover((params: HoverParams) => {
+      const document = this.service.documentService.get(params.textDocument.uri)
+
+      if (!document) return null
+
+      return this.service.hoverService.getHover(document, params.position)
     })
 
     this.connection.onCodeAction((params: CodeActionParams) => {

--- a/javascript/packages/language-server/src/service.ts
+++ b/javascript/packages/language-server/src/service.ts
@@ -14,6 +14,7 @@ import { CodeActionService } from "./code_action_service"
 import { DocumentSaveService } from "./document_save_service"
 import { FoldingRangeService } from "./folding_range_service"
 import { DocumentHighlightService } from "./document_highlight_service"
+import { HoverService } from "./hover_service"
 import { CommentService } from "./comment_service"
 
 import { version } from "../package.json"
@@ -35,6 +36,7 @@ export class Service {
   documentSaveService: DocumentSaveService
   foldingRangeService: FoldingRangeService
   documentHighlightService: DocumentHighlightService
+  hoverService: HoverService
   commentService: CommentService
 
   constructor(connection: Connection, params: InitializeParams) {
@@ -52,6 +54,7 @@ export class Service {
     this.documentSaveService = new DocumentSaveService(this.connection, this.settings, this.autofixService, this.formattingService)
     this.foldingRangeService = new FoldingRangeService(this.parserService)
     this.documentHighlightService = new DocumentHighlightService(this.parserService)
+    this.hoverService = new HoverService(this.parserService)
     this.commentService = new CommentService(this.parserService)
 
     if (params.initializationOptions) {

--- a/javascript/packages/language-server/test/hover_service.test.ts
+++ b/javascript/packages/language-server/test/hover_service.test.ts
@@ -1,0 +1,194 @@
+import dedent from "dedent"
+
+import { describe, it, expect, beforeAll } from "vitest"
+import { Position, MarkupKind } from "vscode-languageserver/node"
+import { TextDocument } from "vscode-languageserver-textdocument"
+
+import { HoverService } from "../src/hover_service"
+import { ParserService } from "../src/parser_service"
+import { Herb } from "@herb-tools/node-wasm"
+
+describe("HoverService", () => {
+  let parserService: ParserService
+  let service: HoverService
+
+  beforeAll(async () => {
+    await Herb.load()
+    parserService = new ParserService()
+    service = new HoverService(parserService)
+  })
+
+  function createDocument(content: string): TextDocument {
+    return TextDocument.create("file:///test.html.erb", "erb", 1, content)
+  }
+
+  function getHover(content: string, line: number, character: number) {
+    const document = createDocument(content)
+    return service.getHover(document, Position.create(line, character))
+  }
+
+  describe("tag.* helpers", () => {
+    it("shows hover for tag.div with block", () => {
+      const content = dedent`
+        <%= tag.div do %>
+          Content
+        <% end %>
+      `
+
+      const hover = getHover(content, 0, 5)
+
+      expect(hover).not.toBeNull()
+      expect(hover!.contents).toHaveProperty("kind", MarkupKind.Markdown)
+
+      const value = (hover!.contents as { value: string }).value
+      expect(value).toContain("```erb")
+      expect(value).toContain("<div>")
+      expect(value).toContain("HTML equivalent")
+    })
+
+    it("shows signature for tag helper", () => {
+      const content = "<%= tag.div do %><% end %>"
+
+      const hover = getHover(content, 0, 5)
+
+      expect(hover).not.toBeNull()
+
+      const value = (hover!.contents as { value: string }).value
+      expect(value).toContain("```ruby")
+      expect(value).toContain("tag.<tag name>(optional content, options)")
+    })
+
+    it("shows documentation link for tag helper", () => {
+      const content = "<%= tag.div do %><% end %>"
+
+      const hover = getHover(content, 0, 5)
+
+      expect(hover).not.toBeNull()
+
+      const value = (hover!.contents as { value: string }).value
+      expect(value).toContain("ActionView::Helpers::TagHelper#tag")
+      expect(value).toContain("https://api.rubyonrails.org/classes/ActionView/Helpers/TagHelper.html#method-i-tag")
+    })
+
+    it("shows hover for tag.div with attributes", () => {
+      const content = '<%= tag.div class: "container" do %><% end %>'
+
+      const hover = getHover(content, 0, 5)
+
+      expect(hover).not.toBeNull()
+
+      const value = (hover!.contents as { value: string }).value
+      expect(value).toContain("<div")
+      expect(value).toContain("container")
+    })
+
+    it("shows hover for tag with content argument", () => {
+      const content = '<%= tag.p "Hello" %>'
+
+      const hover = getHover(content, 0, 5)
+
+      expect(hover).not.toBeNull()
+
+      const value = (hover!.contents as { value: string }).value
+      expect(value).toContain("<p>")
+    })
+  })
+
+  describe("content_tag", () => {
+    it("shows hover for content_tag", () => {
+      const content = '<%= content_tag :div do %><% end %>'
+
+      const hover = getHover(content, 0, 5)
+
+      expect(hover).not.toBeNull()
+
+      const value = (hover!.contents as { value: string }).value
+      expect(value).toContain("<div>")
+    })
+
+    it("shows signature for content_tag", () => {
+      const content = '<%= content_tag :div do %><% end %>'
+
+      const hover = getHover(content, 0, 5)
+
+      expect(hover).not.toBeNull()
+
+      const value = (hover!.contents as { value: string }).value
+      expect(value).toContain("content_tag(")
+    })
+
+    it("shows documentation link for content_tag", () => {
+      const content = '<%= content_tag :div do %><% end %>'
+
+      const hover = getHover(content, 0, 5)
+
+      expect(hover).not.toBeNull()
+
+      const value = (hover!.contents as { value: string }).value
+      expect(value).toContain("ActionView::Helpers::TagHelper#content_tag")
+      expect(value).toContain("https://api.rubyonrails.org/classes/ActionView/Helpers/TagHelper.html#method-i-content_tag")
+    })
+  })
+
+  describe("link_to", () => {
+    it("shows hover for link_to", () => {
+      const content = '<%= link_to "Home", root_path %>'
+
+      const hover = getHover(content, 0, 5)
+
+      expect(hover).not.toBeNull()
+
+      const value = (hover!.contents as { value: string }).value
+      expect(value).toContain("<a")
+    })
+
+    it("shows signature for link_to", () => {
+      const content = '<%= link_to "Home", root_path %>'
+
+      const hover = getHover(content, 0, 5)
+
+      expect(hover).not.toBeNull()
+
+      const value = (hover!.contents as { value: string }).value
+      expect(value).toContain("link_to(")
+    })
+
+    it("shows documentation link for link_to", () => {
+      const content = '<%= link_to "Home", root_path %>'
+
+      const hover = getHover(content, 0, 5)
+
+      expect(hover).not.toBeNull()
+
+      const value = (hover!.contents as { value: string }).value
+      expect(value).toContain("ActionView::Helpers::UrlHelper#link_to")
+      expect(value).toContain("https://api.rubyonrails.org/classes/ActionView/Helpers/UrlHelper.html#method-i-link_to")
+    })
+  })
+
+  describe("non-ActionView elements", () => {
+    it("returns null for plain HTML elements", () => {
+      const content = "<div>hello</div>"
+
+      const hover = getHover(content, 0, 2)
+
+      expect(hover).toBeNull()
+    })
+
+    it("returns null for plain text", () => {
+      const content = "just some text"
+
+      const hover = getHover(content, 0, 5)
+
+      expect(hover).toBeNull()
+    })
+
+    it("returns null for regular ERB expressions", () => {
+      const content = "<%= some_method %>"
+
+      const hover = getHover(content, 0, 5)
+
+      expect(hover).toBeNull()
+    })
+  })
+})

--- a/javascript/packages/rewriter/src/built-ins/action-view-tag-helper-to-html.ts
+++ b/javascript/packages/rewriter/src/built-ins/action-view-tag-helper-to-html.ts
@@ -116,6 +116,7 @@ class ActionViewTagHelperToHTMLVisitor extends Visitor {
             tag_closing: createSyntheticToken("%>"),
             parsed: false,
             valid: true,
+            prism_node: null
           })
         }
 

--- a/javascript/packages/rewriter/src/built-ins/html-to-action-view-tag-helper.ts
+++ b/javascript/packages/rewriter/src/built-ins/html-to-action-view-tag-helper.ts
@@ -5,7 +5,7 @@ import { ASTRewriter } from "../ast-rewriter.js"
 import { asMutable } from "../mutable.js"
 
 import type { RewriteContext } from "../context.js"
-import type { Node, HTMLCloseTagNode, HTMLAttributeValueNode } from "@herb-tools/core"
+import type { Node, HTMLAttributeValueNode } from "@herb-tools/core"
 
 function serializeAttributeValue(value: HTMLAttributeValueNode): string {
   const hasERB = value.children.some(child => isERBContentNode(child))

--- a/src/analyze/action_view/tag.c
+++ b/src/analyze/action_view/tag.c
@@ -23,7 +23,13 @@ char* extract_tag_dot_name(pm_call_node_t* call_node, pm_parser_t* parser, hb_al
   pm_constant_t* constant = pm_constant_pool_id_to_constant(&parser->constant_pool, call_node->name);
   if (!constant) { return NULL; }
 
-  return hb_allocator_strndup(allocator, (const char*) constant->start, constant->length);
+  char* name = hb_allocator_strndup(allocator, (const char*) constant->start, constant->length);
+
+  for (size_t i = 0; i < constant->length && name[i] != '\0'; i++) {
+    if (name[i] == '_') { name[i] = '-'; }
+  }
+
+  return name;
 }
 
 // TODO: this should probably be an array of nodes

--- a/src/analyze/action_view/turbo_frame_tag.c
+++ b/src/analyze/action_view/turbo_frame_tag.c
@@ -28,8 +28,6 @@ char* extract_turbo_frame_tag_content(pm_call_node_t* call_node, pm_parser_t* pa
 }
 
 char* extract_turbo_frame_tag_id(pm_call_node_t* call_node, pm_parser_t* parser, hb_allocator_T* allocator) {
-  (void) parser;
-
   if (!call_node || !call_node->arguments) { return NULL; }
 
   pm_arguments_node_t* arguments = call_node->arguments;
@@ -50,7 +48,31 @@ char* extract_turbo_frame_tag_id(pm_call_node_t* call_node, pm_parser_t* parser,
   }
 
   size_t source_length = first_argument->location.end - first_argument->location.start;
-  return hb_allocator_strndup(allocator, (const char*) first_argument->location.start, source_length);
+  const char* source = (const char*) first_argument->location.start;
+
+  if (first_argument->type == PM_CALL_NODE) {
+    pm_call_node_t* call = (pm_call_node_t*) first_argument;
+    pm_constant_t* call_constant = pm_constant_pool_id_to_constant(&parser->constant_pool, call->name);
+
+    if (call_constant && call_constant->length == 6 && strncmp((const char*) call_constant->start, "dom_id", 6) == 0) {
+      return hb_allocator_strndup(allocator, source, source_length);
+    }
+  }
+
+  const char* prefix = "dom_id(";
+  const char* suffix = ")";
+
+  size_t prefix_length = strlen(prefix);
+  size_t suffix_length = strlen(suffix);
+  size_t total_length = prefix_length + source_length + suffix_length;
+  char* result = hb_allocator_alloc(allocator, total_length + 1);
+
+  memcpy(result, prefix, prefix_length);
+  memcpy(result + prefix_length, source, source_length);
+  memcpy(result + prefix_length + source_length, suffix, suffix_length);
+  result[total_length] = '\0';
+
+  return result;
 }
 
 bool turbo_frame_tag_supports_block(void) {

--- a/test/analyze/action_view/tag_helper/tag_test.rb
+++ b/test/analyze/action_view/tag_helper/tag_test.rb
@@ -129,5 +129,27 @@ module Analyze::ActionView::TagHelper
         <% end %>
       HTML
     end
+
+    test "tag.turbo_frame converts underscore to dash" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <%= tag.turbo_frame id: "tray" do %>
+          Content
+        <% end %>
+      HTML
+    end
+
+    test "tag.trix_editor converts underscore to dash" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <%= tag.trix_editor input: "content", class: "editor" %>
+      HTML
+    end
+
+    test "tag.my_custom_element converts underscores to dashes" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <%= tag.my_custom_element data: { controller: "example" } do %>
+          Content
+        <% end %>
+      HTML
+    end
   end
 end

--- a/test/analyze/action_view/tag_helper/turbo_frame_tag_test.rb
+++ b/test/analyze/action_view/tag_helper/turbo_frame_tag_test.rb
@@ -75,5 +75,19 @@ module Analyze::ActionView::TagHelper
         <% end %>
       HTML
     end
+
+    test "turbo_frame_tag with model wraps in dom_id" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <%= turbo_frame_tag post do %>
+          Content
+        <% end %>
+      HTML
+    end
+
+    test "turbo_frame_tag with instance variable wraps in dom_id" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <%= turbo_frame_tag @post %>
+      HTML
+    end
   end
 end

--- a/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0018_tag.turbo_frame_converts_underscore_to_dash_ff0891824227631e8d26140108af707e-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0018_tag.turbo_frame_converts_underscore_to_dash_ff0891824227631e8d26140108af707e-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,55 @@
+---
+source: "Analyze::ActionView::TagHelper::TagTest#test_0018_tag.turbo_frame converts underscore to dash"
+input: |2-
+<%= tag.turbo_frame id: "tray" do %>
+  Content
+<% end %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(4:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(3:9))
+    │   ├── open_tag:
+    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:36))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " tag.turbo_frame id: "tray" do " (location: (1:3)-(1:34))
+    │   │       ├── tag_closing: "%>" (location: (1:34)-(1:36))
+    │   │       ├── tag_name: "turbo-frame" (location: (1:8)-(1:19))
+    │   │       └── children: (1 item)
+    │   │           └── @ HTMLAttributeNode (location: (1:20)-(1:24))
+    │   │               ├── name:
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:20)-(1:24))
+    │   │               │       └── children: (1 item)
+    │   │               │           └── @ LiteralNode (location: (1:20)-(1:24))
+    │   │               │               └── content: "id"
+    │   │               │
+    │   │               │
+    │   │               ├── equals: "=" (location: (1:20)-(1:24))
+    │   │               └── value:
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:20)-(1:24))
+    │   │                       ├── open_quote: """ (location: (1:20)-(1:24))
+    │   │                       ├── children: (1 item)
+    │   │                       │   └── @ LiteralNode (location: (1:20)-(1:24))
+    │   │                       │       └── content: "tray"
+    │   │                       │
+    │   │                       ├── close_quote: """ (location: (1:24)-(1:24))
+    │   │                       └── quoted: true
+    │   │
+    │   │
+    │   │
+    │   ├── tag_name: "turbo-frame" (location: (1:8)-(1:19))
+    │   ├── body: (1 item)
+    │   │   └── @ HTMLTextNode (location: (1:36)-(3:0))
+    │   │       └── content: "\n  Content\n"
+    │   │
+    │   ├── close_tag:
+    │   │   └── @ ERBEndNode (location: (3:0)-(3:9))
+    │   │       ├── tag_opening: "<%" (location: (3:0)-(3:2))
+    │   │       ├── content: " end " (location: (3:2)-(3:7))
+    │   │       └── tag_closing: "%>" (location: (3:7)-(3:9))
+    │   │
+    │   ├── is_void: false
+    │   └── element_source: "ActionView::Helpers::TagHelper#tag"
+    │
+    └── @ HTMLTextNode (location: (3:9)-(4:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0019_tag.trix_editor_converts_underscore_to_dash_ee7beda70b44ad82d9ffc027bff372bc-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0019_tag.trix_editor_converts_underscore_to_dash_ee7beda70b44ad82d9ffc027bff372bc-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,68 @@
+---
+source: "Analyze::ActionView::TagHelper::TagTest#test_0019_tag.trix_editor converts underscore to dash"
+input: |2-
+<%= tag.trix_editor input: "content", class: "editor" %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:56))
+    │   ├── open_tag:
+    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:56))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " tag.trix_editor input: "content", class: "editor" " (location: (1:3)-(1:54))
+    │   │       ├── tag_closing: "%>" (location: (1:54)-(1:56))
+    │   │       ├── tag_name: "trix-editor" (location: (1:8)-(1:19))
+    │   │       └── children: (2 items)
+    │   │           ├── @ HTMLAttributeNode (location: (1:20)-(1:27))
+    │   │           │   ├── name:
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:20)-(1:27))
+    │   │           │   │       └── children: (1 item)
+    │   │           │   │           └── @ LiteralNode (location: (1:20)-(1:27))
+    │   │           │   │               └── content: "input"
+    │   │           │   │
+    │   │           │   │
+    │   │           │   ├── equals: "=" (location: (1:20)-(1:27))
+    │   │           │   └── value:
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:20)-(1:27))
+    │   │           │           ├── open_quote: """ (location: (1:20)-(1:27))
+    │   │           │           ├── children: (1 item)
+    │   │           │           │   └── @ LiteralNode (location: (1:20)-(1:27))
+    │   │           │           │       └── content: "content"
+    │   │           │           │
+    │   │           │           ├── close_quote: """ (location: (1:27)-(1:27))
+    │   │           │           └── quoted: true
+    │   │           │
+    │   │           │
+    │   │           └── @ HTMLAttributeNode (location: (1:38)-(1:45))
+    │   │               ├── name:
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:38)-(1:45))
+    │   │               │       └── children: (1 item)
+    │   │               │           └── @ LiteralNode (location: (1:38)-(1:45))
+    │   │               │               └── content: "class"
+    │   │               │
+    │   │               │
+    │   │               ├── equals: "=" (location: (1:38)-(1:45))
+    │   │               └── value:
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:38)-(1:45))
+    │   │                       ├── open_quote: """ (location: (1:38)-(1:45))
+    │   │                       ├── children: (1 item)
+    │   │                       │   └── @ LiteralNode (location: (1:38)-(1:45))
+    │   │                       │       └── content: "editor"
+    │   │                       │
+    │   │                       ├── close_quote: """ (location: (1:45)-(1:45))
+    │   │                       └── quoted: true
+    │   │
+    │   │
+    │   │
+    │   ├── tag_name: "trix-editor" (location: (1:8)-(1:19))
+    │   ├── body: []
+    │   ├── close_tag:
+    │   │   └── @ HTMLVirtualCloseTagNode (location: (1:56)-(1:56))
+    │   │       └── tag_name: "trix-editor" (location: (1:8)-(1:19))
+    │   │
+    │   ├── is_void: false
+    │   └── element_source: "ActionView::Helpers::TagHelper#tag"
+    │
+    └── @ HTMLTextNode (location: (1:56)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0020_tag.my_custom_element_converts_underscores_to_dashes_19e316f2d691c14d52a56a1ebb53d623-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0020_tag.my_custom_element_converts_underscores_to_dashes_19e316f2d691c14d52a56a1ebb53d623-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,55 @@
+---
+source: "Analyze::ActionView::TagHelper::TagTest#test_0020_tag.my_custom_element converts underscores to dashes"
+input: |2-
+<%= tag.my_custom_element data: { controller: "example" } do %>
+  Content
+<% end %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(4:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(3:9))
+    │   ├── open_tag:
+    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:63))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " tag.my_custom_element data: { controller: "example" } do " (location: (1:3)-(1:61))
+    │   │       ├── tag_closing: "%>" (location: (1:61)-(1:63))
+    │   │       ├── tag_name: "my-custom-element" (location: (1:8)-(1:25))
+    │   │       └── children: (1 item)
+    │   │           └── @ HTMLAttributeNode (location: (1:34)-(1:46))
+    │   │               ├── name:
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:34)-(1:46))
+    │   │               │       └── children: (1 item)
+    │   │               │           └── @ LiteralNode (location: (1:34)-(1:46))
+    │   │               │               └── content: "data-controller"
+    │   │               │
+    │   │               │
+    │   │               ├── equals: "=" (location: (1:34)-(1:46))
+    │   │               └── value:
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:34)-(1:46))
+    │   │                       ├── open_quote: """ (location: (1:34)-(1:46))
+    │   │                       ├── children: (1 item)
+    │   │                       │   └── @ LiteralNode (location: (1:34)-(1:46))
+    │   │                       │       └── content: "example"
+    │   │                       │
+    │   │                       ├── close_quote: """ (location: (1:46)-(1:46))
+    │   │                       └── quoted: true
+    │   │
+    │   │
+    │   │
+    │   ├── tag_name: "my-custom-element" (location: (1:8)-(1:25))
+    │   ├── body: (1 item)
+    │   │   └── @ HTMLTextNode (location: (1:63)-(3:0))
+    │   │       └── content: "\n  Content\n"
+    │   │
+    │   ├── close_tag:
+    │   │   └── @ ERBEndNode (location: (3:0)-(3:9))
+    │   │       ├── tag_opening: "<%" (location: (3:0)-(3:2))
+    │   │       ├── content: " end " (location: (3:2)-(3:7))
+    │   │       └── tag_closing: "%>" (location: (3:7)-(3:9))
+    │   │
+    │   ├── is_void: false
+    │   └── element_source: "ActionView::Helpers::TagHelper#tag"
+    │
+    └── @ HTMLTextNode (location: (3:9)-(4:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/action_view/tag_helper/turbo_frame_tag_test/test_0011_turbo_frame_tag_with_model_wraps_in_dom_id_6668f957e9b3270e6903c501660fc9af-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/turbo_frame_tag_test/test_0011_turbo_frame_tag_with_model_wraps_in_dom_id_6668f957e9b3270e6903c501660fc9af-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,55 @@
+---
+source: "Analyze::ActionView::TagHelper::TurboFrameTagTest#test_0011_turbo_frame_tag with model wraps in dom_id"
+input: |2-
+<%= turbo_frame_tag post do %>
+  Content
+<% end %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(4:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(3:9))
+    │   ├── open_tag:
+    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:30))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " turbo_frame_tag post do " (location: (1:3)-(1:28))
+    │   │       ├── tag_closing: "%>" (location: (1:28)-(1:30))
+    │   │       ├── tag_name: "turbo-frame" (location: (1:4)-(1:19))
+    │   │       └── children: (1 item)
+    │   │           └── @ HTMLAttributeNode (location: (1:20)-(1:24))
+    │   │               ├── name:
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:20)-(1:24))
+    │   │               │       └── children: (1 item)
+    │   │               │           └── @ LiteralNode (location: (1:20)-(1:24))
+    │   │               │               └── content: "id"
+    │   │               │
+    │   │               │
+    │   │               ├── equals: ":" (location: (1:20)-(1:24))
+    │   │               └── value:
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:20)-(1:24))
+    │   │                       ├── open_quote: ∅
+    │   │                       ├── children: (1 item)
+    │   │                       │   └── @ RubyLiteralNode (location: (1:20)-(1:24))
+    │   │                       │       └── content: "dom_id(post)"
+    │   │                       │
+    │   │                       ├── close_quote: ∅
+    │   │                       └── quoted: false
+    │   │
+    │   │
+    │   │
+    │   ├── tag_name: "turbo-frame" (location: (1:4)-(1:19))
+    │   ├── body: (1 item)
+    │   │   └── @ HTMLTextNode (location: (1:30)-(3:0))
+    │   │       └── content: "\n  Content\n"
+    │   │
+    │   ├── close_tag:
+    │   │   └── @ ERBEndNode (location: (3:0)-(3:9))
+    │   │       ├── tag_opening: "<%" (location: (3:0)-(3:2))
+    │   │       ├── content: " end " (location: (3:2)-(3:7))
+    │   │       └── tag_closing: "%>" (location: (3:7)-(3:9))
+    │   │
+    │   ├── is_void: false
+    │   └── element_source: "Turbo::FramesHelper#turbo_frame_tag"
+    │
+    └── @ HTMLTextNode (location: (3:9)-(4:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/action_view/tag_helper/turbo_frame_tag_test/test_0012_turbo_frame_tag_with_instance_variable_wraps_in_dom_id_8c2535a5f80133daa8817d2bdfcdd4c8-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/turbo_frame_tag_test/test_0012_turbo_frame_tag_with_instance_variable_wraps_in_dom_id_8c2535a5f80133daa8817d2bdfcdd4c8-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,48 @@
+---
+source: "Analyze::ActionView::TagHelper::TurboFrameTagTest#test_0012_turbo_frame_tag with instance variable wraps in dom_id"
+input: |2-
+<%= turbo_frame_tag @post %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:28))
+    │   ├── open_tag:
+    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:28))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " turbo_frame_tag @post " (location: (1:3)-(1:26))
+    │   │       ├── tag_closing: "%>" (location: (1:26)-(1:28))
+    │   │       ├── tag_name: "turbo-frame" (location: (1:4)-(1:19))
+    │   │       └── children: (1 item)
+    │   │           └── @ HTMLAttributeNode (location: (1:20)-(1:25))
+    │   │               ├── name:
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:20)-(1:25))
+    │   │               │       └── children: (1 item)
+    │   │               │           └── @ LiteralNode (location: (1:20)-(1:25))
+    │   │               │               └── content: "id"
+    │   │               │
+    │   │               │
+    │   │               ├── equals: ":" (location: (1:20)-(1:25))
+    │   │               └── value:
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:20)-(1:25))
+    │   │                       ├── open_quote: ∅
+    │   │                       ├── children: (1 item)
+    │   │                       │   └── @ RubyLiteralNode (location: (1:20)-(1:25))
+    │   │                       │       └── content: "dom_id(@post)"
+    │   │                       │
+    │   │                       ├── close_quote: ∅
+    │   │                       └── quoted: false
+    │   │
+    │   │
+    │   │
+    │   ├── tag_name: "turbo-frame" (location: (1:4)-(1:19))
+    │   ├── body: []
+    │   ├── close_tag:
+    │   │   └── @ HTMLVirtualCloseTagNode (location: (1:28)-(1:28))
+    │   │       └── tag_name: "turbo-frame" (location: (1:4)-(1:19))
+    │   │
+    │   ├── is_void: false
+    │   └── element_source: "Turbo::FramesHelper#turbo_frame_tag"
+    │
+    └── @ HTMLTextNode (location: (1:28)-(2:0))
+        └── content: "\n"


### PR DESCRIPTION
This pull request implements a hover provider for Action View Tag Helpers to show what they evaluate to. It uses the foundation introduced in #1347 and uses the rewriters introduced in #1348 to show the "HTML equivalent" in the hover box.

https://github.com/user-attachments/assets/1878a044-716c-4aab-b019-f13ad056cd32

Related #1282 
