### PR TITLE
Parser: Transform postfix conditionals with Action View helpers

### DIFF
--- a/javascript/packages/rewriter/test/action-view-tag-helper-to-html.test.ts
+++ b/javascript/packages/rewriter/test/action-view-tag-helper-to-html.test.ts
@@ -220,7 +220,7 @@ describe("ActionViewTagHelperToHTMLRewriter", () => {
     })
 
     test("tag.h3 with variable content argument and attributes", () => {
-      expect(transform('<%= tag.h3(title, class: "heading") if title.present? %>')).toBe(
+      expect(transform('<%= tag.h3(title, class: "heading") %>')).toBe(
         '<h3 class="heading"><%= title %></h3>'
       )
     })
@@ -253,6 +253,56 @@ describe("ActionViewTagHelperToHTMLRewriter", () => {
       expect(transform('<%= tag.div content %>')).toBe(
         '<div><%= content %></div>'
       )
+    })
+
+    test("tag.h3 with postfix if condition", () => {
+      expect(transform('<%= tag.h3(title, class: "heading") if title.present? %>')).toBe(
+        '<% if title.present? %><h3 class="heading"><%= title %></h3><% end %>'
+      )
+    })
+
+    test("tag.p with postfix unless condition", () => {
+      expect(transform('<%= tag.p message, class: "text" unless hidden? %>')).toBe(
+        '<% unless hidden? %><p class="text"><%= message %></p><% end %>'
+      )
+    })
+
+    test("tag.div with postfix if condition and string content", () => {
+      expect(transform('<%= tag.div "Content", class: "box" if show? %>')).toBe(
+        '<% if show? %><div class="box">Content</div><% end %>'
+      )
+    })
+
+    test("tag.span with postfix if condition and no attributes", () => {
+      expect(transform('<%= tag.span @user.name if @user %>')).toBe(
+        '<% if @user %><span><%= @user.name %></span><% end %>'
+      )
+    })
+
+    test("tag.div with nested tag helpers and postfix conditions", () => {
+      const input = dedent`
+        <%= tag.div(class: wrapper_classes) do %>
+          <%= tag.div(render("icons/\#{icon}"), class: icon_classes) if icon.present? %>
+
+          <%= tag.div do %>
+            <%= tag.h3(title, class: title_classes) if title.present? %>
+            <%= tag.p(message, class: message_classes) %>
+          <% end %>
+        <% end %>
+      `
+
+      const expected = dedent`
+        <div class="<%= wrapper_classes %>">
+          <% if icon.present? %><div class="<%= icon_classes %>"><%= render("icons/\#{icon}") %></div><% end %>
+
+          <div>
+            <% if title.present? %><h3 class="<%= title_classes %>"><%= title %></h3><% end %>
+            <p class="<%= message_classes %>"><%= message %></p>
+          </div>
+        </div>
+      `
+
+      expect(transform(input)).toBe(expected)
     })
 
     test("tag.script with nonce true passes through as literal", () => {

--- a/src/analyze/action_view/tag_helpers.c
+++ b/src/analyze/action_view/tag_helpers.c
@@ -45,6 +45,8 @@ typedef struct {
   const tag_helper_handler_T* matched_handler;
   const char* original_source;
   size_t erb_content_offset;
+  char* condition_source;
+  char* condition_type;
 } tag_helper_parse_context_T;
 
 static tag_helper_parse_context_T* parse_tag_helper_content(
@@ -74,11 +76,15 @@ static tag_helper_parse_context_T* parse_tag_helper_content(
   }
 
   parse_context->info = tag_helper_info_init(allocator);
+  parse_context->condition_source = NULL;
+  parse_context->condition_type = NULL;
+
   tag_helper_search_data_T search = { .tag_helper_node = NULL,
                                       .source = parse_context->prism_source,
                                       .parser = &parse_context->parser,
                                       .info = parse_context->info,
-                                      .found = false };
+                                      .found = false,
+                                      .postfix_conditional_node = NULL };
   pm_visit_node(parse_context->root, search_tag_helper_node, &search);
 
   if (!search.found) {
@@ -88,6 +94,22 @@ static tag_helper_parse_context_T* parse_tag_helper_content(
     hb_allocator_dealloc(allocator, parse_context->content_string);
     hb_allocator_dealloc(allocator, parse_context);
     return NULL;
+  }
+
+  if (search.postfix_conditional_node) {
+    if (search.postfix_conditional_node->type == PM_IF_NODE) {
+      pm_if_node_t* if_node = (pm_if_node_t*) search.postfix_conditional_node;
+      size_t predicate_length = if_node->predicate->location.end - if_node->predicate->location.start;
+      parse_context->condition_source =
+        hb_allocator_strndup(allocator, (const char*) if_node->predicate->location.start, predicate_length);
+      parse_context->condition_type = hb_allocator_strdup(allocator, "if");
+    } else if (search.postfix_conditional_node->type == PM_UNLESS_NODE) {
+      pm_unless_node_t* unless_node = (pm_unless_node_t*) search.postfix_conditional_node;
+      size_t predicate_length = unless_node->predicate->location.end - unless_node->predicate->location.start;
+      parse_context->condition_source =
+        hb_allocator_strndup(allocator, (const char*) unless_node->predicate->location.start, predicate_length);
+      parse_context->condition_type = hb_allocator_strdup(allocator, "unless");
+    }
   }
 
   parse_context->matched_handler = search.matched_handler;
@@ -107,6 +129,92 @@ static void free_tag_helper_parse_context(tag_helper_parse_context_T* parse_cont
     hb_allocator_dealloc(allocator, parse_context->content_string);
     hb_allocator_dealloc(allocator, parse_context);
   }
+}
+
+static AST_NODE_T* wrap_in_conditional_if_needed(
+  AST_NODE_T* element,
+  tag_helper_parse_context_T* parse_context,
+  hb_allocator_T* allocator
+) {
+  if (!element || !parse_context || !parse_context->condition_source || !parse_context->condition_type) {
+    return element;
+  }
+
+  position_T start = element->location.start;
+  position_T end = element->location.end;
+
+  hb_buffer_T content_buffer;
+  hb_buffer_init(&content_buffer, 64, allocator);
+  hb_buffer_append(&content_buffer, " ");
+  hb_buffer_append(&content_buffer, parse_context->condition_type);
+  hb_buffer_append(&content_buffer, " ");
+  hb_buffer_append(&content_buffer, parse_context->condition_source);
+  hb_buffer_append(&content_buffer, " ");
+  const char* content_string = hb_buffer_value(&content_buffer);
+
+  token_T* tag_opening = create_synthetic_token(allocator, "<%", TOKEN_ERB_START, start, start);
+  token_T* content_token = create_synthetic_token(allocator, content_string, TOKEN_ERB_CONTENT, start, end);
+  token_T* tag_closing = create_synthetic_token(allocator, "%>", TOKEN_ERB_END, end, end);
+
+  hb_array_T* statements = hb_array_init(1, allocator);
+  hb_array_append(statements, element);
+
+  token_T* end_opening = create_synthetic_token(allocator, "<%", TOKEN_ERB_START, end, end);
+  token_T* end_content = create_synthetic_token(allocator, " end ", TOKEN_ERB_CONTENT, end, end);
+  token_T* end_closing = create_synthetic_token(allocator, "%>", TOKEN_ERB_END, end, end);
+
+  AST_ERB_END_NODE_T* end_node =
+    ast_erb_end_node_init(end_opening, end_content, end_closing, end, end, hb_array_init(0, allocator), allocator);
+
+  herb_prism_node_T empty_prism_node = HERB_PRISM_NODE_EMPTY;
+
+  if (strcmp(parse_context->condition_type, "if") == 0) {
+    AST_ERB_IF_NODE_T* if_node = ast_erb_if_node_init(
+      tag_opening,
+      content_token,
+      tag_closing,
+      NULL,
+      empty_prism_node,
+      statements,
+      NULL,
+      end_node,
+      start,
+      end,
+      hb_array_init(0, allocator),
+      allocator
+    );
+
+    return (AST_NODE_T*) if_node;
+  } else {
+    AST_ERB_UNLESS_NODE_T* unless_node = ast_erb_unless_node_init(
+      tag_opening,
+      content_token,
+      tag_closing,
+      NULL,
+      empty_prism_node,
+      statements,
+      NULL,
+      end_node,
+      start,
+      end,
+      hb_array_init(0, allocator),
+      allocator
+    );
+
+    return (AST_NODE_T*) unless_node;
+  }
+}
+
+static bool is_postfix_if_node(const pm_node_t* node) {
+  if (node->type != PM_IF_NODE) { return false; }
+  pm_if_node_t* if_node = (pm_if_node_t*) node;
+  return if_node->if_keyword_loc.start != NULL && if_node->end_keyword_loc.start == NULL;
+}
+
+static bool is_postfix_unless_node(const pm_node_t* node) {
+  if (node->type != PM_UNLESS_NODE) { return false; }
+  pm_unless_node_t* unless_node = (pm_unless_node_t*) node;
+  return unless_node->keyword_loc.start != NULL && unless_node->end_keyword_loc.start == NULL;
 }
 
 bool search_tag_helper_node(const pm_node_t* node, void* data) {
@@ -137,6 +245,16 @@ bool search_tag_helper_node(const pm_node_t* node, void* data) {
     }
 
     return false;
+  }
+
+  if (is_postfix_if_node(node) || is_postfix_unless_node(node)) {
+    const pm_node_t* saved = search_data->postfix_conditional_node;
+    search_data->postfix_conditional_node = node;
+    pm_visit_child_nodes(node, search_tag_helper_node, search_data);
+
+    if (!search_data->found) { search_data->postfix_conditional_node = saved; }
+
+    return search_data->found;
   }
 
   pm_visit_child_nodes(node, search_tag_helper_node, search_data);
@@ -1144,6 +1262,7 @@ void transform_tag_helper_array(hb_array_T* array, analyze_ruby_context_T* conte
 
         if (parse_context) {
           replacement = transform_erb_block_to_tag_helper(block_node, context, parse_context);
+          replacement = wrap_in_conditional_if_needed(replacement, parse_context, context->allocator);
           free_tag_helper_parse_context(parse_context);
         }
 
@@ -1240,6 +1359,7 @@ void transform_tag_helper_array(hb_array_T* array, analyze_ruby_context_T* conte
             replacement = transform_tag_helper_with_attributes(erb_node, context, parse_context);
           }
 
+          replacement = wrap_in_conditional_if_needed(replacement, parse_context, context->allocator);
           free_tag_helper_parse_context(parse_context);
         }
 
@@ -1321,6 +1441,20 @@ void transform_tag_helper_array(hb_array_T* array, analyze_ruby_context_T* conte
 
       if (has_trailing && context->source && child->type == AST_ERB_BLOCK_NODE) {
         AST_HTML_ELEMENT_NODE_T* element = (AST_HTML_ELEMENT_NODE_T*) replacement;
+
+        if (replacement->type == AST_ERB_IF_NODE) {
+          AST_ERB_IF_NODE_T* if_node = (AST_ERB_IF_NODE_T*) replacement;
+
+          if (if_node->statements && hb_array_size(if_node->statements) > 0) {
+            element = (AST_HTML_ELEMENT_NODE_T*) hb_array_get(if_node->statements, 0);
+          }
+        } else if (replacement->type == AST_ERB_UNLESS_NODE) {
+          AST_ERB_UNLESS_NODE_T* unless_node = (AST_ERB_UNLESS_NODE_T*) replacement;
+
+          if (unless_node->statements && hb_array_size(unless_node->statements) > 0) {
+            element = (AST_HTML_ELEMENT_NODE_T*) hb_array_get(unless_node->statements, 0);
+          }
+        }
 
         if (element->close_tag && element->close_tag->type == AST_ERB_END_NODE) {
           AST_ERB_END_NODE_T* close_erb = (AST_ERB_END_NODE_T*) element->close_tag;

--- a/src/include/analyze/action_view/tag_helpers.h
+++ b/src/include/analyze/action_view/tag_helpers.h
@@ -17,6 +17,7 @@ typedef struct {
   tag_helper_info_T* info;
   const tag_helper_handler_T* matched_handler;
   bool found;
+  const pm_node_t* postfix_conditional_node;
 } tag_helper_search_data_T;
 
 bool search_tag_helper_node(const pm_node_t* node, void* data);

--- a/test/analyze/action_view/tag_helper/tag_test.rb
+++ b/test/analyze/action_view/tag_helper/tag_test.rb
@@ -548,5 +548,30 @@ module Analyze::ActionView::TagHelper
         <%= tag.div content %>
       HTML
     end
+
+    test "tag.p with postfix if condition" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <%= tag.p message, class: "text" if show_message? %>
+      HTML
+    end
+
+    test "tag.div with postfix unless condition" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <%= tag.div "Content", class: "box" unless hidden? %>
+      HTML
+    end
+
+    test "tag.div with nested tag helpers and postfix conditions" do
+      assert_parsed_snapshot(<<~'HTML', action_view_helpers: true)
+        <%= tag.div(class: wrapper_classes) do %>
+          <%= tag.div(render("icons/#{icon}"), class: icon_classes) if icon.present? %>
+
+          <%= tag.div do %>
+            <%= tag.h3(title, class: title_classes) if title.present? %>
+            <%= tag.p(message, class: message_classes) %>
+          <% end %>
+        <% end %>
+      HTML
+    end
   end
 end

--- a/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0072_tag.h3_with_variable_content_argument_and_attributes_d49d69d716516f83a98a8e5b524530fd-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0072_tag.h3_with_variable_content_argument_and_attributes_d49d69d716516f83a98a8e5b524530fd-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -6,46 +6,60 @@ options: {action_view_helpers: true}
 ---
 @ DocumentNode (location: (1:0)-(2:0))
 └── children: (2 items)
-    ├── @ HTMLElementNode (location: (1:0)-(1:60))
-    │   ├── open_tag:
-    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:60))
-    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
-    │   │       ├── content: " tag.h3(title, class: title_classes) if title.present? " (location: (1:3)-(1:58))
-    │   │       ├── tag_closing: "%>" (location: (1:58)-(1:60))
+    ├── @ ERBIfNode (location: (1:0)-(1:60))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:0))
+    │   ├── content: " if title.present? " (location: (1:0)-(1:60))
+    │   ├── tag_closing: "%>" (location: (1:60)-(1:60))
+    │   ├── then_keyword: ∅
+    │   ├── statements: (1 item)
+    │   │   └── @ HTMLElementNode (location: (1:0)-(1:60))
+    │   │       ├── open_tag:
+    │   │       │   └── @ ERBOpenTagNode (location: (1:0)-(1:60))
+    │   │       │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       │       ├── content: " tag.h3(title, class: title_classes) if title.present? " (location: (1:3)-(1:58))
+    │   │       │       ├── tag_closing: "%>" (location: (1:58)-(1:60))
+    │   │       │       ├── tag_name: "h3" (location: (1:8)-(1:10))
+    │   │       │       └── children: (1 item)
+    │   │       │           └── @ HTMLAttributeNode (location: (1:18)-(1:38))
+    │   │       │               ├── name:
+    │   │       │               │   └── @ HTMLAttributeNameNode (location: (1:18)-(1:23))
+    │   │       │               │       └── children: (1 item)
+    │   │       │               │           └── @ LiteralNode (location: (1:18)-(1:23))
+    │   │       │               │               └── content: "class"
+    │   │       │               │
+    │   │       │               │
+    │   │       │               ├── equals: ": " (location: (1:23)-(1:25))
+    │   │       │               └── value:
+    │   │       │                   └── @ HTMLAttributeValueNode (location: (1:25)-(1:38))
+    │   │       │                       ├── open_quote: ∅
+    │   │       │                       ├── children: (1 item)
+    │   │       │                       │   └── @ RubyLiteralNode (location: (1:25)-(1:38))
+    │   │       │                       │       └── content: "title_classes"
+    │   │       │                       │
+    │   │       │                       ├── close_quote: ∅
+    │   │       │                       └── quoted: false
+    │   │       │
+    │   │       │
+    │   │       │
     │   │       ├── tag_name: "h3" (location: (1:8)-(1:10))
-    │   │       └── children: (1 item)
-    │   │           └── @ HTMLAttributeNode (location: (1:18)-(1:38))
-    │   │               ├── name:
-    │   │               │   └── @ HTMLAttributeNameNode (location: (1:18)-(1:23))
-    │   │               │       └── children: (1 item)
-    │   │               │           └── @ LiteralNode (location: (1:18)-(1:23))
-    │   │               │               └── content: "class"
-    │   │               │
-    │   │               │
-    │   │               ├── equals: ": " (location: (1:23)-(1:25))
-    │   │               └── value:
-    │   │                   └── @ HTMLAttributeValueNode (location: (1:25)-(1:38))
-    │   │                       ├── open_quote: ∅
-    │   │                       ├── children: (1 item)
-    │   │                       │   └── @ RubyLiteralNode (location: (1:25)-(1:38))
-    │   │                       │       └── content: "title_classes"
-    │   │                       │
-    │   │                       ├── close_quote: ∅
-    │   │                       └── quoted: false
+    │   │       ├── body: (1 item)
+    │   │       │   └── @ RubyLiteralNode (location: (1:0)-(1:60))
+    │   │       │       └── content: "title"
+    │   │       │
+    │   │       ├── close_tag:
+    │   │       │   └── @ HTMLVirtualCloseTagNode (location: (1:60)-(1:60))
+    │   │       │       └── tag_name: "h3" (location: (1:8)-(1:10))
+    │   │       │
+    │   │       ├── is_void: false
+    │   │       └── element_source: "ActionView::Helpers::TagHelper#tag"
     │   │
-    │   │
-    │   │
-    │   ├── tag_name: "h3" (location: (1:8)-(1:10))
-    │   ├── body: (1 item)
-    │   │   └── @ RubyLiteralNode (location: (1:0)-(1:60))
-    │   │       └── content: "title"
-    │   │
-    │   ├── close_tag:
-    │   │   └── @ HTMLVirtualCloseTagNode (location: (1:60)-(1:60))
-    │   │       └── tag_name: "h3" (location: (1:8)-(1:10))
-    │   │
-    │   ├── is_void: false
-    │   └── element_source: "ActionView::Helpers::TagHelper#tag"
+    │   ├── subsequent: ∅
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (1:60)-(1:60))
+    │           ├── tag_opening: "<%" (location: (1:60)-(1:60))
+    │           ├── content: " end " (location: (1:60)-(1:60))
+    │           └── tag_closing: "%>" (location: (1:60)-(1:60))
+    │
     │
     └── @ HTMLTextNode (location: (1:60)-(2:0))
         └── content: "\n"

--- a/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0074_tag.div_with_render_call_as_content_argument_and_attributes_2556fd2b06fdcf98ef7e574a9790178d-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0074_tag.div_with_render_call_as_content_argument_and_attributes_2556fd2b06fdcf98ef7e574a9790178d-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -6,46 +6,60 @@ options: {action_view_helpers: true}
 ---
 @ DocumentNode (location: (1:0)-(2:0))
 └── children: (2 items)
-    ├── @ HTMLElementNode (location: (1:0)-(1:77))
-    │   ├── open_tag:
-    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:77))
-    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
-    │   │       ├── content: " tag.div(render("icons/#{icon}"), class: icon_classes) if icon.present? " (location: (1:3)-(1:75))
-    │   │       ├── tag_closing: "%>" (location: (1:75)-(1:77))
+    ├── @ ERBIfNode (location: (1:0)-(1:77))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:0))
+    │   ├── content: " if icon.present? " (location: (1:0)-(1:77))
+    │   ├── tag_closing: "%>" (location: (1:77)-(1:77))
+    │   ├── then_keyword: ∅
+    │   ├── statements: (1 item)
+    │   │   └── @ HTMLElementNode (location: (1:0)-(1:77))
+    │   │       ├── open_tag:
+    │   │       │   └── @ ERBOpenTagNode (location: (1:0)-(1:77))
+    │   │       │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       │       ├── content: " tag.div(render("icons/#{icon}"), class: icon_classes) if icon.present? " (location: (1:3)-(1:75))
+    │   │       │       ├── tag_closing: "%>" (location: (1:75)-(1:77))
+    │   │       │       ├── tag_name: "div" (location: (1:8)-(1:11))
+    │   │       │       └── children: (1 item)
+    │   │       │           └── @ HTMLAttributeNode (location: (1:37)-(1:56))
+    │   │       │               ├── name:
+    │   │       │               │   └── @ HTMLAttributeNameNode (location: (1:37)-(1:42))
+    │   │       │               │       └── children: (1 item)
+    │   │       │               │           └── @ LiteralNode (location: (1:37)-(1:42))
+    │   │       │               │               └── content: "class"
+    │   │       │               │
+    │   │       │               │
+    │   │       │               ├── equals: ": " (location: (1:42)-(1:44))
+    │   │       │               └── value:
+    │   │       │                   └── @ HTMLAttributeValueNode (location: (1:44)-(1:56))
+    │   │       │                       ├── open_quote: ∅
+    │   │       │                       ├── children: (1 item)
+    │   │       │                       │   └── @ RubyLiteralNode (location: (1:44)-(1:56))
+    │   │       │                       │       └── content: "icon_classes"
+    │   │       │                       │
+    │   │       │                       ├── close_quote: ∅
+    │   │       │                       └── quoted: false
+    │   │       │
+    │   │       │
+    │   │       │
     │   │       ├── tag_name: "div" (location: (1:8)-(1:11))
-    │   │       └── children: (1 item)
-    │   │           └── @ HTMLAttributeNode (location: (1:37)-(1:56))
-    │   │               ├── name:
-    │   │               │   └── @ HTMLAttributeNameNode (location: (1:37)-(1:42))
-    │   │               │       └── children: (1 item)
-    │   │               │           └── @ LiteralNode (location: (1:37)-(1:42))
-    │   │               │               └── content: "class"
-    │   │               │
-    │   │               │
-    │   │               ├── equals: ": " (location: (1:42)-(1:44))
-    │   │               └── value:
-    │   │                   └── @ HTMLAttributeValueNode (location: (1:44)-(1:56))
-    │   │                       ├── open_quote: ∅
-    │   │                       ├── children: (1 item)
-    │   │                       │   └── @ RubyLiteralNode (location: (1:44)-(1:56))
-    │   │                       │       └── content: "icon_classes"
-    │   │                       │
-    │   │                       ├── close_quote: ∅
-    │   │                       └── quoted: false
+    │   │       ├── body: (1 item)
+    │   │       │   └── @ RubyLiteralNode (location: (1:0)-(1:77))
+    │   │       │       └── content: "render(\"icons/\#{icon}\")"
+    │   │       │
+    │   │       ├── close_tag:
+    │   │       │   └── @ HTMLVirtualCloseTagNode (location: (1:77)-(1:77))
+    │   │       │       └── tag_name: "div" (location: (1:8)-(1:11))
+    │   │       │
+    │   │       ├── is_void: false
+    │   │       └── element_source: "ActionView::Helpers::TagHelper#tag"
     │   │
-    │   │
-    │   │
-    │   ├── tag_name: "div" (location: (1:8)-(1:11))
-    │   ├── body: (1 item)
-    │   │   └── @ RubyLiteralNode (location: (1:0)-(1:77))
-    │   │       └── content: "render(\"icons/\#{icon}\")"
-    │   │
-    │   ├── close_tag:
-    │   │   └── @ HTMLVirtualCloseTagNode (location: (1:77)-(1:77))
-    │   │       └── tag_name: "div" (location: (1:8)-(1:11))
-    │   │
-    │   ├── is_void: false
-    │   └── element_source: "ActionView::Helpers::TagHelper#tag"
+    │   ├── subsequent: ∅
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (1:77)-(1:77))
+    │           ├── tag_opening: "<%" (location: (1:77)-(1:77))
+    │           ├── content: " end " (location: (1:77)-(1:77))
+    │           └── tag_closing: "%>" (location: (1:77)-(1:77))
+    │
     │
     └── @ HTMLTextNode (location: (1:77)-(2:0))
         └── content: "\n"

--- a/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0078_tag.p_with_postfix_if_condition_69eaa02b9aebd1120acbd4230f5850d7-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0078_tag.p_with_postfix_if_condition_69eaa02b9aebd1120acbd4230f5850d7-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,65 @@
+---
+source: "Analyze::ActionView::TagHelper::TagTest#test_0078_tag.p with postfix if condition"
+input: |2-
+<%= tag.p message, class: "text" if show_message? %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ ERBIfNode (location: (1:0)-(1:52))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:0))
+    │   ├── content: " if show_message? " (location: (1:0)-(1:52))
+    │   ├── tag_closing: "%>" (location: (1:52)-(1:52))
+    │   ├── then_keyword: ∅
+    │   ├── statements: (1 item)
+    │   │   └── @ HTMLElementNode (location: (1:0)-(1:52))
+    │   │       ├── open_tag:
+    │   │       │   └── @ ERBOpenTagNode (location: (1:0)-(1:52))
+    │   │       │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       │       ├── content: " tag.p message, class: "text" if show_message? " (location: (1:3)-(1:50))
+    │   │       │       ├── tag_closing: "%>" (location: (1:50)-(1:52))
+    │   │       │       ├── tag_name: "p" (location: (1:8)-(1:9))
+    │   │       │       └── children: (1 item)
+    │   │       │           └── @ HTMLAttributeNode (location: (1:19)-(1:32))
+    │   │       │               ├── name:
+    │   │       │               │   └── @ HTMLAttributeNameNode (location: (1:19)-(1:24))
+    │   │       │               │       └── children: (1 item)
+    │   │       │               │           └── @ LiteralNode (location: (1:19)-(1:24))
+    │   │       │               │               └── content: "class"
+    │   │       │               │
+    │   │       │               │
+    │   │       │               ├── equals: ": " (location: (1:24)-(1:26))
+    │   │       │               └── value:
+    │   │       │                   └── @ HTMLAttributeValueNode (location: (1:26)-(1:32))
+    │   │       │                       ├── open_quote: """ (location: (1:26)-(1:27))
+    │   │       │                       ├── children: (1 item)
+    │   │       │                       │   └── @ LiteralNode (location: (1:27)-(1:31))
+    │   │       │                       │       └── content: "text"
+    │   │       │                       │
+    │   │       │                       ├── close_quote: """ (location: (1:31)-(1:32))
+    │   │       │                       └── quoted: true
+    │   │       │
+    │   │       │
+    │   │       │
+    │   │       ├── tag_name: "p" (location: (1:8)-(1:9))
+    │   │       ├── body: (1 item)
+    │   │       │   └── @ RubyLiteralNode (location: (1:0)-(1:52))
+    │   │       │       └── content: "message"
+    │   │       │
+    │   │       ├── close_tag:
+    │   │       │   └── @ HTMLVirtualCloseTagNode (location: (1:52)-(1:52))
+    │   │       │       └── tag_name: "p" (location: (1:8)-(1:9))
+    │   │       │
+    │   │       ├── is_void: false
+    │   │       └── element_source: "ActionView::Helpers::TagHelper#tag"
+    │   │
+    │   ├── subsequent: ∅
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (1:52)-(1:52))
+    │           ├── tag_opening: "<%" (location: (1:52)-(1:52))
+    │           ├── content: " end " (location: (1:52)-(1:52))
+    │           └── tag_closing: "%>" (location: (1:52)-(1:52))
+    │
+    │
+    └── @ HTMLTextNode (location: (1:52)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0079_tag.div_with_postfix_unless_condition_e1e81dac220afacfc248fd90ddb51aff-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0079_tag.div_with_postfix_unless_condition_e1e81dac220afacfc248fd90ddb51aff-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,65 @@
+---
+source: "Analyze::ActionView::TagHelper::TagTest#test_0079_tag.div with postfix unless condition"
+input: |2-
+<%= tag.div "Content", class: "box" unless hidden? %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ ERBUnlessNode (location: (1:0)-(1:53))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:0))
+    │   ├── content: " unless hidden? " (location: (1:0)-(1:53))
+    │   ├── tag_closing: "%>" (location: (1:53)-(1:53))
+    │   ├── then_keyword: ∅
+    │   ├── statements: (1 item)
+    │   │   └── @ HTMLElementNode (location: (1:0)-(1:53))
+    │   │       ├── open_tag:
+    │   │       │   └── @ ERBOpenTagNode (location: (1:0)-(1:53))
+    │   │       │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       │       ├── content: " tag.div "Content", class: "box" unless hidden? " (location: (1:3)-(1:51))
+    │   │       │       ├── tag_closing: "%>" (location: (1:51)-(1:53))
+    │   │       │       ├── tag_name: "div" (location: (1:8)-(1:11))
+    │   │       │       └── children: (1 item)
+    │   │       │           └── @ HTMLAttributeNode (location: (1:23)-(1:35))
+    │   │       │               ├── name:
+    │   │       │               │   └── @ HTMLAttributeNameNode (location: (1:23)-(1:28))
+    │   │       │               │       └── children: (1 item)
+    │   │       │               │           └── @ LiteralNode (location: (1:23)-(1:28))
+    │   │       │               │               └── content: "class"
+    │   │       │               │
+    │   │       │               │
+    │   │       │               ├── equals: ": " (location: (1:28)-(1:30))
+    │   │       │               └── value:
+    │   │       │                   └── @ HTMLAttributeValueNode (location: (1:30)-(1:35))
+    │   │       │                       ├── open_quote: """ (location: (1:30)-(1:31))
+    │   │       │                       ├── children: (1 item)
+    │   │       │                       │   └── @ LiteralNode (location: (1:31)-(1:34))
+    │   │       │                       │       └── content: "box"
+    │   │       │                       │
+    │   │       │                       ├── close_quote: """ (location: (1:34)-(1:35))
+    │   │       │                       └── quoted: true
+    │   │       │
+    │   │       │
+    │   │       │
+    │   │       ├── tag_name: "div" (location: (1:8)-(1:11))
+    │   │       ├── body: (1 item)
+    │   │       │   └── @ HTMLTextNode (location: (1:0)-(1:53))
+    │   │       │       └── content: "Content"
+    │   │       │
+    │   │       ├── close_tag:
+    │   │       │   └── @ HTMLVirtualCloseTagNode (location: (1:53)-(1:53))
+    │   │       │       └── tag_name: "div" (location: (1:8)-(1:11))
+    │   │       │
+    │   │       ├── is_void: false
+    │   │       └── element_source: "ActionView::Helpers::TagHelper#tag"
+    │   │
+    │   ├── else_clause: ∅
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (1:53)-(1:53))
+    │           ├── tag_opening: "<%" (location: (1:53)-(1:53))
+    │           ├── content: " end " (location: (1:53)-(1:53))
+    │           └── tag_closing: "%>" (location: (1:53)-(1:53))
+    │
+    │
+    └── @ HTMLTextNode (location: (1:53)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0080_tag.div_with_nested_tag_helpers_and_postfix_conditions_40088ba33690dda12ec80ba69fd139bd-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0080_tag.div_with_nested_tag_helpers_and_postfix_conditions_40088ba33690dda12ec80ba69fd139bd-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,246 @@
+---
+source: "Analyze::ActionView::TagHelper::TagTest#test_0080_tag.div with nested tag helpers and postfix conditions"
+input: |2-
+<%= tag.div(class: wrapper_classes) do %>
+  <%= tag.div(render("icons/#{icon}"), class: icon_classes) if icon.present? %>
+
+  <%= tag.div do %>
+    <%= tag.h3(title, class: title_classes) if title.present? %>
+    <%= tag.p(message, class: message_classes) %>
+  <% end %>
+<% end %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(9:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(8:9))
+    │   ├── open_tag:
+    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:41))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " tag.div(class: wrapper_classes) do " (location: (1:3)-(1:39))
+    │   │       ├── tag_closing: "%>" (location: (1:39)-(1:41))
+    │   │       ├── tag_name: "div" (location: (1:8)-(1:11))
+    │   │       └── children: (1 item)
+    │   │           └── @ HTMLAttributeNode (location: (1:12)-(1:34))
+    │   │               ├── name:
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:12)-(1:17))
+    │   │               │       └── children: (1 item)
+    │   │               │           └── @ LiteralNode (location: (1:12)-(1:17))
+    │   │               │               └── content: "class"
+    │   │               │
+    │   │               │
+    │   │               ├── equals: ": " (location: (1:17)-(1:19))
+    │   │               └── value:
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:19)-(1:34))
+    │   │                       ├── open_quote: ∅
+    │   │                       ├── children: (1 item)
+    │   │                       │   └── @ RubyLiteralNode (location: (1:19)-(1:34))
+    │   │                       │       └── content: "wrapper_classes"
+    │   │                       │
+    │   │                       ├── close_quote: ∅
+    │   │                       └── quoted: false
+    │   │
+    │   │
+    │   │
+    │   ├── tag_name: "div" (location: (1:8)-(1:11))
+    │   ├── body: (5 items)
+    │   │   ├── @ HTMLTextNode (location: (1:41)-(2:2))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ ERBIfNode (location: (2:2)-(2:79))
+    │   │   │   ├── tag_opening: "<%" (location: (2:2)-(2:2))
+    │   │   │   ├── content: " if icon.present? " (location: (2:2)-(2:79))
+    │   │   │   ├── tag_closing: "%>" (location: (2:79)-(2:79))
+    │   │   │   ├── then_keyword: ∅
+    │   │   │   ├── statements: (1 item)
+    │   │   │   │   └── @ HTMLElementNode (location: (2:2)-(2:79))
+    │   │   │   │       ├── open_tag:
+    │   │   │   │       │   └── @ ERBOpenTagNode (location: (2:2)-(2:79))
+    │   │   │   │       │       ├── tag_opening: "<%=" (location: (2:2)-(2:5))
+    │   │   │   │       │       ├── content: " tag.div(render("icons/#{icon}"), class: icon_classes) if icon.present? " (location: (2:5)-(2:77))
+    │   │   │   │       │       ├── tag_closing: "%>" (location: (2:77)-(2:79))
+    │   │   │   │       │       ├── tag_name: "div" (location: (2:10)-(2:13))
+    │   │   │   │       │       └── children: (1 item)
+    │   │   │   │       │           └── @ HTMLAttributeNode (location: (2:39)-(2:58))
+    │   │   │   │       │               ├── name:
+    │   │   │   │       │               │   └── @ HTMLAttributeNameNode (location: (2:39)-(2:44))
+    │   │   │   │       │               │       └── children: (1 item)
+    │   │   │   │       │               │           └── @ LiteralNode (location: (2:39)-(2:44))
+    │   │   │   │       │               │               └── content: "class"
+    │   │   │   │       │               │
+    │   │   │   │       │               │
+    │   │   │   │       │               ├── equals: ": " (location: (2:44)-(2:46))
+    │   │   │   │       │               └── value:
+    │   │   │   │       │                   └── @ HTMLAttributeValueNode (location: (2:46)-(2:58))
+    │   │   │   │       │                       ├── open_quote: ∅
+    │   │   │   │       │                       ├── children: (1 item)
+    │   │   │   │       │                       │   └── @ RubyLiteralNode (location: (2:46)-(2:58))
+    │   │   │   │       │                       │       └── content: "icon_classes"
+    │   │   │   │       │                       │
+    │   │   │   │       │                       ├── close_quote: ∅
+    │   │   │   │       │                       └── quoted: false
+    │   │   │   │       │
+    │   │   │   │       │
+    │   │   │   │       │
+    │   │   │   │       ├── tag_name: "div" (location: (2:10)-(2:13))
+    │   │   │   │       ├── body: (1 item)
+    │   │   │   │       │   └── @ RubyLiteralNode (location: (2:2)-(2:79))
+    │   │   │   │       │       └── content: "render(\"icons/\#{icon}\")"
+    │   │   │   │       │
+    │   │   │   │       ├── close_tag:
+    │   │   │   │       │   └── @ HTMLVirtualCloseTagNode (location: (2:79)-(2:79))
+    │   │   │   │       │       └── tag_name: "div" (location: (2:10)-(2:13))
+    │   │   │   │       │
+    │   │   │   │       ├── is_void: false
+    │   │   │   │       └── element_source: "ActionView::Helpers::TagHelper#tag"
+    │   │   │   │
+    │   │   │   ├── subsequent: ∅
+    │   │   │   └── end_node:
+    │   │   │       └── @ ERBEndNode (location: (2:79)-(2:79))
+    │   │   │           ├── tag_opening: "<%" (location: (2:79)-(2:79))
+    │   │   │           ├── content: " end " (location: (2:79)-(2:79))
+    │   │   │           └── tag_closing: "%>" (location: (2:79)-(2:79))
+    │   │   │
+    │   │   │
+    │   │   ├── @ HTMLTextNode (location: (2:79)-(4:2))
+    │   │   │   └── content: "\n\n  "
+    │   │   │
+    │   │   ├── @ HTMLElementNode (location: (4:2)-(7:11))
+    │   │   │   ├── open_tag:
+    │   │   │   │   └── @ ERBOpenTagNode (location: (4:2)-(4:19))
+    │   │   │   │       ├── tag_opening: "<%=" (location: (4:2)-(4:5))
+    │   │   │   │       ├── content: " tag.div do " (location: (4:5)-(4:17))
+    │   │   │   │       ├── tag_closing: "%>" (location: (4:17)-(4:19))
+    │   │   │   │       ├── tag_name: "div" (location: (4:10)-(4:13))
+    │   │   │   │       └── children: []
+    │   │   │   │
+    │   │   │   ├── tag_name: "div" (location: (4:10)-(4:13))
+    │   │   │   ├── body: (5 items)
+    │   │   │   │   ├── @ HTMLTextNode (location: (4:19)-(5:4))
+    │   │   │   │   │   └── content: "\n    "
+    │   │   │   │   │
+    │   │   │   │   ├── @ ERBIfNode (location: (5:4)-(5:64))
+    │   │   │   │   │   ├── tag_opening: "<%" (location: (5:4)-(5:4))
+    │   │   │   │   │   ├── content: " if title.present? " (location: (5:4)-(5:64))
+    │   │   │   │   │   ├── tag_closing: "%>" (location: (5:64)-(5:64))
+    │   │   │   │   │   ├── then_keyword: ∅
+    │   │   │   │   │   ├── statements: (1 item)
+    │   │   │   │   │   │   └── @ HTMLElementNode (location: (5:4)-(5:64))
+    │   │   │   │   │   │       ├── open_tag:
+    │   │   │   │   │   │       │   └── @ ERBOpenTagNode (location: (5:4)-(5:64))
+    │   │   │   │   │   │       │       ├── tag_opening: "<%=" (location: (5:4)-(5:7))
+    │   │   │   │   │   │       │       ├── content: " tag.h3(title, class: title_classes) if title.present? " (location: (5:7)-(5:62))
+    │   │   │   │   │   │       │       ├── tag_closing: "%>" (location: (5:62)-(5:64))
+    │   │   │   │   │   │       │       ├── tag_name: "h3" (location: (5:12)-(5:14))
+    │   │   │   │   │   │       │       └── children: (1 item)
+    │   │   │   │   │   │       │           └── @ HTMLAttributeNode (location: (5:22)-(5:42))
+    │   │   │   │   │   │       │               ├── name:
+    │   │   │   │   │   │       │               │   └── @ HTMLAttributeNameNode (location: (5:22)-(5:27))
+    │   │   │   │   │   │       │               │       └── children: (1 item)
+    │   │   │   │   │   │       │               │           └── @ LiteralNode (location: (5:22)-(5:27))
+    │   │   │   │   │   │       │               │               └── content: "class"
+    │   │   │   │   │   │       │               │
+    │   │   │   │   │   │       │               │
+    │   │   │   │   │   │       │               ├── equals: ": " (location: (5:27)-(5:29))
+    │   │   │   │   │   │       │               └── value:
+    │   │   │   │   │   │       │                   └── @ HTMLAttributeValueNode (location: (5:29)-(5:42))
+    │   │   │   │   │   │       │                       ├── open_quote: ∅
+    │   │   │   │   │   │       │                       ├── children: (1 item)
+    │   │   │   │   │   │       │                       │   └── @ RubyLiteralNode (location: (5:29)-(5:42))
+    │   │   │   │   │   │       │                       │       └── content: "title_classes"
+    │   │   │   │   │   │       │                       │
+    │   │   │   │   │   │       │                       ├── close_quote: ∅
+    │   │   │   │   │   │       │                       └── quoted: false
+    │   │   │   │   │   │       │
+    │   │   │   │   │   │       │
+    │   │   │   │   │   │       │
+    │   │   │   │   │   │       ├── tag_name: "h3" (location: (5:12)-(5:14))
+    │   │   │   │   │   │       ├── body: (1 item)
+    │   │   │   │   │   │       │   └── @ RubyLiteralNode (location: (5:4)-(5:64))
+    │   │   │   │   │   │       │       └── content: "title"
+    │   │   │   │   │   │       │
+    │   │   │   │   │   │       ├── close_tag:
+    │   │   │   │   │   │       │   └── @ HTMLVirtualCloseTagNode (location: (5:64)-(5:64))
+    │   │   │   │   │   │       │       └── tag_name: "h3" (location: (5:12)-(5:14))
+    │   │   │   │   │   │       │
+    │   │   │   │   │   │       ├── is_void: false
+    │   │   │   │   │   │       └── element_source: "ActionView::Helpers::TagHelper#tag"
+    │   │   │   │   │   │
+    │   │   │   │   │   ├── subsequent: ∅
+    │   │   │   │   │   └── end_node:
+    │   │   │   │   │       └── @ ERBEndNode (location: (5:64)-(5:64))
+    │   │   │   │   │           ├── tag_opening: "<%" (location: (5:64)-(5:64))
+    │   │   │   │   │           ├── content: " end " (location: (5:64)-(5:64))
+    │   │   │   │   │           └── tag_closing: "%>" (location: (5:64)-(5:64))
+    │   │   │   │   │
+    │   │   │   │   │
+    │   │   │   │   ├── @ HTMLTextNode (location: (5:64)-(6:4))
+    │   │   │   │   │   └── content: "\n    "
+    │   │   │   │   │
+    │   │   │   │   ├── @ HTMLElementNode (location: (6:4)-(6:49))
+    │   │   │   │   │   ├── open_tag:
+    │   │   │   │   │   │   └── @ ERBOpenTagNode (location: (6:4)-(6:49))
+    │   │   │   │   │   │       ├── tag_opening: "<%=" (location: (6:4)-(6:7))
+    │   │   │   │   │   │       ├── content: " tag.p(message, class: message_classes) " (location: (6:7)-(6:47))
+    │   │   │   │   │   │       ├── tag_closing: "%>" (location: (6:47)-(6:49))
+    │   │   │   │   │   │       ├── tag_name: "p" (location: (6:12)-(6:13))
+    │   │   │   │   │   │       └── children: (1 item)
+    │   │   │   │   │   │           └── @ HTMLAttributeNode (location: (6:23)-(6:45))
+    │   │   │   │   │   │               ├── name:
+    │   │   │   │   │   │               │   └── @ HTMLAttributeNameNode (location: (6:23)-(6:28))
+    │   │   │   │   │   │               │       └── children: (1 item)
+    │   │   │   │   │   │               │           └── @ LiteralNode (location: (6:23)-(6:28))
+    │   │   │   │   │   │               │               └── content: "class"
+    │   │   │   │   │   │               │
+    │   │   │   │   │   │               │
+    │   │   │   │   │   │               ├── equals: ": " (location: (6:28)-(6:30))
+    │   │   │   │   │   │               └── value:
+    │   │   │   │   │   │                   └── @ HTMLAttributeValueNode (location: (6:30)-(6:45))
+    │   │   │   │   │   │                       ├── open_quote: ∅
+    │   │   │   │   │   │                       ├── children: (1 item)
+    │   │   │   │   │   │                       │   └── @ RubyLiteralNode (location: (6:30)-(6:45))
+    │   │   │   │   │   │                       │       └── content: "message_classes"
+    │   │   │   │   │   │                       │
+    │   │   │   │   │   │                       ├── close_quote: ∅
+    │   │   │   │   │   │                       └── quoted: false
+    │   │   │   │   │   │
+    │   │   │   │   │   │
+    │   │   │   │   │   │
+    │   │   │   │   │   ├── tag_name: "p" (location: (6:12)-(6:13))
+    │   │   │   │   │   ├── body: (1 item)
+    │   │   │   │   │   │   └── @ RubyLiteralNode (location: (6:4)-(6:49))
+    │   │   │   │   │   │       └── content: "message"
+    │   │   │   │   │   │
+    │   │   │   │   │   ├── close_tag:
+    │   │   │   │   │   │   └── @ HTMLVirtualCloseTagNode (location: (6:49)-(6:49))
+    │   │   │   │   │   │       └── tag_name: "p" (location: (6:12)-(6:13))
+    │   │   │   │   │   │
+    │   │   │   │   │   ├── is_void: false
+    │   │   │   │   │   └── element_source: "ActionView::Helpers::TagHelper#tag"
+    │   │   │   │   │
+    │   │   │   │   └── @ HTMLTextNode (location: (6:49)-(7:2))
+    │   │   │   │       └── content: "\n  "
+    │   │   │   │
+    │   │   │   ├── close_tag:
+    │   │   │   │   └── @ ERBEndNode (location: (7:2)-(7:11))
+    │   │   │   │       ├── tag_opening: "<%" (location: (7:2)-(7:4))
+    │   │   │   │       ├── content: " end " (location: (7:4)-(7:9))
+    │   │   │   │       └── tag_closing: "%>" (location: (7:9)-(7:11))
+    │   │   │   │
+    │   │   │   ├── is_void: false
+    │   │   │   └── element_source: "ActionView::Helpers::TagHelper#tag"
+    │   │   │
+    │   │   └── @ HTMLTextNode (location: (7:11)-(8:0))
+    │   │       └── content: "\n"
+    │   │
+    │   ├── close_tag:
+    │   │   └── @ ERBEndNode (location: (8:0)-(8:9))
+    │   │       ├── tag_opening: "<%" (location: (8:0)-(8:2))
+    │   │       ├── content: " end " (location: (8:2)-(8:7))
+    │   │       └── tag_closing: "%>" (location: (8:7)-(8:9))
+    │   │
+    │   ├── is_void: false
+    │   └── element_source: "ActionView::Helpers::TagHelper#tag"
+    │
+    └── @ HTMLTextNode (location: (8:9)-(9:0))
+        └── content: "\n"


### PR DESCRIPTION
This pull request updates the parser to also detect postfix `if` and `unless` conditionals and transforms them to proper `ERBIfNode`/`ERBUnlessNode`s, so the rewriter can properly convert them.

The following template (thanks @jeremysmithco):

```erb
<%= tag.div(class: wrapper_classes) do %>
  <%= tag.div(render("icons/#{icon}"), class: icon_classes) if icon.present? %>

  <%= tag.div do %>
    <%= tag.h3(title, class: title_classes) if title.present? %>
    <%= tag.p message, class: message_classes %>
  <% end %>
<% end %>
```

can now be parsed and transformed to:
```erb
<div class="<%= wrapper_classes %>">
  <% if icon.present? %><div class="<%= icon_classes %>"><%= render("icons/#{icon}") %></div><% end %>

  <div>
    <% if title.present? %><h3 class="<%= title_classes %>"><%= title %></h3><% end %>
    <p class="<%= message_classes %>"><%= message %></p>
  </div>
</div>
```
