### PR TITLE
Linter: Implement `actionview-strict-locals-partial-only` rule

### DIFF
--- a/javascript/packages/linter/docs/rules/README.md
+++ b/javascript/packages/linter/docs/rules/README.md
@@ -10,6 +10,7 @@ This page contains documentation for all Herb Linter rules.
 - [`actionview-no-silent-render`](./actionview-no-silent-render.md) - Disallow calling `render` without outputting the result
 - [`actionview-no-void-element-content`](./actionview-no-void-element-content.md) - Disallow content arguments for void Action View elements
 - [`actionview-strict-locals-first-line`](./actionview-strict-locals-first-line.md) - Require strict locals on the first line of partials with a blank line after.
+- [`actionview-strict-locals-partial-only`](./actionview-strict-locals-partial-only.md) - Only allow strict local definitions in partial files.
 
 
 #### ERB

--- a/javascript/packages/linter/docs/rules/actionview-strict-locals-partial-only.md
+++ b/javascript/packages/linter/docs/rules/actionview-strict-locals-partial-only.md
@@ -1,0 +1,37 @@
+# Linter Rule: Only allow strict local definitions in partial files
+
+**Rule:** `actionview-strict-locals-partial-only`
+
+## Description
+
+Detects strict locals declarations in files that are not Rails partials. Strict locals are only supported in partials (templates whose filename begins with an underscore), so a declaration in any other template has no effect.
+
+## Rationale
+
+A `<%# locals: (...) %>` comment in a non-partial file (such as a view or layout) is misleading. It looks like it constrains the available local variables, but Rails only processes strict locals in partials. Flagging these declarations prevents confusion and keeps templates honest about their actual contract.
+
+## Examples
+
+### ✅ Good
+
+```erb [app/views/users/_card.html.erb]
+<%# locals: (user:) %>
+
+<div class="user-card">
+  <%= user.name %>
+</div>
+```
+
+### 🚫 Bad
+
+```erb [app/views/users/show.html.erb]
+<%# locals: (user:) %>
+
+<div class="user-card">
+  <%= user.name %>
+</div>
+```
+
+## References
+
+- [Action View - Strict Locals](https://guides.rubyonrails.org/action_view_overview.html#strict-locals)

--- a/javascript/packages/linter/src/rules.ts
+++ b/javascript/packages/linter/src/rules.ts
@@ -4,6 +4,7 @@ import { ActionViewNoSilentHelperRule } from "./rules/actionview-no-silent-helpe
 import { ActionViewNoSilentRenderRule } from "./rules/actionview-no-silent-render.js"
 import { ActionViewNoVoidElementContentRule } from "./rules/actionview-no-void-element-content.js"
 import { ActionViewStrictLocalsFirstLineRule } from "./rules/actionview-strict-locals-first-line.js"
+import { ActionViewStrictLocalsPartialOnlyRule } from "./rules/actionview-strict-locals-partial-only.js"
 
 import { ERBCommentSyntax } from "./rules/erb-comment-syntax.js";
 import { ERBNoCaseNodeChildrenRule } from "./rules/erb-no-case-node-children.js"
@@ -95,6 +96,7 @@ export const rules: RuleClass[] = [
   ActionViewNoSilentRenderRule,
   ActionViewNoVoidElementContentRule,
   ActionViewStrictLocalsFirstLineRule,
+  ActionViewStrictLocalsPartialOnlyRule,
 
   ERBCommentSyntax,
   ERBNoCaseNodeChildrenRule,

--- a/javascript/packages/linter/src/rules/actionview-strict-locals-partial-only.ts
+++ b/javascript/packages/linter/src/rules/actionview-strict-locals-partial-only.ts
@@ -1,0 +1,66 @@
+import { BaseRuleVisitor } from "./rule-utils.js"
+import { ParserRule } from "../types.js"
+
+import { isHTMLTextNode } from "@herb-tools/core"
+import { isPartialFile } from "./file-utils.js"
+
+import type { ParseResult, ERBStrictLocalsNode } from "@herb-tools/core"
+import type { UnboundLintOffense, LintOffense, LintContext, FullRuleConfig } from "../types.js"
+
+class ActionViewStrictLocalsPartialOnlyVisitor extends BaseRuleVisitor {
+  visitERBStrictLocalsNode(node: ERBStrictLocalsNode): void {
+    this.addOffense(
+      "Strict locals declarations are only supported in partials. This file is not a partial.",
+      node.location,
+    )
+  }
+}
+
+export class ActionViewStrictLocalsPartialOnlyRule extends ParserRule {
+  static unsafeAutocorrectable = true
+  static ruleName = "actionview-strict-locals-partial-only"
+  static introducedIn = this.version("unreleased")
+
+  get parserOptions() {
+    return { strict_locals: true }
+  }
+
+  get defaultConfig(): FullRuleConfig {
+    return {
+      enabled: true,
+      severity: "warning",
+    }
+  }
+
+  check(result: ParseResult, context?: Partial<LintContext>): UnboundLintOffense[] {
+    if (isPartialFile(context?.fileName) !== false) return []
+
+    const visitor = new ActionViewStrictLocalsPartialOnlyVisitor(this.ruleName, context)
+    visitor.visit(result.value)
+
+    return visitor.offenses
+  }
+
+  autofix(offense: LintOffense, result: ParseResult): ParseResult | null {
+    const children = result.value.children
+
+    const index = children.findIndex(child =>
+      child.location.start.line === offense.location.start.line &&
+      child.location.start.column === offense.location.start.column
+    )
+
+    if (index === -1) return null
+
+    children.splice(index, 1)
+
+    if (index < children.length) {
+      const next = children[index]
+
+      if (isHTMLTextNode(next) && /^\s*\n/.test(next.content)) {
+        children.splice(index, 1)
+      }
+    }
+
+    return result
+  }
+}

--- a/javascript/packages/linter/src/rules/index.ts
+++ b/javascript/packages/linter/src/rules/index.ts
@@ -7,6 +7,7 @@ export * from "./actionview-no-silent-helper.js"
 export * from "./actionview-no-silent-render.js"
 export * from "./actionview-no-void-element-content.js"
 export * from "./actionview-strict-locals-first-line.js"
+export * from "./actionview-strict-locals-partial-only.js"
 
 export * from "./erb-comment-syntax.js"
 export * from "./erb-no-case-node-children.js"

--- a/javascript/packages/linter/test/__snapshots__/cli.test.ts.snap
+++ b/javascript/packages/linter/test/__snapshots__/cli.test.ts.snap
@@ -111,9 +111,10 @@ test/fixtures/ignored.html.erb:8:8
   Fixable      7 offenses | 4 autocorrectable using \`--fix\`
 
  New rules available:
-  Your .herb.yml version is 0.9.2. 3 new rules are disabled to ease upgrades:
+  Your .herb.yml version is 0.9.2. 4 new rules are disabled to ease upgrades:
 
   actionview-no-void-element-content (introduced in next release)
+  actionview-strict-locals-partial-only (introduced in next release)
   html-require-script-nonce (introduced in next release)
   source-indentation (introduced in next release)
 
@@ -181,9 +182,10 @@ test/fixtures/test-file-with-errors.html.erb:2:22
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
 
  New rules available:
-  Your .herb.yml version is 0.9.2. 3 new rules are disabled to ease upgrades:
+  Your .herb.yml version is 0.9.2. 4 new rules are disabled to ease upgrades:
 
   actionview-no-void-element-content (introduced in next release)
+  actionview-strict-locals-partial-only (introduced in next release)
   html-require-script-nonce (introduced in next release)
   source-indentation (introduced in next release)
 
@@ -213,9 +215,10 @@ test/fixtures/no-trailing-newline.html.erb:1:29
   Fixable      1 offense | 1 autocorrectable using \`--fix\`
 
  New rules available:
-  Your .herb.yml version is 0.9.2. 3 new rules are disabled to ease upgrades:
+  Your .herb.yml version is 0.9.2. 4 new rules are disabled to ease upgrades:
 
   actionview-no-void-element-content (introduced in next release)
+  actionview-strict-locals-partial-only (introduced in next release)
   html-require-script-nonce (introduced in next release)
   source-indentation (introduced in next release)
 
@@ -271,9 +274,10 @@ test/fixtures/erb-no-extra-whitespace-inside-tags.html.erb:9:3
   Fixable      3 offenses | 3 autocorrectable using \`--fix\`
 
  New rules available:
-  Your .herb.yml version is 0.9.2. 3 new rules are disabled to ease upgrades:
+  Your .herb.yml version is 0.9.2. 4 new rules are disabled to ease upgrades:
 
   actionview-no-void-element-content (introduced in next release)
+  actionview-strict-locals-partial-only (introduced in next release)
   html-require-script-nonce (introduced in next release)
   source-indentation (introduced in next release)
 
@@ -322,9 +326,10 @@ test/fixtures/ignored.html.erb:6:14
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
 
  New rules available:
-  Your .herb.yml version is 0.9.2. 3 new rules are disabled to ease upgrades:
+  Your .herb.yml version is 0.9.2. 4 new rules are disabled to ease upgrades:
 
   actionview-no-void-element-content (introduced in next release)
+  actionview-strict-locals-partial-only (introduced in next release)
   html-require-script-nonce (introduced in next release)
   source-indentation (introduced in next release)
 
@@ -358,9 +363,10 @@ test/fixtures/parser-errors.html.erb:2:16
   Fixable      1 offense
 
  New rules available:
-  Your .herb.yml version is 0.9.2. 3 new rules are disabled to ease upgrades:
+  Your .herb.yml version is 0.9.2. 4 new rules are disabled to ease upgrades:
 
   actionview-no-void-element-content (introduced in next release)
+  actionview-strict-locals-partial-only (introduced in next release)
   html-require-script-nonce (introduced in next release)
   source-indentation (introduced in next release)
 
@@ -583,9 +589,10 @@ test/fixtures/multiple-rule-offenses.html.erb:4:2
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
 
  New rules available:
-  Your .herb.yml version is 0.9.2. 3 new rules are disabled to ease upgrades:
+  Your .herb.yml version is 0.9.2. 4 new rules are disabled to ease upgrades:
 
   actionview-no-void-element-content (introduced in next release)
+  actionview-strict-locals-partial-only (introduced in next release)
   html-require-script-nonce (introduced in next release)
   source-indentation (introduced in next release)
 
@@ -690,9 +697,10 @@ test/fixtures/few-rule-offenses.html.erb:6:0
   Fixable      6 offenses | 3 autocorrectable using \`--fix\`
 
  New rules available:
-  Your .herb.yml version is 0.9.2. 3 new rules are disabled to ease upgrades:
+  Your .herb.yml version is 0.9.2. 4 new rules are disabled to ease upgrades:
 
   actionview-no-void-element-content (introduced in next release)
+  actionview-strict-locals-partial-only (introduced in next release)
   html-require-script-nonce (introduced in next release)
   source-indentation (introduced in next release)
 
@@ -739,9 +747,10 @@ test/fixtures/bad-file.html.erb:1:16
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
 
  New rules available:
-  Your .herb.yml version is 0.9.2. 3 new rules are disabled to ease upgrades:
+  Your .herb.yml version is 0.9.2. 4 new rules are disabled to ease upgrades:
 
   actionview-no-void-element-content (introduced in next release)
+  actionview-strict-locals-partial-only (introduced in next release)
   html-require-script-nonce (introduced in next release)
   source-indentation (introduced in next release)
 
@@ -758,9 +767,10 @@ exports[`CLI Output Formatting > formats GitHub Actions output correctly for cle
   Offenses     0 offenses
 
  New rules available:
-  Your .herb.yml version is 0.9.2. 3 new rules are disabled to ease upgrades:
+  Your .herb.yml version is 0.9.2. 4 new rules are disabled to ease upgrades:
 
   actionview-no-void-element-content (introduced in next release)
+  actionview-strict-locals-partial-only (introduced in next release)
   html-require-script-nonce (introduced in next release)
   source-indentation (introduced in next release)
 
@@ -825,9 +835,10 @@ test/fixtures/test-file-with-errors.html.erb:2:22
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
 
  New rules available:
-  Your .herb.yml version is 0.9.2. 3 new rules are disabled to ease upgrades:
+  Your .herb.yml version is 0.9.2. 4 new rules are disabled to ease upgrades:
 
   actionview-no-void-element-content (introduced in next release)
+  actionview-strict-locals-partial-only (introduced in next release)
   html-require-script-nonce (introduced in next release)
   source-indentation (introduced in next release)
 
@@ -871,9 +882,10 @@ test/fixtures/test-file-simple.html.erb:2:22
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
 
  New rules available:
-  Your .herb.yml version is 0.9.2. 3 new rules are disabled to ease upgrades:
+  Your .herb.yml version is 0.9.2. 4 new rules are disabled to ease upgrades:
 
   actionview-no-void-element-content (introduced in next release)
+  actionview-strict-locals-partial-only (introduced in next release)
   html-require-script-nonce (introduced in next release)
   source-indentation (introduced in next release)
 
@@ -1085,9 +1097,10 @@ test/fixtures/test-file-with-errors.html.erb:2:22
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
 
  New rules available:
-  Your .herb.yml version is 0.9.2. 3 new rules are disabled to ease upgrades:
+  Your .herb.yml version is 0.9.2. 4 new rules are disabled to ease upgrades:
 
   actionview-no-void-element-content (introduced in next release)
+  actionview-strict-locals-partial-only (introduced in next release)
   html-require-script-nonce (introduced in next release)
   source-indentation (introduced in next release)
 
@@ -1114,9 +1127,10 @@ exports[`CLI Output Formatting > formats simple output correctly 1`] = `
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
 
  New rules available:
-  Your .herb.yml version is 0.9.2. 3 new rules are disabled to ease upgrades:
+  Your .herb.yml version is 0.9.2. 4 new rules are disabled to ease upgrades:
 
   actionview-no-void-element-content (introduced in next release)
+  actionview-strict-locals-partial-only (introduced in next release)
   html-require-script-nonce (introduced in next release)
   source-indentation (introduced in next release)
 
@@ -1143,9 +1157,10 @@ exports[`CLI Output Formatting > formats simple output for bad-file correctly 1`
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
 
  New rules available:
-  Your .herb.yml version is 0.9.2. 3 new rules are disabled to ease upgrades:
+  Your .herb.yml version is 0.9.2. 4 new rules are disabled to ease upgrades:
 
   actionview-no-void-element-content (introduced in next release)
+  actionview-strict-locals-partial-only (introduced in next release)
   html-require-script-nonce (introduced in next release)
   source-indentation (introduced in next release)
 
@@ -1165,9 +1180,10 @@ exports[`CLI Output Formatting > formats success output correctly 1`] = `
   Offenses     0 offenses
 
  New rules available:
-  Your .herb.yml version is 0.9.2. 3 new rules are disabled to ease upgrades:
+  Your .herb.yml version is 0.9.2. 4 new rules are disabled to ease upgrades:
 
   actionview-no-void-element-content (introduced in next release)
+  actionview-strict-locals-partial-only (introduced in next release)
   html-require-script-nonce (introduced in next release)
   source-indentation (introduced in next release)
 
@@ -1187,9 +1203,10 @@ exports[`CLI Output Formatting > handles boolean attributes 1`] = `
   Offenses     0 offenses
 
  New rules available:
-  Your .herb.yml version is 0.9.2. 3 new rules are disabled to ease upgrades:
+  Your .herb.yml version is 0.9.2. 4 new rules are disabled to ease upgrades:
 
   actionview-no-void-element-content (introduced in next release)
+  actionview-strict-locals-partial-only (introduced in next release)
   html-require-script-nonce (introduced in next release)
   source-indentation (introduced in next release)
 
@@ -1232,9 +1249,10 @@ test/fixtures/bad-file.html.erb:1:16
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
 
  New rules available:
-  Your .herb.yml version is 0.9.2. 3 new rules are disabled to ease upgrades:
+  Your .herb.yml version is 0.9.2. 4 new rules are disabled to ease upgrades:
 
   actionview-no-void-element-content (introduced in next release)
+  actionview-strict-locals-partial-only (introduced in next release)
   html-require-script-nonce (introduced in next release)
   source-indentation (introduced in next release)
 
@@ -1374,9 +1392,10 @@ test/fixtures/disabled-1.html.erb:14:19
   Fixable      8 offenses | 1 autocorrectable using \`--fix\`
 
  New rules available:
-  Your .herb.yml version is 0.9.2. 3 new rules are disabled to ease upgrades:
+  Your .herb.yml version is 0.9.2. 4 new rules are disabled to ease upgrades:
 
   actionview-no-void-element-content (introduced in next release)
+  actionview-strict-locals-partial-only (introduced in next release)
   html-require-script-nonce (introduced in next release)
   source-indentation (introduced in next release)
 
@@ -1587,9 +1606,10 @@ test/fixtures/disabled-2.html.erb:2:44
   Fixable      13 offenses | 6 autocorrectable using \`--fix\`
 
  New rules available:
-  Your .herb.yml version is 0.9.2. 3 new rules are disabled to ease upgrades:
+  Your .herb.yml version is 0.9.2. 4 new rules are disabled to ease upgrades:
 
   actionview-no-void-element-content (introduced in next release)
+  actionview-strict-locals-partial-only (introduced in next release)
   html-require-script-nonce (introduced in next release)
   source-indentation (introduced in next release)
 
@@ -1657,9 +1677,10 @@ test/fixtures/test-file-with-errors.html.erb:2:22
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
 
  New rules available:
-  Your .herb.yml version is 0.9.2. 3 new rules are disabled to ease upgrades:
+  Your .herb.yml version is 0.9.2. 4 new rules are disabled to ease upgrades:
 
   actionview-no-void-element-content (introduced in next release)
+  actionview-strict-locals-partial-only (introduced in next release)
   html-require-script-nonce (introduced in next release)
   source-indentation (introduced in next release)
 

--- a/javascript/packages/linter/test/autofix/actionview-strict-locals-partial-only.autofix.test.ts
+++ b/javascript/packages/linter/test/autofix/actionview-strict-locals-partial-only.autofix.test.ts
@@ -1,0 +1,79 @@
+import dedent from "dedent"
+import { describe, test, expect, beforeAll } from "vitest"
+import { Herb } from "@herb-tools/node-wasm"
+import { Linter } from "../../src/linter.js"
+import { ActionViewStrictLocalsPartialOnlyRule } from "../../src/rules/actionview-strict-locals-partial-only.js"
+
+describe("actionview-strict-locals-partial-only autofix", () => {
+  beforeAll(async () => {
+    await Herb.load()
+  })
+
+  test("removes strict locals declaration from non-partial file", () => {
+    const input = dedent`
+      <%# locals: (user:) %>
+
+      <div><%= user.name %></div>
+    `
+    const expected = `<div><%= user.name %></div>`
+
+    const linter = new Linter(Herb, [ActionViewStrictLocalsPartialOnlyRule])
+    const result = linter.autofix(input, { fileName: "show.html.erb" }, undefined, { includeUnsafe: true })
+
+    expect(result.source).toBe(expected)
+    expect(result.fixed).toHaveLength(1)
+    expect(result.unfixed).toHaveLength(0)
+  })
+
+  test("does not autofix without includeUnsafe", () => {
+    const input = dedent`
+      <%# locals: (user:) %>
+
+      <div><%= user.name %></div>
+    `
+
+    const linter = new Linter(Herb, [ActionViewStrictLocalsPartialOnlyRule])
+    const result = linter.autofix(input, { fileName: "show.html.erb" })
+
+    expect(result.source).toBe(input)
+    expect(result.fixed).toHaveLength(0)
+    expect(result.unfixed).toHaveLength(1)
+  })
+
+  test("does not modify partial files", () => {
+    const input = dedent`
+      <%# locals: (user:) %>
+
+      <div><%= user.name %></div>
+    `
+
+    const linter = new Linter(Herb, [ActionViewStrictLocalsPartialOnlyRule])
+    const result = linter.autofix(input, { fileName: "_partial.html.erb" }, undefined, { includeUnsafe: true })
+
+    expect(result.source).toBe(input)
+    expect(result.fixed).toHaveLength(0)
+    expect(result.unfixed).toHaveLength(0)
+  })
+
+  test("removes strict locals and trailing whitespace from layout file", () => {
+    const input = dedent`
+      <%# locals: (title:) %>
+
+      <html>
+        <head><title><%= title %></title></head>
+      </html>
+    `
+    const expected = dedent`
+      <html>
+        <head><title><%= title %></title></head>
+      </html>
+    `
+
+    const linter = new Linter(Herb, [ActionViewStrictLocalsPartialOnlyRule])
+    const result = linter.autofix(input, { fileName: "application.html.erb" }, undefined, { includeUnsafe: true })
+
+    expect(result.source).toBe(expected)
+    expect(result.fixed).toHaveLength(1)
+    expect(result.unfixed).toHaveLength(0)
+  })
+})

--- a/javascript/packages/linter/test/rules/actionview-strict-locals-partial-only.test.ts
+++ b/javascript/packages/linter/test/rules/actionview-strict-locals-partial-only.test.ts
@@ -1,0 +1,91 @@
+import dedent from "dedent"
+import { describe, test } from "vitest"
+import { ActionViewStrictLocalsPartialOnlyRule } from "../../src/rules/actionview-strict-locals-partial-only.js"
+import { createLinterTest } from "../helpers/linter-test-helper.js"
+
+const { expectNoOffenses, expectWarning, assertOffenses } = createLinterTest(ActionViewStrictLocalsPartialOnlyRule)
+
+describe("ActionViewStrictLocalsPartialOnlyRule", () => {
+  test("allows strict locals in partials", () => {
+    expectNoOffenses(dedent`
+      <%# locals: (user:) %>
+
+      <div><%= user.name %></div>
+    `, { fileName: "_partial.html.erb" })
+  })
+
+  test("allows templates without strict locals", () => {
+    expectNoOffenses(dedent`
+      <div><%= user.name %></div>
+    `, { fileName: "show.html.erb" })
+  })
+
+  test("flags strict locals in non-partial files", () => {
+    expectWarning("Strict locals declarations are only supported in partials. This file is not a partial.")
+
+    assertOffenses(dedent`
+      <%# locals: (user:) %>
+
+      <div><%= user.name %></div>
+    `, { fileName: "show.html.erb" })
+  })
+
+  test("flags strict locals in layout files", () => {
+    expectWarning("Strict locals declarations are only supported in partials. This file is not a partial.")
+
+    assertOffenses(dedent`
+      <%# locals: (title:) %>
+
+      <html>
+        <head><title><%= title %></title></head>
+      </html>
+    `, { fileName: "application.html.erb" })
+  })
+
+  test("does not flag when filename is not provided", () => {
+    expectNoOffenses(dedent`
+      <%# locals: (user:) %>
+
+      <div><%= user.name %></div>
+    `)
+  })
+
+  test("allows strict locals in nested partial paths", () => {
+    expectNoOffenses(dedent`
+      <%# locals: (user:) %>
+
+      <div><%= user.name %></div>
+    `, { fileName: "app/views/users/_card.html.erb" })
+  })
+
+  test("flags strict locals in nested non-partial paths", () => {
+    expectWarning("Strict locals declarations are only supported in partials. This file is not a partial.")
+
+    assertOffenses(dedent`
+      <%# locals: (user:) %>
+
+      <div><%= user.name %></div>
+    `, { fileName: "app/views/users/show.html.erb" })
+  })
+
+  test("flags strict locals in component files", () => {
+    expectWarning("Strict locals declarations are only supported in partials. This file is not a partial.")
+
+    assertOffenses(dedent`
+      <%# locals: (title:) %>
+
+      <div class="card"><%= title %></div>
+    `, { fileName: "app/components/card_component.html.erb" })
+  })
+
+  test("flags strict locals not on the first line in non-partial files", () => {
+    expectWarning("Strict locals declarations are only supported in partials. This file is not a partial.")
+
+    assertOffenses(dedent`
+      <div class="wrapper">
+        <%# locals: (user:) %>
+        <%= user.name %>
+      </div>
+    `, { fileName: "show.html.erb" })
+  })
+})


### PR DESCRIPTION
This pull request adds a new `actionview-strict-locals-partial-only` linter rule that detects strict locals declarations in files that are not Rails partials. 

Strict locals are only supported in partials (templates whose filename begins with an underscore), so a declaration in any other template has no effect.

### Good

**`app/views/users/_card.html.erb`**
```erb
<%# locals: (user:) %>

<div class="user-card">
  <%= user.name %>
</div>
```

### Bad

**`app/views/users/show.html.erb`**
```erb
<%# locals: (user:) %>

<div class="user-card">
  <%= user.name %>
</div>
```

**`app/components/card_component.html.erb`**
```erb
<%# locals: (title:) %>

<div class="card"><%= title %></div>
```

Resolves #1464