### PR TITLE
Linter: Add WAI-ARIA Graphics roles to `html-aria-role-must-be-valid`

### DIFF
--- a/javascript/packages/linter/src/rules/rule-utils.ts
+++ b/javascript/packages/linter/src/rules/rule-utils.ts
@@ -389,7 +389,8 @@ export const VALID_ARIA_ROLES = new Set([
   "progressbar", "radio", "radiogroup", "scrollbar", "searchbox", "slider", "spinbutton",
   "status", "switch", "tab", "tablist", "tabpanel", "textbox", "timer", "toolbar", "tree",
   "treegrid", "treeitem",
-  "log", "marquee"
+  "log", "marquee",
+  "graphics-document", "graphics-object", "graphics-symbol"
 ]);
 
 /**


### PR DESCRIPTION
This pull request adds the three roles from the [W3C WAI-ARIA Graphics Module 1.0](https://www.w3.org/TR/graphics-aria-1.0/#roles) spec — `graphics-document`, `graphics-object`, and `graphics-symbol` — to the `VALID_ARIA_ROLES` set so that `html-aria-role-must-be-valid` no longer flags them as unrecognized.

Closes #1726