### PR TITLE
Parser: Wrap `javascript_tag` content in `CDATANode`

### DIFF
--- a/javascript/packages/rewriter/test/action-view-tag-helper-to-html.test.ts
+++ b/javascript/packages/rewriter/test/action-view-tag-helper-to-html.test.ts
@@ -575,7 +575,7 @@ describe("ActionViewTagHelperToHTMLRewriter", () => {
   describe("javascript_tag helpers", () => {
     test("javascript_tag with content as argument", () => {
       expect(transform(`<%= javascript_tag "alert('Hello')" %>`)).toBe(
-        `<script>alert('Hello')</script>`
+        `<script>\n//<![CDATA[\nalert('Hello')\n//]]>\n</script>`
       )
     })
 
@@ -588,7 +588,11 @@ describe("ActionViewTagHelperToHTMLRewriter", () => {
 
       const expected = dedent`
         <script>
+        //<![CDATA[
+
           alert('Hello')
+
+        //]]>
         </script>
       `
 
@@ -597,7 +601,7 @@ describe("ActionViewTagHelperToHTMLRewriter", () => {
 
     test("javascript_tag with type attribute", () => {
       expect(transform(`<%= javascript_tag "alert('Hello')", type: "application/javascript" %>`)).toBe(
-        `<script type="application/javascript">alert('Hello')</script>`
+        `<script type="application/javascript">\n//<![CDATA[\nalert('Hello')\n//]]>\n</script>`
       )
     })
 
@@ -610,7 +614,11 @@ describe("ActionViewTagHelperToHTMLRewriter", () => {
 
       const expected = dedent`
         <script nonce="<%= content_security_policy_nonce %>">
+        //<![CDATA[
+
           alert('Hello')
+
+        //]]>
         </script>
       `
 
@@ -626,7 +634,11 @@ describe("ActionViewTagHelperToHTMLRewriter", () => {
 
       const expected = dedent`
         <script>
+        //<![CDATA[
+
           alert('Hello')
+
+        //]]>
         </script>
       `
 

--- a/src/analyze/action_view/javascript_tag.c
+++ b/src/analyze/action_view/javascript_tag.c
@@ -1,4 +1,9 @@
 #include "../../include/analyze/action_view/tag_helper_handler.h"
+#include "../../include/analyze/action_view/tag_helper_node_builders.h"
+#include "../../include/ast/ast_nodes.h"
+#include "../../include/lib/hb_array.h"
+#include "../../include/lib/hb_string.h"
+#include "../../include/visitor.h"
 
 #include <prism.h>
 #include <stdbool.h>
@@ -43,6 +48,39 @@ char* extract_javascript_tag_content(pm_call_node_t* call_node, pm_parser_t* par
 
 bool javascript_tag_supports_block(void) {
   return true;
+}
+
+bool wrap_javascript_tag_body_visitor(const AST_NODE_T* node, void* data) {
+  hb_allocator_T* allocator = (hb_allocator_T*) data;
+
+  if (node == NULL || node->type != AST_HTML_ELEMENT_NODE) { return true; }
+
+  AST_HTML_ELEMENT_NODE_T* element = (AST_HTML_ELEMENT_NODE_T*) node;
+
+  if (!hb_string_equals(element->element_source, hb_string("ActionView::Helpers::JavaScriptHelper#javascript_tag"))) {
+    return true;
+  }
+
+  if (element->body == NULL || hb_array_size(element->body) == 0) { return false; }
+
+  for (size_t i = 0; i < hb_array_size(element->body); i++) {
+    AST_NODE_T* child = (AST_NODE_T*) hb_array_get(element->body, i);
+    if (child && child->type == AST_CDATA_NODE) { return false; }
+  }
+
+  hb_array_T* cdata_children = hb_array_init(hb_array_size(element->body), allocator);
+
+  for (size_t i = 0; i < hb_array_size(element->body); i++) {
+    hb_array_append(cdata_children, hb_array_get(element->body, i));
+  }
+
+  AST_CDATA_NODE_T* cdata_node =
+    create_javascript_cdata_node(cdata_children, element->base.location.start, element->base.location.end, allocator);
+
+  element->body->size = 0;
+  hb_array_append(element->body, (AST_NODE_T*) cdata_node);
+
+  return false;
 }
 
 const tag_helper_handler_T javascript_tag_handler = {

--- a/src/analyze/action_view/tag_helper_node_builders.c
+++ b/src/analyze/action_view/tag_helper_node_builders.c
@@ -385,3 +385,24 @@ void append_body_content_node(
     if (text_node) { hb_array_append(body, (AST_NODE_T*) text_node); }
   }
 }
+
+AST_CDATA_NODE_T* create_javascript_cdata_node(
+  hb_array_T* children,
+  position_T start,
+  position_T end,
+  hb_allocator_T* allocator
+) {
+  token_T* cdata_opening = create_synthetic_token(allocator, "\n//<![CDATA[\n", TOKEN_CDATA_START, start, end);
+
+  token_T* cdata_closing = create_synthetic_token(allocator, "\n//]]>\n", TOKEN_CDATA_END, start, end);
+
+  return ast_cdata_node_init(
+    cdata_opening,
+    children,
+    cdata_closing,
+    start,
+    end,
+    hb_array_init(0, allocator),
+    allocator
+  );
+}

--- a/src/analyze/action_view/tag_helpers.c
+++ b/src/analyze/action_view/tag_helpers.c
@@ -798,14 +798,37 @@ static AST_NODE_T* transform_tag_helper_with_attributes(
       );
     }
 
-    append_body_content_node(
-      body,
-      helper_content,
-      content_is_ruby_expression,
-      erb_node->base.location.start,
-      erb_node->base.location.end,
-      allocator
-    );
+    if (string_equals(handler->name, "javascript_tag")) {
+      hb_array_T* cdata_children = hb_array_init(1, allocator);
+
+      append_body_content_node(
+        cdata_children,
+        helper_content,
+        content_is_ruby_expression,
+        erb_node->base.location.start,
+        erb_node->base.location.end,
+        allocator
+      );
+
+      AST_CDATA_NODE_T* cdata_node = create_javascript_cdata_node(
+        cdata_children,
+        erb_node->base.location.start,
+        erb_node->base.location.end,
+        allocator
+      );
+
+      if (cdata_node) { hb_array_append(body, (AST_NODE_T*) cdata_node); }
+    } else {
+      append_body_content_node(
+        body,
+        helper_content,
+        content_is_ruby_expression,
+        erb_node->base.location.start,
+        erb_node->base.location.end,
+        allocator
+      );
+    }
+
     hb_allocator_dealloc(allocator, helper_content);
   }
 

--- a/src/include/analyze/action_view/tag_helper_handler.h
+++ b/src/include/analyze/action_view/tag_helper_handler.h
@@ -40,4 +40,7 @@ size_t get_tag_helper_handlers_count(void);
 
 char* extract_inline_block_content(pm_call_node_t* call_node, hb_allocator_T* allocator);
 
+struct AST_NODE_STRUCT;
+bool wrap_javascript_tag_body_visitor(const struct AST_NODE_STRUCT* node, void* data);
+
 #endif

--- a/src/include/analyze/action_view/tag_helper_node_builders.h
+++ b/src/include/analyze/action_view/tag_helper_node_builders.h
@@ -87,6 +87,13 @@ AST_HTML_ATTRIBUTE_NODE_T* create_href_attribute(
   hb_allocator_T* allocator
 );
 
+AST_CDATA_NODE_T* create_javascript_cdata_node(
+  hb_array_T* children,
+  position_T start,
+  position_T end,
+  hb_allocator_T* allocator
+);
+
 void append_body_content_node(
   hb_array_T* body,
   const char* content,

--- a/src/parser.c
+++ b/src/parser.c
@@ -1,4 +1,5 @@
 #include "include/parser/parser.h"
+#include "include/analyze/action_view/tag_helper_handler.h"
 #include "include/ast/ast_node.h"
 #include "include/ast/ast_nodes.h"
 #include "include/errors.h"
@@ -1897,4 +1898,11 @@ void herb_parser_match_html_tags_post_analyze(
   if (document == NULL) { return; }
 
   match_tags_in_node_array(document->children, document->base.errors, options, allocator);
+
+  if (options && options->action_view_helpers) {
+    for (size_t i = 0; i < hb_array_size(document->children); i++) {
+      AST_NODE_T* node = (AST_NODE_T*) hb_array_get(document->children, i);
+      herb_visit_node(node, wrap_javascript_tag_body_visitor, allocator);
+    }
+  }
 }

--- a/test/analyze/action_view/javascript_helper/javascript_tag_test.rb
+++ b/test/analyze/action_view/javascript_helper/javascript_tag_test.rb
@@ -143,5 +143,21 @@ module Analyze::ActionView::JavaScriptHelper
         <% end %>
       HTML
     end
+
+    test "javascript_tag inline CDATA matches ActionView output" do
+      assert_evaluated_actionview_snapshot('<%= javascript_tag "alert(1)" %>')
+    end
+
+    test "javascript_tag block CDATA matches ActionView output" do
+      assert_evaluated_actionview_snapshot(<<~ERB)
+        <%= javascript_tag do %>
+          alert(1)
+        <% end %>
+      ERB
+    end
+
+    test "javascript_tag with type attribute CDATA matches ActionView output" do
+      assert_evaluated_actionview_snapshot('<%= javascript_tag "alert(1)", type: "application/javascript" %>')
+    end
   end
 end

--- a/test/snapshots/analyze/action_view/java_script_helper/java_script_tag_test/test_0001_javascript_tag_with_block_832b9d268f08e319ef11bd4112c58cf5-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/java_script_helper/java_script_tag_test/test_0001_javascript_tag_with_block_832b9d268f08e319ef11bd4112c58cf5-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -19,8 +19,17 @@ options: {action_view_helpers: true}
     │   │
     │   ├── tag_name: "script" (location: (1:4)-(1:18))
     │   ├── body: (1 item)
-    │   │   └── @ LiteralNode (location: (1:24)-(3:0))
-    │   │       └── content: "\n  alert('Hello')\n"
+    │   │   └── @ CDATANode (location: (1:0)-(3:9))
+    │   │       ├── tag_opening: "
+    │   │       //<![CDATA[
+    │   │       " (location: (1:0)-(3:9))
+    │   │       ├── children: (1 item)
+    │   │       │   └── @ LiteralNode (location: (1:24)-(3:0))
+    │   │       │       └── content: "\n  alert('Hello')\n"
+    │   │       │
+    │   │       └── tag_closing: "
+    │   │       //]]>
+    │   │       " (location: (1:0)-(3:9))
     │   │
     │   ├── close_tag:
     │   │   └── @ ERBEndNode (location: (3:0)-(3:9))

--- a/test/snapshots/analyze/action_view/java_script_helper/java_script_tag_test/test_0002_javascript_tag_with_content_as_argument_8db26754779e5ab874c8149c54c70a45-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/java_script_helper/java_script_tag_test/test_0002_javascript_tag_with_content_as_argument_8db26754779e5ab874c8149c54c70a45-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -17,8 +17,17 @@ options: {action_view_helpers: true}
     │   │
     │   ├── tag_name: "script" (location: (1:4)-(1:18))
     │   ├── body: (1 item)
-    │   │   └── @ HTMLTextNode (location: (1:0)-(1:38))
-    │   │       └── content: "alert('Hello')"
+    │   │   └── @ CDATANode (location: (1:0)-(1:38))
+    │   │       ├── tag_opening: "
+    │   │       //<![CDATA[
+    │   │       " (location: (1:0)-(1:38))
+    │   │       ├── children: (1 item)
+    │   │       │   └── @ HTMLTextNode (location: (1:0)-(1:38))
+    │   │       │       └── content: "alert('Hello')"
+    │   │       │
+    │   │       └── tag_closing: "
+    │   │       //]]>
+    │   │       " (location: (1:0)-(1:38))
     │   │
     │   ├── close_tag:
     │   │   └── @ HTMLVirtualCloseTagNode (location: (1:38)-(1:38))

--- a/test/snapshots/analyze/action_view/java_script_helper/java_script_tag_test/test_0003_javascript_tag_with_html_options_240707fc63eb28db4e7997d711eb93d7-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/java_script_helper/java_script_tag_test/test_0003_javascript_tag_with_html_options_240707fc63eb28db4e7997d711eb93d7-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -37,8 +37,17 @@ options: {action_view_helpers: true}
     │   │
     │   ├── tag_name: "script" (location: (1:4)-(1:18))
     │   ├── body: (1 item)
-    │   │   └── @ HTMLTextNode (location: (1:0)-(1:70))
-    │   │       └── content: "alert('Hello')"
+    │   │   └── @ CDATANode (location: (1:0)-(1:70))
+    │   │       ├── tag_opening: "
+    │   │       //<![CDATA[
+    │   │       " (location: (1:0)-(1:70))
+    │   │       ├── children: (1 item)
+    │   │       │   └── @ HTMLTextNode (location: (1:0)-(1:70))
+    │   │       │       └── content: "alert('Hello')"
+    │   │       │
+    │   │       └── tag_closing: "
+    │   │       //]]>
+    │   │       " (location: (1:0)-(1:70))
     │   │
     │   ├── close_tag:
     │   │   └── @ HTMLVirtualCloseTagNode (location: (1:70)-(1:70))

--- a/test/snapshots/analyze/action_view/java_script_helper/java_script_tag_test/test_0004_javascript_tag_with_nonce_true_87cc96d1cafe14079fda2aae23d53d6c-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/java_script_helper/java_script_tag_test/test_0004_javascript_tag_with_nonce_true_87cc96d1cafe14079fda2aae23d53d6c-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -39,8 +39,17 @@ options: {action_view_helpers: true}
     │   │
     │   ├── tag_name: "script" (location: (1:4)-(1:18))
     │   ├── body: (1 item)
-    │   │   └── @ LiteralNode (location: (1:36)-(3:0))
-    │   │       └── content: "\n  alert('Hello')\n"
+    │   │   └── @ CDATANode (location: (1:0)-(3:9))
+    │   │       ├── tag_opening: "
+    │   │       //<![CDATA[
+    │   │       " (location: (1:0)-(3:9))
+    │   │       ├── children: (1 item)
+    │   │       │   └── @ LiteralNode (location: (1:36)-(3:0))
+    │   │       │       └── content: "\n  alert('Hello')\n"
+    │   │       │
+    │   │       └── tag_closing: "
+    │   │       //]]>
+    │   │       " (location: (1:0)-(3:9))
     │   │
     │   ├── close_tag:
     │   │   └── @ ERBEndNode (location: (3:0)-(3:9))

--- a/test/snapshots/analyze/action_view/java_script_helper/java_script_tag_test/test_0005_javascript_tag_with_data_attributes_e9ab9c958a95b83cfb38ff154f2099fe-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/java_script_helper/java_script_tag_test/test_0005_javascript_tag_with_data_attributes_e9ab9c958a95b83cfb38ff154f2099fe-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -39,8 +39,17 @@ options: {action_view_helpers: true}
     │   │
     │   ├── tag_name: "script" (location: (1:4)-(1:18))
     │   ├── body: (1 item)
-    │   │   └── @ LiteralNode (location: (1:52)-(3:0))
-    │   │       └── content: "\n  console.log('Hello')\n"
+    │   │   └── @ CDATANode (location: (1:0)-(3:9))
+    │   │       ├── tag_opening: "
+    │   │       //<![CDATA[
+    │   │       " (location: (1:0)-(3:9))
+    │   │       ├── children: (1 item)
+    │   │       │   └── @ LiteralNode (location: (1:52)-(3:0))
+    │   │       │       └── content: "\n  console.log('Hello')\n"
+    │   │       │
+    │   │       └── tag_closing: "
+    │   │       //]]>
+    │   │       " (location: (1:0)-(3:9))
     │   │
     │   ├── close_tag:
     │   │   └── @ ERBEndNode (location: (3:0)-(3:9))

--- a/test/snapshots/analyze/action_view/java_script_helper/java_script_tag_test/test_0006_javascript_tag_with_variable_content_bab8885d8617c8c95b1e87574daeefcd-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/java_script_helper/java_script_tag_test/test_0006_javascript_tag_with_variable_content_bab8885d8617c8c95b1e87574daeefcd-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -17,8 +17,17 @@ options: {action_view_helpers: true}
     │   │
     │   ├── tag_name: "script" (location: (1:4)-(1:18))
     │   ├── body: (1 item)
-    │   │   └── @ RubyLiteralNode (location: (1:0)-(1:32))
-    │   │       └── content: "js_content"
+    │   │   └── @ CDATANode (location: (1:0)-(1:32))
+    │   │       ├── tag_opening: "
+    │   │       //<![CDATA[
+    │   │       " (location: (1:0)-(1:32))
+    │   │       ├── children: (1 item)
+    │   │       │   └── @ RubyLiteralNode (location: (1:0)-(1:32))
+    │   │       │       └── content: "js_content"
+    │   │       │
+    │   │       └── tag_closing: "
+    │   │       //]]>
+    │   │       " (location: (1:0)-(1:32))
     │   │
     │   ├── close_tag:
     │   │   └── @ HTMLVirtualCloseTagNode (location: (1:32)-(1:32))

--- a/test/snapshots/analyze/action_view/java_script_helper/java_script_tag_test/test_0007_javascript_tag_with_URL_in_comment_(gh-991)_ffcbd0a310aada3e3db5700317bcb79a-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/java_script_helper/java_script_tag_test/test_0007_javascript_tag_with_URL_in_comment_(gh-991)_ffcbd0a310aada3e3db5700317bcb79a-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -19,8 +19,17 @@ options: {action_view_helpers: true}
     │   │
     │   ├── tag_name: "script" (location: (1:3)-(1:17))
     │   ├── body: (1 item)
-    │   │   └── @ LiteralNode (location: (1:23)-(3:0))
-    │   │       └── content: "\n  // <http://example.com>\n"
+    │   │   └── @ CDATANode (location: (1:0)-(3:9))
+    │   │       ├── tag_opening: "
+    │   │       //<![CDATA[
+    │   │       " (location: (1:0)-(3:9))
+    │   │       ├── children: (1 item)
+    │   │       │   └── @ LiteralNode (location: (1:23)-(3:0))
+    │   │       │       └── content: "\n  // <http://example.com>\n"
+    │   │       │
+    │   │       └── tag_closing: "
+    │   │       //]]>
+    │   │       " (location: (1:0)-(3:9))
     │   │
     │   ├── close_tag:
     │   │   └── @ ERBEndNode (location: (3:0)-(3:9))

--- a/test/snapshots/analyze/action_view/java_script_helper/java_script_tag_test/test_0008_javascript_tag_with_HTML-like_content_in_block_(gh-1426)_0cf334dcc33fbec3a50e20bce62ae526-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/java_script_helper/java_script_tag_test/test_0008_javascript_tag_with_HTML-like_content_in_block_(gh-1426)_0cf334dcc33fbec3a50e20bce62ae526-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -19,8 +19,17 @@ options: {action_view_helpers: true}
     │   │
     │   ├── tag_name: "script" (location: (1:4)-(1:18))
     │   ├── body: (1 item)
-    │   │   └── @ LiteralNode (location: (1:24)-(3:0))
-    │   │       └── content: "\n  n <o.length\n"
+    │   │   └── @ CDATANode (location: (1:0)-(3:9))
+    │   │       ├── tag_opening: "
+    │   │       //<![CDATA[
+    │   │       " (location: (1:0)-(3:9))
+    │   │       ├── children: (1 item)
+    │   │       │   └── @ LiteralNode (location: (1:24)-(3:0))
+    │   │       │       └── content: "\n  n <o.length\n"
+    │   │       │
+    │   │       └── tag_closing: "
+    │   │       //]]>
+    │   │       " (location: (1:0)-(3:9))
     │   │
     │   ├── close_tag:
     │   │   └── @ ERBEndNode (location: (3:0)-(3:9))

--- a/test/snapshots/analyze/action_view/java_script_helper/java_script_tag_test/test_0009_javascript_tag_with_embedded_ERB_in_HTML_string_literal_d2bd29d9ea354dbf58a894bd2a7bd725-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/java_script_helper/java_script_tag_test/test_0009_javascript_tag_with_embedded_ERB_in_HTML_string_literal_d2bd29d9ea354dbf58a894bd2a7bd725-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -20,19 +20,28 @@ options: {action_view_helpers: true}
     │   │       └── children: []
     │   │
     │   ├── tag_name: "script" (location: (1:4)-(1:18))
-    │   ├── body: (3 items)
-    │   │   ├── @ LiteralNode (location: (1:24)-(2:22))
-    │   │   │   └── content: "\n  const html = \"<code>"
-    │   │   │
-    │   │   ├── @ ERBContentNode (location: (2:22)-(2:36))
-    │   │   │   ├── tag_opening: "<%=" (location: (2:22)-(2:25))
-    │   │   │   ├── content: " content " (location: (2:25)-(2:34))
-    │   │   │   ├── tag_closing: "%>" (location: (2:34)-(2:36))
-    │   │   │   ├── parsed: false
-    │   │   │   └── valid: false
-    │   │   │
-    │   │   └── @ LiteralNode (location: (2:36)-(5:0))
-    │   │       └── content: "</code>\";\n\n  console.log(html)\n"
+    │   ├── body: (1 item)
+    │   │   └── @ CDATANode (location: (1:0)-(5:9))
+    │   │       ├── tag_opening: "
+    │   │       //<![CDATA[
+    │   │       " (location: (1:0)-(5:9))
+    │   │       ├── children: (3 items)
+    │   │       │   ├── @ LiteralNode (location: (1:24)-(2:22))
+    │   │       │   │   └── content: "\n  const html = \"<code>"
+    │   │       │   │
+    │   │       │   ├── @ ERBContentNode (location: (2:22)-(2:36))
+    │   │       │   │   ├── tag_opening: "<%=" (location: (2:22)-(2:25))
+    │   │       │   │   ├── content: " content " (location: (2:25)-(2:34))
+    │   │       │   │   ├── tag_closing: "%>" (location: (2:34)-(2:36))
+    │   │       │   │   ├── parsed: false
+    │   │       │   │   └── valid: false
+    │   │       │   │
+    │   │       │   └── @ LiteralNode (location: (2:36)-(5:0))
+    │   │       │       └── content: "</code>\";\n\n  console.log(html)\n"
+    │   │       │
+    │   │       └── tag_closing: "
+    │   │       //]]>
+    │   │       " (location: (1:0)-(5:9))
     │   │
     │   ├── close_tag:
     │   │   └── @ ERBEndNode (location: (5:0)-(5:9))

--- a/test/snapshots/analyze/action_view/java_script_helper/java_script_tag_test/test_0010_javascript_tag_with_less-than_operator_and_space_(gh-1426)_0fec7b031a78c15f7db9c89b5578a0a8-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/java_script_helper/java_script_tag_test/test_0010_javascript_tag_with_less-than_operator_and_space_(gh-1426)_0fec7b031a78c15f7db9c89b5578a0a8-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -19,8 +19,17 @@ options: {action_view_helpers: true}
     │   │
     │   ├── tag_name: "script" (location: (1:4)-(1:18))
     │   ├── body: (1 item)
-    │   │   └── @ LiteralNode (location: (1:24)-(3:0))
-    │   │       └── content: "\n  n < o.length\n"
+    │   │   └── @ CDATANode (location: (1:0)-(3:9))
+    │   │       ├── tag_opening: "
+    │   │       //<![CDATA[
+    │   │       " (location: (1:0)-(3:9))
+    │   │       ├── children: (1 item)
+    │   │       │   └── @ LiteralNode (location: (1:24)-(3:0))
+    │   │       │       └── content: "\n  n < o.length\n"
+    │   │       │
+    │   │       └── tag_closing: "
+    │   │       //]]>
+    │   │       " (location: (1:0)-(3:9))
     │   │
     │   ├── close_tag:
     │   │   └── @ ERBEndNode (location: (3:0)-(3:9))

--- a/test/snapshots/analyze/action_view/java_script_helper/java_script_tag_test/test_0011_javascript_tag_with_less-than_in_condition_(gh-1426)_dc4daad5064a8598d8c8fbb8b0b7ceb2-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/java_script_helper/java_script_tag_test/test_0011_javascript_tag_with_less-than_in_condition_(gh-1426)_dc4daad5064a8598d8c8fbb8b0b7ceb2-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -19,8 +19,17 @@ options: {action_view_helpers: true}
     │   │
     │   ├── tag_name: "script" (location: (1:4)-(1:18))
     │   ├── body: (1 item)
-    │   │   └── @ LiteralNode (location: (1:24)-(3:0))
-    │   │       └── content: "\n  if (n<o) console.log(\"hello\")\n"
+    │   │   └── @ CDATANode (location: (1:0)-(3:9))
+    │   │       ├── tag_opening: "
+    │   │       //<![CDATA[
+    │   │       " (location: (1:0)-(3:9))
+    │   │       ├── children: (1 item)
+    │   │       │   └── @ LiteralNode (location: (1:24)-(3:0))
+    │   │       │       └── content: "\n  if (n<o) console.log(\"hello\")\n"
+    │   │       │
+    │   │       └── tag_closing: "
+    │   │       //]]>
+    │   │       " (location: (1:0)-(3:9))
     │   │
     │   ├── close_tag:
     │   │   └── @ ERBEndNode (location: (3:0)-(3:9))

--- a/test/snapshots/analyze/action_view/java_script_helper/java_script_tag_test/test_0012_javascript_tag_with_less-than_in_for_loop_condition_(gh-1426)_8f08ad531748d59d9f663e1cec7134e6-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/java_script_helper/java_script_tag_test/test_0012_javascript_tag_with_less-than_in_for_loop_condition_(gh-1426)_8f08ad531748d59d9f663e1cec7134e6-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -19,8 +19,17 @@ options: {action_view_helpers: true}
     │   │
     │   ├── tag_name: "script" (location: (1:4)-(1:18))
     │   ├── body: (1 item)
-    │   │   └── @ LiteralNode (location: (1:24)-(3:0))
-    │   │       └── content: "\n  for (let i = 0; i<items.length; i++) { console.log(items[i]) }\n"
+    │   │   └── @ CDATANode (location: (1:0)-(3:9))
+    │   │       ├── tag_opening: "
+    │   │       //<![CDATA[
+    │   │       " (location: (1:0)-(3:9))
+    │   │       ├── children: (1 item)
+    │   │       │   └── @ LiteralNode (location: (1:24)-(3:0))
+    │   │       │       └── content: "\n  for (let i = 0; i<items.length; i++) { console.log(items[i]) }\n"
+    │   │       │
+    │   │       └── tag_closing: "
+    │   │       //]]>
+    │   │       " (location: (1:0)-(3:9))
     │   │
     │   ├── close_tag:
     │   │   └── @ ERBEndNode (location: (3:0)-(3:9))

--- a/test/snapshots/analyze/action_view/java_script_helper/java_script_tag_test/test_0013_javascript_tag_with_less-than_in_arrow_function_(gh-1426)_5f1f670ffeb7a1b21251107fba17bc48-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/java_script_helper/java_script_tag_test/test_0013_javascript_tag_with_less-than_in_arrow_function_(gh-1426)_5f1f670ffeb7a1b21251107fba17bc48-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -19,8 +19,17 @@ options: {action_view_helpers: true}
     │   │
     │   ├── tag_name: "script" (location: (1:4)-(1:18))
     │   ├── body: (1 item)
-    │   │   └── @ LiteralNode (location: (1:24)-(3:0))
-    │   │       └── content: "\n  const filtered = items.filter(x => x<threshold)\n"
+    │   │   └── @ CDATANode (location: (1:0)-(3:9))
+    │   │       ├── tag_opening: "
+    │   │       //<![CDATA[
+    │   │       " (location: (1:0)-(3:9))
+    │   │       ├── children: (1 item)
+    │   │       │   └── @ LiteralNode (location: (1:24)-(3:0))
+    │   │       │       └── content: "\n  const filtered = items.filter(x => x<threshold)\n"
+    │   │       │
+    │   │       └── tag_closing: "
+    │   │       //]]>
+    │   │       " (location: (1:0)-(3:9))
     │   │
     │   ├── close_tag:
     │   │   └── @ ERBEndNode (location: (3:0)-(3:9))

--- a/test/snapshots/analyze/action_view/java_script_helper/java_script_tag_test/test_0014_javascript_tag_with_less-than_and_nested_ERB_control_flow_(gh-1426)_00d223eab531334742567daecbec46bf-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/java_script_helper/java_script_tag_test/test_0014_javascript_tag_with_less-than_and_nested_ERB_control_flow_(gh-1426)_00d223eab531334742567daecbec46bf-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -22,29 +22,38 @@ options: {action_view_helpers: true}
     │   │       └── children: []
     │   │
     │   ├── tag_name: "script" (location: (1:4)-(1:18))
-    │   ├── body: (5 items)
-    │   │   ├── @ LiteralNode (location: (1:24)-(3:4))
-    │   │   │   └── content: "\n  if (n<o.length) {\n    "
-    │   │   │
-    │   │   ├── @ ERBContentNode (location: (3:4)-(3:22))
-    │   │   │   ├── tag_opening: "<%" (location: (3:4)-(3:6))
-    │   │   │   ├── content: " if condition " (location: (3:6)-(3:20))
-    │   │   │   ├── tag_closing: "%>" (location: (3:20)-(3:22))
-    │   │   │   ├── parsed: false
-    │   │   │   └── valid: false
-    │   │   │
-    │   │   ├── @ LiteralNode (location: (3:22)-(5:4))
-    │   │   │   └── content: "\n      doSomething()\n    "
-    │   │   │
-    │   │   ├── @ ERBContentNode (location: (5:4)-(5:13))
-    │   │   │   ├── tag_opening: "<%" (location: (5:4)-(5:6))
-    │   │   │   ├── content: " end " (location: (5:6)-(5:11))
-    │   │   │   ├── tag_closing: "%>" (location: (5:11)-(5:13))
-    │   │   │   ├── parsed: false
-    │   │   │   └── valid: false
-    │   │   │
-    │   │   └── @ LiteralNode (location: (5:13)-(7:0))
-    │   │       └── content: "\n  }\n"
+    │   ├── body: (1 item)
+    │   │   └── @ CDATANode (location: (1:0)-(7:9))
+    │   │       ├── tag_opening: "
+    │   │       //<![CDATA[
+    │   │       " (location: (1:0)-(7:9))
+    │   │       ├── children: (5 items)
+    │   │       │   ├── @ LiteralNode (location: (1:24)-(3:4))
+    │   │       │   │   └── content: "\n  if (n<o.length) {\n    "
+    │   │       │   │
+    │   │       │   ├── @ ERBContentNode (location: (3:4)-(3:22))
+    │   │       │   │   ├── tag_opening: "<%" (location: (3:4)-(3:6))
+    │   │       │   │   ├── content: " if condition " (location: (3:6)-(3:20))
+    │   │       │   │   ├── tag_closing: "%>" (location: (3:20)-(3:22))
+    │   │       │   │   ├── parsed: false
+    │   │       │   │   └── valid: false
+    │   │       │   │
+    │   │       │   ├── @ LiteralNode (location: (3:22)-(5:4))
+    │   │       │   │   └── content: "\n      doSomething()\n    "
+    │   │       │   │
+    │   │       │   ├── @ ERBContentNode (location: (5:4)-(5:13))
+    │   │       │   │   ├── tag_opening: "<%" (location: (5:4)-(5:6))
+    │   │       │   │   ├── content: " end " (location: (5:6)-(5:11))
+    │   │       │   │   ├── tag_closing: "%>" (location: (5:11)-(5:13))
+    │   │       │   │   ├── parsed: false
+    │   │       │   │   └── valid: false
+    │   │       │   │
+    │   │       │   └── @ LiteralNode (location: (5:13)-(7:0))
+    │   │       │       └── content: "\n  }\n"
+    │   │       │
+    │   │       └── tag_closing: "
+    │   │       //]]>
+    │   │       " (location: (1:0)-(7:9))
     │   │
     │   ├── close_tag:
     │   │   └── @ ERBEndNode (location: (7:0)-(7:9))

--- a/test/snapshots/analyze/action_view/java_script_helper/java_script_tag_test/test_0015_javascript_tag_with_nonce_false_81613397ceb6ff62c1ff82a8742a83e1-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/java_script_helper/java_script_tag_test/test_0015_javascript_tag_with_nonce_false_81613397ceb6ff62c1ff82a8742a83e1-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -19,8 +19,17 @@ options: {action_view_helpers: true}
     │   │
     │   ├── tag_name: "script" (location: (1:4)-(1:18))
     │   ├── body: (1 item)
-    │   │   └── @ LiteralNode (location: (1:37)-(3:0))
-    │   │       └── content: "\n  alert('Hello')\n"
+    │   │   └── @ CDATANode (location: (1:0)-(3:9))
+    │   │       ├── tag_opening: "
+    │   │       //<![CDATA[
+    │   │       " (location: (1:0)-(3:9))
+    │   │       ├── children: (1 item)
+    │   │       │   └── @ LiteralNode (location: (1:37)-(3:0))
+    │   │       │       └── content: "\n  alert('Hello')\n"
+    │   │       │
+    │   │       └── tag_closing: "
+    │   │       //]]>
+    │   │       " (location: (1:0)-(3:9))
     │   │
     │   ├── close_tag:
     │   │   └── @ ERBEndNode (location: (3:0)-(3:9))

--- a/test/snapshots/analyze/action_view/java_script_helper/java_script_tag_test/test_0016_javascript_tag_inline_CDATA_matches_ActionView_output_6fe4f19045c6b65aa1712189294c15f4.txt
+++ b/test/snapshots/analyze/action_view/java_script_helper/java_script_tag_test/test_0016_javascript_tag_inline_CDATA_matches_ActionView_output_6fe4f19045c6b65aa1712189294c15f4.txt
@@ -1,0 +1,9 @@
+---
+source: "Analyze::ActionView::JavaScriptHelper::JavaScriptTagTest#test_0016_javascript_tag inline CDATA matches ActionView output"
+input: "{source: \"<%= javascript_tag \\\"alert(1)\\\" %>\", locals: {}, options: {}}"
+---
+<script>
+//<![CDATA[
+alert(1)
+//]]>
+</script>

--- a/test/snapshots/analyze/action_view/java_script_helper/java_script_tag_test/test_0017_javascript_tag_block_CDATA_matches_ActionView_output_2adc3ac664a9893320ff2e85b66460d8.txt
+++ b/test/snapshots/analyze/action_view/java_script_helper/java_script_tag_test/test_0017_javascript_tag_block_CDATA_matches_ActionView_output_2adc3ac664a9893320ff2e85b66460d8.txt
@@ -1,0 +1,11 @@
+---
+source: "Analyze::ActionView::JavaScriptHelper::JavaScriptTagTest#test_0017_javascript_tag block CDATA matches ActionView output"
+input: "{source: \"<%= javascript_tag do %>\\n  alert(1)\\n<% end %>\\n\", locals: {}, options: {}}"
+---
+<script>
+//<![CDATA[
+
+  alert(1)
+
+//]]>
+</script>

--- a/test/snapshots/analyze/action_view/java_script_helper/java_script_tag_test/test_0018_javascript_tag_with_type_attribute_CDATA_matches_ActionView_output_87f342385b017cc81088df97d072b03b.txt
+++ b/test/snapshots/analyze/action_view/java_script_helper/java_script_tag_test/test_0018_javascript_tag_with_type_attribute_CDATA_matches_ActionView_output_87f342385b017cc81088df97d072b03b.txt
@@ -1,0 +1,9 @@
+---
+source: "Analyze::ActionView::JavaScriptHelper::JavaScriptTagTest#test_0018_javascript_tag with type attribute CDATA matches ActionView output"
+input: "{source: \"<%= javascript_tag \\\"alert(1)\\\", type: \\\"application/javascript\\\" %>\", locals: {}, options: {}}"
+---
+<script type="application/javascript">
+//<![CDATA[
+alert(1)
+//]]>
+</script>


### PR DESCRIPTION
In Rails, `javascript_tag` wraps content in `//<![CDATA[...//]]>` for XHTML compatibility. This adds the same wrapping at the parser level using `CDATANode` for both inline content and block form.