### PR TITLE
Language Server: Improve Hover Provider to show shallow rewrite

### DIFF
--- a/javascript/packages/language-server/src/hover_service.ts
+++ b/javascript/packages/language-server/src/hover_service.ts
@@ -1,30 +1,56 @@
-import { Hover, MarkupKind, Position } from "vscode-languageserver/node"
+import { Hover, MarkupKind, Position, Range } from "vscode-languageserver/node"
 import { TextDocument } from "vscode-languageserver-textdocument"
 
 import { Visitor } from "@herb-tools/node-wasm"
 import { IdentityPrinter } from "@herb-tools/printer"
 import { ActionViewTagHelperToHTMLRewriter } from "@herb-tools/rewriter"
-import { isERBOpenTagNode } from "@herb-tools/core"
+import { isERBOpenTagNode, isHTMLElementNode } from "@herb-tools/core"
 import { ParserService } from "./parser_service"
-import { nodeToRange, isPositionInRange, rangeSize } from "./range_utils"
+import { lspPosition, isPositionInRange, rangeSize } from "./range_utils"
 import { ACTION_VIEW_HELPERS } from "./action_view_helpers"
 
-import type { Node, HTMLElementNode } from "@herb-tools/core"
-import type { Range } from "vscode-languageserver/node"
+import type { HTMLElementNode, ERBOpenTagNode } from "@herb-tools/core"
 
 class ActionViewElementCollector extends Visitor {
-  public elements: { node: HTMLElementNode; range: Range }[] = []
+  public elements: { node: HTMLElementNode; openTag: ERBOpenTagNode; range: Range }[] = []
 
   visitHTMLElementNode(node: HTMLElementNode): void {
     if (node.element_source && node.element_source !== "HTML" && isERBOpenTagNode(node.open_tag)) {
-      this.elements.push({
-        node,
-        range: nodeToRange(node),
-      })
+      const content = node.open_tag.content
+      const tagName = node.open_tag.tag_name
+
+      if (content && tagName) {
+        const isTagHelper = node.element_source === "ActionView::Helpers::TagHelper#tag"
+        const methodName = isTagHelper ? `tag.${tagName.value}` : node.element_source.split("#").pop()!
+
+        const offset = content.value.indexOf(methodName)
+
+        if (offset !== -1) {
+          const contentStart = lspPosition(content.location.start)
+          const start = Position.create(contentStart.line, contentStart.character + offset)
+          const end = Position.create(start.line, start.character + methodName.length)
+
+          this.elements.push({
+            node,
+            openTag: node.open_tag,
+            range: Range.create(start, end),
+          })
+        }
+      }
     }
 
     this.visitChildNodes(node)
   }
+}
+
+function dedent(text: string): string {
+  const lines = text.split("\n")
+  const indents = lines.filter(line => line.trim().length > 0).map(line => line.match(/^(\s*)/)?.[1].length ?? 0)
+  const minIndent = Math.min(...indents)
+
+  if (minIndent === 0) return text
+
+  return lines.map(line => line.slice(minIndent)).join("\n")
 }
 
 export class HoverService {
@@ -43,7 +69,7 @@ export class HoverService {
     const collector = new ActionViewElementCollector()
     collector.visit(parseResult.value)
 
-    let bestElement: { node: HTMLElementNode; range: Range } | null = null
+    let bestElement: { node: HTMLElementNode; openTag: ERBOpenTagNode; range: Range } | null = null
     let bestSize = Infinity
 
     for (const element of collector.elements) {
@@ -62,9 +88,7 @@ export class HoverService {
     }
 
     const elementSource = bestElement.node.element_source
-    const rewriter = new ActionViewTagHelperToHTMLRewriter()
-    const rewrittenNode = rewriter.rewrite(bestElement.node as Node, { baseDir: process.cwd() })
-    const htmlOutput = IdentityPrinter.print(rewrittenNode)
+    const isLeaf = !bestElement.node.body.some(child => isHTMLElementNode(child))
     const helper = ACTION_VIEW_HELPERS[elementSource]
     const parts: string[] = []
 
@@ -72,7 +96,17 @@ export class HoverService {
       parts.push(`\`\`\`ruby\n${helper.signature}\n\`\`\``)
     }
 
-    parts.push(`**HTML equivalent**\n\`\`\`erb\n${htmlOutput.trim()}\n\`\`\``)
+    if (isLeaf) {
+      const rewriter = new ActionViewTagHelperToHTMLRewriter()
+      const rewrittenNode = rewriter.rewrite(bestElement.node, { baseDir: process.cwd(), shallow: true })
+      const htmlOutput = IdentityPrinter.print(rewrittenNode)
+
+      parts.push(`**HTML equivalent**\n\`\`\`erb\n${dedent(htmlOutput.trim())}\n\`\`\``)
+    } else {
+      const shallowResult = this.rewriteElement(textDocument, bestElement.node, { includeBody: false })
+
+      parts.push(`**HTML equivalent**\n\`\`\`erb\n${dedent(shallowResult.trim())}\n\`\`\``)
+    }
 
     if (helper) {
       parts.push(`[${elementSource}](${helper.documentationURL})`)
@@ -87,4 +121,36 @@ export class HoverService {
     }
   }
 
+  private rewriteElement(textDocument: TextDocument, node: HTMLElementNode, options: { includeBody: boolean }): string {
+    const parseResult = this.parserService.parseContent(textDocument.getText(), {
+      action_view_helpers: true,
+      track_whitespace: true,
+    })
+
+    const rewriter = new ActionViewTagHelperToHTMLRewriter()
+    const collector = new ActionViewElementCollector()
+
+    collector.visit(parseResult.value)
+
+    const match = collector.elements.find(element =>
+      element.node.location.start.line === node.location.start.line &&
+      element.node.location.start.column === node.location.start.column
+    )
+
+    if (!match) return ""
+
+    const rewrittenNode = rewriter.rewrite(match.node, {
+      baseDir: process.cwd(),
+      shallow: true,
+      includeBody: options.includeBody,
+    })
+
+    if (!options.includeBody) {
+      const openTag = match.node.open_tag ? IdentityPrinter.print(match.node.open_tag) : ""
+      const closeTag = match.node.close_tag ? IdentityPrinter.print(match.node.close_tag) : ""
+      return `${openTag}\n  ...\n${closeTag}`
+    }
+
+    return IdentityPrinter.print(rewrittenNode)
+  }
 }

--- a/javascript/packages/language-server/test/hover_service.test.ts
+++ b/javascript/packages/language-server/test/hover_service.test.ts
@@ -1,7 +1,7 @@
 import dedent from "dedent"
 
 import { describe, it, expect, beforeAll } from "vitest"
-import { Position, MarkupKind } from "vscode-languageserver/node"
+import { Position, MarkupKind, Range } from "vscode-languageserver/node"
 import { TextDocument } from "vscode-languageserver-textdocument"
 
 import { HoverService } from "../src/hover_service"
@@ -24,7 +24,20 @@ describe("HoverService", () => {
 
   function getHover(content: string, line: number, character: number) {
     const document = createDocument(content)
+
     return service.getHover(document, Position.create(line, character))
+  }
+
+  function hoverValue(content: string, line: number, character: number): string {
+    const hover = getHover(content, line, character)
+
+    return (hover!.contents as { value: string }).value
+  }
+
+  function hoverRange(content: string, line: number, character: number): Range {
+    const hover = getHover(content, line, character)
+
+    return hover!.range!
   }
 
   describe("tag.* helpers", () => {
@@ -39,94 +52,150 @@ describe("HoverService", () => {
 
       expect(hover).not.toBeNull()
       expect(hover!.contents).toHaveProperty("kind", MarkupKind.Markdown)
+      expect(hoverValue(content, 0, 5)).toMatchInlineSnapshot(`
+        "\`\`\`ruby
+        tag.<tag name>(optional content, options)
+        \`\`\`
 
-      const value = (hover!.contents as { value: string }).value
-      expect(value).toContain("```erb")
-      expect(value).toContain("<div>")
-      expect(value).toContain("HTML equivalent")
-    })
+        **HTML equivalent**
+        \`\`\`erb
+        <div>
+          Content
+        </div>
+        \`\`\`
 
-    it("shows signature for tag helper", () => {
-      const content = "<%= tag.div do %><% end %>"
-
-      const hover = getHover(content, 0, 5)
-
-      expect(hover).not.toBeNull()
-
-      const value = (hover!.contents as { value: string }).value
-      expect(value).toContain("```ruby")
-      expect(value).toContain("tag.<tag name>(optional content, options)")
-    })
-
-    it("shows documentation link for tag helper", () => {
-      const content = "<%= tag.div do %><% end %>"
-
-      const hover = getHover(content, 0, 5)
-
-      expect(hover).not.toBeNull()
-
-      const value = (hover!.contents as { value: string }).value
-      expect(value).toContain("ActionView::Helpers::TagHelper#tag")
-      expect(value).toContain("https://api.rubyonrails.org/classes/ActionView/Helpers/TagHelper.html#method-i-tag")
+        [ActionView::Helpers::TagHelper#tag](https://api.rubyonrails.org/classes/ActionView/Helpers/TagHelper.html#method-i-tag)"
+      `)
+      expect(hoverRange(content, 0, 5)).toMatchInlineSnapshot(`
+        {
+          "end": {
+            "character": 11,
+            "line": 0,
+          },
+          "start": {
+            "character": 4,
+            "line": 0,
+          },
+        }
+      `)
     })
 
     it("shows hover for tag.div with attributes", () => {
       const content = '<%= tag.div class: "container" do %><% end %>'
 
-      const hover = getHover(content, 0, 5)
+      expect(hoverValue(content, 0, 5)).toMatchInlineSnapshot(`
+        "\`\`\`ruby
+        tag.<tag name>(optional content, options)
+        \`\`\`
 
-      expect(hover).not.toBeNull()
+        **HTML equivalent**
+        \`\`\`erb
+        <div class="container"></div>
+        \`\`\`
 
-      const value = (hover!.contents as { value: string }).value
-      expect(value).toContain("<div")
-      expect(value).toContain("container")
+        [ActionView::Helpers::TagHelper#tag](https://api.rubyonrails.org/classes/ActionView/Helpers/TagHelper.html#method-i-tag)"
+      `)
+      expect(hoverRange(content, 0, 5)).toMatchInlineSnapshot(`
+        {
+          "end": {
+            "character": 11,
+            "line": 0,
+          },
+          "start": {
+            "character": 4,
+            "line": 0,
+          },
+        }
+      `)
     })
 
-    it("shows hover for tag with content argument", () => {
+    it("shows hover for tag.p with content argument", () => {
       const content = '<%= tag.p "Hello" %>'
 
-      const hover = getHover(content, 0, 5)
+      expect(hoverValue(content, 0, 5)).toMatchInlineSnapshot(`
+        "\`\`\`ruby
+        tag.<tag name>(optional content, options)
+        \`\`\`
 
-      expect(hover).not.toBeNull()
+        **HTML equivalent**
+        \`\`\`erb
+        <p>Hello</p>
+        \`\`\`
 
-      const value = (hover!.contents as { value: string }).value
-      expect(value).toContain("<p>")
+        [ActionView::Helpers::TagHelper#tag](https://api.rubyonrails.org/classes/ActionView/Helpers/TagHelper.html#method-i-tag)"
+      `)
+      expect(hoverRange(content, 0, 5)).toMatchInlineSnapshot(`
+        {
+          "end": {
+            "character": 9,
+            "line": 0,
+          },
+          "start": {
+            "character": 4,
+            "line": 0,
+          },
+        }
+      `)
     })
   })
 
   describe("content_tag", () => {
-    it("shows hover for content_tag", () => {
+    it("shows hover for content_tag with block", () => {
       const content = '<%= content_tag :div do %><% end %>'
 
-      const hover = getHover(content, 0, 5)
+      expect(hoverValue(content, 0, 5)).toMatchInlineSnapshot(`
+        "\`\`\`ruby
+        content_tag(name, content_or_options_with_block = nil, options = nil, escape = true, &block)
+        \`\`\`
 
-      expect(hover).not.toBeNull()
+        **HTML equivalent**
+        \`\`\`erb
+        <div></div>
+        \`\`\`
 
-      const value = (hover!.contents as { value: string }).value
-      expect(value).toContain("<div>")
+        [ActionView::Helpers::TagHelper#content_tag](https://api.rubyonrails.org/classes/ActionView/Helpers/TagHelper.html#method-i-content_tag)"
+      `)
+      expect(hoverRange(content, 0, 5)).toMatchInlineSnapshot(`
+        {
+          "end": {
+            "character": 15,
+            "line": 0,
+          },
+          "start": {
+            "character": 4,
+            "line": 0,
+          },
+        }
+      `)
     })
 
-    it("shows signature for content_tag", () => {
-      const content = '<%= content_tag :div do %><% end %>'
+    it("shows hover for content_tag with content argument", () => {
+      const content = '<%= content_tag :div, "Hello" %>'
 
-      const hover = getHover(content, 0, 5)
+      expect(hoverValue(content, 0, 5)).toMatchInlineSnapshot(`
+        "\`\`\`ruby
+        content_tag(name, content_or_options_with_block = nil, options = nil, escape = true, &block)
+        \`\`\`
 
-      expect(hover).not.toBeNull()
+        **HTML equivalent**
+        \`\`\`erb
+        <div>Hello</div>
+        \`\`\`
 
-      const value = (hover!.contents as { value: string }).value
-      expect(value).toContain("content_tag(")
-    })
-
-    it("shows documentation link for content_tag", () => {
-      const content = '<%= content_tag :div do %><% end %>'
-
-      const hover = getHover(content, 0, 5)
-
-      expect(hover).not.toBeNull()
-
-      const value = (hover!.contents as { value: string }).value
-      expect(value).toContain("ActionView::Helpers::TagHelper#content_tag")
-      expect(value).toContain("https://api.rubyonrails.org/classes/ActionView/Helpers/TagHelper.html#method-i-content_tag")
+        [ActionView::Helpers::TagHelper#content_tag](https://api.rubyonrails.org/classes/ActionView/Helpers/TagHelper.html#method-i-content_tag)"
+      `)
+      expect(hoverRange(content, 0, 5)).toMatchInlineSnapshot(`
+        {
+          "end": {
+            "character": 15,
+            "line": 0,
+          },
+          "start": {
+            "character": 4,
+            "line": 0,
+          },
+        }
+      `)
     })
   })
 
@@ -134,61 +203,234 @@ describe("HoverService", () => {
     it("shows hover for link_to", () => {
       const content = '<%= link_to "Home", root_path %>'
 
-      const hover = getHover(content, 0, 5)
+      expect(hoverValue(content, 0, 5)).toMatchInlineSnapshot(`
+        "\`\`\`ruby
+        link_to(name = nil, options = nil, html_options = nil, &block)
+        \`\`\`
 
-      expect(hover).not.toBeNull()
+        **HTML equivalent**
+        \`\`\`erb
+        <a href="<%= root_path %>">Home</a>
+        \`\`\`
 
-      const value = (hover!.contents as { value: string }).value
-      expect(value).toContain("<a")
+        [ActionView::Helpers::UrlHelper#link_to](https://api.rubyonrails.org/classes/ActionView/Helpers/UrlHelper.html#method-i-link_to)"
+      `)
+      expect(hoverRange(content, 0, 5)).toMatchInlineSnapshot(`
+        {
+          "end": {
+            "character": 11,
+            "line": 0,
+          },
+          "start": {
+            "character": 4,
+            "line": 0,
+          },
+        }
+      `)
     })
+  })
 
-    it("shows signature for link_to", () => {
+  describe("hover range targets method name only", () => {
+    it("only triggers hover on the method name for link_to", () => {
       const content = '<%= link_to "Home", root_path %>'
 
-      const hover = getHover(content, 0, 5)
-
-      expect(hover).not.toBeNull()
-
-      const value = (hover!.contents as { value: string }).value
-      expect(value).toContain("link_to(")
+      expect(getHover(content, 0, 3)).toBeNull()
+      expect(getHover(content, 0, 12)).toBeNull()
+      expect(getHover(content, 0, 4)).not.toBeNull()
+      expect(getHover(content, 0, 11)).not.toBeNull()
     })
 
-    it("shows documentation link for link_to", () => {
-      const content = '<%= link_to "Home", root_path %>'
+    it("only triggers hover on the method name for tag.div", () => {
+      const content = '<%= tag.div do %><% end %>'
 
-      const hover = getHover(content, 0, 5)
+      expect(getHover(content, 0, 3)).toBeNull()
+      expect(getHover(content, 0, 12)).toBeNull()
+      expect(getHover(content, 0, 4)).not.toBeNull()
+      expect(getHover(content, 0, 11)).not.toBeNull()
+    })
 
-      expect(hover).not.toBeNull()
+    it("only triggers hover on the method name for content_tag", () => {
+      const content = '<%= content_tag :div do %><% end %>'
 
-      const value = (hover!.contents as { value: string }).value
-      expect(value).toContain("ActionView::Helpers::UrlHelper#link_to")
-      expect(value).toContain("https://api.rubyonrails.org/classes/ActionView/Helpers/UrlHelper.html#method-i-link_to")
+      expect(getHover(content, 0, 3)).toBeNull()
+      expect(getHover(content, 0, 16)).toBeNull()
+      expect(getHover(content, 0, 4)).not.toBeNull()
+      expect(getHover(content, 0, 15)).not.toBeNull()
+    })
+  })
+
+  describe("nested elements", () => {
+    it("shows hover for each nested method name independently", () => {
+      const content = dedent`
+        <%= link_to "Devices", sessions_path do %>
+          <%= tag.div class: "hello" %>
+        <% end %>
+      `
+
+      expect(hoverValue(content, 0, 5)).toMatchInlineSnapshot(`
+        "\`\`\`ruby
+        link_to(name = nil, options = nil, html_options = nil, &block)
+        \`\`\`
+
+        **HTML equivalent**
+        \`\`\`erb
+        <a href="Devices">
+          ...
+        </a>
+        \`\`\`
+
+        [ActionView::Helpers::UrlHelper#link_to](https://api.rubyonrails.org/classes/ActionView/Helpers/UrlHelper.html#method-i-link_to)"
+      `)
+      expect(hoverRange(content, 0, 5)).toMatchInlineSnapshot(`
+        {
+          "end": {
+            "character": 11,
+            "line": 0,
+          },
+          "start": {
+            "character": 4,
+            "line": 0,
+          },
+        }
+      `)
+
+      expect(hoverValue(content, 1, 6)).toMatchInlineSnapshot(`
+        "\`\`\`ruby
+        tag.<tag name>(optional content, options)
+        \`\`\`
+
+        **HTML equivalent**
+        \`\`\`erb
+        <div class="hello"></div>
+        \`\`\`
+
+        [ActionView::Helpers::TagHelper#tag](https://api.rubyonrails.org/classes/ActionView/Helpers/TagHelper.html#method-i-tag)"
+      `)
+      expect(hoverRange(content, 1, 6)).toMatchInlineSnapshot(`
+        {
+          "end": {
+            "character": 13,
+            "line": 1,
+          },
+          "start": {
+            "character": 6,
+            "line": 1,
+          },
+        }
+      `)
+    })
+
+    it("does not show hover on body content between nested elements", () => {
+      const content = dedent`
+        <%= link_to "Devices", sessions_path do %>
+          some text
+        <% end %>
+      `
+
+      expect(getHover(content, 1, 5)).toBeNull()
+    })
+
+    it("shows shallow output with expandable details for deeply nested elements", () => {
+      const content = dedent`
+        <%= link_to "Devices", sessions_path do %>
+          <%= tag.div class: "hello" do %>
+            <%= content_tag :div, "Inner" %>
+          <% end %>
+        <% end %>
+      `
+
+      expect(hoverValue(content, 0, 5)).toMatchInlineSnapshot(`
+        "\`\`\`ruby
+        link_to(name = nil, options = nil, html_options = nil, &block)
+        \`\`\`
+
+        **HTML equivalent**
+        \`\`\`erb
+        <a href="Devices">
+          ...
+        </a>
+        \`\`\`
+
+        [ActionView::Helpers::UrlHelper#link_to](https://api.rubyonrails.org/classes/ActionView/Helpers/UrlHelper.html#method-i-link_to)"
+      `)
+      expect(hoverRange(content, 0, 5)).toMatchInlineSnapshot(`
+        {
+          "end": {
+            "character": 11,
+            "line": 0,
+          },
+          "start": {
+            "character": 4,
+            "line": 0,
+          },
+        }
+      `)
+
+      expect(hoverValue(content, 1, 6)).toMatchInlineSnapshot(`
+        "\`\`\`ruby
+        tag.<tag name>(optional content, options)
+        \`\`\`
+
+        **HTML equivalent**
+        \`\`\`erb
+        <div class="hello">
+          ...
+        </div>
+        \`\`\`
+
+        [ActionView::Helpers::TagHelper#tag](https://api.rubyonrails.org/classes/ActionView/Helpers/TagHelper.html#method-i-tag)"
+      `)
+      expect(hoverRange(content, 1, 6)).toMatchInlineSnapshot(`
+        {
+          "end": {
+            "character": 13,
+            "line": 1,
+          },
+          "start": {
+            "character": 6,
+            "line": 1,
+          },
+        }
+      `)
+
+      expect(hoverValue(content, 2, 8)).toMatchInlineSnapshot(`
+        "\`\`\`ruby
+        content_tag(name, content_or_options_with_block = nil, options = nil, escape = true, &block)
+        \`\`\`
+
+        **HTML equivalent**
+        \`\`\`erb
+        <div>Inner</div>
+        \`\`\`
+
+        [ActionView::Helpers::TagHelper#content_tag](https://api.rubyonrails.org/classes/ActionView/Helpers/TagHelper.html#method-i-content_tag)"
+      `)
+      expect(hoverRange(content, 2, 8)).toMatchInlineSnapshot(`
+        {
+          "end": {
+            "character": 19,
+            "line": 2,
+          },
+          "start": {
+            "character": 8,
+            "line": 2,
+          },
+        }
+      `)
     })
   })
 
   describe("non-ActionView elements", () => {
     it("returns null for plain HTML elements", () => {
-      const content = "<div>hello</div>"
-
-      const hover = getHover(content, 0, 2)
-
-      expect(hover).toBeNull()
+      expect(getHover("<div>hello</div>", 0, 2)).toBeNull()
     })
 
     it("returns null for plain text", () => {
-      const content = "just some text"
-
-      const hover = getHover(content, 0, 5)
-
-      expect(hover).toBeNull()
+      expect(getHover("just some text", 0, 5)).toBeNull()
     })
 
     it("returns null for regular ERB expressions", () => {
-      const content = "<%= some_method %>"
-
-      const hover = getHover(content, 0, 5)
-
-      expect(hover).toBeNull()
+      expect(getHover("<%= some_method %>", 0, 5)).toBeNull()
     })
   })
 })

--- a/javascript/packages/rewriter/src/built-ins/action-view-tag-helper-to-html.ts
+++ b/javascript/packages/rewriter/src/built-ins/action-view-tag-helper-to-html.ts
@@ -17,6 +17,15 @@ function createWhitespaceNode(): WhitespaceNode {
 }
 
 class ActionViewTagHelperToHTMLVisitor extends Visitor {
+  private shallow: boolean
+  private includeBody: boolean
+
+  constructor(options: { shallow?: boolean; includeBody?: boolean } = {}) {
+    super()
+    this.shallow = options.shallow ?? false
+    this.includeBody = options.includeBody ?? true
+  }
+
   visitHTMLElementNode(node: HTMLElementNode): void {
     if (!node.element_source) {
       this.visitChildNodes(node)
@@ -104,7 +113,9 @@ class ActionViewTagHelperToHTMLVisitor extends Visitor {
 
     asMutable(node).element_source = "HTML"
 
-    if (node.body) {
+    if (!this.includeBody) {
+      asMutable(node).body = []
+    } else if (node.body) {
       asMutable(node).body = node.body.map(child => {
         if (isRubyLiteralNode(child)) {
           return new ERBContentNode({
@@ -120,7 +131,10 @@ class ActionViewTagHelperToHTMLVisitor extends Visitor {
           })
         }
 
-        this.visit(child)
+        if (!this.shallow) {
+          this.visit(child)
+        }
+
         return child
       })
     }
@@ -169,8 +183,8 @@ export class ActionViewTagHelperToHTMLRewriter extends ASTRewriter {
     return "Converts ActionView tag helpers to raw HTML elements"
   }
 
-  rewrite<T extends Node>(node: T, _context: RewriteContext): T {
-    const visitor = new ActionViewTagHelperToHTMLVisitor()
+  rewrite<T extends Node>(node: T, context: RewriteContext): T {
+    const visitor = new ActionViewTagHelperToHTMLVisitor({ shallow: context.shallow, includeBody: context.includeBody })
 
     visitor.visit(node)
 


### PR DESCRIPTION
This pull request improves the Hover Provider for Action View Tag Helpers introduced in #1356.

The hover now only triggers when the cursor is on the method name (e.g., `link_to`, `tag.div`, `content_tag`) instead of anywhere within the element. This means hovering over child content, attributes, or whitespace no longer shows the hover.

For elements with children, the hover now shows a shallow HTML equivalent with `...` as a placeholder for the body, instead of recursively rewriting all nested Action View helpers.

Given this example:
```erb
<%= link_to sessions_path do %>
  <%= tag.div class: "hello" do %>
    <%= content_tag :div, "Devices & Sessions" %>
  <% end %>
<% end %>
```

When hovering over the `link_to` the popup showed: 

```erb
<a href="<%= sessions_path %>">
  <div class="hello">
    <div>Devices & Sessions</div>
  </div>
</a>
```

Now with this pull request it shows only a shallow version:
```erb
<a href="<%= sessions_path %>">
  ...
</a>
```

**Demo**

https://github.com/user-attachments/assets/d491867f-d473-44df-9224-523b17b4ec8c

Resolves https://github.com/marcoroth/herb/issues/1408