### PR TITLE
C: Fix `hb_string_T` compiler warnings

### DIFF
--- a/src/analyze/action_view/tag_helpers.c
+++ b/src/analyze/action_view/tag_helpers.c
@@ -695,7 +695,7 @@ static AST_NODE_T* transform_erb_block_to_tag_helper(
 
       size_t content_length = end_offset - start_offset;
       char* raw_copy = hb_allocator_strndup(allocator, context->source + start_offset, content_length);
-      hb_string_T raw_content = { .data = raw_copy, .length = content_length };
+      hb_string_T raw_content = { .data = raw_copy, .length = (uint32_t) content_length };
 
       AST_LITERAL_NODE_T* literal_node =
         ast_literal_node_init(raw_content, body_start, body_end, hb_array_init(0, allocator), allocator);

--- a/src/include/util/hb_string.h
+++ b/src/include/util/hb_string.h
@@ -15,7 +15,7 @@ typedef struct HB_STRING_STRUCT {
   uint32_t length;
 } hb_string_T;
 
-#define HB_STRING_EMPTY ((hb_string_T) { .data = "", .length = 0 })
+#define HB_STRING_EMPTY ((hb_string_T) { .data = (char*) "", .length = 0 })
 #define HB_STRING_NULL ((hb_string_T) { .data = NULL, .length = 0 })
 
 #define HB_STRING_LITERAL(string) { .data = (char*) (string), .length = (uint32_t) (sizeof(string) - 1) }


### PR DESCRIPTION
This pull request address the following `hb_string_T` casting warnings when running `bundle exec rake compile`
```
compiling ../../../../ext/herb/../../src/parser.c
../../../../ext/herb/../../src/parser.c:322:31: warning: initializing 'char *' with an expression of type 'const char[1]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
  322 |       ast_html_text_node_init(HB_STRING_EMPTY, start, parser->current_token->location.start, errors, parser->allocator);
      |                               ^~~~~~~~~~~~~~~
../../../../ext/herb/../../src/include/analyze/../util/hb_string.h:18:50: note: expanded from macro 'HB_STRING_EMPTY'
   18 | #define HB_STRING_EMPTY ((hb_string_T) { .data = "", .length = 0 })
      |                                                  ^~
1 warning generated.
compiling ../../../../ext/herb/../../src/parser_helpers.c
../../../../ext/herb/../../src/parser_helpers.c:75:21: warning: initializing 'char *' with an expression of type 'const char[1]' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
   75 |     default: return HB_STRING_EMPTY;
      |                     ^~~~~~~~~~~~~~~
../../../../ext/herb/../../src/include/analyze/../util/hb_string.h:18:50: note: expanded from macro 'HB_STRING_EMPTY'
   18 | #define HB_STRING_EMPTY ((hb_string_T) { .data = "", .length = 0 })
      |                                                  ^~
1 warning generated.
```

```
compiling ../../../../ext/herb/../../src/analyze/action_view/tag_helpers.c
../../../../ext/herb/../../src/analyze/action_view/tag_helpers.c:698:63: warning: implicit conversion loses integer precision: 'size_t' (aka 'unsigned long') to 'uint32_t' (aka 'unsigned int') [-Wshorten-64-to-32]
  698 |       hb_string_T raw_content = { .data = raw_copy, .length = content_length };
      |                                 ~                             ^~~~~~~~~~~~~~
1 warning generated.
```