### PR TITLE
Parser: Handle anonymous `**` in strict locals

### DIFF
--- a/src/analyze/analyze.c
+++ b/src/analyze/analyze.c
@@ -1031,7 +1031,7 @@ void herb_analyze_parse_tree(
 
   herb_visit_node((AST_NODE_T*) document, detect_invalid_erb_structures, &invalid_context);
 
-  herb_analyze_parse_errors(document, source, allocator);
+  herb_analyze_parse_errors(document, source, options, allocator);
 
   herb_parser_match_html_tags_post_analyze(document, options, allocator);
 

--- a/src/analyze/parse_errors.c
+++ b/src/analyze/parse_errors.c
@@ -11,6 +11,37 @@
 #include <stdlib.h>
 #include <string.h>
 
+static bool document_has_anonymous_keyword_rest(AST_DOCUMENT_NODE_T* document) {
+  if (!document || !document->children) { return false; }
+
+  for (size_t index = 0; index < hb_array_size(document->children); index++) {
+    AST_NODE_T* child = hb_array_get(document->children, index);
+    if (!child || child->type != AST_ERB_STRICT_LOCALS_NODE) { continue; }
+
+    AST_ERB_STRICT_LOCALS_NODE_T* strict_locals_node = (AST_ERB_STRICT_LOCALS_NODE_T*) child;
+    if (!strict_locals_node->locals) { continue; }
+
+    for (size_t local_index = 0; local_index < hb_array_size(strict_locals_node->locals); local_index++) {
+      AST_RUBY_STRICT_LOCAL_NODE_T* local = hb_array_get(strict_locals_node->locals, local_index);
+      if (local && local->double_splat && local->name == NULL) { return true; }
+    }
+  }
+
+  return false;
+}
+
+static bool should_skip_forwarding_error(
+  const pm_diagnostic_t* error,
+  bool strict_locals_enabled,
+  bool has_anonymous_keyword_rest
+) {
+  if (error->diag_id != PM_ERR_ARGUMENT_NO_FORWARDING_STAR_STAR) { return false; }
+
+  if (!strict_locals_enabled) { return true; }
+
+  return has_anonymous_keyword_rest;
+}
+
 static void parse_erb_content_errors(AST_NODE_T* erb_node, const char* source, hb_allocator_T* allocator) {
   if (!erb_node || erb_node->type != AST_ERB_CONTENT_NODE) { return; }
   AST_ERB_CONTENT_NODE_T* content_node = (AST_ERB_CONTENT_NODE_T*) erb_node;
@@ -45,10 +76,18 @@ static void parse_erb_content_errors(AST_NODE_T* erb_node, const char* source, h
   free(content);
 }
 
-void herb_analyze_parse_errors(AST_DOCUMENT_NODE_T* document, const char* source, hb_allocator_T* allocator) {
+void herb_analyze_parse_errors(
+  AST_DOCUMENT_NODE_T* document,
+  const char* source,
+  const parser_options_T* parser_options,
+  hb_allocator_T* allocator
+) {
   char* extracted_ruby = herb_extract_ruby_with_semicolons(source, allocator);
 
   if (!extracted_ruby) { return; }
+
+  bool strict_locals_enabled = parser_options && parser_options->strict_locals;
+  bool has_anonymous_keyword_rest = strict_locals_enabled && document_has_anonymous_keyword_rest(document);
 
   pm_parser_t parser;
   pm_options_t options = { 0, .partial_script = true };
@@ -58,6 +97,8 @@ void herb_analyze_parse_errors(AST_DOCUMENT_NODE_T* document, const char* source
 
   for (const pm_diagnostic_t* error = (const pm_diagnostic_t*) parser.error_list.head; error != NULL;
        error = (const pm_diagnostic_t*) error->node.next) {
+    if (should_skip_forwarding_error(error, strict_locals_enabled, has_anonymous_keyword_rest)) { continue; }
+
     size_t error_offset = (size_t) (error->location.start - parser.start);
 
     if (strstr(error->message, "unexpected ';'") != NULL) {

--- a/src/analyze/strict_locals.c
+++ b/src/analyze/strict_locals.c
@@ -440,6 +440,20 @@ static hb_array_T* extract_strict_locals(
 
       hb_array_append(locals, local);
       hb_allocator_dealloc(allocator, name);
+    } else {
+      size_t params_in_content = (size_t) (params_open - content_bytes);
+      size_t operator_prism_start = (size_t) (keyword_rest_param->operator_loc.start - synthetic_start);
+      size_t operator_prism_end = (size_t) (keyword_rest_param->operator_loc.end - synthetic_start);
+      size_t content_start = params_in_content + (operator_prism_start - strlen(SYNTHETIC_PREFIX));
+      size_t content_end = params_in_content + (operator_prism_end - strlen(SYNTHETIC_PREFIX));
+
+      position_T start = byte_offset_to_position(source, erb_content_byte_offset + content_start);
+      position_T end = byte_offset_to_position(source, erb_content_byte_offset + content_end);
+
+      AST_RUBY_STRICT_LOCAL_NODE_T* local =
+        ast_ruby_strict_local_node_init(NULL, NULL, false, true, start, end, hb_array_init(0, allocator), allocator);
+
+      hb_array_append(locals, local);
     }
   }
 

--- a/src/include/analyze/analyze.h
+++ b/src/include/analyze/analyze.h
@@ -44,7 +44,12 @@ typedef struct {
   hb_allocator_T* allocator;
 } invalid_erb_context_T;
 
-void herb_analyze_parse_errors(AST_DOCUMENT_NODE_T* document, const char* source, hb_allocator_T* allocator);
+void herb_analyze_parse_errors(
+  AST_DOCUMENT_NODE_T* document,
+  const char* source,
+  const parser_options_T* options,
+  hb_allocator_T* allocator
+);
 void herb_analyze_parse_tree(
   AST_DOCUMENT_NODE_T* document,
   const char* source,

--- a/test/analyze/strict_locals_test.rb
+++ b/test/analyze/strict_locals_test.rb
@@ -304,5 +304,50 @@ module Analyze
         <%# locals: (user: = "default") %>
       HTML
     end
+
+    test "anonymous double-splat only" do
+      assert_parsed_snapshot(<<~HTML, strict_locals: true)
+        <%# locals: (**) %>
+      HTML
+    end
+
+    test "required local with anonymous double-splat" do
+      assert_parsed_snapshot(<<~HTML, strict_locals: true)
+        <%# locals: (message:, **) %>
+      HTML
+    end
+
+    test "anonymous double-splat with forwarding in expression" do
+      assert_parsed_snapshot(<<~HTML, strict_locals: true)
+        <%# locals: (**) %>
+        <%= helper(**) %>
+      HTML
+    end
+
+    test "anonymous double-splat forwarding without strict_locals option suppresses error" do
+      assert_parsed_snapshot(<<~HTML)
+        <%# locals: (**) %>
+        <%= helper(**) %>
+      HTML
+    end
+
+    test "double-splat forwarding in expression without strict locals declaration keeps error" do
+      assert_parsed_snapshot(<<~HTML, strict_locals: true)
+        <%= helper(**) %>
+      HTML
+    end
+
+    test "double-splat forwarding in expression with strict locals disabled suppresses error" do
+      assert_parsed_snapshot(<<~HTML, strict_locals: false)
+        <%= helper(**) %>
+      HTML
+    end
+
+    test "named double-splat does not suppress forwarding error" do
+      assert_parsed_snapshot(<<~HTML, strict_locals: true)
+        <%# locals: (**attributes) %>
+        <%= helper(**) %>
+      HTML
+    end
   end
 end

--- a/test/snapshots/analyze/strict_locals_test/test_0050_anonymous_double-splat_only_cdec36617fab598c31386015d4a93008-be06ef2eb1a2807fc4c599b8cd1ada02.txt
+++ b/test/snapshots/analyze/strict_locals_test/test_0050_anonymous_double-splat_only_cdec36617fab598c31386015d4a93008-be06ef2eb1a2807fc4c599b8cd1ada02.txt
@@ -1,0 +1,22 @@
+---
+source: "Analyze::StrictLocalsTest#test_0050_anonymous double-splat only"
+input: |2-
+<%# locals: (**) %>
+options: {strict_locals: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ ERBStrictLocalsNode (location: (1:0)-(1:19))
+    │   ├── tag_opening: "<%#" (location: (1:0)-(1:3))
+    │   ├── content: " locals: (**) " (location: (1:3)-(1:17))
+    │   ├── tag_closing: "%>" (location: (1:17)-(1:19))
+    │   └── locals: (1 item)
+    │       └── @ RubyStrictLocalNode (location: (1:13)-(1:15))
+    │           ├── name: ∅
+    │           ├── default_value: ∅
+    │           ├── required: false
+    │           └── double_splat: true
+    │
+    │
+    └── @ HTMLTextNode (location: (1:19)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/strict_locals_test/test_0051_required_local_with_anonymous_double-splat_a8b7af7a574e36f4d43ff4718b23d1a2-be06ef2eb1a2807fc4c599b8cd1ada02.txt
+++ b/test/snapshots/analyze/strict_locals_test/test_0051_required_local_with_anonymous_double-splat_a8b7af7a574e36f4d43ff4718b23d1a2-be06ef2eb1a2807fc4c599b8cd1ada02.txt
@@ -1,0 +1,28 @@
+---
+source: "Analyze::StrictLocalsTest#test_0051_required local with anonymous double-splat"
+input: |2-
+<%# locals: (message:, **) %>
+options: {strict_locals: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ ERBStrictLocalsNode (location: (1:0)-(1:29))
+    │   ├── tag_opening: "<%#" (location: (1:0)-(1:3))
+    │   ├── content: " locals: (message:, **) " (location: (1:3)-(1:27))
+    │   ├── tag_closing: "%>" (location: (1:27)-(1:29))
+    │   └── locals: (2 items)
+    │       ├── @ RubyStrictLocalNode (location: (1:13)-(1:21))
+    │       │   ├── name: "message" (location: (1:13)-(1:21))
+    │       │   ├── default_value: ∅
+    │       │   ├── required: true
+    │       │   └── double_splat: false
+    │       │
+    │       └── @ RubyStrictLocalNode (location: (1:23)-(1:25))
+    │           ├── name: ∅
+    │           ├── default_value: ∅
+    │           ├── required: false
+    │           └── double_splat: true
+    │
+    │
+    └── @ HTMLTextNode (location: (1:29)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/strict_locals_test/test_0052_anonymous_double-splat_with_forwarding_in_expression_e48016da73f7c1a07832f598c3e21827-be06ef2eb1a2807fc4c599b8cd1ada02.txt
+++ b/test/snapshots/analyze/strict_locals_test/test_0052_anonymous_double-splat_with_forwarding_in_expression_e48016da73f7c1a07832f598c3e21827-be06ef2eb1a2807fc4c599b8cd1ada02.txt
@@ -1,0 +1,33 @@
+---
+source: "Analyze::StrictLocalsTest#test_0052_anonymous double-splat with forwarding in expression"
+input: |2-
+<%# locals: (**) %>
+<%= helper(**) %>
+options: {strict_locals: true}
+---
+@ DocumentNode (location: (1:0)-(3:0))
+└── children: (4 items)
+    ├── @ ERBStrictLocalsNode (location: (1:0)-(1:19))
+    │   ├── tag_opening: "<%#" (location: (1:0)-(1:3))
+    │   ├── content: " locals: (**) " (location: (1:3)-(1:17))
+    │   ├── tag_closing: "%>" (location: (1:17)-(1:19))
+    │   └── locals: (1 item)
+    │       └── @ RubyStrictLocalNode (location: (1:13)-(1:15))
+    │           ├── name: ∅
+    │           ├── default_value: ∅
+    │           ├── required: false
+    │           └── double_splat: true
+    │
+    │
+    ├── @ HTMLTextNode (location: (1:19)-(2:0))
+    │   └── content: "\n"
+    │
+    ├── @ ERBContentNode (location: (2:0)-(2:17))
+    │   ├── tag_opening: "<%=" (location: (2:0)-(2:3))
+    │   ├── content: " helper(**) " (location: (2:3)-(2:15))
+    │   ├── tag_closing: "%>" (location: (2:15)-(2:17))
+    │   ├── parsed: true
+    │   └── valid: false
+    │
+    └── @ HTMLTextNode (location: (2:17)-(3:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/strict_locals_test/test_0053_anonymous_double-splat_forwarding_without_strict_locals_option_suppresses_error_e48016da73f7c1a07832f598c3e21827.txt
+++ b/test/snapshots/analyze/strict_locals_test/test_0053_anonymous_double-splat_forwarding_without_strict_locals_option_suppresses_error_e48016da73f7c1a07832f598c3e21827.txt
@@ -1,0 +1,27 @@
+---
+source: "Analyze::StrictLocalsTest#test_0053_anonymous double-splat forwarding without strict_locals option suppresses error"
+input: |2-
+<%# locals: (**) %>
+<%= helper(**) %>
+---
+@ DocumentNode (location: (1:0)-(3:0))
+└── children: (4 items)
+    ├── @ ERBContentNode (location: (1:0)-(1:19))
+    │   ├── tag_opening: "<%#" (location: (1:0)-(1:3))
+    │   ├── content: " locals: (**) " (location: (1:3)-(1:17))
+    │   ├── tag_closing: "%>" (location: (1:17)-(1:19))
+    │   ├── parsed: false
+    │   └── valid: true
+    │
+    ├── @ HTMLTextNode (location: (1:19)-(2:0))
+    │   └── content: "\n"
+    │
+    ├── @ ERBContentNode (location: (2:0)-(2:17))
+    │   ├── tag_opening: "<%=" (location: (2:0)-(2:3))
+    │   ├── content: " helper(**) " (location: (2:3)-(2:15))
+    │   ├── tag_closing: "%>" (location: (2:15)-(2:17))
+    │   ├── parsed: true
+    │   └── valid: false
+    │
+    └── @ HTMLTextNode (location: (2:17)-(3:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/strict_locals_test/test_0054_double-splat_forwarding_in_expression_without_strict_locals_declaration_keeps_error_152e8feadc179fe3c42c1b12f95fb1dd-be06ef2eb1a2807fc4c599b8cd1ada02.txt
+++ b/test/snapshots/analyze/strict_locals_test/test_0054_double-splat_forwarding_in_expression_without_strict_locals_declaration_keeps_error_152e8feadc179fe3c42c1b12f95fb1dd-be06ef2eb1a2807fc4c599b8cd1ada02.txt
@@ -1,0 +1,24 @@
+---
+source: "Analyze::StrictLocalsTest#test_0054_double-splat forwarding in expression without strict locals declaration keeps error"
+input: |2-
+<%= helper(**) %>
+options: {strict_locals: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+├── errors: (1 error)
+│   └── @ RubyParseError (location: (1:11)-(1:13))
+│       ├── message: "argument_no_forwarding_star_star: unexpected `**`; no anonymous keyword rest parameter"
+│       ├── error_message: "unexpected `**`; no anonymous keyword rest parameter"
+│       ├── diagnostic_id: "argument_no_forwarding_star_star"
+│       └── level: "syntax"
+│
+└── children: (2 items)
+    ├── @ ERBContentNode (location: (1:0)-(1:17))
+    │   ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   ├── content: " helper(**) " (location: (1:3)-(1:15))
+    │   ├── tag_closing: "%>" (location: (1:15)-(1:17))
+    │   ├── parsed: true
+    │   └── valid: false
+    │
+    └── @ HTMLTextNode (location: (1:17)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/strict_locals_test/test_0055_double-splat_forwarding_in_expression_with_strict_locals_disabled_suppresses_error_152e8feadc179fe3c42c1b12f95fb1dd-1e3427b21fd7adfde07e89ceb2bc469c.txt
+++ b/test/snapshots/analyze/strict_locals_test/test_0055_double-splat_forwarding_in_expression_with_strict_locals_disabled_suppresses_error_152e8feadc179fe3c42c1b12f95fb1dd-1e3427b21fd7adfde07e89ceb2bc469c.txt
@@ -1,0 +1,17 @@
+---
+source: "Analyze::StrictLocalsTest#test_0055_double-splat forwarding in expression with strict locals disabled suppresses error"
+input: |2-
+<%= helper(**) %>
+options: {strict_locals: false}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ ERBContentNode (location: (1:0)-(1:17))
+    │   ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   ├── content: " helper(**) " (location: (1:3)-(1:15))
+    │   ├── tag_closing: "%>" (location: (1:15)-(1:17))
+    │   ├── parsed: true
+    │   └── valid: false
+    │
+    └── @ HTMLTextNode (location: (1:17)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/strict_locals_test/test_0056_named_double-splat_does_not_suppress_forwarding_error_dee4770161eebd5e74449385e42507e9-be06ef2eb1a2807fc4c599b8cd1ada02.txt
+++ b/test/snapshots/analyze/strict_locals_test/test_0056_named_double-splat_does_not_suppress_forwarding_error_dee4770161eebd5e74449385e42507e9-be06ef2eb1a2807fc4c599b8cd1ada02.txt
@@ -1,0 +1,40 @@
+---
+source: "Analyze::StrictLocalsTest#test_0056_named double-splat does not suppress forwarding error"
+input: |2-
+<%# locals: (**attributes) %>
+<%= helper(**) %>
+options: {strict_locals: true}
+---
+@ DocumentNode (location: (1:0)-(3:0))
+├── errors: (1 error)
+│   └── @ RubyParseError (location: (2:11)-(2:13))
+│       ├── message: "argument_no_forwarding_star_star: unexpected `**`; no anonymous keyword rest parameter"
+│       ├── error_message: "unexpected `**`; no anonymous keyword rest parameter"
+│       ├── diagnostic_id: "argument_no_forwarding_star_star"
+│       └── level: "syntax"
+│
+└── children: (4 items)
+    ├── @ ERBStrictLocalsNode (location: (1:0)-(1:29))
+    │   ├── tag_opening: "<%#" (location: (1:0)-(1:3))
+    │   ├── content: " locals: (**attributes) " (location: (1:3)-(1:27))
+    │   ├── tag_closing: "%>" (location: (1:27)-(1:29))
+    │   └── locals: (1 item)
+    │       └── @ RubyStrictLocalNode (location: (1:15)-(1:25))
+    │           ├── name: "attributes" (location: (1:15)-(1:25))
+    │           ├── default_value: ∅
+    │           ├── required: false
+    │           └── double_splat: true
+    │
+    │
+    ├── @ HTMLTextNode (location: (1:29)-(2:0))
+    │   └── content: "\n"
+    │
+    ├── @ ERBContentNode (location: (2:0)-(2:17))
+    │   ├── tag_opening: "<%=" (location: (2:0)-(2:3))
+    │   ├── content: " helper(**) " (location: (2:3)-(2:15))
+    │   ├── tag_closing: "%>" (location: (2:15)-(2:17))
+    │   ├── parsed: true
+    │   └── valid: false
+    │
+    └── @ HTMLTextNode (location: (2:17)-(3:0))
+        └── content: "\n"


### PR DESCRIPTION
When a partial uses anonymous `**` Prism reports an `argument_no_forwarding_star_star` error for any `**` forwarding in expressions because it parses each ERB tag's Ruby in isolation without knowledge of the enclosing method scope.

In Rails, the compiled template method would include `**` in its signature, making `**` forwarding valid. This is analogous to how Prism's `partial_script` mode already handles `yield` outside a method body.

The following now gets correctly parsed with `strict_locals: true`:
```erb
<%# locals: (**) %>

<%= helper(**) %>
```

Two behaviors depending on the `strict_locals` parser option:
  - `strict_locals: false` (default): Always suppress the error, like `partial_script` does for `yield`
  - `strict_locals: true`: Only suppress the error when the `ERBStrictLocalsNode` actually declares anonymous `**`

Additionally, anonymous `**` in the strict locals declaration now correctly produces a `RubyStrictLocalNode` with `double_splat: true` and no name, instead of being silently skipped.

Discovered while working on https://github.com/marcoroth/herb/issues/1506 and https://github.com/r7kamura/rubocop-erb/pull/66 in https://github.com/ubicloud/ubicloud/blob/855ddca5d24c73cc8a171c6f05127c1b76049ecd/views/components/form/hidden.erb#L2

Resolves https://github.com/marcoroth/herb/issues/1535
