### PR TITLE
Engine: Make sure `validate_ruby` also works on older Rubies

### DIFF
--- a/lib/herb/engine.rb
+++ b/lib/herb/engine.rb
@@ -148,15 +148,7 @@ module Herb
       @src << "; ensure\n  #{@bufvar} = __original_outvar\nend\n" if properties[:ensure]
 
       if properties.fetch(:validate_ruby, false)
-        require "prism"
-
-        prism_result = Prism.parse(@src)
-        syntax_errors = prism_result.errors.reject { |e| e.type == :invalid_yield }
-
-        if syntax_errors.any?
-          details = syntax_errors.map { |e| "  - #{e.message} (line #{e.location.start_line})" }.join("\n")
-          raise InvalidRubyError.new("Compiled template produced invalid Ruby:\n#{details}", compiled_source: @src)
-        end
+        ensure_valid_ruby!(@src)
       end
 
       @src.freeze
@@ -439,6 +431,28 @@ module Herb
     #: () -> Array[Herb::Visitor]
     def default_visitors
       []
+    end
+
+    def ensure_valid_ruby!(source)
+      RubyVM::InstructionSequence.compile(source)
+    rescue SyntaxError => e
+      return if e.message.include?("Invalid yield")
+
+      begin
+        require "prism"
+      rescue LoadError
+        # Prism not available, fall through
+      end
+
+      raise InvalidRubyError.new("Compiled template produced invalid Ruby:\n  - #{e.message}", compiled_source: @src) unless defined?(Prism)
+
+      prism_result = Prism.parse(@src)
+      syntax_errors = prism_result.errors.reject { |error| error.type == :invalid_yield }
+
+      if syntax_errors.any?
+        details = syntax_errors.map { |err| "  - #{err.message} (line #{err.location.start_line})" }.join("\n")
+        raise InvalidRubyError.new("Compiled template produced invalid Ruby:\n#{details}", compiled_source: @src)
+      end
     end
   end
 end

--- a/lib/herb/prism_inspect.rb
+++ b/lib/herb/prism_inspect.rb
@@ -9,7 +9,11 @@ module Herb
       def inspect_prism_serialized(serialized_bytes, source, prefix)
         return "∅" unless serialized_bytes
 
-        require "prism"
+        begin
+          require "prism"
+        rescue LoadError
+          return "(#{serialized_bytes.bytesize} bytes, prism gem not available)"
+        end
 
         node = Prism.load(source, serialized_bytes).value
         return "∅" unless node

--- a/sig/herb/engine.rbs
+++ b/sig/herb/engine.rbs
@@ -89,5 +89,7 @@ module Herb
 
     # : () -> Array[Herb::Visitor]
     def default_visitors: () -> Array[Herb::Visitor]
+
+    def ensure_valid_ruby!: (untyped source) -> untyped
   end
 end

--- a/sig/rubyvm.rbs
+++ b/sig/rubyvm.rbs
@@ -1,0 +1,5 @@
+class RubyVM
+  class InstructionSequence
+    def self.compile: (String source, ?String? file, ?String? path, ?Integer? line, ?freeze: bool, **untyped options) -> RubyVM::InstructionSequence
+  end
+end

--- a/templates/lib/herb/ast/nodes.rb.erb
+++ b/templates/lib/herb/ast/nodes.rb.erb
@@ -37,7 +37,13 @@ module Herb
         return nil unless prism_node
         return nil unless source
 
-        require "prism"
+        begin
+          require "prism"
+        rescue LoadError
+          warn "The 'prism' gem is required to deserialize Prism nodes. Add it to your Gemfile or install it with: gem install prism"
+          return nil
+        end
+
         Prism.load(source, prism_node).value
       end
 

--- a/test/engine/engine_test.rb
+++ b/test/engine/engine_test.rb
@@ -237,5 +237,35 @@ module Engine
 
       assert_compiled_snapshot(template)
     end
+
+    test "validate_ruby passes for valid Ruby" do
+      template = <<~ERB
+        <% if true %>
+          <div>Hello</div>
+        <% end %>
+      ERB
+
+      engine = Herb::Engine.new(template, validate_ruby: true)
+      assert engine.src
+    end
+
+    test "validate_ruby raises InvalidRubyError for invalid compiled Ruby" do
+      engine = Herb::Engine.allocate
+      engine.instance_variable_set(:@src, "def foo(")
+
+      error = assert_raises(Herb::Engine::InvalidRubyError) do
+        engine.send(:ensure_valid_ruby!, "def foo(")
+      end
+
+      assert_match(/Compiled template produced invalid Ruby/, error.message)
+      assert error.compiled_source
+    end
+
+    test "validate_ruby does not raise for valid compiled Ruby" do
+      engine = Herb::Engine.allocate
+      engine.instance_variable_set(:@src, "def foo; end")
+
+      engine.send(:ensure_valid_ruby!, "def foo; end")
+    end
   end
 end


### PR DESCRIPTION
This pull request updates the engine `validate_ruby` option to use `RubyVM::InstructionSequence.compile` to check for syntax errors, as valid syntax might be depended on the version of Ruby you are running.

Resolves #1401