### PR TITLE
Core: Fix `PrismVisitor` skipping node list fields

### DIFF
--- a/javascript/packages/core/src/prism/index.ts
+++ b/javascript/packages/core/src/prism/index.ts
@@ -8,7 +8,7 @@ import type * as PrismNodeTypes from "@ruby/prism/src/nodes.js"
 
 export * as PrismNodes from "@ruby/prism/src/nodes.js"
 
-export { Visitor as PrismVisitor, BasicVisitor as PrismBasicVisitor } from "@ruby/prism/src/visitor.js"
+export { PrismVisitor, PrismBasicVisitor } from "./visitor.js"
 
 export type PrismNode = any
 export type PrismLocation = { startOffset: number; length: number }

--- a/javascript/packages/core/src/prism/visitor.ts
+++ b/javascript/packages/core/src/prism/visitor.ts
@@ -1,0 +1,33 @@
+import { Visitor, BasicVisitor } from "@ruby/prism/src/visitor.js"
+
+import type * as PrismNodes from "@ruby/prism/src/nodes.js"
+
+/**
+ * Workaround for https://github.com/ruby/prism/pull/4187.
+ *
+ * `@ruby/prism` generates `compactChildNodes()` with `compact.concat(this.field)`
+ * and discards the result, so every node list field is dropped from the
+ * traversal, `when`/`in` branch conditions, multiple assignment targets,
+ * `rescue` exceptions, method parameters and the pattern matching nodes.
+ *
+ * Walks `childNodes()` instead, which spreads those arrays correctly. Switching
+ * back to `compactChildNodes()` reintroduces the bug silently. Remove this once
+ * the fix ships upstream.
+ */
+function acceptChildNodes(visitor: BasicVisitor, node: PrismNodes.Node): void {
+  for (const childNode of node.childNodes()) {
+    childNode?.accept(visitor as Visitor)
+  }
+}
+
+export class PrismVisitor extends Visitor {
+  visitChildNodes(node: PrismNodes.Node): void {
+    acceptChildNodes(this, node)
+  }
+}
+
+export class PrismBasicVisitor extends BasicVisitor {
+  visitChildNodes(node: PrismNodes.Node): void {
+    acceptChildNodes(this, node)
+  }
+}

--- a/javascript/packages/core/test/prism-visitor.test.ts
+++ b/javascript/packages/core/test/prism-visitor.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeAll } from "vitest"
+import { loadPrism } from "@ruby/prism"
+
+import { PrismVisitor } from "../src/prism/index.js"
+
+import type { PrismNodes, PrismParseResult } from "../src/prism/index.js"
+
+let parse: (source: string) => PrismParseResult
+
+class CollectingVisitor extends PrismVisitor {
+  public names: string[] = []
+
+  visitInstanceVariableReadNode(node: PrismNodes.InstanceVariableReadNode): void {
+    this.names.push(node.name)
+  }
+
+  visitInstanceVariableTargetNode(node: PrismNodes.InstanceVariableTargetNode): void {
+    this.names.push(node.name)
+  }
+
+  visitInstanceVariableWriteNode(node: PrismNodes.InstanceVariableWriteNode): void {
+    this.names.push(node.name)
+
+    super.visitInstanceVariableWriteNode(node)
+  }
+}
+
+const collect = (source: string): string[] => {
+  const visitor = new CollectingVisitor()
+
+  visitor.visit(parse(source).value)
+
+  return visitor.names
+}
+
+describe("PrismVisitor", () => {
+  beforeAll(async () => {
+    parse = await loadPrism()
+  })
+
+  it("visits nodes nested in plain statements", () => {
+    expect(collect("if a\n  @foo\nend")).toEqual(["@foo"])
+  })
+
+  describe("array-valued children dropped by @ruby/prism's compactChildNodes()", () => {
+    it("visits the conditions and bodies of a case/when", () => {
+      expect(collect("case a\nwhen 1\n  @foo\nend")).toEqual(["@foo"])
+    })
+
+    it("visits the conditions and bodies of a case/in", () => {
+      expect(collect("case [a, b]\nin [1, true]\n  @foo\nend")).toEqual(["@foo"])
+    })
+
+    it("visits the targets of a multiple assignment", () => {
+      expect(collect("@foo, @bar = 1, 2")).toEqual(["@foo", "@bar"])
+    })
+
+    it("visits the exceptions of a rescue clause", () => {
+      expect(collect("begin\n  call\nrescue StandardError\n  @foo\nend")).toEqual(["@foo"])
+    })
+
+    it("visits the parameters of a method definition", () => {
+      expect(collect("def call(a = @foo)\nend")).toEqual(["@foo"])
+    })
+
+    it("visits the elements of an array pattern", () => {
+      expect(collect("case a\nin [Integer => @foo]\n  nil\nend")).toEqual(["@foo"])
+    })
+  })
+})

--- a/javascript/packages/linter/test/rules/erb-no-instance-variables-in-partials.test.ts
+++ b/javascript/packages/linter/test/rules/erb-no-instance-variables-in-partials.test.ts
@@ -128,4 +128,37 @@ describe("ERBNoInstanceVariablesInPartialsRule", () => {
       <% end %>
     `, { fileName: "_toggle.html.erb" })
   })
+
+  describe("control flow @ruby/prism drops from traversal", () => {
+    test("reports instance variables inside a case/when branch", () => {
+      expectError("Avoid using instance variables in partials. Pass `@user` as a local variable instead.")
+
+      assertOffenses(dedent`
+        <% case kind %>
+        <% when :admin %>
+          <%= @user %>
+        <% end %>
+      `, { fileName: "_card.html.erb" })
+    })
+
+    test("reports instance variables inside a case/in branch", () => {
+      expectError("Avoid using instance variables in partials. Pass `@user` as a local variable instead.")
+
+      assertOffenses(dedent`
+        <% case [kind, active] %>
+        <% in [:admin, true] %>
+          <%= @user %>
+        <% end %>
+      `, { fileName: "_card.html.erb" })
+    })
+
+    test("reports instance variables assigned by a multiple assignment", () => {
+      expectError("Avoid setting instance variables in partials. Use a local variable instead of `@first`.")
+      expectError("Avoid setting instance variables in partials. Use a local variable instead of `@second`.")
+
+      assertOffenses(dedent`
+        <% @first, @second = 1, 2 %>
+      `, { fileName: "_card.html.erb" })
+    })
+  })
 })


### PR DESCRIPTION
`@ruby/prism` generates `compactChildNodes()` with `compact.concat(this.field)` and discards the result, so node list fields are dropped from the traversal. Visitors never descended into `when`/`in` branch conditions, multiple assignment targets, `rescue` exceptions or method parameters.

This pull request overrides the Prism visitors and walks `childNodes()` instead, which spreads those arrays correctly. 

This fixes false negatives in `erb-no-instance-variables-in-partials`, `erb-no-debug-output` and `erb-no-unused-literals`.

Upstream fix: https://github.com/ruby/prism/pull/4187