### PR TITLE
Formatter: preserve `<%#=` syntax in commented-out output tags

### DIFF
--- a/javascript/packages/formatter/src/comment-helpers.ts
+++ b/javascript/packages/formatter/src/comment-helpers.ts
@@ -108,13 +108,19 @@ export function formatERBCommentLines(open: string, content: string, close: stri
 
   if (contentLines.length === 1 && contentTrimmedLines.length === 1) {
     const startsWithSpace = content[0] === " "
-    const before = startsWithSpace ? "" : " "
+    // Keep `<%#=` intact — the `=` is the output tag, not comment content.
+    // See: https://github.com/marcoroth/herb/issues/1754
+    const startsWithEquals = content[0] === "="
+    const before = (startsWithSpace || startsWithEquals) ? "" : " "
 
     return { type: 'single-line', text: open + before + content.trimEnd() + ' ' + close }
   }
 
   if (contentTrimmedLines.length === 1) {
-    return { type: 'single-line', text: open + ' ' + content.trim() + ' ' + close }
+    const startsWithEquals = content.trim().startsWith("=")
+    const before = startsWithEquals ? "" : " "
+
+    return { type: 'single-line', text: open + before + content.trim() + ' ' + close }
   }
 
   const firstLineEmpty = contentLines[0].trim() === ""

--- a/javascript/packages/formatter/src/comment-helpers.ts
+++ b/javascript/packages/formatter/src/comment-helpers.ts
@@ -108,8 +108,6 @@ export function formatERBCommentLines(open: string, content: string, close: stri
 
   if (contentLines.length === 1 && contentTrimmedLines.length === 1) {
     const startsWithSpace = content[0] === " "
-    // Keep `<%#=` intact — the `=` is the output tag, not comment content.
-    // See: https://github.com/marcoroth/herb/issues/1754
     const startsWithEquals = content[0] === "="
     const before = (startsWithSpace || startsWithEquals) ? "" : " "
 

--- a/javascript/packages/formatter/test/comment-helpers.test.ts
+++ b/javascript/packages/formatter/test/comment-helpers.test.ts
@@ -150,5 +150,34 @@ describe("comment-helpers", () => {
         expect(result.contentLines).toEqual(["first line", "second line"])
       }
     })
+
+    describe("commented-out output tags (<%#=) — https://github.com/marcoroth/herb/issues/1754", () => {
+      test("does not insert a space between <%# and = on a single line", () => {
+        const result = formatERBCommentLines("<%#", "= tag.link rel: \"manifest\", href: pwa_manifest_path(format: :json) ", "%>")
+
+        expect(result).toEqual({
+          type: "single-line",
+          text: "<%#= tag.link rel: \"manifest\", href: pwa_manifest_path(format: :json) %>"
+        })
+      })
+
+      test("does not insert a space when multiline content collapses to a single line starting with =", () => {
+        const result = formatERBCommentLines("<%#", "\n  = foo\n", "%>")
+
+        expect(result).toEqual({
+          type: "single-line",
+          text: "<%#= foo %>"
+        })
+      })
+
+      test("preserves a genuine comment body that starts with = after a space", () => {
+        const result = formatERBCommentLines("<%#", " = foo", "%>")
+
+        expect(result).toEqual({
+          type: "single-line",
+          text: "<%# = foo %>"
+        })
+      })
+    })
   })
 })

--- a/javascript/packages/formatter/test/erb/comment.test.ts
+++ b/javascript/packages/formatter/test/erb/comment.test.ts
@@ -325,6 +325,20 @@ describe("@herb-tools/formatter", () => {
     expect(result100).toEqual(source100)
   })
 
+  test("preserves <%#= commented-out output tag (https://github.com/marcoroth/herb/issues/1754)", () => {
+    const source = '<%#= tag.link rel: "manifest", href: pwa_manifest_path(format: :json) %>'
+    const result = formatter.format(source)
+
+    expect(result).toEqual('<%#= tag.link rel: "manifest", href: pwa_manifest_path(format: :json) %>')
+  })
+
+  test("does not rewrite a genuine comment whose body starts with =", () => {
+    const source = '<%# = not an output tag %>'
+    const result = formatter.format(source)
+
+    expect(result).toEqual('<%# = not an output tag %>')
+  })
+
   test("preserve newline after ERB comment", () => {
     const source = dedent`
       <div>


### PR DESCRIPTION
The formatter was adding a space between `<%#` and `=`, turning `<%#= tag.link ... %>` into `<%# = tag.link ... %>`. The `=` belongs to the tag, not the comment body. Fix checks if content starts with `=` and skips the leading space.

Fixes #1754