### PR TITLE
VS Code: Fix `vscode-languageserver` import

### DIFF
--- a/javascript/packages/language-server/rollup.config.mjs
+++ b/javascript/packages/language-server/rollup.config.mjs
@@ -42,7 +42,7 @@ export default [
     },
     external: isExternal,
     plugins: [
-      nodeResolve(),
+      nodeResolve({ exportConditions: ["node"] }),
       commonjs(),
       json(),
       typescript({


### PR DESCRIPTION
This fixes #1864. Root cause is the upgrade from `vscode-languageserver` 9.0.1 to 10.0.0.

Version 9 exposed its Node.js entry point as a regular file, but  Version 10 changed the package to use conditional exports. Its Node.js entry point is now declared roughly like this:

```json
{
  "exports": {
    "./node": {
      "types": "./lib/node/main.d.ts",
      "node": "./lib/node/main.js"
    }
  }
}
```

Rollup's node-resolve plugin does not enable that conditional node export by default. The fix is simply to use `nodeResolve`'s [exportConditions](https://github.com/rollup/plugins/blob/master/packages/node-resolve/README.md#exportconditions). 

