### PR TITLE
Linter: Add `.herb.yml` for linter tests

### DIFF
--- a/javascript/packages/linter/.herb.yml
+++ b/javascript/packages/linter/.herb.yml
@@ -1,0 +1,1 @@
+# This file exists so the linter doesn't try to find another config file outside the herb repository

--- a/javascript/packages/linter/test/__snapshots__/cli.test.ts.snap
+++ b/javascript/packages/linter/test/__snapshots__/cli.test.ts.snap
@@ -1,7 +1,9 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`CLI Output Formatting > --ignore-disable-comments 1`] = `
-"[error] ERB tag should not be empty. Remove empty ERB tags or add content. (erb-no-empty-tags)
+"✓ Using Herb config file at /test/herb/javascript/packages/linter/.herb.yml
+
+[error] ERB tag should not be empty. Remove empty ERB tags or add content. (erb-no-empty-tags)
 
 test/fixtures/ignored.html.erb:8:2
 
@@ -109,10 +111,7 @@ test/fixtures/ignored.html.erb:8:8
   Offenses     5 errors | 2 warnings (7 offenses across 1 file)
   Note         3 additional offenses reported (would have been ignored)
   Fixable      7 offenses | 4 autocorrectable using \`--fix\`
-  Rules        83 enabled | 10 not enabled
-
- TIP: Run herb-lint --init to create a .herb.yml and lock the version.
-      This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
+  Rules        83 enabled | 10 not enabled"
 `;
 
 exports[`CLI Output Formatting > Excluded Files > skips excluded file in subdirectory with README.md project indicator 1`] = `
@@ -122,7 +121,9 @@ exports[`CLI Output Formatting > Excluded Files > skips excluded file in subdire
 `;
 
 exports[`CLI Output Formatting > GitHub Actions format escapes special characters in messages 1`] = `
-"::warning file=test/fixtures/test-file-with-errors.html.erb,line=3,col=3,title=html-img-require-alt • @herb-tools/linter@0.9.5::Missing required \`alt\` attribute on \`<img>\` tag. Add \`alt=""\` for decorative images or \`alt="description"\` for informative images. [html-img-require-alt]%0A%0A%0Atest/fixtures/test-file-with-errors.html.erb:3:3%0A%0A      1 │ <div>%0A      2 │   <SPAN>Test content</SPAN>%0A  →   3 │   <img src="test.jpg">%0A        │    ~~~%0A      4 │ </div>%0A      5 │%0A
+"✓ Using Herb config file at /test/herb/javascript/packages/linter/.herb.yml
+
+::warning file=test/fixtures/test-file-with-errors.html.erb,line=3,col=3,title=html-img-require-alt • @herb-tools/linter@0.9.5::Missing required \`alt\` attribute on \`<img>\` tag. Add \`alt=""\` for decorative images or \`alt="description"\` for informative images. [html-img-require-alt]%0A%0A%0Atest/fixtures/test-file-with-errors.html.erb:3:3%0A%0A      1 │ <div>%0A      2 │   <SPAN>Test content</SPAN>%0A  →   3 │   <img src="test.jpg">%0A        │    ~~~%0A      4 │ </div>%0A      5 │%0A
 
 ::error file=test/fixtures/test-file-with-errors.html.erb,line=2,col=3,title=html-tag-name-lowercase • @herb-tools/linter@0.9.5::Opening tag name \`<SPAN>\` should be lowercase. Use \`<span>\` instead. [html-tag-name-lowercase]%0A%0A%0Atest/fixtures/test-file-with-errors.html.erb:2:3%0A%0A      1 │ <div>%0A  →   2 │   <SPAN>Test content</SPAN>%0A        │    ~~~~%0A      3 │   <img src="test.jpg">%0A      4 │ </div>%0A
 
@@ -180,7 +181,9 @@ test/fixtures/test-file-with-errors.html.erb:2:22
 `;
 
 exports[`CLI Output Formatting > GitHub Actions format includes rule codes 1`] = `
-"::error file=test/fixtures/no-trailing-newline.html.erb,line=1,col=29,title=erb-require-trailing-newline • @herb-tools/linter@0.9.5::File must end with trailing newline. [erb-require-trailing-newline]%0A%0A%0Atest/fixtures/no-trailing-newline.html.erb:1:29%0A%0A  →   1 │ <div>No trailing newline</div>%0A        │                              ~%0A
+"✓ Using Herb config file at /test/herb/javascript/packages/linter/.herb.yml
+
+::error file=test/fixtures/no-trailing-newline.html.erb,line=1,col=29,title=erb-require-trailing-newline • @herb-tools/linter@0.9.5::File must end with trailing newline. [erb-require-trailing-newline]%0A%0A%0Atest/fixtures/no-trailing-newline.html.erb:1:29%0A%0A  →   1 │ <div>No trailing newline</div>%0A        │                              ~%0A
 
 [error] File must end with trailing newline. (erb-require-trailing-newline) [Correctable]
 
@@ -203,7 +206,9 @@ test/fixtures/no-trailing-newline.html.erb:1:29
 `;
 
 exports[`CLI Output Formatting > GitHub Actions format includes rule codes 2`] = `
-"[error] Remove extra whitespace after \`<%\`. (erb-no-extra-whitespace-inside-tags) [Correctable]
+"✓ Using Herb config file at /test/herb/javascript/packages/linter/.herb.yml
+
+[error] Remove extra whitespace after \`<%\`. (erb-no-extra-whitespace-inside-tags) [Correctable]
 
 test/fixtures/erb-no-extra-whitespace-inside-tags.html.erb:1:2
 
@@ -261,14 +266,13 @@ test/fixtures/erb-no-extra-whitespace-inside-tags.html.erb:1:4
   Checked      1 file
   Offenses     4 errors | 0 warnings (4 offenses across 1 file)
   Fixable      4 offenses | 3 autocorrectable using \`--fix\`
-  Rules        83 enabled | 10 not enabled
-
- TIP: Run herb-lint --init to create a .herb.yml and lock the version.
-      This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
+  Rules        83 enabled | 10 not enabled"
 `;
 
 exports[`CLI Output Formatting > Ignores disabled rules 1`] = `
-"[error] Opening tag name \`<DIV>\` should be lowercase. Use \`<div>\` instead. (html-tag-name-lowercase) [Correctable]
+"✓ Using Herb config file at /test/herb/javascript/packages/linter/.herb.yml
+
+[error] Opening tag name \`<DIV>\` should be lowercase. Use \`<div>\` instead. (html-tag-name-lowercase) [Correctable]
 
 test/fixtures/ignored.html.erb:6:3
 
@@ -303,14 +307,13 @@ test/fixtures/ignored.html.erb:6:14
   Checked      1 file
   Offenses     2 errors | 0 warnings | 3 ignored (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        83 enabled | 10 not enabled
-
- TIP: Run herb-lint --init to create a .herb.yml and lock the version.
-      This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
+  Rules        83 enabled | 10 not enabled"
 `;
 
 exports[`CLI Output Formatting > allows tag.attributes in attribute position 1`] = `
-"[warning] Avoid using \`tag.attributes\` to set all attributes on \`<div>\`. Use \`tag.div\` or add the attributes directly to the \`<div>\` tag instead. (actionview-no-unnecessary-tag-attributes) [Correctable]
+"✓ Using Herb config file at /test/herb/javascript/packages/linter/.herb.yml
+
+[warning] Avoid using \`tag.attributes\` to set all attributes on \`<div>\`. Use \`tag.div\` or add the attributes directly to the \`<div>\` tag instead. (actionview-no-unnecessary-tag-attributes) [Correctable]
 
 test/fixtures/tag-attributes.html.erb:1:0
 
@@ -343,14 +346,13 @@ test/fixtures/tag-attributes.html.erb:5:0
   Checked      1 file
   Offenses     2 warnings (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        83 enabled | 10 not enabled
-
- TIP: Run herb-lint --init to create a .herb.yml and lock the version.
-      This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
+  Rules        83 enabled | 10 not enabled"
 `;
 
 exports[`CLI Output Formatting > diplays only parsers errors if one is present 1`] = `
-"[error] Unexpected Token. Expected: an identifier, \`@\`, \`<%\`, whitespace, or a newline, found: a character. (\`UNEXPECTED_ERROR\`) (parser-no-errors)
+"✓ Using Herb config file at /test/herb/javascript/packages/linter/.herb.yml
+
+[error] Unexpected Token. Expected: an identifier, \`@\`, \`<%\`, whitespace, or a newline, found: a character. (\`UNEXPECTED_ERROR\`) (parser-no-errors)
 
 test/fixtures/parser-errors.html.erb:2:16
 
@@ -370,14 +372,13 @@ test/fixtures/parser-errors.html.erb:2:16
   Checked      1 file
   Offenses     1 error | 0 warnings (1 offense across 1 file)
   Fixable      0 offenses
-  Rules        83 enabled | 10 not enabled
-
- TIP: Run herb-lint --init to create a .herb.yml and lock the version.
-      This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
+  Rules        83 enabled | 10 not enabled"
 `;
 
 exports[`CLI Output Formatting > displays most violated rules with multiple offenses 1`] = `
-"[error] Add an \`href\` attribute to \`<a>\` to ensure it is focusable and accessible. Links should navigate somewhere. If you need a clickable element without navigation, use a \`<button>\` instead. (html-anchor-require-href)
+"✓ Using Herb config file at /test/herb/javascript/packages/linter/.herb.yml
+
+[error] Add an \`href\` attribute to \`<a>\` to ensure it is focusable and accessible. Links should navigate somewhere. If you need a clickable element without navigation, use a \`<button>\` instead. (html-anchor-require-href)
 
 test/fixtures/multiple-rule-offenses.html.erb:5:3
 
@@ -586,14 +587,13 @@ test/fixtures/multiple-rule-offenses.html.erb:4:2
   Checked      1 file
   Offenses     8 errors | 6 warnings (14 offenses across 1 file)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        83 enabled | 10 not enabled
-
- TIP: Run herb-lint --init to create a .herb.yml and lock the version.
-      This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
+  Rules        83 enabled | 10 not enabled"
 `;
 
 exports[`CLI Output Formatting > displays rule offenses when showing all rules 1`] = `
-"[error] Attribute value should be quoted: \`id="test"\`. Always wrap attribute values in quotes. (html-attribute-values-require-quotes) [Correctable]
+"✓ Using Herb config file at /test/herb/javascript/packages/linter/.herb.yml
+
+[error] Attribute value should be quoted: \`id="test"\`. Always wrap attribute values in quotes. (html-attribute-values-require-quotes) [Correctable]
 
 test/fixtures/few-rule-offenses.html.erb:2:8
 
@@ -684,14 +684,13 @@ test/fixtures/few-rule-offenses.html.erb:6:0
   Checked      1 file
   Offenses     4 errors | 2 warnings (6 offenses across 1 file)
   Fixable      6 offenses | 3 autocorrectable using \`--fix\`
-  Rules        83 enabled | 10 not enabled
-
- TIP: Run herb-lint --init to create a .herb.yml and lock the version.
-      This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
+  Rules        83 enabled | 10 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats GitHub Actions output correctly for bad file 1`] = `
-"::error file=test/fixtures/bad-file.html.erb,line=1,col=1,title=html-tag-name-lowercase • @herb-tools/linter@0.9.5::Opening tag name \`<SPAN>\` should be lowercase. Use \`<span>\` instead. [html-tag-name-lowercase]%0A%0A%0Atest/fixtures/bad-file.html.erb:1:1%0A%0A  →   1 │ <SPAN>Bad file</SPAN>%0A        │  ~~~~%0A      2 │%0A
+"✓ Using Herb config file at /test/herb/javascript/packages/linter/.herb.yml
+
+::error file=test/fixtures/bad-file.html.erb,line=1,col=1,title=html-tag-name-lowercase • @herb-tools/linter@0.9.5::Opening tag name \`<SPAN>\` should be lowercase. Use \`<span>\` instead. [html-tag-name-lowercase]%0A%0A%0Atest/fixtures/bad-file.html.erb:1:1%0A%0A  →   1 │ <SPAN>Bad file</SPAN>%0A        │  ~~~~%0A      2 │%0A
 
 ::error file=test/fixtures/bad-file.html.erb,line=1,col=16,title=html-tag-name-lowercase • @herb-tools/linter@0.9.5::Closing tag name \`</SPAN>\` should be lowercase. Use \`</span>\` instead. [html-tag-name-lowercase]%0A%0A%0Atest/fixtures/bad-file.html.erb:1:16%0A%0A  →   1 │ <SPAN>Bad file</SPAN>%0A        │                 ~~~~%0A      2 │%0A
 
@@ -728,7 +727,8 @@ test/fixtures/bad-file.html.erb:1:16
 `;
 
 exports[`CLI Output Formatting > formats GitHub Actions output correctly for clean file 1`] = `
-"✓ test/fixtures/clean-file.html.erb - No issues found
+"✓ Using Herb config file at /test/herb/javascript/packages/linter/.herb.yml
+✓ test/fixtures/clean-file.html.erb - No issues found
 
 
  Summary:
@@ -739,7 +739,9 @@ exports[`CLI Output Formatting > formats GitHub Actions output correctly for cle
 `;
 
 exports[`CLI Output Formatting > formats GitHub Actions output correctly for file with errors 1`] = `
-"::warning file=test/fixtures/test-file-with-errors.html.erb,line=3,col=3,title=html-img-require-alt • @herb-tools/linter@0.9.5::Missing required \`alt\` attribute on \`<img>\` tag. Add \`alt=""\` for decorative images or \`alt="description"\` for informative images. [html-img-require-alt]%0A%0A%0Atest/fixtures/test-file-with-errors.html.erb:3:3%0A%0A      1 │ <div>%0A      2 │   <SPAN>Test content</SPAN>%0A  →   3 │   <img src="test.jpg">%0A        │    ~~~%0A      4 │ </div>%0A      5 │%0A
+"✓ Using Herb config file at /test/herb/javascript/packages/linter/.herb.yml
+
+::warning file=test/fixtures/test-file-with-errors.html.erb,line=3,col=3,title=html-img-require-alt • @herb-tools/linter@0.9.5::Missing required \`alt\` attribute on \`<img>\` tag. Add \`alt=""\` for decorative images or \`alt="description"\` for informative images. [html-img-require-alt]%0A%0A%0Atest/fixtures/test-file-with-errors.html.erb:3:3%0A%0A      1 │ <div>%0A      2 │   <SPAN>Test content</SPAN>%0A  →   3 │   <img src="test.jpg">%0A        │    ~~~%0A      4 │ </div>%0A      5 │%0A
 
 ::error file=test/fixtures/test-file-with-errors.html.erb,line=2,col=3,title=html-tag-name-lowercase • @herb-tools/linter@0.9.5::Opening tag name \`<SPAN>\` should be lowercase. Use \`<span>\` instead. [html-tag-name-lowercase]%0A%0A%0Atest/fixtures/test-file-with-errors.html.erb:2:3%0A%0A      1 │ <div>%0A  →   2 │   <SPAN>Test content</SPAN>%0A        │    ~~~~%0A      3 │   <img src="test.jpg">%0A      4 │ </div>%0A
 
@@ -797,7 +799,9 @@ test/fixtures/test-file-with-errors.html.erb:2:22
 `;
 
 exports[`CLI Output Formatting > formats GitHub Actions output with --format=github option 1`] = `
-"[error] Opening tag name \`<SPAN>\` should be lowercase. Use \`<span>\` instead. (html-tag-name-lowercase) [Correctable]
+"✓ Using Herb config file at /test/herb/javascript/packages/linter/.herb.yml
+
+[error] Opening tag name \`<SPAN>\` should be lowercase. Use \`<span>\` instead. (html-tag-name-lowercase) [Correctable]
 
 test/fixtures/test-file-simple.html.erb:2:3
 
@@ -830,10 +834,7 @@ test/fixtures/test-file-simple.html.erb:2:22
   Checked      1 file
   Offenses     2 errors | 0 warnings (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        83 enabled | 10 not enabled
-
- TIP: Run herb-lint --init to create a .herb.yml and lock the version.
-      This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
+  Rules        83 enabled | 10 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats JSON output correctly for bad file 1`] = `
@@ -987,7 +988,9 @@ exports[`CLI Output Formatting > formats JSON output correctly for file with err
 `;
 
 exports[`CLI Output Formatting > formats detailed error output correctly 1`] = `
-"[warning] Missing required \`alt\` attribute on \`<img>\` tag. Add \`alt=""\` for decorative images or \`alt="description"\` for informative images. (html-img-require-alt)
+"✓ Using Herb config file at /test/herb/javascript/packages/linter/.herb.yml
+
+[warning] Missing required \`alt\` attribute on \`<img>\` tag. Add \`alt=""\` for decorative images or \`alt="description"\` for informative images. (html-img-require-alt)
 
 test/fixtures/test-file-with-errors.html.erb:3:3
 
@@ -1035,14 +1038,13 @@ test/fixtures/test-file-with-errors.html.erb:2:22
   Checked      1 file
   Offenses     2 errors | 1 warning (3 offenses across 1 file)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        83 enabled | 10 not enabled
-
- TIP: Run herb-lint --init to create a .herb.yml and lock the version.
-      This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
+  Rules        83 enabled | 10 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats simple output correctly 1`] = `
-"test/fixtures/test-file-simple.html.erb:
+"✓ Using Herb config file at /test/herb/javascript/packages/linter/.herb.yml
+
+test/fixtures/test-file-simple.html.erb:
   2:3  ✗ Opening tag name \`<SPAN>\` should be lowercase. Use \`<span>\` instead. (html-tag-name-lowercase) [Correctable]
   2:22 ✗ Closing tag name \`</SPAN>\` should be lowercase. Use \`</span>\` instead. (html-tag-name-lowercase) [Correctable]
 
@@ -1055,14 +1057,13 @@ exports[`CLI Output Formatting > formats simple output correctly 1`] = `
   Checked      1 file
   Offenses     2 errors | 0 warnings (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        83 enabled | 10 not enabled
-
- TIP: Run herb-lint --init to create a .herb.yml and lock the version.
-      This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
+  Rules        83 enabled | 10 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats simple output for bad-file correctly 1`] = `
-"test/fixtures/bad-file.html.erb:
+"✓ Using Herb config file at /test/herb/javascript/packages/linter/.herb.yml
+
+test/fixtures/bad-file.html.erb:
   1:1  ✗ Opening tag name \`<SPAN>\` should be lowercase. Use \`<span>\` instead. (html-tag-name-lowercase) [Correctable]
   1:16 ✗ Closing tag name \`</SPAN>\` should be lowercase. Use \`</span>\` instead. (html-tag-name-lowercase) [Correctable]
 
@@ -1075,42 +1076,37 @@ exports[`CLI Output Formatting > formats simple output for bad-file correctly 1`
   Checked      1 file
   Offenses     2 errors | 0 warnings (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        83 enabled | 10 not enabled
-
- TIP: Run herb-lint --init to create a .herb.yml and lock the version.
-      This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
+  Rules        83 enabled | 10 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats success output correctly 1`] = `
-"✓ test/fixtures/clean-file.html.erb - No issues found
+"✓ Using Herb config file at /test/herb/javascript/packages/linter/.herb.yml
+✓ test/fixtures/clean-file.html.erb - No issues found
 
 
  Summary:
   Checked      1 file
   Offenses     0 offenses
   Fixable      0 offenses
-  Rules        83 enabled | 10 not enabled
-
- TIP: Run herb-lint --init to create a .herb.yml and lock the version.
-      This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
+  Rules        83 enabled | 10 not enabled"
 `;
 
 exports[`CLI Output Formatting > handles boolean attributes 1`] = `
-"✓ test/fixtures/boolean-attribute.html.erb - No issues found
+"✓ Using Herb config file at /test/herb/javascript/packages/linter/.herb.yml
+✓ test/fixtures/boolean-attribute.html.erb - No issues found
 
 
  Summary:
   Checked      1 file
   Offenses     0 offenses
   Fixable      0 offenses
-  Rules        83 enabled | 10 not enabled
-
- TIP: Run herb-lint --init to create a .herb.yml and lock the version.
-      This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
+  Rules        83 enabled | 10 not enabled"
 `;
 
 exports[`CLI Output Formatting > handles multiple errors correctly 1`] = `
-"[error] Opening tag name \`<SPAN>\` should be lowercase. Use \`<span>\` instead. (html-tag-name-lowercase) [Correctable]
+"✓ Using Herb config file at /test/herb/javascript/packages/linter/.herb.yml
+
+[error] Opening tag name \`<SPAN>\` should be lowercase. Use \`<span>\` instead. (html-tag-name-lowercase) [Correctable]
 
 test/fixtures/bad-file.html.erb:1:1
 
@@ -1139,14 +1135,13 @@ test/fixtures/bad-file.html.erb:1:16
   Checked      1 file
   Offenses     2 errors | 0 warnings (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        83 enabled | 10 not enabled
-
- TIP: Run herb-lint --init to create a .herb.yml and lock the version.
-      This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
+  Rules        83 enabled | 10 not enabled"
 `;
 
 exports[`CLI Output Formatting > herb:disable rules 1`] = `
-"[error] Use \`<%#\` instead of \`<% #\` for \`herb:disable\` directives. Herb directives only work with ERB comment syntax (\`<%# ... %>\`). (erb-comment-syntax) [Correctable]
+"✓ Using Herb config file at /test/herb/javascript/packages/linter/.herb.yml
+
+[error] Use \`<%#\` instead of \`<% #\` for \`herb:disable\` directives. Herb directives only work with ERB comment syntax (\`<%# ... %>\`). (erb-comment-syntax) [Correctable]
 
 test/fixtures/disabled-1.html.erb:12:19
 
@@ -1272,14 +1267,13 @@ test/fixtures/disabled-1.html.erb:14:19
   Checked      1 file
   Offenses     2 errors | 6 warnings | 8 ignored (8 offenses across 1 file)
   Fixable      8 offenses | 1 autocorrectable using \`--fix\`
-  Rules        83 enabled | 10 not enabled
-
- TIP: Run herb-lint --init to create a .herb.yml and lock the version.
-      This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
+  Rules        83 enabled | 10 not enabled"
 `;
 
 exports[`CLI Output Formatting > herb:disable rules 2`] = `
-"[warning] Using \`all\` with specific rules is redundant. Use \`herb:disable all\` by itself or list only specific rules. (herb-disable-comment-no-redundant-all)
+"✓ Using Herb config file at /test/herb/javascript/packages/linter/.herb.yml
+
+[warning] Using \`all\` with specific rules is redundant. Use \`herb:disable all\` by itself or list only specific rules. (herb-disable-comment-no-redundant-all)
 
 test/fixtures/disabled-2.html.erb:6:30
 
@@ -1476,14 +1470,13 @@ test/fixtures/disabled-2.html.erb:2:44
   Checked      1 file
   Offenses     6 errors | 7 warnings | 5 ignored (13 offenses across 1 file)
   Fixable      13 offenses | 6 autocorrectable using \`--fix\`
-  Rules        83 enabled | 10 not enabled
-
- TIP: Run herb-lint --init to create a .herb.yml and lock the version.
-      This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
+  Rules        83 enabled | 10 not enabled"
 `;
 
 exports[`CLI Output Formatting > uses GitHub Actions format by default when GITHUB_ACTIONS is true 1`] = `
-"::warning file=test/fixtures/test-file-with-errors.html.erb,line=3,col=3,title=html-img-require-alt • @herb-tools/linter@0.9.5::Missing required \`alt\` attribute on \`<img>\` tag. Add \`alt=""\` for decorative images or \`alt="description"\` for informative images. [html-img-require-alt]%0A%0A%0Atest/fixtures/test-file-with-errors.html.erb:3:3%0A%0A      1 │ <div>%0A      2 │   <SPAN>Test content</SPAN>%0A  →   3 │   <img src="test.jpg">%0A        │    ~~~%0A      4 │ </div>%0A      5 │%0A
+"✓ Using Herb config file at /test/herb/javascript/packages/linter/.herb.yml
+
+::warning file=test/fixtures/test-file-with-errors.html.erb,line=3,col=3,title=html-img-require-alt • @herb-tools/linter@0.9.5::Missing required \`alt\` attribute on \`<img>\` tag. Add \`alt=""\` for decorative images or \`alt="description"\` for informative images. [html-img-require-alt]%0A%0A%0Atest/fixtures/test-file-with-errors.html.erb:3:3%0A%0A      1 │ <div>%0A      2 │   <SPAN>Test content</SPAN>%0A  →   3 │   <img src="test.jpg">%0A        │    ~~~%0A      4 │ </div>%0A      5 │%0A
 
 ::error file=test/fixtures/test-file-with-errors.html.erb,line=2,col=3,title=html-tag-name-lowercase • @herb-tools/linter@0.9.5::Opening tag name \`<SPAN>\` should be lowercase. Use \`<span>\` instead. [html-tag-name-lowercase]%0A%0A%0Atest/fixtures/test-file-with-errors.html.erb:2:3%0A%0A      1 │ <div>%0A  →   2 │   <SPAN>Test content</SPAN>%0A        │    ~~~~%0A      3 │   <img src="test.jpg">%0A      4 │ </div>%0A
 


### PR DESCRIPTION
This pull request adds a `.herb.yml` to the linter package root to prevent CLI tests from accidentally picking up a config file from a parent directory. This was exposed by the `findProjectRootSync` improvement in #1604, which now walks further up the directory tree looking for `.herb.yml`. 

Without a config boundary in the linter package, tests could find `.herb.yml` files outside the repository, leading to failures depending on the developer's local environment.