### PR TITLE
CI: Compare Corpus against pull request base branch

### DIFF
--- a/.github/workflows/corpus.yml
+++ b/.github/workflows/corpus.yml
@@ -47,6 +47,7 @@ jobs:
 
       - name: Install the last released gem
         id: release
+        if: github.event_name != 'pull_request'
         run: |-
           version=$(gem search '^herb$' --remote --no-prerelease | sed -n 's/^herb (\([0-9][0-9.]*\).*/\1/p')
 
@@ -60,11 +61,29 @@ jobs:
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "Comparing against herb $version"
 
+      - name: Check out the base branch
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |-
+          git fetch --depth 1 origin "$BASE_SHA"
+          git worktree add base "$BASE_SHA"
+
+      - name: Build the base branch
+        if: github.event_name == 'pull_request'
+        working-directory: base
+        run: |-
+          bundle install --jobs 4
+          bundle exec rake templates
+          bundle exec rake make
+          bundle exec rake compile
+
       - name: Wait for the corpus clone
         wait: [corpus]
 
       - name: Measure the last release
         id: measure-release
+        if: github.event_name != 'pull_request'
         background: true
         env:
           BUNDLE_GEMFILE: ""
@@ -74,7 +93,23 @@ jobs:
             --version "${{ steps.release.outputs.version }}" \
             --label "released ${{ steps.release.outputs.version }}" \
             --corpus corpus/erb \
-            --out corpus/runs/release.json
+            --out corpus/runs/baseline.json
+
+      - name: Measure the base branch
+        id: measure-base
+        if: github.event_name == 'pull_request'
+        background: true
+        env:
+          BUNDLE_GEMFILE: ""
+          RUBYOPT: ""
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |-
+          corpus/bin/measure-herb \
+            --gem-path base \
+            --label "$BASE_REF (${BASE_SHA::7})" \
+            --corpus corpus/erb \
+            --out corpus/runs/baseline.json
 
       - name: Render Templates
         run: bundle exec rake templates
@@ -85,7 +120,7 @@ jobs:
       - name: Compile Ruby extension
         run: bundle exec rake compile
 
-      - name: Wait for the release measurement
+      - name: Wait for the baseline measurement
         wait-all:
 
       - name: Measure this branch
@@ -107,7 +142,7 @@ jobs:
           set -o pipefail
 
           corpus/bin/diff-runs \
-            corpus/runs/release.json \
+            corpus/runs/baseline.json \
             corpus/runs/branch.json \
             --markdown comment.md \
             --fail-on-regression | tee comparison.txt
@@ -135,7 +170,7 @@ jobs:
         if: always()
         run: |-
           {
-            echo "### Corpus: this branch vs herb ${{ steps.release.outputs.version }}"
+            echo "### Corpus"
             echo
             echo '```'
             cat comparison.txt 2>/dev/null || echo "the comparison did not run"


### PR DESCRIPTION
This pull request changes the corpus workflow to compare pull requests against their base branch instead of the last released gem, and to post the corpus report for improvements, not just regressions.

Previously every pull request was measured against the latest released gem, so the diff inherited everything already merged to main since that release. 

A PR comment could show files "fixed" by other merged PRs, and a regression that landed on main would fail the corpus check on every open PR until it was resolved. The question a PR reviewer actually has is what *this* PR changes.