### PR TITLE
Linter: Allow `content_for` and `provide` in `erb-no-unused-expressions`

### DIFF
--- a/javascript/packages/linter/src/rules/erb-no-unused-expressions.ts
+++ b/javascript/packages/linter/src/rules/erb-no-unused-expressions.ts
@@ -25,6 +25,12 @@ const MUTATION_METHODS = new Set([
   "concat",
 ])
 
+const SIDE_EFFECT_METHODS = new Set([
+  "content_for",
+  "provide",
+  "flush",
+])
+
 class UnusedExpressionCollector extends PrismVisitor {
   public readonly expressions: PrismNode[] = []
 
@@ -51,10 +57,17 @@ class UnusedExpressionCollector extends PrismVisitor {
     return MUTATION_METHODS.has(node.name)
   }
 
+  private isSideEffectCall(node: PrismNode): boolean {
+    if (node.receiver) return false
+
+    return SIDE_EFFECT_METHODS.has(node.name)
+  }
+
   private isUnusedExpression(node: PrismNode, type: string): boolean {
     if (type === "CallNode") {
       if (node.block) return false
       if (this.isMutationCall(node)) return false
+      if (this.isSideEffectCall(node)) return false
       if (isDebugOutputCall(node)) return false
 
       return true

--- a/javascript/packages/linter/test/rules/erb-no-unused-expressions.test.ts
+++ b/javascript/packages/linter/test/rules/erb-no-unused-expressions.test.ts
@@ -88,6 +88,40 @@ describe("ERBNoUnusedExpressionsRule", () => {
       `)
     })
 
+    test("passes for content_for with arguments", () => {
+      expectNoOffenses(dedent`
+        <% content_for :title, "Status" %>
+        <% content_for :description, page_description %>
+      `)
+    })
+
+    test("passes for content_for with single argument", () => {
+      expectNoOffenses(dedent`
+        <% content_for :title %>
+      `)
+    })
+
+    test("passes for content_for with curly brace block", () => {
+      expectNoOffenses(dedent`
+        <% content_for(:head) { %>
+          <title>Page Title</title>
+        <% } %>
+      `)
+    })
+
+    test("passes for provide with arguments", () => {
+      expectNoOffenses(dedent`
+        <% provide :title, "Status" %>
+        <% provide :description, page_description %>
+      `)
+    })
+
+    test("passes for flush", () => {
+      expectNoOffenses(dedent`
+        <% flush %>
+      `)
+    })
+
     test("passes for ERB comments", () => {
       expectNoOffenses(dedent`
         <%# This is a comment %>


### PR DESCRIPTION
This pull request updates the `erb-no-unused-expressions` linter rule to allow side effect method calls like `content_for` without blocks. This was previously flagged:

```erb
<% content_for :title, "My Site" %>
```