### PR TITLE
Automatically label a11y PRs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -129,6 +129,12 @@ linter-autofix:
     - any-glob-to-any-file:
       - '**/javascript/packages/linter/test/autofix/**/*'
 
+a11y:
+  - changed-files:
+    - any-glob-to-any-file:
+      - '**/javascript/packages/linter/src/rules/**/a11y-*'
+      - '**/javascript/packages/linter/docs/rules/**/a11y-*'
+
 language-server:
   - changed-files:
     - any-glob-to-any-file:


### PR DESCRIPTION
## scope

automatically label PRs that include changes to files in 

```
- '**/javascript/packages/linter/src/rules/a11y-*'
- '**/javascript/packages/linter/docs/rules/a11y-*'
```

with the `a11y` github label

## reasoning

inspired by 👇 

<img width="436" height="57" alt="Screenshot 2026-03-28 at 17 04 58" src="https://github.com/user-attachments/assets/92596ead-ca7a-4723-9a9c-9405f35f4358" />

so we don't have to label manually

feel free to close if not wanted 🙏 