### PR TITLE
Parser: Properly transform nested `render` calls

### DIFF
--- a/javascript/packages/linter/test/rules/erb-no-unused-expressions.test.ts
+++ b/javascript/packages/linter/test/rules/erb-no-unused-expressions.test.ts
@@ -187,7 +187,7 @@ describe("ERBNoUnusedExpressionsRule", () => {
       `)
     })
 
-    test.skip("passes for method calls on outer block local inside nested render block", () => {
+    test("passes for method calls on outer block local inside nested render block", () => {
       expectNoOffenses(dedent`
         <%= render LayoutComponent.new do |layout| %>
           <%= render CardComponent.new do |card| %>

--- a/src/analyze/analyze.c
+++ b/src/analyze/analyze.c
@@ -962,6 +962,7 @@ hb_array_T* get_node_children_array(const AST_NODE_T* node) {
     case AST_ERB_ENSURE_NODE: return ((AST_ERB_ENSURE_NODE_T*) node)->statements;
     case AST_ERB_CASE_NODE: return ((AST_ERB_CASE_NODE_T*) node)->children;
     case AST_ERB_WHEN_NODE: return ((AST_ERB_WHEN_NODE_T*) node)->statements;
+    case AST_ERB_RENDER_NODE: return ((AST_ERB_RENDER_NODE_T*) node)->body;
     default: return NULL;
   }
 }

--- a/test/analyze/render_block_test.rb
+++ b/test/analyze/render_block_test.rb
@@ -172,5 +172,16 @@ module Analyze
         <% end %>
       HTML
     end
+
+    test "nested render blocks" do
+      assert_parsed_snapshot(<<~HTML, render_nodes: true)
+        <%= render LayoutComponent.new do |layout| %>
+          <%= render CardComponent.new do |card| %>
+            <% layout.with_sidebar %>
+            <% card.with_header %>
+          <% end %>
+        <% end %>
+      HTML
+    end
   end
 end

--- a/test/snapshots/analyze/render_block_test/test_0022_nested_render_blocks_b15a799fdd21ef9c94eba2aa044b3407-f8009707a6f8814717b65550c888710c.txt
+++ b/test/snapshots/analyze/render_block_test/test_0022_nested_render_blocks_b15a799fdd21ef9c94eba2aa044b3407-f8009707a6f8814717b65550c888710c.txt
@@ -1,0 +1,130 @@
+---
+source: "Analyze::RenderBlockTest#test_0022_nested render blocks"
+input: |2-
+<%= render LayoutComponent.new do |layout| %>
+  <%= render CardComponent.new do |card| %>
+    <% layout.with_sidebar %>
+    <% card.with_header %>
+  <% end %>
+<% end %>
+options: {render_nodes: true}
+---
+@ DocumentNode (location: (1:0)-(7:0))
+└── children: (2 items)
+    ├── @ ERBRenderNode (location: (1:0)-(6:9))
+    │   ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   ├── content: " render LayoutComponent.new do |layout| " (location: (1:3)-(1:43))
+    │   ├── tag_closing: "%>" (location: (1:43)-(1:45))
+    │   ├── keywords:
+    │   │   └── @ RubyRenderKeywordsNode (location: (1:0)-(6:9))
+    │   │       ├── partial: ∅
+    │   │       ├── template_path: ∅
+    │   │       ├── layout: ∅
+    │   │       ├── file: ∅
+    │   │       ├── inline_template: ∅
+    │   │       ├── body: ∅
+    │   │       ├── plain: ∅
+    │   │       ├── html: ∅
+    │   │       ├── renderable: ∅
+    │   │       ├── collection: ∅
+    │   │       ├── object: "LayoutComponent.new" (location: (1:11)-(1:30))
+    │   │       ├── as_name: ∅
+    │   │       ├── spacer_template: ∅
+    │   │       ├── formats: ∅
+    │   │       ├── variants: ∅
+    │   │       ├── handlers: ∅
+    │   │       ├── content_type: ∅
+    │   │       └── locals: []
+    │   │
+    │   ├── body: (3 items)
+    │   │   ├── @ HTMLTextNode (location: (1:45)-(2:2))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ ERBRenderNode (location: (2:2)-(5:11))
+    │   │   │   ├── tag_opening: "<%=" (location: (2:2)-(2:5))
+    │   │   │   ├── content: " render CardComponent.new do |card| " (location: (2:5)-(2:41))
+    │   │   │   ├── tag_closing: "%>" (location: (2:41)-(2:43))
+    │   │   │   ├── keywords:
+    │   │   │   │   └── @ RubyRenderKeywordsNode (location: (2:2)-(5:11))
+    │   │   │   │       ├── partial: ∅
+    │   │   │   │       ├── template_path: ∅
+    │   │   │   │       ├── layout: ∅
+    │   │   │   │       ├── file: ∅
+    │   │   │   │       ├── inline_template: ∅
+    │   │   │   │       ├── body: ∅
+    │   │   │   │       ├── plain: ∅
+    │   │   │   │       ├── html: ∅
+    │   │   │   │       ├── renderable: ∅
+    │   │   │   │       ├── collection: ∅
+    │   │   │   │       ├── object: "CardComponent.new" (location: (2:13)-(2:30))
+    │   │   │   │       ├── as_name: ∅
+    │   │   │   │       ├── spacer_template: ∅
+    │   │   │   │       ├── formats: ∅
+    │   │   │   │       ├── variants: ∅
+    │   │   │   │       ├── handlers: ∅
+    │   │   │   │       ├── content_type: ∅
+    │   │   │   │       └── locals: []
+    │   │   │   │
+    │   │   │   ├── body: (5 items)
+    │   │   │   │   ├── @ HTMLTextNode (location: (2:43)-(3:4))
+    │   │   │   │   │   └── content: "\n    "
+    │   │   │   │   │
+    │   │   │   │   ├── @ ERBContentNode (location: (3:4)-(3:29))
+    │   │   │   │   │   ├── tag_opening: "<%" (location: (3:4)-(3:6))
+    │   │   │   │   │   ├── content: " layout.with_sidebar " (location: (3:6)-(3:27))
+    │   │   │   │   │   ├── tag_closing: "%>" (location: (3:27)-(3:29))
+    │   │   │   │   │   ├── parsed: true
+    │   │   │   │   │   └── valid: true
+    │   │   │   │   │
+    │   │   │   │   ├── @ HTMLTextNode (location: (3:29)-(4:4))
+    │   │   │   │   │   └── content: "\n    "
+    │   │   │   │   │
+    │   │   │   │   ├── @ ERBContentNode (location: (4:4)-(4:26))
+    │   │   │   │   │   ├── tag_opening: "<%" (location: (4:4)-(4:6))
+    │   │   │   │   │   ├── content: " card.with_header " (location: (4:6)-(4:24))
+    │   │   │   │   │   ├── tag_closing: "%>" (location: (4:24)-(4:26))
+    │   │   │   │   │   ├── parsed: true
+    │   │   │   │   │   └── valid: true
+    │   │   │   │   │
+    │   │   │   │   └── @ HTMLTextNode (location: (4:26)-(5:2))
+    │   │   │   │       └── content: "\n  "
+    │   │   │   │
+    │   │   │   ├── block_arguments: (1 item)
+    │   │   │   │   └── @ RubyParameterNode (location: (2:35)-(2:39))
+    │   │   │   │       ├── name: "card" (location: (2:35)-(2:39))
+    │   │   │   │       ├── default_value: ∅
+    │   │   │   │       ├── kind: "positional"
+    │   │   │   │       └── required: true
+    │   │   │   │
+    │   │   │   ├── rescue_clause: ∅
+    │   │   │   ├── else_clause: ∅
+    │   │   │   ├── ensure_clause: ∅
+    │   │   │   └── end_node:
+    │   │   │       └── @ ERBEndNode (location: (5:2)-(5:11))
+    │   │   │           ├── tag_opening: "<%" (location: (5:2)-(5:4))
+    │   │   │           ├── content: " end " (location: (5:4)-(5:9))
+    │   │   │           └── tag_closing: "%>" (location: (5:9)-(5:11))
+    │   │   │
+    │   │   │
+    │   │   └── @ HTMLTextNode (location: (5:11)-(6:0))
+    │   │       └── content: "\n"
+    │   │
+    │   ├── block_arguments: (1 item)
+    │   │   └── @ RubyParameterNode (location: (1:35)-(1:41))
+    │   │       ├── name: "layout" (location: (1:35)-(1:41))
+    │   │       ├── default_value: ∅
+    │   │       ├── kind: "positional"
+    │   │       └── required: true
+    │   │
+    │   ├── rescue_clause: ∅
+    │   ├── else_clause: ∅
+    │   ├── ensure_clause: ∅
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (6:0)-(6:9))
+    │           ├── tag_opening: "<%" (location: (6:0)-(6:2))
+    │           ├── content: " end " (location: (6:2)-(6:7))
+    │           └── tag_closing: "%>" (location: (6:7)-(6:9))
+    │
+    │
+    └── @ HTMLTextNode (location: (6:9)-(7:0))
+        └── content: "\n"


### PR DESCRIPTION
This pull request updates the parser to properly handle and transform nested `render` calls with blocks.

The following now gets properly parsed with `render_nodes: true`:
```erb
<%= render LayoutComponent.new do |layout| %>
  <%= render CardComponent.new do |card| %>
    ...
  <% end %>
<% end %>
```

Previously, the inner render node stayed a `ERBBlockNode` and wasn't transformed to a `ERBRenderNode`.