### PR TITLE
CI: Add Corpus workflow

### DIFF
--- a/.github/workflows/corpus.yml
+++ b/.github/workflows/corpus.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 concurrency:
   group: corpus-${{ github.ref }}
@@ -99,6 +100,7 @@ jobs:
             --out corpus/runs/branch.json
 
       - name: Compare
+        id: compare
         env:
           NO_COLOR: "1"
         run: |-
@@ -107,7 +109,25 @@ jobs:
           corpus/bin/diff-runs \
             corpus/runs/release.json \
             corpus/runs/branch.json \
+            --markdown comment.md \
             --fail-on-regression | tee comparison.txt
+
+      - name: Comment on the pull request
+        if: failure() && github.event_name == 'pull_request' && hashFiles('comment.md') != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NUMBER: ${{ github.event.pull_request.number }}
+        run: |-
+          existing=$(gh api "repos/${{ github.repository }}/issues/$NUMBER/comments" \
+            --jq 'map(select(.body | contains("<!-- corpus-report -->"))) | .[0].id // empty')
+
+          if [ -n "$existing" ]; then
+            gh api -X PATCH "repos/${{ github.repository }}/issues/comments/$existing" -F body=@comment.md >/dev/null
+            echo "Updated comment $existing."
+          else
+            gh pr comment "$NUMBER" --body-file comment.md
+            echo "Posted a new comment."
+          fi
 
       - name: Job summary
         if: always()

--- a/.github/workflows/corpus.yml
+++ b/.github/workflows/corpus.yml
@@ -1,0 +1,129 @@
+name: Corpus
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: corpus-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubicloud-standard-2
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Clone corpus
+        id: corpus
+        background: true
+        run: |-
+          git clone --depth 1 https://github.com/marcoroth/herb-corpus corpus
+
+      - name: Add LLVM apt Repo
+        run: |-
+          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+          sudo add-apt-repository "deb http://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-21 main"
+          sudo apt update
+
+      - name: Install APT dependencies
+        run: xargs sudo apt-get install -y --no-install-recommends < Aptfile
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Install the last released gem
+        id: release
+        run: |-
+          version=$(gem search '^herb$' --remote --no-prerelease | sed -n 's/^herb (\([0-9][0-9.]*\).*/\1/p')
+
+          if [ -z "$version" ]; then
+            echo "Could not resolve the latest released herb version" >&2
+            exit 1
+          fi
+
+          gem install herb -v "$version" --no-document
+
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Comparing against herb $version"
+
+      - name: Wait for the corpus clone
+        wait: [corpus]
+
+      - name: Measure the last release
+        id: measure-release
+        background: true
+        env:
+          BUNDLE_GEMFILE: ""
+          RUBYOPT: ""
+        run: |-
+          corpus/bin/measure-herb \
+            --version "${{ steps.release.outputs.version }}" \
+            --label "released ${{ steps.release.outputs.version }}" \
+            --corpus corpus/erb \
+            --out corpus/runs/release.json
+
+      - name: Render Templates
+        run: bundle exec rake templates
+
+      - name: Compile Herb
+        run: bundle exec rake make
+
+      - name: Compile Ruby extension
+        run: bundle exec rake compile
+
+      - name: Wait for the release measurement
+        wait-all:
+
+      - name: Measure this branch
+        env:
+          BUNDLE_GEMFILE: ""
+          RUBYOPT: ""
+        run: |-
+          corpus/bin/measure-herb \
+            --gem-path "$GITHUB_WORKSPACE" \
+            --label "this branch (${GITHUB_SHA::7})" \
+            --corpus corpus/erb \
+            --out corpus/runs/branch.json
+
+      - name: Compare
+        env:
+          NO_COLOR: "1"
+        run: |-
+          set -o pipefail
+
+          corpus/bin/diff-runs \
+            corpus/runs/release.json \
+            corpus/runs/branch.json \
+            --fail-on-regression | tee comparison.txt
+
+      - name: Job summary
+        if: always()
+        run: |-
+          {
+            echo "### Corpus: this branch vs herb ${{ steps.release.outputs.version }}"
+            echo
+            echo '```'
+            cat comparison.txt 2>/dev/null || echo "the comparison did not run"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload runs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: corpus-runs
+          path: corpus/runs/*.json
+          retention-days: 30


### PR DESCRIPTION
This pull request adds a `Corpus` workflow that parses and compiles every `.erb` file in [herb-corpus](https://github.com/marcoroth/herb-corpus) with this branch and with the last released gem, and fails if a file that used to work no longer does.

The corpus is 250+ real-world Rails applications pinned to exact commits, currently 32'000+ templates. Each one is parsed and checked with `recursive_errors`, then run through `Herb::Engine` and checked with `prism` to confirm the generated Ruby is itself valid Ruby. Compile is the stronger check: a template can parse cleanly and still compile to Ruby that does not parse.

The check is differential, not absolute. Around 1,000 templates fail to parse and 2,400 fail to compile, mostly because the markup really is malformed, and those totals shift as the corpus grows. Only a change in *which* files fail turns the check red, so fixing files is green and breaking a previously working one is not.

The measurement scripts live in herb-corpus rather than here, because a released version has to be measured by exactly the code that measures the branch. A test in this repository cannot do that: `v0.10.2` has no corpus test at all. Both runs share one corpus checkout, so the diff stays attributable to Herb, and the release measurement runs as a background step alongside `rake make` and `rake compile` instead of adding three minutes to the critical path.

In the future, we also want to use the corpus for the linter, formatter and the printer for round-trip checks.
