### PR TITLE
Linter: Improve `html-no-duplicate-ids` rule

### DIFF
--- a/javascript/packages/linter/docs/rules/html-no-duplicate-ids.md
+++ b/javascript/packages/linter/docs/rules/html-no-duplicate-ids.md
@@ -36,13 +36,34 @@ Duplicate IDs in an HTML document can lead to unexpected behavior, especially wh
 <div id="footer">Footer</div>
 ```
 
+## Static vs. dynamic IDs
+
+The severity of an offense depends on whether the `id` can be proven to collide:
+
+- **Static IDs** (e.g. `id="header"`) use the rule's configured `severity` (default `error`), two identical static IDs are unconditionally a duplicate.
+- **Dynamic IDs** (containing an ERB output expression, e.g. `id="<%= dom_id(record) %>"`) are always reported as **hints**, phrased as a *potential* duplicate, regardless of the rule's configured severity.
+
+A dynamic ID can never be statically proven to collide: the same source expression can evaluate to different values (a non-idempotent method, a counter, a value reassigned between outputs), so an error would overclaim certainty. Because of this, reusing the same loop variable across separate blocks is **not** flagged at all:
+
+```erb
+<% good.each do |i| %>
+  <p id="<%= i %>"><%= i %></p>
+<% end %>
+
+<% bad.each do |i| %>
+  <p id="<%= i %>"><%= i %></p>
+<% end %>
+```
+
+The same dynamic expression repeated within the same scope (same document level, same conditional branch) is surfaced as a hint rather than an error:
+
 ```erb
 <div id="<%= dom_id("header") %>">Header</div>
 
-<div id="<%= dom_id("header") %>">Duplicate Header</div>
-
-<div id="<%= dom_id("footer") %>">Footer</div>
+<div id="<%= dom_id("header") %>">Potential duplicate Header</div>
 ```
+
+Hints do not fail a lint run unless you opt in with `failLevel: hint` (or `--fail-level hint`), which is how you enforce potential duplicates in CI when you know your IDs are deterministic.
 
 ## References
 * [W3 org - The id attribute](https://www.w3.org/TR/2011/WD-html5-20110525/elements.html#the-id-attribute)

--- a/javascript/packages/linter/docs/rules/html-no-duplicate-ids.md
+++ b/javascript/packages/linter/docs/rules/html-no-duplicate-ids.md
@@ -65,6 +65,31 @@ The same dynamic expression repeated within the same scope (same document level,
 
 Hints do not fail a lint run unless you opt in with `failLevel: hint` (or `--fail-level hint`), which is how you enforce potential duplicates in CI when you know your IDs are deterministic.
 
+## `<template>` elements
+
+A `<template>` is an inert document fragment — its contents only enter the document once the template is cloned/inflated. Each `<template>` body therefore gets its **own ID context**: IDs inside it don't compete with IDs elsewhere in the document, or with IDs in other templates.
+
+```erb
+<div id="thing">Rendered on load</div>
+
+<template id="thing-template">
+  <div id="thing"></div>
+</template>
+```
+
+Two things are still reported:
+
+- **Duplicates within the same template.** Cloning a template materializes all of its contents at once, so IDs repeated inside one template are a genuine collision:
+
+  ```erb
+  <template>
+    <div id="thing">One</div>
+    <div id="thing">Two</div> <%# Duplicate ID `thing` %>
+  </template>
+  ```
+
+- **The template element's own `id`.** `thing-template` above lives in the surrounding document, so duplicates between template elements — or between a template element and an outside element — are reported as usual.
+
 ## References
 * [W3 org - The id attribute](https://www.w3.org/TR/2011/WD-html5-20110525/elements.html#the-id-attribute)
 * [Rails `ActionView::RecordIdentifier#dom_id`](https://api.rubyonrails.org/classes/ActionView/RecordIdentifier.html#method-i-dom_id)

--- a/javascript/packages/linter/src/rules/html-no-duplicate-ids.ts
+++ b/javascript/packages/linter/src/rules/html-no-duplicate-ids.ts
@@ -3,9 +3,9 @@ import { ControlFlowTrackingVisitor, ControlFlowType } from "./rule-utils"
 import { LiteralNode } from "@herb-tools/core"
 import { Printer, IdentityPrinter } from "@herb-tools/printer"
 
-import { hasERBOutput, getValidatableStaticContent, isEffectivelyStatic, isNode, getStaticAttributeName, isERBOutputNode } from "@herb-tools/core"
+import { hasERBOutput, getValidatableStaticContent, isEffectivelyStatic, isNode, getStaticAttributeName, isERBOutputNode, getTagLocalName } from "@herb-tools/core"
 
-import type { ParseResult, HTMLAttributeNode, ERBContentNode, ParserOptions } from "@herb-tools/core"
+import type { ParseResult, HTMLAttributeNode, HTMLElementNode, ERBContentNode, ParserOptions } from "@herb-tools/core"
 import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types"
 
 interface ControlFlowState {
@@ -34,8 +34,40 @@ class NoDuplicateIdsVisitor extends ControlFlowTrackingVisitor<BaseAutofixContex
   private currentBranchIds: Set<string> = new Set<string>()
   private controlFlowIds: Set<string> = new Set<string>()
 
+  visitHTMLElementNode(node: HTMLElementNode): void {
+    if (getTagLocalName(node) === "template") {
+      this.visitTemplateElementNode(node)
+
+      return
+    }
+
+    super.visitHTMLElementNode(node)
+  }
+
   visitHTMLAttributeNode(node: HTMLAttributeNode): void {
     this.checkAttribute(node)
+  }
+
+  private visitTemplateElementNode(node: HTMLElementNode): void {
+    if (node.open_tag) this.visit(node.open_tag)
+
+    const previousDocumentIds = this.documentIds
+    const previousBranchIds = this.currentBranchIds
+    const previousControlFlowIds = this.controlFlowIds
+
+    this.documentIds = new Set<string>()
+    this.currentBranchIds = new Set<string>()
+    this.controlFlowIds = new Set<string>()
+
+    for (const child of node.body) {
+      this.visit(child)
+    }
+
+    this.documentIds = previousDocumentIds
+    this.currentBranchIds = previousBranchIds
+    this.controlFlowIds = previousControlFlowIds
+
+    if (node.close_tag) this.visit(node.close_tag)
   }
 
   protected onEnterControlFlow(_controlFlowType: ControlFlowType, wasAlreadyInControlFlow: boolean): ControlFlowState {

--- a/javascript/packages/linter/src/rules/html-no-duplicate-ids.ts
+++ b/javascript/packages/linter/src/rules/html-no-duplicate-ids.ts
@@ -119,7 +119,7 @@ class NoDuplicateIdsVisitor extends ControlFlowTrackingVisitor<BaseAutofixContex
     if (this.isInControlFlow) {
       this.handleControlFlowId(identifier, attributeNode, isDynamic)
     } else {
-      this.handleGlobalId(identifier, attributeNode)
+      this.handleGlobalId(identifier, attributeNode, isDynamic)
     }
   }
 
@@ -148,7 +148,7 @@ class NoDuplicateIdsVisitor extends ControlFlowTrackingVisitor<BaseAutofixContex
 
   private handleConditionalId(identifier: string, attributeNode: HTMLAttributeNode, isDynamic: boolean): void {
     if (this.currentBranchIds.has(identifier)) {
-      this.addSameBranchOffense(identifier, attributeNode.location)
+      this.addSameBranchOffense(identifier, attributeNode.location, isDynamic)
       return
     }
 
@@ -162,9 +162,13 @@ class NoDuplicateIdsVisitor extends ControlFlowTrackingVisitor<BaseAutofixContex
     }
   }
 
-  private handleGlobalId(identifier: string, attributeNode: HTMLAttributeNode): void {
+  private handleGlobalId(identifier: string, attributeNode: HTMLAttributeNode, isDynamic: boolean): void {
     if (this.documentIds.has(identifier)) {
-      this.addDuplicateIdOffense(identifier, attributeNode.location)
+      if (isDynamic) {
+        this.addPotentialDuplicateIdOffense(identifier, attributeNode.location)
+      } else {
+        this.addDuplicateIdOffense(identifier, attributeNode.location)
+      }
       return
     }
 
@@ -193,10 +197,29 @@ class NoDuplicateIdsVisitor extends ControlFlowTrackingVisitor<BaseAutofixContex
     )
   }
 
-  private addSameBranchOffense(identifier: string, location: any): void {
+  private addSameBranchOffense(identifier: string, location: any, isDynamic: boolean): void {
+    if (isDynamic) {
+      this.addOffense(
+        `Potential duplicate ID \`${identifier}\` found within the same control flow branch. If this expression evaluates to the same value, IDs must be unique.`,
+        location,
+        undefined,
+        "hint",
+      )
+      return
+    }
+
     this.addOffense(
       `Duplicate ID \`${identifier}\` found within the same control flow branch. IDs must be unique within the same control flow branch.`,
       location,
+    )
+  }
+
+  private addPotentialDuplicateIdOffense(identifier: string, location: any): void {
+    this.addOffense(
+      `Potential duplicate ID \`${identifier}\` found. If this expression evaluates to the same value, IDs must be unique within a document.`,
+      location,
+      undefined,
+      "hint",
     )
   }
 }

--- a/javascript/packages/linter/test/rules/html-no-duplicate-ids.test.ts
+++ b/javascript/packages/linter/test/rules/html-no-duplicate-ids.test.ts
@@ -586,4 +586,611 @@ describe("html-no-duplicate-ids", () => {
       <a href="/" id="home-link">Home</a>
     `)
   })
+
+  describe("<template> elements (issue #1728)", () => {
+    describe("isolation from the surrounding document", () => {
+      test("passes for ID inside <template> matching an ID outside it", () => {
+        expectNoOffenses(dedent`
+          <div id="thing">Rendered on load</div>
+
+          <template id="thing-template">
+            <div id="thing">Re-added from template</div>
+          </template>
+        `)
+      })
+
+      test("passes for ID outside <template> matching an ID inside it (reverse order)", () => {
+        expectNoOffenses(dedent`
+          <template>
+            <div id="thing">Re-added from template</div>
+          </template>
+
+          <div id="thing">Rendered on load</div>
+        `)
+      })
+
+      test("passes for IDs shared across separate <template> elements", () => {
+        expectNoOffenses(dedent`
+          <template>
+            <div id="item"></div>
+          </template>
+
+          <template>
+            <div id="item"></div>
+          </template>
+        `)
+      })
+
+      test("passes for the same ID across three separate <template> elements", () => {
+        expectNoOffenses(dedent`
+          <template>
+            <div id="item"></div>
+          </template>
+
+          <template>
+            <div id="item"></div>
+          </template>
+
+          <template>
+            <div id="item"></div>
+          </template>
+        `)
+      })
+
+      test("passes for templated static ID string used once per <template>", () => {
+        expectNoOffenses(dedent`
+          <template>
+            <div id="my-thing-:templated-value"></div>
+          </template>
+
+          <template>
+            <div id="my-thing-:templated-value"></div>
+          </template>
+        `)
+      })
+
+      test("passes for a <template> nested deep inside other elements", () => {
+        expectNoOffenses(dedent`
+          <div id="dup"></div>
+
+          <div>
+            <section>
+              <template>
+                <div id="dup"></div>
+              </template>
+            </section>
+          </div>
+        `)
+      })
+
+      test("passes for deeply nested IDs inside a <template>", () => {
+        expectNoOffenses(dedent`
+          <div id="deep"></div>
+
+          <template>
+            <div>
+              <section>
+                <span id="deep"></span>
+              </section>
+            </div>
+          </template>
+        `)
+      })
+
+      test("passes for an empty <template>", () => {
+        expectNoOffenses(dedent`
+          <div id="thing"></div>
+          <template></template>
+        `)
+      })
+    })
+
+    describe("duplicates within a single <template>", () => {
+      test("fails for duplicate IDs inside the same <template>", () => {
+        expectError('Duplicate ID `thing` found. IDs must be unique within a document.')
+
+        assertOffenses(dedent`
+          <template>
+            <div id="thing">One</div>
+            <div id="thing">Two</div>
+          </template>
+        `)
+      })
+
+      test("fails for duplicate IDs inside a <template> that also exist outside it", () => {
+        expectError('Duplicate ID `thing` found. IDs must be unique within a document.')
+
+        assertOffenses(dedent`
+          <div id="thing">Outside</div>
+
+          <template>
+            <div id="thing">One</div>
+            <div id="thing">Two</div>
+          </template>
+        `)
+      })
+
+      test("fails once per duplicate for several distinct duplicates in one <template>", () => {
+        expectError('Duplicate ID `first` found. IDs must be unique within a document.')
+        expectError('Duplicate ID `second` found. IDs must be unique within a document.')
+
+        assertOffenses(dedent`
+          <template>
+            <div id="first"></div>
+            <div id="second"></div>
+            <div id="first"></div>
+            <div id="second"></div>
+          </template>
+        `)
+      })
+
+      test("fails for duplicate IDs nested at different depths inside one <template>", () => {
+        expectError('Duplicate ID `deep` found. IDs must be unique within a document.')
+
+        assertOffenses(dedent`
+          <template>
+            <div id="deep"></div>
+            <section>
+              <span id="deep"></span>
+            </section>
+          </template>
+        `)
+      })
+
+      test("fails for the same templated static ID string twice in one <template>", () => {
+        expectError('Duplicate ID `my-thing-:templated-value` found. IDs must be unique within a document.')
+
+        assertOffenses(dedent`
+          <template>
+            <div id="my-thing-:templated-value"></div>
+            <div id="my-thing-:templated-value"></div>
+          </template>
+        `)
+      })
+    })
+
+    describe("the <template> element's own id", () => {
+      test("fails for duplicate IDs on the <template> elements themselves", () => {
+        expectError('Duplicate ID `my-template` found. IDs must be unique within a document.')
+
+        assertOffenses(dedent`
+          <template id="my-template"></template>
+          <template id="my-template"></template>
+        `)
+      })
+
+      test("fails for duplicate ID between a <template> element and an outside element", () => {
+        expectError('Duplicate ID `shared` found. IDs must be unique within a document.')
+
+        assertOffenses(dedent`
+          <template id="shared">
+            <div id="inner"></div>
+          </template>
+          <div id="shared"></div>
+        `)
+      })
+
+      test("fails for duplicate ID between an outside element and a later <template> element", () => {
+        expectError('Duplicate ID `shared` found. IDs must be unique within a document.')
+
+        assertOffenses(dedent`
+          <div id="shared"></div>
+          <template id="shared"></template>
+        `)
+      })
+
+      test("passes when a <template> element's own id matches an ID inside itself", () => {
+        expectNoOffenses(dedent`
+          <template id="same">
+            <div id="same"></div>
+          </template>
+        `)
+      })
+    })
+
+    describe("scope restoration", () => {
+      test("still detects duplicate IDs outside a <template> after visiting one", () => {
+        expectError('Duplicate ID `outside` found. IDs must be unique within a document.')
+
+        assertOffenses(dedent`
+          <div id="outside"></div>
+
+          <template>
+            <div id="inner"></div>
+          </template>
+
+          <div id="outside"></div>
+        `)
+      })
+
+      test("still detects duplicate IDs outside after several <template> elements", () => {
+        expectError('Duplicate ID `outside` found. IDs must be unique within a document.')
+
+        assertOffenses(dedent`
+          <div id="outside"></div>
+
+          <template><div id="a"></div></template>
+          <template><div id="a"></div></template>
+
+          <div id="outside"></div>
+        `)
+      })
+
+      test("does not leak IDs from a <template> into the surrounding document", () => {
+        expectNoOffenses(dedent`
+          <template>
+            <div id="only-in-template"></div>
+          </template>
+
+          <div id="only-in-template"></div>
+        `)
+      })
+    })
+
+    describe("nested <template> elements", () => {
+      test("passes for the same ID in an outer and inner <template>", () => {
+        expectNoOffenses(dedent`
+          <template>
+            <div id="a"></div>
+
+            <template>
+              <div id="a"></div>
+            </template>
+          </template>
+        `)
+      })
+
+      test("fails for duplicate IDs inside a nested <template>", () => {
+        expectError('Duplicate ID `x` found. IDs must be unique within a document.')
+        assertOffenses(dedent`
+          <template>
+            <template>
+              <div id="x"></div>
+              <div id="x"></div>
+            </template>
+          </template>
+        `)
+      })
+
+      test("restores the outer <template> scope after a nested <template>", () => {
+        expectError('Duplicate ID `outer` found. IDs must be unique within a document.')
+        assertOffenses(dedent`
+          <template>
+            <div id="outer"></div>
+
+            <template>
+              <div id="inner"></div>
+            </template>
+
+            <div id="outer"></div>
+          </template>
+        `)
+      })
+
+      test("passes for a nested <template> element's own id matching an outer one", () => {
+        expectNoOffenses(dedent`
+          <template id="tpl">
+            <template id="tpl"></template>
+          </template>
+        `)
+      })
+    })
+
+    describe("interaction with ERB control flow", () => {
+      test("passes for a <template> ID matching an ID in an if branch outside it", () => {
+        expectNoOffenses(dedent`
+          <% if condition %>
+            <template>
+              <div id="x"></div>
+            </template>
+          <% end %>
+
+          <div id="x"></div>
+        `)
+      })
+
+      test("passes for IDs in mutually exclusive branches inside a <template>", () => {
+        expectNoOffenses(dedent`
+          <template>
+            <% if condition %>
+              <div id="a"></div>
+            <% else %>
+              <div id="a"></div>
+            <% end %>
+          </template>
+        `)
+      })
+
+      test("fails for duplicate IDs in the same branch inside a <template>", () => {
+        expectError('Duplicate ID `a` found within the same control flow branch. IDs must be unique within the same control flow branch.')
+        assertOffenses(dedent`
+          <template>
+            <% if condition %>
+              <div id="a"></div>
+              <div id="a"></div>
+            <% end %>
+          </template>
+        `)
+      })
+
+      test("matches outside-template behavior for a static ID in a single block", () => {
+        expectNoOffenses(dedent`
+          <template>
+            <% items.each do |item| %>
+              <div id="static-id"></div>
+            <% end %>
+          </template>
+        `)
+      })
+
+      test("fails for static IDs in separate blocks inside one <template>", () => {
+        expectError('Duplicate ID `static-id` found. IDs must be unique within a document.')
+
+        assertOffenses(dedent`
+          <template>
+            <% first.each do |item| %>
+              <div id="static-id"></div>
+            <% end %>
+
+            <% second.each do |item| %>
+              <div id="static-id"></div>
+            <% end %>
+          </template>
+        `)
+      })
+
+      test("passes for static IDs in blocks in separate <template> elements", () => {
+        expectNoOffenses(dedent`
+          <template>
+            <% first.each do |item| %>
+              <div id="static-id"></div>
+            <% end %>
+          </template>
+
+          <template>
+            <% second.each do |item| %>
+              <div id="static-id"></div>
+            <% end %>
+          </template>
+        `)
+      })
+
+      test("passes for a dynamic ID inside a loop inside a <template>", () => {
+        expectNoOffenses(dedent`
+          <template>
+            <% items.each do |item| %>
+              <div id="item-<%= item.id %>"></div>
+            <% end %>
+          </template>
+        `)
+      })
+
+      test("passes for a <template> inside a loop", () => {
+        expectNoOffenses(dedent`
+          <div id="thing"></div>
+
+          <% items.each do |item| %>
+            <template>
+              <div id="thing"></div>
+            </template>
+          <% end %>
+        `)
+      })
+    })
+
+    describe("interaction with dynamic IDs", () => {
+      test("passes for a dynamic ID inside a <template> matching one outside", () => {
+        expectNoOffenses(dedent`
+          <div id="<%= user.id %>"></div>
+
+          <template>
+            <div id="<%= user.id %>"></div>
+          </template>
+        `)
+      })
+
+      test("hints for a duplicate dynamic ID within the same <template>", () => {
+        expectHint('Potential duplicate ID `<%= user.id %>` found. If this expression evaluates to the same value, IDs must be unique within a document.')
+
+        assertOffenses(dedent`
+          <template>
+            <div id="<%= user.id %>"></div>
+            <div id="<%= user.id %>"></div>
+          </template>
+        `)
+      })
+
+      test("passes for the same dynamic ID across separate <template> elements", () => {
+        expectNoOffenses(dedent`
+          <template>
+            <div id="<%= user.id %>"></div>
+          </template>
+
+          <template>
+            <div id="<%= user.id %>"></div>
+          </template>
+        `)
+      })
+    })
+
+    describe("edge cases", () => {
+      test("treats an uppercase <TEMPLATE> the same as a lowercase one", () => {
+        expectNoOffenses(dedent`
+          <div id="thing"></div>
+
+          <TEMPLATE>
+            <div id="thing"></div>
+          </TEMPLATE>
+        `)
+      })
+
+      test("passes for whitespace-only and empty IDs inside a <template>", () => {
+        expectNoOffenses(dedent`
+          <template>
+            <div id=""></div>
+            <div id="  "></div>
+          </template>
+        `)
+      })
+
+      test("ignores non-id attributes inside a <template>", () => {
+        expectNoOffenses(dedent`
+          <template>
+            <div class="value"></div>
+            <div class="value"></div>
+          </template>
+        `)
+      })
+    })
+  })
+
+  describe("pending: block iteration nodes (ERBBlockEachNode)", () => {
+    describe("static IDs repeat once per iteration", () => {
+      test.todo("fails for a static ID in a single each block", () => {
+        expectError('Duplicate ID `item` found. IDs must be unique within a document.')
+
+        assertOffenses(dedent`
+          <% items.each do |item| %>
+            <div id="item"></div>
+          <% end %>
+        `)
+      })
+
+      test.todo("fails for a static ID in a map block", () => {
+        expectError('Duplicate ID `item` found. IDs must be unique within a document.')
+
+        assertOffenses(dedent`
+          <% items.map do |item| %>
+            <div id="item"></div>
+          <% end %>
+        `)
+      })
+
+      test.todo("fails for a static ID nested deep inside an each block", () => {
+        expectError('Duplicate ID `deep` found. IDs must be unique within a document.')
+
+        assertOffenses(dedent`
+          <% items.each do |item| %>
+            <section>
+              <span id="deep"></span>
+            </section>
+          <% end %>
+        `)
+      })
+
+      test.todo("fails for an effectively-static ID in an each block", () => {
+        expectError('Duplicate ID `item-` found. IDs must be unique within a document.')
+
+        assertOffenses(dedent`
+          <% items.each do |item| %>
+            <div id="item-<% 'static' %>"></div>
+          <% end %>
+        `)
+      })
+
+      test.todo("fails for a static ID in an each block nested in an if branch", () => {
+        expectError('Duplicate ID `item` found. IDs must be unique within a document.')
+
+        assertOffenses(dedent`
+          <% if condition %>
+            <% items.each do |item| %>
+              <div id="item"></div>
+            <% end %>
+          <% end %>
+        `)
+      })
+
+      test.todo("fails for a static ID in nested each blocks", () => {
+        expectError('Duplicate ID `item` found. IDs must be unique within a document.')
+
+        assertOffenses(dedent`
+          <% groups.each do |group| %>
+            <% group.items.each do |item| %>
+              <div id="item"></div>
+            <% end %>
+          <% end %>
+        `)
+      })
+
+      test.todo("fails for a static ID in an each block inside a <template>", () => {
+        expectError('Duplicate ID `item` found. IDs must be unique within a document.')
+
+        assertOffenses(dedent`
+          <template>
+            <% items.each do |item| %>
+              <div id="item"></div>
+            <% end %>
+          </template>
+        `)
+      })
+    })
+
+    describe("IDs that do not vary with the block argument", () => {
+      test.todo("fails for a dynamic ID that never references the block argument", () => {
+        expectError('Duplicate ID `item-<%= unrelated.id %>` found. IDs must be unique within a document.')
+
+        assertOffenses(dedent`
+          <% items.each do |item| %>
+            <div id="item-<%= unrelated.id %>"></div>
+          <% end %>
+        `)
+      })
+
+      test("passes for a dynamic ID that references the block argument", () => {
+        expectNoOffenses(dedent`
+          <% items.each do |item| %>
+            <div id="item-<%= item.id %>"></div>
+          <% end %>
+        `)
+      })
+
+      test("passes for a dynamic ID referencing a nested block argument", () => {
+        expectNoOffenses(dedent`
+          <% groups.each do |group| %>
+            <% group.items.each do |item| %>
+              <div id="item-<%= group.id %>-<%= item.id %>"></div>
+            <% end %>
+          <% end %>
+        `)
+      })
+    })
+
+    describe("regression guard: duplicates within one iteration", () => {
+      test.todo("still reports a duplicate dynamic ID within one each iteration", () => {
+        expectHint('Potential duplicate ID `item-<%= item.id %>` found within the same loop iteration. If this expression evaluates to the same value, IDs must be unique.')
+
+        assertOffenses(dedent`
+          <% items.each do |item| %>
+            <div id="item-<%= item.id %>"></div>
+            <span id="item-<%= item.id %>"></span>
+          <% end %>
+        `)
+      })
+
+      test.todo("still reports a duplicate dynamic ID within one each iteration inside a <template>", () => {
+        expectHint('Potential duplicate ID `item-<%= item.id %>` found within the same loop iteration. If this expression evaluates to the same value, IDs must be unique.')
+
+        assertOffenses(dedent`
+          <template>
+            <% items.each do |item| %>
+              <div id="item-<%= item.id %>"></div>
+              <span id="item-<%= item.id %>"></span>
+            <% end %>
+          </template>
+        `)
+      })
+
+      test.todo("keeps separate each blocks independent once they are loops", () => {
+        expectNoOffenses(dedent`
+          <% first.each do |item| %>
+            <div id="item-<%= item.id %>"></div>
+          <% end %>
+
+          <% second.each do |item| %>
+            <div id="item-<%= item.id %>"></div>
+          <% end %>
+        `)
+      })
+    })
+  })
 })

--- a/javascript/packages/linter/test/rules/html-no-duplicate-ids.test.ts
+++ b/javascript/packages/linter/test/rules/html-no-duplicate-ids.test.ts
@@ -3,7 +3,7 @@ import { describe, test } from "vitest"
 import { HTMLNoDuplicateIdsRule } from "../../src/rules/html-no-duplicate-ids.js"
 import { createLinterTest } from "../helpers/linter-test-helper.js"
 
-const { expectNoOffenses, expectError, assertOffenses } = createLinterTest(HTMLNoDuplicateIdsRule)
+const { expectNoOffenses, expectError, expectHint, assertOffenses } = createLinterTest(HTMLNoDuplicateIdsRule)
 
 describe("html-no-duplicate-ids", () => {
   test("passes for unique IDs", () => {
@@ -31,9 +31,9 @@ describe("html-no-duplicate-ids", () => {
     expectNoOffenses(`<div id="<%= user.id %>"></div>`)
   })
 
-  // TODO: this should also warn if it's in the same "context"
-  test.todo("fails for multiple duplicate IDs in ERB in the same context", () => {
-    expectError('Duplicate ID `<%= user.id %>` found. IDs must be unique within a document.')
+  test("hints for multiple duplicate IDs in ERB in the same context", () => {
+    expectHint('Potential duplicate ID `<%= user.id %>` found. If this expression evaluates to the same value, IDs must be unique within a document.')
+
     assertOffenses(`<div id="<%= user.id %>"></div><span id="<%= user.id %>"></span>`)
   })
 
@@ -273,8 +273,8 @@ describe("html-no-duplicate-ids", () => {
     `)
   })
 
-  test("fails for duplicate output ERB IDs within same conditional branch", () => {
-    expectError('Duplicate ID `user-<%= user.id %>` found within the same control flow branch. IDs must be unique within the same control flow branch.')
+  test("hints for duplicate output ERB IDs within same conditional branch", () => {
+    expectHint('Potential duplicate ID `user-<%= user.id %>` found within the same control flow branch. If this expression evaluates to the same value, IDs must be unique.')
     assertOffenses(dedent`
       <% if condition %>
         <div id="user-<%= user.id %>">User A</div>
@@ -333,8 +333,34 @@ describe("html-no-duplicate-ids", () => {
     `)
   })
 
-  test("fails for duplicate dynamic IDs within same block", () => {
-    expectError('Duplicate ID `item-<%= item.id %>` found within the same control flow branch. IDs must be unique within the same control flow branch.')
+  test("passes for bare output ERB ID reusing the same loop variable in separate each blocks (issue #481)", () => {
+    expectNoOffenses(dedent`
+      <% good, bad = (1..10).partition { rand > 0.5 } %>
+
+      <% good.each do |i| %>
+        <p id="<%= i %>"><%= i %></p>
+      <% end %>
+
+      <% bad.each do |i| %>
+        <p id="<%= i %>"><%= i %></p>
+      <% end %>
+    `)
+  })
+
+  test("passes for bare output ERB ID reusing the same variable in separate for loops (issue #481)", () => {
+    expectNoOffenses(dedent`
+      <% for i in good %>
+        <p id="<%= i %>"><%= i %></p>
+      <% end %>
+
+      <% for i in bad %>
+        <p id="<%= i %>"><%= i %></p>
+      <% end %>
+    `)
+  })
+
+  test("hints for duplicate dynamic IDs within same block", () => {
+    expectHint('Potential duplicate ID `item-<%= item.id %>` found within the same control flow branch. If this expression evaluates to the same value, IDs must be unique.')
 
     assertOffenses(dedent`
       <% items.each do |item| %>


### PR DESCRIPTION
This pull request updates the `html-no-duplicate-ids` rule to stop reporting duplicates it can't actually prove, and to treat `<template>` contents as their own document fragment.

#### Dynamic IDs can't be statically proven to collide

The rule compares the *source text* of `id` attributes. For a dynamic ID that isn't enough to conclude anything, because the same expression can evaluate to a different value on each output, a non-idempotent method, a counter, or a variable reassigned between the two outputs:

```erb
<p id="<%= i %>"></p>
<% i = i.succ %>
<p id="<%= i %>"></p>
```

Reporting that as an `error` overclaims certainty. Any `id` containing an ERB output expression is now reported as a `hint`, worded as a *potential* duplicate:

```diff
- [error] Duplicate ID `<%= user.id %>` found. IDs must be unique within a document.
+ [hint]  Potential duplicate ID `<%= user.id %>` found. If this expression evaluates to the same value, IDs must be unique within a document.
```

Static IDs are unaffected: two identical static IDs are unconditionally a duplicate, so they keep the rule's configured `severity` (default `error`). Hints don't fail a lint run unless you opt into `failLevel: hint`, which is how you can still enforce potential duplicates in CI when you know your IDs are deterministic.

The specific report in #481, the same loop variable reused across separate blocks, was already fixed by #1299 and is now locked in with regression tests:

```erb
<% good, bad = (1..10).partition { rand > 0.5 } %>

<% good.each do |i| %>
  <p id="<%= i %>"><%= i %></p>
<% end %>

<% bad.each do |i| %>
  <p id="<%= i %>"><%= i %></p>
<% end %>
```

#### `<template>` contents get their own ID context

A `<template>` is an inert document fragment: its contents only enter the document once the template is cloned or inflated, so IDs inside one shouldn't compete with IDs elsewhere.

Rather than skipping template contents outright, each `<template>` body now gets its **own** ID context, which keeps the genuine collisions reportable. Cloning a template materializes all of its contents at once, so IDs repeated *within* one template are still a real duplicate. The template's open and close tags are visited in the outer context, so the element's own `id` still belongs to the surrounding document.


```erb
<div id="thing">Rendered on load</div>

<template id="thing-template">
  <div id="thing"></div>
</template>
```

```erb
<template>
  <div id="thing">One</div>
  <div id="thing">Two</div> <%# duplicate `thing` %>
</template>
```

Resolves https://github.com/marcoroth/herb/issues/481
Resolves https://github.com/marcoroth/herb/issues/1728