### PR TITLE
Linter: Fix missing `code` on `erb-no-trailing-whitespace` offenses

### DIFF
--- a/javascript/packages/linter/src/rules/erb-no-trailing-whitespace.ts
+++ b/javascript/packages/linter/src/rules/erb-no-trailing-whitespace.ts
@@ -91,12 +91,7 @@ export class ERBNoTrailingWhitespaceRule extends ParserRule<ERBNoTrailingWhitesp
         const location = Location.from(candidate.line, candidate.column, candidate.line, candidate.column + candidate.length)
         const node = findNodeAtPosition(result.value, candidate.line, candidate.column, (n) => isHTMLTextNode(n) || isLiteralNode(n)) as HTMLTextNode | LiteralNode | null
 
-        offenses.push({
-          rule: this.ruleName,
-          message: "Extra whitespace detected at end of line.",
-          location,
-          autofixContext: node ? { node } : undefined
-        })
+        offenses.push(this.createOffense("Extra whitespace detected at end of line.", location, node ? { node } : undefined))
       }
     }
 

--- a/javascript/packages/linter/test/rules/erb-no-trailing-whitespace.test.ts
+++ b/javascript/packages/linter/test/rules/erb-no-trailing-whitespace.test.ts
@@ -1,6 +1,9 @@
 import dedent from "dedent"
-import { describe, test } from "vitest"
+import { describe, test, expect } from "vitest"
 
+import { Herb } from "@herb-tools/node-wasm"
+
+import { Linter } from "../../src/linter.js"
 import { createLinterTest } from "../helpers/linter-test-helper.js"
 import { ERBNoTrailingWhitespaceRule } from "../../src/rules/erb-no-trailing-whitespace.js"
 
@@ -313,6 +316,20 @@ describe("erb-no-trailing-whitespace", () => {
       expectError("Extra whitespace detected at end of line.", [2, 8])
 
       assertOffenses("<!--  \n comment  \n -->")
+    })
+  })
+
+  describe("offense metadata", () => {
+    test("populates code and source like every other rule", async () => {
+      await Herb.load()
+
+      const linter = new Linter(Herb, [ERBNoTrailingWhitespaceRule])
+      const { offenses } = linter.lint("<div> \n</div>\n", { fileName: "index.html.erb" })
+
+      expect(offenses).toHaveLength(1)
+      expect(offenses[0].rule).toBe("erb-no-trailing-whitespace")
+      expect(offenses[0].code).toBe("erb-no-trailing-whitespace")
+      expect(offenses[0].source).toBe("Herb Linter")
     })
   })
 })


### PR DESCRIPTION
The rule pushed an object literal instead of calling `createOffense`, so `code` and `source` were never set. The simple formatter prints `offense.code`, so every offense from this rule rendered as `(undefined)` 

**Before**
```
$ herb-lint app --simple
  2:19 ✗ Extra whitespace detected at end of line. (undefined) 
```

**After**
```
$ herb-lint app --simple
  2:19 ✗ Extra whitespace detected at end of line. (erb-no-trailing-whitespace)
```