### PR TITLE
Linter: Implement `actionview-no-unnecessary-tag-attributes` autofix

### DIFF
--- a/javascript/packages/linter/src/rules/actionview-no-unnecessary-tag-attributes.ts
+++ b/javascript/packages/linter/src/rules/actionview-no-unnecessary-tag-attributes.ts
@@ -1,16 +1,22 @@
-import { ParserRule } from "../types.js"
-import { BaseRuleVisitor } from "./rule-utils.js"
-import { getTagLocalName, isHTMLOpenTagNode, isERBContentNode, isERBOutputNode, isHTMLAttributeNode, isWhitespaceNode } from "@herb-tools/core"
+import { ParserRule, BaseAutofixContext, Mutable } from "../types.js"
+import { BaseRuleVisitor, findParent } from "./rule-utils.js"
+import { getTagLocalName, isHTMLOpenTagNode, isERBContentNode, isERBOutputNode, isHTMLAttributeNode, isWhitespaceNode, isHTMLElementNode, Location, ERBContentNode, createSyntheticToken } from "@herb-tools/core"
 
-import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types.js"
-import type { ParseResult, HTMLElementNode, HTMLOpenTagNode, ParserOptions, PrismNode } from "@herb-tools/core"
+import type { UnboundLintOffense, LintContext, LintOffense, FullRuleConfig } from "../types.js"
+import type { ParseResult, HTMLElementNode, HTMLOpenTagNode, ParserOptions, PrismNode, Node } from "@herb-tools/core"
 
-function isTagAttributesCall(node: PrismNode): boolean {
-  if (node?.constructor?.name !== "CallNode") return false
-  if (node.name !== "attributes") return false
-  if (node.receiver?.constructor?.name !== "CallNode") return false
+interface UnnecessaryTagAttributesAutofixContext extends BaseAutofixContext {
+  node: Mutable<HTMLOpenTagNode>
+  tagName: string
+  isVoid: boolean
+}
 
-  return node.receiver.name === "tag"
+function isTagAttributesCall(prismNode: PrismNode): boolean {
+  if (prismNode?.constructor?.name !== "CallNode") return false
+  if (prismNode.name !== "attributes") return false
+  if (prismNode.receiver?.constructor?.name !== "CallNode") return false
+
+  return prismNode.receiver.name === "tag"
 }
 
 function hasOnlyTagAttributesChildren(openTag: HTMLOpenTagNode): boolean {
@@ -20,14 +26,59 @@ function hasOnlyTagAttributesChildren(openTag: HTMLOpenTagNode): boolean {
   if (nonWhitespaceChildren.some(isHTMLAttributeNode)) return false
 
   return nonWhitespaceChildren.every(child => {
-    if (!isERBContentNode(child) || !isERBOutputNode(child)) return false
+    if (!isERBContentNode(child)) return false
+    if (!isERBOutputNode(child)) return false
     if (!child.prismNode) return false
 
     return isTagAttributesCall(child.prismNode)
   })
 }
 
-class ActionViewNoUnnecessaryTagAttributesVisitor extends BaseRuleVisitor {
+function extractTagAttributesArguments(openTag: HTMLOpenTagNode | Mutable<HTMLOpenTagNode>): string | null {
+  const erbNode = (openTag.children as Node[]).find(child => isERBContentNode(child) && isERBOutputNode(child))
+
+  if (!erbNode || !isERBContentNode(erbNode)) return null
+
+  const content = erbNode.content?.value?.trim()
+
+  if (!content) return null
+
+  const match = content.match(/^tag\.attributes\((.+)\)$/)
+
+  if (!match) return null
+
+  return match[1]
+}
+
+function createERBOutputNode(content: string): ERBContentNode {
+  return new ERBContentNode({
+    type: "AST_ERB_CONTENT_NODE",
+    location: Location.zero,
+    errors: [],
+    tag_opening: createSyntheticToken("<%="),
+    content: createSyntheticToken(content),
+    tag_closing: createSyntheticToken("%>"),
+    parsed: false,
+    valid: true,
+    prism_node: null,
+  })
+}
+
+function createERBSilentNode(content: string): ERBContentNode {
+  return new ERBContentNode({
+    type: "AST_ERB_CONTENT_NODE",
+    location: Location.zero,
+    errors: [],
+    tag_opening: createSyntheticToken("<%"),
+    content: createSyntheticToken(content),
+    tag_closing: createSyntheticToken("%>"),
+    parsed: false,
+    valid: true,
+    prism_node: null,
+  })
+}
+
+class ActionViewNoUnnecessaryTagAttributesVisitor extends BaseRuleVisitor<UnnecessaryTagAttributesAutofixContext> {
   visitHTMLElementNode(node: HTMLElementNode): void {
     this.checkUnnecessaryTagAttributes(node)
     super.visitHTMLElementNode(node)
@@ -44,11 +95,17 @@ class ActionViewNoUnnecessaryTagAttributesVisitor extends BaseRuleVisitor {
     this.addOffense(
       `Avoid using \`tag.attributes\` to set all attributes on \`<${tagName}>\`. Use \`tag.${tagName}\` or add the attributes directly to the \`<${tagName}>\` tag instead.`,
       node.open_tag.location,
+      {
+        node: node.open_tag,
+        tagName,
+        isVoid: node.is_void,
+      },
     )
   }
 }
 
-export class ActionViewNoUnnecessaryTagAttributesRule extends ParserRule {
+export class ActionViewNoUnnecessaryTagAttributesRule extends ParserRule<UnnecessaryTagAttributesAutofixContext> {
+  static autocorrectable = true
   static ruleName = "actionview-no-unnecessary-tag-attributes"
   static introducedIn = this.version("unreleased")
 
@@ -65,11 +122,47 @@ export class ActionViewNoUnnecessaryTagAttributesRule extends ParserRule {
     }
   }
 
-  check(result: ParseResult, context?: Partial<LintContext>): UnboundLintOffense[] {
+  check(result: ParseResult, context?: Partial<LintContext>): UnboundLintOffense<UnnecessaryTagAttributesAutofixContext>[] {
     const visitor = new ActionViewNoUnnecessaryTagAttributesVisitor(this.ruleName, context)
 
     visitor.visit(result.value)
 
     return visitor.offenses
+  }
+
+  autofix(offense: LintOffense<UnnecessaryTagAttributesAutofixContext>, result: ParseResult): ParseResult | null {
+    if (!offense.autofixContext) return null
+
+    const { node: openTag, tagName, isVoid } = offense.autofixContext
+    const tagAttributesArguments = extractTagAttributesArguments(openTag)
+
+    if (!tagAttributesArguments) return null
+
+    const element = findParent(result.value, openTag as unknown as Node)
+    if (!element || !isHTMLElementNode(element)) return null
+
+    const grandparent = findParent(result.value, element) as Mutable<Node> | null
+    if (!grandparent) return null
+
+    const parentChildren = (grandparent as any).children ?? (grandparent as any).body
+    if (!Array.isArray(parentChildren)) return null
+
+    const elementIndex = parentChildren.indexOf(element)
+    if (elementIndex === -1) return null
+
+    const hasBody = element.body && element.body.length > 0
+
+    if (isVoid || !hasBody) {
+      const erbNode = createERBOutputNode(` tag.${tagName}(${tagAttributesArguments}) `)
+      parentChildren.splice(elementIndex, 1, erbNode)
+    } else {
+      const erbOpenNode = createERBOutputNode(` tag.${tagName}(${tagAttributesArguments}) do `)
+      const erbEndNode = createERBSilentNode(` end `)
+      const replacementNodes: Node[] = [erbOpenNode, ...element.body, erbEndNode]
+
+      parentChildren.splice(elementIndex, 1, ...replacementNodes)
+    }
+
+    return result
   }
 }

--- a/javascript/packages/linter/test/autofix/actionview-no-unnecessary-tag-attributes.autofix.test.ts
+++ b/javascript/packages/linter/test/autofix/actionview-no-unnecessary-tag-attributes.autofix.test.ts
@@ -1,0 +1,103 @@
+import dedent from "dedent"
+import { describe, test, expect, beforeAll } from "vitest"
+import { Herb } from "@herb-tools/node-wasm"
+import { Linter } from "../../src/linter.js"
+import { ActionViewNoUnnecessaryTagAttributesRule } from "../../src/rules/actionview-no-unnecessary-tag-attributes.js"
+
+describe("actionview-no-unnecessary-tag-attributes autofix", () => {
+  beforeAll(async () => {
+    await Herb.load()
+  })
+
+  test("converts void element with tag.attributes to tag helper", () => {
+    const input = `<input <%= tag.attributes(type: :text, aria: { label: "Search" }) %>>`
+    const expected = `<%= tag.input(type: :text, aria: { label: "Search" }) %>`
+
+    const linter = new Linter(Herb, [ActionViewNoUnnecessaryTagAttributesRule])
+    const result = linter.autofix(input)
+
+    expect(result.source).toBe(expected)
+    expect(result.fixed).toHaveLength(1)
+    expect(result.unfixed).toHaveLength(0)
+  })
+
+  test("converts img with tag.attributes to tag helper", () => {
+    const input = `<img <%= tag.attributes(src: image_path("logo.png"), alt: "Logo") %>>`
+    const expected = `<%= tag.img(src: image_path("logo.png"), alt: "Logo") %>`
+
+    const linter = new Linter(Herb, [ActionViewNoUnnecessaryTagAttributesRule])
+    const result = linter.autofix(input)
+
+    expect(result.source).toBe(expected)
+    expect(result.fixed).toHaveLength(1)
+    expect(result.unfixed).toHaveLength(0)
+  })
+
+  test("converts non-void element with tag.attributes to tag helper with do/end", () => {
+    const input = dedent`
+      <div <%= tag.attributes(id: "container", class: "wrapper") %>>
+        Content
+      </div>
+    `
+
+    const expected = dedent`
+      <%= tag.div(id: "container", class: "wrapper") do %>
+        Content
+      <% end %>
+    `
+
+    const linter = new Linter(Herb, [ActionViewNoUnnecessaryTagAttributesRule])
+    const result = linter.autofix(input)
+
+    expect(result.source).toBe(expected)
+    expect(result.fixed).toHaveLength(1)
+    expect(result.unfixed).toHaveLength(0)
+  })
+
+  test("converts non-void element with no content to tag helper", () => {
+    const input = `<div <%= tag.attributes(id: "container", class: "wrapper") %>></div>`
+    const expected = `<%= tag.div(id: "container", class: "wrapper") %>`
+
+    const linter = new Linter(Herb, [ActionViewNoUnnecessaryTagAttributesRule])
+    const result = linter.autofix(input)
+
+    expect(result.source).toBe(expected)
+    expect(result.fixed).toHaveLength(1)
+    expect(result.unfixed).toHaveLength(0)
+  })
+
+  test("converts non-void element with whitespace-only content to tag helper with do/end", () => {
+    const input = `<div <%= tag.attributes(id: "container", class: "wrapper") %>>   </div>`
+    const expected = `<%= tag.div(id: "container", class: "wrapper") do %>   <% end %>`
+
+    const linter = new Linter(Herb, [ActionViewNoUnnecessaryTagAttributesRule])
+    const result = linter.autofix(input)
+
+    expect(result.source).toBe(expected)
+    expect(result.fixed).toHaveLength(1)
+    expect(result.unfixed).toHaveLength(0)
+  })
+
+  test("converts void element with single attribute to tag helper", () => {
+    const input = `<br <%= tag.attributes(class: "spacer") %>>`
+    const expected = `<%= tag.br(class: "spacer") %>`
+
+    const linter = new Linter(Herb, [ActionViewNoUnnecessaryTagAttributesRule])
+    const result = linter.autofix(input)
+
+    expect(result.source).toBe(expected)
+    expect(result.fixed).toHaveLength(1)
+    expect(result.unfixed).toHaveLength(0)
+  })
+
+  test("does not autofix when tag.attributes is mixed with HTML attributes", () => {
+    const input = `<button class="primary" <%= tag.attributes(id: "cta") %>>Click</button>`
+
+    const linter = new Linter(Herb, [ActionViewNoUnnecessaryTagAttributesRule])
+    const result = linter.autofix(input)
+
+    expect(result.source).toBe(input)
+    expect(result.fixed).toHaveLength(0)
+    expect(result.unfixed).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
This pull request implements an autofix for the `actionview-no-unnecessary-tag-attributes` linter rule introduced in #1479.

The following:

```erb
<input <%= tag.attributes(type: :text, aria: { label: "Search" }) %>>
```

can now be autofixed to:
```erb
<%= tag.input(type: :text, aria: { label: "Search" }) %>
```