### PR TITLE
Linter: Implement `erb-no-debug-output` rule

### DIFF
--- a/javascript/packages/language-server/src/linter_service.ts
+++ b/javascript/packages/language-server/src/linter_service.ts
@@ -150,6 +150,7 @@ export class LinterService {
       this.showCustomRuleWarnings()
 
       const linterConfig = projectConfig?.config?.linter || { enabled: true, rules: {} }
+      const hasConfigFile = projectConfig ? Config.exists(projectConfig.projectPath) : false
 
       const config = Config.fromObject({
         linter: {
@@ -161,7 +162,8 @@ export class LinterService {
         }
       }, { projectPath: projectConfig?.projectPath || process.cwd() })
 
-      const { enabled: filteredRules } = Linter.filterRulesByConfig(this.allRules, config.linter?.rules, config.configVersion)
+      const configVersion = hasConfigFile ? config.configVersion : undefined
+      const { enabled: filteredRules } = Linter.filterRulesByConfig(this.allRules, config.linter?.rules, configVersion)
 
       this.linter = new Linter(Herb, filteredRules, config, this.allRules)
     }

--- a/javascript/packages/linter/docs/rules/README.md
+++ b/javascript/packages/linter/docs/rules/README.md
@@ -24,6 +24,7 @@ This page contains documentation for all Herb Linter rules.
 
 - [`erb-comment-syntax`](./erb-comment-syntax.md) - Disallow Ruby comments immediately after ERB tags
 - [`erb-no-case-node-children`](./erb-no-case-node-children.md) - Don't use `children` for `case/when` and `case/in` nodes
+- [`erb-no-debug-output`](./erb-no-debug-output.md) - Disallow debug output methods (`p`, `pp`, `puts`, `print`, `debug`) in ERB templates
 - [`erb-no-conditional-html-element`](./erb-no-conditional-html-element.md) - Disallow conditional HTML elements
 - [`erb-no-duplicate-branch-elements`](./erb-no-duplicate-branch-elements.md) - Disallow duplicate elements across conditional branches
 - [`erb-no-empty-control-flow`](./erb-no-empty-control-flow.md) - Disallow empty ERB control flow blocks

--- a/javascript/packages/linter/docs/rules/erb-no-debug-output.md
+++ b/javascript/packages/linter/docs/rules/erb-no-debug-output.md
@@ -1,0 +1,76 @@
+# Linter Rule: Disallow debug output methods in ERB templates
+
+**Rule:** `erb-no-debug-output`
+
+## Description
+
+This rule disallows using `p`, `pp`, `puts`, `print`, `warn`, `debug`, `byebug`, `binding.pry`, and `binding.irb` in ERB templates. These are debug output methods and debugger breakpoints that should not appear in production templates.
+
+## Rationale
+
+Debug output methods like `p`, `pp`, `puts`, `print`, `warn`, and `debug` are commonly used during development to inspect values, and debugger breakpoints like `byebug`, `binding.pry`, and `binding.irb` are used to pause execution. All of these should be removed before committing code. In ERB templates, `p`, `pp`, `puts`, `print`, and `warn` bypass the rendering pipeline and write directly to stdout/stderr, while `debug` renders a YAML dump into the HTML. None of these should appear in production templates.
+
+Use `<%= ... %>` to display content in the rendered HTML, or use proper logging (e.g., `Rails.logger`) for debugging purposes.
+
+## Examples
+
+
+### ✅ Good
+
+```erb
+<%= @user.name %>
+```
+
+### 🚫 Bad
+
+```erb
+<% puts "hello" %>
+```
+
+```erb
+<% p @user %>
+```
+
+```erb
+<% pp @user %>
+```
+
+```erb
+<% print "debug" %>
+```
+
+```erb
+<%= puts "value" %>
+```
+
+```erb
+<% warn "something went wrong" %>
+```
+
+```erb
+<%= debug @user %>
+```
+
+```erb
+<% byebug %>
+```
+
+```erb
+<% binding.pry %>
+```
+
+```erb
+<% binding.irb %>
+```
+
+## References
+
+- [`Kernel#puts`](https://ruby-doc.org/core/Kernel.html#method-i-puts)
+- [`Kernel#p`](https://ruby-doc.org/core/Kernel.html#method-i-p)
+- [`Kernel#pp`](https://ruby-doc.org/core/Kernel.html#method-i-pp)
+- [`Kernel#print`](https://ruby-doc.org/core/Kernel.html#method-i-print)
+- [`Kernel#warn`](https://ruby-doc.org/core/Kernel.html#method-i-warn)
+- [`ActionView::Helpers::DebugHelper`](https://api.rubyonrails.org/classes/ActionView/Helpers/DebugHelper.html)
+- [`byebug`](https://github.com/deivid-rodriguez/byebug)
+- [`binding.pry`](https://github.com/pry/pry)
+- [`binding.irb`](https://ruby-doc.org/stdlib/libdoc/irb/rdoc/IRB.html)

--- a/javascript/packages/linter/src/rules.ts
+++ b/javascript/packages/linter/src/rules.ts
@@ -13,6 +13,7 @@ import { ActionViewStrictLocalsPartialOnlyRule } from "./rules/actionview-strict
 
 import { ERBCommentSyntax } from "./rules/erb-comment-syntax.js";
 import { ERBNoCaseNodeChildrenRule } from "./rules/erb-no-case-node-children.js"
+import { ERBNoDebugOutputRule } from "./rules/erb-no-debug-output.js"
 import { ERBNoConditionalHTMLElementRule } from "./rules/erb-no-conditional-html-element.js"
 import { ERBNoConditionalOpenTagRule } from "./rules/erb-no-conditional-open-tag.js"
 import { ERBNoDuplicateBranchElementsRule } from "./rules/erb-no-duplicate-branch-elements.js"
@@ -113,6 +114,7 @@ export const rules: RuleClass[] = [
 
   ERBCommentSyntax,
   ERBNoCaseNodeChildrenRule,
+  ERBNoDebugOutputRule,
   ERBNoEmptyControlFlowRule,
   ERBNoConditionalHTMLElementRule,
   ERBNoConditionalOpenTagRule,

--- a/javascript/packages/linter/src/rules/erb-no-debug-output.ts
+++ b/javascript/packages/linter/src/rules/erb-no-debug-output.ts
@@ -1,0 +1,84 @@
+import { PrismVisitor, isERBOutputNode } from "@herb-tools/core"
+import type { ParseResult, ERBContentNode, ParserOptions, PrismNode } from "@herb-tools/core"
+
+import { BaseRuleVisitor, locationFromOffset } from "./rule-utils.js"
+import { ParserRule } from "../types.js"
+import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types.js"
+
+const DEBUG_OUTPUT_METHODS = new Set(["p", "pp", "puts", "print", "warn", "debug", "byebug"])
+
+const BINDING_DEBUGGER_METHODS = new Set(["pry", "irb"])
+
+function isBindingDebuggerCall(node: PrismNode): boolean {
+  if (!BINDING_DEBUGGER_METHODS.has(node.name)) return false
+  if (node.receiver?.constructor?.name !== "CallNode") return false
+
+  return node.receiver.name === "binding" && !node.receiver.receiver
+}
+
+class DebugOutputCallCollector extends PrismVisitor {
+  public readonly calls: PrismNode[] = []
+
+  visitCallNode(node: PrismNode): void {
+    if (!node.receiver && DEBUG_OUTPUT_METHODS.has(node.name)) {
+      this.calls.push(node)
+    } else if (isBindingDebuggerCall(node)) {
+      this.calls.push(node)
+    }
+
+    this.visitChildNodes(node)
+  }
+}
+
+class ERBNoDebugOutputVisitor extends BaseRuleVisitor {
+  visitERBContentNode(node: ERBContentNode): void {
+    const prismNode = node.prismNode
+    if (!prismNode) return
+
+    const source = node.source
+    if (!source) return
+
+    const collector = new DebugOutputCallCollector()
+    collector.visit(prismNode)
+
+    for (const call of collector.calls) {
+      const { startOffset, length } = call.location
+      const location = locationFromOffset(source, startOffset, length)
+      const callSource = source.substring(startOffset, startOffset + length)
+
+      this.addOffense(
+        `Avoid using \`${callSource}\` in ERB templates. Remove the debug output or use \`<%= ... %>\` to display content.`,
+        location,
+        undefined,
+        undefined,
+        ["unnecessary"],
+      )
+    }
+  }
+}
+
+export class ERBNoDebugOutputRule extends ParserRule {
+  static ruleName = "erb-no-debug-output"
+  static introducedIn = this.version("unreleased")
+
+  get defaultConfig(): FullRuleConfig {
+    return {
+      enabled: true,
+      severity: "error",
+    }
+  }
+
+  get parserOptions(): Partial<ParserOptions> {
+    return {
+      prism_nodes: true,
+    }
+  }
+
+  check(result: ParseResult, context?: Partial<LintContext>): UnboundLintOffense[] {
+    const visitor = new ERBNoDebugOutputVisitor(this.ruleName, context)
+
+    visitor.visit(result.value)
+
+    return visitor.offenses
+  }
+}

--- a/javascript/packages/linter/src/rules/erb-no-unused-literals.ts
+++ b/javascript/packages/linter/src/rules/erb-no-unused-literals.ts
@@ -103,6 +103,9 @@ class ERBNoUnusedLiteralsVisitor extends BaseRuleVisitor {
       this.addOffense(
         `Avoid using silent ERB tags for literals. \`${literalSource}\` is evaluated but never used or output.`,
         location,
+        undefined,
+        undefined,
+        ["unnecessary"],
       )
     }
   }

--- a/javascript/packages/linter/src/rules/index.ts
+++ b/javascript/packages/linter/src/rules/index.ts
@@ -18,6 +18,7 @@ export * from "./actionview-strict-locals-partial-only.js"
 
 export * from "./erb-comment-syntax.js"
 export * from "./erb-no-case-node-children.js"
+export * from "./erb-no-debug-output.js"
 export * from "./erb-no-conditional-open-tag.js"
 export * from "./erb-no-duplicate-branch-elements.js"
 export * from "./erb-no-empty-control-flow.js"

--- a/javascript/packages/linter/test/__snapshots__/cli.test.ts.snap
+++ b/javascript/packages/linter/test/__snapshots__/cli.test.ts.snap
@@ -109,7 +109,7 @@ test/fixtures/ignored.html.erb:8:8
   Offenses     5 errors | 2 warnings (7 offenses across 1 file)
   Note         3 additional offenses reported (would have been ignored)
   Fixable      7 offenses | 4 autocorrectable using \`--fix\`
-  Rules        72 enabled | 10 not enabled | 8 skipped (version)
+  Rules        72 enabled | 10 not enabled | 9 skipped (version)
 
  TIP: Run herb-lint --init to create a .herb.yml and lock the version.
       This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
@@ -170,7 +170,7 @@ test/fixtures/test-file-with-errors.html.erb:2:22
   Checked      1 file
   Offenses     2 errors | 1 warning (3 offenses across 1 file)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        72 enabled | 10 not enabled | 8 skipped (version)"
+  Rules        72 enabled | 10 not enabled | 9 skipped (version)"
 `;
 
 exports[`CLI Output Formatting > GitHub Actions format includes rule codes 1`] = `
@@ -193,7 +193,7 @@ test/fixtures/no-trailing-newline.html.erb:1:29
   Checked      1 file
   Offenses     1 error | 0 warnings (1 offense across 1 file)
   Fixable      1 offense | 1 autocorrectable using \`--fix\`
-  Rules        72 enabled | 10 not enabled | 8 skipped (version)"
+  Rules        72 enabled | 10 not enabled | 9 skipped (version)"
 `;
 
 exports[`CLI Output Formatting > GitHub Actions format includes rule codes 2`] = `
@@ -242,7 +242,7 @@ test/fixtures/erb-no-extra-whitespace-inside-tags.html.erb:9:3
   Checked      1 file
   Offenses     3 errors | 0 warnings (3 offenses across 1 file)
   Fixable      3 offenses | 3 autocorrectable using \`--fix\`
-  Rules        72 enabled | 10 not enabled | 8 skipped (version)
+  Rules        72 enabled | 10 not enabled | 9 skipped (version)
 
  TIP: Run herb-lint --init to create a .herb.yml and lock the version.
       This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
@@ -284,7 +284,7 @@ test/fixtures/ignored.html.erb:6:14
   Checked      1 file
   Offenses     2 errors | 0 warnings | 3 ignored (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        72 enabled | 10 not enabled | 8 skipped (version)
+  Rules        72 enabled | 10 not enabled | 9 skipped (version)
 
  TIP: Run herb-lint --init to create a .herb.yml and lock the version.
       This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
@@ -311,7 +311,7 @@ test/fixtures/parser-errors.html.erb:2:16
   Checked      1 file
   Offenses     1 error | 0 warnings (1 offense across 1 file)
   Fixable      0 offenses
-  Rules        72 enabled | 10 not enabled | 8 skipped (version)
+  Rules        72 enabled | 10 not enabled | 9 skipped (version)
 
  TIP: Run herb-lint --init to create a .herb.yml and lock the version.
       This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
@@ -527,7 +527,7 @@ test/fixtures/multiple-rule-offenses.html.erb:4:2
   Checked      1 file
   Offenses     8 errors | 6 warnings (14 offenses across 1 file)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        72 enabled | 10 not enabled | 8 skipped (version)
+  Rules        72 enabled | 10 not enabled | 9 skipped (version)
 
  TIP: Run herb-lint --init to create a .herb.yml and lock the version.
       This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
@@ -625,7 +625,7 @@ test/fixtures/few-rule-offenses.html.erb:6:0
   Checked      1 file
   Offenses     4 errors | 2 warnings (6 offenses across 1 file)
   Fixable      6 offenses | 3 autocorrectable using \`--fix\`
-  Rules        72 enabled | 10 not enabled | 8 skipped (version)
+  Rules        72 enabled | 10 not enabled | 9 skipped (version)
 
  TIP: Run herb-lint --init to create a .herb.yml and lock the version.
       This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
@@ -665,7 +665,7 @@ test/fixtures/bad-file.html.erb:1:16
   Checked      1 file
   Offenses     2 errors | 0 warnings (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        72 enabled | 10 not enabled | 8 skipped (version)"
+  Rules        72 enabled | 10 not enabled | 9 skipped (version)"
 `;
 
 exports[`CLI Output Formatting > formats GitHub Actions output correctly for clean file 1`] = `
@@ -676,7 +676,7 @@ exports[`CLI Output Formatting > formats GitHub Actions output correctly for cle
   Checked      1 file
   Offenses     0 offenses
   Fixable      0 offenses
-  Rules        72 enabled | 10 not enabled | 8 skipped (version)"
+  Rules        72 enabled | 10 not enabled | 9 skipped (version)"
 `;
 
 exports[`CLI Output Formatting > formats GitHub Actions output correctly for file with errors 1`] = `
@@ -734,7 +734,7 @@ test/fixtures/test-file-with-errors.html.erb:2:22
   Checked      1 file
   Offenses     2 errors | 1 warning (3 offenses across 1 file)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        72 enabled | 10 not enabled | 8 skipped (version)"
+  Rules        72 enabled | 10 not enabled | 9 skipped (version)"
 `;
 
 exports[`CLI Output Formatting > formats GitHub Actions output with --format=github option 1`] = `
@@ -771,7 +771,7 @@ test/fixtures/test-file-simple.html.erb:2:22
   Checked      1 file
   Offenses     2 errors | 0 warnings (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        72 enabled | 10 not enabled | 8 skipped (version)
+  Rules        72 enabled | 10 not enabled | 9 skipped (version)
 
  TIP: Run herb-lint --init to create a .herb.yml and lock the version.
       This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
@@ -976,7 +976,7 @@ test/fixtures/test-file-with-errors.html.erb:2:22
   Checked      1 file
   Offenses     2 errors | 1 warning (3 offenses across 1 file)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        72 enabled | 10 not enabled | 8 skipped (version)
+  Rules        72 enabled | 10 not enabled | 9 skipped (version)
 
  TIP: Run herb-lint --init to create a .herb.yml and lock the version.
       This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
@@ -996,7 +996,7 @@ exports[`CLI Output Formatting > formats simple output correctly 1`] = `
   Checked      1 file
   Offenses     2 errors | 0 warnings (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        72 enabled | 10 not enabled | 8 skipped (version)
+  Rules        72 enabled | 10 not enabled | 9 skipped (version)
 
  TIP: Run herb-lint --init to create a .herb.yml and lock the version.
       This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
@@ -1016,7 +1016,7 @@ exports[`CLI Output Formatting > formats simple output for bad-file correctly 1`
   Checked      1 file
   Offenses     2 errors | 0 warnings (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        72 enabled | 10 not enabled | 8 skipped (version)
+  Rules        72 enabled | 10 not enabled | 9 skipped (version)
 
  TIP: Run herb-lint --init to create a .herb.yml and lock the version.
       This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
@@ -1030,7 +1030,7 @@ exports[`CLI Output Formatting > formats success output correctly 1`] = `
   Checked      1 file
   Offenses     0 offenses
   Fixable      0 offenses
-  Rules        72 enabled | 10 not enabled | 8 skipped (version)
+  Rules        72 enabled | 10 not enabled | 9 skipped (version)
 
  TIP: Run herb-lint --init to create a .herb.yml and lock the version.
       This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
@@ -1044,7 +1044,7 @@ exports[`CLI Output Formatting > handles boolean attributes 1`] = `
   Checked      1 file
   Offenses     0 offenses
   Fixable      0 offenses
-  Rules        72 enabled | 10 not enabled | 8 skipped (version)
+  Rules        72 enabled | 10 not enabled | 9 skipped (version)
 
  TIP: Run herb-lint --init to create a .herb.yml and lock the version.
       This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
@@ -1080,7 +1080,7 @@ test/fixtures/bad-file.html.erb:1:16
   Checked      1 file
   Offenses     2 errors | 0 warnings (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        72 enabled | 10 not enabled | 8 skipped (version)
+  Rules        72 enabled | 10 not enabled | 9 skipped (version)
 
  TIP: Run herb-lint --init to create a .herb.yml and lock the version.
       This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
@@ -1213,7 +1213,7 @@ test/fixtures/disabled-1.html.erb:14:19
   Checked      1 file
   Offenses     2 errors | 6 warnings | 8 ignored (8 offenses across 1 file)
   Fixable      8 offenses | 1 autocorrectable using \`--fix\`
-  Rules        72 enabled | 10 not enabled | 8 skipped (version)
+  Rules        72 enabled | 10 not enabled | 9 skipped (version)
 
  TIP: Run herb-lint --init to create a .herb.yml and lock the version.
       This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
@@ -1417,7 +1417,7 @@ test/fixtures/disabled-2.html.erb:2:44
   Checked      1 file
   Offenses     6 errors | 7 warnings | 5 ignored (13 offenses across 1 file)
   Fixable      13 offenses | 6 autocorrectable using \`--fix\`
-  Rules        72 enabled | 10 not enabled | 8 skipped (version)
+  Rules        72 enabled | 10 not enabled | 9 skipped (version)
 
  TIP: Run herb-lint --init to create a .herb.yml and lock the version.
       This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
@@ -1478,5 +1478,5 @@ test/fixtures/test-file-with-errors.html.erb:2:22
   Checked      1 file
   Offenses     2 errors | 1 warning (3 offenses across 1 file)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        72 enabled | 10 not enabled | 8 skipped (version)"
+  Rules        72 enabled | 10 not enabled | 9 skipped (version)"
 `;

--- a/javascript/packages/linter/test/rules/erb-no-debug-output.test.ts
+++ b/javascript/packages/linter/test/rules/erb-no-debug-output.test.ts
@@ -1,0 +1,221 @@
+import dedent from "dedent"
+import { describe, test } from "vitest"
+
+import { ERBNoDebugOutputRule } from "../../src/rules/erb-no-debug-output.js"
+import { createLinterTest } from "../helpers/linter-test-helper.js"
+
+const { expectNoOffenses, expectError, assertOffenses } = createLinterTest(ERBNoDebugOutputRule)
+
+describe("ERBNoDebugOutputRule", () => {
+  describe("valid cases", () => {
+    test("passes for regular method calls", () => {
+      expectNoOffenses(dedent`
+        <% render partial: "header" %>
+        <% some_method %>
+        <% helper_call(arg) %>
+      `)
+    })
+
+    test("passes for output tags", () => {
+      expectNoOffenses(dedent`
+        <%= content_tag(:p, "Hello") %>
+        <%= link_to "Home", root_path %>
+      `)
+    })
+
+    test("passes for control flow", () => {
+      expectNoOffenses(dedent`
+        <% if logged_in? %>
+          <p>Welcome!</p>
+        <% end %>
+      `)
+    })
+
+    test("passes for assignments", () => {
+      expectNoOffenses(dedent`
+        <% name = "hello" %>
+        <% @title = "Hello" %>
+      `)
+    })
+
+    test("passes for method calls with a receiver", () => {
+      expectNoOffenses(dedent`
+        <% $stdout.puts "hello" %>
+        <% logger.print "debug info" %>
+        <% object.p %>
+      `)
+    })
+
+    test("passes for p used as a tag helper", () => {
+      expectNoOffenses(dedent`
+        <%= content_tag(:p, "paragraph") %>
+      `)
+    })
+
+    test("passes for iterators and blocks", () => {
+      expectNoOffenses(dedent`
+        <% @items.each do |item| %>
+          <%= item.name %>
+        <% end %>
+      `)
+    })
+  })
+
+  describe("invalid cases", () => {
+    test("fails for puts in silent tag", () => {
+      expectError('Avoid using `puts "hello"` in ERB templates. Remove the debug output or use `<%= ... %>` to display content.')
+
+      assertOffenses(dedent`
+        <% puts "hello" %>
+      `)
+    })
+
+    test("fails for p in silent tag", () => {
+      expectError("Avoid using `p @user` in ERB templates. Remove the debug output or use `<%= ... %>` to display content.")
+
+      assertOffenses(dedent`
+        <% p @user %>
+      `)
+    })
+
+    test("fails for print in silent tag", () => {
+      expectError('Avoid using `print "debug"` in ERB templates. Remove the debug output or use `<%= ... %>` to display content.')
+
+      assertOffenses(dedent`
+        <% print "debug" %>
+      `)
+    })
+
+    test("fails for puts in output tag", () => {
+      expectError('Avoid using `puts "hello"` in ERB templates. Remove the debug output or use `<%= ... %>` to display content.')
+
+      assertOffenses(dedent`
+        <%= puts "hello" %>
+      `)
+    })
+
+    test("fails for p in output tag", () => {
+      expectError("Avoid using `p @user` in ERB templates. Remove the debug output or use `<%= ... %>` to display content.")
+
+      assertOffenses(dedent`
+        <%= p @user %>
+      `)
+    })
+
+    test("fails for print in output tag", () => {
+      expectError('Avoid using `print "debug"` in ERB templates. Remove the debug output or use `<%= ... %>` to display content.')
+
+      assertOffenses(dedent`
+        <%= print "debug" %>
+      `)
+    })
+
+    test("fails for pp in silent tag", () => {
+      expectError("Avoid using `pp @user` in ERB templates. Remove the debug output or use `<%= ... %>` to display content.")
+
+      assertOffenses(dedent`
+        <% pp @user %>
+      `)
+    })
+
+    test("fails for pp in output tag", () => {
+      expectError("Avoid using `pp @user` in ERB templates. Remove the debug output or use `<%= ... %>` to display content.")
+
+      assertOffenses(dedent`
+        <%= pp @user %>
+      `)
+    })
+
+    test("fails for warn in silent tag", () => {
+      expectError('Avoid using `warn "something went wrong"` in ERB templates. Remove the debug output or use `<%= ... %>` to display content.')
+
+      assertOffenses(dedent`
+        <% warn "something went wrong" %>
+      `)
+    })
+
+    test("fails for debug in output tag", () => {
+      expectError("Avoid using `debug @user` in ERB templates. Remove the debug output or use `<%= ... %>` to display content.")
+
+      assertOffenses(dedent`
+        <%= debug @user %>
+      `)
+    })
+
+    test("fails for debug in silent tag", () => {
+      expectError("Avoid using `debug @user` in ERB templates. Remove the debug output or use `<%= ... %>` to display content.")
+
+      assertOffenses(dedent`
+        <% debug @user %>
+      `)
+    })
+
+    test("fails for byebug", () => {
+      expectError("Avoid using `byebug` in ERB templates. Remove the debug output or use `<%= ... %>` to display content.")
+
+      assertOffenses(dedent`
+        <% byebug %>
+      `)
+    })
+
+    test("fails for binding.pry", () => {
+      expectError("Avoid using `binding.pry` in ERB templates. Remove the debug output or use `<%= ... %>` to display content.")
+
+      assertOffenses(dedent`
+        <% binding.pry %>
+      `)
+    })
+
+    test("fails for binding.irb", () => {
+      expectError("Avoid using `binding.irb` in ERB templates. Remove the debug output or use `<%= ... %>` to display content.")
+
+      assertOffenses(dedent`
+        <% binding.irb %>
+      `)
+    })
+
+    test("fails for puts with no arguments", () => {
+      expectError("Avoid using `puts` in ERB templates. Remove the debug output or use `<%= ... %>` to display content.")
+
+      assertOffenses(dedent`
+        <% puts %>
+      `)
+    })
+
+    test("fails for multiple debug calls", () => {
+      expectError('Avoid using `puts "hello"` in ERB templates. Remove the debug output or use `<%= ... %>` to display content.')
+      expectError("Avoid using `p @user` in ERB templates. Remove the debug output or use `<%= ... %>` to display content.")
+
+      assertOffenses(dedent`
+        <% puts "hello" %>
+        <% p @user %>
+      `)
+    })
+
+    test("fails for puts with multiple arguments", () => {
+      expectError('Avoid using `puts "name:", @user.name` in ERB templates. Remove the debug output or use `<%= ... %>` to display content.')
+
+      assertOffenses(dedent`
+        <% puts "name:", @user.name %>
+      `)
+    })
+
+    test("fails for p with interpolated string", () => {
+      expectError('Avoid using `p "User: #{@user.name}"` in ERB templates. Remove the debug output or use `<%= ... %>` to display content.')
+
+      assertOffenses(dedent`
+        <% p "User: #{@user.name}" %>
+      `)
+    })
+
+    test("fails for debug output inside conditionals", () => {
+      expectError("Avoid using `puts @user` in ERB templates. Remove the debug output or use `<%= ... %>` to display content.")
+
+      assertOffenses(dedent`
+        <% if debug? %>
+          <% puts @user %>
+        <% end %>
+      `)
+    })
+  })
+})


### PR DESCRIPTION
Debug output methods like `p`, `pp`, `puts`, `print`, `warn`, and `debug` are commonly used during development to inspect values, and debugger breakpoints like `byebug`, `binding.pry`, and `binding.irb` are used to pause execution. 

All of these should be removed before committing code. In ERB templates, `p`, `pp`, `puts`, `print`, and `warn` bypass the rendering pipeline and write directly to stdout/stderr, while `debug` renders a YAML dump into the HTML. None of these should appear in production templates.

Use `<%= ... %>` to display content in the rendered HTML, or use proper logging (e.g., `Rails.logger`) for debugging purposes.