### PR TITLE
Language Service: Implement `@herb-tools/language-service` package

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ The Herb ecosystem offers multiple tools that integrate seamlessly into editors,
 | [Herb Parser](https://herb-tools.dev/projects/parser) | Fast, portable, HTML-aware ERB parser written in C. |
 | [Herb Linter](https://herb-tools.dev/projects/linter) | Static analysis to enforce best practices and identify common mistakes. |
 | [Herb Formatter](https://herb-tools.dev/projects/formatter) | Automatic, consistent formatting for HTML+ERB files. *(experimental)* |
+| [Herb Language Service](https://herb-tools.dev/projects/language-service) | HTML+ERB language service with ActionView tag helper support. |
 | [Herb Language Server](https://herb-tools.dev/projects/language-server) | Rich editor integration for VS Code, Zed, Neovim, and more. |
 | [Herb Engine](https://herb-tools.dev/projects/engine) | HTML-aware ERB rendering engine, API-compatible with Erubi. |
 | [Herb Dev Tools](https://herb-tools.dev/projects/dev-tools) | In-browser dev tools for inspecting and debugging templates, shipped with ReActionView. |

--- a/javascript/packages/language-service/README.md
+++ b/javascript/packages/language-service/README.md
@@ -1,10 +1,14 @@
-# Herb Language Service <Badge type="info" text="coming soon" />
+# Herb Language Service
 
 **Package:** [`@herb-tools/language-service`](https://www.npmjs.com/package/@herb-tools/language-service)
 
 ---
 
-HTML+ERB language service built on the Herb parser, providing a compatible API with [`vscode-html-languageservice`](https://github.com/microsoft/vscode-html-languageservice) but with HTML+ERB template understanding.
+HTML+ERB language service built on the Herb parser, providing a compatible API with [`vscode-html-languageservice`](https://github.com/microsoft/vscode-html-languageservice) but with full HTML+ERB template understanding, including ActionView tag helpers.
+
+::: tip
+This package is intended for tooling developers building language servers, editor extensions, or other developer tools on top of Herb. If you're looking to use Herb in your editor, see the [Herb Language Server](/integrations/editors) instead.
+:::
 
 ## Installation
 
@@ -28,19 +32,126 @@ bun add @herb-tools/language-service
 
 ## Features
 
-- **Native HTML+ERB Support**: Built specifically for HTML+ERB templates with deep understanding of Rails ActionView helpers.
-- **Compatible API**: Drop-in replacement for [`vscode-html-languageservice`](https://github.com/microsoft/vscode-html-languageservice) with the same interface.
-- **Custom Data Providers**: Supports extensible HTML data providers for framework-specific attributes.
+- Drop-in replacement for [`vscode-html-languageservice`](https://github.com/microsoft/vscode-html-languageservice) with the same API
+- Parses HTML+ERB using the Herb parser instead of a plain HTML scanner
+- ActionView tag helpers like `<%= tag.div data: { controller: "scroll" } %>` are treated as `<div data-controller="scroll">` for completions and diagnostics
+- Extensible via `IHTMLDataProvider` for framework-specific attributes and values
+- Token list support for space-separated attributes (`class`, `data-controller`, etc.)
+- Falls back to the upstream HTML parser when Herb is not available
+
+## Migrating from `vscode-html-languageservice`
+
+```diff
+- import { getLanguageService } from "vscode-html-languageservice"
++ import { Herb } from "@herb-tools/node-wasm"
++ import { getLanguageService } from "@herb-tools/language-service"
+
++ await Herb.load()
+
+  const service = getLanguageService({
++   herb: Herb,
+    customDataProviders: [myDataProvider],
+  })
+```
+
+All types and functions from `vscode-html-languageservice` are re-exported, so no other import changes are needed.
 
 ## Usage
 
-Replace your import to get enhanced HTML+ERB support with no code changes:
+Pass a Herb instance to get HTML+ERB support:
 
-```diff
-- import { getLanguageService } from 'vscode-html-languageservice'
-+ import { getLanguageService } from '@herb-tools/language-service'
+```typescript
+import { Herb } from "@herb-tools/node-wasm"
+import { getLanguageService } from "@herb-tools/language-service"
+
+await Herb.load()
+
+const service = getLanguageService({
+  herb: Herb,
+  customDataProviders: [myDataProvider],
+})
+
+const document = service.parseHTMLDocument(textDocument)
+const completions = service.doComplete(textDocument, position, document)
 ```
+
+### Without Herb (HTML-only)
+
+When no Herb instance is provided, the service falls back to the upstream `vscode-html-languageservice` parser:
+
+```typescript
+import { getLanguageService } from "@herb-tools/language-service"
+
+const service = getLanguageService({
+  customDataProviders: [myDataProvider],
+})
+```
+
+### Custom Data Providers
+
+Custom data providers let you add framework-specific tags, attributes, and values to the completion and hover engines. The interface is the same [`IHTMLDataProvider`](https://github.com/microsoft/vscode-html-languageservice/blob/main/src/htmlLanguageTypes.ts) from `vscode-html-languageservice`:
+
+```typescript
+import { getLanguageService, type IHTMLDataProvider } from "@herb-tools/language-service"
+
+const stimulusProvider: IHTMLDataProvider = {
+  getId: () => "stimulus",
+  isApplicable: () => true,
+
+  provideTags: () => [],
+
+  provideAttributes: (tag) => [
+    { name: "data-controller" },
+    { name: "data-action" },
+  ],
+
+  provideValues: (tag, attribute) => {
+    if (attribute === "data-controller") {
+      return [{ name: "scroll" }, { name: "search" }]
+    }
+
+    return []
+  },
+}
+
+const service = getLanguageService({
+  herb: Herb,
+  customDataProviders: [stimulusProvider],
+  tokenListAttributes: ["data-controller", "data-action"],
+})
+```
+
+Multiple providers can be composed. The language service queries all applicable providers and merges their results.
+
+### Token List Attributes
+
+Some attributes contain space-separated token lists (e.g., `class="foo bar"` or `data-controller="scroll search"`). Pass `tokenListAttributes` so the language service can provide per-token completions and accurate per-token diagnostic ranges:
+
+```typescript
+const service = getLanguageService({
+  herb: Herb,
+  tokenListAttributes: ["data-controller", "data-action"],
+})
+```
+
+The defaults from `@herb-tools/core`'s `TOKEN_LIST_ATTRIBUTES` (including `class`) are always included.
 
 ## API Compatibility
 
-This package provides the same API as [`vscode-html-languageservice`](https://github.com/microsoft/vscode-html-languageservice).
+This package provides the same `LanguageService` interface as [`vscode-html-languageservice`](https://github.com/microsoft/vscode-html-languageservice):
+
+- `parseHTMLDocument(document)`
+- `doComplete(document, position, htmlDocument)`
+- `doHover(document, position, htmlDocument)`
+- `format(document, range, options)`
+- `findDocumentHighlights(document, position, htmlDocument)`
+- `findDocumentLinks(document, documentContext)`
+- `findDocumentSymbols(document, htmlDocument)`
+- `getFoldingRanges(document, context)`
+- `getSelectionRanges(document, positions)`
+- `doRename(document, position, newName, htmlDocument)`
+- `findMatchingTagPosition(document, position, htmlDocument)`
+- `findLinkedEditingRanges(document, position, htmlDocument)`
+- `createScanner(input, initialOffset)`
+- `setDataProviders(useDefault, providers)`
+- `setCompletionParticipants(participants)`

--- a/javascript/packages/language-service/package.json
+++ b/javascript/packages/language-service/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@herb-tools/language-service",
+  "version": "0.9.2",
+  "description": "HTML+ERB language service built on the Herb parser, providing a compatible API with vscode-html-languageservice",
+  "license": "MIT",
+  "homepage": "https://herb-tools.dev",
+  "bugs": "https://github.com/marcoroth/herb/issues/new?title=Package%20%60@herb-tools/language-service%60:%20",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/marcoroth/herb.git",
+    "directory": "javascript/packages/language-service"
+  },
+  "main": "./dist/herb-language-service.cjs",
+  "module": "./dist/herb-language-service.esm.js",
+  "types": "./dist/types/index.d.ts",
+  "scripts": {
+    "build": "yarn clean && rollup -c",
+    "dev": "rollup -c -w",
+    "clean": "rimraf dist",
+    "test": "vitest run",
+    "prepublishOnly": "yarn clean && yarn build && yarn test"
+  },
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "import": "./dist/herb-language-service.esm.js",
+      "require": "./dist/herb-language-service.cjs",
+      "default": "./dist/herb-language-service.esm.js"
+    }
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "vscode-html-languageservice": "^5.1.0",
+    "vscode-languageserver-textdocument": "^1.0.0"
+  },
+  "peerDependencies": {
+    "@herb-tools/core": "0.9.2",
+    "vscode-html-languageservice": "^5.1.0",
+    "vscode-languageserver-textdocument": "^1.0.0"
+  },
+  "files": [
+    "package.json",
+    "README.md",
+    "dist/",
+    "src/"
+  ]
+}

--- a/javascript/packages/language-service/project.json
+++ b/javascript/packages/language-service/project.json
@@ -1,0 +1,28 @@
+{
+  "name": "@herb-tools/language-service",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "javascript/packages/language-service/src",
+  "projectType": "library",
+  "targets": {
+    "build": {
+      "executor": "nx:run-script",
+      "options": {
+        "script": "build"
+      },
+      "dependsOn": ["@herb-tools/core:build"]
+    },
+    "test": {
+      "executor": "nx:run-script",
+      "options": {
+        "script": "test"
+      }
+    },
+    "clean": {
+      "executor": "nx:run-script",
+      "options": {
+        "script": "clean"
+      }
+    }
+  },
+  "tags": []
+}

--- a/javascript/packages/language-service/rollup.config.mjs
+++ b/javascript/packages/language-service/rollup.config.mjs
@@ -1,0 +1,48 @@
+import typescript from "@rollup/plugin-typescript"
+import { nodeResolve } from "@rollup/plugin-node-resolve"
+
+const external = [
+  "@herb-tools/core",
+  "@herb-tools/node-wasm",
+  "@herb-tools/browser",
+  "vscode-html-languageservice",
+  "vscode-languageserver-textdocument",
+]
+
+export default [
+  {
+    input: "src/index.ts",
+    output: {
+      file: "dist/herb-language-service.esm.js",
+      format: "esm",
+      sourcemap: true,
+    },
+    external,
+    plugins: [
+      nodeResolve(),
+      typescript({
+        tsconfig: "./tsconfig.json",
+        declaration: true,
+        declarationDir: "./dist/types",
+        rootDir: "src/",
+      }),
+    ],
+  },
+
+  {
+    input: "src/index.ts",
+    output: {
+      file: "dist/herb-language-service.cjs",
+      format: "cjs",
+      sourcemap: true,
+    },
+    external,
+    plugins: [
+      nodeResolve(),
+      typescript({
+        tsconfig: "./tsconfig.json",
+        rootDir: "src/",
+      }),
+    ],
+  },
+]

--- a/javascript/packages/language-service/src/ast-adapter.ts
+++ b/javascript/packages/language-service/src/ast-adapter.ts
@@ -1,0 +1,271 @@
+import type {
+  Node as HerbNode,
+  DocumentNode,
+  HTMLElementNode,
+  HTMLConditionalElementNode,
+  HTMLAttributeValueNode,
+  HTMLDoctypeNode,
+} from "@herb-tools/core"
+
+import {
+  isHTMLElementNode,
+  isHTMLConditionalElementNode,
+  isHTMLDoctypeNode,
+  isHTMLAttributeNode,
+  isHTMLOpenTagNode,
+  isERBOpenTagNode,
+  isLiteralNode,
+  isERBContentNode,
+} from "@herb-tools/core"
+
+import { getStaticAttributeName } from "@herb-tools/core"
+
+import { HerbHTMLNode, type AttributeSourceRange } from "./herb-html-node.js"
+import { type LineOffsetTable, locationToOffsets, positionToOffset } from "./offset-utils.js"
+
+export function adaptDocumentChildren(document: DocumentNode, lineOffsets: LineOffsetTable, source: string, tokenListAttributes?: Set<string>): HerbHTMLNode[] {
+  const roots = adaptChildren(document.children, undefined, lineOffsets, source)
+
+  if (tokenListAttributes) {
+    propagateTokenListAttributes(roots, tokenListAttributes)
+  }
+
+  return roots
+}
+
+function propagateTokenListAttributes(nodes: HerbHTMLNode[], tokenListAttributes: Set<string>): void {
+  for (const node of nodes) {
+    node.tokenListAttributes = tokenListAttributes
+    propagateTokenListAttributes(node.children, tokenListAttributes)
+  }
+}
+
+function adaptChildren(herbChildren: HerbNode[], parent: HerbHTMLNode | undefined, lineOffsets: LineOffsetTable, source: string): HerbHTMLNode[] {
+  const result: HerbHTMLNode[] = []
+
+  for (const child of herbChildren) {
+    if (isHTMLElementNode(child)) {
+      result.push(adaptHTMLElement(child, parent, lineOffsets, source))
+    } else if (isHTMLConditionalElementNode(child)) {
+      result.push(adaptConditionalElement(child, parent, lineOffsets, source))
+    } else if (isHTMLDoctypeNode(child)) {
+      result.push(adaptDoctype(child, parent, lineOffsets))
+    } else {
+      result.push(...adaptChildren(child.compactChildNodes(), parent, lineOffsets, source))
+    }
+  }
+
+  return result
+}
+
+function adaptHTMLElement(node: HTMLElementNode, parent: HerbHTMLNode | undefined, lineOffsets: LineOffsetTable, source: string): HerbHTMLNode {
+  const offsets = locationToOffsets(node.location, lineOffsets)
+  const startTagEnd = computeStartTagEnd(node.open_tag, lineOffsets)
+  const endTagStart = node.close_tag
+    ? positionToOffset(node.close_tag.location.start.line, node.close_tag.location.start.column, lineOffsets)
+    : undefined
+  const extracted = extractAttributes(node.open_tag, source, lineOffsets)
+
+  const adapted = new HerbHTMLNode({
+    tag: node.tag_name?.value ?? undefined,
+    start: offsets.start,
+    end: offsets.end,
+    startTagEnd,
+    endTagStart,
+    closed: node.is_void || node.close_tag !== null,
+    attributes: extracted?.attributes,
+    attributeSourceRanges: extracted?.sourceRanges,
+    parent,
+    herbNode: node,
+  })
+
+  adapted.children = adaptChildren(node.body, adapted, lineOffsets, source)
+
+  return adapted
+}
+
+function adaptConditionalElement(node: HTMLConditionalElementNode, parent: HerbHTMLNode | undefined, lineOffsets: LineOffsetTable, source: string): HerbHTMLNode {
+  const offsets = locationToOffsets(node.location, lineOffsets)
+
+  const startTagEnd = node.open_tag
+    ? positionToOffset(node.open_tag.location.end.line, node.open_tag.location.end.column, lineOffsets)
+    : undefined
+
+  const endTagStart = node.close_tag
+    ? positionToOffset(node.close_tag.location.start.line, node.close_tag.location.start.column, lineOffsets)
+    : undefined
+
+  const extracted = node.open_tag && isHTMLOpenTagNode(node.open_tag)
+    ? extractAttributes(node.open_tag, source, lineOffsets)
+    : undefined
+
+  const adapted = new HerbHTMLNode({
+    tag: node.tag_name?.value ?? undefined,
+    start: offsets.start,
+    end: offsets.end,
+    startTagEnd,
+    endTagStart,
+    closed: node.close_tag !== null,
+    attributes: extracted?.attributes,
+    attributeSourceRanges: extracted?.sourceRanges,
+    parent,
+    herbNode: node,
+  })
+
+  adapted.children = adaptChildren(node.body, adapted, lineOffsets, source)
+
+  return adapted
+}
+
+function adaptDoctype(node: HTMLDoctypeNode, parent: HerbHTMLNode | undefined, lineOffsets: LineOffsetTable): HerbHTMLNode {
+  const offsets = locationToOffsets(node.location, lineOffsets)
+
+  return new HerbHTMLNode({
+    tag: "!DOCTYPE",
+    start: offsets.start,
+    end: offsets.end,
+    closed: true,
+    parent,
+    herbNode: node,
+  })
+}
+
+interface ExtractedAttributes {
+  attributes: { [name: string]: string | null }
+  sourceRanges: { [name: string]: AttributeSourceRange }
+}
+
+function extractAttributes(openTag: HTMLElementNode["open_tag"], source: string, lineOffsets: LineOffsetTable): ExtractedAttributes | undefined {
+  if (!openTag) return undefined
+
+  let children: HerbNode[] | undefined
+
+  if (isHTMLOpenTagNode(openTag)) {
+    children = openTag.children
+  } else if (isERBOpenTagNode(openTag)) {
+    children = openTag.children
+  } else {
+    return undefined
+  }
+
+  if (!children || children.length === 0) return undefined
+
+  const attributes: { [name: string]: string | null } = {}
+  const sourceRanges: { [name: string]: AttributeSourceRange } = {}
+
+  for (const child of children) {
+    if (!isHTMLAttributeNode(child)) continue
+
+    const name = child.name ? getStaticAttributeName(child.name) : null
+    if (!name) continue
+
+    attributes[name] = child.value ? extractAttributeValue(child.value) : null
+    sourceRanges[name] = computeAttributeSourceRange(child, name, attributes[name], source, lineOffsets)
+  }
+
+  if (Object.keys(attributes).length === 0) return undefined
+
+  return { attributes, sourceRanges }
+}
+
+function extractAttributeValue(valueNode: HTMLAttributeValueNode): string {
+  const quote = valueNode.open_quote?.value ?? ""
+
+  const content = valueNode.children.map((child) => {
+    if (isLiteralNode(child)) return child.content
+
+    if (isERBContentNode(child)) {
+      const opening = child.tag_opening?.value ?? ""
+      const content = child.content?.value ?? ""
+      const closing = child.tag_closing?.value ?? ""
+
+      return `${opening}${content}${closing}`
+    }
+
+    return ""
+  }).join("")
+
+  const closeQuote = valueNode.close_quote?.value ?? ""
+
+  return `${quote}${content}${closeQuote}`
+}
+
+function computeAttributeSourceRange(attributeNode: HerbNode, name: string, quotedValue: string | null, source: string, lineOffsets: LineOffsetTable): AttributeSourceRange {
+  const attributeOffsets = locationToOffsets(attributeNode.location, lineOffsets)
+  const regionOffset = Math.max(0, attributeOffsets.start - 20)
+
+  const searchRegion = source.slice(
+    regionOffset,
+    attributeOffsets.end + (quotedValue ? quotedValue.length : 0) + 10,
+  )
+
+  let nameIndex = searchRegion.indexOf(name)
+
+  if (nameIndex === -1) {
+    for (const prefix of ["data-", "aria-"]) {
+      if (nameIndex !== -1) break
+
+      if (name.startsWith(prefix)) {
+        const withoutPrefix = name.slice(prefix.length).replace(/-/g, "_")
+        nameIndex = searchRegion.indexOf(withoutPrefix)
+      }
+    }
+  }
+
+  if (nameIndex === -1) {
+    const underscored = name.replace(/-/g, "_")
+
+    nameIndex = searchRegion.indexOf(underscored)
+  }
+
+  if (nameIndex === -1) {
+    const lastSegment = name.includes("-") ? name.slice(name.lastIndexOf("-") + 1) : name
+
+    nameIndex = searchRegion.indexOf(lastSegment)
+  }
+
+  let nameStart: number
+  let nameEnd: number
+
+  if (nameIndex !== -1) {
+    nameStart = regionOffset + nameIndex
+    const matchLength = searchRegion.slice(nameIndex).match(/^[a-zA-Z0-9_-]+/)?.[0]?.length ?? name.length
+    nameEnd = regionOffset + nameIndex + matchLength
+  } else {
+    nameStart = attributeOffsets.start
+    nameEnd = attributeOffsets.end
+  }
+
+  let valueStart = nameEnd
+  let valueEnd = nameEnd
+
+  if (quotedValue) {
+    const afterName = source.slice(nameEnd, nameEnd + quotedValue.length + 20)
+    const valueIndex = afterName.indexOf(quotedValue)
+
+    if (valueIndex !== -1) {
+      valueStart = nameEnd + valueIndex
+      valueEnd = valueStart + quotedValue.length
+    } else {
+      const wideSearch = source.slice(attributeOffsets.start, attributeOffsets.end + quotedValue.length + 10)
+      const wideIndex = wideSearch.indexOf(quotedValue)
+
+      if (wideIndex !== -1) {
+        valueStart = attributeOffsets.start + wideIndex
+        valueEnd = valueStart + quotedValue.length
+      }
+    }
+  }
+
+  return { nameStart, nameEnd, valueStart, valueEnd }
+}
+
+function computeStartTagEnd(openTag: HTMLElementNode["open_tag"], lineOffsets: LineOffsetTable): number | undefined {
+  if (!openTag) return undefined
+
+  return positionToOffset(
+    openTag.location.end.line,
+    openTag.location.end.column,
+    lineOffsets,
+  )
+}

--- a/javascript/packages/language-service/src/herb-html-document.ts
+++ b/javascript/packages/language-service/src/herb-html-document.ts
@@ -1,0 +1,38 @@
+import type { DocumentNode } from "@herb-tools/core"
+import type { HTMLDocument } from "vscode-html-languageservice"
+
+import { HerbHTMLNode } from "./herb-html-node.js"
+import { adaptDocumentChildren } from "./ast-adapter.js"
+import { buildLineOffsetTable } from "./offset-utils.js"
+
+/**
+ * Builds a vscode-html-languageservice-compatible HTMLDocument from
+ * a Herb DocumentNode AST.
+ *
+ * The returned document has the same interface as what
+ * vscode-html-languageservice's parseHTMLDocument returns,
+ * so it can be passed directly to doComplete, doHover, etc.
+ */
+export function buildHTMLDocument(herbDocument: DocumentNode, source: string, tokenListAttributes?: Set<string>): HTMLDocument {
+  const lineOffsets = buildLineOffsetTable(source)
+  const roots = adaptDocumentChildren(herbDocument, lineOffsets, source, tokenListAttributes)
+
+  const rootNode = new HerbHTMLNode({
+    start: 0,
+    end: source.length,
+    closed: true,
+    herbNode: herbDocument,
+  })
+
+  rootNode.children = roots
+
+  for (const root of roots) {
+    root.parent = rootNode
+  }
+
+  return {
+    roots: roots as unknown as HTMLDocument["roots"],
+    findNodeBefore: rootNode.findNodeBefore.bind(rootNode) as HTMLDocument["findNodeBefore"],
+    findNodeAt: rootNode.findNodeAt.bind(rootNode) as HTMLDocument["findNodeAt"],
+  }
+}

--- a/javascript/packages/language-service/src/herb-html-node.ts
+++ b/javascript/packages/language-service/src/herb-html-node.ts
@@ -1,0 +1,208 @@
+import type { Node as HerbNode } from "@herb-tools/core"
+import type { OffsetRange } from "./offset-utils.js"
+
+/**
+ * Source byte offset ranges for an attribute's name and value.
+ * Points to the actual positions in the source text (e.g., the Ruby hash key
+ * for ActionView tag helpers, not the synthesized HTML attribute name).
+ */
+export interface AttributeSourceRange {
+  nameStart: number
+  nameEnd: number
+  valueStart: number
+  valueEnd: number
+}
+
+/**
+ * A node in the HTML document tree that matches the shape of
+ * vscode-html-languageservice's Node interface.
+ *
+ * Wraps a Herb AST node (when available) while exposing the
+ * properties that vscode-html-languageservice consumers expect.
+ */
+export class HerbHTMLNode {
+  tag: string | undefined
+  start: number
+  end: number
+  startTagEnd: number | undefined
+  endTagStart: number | undefined
+  closed: boolean
+  children: HerbHTMLNode[]
+  parent: HerbHTMLNode | undefined
+  attributes: { [name: string]: string | null } | undefined
+  attributeSourceRanges: { [name: string]: AttributeSourceRange } | undefined
+  tokenListAttributes: Set<string> | undefined
+  herbNode: HerbNode | undefined
+
+  constructor(init: {
+    tag?: string
+    start: number
+    end: number
+    startTagEnd?: number
+    endTagStart?: number
+    closed?: boolean
+    children?: HerbHTMLNode[]
+    parent?: HerbHTMLNode
+    attributes?: { [name: string]: string | null }
+    attributeSourceRanges?: { [name: string]: AttributeSourceRange }
+    tokenListAttributes?: Set<string>
+    herbNode?: HerbNode
+  }) {
+    this.tag = init.tag
+    this.start = init.start
+    this.end = init.end
+    this.startTagEnd = init.startTagEnd
+    this.endTagStart = init.endTagStart
+    this.closed = init.closed ?? false
+    this.children = init.children ?? []
+    this.parent = init.parent
+    this.attributes = init.attributes
+    this.attributeSourceRanges = init.attributeSourceRanges
+    this.tokenListAttributes = init.tokenListAttributes
+    this.herbNode = init.herbNode
+  }
+
+  get firstChild(): HerbHTMLNode | undefined {
+    return this.children[0]
+  }
+
+  get lastChild(): HerbHTMLNode | undefined {
+    return this.children[this.children.length - 1]
+  }
+
+  get attributeNames(): string[] {
+    return this.attributes ? Object.keys(this.attributes) : []
+  }
+
+  getAttributeNameRange(attribute: string): OffsetRange | null {
+    const range = this.attributeSourceRanges?.[attribute]
+    if (!range) return null
+
+    return { start: range.nameStart, end: range.nameEnd }
+  }
+
+  getAttributeValueRange(attribute: string): OffsetRange | null {
+    const range = this.attributeSourceRanges?.[attribute]
+    if (!range) return null
+
+    return { start: range.valueStart, end: range.valueEnd }
+  }
+
+  isTokenListAttribute(attribute: string): boolean {
+    return this.tokenListAttributes?.has(attribute) ?? false
+  }
+
+  getAttributeValueTokenRange(attribute: string, token: string, source: string): OffsetRange | null {
+    const range = this.attributeSourceRanges?.[attribute]
+    if (!range) return null
+
+    if (!this.isTokenListAttribute(attribute)) {
+      return { start: range.valueStart, end: range.valueEnd }
+    }
+
+    const valueText = source.slice(range.valueStart, range.valueEnd)
+    const quoteOffset = (valueText.startsWith('"') || valueText.startsWith("'")) ? 1 : 0
+    const unquoted = valueText.slice(quoteOffset, valueText.length - (quoteOffset ? 1 : 0))
+    const tokenIndex = findTokenIndex(unquoted, token)
+
+    if (tokenIndex !== -1) {
+      const start = range.valueStart + quoteOffset + tokenIndex
+      return { start, end: start + token.length }
+    }
+
+    return { start: range.valueStart, end: range.valueEnd }
+  }
+
+  isSameTag(tagInLowerCase: string | undefined): boolean {
+    if (!this.tag || !tagInLowerCase) {
+      return this.tag === tagInLowerCase
+    }
+
+    return this.tag.toLowerCase() === tagInLowerCase
+  }
+
+  /**
+   * Finds the deepest node that starts before the given offset.
+   * Uses the same algorithm as vscode-html-languageservice.
+   */
+  findNodeBefore(offset: number): HerbHTMLNode {
+    const index = findLastIndex(this.children, (c) => c.start <= offset)
+
+    if (index >= 0) {
+      const child = this.children[index]
+
+      if (offset > child.start) {
+        if (offset < child.end) {
+          return child.findNodeBefore(offset)
+        }
+
+        const lastChild = child.lastChild
+        if (lastChild && lastChild.end > child.end) {
+          return child.findNodeBefore(offset)
+        }
+
+        return child
+      }
+    }
+
+    return this
+  }
+
+  findNodeAt(offset: number): HerbHTMLNode {
+    const index = findFirst(this.children, (c) => offset <= c.start) - 1
+
+    if (index >= 0) {
+      const child = this.children[index]
+
+      if (offset > child.start && offset <= child.end) {
+        return child.findNodeAt(offset)
+      }
+    }
+
+    return this
+  }
+}
+
+function findFirst(array: HerbHTMLNode[], predicate: (node: HerbHTMLNode) => boolean): number {
+  let low = 0
+  let high = array.length
+
+  while (low < high) {
+    const mid = Math.floor((low + high) / 2)
+
+    if (predicate(array[mid])) {
+      high = mid
+    } else {
+      low = mid + 1
+    }
+  }
+
+  return low
+}
+
+function findLastIndex(array: HerbHTMLNode[], predicate: (node: HerbHTMLNode) => boolean): number {
+  for (let index = array.length - 1; index >= 0; index--) {
+    if (predicate(array[index])) {
+      return index
+    }
+  }
+
+  return -1
+}
+
+export function findTokenIndex(value: string, search: string): number {
+  const tokens = value.split(/\s+/)
+  let offset = 0
+
+  for (const token of tokens) {
+    const tokenStart = value.indexOf(token, offset)
+
+    if (token === search) {
+      return tokenStart
+    }
+
+    offset = tokenStart + token.length
+  }
+
+  return -1
+}

--- a/javascript/packages/language-service/src/index.ts
+++ b/javascript/packages/language-service/src/index.ts
@@ -1,0 +1,73 @@
+export { getLanguageService } from "./language-service.js"
+export { findTokenIndex, HerbHTMLNode } from "./herb-html-node.js"
+export { buildHTMLDocument } from "./herb-html-document.js"
+export { buildLineOffsetTable, positionToOffset, locationToOffsets } from "./offset-utils.js"
+
+export type { OffsetRange } from "./offset-utils.js"
+export type { AttributeSourceRange } from "./herb-html-node.js"
+export type { LanguageServiceOptions } from "./types.js"
+
+export {
+  newHTMLDataProvider,
+  getDefaultHTMLDataProvider,
+
+  TokenType,
+  ScannerState,
+  ClientCapabilities,
+  FileType,
+
+  TextDocument,
+  Position,
+  Range,
+  Location,
+  MarkupContent,
+  MarkupKind,
+  MarkedString,
+  SelectionRange,
+  WorkspaceEdit,
+  CompletionList,
+  CompletionItemKind,
+  CompletionItem,
+  CompletionItemTag,
+  InsertTextMode,
+  Command,
+  SymbolInformation,
+  DocumentSymbol,
+  SymbolKind,
+  Hover,
+  TextEdit,
+  InsertReplaceEdit,
+  InsertTextFormat,
+  DocumentHighlight,
+  DocumentHighlightKind,
+  DocumentLink,
+  FoldingRange,
+  FoldingRangeKind,
+  Diagnostic,
+  FormattingOptions,
+  Color,
+  ColorInformation,
+  ColorPresentation,
+} from "vscode-html-languageservice"
+
+export type {
+  HTMLDocument,
+  Node,
+  LanguageService,
+  Scanner,
+  IHTMLDataProvider,
+  ITagData,
+  IAttributeData,
+  IValueData,
+  IReference,
+  IValueSet,
+  HTMLDataV1,
+  CompletionConfiguration,
+  HoverSettings,
+  HTMLFormatConfiguration,
+  DocumentContext,
+  ICompletionParticipant,
+  HtmlAttributeValueContext,
+  HtmlContentContext,
+  FileSystemProvider,
+} from "vscode-html-languageservice"

--- a/javascript/packages/language-service/src/language-service.ts
+++ b/javascript/packages/language-service/src/language-service.ts
@@ -1,0 +1,287 @@
+import { HerbHTMLNode } from "./herb-html-node.js"
+import { CompletionItemKind, InsertTextFormat } from "vscode-html-languageservice"
+
+import { buildHTMLDocument } from "./herb-html-document.js"
+import { getLanguageService as getUpstreamLanguageService } from "vscode-html-languageservice"
+
+import { TOKEN_LIST_ATTRIBUTES } from "@herb-tools/core"
+
+import type { ParseOptions } from "@herb-tools/core"
+import type { LanguageServiceOptions } from "./types.js"
+import type { TextDocument } from "vscode-languageserver-textdocument"
+import type { Position, Range, CompletionList, CompletionItem, Hover, TextEdit, DocumentHighlight, DocumentLink, SymbolInformation, DocumentSymbol, FoldingRange, SelectionRange, WorkspaceEdit, IHTMLDataProvider } from "vscode-html-languageservice"
+import type { LanguageService, HTMLDocument, HTMLFormatConfiguration, CompletionConfiguration, HoverSettings, DocumentContext } from "vscode-html-languageservice"
+
+const DEFAULT_HERB_PARSE_OPTIONS: ParseOptions = {
+  analyze: true,
+  action_view_helpers: true,
+  track_whitespace: false,
+  strict: false,
+}
+
+export function getLanguageService(options?: LanguageServiceOptions): LanguageService {
+  const upstream = getUpstreamLanguageService(options)
+  const herb = options?.herb
+  const dataProviders = options?.customDataProviders ?? []
+
+  const tokenListAttributes = new Set([
+    ...TOKEN_LIST_ATTRIBUTES,
+    ...options?.tokenListAttributes ?? [],
+  ])
+
+  const herbParseOptions = {
+    ...DEFAULT_HERB_PARSE_OPTIONS,
+    ...options?.herbParseOptions,
+  }
+
+  return {
+    parseHTMLDocument(document: TextDocument): HTMLDocument {
+      if (!herb?.backend) {
+        return upstream.parseHTMLDocument(document)
+      }
+
+      const source = document.getText()
+
+      try {
+        const result = herb.parse(source, herbParseOptions)
+        return buildHTMLDocument(result.value, source, tokenListAttributes)
+      } catch {
+        return upstream.parseHTMLDocument(document)
+      }
+    },
+
+    createScanner(input: string, initialOffset?: number) {
+      return upstream.createScanner(input, initialOffset)
+    },
+
+    doComplete(
+      document: TextDocument,
+      position: Position,
+      htmlDocument: HTMLDocument,
+      options?: CompletionConfiguration,
+    ): CompletionList {
+      const erbResult = tryERBAttributeCompletion(document, position, htmlDocument, dataProviders, tokenListAttributes)
+      if (erbResult) return erbResult
+
+      return upstream.doComplete(document, position, htmlDocument, options)
+    },
+
+    doComplete2(
+      document: TextDocument,
+      position: Position,
+      htmlDocument: HTMLDocument,
+      documentContext: DocumentContext,
+      options?: CompletionConfiguration,
+    ): Promise<CompletionList> {
+      return upstream.doComplete2(document, position, htmlDocument, documentContext, options)
+    },
+
+    setCompletionParticipants(registeredCompletionParticipants) {
+      upstream.setCompletionParticipants(registeredCompletionParticipants)
+    },
+
+    doHover(
+      document: TextDocument,
+      position: Position,
+      htmlDocument: HTMLDocument,
+      options?: HoverSettings,
+    ): Hover | null {
+      return upstream.doHover(document, position, htmlDocument, options)
+    },
+
+    format(document: TextDocument, range: Range | undefined, options: HTMLFormatConfiguration): TextEdit[] {
+      return upstream.format(document, range, options)
+    },
+
+    findDocumentHighlights(document: TextDocument, position: Position, htmlDocument: HTMLDocument): DocumentHighlight[] {
+      return upstream.findDocumentHighlights(document, position, htmlDocument)
+    },
+
+    findDocumentLinks(document: TextDocument, documentContext: DocumentContext): DocumentLink[] {
+      return upstream.findDocumentLinks(document, documentContext)
+    },
+
+    findDocumentSymbols(document: TextDocument, htmlDocument: HTMLDocument): SymbolInformation[] {
+      return upstream.findDocumentSymbols(document, htmlDocument)
+    },
+
+    findDocumentSymbols2(document: TextDocument, htmlDocument: HTMLDocument): DocumentSymbol[] {
+      return upstream.findDocumentSymbols2(document, htmlDocument)
+    },
+
+    getFoldingRanges(document: TextDocument, context?: { rangeLimit?: number }): FoldingRange[] {
+      return upstream.getFoldingRanges(document, context)
+    },
+
+    getSelectionRanges(document: TextDocument, positions: Position[]): SelectionRange[] {
+      return upstream.getSelectionRanges(document, positions)
+    },
+
+    doQuoteComplete(document: TextDocument, position: Position, htmlDocument: HTMLDocument, options?: CompletionConfiguration): string | null {
+      return upstream.doQuoteComplete(document, position, htmlDocument, options)
+    },
+
+    doTagComplete(document: TextDocument, position: Position, htmlDocument: HTMLDocument): string | null {
+      return upstream.doTagComplete(document, position, htmlDocument)
+    },
+
+    doRename(document: TextDocument, position: Position, newName: string, htmlDocument: HTMLDocument,): WorkspaceEdit | null {
+      return upstream.doRename(document, position, newName, htmlDocument)
+    },
+
+    findMatchingTagPosition(document: TextDocument, position: Position, htmlDocument: HTMLDocument): Position | null {
+      return upstream.findMatchingTagPosition(document, position, htmlDocument)
+    },
+
+    findLinkedEditingRanges(document: TextDocument, position: Position, htmlDocument: HTMLDocument): Range[] | null {
+      return upstream.findLinkedEditingRanges(document, position, htmlDocument)
+    },
+
+    findOnTypeRenameRanges(document: TextDocument, position: Position, htmlDocument: HTMLDocument): Range[] | null {
+      return upstream.findOnTypeRenameRanges(document, position, htmlDocument)
+    },
+
+    setDataProviders(useDefaultDataProvider: boolean, customDataProviders) {
+      upstream.setDataProviders(useDefaultDataProvider, customDataProviders)
+      dataProviders.length = 0
+      dataProviders.push(...customDataProviders)
+    },
+  }
+}
+
+function tryERBAttributeCompletion(document: TextDocument, position: Position, htmlDocument: HTMLDocument, dataProviders: IHTMLDataProvider[], tokenListAttributes: Set<string>): CompletionList | null {
+  const offset = document.offsetAt(position)
+  const node = htmlDocument.findNodeAt(offset) as HerbHTMLNode | undefined
+
+  if (!node?.herbNode) return null
+
+  const herbNode = node.herbNode as { element_source?: string }
+  if (!herbNode.element_source || herbNode.element_source === "HTML") return null
+  if (!node.tag || !node.attributeSourceRanges) return null
+
+  let currentAttribute: string | null = null
+
+  for (const [attributeName, range] of Object.entries(node.attributeSourceRanges)) {
+    if (offset >= range.valueStart && offset <= range.valueEnd) {
+      currentAttribute = attributeName
+
+      break
+    }
+  }
+
+  if (!currentAttribute) {
+    return collectERBAttributeNameCompletions(document, offset, node, dataProviders)
+  }
+
+  const items: CompletionItem[] = []
+  const range = node.attributeSourceRanges[currentAttribute]
+
+  const valueText = document.getText({
+    start: document.positionAt(range.valueStart),
+    end: document.positionAt(range.valueEnd),
+  })
+
+  const hasOpenQuote = valueText.startsWith('"') || valueText.startsWith("'")
+  const hasCloseQuote = valueText.endsWith('"') || valueText.endsWith("'")
+  const contentStart = range.valueStart + (hasOpenQuote ? 1 : 0)
+  const contentEnd = range.valueEnd - (hasCloseQuote ? 1 : 0)
+
+  let wordStart: number
+  let wordEnd: number
+
+  if (tokenListAttributes.has(currentAttribute)) {
+    const source = document.getText()
+    wordStart = offset
+    wordEnd = offset
+
+    while (wordStart > contentStart && source[wordStart - 1] !== " ") {
+      wordStart--
+    }
+    while (wordEnd < contentEnd && source[wordEnd] !== " ") {
+      wordEnd++
+    }
+  } else {
+    wordStart = contentStart
+    wordEnd = contentEnd
+  }
+
+  const replaceRange = {
+    start: document.positionAt(wordStart),
+    end: document.positionAt(wordEnd),
+  }
+
+  for (const provider of dataProviders) {
+    if (!provider.isApplicable(document.languageId)) continue
+
+    for (const value of provider.provideValues(node.tag, currentAttribute)) {
+      items.push({
+        label: value.name,
+        kind: CompletionItemKind.Value,
+        textEdit: { range: replaceRange, newText: value.name },
+        insertTextFormat: InsertTextFormat.PlainText,
+      })
+    }
+  }
+
+  return { isIncomplete: false, items }
+}
+
+function collectERBAttributeNameCompletions(document: TextDocument, offset: number, node: HerbHTMLNode, dataProviders: IHTMLDataProvider[]): CompletionList | null {
+  if (!node.tag) return null
+
+  const existingAttributes = new Set(Object.keys(node.attributes ?? {}))
+  const items: CompletionItem[] = []
+  const source = document.getText()
+  const insideDataHash = isInsideDataHash(source, offset, node.start)
+
+  for (const provider of dataProviders) {
+    if (!provider.isApplicable(document.languageId)) continue
+
+    for (const attr of provider.provideAttributes(node.tag)) {
+      if (existingAttributes.has(attr.name)) continue
+
+      let label: string
+      let insertText: string
+
+      if (insideDataHash && attr.name.startsWith("data-")) {
+        label = attr.name.slice(5).replace(/-/g, "_")
+        insertText = `${label}: `
+      } else if (insideDataHash) {
+        continue
+      } else {
+        label = attr.name.replace(/-/g, "_")
+        insertText = `${label}: `
+      }
+
+      items.push({
+        label,
+        kind: CompletionItemKind.Property,
+        insertText,
+        insertTextFormat: InsertTextFormat.PlainText,
+      })
+    }
+  }
+
+  return items.length > 0 ? { isIncomplete: false, items } : null
+}
+
+function isInsideDataHash(source: string, offset: number, nodeStart: number): boolean {
+  let braceDepth = 0
+
+  for (let i = offset - 1; i >= nodeStart; i--) {
+    const ch = source[i]
+
+    if (ch === "}") {
+      braceDepth++
+    } else if (ch === "{") {
+      if (braceDepth > 0) {
+        braceDepth--
+      } else {
+        const before = source.slice(Math.max(nodeStart, i - 10), i).trimEnd()
+        return before.endsWith("data:")
+      }
+    }
+  }
+
+  return false
+}

--- a/javascript/packages/language-service/src/offset-utils.ts
+++ b/javascript/packages/language-service/src/offset-utils.ts
@@ -1,0 +1,35 @@
+import type { Location as HerbLocation } from "@herb-tools/core"
+
+export type LineOffsetTable = number[]
+
+export interface OffsetRange {
+  start: number
+  end: number
+}
+
+export function buildLineOffsetTable(source: string): LineOffsetTable {
+  const offsets: number[] = [0, 0]
+
+  for (let index = 0; index < source.length; index++) {
+    if (source[index] === "\n") {
+      offsets.push(index + 1)
+    }
+  }
+
+  return offsets
+}
+
+export function positionToOffset(line: number, column: number, lineOffsets: LineOffsetTable): number {
+  if (line < 1 || line >= lineOffsets.length) {
+    return 0
+  }
+
+  return lineOffsets[line] + column
+}
+
+export function locationToOffsets(location: HerbLocation, lineOffsets: LineOffsetTable): OffsetRange {
+  return {
+    start: positionToOffset(location.start.line, location.start.column, lineOffsets),
+    end: positionToOffset(location.end.line, location.end.column, lineOffsets),
+  }
+}

--- a/javascript/packages/language-service/src/types.ts
+++ b/javascript/packages/language-service/src/types.ts
@@ -1,0 +1,9 @@
+import type { HerbBackend } from "@herb-tools/core"
+import type { ParseOptions } from "@herb-tools/core"
+import type { LanguageServiceOptions as UpstreamLanguageServiceOptions } from "vscode-html-languageservice"
+
+export interface LanguageServiceOptions extends UpstreamLanguageServiceOptions {
+  herb?: HerbBackend
+  herbParseOptions?: ParseOptions
+  tokenListAttributes?: string[]
+}

--- a/javascript/packages/language-service/test/completions.test.ts
+++ b/javascript/packages/language-service/test/completions.test.ts
@@ -1,0 +1,119 @@
+import { describe, test, expect } from "vitest"
+
+import { Position } from "../src/index.js"
+import { setupHerb, createService, createDocument } from "./helpers.js"
+
+describe("doComplete", () => {
+  setupHerb()
+
+  describe("regular HTML", () => {
+    test("provides attribute value completions", () => {
+      const service = createService()
+      const document = createDocument(`<div data-controller=""></div>`)
+      const html = service.parseHTMLDocument(document)
+      const completions = service.doComplete(document, Position.create(0, 22), html)
+
+      expect(completions.items.length).toBeGreaterThan(0)
+
+      const labels = completions.items.map(item => item.label)
+      expect(labels).toContain("scroll")
+      expect(labels).toContain("hello")
+      expect(labels).toContain("search")
+    })
+
+    test("provides attribute name completions", () => {
+      const service = createService()
+      const document = createDocument("<div ></div>")
+      const html = service.parseHTMLDocument(document)
+      const completions = service.doComplete(document, Position.create(0, 5), html)
+
+      expect(completions.items.length).toBeGreaterThan(0)
+
+      const labels = completions.items.map(item => item.label)
+      expect(labels).toContain("data-controller")
+      expect(labels).toContain("data-action")
+    })
+  })
+
+  describe("ActionView tag helpers", () => {
+    test("provides attribute value completions for data-controller", () => {
+      const service = createService()
+      const document = createDocument(`<%= tag.div data: { controller: "" } %>`)
+      const html = service.parseHTMLDocument(document)
+      const completions = service.doComplete(document, Position.create(0, 33), html)
+
+      expect(completions.items.length).toBeGreaterThan(0)
+
+      const labels = completions.items.map(item => item.label)
+      expect(labels).toContain("scroll")
+      expect(labels).toContain("hello")
+      expect(labels).toContain("search")
+    })
+
+    test("provides attribute value completions for data-action", () => {
+      const service = createService()
+      const document = createDocument(`<%= tag.div data: { action: "" } %>`)
+      const html = service.parseHTMLDocument(document)
+      const completions = service.doComplete(document, Position.create(0, 29), html)
+
+      expect(completions.items.length).toBeGreaterThan(0)
+
+      const labels = completions.items.map(item => item.label)
+      expect(labels).toContain("click->scroll#go")
+    })
+
+    test("provides completions for second value in multi-value attribute", () => {
+      const service = createService()
+      const source = '<%= tag.div data: { controller: "collapsible s" } %>'
+      const document = createDocument(source)
+      const html = service.parseHTMLDocument(document)
+      const cursorOffset = source.indexOf("s\"") + 1
+
+      const completions = service.doComplete(document, document.positionAt(cursorOffset), html)
+
+      expect(completions.items.length).toBeGreaterThan(0)
+
+      const labels = completions.items.map(item => item.label)
+      expect(labels).toContain("scroll")
+      expect(labels).toContain("search")
+
+      const firstItem = completions.items[0]
+
+      if (firstItem.textEdit && "range" in firstItem.textEdit) {
+        const editStart = document.offsetAt(firstItem.textEdit.range.start)
+        const editEnd = document.offsetAt(firstItem.textEdit.range.end)
+        expect(source.slice(editStart, editEnd)).toBe("s")
+      }
+    })
+
+    test("provides underscored attribute names inside data: {} hash", () => {
+      const service = createService()
+      const source = '<%= tag.div(data: { controller: "dropdown",  }) %>'
+      const document = createDocument(source)
+
+      const html = service.parseHTMLDocument(document)
+      const cursorOffset = source.indexOf(",  }") + 2
+      const completions = service.doComplete(document, document.positionAt(cursorOffset), html)
+
+      expect(completions.items.length).toBeGreaterThan(0)
+
+      const labels = completions.items.map(item => item.label)
+
+      expect(labels).toContain("action")
+      expect(labels).toContain("target")
+
+      expect(labels).not.toContain("data-controller")
+      expect(labels).not.toContain("data-action")
+      expect(labels).not.toContain("controller")
+    })
+
+    test("returns empty completions for unknown attributes", () => {
+      const service = createService()
+      const document = createDocument('<%= tag.div data: { unknown: "" } %>')
+      const html = service.parseHTMLDocument(document)
+      const completions = service.doComplete(document, Position.create(0, 30), html)
+
+      expect(completions.items).toHaveLength(0)
+    })
+  })
+})

--- a/javascript/packages/language-service/test/helpers.ts
+++ b/javascript/packages/language-service/test/helpers.ts
@@ -1,0 +1,57 @@
+import { beforeAll } from "vitest"
+
+import { TextDocument } from "vscode-languageserver-textdocument"
+import { Herb } from "@herb-tools/node-wasm"
+
+import { getLanguageService } from "../src/index.js"
+
+import type { IHTMLDataProvider, LanguageServiceOptions } from "../src/index.js"
+
+export const testDataProvider: IHTMLDataProvider = {
+  getId: () => "test",
+  isApplicable: () => true,
+  provideTags: () => [],
+
+  provideAttributes: (_tag: string) => [
+    { name: "data-controller" },
+    { name: "data-action" },
+    { name: "data-target" },
+  ],
+
+  provideValues: (_tag: string, attribute: string) => {
+    if (attribute === "data-controller") {
+      return [
+        { name: "scroll" },
+        { name: "hello" },
+        { name: "search" },
+      ]
+    }
+
+    if (attribute === "data-action") {
+      return [{ name: "click->scroll#go" }]
+    }
+
+    return []
+  },
+}
+
+export function setupHerb() {
+  beforeAll(async () => {
+    await Herb.load()
+  })
+}
+
+export function createService(options?: Partial<LanguageServiceOptions>) {
+  return getLanguageService({
+    herb: Herb,
+    customDataProviders: [testDataProvider],
+    tokenListAttributes: ["data-controller", "data-action"],
+    ...options,
+  })
+}
+
+export function createDocument(content: string, languageId = "erb") {
+  return TextDocument.create("file:///test.html.erb", languageId, 1, content)
+}
+
+export { Herb, getLanguageService }

--- a/javascript/packages/language-service/test/herb-html-node.test.ts
+++ b/javascript/packages/language-service/test/herb-html-node.test.ts
@@ -1,0 +1,93 @@
+import { describe, test, expect } from "vitest"
+
+import { HerbHTMLNode } from "../src/herb-html-node.js"
+import { setupHerb, createService, createDocument } from "./helpers.js"
+
+describe("HerbHTMLNode", () => {
+  setupHerb()
+
+  test("getAttributeNameRange returns correct range", () => {
+    const service = createService()
+    const source = '<div data-controller="scroll"></div>'
+    const document = createDocument(source)
+    const html = service.parseHTMLDocument(document)
+    const node = html.roots[0] as HerbHTMLNode
+
+    const range = node.getAttributeNameRange("data-controller")
+
+    expect(range).toBeDefined()
+    expect(source.slice(range!.start, range!.end)).toBe("data-controller")
+  })
+
+  test("getAttributeValueRange returns correct range", () => {
+    const service = createService()
+    const source = '<div data-controller="scroll"></div>'
+    const document = createDocument(source)
+    const html = service.parseHTMLDocument(document)
+    const node = html.roots[0] as HerbHTMLNode
+
+    const range = node.getAttributeValueRange("data-controller")
+
+    expect(range).toBeDefined()
+    expect(source.slice(range!.start, range!.end)).toBe('"scroll"')
+  })
+
+  test("getAttributeValueTokenRange finds specific token", () => {
+    const service = createService()
+    const source = '<div data-controller="scroll hello"></div>'
+    const document = createDocument(source)
+    const html = service.parseHTMLDocument(document)
+    const node = html.roots[0] as HerbHTMLNode
+
+    const range = node.getAttributeValueTokenRange("data-controller", "hello", source)
+
+    expect(range).toBeDefined()
+    expect(source.slice(range!.start, range!.end)).toBe("hello")
+  })
+
+  test("getAttributeValueTokenRange does not match partial tokens", () => {
+    const service = createService()
+    const source = '<div data-controller="collapsible bl"></div>'
+    const document = createDocument(source)
+    const html = service.parseHTMLDocument(document)
+    const node = html.roots[0] as HerbHTMLNode
+
+    const range = node.getAttributeValueTokenRange("data-controller", "bl", source)
+
+    expect(range).toBeDefined()
+    expect(source.slice(range!.start, range!.end)).toBe("bl")
+
+    const charBefore = source[range!.start - 1]
+    expect(charBefore).toBe(" ")
+  })
+
+  test("isTokenListAttribute returns correct value", () => {
+    const service = createService()
+    const document = createDocument('<div data-controller="scroll" title="hello"></div>')
+    const html = service.parseHTMLDocument(document)
+    const node = html.roots[0] as HerbHTMLNode
+
+    expect(node.isTokenListAttribute("data-controller")).toBe(true)
+    expect(node.isTokenListAttribute("title")).toBe(false)
+    expect(node.isTokenListAttribute("class")).toBe(true)
+  })
+
+  test("getAttributeNameRange returns null for missing attributes", () => {
+    const service = createService()
+    const document = createDocument("<div></div>")
+    const html = service.parseHTMLDocument(document)
+    const node = html.roots[0] as HerbHTMLNode
+
+    expect(node.getAttributeNameRange("nonexistent")).toBeNull()
+  })
+
+  test("isSameTag compares case-insensitively", () => {
+    const service = createService()
+    const document = createDocument("<DIV></DIV>")
+    const html = service.parseHTMLDocument(document)
+    const node = html.roots[0] as HerbHTMLNode
+
+    expect(node.isSameTag("div")).toBe(true)
+    expect(node.isSameTag("span")).toBe(false)
+  })
+})

--- a/javascript/packages/language-service/test/language-service.test.ts
+++ b/javascript/packages/language-service/test/language-service.test.ts
@@ -1,0 +1,196 @@
+import dedent from "dedent"
+import { describe, test, expect } from "vitest"
+
+import { Position } from "../src/index.js"
+import { setupHerb, createService, createDocument } from "./helpers.js"
+
+import type { IHTMLDataProvider } from "../src/index.js"
+
+describe("@herb-tools/language-service", () => {
+  setupHerb()
+
+  describe("getLanguageService", () => {
+    test("returns a language service", () => {
+      const service = createService()
+
+      expect(service).toBeDefined()
+      expect(service.parseHTMLDocument).toBeTypeOf("function")
+      expect(service.doComplete).toBeTypeOf("function")
+      expect(service.doHover).toBeTypeOf("function")
+    })
+  })
+
+  describe("doHover", () => {
+    test("provides hover for HTML tag names", () => {
+      const service = createService()
+      const document = createDocument("<div></div>")
+      const html = service.parseHTMLDocument(document)
+      const hover = service.doHover(document, Position.create(0, 2), html)
+
+      expect(hover).toBeDefined()
+    })
+
+    test("provides hover for HTML attributes", () => {
+      const service = createService()
+      const document = createDocument('<div class="foo"></div>')
+      const html = service.parseHTMLDocument(document)
+      const hover = service.doHover(document, Position.create(0, 7), html)
+
+      expect(hover).toBeDefined()
+    })
+
+    test("returns null for positions outside elements", () => {
+      const service = createService()
+      const document = createDocument("hello world")
+      const html = service.parseHTMLDocument(document)
+      const hover = service.doHover(document, Position.create(0, 5), html)
+
+      expect(hover).toBeNull()
+    })
+  })
+
+  describe("doTagComplete", () => {
+    test("completes closing tag after >", () => {
+      const service = createService()
+      const document = createDocument("<div>text")
+      const html = service.parseHTMLDocument(document)
+      const result = service.doTagComplete(document, Position.create(0, 5), html)
+
+      expect(result === null || result === "$0</div>").toBe(true)
+    })
+
+    test("does not complete void elements", () => {
+      const service = createService()
+      const document = createDocument("<br>")
+      const html = service.parseHTMLDocument(document)
+      const result = service.doTagComplete(document, Position.create(0, 4), html)
+
+      expect(result).toBeNull()
+    })
+  })
+
+  describe("findDocumentSymbols", () => {
+    test("returns symbols for HTML elements", () => {
+      const service = createService()
+      const document = createDocument("<div><span></span></div>")
+      const html = service.parseHTMLDocument(document)
+      const symbols = service.findDocumentSymbols(document, html)
+
+      expect(symbols.length).toBeGreaterThan(0)
+    })
+
+    test("findDocumentSymbols2 returns nested symbols", () => {
+      const service = createService()
+      const document = createDocument('<div id="main"><span></span></div>')
+      const html = service.parseHTMLDocument(document)
+      const symbols = service.findDocumentSymbols2(document, html)
+
+      expect(symbols.length).toBeGreaterThan(0)
+    })
+  })
+
+  describe("findDocumentHighlights", () => {
+    test("highlights matching open and close tags", () => {
+      const service = createService()
+      const document = createDocument("<div></div>")
+      const html = service.parseHTMLDocument(document)
+      const highlights = service.findDocumentHighlights(document, Position.create(0, 2), html)
+
+      expect(highlights.length).toBeGreaterThanOrEqual(2)
+    })
+  })
+
+  describe("getFoldingRanges", () => {
+    test("returns folding ranges for nested elements", () => {
+      const service = createService()
+      const document = createDocument(dedent`
+        <div>
+          <span>content</span>
+        </div>
+      `)
+      const ranges = service.getFoldingRanges(document)
+
+      expect(ranges.length).toBeGreaterThan(0)
+    })
+  })
+
+  describe("getSelectionRanges", () => {
+    test("returns selection ranges for a position", () => {
+      const service = createService()
+      const document = createDocument("<div><span>text</span></div>")
+      const html = service.parseHTMLDocument(document)
+      const ranges = service.getSelectionRanges(document, [Position.create(0, 12)])
+
+      expect(ranges).toHaveLength(1)
+      expect(ranges[0].parent).toBeDefined()
+    })
+  })
+
+  describe("findMatchingTagPosition", () => {
+    test("finds the closing tag from the opening tag", () => {
+      const service = createService()
+      const document = createDocument("<div></div>")
+      const html = service.parseHTMLDocument(document)
+      const position = service.findMatchingTagPosition(document, Position.create(0, 2), html)
+
+      expect(position).toBeDefined()
+      expect(position!.character).toBe(8)
+    })
+  })
+
+  describe("findLinkedEditingRanges", () => {
+    test("returns linked ranges for tag pairs", () => {
+      const service = createService()
+      const document = createDocument("<div></div>")
+      const html = service.parseHTMLDocument(document)
+      const ranges = service.findLinkedEditingRanges(document, Position.create(0, 2), html)
+
+      expect(ranges).toBeDefined()
+      expect(ranges!).toHaveLength(2)
+    })
+  })
+
+  describe("format", () => {
+    test("formats HTML content", () => {
+      const service = createService()
+      const document = createDocument("<div><span>text</span></div>")
+      const edits = service.format(document, undefined, { tabSize: 2, insertSpaces: true })
+
+      expect(edits.length).toBeGreaterThan(0)
+    })
+  })
+
+  describe("createScanner", () => {
+    test("tokenizes HTML content", () => {
+      const service = createService()
+      const scanner = service.createScanner("<div>")
+      const tokenType = scanner.scan()
+
+      expect(tokenType).toBeDefined()
+      expect(scanner.getTokenText()).toBe("<")
+    })
+  })
+
+  describe("setDataProviders", () => {
+    test("updates data providers", () => {
+      const service = createService()
+
+      const newProvider: IHTMLDataProvider = {
+        getId: () => "new",
+        isApplicable: () => true,
+        provideTags: () => [],
+        provideAttributes: () => [{ name: "data-custom" }],
+        provideValues: () => [],
+      }
+
+      service.setDataProviders(true, [newProvider])
+
+      const document = createDocument("<div ></div>")
+      const html = service.parseHTMLDocument(document)
+      const completions = service.doComplete(document, Position.create(0, 5), html)
+      const labels = completions.items.map(item => item.label)
+
+      expect(labels).toContain("data-custom")
+    })
+  })
+})

--- a/javascript/packages/language-service/test/parse-html-document.test.ts
+++ b/javascript/packages/language-service/test/parse-html-document.test.ts
@@ -1,0 +1,199 @@
+import dedent from "dedent"
+import { describe, test, expect } from "vitest"
+
+import { HerbHTMLNode } from "../src/herb-html-node.js"
+import { setupHerb, createService, createDocument, getLanguageService, testDataProvider } from "./helpers.js"
+
+describe("parseHTMLDocument", () => {
+  setupHerb()
+
+  test("parses a simple HTML element", () => {
+    const service = createService()
+    const document = createDocument(`<div class="foo"></div>`)
+    const html = service.parseHTMLDocument(document)
+
+    expect(html.roots).toHaveLength(1)
+
+    const root = html.roots[0] as HerbHTMLNode
+    expect(root.tag).toBe("div")
+    expect(root.attributes).toEqual({ class: '"foo"' })
+    expect(root.closed).toBe(true)
+  })
+
+  test("parses an ActionView tag helper as an HTML element", () => {
+    const service = createService()
+    const document = createDocument(`<%= tag.div class: "foo" %>`)
+    const html = service.parseHTMLDocument(document)
+
+    expect(html.roots).toHaveLength(1)
+
+    const root = html.roots[0] as HerbHTMLNode
+    expect(root.tag).toBe("div")
+    expect(root.attributes).toEqual({ class: '"foo"' })
+    expect(root.herbNode).toBeDefined()
+    expect((root.herbNode as any).element_source).toBe("ActionView::Helpers::TagHelper#tag")
+  })
+
+  test("parses ActionView nested data hash into data-* attributes", () => {
+    const service = createService()
+    const document = createDocument(`<%= tag.div data: { controller: "scroll", action: "click->scroll#go" } %>`)
+    const html = service.parseHTMLDocument(document)
+    const root = html.roots[0]
+
+    expect(root.tag).toBe("div")
+    expect(root.attributes?.["data-controller"]).toBe('"scroll"')
+    expect(root.attributes?.["data-action"]).toBe('"click->scroll#go"')
+  })
+
+  test("provides attributeSourceRanges for ActionView attributes", () => {
+    const service = createService()
+    const source = '<%= tag.div data: { controller: "scroll" } %>'
+    const document = createDocument(source)
+
+    const html = service.parseHTMLDocument(document)
+    const root = html.roots[0] as HerbHTMLNode
+    const range = root.attributeSourceRanges?.["data-controller"]
+
+    expect(range).toBeDefined()
+    expect(source.slice(range!.nameStart, range!.nameEnd)).toBe("controller")
+    expect(source.slice(range!.valueStart, range!.valueEnd)).toBe('"scroll"')
+  })
+
+  test("provides attributeSourceRanges for regular HTML attributes", () => {
+    const service = createService()
+    const source = '<div data-controller="scroll"></div>'
+    const document = createDocument(source)
+
+    const html = service.parseHTMLDocument(document)
+    const root = html.roots[0] as HerbHTMLNode
+    const range = root.attributeSourceRanges?.["data-controller"]
+
+    expect(range).toBeDefined()
+    expect(source.slice(range!.nameStart, range!.nameEnd)).toBe("data-controller")
+    expect(source.slice(range!.valueStart, range!.valueEnd)).toBe('"scroll"')
+  })
+
+  test("parses mixed HTML and ERB elements", () => {
+    const service = createService()
+    const document = createDocument(dedent`
+      <%= tag.div data: { controller: "scroll" } %>
+      <div data-controller="hello"></div>
+    `)
+
+    const html = service.parseHTMLDocument(document)
+
+    expect(html.roots).toHaveLength(2)
+
+    const first = html.roots[0]
+    const second = html.roots[1]
+
+    expect(first.tag).toBe("div")
+    expect(second.tag).toBe("div")
+
+    expect(first.attributes?.["data-controller"]).toBe('"scroll"')
+    expect(second.attributes?.["data-controller"]).toBe('"hello"')
+  })
+
+  test("falls back to upstream parser when Herb is not loaded", () => {
+    const service = getLanguageService({ customDataProviders: [testDataProvider] })
+    const document = createDocument(`<div class="foo"></div>`)
+    const html = service.parseHTMLDocument(document)
+
+    expect(html.roots).toHaveLength(1)
+  })
+
+  describe("ERB control flow flattening", () => {
+    test("flattens ERB if/else into HTML elements", () => {
+      const service = createService()
+      const document = createDocument(dedent`
+        <% if condition %>
+          <div></div>
+        <% else %>
+          <span></span>
+        <% end %>
+      `)
+      const html = service.parseHTMLDocument(document)
+
+      const tags = html.roots.map(node => node.tag)
+      expect(tags).toContain("div")
+      expect(tags).toContain("span")
+    })
+
+    test("flattens ERB each block", () => {
+      const service = createService()
+      const document = createDocument(dedent`
+        <% @items.each do |item| %>
+          <li><%= item.name %></li>
+        <% end %>
+      `)
+      const html = service.parseHTMLDocument(document)
+
+      const liNode = html.roots.find(node => node.tag === "li")
+      expect(liNode).toBeDefined()
+    })
+
+    test("flattens nested ERB control flow", () => {
+      const service = createService()
+      const document = createDocument(dedent`
+        <% if a %>
+          <% if b %>
+            <div></div>
+          <% end %>
+        <% end %>
+      `)
+      const html = service.parseHTMLDocument(document)
+
+      const divNode = html.roots.find(node => node.tag === "div")
+      expect(divNode).toBeDefined()
+    })
+
+    test("flattens ERB case/when", () => {
+      const service = createService()
+      const document = createDocument(dedent`
+        <% case status %>
+        <% when :active %>
+          <span class="active"></span>
+        <% when :inactive %>
+          <span class="inactive"></span>
+        <% end %>
+      `)
+      const html = service.parseHTMLDocument(document)
+
+      const spans = html.roots.filter(node => node.tag === "span")
+      expect(spans.length).toBeGreaterThanOrEqual(2)
+    })
+  })
+
+  describe("findNodeAt / findNodeBefore", () => {
+    test("findNodeAt returns the correct element", () => {
+      const service = createService()
+      const source = `<div data-controller="scroll"></div>`
+      const document = createDocument(source)
+      const html = service.parseHTMLDocument(document)
+
+      const node = html.findNodeAt(15)
+      expect(node.tag).toBe("div")
+    })
+
+    test("findNodeAt works for ERB tag helpers", () => {
+      const service = createService()
+      const source = `<%= tag.div data: { controller: "scroll" } %>`
+      const document = createDocument(source)
+      const html = service.parseHTMLDocument(document)
+
+      const node = html.findNodeAt(20)
+      expect(node.tag).toBe("div")
+      expect(node.attributes?.["data-controller"]).toBe('"scroll"')
+    })
+
+    test("findNodeBefore returns the correct element", () => {
+      const service = createService()
+      const source = `<div></div><span></span>`
+      const document = createDocument(source)
+      const html = service.parseHTMLDocument(document)
+
+      const node = html.findNodeBefore(15)
+      expect(node.tag).toBe("span")
+    })
+  })
+})

--- a/javascript/packages/language-service/tsconfig.json
+++ b/javascript/packages/language-service/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "types": [],
+    "rootDir": "./src",
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationDir": "./dist/types",
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "moduleDetection": "force",
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2148,6 +2148,11 @@
   resolved "https://registry.yarnpkg.com/@volar/source-map/-/source-map-2.4.27.tgz#8ce6f16e207987078fd866e2faf65c35c4d15987"
   integrity sha512-ynlcBReMgOZj2i6po+qVswtDUeeBRCTgDurjMGShbm8WYZgJ0PA4RmtebBJ0BCYol1qPv3GQF6jK7C9qoVc7lg==
 
+"@vscode/l10n@^0.0.18":
+  version "0.0.18"
+  resolved "https://registry.yarnpkg.com/@vscode/l10n/-/l10n-0.0.18.tgz#916d3a5e960dbab47c1c56f58a7cb5087b135c95"
+  integrity sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ==
+
 "@vscode/test-cli@^0.0.12":
   version "0.0.12"
   resolved "https://registry.yarnpkg.com/@vscode/test-cli/-/test-cli-0.0.12.tgz#38c1405436a1c960e1abc08790ea822fc9b3e412"
@@ -10024,6 +10029,16 @@ vitest@^4.0.0:
     vite "^6.0.0 || ^7.0.0"
     why-is-node-running "^2.3.0"
 
+vscode-html-languageservice@^5.1.0:
+  version "5.6.2"
+  resolved "https://registry.yarnpkg.com/vscode-html-languageservice/-/vscode-html-languageservice-5.6.2.tgz#32f53261da5d0fad4f69c85dc00de6649e210bd1"
+  integrity sha512-ulCrSnFnfQ16YzvwnYUgEbUEl/ZG7u2eV27YhvLObSHKkb8fw1Z9cgsnUwjTEeDIdJDoTDTDpxuhQwoenoLNMg==
+  dependencies:
+    "@vscode/l10n" "^0.0.18"
+    vscode-languageserver-textdocument "^1.0.12"
+    vscode-languageserver-types "^3.17.5"
+    vscode-uri "^3.1.0"
+
 vscode-jsonrpc@8.2.0:
   version "8.2.0"
   resolved "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz"
@@ -10046,12 +10061,12 @@ vscode-languageserver-protocol@3.17.5:
     vscode-jsonrpc "8.2.0"
     vscode-languageserver-types "3.17.5"
 
-vscode-languageserver-textdocument@^1.0.12:
+vscode-languageserver-textdocument@^1.0.0, vscode-languageserver-textdocument@^1.0.12:
   version "1.0.12"
   resolved "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz"
   integrity sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==
 
-vscode-languageserver-types@3.17.5:
+vscode-languageserver-types@3.17.5, vscode-languageserver-types@^3.17.5:
   version "3.17.5"
   resolved "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz"
   integrity sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==
@@ -10062,6 +10077,11 @@ vscode-languageserver@^9.0.1:
   integrity sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==
   dependencies:
     vscode-languageserver-protocol "3.17.5"
+
+vscode-uri@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-3.1.0.tgz#dd09ec5a66a38b5c3fffc774015713496d14e09c"
+  integrity sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==
 
 vue-resize@^2.0.0-alpha.1:
   version "2.0.0-alpha.1"


### PR DESCRIPTION
This pull request introduces a new package, `@herb-tools/language-service`, which provides an HTML+ERB language service with a compatible API to [`vscode-html-languageservice`](https://github.com/microsoft/vscode-html-languageservice).

It uses the Herb parser to understand both regular HTML elements and ActionView tag helpers, and presents them through the same `LanguageService` interface that `vscode-html-languageservice` consumers expect — making it a drop-in replacement.

### What it does

The core idea is that `parseHTMLDocument` uses the Herb parser instead of a plain HTML scanner. This means a template like `<%= tag.div data: { controller: "scroll" } %>` is understood as a `<div>` with a `data-controller="scroll"` attribute completions, diagnostics, and navigation all work as expected, just like they would for regular HTML.

For completions inside ERB tag helpers, the language service detects the Ruby hash context and adapts accordingly. Inside a `data: {}` hash it suggests `action` instead of `data-action`, and for space-separated attributes like `data-controller="scroll search"` it provides per-token completions rather than replacing the entire value.

Each node in the parsed document tracks where its attributes actually appear in the source text via `attributeSourceRanges`. This is important because ActionView tag helpers synthesize attribute names (e.g., `controller:` in Ruby becomes `data-controller` in HTML), so the language service needs to know where to point diagnostics and highlights in the original ERB source.

When no Herb instance is provided the service falls back to the upstream `vscode-html-languageservice` parser, so it works as a regular HTML language service too. All types and functions from `vscode-html-languageservice` are re-exported so consumers only need a single import.

### Stimulus LSP

This package was built with [Stimulus LSP](https://github.com/marcoroth/stimulus-lsp) as the first consumer in mind.

Stimulus LSP currently uses `vscode-html-languageservice` directly, which means it has no understanding of ERB. Controller completions, diagnostics, and go-to-definition only work inside regular HTML `data-controller` attributes.

By switching to `@herb-tools/language-service`, Stimulus LSP gains full support for ActionView tag helpers like `<%= tag.div data: { controller: "scroll", action: "click->scroll#go" } %>` with the same completions, diagnostics, and navigation that already work for plain HTML.

### Usage

```diff
- import { getLanguageService } from 'vscode-html-languageservice'
+ import { Herb } from '@herb-tools/node-wasm'
+ import { getLanguageService } from '@herb-tools/language-service'

+ await Herb.load()

  const service = getLanguageService({
+   herb: Herb,
    customDataProviders: [myDataProvider],
  })
```