### PR TITLE
Docs: Updates custom linter rules documentation

### DIFF
--- a/javascript/packages/linter/README.md
+++ b/javascript/packages/linter/README.md
@@ -535,7 +535,7 @@ export default class NoDivTagsRule extends ParserRule {
   static ruleName = "no-div-tags"
 
   check(result, context) {
-    const visitor = new NoDivTagsVisitor(this.name, context)
+    const visitor = new NoDivTagsVisitor(this.ruleName, context)
     visitor.visit(result.value)
     return visitor.offenses
   }
@@ -569,7 +569,7 @@ export default class NoInlineStylesRule {
   static ruleName = "no-inline-styles"
 
   check(parseResult, context) {
-    const visitor = new NoInlineStylesVisitor(this.name, context)
+    const visitor = new NoInlineStylesVisitor(this.ruleName, context)
     visitor.visit(parseResult.value)
     return visitor.offenses
   }


### PR DESCRIPTION
- Custom linter rule examples use `this.name` when constructing visitors, but `ParserRule` exposes the rule name via `this.ruleName`. 
- Using `this.name` results in undefined being passed to the visitor, causing the rule name to show as undefined in CLI output and breaking (at least my nvim) LSP diagnostics.
