### PR TITLE
Linter: Make `html-no-duplicate-ids` Action View Helpers aware

### DIFF
--- a/javascript/packages/linter/src/rules/html-no-duplicate-ids.ts
+++ b/javascript/packages/linter/src/rules/html-no-duplicate-ids.ts
@@ -5,7 +5,7 @@ import { Printer, IdentityPrinter } from "@herb-tools/printer"
 
 import { hasERBOutput, getValidatableStaticContent, isEffectivelyStatic, isNode, getStaticAttributeName, isERBOutputNode } from "@herb-tools/core"
 
-import type { ParseResult, HTMLAttributeNode, ERBContentNode } from "@herb-tools/core"
+import type { ParseResult, HTMLAttributeNode, ERBContentNode, ParserOptions } from "@herb-tools/core"
 import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types"
 
 interface ControlFlowState {
@@ -209,6 +209,10 @@ export class HTMLNoDuplicateIdsRule extends ParserRule {
       enabled: true,
       severity: "error"
     }
+  }
+
+  get parserOptions(): Partial<ParserOptions> {
+    return { action_view_helpers: true }
   }
 
   check(result: ParseResult, context?: Partial<LintContext>): UnboundLintOffense[] {

--- a/javascript/packages/linter/test/rules/html-no-duplicate-ids.test.ts
+++ b/javascript/packages/linter/test/rules/html-no-duplicate-ids.test.ts
@@ -450,4 +450,114 @@ describe("html-no-duplicate-ids", () => {
       <% end %>
     `)
   })
+
+  test("passes for tag helper with unique id", () => {
+    expectNoOffenses('<%= tag.div id: "unique" %>')
+  })
+
+  test("fails for duplicate IDs between tag helper and HTML element", () => {
+    expectError('Duplicate ID `my-id` found. IDs must be unique within a document.')
+    assertOffenses(dedent`
+      <%= tag.div id: "my-id" do %>
+        content
+      <% end %>
+      <div id="my-id">content</div>
+    `)
+  })
+
+  test("fails for duplicate IDs between two tag helpers", () => {
+    expectError('Duplicate ID `my-id` found. IDs must be unique within a document.')
+    assertOffenses(dedent`
+      <%= tag.div id: "my-id" do %>
+        content
+      <% end %>
+      <%= tag.span id: "my-id" %>
+    `)
+  })
+
+  test("passes for IDs in mutually exclusive branches with HTML and tag helper", () => {
+    expectNoOffenses(dedent`
+      <% if use_tag_helper? %>
+        <%= tag.div id: "my-id" do %>
+          content
+        <% end %>
+      <% else %>
+        <div id="my-id">content</div>
+      <% end %>
+    `)
+  })
+
+  test("fails for duplicate IDs in same branch with void tag helper and HTML", () => {
+    expectError('Duplicate ID `my-id` found within the same control flow branch. IDs must be unique within the same control flow branch.')
+    assertOffenses(dedent`
+      <% if condition? %>
+        <%= tag.img id: "my-id", src: "/image.png", alt: "Photo" %>
+        <img id="my-id" src="/other.png" alt="Other">
+      <% end %>
+    `)
+  })
+
+  test("fails for duplicate IDs in same branch with block tag helper and HTML", () => {
+    expectError('Duplicate ID `my-id` found within the same control flow branch. IDs must be unique within the same control flow branch.')
+    assertOffenses(dedent`
+      <% if condition? %>
+        <%= tag.div id: "my-id" do %>
+          content
+        <% end %>
+        <div id="my-id">content</div>
+      <% end %>
+    `)
+  })
+
+  test("passes for IDs in mutually exclusive branches with tag helpers on both sides", () => {
+    expectNoOffenses(dedent`
+      <% if condition? %>
+        <%= tag.div id: "shared-id" do %>
+          branch one
+        <% end %>
+      <% else %>
+        <%= tag.span id: "shared-id" do %>
+          branch two
+        <% end %>
+      <% end %>
+    `)
+  })
+
+  test("fails for turbo_frame_tag with duplicate id from positional argument and another element", () => {
+    expectError('Duplicate ID `my-frame` found. IDs must be unique within a document.')
+    assertOffenses(dedent`
+      <%= turbo_frame_tag "my-frame" do %>
+        content
+      <% end %>
+      <div id="my-frame">content</div>
+    `)
+  })
+
+  test("passes for turbo_frame_tag id in mutually exclusive branch with HTML id", () => {
+    expectNoOffenses(dedent`
+      <% if turbo? %>
+        <%= turbo_frame_tag "my-frame" do %>
+          content
+        <% end %>
+      <% else %>
+        <div id="my-frame">content</div>
+      <% end %>
+    `)
+  })
+
+  test("fails for image_tag with duplicate id and HTML element", () => {
+    expectError('Duplicate ID `logo` found. IDs must be unique within a document.')
+    assertOffenses(dedent`
+      <%= image_tag "logo.png", id: "logo" %>
+      <img src="logo.png" id="logo">
+    `)
+  })
+
+  test("fails for link_to with duplicate id and HTML element", () => {
+    expectError('Duplicate ID `home-link` found. IDs must be unique within a document.')
+    assertOffenses(dedent`
+      <%= link_to "Home", root_path, id: "home-link" %>
+      <a href="/" id="home-link">Home</a>
+    `)
+  })
 })


### PR DESCRIPTION
Now that we have support for detecting Action View Tag helpers we can update the `html-no-duplicate-ids` linter rule to make it Action View Tag helpers aware.

With this pull request, the following is now also flagged by the `html-no-duplicate-ids` linter rule:

```erb
<%= tag.div id: "my-id" do %>
  content
<% end %>

<div id="my-id">content</div>
```
and

```erb
<%= turbo_frame_tag "my-frame" do %>
  content
<% end %>

<div id="my-frame">content</div>
```

And IDs in mutually exclusive branches with tag helpers on one side and HTML on the other are correctly recognized as non-duplicates:

```erb
<% if use_tag_helper? %>
  <%= tag.div id: "my-id" do %>
    content
  <% end %>
<% else %>
  <div id="my-id">content</div>
<% end %>
```