### PR TITLE
Ruby: Extract `Herb#ensure_installed` helper

### DIFF
--- a/lib/herb.rb
+++ b/lib/herb.rb
@@ -118,5 +118,19 @@ module Herb
     rescue StandardError
       nil
     end
+
+    def ensure_installed(&block)
+      require "bundler/inline"
+
+      verbose = $VERBOSE
+      $VERBOSE = nil
+
+      gemfile(true, quiet: true) do # steep:ignore
+        source "https://rubygems.org" # steep:ignore
+        instance_eval(&block) # steep:ignore
+      end
+    ensure
+      $VERBOSE = verbose
+    end
   end
 end

--- a/lib/herb/action_view/render_analyzer.rb
+++ b/lib/herb/action_view/render_analyzer.rb
@@ -784,12 +784,7 @@ module Herb
       def ensure_parallel!
         return if defined?(Parallel)
 
-        require "bundler/inline"
-
-        gemfile(true, quiet: true) do # steep:ignore
-          source "https://rubygems.org" # steep:ignore
-          gem "parallel" # steep:ignore
-        end
+        Herb.ensure_installed { gem "parallel" } # steep:ignore
       end
 
       def collect_ruby_render_references

--- a/lib/herb/project.rb
+++ b/lib/herb/project.rb
@@ -903,12 +903,7 @@ module Herb
     def ensure_parallel!
       return if defined?(Parallel)
 
-      require "bundler/inline"
-
-      gemfile(true, quiet: true) do
-        source "https://rubygems.org"
-        gem "parallel"
-      end
+      Herb.ensure_installed { gem "parallel" } # steep:ignore
     end
 
     def separator

--- a/sig/herb.rbs
+++ b/sig/herb.rbs
@@ -23,4 +23,6 @@ module Herb
   def self.reset_configuration!: () -> untyped
 
   def self.dev_server_port: (?untyped project_path) -> untyped
+
+  def self.ensure_installed: () ?{ (?) -> untyped } -> untyped
 end


### PR DESCRIPTION
This pull request extracts a shared `Herb.ensure_installed` helper that handles inline gem installation via Bundler. 

Previously, both `RenderAnalyzer` and `Project` duplicated the same `bundler/inline` gemfile block with identical boilerplate for requiring, installing, and suppressing Ruby warnings during gem activation. 

The new helper centralizes this into a single method on the Herb module, making call sites one-liners and suppressing the noisy RDoc constant redefinition warnings that `bundler/inline` triggers in some environments:

```
❯ bundle exec herb actionview graph app/views/profiles/_header.html.erb

 Herb 🌿 v0.9.7

 Building render graph...
/Users/marcoroth/.local/share/mise/installs/ruby/4.0.0/lib/ruby/gems/4.0.0/gems/rdoc-7.0.3/lib/rdoc/version.rb:8: warning: already initialized constant RDoc::VERSION
/Users/marcoroth/.local/share/mise/installs/ruby/4.0.0/lib/ruby/gems/4.0.0/gems/rdoc-7.2.0/lib/rdoc/version.rb:8: warning: previous definition of VERSION was here
/Users/marcoroth/.local/share/mise/installs/ruby/4.0.0/lib/ruby/gems/4.0.0/gems/rdoc-7.0.3/lib/rdoc.rb:68: warning: already initialized constant RDoc::VISIBILITIES
/Users/marcoroth/.local/share/mise/installs/ruby/4.0.0/lib/ruby/gems/4.0.0/gems/rdoc-7.2.0/lib/rdoc.rb:68: warning: previous definition of VISIBILITIES was here
/Users/marcoroth/.local/share/mise/installs/ruby/4.0.0/lib/ruby/gems/4.0.0/gems/rdoc-7.0.3/lib/rdoc.rb:74: warning: already initialized constant RDoc::DOT_DOC_FILENAME
/Users/marcoroth/.local/share/mise/installs/ruby/4.0.0/lib/ruby/gems/4.0.0/gems/rdoc-7.2.0/lib/rdoc.rb:74: warning: previous definition of DOT_DOC_FILENAME was here
/Users/marcoroth/.local/share/mise/installs/ruby/4.0.0/lib/ruby/gems/4.0.0/gems/rdoc-7.0.3/lib/rdoc.rb:79: warning: already initialized constant RDoc::GENERAL_MODIFIERS
/Users/marcoroth/.local/share/mise/installs/ruby/4.0.0/lib/ruby/gems/4.0.0/gems/rdoc-7.2.0/lib/rdoc.rb:79: warning: previous definition of GENERAL_MODIFIERS was here
/Users/marcoroth/.local/share/mise/installs/ruby/4.0.0/lib/ruby/gems/4.0.0/gems/rdoc-7.0.3/lib/rdoc.rb:84: warning: already initialized constant RDoc::CLASS_MODIFIERS
/Users/marcoroth/.local/share/mise/installs/ruby/4.0.0/lib/ruby/gems/4.0.0/gems/rdoc-7.2.0/lib/rdoc.rb:84: warning: previous definition of CLASS_MODIFIERS was here
/Users/marcoroth/.local/share/mise/installs/ruby/4.0.0/lib/ruby/gems/4.0.0/gems/rdoc-7.0.3/lib/rdoc.rb:89: warning: already initialized constant RDoc::ATTR_MODIFIERS
/Users/marcoroth/.local/share/mise/installs/ruby/4.0.0/lib/ruby/gems/4.0.0/gems/rdoc-7.2.0/lib/rdoc.rb:89: warning: previous definition of ATTR_MODIFIERS was here
/Users/marcoroth/.local/share/mise/installs/ruby/4.0.0/lib/ruby/gems/4.0.0/gems/rdoc-7.0.3/lib/rdoc.rb:94: warning: already initialized constant RDoc::CONSTANT_MODIFIERS
/Users/marcoroth/.local/share/mise/installs/ruby/4.0.0/lib/ruby/gems/4.0.0/gems/rdoc-7.2.0/lib/rdoc.rb:94: warning: previous definition of CONSTANT_MODIFIERS was here
/Users/marcoroth/.local/share/mise/installs/ruby/4.0.0/lib/ruby/gems/4.0.0/gems/rdoc-7.0.3/lib/rdoc.rb:99: warning: already initialized constant RDoc::METHOD_MODIFIERS
/Users/marcoroth/.local/share/mise/installs/ruby/4.0.0/lib/ruby/gems/4.0.0/gems/rdoc-7.2.0/lib/rdoc.rb:99: warning: previous definition of METHOD_MODIFIERS was here
/Users/marcoroth/.local/share/mise/installs/ruby/4.0.0/lib/ruby/gems/4.0.0/gems/rdoc-7.0.3/lib/rdoc/markdown.rb:257: warning: already initialized constant RDoc::Markdown::KpegPosInfo
/Users/marcoroth/.local/share/mise/installs/ruby/4.0.0/lib/ruby/gems/4.0.0/gems/rdoc-7.2.0/lib/rdoc/markdown.rb:257: warning: previous definition of KpegPosInfo was here
```

Might be related to https://github.com/marcoroth/herb/issues/1435