### PR TITLE
Linter: Make `html-no-self-closing` Action View Helper aware

### DIFF
--- a/javascript/packages/linter/src/rules/html-no-self-closing.ts
+++ b/javascript/packages/linter/src/rules/html-no-self-closing.ts
@@ -3,7 +3,7 @@ import { isVoidElement, findParent, BaseRuleVisitor } from "./rule-utils.js"
 import { getTagName, getTagLocalName, isWhitespaceNode, Location, HTMLCloseTagNode } from "@herb-tools/core"
 
 import type { UnboundLintOffense, LintContext, LintOffense, FullRuleConfig } from "../types.js"
-import type { Node, HTMLOpenTagNode, HTMLElementNode, SerializedToken, ParseResult } from "@herb-tools/core"
+import type { Node, HTMLOpenTagNode, HTMLElementNode, SerializedToken, ParseResult, ParserOptions } from "@herb-tools/core"
 
 interface NoSelfClosingAutofixContext extends BaseAutofixContext {
   node: Mutable<HTMLOpenTagNode>
@@ -48,6 +48,10 @@ export class HTMLNoSelfClosingRule extends ParserRule<NoSelfClosingAutofixContex
       severity: "error",
       exclude: ["**/views/**/*_mailer/**/*"]
     }
+  }
+
+  get parserOptions(): Partial<ParserOptions> {
+    return { action_view_helpers: true }
   }
 
   check(result: ParseResult, context?: Partial<LintContext>): UnboundLintOffense<NoSelfClosingAutofixContext>[] {

--- a/javascript/packages/linter/test/rules/html-no-self-closing.test.ts
+++ b/javascript/packages/linter/test/rules/html-no-self-closing.test.ts
@@ -130,6 +130,14 @@ describe("html-no-self-closing", () => {
     `)
   })
 
+  test("passes for self-closing elements inside tag.svg helper", () => {
+    expectNoOffenses(`
+      <%= tag.svg(height:, width:) do %>
+        <path d="M29.396,2.303 L27.867,2.924 L25.13,18.045 L25.735,18.571 L27.167,18.045 L29.953,2.781 z" fill="currentColor" />
+      <% end %>
+    `)
+  })
+
   describe("ActionMailer exclusion", () => {
     test("excludes ActionMailer view files without any config", () => {
       const linter = Linter.from(Herb)


### PR DESCRIPTION
Now that we have support for detecting Action View Tag helpers we can update the `html-no-self-closing` linter rule to make it Action View Tag helpers aware.

Since the parser already transforms the nodes we don't need to change anything else about the existing rule.

With this pull request, the following doesn't get flagged anymore:
```erb
<%= tag.svg(height:, width:) do %>
  <path d="M29.396,2.303 L27.867,2.924 L25.13,18.045 L25.735,18.571 L27.167,18.045 L29.953,2.781 z" fill="currentColor" />
<% end %>
```

Previously, this was flagged as:
```
Use `<path></path>` instead of self-closing `<path />` for HTML compatibility. [html-no-self-closing]
```


Resolves #567