### PR TITLE
Parser: Introduce `VoidElementContentError`

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -458,6 +458,17 @@ errors:
 
       fields: []
 
+    - name: VoidElementContentError
+      message:
+        template: "Void element `%s` cannot have content. `%s` does not accept positional arguments."
+        arguments:
+          - tag_name->value
+          - tag_name->value
+
+      fields:
+        - name: tag_name
+          type: token
+
     - name: DotNotationCasingError
       message:
         template: "Dot-notation component tags require the first segment to start with an uppercase letter. `%s` does not start with an uppercase letter."

--- a/sig/herb/errors.rbs
+++ b/sig/herb/errors.rbs
@@ -655,6 +655,24 @@ module Herb
       def tree_inspect: (?indent: Integer, ?depth: Integer, ?depth_limit: Integer) -> String
     end
 
+    class VoidElementContentError < Error
+      include Colors
+
+      attr_reader tag_name: Herb::Token?
+
+      # : (String, Location?, String, Herb::Token) -> void
+      def initialize: (String, Location?, String, Herb::Token) -> void
+
+      # : () -> String
+      def inspect: () -> String
+
+      # : () -> serialized_void_element_content_error
+      def to_hash: () -> serialized_void_element_content_error
+
+      # : (?indent: Integer, ?depth: Integer, ?depth_limit: Integer) -> String
+      def tree_inspect: (?indent: Integer, ?depth: Integer, ?depth_limit: Integer) -> String
+    end
+
     class DotNotationCasingError < Error
       include Colors
 

--- a/src/analyze/action_view/tag_helpers.c
+++ b/src/analyze/action_view/tag_helpers.c
@@ -8,6 +8,7 @@
 #include "../../include/lib/hb_allocator.h"
 #include "../../include/lib/hb_array.h"
 #include "../../include/lib/hb_string.h"
+#include "../../include/lib/string.h"
 #include "../../include/location/position.h"
 #include "../../include/parser/parser_helpers.h"
 #include "../../include/util/html_util.h"
@@ -431,10 +432,22 @@ static AST_NODE_T* transform_tag_helper_with_attributes(
   );
 
   hb_array_T* body = hb_array_init(1, allocator);
-  bool is_void = tag_name && ((strcmp(handler->name, "tag") == 0) || (strcmp(handler->name, "image_tag") == 0))
-              && is_void_element(hb_string_from_c_string(tag_name));
+  hb_array_T* element_errors = hb_array_init(0, allocator);
+  bool is_void = tag_name && is_void_element(hb_string_from_c_string(tag_name))
+              && (string_equals(handler->name, "tag") || string_equals(handler->name, "content_tag")
+                  || string_equals(handler->name, "image_tag"));
 
   if (helper_content) {
+    if (is_void) {
+      append_void_element_content_error(
+        tag_name_token,
+        erb_node->base.location.start,
+        erb_node->base.location.end,
+        allocator,
+        element_errors
+      );
+    }
+
     append_body_content_node(
       body,
       helper_content,
@@ -468,7 +481,7 @@ static AST_NODE_T* transform_tag_helper_with_attributes(
     handler->source,
     erb_node->base.location.start,
     erb_node->base.location.end,
-    hb_array_init(0, allocator),
+    element_errors,
     allocator
   );
 

--- a/test/analyze/action_view/tag_helper/content_tag_test.rb
+++ b/test/analyze/action_view/tag_helper/content_tag_test.rb
@@ -257,5 +257,17 @@ module Analyze::ActionView::TagHelper
         <%= content_tag(:script, "alert('Hello')", nonce: false) %>
       HTML
     end
+
+    test "content_tag with void element img and content argument reports error" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <%= content_tag :img, "hello" %>
+      HTML
+    end
+
+    test "content_tag with void element br and content argument reports error" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <%= content_tag :br, "hello" %>
+      HTML
+    end
   end
 end

--- a/test/analyze/action_view/tag_helper/tag_test.rb
+++ b/test/analyze/action_view/tag_helper/tag_test.rb
@@ -346,5 +346,17 @@ module Analyze::ActionView::TagHelper
         <%= tag.script(nonce: false) { "alert('Hello')".html_safe } %>
       HTML
     end
+
+    test "tag.img with content argument reports void element content error" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <%= tag.img "/image.png" %>
+      HTML
+    end
+
+    test "tag.img with content argument and data attributes reports void element content error" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <%= tag.img "/image.png", data: { controller: "image" } %>
+      HTML
+    end
   end
 end

--- a/test/snapshots/analyze/action_view/tag_helper/content_tag_test/test_0014_content_tag_with_void_element_br_6610ebc45e248144b0795a8f8b1f87f0-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/content_tag_test/test_0014_content_tag_with_void_element_br_6610ebc45e248144b0795a8f8b1f87f0-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -17,11 +17,8 @@ options: {action_view_helpers: true}
     │   │
     │   ├── tag_name: "br" (location: (1:4)-(1:15))
     │   ├── body: []
-    │   ├── close_tag:
-    │   │   └── @ HTMLVirtualCloseTagNode (location: (1:22)-(1:22))
-    │   │       └── tag_name: "br" (location: (1:4)-(1:15))
-    │   │
-    │   ├── is_void: false
+    │   ├── close_tag: ∅
+    │   ├── is_void: true
     │   └── element_source: "ActionView::Helpers::TagHelper#content_tag"
     │
     └── @ HTMLTextNode (location: (1:22)-(2:0))

--- a/test/snapshots/analyze/action_view/tag_helper/content_tag_test/test_0015_content_tag_with_void_element_hr_with_attributes_2a6b2adf7ac8bf91d0a5a8a8dd096a8b-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/content_tag_test/test_0015_content_tag_with_void_element_hr_with_attributes_2a6b2adf7ac8bf91d0a5a8a8dd096a8b-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -37,11 +37,8 @@ options: {action_view_helpers: true}
     │   │
     │   ├── tag_name: "hr" (location: (1:4)-(1:15))
     │   ├── body: []
-    │   ├── close_tag:
-    │   │   └── @ HTMLVirtualCloseTagNode (location: (1:40)-(1:40))
-    │   │       └── tag_name: "hr" (location: (1:4)-(1:15))
-    │   │
-    │   ├── is_void: false
+    │   ├── close_tag: ∅
+    │   ├── is_void: true
     │   └── element_source: "ActionView::Helpers::TagHelper#content_tag"
     │
     └── @ HTMLTextNode (location: (1:40)-(2:0))

--- a/test/snapshots/analyze/action_view/tag_helper/content_tag_test/test_0016_content_tag_with_void_element_img_with_attributes_c1825e08bbcdcebd231eb18e614274ee-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/content_tag_test/test_0016_content_tag_with_void_element_img_with_attributes_c1825e08bbcdcebd231eb18e614274ee-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -57,11 +57,8 @@ options: {action_view_helpers: true}
     │   │
     │   ├── tag_name: "img" (location: (1:4)-(1:15))
     │   ├── body: []
-    │   ├── close_tag:
-    │   │   └── @ HTMLVirtualCloseTagNode (location: (1:56)-(1:56))
-    │   │       └── tag_name: "img" (location: (1:4)-(1:15))
-    │   │
-    │   ├── is_void: false
+    │   ├── close_tag: ∅
+    │   ├── is_void: true
     │   └── element_source: "ActionView::Helpers::TagHelper#content_tag"
     │
     └── @ HTMLTextNode (location: (1:56)-(2:0))

--- a/test/snapshots/analyze/action_view/tag_helper/content_tag_test/test_0037_content_tag_with_void_element_img_and_content_argument_reports_error_5bdb8a95466d4783db7ad280fd6d71ca-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/content_tag_test/test_0037_content_tag_with_void_element_img_and_content_argument_reports_error_5bdb8a95466d4783db7ad280fd6d71ca-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,33 @@
+---
+source: "Analyze::ActionView::TagHelper::ContentTagTest#test_0037_content_tag with void element img and content argument reports error"
+input: |2-
+<%= content_tag :img, "hello" %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:32))
+    │   ├── errors: (1 error)
+    │   │   └── @ VoidElementContentError (location: (1:0)-(1:32))
+    │   │       ├── message: "Void element `img` cannot have content. `img` does not accept positional arguments."
+    │   │       └── tag_name: "img" (location: (1:4)-(1:15))
+    │   │
+    │   ├── open_tag:
+    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:32))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " content_tag :img, "hello" " (location: (1:3)-(1:30))
+    │   │       ├── tag_closing: "%>" (location: (1:30)-(1:32))
+    │   │       ├── tag_name: "img" (location: (1:4)-(1:15))
+    │   │       └── children: []
+    │   │
+    │   ├── tag_name: "img" (location: (1:4)-(1:15))
+    │   ├── body: (1 item)
+    │   │   └── @ HTMLTextNode (location: (1:0)-(1:32))
+    │   │       └── content: "hello"
+    │   │
+    │   ├── close_tag: ∅
+    │   ├── is_void: true
+    │   └── element_source: "ActionView::Helpers::TagHelper#content_tag"
+    │
+    └── @ HTMLTextNode (location: (1:32)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/action_view/tag_helper/content_tag_test/test_0038_content_tag_with_void_element_br_and_content_argument_reports_error_29c54479d2c6354145cc9b90d440d7b8-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/content_tag_test/test_0038_content_tag_with_void_element_br_and_content_argument_reports_error_29c54479d2c6354145cc9b90d440d7b8-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,33 @@
+---
+source: "Analyze::ActionView::TagHelper::ContentTagTest#test_0038_content_tag with void element br and content argument reports error"
+input: |2-
+<%= content_tag :br, "hello" %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:31))
+    │   ├── errors: (1 error)
+    │   │   └── @ VoidElementContentError (location: (1:0)-(1:31))
+    │   │       ├── message: "Void element `br` cannot have content. `br` does not accept positional arguments."
+    │   │       └── tag_name: "br" (location: (1:4)-(1:15))
+    │   │
+    │   ├── open_tag:
+    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:31))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " content_tag :br, "hello" " (location: (1:3)-(1:29))
+    │   │       ├── tag_closing: "%>" (location: (1:29)-(1:31))
+    │   │       ├── tag_name: "br" (location: (1:4)-(1:15))
+    │   │       └── children: []
+    │   │
+    │   ├── tag_name: "br" (location: (1:4)-(1:15))
+    │   ├── body: (1 item)
+    │   │   └── @ HTMLTextNode (location: (1:0)-(1:31))
+    │   │       └── content: "hello"
+    │   │
+    │   ├── close_tag: ∅
+    │   ├── is_void: true
+    │   └── element_source: "ActionView::Helpers::TagHelper#content_tag"
+    │
+    └── @ HTMLTextNode (location: (1:31)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0045_tag.img_with_content_argument_reports_void_element_content_error_084e2a1a8052416f1cead9abb2dbafe0-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0045_tag.img_with_content_argument_reports_void_element_content_error_084e2a1a8052416f1cead9abb2dbafe0-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,33 @@
+---
+source: "Analyze::ActionView::TagHelper::TagTest#test_0045_tag.img with content argument reports void element content error"
+input: |2-
+<%= tag.img "/image.png" %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:27))
+    │   ├── errors: (1 error)
+    │   │   └── @ VoidElementContentError (location: (1:0)-(1:27))
+    │   │       ├── message: "Void element `img` cannot have content. `img` does not accept positional arguments."
+    │   │       └── tag_name: "img" (location: (1:8)-(1:11))
+    │   │
+    │   ├── open_tag:
+    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:27))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " tag.img "/image.png" " (location: (1:3)-(1:25))
+    │   │       ├── tag_closing: "%>" (location: (1:25)-(1:27))
+    │   │       ├── tag_name: "img" (location: (1:8)-(1:11))
+    │   │       └── children: []
+    │   │
+    │   ├── tag_name: "img" (location: (1:8)-(1:11))
+    │   ├── body: (1 item)
+    │   │   └── @ HTMLTextNode (location: (1:0)-(1:27))
+    │   │       └── content: "/image.png"
+    │   │
+    │   ├── close_tag: ∅
+    │   ├── is_void: true
+    │   └── element_source: "ActionView::Helpers::TagHelper#tag"
+    │
+    └── @ HTMLTextNode (location: (1:27)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0046_tag.img_with_content_argument_and_data_attributes_reports_void_element_content_error_27beafc0540b950e2d663a972bde04c5-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0046_tag.img_with_content_argument_and_data_attributes_reports_void_element_content_error_27beafc0540b950e2d663a972bde04c5-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,53 @@
+---
+source: "Analyze::ActionView::TagHelper::TagTest#test_0046_tag.img with content argument and data attributes reports void element content error"
+input: |2-
+<%= tag.img "/image.png", data: { controller: "image" } %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:58))
+    │   ├── errors: (1 error)
+    │   │   └── @ VoidElementContentError (location: (1:0)-(1:58))
+    │   │       ├── message: "Void element `img` cannot have content. `img` does not accept positional arguments."
+    │   │       └── tag_name: "img" (location: (1:8)-(1:11))
+    │   │
+    │   ├── open_tag:
+    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:58))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " tag.img "/image.png", data: { controller: "image" } " (location: (1:3)-(1:56))
+    │   │       ├── tag_closing: "%>" (location: (1:56)-(1:58))
+    │   │       ├── tag_name: "img" (location: (1:8)-(1:11))
+    │   │       └── children: (1 item)
+    │   │           └── @ HTMLAttributeNode (location: (1:34)-(1:53))
+    │   │               ├── name:
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:34)-(1:44))
+    │   │               │       └── children: (1 item)
+    │   │               │           └── @ LiteralNode (location: (1:34)-(1:44))
+    │   │               │               └── content: "data-controller"
+    │   │               │
+    │   │               │
+    │   │               ├── equals: ": " (location: (1:44)-(1:46))
+    │   │               └── value:
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:46)-(1:53))
+    │   │                       ├── open_quote: """ (location: (1:46)-(1:47))
+    │   │                       ├── children: (1 item)
+    │   │                       │   └── @ LiteralNode (location: (1:47)-(1:52))
+    │   │                       │       └── content: "image"
+    │   │                       │
+    │   │                       ├── close_quote: """ (location: (1:52)-(1:53))
+    │   │                       └── quoted: true
+    │   │
+    │   │
+    │   │
+    │   ├── tag_name: "img" (location: (1:8)-(1:11))
+    │   ├── body: (1 item)
+    │   │   └── @ HTMLTextNode (location: (1:0)-(1:58))
+    │   │       └── content: "/image.png"
+    │   │
+    │   ├── close_tag: ∅
+    │   ├── is_void: true
+    │   └── element_source: "ActionView::Helpers::TagHelper#tag"
+    │
+    └── @ HTMLTextNode (location: (1:58)-(2:0))
+        └── content: "\n"


### PR DESCRIPTION
This pull request updates the parser to introduce a new `VoidElementContentError` that gets added to a `HTMLElementNode` that was transformed from a `tag` or `content_tag` call when the tag used is a void element.

For example:
```erb
<%= content_tag :img, "/image.png" %>
```

Now gets parsed as the following with `action_view_helpers: true`:
```js
@ DocumentNode (location: (1:0)-(1:37))
└── children: (1 item)
    └── @ HTMLElementNode (location: (1:0)-(1:37))
        ├── errors: (1 error)
        │   └── @ VoidElementContentError (location: (1:0)-(1:37))
        │       ├── message: "Void element `img` cannot have content. `img` does not accept positional arguments."
        │       └── tag_name: "img" (location: (1:4)-(1:15))
        │
        ├── open_tag:
        │   └── @ ERBOpenTagNode (location: (1:0)-(1:37))
        │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
        │       ├── content: " content_tag :img, "/image.png" " (location: (1:3)-(1:35))
        │       ├── tag_closing: "%>" (location: (1:35)-(1:37))
        │       ├── tag_name: "img" (location: (1:4)-(1:15))
        │       └── children: []
        │
        ├── tag_name: "img" (location: (1:4)-(1:15))
        ├── body: (1 item)
        │   └── @ HTMLTextNode (location: (1:0)-(1:37))
        │       └── content: "/image.png"
        │
        ├── close_tag: ∅
        ├── is_void: true
        └── element_source: "ActionView::Helpers::TagHelper#content_tag"
```

It also catches:
```erb
<%= tag.img "/image.png" %>
```

```js
@ DocumentNode (location: (1:0)-(1:27))
└── children: (1 item)
    └── @ HTMLElementNode (location: (1:0)-(1:27))
        ├── errors: (1 error)
        │   └── @ VoidElementContentError (location: (1:0)-(1:27))
        │       ├── message: "Void element `img` cannot have content. `img` does not accept positional arguments."
        │       └── tag_name: "img" (location: (1:8)-(1:11))
        │
        ├── open_tag:
        │   └── @ ERBOpenTagNode (location: (1:0)-(1:27))
        │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
        │       ├── content: " tag.img "/image.png" " (location: (1:3)-(1:25))
        │       ├── tag_closing: "%>" (location: (1:25)-(1:27))
        │       ├── tag_name: "img" (location: (1:8)-(1:11))
        │       └── children: []
        │
        ├── tag_name: "img" (location: (1:8)-(1:11))
        ├── body: (1 item)
        │   └── @ HTMLTextNode (location: (1:0)-(1:27))
        │       └── content: "/image.png"
        │
        ├── close_tag: ∅
        ├── is_void: true
        └── element_source: "ActionView::Helpers::TagHelper#tag"
```