### PR TITLE
Config: Fix rule-level patterns for matching absolute file paths

### DIFF
--- a/javascript/packages/config/src/config.ts
+++ b/javascript/packages/config/src/config.ts
@@ -286,12 +286,25 @@ export class Config {
    * @param excludePatterns - Array of glob patterns to check against
    * @returns true if the path matches any exclude pattern
    */
+  private normalizeFilePath(filePath: string): string {
+    if (path.isAbsolute(filePath)) {
+      const projectDir = this.projectPath + path.sep
+
+      if (filePath.startsWith(projectDir)) {
+        return filePath.slice(projectDir.length)
+      }
+    }
+
+    return filePath
+  }
+
   private isPathExcluded(filePath: string, excludePatterns?: string[]): boolean {
     if (!excludePatterns || excludePatterns.length === 0) {
       return false
     }
 
-    return excludePatterns.some(pattern => picomatch.isMatch(filePath, pattern))
+    const normalized = this.normalizeFilePath(filePath)
+    return excludePatterns.some(pattern => picomatch.isMatch(normalized, pattern))
   }
 
   /**
@@ -305,7 +318,8 @@ export class Config {
       return true
     }
 
-    return includePatterns.some(pattern => picomatch.isMatch(filePath, pattern))
+    const normalized = this.normalizeFilePath(filePath)
+    return includePatterns.some(pattern => picomatch.isMatch(normalized, pattern))
   }
 
   /**

--- a/javascript/packages/config/test/config.test.ts
+++ b/javascript/packages/config/test/config.test.ts
@@ -862,6 +862,59 @@ describe("@herb-tools/config", () => {
       expect(config.isRuleEnabledForPath("html-tag-name-lowercase", "app/views/index.html.erb")).toBe(false)
     })
 
+    test("isRuleEnabledForPath normalizes absolute file paths against projectPath", () => {
+      const configOptions: HerbConfigOptions = {
+        linter: {
+          rules: {
+            "html-tag-name-lowercase": {
+              exclude: ["app/views/layouts/jasmine.*"]
+            }
+          }
+        }
+      }
+
+      const config = Config.fromObject(configOptions, { projectPath: testDir })
+
+      expect(config.isRuleEnabledForPath("html-tag-name-lowercase", "app/views/layouts/jasmine.html.erb")).toBe(false)
+      expect(config.isRuleEnabledForPath("html-tag-name-lowercase", `${testDir}/app/views/layouts/jasmine.html.erb`)).toBe(false)
+      expect(config.isRuleEnabledForPath("html-tag-name-lowercase", `${testDir}/app/views/home/index.html.erb`)).toBe(true)
+    })
+
+    test("isRuleEnabledForPath normalizes absolute file paths for include patterns", () => {
+      const configOptions: HerbConfigOptions = {
+        linter: {
+          rules: {
+            "html-tag-name-lowercase": {
+              include: ["app/components/**/*"]
+            }
+          }
+        }
+      }
+
+      const config = Config.fromObject(configOptions, { projectPath: testDir })
+
+      expect(config.isRuleEnabledForPath("html-tag-name-lowercase", "app/components/button.html.erb")).toBe(true)
+      expect(config.isRuleEnabledForPath("html-tag-name-lowercase", `${testDir}/app/components/button.html.erb`)).toBe(true)
+      expect(config.isRuleEnabledForPath("html-tag-name-lowercase", `${testDir}/app/views/home/index.html.erb`)).toBe(false)
+    })
+
+    test("isRuleEnabledForPath normalizes absolute file paths for only patterns", () => {
+      const configOptions: HerbConfigOptions = {
+        linter: {
+          rules: {
+            "html-tag-name-lowercase": {
+              only: ["app/views/**/*"]
+            }
+          }
+        }
+      }
+
+      const config = Config.fromObject(configOptions, { projectPath: testDir })
+
+      expect(config.isRuleEnabledForPath("html-tag-name-lowercase", `${testDir}/app/views/home/index.html.erb`)).toBe(true)
+      expect(config.isRuleEnabledForPath("html-tag-name-lowercase", `${testDir}/app/components/button.html.erb`)).toBe(false)
+    })
+
     test("linter.exclude combines with files.exclude for file discovery", () => {
       const configOptions: HerbConfigOptions = {
         files: {

--- a/javascript/packages/linter/test/rule-level-patterns.test.ts
+++ b/javascript/packages/linter/test/rule-level-patterns.test.ts
@@ -177,6 +177,26 @@ describe("Rule-level include/only/exclude patterns", () => {
     })
   })
 
+  describe("rule.exclude with absolute file paths", () => {
+    test("excludes files when fileName is an absolute path", () => {
+      const config = Config.fromObject({
+        linter: {
+          rules: {
+            "html-tag-name-lowercase": {
+              exclude: ["app/views/layouts/jasmine.*"]
+            }
+          }
+        }
+      }, { projectPath: testDir })
+
+      const linter = Linter.from(Herb, config)
+      const source = "<SPAN>Test</SPAN>"
+
+      const result = linter.lint(source, { fileName: "/test/project/app/views/layouts/jasmine.html.erb" })
+      expect(result.offenses.some(offense => offense.rule === "html-tag-name-lowercase")).toBe(false)
+    })
+  })
+
   describe("complex scenarios", () => {
     test("different rules can have different patterns", () => {
       const config = Config.fromObject({

--- a/rust/herb-config/src/linter_config.rs
+++ b/rust/herb-config/src/linter_config.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::path::Path;
 
 use serde::{Deserialize, Serialize};
 
@@ -9,6 +10,26 @@ use crate::{RuleConfig, Severity};
 pub struct LinterConfig {
   #[serde(default)]
   pub rules: HashMap<String, RuleConfig>,
+}
+
+fn normalize_file_path(file_path: &str, project_path: Option<&str>) -> String {
+  if let Some(project) = project_path {
+    let path = Path::new(file_path);
+
+    if path.is_absolute() {
+      let project_prefix = if project.ends_with(std::path::MAIN_SEPARATOR) {
+        project.to_string()
+      } else {
+        format!("{}{}", project, std::path::MAIN_SEPARATOR)
+      };
+
+      if file_path.starts_with(&project_prefix) {
+        return file_path[project_prefix.len()..].to_string();
+      }
+    }
+  }
+
+  file_path.to_string()
 }
 
 impl LinterConfig {
@@ -35,6 +56,13 @@ impl LinterConfig {
   }
 
   pub fn is_rule_enabled_for_path(&self, rule_name: &str, file_path: &str, default_exclude: &[&str]) -> bool {
+    self.is_rule_enabled_for_path_with_project(rule_name, file_path, default_exclude, None)
+  }
+
+  pub fn is_rule_enabled_for_path_with_project(&self, rule_name: &str, file_path: &str, default_exclude: &[&str], project_path: Option<&str>) -> bool {
+    let normalized = normalize_file_path(file_path, project_path);
+    let file_path = normalized.as_str();
+
     if let Some(config) = self.rules.get(rule_name) {
       if !config.only.is_empty() {
         if !is_path_matching(file_path, &config.only) {

--- a/rust/herb-config/tests/linter_config_test.rs
+++ b/rust/herb-config/tests/linter_config_test.rs
@@ -267,6 +267,35 @@ fn is_rule_enabled_for_path_include_overrides_default_exclude() {
 }
 
 #[test]
+fn is_rule_enabled_for_path_normalizes_absolute_paths() {
+  let config = LinterConfig {
+    rules: HashMap::from([(
+      "html-tag-name-lowercase".into(),
+      RuleConfig {
+        exclude: vec!["app/views/layouts/jasmine.*".into()],
+        ..Default::default()
+      },
+    )]),
+  };
+
+  assert!(!config.is_rule_enabled_for_path_with_project("html-tag-name-lowercase", "app/views/layouts/jasmine.html.erb", &[], Some("/test/project"),));
+
+  assert!(!config.is_rule_enabled_for_path_with_project(
+    "html-tag-name-lowercase",
+    "/test/project/app/views/layouts/jasmine.html.erb",
+    &[],
+    Some("/test/project"),
+  ));
+
+  assert!(config.is_rule_enabled_for_path_with_project(
+    "html-tag-name-lowercase",
+    "/test/project/app/views/home/index.html.erb",
+    &[],
+    Some("/test/project"),
+  ));
+}
+
+#[test]
 fn get_rule_config_returns_none_when_not_configured() {
   let config = LinterConfig::new();
 


### PR DESCRIPTION
Rule-level `exclude`, `include`, and `only` patterns in `.herb.yml` silently failed when the linter received an absolute file path (e.g., from the VS Code extension). 

The glob patterns are relative (e.g., `app/views/layouts/jasmine.*`), but `picomatch`/`globset` won't match them against absolute paths like `/home/user/project/app/views/layouts/jasmine.html.erb`.

This adds path normalization in both the JavaScript and Rust config packages. When a file path is absolute and starts with the project path, it gets stripped to a relative path before pattern matching.

Might fix #1630