### PR TITLE
Ruby: Introduce `enforce_actionview_erubi_equality` test helper

### DIFF
--- a/test/snapshot_utils.rb
+++ b/test/snapshot_utils.rb
@@ -71,6 +71,7 @@ module SnapshotUtils
     require "prism"
 
     enforce_erubi_equality = kwargs.delete(:enforce_erubi_equality) || false
+    enforce_actionview_erubi_equality = kwargs.key?(:enforce_actionview_erubi_equality) ? kwargs.delete(:enforce_actionview_erubi_equality) : enforce_erubi_equality
     engine_options = options.merge(kwargs)
 
     engine = Herb::Engine.new(source, engine_options)
@@ -111,6 +112,10 @@ module SnapshotUtils
 
     if should_compare_with_erubi? || enforce_erubi_equality
       compare_with_erubi_evaluated(source, result, locals, engine_options, enforce_equality: enforce_erubi_equality)
+    end
+
+    if should_compare_with_actionview_erubi? || enforce_actionview_erubi_equality
+      compare_with_actionview_erubi_evaluated(source, result, locals, engine_options, enforce_equality: enforce_actionview_erubi_equality)
     end
 
     { engine: engine, result: result }
@@ -246,6 +251,12 @@ module SnapshotUtils
     !ENV["COMPARE_WITH_ERUBI"].nil?
   end
 
+  def should_compare_with_actionview_erubi?
+    return false if class_name.include?("DebugMode")
+
+    !ENV["COMPARE_WITH_ACTIONVIEW_ERUBI"].nil?
+  end
+
   def compare_with_erubi_compiled(source, herb_src, options, enforce_equality: false)
     require_erubi_silently
 
@@ -311,6 +322,91 @@ module SnapshotUtils
     rescue StandardError
       nil
     end
+  end
+
+  def compare_with_actionview_erubi_evaluated(source, herb_result, locals, _options, enforce_equality: false)
+    require "action_view"
+
+    begin
+      erubi_engine = ActionView::Template::Handlers::ERB::Erubi.new(source, bufvar: "@output_buffer")
+
+      view = ActionView::Base.new(ActionView::LookupContext.new([]), {}, nil)
+      view.instance_variable_set(:@output_buffer, ActionView::OutputBuffer.new)
+
+      locals.each do |key, value|
+        name = key.to_s
+
+        if name.start_with?("@")
+          view.instance_variable_set(name, value)
+        else
+          view.define_singleton_method(name) { value }
+        end
+      end
+
+      actionview_result = view.instance_eval(erubi_engine.src).to_s
+
+      diff_output = diff_rendered_outputs_actionview(actionview_result, herb_result)
+      return unless diff_output
+
+      message = "\n#{"=" * 80}\n"
+      message += "WARNING: Herb evaluated output differs from ActionView Erubi\n"
+      message += "#{"=" * 80}\n"
+      message += "Test: #{class_name} #{name}\n"
+      message += "\nTemplate:\n#{source.inspect}\n"
+      message += "\nLocals: #{locals.inspect}\n"
+      message += "\n"
+      message += diff_output
+      message += "\n"
+      message += "#{"=" * 80}\n"
+
+      if ENV["FAIL_ON_ACTIONVIEW_ERUBI_MISMATCH"] || enforce_equality
+        flunk(message)
+      else
+        puts message
+      end
+    rescue StandardError
+      nil
+    end
+  end
+
+  def diff_rendered_outputs_actionview(actionview_output, herb_output)
+    return nil if actionview_output == herb_output
+
+    output = ""
+    output += "String Comparison:\n"
+    output += "#{"─" * 80}\n"
+
+    string_diff = Difftastic::Differ.new(
+      color: :always,
+      left_label: "ActionView Erubi output",
+      right_label: "Herb::Engine output"
+    ).diff_strings(actionview_output, herb_output)
+
+    output += string_diff
+
+    if !string_diff.strip.empty? && !string_diff.include?("No changes.")
+      output += "\n\n"
+      output += "HTML Semantic Comparison:\n"
+      output += "#{"─" * 80}\n"
+
+      begin
+        html_diff = Difftastic::Differ.new(
+          color: :always,
+          left_label: "ActionView Erubi output",
+          right_label: "Herb::Engine output"
+        ).diff_html(actionview_output, herb_output)
+
+        output += if html_diff.strip.empty? || html_diff.include?("No changes.")
+                    "✓ HTML semantics are identical (only formatting/whitespace differs)"
+                  else
+                    html_diff
+                  end
+      rescue StandardError => e
+        output += "Could not parse as HTML: #{e.message}"
+      end
+    end
+
+    output
   end
 
   def format_snapshot_with_metadata(content, source, options = {})

--- a/test/snapshots/engine/evaluation_test/test_0022_complex_real_world_example_3e2dc9c5e29227714d1ec22e3d1f3972.txt
+++ b/test/snapshots/engine/evaluation_test/test_0022_complex_real_world_example_3e2dc9c5e29227714d1ec22e3d1f3972.txt
@@ -1,0 +1,66 @@
+---
+source: "Engine::EvaluationTest#test_0022_complex real world example"
+input: "{source: \"<!DOCTYPE html>\\n<html>\\n  <head>\\n    <title><%= page_title %></title>\\n    <meta name=\\\"description\\\" content=\\\"<%= meta_description %>\\\">\\n  </head>\\n  <body class=\\\"<%= body_classes.join(' ') %>\\\">\\n    <header>\\n      <h1><%= site_name %></h1>\\n      <nav>\\n        <% navigation_items.each do |item| %>\\n          <a href=\\\"<%= item[:url] %>\\\" class=\\\"<%= item[:active] ? 'active' : '' %>\\\">\\n            <%= item[:title] %>\\n          </a>\\n        <% end %>\\n      </nav>\\n    </header>\\n    \\n    <main>\\n      <% if flash_message %>\\n        <div class=\\\"alert alert-<%= flash_type %>\\\">\\n          <%= flash_message %>\\n        </div>\\n      <% end %>\\n      \\n      <section class=\\\"content\\\">\\n        <% unless posts.empty? %>\\n          <% posts.each_with_index do |post, index| %>\\n            <article class=\\\"post\\\" data-index=\\\"<%= index %>\\\">\\n              <h2><%= post.title %></h2>\\n              <p class=\\\"meta\\\">\\n                By <%= post.author %> on <%= post.date.strftime(\\\"%B %d, %Y\\\") %>\\n              </p>\\n              <div class=\\\"content\\\">\\n                <%= post.excerpt %>\\n              </div>\\n              <% if post.tags.any? %>\\n                <div class=\\\"tags\\\">\\n                  <% post.tags.each do |tag| %>\\n                    <span class=\\\"tag\\\"><%= tag %></span>\\n                  <% end %>\\n                </div>\\n              <% end %>\\n            </article>\\n          <% end %>\\n        <% else %>\\n          <p class=\\\"no-posts\\\">No posts available.</p>\\n        <% end %>\\n      </section>\\n    </main>\\n    \\n    <footer>\\n      <p>&copy; <%= Date.new(2025, 12, 31).year %> <%= site_name %></p>\\n    </footer>\\n  </body>\\n</html>\\n\", locals: {page_title: \"My Blog\", meta_description: \"A blog about programming\", body_classes: [\"blog\", \"home\"], site_name: \"My Awesome Blog\", navigation_items: [{title: \"Home\", url: \"/\", active: true}, {title: \"About\", url: \"/about\", active: false}, {title: \"Contact\", url: \"/contact\", active: false}], flash_message: \"Welcome!\", flash_type: \"success\", posts: [#<struct Engine::EvaluationTest::Post title=\"First Post\", author=\"John Doe\", date=Mon, 15 Jan 2024, excerpt=\"This is the first post excerpt.\", tags=[\"ruby\", \"programming\"]>, #<struct Engine::EvaluationTest::Post title=\"Second Post\", author=\"Jane Smith\", date=Thu, 01 Feb 2024, excerpt=\"This is the second post excerpt.\", tags=[\"html\", \"css\"]>]}, options: {escape: false}}"
+---
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>My Blog</title>
+    <meta name="description" content="A blog about programming">
+  </head>
+  <body class="blog home">
+    <header>
+      <h1>My Awesome Blog</h1>
+      <nav>
+          <a href="/" class="active">
+            Home
+          </a>
+          <a href="/about" class="">
+            About
+          </a>
+          <a href="/contact" class="">
+            Contact
+          </a>
+      </nav>
+    </header>
+    
+    <main>
+        <div class="alert alert-success">
+          Welcome!
+        </div>
+      
+      <section class="content">
+            <article class="post" data-index="0">
+              <h2>First Post</h2>
+              <p class="meta">
+                By John Doe on January 15, 2024
+              </p>
+              <div class="content">
+                This is the first post excerpt.
+              </div>
+                <div class="tags">
+                    <span class="tag">ruby</span>
+                    <span class="tag">programming</span>
+                </div>
+            </article>
+            <article class="post" data-index="1">
+              <h2>Second Post</h2>
+              <p class="meta">
+                By Jane Smith on February 01, 2024
+              </p>
+              <div class="content">
+                This is the second post excerpt.
+              </div>
+                <div class="tags">
+                    <span class="tag">html</span>
+                    <span class="tag">css</span>
+                </div>
+            </article>
+      </section>
+    </main>
+    
+    <footer>
+      <p>&copy; 2025 My Awesome Blog</p>
+    </footer>
+  </body>
+</html>


### PR DESCRIPTION
This pull request introduces a new `enforce_actionview_erubi_equality` keyword argument for the `assert_evaluated_snapshot` test helper. This option makes sure the `Herb::Engine` evaluated output matches the `Erubi::Engine` evaluated output through ActionView.

The `enforce_actionview_erubi_equality` is automatically enabled when `enforce_erubi_equality` is being passed, so this now runs automatically on all existing test that have `enforce_erubi_equality: true`.

If, for some reason, the output should differ we can opt-out of `enforce_actionview_erubi_equality` by doing the following:
```ruby
assert_evaluated_snapshot(template, {}, enforce_erubi_equality: true, enforce_actionview_erubi_equality: false)
```

Obviously, just passing `enforce_actionview_erubi_equality: true` also works. In that case we only enforcing the equality of the ActionView evaluated engine output:

 ```ruby
assert_evaluated_snapshot(template, {},  enforce_actionview_erubi_equality: true)
```

Introducing this option allows us to properly test https://github.com/marcoroth/herb/pull/1492.