### PR TITLE
Linter: Skip attribute values in `html-no-unescaped-entities`

### DIFF
--- a/javascript/packages/linter/docs/rules/html-no-unescaped-entities.md
+++ b/javascript/packages/linter/docs/rules/html-no-unescaped-entities.md
@@ -4,9 +4,9 @@
 
 ## Description
 
-Disallow unescaped special characters in HTML attribute values and text content. Characters like `<`, `>`, and `&` have special meaning in HTML and should be replaced with their corresponding character references when used as literal values.
+Disallow unescaped special characters in HTML text content. Characters like `<`, `>`, and `&` have special meaning in HTML and should be replaced with their corresponding character references when used as literal text content.
 
-This rule checks both attribute values and text content for unescaped `<`, `>`, and `&` characters. ERB output tags are ignored, as the escaping responsibility belongs to the Ruby layer. Only the static (literal) portions of mixed attribute values are checked.
+This rule only checks text content. Attribute values are not checked, as the HTML5 spec (§13.2.5.36, §13.2.5.37) permits all characters in quoted attribute values without parse errors.
 
 Content inside raw text elements (`<script>` and `<style>`) is not checked, as character references are not decoded in those contexts per the HTML spec. Content inside escapable raw text elements (`<textarea>` and `<title>`) is still checked.
 
@@ -14,58 +14,46 @@ The `&` detection validates named references against the full HTML spec characte
 
 ## Rationale
 
-Unescaped special characters in HTML can cause parsing ambiguities, rendering issues, and security vulnerabilities. Browsers may interpret unescaped `<` and `>` as tag boundaries, leading to broken layouts or unintended element creation. Unescaped `&` characters can be misinterpreted as the start of a character reference, producing unexpected characters in the output.
+Unescaped special characters in HTML text content can cause parsing ambiguities, rendering issues, and security vulnerabilities. Browsers may interpret unescaped `<` and `>` as tag boundaries, leading to broken layouts or unintended element creation. Unescaped `&` characters can be misinterpreted as the start of a character reference, producing unexpected characters in the output.
 
 Using proper character references ensures that the document is parsed correctly and consistently across all browsers.
 
-| Character | Entity | Context |
-|-----------|--------|---------|
-| `<` | `&lt;` | Attribute values and text content |
-| `>` | `&gt;` | Attribute values and text content |
-| `&` | `&amp;` | Attribute values and text content |
+| Character | Entity  | Context      |
+|-----------|---------|--------------|
+| `<`       | `&lt;`  | Text content |
+| `>`       | `&gt;`  | Text content |
+| `&`       | `&amp;` | Text content |
 
 ## Autofix
 
-This rule provides an **unsafe** autofix that replaces unescaped characters with their corresponding character references. The autofix is considered unsafe because replacing characters may change the intended behavior in some contexts (e.g., URLs with query parameters).
+This rule provides an **unsafe** autofix that replaces unescaped characters with their corresponding character references. The autofix is considered unsafe because replacing characters may change the intended behavior in some contexts.
 
 ## Examples
 
 ### ✅ Good
 
 ```html
-<div class="hello"></div>
+<div>Tom &amp; Jerry</div>
 ```
 
 ```html
-<div data-html="&lt;br&gt;"></div>
+<div data-action="click->controller#method"></div>
 ```
 
 ```html
-<a href="/path?a=1&amp;b=2">Link</a>
+<div class="[&>p:not(:first-of-type)]:pt-4"></div>
 ```
 
 ```html
-<div data-char="&#60;&#62;"></div>
+<a href="/path?a=1&b=2">Link</a>
 ```
 
 ```html
-<div data-char="&#x3C;&#x3E;"></div>
-```
-
-```html
-<div data-html="&lt;div class=&quot;test&quot;&gt;content&lt;/div&gt;"></div>
+<div data-html="<br>"></div>
 ```
 
 ```erb
 <div class="<%= value %>"></div>
-```
-
-```erb
-<div data-value="prefix-<%= value %>-suffix"></div>
-```
-
-```html
-<div>Tom &amp; Jerry</div>
 ```
 
 ```html
@@ -77,22 +65,6 @@ This rule provides an **unsafe** autofix that replaces unescaped characters with
 ```
 
 ### 🚫 Bad
-
-```html
-<div data-html="<br>"></div>
-```
-
-```html
-<div data-expr="a > b"></div>
-```
-
-```html
-<a href="/path?a=1&b=2">Link</a>
-```
-
-```html
-<div data-html="<b>bold & italic</b>"></div>
-```
 
 ```html
 <div>Tom & Jerry</div>
@@ -109,5 +81,6 @@ This rule provides an **unsafe** autofix that replaces unescaped characters with
 ## References
 
 - [HTML Living Standard - Character references](https://html.spec.whatwg.org/multipage/syntax.html#character-references)
-- [HTML Living Standard - Attributes](https://html.spec.whatwg.org/multipage/syntax.html#attributes-2)
+- [HTML Living Standard - Attribute value (double-quoted) state](https://html.spec.whatwg.org/multipage/parsing.html#attribute-value-(double-quoted)-state)
+- [HTML Living Standard - Attribute value (single-quoted) state](https://html.spec.whatwg.org/multipage/parsing.html#attribute-value-(single-quoted)-state)
 - [HTML Living Standard - Raw text elements](https://html.spec.whatwg.org/multipage/syntax.html#raw-text-elements)

--- a/javascript/packages/linter/src/rules/html-no-unescaped-entities.ts
+++ b/javascript/packages/linter/src/rules/html-no-unescaped-entities.ts
@@ -1,12 +1,12 @@
 import { ParserRule, Mutable, BaseAutofixContext } from "../types.js"
-import { AttributeVisitorMixin, StaticAttributeStaticValueParams, StaticAttributeDynamicValueParams, DynamicAttributeStaticValueParams, DynamicAttributeDynamicValueParams, locationFromContentOffset } from "./rule-utils.js"
-import { hasAttributeValue, isLiteralNode, getTagLocalName, Location, isValidCharacterReference } from "@herb-tools/core"
+import { BaseRuleVisitor, locationFromContentOffset } from "./rule-utils.js"
+import { getTagLocalName, isValidCharacterReference } from "@herb-tools/core"
 
 import type { UnboundLintOffense, LintOffense, LintContext, FullRuleConfig } from "../types.js"
-import type { ParseResult, ParserOptions, HTMLTextNode, HTMLElementNode, LiteralNode, Node, HTMLAttributeNode } from "@herb-tools/core"
+import type { ParseResult, ParserOptions, HTMLTextNode, HTMLElementNode } from "@herb-tools/core"
 
 interface UnescapedEntitiesAutofixContext extends BaseAutofixContext {
-  node: Mutable<HTMLTextNode> | Mutable<LiteralNode>
+  node: Mutable<HTMLTextNode>
   character: string
   entity: string
 }
@@ -73,7 +73,9 @@ function findUnescapedOccurrences(value: string): UnescapedOccurrence[] {
 
 const RAW_TEXT_ELEMENTS = new Set(["script", "style"])
 
-class HTMLNoUnescapedEntitiesVisitor extends AttributeVisitorMixin<UnescapedEntitiesAutofixContext> {
+// Per the HTML5 spec (§13.2.5.36, §13.2.5.37), no characters are parse errors
+// in quoted attribute values. Entity checks only apply to text content.
+class HTMLNoUnescapedEntitiesVisitor extends BaseRuleVisitor<UnescapedEntitiesAutofixContext> {
   private elementStack: string[] = []
 
   visitHTMLElementNode(node: HTMLElementNode): void {
@@ -118,69 +120,6 @@ class HTMLNoUnescapedEntitiesVisitor extends AttributeVisitorMixin<UnescapedEnti
     }
 
     super.visitHTMLTextNode(node)
-  }
-
-  private checkAttributeValue(attributeName: string, attributeValue: string, attributeNode: HTMLAttributeNode): void {
-    if (!hasAttributeValue(attributeNode)) return
-    if (!attributeValue) return
-
-    const literalNode = attributeNode.value!.children.find((child) => isLiteralNode(child))
-    if (!literalNode || !isLiteralNode(literalNode)) return
-
-    const occurrences = findUnescapedOccurrences(attributeValue)
-    const startLine = attributeNode.value!.location.start.line
-    const startColumn = attributeNode.value!.location.start.column
-
-    for (const { character, entity, offset } of occurrences) {
-      const location = locationFromContentOffset(startLine, startColumn, attributeValue, offset)
-
-      this.addOffense(
-        `Attribute \`${attributeName}\` contains an unescaped \`${character}\` character. Use \`${entity}\` instead.`,
-        location,
-        { node: literalNode, character, entity, unsafe: true },
-      )
-    }
-  }
-
-  private checkLiteralValueNodes(attributeName: string, valueNodes: Node[], attributeNode: HTMLAttributeNode): void {
-    if (!hasAttributeValue(attributeNode)) return
-
-    for (const node of valueNodes) {
-      if (!isLiteralNode(node)) continue
-      if (!node.content) continue
-
-      const occurrences = findUnescapedOccurrences(node.content)
-      const startLine = node.location.start.line
-      const startColumn = node.location.start.column
-
-      for (const { character, entity, offset } of occurrences) {
-        const location = locationFromContentOffset(startLine, startColumn, node.content, offset)
-
-        this.addOffense(
-          `Attribute \`${attributeName}\` contains an unescaped \`${character}\` character. Use \`${entity}\` instead.`,
-          location,
-          { node, character, entity, unsafe: true },
-        )
-      }
-    }
-  }
-
-  protected checkStaticAttributeStaticValue({ attributeName, attributeValue, attributeNode }: StaticAttributeStaticValueParams): void {
-    this.checkAttributeValue(attributeName, attributeValue, attributeNode)
-  }
-
-  protected checkStaticAttributeDynamicValue({ attributeName, valueNodes, attributeNode }: StaticAttributeDynamicValueParams): void {
-    this.checkLiteralValueNodes(attributeName, valueNodes, attributeNode)
-  }
-
-  protected checkDynamicAttributeStaticValue({ combinedName, attributeValue, attributeNode }: DynamicAttributeStaticValueParams): void {
-    const attributeName = combinedName || "unknown"
-    this.checkAttributeValue(attributeName, attributeValue, attributeNode)
-  }
-
-  protected checkDynamicAttributeDynamicValue({ combinedName, valueNodes, attributeNode }: DynamicAttributeDynamicValueParams): void {
-    const attributeName = combinedName || "unknown"
-    this.checkLiteralValueNodes(attributeName, valueNodes, attributeNode)
   }
 }
 

--- a/javascript/packages/linter/test/autofix/html-no-unescaped-entities.autofix.test.ts
+++ b/javascript/packages/linter/test/autofix/html-no-unescaped-entities.autofix.test.ts
@@ -20,37 +20,24 @@ describe("html-no-unescaped-entities autofix", () => {
     expect(result.unfixed).toHaveLength(0)
   })
 
-  test("replaces < and > in attribute value", () => {
+  test("does not modify attribute values", () => {
     const input = '<div data-html="<br>"></div>'
-    const expected = '<div data-html="&lt;br&gt;"></div>'
 
     const linter = new Linter(Herb, [HTMLNoUnescapedEntitiesRule])
     const result = linter.autofix(input, undefined, undefined, { includeUnsafe: true })
 
-    expect(result.source).toBe(expected)
-    expect(result.fixed).toHaveLength(2)
+    expect(result.source).toBe(input)
+    expect(result.fixed).toHaveLength(0)
   })
 
-  test("replaces bare & in attribute value", () => {
+  test("does not modify bare & in attribute value", () => {
     const input = '<a href="/path?a=1&b=2">Link</a>'
-    const expected = '<a href="/path?a=1&amp;b=2">Link</a>'
 
     const linter = new Linter(Herb, [HTMLNoUnescapedEntitiesRule])
     const result = linter.autofix(input, undefined, undefined, { includeUnsafe: true })
 
-    expect(result.source).toBe(expected)
-    expect(result.fixed).toHaveLength(1)
-  })
-
-  test("replaces multiple unescaped characters in one attribute", () => {
-    const input = '<div data-html="<b>bold & italic</b>"></div>'
-    const expected = '<div data-html="&lt;b&gt;bold &amp; italic&lt;/b&gt;"></div>'
-
-    const linter = new Linter(Herb, [HTMLNoUnescapedEntitiesRule])
-    const result = linter.autofix(input, undefined, undefined, { includeUnsafe: true })
-
-    expect(result.source).toBe(expected)
-    expect(result.fixed).toHaveLength(5)
+    expect(result.source).toBe(input)
+    expect(result.fixed).toHaveLength(0)
   })
 
   test("replaces multiple bare & in text content", () => {

--- a/javascript/packages/linter/test/rules/html-no-unescaped-entities.test.ts
+++ b/javascript/packages/linter/test/rules/html-no-unescaped-entities.test.ts
@@ -69,124 +69,53 @@ describe("html-no-unescaped-entities", () => {
     })
   })
 
-  describe("attribute values - unescaped < character", () => {
-    it("flags unescaped < and > in attribute value", () => {
-      expectWarning("Attribute `data-html` contains an unescaped `<` character. Use `&lt;` instead.")
-      expectWarning("Attribute `data-html` contains an unescaped `>` character. Use `&gt;` instead.")
-
-      assertOffenses('<div data-html="<br>"></div>')
+  describe("attribute values - no offenses for unescaped characters", () => {
+    it("allows < in double-quoted attribute value", () => {
+      expectNoOffenses('<div data-html="<br>"></div>')
     })
 
-    it("flags unescaped < without >", () => {
-      expectWarning("Attribute `data-expr` contains an unescaped `<` character. Use `&lt;` instead.")
-
-      assertOffenses('<div data-expr="a < b"></div>')
-    })
-  })
-
-  describe("attribute values - unescaped > character", () => {
-    it("flags unescaped > in attribute value", () => {
-      expectWarning("Attribute `data-expr` contains an unescaped `>` character. Use `&gt;` instead.")
-
-      assertOffenses('<div data-expr="a > b"></div>')
-    })
-  })
-
-  describe("attribute values - unescaped & character", () => {
-    it("flags bare & not part of a character reference", () => {
-      expectWarning("Attribute `href` contains an unescaped `&` character. Use `&amp;` instead.")
-
-      assertOffenses('<a href="/path?a=1&b=2">Link</a>')
+    it("allows < in single-quoted attribute value", () => {
+      expectNoOffenses("<div data-html='<br>'></div>")
     })
 
-    it("does not flag & that is part of a named reference", () => {
-      expectNoOffenses('<a href="/path?a=1&amp;b=2">Link</a>')
+    it("allows > in double-quoted attribute value", () => {
+      expectNoOffenses('<div data-expr="a > b"></div>')
     })
 
-    it("does not flag & that is part of a numeric reference", () => {
-      expectNoOffenses('<div data-char="&#60;"></div>')
+    it("allows > in single-quoted attribute value", () => {
+      expectNoOffenses("<div data-expr='a > b'></div>")
     })
 
-    it("does not flag & that is part of a hex reference", () => {
-      expectNoOffenses('<div data-char="&#x3C;"></div>')
-    })
-  })
-
-  describe("attribute values - multiple unescaped characters", () => {
-    it("flags each occurrence of unescaped characters in one attribute", () => {
-      expectWarning("Attribute `data-html` contains an unescaped `<` character. Use `&lt;` instead.")
-      expectWarning("Attribute `data-html` contains an unescaped `<` character. Use `&lt;` instead.")
-      expectWarning("Attribute `data-html` contains an unescaped `>` character. Use `&gt;` instead.")
-      expectWarning("Attribute `data-html` contains an unescaped `>` character. Use `&gt;` instead.")
-
-      assertOffenses('<div data-html="<b>bold</b>"></div>')
+    it("allows & in double-quoted attribute value", () => {
+      expectNoOffenses('<a href="/path?a=1&b=2">Link</a>')
     })
 
-    it("flags each occurrence of <, > and & together", () => {
-      expectWarning("Attribute `data-html` contains an unescaped `<` character. Use `&lt;` instead.")
-      expectWarning("Attribute `data-html` contains an unescaped `<` character. Use `&lt;` instead.")
-      expectWarning("Attribute `data-html` contains an unescaped `>` character. Use `&gt;` instead.")
-      expectWarning("Attribute `data-html` contains an unescaped `>` character. Use `&gt;` instead.")
-      expectWarning("Attribute `data-html` contains an unescaped `&` character. Use `&amp;` instead.")
-
-      assertOffenses('<div data-html="<b>bold & italic</b>"></div>')
-    })
-  })
-
-  describe("dynamic attribute name with static value", () => {
-    it("flags unescaped characters in static value with dynamic attribute name", () => {
-      expectWarning("Attribute `data-<%= key %>` contains an unescaped `<` character. Use `&lt;` instead.")
-      expectWarning("Attribute `data-<%= key %>` contains an unescaped `>` character. Use `&gt;` instead.")
-
-      assertOffenses('<div data-<%= key %>="<br>"></div>')
+    it("allows & in single-quoted attribute value", () => {
+      expectNoOffenses("<a href='/path?a=1&b=2'>Link</a>")
     })
 
-    it("allows properly escaped value with dynamic attribute name", () => {
-      expectNoOffenses('<div data-<%= key %>="&lt;br&gt;"></div>')
-    })
-  })
-
-  describe("static attribute name with mixed value", () => {
-    it("flags each occurrence in the static portions of a mixed value", () => {
-      expectWarning("Attribute `data-html` contains an unescaped `<` character. Use `&lt;` instead.")
-      expectWarning("Attribute `data-html` contains an unescaped `>` character. Use `&gt;` instead.")
-      expectWarning("Attribute `data-html` contains an unescaped `<` character. Use `&lt;` instead.")
-      expectWarning("Attribute `data-html` contains an unescaped `>` character. Use `&gt;` instead.")
-
-      assertOffenses('<div data-html="<b><%= content %></b>"></div>')
+    it("allows multiple unescaped characters in attribute value", () => {
+      expectNoOffenses('<div data-html="<b>bold & italic</b>"></div>')
     })
 
-    it("flags bare & in static portion of mixed value", () => {
-      expectWarning("Attribute `href` contains an unescaped `&` character. Use `&amp;` instead.")
-
-      assertOffenses('<a href="/path?a=1&b=<%= value %>">Link</a>')
+    it("allows Stimulus data-action syntax", () => {
+      expectNoOffenses('<div data-action="click->controller#method"></div>')
     })
 
-    it("does not flag when static portions are clean", () => {
-      expectNoOffenses('<div data-value="prefix-<%= value %>-suffix"></div>')
+    it("allows Tailwind arbitrary value syntax", () => {
+      expectNoOffenses('<div class="[&>p:not(:first-of-type)]:pt-4"></div>')
     })
 
-    it("does not flag fully dynamic attribute value", () => {
-      expectNoOffenses('<div class="<%= value %>"></div>')
-    })
-  })
-
-  describe("dynamic attribute name with mixed value", () => {
-    it("flags each occurrence in static portions with dynamic name", () => {
-      expectWarning("Attribute `data-<%= key %>` contains an unescaped `<` character. Use `&lt;` instead.")
-      expectWarning("Attribute `data-<%= key %>` contains an unescaped `>` character. Use `&gt;` instead.")
-      expectWarning("Attribute `data-<%= key %>` contains an unescaped `<` character. Use `&lt;` instead.")
-      expectWarning("Attribute `data-<%= key %>` contains an unescaped `>` character. Use `&gt;` instead.")
-
-      assertOffenses('<div data-<%= key %>="<b><%= content %></b>"></div>')
+    it("allows unescaped characters with dynamic attribute name", () => {
+      expectNoOffenses('<div data-<%= key %>="<br>"></div>')
     })
 
-    it("does not flag when static portions are clean with dynamic name", () => {
-      expectNoOffenses('<div data-<%= key %>="prefix-<%= value %>-suffix"></div>')
+    it("allows unescaped characters in mixed attribute value", () => {
+      expectNoOffenses('<div data-html="<b><%= content %></b>"></div>')
     })
 
-    it("does not flag fully dynamic value with dynamic name", () => {
-      expectNoOffenses('<div data-<%= key %>="<%= value %>"></div>')
+    it("allows bare & in mixed attribute value", () => {
+      expectNoOffenses('<a href="/path?a=1&b=<%= value %>">Link</a>')
     })
   })
 
@@ -248,16 +177,12 @@ describe("html-no-unescaped-entities", () => {
       expectNoOffenses('<style>.foo { content: "a & b"; }</style>')
     })
 
-    it("still flags unescaped characters in script attribute values", () => {
-      expectWarning("Attribute `data-config` contains an unescaped `&` character. Use `&amp;` instead.")
-
-      assertOffenses('<script data-config="a=1&b=2"></script>')
+    it("allows unescaped characters in script attribute values", () => {
+      expectNoOffenses('<script data-config="a=1&b=2"></script>')
     })
 
-    it("still flags unescaped characters in style attribute values", () => {
-      expectWarning("Attribute `data-config` contains an unescaped `&` character. Use `&amp;` instead.")
-
-      assertOffenses('<style data-config="a=1&b=2"></style>')
+    it("allows unescaped characters in style attribute values", () => {
+      expectNoOffenses('<style data-config="a=1&b=2"></style>')
     })
   })
 


### PR DESCRIPTION
This pull request updates the `html-no-unescaped-entities` linter rule to skip looking for unescaped entities  in HTML attribute values

Per the HTML5 spec ([§13.2.5.36](https://html.spec.whatwg.org/multipage/parsing.html#attribute-value-(double-quoted)-state), [§13.2.5.37](https://html.spec.whatwg.org/multipage/parsing.html#attribute-value-(single-quoted)-state)), no characters are parse errors in quoted attribute values. This caused false positives for Stimulus `data-action` syntax and Tailwind arbitrary values.

Resolves #1545 