### PR TITLE
Linter: Fix `erb-no-silent-statement` flagging control-flow keywords

### DIFF
--- a/javascript/packages/linter/docs/rules/erb-no-silent-statement.md
+++ b/javascript/packages/linter/docs/rules/erb-no-silent-statement.md
@@ -6,6 +6,8 @@
 
 Disallow silent ERB tags (`<% %>`) that execute statements whose return value is discarded. Logic like method calls should live in controllers, helpers, or presenters, not in views. Assignments are allowed since they are pragmatic for DRYing up templates.
 
+Control-flow keywords (`next`, `break`, `redo`, `return`, `raise`, and their `if`/`unless` modifier forms) are allowed since they have no return value to discard and cannot be moved out of the template. View-to-layout helpers (`content_for`, `provide`, and other designated side-effect helpers) are also allowed, matching [`erb-no-unused-expressions`](./erb-no-unused-expressions.md).
+
 ## Rationale
 
 Silent ERB tags that aren't control flow or assignments are a code smell. They execute Ruby code whose return value is silently discarded, which usually means the logic belongs in a controller, helper, or presenter rather than the view.
@@ -36,6 +38,19 @@ Silent ERB tags that aren't control flow or assignments are a code smell. They e
 <% users.each do |user| %>
   <p><%= user.name %></p>
 <% end %>
+```
+
+```erb
+<% users.each do |user| %>
+  <% next if user.hidden? %>
+  <% break if reached_limit? %>
+  <p><%= user.name %></p>
+<% end %>
+```
+
+```erb
+<% content_for(:title, "Dashboard") %>
+<% provide(:sidebar, render("sidebar")) %>
 ```
 
 ### 🚫 Bad

--- a/javascript/packages/linter/src/rules/erb-no-silent-statement.ts
+++ b/javascript/packages/linter/src/rules/erb-no-silent-statement.ts
@@ -1,5 +1,5 @@
 import { BaseRuleVisitor } from "./rule-utils.js"
-import { isAssignmentNode } from "./prism-rule-utils.js"
+import { isAssignmentNode, isControlFlowNode, isSideEffectCall, unwrapModifierStatement } from "./prism-rule-utils.js"
 import { ParserRule } from "../types.js"
 
 import { isERBOutputNode } from "@herb-tools/core"
@@ -15,6 +15,11 @@ class ERBNoSilentStatementVisitor extends BaseRuleVisitor {
     if (!prismNode) return
 
     if (isAssignmentNode(prismNode)) return
+
+    const statement = unwrapModifierStatement(prismNode)
+
+    if (isControlFlowNode(statement)) return
+    if (isSideEffectCall(statement)) return
 
     const content = node.content?.value?.trim()
     if (!content) return

--- a/javascript/packages/linter/src/rules/erb-no-unused-expressions.ts
+++ b/javascript/packages/linter/src/rules/erb-no-unused-expressions.ts
@@ -3,7 +3,7 @@ import { PrismVisitor, substringFromByteOffset , locationFromByteOffset } from "
 import { BaseRuleVisitor } from "./rule-utils.js"
 
 import { isERBOutputNode, isRubyParameterNode, isPrismNodeType } from "@herb-tools/core"
-import { isAssignmentNode, isDebugOutputCall, isCallOnLocal } from "./prism-rule-utils.js"
+import { isAssignmentNode, isDebugOutputCall, isCallOnLocal, SIDE_EFFECT_METHODS } from "./prism-rule-utils.js"
 
 import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types.js"
 import type { ParseResult, ERBContentNode, ERBRenderNode, ParserOptions, PrismNode } from "@herb-tools/core"
@@ -23,16 +23,6 @@ const MUTATION_METHODS = new Set([
   "insert",
   "concat",
   "assert_valid_keys",
-])
-
-const SIDE_EFFECT_METHODS = new Set([
-  "content_for",
-  "provide",
-  "flush",
-  "turbo_refreshes_with",
-  "turbo_exempts_page_from_cache",
-  "turbo_exempts_page_from_preview",
-  "turbo_page_requires_reload",
 ])
 
 class UnusedExpressionCollector extends PrismVisitor {

--- a/javascript/packages/linter/src/rules/prism-rule-utils.ts
+++ b/javascript/packages/linter/src/rules/prism-rule-utils.ts
@@ -4,6 +4,56 @@ import type { PrismNode } from "@herb-tools/core"
 export const DEBUG_OUTPUT_METHODS = new Set(["p", "pp", "puts", "print", "warn", "debug", "byebug"])
 export const BINDING_DEBUGGER_METHODS = new Set(["pry", "irb"])
 
+export const SIDE_EFFECT_METHODS = new Set([
+  "content_for",
+  "provide",
+  "flush",
+  "turbo_refreshes_with",
+  "turbo_exempts_page_from_cache",
+  "turbo_exempts_page_from_preview",
+  "turbo_page_requires_reload",
+])
+
+export const CONTROL_FLOW_METHODS = new Set(["raise", "throw", "fail"])
+
+const CONTROL_FLOW_NODE_TYPES = ["BreakNode", "NextNode", "RedoNode", "RetryNode", "ReturnNode"]
+
+export function isSideEffectCall(node: PrismNode): boolean {
+  if (!isPrismNodeType(node, "CallNode")) return false
+  if (node.receiver) return false
+
+  return SIDE_EFFECT_METHODS.has(node.name)
+}
+
+export function isControlFlowNode(node: PrismNode): boolean {
+  const type: string = node?.constructor?.name
+  if (!type) return false
+
+  if (CONTROL_FLOW_NODE_TYPES.includes(type)) return true
+
+  if (isPrismNodeType(node, "CallNode") && !node.receiver) {
+    return CONTROL_FLOW_METHODS.has(node.name)
+  }
+
+  return false
+}
+
+export function unwrapModifierStatement(node: PrismNode): PrismNode {
+  if (
+    !isPrismNodeType(node, "IfNode") &&
+    !isPrismNodeType(node, "UnlessNode") &&
+    !isPrismNodeType(node, "WhileNode") &&
+    !isPrismNodeType(node, "UntilNode")
+  ) {
+    return node
+  }
+
+  const body = node.statements?.body
+  if (!body || body.length !== 1) return node
+
+  return body[0]
+}
+
 export function isAssignmentNode(prismNode: PrismNode): boolean {
   const type: string = prismNode?.constructor?.name
   if (!type) return false

--- a/javascript/packages/linter/test/rules/erb-no-silent-statement.test.ts
+++ b/javascript/packages/linter/test/rules/erb-no-silent-statement.test.ts
@@ -75,6 +75,51 @@ describe("ERBNoSilentStatementRule", () => {
     `)
   })
 
+  test("should not report for control-flow keywords", () => {
+    expectNoOffenses(dedent`
+      <% (1..10).each do |num| %>
+        <% next if num == 3 %>
+        <% next %>
+        <% break if num == 8 %>
+        <% break %>
+        <% redo %>
+        <% raise 'boom' if num == 9 %>
+        <% raise 'boom' %>
+        <%= num %>
+      <% end %>
+    `)
+  })
+
+  test("should not report for control-flow keywords in unless modifier form", () => {
+    expectNoOffenses(dedent`
+      <% (1..10).each do |num| %>
+        <% next unless num.odd? %>
+        <% break unless num < 8 %>
+      <% end %>
+    `)
+  })
+
+  test("should not report for content_for and provide side-effect helpers", () => {
+    expectNoOffenses(dedent`
+      <% content_for(:title, 'Dashboard') %>
+      <% provide(:title, 'Dashboard') %>
+      <% content_for :title, 'Dashboard' if show_title? %>
+    `)
+  })
+
+  test("should still report for method calls guarded by a modifier", () => {
+    expectWarning(
+      'Avoid using silent ERB tags for statements. Move `some_method if condition` to a controller, helper, or presenter.',
+      { line: 2, column: 2 },
+    )
+
+    assertOffenses(dedent`
+      <div>
+        <% some_method if condition %>
+      </div>
+    `)
+  })
+
   test("should report for method calls", () => {
     expectWarning(
       'Avoid using silent ERB tags for statements. Move `some_method` to a controller, helper, or presenter.',


### PR DESCRIPTION
This pull request fixes the `erb-no-silent-statement` linter rule reporting offenses on ERB tags that contain no method call with a discarded return value.

The rule previously flagged any silent tag that wasn't an output tag or an assignment. That caught two categories of code where the diagnostic isn't actionable:

* **Control-flow keywords**  `next`, `break`, `redo`, `return`, and `raise`, along with their `if`/`unless` modifier 
* **`content_for` / `provide`**  [`erb-no-unused-expressions`](https://github.com/marcoroth/herb/blob/main/javascript/packages/linter/src/rules/erb-no-unused-expressions.ts) already recognizes these (and other Turbo helpers) as legitimate side effects via its `SIDE_EFFECT_METHODS` allowlist, so the two rules disagreed on the same code.

Resolves https://github.com/marcoroth/herb/issues/1879