### PR TITLE
Config: Use dynamic `import` for `tinyglobby`

### DIFF
--- a/javascript/packages/config/rollup.config.mjs
+++ b/javascript/packages/config/rollup.config.mjs
@@ -10,6 +10,7 @@ export default [
       file: "dist/herb-config.esm.js",
       format: "esm",
       sourcemap: true,
+      inlineDynamicImports: true,
     },
     external: ["yaml", "fs", "path", "picomatch", "tinyglobby"],
     plugins: [
@@ -31,6 +32,7 @@ export default [
       file: "dist/herb-config.cjs",
       format: "cjs",
       sourcemap: true,
+      inlineDynamicImports: true,
     },
     external: ["yaml", "fs", "path", "picomatch", "tinyglobby"],
     plugins: [

--- a/javascript/packages/config/src/config.ts
+++ b/javascript/packages/config/src/config.ts
@@ -5,8 +5,6 @@ import { stringify, parse, parseDocument, isMap } from "yaml"
 import { ZodError } from "zod"
 import { fromZodError } from "zod-validation-error"
 import picomatch from "picomatch"
-import { glob } from "tinyglobby"
-
 import { DiagnosticSeverity } from "@herb-tools/core"
 import { HerbConfigSchema } from "./config-schema.js"
 import { deepMerge } from "./merge.js"
@@ -254,6 +252,8 @@ export class Config {
     if (patterns.length === 0) {
       return []
     }
+
+    const { glob } = await import("tinyglobby")
 
     return await glob(patterns, {
       cwd: searchDir,


### PR DESCRIPTION
The `tinyglobby` npm modules depends on `fdir` which uses `createRequire` from Node.js's `module` package. 

The top-level import caused a `createRequire is not a function` error when the playground (or any browser consumer) imported `@herb-tools/linter`, which transitively imports `@herb-tools/config`.

Since `glob` is only used in `findFilesForTool` (a Node.js-only code path), a dynamic `import` avoids pulling `fdir` into browser bundles entirely.