### PR TITLE
Core: Introduce `isPrismNodeType` for Prism node type checks

### DIFF
--- a/javascript/packages/core/src/prism/index.ts
+++ b/javascript/packages/core/src/prism/index.ts
@@ -1,6 +1,8 @@
 import { deserialize } from "@ruby/prism/src/deserialize.js"
 import type { ParseResult as PrismParseResult } from "@ruby/prism/src/deserialize.js"
 
+import type * as PrismNodeTypes from "@ruby/prism/src/nodes.js"
+
 export * as PrismNodes from "@ruby/prism/src/nodes.js"
 
 export { Visitor as PrismVisitor, BasicVisitor as PrismBasicVisitor } from "@ruby/prism/src/visitor.js"
@@ -10,6 +12,24 @@ export type PrismLocation = { startOffset: number; length: number }
 export type { PrismParseResult }
 
 export { inspectPrismNode, inspectPrismSerialized } from "./inspect.js"
+
+type PrismNodeConstructors = typeof PrismNodeTypes
+
+type PrismNodeInstanceMap = {
+  [K in keyof PrismNodeConstructors]: PrismNodeConstructors[K] extends new (...args: any[]) => infer R ? R : never
+}
+
+/**
+ * Checks if a Prism node is of a specific type by comparing constructor names.
+ *
+ * This is preferred over `instanceof` because `@ruby/prism` classes may be
+ * duplicated across bundled packages, causing `instanceof` checks to fail.
+ */
+export function isPrismNodeType<T extends keyof PrismNodeInstanceMap>(node: PrismNode | null | undefined, type: T): node is PrismNodeInstanceMap[T] {
+  if (!node) return false
+
+  return node.constructor?.name === type
+}
 
 /**
  * Deserialize a Prism parse result from the raw bytes produced by pm_serialize().

--- a/javascript/packages/linter/src/rules/action-view-utils.ts
+++ b/javascript/packages/linter/src/rules/action-view-utils.ts
@@ -1,12 +1,13 @@
+import { isPrismNodeType } from "@herb-tools/core"
 import type { PrismNode } from "@herb-tools/core"
 
 /**
  * Checks if a Prism node represents a `tag.attributes(...)` call.
  */
 export function isTagAttributesCall(prismNode: PrismNode): boolean {
-  if (prismNode?.constructor?.name !== "CallNode") return false
+  if (!isPrismNodeType(prismNode, "CallNode")) return false
   if (prismNode.name !== "attributes") return false
-  if (prismNode.receiver?.constructor?.name !== "CallNode") return false
+  if (!isPrismNodeType(prismNode.receiver, "CallNode")) return false
 
   return prismNode.receiver.name === "tag"
 }
@@ -21,9 +22,7 @@ export function isTagAttributesCall(prismNode: PrismNode): boolean {
  * - `condition || tag.attributes(...)`
  */
 export function isConditionalTagAttributesCall(prismNode: PrismNode): boolean {
-  const type = prismNode?.constructor?.name
-
-  if (type === "IfNode" || type === "UnlessNode") {
+  if (isPrismNodeType(prismNode, "IfNode") || isPrismNodeType(prismNode, "UnlessNode")) {
     const body = prismNode.statements?.body
 
     if (!Array.isArray(body) || body.length !== 1) return false
@@ -31,7 +30,7 @@ export function isConditionalTagAttributesCall(prismNode: PrismNode): boolean {
     return isTagAttributesCall(body[0])
   }
 
-  if (type === "AndNode" || type === "OrNode") {
+  if (isPrismNodeType(prismNode, "AndNode") || isPrismNodeType(prismNode, "OrNode")) {
     return isTagAttributesCall(prismNode.right)
   }
 

--- a/javascript/packages/linter/src/rules/erb-prefer-direct-output.ts
+++ b/javascript/packages/linter/src/rules/erb-prefer-direct-output.ts
@@ -3,7 +3,7 @@ import { ParserRule, BaseAutofixContext } from "../types.js"
 import { ERBStringToDirectOutputRewriter } from "@herb-tools/rewriter"
 
 import { locationFromOffset } from "./rule-utils.js"
-import { isERBOutputNode, createLiteral, createERBOutputNode, findParentArray } from "@herb-tools/core"
+import { isERBOutputNode, createLiteral, createERBOutputNode, findParentArray, isPrismNodeType } from "@herb-tools/core"
 
 import type { Mutable, ReplacementPart } from "@herb-tools/rewriter"
 import type { ParseResult, ERBContentNode, ParserOptions, Node } from "@herb-tools/core"
@@ -28,7 +28,6 @@ class PreferDirectOutputVisitor extends BaseRuleVisitor<PreferDirectOutputAutofi
 
     if (!ERBStringToDirectOutputRewriter.isStringOutputNode(prismNode)) return
 
-    const nodeType = prismNode.constructor.name
     const replacementParts = ERBStringToDirectOutputRewriter.extractReplacementParts(prismNode, source)
 
     const { startOffset, length } = prismNode.location
@@ -38,7 +37,7 @@ class PreferDirectOutputVisitor extends BaseRuleVisitor<PreferDirectOutputAutofi
       ? { node: node as Mutable<ERBContentNode>, replacementParts }
       : undefined
 
-    if (nodeType === "StringNode") {
+    if (isPrismNodeType(prismNode, "StringNode")) {
       this.addOffense(
         `Avoid outputting string literal \`${content}\`. Write the text directly without wrapping it in an ERB output tag.`,
         stringLocation,
@@ -46,7 +45,7 @@ class PreferDirectOutputVisitor extends BaseRuleVisitor<PreferDirectOutputAutofi
       )
     }
 
-    if (nodeType === "InterpolatedStringNode") {
+    if (isPrismNodeType(prismNode, "InterpolatedStringNode")) {
       this.addOffense(
         `Avoid outputting interpolated string \`${content}\`. Use separate \`<%= %>\` tags for each dynamic value instead.`,
         stringLocation,

--- a/javascript/packages/linter/src/rules/prism-rule-utils.ts
+++ b/javascript/packages/linter/src/rules/prism-rule-utils.ts
@@ -1,3 +1,4 @@
+import { isPrismNodeType } from "@herb-tools/core"
 import type { PrismNode } from "@herb-tools/core"
 
 export const DEBUG_OUTPUT_METHODS = new Set(["p", "pp", "puts", "print", "warn", "debug", "byebug"])
@@ -16,7 +17,7 @@ export function isDebugOutputCall(node: PrismNode): boolean {
   if (BINDING_DEBUGGER_METHODS.has(node.name)) {
     const receiver = node.receiver
 
-    if (receiver?.constructor?.name === "CallNode") {
+    if (isPrismNodeType(receiver, "CallNode")) {
       return receiver.name === "binding" && !receiver.receiver
     }
   }

--- a/javascript/packages/linter/test/__snapshots__/cli.test.ts.snap
+++ b/javascript/packages/linter/test/__snapshots__/cli.test.ts.snap
@@ -303,6 +303,46 @@ test/fixtures/ignored.html.erb:6:14
       This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
 `;
 
+exports[`CLI Output Formatting > allows tag.attributes in attribute position 1`] = `
+"[warning] Avoid using \`tag.attributes\` to set all attributes on \`<div>\`. Use \`tag.div\` or add the attributes directly to the \`<div>\` tag instead. (actionview-no-unnecessary-tag-attributes) [Correctable]
+
+test/fixtures/tag-attributes.html.erb:1:0
+
+  →   1 │ <div <%= tag.attributes(class: ["one", "two", "three"]) %>>
+        │ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      2 │   Content
+      3 │ </div>
+
+
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯  [1/2] ⎯⎯⎯⎯
+
+[warning] Avoid using \`tag.attributes\` to set all attributes on \`<input>\`. Use \`tag.input\` or add the attributes directly to the \`<input>\` tag instead. (actionview-no-unnecessary-tag-attributes) [Correctable]
+
+test/fixtures/tag-attributes.html.erb:5:0
+
+      3 │ </div>
+      4 │ 
+  →   5 │ <input <%= tag.attributes(type: :text, aria: { label: "Search" }) %>>
+        │ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      6 │ 
+      7 │ <button class="primary" <%= tag.attributes(id: "cta", aria: { expanded: false }) %>>Click</button>
+
+
+
+ Rule offenses:
+  actionview-no-unnecessary-tag-attributes (2 offenses in 1 file)
+
+
+ Summary:
+  Checked      1 file
+  Offenses     2 warnings (2 offenses across 1 file)
+  Fixable      2 offenses | 2 autocorrectable using \`--fix\`
+  Rules        83 enabled | 10 not enabled
+
+ TIP: Run herb-lint --init to create a .herb.yml and lock the version.
+      This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
+`;
+
 exports[`CLI Output Formatting > diplays only parsers errors if one is present 1`] = `
 "[error] Unexpected Token. Expected: an identifier, \`@\`, \`<%\`, whitespace, or a newline, found: a character. (\`UNEXPECTED_ERROR\`) (parser-no-errors)
 

--- a/javascript/packages/linter/test/cli.test.ts
+++ b/javascript/packages/linter/test/cli.test.ts
@@ -61,6 +61,14 @@ describe("CLI Output Formatting", () => {
     expect(exitCode).toBe(0)
   })
 
+  test("allows tag.attributes in attribute position", () => {
+    const { output, exitCode } = runLinter("tag-attributes.html.erb", "--no-wrap-lines")
+
+    expect(output).toMatchSnapshot()
+    expect(output).not.toContain("erb-no-output-in-attribute-position")
+    expect(exitCode).toBe(0)
+  })
+
   test("formats success output correctly", () => {
     const { output, exitCode } = runLinter("clean-file.html.erb", "--no-wrap-lines")
 

--- a/javascript/packages/linter/test/fixtures/tag-attributes.html.erb
+++ b/javascript/packages/linter/test/fixtures/tag-attributes.html.erb
@@ -1,0 +1,7 @@
+<div <%= tag.attributes(class: ["one", "two", "three"]) %>>
+  Content
+</div>
+
+<input <%= tag.attributes(type: :text, aria: { label: "Search" }) %>>
+
+<button class="primary" <%= tag.attributes(id: "cta", aria: { expanded: false }) %>>Click</button>

--- a/javascript/packages/rewriter/src/built-ins/erb-string-to-direct-output.ts
+++ b/javascript/packages/rewriter/src/built-ins/erb-string-to-direct-output.ts
@@ -1,4 +1,4 @@
-import { Visitor, isERBOutputNode, createLiteral, createERBOutputNode, findParentArray } from "@herb-tools/core"
+import { Visitor, isERBOutputNode, createLiteral, createERBOutputNode, findParentArray, isPrismNodeType } from "@herb-tools/core"
 
 import { ASTRewriter } from "../ast-rewriter.js"
 
@@ -102,9 +102,7 @@ export class ERBStringToDirectOutputRewriter extends ASTRewriter {
   }
 
   static isStringOutputNode(prismNode: PrismNode): boolean {
-    const nodeType = prismNode.constructor.name
-
-    return nodeType === STRING_NODE_TYPE || nodeType === INTERPOLATED_STRING_NODE_TYPE
+    return isPrismNodeType(prismNode, STRING_NODE_TYPE) || isPrismNodeType(prismNode, INTERPOLATED_STRING_NODE_TYPE)
   }
 
   static extractStringContent(stringNode: PrismNode, source: string): string {
@@ -136,14 +134,12 @@ export class ERBStringToDirectOutputRewriter extends ASTRewriter {
   }
 
   static extractReplacementParts(prismNode: PrismNode, source: string): ReplacementPart[] | null {
-    const nodeType = prismNode.constructor.name
-
-    if (nodeType === STRING_NODE_TYPE) {
+    if (isPrismNodeType(prismNode, STRING_NODE_TYPE)) {
       const textContent = this.extractStringContent(prismNode, source)
       return [{ type: "text", content: textContent }]
     }
 
-    if (nodeType === INTERPOLATED_STRING_NODE_TYPE) {
+    if (isPrismNodeType(prismNode, INTERPOLATED_STRING_NODE_TYPE)) {
       const parts = prismNode.parts
 
       if (!parts || parts.length === 0) return null
@@ -151,15 +147,13 @@ export class ERBStringToDirectOutputRewriter extends ASTRewriter {
       const replacementParts: ReplacementPart[] = []
 
       for (const part of parts) {
-        const partType = part.constructor.name
-
-        if (partType === STRING_NODE_TYPE) {
+        if (isPrismNodeType(part, STRING_NODE_TYPE)) {
           const textContent = this.extractStringContent(part, source)
 
           if (textContent) {
             replacementParts.push({ type: "text", content: textContent })
           }
-        } else if (partType === EMBEDDED_STATEMENTS_NODE_TYPE) {
+        } else if (isPrismNodeType(part, EMBEDDED_STATEMENTS_NODE_TYPE)) {
           const expression = this.extractExpressionSource(part, source)
 
           if (expression) {


### PR DESCRIPTION
Prism node type checks using `constructor.name` are scattered across the linter and rewriter packages. This is fragile because `@ruby/prism` classes may be duplicated across bundled packages, and `instanceof` checks fail across bundle boundaries.

This pull request introduces a centralized `isPrismNodeType` type guard in `@herb-tools/core` that:
- Compares `constructor.name` in a single place
- Acts as a TypeScript type guard, narrowing to the specific `PrismNodes.*` type
- Replaces all direct `constructor.name` checks for Prism nodes across the linter and rewriter

Also adds a CLI test with a `tag.attributes()` fixture to verify the built linter correctly allows `tag.attributes()` in attribute position, which was still being caught earlier because of the failed node type check.