### PR TITLE
Config: Prefer `.herb.yml` over soft project indicators

### DIFF
--- a/javascript/packages/config/src/config.ts
+++ b/javascript/packages/config/src/config.ts
@@ -503,6 +503,8 @@ export class Config {
       currentPath = path.resolve(process.cwd())
     }
 
+    let firstIndicatorMatch: string | undefined
+
     while (true) {
       const configPath = path.join(currentPath, this.configPath)
 
@@ -514,20 +516,23 @@ export class Config {
         // Config not in this directory, continue
       }
 
-      for (const indicator of this.PROJECT_INDICATORS) {
-        try {
-          fsSync.accessSync(path.join(currentPath, indicator))
+      if (!firstIndicatorMatch) {
+        for (const indicator of this.PROJECT_INDICATORS) {
+          try {
+            fsSync.accessSync(path.join(currentPath, indicator))
 
-          return currentPath
-        } catch {
-          // Indicator not found, continue checking
+            firstIndicatorMatch = currentPath
+            break
+          } catch {
+            // Indicator not found, continue checking
+          }
         }
       }
 
       const parentPath = path.dirname(currentPath)
 
       if (parentPath === currentPath) {
-        return process.cwd()
+        return firstIndicatorMatch || process.cwd()
       }
 
       currentPath = parentPath
@@ -864,6 +869,8 @@ export class Config {
       currentPath = path.resolve(process.cwd())
     }
 
+    let firstIndicatorMatch: string | undefined
+
     while (true) {
       const configPath = path.join(currentPath, this.configPath)
 
@@ -875,16 +882,18 @@ export class Config {
         // Config not in this directory, continue
       }
 
-      const isProjectRoot = await this.isProjectRoot(currentPath)
+      if (!firstIndicatorMatch) {
+        const isProjectRoot = await this.isProjectRoot(currentPath)
 
-      if (isProjectRoot) {
-        return { configPath: null, projectRoot: currentPath }
+        if (isProjectRoot) {
+          firstIndicatorMatch = currentPath
+        }
       }
 
       const parentPath = path.dirname(currentPath)
 
       if (parentPath === currentPath) {
-        return { configPath: null, projectRoot: process.cwd() }
+        return { configPath: null, projectRoot: firstIndicatorMatch || process.cwd() }
       }
 
       currentPath = parentPath

--- a/javascript/packages/config/test/find-project-root.test.ts
+++ b/javascript/packages/config/test/find-project-root.test.ts
@@ -1,0 +1,44 @@
+import { describe, test, expect, beforeAll, afterAll } from "vitest"
+import { mkdirSync, writeFileSync, rmSync } from "fs"
+import { join } from "path"
+import { Config } from "../src/config.js"
+
+describe("findProjectRootSync", () => {
+  const tempDir = join(process.cwd(), "tmp-test-find-project-root")
+
+  beforeAll(() => {
+    mkdirSync(join(tempDir, "app", "frontend", "components"), { recursive: true })
+    mkdirSync(join(tempDir, "app", "views", "layouts"), { recursive: true })
+
+    writeFileSync(join(tempDir, ".herb.yml"), "linter:\n  exclude:\n    - 'app/views/**/*.html.erb'\n")
+    writeFileSync(join(tempDir, "app", "frontend", "README.md"), "# Frontend\n")
+    writeFileSync(join(tempDir, "app", "frontend", "components", "button.html.erb"), "<button></button>\n")
+    writeFileSync(join(tempDir, "app", "views", "layouts", "application.html.erb"), "<html></html>\n")
+  })
+
+  afterAll(() => {
+    rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  test("finds project root with .herb.yml over subdirectory with README.md", () => {
+    const filePath = join(tempDir, "app", "frontend", "components", "button.html.erb")
+    const projectRoot = Config.findProjectRootSync(filePath)
+
+    expect(projectRoot).toBe(tempDir)
+  })
+
+  test("finds project root from deeply nested file path", () => {
+    const filePath = join(tempDir, "app", "views", "layouts", "application.html.erb")
+    const projectRoot = Config.findProjectRootSync(filePath)
+
+    expect(projectRoot).toBe(tempDir)
+  })
+
+  test("prefers .herb.yml over soft project indicators like README.md", () => {
+    const filePath = join(tempDir, "app", "frontend", "components", "button.html.erb")
+    const projectRoot = Config.findProjectRootSync(filePath)
+
+    expect(projectRoot).not.toBe(join(tempDir, "app", "frontend"))
+    expect(projectRoot).toBe(tempDir)
+  })
+})

--- a/javascript/packages/linter/test/__snapshots__/cli.test.ts.snap
+++ b/javascript/packages/linter/test/__snapshots__/cli.test.ts.snap
@@ -115,6 +115,12 @@ test/fixtures/ignored.html.erb:8:8
       This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
 `;
 
+exports[`CLI Output Formatting > Excluded Files > skips excluded file in subdirectory with README.md project indicator 1`] = `
+"✓ Using Herb config file at /test/herb/javascript/packages/linter/test/fixtures/.herb.yml
+⚠️  File test/fixtures/subdir/excluded.html.erb is excluded by configuration patterns.
+   Use --force to lint it anyway."
+`;
+
 exports[`CLI Output Formatting > GitHub Actions format escapes special characters in messages 1`] = `
 "::warning file=test/fixtures/test-file-with-errors.html.erb,line=3,col=3,title=html-img-require-alt • @herb-tools/linter@0.9.4::Missing required \`alt\` attribute on \`<img>\` tag. Add \`alt=""\` for decorative images or \`alt="description"\` for informative images. [html-img-require-alt]%0A%0A%0Atest/fixtures/test-file-with-errors.html.erb:3:3%0A%0A      1 │ <div>%0A      2 │   <SPAN>Test content</SPAN>%0A  →   3 │   <img src="test.jpg">%0A        │    ~~~%0A      4 │ </div>%0A      5 │%0A
 

--- a/javascript/packages/linter/test/cli.test.ts
+++ b/javascript/packages/linter/test/cli.test.ts
@@ -287,6 +287,31 @@ describe("CLI Output Formatting", () => {
         try { unlinkSync(configPath) } catch {}
       }
     })
+
+    test("skips excluded file in subdirectory with README.md project indicator", () => {
+      const { mkdirSync, rmSync } = require("fs")
+      const subdir = "test/fixtures/subdir"
+
+      try {
+        mkdirSync(subdir, { recursive: true })
+        writeFileSync(`${subdir}/README.md`, "# Subdir\n")
+        writeFileSync(`${subdir}/excluded.html.erb`, '<img>\n')
+
+        writeFileSync(configPath, dedent`
+          linter:
+            exclude:
+              - "subdir/**/*.html.erb"
+        `)
+
+        const { output, exitCode } = runLinter("subdir/excluded.html.erb")
+
+        expect(output).toMatchSnapshot()
+        expect(exitCode).toBe(0)
+      } finally {
+        try { unlinkSync(configPath) } catch {}
+        try { rmSync(subdir, { recursive: true, force: true }) } catch {}
+      }
+    })
   })
 
   describe("Multiple File Arguments", () => {

--- a/javascript/packages/linter/test/snapshot-serializer.ts
+++ b/javascript/packages/linter/test/snapshot-serializer.ts
@@ -1,0 +1,21 @@
+import { resolve } from "path"
+import type { SnapshotSerializer } from "vitest"
+
+const projectRoot = resolve(__dirname, "..")
+const repoRoot = resolve(__dirname, "../../../..")
+
+const serializer: SnapshotSerializer = {
+  serialize(value: string, config, indentation, depth, refs, printer) {
+    const normalized = value
+      .replaceAll(repoRoot, "/test/herb")
+      .replaceAll(projectRoot, "/test/herb/javascript/packages/linter")
+
+    return printer(normalized, config, indentation, depth, refs)
+  },
+
+  test(value: unknown) {
+    return typeof value === "string" && value.includes(projectRoot)
+  },
+}
+
+export default serializer

--- a/javascript/packages/linter/vitest.config.ts
+++ b/javascript/packages/linter/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  test: {
+    snapshotSerializers: ["./test/snapshot-serializer.ts"],
+  },
+})


### PR DESCRIPTION
The `findProjectRootSync` and `findConfigFile` would stop at the first directory containing any project indicator (like `README.md`), even if `.herb.yml` existed higher up in the directory tree. 

This caused `exclude` patterns to be silently ignored when files were passed from subdirectories that happened to contain a `README.md` or similar indicator.

Now both methods remember the first indicator match as a fallback but keep walking up looking for `.herb.yml`. If found, it takes priority.

Resolves #1595