### PR TITLE
Linter: Support more cases for `erb-no-duplicate-branch-elements`

### DIFF
--- a/javascript/packages/language-server/src/server.ts
+++ b/javascript/packages/language-server/src/server.ts
@@ -186,6 +186,9 @@ export class Server {
 
       if (!document) return []
 
+      const parseResult = this.service.parserService.parseDocument(document)
+      if (parseResult.diagnostics.length > 0) return []
+
       const diagnostics = params.context.diagnostics
       const documentText = document.getText()
 

--- a/javascript/packages/linter/src/rules/erb-no-duplicate-branch-elements.ts
+++ b/javascript/packages/linter/src/rules/erb-no-duplicate-branch-elements.ts
@@ -4,6 +4,7 @@ import { IdentityPrinter } from "@herb-tools/printer"
 
 import {
   isHTMLElementNode,
+  isHTMLOpenTagNode,
   isERBIfNode,
   isERBElseNode,
   isERBUnlessNode,
@@ -27,10 +28,19 @@ type ConditionalNode = ERBIfNode | ERBUnlessNode | ERBCaseNode
 
 interface DuplicateBranchAutofixContext extends BaseAutofixContext {
   node: Mutable<ConditionalNode>
+  allIdentical?: boolean
 }
 
 function getSignificantNodes(statements: Node[]): Node[] {
   return statements.filter(node => !isPureWhitespaceNode(node))
+}
+
+function trimWhitespaceNodes(nodes: Node[]): Node[] {
+  let start = 0
+  let end = nodes.length
+  while (start < end && isPureWhitespaceNode(nodes[start])) start++
+  while (end > start && isPureWhitespaceNode(nodes[end - 1])) end--
+  return nodes.slice(start, end)
 }
 
 function allEquivalentElements(nodes: Node[]): nodes is HTMLElementNode[] {
@@ -172,8 +182,29 @@ class ERBNoDuplicateBranchElementsVisitor extends BaseRuleVisitor<DuplicateBranc
       this.markSubsequentIfNodesAsProcessed(node)
     }
 
+    if (this.allBranchesIdentical(branches)) {
+      this.addOffense(
+        "All branches of this conditional have identical content. The conditional can be removed.",
+        node.location,
+        { node: node as Mutable<ConditionalNode>, allIdentical: true },
+        "warning",
+      )
+
+      return
+    }
+
     const state = { isFirstOffense: true }
     this.checkBranches(branches, node, state)
+  }
+
+  private allBranchesIdentical(branches: Node[][]): boolean {
+    if (branches.length < 2) return false
+
+    const first = branches[0].map(node => IdentityPrinter.print(node)).join("")
+
+    return branches.slice(1).every(branch =>
+      branch.map(node => IdentityPrinter.print(node)).join("") === first
+    )
   }
 
   private markSubsequentIfNodesAsProcessed(node: ERBIfNode): void {
@@ -214,17 +245,37 @@ class ERBNoDuplicateBranchElementsVisitor extends BaseRuleVisitor<DuplicateBranc
 
     for (const element of elements) {
       const printed = IdentityPrinter.print(element.open_tag)
-      const autofixContext = state.isFirstOffense
-        ? { node: conditionalNode as Mutable<ConditionalNode> }
-        : undefined
 
-      this.addOffense(
-        `The \`${printed}\` element is duplicated across all branches of this conditional and can be moved outside.`,
-        bodiesMatch ? element.location : (element?.open_tag?.location || element.location),
-        autofixContext,
-      )
+      if (bodiesMatch) {
+        const autofixContext = state.isFirstOffense
+          ? { node: conditionalNode as Mutable<ConditionalNode> }
+          : undefined
 
-      state.isFirstOffense = false
+        this.addOffense(
+          `The \`${printed}\` element is duplicated across all branches of this conditional and can be moved outside.`,
+          element.location,
+          autofixContext,
+        )
+
+        state.isFirstOffense = false
+      } else {
+        const autofixContext = state.isFirstOffense
+          ? { node: conditionalNode as Mutable<ConditionalNode> }
+          : undefined
+
+        const tagNameLocation = isHTMLOpenTagNode(element.open_tag) && element.open_tag.tag_name?.location
+          ? element.open_tag.tag_name.location
+          : element?.open_tag?.location || element.location
+
+        this.addOffense(
+          `The \`${printed}\` tag is repeated across all branches with different content. Consider extracting the shared tag outside the conditional.`,
+          tagNameLocation,
+          autofixContext,
+          "hint",
+        )
+
+        state.isFirstOffense = false
+      }
     }
 
     if (!bodiesMatch && bodies.every(body => body.length > 0)) {
@@ -260,6 +311,18 @@ export class ERBNoDuplicateBranchElementsRule extends ParserRule<DuplicateBranch
     const branches = collectBranches(conditionalNode as ConditionalNode)
     if (!branches) return null
 
+    if (offense.autofixContext.allIdentical) {
+      const parentInfo = findParentArray(result.value, conditionalNode as unknown as Node)
+      if (!parentInfo) return null
+
+      const { array: parentArray, index: conditionalIndex } = parentInfo
+      const firstBranchContent = trimWhitespaceNodes(branches[0])
+
+      parentArray.splice(conditionalIndex, 1, ...firstBranchContent)
+
+      return result
+    }
+
     const significantBranches = branches.map(getSignificantNodes)
     if (significantBranches.some(branch => branch.length === 0)) return null
 
@@ -274,23 +337,56 @@ export class ERBNoDuplicateBranchElementsRule extends ParserRule<DuplicateBranch
 
     let { array: parentArray, index: conditionalIndex } = parentInfo
     let hasWrapped = false
+    let didMutate = false
+    let failedToHoistPrefix = false
+    let hoistedBefore = false
 
     const hoistElement = (elements: HTMLElementNode[], position: "before" | "after"): void => {
+      const actualPosition = (position === "before" && failedToHoistPrefix) ? "after" : position
       const bodiesMatch = elements.every(element => IdentityPrinter.print(element) === IdentityPrinter.print(elements[0]))
 
       if (bodiesMatch) {
+        if (actualPosition === "after") {
+          const currentLengths = branches.map(b => getSignificantNodes(b as Node[]).length)
+          if (currentLengths.some(l => l !== currentLengths[0])) return
+        }
+
+        if (actualPosition === "after" && position === "before") {
+          const isAtEnd = branches.every((branch, index) => {
+            const nodes = getSignificantNodes(branch as Node[])
+
+            return nodes.length > 0 && nodes[nodes.length - 1] === elements[index]
+          })
+
+          if (!isAtEnd) return
+        }
+
         for (let i = 0; i < branches.length; i++) {
           removeNodeFromArray(branches[i] as Node[], elements[i])
         }
 
-        if (position === "before") {
-          parentArray.splice(conditionalIndex, 0, elements[0])
-          conditionalIndex++
+        if (actualPosition === "before") {
+          parentArray.splice(conditionalIndex, 0, elements[0], createLiteral("\n"))
+          conditionalIndex += 2
+          hoistedBefore = true
         } else {
-          parentArray.splice(conditionalIndex + 1, 0, elements[0])
+          parentArray.splice(conditionalIndex + 1, 0, createLiteral("\n"), elements[0])
         }
+
+        didMutate = true
       } else {
         if (hasWrapped) return
+
+        const canWrap = branches.every((branch, index) => {
+          const remaining = getSignificantNodes(branch)
+
+          return remaining.length === 1 && remaining[0] === elements[index]
+        })
+
+        if (!canWrap) {
+          if (position === "before") failedToHoistPrefix = true
+          return
+        }
 
         for (let i = 0; i < branches.length; i++) {
           replaceNodeWithBody(branches[i] as Node[], elements[i])
@@ -302,6 +398,7 @@ export class ERBNoDuplicateBranchElementsRule extends ParserRule<DuplicateBranch
         parentArray = wrapper.body as Node[]
         conditionalIndex = 1
         hasWrapped = true
+        didMutate = true
       }
     }
 
@@ -315,6 +412,25 @@ export class ERBNoDuplicateBranchElementsRule extends ParserRule<DuplicateBranch
       hoistElement(elements, "after")
     }
 
-    return result
+    if (!hasWrapped && hoistedBefore) {
+      const remaining = branches.map(branch => getSignificantNodes(branch as Node[]))
+
+      if (remaining.every(branch => branch.length === 1) && allEquivalentElements(remaining.map(b => b[0]))) {
+        const elements = remaining.map(b => b[0] as HTMLElementNode)
+        const bodiesMatch = elements.every(el => IdentityPrinter.print(el) === IdentityPrinter.print(elements[0]))
+
+        if (!bodiesMatch && elements.every(el => el.body.length > 0)) {
+          for (let i = 0; i < branches.length; i++) {
+            replaceNodeWithBody(branches[i] as Node[], elements[i])
+          }
+
+          const wrapper = createWrapper(elements[0], [createLiteral("\n"), conditionalNode as unknown as Node, createLiteral("\n")])
+          parentArray[conditionalIndex] = wrapper
+          didMutate = true
+        }
+      }
+    }
+
+    return didMutate ? result : null
   }
 }

--- a/javascript/packages/linter/src/rules/rule-utils.ts
+++ b/javascript/packages/linter/src/rules/rule-utils.ts
@@ -27,6 +27,7 @@ import type {
 import { DEFAULT_LINT_CONTEXT } from "../types.js"
 
 import type * as Nodes from "@herb-tools/core"
+import type { DiagnosticTag } from "@herb-tools/core"
 import type { UnboundLintOffense, LintContext, LintSeverity, BaseAutofixContext } from "../types.js"
 
 export enum ControlFlowType {
@@ -53,7 +54,7 @@ export abstract class BaseRuleVisitor<TAutofixContext extends BaseAutofixContext
    * Helper method to create an unbound lint offense (without severity).
    * The Linter will bind severity based on the rule's config.
    */
-  protected createOffense(message: string, location: Location, autofixContext?: TAutofixContext, severity?: LintSeverity): UnboundLintOffense<TAutofixContext> {
+  protected createOffense(message: string, location: Location, autofixContext?: TAutofixContext, severity?: LintSeverity, tags?: DiagnosticTag[]): UnboundLintOffense<TAutofixContext> {
     return {
       rule: this.ruleName,
       code: this.ruleName,
@@ -62,14 +63,15 @@ export abstract class BaseRuleVisitor<TAutofixContext extends BaseAutofixContext
       location,
       autofixContext,
       severity,
+      tags,
     }
   }
 
   /**
    * Helper method to add an offense to the offenses array
    */
-  protected addOffense(message: string, location: Location, autofixContext?: TAutofixContext, severity?: LintSeverity): void {
-    this.offenses.push(this.createOffense(message, location, autofixContext, severity))
+  protected addOffense(message: string, location: Location, autofixContext?: TAutofixContext, severity?: LintSeverity, tags?: DiagnosticTag[]): void {
+    this.offenses.push(this.createOffense(message, location, autofixContext, severity, tags))
   }
 }
 
@@ -515,7 +517,7 @@ export abstract class BaseLexerRuleVisitor<TAutofixContext extends BaseAutofixCo
    * Helper method to create an unbound lint offense (without severity).
    * The Linter will bind severity based on the rule's config.
    */
-  protected createOffense(message: string, location: Location, autofixContext?: TAutofixContext, severity?: LintSeverity): UnboundLintOffense<TAutofixContext> {
+  protected createOffense(message: string, location: Location, autofixContext?: TAutofixContext, severity?: LintSeverity, tags?: DiagnosticTag[]): UnboundLintOffense<TAutofixContext> {
     return {
       rule: this.ruleName,
       code: this.ruleName,
@@ -524,14 +526,15 @@ export abstract class BaseLexerRuleVisitor<TAutofixContext extends BaseAutofixCo
       location,
       autofixContext,
       severity,
+      tags,
     }
   }
 
   /**
    * Helper method to add an offense to the offenses array
    */
-  protected addOffense(message: string, location: Location, autofixContext?: TAutofixContext, severity?: LintSeverity): void {
-    this.offenses.push(this.createOffense(message, location, autofixContext, severity))
+  protected addOffense(message: string, location: Location, autofixContext?: TAutofixContext, severity?: LintSeverity, tags?: DiagnosticTag[]): void {
+    this.offenses.push(this.createOffense(message, location, autofixContext, severity, tags))
   }
 
   /**
@@ -578,7 +581,7 @@ export abstract class BaseSourceRuleVisitor<TAutofixContext extends BaseAutofixC
    * Helper method to create an unbound lint offense (without severity).
    * The Linter will bind severity based on the rule's config.
    */
-  protected createOffense(message: string, location: Location, autofixContext?: TAutofixContext, severity?: LintSeverity): UnboundLintOffense<TAutofixContext> {
+  protected createOffense(message: string, location: Location, autofixContext?: TAutofixContext, severity?: LintSeverity, tags?: DiagnosticTag[]): UnboundLintOffense<TAutofixContext> {
     return {
       rule: this.ruleName,
       code: this.ruleName,
@@ -587,14 +590,15 @@ export abstract class BaseSourceRuleVisitor<TAutofixContext extends BaseAutofixC
       location,
       autofixContext,
       severity,
+      tags,
     }
   }
 
   /**
    * Helper method to add an offense to the offenses array
    */
-  protected addOffense(message: string, location: Location, autofixContext?: TAutofixContext, severity?: LintSeverity): void {
-    this.offenses.push(this.createOffense(message, location, autofixContext, severity))
+  protected addOffense(message: string, location: Location, autofixContext?: TAutofixContext, severity?: LintSeverity, tags?: DiagnosticTag[]): void {
+    this.offenses.push(this.createOffense(message, location, autofixContext, severity, tags))
   }
 
   /**

--- a/javascript/packages/linter/src/types.ts
+++ b/javascript/packages/linter/src/types.ts
@@ -1,5 +1,6 @@
 import { Diagnostic, LexResult, ParseResult, Location } from "@herb-tools/core"
 
+import type { DiagnosticTag } from "@herb-tools/core"
 import type { rules } from "./rules.js"
 import type { Node, ParserOptions } from "@herb-tools/core"
 import type { RuleConfig } from "@herb-tools/config"
@@ -111,7 +112,7 @@ export abstract class ParserRule<TAutofixContext extends BaseAutofixContext = Ba
     return DEFAULT_LINTER_PARSER_OPTIONS
   }
 
-  protected createOffense(message: string, location: Location, autofixContext?: TAutofixContext, severity?: LintSeverity): UnboundLintOffense<TAutofixContext> {
+  protected createOffense(message: string, location: Location, autofixContext?: TAutofixContext, severity?: LintSeverity, tags?: DiagnosticTag[]): UnboundLintOffense<TAutofixContext> {
     return {
       rule: this.ruleName,
       code: this.ruleName,
@@ -120,6 +121,7 @@ export abstract class ParserRule<TAutofixContext extends BaseAutofixContext = Ba
       location,
       autofixContext,
       severity,
+      tags,
     }
   }
 
@@ -164,7 +166,7 @@ export abstract class LexerRule<TAutofixContext extends BaseAutofixContext = Bas
     return DEFAULT_RULE_CONFIG
   }
 
-  protected createOffense(message: string, location: Location, autofixContext?: TAutofixContext, severity?: LintSeverity): UnboundLintOffense<TAutofixContext> {
+  protected createOffense(message: string, location: Location, autofixContext?: TAutofixContext, severity?: LintSeverity, tags?: DiagnosticTag[]): UnboundLintOffense<TAutofixContext> {
     return {
       rule: this.ruleName,
       code: this.ruleName,
@@ -173,6 +175,7 @@ export abstract class LexerRule<TAutofixContext extends BaseAutofixContext = Bas
       location,
       autofixContext,
       severity,
+      tags,
     }
   }
 
@@ -241,7 +244,7 @@ export abstract class SourceRule<TAutofixContext extends BaseAutofixContext = Ba
     return DEFAULT_RULE_CONFIG
   }
 
-  protected createOffense(message: string, location: Location, autofixContext?: TAutofixContext, severity?: LintSeverity): UnboundLintOffense<TAutofixContext> {
+  protected createOffense(message: string, location: Location, autofixContext?: TAutofixContext, severity?: LintSeverity, tags?: DiagnosticTag[]): UnboundLintOffense<TAutofixContext> {
     return {
       rule: this.ruleName,
       code: this.ruleName,
@@ -250,6 +253,7 @@ export abstract class SourceRule<TAutofixContext extends BaseAutofixContext = Ba
       location,
       autofixContext,
       severity,
+      tags,
     }
   }
 

--- a/javascript/packages/linter/test/autofix/erb-no-duplicate-branch-elements.autofix.test.ts
+++ b/javascript/packages/linter/test/autofix/erb-no-duplicate-branch-elements.autofix.test.ts
@@ -14,7 +14,7 @@ describe("erb-no-duplicate-branch-elements autofix", () => {
     return linter.autofix(input)
   }
 
-  describe("wrapping element (bodies differ)", () => {
+  describe("wrapping element (bodies differ, single element per branch)", () => {
     test("basic if/else with same wrapping div", () => {
       const input = dedent`
         <% if condition %>
@@ -120,59 +120,7 @@ describe("erb-no-duplicate-branch-elements autofix", () => {
       expect(result.fixed).toHaveLength(1)
       expect(result.unfixed).toHaveLength(2)
     })
-  })
 
-  describe("identical elements (bodies match)", () => {
-    test("common prefix elements hoisted before conditional", () => {
-      const input = dedent`
-        <% if condition %>
-          <header>Title</header>
-          <div>Hello</div>
-        <% else %>
-          <header>Title</header>
-          <span>World</span>
-        <% end %>
-      `
-
-      const result = autofix(input)
-
-      expect(result.source).toBe(dedent`
-        <header>Title</header><% if condition %>
-          <div>Hello</div>
-        <% else %>
-          <span>World</span>
-        <% end %>
-      `)
-      expect(result.fixed).toHaveLength(1)
-      expect(result.unfixed).toHaveLength(1)
-    })
-
-    test("common suffix elements hoisted after conditional", () => {
-      const input = dedent`
-        <% if condition %>
-          <div>Hello</div>
-          <footer>Bottom</footer>
-        <% else %>
-          <span>World</span>
-          <footer>Bottom</footer>
-        <% end %>
-      `
-
-      const result = autofix(input)
-
-      expect(result.source).toBe(dedent`
-        <% if condition %>
-          <div>Hello</div>
-        <% else %>
-          <span>World</span>
-        <% end %><footer>Bottom</footer>
-      `)
-      expect(result.fixed).toHaveLength(1)
-      expect(result.unfixed).toHaveLength(1)
-    })
-  })
-
-  describe("nested in element body", () => {
     test("works within element body", () => {
       const input = dedent`
         <main>
@@ -202,21 +150,349 @@ describe("erb-no-duplicate-branch-elements autofix", () => {
     })
   })
 
-  describe("offense without autofixContext", () => {
-    test("offenses without context are unfixed", () => {
+  describe("identical elements (bodies match)", () => {
+    test("common prefix elements hoisted before conditional", () => {
       const input = dedent`
         <% if condition %>
+          <header>Title</header>
           <div>Hello</div>
         <% else %>
-          <div>World</div>
+          <header>Title</header>
+          <span>World</span>
         <% end %>
       `
 
       const result = autofix(input)
 
+      expect(result.source).toBe(dedent`
+        <header>Title</header>
+        <% if condition %>
+          <div>Hello</div>
+        <% else %>
+          <span>World</span>
+        <% end %>
+      `)
+      expect(result.fixed).toHaveLength(1)
+      expect(result.unfixed).toHaveLength(1)
+    })
+
+    test("common suffix elements hoisted after conditional", () => {
+      const input = dedent`
+        <% if condition %>
+          <div>Hello</div>
+          <footer>Bottom</footer>
+        <% else %>
+          <span>World</span>
+          <footer>Bottom</footer>
+        <% end %>
+      `
+
+      const result = autofix(input)
+
+      expect(result.source).toBe(dedent`
+        <% if condition %>
+          <div>Hello</div>
+        <% else %>
+          <span>World</span>
+        <% end %>
+        <footer>Bottom</footer>
+      `)
       expect(result.fixed).toHaveLength(1)
       expect(result.unfixed).toHaveLength(1)
     })
   })
 
+  describe("multiple elements with different bodies", () => {
+    test("does not wrap when branches have multiple sibling elements with different bodies", () => {
+      const input = dedent`
+        <% if condition %>
+          <h3 class="title">Finish setting up</h3>
+          <p class="desc">Complete your setup.</p>
+          <div class="actions">
+            <a href="/setup">Setup</a>
+          </div>
+        <% else %>
+          <h3 class="title">No items</h3>
+          <p class="desc">Get started by creating one.</p>
+          <div class="actions">
+            <a href="/new">Create</a>
+          </div>
+        <% end %>
+      `
+
+      const result = autofix(input)
+
+      expect(result.source).toBe(input)
+      expect(result.fixed).toHaveLength(0)
+    })
+
+    test("wraps after identical prefix elements are hoisted", () => {
+      const input = dedent`
+        <% if condition %>
+          <header>Title</header>
+          <div class="wrapper">Content A</div>
+        <% else %>
+          <header>Title</header>
+          <div class="wrapper">Content B</div>
+        <% end %>
+      `
+
+      const result = autofix(input)
+
+      expect(result.source).toBe(dedent`
+        <header>Title</header>
+        <div class="wrapper">
+          <% if condition %>
+            Content A
+          <% else %>
+            Content B
+          <% end %>
+        </div>
+      `)
+      expect(result.fixed).toHaveLength(1)
+    })
+
+    test("identical prefix then different suffix: hoists prefix only", () => {
+      const input = dedent`
+        <% if condition %>
+          <header>Title</header>
+          <div class="wrapper-1">Content A</div>
+        <% else %>
+          <header>Title</header>
+          <div class="wrapper-2">Content B</div>
+        <% end %>
+      `
+
+      const result = autofix(input)
+
+      expect(result.source).toBe(dedent`
+        <header>Title</header>
+        <% if condition %>
+          <div class="wrapper-1">Content A</div>
+        <% else %>
+          <div class="wrapper-2">Content B</div>
+        <% end %>
+      `)
+      expect(result.fixed).toHaveLength(1)
+    })
+
+    test("different first element, identical second element: hoists second element after conditional", () => {
+      const input = dedent`
+        <% if condition? %>
+          <h1>Hello</h1>
+          <div><%= hello %></div>
+        <% else %>
+          <h1>World</h1>
+          <div><%= hello %></div>
+        <% end %>
+      `
+
+      const result = autofix(input)
+
+      expect(result.source).toBe(dedent`
+        <% if condition? %>
+          <h1>Hello</h1>
+        <% else %>
+          <h1>World</h1>
+        <% end %>
+        <div><%= hello %></div>
+      `)
+      expect(result.fixed).toHaveLength(1)
+      expect(result.unfixed).toHaveLength(3)
+    })
+
+    test("reversed content in branches: no autofix", () => {
+      const input = dedent`
+        <% if condition %>
+          <div>Hello</div>
+          <span>World</span>
+        <% else %>
+          <span>World</span>
+          <div>Hello</div>
+        <% end %>
+      `
+
+      const result = autofix(input)
+
+      expect(result.source).toBe(input)
+      expect(result.fixed).toHaveLength(0)
+    })
+
+    test("identical prefix and suffix elements hoisted before and after, remaining element wrapped", () => {
+      const input = dedent`
+        <% if condition? %>
+          <h1>Hello</h1>
+          <div>One</div>
+          <h1>World</h1>
+        <% else %>
+          <h1>Hello</h1>
+          <div>Two</div>
+          <h1>World</h1>
+        <% end %>
+      `
+
+      const result = autofix(input)
+
+      expect(result.source).toBe(dedent`
+        <h1>Hello</h1>
+        <div>
+          <% if condition? %>
+            One
+          <% else %>
+            Two
+          <% end %>
+        </div>
+        <h1>World</h1>
+      `)
+      expect(result.fixed).toHaveLength(1)
+    })
+
+    test("identical prefix hoisted before even when branches have different lengths", () => {
+      const input = dedent`
+        <% if condition? %>
+          <h1>Hello</h1>
+          <div><%= hello %></div>
+          <h1>World</h1>
+        <% else %>
+          <h1>Hello</h1> Text
+          <div><%= hello %></div>
+          <h1>World</h1>
+        <% end %>
+      `
+
+      const result = autofix(input)
+
+      expect(result.source).toBe(dedent`
+        <h1>Hello</h1>
+        <% if condition? %>
+          <div><%= hello %></div>
+          <h1>World</h1>
+        <% else %> Text
+          <div><%= hello %></div>
+          <h1>World</h1>
+        <% end %>
+      `)
+      expect(result.fixed).toHaveLength(1)
+    })
+
+    test("identical middle element with different surrounding elements: no autofix", () => {
+      const input = dedent`
+        <% if condition? %>
+          <h1>Hello</h1>
+          <div><%= hello %></div>
+          <h1>World</h1>
+        <% else %>
+          <h1>World</h1>
+          <div><%= hello %></div>
+          <h1>Hello</h1>
+        <% end %>
+      `
+
+      const result = autofix(input)
+
+      expect(result.source).toBe(input)
+      expect(result.fixed).toHaveLength(0)
+    })
+  })
+
+  describe("branches with ERB output nodes", () => {
+    test("div with different bodies not hoisted", () => {
+      const input = dedent`
+        <% if condition? %>
+          <% id = "one" %>
+          <div id="<%= id %>">One</div>
+        <% else %>
+          <% id = "two" %>
+          <div id="<%= id %>">Two</div>
+        <% end %>
+      `
+
+      const result = autofix(input)
+
+      expect(result.source).toBe(input)
+      expect(result.fixed).toHaveLength(0)
+    })
+
+    test("identical div suffix with erb attribute hoisted after conditional", () => {
+      const input = dedent`
+        <% if condition? %>
+          <% id = "one" %>
+          <div id="<%= id %>">One</div>
+        <% else %>
+          <% id = "two" %>
+          <div id="<%= id %>">One</div>
+        <% end %>
+      `
+
+      const result = autofix(input)
+
+      expect(result.source).toBe(dedent`
+        <% if condition? %>
+          <% id = "one" %>
+        <% else %>
+          <% id = "two" %>
+        <% end %>
+        <div id="<%= id %>">One</div>
+      `)
+      expect(result.fixed).toHaveLength(1)
+    })
+  })
+
+  describe("all branches identical", () => {
+    test("identical text content: removes conditional", () => {
+      const input = dedent`
+        <% if condition? %>
+          123
+        <% else %>
+          123
+        <% end %>
+      `
+
+      const result = autofix(input)
+
+      expect(result.source).toBe("\n123\n")
+      expect(result.fixed).toHaveLength(1)
+      expect(result.unfixed).toHaveLength(0)
+    })
+
+    test("identical elements: removes conditional", () => {
+      const input = dedent`
+        <% if condition? %>
+          <div><%= hello %></div>
+        <% else %>
+          <div><%= hello %></div>
+        <% end %>
+      `
+
+      const result = autofix(input)
+
+      expect(result.source).toBe("<div><%= hello %></div>")
+      expect(result.fixed).toHaveLength(1)
+      expect(result.unfixed).toHaveLength(0)
+    })
+
+    test("identical multi-element content: removes conditional", () => {
+      const input = dedent`
+        <% if condition? %>
+          <h1>Hello</h1>
+          <div><%= hello %></div>
+          <h1>World</h1>
+        <% else %>
+          <h1>Hello</h1>
+          <div><%= hello %></div>
+          <h1>World</h1>
+        <% end %>
+      `
+
+      const result = autofix(input)
+
+      expect(result.source).toBe(dedent`
+        <h1>Hello</h1>
+        <div><%= hello %></div>
+        <h1>World</h1>
+      `)
+      expect(result.fixed).toHaveLength(1)
+      expect(result.unfixed).toHaveLength(0)
+    })
+  })
 })

--- a/javascript/packages/linter/test/rules/erb-no-duplicate-branch-elements.test.ts
+++ b/javascript/packages/linter/test/rules/erb-no-duplicate-branch-elements.test.ts
@@ -4,7 +4,7 @@ import dedent from "dedent"
 import { ERBNoDuplicateBranchElementsRule } from "../../src/rules/erb-no-duplicate-branch-elements.js"
 import { createLinterTest } from "../helpers/linter-test-helper.js"
 
-const { expectNoOffenses, expectWarning, assertOffenses } = createLinterTest(ERBNoDuplicateBranchElementsRule)
+const { expectNoOffenses, expectWarning, expectHint, assertOffenses } = createLinterTest(ERBNoDuplicateBranchElementsRule)
 
 describe("erb-no-duplicate-branch-elements", () => {
   describe("no offense", () => {
@@ -58,6 +58,106 @@ describe("erb-no-duplicate-branch-elements", () => {
       `)
     })
 
+    it("branches with different text content", () => {
+      expectNoOffenses(dedent`
+        <% if condition %>
+          Hello
+        <% else %>
+          World
+        <% end %>
+      `)
+    })
+
+    it("branches with identical text content", () => {
+      expectWarning("All branches of this conditional have identical content. The conditional can be removed.")
+
+      assertOffenses(dedent`
+        <% if condition? %>
+          123
+        <% else %>
+          123
+        <% end %>
+      `)
+    })
+
+    it("branches with identical multi-element content", () => {
+      expectWarning("All branches of this conditional have identical content. The conditional can be removed.")
+
+      assertOffenses(dedent`
+        <% if condition? %>
+          <h1>Hello</h1>
+          <div><%= hello %></div>
+          <h1>World</h1>
+        <% else %>
+          <h1>Hello</h1>
+          <div><%= hello %></div>
+          <h1>World</h1>
+        <% end %>
+      `)
+    })
+
+    it("identical prefix, different middle, identical suffix", () => {
+      expectWarning("The `<h1>` element is duplicated across all branches of this conditional and can be moved outside.")
+      expectWarning("The `<h1>` element is duplicated across all branches of this conditional and can be moved outside.")
+      expectHint("The `<div>` tag is repeated across all branches with different content. Consider extracting the shared tag outside the conditional.")
+      expectHint("The `<div>` tag is repeated across all branches with different content. Consider extracting the shared tag outside the conditional.")
+      expectWarning("The `<h1>` element is duplicated across all branches of this conditional and can be moved outside.")
+      expectWarning("The `<h1>` element is duplicated across all branches of this conditional and can be moved outside.")
+
+      assertOffenses(dedent`
+        <% if condition? %>
+          <h1>Hello</h1>
+          <div>One</div>
+          <h1>World</h1>
+        <% else %>
+          <h1>Hello</h1>
+          <div>Two</div>
+          <h1>World</h1>
+        <% end %>
+      `)
+    })
+
+    it("branches with different prefix and identical suffix element", () => {
+      expectHint("The `<h1>` tag is repeated across all branches with different content. Consider extracting the shared tag outside the conditional.")
+      expectHint("The `<h1>` tag is repeated across all branches with different content. Consider extracting the shared tag outside the conditional.")
+      expectWarning("The `<div>` element is duplicated across all branches of this conditional and can be moved outside.")
+      expectWarning("The `<div>` element is duplicated across all branches of this conditional and can be moved outside.")
+
+      assertOffenses(dedent`
+        <% if condition? %>
+          <h1>Hello</h1>
+          <div><%= hello %></div>
+        <% else %>
+          <h1>World</h1>
+          <div><%= hello %></div>
+        <% end %>
+      `)
+    })
+
+    it("branches with identical elements containing ERB output", () => {
+      expectWarning("All branches of this conditional have identical content. The conditional can be removed.")
+
+      assertOffenses(dedent`
+        <% if condition? %>
+          <div><%= hello %></div>
+        <% else %>
+          <div><%= hello %></div>
+        <% end %>
+      `)
+    })
+
+    it("branches with identical ERB output", () => {
+      expectWarning("All branches of this conditional have identical content. The conditional can be removed.")
+
+      assertOffenses(dedent`
+        <% if condition? %>
+          <%= hello %>
+        <% else %>
+          <%= hello %>
+        <% end %>
+      `)
+    })
+
     it("unless without else (incomplete coverage)", () => {
       expectNoOffenses(dedent`
         <% unless condition %>
@@ -80,8 +180,8 @@ describe("erb-no-duplicate-branch-elements", () => {
 
   describe("offense: if/else", () => {
     it("basic case with same wrapping div", () => {
-      expectWarning("The `<div>` element is duplicated across all branches of this conditional and can be moved outside.")
-      expectWarning("The `<div>` element is duplicated across all branches of this conditional and can be moved outside.")
+      expectHint("The `<div>` tag is repeated across all branches with different content. Consider extracting the shared tag outside the conditional.")
+      expectHint("The `<div>` tag is repeated across all branches with different content. Consider extracting the shared tag outside the conditional.")
 
       assertOffenses(dedent`
         <% if condition %>
@@ -93,8 +193,8 @@ describe("erb-no-duplicate-branch-elements", () => {
     })
 
     it("case with same wrapping div but different whitesapce", () => {
-      expectWarning("The `<div class=\"card\">` element is duplicated across all branches of this conditional and can be moved outside.")
-      expectWarning("The `<div class=\"card\">` element is duplicated across all branches of this conditional and can be moved outside.")
+      expectHint("The `<div class=\"card\">` tag is repeated across all branches with different content. Consider extracting the shared tag outside the conditional.")
+      expectHint("The `<div class=\"card\">` tag is repeated across all branches with different content. Consider extracting the shared tag outside the conditional.")
 
       assertOffenses(dedent`
         <% if condition %>
@@ -108,8 +208,8 @@ describe("erb-no-duplicate-branch-elements", () => {
     })
 
     it("case with same wrapping div but attributes in different order", () => {
-      expectWarning("The `<div id=\"one\" class=\"card\">` element is duplicated across all branches of this conditional and can be moved outside.")
-      expectWarning("The `<div class=\"card\" id=\"one\">` element is duplicated across all branches of this conditional and can be moved outside.")
+      expectHint("The `<div id=\"one\" class=\"card\">` tag is repeated across all branches with different content. Consider extracting the shared tag outside the conditional.")
+      expectHint("The `<div class=\"card\" id=\"one\">` tag is repeated across all branches with different content. Consider extracting the shared tag outside the conditional.")
 
       assertOffenses(dedent`
         <% if condition %>
@@ -123,8 +223,8 @@ describe("erb-no-duplicate-branch-elements", () => {
     })
 
     it("case with same classes in different order", () => {
-      expectWarning("The `<div class=\"b a\">` element is duplicated across all branches of this conditional and can be moved outside.")
-      expectWarning("The `<div class=\"a b\">` element is duplicated across all branches of this conditional and can be moved outside.")
+      expectHint("The `<div class=\"b a\">` tag is repeated across all branches with different content. Consider extracting the shared tag outside the conditional.")
+      expectHint("The `<div class=\"a b\">` tag is repeated across all branches with different content. Consider extracting the shared tag outside the conditional.")
 
       assertOffenses(dedent`
         <% if condition %>
@@ -136,8 +236,8 @@ describe("erb-no-duplicate-branch-elements", () => {
     })
 
     it("case with same data-controller tokens in different order", () => {
-      expectWarning("The `<div data-controller=\"b a\">` element is duplicated across all branches of this conditional and can be moved outside.")
-      expectWarning("The `<div data-controller=\"a b\">` element is duplicated across all branches of this conditional and can be moved outside.")
+      expectHint("The `<div data-controller=\"b a\">` tag is repeated across all branches with different content. Consider extracting the shared tag outside the conditional.")
+      expectHint("The `<div data-controller=\"a b\">` tag is repeated across all branches with different content. Consider extracting the shared tag outside the conditional.")
 
       assertOffenses(dedent`
         <% if condition %>
@@ -159,8 +259,8 @@ describe("erb-no-duplicate-branch-elements", () => {
     })
 
     it("case with same wrapping div but differnt attribute formatting", () => {
-      expectWarning("The `<div class=\"\n    card\n  \">` element is duplicated across all branches of this conditional and can be moved outside.")
-      expectWarning("The `<div class=\"card\">` element is duplicated across all branches of this conditional and can be moved outside.")
+      expectHint("The `<div class=\"\n    card\n  \">` tag is repeated across all branches with different content. Consider extracting the shared tag outside the conditional.")
+      expectHint("The `<div class=\"card\">` tag is repeated across all branches with different content. Consider extracting the shared tag outside the conditional.")
 
       assertOffenses(dedent`
         <% if condition %>
@@ -174,13 +274,42 @@ describe("erb-no-duplicate-branch-elements", () => {
         <% end %>
       `)
     })
+
+    it("fully identical elements trigger identical branches warning", () => {
+      expectWarning("All branches of this conditional have identical content. The conditional can be removed.")
+
+      assertOffenses(dedent`
+        <% if condition %>
+          <div>Same</div>
+        <% else %>
+          <div>Same</div>
+        <% end %>
+      `)
+    })
+
+    it("identical elements with different bodies are per-element warnings", () => {
+      expectWarning("The `<div>` element is duplicated across all branches of this conditional and can be moved outside.")
+      expectWarning("The `<div>` element is duplicated across all branches of this conditional and can be moved outside.")
+      expectHint("The `<span>` tag is repeated across all branches with different content. Consider extracting the shared tag outside the conditional.")
+      expectHint("The `<span>` tag is repeated across all branches with different content. Consider extracting the shared tag outside the conditional.")
+
+      assertOffenses(dedent`
+        <% if condition %>
+          <div>Hello</div>
+          <span>unique to if</span>
+        <% else %>
+          <div>Hello</div>
+          <span>unique to else</span>
+        <% end %>
+      `)
+    })
   })
 
   describe("offense: if/elsif/else", () => {
     it("same wrapping element in all branches", () => {
-      expectWarning("The `<div>` element is duplicated across all branches of this conditional and can be moved outside.")
-      expectWarning("The `<div>` element is duplicated across all branches of this conditional and can be moved outside.")
-      expectWarning("The `<div>` element is duplicated across all branches of this conditional and can be moved outside.")
+      expectHint("The `<div>` tag is repeated across all branches with different content. Consider extracting the shared tag outside the conditional.")
+      expectHint("The `<div>` tag is repeated across all branches with different content. Consider extracting the shared tag outside the conditional.")
+      expectHint("The `<div>` tag is repeated across all branches with different content. Consider extracting the shared tag outside the conditional.")
 
       assertOffenses(dedent`
         <% if condition %>
@@ -196,8 +325,8 @@ describe("erb-no-duplicate-branch-elements", () => {
 
   describe("offense: unless/else", () => {
     it("same wrapping element", () => {
-      expectWarning("The `<div>` element is duplicated across all branches of this conditional and can be moved outside.")
-      expectWarning("The `<div>` element is duplicated across all branches of this conditional and can be moved outside.")
+      expectHint("The `<div>` tag is repeated across all branches with different content. Consider extracting the shared tag outside the conditional.")
+      expectHint("The `<div>` tag is repeated across all branches with different content. Consider extracting the shared tag outside the conditional.")
 
       assertOffenses(dedent`
         <% unless condition %>
@@ -211,9 +340,9 @@ describe("erb-no-duplicate-branch-elements", () => {
 
   describe("offense: case/when/else", () => {
     it("same wrapping element", () => {
-      expectWarning("The `<div>` element is duplicated across all branches of this conditional and can be moved outside.")
-      expectWarning("The `<div>` element is duplicated across all branches of this conditional and can be moved outside.")
-      expectWarning("The `<div>` element is duplicated across all branches of this conditional and can be moved outside.")
+      expectHint("The `<div>` tag is repeated across all branches with different content. Consider extracting the shared tag outside the conditional.")
+      expectHint("The `<div>` tag is repeated across all branches with different content. Consider extracting the shared tag outside the conditional.")
+      expectHint("The `<div>` tag is repeated across all branches with different content. Consider extracting the shared tag outside the conditional.")
 
       assertOffenses(dedent`
         <% case value %>
@@ -264,10 +393,10 @@ describe("erb-no-duplicate-branch-elements", () => {
 
   describe("offense: recursive descent", () => {
     it("flags both outer and inner common elements", () => {
-      expectWarning("The `<div>` element is duplicated across all branches of this conditional and can be moved outside.")
-      expectWarning("The `<div>` element is duplicated across all branches of this conditional and can be moved outside.")
-      expectWarning("The `<p>` element is duplicated across all branches of this conditional and can be moved outside.")
-      expectWarning("The `<p>` element is duplicated across all branches of this conditional and can be moved outside.")
+      expectHint("The `<div>` tag is repeated across all branches with different content. Consider extracting the shared tag outside the conditional.")
+      expectHint("The `<div>` tag is repeated across all branches with different content. Consider extracting the shared tag outside the conditional.")
+      expectHint("The `<p>` tag is repeated across all branches with different content. Consider extracting the shared tag outside the conditional.")
+      expectHint("The `<p>` tag is repeated across all branches with different content. Consider extracting the shared tag outside the conditional.")
 
       assertOffenses(dedent`
         <% if condition %>
@@ -279,8 +408,8 @@ describe("erb-no-duplicate-branch-elements", () => {
     })
 
     it("flags only outer common elements", () => {
-      expectWarning("The `<div>` element is duplicated across all branches of this conditional and can be moved outside.")
-      expectWarning("The `<div>` element is duplicated across all branches of this conditional and can be moved outside.")
+      expectHint("The `<div>` tag is repeated across all branches with different content. Consider extracting the shared tag outside the conditional.")
+      expectHint("The `<div>` tag is repeated across all branches with different content. Consider extracting the shared tag outside the conditional.")
 
       assertOffenses(dedent`
         <% if condition %>
@@ -304,10 +433,10 @@ describe("erb-no-duplicate-branch-elements", () => {
 
   describe("offense: nested conditionals flagged independently", () => {
     it("each conditional is checked separately", () => {
-      expectWarning("The `<div>` element is duplicated across all branches of this conditional and can be moved outside.")
-      expectWarning("The `<div>` element is duplicated across all branches of this conditional and can be moved outside.")
-      expectWarning("The `<span>` element is duplicated across all branches of this conditional and can be moved outside.")
-      expectWarning("The `<span>` element is duplicated across all branches of this conditional and can be moved outside.")
+      expectHint("The `<div>` tag is repeated across all branches with different content. Consider extracting the shared tag outside the conditional.")
+      expectHint("The `<div>` tag is repeated across all branches with different content. Consider extracting the shared tag outside the conditional.")
+      expectHint("The `<span>` tag is repeated across all branches with different content. Consider extracting the shared tag outside the conditional.")
+      expectHint("The `<span>` tag is repeated across all branches with different content. Consider extracting the shared tag outside the conditional.")
 
       assertOffenses(dedent`
         <% if outer %>


### PR DESCRIPTION
Resolves #1395