### PR TITLE
Engine: Allow `tag.attributes` in `SecurityValidator`

### DIFF
--- a/lib/herb.rb
+++ b/lib/herb.rb
@@ -17,6 +17,7 @@ require_relative "herb/parse_result"
 require_relative "herb/ast"
 require_relative "herb/ast/node"
 require_relative "herb/ast/nodes"
+require_relative "herb/ast/erb_content_node"
 require_relative "herb/ast/helpers"
 
 require_relative "herb/errors"

--- a/lib/herb/ast/erb_content_node.rb
+++ b/lib/herb/ast/erb_content_node.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+# typed: true
+
+module Herb
+  module AST
+    class ERBContentNode < Node
+      #: () -> Prism::node?
+      def parsed_prism_node
+        erb_content = @content&.value&.strip
+        return nil unless erb_content
+
+        begin
+          require "prism"
+        rescue LoadError
+          return nil
+        end
+
+        prism_result = Prism.parse(erb_content)
+        return nil unless prism_result.success?
+
+        prism_result.value.statements.body.first
+      end
+
+      #: () -> Prism::node?
+      def prism
+        return @prism if defined?(@prism)
+
+        @prism = deserialized_prism_node || parsed_prism_node
+      end
+    end
+  end
+end

--- a/lib/herb/engine/validators/security_validator.rb
+++ b/lib/herb/engine/validators/security_validator.rb
@@ -28,6 +28,20 @@ module Herb
 
             next unless child.is_a?(Herb::AST::ERBContentNode) && erb_outputs?(child)
 
+            prism_node = child.prism
+
+            next if prism_node && tag_attributes_prism_node?(prism_node)
+
+            if prism_node && conditional_tag_attributes_prism_node?(prism_node)
+              add_security_error(
+                child.location,
+                "Avoid using conditional `tag.attributes` in attribute position.",
+                "Use `<% if ... %><%= tag.attributes(...) %><% end %>` instead."
+              )
+
+              next
+            end
+
             add_security_error(
               child.location,
               "ERB output tags (<%= %>) are not allowed in attribute position.",
@@ -46,6 +60,32 @@ module Herb
               "Use static attribute names with dynamic values instead."
             )
           end
+        end
+
+        def tag_attributes_prism_node?(prism_node)
+          return false unless prism_node.is_a?(Prism::CallNode)
+          return false unless prism_node.name == :attributes
+
+          receiver = prism_node.receiver
+          return false unless receiver.is_a?(Prism::CallNode)
+
+          receiver.name == :tag
+        end
+
+        def conditional_tag_attributes_prism_node?(prism_node)
+          if prism_node.is_a?(Prism::IfNode) || prism_node.is_a?(Prism::UnlessNode)
+            body = prism_node.statements&.body
+            return false unless body
+            return false unless body.length == 1
+
+            return tag_attributes_prism_node?(body.first)
+          end
+
+          if prism_node.is_a?(Prism::AndNode) || prism_node.is_a?(Prism::OrNode)
+            return tag_attributes_prism_node?(prism_node.right)
+          end
+
+          false
         end
 
         def add_security_error(location, message, suggestion)

--- a/sig/herb/ast/erb_content_node.rbs
+++ b/sig/herb/ast/erb_content_node.rbs
@@ -1,0 +1,13 @@
+# Generated from lib/herb/ast/erb_content_node.rb with RBS::Inline
+
+module Herb
+  module AST
+    class ERBContentNode < Node
+      # : () -> Prism::node?
+      def parsed_prism_node: () -> Prism::node?
+
+      # : () -> Prism::node?
+      def prism: () -> Prism::node?
+    end
+  end
+end

--- a/sig/herb/engine/validators/security_validator.rbs
+++ b/sig/herb/engine/validators/security_validator.rbs
@@ -14,6 +14,10 @@ module Herb
 
         def validate_attribute_name_security: (untyped node) -> untyped
 
+        def tag_attributes_prism_node?: (untyped prism_node) -> untyped
+
+        def conditional_tag_attributes_prism_node?: (untyped prism_node) -> untyped
+
         def add_security_error: (untyped location, untyped message, untyped suggestion) -> untyped
 
         def add_diagnostic: (untyped message, untyped location, untyped severity, ?code: untyped, ?source: untyped, ?suggestion: untyped) -> untyped

--- a/test/engine/secure_compiler_test.rb
+++ b/test/engine/secure_compiler_test.rb
@@ -127,6 +127,61 @@ module Engine
       assert result.is_a?(String)
     end
 
+    test "tag.attributes in attribute position allowed" do
+      template = '<input <%= tag.attributes(type: :text, aria: { label: "Search" }) %>>'
+
+      result = compile_template(template)
+      assert result.is_a?(String)
+    end
+
+    test "tag.attributes mixed with HTML attributes allowed" do
+      template = '<button class="primary" <%= tag.attributes(id: "cta", aria: { expanded: false }) %>>Click</button>'
+
+      result = compile_template(template)
+      assert result.is_a?(String)
+    end
+
+    test "non-tag.attributes erb output in attribute position still blocked" do
+      template = "<div <%= @malicious %>>Content</div>"
+
+      error = assert_raises(Herb::Engine::SecurityError) do
+        compile_template(template)
+      end
+
+      assert_includes error.message, "ERB output tags (<%= %>) are not allowed in attribute position"
+    end
+
+    test "conditional tag.attributes in attribute position blocked" do
+      template = '<div <%= tag.attributes(id: "main") if condition %>></div>'
+
+      error = assert_raises(Herb::Engine::SecurityError) do
+        compile_template(template)
+      end
+
+      assert_includes error.message, "Avoid using conditional `tag.attributes` in attribute position."
+      assert_includes error.suggestion, "Use `<% if ... %><%= tag.attributes(...) %><% end %>` instead."
+    end
+
+    test "tag.attributes with && operator blocked" do
+      template = '<div <%= condition && tag.attributes(id: "main") %>></div>'
+
+      error = assert_raises(Herb::Engine::SecurityError) do
+        compile_template(template)
+      end
+
+      assert_includes error.message, "Avoid using conditional `tag.attributes` in attribute position."
+    end
+
+    test "tag.attributes with ternary blocked" do
+      template = '<div <%= condition ? tag.attributes(id: "a") : tag.attributes(id: "b") %>></div>'
+
+      error = assert_raises(Herb::Engine::SecurityError) do
+        compile_template(template)
+      end
+
+      assert_includes error.message, "Avoid using conditional `tag.attributes` in attribute position."
+    end
+
     test "token optimization basic" do
       template = "<div>Hello</div><span>World</span><p><%= @name %></p>"
       compiled = compile_template(template)


### PR DESCRIPTION
Similar to #1481

Partially solves https://github.com/marcoroth/herb/issues/1459