### PR TITLE
Linter: Narrow `html-no-self-closing` offense location

### DIFF
--- a/javascript/packages/linter/src/rules/html-no-self-closing.ts
+++ b/javascript/packages/linter/src/rules/html-no-self-closing.ts
@@ -27,7 +27,7 @@ class NoSelfClosingVisitor extends BaseRuleVisitor<NoSelfClosingAutofixContext> 
 
       this.addOffense(
         `Use \`${instead}\` instead of self-closing \`<${tagName} />\` for HTML compatibility.`,
-        node.location,
+        node.tag_closing.location,
         {
           node,
           tagName,

--- a/javascript/packages/linter/test/__snapshots__/cli.test.ts.snap
+++ b/javascript/packages/linter/test/__snapshots__/cli.test.ts.snap
@@ -562,12 +562,12 @@ test/fixtures/multiple-rule-offenses.html.erb:10:4
 
 [error] Use \`<img>\` instead of self-closing \`<img />\` for HTML compatibility. (html-no-self-closing) [Correctable]
 
-test/fixtures/multiple-rule-offenses.html.erb:4:2
+test/fixtures/multiple-rule-offenses.html.erb:4:7
 
       2 │ 
       3 │ <div id=test1 class='' data-value=bar>
   →   4 │   <img />
-        │   ~~~~~~~
+        │        ~~
       5 │   <a class="" class="">Link 1</a>
       6 │ </div>
 


### PR DESCRIPTION
This pull request updates the `html-no-self-closing` to update the offense location of the `/>` to only the `node.tag_closing.location` instead of the full `node.location`.

### Before

<img width="50%"  alt="CleanShot 2026-06-05 at 22 24 55@2x" src="https://github.com/user-attachments/assets/93e92875-b755-4bd4-a104-991359c4aceb" />



### After

<img width="50%"  alt="CleanShot 2026-06-05 at 22 24 25@2x" src="https://github.com/user-attachments/assets/d6a7d4ad-fa58-44be-a06a-233b007df89c" />


