### PR TITLE
VS Code: Upgrade `@types/vscode` and `engine` to `v1.100.0`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,7 @@ updates:
       interval: "weekly"
     ignore:
       - dependency-name: "tailwindcss"
+      - dependency-name: "@types/vscode"
 
   - package-ecosystem: "cargo"
     directory: "/rust"

--- a/javascript/packages/vscode/package.json
+++ b/javascript/packages/vscode/package.json
@@ -12,7 +12,7 @@
     "name": "Marco Roth"
   },
   "engines": {
-    "vscode": "^1.43.0"
+    "vscode": "^1.100.0"
   },
   "extensionDependencies": [
     "Shopify.ruby-lsp"
@@ -290,7 +290,7 @@
     "@herb-tools/node-wasm": "0.9.6",
     "@types/mocha": "^10.0.10",
     "@types/node": "25.x",
-    "@types/vscode": "^1.115.0",
+    "@types/vscode": "^1.100.0",
     "@vscode/test-cli": "^0.0.12",
     "@vscode/test-electron": "^2.5.2",
     "@vscode/vsce": "^3.9.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2063,10 +2063,10 @@
     "@types/expect" "^1.20.4"
     "@types/node" "*"
 
-"@types/vscode@^1.115.0":
-  version "1.115.0"
-  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.115.0.tgz#428bef70a03c70dbe9f76438f4b4b7f569962303"
-  integrity sha512-/M8cdznOlqtMqduHKKlIF00v4eum4ZWKgn8YoPRKcN6PDdvoWeeqDaQSnw63ipDbq1Uzz78Wndk/d0uSPwORfA==
+"@types/vscode@^1.100.0":
+  version "1.116.0"
+  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.116.0.tgz#88e90907200b5d2776a2ebfae5fb791833193d79"
+  integrity sha512-sYHp4MO6BqJ2PD7Hjt0hlIS3tMaYsVPJrd0RUjDJ8HtOYnyJIEej0bLSccM8rE77WrC+Xox/kdBwEFDO8MsxNA==
 
 "@types/web-bluetooth@^0.0.21":
   version "0.0.21"


### PR DESCRIPTION
This pull request updates the VS Code version (`engine.vscode`) to be `v1.100.0` or newer. This version was released on [May 8, 2025](https://code.visualstudio.com/updates/v1_100).

Additionally, this fixes the issue that lets the VS Code extension from being published in CI, since the versions mismatched:

```
cd javascript/packages/vscode && npx @vscode/vsce publish --no-dependencies

Error: @types/vscode ^1.115.0 greater than engines.vscode ^1.43.0. Either upgrade engines.vscode or use an older @types/vscode version
Error: Process completed with exit code 1.
```