### PR TITLE
Linter: Fix `html-no-self-closing` to preserve indentation

### DIFF
--- a/javascript/packages/linter/src/rules/html-no-self-closing.ts
+++ b/javascript/packages/linter/src/rules/html-no-self-closing.ts
@@ -55,6 +55,13 @@ export class HTMLNoSelfClosingRule extends ParserRule<NoSelfClosingAutofixContex
     return { action_view_helpers: true }
   }
 
+  private isIndentation(precedingNode: Node | null, node: Node): boolean {
+    return !!precedingNode &&
+      isWhitespaceNode(node) &&
+      isWhitespaceNode(precedingNode) &&
+      (precedingNode.value?.value?.includes("\n") || false)
+  }
+
   check(result: ParseResult, context?: Partial<LintContext>): UnboundLintOffense<NoSelfClosingAutofixContext>[] {
     const visitor = new NoSelfClosingVisitor(this.ruleName, context)
 
@@ -76,8 +83,13 @@ export class HTMLNoSelfClosingRule extends ParserRule<NoSelfClosingAutofixContex
     if (node.children && Array.isArray(node.children)) {
       const children = node.children as Node[]
 
-      if (children.length > 0 && isWhitespaceNode(children[children.length - 1])) {
-        node.children = children.slice(0, -1)
+      if (children.length > 0) {
+        const lastChild = children[children.length - 1]
+        const secondToLastChild = children[children.length - 2] ?? null
+
+        if (isWhitespaceNode(lastChild) && !this.isIndentation(secondToLastChild, lastChild)) {
+          node.children = children.slice(0, -1)
+        }
       }
     }
 

--- a/javascript/packages/linter/test/autofix/html-no-self-closing.autofix.test.ts
+++ b/javascript/packages/linter/test/autofix/html-no-self-closing.autofix.test.ts
@@ -1,3 +1,4 @@
+import dedent from "dedent"
 import { describe, test, expect, beforeAll } from "vitest"
 import { Herb } from "@herb-tools/node-wasm"
 import { Linter } from "../../src/linter.js"
@@ -78,6 +79,40 @@ describe("html-no-self-closing autofix", () => {
   test("preserves whitespace before slash", () => {
     const input = '<input type="text" />'
     const expected = '<input type="text">'
+
+    const linter = new Linter(Herb, [HTMLNoSelfClosingRule])
+    const result = linter.autofix(input)
+
+    expect(result.source).toBe(expected)
+    expect(result.fixed).toHaveLength(1)
+  })
+
+  test("preserves indentation of closing tag for nested void element", () => {
+    const input = dedent`
+      <figure>
+        <img
+          src="/image.png"
+          alt="An image"
+        />
+      </figure>`
+    const expected = dedent`
+      <figure>
+        <img
+          src="/image.png"
+          alt="An image"
+        >
+      </figure>`
+
+    const linter = new Linter(Herb, [HTMLNoSelfClosingRule])
+    const result = linter.autofix(input)
+
+    expect(result.source).toBe(expected)
+    expect(result.fixed).toHaveLength(1)
+  })
+
+  test("drops newline before closing when /> is on its own line without indentation", () => {
+    const input = '<img class="x"\n/>'
+    const expected = '<img class="x">'
 
     const linter = new Linter(Herb, [HTMLNoSelfClosingRule])
     const result = linter.autofix(input)


### PR DESCRIPTION
:wave:  I came across the following issue with the `html-no-self-closing` rule:

When autofixing nested elements whose closing tag appears on a new line, the self-closing tag is correctly fixed, but the indentation is lost and the closing bracket is placed at column 0.

This can be verified with the following example:
#### Before
```
<figure>
  <img
    src="/image.png"
    alt="An image"
  />
</figure>
``` 

#### After
```
<figure>
  <img
    src="/image.png"
    alt="An image"
>
</figure>
``` 

#### With this fix
```
<figure>
  <img
    src="/image.png"
    alt="An image"
  >
</figure>
``` 

P.S. I wasn't sure whether I should open an issue first. Let me know if you'd prefer that for completeness' sake.