### PR TITLE
Formatter: Don't produce indented lines with only whitespace

### DIFF
--- a/javascript/packages/formatter/src/text-flow-engine.ts
+++ b/javascript/packages/formatter/src/text-flow-engine.ts
@@ -292,7 +292,13 @@ export class TextFlowEngine {
       }
 
       if (currentLine && !isClosingPunctuation(word) && nextEffectiveLength > wrapWidth) {
-        lines.push(this.delegate.indent + currentLine.trim())
+        const trimmedLine = currentLine.trim()
+
+        if (trimmedLine) {
+          lines.push(this.delegate.indent + trimmedLine)
+        } else {
+          lines.push("")
+        }
 
         currentLine = word
         effectiveLength = isHerbDisable ? 0 : word.length
@@ -303,7 +309,11 @@ export class TextFlowEngine {
     }
 
     if (currentLine) {
-      lines.push(this.delegate.indent + currentLine.trim())
+      const trimmedLine = currentLine.trim()
+
+      if (trimmedLine) {
+        lines.push(this.delegate.indent + trimmedLine)
+      }
     }
 
     lines.forEach(line => this.delegate.push(line))

--- a/javascript/packages/formatter/test/erb/whitespace-formatting.test.ts
+++ b/javascript/packages/formatter/test/erb/whitespace-formatting.test.ts
@@ -552,4 +552,67 @@ describe("ERB whitespace formatting", () => {
       expect(formatter.format('<%end%>')).toBe('<%end%>')
     })
   })
+
+  describe("no trailing whitespace on blank lines", () => {
+    test("blank lines between ERB expressions inside elements have no trailing whitespace", () => {
+      const source = dedent`
+        <button
+          id="my-button"
+          class="
+            px-2 py-3 flex items-center gap-1
+            font-mono text-xs font-semibold text-primary tracking-wider uppercase
+          "
+        >
+          Learn <%= org.capitalize %>
+          <%= render "svgs/icons/caret_down", width: 16, height: 16, class_name: "fill-current -mt-0.5 [.active_&]:hidden" %>
+
+          <%= render "svgs/icons/x", width: 16, height: 16, class_name: "fill-current -mt-0.5 hidden [.active_&]:block" %>
+        </button>
+      `
+
+      const result = formatter.format(source)
+      const lines = result.split("\n")
+
+      for (const line of lines) {
+        if (line.trim() === "") {
+          expect(line).toBe("")
+        }
+      }
+    })
+
+    test("formatted output contains no lines with only whitespace", () => {
+      const source = dedent`
+        <div>
+          Text content here
+          <%= render "component_a", width: 16, height: 16, class_name: "fill-current -mt-0.5 [.active_&]:hidden" %>
+
+          <%= render "component_b", width: 16, height: 16, class_name: "fill-current -mt-0.5 hidden [.active_&]:block" %>
+        </div>
+      `
+
+      const result = formatter.format(source)
+      const lines = result.split("\n")
+
+      for (const line of lines) {
+        if (line.trim() === "") {
+          expect(line).toBe("")
+        }
+      }
+    })
+
+    test("blank separator lines are truly empty after formatting", () => {
+      const source = dedent`
+        <button>
+          Learn <%= org.capitalize %>
+          <%= render "svgs/icons/caret_down" %>
+
+          <%= render "svgs/icons/x" %>
+        </button>
+      `
+
+      const result = formatter.format(source)
+
+      expect(result).not.toMatch(/^[ \t]+$/m)
+    })
+  })
 })


### PR DESCRIPTION
Previously, the `TextFlowEngine` would produce lines containing only indentation whitespace when wrapping blank separator lines between ERB expressions. For example, a blank line between two `<%= render %>` calls inside an element would be formatted as `"  "` instead of `""`.

This pull request updates the text flow engine to check whether a line has any content after trimming before prepending indentation. If the trimmed line is empty, it pushes a truly empty string instead of indentation-only whitespace.

Discovered while working on https://github.com/hanakai-rb/site/pull/278.