### PR TITLE
Linter: Don't flag render block locals in `erb-no-unused-expressions`

### DIFF
--- a/javascript/packages/linter/src/rules/erb-no-unused-expressions.ts
+++ b/javascript/packages/linter/src/rules/erb-no-unused-expressions.ts
@@ -2,12 +2,12 @@ import { ParserRule } from "../types.js"
 import { PrismVisitor } from "@herb-tools/core"
 import { BaseRuleVisitor } from "./rule-utils.js"
 
-import { isERBOutputNode } from "@herb-tools/core"
-import { isAssignmentNode, isDebugOutputCall } from "./prism-rule-utils.js"
+import { isERBOutputNode, isRubyParameterNode, isPrismNodeType } from "@herb-tools/core"
+import { isAssignmentNode, isDebugOutputCall, isCallOnLocal } from "./prism-rule-utils.js"
 import { locationFromOffset } from "./rule-utils.js"
 
 import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types.js"
-import type { ParseResult, ERBContentNode, ParserOptions, PrismNode } from "@herb-tools/core"
+import type { ParseResult, ERBContentNode, ERBRenderNode, ParserOptions, PrismNode } from "@herb-tools/core"
 
 const MUTATION_METHODS = new Set([
   "<<",
@@ -23,6 +23,7 @@ const MUTATION_METHODS = new Set([
   "replace",
   "insert",
   "concat",
+  "assert_valid_keys",
 ])
 
 const SIDE_EFFECT_METHODS = new Set([
@@ -37,20 +38,25 @@ const SIDE_EFFECT_METHODS = new Set([
 
 class UnusedExpressionCollector extends PrismVisitor {
   public readonly expressions: PrismNode[] = []
+  private readonly blockLocalNames: Set<string>
+
+  constructor(blockLocalNames: Set<string> = new Set()) {
+    super()
+
+    this.blockLocalNames = blockLocalNames
+  }
 
   override visit(node: PrismNode): void {
     if (!node) return
 
-    const type: string = node.constructor?.name ?? ""
-
-    if (type === "ProgramNode" || type === "StatementsNode") {
+    if (isPrismNodeType(node, "ProgramNode") || isPrismNodeType(node, "StatementsNode")) {
       super.visit(node)
       return
     }
 
     if (isAssignmentNode(node)) return
 
-    if (this.isUnusedExpression(node, type)) {
+    if (this.isUnusedExpression(node)) {
       this.expressions.push(node)
     }
   }
@@ -67,28 +73,50 @@ class UnusedExpressionCollector extends PrismVisitor {
     return SIDE_EFFECT_METHODS.has(node.name)
   }
 
-  private isUnusedExpression(node: PrismNode, type: string): boolean {
-    if (type === "CallNode") {
+  private isUnusedExpression(node: PrismNode): boolean {
+    if (isPrismNodeType(node, "CallNode")) {
       if (node.block) return false
       if (this.isMutationCall(node)) return false
       if (this.isSideEffectCall(node)) return false
       if (isDebugOutputCall(node)) return false
+      if (this.blockLocalNames.size > 0 && isCallOnLocal(node, this.blockLocalNames)) return false
 
       return true
     }
 
     return (
-      type === "InstanceVariableReadNode" ||
-      type === "ClassVariableReadNode" ||
-      type === "GlobalVariableReadNode" ||
-      type === "LocalVariableReadNode" ||
-      type === "ConstantReadNode" ||
-      type === "ConstantPathNode"
+      isPrismNodeType(node, "InstanceVariableReadNode") ||
+      isPrismNodeType(node, "ClassVariableReadNode") ||
+      isPrismNodeType(node, "GlobalVariableReadNode") ||
+      isPrismNodeType(node, "LocalVariableReadNode") ||
+      isPrismNodeType(node, "ConstantReadNode") ||
+      isPrismNodeType(node, "ConstantPathNode")
     )
   }
 }
 
 class ERBNoUnusedExpressionsVisitor extends BaseRuleVisitor {
+  private renderBlockLocalNames: Set<string> = new Set()
+
+  visitERBRenderNode(node: ERBRenderNode): void {
+    const previousLocalNames = this.renderBlockLocalNames
+    const localNames = new Set(previousLocalNames)
+
+    for (const argument of node.block_arguments) {
+      if (isRubyParameterNode(argument)) {
+        const name = argument.name?.value
+
+        if (name) {
+          localNames.add(name)
+        }
+      }
+    }
+
+    this.renderBlockLocalNames = localNames
+    this.visitChildNodes(node)
+    this.renderBlockLocalNames = previousLocalNames
+  }
+
   visitERBContentNode(node: ERBContentNode): void {
     if (isERBOutputNode(node)) return
 
@@ -98,7 +126,7 @@ class ERBNoUnusedExpressionsVisitor extends BaseRuleVisitor {
     const source = node.source
     if (!source) return
 
-    const collector = new UnusedExpressionCollector()
+    const collector = new UnusedExpressionCollector(this.renderBlockLocalNames)
     collector.visit(prismNode)
 
     for (const expression of collector.expressions) {

--- a/javascript/packages/linter/src/rules/prism-rule-utils.ts
+++ b/javascript/packages/linter/src/rules/prism-rule-utils.ts
@@ -24,3 +24,28 @@ export function isDebugOutputCall(node: PrismNode): boolean {
 
   return false
 }
+
+export function rootReceiver(node: PrismNode): PrismNode {
+  let current = node
+
+  while (current.receiver) {
+    current = current.receiver
+  }
+
+  return current
+}
+
+export function isCallOnLocal(node: PrismNode, localNames: Set<string>): boolean {
+  const root = rootReceiver(node)
+
+  if (isPrismNodeType(root, "LocalVariableReadNode")) {
+    return localNames.has(root.name)
+  }
+
+  if (isPrismNodeType(root, "CallNode") && !root.receiver) {
+    return localNames.has(root.name)
+  }
+
+  return false
+}
+

--- a/javascript/packages/linter/test/rules/erb-no-unused-expressions.test.ts
+++ b/javascript/packages/linter/test/rules/erb-no-unused-expressions.test.ts
@@ -131,6 +131,18 @@ describe("ERBNoUnusedExpressionsRule", () => {
       `)
     })
 
+    test("passes for assert_valid_keys", () => {
+      expectNoOffenses(dedent`
+        <%
+          link.assert_valid_keys(:href, :name, :leading_icon, :target)
+          href = link.fetch(:href)
+          name = link.fetch(:name)
+          icon = link[:leading_icon]
+          target = link[:target]
+        %>
+      `)
+    })
+
     test("passes for ERB comments", () => {
       expectNoOffenses(dedent`
         <%# This is a comment %>
@@ -147,6 +159,42 @@ describe("ERBNoUnusedExpressionsRule", () => {
       expectNoOffenses(dedent`
         <% render partial: "header" %>
         <% render "footer" %>
+      `)
+    })
+
+    test("passes for method calls on render block locals", () => {
+      expectNoOffenses(dedent`
+        <%= render BlogComponent.new do |component| %>
+          <% component.with_header(classes: "title").with_content("My blog") %>
+        <% end %>
+      `)
+    })
+
+    test("passes for simple method call on render block local", () => {
+      expectNoOffenses(dedent`
+        <%= render BlogComponent.new do |component| %>
+          <% component.with_header %>
+        <% end %>
+      `)
+    })
+
+    test("passes for multiple block locals in render", () => {
+      expectNoOffenses(dedent`
+        <%= render TableComponent.new do |table, index| %>
+          <% table.with_header %>
+          <% index.to_s %>
+        <% end %>
+      `)
+    })
+
+    test.skip("passes for method calls on outer block local inside nested render block", () => {
+      expectNoOffenses(dedent`
+        <%= render LayoutComponent.new do |layout| %>
+          <%= render CardComponent.new do |card| %>
+            <% layout.with_sidebar %>
+            <% card.with_header %>
+          <% end %>
+        <% end %>
       `)
     })
 
@@ -311,6 +359,30 @@ describe("ERBNoUnusedExpressionsRule", () => {
 
       assertOffenses(dedent`
         <% User.count %>
+      `)
+    })
+
+    test("still fails for non-block-local calls inside render block", () => {
+      expectError(
+        "Avoid unused expressions in silent ERB tags. `@user.name` is evaluated but its return value is discarded. Use `<%= ... %>` to output the value or remove the expression.",
+      )
+
+      assertOffenses(dedent`
+        <%= render BlogComponent.new do |component| %>
+          <% @user.name %>
+        <% end %>
+      `)
+    })
+
+    test("still fails for bare block local read inside render block", () => {
+      expectError(
+        "Avoid unused expressions in silent ERB tags. `component` is evaluated but its return value is discarded. Use `<%= ... %>` to output the value or remove the expression.",
+      )
+
+      assertOffenses(dedent`
+        <%= render BlogComponent.new do |component| %>
+          <% component %>
+        <% end %>
       `)
     })
   })


### PR DESCRIPTION
This pull request updates the `erb-no-unused-expressions` linter rule to  not flag method calls on render block locals anymore.

The following is now valid:
```erb
<%= render BlogComponent.new do |component| %>
  <% component.with_header(classes: "title").with_content("My blog") %>
<% end %>
```

Resolves #1580
