### PR TITLE
Core: Update AST Utils for `HTMLConditionalOpenTagNode`

### DIFF
--- a/javascript/packages/core/src/ast-utils.ts
+++ b/javascript/packages/core/src/ast-utils.ts
@@ -13,6 +13,7 @@ import {
   ERBBeginNode,
   HTMLElementNode,
   HTMLOpenTagNode,
+  HTMLConditionalOpenTagNode,
   HTMLCloseTagNode,
   HTMLAttributeNode,
   HTMLAttributeNameNode,
@@ -271,10 +272,10 @@ export function isCommentNode(node: Node): node is HTMLCommentNode | ERBCommentN
  * For conditional open tags, returns null.
  * If given an HTMLOpenTagNode directly, returns it as-is.
  */
-export function getOpenTag(node: HTMLElementNode | HTMLOpenTagNode | null | undefined): HTMLOpenTagNode | null {
+export function getOpenTag(node: HTMLElementNode | HTMLOpenTagNode | HTMLConditionalOpenTagNode | null | undefined): HTMLOpenTagNode | null {
   if (!node) return null
   if (isHTMLOpenTagNode(node)) return node
-  if (isHTMLElementNode(node)) return isHTMLOpenTagNode(node.open_tag) ? node.open_tag : null
+  if (isHTMLElementNode(node) && isHTMLOpenTagNode(node.open_tag)) return node.open_tag
 
   return null
 }
@@ -283,7 +284,7 @@ export function getOpenTag(node: HTMLElementNode | HTMLOpenTagNode | null | unde
  * Gets the children array from an element's open tag, regardless of whether
  * it's an HTMLOpenTagNode or ERBOpenTagNode (used by action view helpers).
  */
-function getOpenTagChildren(node: HTMLElementNode | HTMLOpenTagNode | null | undefined): Node[] {
+function getOpenTagChildren(node: HTMLElementNode | HTMLOpenTagNode | HTMLConditionalOpenTagNode | null | undefined): Node[] {
   if (!node) return []
   if (isHTMLOpenTagNode(node)) return node.children
 
@@ -298,7 +299,7 @@ function getOpenTagChildren(node: HTMLElementNode | HTMLOpenTagNode | null | und
 /**
  * Gets attributes from an HTMLElementNode or HTMLOpenTagNode
  */
-export function getAttributes(node: HTMLElementNode | HTMLOpenTagNode | null | undefined): HTMLAttributeNode[] {
+export function getAttributes(node: HTMLElementNode | HTMLOpenTagNode | HTMLConditionalOpenTagNode | null | undefined): HTMLAttributeNode[] {
   return filterHTMLAttributeNodes(getOpenTagChildren(node))
 }
 
@@ -322,10 +323,10 @@ export function getAttributeName(attributeNode: HTMLAttributeNode, lowercase = t
  * Returns false for null/undefined input.
  */
 export function hasStaticAttributeValue(attributeNode: HTMLAttributeNode | null | undefined): boolean
-export function hasStaticAttributeValue(node: HTMLElementNode | HTMLOpenTagNode | null | undefined, attributeName: string): boolean
-export function hasStaticAttributeValue(nodeOrAttribute: HTMLAttributeNode | HTMLElementNode | HTMLOpenTagNode | null | undefined, attributeName?: string): boolean {
+export function hasStaticAttributeValue(node: HTMLElementNode | HTMLOpenTagNode | HTMLConditionalOpenTagNode | null | undefined, attributeName: string): boolean
+export function hasStaticAttributeValue(nodeOrAttribute: HTMLAttributeNode | HTMLElementNode | HTMLOpenTagNode | HTMLConditionalOpenTagNode | null | undefined, attributeName?: string): boolean {
   const attributeNode = attributeName
-    ? getAttribute(nodeOrAttribute as HTMLElementNode | HTMLOpenTagNode, attributeName)
+    ? getAttribute(nodeOrAttribute as HTMLElementNode | HTMLOpenTagNode | HTMLConditionalOpenTagNode, attributeName)
     : nodeOrAttribute as HTMLAttributeNode | null | undefined
 
   if (!attributeNode?.value?.children) return false
@@ -339,10 +340,10 @@ export function hasStaticAttributeValue(nodeOrAttribute: HTMLAttributeNode | HTM
  * Returns null for null/undefined input.
  */
 export function getStaticAttributeValue(attributeNode: HTMLAttributeNode | null | undefined): string | null
-export function getStaticAttributeValue(node: HTMLElementNode | HTMLOpenTagNode | null | undefined, attributeName: string): string | null
-export function getStaticAttributeValue(nodeOrAttribute: HTMLAttributeNode | HTMLElementNode | HTMLOpenTagNode | null | undefined, attributeName?: string): string | null {
+export function getStaticAttributeValue(node: HTMLElementNode | HTMLOpenTagNode | HTMLConditionalOpenTagNode | null | undefined, attributeName: string): string | null
+export function getStaticAttributeValue(nodeOrAttribute: HTMLAttributeNode | HTMLElementNode | HTMLOpenTagNode | HTMLConditionalOpenTagNode | null | undefined, attributeName?: string): string | null {
   const attributeNode = attributeName
-    ? getAttribute(nodeOrAttribute as HTMLElementNode | HTMLOpenTagNode, attributeName)
+    ? getAttribute(nodeOrAttribute as HTMLElementNode | HTMLOpenTagNode | HTMLConditionalOpenTagNode, attributeName)
     : nodeOrAttribute as HTMLAttributeNode | null | undefined
 
   if (!attributeNode) return null
@@ -367,10 +368,10 @@ export const TOKEN_LIST_ATTRIBUTES = new Set([
  * Returns an empty array for null/undefined/empty input.
  */
 export function getTokenList(value: string | null | undefined): string[]
-export function getTokenList(node: HTMLElementNode | HTMLOpenTagNode | null | undefined, attributeName: string): string[]
-export function getTokenList(valueOrNode: string | HTMLElementNode | HTMLOpenTagNode | null | undefined, attributeName?: string): string[] {
+export function getTokenList(node: HTMLElementNode | HTMLOpenTagNode | HTMLConditionalOpenTagNode | null | undefined, attributeName: string): string[]
+export function getTokenList(valueOrNode: string | HTMLElementNode | HTMLOpenTagNode | HTMLConditionalOpenTagNode | null | undefined, attributeName?: string): string[] {
   const value = attributeName
-    ? getStaticAttributeValue(valueOrNode as HTMLElementNode | HTMLOpenTagNode, attributeName)
+    ? getStaticAttributeValue(valueOrNode as HTMLElementNode | HTMLOpenTagNode | HTMLConditionalOpenTagNode, attributeName)
     : valueOrNode as string | null | undefined
 
   if (!value) return []
@@ -396,7 +397,7 @@ export function findAttributeByName(attributes: Node[], attributeName: string): 
 /**
  * Gets a specific attribute from an HTMLElementNode or HTMLOpenTagNode by name
  */
-export function getAttribute(node: HTMLElementNode | HTMLOpenTagNode | null | undefined, attributeName: string): HTMLAttributeNode | null {
+export function getAttribute(node: HTMLElementNode | HTMLOpenTagNode | HTMLConditionalOpenTagNode | null | undefined, attributeName: string): HTMLAttributeNode | null {
   const attributes = getAttributes(node)
 
   return findAttributeByName(attributes, attributeName)
@@ -405,7 +406,7 @@ export function getAttribute(node: HTMLElementNode | HTMLOpenTagNode | null | un
 /**
  * Checks if an element or open tag has a specific attribute
  */
-export function hasAttribute(node: HTMLElementNode | HTMLOpenTagNode | null | undefined, attributeName: string): boolean {
+export function hasAttribute(node: HTMLElementNode | HTMLOpenTagNode | HTMLConditionalOpenTagNode | null | undefined, attributeName: string): boolean {
   if (!node) return false
 
   return getAttribute(node, attributeName) !== null


### PR DESCRIPTION
This pull request updates the AST utils related to elements and attributes in core to also account for the `HTMLConditionalOpenTagNode` node type, so linter rules like #1669 can more easily build the logic for the linter rules.