### PR TITLE
Linter: Don't flag `<%%=` in `actionview-no-silent-helper`

### DIFF
--- a/javascript/packages/linter/src/rules/actionview-no-silent-helper.ts
+++ b/javascript/packages/linter/src/rules/actionview-no-silent-helper.ts
@@ -19,6 +19,7 @@ class ActionViewNoSilentHelperVisitor extends BaseRuleVisitor {
     const tagOpening = node.open_tag.tag_opening?.value
 
     if (!tagOpening) return
+    if (tagOpening.startsWith("<%%")) return
 
     const helperName = node.element_source.includes("#")
       ? node.element_source.split("#").pop()

--- a/javascript/packages/linter/test/rules/actionview-no-silent-helper.test.ts
+++ b/javascript/packages/linter/test/rules/actionview-no-silent-helper.test.ts
@@ -82,6 +82,32 @@ describe("ActionViewNoSilentHelperRule", () => {
     `)
   })
 
+  test("escaped ERB output tag with tag.div is allowed", () => {
+    expectNoOffenses(dedent`
+      <%%= tag.div(content) %>
+    `)
+  })
+
+  test("escaped ERB tag with link_to is allowed", () => {
+    expectNoOffenses(dedent`
+      <%%= link_to "Home", root_path %>
+    `)
+  })
+
+  test("escaped ERB output tag with tag.div and content is allowed", () => {
+    expectNoOffenses(dedent`
+      <%%= tag.div("Hello", class: "greeting") %>
+    `)
+  })
+
+  test.fails("escaped ERB output tag with tag.div block is allowed", () => {
+    expectNoOffenses(dedent`
+      <%%= tag.div do %>
+        <p>Hello</p>
+      <% end %>
+    `)
+  })
+
   test("silent tag with tag.div is not allowed", () => {
     expectError("Avoid using `<% %>` with `tag`. Use `<%= %>` to ensure the helper's output is rendered.")
 


### PR DESCRIPTION
The following template was previously flagged by the `actionview-no-silent-helper` linter rule:

```erb
<%%= tag.div(content) %>
```

This pull request updates the linter rule to not flag this anymore.


Resolves #1500 