### PR TITLE
Linter: Skip `html-input-require-autocomplete` for disabled inputs

### DIFF
--- a/javascript/packages/linter/docs/rules/html-input-require-autocomplete.md
+++ b/javascript/packages/linter/docs/rules/html-input-require-autocomplete.md
@@ -13,6 +13,8 @@ The HTML `autocomplete` attribute helps users complete forms by using data store
 
 If you prefer not to specify a specific autocomplete value, use `autocomplete="on"` to enable browser defaults or `autocomplete="off"` to explicitly disable it.
 
+Inputs with a `disabled` attribute are exempt from this rule. Disabled inputs are never autofilled, so an `autocomplete` attribute doesn't improve accessibility for them. Adding `autocomplete="off"` can even change behavior in some browsers compared to omitting the attribute entirely.
+
 ## Affected Input Types
 
 This rule applies to the following input types:
@@ -43,6 +45,8 @@ This rule applies to the following input types:
 <input type="url" autocomplete="off">
 
 <input type="password" autocomplete="on">
+
+<input type="email" disabled>
 ```
 
 

--- a/javascript/packages/linter/src/rules/html-input-require-autocomplete.ts
+++ b/javascript/packages/linter/src/rules/html-input-require-autocomplete.ts
@@ -1,4 +1,4 @@
-import { getTagLocalName, getStaticAttributeValue, getAttribute, getAttributeValue } from "@herb-tools/core"
+import { getTagLocalName, getStaticAttributeValue, getAttribute, getAttributeValue, hasAttribute } from "@herb-tools/core"
 import { BaseRuleVisitor } from "./rule-utils.js"
 import { ParserRule } from "../types.js"
 
@@ -29,6 +29,8 @@ class HTMLInputRequireAutocompleteVisitor extends BaseRuleVisitor {
 
   private checkInputTag(node: HTMLOpenTagNode): void {
     if (!this.isInputTag(node) || this.hasAutocomplete(node)) return
+
+    if (hasAttribute(node, "disabled")) return
 
     const typeValue = getStaticAttributeValue(node, "type")
     if (!typeValue) return

--- a/javascript/packages/linter/test/rules/html-input-require-autocomplete.test.ts
+++ b/javascript/packages/linter/test/rules/html-input-require-autocomplete.test.ts
@@ -28,6 +28,24 @@ describe("HTMLInputRequireAutocompleteRule", () => {
     `)
   })
 
+  test("when input is disabled", () => {
+    expectNoOffenses(dedent`
+      <input type="email" disabled>
+    `)
+  })
+
+  test("when input is disabled with a value", () => {
+    expectNoOffenses(dedent`
+      <input type="email" disabled="disabled">
+    `)
+  })
+
+  test("when input is dynamically disabled", () => {
+    expectNoOffenses(dedent`
+      <input type="email" disabled="<%= disabled? %>">
+    `)
+  })
+
   describe.todo("Action View Helpers", () => {
     const formHelpersRequiringAutocomplete = [
       'date_field_tag',


### PR DESCRIPTION
This pull request updates the `html-input-require-autocomplete` rule to skip `<input>` elements that carry a `disabled` attribute.

Disabled inputs are never autofilled by the browser, so an `autocomplete` attribute on them doesn't improve accessibility, which is what the rule's message claims it does. 

The check now bails out before reporting when the tag has a `disabled` attribute:

no longer reported:
```html+erb
<input type="email" disabled>
<input type="email" disabled="disabled">
<input type="email" disabled="<%= disabled? %>">
```

still reported:
```html+erb
<input type="email">
```

Resolves https://github.com/marcoroth/herb/issues/1727