### PR TITLE
CI: Run workflow steps in parallel using `background`/`wait`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,17 +19,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Add LLVM apt Repo
+      - name: Install system dependencies
+        id: system-deps
+        background: true
         run: |-
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
           sudo add-apt-repository "deb http://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-21 main"
           sudo apt update
-
-      - name: Install APT dependencies
-        run: xargs sudo apt-get install -y --no-install-recommends < Aptfile
-
-      - name: Install valgrind
-        run: |-
+          xargs sudo apt-get install -y --no-install-recommends < Aptfile
           sudo apt install -y libc6-dbg
           sudo snap install --classic valgrind
 
@@ -45,39 +42,49 @@ jobs:
         run: bundle exec rake templates
 
       - name: RuboCop
+        id: rubocop
+        background: true
         run: bundle exec rubocop
 
-      - name: clang-format version
-        run: clang-format-21 --version
+      - name: Sorbet
+        id: sorbet
+        background: true
+        run: bundle exec srb tc
 
-      - name: Lint
-        run: bin/lint
-
-      - name: RBS Validation
+      - name: RBS Validation, Steep and RBS Inline
+        id: rbs
+        background: true
         run: |-
           bundle exec rbs collection install --frozen
           bundle exec rbs -Isig validate
+          bundle exec steep check
+          bundle exec rake rbs_inline
 
-      - name: Steep
-        run: bundle exec steep check
+      - name: Wait for system dependencies
+        wait: system-deps
 
-      - name: Sorbet
-        run: bundle exec srb tc
-
-      - name: RBS Inline
-        run: bundle exec rake rbs_inline
-
-      - name: clang-tidy version
-        run: clang-tidy-21 --version
+      - name: Lint
+        id: lint
+        background: true
+        run: |-
+          clang-format-21 --version
+          bin/lint
 
       - name: Tidy
-        run: bin/tidy
+        id: tidy
+        background: true
+        run: |-
+          clang-tidy-21 --version
+          bin/tidy
 
       - name: Compile Herb
         run: bundle exec rake make
 
       - name: Compile Ruby extension
         run: bundle exec rake compile
+
+      - name: Wait for all checks
+        wait-all:
 
       - name: Run Ruby Tests
         run: bundle exec rake test:all

--- a/.github/workflows/javascript.yml
+++ b/.github/workflows/javascript.yml
@@ -31,14 +31,14 @@ jobs:
           node-version-file: ".node-version"
           cache: "yarn"
 
-      - name: Add LLVM apt Repo
+      - name: Install system dependencies
+        id: system-deps
+        background: true
         run: |-
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
           sudo add-apt-repository "deb http://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-21 main"
           sudo apt update
-
-      - name: Install APT dependencies
-        run: grep -v emscripten Aptfile | xargs sudo apt-get install -y --no-install-recommends
+          grep -v emscripten Aptfile | xargs sudo apt-get install -y --no-install-recommends
 
       - name: Setup Emscripten
         uses: mymindstorm/setup-emsdk@v14
@@ -57,15 +57,12 @@ jobs:
       - name: Render Templates
         run: bundle exec rake templates
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version-file: ".node-version"
-          cache: "yarn"
-
       - name: yarn install
         run: yarn install --frozen-lockfile
 
       - name: Install Playwright browsers
+        id: playwright
+        background: true
         run: yarn playwright install
 
       - name: Build tailwind-class-sorter package
@@ -73,12 +70,18 @@ jobs:
           RELEASE_BUILD: ${{ github.event_name == 'release' && 'true' || 'false' }}
         run: yarn nx build @herb-tools/tailwind-class-sorter
 
+      - name: Wait for system dependencies
+        wait: system-deps
+
       - name: Run `build` for all NX packages
         env:
           RELEASE_BUILD: ${{ github.event_name == 'release' && 'true' || 'false' }}
           GITHUB_PR_NUMBER: ${{ github.event.pull_request.number }}
           GITHUB_PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: yarn build
+
+      - name: Wait for Playwright browsers
+        wait: playwright
 
       - name: Run `test` for all NX packages
         run: yarn test

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,17 +22,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          toolchain: stable
-          components: clippy
-
-      - name: Set up Rust Nightly (for rustfmt)
-        uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          toolchain: nightly
-          components: rustfmt
+      - name: Set up Rust toolchains
+        id: rust-toolchains
+        background: true
+        run: |-
+          rustup toolchain install stable --profile minimal --component clippy
+          rustup toolchain install nightly --profile minimal --component rustfmt
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
@@ -52,6 +47,9 @@ jobs:
 
       - name: Compile Herb
         run: bundle exec rake make
+
+      - name: Wait for Rust toolchains
+        wait: rust-toolchains
 
       - name: Check Rust formatting
         run: make format-check


### PR DESCRIPTION
Uses the new GitHub Actions parallel steps keywords to overlap network-bound setup (apt, valgrind, yarn/Playwright downloads) with Ruby setup and to run independent checks (RuboCop, Sorbet, Steep, clang-format, clang-tidy) concurrently.

https://github.blog/changelog/2026-06-25-actions-steps-can-now-be-run-in-parallel/