### PR TITLE
C: Use more sensible start capacity for `hb_array`

### DIFF
--- a/src/util/hb_array.c
+++ b/src/util/hb_array.c
@@ -39,7 +39,7 @@ bool hb_array_append(hb_array_T* array, void* item) {
     size_t new_capacity;
 
     if (array->capacity == 0) {
-      new_capacity = 1;
+      new_capacity = 8;
     } else if (array->capacity > SIZE_MAX / (2 * sizeof(void*))) {
       fprintf(stderr, "Warning: Approaching array size limits, using conservative growth.\n");
       new_capacity = array->capacity + 1024 / sizeof(void*);


### PR DESCRIPTION
This PR changes the start capacity of an array that previously had no capacity.

Instead of using 1, which only allocates a single slot, we allocate 8, which allows more room to grow. 

Given that the `hb_array` only holds pointers to its items, the memory usage is negligible.