### PR TITLE
Parser: Fix `MissingERBEndTagError` for block with `yield`

### DIFF
--- a/src/analyze/control_type.c
+++ b/src/analyze/control_type.c
@@ -110,11 +110,10 @@ static bool find_earliest_control_keyword_walker(const pm_node_t* node, void* da
       if (call->block != NULL && call->block->type == PM_BLOCK_NODE) {
         pm_block_node_t* block_node = (pm_block_node_t*) call->block;
 
-        bool has_do_opening = is_do_block(block_node->opening_loc);
-        bool has_brace_opening = is_brace_block(block_node->opening_loc);
-        bool has_valid_brace_closing = is_closing_brace(block_node->closing_loc);
+        bool has_opening = is_do_block(block_node->opening_loc) || is_brace_block(block_node->opening_loc);
+        bool is_unclosed = !has_valid_block_closing(block_node->opening_loc, block_node->closing_loc);
 
-        if (has_do_opening || (has_brace_opening && !has_valid_brace_closing)) {
+        if (has_opening && is_unclosed) {
           current_type = CONTROL_TYPE_BLOCK;
           keyword_offset = (uint32_t) (node->location.start - context->source_start);
         }
@@ -125,11 +124,10 @@ static bool find_earliest_control_keyword_walker(const pm_node_t* node, void* da
     case PM_LAMBDA_NODE: {
       pm_lambda_node_t* lambda = (pm_lambda_node_t*) node;
 
-      bool has_do_opening = is_do_block(lambda->opening_loc);
-      bool has_brace_opening = is_brace_block(lambda->opening_loc);
-      bool has_valid_brace_closing = is_closing_brace(lambda->closing_loc);
+      bool has_opening = is_do_block(lambda->opening_loc) || is_brace_block(lambda->opening_loc);
+      bool is_unclosed = !has_valid_block_closing(lambda->opening_loc, lambda->closing_loc);
 
-      if (has_do_opening || (has_brace_opening && !has_valid_brace_closing)) {
+      if (has_opening && is_unclosed) {
         current_type = CONTROL_TYPE_BLOCK;
         keyword_offset = (uint32_t) (node->location.start - context->source_start);
       }

--- a/test/analyze/block_test.rb
+++ b/test/analyze/block_test.rb
@@ -451,5 +451,16 @@ module Analyze
         <% end %>
       HTML
     end
+
+    # https://github.com/marcoroth/herb/issues/1770
+    test "closed do/end block with yield in single tag" do
+      assert_parsed_snapshot(<<~HTML)
+        <%
+          meth do
+            yield
+          end
+        %>
+      HTML
+    end
   end
 end

--- a/test/snapshots/analyze/block_test/test_0053_closed_do_end_block_with_yield_in_single_tag_e01a1cc7dddf4cae7ad015ea3c5872f7.txt
+++ b/test/snapshots/analyze/block_test/test_0053_closed_do_end_block_with_yield_in_single_tag_e01a1cc7dddf4cae7ad015ea3c5872f7.txt
@@ -1,0 +1,22 @@
+---
+source: "Analyze::BlockTest#test_0053_closed do/end block with yield in single tag"
+input: |2-
+<%
+  meth do
+    yield
+  end
+%>
+---
+@ DocumentNode (location: (1:0)-(6:0))
+└── children: (2 items)
+    ├── @ ERBYieldNode (location: (1:0)-(5:2))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
+    │   ├── content: "
+    │     meth do
+    │       yield
+    │     end
+    │   " (location: (1:2)-(5:0))
+    │   └── tag_closing: "%>" (location: (5:0)-(5:2))
+    │
+    └── @ HTMLTextNode (location: (5:2)-(6:0))
+        └── content: "\n"


### PR DESCRIPTION
This pull request fixes a `MissingERBEndTagError` reported for a self-contained `do`/`end` block that `yield`s inside a single ERB tag.

Given this template:

```erb
<%
  meth do
    yield
  end
%>
```

The parser incorrectly wrapped the tag in an `ERBBlockNode` and attached a `MissingERBEndTagError`, expecting a separate `<% end %>` tag that should never come:

```
@ DocumentNode
└── @ ERBBlockNode
    └── errors: (1)
        └── @ MissingERBEndTagError
            └── message: "ERB block started here but never closed with an end tag..."
```

The root cause is that `yield` outside a method is a *semantic* error in Prism (`"Invalid yield"`), not a structural one. 

Brace blocks were already gated on whether they were validly closed, which is why the equivalent single-tag brace case already produced a clean `ERBYieldNode`:

```erb
<% content = capture { yield } if block_given? %>
```

This change applies the same `has_valid_block_closing` check to `do` blocks and lambdas, matching the logic already used in `search_block_nodes` and `search_unclosed_control_flows`. A validly-closed block is no longer treated as a block-opener, so the tag now parses cleanly with no errors:

```
@ DocumentNode
└── @ ERBYieldNode (location: (1:0)-(5:2))
    ├── tag_opening: "<%"
    ├── content: "\n  meth do\n    yield\n  end\n"
    └── tag_closing: "%>"
```

Resolves https://github.com/marcoroth/herb/issues/1770