### PR TITLE
Config: Rework `engine.*` configuration

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -202,6 +202,69 @@ linter:
         - 'app/views/admin/**/*'
 ```
 
+## Engine Configuration <Badge type="tip" text="v0.9.0+" />
+
+Configure the template engine behavior:
+
+```yaml [.herb.yml]
+engine:
+  validators:
+    security: true       # Enable/disable security validation (default: true)
+    nesting: true        # Enable/disable HTML nesting validation (default: true)
+    accessibility: true  # Enable/disable accessibility validation (default: true)
+```
+
+### Validators
+
+The engine runs validators on templates during compilation. Each validator can be individually enabled or disabled:
+
+- **`security`**: Detects ERB output tags (`<%= %>`) in unsafe positions like attribute names or attribute positions. Prevents potential XSS vulnerabilities. _(default: `true`)_
+- **`nesting`**: Validates HTML nesting rules, such as block elements inside `<p>`, nested anchors, or interactive elements inside `<button>`. _(default: `true`)_
+- **`accessibility`**: Validates accessibility-related attributes. _(default: `true`)_
+
+When a validator is disabled (`false`), the engine skips it entirely during compilation. This applies regardless of the `validation_mode` used by the engine.
+
+### Validation Mode
+
+The `validation_mode` controls how the engine handles validation results. This is set programmatically when creating an `Herb::Engine` instance, not in `.herb.yml`:
+
+- **`:raise`** (default): Raises an exception when validation errors are found
+- **`:overlay`**: Renders validation errors as an in-browser overlay (used by [ReActionView](https://github.com/marcoroth/reactionview) in development)
+- **`:none`**: Skips validation entirely
+
+**Raises on validation errors (default)**
+```ruby
+Herb::Engine.new(source, validation_mode: :raise)
+```
+
+**Shows errors as in-browser overlay**
+```ruby
+Herb::Engine.new(source, validation_mode: :overlay)
+```
+
+**Skips all validation**
+```ruby
+Herb::Engine.new(source, validation_mode: :none)
+```
+
+### Overriding Validators Programmatically
+
+Validator settings from `.herb.yml` can be overridden when creating an engine instance:
+
+**Disable security validator for this template only**
+```ruby
+Herb::Engine.new(source, validators: { security: false })
+```
+
+**Disable all validators**
+```ruby
+Herb::Engine.new(source, validators: {
+  security: false,
+  nesting: false,
+  accessibility: false,
+})
+```
+
 ## Formatter Configuration
 
 Configure the formatter behavior:

--- a/docs/docs/projects/engine.md
+++ b/docs/docs/projects/engine.md
@@ -1,3 +1,80 @@
-# `Herb::Engine`
+# `Herb::Engine` <Badge type="tip" text="v0.7.0+" />
 
-See [`marcoroth/reactionview`](https://github.com/marcoroth/reactionview) for now.
+`Herb::Engine` is a drop-in replacement for [`Erubi::Engine`](https://github.com/jeremyevans/erubi) that compiles HTML+ERB templates into Ruby code. It extends Erubi's functionality with HTML-aware parsing, validation, and security checks.
+
+## Usage
+
+Basic usage (same as `Erubi::Engine`):
+
+```ruby
+engine = Herb::Engine.new(source)
+puts engine.src
+```
+
+With options:
+```ruby
+engine = Herb::Engine.new(source,
+  filename: "app/views/users/show.html.erb",
+  escape: true,
+)
+```
+
+## Erubi Compatibility
+
+`Herb::Engine` accepts all the same options as `Erubi::Engine`:
+
+- `bufvar` / `outvar` — Buffer variable name
+- `bufval` — Initial buffer value
+- `escape` / `escape_html` — Whether `<%= %>` escapes by default
+- `escapefunc` — Escape function name
+- `filename` — Template filename
+- `freeze` — Add frozen string literal comment
+- `freeze_template_literals` — Freeze template string literals
+- `preamble` / `postamble` — Custom preamble/postamble
+- `chain_appends` — Chain `<<` calls for performance
+- `ensure` — Wrap in begin/ensure block
+- `src` — Initial source string
+
+## Herb-Specific Options
+
+In addition to Erubi options, `Herb::Engine` supports:
+
+| Option | Default | Description |
+|---|---|---|
+| `validation_mode` | `:raise` | How to handle validation errors: `:raise`, `:overlay`, or `:none` |
+| `validators` | `{}` | Per-validator overrides (e.g., `{ security: false }`) |
+| `strict` | `true` | Whether to use strict parsing mode |
+| `visitors` | `[]` | AST visitors to run before compilation |
+| `project_path` | `Dir.pwd` | Project root for relative path resolution |
+| `debug` | `false` | Enable debug mode |
+
+## Validators
+
+The engine runs validators on parsed templates to catch errors before compilation. Each validator can be enabled or disabled via [`.herb.yml` configuration](/configuration#engine-configuration) or per-instance overrides.
+
+| Validator | Description |
+|---|---|
+| Security | Detects ERB output in unsafe positions (attribute names, attribute positions) |
+| Nesting | Validates HTML nesting rules (e.g., no `<div>` inside `<p>`) |
+| Accessibility | Validates accessibility-related attributes |
+
+Disable security validator for this template:
+```ruby
+Herb::Engine.new(source, validators: { security: false })
+```
+
+See [Engine Configuration](/configuration#engine-configuration) for `.herb.yml` configuration.
+
+## Validation Mode
+
+Controls how the engine presents validation results:
+
+- **`:raise`** — Raises `SecurityError` or `CompilationError` (default, used in tests and CLI)
+- **`:overlay`** — Renders errors as in-browser overlay (used by [ReActionView](https://github.com/marcoroth/reactionview) in development)
+- **`:none`** — Skips validation entirely
+
+## ReActionView Integration
+
+[ReActionView](https://github.com/marcoroth/reactionview) registers `Herb::Engine` as the template handler for `.html.erb` and `.html.herb` files in Rails. It uses `validation_mode: :overlay` so validation errors appear as in-browser overlays during development instead of raising exceptions.
+
+Validator settings from `.herb.yml` are respected automatically — no ReActionView-specific configuration needed.

--- a/javascript/packages/config/src/config-schema.ts
+++ b/javascript/packages/config/src/config-schema.ts
@@ -39,10 +39,14 @@ export const FormatterConfigSchema = z.object({
   rewriter: RewriterConfigSchema.describe("Rewriter configuration for pre and post-format transformations"),
 }).strict().optional()
 
-export const SecurityModeSchema = z.enum(["error", "warn", "ignore"])
+export const ValidatorsConfigSchema = z.object({
+  security: z.boolean().optional().describe("Enable or disable the security validator (default: true)"),
+  nesting: z.boolean().optional().describe("Enable or disable the nesting validator (default: true)"),
+  accessibility: z.boolean().optional().describe("Enable or disable the accessibility validator (default: true)"),
+}).strict().optional()
 
 export const EngineConfigSchema = z.object({
-  security: SecurityModeSchema.optional().describe("Security mode for ERB output in HTML attributes. 'error' raises immediately, 'warn' logs a warning, 'ignore' skips validation"),
+  validators: ValidatorsConfigSchema.describe("Per-validator enable/disable configuration"),
 }).strict().optional()
 
 export const HerbConfigSchema = z.object({

--- a/javascript/packages/config/src/config-template.yml
+++ b/javascript/packages/config/src/config-template.yml
@@ -25,9 +25,10 @@ version: 0.8.10
 #     - 'tmp/**/*'
 
 # engine:
-#   # Security mode for ERB output in HTML attributes
-#   # Valid values: error (default), warn, ignore
-#   security: error
+#   validators:
+#     security: true       # default: true
+#     nesting: true        # default: true
+#     accessibility: true  # default: true
 
 linter:
   enabled: true

--- a/javascript/packages/config/src/config.ts
+++ b/javascript/packages/config/src/config.ts
@@ -61,8 +61,14 @@ export type FormatterConfig = {
   }
 }
 
+export type ValidatorsConfig = {
+  security?: boolean
+  nesting?: boolean
+  accessibility?: boolean
+}
+
 export type EngineConfig = {
-  security?: 'error' | 'warn' | 'ignore'
+  validators?: ValidatorsConfig
 }
 
 export type HerbConfigOptions = {

--- a/lib/herb/configuration.rb
+++ b/lib/herb/configuration.rb
@@ -62,6 +62,18 @@ module Herb
       @config["engine"] || {}
     end
 
+    def enabled_validators(overrides = {})
+      config = dig("engine", "validators") || {}
+
+      {
+        security: config.fetch("security", true),
+        nesting: config.fetch("nesting", true),
+        accessibility: config.fetch("accessibility", true),
+      }.merge(
+        overrides.to_h { |key, value| [key.to_sym, !!value] }
+      )
+    end
+
     def formatter
       @config["formatter"] || {}
     end

--- a/lib/herb/defaults.yml
+++ b/lib/herb/defaults.yml
@@ -17,7 +17,10 @@ files:
     - "vendor/**/*"
 
 engine:
-  security: error
+  validators:
+    security: true
+    nesting: true
+    accessibility: true
 
 linter:
   enabled: true

--- a/lib/herb/engine.rb
+++ b/lib/herb/engine.rb
@@ -18,7 +18,7 @@ require_relative "engine/validators/accessibility_validator"
 module Herb
   class Engine
     attr_reader :src, :filename, :project_path, :relative_file_path, :bufvar, :debug, :content_for_head,
-                :validation_error_template, :visitors, :security_mode
+                :validation_error_template, :visitors, :enabled_validators
 
     ESCAPE_TABLE = {
       "&" => "&amp;",
@@ -62,9 +62,7 @@ module Herb
       @content_for_head = properties[:content_for_head]
       @validation_error_template = nil
       @validation_mode = properties.fetch(:validation_mode, :raise)
-      @security_mode = properties.fetch(:security) {
-        Herb.configuration.dig("engine", "security") || :error
-      }.to_sym
+      @enabled_validators = Herb.configuration.enabled_validators(properties[:validators] || {})
       @strict = properties.fetch(:strict, true)
       @visitors = properties.fetch(:visitors, default_visitors)
 
@@ -80,11 +78,6 @@ module Herb
       unless [:raise, :overlay, :none].include?(@validation_mode)
         raise ArgumentError,
               "validation_mode must be one of :raise, :overlay, or :none, got #{@validation_mode.inspect}"
-      end
-
-      unless [:error, :warn, :ignore].include?(@security_mode)
-        raise ArgumentError,
-              "security must be one of :error, :warn, or :ignore, got #{@security_mode.inspect}"
       end
 
       @freeze = properties[:freeze]
@@ -126,12 +119,12 @@ module Herb
           # Skip both errors and compilation, but still need minimal Ruby code
         end
       else
-        validation_errors = run_validation(ast) unless @validation_mode == :none
-        all_errors = parser_errors + (validation_errors || [])
+        validators = run_validation(ast) unless @validation_mode == :none
 
-        handle_validation_errors(all_errors, input) if @validation_mode == :raise && all_errors.any?
-
-        add_validation_overlay(validation_errors, input) if @validation_mode == :overlay && validation_errors&.any?
+        if validators
+          handle_validation_errors(validators, input) if @validation_mode == :raise
+          add_validation_overlay(validators, input) if @validation_mode == :overlay
+        end
 
         @visitors.each do |visitor|
           ast.accept(visitor)
@@ -333,19 +326,16 @@ module Herb
 
     def run_validation(ast)
       validators = [
-        Validators::SecurityValidator.new,
-        Validators::NestingValidator.new,
-        Validators::AccessibilityValidator.new
+        Validators::SecurityValidator.new(enabled: @enabled_validators[:security]),
+        Validators::NestingValidator.new(enabled: @enabled_validators[:nesting]),
+        Validators::AccessibilityValidator.new(enabled: @enabled_validators[:accessibility])
       ]
 
-      errors = [] #: Array[untyped]
-
-      validators.each do |validator|
+      validators.select(&:enabled?).each do |validator|
         ast.accept(validator)
-        errors.concat(validator.errors)
       end
 
-      errors
+      validators
     end
 
     def handle_parser_errors(parser_errors, input, _ast)
@@ -365,54 +355,29 @@ module Herb
       end
     end
 
-    def handle_validation_errors(errors, input)
+    def handle_validation_errors(validators, input)
+      errors = validators.select(&:enabled?).flat_map(&:errors)
       return unless errors.any?
 
-      security_errors = errors.select { |error|
-        error.is_a?(Hash) && error[:source] == "SecurityValidator"
-      }
+      security_error = errors.find { |error| error[:source] == "SecurityValidator" }
 
-      non_security_errors = errors.reject { |error|
-        error.is_a?(Hash) && error[:source] == "SecurityValidator"
-      }
-
-      if security_errors.any?
-        case @security_mode
-        when :error
-          security_error = security_errors.first
-          line = security_error[:location]&.start&.line
-          column = security_error[:location]&.start&.column
-          suggestion = security_error[:suggestion]
-
-          raise SecurityError.new(
-            security_error[:message],
-            line: line,
-            column: column,
-            filename: @filename,
-            suggestion: suggestion
-          )
-        when :warn
-          security_errors.each do |security_error|
-            line = security_error[:location]&.start&.line
-            column = security_error[:location]&.start&.column
-            location_str = @filename ? "#{@filename}:#{line}:#{column}" : "#{line}:#{column}"
-
-            warn "WARNING: Security issue at #{location_str}: #{security_error[:message]}"
-            warn "  Suggestion: #{security_error[:suggestion]}" if security_error[:suggestion]
-          end
-        when :ignore
-          # Skip security errors silently
-        end
+      if security_error
+        raise SecurityError.new(
+          security_error[:message],
+          line: security_error[:location]&.start&.line,
+          column: security_error[:location]&.start&.column,
+          filename: @filename,
+          suggestion: security_error[:suggestion]
+        )
       end
 
-      return unless non_security_errors.any?
-
-      formatter = ErrorFormatter.new(input, non_security_errors, filename: @filename)
+      formatter = ErrorFormatter.new(input, errors, filename: @filename)
       message = formatter.format_all
       raise CompilationError, "\n#{message}"
     end
 
-    def add_validation_overlay(errors, input = nil)
+    def add_validation_overlay(validators, input = nil)
+      errors = validators.select(&:enabled?).flat_map(&:errors)
       return unless errors.any?
 
       templates = errors.map { |error|

--- a/lib/herb/engine/validator.rb
+++ b/lib/herb/engine/validator.rb
@@ -3,12 +3,17 @@
 module Herb
   class Engine
     class Validator < Herb::Visitor
-      attr_reader :diagnostics
+      attr_reader :diagnostics, :enabled
 
-      def initialize
-        super
+      def initialize(enabled: true)
+        super()
 
+        @enabled = enabled
         @diagnostics = []
+      end
+
+      def enabled?
+        @enabled
       end
 
       def validate(node)

--- a/rust/herb-config/src/herb_config.rs
+++ b/rust/herb-config/src/herb_config.rs
@@ -70,21 +70,33 @@ impl Default for HerbFormatterConfig {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct HerbEngineConfig {
-  #[serde(default = "default_security_mode")]
-  pub security: String,
+pub struct HerbValidatorsConfig {
+  #[serde(default = "default_validator_enabled")]
+  pub security: bool,
+  #[serde(default = "default_validator_enabled")]
+  pub nesting: bool,
+  #[serde(default = "default_validator_enabled")]
+  pub accessibility: bool,
 }
 
-fn default_security_mode() -> String {
-  "error".to_string()
+fn default_validator_enabled() -> bool {
+  true
 }
 
-impl Default for HerbEngineConfig {
+impl Default for HerbValidatorsConfig {
   fn default() -> Self {
     Self {
-      security: default_security_mode(),
+      security: true,
+      nesting: true,
+      accessibility: true,
     }
   }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct HerbEngineConfig {
+  #[serde(default)]
+  pub validators: HerbValidatorsConfig,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]

--- a/sig/herb/configuration.rbs
+++ b/sig/herb/configuration.rbs
@@ -34,6 +34,8 @@ module Herb
 
     def engine: () -> untyped
 
+    def enabled_validators: (?untyped overrides) -> untyped
+
     def formatter: () -> untyped
 
     def include_patterns_for: (untyped tool) -> untyped

--- a/sig/herb/engine.rbs
+++ b/sig/herb/engine.rbs
@@ -20,7 +20,7 @@ module Herb
 
     attr_reader visitors: untyped
 
-    attr_reader security_mode: untyped
+    attr_reader enabled_validators: untyped
 
     ESCAPE_TABLE: untyped
 
@@ -79,9 +79,9 @@ module Herb
 
     def handle_parser_errors: (untyped parser_errors, untyped input, untyped _ast) -> untyped
 
-    def handle_validation_errors: (untyped errors, untyped input) -> untyped
+    def handle_validation_errors: (untyped validators, untyped input) -> untyped
 
-    def add_validation_overlay: (untyped errors, ?untyped input) -> untyped
+    def add_validation_overlay: (untyped validators, ?untyped input) -> untyped
 
     def escape_attr: (untyped text) -> untyped
 

--- a/sig/herb/engine/validator.rbs
+++ b/sig/herb/engine/validator.rbs
@@ -5,7 +5,11 @@ module Herb
     class Validator < Herb::Visitor
       attr_reader diagnostics: untyped
 
-      def initialize: () -> untyped
+      attr_reader enabled: untyped
+
+      def initialize: (?enabled: untyped) -> untyped
+
+      def enabled?: () -> untyped
 
       def validate: (untyped node) -> untyped
 

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -514,31 +514,57 @@ class ConfigurationTest < Minitest::Spec
     assert_equal 1, files.size
   end
 
-  test "engine config defaults to security error" do
+  test "engine validators default to true" do
     config = Herb::Configuration.load(@temp_dir)
 
-    assert_equal "error", config.engine["security"]
+    assert_equal true, config.dig("engine", "validators", "security")
+    assert_equal true, config.dig("engine", "validators", "nesting")
+    assert_equal true, config.dig("engine", "validators", "accessibility")
   end
 
-  test "engine security can be set to warn" do
+  test "engine validator security can be disabled" do
     write_config(<<~YAML)
       engine:
-        security: warn
+        validators:
+          security: false
     YAML
 
     config = Herb::Configuration.load(@temp_dir)
 
-    assert_equal "warn", config.engine["security"]
+    assert_equal false, config.dig("engine", "validators", "security")
   end
 
-  test "engine security can be set to ignore" do
+  test "engine validator nesting can be disabled" do
     write_config(<<~YAML)
       engine:
-        security: ignore
+        validators:
+          nesting: false
     YAML
 
     config = Herb::Configuration.load(@temp_dir)
 
-    assert_equal "ignore", config.engine["security"]
+    assert_equal false, config.dig("engine", "validators", "nesting")
+  end
+
+  test "enabled_validators resolves from config" do
+    write_config(<<~YAML)
+      engine:
+        validators:
+          security: false
+    YAML
+
+    config = Herb::Configuration.load(@temp_dir)
+
+    assert_equal({ security: false, nesting: true, accessibility: true }, config.enabled_validators)
+  end
+
+  test "enabled_validators accepts overrides" do
+    config = Herb::Configuration.load(@temp_dir)
+
+    result = config.enabled_validators(nesting: false)
+
+    assert_equal true, result[:security]
+    assert_equal false, result[:nesting]
+    assert_equal true, result[:accessibility]
   end
 end

--- a/test/engine/security_modes_test.rb
+++ b/test/engine/security_modes_test.rb
@@ -3,18 +3,19 @@
 require_relative "../test_helper"
 
 module Engine
-  class SecurityModesTest < Minitest::Spec
+  class ValidatorConfigTest < Minitest::Spec
     include SnapshotUtils
 
     before do
       @security_violation_template = "<div <%= @malicious %>>Content</div>"
       @attribute_name_violation = '<div data-<%= @name %>="value">Content</div>'
       @valid_template = "<div>Valid template</div>"
+      @invalid_nesting_template = "<p><div>Invalid nesting</div></p>"
     end
 
-    test "security: 'error' mode raises SecurityError (default)" do
+    test "security validator raises SecurityError by default" do
       error = assert_raises(Herb::Engine::SecurityError) do
-        Herb::Engine.new(@security_violation_template, security: :error)
+        Herb::Engine.new(@security_violation_template)
       end
 
       assert_includes error.message, "ERB output tags"
@@ -22,165 +23,83 @@ module Engine
       assert_equal 5, error.column
     end
 
-    test "security mode defaults to 'error' when not specified" do
-      error = assert_raises(Herb::Engine::SecurityError) do
-        Herb::Engine.new(@security_violation_template)
-      end
-
-      assert_includes error.message, "ERB output tags"
-    end
-
-    test "security: 'warn' mode logs warning but compiles successfully" do
-      original_stderr = $stderr
-      $stderr = StringIO.new
-
-      engine = Herb::Engine.new(@security_violation_template, security: :warn)
-
-      $stderr.rewind
-      output = $stderr.read
-      $stderr = original_stderr
-
-      assert output.include?("WARNING: Security issue")
-      assert output.include?("ERB output tags")
-      assert output.include?("Suggestion:")
-      assert_kind_of String, engine.src
-    end
-
-    test "security: 'ignore' mode silently skips security validation" do
-      engine = Herb::Engine.new(@security_violation_template, security: :ignore)
+    test "security validator can be disabled" do
+      engine = Herb::Engine.new(@security_violation_template, validators: { security: false })
 
       assert_kind_of String, engine.src
       refute_empty engine.src
     end
 
-    test "security: 'warn' mode logs multiple security violations" do
-      template = '<div <%= @attr1 %> data-<%= @name %>="value">Content</div>'
+    test "nesting validator raises CompilationError by default" do
+      error = assert_raises(Herb::Engine::CompilationError) do
+        Herb::Engine.new(@invalid_nesting_template)
+      end
 
-      original_stderr = $stderr
-      $stderr = StringIO.new
+      assert_includes error.message, "InvalidNestingError"
+    end
 
-      engine = Herb::Engine.new(template, security: :warn)
+    test "nesting validator can be disabled" do
+      engine = Herb::Engine.new(@invalid_nesting_template, validators: { nesting: false })
 
-      $stderr.rewind
-      output = $stderr.read
-      $stderr = original_stderr
-
-      assert output.scan("WARNING: Security issue").count >= 1
       assert_kind_of String, engine.src
     end
 
-    test "security: 'error' mode still raises non-security validation errors" do
-      invalid_nesting_template = "<p><div>Invalid nesting</div></p>"
-
+    test "disabling security does not disable nesting" do
       error = assert_raises(Herb::Engine::CompilationError) do
-        Herb::Engine.new(invalid_nesting_template, security: :error)
+        Herb::Engine.new(@invalid_nesting_template, validators: { security: false })
       end
 
       assert_includes error.message, "InvalidNestingError"
     end
 
-    test "security: 'warn' mode still raises non-security validation errors" do
-      invalid_nesting_template = "<p><div>Invalid nesting</div></p>"
-
-      error = assert_raises(Herb::Engine::CompilationError) do
-        Herb::Engine.new(invalid_nesting_template, security: :warn)
+    test "disabling nesting does not disable security" do
+      error = assert_raises(Herb::Engine::SecurityError) do
+        Herb::Engine.new(@security_violation_template, validators: { nesting: false })
       end
 
-      assert_includes error.message, "InvalidNestingError"
+      assert_includes error.message, "ERB output tags"
     end
 
-    test "security: 'ignore' mode still raises non-security validation errors" do
-      invalid_nesting_template = "<p><div>Invalid nesting</div></p>"
+    test "multiple validators can be disabled" do
+      template = "<p><div <%= @attr %>>Content</div></p>"
 
-      error = assert_raises(Herb::Engine::CompilationError) do
-        Herb::Engine.new(invalid_nesting_template, security: :ignore)
-      end
+      engine = Herb::Engine.new(template, validators: {
+        security: false,
+        nesting: false,
+      })
 
-      assert_includes error.message, "InvalidNestingError"
+      assert_kind_of String, engine.src
     end
 
-    test "invalid security mode raises ArgumentError" do
-      error = assert_raises(ArgumentError) do
-        Herb::Engine.new(@valid_template, security: :invalid)
-      end
-
-      assert_includes error.message, "security must be one of :error, :warn, or :ignore"
-      assert_includes error.message, ":invalid"
-    end
-
-    test "security mode works with validation_mode: :overlay" do
-      # When validation_mode is :overlay, validation errors are rendered as an overlay
-      # rather than raising or logging to stderr
+    test "disabled validators work with validation_mode: :overlay" do
       engine = Herb::Engine.new(@security_violation_template,
-                                security: :warn,
+                                validators: { security: false },
                                 validation_mode: :overlay)
 
       assert_kind_of String, engine.src
     end
 
-    test "security mode works with validation_mode: :none" do
-      # When validation_mode is :none, security checks don't run
+    test "validators do not run when validation_mode: :none" do
       engine = Herb::Engine.new(@security_violation_template,
-                                security: :error,
                                 validation_mode: :none)
 
       assert_kind_of String, engine.src
     end
 
-    test "security: 'warn' includes filename in warning message" do
-      original_stderr = $stderr
-      $stderr = StringIO.new
+    test "enabled_validators returns resolved config" do
+      engine = Herb::Engine.new(@valid_template, validators: { security: false })
 
-      Herb::Engine.new(@security_violation_template,
-                       security: :warn,
-                       filename: "test_template.html.erb")
-
-      $stderr.rewind
-      output = $stderr.read
-      $stderr = original_stderr
-
-      assert output.include?("test_template.html.erb")
+      assert_equal false, engine.enabled_validators[:security]
+      assert_equal true, engine.enabled_validators[:nesting]
+      assert_equal true, engine.enabled_validators[:accessibility]
     end
 
-    test "security: 'warn' formats location without filename" do
-      original_stderr = $stderr
-      $stderr = StringIO.new
+    test "all validators enabled by default" do
+      engine = Herb::Engine.new(@valid_template)
 
-      Herb::Engine.new(@security_violation_template, security: :warn)
-
-      $stderr.rewind
-      output = $stderr.read
-      $stderr = original_stderr
-
-      assert output.match?(/\d+:\d+/)
-    end
-
-    test "security mode reads from .herb.yml configuration" do
-      temp_dir = Dir.mktmpdir("herb_security_config_test")
-      File.write(File.join(temp_dir, ".herb.yml"), "engine:\n  security: ignore\n")
-
-      Herb.configure(temp_dir)
-
-      engine = Herb::Engine.new(@security_violation_template)
-      assert_kind_of String, engine.src
-      assert_equal :ignore, engine.security_mode
-    ensure
-      Herb.reset_configuration!
-      FileUtils.rm_rf(temp_dir)
-    end
-
-    test "explicit security parameter overrides .herb.yml configuration" do
-      temp_dir = Dir.mktmpdir("herb_security_config_test")
-      File.write(File.join(temp_dir, ".herb.yml"), "engine:\n  security: ignore\n")
-
-      Herb.configure(temp_dir)
-
-      assert_raises(Herb::Engine::SecurityError) do
-        Herb::Engine.new(@security_violation_template, security: :error)
-      end
-    ensure
-      Herb.reset_configuration!
-      FileUtils.rm_rf(temp_dir)
+      assert_equal true, engine.enabled_validators[:security]
+      assert_equal true, engine.enabled_validators[:nesting]
+      assert_equal true, engine.enabled_validators[:accessibility]
     end
   end
 end


### PR DESCRIPTION
This pull request refactors the engine validator configuration introduced in #1315 to be simpler and more consistent, especially when in used with ReActionView.


The original `engine.security` config had three modes (`error`, `warn`, `ignore`) which overlapped with `validation_mode` (`:raise`, `:overlay`, `:none`) that already controls how the engine handles validation results. 

Having both created confusing interactions, e.g., `security: :ignore` had no effect when `validation_mode: :overlay` was used (which is the default in ReActionView). 

Splitting the concerns makes it clear: `validation_mode` controls _how_ errors are presented, `validators` controls _which_ validators run.


**Before** 
```yaml
# .herb.yml

  engine:
    security: error 
```

```ruby
Herb::Engine.new(source, security: :warn)
```

**After**
```yaml
# .herb.yml

  engine:
    validators:
      security: true     
      nesting: true     
      accessibility: true 
```

```ruby
Herb::Engine.new(source, validators: { security: false })
```

Follow up on #1315

/cc @joelhawksley 