### PR TITLE
Formatter: Preserve whitespace for inline element edges punctuation

### DIFF
--- a/javascript/packages/formatter/src/format-helpers.ts
+++ b/javascript/packages/formatter/src/format-helpers.ts
@@ -462,15 +462,55 @@ export function isLineBreakingElement(node: Node): boolean {
  * Then split into words
  */
 export function normalizeAndSplitWords(text: string): string[] {
-  const normalized = text.replace(/\s+/g, ' ')
+  const normalized = text.replace(ASCII_WHITESPACE, ' ')
+
   return normalized.trim().split(' ')
+}
+
+/**
+ * Check if a character is ASCII whitespace.
+ *
+ * Deliberately not `\s`: Unicode whitespace such as NBSP (U+00A0) is content,
+ * not layout, and must survive formatting — the same reason
+ * {@link ASCII_WHITESPACE} exists.
+ */
+export function isAsciiWhitespace(character: string): boolean {
+  return character === " " || character === "\t" || character === "\n" || character === "\r"
+}
+
+/**
+ * Check if text starts with whitespace
+ */
+export function startsWithWhitespace(text: string): boolean {
+  return text.length > 0 && isAsciiWhitespace(text[0])
 }
 
 /**
  * Check if text ends with whitespace
  */
 export function endsWithWhitespace(text: string): boolean {
-  return /\s$/.test(text)
+  return text.length > 0 && isAsciiWhitespace(text[text.length - 1])
+}
+
+/**
+ * Collapse the whitespace runs at either end of `text` down to a single space
+ * when that edge is rendered, or remove them when it isn't.
+ */
+export function setEdgeWhitespace(text: string, keepLeading: boolean, keepTrailing: boolean): string {
+  let start = 0
+  let end = text.length
+
+  while (start < end && isAsciiWhitespace(text[start])) start++
+  while (end > start && isAsciiWhitespace(text[end - 1])) end--
+
+  if (start === end) {
+    return text.length > 0 && keepLeading && keepTrailing ? " " : ""
+  }
+
+  const leading = start > 0 && keepLeading ? " " : ""
+  const trailing = end < text.length && keepTrailing ? " " : ""
+
+  return leading + text.slice(start, end) + trailing
 }
 
 /**

--- a/javascript/packages/formatter/src/format-helpers.ts
+++ b/javascript/packages/formatter/src/format-helpers.ts
@@ -194,8 +194,6 @@ export function buildLineWithWord(currentLine: string, word: string): string {
   }
 
   if (isClosingPunctuation(word)) {
-    currentLine = currentLine.trimEnd()
-
     return `${currentLine}${word}`
   }
 

--- a/javascript/packages/formatter/src/format-printer.ts
+++ b/javascript/packages/formatter/src/format-printer.ts
@@ -4,7 +4,7 @@ import { AttributeRenderer } from "./attribute-renderer.js"
 import { SpacingAnalyzer } from "./spacing-analyzer.js"
 import { HerbDisableCollector } from "./herb-disable-collector.js"
 
-import { isTextFlowNode } from "./text-flow-helpers.js"
+import { isTextFlowNode, hasFlowContentBefore, hasFlowContentAfter } from "./text-flow-helpers.js"
 import { extractHTMLCommentContent, formatHTMLCommentInner, formatERBCommentLines } from "./comment-helpers.js"
 
 import type { ERBNode } from "@herb-tools/core"
@@ -141,6 +141,7 @@ export class FormatPrinter extends Printer implements TextFlowDelegate, Attribut
   private elementStack: HTMLElementNode[] = []
   private elementFormattingAnalysis = new Map<HTMLElementNode, ElementFormattingAnalysis>()
   private nodeIsMultiline = new Map<Node, boolean>()
+  private inlineFlowContext = new Map<Node, { before: boolean, after: boolean }>()
   private stringLineCount: number = 0
   private textFlow: TextFlowEngine
   private attributeRenderer: AttributeRenderer
@@ -173,13 +174,59 @@ export class FormatPrinter extends Printer implements TextFlowDelegate, Attribut
     this.indentLevel = 0
     this.stringLineCount = 0
     this.nodeIsMultiline.clear()
+    this.inlineFlowContext.clear()
     this.spacingAnalyzer.clear()
+
+    this.collectInlineFlowContext(node, false, false)
 
     this.visit(node)
 
     this.spliceHerbDisableComments()
 
     return this.lines.join("\n")
+  }
+
+  private inlineFlowChildren(node: Node): Node[] | null {
+    if (isNode(node, DocumentNode)) return node.children
+    if (isNode(node, HTMLElementNode)) return node.body
+    if (isERBControlFlowNode(node) && Array.isArray((node as any).statements)) return (node as any).statements
+    if (Array.isArray((node as any).body)) return (node as any).body
+
+    return null
+  }
+
+  private collectInlineFlowContext(node: Node, inheritedBefore: boolean, inheritedAfter: boolean): void {
+    const list = this.inlineFlowChildren(node)
+
+    if (!list) {
+      for (const child of node.compactChildNodes()) {
+        this.collectInlineFlowContext(child, false, false)
+      }
+
+      return
+    }
+
+    const firstIndex = list.findIndex(child => !isPureWhitespaceNode(child))
+    const lastIndex = list.reduce((found, child, index) => isPureWhitespaceNode(child) ? found : index, -1)
+
+    list.forEach((child, index) => {
+      const before = hasFlowContentBefore(list, index) || (firstIndex >= 0 && index <= firstIndex && inheritedBefore)
+      const after = hasFlowContentAfter(list, index) || (lastIndex >= 0 && index >= lastIndex && inheritedAfter)
+
+      this.inlineFlowContext.set(child, { before, after })
+
+      const staysInline =
+        (isNode(child, HTMLElementNode) && isInlineElement(getTagName(child))) ||
+        isERBControlFlowNode(child)
+
+      this.collectInlineFlowContext(child, staysInline && before, staysInline && after)
+    })
+  }
+
+  private edgeWhitespaceIsRendered(node: Node | null): { before: boolean, after: boolean } {
+    if (!node) return { before: false, after: false }
+
+    return this.inlineFlowContext.get(node) ?? { before: false, after: false }
   }
 
   private spliceHerbDisableComments(): void {
@@ -720,9 +767,18 @@ export class FormatPrinter extends Printer implements TextFlowDelegate, Attribut
 
     const content = lines.join('')
 
-    const inlineContent = shouldPreserveSpaces
-      ? (hasTextFlow ? content.replace(ASCII_WHITESPACE, ' ') : content)
-      : (hasTextFlow ? content.replace(ASCII_WHITESPACE, ' ').trim() : content.trim())
+    let inlineContent: string
+
+    if (shouldPreserveSpaces) {
+      inlineContent = hasTextFlow ? content.replace(ASCII_WHITESPACE, ' ') : content
+    } else {
+      const normalized = hasTextFlow ? content.replace(ASCII_WHITESPACE, ' ') : content
+      const edge = this.edgeWhitespaceIsRendered(this.currentElement)
+
+      inlineContent = normalized
+        .replace(/^[ \t\n\r]+/, edge.before ? ' ' : '')
+        .replace(/[ \t\n\r]+$/, edge.after ? ' ' : '')
+    }
 
     if (inlineContent) {
       this.pushToLastLine(inlineContent)
@@ -904,7 +960,12 @@ export class FormatPrinter extends Printer implements TextFlowDelegate, Attribut
   visitHTMLTextNode(node: HTMLTextNode) {
     if (this.inlineMode) {
       const collapsed = node.content.replace(ASCII_WHITESPACE, ' ')
-      const normalizedContent = this.preserveInlineWhitespace ? collapsed : collapsed.trim()
+      const edge = this.edgeWhitespaceIsRendered(node)
+      const normalizedContent = this.preserveInlineWhitespace
+        ? collapsed
+        : collapsed
+            .replace(/^ +/, edge.before ? ' ' : '')
+            .replace(/ +$/, edge.after ? ' ' : '')
 
       if (normalizedContent) {
         this.push(normalizedContent)
@@ -1574,7 +1635,7 @@ export class FormatPrinter extends Printer implements TextFlowDelegate, Attribut
     result += this.attributeRenderer.renderAttributesString(attributes, tagName)
     result += ">"
 
-    const childrenContent = this.tryRenderChildrenInline(children, tagName)
+    const childrenContent = this.tryRenderChildrenInline(children, tagName, _node)
 
     if (!childrenContent) return null
 
@@ -1587,12 +1648,16 @@ export class FormatPrinter extends Printer implements TextFlowDelegate, Attribut
   /**
    * Try to render just the children inline (without tags)
    */
-  private tryRenderChildrenInline(children: Node[], tagName?: string): string | null {
+  private tryRenderChildrenInline(children: Node[], tagName?: string, element?: Node): string | null {
     let result = ""
     let hasInternalWhitespace = false
 
     const hasOnlyTextContent = children.every(child => isNode(child, HTMLTextNode) || isNode(child, WhitespaceNode))
     const shouldPreserveSpaces = hasOnlyTextContent && tagName && isInlineElement(tagName)
+
+    const edge = this.edgeWhitespaceIsRendered(element ?? null)
+    const leadingWhitespaceIsRendered = edge.before
+    const trailingWhitespaceIsRendered = edge.after
 
     for (const child of children) {
       if (isNode(child, HTMLTextNode)) {
@@ -1620,6 +1685,8 @@ export class FormatPrinter extends Printer implements TextFlowDelegate, Attribut
         if (result) {
           result += ' '
           hasInternalWhitespace = true
+        } else if (leadingWhitespaceIsRendered) {
+          result += ' '
         }
       } else if (isNode(child, HTMLElementNode)) {
         const tagName = getTagName(child)
@@ -1648,11 +1715,9 @@ export class FormatPrinter extends Printer implements TextFlowDelegate, Attribut
       return result
     }
 
-    if (hasInternalWhitespace) {
-      return result.trimEnd()
-    }
-
-    return result.trim()
+    return result
+      .replace(/^[ \t\n\r]+/, leadingWhitespaceIsRendered ? ' ' : '')
+      .replace(/[ \t\n\r]+$/, trailingWhitespaceIsRendered ? ' ' : '')
   }
 
   /**

--- a/javascript/packages/formatter/src/format-printer.ts
+++ b/javascript/packages/formatter/src/format-printer.ts
@@ -42,8 +42,11 @@ import {
   hasMixedTextAndInlineContent,
   hasMultilineTextContent,
   isContentPreserving,
+  endsWithWhitespace,
   isFrontmatter,
   isInlineElement,
+  setEdgeWhitespace,
+  startsWithWhitespace,
   isNonWhitespaceNode,
   shouldAppendToLastLine,
   shouldPreserveUserSpacing,
@@ -775,9 +778,7 @@ export class FormatPrinter extends Printer implements TextFlowDelegate, Attribut
       const normalized = hasTextFlow ? content.replace(ASCII_WHITESPACE, ' ') : content
       const edge = this.edgeWhitespaceIsRendered(this.currentElement)
 
-      inlineContent = normalized
-        .replace(/^[ \t\n\r]+/, edge.before ? ' ' : '')
-        .replace(/[ \t\n\r]+$/, edge.after ? ' ' : '')
+      inlineContent = setEdgeWhitespace(normalized, edge.before, edge.after)
     }
 
     if (inlineContent) {
@@ -963,9 +964,7 @@ export class FormatPrinter extends Printer implements TextFlowDelegate, Attribut
       const edge = this.edgeWhitespaceIsRendered(node)
       const normalizedContent = this.preserveInlineWhitespace
         ? collapsed
-        : collapsed
-            .replace(/^ +/, edge.before ? ' ' : '')
-            .replace(/ +$/, edge.after ? ' ' : '')
+        : setEdgeWhitespace(collapsed, edge.before, edge.after)
 
       if (normalizedContent) {
         this.push(normalizedContent)
@@ -1662,8 +1661,8 @@ export class FormatPrinter extends Printer implements TextFlowDelegate, Attribut
     for (const child of children) {
       if (isNode(child, HTMLTextNode)) {
         const normalizedContent = child.content.replace(ASCII_WHITESPACE, ' ')
-        const hasLeadingSpace = /^[ \t\n\r]/.test(child.content)
-        const hasTrailingSpace = /[ \t\n\r]$/.test(child.content)
+        const hasLeadingSpace = startsWithWhitespace(child.content)
+        const hasTrailingSpace = endsWithWhitespace(child.content)
         const trimmedContent = normalizedContent.trim()
 
         if (trimmedContent) {
@@ -1715,9 +1714,7 @@ export class FormatPrinter extends Printer implements TextFlowDelegate, Attribut
       return result
     }
 
-    return result
-      .replace(/^[ \t\n\r]+/, leadingWhitespaceIsRendered ? ' ' : '')
-      .replace(/[ \t\n\r]+$/, trailingWhitespaceIsRendered ? ' ' : '')
+    return setEdgeWhitespace(result, leadingWhitespaceIsRendered, trailingWhitespaceIsRendered)
   }
 
   /**

--- a/javascript/packages/formatter/src/text-flow-engine.ts
+++ b/javascript/packages/formatter/src/text-flow-engine.ts
@@ -238,7 +238,15 @@ export class TextFlowEngine {
             }
           }
 
-          words.push(...trimmedText.split(' '))
+          const parts = trimmedText.split(' ')
+
+          for (let part = 1; part < parts.length; part++) {
+            if (isClosingPunctuation(parts[part]) && !parts[part - 1].endsWith(' ')) {
+              parts[part - 1] += ' '
+            }
+          }
+
+          words.push(...parts)
 
           if (hasTrailingSpace && words.length > 0) {
             const lastIndex = words.length - 1

--- a/javascript/packages/formatter/src/text-flow-helpers.ts
+++ b/javascript/packages/formatter/src/text-flow-helpers.ts
@@ -189,6 +189,45 @@ export function isGluedControlFlowNode(children: Node[], index: number): boolean
   return gluedBefore || gluedAfter
 }
 
+function endsInlineFlow(node: Node): boolean {
+  return isNode(node, HTMLElementNode) && !isInlineElement(getTagName(node))
+}
+
+export function hasFlowContentBefore(siblings: Node[], index: number): boolean {
+  for (let i = index - 1; i >= 0; i--) {
+    const sibling = siblings[i]
+
+    if (endsInlineFlow(sibling)) return false
+
+    const role = flowRole(sibling)
+
+    if (role === 'separator') return false
+
+    if (role === 'visible') {
+      return !(isNode(sibling, HTMLTextNode) && endsWithWhitespace(sibling.content))
+    }
+  }
+
+  return false
+}
+export function hasFlowContentAfter(siblings: Node[], index: number): boolean {
+  for (let i = index + 1; i < siblings.length; i++) {
+    const sibling = siblings[i]
+
+    if (endsInlineFlow(sibling)) return false
+
+    const role = flowRole(sibling)
+
+    if (role === 'separator') return false
+
+    if (role === 'visible') {
+      return !(isNode(sibling, HTMLTextNode) && /^[ \t\n\r]/.test(sibling.content))
+    }
+  }
+
+  return false
+}
+
 /**
  * Try to merge text that follows an atomic unit (ERB/inline) with no whitespace.
  * Merges the first word of the text into the preceding atomic unit.
@@ -216,7 +255,7 @@ export function tryMergeTextAfterAtomic(result: ContentUnitWithNode[], textNode:
   lastUnit.unit.content += firstWord
 
   if (words.length > 1) {
-    let remainingText = words.slice(1).join(' ')
+    let remainingText = ' ' + words.slice(1).join(' ')
 
     if (endsWithWhitespace(textNode.content)) {
       remainingText += ' '
@@ -254,7 +293,8 @@ export function tryMergeAtomicAfterText(result: ContentUnitWithNode[], children:
   result.pop()
 
   if (words.length > 1) {
-    const remainingText = words.slice(0, -1).join(' ')
+    const leading = /^[ \t\n\r]/.test(lastUnit.unit.content) ? ' ' : ''
+    const remainingText = leading + words.slice(0, -1).join(' ') + ' '
 
     result.push({
       unit: { content: remainingText, type: 'text', isAtomic: false, breaksFlow: false },

--- a/javascript/packages/formatter/src/text-flow-helpers.ts
+++ b/javascript/packages/formatter/src/text-flow-helpers.ts
@@ -8,6 +8,7 @@ import {
   hasWhitespaceBetween,
   isInlineElement,
   normalizeAndSplitWords,
+  startsWithWhitespace,
 } from "./format-helpers.js"
 
 /**
@@ -184,7 +185,7 @@ export function isGluedControlFlowNode(children: Node[], index: number): boolean
   const gluedAfter =
     next !== undefined &&
     flowRole(next) === 'visible' &&
-    !(isNode(next, HTMLTextNode) && /^[ \t\n\r]/.test(next.content))
+    !(isNode(next, HTMLTextNode) && startsWithWhitespace(next.content))
 
   return gluedBefore || gluedAfter
 }
@@ -221,7 +222,7 @@ export function hasFlowContentAfter(siblings: Node[], index: number): boolean {
     if (role === 'separator') return false
 
     if (role === 'visible') {
-      return !(isNode(sibling, HTMLTextNode) && /^[ \t\n\r]/.test(sibling.content))
+      return !(isNode(sibling, HTMLTextNode) && startsWithWhitespace(sibling.content))
     }
   }
 
@@ -293,7 +294,7 @@ export function tryMergeAtomicAfterText(result: ContentUnitWithNode[], children:
   result.pop()
 
   if (words.length > 1) {
-    const leading = /^[ \t\n\r]/.test(lastUnit.unit.content) ? ' ' : ''
+    const leading = startsWithWhitespace(lastUnit.unit.content) ? ' ' : ''
     const remainingText = leading + words.slice(0, -1).join(' ') + ' '
 
     result.push({
@@ -343,7 +344,7 @@ export function hasWhitespaceBeforeNode(children: Node[], lastProcessedIndex: nu
     return true
   }
 
-  if (isNode(currentNode, HTMLTextNode) && /^[ \t\n\r]/.test(currentNode.content)) {
+  if (isNode(currentNode, HTMLTextNode) && startsWithWhitespace(currentNode.content)) {
     return true
   }
 

--- a/javascript/packages/formatter/test/erb/whitespace-preservation.test.ts
+++ b/javascript/packages/formatter/test/erb/whitespace-preservation.test.ts
@@ -231,13 +231,82 @@ describe("whitespace preservation around ERB control flow", () => {
     })
   })
 
-  describe("known gaps", () => {
-    test.fails("inline container keeps a leading space before an inline child", () => {
+  describe("#1883 — whitespace at the edges of an inline element", () => {
+    test("keeps edge whitespace when the element has inline neighbours", () => {
+      expectFormattedToMatch(`<p>x<span> <em>y</em> </span>z</p>`)
+    })
+
+    test("keeps a leading space before an inline child", () => {
       expectFormattedToMatch(`<p>D<span> <em>x</em>'s dog</span>!</p>`)
     })
 
-    test.fails("inline container keeps a leading space before ERB control flow", () => {
+    test("keeps a leading space after an adjacent inline element", () => {
+      expectFormattedToMatch(`<div><a href="/x">one</a><span> <em>two</em></span></div>`)
+    })
+
+    test("keeps a leading space before ERB control flow", () => {
       expectFormattedToMatch(`<span>Hello<% if owner %> <%= owner.name %>'s dog<% end %>!</span>`)
+    })
+
+    test("inherits edge context through an inline ancestor", () => {
+      expectFormattedToMatch(`<p>x<em><span> y </span></em>z</p>`)
+    })
+
+    test("drops edge whitespace at a block boundary, where it would collapse anyway", () => {
+      expect(formatter.format(`<div><span> <em>x</em> </span></div>`)).toEqual(
+        `<div><span><em>x</em></span></div>`
+      )
+    })
+
+    test("drops a redundant inner space when the outside already separates", () => {
+      expect(formatter.format(`<p>text <span> <em>x</em></span></p>`)).toEqual(
+        `<p>text <span><em>x</em></span></p>`
+      )
+    })
+  })
+
+  describe("space-separated punctuation keeps its space", () => {
+    test("colon in a control-flow body", () => {
+      expect(formatter.format(`<p><% if x %>Label <%= a %> : value<% end %></p>`)).toEqual(dedent`
+        <p>
+          <% if x %>
+            Label <%= a %> : value
+          <% end %>
+        </p>
+      `)
+    })
+
+    test("ruby ternary survives intact", () => {
+      const source = dedent`
+        <% if x %>
+          <%= f %>: this.<%= f %> ? this.<%= f %>.toJSON() : null,
+        <% end %>
+      `
+
+      expectFormattedToMatch(source)
+    })
+
+    test("punctuation glued in the source stays glued", () => {
+      expect(formatter.format(`<p><% if x %>Label <%= a %>: value<% end %></p>`)).toEqual(dedent`
+        <p>
+          <% if x %>
+            Label <%= a %>: value
+          <% end %>
+        </p>
+      `)
+    })
+
+    test("punctuation separated from an inline element keeps the space", () => {
+      expect(formatter.format(dedent`
+        <div>
+          Check <em>this</em>
+          : it works!
+        </div>
+      `)).toEqual(dedent`
+        <div>
+          Check <em>this</em> : it works!
+        </div>
+      `)
     })
   })
 })

--- a/javascript/packages/formatter/test/erb/whitespace-preservation.test.ts
+++ b/javascript/packages/formatter/test/erb/whitespace-preservation.test.ts
@@ -50,77 +50,101 @@ describe("whitespace preservation around ERB control flow", () => {
     test("keeps glue when only the opening tag is glued", () => {
       const source = `<p>Hello<% if x %> a <% end %></p>`
 
-      expect(formatter.format(source)).toEqual(dedent`
+      const expected = dedent`
         <p>
           Hello<% if x %> a <% end %>
         </p>
-      `)
+      `
+
+      expect(formatter.format(source)).toEqual(expected)
+      expectFormattedToMatch(expected)
     })
 
     test("keeps glue when only the closing tag is glued", () => {
       const source = `<p><% if x %>a<% end %>!</p>`
 
-      expect(formatter.format(source)).toEqual(dedent`
+      const expected = dedent`
         <p>
           <% if x %>a<% end %>!
         </p>
-      `)
+      `
+
+      expect(formatter.format(source)).toEqual(expected)
+      expectFormattedToMatch(expected)
     })
 
     test("keeps glue on both sides with no inner whitespace", () => {
       const source = `<p>E<% if x %>xy<% end %>!</p>`
 
-      expect(formatter.format(source)).toEqual(dedent`
+      const expected = dedent`
         <p>
           E<% if x %>xy<% end %>!
         </p>
-      `)
+      `
+
+      expect(formatter.format(source)).toEqual(expected)
+      expectFormattedToMatch(expected)
     })
 
     test("overflowing glued content stays on one line rather than breaking", () => {
       const source = `<p>Hello<% if owner %> <%= owner.name %>'s extremely long dog name here that overflows<% end %>!</p>`
 
-      expect(formatter.format(source)).toEqual(dedent`
+      const expected = dedent`
         <p>
           Hello<% if owner %> <%= owner.name %>'s extremely long dog name here that overflows<% end %>!
         </p>
-      `)
+      `
+
+      expect(formatter.format(source)).toEqual(expected)
+      expectFormattedToMatch(expected)
     })
   })
 
   describe("control-flow keywords other than if", () => {
     test("unless", () => {
-      expect(formatter.format(`<p>A<% unless x %>b<% end %>!</p>`)).toEqual(dedent`
+      const expected = dedent`
         <p>
           A<% unless x %>b<% end %>!
         </p>
-      `)
+      `
+
+      expect(formatter.format(`<p>A<% unless x %>b<% end %>!</p>`)).toEqual(expected)
+      expectFormattedToMatch(expected)
     })
 
     test("case/when", () => {
-      expect(formatter.format(`<p>A<% case x %><% when 1 %>one<% end %>!</p>`)).toEqual(dedent`
+      const expected = dedent`
         <p>
           A<% case x %><% when 1 %>one<% end %>!
         </p>
-      `)
+      `
+
+      expect(formatter.format(`<p>A<% case x %><% when 1 %>one<% end %>!</p>`)).toEqual(expected)
+      expectFormattedToMatch(expected)
     })
 
     test("nested control flow", () => {
-      expect(formatter.format(`<p>A<% if x %><% if y %>b<% end %><% end %>!</p>`)).toEqual(dedent`
+      const expected = dedent`
         <p>
           A<% if x %><% if y %>b<% end %><% end %>!
         </p>
-      `)
+      `
+
+      expect(formatter.format(`<p>A<% if x %><% if y %>b<% end %><% end %>!</p>`)).toEqual(expected)
+      expectFormattedToMatch(expected)
     })
 
     test("while loop keeps a glued trailing statement attached", () => {
       const source = `<% while i < 3 %><b><%= i %></b><% i += 1 %><% end %>`
 
-      expect(formatter.format(source)).toEqual(dedent`
+      const expected = dedent`
         <% while i < 3 %>
           <b><%= i %></b><% i += 1 %>
         <% end %>
-      `)
+      `
+
+      expect(formatter.format(source)).toEqual(expected)
+      expectFormattedToMatch(expected)
     })
   })
 
@@ -128,7 +152,7 @@ describe("whitespace preservation around ERB control flow", () => {
     test("spaces on both sides means breaking is safe", () => {
       const source = `<p>Hello <% if x %>a<% end %> there</p>`
 
-      expect(formatter.format(source)).toEqual(dedent`
+      const expected = dedent`
         <p>
           Hello
           <% if x %>
@@ -136,7 +160,10 @@ describe("whitespace preservation around ERB control flow", () => {
           <% end %>
           there
         </p>
-      `)
+      `
+
+      expect(formatter.format(source)).toEqual(expected)
+      expectFormattedToMatch(expected)
     })
 
     test("free-standing control flow keeps its block layout", () => {
@@ -154,7 +181,7 @@ describe("whitespace preservation around ERB control flow", () => {
     test("block element inside glued control flow", () => {
       const source = `<p>A<% if x %><div>b</div><% end %>!</p>`
 
-      expect(formatter.format(source)).toEqual(dedent`
+      const expected = dedent`
         <p>
           A
           <% if x %>
@@ -162,7 +189,10 @@ describe("whitespace preservation around ERB control flow", () => {
           <% end %>
           !
         </p>
-      `)
+      `
+
+      expect(formatter.format(source)).toEqual(expected)
+      expectFormattedToMatch(expected)
     })
   })
 
@@ -205,7 +235,10 @@ describe("whitespace preservation around ERB control flow", () => {
         </span></div>
       `
 
-      expect(formatter.format(source)).toEqual(`<div><span><em>a</em> <em>b</em></span></div>`)
+      const expected = `<div><span><em>a</em> <em>b</em></span></div>`
+
+      expect(formatter.format(source)).toEqual(expected)
+      expectFormattedToMatch(expected)
     })
 
     test("keeps the space between two ERB outputs", () => {
@@ -216,7 +249,10 @@ describe("whitespace preservation around ERB control flow", () => {
         </label></div>
       `
 
-      expect(formatter.format(source)).toEqual(`<div><label><%= a %> <%= b %></label></div>`)
+      const expected = `<div><label><%= a %> <%= b %></label></div>`
+
+      expect(formatter.format(source)).toEqual(expected)
+      expectFormattedToMatch(expected)
     })
 
     test("keeps the space between text and an inline element", () => {
@@ -227,7 +263,10 @@ describe("whitespace preservation around ERB control flow", () => {
         </span></div>
       `
 
-      expect(formatter.format(source)).toEqual(`<div><span>text <em>x</em></span></div>`)
+      const expected = `<div><span>text <em>x</em></span></div>`
+
+      expect(formatter.format(source)).toEqual(expected)
+      expectFormattedToMatch(expected)
     })
   })
 
@@ -253,27 +292,45 @@ describe("whitespace preservation around ERB control flow", () => {
     })
 
     test("drops edge whitespace at a block boundary, where it would collapse anyway", () => {
-      expect(formatter.format(`<div><span> <em>x</em> </span></div>`)).toEqual(
-        `<div><span><em>x</em></span></div>`
-      )
+      const expected = `<div><span><em>x</em></span></div>`
+
+      expect(formatter.format(`<div><span> <em>x</em> </span></div>`)).toEqual(expected)
+      expectFormattedToMatch(expected)
     })
 
     test("drops a redundant inner space when the outside already separates", () => {
-      expect(formatter.format(`<p>text <span> <em>x</em></span></p>`)).toEqual(
-        `<p>text <span><em>x</em></span></p>`
-      )
+      const expected = `<p>text <span><em>x</em></span></p>`
+
+      expect(formatter.format(`<p>text <span> <em>x</em></span></p>`)).toEqual(expected)
+      expectFormattedToMatch(expected)
     })
   })
 
   describe("space-separated punctuation keeps its space", () => {
     test("colon in a control-flow body", () => {
-      expect(formatter.format(`<p><% if x %>Label <%= a %> : value<% end %></p>`)).toEqual(dedent`
+      const expected = dedent`
         <p>
           <% if x %>
             Label <%= a %> : value
           <% end %>
         </p>
-      `)
+      `
+
+      expect(formatter.format(`<p><% if x %>Label <%= a %> : value<% end %></p>`)).toEqual(expected)
+      expectFormattedToMatch(expected)
+    })
+
+    test("question mark in a control-flow body", () => {
+      const expected = dedent`
+        <p>
+          <% if x %>
+            Ready <%= a %> ? yes
+          <% end %>
+        </p>
+      `
+
+      expect(formatter.format(`<p><% if x %>Ready <%= a %> ? yes<% end %></p>`)).toEqual(expected)
+      expectFormattedToMatch(expected)
     })
 
     test("ruby ternary survives intact", () => {
@@ -287,26 +344,17 @@ describe("whitespace preservation around ERB control flow", () => {
     })
 
     test("punctuation glued in the source stays glued", () => {
-      expect(formatter.format(`<p><% if x %>Label <%= a %>: value<% end %></p>`)).toEqual(dedent`
+      const expected = dedent`
         <p>
           <% if x %>
             Label <%= a %>: value
           <% end %>
         </p>
-      `)
+      `
+
+      expect(formatter.format(`<p><% if x %>Label <%= a %>: value<% end %></p>`)).toEqual(expected)
+      expectFormattedToMatch(expected)
     })
 
-    test("punctuation separated from an inline element keeps the space", () => {
-      expect(formatter.format(dedent`
-        <div>
-          Check <em>this</em>
-          : it works!
-        </div>
-      `)).toEqual(dedent`
-        <div>
-          Check <em>this</em> : it works!
-        </div>
-      `)
-    })
   })
 })

--- a/javascript/packages/formatter/test/html/text-content.test.ts
+++ b/javascript/packages/formatter/test/html/text-content.test.ts
@@ -289,11 +289,14 @@ describe("@herb-tools/formatter", () => {
       </div>
     `)
 
-    expect(result).toEqual(dedent`
+    const expected = dedent`
       <div>
         Check <em>this</em> : it works!
       </div>
-    `)
+    `
+
+    expect(result).toEqual(expected)
+    expectFormattedToMatch(expected)
   })
 
   test("punctuation glued to an inline element stays glued", () => {

--- a/javascript/packages/formatter/test/html/text-content.test.ts
+++ b/javascript/packages/formatter/test/html/text-content.test.ts
@@ -291,8 +291,18 @@ describe("@herb-tools/formatter", () => {
 
     expect(result).toEqual(dedent`
       <div>
-        Check <em>this</em>: it works!
+        Check <em>this</em> : it works!
       </div>
+    `)
+  })
+
+  test("punctuation glued to an inline element stays glued", () => {
+    const result = formatter.format(dedent`
+      <div>Check <em>this</em>: it works!</div>
+    `)
+
+    expect(result).toEqual(dedent`
+      <div>Check <em>this</em>: it works!</div>
     `)
   })
 

--- a/javascript/packages/formatter/test/text-flow-helpers.test.ts
+++ b/javascript/packages/formatter/test/text-flow-helpers.test.ts
@@ -195,7 +195,7 @@ describe("text-flow-helpers", () => {
       expect(merged).toBe(true)
       expect(result[0].unit.content).toBe('<%= tag %>text')
       expect(result.length).toBe(2)
-      expect(result[1].unit.content).toBe('more')
+      expect(result[1].unit.content).toBe(' more')
     })
 
     test("still merges when raw content has leading space (normalizeAndSplitWords trims)", () => {
@@ -254,7 +254,7 @@ describe("text-flow-helpers", () => {
 
       expect(merged).toBe(true)
       expect(result.length).toBe(2)
-      expect(result[0].unit.content).toBe('hello')
+      expect(result[0].unit.content).toBe('hello ')
       expect(result[0].unit.type).toBe('text')
       expect(result[1].unit.content).toBe('world<%= tag %>')
       expect(result[1].unit.type).toBe('erb')


### PR DESCRIPTION
Follow up on #1863.

This pull request fixes the two remaining ways the formatter could change rendered whitespace: at the edges of an inline element, and around punctuation that had a space in front of it.

#### Whitespace at the edges of an inline element

Whitespace just inside an inline element is rendered whenever that element has inline neighbours, so dropping it changes the output:

```erb
<p>x<span> <em>y</em> </span>z</p>
```

formatted to 
```erb
<p>x<span><em>y</em></span>z</p>
``` 

turning `x y z` into `xyz`. 

The same happened with 
```erb
<div><a href="/x">one</a><span> <em>two</em></span></div>`
```

`one two` → `onetwo`

It is only safe to drop that whitespace when it would collapse anyway, which is the case at a block boundary:

```erb
<div><span> <em>x</em> </span></div>
```

Here `<span><em>x</em></span>` is correct, and it is what #1883 asks for.

#### Space-separated punctuation

`:` and `?` are glued to whatever precedes them, which is right for `<%= name %>:` in prose but not when the source had a space:

```erb
<p><% if x %>Label <%= a %> : value<% end %></p>
```

formatted to `Label <%= a %>: value`, changing `Label X : value` into `Label X: value`. 

Resolves #1883.
