### PR TITLE
Parser: Transform Action View tag helpers inside control flow blocks

### DIFF
--- a/src/analyze/action_view/tag_helpers.c
+++ b/src/analyze/action_view/tag_helpers.c
@@ -1062,21 +1062,8 @@ static AST_NODE_T* transform_link_to_helper(
   return (AST_NODE_T*) element;
 }
 
-void transform_tag_helper_blocks(const AST_NODE_T* node, analyze_ruby_context_T* context) {
-  if (!node || !context) { return; }
-
-  hb_array_T* array = NULL;
-
-  switch (node->type) {
-    case AST_DOCUMENT_NODE: array = ((AST_DOCUMENT_NODE_T*) node)->children; break;
-    case AST_HTML_ELEMENT_NODE: array = ((AST_HTML_ELEMENT_NODE_T*) node)->body; break;
-    case AST_HTML_OPEN_TAG_NODE: array = ((AST_HTML_OPEN_TAG_NODE_T*) node)->children; break;
-    case AST_HTML_ATTRIBUTE_VALUE_NODE: array = ((AST_HTML_ATTRIBUTE_VALUE_NODE_T*) node)->children; break;
-    case AST_ERB_BLOCK_NODE: array = ((AST_ERB_BLOCK_NODE_T*) node)->body; break;
-    default: return;
-  }
-
-  if (!array) { return; }
+void transform_tag_helper_array(hb_array_T* array, analyze_ruby_context_T* context) {
+  if (!array || !context) { return; }
 
   for (size_t i = 0; i < hb_array_size(array); i++) {
     AST_NODE_T* child = hb_array_get(array, i);
@@ -1228,6 +1215,45 @@ void transform_tag_helper_blocks(const AST_NODE_T* node, analyze_ruby_context_T*
 
       hb_array_set(array, i, replacement);
     }
+  }
+}
+
+void transform_tag_helper_blocks(const AST_NODE_T* node, analyze_ruby_context_T* context) {
+  if (!node || !context) { return; }
+
+  switch (node->type) {
+    case AST_DOCUMENT_NODE: transform_tag_helper_array(((AST_DOCUMENT_NODE_T*) node)->children, context); break;
+    case AST_HTML_ELEMENT_NODE: transform_tag_helper_array(((AST_HTML_ELEMENT_NODE_T*) node)->body, context); break;
+    case AST_HTML_CONDITIONAL_ELEMENT_NODE:
+      transform_tag_helper_array(((AST_HTML_CONDITIONAL_ELEMENT_NODE_T*) node)->body, context);
+      break;
+    case AST_HTML_OPEN_TAG_NODE:
+      transform_tag_helper_array(((AST_HTML_OPEN_TAG_NODE_T*) node)->children, context);
+      break;
+    case AST_HTML_ATTRIBUTE_VALUE_NODE:
+      transform_tag_helper_array(((AST_HTML_ATTRIBUTE_VALUE_NODE_T*) node)->children, context);
+      break;
+    case AST_ERB_BLOCK_NODE: transform_tag_helper_array(((AST_ERB_BLOCK_NODE_T*) node)->body, context); break;
+    case AST_ERB_IF_NODE: transform_tag_helper_array(((AST_ERB_IF_NODE_T*) node)->statements, context); break;
+    case AST_ERB_ELSE_NODE: transform_tag_helper_array(((AST_ERB_ELSE_NODE_T*) node)->statements, context); break;
+    case AST_ERB_UNLESS_NODE: transform_tag_helper_array(((AST_ERB_UNLESS_NODE_T*) node)->statements, context); break;
+    case AST_ERB_CASE_NODE:
+      transform_tag_helper_array(((AST_ERB_CASE_NODE_T*) node)->children, context);
+      transform_tag_helper_array(((AST_ERB_CASE_NODE_T*) node)->conditions, context);
+      break;
+    case AST_ERB_CASE_MATCH_NODE:
+      transform_tag_helper_array(((AST_ERB_CASE_MATCH_NODE_T*) node)->children, context);
+      transform_tag_helper_array(((AST_ERB_CASE_MATCH_NODE_T*) node)->conditions, context);
+      break;
+    case AST_ERB_WHEN_NODE: transform_tag_helper_array(((AST_ERB_WHEN_NODE_T*) node)->statements, context); break;
+    case AST_ERB_WHILE_NODE: transform_tag_helper_array(((AST_ERB_WHILE_NODE_T*) node)->statements, context); break;
+    case AST_ERB_UNTIL_NODE: transform_tag_helper_array(((AST_ERB_UNTIL_NODE_T*) node)->statements, context); break;
+    case AST_ERB_FOR_NODE: transform_tag_helper_array(((AST_ERB_FOR_NODE_T*) node)->statements, context); break;
+    case AST_ERB_BEGIN_NODE: transform_tag_helper_array(((AST_ERB_BEGIN_NODE_T*) node)->statements, context); break;
+    case AST_ERB_RESCUE_NODE: transform_tag_helper_array(((AST_ERB_RESCUE_NODE_T*) node)->statements, context); break;
+    case AST_ERB_ENSURE_NODE: transform_tag_helper_array(((AST_ERB_ENSURE_NODE_T*) node)->statements, context); break;
+    case AST_ERB_IN_NODE: transform_tag_helper_array(((AST_ERB_IN_NODE_T*) node)->statements, context); break;
+    default: break;
   }
 }
 

--- a/test/analyze/action_view/tag_helper/tag_test.rb
+++ b/test/analyze/action_view/tag_helper/tag_test.rb
@@ -279,5 +279,60 @@ module Analyze::ActionView::TagHelper
       assert_parsed_snapshot(template, action_view_helpers: true)
       assert_parsed_snapshot(template)
     end
+
+    test "tag.div inside if block" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <% if condition? %>
+          <%= tag.div id: "my-id" do %>
+            Content
+          <% end %>
+        <% end %>
+      HTML
+    end
+
+    test "tag.img inside if block" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <% if condition? %>
+          <%= tag.img src: "/image.png", alt: "Photo" %>
+        <% end %>
+      HTML
+    end
+
+    test "tag.div inside if/else branches" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <% if condition? %>
+          <%= tag.div id: "my-id" do %>
+            Branch one
+          <% end %>
+        <% else %>
+          <%= tag.span id: "my-id" do %>
+            Branch two
+          <% end %>
+        <% end %>
+      HTML
+    end
+
+    test "tag.div inside case/when branches" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <% case status %>
+        <% when "active" %>
+          <%= tag.div class: "active" do %>
+            Active
+          <% end %>
+        <% when "inactive" %>
+          <%= tag.div class: "inactive" do %>
+            Inactive
+          <% end %>
+        <% end %>
+      HTML
+    end
+
+    test "tag.img inside each loop" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <% @items.each do |item| %>
+          <%= tag.img src: item.image_url, alt: item.name %>
+        <% end %>
+      HTML
+    end
   end
 end

--- a/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0038_tag.div_inside_if_block_08a29db5bf73b15e128a208d370a193c-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0038_tag.div_inside_if_block_08a29db5bf73b15e128a208d370a193c-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,77 @@
+---
+source: "Analyze::ActionView::TagHelper::TagTest#test_0038_tag.div inside if block"
+input: |2-
+<% if condition? %>
+  <%= tag.div id: "my-id" do %>
+    Content
+  <% end %>
+<% end %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(6:0))
+└── children: (2 items)
+    ├── @ ERBIfNode (location: (1:0)-(5:9))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
+    │   ├── content: " if condition? " (location: (1:2)-(1:17))
+    │   ├── tag_closing: "%>" (location: (1:17)-(1:19))
+    │   ├── then_keyword: ∅
+    │   ├── statements: (3 items)
+    │   │   ├── @ HTMLTextNode (location: (1:19)-(2:2))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ HTMLElementNode (location: (2:2)-(4:11))
+    │   │   │   ├── open_tag:
+    │   │   │   │   └── @ ERBOpenTagNode (location: (2:2)-(2:31))
+    │   │   │   │       ├── tag_opening: "<%=" (location: (2:2)-(2:5))
+    │   │   │   │       ├── content: " tag.div id: "my-id" do " (location: (2:5)-(2:29))
+    │   │   │   │       ├── tag_closing: "%>" (location: (2:29)-(2:31))
+    │   │   │   │       ├── tag_name: "div" (location: (2:10)-(2:13))
+    │   │   │   │       └── children: (1 item)
+    │   │   │   │           └── @ HTMLAttributeNode (location: (2:14)-(2:18))
+    │   │   │   │               ├── name:
+    │   │   │   │               │   └── @ HTMLAttributeNameNode (location: (2:14)-(2:18))
+    │   │   │   │               │       └── children: (1 item)
+    │   │   │   │               │           └── @ LiteralNode (location: (2:14)-(2:18))
+    │   │   │   │               │               └── content: "id"
+    │   │   │   │               │
+    │   │   │   │               │
+    │   │   │   │               ├── equals: "=" (location: (2:14)-(2:18))
+    │   │   │   │               └── value:
+    │   │   │   │                   └── @ HTMLAttributeValueNode (location: (2:14)-(2:18))
+    │   │   │   │                       ├── open_quote: """ (location: (2:14)-(2:18))
+    │   │   │   │                       ├── children: (1 item)
+    │   │   │   │                       │   └── @ LiteralNode (location: (2:14)-(2:18))
+    │   │   │   │                       │       └── content: "my-id"
+    │   │   │   │                       │
+    │   │   │   │                       ├── close_quote: """ (location: (2:18)-(2:18))
+    │   │   │   │                       └── quoted: true
+    │   │   │   │
+    │   │   │   │
+    │   │   │   │
+    │   │   │   ├── tag_name: "div" (location: (2:10)-(2:13))
+    │   │   │   ├── body: (1 item)
+    │   │   │   │   └── @ HTMLTextNode (location: (2:31)-(4:2))
+    │   │   │   │       └── content: "\n    Content\n  "
+    │   │   │   │
+    │   │   │   ├── close_tag:
+    │   │   │   │   └── @ ERBEndNode (location: (4:2)-(4:11))
+    │   │   │   │       ├── tag_opening: "<%" (location: (4:2)-(4:4))
+    │   │   │   │       ├── content: " end " (location: (4:4)-(4:9))
+    │   │   │   │       └── tag_closing: "%>" (location: (4:9)-(4:11))
+    │   │   │   │
+    │   │   │   ├── is_void: false
+    │   │   │   └── element_source: "ActionView::Helpers::TagHelper#tag"
+    │   │   │
+    │   │   └── @ HTMLTextNode (location: (4:11)-(5:0))
+    │   │       └── content: "\n"
+    │   │
+    │   ├── subsequent: ∅
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (5:0)-(5:9))
+    │           ├── tag_opening: "<%" (location: (5:0)-(5:2))
+    │           ├── content: " end " (location: (5:2)-(5:7))
+    │           └── tag_closing: "%>" (location: (5:7)-(5:9))
+    │
+    │
+    └── @ HTMLTextNode (location: (5:9)-(6:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0039_tag.img_inside_if_block_172928c57b9767e9ab8e8b140f070cf4-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0039_tag.img_inside_if_block_172928c57b9767e9ab8e8b140f070cf4-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,87 @@
+---
+source: "Analyze::ActionView::TagHelper::TagTest#test_0039_tag.img inside if block"
+input: |2-
+<% if condition? %>
+  <%= tag.img src: "/image.png", alt: "Photo" %>
+<% end %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(4:0))
+└── children: (2 items)
+    ├── @ ERBIfNode (location: (1:0)-(3:9))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
+    │   ├── content: " if condition? " (location: (1:2)-(1:17))
+    │   ├── tag_closing: "%>" (location: (1:17)-(1:19))
+    │   ├── then_keyword: ∅
+    │   ├── statements: (3 items)
+    │   │   ├── @ HTMLTextNode (location: (1:19)-(2:2))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ HTMLElementNode (location: (2:2)-(2:48))
+    │   │   │   ├── open_tag:
+    │   │   │   │   └── @ ERBOpenTagNode (location: (2:2)-(2:48))
+    │   │   │   │       ├── tag_opening: "<%=" (location: (2:2)-(2:5))
+    │   │   │   │       ├── content: " tag.img src: "/image.png", alt: "Photo" " (location: (2:5)-(2:46))
+    │   │   │   │       ├── tag_closing: "%>" (location: (2:46)-(2:48))
+    │   │   │   │       ├── tag_name: "img" (location: (2:10)-(2:13))
+    │   │   │   │       └── children: (2 items)
+    │   │   │   │           ├── @ HTMLAttributeNode (location: (2:14)-(2:19))
+    │   │   │   │           │   ├── name:
+    │   │   │   │           │   │   └── @ HTMLAttributeNameNode (location: (2:14)-(2:19))
+    │   │   │   │           │   │       └── children: (1 item)
+    │   │   │   │           │   │           └── @ LiteralNode (location: (2:14)-(2:19))
+    │   │   │   │           │   │               └── content: "src"
+    │   │   │   │           │   │
+    │   │   │   │           │   │
+    │   │   │   │           │   ├── equals: "=" (location: (2:14)-(2:19))
+    │   │   │   │           │   └── value:
+    │   │   │   │           │       └── @ HTMLAttributeValueNode (location: (2:14)-(2:19))
+    │   │   │   │           │           ├── open_quote: """ (location: (2:14)-(2:19))
+    │   │   │   │           │           ├── children: (1 item)
+    │   │   │   │           │           │   └── @ LiteralNode (location: (2:14)-(2:19))
+    │   │   │   │           │           │       └── content: "/image.png"
+    │   │   │   │           │           │
+    │   │   │   │           │           ├── close_quote: """ (location: (2:19)-(2:19))
+    │   │   │   │           │           └── quoted: true
+    │   │   │   │           │
+    │   │   │   │           │
+    │   │   │   │           └── @ HTMLAttributeNode (location: (2:33)-(2:38))
+    │   │   │   │               ├── name:
+    │   │   │   │               │   └── @ HTMLAttributeNameNode (location: (2:33)-(2:38))
+    │   │   │   │               │       └── children: (1 item)
+    │   │   │   │               │           └── @ LiteralNode (location: (2:33)-(2:38))
+    │   │   │   │               │               └── content: "alt"
+    │   │   │   │               │
+    │   │   │   │               │
+    │   │   │   │               ├── equals: "=" (location: (2:33)-(2:38))
+    │   │   │   │               └── value:
+    │   │   │   │                   └── @ HTMLAttributeValueNode (location: (2:33)-(2:38))
+    │   │   │   │                       ├── open_quote: """ (location: (2:33)-(2:38))
+    │   │   │   │                       ├── children: (1 item)
+    │   │   │   │                       │   └── @ LiteralNode (location: (2:33)-(2:38))
+    │   │   │   │                       │       └── content: "Photo"
+    │   │   │   │                       │
+    │   │   │   │                       ├── close_quote: """ (location: (2:38)-(2:38))
+    │   │   │   │                       └── quoted: true
+    │   │   │   │
+    │   │   │   │
+    │   │   │   │
+    │   │   │   ├── tag_name: "img" (location: (2:10)-(2:13))
+    │   │   │   ├── body: []
+    │   │   │   ├── close_tag: ∅
+    │   │   │   ├── is_void: true
+    │   │   │   └── element_source: "ActionView::Helpers::TagHelper#tag"
+    │   │   │
+    │   │   └── @ HTMLTextNode (location: (2:48)-(3:0))
+    │   │       └── content: "\n"
+    │   │
+    │   ├── subsequent: ∅
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (3:0)-(3:9))
+    │           ├── tag_opening: "<%" (location: (3:0)-(3:2))
+    │           ├── content: " end " (location: (3:2)-(3:7))
+    │           └── tag_closing: "%>" (location: (3:7)-(3:9))
+    │
+    │
+    └── @ HTMLTextNode (location: (3:9)-(4:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0040_tag.div_inside_if_else_branches_f07868e165e21c5ed772e30b0572d459-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0040_tag.div_inside_if_else_branches_f07868e165e21c5ed772e30b0572d459-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,136 @@
+---
+source: "Analyze::ActionView::TagHelper::TagTest#test_0040_tag.div inside if/else branches"
+input: |2-
+<% if condition? %>
+  <%= tag.div id: "my-id" do %>
+    Branch one
+  <% end %>
+<% else %>
+  <%= tag.span id: "my-id" do %>
+    Branch two
+  <% end %>
+<% end %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(10:0))
+└── children: (2 items)
+    ├── @ ERBIfNode (location: (1:0)-(9:9))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
+    │   ├── content: " if condition? " (location: (1:2)-(1:17))
+    │   ├── tag_closing: "%>" (location: (1:17)-(1:19))
+    │   ├── then_keyword: ∅
+    │   ├── statements: (3 items)
+    │   │   ├── @ HTMLTextNode (location: (1:19)-(2:2))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ HTMLElementNode (location: (2:2)-(4:11))
+    │   │   │   ├── open_tag:
+    │   │   │   │   └── @ ERBOpenTagNode (location: (2:2)-(2:31))
+    │   │   │   │       ├── tag_opening: "<%=" (location: (2:2)-(2:5))
+    │   │   │   │       ├── content: " tag.div id: "my-id" do " (location: (2:5)-(2:29))
+    │   │   │   │       ├── tag_closing: "%>" (location: (2:29)-(2:31))
+    │   │   │   │       ├── tag_name: "div" (location: (2:10)-(2:13))
+    │   │   │   │       └── children: (1 item)
+    │   │   │   │           └── @ HTMLAttributeNode (location: (2:14)-(2:18))
+    │   │   │   │               ├── name:
+    │   │   │   │               │   └── @ HTMLAttributeNameNode (location: (2:14)-(2:18))
+    │   │   │   │               │       └── children: (1 item)
+    │   │   │   │               │           └── @ LiteralNode (location: (2:14)-(2:18))
+    │   │   │   │               │               └── content: "id"
+    │   │   │   │               │
+    │   │   │   │               │
+    │   │   │   │               ├── equals: "=" (location: (2:14)-(2:18))
+    │   │   │   │               └── value:
+    │   │   │   │                   └── @ HTMLAttributeValueNode (location: (2:14)-(2:18))
+    │   │   │   │                       ├── open_quote: """ (location: (2:14)-(2:18))
+    │   │   │   │                       ├── children: (1 item)
+    │   │   │   │                       │   └── @ LiteralNode (location: (2:14)-(2:18))
+    │   │   │   │                       │       └── content: "my-id"
+    │   │   │   │                       │
+    │   │   │   │                       ├── close_quote: """ (location: (2:18)-(2:18))
+    │   │   │   │                       └── quoted: true
+    │   │   │   │
+    │   │   │   │
+    │   │   │   │
+    │   │   │   ├── tag_name: "div" (location: (2:10)-(2:13))
+    │   │   │   ├── body: (1 item)
+    │   │   │   │   └── @ HTMLTextNode (location: (2:31)-(4:2))
+    │   │   │   │       └── content: "\n    Branch one\n  "
+    │   │   │   │
+    │   │   │   ├── close_tag:
+    │   │   │   │   └── @ ERBEndNode (location: (4:2)-(4:11))
+    │   │   │   │       ├── tag_opening: "<%" (location: (4:2)-(4:4))
+    │   │   │   │       ├── content: " end " (location: (4:4)-(4:9))
+    │   │   │   │       └── tag_closing: "%>" (location: (4:9)-(4:11))
+    │   │   │   │
+    │   │   │   ├── is_void: false
+    │   │   │   └── element_source: "ActionView::Helpers::TagHelper#tag"
+    │   │   │
+    │   │   └── @ HTMLTextNode (location: (4:11)-(5:0))
+    │   │       └── content: "\n"
+    │   │
+    │   ├── subsequent:
+    │   │   └── @ ERBElseNode (location: (5:0)-(9:0))
+    │   │       ├── tag_opening: "<%" (location: (5:0)-(5:2))
+    │   │       ├── content: " else " (location: (5:2)-(5:8))
+    │   │       ├── tag_closing: "%>" (location: (5:8)-(5:10))
+    │   │       └── statements: (3 items)
+    │   │           ├── @ HTMLTextNode (location: (5:10)-(6:2))
+    │   │           │   └── content: "\n  "
+    │   │           │
+    │   │           ├── @ HTMLElementNode (location: (6:2)-(8:11))
+    │   │           │   ├── open_tag:
+    │   │           │   │   └── @ ERBOpenTagNode (location: (6:2)-(6:32))
+    │   │           │   │       ├── tag_opening: "<%=" (location: (6:2)-(6:5))
+    │   │           │   │       ├── content: " tag.span id: "my-id" do " (location: (6:5)-(6:30))
+    │   │           │   │       ├── tag_closing: "%>" (location: (6:30)-(6:32))
+    │   │           │   │       ├── tag_name: "span" (location: (6:10)-(6:14))
+    │   │           │   │       └── children: (1 item)
+    │   │           │   │           └── @ HTMLAttributeNode (location: (6:15)-(6:19))
+    │   │           │   │               ├── name:
+    │   │           │   │               │   └── @ HTMLAttributeNameNode (location: (6:15)-(6:19))
+    │   │           │   │               │       └── children: (1 item)
+    │   │           │   │               │           └── @ LiteralNode (location: (6:15)-(6:19))
+    │   │           │   │               │               └── content: "id"
+    │   │           │   │               │
+    │   │           │   │               │
+    │   │           │   │               ├── equals: "=" (location: (6:15)-(6:19))
+    │   │           │   │               └── value:
+    │   │           │   │                   └── @ HTMLAttributeValueNode (location: (6:15)-(6:19))
+    │   │           │   │                       ├── open_quote: """ (location: (6:15)-(6:19))
+    │   │           │   │                       ├── children: (1 item)
+    │   │           │   │                       │   └── @ LiteralNode (location: (6:15)-(6:19))
+    │   │           │   │                       │       └── content: "my-id"
+    │   │           │   │                       │
+    │   │           │   │                       ├── close_quote: """ (location: (6:19)-(6:19))
+    │   │           │   │                       └── quoted: true
+    │   │           │   │
+    │   │           │   │
+    │   │           │   │
+    │   │           │   ├── tag_name: "span" (location: (6:10)-(6:14))
+    │   │           │   ├── body: (1 item)
+    │   │           │   │   └── @ HTMLTextNode (location: (6:32)-(8:2))
+    │   │           │   │       └── content: "\n    Branch two\n  "
+    │   │           │   │
+    │   │           │   ├── close_tag:
+    │   │           │   │   └── @ ERBEndNode (location: (8:2)-(8:11))
+    │   │           │   │       ├── tag_opening: "<%" (location: (8:2)-(8:4))
+    │   │           │   │       ├── content: " end " (location: (8:4)-(8:9))
+    │   │           │   │       └── tag_closing: "%>" (location: (8:9)-(8:11))
+    │   │           │   │
+    │   │           │   ├── is_void: false
+    │   │           │   └── element_source: "ActionView::Helpers::TagHelper#tag"
+    │   │           │
+    │   │           └── @ HTMLTextNode (location: (8:11)-(9:0))
+    │   │               └── content: "\n"
+    │   │
+    │   │
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (9:0)-(9:9))
+    │           ├── tag_opening: "<%" (location: (9:0)-(9:2))
+    │           ├── content: " end " (location: (9:2)-(9:7))
+    │           └── tag_closing: "%>" (location: (9:7)-(9:9))
+    │
+    │
+    └── @ HTMLTextNode (location: (9:9)-(10:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0041_tag.div_inside_case_when_branches_b44502a2e213c448870f0e12b34aef1b-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0041_tag.div_inside_case_when_branches_b44502a2e213c448870f0e12b34aef1b-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,148 @@
+---
+source: "Analyze::ActionView::TagHelper::TagTest#test_0041_tag.div inside case/when branches"
+input: |2-
+<% case status %>
+<% when "active" %>
+  <%= tag.div class: "active" do %>
+    Active
+  <% end %>
+<% when "inactive" %>
+  <%= tag.div class: "inactive" do %>
+    Inactive
+  <% end %>
+<% end %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(11:0))
+└── children: (2 items)
+    ├── @ ERBCaseNode (location: (1:0)-(10:9))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
+    │   ├── content: " case status " (location: (1:2)-(1:15))
+    │   ├── tag_closing: "%>" (location: (1:15)-(1:17))
+    │   ├── children: (1 item)
+    │   │   └── @ HTMLTextNode (location: (1:17)-(2:0))
+    │   │       └── content: "\n"
+    │   │
+    │   ├── conditions: (2 items)
+    │   │   ├── @ ERBWhenNode (location: (2:0)-(2:19))
+    │   │   │   ├── tag_opening: "<%" (location: (2:0)-(2:2))
+    │   │   │   ├── content: " when "active" " (location: (2:2)-(2:17))
+    │   │   │   ├── tag_closing: "%>" (location: (2:17)-(2:19))
+    │   │   │   ├── then_keyword: ∅
+    │   │   │   └── statements: (3 items)
+    │   │   │       ├── @ HTMLTextNode (location: (2:19)-(3:2))
+    │   │   │       │   └── content: "\n  "
+    │   │   │       │
+    │   │   │       ├── @ HTMLElementNode (location: (3:2)-(5:11))
+    │   │   │       │   ├── open_tag:
+    │   │   │       │   │   └── @ ERBOpenTagNode (location: (3:2)-(3:35))
+    │   │   │       │   │       ├── tag_opening: "<%=" (location: (3:2)-(3:5))
+    │   │   │       │   │       ├── content: " tag.div class: "active" do " (location: (3:5)-(3:33))
+    │   │   │       │   │       ├── tag_closing: "%>" (location: (3:33)-(3:35))
+    │   │   │       │   │       ├── tag_name: "div" (location: (3:10)-(3:13))
+    │   │   │       │   │       └── children: (1 item)
+    │   │   │       │   │           └── @ HTMLAttributeNode (location: (3:14)-(3:21))
+    │   │   │       │   │               ├── name:
+    │   │   │       │   │               │   └── @ HTMLAttributeNameNode (location: (3:14)-(3:21))
+    │   │   │       │   │               │       └── children: (1 item)
+    │   │   │       │   │               │           └── @ LiteralNode (location: (3:14)-(3:21))
+    │   │   │       │   │               │               └── content: "class"
+    │   │   │       │   │               │
+    │   │   │       │   │               │
+    │   │   │       │   │               ├── equals: "=" (location: (3:14)-(3:21))
+    │   │   │       │   │               └── value:
+    │   │   │       │   │                   └── @ HTMLAttributeValueNode (location: (3:14)-(3:21))
+    │   │   │       │   │                       ├── open_quote: """ (location: (3:14)-(3:21))
+    │   │   │       │   │                       ├── children: (1 item)
+    │   │   │       │   │                       │   └── @ LiteralNode (location: (3:14)-(3:21))
+    │   │   │       │   │                       │       └── content: "active"
+    │   │   │       │   │                       │
+    │   │   │       │   │                       ├── close_quote: """ (location: (3:21)-(3:21))
+    │   │   │       │   │                       └── quoted: true
+    │   │   │       │   │
+    │   │   │       │   │
+    │   │   │       │   │
+    │   │   │       │   ├── tag_name: "div" (location: (3:10)-(3:13))
+    │   │   │       │   ├── body: (1 item)
+    │   │   │       │   │   └── @ HTMLTextNode (location: (3:35)-(5:2))
+    │   │   │       │   │       └── content: "\n    Active\n  "
+    │   │   │       │   │
+    │   │   │       │   ├── close_tag:
+    │   │   │       │   │   └── @ ERBEndNode (location: (5:2)-(5:11))
+    │   │   │       │   │       ├── tag_opening: "<%" (location: (5:2)-(5:4))
+    │   │   │       │   │       ├── content: " end " (location: (5:4)-(5:9))
+    │   │   │       │   │       └── tag_closing: "%>" (location: (5:9)-(5:11))
+    │   │   │       │   │
+    │   │   │       │   ├── is_void: false
+    │   │   │       │   └── element_source: "ActionView::Helpers::TagHelper#tag"
+    │   │   │       │
+    │   │   │       └── @ HTMLTextNode (location: (5:11)-(6:0))
+    │   │   │           └── content: "\n"
+    │   │   │
+    │   │   │
+    │   │   └── @ ERBWhenNode (location: (6:0)-(6:21))
+    │   │       ├── tag_opening: "<%" (location: (6:0)-(6:2))
+    │   │       ├── content: " when "inactive" " (location: (6:2)-(6:19))
+    │   │       ├── tag_closing: "%>" (location: (6:19)-(6:21))
+    │   │       ├── then_keyword: ∅
+    │   │       └── statements: (3 items)
+    │   │           ├── @ HTMLTextNode (location: (6:21)-(7:2))
+    │   │           │   └── content: "\n  "
+    │   │           │
+    │   │           ├── @ HTMLElementNode (location: (7:2)-(9:11))
+    │   │           │   ├── open_tag:
+    │   │           │   │   └── @ ERBOpenTagNode (location: (7:2)-(7:37))
+    │   │           │   │       ├── tag_opening: "<%=" (location: (7:2)-(7:5))
+    │   │           │   │       ├── content: " tag.div class: "inactive" do " (location: (7:5)-(7:35))
+    │   │           │   │       ├── tag_closing: "%>" (location: (7:35)-(7:37))
+    │   │           │   │       ├── tag_name: "div" (location: (7:10)-(7:13))
+    │   │           │   │       └── children: (1 item)
+    │   │           │   │           └── @ HTMLAttributeNode (location: (7:14)-(7:21))
+    │   │           │   │               ├── name:
+    │   │           │   │               │   └── @ HTMLAttributeNameNode (location: (7:14)-(7:21))
+    │   │           │   │               │       └── children: (1 item)
+    │   │           │   │               │           └── @ LiteralNode (location: (7:14)-(7:21))
+    │   │           │   │               │               └── content: "class"
+    │   │           │   │               │
+    │   │           │   │               │
+    │   │           │   │               ├── equals: "=" (location: (7:14)-(7:21))
+    │   │           │   │               └── value:
+    │   │           │   │                   └── @ HTMLAttributeValueNode (location: (7:14)-(7:21))
+    │   │           │   │                       ├── open_quote: """ (location: (7:14)-(7:21))
+    │   │           │   │                       ├── children: (1 item)
+    │   │           │   │                       │   └── @ LiteralNode (location: (7:14)-(7:21))
+    │   │           │   │                       │       └── content: "inactive"
+    │   │           │   │                       │
+    │   │           │   │                       ├── close_quote: """ (location: (7:21)-(7:21))
+    │   │           │   │                       └── quoted: true
+    │   │           │   │
+    │   │           │   │
+    │   │           │   │
+    │   │           │   ├── tag_name: "div" (location: (7:10)-(7:13))
+    │   │           │   ├── body: (1 item)
+    │   │           │   │   └── @ HTMLTextNode (location: (7:37)-(9:2))
+    │   │           │   │       └── content: "\n    Inactive\n  "
+    │   │           │   │
+    │   │           │   ├── close_tag:
+    │   │           │   │   └── @ ERBEndNode (location: (9:2)-(9:11))
+    │   │           │   │       ├── tag_opening: "<%" (location: (9:2)-(9:4))
+    │   │           │   │       ├── content: " end " (location: (9:4)-(9:9))
+    │   │           │   │       └── tag_closing: "%>" (location: (9:9)-(9:11))
+    │   │           │   │
+    │   │           │   ├── is_void: false
+    │   │           │   └── element_source: "ActionView::Helpers::TagHelper#tag"
+    │   │           │
+    │   │           └── @ HTMLTextNode (location: (9:11)-(10:0))
+    │   │               └── content: "\n"
+    │   │
+    │   │
+    │   ├── else_clause: ∅
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (10:0)-(10:9))
+    │           ├── tag_opening: "<%" (location: (10:0)-(10:2))
+    │           ├── content: " end " (location: (10:2)-(10:7))
+    │           └── tag_closing: "%>" (location: (10:7)-(10:9))
+    │
+    │
+    └── @ HTMLTextNode (location: (10:9)-(11:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0042_tag.img_inside_each_loop_60089b96bf7fe18cb9f1e9134e05bc6e-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0042_tag.img_inside_each_loop_60089b96bf7fe18cb9f1e9134e05bc6e-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,85 @@
+---
+source: "Analyze::ActionView::TagHelper::TagTest#test_0042_tag.img inside each loop"
+input: |2-
+<% @items.each do |item| %>
+  <%= tag.img src: item.image_url, alt: item.name %>
+<% end %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(4:0))
+└── children: (2 items)
+    ├── @ ERBBlockNode (location: (1:0)-(3:9))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
+    │   ├── content: " @items.each do |item| " (location: (1:2)-(1:25))
+    │   ├── tag_closing: "%>" (location: (1:25)-(1:27))
+    │   ├── body: (3 items)
+    │   │   ├── @ HTMLTextNode (location: (1:27)-(2:2))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ HTMLElementNode (location: (2:2)-(2:52))
+    │   │   │   ├── open_tag:
+    │   │   │   │   └── @ ERBOpenTagNode (location: (2:2)-(2:52))
+    │   │   │   │       ├── tag_opening: "<%=" (location: (2:2)-(2:5))
+    │   │   │   │       ├── content: " tag.img src: item.image_url, alt: item.name " (location: (2:5)-(2:50))
+    │   │   │   │       ├── tag_closing: "%>" (location: (2:50)-(2:52))
+    │   │   │   │       ├── tag_name: "img" (location: (2:10)-(2:13))
+    │   │   │   │       └── children: (2 items)
+    │   │   │   │           ├── @ HTMLAttributeNode (location: (2:14)-(2:19))
+    │   │   │   │           │   ├── name:
+    │   │   │   │           │   │   └── @ HTMLAttributeNameNode (location: (2:14)-(2:19))
+    │   │   │   │           │   │       └── children: (1 item)
+    │   │   │   │           │   │           └── @ LiteralNode (location: (2:14)-(2:19))
+    │   │   │   │           │   │               └── content: "src"
+    │   │   │   │           │   │
+    │   │   │   │           │   │
+    │   │   │   │           │   ├── equals: ":" (location: (2:14)-(2:19))
+    │   │   │   │           │   └── value:
+    │   │   │   │           │       └── @ HTMLAttributeValueNode (location: (2:14)-(2:19))
+    │   │   │   │           │           ├── open_quote: ∅
+    │   │   │   │           │           ├── children: (1 item)
+    │   │   │   │           │           │   └── @ RubyLiteralNode (location: (2:14)-(2:19))
+    │   │   │   │           │           │       └── content: "item.image_url"
+    │   │   │   │           │           │
+    │   │   │   │           │           ├── close_quote: ∅
+    │   │   │   │           │           └── quoted: false
+    │   │   │   │           │
+    │   │   │   │           │
+    │   │   │   │           └── @ HTMLAttributeNode (location: (2:35)-(2:40))
+    │   │   │   │               ├── name:
+    │   │   │   │               │   └── @ HTMLAttributeNameNode (location: (2:35)-(2:40))
+    │   │   │   │               │       └── children: (1 item)
+    │   │   │   │               │           └── @ LiteralNode (location: (2:35)-(2:40))
+    │   │   │   │               │               └── content: "alt"
+    │   │   │   │               │
+    │   │   │   │               │
+    │   │   │   │               ├── equals: ":" (location: (2:35)-(2:40))
+    │   │   │   │               └── value:
+    │   │   │   │                   └── @ HTMLAttributeValueNode (location: (2:35)-(2:40))
+    │   │   │   │                       ├── open_quote: ∅
+    │   │   │   │                       ├── children: (1 item)
+    │   │   │   │                       │   └── @ RubyLiteralNode (location: (2:35)-(2:40))
+    │   │   │   │                       │       └── content: "item.name"
+    │   │   │   │                       │
+    │   │   │   │                       ├── close_quote: ∅
+    │   │   │   │                       └── quoted: false
+    │   │   │   │
+    │   │   │   │
+    │   │   │   │
+    │   │   │   ├── tag_name: "img" (location: (2:10)-(2:13))
+    │   │   │   ├── body: []
+    │   │   │   ├── close_tag: ∅
+    │   │   │   ├── is_void: true
+    │   │   │   └── element_source: "ActionView::Helpers::TagHelper#tag"
+    │   │   │
+    │   │   └── @ HTMLTextNode (location: (2:52)-(3:0))
+    │   │       └── content: "\n"
+    │   │
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (3:0)-(3:9))
+    │           ├── tag_opening: "<%" (location: (3:0)-(3:2))
+    │           ├── content: " end " (location: (3:2)-(3:7))
+    │           └── tag_closing: "%>" (location: (3:7)-(3:9))
+    │
+    │
+    └── @ HTMLTextNode (location: (3:9)-(4:0))
+        └── content: "\n"


### PR DESCRIPTION
This pull request fixes a bug in the `action_view_helpers` parser analysis where tag helpers inside control flow blocks were not being transformed into `HTMLElementNode` AST representations. They remained as `ERBContentNode`, making them invisible to consumers relying on the transformed AST.

For example, the following template with `action_view_helpers: true`:

```erb
<% if condition? %>
  <%= tag.img src: "/image.png", alt: "Photo" %>
<% end %>
```

  Previously produced:
```js
  @ ERBIfNode (location: (1:0)-(3:9))
  ├── statements: (1 item)
  │   └── @ ERBContentNode (location: (2:2)-(2:48))
  │       ├── tag_opening: "<%=" (location: (2:2)-(2:5))
  │       ├── content: " tag.img src: \"/image.png\", alt: \"Photo\" " (location: (2:5)-(2:46))
  │       └── tag_closing: "%>" (location: (2:46)-(2:48))
```

Now correctly produces:
```js
  @ ERBIfNode (location: (1:0)-(3:9))
  ├── statements: (1 item)
  │   └── @ HTMLElementNode (location: (2:2)-(2:48))
  │       ├── open_tag:
  │       │   └── @ ERBOpenTagNode (location: (2:2)-(2:48))
  │       │       ├── tag_opening: "<%=" (location: (2:2)-(2:5))
  │       │       ├── content: " tag.img src: \"/image.png\", alt: \"Photo\" " (location: (2:5)-(2:46))
  │       │       ├── tag_closing: "%>" (location: (2:46)-(2:48))
  │       │       ├── tag_name: "img" (location: (2:10)-(2:13))
  │       │       └── children: (2 items)
  │       │           ├── @ HTMLAttributeNode (name: "src", value: "/image.png")
  │       │           └── @ HTMLAttributeNode (name: "alt", value: "Photo")
  │       │
  │       ├── tag_name: "img" (location: (2:10)-(2:13))
  │       ├── body: []
  │       ├── close_tag: ∅
  │       ├── is_void: true
  │       └── element_source: "ActionView::Helpers::TagHelper#tag"
```