### PR TITLE
C: Fix O(n) linked list walk in `hb_arena_append_page()`

### DIFF
--- a/src/util/hb_arena.c
+++ b/src/util/hb_arena.c
@@ -75,9 +75,7 @@ static bool hb_arena_append_page(hb_arena_T* allocator, size_t page_size) {
     allocator->head = page;
     allocator->tail = page;
   } else {
-    hb_arena_page_T* last = allocator->tail;
-
-    last->next = page;
+    allocator->tail->next = page;
     allocator->tail = page;
   }
 


### PR DESCRIPTION
This PR changes the way we add pages in the arena allocator, instead of seeking to the tail page starting from the head, we directly use the tail page. 

Additionally this PR asserts that if the head page is null, the tail page also should be null.

Resolves https://github.com/marcoroth/herb/issues/1340