### PR TITLE
fix(dev-tools): draw debug outlines with CSS classes

### DIFF
--- a/javascript/packages/dev-tools/src/herb-overlay.ts
+++ b/javascript/packages/dev-tools/src/herb-overlay.ts
@@ -40,6 +40,50 @@ export class HerbOverlay {
     { value: 'zed', label: 'Zed' },
   ];
 
+  private static readonly DEBUG_OUTLINE_CLASS = {
+    view: 'herb-debug-outline--view',
+    partial: 'herb-debug-outline--partial',
+    component: 'herb-debug-outline--component',
+    erb: 'herb-debug-outline--erb',
+  } as const;
+
+  private applyDebugOutline(element: HTMLElement, type: keyof typeof HerbOverlay.DEBUG_OUTLINE_CLASS) {
+    element.classList.add(HerbOverlay.DEBUG_OUTLINE_CLASS[type]);
+
+    if (element.tagName.toLowerCase() === 'html') {
+      element.classList.add('herb-debug-outline--root');
+    }
+  }
+
+  private removeDebugOutline(element: HTMLElement, type: keyof typeof HerbOverlay.DEBUG_OUTLINE_CLASS) {
+    element.classList.remove(HerbOverlay.DEBUG_OUTLINE_CLASS[type]);
+    element.classList.remove('herb-debug-outline--root');
+  }
+
+  private clearAllDebugOutlineClasses(element: HTMLElement) {
+    element.classList.remove(
+      HerbOverlay.DEBUG_OUTLINE_CLASS.view,
+      HerbOverlay.DEBUG_OUTLINE_CLASS.partial,
+      HerbOverlay.DEBUG_OUTLINE_CLASS.component,
+      HerbOverlay.DEBUG_OUTLINE_CLASS.erb,
+      'herb-debug-outline--root'
+    );
+  }
+
+  private ensurePositionAnchor(element: HTMLElement) {
+    if (window.getComputedStyle(element).position === 'static') {
+      element.classList.add('herb-debug-position-anchor');
+      element.setAttribute('data-herb-debug-position-anchored', 'true');
+    }
+  }
+
+  private removePositionAnchor(element: HTMLElement) {
+    if (element.getAttribute('data-herb-debug-position-anchored') === 'true') {
+      element.classList.remove('herb-debug-position-anchor');
+      element.removeAttribute('data-herb-debug-position-anchored');
+    }
+  }
+
   constructor(private options: HerbDevToolsOptions = {}) {
     if (options.autoInit !== false) {
       this.init();
@@ -437,16 +481,10 @@ export class HerbOverlay {
       const element = outline as HTMLElement;
 
       if (this.showingViewOutlines) {
-        element.style.outline = '2px dotted #3b82f6';
-        element.style.outlineOffset = element.tagName.toLowerCase() === 'html' ? '-2px' : '2px';
-        element.classList.add('show-outline');
-
+        this.applyDebugOutline(element, 'view');
         this.createOverlayLabel(element, 'view');
       } else {
-        element.style.outline = 'none';
-        element.style.outlineOffset = '0';
-        element.classList.remove('show-outline');
-
+        this.removeDebugOutline(element, 'view');
         this.removeOverlayLabel(element);
       }
     });
@@ -462,16 +500,10 @@ export class HerbOverlay {
       const element = outline as HTMLElement;
 
       if (this.showingPartialOutlines) {
-        element.style.outline = '2px dotted #10b981';
-        element.style.outlineOffset = element.tagName.toLowerCase() === 'html' ? '-2px' : '2px';
-        element.classList.add('show-outline');
-
+        this.applyDebugOutline(element, 'partial');
         this.createOverlayLabel(element, 'partial');
       } else {
-        element.style.outline = 'none';
-        element.style.outlineOffset = '0';
-        element.classList.remove('show-outline');
-
+        this.removeDebugOutline(element, 'partial');
         this.removeOverlayLabel(element);
       }
     });
@@ -487,16 +519,10 @@ export class HerbOverlay {
       const element = outline as HTMLElement;
 
       if (this.showingComponentOutlines) {
-        element.style.outline = '2px dotted #f59e0b';
-        element.style.outlineOffset = element.tagName.toLowerCase() === 'html' ? '-2px' : '2px';
-        element.classList.add('show-outline');
-
+        this.applyDebugOutline(element, 'component');
         this.createOverlayLabel(element, 'component');
       } else {
-        element.style.outline = 'none';
-        element.style.outlineOffset = '0';
-        element.classList.remove('show-outline');
-
+        this.removeDebugOutline(element, 'component');
         this.removeOverlayLabel(element);
       }
     });
@@ -543,19 +569,12 @@ export class HerbOverlay {
     if (shouldAttachToParent && element.parentElement) {
       const parent = element.parentElement;
 
-      element.style.outline = 'none';
-      element.classList.remove('show-outline');
-
-      const outlineColor = type === 'component' ? '#f59e0b' : type === 'partial' ? '#10b981' : '#3b82f6';
-      parent.style.outline = `2px dotted ${outlineColor}`;
-      parent.style.outlineOffset = parent.tagName.toLowerCase() === 'html' ? '-2px' : '2px';
-      parent.classList.add('show-outline');
+      this.clearAllDebugOutlineClasses(element);
+      this.applyDebugOutline(parent, type);
 
       parent.setAttribute('data-herb-debug-attached-outline-type', type);
 
-      if (window.getComputedStyle(parent).position === 'static') {
-        parent.style.position = 'relative';
-      }
+      this.ensurePositionAnchor(parent);
       label.style.position = 'absolute';
       label.style.top = '0';
       label.style.left = '0';
@@ -568,9 +587,7 @@ export class HerbOverlay {
       label.style.top = '0';
     }
 
-    if (window.getComputedStyle(element).position === 'static') {
-      element.style.position = 'relative';
-    }
+    this.ensurePositionAnchor(element);
     element.appendChild(label);
   }
 
@@ -585,16 +602,24 @@ export class HerbOverlay {
         label.remove();
       }
 
-      parent.style.outline = 'none';
-      parent.style.outlineOffset = '0';
-      parent.classList.remove('show-outline');
+      const attachedType = parent.getAttribute('data-herb-debug-attached-outline-type') as 'view' | 'partial' | 'component' | null;
+
+      if (attachedType) {
+        this.removeDebugOutline(parent, attachedType);
+      } else {
+        this.clearAllDebugOutlineClasses(parent);
+      }
+
       parent.removeAttribute('data-herb-debug-attached-outline-type');
+      this.removePositionAnchor(parent);
     } else {
       const label = element.querySelector('.herb-overlay-label');
 
       if (label) {
         label.remove();
       }
+
+      this.removePositionAnchor(element);
     }
   }
 
@@ -665,9 +690,7 @@ export class HerbOverlay {
       const realElement = (element.children[0] as HTMLElement) || element
 
       if (this.showingERBOutlines) {
-
-        realElement.style.outline = '2px dotted #a78bfa';
-        realElement.style.outlineOffset = '1px';
+        this.applyDebugOutline(realElement, 'erb');
 
         if (needsWrapperToggled) {
           element.style.display = 'inline';
@@ -681,8 +704,7 @@ export class HerbOverlay {
           this.addERBHoverReveal(element);
         }
       } else {
-        realElement.style.outline = 'none';
-        realElement.style.outlineOffset = '0';
+        this.removeDebugOutline(realElement, 'erb');
 
         if (needsWrapperToggled) {
           element.style.display = 'contents';

--- a/javascript/packages/dev-tools/src/styles.css
+++ b/javascript/packages/dev-tools/src/styles.css
@@ -502,6 +502,37 @@
   background-color: #f5f3ff;
 }
 
+/* Debug outlines use classes (not inline styles) so user outline utilities are preserved */
+.herb-debug-outline--view {
+  outline: 2px dotted #3b82f6;
+  outline-offset: 2px;
+}
+
+.herb-debug-outline--partial {
+  outline: 2px dotted #10b981;
+  outline-offset: 2px;
+}
+
+.herb-debug-outline--component {
+  outline: 2px dotted #f59e0b;
+  outline-offset: 2px;
+}
+
+.herb-debug-outline--erb {
+  outline: 2px dotted #a78bfa;
+  outline-offset: 1px;
+}
+
+.herb-debug-outline--view.herb-debug-outline--root,
+.herb-debug-outline--partial.herb-debug-outline--root,
+.herb-debug-outline--component.herb-debug-outline--root {
+  outline-offset: -2px;
+}
+
+.herb-debug-position-anchor {
+  position: relative;
+}
+
 .herb-toggle-label:hover .herb-toggle-switch {
   background: #94a3b8;
 }


### PR DESCRIPTION
## Summary

Debug outlines in `@herb-tools/dev-tools` were applied via inline `outline` / `outline-offset` styles. When outlines were disabled (including on initial load), the code set `outline: none` and `outline-offset: 0` on every ERB output element, which overrode user styles such as Tailwind `outline-*` utilities.

This change draws debug outlines using dedicated CSS classes instead of inline styles. When outlines are off, classes are simply removed and user styles are left intact.

Fixes https://github.com/marcoroth/reactionview/issues/36

## Changes

- Add `.herb-debug-outline--{view,partial,component,erb}` classes in `styles.css`
- Replace inline outline manipulation in `herb-overlay.ts` with `applyDebugOutline` / `removeDebugOutline` helpers
- Use `.herb-debug-position-anchor` instead of inline `position: relative` where needed

## Test plan

- [ ] Enable debug mode on a page with Tailwind `outline-*` on form inputs — outlines should look correct with all Herb outline toggles off
- [ ] Toggle View / Partial / Component / ERB Output outlines on and off — debug dotted borders appear and disappear without breaking user outlines
- [ ] Verify `data-herb-debug-attach-to-parent` elements still show labels on the parent
- [ ] Turbo navigation: toggles and outlines still work after `turbo:load`


Made with [Cursor](https://cursor.com)