### PR TITLE
Docs: Note multi-attribute wrap behavior on `maxLineLength`

### DIFF
--- a/javascript/packages/formatter/README.md
+++ b/javascript/packages/formatter/README.md
@@ -226,7 +226,7 @@ The `include` patterns are **additive** - they add to the defaults.
 
 - **`enabled`**: `true` or `false` - Must be `true` to enable formatting
 - **`indentWidth`**: Number (default: `2`) - Spaces per indentation level
-- **`maxLineLength`**: Number (default: `80`) - Maximum line length before wrapping
+- **`maxLineLength`**: Number (default: `80`) - Maximum line length before wrapping. Note: tags with **more than 3 attributes** are always wrapped one-per-line, independent of `maxLineLength`.
 - **`include`**: Array of glob patterns - Additional patterns to format (additive to defaults)
 - **`exclude`**: Array of glob patterns - Patterns to exclude from formatting
 


### PR DESCRIPTION
The formatter wraps tags one-attribute-per-line under two conditions (see [`attribute-renderer.ts#L91`](https://github.com/marcoroth/herb/blob/b64d55b73e5fadc88e1716ea4e61b47ce6b2d6e7/javascript/packages/formatter/src/attribute-renderer.ts#L91)):

1. The opening tag would exceed `maxLineLength`, OR
2. The tag has more than 3 attributes

Only the first is documented today. The second can be surprising in practice — `<div a="1" b="2" c="3" d="4">` wraps even though it's 36 characters wide, well under the 80-char default. This PR adds a short note on the `maxLineLength` option flagging the count rule.

The docs site (`docs/docs/projects/formatter.md`) `@include`s this README, so herb-tools.dev picks the change up automatically.