### PR TITLE
Linter: Detect `erb-no-unsafe-raw` via Prism instead of regex

### DIFF
--- a/javascript/packages/linter/src/rules/erb-no-unsafe-raw.ts
+++ b/javascript/packages/linter/src/rules/erb-no-unsafe-raw.ts
@@ -1,12 +1,9 @@
 import { ParserRule } from "../types.js"
 import { ElementStackVisitor } from "./rule-utils.js"
-import { isERBOutputNode } from "@herb-tools/core"
+import { PrismVisitor, isERBOutputNode } from "@herb-tools/core"
 
 import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types.js"
-import type { ParseResult, ERBContentNode } from "@herb-tools/core"
-
-const RAW_PATTERN = /\braw[\s(]/
-const HTML_SAFE_PATTERN = /\.html_safe\b/
+import type { ParseResult, ParserOptions, ERBContentNode, PrismNode } from "@herb-tools/core"
 
 const RAW_TEXT_ELEMENTS = new Set([
   "title",
@@ -21,21 +18,42 @@ const RAW_TEXT_ELEMENTS = new Set([
   "plaintext",
 ])
 
+class UnsafeRawCallDetector extends PrismVisitor {
+  public hasRawCall = false
+  public hasHtmlSafeCall = false
+
+  visitCallNode(node: PrismNode): void {
+    if (node.name === "raw" && !node.receiver) {
+      this.hasRawCall = true
+    }
+
+    if (node.name === "html_safe") {
+      this.hasHtmlSafeCall = true
+    }
+
+    this.visitChildNodes(node)
+  }
+}
+
 class ERBNoUnsafeRawVisitor extends ElementStackVisitor {
   visitERBContentNode(node: ERBContentNode): void {
     if (this.isInsideElement(...RAW_TEXT_ELEMENTS)) return
     if (!isERBOutputNode(node)) return
 
-    const content = node.content?.value || ""
+    const prismNode = node.prismNode
+    if (!prismNode) return
 
-    if (RAW_PATTERN.test(content)) {
+    const detector = new UnsafeRawCallDetector()
+    detector.visit(prismNode)
+
+    if (detector.hasRawCall) {
       this.addOffense(
         "Avoid `raw()` in ERB output. It bypasses HTML escaping and can cause cross-site scripting (XSS) vulnerabilities.",
         node.location,
       )
     }
 
-    if (HTML_SAFE_PATTERN.test(content)) {
+    if (detector.hasHtmlSafeCall) {
       this.addOffense(
         "Avoid `.html_safe` in ERB output. It bypasses HTML escaping and can cause cross-site scripting (XSS) vulnerabilities.",
         node.location,
@@ -52,6 +70,12 @@ export class ERBNoUnsafeRawRule extends ParserRule {
     return {
       enabled: true,
       severity: "error"
+    }
+  }
+
+  get parserOptions(): Partial<ParserOptions> {
+    return {
+      prism_nodes: true,
     }
   }
 

--- a/javascript/packages/linter/test/rules/erb-no-unsafe-raw.test.ts
+++ b/javascript/packages/linter/test/rules/erb-no-unsafe-raw.test.ts
@@ -136,6 +136,35 @@ describe("ERBNoUnsafeRawRule", () => {
   })
 
   describe("safe usage", () => {
+    test("raw inside a Ruby comment is allowed", () => {
+      expectNoOffenses(dedent`
+        <%= render SomeComponent.new(
+          columns: [
+            # This comment mentions the raw upstream value.
+            { title: "Name", value: ->(record) { record.name } }
+          ]
+        ) %>
+      `)
+    })
+
+    test("raw inside a trailing Ruby comment is allowed", () => {
+      expectNoOffenses(dedent`
+        <%= user_input # raw was considered here %>
+      `)
+    })
+
+    test("html_safe inside a Ruby comment is allowed", () => {
+      expectNoOffenses(dedent`
+        <%= user_input # avoid calling .html_safe here %>
+      `)
+    })
+
+    test("raw as part of a string literal is allowed", () => {
+      expectNoOffenses(dedent`
+        <p><%= "raw text is fine" %></p>
+      `)
+    })
+
     test("safe ERB output in attribute value is allowed", () => {
       expectNoOffenses(dedent`
         <div class="<%= user_input %>"></div>


### PR DESCRIPTION
This pull request fixes a false positive in `erb-no-unsafe-raw` where the word `raw` inside a Ruby comment (or a string literal) in an ERB output block was reported as an unsafe `raw()` call.

For example, this template has no `raw()` call at all, but was flagged:

```erb
<%= render SomeComponent.new(
  columns: [
    # This comment mentions the raw upstream value.
    { title: "Name", value: ->(record) { record.name } }
  ]
) %>
```

The reported offense pointed at `<%= render SomeComponent.new(`, making it look like rendering the component was unsafe:

```text
Avoid `raw()` in ERB output. It bypasses HTML escaping and can cause cross-site scripting (XSS) vulnerabilities.
```

The rule now inspects the Prism AST instead of the raw source, mirroring `erb-no-unsafe-script-interpolation`. It opts into `prism_nodes: true` and walks each output node's Prism program, flagging only a real receiver-less `raw(...)` call node or an `html_safe` call node. Comments and string literals are not call nodes, so they are ignored.

Resolves https://github.com/marcoroth/herb/issues/1807