### PR TITLE
Linter: Make `no-output-in-attribute-position` `tag.attributes` aware

### DIFF
--- a/javascript/packages/linter/src/rules/action-view-utils.ts
+++ b/javascript/packages/linter/src/rules/action-view-utils.ts
@@ -1,0 +1,39 @@
+import type { PrismNode } from "@herb-tools/core"
+
+/**
+ * Checks if a Prism node represents a `tag.attributes(...)` call.
+ */
+export function isTagAttributesCall(prismNode: PrismNode): boolean {
+  if (prismNode?.constructor?.name !== "CallNode") return false
+  if (prismNode.name !== "attributes") return false
+  if (prismNode.receiver?.constructor?.name !== "CallNode") return false
+
+  return prismNode.receiver.name === "tag"
+}
+
+/**
+ * Checks if a Prism node wraps a `tag.attributes(...)` call in a conditional or logical expression.
+ * Matches patterns like:
+ * - `tag.attributes(...) if condition`
+ * - `tag.attributes(...) unless condition`
+ * - `condition ? tag.attributes(...) : tag.attributes(...)`
+ * - `condition && tag.attributes(...)`
+ * - `condition || tag.attributes(...)`
+ */
+export function isConditionalTagAttributesCall(prismNode: PrismNode): boolean {
+  const type = prismNode?.constructor?.name
+
+  if (type === "IfNode" || type === "UnlessNode") {
+    const body = prismNode.statements?.body
+
+    if (!Array.isArray(body) || body.length !== 1) return false
+
+    return isTagAttributesCall(body[0])
+  }
+
+  if (type === "AndNode" || type === "OrNode") {
+    return isTagAttributesCall(prismNode.right)
+  }
+
+  return false
+}

--- a/javascript/packages/linter/src/rules/actionview-no-unnecessary-tag-attributes.ts
+++ b/javascript/packages/linter/src/rules/actionview-no-unnecessary-tag-attributes.ts
@@ -1,22 +1,15 @@
 import { ParserRule, BaseAutofixContext, Mutable } from "../types.js"
 import { BaseRuleVisitor, findParent } from "./rule-utils.js"
+import { isTagAttributesCall } from "./action-view-utils.js"
 import { getTagLocalName, isHTMLOpenTagNode, isERBContentNode, isERBOutputNode, isHTMLAttributeNode, isWhitespaceNode, isHTMLElementNode, Location, ERBContentNode, createSyntheticToken } from "@herb-tools/core"
 
 import type { UnboundLintOffense, LintContext, LintOffense, FullRuleConfig } from "../types.js"
-import type { ParseResult, HTMLElementNode, HTMLOpenTagNode, ParserOptions, PrismNode, Node } from "@herb-tools/core"
+import type { ParseResult, HTMLElementNode, HTMLOpenTagNode, ParserOptions, Node } from "@herb-tools/core"
 
 interface UnnecessaryTagAttributesAutofixContext extends BaseAutofixContext {
   node: Mutable<HTMLOpenTagNode>
   tagName: string
   isVoid: boolean
-}
-
-function isTagAttributesCall(prismNode: PrismNode): boolean {
-  if (prismNode?.constructor?.name !== "CallNode") return false
-  if (prismNode.name !== "attributes") return false
-  if (prismNode.receiver?.constructor?.name !== "CallNode") return false
-
-  return prismNode.receiver.name === "tag"
 }
 
 function hasOnlyTagAttributesChildren(openTag: HTMLOpenTagNode): boolean {

--- a/javascript/packages/linter/src/rules/erb-no-output-in-attribute-position.ts
+++ b/javascript/packages/linter/src/rules/erb-no-output-in-attribute-position.ts
@@ -1,15 +1,29 @@
 import { ParserRule } from "../types.js"
 import { BaseRuleVisitor } from "./rule-utils.js"
-import { isERBNode, isERBOutputNode } from "@herb-tools/core"
+import { isTagAttributesCall, isConditionalTagAttributesCall } from "./action-view-utils.js"
+import { isERBNode, isERBOutputNode, isERBContentNode } from "@herb-tools/core"
 
 import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types.js"
-import type { ParseResult, HTMLOpenTagNode } from "@herb-tools/core"
+import type { ParseResult, HTMLOpenTagNode, ParserOptions } from "@herb-tools/core"
 
 class ERBNoOutputInAttributePositionVisitor extends BaseRuleVisitor {
   visitHTMLOpenTagNode(node: HTMLOpenTagNode): void {
     for (const child of node.children) {
       if (!isERBNode(child)) continue
       if (!isERBOutputNode(child)) continue
+      if (!isERBContentNode(child)) continue
+
+      const prismNode = child.prismNode
+      if (prismNode && isTagAttributesCall(prismNode)) continue
+
+      if (prismNode && isConditionalTagAttributesCall(prismNode)) {
+        this.addOffense(
+          "Avoid using conditional `tag.attributes` in attribute position. Use `<% if ... %><%= tag.attributes(...) %><% end %>` instead.",
+          child.location,
+        )
+
+        continue
+      }
 
       this.addOffense(
         "Avoid `<%= %>` in attribute position. Use `<% if ... %>` with static attributes instead.",
@@ -29,6 +43,12 @@ export class ERBNoOutputInAttributePositionRule extends ParserRule {
     return {
       enabled: true,
       severity: "error"
+    }
+  }
+
+  get parserOptions(): Partial<ParserOptions> {
+    return {
+      prism_nodes: true,
     }
   }
 

--- a/javascript/packages/linter/src/rules/index.ts
+++ b/javascript/packages/linter/src/rules/index.ts
@@ -1,6 +1,7 @@
 export * from "./rule-utils.js"
 export * from "./file-utils.js"
 export * from "./string-utils.js"
+export * from "./action-view-utils.js"
 export * from "./herb-disable-comment-base.js"
 
 export * from "./actionview-no-silent-helper.js"

--- a/javascript/packages/linter/test/rules/erb-no-output-in-attribute-position.test.ts
+++ b/javascript/packages/linter/test/rules/erb-no-output-in-attribute-position.test.ts
@@ -8,6 +8,7 @@ import { createLinterTest } from "../helpers/linter-test-helper.js"
 const { expectNoOffenses, expectError, assertOffenses } = createLinterTest(ERBNoOutputInAttributePositionRule)
 
 const MESSAGE = "Avoid `<%= %>` in attribute position. Use `<% if ... %>` with static attributes instead."
+const CONDITIONAL_MESSAGE = "Avoid using conditional `tag.attributes` in attribute position. Use `<% if ... %><%= tag.attributes(...) %><% end %>` instead."
 
 describe("ERBNoOutputInAttributePositionRule", () => {
   describe("not allowed", () => {
@@ -35,6 +36,78 @@ describe("ERBNoOutputInAttributePositionRule", () => {
         <div <%= first_attrs %> <%= second_attrs %>></div>
       `)
     })
+
+    test("tag.div in attribute position is not allowed", () => {
+      expectError(MESSAGE)
+
+      assertOffenses(dedent`
+        <div <%= tag.div %>>Content</div>
+      `)
+    })
+
+    test("tag.attributes with trailing non-tag.attributes expression is not allowed", () => {
+      expectError(MESSAGE)
+
+      assertOffenses(dedent`
+        <div <%= tag.attributes(id: "main") && "extra" %>></div>
+      `)
+    })
+
+    test("tag.attributes inside string interpolation is not allowed", () => {
+      expectError(MESSAGE)
+
+      assertOffenses(dedent`
+        <div <%= "#{output} #{tag.attributes(id: "main")}" %>></div>
+      `)
+    })
+
+    test("other tag helper in attribute position is not allowed", () => {
+      expectError(MESSAGE)
+
+      assertOffenses(dedent`
+        <div <%= tag.attributes_for(:div) %>></div>
+      `)
+    })
+
+    test("tag.attributes with inline if is not allowed", () => {
+      expectError(CONDITIONAL_MESSAGE)
+
+      assertOffenses(dedent`
+        <div <%= tag.attributes(id: "main") if condition %>></div>
+      `)
+    })
+
+    test("tag.attributes with inline unless is not allowed", () => {
+      expectError(CONDITIONAL_MESSAGE)
+
+      assertOffenses(dedent`
+        <div <%= tag.attributes(id: "main") unless disabled %>></div>
+      `)
+    })
+
+    test("tag.attributes with ternary is not allowed", () => {
+      expectError(CONDITIONAL_MESSAGE)
+
+      assertOffenses(dedent`
+        <div <%= condition ? tag.attributes(id: "a") : tag.attributes(id: "b") %>></div>
+      `)
+    })
+
+    test("tag.attributes with && operator is not allowed", () => {
+      expectError(CONDITIONAL_MESSAGE)
+
+      assertOffenses(dedent`
+        <div <%= condition && tag.attributes(id: "main") %>></div>
+      `)
+    })
+
+    test("tag.attributes with || operator is not allowed", () => {
+      expectError(CONDITIONAL_MESSAGE)
+
+      assertOffenses(dedent`
+        <div <%= tag.attributes(id: "a") || tag.attributes(id: "b") %>></div>
+      `)
+    })
   })
 
   describe("allowed", () => {
@@ -58,6 +131,18 @@ describe("ERBNoOutputInAttributePositionRule", () => {
       expectNoOffenses(dedent`
         <div <% if active? %>class="active"<% end %>></div>
         <input <% unless disabled %>enabled<% end %>>
+      `)
+    })
+
+    test("tag.attributes in attribute position", () => {
+      expectNoOffenses(dedent`
+        <input <%= tag.attributes(type: :text, aria: { label: "Search" }) %>>
+      `)
+    })
+
+    test("tag.attributes mixed with HTML attributes", () => {
+      expectNoOffenses(dedent`
+        <button class="primary" <%= tag.attributes(id: "cta", aria: { expanded: false }) %>>Click</button>
       `)
     })
   })


### PR DESCRIPTION
Using the detection of `tag.attributes` in https://github.com/marcoroth/herb/pull/1461 we can now make the `erb-no-output-in-attribute-position` linter rule aware of `<%= tag.attributes(...) %>` and allow them as "safe" in attribute positions.

The following is now not flagged by the `erb-no-output-in-attribute-position` liner rule anymore:

```erb
 <input <%= tag.attributes(type: :text, aria: { label: "Search" }) %>>
```

Partially solves https://github.com/marcoroth/herb/issues/1459
