### PR TITLE
Parser: Fix infinite loop when parsing unclosed ERB tags

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -890,7 +890,7 @@ static void parser_skip_erb_content(lexer_T* lexer) {
   do {
     token = lexer_next_token(lexer);
 
-    if (token->type == TOKEN_ERB_END) {
+    if (token->type == TOKEN_ERB_END || token->type == TOKEN_EOF) {
       token_free(token, lexer->allocator);
       break;
     }
@@ -904,6 +904,11 @@ static bool parser_lookahead_erb_is_attribute(lexer_T* lexer) {
 
   do {
     after = lexer_next_token(lexer);
+
+    if (after->type == TOKEN_EOF) {
+      token_free(after, lexer->allocator);
+      return false;
+    }
 
     if (after->type == TOKEN_EQUALS) {
       token_free(after, lexer->allocator);

--- a/test/parser/error_recovery_test.rb
+++ b/test/parser/error_recovery_test.rb
@@ -120,5 +120,13 @@ module Parser
         </div>
       HTML
     end
+
+    test "unclosed ERB tag in attribute position at EOF" do
+      assert_parsed_snapshot(%(<input <%= tag.attributes(type: :text) %))
+    end
+
+    test "unclosed HTML tag after ERB tag in attribute position at EOF" do
+      assert_parsed_snapshot(%(<input <%= tag.attributes(type: :text) %>))
+    end
   end
 end

--- a/test/snapshots/parser/error_recovery_test/test_0012_unclosed_ERB_tag_in_attribute_position_at_EOF_with_action_view_helpers_b478cd926ce19e543b598a89bd82c5c2-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/parser/error_recovery_test/test_0012_unclosed_ERB_tag_in_attribute_position_at_EOF_with_action_view_helpers_b478cd926ce19e543b598a89bd82c5c2-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,43 @@
+---
+source: "Parser::ErrorRecoveryTest#test_0012_unclosed ERB tag in attribute position at EOF with action_view_helpers"
+input: "<input <%= tag.attributes(type: :text) %"
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(1:40))
+├── errors: (2 errors)
+│   ├── @ RubyParseError (location: (1:40)-(1:40))
+│   │   ├── message: "expect_expression_after_operator: unexpected end-of-input; expected an expression after the operator"
+│   │   ├── error_message: "unexpected end-of-input; expected an expression after the operator"
+│   │   ├── diagnostic_id: "expect_expression_after_operator"
+│   │   └── level: "syntax"
+│   │
+│   └── @ RubyParseError (location: (1:40)-(1:40))
+│       ├── message: "unexpected_token_close_context: unexpected end-of-input, assuming it is closing the parent top level context"
+│       ├── error_message: "unexpected end-of-input, assuming it is closing the parent top level context"
+│       ├── diagnostic_id: "unexpected_token_close_context"
+│       └── level: "syntax"
+│
+└── children: (1 item)
+    └── @ HTMLOpenTagNode (location: (1:0)-(1:40))
+        ├── errors: (1 error)
+        │   └── @ UnclosedOpenTagError (location: (1:1)-(1:40))
+        │       ├── message: "Opening tag `<input>` at (1:1) is missing closing `>`."
+        │       └── tag_name: "input" (location: (1:1)-(1:6))
+        │
+        ├── tag_opening: "<" (location: (1:0)-(1:1))
+        ├── tag_name: "input" (location: (1:1)-(1:6))
+        ├── tag_closing: ∅
+        ├── children: (1 item)
+        │   └── @ ERBContentNode (location: (1:7)-(1:40))
+        │       ├── errors: (1 error)
+        │       │   └── @ UnclosedERBTagError (location: (1:7)-(1:40))
+        │       │       ├── message: "ERB tag `<%=` at (1:7) is missing closing `%>`."
+        │       │       └── opening_tag: "<%=" (location: (1:7)-(1:10))
+        │       │
+        │       ├── tag_opening: "<%=" (location: (1:7)-(1:10))
+        │       ├── content: " tag.attributes(type: :text) %" (location: (1:10)-(1:40))
+        │       ├── tag_closing: ∅
+        │       ├── parsed: true
+        │       └── valid: false
+        │
+        └── is_void: false

--- a/test/snapshots/parser/error_recovery_test/test_0021_unclosed_ERB_tag_in_attribute_position_at_EOF_b478cd926ce19e543b598a89bd82c5c2.txt
+++ b/test/snapshots/parser/error_recovery_test/test_0021_unclosed_ERB_tag_in_attribute_position_at_EOF_b478cd926ce19e543b598a89bd82c5c2.txt
@@ -1,0 +1,42 @@
+---
+source: "Parser::ErrorRecoveryTest#test_0021_unclosed ERB tag in attribute position at EOF"
+input: "<input <%= tag.attributes(type: :text) %"
+---
+@ DocumentNode (location: (1:0)-(1:40))
+├── errors: (2 errors)
+│   ├── @ RubyParseError (location: (1:40)-(1:40))
+│   │   ├── message: "expect_expression_after_operator: unexpected end-of-input; expected an expression after the operator"
+│   │   ├── error_message: "unexpected end-of-input; expected an expression after the operator"
+│   │   ├── diagnostic_id: "expect_expression_after_operator"
+│   │   └── level: "syntax"
+│   │
+│   └── @ RubyParseError (location: (1:40)-(1:40))
+│       ├── message: "unexpected_token_close_context: unexpected end-of-input, assuming it is closing the parent top level context"
+│       ├── error_message: "unexpected end-of-input, assuming it is closing the parent top level context"
+│       ├── diagnostic_id: "unexpected_token_close_context"
+│       └── level: "syntax"
+│
+└── children: (1 item)
+    └── @ HTMLOpenTagNode (location: (1:0)-(1:40))
+        ├── errors: (1 error)
+        │   └── @ UnclosedOpenTagError (location: (1:1)-(1:40))
+        │       ├── message: "Opening tag `<input>` at (1:1) is missing closing `>`."
+        │       └── tag_name: "input" (location: (1:1)-(1:6))
+        │
+        ├── tag_opening: "<" (location: (1:0)-(1:1))
+        ├── tag_name: "input" (location: (1:1)-(1:6))
+        ├── tag_closing: ∅
+        ├── children: (1 item)
+        │   └── @ ERBContentNode (location: (1:7)-(1:40))
+        │       ├── errors: (1 error)
+        │       │   └── @ UnclosedERBTagError (location: (1:7)-(1:40))
+        │       │       ├── message: "ERB tag `<%=` at (1:7) is missing closing `%>`."
+        │       │       └── opening_tag: "<%=" (location: (1:7)-(1:10))
+        │       │
+        │       ├── tag_opening: "<%=" (location: (1:7)-(1:10))
+        │       ├── content: " tag.attributes(type: :text) %" (location: (1:10)-(1:40))
+        │       ├── tag_closing: ∅
+        │       ├── parsed: true
+        │       └── valid: false
+        │
+        └── is_void: false

--- a/test/snapshots/parser/error_recovery_test/test_0022_unclosed_HTML_tag_after_ERB_tag_in_attribute_position_at_EOF_666e92f95b3484e27f47265c944313a8.txt
+++ b/test/snapshots/parser/error_recovery_test/test_0022_unclosed_HTML_tag_after_ERB_tag_in_attribute_position_at_EOF_666e92f95b3484e27f47265c944313a8.txt
@@ -1,0 +1,24 @@
+---
+source: "Parser::ErrorRecoveryTest#test_0022_unclosed HTML tag after ERB tag in attribute position at EOF"
+input: "<input <%= tag.attributes(type: :text) %>"
+---
+@ DocumentNode (location: (1:0)-(1:41))
+└── children: (1 item)
+    └── @ HTMLOpenTagNode (location: (1:0)-(1:41))
+        ├── errors: (1 error)
+        │   └── @ UnclosedOpenTagError (location: (1:1)-(1:41))
+        │       ├── message: "Opening tag `<input>` at (1:1) is missing closing `>`."
+        │       └── tag_name: "input" (location: (1:1)-(1:6))
+        │
+        ├── tag_opening: "<" (location: (1:0)-(1:1))
+        ├── tag_name: "input" (location: (1:1)-(1:6))
+        ├── tag_closing: ∅
+        ├── children: (1 item)
+        │   └── @ ERBContentNode (location: (1:7)-(1:41))
+        │       ├── tag_opening: "<%=" (location: (1:7)-(1:10))
+        │       ├── content: " tag.attributes(type: :text) " (location: (1:10)-(1:39))
+        │       ├── tag_closing: "%>" (location: (1:39)-(1:41))
+        │       ├── parsed: true
+        │       └── valid: true
+        │
+        └── is_void: false


### PR DESCRIPTION
This pull request fixes a bug in the parser where the parser would stall and run into an infinite loop when trying to parser a document like:

```erb
<input <%= tag.attributes(type: :text) %
```