### PR TITLE
Parser: Match Rails attribute ordering for Action View helpers

### DIFF
--- a/javascript/packages/rewriter/test/action-view-tag-helper-to-html.test.ts
+++ b/javascript/packages/rewriter/test/action-view-tag-helper-to-html.test.ts
@@ -449,7 +449,7 @@ describe("ActionViewTagHelperToHTMLRewriter", () => {
 
     test("link_to with inline block and attributes", () => {
       expect(transform('<%= link_to("/about", class: "btn") { "About" } %>')).toBe(
-        '<a href="/about" class="btn">About</a>'
+        '<a class="btn" href="/about">About</a>'
       )
     })
 
@@ -503,7 +503,7 @@ describe("ActionViewTagHelperToHTMLRewriter", () => {
 
     test("turbo_frame_tag with loading lazy", () => {
       expect(transform('<%= turbo_frame_tag "tray", src: tray_path(tray), loading: "lazy" %>')).toBe(
-        '<turbo-frame id="tray" src="<%= tray_path(tray) %>" loading="lazy"></turbo-frame>'
+        '<turbo-frame loading="lazy" id="tray" src="<%= tray_path(tray) %>"></turbo-frame>'
       )
     })
 
@@ -515,7 +515,7 @@ describe("ActionViewTagHelperToHTMLRewriter", () => {
       `
 
       const expected = dedent`
-        <turbo-frame id="tray" class="frame">
+        <turbo-frame class="frame" id="tray">
           Content
         </turbo-frame>
       `
@@ -547,7 +547,7 @@ describe("ActionViewTagHelperToHTMLRewriter", () => {
       `
 
       const expected = dedent`
-        <turbo-frame id="tray" data-controller="frame">
+        <turbo-frame data-controller="frame" id="tray">
           Content
         </turbo-frame>
       `
@@ -563,7 +563,7 @@ describe("ActionViewTagHelperToHTMLRewriter", () => {
       `
 
       const expected = dedent`
-        <turbo-frame id="tray" <%= tag.attributes(**attributes) %>>
+        <turbo-frame <%= tag.attributes(**attributes) %> id="tray">
           Content
         </turbo-frame>
       `
@@ -655,7 +655,7 @@ describe("ActionViewTagHelperToHTMLRewriter", () => {
 
     test("javascript_include_tag with defer", () => {
       expect(transform(`<%= javascript_include_tag "application", defer: true %>`)).toBe(
-        `<script src="<%= javascript_path("application") %>" defer></script>`
+        `<script defer src="<%= javascript_path("application") %>"></script>`
       )
     })
 
@@ -670,7 +670,7 @@ describe("ActionViewTagHelperToHTMLRewriter", () => {
 
     test("javascript_include_tag with nonce true resolves to content_security_policy_nonce", () => {
       expect(transform(`<%= javascript_include_tag "application", nonce: true %>`)).toBe(
-        `<script src="<%= javascript_path("application") %>" nonce="<%= content_security_policy_nonce %>"></script>`
+        `<script nonce="<%= content_security_policy_nonce %>" src="<%= javascript_path("application") %>"></script>`
       )
     })
 
@@ -682,13 +682,13 @@ describe("ActionViewTagHelperToHTMLRewriter", () => {
 
     test("javascript_include_tag with interpolated nonce", () => {
       expect(transform('<%= javascript_include_tag "application", nonce: "static-#{dynamic}" %>')).toBe(
-        '<script src="<%= javascript_path("application") %>" nonce="static-<%= dynamic %>"></script>'
+        '<script nonce="static-<%= dynamic %>" src="<%= javascript_path("application") %>"></script>'
       )
     })
 
     test("javascript_include_tag with data attributes", () => {
       expect(transform(`<%= javascript_include_tag "application", data: { turbo_track: "reload" } %>`)).toBe(
-        `<script src="<%= javascript_path("application") %>" data-turbo-track="reload"></script>`
+        `<script data-turbo-track="reload" src="<%= javascript_path("application") %>"></script>`
       )
     })
 
@@ -718,25 +718,25 @@ describe("ActionViewTagHelperToHTMLRewriter", () => {
 
     test("javascript_include_tag with URL and nonce", () => {
       expect(transform(`<%= javascript_include_tag "http://www.example.com/xmlhr.js", nonce: true %>`)).toBe(
-        `<script src="http://www.example.com/xmlhr.js" nonce="<%= content_security_policy_nonce %>"></script>`
+        `<script nonce="<%= content_security_policy_nonce %>" src="http://www.example.com/xmlhr.js"></script>`
       )
     })
 
     test("javascript_include_tag with URL and async", () => {
       expect(transform(`<%= javascript_include_tag "http://www.example.com/xmlhr.js", async: true %>`)).toBe(
-        `<script src="http://www.example.com/xmlhr.js" async></script>`
+        `<script async src="http://www.example.com/xmlhr.js"></script>`
       )
     })
 
     test("javascript_include_tag with URL and defer", () => {
       expect(transform(`<%= javascript_include_tag "http://www.example.com/xmlhr.js", defer: true %>`)).toBe(
-        `<script src="http://www.example.com/xmlhr.js" defer></script>`
+        `<script defer src="http://www.example.com/xmlhr.js"></script>`
       )
     })
 
     test("javascript_include_tag with defer as string", () => {
       expect(transform(`<%= javascript_include_tag "application", defer: "true" %>`)).toBe(
-        `<script src="<%= javascript_path("application") %>" defer="true"></script>`
+        `<script defer="true" src="<%= javascript_path("application") %>"></script>`
       )
     })
 
@@ -789,13 +789,13 @@ describe("ActionViewTagHelperToHTMLRewriter", () => {
 
     test("image_tag with alt attribute", () => {
       expect(transform('<%= image_tag "icon.png", alt: "Icon" %>')).toBe(
-        '<img src="<%= image_path("icon.png") %>" alt="Icon" />'
+        '<img alt="Icon" src="<%= image_path("icon.png") %>" />'
       )
     })
 
     test("image_tag with multiple attributes", () => {
       expect(transform('<%= image_tag "photo.jpg", alt: "Photo", class: "avatar" %>')).toBe(
-        '<img src="<%= image_path("photo.jpg") %>" alt="Photo" class="avatar" />'
+        '<img alt="Photo" class="avatar" src="<%= image_path("photo.jpg") %>" />'
       )
     })
 
@@ -849,13 +849,13 @@ describe("ActionViewTagHelperToHTMLRewriter", () => {
 
     test("image_tag with data attributes", () => {
       expect(transform('<%= image_tag "icon.png", data: { controller: "image" } %>')).toBe(
-        '<img src="<%= image_path("icon.png") %>" data-controller="image" />'
+        '<img data-controller="image" src="<%= image_path("icon.png") %>" />'
       )
     })
 
     test("image_tag with splat attributes", () => {
       expect(transform('<%= image_tag "icon.png", **attributes %>')).toBe(
-        '<img src="<%= image_path("icon.png") %>" <%= tag.attributes(**attributes) %> />'
+        '<img <%= tag.attributes(**attributes) %> src="<%= image_path("icon.png") %>" />'
       )
     })
 
@@ -867,31 +867,31 @@ describe("ActionViewTagHelperToHTMLRewriter", () => {
 
     test("image_tag with size WxH creates width and height attributes", () => {
       expect(transform('<%= image_tag "icon.png", size: "32x32" %>')).toBe(
-        '<img src="<%= image_path("icon.png") %>" width="32" height="32" />'
+        '<img width="32" height="32" src="<%= image_path("icon.png") %>" />'
       )
     })
 
     test("image_tag with size N creates square width and height attributes", () => {
       expect(transform('<%= image_tag "icon.png", size: "32" %>')).toBe(
-        '<img src="<%= image_path("icon.png") %>" width="32" height="32" />'
+        '<img width="32" height="32" src="<%= image_path("icon.png") %>" />'
       )
     })
 
     test("image_tag with size and other attributes", () => {
       expect(transform('<%= image_tag "icon.png", size: "32x32", alt: "Icon", class: "avatar" %>')).toBe(
-        '<img src="<%= image_path("icon.png") %>" alt="Icon" class="avatar" width="32" height="32" />'
+        '<img alt="Icon" class="avatar" width="32" height="32" src="<%= image_path("icon.png") %>" />'
       )
     })
 
     test("image_tag with dynamic size expands to width and height", () => {
       expect(transform('<%= image_tag "icon.png", size: some_var %>')).toBe(
-        '<img src="<%= image_path("icon.png") %>" width="<%= some_var.to_s.split("x", 2)[0] %>" height="<%= some_var.to_s.split("x", 2)[-1] %>" />'
+        '<img width="<%= some_var.to_s.split("x", 2)[0] %>" height="<%= some_var.to_s.split("x", 2)[-1] %>" src="<%= image_path("icon.png") %>" />'
       )
     })
 
     test("image_tag with string source does not segfault with path_options signature", () => {
       expect(transform('<%= image_tag "logo.png", alt: "Logo", class: "brand" %>')).toBe(
-        '<img src="<%= image_path("logo.png") %>" alt="Logo" class="brand" />'
+        '<img alt="Logo" class="brand" src="<%= image_path("logo.png") %>" />'
       )
     })
   })

--- a/src/analyze/action_view/tag_helpers.c
+++ b/src/analyze/action_view/tag_helpers.c
@@ -639,7 +639,15 @@ static AST_NODE_T* transform_tag_helper_with_attributes(
         id_is_ruby_expression ? create_html_attribute_with_ruby_literal("id", id_value, id_start, id_end, allocator)
                               : create_html_attribute_node("id", id_value, id_start, id_end, allocator);
 
-      if (id_attribute) { attributes = prepend_attribute(attributes, (AST_NODE_T*) id_attribute, allocator); }
+      if (id_attribute) {
+        AST_NODE_T* src_node = remove_attribute_by_name(attributes, "src");
+        AST_NODE_T* target_node = remove_attribute_by_name(attributes, "target");
+
+        hb_array_append(attributes, (AST_NODE_T*) id_attribute);
+
+        if (src_node) { hb_array_append(attributes, src_node); }
+        if (target_node) { hb_array_append(attributes, target_node); }
+      }
 
       hb_allocator_dealloc(allocator, id_value);
     }
@@ -679,7 +687,7 @@ static AST_NODE_T* transform_tag_helper_with_attributes(
           ? create_html_attribute_node("src", source_attribute_value, source_start, source_end, allocator)
           : create_html_attribute_with_ruby_literal("src", source_attribute_value, source_start, source_end, allocator);
 
-      if (source_attribute) { attributes = prepend_attribute(attributes, (AST_NODE_T*) source_attribute, allocator); }
+      if (source_attribute) { hb_array_append(attributes, (AST_NODE_T*) source_attribute); }
 
       if (source_attribute_value != source_value) { hb_allocator_dealloc(allocator, source_attribute_value); }
       hb_allocator_dealloc(allocator, source_value);
@@ -723,7 +731,7 @@ static AST_NODE_T* transform_tag_helper_with_attributes(
           ? create_html_attribute_node("src", source_attribute_value, source_start, source_end, allocator)
           : create_html_attribute_with_ruby_literal("src", source_attribute_value, source_start, source_end, allocator);
 
-      if (source_attribute) { attributes = prepend_attribute(attributes, (AST_NODE_T*) source_attribute, allocator); }
+      if (source_attribute) { hb_array_append(attributes, (AST_NODE_T*) source_attribute); }
       if (source_attribute_value != source_value) { hb_allocator_dealloc(allocator, source_attribute_value); }
 
       hb_allocator_dealloc(allocator, source_value);
@@ -1140,7 +1148,7 @@ static AST_NODE_T* transform_erb_block_to_tag_helper(
       AST_HTML_ATTRIBUTE_NODE_T* href_attribute =
         create_href_attribute(href, href_is_ruby_expression, href_start, href_end, allocator);
 
-      if (href_attribute) { attributes = prepend_attribute(attributes, (AST_NODE_T*) href_attribute, allocator); }
+      if (href_attribute) { hb_array_append(attributes, (AST_NODE_T*) href_attribute); }
 
       hb_allocator_dealloc(allocator, href);
     }
@@ -1161,7 +1169,15 @@ static AST_NODE_T* transform_erb_block_to_tag_helper(
         id_is_ruby_expression ? create_html_attribute_with_ruby_literal("id", id_value, id_start, id_end, allocator)
                               : create_html_attribute_node("id", id_value, id_start, id_end, allocator);
 
-      if (id_attribute) { attributes = prepend_attribute(attributes, (AST_NODE_T*) id_attribute, allocator); }
+      if (id_attribute) {
+        AST_NODE_T* src_node = remove_attribute_by_name(attributes, "src");
+        AST_NODE_T* target_node = remove_attribute_by_name(attributes, "target");
+
+        hb_array_append(attributes, (AST_NODE_T*) id_attribute);
+
+        if (src_node) { hb_array_append(attributes, src_node); }
+        if (target_node) { hb_array_append(attributes, target_node); }
+      }
 
       hb_allocator_dealloc(allocator, id_value);
     }
@@ -1418,7 +1434,7 @@ static AST_NODE_T* transform_link_to_helper(
     AST_HTML_ATTRIBUTE_NODE_T* href_attribute =
       create_href_attribute(href, href_is_ruby_expression, href_start, href_end, allocator);
 
-    if (href_attribute) { attributes = prepend_attribute(attributes, (AST_NODE_T*) href_attribute, allocator); }
+    if (href_attribute) { hb_array_append(attributes, (AST_NODE_T*) href_attribute); }
     if (!info->content) {
       href_for_body = hb_allocator_strdup(allocator, href);
       href_for_body_is_ruby_expression = href_is_ruby_expression;

--- a/test/snapshots/analyze/action_view/asset_tag_helper/image_tag_test/test_0002_image_tag_with_alt_ca71658e371baf645d2c54d2a8b8d63d-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/asset_tag_helper/image_tag_test/test_0002_image_tag_with_alt_ca71658e371baf645d2c54d2a8b8d63d-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -14,44 +14,44 @@ options: {action_view_helpers: true}
     │   │       ├── tag_closing: "%>" (location: (1:44)-(1:46))
     │   │       ├── tag_name: "img" (location: (1:4)-(1:13))
     │   │       └── children: (2 items)
-    │   │           ├── @ HTMLAttributeNode (location: (1:14)-(1:27))
+    │   │           ├── @ HTMLAttributeNode (location: (1:29)-(1:43))
     │   │           │   ├── name:
-    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:14)-(1:27))
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:29)-(1:32))
     │   │           │   │       └── children: (1 item)
-    │   │           │   │           └── @ LiteralNode (location: (1:14)-(1:27))
-    │   │           │   │               └── content: "src"
+    │   │           │   │           └── @ LiteralNode (location: (1:29)-(1:32))
+    │   │           │   │               └── content: "alt"
     │   │           │   │
     │   │           │   │
-    │   │           │   ├── equals: ":" (location: (1:14)-(1:27))
+    │   │           │   ├── equals: ": " (location: (1:32)-(1:34))
     │   │           │   └── value:
-    │   │           │       └── @ HTMLAttributeValueNode (location: (1:14)-(1:27))
-    │   │           │           ├── open_quote: ∅
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:34)-(1:43))
+    │   │           │           ├── open_quote: """ (location: (1:34)-(1:35))
     │   │           │           ├── children: (1 item)
-    │   │           │           │   └── @ RubyLiteralNode (location: (1:14)-(1:27))
-    │   │           │           │       └── content: "image_path(\"example.jpg\")"
+    │   │           │           │   └── @ LiteralNode (location: (1:35)-(1:42))
+    │   │           │           │       └── content: "Example"
     │   │           │           │
-    │   │           │           ├── close_quote: ∅
-    │   │           │           └── quoted: false
+    │   │           │           ├── close_quote: """ (location: (1:42)-(1:43))
+    │   │           │           └── quoted: true
     │   │           │
     │   │           │
-    │   │           └── @ HTMLAttributeNode (location: (1:29)-(1:43))
+    │   │           └── @ HTMLAttributeNode (location: (1:14)-(1:27))
     │   │               ├── name:
-    │   │               │   └── @ HTMLAttributeNameNode (location: (1:29)-(1:32))
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:14)-(1:27))
     │   │               │       └── children: (1 item)
-    │   │               │           └── @ LiteralNode (location: (1:29)-(1:32))
-    │   │               │               └── content: "alt"
+    │   │               │           └── @ LiteralNode (location: (1:14)-(1:27))
+    │   │               │               └── content: "src"
     │   │               │
     │   │               │
-    │   │               ├── equals: ": " (location: (1:32)-(1:34))
+    │   │               ├── equals: ":" (location: (1:14)-(1:27))
     │   │               └── value:
-    │   │                   └── @ HTMLAttributeValueNode (location: (1:34)-(1:43))
-    │   │                       ├── open_quote: """ (location: (1:34)-(1:35))
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:14)-(1:27))
+    │   │                       ├── open_quote: ∅
     │   │                       ├── children: (1 item)
-    │   │                       │   └── @ LiteralNode (location: (1:35)-(1:42))
-    │   │                       │       └── content: "Example"
+    │   │                       │   └── @ RubyLiteralNode (location: (1:14)-(1:27))
+    │   │                       │       └── content: "image_path(\"example.jpg\")"
     │   │                       │
-    │   │                       ├── close_quote: """ (location: (1:42)-(1:43))
-    │   │                       └── quoted: true
+    │   │                       ├── close_quote: ∅
+    │   │                       └── quoted: false
     │   │
     │   │
     │   │

--- a/test/snapshots/analyze/action_view/asset_tag_helper/image_tag_test/test_0005_image_tag_with_data_attributes_b602e55129972c0dce9b31e203767a56-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/asset_tag_helper/image_tag_test/test_0005_image_tag_with_data_attributes_b602e55129972c0dce9b31e203767a56-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -14,26 +14,6 @@ options: {action_view_helpers: true}
     │   │       ├── tag_closing: "%>" (location: (1:75)-(1:77))
     │   │       ├── tag_name: "img" (location: (1:4)-(1:13))
     │   │       └── children: (3 items)
-    │   │           ├── @ HTMLAttributeNode (location: (1:14)-(1:27))
-    │   │           │   ├── name:
-    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:14)-(1:27))
-    │   │           │   │       └── children: (1 item)
-    │   │           │   │           └── @ LiteralNode (location: (1:14)-(1:27))
-    │   │           │   │               └── content: "src"
-    │   │           │   │
-    │   │           │   │
-    │   │           │   ├── equals: ":" (location: (1:14)-(1:27))
-    │   │           │   └── value:
-    │   │           │       └── @ HTMLAttributeValueNode (location: (1:14)-(1:27))
-    │   │           │           ├── open_quote: ∅
-    │   │           │           ├── children: (1 item)
-    │   │           │           │   └── @ RubyLiteralNode (location: (1:14)-(1:27))
-    │   │           │           │       └── content: "image_path(\"example.jpg\")"
-    │   │           │           │
-    │   │           │           ├── close_quote: ∅
-    │   │           │           └── quoted: false
-    │   │           │
-    │   │           │
     │   │           ├── @ HTMLAttributeNode (location: (1:37)-(1:58))
     │   │           │   ├── name:
     │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:37)-(1:47))
@@ -54,21 +34,41 @@ options: {action_view_helpers: true}
     │   │           │           └── quoted: true
     │   │           │
     │   │           │
-    │   │           └── @ HTMLAttributeNode (location: (1:60)-(1:72))
+    │   │           ├── @ HTMLAttributeNode (location: (1:60)-(1:72))
+    │   │           │   ├── name:
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:60)-(1:67))
+    │   │           │   │       └── children: (1 item)
+    │   │           │   │           └── @ LiteralNode (location: (1:60)-(1:67))
+    │   │           │   │               └── content: "data-user-id"
+    │   │           │   │
+    │   │           │   │
+    │   │           │   ├── equals: ": " (location: (1:67)-(1:69))
+    │   │           │   └── value:
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:69)-(1:72))
+    │   │           │           ├── open_quote: ∅
+    │   │           │           ├── children: (1 item)
+    │   │           │           │   └── @ LiteralNode (location: (1:69)-(1:72))
+    │   │           │           │       └── content: "123"
+    │   │           │           │
+    │   │           │           ├── close_quote: ∅
+    │   │           │           └── quoted: false
+    │   │           │
+    │   │           │
+    │   │           └── @ HTMLAttributeNode (location: (1:14)-(1:27))
     │   │               ├── name:
-    │   │               │   └── @ HTMLAttributeNameNode (location: (1:60)-(1:67))
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:14)-(1:27))
     │   │               │       └── children: (1 item)
-    │   │               │           └── @ LiteralNode (location: (1:60)-(1:67))
-    │   │               │               └── content: "data-user-id"
+    │   │               │           └── @ LiteralNode (location: (1:14)-(1:27))
+    │   │               │               └── content: "src"
     │   │               │
     │   │               │
-    │   │               ├── equals: ": " (location: (1:67)-(1:69))
+    │   │               ├── equals: ":" (location: (1:14)-(1:27))
     │   │               └── value:
-    │   │                   └── @ HTMLAttributeValueNode (location: (1:69)-(1:72))
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:14)-(1:27))
     │   │                       ├── open_quote: ∅
     │   │                       ├── children: (1 item)
-    │   │                       │   └── @ LiteralNode (location: (1:69)-(1:72))
-    │   │                       │       └── content: "123"
+    │   │                       │   └── @ RubyLiteralNode (location: (1:14)-(1:27))
+    │   │                       │       └── content: "image_path(\"example.jpg\")"
     │   │                       │
     │   │                       ├── close_quote: ∅
     │   │                       └── quoted: false

--- a/test/snapshots/analyze/action_view/asset_tag_helper/image_tag_test/test_0006_image_tag_with_string_source_and_attributes_d58548095155928ff33e27bcf27dae24-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/asset_tag_helper/image_tag_test/test_0006_image_tag_with_string_source_and_attributes_d58548095155928ff33e27bcf27dae24-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -14,26 +14,6 @@ options: {action_view_helpers: true}
     │   │       ├── tag_closing: "%>" (location: (1:54)-(1:56))
     │   │       ├── tag_name: "img" (location: (1:4)-(1:13))
     │   │       └── children: (3 items)
-    │   │           ├── @ HTMLAttributeNode (location: (1:14)-(1:24))
-    │   │           │   ├── name:
-    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:14)-(1:24))
-    │   │           │   │       └── children: (1 item)
-    │   │           │   │           └── @ LiteralNode (location: (1:14)-(1:24))
-    │   │           │   │               └── content: "src"
-    │   │           │   │
-    │   │           │   │
-    │   │           │   ├── equals: ":" (location: (1:14)-(1:24))
-    │   │           │   └── value:
-    │   │           │       └── @ HTMLAttributeValueNode (location: (1:14)-(1:24))
-    │   │           │           ├── open_quote: ∅
-    │   │           │           ├── children: (1 item)
-    │   │           │           │   └── @ RubyLiteralNode (location: (1:14)-(1:24))
-    │   │           │           │       └── content: "image_path(\"logo.png\")"
-    │   │           │           │
-    │   │           │           ├── close_quote: ∅
-    │   │           │           └── quoted: false
-    │   │           │
-    │   │           │
     │   │           ├── @ HTMLAttributeNode (location: (1:26)-(1:37))
     │   │           │   ├── name:
     │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:26)-(1:29))
@@ -54,24 +34,44 @@ options: {action_view_helpers: true}
     │   │           │           └── quoted: true
     │   │           │
     │   │           │
-    │   │           └── @ HTMLAttributeNode (location: (1:39)-(1:53))
+    │   │           ├── @ HTMLAttributeNode (location: (1:39)-(1:53))
+    │   │           │   ├── name:
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:39)-(1:44))
+    │   │           │   │       └── children: (1 item)
+    │   │           │   │           └── @ LiteralNode (location: (1:39)-(1:44))
+    │   │           │   │               └── content: "class"
+    │   │           │   │
+    │   │           │   │
+    │   │           │   ├── equals: ": " (location: (1:44)-(1:46))
+    │   │           │   └── value:
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:46)-(1:53))
+    │   │           │           ├── open_quote: """ (location: (1:46)-(1:47))
+    │   │           │           ├── children: (1 item)
+    │   │           │           │   └── @ LiteralNode (location: (1:47)-(1:52))
+    │   │           │           │       └── content: "brand"
+    │   │           │           │
+    │   │           │           ├── close_quote: """ (location: (1:52)-(1:53))
+    │   │           │           └── quoted: true
+    │   │           │
+    │   │           │
+    │   │           └── @ HTMLAttributeNode (location: (1:14)-(1:24))
     │   │               ├── name:
-    │   │               │   └── @ HTMLAttributeNameNode (location: (1:39)-(1:44))
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:14)-(1:24))
     │   │               │       └── children: (1 item)
-    │   │               │           └── @ LiteralNode (location: (1:39)-(1:44))
-    │   │               │               └── content: "class"
+    │   │               │           └── @ LiteralNode (location: (1:14)-(1:24))
+    │   │               │               └── content: "src"
     │   │               │
     │   │               │
-    │   │               ├── equals: ": " (location: (1:44)-(1:46))
+    │   │               ├── equals: ":" (location: (1:14)-(1:24))
     │   │               └── value:
-    │   │                   └── @ HTMLAttributeValueNode (location: (1:46)-(1:53))
-    │   │                       ├── open_quote: """ (location: (1:46)-(1:47))
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:14)-(1:24))
+    │   │                       ├── open_quote: ∅
     │   │                       ├── children: (1 item)
-    │   │                       │   └── @ LiteralNode (location: (1:47)-(1:52))
-    │   │                       │       └── content: "brand"
+    │   │                       │   └── @ RubyLiteralNode (location: (1:14)-(1:24))
+    │   │                       │       └── content: "image_path(\"logo.png\")"
     │   │                       │
-    │   │                       ├── close_quote: """ (location: (1:52)-(1:53))
-    │   │                       └── quoted: true
+    │   │                       ├── close_quote: ∅
+    │   │                       └── quoted: false
     │   │
     │   │
     │   │

--- a/test/snapshots/analyze/action_view/asset_tag_helper/image_tag_test/test_0008_image_tag_with_static_size_WxH_786dcb30de241afa9011827f52be1c9e-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/asset_tag_helper/image_tag_test/test_0008_image_tag_with_static_size_WxH_786dcb30de241afa9011827f52be1c9e-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -14,26 +14,6 @@ options: {action_view_helpers: true}
     │   │       ├── tag_closing: "%>" (location: (1:40)-(1:42))
     │   │       ├── tag_name: "img" (location: (1:4)-(1:13))
     │   │       └── children: (3 items)
-    │   │           ├── @ HTMLAttributeNode (location: (1:14)-(1:24))
-    │   │           │   ├── name:
-    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:14)-(1:24))
-    │   │           │   │       └── children: (1 item)
-    │   │           │   │           └── @ LiteralNode (location: (1:14)-(1:24))
-    │   │           │   │               └── content: "src"
-    │   │           │   │
-    │   │           │   │
-    │   │           │   ├── equals: ":" (location: (1:14)-(1:24))
-    │   │           │   └── value:
-    │   │           │       └── @ HTMLAttributeValueNode (location: (1:14)-(1:24))
-    │   │           │           ├── open_quote: ∅
-    │   │           │           ├── children: (1 item)
-    │   │           │           │   └── @ RubyLiteralNode (location: (1:14)-(1:24))
-    │   │           │           │       └── content: "image_path(\"icon.png\")"
-    │   │           │           │
-    │   │           │           ├── close_quote: ∅
-    │   │           │           └── quoted: false
-    │   │           │
-    │   │           │
     │   │           ├── @ HTMLAttributeNode (location: (1:26)-(1:26))
     │   │           │   ├── name:
     │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:26)-(1:26))
@@ -54,24 +34,44 @@ options: {action_view_helpers: true}
     │   │           │           └── quoted: true
     │   │           │
     │   │           │
-    │   │           └── @ HTMLAttributeNode (location: (1:26)-(1:26))
+    │   │           ├── @ HTMLAttributeNode (location: (1:26)-(1:26))
+    │   │           │   ├── name:
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:26)-(1:26))
+    │   │           │   │       └── children: (1 item)
+    │   │           │   │           └── @ LiteralNode (location: (1:26)-(1:26))
+    │   │           │   │               └── content: "height"
+    │   │           │   │
+    │   │           │   │
+    │   │           │   ├── equals: "=" (location: (1:26)-(1:26))
+    │   │           │   └── value:
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:26)-(1:26))
+    │   │           │           ├── open_quote: """ (location: (1:26)-(1:26))
+    │   │           │           ├── children: (1 item)
+    │   │           │           │   └── @ LiteralNode (location: (1:26)-(1:26))
+    │   │           │           │       └── content: "32"
+    │   │           │           │
+    │   │           │           ├── close_quote: """ (location: (1:26)-(1:26))
+    │   │           │           └── quoted: true
+    │   │           │
+    │   │           │
+    │   │           └── @ HTMLAttributeNode (location: (1:14)-(1:24))
     │   │               ├── name:
-    │   │               │   └── @ HTMLAttributeNameNode (location: (1:26)-(1:26))
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:14)-(1:24))
     │   │               │       └── children: (1 item)
-    │   │               │           └── @ LiteralNode (location: (1:26)-(1:26))
-    │   │               │               └── content: "height"
+    │   │               │           └── @ LiteralNode (location: (1:14)-(1:24))
+    │   │               │               └── content: "src"
     │   │               │
     │   │               │
-    │   │               ├── equals: "=" (location: (1:26)-(1:26))
+    │   │               ├── equals: ":" (location: (1:14)-(1:24))
     │   │               └── value:
-    │   │                   └── @ HTMLAttributeValueNode (location: (1:26)-(1:26))
-    │   │                       ├── open_quote: """ (location: (1:26)-(1:26))
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:14)-(1:24))
+    │   │                       ├── open_quote: ∅
     │   │                       ├── children: (1 item)
-    │   │                       │   └── @ LiteralNode (location: (1:26)-(1:26))
-    │   │                       │       └── content: "32"
+    │   │                       │   └── @ RubyLiteralNode (location: (1:14)-(1:24))
+    │   │                       │       └── content: "image_path(\"icon.png\")"
     │   │                       │
-    │   │                       ├── close_quote: """ (location: (1:26)-(1:26))
-    │   │                       └── quoted: true
+    │   │                       ├── close_quote: ∅
+    │   │                       └── quoted: false
     │   │
     │   │
     │   │

--- a/test/snapshots/analyze/action_view/asset_tag_helper/image_tag_test/test_0009_image_tag_with_static_size_N_b7439b4cd2add9699ab71226110c31a9-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/asset_tag_helper/image_tag_test/test_0009_image_tag_with_static_size_N_b7439b4cd2add9699ab71226110c31a9-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -14,26 +14,6 @@ options: {action_view_helpers: true}
     │   │       ├── tag_closing: "%>" (location: (1:37)-(1:39))
     │   │       ├── tag_name: "img" (location: (1:4)-(1:13))
     │   │       └── children: (3 items)
-    │   │           ├── @ HTMLAttributeNode (location: (1:14)-(1:24))
-    │   │           │   ├── name:
-    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:14)-(1:24))
-    │   │           │   │       └── children: (1 item)
-    │   │           │   │           └── @ LiteralNode (location: (1:14)-(1:24))
-    │   │           │   │               └── content: "src"
-    │   │           │   │
-    │   │           │   │
-    │   │           │   ├── equals: ":" (location: (1:14)-(1:24))
-    │   │           │   └── value:
-    │   │           │       └── @ HTMLAttributeValueNode (location: (1:14)-(1:24))
-    │   │           │           ├── open_quote: ∅
-    │   │           │           ├── children: (1 item)
-    │   │           │           │   └── @ RubyLiteralNode (location: (1:14)-(1:24))
-    │   │           │           │       └── content: "image_path(\"icon.png\")"
-    │   │           │           │
-    │   │           │           ├── close_quote: ∅
-    │   │           │           └── quoted: false
-    │   │           │
-    │   │           │
     │   │           ├── @ HTMLAttributeNode (location: (1:26)-(1:26))
     │   │           │   ├── name:
     │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:26)-(1:26))
@@ -54,24 +34,44 @@ options: {action_view_helpers: true}
     │   │           │           └── quoted: true
     │   │           │
     │   │           │
-    │   │           └── @ HTMLAttributeNode (location: (1:26)-(1:26))
+    │   │           ├── @ HTMLAttributeNode (location: (1:26)-(1:26))
+    │   │           │   ├── name:
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:26)-(1:26))
+    │   │           │   │       └── children: (1 item)
+    │   │           │   │           └── @ LiteralNode (location: (1:26)-(1:26))
+    │   │           │   │               └── content: "height"
+    │   │           │   │
+    │   │           │   │
+    │   │           │   ├── equals: "=" (location: (1:26)-(1:26))
+    │   │           │   └── value:
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:26)-(1:26))
+    │   │           │           ├── open_quote: """ (location: (1:26)-(1:26))
+    │   │           │           ├── children: (1 item)
+    │   │           │           │   └── @ LiteralNode (location: (1:26)-(1:26))
+    │   │           │           │       └── content: "32"
+    │   │           │           │
+    │   │           │           ├── close_quote: """ (location: (1:26)-(1:26))
+    │   │           │           └── quoted: true
+    │   │           │
+    │   │           │
+    │   │           └── @ HTMLAttributeNode (location: (1:14)-(1:24))
     │   │               ├── name:
-    │   │               │   └── @ HTMLAttributeNameNode (location: (1:26)-(1:26))
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:14)-(1:24))
     │   │               │       └── children: (1 item)
-    │   │               │           └── @ LiteralNode (location: (1:26)-(1:26))
-    │   │               │               └── content: "height"
+    │   │               │           └── @ LiteralNode (location: (1:14)-(1:24))
+    │   │               │               └── content: "src"
     │   │               │
     │   │               │
-    │   │               ├── equals: "=" (location: (1:26)-(1:26))
+    │   │               ├── equals: ":" (location: (1:14)-(1:24))
     │   │               └── value:
-    │   │                   └── @ HTMLAttributeValueNode (location: (1:26)-(1:26))
-    │   │                       ├── open_quote: """ (location: (1:26)-(1:26))
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:14)-(1:24))
+    │   │                       ├── open_quote: ∅
     │   │                       ├── children: (1 item)
-    │   │                       │   └── @ LiteralNode (location: (1:26)-(1:26))
-    │   │                       │       └── content: "32"
+    │   │                       │   └── @ RubyLiteralNode (location: (1:14)-(1:24))
+    │   │                       │       └── content: "image_path(\"icon.png\")"
     │   │                       │
-    │   │                       ├── close_quote: """ (location: (1:26)-(1:26))
-    │   │                       └── quoted: true
+    │   │                       ├── close_quote: ∅
+    │   │                       └── quoted: false
     │   │
     │   │
     │   │

--- a/test/snapshots/analyze/action_view/asset_tag_helper/image_tag_test/test_0010_image_tag_with_dynamic_size_42a8ce9eb0ee2da32c39164a8b1755cd-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/asset_tag_helper/image_tag_test/test_0010_image_tag_with_dynamic_size_42a8ce9eb0ee2da32c39164a8b1755cd-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -14,26 +14,6 @@ options: {action_view_helpers: true}
     │   │       ├── tag_closing: "%>" (location: (1:41)-(1:43))
     │   │       ├── tag_name: "img" (location: (1:4)-(1:13))
     │   │       └── children: (3 items)
-    │   │           ├── @ HTMLAttributeNode (location: (1:14)-(1:24))
-    │   │           │   ├── name:
-    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:14)-(1:24))
-    │   │           │   │       └── children: (1 item)
-    │   │           │   │           └── @ LiteralNode (location: (1:14)-(1:24))
-    │   │           │   │               └── content: "src"
-    │   │           │   │
-    │   │           │   │
-    │   │           │   ├── equals: ":" (location: (1:14)-(1:24))
-    │   │           │   └── value:
-    │   │           │       └── @ HTMLAttributeValueNode (location: (1:14)-(1:24))
-    │   │           │           ├── open_quote: ∅
-    │   │           │           ├── children: (1 item)
-    │   │           │           │   └── @ RubyLiteralNode (location: (1:14)-(1:24))
-    │   │           │           │       └── content: "image_path(\"icon.png\")"
-    │   │           │           │
-    │   │           │           ├── close_quote: ∅
-    │   │           │           └── quoted: false
-    │   │           │
-    │   │           │
     │   │           ├── @ HTMLAttributeNode (location: (1:26)-(1:26))
     │   │           │   ├── name:
     │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:26)-(1:26))
@@ -54,21 +34,41 @@ options: {action_view_helpers: true}
     │   │           │           └── quoted: false
     │   │           │
     │   │           │
-    │   │           └── @ HTMLAttributeNode (location: (1:26)-(1:26))
+    │   │           ├── @ HTMLAttributeNode (location: (1:26)-(1:26))
+    │   │           │   ├── name:
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:26)-(1:26))
+    │   │           │   │       └── children: (1 item)
+    │   │           │   │           └── @ LiteralNode (location: (1:26)-(1:26))
+    │   │           │   │               └── content: "height"
+    │   │           │   │
+    │   │           │   │
+    │   │           │   ├── equals: ":" (location: (1:26)-(1:26))
+    │   │           │   └── value:
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:26)-(1:26))
+    │   │           │           ├── open_quote: ∅
+    │   │           │           ├── children: (1 item)
+    │   │           │           │   └── @ RubyLiteralNode (location: (1:26)-(1:26))
+    │   │           │           │       └── content: "some_var.to_s.split(\"x\", 2)[-1]"
+    │   │           │           │
+    │   │           │           ├── close_quote: ∅
+    │   │           │           └── quoted: false
+    │   │           │
+    │   │           │
+    │   │           └── @ HTMLAttributeNode (location: (1:14)-(1:24))
     │   │               ├── name:
-    │   │               │   └── @ HTMLAttributeNameNode (location: (1:26)-(1:26))
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:14)-(1:24))
     │   │               │       └── children: (1 item)
-    │   │               │           └── @ LiteralNode (location: (1:26)-(1:26))
-    │   │               │               └── content: "height"
+    │   │               │           └── @ LiteralNode (location: (1:14)-(1:24))
+    │   │               │               └── content: "src"
     │   │               │
     │   │               │
-    │   │               ├── equals: ":" (location: (1:26)-(1:26))
+    │   │               ├── equals: ":" (location: (1:14)-(1:24))
     │   │               └── value:
-    │   │                   └── @ HTMLAttributeValueNode (location: (1:26)-(1:26))
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:14)-(1:24))
     │   │                       ├── open_quote: ∅
     │   │                       ├── children: (1 item)
-    │   │                       │   └── @ RubyLiteralNode (location: (1:26)-(1:26))
-    │   │                       │       └── content: "some_var.to_s.split(\"x\", 2)[-1]"
+    │   │                       │   └── @ RubyLiteralNode (location: (1:14)-(1:24))
+    │   │                       │       └── content: "image_path(\"icon.png\")"
     │   │                       │
     │   │                       ├── close_quote: ∅
     │   │                       └── quoted: false

--- a/test/snapshots/analyze/action_view/asset_tag_helper/image_tag_test/test_0011_image_tag_with_size_and_other_attributes_c56689a70a92d3a82ca94b6cd1d3028f-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/asset_tag_helper/image_tag_test/test_0011_image_tag_with_size_and_other_attributes_c56689a70a92d3a82ca94b6cd1d3028f-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -14,26 +14,6 @@ options: {action_view_helpers: true}
     │   │       ├── tag_closing: "%>" (location: (1:70)-(1:72))
     │   │       ├── tag_name: "img" (location: (1:4)-(1:13))
     │   │       └── children: (5 items)
-    │   │           ├── @ HTMLAttributeNode (location: (1:14)-(1:24))
-    │   │           │   ├── name:
-    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:14)-(1:24))
-    │   │           │   │       └── children: (1 item)
-    │   │           │   │           └── @ LiteralNode (location: (1:14)-(1:24))
-    │   │           │   │               └── content: "src"
-    │   │           │   │
-    │   │           │   │
-    │   │           │   ├── equals: ":" (location: (1:14)-(1:24))
-    │   │           │   └── value:
-    │   │           │       └── @ HTMLAttributeValueNode (location: (1:14)-(1:24))
-    │   │           │           ├── open_quote: ∅
-    │   │           │           ├── children: (1 item)
-    │   │           │           │   └── @ RubyLiteralNode (location: (1:14)-(1:24))
-    │   │           │           │       └── content: "image_path(\"icon.png\")"
-    │   │           │           │
-    │   │           │           ├── close_quote: ∅
-    │   │           │           └── quoted: false
-    │   │           │
-    │   │           │
     │   │           ├── @ HTMLAttributeNode (location: (1:41)-(1:52))
     │   │           │   ├── name:
     │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:41)-(1:44))
@@ -94,24 +74,44 @@ options: {action_view_helpers: true}
     │   │           │           └── quoted: true
     │   │           │
     │   │           │
-    │   │           └── @ HTMLAttributeNode (location: (1:26)-(1:26))
+    │   │           ├── @ HTMLAttributeNode (location: (1:26)-(1:26))
+    │   │           │   ├── name:
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:26)-(1:26))
+    │   │           │   │       └── children: (1 item)
+    │   │           │   │           └── @ LiteralNode (location: (1:26)-(1:26))
+    │   │           │   │               └── content: "height"
+    │   │           │   │
+    │   │           │   │
+    │   │           │   ├── equals: "=" (location: (1:26)-(1:26))
+    │   │           │   └── value:
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:26)-(1:26))
+    │   │           │           ├── open_quote: """ (location: (1:26)-(1:26))
+    │   │           │           ├── children: (1 item)
+    │   │           │           │   └── @ LiteralNode (location: (1:26)-(1:26))
+    │   │           │           │       └── content: "32"
+    │   │           │           │
+    │   │           │           ├── close_quote: """ (location: (1:26)-(1:26))
+    │   │           │           └── quoted: true
+    │   │           │
+    │   │           │
+    │   │           └── @ HTMLAttributeNode (location: (1:14)-(1:24))
     │   │               ├── name:
-    │   │               │   └── @ HTMLAttributeNameNode (location: (1:26)-(1:26))
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:14)-(1:24))
     │   │               │       └── children: (1 item)
-    │   │               │           └── @ LiteralNode (location: (1:26)-(1:26))
-    │   │               │               └── content: "height"
+    │   │               │           └── @ LiteralNode (location: (1:14)-(1:24))
+    │   │               │               └── content: "src"
     │   │               │
     │   │               │
-    │   │               ├── equals: "=" (location: (1:26)-(1:26))
+    │   │               ├── equals: ":" (location: (1:14)-(1:24))
     │   │               └── value:
-    │   │                   └── @ HTMLAttributeValueNode (location: (1:26)-(1:26))
-    │   │                       ├── open_quote: """ (location: (1:26)-(1:26))
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:14)-(1:24))
+    │   │                       ├── open_quote: ∅
     │   │                       ├── children: (1 item)
-    │   │                       │   └── @ LiteralNode (location: (1:26)-(1:26))
-    │   │                       │       └── content: "32"
+    │   │                       │   └── @ RubyLiteralNode (location: (1:14)-(1:24))
+    │   │                       │       └── content: "image_path(\"icon.png\")"
     │   │                       │
-    │   │                       ├── close_quote: """ (location: (1:26)-(1:26))
-    │   │                       └── quoted: true
+    │   │                       ├── close_quote: ∅
+    │   │                       └── quoted: false
     │   │
     │   │
     │   │

--- a/test/snapshots/analyze/action_view/asset_tag_helper/java_script_include_tag_test/test_0003_javascript_include_tag_with_defer_3bfdc4f61b770eb2a3dc138c52381ba7-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/asset_tag_helper/java_script_include_tag_test/test_0003_javascript_include_tag_with_defer_3bfdc4f61b770eb2a3dc138c52381ba7-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -14,36 +14,36 @@ options: {action_view_helpers: true}
     │   │       ├── tag_closing: "%>" (location: (1:54)-(1:56))
     │   │       ├── tag_name: "script" (location: (1:4)-(1:26))
     │   │       └── children: (2 items)
-    │   │           ├── @ HTMLAttributeNode (location: (1:27)-(1:40))
+    │   │           ├── @ HTMLAttributeNode (location: (1:42)-(1:47))
     │   │           │   ├── name:
-    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:27)-(1:40))
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:42)-(1:47))
     │   │           │   │       └── children: (1 item)
-    │   │           │   │           └── @ LiteralNode (location: (1:27)-(1:40))
-    │   │           │   │               └── content: "src"
+    │   │           │   │           └── @ LiteralNode (location: (1:42)-(1:47))
+    │   │           │   │               └── content: "defer"
     │   │           │   │
     │   │           │   │
-    │   │           │   ├── equals: ":" (location: (1:27)-(1:40))
-    │   │           │   └── value:
-    │   │           │       └── @ HTMLAttributeValueNode (location: (1:27)-(1:40))
-    │   │           │           ├── open_quote: ∅
-    │   │           │           ├── children: (1 item)
-    │   │           │           │   └── @ RubyLiteralNode (location: (1:27)-(1:40))
-    │   │           │           │       └── content: "javascript_path(\"application\")"
-    │   │           │           │
-    │   │           │           ├── close_quote: ∅
-    │   │           │           └── quoted: false
+    │   │           │   ├── equals: ∅
+    │   │           │   └── value: ∅
     │   │           │
-    │   │           │
-    │   │           └── @ HTMLAttributeNode (location: (1:42)-(1:47))
+    │   │           └── @ HTMLAttributeNode (location: (1:27)-(1:40))
     │   │               ├── name:
-    │   │               │   └── @ HTMLAttributeNameNode (location: (1:42)-(1:47))
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:27)-(1:40))
     │   │               │       └── children: (1 item)
-    │   │               │           └── @ LiteralNode (location: (1:42)-(1:47))
-    │   │               │               └── content: "defer"
+    │   │               │           └── @ LiteralNode (location: (1:27)-(1:40))
+    │   │               │               └── content: "src"
     │   │               │
     │   │               │
-    │   │               ├── equals: ∅
-    │   │               └── value: ∅
+    │   │               ├── equals: ":" (location: (1:27)-(1:40))
+    │   │               └── value:
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:27)-(1:40))
+    │   │                       ├── open_quote: ∅
+    │   │                       ├── children: (1 item)
+    │   │                       │   └── @ RubyLiteralNode (location: (1:27)-(1:40))
+    │   │                       │       └── content: "javascript_path(\"application\")"
+    │   │                       │
+    │   │                       ├── close_quote: ∅
+    │   │                       └── quoted: false
+    │   │
     │   │
     │   │
     │   ├── tag_name: "script" (location: (1:4)-(1:26))

--- a/test/snapshots/analyze/action_view/asset_tag_helper/java_script_include_tag_test/test_0004_javascript_include_tag_with_nonce_true_4e9ac675501ab7d7b7f4b9cd0c549e49-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/asset_tag_helper/java_script_include_tag_test/test_0004_javascript_include_tag_with_nonce_true_4e9ac675501ab7d7b7f4b9cd0c549e49-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -14,41 +14,41 @@ options: {action_view_helpers: true}
     │   │       ├── tag_closing: "%>" (location: (1:54)-(1:56))
     │   │       ├── tag_name: "script" (location: (1:4)-(1:26))
     │   │       └── children: (2 items)
-    │   │           ├── @ HTMLAttributeNode (location: (1:27)-(1:40))
+    │   │           ├── @ HTMLAttributeNode (location: (1:42)-(1:53))
     │   │           │   ├── name:
-    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:27)-(1:40))
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:42)-(1:47))
     │   │           │   │       └── children: (1 item)
-    │   │           │   │           └── @ LiteralNode (location: (1:27)-(1:40))
-    │   │           │   │               └── content: "src"
+    │   │           │   │           └── @ LiteralNode (location: (1:42)-(1:47))
+    │   │           │   │               └── content: "nonce"
     │   │           │   │
     │   │           │   │
-    │   │           │   ├── equals: ":" (location: (1:27)-(1:40))
+    │   │           │   ├── equals: ": " (location: (1:47)-(1:49))
     │   │           │   └── value:
-    │   │           │       └── @ HTMLAttributeValueNode (location: (1:27)-(1:40))
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:49)-(1:53))
     │   │           │           ├── open_quote: ∅
     │   │           │           ├── children: (1 item)
-    │   │           │           │   └── @ RubyLiteralNode (location: (1:27)-(1:40))
-    │   │           │           │       └── content: "javascript_path(\"application\")"
+    │   │           │           │   └── @ RubyLiteralNode (location: (1:49)-(1:53))
+    │   │           │           │       └── content: "content_security_policy_nonce"
     │   │           │           │
     │   │           │           ├── close_quote: ∅
     │   │           │           └── quoted: false
     │   │           │
     │   │           │
-    │   │           └── @ HTMLAttributeNode (location: (1:42)-(1:53))
+    │   │           └── @ HTMLAttributeNode (location: (1:27)-(1:40))
     │   │               ├── name:
-    │   │               │   └── @ HTMLAttributeNameNode (location: (1:42)-(1:47))
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:27)-(1:40))
     │   │               │       └── children: (1 item)
-    │   │               │           └── @ LiteralNode (location: (1:42)-(1:47))
-    │   │               │               └── content: "nonce"
+    │   │               │           └── @ LiteralNode (location: (1:27)-(1:40))
+    │   │               │               └── content: "src"
     │   │               │
     │   │               │
-    │   │               ├── equals: ": " (location: (1:47)-(1:49))
+    │   │               ├── equals: ":" (location: (1:27)-(1:40))
     │   │               └── value:
-    │   │                   └── @ HTMLAttributeValueNode (location: (1:49)-(1:53))
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:27)-(1:40))
     │   │                       ├── open_quote: ∅
     │   │                       ├── children: (1 item)
-    │   │                       │   └── @ RubyLiteralNode (location: (1:49)-(1:53))
-    │   │                       │       └── content: "content_security_policy_nonce"
+    │   │                       │   └── @ RubyLiteralNode (location: (1:27)-(1:40))
+    │   │                       │       └── content: "javascript_path(\"application\")"
     │   │                       │
     │   │                       ├── close_quote: ∅
     │   │                       └── quoted: false

--- a/test/snapshots/analyze/action_view/asset_tag_helper/java_script_include_tag_test/test_0005_javascript_include_tag_with_data_attributes_fd42b1b34d860b548fb70621782b3714-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/asset_tag_helper/java_script_include_tag_test/test_0005_javascript_include_tag_with_data_attributes_fd42b1b34d860b548fb70621782b3714-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -14,44 +14,44 @@ options: {action_view_helpers: true}
     │   │       ├── tag_closing: "%>" (location: (1:74)-(1:76))
     │   │       ├── tag_name: "script" (location: (1:4)-(1:26))
     │   │       └── children: (2 items)
-    │   │           ├── @ HTMLAttributeNode (location: (1:27)-(1:40))
+    │   │           ├── @ HTMLAttributeNode (location: (1:50)-(1:71))
     │   │           │   ├── name:
-    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:27)-(1:40))
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:50)-(1:61))
     │   │           │   │       └── children: (1 item)
-    │   │           │   │           └── @ LiteralNode (location: (1:27)-(1:40))
-    │   │           │   │               └── content: "src"
+    │   │           │   │           └── @ LiteralNode (location: (1:50)-(1:61))
+    │   │           │   │               └── content: "data-turbo-track"
     │   │           │   │
     │   │           │   │
-    │   │           │   ├── equals: ":" (location: (1:27)-(1:40))
+    │   │           │   ├── equals: ": " (location: (1:61)-(1:63))
     │   │           │   └── value:
-    │   │           │       └── @ HTMLAttributeValueNode (location: (1:27)-(1:40))
-    │   │           │           ├── open_quote: ∅
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:63)-(1:71))
+    │   │           │           ├── open_quote: """ (location: (1:63)-(1:64))
     │   │           │           ├── children: (1 item)
-    │   │           │           │   └── @ RubyLiteralNode (location: (1:27)-(1:40))
-    │   │           │           │       └── content: "javascript_path(\"application\")"
+    │   │           │           │   └── @ LiteralNode (location: (1:64)-(1:70))
+    │   │           │           │       └── content: "reload"
     │   │           │           │
-    │   │           │           ├── close_quote: ∅
-    │   │           │           └── quoted: false
+    │   │           │           ├── close_quote: """ (location: (1:70)-(1:71))
+    │   │           │           └── quoted: true
     │   │           │
     │   │           │
-    │   │           └── @ HTMLAttributeNode (location: (1:50)-(1:71))
+    │   │           └── @ HTMLAttributeNode (location: (1:27)-(1:40))
     │   │               ├── name:
-    │   │               │   └── @ HTMLAttributeNameNode (location: (1:50)-(1:61))
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:27)-(1:40))
     │   │               │       └── children: (1 item)
-    │   │               │           └── @ LiteralNode (location: (1:50)-(1:61))
-    │   │               │               └── content: "data-turbo-track"
+    │   │               │           └── @ LiteralNode (location: (1:27)-(1:40))
+    │   │               │               └── content: "src"
     │   │               │
     │   │               │
-    │   │               ├── equals: ": " (location: (1:61)-(1:63))
+    │   │               ├── equals: ":" (location: (1:27)-(1:40))
     │   │               └── value:
-    │   │                   └── @ HTMLAttributeValueNode (location: (1:63)-(1:71))
-    │   │                       ├── open_quote: """ (location: (1:63)-(1:64))
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:27)-(1:40))
+    │   │                       ├── open_quote: ∅
     │   │                       ├── children: (1 item)
-    │   │                       │   └── @ LiteralNode (location: (1:64)-(1:70))
-    │   │                       │       └── content: "reload"
+    │   │                       │   └── @ RubyLiteralNode (location: (1:27)-(1:40))
+    │   │                       │       └── content: "javascript_path(\"application\")"
     │   │                       │
-    │   │                       ├── close_quote: """ (location: (1:70)-(1:71))
-    │   │                       └── quoted: true
+    │   │                       ├── close_quote: ∅
+    │   │                       └── quoted: false
     │   │
     │   │
     │   │

--- a/test/snapshots/analyze/action_view/asset_tag_helper/java_script_include_tag_test/test_0011_javascript_include_tag_with_URL_and_nonce_e6e5ca2ea1add00d7447893972171cd4-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/asset_tag_helper/java_script_include_tag_test/test_0011_javascript_include_tag_with_URL_and_nonce_e6e5ca2ea1add00d7447893972171cd4-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -14,44 +14,44 @@ options: {action_view_helpers: true}
     │   │       ├── tag_closing: "%>" (location: (1:74)-(1:76))
     │   │       ├── tag_name: "script" (location: (1:4)-(1:26))
     │   │       └── children: (2 items)
-    │   │           ├── @ HTMLAttributeNode (location: (1:27)-(1:60))
+    │   │           ├── @ HTMLAttributeNode (location: (1:62)-(1:73))
     │   │           │   ├── name:
-    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:27)-(1:60))
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:62)-(1:67))
     │   │           │   │       └── children: (1 item)
-    │   │           │   │           └── @ LiteralNode (location: (1:27)-(1:60))
-    │   │           │   │               └── content: "src"
+    │   │           │   │           └── @ LiteralNode (location: (1:62)-(1:67))
+    │   │           │   │               └── content: "nonce"
     │   │           │   │
     │   │           │   │
-    │   │           │   ├── equals: "=" (location: (1:27)-(1:60))
+    │   │           │   ├── equals: ": " (location: (1:67)-(1:69))
     │   │           │   └── value:
-    │   │           │       └── @ HTMLAttributeValueNode (location: (1:27)-(1:60))
-    │   │           │           ├── open_quote: """ (location: (1:27)-(1:27))
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:69)-(1:73))
+    │   │           │           ├── open_quote: ∅
     │   │           │           ├── children: (1 item)
-    │   │           │           │   └── @ LiteralNode (location: (1:27)-(1:60))
-    │   │           │           │       └── content: "http://www.example.com/xmlhr.js"
+    │   │           │           │   └── @ RubyLiteralNode (location: (1:69)-(1:73))
+    │   │           │           │       └── content: "content_security_policy_nonce"
     │   │           │           │
-    │   │           │           ├── close_quote: """ (location: (1:60)-(1:60))
-    │   │           │           └── quoted: true
+    │   │           │           ├── close_quote: ∅
+    │   │           │           └── quoted: false
     │   │           │
     │   │           │
-    │   │           └── @ HTMLAttributeNode (location: (1:62)-(1:73))
+    │   │           └── @ HTMLAttributeNode (location: (1:27)-(1:60))
     │   │               ├── name:
-    │   │               │   └── @ HTMLAttributeNameNode (location: (1:62)-(1:67))
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:27)-(1:60))
     │   │               │       └── children: (1 item)
-    │   │               │           └── @ LiteralNode (location: (1:62)-(1:67))
-    │   │               │               └── content: "nonce"
+    │   │               │           └── @ LiteralNode (location: (1:27)-(1:60))
+    │   │               │               └── content: "src"
     │   │               │
     │   │               │
-    │   │               ├── equals: ": " (location: (1:67)-(1:69))
+    │   │               ├── equals: "=" (location: (1:27)-(1:60))
     │   │               └── value:
-    │   │                   └── @ HTMLAttributeValueNode (location: (1:69)-(1:73))
-    │   │                       ├── open_quote: ∅
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:27)-(1:60))
+    │   │                       ├── open_quote: """ (location: (1:27)-(1:27))
     │   │                       ├── children: (1 item)
-    │   │                       │   └── @ RubyLiteralNode (location: (1:69)-(1:73))
-    │   │                       │       └── content: "content_security_policy_nonce"
+    │   │                       │   └── @ LiteralNode (location: (1:27)-(1:60))
+    │   │                       │       └── content: "http://www.example.com/xmlhr.js"
     │   │                       │
-    │   │                       ├── close_quote: ∅
-    │   │                       └── quoted: false
+    │   │                       ├── close_quote: """ (location: (1:60)-(1:60))
+    │   │                       └── quoted: true
     │   │
     │   │
     │   │

--- a/test/snapshots/analyze/action_view/asset_tag_helper/java_script_include_tag_test/test_0012_javascript_include_tag_with_URL_and_async_66c17a6412db1cd30d6f46bdbfc20e71-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/asset_tag_helper/java_script_include_tag_test/test_0012_javascript_include_tag_with_URL_and_async_66c17a6412db1cd30d6f46bdbfc20e71-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -14,36 +14,36 @@ options: {action_view_helpers: true}
     │   │       ├── tag_closing: "%>" (location: (1:74)-(1:76))
     │   │       ├── tag_name: "script" (location: (1:4)-(1:26))
     │   │       └── children: (2 items)
-    │   │           ├── @ HTMLAttributeNode (location: (1:27)-(1:60))
+    │   │           ├── @ HTMLAttributeNode (location: (1:62)-(1:67))
     │   │           │   ├── name:
-    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:27)-(1:60))
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:62)-(1:67))
     │   │           │   │       └── children: (1 item)
-    │   │           │   │           └── @ LiteralNode (location: (1:27)-(1:60))
-    │   │           │   │               └── content: "src"
+    │   │           │   │           └── @ LiteralNode (location: (1:62)-(1:67))
+    │   │           │   │               └── content: "async"
     │   │           │   │
     │   │           │   │
-    │   │           │   ├── equals: "=" (location: (1:27)-(1:60))
-    │   │           │   └── value:
-    │   │           │       └── @ HTMLAttributeValueNode (location: (1:27)-(1:60))
-    │   │           │           ├── open_quote: """ (location: (1:27)-(1:27))
-    │   │           │           ├── children: (1 item)
-    │   │           │           │   └── @ LiteralNode (location: (1:27)-(1:60))
-    │   │           │           │       └── content: "http://www.example.com/xmlhr.js"
-    │   │           │           │
-    │   │           │           ├── close_quote: """ (location: (1:60)-(1:60))
-    │   │           │           └── quoted: true
+    │   │           │   ├── equals: ∅
+    │   │           │   └── value: ∅
     │   │           │
-    │   │           │
-    │   │           └── @ HTMLAttributeNode (location: (1:62)-(1:67))
+    │   │           └── @ HTMLAttributeNode (location: (1:27)-(1:60))
     │   │               ├── name:
-    │   │               │   └── @ HTMLAttributeNameNode (location: (1:62)-(1:67))
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:27)-(1:60))
     │   │               │       └── children: (1 item)
-    │   │               │           └── @ LiteralNode (location: (1:62)-(1:67))
-    │   │               │               └── content: "async"
+    │   │               │           └── @ LiteralNode (location: (1:27)-(1:60))
+    │   │               │               └── content: "src"
     │   │               │
     │   │               │
-    │   │               ├── equals: ∅
-    │   │               └── value: ∅
+    │   │               ├── equals: "=" (location: (1:27)-(1:60))
+    │   │               └── value:
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:27)-(1:60))
+    │   │                       ├── open_quote: """ (location: (1:27)-(1:27))
+    │   │                       ├── children: (1 item)
+    │   │                       │   └── @ LiteralNode (location: (1:27)-(1:60))
+    │   │                       │       └── content: "http://www.example.com/xmlhr.js"
+    │   │                       │
+    │   │                       ├── close_quote: """ (location: (1:60)-(1:60))
+    │   │                       └── quoted: true
+    │   │
     │   │
     │   │
     │   ├── tag_name: "script" (location: (1:4)-(1:26))

--- a/test/snapshots/analyze/action_view/asset_tag_helper/java_script_include_tag_test/test_0013_javascript_include_tag_with_URL_and_defer_dd8c527689fccedcd61334018c4747bd-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/asset_tag_helper/java_script_include_tag_test/test_0013_javascript_include_tag_with_URL_and_defer_dd8c527689fccedcd61334018c4747bd-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -14,36 +14,36 @@ options: {action_view_helpers: true}
     │   │       ├── tag_closing: "%>" (location: (1:74)-(1:76))
     │   │       ├── tag_name: "script" (location: (1:4)-(1:26))
     │   │       └── children: (2 items)
-    │   │           ├── @ HTMLAttributeNode (location: (1:27)-(1:60))
+    │   │           ├── @ HTMLAttributeNode (location: (1:62)-(1:67))
     │   │           │   ├── name:
-    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:27)-(1:60))
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:62)-(1:67))
     │   │           │   │       └── children: (1 item)
-    │   │           │   │           └── @ LiteralNode (location: (1:27)-(1:60))
-    │   │           │   │               └── content: "src"
+    │   │           │   │           └── @ LiteralNode (location: (1:62)-(1:67))
+    │   │           │   │               └── content: "defer"
     │   │           │   │
     │   │           │   │
-    │   │           │   ├── equals: "=" (location: (1:27)-(1:60))
-    │   │           │   └── value:
-    │   │           │       └── @ HTMLAttributeValueNode (location: (1:27)-(1:60))
-    │   │           │           ├── open_quote: """ (location: (1:27)-(1:27))
-    │   │           │           ├── children: (1 item)
-    │   │           │           │   └── @ LiteralNode (location: (1:27)-(1:60))
-    │   │           │           │       └── content: "http://www.example.com/xmlhr.js"
-    │   │           │           │
-    │   │           │           ├── close_quote: """ (location: (1:60)-(1:60))
-    │   │           │           └── quoted: true
+    │   │           │   ├── equals: ∅
+    │   │           │   └── value: ∅
     │   │           │
-    │   │           │
-    │   │           └── @ HTMLAttributeNode (location: (1:62)-(1:67))
+    │   │           └── @ HTMLAttributeNode (location: (1:27)-(1:60))
     │   │               ├── name:
-    │   │               │   └── @ HTMLAttributeNameNode (location: (1:62)-(1:67))
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:27)-(1:60))
     │   │               │       └── children: (1 item)
-    │   │               │           └── @ LiteralNode (location: (1:62)-(1:67))
-    │   │               │               └── content: "defer"
+    │   │               │           └── @ LiteralNode (location: (1:27)-(1:60))
+    │   │               │               └── content: "src"
     │   │               │
     │   │               │
-    │   │               ├── equals: ∅
-    │   │               └── value: ∅
+    │   │               ├── equals: "=" (location: (1:27)-(1:60))
+    │   │               └── value:
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:27)-(1:60))
+    │   │                       ├── open_quote: """ (location: (1:27)-(1:27))
+    │   │                       ├── children: (1 item)
+    │   │                       │   └── @ LiteralNode (location: (1:27)-(1:60))
+    │   │                       │       └── content: "http://www.example.com/xmlhr.js"
+    │   │                       │
+    │   │                       ├── close_quote: """ (location: (1:60)-(1:60))
+    │   │                       └── quoted: true
+    │   │
     │   │
     │   │
     │   ├── tag_name: "script" (location: (1:4)-(1:26))

--- a/test/snapshots/analyze/action_view/asset_tag_helper/java_script_include_tag_test/test_0017_javascript_include_tag_with_defer_as_string_4c048dd6a94063b7c42f5a763359f534-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/asset_tag_helper/java_script_include_tag_test/test_0017_javascript_include_tag_with_defer_as_string_4c048dd6a94063b7c42f5a763359f534-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -14,44 +14,44 @@ options: {action_view_helpers: true}
     │   │       ├── tag_closing: "%>" (location: (1:56)-(1:58))
     │   │       ├── tag_name: "script" (location: (1:4)-(1:26))
     │   │       └── children: (2 items)
-    │   │           ├── @ HTMLAttributeNode (location: (1:27)-(1:40))
+    │   │           ├── @ HTMLAttributeNode (location: (1:42)-(1:55))
     │   │           │   ├── name:
-    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:27)-(1:40))
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:42)-(1:47))
     │   │           │   │       └── children: (1 item)
-    │   │           │   │           └── @ LiteralNode (location: (1:27)-(1:40))
-    │   │           │   │               └── content: "src"
+    │   │           │   │           └── @ LiteralNode (location: (1:42)-(1:47))
+    │   │           │   │               └── content: "defer"
     │   │           │   │
     │   │           │   │
-    │   │           │   ├── equals: ":" (location: (1:27)-(1:40))
+    │   │           │   ├── equals: ": " (location: (1:47)-(1:49))
     │   │           │   └── value:
-    │   │           │       └── @ HTMLAttributeValueNode (location: (1:27)-(1:40))
-    │   │           │           ├── open_quote: ∅
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:49)-(1:55))
+    │   │           │           ├── open_quote: """ (location: (1:49)-(1:50))
     │   │           │           ├── children: (1 item)
-    │   │           │           │   └── @ RubyLiteralNode (location: (1:27)-(1:40))
-    │   │           │           │       └── content: "javascript_path(\"application\")"
+    │   │           │           │   └── @ LiteralNode (location: (1:50)-(1:54))
+    │   │           │           │       └── content: "true"
     │   │           │           │
-    │   │           │           ├── close_quote: ∅
-    │   │           │           └── quoted: false
+    │   │           │           ├── close_quote: """ (location: (1:54)-(1:55))
+    │   │           │           └── quoted: true
     │   │           │
     │   │           │
-    │   │           └── @ HTMLAttributeNode (location: (1:42)-(1:55))
+    │   │           └── @ HTMLAttributeNode (location: (1:27)-(1:40))
     │   │               ├── name:
-    │   │               │   └── @ HTMLAttributeNameNode (location: (1:42)-(1:47))
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:27)-(1:40))
     │   │               │       └── children: (1 item)
-    │   │               │           └── @ LiteralNode (location: (1:42)-(1:47))
-    │   │               │               └── content: "defer"
+    │   │               │           └── @ LiteralNode (location: (1:27)-(1:40))
+    │   │               │               └── content: "src"
     │   │               │
     │   │               │
-    │   │               ├── equals: ": " (location: (1:47)-(1:49))
+    │   │               ├── equals: ":" (location: (1:27)-(1:40))
     │   │               └── value:
-    │   │                   └── @ HTMLAttributeValueNode (location: (1:49)-(1:55))
-    │   │                       ├── open_quote: """ (location: (1:49)-(1:50))
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:27)-(1:40))
+    │   │                       ├── open_quote: ∅
     │   │                       ├── children: (1 item)
-    │   │                       │   └── @ LiteralNode (location: (1:50)-(1:54))
-    │   │                       │       └── content: "true"
+    │   │                       │   └── @ RubyLiteralNode (location: (1:27)-(1:40))
+    │   │                       │       └── content: "javascript_path(\"application\")"
     │   │                       │
-    │   │                       ├── close_quote: """ (location: (1:54)-(1:55))
-    │   │                       └── quoted: true
+    │   │                       ├── close_quote: ∅
+    │   │                       └── quoted: false
     │   │
     │   │
     │   │

--- a/test/snapshots/analyze/action_view/asset_tag_helper/java_script_include_tag_test/test_0018_javascript_include_tag_with_interpolated_nonce_648fad9a18f31eddcce31571252a280c-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/asset_tag_helper/java_script_include_tag_test/test_0018_javascript_include_tag_with_interpolated_nonce_648fad9a18f31eddcce31571252a280c-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -14,44 +14,44 @@ options: {action_view_helpers: true}
     │   │       ├── tag_closing: "%>" (location: (1:69)-(1:71))
     │   │       ├── tag_name: "script" (location: (1:4)-(1:26))
     │   │       └── children: (2 items)
-    │   │           ├── @ HTMLAttributeNode (location: (1:27)-(1:40))
+    │   │           ├── @ HTMLAttributeNode (location: (1:42)-(1:68))
     │   │           │   ├── name:
-    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:27)-(1:40))
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:42)-(1:68))
     │   │           │   │       └── children: (1 item)
-    │   │           │   │           └── @ LiteralNode (location: (1:27)-(1:40))
-    │   │           │   │               └── content: "src"
+    │   │           │   │           └── @ LiteralNode (location: (1:42)-(1:68))
+    │   │           │   │               └── content: "nonce"
     │   │           │   │
     │   │           │   │
-    │   │           │   ├── equals: ":" (location: (1:27)-(1:40))
+    │   │           │   ├── equals: "=" (location: (1:42)-(1:68))
     │   │           │   └── value:
-    │   │           │       └── @ HTMLAttributeValueNode (location: (1:27)-(1:40))
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:42)-(1:68))
     │   │           │           ├── open_quote: ∅
-    │   │           │           ├── children: (1 item)
-    │   │           │           │   └── @ RubyLiteralNode (location: (1:27)-(1:40))
-    │   │           │           │       └── content: "javascript_path(\"application\")"
+    │   │           │           ├── children: (2 items)
+    │   │           │           │   ├── @ LiteralNode (location: (1:42)-(1:68))
+    │   │           │           │   │   └── content: "static-"
+    │   │           │           │   │
+    │   │           │           │   └── @ RubyLiteralNode (location: (1:42)-(1:68))
+    │   │           │           │       └── content: "dynamic"
     │   │           │           │
     │   │           │           ├── close_quote: ∅
     │   │           │           └── quoted: false
     │   │           │
     │   │           │
-    │   │           └── @ HTMLAttributeNode (location: (1:42)-(1:68))
+    │   │           └── @ HTMLAttributeNode (location: (1:27)-(1:40))
     │   │               ├── name:
-    │   │               │   └── @ HTMLAttributeNameNode (location: (1:42)-(1:68))
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:27)-(1:40))
     │   │               │       └── children: (1 item)
-    │   │               │           └── @ LiteralNode (location: (1:42)-(1:68))
-    │   │               │               └── content: "nonce"
+    │   │               │           └── @ LiteralNode (location: (1:27)-(1:40))
+    │   │               │               └── content: "src"
     │   │               │
     │   │               │
-    │   │               ├── equals: "=" (location: (1:42)-(1:68))
+    │   │               ├── equals: ":" (location: (1:27)-(1:40))
     │   │               └── value:
-    │   │                   └── @ HTMLAttributeValueNode (location: (1:42)-(1:68))
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:27)-(1:40))
     │   │                       ├── open_quote: ∅
-    │   │                       ├── children: (2 items)
-    │   │                       │   ├── @ LiteralNode (location: (1:42)-(1:68))
-    │   │                       │   │   └── content: "static-"
-    │   │                       │   │
-    │   │                       │   └── @ RubyLiteralNode (location: (1:42)-(1:68))
-    │   │                       │       └── content: "dynamic"
+    │   │                       ├── children: (1 item)
+    │   │                       │   └── @ RubyLiteralNode (location: (1:27)-(1:40))
+    │   │                       │       └── content: "javascript_path(\"application\")"
     │   │                       │
     │   │                       ├── close_quote: ∅
     │   │                       └── quoted: false

--- a/test/snapshots/analyze/action_view/tag_helper/turbo_frame_tag_test/test_0005_turbo_frame_tag_with_loading_lazy_3873b60a7854be0ab998716afea66db8-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/turbo_frame_tag_test/test_0005_turbo_frame_tag_with_loading_lazy_3873b60a7854be0ab998716afea66db8-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -14,6 +14,26 @@ options: {action_view_helpers: true}
     │   │       ├── tag_closing: "%>" (location: (1:66)-(1:68))
     │   │       ├── tag_name: "turbo-frame" (location: (1:4)-(1:19))
     │   │       └── children: (3 items)
+    │   │           ├── @ HTMLAttributeNode (location: (1:50)-(1:65))
+    │   │           │   ├── name:
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:50)-(1:57))
+    │   │           │   │       └── children: (1 item)
+    │   │           │   │           └── @ LiteralNode (location: (1:50)-(1:57))
+    │   │           │   │               └── content: "loading"
+    │   │           │   │
+    │   │           │   │
+    │   │           │   ├── equals: ": " (location: (1:57)-(1:59))
+    │   │           │   └── value:
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:59)-(1:65))
+    │   │           │           ├── open_quote: """ (location: (1:59)-(1:60))
+    │   │           │           ├── children: (1 item)
+    │   │           │           │   └── @ LiteralNode (location: (1:60)-(1:64))
+    │   │           │           │       └── content: "lazy"
+    │   │           │           │
+    │   │           │           ├── close_quote: """ (location: (1:64)-(1:65))
+    │   │           │           └── quoted: true
+    │   │           │
+    │   │           │
     │   │           ├── @ HTMLAttributeNode (location: (1:20)-(1:26))
     │   │           │   ├── name:
     │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:20)-(1:26))
@@ -34,44 +54,24 @@ options: {action_view_helpers: true}
     │   │           │           └── quoted: true
     │   │           │
     │   │           │
-    │   │           ├── @ HTMLAttributeNode (location: (1:28)-(1:48))
-    │   │           │   ├── name:
-    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:28)-(1:31))
-    │   │           │   │       └── children: (1 item)
-    │   │           │   │           └── @ LiteralNode (location: (1:28)-(1:31))
-    │   │           │   │               └── content: "src"
-    │   │           │   │
-    │   │           │   │
-    │   │           │   ├── equals: ": " (location: (1:31)-(1:33))
-    │   │           │   └── value:
-    │   │           │       └── @ HTMLAttributeValueNode (location: (1:33)-(1:48))
-    │   │           │           ├── open_quote: ∅
-    │   │           │           ├── children: (1 item)
-    │   │           │           │   └── @ RubyLiteralNode (location: (1:33)-(1:48))
-    │   │           │           │       └── content: "tray_path(tray)"
-    │   │           │           │
-    │   │           │           ├── close_quote: ∅
-    │   │           │           └── quoted: false
-    │   │           │
-    │   │           │
-    │   │           └── @ HTMLAttributeNode (location: (1:50)-(1:65))
+    │   │           └── @ HTMLAttributeNode (location: (1:28)-(1:48))
     │   │               ├── name:
-    │   │               │   └── @ HTMLAttributeNameNode (location: (1:50)-(1:57))
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:28)-(1:31))
     │   │               │       └── children: (1 item)
-    │   │               │           └── @ LiteralNode (location: (1:50)-(1:57))
-    │   │               │               └── content: "loading"
+    │   │               │           └── @ LiteralNode (location: (1:28)-(1:31))
+    │   │               │               └── content: "src"
     │   │               │
     │   │               │
-    │   │               ├── equals: ": " (location: (1:57)-(1:59))
+    │   │               ├── equals: ": " (location: (1:31)-(1:33))
     │   │               └── value:
-    │   │                   └── @ HTMLAttributeValueNode (location: (1:59)-(1:65))
-    │   │                       ├── open_quote: """ (location: (1:59)-(1:60))
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:33)-(1:48))
+    │   │                       ├── open_quote: ∅
     │   │                       ├── children: (1 item)
-    │   │                       │   └── @ LiteralNode (location: (1:60)-(1:64))
-    │   │                       │       └── content: "lazy"
+    │   │                       │   └── @ RubyLiteralNode (location: (1:33)-(1:48))
+    │   │                       │       └── content: "tray_path(tray)"
     │   │                       │
-    │   │                       ├── close_quote: """ (location: (1:64)-(1:65))
-    │   │                       └── quoted: true
+    │   │                       ├── close_quote: ∅
+    │   │                       └── quoted: false
     │   │
     │   │
     │   │

--- a/test/snapshots/analyze/action_view/tag_helper/turbo_frame_tag_test/test_0007_turbo_frame_tag_with_class_attribute_3ea1bbf5e8a22ee640842e87a237075e-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/turbo_frame_tag_test/test_0007_turbo_frame_tag_with_class_attribute_3ea1bbf5e8a22ee640842e87a237075e-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -16,43 +16,43 @@ options: {action_view_helpers: true}
     │   │       ├── tag_closing: "%>" (location: (1:46)-(1:48))
     │   │       ├── tag_name: "turbo-frame" (location: (1:4)-(1:19))
     │   │       └── children: (2 items)
-    │   │           ├── @ HTMLAttributeNode (location: (1:20)-(1:26))
+    │   │           ├── @ HTMLAttributeNode (location: (1:28)-(1:42))
     │   │           │   ├── name:
-    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:20)-(1:26))
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:28)-(1:33))
     │   │           │   │       └── children: (1 item)
-    │   │           │   │           └── @ LiteralNode (location: (1:20)-(1:26))
-    │   │           │   │               └── content: "id"
+    │   │           │   │           └── @ LiteralNode (location: (1:28)-(1:33))
+    │   │           │   │               └── content: "class"
     │   │           │   │
     │   │           │   │
-    │   │           │   ├── equals: "=" (location: (1:20)-(1:26))
+    │   │           │   ├── equals: ": " (location: (1:33)-(1:35))
     │   │           │   └── value:
-    │   │           │       └── @ HTMLAttributeValueNode (location: (1:20)-(1:26))
-    │   │           │           ├── open_quote: """ (location: (1:20)-(1:20))
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:35)-(1:42))
+    │   │           │           ├── open_quote: """ (location: (1:35)-(1:36))
     │   │           │           ├── children: (1 item)
-    │   │           │           │   └── @ LiteralNode (location: (1:20)-(1:26))
-    │   │           │           │       └── content: "tray"
+    │   │           │           │   └── @ LiteralNode (location: (1:36)-(1:41))
+    │   │           │           │       └── content: "frame"
     │   │           │           │
-    │   │           │           ├── close_quote: """ (location: (1:26)-(1:26))
+    │   │           │           ├── close_quote: """ (location: (1:41)-(1:42))
     │   │           │           └── quoted: true
     │   │           │
     │   │           │
-    │   │           └── @ HTMLAttributeNode (location: (1:28)-(1:42))
+    │   │           └── @ HTMLAttributeNode (location: (1:20)-(1:26))
     │   │               ├── name:
-    │   │               │   └── @ HTMLAttributeNameNode (location: (1:28)-(1:33))
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:20)-(1:26))
     │   │               │       └── children: (1 item)
-    │   │               │           └── @ LiteralNode (location: (1:28)-(1:33))
-    │   │               │               └── content: "class"
+    │   │               │           └── @ LiteralNode (location: (1:20)-(1:26))
+    │   │               │               └── content: "id"
     │   │               │
     │   │               │
-    │   │               ├── equals: ": " (location: (1:33)-(1:35))
+    │   │               ├── equals: "=" (location: (1:20)-(1:26))
     │   │               └── value:
-    │   │                   └── @ HTMLAttributeValueNode (location: (1:35)-(1:42))
-    │   │                       ├── open_quote: """ (location: (1:35)-(1:36))
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:20)-(1:26))
+    │   │                       ├── open_quote: """ (location: (1:20)-(1:20))
     │   │                       ├── children: (1 item)
-    │   │                       │   └── @ LiteralNode (location: (1:36)-(1:41))
-    │   │                       │       └── content: "frame"
+    │   │                       │   └── @ LiteralNode (location: (1:20)-(1:26))
+    │   │                       │       └── content: "tray"
     │   │                       │
-    │   │                       ├── close_quote: """ (location: (1:41)-(1:42))
+    │   │                       ├── close_quote: """ (location: (1:26)-(1:26))
     │   │                       └── quoted: true
     │   │
     │   │

--- a/test/snapshots/analyze/action_view/tag_helper/turbo_frame_tag_test/test_0008_turbo_frame_tag_with_data_attributes_f5a9f46c018293416bb2ffe68fc80893-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/turbo_frame_tag_test/test_0008_turbo_frame_tag_with_data_attributes_f5a9f46c018293416bb2ffe68fc80893-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -16,26 +16,6 @@ options: {action_view_helpers: true}
     │   │       ├── tag_closing: "%>" (location: (1:90)-(1:92))
     │   │       ├── tag_name: "turbo-frame" (location: (1:4)-(1:19))
     │   │       └── children: (3 items)
-    │   │           ├── @ HTMLAttributeNode (location: (1:20)-(1:26))
-    │   │           │   ├── name:
-    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:20)-(1:26))
-    │   │           │   │       └── children: (1 item)
-    │   │           │   │           └── @ LiteralNode (location: (1:20)-(1:26))
-    │   │           │   │               └── content: "id"
-    │   │           │   │
-    │   │           │   │
-    │   │           │   ├── equals: "=" (location: (1:20)-(1:26))
-    │   │           │   └── value:
-    │   │           │       └── @ HTMLAttributeValueNode (location: (1:20)-(1:26))
-    │   │           │           ├── open_quote: """ (location: (1:20)-(1:20))
-    │   │           │           ├── children: (1 item)
-    │   │           │           │   └── @ LiteralNode (location: (1:20)-(1:26))
-    │   │           │           │       └── content: "tray"
-    │   │           │           │
-    │   │           │           ├── close_quote: """ (location: (1:26)-(1:26))
-    │   │           │           └── quoted: true
-    │   │           │
-    │   │           │
     │   │           ├── @ HTMLAttributeNode (location: (1:36)-(1:55))
     │   │           │   ├── name:
     │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:36)-(1:46))
@@ -56,23 +36,43 @@ options: {action_view_helpers: true}
     │   │           │           └── quoted: true
     │   │           │
     │   │           │
-    │   │           └── @ HTMLAttributeNode (location: (1:57)-(1:84))
+    │   │           ├── @ HTMLAttributeNode (location: (1:57)-(1:84))
+    │   │           │   ├── name:
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:57)-(1:63))
+    │   │           │   │       └── children: (1 item)
+    │   │           │   │           └── @ LiteralNode (location: (1:57)-(1:63))
+    │   │           │   │               └── content: "data-action"
+    │   │           │   │
+    │   │           │   │
+    │   │           │   ├── equals: ": " (location: (1:63)-(1:65))
+    │   │           │   └── value:
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:65)-(1:84))
+    │   │           │           ├── open_quote: """ (location: (1:65)-(1:66))
+    │   │           │           ├── children: (1 item)
+    │   │           │           │   └── @ LiteralNode (location: (1:66)-(1:83))
+    │   │           │           │       └── content: "click->frame#load"
+    │   │           │           │
+    │   │           │           ├── close_quote: """ (location: (1:83)-(1:84))
+    │   │           │           └── quoted: true
+    │   │           │
+    │   │           │
+    │   │           └── @ HTMLAttributeNode (location: (1:20)-(1:26))
     │   │               ├── name:
-    │   │               │   └── @ HTMLAttributeNameNode (location: (1:57)-(1:63))
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:20)-(1:26))
     │   │               │       └── children: (1 item)
-    │   │               │           └── @ LiteralNode (location: (1:57)-(1:63))
-    │   │               │               └── content: "data-action"
+    │   │               │           └── @ LiteralNode (location: (1:20)-(1:26))
+    │   │               │               └── content: "id"
     │   │               │
     │   │               │
-    │   │               ├── equals: ": " (location: (1:63)-(1:65))
+    │   │               ├── equals: "=" (location: (1:20)-(1:26))
     │   │               └── value:
-    │   │                   └── @ HTMLAttributeValueNode (location: (1:65)-(1:84))
-    │   │                       ├── open_quote: """ (location: (1:65)-(1:66))
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:20)-(1:26))
+    │   │                       ├── open_quote: """ (location: (1:20)-(1:20))
     │   │                       ├── children: (1 item)
-    │   │                       │   └── @ LiteralNode (location: (1:66)-(1:83))
-    │   │                       │       └── content: "click->frame#load"
+    │   │                       │   └── @ LiteralNode (location: (1:20)-(1:26))
+    │   │                       │       └── content: "tray"
     │   │                       │
-    │   │                       ├── close_quote: """ (location: (1:83)-(1:84))
+    │   │                       ├── close_quote: """ (location: (1:26)-(1:26))
     │   │                       └── quoted: true
     │   │
     │   │

--- a/test/snapshots/analyze/action_view/tag_helper/turbo_frame_tag_test/test_0010_turbo_frame_tag_with_attributes_splat_df5fcd88eeb491a403b626e1ee216ab6-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/turbo_frame_tag_test/test_0010_turbo_frame_tag_with_attributes_splat_df5fcd88eeb491a403b626e1ee216ab6-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -16,29 +16,29 @@ options: {action_view_helpers: true}
     │   │       ├── tag_closing: "%>" (location: (1:44)-(1:46))
     │   │       ├── tag_name: "turbo-frame" (location: (1:4)-(1:19))
     │   │       └── children: (2 items)
-    │   │           ├── @ HTMLAttributeNode (location: (1:20)-(1:26))
-    │   │           │   ├── name:
-    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:20)-(1:26))
-    │   │           │   │       └── children: (1 item)
-    │   │           │   │           └── @ LiteralNode (location: (1:20)-(1:26))
-    │   │           │   │               └── content: "id"
-    │   │           │   │
-    │   │           │   │
-    │   │           │   ├── equals: "=" (location: (1:20)-(1:26))
-    │   │           │   └── value:
-    │   │           │       └── @ HTMLAttributeValueNode (location: (1:20)-(1:26))
-    │   │           │           ├── open_quote: """ (location: (1:20)-(1:20))
-    │   │           │           ├── children: (1 item)
-    │   │           │           │   └── @ LiteralNode (location: (1:20)-(1:26))
-    │   │           │           │       └── content: "tray"
-    │   │           │           │
-    │   │           │           ├── close_quote: """ (location: (1:26)-(1:26))
-    │   │           │           └── quoted: true
+    │   │           ├── @ RubyHTMLAttributesSplatNode (location: (1:28)-(1:28))
+    │   │           │   ├── content: "tag.attributes(**attributes)"
+    │   │           │   └── prefix: ""
     │   │           │
-    │   │           │
-    │   │           └── @ RubyHTMLAttributesSplatNode (location: (1:28)-(1:28))
-    │   │               ├── content: "tag.attributes(**attributes)"
-    │   │               └── prefix: ""
+    │   │           └── @ HTMLAttributeNode (location: (1:20)-(1:26))
+    │   │               ├── name:
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:20)-(1:26))
+    │   │               │       └── children: (1 item)
+    │   │               │           └── @ LiteralNode (location: (1:20)-(1:26))
+    │   │               │               └── content: "id"
+    │   │               │
+    │   │               │
+    │   │               ├── equals: "=" (location: (1:20)-(1:26))
+    │   │               └── value:
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:20)-(1:26))
+    │   │                       ├── open_quote: """ (location: (1:20)-(1:20))
+    │   │                       ├── children: (1 item)
+    │   │                       │   └── @ LiteralNode (location: (1:20)-(1:26))
+    │   │                       │       └── content: "tray"
+    │   │                       │
+    │   │                       ├── close_quote: """ (location: (1:26)-(1:26))
+    │   │                       └── quoted: true
+    │   │
     │   │
     │   │
     │   ├── tag_name: "turbo-frame" (location: (1:4)-(1:19))

--- a/test/snapshots/analyze/action_view/url_helper/link_to_test/test_0002_link_to_with_html_options_78b74bf8d70e0640868d80536a0c3786-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/url_helper/link_to_test/test_0002_link_to_with_html_options_78b74bf8d70e0640868d80536a0c3786-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -14,43 +14,43 @@ options: {action_view_helpers: true}
     │   │       ├── tag_closing: "%>" (location: (1:46)-(1:48))
     │   │       ├── tag_name: "a" (location: (1:4)-(1:11))
     │   │       └── children: (2 items)
-    │   │           ├── @ HTMLAttributeNode (location: (1:24)-(1:27))
+    │   │           ├── @ HTMLAttributeNode (location: (1:29)-(1:45))
     │   │           │   ├── name:
-    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:24)-(1:27))
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:29)-(1:34))
     │   │           │   │       └── children: (1 item)
-    │   │           │   │           └── @ LiteralNode (location: (1:24)-(1:27))
-    │   │           │   │               └── content: "href"
+    │   │           │   │           └── @ LiteralNode (location: (1:29)-(1:34))
+    │   │           │   │               └── content: "class"
     │   │           │   │
     │   │           │   │
-    │   │           │   ├── equals: "=" (location: (1:24)-(1:27))
+    │   │           │   ├── equals: ": " (location: (1:34)-(1:36))
     │   │           │   └── value:
-    │   │           │       └── @ HTMLAttributeValueNode (location: (1:24)-(1:27))
-    │   │           │           ├── open_quote: """ (location: (1:24)-(1:24))
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:36)-(1:45))
+    │   │           │           ├── open_quote: """ (location: (1:36)-(1:37))
     │   │           │           ├── children: (1 item)
-    │   │           │           │   └── @ LiteralNode (location: (1:24)-(1:27))
-    │   │           │           │       └── content: "#"
+    │   │           │           │   └── @ LiteralNode (location: (1:37)-(1:44))
+    │   │           │           │       └── content: "example"
     │   │           │           │
-    │   │           │           ├── close_quote: """ (location: (1:27)-(1:27))
+    │   │           │           ├── close_quote: """ (location: (1:44)-(1:45))
     │   │           │           └── quoted: true
     │   │           │
     │   │           │
-    │   │           └── @ HTMLAttributeNode (location: (1:29)-(1:45))
+    │   │           └── @ HTMLAttributeNode (location: (1:24)-(1:27))
     │   │               ├── name:
-    │   │               │   └── @ HTMLAttributeNameNode (location: (1:29)-(1:34))
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:24)-(1:27))
     │   │               │       └── children: (1 item)
-    │   │               │           └── @ LiteralNode (location: (1:29)-(1:34))
-    │   │               │               └── content: "class"
+    │   │               │           └── @ LiteralNode (location: (1:24)-(1:27))
+    │   │               │               └── content: "href"
     │   │               │
     │   │               │
-    │   │               ├── equals: ": " (location: (1:34)-(1:36))
+    │   │               ├── equals: "=" (location: (1:24)-(1:27))
     │   │               └── value:
-    │   │                   └── @ HTMLAttributeValueNode (location: (1:36)-(1:45))
-    │   │                       ├── open_quote: """ (location: (1:36)-(1:37))
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:24)-(1:27))
+    │   │                       ├── open_quote: """ (location: (1:24)-(1:24))
     │   │                       ├── children: (1 item)
-    │   │                       │   └── @ LiteralNode (location: (1:37)-(1:44))
-    │   │                       │       └── content: "example"
+    │   │                       │   └── @ LiteralNode (location: (1:24)-(1:27))
+    │   │                       │       └── content: "#"
     │   │                       │
-    │   │                       ├── close_quote: """ (location: (1:44)-(1:45))
+    │   │                       ├── close_quote: """ (location: (1:27)-(1:27))
     │   │                       └── quoted: true
     │   │
     │   │

--- a/test/snapshots/analyze/action_view/url_helper/link_to_test/test_0005_link_to_with_method_05afcd9ff3288ff96de215f6df72ad0a-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/url_helper/link_to_test/test_0005_link_to_with_method_05afcd9ff3288ff96de215f6df72ad0a-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -14,26 +14,6 @@ options: {action_view_helpers: true}
     │   │       ├── tag_closing: "%>" (location: (1:50)-(1:52))
     │   │       ├── tag_name: "a" (location: (1:4)-(1:11))
     │   │       └── children: (3 items)
-    │   │           ├── @ HTMLAttributeNode (location: (1:22)-(1:31))
-    │   │           │   ├── name:
-    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:22)-(1:31))
-    │   │           │   │       └── children: (1 item)
-    │   │           │   │           └── @ LiteralNode (location: (1:22)-(1:31))
-    │   │           │   │               └── content: "href"
-    │   │           │   │
-    │   │           │   │
-    │   │           │   ├── equals: ":" (location: (1:22)-(1:31))
-    │   │           │   └── value:
-    │   │           │       └── @ HTMLAttributeValueNode (location: (1:22)-(1:31))
-    │   │           │           ├── open_quote: ∅
-    │   │           │           ├── children: (1 item)
-    │   │           │           │   └── @ RubyLiteralNode (location: (1:22)-(1:31))
-    │   │           │           │       └── content: "root_path"
-    │   │           │           │
-    │   │           │           ├── close_quote: ∅
-    │   │           │           └── quoted: false
-    │   │           │
-    │   │           │
     │   │           ├── @ HTMLAttributeNode (location: (1:33)-(1:49))
     │   │           │   ├── name:
     │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:33)-(1:39))
@@ -54,24 +34,44 @@ options: {action_view_helpers: true}
     │   │           │           └── quoted: true
     │   │           │
     │   │           │
-    │   │           └── @ HTMLAttributeNode (location: (1:0)-(1:0))
+    │   │           ├── @ HTMLAttributeNode (location: (1:0)-(1:0))
+    │   │           │   ├── name:
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:0)-(1:0))
+    │   │           │   │       └── children: (1 item)
+    │   │           │   │           └── @ LiteralNode (location: (1:0)-(1:0))
+    │   │           │   │               └── content: "rel"
+    │   │           │   │
+    │   │           │   │
+    │   │           │   ├── equals: "=" (location: (1:0)-(1:0))
+    │   │           │   └── value:
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:0)-(1:0))
+    │   │           │           ├── open_quote: """ (location: (1:0)-(1:0))
+    │   │           │           ├── children: (1 item)
+    │   │           │           │   └── @ LiteralNode (location: (1:0)-(1:0))
+    │   │           │           │       └── content: "nofollow"
+    │   │           │           │
+    │   │           │           ├── close_quote: """ (location: (1:0)-(1:0))
+    │   │           │           └── quoted: true
+    │   │           │
+    │   │           │
+    │   │           └── @ HTMLAttributeNode (location: (1:22)-(1:31))
     │   │               ├── name:
-    │   │               │   └── @ HTMLAttributeNameNode (location: (1:0)-(1:0))
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:22)-(1:31))
     │   │               │       └── children: (1 item)
-    │   │               │           └── @ LiteralNode (location: (1:0)-(1:0))
-    │   │               │               └── content: "rel"
+    │   │               │           └── @ LiteralNode (location: (1:22)-(1:31))
+    │   │               │               └── content: "href"
     │   │               │
     │   │               │
-    │   │               ├── equals: "=" (location: (1:0)-(1:0))
+    │   │               ├── equals: ":" (location: (1:22)-(1:31))
     │   │               └── value:
-    │   │                   └── @ HTMLAttributeValueNode (location: (1:0)-(1:0))
-    │   │                       ├── open_quote: """ (location: (1:0)-(1:0))
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:22)-(1:31))
+    │   │                       ├── open_quote: ∅
     │   │                       ├── children: (1 item)
-    │   │                       │   └── @ LiteralNode (location: (1:0)-(1:0))
-    │   │                       │       └── content: "nofollow"
+    │   │                       │   └── @ RubyLiteralNode (location: (1:22)-(1:31))
+    │   │                       │       └── content: "root_path"
     │   │                       │
-    │   │                       ├── close_quote: """ (location: (1:0)-(1:0))
-    │   │                       └── quoted: true
+    │   │                       ├── close_quote: ∅
+    │   │                       └── quoted: false
     │   │
     │   │
     │   │

--- a/test/snapshots/analyze/action_view/url_helper/link_to_test/test_0006_link_to_with_confirm_1fb37cc733a8ebaa5e62756c2786a145-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/url_helper/link_to_test/test_0006_link_to_with_confirm_1fb37cc733a8ebaa5e62756c2786a145-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -14,44 +14,44 @@ options: {action_view_helpers: true}
     │   │       ├── tag_closing: "%>" (location: (1:68)-(1:70))
     │   │       ├── tag_name: "a" (location: (1:4)-(1:11))
     │   │       └── children: (2 items)
-    │   │           ├── @ HTMLAttributeNode (location: (1:22)-(1:31))
+    │   │           ├── @ HTMLAttributeNode (location: (1:41)-(1:65))
     │   │           │   ├── name:
-    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:22)-(1:31))
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:41)-(1:48))
     │   │           │   │       └── children: (1 item)
-    │   │           │   │           └── @ LiteralNode (location: (1:22)-(1:31))
-    │   │           │   │               └── content: "href"
+    │   │           │   │           └── @ LiteralNode (location: (1:41)-(1:48))
+    │   │           │   │               └── content: "data-confirm"
     │   │           │   │
     │   │           │   │
-    │   │           │   ├── equals: ":" (location: (1:22)-(1:31))
+    │   │           │   ├── equals: ": " (location: (1:48)-(1:50))
     │   │           │   └── value:
-    │   │           │       └── @ HTMLAttributeValueNode (location: (1:22)-(1:31))
-    │   │           │           ├── open_quote: ∅
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:50)-(1:65))
+    │   │           │           ├── open_quote: """ (location: (1:50)-(1:51))
     │   │           │           ├── children: (1 item)
-    │   │           │           │   └── @ RubyLiteralNode (location: (1:22)-(1:31))
-    │   │           │           │       └── content: "root_path"
+    │   │           │           │   └── @ LiteralNode (location: (1:51)-(1:64))
+    │   │           │           │       └── content: "Are you sure?"
     │   │           │           │
-    │   │           │           ├── close_quote: ∅
-    │   │           │           └── quoted: false
+    │   │           │           ├── close_quote: """ (location: (1:64)-(1:65))
+    │   │           │           └── quoted: true
     │   │           │
     │   │           │
-    │   │           └── @ HTMLAttributeNode (location: (1:41)-(1:65))
+    │   │           └── @ HTMLAttributeNode (location: (1:22)-(1:31))
     │   │               ├── name:
-    │   │               │   └── @ HTMLAttributeNameNode (location: (1:41)-(1:48))
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:22)-(1:31))
     │   │               │       └── children: (1 item)
-    │   │               │           └── @ LiteralNode (location: (1:41)-(1:48))
-    │   │               │               └── content: "data-confirm"
+    │   │               │           └── @ LiteralNode (location: (1:22)-(1:31))
+    │   │               │               └── content: "href"
     │   │               │
     │   │               │
-    │   │               ├── equals: ": " (location: (1:48)-(1:50))
+    │   │               ├── equals: ":" (location: (1:22)-(1:31))
     │   │               └── value:
-    │   │                   └── @ HTMLAttributeValueNode (location: (1:50)-(1:65))
-    │   │                       ├── open_quote: """ (location: (1:50)-(1:51))
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:22)-(1:31))
+    │   │                       ├── open_quote: ∅
     │   │                       ├── children: (1 item)
-    │   │                       │   └── @ LiteralNode (location: (1:51)-(1:64))
-    │   │                       │       └── content: "Are you sure?"
+    │   │                       │   └── @ RubyLiteralNode (location: (1:22)-(1:31))
+    │   │                       │       └── content: "root_path"
     │   │                       │
-    │   │                       ├── close_quote: """ (location: (1:64)-(1:65))
-    │   │                       └── quoted: true
+    │   │                       ├── close_quote: ∅
+    │   │                       └── quoted: false
     │   │
     │   │
     │   │

--- a/test/snapshots/analyze/action_view/url_helper/link_to_test/test_0007_link_to_with_data-turbo-method_981b8fc03dc6192851d05e50bf045e96-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/url_helper/link_to_test/test_0007_link_to_with_data-turbo-method_981b8fc03dc6192851d05e50bf045e96-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -14,44 +14,44 @@ options: {action_view_helpers: true}
     │   │       ├── tag_closing: "%>" (location: (1:66)-(1:68))
     │   │       ├── tag_name: "a" (location: (1:4)-(1:11))
     │   │       └── children: (2 items)
-    │   │           ├── @ HTMLAttributeNode (location: (1:22)-(1:31))
+    │   │           ├── @ HTMLAttributeNode (location: (1:41)-(1:63))
     │   │           │   ├── name:
-    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:22)-(1:31))
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:41)-(1:53))
     │   │           │   │       └── children: (1 item)
-    │   │           │   │           └── @ LiteralNode (location: (1:22)-(1:31))
-    │   │           │   │               └── content: "href"
+    │   │           │   │           └── @ LiteralNode (location: (1:41)-(1:53))
+    │   │           │   │               └── content: "data-turbo-method"
     │   │           │   │
     │   │           │   │
-    │   │           │   ├── equals: ":" (location: (1:22)-(1:31))
+    │   │           │   ├── equals: ": " (location: (1:53)-(1:55))
     │   │           │   └── value:
-    │   │           │       └── @ HTMLAttributeValueNode (location: (1:22)-(1:31))
-    │   │           │           ├── open_quote: ∅
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:55)-(1:63))
+    │   │           │           ├── open_quote: """ (location: (1:55)-(1:56))
     │   │           │           ├── children: (1 item)
-    │   │           │           │   └── @ RubyLiteralNode (location: (1:22)-(1:31))
-    │   │           │           │       └── content: "root_path"
+    │   │           │           │   └── @ LiteralNode (location: (1:56)-(1:62))
+    │   │           │           │       └── content: "delete"
     │   │           │           │
-    │   │           │           ├── close_quote: ∅
-    │   │           │           └── quoted: false
+    │   │           │           ├── close_quote: """ (location: (1:62)-(1:63))
+    │   │           │           └── quoted: true
     │   │           │
     │   │           │
-    │   │           └── @ HTMLAttributeNode (location: (1:41)-(1:63))
+    │   │           └── @ HTMLAttributeNode (location: (1:22)-(1:31))
     │   │               ├── name:
-    │   │               │   └── @ HTMLAttributeNameNode (location: (1:41)-(1:53))
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:22)-(1:31))
     │   │               │       └── children: (1 item)
-    │   │               │           └── @ LiteralNode (location: (1:41)-(1:53))
-    │   │               │               └── content: "data-turbo-method"
+    │   │               │           └── @ LiteralNode (location: (1:22)-(1:31))
+    │   │               │               └── content: "href"
     │   │               │
     │   │               │
-    │   │               ├── equals: ": " (location: (1:53)-(1:55))
+    │   │               ├── equals: ":" (location: (1:22)-(1:31))
     │   │               └── value:
-    │   │                   └── @ HTMLAttributeValueNode (location: (1:55)-(1:63))
-    │   │                       ├── open_quote: """ (location: (1:55)-(1:56))
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:22)-(1:31))
+    │   │                       ├── open_quote: ∅
     │   │                       ├── children: (1 item)
-    │   │                       │   └── @ LiteralNode (location: (1:56)-(1:62))
-    │   │                       │       └── content: "delete"
+    │   │                       │   └── @ RubyLiteralNode (location: (1:22)-(1:31))
+    │   │                       │       └── content: "root_path"
     │   │                       │
-    │   │                       ├── close_quote: """ (location: (1:62)-(1:63))
-    │   │                       └── quoted: true
+    │   │                       ├── close_quote: ∅
+    │   │                       └── quoted: false
     │   │
     │   │
     │   │

--- a/test/snapshots/analyze/action_view/url_helper/link_to_test/test_0008_link_to_with_data-turbo-confirm_387a425d6f1370e9a48371259946d5a4-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/url_helper/link_to_test/test_0008_link_to_with_data-turbo-confirm_387a425d6f1370e9a48371259946d5a4-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -14,44 +14,44 @@ options: {action_view_helpers: true}
     │   │       ├── tag_closing: "%>" (location: (1:74)-(1:76))
     │   │       ├── tag_name: "a" (location: (1:4)-(1:11))
     │   │       └── children: (2 items)
-    │   │           ├── @ HTMLAttributeNode (location: (1:22)-(1:31))
+    │   │           ├── @ HTMLAttributeNode (location: (1:41)-(1:71))
     │   │           │   ├── name:
-    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:22)-(1:31))
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:41)-(1:54))
     │   │           │   │       └── children: (1 item)
-    │   │           │   │           └── @ LiteralNode (location: (1:22)-(1:31))
-    │   │           │   │               └── content: "href"
+    │   │           │   │           └── @ LiteralNode (location: (1:41)-(1:54))
+    │   │           │   │               └── content: "data-turbo-confirm"
     │   │           │   │
     │   │           │   │
-    │   │           │   ├── equals: ":" (location: (1:22)-(1:31))
+    │   │           │   ├── equals: ": " (location: (1:54)-(1:56))
     │   │           │   └── value:
-    │   │           │       └── @ HTMLAttributeValueNode (location: (1:22)-(1:31))
-    │   │           │           ├── open_quote: ∅
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:56)-(1:71))
+    │   │           │           ├── open_quote: """ (location: (1:56)-(1:57))
     │   │           │           ├── children: (1 item)
-    │   │           │           │   └── @ RubyLiteralNode (location: (1:22)-(1:31))
-    │   │           │           │       └── content: "root_path"
+    │   │           │           │   └── @ LiteralNode (location: (1:57)-(1:70))
+    │   │           │           │       └── content: "Are you sure?"
     │   │           │           │
-    │   │           │           ├── close_quote: ∅
-    │   │           │           └── quoted: false
+    │   │           │           ├── close_quote: """ (location: (1:70)-(1:71))
+    │   │           │           └── quoted: true
     │   │           │
     │   │           │
-    │   │           └── @ HTMLAttributeNode (location: (1:41)-(1:71))
+    │   │           └── @ HTMLAttributeNode (location: (1:22)-(1:31))
     │   │               ├── name:
-    │   │               │   └── @ HTMLAttributeNameNode (location: (1:41)-(1:54))
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:22)-(1:31))
     │   │               │       └── children: (1 item)
-    │   │               │           └── @ LiteralNode (location: (1:41)-(1:54))
-    │   │               │               └── content: "data-turbo-confirm"
+    │   │               │           └── @ LiteralNode (location: (1:22)-(1:31))
+    │   │               │               └── content: "href"
     │   │               │
     │   │               │
-    │   │               ├── equals: ": " (location: (1:54)-(1:56))
+    │   │               ├── equals: ":" (location: (1:22)-(1:31))
     │   │               └── value:
-    │   │                   └── @ HTMLAttributeValueNode (location: (1:56)-(1:71))
-    │   │                       ├── open_quote: """ (location: (1:56)-(1:57))
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:22)-(1:31))
+    │   │                       ├── open_quote: ∅
     │   │                       ├── children: (1 item)
-    │   │                       │   └── @ LiteralNode (location: (1:57)-(1:70))
-    │   │                       │       └── content: "Are you sure?"
+    │   │                       │   └── @ RubyLiteralNode (location: (1:22)-(1:31))
+    │   │                       │       └── content: "root_path"
     │   │                       │
-    │   │                       ├── close_quote: """ (location: (1:70)-(1:71))
-    │   │                       └── quoted: true
+    │   │                       ├── close_quote: ∅
+    │   │                       └── quoted: false
     │   │
     │   │
     │   │

--- a/test/snapshots/analyze/action_view/url_helper/link_to_test/test_0010_link_to_with_data_attributes_using_string_key_hashrocket_fa6e9e7277f4f32cb23d55cf94b6d4f9-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/url_helper/link_to_test/test_0010_link_to_with_data_attributes_using_string_key_hashrocket_fa6e9e7277f4f32cb23d55cf94b6d4f9-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -14,44 +14,44 @@ options: {action_view_helpers: true}
     │   │       ├── tag_closing: "%>" (location: (1:62)-(1:64))
     │   │       ├── tag_name: "a" (location: (1:4)-(1:11))
     │   │       └── children: (2 items)
-    │   │           ├── @ HTMLAttributeNode (location: (1:21)-(1:30))
+    │   │           ├── @ HTMLAttributeNode (location: (1:41)-(1:59))
     │   │           │   ├── name:
-    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:21)-(1:30))
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:41)-(1:47))
     │   │           │   │       └── children: (1 item)
-    │   │           │   │           └── @ LiteralNode (location: (1:21)-(1:30))
-    │   │           │   │               └── content: "href"
+    │   │           │   │           └── @ LiteralNode (location: (1:41)-(1:47))
+    │   │           │   │               └── content: "data-action"
     │   │           │   │
     │   │           │   │
-    │   │           │   ├── equals: ":" (location: (1:21)-(1:30))
+    │   │           │   ├── equals: " => " (location: (1:48)-(1:52))
     │   │           │   └── value:
-    │   │           │       └── @ HTMLAttributeValueNode (location: (1:21)-(1:30))
-    │   │           │           ├── open_quote: ∅
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:52)-(1:59))
+    │   │           │           ├── open_quote: """ (location: (1:52)-(1:53))
     │   │           │           ├── children: (1 item)
-    │   │           │           │   └── @ RubyLiteralNode (location: (1:21)-(1:30))
-    │   │           │           │       └── content: "root_path"
+    │   │           │           │   └── @ LiteralNode (location: (1:53)-(1:58))
+    │   │           │           │       └── content: "value"
     │   │           │           │
-    │   │           │           ├── close_quote: ∅
-    │   │           │           └── quoted: false
+    │   │           │           ├── close_quote: """ (location: (1:58)-(1:59))
+    │   │           │           └── quoted: true
     │   │           │
     │   │           │
-    │   │           └── @ HTMLAttributeNode (location: (1:41)-(1:59))
+    │   │           └── @ HTMLAttributeNode (location: (1:21)-(1:30))
     │   │               ├── name:
-    │   │               │   └── @ HTMLAttributeNameNode (location: (1:41)-(1:47))
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:21)-(1:30))
     │   │               │       └── children: (1 item)
-    │   │               │           └── @ LiteralNode (location: (1:41)-(1:47))
-    │   │               │               └── content: "data-action"
+    │   │               │           └── @ LiteralNode (location: (1:21)-(1:30))
+    │   │               │               └── content: "href"
     │   │               │
     │   │               │
-    │   │               ├── equals: " => " (location: (1:48)-(1:52))
+    │   │               ├── equals: ":" (location: (1:21)-(1:30))
     │   │               └── value:
-    │   │                   └── @ HTMLAttributeValueNode (location: (1:52)-(1:59))
-    │   │                       ├── open_quote: """ (location: (1:52)-(1:53))
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:21)-(1:30))
+    │   │                       ├── open_quote: ∅
     │   │                       ├── children: (1 item)
-    │   │                       │   └── @ LiteralNode (location: (1:53)-(1:58))
-    │   │                       │       └── content: "value"
+    │   │                       │   └── @ RubyLiteralNode (location: (1:21)-(1:30))
+    │   │                       │       └── content: "root_path"
     │   │                       │
-    │   │                       ├── close_quote: """ (location: (1:58)-(1:59))
-    │   │                       └── quoted: true
+    │   │                       ├── close_quote: ∅
+    │   │                       └── quoted: false
     │   │
     │   │
     │   │

--- a/test/snapshots/analyze/action_view/url_helper/link_to_test/test_0011_link_to_with_data_attributes_using_symbol_key_hashrocket_fccad1805744837b2d3640f85489a2a4-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/url_helper/link_to_test/test_0011_link_to_with_data_attributes_using_symbol_key_hashrocket_fccad1805744837b2d3640f85489a2a4-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -14,44 +14,44 @@ options: {action_view_helpers: true}
     │   │       ├── tag_closing: "%>" (location: (1:61)-(1:63))
     │   │       ├── tag_name: "a" (location: (1:4)-(1:11))
     │   │       └── children: (2 items)
-    │   │           ├── @ HTMLAttributeNode (location: (1:21)-(1:30))
+    │   │           ├── @ HTMLAttributeNode (location: (1:41)-(1:58))
     │   │           │   ├── name:
-    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:21)-(1:30))
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:41)-(1:47))
     │   │           │   │       └── children: (1 item)
-    │   │           │   │           └── @ LiteralNode (location: (1:21)-(1:30))
-    │   │           │   │               └── content: "href"
+    │   │           │   │           └── @ LiteralNode (location: (1:41)-(1:47))
+    │   │           │   │               └── content: "data-action"
     │   │           │   │
     │   │           │   │
-    │   │           │   ├── equals: ":" (location: (1:21)-(1:30))
+    │   │           │   ├── equals: " => " (location: (1:47)-(1:51))
     │   │           │   └── value:
-    │   │           │       └── @ HTMLAttributeValueNode (location: (1:21)-(1:30))
-    │   │           │           ├── open_quote: ∅
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:51)-(1:58))
+    │   │           │           ├── open_quote: """ (location: (1:51)-(1:52))
     │   │           │           ├── children: (1 item)
-    │   │           │           │   └── @ RubyLiteralNode (location: (1:21)-(1:30))
-    │   │           │           │       └── content: "root_path"
+    │   │           │           │   └── @ LiteralNode (location: (1:52)-(1:57))
+    │   │           │           │       └── content: "value"
     │   │           │           │
-    │   │           │           ├── close_quote: ∅
-    │   │           │           └── quoted: false
+    │   │           │           ├── close_quote: """ (location: (1:57)-(1:58))
+    │   │           │           └── quoted: true
     │   │           │
     │   │           │
-    │   │           └── @ HTMLAttributeNode (location: (1:41)-(1:58))
+    │   │           └── @ HTMLAttributeNode (location: (1:21)-(1:30))
     │   │               ├── name:
-    │   │               │   └── @ HTMLAttributeNameNode (location: (1:41)-(1:47))
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:21)-(1:30))
     │   │               │       └── children: (1 item)
-    │   │               │           └── @ LiteralNode (location: (1:41)-(1:47))
-    │   │               │               └── content: "data-action"
+    │   │               │           └── @ LiteralNode (location: (1:21)-(1:30))
+    │   │               │               └── content: "href"
     │   │               │
     │   │               │
-    │   │               ├── equals: " => " (location: (1:47)-(1:51))
+    │   │               ├── equals: ":" (location: (1:21)-(1:30))
     │   │               └── value:
-    │   │                   └── @ HTMLAttributeValueNode (location: (1:51)-(1:58))
-    │   │                       ├── open_quote: """ (location: (1:51)-(1:52))
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:21)-(1:30))
+    │   │                       ├── open_quote: ∅
     │   │                       ├── children: (1 item)
-    │   │                       │   └── @ LiteralNode (location: (1:52)-(1:57))
-    │   │                       │       └── content: "value"
+    │   │                       │   └── @ RubyLiteralNode (location: (1:21)-(1:30))
+    │   │                       │       └── content: "root_path"
     │   │                       │
-    │   │                       ├── close_quote: """ (location: (1:57)-(1:58))
-    │   │                       └── quoted: true
+    │   │                       ├── close_quote: ∅
+    │   │                       └── quoted: false
     │   │
     │   │
     │   │

--- a/test/snapshots/analyze/action_view/url_helper/link_to_test/test_0013_link_to_with_block_and_path_helper_and_attributes_6b96a8893d8a9eb00711678aa96ac1ac-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/url_helper/link_to_test/test_0013_link_to_with_block_and_path_helper_and_attributes_6b96a8893d8a9eb00711678aa96ac1ac-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -16,44 +16,44 @@ options: {action_view_helpers: true}
     │   │       ├── tag_closing: "%>" (location: (1:39)-(1:41))
     │   │       ├── tag_name: "a" (location: (1:4)-(1:11))
     │   │       └── children: (2 items)
-    │   │           ├── @ HTMLAttributeNode (location: (1:12)-(1:21))
+    │   │           ├── @ HTMLAttributeNode (location: (1:23)-(1:35))
     │   │           │   ├── name:
-    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:12)-(1:21))
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:23)-(1:28))
     │   │           │   │       └── children: (1 item)
-    │   │           │   │           └── @ LiteralNode (location: (1:12)-(1:21))
-    │   │           │   │               └── content: "href"
+    │   │           │   │           └── @ LiteralNode (location: (1:23)-(1:28))
+    │   │           │   │               └── content: "class"
     │   │           │   │
     │   │           │   │
-    │   │           │   ├── equals: ":" (location: (1:12)-(1:21))
+    │   │           │   ├── equals: ": " (location: (1:28)-(1:30))
     │   │           │   └── value:
-    │   │           │       └── @ HTMLAttributeValueNode (location: (1:12)-(1:21))
-    │   │           │           ├── open_quote: ∅
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:30)-(1:35))
+    │   │           │           ├── open_quote: """ (location: (1:30)-(1:31))
     │   │           │           ├── children: (1 item)
-    │   │           │           │   └── @ RubyLiteralNode (location: (1:12)-(1:21))
-    │   │           │           │       └── content: "root_path"
+    │   │           │           │   └── @ LiteralNode (location: (1:31)-(1:34))
+    │   │           │           │       └── content: "btn"
     │   │           │           │
-    │   │           │           ├── close_quote: ∅
-    │   │           │           └── quoted: false
+    │   │           │           ├── close_quote: """ (location: (1:34)-(1:35))
+    │   │           │           └── quoted: true
     │   │           │
     │   │           │
-    │   │           └── @ HTMLAttributeNode (location: (1:23)-(1:35))
+    │   │           └── @ HTMLAttributeNode (location: (1:12)-(1:21))
     │   │               ├── name:
-    │   │               │   └── @ HTMLAttributeNameNode (location: (1:23)-(1:28))
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:12)-(1:21))
     │   │               │       └── children: (1 item)
-    │   │               │           └── @ LiteralNode (location: (1:23)-(1:28))
-    │   │               │               └── content: "class"
+    │   │               │           └── @ LiteralNode (location: (1:12)-(1:21))
+    │   │               │               └── content: "href"
     │   │               │
     │   │               │
-    │   │               ├── equals: ": " (location: (1:28)-(1:30))
+    │   │               ├── equals: ":" (location: (1:12)-(1:21))
     │   │               └── value:
-    │   │                   └── @ HTMLAttributeValueNode (location: (1:30)-(1:35))
-    │   │                       ├── open_quote: """ (location: (1:30)-(1:31))
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:12)-(1:21))
+    │   │                       ├── open_quote: ∅
     │   │                       ├── children: (1 item)
-    │   │                       │   └── @ LiteralNode (location: (1:31)-(1:34))
-    │   │                       │       └── content: "btn"
+    │   │                       │   └── @ RubyLiteralNode (location: (1:12)-(1:21))
+    │   │                       │       └── content: "root_path"
     │   │                       │
-    │   │                       ├── close_quote: """ (location: (1:34)-(1:35))
-    │   │                       └── quoted: true
+    │   │                       ├── close_quote: ∅
+    │   │                       └── quoted: false
     │   │
     │   │
     │   │

--- a/test/snapshots/analyze/action_view/url_helper/link_to_test/test_0021_link_to_with_id_and_class_aec789089079b2d9d8d794bf64834706-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/url_helper/link_to_test/test_0021_link_to_with_id_and_class_aec789089079b2d9d8d794bf64834706-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -14,26 +14,6 @@ options: {action_view_helpers: true}
     │   │       ├── tag_closing: "%>" (location: (1:68)-(1:70))
     │   │       ├── tag_name: "a" (location: (1:4)-(1:11))
     │   │       └── children: (3 items)
-    │   │           ├── @ HTMLAttributeNode (location: (1:24)-(1:37))
-    │   │           │   ├── name:
-    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:24)-(1:37))
-    │   │           │   │       └── children: (1 item)
-    │   │           │   │           └── @ LiteralNode (location: (1:24)-(1:37))
-    │   │           │   │               └── content: "href"
-    │   │           │   │
-    │   │           │   │
-    │   │           │   ├── equals: ":" (location: (1:24)-(1:37))
-    │   │           │   └── value:
-    │   │           │       └── @ HTMLAttributeValueNode (location: (1:24)-(1:37))
-    │   │           │           ├── open_quote: ∅
-    │   │           │           ├── children: (1 item)
-    │   │           │           │   └── @ RubyLiteralNode (location: (1:24)-(1:37))
-    │   │           │           │       └── content: "articles_path"
-    │   │           │           │
-    │   │           │           ├── close_quote: ∅
-    │   │           │           └── quoted: false
-    │   │           │
-    │   │           │
     │   │           ├── @ HTMLAttributeNode (location: (1:39)-(1:49))
     │   │           │   ├── name:
     │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:39)-(1:41))
@@ -54,24 +34,44 @@ options: {action_view_helpers: true}
     │   │           │           └── quoted: true
     │   │           │
     │   │           │
-    │   │           └── @ HTMLAttributeNode (location: (1:51)-(1:67))
+    │   │           ├── @ HTMLAttributeNode (location: (1:51)-(1:67))
+    │   │           │   ├── name:
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:51)-(1:56))
+    │   │           │   │       └── children: (1 item)
+    │   │           │   │           └── @ LiteralNode (location: (1:51)-(1:56))
+    │   │           │   │               └── content: "class"
+    │   │           │   │
+    │   │           │   │
+    │   │           │   ├── equals: ": " (location: (1:56)-(1:58))
+    │   │           │   └── value:
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:58)-(1:67))
+    │   │           │           ├── open_quote: """ (location: (1:58)-(1:59))
+    │   │           │           ├── children: (1 item)
+    │   │           │           │   └── @ LiteralNode (location: (1:59)-(1:66))
+    │   │           │           │       └── content: "article"
+    │   │           │           │
+    │   │           │           ├── close_quote: """ (location: (1:66)-(1:67))
+    │   │           │           └── quoted: true
+    │   │           │
+    │   │           │
+    │   │           └── @ HTMLAttributeNode (location: (1:24)-(1:37))
     │   │               ├── name:
-    │   │               │   └── @ HTMLAttributeNameNode (location: (1:51)-(1:56))
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:24)-(1:37))
     │   │               │       └── children: (1 item)
-    │   │               │           └── @ LiteralNode (location: (1:51)-(1:56))
-    │   │               │               └── content: "class"
+    │   │               │           └── @ LiteralNode (location: (1:24)-(1:37))
+    │   │               │               └── content: "href"
     │   │               │
     │   │               │
-    │   │               ├── equals: ": " (location: (1:56)-(1:58))
+    │   │               ├── equals: ":" (location: (1:24)-(1:37))
     │   │               └── value:
-    │   │                   └── @ HTMLAttributeValueNode (location: (1:58)-(1:67))
-    │   │                       ├── open_quote: """ (location: (1:58)-(1:59))
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:24)-(1:37))
+    │   │                       ├── open_quote: ∅
     │   │                       ├── children: (1 item)
-    │   │                       │   └── @ LiteralNode (location: (1:59)-(1:66))
-    │   │                       │       └── content: "article"
+    │   │                       │   └── @ RubyLiteralNode (location: (1:24)-(1:37))
+    │   │                       │       └── content: "articles_path"
     │   │                       │
-    │   │                       ├── close_quote: """ (location: (1:66)-(1:67))
-    │   │                       └── quoted: true
+    │   │                       ├── close_quote: ∅
+    │   │                       └── quoted: false
     │   │
     │   │
     │   │

--- a/test/snapshots/analyze/action_view/url_helper/link_to_test/test_0022_link_to_with_target_and_rel_89710749e4ec35b8e492031114102288-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/url_helper/link_to_test/test_0022_link_to_with_target_and_rel_89710749e4ec35b8e492031114102288-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -14,26 +14,6 @@ options: {action_view_helpers: true}
     │   │       ├── tag_closing: "%>" (location: (1:94)-(1:96))
     │   │       ├── tag_name: "a" (location: (1:4)-(1:11))
     │   │       └── children: (3 items)
-    │   │           ├── @ HTMLAttributeNode (location: (1:29)-(1:58))
-    │   │           │   ├── name:
-    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:29)-(1:58))
-    │   │           │   │       └── children: (1 item)
-    │   │           │   │           └── @ LiteralNode (location: (1:29)-(1:58))
-    │   │           │   │               └── content: "href"
-    │   │           │   │
-    │   │           │   │
-    │   │           │   ├── equals: "=" (location: (1:29)-(1:58))
-    │   │           │   └── value:
-    │   │           │       └── @ HTMLAttributeValueNode (location: (1:29)-(1:58))
-    │   │           │           ├── open_quote: """ (location: (1:29)-(1:29))
-    │   │           │           ├── children: (1 item)
-    │   │           │           │   └── @ LiteralNode (location: (1:29)-(1:58))
-    │   │           │           │       └── content: "http://www.rubyonrails.org/"
-    │   │           │           │
-    │   │           │           ├── close_quote: """ (location: (1:58)-(1:58))
-    │   │           │           └── quoted: true
-    │   │           │
-    │   │           │
     │   │           ├── @ HTMLAttributeNode (location: (1:60)-(1:76))
     │   │           │   ├── name:
     │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:60)-(1:66))
@@ -54,23 +34,43 @@ options: {action_view_helpers: true}
     │   │           │           └── quoted: true
     │   │           │
     │   │           │
-    │   │           └── @ HTMLAttributeNode (location: (1:78)-(1:93))
+    │   │           ├── @ HTMLAttributeNode (location: (1:78)-(1:93))
+    │   │           │   ├── name:
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:78)-(1:81))
+    │   │           │   │       └── children: (1 item)
+    │   │           │   │           └── @ LiteralNode (location: (1:78)-(1:81))
+    │   │           │   │               └── content: "rel"
+    │   │           │   │
+    │   │           │   │
+    │   │           │   ├── equals: ": " (location: (1:81)-(1:83))
+    │   │           │   └── value:
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:83)-(1:93))
+    │   │           │           ├── open_quote: """ (location: (1:83)-(1:84))
+    │   │           │           ├── children: (1 item)
+    │   │           │           │   └── @ LiteralNode (location: (1:84)-(1:92))
+    │   │           │           │       └── content: "nofollow"
+    │   │           │           │
+    │   │           │           ├── close_quote: """ (location: (1:92)-(1:93))
+    │   │           │           └── quoted: true
+    │   │           │
+    │   │           │
+    │   │           └── @ HTMLAttributeNode (location: (1:29)-(1:58))
     │   │               ├── name:
-    │   │               │   └── @ HTMLAttributeNameNode (location: (1:78)-(1:81))
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:29)-(1:58))
     │   │               │       └── children: (1 item)
-    │   │               │           └── @ LiteralNode (location: (1:78)-(1:81))
-    │   │               │               └── content: "rel"
+    │   │               │           └── @ LiteralNode (location: (1:29)-(1:58))
+    │   │               │               └── content: "href"
     │   │               │
     │   │               │
-    │   │               ├── equals: ": " (location: (1:81)-(1:83))
+    │   │               ├── equals: "=" (location: (1:29)-(1:58))
     │   │               └── value:
-    │   │                   └── @ HTMLAttributeValueNode (location: (1:83)-(1:93))
-    │   │                       ├── open_quote: """ (location: (1:83)-(1:84))
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:29)-(1:58))
+    │   │                       ├── open_quote: """ (location: (1:29)-(1:29))
     │   │                       ├── children: (1 item)
-    │   │                       │   └── @ LiteralNode (location: (1:84)-(1:92))
-    │   │                       │       └── content: "nofollow"
+    │   │                       │   └── @ LiteralNode (location: (1:29)-(1:58))
+    │   │                       │       └── content: "http://www.rubyonrails.org/"
     │   │                       │
-    │   │                       ├── close_quote: """ (location: (1:92)-(1:93))
+    │   │                       ├── close_quote: """ (location: (1:58)-(1:58))
     │   │                       └── quoted: true
     │   │
     │   │

--- a/test/snapshots/analyze/action_view/url_helper/link_to_test/test_0023_link_to_with_turbo_method_on_model_033b28bcc77ab8dbdaf2ae44a3c1e9a0-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/url_helper/link_to_test/test_0023_link_to_with_turbo_method_on_model_033b28bcc77ab8dbdaf2ae44a3c1e9a0-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -14,41 +14,41 @@ options: {action_view_helpers: true}
     │   │       ├── tag_closing: "%>" (location: (1:72)-(1:74))
     │   │       ├── tag_name: "a" (location: (1:4)-(1:11))
     │   │       └── children: (2 items)
-    │   │           ├── @ HTMLAttributeNode (location: (1:30)-(1:38))
+    │   │           ├── @ HTMLAttributeNode (location: (1:48)-(1:69))
     │   │           │   ├── name:
-    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:30)-(1:38))
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:48)-(1:60))
     │   │           │   │       └── children: (1 item)
-    │   │           │   │           └── @ LiteralNode (location: (1:30)-(1:38))
-    │   │           │   │               └── content: "href"
+    │   │           │   │           └── @ LiteralNode (location: (1:48)-(1:60))
+    │   │           │   │               └── content: "data-turbo-method"
     │   │           │   │
     │   │           │   │
-    │   │           │   ├── equals: ":" (location: (1:30)-(1:38))
+    │   │           │   ├── equals: ": " (location: (1:60)-(1:62))
     │   │           │   └── value:
-    │   │           │       └── @ HTMLAttributeValueNode (location: (1:30)-(1:38))
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:63)-(1:69))
     │   │           │           ├── open_quote: ∅
     │   │           │           ├── children: (1 item)
-    │   │           │           │   └── @ RubyLiteralNode (location: (1:30)-(1:38))
-    │   │           │           │       └── content: "url_for(@profile)"
+    │   │           │           │   └── @ LiteralNode (location: (1:63)-(1:69))
+    │   │           │           │       └── content: "delete"
     │   │           │           │
     │   │           │           ├── close_quote: ∅
     │   │           │           └── quoted: false
     │   │           │
     │   │           │
-    │   │           └── @ HTMLAttributeNode (location: (1:48)-(1:69))
+    │   │           └── @ HTMLAttributeNode (location: (1:30)-(1:38))
     │   │               ├── name:
-    │   │               │   └── @ HTMLAttributeNameNode (location: (1:48)-(1:60))
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:30)-(1:38))
     │   │               │       └── children: (1 item)
-    │   │               │           └── @ LiteralNode (location: (1:48)-(1:60))
-    │   │               │               └── content: "data-turbo-method"
+    │   │               │           └── @ LiteralNode (location: (1:30)-(1:38))
+    │   │               │               └── content: "href"
     │   │               │
     │   │               │
-    │   │               ├── equals: ": " (location: (1:60)-(1:62))
+    │   │               ├── equals: ":" (location: (1:30)-(1:38))
     │   │               └── value:
-    │   │                   └── @ HTMLAttributeValueNode (location: (1:63)-(1:69))
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:30)-(1:38))
     │   │                       ├── open_quote: ∅
     │   │                       ├── children: (1 item)
-    │   │                       │   └── @ LiteralNode (location: (1:63)-(1:69))
-    │   │                       │       └── content: "delete"
+    │   │                       │   └── @ RubyLiteralNode (location: (1:30)-(1:38))
+    │   │                       │       └── content: "url_for(@profile)"
     │   │                       │
     │   │                       ├── close_quote: ∅
     │   │                       └── quoted: false

--- a/test/snapshots/analyze/action_view/url_helper/link_to_test/test_0024_link_to_with_turbo_confirm_and_string_url_923da1151974e6003184af7aedcc0d17-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/url_helper/link_to_test/test_0024_link_to_with_turbo_confirm_and_string_url_923da1151974e6003184af7aedcc0d17-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -14,43 +14,43 @@ options: {action_view_helpers: true}
     │   │       ├── tag_closing: "%>" (location: (1:101)-(1:103))
     │   │       ├── tag_name: "a" (location: (1:4)-(1:11))
     │   │       └── children: (2 items)
-    │   │           ├── @ HTMLAttributeNode (location: (1:32)-(1:58))
+    │   │           ├── @ HTMLAttributeNode (location: (1:68)-(1:98))
     │   │           │   ├── name:
-    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:32)-(1:58))
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:68)-(1:81))
     │   │           │   │       └── children: (1 item)
-    │   │           │   │           └── @ LiteralNode (location: (1:32)-(1:58))
-    │   │           │   │               └── content: "href"
+    │   │           │   │           └── @ LiteralNode (location: (1:68)-(1:81))
+    │   │           │   │               └── content: "data-turbo-confirm"
     │   │           │   │
     │   │           │   │
-    │   │           │   ├── equals: "=" (location: (1:32)-(1:58))
+    │   │           │   ├── equals: ": " (location: (1:81)-(1:83))
     │   │           │   └── value:
-    │   │           │       └── @ HTMLAttributeValueNode (location: (1:32)-(1:58))
-    │   │           │           ├── open_quote: """ (location: (1:32)-(1:32))
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:83)-(1:98))
+    │   │           │           ├── open_quote: """ (location: (1:83)-(1:84))
     │   │           │           ├── children: (1 item)
-    │   │           │           │   └── @ LiteralNode (location: (1:32)-(1:58))
-    │   │           │           │       └── content: "https://rubyonrails.org/"
+    │   │           │           │   └── @ LiteralNode (location: (1:84)-(1:97))
+    │   │           │           │       └── content: "Are you sure?"
     │   │           │           │
-    │   │           │           ├── close_quote: """ (location: (1:58)-(1:58))
+    │   │           │           ├── close_quote: """ (location: (1:97)-(1:98))
     │   │           │           └── quoted: true
     │   │           │
     │   │           │
-    │   │           └── @ HTMLAttributeNode (location: (1:68)-(1:98))
+    │   │           └── @ HTMLAttributeNode (location: (1:32)-(1:58))
     │   │               ├── name:
-    │   │               │   └── @ HTMLAttributeNameNode (location: (1:68)-(1:81))
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:32)-(1:58))
     │   │               │       └── children: (1 item)
-    │   │               │           └── @ LiteralNode (location: (1:68)-(1:81))
-    │   │               │               └── content: "data-turbo-confirm"
+    │   │               │           └── @ LiteralNode (location: (1:32)-(1:58))
+    │   │               │               └── content: "href"
     │   │               │
     │   │               │
-    │   │               ├── equals: ": " (location: (1:81)-(1:83))
+    │   │               ├── equals: "=" (location: (1:32)-(1:58))
     │   │               └── value:
-    │   │                   └── @ HTMLAttributeValueNode (location: (1:83)-(1:98))
-    │   │                       ├── open_quote: """ (location: (1:83)-(1:84))
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:32)-(1:58))
+    │   │                       ├── open_quote: """ (location: (1:32)-(1:32))
     │   │                       ├── children: (1 item)
-    │   │                       │   └── @ LiteralNode (location: (1:84)-(1:97))
-    │   │                       │       └── content: "Are you sure?"
+    │   │                       │   └── @ LiteralNode (location: (1:32)-(1:58))
+    │   │                       │       └── content: "https://rubyonrails.org/"
     │   │                       │
-    │   │                       ├── close_quote: """ (location: (1:97)-(1:98))
+    │   │                       ├── close_quote: """ (location: (1:58)-(1:58))
     │   │                       └── quoted: true
     │   │
     │   │

--- a/test/snapshots/analyze/action_view/url_helper/link_to_test/test_0027_link_to_with_method_delete_using_rails_ujs_964963ac5446c616a279e88c31222aa7-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/url_helper/link_to_test/test_0027_link_to_with_method_delete_using_rails_ujs_964963ac5446c616a279e88c31222aa7-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -14,26 +14,6 @@ options: {action_view_helpers: true}
     │   │       ├── tag_closing: "%>" (location: (1:70)-(1:72))
     │   │       ├── tag_name: "a" (location: (1:4)-(1:11))
     │   │       └── children: (3 items)
-    │   │           ├── @ HTMLAttributeNode (location: (1:30)-(1:52))
-    │   │           │   ├── name:
-    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:30)-(1:52))
-    │   │           │   │       └── children: (1 item)
-    │   │           │   │           └── @ LiteralNode (location: (1:30)-(1:52))
-    │   │           │   │               └── content: "href"
-    │   │           │   │
-    │   │           │   │
-    │   │           │   ├── equals: ":" (location: (1:30)-(1:52))
-    │   │           │   └── value:
-    │   │           │       └── @ HTMLAttributeValueNode (location: (1:30)-(1:52))
-    │   │           │           ├── open_quote: ∅
-    │   │           │           ├── children: (1 item)
-    │   │           │           │   └── @ RubyLiteralNode (location: (1:30)-(1:52))
-    │   │           │           │       └── content: "profile_path(@profile)"
-    │   │           │           │
-    │   │           │           ├── close_quote: ∅
-    │   │           │           └── quoted: false
-    │   │           │
-    │   │           │
     │   │           ├── @ HTMLAttributeNode (location: (1:54)-(1:69))
     │   │           │   ├── name:
     │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:54)-(1:60))
@@ -54,24 +34,44 @@ options: {action_view_helpers: true}
     │   │           │           └── quoted: false
     │   │           │
     │   │           │
-    │   │           └── @ HTMLAttributeNode (location: (1:0)-(1:0))
+    │   │           ├── @ HTMLAttributeNode (location: (1:0)-(1:0))
+    │   │           │   ├── name:
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:0)-(1:0))
+    │   │           │   │       └── children: (1 item)
+    │   │           │   │           └── @ LiteralNode (location: (1:0)-(1:0))
+    │   │           │   │               └── content: "rel"
+    │   │           │   │
+    │   │           │   │
+    │   │           │   ├── equals: "=" (location: (1:0)-(1:0))
+    │   │           │   └── value:
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:0)-(1:0))
+    │   │           │           ├── open_quote: """ (location: (1:0)-(1:0))
+    │   │           │           ├── children: (1 item)
+    │   │           │           │   └── @ LiteralNode (location: (1:0)-(1:0))
+    │   │           │           │       └── content: "nofollow"
+    │   │           │           │
+    │   │           │           ├── close_quote: """ (location: (1:0)-(1:0))
+    │   │           │           └── quoted: true
+    │   │           │
+    │   │           │
+    │   │           └── @ HTMLAttributeNode (location: (1:30)-(1:52))
     │   │               ├── name:
-    │   │               │   └── @ HTMLAttributeNameNode (location: (1:0)-(1:0))
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:30)-(1:52))
     │   │               │       └── children: (1 item)
-    │   │               │           └── @ LiteralNode (location: (1:0)-(1:0))
-    │   │               │               └── content: "rel"
+    │   │               │           └── @ LiteralNode (location: (1:30)-(1:52))
+    │   │               │               └── content: "href"
     │   │               │
     │   │               │
-    │   │               ├── equals: "=" (location: (1:0)-(1:0))
+    │   │               ├── equals: ":" (location: (1:30)-(1:52))
     │   │               └── value:
-    │   │                   └── @ HTMLAttributeValueNode (location: (1:0)-(1:0))
-    │   │                       ├── open_quote: """ (location: (1:0)-(1:0))
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:30)-(1:52))
+    │   │                       ├── open_quote: ∅
     │   │                       ├── children: (1 item)
-    │   │                       │   └── @ LiteralNode (location: (1:0)-(1:0))
-    │   │                       │       └── content: "nofollow"
+    │   │                       │   └── @ RubyLiteralNode (location: (1:30)-(1:52))
+    │   │                       │       └── content: "profile_path(@profile)"
     │   │                       │
-    │   │                       ├── close_quote: """ (location: (1:0)-(1:0))
-    │   │                       └── quoted: true
+    │   │                       ├── close_quote: ∅
+    │   │                       └── quoted: false
     │   │
     │   │
     │   │

--- a/test/snapshots/analyze/action_view/url_helper/link_to_test/test_0028_link_to_with_data_confirm_using_rails_ujs_18ca02a23838806d775893dc67872d04-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/url_helper/link_to_test/test_0028_link_to_with_data_confirm_using_rails_ujs_18ca02a23838806d775893dc67872d04-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -14,43 +14,43 @@ options: {action_view_helpers: true}
     │   │       ├── tag_closing: "%>" (location: (1:98)-(1:100))
     │   │       ├── tag_name: "a" (location: (1:4)-(1:11))
     │   │       └── children: (2 items)
-    │   │           ├── @ HTMLAttributeNode (location: (1:32)-(1:61))
+    │   │           ├── @ HTMLAttributeNode (location: (1:71)-(1:95))
     │   │           │   ├── name:
-    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:32)-(1:61))
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:71)-(1:78))
     │   │           │   │       └── children: (1 item)
-    │   │           │   │           └── @ LiteralNode (location: (1:32)-(1:61))
-    │   │           │   │               └── content: "href"
+    │   │           │   │           └── @ LiteralNode (location: (1:71)-(1:78))
+    │   │           │   │               └── content: "data-confirm"
     │   │           │   │
     │   │           │   │
-    │   │           │   ├── equals: "=" (location: (1:32)-(1:61))
+    │   │           │   ├── equals: ": " (location: (1:78)-(1:80))
     │   │           │   └── value:
-    │   │           │       └── @ HTMLAttributeValueNode (location: (1:32)-(1:61))
-    │   │           │           ├── open_quote: """ (location: (1:32)-(1:32))
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:80)-(1:95))
+    │   │           │           ├── open_quote: """ (location: (1:80)-(1:81))
     │   │           │           ├── children: (1 item)
-    │   │           │           │   └── @ LiteralNode (location: (1:32)-(1:61))
-    │   │           │           │       └── content: "http://www.rubyonrails.org/"
+    │   │           │           │   └── @ LiteralNode (location: (1:81)-(1:94))
+    │   │           │           │       └── content: "Are you sure?"
     │   │           │           │
-    │   │           │           ├── close_quote: """ (location: (1:61)-(1:61))
+    │   │           │           ├── close_quote: """ (location: (1:94)-(1:95))
     │   │           │           └── quoted: true
     │   │           │
     │   │           │
-    │   │           └── @ HTMLAttributeNode (location: (1:71)-(1:95))
+    │   │           └── @ HTMLAttributeNode (location: (1:32)-(1:61))
     │   │               ├── name:
-    │   │               │   └── @ HTMLAttributeNameNode (location: (1:71)-(1:78))
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:32)-(1:61))
     │   │               │       └── children: (1 item)
-    │   │               │           └── @ LiteralNode (location: (1:71)-(1:78))
-    │   │               │               └── content: "data-confirm"
+    │   │               │           └── @ LiteralNode (location: (1:32)-(1:61))
+    │   │               │               └── content: "href"
     │   │               │
     │   │               │
-    │   │               ├── equals: ": " (location: (1:78)-(1:80))
+    │   │               ├── equals: "=" (location: (1:32)-(1:61))
     │   │               └── value:
-    │   │                   └── @ HTMLAttributeValueNode (location: (1:80)-(1:95))
-    │   │                       ├── open_quote: """ (location: (1:80)-(1:81))
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:32)-(1:61))
+    │   │                       ├── open_quote: """ (location: (1:32)-(1:32))
     │   │                       ├── children: (1 item)
-    │   │                       │   └── @ LiteralNode (location: (1:81)-(1:94))
-    │   │                       │       └── content: "Are you sure?"
+    │   │                       │   └── @ LiteralNode (location: (1:32)-(1:61))
+    │   │                       │       └── content: "http://www.rubyonrails.org/"
     │   │                       │
-    │   │                       ├── close_quote: """ (location: (1:94)-(1:95))
+    │   │                       ├── close_quote: """ (location: (1:61)-(1:61))
     │   │                       └── quoted: true
     │   │
     │   │

--- a/test/snapshots/analyze/action_view/url_helper/link_to_test/test_0030_link_to_with_remote_true_1fb75839ecae1cddd9451712ac091b36-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/url_helper/link_to_test/test_0030_link_to_with_remote_true_1fb75839ecae1cddd9451712ac091b36-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -14,41 +14,41 @@ options: {action_view_helpers: true}
     │   │       ├── tag_closing: "%>" (location: (1:46)-(1:48))
     │   │       ├── tag_name: "a" (location: (1:4)-(1:11))
     │   │       └── children: (2 items)
-    │   │           ├── @ HTMLAttributeNode (location: (1:22)-(1:31))
+    │   │           ├── @ HTMLAttributeNode (location: (1:33)-(1:45))
     │   │           │   ├── name:
-    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:22)-(1:31))
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:33)-(1:39))
     │   │           │   │       └── children: (1 item)
-    │   │           │   │           └── @ LiteralNode (location: (1:22)-(1:31))
-    │   │           │   │               └── content: "href"
+    │   │           │   │           └── @ LiteralNode (location: (1:33)-(1:39))
+    │   │           │   │               └── content: "data-remote"
     │   │           │   │
     │   │           │   │
-    │   │           │   ├── equals: ":" (location: (1:22)-(1:31))
+    │   │           │   ├── equals: ": " (location: (1:39)-(1:41))
     │   │           │   └── value:
-    │   │           │       └── @ HTMLAttributeValueNode (location: (1:22)-(1:31))
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:41)-(1:45))
     │   │           │           ├── open_quote: ∅
     │   │           │           ├── children: (1 item)
-    │   │           │           │   └── @ RubyLiteralNode (location: (1:22)-(1:31))
-    │   │           │           │       └── content: "root_path"
+    │   │           │           │   └── @ LiteralNode (location: (1:41)-(1:45))
+    │   │           │           │       └── content: "true"
     │   │           │           │
     │   │           │           ├── close_quote: ∅
     │   │           │           └── quoted: false
     │   │           │
     │   │           │
-    │   │           └── @ HTMLAttributeNode (location: (1:33)-(1:45))
+    │   │           └── @ HTMLAttributeNode (location: (1:22)-(1:31))
     │   │               ├── name:
-    │   │               │   └── @ HTMLAttributeNameNode (location: (1:33)-(1:39))
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:22)-(1:31))
     │   │               │       └── children: (1 item)
-    │   │               │           └── @ LiteralNode (location: (1:33)-(1:39))
-    │   │               │               └── content: "data-remote"
+    │   │               │           └── @ LiteralNode (location: (1:22)-(1:31))
+    │   │               │               └── content: "href"
     │   │               │
     │   │               │
-    │   │               ├── equals: ": " (location: (1:39)-(1:41))
+    │   │               ├── equals: ":" (location: (1:22)-(1:31))
     │   │               └── value:
-    │   │                   └── @ HTMLAttributeValueNode (location: (1:41)-(1:45))
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:22)-(1:31))
     │   │                       ├── open_quote: ∅
     │   │                       ├── children: (1 item)
-    │   │                       │   └── @ LiteralNode (location: (1:41)-(1:45))
-    │   │                       │       └── content: "true"
+    │   │                       │   └── @ RubyLiteralNode (location: (1:22)-(1:31))
+    │   │                       │       └── content: "root_path"
     │   │                       │
     │   │                       ├── close_quote: ∅
     │   │                       └── quoted: false

--- a/test/snapshots/analyze/action_view/url_helper/link_to_test/test_0031_link_to_with_data_disable_with_388a05e4f3c688188cb2629e2e94d265-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/url_helper/link_to_test/test_0031_link_to_with_data_disable_with_388a05e4f3c688188cb2629e2e94d265-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -14,44 +14,44 @@ options: {action_view_helpers: true}
     │   │       ├── tag_closing: "%>" (location: (1:73)-(1:75))
     │   │       ├── tag_name: "a" (location: (1:4)-(1:11))
     │   │       └── children: (2 items)
-    │   │           ├── @ HTMLAttributeNode (location: (1:22)-(1:31))
+    │   │           ├── @ HTMLAttributeNode (location: (1:41)-(1:70))
     │   │           │   ├── name:
-    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:22)-(1:31))
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:41)-(1:53))
     │   │           │   │       └── children: (1 item)
-    │   │           │   │           └── @ LiteralNode (location: (1:22)-(1:31))
-    │   │           │   │               └── content: "href"
+    │   │           │   │           └── @ LiteralNode (location: (1:41)-(1:53))
+    │   │           │   │               └── content: "data-disable-with"
     │   │           │   │
     │   │           │   │
-    │   │           │   ├── equals: ":" (location: (1:22)-(1:31))
+    │   │           │   ├── equals: ": " (location: (1:53)-(1:55))
     │   │           │   └── value:
-    │   │           │       └── @ HTMLAttributeValueNode (location: (1:22)-(1:31))
-    │   │           │           ├── open_quote: ∅
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:55)-(1:70))
+    │   │           │           ├── open_quote: """ (location: (1:55)-(1:56))
     │   │           │           ├── children: (1 item)
-    │   │           │           │   └── @ RubyLiteralNode (location: (1:22)-(1:31))
-    │   │           │           │       └── content: "root_path"
+    │   │           │           │   └── @ LiteralNode (location: (1:56)-(1:69))
+    │   │           │           │       └── content: "Submitting..."
     │   │           │           │
-    │   │           │           ├── close_quote: ∅
-    │   │           │           └── quoted: false
+    │   │           │           ├── close_quote: """ (location: (1:69)-(1:70))
+    │   │           │           └── quoted: true
     │   │           │
     │   │           │
-    │   │           └── @ HTMLAttributeNode (location: (1:41)-(1:70))
+    │   │           └── @ HTMLAttributeNode (location: (1:22)-(1:31))
     │   │               ├── name:
-    │   │               │   └── @ HTMLAttributeNameNode (location: (1:41)-(1:53))
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:22)-(1:31))
     │   │               │       └── children: (1 item)
-    │   │               │           └── @ LiteralNode (location: (1:41)-(1:53))
-    │   │               │               └── content: "data-disable-with"
+    │   │               │           └── @ LiteralNode (location: (1:22)-(1:31))
+    │   │               │               └── content: "href"
     │   │               │
     │   │               │
-    │   │               ├── equals: ": " (location: (1:53)-(1:55))
+    │   │               ├── equals: ":" (location: (1:22)-(1:31))
     │   │               └── value:
-    │   │                   └── @ HTMLAttributeValueNode (location: (1:55)-(1:70))
-    │   │                       ├── open_quote: """ (location: (1:55)-(1:56))
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:22)-(1:31))
+    │   │                       ├── open_quote: ∅
     │   │                       ├── children: (1 item)
-    │   │                       │   └── @ LiteralNode (location: (1:56)-(1:69))
-    │   │                       │       └── content: "Submitting..."
+    │   │                       │   └── @ RubyLiteralNode (location: (1:22)-(1:31))
+    │   │                       │       └── content: "root_path"
     │   │                       │
-    │   │                       ├── close_quote: """ (location: (1:69)-(1:70))
-    │   │                       └── quoted: true
+    │   │                       ├── close_quote: ∅
+    │   │                       └── quoted: false
     │   │
     │   │
     │   │

--- a/test/snapshots/analyze/action_view/url_helper/link_to_test/test_0033_link_to_with_explicit_url_hash_and_html_options_46fc66e4967f453b35c213aabeeed8a1-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/url_helper/link_to_test/test_0033_link_to_with_explicit_url_hash_and_html_options_46fc66e4967f453b35c213aabeeed8a1-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -14,44 +14,44 @@ options: {action_view_helpers: true}
     │   │       ├── tag_closing: "%>" (location: (1:80)-(1:82))
     │   │       ├── tag_name: "a" (location: (1:4)-(1:11))
     │   │       └── children: (2 items)
-    │   │           ├── @ HTMLAttributeNode (location: (1:23)-(1:65))
+    │   │           ├── @ HTMLAttributeNode (location: (1:67)-(1:79))
     │   │           │   ├── name:
-    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:23)-(1:65))
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:67)-(1:72))
     │   │           │   │       └── children: (1 item)
-    │   │           │   │           └── @ LiteralNode (location: (1:23)-(1:65))
-    │   │           │   │               └── content: "href"
+    │   │           │   │           └── @ LiteralNode (location: (1:67)-(1:72))
+    │   │           │   │               └── content: "class"
     │   │           │   │
     │   │           │   │
-    │   │           │   ├── equals: ":" (location: (1:23)-(1:65))
+    │   │           │   ├── equals: ": " (location: (1:72)-(1:74))
     │   │           │   └── value:
-    │   │           │       └── @ HTMLAttributeValueNode (location: (1:23)-(1:65))
-    │   │           │           ├── open_quote: ∅
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:74)-(1:79))
+    │   │           │           ├── open_quote: """ (location: (1:74)-(1:75))
     │   │           │           ├── children: (1 item)
-    │   │           │           │   └── @ RubyLiteralNode (location: (1:23)-(1:65))
-    │   │           │           │       └── content: "url_for({ controller: \"profiles\", action: \"show\" })"
+    │   │           │           │   └── @ LiteralNode (location: (1:75)-(1:78))
+    │   │           │           │       └── content: "btn"
     │   │           │           │
-    │   │           │           ├── close_quote: ∅
-    │   │           │           └── quoted: false
+    │   │           │           ├── close_quote: """ (location: (1:78)-(1:79))
+    │   │           │           └── quoted: true
     │   │           │
     │   │           │
-    │   │           └── @ HTMLAttributeNode (location: (1:67)-(1:79))
+    │   │           └── @ HTMLAttributeNode (location: (1:23)-(1:65))
     │   │               ├── name:
-    │   │               │   └── @ HTMLAttributeNameNode (location: (1:67)-(1:72))
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:23)-(1:65))
     │   │               │       └── children: (1 item)
-    │   │               │           └── @ LiteralNode (location: (1:67)-(1:72))
-    │   │               │               └── content: "class"
+    │   │               │           └── @ LiteralNode (location: (1:23)-(1:65))
+    │   │               │               └── content: "href"
     │   │               │
     │   │               │
-    │   │               ├── equals: ": " (location: (1:72)-(1:74))
+    │   │               ├── equals: ":" (location: (1:23)-(1:65))
     │   │               └── value:
-    │   │                   └── @ HTMLAttributeValueNode (location: (1:74)-(1:79))
-    │   │                       ├── open_quote: """ (location: (1:74)-(1:75))
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:23)-(1:65))
+    │   │                       ├── open_quote: ∅
     │   │                       ├── children: (1 item)
-    │   │                       │   └── @ LiteralNode (location: (1:75)-(1:78))
-    │   │                       │       └── content: "btn"
+    │   │                       │   └── @ RubyLiteralNode (location: (1:23)-(1:65))
+    │   │                       │       └── content: "url_for({ controller: \"profiles\", action: \"show\" })"
     │   │                       │
-    │   │                       ├── close_quote: """ (location: (1:78)-(1:79))
-    │   │                       └── quoted: true
+    │   │                       ├── close_quote: ∅
+    │   │                       └── quoted: false
     │   │
     │   │
     │   │

--- a/test/snapshots/analyze/action_view/url_helper/link_to_test/test_0034_link_to_with_explicit_url_hash_and_html_options_block_form_56d3f6519b9618fc297a525814e2714a-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/url_helper/link_to_test/test_0034_link_to_with_explicit_url_hash_and_html_options_block_form_56d3f6519b9618fc297a525814e2714a-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -16,44 +16,44 @@ options: {action_view_helpers: true}
     │   │       ├── tag_closing: "%>" (location: (1:73)-(1:75))
     │   │       ├── tag_name: "a" (location: (1:4)-(1:11))
     │   │       └── children: (2 items)
-    │   │           ├── @ HTMLAttributeNode (location: (1:12)-(1:54))
+    │   │           ├── @ HTMLAttributeNode (location: (1:56)-(1:68))
     │   │           │   ├── name:
-    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:12)-(1:54))
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:56)-(1:61))
     │   │           │   │       └── children: (1 item)
-    │   │           │   │           └── @ LiteralNode (location: (1:12)-(1:54))
-    │   │           │   │               └── content: "href"
+    │   │           │   │           └── @ LiteralNode (location: (1:56)-(1:61))
+    │   │           │   │               └── content: "class"
     │   │           │   │
     │   │           │   │
-    │   │           │   ├── equals: ":" (location: (1:12)-(1:54))
+    │   │           │   ├── equals: ": " (location: (1:61)-(1:63))
     │   │           │   └── value:
-    │   │           │       └── @ HTMLAttributeValueNode (location: (1:12)-(1:54))
-    │   │           │           ├── open_quote: ∅
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:63)-(1:68))
+    │   │           │           ├── open_quote: """ (location: (1:63)-(1:64))
     │   │           │           ├── children: (1 item)
-    │   │           │           │   └── @ RubyLiteralNode (location: (1:12)-(1:54))
-    │   │           │           │       └── content: "url_for({ controller: \"profiles\", action: \"show\" })"
+    │   │           │           │   └── @ LiteralNode (location: (1:64)-(1:67))
+    │   │           │           │       └── content: "btn"
     │   │           │           │
-    │   │           │           ├── close_quote: ∅
-    │   │           │           └── quoted: false
+    │   │           │           ├── close_quote: """ (location: (1:67)-(1:68))
+    │   │           │           └── quoted: true
     │   │           │
     │   │           │
-    │   │           └── @ HTMLAttributeNode (location: (1:56)-(1:68))
+    │   │           └── @ HTMLAttributeNode (location: (1:12)-(1:54))
     │   │               ├── name:
-    │   │               │   └── @ HTMLAttributeNameNode (location: (1:56)-(1:61))
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:12)-(1:54))
     │   │               │       └── children: (1 item)
-    │   │               │           └── @ LiteralNode (location: (1:56)-(1:61))
-    │   │               │               └── content: "class"
+    │   │               │           └── @ LiteralNode (location: (1:12)-(1:54))
+    │   │               │               └── content: "href"
     │   │               │
     │   │               │
-    │   │               ├── equals: ": " (location: (1:61)-(1:63))
+    │   │               ├── equals: ":" (location: (1:12)-(1:54))
     │   │               └── value:
-    │   │                   └── @ HTMLAttributeValueNode (location: (1:63)-(1:68))
-    │   │                       ├── open_quote: """ (location: (1:63)-(1:64))
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:12)-(1:54))
+    │   │                       ├── open_quote: ∅
     │   │                       ├── children: (1 item)
-    │   │                       │   └── @ LiteralNode (location: (1:64)-(1:67))
-    │   │                       │       └── content: "btn"
+    │   │                       │   └── @ RubyLiteralNode (location: (1:12)-(1:54))
+    │   │                       │       └── content: "url_for({ controller: \"profiles\", action: \"show\" })"
     │   │                       │
-    │   │                       ├── close_quote: """ (location: (1:67)-(1:68))
-    │   │                       └── quoted: true
+    │   │                       ├── close_quote: ∅
+    │   │                       └── quoted: false
     │   │
     │   │
     │   │

--- a/test/snapshots/analyze/action_view/url_helper/link_to_test/test_0036_link_to_with_inline_block_and_attributes_82dd05b7799745c34482d86f25410af4-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/url_helper/link_to_test/test_0036_link_to_with_inline_block_and_attributes_82dd05b7799745c34482d86f25410af4-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -14,43 +14,43 @@ options: {action_view_helpers: true}
     │   │       ├── tag_closing: "%>" (location: (1:48)-(1:50))
     │   │       ├── tag_name: "a" (location: (1:4)-(1:11))
     │   │       └── children: (2 items)
-    │   │           ├── @ HTMLAttributeNode (location: (1:12)-(1:20))
+    │   │           ├── @ HTMLAttributeNode (location: (1:22)-(1:34))
     │   │           │   ├── name:
-    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:12)-(1:20))
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:22)-(1:27))
     │   │           │   │       └── children: (1 item)
-    │   │           │   │           └── @ LiteralNode (location: (1:12)-(1:20))
-    │   │           │   │               └── content: "href"
+    │   │           │   │           └── @ LiteralNode (location: (1:22)-(1:27))
+    │   │           │   │               └── content: "class"
     │   │           │   │
     │   │           │   │
-    │   │           │   ├── equals: "=" (location: (1:12)-(1:20))
+    │   │           │   ├── equals: ": " (location: (1:27)-(1:29))
     │   │           │   └── value:
-    │   │           │       └── @ HTMLAttributeValueNode (location: (1:12)-(1:20))
-    │   │           │           ├── open_quote: """ (location: (1:12)-(1:12))
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:29)-(1:34))
+    │   │           │           ├── open_quote: """ (location: (1:29)-(1:30))
     │   │           │           ├── children: (1 item)
-    │   │           │           │   └── @ LiteralNode (location: (1:12)-(1:20))
-    │   │           │           │       └── content: "/about"
+    │   │           │           │   └── @ LiteralNode (location: (1:30)-(1:33))
+    │   │           │           │       └── content: "btn"
     │   │           │           │
-    │   │           │           ├── close_quote: """ (location: (1:20)-(1:20))
+    │   │           │           ├── close_quote: """ (location: (1:33)-(1:34))
     │   │           │           └── quoted: true
     │   │           │
     │   │           │
-    │   │           └── @ HTMLAttributeNode (location: (1:22)-(1:34))
+    │   │           └── @ HTMLAttributeNode (location: (1:12)-(1:20))
     │   │               ├── name:
-    │   │               │   └── @ HTMLAttributeNameNode (location: (1:22)-(1:27))
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:12)-(1:20))
     │   │               │       └── children: (1 item)
-    │   │               │           └── @ LiteralNode (location: (1:22)-(1:27))
-    │   │               │               └── content: "class"
+    │   │               │           └── @ LiteralNode (location: (1:12)-(1:20))
+    │   │               │               └── content: "href"
     │   │               │
     │   │               │
-    │   │               ├── equals: ": " (location: (1:27)-(1:29))
+    │   │               ├── equals: "=" (location: (1:12)-(1:20))
     │   │               └── value:
-    │   │                   └── @ HTMLAttributeValueNode (location: (1:29)-(1:34))
-    │   │                       ├── open_quote: """ (location: (1:29)-(1:30))
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:12)-(1:20))
+    │   │                       ├── open_quote: """ (location: (1:12)-(1:12))
     │   │                       ├── children: (1 item)
-    │   │                       │   └── @ LiteralNode (location: (1:30)-(1:33))
-    │   │                       │       └── content: "btn"
+    │   │                       │   └── @ LiteralNode (location: (1:12)-(1:20))
+    │   │                       │       └── content: "/about"
     │   │                       │
-    │   │                       ├── close_quote: """ (location: (1:33)-(1:34))
+    │   │                       ├── close_quote: """ (location: (1:20)-(1:20))
     │   │                       └── quoted: true
     │   │
     │   │

--- a/test/snapshots/analyze/action_view/url_helper/link_to_test/test_0037_link_to_with_inline_block_and_data_attributes_1689598922ad4d857d1c4d407d57ec48-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/url_helper/link_to_test/test_0037_link_to_with_inline_block_and_data_attributes_1689598922ad4d857d1c4d407d57ec48-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -14,43 +14,43 @@ options: {action_view_helpers: true}
     │   │       ├── tag_closing: "%>" (location: (1:71)-(1:73))
     │   │       ├── tag_name: "a" (location: (1:4)-(1:11))
     │   │       └── children: (2 items)
-    │   │           ├── @ HTMLAttributeNode (location: (1:12)-(1:22))
+    │   │           ├── @ HTMLAttributeNode (location: (1:32)-(1:54))
     │   │           │   ├── name:
-    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:12)-(1:22))
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:32)-(1:44))
     │   │           │   │       └── children: (1 item)
-    │   │           │   │           └── @ LiteralNode (location: (1:12)-(1:22))
-    │   │           │   │               └── content: "href"
+    │   │           │   │           └── @ LiteralNode (location: (1:32)-(1:44))
+    │   │           │   │               └── content: "data-turbo-method"
     │   │           │   │
     │   │           │   │
-    │   │           │   ├── equals: "=" (location: (1:12)-(1:22))
+    │   │           │   ├── equals: ": " (location: (1:44)-(1:46))
     │   │           │   └── value:
-    │   │           │       └── @ HTMLAttributeValueNode (location: (1:12)-(1:22))
-    │   │           │           ├── open_quote: """ (location: (1:12)-(1:12))
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:46)-(1:54))
+    │   │           │           ├── open_quote: """ (location: (1:46)-(1:47))
     │   │           │           ├── children: (1 item)
-    │   │           │           │   └── @ LiteralNode (location: (1:12)-(1:22))
-    │   │           │           │       └── content: "/profile"
+    │   │           │           │   └── @ LiteralNode (location: (1:47)-(1:53))
+    │   │           │           │       └── content: "delete"
     │   │           │           │
-    │   │           │           ├── close_quote: """ (location: (1:22)-(1:22))
+    │   │           │           ├── close_quote: """ (location: (1:53)-(1:54))
     │   │           │           └── quoted: true
     │   │           │
     │   │           │
-    │   │           └── @ HTMLAttributeNode (location: (1:32)-(1:54))
+    │   │           └── @ HTMLAttributeNode (location: (1:12)-(1:22))
     │   │               ├── name:
-    │   │               │   └── @ HTMLAttributeNameNode (location: (1:32)-(1:44))
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:12)-(1:22))
     │   │               │       └── children: (1 item)
-    │   │               │           └── @ LiteralNode (location: (1:32)-(1:44))
-    │   │               │               └── content: "data-turbo-method"
+    │   │               │           └── @ LiteralNode (location: (1:12)-(1:22))
+    │   │               │               └── content: "href"
     │   │               │
     │   │               │
-    │   │               ├── equals: ": " (location: (1:44)-(1:46))
+    │   │               ├── equals: "=" (location: (1:12)-(1:22))
     │   │               └── value:
-    │   │                   └── @ HTMLAttributeValueNode (location: (1:46)-(1:54))
-    │   │                       ├── open_quote: """ (location: (1:46)-(1:47))
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:12)-(1:22))
+    │   │                       ├── open_quote: """ (location: (1:12)-(1:12))
     │   │                       ├── children: (1 item)
-    │   │                       │   └── @ LiteralNode (location: (1:47)-(1:53))
-    │   │                       │       └── content: "delete"
+    │   │                       │   └── @ LiteralNode (location: (1:12)-(1:22))
+    │   │                       │       └── content: "/profile"
     │   │                       │
-    │   │                       ├── close_quote: """ (location: (1:53)-(1:54))
+    │   │                       ├── close_quote: """ (location: (1:22)-(1:22))
     │   │                       └── quoted: true
     │   │
     │   │

--- a/test/snapshots/analyze/action_view/url_helper/link_to_test/test_0040_link_to_with_inline_block_and_multiple_data_attributes_2780c967fb2eabe085bd232ea08f9c4e-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/url_helper/link_to_test/test_0040_link_to_with_inline_block_and_multiple_data_attributes_2780c967fb2eabe085bd232ea08f9c4e-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -14,26 +14,6 @@ options: {action_view_helpers: true}
     │   │       ├── tag_closing: "%>" (location: (1:95)-(1:97))
     │   │       ├── tag_name: "a" (location: (1:4)-(1:11))
     │   │       └── children: (3 items)
-    │   │           ├── @ HTMLAttributeNode (location: (1:12)-(1:22))
-    │   │           │   ├── name:
-    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:12)-(1:22))
-    │   │           │   │       └── children: (1 item)
-    │   │           │   │           └── @ LiteralNode (location: (1:12)-(1:22))
-    │   │           │   │               └── content: "href"
-    │   │           │   │
-    │   │           │   │
-    │   │           │   ├── equals: "=" (location: (1:12)-(1:22))
-    │   │           │   └── value:
-    │   │           │       └── @ HTMLAttributeValueNode (location: (1:12)-(1:22))
-    │   │           │           ├── open_quote: """ (location: (1:12)-(1:12))
-    │   │           │           ├── children: (1 item)
-    │   │           │           │   └── @ LiteralNode (location: (1:12)-(1:22))
-    │   │           │           │       └── content: "/profile"
-    │   │           │           │
-    │   │           │           ├── close_quote: """ (location: (1:22)-(1:22))
-    │   │           │           └── quoted: true
-    │   │           │
-    │   │           │
     │   │           ├── @ HTMLAttributeNode (location: (1:32)-(1:54))
     │   │           │   ├── name:
     │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:32)-(1:44))
@@ -54,23 +34,43 @@ options: {action_view_helpers: true}
     │   │           │           └── quoted: true
     │   │           │
     │   │           │
-    │   │           └── @ HTMLAttributeNode (location: (1:56)-(1:78))
+    │   │           ├── @ HTMLAttributeNode (location: (1:56)-(1:78))
+    │   │           │   ├── name:
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:56)-(1:69))
+    │   │           │   │       └── children: (1 item)
+    │   │           │   │           └── @ LiteralNode (location: (1:56)-(1:69))
+    │   │           │   │               └── content: "data-turbo-confirm"
+    │   │           │   │
+    │   │           │   │
+    │   │           │   ├── equals: ": " (location: (1:69)-(1:71))
+    │   │           │   └── value:
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:71)-(1:78))
+    │   │           │           ├── open_quote: """ (location: (1:71)-(1:72))
+    │   │           │           ├── children: (1 item)
+    │   │           │           │   └── @ LiteralNode (location: (1:72)-(1:77))
+    │   │           │           │       └── content: "Sure?"
+    │   │           │           │
+    │   │           │           ├── close_quote: """ (location: (1:77)-(1:78))
+    │   │           │           └── quoted: true
+    │   │           │
+    │   │           │
+    │   │           └── @ HTMLAttributeNode (location: (1:12)-(1:22))
     │   │               ├── name:
-    │   │               │   └── @ HTMLAttributeNameNode (location: (1:56)-(1:69))
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:12)-(1:22))
     │   │               │       └── children: (1 item)
-    │   │               │           └── @ LiteralNode (location: (1:56)-(1:69))
-    │   │               │               └── content: "data-turbo-confirm"
+    │   │               │           └── @ LiteralNode (location: (1:12)-(1:22))
+    │   │               │               └── content: "href"
     │   │               │
     │   │               │
-    │   │               ├── equals: ": " (location: (1:69)-(1:71))
+    │   │               ├── equals: "=" (location: (1:12)-(1:22))
     │   │               └── value:
-    │   │                   └── @ HTMLAttributeValueNode (location: (1:71)-(1:78))
-    │   │                       ├── open_quote: """ (location: (1:71)-(1:72))
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:12)-(1:22))
+    │   │                       ├── open_quote: """ (location: (1:12)-(1:12))
     │   │                       ├── children: (1 item)
-    │   │                       │   └── @ LiteralNode (location: (1:72)-(1:77))
-    │   │                       │       └── content: "Sure?"
+    │   │                       │   └── @ LiteralNode (location: (1:12)-(1:22))
+    │   │                       │       └── content: "/profile"
     │   │                       │
-    │   │                       ├── close_quote: """ (location: (1:77)-(1:78))
+    │   │                       ├── close_quote: """ (location: (1:22)-(1:22))
     │   │                       └── quoted: true
     │   │
     │   │

--- a/test/snapshots/analyze/action_view/url_helper/link_to_test/test_0042_link_to_with_inline_block_and_path_helper_and_attributes_52426391106d522eefa466f1fc84be8b-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/url_helper/link_to_test/test_0042_link_to_with_inline_block_and_path_helper_and_attributes_52426391106d522eefa466f1fc84be8b-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -14,26 +14,6 @@ options: {action_view_helpers: true}
     │   │       ├── tag_closing: "%>" (location: (1:82)-(1:84))
     │   │       ├── tag_name: "a" (location: (1:4)-(1:11))
     │   │       └── children: (3 items)
-    │   │           ├── @ HTMLAttributeNode (location: (1:12)-(1:21))
-    │   │           │   ├── name:
-    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:12)-(1:21))
-    │   │           │   │       └── children: (1 item)
-    │   │           │   │           └── @ LiteralNode (location: (1:12)-(1:21))
-    │   │           │   │               └── content: "href"
-    │   │           │   │
-    │   │           │   │
-    │   │           │   ├── equals: ":" (location: (1:12)-(1:21))
-    │   │           │   └── value:
-    │   │           │       └── @ HTMLAttributeValueNode (location: (1:12)-(1:21))
-    │   │           │           ├── open_quote: ∅
-    │   │           │           ├── children: (1 item)
-    │   │           │           │   └── @ RubyLiteralNode (location: (1:12)-(1:21))
-    │   │           │           │       └── content: "root_path"
-    │   │           │           │
-    │   │           │           ├── close_quote: ∅
-    │   │           │           └── quoted: false
-    │   │           │
-    │   │           │
     │   │           ├── @ HTMLAttributeNode (location: (1:23)-(1:35))
     │   │           │   ├── name:
     │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:23)-(1:28))
@@ -54,24 +34,44 @@ options: {action_view_helpers: true}
     │   │           │           └── quoted: true
     │   │           │
     │   │           │
-    │   │           └── @ HTMLAttributeNode (location: (1:45)-(1:67))
+    │   │           ├── @ HTMLAttributeNode (location: (1:45)-(1:67))
+    │   │           │   ├── name:
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:45)-(1:57))
+    │   │           │   │       └── children: (1 item)
+    │   │           │   │           └── @ LiteralNode (location: (1:45)-(1:57))
+    │   │           │   │               └── content: "data-turbo-method"
+    │   │           │   │
+    │   │           │   │
+    │   │           │   ├── equals: ": " (location: (1:57)-(1:59))
+    │   │           │   └── value:
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:59)-(1:67))
+    │   │           │           ├── open_quote: """ (location: (1:59)-(1:60))
+    │   │           │           ├── children: (1 item)
+    │   │           │           │   └── @ LiteralNode (location: (1:60)-(1:66))
+    │   │           │           │       └── content: "delete"
+    │   │           │           │
+    │   │           │           ├── close_quote: """ (location: (1:66)-(1:67))
+    │   │           │           └── quoted: true
+    │   │           │
+    │   │           │
+    │   │           └── @ HTMLAttributeNode (location: (1:12)-(1:21))
     │   │               ├── name:
-    │   │               │   └── @ HTMLAttributeNameNode (location: (1:45)-(1:57))
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:12)-(1:21))
     │   │               │       └── children: (1 item)
-    │   │               │           └── @ LiteralNode (location: (1:45)-(1:57))
-    │   │               │               └── content: "data-turbo-method"
+    │   │               │           └── @ LiteralNode (location: (1:12)-(1:21))
+    │   │               │               └── content: "href"
     │   │               │
     │   │               │
-    │   │               ├── equals: ": " (location: (1:57)-(1:59))
+    │   │               ├── equals: ":" (location: (1:12)-(1:21))
     │   │               └── value:
-    │   │                   └── @ HTMLAttributeValueNode (location: (1:59)-(1:67))
-    │   │                       ├── open_quote: """ (location: (1:59)-(1:60))
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:12)-(1:21))
+    │   │                       ├── open_quote: ∅
     │   │                       ├── children: (1 item)
-    │   │                       │   └── @ LiteralNode (location: (1:60)-(1:66))
-    │   │                       │       └── content: "delete"
+    │   │                       │   └── @ RubyLiteralNode (location: (1:12)-(1:21))
+    │   │                       │       └── content: "root_path"
     │   │                       │
-    │   │                       ├── close_quote: """ (location: (1:66)-(1:67))
-    │   │                       └── quoted: true
+    │   │                       ├── close_quote: ∅
+    │   │                       └── quoted: false
     │   │
     │   │
     │   │

--- a/test/snapshots/analyze/action_view/url_helper/link_to_test/test_0043_link_to_with_inline_block_and_explicit_hash_options_8bcc711298f6b3a70fe083a99ba5a7ca-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/url_helper/link_to_test/test_0043_link_to_with_inline_block_and_explicit_hash_options_8bcc711298f6b3a70fe083a99ba5a7ca-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -14,43 +14,43 @@ options: {action_view_helpers: true}
     │   │       ├── tag_closing: "%>" (location: (1:48)-(1:50))
     │   │       ├── tag_name: "a" (location: (1:4)-(1:11))
     │   │       └── children: (2 items)
-    │   │           ├── @ HTMLAttributeNode (location: (1:12)-(1:20))
+    │   │           ├── @ HTMLAttributeNode (location: (1:24)-(1:36))
     │   │           │   ├── name:
-    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:12)-(1:20))
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:24)-(1:29))
     │   │           │   │       └── children: (1 item)
-    │   │           │   │           └── @ LiteralNode (location: (1:12)-(1:20))
-    │   │           │   │               └── content: "href"
+    │   │           │   │           └── @ LiteralNode (location: (1:24)-(1:29))
+    │   │           │   │               └── content: "class"
     │   │           │   │
     │   │           │   │
-    │   │           │   ├── equals: "=" (location: (1:12)-(1:20))
+    │   │           │   ├── equals: ": " (location: (1:29)-(1:31))
     │   │           │   └── value:
-    │   │           │       └── @ HTMLAttributeValueNode (location: (1:12)-(1:20))
-    │   │           │           ├── open_quote: """ (location: (1:12)-(1:12))
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:31)-(1:36))
+    │   │           │           ├── open_quote: """ (location: (1:31)-(1:32))
     │   │           │           ├── children: (1 item)
-    │   │           │           │   └── @ LiteralNode (location: (1:12)-(1:20))
-    │   │           │           │       └── content: "/about"
+    │   │           │           │   └── @ LiteralNode (location: (1:32)-(1:35))
+    │   │           │           │       └── content: "btn"
     │   │           │           │
-    │   │           │           ├── close_quote: """ (location: (1:20)-(1:20))
+    │   │           │           ├── close_quote: """ (location: (1:35)-(1:36))
     │   │           │           └── quoted: true
     │   │           │
     │   │           │
-    │   │           └── @ HTMLAttributeNode (location: (1:24)-(1:36))
+    │   │           └── @ HTMLAttributeNode (location: (1:12)-(1:20))
     │   │               ├── name:
-    │   │               │   └── @ HTMLAttributeNameNode (location: (1:24)-(1:29))
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:12)-(1:20))
     │   │               │       └── children: (1 item)
-    │   │               │           └── @ LiteralNode (location: (1:24)-(1:29))
-    │   │               │               └── content: "class"
+    │   │               │           └── @ LiteralNode (location: (1:12)-(1:20))
+    │   │               │               └── content: "href"
     │   │               │
     │   │               │
-    │   │               ├── equals: ": " (location: (1:29)-(1:31))
+    │   │               ├── equals: "=" (location: (1:12)-(1:20))
     │   │               └── value:
-    │   │                   └── @ HTMLAttributeValueNode (location: (1:31)-(1:36))
-    │   │                       ├── open_quote: """ (location: (1:31)-(1:32))
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:12)-(1:20))
+    │   │                       ├── open_quote: """ (location: (1:12)-(1:12))
     │   │                       ├── children: (1 item)
-    │   │                       │   └── @ LiteralNode (location: (1:32)-(1:35))
-    │   │                       │       └── content: "btn"
+    │   │                       │   └── @ LiteralNode (location: (1:12)-(1:20))
+    │   │                       │       └── content: "/about"
     │   │                       │
-    │   │                       ├── close_quote: """ (location: (1:35)-(1:36))
+    │   │                       ├── close_quote: """ (location: (1:20)-(1:20))
     │   │                       └── quoted: true
     │   │
     │   │

--- a/test/snapshots/analyze/action_view/url_helper/link_to_test/test_0044_link_to_with_inline_block_and_variable_options_52dcd6e5548da50405eeca6035f3885b-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/url_helper/link_to_test/test_0044_link_to_with_inline_block_and_variable_options_52dcd6e5548da50405eeca6035f3885b-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -14,29 +14,29 @@ options: {action_view_helpers: true}
     │   │       ├── tag_closing: "%>" (location: (1:45)-(1:47))
     │   │       ├── tag_name: "a" (location: (1:4)-(1:11))
     │   │       └── children: (2 items)
-    │   │           ├── @ HTMLAttributeNode (location: (1:12)-(1:20))
-    │   │           │   ├── name:
-    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:12)-(1:20))
-    │   │           │   │       └── children: (1 item)
-    │   │           │   │           └── @ LiteralNode (location: (1:12)-(1:20))
-    │   │           │   │               └── content: "href"
-    │   │           │   │
-    │   │           │   │
-    │   │           │   ├── equals: "=" (location: (1:12)-(1:20))
-    │   │           │   └── value:
-    │   │           │       └── @ HTMLAttributeValueNode (location: (1:12)-(1:20))
-    │   │           │           ├── open_quote: """ (location: (1:12)-(1:12))
-    │   │           │           ├── children: (1 item)
-    │   │           │           │   └── @ LiteralNode (location: (1:12)-(1:20))
-    │   │           │           │       └── content: "/about"
-    │   │           │           │
-    │   │           │           ├── close_quote: """ (location: (1:20)-(1:20))
-    │   │           │           └── quoted: true
+    │   │           ├── @ RubyHTMLAttributesSplatNode (location: (1:22)-(1:22))
+    │   │           │   ├── content: "tag.attributes(**html_opts)"
+    │   │           │   └── prefix: ""
     │   │           │
-    │   │           │
-    │   │           └── @ RubyHTMLAttributesSplatNode (location: (1:22)-(1:22))
-    │   │               ├── content: "tag.attributes(**html_opts)"
-    │   │               └── prefix: ""
+    │   │           └── @ HTMLAttributeNode (location: (1:12)-(1:20))
+    │   │               ├── name:
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:12)-(1:20))
+    │   │               │       └── children: (1 item)
+    │   │               │           └── @ LiteralNode (location: (1:12)-(1:20))
+    │   │               │               └── content: "href"
+    │   │               │
+    │   │               │
+    │   │               ├── equals: "=" (location: (1:12)-(1:20))
+    │   │               └── value:
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:12)-(1:20))
+    │   │                       ├── open_quote: """ (location: (1:12)-(1:12))
+    │   │                       ├── children: (1 item)
+    │   │                       │   └── @ LiteralNode (location: (1:12)-(1:20))
+    │   │                       │       └── content: "/about"
+    │   │                       │
+    │   │                       ├── close_quote: """ (location: (1:20)-(1:20))
+    │   │                       └── quoted: true
+    │   │
     │   │
     │   │
     │   ├── tag_name: "a" (location: (1:4)-(1:11))

--- a/test/snapshots/analyze/action_view/url_helper/link_to_test/test_0045_link_to_with_inline_block_and_path_helper_with_variable_options_4ef0d7199cab190bc199910810c50b7c-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/url_helper/link_to_test/test_0045_link_to_with_inline_block_and_path_helper_with_variable_options_4ef0d7199cab190bc199910810c50b7c-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -14,29 +14,29 @@ options: {action_view_helpers: true}
     │   │       ├── tag_closing: "%>" (location: (1:43)-(1:45))
     │   │       ├── tag_name: "a" (location: (1:4)-(1:11))
     │   │       └── children: (2 items)
-    │   │           ├── @ HTMLAttributeNode (location: (1:12)-(1:21))
-    │   │           │   ├── name:
-    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:12)-(1:21))
-    │   │           │   │       └── children: (1 item)
-    │   │           │   │           └── @ LiteralNode (location: (1:12)-(1:21))
-    │   │           │   │               └── content: "href"
-    │   │           │   │
-    │   │           │   │
-    │   │           │   ├── equals: ":" (location: (1:12)-(1:21))
-    │   │           │   └── value:
-    │   │           │       └── @ HTMLAttributeValueNode (location: (1:12)-(1:21))
-    │   │           │           ├── open_quote: ∅
-    │   │           │           ├── children: (1 item)
-    │   │           │           │   └── @ RubyLiteralNode (location: (1:12)-(1:21))
-    │   │           │           │       └── content: "root_path"
-    │   │           │           │
-    │   │           │           ├── close_quote: ∅
-    │   │           │           └── quoted: false
+    │   │           ├── @ RubyHTMLAttributesSplatNode (location: (1:23)-(1:23))
+    │   │           │   ├── content: "tag.attributes(**options)"
+    │   │           │   └── prefix: ""
     │   │           │
-    │   │           │
-    │   │           └── @ RubyHTMLAttributesSplatNode (location: (1:23)-(1:23))
-    │   │               ├── content: "tag.attributes(**options)"
-    │   │               └── prefix: ""
+    │   │           └── @ HTMLAttributeNode (location: (1:12)-(1:21))
+    │   │               ├── name:
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:12)-(1:21))
+    │   │               │       └── children: (1 item)
+    │   │               │           └── @ LiteralNode (location: (1:12)-(1:21))
+    │   │               │               └── content: "href"
+    │   │               │
+    │   │               │
+    │   │               ├── equals: ":" (location: (1:12)-(1:21))
+    │   │               └── value:
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:12)-(1:21))
+    │   │                       ├── open_quote: ∅
+    │   │                       ├── children: (1 item)
+    │   │                       │   └── @ RubyLiteralNode (location: (1:12)-(1:21))
+    │   │                       │       └── content: "root_path"
+    │   │                       │
+    │   │                       ├── close_quote: ∅
+    │   │                       └── quoted: false
+    │   │
     │   │
     │   │
     │   ├── tag_name: "a" (location: (1:4)-(1:11))

--- a/test/snapshots/analyze/action_view/url_helper/link_to_test/test_0047_link_to_with_symbol_hashrocket_class_attribute_d8747184fbfad5a9dfa2724f8ac127e7-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/url_helper/link_to_test/test_0047_link_to_with_symbol_hashrocket_class_attribute_d8747184fbfad5a9dfa2724f8ac127e7-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -14,43 +14,43 @@ options: {action_view_helpers: true}
     │   │       ├── tag_closing: "%>" (location: (1:55)-(1:57))
     │   │       ├── tag_name: "a" (location: (1:4)-(1:11))
     │   │       └── children: (2 items)
-    │   │           ├── @ HTMLAttributeNode (location: (1:26)-(1:33))
+    │   │           ├── @ HTMLAttributeNode (location: (1:36)-(1:54))
     │   │           │   ├── name:
-    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:26)-(1:33))
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:36)-(1:41))
     │   │           │   │       └── children: (1 item)
-    │   │           │   │           └── @ LiteralNode (location: (1:26)-(1:33))
-    │   │           │   │               └── content: "href"
+    │   │           │   │           └── @ LiteralNode (location: (1:36)-(1:41))
+    │   │           │   │               └── content: "class"
     │   │           │   │
     │   │           │   │
-    │   │           │   ├── equals: "=" (location: (1:26)-(1:33))
+    │   │           │   ├── equals: " => " (location: (1:41)-(1:45))
     │   │           │   └── value:
-    │   │           │       └── @ HTMLAttributeValueNode (location: (1:26)-(1:33))
-    │   │           │           ├── open_quote: """ (location: (1:26)-(1:26))
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:45)-(1:54))
+    │   │           │           ├── open_quote: """ (location: (1:45)-(1:46))
     │   │           │           ├── children: (1 item)
-    │   │           │           │   └── @ LiteralNode (location: (1:26)-(1:33))
-    │   │           │           │       └── content: "/path"
+    │   │           │           │   └── @ LiteralNode (location: (1:46)-(1:53))
+    │   │           │           │       └── content: "classes"
     │   │           │           │
-    │   │           │           ├── close_quote: """ (location: (1:33)-(1:33))
+    │   │           │           ├── close_quote: """ (location: (1:53)-(1:54))
     │   │           │           └── quoted: true
     │   │           │
     │   │           │
-    │   │           └── @ HTMLAttributeNode (location: (1:36)-(1:54))
+    │   │           └── @ HTMLAttributeNode (location: (1:26)-(1:33))
     │   │               ├── name:
-    │   │               │   └── @ HTMLAttributeNameNode (location: (1:36)-(1:41))
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:26)-(1:33))
     │   │               │       └── children: (1 item)
-    │   │               │           └── @ LiteralNode (location: (1:36)-(1:41))
-    │   │               │               └── content: "class"
+    │   │               │           └── @ LiteralNode (location: (1:26)-(1:33))
+    │   │               │               └── content: "href"
     │   │               │
     │   │               │
-    │   │               ├── equals: " => " (location: (1:41)-(1:45))
+    │   │               ├── equals: "=" (location: (1:26)-(1:33))
     │   │               └── value:
-    │   │                   └── @ HTMLAttributeValueNode (location: (1:45)-(1:54))
-    │   │                       ├── open_quote: """ (location: (1:45)-(1:46))
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:26)-(1:33))
+    │   │                       ├── open_quote: """ (location: (1:26)-(1:26))
     │   │                       ├── children: (1 item)
-    │   │                       │   └── @ LiteralNode (location: (1:46)-(1:53))
-    │   │                       │       └── content: "classes"
+    │   │                       │   └── @ LiteralNode (location: (1:26)-(1:33))
+    │   │                       │       └── content: "/path"
     │   │                       │
-    │   │                       ├── close_quote: """ (location: (1:53)-(1:54))
+    │   │                       ├── close_quote: """ (location: (1:33)-(1:33))
     │   │                       └── quoted: true
     │   │
     │   │

--- a/test/snapshots/analyze/action_view/url_helper/link_to_test/test_0048_link_to_with_string_hashrocket_class_attribute_d814a1f74ee14557fb1539554996c2b7-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/url_helper/link_to_test/test_0048_link_to_with_string_hashrocket_class_attribute_d814a1f74ee14557fb1539554996c2b7-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -14,43 +14,43 @@ options: {action_view_helpers: true}
     │   │       ├── tag_closing: "%>" (location: (1:56)-(1:58))
     │   │       ├── tag_name: "a" (location: (1:4)-(1:11))
     │   │       └── children: (2 items)
-    │   │           ├── @ HTMLAttributeNode (location: (1:26)-(1:33))
+    │   │           ├── @ HTMLAttributeNode (location: (1:36)-(1:55))
     │   │           │   ├── name:
-    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:26)-(1:33))
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:36)-(1:41))
     │   │           │   │       └── children: (1 item)
-    │   │           │   │           └── @ LiteralNode (location: (1:26)-(1:33))
-    │   │           │   │               └── content: "href"
+    │   │           │   │           └── @ LiteralNode (location: (1:36)-(1:41))
+    │   │           │   │               └── content: "class"
     │   │           │   │
     │   │           │   │
-    │   │           │   ├── equals: "=" (location: (1:26)-(1:33))
+    │   │           │   ├── equals: " => " (location: (1:42)-(1:46))
     │   │           │   └── value:
-    │   │           │       └── @ HTMLAttributeValueNode (location: (1:26)-(1:33))
-    │   │           │           ├── open_quote: """ (location: (1:26)-(1:26))
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:46)-(1:55))
+    │   │           │           ├── open_quote: """ (location: (1:46)-(1:47))
     │   │           │           ├── children: (1 item)
-    │   │           │           │   └── @ LiteralNode (location: (1:26)-(1:33))
-    │   │           │           │       └── content: "/path"
+    │   │           │           │   └── @ LiteralNode (location: (1:47)-(1:54))
+    │   │           │           │       └── content: "classes"
     │   │           │           │
-    │   │           │           ├── close_quote: """ (location: (1:33)-(1:33))
+    │   │           │           ├── close_quote: """ (location: (1:54)-(1:55))
     │   │           │           └── quoted: true
     │   │           │
     │   │           │
-    │   │           └── @ HTMLAttributeNode (location: (1:36)-(1:55))
+    │   │           └── @ HTMLAttributeNode (location: (1:26)-(1:33))
     │   │               ├── name:
-    │   │               │   └── @ HTMLAttributeNameNode (location: (1:36)-(1:41))
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:26)-(1:33))
     │   │               │       └── children: (1 item)
-    │   │               │           └── @ LiteralNode (location: (1:36)-(1:41))
-    │   │               │               └── content: "class"
+    │   │               │           └── @ LiteralNode (location: (1:26)-(1:33))
+    │   │               │               └── content: "href"
     │   │               │
     │   │               │
-    │   │               ├── equals: " => " (location: (1:42)-(1:46))
+    │   │               ├── equals: "=" (location: (1:26)-(1:33))
     │   │               └── value:
-    │   │                   └── @ HTMLAttributeValueNode (location: (1:46)-(1:55))
-    │   │                       ├── open_quote: """ (location: (1:46)-(1:47))
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:26)-(1:33))
+    │   │                       ├── open_quote: """ (location: (1:26)-(1:26))
     │   │                       ├── children: (1 item)
-    │   │                       │   └── @ LiteralNode (location: (1:47)-(1:54))
-    │   │                       │       └── content: "classes"
+    │   │                       │   └── @ LiteralNode (location: (1:26)-(1:33))
+    │   │                       │       └── content: "/path"
     │   │                       │
-    │   │                       ├── close_quote: """ (location: (1:54)-(1:55))
+    │   │                       ├── close_quote: """ (location: (1:33)-(1:33))
     │   │                       └── quoted: true
     │   │
     │   │

--- a/test/snapshots/analyze/action_view/url_helper/link_to_test/test_0049_link_to_with_label_syntax_class_attribute_12e3295fc74d99a24afd9404892cca1d-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/url_helper/link_to_test/test_0049_link_to_with_label_syntax_class_attribute_12e3295fc74d99a24afd9404892cca1d-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -14,43 +14,43 @@ options: {action_view_helpers: true}
     │   │       ├── tag_closing: "%>" (location: (1:52)-(1:54))
     │   │       ├── tag_name: "a" (location: (1:4)-(1:11))
     │   │       └── children: (2 items)
-    │   │           ├── @ HTMLAttributeNode (location: (1:26)-(1:33))
+    │   │           ├── @ HTMLAttributeNode (location: (1:35)-(1:51))
     │   │           │   ├── name:
-    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:26)-(1:33))
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:35)-(1:40))
     │   │           │   │       └── children: (1 item)
-    │   │           │   │           └── @ LiteralNode (location: (1:26)-(1:33))
-    │   │           │   │               └── content: "href"
+    │   │           │   │           └── @ LiteralNode (location: (1:35)-(1:40))
+    │   │           │   │               └── content: "class"
     │   │           │   │
     │   │           │   │
-    │   │           │   ├── equals: "=" (location: (1:26)-(1:33))
+    │   │           │   ├── equals: ": " (location: (1:40)-(1:42))
     │   │           │   └── value:
-    │   │           │       └── @ HTMLAttributeValueNode (location: (1:26)-(1:33))
-    │   │           │           ├── open_quote: """ (location: (1:26)-(1:26))
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:42)-(1:51))
+    │   │           │           ├── open_quote: """ (location: (1:42)-(1:43))
     │   │           │           ├── children: (1 item)
-    │   │           │           │   └── @ LiteralNode (location: (1:26)-(1:33))
-    │   │           │           │       └── content: "/path"
+    │   │           │           │   └── @ LiteralNode (location: (1:43)-(1:50))
+    │   │           │           │       └── content: "classes"
     │   │           │           │
-    │   │           │           ├── close_quote: """ (location: (1:33)-(1:33))
+    │   │           │           ├── close_quote: """ (location: (1:50)-(1:51))
     │   │           │           └── quoted: true
     │   │           │
     │   │           │
-    │   │           └── @ HTMLAttributeNode (location: (1:35)-(1:51))
+    │   │           └── @ HTMLAttributeNode (location: (1:26)-(1:33))
     │   │               ├── name:
-    │   │               │   └── @ HTMLAttributeNameNode (location: (1:35)-(1:40))
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:26)-(1:33))
     │   │               │       └── children: (1 item)
-    │   │               │           └── @ LiteralNode (location: (1:35)-(1:40))
-    │   │               │               └── content: "class"
+    │   │               │           └── @ LiteralNode (location: (1:26)-(1:33))
+    │   │               │               └── content: "href"
     │   │               │
     │   │               │
-    │   │               ├── equals: ": " (location: (1:40)-(1:42))
+    │   │               ├── equals: "=" (location: (1:26)-(1:33))
     │   │               └── value:
-    │   │                   └── @ HTMLAttributeValueNode (location: (1:42)-(1:51))
-    │   │                       ├── open_quote: """ (location: (1:42)-(1:43))
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:26)-(1:33))
+    │   │                       ├── open_quote: """ (location: (1:26)-(1:26))
     │   │                       ├── children: (1 item)
-    │   │                       │   └── @ LiteralNode (location: (1:43)-(1:50))
-    │   │                       │       └── content: "classes"
+    │   │                       │   └── @ LiteralNode (location: (1:26)-(1:33))
+    │   │                       │       └── content: "/path"
     │   │                       │
-    │   │                       ├── close_quote: """ (location: (1:50)-(1:51))
+    │   │                       ├── close_quote: """ (location: (1:33)-(1:33))
     │   │                       └── quoted: true
     │   │
     │   │

--- a/test/snapshots/analyze/action_view/url_helper/link_to_test/test_0050_link_to_with_quoted_label_syntax_class_attribute_e2903638f3fed3456f5845dd19653128-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/url_helper/link_to_test/test_0050_link_to_with_quoted_label_syntax_class_attribute_e2903638f3fed3456f5845dd19653128-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -14,43 +14,43 @@ options: {action_view_helpers: true}
     │   │       ├── tag_closing: "%>" (location: (1:54)-(1:56))
     │   │       ├── tag_name: "a" (location: (1:4)-(1:11))
     │   │       └── children: (2 items)
-    │   │           ├── @ HTMLAttributeNode (location: (1:26)-(1:33))
+    │   │           ├── @ HTMLAttributeNode (location: (1:36)-(1:53))
     │   │           │   ├── name:
-    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:26)-(1:33))
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:36)-(1:41))
     │   │           │   │       └── children: (1 item)
-    │   │           │   │           └── @ LiteralNode (location: (1:26)-(1:33))
-    │   │           │   │               └── content: "href"
+    │   │           │   │           └── @ LiteralNode (location: (1:36)-(1:41))
+    │   │           │   │               └── content: "class"
     │   │           │   │
     │   │           │   │
-    │   │           │   ├── equals: "=" (location: (1:26)-(1:33))
+    │   │           │   ├── equals: ": " (location: (1:42)-(1:44))
     │   │           │   └── value:
-    │   │           │       └── @ HTMLAttributeValueNode (location: (1:26)-(1:33))
-    │   │           │           ├── open_quote: """ (location: (1:26)-(1:26))
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:44)-(1:53))
+    │   │           │           ├── open_quote: """ (location: (1:44)-(1:45))
     │   │           │           ├── children: (1 item)
-    │   │           │           │   └── @ LiteralNode (location: (1:26)-(1:33))
-    │   │           │           │       └── content: "/path"
+    │   │           │           │   └── @ LiteralNode (location: (1:45)-(1:52))
+    │   │           │           │       └── content: "classes"
     │   │           │           │
-    │   │           │           ├── close_quote: """ (location: (1:33)-(1:33))
+    │   │           │           ├── close_quote: """ (location: (1:52)-(1:53))
     │   │           │           └── quoted: true
     │   │           │
     │   │           │
-    │   │           └── @ HTMLAttributeNode (location: (1:36)-(1:53))
+    │   │           └── @ HTMLAttributeNode (location: (1:26)-(1:33))
     │   │               ├── name:
-    │   │               │   └── @ HTMLAttributeNameNode (location: (1:36)-(1:41))
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:26)-(1:33))
     │   │               │       └── children: (1 item)
-    │   │               │           └── @ LiteralNode (location: (1:36)-(1:41))
-    │   │               │               └── content: "class"
+    │   │               │           └── @ LiteralNode (location: (1:26)-(1:33))
+    │   │               │               └── content: "href"
     │   │               │
     │   │               │
-    │   │               ├── equals: ": " (location: (1:42)-(1:44))
+    │   │               ├── equals: "=" (location: (1:26)-(1:33))
     │   │               └── value:
-    │   │                   └── @ HTMLAttributeValueNode (location: (1:44)-(1:53))
-    │   │                       ├── open_quote: """ (location: (1:44)-(1:45))
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:26)-(1:33))
+    │   │                       ├── open_quote: """ (location: (1:26)-(1:26))
     │   │                       ├── children: (1 item)
-    │   │                       │   └── @ LiteralNode (location: (1:45)-(1:52))
-    │   │                       │       └── content: "classes"
+    │   │                       │   └── @ LiteralNode (location: (1:26)-(1:33))
+    │   │                       │       └── content: "/path"
     │   │                       │
-    │   │                       ├── close_quote: """ (location: (1:52)-(1:53))
+    │   │                       ├── close_quote: """ (location: (1:33)-(1:33))
     │   │                       └── quoted: true
     │   │
     │   │

--- a/test/snapshots/analyze/action_view/url_helper/link_to_test/test_0051_link_to_with_mixed_data_attribute_syntax_29568bb9304ef1d9bcfe20cfa2f02bd8-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/url_helper/link_to_test/test_0051_link_to_with_mixed_data_attribute_syntax_29568bb9304ef1d9bcfe20cfa2f02bd8-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -14,26 +14,6 @@ options: {action_view_helpers: true}
     │   │       ├── tag_closing: "%>" (location: (1:84)-(1:86))
     │   │       ├── tag_name: "a" (location: (1:4)-(1:11))
     │   │       └── children: (3 items)
-    │   │           ├── @ HTMLAttributeNode (location: (1:26)-(1:33))
-    │   │           │   ├── name:
-    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:26)-(1:33))
-    │   │           │   │       └── children: (1 item)
-    │   │           │   │           └── @ LiteralNode (location: (1:26)-(1:33))
-    │   │           │   │               └── content: "href"
-    │   │           │   │
-    │   │           │   │
-    │   │           │   ├── equals: "=" (location: (1:26)-(1:33))
-    │   │           │   └── value:
-    │   │           │       └── @ HTMLAttributeValueNode (location: (1:26)-(1:33))
-    │   │           │           ├── open_quote: """ (location: (1:26)-(1:26))
-    │   │           │           ├── children: (1 item)
-    │   │           │           │   └── @ LiteralNode (location: (1:26)-(1:33))
-    │   │           │           │       └── content: "/path"
-    │   │           │           │
-    │   │           │           ├── close_quote: """ (location: (1:33)-(1:33))
-    │   │           │           └── quoted: true
-    │   │           │
-    │   │           │
     │   │           ├── @ HTMLAttributeNode (location: (1:43)-(1:62))
     │   │           │   ├── name:
     │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:43)-(1:53))
@@ -54,23 +34,43 @@ options: {action_view_helpers: true}
     │   │           │           └── quoted: true
     │   │           │
     │   │           │
-    │   │           └── @ HTMLAttributeNode (location: (1:65)-(1:81))
+    │   │           ├── @ HTMLAttributeNode (location: (1:65)-(1:81))
+    │   │           │   ├── name:
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:65)-(1:70))
+    │   │           │   │       └── children: (1 item)
+    │   │           │   │           └── @ LiteralNode (location: (1:65)-(1:70))
+    │   │           │   │               └── content: "data-hello"
+    │   │           │   │
+    │   │           │   │
+    │   │           │   ├── equals: " => " (location: (1:70)-(1:74))
+    │   │           │   └── value:
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:74)-(1:81))
+    │   │           │           ├── open_quote: """ (location: (1:74)-(1:75))
+    │   │           │           ├── children: (1 item)
+    │   │           │           │   └── @ LiteralNode (location: (1:75)-(1:80))
+    │   │           │           │       └── content: "value"
+    │   │           │           │
+    │   │           │           ├── close_quote: """ (location: (1:80)-(1:81))
+    │   │           │           └── quoted: true
+    │   │           │
+    │   │           │
+    │   │           └── @ HTMLAttributeNode (location: (1:26)-(1:33))
     │   │               ├── name:
-    │   │               │   └── @ HTMLAttributeNameNode (location: (1:65)-(1:70))
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:26)-(1:33))
     │   │               │       └── children: (1 item)
-    │   │               │           └── @ LiteralNode (location: (1:65)-(1:70))
-    │   │               │               └── content: "data-hello"
+    │   │               │           └── @ LiteralNode (location: (1:26)-(1:33))
+    │   │               │               └── content: "href"
     │   │               │
     │   │               │
-    │   │               ├── equals: " => " (location: (1:70)-(1:74))
+    │   │               ├── equals: "=" (location: (1:26)-(1:33))
     │   │               └── value:
-    │   │                   └── @ HTMLAttributeValueNode (location: (1:74)-(1:81))
-    │   │                       ├── open_quote: """ (location: (1:74)-(1:75))
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:26)-(1:33))
+    │   │                       ├── open_quote: """ (location: (1:26)-(1:26))
     │   │                       ├── children: (1 item)
-    │   │                       │   └── @ LiteralNode (location: (1:75)-(1:80))
-    │   │                       │       └── content: "value"
+    │   │                       │   └── @ LiteralNode (location: (1:26)-(1:33))
+    │   │                       │       └── content: "/path"
     │   │                       │
-    │   │                       ├── close_quote: """ (location: (1:80)-(1:81))
+    │   │                       ├── close_quote: """ (location: (1:33)-(1:33))
     │   │                       └── quoted: true
     │   │
     │   │


### PR DESCRIPTION
In Rails, keyword attributes (like `class`, `data-controller`, `defer`) appear before positional attributes (`src`, `href`, `id`) in the rendered HTML. 

Previously, the parser used `prepend_attribute` which placed positional attributes first, producing a different ordering than Rails.

This changes all `prepend_attribute` calls to `hb_array_append`, so positional attributes (`src`, `href`, `id`) are appended after keyword attributes matching the rendered Rails output.

For `turbo_frame_tag`, the `id` attribute is inserted before `src` and `target` (but after other keyword attributes) to match how `turbo-rails` renders `<turbo-frame>` elements.