### PR TITLE
Linter CLI: Improve `--upgrade` to only disable rules with offenses

### DIFF
--- a/javascript/packages/linter/src/cli.ts
+++ b/javascript/packages/linter/src/cli.ts
@@ -192,15 +192,58 @@ export class CLI {
 
       const { skippedByVersion } = Linter.filterRulesByConfig(rules, config.linter?.rules, configVersion)
 
-      const rulesMutation: Record<string, { enabled: boolean }> = {}
+      let rulesToDisable: typeof skippedByVersion = []
+      let rulesToEnable: typeof skippedByVersion = []
+      const ruleOffenseCounts = new Map<string, number>()
 
-      for (const rule of skippedByVersion) {
-        rulesMutation[rule.ruleName] = { enabled: false }
+      if (skippedByVersion.length > 0) {
+        console.log(`\n${colorize("↻", "cyan")} Checking ${colorize(String(skippedByVersion.length), "bold")} new ${skippedByVersion.length === 1 ? "rule" : "rules"} against your codebase...`)
+
+        const skippedRulesConfig: Record<string, { enabled: boolean }> = {}
+
+        for (const rule of skippedByVersion) {
+          skippedRulesConfig[rule.ruleName] = { enabled: true }
+        }
+
+        const upgradeConfig = Config.fromObject({
+          ...config.options,
+          linter: {
+            ...config.options.linter,
+            rules: { ...config.options.linter?.rules, ...skippedRulesConfig }
+          }
+        }, { projectPath: this.projectPath, configVersion: version })
+
+        const upgradeContext: ProcessingContext = {
+          projectPath: this.projectPath,
+          config: upgradeConfig,
+          jobs,
+        }
+
+        await Herb.load()
+
+        const files = await config.findFilesForTool('linter', this.projectPath)
+        const upgradeProcessor = new FileProcessor()
+        const results = await upgradeProcessor.processFiles(files, 'json', upgradeContext)
+
+        for (const [ruleName, data] of results.ruleOffenses) {
+          ruleOffenseCounts.set(ruleName, data.count)
+        }
+
+        rulesToDisable = skippedByVersion.filter(rule => ruleOffenseCounts.has(rule.ruleName))
+        rulesToEnable = skippedByVersion.filter(rule => !ruleOffenseCounts.has(rule.ruleName))
+
+        const rulesMutation: Record<string, { enabled: boolean }> = {}
+
+        for (const rule of rulesToDisable) {
+          rulesMutation[rule.ruleName] = { enabled: false }
+        }
+
+        if (Object.keys(rulesMutation).length > 0) {
+          await Config.mutateConfigFile(config.path, {
+            linter: { rules: rulesMutation }
+          })
+        }
       }
-
-      await Config.mutateConfigFile(config.path, {
-        linter: { rules: rulesMutation }
-      })
 
       const { promises: fs } = await import("fs")
       let content = await fs.readFile(config.path, "utf-8")
@@ -209,16 +252,29 @@ export class CLI {
 
       console.log(`\n${colorize("✓", "brightGreen")} Updated ${colorize(".herb.yml", "cyan")} version from ${colorize(configVersion, "cyan")} to ${colorize(version, "cyan")}`)
 
-      if (skippedByVersion.length > 0) {
-        console.log(`${colorize("✓", "brightGreen")} Disabled ${colorize(String(skippedByVersion.length), "bold")} newly introduced ${skippedByVersion.length === 1 ? "rule" : "rules"}:`)
-        console.log("")
+      if (rulesToEnable.length > 0) {
+        console.log(`\n${colorize("✓", "brightGreen")} Enabled ${colorize(String(rulesToEnable.length), "bold")} new ${rulesToEnable.length === 1 ? "rule" : "rules"} (no offenses found):\n`)
 
-        for (const rule of skippedByVersion) {
-          console.log(`  ${colorize(rule.ruleName, "white")}: ${colorize("enabled: false", "gray")}`)
+        for (const rule of rulesToEnable) {
+          console.log(`  ${colorize("✓", "brightGreen")} ${colorize(rule.ruleName, "white")}`)
+        }
+      }
+
+      if (rulesToDisable.length > 0) {
+        const totalOffenses = Array.from(ruleOffenseCounts.values()).reduce((sum, count) => sum + count, 0)
+
+        console.log(`\n${colorize("!", "yellow")} Found ${colorize(String(totalOffenses), "bold")} ${totalOffenses === 1 ? "offense" : "offenses"} across ${colorize(String(rulesToDisable.length), "bold")} new ${rulesToDisable.length === 1 ? "rule" : "rules"}. Disabled to ease the upgrade:\n`)
+
+        for (const rule of rulesToDisable) {
+          const offenseCount = ruleOffenseCounts.get(rule.ruleName) || 0
+          console.log(`  ${colorize("✗", "red")} ${colorize(rule.ruleName, "white")} ${colorize(`(${offenseCount} ${offenseCount === 1 ? "offense" : "offenses"})`, "gray")}`)
         }
 
-        console.log("")
-        console.log(`  Enable rules individually in your ${colorize(".herb.yml", "cyan")} when you're ready.`)
+        console.log(`\n  When you're ready, review the disabled ${rulesToDisable.length === 1 ? "rule" : "rules"} in your ${colorize(".herb.yml", "cyan")} and re-enable them after fixing the offenses.`)
+      }
+
+      if (skippedByVersion.length === 0) {
+        console.log(`\n${colorize("✓", "brightGreen")} No new rules to configure.`)
       }
 
       console.log("")
@@ -299,6 +355,8 @@ export class CLI {
         processingConfig = modifiedConfig
       }
 
+      const hasConfigFile = Config.exists(configFile || this.projectPath)
+
       const context: ProcessingContext = {
         projectPath: this.projectPath,
         configPath: configFile,
@@ -308,6 +366,7 @@ export class CLI {
         ignoreDisableComments,
         linterConfig,
         config: processingConfig,
+        hasConfigFile,
         loadCustomRules,
         jobs
       }

--- a/javascript/packages/linter/src/cli/file-processor.ts
+++ b/javascript/packages/linter/src/cli/file-processor.ts
@@ -33,6 +33,7 @@ export interface ProcessingContext {
   ignoreDisableComments?: boolean
   linterConfig?: HerbConfigOptions['linter']
   config?: Config
+  hasConfigFile?: boolean
   loadCustomRules?: boolean
   jobs?: number
 }

--- a/javascript/packages/linter/src/cli/output-manager.ts
+++ b/javascript/packages/linter/src/cli/output-manager.ts
@@ -62,6 +62,8 @@ export class OutputManager {
           ignoreDisableComments: context?.ignoreDisableComments,
           rulesSkippedByVersion,
           configVersion: context?.config?.configVersion,
+          configPath: context?.config?.path,
+          hasConfigFile: context?.hasConfigFile,
           toolVersion: options.toolVersion,
         })
       }
@@ -125,6 +127,8 @@ export class OutputManager {
         ignoreDisableComments: context?.ignoreDisableComments,
         rulesSkippedByVersion,
         configVersion: context?.config?.configVersion,
+        configPath: context?.config?.path,
+        hasConfigFile: context?.hasConfigFile,
         toolVersion: options.toolVersion,
       })
     }

--- a/javascript/packages/linter/src/cli/summary-reporter.ts
+++ b/javascript/packages/linter/src/cli/summary-reporter.ts
@@ -23,6 +23,8 @@ export interface SummaryData {
   ignoreDisableComments?: boolean
   rulesSkippedByVersion?: VersionSkippedRule[]
   configVersion?: string
+  configPath?: string
+  hasConfigFile?: boolean
   toolVersion?: string
 }
 
@@ -132,22 +134,24 @@ export class SummaryReporter {
       console.log(` ${colorize("✓", "brightGreen")} ${colorize("All files are clean!", "green")}`)
     }
 
-    this.displayVersionSkippedRules(data.rulesSkippedByVersion, data.configVersion, data.toolVersion)
+    this.displayVersionSkippedRules(data)
   }
 
-  displayVersionSkippedRules(skippedRules?: VersionSkippedRule[], configVersion?: string, toolVersion?: string): void {
+  displayVersionSkippedRules(data: SummaryData): void {
+    const { rulesSkippedByVersion: skippedRules, configVersion, configPath, hasConfigFile, toolVersion } = data
+
     if (!skippedRules || skippedRules.length === 0) return
+    if (!hasConfigFile) return
 
     const ruleCount = skippedRules.length
     const suggestedVersion = toolVersion || configVersion || "latest"
 
     console.log("")
     console.log(` ${colorize(`New rules available:`, "bold")}`)
+    console.log(`  Your ${colorize(".herb.yml", "cyan")} version is ${colorize(configVersion!, "cyan")}. ${colorize(String(ruleCount), "bold")} new ${this.pluralize(ruleCount, "rule")} ${ruleCount === 1 ? "is" : "are"} disabled to ease upgrades:`)
 
-    if (configVersion) {
-      console.log(`  Your ${colorize(".herb.yml", "cyan")} version is ${colorize(configVersion, "cyan")}. ${colorize(String(ruleCount), "bold")} new ${this.pluralize(ruleCount, "rule")} ${ruleCount === 1 ? "is" : "are"} disabled to ease upgrades:`)
-    } else {
-      console.log(`  ${colorize(String(ruleCount), "bold")} ${this.pluralize(ruleCount, "rule")} ${ruleCount === 1 ? "is" : "are"} available in newer versions:`)
+    if (configPath) {
+      console.log(`  ${colorize("from Herb config:", "gray")} ${colorize(configPath, "cyan")}`)
     }
 
     console.log("")
@@ -174,8 +178,8 @@ export class SummaryReporter {
     }
 
     console.log("")
-    console.log(`  Run ${colorize("herb-lint --upgrade", "cyan")} to update the version and disable all new rules, or`)
-    console.log(`  update the version in your ${colorize(".herb.yml", "cyan")} to ${colorize(`"${suggestedVersion}"`, "cyan")} to enable them all at once.`)
+    console.log(`  Run ${colorize("herb-lint --upgrade", "cyan")} to update the version. Rules with no offenses will be`)
+    console.log(`  enabled automatically; rules with offenses will be disabled to ease the upgrade.`)
   }
 
   displayMostViolatedRules(ruleOffenses: Map<string, { count: number, files: Set<string> }>, limit: number = 5): void {

--- a/javascript/packages/linter/test/__snapshots__/cli.test.ts.snap
+++ b/javascript/packages/linter/test/__snapshots__/cli.test.ts.snap
@@ -110,18 +110,6 @@ test/fixtures/ignored.html.erb:8:8
   Note         3 additional offenses reported (would have been ignored)
   Fixable      7 offenses | 4 autocorrectable using \`--fix\`
 
- New rules available:
-  Your .herb.yml version is 0.9.2. 5 new rules are disabled to ease upgrades:
-
-  actionview-no-unnecessary-tag-attributes (introduced in next release)
-  actionview-no-void-element-content (introduced in next release)
-  actionview-strict-locals-partial-only (introduced in next release)
-  html-require-script-nonce (introduced in next release)
-  source-indentation (introduced in next release)
-
-  Run herb-lint --upgrade to update the version and disable all new rules, or
-  update the version in your .herb.yml to "0.9.2" to enable them all at once.
-
  TIP: Run herb-lint --init to create a .herb.yml and lock the version.
       This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
 `;
@@ -180,19 +168,7 @@ test/fixtures/test-file-with-errors.html.erb:2:22
  Summary:
   Checked      1 file
   Offenses     2 errors | 1 warning (3 offenses across 1 file)
-  Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-
- New rules available:
-  Your .herb.yml version is 0.9.2. 5 new rules are disabled to ease upgrades:
-
-  actionview-no-unnecessary-tag-attributes (introduced in next release)
-  actionview-no-void-element-content (introduced in next release)
-  actionview-strict-locals-partial-only (introduced in next release)
-  html-require-script-nonce (introduced in next release)
-  source-indentation (introduced in next release)
-
-  Run herb-lint --upgrade to update the version and disable all new rules, or
-  update the version in your .herb.yml to "0.9.2" to enable them all at once."
+  Fixable      3 offenses | 2 autocorrectable using \`--fix\`"
 `;
 
 exports[`CLI Output Formatting > GitHub Actions format includes rule codes 1`] = `
@@ -214,19 +190,7 @@ test/fixtures/no-trailing-newline.html.erb:1:29
  Summary:
   Checked      1 file
   Offenses     1 error | 0 warnings (1 offense across 1 file)
-  Fixable      1 offense | 1 autocorrectable using \`--fix\`
-
- New rules available:
-  Your .herb.yml version is 0.9.2. 5 new rules are disabled to ease upgrades:
-
-  actionview-no-unnecessary-tag-attributes (introduced in next release)
-  actionview-no-void-element-content (introduced in next release)
-  actionview-strict-locals-partial-only (introduced in next release)
-  html-require-script-nonce (introduced in next release)
-  source-indentation (introduced in next release)
-
-  Run herb-lint --upgrade to update the version and disable all new rules, or
-  update the version in your .herb.yml to "0.9.2" to enable them all at once."
+  Fixable      1 offense | 1 autocorrectable using \`--fix\`"
 `;
 
 exports[`CLI Output Formatting > GitHub Actions format includes rule codes 2`] = `
@@ -276,18 +240,6 @@ test/fixtures/erb-no-extra-whitespace-inside-tags.html.erb:9:3
   Offenses     3 errors | 0 warnings (3 offenses across 1 file)
   Fixable      3 offenses | 3 autocorrectable using \`--fix\`
 
- New rules available:
-  Your .herb.yml version is 0.9.2. 5 new rules are disabled to ease upgrades:
-
-  actionview-no-unnecessary-tag-attributes (introduced in next release)
-  actionview-no-void-element-content (introduced in next release)
-  actionview-strict-locals-partial-only (introduced in next release)
-  html-require-script-nonce (introduced in next release)
-  source-indentation (introduced in next release)
-
-  Run herb-lint --upgrade to update the version and disable all new rules, or
-  update the version in your .herb.yml to "0.9.2" to enable them all at once.
-
  TIP: Run herb-lint --init to create a .herb.yml and lock the version.
       This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
 `;
@@ -329,18 +281,6 @@ test/fixtures/ignored.html.erb:6:14
   Offenses     2 errors | 0 warnings | 3 ignored (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
 
- New rules available:
-  Your .herb.yml version is 0.9.2. 5 new rules are disabled to ease upgrades:
-
-  actionview-no-unnecessary-tag-attributes (introduced in next release)
-  actionview-no-void-element-content (introduced in next release)
-  actionview-strict-locals-partial-only (introduced in next release)
-  html-require-script-nonce (introduced in next release)
-  source-indentation (introduced in next release)
-
-  Run herb-lint --upgrade to update the version and disable all new rules, or
-  update the version in your .herb.yml to "0.9.2" to enable them all at once.
-
  TIP: Run herb-lint --init to create a .herb.yml and lock the version.
       This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
 `;
@@ -366,18 +306,6 @@ test/fixtures/parser-errors.html.erb:2:16
   Checked      1 file
   Offenses     1 error | 0 warnings (1 offense across 1 file)
   Fixable      1 offense
-
- New rules available:
-  Your .herb.yml version is 0.9.2. 5 new rules are disabled to ease upgrades:
-
-  actionview-no-unnecessary-tag-attributes (introduced in next release)
-  actionview-no-void-element-content (introduced in next release)
-  actionview-strict-locals-partial-only (introduced in next release)
-  html-require-script-nonce (introduced in next release)
-  source-indentation (introduced in next release)
-
-  Run herb-lint --upgrade to update the version and disable all new rules, or
-  update the version in your .herb.yml to "0.9.2" to enable them all at once.
 
  TIP: Run herb-lint --init to create a .herb.yml and lock the version.
       This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
@@ -594,18 +522,6 @@ test/fixtures/multiple-rule-offenses.html.erb:4:2
   Offenses     8 errors | 6 warnings (14 offenses across 1 file)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
 
- New rules available:
-  Your .herb.yml version is 0.9.2. 5 new rules are disabled to ease upgrades:
-
-  actionview-no-unnecessary-tag-attributes (introduced in next release)
-  actionview-no-void-element-content (introduced in next release)
-  actionview-strict-locals-partial-only (introduced in next release)
-  html-require-script-nonce (introduced in next release)
-  source-indentation (introduced in next release)
-
-  Run herb-lint --upgrade to update the version and disable all new rules, or
-  update the version in your .herb.yml to "0.9.2" to enable them all at once.
-
  TIP: Run herb-lint --init to create a .herb.yml and lock the version.
       This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
 `;
@@ -703,18 +619,6 @@ test/fixtures/few-rule-offenses.html.erb:6:0
   Offenses     4 errors | 2 warnings (6 offenses across 1 file)
   Fixable      6 offenses | 3 autocorrectable using \`--fix\`
 
- New rules available:
-  Your .herb.yml version is 0.9.2. 5 new rules are disabled to ease upgrades:
-
-  actionview-no-unnecessary-tag-attributes (introduced in next release)
-  actionview-no-void-element-content (introduced in next release)
-  actionview-strict-locals-partial-only (introduced in next release)
-  html-require-script-nonce (introduced in next release)
-  source-indentation (introduced in next release)
-
-  Run herb-lint --upgrade to update the version and disable all new rules, or
-  update the version in your .herb.yml to "0.9.2" to enable them all at once.
-
  TIP: Run herb-lint --init to create a .herb.yml and lock the version.
       This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
 `;
@@ -752,19 +656,7 @@ test/fixtures/bad-file.html.erb:1:16
  Summary:
   Checked      1 file
   Offenses     2 errors | 0 warnings (2 offenses across 1 file)
-  Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-
- New rules available:
-  Your .herb.yml version is 0.9.2. 5 new rules are disabled to ease upgrades:
-
-  actionview-no-unnecessary-tag-attributes (introduced in next release)
-  actionview-no-void-element-content (introduced in next release)
-  actionview-strict-locals-partial-only (introduced in next release)
-  html-require-script-nonce (introduced in next release)
-  source-indentation (introduced in next release)
-
-  Run herb-lint --upgrade to update the version and disable all new rules, or
-  update the version in your .herb.yml to "0.9.2" to enable them all at once."
+  Fixable      2 offenses | 2 autocorrectable using \`--fix\`"
 `;
 
 exports[`CLI Output Formatting > formats GitHub Actions output correctly for clean file 1`] = `
@@ -773,19 +665,7 @@ exports[`CLI Output Formatting > formats GitHub Actions output correctly for cle
 
  Summary:
   Checked      1 file
-  Offenses     0 offenses
-
- New rules available:
-  Your .herb.yml version is 0.9.2. 5 new rules are disabled to ease upgrades:
-
-  actionview-no-unnecessary-tag-attributes (introduced in next release)
-  actionview-no-void-element-content (introduced in next release)
-  actionview-strict-locals-partial-only (introduced in next release)
-  html-require-script-nonce (introduced in next release)
-  source-indentation (introduced in next release)
-
-  Run herb-lint --upgrade to update the version and disable all new rules, or
-  update the version in your .herb.yml to "0.9.2" to enable them all at once."
+  Offenses     0 offenses"
 `;
 
 exports[`CLI Output Formatting > formats GitHub Actions output correctly for file with errors 1`] = `
@@ -842,19 +722,7 @@ test/fixtures/test-file-with-errors.html.erb:2:22
  Summary:
   Checked      1 file
   Offenses     2 errors | 1 warning (3 offenses across 1 file)
-  Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-
- New rules available:
-  Your .herb.yml version is 0.9.2. 5 new rules are disabled to ease upgrades:
-
-  actionview-no-unnecessary-tag-attributes (introduced in next release)
-  actionview-no-void-element-content (introduced in next release)
-  actionview-strict-locals-partial-only (introduced in next release)
-  html-require-script-nonce (introduced in next release)
-  source-indentation (introduced in next release)
-
-  Run herb-lint --upgrade to update the version and disable all new rules, or
-  update the version in your .herb.yml to "0.9.2" to enable them all at once."
+  Fixable      3 offenses | 2 autocorrectable using \`--fix\`"
 `;
 
 exports[`CLI Output Formatting > formats GitHub Actions output with --format=github option 1`] = `
@@ -891,18 +759,6 @@ test/fixtures/test-file-simple.html.erb:2:22
   Checked      1 file
   Offenses     2 errors | 0 warnings (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-
- New rules available:
-  Your .herb.yml version is 0.9.2. 5 new rules are disabled to ease upgrades:
-
-  actionview-no-unnecessary-tag-attributes (introduced in next release)
-  actionview-no-void-element-content (introduced in next release)
-  actionview-strict-locals-partial-only (introduced in next release)
-  html-require-script-nonce (introduced in next release)
-  source-indentation (introduced in next release)
-
-  Run herb-lint --upgrade to update the version and disable all new rules, or
-  update the version in your .herb.yml to "0.9.2" to enable them all at once.
 
  TIP: Run herb-lint --init to create a .herb.yml and lock the version.
       This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
@@ -1108,18 +964,6 @@ test/fixtures/test-file-with-errors.html.erb:2:22
   Offenses     2 errors | 1 warning (3 offenses across 1 file)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
 
- New rules available:
-  Your .herb.yml version is 0.9.2. 5 new rules are disabled to ease upgrades:
-
-  actionview-no-unnecessary-tag-attributes (introduced in next release)
-  actionview-no-void-element-content (introduced in next release)
-  actionview-strict-locals-partial-only (introduced in next release)
-  html-require-script-nonce (introduced in next release)
-  source-indentation (introduced in next release)
-
-  Run herb-lint --upgrade to update the version and disable all new rules, or
-  update the version in your .herb.yml to "0.9.2" to enable them all at once.
-
  TIP: Run herb-lint --init to create a .herb.yml and lock the version.
       This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
 `;
@@ -1138,18 +982,6 @@ exports[`CLI Output Formatting > formats simple output correctly 1`] = `
   Checked      1 file
   Offenses     2 errors | 0 warnings (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-
- New rules available:
-  Your .herb.yml version is 0.9.2. 5 new rules are disabled to ease upgrades:
-
-  actionview-no-unnecessary-tag-attributes (introduced in next release)
-  actionview-no-void-element-content (introduced in next release)
-  actionview-strict-locals-partial-only (introduced in next release)
-  html-require-script-nonce (introduced in next release)
-  source-indentation (introduced in next release)
-
-  Run herb-lint --upgrade to update the version and disable all new rules, or
-  update the version in your .herb.yml to "0.9.2" to enable them all at once.
 
  TIP: Run herb-lint --init to create a .herb.yml and lock the version.
       This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
@@ -1170,18 +1002,6 @@ exports[`CLI Output Formatting > formats simple output for bad-file correctly 1`
   Offenses     2 errors | 0 warnings (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
 
- New rules available:
-  Your .herb.yml version is 0.9.2. 5 new rules are disabled to ease upgrades:
-
-  actionview-no-unnecessary-tag-attributes (introduced in next release)
-  actionview-no-void-element-content (introduced in next release)
-  actionview-strict-locals-partial-only (introduced in next release)
-  html-require-script-nonce (introduced in next release)
-  source-indentation (introduced in next release)
-
-  Run herb-lint --upgrade to update the version and disable all new rules, or
-  update the version in your .herb.yml to "0.9.2" to enable them all at once.
-
  TIP: Run herb-lint --init to create a .herb.yml and lock the version.
       This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
 `;
@@ -1194,18 +1014,6 @@ exports[`CLI Output Formatting > formats success output correctly 1`] = `
   Checked      1 file
   Offenses     0 offenses
 
- New rules available:
-  Your .herb.yml version is 0.9.2. 5 new rules are disabled to ease upgrades:
-
-  actionview-no-unnecessary-tag-attributes (introduced in next release)
-  actionview-no-void-element-content (introduced in next release)
-  actionview-strict-locals-partial-only (introduced in next release)
-  html-require-script-nonce (introduced in next release)
-  source-indentation (introduced in next release)
-
-  Run herb-lint --upgrade to update the version and disable all new rules, or
-  update the version in your .herb.yml to "0.9.2" to enable them all at once.
-
  TIP: Run herb-lint --init to create a .herb.yml and lock the version.
       This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
 `;
@@ -1217,18 +1025,6 @@ exports[`CLI Output Formatting > handles boolean attributes 1`] = `
  Summary:
   Checked      1 file
   Offenses     0 offenses
-
- New rules available:
-  Your .herb.yml version is 0.9.2. 5 new rules are disabled to ease upgrades:
-
-  actionview-no-unnecessary-tag-attributes (introduced in next release)
-  actionview-no-void-element-content (introduced in next release)
-  actionview-strict-locals-partial-only (introduced in next release)
-  html-require-script-nonce (introduced in next release)
-  source-indentation (introduced in next release)
-
-  Run herb-lint --upgrade to update the version and disable all new rules, or
-  update the version in your .herb.yml to "0.9.2" to enable them all at once.
 
  TIP: Run herb-lint --init to create a .herb.yml and lock the version.
       This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
@@ -1264,18 +1060,6 @@ test/fixtures/bad-file.html.erb:1:16
   Checked      1 file
   Offenses     2 errors | 0 warnings (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-
- New rules available:
-  Your .herb.yml version is 0.9.2. 5 new rules are disabled to ease upgrades:
-
-  actionview-no-unnecessary-tag-attributes (introduced in next release)
-  actionview-no-void-element-content (introduced in next release)
-  actionview-strict-locals-partial-only (introduced in next release)
-  html-require-script-nonce (introduced in next release)
-  source-indentation (introduced in next release)
-
-  Run herb-lint --upgrade to update the version and disable all new rules, or
-  update the version in your .herb.yml to "0.9.2" to enable them all at once.
 
  TIP: Run herb-lint --init to create a .herb.yml and lock the version.
       This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
@@ -1408,18 +1192,6 @@ test/fixtures/disabled-1.html.erb:14:19
   Checked      1 file
   Offenses     2 errors | 6 warnings | 8 ignored (8 offenses across 1 file)
   Fixable      8 offenses | 1 autocorrectable using \`--fix\`
-
- New rules available:
-  Your .herb.yml version is 0.9.2. 5 new rules are disabled to ease upgrades:
-
-  actionview-no-unnecessary-tag-attributes (introduced in next release)
-  actionview-no-void-element-content (introduced in next release)
-  actionview-strict-locals-partial-only (introduced in next release)
-  html-require-script-nonce (introduced in next release)
-  source-indentation (introduced in next release)
-
-  Run herb-lint --upgrade to update the version and disable all new rules, or
-  update the version in your .herb.yml to "0.9.2" to enable them all at once.
 
  TIP: Run herb-lint --init to create a .herb.yml and lock the version.
       This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
@@ -1624,18 +1396,6 @@ test/fixtures/disabled-2.html.erb:2:44
   Offenses     6 errors | 7 warnings | 5 ignored (13 offenses across 1 file)
   Fixable      13 offenses | 6 autocorrectable using \`--fix\`
 
- New rules available:
-  Your .herb.yml version is 0.9.2. 5 new rules are disabled to ease upgrades:
-
-  actionview-no-unnecessary-tag-attributes (introduced in next release)
-  actionview-no-void-element-content (introduced in next release)
-  actionview-strict-locals-partial-only (introduced in next release)
-  html-require-script-nonce (introduced in next release)
-  source-indentation (introduced in next release)
-
-  Run herb-lint --upgrade to update the version and disable all new rules, or
-  update the version in your .herb.yml to "0.9.2" to enable them all at once.
-
  TIP: Run herb-lint --init to create a .herb.yml and lock the version.
       This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
 `;
@@ -1694,17 +1454,5 @@ test/fixtures/test-file-with-errors.html.erb:2:22
  Summary:
   Checked      1 file
   Offenses     2 errors | 1 warning (3 offenses across 1 file)
-  Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-
- New rules available:
-  Your .herb.yml version is 0.9.2. 5 new rules are disabled to ease upgrades:
-
-  actionview-no-unnecessary-tag-attributes (introduced in next release)
-  actionview-no-void-element-content (introduced in next release)
-  actionview-strict-locals-partial-only (introduced in next release)
-  html-require-script-nonce (introduced in next release)
-  source-indentation (introduced in next release)
-
-  Run herb-lint --upgrade to update the version and disable all new rules, or
-  update the version in your .herb.yml to "0.9.2" to enable them all at once."
+  Fixable      3 offenses | 2 autocorrectable using \`--fix\`"
 `;

--- a/javascript/packages/linter/test/upgrade.test.ts
+++ b/javascript/packages/linter/test/upgrade.test.ts
@@ -1,0 +1,144 @@
+import { describe, test, expect, beforeAll } from "vitest"
+import { Herb } from "@herb-tools/node-wasm"
+import { Linter } from "../src/linter.js"
+import { rules } from "../src/rules.js"
+import { HTMLTagNameLowercaseRule } from "../src/rules/html-tag-name-lowercase.js"
+import { HTMLNoSelfClosingRule } from "../src/rules/html-no-self-closing.js"
+import { HTMLImgRequireAltRule } from "../src/rules/html-img-require-alt.js"
+import { HTMLNoDuplicateAttributesRule } from "../src/rules/html-no-duplicate-attributes.js"
+
+import type { VersionSkippedRule } from "../src/linter.js"
+import type { RuleClass } from "../src/types.js"
+
+describe("Smart upgrade", () => {
+  beforeAll(async () => {
+    await Herb.load()
+  })
+
+  describe("filterRulesByConfig version gating", () => {
+    test("rules introduced after config version are skipped", () => {
+      const { skippedByVersion } = Linter.filterRulesByConfig(rules, {}, "0.4.0")
+
+      expect(skippedByVersion.length).toBeGreaterThan(0)
+      expect(skippedByVersion.every(rule => rule.introducedIn > "0.4.0")).toBe(true)
+    })
+
+    test("rules at or before config version are enabled", () => {
+      const { enabled, skippedByVersion } = Linter.filterRulesByConfig(rules, {}, "0.4.0")
+
+      expect(enabled.length).toBeGreaterThan(0)
+
+      const skippedNames = new Set(skippedByVersion.map(rule => rule.ruleName))
+      const enabledNames = new Set(enabled.map(rule => rule.ruleName))
+
+      for (const name of enabledNames) {
+        expect(skippedNames.has(name)).toBe(false)
+      }
+    })
+
+    test("explicitly enabled rules bypass version gating", () => {
+      const { enabled } = Linter.filterRulesByConfig(rules, {
+        "actionview-no-unnecessary-tag-attributes": { enabled: true }
+      }, "0.4.0")
+
+      const enabledNames = enabled.map(rule => rule.ruleName)
+      expect(enabledNames).toContain("actionview-no-unnecessary-tag-attributes")
+    })
+
+    test("explicitly disabled rules are not enabled", () => {
+      const { enabled } = Linter.filterRulesByConfig(rules, {
+        "html-tag-name-lowercase": { enabled: false }
+      }, "0.4.0")
+
+      const enabledNames = enabled.map(rule => rule.ruleName)
+      expect(enabledNames).not.toContain("html-tag-name-lowercase")
+    })
+  })
+
+  describe("offense-based rule splitting", () => {
+    function splitRules(skippedByVersion: VersionSkippedRule[], ruleClasses: RuleClass[], source: string, fileName?: string) {
+      const linter = new Linter(Herb, ruleClasses)
+      const result = linter.lint(source, { fileName })
+      const ruleOffenseCounts = new Map<string, number>()
+
+      for (const offense of result.offenses) {
+        ruleOffenseCounts.set(offense.rule, (ruleOffenseCounts.get(offense.rule) || 0) + 1)
+      }
+
+      const rulesToDisable = skippedByVersion.filter(rule => ruleOffenseCounts.has(rule.ruleName))
+      const rulesToEnable = skippedByVersion.filter(rule => !ruleOffenseCounts.has(rule.ruleName))
+
+      return { rulesToDisable, rulesToEnable, ruleOffenseCounts }
+    }
+
+    test("rules with no offenses are marked to enable", () => {
+      const skippedByVersion: VersionSkippedRule[] = [
+        { ruleName: "html-tag-name-lowercase", introducedIn: "0.5.0" },
+        { ruleName: "html-img-require-alt", introducedIn: "0.5.0" },
+      ]
+
+      const { rulesToEnable, rulesToDisable } = splitRules(
+        skippedByVersion,
+        [HTMLTagNameLowercaseRule, HTMLImgRequireAltRule],
+        '<div><img src="logo.png" alt="Logo"></div>'
+      )
+
+      expect(rulesToEnable.map(rule => rule.ruleName)).toContain("html-tag-name-lowercase")
+      expect(rulesToEnable.map(rule => rule.ruleName)).toContain("html-img-require-alt")
+      expect(rulesToDisable).toHaveLength(0)
+    })
+
+    test("rules with offenses are marked to disable", () => {
+      const skippedByVersion: VersionSkippedRule[] = [
+        { ruleName: "html-tag-name-lowercase", introducedIn: "0.5.0" },
+        { ruleName: "html-img-require-alt", introducedIn: "0.5.0" },
+      ]
+
+      const { rulesToEnable, rulesToDisable, ruleOffenseCounts } = splitRules(
+        skippedByVersion,
+        [HTMLTagNameLowercaseRule, HTMLImgRequireAltRule],
+        '<DIV><img src="logo.png"></DIV>'
+      )
+
+      expect(rulesToDisable.map(rule => rule.ruleName)).toContain("html-tag-name-lowercase")
+      expect(rulesToDisable.map(rule => rule.ruleName)).toContain("html-img-require-alt")
+      expect(rulesToEnable).toHaveLength(0)
+      expect(ruleOffenseCounts.get("html-tag-name-lowercase")).toBe(2)
+      expect(ruleOffenseCounts.get("html-img-require-alt")).toBe(1)
+    })
+
+    test("splits rules correctly when some have offenses and some do not", () => {
+      const skippedByVersion: VersionSkippedRule[] = [
+        { ruleName: "html-tag-name-lowercase", introducedIn: "0.5.0" },
+        { ruleName: "html-img-require-alt", introducedIn: "0.5.0" },
+        { ruleName: "html-no-duplicate-attributes", introducedIn: "0.5.0" },
+      ]
+
+      const { rulesToEnable, rulesToDisable } = splitRules(
+        skippedByVersion,
+        [HTMLTagNameLowercaseRule, HTMLImgRequireAltRule, HTMLNoDuplicateAttributesRule],
+        '<div><img src="logo.png"></div>'
+      )
+
+      expect(rulesToEnable.map(rule => rule.ruleName)).toContain("html-tag-name-lowercase")
+      expect(rulesToEnable.map(rule => rule.ruleName)).toContain("html-no-duplicate-attributes")
+      expect(rulesToDisable.map(rule => rule.ruleName)).toContain("html-img-require-alt")
+    })
+
+    test("all rules enabled when source is clean", () => {
+      const skippedByVersion: VersionSkippedRule[] = [
+        { ruleName: "html-tag-name-lowercase", introducedIn: "0.5.0" },
+        { ruleName: "html-no-self-closing", introducedIn: "0.5.0" },
+      ]
+
+      const { rulesToEnable, rulesToDisable } = splitRules(
+        skippedByVersion,
+        [HTMLTagNameLowercaseRule, HTMLNoSelfClosingRule],
+        '<div>Clean content</div>'
+      )
+
+      expect(rulesToEnable).toHaveLength(2)
+      expect(rulesToDisable).toHaveLength(0)
+    })
+  })
+})


### PR DESCRIPTION
This pull request is a follow up on https://github.com/marcoroth/herb/pull/1453 and improves the `--upgrade` command in the linter CLI.

Previously, `herb-lint --upgrade` blindly disabled all newly introduced rules. Now it lints the codebase first with the new rules and:
 - Enables rules that produce zero offenses (safe to adopt immediately)
  - Disables only rules that have existing offenses, with offense counts shown

<img width="2532" height="1898" alt="CleanShot 2026-03-23 at 23 49 16@2x" src="https://github.com/user-attachments/assets/6a1e8f39-5059-4788-ab64-f73c881db124" />

Demo:



https://github.com/user-attachments/assets/931754bf-a3be-4c9c-a97d-ebf2578fde24

