### PR TITLE
Parser: Support Action View tag helpers with inline blocks

### DIFF
--- a/src/analyze/action_view/content_tag.c
+++ b/src/analyze/action_view/content_tag.c
@@ -38,23 +38,28 @@ char* extract_content_tag_name(pm_call_node_t* call_node, pm_parser_t* parser, h
 char* extract_content_tag_content(pm_call_node_t* call_node, pm_parser_t* parser, hb_allocator_T* allocator) {
   (void) parser;
 
-  if (!call_node || !call_node->arguments) { return NULL; }
+  if (!call_node) { return NULL; }
 
-  pm_arguments_node_t* arguments = call_node->arguments;
-  if (arguments->arguments.size < 2) { return NULL; }
+  if (call_node->arguments) {
+    pm_arguments_node_t* arguments = call_node->arguments;
 
-  pm_node_t* second_argument = arguments->arguments.nodes[1];
+    if (arguments->arguments.size >= 2) {
+      pm_node_t* second_argument = arguments->arguments.nodes[1];
 
-  if (second_argument->type == PM_KEYWORD_HASH_NODE) { return NULL; }
+      if (second_argument->type != PM_KEYWORD_HASH_NODE) {
+        if (second_argument->type == PM_STRING_NODE) {
+          pm_string_node_t* string_node = (pm_string_node_t*) second_argument;
+          size_t length = pm_string_length(&string_node->unescaped);
+          return hb_allocator_strndup(allocator, (const char*) pm_string_source(&string_node->unescaped), length);
+        }
 
-  if (second_argument->type == PM_STRING_NODE) {
-    pm_string_node_t* string_node = (pm_string_node_t*) second_argument;
-    size_t length = pm_string_length(&string_node->unescaped);
-    return hb_allocator_strndup(allocator, (const char*) pm_string_source(&string_node->unescaped), length);
+        size_t source_length = second_argument->location.end - second_argument->location.start;
+        return hb_allocator_strndup(allocator, (const char*) second_argument->location.start, source_length);
+      }
+    }
   }
 
-  size_t source_length = second_argument->location.end - second_argument->location.start;
-  return hb_allocator_strndup(allocator, (const char*) second_argument->location.start, source_length);
+  return extract_inline_block_content(call_node, allocator);
 }
 
 bool content_tag_supports_block(void) {

--- a/src/analyze/action_view/link_to.c
+++ b/src/analyze/action_view/link_to.c
@@ -56,7 +56,12 @@ char* extract_link_to_tag_name(pm_call_node_t* call_node, pm_parser_t* parser, h
 char* extract_link_to_content(pm_call_node_t* call_node, pm_parser_t* parser, hb_allocator_T* allocator) {
   (void) parser;
 
-  if (!call_node || !call_node->arguments) { return NULL; }
+  if (!call_node) { return NULL; }
+
+  char* block_content = extract_inline_block_content(call_node, allocator);
+  if (block_content) { return block_content; }
+
+  if (!call_node->arguments) { return NULL; }
 
   pm_arguments_node_t* arguments = call_node->arguments;
   if (!arguments->arguments.size) { return NULL; }
@@ -96,6 +101,25 @@ char* extract_link_to_href(pm_call_node_t* call_node, pm_parser_t* parser, hb_al
   if (!call_node || !call_node->arguments) { return NULL; }
 
   pm_arguments_node_t* arguments = call_node->arguments;
+  bool has_inline_block = call_node->block && call_node->block->type == PM_BLOCK_NODE;
+
+  if (has_inline_block && arguments->arguments.size >= 1) {
+    pm_node_t* first_argument = arguments->arguments.nodes[0];
+
+    if (first_argument->type == PM_STRING_NODE) {
+      pm_string_node_t* string_node = (pm_string_node_t*) first_argument;
+      size_t length = pm_string_length(&string_node->unescaped);
+      return hb_allocator_strndup(allocator, (const char*) pm_string_source(&string_node->unescaped), length);
+    }
+
+    size_t source_length = first_argument->location.end - first_argument->location.start;
+
+    if (is_route_helper_node(first_argument, parser)) {
+      return hb_allocator_strndup(allocator, (const char*) first_argument->location.start, source_length);
+    }
+
+    return wrap_in_url_for((const char*) first_argument->location.start, source_length, allocator);
+  }
 
   // Format: "url_for(<expression>)"
   if (arguments->arguments.size == 1) {

--- a/src/analyze/action_view/registry.c
+++ b/src/analyze/action_view/registry.c
@@ -58,3 +58,26 @@ tag_helper_handler_T* get_tag_helper_handlers(void) {
 size_t get_tag_helper_handlers_count(void) {
   return handlers_count;
 }
+
+char* extract_inline_block_content(pm_call_node_t* call_node, hb_allocator_T* allocator) {
+  if (!call_node || !call_node->block || call_node->block->type != PM_BLOCK_NODE) { return NULL; }
+
+  pm_block_node_t* block_node = (pm_block_node_t*) call_node->block;
+
+  if (!block_node->body || block_node->body->type != PM_STATEMENTS_NODE) { return NULL; }
+
+  pm_statements_node_t* statements = (pm_statements_node_t*) block_node->body;
+
+  if (statements->body.size != 1) { return NULL; }
+
+  pm_node_t* statement = statements->body.nodes[0];
+
+  if (statement->type == PM_STRING_NODE) {
+    pm_string_node_t* string_node = (pm_string_node_t*) statement;
+    size_t length = pm_string_length(&string_node->unescaped);
+    return hb_allocator_strndup(allocator, (const char*) pm_string_source(&string_node->unescaped), length);
+  }
+
+  size_t source_length = statement->location.end - statement->location.start;
+  return hb_allocator_strndup(allocator, (const char*) statement->location.start, source_length);
+}

--- a/src/analyze/action_view/tag.c
+++ b/src/analyze/action_view/tag.c
@@ -36,20 +36,23 @@ char* extract_tag_dot_name(pm_call_node_t* call_node, pm_parser_t* parser, hb_al
 char* extract_tag_dot_content(pm_call_node_t* call_node, pm_parser_t* parser, hb_allocator_T* allocator) {
   (void) parser;
 
-  if (!call_node || !call_node->arguments) { return NULL; }
+  if (!call_node) { return NULL; }
 
-  pm_arguments_node_t* arguments = call_node->arguments;
-  if (!arguments->arguments.size) { return NULL; }
+  if (call_node->arguments) {
+    pm_arguments_node_t* arguments = call_node->arguments;
 
-  pm_node_t* first_argument = arguments->arguments.nodes[0];
+    if (arguments->arguments.size) {
+      pm_node_t* first_argument = arguments->arguments.nodes[0];
 
-  if (first_argument->type == PM_STRING_NODE) {
-    pm_string_node_t* string_node = (pm_string_node_t*) first_argument;
-    size_t length = pm_string_length(&string_node->unescaped);
-    return hb_allocator_strndup(allocator, (const char*) pm_string_source(&string_node->unescaped), length);
+      if (first_argument->type == PM_STRING_NODE) {
+        pm_string_node_t* string_node = (pm_string_node_t*) first_argument;
+        size_t length = pm_string_length(&string_node->unescaped);
+        return hb_allocator_strndup(allocator, (const char*) pm_string_source(&string_node->unescaped), length);
+      }
+    }
   }
 
-  return NULL;
+  return extract_inline_block_content(call_node, allocator);
 }
 
 bool tag_dot_supports_block(void) {

--- a/src/analyze/action_view/tag_helpers.c
+++ b/src/analyze/action_view/tag_helpers.c
@@ -262,13 +262,29 @@ static AST_NODE_T* transform_tag_helper_with_attributes(
   if (parse_context->info->call_node && handler->extract_content) {
     helper_content = handler->extract_content(parse_context->info->call_node, &parse_context->parser, allocator);
 
-    if (helper_content && parse_context->info->call_node->arguments) {
-      if (strcmp(handler->name, "content_tag") == 0 && parse_context->info->call_node->arguments->arguments.size >= 2) {
-        content_is_ruby_expression =
-          (parse_context->info->call_node->arguments->arguments.nodes[1]->type != PM_STRING_NODE);
-      } else if (parse_context->info->call_node->arguments->arguments.size >= 1) {
-        content_is_ruby_expression =
-          (parse_context->info->call_node->arguments->arguments.nodes[0]->type != PM_STRING_NODE);
+    if (helper_content) {
+      pm_call_node_t* call = parse_context->info->call_node;
+
+      if (call->arguments) {
+        if (strcmp(handler->name, "content_tag") == 0 && call->arguments->arguments.size >= 2
+            && call->arguments->arguments.nodes[1]->type != PM_KEYWORD_HASH_NODE) {
+          content_is_ruby_expression = (call->arguments->arguments.nodes[1]->type != PM_STRING_NODE);
+        } else if (strcmp(handler->name, "content_tag") != 0 && call->arguments->arguments.size >= 1
+                   && call->arguments->arguments.nodes[0]->type != PM_KEYWORD_HASH_NODE) {
+          content_is_ruby_expression = (call->arguments->arguments.nodes[0]->type != PM_STRING_NODE);
+        }
+      }
+
+      if (!content_is_ruby_expression && call->block && call->block->type == PM_BLOCK_NODE) {
+        pm_block_node_t* block_node = (pm_block_node_t*) call->block;
+
+        if (block_node->body && block_node->body->type == PM_STATEMENTS_NODE) {
+          pm_statements_node_t* statements = (pm_statements_node_t*) block_node->body;
+
+          if (statements->body.size == 1) {
+            content_is_ruby_expression = (statements->body.nodes[0]->type != PM_STRING_NODE);
+          }
+        }
       }
     }
   }
@@ -492,7 +508,9 @@ static AST_NODE_T* transform_link_to_helper(
 
   hb_array_T* attributes = NULL;
   pm_arguments_node_t* link_arguments = info->call_node->arguments;
-  bool keyword_hash_is_url = link_arguments && link_arguments->arguments.size == 2
+  bool has_inline_block = info->call_node->block && info->call_node->block->type == PM_BLOCK_NODE;
+
+  bool keyword_hash_is_url = !has_inline_block && link_arguments && link_arguments->arguments.size == 2
                           && link_arguments->arguments.nodes[1]->type == PM_KEYWORD_HASH_NODE;
 
   if (!keyword_hash_is_url) {
@@ -549,7 +567,12 @@ static AST_NODE_T* transform_link_to_helper(
       pm_arguments_node_t* arguments = info->call_node->arguments;
       pm_node_t* href_argument = NULL;
 
-      if (arguments->arguments.size >= 2) {
+      if (has_inline_block) {
+        if (arguments->arguments.size >= 1) {
+          href_argument = arguments->arguments.nodes[0];
+          href_is_ruby_expression = (href_argument->type != PM_STRING_NODE);
+        }
+      } else if (arguments->arguments.size >= 2) {
         href_argument = arguments->arguments.nodes[1];
         href_is_ruby_expression = (href_argument->type != PM_STRING_NODE);
       } else if (arguments->arguments.size == 1) {
@@ -602,7 +625,17 @@ static AST_NODE_T* transform_link_to_helper(
   if (info->content) {
     bool content_is_ruby_expression = false;
 
-    if (info->call_node && info->call_node->arguments && info->call_node->arguments->arguments.size >= 1) {
+    if (has_inline_block && info->call_node->block && info->call_node->block->type == PM_BLOCK_NODE) {
+      pm_block_node_t* block_node = (pm_block_node_t*) info->call_node->block;
+
+      if (block_node->body && block_node->body->type == PM_STATEMENTS_NODE) {
+        pm_statements_node_t* statements = (pm_statements_node_t*) block_node->body;
+
+        if (statements->body.size == 1) {
+          content_is_ruby_expression = (statements->body.nodes[0]->type != PM_STRING_NODE);
+        }
+      }
+    } else if (info->call_node && info->call_node->arguments && info->call_node->arguments->arguments.size >= 1) {
       pm_node_t* first_argument = info->call_node->arguments->arguments.nodes[0];
       content_is_ruby_expression = (first_argument->type != PM_STRING_NODE);
     }

--- a/src/include/analyze/action_view/tag_helper_handler.h
+++ b/src/include/analyze/action_view/tag_helper_handler.h
@@ -38,4 +38,6 @@ void tag_helper_info_free(tag_helper_info_T** info);
 tag_helper_handler_T* get_tag_helper_handlers(void);
 size_t get_tag_helper_handlers_count(void);
 
+char* extract_inline_block_content(pm_call_node_t* call_node, hb_allocator_T* allocator);
+
 #endif

--- a/test/analyze/action_view/tag_helper/content_tag_test.rb
+++ b/test/analyze/action_view/tag_helper/content_tag_test.rb
@@ -149,5 +149,29 @@ module Analyze::ActionView::TagHelper
         <% end %>
       HTML
     end
+
+    test "content_tag with inline block" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <%= content_tag(:details) { "Some content" } %>
+      HTML
+    end
+
+    test "content_tag with inline block and attributes" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <%= content_tag(:div, class: "container") { "Hello" } %>
+      HTML
+    end
+
+    test "content_tag with inline block and ruby expression" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <%= content_tag(:p) { @user.name } %>
+      HTML
+    end
+
+    test "content_tag with inline block and symbol tag name" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <%= content_tag(:span) { "Text" } %>
+      HTML
+    end
   end
 end

--- a/test/analyze/action_view/tag_helper/tag_test.rb
+++ b/test/analyze/action_view/tag_helper/tag_test.rb
@@ -151,5 +151,29 @@ module Analyze::ActionView::TagHelper
         <% end %>
       HTML
     end
+
+    test "tag.details with inline block" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <%= tag.details { "Some content" } %>
+      HTML
+    end
+
+    test "tag.div with inline block and attributes" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <%= tag.div(class: "container") { "Hello" } %>
+      HTML
+    end
+
+    test "tag.p with inline block and ruby expression" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <%= tag.p { @user.name } %>
+      HTML
+    end
+
+    test "tag.span with inline block" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <%= tag.span { "Text" } %>
+      HTML
+    end
   end
 end

--- a/test/analyze/action_view/url_helper/link_to_test.rb
+++ b/test/analyze/action_view/url_helper/link_to_test.rb
@@ -221,5 +221,35 @@ module Analyze::ActionView::UrlHelper
         <% end %>
       HTML
     end
+
+    test "link_to with inline block" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <%= link_to("#") { "Click me" } %>
+      HTML
+    end
+
+    test "link_to with inline block and attributes" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <%= link_to("/about", class: "btn") { "About" } %>
+      HTML
+    end
+
+    test "link_to with inline block and data attributes" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <%= link_to("/profile", data: { turbo_method: "delete" }) { "Delete" } %>
+      HTML
+    end
+
+    test "link_to with inline block and path helper" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <%= link_to(root_path) { "Home" } %>
+      HTML
+    end
+
+    test "link_to with inline block and ruby expression" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <%= link_to("#") { @user.name } %>
+      HTML
+    end
   end
 end

--- a/test/snapshots/analyze/action_view/tag_helper/content_tag_test/test_0021_content_tag_with_inline_block_c40e688f117ff3e3a9124d87f9addbc9-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/content_tag_test/test_0021_content_tag_with_inline_block_c40e688f117ff3e3a9124d87f9addbc9-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,31 @@
+---
+source: "Analyze::ActionView::TagHelper::ContentTagTest#test_0021_content_tag with inline block"
+input: |2-
+<%= content_tag(:details) { "Some content" } %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:47))
+    │   ├── open_tag:
+    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:47))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " content_tag(:details) { "Some content" } " (location: (1:3)-(1:45))
+    │   │       ├── tag_closing: "%>" (location: (1:45)-(1:47))
+    │   │       ├── tag_name: "details" (location: (1:4)-(1:15))
+    │   │       └── children: []
+    │   │
+    │   ├── tag_name: "details" (location: (1:4)-(1:15))
+    │   ├── body: (1 item)
+    │   │   └── @ HTMLTextNode (location: (1:0)-(1:47))
+    │   │       └── content: "Some content"
+    │   │
+    │   ├── close_tag:
+    │   │   └── @ HTMLVirtualCloseTagNode (location: (1:47)-(1:47))
+    │   │       └── tag_name: "details" (location: (1:4)-(1:15))
+    │   │
+    │   ├── is_void: false
+    │   └── element_source: "ActionView::Helpers::TagHelper#content_tag"
+    │
+    └── @ HTMLTextNode (location: (1:47)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/action_view/tag_helper/content_tag_test/test_0022_content_tag_with_inline_block_and_attributes_c07f1d1ac960aadbe562770eb8d8821c-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/content_tag_test/test_0022_content_tag_with_inline_block_and_attributes_c07f1d1ac960aadbe562770eb8d8821c-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,51 @@
+---
+source: "Analyze::ActionView::TagHelper::ContentTagTest#test_0022_content_tag with inline block and attributes"
+input: |2-
+<%= content_tag(:div, class: "container") { "Hello" } %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:56))
+    │   ├── open_tag:
+    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:56))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " content_tag(:div, class: "container") { "Hello" } " (location: (1:3)-(1:54))
+    │   │       ├── tag_closing: "%>" (location: (1:54)-(1:56))
+    │   │       ├── tag_name: "div" (location: (1:4)-(1:15))
+    │   │       └── children: (1 item)
+    │   │           └── @ HTMLAttributeNode (location: (1:22)-(1:29))
+    │   │               ├── name:
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:22)-(1:29))
+    │   │               │       └── children: (1 item)
+    │   │               │           └── @ LiteralNode (location: (1:22)-(1:29))
+    │   │               │               └── content: "class"
+    │   │               │
+    │   │               │
+    │   │               ├── equals: "=" (location: (1:22)-(1:29))
+    │   │               └── value:
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:22)-(1:29))
+    │   │                       ├── open_quote: """ (location: (1:22)-(1:29))
+    │   │                       ├── children: (1 item)
+    │   │                       │   └── @ LiteralNode (location: (1:22)-(1:29))
+    │   │                       │       └── content: "container"
+    │   │                       │
+    │   │                       ├── close_quote: """ (location: (1:29)-(1:29))
+    │   │                       └── quoted: true
+    │   │
+    │   │
+    │   │
+    │   ├── tag_name: "div" (location: (1:4)-(1:15))
+    │   ├── body: (1 item)
+    │   │   └── @ HTMLTextNode (location: (1:0)-(1:56))
+    │   │       └── content: "Hello"
+    │   │
+    │   ├── close_tag:
+    │   │   └── @ HTMLVirtualCloseTagNode (location: (1:56)-(1:56))
+    │   │       └── tag_name: "div" (location: (1:4)-(1:15))
+    │   │
+    │   ├── is_void: false
+    │   └── element_source: "ActionView::Helpers::TagHelper#content_tag"
+    │
+    └── @ HTMLTextNode (location: (1:56)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/action_view/tag_helper/content_tag_test/test_0023_content_tag_with_inline_block_and_ruby_expression_97b60d7fa99f31312c8c76c5aed0c255-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/content_tag_test/test_0023_content_tag_with_inline_block_and_ruby_expression_97b60d7fa99f31312c8c76c5aed0c255-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,31 @@
+---
+source: "Analyze::ActionView::TagHelper::ContentTagTest#test_0023_content_tag with inline block and ruby expression"
+input: |2-
+<%= content_tag(:p) { @user.name } %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:37))
+    │   ├── open_tag:
+    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:37))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " content_tag(:p) { @user.name } " (location: (1:3)-(1:35))
+    │   │       ├── tag_closing: "%>" (location: (1:35)-(1:37))
+    │   │       ├── tag_name: "p" (location: (1:4)-(1:15))
+    │   │       └── children: []
+    │   │
+    │   ├── tag_name: "p" (location: (1:4)-(1:15))
+    │   ├── body: (1 item)
+    │   │   └── @ RubyLiteralNode (location: (1:0)-(1:37))
+    │   │       └── content: "@user.name"
+    │   │
+    │   ├── close_tag:
+    │   │   └── @ HTMLVirtualCloseTagNode (location: (1:37)-(1:37))
+    │   │       └── tag_name: "p" (location: (1:4)-(1:15))
+    │   │
+    │   ├── is_void: false
+    │   └── element_source: "ActionView::Helpers::TagHelper#content_tag"
+    │
+    └── @ HTMLTextNode (location: (1:37)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/action_view/tag_helper/content_tag_test/test_0024_content_tag_with_inline_block_and_symbol_tag_name_5db4803f72d733bc16e58542c9b83648-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/content_tag_test/test_0024_content_tag_with_inline_block_and_symbol_tag_name_5db4803f72d733bc16e58542c9b83648-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,31 @@
+---
+source: "Analyze::ActionView::TagHelper::ContentTagTest#test_0024_content_tag with inline block and symbol tag name"
+input: |2-
+<%= content_tag(:span) { "Text" } %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:36))
+    │   ├── open_tag:
+    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:36))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " content_tag(:span) { "Text" } " (location: (1:3)-(1:34))
+    │   │       ├── tag_closing: "%>" (location: (1:34)-(1:36))
+    │   │       ├── tag_name: "span" (location: (1:4)-(1:15))
+    │   │       └── children: []
+    │   │
+    │   ├── tag_name: "span" (location: (1:4)-(1:15))
+    │   ├── body: (1 item)
+    │   │   └── @ HTMLTextNode (location: (1:0)-(1:36))
+    │   │       └── content: "Text"
+    │   │
+    │   ├── close_tag:
+    │   │   └── @ HTMLVirtualCloseTagNode (location: (1:36)-(1:36))
+    │   │       └── tag_name: "span" (location: (1:4)-(1:15))
+    │   │
+    │   ├── is_void: false
+    │   └── element_source: "ActionView::Helpers::TagHelper#content_tag"
+    │
+    └── @ HTMLTextNode (location: (1:36)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0021_tag.details_with_inline_block_2c2937a180dc9992676fd6d030ce9595-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0021_tag.details_with_inline_block_2c2937a180dc9992676fd6d030ce9595-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,31 @@
+---
+source: "Analyze::ActionView::TagHelper::TagTest#test_0021_tag.details with inline block"
+input: |2-
+<%= tag.details { "Some content" } %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:37))
+    │   ├── open_tag:
+    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:37))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " tag.details { "Some content" } " (location: (1:3)-(1:35))
+    │   │       ├── tag_closing: "%>" (location: (1:35)-(1:37))
+    │   │       ├── tag_name: "details" (location: (1:8)-(1:15))
+    │   │       └── children: []
+    │   │
+    │   ├── tag_name: "details" (location: (1:8)-(1:15))
+    │   ├── body: (1 item)
+    │   │   └── @ HTMLTextNode (location: (1:0)-(1:37))
+    │   │       └── content: "Some content"
+    │   │
+    │   ├── close_tag:
+    │   │   └── @ HTMLVirtualCloseTagNode (location: (1:37)-(1:37))
+    │   │       └── tag_name: "details" (location: (1:8)-(1:15))
+    │   │
+    │   ├── is_void: false
+    │   └── element_source: "ActionView::Helpers::TagHelper#tag"
+    │
+    └── @ HTMLTextNode (location: (1:37)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0022_tag.div_with_inline_block_and_attributes_927cbf38c52485921360a2ba04bcf856-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0022_tag.div_with_inline_block_and_attributes_927cbf38c52485921360a2ba04bcf856-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,51 @@
+---
+source: "Analyze::ActionView::TagHelper::TagTest#test_0022_tag.div with inline block and attributes"
+input: |2-
+<%= tag.div(class: "container") { "Hello" } %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:46))
+    │   ├── open_tag:
+    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:46))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " tag.div(class: "container") { "Hello" } " (location: (1:3)-(1:44))
+    │   │       ├── tag_closing: "%>" (location: (1:44)-(1:46))
+    │   │       ├── tag_name: "div" (location: (1:8)-(1:11))
+    │   │       └── children: (1 item)
+    │   │           └── @ HTMLAttributeNode (location: (1:12)-(1:19))
+    │   │               ├── name:
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:12)-(1:19))
+    │   │               │       └── children: (1 item)
+    │   │               │           └── @ LiteralNode (location: (1:12)-(1:19))
+    │   │               │               └── content: "class"
+    │   │               │
+    │   │               │
+    │   │               ├── equals: "=" (location: (1:12)-(1:19))
+    │   │               └── value:
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:12)-(1:19))
+    │   │                       ├── open_quote: """ (location: (1:12)-(1:19))
+    │   │                       ├── children: (1 item)
+    │   │                       │   └── @ LiteralNode (location: (1:12)-(1:19))
+    │   │                       │       └── content: "container"
+    │   │                       │
+    │   │                       ├── close_quote: """ (location: (1:19)-(1:19))
+    │   │                       └── quoted: true
+    │   │
+    │   │
+    │   │
+    │   ├── tag_name: "div" (location: (1:8)-(1:11))
+    │   ├── body: (1 item)
+    │   │   └── @ HTMLTextNode (location: (1:0)-(1:46))
+    │   │       └── content: "Hello"
+    │   │
+    │   ├── close_tag:
+    │   │   └── @ HTMLVirtualCloseTagNode (location: (1:46)-(1:46))
+    │   │       └── tag_name: "div" (location: (1:8)-(1:11))
+    │   │
+    │   ├── is_void: false
+    │   └── element_source: "ActionView::Helpers::TagHelper#tag"
+    │
+    └── @ HTMLTextNode (location: (1:46)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0023_tag.p_with_inline_block_and_ruby_expression_bc15078c869718f854372b4bf111ee10-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0023_tag.p_with_inline_block_and_ruby_expression_bc15078c869718f854372b4bf111ee10-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,31 @@
+---
+source: "Analyze::ActionView::TagHelper::TagTest#test_0023_tag.p with inline block and ruby expression"
+input: |2-
+<%= tag.p { @user.name } %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:27))
+    │   ├── open_tag:
+    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:27))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " tag.p { @user.name } " (location: (1:3)-(1:25))
+    │   │       ├── tag_closing: "%>" (location: (1:25)-(1:27))
+    │   │       ├── tag_name: "p" (location: (1:8)-(1:9))
+    │   │       └── children: []
+    │   │
+    │   ├── tag_name: "p" (location: (1:8)-(1:9))
+    │   ├── body: (1 item)
+    │   │   └── @ RubyLiteralNode (location: (1:0)-(1:27))
+    │   │       └── content: "@user.name"
+    │   │
+    │   ├── close_tag:
+    │   │   └── @ HTMLVirtualCloseTagNode (location: (1:27)-(1:27))
+    │   │       └── tag_name: "p" (location: (1:8)-(1:9))
+    │   │
+    │   ├── is_void: false
+    │   └── element_source: "ActionView::Helpers::TagHelper#tag"
+    │
+    └── @ HTMLTextNode (location: (1:27)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0024_tag.span_with_inline_block_42e332c7e86750c83781d4b8f290d224-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0024_tag.span_with_inline_block_42e332c7e86750c83781d4b8f290d224-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,31 @@
+---
+source: "Analyze::ActionView::TagHelper::TagTest#test_0024_tag.span with inline block"
+input: |2-
+<%= tag.span { "Text" } %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:26))
+    │   ├── open_tag:
+    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:26))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " tag.span { "Text" } " (location: (1:3)-(1:24))
+    │   │       ├── tag_closing: "%>" (location: (1:24)-(1:26))
+    │   │       ├── tag_name: "span" (location: (1:8)-(1:12))
+    │   │       └── children: []
+    │   │
+    │   ├── tag_name: "span" (location: (1:8)-(1:12))
+    │   ├── body: (1 item)
+    │   │   └── @ HTMLTextNode (location: (1:0)-(1:26))
+    │   │       └── content: "Text"
+    │   │
+    │   ├── close_tag:
+    │   │   └── @ HTMLVirtualCloseTagNode (location: (1:26)-(1:26))
+    │   │       └── tag_name: "span" (location: (1:8)-(1:12))
+    │   │
+    │   ├── is_void: false
+    │   └── element_source: "ActionView::Helpers::TagHelper#tag"
+    │
+    └── @ HTMLTextNode (location: (1:26)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/action_view/url_helper/link_to_test/test_0035_link_to_with_inline_block_cfc32c059fb073a29a787ff10f75ebf3-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/url_helper/link_to_test/test_0035_link_to_with_inline_block_cfc32c059fb073a29a787ff10f75ebf3-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,51 @@
+---
+source: "Analyze::ActionView::UrlHelper::LinkToTest#test_0035_link_to with inline block"
+input: |2-
+<%= link_to("#") { "Click me" } %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:34))
+    │   ├── open_tag:
+    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:34))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " link_to("#") { "Click me" } " (location: (1:3)-(1:32))
+    │   │       ├── tag_closing: "%>" (location: (1:32)-(1:34))
+    │   │       ├── tag_name: "a" (location: (1:4)-(1:11))
+    │   │       └── children: (1 item)
+    │   │           └── @ HTMLAttributeNode (location: (1:12)-(1:15))
+    │   │               ├── name:
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:12)-(1:15))
+    │   │               │       └── children: (1 item)
+    │   │               │           └── @ LiteralNode (location: (1:12)-(1:15))
+    │   │               │               └── content: "href"
+    │   │               │
+    │   │               │
+    │   │               ├── equals: "=" (location: (1:12)-(1:15))
+    │   │               └── value:
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:12)-(1:15))
+    │   │                       ├── open_quote: """ (location: (1:12)-(1:15))
+    │   │                       ├── children: (1 item)
+    │   │                       │   └── @ LiteralNode (location: (1:12)-(1:15))
+    │   │                       │       └── content: "#"
+    │   │                       │
+    │   │                       ├── close_quote: """ (location: (1:15)-(1:15))
+    │   │                       └── quoted: true
+    │   │
+    │   │
+    │   │
+    │   ├── tag_name: "a" (location: (1:4)-(1:11))
+    │   ├── body: (1 item)
+    │   │   └── @ HTMLTextNode (location: (1:0)-(1:34))
+    │   │       └── content: "Click me"
+    │   │
+    │   ├── close_tag:
+    │   │   └── @ HTMLVirtualCloseTagNode (location: (1:34)-(1:34))
+    │   │       └── tag_name: "a" (location: (1:4)-(1:11))
+    │   │
+    │   ├── is_void: false
+    │   └── element_source: "ActionView::Helpers::UrlHelper#link_to"
+    │
+    └── @ HTMLTextNode (location: (1:34)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/action_view/url_helper/link_to_test/test_0036_link_to_with_inline_block_and_attributes_82dd05b7799745c34482d86f25410af4-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/url_helper/link_to_test/test_0036_link_to_with_inline_block_and_attributes_82dd05b7799745c34482d86f25410af4-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,71 @@
+---
+source: "Analyze::ActionView::UrlHelper::LinkToTest#test_0036_link_to with inline block and attributes"
+input: |2-
+<%= link_to("/about", class: "btn") { "About" } %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:50))
+    │   ├── open_tag:
+    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:50))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " link_to("/about", class: "btn") { "About" } " (location: (1:3)-(1:48))
+    │   │       ├── tag_closing: "%>" (location: (1:48)-(1:50))
+    │   │       ├── tag_name: "a" (location: (1:4)-(1:11))
+    │   │       └── children: (2 items)
+    │   │           ├── @ HTMLAttributeNode (location: (1:12)-(1:20))
+    │   │           │   ├── name:
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:12)-(1:20))
+    │   │           │   │       └── children: (1 item)
+    │   │           │   │           └── @ LiteralNode (location: (1:12)-(1:20))
+    │   │           │   │               └── content: "href"
+    │   │           │   │
+    │   │           │   │
+    │   │           │   ├── equals: "=" (location: (1:12)-(1:20))
+    │   │           │   └── value:
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:12)-(1:20))
+    │   │           │           ├── open_quote: """ (location: (1:12)-(1:20))
+    │   │           │           ├── children: (1 item)
+    │   │           │           │   └── @ LiteralNode (location: (1:12)-(1:20))
+    │   │           │           │       └── content: "/about"
+    │   │           │           │
+    │   │           │           ├── close_quote: """ (location: (1:20)-(1:20))
+    │   │           │           └── quoted: true
+    │   │           │
+    │   │           │
+    │   │           └── @ HTMLAttributeNode (location: (1:22)-(1:29))
+    │   │               ├── name:
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:22)-(1:29))
+    │   │               │       └── children: (1 item)
+    │   │               │           └── @ LiteralNode (location: (1:22)-(1:29))
+    │   │               │               └── content: "class"
+    │   │               │
+    │   │               │
+    │   │               ├── equals: "=" (location: (1:22)-(1:29))
+    │   │               └── value:
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:22)-(1:29))
+    │   │                       ├── open_quote: """ (location: (1:22)-(1:29))
+    │   │                       ├── children: (1 item)
+    │   │                       │   └── @ LiteralNode (location: (1:22)-(1:29))
+    │   │                       │       └── content: "btn"
+    │   │                       │
+    │   │                       ├── close_quote: """ (location: (1:29)-(1:29))
+    │   │                       └── quoted: true
+    │   │
+    │   │
+    │   │
+    │   ├── tag_name: "a" (location: (1:4)-(1:11))
+    │   ├── body: (1 item)
+    │   │   └── @ HTMLTextNode (location: (1:0)-(1:50))
+    │   │       └── content: "About"
+    │   │
+    │   ├── close_tag:
+    │   │   └── @ HTMLVirtualCloseTagNode (location: (1:50)-(1:50))
+    │   │       └── tag_name: "a" (location: (1:4)-(1:11))
+    │   │
+    │   ├── is_void: false
+    │   └── element_source: "ActionView::Helpers::UrlHelper#link_to"
+    │
+    └── @ HTMLTextNode (location: (1:50)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/action_view/url_helper/link_to_test/test_0037_link_to_with_inline_block_and_data_attributes_1689598922ad4d857d1c4d407d57ec48-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/url_helper/link_to_test/test_0037_link_to_with_inline_block_and_data_attributes_1689598922ad4d857d1c4d407d57ec48-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,71 @@
+---
+source: "Analyze::ActionView::UrlHelper::LinkToTest#test_0037_link_to with inline block and data attributes"
+input: |2-
+<%= link_to("/profile", data: { turbo_method: "delete" }) { "Delete" } %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:73))
+    │   ├── open_tag:
+    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:73))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " link_to("/profile", data: { turbo_method: "delete" }) { "Delete" } " (location: (1:3)-(1:71))
+    │   │       ├── tag_closing: "%>" (location: (1:71)-(1:73))
+    │   │       ├── tag_name: "a" (location: (1:4)-(1:11))
+    │   │       └── children: (2 items)
+    │   │           ├── @ HTMLAttributeNode (location: (1:12)-(1:22))
+    │   │           │   ├── name:
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:12)-(1:22))
+    │   │           │   │       └── children: (1 item)
+    │   │           │   │           └── @ LiteralNode (location: (1:12)-(1:22))
+    │   │           │   │               └── content: "href"
+    │   │           │   │
+    │   │           │   │
+    │   │           │   ├── equals: "=" (location: (1:12)-(1:22))
+    │   │           │   └── value:
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:12)-(1:22))
+    │   │           │           ├── open_quote: """ (location: (1:12)-(1:22))
+    │   │           │           ├── children: (1 item)
+    │   │           │           │   └── @ LiteralNode (location: (1:12)-(1:22))
+    │   │           │           │       └── content: "/profile"
+    │   │           │           │
+    │   │           │           ├── close_quote: """ (location: (1:22)-(1:22))
+    │   │           │           └── quoted: true
+    │   │           │
+    │   │           │
+    │   │           └── @ HTMLAttributeNode (location: (1:32)-(1:46))
+    │   │               ├── name:
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:32)-(1:46))
+    │   │               │       └── children: (1 item)
+    │   │               │           └── @ LiteralNode (location: (1:32)-(1:46))
+    │   │               │               └── content: "data-turbo-method"
+    │   │               │
+    │   │               │
+    │   │               ├── equals: "=" (location: (1:32)-(1:46))
+    │   │               └── value:
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:32)-(1:46))
+    │   │                       ├── open_quote: """ (location: (1:32)-(1:46))
+    │   │                       ├── children: (1 item)
+    │   │                       │   └── @ LiteralNode (location: (1:32)-(1:46))
+    │   │                       │       └── content: "delete"
+    │   │                       │
+    │   │                       ├── close_quote: """ (location: (1:46)-(1:46))
+    │   │                       └── quoted: true
+    │   │
+    │   │
+    │   │
+    │   ├── tag_name: "a" (location: (1:4)-(1:11))
+    │   ├── body: (1 item)
+    │   │   └── @ HTMLTextNode (location: (1:0)-(1:73))
+    │   │       └── content: "Delete"
+    │   │
+    │   ├── close_tag:
+    │   │   └── @ HTMLVirtualCloseTagNode (location: (1:73)-(1:73))
+    │   │       └── tag_name: "a" (location: (1:4)-(1:11))
+    │   │
+    │   ├── is_void: false
+    │   └── element_source: "ActionView::Helpers::UrlHelper#link_to"
+    │
+    └── @ HTMLTextNode (location: (1:73)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/action_view/url_helper/link_to_test/test_0038_link_to_with_inline_block_and_path_helper_091a412514e23ef8caa87f607b3600af-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/url_helper/link_to_test/test_0038_link_to_with_inline_block_and_path_helper_091a412514e23ef8caa87f607b3600af-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,51 @@
+---
+source: "Analyze::ActionView::UrlHelper::LinkToTest#test_0038_link_to with inline block and path helper"
+input: |2-
+<%= link_to(root_path) { "Home" } %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:36))
+    │   ├── open_tag:
+    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:36))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " link_to(root_path) { "Home" } " (location: (1:3)-(1:34))
+    │   │       ├── tag_closing: "%>" (location: (1:34)-(1:36))
+    │   │       ├── tag_name: "a" (location: (1:4)-(1:11))
+    │   │       └── children: (1 item)
+    │   │           └── @ HTMLAttributeNode (location: (1:12)-(1:21))
+    │   │               ├── name:
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:12)-(1:21))
+    │   │               │       └── children: (1 item)
+    │   │               │           └── @ LiteralNode (location: (1:12)-(1:21))
+    │   │               │               └── content: "href"
+    │   │               │
+    │   │               │
+    │   │               ├── equals: ":" (location: (1:12)-(1:21))
+    │   │               └── value:
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:12)-(1:21))
+    │   │                       ├── open_quote: ∅
+    │   │                       ├── children: (1 item)
+    │   │                       │   └── @ RubyLiteralNode (location: (1:12)-(1:21))
+    │   │                       │       └── content: "root_path"
+    │   │                       │
+    │   │                       ├── close_quote: ∅
+    │   │                       └── quoted: false
+    │   │
+    │   │
+    │   │
+    │   ├── tag_name: "a" (location: (1:4)-(1:11))
+    │   ├── body: (1 item)
+    │   │   └── @ HTMLTextNode (location: (1:0)-(1:36))
+    │   │       └── content: "Home"
+    │   │
+    │   ├── close_tag:
+    │   │   └── @ HTMLVirtualCloseTagNode (location: (1:36)-(1:36))
+    │   │       └── tag_name: "a" (location: (1:4)-(1:11))
+    │   │
+    │   ├── is_void: false
+    │   └── element_source: "ActionView::Helpers::UrlHelper#link_to"
+    │
+    └── @ HTMLTextNode (location: (1:36)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/action_view/url_helper/link_to_test/test_0039_link_to_with_inline_block_and_ruby_expression_73dbc51ff2212f96db547128feb69cab-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/url_helper/link_to_test/test_0039_link_to_with_inline_block_and_ruby_expression_73dbc51ff2212f96db547128feb69cab-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,51 @@
+---
+source: "Analyze::ActionView::UrlHelper::LinkToTest#test_0039_link_to with inline block and ruby expression"
+input: |2-
+<%= link_to("#") { @user.name } %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:34))
+    │   ├── open_tag:
+    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:34))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " link_to("#") { @user.name } " (location: (1:3)-(1:32))
+    │   │       ├── tag_closing: "%>" (location: (1:32)-(1:34))
+    │   │       ├── tag_name: "a" (location: (1:4)-(1:11))
+    │   │       └── children: (1 item)
+    │   │           └── @ HTMLAttributeNode (location: (1:12)-(1:15))
+    │   │               ├── name:
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:12)-(1:15))
+    │   │               │       └── children: (1 item)
+    │   │               │           └── @ LiteralNode (location: (1:12)-(1:15))
+    │   │               │               └── content: "href"
+    │   │               │
+    │   │               │
+    │   │               ├── equals: "=" (location: (1:12)-(1:15))
+    │   │               └── value:
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:12)-(1:15))
+    │   │                       ├── open_quote: """ (location: (1:12)-(1:15))
+    │   │                       ├── children: (1 item)
+    │   │                       │   └── @ LiteralNode (location: (1:12)-(1:15))
+    │   │                       │       └── content: "#"
+    │   │                       │
+    │   │                       ├── close_quote: """ (location: (1:15)-(1:15))
+    │   │                       └── quoted: true
+    │   │
+    │   │
+    │   │
+    │   ├── tag_name: "a" (location: (1:4)-(1:11))
+    │   ├── body: (1 item)
+    │   │   └── @ RubyLiteralNode (location: (1:0)-(1:34))
+    │   │       └── content: "@user.name"
+    │   │
+    │   ├── close_tag:
+    │   │   └── @ HTMLVirtualCloseTagNode (location: (1:34)-(1:34))
+    │   │       └── tag_name: "a" (location: (1:4)-(1:11))
+    │   │
+    │   ├── is_void: false
+    │   └── element_source: "ActionView::Helpers::UrlHelper#link_to"
+    │
+    └── @ HTMLTextNode (location: (1:34)-(2:0))
+        └── content: "\n"


### PR DESCRIPTION
This pull request adds support for detecting Action View tag helpers using inline brace block syntax (`{ }`) in addition to the existing `do...end` block syntax.

Previously, the parser only recognized multi-line block forms like:
```erb
<%= content_tag :div do %>
  Content
<% end %>
```

With this change, inline block forms are now also detected and transformed into `HTMLElementNode` representations:
```erb
<%= content_tag(:div) { "Content" } %>
```

Resolves #1369 