### PR TITLE
Linter: Fix `erb-no-unused-literals` false positives

### DIFF
--- a/javascript/packages/linter/src/rules/erb-no-unused-literals.ts
+++ b/javascript/packages/linter/src/rules/erb-no-unused-literals.ts
@@ -1,14 +1,13 @@
-import { isERBOutputNode, PrismVisitor, PrismNodes } from "@herb-tools/core"
-import type { ParseResult, ERBContentNode, ParserOptions, PrismNode } from "@herb-tools/core"
-
-import { BaseRuleVisitor, locationFromOffset } from "./rule-utils.js"
-import { isAssignmentNode } from "./prism-rule-utils.js"
 import { ParserRule } from "../types.js"
-import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types.js"
+import { BaseRuleVisitor } from "./rule-utils.js"
+import { PrismVisitor, PrismNodes } from "@herb-tools/core"
 
-function isCallNode(node: PrismNode): boolean {
-  return node?.constructor?.name === "CallNode"
-}
+import { isERBOutputNode} from "@herb-tools/core"
+import { locationFromOffset } from "./rule-utils.js"
+import { isAssignmentNode } from "./prism-rule-utils.js"
+
+import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types.js"
+import type { ParseResult, ERBContentNode, ParserOptions, PrismNode } from "@herb-tools/core"
 
 class LiteralCollector extends PrismVisitor {
   public readonly literals: PrismNode[] = []
@@ -17,12 +16,11 @@ class LiteralCollector extends PrismVisitor {
     if (!node) return
     if (isAssignmentNode(node)) return
 
-    if (isCallNode(node)) {
-      this.visit(node.receiver)
-      return
-    }
-
     super.visit(node)
+  }
+
+  visitCallNode(node: PrismNode): void {
+    this.visit(node.receiver)
   }
 
   visitArrayNode(node: PrismNodes.ArrayNode): void {

--- a/javascript/packages/linter/test/rules/erb-no-unused-literals.test.ts
+++ b/javascript/packages/linter/test/rules/erb-no-unused-literals.test.ts
@@ -41,6 +41,68 @@ describe("ERBNoUnusedLiteralsRule", () => {
     `)
   })
 
+  test("passes for bracket assignment", () => {
+    expectNoOffenses(dedent`
+      <% @hash[:key] = value %>
+      <% @array[0] = value %>
+      <% @hash["string_key"] = value %>
+    `)
+  })
+
+  test("passes for method calls with literal arguments", () => {
+    expectNoOffenses(dedent`
+      <% render partial: "header" %>
+      <% redirect_to "/home" %>
+      <% flash[:notice] = "Saved" %>
+      <% link_to "Home", root_path %>
+    `)
+  })
+
+  test("passes for method calls with integer arguments", () => {
+    expectNoOffenses(dedent`
+      <% sleep 1 %>
+      <% @items.insert(0, item) %>
+      <% @items.delete_at(2) %>
+    `)
+  })
+
+  test("passes for method calls with symbol arguments", () => {
+    expectNoOffenses(dedent`
+      <% content_for :head do %>
+        <title>Page Title</title>
+      <% end %>
+    `)
+  })
+
+  test("passes for method calls with hash arguments", () => {
+    expectNoOffenses(dedent`
+      <% render partial: "header", locals: { title: "Hello" } %>
+    `)
+  })
+
+  test("passes for method calls with array arguments", () => {
+    expectNoOffenses(dedent`
+      <% @items.push([1, 2, 3]) %>
+    `)
+  })
+
+  test("passes for shovel operator with literal", () => {
+    expectNoOffenses(dedent`
+      <% @items << "new item" %>
+      <% @items << 42 %>
+      <% @items << :symbol %>
+    `)
+  })
+
+  test("passes for mutation methods with literal arguments", () => {
+    expectNoOffenses(dedent`
+      <% @items.push("item") %>
+      <% @items.unshift(0) %>
+      <% @hash.delete(:key) %>
+      <% @items.concat(["a", "b"]) %>
+    `)
+  })
+
   test("fails for array literals", () => {
     expectError("Avoid using silent ERB tags for literals. `[:foo, :bar]` is evaluated but never used or output.")
 


### PR DESCRIPTION
The `LiteralCollector` relied on a `visit()` override to prevent traversal into `CallNode` arguments. However, `PrismVisitor` dispatches via `node.accept()` which calls `visitCallNode()` directly, bypassing the `visit()` override.

This caused literals used as arguments (e.g., `:key` in `@hash[:key] = value`) to be incorrectly flagged.

This pull request fixes this by overriding `visitCallNode` instead, which is always called regardless of the dispatch path.