### PR TITLE
Language Server: Report language server version on initialization

### DIFF
--- a/javascript/packages/language-server/src/server.ts
+++ b/javascript/packages/language-server/src/server.ts
@@ -45,7 +45,7 @@ export class Server {
 
       const result: InitializeResult = {
         serverInfo: {
-          name: "Herb LSP",
+          name: "Herb Language Server",
           version,
         },
         capabilities: {

--- a/javascript/packages/language-server/src/server.ts
+++ b/javascript/packages/language-server/src/server.ts
@@ -22,6 +22,7 @@ import {
 import { Service } from "./service"
 import { PersonalHerbSettings } from "./settings"
 import { Config } from "@herb-tools/config"
+import { version } from "../package.json"
 
 export class Server {
   private service!: Service
@@ -43,6 +44,10 @@ export class Server {
       })
 
       const result: InitializeResult = {
+        serverInfo: {
+          name: "Herb LSP",
+          version,
+        },
         capabilities: {
           textDocumentSync: {
             openClose: true,


### PR DESCRIPTION
Some language servers I use report versions, such as [Ruby LSP](https://github.com/Shopify/ruby-lsp/blob/d4a9dfa3df4e597830f2260f5b1dd40285e7a8ba/lib/ruby_lsp/server.rb#L295-L298) and `vtsls`, which Zed then shows in its summary card.

<img width="455" height="267" alt="Screenshot 2026-04-10 at 16 23 04" src="https://github.com/user-attachments/assets/0a00665c-113b-4df1-a45f-e184855bc1f0" />
