### PR TITLE
Formatter: Preserve content in script and style ERB blocks

### DIFF
--- a/javascript/packages/formatter/src/format-printer.ts
+++ b/javascript/packages/formatter/src/format-printer.ts
@@ -7,7 +7,7 @@ import { HerbDisableCollector } from "./herb-disable-collector.js"
 import { isTextFlowNode, hasFlowContentBefore, hasFlowContentAfter } from "./text-flow-helpers.js"
 import { extractHTMLCommentContent, formatHTMLCommentInner, formatERBCommentLines } from "./comment-helpers.js"
 
-import type { ERBNode } from "@herb-tools/core"
+import type { ERBNode, HerbBackend } from "@herb-tools/core"
 import type { FormatOptions } from "./options.js"
 import type { TextFlowDelegate } from "./text-flow-engine.js"
 import type { CollectedHerbDisable } from "./herb-disable-collector.js"
@@ -33,6 +33,7 @@ import {
   isHTMLOpenTagNode,
   isPureWhitespaceNode,
   filterNodes,
+  getHelper,
 } from "@herb-tools/core"
 
 import {
@@ -54,6 +55,7 @@ import {
 
 import {
   ASCII_WHITESPACE,
+  CONTENT_PRESERVING_ELEMENTS,
   SPACEABLE_CONTAINERS,
 } from "./format-helpers.js"
 
@@ -153,9 +155,13 @@ export class FormatPrinter extends Printer implements TextFlowDelegate, Attribut
 
   public source: string
 
-  constructor(source: string, options: Required<FormatOptions>) {
+  private herb?: HerbBackend
+  private erbBlockTagNameCache = new Map<Node, string | null>()
+
+  constructor(source: string, options: Required<FormatOptions>, herb?: HerbBackend) {
     super()
 
+    this.herb = herb
     this.source = source
     this.indentWidth = options.indentWidth
     this.maxLineLength = options.maxLineLength
@@ -178,6 +184,7 @@ export class FormatPrinter extends Printer implements TextFlowDelegate, Attribut
     this.stringLineCount = 0
     this.nodeIsMultiline.clear()
     this.inlineFlowContext.clear()
+    this.erbBlockTagNameCache.clear()
     this.spacingAnalyzer.clear()
 
     this.collectInlineFlowContext(node, false, false)
@@ -1144,21 +1151,89 @@ export class FormatPrinter extends Printer implements TextFlowDelegate, Attribut
     this.trackBoundary(node, () => {
       this.printERBNode(node)
 
-      this.withIndent(() => {
-        const hasTextFlow = this.textFlow.isInTextFlowContext(node.body)
+      if (this.isContentPreservingBlock(node)) {
+        this.visitPreservedERBBlockBody(node)
+      } else {
+        this.withIndent(() => {
+          const hasTextFlow = this.textFlow.isInTextFlowContext(node.body)
 
-        if (hasTextFlow) {
-          this.textFlow.visitTextFlowChildren(node.body)
-        } else {
-          this.visitElementChildren(node.body, null)
-        }
-      })
+          if (hasTextFlow) {
+            this.textFlow.visitTextFlowChildren(node.body)
+          } else {
+            this.visitElementChildren(node.body, null)
+          }
+        })
+      }
 
       if (node.rescue_clause) this.visit(node.rescue_clause)
       if (node.else_clause) this.visit(node.else_clause)
       if (node.ensure_clause) this.visit(node.ensure_clause)
       if (node.end_node) this.visit(node.end_node)
     })
+  }
+
+  private visitPreservedERBBlockBody(node: ERBBlockNode): void {
+    const raw = node.body.map(child => IdentityPrinter.print(child)).join("")
+    const lines = raw.split("\n")
+
+    if (lines.length > 0 && lines[0].trim() === "") lines.shift()
+    if (lines.length > 0 && lines[lines.length - 1].trim() === "") lines.pop()
+
+    lines.forEach(line => this.push(line))
+  }
+
+  private isContentPreservingBlock(node: ERBBlockNode): boolean {
+    const tagName = this.resolveERBBlockTagName(node)
+
+    return tagName !== null && CONTENT_PRESERVING_ELEMENTS.has(tagName)
+  }
+
+  private resolveERBBlockTagName(node: ERBBlockNode): string | null {
+    if (this.erbBlockTagNameCache.has(node)) return this.erbBlockTagNameCache.get(node)!
+
+    const resolved = this.prismERBBlockTagName(node)
+    this.erbBlockTagNameCache.set(node, resolved)
+
+    return resolved
+  }
+
+  private prismERBBlockTagName(node: ERBBlockNode): string | null {
+    if (!this.herb) return null
+
+    const content = node.content?.value ?? ""
+
+    try {
+      const result = this.herb.parse(`<%${content}%><% end %>`, { prism_nodes: true })
+      const block = result.value.children.find(child => isNode(child, ERBBlockNode)) as ERBBlockNode | undefined
+      const call = block?.prismNode
+
+      if (!call) return null
+
+      if (call.receiver) {
+        const receiver = call.receiver
+
+        if (receiver.name === "tag" && !receiver.receiver && typeof call.name === "string") {
+          return call.name.toLowerCase()
+        }
+
+        return null
+      }
+
+      const helper = getHelper(call.name)
+
+      if (helper?.supportsBlock && helper.tagName) return helper.tagName.toLowerCase()
+
+      if (call.name === "content_tag") {
+        const first = call.arguments_?.arguments_?.[0]
+        const value = first?.unescaped?.value
+
+        return typeof value === "string" ? value.toLowerCase() : null
+      }
+    } catch {
+      return null
+    }
+
+    return null
   }
 
   visitERBIfNode(node: ERBIfNode) {

--- a/javascript/packages/formatter/src/formatter.ts
+++ b/javascript/packages/formatter/src/formatter.ts
@@ -88,7 +88,7 @@ export class Formatter {
       }
     }
 
-    let formatted = new FormatPrinter(source, resolvedOptions).print(node)
+    let formatted = new FormatPrinter(source, resolvedOptions, this.herb).print(node)
 
     if (resolvedOptions.postRewriters.length > 0) {
       const context: RewriteContext = {

--- a/javascript/packages/formatter/test/erb/block.test.ts
+++ b/javascript/packages/formatter/test/erb/block.test.ts
@@ -1,10 +1,12 @@
 import { describe, test, expect, beforeAll } from "vitest"
 import { Herb } from "@herb-tools/node-wasm"
 import { Formatter } from "../../src"
+import { createExpectFormattedToMatch } from "../helpers"
 
 import dedent from "dedent"
 
 let formatter: Formatter
+let expectFormattedToMatch: ReturnType<typeof createExpectFormattedToMatch>
 
 describe("@herb-tools/formatter", () => {
   beforeAll(async () => {
@@ -14,6 +16,8 @@ describe("@herb-tools/formatter", () => {
       indentWidth: 2,
       maxLineLength: 80
     })
+
+    expectFormattedToMatch = createExpectFormattedToMatch(formatter)
   })
 
   test("formats block with rescue", () => {
@@ -129,5 +133,132 @@ describe("@herb-tools/formatter", () => {
 
     const output = formatter.format(input)
     expect(output).toEqual(expected)
+  })
+
+  describe("content-preserving helper blocks (#1702)", () => {
+    test("preserves newlines between JavaScript statements inside javascript_tag do", () => {
+      expectFormattedToMatch(dedent`
+        <%= javascript_tag do %>
+          const a = 1
+          console.log(a)
+        <% end %>
+      `)
+    })
+
+    test("preserves more than two statements", () => {
+      expectFormattedToMatch(dedent`
+        <%= javascript_tag do %>
+          const a = 1
+          const b = 2
+          console.log(a + b)
+        <% end %>
+      `)
+    })
+
+    test("preserves content when the helper takes options", () => {
+      expectFormattedToMatch(dedent`
+        <%= javascript_tag(type: "module") do %>
+          import x from "y"
+          x()
+        <% end %>
+      `)
+    })
+
+    test("preserves content when the helper takes a keyword argument", () => {
+      expectFormattedToMatch(dedent`
+        <%= javascript_tag nonce: true do %>
+          const a = 1
+          console.log(a)
+        <% end %>
+      `)
+    })
+
+    test("preserves interpolated ERB inside the block", () => {
+      expectFormattedToMatch(dedent`
+        <%= javascript_tag do %>
+          var x = <%= value %>;
+          console.log(x)
+        <% end %>
+      `)
+    })
+
+    test("preserves content when nested in an element", () => {
+      expectFormattedToMatch(dedent`
+        <div>
+          <%= javascript_tag do %>
+            const a = 1
+            console.log(a)
+          <% end %>
+        </div>
+      `)
+    })
+
+    test("preserves content in a content_tag :script block", () => {
+      expectFormattedToMatch(dedent`
+        <%= content_tag :script do %>
+          const a = 1
+          console.log(a)
+        <% end %>
+      `)
+    })
+
+    test("preserves content in a content_tag :style block", () => {
+      expectFormattedToMatch(dedent`
+        <%= content_tag :style do %>
+          .a { color: red }
+          .b { color: blue }
+        <% end %>
+      `)
+    })
+
+    test("preserves content for a quoted or parenthesised tag name", () => {
+      expectFormattedToMatch(dedent`
+        <%= content_tag("script", type: "module") do %>
+          import x from "y"
+          x()
+        <% end %>
+      `)
+    })
+
+    test("preserves content for the tag builder", () => {
+      expectFormattedToMatch(dedent`
+        <%= tag.style do %>
+          .a { color: red }
+          .b { color: blue }
+        <% end %>
+      `)
+    })
+
+    test("still collapses HTML text in a content_tag :div block", () => {
+      const expected = dedent`
+        <%= content_tag :div do %>
+          Hello world
+        <% end %>
+      `
+
+      expect(formatter.format(dedent`
+        <%= content_tag :div do %>
+          Hello
+          world
+        <% end %>
+      `)).toEqual(expected)
+      expectFormattedToMatch(expected)
+    })
+
+    test("still collapses HTML text in a capture block", () => {
+      const expected = dedent`
+        <%= capture do %>
+          Hello world
+        <% end %>
+      `
+
+      expect(formatter.format(dedent`
+        <%= capture do %>
+          Hello
+          world
+        <% end %>
+      `)).toEqual(expected)
+      expectFormattedToMatch(expected)
+    })
   })
 })

--- a/javascript/packages/formatter/test/erb/content-preserving-blocks.test.ts
+++ b/javascript/packages/formatter/test/erb/content-preserving-blocks.test.ts
@@ -1,0 +1,391 @@
+import { describe, test, expect, beforeAll } from "vitest"
+import { Herb } from "@herb-tools/node-wasm"
+import { Formatter } from "../../src"
+import { createExpectFormattedToMatch } from "../helpers"
+
+import dedent from "dedent"
+
+let formatter: Formatter
+let expectFormattedToMatch: ReturnType<typeof createExpectFormattedToMatch>
+
+describe("content-preserving ERB blocks (#1702)", () => {
+  beforeAll(async () => {
+    await Herb.load()
+
+    formatter = new Formatter(Herb, { indentWidth: 2, maxLineLength: 80 })
+    expectFormattedToMatch = createExpectFormattedToMatch(formatter)
+  })
+
+  describe("javascript_tag", () => {
+    test("preserves newlines between statements", () => {
+      expectFormattedToMatch(dedent`
+        <%= javascript_tag do %>
+          const a = 1
+          console.log(a)
+        <% end %>
+      `)
+    })
+
+    test("preserves blank lines between statements", () => {
+      expectFormattedToMatch(dedent`
+        <%= javascript_tag do %>
+          const a = 1
+
+          console.log(a)
+        <% end %>
+      `)
+    })
+
+    test("preserves relative indentation", () => {
+      expectFormattedToMatch(dedent`
+        <%= javascript_tag do %>
+          function outer() {
+            if (x) {
+              inner()
+            }
+          }
+        <% end %>
+      `)
+    })
+
+    test("preserves content that would otherwise be wrapped at maxLineLength", () => {
+      expectFormattedToMatch(dedent`
+        <%= javascript_tag do %>
+          const message = "a very long string literal that comfortably exceeds the eighty column limit"
+        <% end %>
+      `)
+    })
+
+    test("preserves interpolated ERB inside the block", () => {
+      expectFormattedToMatch(dedent`
+        <%= javascript_tag do %>
+          var x = <%= value %>;
+          console.log(x)
+        <% end %>
+      `)
+    })
+
+    test("preserves content with a trailing semicolon-free ASI hazard", () => {
+      expectFormattedToMatch(dedent`
+        <%= javascript_tag do %>
+          const a = 1
+          (function () { run() })()
+        <% end %>
+      `)
+    })
+
+    test("handles an empty block", () => {
+      expectFormattedToMatch(dedent`
+        <%= javascript_tag do %>
+        <% end %>
+      `)
+    })
+
+    test("preserves content when nested inside elements", () => {
+      expectFormattedToMatch(dedent`
+        <div>
+          <section>
+            <%= javascript_tag do %>
+              const a = 1
+              console.log(a)
+            <% end %>
+          </section>
+        </div>
+      `)
+    })
+
+    test("preserves content for each of several sibling blocks", () => {
+      expectFormattedToMatch(dedent`
+        <%= javascript_tag do %>
+          const a = 1
+          use(a)
+        <% end %>
+
+        <%= javascript_tag do %>
+          const b = 2
+          use(b)
+        <% end %>
+      `)
+    })
+
+    test("preserves non-ASCII content untouched", () => {
+      expectFormattedToMatch(dedent`
+        <%= javascript_tag do %>
+          const label = "café – naïve"
+          console.log(label)
+        <% end %>
+      `)
+    })
+  })
+
+  describe("tag name from an argument", () => {
+    test("content_tag with a symbol", () => {
+      expectFormattedToMatch(dedent`
+        <%= content_tag :script do %>
+          const a = 1
+          console.log(a)
+        <% end %>
+      `)
+    })
+
+    test("content_tag with a double-quoted string", () => {
+      expectFormattedToMatch(dedent`
+        <%= content_tag "style" do %>
+          .a { color: red }
+          .b { color: blue }
+        <% end %>
+      `)
+    })
+
+    test("content_tag with a single-quoted string", () => {
+      expectFormattedToMatch(dedent`
+        <%= content_tag 'script' do %>
+          const a = 1
+          console.log(a)
+        <% end %>
+      `)
+    })
+
+    test("content_tag with parentheses and options", () => {
+      expectFormattedToMatch(dedent`
+        <%= content_tag(:script, type: "module") do %>
+          import x from "y"
+          x()
+        <% end %>
+      `)
+    })
+
+    test("content_tag :pre", () => {
+      expectFormattedToMatch(dedent`
+        <%= content_tag :pre do %>
+          line one
+            line two indented
+        <% end %>
+      `)
+    })
+
+    test("content_tag :textarea", () => {
+      expectFormattedToMatch(dedent`
+        <%= content_tag :textarea do %>
+          first line
+          second line
+        <% end %>
+      `)
+    })
+
+    test("content_tag with an uppercase tag name", () => {
+      expectFormattedToMatch(dedent`
+        <%= content_tag :SCRIPT do %>
+          const a = 1
+          console.log(a)
+        <% end %>
+      `)
+    })
+
+    test("tag builder", () => {
+      expectFormattedToMatch(dedent`
+        <%= tag.script do %>
+          const a = 1
+          console.log(a)
+        <% end %>
+      `)
+    })
+
+    test("tag builder with attributes", () => {
+      expectFormattedToMatch(dedent`
+        <%= tag.style media: "print" do %>
+          .a { color: red }
+          .b { color: blue }
+        <% end %>
+      `)
+    })
+  })
+
+  describe("blocks that hold HTML are still collapsed", () => {
+    const collapses = (source: string, expected: string) => {
+      expect(formatter.format(source)).toEqual(expected)
+      expectFormattedToMatch(expected)
+    }
+
+    test("capture", () => {
+      collapses(
+        dedent`
+          <%= capture do %>
+            Hello
+            world
+          <% end %>
+        `,
+        dedent`
+          <%= capture do %>
+            Hello world
+          <% end %>
+        `
+      )
+    })
+
+    test("content_tag :div", () => {
+      collapses(
+        dedent`
+          <%= content_tag :div do %>
+            Hello
+            world
+          <% end %>
+        `,
+        dedent`
+          <%= content_tag :div do %>
+            Hello world
+          <% end %>
+        `
+      )
+    })
+
+    test("tag.div", () => {
+      collapses(
+        dedent`
+          <%= tag.div do %>
+            Hello
+            world
+          <% end %>
+        `,
+        dedent`
+          <%= tag.div do %>
+            Hello world
+          <% end %>
+        `
+      )
+    })
+
+    test("each", () => {
+      collapses(
+        dedent`
+          <% items.each do |item| %>
+            Hello
+            world
+          <% end %>
+        `,
+        dedent`
+          <% items.each do |item| %>
+            Hello world
+          <% end %>
+        `
+      )
+    })
+  })
+
+  describe("not claimed when the emitted tag is unknown", () => {
+    test("receiver call", () => {
+      expectFormattedToMatch(dedent`
+        <%= helpers.javascript_tag do %>
+          Hello world
+        <% end %>
+      `)
+    })
+
+    test("safe navigation receiver", () => {
+      expectFormattedToMatch(dedent`
+        <%= obj&.javascript_tag do %>
+          Hello world
+        <% end %>
+      `)
+    })
+
+    test("a near-miss helper name", () => {
+      expectFormattedToMatch(dedent`
+        <%= javascript_tag_wrapper do %>
+          Hello world
+        <% end %>
+      `)
+    })
+
+    test("content_tag with a variable tag name", () => {
+      expectFormattedToMatch(dedent`
+        <%= content_tag tag_name do %>
+          Hello world
+        <% end %>
+      `)
+    })
+  })
+
+  describe("resolution is robust", () => {
+    test("a leading Ruby comment before the call", () => {
+      expectFormattedToMatch(dedent`
+        <%= # which tag?
+          javascript_tag do %>
+          const a = 1
+          console.log(a)
+        <% end %>
+      `)
+    })
+
+    test("a block parameter on the helper", () => {
+      const source = dedent`
+        <%= javascript_tag do |x| %>
+          const a = 1
+          console.log(a)
+        <% end %>
+      `
+
+      expect(() => formatter.format(source)).not.toThrow()
+    })
+
+    test("trim markers on the tags", () => {
+      const source = dedent`
+        <%= javascript_tag do -%>
+          const a = 1
+          console.log(a)
+        <% end -%>
+      `
+
+      expect(() => formatter.format(source)).not.toThrow()
+      expect(formatter.format(source)).toContain("const a = 1\n")
+    })
+
+    test("a `<%` sequence inside the block header does not break resolution", () => {
+      const source = dedent`
+        <%= javascript_tag class: "a<%b" do %>
+          const a = 1
+          console.log(a)
+        <% end %>
+      `
+
+      expect(() => formatter.format(source)).not.toThrow()
+    })
+
+    test("formatting the same source twice is stable", () => {
+      const source = dedent`
+        <%= javascript_tag do %>
+          const a = 1
+          console.log(a)
+        <% end %>
+
+        <%= content_tag :style do %>
+          .a { color: red }
+        <% end %>
+      `
+
+      const once = formatter.format(source)
+
+      expect(formatter.format(once)).toEqual(once)
+      expect(once).toEqual(source)
+    })
+
+    test("a single formatter instance handles mixed documents in sequence", () => {
+      const preserved = dedent`
+        <%= javascript_tag do %>
+          const a = 1
+          console.log(a)
+        <% end %>
+      `
+
+      const collapsed = dedent`
+        <%= content_tag :div do %>
+          Hello world
+        <% end %>
+      `
+
+      expect(formatter.format(preserved)).toEqual(preserved)
+      expect(formatter.format(collapsed)).toEqual(collapsed)
+      expect(formatter.format(preserved)).toEqual(preserved)
+    })
+  })
+})


### PR DESCRIPTION
This pull request stops the formatter collapsing the newlines inside ERB blocks whose content isn't HTML.

```erb
<%= javascript_tag do %>
  const a = 1
  console.log(a)
<% end %>
```

formatted to

```erb
<%= javascript_tag do %>
  const a = 1 console.log(a)
<% end %>
```

Merging those two statements onto one line can change what the JavaScript means through automatic semicolon insertion, or make it a syntax error outright.

Resolves https://github.com/marcoroth/herb/issues/1702