### PR TITLE
Linter: Implement `actionview-no-silent-helper` rule

### DIFF
--- a/javascript/packages/linter/docs/rules/README.md
+++ b/javascript/packages/linter/docs/rules/README.md
@@ -4,6 +4,7 @@ This page contains documentation for all Herb Linter rules.
 
 ## Available Rules
 
+- [`actionview-no-silent-helper`](./actionview-no-silent-helper.md) - Disallow silent ERB tags for Action View helpers
 - [`erb-comment-syntax`](./erb-comment-syntax.md) - Disallow Ruby comments immediately after ERB tags
 - [`erb-no-case-node-children`](./erb-no-case-node-children.md) - Don't use `children` for `case/when` and `case/in` nodes
 - [`erb-no-conditional-html-element`](./erb-no-conditional-html-element.md) - Disallow conditional HTML elements

--- a/javascript/packages/linter/docs/rules/actionview-no-silent-helper.md
+++ b/javascript/packages/linter/docs/rules/actionview-no-silent-helper.md
@@ -1,0 +1,57 @@
+# Linter Rule: Disallow silent ERB tags for Action View helpers
+
+**Rule:** `actionview-no-silent-helper`
+
+## Description
+
+Action View helpers like `link_to`, `form_with`, and `content_tag` must use output ERB tags (`<%= %>`) so their rendered HTML is included in the page. Using silent ERB tags (`<% %>`) discards the helper's output entirely.
+
+## Rationale
+
+Action View helpers generate HTML that needs to be rendered into the template. When a helper is called with a silent ERB tag (`<% %>`), the return value is evaluated but silently discarded, meaning the generated HTML never appears in the output. This is almost always a mistake and can lead to confusing bugs where elements are missing from the page with no obvious cause. Using `<%= %>` ensures the helper's output is properly rendered.
+
+## Examples
+
+### ✅ Good
+
+```erb
+<%= link_to "Home", root_path %>
+```
+
+```erb
+<%= form_with model: @user do |f| %>
+  <%= f.text_field :name %>
+<% end %>
+```
+
+```erb
+<%= button_to "Delete", user_path(@user), method: :delete %>
+```
+
+```erb
+<%= content_tag :div, "Hello", class: "greeting" %>
+```
+
+### 🚫 Bad
+
+```erb
+<% link_to "Home", root_path %>
+```
+
+```erb
+<% form_with model: @user do |f| %>
+  <%= f.text_field :name %>
+<% end %>
+```
+
+```erb
+<% button_to "Delete", user_path(@user), method: :delete %>
+```
+
+```erb
+<% content_tag :div, "Hello", class: "greeting" %>
+```
+
+## References
+
+* [Rails Action View Helpers documentation](https://api.rubyonrails.org/classes/ActionView/Helpers.html)

--- a/javascript/packages/linter/src/rules.ts
+++ b/javascript/packages/linter/src/rules.ts
@@ -1,41 +1,43 @@
 import type { RuleClass } from "./types.js"
 
+import { ActionViewNoSilentHelperRule } from "./rules/actionview-no-silent-helper.js"
+
 import { ERBCommentSyntax } from "./rules/erb-comment-syntax.js";
 import { ERBNoCaseNodeChildrenRule } from "./rules/erb-no-case-node-children.js"
-import { ERBNoInlineCaseConditionsRule } from "./rules/erb-no-inline-case-conditions.js"
 import { ERBNoConditionalHTMLElementRule } from "./rules/erb-no-conditional-html-element.js"
-import { ERBNoDuplicateBranchElementsRule } from "./rules/erb-no-duplicate-branch-elements.js"
 import { ERBNoConditionalOpenTagRule } from "./rules/erb-no-conditional-open-tag.js"
+import { ERBNoDuplicateBranchElementsRule } from "./rules/erb-no-duplicate-branch-elements.js"
 import { ERBNoEmptyTagsRule } from "./rules/erb-no-empty-tags.js"
-import { ERBNoInterpolatedClassNamesRule } from "./rules/erb-no-interpolated-class-names.js"
 import { ERBNoExtraNewLineRule } from "./rules/erb-no-extra-newline.js"
 import { ERBNoExtraWhitespaceRule } from "./rules/erb-no-extra-whitespace-inside-tags.js"
-import { ERBNoOutputControlFlowRule } from "./rules/erb-no-output-control-flow.js"
-import { ERBNoThenInControlFlowRule } from "./rules/erb-no-then-in-control-flow.js"
-import { ERBNoSilentTagInAttributeNameRule } from "./rules/erb-no-silent-tag-in-attribute-name.js"
-import { ERBNoTrailingWhitespaceRule } from "./rules/erb-no-trailing-whitespace.js"
-import { ERBPreferImageTagHelperRule } from "./rules/erb-prefer-image-tag-helper.js"
-import { ERBRequireTrailingNewlineRule } from "./rules/erb-require-trailing-newline.js"
-import { ERBRequireWhitespaceRule } from "./rules/erb-require-whitespace-inside-tags.js"
+import { ERBNoInlineCaseConditionsRule } from "./rules/erb-no-inline-case-conditions.js"
+import { ERBNoInstanceVariablesInPartialsRule } from "./rules/erb-no-instance-variables-in-partials.js"
+import { ERBNoInterpolatedClassNamesRule } from "./rules/erb-no-interpolated-class-names.js"
 import { ERBNoJavascriptTagHelperRule } from "./rules/erb-no-javascript-tag-helper.js"
+import { ERBNoOutputControlFlowRule } from "./rules/erb-no-output-control-flow.js"
+import { ERBNoOutputInAttributeNameRule } from "./rules/erb-no-output-in-attribute-name.js"
+import { ERBNoOutputInAttributePositionRule } from "./rules/erb-no-output-in-attribute-position.js"
 import { ERBNoRawOutputInAttributeValueRule } from "./rules/erb-no-raw-output-in-attribute-value.js"
+import { ERBNoSilentTagInAttributeNameRule } from "./rules/erb-no-silent-tag-in-attribute-name.js"
 import { ERBNoStatementInScriptRule } from "./rules/erb-no-statement-in-script.js"
+import { ERBNoThenInControlFlowRule } from "./rules/erb-no-then-in-control-flow.js"
+import { ERBNoTrailingWhitespaceRule } from "./rules/erb-no-trailing-whitespace.js"
 import { ERBNoUnsafeJSAttributeRule } from "./rules/erb-no-unsafe-js-attribute.js"
 import { ERBNoUnsafeRawRule } from "./rules/erb-no-unsafe-raw.js"
 import { ERBNoUnsafeScriptInterpolationRule } from "./rules/erb-no-unsafe-script-interpolation.js"
+import { ERBPreferImageTagHelperRule } from "./rules/erb-prefer-image-tag-helper.js"
+import { ERBRequireTrailingNewlineRule } from "./rules/erb-require-trailing-newline.js"
+import { ERBRequireWhitespaceRule } from "./rules/erb-require-whitespace-inside-tags.js"
 import { ERBRightTrimRule } from "./rules/erb-right-trim.js"
-import { ERBNoOutputInAttributePositionRule } from "./rules/erb-no-output-in-attribute-position.js"
-import { ERBNoOutputInAttributeNameRule } from "./rules/erb-no-output-in-attribute-name.js"
 import { ERBStrictLocalsCommentSyntaxRule } from "./rules/erb-strict-locals-comment-syntax.js"
-import { ERBNoInstanceVariablesInPartialsRule } from "./rules/erb-no-instance-variables-in-partials.js"
 import { ERBStrictLocalsRequiredRule } from "./rules/erb-strict-locals-required.js"
 
-import { HerbDisableCommentValidRuleNameRule } from "./rules/herb-disable-comment-valid-rule-name.js"
-import { HerbDisableCommentNoRedundantAllRule } from "./rules/herb-disable-comment-no-redundant-all.js"
-import { HerbDisableCommentNoDuplicateRulesRule } from "./rules/herb-disable-comment-no-duplicate-rules.js"
-import { HerbDisableCommentMissingRulesRule } from "./rules/herb-disable-comment-missing-rules.js"
 import { HerbDisableCommentMalformedRule } from "./rules/herb-disable-comment-malformed.js"
+import { HerbDisableCommentMissingRulesRule } from "./rules/herb-disable-comment-missing-rules.js"
+import { HerbDisableCommentNoDuplicateRulesRule } from "./rules/herb-disable-comment-no-duplicate-rules.js"
+import { HerbDisableCommentNoRedundantAllRule } from "./rules/herb-disable-comment-no-redundant-all.js"
 import { HerbDisableCommentUnnecessaryRule } from "./rules/herb-disable-comment-unnecessary.js"
+import { HerbDisableCommentValidRuleNameRule } from "./rules/herb-disable-comment-valid-rule-name.js"
 
 import { HTMLAllowedScriptTypeRule } from "./rules/html-allowed-script-type.js"
 import { HTMLAnchorRequireHrefRule } from "./rules/html-anchor-require-href.js"
@@ -72,49 +74,52 @@ import { HTMLNoTitleAttributeRule } from "./rules/html-no-title-attribute.js"
 import { HTMLNoUnderscoresInAttributeNamesRule } from "./rules/html-no-underscores-in-attribute-names.js"
 import { HTMLRequireClosingTagsRule } from "./rules/html-require-closing-tags.js"
 import { HTMLTagNameLowercaseRule } from "./rules/html-tag-name-lowercase.js"
-import { TurboPermanentRequireIdRule } from "./rules/turbo-permanent-require-id.js"
-
-import { SVGTagNameCapitalizationRule } from "./rules/svg-tag-name-capitalization.js"
 
 import { ParserNoErrorsRule } from "./rules/parser-no-errors.js"
 
+import { SVGTagNameCapitalizationRule } from "./rules/svg-tag-name-capitalization.js"
+
+import { TurboPermanentRequireIdRule } from "./rules/turbo-permanent-require-id.js"
+
 export const rules: RuleClass[] = [
+  ActionViewNoSilentHelperRule,
+
   ERBCommentSyntax,
   ERBNoCaseNodeChildrenRule,
-  ERBNoInlineCaseConditionsRule,
   ERBNoConditionalHTMLElementRule,
-  ERBNoDuplicateBranchElementsRule,
   ERBNoConditionalOpenTagRule,
+  ERBNoDuplicateBranchElementsRule,
   ERBNoEmptyTagsRule,
-  ERBNoInterpolatedClassNamesRule,
   ERBNoExtraNewLineRule,
   ERBNoExtraWhitespaceRule,
-  ERBNoOutputControlFlowRule,
-  ERBNoThenInControlFlowRule,
-  ERBNoSilentTagInAttributeNameRule,
-  ERBNoTrailingWhitespaceRule,
-  ERBPreferImageTagHelperRule,
-  ERBRequireTrailingNewlineRule,
-  ERBRequireWhitespaceRule,
+  ERBNoInlineCaseConditionsRule,
+  ERBNoInstanceVariablesInPartialsRule,
+  ERBNoInterpolatedClassNamesRule,
   ERBNoJavascriptTagHelperRule,
+  ERBNoOutputControlFlowRule,
+  ERBNoOutputInAttributeNameRule,
+  ERBNoOutputInAttributePositionRule,
   ERBNoRawOutputInAttributeValueRule,
+  ERBNoSilentTagInAttributeNameRule,
   ERBNoStatementInScriptRule,
+  ERBNoThenInControlFlowRule,
+  ERBNoTrailingWhitespaceRule,
   ERBNoUnsafeJSAttributeRule,
   ERBNoUnsafeRawRule,
   ERBNoUnsafeScriptInterpolationRule,
+  ERBPreferImageTagHelperRule,
+  ERBRequireTrailingNewlineRule,
+  ERBRequireWhitespaceRule,
   ERBRightTrimRule,
-  ERBNoOutputInAttributePositionRule,
-  ERBNoOutputInAttributeNameRule,
-  ERBNoInstanceVariablesInPartialsRule,
   ERBStrictLocalsCommentSyntaxRule,
   ERBStrictLocalsRequiredRule,
 
-  HerbDisableCommentValidRuleNameRule,
-  HerbDisableCommentNoRedundantAllRule,
-  HerbDisableCommentNoDuplicateRulesRule,
-  HerbDisableCommentMissingRulesRule,
   HerbDisableCommentMalformedRule,
+  HerbDisableCommentMissingRulesRule,
+  HerbDisableCommentNoDuplicateRulesRule,
+  HerbDisableCommentNoRedundantAllRule,
   HerbDisableCommentUnnecessaryRule,
+  HerbDisableCommentValidRuleNameRule,
 
   HTMLAllowedScriptTypeRule,
   HTMLAnchorRequireHrefRule,
@@ -151,9 +156,10 @@ export const rules: RuleClass[] = [
   HTMLNoUnderscoresInAttributeNamesRule,
   HTMLRequireClosingTagsRule,
   HTMLTagNameLowercaseRule,
-  TurboPermanentRequireIdRule,
+
+  ParserNoErrorsRule,
 
   SVGTagNameCapitalizationRule,
 
-  ParserNoErrorsRule,
+  TurboPermanentRequireIdRule,
 ]

--- a/javascript/packages/linter/src/rules/actionview-no-silent-helper.ts
+++ b/javascript/packages/linter/src/rules/actionview-no-silent-helper.ts
@@ -1,0 +1,58 @@
+import { ParserRule } from "../types.js"
+import { BaseRuleVisitor } from "./rule-utils.js"
+import { isERBOpenTagNode, isERBOutputNode } from "@herb-tools/core"
+
+import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types.js"
+import type { ParseResult, HTMLElementNode, ParserOptions } from "@herb-tools/core"
+
+class ActionViewNoSilentHelperVisitor extends BaseRuleVisitor {
+  visitHTMLElementNode(node: HTMLElementNode): void {
+    this.checkActionViewHelper(node)
+    super.visitHTMLElementNode(node)
+  }
+
+  private checkActionViewHelper(node: HTMLElementNode): void {
+    if (!node.element_source || node.element_source === "HTML") return
+    if (!isERBOpenTagNode(node.open_tag)) return
+    if (isERBOutputNode(node.open_tag)) return
+
+    const tagOpening = node.open_tag.tag_opening?.value
+
+    if (!tagOpening) return
+
+    const helperName = node.element_source.includes("#")
+      ? node.element_source.split("#").pop()
+      : node.element_source
+
+    this.addOffense(
+      `Avoid using \`${tagOpening} %>\` with \`${helperName}\`. Use \`<%= %>\` to ensure the helper's output is rendered.`,
+      node.open_tag.location,
+    )
+  }
+}
+
+export class ActionViewNoSilentHelperRule extends ParserRule {
+  static ruleName = "actionview-no-silent-helper"
+
+  get defaultConfig(): FullRuleConfig {
+    return {
+      enabled: true,
+      severity: "error"
+    }
+  }
+
+  get parserOptions(): Partial<ParserOptions> {
+    return {
+      track_whitespace: true,
+      action_view_helpers: true,
+    }
+  }
+
+  check(result: ParseResult, context?: Partial<LintContext>): UnboundLintOffense[] {
+    const visitor = new ActionViewNoSilentHelperVisitor(this.ruleName, context)
+
+    visitor.visit(result.value)
+
+    return visitor.offenses
+  }
+}

--- a/javascript/packages/linter/test/__snapshots__/cli.test.ts.snap
+++ b/javascript/packages/linter/test/__snapshots__/cli.test.ts.snap
@@ -787,7 +787,7 @@ exports[`CLI Output Formatting > formats JSON output correctly for bad file 1`] 
   "summary": {
     "filesChecked": 1,
     "filesWithOffenses": 1,
-    "ruleCount": 68,
+    "ruleCount": 69,
     "totalErrors": 2,
     "totalHints": 0,
     "totalIgnored": 0,
@@ -808,7 +808,7 @@ exports[`CLI Output Formatting > formats JSON output correctly for clean file 1`
   "summary": {
     "filesChecked": 1,
     "filesWithOffenses": 0,
-    "ruleCount": 68,
+    "ruleCount": 69,
     "totalErrors": 0,
     "totalHints": 0,
     "totalIgnored": 0,
@@ -881,7 +881,7 @@ exports[`CLI Output Formatting > formats JSON output correctly for file with err
   "summary": {
     "filesChecked": 1,
     "filesWithOffenses": 1,
-    "ruleCount": 68,
+    "ruleCount": 69,
     "totalErrors": 2,
     "totalHints": 0,
     "totalIgnored": 0,
@@ -1041,47 +1041,20 @@ test/fixtures/disabled-1.html.erb:12:19
 
 ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯  [1/8] ⎯⎯⎯⎯
 
-[warning] Using \`all\` with specific rules is redundant. Use \`herb:disable all\` by itself or list only specific rules. (herb-disable-comment-no-redundant-all)
+[error] \`herb:disable\` comment is missing rule names. Specify \`all\` or list specific rules to disable. (herb-disable-comment-missing-rules)
 
-test/fixtures/disabled-1.html.erb:2:36
+test/fixtures/disabled-1.html.erb:10:19
 
-      1 │ <div>
-  →   2 │   <DIV>hello</DIV> <%# herb:disable all, html-tag-name-lowercase %>
-        │                                     ~~~
-      3 │ 
-      4 │   <DIV>hello</DIV> <%# herb:disable html-tag-name-lowercase, all %>
+      8 │   <DIV>hello</DIV> <%# herb:disable html-tag-name-lowercase, 
+        │ html-tag-name-lowercase %>
+      9 │ 
+  →  10 │   <div>hello</div> <%# herb:disable %>
+        │                    ~~~~~~~~~~~~~~~~~~~
+     11 │ 
+     12 │   <div>hello</div> <% # herb:disable %>
 
 
 ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯  [2/8] ⎯⎯⎯⎯
-
-[warning] Using \`all\` with specific rules is redundant. Use \`herb:disable all\` by itself or list only specific rules. (herb-disable-comment-no-redundant-all)
-
-test/fixtures/disabled-1.html.erb:4:61
-
-      2 │   <DIV>hello</DIV> <%# herb:disable all, html-tag-name-lowercase %>
-      3 │ 
-  →   4 │   <DIV>hello</DIV> <%# herb:disable html-tag-name-lowercase, all %>
-        │                                                              ~~~
-      5 │ 
-      6 │   <DIV>hello</DIV> <%# herb:disable all, all %>
-
-
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯  [3/8] ⎯⎯⎯⎯
-
-[warning] Using \`all\` with specific rules is redundant. Use \`herb:disable all\` by itself or list only specific rules. (herb-disable-comment-no-redundant-all)
-
-test/fixtures/disabled-1.html.erb:6:36
-
-      4 │   <DIV>hello</DIV> <%# herb:disable html-tag-name-lowercase, all %>
-      5 │ 
-  →   6 │   <DIV>hello</DIV> <%# herb:disable all, all %>
-        │                                     ~~~
-      7 │ 
-      8 │   <DIV>hello</DIV> <%# herb:disable html-tag-name-lowercase, 
-        │ html-tag-name-lowercase %>
-
-
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯  [4/8] ⎯⎯⎯⎯
 
 [warning] Duplicate rule \`all\` in \`herb:disable\` comment. Remove the duplicate. (herb-disable-comment-no-duplicate-rules)
 
@@ -1096,7 +1069,7 @@ test/fixtures/disabled-1.html.erb:6:41
         │ html-tag-name-lowercase %>
 
 
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯  [5/8] ⎯⎯⎯⎯
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯  [3/8] ⎯⎯⎯⎯
 
 [warning] Duplicate rule \`html-tag-name-lowercase\` in \`herb:disable\` comment. Remove the duplicate. (herb-disable-comment-no-duplicate-rules)
 
@@ -1111,19 +1084,46 @@ test/fixtures/disabled-1.html.erb:8:61
      10 │   <div>hello</div> <%# herb:disable %>
 
 
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯  [4/8] ⎯⎯⎯⎯
+
+[warning] Using \`all\` with specific rules is redundant. Use \`herb:disable all\` by itself or list only specific rules. (herb-disable-comment-no-redundant-all)
+
+test/fixtures/disabled-1.html.erb:2:36
+
+      1 │ <div>
+  →   2 │   <DIV>hello</DIV> <%# herb:disable all, html-tag-name-lowercase %>
+        │                                     ~~~
+      3 │ 
+      4 │   <DIV>hello</DIV> <%# herb:disable html-tag-name-lowercase, all %>
+
+
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯  [5/8] ⎯⎯⎯⎯
+
+[warning] Using \`all\` with specific rules is redundant. Use \`herb:disable all\` by itself or list only specific rules. (herb-disable-comment-no-redundant-all)
+
+test/fixtures/disabled-1.html.erb:4:61
+
+      2 │   <DIV>hello</DIV> <%# herb:disable all, html-tag-name-lowercase %>
+      3 │ 
+  →   4 │   <DIV>hello</DIV> <%# herb:disable html-tag-name-lowercase, all %>
+        │                                                              ~~~
+      5 │ 
+      6 │   <DIV>hello</DIV> <%# herb:disable all, all %>
+
+
 ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯  [6/8] ⎯⎯⎯⎯
 
-[error] \`herb:disable\` comment is missing rule names. Specify \`all\` or list specific rules to disable. (herb-disable-comment-missing-rules)
+[warning] Using \`all\` with specific rules is redundant. Use \`herb:disable all\` by itself or list only specific rules. (herb-disable-comment-no-redundant-all)
 
-test/fixtures/disabled-1.html.erb:10:19
+test/fixtures/disabled-1.html.erb:6:36
 
+      4 │   <DIV>hello</DIV> <%# herb:disable html-tag-name-lowercase, all %>
+      5 │ 
+  →   6 │   <DIV>hello</DIV> <%# herb:disable all, all %>
+        │                                     ~~~
+      7 │ 
       8 │   <DIV>hello</DIV> <%# herb:disable html-tag-name-lowercase, 
         │ html-tag-name-lowercase %>
-      9 │ 
-  →  10 │   <div>hello</div> <%# herb:disable %>
-        │                    ~~~~~~~~~~~~~~~~~~~
-     11 │ 
-     12 │   <div>hello</div> <% # herb:disable %>
 
 
 ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯  [7/8] ⎯⎯⎯⎯
@@ -1156,7 +1156,22 @@ test/fixtures/disabled-1.html.erb:14:19
 `;
 
 exports[`CLI Output Formatting > herb:disable rules 2`] = `
-"[warning] Unknown rule \`this-rule-doesnt-exist\`. Did you mean \`erb-no-empty-tags\`? (herb-disable-comment-valid-rule-name)
+"[warning] Using \`all\` with specific rules is redundant. Use \`herb:disable all\` by itself or list only specific rules. (herb-disable-comment-no-redundant-all)
+
+test/fixtures/disabled-2.html.erb:6:30
+
+      4 │   <DIV></DIV><%# herb:disable this-rule-doesnt-exist %>
+      5 │ 
+  →   6 │   <DIV></DIV><%# herb:disable all, this-rule-doesnt-exist %>
+        │                               ~~~
+      7 │ 
+      8 │   <DIV></DIV><%# herb:disable html-tag-name-lowercase, 
+        │ this-rule-doesnt-exist %>
+
+
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯  [1/13] ⎯⎯⎯⎯
+
+[warning] Unknown rule \`this-rule-doesnt-exist\`. Did you mean \`erb-no-empty-tags\`? (herb-disable-comment-valid-rule-name)
 
 test/fixtures/disabled-2.html.erb:4:30
 
@@ -1168,7 +1183,7 @@ test/fixtures/disabled-2.html.erb:4:30
       6 │   <DIV></DIV><%# herb:disable all, this-rule-doesnt-exist %>
 
 
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯  [1/13] ⎯⎯⎯⎯
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯  [2/13] ⎯⎯⎯⎯
 
 [warning] Unknown rule \`this-rule-doesnt-exist\`. Did you mean \`erb-no-empty-tags\`? (herb-disable-comment-valid-rule-name)
 
@@ -1183,7 +1198,7 @@ test/fixtures/disabled-2.html.erb:6:35
         │ this-rule-doesnt-exist %>
 
 
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯  [2/13] ⎯⎯⎯⎯
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯  [3/13] ⎯⎯⎯⎯
 
 [warning] Unknown rule \`this-rule-doesnt-exist\`. Did you mean \`erb-no-empty-tags\`? (herb-disable-comment-valid-rule-name)
 
@@ -1198,7 +1213,7 @@ test/fixtures/disabled-2.html.erb:8:55
      10 │   <DIV></DIV><%# herb:disable herb %>
 
 
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯  [3/13] ⎯⎯⎯⎯
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯  [4/13] ⎯⎯⎯⎯
 
 [warning] Unknown rule \`herb\`. Did you mean \`all\`? (herb-disable-comment-valid-rule-name)
 
@@ -1213,7 +1228,7 @@ test/fixtures/disabled-2.html.erb:10:30
      12 │   <DIV></DIV><%# herb:disable disable %>
 
 
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯  [4/13] ⎯⎯⎯⎯
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯  [5/13] ⎯⎯⎯⎯
 
 [warning] Unknown rule \`disable\`. Did you mean \`all\`? (herb-disable-comment-valid-rule-name)
 
@@ -1225,21 +1240,6 @@ test/fixtures/disabled-2.html.erb:12:30
         │                               ~~~~~~~
      13 │ </div>
      14 │
-
-
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯  [5/13] ⎯⎯⎯⎯
-
-[warning] Using \`all\` with specific rules is redundant. Use \`herb:disable all\` by itself or list only specific rules. (herb-disable-comment-no-redundant-all)
-
-test/fixtures/disabled-2.html.erb:6:30
-
-      4 │   <DIV></DIV><%# herb:disable this-rule-doesnt-exist %>
-      5 │ 
-  →   6 │   <DIV></DIV><%# herb:disable all, this-rule-doesnt-exist %>
-        │                               ~~~
-      7 │ 
-      8 │   <DIV></DIV><%# herb:disable html-tag-name-lowercase, 
-        │ this-rule-doesnt-exist %>
 
 
 ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯  [6/13] ⎯⎯⎯⎯

--- a/javascript/packages/linter/test/autofix/actionview-no-silent-helper.autofix.test.ts
+++ b/javascript/packages/linter/test/autofix/actionview-no-silent-helper.autofix.test.ts
@@ -1,0 +1,95 @@
+import dedent from "dedent"
+
+import { describe, test, expect, beforeAll } from "vitest"
+
+import { Herb } from "@herb-tools/node-wasm"
+import { Linter } from "../../src/linter.js"
+
+import { ActionViewNoSilentHelperRule } from "../../src/rules/actionview-no-silent-helper.js"
+
+describe("actionview-no-silent-helper autofix", () => {
+  beforeAll(async () => {
+    await Herb.load()
+  })
+
+  test.skip("output tag is not modified", () => {
+    const input = dedent`
+      <%= link_to "Home", root_path %>
+    `
+
+    const linter = new Linter(Herb, [ActionViewNoSilentHelperRule])
+    const result = linter.autofix(input, { fileName: "test.html.erb" }, undefined, { includeUnsafe: true })
+
+    expect(result.source).toBe(input)
+    expect(result.fixed).toHaveLength(0)
+    expect(result.unfixed).toHaveLength(0)
+  })
+
+  test.skip("fixes silent tag to output tag for link_to", () => {
+    const input = dedent`
+      <% link_to "Home", root_path %>
+    `
+
+    const expected = dedent`
+      <%= link_to "Home", root_path %>
+    `
+
+    const linter = new Linter(Herb, [ActionViewNoSilentHelperRule])
+    const result = linter.autofix(input, { fileName: "test.html.erb" }, undefined, { includeUnsafe: true })
+
+    expect(result.source).toBe(expected)
+    expect(result.fixed).toHaveLength(1)
+    expect(result.unfixed).toHaveLength(0)
+  })
+
+  test.skip("fixes silent tag to output tag for content_tag", () => {
+    const input = dedent`
+      <% content_tag :div, "Hello", class: "greeting" %>
+    `
+
+    const expected = dedent`
+      <%= content_tag :div, "Hello", class: "greeting" %>
+    `
+
+    const linter = new Linter(Herb, [ActionViewNoSilentHelperRule])
+    const result = linter.autofix(input, { fileName: "test.html.erb" }, undefined, { includeUnsafe: true })
+
+    expect(result.source).toBe(expected)
+    expect(result.fixed).toHaveLength(1)
+    expect(result.unfixed).toHaveLength(0)
+  })
+
+  test.skip("fixes trimmed silent tag to output tag", () => {
+    const input = dedent`
+      <%- link_to "Home", root_path %>
+    `
+
+    const expected = dedent`
+      <%= link_to "Home", root_path %>
+    `
+
+    const linter = new Linter(Herb, [ActionViewNoSilentHelperRule])
+    const result = linter.autofix(input, { fileName: "test.html.erb" }, undefined, { includeUnsafe: true })
+
+    expect(result.source).toBe(expected)
+    expect(result.fixed).toHaveLength(1)
+    expect(result.unfixed).toHaveLength(0)
+  })
+
+  test.skip("fixes silent tag for turbo_frame_tag", () => {
+    const input = dedent`
+      <% turbo_frame_tag "test" %>
+    `
+
+    const expected = dedent`
+      <%= turbo_frame_tag "test" %>
+    `
+
+    const linter = new Linter(Herb, [ActionViewNoSilentHelperRule])
+    const result = linter.autofix(input, { fileName: "test.html.erb" }, undefined, { includeUnsafe: true })
+
+    expect(result.source).toBe(expected)
+    expect(result.fixed).toHaveLength(1)
+    expect(result.unfixed).toHaveLength(0)
+  })
+})

--- a/javascript/packages/linter/test/rules/actionview-no-silent-helper.test.ts
+++ b/javascript/packages/linter/test/rules/actionview-no-silent-helper.test.ts
@@ -1,0 +1,92 @@
+import dedent from "dedent"
+
+import { describe, test } from "vitest"
+
+import { ActionViewNoSilentHelperRule } from "../../src/rules/actionview-no-silent-helper.js"
+import { createLinterTest } from "../helpers/linter-test-helper.js"
+
+const { expectNoOffenses, expectError, assertOffenses } = createLinterTest(ActionViewNoSilentHelperRule)
+
+describe("ActionViewNoSilentHelperRule", () => {
+  test("output tag with link_to is allowed", () => {
+    expectNoOffenses(dedent`
+      <%= link_to "Home", root_path %>
+    `)
+  })
+
+  test("output tag with form_with is allowed", () => {
+    expectNoOffenses(dedent`
+      <%= form_with model: @user do |f| %>
+        <%= f.text_field :name %>
+      <% end %>
+    `)
+  })
+
+  test("output tag with button_to is allowed", () => {
+    expectNoOffenses(dedent`
+      <%= button_to "Delete", user_path(@user), method: :delete %>
+    `)
+  })
+
+  test("output tag with content_tag is allowed", () => {
+    expectNoOffenses(dedent`
+      <%= content_tag :div, "Hello", class: "greeting" %>
+    `)
+  })
+
+  test("regular HTML elements are allowed", () => {
+    expectNoOffenses(dedent`
+      <div class="container">
+        <p>Hello</p>
+      </div>
+    `)
+  })
+
+  test("silent ERB statements are allowed", () => {
+    expectNoOffenses(dedent`
+      <% if true %>
+        <p>Hello</p>
+      <% end %>
+    `)
+  })
+
+  test("silent tag with link_to is not allowed", () => {
+    expectError("Avoid using `<% %>` with `link_to`. Use `<%= %>` to ensure the helper's output is rendered.")
+
+    assertOffenses(dedent`
+      <% link_to "Home", root_path %>
+    `)
+  })
+
+  test("silent tag with content_tag is not allowed", () => {
+    expectError("Avoid using `<% %>` with `content_tag`. Use `<%= %>` to ensure the helper's output is rendered.")
+
+    assertOffenses(dedent`
+      <% content_tag :div, "Hello", class: "greeting" %>
+    `)
+  })
+
+  test("silent tag with turbo_frame_tag is not allowed", () => {
+    expectError("Avoid using `<% %>` with `turbo_frame_tag`. Use `<%= %>` to ensure the helper's output is rendered.")
+
+    assertOffenses(dedent`
+      <% turbo_frame_tag "test" %>
+    `)
+  })
+
+  test("trimmed silent tag with link_to is not allowed", () => {
+    expectError("Avoid using `<%- %>` with `link_to`. Use `<%= %>` to ensure the helper's output is rendered.")
+
+    assertOffenses(dedent`
+      <%- link_to "Home", root_path %>
+    `)
+  })
+
+  test("silent tag with tag.div is not allowed", () => {
+    expectError("Avoid using `<% %>` with `tag`. Use `<%= %>` to ensure the helper's output is rendered.")
+
+    assertOffenses(dedent`
+      <% tag.div "Hello" %>
+    `)
+  })
+})


### PR DESCRIPTION
This pull request implements a linter rule that makes sure that all Action View Tag helpers are called with a `<%=`. Calling an Action View tag helper with a `<%` doesn't output the rendered result from the helper.

<img width="1602" height="900" alt="CleanShot 2026-03-11 at 12 32 14@2x" src="https://github.com/user-attachments/assets/1d2fea71-4544-4c11-b442-3f4a5a19ef3b" />


Resolves https://github.com/marcoroth/herb/issues/180