### PR TITLE
Linter CLI: Print a progress message when linting multiple files

### DIFF
--- a/javascript/packages/linter/src/cli.ts
+++ b/javascript/packages/linter/src/cli.ts
@@ -403,6 +403,10 @@ export class CLI {
         this.exitWithInfo(`No files found matching patterns: ${patterns.join(', ') || 'from config'}`, formatOption, 0, { startTime, startDate, showTiming })
       }
 
+      if (files.length > 1 && formatOption !== 'json' && !useGitHubActions) {
+        console.error(colorize(`Found ${files.length} files, linting...`, "gray"))
+      }
+
       let processingConfig = config
 
       if (force && explicitFiles.length > 0) {

--- a/javascript/packages/linter/test/cli.test.ts
+++ b/javascript/packages/linter/test/cli.test.ts
@@ -343,6 +343,13 @@ describe("CLI Output Formatting", () => {
       expect(exitCode).toBe(0)
     })
 
+    test("prints a progress message when linting multiple files", () => {
+      const { output, exitCode } = runLinterMultiFile("clean-file.html.erb", "boolean-attribute.html.erb")
+
+      expect(output).toContain("Found 2 files, linting...")
+      expect(exitCode).toBe(0)
+    })
+
     test("lints multiple files with errors", () => {
       const { output, exitCode } = runLinterMultiFile("test-file-with-errors.html.erb", "bad-file.html.erb")
 


### PR DESCRIPTION
This pull request adds a lightweight progress message to the linter CLI so that runs over more than one file give immediate feedback that work has started.

Previously, when linting a larger set of files there was no output until the results were ready, which could make the CLI feel unresponsive on bigger projects. Now, once the file list is resolved, the CLI prints how many files it's about to lint:

```text
Found 42 files, linting...
```

The message is written to `stderr` (via `console.error`) so it stays out of the way of the actual results on `stdout`.