### PR TITLE
Engine: Fix compilation of `CDATANode`

### DIFF
--- a/lib/herb/engine/compiler.rb
+++ b/lib/herb/engine/compiler.rb
@@ -156,9 +156,9 @@ module Herb
       end
 
       def visit_cdata_node(node)
-        add_text(node.cdata_opening.value)
+        add_text(node.tag_opening.value)
         visit_all(node.children)
-        add_text(node.cdata_closing.value)
+        add_text(node.tag_closing.value)
       end
 
       def visit_erb_content_node(node)

--- a/test/engine/engine_test.rb
+++ b/test/engine/engine_test.rb
@@ -267,5 +267,15 @@ module Engine
 
       engine.send(:ensure_valid_ruby!, "def foo; end")
     end
+
+    test "CDATA section compiles correctly" do
+      assert_compiled_snapshot("<![CDATA[ content ]]>", enforce_erubi_equality: true)
+      assert_evaluated_snapshot("<![CDATA[ content ]]>")
+    end
+
+    test "CDATA section inside script compiles correctly" do
+      assert_compiled_snapshot("<script><![CDATA[ alert(1) ]]></script>", enforce_erubi_equality: true)
+      assert_evaluated_snapshot("<script><![CDATA[ alert(1) ]]></script>")
+    end
   end
 end

--- a/test/snapshots/engine/engine_test/test_0027_CDATA_section_compiles_correctly_1e16ab21f813e5426f081308e0aebadb.txt
+++ b/test/snapshots/engine/engine_test/test_0027_CDATA_section_compiles_correctly_1e16ab21f813e5426f081308e0aebadb.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::EngineTest#test_0027_CDATA section compiles correctly"
+input: "{source: \"<![CDATA[ content ]]>\", options: {}}"
+---
+_buf = ::String.new; _buf << '<![CDATA[ content ]]>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/engine_test/test_0027_CDATA_section_compiles_correctly_4bed725b02fbd35f80896083bc21a9d0.txt
+++ b/test/snapshots/engine/engine_test/test_0027_CDATA_section_compiles_correctly_4bed725b02fbd35f80896083bc21a9d0.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::EngineTest#test_0027_CDATA section compiles correctly"
+input: "{source: \"<![CDATA[ content ]]>\", locals: {}, options: {}}"
+---
+<![CDATA[ content ]]>

--- a/test/snapshots/engine/engine_test/test_0028_CDATA_section_inside_script_compiles_correctly_9139ab01804be44e1e591acc08ae34ce.txt
+++ b/test/snapshots/engine/engine_test/test_0028_CDATA_section_inside_script_compiles_correctly_9139ab01804be44e1e591acc08ae34ce.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::EngineTest#test_0028_CDATA section inside script compiles correctly"
+input: "{source: \"<script><![CDATA[ alert(1) ]]></script>\", options: {}}"
+---
+_buf = ::String.new; _buf << '<script><![CDATA[ alert(1) ]]></script>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/engine_test/test_0028_CDATA_section_inside_script_compiles_correctly_a9915509025a78badc7ff273c434dc0d.txt
+++ b/test/snapshots/engine/engine_test/test_0028_CDATA_section_inside_script_compiles_correctly_a9915509025a78badc7ff273c434dc0d.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::EngineTest#test_0028_CDATA section inside script compiles correctly"
+input: "{source: \"<script><![CDATA[ alert(1) ]]></script>\", locals: {}, options: {}}"
+---
+<script><![CDATA[ alert(1) ]]></script>


### PR DESCRIPTION
The `visit_cdata_node` method in the Engine compiler referenced `node.cdata_opening` and `node.cdata_closing`, but the `CDATANode` fields are actually `tag_opening` and `tag_closing`. 

This would crash with a `NoMethodError` whenever the compiler encountered a `CDATA` section, e.g. 
```html
<![CDATA[ content ]]>
```

This pull request fixes the compiler to properly compile templates with `CDATANode`s.