### PR TITLE
Linter: Allow `application/ld+json` for `html-allowed-script-type` rule

### DIFF
--- a/javascript/packages/linter/docs/rules/html-allowed-script-type.md
+++ b/javascript/packages/linter/docs/rules/html-allowed-script-type.md
@@ -4,13 +4,15 @@
 
 ## Description
 
-Restricts which `type` attribute values are permitted on `<script>` tags. Only approved types are allowed: `text/javascript`. An empty or valueless `type` attribute is reported.
+Restricts which `type` attribute values are permitted on `<script>` tags. Only approved types are allowed: `text/javascript`, `module`, `importmap`, `speculationrules`, and `application/ld+json`. An empty or valueless `type` attribute is reported.
 
 ## Rationale
 
 Developers frequently use `<script>` tags with non-executable type attributes (like `application/json` or `text/html`) to embed data in pages. However, these tags share parsing quirks with executable scripts and can create security risks. For example, unescaped `</script><script>` sequences inside a `text/html` script tag could enable XSS attacks.
 
 By restricting the allowed `type` values and requiring the `type` attribute to be present, this rule helps catch typos and discourages unsafe or unintended script usage patterns.
+
+An exception is made for `application/ld+json`, which the HTML specification treats as an inert [data block](https://html.spec.whatwg.org/multipage/scripting.html#data-block): it is the standard mechanism for embedding JSON-LD structured data, and consumers such as search engines only recognize it inside a `<script>` element.
 
 ## Examples
 
@@ -25,6 +27,16 @@ By restricting the allowed `type` values and requiring the `type` attribute to b
 ```erb
 <script>
   console.log("Hello")
+</script>
+```
+
+```erb
+<script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    "name": "Example"
+  }
 </script>
 ```
 
@@ -43,6 +55,12 @@ By restricting the allowed `type` values and requiring the `type` attribute to b
 ```
 
 ```erb
+<script type="application/json">
+  { "name": "Example" }
+</script>
+```
+
+```erb
 <script type="">
   console.log("Hello")
 </script>
@@ -57,3 +75,4 @@ By restricting the allowed `type` values and requiring the `type` attribute to b
 ## References
 
 - [Inspiration: ERB Lint `AllowedScriptType` rule](https://github.com/Shopify/erb_lint/tree/main?tab=readme-ov-file#allowedscripttype)
+- [HTML specification: data blocks](https://html.spec.whatwg.org/multipage/scripting.html#data-block)

--- a/javascript/packages/linter/src/rules/html-allowed-script-type.ts
+++ b/javascript/packages/linter/src/rules/html-allowed-script-type.ts
@@ -8,7 +8,7 @@ import type { HTMLAttributeNode, HTMLOpenTagNode, ParseResult } from "@herb-tool
 // NOTE: Rules are not configurable for now, keep some sane defaults
 //   See https://github.com/marcoroth/herb/issues/1204
 const ALLOW_BLANK = true
-const ALLOWED_TYPES = ["text/javascript", "module", "importmap", "speculationrules"]
+const ALLOWED_TYPES = ["text/javascript", "module", "importmap", "speculationrules", "application/ld+json"]
 
 class AllowedScriptTypeVisitor extends BaseRuleVisitor {
   visitHTMLOpenTagNode(node: HTMLOpenTagNode): void {

--- a/javascript/packages/linter/test/rules/html-allowed-script-type.test.ts
+++ b/javascript/packages/linter/test/rules/html-allowed-script-type.test.ts
@@ -37,12 +37,16 @@ describe("html-allowed-script-type", () => {
     expectNoOffenses('<script type="speculationrules"></script>')
   })
 
+  test("passes when type is application/ld+json", () => {
+    expectNoOffenses('<script type="application/ld+json"></script>')
+  })
+
   test("passes for script tag with ERB in type attribute", () => {
     expectNoOffenses('<script type="<%= script_type %>"></script>')
   })
 
   test("fails when type is not allowed", () => {
-    expectError('Avoid using `text/yavascript` as the `type` attribute for the `<script>` tag. Must be one of: `text/javascript`, `module`, `importmap`, `speculationrules` or blank.')
+    expectError('Avoid using `text/yavascript` as the `type` attribute for the `<script>` tag. Must be one of: `text/javascript`, `module`, `importmap`, `speculationrules`, `application/ld+json` or blank.')
 
     assertOffenses('<script type="text/yavascript"></script>')
   })


### PR DESCRIPTION
`application/ld+json` is the standard mechanism for embedding JSON-LD structured data, and the HTML specification treats it as an inert data block. Same fix as #1393 / #1413 made for `module` and `importmap`.

https://html.spec.whatwg.org/multipage/scripting.html#data-block