### PR TITLE
Core: Make `Node.accept()` methods more defensive

### DIFF
--- a/javascript/packages/core/test/visitor.test.ts
+++ b/javascript/packages/core/test/visitor.test.ts
@@ -6,6 +6,7 @@ import {
   HTMLElementNode,
   HTMLTextNode,
   ERBContentNode,
+  RubyParameterNode,
 } from "../src/index.js"
 
 import type { Node } from "../src/index.js"
@@ -72,5 +73,47 @@ describe("Visitor", () => {
       "HTMLTextNode",
       "ERBContentNode",
     ])
+  })
+
+  test("accept does not crash when visitor is missing a visit method", () => {
+    const position = new Position(1, 0)
+    const location = new Location(position, position)
+
+    const node = new RubyParameterNode({
+      type: "AST_RUBY_PARAMETER_NODE",
+      location,
+      errors: [],
+      name: null,
+      default_value: null,
+      kind: "required",
+      required: true,
+    })
+
+    const incompleteVisitor = new Visitor()
+    delete (incompleteVisitor as any).visitRubyParameterNode
+
+    expect(() => {
+      node.accept(incompleteVisitor)
+    }).not.toThrow()
+  })
+
+  test("accept calls the visitor method when it exists", () => {
+    const position = new Position(1, 0)
+    const location = new Location(position, position)
+
+    const node = new RubyParameterNode({
+      type: "AST_RUBY_PARAMETER_NODE",
+      location,
+      errors: [],
+      name: null,
+      default_value: null,
+      kind: "required",
+      required: true,
+    })
+
+    const visitor = new RecordingVisitor()
+    node.accept(visitor)
+
+    expect(visitor.visited).toContain("RubyParameterNode")
   })
 })

--- a/templates/javascript/packages/core/src/nodes.ts.erb
+++ b/templates/javascript/packages/core/src/nodes.ts.erb
@@ -318,7 +318,11 @@ export class <%= node.name %> extends Node {
   }
 
   accept(visitor: Visitor): void {
-    visitor.visit<%= node.name %>(this)
+    const visitMethod = visitor.visit<%= node.name %> as ((node: <%= node.name %>) => void) | undefined
+
+    if (typeof visitMethod === "function") {
+      visitMethod.call(visitor, this)
+    }
   }
 
   childNodes(): (Node | null | undefined)[] {


### PR DESCRIPTION
When a custom linter rule is built against an older `@herb-tools/core` that doesn't have a visit method for a newer node type, the `accept()` call would crash with `visitor.visitXxxNode is not a function`.

Now `accept()` checks if the visitor method exists before calling it, so older visitors gracefully skip unknown node types instead of crashing.