### PR TITLE
Formatter: Don't add or remove whitespace at glued content boundaries

### DIFF
--- a/javascript/packages/formatter/src/format-printer.ts
+++ b/javascript/packages/formatter/src/format-printer.ts
@@ -719,6 +719,26 @@ export class FormatPrinter extends Printer implements TextFlowDelegate, Attribut
     }
   }
 
+  /**
+   * Visit ERB control-flow statements (the body of an `if`, `each`, `case`, …).
+   *
+   * When the statements contain rendered output glued directly together with no
+   * whitespace between (e.g. `<%= user.name %>'s dog` or `<%= greeting %>,`),
+   * route them through the text-flow engine so the glued content isn't split
+   * onto separate lines — which would inject whitespace into the rendered HTML
+   * (#1729). When the statements are only ever separated by whitespace (e.g. a
+   * list of standalone `<%= … %>` outputs), or the gluing only involves a
+   * non-output `<% … %>` statement (which renders nothing), breaking across
+   * lines is rendering-safe, so we keep the existing per-node visiting that
+   * breaks at ERB boundaries.
+   */
+  private visitStatements(statements: Node[]) {
+    if (this.textFlow.hasGluedTextFlowBoundary(statements)) {
+      this.textFlow.visitTextFlowChildren(statements)
+    } else {
+      this.visitAll(statements)
+    }
+  }
 
   /**
    * Visit element children with intelligent spacing logic
@@ -1036,7 +1056,7 @@ export class FormatPrinter extends Printer implements TextFlowDelegate, Attribut
   visitERBInNode(node: ERBInNode) {
     this.trackBoundary(node, () => {
       this.printERBNode(node)
-      this.withIndent(() => this.visitAll(node.statements))
+      this.withIndent(() => this.visitStatements(node.statements))
     })
   }
 
@@ -1111,7 +1131,7 @@ export class FormatPrinter extends Printer implements TextFlowDelegate, Attribut
         this.printERBNode(node)
 
         this.withIndent(() => {
-          this.visitAll(node.statements)
+          this.visitStatements(node.statements)
         })
 
         if (node.subsequent) this.visit(node.subsequent)
@@ -1126,13 +1146,13 @@ export class FormatPrinter extends Printer implements TextFlowDelegate, Attribut
     if (this.inlineMode) {
       this.visitAll(node.statements)
     } else {
-      this.withIndent(() => this.visitAll(node.statements))
+      this.withIndent(() => this.visitStatements(node.statements))
     }
   }
 
   visitERBWhenNode(node: ERBWhenNode) {
     this.printERBNode(node)
-    this.withIndent(() => this.visitAll(node.statements))
+    this.withIndent(() => this.visitStatements(node.statements))
   }
 
   visitERBCaseNode(node: ERBCaseNode) {
@@ -1150,7 +1170,7 @@ export class FormatPrinter extends Printer implements TextFlowDelegate, Attribut
   visitERBBeginNode(node: ERBBeginNode) {
     this.trackBoundary(node, () => {
       this.printERBNode(node)
-      this.withIndent(() => this.visitAll(node.statements))
+      this.withIndent(() => this.visitStatements(node.statements))
 
       if (node.rescue_clause) this.visit(node.rescue_clause)
       if (node.else_clause) this.visit(node.else_clause)
@@ -1162,7 +1182,7 @@ export class FormatPrinter extends Printer implements TextFlowDelegate, Attribut
   visitERBWhileNode(node: ERBWhileNode) {
     this.trackBoundary(node, () => {
       this.printERBNode(node)
-      this.withIndent(() => this.visitAll(node.statements))
+      this.withIndent(() => this.visitStatements(node.statements))
 
       if (node.end_node) this.visit(node.end_node)
     })
@@ -1171,7 +1191,7 @@ export class FormatPrinter extends Printer implements TextFlowDelegate, Attribut
   visitERBUntilNode(node: ERBUntilNode) {
     this.trackBoundary(node, () => {
       this.printERBNode(node)
-      this.withIndent(() => this.visitAll(node.statements))
+      this.withIndent(() => this.visitStatements(node.statements))
 
       if (node.end_node) this.visit(node.end_node)
     })
@@ -1180,7 +1200,7 @@ export class FormatPrinter extends Printer implements TextFlowDelegate, Attribut
   visitERBForNode(node: ERBForNode) {
     this.trackBoundary(node, () => {
       this.printERBNode(node)
-      this.withIndent(() => this.visitAll(node.statements))
+      this.withIndent(() => this.visitStatements(node.statements))
 
       if (node.end_node) this.visit(node.end_node)
     })
@@ -1188,18 +1208,18 @@ export class FormatPrinter extends Printer implements TextFlowDelegate, Attribut
 
   visitERBRescueNode(node: ERBRescueNode) {
     this.printERBNode(node)
-    this.withIndent(() => this.visitAll(node.statements))
+    this.withIndent(() => this.visitStatements(node.statements))
   }
 
   visitERBEnsureNode(node: ERBEnsureNode) {
     this.printERBNode(node)
-    this.withIndent(() => this.visitAll(node.statements))
+    this.withIndent(() => this.visitStatements(node.statements))
   }
 
   visitERBUnlessNode(node: ERBUnlessNode) {
     this.trackBoundary(node, () => {
       this.printERBNode(node)
-      this.withIndent(() => this.visitAll(node.statements))
+      this.withIndent(() => this.visitStatements(node.statements))
 
       if (node.else_clause) this.visit(node.else_clause)
       if (node.end_node) this.visit(node.end_node)

--- a/javascript/packages/formatter/src/format-printer.ts
+++ b/javascript/packages/formatter/src/format-printer.ts
@@ -135,6 +135,7 @@ export class FormatPrinter extends Printer implements TextFlowDelegate, Attribut
   private lines: string[] = []
   private indentLevel: number = 0
   private inlineMode: boolean = false
+  private preserveInlineWhitespace: boolean = false
   private inContentPreservingContext: boolean = false
   private inConditionalOpenTagContext: boolean = false
   private elementStack: HTMLElementNode[] = []
@@ -404,6 +405,15 @@ export class FormatPrinter extends Printer implements TextFlowDelegate, Attribut
     return result
   }
 
+  private withPreservedInlineWhitespace<T>(callback: () => T): T {
+    const was = this.preserveInlineWhitespace
+    this.preserveInlineWhitespace = true
+    const result = callback()
+    this.preserveInlineWhitespace = was
+
+    return result
+  }
+
   private withContentPreserving<T>(callback: () => T): T {
     const was = this.inContentPreservingContext
     this.inContentPreservingContext = true
@@ -667,7 +677,7 @@ export class FormatPrinter extends Printer implements TextFlowDelegate, Attribut
   private visitInlineElementBody(body: Node[], tagName: string, hasTextFlow: boolean, children: Node[]) {
     if (children.length === 0) return
 
-    const nodesToRender = hasTextFlow ? body : children
+    const nodesToRender = hasTextFlow || isInlineElement(tagName) ? body : children
 
     const hasOnlyTextContent = nodesToRender.every(child => isNode(child, HTMLTextNode) || isNode(child, WhitespaceNode))
     const shouldPreserveSpaces = hasOnlyTextContent && isInlineElement(tagName)
@@ -720,24 +730,19 @@ export class FormatPrinter extends Printer implements TextFlowDelegate, Attribut
   }
 
   /**
-   * Visit ERB control-flow statements (the body of an `if`, `each`, `case`, …).
+   * Visit ERB control-flow statements (the body of an `if`, `while`, `when`, …).
    *
-   * When the statements contain rendered output glued directly together with no
-   * whitespace between (e.g. `<%= user.name %>'s dog` or `<%= greeting %>,`),
-   * route them through the text-flow engine so the glued content isn't split
-   * onto separate lines — which would inject whitespace into the rendered HTML
-   * (#1729). When the statements are only ever separated by whitespace (e.g. a
-   * list of standalone `<%= … %>` outputs), or the gluing only involves a
-   * non-output `<% … %>` statement (which renders nothing), breaking across
-   * lines is rendering-safe, so we keep the existing per-node visiting that
-   * breaks at ERB boundaries.
+   * These go through the same path as element bodies so that they get the
+   * whitespace-preserving machinery, `shouldAppendToLastLine` and text-flow
+   * runs, which plain `visitAll` skipped, letting line breaks land on glued
+   * content and inject whitespace into the rendered output (#1729).
+   *
+   * Blank-line insertion stays off: the "rule of three" spacing is a layout
+   * choice for sibling *elements*, and applying it inside a control-flow body
+   * would start inserting blank lines into ERB that never had them.
    */
   private visitStatements(statements: Node[]) {
-    if (this.textFlow.hasGluedTextFlowBoundary(statements)) {
-      this.textFlow.visitTextFlowChildren(statements)
-    } else {
-      this.visitAll(statements)
-    }
+    this.visitElementChildren(statements, null, { allowBlankLines: false })
   }
 
   /**
@@ -745,7 +750,9 @@ export class FormatPrinter extends Printer implements TextFlowDelegate, Attribut
    *
    * Tracks line positions and immediately splices blank lines after rendering each child.
    */
-  private visitElementChildren(body: Node[], parentElement: HTMLElementNode | null) {
+  private visitElementChildren(body: Node[], parentElement: HTMLElementNode | null, options: { allowBlankLines?: boolean } = {}) {
+    const { allowBlankLines = true } = options
+
     let lastMeaningfulNode: Node | null = null
     let hasHandledSpacing = false
 
@@ -788,7 +795,7 @@ export class FormatPrinter extends Printer implements TextFlowDelegate, Attribut
       const childStartLine = this.stringLineCount
       this.visit(child)
 
-      if (lastMeaningfulNode && !hasHandledSpacing) {
+      if (allowBlankLines && lastMeaningfulNode && !hasHandledSpacing) {
         const shouldAddSpacing = this.spacingAnalyzer.shouldAddSpacingBetweenSiblings(parentElement, body, index)
 
         if (shouldAddSpacing) {
@@ -896,7 +903,8 @@ export class FormatPrinter extends Printer implements TextFlowDelegate, Attribut
 
   visitHTMLTextNode(node: HTMLTextNode) {
     if (this.inlineMode) {
-      const normalizedContent = node.content.replace(ASCII_WHITESPACE, ' ').trim()
+      const collapsed = node.content.replace(ASCII_WHITESPACE, ' ')
+      const normalizedContent = this.preserveInlineWhitespace ? collapsed : collapsed.trim()
 
       if (normalizedContent) {
         this.push(normalizedContent)
@@ -1463,10 +1471,46 @@ export class FormatPrinter extends Printer implements TextFlowDelegate, Attribut
   }
 
   /**
+   * Render an ERB control-flow node (`<% if %> … <% end %>`) as a single
+   * atomic token for text flow, preserving every space that is significant in
+   * the rendered output.
+   *
+   * Returns null when the node cannot be represented on one line, it wraps a
+   * block-level element, or one of its ERB tags spans multiple lines, in
+   * which case the caller falls back to the normal block layout.
+   */
+  tryRenderControlFlowInline(node: Node): string | null {
+    const contained = this.captureNodes(() => this.visit(node))
+
+    const hasBlockContent = contained.some(child =>
+      isNode(child, HTMLElementNode) && !isInlineElement(getTagName(child))
+    )
+
+    if (hasBlockContent) return null
+
+    const hasMultilineERB = contained.some(child =>
+      isERBNode(child) && (child.content?.value ?? "").includes("\n")
+    )
+
+    if (hasMultilineERB) return null
+
+    const rendered = this.withInlineMode(() =>
+      this.withPreservedInlineWhitespace(() => this.capture(() => this.visit(node)).join(""))
+    )
+
+    return rendered.trim() ? rendered : null
+  }
+
+  /**
    * Try to render an inline element, returning the full inline string or null if it can't be inlined.
    */
   tryRenderInlineElement(element: HTMLElementNode): string | null {
     const tagName = getTagName(element)
+    const tagClosing = getOpenTagClosing(element)
+
+    if (element.is_void || tagClosing?.value === "/>") {
+      return this.renderInlineElementAsString(element)
+    }
 
     return this.tryRenderInlineFull(element, tagName, filterNodes(getOpenTagChildren(element), HTMLAttributeNode), element.body)
   }

--- a/javascript/packages/formatter/src/text-flow-analyzer.ts
+++ b/javascript/packages/formatter/src/text-flow-analyzer.ts
@@ -10,8 +10,10 @@ import {
 } from "./format-helpers.js"
 
 import {
+  isGluedControlFlowNode,
   hasWhitespaceBeforeNode as hasWhitespaceBeforeNodeHelper,
   lastUnitEndsWithWhitespace as lastUnitEndsWithWhitespaceHelper,
+  tryFuseAdjacentAtomic as tryFuseAdjacentAtomicHelper,
   tryMergeAtomicAfterText as tryMergeAtomicAfterTextHelper,
   tryMergeTextAfterAtomic as tryMergeTextAfterAtomicHelper,
 } from "./text-flow-helpers.js"
@@ -23,6 +25,7 @@ import {
 export interface TextFlowAnalyzerDelegate {
   tryRenderInlineElement(element: HTMLElementNode): string | null
   renderERBAsString(node: ERBContentNode): string
+  tryRenderControlFlowInline(node: Node): string | null
 }
 
 /**
@@ -99,6 +102,16 @@ export class TextFlowAnalyzer {
         }
 
         lastProcessedIndex = i
+      } else if (isGluedControlFlowNode(children, i)) {
+        const merged = this.processGluedControlFlowNode(result, children, child, i, lastProcessedIndex)
+
+        if (merged) {
+          lastProcessedIndex = i
+
+          continue
+        }
+
+        lastProcessedIndex = i
       } else {
         result.push({
           unit: { content: '', type: 'block', isAtomic: false, breaksFlow: true },
@@ -143,10 +156,45 @@ export class TextFlowAnalyzer {
       return false
     }
 
-    if (lastProcessedIndex >= 0) {
-      const hasWhitespace = hasWhitespaceBetween(children, lastProcessedIndex, index) || lastUnitEndsWithWhitespaceHelper(result)
+    const hasWhitespace = lastProcessedIndex < 0 ||
+      hasWhitespaceBetween(children, lastProcessedIndex, index) ||
+      lastUnitEndsWithWhitespaceHelper(result)
 
-      if (!hasWhitespace && tryMergeAtomicAfterTextHelper(result, children, lastProcessedIndex, inlineContent, 'inline', child)) {
+    if (isLineBreakingElement(child)) {
+      if (hasWhitespace) {
+        result.push({
+          unit: { content: '', type: 'block', isAtomic: false, breaksFlow: true },
+          node: child
+        })
+
+        return false
+      }
+
+      const fused =
+        tryMergeAtomicAfterTextHelper(result, children, lastProcessedIndex, inlineContent, 'inline', child) ||
+        tryFuseAdjacentAtomicHelper(result, inlineContent)
+
+      if (!fused) {
+        result.push({
+          unit: { content: inlineContent, type: 'inline', isAtomic: true, breaksFlow: false },
+          node: child
+        })
+      }
+
+      result.push({
+        unit: { content: '', type: 'text', isAtomic: false, breaksFlow: true },
+        node: null
+      })
+
+      return true
+    }
+
+    if (!hasWhitespace) {
+      if (tryMergeAtomicAfterTextHelper(result, children, lastProcessedIndex, inlineContent, 'inline', child)) {
+        return true
+      }
+
+      if (tryFuseAdjacentAtomicHelper(result, inlineContent)) {
         return true
       }
     }
@@ -159,14 +207,63 @@ export class TextFlowAnalyzer {
     return false
   }
 
+  /**
+   * A control-flow node glued to its neighbours cannot be broken onto its own
+   * lines without injecting whitespace, so it becomes one atomic token that
+   * the wrapper is unable to split.
+   *
+   * If it can't be flattened onto a single line we fall back to the normal
+   * block layout, the break is still wrong, but it is the pre-existing
+   * behaviour rather than a mangled inline render.
+   */
+  private processGluedControlFlowNode(result: ContentUnitWithNode[], children: Node[], child: Node, index: number, lastProcessedIndex: number): boolean {
+    const inlineContent = this.delegate.tryRenderControlFlowInline(child)
+
+    if (inlineContent === null) {
+      result.push({
+        unit: { content: '', type: 'block', isAtomic: false, breaksFlow: true },
+        node: child
+      })
+
+      return false
+    }
+
+    if (lastProcessedIndex >= 0) {
+      const hasWhitespace = hasWhitespaceBetween(children, lastProcessedIndex, index) || lastUnitEndsWithWhitespaceHelper(result)
+
+      if (!hasWhitespace) {
+        if (tryMergeAtomicAfterTextHelper(result, children, lastProcessedIndex, inlineContent, 'erb', child)) {
+          return true
+        }
+
+        if (tryFuseAdjacentAtomicHelper(result, inlineContent)) {
+          return true
+        }
+      }
+    }
+
+    result.push({
+      unit: { content: inlineContent, type: 'erb', isAtomic: true, breaksFlow: false },
+      node: child
+    })
+
+    return false
+  }
+
   private processERBContentNode(result: ContentUnitWithNode[], children: Node[], child: ERBContentNode, index: number, lastProcessedIndex: number): boolean {
     const erbContent = this.delegate.renderERBAsString(child)
 
     if (lastProcessedIndex >= 0) {
       const hasWhitespace = hasWhitespaceBetween(children, lastProcessedIndex, index) || lastUnitEndsWithWhitespaceHelper(result)
 
-      if (!hasWhitespace && tryMergeAtomicAfterTextHelper(result, children, lastProcessedIndex, erbContent, 'erb', child)) {
-        return true
+      if (!hasWhitespace) {
+        if (tryMergeAtomicAfterTextHelper(result, children, lastProcessedIndex, erbContent, 'erb', child)) {
+          return true
+        }
+
+        if (tryFuseAdjacentAtomicHelper(result, erbContent)) {
+          return true
+        }
       }
 
       if (hasWhitespace && result.length > 0) {

--- a/javascript/packages/formatter/src/text-flow-engine.ts
+++ b/javascript/packages/formatter/src/text-flow-engine.ts
@@ -15,6 +15,7 @@ import {
 
 import {
   collectTextFlowRun as collectTextFlowRunHelper,
+  hasGluedTextFlowBoundary as hasGluedTextFlowBoundaryHelper,
   isInTextFlowContext as isInTextFlowContextHelper,
   isTextFlowNode as isTextFlowNodeHelper,
   tryMergePunctuationText as tryMergePunctuationTextHelper,
@@ -65,6 +66,10 @@ export class TextFlowEngine {
 
   isInTextFlowContext(children: Node[]): boolean {
     return isInTextFlowContextHelper(children)
+  }
+
+  hasGluedTextFlowBoundary(children: Node[]): boolean {
+    return hasGluedTextFlowBoundaryHelper(children)
   }
 
   collectTextFlowRun(body: Node[], startIndex: number): { nodes: Node[], endIndex: number } | null {

--- a/javascript/packages/formatter/src/text-flow-engine.ts
+++ b/javascript/packages/formatter/src/text-flow-engine.ts
@@ -15,7 +15,6 @@ import {
 
 import {
   collectTextFlowRun as collectTextFlowRunHelper,
-  hasGluedTextFlowBoundary as hasGluedTextFlowBoundaryHelper,
   isInTextFlowContext as isInTextFlowContextHelper,
   isTextFlowNode as isTextFlowNodeHelper,
   tryMergePunctuationText as tryMergePunctuationTextHelper,
@@ -66,10 +65,6 @@ export class TextFlowEngine {
 
   isInTextFlowContext(children: Node[]): boolean {
     return isInTextFlowContextHelper(children)
-  }
-
-  hasGluedTextFlowBoundary(children: Node[]): boolean {
-    return hasGluedTextFlowBoundaryHelper(children)
   }
 
   collectTextFlowRun(body: Node[], startIndex: number): { nodes: Node[], endIndex: number } | null {

--- a/javascript/packages/formatter/src/text-flow-helpers.ts
+++ b/javascript/packages/formatter/src/text-flow-helpers.ts
@@ -1,4 +1,4 @@
-import { isNode, getTagName } from "@herb-tools/core"
+import { isNode, getTagName, isERBOutputNode } from "@herb-tools/core"
 import { Node, HTMLTextNode, HTMLElementNode, ERBContentNode, WhitespaceNode } from "@herb-tools/core"
 
 import type { ContentUnitWithNode } from "./format-helpers.js"
@@ -112,6 +112,64 @@ export function isInTextFlowContext(children: Node[]): boolean {
   if (!allInline) return false
 
   return true
+}
+
+/**
+ * Check whether a node renders visible output that participates in text flow:
+ * non-empty text, an ERB *output* tag (`<%= %>` / `<%== %>`), or an inline
+ * element. Control-flow / non-output ERB (`<% ... %>`) renders nothing, so it
+ * never contributes rendered whitespace.
+ */
+function rendersVisibleOutput(node: Node): boolean {
+  if (isNode(node, HTMLTextNode)) return node.content.trim() !== ""
+  if (isERBOutputNode(node)) return true
+  if (isNode(node, HTMLElementNode)) return isInlineElement(getTagName(node))
+
+  return false
+}
+
+/**
+ * Check whether a list of statements/children contains a "glued" text-flow
+ * boundary: two adjacent nodes that both render visible output and touch
+ * without any whitespace between them, e.g. `<%= user.name %>'s dog`,
+ * `<%= greeting %>,` or `John<%= suffix %>`.
+ *
+ * Breaking such a boundary onto separate lines would inject whitespace into the
+ * rendered HTML that wasn't in the source (#1729). When nodes are separated by
+ * whitespace, or one side renders nothing (a `<% ... %>` control statement such
+ * as `<% i += 1 %>`), breaking across lines is rendering-safe, so this returns
+ * false and callers can keep their per-node visiting.
+ */
+export function hasGluedTextFlowBoundary(children: Node[]): boolean {
+  let previousNode: Node | null = null
+  let previousIndex = -1
+
+  for (let index = 0; index < children.length; index++) {
+    const child = children[index]
+
+    // Whitespace, and any node that renders nothing, breaks the glue chain:
+    // there is no rendered content on this side to be split apart.
+    if (!rendersVisibleOutput(child)) {
+      previousNode = null
+      previousIndex = -1
+
+      continue
+    }
+
+    if (previousNode) {
+      const separated =
+        hasWhitespaceBetween(children, previousIndex, index) ||
+        (isNode(previousNode, HTMLTextNode) && endsWithWhitespace(previousNode.content)) ||
+        (isNode(child, HTMLTextNode) && /^[ \t\n\r]/.test(child.content))
+
+      if (!separated) return true
+    }
+
+    previousNode = child
+    previousIndex = index
+  }
+
+  return false
 }
 
 /**

--- a/javascript/packages/formatter/src/text-flow-helpers.ts
+++ b/javascript/packages/formatter/src/text-flow-helpers.ts
@@ -1,4 +1,4 @@
-import { isNode, getTagName, isERBOutputNode } from "@herb-tools/core"
+import { isNode, getTagName, isERBNode, isERBOutputNode } from "@herb-tools/core"
 import { Node, HTMLTextNode, HTMLElementNode, ERBContentNode, WhitespaceNode } from "@herb-tools/core"
 
 import type { ContentUnitWithNode } from "./format-helpers.js"
@@ -10,14 +10,20 @@ import {
   normalizeAndSplitWords,
 } from "./format-helpers.js"
 
-
 /**
- * Check if a node participates in text flow
+ * Check if a node participates in text flow.
+ *
+ * When `children`/`index` are supplied, an ERB control-flow node also
+ * participates if it is glued to visible content, see
+ * {@link isGluedControlFlowNode}. Without that context it does not, which
+ * keeps the existing block layout for free-standing control flow.
  */
-export function isTextFlowNode(node: Node): boolean {
+export function isTextFlowNode(node: Node, children?: Node[], index?: number): boolean {
   if (isNode(node, ERBContentNode)) return true
   if (isNode(node, HTMLTextNode) && node.content.trim() !== "") return true
   if (isNode(node, HTMLElementNode) && isInlineElement(getTagName(node))) return true
+
+  if (children && index !== undefined && isGluedControlFlowNode(children, index)) return true
 
   return false
 }
@@ -45,7 +51,7 @@ export function collectTextFlowRun(body: Node[], startIndex: number): { nodes: N
   while (index < body.length) {
     const child = body[index]
 
-    if (isTextFlowNode(child)) {
+    if (isTextFlowNode(child, body, index)) {
       nodes.push(child)
       textFlowCount++
       index++
@@ -53,7 +59,7 @@ export function collectTextFlowRun(body: Node[], startIndex: number): { nodes: N
       let hasMoreTextFlow = false
 
       for (let lookaheadIndex = index + 1; lookaheadIndex < body.length; lookaheadIndex++) {
-        if (isTextFlowNode(body[lookaheadIndex])) {
+        if (isTextFlowNode(body[lookaheadIndex], body, lookaheadIndex)) {
           hasMoreTextFlow = true
           break
         }
@@ -78,7 +84,11 @@ export function collectTextFlowRun(body: Node[], startIndex: number): { nodes: N
 
   if (textFlowCount >= 2) {
     const hasText = nodes.some(node => isNode(node, HTMLTextNode) && node.content.trim() !== "")
-    const hasAtomicContent = nodes.some(node => isNode(node, ERBContentNode) || (isNode(node, HTMLElementNode) && isInlineElement(getTagName(node))))
+    const hasAtomicContent = nodes.some((node, nodeIndex) =>
+      isNode(node, ERBContentNode) ||
+      (isNode(node, HTMLElementNode) && isInlineElement(getTagName(node))) ||
+      isGluedControlFlowNode(nodes, nodeIndex)
+    )
 
     if (hasText && hasAtomicContent) {
       return { nodes, endIndex: index }
@@ -106,7 +116,7 @@ export function isInTextFlowContext(children: Node[]): boolean {
       return isInlineElement(getTagName(child))
     }
 
-    return false
+    return isGluedControlFlowNode(children, children.indexOf(child))
   })
 
   if (!allInline) return false
@@ -115,61 +125,68 @@ export function isInTextFlowContext(children: Node[]): boolean {
 }
 
 /**
- * Check whether a node renders visible output that participates in text flow:
- * non-empty text, an ERB *output* tag (`<%= %>` / `<%== %>`), or an inline
- * element. Control-flow / non-output ERB (`<% ... %>`) renders nothing, so it
- * never contributes rendered whitespace.
+ * How a node participates in the rendered character stream.
+ *
+ * - `visible`, emits characters: non-empty text, an ERB *output* tag
+ *   (`<%= %>` / `<%== %>`), or an inline element.
+ * - `transparent`, emits nothing *itself*, but does not separate its
+ *   neighbours either. A non-output ERB tag (`<% if %>`, `<% end %>`,
+ *   `<% i += 1 %>`) is zero-width, so the content on either side of it is
+ *   adjacent in the rendered output and a line break placed next to it is
+ *   still a rendered space.
+ * - `separator`, whitespace, or a block-level node that already forces a
+ *   break; there is nothing to glue across.
  */
-function rendersVisibleOutput(node: Node): boolean {
-  if (isNode(node, HTMLTextNode)) return node.content.trim() !== ""
-  if (isERBOutputNode(node)) return true
-  if (isNode(node, HTMLElementNode)) return isInlineElement(getTagName(node))
+type FlowRole = 'visible' | 'transparent' | 'separator'
 
-  return false
+function flowRole(node: Node): FlowRole {
+  if (isNode(node, HTMLTextNode)) {
+    return node.content.trim() !== "" ? 'visible' : 'separator'
+  }
+
+  if (isNode(node, WhitespaceNode)) return 'separator'
+  if (isERBOutputNode(node)) return 'visible'
+  if (isERBNode(node)) return 'transparent'
+
+  if (isNode(node, HTMLElementNode)) {
+    return isInlineElement(getTagName(node)) ? 'visible' : 'separator'
+  }
+
+  return 'separator'
 }
 
 /**
- * Check whether a list of statements/children contains a "glued" text-flow
- * boundary: two adjacent nodes that both render visible output and touch
- * without any whitespace between them, e.g. `<%= user.name %>'s dog`,
- * `<%= greeting %>,` or `John<%= suffix %>`.
+ * Check whether a control-flow ERB node touches visible content on either side
+ * with no whitespace in between, e.g. `Hello<% if owner %>` or
+ * `<% end %>!`.
  *
- * Breaking such a boundary onto separate lines would inject whitespace into the
- * rendered HTML that wasn't in the source (#1729). When nodes are separated by
- * whitespace, or one side renders nothing (a `<% ... %>` control statement such
- * as `<% i += 1 %>`), breaking across lines is rendering-safe, so this returns
- * false and callers can keep their per-node visiting.
+ * The `<% … %>` tags emit no characters, but that is precisely why they cannot
+ * keep their neighbours apart: in `dog<% end %>!` the `dog` and the `!` are
+ * adjacent in the rendered output, so putting a newline before the `<% end %>`
+ * still injects a space (#1729).
+ *
+ * When this holds, the control-flow node has to participate in text flow as an
+ * atomic unit rather than being laid out as a block.
  */
-export function hasGluedTextFlowBoundary(children: Node[]): boolean {
-  let previousNode: Node | null = null
-  let previousIndex = -1
+export function isGluedControlFlowNode(children: Node[], index: number): boolean {
+  const node = children[index]
 
-  for (let index = 0; index < children.length; index++) {
-    const child = children[index]
+  if (!isERBNode(node) || isERBOutputNode(node)) return false
 
-    // Whitespace, and any node that renders nothing, breaks the glue chain:
-    // there is no rendered content on this side to be split apart.
-    if (!rendersVisibleOutput(child)) {
-      previousNode = null
-      previousIndex = -1
+  const previous = children[index - 1]
+  const next = children[index + 1]
 
-      continue
-    }
+  const gluedBefore =
+    previous !== undefined &&
+    flowRole(previous) === 'visible' &&
+    !(isNode(previous, HTMLTextNode) && endsWithWhitespace(previous.content))
 
-    if (previousNode) {
-      const separated =
-        hasWhitespaceBetween(children, previousIndex, index) ||
-        (isNode(previousNode, HTMLTextNode) && endsWithWhitespace(previousNode.content)) ||
-        (isNode(child, HTMLTextNode) && /^[ \t\n\r]/.test(child.content))
+  const gluedAfter =
+    next !== undefined &&
+    flowRole(next) === 'visible' &&
+    !(isNode(next, HTMLTextNode) && /^[ \t\n\r]/.test(next.content))
 
-      if (!separated) return true
-    }
-
-    previousNode = child
-    previousIndex = index
-  }
-
-  return false
+  return gluedBefore || gluedAfter
 }
 
 /**
@@ -249,6 +266,31 @@ export function tryMergeAtomicAfterText(result: ContentUnitWithNode[], children:
     unit: { content: lastWord + atomicContent, type: atomicType, isAtomic: true, breaksFlow: false },
     node: atomicNode
   })
+
+  return true
+}
+
+/**
+ * Fuse an atomic unit (ERB / inline element) onto a preceding atomic unit when
+ * the two touch with no whitespace between them, e.g. `<%= greeting %>,<br>`.
+ *
+ * `tryMergeAtomicAfterText` only handles an atomic following *text*. When the
+ * predecessor is itself atomic the two stay separate tokens, and the wrapper's
+ * `needsSpaceBetween` then puts a space between them, injecting whitespace
+ * that was not in the source (#469).
+ *
+ * Returns true if the fuse was performed.
+ */
+export function tryFuseAdjacentAtomic(result: ContentUnitWithNode[], content: string): boolean {
+  if (result.length === 0) return false
+
+  const lastUnit = result[result.length - 1]
+
+  if (!lastUnit.unit.isAtomic) return false
+  if (lastUnit.unit.type !== 'erb' && lastUnit.unit.type !== 'inline') return false
+  if (endsWithWhitespace(lastUnit.unit.content)) return false
+
+  lastUnit.unit.content += content
 
   return true
 }

--- a/javascript/packages/formatter/test/erb/erb.test.ts
+++ b/javascript/packages/formatter/test/erb/erb.test.ts
@@ -364,8 +364,7 @@ describe("@herb-tools/formatter", () => {
 
     expect(result).toBe(dedent`
       <p>
-        Should not be duplicated.
-        <br />
+        Should not be duplicated.<br />
         Text with a inline
         element<a href="mailto:something@something.com">something@something.com</a>
         and some more text after
@@ -1349,18 +1348,14 @@ describe("@herb-tools/formatter", () => {
       </p>
 
       <p>
-        Subscription Details:
-        <br>
-        Plan Name: <b><%= @subscription.plan&.name || "Custom Plan" %></b>
-        <br>
-        Resumption Date: <b><%= render_date(Time.current, format: '%B %e, %Y') %></b>
-        <br>
+        Subscription Details:<br>
+        Plan Name: <b><%= @subscription.plan&.name || "Custom Plan" %></b><br>
+        Resumption Date:
+        <b><%= render_date(Time.current, format: '%B %e, %Y') %></b><br>
         Pickups Left:
-        <b><%= @subscription.credit_service.available_credits.values.first || 0 %><%= " (#{@subscription.loads * 20}lbs per pickup)" if @subscription.loads > 0 %></b>
-        <br>
+        <b><%= @subscription.credit_service.available_credits.values.first || 0 %><%= " (#{@subscription.loads * 20}lbs per pickup)" if @subscription.loads > 0 %></b><br>
         Next Billing Date:
-        <b><%= render_date(@subscription.current_period_end, format: '%B %e, %Y') %></b>
-        <br>
+        <b><%= render_date(@subscription.current_period_end, format: '%B %e, %Y') %></b><br>
       </p>
 
       <p>Why wait now? Schedule your next pickup today!</p>

--- a/javascript/packages/formatter/test/erb/glued-text-flow.test.ts
+++ b/javascript/packages/formatter/test/erb/glued-text-flow.test.ts
@@ -1,0 +1,148 @@
+import { describe, test, expect, beforeAll } from "vitest"
+import { Herb } from "@herb-tools/node-wasm"
+import { Formatter } from "../../src"
+import { createExpectFormattedToMatch } from "../helpers"
+
+import dedent from "dedent"
+
+let formatter: Formatter
+let expectFormattedToMatch: ReturnType<typeof createExpectFormattedToMatch>
+
+describe("ERB glued text flow", () => {
+  beforeAll(async () => {
+    await Herb.load()
+
+    formatter = new Formatter(Herb, {
+      indentWidth: 2,
+      maxLineLength: 80
+    })
+
+    expectFormattedToMatch = createExpectFormattedToMatch(formatter)
+  })
+
+  test("does not split text glued to ERB output inside an if", () => {
+    const source = dedent`
+      <p>
+        Hello
+        <% if user %>
+          <%= user.name %>'s dog
+        <% end %>
+      </p>
+    `
+
+    expectFormattedToMatch(source)
+  })
+
+  test("does not split text glued to ERB output when if starts inline", () => {
+    const source = dedent`
+      <p>
+        Hello<% if owner %> <%= owner.name %>'s dog<% end %>!
+        It's time for your walk.
+      </p>
+    `
+
+    const expected = dedent`
+      <p>
+        Hello
+        <% if owner %>
+          <%= owner.name %>'s dog
+        <% end %>!
+        It's time for your walk.
+      </p>
+    `
+
+    expect(formatter.format(source)).toEqual(expected)
+    expectFormattedToMatch(expected)
+  })
+
+  test("keeps punctuation glued to ERB output alongside block content in an if", () => {
+    const source = dedent`
+      <% if something? %>
+        <%= @user.preferred_greeting %>,<br>
+        <br>
+        <p>blah blah</p>
+      <% end %>
+    `
+
+    const expected = dedent`
+      <% if something? %>
+        <%= @user.preferred_greeting %>,
+        <br>
+        <br>
+        <p>blah blah</p>
+      <% end %>
+    `
+
+    expect(formatter.format(source)).toEqual(expected)
+    expectFormattedToMatch(expected)
+  })
+
+  test("keeps punctuation glued to ERB output inside a block", () => {
+    const source = dedent`
+      <% capture do %>
+        <%= @user.preferred_greeting %>,<br>
+        <br>
+        <p>blah blah</p>
+      <% end %>
+    `
+
+    const expected = dedent`
+      <% capture do %>
+        <%= @user.preferred_greeting %>,
+        <br>
+        <br>
+        <p>blah blah</p>
+      <% end %>
+    `
+
+    expect(formatter.format(source)).toEqual(expected)
+    expectFormattedToMatch(expected)
+  })
+
+  test("keeps ERB output glued to preceding text inside an if", () => {
+    const source = dedent`
+      <p>
+        <% if user %>
+          Hello <%= user.name %>, welcome back
+        <% end %>
+      </p>
+    `
+
+    expectFormattedToMatch(source)
+  })
+
+  test("still breaks whitespace-separated ERB outputs at ERB boundaries", () => {
+    const source = dedent`
+      <div>
+        <span>
+          <% if show_full_name? %>
+            <%= user.first_name %>
+            <%= user.middle_name %>
+            <%= user.last_name %>
+            <%= user.suffix %>
+            -
+            <%= formatted_date(user.birth_date, format: :long) %>
+          <% end %>
+        </span>
+      </div>
+    `
+
+    expectFormattedToMatch(source)
+  })
+
+  test("still breaks a non-output ERB statement glued to an inline element", () => {
+    const source = dedent`
+      <% while i < 3 %><b><%= i %></b><% i += 1 %><% end %>
+    `
+
+    const expected = dedent`
+      <% while i < 3 %>
+        <b><%= i %></b>
+        <% i += 1 %>
+      <% end %>
+    `
+
+    expect(formatter.format(source)).toEqual(expected)
+    expectFormattedToMatch(expected)
+  })
+})

--- a/javascript/packages/formatter/test/erb/glued-text-flow.test.ts
+++ b/javascript/packages/formatter/test/erb/glued-text-flow.test.ts
@@ -43,11 +43,7 @@ describe("ERB glued text flow", () => {
 
     const expected = dedent`
       <p>
-        Hello
-        <% if owner %>
-          <%= owner.name %>'s dog
-        <% end %>!
-        It's time for your walk.
+        Hello<% if owner %> <%= owner.name %>'s dog<% end %>! It's time for your walk.
       </p>
     `
 
@@ -66,8 +62,7 @@ describe("ERB glued text flow", () => {
 
     const expected = dedent`
       <% if something? %>
-        <%= @user.preferred_greeting %>,
-        <br>
+        <%= @user.preferred_greeting %>,<br>
         <br>
         <p>blah blah</p>
       <% end %>
@@ -88,8 +83,7 @@ describe("ERB glued text flow", () => {
 
     const expected = dedent`
       <% capture do %>
-        <%= @user.preferred_greeting %>,
-        <br>
+        <%= @user.preferred_greeting %>,<br>
         <br>
         <p>blah blah</p>
       <% end %>
@@ -111,38 +105,4 @@ describe("ERB glued text flow", () => {
     expectFormattedToMatch(source)
   })
 
-  test("still breaks whitespace-separated ERB outputs at ERB boundaries", () => {
-    const source = dedent`
-      <div>
-        <span>
-          <% if show_full_name? %>
-            <%= user.first_name %>
-            <%= user.middle_name %>
-            <%= user.last_name %>
-            <%= user.suffix %>
-            -
-            <%= formatted_date(user.birth_date, format: :long) %>
-          <% end %>
-        </span>
-      </div>
-    `
-
-    expectFormattedToMatch(source)
-  })
-
-  test("still breaks a non-output ERB statement glued to an inline element", () => {
-    const source = dedent`
-      <% while i < 3 %><b><%= i %></b><% i += 1 %><% end %>
-    `
-
-    const expected = dedent`
-      <% while i < 3 %>
-        <b><%= i %></b>
-        <% i += 1 %>
-      <% end %>
-    `
-
-    expect(formatter.format(source)).toEqual(expected)
-    expectFormattedToMatch(expected)
-  })
 })

--- a/javascript/packages/formatter/test/erb/if.test.ts
+++ b/javascript/packages/formatter/test/erb/if.test.ts
@@ -373,7 +373,7 @@ describe("@herb-tools/formatter", () => {
       expect(output).toEqual(input)
     })
 
-    test("if with multiple consecutive ERB outputs - breaks at ERB boundaries", () => {
+    test("if with multiple consecutive ERB outputs wraps like any other body", () => {
       const input = dedent`
         <div>
           <span>
@@ -389,7 +389,17 @@ describe("@herb-tools/formatter", () => {
         </div>
       `
       const output = formatter.format(input)
-      expect(output).toEqual(input)
+
+      expect(output).toEqual(dedent`
+        <div>
+          <span>
+            <% if show_full_name? %>
+              <%= user.first_name %> <%= user.middle_name %> <%= user.last_name %>
+              <%= user.suffix %> - <%= formatted_date(user.birth_date, format: :long) %>
+            <% end %>
+          </span>
+        </div>
+      `)
     })
 
     test("if with mixed inline HTML elements - breaks at ERB boundaries", () => {

--- a/javascript/packages/formatter/test/erb/until.test.ts
+++ b/javascript/packages/formatter/test/erb/until.test.ts
@@ -23,8 +23,7 @@ describe("@herb-tools/formatter", () => {
     const result = formatter.format(source)
     expect(result).toEqual(dedent`
       <% until i == 3 %>
-        <b><%= i %></b>
-        <% i += 1 %>
+        <b><%= i %></b><% i += 1 %>
       <% end %>
     `)
   })

--- a/javascript/packages/formatter/test/erb/while.test.ts
+++ b/javascript/packages/formatter/test/erb/while.test.ts
@@ -23,8 +23,7 @@ describe("@herb-tools/formatter", () => {
     const result = formatter.format(source)
     expect(result).toEqual(dedent`
       <% while i < 3 %>
-        <b><%= i %></b>
-        <% i += 1 %>
+        <b><%= i %></b><% i += 1 %>
       <% end %>
     `)
   })

--- a/javascript/packages/formatter/test/erb/whitespace-preservation.test.ts
+++ b/javascript/packages/formatter/test/erb/whitespace-preservation.test.ts
@@ -1,0 +1,243 @@
+import { describe, test, expect, beforeAll } from "vitest"
+import { Herb } from "@herb-tools/node-wasm"
+import { Formatter } from "../../src"
+import { createExpectFormattedToMatch } from "../helpers"
+
+import dedent from "dedent"
+
+let formatter: Formatter
+let expectFormattedToMatch: ReturnType<typeof createExpectFormattedToMatch>
+
+describe("whitespace preservation around ERB control flow", () => {
+  beforeAll(async () => {
+    await Herb.load()
+
+    formatter = new Formatter(Herb, { indentWidth: 2, maxLineLength: 80 })
+    expectFormattedToMatch = createExpectFormattedToMatch(formatter)
+  })
+
+  describe("#1729 — text glued across a control-flow boundary", () => {
+    test("keeps text glued on both sides of an if inside a block element", () => {
+      const source = `<p>Hello<% if owner %> <%= owner.name %>'s dog<% end %>!</p>`
+
+      const expected = dedent`
+        <p>
+          Hello<% if owner %> <%= owner.name %>'s dog<% end %>!
+        </p>
+      `
+
+      expect(formatter.format(source)).toEqual(expected)
+      expectFormattedToMatch(expected)
+    })
+
+    test("keeps text glued inside a div", () => {
+      const source = `<div>Hello<% if owner %> <%= owner.name %>'s dog<% end %>!</div>`
+
+      const expected = dedent`
+        <div>
+          Hello<% if owner %> <%= owner.name %>'s dog<% end %>!
+        </div>
+      `
+
+      expect(formatter.format(source)).toEqual(expected)
+      expectFormattedToMatch(expected)
+    })
+
+    test("leaves an already-inline document-root fragment untouched", () => {
+      expectFormattedToMatch(`Hello<% if owner %> <%= owner.name %>'s dog<% end %>!`)
+    })
+
+    test("keeps glue when only the opening tag is glued", () => {
+      const source = `<p>Hello<% if x %> a <% end %></p>`
+
+      expect(formatter.format(source)).toEqual(dedent`
+        <p>
+          Hello<% if x %> a <% end %>
+        </p>
+      `)
+    })
+
+    test("keeps glue when only the closing tag is glued", () => {
+      const source = `<p><% if x %>a<% end %>!</p>`
+
+      expect(formatter.format(source)).toEqual(dedent`
+        <p>
+          <% if x %>a<% end %>!
+        </p>
+      `)
+    })
+
+    test("keeps glue on both sides with no inner whitespace", () => {
+      const source = `<p>E<% if x %>xy<% end %>!</p>`
+
+      expect(formatter.format(source)).toEqual(dedent`
+        <p>
+          E<% if x %>xy<% end %>!
+        </p>
+      `)
+    })
+
+    test("overflowing glued content stays on one line rather than breaking", () => {
+      const source = `<p>Hello<% if owner %> <%= owner.name %>'s extremely long dog name here that overflows<% end %>!</p>`
+
+      expect(formatter.format(source)).toEqual(dedent`
+        <p>
+          Hello<% if owner %> <%= owner.name %>'s extremely long dog name here that overflows<% end %>!
+        </p>
+      `)
+    })
+  })
+
+  describe("control-flow keywords other than if", () => {
+    test("unless", () => {
+      expect(formatter.format(`<p>A<% unless x %>b<% end %>!</p>`)).toEqual(dedent`
+        <p>
+          A<% unless x %>b<% end %>!
+        </p>
+      `)
+    })
+
+    test("case/when", () => {
+      expect(formatter.format(`<p>A<% case x %><% when 1 %>one<% end %>!</p>`)).toEqual(dedent`
+        <p>
+          A<% case x %><% when 1 %>one<% end %>!
+        </p>
+      `)
+    })
+
+    test("nested control flow", () => {
+      expect(formatter.format(`<p>A<% if x %><% if y %>b<% end %><% end %>!</p>`)).toEqual(dedent`
+        <p>
+          A<% if x %><% if y %>b<% end %><% end %>!
+        </p>
+      `)
+    })
+
+    test("while loop keeps a glued trailing statement attached", () => {
+      const source = `<% while i < 3 %><b><%= i %></b><% i += 1 %><% end %>`
+
+      expect(formatter.format(source)).toEqual(dedent`
+        <% while i < 3 %>
+          <b><%= i %></b><% i += 1 %>
+        <% end %>
+      `)
+    })
+  })
+
+  describe("whitespace-separated control flow is still laid out as a block", () => {
+    test("spaces on both sides means breaking is safe", () => {
+      const source = `<p>Hello <% if x %>a<% end %> there</p>`
+
+      expect(formatter.format(source)).toEqual(dedent`
+        <p>
+          Hello
+          <% if x %>
+            a
+          <% end %>
+          there
+        </p>
+      `)
+    })
+
+    test("free-standing control flow keeps its block layout", () => {
+      expectFormattedToMatch(dedent`
+        <div>
+          <% if x %>
+            <p>a</p>
+          <% end %>
+        </div>
+      `)
+    })
+  })
+
+  describe("falls back to block layout when the node cannot be inlined", () => {
+    test("block element inside glued control flow", () => {
+      const source = `<p>A<% if x %><div>b</div><% end %>!</p>`
+
+      expect(formatter.format(source)).toEqual(dedent`
+        <p>
+          A
+          <% if x %>
+            <div>b</div>
+          <% end %>
+          !
+        </p>
+      `)
+    })
+  })
+
+  describe("#469 / #1729 (comment) — output glued to punctuation and <br>", () => {
+    test("at the document root the comma stays glued to the <br>", () => {
+      expectFormattedToMatch(dedent`
+        <%= @user.preferred_greeting %>,<br>
+        <br>
+        <p>blah blah</p>
+      `)
+    })
+
+    test("inside an if the comma stays glued to the <br>", () => {
+      expectFormattedToMatch(dedent`
+        <% if something? %>
+          <%= @user.preferred_greeting %>,<br>
+          <br>
+          <p>blah blah</p>
+        <% end %>
+      `)
+    })
+
+    test("inside a capture block the comma stays glued to the <br>", () => {
+      expectFormattedToMatch(dedent`
+        <% capture do %>
+          <%= @user.preferred_greeting %>,<br>
+          <br>
+          <p>blah blah</p>
+        <% end %>
+      `)
+    })
+  })
+
+  describe("#1883 — whitespace between children of an inline element", () => {
+    test("keeps the space between two inline elements", () => {
+      const source = dedent`
+        <div><span>
+          <em>a</em>
+          <em>b</em>
+        </span></div>
+      `
+
+      expect(formatter.format(source)).toEqual(`<div><span><em>a</em> <em>b</em></span></div>`)
+    })
+
+    test("keeps the space between two ERB outputs", () => {
+      const source = dedent`
+        <div><label>
+          <%= a %>
+          <%= b %>
+        </label></div>
+      `
+
+      expect(formatter.format(source)).toEqual(`<div><label><%= a %> <%= b %></label></div>`)
+    })
+
+    test("keeps the space between text and an inline element", () => {
+      const source = dedent`
+        <div><span>
+          text
+          <em>x</em>
+        </span></div>
+      `
+
+      expect(formatter.format(source)).toEqual(`<div><span>text <em>x</em></span></div>`)
+    })
+  })
+
+  describe("known gaps", () => {
+    test.fails("inline container keeps a leading space before an inline child", () => {
+      expectFormattedToMatch(`<p>D<span> <em>x</em>'s dog</span>!</p>`)
+    })
+
+    test.fails("inline container keeps a leading space before ERB control flow", () => {
+      expectFormattedToMatch(`<span>Hello<% if owner %> <%= owner.name %>'s dog<% end %>!</span>`)
+    })
+  })
+})

--- a/javascript/packages/formatter/test/html/tags.test.ts
+++ b/javascript/packages/formatter/test/html/tags.test.ts
@@ -66,16 +66,13 @@ describe("@herb-tools/formatter", () => {
       </p>
     `
     const result = formatter.format(source)
+
     expect(result).toEqual(dedent`
       <p>
-        One
-        <br>
-        Two
-        <br>
-        Three
-        <br>
-        Four
-        <br>
+        One<br>
+        Two<br>
+        Three<br>
+        Four<br>
       </p>
     `)
   })
@@ -100,16 +97,13 @@ describe("@herb-tools/formatter", () => {
       </p>
     `
     const result = formatter.format(source)
+
     expect(result).toEqual(dedent`
       <p>
-        One
-        <hr>
-        Two
-        <hr>
-        Three
-        <hr>
-        Four
-        <hr>
+        One<hr>
+        Two<hr>
+        Three<hr>
+        Four<hr>
       </p>
     `)
   })

--- a/javascript/packages/formatter/test/text-flow-analyzer.test.ts
+++ b/javascript/packages/formatter/test/text-flow-analyzer.test.ts
@@ -371,18 +371,23 @@ describe("TextFlowAnalyzer", () => {
       expect(erbUnits[2].unit.content).toBe("<%= c %>")
     })
 
-    test("two adjacent inline elements produce two separate inline units", () => {
+    test("two adjacent inline elements fuse into one atomic unit", () => {
       const analyzer = new TextFlowAnalyzer(createMockAnalyzerDelegate())
       const body = parseBody("<p><em>a</em><strong>b</strong></p>")
       const units = analyzer.buildContentUnits(body)
 
-      expect(units).toHaveLength(2)
+      expect(units).toHaveLength(1)
       expect(units[0].unit).toEqual({
-        type: "inline", content: "<em>a</em>", isAtomic: true, breaksFlow: false,
+        type: "inline", content: "<em>a</em><strong>b</strong>", isAtomic: true, breaksFlow: false,
       })
-      expect(units[1].unit).toEqual({
-        type: "inline", content: "<strong>b</strong>", isAtomic: true, breaksFlow: false,
-      })
+    })
+
+    test("two inline elements separated by whitespace stay separate units", () => {
+      const analyzer = new TextFlowAnalyzer(createMockAnalyzerDelegate())
+      const body = parseBody("<p><em>a</em> <strong>b</strong></p>")
+      const units = analyzer.buildContentUnits(body)
+
+      expect(units.filter(({ unit }) => unit.type === "inline")).toHaveLength(2)
     })
   })
 


### PR DESCRIPTION
## Overview

The formatter is free to turn a space into a newline and back — HTML collapses both to a single space. What it must never do is **introduce** whitespace where the source had none, or **remove** whitespace where the source had some, because either changes the rendered output.

Three open issues turned out to be instances of that one invariant:

```erb
<p>Hello<% if owner %> <%= owner.name %>'s dog<% end %>!</p>
```

rendered `Hello Peggy's dog!` before formatting and `Hello Peggy's dog !` after — and `Hello!` became `Hello !` when the branch wasn't taken.

The original approach in this PR gated on a "glued boundary" and treated a non-output `<% … %>` tag as *breaking* the glue chain, on the reasoning that the tag renders nothing so a line break next to it is safe. That reasoning conflates two different things: the tag emits no characters (true), and a newline placed *next to* the tag emits no characters (false). Everything outside `<% %>` delimiters is literal template output, so a newline before `<% end %>` still lands in the rendered stream. That's why only one side of the boundary got fixed.

## Related Issue

Closes #1729.
Closes #469.

Partially addresses #1883 — the whitespace *between* children of an inline element is fixed here. The leading/trailing case (`x<span> y </span>z` → `xyz`) is a separate, context-dependent problem and remains open.

## Affected Component(s)

- [x] 💅 Formatter
- [x] 📦 JavaScript / Node.js / WebAssembly

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Main Technical Changes

**Non-output ERB is modelled as transparent, not as a separator.** `flowRole()` classifies a node as `visible`, `transparent` or `separator`. A `<% if %>` / `<% end %>` / `<% i += 1 %>` tag is zero-width, so glue propagates *across* it: in `dog<% end %>!` the `dog` and the `!` are adjacent in the output and neither boundary can take a break. `hasGluedTextFlowBoundary` is removed in favour of `isGluedControlFlowNode`, and a glued control-flow node becomes a single atomic token in text flow (`tryRenderControlFlowInline`), falling back to the previous block layout when it wraps a block element or multiline ERB.

**ERB control-flow bodies use the same path as element bodies.** `visitStatements` routes `if` / `unless` / `when` / `in` / `begin` / `while` / `until` / `for` / `rescue` / `ensure` / `else` through `visitElementChildren` instead of bare `visitAll`, which had been skipping `shouldAppendToLastLine` and text-flow runs entirely. `ERBBlockNode` and `ERBRenderNode` already did this; the other eleven were the exception. Blank-line insertion is disabled on that path — the "rule of three" is a layout choice for sibling *elements* and would start inserting blank lines into ERB that never had them.

**Void elements stay attached to glued content.** `<br>` / `<hr>` have no children, so `tryRenderInlineFull` reported them as un-inlineable and they broke the surrounding flow, detaching the comma in `<%= greeting %>,<br>` (#469). They are now inlineable when glued to what precedes them, and still end the line they land on. When whitespace separates them they keep their own line as before.

**Whitespace between children of an inline element is preserved.** `filterSignificantChildren` only keeps a whitespace text node that is exactly `" "`, so the `"\n  "` between two `<em>`s was dropped before rendering and `a b` became `ab` (#1883). Inline elements now render from the unfiltered body.

### Changed expectations

Seven existing tests asserted output that injected whitespace the source did not have. Worth reviewing closely:

| test | was asserting |
|---|---|
| `while` / `until` loops | `<b><%= i %></b>` split from a glued `<% i += 1 %>`, putting a space between loop iterations |
| `<br> in <p>` / `<hr> in <p>` | `One` split from its glued `<br>` |
| `erb.test.ts` #564-comment, #436 Example 6 | same, for `.<br />` and `Details:<br>` |
| `glued-text-flow.test.ts` punctuation tests | the comma detached from the `<br>` — the #469 symptom itself |
| `if with multiple consecutive ERB outputs` | ERB outputs not wrapping, unlike every other body |

In three of these the **document-root variant of the same test already asserted the corrected form** — for example the `<br>` test directly above `<br> in <p>` expects `One<br>` on one line. Element and control-flow bodies were the outliers, not the new behaviour.

## How to Test

```bash
cd javascript/packages/formatter
yarn vitest run
```

New suite: `test/erb/whitespace-preservation.test.ts` — glue on either or both sides of a control-flow node, across `unless` / `case` / `while` / nested control flow, overflow staying on one line, whitespace-separated control flow still laid out as a block, fallback when a block element or multiline ERB is inside, the three #469 cases from the issue, and the #1883 inner-whitespace cases.

Three `test.fails` document what is deliberately left open: two leading/trailing-whitespace cases from #1883, plus a pre-existing comment-indent case.

Quick manual check:

```erb
<p>  Hello<% if owner %> <%= owner.name %>'s dog<% end %>!</p>
```

should format to, and stay at:

```erb
<p>
  Hello<% if owner %> <%= owner.name %>'s dog<% end %>!
</p>
```

## Checklist

- [x] 🧪 Tests added or updated
- [x] 🔨 Ran the relevant test suites
- [ ] 📚 Documentation updated (if applicable)
- [x] 🧭 Commit messages follow the `Component: Description` convention
