### PR TITLE
Formatter: Fix trailing whitespace in `<pre>` with inline child elements

### DIFF
--- a/javascript/packages/formatter/src/format-printer.ts
+++ b/javascript/packages/formatter/src/format-printer.ts
@@ -865,7 +865,7 @@ export class FormatPrinter extends Printer implements TextFlowDelegate, Attribut
     const analysis = this.currentElement && this.elementFormattingAnalysis.get(this.currentElement)
     const closeTagInline = analysis?.closeTagInline
 
-    if (this.currentElement && closeTagInline) {
+    if (this.inContentPreservingContext || (this.currentElement && closeTagInline)) {
       this.pushToLastLine(closingTag)
     } else {
       this.pushWithIndent(closingTag)

--- a/javascript/packages/formatter/test/html/content-preserving-tags.test.ts
+++ b/javascript/packages/formatter/test/html/content-preserving-tags.test.ts
@@ -170,6 +170,14 @@ describe("@herb-tools/formatter - content preserving tags", () => {
     `)
   })
 
+  test("preserves pre with inline child element exceeding max line length", () => {
+    const content = "x".repeat(66)
+    const source = `<div>\n  <pre><code>${content}</code></pre>\n</div>`
+    const result = formatter.format(source)
+    expect(result).toEqual(source)
+    expect(formatter.format(result)).toEqual(result)
+  })
+
   test("preserves textarea with ERB control flow", () => {
     const source = dedent`
       <textarea>


### PR DESCRIPTION
After upgrading to the latest Herb version, formatting `<pre><code>` blocks nested inside another element became non-idempotent.

Each formatter run appends trailing whitespace before the closing tag, which then triggers lint errors.

I added a failing test.