### PR TITLE
Core: Add `deserializeDiagnostic` and type worker offenses as serialized

### DIFF
--- a/javascript/packages/core/src/diagnostic.ts
+++ b/javascript/packages/core/src/diagnostic.ts
@@ -52,6 +52,16 @@ export interface SerializedDiagnostic {
   tags?: DiagnosticTag[]
 }
 
+/**
+ * Rebuilds a `Diagnostic` from its serialized form.
+ *
+ * @param diagnostic - The serialized diagnostic to rebuild
+ * @returns The diagnostic with its `Location` restored
+ */
+export function deserializeDiagnostic(diagnostic: SerializedDiagnostic): Diagnostic {
+  return { ...diagnostic, location: Location.from(diagnostic.location) }
+}
+
 export type MonacoSeverity = "error" | "warning" | "info"
 
 /**

--- a/javascript/packages/core/test/diagnostic.test.ts
+++ b/javascript/packages/core/test/diagnostic.test.ts
@@ -1,0 +1,48 @@
+import { describe, test, expect } from "vitest"
+
+import { Location, deserializeDiagnostic } from "../src/index.js"
+
+import type { SerializedDiagnostic } from "../src/index.js"
+
+const serialized: SerializedDiagnostic = {
+  message: "Extra whitespace detected at end of line.",
+  location: { start: { line: 2, column: 19 }, end: { line: 2, column: 20 } },
+  severity: "error",
+  code: "erb-no-trailing-whitespace",
+  source: "Herb Linter"
+}
+
+describe("deserializeDiagnostic", () => {
+  test("restores the Location instance", () => {
+    const diagnostic = deserializeDiagnostic(serialized)
+
+    expect(diagnostic.location).toBeInstanceOf(Location)
+    expect(typeof diagnostic.location.toJSON).toBe("function")
+  })
+
+  test("preserves the location values", () => {
+    const { location } = deserializeDiagnostic(serialized)
+
+    expect(location.start.line).toBe(2)
+    expect(location.start.column).toBe(19)
+    expect(location.end.line).toBe(2)
+    expect(location.end.column).toBe(20)
+  })
+
+  test("preserves the remaining fields", () => {
+    const diagnostic = deserializeDiagnostic(serialized)
+
+    expect(diagnostic.message).toBe(serialized.message)
+    expect(diagnostic.severity).toBe("error")
+    expect(diagnostic.code).toBe("erb-no-trailing-whitespace")
+    expect(diagnostic.source).toBe("Herb Linter")
+  })
+
+  test("round-trips a structured clone, as it crosses a worker boundary", () => {
+    const clone = structuredClone(serialized) as SerializedDiagnostic
+    const diagnostic = deserializeDiagnostic(clone)
+
+    expect(diagnostic.location).toBeInstanceOf(Location)
+    expect(JSON.stringify(diagnostic.location)).toBe(JSON.stringify(Location.from(serialized.location)))
+  })
+})

--- a/javascript/packages/linter/src/cli/file-processor.ts
+++ b/javascript/packages/linter/src/cli/file-processor.ts
@@ -10,7 +10,7 @@ import { resolve, dirname, join } from "node:path"
 import { fileURLToPath } from "node:url"
 import { availableParallelism } from "node:os"
 import { colorize } from "@herb-tools/highlighter"
-import { Location } from "@herb-tools/core"
+import { deserializeDiagnostic } from "@herb-tools/core"
 
 import type { Diagnostic } from "@herb-tools/core"
 import type { FormatOption } from "./argument-parser.js"
@@ -364,7 +364,7 @@ export class FileProcessor {
       for (const offense of result.offenses) {
         allOffenses.push({
           filename: offense.filename,
-          offense: { ...offense.offense, location: Location.from(offense.offense.location) },
+          offense: deserializeDiagnostic(offense.offense),
           content: offense.content,
           autocorrectable: offense.autocorrectable
         })

--- a/javascript/packages/linter/src/cli/lint-worker.ts
+++ b/javascript/packages/linter/src/cli/lint-worker.ts
@@ -5,9 +5,10 @@ import { resolve } from "node:path"
 import { Herb } from "@herb-tools/node-wasm"
 import { Config } from "@herb-tools/config"
 
-import { Diagnostic } from "@herb-tools/core"
 import { Linter } from "../linter.js"
 import { loadCustomRules } from "../loader.js"
+
+import type { SerializedDiagnostic } from "@herb-tools/core"
 
 export interface WorkerInput {
   files: string[]
@@ -21,7 +22,7 @@ export interface WorkerInput {
 
 export interface WorkerOffense {
   filename: string
-  offense: Diagnostic
+  offense: SerializedDiagnostic
   content: string
   autocorrectable: boolean
 }


### PR DESCRIPTION
`WorkerOffense.offense` was typed `Diagnostic`, but structured cloning drops prototypes, so `location` arrives as plain data. The type promised a `Location` instance that wasn't there, which is how the `--json` crash in #1887 got past the compiler.

This pull request types the worker payload as `SerializedDiagnostic` and adds the matching deserializer to core, so dropping the conversion is now a build error rather than a runtime failure in `--json` only.