### PR TITLE
Ruby CLI: Add `--trim` flag for Engine

### DIFF
--- a/lib/herb/cli.rb
+++ b/lib/herb/cli.rb
@@ -8,7 +8,7 @@ require "optparse"
 class Herb::CLI
   include Herb::Colors
 
-  attr_accessor :json, :silent, :log_file, :no_timing, :local, :escape, :no_escape, :freeze, :debug, :tool, :strict, :analyze, :track_whitespace, :verbose, :isolate, :arena_stats, :leak_check, :action_view_helpers
+  attr_accessor :json, :silent, :log_file, :no_timing, :local, :escape, :no_escape, :freeze, :debug, :tool, :strict, :analyze, :track_whitespace, :verbose, :isolate, :arena_stats, :leak_check, :action_view_helpers, :trim
 
   def initialize(args)
     @args = args
@@ -302,6 +302,10 @@ class Herb::CLI
         self.action_view_helpers = true
       end
 
+      parser.on("--trim", "Enable trimming of leading/trailing whitespace (for compile/render commands)") do
+        self.trim = true
+      end
+
       parser.on("--tool TOOL", "Show config for specific tool: linter, formatter (for config command)") do |t|
         self.tool = t.to_sym
       end
@@ -446,6 +450,7 @@ class Herb::CLI
         options[:debug_filename] = @file if @file
       end
 
+      options[:trim] = true if trim
       options[:validate_ruby] = true
       engine = Herb::Engine.new(file_content, options)
 
@@ -533,6 +538,7 @@ class Herb::CLI
         options[:debug_filename] = @file if @file
       end
 
+      options[:trim] = true if trim
       engine = Herb::Engine.new(file_content, options)
       compiled_code = engine.src
 


### PR DESCRIPTION
This pull request adds a new `--trim` CLI flag for the `compile` and `render` commands in the `herb` Ruby CLI. When invoked with the `--trim` flag, the CLI passes `trim: true` to the `Herb::Engine.new` call when compiling and rendering a template.

Discovered while reviewing https://github.com/marcoroth/herb/pull/1492.

