### PR TITLE
Linter: Allow slots setters on slot builders in `erb-no-unused-expressions`

### DIFF
--- a/javascript/packages/linter/docs/rules/erb-no-unused-expressions.md
+++ b/javascript/packages/linter/docs/rules/erb-no-unused-expressions.md
@@ -46,6 +46,16 @@ These expressions are evaluated but unused, they don't produce output (not `<%= 
 <% end %>
 ```
 
+ViewComponent slot setters are intentional side effects and are not flagged, including on builder objects yielded by nested slots:
+
+```erb
+<%= render ListComponent.new do |list| %>
+  <% list.with_item do |item| %>
+    <% item.with_icon("home") %>
+  <% end %>
+<% end %>
+```
+
 ### 🚫 Bad
 
 ```erb

--- a/javascript/packages/linter/src/rules/erb-no-unused-expressions.ts
+++ b/javascript/packages/linter/src/rules/erb-no-unused-expressions.ts
@@ -6,7 +6,7 @@ import { isERBOutputNode, isRubyParameterNode, isPrismNodeType } from "@herb-too
 import { isAssignmentNode, isDebugOutputCall, isCallOnLocal } from "./prism-rule-utils.js"
 
 import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types.js"
-import type { ParseResult, ERBContentNode, ERBRenderNode, ParserOptions, PrismNode } from "@herb-tools/core"
+import type { ParseResult, ERBContentNode, ERBRenderNode, ERBBlockNode, ParserOptions, PrismNode } from "@herb-tools/core"
 
 const MUTATION_METHODS = new Set([
   "<<",
@@ -95,10 +95,28 @@ class UnusedExpressionCollector extends PrismVisitor {
 }
 
 class ERBNoUnusedExpressionsVisitor extends BaseRuleVisitor {
-  private renderBlockLocalNames: Set<string> = new Set()
+  private exemptLocalNames: Set<string> = new Set()
 
   visitERBRenderNode(node: ERBRenderNode): void {
-    const previousLocalNames = this.renderBlockLocalNames
+    this.visitExemptingBlockArguments(node)
+  }
+
+  visitERBBlockNode(node: ERBBlockNode): void {
+    const prismNode = node.prismNode
+
+    if (prismNode && this.isSlotSetterCall(prismNode)) {
+      this.visitExemptingBlockArguments(node)
+    } else {
+      this.visitChildNodes(node)
+    }
+  }
+
+  private isSlotSetterCall(node: PrismNode): boolean {
+    return isPrismNodeType(node, "CallNode") && Boolean(node.receiver) && node.name.startsWith("with_")
+  }
+
+  private visitExemptingBlockArguments(node: ERBRenderNode | ERBBlockNode): void {
+    const previousLocalNames = this.exemptLocalNames
     const localNames = new Set(previousLocalNames)
 
     for (const argument of node.block_arguments) {
@@ -111,9 +129,9 @@ class ERBNoUnusedExpressionsVisitor extends BaseRuleVisitor {
       }
     }
 
-    this.renderBlockLocalNames = localNames
+    this.exemptLocalNames = localNames
     this.visitChildNodes(node)
-    this.renderBlockLocalNames = previousLocalNames
+    this.exemptLocalNames = previousLocalNames
   }
 
   visitERBContentNode(node: ERBContentNode): void {
@@ -125,7 +143,7 @@ class ERBNoUnusedExpressionsVisitor extends BaseRuleVisitor {
     const source = node.source
     if (!source) return
 
-    const collector = new UnusedExpressionCollector(this.renderBlockLocalNames)
+    const collector = new UnusedExpressionCollector(this.exemptLocalNames)
     collector.visit(prismNode)
 
     for (const expression of collector.expressions) {

--- a/javascript/packages/linter/test/rules/erb-no-unused-expressions.test.ts
+++ b/javascript/packages/linter/test/rules/erb-no-unused-expressions.test.ts
@@ -198,6 +198,51 @@ describe("ERBNoUnusedExpressionsRule", () => {
       `)
     })
 
+    test("passes for slot setters on a builder yielded by a nested slot block", () => {
+      expectNoOffenses(dedent`
+        <%= render ListComponent.new do |list| %>
+          <% list.with_item do |item| %>
+            <% item.with_icon("home") %>
+          <% end %>
+        <% end %>
+      `)
+    })
+
+    test("passes for deeply nested slot builders", () => {
+      expectNoOffenses(dedent`
+        <%= render(Ui::Page::Component.new(styles: "overflow-auto")) do |c| %>
+          <% c.with_header do |h| %>
+            <% h.with_title_content "Data Sources" %>
+            <% h.with_description_content "Manage your data sources" %>
+            <% h.with_action_button(text: "Integrations", url: integrations_path, variant: :secondary) %>
+          <% end %>
+        <% end %>
+      `)
+    })
+
+    test("passes for slot setters on a builder yielded by an assigned component", () => {
+      expectNoOffenses(dedent`
+        <% component = CardComponent.new %>
+        <% component.with_header do |header| %>
+          <% header.with_title("Hello") %>
+        <% end %>
+      `)
+    })
+
+    test("passes for slot builder locals shadowing across sibling slot blocks", () => {
+      expectNoOffenses(dedent`
+        <%= render ListComponent.new do |list| %>
+          <% list.with_item do |item| %>
+            <% item.with_icon("home") %>
+          <% end %>
+
+          <% list.with_footer do |footer| %>
+            <% footer.with_link("More") %>
+          <% end %>
+        <% end %>
+      `)
+    })
+
     test("passes for shovel operator", () => {
       expectNoOffenses(dedent`
         <% @items << item %>
@@ -382,6 +427,32 @@ describe("ERBNoUnusedExpressionsRule", () => {
       assertOffenses(dedent`
         <%= render BlogComponent.new do |component| %>
           <% component %>
+        <% end %>
+      `)
+    })
+
+    test("still fails for calls on an arbitrary (non-slot) block local", () => {
+      expectError(
+        "Avoid unused expressions in silent ERB tags. `x.slot_setter(\"d\")` is evaluated but its return value is discarded. Use `<%= ... %>` to output the value or remove the expression.",
+      )
+
+      assertOffenses(dedent`
+        <% plain_method do |x| %>
+          <% x.slot_setter("d") %>
+        <% end %>
+      `)
+    })
+
+    test("still fails for calls on a receiver other than a slot builder inside a slot block", () => {
+      expectError(
+        "Avoid unused expressions in silent ERB tags. `other_receiver.slot_setter(\"c\")` is evaluated but its return value is discarded. Use `<%= ... %>` to output the value or remove the expression.",
+      )
+
+      assertOffenses(dedent`
+        <%= render Outer.new do |outer| %>
+          <% outer.with_item do |item| %>
+            <% other_receiver.slot_setter("c") %>
+          <% end %>
         <% end %>
       `)
     })


### PR DESCRIPTION
This pull request extends the render-block exemption in `erb-no-unused-expressions` so it also recognizes the builder objects yielded by ViewComponent slot blocks.

```erb
<%= render ListComponent.new do |list| %>
  <% list.with_item do |item| %>
    <% item.with_icon("home") %>   <%# no longer flagged %>
  <% end %>
<% end %>
```

The rule already knows that a slot setter called on a `render(...) do |component|` param is an intentional side effect, `<% component.with_header(...) %>` is correctly not flagged. 

That exemption was scoped purely to the receiver yielded by the `render` block, so it didn't apply one level down: ViewComponent slots can themselves yield a builder (`renders_one`/`renders_many` with a block), and populating that builder's slots looks identical, `<% item.with_icon(...) %>`. 

Those nested setters were flagged as unused expressions even though they're the correct, documented way to populate a slot. The rule's suggested fix (switch to `<%= %>`) would be actively wrong there, outputting the setter's return value and producing duplicated or malformed markup.



Resolves https://github.com/marcoroth/herb/issues/1822