### PR TITLE
Linter CLI: Implement `--disable-failing`

### DIFF
--- a/javascript/packages/linter/src/cli.ts
+++ b/javascript/packages/linter/src/cli.ts
@@ -147,7 +147,7 @@ export class CLI {
     const startTime = Date.now()
     const startDate = new Date()
 
-    const { patterns, configFile, formatOption, showTiming, theme, wrapLines, truncateLines, useGitHubActions, fix, fixUnsafe, ignoreDisableComments, force, init, upgrade, loadCustomRules, failLevel, jobs } = this.argumentParser.parse(process.argv)
+    const { patterns, configFile, formatOption, showTiming, theme, wrapLines, truncateLines, useGitHubActions, fix, fixUnsafe, ignoreDisableComments, force, init, upgrade, disableFailing, loadCustomRules, failLevel, jobs } = this.argumentParser.parse(process.argv)
 
     this.determineProjectPath(patterns)
 
@@ -225,8 +225,11 @@ export class CLI {
         const upgradeProcessor = new FileProcessor()
         const results = await upgradeProcessor.processFiles(files, 'json', upgradeContext)
 
-        for (const [ruleName, data] of results.ruleOffenses) {
-          ruleOffenseCounts.set(ruleName, data.count)
+        for (const { offense } of results.allOffenses) {
+          if (offense.severity !== "error" && offense.severity !== "warning") continue
+
+          const ruleName = offense.code || ""
+          ruleOffenseCounts.set(ruleName, (ruleOffenseCounts.get(ruleName) || 0) + 1)
         }
 
         rulesToDisable = skippedByVersion.filter(rule => ruleOffenseCounts.has(rule.ruleName))
@@ -278,6 +281,68 @@ export class CLI {
       }
 
       console.log("")
+      process.exit(0)
+    }
+
+    if (disableFailing) {
+      const configPath = configFile || this.projectPath
+
+      if (!Config.exists(configPath)) {
+        console.error(`\n✗ No .herb.yml found. Run ${colorize("herb-lint --init", "cyan")} first.\n`)
+        process.exit(1)
+      }
+
+      const config = await Config.load(configPath, { version, exitOnError: true, createIfMissing: false, silent: true })
+
+      console.log(`\n${colorize("↻", "cyan")} Linting codebase to find rules with offenses...`)
+
+      await Herb.load()
+
+      const files = await config.findFilesForTool('linter', this.projectPath)
+
+      const disableFailingContext: ProcessingContext = {
+        projectPath: this.projectPath,
+        config,
+        jobs,
+      }
+
+      const processor = new FileProcessor()
+      const results = await processor.processFiles(files, 'json', disableFailingContext)
+      const failingRules = new Map<string, number>()
+      const PROTECTED_RULES = new Set(["parser-no-errors"])
+
+      for (const { offense } of results.allOffenses) {
+        if (PROTECTED_RULES.has(offense.code || "")) continue
+        if (offense.severity !== "error" && offense.severity !== "warning") continue
+
+        failingRules.set(offense.code || "", (failingRules.get(offense.code || "") || 0) + 1)
+      }
+
+      if (failingRules.size === 0) {
+        console.log(`\n${colorize("✓", "brightGreen")} No offenses found. All rules are passing!\n`)
+        process.exit(0)
+      }
+
+      const rulesMutation: Record<string, { enabled: boolean }> = {}
+
+      for (const ruleName of failingRules.keys()) {
+        rulesMutation[ruleName] = { enabled: false }
+      }
+
+      await Config.mutateConfigFile(config.path, {
+        linter: { rules: rulesMutation }
+      })
+
+      const totalOffenses = Array.from(failingRules.values()).reduce((sum, count) => sum + count, 0)
+      const sortedRules = Array.from(failingRules.entries()).sort((a, b) => b[1] - a[1])
+
+      console.log(`\n${colorize("!", "yellow")} Found ${colorize(String(totalOffenses), "bold")} ${totalOffenses === 1 ? "offense" : "offenses"} across ${colorize(String(failingRules.size), "bold")} ${failingRules.size === 1 ? "rule" : "rules"}. Disabled in ${colorize(".herb.yml", "cyan")}:\n`)
+
+      for (const [ruleName, count] of sortedRules) {
+        console.log(`  ${colorize("✗", "red")} ${colorize(ruleName, "white")} ${colorize(`(${count} ${count === 1 ? "offense" : "offenses"})`, "gray")}`)
+      }
+
+      console.log(`\n  When you're ready, review the disabled rules in your ${colorize(".herb.yml", "cyan")} and re-enable them after fixing the offenses.\n`)
       process.exit(0)
     }
 

--- a/javascript/packages/linter/src/cli/argument-parser.ts
+++ b/javascript/packages/linter/src/cli/argument-parser.ts
@@ -27,6 +27,7 @@ export interface ParsedArguments {
   force: boolean
   init: boolean
   upgrade: boolean
+  disableFailing: boolean
   loadCustomRules: boolean
   failLevel?: DiagnosticSeverity
   jobs: number
@@ -45,6 +46,7 @@ export class ArgumentParser {
       -v, --version                 show version
       --init                        create a .herb.yml configuration file in the current directory
       --upgrade                     update .herb.yml version and disable all newly introduced rules
+      --disable-failing             lint the codebase and disable all rules that have offenses in .herb.yml
       -c, --config-file <path>      explicitly specify path to .herb.yml config file
       --force                       force linting even if disabled in .herb.yml
       --fix                         automatically fix auto-correctable offenses
@@ -74,6 +76,7 @@ export class ArgumentParser {
         version: { type: "boolean", short: "v" },
         init: { type: "boolean" },
         upgrade: { type: "boolean" },
+        "disable-failing": { type: "boolean" },
         "config-file": { type: "string", short: "c" },
         force: { type: "boolean" },
         fix: { type: "boolean" },
@@ -159,6 +162,7 @@ export class ArgumentParser {
     const configFile = values["config-file"]
     const init = values.init || false
     const upgrade = values.upgrade || false
+    const disableFailing = values["disable-failing"] || false
     const loadCustomRules = !values["no-custom-rules"]
 
     let failLevel: DiagnosticSeverity | undefined
@@ -185,7 +189,7 @@ export class ArgumentParser {
       jobs = parsed
     }
 
-    return { patterns, configFile, formatOption, showTiming, theme, wrapLines, truncateLines, useGitHubActions, fix, fixUnsafe, ignoreDisableComments, force, init, upgrade, loadCustomRules, failLevel, jobs }
+    return { patterns, configFile, formatOption, showTiming, theme, wrapLines, truncateLines, useGitHubActions, fix, fixUnsafe, ignoreDisableComments, force, init, upgrade, disableFailing, loadCustomRules, failLevel, jobs }
   }
 
   private getFilePatterns(positionals: string[]): string[] {

--- a/javascript/packages/linter/test/disable-failing.test.ts
+++ b/javascript/packages/linter/test/disable-failing.test.ts
@@ -1,0 +1,84 @@
+import { describe, test, expect, beforeAll } from "vitest"
+import { Herb } from "@herb-tools/node-wasm"
+import { Linter } from "../src/linter.js"
+import { HTMLTagNameLowercaseRule } from "../src/rules/html-tag-name-lowercase.js"
+import { HTMLImgRequireAltRule } from "../src/rules/html-img-require-alt.js"
+import { HTMLNoDuplicateAttributesRule } from "../src/rules/html-no-duplicate-attributes.js"
+import { ParserNoErrorsRule } from "../src/rules/parser-no-errors.js"
+
+import type { RuleClass } from "../src/types.js"
+
+const PROTECTED_RULES = new Set(["parser-no-errors"])
+
+function findFailingRules(ruleClasses: RuleClass[], source: string, fileName?: string) {
+  const linter = new Linter(Herb, ruleClasses)
+  const result = linter.lint(source, { fileName })
+  const failingRules = new Map<string, number>()
+
+  for (const offense of result.offenses) {
+    if (PROTECTED_RULES.has(offense.rule)) continue
+    if (offense.severity !== "error" && offense.severity !== "warning") continue
+
+    failingRules.set(offense.rule, (failingRules.get(offense.rule) || 0) + 1)
+  }
+
+  return failingRules
+}
+
+describe("disable-failing", () => {
+  beforeAll(async () => {
+    await Herb.load()
+  })
+
+  test("identifies rules with offenses", () => {
+    const failingRules = findFailingRules(
+      [HTMLTagNameLowercaseRule, HTMLImgRequireAltRule],
+      '<DIV><img src="logo.png"></DIV>'
+    )
+
+    expect(failingRules.has("html-tag-name-lowercase")).toBe(true)
+    expect(failingRules.has("html-img-require-alt")).toBe(true)
+    expect(failingRules.get("html-tag-name-lowercase")).toBe(2)
+    expect(failingRules.get("html-img-require-alt")).toBe(1)
+  })
+
+  test("returns empty map when no offenses", () => {
+    const failingRules = findFailingRules(
+      [HTMLTagNameLowercaseRule, HTMLImgRequireAltRule],
+      '<div><img src="logo.png" alt="Logo"></div>'
+    )
+
+    expect(failingRules.size).toBe(0)
+  })
+
+  test("only includes rules that have offenses", () => {
+    const failingRules = findFailingRules(
+      [HTMLTagNameLowercaseRule, HTMLImgRequireAltRule, HTMLNoDuplicateAttributesRule],
+      '<div><img src="logo.png"></div>'
+    )
+
+    expect(failingRules.has("html-img-require-alt")).toBe(true)
+    expect(failingRules.has("html-tag-name-lowercase")).toBe(false)
+    expect(failingRules.has("html-no-duplicate-attributes")).toBe(false)
+  })
+
+  test("parser-no-errors is excluded when source has parse errors", () => {
+    const failingRules = findFailingRules(
+      [ParserNoErrorsRule],
+      '<div><span'
+    )
+
+    expect(failingRules.has("parser-no-errors")).toBe(false)
+    expect(failingRules.size).toBe(0)
+  })
+
+  test("parser-no-errors is excluded but other rules still report", () => {
+    const failingRules = findFailingRules(
+      [HTMLImgRequireAltRule],
+      '<img src="logo.png">'
+    )
+
+    expect(failingRules.has("html-img-require-alt")).toBe(true)
+    expect(failingRules.has("parser-no-errors")).toBe(false)
+  })
+})

--- a/javascript/packages/linter/test/upgrade.test.ts
+++ b/javascript/packages/linter/test/upgrade.test.ts
@@ -141,4 +141,5 @@ describe("Smart upgrade", () => {
       expect(rulesToDisable).toHaveLength(0)
     })
   })
+
 })


### PR DESCRIPTION
This pull request implements a new `--disable-failing` flag for the Linter CLI that lints the codebase and then disables all rules that cause offenses by adding a disable rule entry for each rule in `.herb.yml`.