### PR TITLE
Linter: Allow `return`/`break`/`next` in `erb-no-unused-literals`

### DIFF
--- a/javascript/packages/linter/src/rules/erb-no-unused-literals.ts
+++ b/javascript/packages/linter/src/rules/erb-no-unused-literals.ts
@@ -55,6 +55,11 @@ class LiteralCollector extends PrismVisitor {
   visitMultiWriteNode(): void {}
   visitMatchWriteNode(): void {}
 
+  // Stop traversal into control flow nodes where literals are used as return/flow values.
+  visitReturnNode(): void {}
+  visitBreakNode(): void {}
+  visitNextNode(): void {}
+
   visitArrayNode(node: PrismNodes.ArrayNode): void {
     this.literals.push(node)
   }

--- a/javascript/packages/linter/test/rules/erb-no-unused-literals.test.ts
+++ b/javascript/packages/linter/test/rules/erb-no-unused-literals.test.ts
@@ -343,6 +343,37 @@ describe("ERBNoUnusedLiteralsRule", () => {
     `)
   })
 
+  test("passes for return with literal value", () => {
+    expectNoOffenses(dedent`
+      <% return "" unless versions.length > 1 %>
+      <% return nil %>
+      <% return 0 %>
+      <% return false %>
+      <% return [] %>
+      <% return "default" %>
+    `)
+  })
+
+  test("passes for break with literal value", () => {
+    expectNoOffenses(dedent`
+      <% items.each do |item| %>
+        <% break "" %>
+        <% break nil %>
+        <% break 0 %>
+      <% end %>
+    `)
+  })
+
+  test("passes for next with literal value", () => {
+    expectNoOffenses(dedent`
+      <% items.each do |item| %>
+        <% next "" %>
+        <% next nil %>
+        <% next 0 %>
+      <% end %>
+    `)
+  })
+
   test("passes for method calls without literal receiver", () => {
     expectNoOffenses(dedent`
       <% some_method.call %>


### PR DESCRIPTION
Fixes a false positive in `erb-no-unused-literals` where literals used as values in `return`, `break`, and `next` statements were incorrectly flagged as unused.