### PR TITLE
Formatter: Fix disabled formatter stdin output

### DIFF
--- a/javascript/packages/formatter/src/cli.ts
+++ b/javascript/packages/formatter/src/cli.ts
@@ -156,6 +156,7 @@ export class CLI {
       this.determineProjectPath(positionals)
 
       const file = positionals[0]
+      const isUsingStdin = (!file && !process.stdin.isTTY) || file === "-"
 
       if (isInitMode) {
         const configPath = configFile || this.projectPath
@@ -196,9 +197,13 @@ export class CLI {
       const formatterConfig = config.formatter || {}
 
       if (hasConfigFile && formatterConfig.enabled === false && !isForceMode) {
-        console.log("Formatter is disabled in .herb.yml configuration.")
-        console.log("To enable formatting, set formatter.enabled: true in .herb.yml")
-        console.log("Or use --force to format anyway.")
+        console.error("Formatter is disabled in .herb.yml configuration.")
+        console.error("To enable formatting, set formatter.enabled: true in .herb.yml")
+        console.error("Or use --force to format anyway.")
+
+        if (isUsingStdin) {
+          process.stdout.write(await this.readStdin())
+        }
 
         process.exit(0)
       }

--- a/javascript/packages/formatter/test/cli.test.ts
+++ b/javascript/packages/formatter/test/cli.test.ts
@@ -78,6 +78,24 @@ describe("CLI Binary", () => {
     expect(result.stdout).toContain('</div>')
   })
 
+  it("should return stdin unchanged when formatting is disabled", async () => {
+    const configFile = "test-dir/.herb.yml"
+    const input = '<div class="test"><div><%= user.name %></div></div>'
+
+    await mkdir("test-dir", { recursive: true })
+    await writeFile(configFile, dedent`
+      version: 0.10.1
+      formatter:
+        enabled: false
+    `)
+
+    const result = await execBinary(["--config-file", configFile], input)
+
+    expectExitCode(result, 0)
+    expect(result.stdout).toBe(input)
+    expect(result.stderr).toContain("Formatter is disabled in .herb.yml configuration.")
+  })
+
   it("should format HTML/ERB from file", async () => {
     const testFile = "test-format.html.erb"
     const input = '<div class="container"><%= "Hello" %><p>World</p></div>'


### PR DESCRIPTION
Came across this with my Neovim setup in the Rubyevents repo, where the formatter is disabled via `.herb.yml`.

Editing any erb file results in the buffer being replaced with:
```
Formatter is disabled in .herb.yml configuration.
To enable formatting, set formatter.enabled: true in .herb.yml
Or use --force to format anyway.
``` 

The relevant configuration, in case you're interested, is: 

```lua
return {
  "stevearc/conform.nvim",
  opts = {
    formatters = {
      herb_format = {
        command = "herb-format",
        stdin = true,
      },
    },
  },
}
```

This is the same class of bug as #574, which moved the experimental-preview warning to stderr for exactly this reason.

 ## Fix

 - Print the disabled notice to stderr instead of stdout.
 - When input is coming from stdin (- or piped with no file arg), echo the original source back to stdout so the formatter is a clean no-op.
 - Exit code stays 0 — a disabled formatter is an intentional no-op, not an error.

 ## Testing

 - yarn workspace @herb-tools/formatter test --run test/cli.test.ts — 67 passing, including a new case asserting stdin is returned verbatim and the notice lands on stderr.
 - Manual: printf '<div>  x </div>\n' | node bin/herb-format - in a project with formatter.enabled: false now prints the input unchanged on stdout, notice on stderr.
