### PR TITLE
Linter CLI: Introduce `--only` flag for running specific rule

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -78,7 +78,7 @@ herb-format --force --check app/views/
 
 When using `--force` on an explicitly specified file that is excluded by configuration patterns, the CLI will show a warning but proceed with processing the file.
 
-The linter CLI also supports an `--only` flag to run a specific set of rules, ignoring the rule configuration in `.herb.yml`.
+The linter CLI also supports an `--only` flag <Badge type="info" text="^0.10.3" /> to run a specific set of rules, ignoring the rule configuration in `.herb.yml`.
 
 Only run the given rules, regardless of how they are configured:
 ```bash

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -39,13 +39,15 @@ If you're using Herb in a project with multiple developers, it's highly recommen
 
 ### Creating a Configuration File
 
-To create a `.herb.yml` configuration file in your project, run either CLI tool with the `--init` flag:
+To create a `.herb.yml` configuration file in your project, run either CLI tool with the `--init` flag.
 
+Create config using the linter:
 ```bash
-# Create config using the linter
 herb-lint --init
+```
 
-# Or create config using the formatter
+Or create config using the formatter:
+```bash
 herb-format --init
 ```
 
@@ -56,20 +58,34 @@ This will generate a configuration file with sensible defaults:
 
 ## Command Line Overrides
 
-The CLIs support a `--force` flag to override project configuration:
+The CLIs support a `--force` flag to override project configuration.
 
+
+Force linting even if disabled in `.herb.yml`:
 ```bash
-# Force linting even if disabled in .herb.yml
 herb-lint --force app/views/
+```
 
-# Force linting on a file excluded by configuration
+Force linting on a file excluded by configuration:
+```bash
 herb-lint --force app/views/excluded-file.html.erb
+```
 
-# Force formatting even if disabled in .herb.yml
+Force formatting even if disabled in `.herb.yml`:
+```bash
 herb-format --force --check app/views/
 ```
 
 When using `--force` on an explicitly specified file that is excluded by configuration patterns, the CLI will show a warning but proceed with processing the file.
+
+The linter CLI also supports an `--only` flag to run a specific set of rules, ignoring the rule configuration in `.herb.yml`.
+
+Only run the given rules, regardless of how they are configured:
+```bash
+herb-lint --only html-img-require-alt,html-tag-name-lowercase app/views/
+```
+
+Rules passed to `--only` run even when they are disabled, not enabled by default, gated by the `version` in your `.herb.yml`, or excluded through rule-level path patterns. Which files get linted and the configured severities are unaffected.
 
 ## Linter Configuration
 

--- a/javascript/packages/linter/README.md
+++ b/javascript/packages/linter/README.md
@@ -214,7 +214,7 @@ linter:
 
 The CLI flag takes precedence over the configuration file.
 
-**Running Specific Rules:**
+**Running Specific Rules:** <Badge type="info" text="^0.10.3" />
 
 Only run a single rule:
 ```bash

--- a/javascript/packages/linter/README.md
+++ b/javascript/packages/linter/README.md
@@ -214,6 +214,41 @@ linter:
 
 The CLI flag takes precedence over the configuration file.
 
+**Running Specific Rules:**
+
+Only run a single rule:
+```bash
+npx @herb-tools/linter --only html-img-require-alt
+```
+
+Only run multiple rules (comma-separated):
+```bash
+npx @herb-tools/linter --only html-img-require-alt,html-tag-name-lowercase
+```
+
+The flag can also be passed multiple times:
+```bash
+npx @herb-tools/linter --only html-img-require-alt --only html-tag-name-lowercase
+```
+
+Combine it with `--fix` to only autocorrect a specific rule:
+```bash
+npx @herb-tools/linter --fix --only html-tag-name-lowercase
+```
+
+The `--only` option runs exactly the given rules and ignores the rule configuration in `.herb.yml`. This means rules are run even if they are:
+
+- disabled via `enabled: false`
+- not enabled by default
+- skipped because they were introduced after the `version` in your `.herb.yml`
+- excluded for the linted files via rule-level `only`, `include` or `exclude` patterns
+
+This is useful for rolling out a single rule across a codebase, or for checking what a rule would report before enabling it in `.herb.yml`.
+
+Everything else still applies: which files get linted is unchanged, severity overrides from `.herb.yml` are respected, and offenses suppressed with `<%# herb:disable %>` comments stay suppressed (use `--ignore-disable-comments` to report them anyway).
+
+Passing an unknown rule name exits with an error, so typos won't silently lint nothing.
+
 **Autofix:**
 
 Automatically fix auto-correctable offenses:

--- a/javascript/packages/linter/src/cli.ts
+++ b/javascript/packages/linter/src/cli.ts
@@ -137,6 +137,10 @@ export class CLI {
     // Hook for subclasses to add custom output before processing
   }
 
+  protected additionalRuleNames(): string[] {
+    return []
+  }
+
   protected async afterProcess(_results: any, _outputOptions: any): Promise<void> {
     // Hook for subclasses to add custom output after processing
   }
@@ -147,7 +151,7 @@ export class CLI {
     const startTime = Date.now()
     const startDate = new Date()
 
-    const { patterns, configFile, formatOption, showTiming, theme, wrapLines, truncateLines, useGitHubActions, fix, fixUnsafe, ignoreDisableComments, force, init, upgrade, disableFailing, loadCustomRules, failLevel, jobs } = this.argumentParser.parse(process.argv)
+    const { patterns, configFile, formatOption, showTiming, theme, wrapLines, truncateLines, useGitHubActions, fix, fixUnsafe, ignoreDisableComments, force, init, upgrade, disableFailing, loadCustomRules, failLevel, jobs, only } = this.argumentParser.parse(process.argv)
 
     this.determineProjectPath(patterns)
 
@@ -374,6 +378,20 @@ export class CLI {
         console.log()
       }
 
+      if (only) {
+        const unknownRules = await this.fileProcessor.findUnknownRules(only, { projectPath: this.projectPath, loadCustomRules }, formatOption, this.additionalRuleNames())
+
+        if (unknownRules.length > 0) {
+          const messages = unknownRules.map(({ name, suggestion }) => {
+            const suggestionText = suggestion ? ` Did you mean ${colorize(suggestion, "cyan")}?` : ""
+
+            return `✗ Unknown rule ${colorize(name, "cyan")} passed to --only.${suggestionText}`
+          })
+
+          this.exitWithError(messages.join("\n"), formatOption)
+        }
+      }
+
       let files: string[]
       const explicitFiles: string[] = []
 
@@ -437,7 +455,8 @@ export class CLI {
         config: processingConfig,
         hasConfigFile,
         loadCustomRules,
-        jobs
+        jobs,
+        only
       }
 
       const results = await this.fileProcessor.processFiles(files, formatOption, context)

--- a/javascript/packages/linter/src/cli/argument-parser.ts
+++ b/javascript/packages/linter/src/cli/argument-parser.ts
@@ -31,6 +31,7 @@ export interface ParsedArguments {
   loadCustomRules: boolean
   failLevel?: DiagnosticSeverity
   jobs: number
+  only?: string[]
 }
 
 export class ArgumentParser {
@@ -49,6 +50,9 @@ export class ArgumentParser {
       --disable-failing             lint the codebase and disable all rules that have offenses in .herb.yml
       -c, --config-file <path>      explicitly specify path to .herb.yml config file
       --force                       force linting even if disabled in .herb.yml
+      --only <rules>                only run the given rules, ignoring the rule configuration in .herb.yml
+                                    accepts a comma-separated list and can be passed multiple times
+                                    (e.g., herb-lint --only html-img-require-alt,html-tag-name-lowercase)
       --fix                         automatically fix auto-correctable offenses
       --fix-unsafely                also apply unsafe auto-fixes (implies --fix)
       --ignore-disable-comments     report offenses even when suppressed with <%# herb:disable %> comments
@@ -79,6 +83,7 @@ export class ArgumentParser {
         "disable-failing": { type: "boolean" },
         "config-file": { type: "string", short: "c" },
         force: { type: "boolean" },
+        only: { type: "string", multiple: true },
         fix: { type: "boolean" },
         "fix-unsafely": { type: "boolean" },
         "ignore-disable-comments": { type: "boolean" },
@@ -165,6 +170,17 @@ export class ArgumentParser {
     const disableFailing = values["disable-failing"] || false
     const loadCustomRules = !values["no-custom-rules"]
 
+    let only: string[] | undefined
+
+    if (values.only) {
+      only = [...new Set(values.only.flatMap(value => value.split(",")).map(ruleName => ruleName.trim()).filter(Boolean))]
+
+      if (only.length === 0) {
+        console.error(`Error: --only requires at least one rule name.`)
+        process.exit(1)
+      }
+    }
+
     let failLevel: DiagnosticSeverity | undefined
     if (values["fail-level"]) {
       const level = values["fail-level"]
@@ -189,7 +205,7 @@ export class ArgumentParser {
       jobs = parsed
     }
 
-    return { patterns, configFile, formatOption, showTiming, theme, wrapLines, truncateLines, useGitHubActions, fix, fixUnsafe, ignoreDisableComments, force, init, upgrade, disableFailing, loadCustomRules, failLevel, jobs }
+    return { patterns, configFile, formatOption, showTiming, theme, wrapLines, truncateLines, useGitHubActions, fix, fixUnsafe, ignoreDisableComments, force, init, upgrade, disableFailing, loadCustomRules, failLevel, jobs, only }
   }
 
   private getFilePatterns(positionals: string[]): string[] {

--- a/javascript/packages/linter/src/cli/file-processor.ts
+++ b/javascript/packages/linter/src/cli/file-processor.ts
@@ -10,13 +10,14 @@ import { resolve, dirname, join } from "node:path"
 import { fileURLToPath } from "node:url"
 import { availableParallelism } from "node:os"
 import { colorize } from "@herb-tools/highlighter"
-import { deserializeDiagnostic } from "@herb-tools/core"
+import { deserializeDiagnostic, didyoumean } from "@herb-tools/core"
 
 import type { Diagnostic } from "@herb-tools/core"
 import type { FormatOption } from "./argument-parser.js"
 import type { HerbConfigOptions } from "@herb-tools/config"
 import type { WorkerInput, WorkerResult } from "./lint-worker.js"
 import type { VersionSkippedRule } from "../linter.js"
+import type { RuleClass } from "../types.js"
 
 export interface ProcessedFile {
   filename: string
@@ -37,6 +38,12 @@ export interface ProcessingContext {
   hasConfigFile?: boolean
   loadCustomRules?: boolean
   jobs?: number
+  only?: string[]
+}
+
+export interface UnknownRule {
+  name: string
+  suggestion?: string
 }
 
 export interface ProcessingResult {
@@ -64,9 +71,92 @@ export interface ProcessingResult {
  */
 const PARALLEL_FILE_THRESHOLD = 10
 
+/**
+ * Maximum Levenshtein distance for suggesting a rule name for an unknown rule.
+ * Keeps typo suggestions while staying silent for names that aren't close to any rule.
+ */
+const SUGGESTION_DISTANCE_THRESHOLD = 8
+
 export class FileProcessor {
   private linter: Linter | null = null
   private customRulesLoaded: boolean = false
+  private customRules: RuleClass[] | undefined = undefined
+
+  /**
+   * Loads the project's custom rules once and caches them for subsequent calls.
+   */
+  private async loadCustomRulesOnce(context?: ProcessingContext, formatOption: FormatOption = 'detailed'): Promise<RuleClass[] | undefined> {
+    if (this.customRulesLoaded) return this.customRules
+    if (!context?.loadCustomRules) return undefined
+
+    try {
+      const result = await loadCustomRules({
+        baseDir: context.projectPath,
+        silent: formatOption === 'json'
+      })
+
+      this.customRules = result.rules
+
+      if (result.rules.length > 0 && formatOption !== 'json') {
+        const ruleText = result.rules.length === 1 ? 'rule' : 'rules'
+        console.log(colorize(`\nLoaded ${result.rules.length} custom ${ruleText}:`, "green"))
+
+        for (const { name, path } of result.ruleInfo) {
+          const relativePath = context.projectPath ? path.replace(context.projectPath + '/', '') : path
+          console.log(colorize(`  • ${name}`, "cyan") + colorize(` (${relativePath})`, "dim"))
+        }
+
+        if (result.warnings.length > 0) {
+          console.log()
+
+          for (const warning of result.warnings) {
+            console.warn(colorize(`  ⚠ ${warning}`, "yellow"))
+          }
+        }
+
+        console.log()
+      }
+    } catch (error) {
+      if (formatOption !== 'json') {
+        console.warn(colorize(`Warning: Failed to load custom rules: ${error}`, "yellow"))
+      }
+    }
+
+    this.customRulesLoaded = true
+
+    return this.customRules
+  }
+
+  /**
+   * Returns the rule names from the given list that don't match any built-in or custom rule,
+   * along with a suggestion for the closest matching rule name when there is one.
+   *
+   * @param additionalRuleNames - Rule names provided by a CLI on top of the built-in rules (e.g. Stimulus rules)
+   */
+  async findUnknownRules(ruleNames: string[], context?: ProcessingContext, formatOption: FormatOption = 'detailed', additionalRuleNames: string[] = []): Promise<UnknownRule[]> {
+    const customRules = await this.loadCustomRulesOnce(context, formatOption)
+    const availableRuleNames = [...rules, ...(customRules || [])].map(ruleClass => ruleClass.ruleName).concat(additionalRuleNames)
+
+    return ruleNames
+      .filter(ruleName => !availableRuleNames.includes(ruleName))
+      .map(ruleName => ({ name: ruleName, suggestion: this.suggestRuleName(ruleName, availableRuleNames) }))
+  }
+
+  /**
+   * Suggests the closest matching rule name for a rule name that doesn't exist.
+   * Prefers rule names that contain (or are contained in) the given name, so partial
+   * names like `erb-no-silent` suggest `erb-no-silent-statement`. Names that are too
+   * far off don't get a suggestion at all.
+   */
+  private suggestRuleName(ruleName: string, availableRuleNames: string[]): string | undefined {
+    const partialMatches = availableRuleNames
+      .filter(availableRuleName => availableRuleName.includes(ruleName) || ruleName.includes(availableRuleName))
+      .sort((a, b) => a.length - b.length)
+
+    if (partialMatches.length > 0) return partialMatches[0]
+
+    return didyoumean(ruleName, availableRuleNames, SUGGESTION_DISTANCE_THRESHOLD) ?? undefined
+  }
 
   private isRuleAutocorrectable(ruleName: string): boolean {
     if (!this.linter) return false
@@ -106,49 +196,9 @@ export class FileProcessor {
     const ruleOffenses = new Map<string, { count: number, files: Set<string> }>()
 
     if (!this.linter) {
-      let customRules = undefined
-      let customRuleInfo: Array<{ name: string, path: string }> = []
-      let customRuleWarnings: string[] = []
+      const customRules = await this.loadCustomRulesOnce(context, formatOption)
 
-      if (context?.loadCustomRules && !this.customRulesLoaded) {
-        try {
-          const result = await loadCustomRules({
-            baseDir: context.projectPath,
-            silent: formatOption === 'json'
-          })
-
-          customRules = result.rules
-          customRuleInfo = result.ruleInfo
-          customRuleWarnings = result.warnings
-
-          this.customRulesLoaded = true
-
-          if (customRules.length > 0 && formatOption !== 'json') {
-            const ruleText = customRules.length === 1 ? 'rule' : 'rules'
-            console.log(colorize(`\nLoaded ${customRules.length} custom ${ruleText}:`, "green"))
-
-            for (const { name, path } of customRuleInfo) {
-              const relativePath = context.projectPath ? path.replace(context.projectPath + '/', '') : path
-              console.log(colorize(`  • ${name}`, "cyan") + colorize(` (${relativePath})`, "dim"))
-            }
-
-            if (customRuleWarnings.length > 0) {
-              console.log()
-              for (const warning of customRuleWarnings) {
-                console.warn(colorize(`  ⚠ ${warning}`, "yellow"))
-              }
-            }
-
-            console.log()
-          }
-        } catch (error) {
-          if (formatOption !== 'json') {
-            console.warn(colorize(`Warning: Failed to load custom rules: ${error}`, "yellow"))
-          }
-        }
-      }
-
-      this.linter = Linter.from(Herb, context?.config, customRules)
+      this.linter = Linter.from(Herb, context?.config, customRules, { only: context?.only })
     }
 
     for (const filename of files) {
@@ -264,7 +314,7 @@ export class FileProcessor {
     const workerPath = this.resolveWorkerPath()
 
     const configVersion = context?.config?.configVersion
-    const filterResult = Linter.filterRulesByConfig(rules, context?.config?.linter?.rules, configVersion)
+    const filterResult = Linter.filterRulesByConfig(rules, context?.config?.linter?.rules, configVersion, { only: context?.only })
 
     const workerPromises = chunks.map(chunk => this.runWorker(workerPath, chunk, context))
     const workerResults = await Promise.all(workerPromises)
@@ -313,6 +363,7 @@ export class FileProcessor {
         fixUnsafe: context?.fixUnsafe || false,
         ignoreDisableComments: context?.ignoreDisableComments || false,
         loadCustomRules: context?.loadCustomRules || false,
+        only: context?.only,
       }
 
       const worker = new Worker(workerPath, { workerData })

--- a/javascript/packages/linter/src/cli/lint-worker.ts
+++ b/javascript/packages/linter/src/cli/lint-worker.ts
@@ -18,6 +18,7 @@ export interface WorkerInput {
   fixUnsafe: boolean
   ignoreDisableComments: boolean
   loadCustomRules: boolean
+  only?: string[]
 }
 
 export interface WorkerOffense {
@@ -65,7 +66,7 @@ async function run() {
     }
   }
 
-  const linter = Linter.from(Herb, config, customRules)
+  const linter = Linter.from(Herb, config, customRules, { only: data.only })
 
   let totalErrors = 0
   let totalWarnings = 0

--- a/javascript/packages/linter/src/cli/output-manager.ts
+++ b/javascript/packages/linter/src/cli/output-manager.ts
@@ -67,6 +67,7 @@ export class OutputManager {
           configPath: context?.config?.path,
           hasConfigFile: context?.hasConfigFile,
           toolVersion: options.toolVersion,
+          only: context?.only,
         })
       }
     } else if (options.formatOption === "json") {
@@ -134,6 +135,7 @@ export class OutputManager {
         configPath: context?.config?.path,
         hasConfigFile: context?.hasConfigFile,
         toolVersion: options.toolVersion,
+        only: context?.only,
       })
     }
   }

--- a/javascript/packages/linter/src/cli/summary-reporter.ts
+++ b/javascript/packages/linter/src/cli/summary-reporter.ts
@@ -28,6 +28,7 @@ export interface SummaryData {
   configPath?: string
   hasConfigFile?: boolean
   toolVersion?: string
+  only?: string[]
 }
 
 export class SummaryReporter {
@@ -130,6 +131,7 @@ export class SummaryReporter {
     const skippedCount = data.rulesSkippedByVersion?.length ?? 0
     const rulesParts = [colorize(colorize(`${ruleCount} enabled`, "green"), "bold")]
 
+    if (data.only && data.only.length > 0) rulesParts.push(colorize(`filtered by --only`, "cyan"))
     if (notEnabledCount > 0) rulesParts.push(colorize(`${notEnabledCount} not enabled`, "cyan"))
     if (disabledCount > 0) rulesParts.push(colorize(`${disabledCount} disabled`, "yellow"))
     if (skippedCount > 0) rulesParts.push(colorize(`${skippedCount} skipped (version)`, "gray"))

--- a/javascript/packages/linter/src/linter.ts
+++ b/javascript/packages/linter/src/linter.ts
@@ -61,12 +61,17 @@ export interface FilterRulesResult {
   notEnabledByDefault: number
 }
 
+export interface FilterRulesOptions {
+  only?: string[]
+}
+
 export class Linter {
   public rules: RuleClass[]
   public rulesSkippedByVersion: VersionSkippedRule[] = []
   public rulesDisabledByConfig: number = 0
   public rulesNotEnabledByDefault: number = 0
   public mode: LinterMode = "cli"
+  public onlyRules?: string[]
 
   protected allAvailableRules: RuleClass[]
   protected herb: HerbBackend
@@ -80,17 +85,19 @@ export class Linter {
    * @param herb - The Herb backend instance for parsing and lexing
    * @param config - Optional full Config instance for rule filtering, severity overrides, and path-based filtering
    * @param customRules - Optional array of custom rules to include alongside built-in rules
+   * @param options - Optional filtering options, like restricting the linter to a set of rules via `only`
    * @returns A configured Linter instance
    */
-  static from(herb: HerbBackend, config?: Config, customRules?: RuleClass[]): Linter {
+  static from(herb: HerbBackend, config?: Config, customRules?: RuleClass[], options?: FilterRulesOptions): Linter {
     const allRules = customRules ? [...rules, ...customRules] : rules
     const configVersion = config?.configVersion
-    const filterResult = Linter.filterRulesByConfig(allRules, config?.linter?.rules, configVersion)
+    const filterResult = Linter.filterRulesByConfig(allRules, config?.linter?.rules, configVersion, options)
 
     const linter = new Linter(herb, filterResult.enabled, config, allRules)
     linter.rulesSkippedByVersion = filterResult.skippedByVersion
     linter.rulesDisabledByConfig = filterResult.disabledByConfig
     linter.rulesNotEnabledByDefault = filterResult.notEnabledByDefault
+    linter.onlyRules = Linter.normalizeOnlyRules(options?.only)
 
     return linter
   }
@@ -123,16 +130,32 @@ export class Linter {
    * 2. Version gating (if rule.introducedIn > configVersion, skip unless explicitly enabled)
    * 3. Default config from rule's defaultConfig getter
    *
+   * When `options.only` is provided all of the above is bypassed and exactly the
+   * requested rules are enabled, regardless of the user configuration.
+   *
    * @param allRules - All available rule classes to filter from
    * @param userRulesConfig - Optional user configuration for rules
    * @param configVersion - Optional version from the user's .herb.yml for version-gated filtering
+   * @param options - Optional filtering options, like restricting the linter to a set of rules via `only`
    * @returns Object with enabled rules and rules skipped due to version gating
    */
   static filterRulesByConfig(
     allRules: RuleClass[],
     userRulesConfig?: Record<string, RuleConfig>,
-    configVersion?: string
+    configVersion?: string,
+    options?: FilterRulesOptions
   ): FilterRulesResult {
+    const onlyRules = Linter.normalizeOnlyRules(options?.only)
+
+    if (onlyRules) {
+      return {
+        enabled: allRules.filter(ruleClass => onlyRules.includes(ruleClass.ruleName)),
+        skippedByVersion: [],
+        disabledByConfig: 0,
+        notEnabledByDefault: 0
+      }
+    }
+
     const enabled: RuleClass[] = []
     const skippedByVersion: VersionSkippedRule[] = []
     let disabledByConfig = 0
@@ -176,6 +199,17 @@ export class Linter {
     }
 
     return { enabled, skippedByVersion, disabledByConfig, notEnabledByDefault }
+  }
+
+  /**
+   * Normalizes a list of rule names for `only` filtering.
+   * @param only - Optional list of rule names
+   * @returns Deduplicated list of rule names, or undefined when no rules were requested
+   */
+  protected static normalizeOnlyRules(only?: string[]): string[] | undefined {
+    if (!only || only.length === 0) return undefined
+
+    return [...new Set(only)]
   }
 
   /**
@@ -256,7 +290,7 @@ export class Linter {
   ): UnboundLintOffense[] {
     const ruleName = rule.ruleName
 
-    if (this.config && context?.fileName) {
+    if (this.config && context?.fileName && !this.onlyRules) {
       if (!this.config.isRuleEnabledForPath(ruleName, context.fileName)) {
         return []
       }

--- a/javascript/packages/linter/test/cli.test.ts
+++ b/javascript/packages/linter/test/cli.test.ts
@@ -664,6 +664,77 @@ describe("CLI Output Formatting", () => {
       }
     })
 
+    test("leaves autocorrectable offenses of other rules untouched", () => {
+      const fixturePath = "test/fixtures/only-fix-other-rules.html.erb"
+      const { readFileSync } = require("fs")
+
+      try {
+        writeFileSync(fixturePath, dedent`
+          <DIV>
+            <img src='test.jpg' alt='test'>
+          </DIV>
+        ` + "\n")
+
+        const { output } = runLinter("only-fix-other-rules.html.erb", "--simple", "--fix", "--only", "html-tag-name-lowercase")
+        const fixedContent = readFileSync(fixturePath, "utf-8")
+
+        expect(output).toContain("Fixed 2 offenses")
+        expect(fixedContent).toContain("<div>")
+        expect(fixedContent).toContain(`<img src='test.jpg' alt='test'>`)
+
+        runLinter("only-fix-other-rules.html.erb", "--simple", "--fix")
+
+        expect(readFileSync(fixturePath, "utf-8")).toContain(`<img src="test.jpg" alt="test">`)
+      } finally {
+        try { unlinkSync(fixturePath) } catch {}
+      }
+    })
+
+    test("fixes rules that are disabled in .herb.yml", () => {
+      const fixturePath = "test/fixtures/only-fix-disabled.html.erb"
+      const { readFileSync } = require("fs")
+
+      try {
+        writeFileSync(configPath, dedent`
+          linter:
+            rules:
+              html-tag-name-lowercase:
+                enabled: false
+        `)
+
+        writeFileSync(fixturePath, `<DIV>test</DIV>\n`)
+
+        const { output } = runLinter("only-fix-disabled.html.erb", "--simple", "--fix", "--only", "html-tag-name-lowercase")
+
+        expect(output).toContain("Fixed 2 offenses")
+        expect(readFileSync(fixturePath, "utf-8")).toBe("<div>test</div>\n")
+      } finally {
+        try { unlinkSync(configPath) } catch {}
+        try { unlinkSync(fixturePath) } catch {}
+      }
+    })
+
+    test("applies unsafe fixes with --fix-unsafely", () => {
+      const fixturePath = "test/fixtures/only-fix-unsafely.html.erb"
+      const { readFileSync } = require("fs")
+
+      try {
+        writeFileSync(fixturePath, `<div>Tom & Jerry</div>\n`)
+
+        const safe = runLinter("only-fix-unsafely.html.erb", "--simple", "--fix", "--only", "html-no-unescaped-entities")
+
+        expect(safe.output).not.toContain("Fixed")
+        expect(readFileSync(fixturePath, "utf-8")).toBe("<div>Tom & Jerry</div>\n")
+
+        const unsafe = runLinter("only-fix-unsafely.html.erb", "--simple", "--fix-unsafely", "--only", "html-no-unescaped-entities")
+
+        expect(unsafe.output).toContain("Fixed 1 offense")
+        expect(readFileSync(fixturePath, "utf-8")).toBe("<div>Tom &amp; Jerry</div>\n")
+      } finally {
+        try { unlinkSync(fixturePath) } catch {}
+      }
+    })
+
     test("exits with an error for unknown rule names", () => {
       const { output, exitCode } = runLinter("test-file-with-errors.html.erb", "--simple", "--only", "html-img-require-altt")
 

--- a/javascript/packages/linter/test/cli.test.ts
+++ b/javascript/packages/linter/test/cli.test.ts
@@ -568,6 +568,231 @@ describe("CLI Output Formatting", () => {
     })
   })
 
+  describe("--only", () => {
+    const { writeFileSync, unlinkSync } = require("fs")
+    const configPath = "test/fixtures/.herb.yml"
+
+    test("only reports offenses for the given rule", () => {
+      const { output, exitCode } = runLinter("test-file-with-errors.html.erb", "--simple", "--only", "html-img-require-alt")
+
+      expect(output).toContain("html-img-require-alt")
+      expect(output).not.toContain("html-tag-name-lowercase")
+      expect(output).toContain("1 enabled | filtered by --only")
+      expect(exitCode).toBe(0)
+    })
+
+    test("accepts a comma-separated list of rules", () => {
+      const { output, exitCode } = runLinter("test-file-with-errors.html.erb", "--simple", "--only", "html-img-require-alt,html-tag-name-lowercase")
+
+      expect(output).toContain("html-img-require-alt")
+      expect(output).toContain("html-tag-name-lowercase")
+      expect(output).toContain("2 enabled | filtered by --only")
+      expect(exitCode).toBe(1)
+    })
+
+    test("can be passed multiple times", () => {
+      const { output, exitCode } = runLinter("test-file-with-errors.html.erb", "--simple", "--only", "html-img-require-alt", "--only", "html-tag-name-lowercase")
+
+      expect(output).toContain("html-img-require-alt")
+      expect(output).toContain("html-tag-name-lowercase")
+      expect(output).toContain("2 enabled | filtered by --only")
+      expect(exitCode).toBe(1)
+    })
+
+    test("runs rules that are disabled in .herb.yml", () => {
+      try {
+        writeFileSync(configPath, dedent`
+          linter:
+            rules:
+              html-img-require-alt:
+                enabled: false
+        `)
+
+        const withoutOnly = runLinter("test-file-with-errors.html.erb", "--simple")
+        expect(withoutOnly.output).not.toContain("html-img-require-alt")
+
+        const { output, exitCode } = runLinter("test-file-with-errors.html.erb", "--simple", "--only", "html-img-require-alt")
+
+        expect(output).toContain("html-img-require-alt")
+        expect(exitCode).toBe(0)
+      } finally {
+        try { unlinkSync(configPath) } catch {}
+      }
+    })
+
+    test("ignores rule-level exclude patterns from .herb.yml", () => {
+      try {
+        writeFileSync(configPath, dedent`
+          linter:
+            rules:
+              html-tag-name-lowercase:
+                exclude:
+                  - '**/*.html.erb'
+        `)
+
+        const withoutOnly = runLinter("test-file-with-errors.html.erb", "--simple")
+        expect(withoutOnly.output).not.toContain("html-tag-name-lowercase")
+
+        const { output, exitCode } = runLinter("test-file-with-errors.html.erb", "--simple", "--only", "html-tag-name-lowercase")
+
+        expect(output).toContain("html-tag-name-lowercase")
+        expect(exitCode).toBe(1)
+      } finally {
+        try { unlinkSync(configPath) } catch {}
+      }
+    })
+
+    test("only fixes offenses of the given rules", () => {
+      const fixturePath = "test/fixtures/only-fix.html.erb"
+      const { readFileSync } = require("fs")
+
+      try {
+        writeFileSync(fixturePath, dedent`
+          <DIV>
+            <img src="test.jpg">
+          </DIV>
+        ` + "\n")
+
+        const { output } = runLinter("only-fix.html.erb", "--simple", "--fix", "--only", "html-tag-name-lowercase")
+        const fixedContent = readFileSync(fixturePath, "utf-8")
+
+        expect(output).toContain("Fixed 2 offenses")
+        expect(fixedContent).toContain("<div>")
+        expect(fixedContent).toContain(`<img src="test.jpg">`)
+      } finally {
+        try { unlinkSync(fixturePath) } catch {}
+      }
+    })
+
+    test("exits with an error for unknown rule names", () => {
+      const { output, exitCode } = runLinter("test-file-with-errors.html.erb", "--simple", "--only", "html-img-require-altt")
+
+      expect(output).toContain("Unknown rule html-img-require-altt passed to --only")
+      expect(output).toContain("Did you mean html-img-require-alt?")
+      expect(exitCode).toBe(1)
+    })
+
+    test("suggests the full rule name for a partial rule name", () => {
+      const { output, exitCode } = runLinter("test-file-with-errors.html.erb", "--simple", "--only", "erb-no-silent")
+
+      expect(output).toContain("Unknown rule erb-no-silent passed to --only")
+      expect(output).toContain("Did you mean erb-no-silent-statement?")
+      expect(exitCode).toBe(1)
+    })
+
+    test("doesn't suggest a rule name when nothing is close", () => {
+      const { output, exitCode } = runLinter("test-file-with-errors.html.erb", "--simple", "--only", "zzzzzzzzzzzzzzzzzzzzzz")
+
+      expect(output).toContain("Unknown rule zzzzzzzzzzzzzzzzzzzzzz passed to --only")
+      expect(output).not.toContain("Did you mean")
+      expect(exitCode).toBe(1)
+    })
+
+    test("reports every unknown rule name", () => {
+      const { output, exitCode } = runLinter("test-file-with-errors.html.erb", "--simple", "--only", "html-img-alt,html-tag-name-lowercase,html-lowercase-tag")
+
+      expect(output).toContain("Unknown rule html-img-alt passed to --only")
+      expect(output).toContain("Unknown rule html-lowercase-tag passed to --only")
+      expect(output).not.toContain("Unknown rule html-tag-name-lowercase")
+      expect(exitCode).toBe(1)
+    })
+
+    test("reports unknown rule names in the JSON output", () => {
+      const { output, exitCode } = runLinter("test-file-with-errors.html.erb", "--json", "--only", "html-img-require-altt")
+      const result = JSON.parse(output)
+
+      expect(result.completed).toBe(false)
+      expect(result.message).toContain("Unknown rule html-img-require-altt passed to --only")
+      expect(result.offenses).toEqual([])
+      expect(exitCode).toBe(1)
+    })
+
+    test("exits with an error when no rule name is given", () => {
+      const { output, exitCode } = runLinter("test-file-with-errors.html.erb", "--simple", "--only", `""`)
+
+      expect(output).toContain("--only requires at least one rule name")
+      expect(exitCode).toBe(1)
+    })
+
+    test("runs rules that are not enabled by default", () => {
+      const fixturePath = "test/fixtures/only-not-enabled-by-default.html.erb"
+
+      try {
+        writeFileSync(fixturePath, `<div disabled>Save</div>\n`)
+
+        const withoutOnly = runLinter("only-not-enabled-by-default.html.erb", "--simple")
+        expect(withoutOnly.output).not.toContain("a11y-disabled-attribute")
+
+        const { output } = runLinter("only-not-enabled-by-default.html.erb", "--simple", "--only", "a11y-disabled-attribute")
+
+        expect(output).toContain("a11y-disabled-attribute")
+        expect(output).toContain("1 enabled | filtered by --only")
+      } finally {
+        try { unlinkSync(fixturePath) } catch {}
+      }
+    })
+
+    test("runs rules that are skipped by the version in .herb.yml", () => {
+      const fixturePath = "test/fixtures/only-version-gated.html.erb"
+
+      try {
+        writeFileSync(configPath, dedent`
+          version: 0.4.0
+        `)
+
+        writeFileSync(fixturePath, dedent`
+          <div>
+            <foobar>hi</foobar>
+          </div>
+        ` + "\n")
+
+        const withoutOnly = runLinter("only-version-gated.html.erb", "--simple")
+        expect(withoutOnly.output).toContain("New rules available")
+        expect(withoutOnly.output).not.toContain("Unknown HTML tag")
+
+        const { output } = runLinter("only-version-gated.html.erb", "--simple", "--only", "html-no-unknown-tag")
+
+        expect(output).toContain("html-no-unknown-tag")
+        expect(output).not.toContain("New rules available")
+      } finally {
+        try { unlinkSync(configPath) } catch {}
+        try { unlinkSync(fixturePath) } catch {}
+      }
+    })
+
+    test("still respects herb:disable comments", () => {
+      const fixturePath = "test/fixtures/only-disable-comment.html.erb"
+
+      try {
+        writeFileSync(fixturePath, dedent`
+          <DIV>test</DIV> <%# herb:disable html-tag-name-lowercase %>
+        ` + "\n")
+
+        const { output, exitCode } = runLinter("only-disable-comment.html.erb", "--simple", "--only", "html-tag-name-lowercase")
+
+        expect(output).not.toContain("should be lowercase")
+        expect(output).toContain("2 ignored")
+        expect(exitCode).toBe(0)
+
+        const ignoring = runLinter("only-disable-comment.html.erb", "--simple", "--only", "html-tag-name-lowercase", "--ignore-disable-comments")
+
+        expect(ignoring.output).toContain("should be lowercase")
+        expect(ignoring.exitCode).toBe(1)
+      } finally {
+        try { unlinkSync(fixturePath) } catch {}
+      }
+    })
+
+    test("applies when the run is split across workers", () => {
+      const { output, exitCode } = runLinter("parallel", "--jobs", "4", "--json", "--only", "html-tag-name-lowercase")
+      const result = JSON.parse(output)
+
+      expect(result.offenses).toHaveLength(0)
+      expect(result.summary.ruleCount).toBe(1)
+      expect(exitCode).toBe(0)
+    })
+  })
+
   describe("Directory Scoping (issue #1045)", () => {
     const { mkdirSync, writeFileSync, rmSync, existsSync } = require("fs")
     const { join } = require("path")
@@ -657,11 +882,11 @@ describe("CLI Output Formatting", () => {
     const { join } = require("path")
     const tempDir = "test/fixtures/custom-rules-test"
 
-    function runLinterFromPath(filePath: string): { output: string, exitCode: number } {
+    function runLinterFromPath(filePath: string, ...args: string[]): { output: string, exitCode: number } {
       try {
         const { execSync } = require("child_process")
 
-        const output = execSync(`bin/herb-lint ${filePath} --no-timing 2>&1`, {
+        const output = execSync(`bin/herb-lint ${filePath} ${args.join(" ")} --no-timing 2>&1`, {
           encoding: "utf-8",
           env: { ...process.env, NO_COLOR: "1", FORCE_COLOR: undefined, GITHUB_ACTIONS: undefined }
         })
@@ -718,6 +943,87 @@ describe("CLI Output Formatting", () => {
         expect(output).toContain("Loaded 1 custom rule")
         expect(output).toContain("no-hello-world")
         expect(output).toContain("Text contains 'hello world' which is not allowed")
+        expect(exitCode).toBe(1)
+      } finally {
+        if (existsSync(tempDir)) {
+          rmSync(tempDir, { recursive: true, force: true })
+        }
+      }
+    })
+
+    test("can select a custom rule with --only", () => {
+      try {
+        mkdirSync(join(tempDir, ".herb/rules"), { recursive: true })
+        mkdirSync(join(tempDir, "app/views/widgets"), { recursive: true })
+
+        writeFileSync(join(tempDir, ".herb.yml"), dedent`
+          version: 0.10.2
+          linter:
+            enabled: true
+        `)
+
+        writeFileSync(join(tempDir, ".herb/rules/no-hello-world.mjs"), dedent`
+          export default class NoHelloWorldRule {
+            static ruleName = "no-hello-world"
+
+            check(document, context) {
+              const source = document.source || ""
+
+              if (!source.includes("hello world")) return []
+
+              return [{
+                message: "Text contains 'hello world' which is not allowed",
+                location: {
+                  start: { line: 1, column: 1 },
+                  end: { line: 1, column: 22 }
+                }
+              }]
+            }
+          }
+        `)
+
+        writeFileSync(join(tempDir, "app/views/widgets/test.html.erb"), `<DIV>hello world</DIV>\n`)
+
+        const { output, exitCode } = runLinterFromPath(join(tempDir, "app/views/widgets/test.html.erb"), "--simple", "--only", "no-hello-world")
+
+        expect(output).toContain("Text contains 'hello world' which is not allowed")
+        expect(output).not.toContain("html-tag-name-lowercase")
+        expect(output).toContain("1 enabled | filtered by --only")
+        expect(exitCode).toBe(1)
+      } finally {
+        if (existsSync(tempDir)) {
+          rmSync(tempDir, { recursive: true, force: true })
+        }
+      }
+    })
+
+    test("suggests a custom rule name for an unknown --only rule", () => {
+      try {
+        mkdirSync(join(tempDir, ".herb/rules"), { recursive: true })
+        mkdirSync(join(tempDir, "app/views"), { recursive: true })
+
+        writeFileSync(join(tempDir, ".herb.yml"), dedent`
+          version: 0.10.2
+          linter:
+            enabled: true
+        `)
+
+        writeFileSync(join(tempDir, ".herb/rules/no-hello-world.mjs"), dedent`
+          export default class NoHelloWorldRule {
+            static ruleName = "no-hello-world"
+
+            check(document, context) {
+              return []
+            }
+          }
+        `)
+
+        writeFileSync(join(tempDir, "app/views/test.html.erb"), "<div></div>\n")
+
+        const { output, exitCode } = runLinterFromPath(join(tempDir, "app/views/test.html.erb"), "--simple", "--only", "no-hello-wold")
+
+        expect(output).toContain("Unknown rule no-hello-wold passed to --only")
+        expect(output).toContain("Did you mean no-hello-world?")
         expect(exitCode).toBe(1)
       } finally {
         if (existsSync(tempDir)) {

--- a/javascript/packages/linter/test/linter.test.ts
+++ b/javascript/packages/linter/test/linter.test.ts
@@ -683,6 +683,93 @@ describe("@herb-tools/linter", () => {
     })
   })
 
+  describe("`only` rule filtering", () => {
+    class EnabledRule extends ParserRule {
+      static ruleName = "enabled-rule"
+
+      get defaultConfig(): FullRuleConfig {
+        return { enabled: true, severity: "error" }
+      }
+
+      check(): UnboundLintOffense[] { return [] }
+    }
+
+    class DisabledRule extends ParserRule {
+      static ruleName = "disabled-rule"
+
+      get defaultConfig(): FullRuleConfig {
+        return { enabled: false, severity: "error" }
+      }
+
+      check(): UnboundLintOffense[] { return [] }
+    }
+
+    class VersionGatedRule extends ParserRule {
+      static ruleName = "version-gated-rule"
+      static introducedIn = "0.9.0" as const
+
+      get defaultConfig(): FullRuleConfig {
+        return { enabled: true, severity: "error" }
+      }
+
+      check(): UnboundLintOffense[] { return [] }
+    }
+
+    test("enables exactly the requested rules", () => {
+      const { enabled } = Linter.filterRulesByConfig([EnabledRule, DisabledRule, VersionGatedRule], undefined, undefined, {
+        only: ["disabled-rule"]
+      })
+
+      expect(enabled).toHaveLength(1)
+      expect(enabled[0].ruleName).toBe("disabled-rule")
+    })
+
+    test("ignores rules disabled in the config and version gating", () => {
+      const { enabled, skippedByVersion, disabledByConfig, notEnabledByDefault } = Linter.filterRulesByConfig(
+        [EnabledRule, DisabledRule, VersionGatedRule],
+        { "disabled-rule": { enabled: false } },
+        "0.8.0",
+        { only: ["disabled-rule", "version-gated-rule"] }
+      )
+
+      expect(enabled.map(ruleClass => ruleClass.ruleName)).toEqual(["disabled-rule", "version-gated-rule"])
+      expect(skippedByVersion).toHaveLength(0)
+      expect(disabledByConfig).toBe(0)
+      expect(notEnabledByDefault).toBe(0)
+    })
+
+    test("ignores unknown rule names", () => {
+      const { enabled } = Linter.filterRulesByConfig([EnabledRule, DisabledRule], undefined, undefined, {
+        only: ["does-not-exist"]
+      })
+
+      expect(enabled).toHaveLength(0)
+    })
+
+    test("falls back to the regular filtering when the list is empty", () => {
+      const { enabled } = Linter.filterRulesByConfig([EnabledRule, DisabledRule], undefined, undefined, { only: [] })
+
+      expect(enabled).toHaveLength(1)
+      expect(enabled[0].ruleName).toBe("enabled-rule")
+    })
+
+    test("Linter.from() only runs the requested rules", () => {
+      const config = Config.fromObject({
+        linter: {
+          enabled: true,
+          rules: { "html-tag-name-lowercase": { enabled: false } }
+        }
+      })
+
+      const linter = Linter.from(Herb, config, undefined, { only: ["html-tag-name-lowercase"] })
+      const result = linter.lint("<DIV></DIV>", { fileName: "template.html.erb" })
+
+      expect(linter.getRuleCount()).toBe(1)
+      expect(linter.onlyRules).toEqual(["html-tag-name-lowercase"])
+      expect(result.offenses.map(offense => offense.rule)).toEqual(["html-tag-name-lowercase", "html-tag-name-lowercase"])
+    })
+  })
+
   describe("Version-gated rule filtering", () => {
     class OldRule extends ParserRule {
       static ruleName = "old-rule"

--- a/javascript/packages/stimulus-lint/src/cli.ts
+++ b/javascript/packages/stimulus-lint/src/cli.ts
@@ -19,12 +19,17 @@ class StimulusFileProcessor extends FileProcessor {
     this.stimulusProject = stimulusProject
   }
 
+  async findUnknownRules(ruleNames: string[], context?: any, formatOption: any = 'detailed', additionalRuleNames: string[] = []) {
+    return this.parentProcessor.findUnknownRules(ruleNames, context, formatOption, additionalRuleNames)
+  }
+
   async processFiles(files: string[], formatOption: any = 'detailed', context?: any) {
     const lintStartTime = Date.now()
 
     const baseResults = await this.parentProcessor.processFiles(files, formatOption, context)
 
-    const stimulusLinter = new StimulusLinter(Herb, defaultRules, this.stimulusProject)
+    const stimulusRules = context?.only ? defaultRules.filter(rule => context.only.includes(rule.ruleName)) : defaultRules
+    const stimulusLinter = new StimulusLinter(Herb, stimulusRules, this.stimulusProject)
 
     for (const filename of files) {
       const filePath = context?.projectPath ? resolve(context.projectPath, filename) : resolve(filename)
@@ -136,6 +141,10 @@ export class CLI extends HerbLinterCLI {
 
   constructor() {
     super()
+  }
+
+  protected additionalRuleNames(): string[] {
+    return defaultRules.map(rule => rule.ruleName)
   }
 
   protected async beforeProcess(): Promise<void> {


### PR DESCRIPTION
This pull request introduces an `--only` flag for the linter CLI that runs exactly the given rules and ignores the rule configuration in `.herb.yml`.

Today the only way to try out a single rule against a codebase is to edit `.herb.yml`, run the linter, and then revert the change. That's especially awkward for rules that are currently disabled, not enabled by default, or gated behind the `version` in the config, which are exactly the rules you want to try before committing to them.

Only run a single rule:
```bash
herb-lint --only html-img-require-alt
```

Only run multiple rules (comma-separated):
```bash
herb-lint --only html-img-require-alt,html-tag-name-lowercase
```

The flag can also be passed multiple times:
```bash
herb-lint --only html-img-require-alt --only html-tag-name-lowercase
```

Combine it with `--fix` to only autocorrect a specific rule:
```bash
herb-lint --fix --only html-tag-name-lowercase
```

The `Rules` line reports the filter instead of the config-based counts, and the "New rules available" upgrade hint is suppressed, since version gating doesn't apply with `--only`:

```
 Summary:
  Checked      1 file
  Offenses     1 warning (1 offense across 1 file)
  Fixable      0 offenses
  Rules        1 enabled | filtered by --only
```