### PR TITLE
Dev Tools: Don't log to the console when no error overlay is created

### DIFF
--- a/javascript/packages/dev-tools/src/error-overlay.ts
+++ b/javascript/packages/dev-tools/src/error-overlay.ts
@@ -215,15 +215,9 @@ export class ErrorOverlay {
     this.detectValidationErrors();
     scanForOptimizationMismatches();
 
-    const hasParserErrors = document.querySelector('.herb-parser-error-overlay') !== null;
-
     if (this.getTotalErrorCount() > 0) {
       this.createOverlay();
       this.setupToggleHandler();
-    } else if (hasParserErrors) {
-      console.log('[ErrorOverlay] Parser error overlay already displayed');
-    } else {
-      console.log('[ErrorOverlay] No errors found, not creating overlay');
     }
   }
 


### PR DESCRIPTION
Every page load in an app using the dev tools (e.g. via ReActionView's debug mode) currently logs `[ErrorOverlay] No errors found, not creating overlay` to the browser console — several times per load with Turbo. Since having no errors is the normal case, this is just noise in the console.

This removes the two informational `console.log` calls from `ErrorOverlay#init` (and the `hasParserErrors` lookup that only existed to pick between them). The `console.error`/`console.warn` calls on actual failure paths are untouched.