### PR TITLE
Config: New rules should be a enabled without a `version` key

### DIFF
--- a/javascript/packages/config/src/config.ts
+++ b/javascript/packages/config/src/config.ts
@@ -124,12 +124,12 @@ export class Config {
 
   public readonly path: string
   public config: HerbConfig
-  public readonly configVersion: string
+  public readonly configVersion: string | undefined
 
   constructor(projectPath: string, config: HerbConfig, configVersion?: string) {
     this.path = Config.configPathFromProjectPath(projectPath)
     this.config = config
-    this.configVersion = configVersion ?? config.version
+    this.configVersion = configVersion
   }
 
   get projectPath(): string {
@@ -1139,6 +1139,8 @@ export class Config {
       parsed = {}
     }
 
+    const hasExplicitVersion = !!parsed.version
+
     if (!parsed.version) {
       parsed.version = version
     }
@@ -1163,7 +1165,7 @@ export class Config {
       throw error
     }
 
-    const userConfigVersion: string = parsed.version || version
+    const userConfigVersion = hasExplicitVersion ? parsed.version : undefined
 
     const defaults = this.getDefaultConfig(version)
     const resolved = deepMerge(defaults, parsed as Partial<HerbConfig>)

--- a/javascript/packages/config/test/config.test.ts
+++ b/javascript/packages/config/test/config.test.ts
@@ -1315,10 +1315,10 @@ describe("@herb-tools/config", () => {
   })
 
   describe("Config.configVersion", () => {
-    test("defaults to config.version when not provided", () => {
+    test("is undefined when not provided", () => {
       const config = new Config(testDir, { version: "0.9.3" })
 
-      expect(config.configVersion).toBe("0.9.3")
+      expect(config.configVersion).toBeUndefined()
     })
 
     test("preserves explicit configVersion", () => {
@@ -1334,10 +1334,10 @@ describe("@herb-tools/config", () => {
       expect(config.configVersion).toBe("0.7.0")
     })
 
-    test("fromObject defaults configVersion to tool version when not specified", () => {
+    test("fromObject defaults configVersion to undefined when not specified", () => {
       const config = Config.fromObject({}, { projectPath: testDir })
 
-      expect(config.configVersion).toBe(config.version)
+      expect(config.configVersion).toBeUndefined()
     })
 
     test("load preserves user config version from .herb.yml", async () => {
@@ -1349,12 +1349,20 @@ describe("@herb-tools/config", () => {
       expect(config.configVersion).toBe("0.8.0")
     })
 
-    test("load defaults configVersion to tool version when .herb.yml has no version", async () => {
+    test("load defaults configVersion to undefined when .herb.yml has no version", async () => {
       createTestFile(testDir, ".herb.yml", "linter:\n  enabled: true\n")
 
       const config = await Config.load(testDir, { version: "0.9.3", silent: true })
 
-      expect(config.configVersion).toBe("0.9.3")
+      expect(config.configVersion).toBeUndefined()
+    })
+
+    test("load defaults configVersion to undefined when no .herb.yml exists", async () => {
+      createTestFile(testDir, ".git/HEAD", "ref: refs/heads/main\n")
+
+      const config = await Config.load(testDir, { version: "0.9.3", silent: true })
+
+      expect(config.configVersion).toBeUndefined()
     })
   })
 

--- a/javascript/packages/language-server/src/linter_service.ts
+++ b/javascript/packages/language-server/src/linter_service.ts
@@ -150,7 +150,6 @@ export class LinterService {
       this.showCustomRuleWarnings()
 
       const linterConfig = projectConfig?.config?.linter || { enabled: true, rules: {} }
-      const hasConfigFile = projectConfig ? Config.exists(projectConfig.projectPath) : false
 
       const config = Config.fromObject({
         linter: {
@@ -160,10 +159,12 @@ export class LinterService {
             'parser-no-errors': { enabled: false }
           }
         }
-      }, { projectPath: projectConfig?.projectPath || process.cwd() })
+      }, {
+        projectPath: projectConfig?.projectPath || process.cwd(),
+        configVersion: projectConfig?.configVersion
+      })
 
-      const configVersion = hasConfigFile ? config.configVersion : undefined
-      const { enabled: filteredRules } = Linter.filterRulesByConfig(this.allRules, config.linter?.rules, configVersion)
+      const { enabled: filteredRules } = Linter.filterRulesByConfig(this.allRules, config.linter?.rules, config.configVersion)
 
       this.linter = new Linter(Herb, filteredRules, config, this.allRules)
       this.linter.mode = "editor"

--- a/javascript/packages/linter/src/cli.ts
+++ b/javascript/packages/linter/src/cli.ts
@@ -253,7 +253,7 @@ export class CLI {
       content = content.replace(/^version:\s*.+$/m, `version: ${version}`)
       await fs.writeFile(config.path, content, "utf-8")
 
-      console.log(`\n${colorize("✓", "brightGreen")} Updated ${colorize(".herb.yml", "cyan")} version from ${colorize(configVersion, "cyan")} to ${colorize(version, "cyan")}`)
+      console.log(`\n${colorize("✓", "brightGreen")} Updated ${colorize(".herb.yml", "cyan")} version from ${colorize(configVersion ?? "unversioned", "cyan")} to ${colorize(version, "cyan")}`)
 
       if (rulesToEnable.length > 0) {
         console.log(`\n${colorize("✓", "brightGreen")} Enabled ${colorize(String(rulesToEnable.length), "bold")} new ${rulesToEnable.length === 1 ? "rule" : "rules"} (no offenses found):\n`)

--- a/javascript/packages/linter/test/__snapshots__/cli.test.ts.snap
+++ b/javascript/packages/linter/test/__snapshots__/cli.test.ts.snap
@@ -109,7 +109,7 @@ test/fixtures/ignored.html.erb:8:8
   Offenses     5 errors | 2 warnings (7 offenses across 1 file)
   Note         3 additional offenses reported (would have been ignored)
   Fixable      7 offenses | 4 autocorrectable using \`--fix\`
-  Rules        82 enabled | 10 not enabled | 1 skipped (version)
+  Rules        83 enabled | 10 not enabled
 
  TIP: Run herb-lint --init to create a .herb.yml and lock the version.
       This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
@@ -170,7 +170,7 @@ test/fixtures/test-file-with-errors.html.erb:2:22
   Checked      1 file
   Offenses     2 errors | 1 warning (3 offenses across 1 file)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        82 enabled | 10 not enabled | 1 skipped (version)"
+  Rules        83 enabled | 10 not enabled"
 `;
 
 exports[`CLI Output Formatting > GitHub Actions format includes rule codes 1`] = `
@@ -193,7 +193,7 @@ test/fixtures/no-trailing-newline.html.erb:1:29
   Checked      1 file
   Offenses     1 error | 0 warnings (1 offense across 1 file)
   Fixable      1 offense | 1 autocorrectable using \`--fix\`
-  Rules        82 enabled | 10 not enabled | 1 skipped (version)"
+  Rules        83 enabled | 10 not enabled"
 `;
 
 exports[`CLI Output Formatting > GitHub Actions format includes rule codes 2`] = `
@@ -255,7 +255,7 @@ test/fixtures/erb-no-extra-whitespace-inside-tags.html.erb:1:4
   Checked      1 file
   Offenses     4 errors | 0 warnings (4 offenses across 1 file)
   Fixable      4 offenses | 3 autocorrectable using \`--fix\`
-  Rules        82 enabled | 10 not enabled | 1 skipped (version)
+  Rules        83 enabled | 10 not enabled
 
  TIP: Run herb-lint --init to create a .herb.yml and lock the version.
       This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
@@ -297,7 +297,7 @@ test/fixtures/ignored.html.erb:6:14
   Checked      1 file
   Offenses     2 errors | 0 warnings | 3 ignored (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        82 enabled | 10 not enabled | 1 skipped (version)
+  Rules        83 enabled | 10 not enabled
 
  TIP: Run herb-lint --init to create a .herb.yml and lock the version.
       This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
@@ -324,7 +324,7 @@ test/fixtures/parser-errors.html.erb:2:16
   Checked      1 file
   Offenses     1 error | 0 warnings (1 offense across 1 file)
   Fixable      0 offenses
-  Rules        82 enabled | 10 not enabled | 1 skipped (version)
+  Rules        83 enabled | 10 not enabled
 
  TIP: Run herb-lint --init to create a .herb.yml and lock the version.
       This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
@@ -540,7 +540,7 @@ test/fixtures/multiple-rule-offenses.html.erb:4:2
   Checked      1 file
   Offenses     8 errors | 6 warnings (14 offenses across 1 file)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        82 enabled | 10 not enabled | 1 skipped (version)
+  Rules        83 enabled | 10 not enabled
 
  TIP: Run herb-lint --init to create a .herb.yml and lock the version.
       This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
@@ -638,7 +638,7 @@ test/fixtures/few-rule-offenses.html.erb:6:0
   Checked      1 file
   Offenses     4 errors | 2 warnings (6 offenses across 1 file)
   Fixable      6 offenses | 3 autocorrectable using \`--fix\`
-  Rules        82 enabled | 10 not enabled | 1 skipped (version)
+  Rules        83 enabled | 10 not enabled
 
  TIP: Run herb-lint --init to create a .herb.yml and lock the version.
       This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
@@ -678,7 +678,7 @@ test/fixtures/bad-file.html.erb:1:16
   Checked      1 file
   Offenses     2 errors | 0 warnings (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        82 enabled | 10 not enabled | 1 skipped (version)"
+  Rules        83 enabled | 10 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats GitHub Actions output correctly for clean file 1`] = `
@@ -689,7 +689,7 @@ exports[`CLI Output Formatting > formats GitHub Actions output correctly for cle
   Checked      1 file
   Offenses     0 offenses
   Fixable      0 offenses
-  Rules        82 enabled | 10 not enabled | 1 skipped (version)"
+  Rules        83 enabled | 10 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats GitHub Actions output correctly for file with errors 1`] = `
@@ -747,7 +747,7 @@ test/fixtures/test-file-with-errors.html.erb:2:22
   Checked      1 file
   Offenses     2 errors | 1 warning (3 offenses across 1 file)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        82 enabled | 10 not enabled | 1 skipped (version)"
+  Rules        83 enabled | 10 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats GitHub Actions output with --format=github option 1`] = `
@@ -784,7 +784,7 @@ test/fixtures/test-file-simple.html.erb:2:22
   Checked      1 file
   Offenses     2 errors | 0 warnings (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        82 enabled | 10 not enabled | 1 skipped (version)
+  Rules        83 enabled | 10 not enabled
 
  TIP: Run herb-lint --init to create a .herb.yml and lock the version.
       This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
@@ -834,7 +834,7 @@ exports[`CLI Output Formatting > formats JSON output correctly for bad file 1`] 
   "summary": {
     "filesChecked": 1,
     "filesWithOffenses": 1,
-    "ruleCount": 82,
+    "ruleCount": 83,
     "totalErrors": 2,
     "totalHints": 0,
     "totalIgnored": 0,
@@ -855,7 +855,7 @@ exports[`CLI Output Formatting > formats JSON output correctly for clean file 1`
   "summary": {
     "filesChecked": 1,
     "filesWithOffenses": 0,
-    "ruleCount": 82,
+    "ruleCount": 83,
     "totalErrors": 0,
     "totalHints": 0,
     "totalIgnored": 0,
@@ -928,7 +928,7 @@ exports[`CLI Output Formatting > formats JSON output correctly for file with err
   "summary": {
     "filesChecked": 1,
     "filesWithOffenses": 1,
-    "ruleCount": 82,
+    "ruleCount": 83,
     "totalErrors": 2,
     "totalHints": 0,
     "totalIgnored": 0,
@@ -989,7 +989,7 @@ test/fixtures/test-file-with-errors.html.erb:2:22
   Checked      1 file
   Offenses     2 errors | 1 warning (3 offenses across 1 file)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        82 enabled | 10 not enabled | 1 skipped (version)
+  Rules        83 enabled | 10 not enabled
 
  TIP: Run herb-lint --init to create a .herb.yml and lock the version.
       This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
@@ -1009,7 +1009,7 @@ exports[`CLI Output Formatting > formats simple output correctly 1`] = `
   Checked      1 file
   Offenses     2 errors | 0 warnings (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        82 enabled | 10 not enabled | 1 skipped (version)
+  Rules        83 enabled | 10 not enabled
 
  TIP: Run herb-lint --init to create a .herb.yml and lock the version.
       This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
@@ -1029,7 +1029,7 @@ exports[`CLI Output Formatting > formats simple output for bad-file correctly 1`
   Checked      1 file
   Offenses     2 errors | 0 warnings (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        82 enabled | 10 not enabled | 1 skipped (version)
+  Rules        83 enabled | 10 not enabled
 
  TIP: Run herb-lint --init to create a .herb.yml and lock the version.
       This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
@@ -1043,7 +1043,7 @@ exports[`CLI Output Formatting > formats success output correctly 1`] = `
   Checked      1 file
   Offenses     0 offenses
   Fixable      0 offenses
-  Rules        82 enabled | 10 not enabled | 1 skipped (version)
+  Rules        83 enabled | 10 not enabled
 
  TIP: Run herb-lint --init to create a .herb.yml and lock the version.
       This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
@@ -1057,7 +1057,7 @@ exports[`CLI Output Formatting > handles boolean attributes 1`] = `
   Checked      1 file
   Offenses     0 offenses
   Fixable      0 offenses
-  Rules        82 enabled | 10 not enabled | 1 skipped (version)
+  Rules        83 enabled | 10 not enabled
 
  TIP: Run herb-lint --init to create a .herb.yml and lock the version.
       This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
@@ -1093,7 +1093,7 @@ test/fixtures/bad-file.html.erb:1:16
   Checked      1 file
   Offenses     2 errors | 0 warnings (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        82 enabled | 10 not enabled | 1 skipped (version)
+  Rules        83 enabled | 10 not enabled
 
  TIP: Run herb-lint --init to create a .herb.yml and lock the version.
       This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
@@ -1226,7 +1226,7 @@ test/fixtures/disabled-1.html.erb:14:19
   Checked      1 file
   Offenses     2 errors | 6 warnings | 8 ignored (8 offenses across 1 file)
   Fixable      8 offenses | 1 autocorrectable using \`--fix\`
-  Rules        82 enabled | 10 not enabled | 1 skipped (version)
+  Rules        83 enabled | 10 not enabled
 
  TIP: Run herb-lint --init to create a .herb.yml and lock the version.
       This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
@@ -1430,7 +1430,7 @@ test/fixtures/disabled-2.html.erb:2:44
   Checked      1 file
   Offenses     6 errors | 7 warnings | 5 ignored (13 offenses across 1 file)
   Fixable      13 offenses | 6 autocorrectable using \`--fix\`
-  Rules        82 enabled | 10 not enabled | 1 skipped (version)
+  Rules        83 enabled | 10 not enabled
 
  TIP: Run herb-lint --init to create a .herb.yml and lock the version.
       This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
@@ -1491,5 +1491,5 @@ test/fixtures/test-file-with-errors.html.erb:2:22
   Checked      1 file
   Offenses     2 errors | 1 warning (3 offenses across 1 file)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        82 enabled | 10 not enabled | 1 skipped (version)"
+  Rules        83 enabled | 10 not enabled"
 `;

--- a/javascript/packages/linter/test/linter.test.ts
+++ b/javascript/packages/linter/test/linter.test.ts
@@ -859,6 +859,46 @@ describe("@herb-tools/linter", () => {
       expect(releasedSkipped).toHaveLength(0)
     })
 
+    test("includes unreleased rules when configVersion is undefined (no .herb.yml)", () => {
+      const { enabled, skippedByVersion } = Linter.filterRulesByConfig(
+        [OldRule, NewRule, NewerRule],
+        undefined,
+        undefined
+      )
+
+      expect(enabled).toHaveLength(3)
+      expect(skippedByVersion).toHaveLength(0)
+    })
+
+    test("includes unreleased rules when .herb.yml has no explicit version", () => {
+      const config = Config.fromObject({
+        linter: { enabled: true }
+      })
+
+      expect(config.configVersion).toBeUndefined()
+
+      const { enabled, skippedByVersion } = Linter.filterRulesByConfig(
+        [OldRule, NewRule, NewerRule],
+        config.linter?.rules,
+        config.configVersion
+      )
+
+      expect(enabled).toHaveLength(3)
+      expect(skippedByVersion).toHaveLength(0)
+    })
+
+    test("Linter.from() enables unreleased rules when configVersion is undefined", () => {
+      const config = Config.fromObject({
+        linter: { enabled: true }
+      })
+
+      expect(config.configVersion).toBeUndefined()
+
+      const linter = Linter.from(Herb, config)
+
+      expect(linter.rulesSkippedByVersion).toHaveLength(0)
+    })
+
     test("version-gated rules do not produce offenses", () => {
       const config = Config.fromObject({
         linter: { enabled: true }


### PR DESCRIPTION
When no `.herb.yml` exists or it has no explicit `version` key, `configVersion` is now `undefined` instead of defaulting to the tool version. This ensures all rules (including newly added ones) are enabled by default for users without a config file.

Previously, new rules were silently skipped because `configVersion` matched the current tool version, which was treated as a version gate.