### PR TITLE
Linter: Improve `html-no-space-in-tag` rule

### DIFF
--- a/javascript/packages/linter/docs/rules/html-no-space-in-tag.md
+++ b/javascript/packages/linter/docs/rules/html-no-space-in-tag.md
@@ -5,12 +5,15 @@
 ## Description
 
 Enforce consistent spacing within HTML opening and closing tags. This rule ensures:
-- Exactly one space between tag name and first attribute
-- Exactly one space between attributes
+- Exactly one space between the tag name and the first attribute on the same line
+- Exactly one space between attributes on the same line
 - No extra spaces before the closing `>` in non-self-closing tags
 - Exactly one space before `/>` in self-closing tags
 - No whitespace in closing tags (e.g., `</div>`)
-- Consistent indentation in multiline tags
+- No blank lines inside a multiline tag
+- The closing `>`/`/>`, when placed on its own line, aligned with the opening tag
+
+The indentation of attribute lines in a multiline tag is intentionally **not** enforced by this rule — attributes may be aligned or hanging-indented as you prefer, and normalizing indentation is left to the formatter.
 
 ## Rationale
 
@@ -37,6 +40,11 @@ Self-closing tags (`<img />`, `<br />`) should have exactly one space before the
 >
   foo
 </div>
+
+<div class="foo"
+     data-x="bar">
+  foo
+</div>
 ```
 
 ### 🚫 Bad
@@ -46,14 +54,18 @@ Self-closing tags (`<img />`, `<br />`) should have exactly one space before the
 
 <div class="foo" ></div>
 
-<img alt="Logo" src="/logo.png">
-
 <div class="foo"      data-x="bar"></div>
 
 <div
-   class="foo"
-    data-x="bar"
+
+  class="foo"
 >
+  foo
+</div>
+
+<div
+  class="foo"
+  >
   foo
 </div>
 

--- a/javascript/packages/linter/src/rules/html-no-space-in-tag.ts
+++ b/javascript/packages/linter/src/rules/html-no-space-in-tag.ts
@@ -78,10 +78,14 @@ class HTMLNoSpaceInTagVisitor extends BaseRuleVisitor<HTMLNoSpaceInTagAutofixCon
   }
 
   private checkMultilineTag(node: HTMLOpenTagNode): void {
-    const whitespaceNodes = filterWhitespaceNodes(node.children)
+    const { children, tag_closing } = node
+    const isSelfClosing = tag_closing ? this.isSelfClosing(tag_closing) : false
+    const whitespaceNodes = filterWhitespaceNodes(children)
+    const lastChild = children[children.length - 1]
+
     let previousWhitespace: WhitespaceNode | null = null
 
-    whitespaceNodes.forEach((whitespace, index) => {
+    whitespaceNodes.forEach((whitespace) => {
       const content = this.getWhitespaceContent(whitespace)
       if (!content) return
 
@@ -93,11 +97,46 @@ class HTMLNoSpaceInTagVisitor extends BaseRuleVisitor<HTMLNoSpaceInTagAutofixCon
       }
 
       if (this.isNonNewlineWhitespace(content)) {
-        this.checkIndentation(whitespace, index, whitespaceNodes.length, node)
+        const isLineLeading = previousWhitespace ? this.containsNewline(previousWhitespace) : false
+        const isLastChild = whitespace === lastChild
+
+        if (isLineLeading) {
+          if (isLastChild) {
+            this.checkClosingBracketIndentation(whitespace, node)
+          }
+        } else {
+          this.checkInlineWhitespace(whitespace, content, isLastChild, isSelfClosing)
+        }
       }
 
       previousWhitespace = whitespace
     })
+  }
+
+  private checkClosingBracketIndentation(whitespace: WhitespaceNode, node: HTMLOpenTagNode): void {
+    if (whitespace.location.end.column === node.location.start.column) return
+
+    this.addOffense(MESSAGES.EXTRA_SPACE_NO_SPACE, whitespace.location, { node: whitespace, message: MESSAGES.EXTRA_SPACE_NO_SPACE })
+  }
+
+  private checkInlineWhitespace(whitespace: WhitespaceNode, content: string, isLastChild: boolean, isSelfClosing: boolean): void {
+    if (isLastChild) {
+      if (isSelfClosing) {
+        if (content !== ' ') {
+          this.addOffense(MESSAGES.EXTRA_SPACE_SINGLE_SPACE, whitespace.location, { node: whitespace, message: MESSAGES.EXTRA_SPACE_SINGLE_SPACE })
+        }
+
+        return
+      }
+
+      this.addOffense(MESSAGES.EXTRA_SPACE_NO_SPACE, whitespace.location, { node: whitespace, message: MESSAGES.EXTRA_SPACE_NO_SPACE })
+
+      return
+    }
+
+    if (content.length > 1) {
+      this.addOffense(MESSAGES.EXTRA_SPACE_SINGLE_SPACE, whitespace.location, { node: whitespace, message: MESSAGES.EXTRA_SPACE_SINGLE_SPACE })
+    }
   }
 
   private hasConsecutiveNewlines(content: string, previousWhitespace: WhitespaceNode | null): boolean {
@@ -113,13 +152,8 @@ class HTMLNoSpaceInTagVisitor extends BaseRuleVisitor<HTMLNoSpaceInTagAutofixCon
     return !content.includes("\n")
   }
 
-  private checkIndentation(whitespace: WhitespaceNode, index: number, totalWhitespaceNodes: number, node: HTMLOpenTagNode): void {
-    const isLastWhitespace = index === totalWhitespaceNodes - 1
-    const expectedIndent = isLastWhitespace ? node.location.start.column : node.location.start.column + 2
-
-    if (whitespace.location.end.column === expectedIndent) return
-
-    this.addOffense(MESSAGES.EXTRA_SPACE_NO_SPACE, whitespace.location, { node: whitespace, message: MESSAGES.EXTRA_SPACE_NO_SPACE })
+  private containsNewline(whitespace: WhitespaceNode): boolean {
+    return whitespace.value?.value?.includes("\n") ?? false
   }
 
   private isSelfClosing(tag_closing: Token): boolean {
@@ -142,8 +176,7 @@ class HTMLNoSpaceInTagVisitor extends BaseRuleVisitor<HTMLNoSpaceInTagAutofixCon
 }
 
 export class HTMLNoSpaceInTagRule extends ParserRule<HTMLNoSpaceInTagAutofixContext> {
-  // TODO: enable and fix autofix
-  static autocorrectable = false
+  static autocorrectable = true
   static ruleName = "html-no-space-in-tag"
   static introducedIn = this.version("0.8.0")
 
@@ -181,17 +214,19 @@ export class HTMLNoSpaceInTagRule extends ParserRule<HTMLNoSpaceInTagAutofixCont
 
     switch (message) {
       case MESSAGES.EXTRA_SPACE_NO_SPACE: {
-        let selfClosing = false
-        let beginningOfLine = false
-
         const parent = findParent(result.value, node)
+        const parentTag = parent && isHTMLOpenTagNode(parent) ? parent : null
+        const beginningOfLine = node.location.start.column === 0
 
-        if (parent && isHTMLOpenTagNode(parent)) {
-          selfClosing = parent.tag_closing?.value === "/>"
-          beginningOfLine = node.location.start.column === 0
+        if (parentTag && beginningOfLine) {
+          whitespaceNode.value.value = " ".repeat(parentTag.location.start.column)
+
+          return result
         }
 
-        whitespaceNode.value.value = selfClosing && !beginningOfLine ? " " : ""
+        const selfClosing = parentTag?.tag_closing?.value === "/>"
+
+        whitespaceNode.value.value = selfClosing ? " " : ""
 
         return result
       }

--- a/javascript/packages/linter/src/rules/html-no-space-in-tag.ts
+++ b/javascript/packages/linter/src/rules/html-no-space-in-tag.ts
@@ -178,11 +178,12 @@ class HTMLNoSpaceInTagVisitor extends BaseRuleVisitor<HTMLNoSpaceInTagAutofixCon
 export class HTMLNoSpaceInTagRule extends ParserRule<HTMLNoSpaceInTagAutofixContext> {
   static autocorrectable = true
   static ruleName = "html-no-space-in-tag"
-  static introducedIn = this.version("0.8.0")
+  // Initially introduced in 0.8.0 (#559)
+  static introducedIn = this.version("unreleased")
 
   get defaultConfig(): FullRuleConfig {
     return {
-      enabled: false,
+      enabled: true,
       severity: "error"
     }
   }

--- a/javascript/packages/linter/src/rules/html-no-space-in-tag.ts
+++ b/javascript/packages/linter/src/rules/html-no-space-in-tag.ts
@@ -80,20 +80,30 @@ class HTMLNoSpaceInTagVisitor extends BaseRuleVisitor<HTMLNoSpaceInTagAutofixCon
   private checkMultilineTag(node: HTMLOpenTagNode): void {
     const { children, tag_closing } = node
     const isSelfClosing = tag_closing ? this.isSelfClosing(tag_closing) : false
-    const whitespaceNodes = filterWhitespaceNodes(children)
     const lastChild = children[children.length - 1]
 
     let previousWhitespace: WhitespaceNode | null = null
 
-    whitespaceNodes.forEach((whitespace) => {
+    for (const child of children) {
+      if (!isWhitespaceNode(child)) {
+        previousWhitespace = null
+
+        continue
+      }
+
+      const whitespace = child as WhitespaceNode
       const content = this.getWhitespaceContent(whitespace)
-      if (!content) return
+      if (!content) {
+        previousWhitespace = whitespace
+
+        continue
+      }
 
       if (this.hasConsecutiveNewlines(content, previousWhitespace)) {
         this.addOffense(MESSAGES.EXTRA_SPACE_SINGLE_BREAK, whitespace.location, { node: whitespace, message: MESSAGES.EXTRA_SPACE_SINGLE_BREAK })
         previousWhitespace = whitespace
 
-        return
+        continue
       }
 
       if (this.isNonNewlineWhitespace(content)) {
@@ -110,7 +120,7 @@ class HTMLNoSpaceInTagVisitor extends BaseRuleVisitor<HTMLNoSpaceInTagAutofixCon
       }
 
       previousWhitespace = whitespace
-    })
+    }
   }
 
   private checkClosingBracketIndentation(whitespace: WhitespaceNode, node: HTMLOpenTagNode): void {

--- a/javascript/packages/linter/test/__snapshots__/cli.test.ts.snap
+++ b/javascript/packages/linter/test/__snapshots__/cli.test.ts.snap
@@ -111,7 +111,7 @@ test/fixtures/ignored.html.erb:8:8
   Offenses     5 errors | 2 warnings (7 offenses across 1 file)
   Note         3 additional offenses reported (would have been ignored)
   Fixable      7 offenses | 4 autocorrectable using \`--fix\`
-  Rules        83 enabled | 16 not enabled"
+  Rules        84 enabled | 15 not enabled"
 `;
 
 exports[`CLI Output Formatting > Excluded Files > skips excluded file in subdirectory with README.md project indicator 1`] = `
@@ -177,7 +177,7 @@ test/fixtures/test-file-with-errors.html.erb:2:22
   Checked      1 file
   Offenses     2 errors | 1 warning (3 offenses across 1 file)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        83 enabled | 16 not enabled"
+  Rules        84 enabled | 15 not enabled"
 `;
 
 exports[`CLI Output Formatting > GitHub Actions format includes rule codes 1`] = `
@@ -202,7 +202,7 @@ test/fixtures/no-trailing-newline.html.erb:1:29
   Checked      1 file
   Offenses     1 error | 0 warnings (1 offense across 1 file)
   Fixable      1 offense | 1 autocorrectable using \`--fix\`
-  Rules        83 enabled | 16 not enabled"
+  Rules        84 enabled | 15 not enabled"
 `;
 
 exports[`CLI Output Formatting > GitHub Actions format includes rule codes 2`] = `
@@ -266,7 +266,7 @@ test/fixtures/erb-no-extra-whitespace-inside-tags.html.erb:1:4
   Checked      1 file
   Offenses     4 errors | 0 warnings (4 offenses across 1 file)
   Fixable      4 offenses | 3 autocorrectable using \`--fix\`
-  Rules        83 enabled | 16 not enabled"
+  Rules        84 enabled | 15 not enabled"
 `;
 
 exports[`CLI Output Formatting > Ignores disabled rules 1`] = `
@@ -307,7 +307,7 @@ test/fixtures/ignored.html.erb:6:14
   Checked      1 file
   Offenses     2 errors | 0 warnings | 3 ignored (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        83 enabled | 16 not enabled"
+  Rules        84 enabled | 15 not enabled"
 `;
 
 exports[`CLI Output Formatting > allows tag.attributes in attribute position 1`] = `
@@ -346,7 +346,7 @@ test/fixtures/tag-attributes.html.erb:5:0
   Checked      1 file
   Offenses     2 warnings (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        83 enabled | 16 not enabled"
+  Rules        84 enabled | 15 not enabled"
 `;
 
 exports[`CLI Output Formatting > diplays only parsers errors if one is present 1`] = `
@@ -372,7 +372,7 @@ test/fixtures/parser-errors.html.erb:2:16
   Checked      1 file
   Offenses     1 error | 0 warnings (1 offense across 1 file)
   Fixable      0 offenses
-  Rules        83 enabled | 16 not enabled"
+  Rules        84 enabled | 15 not enabled"
 `;
 
 exports[`CLI Output Formatting > displays most violated rules with multiple offenses 1`] = `
@@ -587,7 +587,7 @@ test/fixtures/multiple-rule-offenses.html.erb:4:7
   Checked      1 file
   Offenses     8 errors | 6 warnings (14 offenses across 1 file)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        83 enabled | 16 not enabled"
+  Rules        84 enabled | 15 not enabled"
 `;
 
 exports[`CLI Output Formatting > displays rule offenses when showing all rules 1`] = `
@@ -684,7 +684,7 @@ test/fixtures/few-rule-offenses.html.erb:6:0
   Checked      1 file
   Offenses     4 errors | 2 warnings (6 offenses across 1 file)
   Fixable      6 offenses | 3 autocorrectable using \`--fix\`
-  Rules        83 enabled | 16 not enabled"
+  Rules        84 enabled | 15 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats GitHub Actions output correctly for bad file 1`] = `
@@ -723,7 +723,7 @@ test/fixtures/bad-file.html.erb:1:16
   Checked      1 file
   Offenses     2 errors | 0 warnings (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        83 enabled | 16 not enabled"
+  Rules        84 enabled | 15 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats GitHub Actions output correctly for clean file 1`] = `
@@ -735,7 +735,7 @@ exports[`CLI Output Formatting > formats GitHub Actions output correctly for cle
   Checked      1 file
   Offenses     0 offenses
   Fixable      0 offenses
-  Rules        83 enabled | 16 not enabled"
+  Rules        84 enabled | 15 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats GitHub Actions output correctly for file with errors 1`] = `
@@ -795,7 +795,7 @@ test/fixtures/test-file-with-errors.html.erb:2:22
   Checked      1 file
   Offenses     2 errors | 1 warning (3 offenses across 1 file)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        83 enabled | 16 not enabled"
+  Rules        84 enabled | 15 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats GitHub Actions output with --format=github option 1`] = `
@@ -834,7 +834,7 @@ test/fixtures/test-file-simple.html.erb:2:22
   Checked      1 file
   Offenses     2 errors | 0 warnings (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        83 enabled | 16 not enabled"
+  Rules        84 enabled | 15 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats JSON output correctly for bad file 1`] = `
@@ -881,7 +881,7 @@ exports[`CLI Output Formatting > formats JSON output correctly for bad file 1`] 
   "summary": {
     "filesChecked": 1,
     "filesWithOffenses": 1,
-    "ruleCount": 83,
+    "ruleCount": 84,
     "totalErrors": 2,
     "totalHints": 0,
     "totalIgnored": 0,
@@ -902,7 +902,7 @@ exports[`CLI Output Formatting > formats JSON output correctly for clean file 1`
   "summary": {
     "filesChecked": 1,
     "filesWithOffenses": 0,
-    "ruleCount": 83,
+    "ruleCount": 84,
     "totalErrors": 0,
     "totalHints": 0,
     "totalIgnored": 0,
@@ -975,7 +975,7 @@ exports[`CLI Output Formatting > formats JSON output correctly for file with err
   "summary": {
     "filesChecked": 1,
     "filesWithOffenses": 1,
-    "ruleCount": 83,
+    "ruleCount": 84,
     "totalErrors": 2,
     "totalHints": 0,
     "totalIgnored": 0,
@@ -1038,7 +1038,7 @@ test/fixtures/test-file-with-errors.html.erb:2:22
   Checked      1 file
   Offenses     2 errors | 1 warning (3 offenses across 1 file)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        83 enabled | 16 not enabled"
+  Rules        84 enabled | 15 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats simple output correctly 1`] = `
@@ -1057,7 +1057,7 @@ test/fixtures/test-file-simple.html.erb:
   Checked      1 file
   Offenses     2 errors | 0 warnings (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        83 enabled | 16 not enabled"
+  Rules        84 enabled | 15 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats simple output for bad-file correctly 1`] = `
@@ -1076,7 +1076,7 @@ test/fixtures/bad-file.html.erb:
   Checked      1 file
   Offenses     2 errors | 0 warnings (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        83 enabled | 16 not enabled"
+  Rules        84 enabled | 15 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats success output correctly 1`] = `
@@ -1088,7 +1088,7 @@ exports[`CLI Output Formatting > formats success output correctly 1`] = `
   Checked      1 file
   Offenses     0 offenses
   Fixable      0 offenses
-  Rules        83 enabled | 16 not enabled"
+  Rules        84 enabled | 15 not enabled"
 `;
 
 exports[`CLI Output Formatting > handles boolean attributes 1`] = `
@@ -1100,7 +1100,7 @@ exports[`CLI Output Formatting > handles boolean attributes 1`] = `
   Checked      1 file
   Offenses     0 offenses
   Fixable      0 offenses
-  Rules        83 enabled | 16 not enabled"
+  Rules        84 enabled | 15 not enabled"
 `;
 
 exports[`CLI Output Formatting > handles multiple errors correctly 1`] = `
@@ -1135,7 +1135,7 @@ test/fixtures/bad-file.html.erb:1:16
   Checked      1 file
   Offenses     2 errors | 0 warnings (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        83 enabled | 16 not enabled"
+  Rules        84 enabled | 15 not enabled"
 `;
 
 exports[`CLI Output Formatting > herb:disable rules 1`] = `
@@ -1267,7 +1267,7 @@ test/fixtures/disabled-1.html.erb:14:19
   Checked      1 file
   Offenses     2 errors | 6 warnings | 8 ignored (8 offenses across 1 file)
   Fixable      8 offenses | 1 autocorrectable using \`--fix\`
-  Rules        83 enabled | 16 not enabled"
+  Rules        84 enabled | 15 not enabled"
 `;
 
 exports[`CLI Output Formatting > herb:disable rules 2`] = `
@@ -1470,7 +1470,7 @@ test/fixtures/disabled-2.html.erb:2:44
   Checked      1 file
   Offenses     6 errors | 7 warnings | 5 ignored (13 offenses across 1 file)
   Fixable      13 offenses | 6 autocorrectable using \`--fix\`
-  Rules        83 enabled | 16 not enabled"
+  Rules        84 enabled | 15 not enabled"
 `;
 
 exports[`CLI Output Formatting > uses GitHub Actions format by default when GITHUB_ACTIONS is true 1`] = `
@@ -1530,5 +1530,5 @@ test/fixtures/test-file-with-errors.html.erb:2:22
   Checked      1 file
   Offenses     2 errors | 1 warning (3 offenses across 1 file)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        83 enabled | 16 not enabled"
+  Rules        84 enabled | 15 not enabled"
 `;

--- a/javascript/packages/linter/test/autofix/html-no-space-in-tag.autofix.test.ts
+++ b/javascript/packages/linter/test/autofix/html-no-space-in-tag.autofix.test.ts
@@ -121,6 +121,36 @@ describe("html-no-space-in-tag autofix", () => {
       expect(result.fixed).toHaveLength(0)
       expect(result.unfixed).toHaveLength(0)
     })
+
+    test("does not merge unindented attributes on separate lines", () => {
+      const input = dedent`
+        <a
+        href="https://example.com/path"
+        target="_blank">TOTP</a>
+      `
+
+      const linter = new Linter(Herb, [HTMLNoSpaceInTagRule])
+      const result = linter.autofix(input, { fileName: 'test.html.erb' })
+
+      expect(result.source).toBe(input)
+      expect(result.fixed).toHaveLength(0)
+      expect(result.unfixed).toHaveLength(0)
+    })
+
+    test("does not merge unindented ERB attributes on separate lines", () => {
+      const input = dedent`
+        <div
+        data-base-path="<%= a %>"
+        data-available-locales="<%= b %>">z</div>
+      `
+
+      const linter = new Linter(Herb, [HTMLNoSpaceInTagRule])
+      const result = linter.autofix(input, { fileName: 'test.html.erb' })
+
+      expect(result.source).toBe(input)
+      expect(result.fixed).toHaveLength(0)
+      expect(result.unfixed).toHaveLength(0)
+    })
   })
 
   describe("when no space should be present", () => {
@@ -521,6 +551,27 @@ describe("html-no-space-in-tag autofix", () => {
             type="password"
           />
         </div>
+      `
+
+      const linter = new Linter(Herb, [HTMLNoSpaceInTagRule])
+      const result = linter.autofix(input, { fileName: 'test.html.erb' })
+
+      expect(result.source).toBe(expected)
+      expect(result.fixed).toHaveLength(1)
+      expect(result.unfixed).toHaveLength(0)
+    })
+
+    test("removes a genuine blank line between unindented attributes", () => {
+      const input = dedent`
+        <a
+        href="x"
+
+        target="_blank">y</a>
+      `
+      const expected = dedent`
+        <a
+        href="x"
+        target="_blank">y</a>
       `
 
       const linter = new Linter(Herb, [HTMLNoSpaceInTagRule])

--- a/javascript/packages/linter/test/autofix/html-no-space-in-tag.autofix.test.ts
+++ b/javascript/packages/linter/test/autofix/html-no-space-in-tag.autofix.test.ts
@@ -105,6 +105,22 @@ describe("html-no-space-in-tag autofix", () => {
       expect(result.fixed).toHaveLength(0)
       expect(result.unfixed).toHaveLength(0)
     })
+
+    test("multi line tag with first attribute on the opening line (hanging indent) - #695", () => {
+      const input = dedent`
+        <div data-a="foo"
+             data-b="bar">
+          lorem
+        </div>
+      `
+
+      const linter = new Linter(Herb, [HTMLNoSpaceInTagRule])
+      const result = linter.autofix(input, { fileName: 'test.html.erb' })
+
+      expect(result.source).toBe(input)
+      expect(result.fixed).toHaveLength(0)
+      expect(result.unfixed).toHaveLength(0)
+    })
   })
 
   describe("when no space should be present", () => {
@@ -295,7 +311,7 @@ describe("html-no-space-in-tag autofix", () => {
       const result = linter.autofix(input, { fileName: 'test.html.erb' })
 
       expect(result.source).toBe(expected)
-      expect(result.fixed).toHaveLength(2)
+      expect(result.fixed).toHaveLength(1)
       expect(result.unfixed).toHaveLength(0)
     })
 
@@ -335,7 +351,7 @@ describe("html-no-space-in-tag autofix", () => {
       const result = linter.autofix(input, { fileName: 'test.html.erb' })
 
       expect(result.source).toBe(expected)
-      expect(result.fixed).toHaveLength(2)
+      expect(result.fixed).toHaveLength(1)
       expect(result.unfixed).toHaveLength(0)
     })
 
@@ -404,6 +420,114 @@ describe("html-no-space-in-tag autofix", () => {
 
       expect(result.source).toBe(expected)
       expect(result.fixed).toHaveLength(0)
+      expect(result.unfixed).toHaveLength(0)
+    })
+
+    test("collapses extra space between name and first attribute on the opening line", () => {
+      const input = dedent`
+        <div  data-a="foo"
+          data-b="bar">
+        </div>
+      `
+      const expected = dedent`
+        <div data-a="foo"
+          data-b="bar">
+        </div>
+      `
+
+      const linter = new Linter(Herb, [HTMLNoSpaceInTagRule])
+      const result = linter.autofix(input, { fileName: 'test.html.erb' })
+
+      expect(result.source).toBe(expected)
+      expect(result.fixed).toHaveLength(1)
+      expect(result.unfixed).toHaveLength(0)
+    })
+
+    test("collapses extra space between attributes on a continuation line", () => {
+      const input = dedent`
+        <div
+          data-a="foo"  data-b="bar">
+        </div>
+      `
+      const expected = dedent`
+        <div
+          data-a="foo" data-b="bar">
+        </div>
+      `
+
+      const linter = new Linter(Herb, [HTMLNoSpaceInTagRule])
+      const result = linter.autofix(input, { fileName: 'test.html.erb' })
+
+      expect(result.source).toBe(expected)
+      expect(result.fixed).toHaveLength(1)
+      expect(result.unfixed).toHaveLength(0)
+    })
+
+    test("removes space before the closing bracket on an attribute line", () => {
+      const input = dedent`
+        <div
+          data-a="foo" >
+        </div>
+      `
+      const expected = dedent`
+        <div
+          data-a="foo">
+        </div>
+      `
+
+      const linter = new Linter(Herb, [HTMLNoSpaceInTagRule])
+      const result = linter.autofix(input, { fileName: 'test.html.erb' })
+
+      expect(result.source).toBe(expected)
+      expect(result.fixed).toHaveLength(1)
+      expect(result.unfixed).toHaveLength(0)
+    })
+
+    test("aligns an over-indented closing bracket to the tag column in a nested tag", () => {
+      const input = dedent`
+        <div>
+          <input
+            type="password"
+              >
+        </div>
+      `
+      const expected = dedent`
+        <div>
+          <input
+            type="password"
+          >
+        </div>
+      `
+
+      const linter = new Linter(Herb, [HTMLNoSpaceInTagRule])
+      const result = linter.autofix(input, { fileName: 'test.html.erb' })
+
+      expect(result.source).toBe(expected)
+      expect(result.fixed).toHaveLength(1)
+      expect(result.unfixed).toHaveLength(0)
+    })
+
+    test("aligns an over-indented self-closing bracket to the tag column in a nested tag", () => {
+      const input = dedent`
+        <div>
+          <input
+            type="password"
+              />
+        </div>
+      `
+      const expected = dedent`
+        <div>
+          <input
+            type="password"
+          />
+        </div>
+      `
+
+      const linter = new Linter(Herb, [HTMLNoSpaceInTagRule])
+      const result = linter.autofix(input, { fileName: 'test.html.erb' })
+
+      expect(result.source).toBe(expected)
+      expect(result.fixed).toHaveLength(1)
       expect(result.unfixed).toHaveLength(0)
     })
   })

--- a/javascript/packages/linter/test/rules/html-no-space-in-tag.test.ts
+++ b/javascript/packages/linter/test/rules/html-no-space-in-tag.test.ts
@@ -87,6 +87,22 @@ describe("HTMLNoSpaceInTagRule", () => {
         </div>
       `)
     })
+
+    test("multi line tag with unindented attributes on separate lines", () => {
+      expectNoOffenses(dedent`
+        <a
+        href="https://example.com/path"
+        target="_blank">TOTP</a>
+      `)
+    })
+
+    test("multi line tag with unindented ERB attributes on separate lines", () => {
+      expectNoOffenses(dedent`
+        <div
+        data-base-path="<%= a %>"
+        data-available-locales="<%= b %>">z</div>
+      `)
+    })
   })
 
   describe("when no space should be present", () => {
@@ -223,7 +239,7 @@ describe("HTMLNoSpaceInTagRule", () => {
     })
 
     test("extra space between name and first attribute on the opening line of a multiline tag", () => {
-      expectError("Extra space detected where there should be a single space.")
+      expectError("Extra space detected where there should be a single space.", [1, 4])
 
       assertOffenses(dedent`
         <div  data-a="foo"
@@ -233,7 +249,7 @@ describe("HTMLNoSpaceInTagRule", () => {
     })
 
     test("extra space between attributes on a continuation line", () => {
-      expectError("Extra space detected where there should be a single space.")
+      expectError("Extra space detected where there should be a single space.", [2, 14])
 
       assertOffenses(dedent`
         <div
@@ -243,7 +259,7 @@ describe("HTMLNoSpaceInTagRule", () => {
     })
 
     test("extra space before the closing bracket on an attribute line", () => {
-      expectError("Extra space detected where there should be no space.")
+      expectError("Extra space detected where there should be no space.", [2, 14])
 
       assertOffenses(dedent`
         <div
@@ -253,7 +269,7 @@ describe("HTMLNoSpaceInTagRule", () => {
     })
 
     test("closing bracket over-indented in a nested tag", () => {
-      expectError("Extra space detected where there should be no space.")
+      expectError("Extra space detected where there should be no space.", [4, 0])
 
       assertOffenses(dedent`
         <div>
@@ -261,6 +277,17 @@ describe("HTMLNoSpaceInTagRule", () => {
             type="password"
               >
         </div>
+      `)
+    })
+
+    test("blank line between unindented attributes on separate lines", () => {
+      expectError("Extra space detected where there should be a single space or a single line break.", [3, 0])
+
+      assertOffenses(dedent`
+        <a
+        href="x"
+
+        target="_blank">y</a>
       `)
     })
   })

--- a/javascript/packages/linter/test/rules/html-no-space-in-tag.test.ts
+++ b/javascript/packages/linter/test/rules/html-no-space-in-tag.test.ts
@@ -69,6 +69,24 @@ describe("HTMLNoSpaceInTagRule", () => {
         </div>
       `)
     })
+
+    test("multi line tag with first attribute on the opening line (hanging indent) - #695", () => {
+      expectNoOffenses(dedent`
+        <div data-a="foo"
+             data-b="bar">
+          lorem
+        </div>
+      `)
+    })
+
+    test("multi line tag with attributes aligned to a non-default indentation", () => {
+      expectNoOffenses(dedent`
+        <div class="a"
+             id="b"
+             data-c="c">
+        </div>
+      `)
+    })
   })
 
   describe("when no space should be present", () => {
@@ -144,7 +162,6 @@ describe("HTMLNoSpaceInTagRule", () => {
 
     test("extra newline between name and first attribute", () => {
       expectError("Extra space detected where there should be a single space or a single line break.")
-      expectError("Extra space detected where there should be no space.")
 
       assertOffenses(dedent`
         <input
@@ -166,7 +183,6 @@ describe("HTMLNoSpaceInTagRule", () => {
 
     test("extra newline between attributes", () => {
       expectError("Extra space detected where there should be a single space or a single line break.")
-      expectError("Extra space detected where there should be no space.")
 
       assertOffenses(dedent`
         <input
@@ -204,6 +220,48 @@ describe("HTMLNoSpaceInTagRule", () => {
 
     test("non-space detected between attributes", () => {
       expectNoOffenses(`<input class="hide"/name="foo" />`, { allowInvalidSyntax: true })
+    })
+
+    test("extra space between name and first attribute on the opening line of a multiline tag", () => {
+      expectError("Extra space detected where there should be a single space.")
+
+      assertOffenses(dedent`
+        <div  data-a="foo"
+          data-b="bar">
+        </div>
+      `)
+    })
+
+    test("extra space between attributes on a continuation line", () => {
+      expectError("Extra space detected where there should be a single space.")
+
+      assertOffenses(dedent`
+        <div
+          data-a="foo"  data-b="bar">
+        </div>
+      `)
+    })
+
+    test("extra space before the closing bracket on an attribute line", () => {
+      expectError("Extra space detected where there should be no space.")
+
+      assertOffenses(dedent`
+        <div
+          data-a="foo" >
+        </div>
+      `)
+    })
+
+    test("closing bracket over-indented in a nested tag", () => {
+      expectError("Extra space detected where there should be no space.")
+
+      assertOffenses(dedent`
+        <div>
+          <input
+            type="password"
+              >
+        </div>
+      `)
     })
   })
 })


### PR DESCRIPTION
This pull request reworks the `html-no-space-in-tag` rule to fix the autofix corrupting valid multiline tags, removes a class of false positives, corrects the autofix for indented and nested tags, and re-enables the rule (and its autofix) now that it is accurate again.

The rule was removed from the default rules in #697 because it produced false positives and could corrupt documents when running with `--fix`. This pull request addresses the underlying accuracy problems and reverses that temporary opt-out.

Given this valid markup:

```html+erb
<div data-a="foo"
     data-b="bar">
  lorem
</div>
```

running the autofix produced:

```html+erb
<divdata-a="foo"
data-b="bar">
  lorem
</div>
```

The multiline branch ran an indentation check on every non-newline whitespace node, treating each as line-leading indentation that had to equal the tag's start column `+ 2` (or the start column for the last one).

With this, the example above is recognized as valid and left untouched.

no longer flagged:
```html+erb
<div data-a="foo"
     data-b="bar">
  lorem
</div>
```

still flagged:
```html+erb
<div  data-a="foo"
  data-b="bar">
</div>
```

#### Autofix alignment in nested tags

The autofix for a closing bracket on its own line previously stripped the indentation to column `0`, which misaligned nested tags. It now aligns the bracket to the opening tag's start column:

```diff
 <div>
   <input
     type="password"
-      >
+  >
 </div>
```

The same applies to a self-closing `/>` on its own line.

Resolves #695.