### PR TITLE
Linter: Allow more types for `html-allowed-script-type` rule

### DIFF
--- a/javascript/packages/linter/src/rules/html-allowed-script-type.ts
+++ b/javascript/packages/linter/src/rules/html-allowed-script-type.ts
@@ -5,10 +5,10 @@ import { getTagLocalName, getAttribute, getStaticAttributeValue, hasAttributeVal
 import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types.js"
 import type { HTMLAttributeNode, HTMLOpenTagNode, ParseResult } from "@herb-tools/core"
 
-const ALLOWED_TYPES = ["text/javascript"]
 // NOTE: Rules are not configurable for now, keep some sane defaults
 //   See https://github.com/marcoroth/herb/issues/1204
 const ALLOW_BLANK = true
+const ALLOWED_TYPES = ["text/javascript", "module", "importmap", "speculationrules"]
 
 class AllowedScriptTypeVisitor extends BaseRuleVisitor {
   visitHTMLOpenTagNode(node: HTMLOpenTagNode): void {

--- a/javascript/packages/linter/test/rules/html-allowed-script-type.test.ts
+++ b/javascript/packages/linter/test/rules/html-allowed-script-type.test.ts
@@ -21,8 +21,20 @@ describe("html-allowed-script-type", () => {
     assertOffenses('<script type=""></script>')
   })
 
-  test("passes when type is allowed", () => {
+  test("passes when type is text/javascript", () => {
     expectNoOffenses('<script type="text/javascript"></script>')
+  })
+
+  test("passes when type is module", () => {
+    expectNoOffenses('<script type="module"></script>')
+  })
+
+  test("passes when type is importmap", () => {
+    expectNoOffenses('<script type="importmap"></script>')
+  })
+
+  test("passes when type is speculationrules", () => {
+    expectNoOffenses('<script type="speculationrules"></script>')
   })
 
   test("passes for script tag with ERB in type attribute", () => {
@@ -30,7 +42,7 @@ describe("html-allowed-script-type", () => {
   })
 
   test("fails when type is not allowed", () => {
-    expectError('Avoid using `text/yavascript` as the `type` attribute for the `<script>` tag. Must be one of: `text/javascript` or blank.')
+    expectError('Avoid using `text/yavascript` as the `type` attribute for the `<script>` tag. Must be one of: `text/javascript`, `module`, `importmap`, `speculationrules` or blank.')
 
     assertOffenses('<script type="text/yavascript"></script>')
   })


### PR DESCRIPTION
Resolves #1393