### PR TITLE
Ruby CLI: Show compiled source when `compile` produces invalid Ruby

### DIFF
--- a/lib/herb/cli.rb
+++ b/lib/herb/cli.rb
@@ -462,6 +462,24 @@ class Herb::CLI
       end
 
       exit(0)
+    rescue Herb::Engine::InvalidRubyError => e
+      if json
+        result = {
+          success: false,
+          error: e.message,
+          source: e.compiled_source,
+          filename: @file,
+        }
+        puts result.to_json
+      elsif silent
+        puts "Failed"
+      else
+        puts e.compiled_source if e.compiled_source
+        puts
+        puts e.message
+      end
+
+      exit(1)
     rescue Herb::Engine::CompilationError => e
       if json
         result = {

--- a/lib/herb/engine.rb
+++ b/lib/herb/engine.rb
@@ -32,6 +32,13 @@ module Herb
     end
 
     class InvalidRubyError < CompilationError
+      attr_reader :compiled_source
+
+      def initialize(message, compiled_source: nil)
+        @compiled_source = compiled_source
+
+        super(message)
+      end
     end
 
     def initialize(input, properties = {})
@@ -155,7 +162,7 @@ module Herb
 
         if syntax_errors.any?
           details = syntax_errors.map { |e| "  - #{e.message} (line #{e.location.start_line})" }.join("\n")
-          raise InvalidRubyError, "Compiled template produced invalid Ruby:\n#{details}"
+          raise InvalidRubyError.new("Compiled template produced invalid Ruby:\n#{details}", compiled_source: @src)
         end
       end
 

--- a/sig/herb/engine.rbs
+++ b/sig/herb/engine.rbs
@@ -28,6 +28,9 @@ module Herb
     end
 
     class InvalidRubyError < CompilationError
+      attr_reader compiled_source: untyped
+
+      def initialize: (untyped message, ?compiled_source: untyped) -> untyped
     end
 
     def initialize: (untyped input, ?untyped properties) -> untyped


### PR DESCRIPTION
This pull request updates the Ruby CLI to show the compiled source when the  `compile` subcommand produced invalid Ruby

**Before**
```
❯ bin/herb compile test.html.erb
Compiled template produced invalid Ruby:
  - unexpected end-of-input, assuming it is closing the parent top level context (line 4)
  - expected a matching `)` (line 5)
  - unexpected end-of-input; expected a `)` to close the arguments (line 4)
``` 

**After**
```
❯ bin/herb compile test.html.erb
__herb = ::Herb::Engine; _buf = ::String.new; _buf << __herb.h((render Foo.new do; _buf << 'hello'.freeze; end # comment))
 _buf << '
'.freeze;
_buf.to_s

Compiled template produced invalid Ruby:
  - unexpected end-of-input, assuming it is closing the parent top level context (line 4)
  - expected a matching `)` (line 5)
  - unexpected end-of-input; expected a `)` to close the arguments (line 4)
``` 

Inspired while working on #1363 