### PR TITLE
Engine: Fix `NameError` in `:overlay` mode for parser errors

### DIFF
--- a/lib/herb/engine/parser_error_overlay.rb
+++ b/lib/herb/engine/parser_error_overlay.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "digest"
+
 module Herb
   class Engine
     class ParserErrorOverlay

--- a/test/engine/validation_modes_test.rb
+++ b/test/engine/validation_modes_test.rb
@@ -95,5 +95,27 @@ module Engine
         Herb::Engine.new(@invalid_security_template, validation_mode: :raise, debug: true)
       end
     end
+
+    test ":overlay mode compiles parser errors into the template" do
+      engine = Herb::Engine.new("<div><span>Content</div>", validation_mode: :overlay)
+
+      assert_includes engine.src, "data-herb-parser-error"
+      assert_includes engine.src, "Add missing closing tag"
+      assert_includes engine.src, "suggestions-"
+    end
+
+    test ":overlay mode compiles parser errors in a process that only loads herb" do
+      script = <<~RUBY
+        require "herb"
+        require "herb/engine"
+        Herb::Engine.new("<div><span>Content</div>", validation_mode: :overlay)
+        print "ok"
+      RUBY
+
+      lib = File.expand_path("../../lib", __dir__)
+      output = IO.popen([RbConfig.ruby, "-I#{lib}", "-e", script], err: [:child, :out], &:read)
+
+      assert_equal "ok", output.strip
+    end
   end
 end


### PR DESCRIPTION
Compiling a template that has a parser error with `validation_mode: :overlay` raises a `NameError` instead of rendering the error overlay:

```ruby
Herb::Engine.new("<div><span>Content</div>", validation_mode: :overlay)
```
```
/Users/marcoroth/Development/tilt/herb/lib/herb/engine/parser_error_overlay.rb:532:in 'Herb::Engine::ParserErrorOverlay#generate_suggestions_section': uninitialized constant Herb::Engine::ParserErrorOverlay::Digest (NameError)

        section_id = "suggestions-#{Digest::MD5.hexdigest(suggestions.inspect)}"
                                    ^^^^^^
        from /Users/marcoroth/Development/tilt/herb/lib/herb/engine/parser_error_overlay.rb:442:in 'Herb::Engine::ParserErrorOverlay#generate_error_sections'
        from /Users/marcoroth/Development/tilt/herb/lib/herb/engine/parser_error_overlay.rb:348:in 'Herb::Engine::ParserErrorOverlay#generate_html'
        from /Users/marcoroth/Development/tilt/herb/lib/herb/engine.rb:513:in 'Herb::Engine#add_parser_error_overlay'
        from /Users/marcoroth/Development/tilt/herb/lib/herb/engine.rb:146:in 'Herb::Engine#initialize'
        from (irb):2:in '<main>'
        from /Users/marcoroth/.local/share/mise/installs/ruby/4.0.2/lib/ruby/gems/4.0.0/gems/irb-1.18.0/exe/irb:9:in '<top (required)>'
        from /Users/marcoroth/.local/share/mise/installs/ruby/4.0.2/lib/ruby/4.0.0/rubygems.rb:304:in 'Kernel#load'
        from /Users/marcoroth/.local/share/mise/installs/ruby/4.0.2/lib/ruby/4.0.0/rubygems.rb:304:in 'Gem.activate_and_load_bin_path'
        from /Users/marcoroth/.local/share/mise/installs/ruby/4.0.2/bin/irb:25:in '<main>'
```

`ParserErrorOverlay#generate_suggestions_section` uses `Digest::MD5.hexdigest` to build the `section_id` for the suggestions section, but `digest` was never required anywhere in `lib/`. This adds the missing `require "digest"`.

The test suite didn't catch this because `test/snapshot_utils.rb` requires `digest` itself for snapshot filenames, so `Digest` was always already loaded by the time any test ran. The failure only ever shows up for users of the gem.

Found while trying to add `Herb::Engine` to Tilt.
