### PR TITLE
Linter: Treat `breadcrumb` as a side-effecting helper in `erb-no-unused-expressions`

### DIFF
--- a/javascript/packages/linter/src/rules/erb-no-unused-expressions.ts
+++ b/javascript/packages/linter/src/rules/erb-no-unused-expressions.ts
@@ -27,6 +27,7 @@ const MUTATION_METHODS = new Set([
 ])
 
 const SIDE_EFFECT_METHODS = new Set([
+  "breadcrumb",
   "content_for",
   "provide",
   "flush",

--- a/javascript/packages/linter/test/rules/erb-no-unused-expressions.test.ts
+++ b/javascript/packages/linter/test/rules/erb-no-unused-expressions.test.ts
@@ -131,6 +131,13 @@ describe("ERBNoUnusedExpressionsRule", () => {
       `)
     })
 
+    test("passes for breadcrumb", () => {
+      expectNoOffenses(dedent`
+        <% breadcrumb :page %>
+        <% breadcrumb :product, @product %>
+      `)
+    })
+
     test("passes for assert_valid_keys", () => {
       expectNoOffenses(dedent`
         <%


### PR DESCRIPTION
## What

Adds `breadcrumb` to `SIDE_EFFECT_METHODS` in `erb-no-unused-expressions`, so `<% breadcrumb :key %>` calls are no longer reported as unused expressions.

## Why

[gretel](https://github.com/lassebunk/gretel) — a widely used breadcrumbs gem — exposes `breadcrumb` as a view helper that is called purely for its side effect. It sets the current breadcrumb trail and is meant to be used in a silent tag:

```erb
<% breadcrumb :product, @product %>
```

Under the hood it just assigns the renderer and returns it:

```ruby
def breadcrumb(key = nil, *args)
  @_gretel_renderer = Gretel::Renderer.new(self, key, *args)
end
```

This is the same shape as `content_for`, `provide`, and the `turbo_*` helpers already on the allowlist: a bare, receiver-less call used for a side effect, whose return value is intentionally discarded (you can't meaningfully `<%= %>` it — that would print a `Gretel::Renderer`). Today the rule flags every `<% breadcrumb %>`, so an app that renders breadcrumbs on most pages gets one offense per view, which in practice forces disabling the rule project-wide.

## Verification

- Added a `valid cases` test mirroring the existing `provide` / Turbo tests.
- Behaviorally confirmed against the published `0.10.1` build: with `breadcrumb` allowlisted, `<% breadcrumb :key %>` passes while a genuine `<% @foo %>` is still reported.

I wasn't able to run the full JS test suite locally (the workspace build pulls in the native/Emscripten toolchain), so I'd appreciate CI confirming the added test.
