### PR TITLE
Linter: Introduce `actionview-no-unnecessary-tag-attributes` linter rule

### DIFF
--- a/javascript/packages/linter/docs/rules/actionview-no-unnecessary-tag-attributes.md
+++ b/javascript/packages/linter/docs/rules/actionview-no-unnecessary-tag-attributes.md
@@ -1,0 +1,79 @@
+# Linter Rule: Disallow unnecessary `tag.attributes` usage
+
+**Rule:** `actionview-no-unnecessary-tag-attributes`
+
+## Description
+
+Disallow using `tag.attributes` inside a plain HTML tag when the same result can be achieved with a tag helper like `tag.input`, `tag.div`, etc., or by adding the attributes directly to the HTML tag.
+
+## Rationale
+
+Rails provides tag helpers (`tag.input`, `tag.div`, `tag.span`, etc.) that generate complete HTML elements with properly escaped attributes. Using `tag.attributes` inside a manually written HTML tag to achieve the same result is redundant and harder to read.
+
+The `tag.attributes` helper is useful when combined with other HTML attributes or in contexts where a full tag helper cannot be used, but wrapping all attributes of a plain HTML element in `tag.attributes` is unnecessary and less idiomatic.
+
+Using a tag helper or plain HTML attributes instead is:
+- More concise and idiomatic Rails.
+- Easier to read and maintain.
+- Less error-prone since the helper handles escaping and self-closing behavior.
+
+## Examples
+
+### ✅ Good
+
+```erb
+<input type="text" aria-label="Search">
+```
+
+```erb
+<%= tag.input type: :text, aria: { label: "Search" } %>
+```
+
+```erb
+<div id="container" class="wrapper">
+  Content
+</div>
+```
+
+```erb
+<%= tag.div id: "container", class: "wrapper" do %>
+  Content
+<% end %>
+```
+
+```erb
+<img src="<%= image_path("logo.png") %>" alt="Logo">
+```
+
+```erb
+<%= tag.img src: image_path("logo.png"), alt: "Logo" %>
+```
+
+Using `tag.attributes` alongside regular HTML attributes is allowed:
+
+```erb
+<button class="primary" <%= tag.attributes(id: @call_to_action_id, aria: { expanded: @expanded }) %>>
+  Get Started!
+</button>
+```
+
+### 🚫 Bad
+
+```erb
+<input <%= tag.attributes(type: :text, aria: { label: "Search" }) %>>
+```
+
+```erb
+<div <%= tag.attributes(id: @container_id, class: @wrapper_class) %>>
+  Content
+</div>
+```
+
+```erb
+<img <%= tag.attributes(src: image_path("logo.png"), alt: "Logo") %>>
+```
+
+## References
+
+* [Rails `tag` API](https://api.rubyonrails.org/classes/ActionView/Helpers/TagHelper.html#method-i-tag)
+* [Rails `tag.attributes` API](https://api.rubyonrails.org/classes/ActionView/Helpers/TagHelper.html#method-i-tag)

--- a/javascript/packages/linter/src/rules.ts
+++ b/javascript/packages/linter/src/rules.ts
@@ -2,6 +2,7 @@ import type { RuleClass } from "./types.js"
 
 import { ActionViewNoSilentHelperRule } from "./rules/actionview-no-silent-helper.js"
 import { ActionViewNoSilentRenderRule } from "./rules/actionview-no-silent-render.js"
+import { ActionViewNoUnnecessaryTagAttributesRule } from "./rules/actionview-no-unnecessary-tag-attributes.js"
 import { ActionViewNoVoidElementContentRule } from "./rules/actionview-no-void-element-content.js"
 import { ActionViewStrictLocalsFirstLineRule } from "./rules/actionview-strict-locals-first-line.js"
 import { ActionViewStrictLocalsPartialOnlyRule } from "./rules/actionview-strict-locals-partial-only.js"
@@ -94,6 +95,7 @@ import { TurboPermanentRequireIdRule } from "./rules/turbo-permanent-require-id.
 export const rules: RuleClass[] = [
   ActionViewNoSilentHelperRule,
   ActionViewNoSilentRenderRule,
+  ActionViewNoUnnecessaryTagAttributesRule,
   ActionViewNoVoidElementContentRule,
   ActionViewStrictLocalsFirstLineRule,
   ActionViewStrictLocalsPartialOnlyRule,

--- a/javascript/packages/linter/src/rules/actionview-no-unnecessary-tag-attributes.ts
+++ b/javascript/packages/linter/src/rules/actionview-no-unnecessary-tag-attributes.ts
@@ -1,0 +1,75 @@
+import { ParserRule } from "../types.js"
+import { BaseRuleVisitor } from "./rule-utils.js"
+import { getTagLocalName, isHTMLOpenTagNode, isERBContentNode, isERBOutputNode, isHTMLAttributeNode, isWhitespaceNode } from "@herb-tools/core"
+
+import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types.js"
+import type { ParseResult, HTMLElementNode, HTMLOpenTagNode, ParserOptions, PrismNode } from "@herb-tools/core"
+
+function isTagAttributesCall(node: PrismNode): boolean {
+  if (node?.constructor?.name !== "CallNode") return false
+  if (node.name !== "attributes") return false
+  if (node.receiver?.constructor?.name !== "CallNode") return false
+
+  return node.receiver.name === "tag"
+}
+
+function hasOnlyTagAttributesChildren(openTag: HTMLOpenTagNode): boolean {
+  const nonWhitespaceChildren = openTag.children.filter(child => !isWhitespaceNode(child))
+
+  if (nonWhitespaceChildren.length === 0) return false
+  if (nonWhitespaceChildren.some(isHTMLAttributeNode)) return false
+
+  return nonWhitespaceChildren.every(child => {
+    if (!isERBContentNode(child) || !isERBOutputNode(child)) return false
+    if (!child.prismNode) return false
+
+    return isTagAttributesCall(child.prismNode)
+  })
+}
+
+class ActionViewNoUnnecessaryTagAttributesVisitor extends BaseRuleVisitor {
+  visitHTMLElementNode(node: HTMLElementNode): void {
+    this.checkUnnecessaryTagAttributes(node)
+    super.visitHTMLElementNode(node)
+  }
+
+  private checkUnnecessaryTagAttributes(node: HTMLElementNode): void {
+    if (!isHTMLOpenTagNode(node.open_tag)) return
+
+    const tagName = getTagLocalName(node.open_tag)
+
+    if (!tagName) return
+    if (!hasOnlyTagAttributesChildren(node.open_tag)) return
+
+    this.addOffense(
+      `Avoid using \`tag.attributes\` to set all attributes on \`<${tagName}>\`. Use \`tag.${tagName}\` or add the attributes directly to the \`<${tagName}>\` tag instead.`,
+      node.open_tag.location,
+    )
+  }
+}
+
+export class ActionViewNoUnnecessaryTagAttributesRule extends ParserRule {
+  static ruleName = "actionview-no-unnecessary-tag-attributes"
+  static introducedIn = this.version("unreleased")
+
+  get defaultConfig(): FullRuleConfig {
+    return {
+      enabled: true,
+      severity: "warning",
+    }
+  }
+
+  get parserOptions(): Partial<ParserOptions> {
+    return {
+      prism_nodes: true,
+    }
+  }
+
+  check(result: ParseResult, context?: Partial<LintContext>): UnboundLintOffense[] {
+    const visitor = new ActionViewNoUnnecessaryTagAttributesVisitor(this.ruleName, context)
+
+    visitor.visit(result.value)
+
+    return visitor.offenses
+  }
+}

--- a/javascript/packages/linter/src/rules/index.ts
+++ b/javascript/packages/linter/src/rules/index.ts
@@ -5,6 +5,7 @@ export * from "./herb-disable-comment-base.js"
 
 export * from "./actionview-no-silent-helper.js"
 export * from "./actionview-no-silent-render.js"
+export * from "./actionview-no-unnecessary-tag-attributes.js"
 export * from "./actionview-no-void-element-content.js"
 export * from "./actionview-strict-locals-first-line.js"
 export * from "./actionview-strict-locals-partial-only.js"

--- a/javascript/packages/linter/test/__snapshots__/cli.test.ts.snap
+++ b/javascript/packages/linter/test/__snapshots__/cli.test.ts.snap
@@ -111,8 +111,9 @@ test/fixtures/ignored.html.erb:8:8
   Fixable      7 offenses | 4 autocorrectable using \`--fix\`
 
  New rules available:
-  Your .herb.yml version is 0.9.2. 4 new rules are disabled to ease upgrades:
+  Your .herb.yml version is 0.9.2. 5 new rules are disabled to ease upgrades:
 
+  actionview-no-unnecessary-tag-attributes (introduced in next release)
   actionview-no-void-element-content (introduced in next release)
   actionview-strict-locals-partial-only (introduced in next release)
   html-require-script-nonce (introduced in next release)
@@ -182,8 +183,9 @@ test/fixtures/test-file-with-errors.html.erb:2:22
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
 
  New rules available:
-  Your .herb.yml version is 0.9.2. 4 new rules are disabled to ease upgrades:
+  Your .herb.yml version is 0.9.2. 5 new rules are disabled to ease upgrades:
 
+  actionview-no-unnecessary-tag-attributes (introduced in next release)
   actionview-no-void-element-content (introduced in next release)
   actionview-strict-locals-partial-only (introduced in next release)
   html-require-script-nonce (introduced in next release)
@@ -215,8 +217,9 @@ test/fixtures/no-trailing-newline.html.erb:1:29
   Fixable      1 offense | 1 autocorrectable using \`--fix\`
 
  New rules available:
-  Your .herb.yml version is 0.9.2. 4 new rules are disabled to ease upgrades:
+  Your .herb.yml version is 0.9.2. 5 new rules are disabled to ease upgrades:
 
+  actionview-no-unnecessary-tag-attributes (introduced in next release)
   actionview-no-void-element-content (introduced in next release)
   actionview-strict-locals-partial-only (introduced in next release)
   html-require-script-nonce (introduced in next release)
@@ -274,8 +277,9 @@ test/fixtures/erb-no-extra-whitespace-inside-tags.html.erb:9:3
   Fixable      3 offenses | 3 autocorrectable using \`--fix\`
 
  New rules available:
-  Your .herb.yml version is 0.9.2. 4 new rules are disabled to ease upgrades:
+  Your .herb.yml version is 0.9.2. 5 new rules are disabled to ease upgrades:
 
+  actionview-no-unnecessary-tag-attributes (introduced in next release)
   actionview-no-void-element-content (introduced in next release)
   actionview-strict-locals-partial-only (introduced in next release)
   html-require-script-nonce (introduced in next release)
@@ -326,8 +330,9 @@ test/fixtures/ignored.html.erb:6:14
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
 
  New rules available:
-  Your .herb.yml version is 0.9.2. 4 new rules are disabled to ease upgrades:
+  Your .herb.yml version is 0.9.2. 5 new rules are disabled to ease upgrades:
 
+  actionview-no-unnecessary-tag-attributes (introduced in next release)
   actionview-no-void-element-content (introduced in next release)
   actionview-strict-locals-partial-only (introduced in next release)
   html-require-script-nonce (introduced in next release)
@@ -363,8 +368,9 @@ test/fixtures/parser-errors.html.erb:2:16
   Fixable      1 offense
 
  New rules available:
-  Your .herb.yml version is 0.9.2. 4 new rules are disabled to ease upgrades:
+  Your .herb.yml version is 0.9.2. 5 new rules are disabled to ease upgrades:
 
+  actionview-no-unnecessary-tag-attributes (introduced in next release)
   actionview-no-void-element-content (introduced in next release)
   actionview-strict-locals-partial-only (introduced in next release)
   html-require-script-nonce (introduced in next release)
@@ -589,8 +595,9 @@ test/fixtures/multiple-rule-offenses.html.erb:4:2
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
 
  New rules available:
-  Your .herb.yml version is 0.9.2. 4 new rules are disabled to ease upgrades:
+  Your .herb.yml version is 0.9.2. 5 new rules are disabled to ease upgrades:
 
+  actionview-no-unnecessary-tag-attributes (introduced in next release)
   actionview-no-void-element-content (introduced in next release)
   actionview-strict-locals-partial-only (introduced in next release)
   html-require-script-nonce (introduced in next release)
@@ -697,8 +704,9 @@ test/fixtures/few-rule-offenses.html.erb:6:0
   Fixable      6 offenses | 3 autocorrectable using \`--fix\`
 
  New rules available:
-  Your .herb.yml version is 0.9.2. 4 new rules are disabled to ease upgrades:
+  Your .herb.yml version is 0.9.2. 5 new rules are disabled to ease upgrades:
 
+  actionview-no-unnecessary-tag-attributes (introduced in next release)
   actionview-no-void-element-content (introduced in next release)
   actionview-strict-locals-partial-only (introduced in next release)
   html-require-script-nonce (introduced in next release)
@@ -747,8 +755,9 @@ test/fixtures/bad-file.html.erb:1:16
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
 
  New rules available:
-  Your .herb.yml version is 0.9.2. 4 new rules are disabled to ease upgrades:
+  Your .herb.yml version is 0.9.2. 5 new rules are disabled to ease upgrades:
 
+  actionview-no-unnecessary-tag-attributes (introduced in next release)
   actionview-no-void-element-content (introduced in next release)
   actionview-strict-locals-partial-only (introduced in next release)
   html-require-script-nonce (introduced in next release)
@@ -767,8 +776,9 @@ exports[`CLI Output Formatting > formats GitHub Actions output correctly for cle
   Offenses     0 offenses
 
  New rules available:
-  Your .herb.yml version is 0.9.2. 4 new rules are disabled to ease upgrades:
+  Your .herb.yml version is 0.9.2. 5 new rules are disabled to ease upgrades:
 
+  actionview-no-unnecessary-tag-attributes (introduced in next release)
   actionview-no-void-element-content (introduced in next release)
   actionview-strict-locals-partial-only (introduced in next release)
   html-require-script-nonce (introduced in next release)
@@ -835,8 +845,9 @@ test/fixtures/test-file-with-errors.html.erb:2:22
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
 
  New rules available:
-  Your .herb.yml version is 0.9.2. 4 new rules are disabled to ease upgrades:
+  Your .herb.yml version is 0.9.2. 5 new rules are disabled to ease upgrades:
 
+  actionview-no-unnecessary-tag-attributes (introduced in next release)
   actionview-no-void-element-content (introduced in next release)
   actionview-strict-locals-partial-only (introduced in next release)
   html-require-script-nonce (introduced in next release)
@@ -882,8 +893,9 @@ test/fixtures/test-file-simple.html.erb:2:22
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
 
  New rules available:
-  Your .herb.yml version is 0.9.2. 4 new rules are disabled to ease upgrades:
+  Your .herb.yml version is 0.9.2. 5 new rules are disabled to ease upgrades:
 
+  actionview-no-unnecessary-tag-attributes (introduced in next release)
   actionview-no-void-element-content (introduced in next release)
   actionview-strict-locals-partial-only (introduced in next release)
   html-require-script-nonce (introduced in next release)
@@ -1097,8 +1109,9 @@ test/fixtures/test-file-with-errors.html.erb:2:22
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
 
  New rules available:
-  Your .herb.yml version is 0.9.2. 4 new rules are disabled to ease upgrades:
+  Your .herb.yml version is 0.9.2. 5 new rules are disabled to ease upgrades:
 
+  actionview-no-unnecessary-tag-attributes (introduced in next release)
   actionview-no-void-element-content (introduced in next release)
   actionview-strict-locals-partial-only (introduced in next release)
   html-require-script-nonce (introduced in next release)
@@ -1127,8 +1140,9 @@ exports[`CLI Output Formatting > formats simple output correctly 1`] = `
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
 
  New rules available:
-  Your .herb.yml version is 0.9.2. 4 new rules are disabled to ease upgrades:
+  Your .herb.yml version is 0.9.2. 5 new rules are disabled to ease upgrades:
 
+  actionview-no-unnecessary-tag-attributes (introduced in next release)
   actionview-no-void-element-content (introduced in next release)
   actionview-strict-locals-partial-only (introduced in next release)
   html-require-script-nonce (introduced in next release)
@@ -1157,8 +1171,9 @@ exports[`CLI Output Formatting > formats simple output for bad-file correctly 1`
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
 
  New rules available:
-  Your .herb.yml version is 0.9.2. 4 new rules are disabled to ease upgrades:
+  Your .herb.yml version is 0.9.2. 5 new rules are disabled to ease upgrades:
 
+  actionview-no-unnecessary-tag-attributes (introduced in next release)
   actionview-no-void-element-content (introduced in next release)
   actionview-strict-locals-partial-only (introduced in next release)
   html-require-script-nonce (introduced in next release)
@@ -1180,8 +1195,9 @@ exports[`CLI Output Formatting > formats success output correctly 1`] = `
   Offenses     0 offenses
 
  New rules available:
-  Your .herb.yml version is 0.9.2. 4 new rules are disabled to ease upgrades:
+  Your .herb.yml version is 0.9.2. 5 new rules are disabled to ease upgrades:
 
+  actionview-no-unnecessary-tag-attributes (introduced in next release)
   actionview-no-void-element-content (introduced in next release)
   actionview-strict-locals-partial-only (introduced in next release)
   html-require-script-nonce (introduced in next release)
@@ -1203,8 +1219,9 @@ exports[`CLI Output Formatting > handles boolean attributes 1`] = `
   Offenses     0 offenses
 
  New rules available:
-  Your .herb.yml version is 0.9.2. 4 new rules are disabled to ease upgrades:
+  Your .herb.yml version is 0.9.2. 5 new rules are disabled to ease upgrades:
 
+  actionview-no-unnecessary-tag-attributes (introduced in next release)
   actionview-no-void-element-content (introduced in next release)
   actionview-strict-locals-partial-only (introduced in next release)
   html-require-script-nonce (introduced in next release)
@@ -1249,8 +1266,9 @@ test/fixtures/bad-file.html.erb:1:16
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
 
  New rules available:
-  Your .herb.yml version is 0.9.2. 4 new rules are disabled to ease upgrades:
+  Your .herb.yml version is 0.9.2. 5 new rules are disabled to ease upgrades:
 
+  actionview-no-unnecessary-tag-attributes (introduced in next release)
   actionview-no-void-element-content (introduced in next release)
   actionview-strict-locals-partial-only (introduced in next release)
   html-require-script-nonce (introduced in next release)
@@ -1392,8 +1410,9 @@ test/fixtures/disabled-1.html.erb:14:19
   Fixable      8 offenses | 1 autocorrectable using \`--fix\`
 
  New rules available:
-  Your .herb.yml version is 0.9.2. 4 new rules are disabled to ease upgrades:
+  Your .herb.yml version is 0.9.2. 5 new rules are disabled to ease upgrades:
 
+  actionview-no-unnecessary-tag-attributes (introduced in next release)
   actionview-no-void-element-content (introduced in next release)
   actionview-strict-locals-partial-only (introduced in next release)
   html-require-script-nonce (introduced in next release)
@@ -1606,8 +1625,9 @@ test/fixtures/disabled-2.html.erb:2:44
   Fixable      13 offenses | 6 autocorrectable using \`--fix\`
 
  New rules available:
-  Your .herb.yml version is 0.9.2. 4 new rules are disabled to ease upgrades:
+  Your .herb.yml version is 0.9.2. 5 new rules are disabled to ease upgrades:
 
+  actionview-no-unnecessary-tag-attributes (introduced in next release)
   actionview-no-void-element-content (introduced in next release)
   actionview-strict-locals-partial-only (introduced in next release)
   html-require-script-nonce (introduced in next release)
@@ -1677,8 +1697,9 @@ test/fixtures/test-file-with-errors.html.erb:2:22
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
 
  New rules available:
-  Your .herb.yml version is 0.9.2. 4 new rules are disabled to ease upgrades:
+  Your .herb.yml version is 0.9.2. 5 new rules are disabled to ease upgrades:
 
+  actionview-no-unnecessary-tag-attributes (introduced in next release)
   actionview-no-void-element-content (introduced in next release)
   actionview-strict-locals-partial-only (introduced in next release)
   html-require-script-nonce (introduced in next release)

--- a/javascript/packages/linter/test/rules/actionview-no-unnecessary-tag-attributes.test.ts
+++ b/javascript/packages/linter/test/rules/actionview-no-unnecessary-tag-attributes.test.ts
@@ -1,0 +1,100 @@
+import dedent from "dedent"
+
+import { describe, test } from "vitest"
+
+import { ActionViewNoUnnecessaryTagAttributesRule } from "../../src/rules/actionview-no-unnecessary-tag-attributes.js"
+import { createLinterTest } from "../helpers/linter-test-helper.js"
+
+const { expectNoOffenses, expectWarning, assertOffenses } = createLinterTest(ActionViewNoUnnecessaryTagAttributesRule)
+
+describe("ActionViewNoUnnecessaryTagAttributesRule", () => {
+  test("regular HTML input with attributes is allowed", () => {
+    expectNoOffenses(dedent`
+      <input type="text" aria-label="Search">
+    `)
+  })
+
+  test("tag helper for input is allowed", () => {
+    expectNoOffenses(dedent`
+      <%= tag.input type: :text, aria: { label: "Search" } %>
+    `)
+  })
+
+  test("regular HTML div with attributes is allowed", () => {
+    expectNoOffenses(dedent`
+      <div id="container" class="wrapper">
+        Content
+      </div>
+    `)
+  })
+
+  test("tag helper for div is allowed", () => {
+    expectNoOffenses(dedent`
+      <%= tag.div id: "container", class: "wrapper" do %>
+        Content
+      <% end %>
+    `)
+  })
+
+  test("regular HTML img with attributes is allowed", () => {
+    expectNoOffenses(dedent`
+      <img src="logo.png" alt="Logo">
+    `)
+  })
+
+  test("tag helper for img is allowed", () => {
+    expectNoOffenses(dedent`
+      <%= tag.img src: "logo.png", alt: "Logo" %>
+    `)
+  })
+
+  test("element with no attributes is allowed", () => {
+    expectNoOffenses(dedent`
+      <div>Content</div>
+    `)
+  })
+
+  test("mixed HTML and tag.attributes attributes is allowed", () => {
+    expectNoOffenses(dedent`
+      <button class="primary" <%= tag.attributes(id: "call-to-action", disabled: false, aria: { expanded: false }) %>>Get Started!</button>
+    `)
+  })
+
+  test("HTML attribute before tag.attributes is allowed", () => {
+    expectNoOffenses(dedent`
+      <button class="primary" <%= tag.attributes(id: "call-to-action", disabled: false, aria: { expanded: false }) %>>Get Started!</button>
+    `)
+  })
+
+  test("HTML attribute after tag.attributes is allowed", () => {
+    expectNoOffenses(dedent`
+      <button <%= tag.attributes(id: "call-to-action", disabled: false, aria: { expanded: false }) %> class="primary">Get Started!</button>
+    `)
+  })
+
+  test("input with only tag.attributes is not allowed", () => {
+    expectWarning("Avoid using `tag.attributes` to set all attributes on `<input>`. Use `tag.input` or add the attributes directly to the `<input>` tag instead.")
+
+    assertOffenses(dedent`
+      <input <%= tag.attributes(type: :text, aria: { label: "Search" }) %>>
+    `)
+  })
+
+  test("div with only tag.attributes is not allowed", () => {
+    expectWarning("Avoid using `tag.attributes` to set all attributes on `<div>`. Use `tag.div` or add the attributes directly to the `<div>` tag instead.")
+
+    assertOffenses(dedent`
+      <div <%= tag.attributes(id: "container", class: "wrapper") %>>
+        Content
+      </div>
+    `)
+  })
+
+  test("img with only tag.attributes is not allowed", () => {
+    expectWarning("Avoid using `tag.attributes` to set all attributes on `<img>`. Use `tag.img` or add the attributes directly to the `<img>` tag instead.")
+
+    assertOffenses(dedent`
+      <img <%= tag.attributes(src: "logo.png", alt: "Logo") %>>
+    `)
+  })
+})


### PR DESCRIPTION
Resolves #1458