### PR TITLE
Formatter: Keep `herb:disable` on same line

### DIFF
--- a/javascript/packages/formatter/src/format-helpers.ts
+++ b/javascript/packages/formatter/src/format-helpers.ts
@@ -21,7 +21,6 @@ export interface ContentUnit {
   type: 'text' | 'inline' | 'erb' | 'block'
   isAtomic: boolean
   breaksFlow: boolean
-  isHerbDisable?: boolean
 }
 
 /**
@@ -130,33 +129,6 @@ export function filterSignificantChildren(body: Node[]): Node[] {
 
     return true
   })
-}
-
-/**
- * Smart filter that preserves exactly ONE whitespace before herb:disable comments
- */
-export function filterEmptyNodesForHerbDisable(nodes: Node[]): Node[] {
-  const result: Node[] = []
-  let pendingWhitespace: Node | null = null
-
-  for (const node of nodes) {
-    const isHerbDisable = isNode(node, ERBContentNode) && isHerbDisableComment(node)
-
-    if (isPureWhitespaceNode(node)) {
-      if (!pendingWhitespace) {
-        pendingWhitespace = node
-      }
-    } else {
-      if (isHerbDisable && pendingWhitespace) {
-        result.push(pendingWhitespace)
-      }
-
-      pendingWhitespace = null
-      result.push(node)
-    }
-  }
-
-  return result
 }
 
 // --- Punctuation and Word Spacing Functions ---
@@ -506,7 +478,7 @@ export function endsWithWhitespace(text: string): boolean {
 /**
  * Check if an ERB content node is a herb:disable comment
  */
-export function isHerbDisableComment(node: Node): boolean {
+export function isHerbDisableComment(node: Node): node is ERBContentNode & { tag_opening: { value: "<%#" } } {
   if (!isNode(node, ERBContentNode)) return false
   if (node.tag_opening?.value !== "<%#") return false
 
@@ -514,21 +486,6 @@ export function isHerbDisableComment(node: Node): boolean {
   const trimmed = content.trim()
 
   return trimmed.startsWith("herb:disable")
-}
-
-/**
- * Check if children contain a leading herb:disable comment (after optional whitespace)
- */
-export function hasLeadingHerbDisable(children: Node[]): boolean {
-  for (const child of children) {
-    if (isNode(child, WhitespaceNode) || (isNode(child, HTMLTextNode) && child.content.trim() === "")) {
-      continue
-    }
-
-    return isNode(child, ERBContentNode) && isHerbDisableComment(child)
-  }
-
-  return false
 }
 
 /**

--- a/javascript/packages/formatter/src/format-printer.ts
+++ b/javascript/packages/formatter/src/format-printer.ts
@@ -2,12 +2,15 @@ import { Printer, IdentityPrinter } from "@herb-tools/printer"
 import { TextFlowEngine } from "./text-flow-engine.js"
 import { AttributeRenderer } from "./attribute-renderer.js"
 import { SpacingAnalyzer } from "./spacing-analyzer.js"
+import { HerbDisableCollector } from "./herb-disable-collector.js"
+
 import { isTextFlowNode } from "./text-flow-helpers.js"
 import { extractHTMLCommentContent, formatHTMLCommentInner, formatERBCommentLines } from "./comment-helpers.js"
 
 import type { ERBNode } from "@herb-tools/core"
 import type { FormatOptions } from "./options.js"
 import type { TextFlowDelegate } from "./text-flow-engine.js"
+import type { CollectedHerbDisable } from "./herb-disable-collector.js"
 import type { AttributeRendererDelegate } from "./attribute-renderer.js"
 import type { ElementFormattingAnalysis } from "./format-helpers.js"
 
@@ -34,15 +37,12 @@ import {
 
 import {
   areAllNestedElementsInline,
-  filterEmptyNodesForHerbDisable,
   filterSignificantChildren,
   hasComplexERBControlFlow,
   hasMixedTextAndInlineContent,
   hasMultilineTextContent,
   isContentPreserving,
   isFrontmatter,
-  hasLeadingHerbDisable,
-  isHerbDisableComment,
   isInlineElement,
   isNonWhitespaceNode,
   shouldAppendToLastLine,
@@ -142,6 +142,7 @@ export class FormatPrinter extends Printer implements TextFlowDelegate, Attribut
   private textFlow: TextFlowEngine
   private attributeRenderer: AttributeRenderer
   private spacingAnalyzer: SpacingAnalyzer
+  private collectedHerbDisable: CollectedHerbDisable[] = []
 
   public source: string
 
@@ -161,7 +162,10 @@ export class FormatPrinter extends Printer implements TextFlowDelegate, Attribut
 
     const node: Node = isParseResult(input) ? input.value : input
 
-    // TODO: refactor to use @herb-tools/printer infrastructre (or rework printer use push and this.lines)
+    const collector = new HerbDisableCollector()
+    collector.visit(node)
+    this.collectedHerbDisable = collector.collected
+
     this.lines = []
     this.indentLevel = 0
     this.stringLineCount = 0
@@ -170,7 +174,105 @@ export class FormatPrinter extends Printer implements TextFlowDelegate, Attribut
 
     this.visit(node)
 
+    this.spliceHerbDisableComments()
+
     return this.lines.join("\n")
+  }
+
+  private spliceHerbDisableComments(): void {
+    const documentRootComments: string[] = []
+
+    for (const entry of this.collectedHerbDisable) {
+      if (!entry.anchor && isNode(entry.parentNode, DocumentNode)) {
+        documentRootComments.push(entry.commentText)
+        continue
+      }
+
+      const outputLine = this.findOutputLineForHerbDisable(entry)
+
+      if (outputLine >= 0 && outputLine < this.lines.length) {
+        const currentLine = this.lines[outputLine].trimEnd()
+        const separator = currentLine.endsWith(" ") ? "" : " "
+        this.lines[outputLine] = currentLine + separator + entry.commentText
+      }
+    }
+
+    if (documentRootComments.length > 0) {
+      this.lines.unshift(...documentRootComments, "")
+    }
+  }
+
+  private findOutputLineForHerbDisable(entry: CollectedHerbDisable): number {
+    if (isNode(entry.anchor, HTMLOpenTagNode) && isNode(entry.parentNode, HTMLElementNode)) {
+      const tagSearch = `<${getTagName(entry.anchor)}`
+
+      for (let index = 0; index < this.lines.length; index++) {
+        if (this.lines[index].includes(tagSearch)) {
+          if (this.lines[index].includes("\n")) {
+            const subLines = this.lines[index].split("\n")
+            const commentText = entry.commentText
+            const firstLine = subLines[0].trimEnd()
+            const separator = firstLine.endsWith(" ") ? "" : " "
+            subLines[0] = firstLine + separator + commentText
+            this.lines[index] = subLines.join("\n")
+
+            return -1
+          }
+
+          for (let forward = index + 1; forward < this.lines.length; forward++) {
+            if (this.lines[forward].trim() === ">") return forward
+          }
+
+          return index
+        }
+      }
+    }
+
+    const searchContent = this.getSearchableContentForNode(entry.anchor) ?? this.getSearchableContentForNode(entry.parentNode)
+
+    if (searchContent) {
+      for (let index = 0; index < this.lines.length; index++) {
+        if (this.lines[index].includes(searchContent)) return index
+      }
+    }
+
+    return this.lines.length > 0 ? this.lines.length - 1 : 0
+  }
+
+  private getSearchableContentForNode(node: Node | null): string | null {
+    if (!node) return null
+
+    if (isNode(node, HTMLOpenTagNode)) {
+      return `<${getTagName(node)}`
+    }
+
+    if (isNode(node, HTMLElementNode)) {
+      if (node.close_tag) {
+        return `</${getTagName(node)}`
+      }
+
+      return `<${getTagName(node)}`
+    }
+
+    if (isNode(node, HTMLCloseTagNode)) {
+      return `</${getTagName(node)}`
+    }
+
+    if (isNode(node, HTMLAttributeNode) && isNode(node.name, HTMLAttributeNameNode)) {
+      return getCombinedAttributeName(node.name)
+    }
+
+    if (isNode(node, HTMLTextNode)) {
+      const firstWord = node.content.trim().split(/\s+/)[0]
+
+      return firstWord || null
+    }
+
+    if (isNode(node, ERBContentNode)) {
+      return IdentityPrinter.print(node).trim()
+    }
+
+    return null
   }
 
   /**
@@ -357,26 +459,7 @@ export class FormatPrinter extends Printer implements TextFlowDelegate, Attribut
    * Render multiline attributes for a tag
    */
   private renderMultilineAttributes(tagName: string, allChildren: Node[] = [], isSelfClosing: boolean = false,) {
-    const herbDisableComments = allChildren.filter(child =>
-      isNode(child, ERBContentNode) && isHerbDisableComment(child)
-    )
-
-    let openingLine = `<${tagName}`
-
-    if (herbDisableComments.length > 0) {
-      const commentLines = this.capture(() => {
-        herbDisableComments.forEach(comment => {
-          this.withInlineMode(() => {
-            this.lines.push(" ")
-            this.visit(comment)
-          })
-        })
-      })
-
-      openingLine += commentLines.join("")
-    }
-
-    this.pushWithIndent(openingLine)
+    this.pushWithIndent(`<${tagName}`)
 
     this.withIndent(() => {
       this.attributeRenderer.indentLevel = this.indentLevel
@@ -384,10 +467,6 @@ export class FormatPrinter extends Printer implements TextFlowDelegate, Attribut
         if (isNode(child, HTMLAttributeNode)) {
           this.pushWithIndent(this.attributeRenderer.renderAttribute(child, tagName))
         } else if (!isNode(child, WhitespaceNode)) {
-          if (isNode(child, ERBContentNode) && isHerbDisableComment(child)) {
-            return
-          }
-
           this.visit(child)
         }
       })
@@ -561,20 +640,11 @@ export class FormatPrinter extends Printer implements TextFlowDelegate, Attribut
 
     if (children.length === 0) return
 
-    const { comment, hasLeadingWhitespace, remainingChildren, remainingBody } = this.stripLeadingHerbDisable(children, body)
-
-    if (comment) {
-      const herbDisableString = this.captureHerbDisableInline(comment)
-      this.pushToLastLine((hasLeadingWhitespace ? ' ' : '') + herbDisableString)
-    }
-
-    if (remainingChildren.length === 0) return
-
     this.withIndent(() => {
       if (hasTextFlow) {
-        this.textFlow.visitTextFlowChildren(remainingBody)
+        this.textFlow.visitTextFlowChildren(body)
       } else {
-        this.visitElementChildren(comment ? remainingChildren : body, element)
+        this.visitElementChildren(body, element)
       }
     })
   }
@@ -647,60 +717,6 @@ export class FormatPrinter extends Printer implements TextFlowDelegate, Attribut
     }
   }
 
-  private stripLeadingHerbDisable(children: Node[], body: Node[]): {
-    comment: Node | null
-    hasLeadingWhitespace: boolean
-    remainingChildren: Node[]
-    remainingBody: Node[]
-  } {
-    let leadingHerbDisableComment: Node | null = null
-    let leadingHerbDisableIndex = -1
-    let firstWhitespaceIndex = -1
-
-    for (let i = 0; i < children.length; i++) {
-      const child = children[i]
-
-      if (isNode(child, WhitespaceNode) || isPureWhitespaceNode(child)) {
-        if (firstWhitespaceIndex < 0) {
-          firstWhitespaceIndex = i
-        }
-
-        continue
-      }
-
-      if (isNode(child, ERBContentNode) && isHerbDisableComment(child)) {
-        leadingHerbDisableComment = child
-        leadingHerbDisableIndex = i
-      }
-
-      break
-    }
-
-    if (!leadingHerbDisableComment || leadingHerbDisableIndex < 0) {
-      return { comment: null, hasLeadingWhitespace: false, remainingChildren: children, remainingBody: body }
-    }
-
-    const filterOut = (nodes: Node[]) => nodes.filter((_, index) => {
-      if (index === leadingHerbDisableIndex) return false
-
-      if (firstWhitespaceIndex >= 0 && index === leadingHerbDisableIndex - 1) {
-        const child = nodes[index]
-
-        if (isNode(child, WhitespaceNode) || isPureWhitespaceNode(child)) {
-          return false
-        }
-      }
-
-      return true
-    })
-
-    return {
-      comment: leadingHerbDisableComment,
-      hasLeadingWhitespace: firstWhitespaceIndex >= 0 && firstWhitespaceIndex < leadingHerbDisableIndex,
-      remainingChildren: filterOut(children),
-      remainingBody: filterOut(body),
-    }
-  }
 
   /**
    * Visit element children with intelligent spacing logic
@@ -737,18 +753,6 @@ export class FormatPrinter extends Printer implements TextFlowDelegate, Attribut
         index = textFlowResult.newIndex
         lastMeaningfulNode = textFlowResult.lastMeaningfulNode
         hasHandledSpacing = textFlowResult.hasHandledSpacing
-        continue
-      }
-
-      const herbDisableResult: ChildVisitResult | null =
-        isNode(child, HTMLElementNode) && child.close_tag
-          ? this.visitChildWithTrailingHerbDisable(child, body, index, parentElement, lastMeaningfulNode, hasHandledSpacing)
-          : null
-
-      if (herbDisableResult) {
-        index = herbDisableResult.newIndex
-        lastMeaningfulNode = herbDisableResult.lastMeaningfulNode
-        hasHandledSpacing = herbDisableResult.hasHandledSpacing
         continue
       }
 
@@ -808,44 +812,6 @@ export class FormatPrinter extends Printer implements TextFlowDelegate, Attribut
       lastMeaningfulNode: run.nodes[run.nodes.length - 1],
       hasHandledSpacing: hasBlankLineAfter,
     }
-  }
-
-  private visitChildWithTrailingHerbDisable(child: HTMLElementNode, body: Node[], index: number, parentElement: HTMLElementNode | null, lastMeaningfulNode: Node | null, hasHandledSpacing: boolean): ChildVisitResult | null {
-    for (let j = index + 1; j < body.length; j++) {
-      const nextChild = body[j]
-
-      if (isNode(nextChild, WhitespaceNode) || isPureWhitespaceNode(nextChild)) {
-        continue
-      }
-
-      if (isNode(nextChild, ERBContentNode) && isHerbDisableComment(nextChild)) {
-        const childStartLine = this.stringLineCount
-        this.visit(child)
-
-        if (lastMeaningfulNode && !hasHandledSpacing) {
-          const shouldAddSpacing = this.spacingAnalyzer.shouldAddSpacingBetweenSiblings(parentElement, body, index)
-
-          if (shouldAddSpacing) {
-            this.lines.splice(childStartLine, 0, "")
-            this.stringLineCount++
-          }
-        }
-
-        const herbDisableString = this.captureHerbDisableInline(nextChild)
-
-        this.pushToLastLine(' ' + herbDisableString)
-
-        return {
-          newIndex: j,
-          lastMeaningfulNode: child,
-          hasHandledSpacing: false,
-        }
-      }
-
-      break
-    }
-
-    return null
   }
 
   visitHTMLOpenTagNode(node: HTMLOpenTagNode) {
@@ -1113,7 +1079,7 @@ export class FormatPrinter extends Printer implements TextFlowDelegate, Attribut
         this.printERBNode(node)
 
         this.withIndent(() => {
-          node.statements.forEach(child => this.visit(child))
+          this.visitAll(node.statements)
         })
 
         if (node.subsequent) this.visit(node.subsequent)
@@ -1277,6 +1243,7 @@ export class FormatPrinter extends Printer implements TextFlowDelegate, Attribut
     const openTagClosing = getOpenTagClosing(node)
 
     if (!openTagInline) return false
+
     if (children.length === 0) return true
 
     const hasNonInlineChildElements = children.some(child => {
@@ -1288,10 +1255,6 @@ export class FormatPrinter extends Printer implements TextFlowDelegate, Attribut
     })
 
     if (hasNonInlineChildElements) return false
-
-    if (hasLeadingHerbDisable(node.body) && !isInlineElement(tagName)) {
-      return false
-    }
 
     if (isInlineElement(tagName)) {
       const fullInlineResult = this.tryRenderInlineFull(node, tagName, filterNodes(getOpenTagChildren(node), HTMLAttributeNode), node.body)
@@ -1372,15 +1335,6 @@ export class FormatPrinter extends Printer implements TextFlowDelegate, Attribut
 
   // --- Utility methods ---
 
-  private captureHerbDisableInline(node: Node): string {
-    return this.capture(() => {
-      const savedIndentLevel = this.indentLevel
-      this.indentLevel = 0
-      this.withInlineMode(() => this.visit(node))
-      this.indentLevel = savedIndentLevel
-    }).join("")
-  }
-
   private fitsOnCurrentLine(content: string): boolean {
     return this.indent.length + content.length <= this.maxLineLength
   }
@@ -1441,11 +1395,9 @@ export class FormatPrinter extends Printer implements TextFlowDelegate, Attribut
       return `<${tagName}${attributesString}${isSelfClosing ? " />" : ">"}`
     }
 
-    const childrenToRender = this.getFilteredChildren(element.body)
-
     const childInline = this.tryRenderInlineFull(element, tagName,
       filterNodes(getOpenTagChildren(element), HTMLAttributeNode),
-      childrenToRender
+      element.body
     )
 
     return childInline !== null ? childInline : ""
@@ -1463,9 +1415,8 @@ export class FormatPrinter extends Printer implements TextFlowDelegate, Attribut
    */
   tryRenderInlineElement(element: HTMLElementNode): string | null {
     const tagName = getTagName(element)
-    const childrenToRender = this.getFilteredChildren(element.body)
 
-    return this.tryRenderInlineFull(element, tagName, filterNodes(getOpenTagChildren(element), HTMLAttributeNode), childrenToRender)
+    return this.tryRenderInlineFull(element, tagName, filterNodes(getOpenTagChildren(element), HTMLAttributeNode), element.body)
   }
 
 
@@ -1543,9 +1494,7 @@ export class FormatPrinter extends Printer implements TextFlowDelegate, Attribut
   private tryRenderChildrenInline(children: Node[], tagName?: string): string | null {
     let result = ""
     let hasInternalWhitespace = false
-    let addedLeadingSpace = false
 
-    const hasHerbDisable = hasLeadingHerbDisable(children)
     const hasOnlyTextContent = children.every(child => isNode(child, HTMLTextNode) || isNode(child, WhitespaceNode))
     const shouldPreserveSpaces = hasOnlyTextContent && tagName && isInlineElement(tagName)
 
@@ -1572,10 +1521,7 @@ export class FormatPrinter extends Printer implements TextFlowDelegate, Attribut
       }
 
       if (isPureWhitespaceNode(child) && !result.endsWith(' ')) {
-        if (!result && hasHerbDisable && !addedLeadingSpace) {
-          result += ' '
-          addedLeadingSpace = true
-        } else if (result) {
+        if (result) {
           result += ' '
           hasInternalWhitespace = true
         }
@@ -1586,10 +1532,9 @@ export class FormatPrinter extends Printer implements TextFlowDelegate, Attribut
           return null
         }
 
-        const childrenToRender = this.getFilteredChildren(child.body)
         const childInline = this.tryRenderInlineFull(child, tagName,
           filterNodes(getOpenTagChildren(child), HTMLAttributeNode),
-          childrenToRender
+          child.body
         )
 
         if (!childInline) {
@@ -1607,7 +1552,7 @@ export class FormatPrinter extends Printer implements TextFlowDelegate, Attribut
       return result
     }
 
-    if (hasHerbDisable && result.startsWith(' ') || hasInternalWhitespace) {
+    if (hasInternalWhitespace) {
       return result.trimEnd()
     }
 
@@ -1644,22 +1589,6 @@ export class FormatPrinter extends Printer implements TextFlowDelegate, Attribut
     return `<${tagName}>${content}</${tagName}>`
   }
 
-  /**
-   * Get filtered children, using smart herb:disable filtering if needed
-   */
-  private getFilteredChildren(body: Node[]): Node[] {
-    const hasHerbDisable = body.some(child =>
-      isNode(child, ERBContentNode) && isHerbDisableComment(child)
-    )
-
-    return hasHerbDisable ? filterEmptyNodesForHerbDisable(body) : body
-  }
-
-  private renderElementInline(element: HTMLElementNode): string {
-    const children = this.getFilteredChildren(element.body)
-
-    return this.renderChildrenInline(children)
-  }
 
   private renderChildrenInline(children: Node[]) {
     let content = ''
@@ -1672,7 +1601,7 @@ export class FormatPrinter extends Printer implements TextFlowDelegate, Attribut
         const attributes = filterNodes(getOpenTagChildren(child), HTMLAttributeNode)
         this.attributeRenderer.indentLevel = this.indentLevel
         const attributesString = this.attributeRenderer.renderAttributesString(attributes, tagName)
-        const childContent = this.renderElementInline(child)
+        const childContent = this.renderChildrenInline(child.body)
 
         content += `<${tagName}${attributesString}>${childContent}</${tagName}>`
       } else if (isNode(child, ERBContentNode)) {

--- a/javascript/packages/formatter/src/herb-disable-collector.ts
+++ b/javascript/packages/formatter/src/herb-disable-collector.ts
@@ -1,0 +1,89 @@
+import { IdentityPrinter } from "@herb-tools/printer"
+import { Visitor, Node, ERBContentNode, HTMLOpenTagNode, HTMLElementNode, WhitespaceNode, isNode, isPureWhitespaceNode } from "@herb-tools/core"
+import { isHerbDisableComment } from "./format-helpers.js"
+
+export interface CollectedHerbDisable {
+  node: ERBContentNode
+  anchor: Node | null
+  parentNode: Node
+  commentText: string
+}
+
+/**
+ * HerbDisableCollector walks the AST before formatting, collects all
+ * herb:disable comment nodes, finds their anchor nodes (the preceding
+ * sibling on the same source line), and removes them from the AST.
+ *
+ * After formatting, the collected comments are spliced back onto the
+ * correct output lines based on where their anchors ended up.
+ */
+export class HerbDisableCollector extends Visitor {
+  readonly collected: CollectedHerbDisable[] = []
+
+  visitChildNodes(node: Node): void {
+    this.processArraysOnNode(node)
+    super.visitChildNodes(node)
+  }
+
+  private processArraysOnNode(node: Node): void {
+    for (const value of Object.values(node)) {
+      if (!Array.isArray(value)) continue
+
+      this.processArray(value, node)
+    }
+  }
+
+  private processArray(array: Node[], parentNode: Node): void {
+    for (let index = array.length - 1; index >= 0; index--) {
+      const child = array[index]
+
+      if (!isHerbDisableComment(child)) continue
+
+      const anchor = this.findAnchor(array, index, parentNode)
+
+      this.collected.push({
+        node: child,
+        anchor,
+        parentNode,
+        commentText: IdentityPrinter.print(child).trim(),
+      })
+
+      array.splice(index, 1)
+    }
+  }
+
+  private findAnchor(array: Node[], herbDisableIndex: number, parentNode: Node): Node | null {
+    const herbDisableNode = array[herbDisableIndex]
+
+    for (let index = herbDisableIndex - 1; index >= 0; index--) {
+      const sibling = array[index]
+
+      if (isPureWhitespaceNode(sibling) || isNode(sibling, WhitespaceNode)) continue
+      if (isHerbDisableComment(sibling)) continue
+
+      if (sibling.location.end.line === herbDisableNode.location.start.line) {
+        return sibling
+      }
+
+      if (isNode(parentNode, HTMLElementNode)) {
+        return sibling
+      }
+
+      break
+    }
+
+    if (isNode(parentNode, HTMLOpenTagNode)) {
+      return parentNode
+    }
+
+    if (isNode(parentNode, HTMLElementNode)) {
+      const openTag = parentNode.open_tag
+
+      if (openTag && openTag.location.end.line === herbDisableNode.location.start.line) {
+        return openTag
+      }
+    }
+
+    return null
+  }
+}

--- a/javascript/packages/formatter/src/text-flow-analyzer.ts
+++ b/javascript/packages/formatter/src/text-flow-analyzer.ts
@@ -5,7 +5,6 @@ import type { ContentUnitWithNode } from "./format-helpers.js"
 
 import {
   hasWhitespaceBetween,
-  isHerbDisableComment,
   isInlineElement,
   isLineBreakingElement,
 } from "./format-helpers.js"
@@ -162,7 +161,6 @@ export class TextFlowAnalyzer {
 
   private processERBContentNode(result: ContentUnitWithNode[], children: Node[], child: ERBContentNode, index: number, lastProcessedIndex: number): boolean {
     const erbContent = this.delegate.renderERBAsString(child)
-    const herbDisable = isHerbDisableComment(child)
 
     if (lastProcessedIndex >= 0) {
       const hasWhitespace = hasWhitespaceBetween(children, lastProcessedIndex, index) || lastUnitEndsWithWhitespaceHelper(result)
@@ -185,11 +183,11 @@ export class TextFlowAnalyzer {
     }
 
     result.push({
-      unit: { content: erbContent, type: 'erb', isAtomic: true, breaksFlow: false, isHerbDisable: herbDisable },
+      unit: { content: erbContent, type: 'erb', isAtomic: true, breaksFlow: false },
       node: child
     })
 
-    if (isERBCommentNode(child) && !herbDisable) {
+    if (isERBCommentNode(child)) {
       for (let j = index + 1; j < children.length; j++) {
         const nextChild = children[j]
         if (isNode(nextChild, WhitespaceNode)) continue

--- a/javascript/packages/formatter/src/text-flow-engine.ts
+++ b/javascript/packages/formatter/src/text-flow-engine.ts
@@ -212,7 +212,7 @@ export class TextFlowEngine {
 
   private buildAndWrapTextFlow(children: Node[]): void {
     const unitsWithNodes: ContentUnitWithNode[] = this.analyzer.buildContentUnits(children)
-    const words: Array<{ word: string, isHerbDisable: boolean }> = []
+    const words: string[] = []
 
     for (const { unit, node } of unitsWithNodes) {
       if (unit.breaksFlow) {
@@ -222,7 +222,7 @@ export class TextFlowEngine {
           this.delegate.visit(node)
         }
       } else if (unit.isAtomic) {
-        words.push({ word: unit.content, isHerbDisable: unit.isHerbDisable || false })
+        words.push(unit.content)
       } else {
         const text = unit.content.replace(ASCII_WHITESPACE, ' ')
         const hasLeadingSpace = text.startsWith(' ')
@@ -231,65 +231,57 @@ export class TextFlowEngine {
 
         if (trimmedText) {
           if (hasLeadingSpace && words.length > 0) {
-            const lastWord = words[words.length - 1]
+            const lastIndex = words.length - 1
 
-            if (!lastWord.word.endsWith(' ')) {
-              lastWord.word += ' '
+            if (!words[lastIndex].endsWith(' ')) {
+              words[lastIndex] += ' '
             }
           }
 
-          const textWords = trimmedText.split(' ').map(w => ({ word: w, isHerbDisable: false }))
-          words.push(...textWords)
+          words.push(...trimmedText.split(' '))
 
           if (hasTrailingSpace && words.length > 0) {
-            const lastWord = words[words.length - 1]
+            const lastIndex = words.length - 1
 
-            if (!isClosingPunctuation(lastWord.word)) {
-              lastWord.word += ' '
+            if (!isClosingPunctuation(words[lastIndex])) {
+              words[lastIndex] += ' '
             }
           }
         } else if (text === ' ' && words.length > 0) {
-          const lastWord = words[words.length - 1]
+          const lastIndex = words.length - 1
 
-          if (!lastWord.word.endsWith(' ')) {
-            lastWord.word += ' '
+          if (!words[lastIndex].endsWith(' ')) {
+            words[lastIndex] += ' '
           }
         }
       }
     }
 
-    // Trim trailing space from last word before final flush - trailing spaces are
-    // informational for spacing with subsequent words but shouldn't inflate
-    // effective length when it's the final word (it gets trimmed from output anyway)
+    // Trim trailing space from last word before final flush
     if (words.length > 0) {
-      words[words.length - 1].word = words[words.length - 1].word.trimEnd()
+      words[words.length - 1] = words[words.length - 1].trimEnd()
     }
 
     this.flushWords(words)
   }
 
-  private flushWords(words: Array<{ word: string, isHerbDisable: boolean }>): void {
+  private flushWords(words: string[]): void {
     if (words.length > 0) {
       this.wrapAndPushWords(words)
       words.length = 0
     }
   }
 
-  private wrapAndPushWords(words: Array<{ word: string, isHerbDisable: boolean }>): void {
+  private wrapAndPushWords(words: string[]): void {
     const wrapWidth = this.delegate.maxLineLength - this.delegate.indent.length
     const lines: string[] = []
     let currentLine = ""
     let effectiveLength = 0
 
-    for (const { word, isHerbDisable } of words) {
+    for (const word of words) {
       const nextLine = buildLineWithWord(currentLine, word)
-
-      let nextEffectiveLength = effectiveLength
-
-      if (!isHerbDisable) {
-        const spaceBefore = currentLine && needsSpaceBetween(currentLine, word) ? 1 : 0
-        nextEffectiveLength = effectiveLength + spaceBefore + word.length
-      }
+      const spaceBefore = currentLine && needsSpaceBetween(currentLine, word) ? 1 : 0
+      const nextEffectiveLength = effectiveLength + spaceBefore + word.length
 
       if (currentLine && !isClosingPunctuation(word) && nextEffectiveLength > wrapWidth) {
         const trimmedLine = currentLine.trim()
@@ -301,7 +293,7 @@ export class TextFlowEngine {
         }
 
         currentLine = word
-        effectiveLength = isHerbDisable ? 0 : word.length
+        effectiveLength = word.length
       } else {
         currentLine = nextLine
         effectiveLength = nextEffectiveLength

--- a/javascript/packages/formatter/test/helpers.ts
+++ b/javascript/packages/formatter/test/helpers.ts
@@ -1,9 +1,20 @@
 import { expect } from "vitest"
 import { Formatter } from "../src"
 
+export interface ExpectFormattedToMatchOptions {
+  passes?: number
+}
+
 export function createExpectFormattedToMatch(formatter: Formatter) {
-  return function expectFormattedToMatch(source: string) {
-    const result = formatter.format(source)
+  return function expectFormattedToMatch(source: string, options: ExpectFormattedToMatchOptions = {}) {
+    const { passes = 1 } = options
+
+    let result = source
+
+    for (let pass = 0; pass < passes; pass++) {
+      result = formatter.format(result)
+    }
+
     expect(result).toEqual(source)
   }
 }

--- a/javascript/packages/formatter/test/herb-disable-comment-formatting.test.ts
+++ b/javascript/packages/formatter/test/herb-disable-comment-formatting.test.ts
@@ -66,12 +66,18 @@ describe("herb:disable comment formatting", () => {
     `)
   })
 
-  test("should not count herb:disable comment length in line wrapping calculations", () => {
-    expectFormattedToMatch(dedent`
+  test("element with short content inlines when herb:disable is removed", () => {
+    const source = dedent`
       <DIV> <%# herb:disable html-tag-name-lowercase, some-super-long-rule-names-that-should-make-this-wrap-but-it-doesnt-because-its-a-herb-disable-comment %>
         Short text here that should not wrap.
       </DIV>
-    `)
+    `
+
+    const result = formatter.format(source)
+
+    expect(result).toBe(
+      `<DIV>Short text here that should not wrap.</DIV> <%# herb:disable html-tag-name-lowercase, some-super-long-rule-names-that-should-make-this-wrap-but-it-doesnt-because-its-a-herb-disable-comment %>`
+    )
   })
 
   test("should treat herb:disable as 'invisible' for text flow wrapping", () => {
@@ -108,17 +114,31 @@ describe("herb:disable comment formatting", () => {
     `)
   })
 
-  test("should handle multiple rule names in herb:disable comment", () => {
-    expectFormattedToMatch(dedent`
+  test("element with short content and multiple rules inlines", () => {
+    const source = dedent`
       <DIV> <%# herb:disable rule-one, rule-two, rule-three %>
         Text content here.
       </DIV>
-    `)
+    `
+
+    const result = formatter.format(source)
+
+    expect(result).toBe(
+      `<DIV>Text content here.</DIV> <%# herb:disable rule-one, rule-two, rule-three %>`
+    )
   })
 
-  test("should preserve herb:disable comment whitespace and position", () => {
-    expectFormattedToMatch(dedent`
+  test("should always add a space before herb:disable comment", () => {
+    const source = dedent`
       <DIV><%# herb:disable html-tag-name-lowercase %>
+        Content here.
+      </DIV>
+    `
+
+    const result = formatter.format(source)
+
+    expect(result).toBe(dedent`
+      <DIV> <%# herb:disable html-tag-name-lowercase %>
         Content here.
       </DIV>
     `)
@@ -153,7 +173,7 @@ describe("herb:disable comment formatting", () => {
 
     expect(result).toBe(dedent`
       <p>
-        Some text with <span> <%# herb:disable some-rule %>inline content</span> here.
+        Some text with <span>inline content</span> here. <%# herb:disable some-rule %>
       </p>
     `)
   })
@@ -169,11 +189,9 @@ describe("herb:disable comment formatting", () => {
 
     const result = formatter.format(source)
 
-    expect(result).toBe(dedent`
-      <DIV> <%# herb:disable html-tag-name-lowercase %>
-        Some content here. <%# herb:disable another-rule %> More content.
-      </DIV>
-    `)
+    expect(result).toBe(
+      `<DIV>Some content here.More content.</DIV> <%# herb:disable another-rule %> <%# herb:disable html-tag-name-lowercase %>`
+    )
   })
 
   test("should handle empty elements with herb:disable", () => {
@@ -184,10 +202,9 @@ describe("herb:disable comment formatting", () => {
 
     const result = formatter.format(source)
 
-    expect(result).toBe(dedent`
-      <div> <%# herb:disable some-rule %>
-      </div>
-    `)
+    expect(result).toBe(
+      `<div></div> <%# herb:disable some-rule %>`
+    )
   })
 
   test("should handle herb:disable with ERB output tags", () => {
@@ -199,11 +216,9 @@ describe("herb:disable comment formatting", () => {
 
     const result = formatter.format(source)
 
-    expect(result).toBe(dedent`
-      <div> <%# herb:disable some-rule %>
-        <%= content %>
-      </div>
-    `)
+    expect(result).toBe(
+      `<div><%= content %></div> <%# herb:disable some-rule %>`
+    )
   })
 
   test("should handle deeply nested herb:disable (3 levels)", () => {
@@ -222,20 +237,24 @@ describe("herb:disable comment formatting", () => {
     expect(result).toBe(dedent`
       <div>
         <section>
-          <DIV> <%# herb:disable html-tag-name-lowercase %>
-            Content here.
-          </DIV>
+          <DIV>Content here.</DIV> <%# herb:disable html-tag-name-lowercase %>
         </section>
       </div>
     `)
   })
 
-  test("should handle very long herb:disable rule lists", () => {
-    expectFormattedToMatch(dedent`
+  test("element with short content and long rule list inlines", () => {
+    const source = dedent`
       <DIV> <%# herb:disable rule-one, rule-two, rule-three, rule-four, rule-five, rule-six, rule-seven %>
         Content.
       </DIV>
-    `)
+    `
+
+    const result = formatter.format(source)
+
+    expect(result).toBe(
+      `<DIV>Content.</DIV> <%# herb:disable rule-one, rule-two, rule-three, rule-four, rule-five, rule-six, rule-seven %>`
+    )
   })
 
   test("should handle herb:disable between sibling elements", () => {
@@ -267,11 +286,9 @@ describe("herb:disable comment formatting", () => {
 
     const result = formatter.format(source)
 
-    expect(result).toBe(dedent`
-      <DIV> <%# herb:disable rule-one %>
-        <%# herb:disable rule-two %> Content here.
-      </DIV>
-    `)
+    expect(result).toBe(
+      `<DIV>Content here.</DIV> <%# herb:disable rule-two %> <%# herb:disable rule-one %>`
+    )
   })
 
   test("reproduces the exact issue from #738", () => {
@@ -314,5 +331,409 @@ describe("herb:disable comment formatting", () => {
         Close
       </a>
     `)
+  })
+
+  test("keeps herb:disable comment on the same line as the attribute it follows", () => {
+    const source = dedent`
+      <li>
+        <div
+          data-testid="blog-post"
+          class="theme-<%= theme %> some-long-classes" <%# herb:disable erb-no-interpolated-class-names %>
+        >
+          content
+        </div>
+      </li>
+    `
+
+    const result = formatter.format(source)
+
+    expect(result).toBe(dedent`
+      <li>
+        <div data-testid="blog-post" class="theme-<%= theme %> some-long-classes"> <%# herb:disable erb-no-interpolated-class-names %>
+          content
+        </div>
+      </li>
+    `)
+  })
+
+  test("keeps herb:disable comment stay the same line ", () => {
+     expectFormattedToMatch(dedent`
+      <li>
+        <div
+          data-testid="blog-post"
+          class="theme-<%= theme %> some-long-classes that make sure this stay multiline" <%# herb:disable erb-no-interpolated-class-names %>
+        >
+          content
+        </div>
+      </li>
+    `)
+  })
+
+  test("keeps herb:disable on tag name line when it appears before any attributes", () => {
+    const source = dedent`
+      <a <%# herb:disable html-anchor-require-href %>
+        class="btn btn-secondary"
+        aria-label="Close"
+      >
+        Close
+      </a>
+    `
+
+    const result = formatter.format(source)
+
+    expect(result).toBe(
+      `<a class="btn btn-secondary" aria-label="Close"> Close </a> <%# herb:disable html-anchor-require-href %>`
+    )
+  })
+
+  test("keeps herb:disable comment on the attribute line in a loop", () => {
+    expectFormattedToMatch(dedent`
+      <ol>
+        <% posts.each do |post| %>
+          <li <%# herb:disable another-long-disable-comment-name %>
+            data-testid="blog-post some-long-value some-long-value" <%# herb:disable another-long-disable-comment-name %>
+            class="theme-<%= post.org %>-light some-long-class-name" <%# herb:disable erb-no-interpolated-class-names %>
+          > <%# herb:disable another-long-disable-comment-name %>
+            content
+          </li>
+        <% end %>
+      </ol>
+    `)
+  })
+
+  test("keeps herb:disable on same line as ERB output inside if block", () => {
+    expectFormattedToMatch(dedent`
+      <% if content_for(:pre_main) %>
+        <%= raw content_for(:pre_main) %> <%# herb:disable erb-no-unsafe-raw %>
+      <% end %>
+    `)
+  })
+
+  test("keeps herb:disable on same line as ERB output inside else block", () => {
+    expectFormattedToMatch(dedent`
+      <% if condition %>
+        <%= safe_content %>
+      <% else %>
+        <%= raw fallback %> <%# herb:disable erb-no-unsafe-raw %>
+      <% end %>
+    `)
+  })
+
+  test("keeps herb:disable on same line as ERB output inside unless block", () => {
+    expectFormattedToMatch(dedent`
+      <% unless invalid? %>
+        <%= raw content %> <%# herb:disable erb-no-unsafe-raw %>
+      <% end %>
+    `)
+  })
+
+  test("keeps herb:disable on same line as ERB output inside while block", () => {
+    expectFormattedToMatch(dedent`
+      <% while items.any? %>
+        <%= raw items.pop %> <%# herb:disable erb-no-unsafe-raw %>
+      <% end %>
+    `)
+  })
+
+  test("keeps herb:disable on same line as ERB output inside until block", () => {
+    expectFormattedToMatch(dedent`
+      <% until done? %>
+        <%= raw next_item %> <%# herb:disable erb-no-unsafe-raw %>
+      <% end %>
+    `)
+  })
+
+  test("keeps herb:disable on same line as ERB output inside for block", () => {
+    expectFormattedToMatch(dedent`
+      <% for item in items %>
+        <%= raw item %> <%# herb:disable erb-no-unsafe-raw %>
+      <% end %>
+    `)
+  })
+
+  test("keeps herb:disable on same line as ERB output inside case/when block", () => {
+    expectFormattedToMatch(dedent`
+      <% case status %>
+      <% when "active" %>
+        <%= raw active_content %> <%# herb:disable erb-no-unsafe-raw %>
+      <% when "inactive" %>
+        <%= raw inactive_content %> <%# herb:disable erb-no-unsafe-raw %>
+      <% end %>
+    `)
+  })
+
+  test("keeps herb:disable on same line as ERB output inside begin/rescue block", () => {
+    expectFormattedToMatch(dedent`
+      <% begin %>
+        <%= raw try_content %> <%# herb:disable erb-no-unsafe-raw %>
+      <% rescue StandardError %>
+        <%= raw rescue_content %> <%# herb:disable erb-no-unsafe-raw %>
+      <% end %>
+    `)
+  })
+
+  test("keeps herb:disable on same line as ERB output inside ensure block", () => {
+    expectFormattedToMatch(dedent`
+      <% begin %>
+        <%= content %>
+      <% ensure %>
+        <%= raw cleanup %> <%# herb:disable erb-no-unsafe-raw %>
+      <% end %>
+    `)
+  })
+
+  test("keeps multiple herb:disable comments on their respective lines inside if block", () => {
+    expectFormattedToMatch(dedent`
+      <% if condition %>
+        <%= raw first %> <%# herb:disable erb-no-unsafe-raw %>
+        <%= raw second %> <%# herb:disable erb-no-unsafe-raw %>
+      <% end %>
+    `)
+  })
+
+  test("keeps herb:disable on respective lines across if/else branches", () => {
+    expectFormattedToMatch(dedent`
+      <% if condition %>
+        <%= raw content_a %> <%# herb:disable erb-no-unsafe-raw %>
+      <% else %>
+        <%= raw content_b %> <%# herb:disable erb-no-unsafe-raw %>
+      <% end %>
+    `)
+  })
+
+  test("keeps herb:disable inside nested if blocks", () => {
+    expectFormattedToMatch(dedent`
+      <% if outer %>
+        <% if inner %>
+          <%= raw content %> <%# herb:disable erb-no-unsafe-raw %>
+        <% end %>
+      <% end %>
+    `)
+  })
+
+  test("keeps herb:disable inside if block nested in each loop", () => {
+    expectFormattedToMatch(dedent`
+      <% items.each do |item| %>
+        <% if item.special? %>
+          <%= raw item.content %> <%# herb:disable erb-no-unsafe-raw %>
+        <% end %>
+      <% end %>
+    `)
+  })
+
+  test("keeps herb:disable after ERB output followed by HTML in if block", () => {
+    expectFormattedToMatch(dedent`
+      <% if show? %>
+        <%= raw header %> <%# herb:disable erb-no-unsafe-raw %>
+        <div>content</div>
+      <% end %>
+    `)
+  })
+
+  test("keeps herb:disable after ERB output preceded by HTML in if block", () => {
+    expectFormattedToMatch(dedent`
+      <% if show? %>
+        <div>content</div>
+        <%= raw footer %> <%# herb:disable erb-no-unsafe-raw %>
+      <% end %>
+    `)
+  })
+
+  test("standalone herb:disable in ERB block attaches to last line", () => {
+    const source = dedent`
+      <% if condition %>
+        <div>content</div>
+        <%# herb:disable some-rule %>
+        <%= output %>
+      <% end %>
+    `
+
+    const result = formatter.format(source)
+
+    expect(result).toBe(dedent`
+      <% if condition %>
+        <div>content</div>
+        <%= output %>
+      <% end %> <%# herb:disable some-rule %>
+    `)
+  })
+
+  test("keeps herb:disable after HTML element inside ERB if block", () => {
+    expectFormattedToMatch(dedent`
+      <% if condition %>
+        <div>content</div> <%# herb:disable some-rule %>
+        <%= output %>
+      <% end %>
+    `)
+  })
+
+  test("keeps herb:disable on same line as ERB output at document root", () => {
+    expectFormattedToMatch(dedent`
+      <%= raw content %> <%# herb:disable erb-no-unsafe-raw %>
+    `)
+  })
+
+  test("standalone herb:disable in empty if block attaches to last line", () => {
+    const source = dedent`
+      <% if condition %>
+        <%# herb:disable some-rule %>
+      <% end %>
+    `
+
+    const result = formatter.format(source)
+
+    expect(result).toBe(dedent`
+      <% if condition %>
+      <% end %> <%# herb:disable some-rule %>
+    `)
+  })
+
+  test("herb:disable on same line as ERB action stays on that line", () => {
+    expectFormattedToMatch(dedent`
+      <% if condition %>
+        <% perform_action %> <%# herb:disable some-rule %>
+        <%= output %>
+      <% end %>
+    `)
+  })
+
+  test("standalone herb:disable between ERB statements attaches to last line", () => {
+    const source = dedent`
+      <% if condition %>
+        <% perform_action %>
+        <%# herb:disable some-rule %>
+        <%= output %>
+      <% end %>
+    `
+
+    const result = formatter.format(source)
+
+    expect(result).toBe(dedent`
+      <% if condition %>
+        <% perform_action %>
+        <%= output %>
+      <% end %> <%# herb:disable some-rule %>
+    `)
+  })
+
+  test("keeps herb:disable after ERB action in if block (duplicate check)", () => {
+    expectFormattedToMatch(dedent`
+      <% if condition %>
+        <% perform_action %> <%# herb:disable some-rule %>
+        <%= output %>
+      <% end %>
+    `)
+  })
+
+  test("keeps herb:disable on pre element opening tag", () => {
+    expectFormattedToMatch(dedent`
+      <pre> <%# herb:disable some-rule %>
+        preserved   content
+      </pre>
+    `)
+  })
+
+  test("keeps herb:disable on script element opening tag", () => {
+    expectFormattedToMatch(dedent`
+      <script> <%# herb:disable some-rule %>
+        console.log("hello");
+      </script>
+    `)
+  })
+
+  test("keeps herb:disable on style element opening tag", () => {
+    expectFormattedToMatch(dedent`
+      <style> <%# herb:disable some-rule %>
+        .foo { color: red; }
+      </style>
+    `)
+  })
+
+  test("keeps herb:disable on textarea element opening tag", () => {
+    expectFormattedToMatch(dedent`
+      <textarea> <%# herb:disable some-rule %>
+        preserved content here
+      </textarea>
+    `)
+  })
+
+  test("keeps herb:disable on void img element", () => {
+    expectFormattedToMatch(dedent`
+      <img src="photo.jpg"> <%# herb:disable html-img-require-alt %>
+    `)
+  })
+
+  test("keeps herb:disable on br element inside block element", () => {
+    expectFormattedToMatch(dedent`
+      <div>
+        <br> <%# herb:disable some-rule %>
+        <p>content</p>
+      </div>
+    `)
+  })
+
+  test("keeps herb:disable on hr element inside block element", () => {
+    expectFormattedToMatch(dedent`
+      <div>
+        <hr> <%# herb:disable some-rule %>
+        <p>content</p>
+      </div>
+    `)
+  })
+
+  test("keeps herb:disable in deeply nested ERB blocks", () => {
+    expectFormattedToMatch(dedent`
+      <% items.each do |item| %>
+        <% if item.visible? %>
+          <% item.tags.each do |tag| %>
+            <%= raw tag.name %> <%# herb:disable erb-no-unsafe-raw %>
+          <% end %>
+        <% end %>
+      <% end %>
+    `)
+  })
+
+  test("is idempotent for herb:disable on multiline open tag", () => {
+    expectFormattedToMatch(dedent`
+      <div
+        data-controller="tooltip"
+        data-tooltip-content="hello world"
+        class="some-long-class-name another-class"
+      > <%# herb:disable some-rule %>
+        content
+      </div>
+    `, { passes: 2 })
+  })
+
+  test("is idempotent for herb:disable on closing tag", () => {
+    expectFormattedToMatch(dedent`
+      <DIV>
+        Some content here that needs formatting.
+      </DIV> <%# herb:disable html-tag-name-lowercase %>
+    `, { passes: 2 })
+  })
+
+  test("is idempotent for herb:disable on inline element", () => {
+    expectFormattedToMatch(dedent`
+      <p>
+        Some text with <span>inline content</span> here. <%# herb:disable some-rule %>
+      </p>
+    `, { passes: 2 })
+  })
+
+  test("is idempotent for herb:disable on ERB output in if block", () => {
+    expectFormattedToMatch(dedent`
+      <% if content_for(:pre_main) %>
+        <%= raw content_for(:pre_main) %> <%# herb:disable erb-no-unsafe-raw %>
+      <% end %>
+    `, { passes: 2 })
+  })
+
+  test("is idempotent for herb:disable on pre element", () => {
+    expectFormattedToMatch(dedent`
+      <pre> <%# herb:disable some-rule %>
+        preserved   content
+      </pre>
+    `, { passes: 2 })
   })
 })

--- a/javascript/packages/formatter/test/herb-formatter-ignore.test.ts
+++ b/javascript/packages/formatter/test/herb-formatter-ignore.test.ts
@@ -85,6 +85,69 @@ describe("herb:formatter ignore directive", () => {
     const result = formatter.format(source)
     expect(result).toBe(dedent`
       <%# herb:disable all %>
+
+      <DIV>
+        <SPAN>content</SPAN>
+      </DIV>
+    `)
+  })
+
+  test("multiple on the top-level", () => {
+    const source = dedent`
+      <%# herb:disable all %>
+      <DIV>
+            <SPAN>content</SPAN>
+      </DIV>
+
+      <%# herb:disable all %>
+      <DIV>
+            <SPAN>content</SPAN>
+      </DIV>
+    `
+
+    const result = formatter.format(source)
+
+    expect(result).toBe(dedent`
+      <%# herb:disable all %>
+      <%# herb:disable all %>
+
+      <DIV>
+        <SPAN>content</SPAN>
+      </DIV>
+
+      <DIV>
+        <SPAN>content</SPAN>
+      </DIV>
+    `)
+  })
+
+  test("multiple on the top-level", () => {
+    const source = dedent`
+      <%# herb:disable all %>
+      <DIV>
+            <SPAN>content</SPAN>
+      </DIV>
+
+      <%# herb:disable all %>
+      <%# herb:disable all %>
+      <DIV>
+            <SPAN>content</SPAN>
+      </DIV>
+      <%# herb:disable all %>
+    `
+
+    const result = formatter.format(source)
+
+    expect(result).toBe(dedent`
+      <%# herb:disable all %>
+      <%# herb:disable all %>
+      <%# herb:disable all %>
+      <%# herb:disable all %>
+
+      <DIV>
+        <SPAN>content</SPAN>
+      </DIV>
+
       <DIV>
         <SPAN>content</SPAN>
       </DIV>

--- a/javascript/packages/formatter/test/text-flow-analyzer.test.ts
+++ b/javascript/packages/formatter/test/text-flow-analyzer.test.ts
@@ -64,13 +64,13 @@ describe("TextFlowAnalyzer", () => {
 
       expect(units).toHaveLength(3)
       expect(units[0].unit).toEqual({
-        type: "erb", content: "<%= a %>", isAtomic: true, breaksFlow: false, isHerbDisable: false,
+        type: "erb", content: "<%= a %>", isAtomic: true, breaksFlow: false,
       })
       expect(units[1].unit).toEqual({
         type: "text", content: " ", isAtomic: true, breaksFlow: false,
       })
       expect(units[2].unit).toEqual({
-        type: "erb", content: "<%= b %>", isAtomic: true, breaksFlow: false, isHerbDisable: false,
+        type: "erb", content: "<%= b %>", isAtomic: true, breaksFlow: false,
       })
     })
 
@@ -180,11 +180,11 @@ describe("TextFlowAnalyzer", () => {
 
       expect(units).toHaveLength(1)
       expect(units[0].unit).toEqual({
-        type: "erb", content: "<%= name %>", isAtomic: true, breaksFlow: false, isHerbDisable: false,
+        type: "erb", content: "<%= name %>", isAtomic: true, breaksFlow: false,
       })
     })
 
-    test("marks herb:disable ERB comments with isHerbDisable", () => {
+    test("herb:disable comments are treated as regular ERB content units", () => {
       const analyzer = new TextFlowAnalyzer(createMockAnalyzerDelegate())
       const body = parseBody("<p>text <%# herb:disable SomeRule %></p>")
       const units = analyzer.buildContentUnits(body)
@@ -192,7 +192,6 @@ describe("TextFlowAnalyzer", () => {
       expect(units).toHaveLength(2)
       expect(units[0].unit.type).toBe("text")
       expect(units[1].unit.type).toBe("erb")
-      expect(units[1].unit.isHerbDisable).toBe(true)
     })
 
     test("merges ERB with preceding text when no whitespace", () => {
@@ -219,7 +218,7 @@ describe("TextFlowAnalyzer", () => {
         type: "text", content: " ", isAtomic: true, breaksFlow: false,
       })
       expect(units[2].unit).toEqual({
-        type: "erb", content: "<%= x %>", isAtomic: true, breaksFlow: false, isHerbDisable: false,
+        type: "erb", content: "<%= x %>", isAtomic: true, breaksFlow: false,
       })
     })
 
@@ -325,7 +324,7 @@ describe("TextFlowAnalyzer", () => {
         type: "text", content: "before ", isAtomic: false, breaksFlow: false,
       })
       expect(units[1].unit).toEqual({
-        type: "erb", content: "<%= x %>", isAtomic: true, breaksFlow: false, isHerbDisable: false,
+        type: "erb", content: "<%= x %>", isAtomic: true, breaksFlow: false,
       })
       expect(units[2].unit).toEqual({
         type: "text", content: " after", isAtomic: false, breaksFlow: false,


### PR DESCRIPTION
Previously, `herb:disable` comment handling was scattered across 7+ locations in the formatter: `format-printer.ts`, `text-flow-analyzer.ts`, and `text-flow-engine.ts`. Every formatting path (multiline attributes, inline rendering, text flow wrapping, element body rendering) needed its own `herb:disable` awareness, making the logic fragile and hard to extend.

This pull request replaces all of that with a simple three-phase approach: **collect → remove → format → splice**.

A new `HerbDisableCollector` walks the AST before formatting, records each `herb:disable` comment along with its anchor (the preceding node on the same source line), and removes it from the AST. 

The formatter then runs with zero `herb:disable` awareness. After formatting, the collected comments are spliced back onto the correct output lines by searching for where their anchors ended up.

The text flow engine simplifies from `Array<{ word: string, isHerbDisable: boolean }>` to plain `string[]` since `herb:disable` words no longer need special zero-width treatment during line wrapping.

Discovered while working on https://github.com/hanakai-rb/site/pull/278.