### PR TITLE
Linter: Make `erb-no-javascript-tag-helper` Action View helper aware

### DIFF
--- a/javascript/packages/linter/src/rules/erb-no-javascript-tag-helper.ts
+++ b/javascript/packages/linter/src/rules/erb-no-javascript-tag-helper.ts
@@ -1,29 +1,29 @@
 import { ParserRule } from "../types.js"
 import { BaseRuleVisitor } from "./rule-utils.js"
-import { isERBNode, isERBOutputNode } from "@herb-tools/core"
+import { getTagLocalName, isERBOpenTagNode } from "@herb-tools/core"
 
 import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types.js"
-import type { ParseResult, DocumentNode } from "@herb-tools/core"
+import type { ParseResult, ParserOptions, HTMLElementNode } from "@herb-tools/core"
 
-const JAVASCRIPT_TAG_PATTERN = /\bjavascript_tag\b/
+const JAVASCRIPT_TAG_ELEMENT_SOURCE = "ActionView::Helpers::JavaScriptHelper#javascript_tag"
 
 class ERBNoJavascriptTagHelperVisitor extends BaseRuleVisitor {
-  visitDocumentNode(node: DocumentNode): void {
-    for (const child of node.children || []) {
-      if (!isERBNode(child)) continue
-      if (!isERBOutputNode(child)) continue
-
-      const content = child.content?.value || ""
-
-      if (JAVASCRIPT_TAG_PATTERN.test(content)) {
-        this.addOffense(
-          "Avoid `javascript_tag`. Use inline `<script>` tags instead.",
-          child.location,
-        )
-      }
+  visitHTMLElementNode(node: HTMLElementNode): void {
+    if (this.isJavascriptTagHelper(node)) {
+      this.addOffense(
+        "Avoid `javascript_tag`. Use inline `<script>` tags instead.",
+        node.open_tag!.location,
+      )
     }
 
-    super.visitDocumentNode(node)
+    super.visitHTMLElementNode(node)
+  }
+
+  private isJavascriptTagHelper(node: HTMLElementNode): node is HTMLElementNode {
+    if (getTagLocalName(node) !== "script") return false
+    if (!isERBOpenTagNode(node.open_tag)) return false
+
+    return node.element_source === JAVASCRIPT_TAG_ELEMENT_SOURCE
   }
 }
 
@@ -34,6 +34,12 @@ export class ERBNoJavascriptTagHelperRule extends ParserRule {
     return {
       enabled: true,
       severity: "warning"
+    }
+  }
+
+  get parserOptions(): Partial<ParserOptions> {
+    return {
+      action_view_helpers: true,
     }
   }
 

--- a/javascript/packages/linter/test/rules/erb-no-javascript-tag-helper.test.ts
+++ b/javascript/packages/linter/test/rules/erb-no-javascript-tag-helper.test.ts
@@ -25,4 +25,10 @@ describe("ERBNoJavascriptTagHelperRule", () => {
       </script>
     `)
   })
+
+  test("javascript_include_tag is ignored", () => {
+    expectNoOffenses(dedent`
+      <%= javascript_include_tag "application" %>
+    `)
+  })
 })


### PR DESCRIPTION
closes #553

the rule was already implemented via #1330, this just makes the rule Action View Helper aware to bring it in line with similar recent changes, such as #1438
