### PR TITLE
Add sig/manifest.yaml to declare stdlib dependencies

### DIFF
--- a/herb.gemspec
+++ b/herb.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |spec|
     "lib/**/*.rb",
     "lib/**/*.yml",
     "sig/**/*.rbs",
+    "sig/manifest.yaml",
     "src/**/*.{c,h}",
     "ext/**/*.{c,h}",
     "templates/**/*.{rb,erb}",

--- a/sig/manifest.yaml
+++ b/sig/manifest.yaml
@@ -1,0 +1,13 @@
+dependencies:
+  - name: delegate
+  - name: did_you_mean
+  - name: fileutils
+  - name: json
+  - name: optparse
+  - name: pathname
+  - name: socket
+  - name: stringio
+  - name: tempfile
+  - name: time
+  - name: timeout
+  - name: yaml


### PR DESCRIPTION
`sig/herb/token_list.rbs` declares a class inheriting from `SimpleDelegator`, which comes from the `delegate` standard library. Since `delegate` is a default gem, it does not appear in the gemspec, and `rbs collection install` cannot resolve it on the consumer side.

With Steep 2.0, this previously-silent issue surfaces as a hard error:

    Type checking failed due to error in library RBS file
    Cannot find type `SimpleDelegator`
    (.../herb-0.10.1/sig/herb/token_list.rbs:4:2)
    Diagnostic ID: Ruby::LibraryRBSError

Declare the implicit standard library dependencies in `sig/manifest.yaml` so downstream users get correct type resolution.

Refs: https://github.com/ruby/rbs/blob/master/docs/gem.md