### PR TITLE
Parser: Fix parsing of angle brackets and quotes inside attribute values

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -479,7 +479,9 @@ static AST_HTML_ATTRIBUTE_VALUE_NODE_T* parser_parse_quoted_html_attribute_value
 
       if (equals_token && equals_token->type == TOKEN_EQUALS) {
         token_T* after_equals = lexer_next_token(parser->lexer);
-        looks_like_new_attribute = (after_equals && after_equals->type == TOKEN_QUOTE);
+        looks_like_new_attribute =
+          (after_equals && after_equals->type == TOKEN_QUOTE && opening_quote != NULL
+           && hb_string_equals(after_equals->value, opening_quote->value));
 
         if (after_equals) { token_free(after_equals, parser->allocator); }
       }

--- a/test/parser/attributes_test.rb
+++ b/test/parser/attributes_test.rb
@@ -513,5 +513,61 @@ module Parser
     test "issue #1211: attribute value with backslash" do
       assert_parsed_snapshot('<button data-shortcut="S,s,\">S \</button>')
     end
+
+    test "attribute value with HTML content in double quotes" do
+      assert_parsed_snapshot(%(<iframe srcdoc="<base target='foo'>"></iframe>))
+    end
+
+    test "attribute value with HTML content in single quotes" do
+      assert_parsed_snapshot(%(<iframe srcdoc='<base target="foo">'></iframe>))
+    end
+
+    test "attribute value with angle brackets and nested tags" do
+      assert_parsed_snapshot(%(<div data-template="<h1>Hello</h1>"></div>))
+    end
+
+    test "attribute value with self-closing tag inside" do
+      assert_parsed_snapshot(%(<div data-content="<br/>"></div>))
+    end
+
+    test "attribute value with inner attributes using different quote type in double quotes" do
+      assert_parsed_snapshot(%(<div data-html="<span class='highlight'>text</span>"></div>))
+    end
+
+    test "attribute value with inner attributes using different quote type in single quotes" do
+      assert_parsed_snapshot(%(<div data-html='<span class="highlight">text</span>'></div>))
+    end
+
+    test "attribute value with multiple nested attributes same quote type" do
+      assert_parsed_snapshot(%(<iframe srcdoc="<div class="test">"></iframe>))
+    end
+
+    test "attribute value with greater than comparison" do
+      assert_parsed_snapshot(%(<div data-expr="a > b"></div>))
+    end
+
+    test "attribute value with less than comparison" do
+      assert_parsed_snapshot(%(<div data-expr="a < b"></div>))
+    end
+
+    test "attribute value with both angle brackets as comparison" do
+      assert_parsed_snapshot(%(<div data-expr="a < b > c"></div>))
+    end
+
+    test "attribute value with closing tag syntax" do
+      assert_parsed_snapshot(%(<div data-html="</div>"></div>))
+    end
+
+    test "attribute value with self-closing slash gt" do
+      assert_parsed_snapshot(%(<div data-html="a /> b"></div>))
+    end
+
+    test "attribute value with HTML comment syntax" do
+      assert_parsed_snapshot(%(<div data-html="<!-- comment -->"></div>))
+    end
+
+    test "attribute value with multiple greater than signs" do
+      assert_parsed_snapshot(%(<div data-arrows="a >> b >>> c"></div>))
+    end
   end
 end

--- a/test/snapshots/parser/attributes_test/test_0122_attribute_value_with_HTML_content_in_double_quotes_e5c77f0eb3bb473c0528739accce89c5.txt
+++ b/test/snapshots/parser/attributes_test/test_0122_attribute_value_with_HTML_content_in_double_quotes_e5c77f0eb3bb473c0528739accce89c5.txt
@@ -1,0 +1,46 @@
+---
+source: "Parser::AttributesTest#test_0122_attribute value with HTML content in double quotes"
+input: "<iframe srcdoc=\"<base target='foo'>\"></iframe>"
+---
+@ DocumentNode (location: (1:0)-(1:46))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:46))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:37))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "iframe" (location: (1:1)-(1:7))
+        │       ├── tag_closing: ">" (location: (1:36)-(1:37))
+        │       ├── children: (1 item)
+        │       │   └── @ HTMLAttributeNode (location: (1:8)-(1:36))
+        │       │       ├── name:
+        │       │       │   └── @ HTMLAttributeNameNode (location: (1:8)-(1:14))
+        │       │       │       └── children: (1 item)
+        │       │       │           └── @ LiteralNode (location: (1:8)-(1:14))
+        │       │       │               └── content: "srcdoc"
+        │       │       │
+        │       │       │
+        │       │       ├── equals: "=" (location: (1:14)-(1:15))
+        │       │       └── value:
+        │       │           └── @ HTMLAttributeValueNode (location: (1:15)-(1:36))
+        │       │               ├── open_quote: """ (location: (1:15)-(1:16))
+        │       │               ├── children: (1 item)
+        │       │               │   └── @ LiteralNode (location: (1:16)-(1:35))
+        │       │               │       └── content: "<base target='foo'>"
+        │       │               │
+        │       │               ├── close_quote: """ (location: (1:35)-(1:36))
+        │       │               └── quoted: true
+        │       │
+        │       │
+        │       └── is_void: false
+        │
+        ├── tag_name: "iframe" (location: (1:1)-(1:7))
+        ├── body: []
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:37)-(1:46))
+        │       ├── tag_opening: "</" (location: (1:37)-(1:39))
+        │       ├── tag_name: "iframe" (location: (1:39)-(1:45))
+        │       ├── children: []
+        │       └── tag_closing: ">" (location: (1:45)-(1:46))
+        │
+        ├── is_void: false
+        └── element_source: "HTML"

--- a/test/snapshots/parser/attributes_test/test_0123_attribute_value_with_HTML_content_in_single_quotes_196933f4d9a4449e3abaf99c44969247.txt
+++ b/test/snapshots/parser/attributes_test/test_0123_attribute_value_with_HTML_content_in_single_quotes_196933f4d9a4449e3abaf99c44969247.txt
@@ -1,0 +1,46 @@
+---
+source: "Parser::AttributesTest#test_0123_attribute value with HTML content in single quotes"
+input: "<iframe srcdoc='<base target=\"foo\">'></iframe>"
+---
+@ DocumentNode (location: (1:0)-(1:46))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:46))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:37))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "iframe" (location: (1:1)-(1:7))
+        │       ├── tag_closing: ">" (location: (1:36)-(1:37))
+        │       ├── children: (1 item)
+        │       │   └── @ HTMLAttributeNode (location: (1:8)-(1:36))
+        │       │       ├── name:
+        │       │       │   └── @ HTMLAttributeNameNode (location: (1:8)-(1:14))
+        │       │       │       └── children: (1 item)
+        │       │       │           └── @ LiteralNode (location: (1:8)-(1:14))
+        │       │       │               └── content: "srcdoc"
+        │       │       │
+        │       │       │
+        │       │       ├── equals: "=" (location: (1:14)-(1:15))
+        │       │       └── value:
+        │       │           └── @ HTMLAttributeValueNode (location: (1:15)-(1:36))
+        │       │               ├── open_quote: "'" (location: (1:15)-(1:16))
+        │       │               ├── children: (1 item)
+        │       │               │   └── @ LiteralNode (location: (1:16)-(1:35))
+        │       │               │       └── content: "<base target=\"foo\">"
+        │       │               │
+        │       │               ├── close_quote: "'" (location: (1:35)-(1:36))
+        │       │               └── quoted: true
+        │       │
+        │       │
+        │       └── is_void: false
+        │
+        ├── tag_name: "iframe" (location: (1:1)-(1:7))
+        ├── body: []
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:37)-(1:46))
+        │       ├── tag_opening: "</" (location: (1:37)-(1:39))
+        │       ├── tag_name: "iframe" (location: (1:39)-(1:45))
+        │       ├── children: []
+        │       └── tag_closing: ">" (location: (1:45)-(1:46))
+        │
+        ├── is_void: false
+        └── element_source: "HTML"

--- a/test/snapshots/parser/attributes_test/test_0124_attribute_value_with_angle_brackets_and_nested_tags_7f498a00a91083e4a400dad6f77a333a.txt
+++ b/test/snapshots/parser/attributes_test/test_0124_attribute_value_with_angle_brackets_and_nested_tags_7f498a00a91083e4a400dad6f77a333a.txt
@@ -1,0 +1,46 @@
+---
+source: "Parser::AttributesTest#test_0124_attribute value with angle brackets and nested tags"
+input: "<div data-template=\"<h1>Hello</h1>\"></div>"
+---
+@ DocumentNode (location: (1:0)-(1:42))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:42))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:36))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "div" (location: (1:1)-(1:4))
+        │       ├── tag_closing: ">" (location: (1:35)-(1:36))
+        │       ├── children: (1 item)
+        │       │   └── @ HTMLAttributeNode (location: (1:5)-(1:35))
+        │       │       ├── name:
+        │       │       │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:18))
+        │       │       │       └── children: (1 item)
+        │       │       │           └── @ LiteralNode (location: (1:5)-(1:18))
+        │       │       │               └── content: "data-template"
+        │       │       │
+        │       │       │
+        │       │       ├── equals: "=" (location: (1:18)-(1:19))
+        │       │       └── value:
+        │       │           └── @ HTMLAttributeValueNode (location: (1:19)-(1:35))
+        │       │               ├── open_quote: """ (location: (1:19)-(1:20))
+        │       │               ├── children: (1 item)
+        │       │               │   └── @ LiteralNode (location: (1:20)-(1:34))
+        │       │               │       └── content: "<h1>Hello</h1>"
+        │       │               │
+        │       │               ├── close_quote: """ (location: (1:34)-(1:35))
+        │       │               └── quoted: true
+        │       │
+        │       │
+        │       └── is_void: false
+        │
+        ├── tag_name: "div" (location: (1:1)-(1:4))
+        ├── body: []
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:36)-(1:42))
+        │       ├── tag_opening: "</" (location: (1:36)-(1:38))
+        │       ├── tag_name: "div" (location: (1:38)-(1:41))
+        │       ├── children: []
+        │       └── tag_closing: ">" (location: (1:41)-(1:42))
+        │
+        ├── is_void: false
+        └── element_source: "HTML"

--- a/test/snapshots/parser/attributes_test/test_0125_attribute_value_with_self-closing_tag_inside_68ef296e073d473a96c2368c6cf1a40b.txt
+++ b/test/snapshots/parser/attributes_test/test_0125_attribute_value_with_self-closing_tag_inside_68ef296e073d473a96c2368c6cf1a40b.txt
@@ -1,0 +1,46 @@
+---
+source: "Parser::AttributesTest#test_0125_attribute value with self-closing tag inside"
+input: "<div data-content=\"<br/>\"></div>"
+---
+@ DocumentNode (location: (1:0)-(1:32))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:32))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:26))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "div" (location: (1:1)-(1:4))
+        │       ├── tag_closing: ">" (location: (1:25)-(1:26))
+        │       ├── children: (1 item)
+        │       │   └── @ HTMLAttributeNode (location: (1:5)-(1:25))
+        │       │       ├── name:
+        │       │       │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:17))
+        │       │       │       └── children: (1 item)
+        │       │       │           └── @ LiteralNode (location: (1:5)-(1:17))
+        │       │       │               └── content: "data-content"
+        │       │       │
+        │       │       │
+        │       │       ├── equals: "=" (location: (1:17)-(1:18))
+        │       │       └── value:
+        │       │           └── @ HTMLAttributeValueNode (location: (1:18)-(1:25))
+        │       │               ├── open_quote: """ (location: (1:18)-(1:19))
+        │       │               ├── children: (1 item)
+        │       │               │   └── @ LiteralNode (location: (1:19)-(1:24))
+        │       │               │       └── content: "<br/>"
+        │       │               │
+        │       │               ├── close_quote: """ (location: (1:24)-(1:25))
+        │       │               └── quoted: true
+        │       │
+        │       │
+        │       └── is_void: false
+        │
+        ├── tag_name: "div" (location: (1:1)-(1:4))
+        ├── body: []
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:26)-(1:32))
+        │       ├── tag_opening: "</" (location: (1:26)-(1:28))
+        │       ├── tag_name: "div" (location: (1:28)-(1:31))
+        │       ├── children: []
+        │       └── tag_closing: ">" (location: (1:31)-(1:32))
+        │
+        ├── is_void: false
+        └── element_source: "HTML"

--- a/test/snapshots/parser/attributes_test/test_0126_attribute_value_with_inner_attributes_using_different_quote_type_in_double_quotes_2ad14321709dc65c50e3a497c1cff9c8.txt
+++ b/test/snapshots/parser/attributes_test/test_0126_attribute_value_with_inner_attributes_using_different_quote_type_in_double_quotes_2ad14321709dc65c50e3a497c1cff9c8.txt
@@ -1,0 +1,46 @@
+---
+source: "Parser::AttributesTest#test_0126_attribute value with inner attributes using different quote type in double quotes"
+input: "<div data-html=\"<span class='highlight'>text</span>\"></div>"
+---
+@ DocumentNode (location: (1:0)-(1:59))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:59))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:53))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "div" (location: (1:1)-(1:4))
+        │       ├── tag_closing: ">" (location: (1:52)-(1:53))
+        │       ├── children: (1 item)
+        │       │   └── @ HTMLAttributeNode (location: (1:5)-(1:52))
+        │       │       ├── name:
+        │       │       │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:14))
+        │       │       │       └── children: (1 item)
+        │       │       │           └── @ LiteralNode (location: (1:5)-(1:14))
+        │       │       │               └── content: "data-html"
+        │       │       │
+        │       │       │
+        │       │       ├── equals: "=" (location: (1:14)-(1:15))
+        │       │       └── value:
+        │       │           └── @ HTMLAttributeValueNode (location: (1:15)-(1:52))
+        │       │               ├── open_quote: """ (location: (1:15)-(1:16))
+        │       │               ├── children: (1 item)
+        │       │               │   └── @ LiteralNode (location: (1:16)-(1:51))
+        │       │               │       └── content: "<span class='highlight'>text</span>"
+        │       │               │
+        │       │               ├── close_quote: """ (location: (1:51)-(1:52))
+        │       │               └── quoted: true
+        │       │
+        │       │
+        │       └── is_void: false
+        │
+        ├── tag_name: "div" (location: (1:1)-(1:4))
+        ├── body: []
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:53)-(1:59))
+        │       ├── tag_opening: "</" (location: (1:53)-(1:55))
+        │       ├── tag_name: "div" (location: (1:55)-(1:58))
+        │       ├── children: []
+        │       └── tag_closing: ">" (location: (1:58)-(1:59))
+        │
+        ├── is_void: false
+        └── element_source: "HTML"

--- a/test/snapshots/parser/attributes_test/test_0127_attribute_value_with_inner_attributes_using_different_quote_type_in_single_quotes_f549f420ee65b49739afa842180b356a.txt
+++ b/test/snapshots/parser/attributes_test/test_0127_attribute_value_with_inner_attributes_using_different_quote_type_in_single_quotes_f549f420ee65b49739afa842180b356a.txt
@@ -1,0 +1,46 @@
+---
+source: "Parser::AttributesTest#test_0127_attribute value with inner attributes using different quote type in single quotes"
+input: "<div data-html='<span class=\"highlight\">text</span>'></div>"
+---
+@ DocumentNode (location: (1:0)-(1:59))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:59))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:53))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "div" (location: (1:1)-(1:4))
+        │       ├── tag_closing: ">" (location: (1:52)-(1:53))
+        │       ├── children: (1 item)
+        │       │   └── @ HTMLAttributeNode (location: (1:5)-(1:52))
+        │       │       ├── name:
+        │       │       │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:14))
+        │       │       │       └── children: (1 item)
+        │       │       │           └── @ LiteralNode (location: (1:5)-(1:14))
+        │       │       │               └── content: "data-html"
+        │       │       │
+        │       │       │
+        │       │       ├── equals: "=" (location: (1:14)-(1:15))
+        │       │       └── value:
+        │       │           └── @ HTMLAttributeValueNode (location: (1:15)-(1:52))
+        │       │               ├── open_quote: "'" (location: (1:15)-(1:16))
+        │       │               ├── children: (1 item)
+        │       │               │   └── @ LiteralNode (location: (1:16)-(1:51))
+        │       │               │       └── content: "<span class=\"highlight\">text</span>"
+        │       │               │
+        │       │               ├── close_quote: "'" (location: (1:51)-(1:52))
+        │       │               └── quoted: true
+        │       │
+        │       │
+        │       └── is_void: false
+        │
+        ├── tag_name: "div" (location: (1:1)-(1:4))
+        ├── body: []
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:53)-(1:59))
+        │       ├── tag_opening: "</" (location: (1:53)-(1:55))
+        │       ├── tag_name: "div" (location: (1:55)-(1:58))
+        │       ├── children: []
+        │       └── tag_closing: ">" (location: (1:58)-(1:59))
+        │
+        ├── is_void: false
+        └── element_source: "HTML"

--- a/test/snapshots/parser/attributes_test/test_0128_attribute_value_with_multiple_nested_attributes_same_quote_type_18fd503fbcf9d4e3568800c59cd1881b.txt
+++ b/test/snapshots/parser/attributes_test/test_0128_attribute_value_with_multiple_nested_attributes_same_quote_type_18fd503fbcf9d4e3568800c59cd1881b.txt
@@ -1,0 +1,74 @@
+---
+source: "Parser::AttributesTest#test_0128_attribute value with multiple nested attributes same quote type"
+input: "<iframe srcdoc=\"<div class=\"test\">\"></iframe>"
+---
+@ DocumentNode (location: (1:0)-(1:45))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:45))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:34))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "iframe" (location: (1:1)-(1:7))
+        │       ├── tag_closing: ">" (location: (1:33)-(1:34))
+        │       ├── children: (2 items)
+        │       │   ├── @ HTMLAttributeNode (location: (1:8)-(1:21))
+        │       │   │   ├── name:
+        │       │   │   │   └── @ HTMLAttributeNameNode (location: (1:8)-(1:14))
+        │       │   │   │       └── children: (1 item)
+        │       │   │   │           └── @ LiteralNode (location: (1:8)-(1:14))
+        │       │   │   │               └── content: "srcdoc"
+        │       │   │   │
+        │       │   │   │
+        │       │   │   ├── equals: "=" (location: (1:14)-(1:15))
+        │       │   │   └── value:
+        │       │   │       └── @ HTMLAttributeValueNode (location: (1:15)-(1:21))
+        │       │   │           ├── errors: (1 error)
+        │       │   │           │   └── @ UnclosedQuoteError (location: (1:15)-(1:21))
+        │       │   │           │       ├── message: "Attribute value opened with \" at (1:15) was never closed."
+        │       │   │           │       └── opening_quote: """ (location: (1:15)-(1:16))
+        │       │   │           │
+        │       │   │           ├── open_quote: """ (location: (1:15)-(1:16))
+        │       │   │           ├── children: (1 item)
+        │       │   │           │   └── @ LiteralNode (location: (1:16)-(1:21))
+        │       │   │           │       └── content: "<div "
+        │       │   │           │
+        │       │   │           ├── close_quote: ∅
+        │       │   │           └── quoted: true
+        │       │   │
+        │       │   │
+        │       │   └── @ HTMLAttributeNode (location: (1:21)-(1:33))
+        │       │       ├── name:
+        │       │       │   └── @ HTMLAttributeNameNode (location: (1:21)-(1:26))
+        │       │       │       └── children: (1 item)
+        │       │       │           └── @ LiteralNode (location: (1:21)-(1:26))
+        │       │       │               └── content: "class"
+        │       │       │
+        │       │       │
+        │       │       ├── equals: "=" (location: (1:26)-(1:27))
+        │       │       └── value:
+        │       │           └── @ HTMLAttributeValueNode (location: (1:27)-(1:33))
+        │       │               ├── open_quote: """ (location: (1:27)-(1:28))
+        │       │               ├── children: (1 item)
+        │       │               │   └── @ LiteralNode (location: (1:28)-(1:32))
+        │       │               │       └── content: "test"
+        │       │               │
+        │       │               ├── close_quote: """ (location: (1:32)-(1:33))
+        │       │               └── quoted: true
+        │       │
+        │       │
+        │       └── is_void: false
+        │
+        ├── tag_name: "iframe" (location: (1:1)-(1:7))
+        ├── body: (1 item)
+        │   └── @ HTMLTextNode (location: (1:34)-(1:36))
+        │       └── content: "\">"
+        │
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:36)-(1:45))
+        │       ├── tag_opening: "</" (location: (1:36)-(1:38))
+        │       ├── tag_name: "iframe" (location: (1:38)-(1:44))
+        │       ├── children: []
+        │       └── tag_closing: ">" (location: (1:44)-(1:45))
+        │
+        ├── is_void: false
+        └── element_source: "HTML"

--- a/test/snapshots/parser/attributes_test/test_0129_attribute_value_with_greater_than_comparison_f3efa8885d122964e1dc1fb907df991d.txt
+++ b/test/snapshots/parser/attributes_test/test_0129_attribute_value_with_greater_than_comparison_f3efa8885d122964e1dc1fb907df991d.txt
@@ -1,0 +1,46 @@
+---
+source: "Parser::AttributesTest#test_0129_attribute value with greater than comparison"
+input: "<div data-expr=\"a > b\"></div>"
+---
+@ DocumentNode (location: (1:0)-(1:29))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:29))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:23))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "div" (location: (1:1)-(1:4))
+        │       ├── tag_closing: ">" (location: (1:22)-(1:23))
+        │       ├── children: (1 item)
+        │       │   └── @ HTMLAttributeNode (location: (1:5)-(1:22))
+        │       │       ├── name:
+        │       │       │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:14))
+        │       │       │       └── children: (1 item)
+        │       │       │           └── @ LiteralNode (location: (1:5)-(1:14))
+        │       │       │               └── content: "data-expr"
+        │       │       │
+        │       │       │
+        │       │       ├── equals: "=" (location: (1:14)-(1:15))
+        │       │       └── value:
+        │       │           └── @ HTMLAttributeValueNode (location: (1:15)-(1:22))
+        │       │               ├── open_quote: """ (location: (1:15)-(1:16))
+        │       │               ├── children: (1 item)
+        │       │               │   └── @ LiteralNode (location: (1:16)-(1:21))
+        │       │               │       └── content: "a > b"
+        │       │               │
+        │       │               ├── close_quote: """ (location: (1:21)-(1:22))
+        │       │               └── quoted: true
+        │       │
+        │       │
+        │       └── is_void: false
+        │
+        ├── tag_name: "div" (location: (1:1)-(1:4))
+        ├── body: []
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:23)-(1:29))
+        │       ├── tag_opening: "</" (location: (1:23)-(1:25))
+        │       ├── tag_name: "div" (location: (1:25)-(1:28))
+        │       ├── children: []
+        │       └── tag_closing: ">" (location: (1:28)-(1:29))
+        │
+        ├── is_void: false
+        └── element_source: "HTML"

--- a/test/snapshots/parser/attributes_test/test_0130_attribute_value_with_less_than_comparison_43072d0d77181083a1ccef5409a0ea86.txt
+++ b/test/snapshots/parser/attributes_test/test_0130_attribute_value_with_less_than_comparison_43072d0d77181083a1ccef5409a0ea86.txt
@@ -1,0 +1,46 @@
+---
+source: "Parser::AttributesTest#test_0130_attribute value with less than comparison"
+input: "<div data-expr=\"a < b\"></div>"
+---
+@ DocumentNode (location: (1:0)-(1:29))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:29))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:23))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "div" (location: (1:1)-(1:4))
+        │       ├── tag_closing: ">" (location: (1:22)-(1:23))
+        │       ├── children: (1 item)
+        │       │   └── @ HTMLAttributeNode (location: (1:5)-(1:22))
+        │       │       ├── name:
+        │       │       │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:14))
+        │       │       │       └── children: (1 item)
+        │       │       │           └── @ LiteralNode (location: (1:5)-(1:14))
+        │       │       │               └── content: "data-expr"
+        │       │       │
+        │       │       │
+        │       │       ├── equals: "=" (location: (1:14)-(1:15))
+        │       │       └── value:
+        │       │           └── @ HTMLAttributeValueNode (location: (1:15)-(1:22))
+        │       │               ├── open_quote: """ (location: (1:15)-(1:16))
+        │       │               ├── children: (1 item)
+        │       │               │   └── @ LiteralNode (location: (1:16)-(1:21))
+        │       │               │       └── content: "a < b"
+        │       │               │
+        │       │               ├── close_quote: """ (location: (1:21)-(1:22))
+        │       │               └── quoted: true
+        │       │
+        │       │
+        │       └── is_void: false
+        │
+        ├── tag_name: "div" (location: (1:1)-(1:4))
+        ├── body: []
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:23)-(1:29))
+        │       ├── tag_opening: "</" (location: (1:23)-(1:25))
+        │       ├── tag_name: "div" (location: (1:25)-(1:28))
+        │       ├── children: []
+        │       └── tag_closing: ">" (location: (1:28)-(1:29))
+        │
+        ├── is_void: false
+        └── element_source: "HTML"

--- a/test/snapshots/parser/attributes_test/test_0131_attribute_value_with_both_angle_brackets_as_comparison_ed171988999b8d620b87471ca03beab9.txt
+++ b/test/snapshots/parser/attributes_test/test_0131_attribute_value_with_both_angle_brackets_as_comparison_ed171988999b8d620b87471ca03beab9.txt
@@ -1,0 +1,46 @@
+---
+source: "Parser::AttributesTest#test_0131_attribute value with both angle brackets as comparison"
+input: "<div data-expr=\"a < b > c\"></div>"
+---
+@ DocumentNode (location: (1:0)-(1:33))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:33))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:27))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "div" (location: (1:1)-(1:4))
+        │       ├── tag_closing: ">" (location: (1:26)-(1:27))
+        │       ├── children: (1 item)
+        │       │   └── @ HTMLAttributeNode (location: (1:5)-(1:26))
+        │       │       ├── name:
+        │       │       │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:14))
+        │       │       │       └── children: (1 item)
+        │       │       │           └── @ LiteralNode (location: (1:5)-(1:14))
+        │       │       │               └── content: "data-expr"
+        │       │       │
+        │       │       │
+        │       │       ├── equals: "=" (location: (1:14)-(1:15))
+        │       │       └── value:
+        │       │           └── @ HTMLAttributeValueNode (location: (1:15)-(1:26))
+        │       │               ├── open_quote: """ (location: (1:15)-(1:16))
+        │       │               ├── children: (1 item)
+        │       │               │   └── @ LiteralNode (location: (1:16)-(1:25))
+        │       │               │       └── content: "a < b > c"
+        │       │               │
+        │       │               ├── close_quote: """ (location: (1:25)-(1:26))
+        │       │               └── quoted: true
+        │       │
+        │       │
+        │       └── is_void: false
+        │
+        ├── tag_name: "div" (location: (1:1)-(1:4))
+        ├── body: []
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:27)-(1:33))
+        │       ├── tag_opening: "</" (location: (1:27)-(1:29))
+        │       ├── tag_name: "div" (location: (1:29)-(1:32))
+        │       ├── children: []
+        │       └── tag_closing: ">" (location: (1:32)-(1:33))
+        │
+        ├── is_void: false
+        └── element_source: "HTML"

--- a/test/snapshots/parser/attributes_test/test_0132_attribute_value_with_closing_tag_syntax_a83e2166ef03371db024062c485332ff.txt
+++ b/test/snapshots/parser/attributes_test/test_0132_attribute_value_with_closing_tag_syntax_a83e2166ef03371db024062c485332ff.txt
@@ -1,0 +1,46 @@
+---
+source: "Parser::AttributesTest#test_0132_attribute value with closing tag syntax"
+input: "<div data-html=\"</div>\"></div>"
+---
+@ DocumentNode (location: (1:0)-(1:30))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:30))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:24))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "div" (location: (1:1)-(1:4))
+        │       ├── tag_closing: ">" (location: (1:23)-(1:24))
+        │       ├── children: (1 item)
+        │       │   └── @ HTMLAttributeNode (location: (1:5)-(1:23))
+        │       │       ├── name:
+        │       │       │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:14))
+        │       │       │       └── children: (1 item)
+        │       │       │           └── @ LiteralNode (location: (1:5)-(1:14))
+        │       │       │               └── content: "data-html"
+        │       │       │
+        │       │       │
+        │       │       ├── equals: "=" (location: (1:14)-(1:15))
+        │       │       └── value:
+        │       │           └── @ HTMLAttributeValueNode (location: (1:15)-(1:23))
+        │       │               ├── open_quote: """ (location: (1:15)-(1:16))
+        │       │               ├── children: (1 item)
+        │       │               │   └── @ LiteralNode (location: (1:16)-(1:22))
+        │       │               │       └── content: "</div>"
+        │       │               │
+        │       │               ├── close_quote: """ (location: (1:22)-(1:23))
+        │       │               └── quoted: true
+        │       │
+        │       │
+        │       └── is_void: false
+        │
+        ├── tag_name: "div" (location: (1:1)-(1:4))
+        ├── body: []
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:24)-(1:30))
+        │       ├── tag_opening: "</" (location: (1:24)-(1:26))
+        │       ├── tag_name: "div" (location: (1:26)-(1:29))
+        │       ├── children: []
+        │       └── tag_closing: ">" (location: (1:29)-(1:30))
+        │
+        ├── is_void: false
+        └── element_source: "HTML"

--- a/test/snapshots/parser/attributes_test/test_0133_attribute_value_with_self-closing_slash_gt_8cd162e92a544e7fbcc39d343331d43c.txt
+++ b/test/snapshots/parser/attributes_test/test_0133_attribute_value_with_self-closing_slash_gt_8cd162e92a544e7fbcc39d343331d43c.txt
@@ -1,0 +1,46 @@
+---
+source: "Parser::AttributesTest#test_0133_attribute value with self-closing slash gt"
+input: "<div data-html=\"a /> b\"></div>"
+---
+@ DocumentNode (location: (1:0)-(1:30))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:30))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:24))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "div" (location: (1:1)-(1:4))
+        │       ├── tag_closing: ">" (location: (1:23)-(1:24))
+        │       ├── children: (1 item)
+        │       │   └── @ HTMLAttributeNode (location: (1:5)-(1:23))
+        │       │       ├── name:
+        │       │       │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:14))
+        │       │       │       └── children: (1 item)
+        │       │       │           └── @ LiteralNode (location: (1:5)-(1:14))
+        │       │       │               └── content: "data-html"
+        │       │       │
+        │       │       │
+        │       │       ├── equals: "=" (location: (1:14)-(1:15))
+        │       │       └── value:
+        │       │           └── @ HTMLAttributeValueNode (location: (1:15)-(1:23))
+        │       │               ├── open_quote: """ (location: (1:15)-(1:16))
+        │       │               ├── children: (1 item)
+        │       │               │   └── @ LiteralNode (location: (1:16)-(1:22))
+        │       │               │       └── content: "a /> b"
+        │       │               │
+        │       │               ├── close_quote: """ (location: (1:22)-(1:23))
+        │       │               └── quoted: true
+        │       │
+        │       │
+        │       └── is_void: false
+        │
+        ├── tag_name: "div" (location: (1:1)-(1:4))
+        ├── body: []
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:24)-(1:30))
+        │       ├── tag_opening: "</" (location: (1:24)-(1:26))
+        │       ├── tag_name: "div" (location: (1:26)-(1:29))
+        │       ├── children: []
+        │       └── tag_closing: ">" (location: (1:29)-(1:30))
+        │
+        ├── is_void: false
+        └── element_source: "HTML"

--- a/test/snapshots/parser/attributes_test/test_0134_attribute_value_with_HTML_comment_syntax_cae37fd20af045c6e7f9bff5a481b8d9.txt
+++ b/test/snapshots/parser/attributes_test/test_0134_attribute_value_with_HTML_comment_syntax_cae37fd20af045c6e7f9bff5a481b8d9.txt
@@ -1,0 +1,46 @@
+---
+source: "Parser::AttributesTest#test_0134_attribute value with HTML comment syntax"
+input: "<div data-html=\"<!-- comment -->\"></div>"
+---
+@ DocumentNode (location: (1:0)-(1:40))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:40))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:34))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "div" (location: (1:1)-(1:4))
+        │       ├── tag_closing: ">" (location: (1:33)-(1:34))
+        │       ├── children: (1 item)
+        │       │   └── @ HTMLAttributeNode (location: (1:5)-(1:33))
+        │       │       ├── name:
+        │       │       │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:14))
+        │       │       │       └── children: (1 item)
+        │       │       │           └── @ LiteralNode (location: (1:5)-(1:14))
+        │       │       │               └── content: "data-html"
+        │       │       │
+        │       │       │
+        │       │       ├── equals: "=" (location: (1:14)-(1:15))
+        │       │       └── value:
+        │       │           └── @ HTMLAttributeValueNode (location: (1:15)-(1:33))
+        │       │               ├── open_quote: """ (location: (1:15)-(1:16))
+        │       │               ├── children: (1 item)
+        │       │               │   └── @ LiteralNode (location: (1:16)-(1:32))
+        │       │               │       └── content: "<!-- comment -->"
+        │       │               │
+        │       │               ├── close_quote: """ (location: (1:32)-(1:33))
+        │       │               └── quoted: true
+        │       │
+        │       │
+        │       └── is_void: false
+        │
+        ├── tag_name: "div" (location: (1:1)-(1:4))
+        ├── body: []
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:34)-(1:40))
+        │       ├── tag_opening: "</" (location: (1:34)-(1:36))
+        │       ├── tag_name: "div" (location: (1:36)-(1:39))
+        │       ├── children: []
+        │       └── tag_closing: ">" (location: (1:39)-(1:40))
+        │
+        ├── is_void: false
+        └── element_source: "HTML"

--- a/test/snapshots/parser/attributes_test/test_0135_attribute_value_with_multiple_greater_than_signs_24ca9c0370ab191614d78e8385cfe320.txt
+++ b/test/snapshots/parser/attributes_test/test_0135_attribute_value_with_multiple_greater_than_signs_24ca9c0370ab191614d78e8385cfe320.txt
@@ -1,0 +1,46 @@
+---
+source: "Parser::AttributesTest#test_0135_attribute value with multiple greater than signs"
+input: "<div data-arrows=\"a >> b >>> c\"></div>"
+---
+@ DocumentNode (location: (1:0)-(1:38))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:38))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:32))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "div" (location: (1:1)-(1:4))
+        │       ├── tag_closing: ">" (location: (1:31)-(1:32))
+        │       ├── children: (1 item)
+        │       │   └── @ HTMLAttributeNode (location: (1:5)-(1:31))
+        │       │       ├── name:
+        │       │       │   └── @ HTMLAttributeNameNode (location: (1:5)-(1:16))
+        │       │       │       └── children: (1 item)
+        │       │       │           └── @ LiteralNode (location: (1:5)-(1:16))
+        │       │       │               └── content: "data-arrows"
+        │       │       │
+        │       │       │
+        │       │       ├── equals: "=" (location: (1:16)-(1:17))
+        │       │       └── value:
+        │       │           └── @ HTMLAttributeValueNode (location: (1:17)-(1:31))
+        │       │               ├── open_quote: """ (location: (1:17)-(1:18))
+        │       │               ├── children: (1 item)
+        │       │               │   └── @ LiteralNode (location: (1:18)-(1:30))
+        │       │               │       └── content: "a >> b >>> c"
+        │       │               │
+        │       │               ├── close_quote: """ (location: (1:30)-(1:31))
+        │       │               └── quoted: true
+        │       │
+        │       │
+        │       └── is_void: false
+        │
+        ├── tag_name: "div" (location: (1:1)-(1:4))
+        ├── body: []
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (1:32)-(1:38))
+        │       ├── tag_opening: "</" (location: (1:32)-(1:34))
+        │       ├── tag_name: "div" (location: (1:34)-(1:37))
+        │       ├── children: []
+        │       └── tag_closing: ">" (location: (1:37)-(1:38))
+        │
+        ├── is_void: false
+        └── element_source: "HTML"


### PR DESCRIPTION
This pull request updates the parser to handle angle brackets and quotes in attribute values.

Previously, the parser's "looks like new attribute" heuristic would incorrectly trigger when a quoted attribute value contained HTML-like content with attributes using a different quote type. 

The heuristic now only fires when the inner quote type matches the outer opening quote, which is the actual indicator of an unclosed attribute value.

The following snippet:
```html
<iframe srcdoc="<base target='foo'>"></iframe>
```

now gets correctly parsed as:
```js
@ DocumentNode (location: (1:0)-(1:46))
└── children: (1 item)
    └── @ HTMLElementNode (location: (1:0)-(1:46))
        ├── open_tag:
        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:37))
        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
        │       ├── tag_name: "iframe" (location: (1:1)-(1:7))
        │       ├── tag_closing: ">" (location: (1:36)-(1:37))
        │       ├── children: (1 item)
        │       │   └── @ HTMLAttributeNode (location: (1:8)-(1:36))
        │       │       ├── name:
        │       │       │   └── @ HTMLAttributeNameNode (location: (1:8)-(1:14))
        │       │       │       └── children: (1 item)
        │       │       │           └── @ LiteralNode (location: (1:8)-(1:14))
        │       │       │               └── content: "srcdoc"
        │       │       │
        │       │       ├── equals: "=" (location: (1:14)-(1:15))
        │       │       └── value:
        │       │           └── @ HTMLAttributeValueNode (location: (1:15)-(1:36))
        │       │               ├── open_quote: """ (location: (1:15)-(1:16))
        │       │               ├── children: (1 item)
        │       │               │   └── @ LiteralNode (location: (1:16)-(1:35))
        │       │               │       └── content: "<base target='foo'>"
        │       │               │
        │       │               ├── close_quote: """ (location: (1:35)-(1:36))
        │       │               └── quoted: true
        │       │
        │       └── is_void: false
        │
        ├── tag_name: "iframe" (location: (1:1)-(1:7))
        ├── body: []
        ├── close_tag:
        │   └── @ HTMLCloseTagNode (location: (1:37)-(1:46))
        │       ├── tag_opening: "</" (location: (1:37)-(1:39))
        │       ├── tag_name: "iframe" (location: (1:39)-(1:45))
        │       ├── children: []
        │       └── tag_closing: ">" (location: (1:45)-(1:46))
        │
        ├── is_void: false
        └── element_source: "HTML"
```

Previously, this produced an `UnclosedQuoteError` error. 

Resolves #1507 