### PR TITLE
Language Server: Restrict rewrite code actions to open tag range

### DIFF
--- a/javascript/packages/language-server/src/rewrite_code_action_service.ts
+++ b/javascript/packages/language-server/src/rewrite_code_action_service.ts
@@ -12,7 +12,8 @@ import type { Node, HTMLElementNode } from "@herb-tools/core"
 
 interface CollectedElement {
   node: HTMLElementNode
-  range: Range
+  elementRange: Range
+  openTagRange: Range
 }
 
 class ElementCollector extends Visitor {
@@ -23,12 +24,14 @@ class ElementCollector extends Visitor {
     if (node.element_source && node.element_source !== "HTML" && isERBOpenTagNode(node.open_tag)) {
       this.actionViewElements.push({
         node,
-        range: nodeToRange(node),
+        elementRange: nodeToRange(node),
+        openTagRange: nodeToRange(node.open_tag),
       })
     } else if (isHTMLOpenTagNode(node.open_tag) && node.open_tag.tag_name) {
       this.htmlElements.push({
         node,
-        range: nodeToRange(node),
+        elementRange: nodeToRange(node),
+        openTagRange: nodeToRange(node.open_tag),
       })
     }
 
@@ -55,7 +58,7 @@ export class RewriteCodeActionService {
     const actions: CodeAction[] = []
 
     for (const element of collector.actionViewElements) {
-      if (!this.rangesOverlap(element.range, requestedRange)) continue
+      if (!this.rangesOverlap(element.openTagRange, requestedRange)) continue
 
       const action = this.createActionViewToHTMLAction(document, element)
 
@@ -65,7 +68,7 @@ export class RewriteCodeActionService {
     }
 
     for (const element of collector.htmlElements) {
-      if (!this.rangesOverlap(element.range, requestedRange)) continue
+      if (!this.rangesOverlap(element.openTagRange, requestedRange)) continue
 
       const action = this.createHTMLToActionViewAction(document, element)
 
@@ -78,7 +81,7 @@ export class RewriteCodeActionService {
   }
 
   private createActionViewToHTMLAction(document: TextDocument, element: CollectedElement): CodeAction | null {
-    const originalText = document.getText(element.range)
+    const originalText = document.getText(element.elementRange)
 
     const parseResult = this.parserService.parseContent(originalText, {
       action_view_helpers: true,
@@ -96,7 +99,7 @@ export class RewriteCodeActionService {
 
     const edit: WorkspaceEdit = {
       changes: {
-        [document.uri]: [TextEdit.replace(element.range, rewrittenText)]
+        [document.uri]: [TextEdit.replace(element.elementRange, rewrittenText)]
       }
     }
 
@@ -113,7 +116,7 @@ export class RewriteCodeActionService {
   }
 
   private createHTMLToActionViewAction(document: TextDocument, element: CollectedElement): CodeAction | null {
-    const originalText = document.getText(element.range)
+    const originalText = document.getText(element.elementRange)
 
     const parseResult = this.parserService.parseContent(originalText, {
       track_whitespace: true,
@@ -130,7 +133,7 @@ export class RewriteCodeActionService {
 
     const edit: WorkspaceEdit = {
       changes: {
-        [document.uri]: [TextEdit.replace(element.range, rewrittenText)]
+        [document.uri]: [TextEdit.replace(element.elementRange, rewrittenText)]
       }
     }
 

--- a/javascript/packages/language-server/test/rewrite_code_action_service.test.ts
+++ b/javascript/packages/language-server/test/rewrite_code_action_service.test.ts
@@ -36,7 +36,7 @@ describe("RewriteCodeActionService", () => {
         <% end %>
       `
 
-      const actions = getCodeActions(content, 0, 0, 2, 8)
+      const actions = getCodeActions(content, 0, 0, 0, 17)
 
       const convertAction = actions.find(a => a.title.includes("Convert to"))
       expect(convertAction).toBeDefined()
@@ -51,7 +51,7 @@ describe("RewriteCodeActionService", () => {
         <% end %>
       `
 
-      const actions = getCodeActions(content, 0, 0, 2, 8)
+      const actions = getCodeActions(content, 0, 0, 0, 17)
 
       const convertAction = actions.find(a => a.title.includes("<div>"))
       expect(convertAction).toBeDefined()
@@ -61,6 +61,19 @@ describe("RewriteCodeActionService", () => {
       expect(changes).toHaveLength(1)
       expect(changes[0].newText).toContain("<div>")
       expect(changes[0].newText).toContain("</div>")
+    })
+
+    it("does not offer actions when cursor is on child content", () => {
+      const content = dedent`
+        <%= tag.div do %>
+          Content
+        <% end %>
+      `
+
+      const actions = getCodeActions(content, 1, 2, 1, 9)
+
+      const convertAction = actions.find(a => a.title.includes("<div>"))
+      expect(convertAction).toBeUndefined()
     })
 
     it("offers convert for tag.span", () => {
@@ -128,6 +141,19 @@ describe("RewriteCodeActionService", () => {
 
       const convertAction = actions.find(a => a.title.includes("tag.span"))
       expect(convertAction).toBeDefined()
+    })
+
+    it("does not offer actions when cursor is on child content", () => {
+      const content = dedent`
+        <div>
+          Content
+        </div>
+      `
+
+      const actions = getCodeActions(content, 1, 2, 1, 9)
+
+      const convertAction = actions.find(a => a.title.includes("tag.div"))
+      expect(convertAction).toBeUndefined()
     })
   })
 


### PR DESCRIPTION
This pull request updates the code actions for rewriting HTML elements in the language server only on the line of the HTML open tag itself.

Previously, it took the whole rang of the element and therefore also showed a lot of "unrelated" rewrite actions based on the hierarchy.

**Before**
<img width="1334" height="660" alt="CleanShot 2026-04-03 at 04 54 57@2x" src="https://github.com/user-attachments/assets/dda713eb-5cc6-468e-b069-0d7bdc82388a" />

**After**

<img width="1374" height="654" alt="CleanShot 2026-04-03 at 04 53 22@2x" src="https://github.com/user-attachments/assets/25f67721-d963-411a-9074-695f1ebc28af" />



Resolves https://github.com/marcoroth/herb/issues/1382