### PR TITLE
Parser: Don't search for Action View Tag Helpers recursively

### DIFF
--- a/src/analyze/action_view/tag_helpers.c
+++ b/src/analyze/action_view/tag_helpers.c
@@ -127,6 +127,8 @@ bool search_tag_helper_node(const pm_node_t* node, void* data) {
         return true;
       }
     }
+
+    return false;
   }
 
   pm_visit_child_nodes(node, search_tag_helper_node, search_data);

--- a/test/analyze/action_view/tag_helper/content_tag_test.rb
+++ b/test/analyze/action_view/tag_helper/content_tag_test.rb
@@ -217,5 +217,11 @@ module Analyze::ActionView::TagHelper
         <%= content_tag :script, "alert('Hello')", type: "application/javascript" %>
       HTML
     end
+
+    test "content_tag nested as argument to another method is not incorrectly detected as top-level tag helper" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <%= t(".terms_notice", link: content_tag(:a, t(".terms_of_service"), href: terms_path)).html_safe %>
+      HTML
+    end
   end
 end

--- a/test/analyze/action_view/tag_helper/tag_test.rb
+++ b/test/analyze/action_view/tag_helper/tag_test.rb
@@ -221,5 +221,35 @@ module Analyze::ActionView::TagHelper
         <%= tag.script src: "/assets/application.js", defer: true %>
       HTML
     end
+
+    test "tag.div nested inside unknown helper block is not incorrectly detected as top-level tag helper" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <%= my_component(data: @items) do |component|
+          component.with_slot do
+            tag.div class: "container" do
+              link_to("Click", url_path)
+            end
+          end
+        end %>
+      HTML
+    end
+
+    test "tag helpers nested inside lambda inside unknown helper are not incorrectly detected" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <%= my_table(data: @things) do |table|
+          table.with_column(value: lambda do |thing|
+            tag.div class: "flex" do
+              link_to(thing.name, thing_path(thing))
+            end
+          end)
+        end %>
+      HTML
+    end
+
+    test "tag.meta nested as argument to content_for is not incorrectly detected as top-level tag helper" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <% content_for :head, tag.meta(name: "viewport", content: "width=device-width, initial-scale=1") %>
+      HTML
+    end
   end
 end

--- a/test/snapshots/analyze/action_view/tag_helper/content_tag_test/test_0032_content_tag_nested_as_argument_to_another_method_is_not_incorrectly_detected_as_top-level_tag_helper_344731c2d70775305e3f7744a16f2a1e-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/content_tag_test/test_0032_content_tag_nested_as_argument_to_another_method_is_not_incorrectly_detected_as_top-level_tag_helper_344731c2d70775305e3f7744a16f2a1e-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,17 @@
+---
+source: "Analyze::ActionView::TagHelper::ContentTagTest#test_0032_content_tag nested as argument to another method is not incorrectly detected as top-level tag helper"
+input: |2-
+<%= t(".terms_notice", link: content_tag(:a, t(".terms_of_service"), href: terms_path)).html_safe %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ ERBContentNode (location: (1:0)-(1:100))
+    │   ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   ├── content: " t(".terms_notice", link: content_tag(:a, t(".terms_of_service"), href: terms_path)).html_safe " (location: (1:3)-(1:98))
+    │   ├── tag_closing: "%>" (location: (1:98)-(1:100))
+    │   ├── parsed: true
+    │   └── valid: true
+    │
+    └── @ HTMLTextNode (location: (1:100)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0032_tag.div_nested_inside_unknown_helper_block_is_not_incorrectly_detected_as_top-level_tag_helper_ef9f1ab8c52461760dc551efdc83bca6-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0032_tag.div_nested_inside_unknown_helper_block_is_not_incorrectly_detected_as_top-level_tag_helper_ef9f1ab8c52461760dc551efdc83bca6-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,29 @@
+---
+source: "Analyze::ActionView::TagHelper::TagTest#test_0032_tag.div nested inside unknown helper block is not incorrectly detected as top-level tag helper"
+input: |2-
+<%= my_component(data: @items) do |component|
+  component.with_slot do
+    tag.div class: "container" do
+      link_to("Click", url_path)
+    end
+  end
+end %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(8:0))
+└── children: (2 items)
+    ├── @ ERBContentNode (location: (1:0)-(7:6))
+    │   ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   ├── content: " my_component(data: @items) do |component|
+    │     component.with_slot do
+    │       tag.div class: "container" do
+    │         link_to("Click", url_path)
+    │       end
+    │     end
+    │   end " (location: (1:3)-(7:4))
+    │   ├── tag_closing: "%>" (location: (7:4)-(7:6))
+    │   ├── parsed: true
+    │   └── valid: true
+    │
+    └── @ HTMLTextNode (location: (7:6)-(8:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0033_tag_helpers_nested_inside_lambda_inside_unknown_helper_are_not_incorrectly_detected_b883fe75cdcaabb4d70714e419d632d9-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0033_tag_helpers_nested_inside_lambda_inside_unknown_helper_are_not_incorrectly_detected_b883fe75cdcaabb4d70714e419d632d9-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,29 @@
+---
+source: "Analyze::ActionView::TagHelper::TagTest#test_0033_tag helpers nested inside lambda inside unknown helper are not incorrectly detected"
+input: |2-
+<%= my_table(data: @things) do |table|
+  table.with_column(value: lambda do |thing|
+    tag.div class: "flex" do
+      link_to(thing.name, thing_path(thing))
+    end
+  end)
+end %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(8:0))
+└── children: (2 items)
+    ├── @ ERBContentNode (location: (1:0)-(7:6))
+    │   ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   ├── content: " my_table(data: @things) do |table|
+    │     table.with_column(value: lambda do |thing|
+    │       tag.div class: "flex" do
+    │         link_to(thing.name, thing_path(thing))
+    │       end
+    │     end)
+    │   end " (location: (1:3)-(7:4))
+    │   ├── tag_closing: "%>" (location: (7:4)-(7:6))
+    │   ├── parsed: true
+    │   └── valid: true
+    │
+    └── @ HTMLTextNode (location: (7:6)-(8:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0034_tag.meta_nested_as_argument_to_content_for_is_not_incorrectly_detected_as_top-level_tag_helper_44a9ce7b1c6c56530f4e7bf3b31d59d7-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0034_tag.meta_nested_as_argument_to_content_for_is_not_incorrectly_detected_as_top-level_tag_helper_44a9ce7b1c6c56530f4e7bf3b31d59d7-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,17 @@
+---
+source: "Analyze::ActionView::TagHelper::TagTest#test_0034_tag.meta nested as argument to content_for is not incorrectly detected as top-level tag helper"
+input: |2-
+<% content_for :head, tag.meta(name: "viewport", content: "width=device-width, initial-scale=1") %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ ERBContentNode (location: (1:0)-(1:99))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
+    │   ├── content: " content_for :head, tag.meta(name: "viewport", content: "width=device-width, initial-scale=1") " (location: (1:2)-(1:97))
+    │   ├── tag_closing: "%>" (location: (1:97)-(1:99))
+    │   ├── parsed: true
+    │   └── valid: true
+    │
+    └── @ HTMLTextNode (location: (1:99)-(2:0))
+        └── content: "\n"


### PR DESCRIPTION
This pull request fixes a bug in the parser analysis phase with `action_view_helpers: true` enabled where `search_tag_helper_node` would recursively traverse the entire Prism AST of an ERB expression, causing tag helpers nested inside another call's arguments or block body to be incorrectly detected and transformed as the top-level tag helper.

For example, the following template:

```erb
<% content_for :head, tag.meta(name: "viewport", content: "width=device-width, initial-scale=1") %>
```

Would incorrectly transform the `ERBContentNode` as if `tag.meta` were the outermost call. It now correctly produces the following using `action_view_helpers: true`:

```js
@ DocumentNode (location: (1:0)-(2:0))
└── children: (2 items)
    ├── @ ERBContentNode (location: (1:0)-(1:99))
    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
    │   ├── content: " content_for :head, tag.meta(name: "viewport", content: "width=device-width, initial-scale=1") " (location: (1:2)-(1:97))
    │   ├── tag_closing: "%>" (location: (1:97)-(1:99))
    │   ├── parsed: true
    │   └── valid: true
    │
    └── @ HTMLTextNode (location: (1:99)-(2:0))
        └── content: "\n"
```

The fix stops recursion at any `PM_CALL_NODE` that doesn't match a known tag helper. A tag helper must be the outermost call in the ERB expression, not nested inside another call's arguments or block body.

Resolves #1423
Resolves #1429 