### PR TITLE
Parser: Allow analyzing `<%%=` and `<%%` tags

### DIFF
--- a/src/analyze/analyze.c
+++ b/src/analyze/analyze.c
@@ -75,8 +75,7 @@ static bool analyze_erb_content(const AST_NODE_T* node, void* data) {
 
     hb_string_T opening = erb_content_node->tag_opening->value;
 
-    if (!hb_string_equals(opening, hb_string("<%%")) && !hb_string_equals(opening, hb_string("<%%="))
-        && !hb_string_equals(opening, hb_string("<%#")) && !hb_string_equals(opening, hb_string("<%graphql"))) {
+    if (!hb_string_equals(opening, hb_string("<%#")) && !hb_string_equals(opening, hb_string("<%graphql"))) {
       analyzed_ruby_T* analyzed = herb_analyze_ruby(erb_content_node->content->value);
 
       erb_content_node->parsed = true;

--- a/test/analyze/escape_test.rb
+++ b/test/analyze/escape_test.rb
@@ -13,5 +13,15 @@ module Analyze
     test "escaped erb output tag" do
       assert_parsed_snapshot("<%%= 'Test' %%>")
     end
+
+    test "escaped erb output tag with block" do
+      assert_parsed_snapshot("<%%= tag.div do %>\n  Hello\n<% end %>")
+      assert_parsed_snapshot("<%%= tag.div do %>\n  Hello\n<%% end %>")
+    end
+
+    test "escaped erb tag with block" do
+      assert_parsed_snapshot("<%% [1, 2, 3].each do |item| %>\n  Hello\n<% end %>")
+      assert_parsed_snapshot("<%% [1, 2, 3].each do |item| %>\n  Hello\n<%% end %>")
+    end
   end
 end

--- a/test/snapshots/analyze/escape_test/test_0001_escaped_erb_tag_94dbe0d71e8d4a3dbd06d39ffcad350c.txt
+++ b/test/snapshots/analyze/escape_test/test_0001_escaped_erb_tag_94dbe0d71e8d4a3dbd06d39ffcad350c.txt
@@ -8,5 +8,5 @@ input: "<%% 'Test' %%>"
         ├── tag_opening: "<%%" (location: (1:0)-(1:3))
         ├── content: " 'Test' " (location: (1:3)-(1:11))
         ├── tag_closing: "%%>" (location: (1:11)-(1:14))
-        ├── parsed: false
+        ├── parsed: true
         └── valid: true

--- a/test/snapshots/analyze/escape_test/test_0002_escaped_erb_output_tag_1ded89a552e264d13fefa7cc822a35c0.txt
+++ b/test/snapshots/analyze/escape_test/test_0002_escaped_erb_output_tag_1ded89a552e264d13fefa7cc822a35c0.txt
@@ -8,5 +8,5 @@ input: "<%%= 'Test' %%>"
         ├── tag_opening: "<%%=" (location: (1:0)-(1:4))
         ├── content: " 'Test' " (location: (1:4)-(1:12))
         ├── tag_closing: "%%>" (location: (1:12)-(1:15))
-        ├── parsed: false
+        ├── parsed: true
         └── valid: true

--- a/test/snapshots/analyze/escape_test/test_0003_escaped_erb_output_tag_with_block_1f0ec57fd07c0a35032c107c0a0cfaf9.txt
+++ b/test/snapshots/analyze/escape_test/test_0003_escaped_erb_output_tag_with_block_1f0ec57fd07c0a35032c107c0a0cfaf9.txt
@@ -1,0 +1,25 @@
+---
+source: "Analyze::EscapeTest#test_0003_escaped erb output tag with block"
+input: |2-
+<%%= tag.div do %>
+  Hello
+<%% end %>
+---
+@ DocumentNode (location: (1:0)-(3:10))
+└── children: (1 item)
+    └── @ ERBBlockNode (location: (1:0)-(3:10))
+        ├── tag_opening: "<%%=" (location: (1:0)-(1:4))
+        ├── content: " tag.div do " (location: (1:4)-(1:16))
+        ├── tag_closing: "%>" (location: (1:16)-(1:18))
+        ├── body: (1 item)
+        │   └── @ HTMLTextNode (location: (1:18)-(3:0))
+        │       └── content: "\n  Hello\n"
+        │
+        ├── rescue_clause: ∅
+        ├── else_clause: ∅
+        ├── ensure_clause: ∅
+        └── end_node:
+            └── @ ERBEndNode (location: (3:0)-(3:10))
+                ├── tag_opening: "<%%" (location: (3:0)-(3:3))
+                ├── content: " end " (location: (3:3)-(3:8))
+                └── tag_closing: "%>" (location: (3:8)-(3:10))

--- a/test/snapshots/analyze/escape_test/test_0003_escaped_erb_output_tag_with_block_b2587e8ebcd4f8eb02c355492634e2a1.txt
+++ b/test/snapshots/analyze/escape_test/test_0003_escaped_erb_output_tag_with_block_b2587e8ebcd4f8eb02c355492634e2a1.txt
@@ -1,0 +1,32 @@
+---
+source: "Analyze::EscapeTest#test_0003_escaped erb output tag with block"
+input: |2-
+<%%= tag.div do %>
+  Hello
+<% end %>
+---
+@ DocumentNode (location: (1:0)-(3:9))
+├── errors: (1 error)
+│   └── @ RubyParseError (location: (3:3)-(3:6))
+│       ├── message: "unexpected_token_ignore: unexpected 'end', ignoring it"
+│       ├── error_message: "unexpected 'end', ignoring it"
+│       ├── diagnostic_id: "unexpected_token_ignore"
+│       └── level: "syntax"
+│
+└── children: (1 item)
+    └── @ ERBBlockNode (location: (1:0)-(3:9))
+        ├── tag_opening: "<%%=" (location: (1:0)-(1:4))
+        ├── content: " tag.div do " (location: (1:4)-(1:16))
+        ├── tag_closing: "%>" (location: (1:16)-(1:18))
+        ├── body: (1 item)
+        │   └── @ HTMLTextNode (location: (1:18)-(3:0))
+        │       └── content: "\n  Hello\n"
+        │
+        ├── rescue_clause: ∅
+        ├── else_clause: ∅
+        ├── ensure_clause: ∅
+        └── end_node:
+            └── @ ERBEndNode (location: (3:0)-(3:9))
+                ├── tag_opening: "<%" (location: (3:0)-(3:2))
+                ├── content: " end " (location: (3:2)-(3:7))
+                └── tag_closing: "%>" (location: (3:7)-(3:9))

--- a/test/snapshots/analyze/escape_test/test_0004_escaped_erb_tag_with_block_a009af1340fdc4f51ad746f09cf78ff0.txt
+++ b/test/snapshots/analyze/escape_test/test_0004_escaped_erb_tag_with_block_a009af1340fdc4f51ad746f09cf78ff0.txt
@@ -1,0 +1,25 @@
+---
+source: "Analyze::EscapeTest#test_0004_escaped erb tag with block"
+input: |2-
+<%% [1, 2, 3].each do |item| %>
+  Hello
+<%% end %>
+---
+@ DocumentNode (location: (1:0)-(3:10))
+└── children: (1 item)
+    └── @ ERBBlockNode (location: (1:0)-(3:10))
+        ├── tag_opening: "<%%" (location: (1:0)-(1:3))
+        ├── content: " [1, 2, 3].each do |item| " (location: (1:3)-(1:29))
+        ├── tag_closing: "%>" (location: (1:29)-(1:31))
+        ├── body: (1 item)
+        │   └── @ HTMLTextNode (location: (1:31)-(3:0))
+        │       └── content: "\n  Hello\n"
+        │
+        ├── rescue_clause: ∅
+        ├── else_clause: ∅
+        ├── ensure_clause: ∅
+        └── end_node:
+            └── @ ERBEndNode (location: (3:0)-(3:10))
+                ├── tag_opening: "<%%" (location: (3:0)-(3:3))
+                ├── content: " end " (location: (3:3)-(3:8))
+                └── tag_closing: "%>" (location: (3:8)-(3:10))

--- a/test/snapshots/analyze/escape_test/test_0004_escaped_erb_tag_with_block_b9025d58e44a90a7fc6f896edac0e5e9.txt
+++ b/test/snapshots/analyze/escape_test/test_0004_escaped_erb_tag_with_block_b9025d58e44a90a7fc6f896edac0e5e9.txt
@@ -1,0 +1,32 @@
+---
+source: "Analyze::EscapeTest#test_0004_escaped erb tag with block"
+input: |2-
+<%% [1, 2, 3].each do |item| %>
+  Hello
+<% end %>
+---
+@ DocumentNode (location: (1:0)-(3:9))
+├── errors: (1 error)
+│   └── @ RubyParseError (location: (3:3)-(3:6))
+│       ├── message: "unexpected_token_ignore: unexpected 'end', ignoring it"
+│       ├── error_message: "unexpected 'end', ignoring it"
+│       ├── diagnostic_id: "unexpected_token_ignore"
+│       └── level: "syntax"
+│
+└── children: (1 item)
+    └── @ ERBBlockNode (location: (1:0)-(3:9))
+        ├── tag_opening: "<%%" (location: (1:0)-(1:3))
+        ├── content: " [1, 2, 3].each do |item| " (location: (1:3)-(1:29))
+        ├── tag_closing: "%>" (location: (1:29)-(1:31))
+        ├── body: (1 item)
+        │   └── @ HTMLTextNode (location: (1:31)-(3:0))
+        │       └── content: "\n  Hello\n"
+        │
+        ├── rescue_clause: ∅
+        ├── else_clause: ∅
+        ├── ensure_clause: ∅
+        └── end_node:
+            └── @ ERBEndNode (location: (3:0)-(3:9))
+                ├── tag_opening: "<%" (location: (3:0)-(3:2))
+                ├── content: " end " (location: (3:2)-(3:7))
+                └── tag_closing: "%>" (location: (3:7)-(3:9))


### PR DESCRIPTION
Escaped ERB tags (`<%%=` and `<%%`) were excluded from Ruby analysis, which prevented block detection from working on them. 

This meant `<%%= tag.div do %>...<% end %>` was incorrectly parsed as separate `ERBContentNode`s with an orphaned `end` error, instead of being recognized as a single `ERBBlockNode`.

The following now gets correctly parsed:
```erb
<%%= tag.div do %>        
  Hello
<%% end %>
```

Resolves https://github.com/marcoroth/herb/issues/1533