### PR TITLE
Parser: Support `tag.attributes` Action View helper

### DIFF
--- a/javascript/packages/rewriter/src/built-ins/action-view-tag-helper-to-html.ts
+++ b/javascript/packages/rewriter/src/built-ins/action-view-tag-helper-to-html.ts
@@ -1,5 +1,5 @@
 import { Visitor, Location, HTMLOpenTagNode, HTMLCloseTagNode, HTMLElementNode, HTMLAttributeValueNode, WhitespaceNode, ERBContentNode } from "@herb-tools/core"
-import { isHTMLAttributeNode, isERBOpenTagNode, isRubyLiteralNode, isRubyHTMLAttributesSplatNode, createSyntheticToken } from "@herb-tools/core"
+import { isHTMLAttributeNode, isERBOpenTagNode, isRubyLiteralNode, isRubyHTMLAttributesSplatNode, isWhitespaceNode, createSyntheticToken } from "@herb-tools/core"
 
 import { ASTRewriter } from "../ast-rewriter.js"
 import { asMutable } from "../mutable.js"
@@ -24,6 +24,36 @@ class ActionViewTagHelperToHTMLVisitor extends Visitor {
     super()
     this.shallow = options.shallow ?? false
     this.includeBody = options.includeBody ?? true
+  }
+
+  visitHTMLOpenTagNode(node: HTMLOpenTagNode): void {
+    const newChildren: Node[] = []
+
+    for (let index = 0; index < node.children.length; index++) {
+      const child = node.children[index]
+
+      if (isHTMLAttributeNode(child)) {
+        if (child.equals && child.equals.value !== "=") {
+          asMutable(child).equals = createSyntheticToken("=")
+        }
+
+        if (child.value) {
+          this.transformAttributeValue(child.value)
+        }
+
+        const previous = index > 0 ? node.children[index - 1] : null
+
+        if (!previous || !isWhitespaceNode(previous)) {
+          newChildren.push(createWhitespaceNode())
+        }
+      }
+
+      newChildren.push(child)
+    }
+
+    asMutable(node).children = newChildren
+
+    this.visitChildNodes(node)
   }
 
   visitHTMLElementNode(node: HTMLElementNode): void {

--- a/javascript/packages/rewriter/test/action-view-tag-helper-to-html.test.ts
+++ b/javascript/packages/rewriter/test/action-view-tag-helper-to-html.test.ts
@@ -684,6 +684,32 @@ describe("ActionViewTagHelperToHTMLRewriter", () => {
     })
   })
 
+  describe("tag.attributes", () => {
+    test("tag.attributes extracts attributes into parent element", () => {
+      expect(transform('<input <%= tag.attributes(type: :text, aria: { label: "Search" }) %>>')).toBe(
+        '<input type="text" aria-label="Search">'
+      )
+    })
+
+    test("tag.attributes with attributes after", () => {
+      expect(transform('<button <%= tag.attributes(id: "cta", aria: { expanded: false }) %> class="primary">Click</button>')).toBe(
+        '<button id="cta" aria-expanded="false" class="primary">Click</button>'
+      )
+    })
+
+    test("tag.attributes with attributes before", () => {
+      expect(transform('<button class="primary" <%= tag.attributes(id: "cta") %>>Click</button>')).toBe(
+        '<button class="primary" id="cta">Click</button>'
+      )
+    })
+
+    test("tag.attributes with data hash", () => {
+      expect(transform('<div <%= tag.attributes(data: { controller: "hello" }) %>></div>')).toBe(
+        '<div data-controller="hello"></div>'
+      )
+    })
+  })
+
   describe("non-ActionView elements", () => {
     test("regular HTML elements are not modified", () => {
       expect(transform('<div class="content">Hello</div>')).toBe(

--- a/src/analyze/action_view/tag_helpers.c
+++ b/src/analyze/action_view/tag_helpers.c
@@ -1201,6 +1201,41 @@ void transform_tag_helper_array(hb_array_T* array, analyze_ruby_context_T* conte
             }
           } else if (strcmp(parse_context->matched_handler->name, "link_to") == 0) {
             replacement = transform_link_to_helper(erb_node, context, parse_context);
+          } else if (string_equals(parse_context->matched_handler->name, "tag") && parse_context->info->tag_name
+                     && string_equals(parse_context->info->tag_name, "attributes")) {
+            hb_array_T* attributes = NULL;
+
+            if (parse_context->info->call_node) {
+              attributes = extract_html_attributes_from_call_node(
+                parse_context->info->call_node,
+                parse_context->prism_source,
+                parse_context->original_source,
+                parse_context->erb_content_offset,
+                context->allocator
+              );
+            }
+
+            if (attributes && hb_array_size(attributes) > 0) {
+              size_t old_size = hb_array_size(array);
+              size_t attributes_size = hb_array_size(attributes);
+              hb_array_T* new_array = hb_array_init(old_size - 1 + attributes_size, context->allocator);
+
+              for (size_t j = 0; j < old_size; j++) {
+                if (j == i) {
+                  for (size_t k = 0; k < attributes_size; k++) {
+                    hb_array_append(new_array, hb_array_get(attributes, k));
+                  }
+                } else {
+                  hb_array_append(new_array, hb_array_get(array, j));
+                }
+              }
+
+              array->items = new_array->items;
+              array->size = new_array->size;
+              array->capacity = new_array->capacity;
+
+              i += attributes_size - 1;
+            }
           } else {
             replacement = transform_tag_helper_with_attributes(erb_node, context, parse_context);
           }
@@ -1209,6 +1244,73 @@ void transform_tag_helper_array(hb_array_T* array, analyze_ruby_context_T* conte
         }
 
         free(erb_string);
+      }
+    } else if (child->type == AST_HTML_ATTRIBUTE_NODE) {
+      AST_HTML_ATTRIBUTE_NODE_T* attribute_node = (AST_HTML_ATTRIBUTE_NODE_T*) child;
+
+      if (attribute_node->name && !attribute_node->equals && !attribute_node->value && attribute_node->name->children
+          && hb_array_size(attribute_node->name->children) == 1) {
+        AST_NODE_T* name_child = hb_array_get(attribute_node->name->children, 0);
+
+        if (name_child && name_child->type == AST_ERB_CONTENT_NODE) {
+          AST_ERB_CONTENT_NODE_T* erb_node = (AST_ERB_CONTENT_NODE_T*) name_child;
+          token_T* erb_content = erb_node->content;
+
+          if (erb_content && !hb_string_is_empty(erb_content->value)) {
+            char* erb_string = hb_string_to_c_string_using_malloc(erb_content->value);
+            size_t erb_content_offset = 0;
+
+            if (context->source) {
+              erb_content_offset = calculate_byte_offset_from_position(context->source, erb_content->location.start);
+            }
+
+            tag_helper_parse_context_T* parse_context =
+              parse_tag_helper_content(erb_string, context->source, erb_content_offset, context->allocator);
+
+            if (parse_context && string_equals(parse_context->matched_handler->name, "tag")
+                && parse_context->info->tag_name && string_equals(parse_context->info->tag_name, "attributes")) {
+              hb_array_T* attributes = NULL;
+
+              if (parse_context->info->call_node) {
+                attributes = extract_html_attributes_from_call_node(
+                  parse_context->info->call_node,
+                  parse_context->prism_source,
+                  parse_context->original_source,
+                  parse_context->erb_content_offset,
+                  context->allocator
+                );
+              }
+
+              if (attributes && hb_array_size(attributes) > 0) {
+                size_t old_size = hb_array_size(array);
+                size_t attributes_size = hb_array_size(attributes);
+                hb_array_T* new_array = hb_array_init(old_size - 1 + attributes_size, context->allocator);
+
+                for (size_t j = 0; j < old_size; j++) {
+                  if (j == i) {
+                    for (size_t k = 0; k < attributes_size; k++) {
+                      hb_array_append(new_array, hb_array_get(attributes, k));
+                    }
+                  } else {
+                    hb_array_append(new_array, hb_array_get(array, j));
+                  }
+                }
+
+                array->items = new_array->items;
+                array->size = new_array->size;
+                array->capacity = new_array->capacity;
+
+                i += attributes_size - 1;
+              }
+
+              free_tag_helper_parse_context(parse_context);
+            } else if (parse_context) {
+              free_tag_helper_parse_context(parse_context);
+            }
+
+            free(erb_string);
+          }
+        }
       }
     }
 

--- a/test/analyze/action_view/tag_helper/tag_test.rb
+++ b/test/analyze/action_view/tag_helper/tag_test.rb
@@ -358,5 +358,31 @@ module Analyze::ActionView::TagHelper
         <%= tag.img "/image.png", data: { controller: "image" } %>
       HTML
     end
+
+    test "tag.attributes inside HTML open tag extracts attributes" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <input <%= tag.attributes(type: :text, aria: { label: "Search" }) %>>
+      HTML
+    end
+
+    test "tag.attributes with mixed HTML attributes and disabled false" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <button <%= tag.attributes(id: "call-to-action", disabled: false, aria: { expanded: false }) %> class="primary">Get Started!</button>
+      HTML
+    end
+
+    test "tag.attributes with attribute before" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <button class="primary" <%= tag.attributes(id: "call-to-action", disabled: false, aria: { expanded: false }) %>>Get Started!</button>
+      HTML
+    end
+
+    test "tag.attributes with attribute before and after" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <button class="primary" <%= tag.attributes(id: "call-to-action", disabled: false, aria: { expanded: false }) %> data-controller="hello">
+          Get Started!
+        </button>
+      HTML
+    end
   end
 end

--- a/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0047_tag.attributes_inside_HTML_open_tag_extracts_attributes_e0eaae0ef9762a0ebbb46b3265215a97-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0047_tag.attributes_inside_HTML_open_tag_extracts_attributes_e0eaae0ef9762a0ebbb46b3265215a97-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,65 @@
+---
+source: "Analyze::ActionView::TagHelper::TagTest#test_0047_tag.attributes inside HTML open tag extracts attributes"
+input: |2-
+<input <%= tag.attributes(type: :text, aria: { label: "Search" }) %>>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:69))
+    │   ├── open_tag:
+    │   │   └── @ HTMLOpenTagNode (location: (1:0)-(1:69))
+    │   │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+    │   │       ├── tag_name: "input" (location: (1:1)-(1:6))
+    │   │       ├── tag_closing: ">" (location: (1:68)-(1:69))
+    │   │       ├── children: (2 items)
+    │   │       │   ├── @ HTMLAttributeNode (location: (1:26)-(1:37))
+    │   │       │   │   ├── name:
+    │   │       │   │   │   └── @ HTMLAttributeNameNode (location: (1:26)-(1:30))
+    │   │       │   │   │       └── children: (1 item)
+    │   │       │   │   │           └── @ LiteralNode (location: (1:26)-(1:30))
+    │   │       │   │   │               └── content: "type"
+    │   │       │   │   │
+    │   │       │   │   │
+    │   │       │   │   ├── equals: ": " (location: (1:30)-(1:32))
+    │   │       │   │   └── value:
+    │   │       │   │       └── @ HTMLAttributeValueNode (location: (1:33)-(1:37))
+    │   │       │   │           ├── open_quote: ∅
+    │   │       │   │           ├── children: (1 item)
+    │   │       │   │           │   └── @ LiteralNode (location: (1:33)-(1:37))
+    │   │       │   │           │       └── content: "text"
+    │   │       │   │           │
+    │   │       │   │           ├── close_quote: ∅
+    │   │       │   │           └── quoted: false
+    │   │       │   │
+    │   │       │   │
+    │   │       │   └── @ HTMLAttributeNode (location: (1:47)-(1:62))
+    │   │       │       ├── name:
+    │   │       │       │   └── @ HTMLAttributeNameNode (location: (1:47)-(1:52))
+    │   │       │       │       └── children: (1 item)
+    │   │       │       │           └── @ LiteralNode (location: (1:47)-(1:52))
+    │   │       │       │               └── content: "aria-label"
+    │   │       │       │
+    │   │       │       │
+    │   │       │       ├── equals: ": " (location: (1:52)-(1:54))
+    │   │       │       └── value:
+    │   │       │           └── @ HTMLAttributeValueNode (location: (1:54)-(1:62))
+    │   │       │               ├── open_quote: """ (location: (1:54)-(1:55))
+    │   │       │               ├── children: (1 item)
+    │   │       │               │   └── @ LiteralNode (location: (1:55)-(1:61))
+    │   │       │               │       └── content: "Search"
+    │   │       │               │
+    │   │       │               ├── close_quote: """ (location: (1:61)-(1:62))
+    │   │       │               └── quoted: true
+    │   │       │
+    │   │       │
+    │   │       └── is_void: false
+    │   │
+    │   ├── tag_name: "input" (location: (1:1)-(1:6))
+    │   ├── body: []
+    │   ├── close_tag: ∅
+    │   ├── is_void: true
+    │   └── element_source: "HTML"
+    │
+    └── @ HTMLTextNode (location: (1:69)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0048_tag.attributes_with_mixed_HTML_attributes_and_disabled_false_0a0702154698a698b3d3ee31c36614e9-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0048_tag.attributes_with_mixed_HTML_attributes_and_disabled_false_0a0702154698a698b3d3ee31c36614e9-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,94 @@
+---
+source: "Analyze::ActionView::TagHelper::TagTest#test_0048_tag.attributes with mixed HTML attributes and disabled false"
+input: |2-
+<button <%= tag.attributes(id: "call-to-action", disabled: false, aria: { expanded: false }) %> class="primary">Get Started!</button>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:133))
+    │   ├── open_tag:
+    │   │   └── @ HTMLOpenTagNode (location: (1:0)-(1:112))
+    │   │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+    │   │       ├── tag_name: "button" (location: (1:1)-(1:7))
+    │   │       ├── tag_closing: ">" (location: (1:111)-(1:112))
+    │   │       ├── children: (3 items)
+    │   │       │   ├── @ HTMLAttributeNode (location: (1:27)-(1:47))
+    │   │       │   │   ├── name:
+    │   │       │   │   │   └── @ HTMLAttributeNameNode (location: (1:27)-(1:29))
+    │   │       │   │   │       └── children: (1 item)
+    │   │       │   │   │           └── @ LiteralNode (location: (1:27)-(1:29))
+    │   │       │   │   │               └── content: "id"
+    │   │       │   │   │
+    │   │       │   │   │
+    │   │       │   │   ├── equals: ": " (location: (1:29)-(1:31))
+    │   │       │   │   └── value:
+    │   │       │   │       └── @ HTMLAttributeValueNode (location: (1:31)-(1:47))
+    │   │       │   │           ├── open_quote: """ (location: (1:31)-(1:32))
+    │   │       │   │           ├── children: (1 item)
+    │   │       │   │           │   └── @ LiteralNode (location: (1:32)-(1:46))
+    │   │       │   │           │       └── content: "call-to-action"
+    │   │       │   │           │
+    │   │       │   │           ├── close_quote: """ (location: (1:46)-(1:47))
+    │   │       │   │           └── quoted: true
+    │   │       │   │
+    │   │       │   │
+    │   │       │   ├── @ HTMLAttributeNode (location: (1:74)-(1:89))
+    │   │       │   │   ├── name:
+    │   │       │   │   │   └── @ HTMLAttributeNameNode (location: (1:74)-(1:82))
+    │   │       │   │   │       └── children: (1 item)
+    │   │       │   │   │           └── @ LiteralNode (location: (1:74)-(1:82))
+    │   │       │   │   │               └── content: "aria-expanded"
+    │   │       │   │   │
+    │   │       │   │   │
+    │   │       │   │   ├── equals: ": " (location: (1:82)-(1:84))
+    │   │       │   │   └── value:
+    │   │       │   │       └── @ HTMLAttributeValueNode (location: (1:84)-(1:89))
+    │   │       │   │           ├── open_quote: ∅
+    │   │       │   │           ├── children: (1 item)
+    │   │       │   │           │   └── @ LiteralNode (location: (1:84)-(1:89))
+    │   │       │   │           │       └── content: "false"
+    │   │       │   │           │
+    │   │       │   │           ├── close_quote: ∅
+    │   │       │   │           └── quoted: false
+    │   │       │   │
+    │   │       │   │
+    │   │       │   └── @ HTMLAttributeNode (location: (1:96)-(1:111))
+    │   │       │       ├── name:
+    │   │       │       │   └── @ HTMLAttributeNameNode (location: (1:96)-(1:101))
+    │   │       │       │       └── children: (1 item)
+    │   │       │       │           └── @ LiteralNode (location: (1:96)-(1:101))
+    │   │       │       │               └── content: "class"
+    │   │       │       │
+    │   │       │       │
+    │   │       │       ├── equals: "=" (location: (1:101)-(1:102))
+    │   │       │       └── value:
+    │   │       │           └── @ HTMLAttributeValueNode (location: (1:102)-(1:111))
+    │   │       │               ├── open_quote: """ (location: (1:102)-(1:103))
+    │   │       │               ├── children: (1 item)
+    │   │       │               │   └── @ LiteralNode (location: (1:103)-(1:110))
+    │   │       │               │       └── content: "primary"
+    │   │       │               │
+    │   │       │               ├── close_quote: """ (location: (1:110)-(1:111))
+    │   │       │               └── quoted: true
+    │   │       │
+    │   │       │
+    │   │       └── is_void: false
+    │   │
+    │   ├── tag_name: "button" (location: (1:1)-(1:7))
+    │   ├── body: (1 item)
+    │   │   └── @ HTMLTextNode (location: (1:112)-(1:124))
+    │   │       └── content: "Get Started!"
+    │   │
+    │   ├── close_tag:
+    │   │   └── @ HTMLCloseTagNode (location: (1:124)-(1:133))
+    │   │       ├── tag_opening: "</" (location: (1:124)-(1:126))
+    │   │       ├── tag_name: "button" (location: (1:126)-(1:132))
+    │   │       ├── children: []
+    │   │       └── tag_closing: ">" (location: (1:132)-(1:133))
+    │   │
+    │   ├── is_void: false
+    │   └── element_source: "HTML"
+    │
+    └── @ HTMLTextNode (location: (1:133)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0049_tag.attributes_with_attribute_before_69526b8c7b82b45f37882d0d6d710030-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0049_tag.attributes_with_attribute_before_69526b8c7b82b45f37882d0d6d710030-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,94 @@
+---
+source: "Analyze::ActionView::TagHelper::TagTest#test_0049_tag.attributes with attribute before"
+input: |2-
+<button class="primary" <%= tag.attributes(id: "call-to-action", disabled: false, aria: { expanded: false }) %>>Get Started!</button>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:133))
+    │   ├── open_tag:
+    │   │   └── @ HTMLOpenTagNode (location: (1:0)-(1:112))
+    │   │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+    │   │       ├── tag_name: "button" (location: (1:1)-(1:7))
+    │   │       ├── tag_closing: ">" (location: (1:111)-(1:112))
+    │   │       ├── children: (3 items)
+    │   │       │   ├── @ HTMLAttributeNode (location: (1:8)-(1:23))
+    │   │       │   │   ├── name:
+    │   │       │   │   │   └── @ HTMLAttributeNameNode (location: (1:8)-(1:13))
+    │   │       │   │   │       └── children: (1 item)
+    │   │       │   │   │           └── @ LiteralNode (location: (1:8)-(1:13))
+    │   │       │   │   │               └── content: "class"
+    │   │       │   │   │
+    │   │       │   │   │
+    │   │       │   │   ├── equals: "=" (location: (1:13)-(1:14))
+    │   │       │   │   └── value:
+    │   │       │   │       └── @ HTMLAttributeValueNode (location: (1:14)-(1:23))
+    │   │       │   │           ├── open_quote: """ (location: (1:14)-(1:15))
+    │   │       │   │           ├── children: (1 item)
+    │   │       │   │           │   └── @ LiteralNode (location: (1:15)-(1:22))
+    │   │       │   │           │       └── content: "primary"
+    │   │       │   │           │
+    │   │       │   │           ├── close_quote: """ (location: (1:22)-(1:23))
+    │   │       │   │           └── quoted: true
+    │   │       │   │
+    │   │       │   │
+    │   │       │   ├── @ HTMLAttributeNode (location: (1:43)-(1:63))
+    │   │       │   │   ├── name:
+    │   │       │   │   │   └── @ HTMLAttributeNameNode (location: (1:43)-(1:45))
+    │   │       │   │   │       └── children: (1 item)
+    │   │       │   │   │           └── @ LiteralNode (location: (1:43)-(1:45))
+    │   │       │   │   │               └── content: "id"
+    │   │       │   │   │
+    │   │       │   │   │
+    │   │       │   │   ├── equals: ": " (location: (1:45)-(1:47))
+    │   │       │   │   └── value:
+    │   │       │   │       └── @ HTMLAttributeValueNode (location: (1:47)-(1:63))
+    │   │       │   │           ├── open_quote: """ (location: (1:47)-(1:48))
+    │   │       │   │           ├── children: (1 item)
+    │   │       │   │           │   └── @ LiteralNode (location: (1:48)-(1:62))
+    │   │       │   │           │       └── content: "call-to-action"
+    │   │       │   │           │
+    │   │       │   │           ├── close_quote: """ (location: (1:62)-(1:63))
+    │   │       │   │           └── quoted: true
+    │   │       │   │
+    │   │       │   │
+    │   │       │   └── @ HTMLAttributeNode (location: (1:90)-(1:105))
+    │   │       │       ├── name:
+    │   │       │       │   └── @ HTMLAttributeNameNode (location: (1:90)-(1:98))
+    │   │       │       │       └── children: (1 item)
+    │   │       │       │           └── @ LiteralNode (location: (1:90)-(1:98))
+    │   │       │       │               └── content: "aria-expanded"
+    │   │       │       │
+    │   │       │       │
+    │   │       │       ├── equals: ": " (location: (1:98)-(1:100))
+    │   │       │       └── value:
+    │   │       │           └── @ HTMLAttributeValueNode (location: (1:100)-(1:105))
+    │   │       │               ├── open_quote: ∅
+    │   │       │               ├── children: (1 item)
+    │   │       │               │   └── @ LiteralNode (location: (1:100)-(1:105))
+    │   │       │               │       └── content: "false"
+    │   │       │               │
+    │   │       │               ├── close_quote: ∅
+    │   │       │               └── quoted: false
+    │   │       │
+    │   │       │
+    │   │       └── is_void: false
+    │   │
+    │   ├── tag_name: "button" (location: (1:1)-(1:7))
+    │   ├── body: (1 item)
+    │   │   └── @ HTMLTextNode (location: (1:112)-(1:124))
+    │   │       └── content: "Get Started!"
+    │   │
+    │   ├── close_tag:
+    │   │   └── @ HTMLCloseTagNode (location: (1:124)-(1:133))
+    │   │       ├── tag_opening: "</" (location: (1:124)-(1:126))
+    │   │       ├── tag_name: "button" (location: (1:126)-(1:132))
+    │   │       ├── children: []
+    │   │       └── tag_closing: ">" (location: (1:132)-(1:133))
+    │   │
+    │   ├── is_void: false
+    │   └── element_source: "HTML"
+    │
+    └── @ HTMLTextNode (location: (1:133)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0050_tag.attributes_with_attribute_before_and_after_6118563c87f6d0c0b220453a8d4aa554-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0050_tag.attributes_with_attribute_before_and_after_6118563c87f6d0c0b220453a8d4aa554-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,116 @@
+---
+source: "Analyze::ActionView::TagHelper::TagTest#test_0050_tag.attributes with attribute before and after"
+input: |2-
+<button class="primary" <%= tag.attributes(id: "call-to-action", disabled: false, aria: { expanded: false }) %> data-controller="hello">
+  Get Started!
+</button>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(4:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(3:9))
+    │   ├── open_tag:
+    │   │   └── @ HTMLOpenTagNode (location: (1:0)-(1:136))
+    │   │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+    │   │       ├── tag_name: "button" (location: (1:1)-(1:7))
+    │   │       ├── tag_closing: ">" (location: (1:135)-(1:136))
+    │   │       ├── children: (4 items)
+    │   │       │   ├── @ HTMLAttributeNode (location: (1:8)-(1:23))
+    │   │       │   │   ├── name:
+    │   │       │   │   │   └── @ HTMLAttributeNameNode (location: (1:8)-(1:13))
+    │   │       │   │   │       └── children: (1 item)
+    │   │       │   │   │           └── @ LiteralNode (location: (1:8)-(1:13))
+    │   │       │   │   │               └── content: "class"
+    │   │       │   │   │
+    │   │       │   │   │
+    │   │       │   │   ├── equals: "=" (location: (1:13)-(1:14))
+    │   │       │   │   └── value:
+    │   │       │   │       └── @ HTMLAttributeValueNode (location: (1:14)-(1:23))
+    │   │       │   │           ├── open_quote: """ (location: (1:14)-(1:15))
+    │   │       │   │           ├── children: (1 item)
+    │   │       │   │           │   └── @ LiteralNode (location: (1:15)-(1:22))
+    │   │       │   │           │       └── content: "primary"
+    │   │       │   │           │
+    │   │       │   │           ├── close_quote: """ (location: (1:22)-(1:23))
+    │   │       │   │           └── quoted: true
+    │   │       │   │
+    │   │       │   │
+    │   │       │   ├── @ HTMLAttributeNode (location: (1:43)-(1:63))
+    │   │       │   │   ├── name:
+    │   │       │   │   │   └── @ HTMLAttributeNameNode (location: (1:43)-(1:45))
+    │   │       │   │   │       └── children: (1 item)
+    │   │       │   │   │           └── @ LiteralNode (location: (1:43)-(1:45))
+    │   │       │   │   │               └── content: "id"
+    │   │       │   │   │
+    │   │       │   │   │
+    │   │       │   │   ├── equals: ": " (location: (1:45)-(1:47))
+    │   │       │   │   └── value:
+    │   │       │   │       └── @ HTMLAttributeValueNode (location: (1:47)-(1:63))
+    │   │       │   │           ├── open_quote: """ (location: (1:47)-(1:48))
+    │   │       │   │           ├── children: (1 item)
+    │   │       │   │           │   └── @ LiteralNode (location: (1:48)-(1:62))
+    │   │       │   │           │       └── content: "call-to-action"
+    │   │       │   │           │
+    │   │       │   │           ├── close_quote: """ (location: (1:62)-(1:63))
+    │   │       │   │           └── quoted: true
+    │   │       │   │
+    │   │       │   │
+    │   │       │   ├── @ HTMLAttributeNode (location: (1:90)-(1:105))
+    │   │       │   │   ├── name:
+    │   │       │   │   │   └── @ HTMLAttributeNameNode (location: (1:90)-(1:98))
+    │   │       │   │   │       └── children: (1 item)
+    │   │       │   │   │           └── @ LiteralNode (location: (1:90)-(1:98))
+    │   │       │   │   │               └── content: "aria-expanded"
+    │   │       │   │   │
+    │   │       │   │   │
+    │   │       │   │   ├── equals: ": " (location: (1:98)-(1:100))
+    │   │       │   │   └── value:
+    │   │       │   │       └── @ HTMLAttributeValueNode (location: (1:100)-(1:105))
+    │   │       │   │           ├── open_quote: ∅
+    │   │       │   │           ├── children: (1 item)
+    │   │       │   │           │   └── @ LiteralNode (location: (1:100)-(1:105))
+    │   │       │   │           │       └── content: "false"
+    │   │       │   │           │
+    │   │       │   │           ├── close_quote: ∅
+    │   │       │   │           └── quoted: false
+    │   │       │   │
+    │   │       │   │
+    │   │       │   └── @ HTMLAttributeNode (location: (1:112)-(1:135))
+    │   │       │       ├── name:
+    │   │       │       │   └── @ HTMLAttributeNameNode (location: (1:112)-(1:127))
+    │   │       │       │       └── children: (1 item)
+    │   │       │       │           └── @ LiteralNode (location: (1:112)-(1:127))
+    │   │       │       │               └── content: "data-controller"
+    │   │       │       │
+    │   │       │       │
+    │   │       │       ├── equals: "=" (location: (1:127)-(1:128))
+    │   │       │       └── value:
+    │   │       │           └── @ HTMLAttributeValueNode (location: (1:128)-(1:135))
+    │   │       │               ├── open_quote: """ (location: (1:128)-(1:129))
+    │   │       │               ├── children: (1 item)
+    │   │       │               │   └── @ LiteralNode (location: (1:129)-(1:134))
+    │   │       │               │       └── content: "hello"
+    │   │       │               │
+    │   │       │               ├── close_quote: """ (location: (1:134)-(1:135))
+    │   │       │               └── quoted: true
+    │   │       │
+    │   │       │
+    │   │       └── is_void: false
+    │   │
+    │   ├── tag_name: "button" (location: (1:1)-(1:7))
+    │   ├── body: (1 item)
+    │   │   └── @ HTMLTextNode (location: (1:136)-(3:0))
+    │   │       └── content: "\n  Get Started!\n"
+    │   │
+    │   ├── close_tag:
+    │   │   └── @ HTMLCloseTagNode (location: (3:0)-(3:9))
+    │   │       ├── tag_opening: "</" (location: (3:0)-(3:2))
+    │   │       ├── tag_name: "button" (location: (3:2)-(3:8))
+    │   │       ├── children: []
+    │   │       └── tag_closing: ">" (location: (3:8)-(3:9))
+    │   │
+    │   ├── is_void: false
+    │   └── element_source: "HTML"
+    │
+    └── @ HTMLTextNode (location: (3:9)-(4:0))
+        └── content: "\n"


### PR DESCRIPTION
This pull request updates the parser to detect and transform the `tag.attributes` Action View helper.

With this pull request, the following example:
```erb
<input <%= tag.attributes(type: :text, aria: { label: "Search" }) %>>
```

Now gets parsed as this using `action_view_helpers: true`:
```js
@ DocumentNode (location: (1:0)-(1:6))
└── children: (1 item)
    └── @ HTMLElementNode (location: (1:0)-(1:69))
        ├── open_tag:
        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:69))
        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
        │       ├── tag_name: "input" (location: (1:1)-(1:6))
        │       ├── tag_closing: ">" (location: (1:68)-(1:69))
        │       ├── children: (2 items)
        │       │   ├── @ HTMLAttributeNode (location: (1:26)-(1:37))
        │       │   │   ├── name:
        │       │   │   │   └── @ HTMLAttributeNameNode (location: (1:26)-(1:30))
        │       │   │   │       └── children: (1 item)
        │       │   │   │           └── @ LiteralNode (location: (1:26)-(1:30))
        │       │   │   │               └── content: "type"
        │       │   │   │
        │       │   │   ├── equals: ": " (location: (1:30)-(1:32))
        │       │   │   └── value:
        │       │   │       └── @ HTMLAttributeValueNode (location: (1:33)-(1:37))
        │       │   │           ├── open_quote: ∅
        │       │   │           ├── children: (1 item)
        │       │   │           │   └── @ LiteralNode (location: (1:33)-(1:37))
        │       │   │           │       └── content: "text"
        │       │   │           │
        │       │   │           ├── close_quote: ∅
        │       │   │           └── quoted: false
        │       │   │
        │       │   └── @ HTMLAttributeNode (location: (1:47)-(1:62))
        │       │       ├── name:
        │       │       │   └── @ HTMLAttributeNameNode (location: (1:47)-(1:52))
        │       │       │       └── children: (1 item)
        │       │       │           └── @ LiteralNode (location: (1:47)-(1:52))
        │       │       │               └── content: "aria-label"
        │       │       │
        │       │       ├── equals: ": " (location: (1:52)-(1:54))
        │       │       └── value:
        │       │           └── @ HTMLAttributeValueNode (location: (1:54)-(1:62))
        │       │               ├── open_quote: """ (location: (1:54)-(1:55))
        │       │               ├── children: (1 item)
        │       │               │   └── @ LiteralNode (location: (1:55)-(1:61))
        │       │               │       └── content: "Search"
        │       │               │
        │       │               ├── close_quote: """ (location: (1:61)-(1:62))
        │       │               └── quoted: true
        │       │
        │       └── is_void: false
        │
        ├── tag_name: "input" (location: (1:1)-(1:6))
        ├── body: []
        ├── close_tag: ∅
        ├── is_void: true
        └── element_source: "HTML"
```

This pull request also updates the rewriter to rewrite from/to:
```erb
<input type="text" aria-label="Search">
```

Enables https://github.com/marcoroth/herb/issues/1458
Enables https://github.com/marcoroth/herb/issues/1459