### PR TITLE
JavaScript: Remove `registry-url` to allow trusted publishing to NPM

### DIFF
--- a/.github/workflows/javascript.yml
+++ b/.github/workflows/javascript.yml
@@ -132,7 +132,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          registry-url: 'https://registry.npmjs.org'
 
       - name: Download package artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
The `publish` job used `actions/setup-node` with `registry-url`, which automatically sets `NODE_AUTH_TOKEN` to the GitHub token. npm then tried to authenticate with that GitHub token against the npm registry, which npm doesn't recognize, resulting in a 404. 

The OIDC provenance signing worked fine (it uses a separate code path), but the actual publish authentication never fell through to the OIDC trusted publishing flow because `NODE_AUTH_TOKEN` was already set. 

Removing `registry-url` should prevent `setup-node` from creating the `.npmrc` and setting `NODE_AUTH_TOKEN`, so npm defaults to its OIDC-based authentication when `--provenance` is used with `id-token:  write`.