### PR TITLE
Linter: Introduce version gated linter rules

### DIFF
--- a/bin/check_rule_versions
+++ b/bin/check_rule_versions
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Pre-release check: ensures no linter rules have introducedIn = "unreleased".
+# All rules must have a concrete version before publishing a release.
+
+set -euo pipefail
+
+RULES_DIR="javascript/packages/linter/src/rules"
+
+unreleased_rules=$(grep -rl 'static introducedIn = "unreleased"' "$RULES_DIR" 2>/dev/null || true)
+
+if [ -n "$unreleased_rules" ]; then
+  echo ""
+  echo "✗ Found linter rules with introducedIn = \"unreleased\":"
+  echo ""
+
+  for file in $unreleased_rules; do
+    rule_name=$(grep 'static ruleName' "$file" | head -1 | sed 's/.*= "//;s/".*//')
+    echo "  • $rule_name ($file)"
+  done
+
+  echo ""
+  echo "  Update these rules to the release version before publishing."
+  echo ""
+  exit 1
+fi
+
+echo "✓ All linter rules have concrete introducedIn versions."

--- a/bin/publish_packages
+++ b/bin/publish_packages
@@ -4,6 +4,9 @@ set -euo pipefail
 
 npm login
 
+echo "Checking linter rule versions..."
+bin/check_rule_versions
+
 echo "Building all packages..."
 yarn nx run-many -t build --all
 

--- a/javascript/packages/config/src/config.ts
+++ b/javascript/packages/config/src/config.ts
@@ -92,6 +92,7 @@ export type LoadOptions = {
 export type FromObjectOptions = {
   projectPath?: string
   version?: string
+  configVersion?: string
 }
 
 export class Config {
@@ -111,10 +112,12 @@ export class Config {
 
   public readonly path: string
   public config: HerbConfig
+  public readonly configVersion: string
 
-  constructor(projectPath: string, config: HerbConfig) {
+  constructor(projectPath: string, config: HerbConfig, configVersion?: string) {
     this.path = Config.configPathFromProjectPath(projectPath)
     this.config = config
+    this.configVersion = configVersion ?? config.version
   }
 
   get projectPath(): string {
@@ -807,7 +810,7 @@ export class Config {
     partial: Partial<HerbConfigOptions>,
     options: FromObjectOptions = {}
   ): Config {
-    const { projectPath = process.cwd(), version = DEFAULT_VERSION } = options
+    const { projectPath = process.cwd(), version = DEFAULT_VERSION, configVersion } = options
     const defaults = this.getDefaultConfig(version)
     const merged: HerbConfig = deepMerge(defaults, partial as any)
 
@@ -825,7 +828,7 @@ export class Config {
       throw error
     }
 
-    return new Config(projectPath, merged)
+    return new Config(projectPath, merged, configVersion)
   }
 
   /**
@@ -1148,19 +1151,14 @@ export class Config {
       throw error
     }
 
-    if (parsed.version && parsed.version !== version) {
-      console.error(`\n⚠️ Configuration version mismatch in ${configPath}`)
-      console.error(`   Config version: ${parsed.version}`)
-      console.error(`   Current version: ${version}`)
-      console.error(`   Consider updating your .herb.yml file.\n`)
-    }
+    const userConfigVersion: string = parsed.version || version
 
     const defaults = this.getDefaultConfig(version)
     const resolved = deepMerge(defaults, parsed as Partial<HerbConfig>)
 
     resolved.version = version
 
-    return new Config(projectRoot, resolved)
+    return new Config(projectRoot, resolved, userConfigVersion)
   }
 
   /**

--- a/javascript/packages/config/test/config.test.ts
+++ b/javascript/packages/config/test/config.test.ts
@@ -1227,4 +1227,122 @@ describe("@herb-tools/config", () => {
       expect(defaultPatterns).toContain("**/*.turbo_stream.erb")
     })
   })
+
+  describe("Config.configVersion", () => {
+    test("defaults to config.version when not provided", () => {
+      const config = new Config(testDir, { version: "0.9.2" })
+
+      expect(config.configVersion).toBe("0.9.2")
+    })
+
+    test("preserves explicit configVersion", () => {
+      const config = new Config(testDir, { version: "0.9.2" }, "0.8.0")
+
+      expect(config.version).toBe("0.9.2")
+      expect(config.configVersion).toBe("0.8.0")
+    })
+
+    test("fromObject passes configVersion through", () => {
+      const config = Config.fromObject({}, { projectPath: testDir, configVersion: "0.7.0" })
+
+      expect(config.configVersion).toBe("0.7.0")
+    })
+
+    test("fromObject defaults configVersion to tool version when not specified", () => {
+      const config = Config.fromObject({}, { projectPath: testDir })
+
+      expect(config.configVersion).toBe(config.version)
+    })
+
+    test("load preserves user config version from .herb.yml", async () => {
+      createTestFile(testDir, ".herb.yml", "version: 0.8.0\n\nlinter:\n  enabled: true\n")
+
+      const config = await Config.load(testDir, { version: "0.9.2", silent: true })
+
+      expect(config.version).toBe("0.9.2")
+      expect(config.configVersion).toBe("0.8.0")
+    })
+
+    test("load defaults configVersion to tool version when .herb.yml has no version", async () => {
+      createTestFile(testDir, ".herb.yml", "linter:\n  enabled: true\n")
+
+      const config = await Config.load(testDir, { version: "0.9.2", silent: true })
+
+      expect(config.configVersion).toBe("0.9.2")
+    })
+  })
+
+  describe("Config upgrade workflow", () => {
+    test("mutateConfigFile adds disabled rules", async () => {
+      const configContent = dedent`
+        version: 0.8.0
+
+        linter:
+          enabled: true
+      `
+
+      createTestFile(testDir, ".herb.yml", configContent + "\n")
+
+      await Config.mutateConfigFile(join(testDir, ".herb.yml"), {
+        linter: {
+          rules: {
+            "new-rule-a": { enabled: false },
+            "new-rule-b": { enabled: false }
+          }
+        }
+      })
+
+      const config = await Config.load(testDir, { version: "0.9.2", silent: true })
+
+      expect(config.linter?.rules?.["new-rule-a"]?.enabled).toBe(false)
+      expect(config.linter?.rules?.["new-rule-b"]?.enabled).toBe(false)
+    })
+
+    test("mutateConfigFile preserves existing rules", async () => {
+      const configContent = dedent`
+        version: 0.8.0
+
+        linter:
+          enabled: true
+          rules:
+            existing-rule:
+              enabled: false
+      `
+
+      createTestFile(testDir, ".herb.yml", configContent + "\n")
+
+      await Config.mutateConfigFile(join(testDir, ".herb.yml"), {
+        linter: {
+          rules: {
+            "new-rule": { enabled: false }
+          }
+        }
+      })
+
+      const config = await Config.load(testDir, { version: "0.9.2", silent: true })
+
+      expect(config.linter?.rules?.["existing-rule"]?.enabled).toBe(false)
+      expect(config.linter?.rules?.["new-rule"]?.enabled).toBe(false)
+    })
+
+    test("version can be updated via file content replacement", async () => {
+      const configContent = dedent`
+        version: 0.8.0
+
+        linter:
+          enabled: true
+      `
+
+      const configPath = createTestFile(testDir, ".herb.yml", configContent + "\n")
+
+      const { readFileSync, writeFileSync } = await import("fs")
+      let content = readFileSync(configPath, "utf-8")
+      content = content.replace(/^version:\s*.+$/m, "version: 0.9.2")
+      writeFileSync(configPath, content, "utf-8")
+
+      const config = await Config.load(testDir, { version: "0.9.2", silent: true })
+
+      expect(config.configVersion).toBe("0.9.2")
+    })
+  })
 })

--- a/javascript/packages/language-server/src/linter_service.ts
+++ b/javascript/packages/language-server/src/linter_service.ts
@@ -161,7 +161,7 @@ export class LinterService {
         }
       }, { projectPath: projectConfig?.projectPath || process.cwd() })
 
-      const filteredRules = Linter.filterRulesByConfig(this.allRules, config.linter?.rules)
+      const { enabled: filteredRules } = Linter.filterRulesByConfig(this.allRules, config.linter?.rules, config.configVersion)
 
       this.linter = new Linter(Herb, filteredRules, config, this.allRules)
     }

--- a/javascript/packages/linter/package.json
+++ b/javascript/packages/linter/package.json
@@ -22,7 +22,8 @@
     "watch": "tsc -b -w",
     "test": "vitest run",
     "test:watch": "vitest --watch",
-    "prepublishOnly": "yarn clean && yarn build && yarn test"
+    "check:rule-versions": "! grep -rl 'static introducedIn = \"unreleased\"' src/rules/ 2>/dev/null || (echo '\\n✗ Found linter rules with introducedIn = \"unreleased\". Update them to a release version before publishing.\\n' && exit 1)",
+    "prepublishOnly": "yarn check:rule-versions && yarn clean && yarn build && yarn test"
   },
   "exports": {
     "./package.json": "./package.json",

--- a/javascript/packages/linter/src/cli.ts
+++ b/javascript/packages/linter/src/cli.ts
@@ -4,7 +4,10 @@ import { Config, addHerbExtensionRecommendation, getExtensionsJsonRelativePath }
 
 import { existsSync, statSync } from "fs"
 import { resolve, relative } from "path"
+import { colorize } from "@herb-tools/highlighter"
 
+import { Linter } from "./linter.js"
+import { rules } from "./rules.js"
 import { ArgumentParser } from "./cli/argument-parser.js"
 import { FileProcessor } from "./cli/file-processor.js"
 import { OutputManager } from "./cli/output-manager.js"
@@ -144,7 +147,7 @@ export class CLI {
     const startTime = Date.now()
     const startDate = new Date()
 
-    const { patterns, configFile, formatOption, showTiming, theme, wrapLines, truncateLines, useGitHubActions, fix, fixUnsafe, ignoreDisableComments, force, init, loadCustomRules, failLevel, jobs } = this.argumentParser.parse(process.argv)
+    const { patterns, configFile, formatOption, showTiming, theme, wrapLines, truncateLines, useGitHubActions, fix, fixUnsafe, ignoreDisableComments, force, init, upgrade, loadCustomRules, failLevel, jobs } = this.argumentParser.parse(process.argv)
 
     this.determineProjectPath(patterns)
 
@@ -171,6 +174,57 @@ export class CLI {
       process.exit(0)
     }
 
+    if (upgrade) {
+      const configPath = configFile || this.projectPath
+
+      if (!Config.exists(configPath)) {
+        console.error(`\n✗ No .herb.yml found. Run ${colorize("herb-lint --init", "cyan")} first.\n`)
+        process.exit(1)
+      }
+
+      const config = await Config.load(configPath, { version, exitOnError: true, createIfMissing: false, silent: true })
+      const configVersion = config.configVersion
+
+      if (configVersion === version) {
+        console.log(`\n✓ Your .herb.yml is already at version ${version}. Nothing to upgrade.\n`)
+        process.exit(0)
+      }
+
+      const { skippedByVersion } = Linter.filterRulesByConfig(rules, config.linter?.rules, configVersion)
+
+      const rulesMutation: Record<string, { enabled: boolean }> = {}
+
+      for (const rule of skippedByVersion) {
+        rulesMutation[rule.ruleName] = { enabled: false }
+      }
+
+      await Config.mutateConfigFile(config.path, {
+        linter: { rules: rulesMutation }
+      })
+
+      const { promises: fs } = await import("fs")
+      let content = await fs.readFile(config.path, "utf-8")
+      content = content.replace(/^version:\s*.+$/m, `version: ${version}`)
+      await fs.writeFile(config.path, content, "utf-8")
+
+      console.log(`\n${colorize("✓", "brightGreen")} Updated ${colorize(".herb.yml", "cyan")} version from ${colorize(configVersion, "cyan")} to ${colorize(version, "cyan")}`)
+
+      if (skippedByVersion.length > 0) {
+        console.log(`${colorize("✓", "brightGreen")} Disabled ${colorize(String(skippedByVersion.length), "bold")} newly introduced ${skippedByVersion.length === 1 ? "rule" : "rules"}:`)
+        console.log("")
+
+        for (const rule of skippedByVersion) {
+          console.log(`  ${colorize(rule.ruleName, "white")}: ${colorize("enabled: false", "gray")}`)
+        }
+
+        console.log("")
+        console.log(`  Enable rules individually in your ${colorize(".herb.yml", "cyan")} when you're ready.`)
+      }
+
+      console.log("")
+      process.exit(0)
+    }
+
     const silent = formatOption === 'json'
     const config = await Config.load(configFile || this.projectPath, { version, exitOnError: true, createIfMissing: false, silent })
     const linterConfig = config.options.linter || {}
@@ -183,7 +237,8 @@ export class CLI {
       showTiming,
       useGitHubActions,
       startTime,
-      startDate
+      startDate,
+      toolVersion: version
     }
 
     try {
@@ -260,6 +315,13 @@ export class CLI {
       const results = await this.fileProcessor.processFiles(files, formatOption, context)
 
       await this.outputManager.outputResults({ ...results, files }, outputOptions)
+
+      if (!Config.exists(this.projectPath) && formatOption !== 'json' && !useGitHubActions) {
+        console.log("")
+        console.log(` ${colorize("TIP:", "bold")} Run ${colorize("herb-lint --init", "cyan")} to create a ${colorize(".herb.yml", "cyan")} and lock the ${colorize("version", "cyan")}.`)
+        console.log(`      This ensures upgrading Herb won't enable new rules until you update the ${colorize("version", "cyan")} in ${colorize(".herb.yml", "cyan")}.`)
+      }
+
       await this.afterProcess(results, outputOptions)
 
       const effectiveFailLevel = failLevel || linterConfig.failLevel

--- a/javascript/packages/linter/src/cli/argument-parser.ts
+++ b/javascript/packages/linter/src/cli/argument-parser.ts
@@ -26,6 +26,7 @@ export interface ParsedArguments {
   ignoreDisableComments: boolean
   force: boolean
   init: boolean
+  upgrade: boolean
   loadCustomRules: boolean
   failLevel?: DiagnosticSeverity
   jobs: number
@@ -43,6 +44,7 @@ export class ArgumentParser {
       -h, --help                    show help
       -v, --version                 show version
       --init                        create a .herb.yml configuration file in the current directory
+      --upgrade                     update .herb.yml version and disable all newly introduced rules
       -c, --config-file <path>      explicitly specify path to .herb.yml config file
       --force                       force linting even if disabled in .herb.yml
       --fix                         automatically fix auto-correctable offenses
@@ -71,6 +73,7 @@ export class ArgumentParser {
         help: { type: "boolean", short: "h" },
         version: { type: "boolean", short: "v" },
         init: { type: "boolean" },
+        upgrade: { type: "boolean" },
         "config-file": { type: "string", short: "c" },
         force: { type: "boolean" },
         fix: { type: "boolean" },
@@ -155,6 +158,7 @@ export class ArgumentParser {
     const ignoreDisableComments = values["ignore-disable-comments"] || false
     const configFile = values["config-file"]
     const init = values.init || false
+    const upgrade = values.upgrade || false
     const loadCustomRules = !values["no-custom-rules"]
 
     let failLevel: DiagnosticSeverity | undefined
@@ -181,7 +185,7 @@ export class ArgumentParser {
       jobs = parsed
     }
 
-    return { patterns, configFile, formatOption, showTiming, theme, wrapLines, truncateLines, useGitHubActions, fix, fixUnsafe, ignoreDisableComments, force, init, loadCustomRules, failLevel, jobs }
+    return { patterns, configFile, formatOption, showTiming, theme, wrapLines, truncateLines, useGitHubActions, fix, fixUnsafe, ignoreDisableComments, force, init, upgrade, loadCustomRules, failLevel, jobs }
   }
 
   private getFilePatterns(positionals: string[]): string[] {

--- a/javascript/packages/linter/src/cli/file-processor.ts
+++ b/javascript/packages/linter/src/cli/file-processor.ts
@@ -1,5 +1,6 @@
 import { Herb } from "@herb-tools/node-wasm"
 import { Linter } from "../linter.js"
+import { rules } from "../rules.js"
 import { loadCustomRules } from "../loader.js"
 import { Config } from "@herb-tools/config"
 
@@ -14,6 +15,7 @@ import type { Diagnostic } from "@herb-tools/core"
 import type { FormatOption } from "./argument-parser.js"
 import type { HerbConfigOptions } from "@herb-tools/config"
 import type { WorkerInput, WorkerResult } from "./lint-worker.js"
+import type { VersionSkippedRule } from "../linter.js"
 
 export interface ProcessedFile {
   filename: string
@@ -47,6 +49,7 @@ export interface ProcessingResult {
   ruleCount: number
   allOffenses: ProcessedFile[]
   ruleOffenses: Map<string, { count: number, files: Set<string> }>
+  rulesSkippedByVersion: VersionSkippedRule[]
   context?: ProcessingContext
 }
 
@@ -238,6 +241,7 @@ export class FileProcessor {
       ruleCount,
       allOffenses,
       ruleOffenses,
+      rulesSkippedByVersion: this.linter?.rulesSkippedByVersion ?? [],
       context
     }
 
@@ -253,6 +257,9 @@ export class FileProcessor {
     const chunks = this.splitIntoChunks(files, workerCount)
     const workerPath = this.resolveWorkerPath()
 
+    const configVersion = context?.config?.configVersion
+    const { skippedByVersion } = Linter.filterRulesByConfig(rules, context?.config?.linter?.rules, configVersion)
+
     const workerPromises = chunks.map(chunk => this.runWorker(workerPath, chunk, context))
     const workerResults = await Promise.all(workerPromises)
 
@@ -262,7 +269,10 @@ export class FileProcessor {
       }
     }
 
-    return this.aggregateWorkerResults(workerResults, formatOption, context)
+    const aggregated = this.aggregateWorkerResults(workerResults, formatOption, context)
+    aggregated.rulesSkippedByVersion = skippedByVersion
+
+    return aggregated
   }
 
   private resolveWorkerPath(): string {
@@ -383,6 +393,7 @@ export class FileProcessor {
       ruleCount,
       allOffenses,
       ruleOffenses,
+      rulesSkippedByVersion: [],
       context
     }
 

--- a/javascript/packages/linter/src/cli/output-manager.ts
+++ b/javascript/packages/linter/src/cli/output-manager.ts
@@ -14,6 +14,7 @@ interface OutputOptions {
   useGitHubActions: boolean
   startTime: number
   startDate: Date
+  toolVersion?: string
 }
 
 interface LintResults extends ProcessingResult {
@@ -27,7 +28,7 @@ export class OutputManager {
    * Output successful lint results
    */
   async outputResults(results: LintResults, options: OutputOptions): Promise<void> {
-    const { allOffenses, files, totalErrors, totalWarnings, totalInfo, totalHints, totalIgnored, totalWouldBeIgnored, filesWithOffenses, ruleCount, ruleOffenses, context } = results
+    const { allOffenses, files, totalErrors, totalWarnings, totalInfo, totalHints, totalIgnored, totalWouldBeIgnored, filesWithOffenses, ruleCount, ruleOffenses, rulesSkippedByVersion, context } = results
 
     const autofixableCount = allOffenses.filter(offense => offense.autocorrectable).length
 
@@ -59,6 +60,9 @@ export class OutputManager {
           ruleOffenses,
           autofixableCount,
           ignoreDisableComments: context?.ignoreDisableComments,
+          rulesSkippedByVersion,
+          configVersion: context?.config?.configVersion,
+          toolVersion: options.toolVersion,
         })
       }
     } else if (options.formatOption === "json") {
@@ -119,6 +123,9 @@ export class OutputManager {
         ruleOffenses,
         autofixableCount,
         ignoreDisableComments: context?.ignoreDisableComments,
+        rulesSkippedByVersion,
+        configVersion: context?.config?.configVersion,
+        toolVersion: options.toolVersion,
       })
     }
   }

--- a/javascript/packages/linter/src/cli/summary-reporter.ts
+++ b/javascript/packages/linter/src/cli/summary-reporter.ts
@@ -1,6 +1,9 @@
 import { colorize, hyperlink } from "@herb-tools/highlighter"
+import { UNRELEASED_VERSION, compareSemver } from "../semver.js"
 
 import { ruleDocumentationUrl } from "../urls.js"
+
+import type { VersionSkippedRule } from "../linter.js"
 
 export interface SummaryData {
   files: string[]
@@ -18,6 +21,9 @@ export interface SummaryData {
   ruleOffenses: Map<string, { count: number, files: Set<string> }>
   autofixableCount: number
   ignoreDisableComments?: boolean
+  rulesSkippedByVersion?: VersionSkippedRule[]
+  configVersion?: string
+  toolVersion?: string
 }
 
 export class SummaryReporter {
@@ -125,6 +131,51 @@ export class SummaryReporter {
       console.log("")
       console.log(` ${colorize("✓", "brightGreen")} ${colorize("All files are clean!", "green")}`)
     }
+
+    this.displayVersionSkippedRules(data.rulesSkippedByVersion, data.configVersion, data.toolVersion)
+  }
+
+  displayVersionSkippedRules(skippedRules?: VersionSkippedRule[], configVersion?: string, toolVersion?: string): void {
+    if (!skippedRules || skippedRules.length === 0) return
+
+    const ruleCount = skippedRules.length
+    const suggestedVersion = toolVersion || configVersion || "latest"
+
+    console.log("")
+    console.log(` ${colorize(`New rules available:`, "bold")}`)
+
+    if (configVersion) {
+      console.log(`  Your ${colorize(".herb.yml", "cyan")} version is ${colorize(configVersion, "cyan")}. ${colorize(String(ruleCount), "bold")} new ${this.pluralize(ruleCount, "rule")} ${ruleCount === 1 ? "is" : "are"} disabled to ease upgrades:`)
+    } else {
+      console.log(`  ${colorize(String(ruleCount), "bold")} ${this.pluralize(ruleCount, "rule")} ${ruleCount === 1 ? "is" : "are"} available in newer versions:`)
+    }
+
+    console.log("")
+
+    const grouped = new Map<string, string[]>()
+
+    for (const rule of skippedRules) {
+      const existing = grouped.get(rule.introducedIn) || []
+      existing.push(rule.ruleName)
+      grouped.set(rule.introducedIn, existing)
+    }
+
+    const sortedVersions = Array.from(grouped.keys()).sort((a, b) => compareSemver(a, b))
+
+    for (const version of sortedVersions) {
+      const ruleNames = grouped.get(version)!
+      const versionLabel = version === UNRELEASED_VERSION ? "next release" : version
+
+      for (const ruleName of ruleNames) {
+        const ruleText = colorize(ruleName, "white")
+        const ruleLink = hyperlink(ruleText, ruleDocumentationUrl(ruleName))
+        console.log(`  ${ruleLink} ${colorize(`(introduced in ${versionLabel})`, "gray")}`)
+      }
+    }
+
+    console.log("")
+    console.log(`  Run ${colorize("herb-lint --upgrade", "cyan")} to update the version and disable all new rules, or`)
+    console.log(`  update the version in your ${colorize(".herb.yml", "cyan")} to ${colorize(`"${suggestedVersion}"`, "cyan")} to enable them all at once.`)
   }
 
   displayMostViolatedRules(ruleOffenses: Map<string, { count: number, files: Set<string> }>, limit: number = 5): void {

--- a/javascript/packages/linter/src/linter.ts
+++ b/javascript/packages/linter/src/linter.ts
@@ -12,8 +12,9 @@ import { ParseCache } from "./parse-cache.js"
 import { ParserNoErrorsRule } from "./rules/parser-no-errors.js"
 
 import { DEFAULT_RULE_CONFIG } from "./types.js"
+import { semverGreaterThan } from "./semver.js"
 
-import type { RuleClass, ParserRuleClass, LexerRuleClass, SourceRuleClass, Rule, ParserRule, LexerRule, SourceRule, LintResult, LintOffense, UnboundLintOffense, LintContext, AutofixResult } from "./types.js"
+import type { RuleClass, ParserRuleClass, LexerRuleClass, SourceRuleClass, Rule, ParserRule, LexerRule, SourceRule, LintResult, LintOffense, UnboundLintOffense, LintContext, AutofixResult, RuleVersion } from "./types.js"
 import type { ParseResult, LexResult, HerbBackend } from "@herb-tools/core"
 import type { RuleConfig, Config } from "@herb-tools/config"
 
@@ -47,8 +48,20 @@ export interface LinterOptions {
   silentCustomRules?: boolean
 }
 
+export interface VersionSkippedRule {
+  ruleName: string
+  introducedIn: RuleVersion
+}
+
+export interface FilterRulesResult {
+  enabled: RuleClass[]
+  skippedByVersion: VersionSkippedRule[]
+}
+
 export class Linter {
   public rules: RuleClass[]
+  public rulesSkippedByVersion: VersionSkippedRule[] = []
+
   protected allAvailableRules: RuleClass[]
   protected herb: HerbBackend
   protected parseCache: ParseCache
@@ -65,11 +78,13 @@ export class Linter {
    */
   static from(herb: HerbBackend, config?: Config, customRules?: RuleClass[]): Linter {
     const allRules = customRules ? [...rules, ...customRules] : rules
-    const filteredRules = config?.linter?.rules
-      ? Linter.filterRulesByConfig(allRules, config.linter.rules)
-      : undefined
+    const configVersion = config?.configVersion
+    const filterResult = Linter.filterRulesByConfig(allRules, config?.linter?.rules, configVersion)
 
-    return new Linter(herb, filteredRules, config, allRules)
+    const linter = new Linter(herb, filterResult.enabled, config, allRules)
+    linter.rulesSkippedByVersion = filterResult.skippedByVersion
+
+    return linter
   }
 
   /**
@@ -93,32 +108,58 @@ export class Linter {
   }
 
   /**
-   * Filters rules based on default config and optional user config overrides.
+   * Filters rules based on default config, user config overrides, and version gating.
    *
    * Priority:
-   * 1. User config override (if rule config exists in userRulesConfig)
-   * 2. Default config from rule's defaultConfig getter
+   * 1. User explicitly enabled/disabled (if rule config exists in userRulesConfig)
+   * 2. Version gating (if rule.introducedIn > configVersion, skip unless explicitly enabled)
+   * 3. Default config from rule's defaultConfig getter
    *
    * @param allRules - All available rule classes to filter from
    * @param userRulesConfig - Optional user configuration for rules
-   * @returns Filtered array of rule classes that should be enabled
+   * @param configVersion - Optional version from the user's .herb.yml for version-gated filtering
+   * @returns Object with enabled rules and rules skipped due to version gating
    */
   static filterRulesByConfig(
     allRules: RuleClass[],
-    userRulesConfig?: Record<string, RuleConfig>
-  ): RuleClass[] {
-    return allRules.filter(ruleClass => {
-      const instance = new ruleClass()
+    userRulesConfig?: Record<string, RuleConfig>,
+    configVersion?: string
+  ): FilterRulesResult {
+    const enabled: RuleClass[] = []
+    const skippedByVersion: VersionSkippedRule[] = []
 
+    for (const ruleClass of allRules) {
+      const instance = new ruleClass()
       const defaultEnabled = instance.defaultConfig?.enabled ?? DEFAULT_RULE_CONFIG.enabled
       const userRuleConfig = userRulesConfig?.[ruleClass.ruleName]
 
       if (userRuleConfig !== undefined) {
-        return userRuleConfig.enabled !== false
+        if (userRuleConfig.enabled !== false) {
+          enabled.push(ruleClass)
+        }
+
+        continue
       }
 
-      return defaultEnabled
-    })
+      if (configVersion && ruleClass.introducedIn) {
+        if (semverGreaterThan(ruleClass.introducedIn, configVersion)) {
+          if (defaultEnabled) {
+            skippedByVersion.push({
+              ruleName: ruleClass.ruleName,
+              introducedIn: ruleClass.introducedIn,
+            })
+          }
+
+          continue
+        }
+      }
+
+      if (defaultEnabled) {
+        enabled.push(ruleClass)
+      }
+    }
+
+    return { enabled, skippedByVersion }
   }
 
   /**
@@ -128,7 +169,7 @@ export class Linter {
    * @returns Array of default rule classes
    */
   protected getDefaultRules(): RuleClass[] {
-    return Linter.filterRulesByConfig(rules)
+    return Linter.filterRulesByConfig(rules).enabled
   }
 
   /**

--- a/javascript/packages/linter/src/rules/actionview-no-silent-helper.ts
+++ b/javascript/packages/linter/src/rules/actionview-no-silent-helper.ts
@@ -33,6 +33,7 @@ class ActionViewNoSilentHelperVisitor extends BaseRuleVisitor {
 
 export class ActionViewNoSilentHelperRule extends ParserRule {
   static ruleName = "actionview-no-silent-helper"
+  static introducedIn = this.version("0.9.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/actionview-no-silent-render.ts
+++ b/javascript/packages/linter/src/rules/actionview-no-silent-render.ts
@@ -20,6 +20,7 @@ class ActionViewNoSilentRenderVisitor extends BaseRuleVisitor {
 
 export class ActionViewNoSilentRenderRule extends ParserRule {
   static ruleName = "actionview-no-silent-render"
+  static introducedIn = this.version("0.9.1")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/erb-comment-syntax.ts
+++ b/javascript/packages/linter/src/rules/erb-comment-syntax.ts
@@ -35,6 +35,7 @@ class ERBCommentSyntaxVisitor extends BaseRuleVisitor<ERBCommentSyntaxAutofixCon
 export class ERBCommentSyntax extends ParserRule<ERBCommentSyntaxAutofixContext> {
   static autocorrectable = true
   static ruleName = "erb-comment-syntax"
+  static introducedIn = this.version("0.7.5")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/erb-no-case-node-children.ts
+++ b/javascript/packages/linter/src/rules/erb-no-case-node-children.ts
@@ -52,6 +52,7 @@ class ERBNoCaseNodeChildrenVisitor extends BaseRuleVisitor {
 
 export class ERBNoCaseNodeChildrenRule extends ParserRule {
   static ruleName = "erb-no-case-node-children"
+  static introducedIn = this.version("0.8.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/erb-no-conditional-html-element.ts
+++ b/javascript/packages/linter/src/rules/erb-no-conditional-html-element.ts
@@ -35,6 +35,7 @@ class ERBNoConditionalHTMLElementRuleVisitor extends BaseRuleVisitor {
 
 export class ERBNoConditionalHTMLElementRule extends ParserRule {
   static ruleName = "erb-no-conditional-html-element"
+  static introducedIn = this.version("0.9.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/erb-no-conditional-open-tag.ts
+++ b/javascript/packages/linter/src/rules/erb-no-conditional-open-tag.ts
@@ -19,6 +19,7 @@ class ERBNoConditionalOpenTagRuleVisitor extends BaseRuleVisitor {
 
 export class ERBNoConditionalOpenTagRule extends ParserRule {
   static ruleName = "erb-no-conditional-open-tag"
+  static introducedIn = this.version("0.9.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/erb-no-duplicate-branch-elements.ts
+++ b/javascript/packages/linter/src/rules/erb-no-duplicate-branch-elements.ts
@@ -286,6 +286,7 @@ class ERBNoDuplicateBranchElementsVisitor extends BaseRuleVisitor<DuplicateBranc
 
 export class ERBNoDuplicateBranchElementsRule extends ParserRule<DuplicateBranchAutofixContext> {
   static ruleName = "erb-no-duplicate-branch-elements"
+  static introducedIn = this.version("0.9.0")
   static autocorrectable = true
   static reindentAfterAutofix = true
 

--- a/javascript/packages/linter/src/rules/erb-no-empty-control-flow.ts
+++ b/javascript/packages/linter/src/rules/erb-no-empty-control-flow.ts
@@ -237,6 +237,7 @@ class ERBNoEmptyControlFlowVisitor extends BaseRuleVisitor {
 
 export class ERBNoEmptyControlFlowRule extends ParserRule {
   static ruleName = "erb-no-empty-control-flow"
+  static introducedIn = this.version("0.9.1")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/erb-no-empty-tags.ts
+++ b/javascript/packages/linter/src/rules/erb-no-empty-tags.ts
@@ -23,6 +23,7 @@ class ERBNoEmptyTagsVisitor extends BaseRuleVisitor {
 
 export class ERBNoEmptyTagsRule extends ParserRule {
   static ruleName = "erb-no-empty-tags"
+  static introducedIn = this.version("0.4.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/erb-no-extra-newline.ts
+++ b/javascript/packages/linter/src/rules/erb-no-extra-newline.ts
@@ -42,6 +42,7 @@ class ERBNoExtraNewLineVisitor extends BaseSourceRuleVisitor<ERBNoExtraNewLineAu
 export class ERBNoExtraNewLineRule extends SourceRule {
   static autocorrectable = true
   static ruleName = "erb-no-extra-newline"
+  static introducedIn = this.version("0.8.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/erb-no-extra-whitespace-inside-tags.ts
+++ b/javascript/packages/linter/src/rules/erb-no-extra-whitespace-inside-tags.ts
@@ -125,6 +125,7 @@ class ERBNoExtraWhitespaceInsideTagsVisitor extends BaseRuleVisitor<ERBNoExtraWh
 export class ERBNoExtraWhitespaceRule extends ParserRule<ERBNoExtraWhitespaceAutofixContext> {
   static autocorrectable = true
   static ruleName = "erb-no-extra-whitespace-inside-tags"
+  static introducedIn = this.version("0.8.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/erb-no-inline-case-conditions.ts
+++ b/javascript/packages/linter/src/rules/erb-no-inline-case-conditions.ts
@@ -32,6 +32,7 @@ class ERBNoInlineCaseConditionsVisitor extends BaseRuleVisitor {
 
 export class ERBNoInlineCaseConditionsRule extends ParserRule {
   static ruleName = "erb-no-inline-case-conditions"
+  static introducedIn = this.version("0.9.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/erb-no-instance-variables-in-partials.ts
+++ b/javascript/packages/linter/src/rules/erb-no-instance-variables-in-partials.ts
@@ -60,6 +60,7 @@ class InstanceVariableCollector extends PrismVisitor {
 
 export class ERBNoInstanceVariablesInPartialsRule extends ParserRule {
   static ruleName = "erb-no-instance-variables-in-partials"
+  static introducedIn = this.version("0.9.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/erb-no-interpolated-class-names.ts
+++ b/javascript/packages/linter/src/rules/erb-no-interpolated-class-names.ts
@@ -47,6 +47,7 @@ class ERBNoInterpolatedClassNamesVisitor extends AttributeVisitorMixin {
 
 export class ERBNoInterpolatedClassNamesRule extends ParserRule {
   static ruleName = "erb-no-interpolated-class-names"
+  static introducedIn = this.version("0.9.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/erb-no-javascript-tag-helper.ts
+++ b/javascript/packages/linter/src/rules/erb-no-javascript-tag-helper.ts
@@ -29,6 +29,7 @@ class ERBNoJavascriptTagHelperVisitor extends BaseRuleVisitor {
 
 export class ERBNoJavascriptTagHelperRule extends ParserRule {
   static ruleName = "erb-no-javascript-tag-helper"
+  static introducedIn = this.version("0.9.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/erb-no-output-control-flow.ts
+++ b/javascript/packages/linter/src/rules/erb-no-output-control-flow.ts
@@ -51,6 +51,7 @@ class ERBNoOutputControlFlowRuleVisitor extends BaseRuleVisitor {
 
 export class ERBNoOutputControlFlowRule extends ParserRule {
   static ruleName = "erb-no-output-control-flow"
+  static introducedIn = this.version("0.4.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/erb-no-output-in-attribute-name.ts
+++ b/javascript/packages/linter/src/rules/erb-no-output-in-attribute-name.ts
@@ -23,6 +23,7 @@ class ERBNoOutputInAttributeNameVisitor extends BaseRuleVisitor {
 
 export class ERBNoOutputInAttributeNameRule extends ParserRule {
   static ruleName = "erb-no-output-in-attribute-name"
+  static introducedIn = this.version("0.9.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/erb-no-output-in-attribute-position.ts
+++ b/javascript/packages/linter/src/rules/erb-no-output-in-attribute-position.ts
@@ -23,6 +23,7 @@ class ERBNoOutputInAttributePositionVisitor extends BaseRuleVisitor {
 
 export class ERBNoOutputInAttributePositionRule extends ParserRule {
   static ruleName = "erb-no-output-in-attribute-position"
+  static introducedIn = this.version("0.9.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/erb-no-raw-output-in-attribute-value.ts
+++ b/javascript/packages/linter/src/rules/erb-no-raw-output-in-attribute-value.ts
@@ -31,6 +31,7 @@ class ERBNoRawOutputInAttributeValueVisitor extends AttributeVisitorMixin {
 
 export class ERBNoRawOutputInAttributeValueRule extends ParserRule {
   static ruleName = "erb-no-raw-output-in-attribute-value"
+  static introducedIn = this.version("0.9.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/erb-no-silent-statement.ts
+++ b/javascript/packages/linter/src/rules/erb-no-silent-statement.ts
@@ -34,6 +34,7 @@ class ERBNoSilentStatementVisitor extends BaseRuleVisitor {
 
 export class ERBNoSilentStatementRule extends ParserRule {
   static ruleName = "erb-no-silent-statement"
+  static introducedIn = this.version("0.9.1")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/erb-no-silent-tag-in-attribute-name.ts
+++ b/javascript/packages/linter/src/rules/erb-no-silent-tag-in-attribute-name.ts
@@ -28,6 +28,7 @@ class ERBNoSilentTagInAttributeNameVisitor extends BaseRuleVisitor {
 
 export class ERBNoSilentTagInAttributeNameRule extends ParserRule {
   static ruleName = "erb-no-silent-tag-in-attribute-name"
+  static introducedIn = this.version("0.6.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/erb-no-statement-in-script.ts
+++ b/javascript/packages/linter/src/rules/erb-no-statement-in-script.ts
@@ -66,6 +66,7 @@ class ERBNoStatementInScriptVisitor extends BaseRuleVisitor {
 
 export class ERBNoStatementInScriptRule extends ParserRule {
   static ruleName = "erb-no-statement-in-script"
+  static introducedIn = this.version("0.9.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/erb-no-then-in-control-flow.ts
+++ b/javascript/packages/linter/src/rules/erb-no-then-in-control-flow.ts
@@ -40,6 +40,7 @@ class ERBNoThenInControlFlowVisitor extends BaseRuleVisitor {
 
 export class ERBNoThenInControlFlowRule extends ParserRule {
   static ruleName = "erb-no-then-in-control-flow"
+  static introducedIn = this.version("0.9.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/erb-no-trailing-whitespace.ts
+++ b/javascript/packages/linter/src/rules/erb-no-trailing-whitespace.ts
@@ -68,6 +68,7 @@ class SkipZoneCollector extends Visitor {
 export class ERBNoTrailingWhitespaceRule extends ParserRule<ERBNoTrailingWhitespaceAutofixContext> {
   static autocorrectable = true
   static ruleName = "erb-no-trailing-whitespace"
+  static introducedIn = this.version("0.9.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/erb-no-unsafe-js-attribute.ts
+++ b/javascript/packages/linter/src/rules/erb-no-unsafe-js-attribute.ts
@@ -31,6 +31,7 @@ class ERBNoUnsafeJSAttributeVisitor extends AttributeVisitorMixin {
 
 export class ERBNoUnsafeJSAttributeRule extends ParserRule {
   static ruleName = "erb-no-unsafe-js-attribute"
+  static introducedIn = this.version("0.9.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/erb-no-unsafe-raw.ts
+++ b/javascript/packages/linter/src/rules/erb-no-unsafe-raw.ts
@@ -67,6 +67,7 @@ class ERBNoUnsafeRawVisitor extends BaseRuleVisitor {
 
 export class ERBNoUnsafeRawRule extends ParserRule {
   static ruleName = "erb-no-unsafe-raw"
+  static introducedIn = this.version("0.9.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/erb-no-unsafe-script-interpolation.ts
+++ b/javascript/packages/linter/src/rules/erb-no-unsafe-script-interpolation.ts
@@ -98,6 +98,7 @@ class ERBNoUnsafeScriptInterpolationVisitor extends BaseRuleVisitor {
 
 export class ERBNoUnsafeScriptInterpolationRule extends ParserRule {
   static ruleName = "erb-no-unsafe-script-interpolation"
+  static introducedIn = this.version("0.9.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/erb-prefer-image-tag-helper.ts
+++ b/javascript/packages/linter/src/rules/erb-prefer-image-tag-helper.ts
@@ -92,6 +92,7 @@ class ERBPreferImageTagHelperVisitor extends BaseRuleVisitor {
 
 export class ERBPreferImageTagHelperRule extends ParserRule {
   static ruleName = "erb-prefer-image-tag-helper"
+  static introducedIn = this.version("0.4.3")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/erb-require-trailing-newline.ts
+++ b/javascript/packages/linter/src/rules/erb-require-trailing-newline.ts
@@ -25,6 +25,7 @@ class ERBRequireTrailingNewlineVisitor extends BaseSourceRuleVisitor {
 export class ERBRequireTrailingNewlineRule extends SourceRule {
   static autocorrectable = true
   static ruleName = "erb-require-trailing-newline"
+  static introducedIn = this.version("0.8.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/erb-require-whitespace-inside-tags.ts
+++ b/javascript/packages/linter/src/rules/erb-require-whitespace-inside-tags.ts
@@ -135,6 +135,7 @@ class RequireWhitespaceInsideTags extends BaseRuleVisitor<ERBRequireWhitespaceAu
 export class ERBRequireWhitespaceRule extends ParserRule<ERBRequireWhitespaceAutofixContext> {
   static autocorrectable = true
   static ruleName = "erb-require-whitespace-inside-tags"
+  static introducedIn = this.version("0.4.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/erb-right-trim.ts
+++ b/javascript/packages/linter/src/rules/erb-right-trim.ts
@@ -27,6 +27,7 @@ class ERBRightTrimVisitor extends BaseRuleVisitor<ERBRightTrimAutofixContext> {
 export class ERBRightTrimRule extends ParserRule<ERBRightTrimAutofixContext> {
   static autocorrectable = true
   static ruleName = "erb-right-trim"
+  static introducedIn = this.version("0.7.5")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/erb-strict-locals-comment-syntax.ts
+++ b/javascript/packages/linter/src/rules/erb-strict-locals-comment-syntax.ts
@@ -108,6 +108,7 @@ class ERBStrictLocalsCommentSyntaxVisitor extends BaseRuleVisitor {
 
 export class ERBStrictLocalsCommentSyntaxRule extends ParserRule {
   static ruleName = "erb-strict-locals-comment-syntax"
+  static introducedIn = this.version("0.8.8")
 
   get parserOptions() {
     return { strict_locals: true }

--- a/javascript/packages/linter/src/rules/erb-strict-locals-required.ts
+++ b/javascript/packages/linter/src/rules/erb-strict-locals-required.ts
@@ -18,6 +18,7 @@ class ERBStrictLocalsRequiredVisitor extends BaseRuleVisitor {
 export class ERBStrictLocalsRequiredRule extends ParserRule {
   static unsafeAutocorrectable = true
   static ruleName = "erb-strict-locals-required"
+  static introducedIn = this.version("0.8.8")
 
   get parserOptions() {
     return { strict_locals: true }

--- a/javascript/packages/linter/src/rules/herb-disable-comment-malformed.ts
+++ b/javascript/packages/linter/src/rules/herb-disable-comment-malformed.ts
@@ -48,6 +48,7 @@ class HerbDisableCommentMalformedVisitor extends HerbDisableCommentBaseVisitor {
 
 export class HerbDisableCommentMalformedRule extends ParserRule {
   static ruleName = "herb-disable-comment-malformed"
+  static introducedIn = this.version("0.8.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/herb-disable-comment-missing-rules.ts
+++ b/javascript/packages/linter/src/rules/herb-disable-comment-missing-rules.ts
@@ -23,6 +23,7 @@ class HerbDisableCommentMissingRulesVisitor extends HerbDisableCommentBaseVisito
 
 export class HerbDisableCommentMissingRulesRule extends ParserRule {
   static ruleName = "herb-disable-comment-missing-rules"
+  static introducedIn = this.version("0.8.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/herb-disable-comment-no-duplicate-rules.ts
+++ b/javascript/packages/linter/src/rules/herb-disable-comment-no-duplicate-rules.ts
@@ -28,6 +28,7 @@ class HerbDisableCommentNoDuplicateRulesVisitor extends HerbDisableCommentParsed
 
 export class HerbDisableCommentNoDuplicateRulesRule extends ParserRule {
   static ruleName = "herb-disable-comment-no-duplicate-rules"
+  static introducedIn = this.version("0.8.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/herb-disable-comment-no-redundant-all.ts
+++ b/javascript/packages/linter/src/rules/herb-disable-comment-no-redundant-all.ts
@@ -22,6 +22,7 @@ class HerbDisableCommentNoRedundantAllVisitor extends HerbDisableCommentParsedVi
 
 export class HerbDisableCommentNoRedundantAllRule extends ParserRule {
   static ruleName = "herb-disable-comment-no-redundant-all"
+  static introducedIn = this.version("0.8.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/herb-disable-comment-unnecessary.ts
+++ b/javascript/packages/linter/src/rules/herb-disable-comment-unnecessary.ts
@@ -73,6 +73,7 @@ class HerbDisableCommentUnnecessaryVisitor extends HerbDisableCommentParsedVisit
 
 export class HerbDisableCommentUnnecessaryRule extends ParserRule {
   static ruleName = "herb-disable-comment-unnecessary"
+  static introducedIn = this.version("0.8.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/herb-disable-comment-valid-rule-name.ts
+++ b/javascript/packages/linter/src/rules/herb-disable-comment-valid-rule-name.ts
@@ -35,6 +35,7 @@ class HerbDisableCommentValidRuleNameVisitor extends HerbDisableCommentParsedVis
 
 export class HerbDisableCommentValidRuleNameRule extends ParserRule {
   static ruleName = "herb-disable-comment-valid-rule-name"
+  static introducedIn = this.version("0.8.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/html-allowed-script-type.ts
+++ b/javascript/packages/linter/src/rules/html-allowed-script-type.ts
@@ -66,6 +66,7 @@ class AllowedScriptTypeVisitor extends BaseRuleVisitor {
 
 export class HTMLAllowedScriptTypeRule extends ParserRule {
   static ruleName = "html-allowed-script-type"
+  static introducedIn = this.version("0.9.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/html-anchor-require-href.ts
+++ b/javascript/packages/linter/src/rules/html-anchor-require-href.ts
@@ -84,6 +84,7 @@ class AnchorRequireHrefVisitor extends BaseRuleVisitor {
 
 export class HTMLAnchorRequireHrefRule extends ParserRule {
   static ruleName = "html-anchor-require-href"
+  static introducedIn = this.version("0.4.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/html-aria-attribute-must-be-valid.ts
+++ b/javascript/packages/linter/src/rules/html-aria-attribute-must-be-valid.ts
@@ -26,6 +26,7 @@ class AriaAttributeMustBeValid extends AttributeVisitorMixin {
 
 export class HTMLAriaAttributeMustBeValid extends ParserRule {
   static ruleName = "html-aria-attribute-must-be-valid"
+  static introducedIn = this.version("0.4.1")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/html-aria-label-is-well-formatted.ts
+++ b/javascript/packages/linter/src/rules/html-aria-label-is-well-formatted.ts
@@ -45,6 +45,7 @@ class AriaLabelIsWellFormattedVisitor extends AttributeVisitorMixin {
 
 export class HTMLAriaLabelIsWellFormattedRule extends ParserRule {
   static ruleName = "html-aria-label-is-well-formatted"
+  static introducedIn = this.version("0.6.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/html-aria-level-must-be-valid.ts
+++ b/javascript/packages/linter/src/rules/html-aria-level-must-be-valid.ts
@@ -64,6 +64,7 @@ class HTMLAriaLevelMustBeValidVisitor extends AttributeVisitorMixin {
 
 export class HTMLAriaLevelMustBeValidRule extends ParserRule {
   static ruleName = "html-aria-level-must-be-valid"
+  static introducedIn = this.version("0.4.3")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/html-aria-role-heading-requires-level.ts
+++ b/javascript/packages/linter/src/rules/html-aria-role-heading-requires-level.ts
@@ -22,6 +22,7 @@ class AriaRoleHeadingRequiresLevel extends AttributeVisitorMixin {
 
 export class HTMLAriaRoleHeadingRequiresLevelRule extends ParserRule {
   static ruleName = "html-aria-role-heading-requires-level"
+  static introducedIn = this.version("0.4.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/html-aria-role-must-be-valid.ts
+++ b/javascript/packages/linter/src/rules/html-aria-role-must-be-valid.ts
@@ -19,6 +19,7 @@ class AriaRoleMustBeValid extends AttributeVisitorMixin {
 
 export class HTMLAriaRoleMustBeValidRule extends ParserRule {
   static ruleName = "html-aria-role-must-be-valid"
+  static introducedIn = this.version("0.4.1")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/html-attribute-double-quotes.ts
+++ b/javascript/packages/linter/src/rules/html-attribute-double-quotes.ts
@@ -45,6 +45,7 @@ class AttributeDoubleQuotesVisitor extends AttributeVisitorMixin<AttributeDouble
 export class HTMLAttributeDoubleQuotesRule extends ParserRule<AttributeDoubleQuotesAutofixContext> {
   static autocorrectable = true
   static ruleName = "html-attribute-double-quotes"
+  static introducedIn = this.version("0.4.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/html-attribute-equals-spacing.ts
+++ b/javascript/packages/linter/src/rules/html-attribute-equals-spacing.ts
@@ -35,6 +35,7 @@ class HTMLAttributeEqualsSpacingVisitor extends BaseRuleVisitor<AttributeEqualsS
 export class HTMLAttributeEqualsSpacingRule extends ParserRule<AttributeEqualsSpacingAutofixContext> {
   static autocorrectable = true
   static ruleName = "html-attribute-equals-spacing"
+  static introducedIn = this.version("0.6.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/html-attribute-values-require-quotes.ts
+++ b/javascript/packages/linter/src/rules/html-attribute-values-require-quotes.ts
@@ -53,6 +53,7 @@ class AttributeValuesRequireQuotesVisitor extends AttributeVisitorMixin<Attribut
 export class HTMLAttributeValuesRequireQuotesRule extends ParserRule<AttributeValuesRequireQuotesAutofixContext> {
   static autocorrectable = true
   static ruleName = "html-attribute-values-require-quotes"
+  static introducedIn = this.version("0.4.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/html-avoid-both-disabled-and-aria-disabled.ts
+++ b/javascript/packages/linter/src/rules/html-avoid-both-disabled-and-aria-disabled.ts
@@ -53,6 +53,7 @@ class AvoidBothDisabledAndAriaDisabledVisitor extends BaseRuleVisitor {
 
 export class HTMLAvoidBothDisabledAndAriaDisabledRule extends ParserRule {
   static ruleName = "html-avoid-both-disabled-and-aria-disabled"
+  static introducedIn = this.version("0.6.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/html-body-only-elements.ts
+++ b/javascript/packages/linter/src/rules/html-body-only-elements.ts
@@ -42,6 +42,7 @@ class HTMLBodyOnlyElementsVisitor extends BaseRuleVisitor {
 export class HTMLBodyOnlyElementsRule extends ParserRule {
   static autocorrectable = false
   static ruleName = "html-body-only-elements"
+  static introducedIn = this.version("0.8.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/html-boolean-attributes-no-value.ts
+++ b/javascript/packages/linter/src/rules/html-boolean-attributes-no-value.ts
@@ -36,6 +36,7 @@ class BooleanAttributesNoValueVisitor extends AttributeVisitorMixin<BooleanAttri
 export class HTMLBooleanAttributesNoValueRule extends ParserRule<BooleanAttributeAutofixContext> {
   static autocorrectable = true
   static ruleName = "html-boolean-attributes-no-value"
+  static introducedIn = this.version("0.4.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/html-details-has-summary.ts
+++ b/javascript/packages/linter/src/rules/html-details-has-summary.ts
@@ -47,6 +47,7 @@ class DetailsHasSummaryVisitor extends BaseRuleVisitor {
 
 export class HTMLDetailsHasSummaryRule extends ParserRule {
   static ruleName = "html-details-has-summary"
+  static introducedIn = this.version("0.9.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/html-head-only-elements.ts
+++ b/javascript/packages/linter/src/rules/html-head-only-elements.ts
@@ -53,6 +53,7 @@ class HeadOnlyElementsVisitor extends BaseRuleVisitor {
 export class HTMLHeadOnlyElementsRule extends ParserRule {
   static autocorrectable = false
   static ruleName = "html-head-only-elements"
+  static introducedIn = this.version("0.8.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/html-iframe-has-title.ts
+++ b/javascript/packages/linter/src/rules/html-iframe-has-title.ts
@@ -46,6 +46,7 @@ class IframeHasTitleVisitor extends BaseRuleVisitor {
 
 export class HTMLIframeHasTitleRule extends ParserRule {
   static ruleName = "html-iframe-has-title"
+  static introducedIn = this.version("0.6.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/html-img-require-alt.ts
+++ b/javascript/packages/linter/src/rules/html-img-require-alt.ts
@@ -53,6 +53,7 @@ class ImgRequireAltVisitor extends BaseRuleVisitor {
 
 export class HTMLImgRequireAltRule extends ParserRule {
   static ruleName = "html-img-require-alt"
+  static introducedIn = this.version("0.4.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/html-input-require-autocomplete.ts
+++ b/javascript/packages/linter/src/rules/html-input-require-autocomplete.ts
@@ -64,6 +64,7 @@ class HTMLInputRequireAutocompleteVisitor extends BaseRuleVisitor {
 
 export class HTMLInputRequireAutocompleteRule extends ParserRule {
   static ruleName = "html-input-require-autocomplete"
+  static introducedIn = this.version("0.8.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/html-navigation-has-label.ts
+++ b/javascript/packages/linter/src/rules/html-navigation-has-label.ts
@@ -53,6 +53,7 @@ class NavigationHasLabelVisitor extends BaseRuleVisitor {
 
 export class HTMLNavigationHasLabelRule extends ParserRule {
   static ruleName = "html-navigation-has-label"
+  static introducedIn = this.version("0.6.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/html-no-abstract-roles.ts
+++ b/javascript/packages/linter/src/rules/html-no-abstract-roles.ts
@@ -22,6 +22,7 @@ class NoAbstractRolesVisitor extends AttributeVisitorMixin {
 
 export class HTMLNoAbstractRolesRule extends ParserRule {
   static ruleName = "html-no-abstract-roles"
+  static introducedIn = this.version("0.9.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/html-no-aria-hidden-on-body.ts
+++ b/javascript/packages/linter/src/rules/html-no-aria-hidden-on-body.ts
@@ -40,6 +40,7 @@ class NoAriaHiddenBodyVisitor extends BaseRuleVisitor {
 
 export class HTMLNoAriaHiddenOnBodyRule extends ParserRule {
   static ruleName = "html-no-aria-hidden-on-body"
+  static introducedIn = this.version("0.9.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/html-no-aria-hidden-on-focusable.ts
+++ b/javascript/packages/linter/src/rules/html-no-aria-hidden-on-focusable.ts
@@ -79,6 +79,7 @@ class NoAriaHiddenOnFocusableVisitor extends BaseRuleVisitor {
 
 export class HTMLNoAriaHiddenOnFocusableRule extends ParserRule {
   static ruleName = "html-no-aria-hidden-on-focusable"
+  static introducedIn = this.version("0.6.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/html-no-block-inside-inline.ts
+++ b/javascript/packages/linter/src/rules/html-no-block-inside-inline.ts
@@ -69,6 +69,7 @@ class BlockInsideInlineVisitor extends BaseRuleVisitor {
 
 export class HTMLNoBlockInsideInlineRule extends ParserRule {
   static ruleName = "html-no-block-inside-inline"
+  static introducedIn = this.version("0.4.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/html-no-duplicate-attributes.ts
+++ b/javascript/packages/linter/src/rules/html-no-duplicate-attributes.ts
@@ -173,6 +173,7 @@ class NoDuplicateAttributesVisitor extends ControlFlowTrackingVisitor<
 
 export class HTMLNoDuplicateAttributesRule extends ParserRule {
   static ruleName = "html-no-duplicate-attributes"
+  static introducedIn = this.version("0.4.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/html-no-duplicate-ids.ts
+++ b/javascript/packages/linter/src/rules/html-no-duplicate-ids.ts
@@ -203,6 +203,7 @@ class NoDuplicateIdsVisitor extends ControlFlowTrackingVisitor<BaseAutofixContex
 
 export class HTMLNoDuplicateIdsRule extends ParserRule {
   static ruleName = "html-no-duplicate-ids"
+  static introducedIn = this.version("0.4.1")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/html-no-duplicate-meta-names.ts
+++ b/javascript/packages/linter/src/rules/html-no-duplicate-meta-names.ts
@@ -184,6 +184,7 @@ class HTMLNoDuplicateMetaNamesVisitor extends ControlFlowTrackingVisitor<BaseAut
 export class HTMLNoDuplicateMetaNamesRule extends ParserRule {
   static autocorrectable = false
   static ruleName = "html-no-duplicate-meta-names"
+  static introducedIn = this.version("0.8.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/html-no-empty-attributes.ts
+++ b/javascript/packages/linter/src/rules/html-no-empty-attributes.ts
@@ -121,6 +121,7 @@ class NoEmptyAttributesVisitor extends AttributeVisitorMixin {
 
 export class HTMLNoEmptyAttributesRule extends ParserRule {
   static ruleName = "html-no-empty-attributes"
+  static introducedIn = this.version("0.7.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/html-no-empty-headings.ts
+++ b/javascript/packages/linter/src/rules/html-no-empty-headings.ts
@@ -106,6 +106,7 @@ class NoEmptyHeadingsVisitor extends BaseRuleVisitor {
 
 export class HTMLNoEmptyHeadingsRule extends ParserRule {
   static ruleName = "html-no-empty-headings"
+  static introducedIn = this.version("0.4.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/html-no-nested-links.ts
+++ b/javascript/packages/linter/src/rules/html-no-nested-links.ts
@@ -65,6 +65,7 @@ class NestedLinkVisitor extends BaseRuleVisitor {
 
 export class HTMLNoNestedLinksRule extends ParserRule {
   static ruleName = "html-no-nested-links"
+  static introducedIn = this.version("0.4.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/html-no-positive-tab-index.ts
+++ b/javascript/packages/linter/src/rules/html-no-positive-tab-index.ts
@@ -21,6 +21,7 @@ class NoPositiveTabIndexVisitor extends AttributeVisitorMixin {
 
 export class HTMLNoPositiveTabIndexRule extends ParserRule {
   static ruleName = "html-no-positive-tab-index"
+  static introducedIn = this.version("0.6.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/html-no-self-closing.ts
+++ b/javascript/packages/linter/src/rules/html-no-self-closing.ts
@@ -41,6 +41,7 @@ class NoSelfClosingVisitor extends BaseRuleVisitor<NoSelfClosingAutofixContext> 
 export class HTMLNoSelfClosingRule extends ParserRule<NoSelfClosingAutofixContext> {
   static autocorrectable = true
   static ruleName = "html-no-self-closing"
+  static introducedIn = this.version("0.6.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/html-no-space-in-tag.ts
+++ b/javascript/packages/linter/src/rules/html-no-space-in-tag.ts
@@ -145,6 +145,7 @@ export class HTMLNoSpaceInTagRule extends ParserRule<HTMLNoSpaceInTagAutofixCont
   // TODO: enable and fix autofix
   static autocorrectable = false
   static ruleName = "html-no-space-in-tag"
+  static introducedIn = this.version("0.8.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/html-no-title-attribute.ts
+++ b/javascript/packages/linter/src/rules/html-no-title-attribute.ts
@@ -31,6 +31,7 @@ class NoTitleAttributeVisitor extends BaseRuleVisitor {
 
 export class HTMLNoTitleAttributeRule extends ParserRule {
   static ruleName = "html-no-title-attribute"
+  static introducedIn = this.version("0.6.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/html-no-underscores-in-attribute-names.ts
+++ b/javascript/packages/linter/src/rules/html-no-underscores-in-attribute-names.ts
@@ -48,6 +48,7 @@ class HTMLNoUnderscoresInAttributeNamesVisitor extends AttributeVisitorMixin {
 
 export class HTMLNoUnderscoresInAttributeNamesRule extends ParserRule {
   static ruleName = "html-no-underscores-in-attribute-names"
+  static introducedIn = this.version("0.7.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/html-require-closing-tags.ts
+++ b/javascript/packages/linter/src/rules/html-require-closing-tags.ts
@@ -19,6 +19,7 @@ class RequireClosingTagsVisitor extends BaseRuleVisitor {
 export class HTMLRequireClosingTagsRule extends ParserRule {
   static autocorrectable = false
   static ruleName = "html-require-closing-tags"
+  static introducedIn = this.version("0.9.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/html-require-script-nonce.ts
+++ b/javascript/packages/linter/src/rules/html-require-script-nonce.ts
@@ -85,6 +85,7 @@ class RequireScriptNonceVisitor extends BaseRuleVisitor {
 
 export class HTMLRequireScriptNonceRule extends ParserRule {
   static ruleName = "html-require-script-nonce"
+  static introducedIn = this.version("unreleased")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/html-tag-name-lowercase.ts
+++ b/javascript/packages/linter/src/rules/html-tag-name-lowercase.ts
@@ -74,6 +74,7 @@ class TagNameLowercaseVisitor extends BaseRuleVisitor<TagNameAutofixContext> {
 export class HTMLTagNameLowercaseRule extends ParserRule<TagNameAutofixContext> {
   static autocorrectable = true
   static ruleName = "html-tag-name-lowercase"
+  static introducedIn = this.version("0.4.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/parser-no-errors.ts
+++ b/javascript/packages/linter/src/rules/parser-no-errors.ts
@@ -5,6 +5,7 @@ import type { ParseResult, HerbError } from "@herb-tools/core"
 
 export class ParserNoErrorsRule extends ParserRule {
   static ruleName = "parser-no-errors"
+  static introducedIn = this.version("0.5.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/svg-tag-name-capitalization.ts
+++ b/javascript/packages/linter/src/rules/svg-tag-name-capitalization.ts
@@ -70,6 +70,7 @@ class SVGTagNameCapitalizationVisitor extends BaseRuleVisitor<SVGTagNameCapitali
 export class SVGTagNameCapitalizationRule extends ParserRule<SVGTagNameCapitalizationAutofixContext> {
   static autocorrectable = true
   static ruleName = "svg-tag-name-capitalization"
+  static introducedIn = this.version("0.4.2")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/rules/turbo-permanent-require-id.ts
+++ b/javascript/packages/linter/src/rules/turbo-permanent-require-id.ts
@@ -31,6 +31,7 @@ class TurboPermanentRequireIdVisitor extends BaseRuleVisitor {
 
 export class TurboPermanentRequireIdRule extends ParserRule {
   static ruleName = "turbo-permanent-require-id"
+  static introducedIn = this.version("0.9.0")
 
   get defaultConfig(): FullRuleConfig {
     return {

--- a/javascript/packages/linter/src/semver.ts
+++ b/javascript/packages/linter/src/semver.ts
@@ -1,0 +1,40 @@
+export type SemverVersion = `${number}.${number}.${number}`
+export type RuleVersion = SemverVersion | "unreleased"
+
+export const UNRELEASED_VERSION: RuleVersion = "unreleased"
+
+export function parseSemver(version: string): [number, number, number] {
+  const parts = version.split(".")
+
+  if (parts.length < 2 || parts.length > 3) {
+    return [0, 0, 0]
+  }
+
+  const major = parseInt(parts[0], 10)
+  const minor = parseInt(parts[1], 10)
+  const patch = parts[2] !== undefined ? parseInt(parts[2], 10) : 0
+
+  if (isNaN(major) || isNaN(minor) || isNaN(patch)) {
+    return [0, 0, 0]
+  }
+
+  return [major, minor, patch]
+}
+
+export function compareSemver(a: string, b: string): number {
+  if (a === UNRELEASED_VERSION && b === UNRELEASED_VERSION) return 0
+  if (a === UNRELEASED_VERSION) return 1
+  if (b === UNRELEASED_VERSION) return -1
+
+  const [majorA, minorA, patchA] = parseSemver(a)
+  const [majorB, minorB, patchB] = parseSemver(b)
+
+  if (majorA !== majorB) return majorA - majorB
+  if (minorA !== minorB) return minorA - minorB
+
+  return patchA - patchB
+}
+
+export function semverGreaterThan(a: string, b: string): boolean {
+  return compareSemver(a, b) > 0
+}

--- a/javascript/packages/linter/src/types.ts
+++ b/javascript/packages/linter/src/types.ts
@@ -5,10 +5,13 @@ import type { rules } from "./rules.js"
 import type { Node, ParserOptions } from "@herb-tools/core"
 import type { RuleConfig } from "@herb-tools/config"
 import type { Mutable } from "@herb-tools/rewriter"
+import type { RuleVersion } from "./semver.js"
 
 export type { Mutable } from "@herb-tools/rewriter"
+export type { RuleVersion } from "./semver.js"
 
 export type LintSeverity = "error" | "warning" | "info" | "hint"
+
 
 export const DEFAULT_LINTER_PARSER_OPTIONS: Partial<ParserOptions> = {
   track_whitespace: true,
@@ -93,6 +96,10 @@ export const DEFAULT_RULE_CONFIG: FullRuleConfig = {
 export abstract class ParserRule<TAutofixContext extends BaseAutofixContext = BaseAutofixContext> {
   static type = "parser" as const
   static ruleName: string
+  /** The version in which this rule was introduced. Used for version-gated rule filtering. */
+  static introducedIn: RuleVersion
+
+  static version(version: RuleVersion): RuleVersion { return version }
   /** Indicates whether this rule supports autofix. Defaults to false. */
   static autocorrectable = false
   /** Indicates whether this rule supports unsafe autofix (requires --fix-unsafely). Defaults to false. */
@@ -153,6 +160,11 @@ export abstract class ParserRule<TAutofixContext extends BaseAutofixContext = Ba
 export abstract class LexerRule<TAutofixContext extends BaseAutofixContext = BaseAutofixContext> {
   static type = "lexer" as const
   static ruleName: string
+  /** The version in which this rule was introduced. Used for version-gated rule filtering. */
+  static introducedIn: RuleVersion
+
+  static version(version: RuleVersion): RuleVersion { return version }
+
   /** Indicates whether this rule supports autofix. Defaults to false. */
   static autocorrectable = false
   /** Indicates whether this rule supports unsafe autofix (requires --fix-unsafely). Defaults to false. */
@@ -205,6 +217,7 @@ export interface LexerRuleConstructor {
   type: "lexer"
   new (): LexerRule
   ruleName: string
+  introducedIn: RuleVersion
 }
 
 /**
@@ -231,6 +244,11 @@ export const DEFAULT_LINT_CONTEXT: LintContext = {
 export abstract class SourceRule<TAutofixContext extends BaseAutofixContext = BaseAutofixContext> {
   static type = "source" as const
   static ruleName: string
+  /** The version in which this rule was introduced. Used for version-gated rule filtering. */
+  static introducedIn: RuleVersion
+
+  static version(version: RuleVersion): RuleVersion { return version }
+
   /** Indicates whether this rule supports autofix. Defaults to false. */
   static autocorrectable = false
   /** Indicates whether this rule supports unsafe autofix (requires --fix-unsafely). Defaults to false. */
@@ -283,6 +301,7 @@ export interface SourceRuleConstructor {
   type: "source"
   new (): SourceRule
   ruleName: string
+  introducedIn: RuleVersion
 }
 
 /**
@@ -293,6 +312,7 @@ export interface SourceRuleConstructor {
 export type ParserRuleClass = (new () => ParserRule) & {
   type?: "parser"
   ruleName: string
+  introducedIn: RuleVersion
   reindentAfterAutofix?: boolean
 }
 

--- a/javascript/packages/linter/test/__snapshots__/cli.test.ts.snap
+++ b/javascript/packages/linter/test/__snapshots__/cli.test.ts.snap
@@ -108,7 +108,18 @@ test/fixtures/ignored.html.erb:8:8
   Checked      1 file
   Offenses     5 errors | 2 warnings (7 offenses across 1 file)
   Note         3 additional offenses reported (would have been ignored)
-  Fixable      7 offenses | 4 autocorrectable using \`--fix\`"
+  Fixable      7 offenses | 4 autocorrectable using \`--fix\`
+
+ New rules available:
+  Your .herb.yml version is 0.9.2. 1 new rule is disabled to ease upgrades:
+
+  html-require-script-nonce (introduced in next release)
+
+  Run herb-lint --upgrade to update the version and disable all new rules, or
+  update the version in your .herb.yml to "0.9.2" to enable them all at once.
+
+ TIP: Run herb-lint --init to create a .herb.yml and lock the version.
+      This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
 `;
 
 exports[`CLI Output Formatting > GitHub Actions format escapes special characters in messages 1`] = `
@@ -165,7 +176,15 @@ test/fixtures/test-file-with-errors.html.erb:2:22
  Summary:
   Checked      1 file
   Offenses     2 errors | 1 warning (3 offenses across 1 file)
-  Fixable      3 offenses | 2 autocorrectable using \`--fix\`"
+  Fixable      3 offenses | 2 autocorrectable using \`--fix\`
+
+ New rules available:
+  Your .herb.yml version is 0.9.2. 1 new rule is disabled to ease upgrades:
+
+  html-require-script-nonce (introduced in next release)
+
+  Run herb-lint --upgrade to update the version and disable all new rules, or
+  update the version in your .herb.yml to "0.9.2" to enable them all at once."
 `;
 
 exports[`CLI Output Formatting > GitHub Actions format includes rule codes 1`] = `
@@ -187,7 +206,15 @@ test/fixtures/no-trailing-newline.html.erb:1:29
  Summary:
   Checked      1 file
   Offenses     1 error | 0 warnings (1 offense across 1 file)
-  Fixable      1 offense | 1 autocorrectable using \`--fix\`"
+  Fixable      1 offense | 1 autocorrectable using \`--fix\`
+
+ New rules available:
+  Your .herb.yml version is 0.9.2. 1 new rule is disabled to ease upgrades:
+
+  html-require-script-nonce (introduced in next release)
+
+  Run herb-lint --upgrade to update the version and disable all new rules, or
+  update the version in your .herb.yml to "0.9.2" to enable them all at once."
 `;
 
 exports[`CLI Output Formatting > GitHub Actions format includes rule codes 2`] = `
@@ -235,7 +262,18 @@ test/fixtures/erb-no-extra-whitespace-inside-tags.html.erb:9:3
  Summary:
   Checked      1 file
   Offenses     3 errors | 0 warnings (3 offenses across 1 file)
-  Fixable      3 offenses | 3 autocorrectable using \`--fix\`"
+  Fixable      3 offenses | 3 autocorrectable using \`--fix\`
+
+ New rules available:
+  Your .herb.yml version is 0.9.2. 1 new rule is disabled to ease upgrades:
+
+  html-require-script-nonce (introduced in next release)
+
+  Run herb-lint --upgrade to update the version and disable all new rules, or
+  update the version in your .herb.yml to "0.9.2" to enable them all at once.
+
+ TIP: Run herb-lint --init to create a .herb.yml and lock the version.
+      This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
 `;
 
 exports[`CLI Output Formatting > Ignores disabled rules 1`] = `
@@ -273,7 +311,18 @@ test/fixtures/ignored.html.erb:6:14
  Summary:
   Checked      1 file
   Offenses     2 errors | 0 warnings | 3 ignored (2 offenses across 1 file)
-  Fixable      2 offenses | 2 autocorrectable using \`--fix\`"
+  Fixable      2 offenses | 2 autocorrectable using \`--fix\`
+
+ New rules available:
+  Your .herb.yml version is 0.9.2. 1 new rule is disabled to ease upgrades:
+
+  html-require-script-nonce (introduced in next release)
+
+  Run herb-lint --upgrade to update the version and disable all new rules, or
+  update the version in your .herb.yml to "0.9.2" to enable them all at once.
+
+ TIP: Run herb-lint --init to create a .herb.yml and lock the version.
+      This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
 `;
 
 exports[`CLI Output Formatting > diplays only parsers errors if one is present 1`] = `
@@ -296,7 +345,18 @@ test/fixtures/parser-errors.html.erb:2:16
  Summary:
   Checked      1 file
   Offenses     1 error | 0 warnings (1 offense across 1 file)
-  Fixable      1 offense"
+  Fixable      1 offense
+
+ New rules available:
+  Your .herb.yml version is 0.9.2. 1 new rule is disabled to ease upgrades:
+
+  html-require-script-nonce (introduced in next release)
+
+  Run herb-lint --upgrade to update the version and disable all new rules, or
+  update the version in your .herb.yml to "0.9.2" to enable them all at once.
+
+ TIP: Run herb-lint --init to create a .herb.yml and lock the version.
+      This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
 `;
 
 exports[`CLI Output Formatting > displays most violated rules with multiple offenses 1`] = `
@@ -508,7 +568,18 @@ test/fixtures/multiple-rule-offenses.html.erb:4:2
  Summary:
   Checked      1 file
   Offenses     8 errors | 6 warnings (14 offenses across 1 file)
-  Fixable      14 offenses | 4 autocorrectable using \`--fix\`"
+  Fixable      14 offenses | 4 autocorrectable using \`--fix\`
+
+ New rules available:
+  Your .herb.yml version is 0.9.2. 1 new rule is disabled to ease upgrades:
+
+  html-require-script-nonce (introduced in next release)
+
+  Run herb-lint --upgrade to update the version and disable all new rules, or
+  update the version in your .herb.yml to "0.9.2" to enable them all at once.
+
+ TIP: Run herb-lint --init to create a .herb.yml and lock the version.
+      This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
 `;
 
 exports[`CLI Output Formatting > displays rule offenses when showing all rules 1`] = `
@@ -602,7 +673,18 @@ test/fixtures/few-rule-offenses.html.erb:6:0
  Summary:
   Checked      1 file
   Offenses     4 errors | 2 warnings (6 offenses across 1 file)
-  Fixable      6 offenses | 3 autocorrectable using \`--fix\`"
+  Fixable      6 offenses | 3 autocorrectable using \`--fix\`
+
+ New rules available:
+  Your .herb.yml version is 0.9.2. 1 new rule is disabled to ease upgrades:
+
+  html-require-script-nonce (introduced in next release)
+
+  Run herb-lint --upgrade to update the version and disable all new rules, or
+  update the version in your .herb.yml to "0.9.2" to enable them all at once.
+
+ TIP: Run herb-lint --init to create a .herb.yml and lock the version.
+      This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
 `;
 
 exports[`CLI Output Formatting > formats GitHub Actions output correctly for bad file 1`] = `
@@ -638,7 +720,15 @@ test/fixtures/bad-file.html.erb:1:16
  Summary:
   Checked      1 file
   Offenses     2 errors | 0 warnings (2 offenses across 1 file)
-  Fixable      2 offenses | 2 autocorrectable using \`--fix\`"
+  Fixable      2 offenses | 2 autocorrectable using \`--fix\`
+
+ New rules available:
+  Your .herb.yml version is 0.9.2. 1 new rule is disabled to ease upgrades:
+
+  html-require-script-nonce (introduced in next release)
+
+  Run herb-lint --upgrade to update the version and disable all new rules, or
+  update the version in your .herb.yml to "0.9.2" to enable them all at once."
 `;
 
 exports[`CLI Output Formatting > formats GitHub Actions output correctly for clean file 1`] = `
@@ -647,7 +737,15 @@ exports[`CLI Output Formatting > formats GitHub Actions output correctly for cle
 
  Summary:
   Checked      1 file
-  Offenses     0 offenses"
+  Offenses     0 offenses
+
+ New rules available:
+  Your .herb.yml version is 0.9.2. 1 new rule is disabled to ease upgrades:
+
+  html-require-script-nonce (introduced in next release)
+
+  Run herb-lint --upgrade to update the version and disable all new rules, or
+  update the version in your .herb.yml to "0.9.2" to enable them all at once."
 `;
 
 exports[`CLI Output Formatting > formats GitHub Actions output correctly for file with errors 1`] = `
@@ -704,7 +802,15 @@ test/fixtures/test-file-with-errors.html.erb:2:22
  Summary:
   Checked      1 file
   Offenses     2 errors | 1 warning (3 offenses across 1 file)
-  Fixable      3 offenses | 2 autocorrectable using \`--fix\`"
+  Fixable      3 offenses | 2 autocorrectable using \`--fix\`
+
+ New rules available:
+  Your .herb.yml version is 0.9.2. 1 new rule is disabled to ease upgrades:
+
+  html-require-script-nonce (introduced in next release)
+
+  Run herb-lint --upgrade to update the version and disable all new rules, or
+  update the version in your .herb.yml to "0.9.2" to enable them all at once."
 `;
 
 exports[`CLI Output Formatting > formats GitHub Actions output with --format=github option 1`] = `
@@ -740,7 +846,18 @@ test/fixtures/test-file-simple.html.erb:2:22
  Summary:
   Checked      1 file
   Offenses     2 errors | 0 warnings (2 offenses across 1 file)
-  Fixable      2 offenses | 2 autocorrectable using \`--fix\`"
+  Fixable      2 offenses | 2 autocorrectable using \`--fix\`
+
+ New rules available:
+  Your .herb.yml version is 0.9.2. 1 new rule is disabled to ease upgrades:
+
+  html-require-script-nonce (introduced in next release)
+
+  Run herb-lint --upgrade to update the version and disable all new rules, or
+  update the version in your .herb.yml to "0.9.2" to enable them all at once.
+
+ TIP: Run herb-lint --init to create a .herb.yml and lock the version.
+      This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
 `;
 
 exports[`CLI Output Formatting > formats JSON output correctly for bad file 1`] = `
@@ -787,7 +904,7 @@ exports[`CLI Output Formatting > formats JSON output correctly for bad file 1`] 
   "summary": {
     "filesChecked": 1,
     "filesWithOffenses": 1,
-    "ruleCount": 73,
+    "ruleCount": 72,
     "totalErrors": 2,
     "totalHints": 0,
     "totalIgnored": 0,
@@ -808,7 +925,7 @@ exports[`CLI Output Formatting > formats JSON output correctly for clean file 1`
   "summary": {
     "filesChecked": 1,
     "filesWithOffenses": 0,
-    "ruleCount": 73,
+    "ruleCount": 72,
     "totalErrors": 0,
     "totalHints": 0,
     "totalIgnored": 0,
@@ -881,7 +998,7 @@ exports[`CLI Output Formatting > formats JSON output correctly for file with err
   "summary": {
     "filesChecked": 1,
     "filesWithOffenses": 1,
-    "ruleCount": 73,
+    "ruleCount": 72,
     "totalErrors": 2,
     "totalHints": 0,
     "totalIgnored": 0,
@@ -941,7 +1058,18 @@ test/fixtures/test-file-with-errors.html.erb:2:22
  Summary:
   Checked      1 file
   Offenses     2 errors | 1 warning (3 offenses across 1 file)
-  Fixable      3 offenses | 2 autocorrectable using \`--fix\`"
+  Fixable      3 offenses | 2 autocorrectable using \`--fix\`
+
+ New rules available:
+  Your .herb.yml version is 0.9.2. 1 new rule is disabled to ease upgrades:
+
+  html-require-script-nonce (introduced in next release)
+
+  Run herb-lint --upgrade to update the version and disable all new rules, or
+  update the version in your .herb.yml to "0.9.2" to enable them all at once.
+
+ TIP: Run herb-lint --init to create a .herb.yml and lock the version.
+      This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
 `;
 
 exports[`CLI Output Formatting > formats simple output correctly 1`] = `
@@ -957,7 +1085,18 @@ exports[`CLI Output Formatting > formats simple output correctly 1`] = `
  Summary:
   Checked      1 file
   Offenses     2 errors | 0 warnings (2 offenses across 1 file)
-  Fixable      2 offenses | 2 autocorrectable using \`--fix\`"
+  Fixable      2 offenses | 2 autocorrectable using \`--fix\`
+
+ New rules available:
+  Your .herb.yml version is 0.9.2. 1 new rule is disabled to ease upgrades:
+
+  html-require-script-nonce (introduced in next release)
+
+  Run herb-lint --upgrade to update the version and disable all new rules, or
+  update the version in your .herb.yml to "0.9.2" to enable them all at once.
+
+ TIP: Run herb-lint --init to create a .herb.yml and lock the version.
+      This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
 `;
 
 exports[`CLI Output Formatting > formats simple output for bad-file correctly 1`] = `
@@ -973,7 +1112,18 @@ exports[`CLI Output Formatting > formats simple output for bad-file correctly 1`
  Summary:
   Checked      1 file
   Offenses     2 errors | 0 warnings (2 offenses across 1 file)
-  Fixable      2 offenses | 2 autocorrectable using \`--fix\`"
+  Fixable      2 offenses | 2 autocorrectable using \`--fix\`
+
+ New rules available:
+  Your .herb.yml version is 0.9.2. 1 new rule is disabled to ease upgrades:
+
+  html-require-script-nonce (introduced in next release)
+
+  Run herb-lint --upgrade to update the version and disable all new rules, or
+  update the version in your .herb.yml to "0.9.2" to enable them all at once.
+
+ TIP: Run herb-lint --init to create a .herb.yml and lock the version.
+      This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
 `;
 
 exports[`CLI Output Formatting > formats success output correctly 1`] = `
@@ -982,7 +1132,18 @@ exports[`CLI Output Formatting > formats success output correctly 1`] = `
 
  Summary:
   Checked      1 file
-  Offenses     0 offenses"
+  Offenses     0 offenses
+
+ New rules available:
+  Your .herb.yml version is 0.9.2. 1 new rule is disabled to ease upgrades:
+
+  html-require-script-nonce (introduced in next release)
+
+  Run herb-lint --upgrade to update the version and disable all new rules, or
+  update the version in your .herb.yml to "0.9.2" to enable them all at once.
+
+ TIP: Run herb-lint --init to create a .herb.yml and lock the version.
+      This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
 `;
 
 exports[`CLI Output Formatting > handles boolean attributes 1`] = `
@@ -991,7 +1152,18 @@ exports[`CLI Output Formatting > handles boolean attributes 1`] = `
 
  Summary:
   Checked      1 file
-  Offenses     0 offenses"
+  Offenses     0 offenses
+
+ New rules available:
+  Your .herb.yml version is 0.9.2. 1 new rule is disabled to ease upgrades:
+
+  html-require-script-nonce (introduced in next release)
+
+  Run herb-lint --upgrade to update the version and disable all new rules, or
+  update the version in your .herb.yml to "0.9.2" to enable them all at once.
+
+ TIP: Run herb-lint --init to create a .herb.yml and lock the version.
+      This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
 `;
 
 exports[`CLI Output Formatting > handles multiple errors correctly 1`] = `
@@ -1023,7 +1195,18 @@ test/fixtures/bad-file.html.erb:1:16
  Summary:
   Checked      1 file
   Offenses     2 errors | 0 warnings (2 offenses across 1 file)
-  Fixable      2 offenses | 2 autocorrectable using \`--fix\`"
+  Fixable      2 offenses | 2 autocorrectable using \`--fix\`
+
+ New rules available:
+  Your .herb.yml version is 0.9.2. 1 new rule is disabled to ease upgrades:
+
+  html-require-script-nonce (introduced in next release)
+
+  Run herb-lint --upgrade to update the version and disable all new rules, or
+  update the version in your .herb.yml to "0.9.2" to enable them all at once.
+
+ TIP: Run herb-lint --init to create a .herb.yml and lock the version.
+      This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
 `;
 
 exports[`CLI Output Formatting > herb:disable rules 1`] = `
@@ -1152,7 +1335,18 @@ test/fixtures/disabled-1.html.erb:14:19
  Summary:
   Checked      1 file
   Offenses     2 errors | 6 warnings | 8 ignored (8 offenses across 1 file)
-  Fixable      8 offenses | 1 autocorrectable using \`--fix\`"
+  Fixable      8 offenses | 1 autocorrectable using \`--fix\`
+
+ New rules available:
+  Your .herb.yml version is 0.9.2. 1 new rule is disabled to ease upgrades:
+
+  html-require-script-nonce (introduced in next release)
+
+  Run herb-lint --upgrade to update the version and disable all new rules, or
+  update the version in your .herb.yml to "0.9.2" to enable them all at once.
+
+ TIP: Run herb-lint --init to create a .herb.yml and lock the version.
+      This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
 `;
 
 exports[`CLI Output Formatting > herb:disable rules 2`] = `
@@ -1352,7 +1546,18 @@ test/fixtures/disabled-2.html.erb:2:44
  Summary:
   Checked      1 file
   Offenses     6 errors | 7 warnings | 5 ignored (13 offenses across 1 file)
-  Fixable      13 offenses | 6 autocorrectable using \`--fix\`"
+  Fixable      13 offenses | 6 autocorrectable using \`--fix\`
+
+ New rules available:
+  Your .herb.yml version is 0.9.2. 1 new rule is disabled to ease upgrades:
+
+  html-require-script-nonce (introduced in next release)
+
+  Run herb-lint --upgrade to update the version and disable all new rules, or
+  update the version in your .herb.yml to "0.9.2" to enable them all at once.
+
+ TIP: Run herb-lint --init to create a .herb.yml and lock the version.
+      This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
 `;
 
 exports[`CLI Output Formatting > uses GitHub Actions format by default when GITHUB_ACTIONS is true 1`] = `
@@ -1409,5 +1614,13 @@ test/fixtures/test-file-with-errors.html.erb:2:22
  Summary:
   Checked      1 file
   Offenses     2 errors | 1 warning (3 offenses across 1 file)
-  Fixable      3 offenses | 2 autocorrectable using \`--fix\`"
+  Fixable      3 offenses | 2 autocorrectable using \`--fix\`
+
+ New rules available:
+  Your .herb.yml version is 0.9.2. 1 new rule is disabled to ease upgrades:
+
+  html-require-script-nonce (introduced in next release)
+
+  Run herb-lint --upgrade to update the version and disable all new rules, or
+  update the version in your .herb.yml to "0.9.2" to enable them all at once."
 `;

--- a/javascript/packages/linter/test/linter.test.ts
+++ b/javascript/packages/linter/test/linter.test.ts
@@ -89,6 +89,7 @@ describe("@herb-tools/linter", () => {
   describe("Rule enablement", () => {
     class EnabledParserRule extends ParserRule {
       static ruleName = "enabled-parser-rule"
+      static introducedIn = "0.1.0"
 
       get defaultConfig() {
         return { enabled: true, severity: "error" as const }
@@ -107,6 +108,7 @@ describe("@herb-tools/linter", () => {
 
     class DisabledParserRule extends ParserRule {
       static ruleName = "disabled-parser-rule"
+      static introducedIn = "0.1.0"
 
       get defaultConfig() {
         return { enabled: true, severity: "error" as const }
@@ -129,6 +131,7 @@ describe("@herb-tools/linter", () => {
 
     class FileBasedRule extends SourceRule {
       static ruleName = "file-based-rule"
+      static introducedIn = "0.1.0"
 
       get defaultConfig() {
         return { enabled: true, severity: "info" as const }
@@ -151,6 +154,7 @@ describe("@herb-tools/linter", () => {
 
     class ContentBasedRule extends ParserRule {
       static ruleName = "content-based-rule"
+      static introducedIn = "0.1.0"
 
       get defaultConfig() {
         return { enabled: true, severity: "info" as const }
@@ -385,6 +389,7 @@ describe("@herb-tools/linter", () => {
     test("filters rules based on default config", () => {
       class EnabledByDefaultRule extends ParserRule {
         static ruleName = "enabled-by-default-rule"
+        static introducedIn = "0.1.0"
 
         get defaultConfig(): FullRuleConfig {
           return {
@@ -406,6 +411,7 @@ describe("@herb-tools/linter", () => {
 
       class DisabledByDefaultRule extends ParserRule {
         static ruleName = "disabled-by-default-rule"
+        static introducedIn = "0.1.0"
 
         get defaultConfig(): FullRuleConfig {
           return {
@@ -426,7 +432,7 @@ describe("@herb-tools/linter", () => {
       }
 
       const html = `<div>test</div>`
-      const filteredRules = Linter.filterRulesByConfig([EnabledByDefaultRule, DisabledByDefaultRule])
+      const { enabled: filteredRules } = Linter.filterRulesByConfig([EnabledByDefaultRule, DisabledByDefaultRule])
       const linter = new Linter(Herb, filteredRules)
       const lintResult = linter.lint(html)
 
@@ -437,6 +443,7 @@ describe("@herb-tools/linter", () => {
     test("user config can enable a disabled-by-default rule", () => {
       class DisabledByDefaultRule extends ParserRule {
         static ruleName = "disabled-by-default-rule"
+        static introducedIn = "0.1.0"
 
         get defaultConfig(): FullRuleConfig {
           return {
@@ -467,7 +474,7 @@ describe("@herb-tools/linter", () => {
         }
       })
 
-      const filteredRules = Linter.filterRulesByConfig([DisabledByDefaultRule], config.linter?.rules)
+      const { enabled: filteredRules } = Linter.filterRulesByConfig([DisabledByDefaultRule], config.linter?.rules)
       const linter = new Linter(Herb, filteredRules, config)
       const lintResult = linter.lint(html)
 
@@ -487,7 +494,7 @@ describe("@herb-tools/linter", () => {
         }
       })
 
-      const filteredRules = Linter.filterRulesByConfig([HTMLTagNameLowercaseRule], config.linter?.rules)
+      const { enabled: filteredRules } = Linter.filterRulesByConfig([HTMLTagNameLowercaseRule], config.linter?.rules)
       const linter = new Linter(Herb, filteredRules, config)
       const lintResult = linter.lint(html)
 
@@ -556,6 +563,7 @@ describe("@herb-tools/linter", () => {
     test("Linter.from() with config enables and overrides severity", () => {
       class TestRule extends ParserRule {
         static ruleName = "test-rule"
+        static introducedIn = "0.1.0"
 
         get defaultConfig(): FullRuleConfig {
           return {
@@ -587,7 +595,7 @@ describe("@herb-tools/linter", () => {
         }
       })
 
-      const filteredRules = Linter.filterRulesByConfig([TestRule], config.linter?.rules)
+      const { enabled: filteredRules } = Linter.filterRulesByConfig([TestRule], config.linter?.rules)
       const linter = new Linter(Herb, filteredRules, config)
       const lintResult = linter.lint(html)
 
@@ -614,6 +622,7 @@ describe("@herb-tools/linter", () => {
     test("Linter.filterRulesByConfig with empty config returns default enabled", () => {
       class EnabledRule extends ParserRule {
         static ruleName = "enabled-rule"
+        static introducedIn = "0.1.0"
 
         get defaultConfig(): FullRuleConfig {
           return { enabled: true, severity: "error" }
@@ -624,6 +633,7 @@ describe("@herb-tools/linter", () => {
 
       class DisabledRule extends ParserRule {
         static ruleName = "disabled-rule"
+        static introducedIn = "0.1.0"
 
         get defaultConfig(): FullRuleConfig {
           return { enabled: false, severity: "error" }
@@ -632,7 +642,7 @@ describe("@herb-tools/linter", () => {
         check(): UnboundLintOffense[] { return [] }
       }
 
-      const filtered = Linter.filterRulesByConfig([EnabledRule, DisabledRule])
+      const { enabled: filtered } = Linter.filterRulesByConfig([EnabledRule, DisabledRule])
 
       expect(filtered).toHaveLength(1)
       expect(filtered[0].ruleName).toBe("enabled-rule")
@@ -641,6 +651,7 @@ describe("@herb-tools/linter", () => {
     test("Linter.filterRulesByConfig respects user config", () => {
       class EnabledRule extends ParserRule {
         static ruleName = "enabled-rule"
+        static introducedIn = "0.1.0"
 
         get defaultConfig(): FullRuleConfig {
           return { enabled: true, severity: "error" }
@@ -651,6 +662,7 @@ describe("@herb-tools/linter", () => {
 
       class DisabledRule extends ParserRule {
         static ruleName = "disabled-rule"
+        static introducedIn = "0.1.0"
 
         get defaultConfig(): FullRuleConfig {
           return { enabled: false, severity: "error" }
@@ -664,10 +676,205 @@ describe("@herb-tools/linter", () => {
         "disabled-rule": { enabled: true }
       }
 
-      const filtered = Linter.filterRulesByConfig([EnabledRule, DisabledRule], config)
+      const { enabled: filtered } = Linter.filterRulesByConfig([EnabledRule, DisabledRule], config)
 
       expect(filtered).toHaveLength(1)
       expect(filtered[0].ruleName).toBe("disabled-rule")
+    })
+  })
+
+  describe("Version-gated rule filtering", () => {
+    class OldRule extends ParserRule {
+      static ruleName = "old-rule"
+      static introducedIn = "0.4.0" as const
+
+      get defaultConfig(): FullRuleConfig {
+        return { enabled: true, severity: "error" }
+      }
+
+      check(): UnboundLintOffense[] { return [] }
+    }
+
+    class NewRule extends ParserRule {
+      static ruleName = "new-rule"
+      static introducedIn = "0.9.0" as const
+
+      get defaultConfig(): FullRuleConfig {
+        return { enabled: true, severity: "error" }
+      }
+
+      check(_result: ParseResult): UnboundLintOffense[] {
+        return [{
+          message: "New rule triggered",
+          location: Location.from(1, 1, 1, 1),
+          rule: this.ruleName,
+          code: this.ruleName,
+          source: "linter"
+        }]
+      }
+    }
+
+    class NewerRule extends ParserRule {
+      static ruleName = "newer-rule"
+      static introducedIn = "0.9.1" as const
+
+      get defaultConfig(): FullRuleConfig {
+        return { enabled: true, severity: "warning" }
+      }
+
+      check(): UnboundLintOffense[] { return [] }
+    }
+
+    class DisabledNewRule extends ParserRule {
+      static ruleName = "disabled-new-rule"
+      static introducedIn = "0.9.0" as const
+
+      get defaultConfig(): FullRuleConfig {
+        return { enabled: false, severity: "error" }
+      }
+
+      check(): UnboundLintOffense[] { return [] }
+    }
+
+    test("includes all rules when no configVersion is provided", () => {
+      const { enabled, skippedByVersion } = Linter.filterRulesByConfig([OldRule, NewRule, NewerRule])
+
+      expect(enabled).toHaveLength(3)
+      expect(skippedByVersion).toHaveLength(0)
+    })
+
+    test("skips rules introduced after the config version", () => {
+      const { enabled, skippedByVersion } = Linter.filterRulesByConfig(
+        [OldRule, NewRule, NewerRule],
+        undefined,
+        "0.8.0"
+      )
+
+      expect(enabled).toHaveLength(1)
+      expect(enabled[0].ruleName).toBe("old-rule")
+
+      expect(skippedByVersion).toHaveLength(2)
+      expect(skippedByVersion[0].ruleName).toBe("new-rule")
+      expect(skippedByVersion[0].introducedIn).toBe("0.9.0")
+      expect(skippedByVersion[1].ruleName).toBe("newer-rule")
+      expect(skippedByVersion[1].introducedIn).toBe("0.9.1")
+    })
+
+    test("includes rules matching the config version exactly", () => {
+      const { enabled, skippedByVersion } = Linter.filterRulesByConfig(
+        [OldRule, NewRule, NewerRule],
+        undefined,
+        "0.9.0"
+      )
+
+      expect(enabled).toHaveLength(2)
+      expect(enabled[0].ruleName).toBe("old-rule")
+      expect(enabled[1].ruleName).toBe("new-rule")
+
+      expect(skippedByVersion).toHaveLength(1)
+      expect(skippedByVersion[0].ruleName).toBe("newer-rule")
+    })
+
+    test("includes all rules when config version matches latest", () => {
+      const { enabled, skippedByVersion } = Linter.filterRulesByConfig(
+        [OldRule, NewRule, NewerRule],
+        undefined,
+        "0.9.1"
+      )
+
+      expect(enabled).toHaveLength(3)
+      expect(skippedByVersion).toHaveLength(0)
+    })
+
+    test("user explicitly enabling a rule overrides version gating", () => {
+      const userConfig = {
+        "new-rule": { enabled: true }
+      }
+
+      const { enabled, skippedByVersion } = Linter.filterRulesByConfig(
+        [OldRule, NewRule, NewerRule],
+        userConfig,
+        "0.8.0"
+      )
+
+      expect(enabled).toHaveLength(2)
+
+      const enabledNames = enabled.map(rule => rule.ruleName)
+      expect(enabledNames).toContain("new-rule")
+      expect(enabledNames).toContain("old-rule")
+
+      expect(skippedByVersion).toHaveLength(1)
+      expect(skippedByVersion[0].ruleName).toBe("newer-rule")
+    })
+
+    test("user explicitly disabling a rule is respected regardless of version", () => {
+      const userConfig = {
+        "old-rule": { enabled: false }
+      }
+
+      const { enabled } = Linter.filterRulesByConfig(
+        [OldRule, NewRule],
+        userConfig,
+        "0.9.0"
+      )
+
+      expect(enabled).toHaveLength(1)
+      expect(enabled[0].ruleName).toBe("new-rule")
+    })
+
+    test("disabled-by-default rules are not included in skippedByVersion", () => {
+      const { enabled, skippedByVersion } = Linter.filterRulesByConfig(
+        [OldRule, DisabledNewRule],
+        undefined,
+        "0.8.0"
+      )
+
+      expect(enabled).toHaveLength(1)
+      expect(enabled[0].ruleName).toBe("old-rule")
+
+      expect(skippedByVersion).toHaveLength(0)
+    })
+
+    test("Linter.from() applies version gating from config", () => {
+      const config = Config.fromObject({
+        linter: { enabled: true }
+      }, { configVersion: "0.8.0" })
+
+      const linter = Linter.from(Herb, config)
+
+      expect(linter.rulesSkippedByVersion.length).toBeGreaterThan(0)
+    })
+
+    test("Linter.from() includes all released rules when config version is current", () => {
+      const config = Config.fromObject({
+        linter: { enabled: true }
+      })
+
+      const linter = Linter.from(Herb, config)
+
+      const releasedSkipped = linter.rulesSkippedByVersion.filter(
+        rule => rule.introducedIn !== "unreleased"
+      )
+
+      expect(releasedSkipped).toHaveLength(0)
+    })
+
+    test("version-gated rules do not produce offenses", () => {
+      const config = Config.fromObject({
+        linter: { enabled: true }
+      }, { configVersion: "0.8.0" })
+
+      const filteredRules = Linter.filterRulesByConfig(
+        [OldRule, NewRule],
+        config.linter?.rules,
+        config.configVersion
+      )
+
+      const linter = new Linter(Herb, filteredRules.enabled, config)
+      const result = linter.lint("<div>test</div>")
+
+      const ruleNames = result.offenses.map(offense => offense.rule)
+      expect(ruleNames).not.toContain("new-rule")
     })
   })
 })

--- a/javascript/packages/linter/test/semver.test.ts
+++ b/javascript/packages/linter/test/semver.test.ts
@@ -1,0 +1,110 @@
+import { describe, test, expect } from "vitest"
+
+import { parseSemver, compareSemver, semverGreaterThan, UNRELEASED_VERSION } from "../src/semver.js"
+
+describe("@herb-tools/linter", () => {
+  describe("parseSemver", () => {
+    test("parses major.minor.patch", () => {
+      expect(parseSemver("1.2.3")).toEqual([1, 2, 3])
+    })
+
+    test("parses major.minor without patch", () => {
+      expect(parseSemver("1.2")).toEqual([1, 2, 0])
+    })
+
+    test("parses zero versions", () => {
+      expect(parseSemver("0.0.0")).toEqual([0, 0, 0])
+    })
+
+    test("parses large version numbers", () => {
+      expect(parseSemver("10.20.30")).toEqual([10, 20, 30])
+    })
+
+    test("returns [0,0,0] for invalid strings", () => {
+      expect(parseSemver("invalid")).toEqual([0, 0, 0])
+    })
+
+    test("returns [0,0,0] for empty string", () => {
+      expect(parseSemver("")).toEqual([0, 0, 0])
+    })
+
+    test("returns [0,0,0] for too many parts", () => {
+      expect(parseSemver("1.2.3.4")).toEqual([0, 0, 0])
+    })
+
+    test("returns [0,0,0] for non-numeric parts", () => {
+      expect(parseSemver("a.b.c")).toEqual([0, 0, 0])
+    })
+  })
+
+  describe("compareSemver", () => {
+    test("returns 0 for equal versions", () => {
+      expect(compareSemver("1.2.3", "1.2.3")).toBe(0)
+    })
+
+    test("returns positive when first is greater (major)", () => {
+      expect(compareSemver("2.0.0", "1.0.0")).toBeGreaterThan(0)
+    })
+
+    test("returns negative when first is lesser (major)", () => {
+      expect(compareSemver("1.0.0", "2.0.0")).toBeLessThan(0)
+    })
+
+    test("returns positive when first is greater (minor)", () => {
+      expect(compareSemver("1.2.0", "1.1.0")).toBeGreaterThan(0)
+    })
+
+    test("returns negative when first is lesser (minor)", () => {
+      expect(compareSemver("1.1.0", "1.2.0")).toBeLessThan(0)
+    })
+
+    test("returns positive when first is greater (patch)", () => {
+      expect(compareSemver("1.2.4", "1.2.3")).toBeGreaterThan(0)
+    })
+
+    test("returns negative when first is lesser (patch)", () => {
+      expect(compareSemver("1.2.3", "1.2.4")).toBeLessThan(0)
+    })
+
+    test("unreleased is greater than any version", () => {
+      expect(compareSemver(UNRELEASED_VERSION, "99.99.99")).toBeGreaterThan(0)
+    })
+
+    test("any version is less than unreleased", () => {
+      expect(compareSemver("99.99.99", UNRELEASED_VERSION)).toBeLessThan(0)
+    })
+
+    test("unreleased equals unreleased", () => {
+      expect(compareSemver(UNRELEASED_VERSION, UNRELEASED_VERSION)).toBe(0)
+    })
+  })
+
+  describe("semverGreaterThan", () => {
+    test("returns true when first is greater", () => {
+      expect(semverGreaterThan("0.9.0", "0.8.10")).toBe(true)
+    })
+
+    test("returns false when first is lesser", () => {
+      expect(semverGreaterThan("0.8.10", "0.9.0")).toBe(false)
+    })
+
+    test("returns false when equal", () => {
+      expect(semverGreaterThan("0.9.0", "0.9.0")).toBe(false)
+    })
+
+    test("unreleased is greater than any version", () => {
+      expect(semverGreaterThan(UNRELEASED_VERSION, "99.99.99")).toBe(true)
+    })
+
+    test("no version is greater than unreleased", () => {
+      expect(semverGreaterThan("99.99.99", UNRELEASED_VERSION)).toBe(false)
+    })
+
+    test("handles real-world version comparison", () => {
+      expect(semverGreaterThan("0.9.0", "0.8.10")).toBe(true)
+      expect(semverGreaterThan("0.9.1", "0.9.0")).toBe(true)
+      expect(semverGreaterThan("0.8.10", "0.8.9")).toBe(true)
+      expect(semverGreaterThan("0.4.0", "0.9.2")).toBe(false)
+    })
+  })
+})


### PR DESCRIPTION
This pull request introduces version-gated linter rule filtering so that upgrading Herb doesn't unexpectedly enable new rules for users who have locked their `.herb.yml` version.

Each rule now declares `static introducedIn = this.version("X.Y.Z")` indicating the version it was first released in. When a user's `.herb.yml` version is older than a rule's `introducedIn`, that rule is automatically skipped. Users can still explicitly enable any rule in their config regardless of version


**No `.herb.yml`**

<img width="2093" height="623" alt="CleanShot 2026-03-22 at 04 54 37@2x" src="https://github.com/user-attachments/assets/9449b98d-ace2-4446-a3d4-36d9ffc275ab" />

**`.herb.yml` with older version**

<img width="1942" height="2022" alt="CleanShot 2026-03-22 at 04 55 27@2x" src="https://github.com/user-attachments/assets/95315081-693d-4614-963e-de57428544b5" />


**Running `--upgrade`**


<img width="1928" height="1748" alt="CleanShot 2026-03-22 at 04 59 31@2x" src="https://github.com/user-attachments/assets/245a6ac3-3c3e-4757-aee8-3c938e0da80b" />


