### PR TITLE
Linter CLI: Fix `--json` output when linting is parallelized

### DIFF
--- a/javascript/packages/linter/src/cli/file-processor.ts
+++ b/javascript/packages/linter/src/cli/file-processor.ts
@@ -10,6 +10,7 @@ import { resolve, dirname, join } from "node:path"
 import { fileURLToPath } from "node:url"
 import { availableParallelism } from "node:os"
 import { colorize } from "@herb-tools/highlighter"
+import { Location } from "@herb-tools/core"
 
 import type { Diagnostic } from "@herb-tools/core"
 import type { FormatOption } from "./argument-parser.js"
@@ -363,7 +364,7 @@ export class FileProcessor {
       for (const offense of result.offenses) {
         allOffenses.push({
           filename: offense.filename,
-          offense: offense.offense,
+          offense: { ...offense.offense, location: Location.from(offense.offense.location) },
           content: offense.content,
           autocorrectable: offense.autocorrectable
         })

--- a/javascript/packages/linter/test/cli.test.ts
+++ b/javascript/packages/linter/test/cli.test.ts
@@ -893,4 +893,26 @@ describe("CLI Output Formatting", () => {
       }
     })
   })
+
+  describe("parallel linting", () => {
+    test("emits JSON when the run is split across workers", () => {
+      const { output, exitCode } = runLinter("parallel", "--jobs", "4", "--json")
+      const result = JSON.parse(output)
+
+      expect(result.completed).toBe(true)
+      expect(result.message).toBeNull()
+      expect(result.offenses).toHaveLength(12)
+      expect(result.offenses[0].location.start).toEqual({ line: 2, column: 3 })
+      expect(exitCode).toBe(0)
+    })
+
+    test("produces the same JSON with and without workers", () => {
+      const parallel = JSON.parse(runLinter("parallel", "--jobs", "4", "--json").output)
+      const serial = JSON.parse(runLinter("parallel", "--jobs", "1", "--json").output)
+
+      const normalize = (result: any) => result.offenses.map((offense: any) => ({ ...offense, filename: offense.filename })).sort((a: any, b: any) => a.filename.localeCompare(b.filename))
+
+      expect(normalize(parallel)).toEqual(normalize(serial))
+    })
+  })
 })

--- a/javascript/packages/linter/test/fixtures/parallel/file-1.html.erb
+++ b/javascript/packages/linter/test/fixtures/parallel/file-1.html.erb
@@ -1,0 +1,3 @@
+<div>
+  <img src="a.png">
+</div>

--- a/javascript/packages/linter/test/fixtures/parallel/file-10.html.erb
+++ b/javascript/packages/linter/test/fixtures/parallel/file-10.html.erb
@@ -1,0 +1,3 @@
+<div>
+  <img src="a.png">
+</div>

--- a/javascript/packages/linter/test/fixtures/parallel/file-11.html.erb
+++ b/javascript/packages/linter/test/fixtures/parallel/file-11.html.erb
@@ -1,0 +1,3 @@
+<div>
+  <img src="a.png">
+</div>

--- a/javascript/packages/linter/test/fixtures/parallel/file-12.html.erb
+++ b/javascript/packages/linter/test/fixtures/parallel/file-12.html.erb
@@ -1,0 +1,3 @@
+<div>
+  <img src="a.png">
+</div>

--- a/javascript/packages/linter/test/fixtures/parallel/file-2.html.erb
+++ b/javascript/packages/linter/test/fixtures/parallel/file-2.html.erb
@@ -1,0 +1,3 @@
+<div>
+  <img src="a.png">
+</div>

--- a/javascript/packages/linter/test/fixtures/parallel/file-3.html.erb
+++ b/javascript/packages/linter/test/fixtures/parallel/file-3.html.erb
@@ -1,0 +1,3 @@
+<div>
+  <img src="a.png">
+</div>

--- a/javascript/packages/linter/test/fixtures/parallel/file-4.html.erb
+++ b/javascript/packages/linter/test/fixtures/parallel/file-4.html.erb
@@ -1,0 +1,3 @@
+<div>
+  <img src="a.png">
+</div>

--- a/javascript/packages/linter/test/fixtures/parallel/file-5.html.erb
+++ b/javascript/packages/linter/test/fixtures/parallel/file-5.html.erb
@@ -1,0 +1,3 @@
+<div>
+  <img src="a.png">
+</div>

--- a/javascript/packages/linter/test/fixtures/parallel/file-6.html.erb
+++ b/javascript/packages/linter/test/fixtures/parallel/file-6.html.erb
@@ -1,0 +1,3 @@
+<div>
+  <img src="a.png">
+</div>

--- a/javascript/packages/linter/test/fixtures/parallel/file-7.html.erb
+++ b/javascript/packages/linter/test/fixtures/parallel/file-7.html.erb
@@ -1,0 +1,3 @@
+<div>
+  <img src="a.png">
+</div>

--- a/javascript/packages/linter/test/fixtures/parallel/file-8.html.erb
+++ b/javascript/packages/linter/test/fixtures/parallel/file-8.html.erb
@@ -1,0 +1,3 @@
+<div>
+  <img src="a.png">
+</div>

--- a/javascript/packages/linter/test/fixtures/parallel/file-9.html.erb
+++ b/javascript/packages/linter/test/fixtures/parallel/file-9.html.erb
@@ -1,0 +1,3 @@
+<div>
+  <img src="a.png">
+</div>


### PR DESCRIPTION
Offenses cross the worker boundary as structured clones, which keep the data but drop the prototypes, so `location` arrives as a plain object. The JSON formatter calls `location.toJSON()` and throws.

`$ herb-lint . --json --jobs 4`:
```
{ "offenses": [], "completed": false,
  "message": "Error: TypeError: offense.location.toJSON is not a function" }
```

Workers kick in at 10+ files with `--jobs > 1`, which is most real projects, so `--json` was effectively unusable there. `aggregateWorkerResults` now rebuilds the location with `Location.from()`.

Resolves https://github.com/marcoroth/herb/issues/1759