### PR TITLE
CI: Improve timeout handling in corpus check

### DIFF
--- a/.github/workflows/corpus.yml
+++ b/.github/workflows/corpus.yml
@@ -113,7 +113,7 @@ jobs:
             --fail-on-regression | tee comparison.txt
 
       - name: Comment on the pull request
-        if: failure() && github.event_name == 'pull_request' && hashFiles('comment.md') != ''
+        if: (!cancelled()) && github.event_name == 'pull_request' && hashFiles('comment.md') != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NUMBER: ${{ github.event.pull_request.number }}
@@ -124,6 +124,8 @@ jobs:
           if [ -n "$existing" ]; then
             gh api -X PATCH "repos/${{ github.repository }}/issues/comments/$existing" -F body=@comment.md >/dev/null
             echo "Updated comment $existing."
+          elif grep -q "<!-- corpus-no-changes -->" comment.md; then
+            echo "No outcome changes; not posting a comment."
           else
             gh pr comment "$NUMBER" --body-file comment.md
             echo "Posted a new comment."

--- a/lib/herb/cli.rb
+++ b/lib/herb/cli.rb
@@ -8,7 +8,7 @@ require "optparse"
 class Herb::CLI
   include Herb::Colors
 
-  attr_accessor :json, :silent, :log_file, :no_timing, :local, :escape, :no_escape, :freeze, :debug, :tool, :strict, :analyze, :track_whitespace, :verbose, :isolate, :arena_stats, :leak_check, :action_view_helpers, :trim, :optimize
+  attr_accessor :json, :silent, :log_file, :no_timing, :local, :escape, :no_escape, :freeze, :debug, :tool, :strict, :analyze, :track_whitespace, :verbose, :isolate, :arena_stats, :leak_check, :action_view_helpers, :trim, :optimize, :file_timeout
 
   def initialize(args)
     @args = args
@@ -154,6 +154,7 @@ class Herb::CLI
                   project.silent = silent
                   project.verbose = verbose || ci?
                   project.isolate = isolate
+                  project.file_timeout = file_timeout if file_timeout
                   project.validate_ruby = true
                   project.arena_stats = arena_stats
                   project.leak_check = leak_check
@@ -267,6 +268,10 @@ class Herb::CLI
 
       parser.on("--isolate", "Fork each file into its own process for crash isolation (slower)") do
         self.isolate = true
+      end
+
+      parser.on("--timeout SECONDS", Float, "Per-file timeout for parse + compile (for analyze command) (default: #{Herb::Project::DEFAULT_FILE_TIMEOUT})") do |seconds|
+        self.file_timeout = seconds
       end
 
       parser.on("--log-file", "Enable log file generation") do

--- a/lib/herb/project.rb
+++ b/lib/herb/project.rb
@@ -12,7 +12,9 @@ module Herb
   class Project
     include Colors
 
-    attr_accessor :project_path, :output_file, :no_log_file, :no_timing, :silent, :verbose, :isolate, :validate_ruby, :file_paths, :arena_stats, :leak_check
+    attr_accessor :project_path, :output_file, :no_log_file, :no_timing, :silent, :verbose, :isolate, :validate_ruby, :file_paths, :arena_stats, :leak_check, :file_timeout
+
+    DEFAULT_FILE_TIMEOUT = 1 # seconds per file for parse + compile
 
     # Known error types that indicate issues in the user's template, not bugs in the parser.
     TEMPLATE_ERRORS = [
@@ -126,6 +128,7 @@ module Herb
 
       date = Time.now.strftime("%Y-%m-%d_%H-%M-%S")
       @output_file = output_file || "#{date}_erb_parsing_result_#{@project_path.basename}.log"
+      @file_timeout = DEFAULT_FILE_TIMEOUT
     end
 
     def configuration
@@ -354,7 +357,7 @@ module Herb
         result[:leak_check] = capture_leak_check(file_content)
       end
 
-      Timeout.timeout(1) do
+      Timeout.timeout(file_timeout) do
         parse_result = Herb.parse(file_content)
 
         if parse_result.failed?
@@ -369,7 +372,7 @@ module Herb
       result
     rescue Timeout::Error
       result.merge(status: :timeout, file_content: file_content,
-                   log: "⏱️ Parsing #{file_path} timed out after 1 second")
+                   log: "⏱️ Parsing #{file_path} timed out after #{file_timeout} #{pluralize(file_timeout, "second")}")
     rescue StandardError => e
       file_content ||= begin
         File.read(file_path)
@@ -388,7 +391,7 @@ module Herb
       stdout_file = Tempfile.new("stdout")
       stderr_file = Tempfile.new("stderr")
 
-      Timeout.timeout(1) do
+      Timeout.timeout(file_timeout) do
         pid = Process.fork do
           $stdout.reopen(stdout_file.path, "w")
           $stderr.reopen(stderr_file.path, "w")
@@ -431,7 +434,7 @@ module Herb
         nil
       end
 
-      { file_path: file_path, status: :timeout, file_content: file_content, log: "⏱️ Parsing #{file_path} timed out after 1 second" }
+      { file_path: file_path, status: :timeout, file_content: file_content, log: "⏱️ Parsing #{file_path} timed out after #{file_timeout} #{pluralize(file_timeout, "second")}" }
     rescue StandardError => e
       file_content ||= begin
         File.read(file_path)


### PR DESCRIPTION
This pull request adds a `file_timeout` option to `Herb::Project` and a `--timeout` flag to `herb analyze` which replaces the hard-coded 1-second per-file timeout.

`Herb::Project` wraps each file's processing in `Timeout.timeout(1)`. That window covers much more than parsing: for a file with validation errors, it includes up to three full `Herb::Engine` compilations (default, `validation_mode: :none` retry, `strict: false` retry), Ruby validation, and error overlay rendering. 