### PR TITLE
Linter: Fix `erb-no-unused-literals` to handle all assignments

### DIFF
--- a/javascript/packages/linter/src/rules/erb-no-unused-literals.ts
+++ b/javascript/packages/linter/src/rules/erb-no-unused-literals.ts
@@ -2,9 +2,8 @@ import { ParserRule } from "../types.js"
 import { BaseRuleVisitor } from "./rule-utils.js"
 import { PrismVisitor, PrismNodes } from "@herb-tools/core"
 
-import { isERBOutputNode} from "@herb-tools/core"
+import { isERBOutputNode } from "@herb-tools/core"
 import { locationFromOffset } from "./rule-utils.js"
-import { isAssignmentNode } from "./prism-rule-utils.js"
 
 import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types.js"
 import type { ParseResult, ERBContentNode, ParserOptions, PrismNode } from "@herb-tools/core"
@@ -14,14 +13,47 @@ class LiteralCollector extends PrismVisitor {
 
   override visit(node: PrismNode): void {
     if (!node) return
-    if (isAssignmentNode(node)) return
 
     super.visit(node)
   }
 
   visitCallNode(node: PrismNode): void {
-    this.visit(node.receiver)
+    this.visit(node.receiver) // Only visit the receiver of a call, not its arguments.
   }
+
+  // Stop traversal into all assignment node types.
+  visitLocalVariableWriteNode(): void {}
+  visitLocalVariableAndWriteNode(): void {}
+  visitLocalVariableOperatorWriteNode(): void {}
+  visitLocalVariableOrWriteNode(): void {}
+  visitInstanceVariableWriteNode(): void {}
+  visitInstanceVariableAndWriteNode(): void {}
+  visitInstanceVariableOperatorWriteNode(): void {}
+  visitInstanceVariableOrWriteNode(): void {}
+  visitClassVariableWriteNode(): void {}
+  visitClassVariableAndWriteNode(): void {}
+  visitClassVariableOperatorWriteNode(): void {}
+  visitClassVariableOrWriteNode(): void {}
+  visitGlobalVariableWriteNode(): void {}
+  visitGlobalVariableAndWriteNode(): void {}
+  visitGlobalVariableOperatorWriteNode(): void {}
+  visitGlobalVariableOrWriteNode(): void {}
+  visitConstantWriteNode(): void {}
+  visitConstantAndWriteNode(): void {}
+  visitConstantOperatorWriteNode(): void {}
+  visitConstantOrWriteNode(): void {}
+  visitConstantPathWriteNode(): void {}
+  visitConstantPathAndWriteNode(): void {}
+  visitConstantPathOperatorWriteNode(): void {}
+  visitConstantPathOrWriteNode(): void {}
+  visitIndexAndWriteNode(): void {}
+  visitIndexOperatorWriteNode(): void {}
+  visitIndexOrWriteNode(): void {}
+  visitCallAndWriteNode(): void {}
+  visitCallOperatorWriteNode(): void {}
+  visitCallOrWriteNode(): void {}
+  visitMultiWriteNode(): void {}
+  visitMatchWriteNode(): void {}
 
   visitArrayNode(node: PrismNodes.ArrayNode): void {
     this.literals.push(node)

--- a/javascript/packages/linter/test/rules/erb-no-unused-literals.test.ts
+++ b/javascript/packages/linter/test/rules/erb-no-unused-literals.test.ts
@@ -28,6 +28,7 @@ describe("ERBNoUnusedLiteralsRule", () => {
     expectNoOffenses(dedent`
       <% some_method %>
       <% helper_call(arg) %>
+      <% helper_call("arg") %>
     `)
   })
 
@@ -38,6 +39,59 @@ describe("ERBNoUnusedLiteralsRule", () => {
       <% @title = "Hello" %>
       <% names = ["Alice", "Bob"] %>
       <% config = { key: "value" } %>
+    `)
+  })
+
+  test("passes for assignments with ternary operator", () => {
+    expectNoOffenses(dedent`
+      <% dynamic_link = post.published? ? post_path(post) : "/" %>
+    `)
+  })
+
+  test("passes for operator assignments", () => {
+    expectNoOffenses(dedent`
+      <% count += 1 %>
+      <% name ||= "default" %>
+      <% value &&= "updated" %>
+    `)
+  })
+
+  test("passes for instance variable or-assign", () => {
+    expectNoOffenses(dedent`
+      <% @config ||= { key: "value" } %>
+      <% @title ||= "Default Title" %>
+      <% @items ||= [] %>
+    `)
+  })
+
+  test("passes for class variable operator assignments", () => {
+    expectNoOffenses(dedent`
+      <% @@count += 1 %>
+    `)
+  })
+
+  test("passes for global variable assignments", () => {
+    expectNoOffenses(dedent`
+      <% $debug = true %>
+      <% $locale = "en" %>
+    `)
+  })
+
+  test("passes for multi-write assignments", () => {
+    expectNoOffenses(dedent`
+      <% a, b = 1, 2 %>
+    `)
+  })
+
+  test("passes for constant assignments", () => {
+    expectNoOffenses(dedent`
+      <% MAX_RETRIES = 3 %>
+    `)
+  })
+
+  test("passes for constant path assignments", () => {
+    expectNoOffenses(dedent`
+      <% Config::MAX = 100 %>
     `)
   })
 
@@ -271,6 +325,24 @@ describe("ERBNoUnusedLiteralsRule", () => {
     `)
   })
 
+  test("fails for string literals in ternary without assignment", () => {
+    expectError('Avoid using silent ERB tags for literals. `"true"` is evaluated but never used or output.')
+    expectError('Avoid using silent ERB tags for literals. `"false"` is evaluated but never used or output.')
+
+    assertOffenses(dedent`
+      <% condition? ? "true" : "false" %>
+    `)
+  })
+
+  test("fails for boolean literals in ternary without assignment", () => {
+    expectError('Avoid using silent ERB tags for literals. `true` is evaluated but never used or output.')
+    expectError('Avoid using silent ERB tags for literals. `false` is evaluated but never used or output.')
+
+    assertOffenses(dedent`
+      <% condition? ? true : false %>
+    `)
+  })
+
   test("passes for method calls without literal receiver", () => {
     expectNoOffenses(dedent`
       <% some_method.call %>
@@ -291,6 +363,31 @@ describe("ERBNoUnusedLiteralsRule", () => {
 
     assertOffenses(dedent`
       <% valid? && "success" %>
+    `)
+  })
+
+  test("fails for literal in logical OR", () => {
+    expectError('Avoid using silent ERB tags for literals. `"fallback"` is evaluated but never used or output.')
+
+    assertOffenses(dedent`
+      <% valid? || "fallback" %>
+    `)
+  })
+
+  test("fails for literals in ternary without assignment", () => {
+    expectError('Avoid using silent ERB tags for literals. `"yes"` is evaluated but never used or output.')
+    expectError('Avoid using silent ERB tags for literals. `"no"` is evaluated but never used or output.')
+
+    assertOffenses(dedent`
+      <% post.published? ? "yes" : "no" %>
+    `)
+  })
+
+  test("fails for frozen string literal", () => {
+    expectError('Avoid using silent ERB tags for literals. `"hello"` is evaluated but never used or output.')
+
+    assertOffenses(dedent`
+      <% "hello".freeze %>
     `)
   })
 })


### PR DESCRIPTION
The `LiteralCollector` relied on an `isAssignmentNode` check in `visit()` to skip assignments. However, `PrismVisitor` dispatches via `node.accept()` which bypasses `visit()`.

This fixes the issue by overriding all `WriteNode` visitor methods as no-ops instead.

Resolves #1547 