### PR TITLE
Ruby: Bump Ruby minimum version to 3.2

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 AllCops:
   NewCops: enable
   SuggestExtensions: false
-  TargetRubyVersion: 3.0
+  TargetRubyVersion: 3.2
   Exclude:
     - 'pkg/**/*'
     - 'vendor/**/*'

--- a/herb.gemspec
+++ b/herb.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.homepage = "https://herb-tools.dev"
   spec.license = "MIT"
 
-  spec.required_ruby_version = ">= 3.0.0"
+  spec.required_ruby_version = ">= 3.2.0"
   spec.require_paths = ["lib"]
 
   spec.files = Dir[

--- a/lib/herb.rb
+++ b/lib/herb.rb
@@ -69,13 +69,13 @@ end
 module Herb
   class << self
     #: (String path, ?arena_stats: bool) -> LexResult
-    def lex_file(path, **options)
-      lex(File.read(path), **options)
+    def lex_file(path, **)
+      lex(File.read(path), **)
     end
 
     #: (String path, ?track_whitespace: bool, ?analyze: bool, ?strict: bool, ?arena_stats: bool) -> ParseResult
-    def parse_file(path, **options)
-      parse(File.read(path), **options)
+    def parse_file(path, **)
+      parse(File.read(path), **)
     end
 
     #: (String source) -> Prism::ParseResult

--- a/lib/herb/bootstrap.rb
+++ b/lib/herb/bootstrap.rb
@@ -18,7 +18,6 @@ module Herb
 
     def self.generate_templates
       require "pathname"
-      require "set"
       require_relative "../../templates/template"
 
       Dir.chdir(ROOT_PATH) do

--- a/lib/herb/engine.rb
+++ b/lib/herb/engine.rb
@@ -337,7 +337,7 @@ module Herb
       @src << postamble
     end
 
-    def with_buffer(&_block)
+    def with_buffer(&)
       if @chain_appends
         @src << "; " << @bufvar unless @buffer_on_stack
         yield

--- a/lib/herb/engine/compiler.rb
+++ b/lib/herb/engine/compiler.rb
@@ -165,7 +165,7 @@ module Herb
         process_erb_tag(node)
       end
 
-      def visit_erb_control_node(node, &_block)
+      def visit_erb_control_node(node, &)
         if node.content
           apply_trim(node, node.content.value.strip)
         end

--- a/templates/template.rb
+++ b/templates/template.rb
@@ -66,9 +66,9 @@ module Herb
     end
 
     class ArrayField < Field
-      def initialize(kind:, **options)
+      def initialize(kind:, **)
         @kind = kind
-        super(**options)
+        super(**)
       end
 
       def ruby_type
@@ -107,9 +107,9 @@ module Herb
     end
 
     class NodeField < Field
-      def initialize(kind:, **options)
+      def initialize(kind:, **)
         @kind = kind
-        super(**options)
+        super(**)
       end
 
       def c_type


### PR DESCRIPTION
The Ruby 3.0 series has been EOL for over 2 years, and Ruby 3.2 was also just EOL'd. Lets bump the minimum Ruby version for Herb v0.10 to Ruby 3.2, so we can use `Data` in the gem itself, #1518 is already making use of `Data` already.