### PR TITLE
Formatter: Keep ERB in attribute position on inline

### DIFF
--- a/javascript/packages/formatter/src/format-printer.ts
+++ b/javascript/packages/formatter/src/format-printer.ts
@@ -1380,7 +1380,7 @@ export class FormatPrinter extends Printer implements TextFlowDelegate, Attribut
       const fullInlineResult = this.tryRenderInlineFull(node, tagName, filterNodes(getOpenTagChildren(node), HTMLAttributeNode), node.body)
 
       if (fullInlineResult) {
-        return this.fitsOnCurrentLine(fullInlineResult)
+        return this.fitsOnCurrentLine(fullInlineResult) || this.contentIsGluedToTags(node)
       }
 
       return false
@@ -1454,6 +1454,20 @@ export class FormatPrinter extends Printer implements TextFlowDelegate, Attribut
 
 
   // --- Utility methods ---
+
+  private contentIsGluedToTags(node: HTMLElementNode): boolean {
+    const body = node.body
+
+    if (body.length === 0) return false
+
+    const first = body[0]
+    const last = body[body.length - 1]
+
+    const gluedStart = !isPureWhitespaceNode(first) && !(isNode(first, HTMLTextNode) && startsWithWhitespace(first.content))
+    const gluedEnd = !isPureWhitespaceNode(last) && !(isNode(last, HTMLTextNode) && endsWithWhitespace(last.content))
+
+    return gluedStart || gluedEnd
+  }
 
   private fitsOnCurrentLine(content: string): boolean {
     return this.indent.length + content.length <= this.maxLineLength
@@ -1628,11 +1642,10 @@ export class FormatPrinter extends Printer implements TextFlowDelegate, Attribut
    * Try to render a complete element inline including opening tag, children, and closing tag
    */
   private tryRenderInlineFull(_node: HTMLElementNode, tagName: string, attributes: HTMLAttributeNode[], children: Node[]): string | null {
-    let result = `<${tagName}`
+    const openTagChildren = getOpenTagChildren(_node)
+    const inlineNodes = this.extractInlineNodes(openTagChildren)
 
-    this.attributeRenderer.indentLevel = this.indentLevel
-    result += this.attributeRenderer.renderAttributesString(attributes, tagName)
-    result += ">"
+    let result = this.renderInlineOpen(tagName, attributes, false, inlineNodes, openTagChildren)
 
     const childrenContent = this.tryRenderChildrenInline(children, tagName, _node)
 

--- a/javascript/packages/formatter/test/html/attribute-erb-spacing.test.ts
+++ b/javascript/packages/formatter/test/html/attribute-erb-spacing.test.ts
@@ -1,10 +1,12 @@
 import { describe, test, expect, beforeAll } from "vitest"
 import { Herb } from "@herb-tools/node-wasm"
 import { Formatter } from "../../src"
+import { createExpectFormattedToMatch } from "../helpers"
 
 import dedent from "dedent"
 
 let formatter: Formatter
+let expectFormattedToMatch: ReturnType<typeof createExpectFormattedToMatch>
 
 describe("Attribute ERB Spacing", () => {
   beforeAll(async () => {
@@ -14,6 +16,8 @@ describe("Attribute ERB Spacing", () => {
       indentWidth: 2,
       maxLineLength: 80
     })
+
+    expectFormattedToMatch = createExpectFormattedToMatch(formatter)
   })
 
   describe("TOKEN_LIST_ATTRIBUTES (should add spaces around ERB)", () => {
@@ -258,6 +262,35 @@ describe("Attribute ERB Spacing", () => {
           Content
         </div>
       `)
+    })
+  })
+
+  describe("ERB in attribute position on an inline element (#1771)", () => {
+    test("keeps the ERB when the element is followed by text", () => {
+      expectFormattedToMatch(`<span <%= call(:me) %>>Foo</span> / Bar`)
+    })
+
+    test("keeps the ERB alongside a static attribute", () => {
+      expectFormattedToMatch(`<strong class="swole" <%= call(:me) %>>Bar</strong> / Baz`)
+    })
+
+    test("keeps the ERB for several inline elements in the same text flow", () => {
+      expectFormattedToMatch(dedent`
+        <span <%= call(:me) %>>Foo</span> / Bar
+        <strong class="swole" <%= call(:me) %>>Bar</strong> / Baz
+      `)
+    })
+
+    test("keeps the ERB when the element is followed by a block element", () => {
+      expectFormattedToMatch(dedent`
+        <strong <%= call(:me) %>>0</strong>
+        / 2048 character limit
+        <div></div>
+      `)
+    })
+
+    test("keeps the ERB when the element is nested in a block element", () => {
+      expectFormattedToMatch(`<p><span <%= call(:me) %>>Foo</span> / Bar</p>`)
     })
   })
 })

--- a/javascript/packages/formatter/test/spacing.test.ts
+++ b/javascript/packages/formatter/test/spacing.test.ts
@@ -180,9 +180,7 @@ describe("Spacing", () => {
         <div id="speakers" class="grid gap-4 min-w-full mb-6">
           <% @speakers_without_github.each do |speaker| %>
             <%= content_tag :div, id: dom_id(speaker), class: "flex justify-between p-4 rounded-lg border bg-white" do %>
-              <span>
-                <%= link_to speaker.name, edit_speaker_path(speaker), class: "underline link", data: {turbo_frame: "modal"} %>
-              </span>
+              <span><%= link_to speaker.name, edit_speaker_path(speaker), class: "underline link", data: {turbo_frame: "modal"} %></span>
 
               <span>
                 <%= link_to "https://github.com/search?q=#{speaker.name}&type=users", target: "_blank", class: "underline link" do %>


### PR DESCRIPTION
This pull request fixes the formatter silently discarding an ERB tag in attribute position when the element is inline and part of a text flow.

```erb
<span <%= call(:me) %>>Foo</span> / Bar
<strong class="swole" <%= call(:me) %>>Bar</strong> / Baz
```

formatted to

```erb
<span>Foo</span> / Bar
<strong class="swole">Bar</strong> / Baz
```

dropping `<%= call(:me) %>` from both tags.

Resolves https://github.com/marcoroth/herb/issues/1771