### PR TITLE
Linter: Allow Turbo helpers in `erb-no-unused-expressions`

### DIFF
--- a/javascript/packages/linter/src/rules/erb-no-unused-expressions.ts
+++ b/javascript/packages/linter/src/rules/erb-no-unused-expressions.ts
@@ -29,6 +29,10 @@ const SIDE_EFFECT_METHODS = new Set([
   "content_for",
   "provide",
   "flush",
+  "turbo_refreshes_with",
+  "turbo_exempts_page_from_cache",
+  "turbo_exempts_page_from_preview",
+  "turbo_page_requires_reload",
 ])
 
 class UnusedExpressionCollector extends PrismVisitor {

--- a/javascript/packages/linter/test/rules/erb-no-unused-expressions.test.ts
+++ b/javascript/packages/linter/test/rules/erb-no-unused-expressions.test.ts
@@ -122,6 +122,15 @@ describe("ERBNoUnusedExpressionsRule", () => {
       `)
     })
 
+    test("passes for Turbo helpers", () => {
+      expectNoOffenses(dedent`
+        <% turbo_refreshes_with method: :morph, scroll: :preserve %>
+        <% turbo_exempts_page_from_cache %>
+        <% turbo_exempts_page_from_preview %>
+        <% turbo_page_requires_reload %>
+      `)
+    })
+
     test("passes for ERB comments", () => {
       expectNoOffenses(dedent`
         <%# This is a comment %>


### PR DESCRIPTION
Similar to #1559, this pull request updates the `erb-no-unused-expressions` linter rule to allow the Turbo methods as side effect methods.

I guess ideally, we could make this list configurable in the `.herb.yml` via #1204.