### PR TITLE
Linter: Re-export linter rule utils from `core`

### DIFF
--- a/javascript/packages/core/src/ast-utils.ts
+++ b/javascript/packages/core/src/ast-utils.ts
@@ -188,7 +188,7 @@ export function hasStaticAttributeName(attributeNameNode: HTMLAttributeNameNode)
 /**
  * Checks if an HTML attribute name node has dynamic content (contains ERB)
  */
-export function hasDynamicAttributeName(attributeNameNode: HTMLAttributeNameNode): boolean {
+export function hasDynamicAttributeNameNode(attributeNameNode: HTMLAttributeNameNode): boolean {
   if (!attributeNameNode.children) {
     return false
   }
@@ -383,12 +383,11 @@ export function hasAttribute(node: HTMLElementNode | HTMLOpenTagNode | null | un
 
 /**
  * Checks if an attribute has a dynamic (ERB-containing) name.
- * Accepts an HTMLAttributeNode (wraps the core HTMLAttributeNameNode-level check).
  */
-export function hasDynamicAttributeNameOnAttribute(attributeNode: HTMLAttributeNode): boolean {
+export function hasDynamicAttributeName(attributeNode: HTMLAttributeNode): boolean {
   if (!isHTMLAttributeNameNode(attributeNode.name)) return false
 
-  return hasDynamicAttributeName(attributeNode.name)
+  return hasDynamicAttributeNameNode(attributeNode.name)
 }
 
 /**

--- a/javascript/packages/core/test/ast-utils.test.ts
+++ b/javascript/packages/core/test/ast-utils.test.ts
@@ -15,7 +15,7 @@ import {
   getValidatableStaticContent,
   getCombinedStringFromNodes,
   hasStaticAttributeName,
-  hasDynamicAttributeName,
+  hasDynamicAttributeNameNode,
   getStaticAttributeName,
   getCombinedAttributeName,
   Location,
@@ -359,14 +359,14 @@ describe("ast-utils", () => {
     })
   })
 
-  describe("hasDynamicAttributeName", () => {
+  describe("hasDynamicAttributeNameNode", () => {
     test("returns true for attribute with ERB children", () => {
       const attributeNode = createAttributeNameNode([
         createLiteralNode("data-"),
         createERBContentNode("<%=", "name")
       ])
 
-      expect(hasDynamicAttributeName(attributeNode)).toBe(true)
+      expect(hasDynamicAttributeNameNode(attributeNode)).toBe(true)
     })
 
     test("returns false for attribute with only literal children", () => {
@@ -375,14 +375,14 @@ describe("ast-utils", () => {
         createLiteralNode("-test")
       ])
 
-      expect(hasDynamicAttributeName(attributeNode)).toBe(false)
+      expect(hasDynamicAttributeNameNode(attributeNode)).toBe(false)
     })
 
     test("returns false for attribute without children", () => {
       const attributeNode = createAttributeNameNode([])
       attributeNode.children = undefined as any
 
-      expect(hasDynamicAttributeName(attributeNode)).toBe(false)
+      expect(hasDynamicAttributeNameNode(attributeNode)).toBe(false)
     })
   })
 

--- a/javascript/packages/linter/src/index.ts
+++ b/javascript/packages/linter/src/index.ts
@@ -4,3 +4,24 @@ export * from "./types.js"
 
 export { ruleDocumentationUrl } from "./urls.js"
 export { rules } from "./rules.js"
+
+export {
+  findAttributeByName,
+  getAttribute,
+  getAttributeName,
+  getAttributes,
+  getAttributeValue,
+  getAttributeValueNodes,
+  getAttributeValueQuoteType,
+  getCombinedAttributeNameString,
+  getStaticAttributeValue,
+  getStaticAttributeValueContent,
+  getTagName,
+  hasAttribute,
+  hasAttributeValue,
+  hasDynamicAttributeName,
+  hasDynamicAttributeValue,
+  hasStaticAttributeValue,
+  hasStaticAttributeValueContent,
+  isAttributeValueQuoted,
+} from "@herb-tools/core"

--- a/javascript/packages/linter/src/rules/rule-utils.ts
+++ b/javascript/packages/linter/src/rules/rule-utils.ts
@@ -7,7 +7,7 @@ import {
   getValidatableStaticContent,
   getAttributeName,
   getStaticAttributeValue,
-  hasDynamicAttributeNameOnAttribute as hasDynamicAttributeName,
+  hasDynamicAttributeName,
   getCombinedAttributeNameString,
   getAttributeValueNodes,
   getAttributeValue,


### PR DESCRIPTION
Resolves #1394