### PR TITLE
Parser: Handle more Action View helpers transformations cases

### DIFF
--- a/bin/actionview-render
+++ b/bin/actionview-render
@@ -67,6 +67,7 @@ class ActionViewRenderer
   end
 
   def render_template
+    require "bigdecimal"
     require "action_view"
 
     lookup_context = ActionView::LookupContext.new([])

--- a/javascript/packages/language-service/test/parse-html-document.test.ts
+++ b/javascript/packages/language-service/test/parse-html-document.test.ts
@@ -34,6 +34,32 @@ describe("parseHTMLDocument", () => {
     expect((root.herbNode as any).element_source).toBe("ActionView::Helpers::TagHelper#tag")
   })
 
+  test("parses ActionView tag.img with content argument as void element", () => {
+    const service = createService()
+    const document = createDocument('<%= tag.img "/image.png" %>')
+    const html = service.parseHTMLDocument(document)
+
+    expect(html.roots).toHaveLength(1)
+
+    const root = html.roots[0] as HerbHTMLNode
+    expect(root.tag).toBe("img")
+    expect(root.herbNode).toBeDefined()
+    expect((root.herbNode as any).element_source).toBe("ActionView::Helpers::TagHelper#tag")
+    expect((root.herbNode as any).is_void).toBe(true)
+  })
+
+  test("parses ActionView tag.img with content argument and data attributes", () => {
+    const service = createService()
+    const document = createDocument('<%= tag.img "/image.png", data: { controller: "image" } %>')
+    const html = service.parseHTMLDocument(document)
+
+    expect(html.roots).toHaveLength(1)
+
+    const root = html.roots[0] as HerbHTMLNode
+    expect(root.tag).toBe("img")
+    expect(root.attributes?.["data-controller"]).toBe('"image"')
+  })
+
   test("parses ActionView nested data hash into data-* attributes", () => {
     const service = createService()
     const document = createDocument(`<%= tag.div data: { controller: "scroll", action: "click->scroll#go" } %>`)

--- a/javascript/packages/node/binding.gyp
+++ b/javascript/packages/node/binding.gyp
@@ -64,6 +64,7 @@
         "./extension/libherb/prism/ruby_parser.c",
         "./extension/libherb/util/html_util.c",
         "./extension/libherb/util/io.c",
+        "./extension/libherb/util/ruby_util.c",
         "./extension/libherb/util/utf8.c",
         "./extension/libherb/util/util.c",
         "./extension/libherb/visitor.c",

--- a/javascript/packages/rewriter/test/action-view-tag-helper-to-html.test.ts
+++ b/javascript/packages/rewriter/test/action-view-tag-helper-to-html.test.ts
@@ -143,7 +143,7 @@ describe("ActionViewTagHelperToHTMLRewriter", () => {
       `
 
       const expected = dedent`
-        <div data-controller="content" data-user-id="<%= 123 %>">
+        <div data-controller="content" data-user-id="123">
           Content
         </div>
       `
@@ -164,6 +164,18 @@ describe("ActionViewTagHelperToHTMLRewriter", () => {
     test("tag.img void element with attributes", () => {
       expect(transform('<%= tag.img src: "image.png", alt: "Photo" %>')).toBe(
         '<img src="image.png" alt="Photo" />'
+      )
+    })
+
+    test("tag.img with content argument reports parser error", () => {
+      expect(() => transform('<%= tag.img "/image.png" %>')).toThrow(
+        "Void element `img` cannot have content"
+      )
+    })
+
+    test("tag.img with content argument and data attributes reports parser error", () => {
+      expect(() => transform('<%= tag.img "/image.png", data: { controller: "image" } %>')).toThrow(
+        "Void element `img` cannot have content"
       )
     })
 
@@ -680,6 +692,64 @@ describe("ActionViewTagHelperToHTMLRewriter", () => {
     test("image_tag with data attributes", () => {
       expect(transform('<%= image_tag "icon.png", data: { controller: "image" } %>')).toBe(
         '<img src="<%= image_path("icon.png") %>" data-controller="image" />'
+      )
+    })
+  })
+
+  describe("class attribute handling", () => {
+    test("tag.div with conditional class hash wraps in token_list", () => {
+      expect(transform('<%= tag.div class: { active: true, hidden: false } %>')).toBe(
+        '<div class="<%= token_list({ active: true, hidden: false }) %>"></div>'
+      )
+    })
+
+    test("tag.div with dynamic conditional class hash wraps in token_list", () => {
+      expect(transform('<%= tag.div class: { active: @is_active } %>')).toBe(
+        '<div class="<%= token_list({ active: @is_active }) %>"></div>'
+      )
+    })
+
+    test("tag.div with mixed array class wraps in token_list", () => {
+      expect(transform('<%= tag.div class: ["a", variable] %>')).toBe(
+        '<div class="<%= token_list(["a", variable]) %>"></div>'
+      )
+    })
+
+    test("tag.div with static string array class joins with spaces", () => {
+      expect(transform('<%= tag.div class: ["kitties", "puppies"] %>')).toBe(
+        '<div class="kitties puppies"></div>'
+      )
+    })
+
+    test("tag.div with %w() class joins with spaces", () => {
+      expect(transform('<%= tag.div class: %w( kitties puppies ) %>')).toBe(
+        '<div class="kitties puppies"></div>'
+      )
+    })
+
+    test("content_tag with mixed array and conditional hash class wraps in token_list", () => {
+      expect(transform('<%= content_tag(:div, "Hello world!", class: ["strong", { highlight: current_user.admin? }]) %>')).toBe(
+        '<div class="<%= token_list(["strong", { highlight: current_user.admin? }]) %>">Hello world!</div>'
+      )
+    })
+  })
+
+  describe("data attribute handling", () => {
+    test("tag.div with integer data attribute inlines directly", () => {
+      expect(transform('<%= tag.div data: { count: 42 } %>')).toBe(
+        '<div data-count="42"></div>'
+      )
+    })
+
+    test("tag.div with array data attribute wraps in .to_json", () => {
+      expect(transform('<%= tag.div data: { items: ["a", "b"] } %>')).toBe(
+        '<div data-items="<%= ["a", "b"].to_json %>"></div>'
+      )
+    })
+
+    test("tag.div with nested hash data attribute wraps in .to_json", () => {
+      expect(transform('<%= tag.div data: { config: { nested: "hash" } } %>')).toBe(
+        '<div data-config="<%= { nested: "hash" }.to_json %>"></div>'
       )
     })
   })

--- a/src/analyze/action_view/attribute_extraction_helpers.c
+++ b/src/analyze/action_view/attribute_extraction_helpers.c
@@ -2,6 +2,7 @@
 #include "../../include/analyze/action_view/tag_helper_node_builders.h"
 #include "../../include/lib/hb_allocator.h"
 #include "../../include/lib/hb_array.h"
+#include "../../include/lib/hb_buffer.h"
 #include "../../include/lib/hb_string.h"
 #include "../../include/util/html_util.h"
 #include "../../include/util/util.h"
@@ -208,12 +209,56 @@ static char* build_prefixed_key(const char* prefix, const char* raw_key, hb_allo
   return result;
 }
 
+static bool is_static_string_array(pm_array_node_t* array) {
+  if (!array || array->elements.size == 0) { return false; }
+
+  for (size_t i = 0; i < array->elements.size; i++) {
+    pm_node_t* element = array->elements.nodes[i];
+
+    if (element->type != PM_STRING_NODE && element->type != PM_SYMBOL_NODE) { return false; }
+  }
+
+  return true;
+}
+
+static char* join_static_string_array(pm_array_node_t* array, hb_allocator_T* allocator) {
+  hb_buffer_T buffer;
+  hb_buffer_init(&buffer, 64, allocator);
+
+  for (size_t i = 0; i < array->elements.size; i++) {
+    if (i > 0) { hb_buffer_append(&buffer, " "); }
+
+    char* value = extract_string_from_prism_node(array->elements.nodes[i], allocator);
+
+    if (value) {
+      hb_buffer_append(&buffer, value);
+      hb_allocator_dealloc(allocator, value);
+    }
+  }
+
+  char* result = hb_allocator_strdup(allocator, hb_buffer_value(&buffer));
+
+  return result;
+}
+
 static AST_HTML_ATTRIBUTE_NODE_T* create_attribute_from_value(
   const char* name_string,
   pm_node_t* value_node,
   attribute_positions_T* positions,
-  hb_allocator_T* allocator
+  hb_allocator_T* allocator,
+  bool is_nested
 ) {
+  if (value_node->type == PM_ARRAY_NODE && !is_nested && is_static_string_array((pm_array_node_t*) value_node)) {
+    char* joined = join_static_string_array((pm_array_node_t*) value_node, allocator);
+    if (!joined) { return NULL; }
+
+    AST_HTML_ATTRIBUTE_NODE_T* attribute =
+      create_html_attribute_node_precise(name_string, joined, positions, allocator);
+    hb_allocator_dealloc(allocator, joined);
+
+    return attribute;
+  }
+
   if (value_node->type == PM_SYMBOL_NODE || value_node->type == PM_STRING_NODE) {
     char* value_string = extract_string_from_prism_node(value_node, allocator);
     if (!value_string) { return NULL; }
@@ -227,10 +272,22 @@ static AST_HTML_ATTRIBUTE_NODE_T* create_attribute_from_value(
     if (is_boolean_attribute(hb_string((char*) name_string))) {
       return create_html_attribute_node_precise(name_string, NULL, positions, allocator);
     }
+
     return create_html_attribute_node_precise(name_string, "true", positions, allocator);
   } else if (value_node->type == PM_FALSE_NODE) {
     if (is_boolean_attribute(hb_string((char*) name_string))) { return NULL; }
+
     return create_html_attribute_node_precise(name_string, "false", positions, allocator);
+  } else if (value_node->type == PM_INTEGER_NODE) {
+    size_t value_length = value_node->location.end - value_node->location.start;
+    char* value_string = hb_allocator_strndup(allocator, (const char*) value_node->location.start, value_length);
+    if (!value_string) { return NULL; }
+
+    AST_HTML_ATTRIBUTE_NODE_T* attribute =
+      create_html_attribute_node_precise(name_string, value_string, positions, allocator);
+    hb_allocator_dealloc(allocator, value_string);
+
+    return attribute;
   } else if (value_node->type == PM_INTERPOLATED_STRING_NODE) {
     return create_html_attribute_with_interpolated_value(
       name_string,
@@ -241,12 +298,36 @@ static AST_HTML_ATTRIBUTE_NODE_T* create_attribute_from_value(
     );
   } else {
     size_t value_length = value_node->location.end - value_node->location.start;
-    char* ruby_content = hb_allocator_strndup(allocator, (const char*) value_node->location.start, value_length);
+    char* raw_content = hb_allocator_strndup(allocator, (const char*) value_node->location.start, value_length);
 
-    if (ruby_content && value_node->location.start) {
+    if (raw_content && value_node->location.start) {
+      char* ruby_content = raw_content;
+
+      if (!is_nested && strcmp(name_string, "class") == 0
+          && (value_node->type == PM_HASH_NODE || value_node->type == PM_ARRAY_NODE)) {
+        hb_buffer_T class_buffer;
+        hb_buffer_init(&class_buffer, value_length + 16, allocator);
+        hb_buffer_append(&class_buffer, "token_list(");
+        hb_buffer_append(&class_buffer, raw_content);
+        hb_buffer_append(&class_buffer, ")");
+
+        ruby_content = hb_buffer_value(&class_buffer);
+      }
+
+      // Rails calls .to_json on non-string/symbol values inside data:/aria: hashes
+      if (is_nested) {
+        hb_buffer_T json_buffer;
+        hb_buffer_init(&json_buffer, value_length + 16, allocator);
+        hb_buffer_append(&json_buffer, raw_content);
+        hb_buffer_append(&json_buffer, ".to_json");
+
+        ruby_content = hb_buffer_value(&json_buffer);
+      }
+
       AST_HTML_ATTRIBUTE_NODE_T* attribute =
         create_html_attribute_with_ruby_literal_precise(name_string, ruby_content, positions, allocator);
-      hb_allocator_dealloc(allocator, ruby_content);
+      hb_allocator_dealloc(allocator, raw_content);
+
       return attribute;
     }
 
@@ -318,6 +399,11 @@ AST_HTML_ATTRIBUTE_NODE_T* extract_html_attribute_from_assoc(
   char* name_string = extract_string_from_prism_node(assoc->key, allocator);
   if (!name_string) { return NULL; }
 
+  if (strcmp(name_string, "escape") == 0) {
+    hb_allocator_dealloc(allocator, name_string);
+    return NULL;
+  }
+
   if (!assoc->value) {
     hb_allocator_dealloc(allocator, name_string);
     return NULL;
@@ -365,7 +451,7 @@ AST_HTML_ATTRIBUTE_NODE_T* extract_html_attribute_from_assoc(
 
   char* dashed_name = convert_underscores_to_dashes(name_string);
   AST_HTML_ATTRIBUTE_NODE_T* attribute_node =
-    create_attribute_from_value(dashed_name ? dashed_name : name_string, assoc->value, &positions, allocator);
+    create_attribute_from_value(dashed_name ? dashed_name : name_string, assoc->value, &positions, allocator, false);
 
   if (dashed_name) { free(dashed_name); }
   hb_allocator_dealloc(allocator, name_string);
@@ -467,7 +553,7 @@ hb_array_T* extract_html_attributes_from_keyword_hash(
             fill_attribute_positions(hash_assoc, source, original_source, erb_content_offset, &hash_positions);
 
             AST_HTML_ATTRIBUTE_NODE_T* attribute =
-              create_attribute_from_value(attribute_key_string, hash_assoc->value, &hash_positions, allocator);
+              create_attribute_from_value(attribute_key_string, hash_assoc->value, &hash_positions, allocator, true);
 
             if (attribute) { hb_array_append(attributes, attribute); }
             hb_allocator_dealloc(allocator, attribute_key_string);

--- a/src/analyze/action_view/tag.c
+++ b/src/analyze/action_view/tag.c
@@ -1,4 +1,5 @@
 #include "../../include/analyze/action_view/tag_helper_handler.h"
+#include "../../include/util/ruby_util.h"
 
 #include <prism.h>
 #include <stdbool.h>
@@ -22,6 +23,10 @@ char* extract_tag_dot_name(pm_call_node_t* call_node, pm_parser_t* parser, hb_al
 
   pm_constant_t* constant = pm_constant_pool_id_to_constant(&parser->constant_pool, call_node->name);
   if (!constant) { return NULL; }
+
+  if (is_ruby_introspection_method(hb_string_from_data((const char*) constant->start, constant->length))) {
+    return NULL;
+  }
 
   char* name = hb_allocator_strndup(allocator, (const char*) constant->start, constant->length);
 

--- a/src/analyze/action_view/tag_helpers.c
+++ b/src/analyze/action_view/tag_helpers.c
@@ -132,7 +132,7 @@ bool search_tag_helper_node(const pm_node_t* node, void* data) {
           search_data->info->has_block = handlers[i].supports_block();
         }
 
-        return true;
+        return false;
       }
     }
 

--- a/src/include/util/ruby_util.h
+++ b/src/include/util/ruby_util.h
@@ -1,0 +1,9 @@
+#ifndef HERB_RUBY_UTIL_H
+#define HERB_RUBY_UTIL_H
+
+#include "../lib/hb_string.h"
+#include <stdbool.h>
+
+bool is_ruby_introspection_method(hb_string_T method_name);
+
+#endif

--- a/src/util/ruby_util.c
+++ b/src/util/ruby_util.c
@@ -1,0 +1,42 @@
+#include "../include/util/ruby_util.h"
+#include "../include/lib/hb_string.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+
+static hb_string_T ruby_introspection_methods[] = HB_STRING_LIST(
+  "send",
+  "public_send",
+  "__send__",
+  "try",
+  "try!",
+  "method",
+  "class",
+  "inspect",
+  "to_s",
+  "object_id",
+  "__id__",
+  "dup",
+  "clone",
+  "freeze",
+  "frozen",
+  "tap",
+  "then",
+  "yield_self"
+);
+
+bool is_ruby_introspection_method(hb_string_T method_name) {
+  size_t count = sizeof(ruby_introspection_methods) / sizeof(ruby_introspection_methods[0]);
+
+  for (size_t index = 0; index < count; index++) {
+    if (hb_string_equals(method_name, ruby_introspection_methods[index])) { return true; }
+  }
+
+  if (method_name.length > 0) {
+    char last_char = method_name.data[method_name.length - 1];
+
+    if (last_char == '?' || last_char == '!') { return true; }
+  }
+
+  return false;
+}

--- a/test/analyze/action_view/tag_helper/content_tag_test.rb
+++ b/test/analyze/action_view/tag_helper/content_tag_test.rb
@@ -269,5 +269,20 @@ module Analyze::ActionView::TagHelper
         <%= content_tag :br, "hello" %>
       HTML
     end
+
+    test "content_tag with mixed array and conditional hash class" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <%= content_tag(:div, "Hello world!", class: ["strong", { highlight: current_user.admin? }]) %>
+      HTML
+    end
+
+    # TODO: The outer content_tag(:div) is correctly detected, but the inner content_tag(:p, "Hello world!")
+    # remains as a RubyLiteralNode in the body instead of being resolved to <p>Hello world!</p>.
+    # Rails renders: <div class="strong"><p>Hello world!</p></div>
+    test "content_tag with nested content_tag as content argument" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <%= content_tag(:div, content_tag(:p, "Hello world!"), class: "strong") %>
+      HTML
+    end
   end
 end

--- a/test/analyze/action_view/tag_helper/tag_test.rb
+++ b/test/analyze/action_view/tag_helper/tag_test.rb
@@ -384,5 +384,133 @@ module Analyze::ActionView::TagHelper
         </button>
       HTML
     end
+
+    test "tag.send is treated as dynamic and not converted" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <%= tag.send(:some_tag_name) %>
+      HTML
+    end
+
+    test "tag.public_send is treated as dynamic and not converted" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <%= tag.public_send(:div) %>
+      HTML
+    end
+
+    test "tag.try is treated as dynamic and not converted" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <%= tag.try(:div) %>
+      HTML
+    end
+
+    test "tag.class is treated as dynamic and not converted" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <%= tag.class %>
+      HTML
+    end
+
+    test "tag.method is treated as dynamic and not converted" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <%= tag.method(:div) %>
+      HTML
+    end
+
+    test "tag.frozen? is treated as dynamic and not converted" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <%= tag.frozen? %>
+      HTML
+    end
+
+    # TODO: Rails renders `disabled="disabled"` — we render as a boolean attribute without a value.
+    # Both are valid HTML, but we could match Rails by rendering `disabled="disabled"` for `true` values.
+    test "tag.input void element with boolean attribute" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <%= tag.input type: "text", disabled: true %>
+      HTML
+    end
+
+    test "tag.section with %w() class attribute" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <%= tag.section class: %w( kitties puppies ) %>
+      HTML
+    end
+
+    test "tag.section with array class attribute" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <%= tag.section class: ["kitties", "puppies"] %>
+      HTML
+    end
+
+    test "tag.section with mixed array class attribute keeps as ruby literal" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <%= tag.section class: ["kitties", variable] %>
+      HTML
+    end
+
+    test "tag.section with symbol array class attribute" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <%= tag.section class: [:kitties, :puppies] %>
+      HTML
+    end
+
+    test "tag.div with conditional class hash" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <%= tag.div class: { active: true, hidden: false } %>
+      HTML
+    end
+
+    test "tag.div with dynamic conditional class hash" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <%= tag.div class: { active: @is_active } %>
+      HTML
+    end
+
+    test "tag.div with symbol id attribute" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <%= tag.div id: :main %>
+      HTML
+    end
+
+    test "tag.div with aria hash attributes" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <%= tag.div aria: { label: "hello", hidden: true } %>
+      HTML
+    end
+
+    test "tag.div with data hash containing %w() array value" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <%= tag.div data: { city_state: %w( Chicago IL ) } %>
+      HTML
+    end
+
+    test "tag.div with data hash containing array value" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <%= tag.div data: { city_state: ["Chicago", "IL"] } %>
+      HTML
+    end
+
+    test "tag.img with escape false option" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <%= tag.img src: "open & shut.png", escape: false %>
+      HTML
+    end
+
+    test "tag.div with data hash containing symbol value" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <%= tag.div data: { status: :active } %>
+      HTML
+    end
+
+    test "tag.div with data hash containing integer value" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <%= tag.div data: { count: 42 } %>
+      HTML
+    end
+
+    test "tag.div with data hash containing nested hash value" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <%= tag.div data: { config: { nested: "hash" } } %>
+      HTML
+    end
   end
 end

--- a/test/snapshots/analyze/action_view/tag_helper/content_tag_test/test_0005_content_tag_with_data_attributes_in_hash_style_e64ecc1b22908d47ba5ba90d53c7985a-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/content_tag_test/test_0005_content_tag_with_data_attributes_in_hash_style_e64ecc1b22908d47ba5ba90d53c7985a-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -49,7 +49,7 @@ options: {action_view_helpers: true}
     │   │                   └── @ HTMLAttributeValueNode (location: (1:62)-(1:65))
     │   │                       ├── open_quote: ∅
     │   │                       ├── children: (1 item)
-    │   │                       │   └── @ RubyLiteralNode (location: (1:62)-(1:65))
+    │   │                       │   └── @ LiteralNode (location: (1:62)-(1:65))
     │   │                       │       └── content: "123"
     │   │                       │
     │   │                       ├── close_quote: ∅

--- a/test/snapshots/analyze/action_view/tag_helper/content_tag_test/test_0008_content_tag_with_attributes_in_string_key_hash_style_ac53f625818a5fff221bd5f7842552ed-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/content_tag_test/test_0008_content_tag_with_attributes_in_string_key_hash_style_ac53f625818a5fff221bd5f7842552ed-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -49,7 +49,7 @@ options: {action_view_helpers: true}
     │   │                   └── @ HTMLAttributeValueNode (location: (1:70)-(1:73))
     │   │                       ├── open_quote: ∅
     │   │                       ├── children: (1 item)
-    │   │                       │   └── @ RubyLiteralNode (location: (1:70)-(1:73))
+    │   │                       │   └── @ LiteralNode (location: (1:70)-(1:73))
     │   │                       │       └── content: "123"
     │   │                       │
     │   │                       ├── close_quote: ∅

--- a/test/snapshots/analyze/action_view/tag_helper/content_tag_test/test_0009_content_tag_with_data_attributes_in_underscore_style_0c84de2e6bae6222091c4293148ae8d4-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/content_tag_test/test_0009_content_tag_with_data_attributes_in_underscore_style_0c84de2e6bae6222091c4293148ae8d4-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -49,7 +49,7 @@ options: {action_view_helpers: true}
     │   │                   └── @ HTMLAttributeValueNode (location: (1:69)-(1:72))
     │   │                       ├── open_quote: ∅
     │   │                       ├── children: (1 item)
-    │   │                       │   └── @ RubyLiteralNode (location: (1:69)-(1:72))
+    │   │                       │   └── @ LiteralNode (location: (1:69)-(1:72))
     │   │                       │       └── content: "123"
     │   │                       │
     │   │                       ├── close_quote: ∅

--- a/test/snapshots/analyze/action_view/tag_helper/content_tag_test/test_0010_content_tag_with_data_attributes_in_string_key_hash_style_5074a3c40b88e491531f6f84e961e04b-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/content_tag_test/test_0010_content_tag_with_data_attributes_in_string_key_hash_style_5074a3c40b88e491531f6f84e961e04b-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -49,7 +49,7 @@ options: {action_view_helpers: true}
     │   │                   └── @ HTMLAttributeValueNode (location: (1:86)-(1:89))
     │   │                       ├── open_quote: ∅
     │   │                       ├── children: (1 item)
-    │   │                       │   └── @ RubyLiteralNode (location: (1:86)-(1:89))
+    │   │                       │   └── @ LiteralNode (location: (1:86)-(1:89))
     │   │                       │       └── content: "123"
     │   │                       │
     │   │                       ├── close_quote: ∅

--- a/test/snapshots/analyze/action_view/tag_helper/content_tag_test/test_0039_content_tag_with_mixed_array_and_conditional_hash_class_8511e010d090e8c2e123f2176274be34-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/content_tag_test/test_0039_content_tag_with_mixed_array_and_conditional_hash_class_8511e010d090e8c2e123f2176274be34-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,51 @@
+---
+source: "Analyze::ActionView::TagHelper::ContentTagTest#test_0039_content_tag with mixed array and conditional hash class"
+input: |2-
+<%= content_tag(:div, "Hello world!", class: ["strong", { highlight: current_user.admin? }]) %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:95))
+    │   ├── open_tag:
+    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:95))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " content_tag(:div, "Hello world!", class: ["strong", { highlight: current_user.admin? }]) " (location: (1:3)-(1:93))
+    │   │       ├── tag_closing: "%>" (location: (1:93)-(1:95))
+    │   │       ├── tag_name: "div" (location: (1:4)-(1:15))
+    │   │       └── children: (1 item)
+    │   │           └── @ HTMLAttributeNode (location: (1:38)-(1:91))
+    │   │               ├── name:
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:38)-(1:43))
+    │   │               │       └── children: (1 item)
+    │   │               │           └── @ LiteralNode (location: (1:38)-(1:43))
+    │   │               │               └── content: "class"
+    │   │               │
+    │   │               │
+    │   │               ├── equals: ": " (location: (1:43)-(1:45))
+    │   │               └── value:
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:45)-(1:91))
+    │   │                       ├── open_quote: ∅
+    │   │                       ├── children: (1 item)
+    │   │                       │   └── @ RubyLiteralNode (location: (1:45)-(1:91))
+    │   │                       │       └── content: "token_list([\"strong\", { highlight: current_user.admin? }])"
+    │   │                       │
+    │   │                       ├── close_quote: ∅
+    │   │                       └── quoted: false
+    │   │
+    │   │
+    │   │
+    │   ├── tag_name: "div" (location: (1:4)-(1:15))
+    │   ├── body: (1 item)
+    │   │   └── @ HTMLTextNode (location: (1:0)-(1:95))
+    │   │       └── content: "Hello world!"
+    │   │
+    │   ├── close_tag:
+    │   │   └── @ HTMLVirtualCloseTagNode (location: (1:95)-(1:95))
+    │   │       └── tag_name: "div" (location: (1:4)-(1:15))
+    │   │
+    │   ├── is_void: false
+    │   └── element_source: "ActionView::Helpers::TagHelper#content_tag"
+    │
+    └── @ HTMLTextNode (location: (1:95)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/action_view/tag_helper/content_tag_test/test_0040_content_tag_with_nested_content_tag_as_content_argument_f3310850d8dadb77fff4e86a6b7f1ed1-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/content_tag_test/test_0040_content_tag_with_nested_content_tag_as_content_argument_f3310850d8dadb77fff4e86a6b7f1ed1-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,51 @@
+---
+source: "Analyze::ActionView::TagHelper::ContentTagTest#test_0040_content_tag with nested content_tag as content argument"
+input: |2-
+<%= content_tag(:div, content_tag(:p, "Hello world!"), class: "strong") %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:74))
+    │   ├── open_tag:
+    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:74))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " content_tag(:div, content_tag(:p, "Hello world!"), class: "strong") " (location: (1:3)-(1:72))
+    │   │       ├── tag_closing: "%>" (location: (1:72)-(1:74))
+    │   │       ├── tag_name: "div" (location: (1:4)-(1:15))
+    │   │       └── children: (1 item)
+    │   │           └── @ HTMLAttributeNode (location: (1:55)-(1:70))
+    │   │               ├── name:
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:55)-(1:60))
+    │   │               │       └── children: (1 item)
+    │   │               │           └── @ LiteralNode (location: (1:55)-(1:60))
+    │   │               │               └── content: "class"
+    │   │               │
+    │   │               │
+    │   │               ├── equals: ": " (location: (1:60)-(1:62))
+    │   │               └── value:
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:62)-(1:70))
+    │   │                       ├── open_quote: """ (location: (1:62)-(1:63))
+    │   │                       ├── children: (1 item)
+    │   │                       │   └── @ LiteralNode (location: (1:63)-(1:69))
+    │   │                       │       └── content: "strong"
+    │   │                       │
+    │   │                       ├── close_quote: """ (location: (1:69)-(1:70))
+    │   │                       └── quoted: true
+    │   │
+    │   │
+    │   │
+    │   ├── tag_name: "div" (location: (1:4)-(1:15))
+    │   ├── body: (1 item)
+    │   │   └── @ RubyLiteralNode (location: (1:0)-(1:74))
+    │   │       └── content: "content_tag(:p, \"Hello world!\")"
+    │   │
+    │   ├── close_tag:
+    │   │   └── @ HTMLVirtualCloseTagNode (location: (1:74)-(1:74))
+    │   │       └── tag_name: "div" (location: (1:4)-(1:15))
+    │   │
+    │   ├── is_void: false
+    │   └── element_source: "ActionView::Helpers::TagHelper#content_tag"
+    │
+    └── @ HTMLTextNode (location: (1:74)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0005_tag.div_with_data_attributes_in_hash_style_d8e0a2cc74842de804b4d589d61f39bb-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0005_tag.div_with_data_attributes_in_hash_style_d8e0a2cc74842de804b4d589d61f39bb-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -49,7 +49,7 @@ options: {action_view_helpers: true}
     │   │                   └── @ HTMLAttributeValueNode (location: (1:52)-(1:55))
     │   │                       ├── open_quote: ∅
     │   │                       ├── children: (1 item)
-    │   │                       │   └── @ RubyLiteralNode (location: (1:52)-(1:55))
+    │   │                       │   └── @ LiteralNode (location: (1:52)-(1:55))
     │   │                       │       └── content: "123"
     │   │                       │
     │   │                       ├── close_quote: ∅

--- a/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0006_tag.div_with_attributes_in_string_key_hash_style_14bbe0bec4fc979307b6d8e5c3478c00-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0006_tag.div_with_attributes_in_string_key_hash_style_14bbe0bec4fc979307b6d8e5c3478c00-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -49,7 +49,7 @@ options: {action_view_helpers: true}
     │   │                   └── @ HTMLAttributeValueNode (location: (1:60)-(1:63))
     │   │                       ├── open_quote: ∅
     │   │                       ├── children: (1 item)
-    │   │                       │   └── @ RubyLiteralNode (location: (1:60)-(1:63))
+    │   │                       │   └── @ LiteralNode (location: (1:60)-(1:63))
     │   │                       │       └── content: "123"
     │   │                       │
     │   │                       ├── close_quote: ∅

--- a/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0007_tag.div_with_data_attributes_in_underscore_style_451e931eee076faac2c6bcea0846a680-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0007_tag.div_with_data_attributes_in_underscore_style_451e931eee076faac2c6bcea0846a680-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -49,7 +49,7 @@ options: {action_view_helpers: true}
     │   │                   └── @ HTMLAttributeValueNode (location: (1:59)-(1:62))
     │   │                       ├── open_quote: ∅
     │   │                       ├── children: (1 item)
-    │   │                       │   └── @ RubyLiteralNode (location: (1:59)-(1:62))
+    │   │                       │   └── @ LiteralNode (location: (1:59)-(1:62))
     │   │                       │       └── content: "123"
     │   │                       │
     │   │                       ├── close_quote: ∅

--- a/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0008_tag.div_with_data_attributes_in_string_key_hash_style_8da6a10f3db724c66ae6696545da94d2-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0008_tag.div_with_data_attributes_in_string_key_hash_style_8da6a10f3db724c66ae6696545da94d2-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -49,7 +49,7 @@ options: {action_view_helpers: true}
     │   │                   └── @ HTMLAttributeValueNode (location: (1:65)-(1:68))
     │   │                       ├── open_quote: ∅
     │   │                       ├── children: (1 item)
-    │   │                       │   └── @ RubyLiteralNode (location: (1:65)-(1:68))
+    │   │                       │   └── @ LiteralNode (location: (1:65)-(1:68))
     │   │                       │       └── content: "123"
     │   │                       │
     │   │                       ├── close_quote: ∅

--- a/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0014_tag.div_with_attributes_in_string_key_hash_style_without_block_0d3b4780e4777ebfb2350eaf8cc639dc-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0014_tag.div_with_attributes_in_string_key_hash_style_without_block_0d3b4780e4777ebfb2350eaf8cc639dc-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -47,7 +47,7 @@ options: {action_view_helpers: true}
     │   │                   └── @ HTMLAttributeValueNode (location: (1:60)-(1:63))
     │   │                       ├── open_quote: ∅
     │   │                       ├── children: (1 item)
-    │   │                       │   └── @ RubyLiteralNode (location: (1:60)-(1:63))
+    │   │                       │   └── @ LiteralNode (location: (1:60)-(1:63))
     │   │                       │       └── content: "123"
     │   │                       │
     │   │                       ├── close_quote: ∅

--- a/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0051_tag.send_is_treated_as_dynamic_and_not_converted_96b044ef230bd28b67b17284f253ef6e-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0051_tag.send_is_treated_as_dynamic_and_not_converted_96b044ef230bd28b67b17284f253ef6e-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,28 @@
+---
+source: "Analyze::ActionView::TagHelper::TagTest#test_0051_tag.send is treated as dynamic and not converted"
+input: |2-
+<%= tag.send(:some_tag_name) %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:31))
+    │   ├── open_tag:
+    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:31))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " tag.send(:some_tag_name) " (location: (1:3)-(1:29))
+    │   │       ├── tag_closing: "%>" (location: (1:29)-(1:31))
+    │   │       ├── tag_name: ∅
+    │   │       └── children: []
+    │   │
+    │   ├── tag_name: ∅
+    │   ├── body: []
+    │   ├── close_tag:
+    │   │   └── @ HTMLVirtualCloseTagNode (location: (1:31)-(1:31))
+    │   │       └── tag_name: ∅
+    │   │
+    │   ├── is_void: false
+    │   └── element_source: "ActionView::Helpers::TagHelper#tag"
+    │
+    └── @ HTMLTextNode (location: (1:31)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0052_tag.public_send_is_treated_as_dynamic_and_not_converted_99d81f9335ffa79bb611dc3d98f08444-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0052_tag.public_send_is_treated_as_dynamic_and_not_converted_99d81f9335ffa79bb611dc3d98f08444-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,28 @@
+---
+source: "Analyze::ActionView::TagHelper::TagTest#test_0052_tag.public_send is treated as dynamic and not converted"
+input: |2-
+<%= tag.public_send(:div) %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:28))
+    │   ├── open_tag:
+    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:28))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " tag.public_send(:div) " (location: (1:3)-(1:26))
+    │   │       ├── tag_closing: "%>" (location: (1:26)-(1:28))
+    │   │       ├── tag_name: ∅
+    │   │       └── children: []
+    │   │
+    │   ├── tag_name: ∅
+    │   ├── body: []
+    │   ├── close_tag:
+    │   │   └── @ HTMLVirtualCloseTagNode (location: (1:28)-(1:28))
+    │   │       └── tag_name: ∅
+    │   │
+    │   ├── is_void: false
+    │   └── element_source: "ActionView::Helpers::TagHelper#tag"
+    │
+    └── @ HTMLTextNode (location: (1:28)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0053_tag.try_is_treated_as_dynamic_and_not_converted_5b306644e6f74600784c8798adfca43e-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0053_tag.try_is_treated_as_dynamic_and_not_converted_5b306644e6f74600784c8798adfca43e-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,28 @@
+---
+source: "Analyze::ActionView::TagHelper::TagTest#test_0053_tag.try is treated as dynamic and not converted"
+input: |2-
+<%= tag.try(:div) %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:20))
+    │   ├── open_tag:
+    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:20))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " tag.try(:div) " (location: (1:3)-(1:18))
+    │   │       ├── tag_closing: "%>" (location: (1:18)-(1:20))
+    │   │       ├── tag_name: ∅
+    │   │       └── children: []
+    │   │
+    │   ├── tag_name: ∅
+    │   ├── body: []
+    │   ├── close_tag:
+    │   │   └── @ HTMLVirtualCloseTagNode (location: (1:20)-(1:20))
+    │   │       └── tag_name: ∅
+    │   │
+    │   ├── is_void: false
+    │   └── element_source: "ActionView::Helpers::TagHelper#tag"
+    │
+    └── @ HTMLTextNode (location: (1:20)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0054_tag.class_is_treated_as_dynamic_and_not_converted_2946ca9fd45ed02f3812eb296393e2af-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0054_tag.class_is_treated_as_dynamic_and_not_converted_2946ca9fd45ed02f3812eb296393e2af-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,28 @@
+---
+source: "Analyze::ActionView::TagHelper::TagTest#test_0054_tag.class is treated as dynamic and not converted"
+input: |2-
+<%= tag.class %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:16))
+    │   ├── open_tag:
+    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:16))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " tag.class " (location: (1:3)-(1:14))
+    │   │       ├── tag_closing: "%>" (location: (1:14)-(1:16))
+    │   │       ├── tag_name: ∅
+    │   │       └── children: []
+    │   │
+    │   ├── tag_name: ∅
+    │   ├── body: []
+    │   ├── close_tag:
+    │   │   └── @ HTMLVirtualCloseTagNode (location: (1:16)-(1:16))
+    │   │       └── tag_name: ∅
+    │   │
+    │   ├── is_void: false
+    │   └── element_source: "ActionView::Helpers::TagHelper#tag"
+    │
+    └── @ HTMLTextNode (location: (1:16)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0055_tag.method_is_treated_as_dynamic_and_not_converted_dcd17f61859406046ca77dfd6dbc3180-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0055_tag.method_is_treated_as_dynamic_and_not_converted_dcd17f61859406046ca77dfd6dbc3180-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,28 @@
+---
+source: "Analyze::ActionView::TagHelper::TagTest#test_0055_tag.method is treated as dynamic and not converted"
+input: |2-
+<%= tag.method(:div) %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:23))
+    │   ├── open_tag:
+    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:23))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " tag.method(:div) " (location: (1:3)-(1:21))
+    │   │       ├── tag_closing: "%>" (location: (1:21)-(1:23))
+    │   │       ├── tag_name: ∅
+    │   │       └── children: []
+    │   │
+    │   ├── tag_name: ∅
+    │   ├── body: []
+    │   ├── close_tag:
+    │   │   └── @ HTMLVirtualCloseTagNode (location: (1:23)-(1:23))
+    │   │       └── tag_name: ∅
+    │   │
+    │   ├── is_void: false
+    │   └── element_source: "ActionView::Helpers::TagHelper#tag"
+    │
+    └── @ HTMLTextNode (location: (1:23)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0056_tag.frozen_is_treated_as_dynamic_and_not_converted_19506bd2239143e455cfd0dab224ddc6-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0056_tag.frozen_is_treated_as_dynamic_and_not_converted_19506bd2239143e455cfd0dab224ddc6-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,28 @@
+---
+source: "Analyze::ActionView::TagHelper::TagTest#test_0056_tag.frozen? is treated as dynamic and not converted"
+input: |2-
+<%= tag.frozen? %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:18))
+    │   ├── open_tag:
+    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:18))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " tag.frozen? " (location: (1:3)-(1:16))
+    │   │       ├── tag_closing: "%>" (location: (1:16)-(1:18))
+    │   │       ├── tag_name: ∅
+    │   │       └── children: []
+    │   │
+    │   ├── tag_name: ∅
+    │   ├── body: []
+    │   ├── close_tag:
+    │   │   └── @ HTMLVirtualCloseTagNode (location: (1:18)-(1:18))
+    │   │       └── tag_name: ∅
+    │   │
+    │   ├── is_void: false
+    │   └── element_source: "ActionView::Helpers::TagHelper#tag"
+    │
+    └── @ HTMLTextNode (location: (1:18)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0057_tag.input_void_element_with_boolean_attribute_25b971f7354b53939fa88ea0486135a4-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0057_tag.input_void_element_with_boolean_attribute_25b971f7354b53939fa88ea0486135a4-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,56 @@
+---
+source: "Analyze::ActionView::TagHelper::TagTest#test_0057_tag.input void element with boolean attribute"
+input: |2-
+<%= tag.input type: "text", disabled: true %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:45))
+    │   ├── open_tag:
+    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:45))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " tag.input type: "text", disabled: true " (location: (1:3)-(1:43))
+    │   │       ├── tag_closing: "%>" (location: (1:43)-(1:45))
+    │   │       ├── tag_name: "input" (location: (1:8)-(1:13))
+    │   │       └── children: (2 items)
+    │   │           ├── @ HTMLAttributeNode (location: (1:14)-(1:26))
+    │   │           │   ├── name:
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:14)-(1:18))
+    │   │           │   │       └── children: (1 item)
+    │   │           │   │           └── @ LiteralNode (location: (1:14)-(1:18))
+    │   │           │   │               └── content: "type"
+    │   │           │   │
+    │   │           │   │
+    │   │           │   ├── equals: ": " (location: (1:18)-(1:20))
+    │   │           │   └── value:
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:20)-(1:26))
+    │   │           │           ├── open_quote: """ (location: (1:20)-(1:21))
+    │   │           │           ├── children: (1 item)
+    │   │           │           │   └── @ LiteralNode (location: (1:21)-(1:25))
+    │   │           │           │       └── content: "text"
+    │   │           │           │
+    │   │           │           ├── close_quote: """ (location: (1:25)-(1:26))
+    │   │           │           └── quoted: true
+    │   │           │
+    │   │           │
+    │   │           └── @ HTMLAttributeNode (location: (1:28)-(1:36))
+    │   │               ├── name:
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:28)-(1:36))
+    │   │               │       └── children: (1 item)
+    │   │               │           └── @ LiteralNode (location: (1:28)-(1:36))
+    │   │               │               └── content: "disabled"
+    │   │               │
+    │   │               │
+    │   │               ├── equals: ∅
+    │   │               └── value: ∅
+    │   │
+    │   │
+    │   ├── tag_name: "input" (location: (1:8)-(1:13))
+    │   ├── body: []
+    │   ├── close_tag: ∅
+    │   ├── is_void: true
+    │   └── element_source: "ActionView::Helpers::TagHelper#tag"
+    │
+    └── @ HTMLTextNode (location: (1:45)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0058_tag.section_with_%w()_class_attribute_63caff49fdf4aa472942f37a2d642dbf-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0058_tag.section_with_%w()_class_attribute_63caff49fdf4aa472942f37a2d642dbf-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,48 @@
+---
+source: "Analyze::ActionView::TagHelper::TagTest#test_0058_tag.section with %w() class attribute"
+input: |2-
+<%= tag.section class: %w( kitties puppies ) %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:47))
+    │   ├── open_tag:
+    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:47))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " tag.section class: %w( kitties puppies ) " (location: (1:3)-(1:45))
+    │   │       ├── tag_closing: "%>" (location: (1:45)-(1:47))
+    │   │       ├── tag_name: "section" (location: (1:8)-(1:15))
+    │   │       └── children: (1 item)
+    │   │           └── @ HTMLAttributeNode (location: (1:16)-(1:44))
+    │   │               ├── name:
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:16)-(1:21))
+    │   │               │       └── children: (1 item)
+    │   │               │           └── @ LiteralNode (location: (1:16)-(1:21))
+    │   │               │               └── content: "class"
+    │   │               │
+    │   │               │
+    │   │               ├── equals: ": " (location: (1:21)-(1:23))
+    │   │               └── value:
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:23)-(1:44))
+    │   │                       ├── open_quote: ∅
+    │   │                       ├── children: (1 item)
+    │   │                       │   └── @ LiteralNode (location: (1:23)-(1:44))
+    │   │                       │       └── content: "kitties puppies"
+    │   │                       │
+    │   │                       ├── close_quote: ∅
+    │   │                       └── quoted: false
+    │   │
+    │   │
+    │   │
+    │   ├── tag_name: "section" (location: (1:8)-(1:15))
+    │   ├── body: []
+    │   ├── close_tag:
+    │   │   └── @ HTMLVirtualCloseTagNode (location: (1:47)-(1:47))
+    │   │       └── tag_name: "section" (location: (1:8)-(1:15))
+    │   │
+    │   ├── is_void: false
+    │   └── element_source: "ActionView::Helpers::TagHelper#tag"
+    │
+    └── @ HTMLTextNode (location: (1:47)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0059_tag.section_with_array_class_attribute_ab8b0a89a3f365e6b1bbee619a8c2351-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0059_tag.section_with_array_class_attribute_ab8b0a89a3f365e6b1bbee619a8c2351-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,48 @@
+---
+source: "Analyze::ActionView::TagHelper::TagTest#test_0059_tag.section with array class attribute"
+input: |2-
+<%= tag.section class: ["kitties", "puppies"] %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:48))
+    │   ├── open_tag:
+    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:48))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " tag.section class: ["kitties", "puppies"] " (location: (1:3)-(1:46))
+    │   │       ├── tag_closing: "%>" (location: (1:46)-(1:48))
+    │   │       ├── tag_name: "section" (location: (1:8)-(1:15))
+    │   │       └── children: (1 item)
+    │   │           └── @ HTMLAttributeNode (location: (1:16)-(1:45))
+    │   │               ├── name:
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:16)-(1:21))
+    │   │               │       └── children: (1 item)
+    │   │               │           └── @ LiteralNode (location: (1:16)-(1:21))
+    │   │               │               └── content: "class"
+    │   │               │
+    │   │               │
+    │   │               ├── equals: ": " (location: (1:21)-(1:23))
+    │   │               └── value:
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:23)-(1:45))
+    │   │                       ├── open_quote: ∅
+    │   │                       ├── children: (1 item)
+    │   │                       │   └── @ LiteralNode (location: (1:23)-(1:45))
+    │   │                       │       └── content: "kitties puppies"
+    │   │                       │
+    │   │                       ├── close_quote: ∅
+    │   │                       └── quoted: false
+    │   │
+    │   │
+    │   │
+    │   ├── tag_name: "section" (location: (1:8)-(1:15))
+    │   ├── body: []
+    │   ├── close_tag:
+    │   │   └── @ HTMLVirtualCloseTagNode (location: (1:48)-(1:48))
+    │   │       └── tag_name: "section" (location: (1:8)-(1:15))
+    │   │
+    │   ├── is_void: false
+    │   └── element_source: "ActionView::Helpers::TagHelper#tag"
+    │
+    └── @ HTMLTextNode (location: (1:48)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0060_tag.section_with_mixed_array_class_attribute_keeps_as_ruby_literal_922f4304cc524070cb9352d52dd4a044-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0060_tag.section_with_mixed_array_class_attribute_keeps_as_ruby_literal_922f4304cc524070cb9352d52dd4a044-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,48 @@
+---
+source: "Analyze::ActionView::TagHelper::TagTest#test_0060_tag.section with mixed array class attribute keeps as ruby literal"
+input: |2-
+<%= tag.section class: ["kitties", variable] %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:47))
+    │   ├── open_tag:
+    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:47))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " tag.section class: ["kitties", variable] " (location: (1:3)-(1:45))
+    │   │       ├── tag_closing: "%>" (location: (1:45)-(1:47))
+    │   │       ├── tag_name: "section" (location: (1:8)-(1:15))
+    │   │       └── children: (1 item)
+    │   │           └── @ HTMLAttributeNode (location: (1:16)-(1:44))
+    │   │               ├── name:
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:16)-(1:21))
+    │   │               │       └── children: (1 item)
+    │   │               │           └── @ LiteralNode (location: (1:16)-(1:21))
+    │   │               │               └── content: "class"
+    │   │               │
+    │   │               │
+    │   │               ├── equals: ": " (location: (1:21)-(1:23))
+    │   │               └── value:
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:23)-(1:44))
+    │   │                       ├── open_quote: ∅
+    │   │                       ├── children: (1 item)
+    │   │                       │   └── @ RubyLiteralNode (location: (1:23)-(1:44))
+    │   │                       │       └── content: "token_list([\"kitties\", variable])"
+    │   │                       │
+    │   │                       ├── close_quote: ∅
+    │   │                       └── quoted: false
+    │   │
+    │   │
+    │   │
+    │   ├── tag_name: "section" (location: (1:8)-(1:15))
+    │   ├── body: []
+    │   ├── close_tag:
+    │   │   └── @ HTMLVirtualCloseTagNode (location: (1:47)-(1:47))
+    │   │       └── tag_name: "section" (location: (1:8)-(1:15))
+    │   │
+    │   ├── is_void: false
+    │   └── element_source: "ActionView::Helpers::TagHelper#tag"
+    │
+    └── @ HTMLTextNode (location: (1:47)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0061_tag.section_with_symbol_array_class_attribute_14b5bcc5dc18f9f3c6adcca6fef4a1fb-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0061_tag.section_with_symbol_array_class_attribute_14b5bcc5dc18f9f3c6adcca6fef4a1fb-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,48 @@
+---
+source: "Analyze::ActionView::TagHelper::TagTest#test_0061_tag.section with symbol array class attribute"
+input: |2-
+<%= tag.section class: [:kitties, :puppies] %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:46))
+    │   ├── open_tag:
+    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:46))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " tag.section class: [:kitties, :puppies] " (location: (1:3)-(1:44))
+    │   │       ├── tag_closing: "%>" (location: (1:44)-(1:46))
+    │   │       ├── tag_name: "section" (location: (1:8)-(1:15))
+    │   │       └── children: (1 item)
+    │   │           └── @ HTMLAttributeNode (location: (1:16)-(1:43))
+    │   │               ├── name:
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:16)-(1:21))
+    │   │               │       └── children: (1 item)
+    │   │               │           └── @ LiteralNode (location: (1:16)-(1:21))
+    │   │               │               └── content: "class"
+    │   │               │
+    │   │               │
+    │   │               ├── equals: ": " (location: (1:21)-(1:23))
+    │   │               └── value:
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:23)-(1:43))
+    │   │                       ├── open_quote: ∅
+    │   │                       ├── children: (1 item)
+    │   │                       │   └── @ LiteralNode (location: (1:23)-(1:43))
+    │   │                       │       └── content: "kitties puppies"
+    │   │                       │
+    │   │                       ├── close_quote: ∅
+    │   │                       └── quoted: false
+    │   │
+    │   │
+    │   │
+    │   ├── tag_name: "section" (location: (1:8)-(1:15))
+    │   ├── body: []
+    │   ├── close_tag:
+    │   │   └── @ HTMLVirtualCloseTagNode (location: (1:46)-(1:46))
+    │   │       └── tag_name: "section" (location: (1:8)-(1:15))
+    │   │
+    │   ├── is_void: false
+    │   └── element_source: "ActionView::Helpers::TagHelper#tag"
+    │
+    └── @ HTMLTextNode (location: (1:46)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0062_tag.div_with_conditional_class_hash_20faf874bb340bd229d2804d48e79247-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0062_tag.div_with_conditional_class_hash_20faf874bb340bd229d2804d48e79247-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,48 @@
+---
+source: "Analyze::ActionView::TagHelper::TagTest#test_0062_tag.div with conditional class hash"
+input: |2-
+<%= tag.div class: { active: true, hidden: false } %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:53))
+    │   ├── open_tag:
+    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:53))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " tag.div class: { active: true, hidden: false } " (location: (1:3)-(1:51))
+    │   │       ├── tag_closing: "%>" (location: (1:51)-(1:53))
+    │   │       ├── tag_name: "div" (location: (1:8)-(1:11))
+    │   │       └── children: (1 item)
+    │   │           └── @ HTMLAttributeNode (location: (1:12)-(1:50))
+    │   │               ├── name:
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:12)-(1:17))
+    │   │               │       └── children: (1 item)
+    │   │               │           └── @ LiteralNode (location: (1:12)-(1:17))
+    │   │               │               └── content: "class"
+    │   │               │
+    │   │               │
+    │   │               ├── equals: ": " (location: (1:17)-(1:19))
+    │   │               └── value:
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:19)-(1:50))
+    │   │                       ├── open_quote: ∅
+    │   │                       ├── children: (1 item)
+    │   │                       │   └── @ RubyLiteralNode (location: (1:19)-(1:50))
+    │   │                       │       └── content: "token_list({ active: true, hidden: false })"
+    │   │                       │
+    │   │                       ├── close_quote: ∅
+    │   │                       └── quoted: false
+    │   │
+    │   │
+    │   │
+    │   ├── tag_name: "div" (location: (1:8)-(1:11))
+    │   ├── body: []
+    │   ├── close_tag:
+    │   │   └── @ HTMLVirtualCloseTagNode (location: (1:53)-(1:53))
+    │   │       └── tag_name: "div" (location: (1:8)-(1:11))
+    │   │
+    │   ├── is_void: false
+    │   └── element_source: "ActionView::Helpers::TagHelper#tag"
+    │
+    └── @ HTMLTextNode (location: (1:53)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0063_tag.div_with_dynamic_conditional_class_hash_c1267fef8afdff54a94d52f9dc13f619-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0063_tag.div_with_dynamic_conditional_class_hash_c1267fef8afdff54a94d52f9dc13f619-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,48 @@
+---
+source: "Analyze::ActionView::TagHelper::TagTest#test_0063_tag.div with dynamic conditional class hash"
+input: |2-
+<%= tag.div class: { active: @is_active } %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:44))
+    │   ├── open_tag:
+    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:44))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " tag.div class: { active: @is_active } " (location: (1:3)-(1:42))
+    │   │       ├── tag_closing: "%>" (location: (1:42)-(1:44))
+    │   │       ├── tag_name: "div" (location: (1:8)-(1:11))
+    │   │       └── children: (1 item)
+    │   │           └── @ HTMLAttributeNode (location: (1:12)-(1:41))
+    │   │               ├── name:
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:12)-(1:17))
+    │   │               │       └── children: (1 item)
+    │   │               │           └── @ LiteralNode (location: (1:12)-(1:17))
+    │   │               │               └── content: "class"
+    │   │               │
+    │   │               │
+    │   │               ├── equals: ": " (location: (1:17)-(1:19))
+    │   │               └── value:
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:19)-(1:41))
+    │   │                       ├── open_quote: ∅
+    │   │                       ├── children: (1 item)
+    │   │                       │   └── @ RubyLiteralNode (location: (1:19)-(1:41))
+    │   │                       │       └── content: "token_list({ active: @is_active })"
+    │   │                       │
+    │   │                       ├── close_quote: ∅
+    │   │                       └── quoted: false
+    │   │
+    │   │
+    │   │
+    │   ├── tag_name: "div" (location: (1:8)-(1:11))
+    │   ├── body: []
+    │   ├── close_tag:
+    │   │   └── @ HTMLVirtualCloseTagNode (location: (1:44)-(1:44))
+    │   │       └── tag_name: "div" (location: (1:8)-(1:11))
+    │   │
+    │   ├── is_void: false
+    │   └── element_source: "ActionView::Helpers::TagHelper#tag"
+    │
+    └── @ HTMLTextNode (location: (1:44)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0064_tag.div_with_symbol_id_attribute_c64bbe9b704808a35aed8b7c15f00fbf-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0064_tag.div_with_symbol_id_attribute_c64bbe9b704808a35aed8b7c15f00fbf-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,48 @@
+---
+source: "Analyze::ActionView::TagHelper::TagTest#test_0064_tag.div with symbol id attribute"
+input: |2-
+<%= tag.div id: :main %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:24))
+    │   ├── open_tag:
+    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:24))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " tag.div id: :main " (location: (1:3)-(1:22))
+    │   │       ├── tag_closing: "%>" (location: (1:22)-(1:24))
+    │   │       ├── tag_name: "div" (location: (1:8)-(1:11))
+    │   │       └── children: (1 item)
+    │   │           └── @ HTMLAttributeNode (location: (1:12)-(1:21))
+    │   │               ├── name:
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:12)-(1:14))
+    │   │               │       └── children: (1 item)
+    │   │               │           └── @ LiteralNode (location: (1:12)-(1:14))
+    │   │               │               └── content: "id"
+    │   │               │
+    │   │               │
+    │   │               ├── equals: ": " (location: (1:14)-(1:16))
+    │   │               └── value:
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:17)-(1:21))
+    │   │                       ├── open_quote: ∅
+    │   │                       ├── children: (1 item)
+    │   │                       │   └── @ LiteralNode (location: (1:17)-(1:21))
+    │   │                       │       └── content: "main"
+    │   │                       │
+    │   │                       ├── close_quote: ∅
+    │   │                       └── quoted: false
+    │   │
+    │   │
+    │   │
+    │   ├── tag_name: "div" (location: (1:8)-(1:11))
+    │   ├── body: []
+    │   ├── close_tag:
+    │   │   └── @ HTMLVirtualCloseTagNode (location: (1:24)-(1:24))
+    │   │       └── tag_name: "div" (location: (1:8)-(1:11))
+    │   │
+    │   ├── is_void: false
+    │   └── element_source: "ActionView::Helpers::TagHelper#tag"
+    │
+    └── @ HTMLTextNode (location: (1:24)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0065_tag.div_with_aria_hash_attributes_d09e3ad879feeadf8b264ec689cb4b7e-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0065_tag.div_with_aria_hash_attributes_d09e3ad879feeadf8b264ec689cb4b7e-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,68 @@
+---
+source: "Analyze::ActionView::TagHelper::TagTest#test_0065_tag.div with aria hash attributes"
+input: |2-
+<%= tag.div aria: { label: "hello", hidden: true } %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:53))
+    │   ├── open_tag:
+    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:53))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " tag.div aria: { label: "hello", hidden: true } " (location: (1:3)-(1:51))
+    │   │       ├── tag_closing: "%>" (location: (1:51)-(1:53))
+    │   │       ├── tag_name: "div" (location: (1:8)-(1:11))
+    │   │       └── children: (2 items)
+    │   │           ├── @ HTMLAttributeNode (location: (1:20)-(1:34))
+    │   │           │   ├── name:
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:20)-(1:25))
+    │   │           │   │       └── children: (1 item)
+    │   │           │   │           └── @ LiteralNode (location: (1:20)-(1:25))
+    │   │           │   │               └── content: "aria-label"
+    │   │           │   │
+    │   │           │   │
+    │   │           │   ├── equals: ": " (location: (1:25)-(1:27))
+    │   │           │   └── value:
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:27)-(1:34))
+    │   │           │           ├── open_quote: """ (location: (1:27)-(1:28))
+    │   │           │           ├── children: (1 item)
+    │   │           │           │   └── @ LiteralNode (location: (1:28)-(1:33))
+    │   │           │           │       └── content: "hello"
+    │   │           │           │
+    │   │           │           ├── close_quote: """ (location: (1:33)-(1:34))
+    │   │           │           └── quoted: true
+    │   │           │
+    │   │           │
+    │   │           └── @ HTMLAttributeNode (location: (1:36)-(1:48))
+    │   │               ├── name:
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:36)-(1:42))
+    │   │               │       └── children: (1 item)
+    │   │               │           └── @ LiteralNode (location: (1:36)-(1:42))
+    │   │               │               └── content: "aria-hidden"
+    │   │               │
+    │   │               │
+    │   │               ├── equals: ": " (location: (1:42)-(1:44))
+    │   │               └── value:
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:44)-(1:48))
+    │   │                       ├── open_quote: ∅
+    │   │                       ├── children: (1 item)
+    │   │                       │   └── @ LiteralNode (location: (1:44)-(1:48))
+    │   │                       │       └── content: "true"
+    │   │                       │
+    │   │                       ├── close_quote: ∅
+    │   │                       └── quoted: false
+    │   │
+    │   │
+    │   │
+    │   ├── tag_name: "div" (location: (1:8)-(1:11))
+    │   ├── body: []
+    │   ├── close_tag:
+    │   │   └── @ HTMLVirtualCloseTagNode (location: (1:53)-(1:53))
+    │   │       └── tag_name: "div" (location: (1:8)-(1:11))
+    │   │
+    │   ├── is_void: false
+    │   └── element_source: "ActionView::Helpers::TagHelper#tag"
+    │
+    └── @ HTMLTextNode (location: (1:53)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0066_tag.div_with_data_hash_containing_%w()_array_value_d85064b5c14cbdb5239503045d88f921-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0066_tag.div_with_data_hash_containing_%w()_array_value_d85064b5c14cbdb5239503045d88f921-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,48 @@
+---
+source: "Analyze::ActionView::TagHelper::TagTest#test_0066_tag.div with data hash containing %w() array value"
+input: |2-
+<%= tag.div data: { city_state: %w( Chicago IL ) } %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:53))
+    │   ├── open_tag:
+    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:53))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " tag.div data: { city_state: %w( Chicago IL ) } " (location: (1:3)-(1:51))
+    │   │       ├── tag_closing: "%>" (location: (1:51)-(1:53))
+    │   │       ├── tag_name: "div" (location: (1:8)-(1:11))
+    │   │       └── children: (1 item)
+    │   │           └── @ HTMLAttributeNode (location: (1:20)-(1:48))
+    │   │               ├── name:
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:20)-(1:30))
+    │   │               │       └── children: (1 item)
+    │   │               │           └── @ LiteralNode (location: (1:20)-(1:30))
+    │   │               │               └── content: "data-city-state"
+    │   │               │
+    │   │               │
+    │   │               ├── equals: ": " (location: (1:30)-(1:32))
+    │   │               └── value:
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:32)-(1:48))
+    │   │                       ├── open_quote: ∅
+    │   │                       ├── children: (1 item)
+    │   │                       │   └── @ RubyLiteralNode (location: (1:32)-(1:48))
+    │   │                       │       └── content: "%w( Chicago IL ).to_json"
+    │   │                       │
+    │   │                       ├── close_quote: ∅
+    │   │                       └── quoted: false
+    │   │
+    │   │
+    │   │
+    │   ├── tag_name: "div" (location: (1:8)-(1:11))
+    │   ├── body: []
+    │   ├── close_tag:
+    │   │   └── @ HTMLVirtualCloseTagNode (location: (1:53)-(1:53))
+    │   │       └── tag_name: "div" (location: (1:8)-(1:11))
+    │   │
+    │   ├── is_void: false
+    │   └── element_source: "ActionView::Helpers::TagHelper#tag"
+    │
+    └── @ HTMLTextNode (location: (1:53)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0067_tag.div_with_data_hash_containing_array_value_683d3598e451685b32baa2b0e3022244-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0067_tag.div_with_data_hash_containing_array_value_683d3598e451685b32baa2b0e3022244-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,48 @@
+---
+source: "Analyze::ActionView::TagHelper::TagTest#test_0067_tag.div with data hash containing array value"
+input: |2-
+<%= tag.div data: { city_state: ["Chicago", "IL"] } %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:54))
+    │   ├── open_tag:
+    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:54))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " tag.div data: { city_state: ["Chicago", "IL"] } " (location: (1:3)-(1:52))
+    │   │       ├── tag_closing: "%>" (location: (1:52)-(1:54))
+    │   │       ├── tag_name: "div" (location: (1:8)-(1:11))
+    │   │       └── children: (1 item)
+    │   │           └── @ HTMLAttributeNode (location: (1:20)-(1:49))
+    │   │               ├── name:
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:20)-(1:30))
+    │   │               │       └── children: (1 item)
+    │   │               │           └── @ LiteralNode (location: (1:20)-(1:30))
+    │   │               │               └── content: "data-city-state"
+    │   │               │
+    │   │               │
+    │   │               ├── equals: ": " (location: (1:30)-(1:32))
+    │   │               └── value:
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:32)-(1:49))
+    │   │                       ├── open_quote: ∅
+    │   │                       ├── children: (1 item)
+    │   │                       │   └── @ RubyLiteralNode (location: (1:32)-(1:49))
+    │   │                       │       └── content: "[\"Chicago\", \"IL\"].to_json"
+    │   │                       │
+    │   │                       ├── close_quote: ∅
+    │   │                       └── quoted: false
+    │   │
+    │   │
+    │   │
+    │   ├── tag_name: "div" (location: (1:8)-(1:11))
+    │   ├── body: []
+    │   ├── close_tag:
+    │   │   └── @ HTMLVirtualCloseTagNode (location: (1:54)-(1:54))
+    │   │       └── tag_name: "div" (location: (1:8)-(1:11))
+    │   │
+    │   ├── is_void: false
+    │   └── element_source: "ActionView::Helpers::TagHelper#tag"
+    │
+    └── @ HTMLTextNode (location: (1:54)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0068_tag.img_with_escape_false_option_a66f2db748d6c9ecb329c3c6f606e650-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0068_tag.img_with_escape_false_option_a66f2db748d6c9ecb329c3c6f606e650-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,45 @@
+---
+source: "Analyze::ActionView::TagHelper::TagTest#test_0068_tag.img with escape false option"
+input: |2-
+<%= tag.img src: "open & shut.png", escape: false %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:52))
+    │   ├── open_tag:
+    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:52))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " tag.img src: "open & shut.png", escape: false " (location: (1:3)-(1:50))
+    │   │       ├── tag_closing: "%>" (location: (1:50)-(1:52))
+    │   │       ├── tag_name: "img" (location: (1:8)-(1:11))
+    │   │       └── children: (1 item)
+    │   │           └── @ HTMLAttributeNode (location: (1:12)-(1:34))
+    │   │               ├── name:
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:12)-(1:15))
+    │   │               │       └── children: (1 item)
+    │   │               │           └── @ LiteralNode (location: (1:12)-(1:15))
+    │   │               │               └── content: "src"
+    │   │               │
+    │   │               │
+    │   │               ├── equals: ": " (location: (1:15)-(1:17))
+    │   │               └── value:
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:17)-(1:34))
+    │   │                       ├── open_quote: """ (location: (1:17)-(1:18))
+    │   │                       ├── children: (1 item)
+    │   │                       │   └── @ LiteralNode (location: (1:18)-(1:33))
+    │   │                       │       └── content: "open & shut.png"
+    │   │                       │
+    │   │                       ├── close_quote: """ (location: (1:33)-(1:34))
+    │   │                       └── quoted: true
+    │   │
+    │   │
+    │   │
+    │   ├── tag_name: "img" (location: (1:8)-(1:11))
+    │   ├── body: []
+    │   ├── close_tag: ∅
+    │   ├── is_void: true
+    │   └── element_source: "ActionView::Helpers::TagHelper#tag"
+    │
+    └── @ HTMLTextNode (location: (1:52)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0069_tag.div_with_data_hash_containing_symbol_value_7f8cfd0aa374d0bfd16a7d014193883f-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0069_tag.div_with_data_hash_containing_symbol_value_7f8cfd0aa374d0bfd16a7d014193883f-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,48 @@
+---
+source: "Analyze::ActionView::TagHelper::TagTest#test_0069_tag.div with data hash containing symbol value"
+input: |2-
+<%= tag.div data: { status: :active } %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:40))
+    │   ├── open_tag:
+    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:40))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " tag.div data: { status: :active } " (location: (1:3)-(1:38))
+    │   │       ├── tag_closing: "%>" (location: (1:38)-(1:40))
+    │   │       ├── tag_name: "div" (location: (1:8)-(1:11))
+    │   │       └── children: (1 item)
+    │   │           └── @ HTMLAttributeNode (location: (1:20)-(1:35))
+    │   │               ├── name:
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:20)-(1:26))
+    │   │               │       └── children: (1 item)
+    │   │               │           └── @ LiteralNode (location: (1:20)-(1:26))
+    │   │               │               └── content: "data-status"
+    │   │               │
+    │   │               │
+    │   │               ├── equals: ": " (location: (1:26)-(1:28))
+    │   │               └── value:
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:29)-(1:35))
+    │   │                       ├── open_quote: ∅
+    │   │                       ├── children: (1 item)
+    │   │                       │   └── @ LiteralNode (location: (1:29)-(1:35))
+    │   │                       │       └── content: "active"
+    │   │                       │
+    │   │                       ├── close_quote: ∅
+    │   │                       └── quoted: false
+    │   │
+    │   │
+    │   │
+    │   ├── tag_name: "div" (location: (1:8)-(1:11))
+    │   ├── body: []
+    │   ├── close_tag:
+    │   │   └── @ HTMLVirtualCloseTagNode (location: (1:40)-(1:40))
+    │   │       └── tag_name: "div" (location: (1:8)-(1:11))
+    │   │
+    │   ├── is_void: false
+    │   └── element_source: "ActionView::Helpers::TagHelper#tag"
+    │
+    └── @ HTMLTextNode (location: (1:40)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0070_tag.div_with_data_hash_containing_integer_value_bd644aec11820868ec0be7ff46407f9c-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0070_tag.div_with_data_hash_containing_integer_value_bd644aec11820868ec0be7ff46407f9c-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,48 @@
+---
+source: "Analyze::ActionView::TagHelper::TagTest#test_0070_tag.div with data hash containing integer value"
+input: |2-
+<%= tag.div data: { count: 42 } %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:34))
+    │   ├── open_tag:
+    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:34))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " tag.div data: { count: 42 } " (location: (1:3)-(1:32))
+    │   │       ├── tag_closing: "%>" (location: (1:32)-(1:34))
+    │   │       ├── tag_name: "div" (location: (1:8)-(1:11))
+    │   │       └── children: (1 item)
+    │   │           └── @ HTMLAttributeNode (location: (1:20)-(1:29))
+    │   │               ├── name:
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:20)-(1:25))
+    │   │               │       └── children: (1 item)
+    │   │               │           └── @ LiteralNode (location: (1:20)-(1:25))
+    │   │               │               └── content: "data-count"
+    │   │               │
+    │   │               │
+    │   │               ├── equals: ": " (location: (1:25)-(1:27))
+    │   │               └── value:
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:27)-(1:29))
+    │   │                       ├── open_quote: ∅
+    │   │                       ├── children: (1 item)
+    │   │                       │   └── @ LiteralNode (location: (1:27)-(1:29))
+    │   │                       │       └── content: "42"
+    │   │                       │
+    │   │                       ├── close_quote: ∅
+    │   │                       └── quoted: false
+    │   │
+    │   │
+    │   │
+    │   ├── tag_name: "div" (location: (1:8)-(1:11))
+    │   ├── body: []
+    │   ├── close_tag:
+    │   │   └── @ HTMLVirtualCloseTagNode (location: (1:34)-(1:34))
+    │   │       └── tag_name: "div" (location: (1:8)-(1:11))
+    │   │
+    │   ├── is_void: false
+    │   └── element_source: "ActionView::Helpers::TagHelper#tag"
+    │
+    └── @ HTMLTextNode (location: (1:34)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0071_tag.div_with_data_hash_containing_nested_hash_value_df679d25a911db3c884b69f422ae682c-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0071_tag.div_with_data_hash_containing_nested_hash_value_df679d25a911db3c884b69f422ae682c-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,48 @@
+---
+source: "Analyze::ActionView::TagHelper::TagTest#test_0071_tag.div with data hash containing nested hash value"
+input: |2-
+<%= tag.div data: { config: { nested: "hash" } } %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:51))
+    │   ├── open_tag:
+    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:51))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " tag.div data: { config: { nested: "hash" } } " (location: (1:3)-(1:49))
+    │   │       ├── tag_closing: "%>" (location: (1:49)-(1:51))
+    │   │       ├── tag_name: "div" (location: (1:8)-(1:11))
+    │   │       └── children: (1 item)
+    │   │           └── @ HTMLAttributeNode (location: (1:20)-(1:46))
+    │   │               ├── name:
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:20)-(1:26))
+    │   │               │       └── children: (1 item)
+    │   │               │           └── @ LiteralNode (location: (1:20)-(1:26))
+    │   │               │               └── content: "data-config"
+    │   │               │
+    │   │               │
+    │   │               ├── equals: ": " (location: (1:26)-(1:28))
+    │   │               └── value:
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:28)-(1:46))
+    │   │                       ├── open_quote: ∅
+    │   │                       ├── children: (1 item)
+    │   │                       │   └── @ RubyLiteralNode (location: (1:28)-(1:46))
+    │   │                       │       └── content: "{ nested: \"hash\" }.to_json"
+    │   │                       │
+    │   │                       ├── close_quote: ∅
+    │   │                       └── quoted: false
+    │   │
+    │   │
+    │   │
+    │   ├── tag_name: "div" (location: (1:8)-(1:11))
+    │   ├── body: []
+    │   ├── close_tag:
+    │   │   └── @ HTMLVirtualCloseTagNode (location: (1:51)-(1:51))
+    │   │       └── tag_name: "div" (location: (1:8)-(1:11))
+    │   │
+    │   ├── is_void: false
+    │   └── element_source: "ActionView::Helpers::TagHelper#tag"
+    │
+    └── @ HTMLTextNode (location: (1:51)-(2:0))
+        └── content: "\n"


### PR DESCRIPTION
This pull request improves how the parser handles several Action View helper patterns to more closely match Rails' runtime behavior.

The attribute extraction now handles static string and symbol arrays in class attributes by joining them into space-separated values, matching how Rails renders `class: ["kitties", "puppies"]` as `class="kitties puppies"`. 

Mixed arrays containing variables or conditional hashes are wrapped in `token_list(...)` instead, so the output evaluates correctly at runtime. For example, `class: { active: true, hidden: false }` now produces `class="<%= token_list({ active: true, hidden: false }) %>"` rather than leaving the hash as a raw Ruby literal.

For `data:` and `aria:` hash values, non-string types are now wrapped in `.to_json` to match Rails' `prefix_tag_option` behavior, while integers and symbols are inlined directly as literal values.

Additionally, Ruby introspection methods like `tag.send`, `tag.class`, `tag.method`, and methods ending in `?` or `!` are no longer treated as tag names. These are recognized as dynamic calls with `tag_name: null`, following the same pattern used by `content_tag` with a variable tag name.

The `escape` keyword argument is now filtered from extracted attributes, matching Rails which consumes it internally and does not render it as an HTML attribute. The `search_tag_helper_node` function was also fixed to correctly find the outermost matching call when tag helpers are nested as arguments, such as `content_tag(:div, content_tag(:p, "Hello world!"))`.