### PR TITLE
Linter: Make `html-img-require-alt` Action View helper aware

### DIFF
--- a/javascript/packages/linter/src/rules/html-img-require-alt.ts
+++ b/javascript/packages/linter/src/rules/html-img-require-alt.ts
@@ -1,24 +1,26 @@
 import { BaseRuleVisitor } from "./rule-utils.js"
-import { hasAttribute, getAttribute, hasAttributeValue, getTagLocalName } from "@herb-tools/core"
+import { hasAttribute, getAttribute, hasAttributeValue, getTagLocalName, isHTMLOpenTagNode, isERBOpenTagNode, filterHTMLAttributeNodes, findAttributeByName } from "@herb-tools/core"
 
 import { ParserRule } from "../types.js"
 import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types.js"
-import type { HTMLOpenTagNode, ParseResult } from "@herb-tools/core"
+import type { HTMLElementNode, HTMLAttributeNode, ParseResult, ParserOptions } from "@herb-tools/core"
 
 class ImgRequireAltVisitor extends BaseRuleVisitor {
-  visitHTMLOpenTagNode(node: HTMLOpenTagNode): void {
+  visitHTMLElementNode(node: HTMLElementNode): void {
     this.checkImgTag(node)
-    super.visitHTMLOpenTagNode(node)
+    super.visitHTMLElementNode(node)
   }
 
-  private checkImgTag(node: HTMLOpenTagNode): void {
+  private checkImgTag(node: HTMLElementNode): void {
     const tagName = getTagLocalName(node)
 
     if (tagName !== "img") {
       return
     }
 
-    if (!hasAttribute(node, "alt")) {
+    const altAttribute = this.getAltAttribute(node)
+
+    if (!altAttribute) {
       this.addOffense(
         'Missing required `alt` attribute on `<img>` tag. Add `alt=""` for decorative images or `alt="description"` for informative images.',
         node.tag_name!.location
@@ -26,14 +28,26 @@ class ImgRequireAltVisitor extends BaseRuleVisitor {
       return
     }
 
-    const altAttribute = getAttribute(node, "alt")
-
-    if (altAttribute && !hasAttributeValue(altAttribute)) {
+    if (!hasAttributeValue(altAttribute)) {
       this.addOffense(
         'The `alt` attribute has no value. Add `alt=""` for decorative images or `alt="description"` for informative images.',
         altAttribute.location
       )
     }
+  }
+
+  private getAltAttribute(node: HTMLElementNode): HTMLAttributeNode | null {
+    const openTag = node.open_tag
+
+    if (isHTMLOpenTagNode(openTag)) {
+      return getAttribute(openTag, "alt")
+    }
+
+    if (isERBOpenTagNode(openTag)) {
+      return findAttributeByName(filterHTMLAttributeNodes(openTag.children), "alt")
+    }
+
+    return null
   }
 }
 
@@ -45,6 +59,10 @@ export class HTMLImgRequireAltRule extends ParserRule {
       enabled: true,
       severity: "warning"
     }
+  }
+
+  get parserOptions(): Partial<ParserOptions> {
+    return { action_view_helpers: true }
   }
 
   check(result: ParseResult, context?: Partial<LintContext>): UnboundLintOffense[] {

--- a/javascript/packages/linter/test/rules/erb-prefer-image-tag-helper.test.ts
+++ b/javascript/packages/linter/test/rules/erb-prefer-image-tag-helper.test.ts
@@ -131,4 +131,20 @@ describe("erb-prefer-image-tag-helper", () => {
   test("passes for img with only http URL", () => {
     expectNoOffenses('<img src="http://example.com/image.jpg" alt="External image">')
   })
+
+  test("passes for image_tag with string source", () => {
+    expectNoOffenses('<%= image_tag "logo.png", alt: "Company logo" %>')
+  })
+
+  test("passes for image_tag with ruby expression source", () => {
+    expectNoOffenses('<%= image_tag user.avatar, alt: "Avatar" %>')
+  })
+
+  test("passes for image_tag with image_path source", () => {
+    expectNoOffenses('<%= image_tag image_path("logo.png"), alt: "Logo" %>')
+  })
+
+  test("passes for image_tag with asset_path source", () => {
+    expectNoOffenses('<%= image_tag asset_path("banner.jpg"), alt: "Banner" %>')
+  })
 })

--- a/javascript/packages/linter/test/rules/html-img-require-alt.test.ts
+++ b/javascript/packages/linter/test/rules/html-img-require-alt.test.ts
@@ -50,4 +50,22 @@ describe("html-img-require-alt", () => {
     expectWarning('The `alt` attribute has no value. Add `alt=""` for decorative images or `alt="description"` for informative images.')
     assertOffenses('<img src="/avatar.jpg" alt>')
   })
+
+  test("passes for image_tag helper with alt attribute", () => {
+    expectNoOffenses('<%= image_tag "logo.png", alt: "Company logo" %>')
+  })
+
+  test("fails for image_tag helper without alt attribute", () => {
+    expectWarning('Missing required `alt` attribute on `<img>` tag. Add `alt=""` for decorative images or `alt="description"` for informative images.')
+    assertOffenses('<%= image_tag "logo.png" %>')
+  })
+
+  test("passes for image_tag helper with empty alt attribute", () => {
+    expectNoOffenses('<%= image_tag "logo.png", alt: "" %>')
+  })
+
+  test("fails for image_tag helper with ruby expression and no alt", () => {
+    expectWarning('Missing required `alt` attribute on `<img>` tag. Add `alt=""` for decorative images or `alt="description"` for informative images.')
+    assertOffenses('<%= image_tag user.avatar %>')
+  })
 })


### PR DESCRIPTION
With #1437, we can now also make the `html-img-require-alt` linter rule Action View helper aware, so that we can catch missing `[alt]` attributes on `<%= image_tag %>` helpers.

The following snippets is now also flagged by the `html-img-require-alt` linter rule:

```erb
<%= image_tag image_path("picture.png"), class: "image" %>
```