### PR TITLE
Engine: Add `title` to excluded tags

### DIFF
--- a/lib/herb/engine/debug_visitor.rb
+++ b/lib/herb/engine/debug_visitor.rb
@@ -336,7 +336,7 @@ module Herb
       end
 
       def in_excluded_context?
-        excluded_tags = ["script", "style", "head", "textarea", "pre", "svg", "math"]
+        excluded_tags = ["script", "style", "head", "title", "textarea", "pre", "svg", "math"]
         return true if excluded_tags.any? { |tag| @element_stack.include?(tag) }
 
         if @erb_block_stack.any? { |node| javascript_tag?(node.content.value.strip) || include_debug_disable_comment?(node.content.value.strip) }

--- a/test/engine/debug_mode_test.rb
+++ b/test/engine/debug_mode_test.rb
@@ -610,5 +610,11 @@ module Engine
 
       assert_compiled_snapshot(template, debug: true)
     end
+
+    test "standalone title content erb expressions do NOT get debug spans" do
+      assert_compiled_snapshot(<<~ERB, debug: true)
+        <title><%= @page_title %></title>
+      ERB
+    end
   end
 end

--- a/test/snapshots/engine/debug_mode_test/test_0070_standalone_title_content_erb_expressions_do_NOT_get_debug_spans_87b5a2c19c8999134835113fb0835e4d.txt
+++ b/test/snapshots/engine/debug_mode_test/test_0070_standalone_title_content_erb_expressions_do_NOT_get_debug_spans_87b5a2c19c8999134835113fb0835e4d.txt
@@ -1,0 +1,7 @@
+---
+source: "Engine::DebugModeTest#test_0070_standalone title content erb expressions do NOT get debug spans"
+input: "{source: \"<title><%= @page_title %></title>\\n\", options: {debug: true}}"
+---
+_buf = ::String.new; _buf << '<title data-herb-debug-outline-type="view" data-herb-debug-file-name="unknown" data-herb-debug-file-relative-path="unknown" data-herb-debug-file-full-path="unknown">'.freeze; _buf << (@page_title).to_s; _buf << '</title>
+'.freeze;
+_buf.to_s


### PR DESCRIPTION
This isn't a problem in most Rails apps since most apps have the `head` and `title` tag in the same view file (the layout file) but I have a project that breaks out the `title` into a separate partial so it can be included in several layouts. When that happens, a literal span gets included in the browser title.

**shared/_head.html.erb**

```
<%# locals: () %>
<title>
  <% if content_for?(:title) %>
    <%= content_for(:title) %> |
  <% end %>
  <%= Jumpstart.config.application_name %>
</title>
```

**Before**

<img width="248" height="78" alt="Screenshot 2026-07-27 at 7 04 24 PM" src="https://github.com/user-attachments/assets/f0aa062d-7b54-4884-966b-c9c71f268482" />

**After**

<img width="244" height="90" alt="Screenshot 2026-07-27 at 7 05 50 PM" src="https://github.com/user-attachments/assets/ceda7e4d-f1e5-43a3-ba97-602a5bae8019" />
