### PR TITLE
VS Code: Don't register Toggle Comment as global shortcut

### DIFF
--- a/javascript/packages/vscode/package.json
+++ b/javascript/packages/vscode/package.json
@@ -140,6 +140,16 @@
         "when": "false"
       },
       {
+        "command": "herb.toggleLineComment",
+        "title": "Herb: Toggle Line Comment",
+        "when": "editorLangId == erb"
+      },
+      {
+        "command": "herb.toggleBlockComment",
+        "title": "Herb: Toggle Block Comment",
+        "when": "editorLangId == erb"
+      },
+      {
         "command": "herb.toggleLinter",
         "title": "Herb: Toggle Linter",
         "icon": "$(symbol-boolean)"
@@ -158,6 +168,20 @@
         "command": "herb.setMaxLineLength",
         "title": "Herb: Set Max Line Length",
         "icon": "$(symbol-numeric)"
+      }
+    ],
+    "keybindings": [
+      {
+        "command": "herb.toggleLineComment",
+        "key": "ctrl+/",
+        "mac": "cmd+/",
+        "when": "editorTextFocus && editorLangId == erb"
+      },
+      {
+        "command": "herb.toggleBlockComment",
+        "key": "shift+alt+a",
+        "mac": "shift+alt+a",
+        "when": "editorTextFocus && editorLangId == erb"
       }
     ],
     "viewsContainers": {

--- a/javascript/packages/vscode/src/extension.ts
+++ b/javascript/packages/vscode/src/extension.ts
@@ -160,23 +160,19 @@ export async function activate(context: vscode.ExtensionContext) {
       await client.updateConfiguration()
     }),
 
-    vscode.commands.registerCommand('editor.action.commentLine', async () => {
+    vscode.commands.registerCommand('herb.toggleLineComment', async () => {
       const editor = vscode.window.activeTextEditor
 
-      if (editor?.document.languageId === 'erb') {
+      if (editor) {
         await sendCommentRequest(editor, 'herb/toggleLineComment')
-      } else {
-        await vscode.commands.executeCommand('default:editor.action.commentLine')
       }
     }),
 
-    vscode.commands.registerCommand('editor.action.blockComment', async () => {
+    vscode.commands.registerCommand('herb.toggleBlockComment', async () => {
       const editor = vscode.window.activeTextEditor
 
-      if (editor?.document.languageId === 'erb') {
+      if (editor) {
         await sendCommentRequest(editor, 'herb/toggleBlockComment')
-      } else {
-        await vscode.commands.executeCommand('default:editor.action.blockComment')
       }
     })
   )


### PR DESCRIPTION
This pull request fixes the Herb extension from globally overriding VS Code's built-in comment commands (`editor.action.commentLine` and `editor.action.blockComment`). 

Previously, the extension hijacked these commands for all file types and tried to fall back to the default behavior via `default:editor.action.commentLine` for non-ERB files, but that fallback mechanism isn't reliable. Instead we register our comment actions and assign them with a shortcut in ERB files.

Resolves #1405