### PR TITLE
Engine: Delegate `add_expression_block` for Erubi compatibility

### DIFF
--- a/lib/herb/engine.rb
+++ b/lib/herb/engine.rb
@@ -230,11 +230,17 @@ module Herb
       @buffer_on_stack = false
     end
 
+    def expression_block?
+      @_in_expression_block || false
+    end
+
     def add_expression(indicator, code)
-      if (indicator == "=") ^ @escape
-        add_expression_result(code)
+      unescaped = (indicator == "=") ^ @escape
+
+      if expression_block?
+        unescaped ? add_expression_block_result(code) : add_expression_block_result_escaped(code)
       else
-        add_expression_result_escaped(code)
+        unescaped ? add_expression_result(code) : add_expression_result_escaped(code)
       end
     end
 
@@ -251,39 +257,48 @@ module Herb
     end
 
     def add_expression_block(indicator, code)
-      if (indicator == "=") ^ @escape
-        add_expression_block_result(code)
-      else
-        add_expression_block_result_escaped(code)
-      end
+      @_in_expression_block = true
+      @_expression_block_open_paren = false
+
+      add_expression(indicator, code)
+    ensure
+      @_in_expression_block = false
     end
 
     def add_expression_block_result(code)
+      @_expression_block_open_paren = true
+
       with_buffer {
         @src << " << (" << code << trailing_newline(code)
       }
     end
 
     def add_expression_block_result_escaped(code)
+      @_expression_block_open_paren = true
+
       with_buffer {
         @src << " << " << @escapefunc << "((" << code << trailing_newline(code)
       }
     end
 
     def add_expression_block_end(code, escaped: false)
-      terminate_expression
+      if @_expression_block_open_paren
+        terminate_expression
 
-      trailing_newline = code.end_with?("\n")
-      code_stripped = code.chomp
+        trailing_newline = code.end_with?("\n")
+        code_stripped = code.chomp
 
-      @src.chomp! if @src.end_with?("\n") && code_stripped.start_with?(" ")
+        @src.chomp! if @src.end_with?("\n") && code_stripped.start_with?(" ")
 
-      @src << " " << code_stripped
-      @src << "\n" if self.class.comment?(code_stripped)
-      @src << (escaped ? "))" : ")")
-      @src << (trailing_newline ? "\n" : ";")
+        @src << " " << code_stripped
+        @src << "\n" if self.class.comment?(code_stripped)
+        @src << (escaped ? "))" : ")")
+        @src << (trailing_newline ? "\n" : ";")
 
-      @buffer_on_stack = false
+        @buffer_on_stack = false
+      else
+        add_code(code)
+      end
     end
 
     def trailing_newline(code)

--- a/sig/herb/engine.rbs
+++ b/sig/herb/engine.rbs
@@ -51,6 +51,8 @@ module Herb
 
     def add_code: (untyped code) -> untyped
 
+    def expression_block?: () -> untyped
+
     def add_expression: (untyped indicator, untyped code) -> untyped
 
     def add_expression_result: (untyped code) -> untyped

--- a/test/engine/rails_compatibility_test.rb
+++ b/test/engine/rails_compatibility_test.rb
@@ -8,8 +8,6 @@ require_relative "../../lib/herb/engine"
 module Engine
   class RailsCompatibilityTest < Minitest::Spec
     class RailsHerb < ::Herb::Engine
-      BLOCK_EXPR = /((\s|\))do|\{)(\s*\|[^|]*\|)?\s*\Z/
-
       def initialize(input, properties = {})
         @newline_pending = 0
 
@@ -47,17 +45,21 @@ module Engine
         flush_newline_if_pending(@src)
 
         with_buffer do
-          @src << if ((indicator == "==") && !@escape) || ((indicator == "=") && @escape)
-                    ".append="
-                  else
-                    ".safe_expr_append="
-                  end
+          @src << expression_append_method(indicator)
 
-          if BLOCK_EXPR.match?(code)
+          if expression_block?
             @src << " " << code
           else
             @src << "(" << code << ")"
           end
+        end
+      end
+
+      def expression_append_method(indicator)
+        if ((indicator == "==") && !@escape) || ((indicator == "=") && @escape)
+          ".append="
+        else
+          ".safe_expr_append="
         end
       end
 
@@ -154,6 +156,19 @@ module Engine
       engine = RailsHerb.new(template, escape: true)
 
       assert_equal " @output_buffer.safe_append='<h1>'.freeze; @output_buffer.append=(@title); @output_buffer.safe_append='</h1>'.freeze;\n@output_buffer", engine.src
+    end
+
+    test "rails erb handler output block expressions use add_expression override" do
+      template = '<%= link_to "/path", class: "btn" do %>Click me<% end %>'
+
+      engine = RailsHerb.new(template, escape: true)
+
+      assert_includes engine.src, ".append="
+      refute_includes engine.src, " << "
+
+      result = Prism.parse(engine.src)
+      syntax_errors = result.errors.reject { |e| e.type == :invalid_yield }
+      assert syntax_errors.empty?, "Compiled output is not valid Ruby: #{syntax_errors.map(&:message).join(", ")}"
     end
 
     test "drop-in replacement compatibility" do


### PR DESCRIPTION
This pull request updates `add_expression_block` in the `Herb::Engine` to delegate to `add_expression` instead of dispatching directly to block result methods. This makes `Herb::Engine` a true drop-in replacement for `Erubi::Engine` when subclassed.

Previously, subclasses that overrode `add_expression` (like ActionView's Erubi handler does) would not have their override apply to block expressions, because `add_expression_block` bypassed `add_expression` entirely. This meant subclasses also had to override `add_expression_block` and `add_expression_block_end` to handle blocks correctly. This pattern led to bugs like unmatched closing parentheses.

Now, `add_expression_block` sets an `expression_block?` flag and delegates to `add_expression`. The default `add_expression` checks this flag to route to the appropriate block result methods, preserving the correct `<< (code do ... end)` output for standalone usage.

A new `@_expression_block_open_paren` flag tracks whether the opening method added a parenthesis, so `add_expression_block_end` knows whether to close with `)` or just emit `end` as regular code.

When no methods are overridden, the default `add_expression` routes block expressions to the existing `add_expression_block_result` methods, preserving Herb's smart block handling with proper parenthesization.

When a subclass overrides only `add_expression`, the same pattern ActionView uses with Erubi, block expressions now flow through that override automatically. The `expression_block?` predicate lets the subclass distinguish blocks from regular expressions without relying on a `BLOCK_EXPR` regex, since the parser already knows.

When a subclass overrides `add_expression_block` directly, that override takes precedence and the delegation never happens.

Related https://github.com/marcoroth/reactionview/pull/83
Related https://github.com/marcoroth/reactionview/pull/84