### PR TITLE
Ruby: Check RBS validity on CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,6 +53,11 @@ jobs:
       - name: Lint
         run: bin/lint
 
+      - name: RBS Validation
+        run: |-
+          bundle exec rbs collection install --frozen
+          bundle exec rbs -Isig validate
+
       - name: Steep
         run: bundle exec steep check
 

--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,9 @@ tmp/*
 # Bundler Config
 !/.bundle/config
 
+# RBS Collection files
+.gem_rbs_collection/*
+
 # Bundler
 vendor/*
 vendor/bundle/*

--- a/Gemfile
+++ b/Gemfile
@@ -24,8 +24,5 @@ gem "reactionview", "~> 0.3.0"
 gem "reline", "~> 0.6"
 gem "rubocop", "~> 1.71"
 gem "sorbet"
+gem "steep", "~> 2.0"
 gem "turbo-rails", "~> 2.0"
-
-# TODO: Remove once https://github.com/ruby/rbs/pull/2850 is merged and released
-gem "rbs", github: "marcoroth/rbs", branch: "psych-load-unsafe-file"
-gem "steep", github: "soutaro/steep", branch: "master"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,42 +1,9 @@
 GIT
-  remote: https://github.com/marcoroth/rbs.git
-  revision: 6ed90f144c592a5d744b1a03df42bf834f137416
-  branch: psych-load-unsafe-file
-  specs:
-    rbs (4.0.0.dev.5)
-      logger
-      prism (>= 1.6.0)
-      tsort
-
-GIT
   remote: https://github.com/ruby/prism.git
   revision: c0e37816e97e23e92524a4070e1b99a4025bc63f
   tag: v1.9.0
   specs:
     prism (1.9.0)
-
-GIT
-  remote: https://github.com/soutaro/steep.git
-  revision: 03e3440e16b64f314c9c7b5afd33888fb74ac11a
-  branch: master
-  specs:
-    steep (2.0.0.dev)
-      activesupport (>= 5.1)
-      concurrent-ruby (>= 1.1.10)
-      csv (>= 3.0.9)
-      fileutils (>= 1.1.0)
-      json (>= 2.1.0)
-      language_server-protocol (>= 3.17.0.4, < 4.0)
-      listen (~> 3.0)
-      logger (>= 1.3.0)
-      mutex_m (>= 0.3.0)
-      parser (>= 3.2)
-      rainbow (>= 2.2.2, < 4.0)
-      rbs (~> 4.0.0.dev)
-      securerandom (>= 0.1)
-      strscan (>= 1.0.0)
-      terminal-table (>= 2, < 5)
-      uri (>= 0.12.0)
 
 PATH
   remote: .
@@ -185,7 +152,6 @@ GEM
     minitest (5.27.0)
     minitest-difftastic (0.2.1)
       difftastic (~> 0.6)
-    mutex_m (0.3.0)
     nokogiri (1.19.3-aarch64-linux-gnu)
       racc (~> 1.4)
     nokogiri (1.19.3-aarch64-linux-musl)
@@ -249,6 +215,10 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
+    rbs (4.0.2)
+      logger
+      prism (>= 1.6.0)
+      tsort
     rbs-inline (0.13.0)
       prism (>= 0.29)
       rbs (>= 3.8.0)
@@ -283,6 +253,22 @@ GEM
     sorbet-static (0.6.13185-aarch64-linux)
     sorbet-static (0.6.13185-universal-darwin)
     sorbet-static (0.6.13185-x86_64-linux)
+    steep (2.0.0)
+      concurrent-ruby (>= 1.1.10)
+      csv (>= 3.0.9)
+      fileutils (>= 1.1.0)
+      json (>= 2.1.0)
+      language_server-protocol (>= 3.17.0.4, < 4.0)
+      listen (~> 3.0)
+      logger (>= 1.3.0)
+      parser (>= 3.2)
+      prism (>= 0.25.0)
+      rainbow (>= 2.2.2, < 4.0)
+      rbs (~> 4.0)
+      securerandom (>= 0.1)
+      strscan (>= 1.0.0)
+      terminal-table (>= 2, < 5)
+      uri (>= 0.12.0)
     stringio (3.2.0)
     strscan (3.1.7)
     terminal-table (4.0.0)
@@ -328,13 +314,12 @@ DEPENDENCIES
   rake (~> 13.4)
   rake-compiler (~> 1.3)
   rake-compiler-dock (~> 1.12)
-  rbs!
   rbs-inline (~> 0.13)
   reactionview (~> 0.3.0)
   reline (~> 0.6)
   rubocop (~> 1.71)
   sorbet
-  steep!
+  steep (~> 2.0)
   turbo-rails (~> 2.0)
 
 BUNDLED WITH

--- a/Steepfile
+++ b/Steepfile
@@ -6,6 +6,7 @@ target :lib do
   check "lib"
 
   library "delegate"
+  library "did_you_mean"
   library "digest"
   library "json"
   library "pathname"

--- a/lib/herb/action_view/render_analyzer.rb
+++ b/lib/herb/action_view/render_analyzer.rb
@@ -784,7 +784,7 @@ module Herb
       def ensure_parallel!
         return if defined?(Parallel)
 
-        Herb.ensure_installed { gem "parallel" } # steep:ignore
+        Herb.ensure_installed { gem "parallel" }
       end
 
       def collect_ruby_render_references

--- a/rbs_collection.lock.yaml
+++ b/rbs_collection.lock.yaml
@@ -1,0 +1,392 @@
+---
+path: ".gem_rbs_collection"
+gems:
+- name: actionpack
+  version: '7.2'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 81fa8bd0617286078617a62b6a3229cebfd4af23
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: actionview
+  version: '6.0'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 81fa8bd0617286078617a62b6a3229cebfd4af23
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: activesupport
+  version: '7.0'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 81fa8bd0617286078617a62b6a3229cebfd4af23
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: ast
+  version: '2.4'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 81fa8bd0617286078617a62b6a3229cebfd4af23
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: base64
+  version: 0.3.0
+  source:
+    type: rubygems
+- name: benchmark
+  version: '0'
+  source:
+    type: stdlib
+- name: bigdecimal
+  version: 4.1.2
+  source:
+    type: rubygems
+- name: bubbles
+  version: 0.1.1
+  source:
+    type: rubygems
+- name: bubbletea
+  version: 0.1.4
+  source:
+    type: rubygems
+- name: cgi
+  version: '0.5'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 81fa8bd0617286078617a62b6a3229cebfd4af23
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: charm
+  version: 0.1.0
+  source:
+    type: rubygems
+- name: concurrent-ruby
+  version: '1.1'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 81fa8bd0617286078617a62b6a3229cebfd4af23
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: connection_pool
+  version: '2.4'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 81fa8bd0617286078617a62b6a3229cebfd4af23
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: csv
+  version: '3.3'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 81fa8bd0617286078617a62b6a3229cebfd4af23
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: date
+  version: '0'
+  source:
+    type: stdlib
+- name: dbm
+  version: '0'
+  source:
+    type: stdlib
+- name: digest
+  version: '0'
+  source:
+    type: stdlib
+- name: erb
+  version: '0'
+  source:
+    type: stdlib
+- name: ffi
+  version: 1.17.3
+  source:
+    type: rubygems
+- name: fileutils
+  version: '0'
+  source:
+    type: stdlib
+- name: forwardable
+  version: '0'
+  source:
+    type: stdlib
+- name: gum
+  version: 0.3.2
+  source:
+    type: rubygems
+- name: harmonica
+  version: 0.1.1
+  source:
+    type: rubygems
+- name: i18n
+  version: '1.10'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 81fa8bd0617286078617a62b6a3229cebfd4af23
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: io-console
+  version: '0'
+  source:
+    type: stdlib
+- name: json
+  version: '0'
+  source:
+    type: stdlib
+- name: lint_roller
+  version: '1.1'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 81fa8bd0617286078617a62b6a3229cebfd4af23
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: lipgloss
+  version: 0.2.2
+  source:
+    type: rubygems
+- name: listen
+  version: '3.9'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 81fa8bd0617286078617a62b6a3229cebfd4af23
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: logger
+  version: '1.7'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 81fa8bd0617286078617a62b6a3229cebfd4af23
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: minitest
+  version: '5.25'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 81fa8bd0617286078617a62b6a3229cebfd4af23
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: minitest-difftastic
+  version: 0.2.1
+  source:
+    type: rubygems
+- name: monitor
+  version: '0'
+  source:
+    type: stdlib
+- name: nokogiri
+  version: '1.11'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 81fa8bd0617286078617a62b6a3229cebfd4af23
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: openssl
+  version: '0'
+  source:
+    type: stdlib
+- name: optparse
+  version: '0'
+  source:
+    type: stdlib
+- name: parallel
+  version: '1.20'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 81fa8bd0617286078617a62b6a3229cebfd4af23
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: parser
+  version: '3.2'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 81fa8bd0617286078617a62b6a3229cebfd4af23
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: pp
+  version: '0'
+  source:
+    type: stdlib
+- name: prettyprint
+  version: '0'
+  source:
+    type: stdlib
+- name: prism
+  version: 1.9.0
+  source:
+    type: rubygems
+- name: pstore
+  version: '0.2'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 81fa8bd0617286078617a62b6a3229cebfd4af23
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: psych
+  version: '0'
+  source:
+    type: stdlib
+- name: rack
+  version: '2.2'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 81fa8bd0617286078617a62b6a3229cebfd4af23
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: rails-dom-testing
+  version: '2.0'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 81fa8bd0617286078617a62b6a3229cebfd4af23
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: rails-html-sanitizer
+  version: '1.6'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 81fa8bd0617286078617a62b6a3229cebfd4af23
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: railties
+  version: '6.0'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 81fa8bd0617286078617a62b6a3229cebfd4af23
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: rainbow
+  version: '3.0'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 81fa8bd0617286078617a62b6a3229cebfd4af23
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: rake
+  version: '13.0'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 81fa8bd0617286078617a62b6a3229cebfd4af23
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: random-formatter
+  version: '0'
+  source:
+    type: stdlib
+- name: rbs
+  version: 4.0.2
+  source:
+    type: rubygems
+- name: rbs-inline
+  version: 0.13.0
+  source:
+    type: rubygems
+- name: rdoc
+  version: '0'
+  source:
+    type: stdlib
+- name: reactionview
+  version: 0.3.0
+  source:
+    type: rubygems
+- name: regexp_parser
+  version: '2.8'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 81fa8bd0617286078617a62b6a3229cebfd4af23
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: rubocop
+  version: '1.57'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 81fa8bd0617286078617a62b6a3229cebfd4af23
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: rubocop-ast
+  version: '1.46'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 81fa8bd0617286078617a62b6a3229cebfd4af23
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: securerandom
+  version: '0'
+  source:
+    type: stdlib
+- name: singleton
+  version: '0'
+  source:
+    type: stdlib
+- name: socket
+  version: '0'
+  source:
+    type: stdlib
+- name: stringio
+  version: '0'
+  source:
+    type: stdlib
+- name: strscan
+  version: '0'
+  source:
+    type: stdlib
+- name: tempfile
+  version: '0'
+  source:
+    type: stdlib
+- name: thor
+  version: '1.2'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 81fa8bd0617286078617a62b6a3229cebfd4af23
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: time
+  version: '0'
+  source:
+    type: stdlib
+- name: timeout
+  version: '0'
+  source:
+    type: stdlib
+- name: tsort
+  version: '0'
+  source:
+    type: stdlib
+- name: tzinfo
+  version: '2.0'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 81fa8bd0617286078617a62b6a3229cebfd4af23
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: uri
+  version: '0'
+  source:
+    type: stdlib
+gemfile_lock_path: Gemfile.lock

--- a/rbs_collection.yaml
+++ b/rbs_collection.yaml
@@ -1,0 +1,18 @@
+# Download sources
+sources:
+  - type: git
+    name: ruby/gem_rbs_collection
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    revision: main
+    repo_dir: gems
+
+# You can specify local directories as sources also.
+# - type: local
+#   path: path/to/your/local/repository
+
+# A directory to install the downloaded RBSs
+path: .gem_rbs_collection
+
+gems:
+  - name: herb
+    ignore: true

--- a/sig/vendor/did_you_mean.rbs
+++ b/sig/vendor/did_you_mean.rbs
@@ -1,6 +1,0 @@
-module DidYouMean
-  class SpellChecker
-    def initialize: (dictionary: Array[String]) -> void
-    def correct: (String input) -> Array[String]
-  end
-end

--- a/sig/vendor/parallel.rbs
+++ b/sig/vendor/parallel.rbs
@@ -1,4 +1,0 @@
-module Parallel
-  def self.map: [T, U] (Array[T], ?in_processes: Integer) { (T) -> U } -> Array[U]
-  def self.processor_count: () -> Integer
-end


### PR DESCRIPTION
To avoid the regressions of the RBS definition, this adds automatic RBS validation on CI.

This also contains the following changes around RBS:

* Update to RBS-4.0 and Steep-2.0
* Manage types of dependencies via rbs_collection.yaml (see https://github.com/ruby/rbs/blob/master/docs/collection.md)

ref: https://github.com/marcoroth/herb/pull/1711#pullrequestreview-4230602410