### PR TITLE
Linter: Add `ElementStackVisitor` and migrate rules

### DIFF
--- a/javascript/packages/linter/src/rules/a11y-no-aria-unsupported-elements.ts
+++ b/javascript/packages/linter/src/rules/a11y-no-aria-unsupported-elements.ts
@@ -1,38 +1,31 @@
-import type { ParseResult, ParserOptions, HTMLElementNode, HTMLAttributeNode } from "@herb-tools/core"
-import { getTagLocalName, getAttributeName, isERBOpenTagNode, isHTMLOpenTagNode, filterHTMLAttributeNodes } from "@herb-tools/core"
-
-import { BaseRuleVisitor } from "./rule-utils.js"
 import { ParserRule } from "../types.js"
+import { ElementStackVisitor } from "./rule-utils.js"
+
+import { getAttributeName } from "@herb-tools/core"
+
+import type { ParseResult, ParserOptions, HTMLAttributeNode } from "@herb-tools/core"
 import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types.js"
 
-const UNSUPPORTED_ELEMENTS = new Set([
-  "html",
-  "meta",
-  "script",
-  "style",
-])
+class NoAriaUnsupportedElementsVisitor extends ElementStackVisitor {
+  private UNSUPPORTED_ELEMENTS = new Set([
+    "html",
+    "meta",
+    "script",
+    "style",
+  ])
 
-class NoAriaUnsupportedElementsVisitor extends BaseRuleVisitor {
-  private currentTagName: string | null = null
-  
-  visitHTMLElementNode(node: HTMLElementNode): void {  
-    this.currentTagName = getTagLocalName(node)
-    super.visitHTMLElementNode(node)
-    this.currentTagName = null
-  }
-  
   visitHTMLAttributeNode(node: HTMLAttributeNode): void {
-    if (!this.currentTagName || !UNSUPPORTED_ELEMENTS.has(this.currentTagName)) return
-  
+    if (!this.currentTagName || !this.UNSUPPORTED_ELEMENTS.has(this.currentTagName)) return
+
     const attributeName = getAttributeName(node)
     if (!attributeName) return
     if (!attributeName.startsWith("aria-") && attributeName !== "role") return
-  
+
     this.addOffense(
       `The \`${attributeName}\` attribute is not supported on the \`<${this.currentTagName}>\` element. ARIA roles, states, and properties should not be used on elements that are not visible or not interactive.`,
       node.location,
     )
-  
+
     super.visitHTMLAttributeNode(node)
   }
 }

--- a/javascript/packages/linter/src/rules/erb-no-interpolated-class-names.ts
+++ b/javascript/packages/linter/src/rules/erb-no-interpolated-class-names.ts
@@ -1,8 +1,8 @@
-import { isLiteralNode, isPureWhitespaceNode, splitLiteralsAtWhitespace, groupNodesByClass } from "@herb-tools/core"
 import { IdentityPrinter } from "@herb-tools/printer"
-
 import { ParserRule } from "../types.js"
 import { AttributeVisitorMixin } from "./rule-utils.js"
+
+import { isLiteralNode, isPureWhitespaceNode, splitLiteralsAtWhitespace, groupNodesByClass } from "@herb-tools/core"
 
 import type { Node } from "@herb-tools/core"
 import type { StaticAttributeDynamicValueParams } from "./rule-utils.js"

--- a/javascript/packages/linter/src/rules/erb-no-unsafe-raw.ts
+++ b/javascript/packages/linter/src/rules/erb-no-unsafe-raw.ts
@@ -1,9 +1,9 @@
 import { ParserRule } from "../types.js"
-import { BaseRuleVisitor } from "./rule-utils.js"
-import { isERBOutputNode, getTagLocalName, isHTMLOpenTagNode } from "@herb-tools/core"
+import { ElementStackVisitor } from "./rule-utils.js"
+import { isERBOutputNode } from "@herb-tools/core"
 
 import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types.js"
-import type { ParseResult, ERBContentNode, HTMLElementNode } from "@herb-tools/core"
+import type { ParseResult, ERBContentNode } from "@herb-tools/core"
 
 const RAW_PATTERN = /\braw[\s(]/
 const HTML_SAFE_PATTERN = /\.html_safe\b/
@@ -21,30 +21,9 @@ const RAW_TEXT_ELEMENTS = new Set([
   "plaintext",
 ])
 
-class ERBNoUnsafeRawVisitor extends BaseRuleVisitor {
-  private insideRawTextElement = false
-
-  visitHTMLElementNode(node: HTMLElementNode): void {
-    if (!isHTMLOpenTagNode(node.open_tag)) {
-      super.visitHTMLElementNode(node)
-      return
-    }
-
-    const tagName = getTagLocalName(node.open_tag)
-
-    if (tagName && RAW_TEXT_ELEMENTS.has(tagName)) {
-      const wasInside = this.insideRawTextElement
-      this.insideRawTextElement = true
-      super.visitHTMLElementNode(node)
-      this.insideRawTextElement = wasInside
-      return
-    }
-
-    super.visitHTMLElementNode(node)
-  }
-
+class ERBNoUnsafeRawVisitor extends ElementStackVisitor {
   visitERBContentNode(node: ERBContentNode): void {
-    if (this.insideRawTextElement) return
+    if (this.isInsideElement(...RAW_TEXT_ELEMENTS)) return
     if (!isERBOutputNode(node)) return
 
     const content = node.content?.value || ""

--- a/javascript/packages/linter/src/rules/html-body-only-elements.ts
+++ b/javascript/packages/linter/src/rules/html-body-only-elements.ts
@@ -1,41 +1,22 @@
 import { ParserRule } from "../types.js"
-import { BaseRuleVisitor, isBodyOnlyTag } from "./rule-utils.js"
+import { ElementStackVisitor, isBodyOnlyTag } from "./rule-utils.js"
 import { getTagLocalName } from "@herb-tools/core"
 
 import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types.js"
 import type { HTMLElementNode, ParseResult } from "@herb-tools/core"
 
-class HTMLBodyOnlyElementsVisitor extends BaseRuleVisitor {
-  private elementStack: string[] = []
-
+class HTMLBodyOnlyElementsVisitor extends ElementStackVisitor {
   visitHTMLElementNode(node: HTMLElementNode): void {
     const tagName = getTagLocalName(node)
-    if (!tagName) return
 
-    this.checkBodyOnlyElement(node, tagName)
+    if (tagName && !this.isInsideElement("body") && this.isInsideElement("head") && isBodyOnlyTag(tagName)) {
+      this.addOffense(
+        `Element \`<${tagName}>\` must be placed inside the \`<body>\` tag.`,
+        node.location,
+      )
+    }
 
-    this.elementStack.push(tagName)
-    this.visitChildNodes(node)
-    this.elementStack.pop()
-  }
-
-  private checkBodyOnlyElement(node: HTMLElementNode, tagName: string): void {
-    if (this.insideBody) return
-    if (!this.insideHead) return
-    if (!isBodyOnlyTag(tagName)) return
-
-    this.addOffense(
-      `Element \`<${tagName}>\` must be placed inside the \`<body>\` tag.`,
-      node.location,
-    )
-  }
-
-  private get insideBody(): boolean {
-    return this.elementStack.includes("body")
-  }
-
-  private get insideHead(): boolean {
-    return this.elementStack.includes("head")
+    super.visitHTMLElementNode(node)
   }
 }
 

--- a/javascript/packages/linter/src/rules/html-head-only-elements.ts
+++ b/javascript/packages/linter/src/rules/html-head-only-elements.ts
@@ -1,52 +1,27 @@
 import { ParserRule } from "../types"
-import { BaseRuleVisitor, isHeadOnlyTag } from "./rule-utils"
+import { ElementStackVisitor, isHeadOnlyTag } from "./rule-utils"
 import { hasAttribute, getTagLocalName } from "@herb-tools/core"
 
 import type { ParseResult, HTMLElementNode } from "@herb-tools/core"
 import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types"
 
-class HeadOnlyElementsVisitor extends BaseRuleVisitor {
-  private elementStack: string[] = []
-
+class HeadOnlyElementsVisitor extends ElementStackVisitor {
   visitHTMLElementNode(node: HTMLElementNode): void {
     const tagName = getTagLocalName(node)
-    if (!tagName) return
 
-    this.checkHeadOnlyElement(node, tagName)
+    if (tagName && !this.isInsideElement("head") && this.isInsideElement("body") && isHeadOnlyTag(tagName)) {
+      const isAllowedInSVG = (tagName === "title" || tagName === "style") && this.isInsideElement("svg")
+      const isMetaWithItemprop = tagName === "meta" && hasAttribute(node, "itemprop")
 
-    this.elementStack.push(tagName)
-    this.visitChildNodes(node)
-    this.elementStack.pop()
-  }
+      if (!isAllowedInSVG && !isMetaWithItemprop) {
+        this.addOffense(
+          `Element \`<${tagName}>\` must be placed inside the \`<head>\` tag.`,
+          node.location,
+        )
+      }
+    }
 
-  private checkHeadOnlyElement(node: HTMLElementNode, tagName: string): void {
-    if (this.insideHead) return
-    if (!this.insideBody) return
-    if (!isHeadOnlyTag(tagName)) return
-    if (tagName === "title" && this.insideSVG) return
-    if (tagName === "style" && this.insideSVG) return
-    if (tagName === "meta" && this.hasItempropAttribute(node)) return
-
-    this.addOffense(
-      `Element \`<${tagName}>\` must be placed inside the \`<head>\` tag.`,
-      node.location,
-    )
-  }
-
-  private hasItempropAttribute(node: HTMLElementNode): boolean {
-    return hasAttribute(node, "itemprop")
-  }
-
-  private get insideHead(): boolean {
-    return this.elementStack.includes("head")
-  }
-
-  private get insideBody(): boolean {
-    return this.elementStack.includes("body")
-  }
-
-  private get insideSVG(): boolean {
-    return this.elementStack.includes("svg")
+    super.visitHTMLElementNode(node)
   }
 }
 

--- a/javascript/packages/linter/src/rules/html-tag-name-lowercase.ts
+++ b/javascript/packages/linter/src/rules/html-tag-name-lowercase.ts
@@ -1,9 +1,9 @@
 import { ParserRule, BaseAutofixContext, Mutable } from "../types.js"
-import { BaseRuleVisitor, findParent } from "./rule-utils.js"
-import { isNode, getTagName, getTagLocalName, HTMLOpenTagNode, isHTMLElementNode, isHTMLCloseTagNode, getOpenTag } from "@herb-tools/core"
+import { BaseRuleVisitor, ElementStackVisitor, findParent } from "./rule-utils.js"
+import { getTagName, getOpenTag, isHTMLOpenTagNode, isHTMLElementNode } from "@herb-tools/core"
 
 import type { UnboundLintOffense, LintOffense, LintContext, FullRuleConfig } from "../types.js"
-import type { HTMLElementNode, HTMLCloseTagNode, ParseResult, XMLDeclarationNode, Node } from "@herb-tools/core"
+import type { HTMLOpenTagNode, HTMLCloseTagNode, ParseResult, XMLDeclarationNode, Node } from "@herb-tools/core"
 
 interface TagNameAutofixContext extends BaseAutofixContext {
   node: Mutable<HTMLOpenTagNode | HTMLCloseTagNode>
@@ -24,38 +24,32 @@ class XMLDeclarationChecker extends BaseRuleVisitor {
   }
 }
 
-class TagNameLowercaseVisitor extends BaseRuleVisitor<TagNameAutofixContext> {
-  visitHTMLElementNode(node: HTMLElementNode): void {
-    if (getTagLocalName(node) === "svg") {
-      this.checkTagName(getOpenTag(node))
-
-      if (node.close_tag && isHTMLCloseTagNode(node.close_tag)) {
-        this.checkTagName(node.close_tag)
-      }
-    } else {
-      super.visitHTMLElementNode(node)
-    }
-  }
-
+class TagNameLowercaseVisitor extends ElementStackVisitor<TagNameAutofixContext> {
   visitHTMLOpenTagNode(node: HTMLOpenTagNode) {
-    this.checkTagName(node)
+    if (!this.isInsideElement("svg") || this.currentTagName === "svg") {
+      this.checkTagName(node)
+    }
+
+    super.visitHTMLOpenTagNode(node)
   }
 
   visitHTMLCloseTagNode(node: HTMLCloseTagNode) {
-    this.checkTagName(node)
+    if (!this.isInsideElement("svg") || this.currentTagName === "svg") {
+      this.checkTagName(node)
+    }
+
+    super.visitHTMLCloseTagNode(node)
   }
 
-  private checkTagName(node: HTMLOpenTagNode | HTMLCloseTagNode | null): void {
-    if (!node) return
-
+  private checkTagName(node: HTMLOpenTagNode | HTMLCloseTagNode): void {
     const tagName = getTagName(node)
 
     if (!tagName) return
 
     const lowercaseTagName = tagName.toLowerCase()
 
-    const type = isNode(node, HTMLOpenTagNode) ? "Opening" : "Closing"
-    const open = isNode(node, HTMLOpenTagNode) ? "<" : "</"
+    const type = isHTMLOpenTagNode(node) ? "Opening" : "Closing"
+    const open = isHTMLOpenTagNode(node) ? "<" : "</"
 
     if (tagName !== lowercaseTagName) {
       this.addOffense(

--- a/javascript/packages/linter/src/rules/rule-utils.ts
+++ b/javascript/packages/linter/src/rules/rule-utils.ts
@@ -11,12 +11,14 @@ import {
   getCombinedAttributeNameString,
   getAttributeValueNodes,
   getAttributeValue,
+  getTagLocalName,
   forEachAttribute,
 } from "@herb-tools/core"
 
 import type {
   HTMLAttributeNameNode,
   HTMLAttributeNode,
+  HTMLElementNode,
   HTMLOpenTagNode,
   LexResult,
   Token,
@@ -164,6 +166,73 @@ export abstract class ControlFlowTrackingVisitor<TAutofixContext extends BaseAut
   protected abstract onExitBranch(stateToRestore: TBranchState): void
 }
 
+
+/**
+ * Mixin that tracks the current HTML element stack during AST traversal.
+ * Provides convenient access to the current element, tag name, parent element,
+ * and ancestry checks.
+ *
+ * Useful for rules that need element context when visiting child nodes
+ * (e.g., checking attributes in the context of their parent element).
+ *
+ * @template TAutofixContext - Type for autofix context (node + custom data)
+ */
+export abstract class ElementStackVisitor<TAutofixContext extends BaseAutofixContext = BaseAutofixContext> extends BaseRuleVisitor<TAutofixContext> {
+  private elementStack: HTMLElementNode[] = []
+
+  visitHTMLElementNode(node: HTMLElementNode): void {
+    this.elementStack.push(node)
+    super.visitHTMLElementNode(node)
+    this.elementStack.pop()
+  }
+
+  /**
+   * The current HTML element being visited, or null if not inside an element.
+   */
+  protected get currentElement(): HTMLElementNode | null {
+    return this.elementStack.at(-1) ?? null
+  }
+
+  /**
+   * The tag name of the current HTML element, or null if not inside an element.
+   */
+  protected get currentTagName(): string | null {
+    const element = this.currentElement
+    return element ? getTagLocalName(element) : null
+  }
+
+  /**
+   * The parent HTML element (one level up), or null if at the top level.
+   */
+  protected get parentElement(): HTMLElementNode | null {
+    return this.elementStack.at(-2) ?? null
+  }
+
+  /**
+   * The tag name of the parent HTML element, or null if at the top level.
+   */
+  protected get parentTagName(): string | null {
+    const element = this.parentElement
+    return element ? getTagLocalName(element) : null
+  }
+
+  /**
+   * Checks if the current traversal position is inside an element with any of the given tag names.
+   */
+  protected isInsideElement(...tagNames: string[]): boolean {
+    return this.elementStack.some(element => {
+      const name = getTagLocalName(element)
+      return name !== null && tagNames.includes(name)
+    })
+  }
+
+  /**
+   * The current nesting depth (number of ancestor HTML elements).
+   */
+  protected get elementDepth(): number {
+    return this.elementStack.length
+  }
+}
 
 /**
  * Common HTML element categorization

--- a/javascript/packages/linter/src/rules/svg-tag-name-capitalization.ts
+++ b/javascript/packages/linter/src/rules/svg-tag-name-capitalization.ts
@@ -1,69 +1,49 @@
 import { ParserRule } from "../types.js"
-import { BaseRuleVisitor, SVG_CAMEL_CASE_ELEMENTS, SVG_LOWERCASE_TO_CAMELCASE } from "./rule-utils.js"
-import { isHTMLOpenTagNode, isHTMLCloseTagNode } from "@herb-tools/core"
+import { ElementStackVisitor, SVG_CAMEL_CASE_ELEMENTS, SVG_LOWERCASE_TO_CAMELCASE } from "./rule-utils.js"
 
 import type { UnboundLintOffense, LintOffense, LintContext, BaseAutofixContext, Mutable, FullRuleConfig } from "../types.js"
-import type { HTMLElementNode, HTMLOpenTagNode, HTMLCloseTagNode, ParseResult } from "@herb-tools/core"
+import type { HTMLOpenTagNode, HTMLCloseTagNode, ERBOpenTagNode, Token, ParseResult, ParserOptions } from "@herb-tools/core"
+
+type HTMLTagNode = HTMLOpenTagNode | HTMLCloseTagNode
 
 interface SVGTagNameCapitalizationAutofixContext extends BaseAutofixContext {
-  node: Mutable<HTMLOpenTagNode | HTMLCloseTagNode>
+  node: Mutable<HTMLTagNode>
   currentTagName: string
   correctCamelCase: string
 }
 
-class SVGTagNameCapitalizationVisitor extends BaseRuleVisitor<SVGTagNameCapitalizationAutofixContext> {
-  private insideSVG = false
-
-  visitHTMLElementNode(node: HTMLElementNode): void {
-    const tagName = node.tag_name?.value
-
-    if (tagName && ["svg"].includes(tagName.toLowerCase())) {
-      const wasInsideSVG = this.insideSVG
-      this.insideSVG = true
-      this.visitChildNodes(node)
-      this.insideSVG = wasInsideSVG
-      return
-    }
-
-    if (this.insideSVG) {
-      if (isHTMLOpenTagNode(node.open_tag)) {
-        this.checkTagName(node.open_tag)
-      }
-
-      if (node.close_tag && isHTMLCloseTagNode(node.close_tag)) {
-        this.checkTagName(node.close_tag)
-      }
-    }
-
-    this.visitChildNodes(node)
+class SVGTagNameCapitalizationVisitor extends ElementStackVisitor<SVGTagNameCapitalizationAutofixContext> {
+  visitHTMLOpenTagNode(node: HTMLOpenTagNode): void {
+    this.checkTagName(node.tag_name, "Opening", node)
+    super.visitHTMLOpenTagNode(node)
   }
 
+  visitHTMLCloseTagNode(node: HTMLCloseTagNode): void {
+    this.checkTagName(node.tag_name, "Closing", node)
+    super.visitHTMLCloseTagNode(node)
+  }
 
-  private checkTagName(node: HTMLOpenTagNode | HTMLCloseTagNode): void {
-    const tagName = node.tag_name?.value
+  visitERBOpenTagNode(node: ERBOpenTagNode): void {
+    this.checkTagName(node.tag_name, "ERB opening")
+    super.visitERBOpenTagNode(node)
+  }
+
+  private checkTagName(tagNameToken: Token | null, type: string, autofixNode?: HTMLTagNode): void {
+    if (!this.isInsideElement("svg")) return
+
+    const tagName = tagNameToken?.value
     if (!tagName) return
 
     if (SVG_CAMEL_CASE_ELEMENTS.has(tagName)) return
 
-    const lowercaseTagName = tagName.toLowerCase()
-    const correctCamelCase = SVG_LOWERCASE_TO_CAMELCASE.get(lowercaseTagName)
+    const correctCamelCase = SVG_LOWERCASE_TO_CAMELCASE.get(tagName.toLowerCase())
+    if (!correctCamelCase || tagName === correctCamelCase) return
 
-    if (correctCamelCase && tagName !== correctCamelCase) {
-      let type: string = node.type
-
-      if (isHTMLOpenTagNode(node)) type = "Opening"
-      if (isHTMLCloseTagNode(node)) type = "Closing"
-
-      this.addOffense(
-        `${type} SVG tag name \`${tagName}\` should use proper capitalization. Use \`${correctCamelCase}\` instead.`,
-        node.tag_name!.location,
-        {
-          node,
-          currentTagName: tagName,
-          correctCamelCase
-        }
-      )
-    }
+    this.addOffense(
+      `${type} SVG tag name \`${tagName}\` should use proper capitalization. Use \`${correctCamelCase}\` instead.`,
+      tagNameToken!.location,
+      autofixNode ? { node: autofixNode, currentTagName: tagName, correctCamelCase } : undefined
+    )
   }
 }
 
@@ -76,6 +56,12 @@ export class SVGTagNameCapitalizationRule extends ParserRule<SVGTagNameCapitaliz
     return {
       enabled: true,
       severity: "error"
+    }
+  }
+
+  get parserOptions(): Partial<ParserOptions> {
+    return {
+      action_view_helpers: true,
     }
   }
 

--- a/javascript/packages/linter/test/autofix/svg-tag-name-capitalization.autofix.test.ts
+++ b/javascript/packages/linter/test/autofix/svg-tag-name-capitalization.autofix.test.ts
@@ -85,4 +85,26 @@ describe("svg-tag-name-capitalization autofix", () => {
     expect(result.source).toBe(expected)
     expect(result.fixed).toHaveLength(2)
   })
+
+  test("does not autofix ERB tag helpers", () => {
+    const input = `<svg><%= tag.lineargradient id: "grad1" do %><stop offset="0%" /><% end %></svg>`
+
+    const linter = new Linter(Herb, [SVGTagNameCapitalizationRule])
+    const result = linter.autofix(input)
+
+    expect(result.source).toBe(input)
+    expect(result.fixed).toHaveLength(0)
+    expect(result.unfixed).toHaveLength(1)
+  })
+
+  test("does not autofix content_tag helpers", () => {
+    const input = `<svg><%= content_tag :lineargradient, id: "grad1" do %><stop offset="0%" /><% end %></svg>`
+
+    const linter = new Linter(Herb, [SVGTagNameCapitalizationRule])
+    const result = linter.autofix(input)
+
+    expect(result.source).toBe(input)
+    expect(result.fixed).toHaveLength(0)
+    expect(result.unfixed).toHaveLength(1)
+  })
 })

--- a/javascript/packages/linter/test/rules/svg-tag-name-capitalization.test.ts
+++ b/javascript/packages/linter/test/rules/svg-tag-name-capitalization.test.ts
@@ -98,6 +98,74 @@ describe("svg-tag-name-capitalization", () => {
     `)
   })
 
+  test("fails for incorrectly cased tag.* helpers inside SVG", () => {
+    expectError('ERB opening SVG tag name `lineargradient` should use proper capitalization. Use `linearGradient` instead.')
+    expectError('ERB opening SVG tag name `clippath` should use proper capitalization. Use `clipPath` instead.')
+
+    assertOffenses(`
+      <svg>
+        <%= tag.lineargradient id: "grad1" do %>
+          <stop offset="0%" />
+        <% end %>
+        <%= tag.clippath id: "clip" do %>
+          <rect x="0" y="0" width="100" height="100" />
+        <% end %>
+      </svg>
+    `)
+  })
+
+  test("fails for incorrectly cased content_tag helpers inside SVG", () => {
+    expectError('ERB opening SVG tag name `lineargradient` should use proper capitalization. Use `linearGradient` instead.')
+    expectError('ERB opening SVG tag name `foreignobject` should use proper capitalization. Use `foreignObject` instead.')
+
+    assertOffenses(`
+      <svg>
+        <%= content_tag :lineargradient, id: "grad1" do %>
+          <stop offset="0%" />
+        <% end %>
+        <%= content_tag :foreignobject do %>
+          <div>HTML content</div>
+        <% end %>
+      </svg>
+    `)
+  })
+
+  test("passes for correctly cased tag.* helpers inside SVG", () => {
+    expectNoOffenses(`
+      <svg>
+        <%= tag.linearGradient id: "grad1" do %>
+          <stop offset="0%" />
+        <% end %>
+        <%= tag.clipPath id: "clip" do %>
+          <rect x="0" y="0" width="100" height="100" />
+        <% end %>
+      </svg>
+    `)
+  })
+
+  test("passes for correctly cased content_tag helpers inside SVG", () => {
+    expectNoOffenses(`
+      <svg>
+        <%= content_tag :linearGradient, id: "grad1" do %>
+          <stop offset="0%" />
+        <% end %>
+      </svg>
+    `)
+  })
+
+  test("ignores ERB tag helpers outside SVG", () => {
+    expectNoOffenses(`
+      <div>
+        <%= tag.lineargradient id: "grad1" do %>
+          <stop offset="0%" />
+        <% end %>
+        <%= content_tag :clippath do %>
+          <rect x="0" y="0" width="100" height="100" />
+        <% end %>
+      </div>
+    `)
+  })
+
   test("only checks elements within SVG context", () => {
     expectError('Opening SVG tag name `LINEARGRADIENT` should use proper capitalization. Use `linearGradient` instead.')
     expectError('Closing SVG tag name `LINEARGRADIENT` should use proper capitalization. Use `linearGradient` instead.')


### PR DESCRIPTION
This pull request introduces a new `ElementStackVisitor`. A base class for linter rules that need to know their position in the HTML element hierarchy during the syntax tree traversal. 

It automatically maintains an element stack by pushing/popping in `visitHTMLElementNode`, and exposes convenient accessors like `currentTagName`, `parentElement`, `isInsideElement("svg")`, and `elementDepth`. 

Rules that previously maintained their own `elementStack: string[]` or `insideSVG: boolean` flags can now extend `ElementStackVisitor` instead and get this behavior for free.

This pull request migrates the following 6 to use the new `ElementStackVisitor` base class.

|               Rule                |                              What was removed                              |
|-----------------------------------|----------------------------------------------------------------------------|
| `html-body-only-elements`           | Manual `elementStack: string[]` with `insideBody`/`insideHead` getters           |
| `html-head-only-elements`           | Manual `elementStack: string[]` with `insideHead`/`insideBody`/`insideSVG` getters |
| `erb-no-unsafe-raw`                 | Manual `insideRawTextElement` boolean with save/restore                      |
| `svg-tag-name-capitalization`       | Manual `insideSVG` boolean with save/restore                                 |
| `html-tag-name-lowercase`           | Manual SVG-skipping logic in `visitHTMLElementNode`                          |
| `a11y-no-aria-unsupported-elements` | Manual `currentTagName` tracking with save/restore                           |


Two more rules also maintain manual element stacks but extend other base classes which aren't compatible with `ElementStackVisitor` today:

- `html-no-unescaped-entities` (extends `AttributeVisitorMixin`)
- `html-no-duplicate-meta-names`  (extends `ControlFlowTrackingVisitor`)
