### PR TITLE
Linter: Update `html-no-duplicate-ids` to use `ERBIterationBlockNode`

### DIFF
--- a/javascript/packages/linter/src/rules/html-no-duplicate-ids.ts
+++ b/javascript/packages/linter/src/rules/html-no-duplicate-ids.ts
@@ -2,8 +2,9 @@ import { ParserRule, BaseAutofixContext } from "../types"
 import { ControlFlowTrackingVisitor, ControlFlowType } from "./rule-utils"
 import { Printer, IdentityPrinter } from "@herb-tools/printer"
 
-import { hasDynamicOutput, getValidatableStaticContent, getStaticAttributeName, isERBOutputNode, getTagLocalName } from "@herb-tools/core"
+import { hasDynamicOutput, getValidatableStaticContent, getStaticAttributeName, isERBOutputNode, isRubyLiteralNode, isRubyParameterNode, getTagLocalName } from "@herb-tools/core"
 
+import type * as Nodes from "@herb-tools/core"
 import type { ParseResult, HTMLAttributeNode, HTMLElementNode, LiteralNode, ERBContentNode, RubyLiteralNode, ParserOptions } from "@herb-tools/core"
 import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types"
 
@@ -36,6 +37,9 @@ class NoDuplicateIdsVisitor extends ControlFlowTrackingVisitor<BaseAutofixContex
   private documentIds: Set<string> = new Set<string>()
   private currentBranchIds: Set<string> = new Set<string>()
   private controlFlowIds: Set<string> = new Set<string>()
+  private loopVariableScopes: string[][] = []
+
+  private static readonly IMPLICIT_BLOCK_PARAMETERS = ["it", "_1", "_2", "_3", "_4", "_5", "_6", "_7", "_8", "_9"]
 
   visitHTMLElementNode(node: HTMLElementNode): void {
     if (getTagLocalName(node) === "template") {
@@ -51,16 +55,51 @@ class NoDuplicateIdsVisitor extends ControlFlowTrackingVisitor<BaseAutofixContex
     this.checkAttribute(node)
   }
 
+  visitERBIterationBlockNode(node: Nodes.ERBIterationBlockNode): void {
+    const declared = node.block_arguments
+      .filter(isRubyParameterNode)
+      .map(argument => argument.name?.value)
+      .filter((name): name is string => Boolean(name))
+
+    const names = declared.length > 0 ? declared : NoDuplicateIdsVisitor.IMPLICIT_BLOCK_PARAMETERS
+
+    this.loopVariableScopes.push(names)
+    super.visitERBIterationBlockNode(node)
+    this.loopVariableScopes.pop()
+  }
+
+  private variesPerIteration(attributeNode: HTMLAttributeNode): boolean {
+    const names = this.loopVariableScopes[this.loopVariableScopes.length - 1] ?? []
+
+    if (names.length === 0) return false
+
+    return (attributeNode.value?.children ?? []).some(child => {
+      let code: string | null = null
+
+      if (isERBOutputNode(child)) code = (child as ERBContentNode).content?.value ?? ""
+      if (isRubyLiteralNode(child)) code = (child as RubyLiteralNode).content ?? ""
+
+      if (code === null) return false
+
+      return names.some(name => new RegExp(`(?<![A-Za-z0-9_])${name}(?![A-Za-z0-9_])`).test(code!))
+    })
+  }
+
   private visitTemplateElementNode(node: HTMLElementNode): void {
     if (node.open_tag) this.visit(node.open_tag)
 
     const previousDocumentIds = this.documentIds
     const previousBranchIds = this.currentBranchIds
     const previousControlFlowIds = this.controlFlowIds
+    const previousIsInControlFlow = this.isInControlFlow
+    const previousControlFlowType = this.currentControlFlowType
 
     this.documentIds = new Set<string>()
     this.currentBranchIds = new Set<string>()
     this.controlFlowIds = new Set<string>()
+
+    this.isInControlFlow = false
+    this.currentControlFlowType = null
 
     for (const child of node.body) {
       this.visit(child)
@@ -69,6 +108,8 @@ class NoDuplicateIdsVisitor extends ControlFlowTrackingVisitor<BaseAutofixContex
     this.documentIds = previousDocumentIds
     this.currentBranchIds = previousBranchIds
     this.controlFlowIds = previousControlFlowIds
+    this.isInControlFlow = previousIsInControlFlow
+    this.currentControlFlowType = previousControlFlowType
 
     if (node.close_tag) this.visit(node.close_tag)
   }
@@ -132,10 +173,6 @@ class NoDuplicateIdsVisitor extends ControlFlowTrackingVisitor<BaseAutofixContex
     const valueNodes = attributeNode.value?.children || []
     const isDynamic = hasDynamicOutput(valueNodes)
 
-    if (isDynamic && this.isInControlFlow && this.currentControlFlowType === ControlFlowType.LOOP) {
-      return null
-    }
-
     const identifier = isDynamic ? OutputPrinter.print(valueNodes) : getValidatableStaticContent(valueNodes)
     if (!identifier) return null
 
@@ -169,24 +206,33 @@ class NoDuplicateIdsVisitor extends ControlFlowTrackingVisitor<BaseAutofixContex
   }
 
   private handleLoopId(identifier: string, attributeNode: HTMLAttributeNode, isDynamic: boolean): void {
-    if (!isDynamic) {
-      this.addDuplicateIdOffense(identifier, attributeNode.location)
+    if (this.currentBranchIds.has(identifier)) {
+      this.addSameLoopIterationOffense(identifier, attributeNode.location, isDynamic)
+
       return
     }
 
-    if (this.currentBranchIds.has(identifier)) {
-      this.addSameLoopIterationOffense(identifier, attributeNode.location)
+    if (!isDynamic) {
+      this.addDuplicateIdOffense(identifier, attributeNode.location)
+
+      return
+    }
+
+    if (this.loopVariableScopes.length > 0 && !this.variesPerIteration(attributeNode)) {
+      this.addDuplicateIdOffense(identifier, attributeNode.location)
     }
   }
 
   private handleConditionalId(identifier: string, attributeNode: HTMLAttributeNode, isDynamic: boolean): void {
     if (this.currentBranchIds.has(identifier)) {
       this.addSameBranchOffense(identifier, attributeNode.location, isDynamic)
+
       return
     }
 
     if (!isDynamic && this.documentIds.has(identifier)) {
       this.addDuplicateIdOffense(identifier, attributeNode.location)
+
       return
     }
 
@@ -202,6 +248,7 @@ class NoDuplicateIdsVisitor extends ControlFlowTrackingVisitor<BaseAutofixContex
       } else {
         this.addDuplicateIdOffense(identifier, attributeNode.location)
       }
+
       return
     }
 
@@ -215,7 +262,18 @@ class NoDuplicateIdsVisitor extends ControlFlowTrackingVisitor<BaseAutofixContex
     )
   }
 
-  private addSameLoopIterationOffense(identifier: string, location: any): void {
+  private addSameLoopIterationOffense(identifier: string, location: any, isDynamic: boolean): void {
+    if (isDynamic) {
+      this.addOffense(
+        `Potential duplicate ID \`${identifier}\` found within the same loop iteration. If this expression evaluates to the same value, IDs must be unique.`,
+        location,
+        undefined,
+        "hint",
+      )
+
+      return
+    }
+
     this.addOffense(
       `Duplicate ID \`${identifier}\` found within the same loop iteration. IDs must be unique within the same loop iteration.`,
       location,
@@ -230,6 +288,7 @@ class NoDuplicateIdsVisitor extends ControlFlowTrackingVisitor<BaseAutofixContex
         undefined,
         "hint",
       )
+
       return
     }
 
@@ -261,7 +320,10 @@ export class HTMLNoDuplicateIdsRule extends ParserRule {
   }
 
   get parserOptions(): Partial<ParserOptions> {
-    return { action_view_helpers: true }
+    return {
+      action_view_helpers: true,
+      iteration_nodes: true
+    }
   }
 
   check(result: ParseResult, context?: Partial<LintContext>): UnboundLintOffense[] {

--- a/javascript/packages/linter/src/rules/rule-utils.ts
+++ b/javascript/packages/linter/src/rules/rule-utils.ts
@@ -153,7 +153,7 @@ export abstract class ControlFlowTrackingVisitor<TAutofixContext extends BaseAut
   }
 
   visitERBIterationBlockNode(node: Nodes.ERBIterationBlockNode): void {
-    this.handleControlFlowNode(node, ControlFlowType.CONDITIONAL, () => super.visitERBIterationBlockNode(node))
+    this.handleControlFlowNode(node, ControlFlowType.LOOP, () => super.visitERBIterationBlockNode(node))
   }
 
   visitERBElseNode(node: Nodes.ERBElseNode): void {

--- a/javascript/packages/linter/test/rules/html-no-duplicate-ids.test.ts
+++ b/javascript/packages/linter/test/rules/html-no-duplicate-ids.test.ts
@@ -222,7 +222,9 @@ describe("html-no-duplicate-ids", () => {
   })
 
   test("fails for non-output ERB IDs in loops (same value repeated)", () => {
-    expectError('Duplicate ID `user-` found within the same control flow branch. IDs must be unique within the same control flow branch.')
+    expectError('Duplicate ID `user-` found. IDs must be unique within a document.')
+    expectError('Duplicate ID `user-` found within the same loop iteration. IDs must be unique within the same loop iteration.')
+
     assertOffenses(dedent`
       <% users.each do |user| %>
         <div id="user-<% 'static' %>">User</div>
@@ -247,6 +249,7 @@ describe("html-no-duplicate-ids", () => {
 
   test("fails for static ID in while loops", () => {
     expectError('Duplicate ID `static-id` found. IDs must be unique within a document.')
+
     assertOffenses(dedent`
       <% while condition %>
         <div id="static-id">Item</div>
@@ -256,6 +259,7 @@ describe("html-no-duplicate-ids", () => {
 
   test("fails for non-dynamic ID in until loops", () => {
     expectError('Duplicate ID `static-id` found. IDs must be unique within a document.')
+
     assertOffenses(dedent`
       <% until condition %>
         <div id="static-id">Item</div>
@@ -275,6 +279,7 @@ describe("html-no-duplicate-ids", () => {
 
   test("hints for duplicate output ERB IDs within same conditional branch", () => {
     expectHint('Potential duplicate ID `user-<%= user.id %>` found within the same control flow branch. If this expression evaluates to the same value, IDs must be unique.')
+
     assertOffenses(dedent`
       <% if condition %>
         <div id="user-<%= user.id %>">User A</div>
@@ -304,8 +309,9 @@ describe("html-no-duplicate-ids", () => {
     `)
   })
 
-  test.todo("fails for static attribute in a loop context", () => {
+  test("fails for static attribute in a loop context", () => {
     expectError('Duplicate ID `user` found. IDs must be unique within a document.')
+
     assertOffenses(dedent`
       <% @users.each do |user| %>
         <div id="user"></div>
@@ -360,7 +366,7 @@ describe("html-no-duplicate-ids", () => {
   })
 
   test("hints for duplicate dynamic IDs within same block", () => {
-    expectHint('Potential duplicate ID `item-<%= item.id %>` found within the same control flow branch. If this expression evaluates to the same value, IDs must be unique.')
+    expectHint('Potential duplicate ID `item-<%= item.id %>` found within the same loop iteration. If this expression evaluates to the same value, IDs must be unique.')
 
     assertOffenses(dedent`
       <% items.each do |item| %>
@@ -386,8 +392,10 @@ describe("html-no-duplicate-ids", () => {
     `)
   })
 
-  test("passes for dynamic ID in global scope and same dynamic ID in a block", () => {
-    expectNoOffenses(dedent`
+  test("fails for a dynamic ID in a block that does not reference the block argument", () => {
+    expectError('Duplicate ID `user-<%= user.id %>` found. IDs must be unique within a document.')
+
+    assertOffenses(dedent`
       <div id="user-<%= user.id %>"></div>
 
       <% items.each do |item| %>
@@ -396,8 +404,10 @@ describe("html-no-duplicate-ids", () => {
     `)
   })
 
-  test("passes for dynamic ID in a block and same dynamic ID in global scope", () => {
-    expectNoOffenses(dedent`
+  test("fails for a dynamic ID in a block that does not reference the block argument, block first", () => {
+    expectError('Duplicate ID `user-<%= user.id %>` found. IDs must be unique within a document.')
+
+    assertOffenses(dedent`
       <% items.each do |item| %>
         <div id="user-<%= user.id %>"></div>
       <% end %>
@@ -451,6 +461,7 @@ describe("html-no-duplicate-ids", () => {
   })
 
   test("fails for static IDs in separate each blocks", () => {
+    expectError('Duplicate ID `static-id` found. IDs must be unique within a document.')
     expectError('Duplicate ID `static-id` found. IDs must be unique within a document.')
     assertOffenses(dedent`
       <% first.each do |item| %>
@@ -1002,7 +1013,9 @@ describe("html-no-duplicate-ids", () => {
       })
 
       test("matches outside-template behavior for a static ID in a single block", () => {
-        expectNoOffenses(dedent`
+        expectError('Duplicate ID `static-id` found. IDs must be unique within a document.')
+
+        assertOffenses(dedent`
           <template>
             <% items.each do |item| %>
               <div id="static-id"></div>
@@ -1012,6 +1025,7 @@ describe("html-no-duplicate-ids", () => {
       })
 
       test("fails for static IDs in separate blocks inside one <template>", () => {
+        expectError('Duplicate ID `static-id` found. IDs must be unique within a document.')
         expectError('Duplicate ID `static-id` found. IDs must be unique within a document.')
 
         assertOffenses(dedent`
@@ -1027,8 +1041,11 @@ describe("html-no-duplicate-ids", () => {
         `)
       })
 
-      test("passes for static IDs in blocks in separate <template> elements", () => {
-        expectNoOffenses(dedent`
+      test("reports static IDs in blocks in separate <template> elements", () => {
+        expectError('Duplicate ID `static-id` found. IDs must be unique within a document.')
+        expectError('Duplicate ID `static-id` found. IDs must be unique within a document.')
+
+        assertOffenses(dedent`
           <template>
             <% first.each do |item| %>
               <div id="static-id"></div>
@@ -1132,9 +1149,9 @@ describe("html-no-duplicate-ids", () => {
     })
   })
 
-  describe("pending: block iteration nodes (ERBBlockEachNode)", () => {
+  describe("block iteration nodes (ERBIterationBlockNode)", () => {
     describe("static IDs repeat once per iteration", () => {
-      test.todo("fails for a static ID in a single each block", () => {
+      test("fails for a static ID in a single each block", () => {
         expectError('Duplicate ID `item` found. IDs must be unique within a document.')
 
         assertOffenses(dedent`
@@ -1144,7 +1161,27 @@ describe("html-no-duplicate-ids", () => {
         `)
       })
 
-      test.todo("fails for a static ID in a map block", () => {
+      test("fails for a static ID in a times block", () => {
+        expectError('Duplicate ID `row` found. IDs must be unique within a document.')
+
+        assertOffenses(dedent`
+          <% 3.times do |index| %>
+            <div id="row"></div>
+          <% end %>
+        `)
+      })
+
+      test("fails for a static ID in an upto block", () => {
+        expectError('Duplicate ID `row` found. IDs must be unique within a document.')
+
+        assertOffenses(dedent`
+          <% 1.upto(5) do |index| %>
+            <div id="row"></div>
+          <% end %>
+        `)
+      })
+
+      test("fails for a static ID in a map block", () => {
         expectError('Duplicate ID `item` found. IDs must be unique within a document.')
 
         assertOffenses(dedent`
@@ -1154,7 +1191,7 @@ describe("html-no-duplicate-ids", () => {
         `)
       })
 
-      test.todo("fails for a static ID nested deep inside an each block", () => {
+      test("fails for a static ID nested deep inside an each block", () => {
         expectError('Duplicate ID `deep` found. IDs must be unique within a document.')
 
         assertOffenses(dedent`
@@ -1166,7 +1203,7 @@ describe("html-no-duplicate-ids", () => {
         `)
       })
 
-      test.todo("fails for an effectively-static ID in an each block", () => {
+      test("fails for an effectively-static ID in an each block", () => {
         expectError('Duplicate ID `item-` found. IDs must be unique within a document.')
 
         assertOffenses(dedent`
@@ -1176,7 +1213,7 @@ describe("html-no-duplicate-ids", () => {
         `)
       })
 
-      test.todo("fails for a static ID in an each block nested in an if branch", () => {
+      test("fails for a static ID in an each block nested in an if branch", () => {
         expectError('Duplicate ID `item` found. IDs must be unique within a document.')
 
         assertOffenses(dedent`
@@ -1188,7 +1225,7 @@ describe("html-no-duplicate-ids", () => {
         `)
       })
 
-      test.todo("fails for a static ID in nested each blocks", () => {
+      test("fails for a static ID in nested each blocks", () => {
         expectError('Duplicate ID `item` found. IDs must be unique within a document.')
 
         assertOffenses(dedent`
@@ -1200,7 +1237,7 @@ describe("html-no-duplicate-ids", () => {
         `)
       })
 
-      test.todo("fails for a static ID in an each block inside a <template>", () => {
+      test("fails for a static ID in an each block inside a <template>", () => {
         expectError('Duplicate ID `item` found. IDs must be unique within a document.')
 
         assertOffenses(dedent`
@@ -1214,7 +1251,7 @@ describe("html-no-duplicate-ids", () => {
     })
 
     describe("IDs that do not vary with the block argument", () => {
-      test.todo("fails for a dynamic ID that never references the block argument", () => {
+      test("fails for a dynamic ID that never references the block argument", () => {
         expectError('Duplicate ID `item-<%= unrelated.id %>` found. IDs must be unique within a document.')
 
         assertOffenses(dedent`
@@ -1232,6 +1269,72 @@ describe("html-no-duplicate-ids", () => {
         `)
       })
 
+      test("passes for a dynamic ID referencing the implicit `it` parameter", () => {
+        expectNoOffenses(dedent`
+          <% items.each do %>
+            <div id="item-<%= it %>"></div>
+          <% end %>
+        `)
+      })
+
+      test("passes for a dynamic ID referencing a numbered block parameter", () => {
+        expectNoOffenses(dedent`
+          <% items.each do %>
+            <div id="item-<%= _1 %>"></div>
+          <% end %>
+        `)
+      })
+
+      test("passes for a dynamic ID referencing a destructured block argument", () => {
+        expectNoOffenses(dedent`
+          <% pairs.each do |(key, value)| %>
+            <div id="pair-<%= key %>-<%= value %>"></div>
+          <% end %>
+        `)
+      })
+
+      test("passes for a dynamic ID referencing a splat block argument", () => {
+        expectNoOffenses(dedent`
+          <% rows.each do |*columns| %>
+            <div id="row-<%= columns.first %>"></div>
+          <% end %>
+        `)
+      })
+
+      test("fails when the block argument name is only a prefix of the referenced name", () => {
+        expectError('Duplicate ID `item-<%= items_count %>` found. IDs must be unique within a document.')
+
+        assertOffenses(dedent`
+          <% items.each do |item| %>
+            <div id="item-<%= items_count %>"></div>
+          <% end %>
+        `)
+      })
+
+      test("fails for an interpolated helper ID that never references the block argument", () => {
+        expectError('Duplicate ID `#{unrelated.name}-published` found. IDs must be unique within a document.')
+
+        assertOffenses(dedent`
+          <% events.each do |event| %>
+            <%= link_to event["url"], id: "#{unrelated.name}-published" do %>
+              <div></div>
+            <% end %>
+          <% end %>
+        `)
+      })
+
+      test("fails for a dynamic ID referencing only the outer block argument", () => {
+        expectError('Duplicate ID `group-<%= group.id %>` found. IDs must be unique within a document.')
+
+        assertOffenses(dedent`
+          <% groups.each do |group| %>
+            <% group.items.each do |item| %>
+              <div id="group-<%= group.id %>"></div>
+            <% end %>
+          <% end %>
+        `)
+      })
+
       test("passes for a dynamic ID referencing a nested block argument", () => {
         expectNoOffenses(dedent`
           <% groups.each do |group| %>
@@ -1244,7 +1347,7 @@ describe("html-no-duplicate-ids", () => {
     })
 
     describe("regression guard: duplicates within one iteration", () => {
-      test.todo("still reports a duplicate dynamic ID within one each iteration", () => {
+      test("still reports a duplicate dynamic ID within one each iteration", () => {
         expectHint('Potential duplicate ID `item-<%= item.id %>` found within the same loop iteration. If this expression evaluates to the same value, IDs must be unique.')
 
         assertOffenses(dedent`
@@ -1255,7 +1358,7 @@ describe("html-no-duplicate-ids", () => {
         `)
       })
 
-      test.todo("still reports a duplicate dynamic ID within one each iteration inside a <template>", () => {
+      test("still reports a duplicate dynamic ID within one each iteration inside a <template>", () => {
         expectHint('Potential duplicate ID `item-<%= item.id %>` found within the same loop iteration. If this expression evaluates to the same value, IDs must be unique.')
 
         assertOffenses(dedent`
@@ -1268,7 +1371,7 @@ describe("html-no-duplicate-ids", () => {
         `)
       })
 
-      test.todo("keeps separate each blocks independent once they are loops", () => {
+      test("keeps separate each blocks independent once they are loops", () => {
         expectNoOffenses(dedent`
           <% first.each do |item| %>
             <div id="item-<%= item.id %>"></div>


### PR DESCRIPTION
Follow up on #1912.

This pull request updates `html-no-duplicate-ids` to treat iteration blocks as loops, which enables the pending `test.todo` cases the rule already carried for this scenario.

The rule always had complete loop handling. A static ID inside a loop is reported immediately because it renders once per iteration, and a dynamic ID that varies per iteration is skipped. 

The only missing piece was that `each` blocks were classified as `CONDITIONAL`, because a plain `ERBBlockNode` gives no way to tell a loop apart from a builder block. 

With `ERBIterationBlockNode` that distinction exists, so the rule opts into `iteration_nodes` and maps the node to `ControlFlowType.LOOP`.

```erb
<% items.each do |item| %>
  <div id="item"></div>
<% end %>
```

```
Duplicate ID `item` found. IDs must be unique within a document.
```

#### IDs that can't vary

A dynamic ID inside an iteration block that never references the block argument renders the same value every iteration, so it is a duplicate too. `block_arguments` on the node makes this decidable:

```erb
<% items.each do |item| %>
  <div id="item-<%= item.id %>"></div>  <%# passes, varies per iteration %>
<% end %>

<% items.each do |item| %>
  <div id="user-<%= user.id %>"></div>  <%# fails, constant across iterations %>
<% end %>
```

Only the innermost block's arguments count. Inside nested blocks an ID built from the outer variable alone is still constant for every inner iteration:

```erb
<% groups.each do |group| %>
  <% group.items.each do |item| %>
    <div id="group-<%= group.id %>"></div>              <%# fails %>
    <div id="group-<%= group.id %>-<%= item.id %>"></div>  <%# passes %>
  <% end %>
<% end %>
```

Only the ERB expressions are searched, never the literal parts, so `id="item-<%= items_count %>"` isn't treated as referencing `item` just because the prefix happens to contain it. A block with no declared parameters falls back to Ruby's implicit block parameters, so `<%= it %>` and `<%= _1 %>` are recognised as varying. `while`, `until` and `for` loops keep the previous permissive behaviour, since their loop variables aren't known.

#### Duplicates within one iteration

`extractIdValue` discarded every dynamic ID inside a loop, which made `addSameLoopIterationOffense` unreachable. Removing that early return lets `handleLoopId` distinguish "varies per iteration" from "repeated within one iteration":

```erb
<% items.each do |item| %>
  <div id="item-<%= item.id %>"></div>
  <span id="item-<%= item.id %>"></span>
<% end %>
```

```
Potential duplicate ID `item-<%= item.id %>` found within the same loop iteration. If this expression evaluates to the same value, IDs must be unique.
```

Relatedly, `handleLoopId` returned early for static IDs, so a static ID repeated inside one iteration reported the generic document-level message twice. The within-iteration finding is the more specific one and now wins:

```erb
<% users.each do |user| %>
  <div id="user-<% 'static' %>">User</div>
  <div id="user-<% 'static' %>">Duplicate</div>
<% end %>
```

```
Duplicate ID `user-` found. IDs must be unique within a document.
Duplicate ID `user-` found within the same loop iteration. IDs must be unique within the same loop iteration.
```

#### `<template>` scope

`visitTemplateElementNode` reset the ID sets but not the control flow context, so a `<template>` nested in a loop had its static IDs reported as repeating once per iteration. A `<template>` is inert and instantiated separately, so its contents now start from a clean control flow scope as well. A loop *inside* a `<template>` still behaves normally.

Several existing tests encoded the previous behaviour, where a static ID in a single `each` block produced no offense, and have been updated. The consistent model is that a static ID inside an iteration block is always a duplicate, regardless of `<template>` nesting or how many blocks there are.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>