### PR TITLE
docs: replace deprecated yarn global examples

### DIFF
--- a/docs/docs/integrations/editors.md
+++ b/docs/docs/integrations/editors.md
@@ -38,7 +38,7 @@ npm install -g @herb-tools/language-server
 ```
 
 ```bash [yarn]
-yarn global add @herb-tools/language-server
+yarn dlx @herb-tools/language-server --stdio
 ```
 
 ```bash [pnpm]

--- a/docs/docs/integrations/editors/helix.md
+++ b/docs/docs/integrations/editors/helix.md
@@ -23,7 +23,7 @@ npm install -g @herb-tools/language-server
 ```
 
 ```bash [yarn]
-yarn global add @herb-tools/language-server
+yarn dlx @herb-tools/language-server --stdio
 ```
 
 ```bash [pnpm]

--- a/docs/docs/integrations/editors/neovim.md
+++ b/docs/docs/integrations/editors/neovim.md
@@ -25,7 +25,7 @@ npm install -g @herb-tools/language-server
 ```
 
 ```bash [yarn]
-yarn global add @herb-tools/language-server
+yarn dlx @herb-tools/language-server --stdio
 ```
 
 ```bash [pnpm]
@@ -78,7 +78,7 @@ npm install -g @herb-tools/language-server
 ```
 
 ```bash [yarn]
-yarn global add @herb-tools/language-server
+yarn dlx @herb-tools/language-server --stdio
 ```
 
 ```bash [pnpm]

--- a/docs/docs/integrations/editors/sublime.md
+++ b/docs/docs/integrations/editors/sublime.md
@@ -27,7 +27,7 @@ npm install -g @herb-tools/language-server
 ```
 
 ```bash [yarn]
-yarn global add @herb-tools/language-server
+yarn dlx @herb-tools/language-server --stdio
 ```
 
 ```bash [pnpm]

--- a/docs/docs/integrations/editors/vim.md
+++ b/docs/docs/integrations/editors/vim.md
@@ -25,7 +25,7 @@ npm install -g @herb-tools/language-server
 ```
 
 ```bash [yarn]
-yarn global add @herb-tools/language-server
+yarn dlx @herb-tools/language-server --stdio
 ```
 
 ```bash [pnpm]

--- a/javascript/packages/formatter/README.md
+++ b/javascript/packages/formatter/README.md
@@ -26,7 +26,7 @@ pnpm add -g @herb-tools/formatter
 ```
 
 ```shell [yarn]
-yarn global add @herb-tools/formatter
+yarn dlx @herb-tools/formatter
 ```
 
 ```shell [bun]

--- a/javascript/packages/language-server/README.md
+++ b/javascript/packages/language-server/README.md
@@ -66,10 +66,10 @@ You can use the language server in any editor that supports the [Language Server
 npm install -g @herb-tools/language-server
 ```
 
-###### Yarn (Global)
+###### Yarn (dlx)
 
 ```bash
-yarn global add @herb-tools/language-server
+yarn dlx @herb-tools/language-server --stdio
 ```
 
 ##### Preview Releases

--- a/javascript/packages/linter/README.md
+++ b/javascript/packages/linter/README.md
@@ -21,7 +21,7 @@ pnpm add -g @herb-tools/linter
 ```
 
 ```shell [yarn]
-yarn global add @herb-tools/linter
+yarn dlx @herb-tools/linter
 ```
 
 ```shell [bun]


### PR DESCRIPTION
## Summary
- replace deprecated `yarn global add` examples with `yarn dlx` commands
- update language-server, formatter, linter, and editor integration docs

Fixes #1312