### PR TITLE
Linter: Update `erb-no-output-control-flow` to use `ERBIterationBlockNode`

### DIFF
--- a/javascript/packages/linter/src/rules/erb-no-output-control-flow.ts
+++ b/javascript/packages/linter/src/rules/erb-no-output-control-flow.ts
@@ -1,7 +1,7 @@
 import { BaseRuleVisitor } from "./rule-utils.js"
-
-import type { ParseResult, ERBIfNode, ERBUnlessNode, ERBElseNode, ERBEndNode } from "@herb-tools/core"
 import { ParserRule } from "../types.js"
+
+import type { ParseResult, ERBIfNode, ERBUnlessNode, ERBElseNode, ERBEndNode, ERBIterationBlockNode, ParserOptions } from "@herb-tools/core"
 import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types.js"
 
 class ERBNoOutputControlFlowRuleVisitor extends BaseRuleVisitor {
@@ -23,6 +23,29 @@ class ERBNoOutputControlFlowRuleVisitor extends BaseRuleVisitor {
   visitERBEndNode(node: ERBEndNode): void {
     this.checkOutputControlFlow(node)
     this.visitChildNodes(node)
+  }
+
+  visitERBIterationBlockNode(node: ERBIterationBlockNode): void {
+    this.checkOutputIterationBlock(node)
+    this.visitChildNodes(node)
+  }
+
+  private checkOutputIterationBlock(node: ERBIterationBlockNode): void {
+    const openTag = node.tag_opening
+
+    if (!openTag) return
+    if (openTag.value !== "<%=") return
+
+    const method = node.message?.value ?? "each"
+
+    const content = node.content?.value ?? " "
+    const tagClosing = node.tag_closing?.value ?? "%>"
+    const suggestion = `<%${content}${tagClosing}`.replace(/\s*\n\s*/g, " ")
+
+    this.addOffense(
+      `Iteration blocks like \`${method}\` should not be used with output tags, they return the collection instead of the rendered output. Use \`${suggestion}\` instead.`,
+      openTag.location,
+    )
   }
 
   private static readonly CONTROL_BLOCK_NAMES: Record<string, string> = {
@@ -57,6 +80,12 @@ export class ERBNoOutputControlFlowRule extends ParserRule {
     return {
       enabled: true,
       severity: "error"
+    }
+  }
+
+  get parserOptions(): Partial<ParserOptions> {
+    return {
+      iteration_nodes: true
     }
   }
 

--- a/javascript/packages/linter/test/rules/erb-no-output-control-flow.test.ts
+++ b/javascript/packages/linter/test/rules/erb-no-output-control-flow.test.ts
@@ -135,4 +135,140 @@ describe("erb-no-output-control-flow", () => {
 
     expectNoOffenses(html)
   })
+
+  it("should allow iteration blocks without output tags", () => {
+    expectNoOffenses(dedent`
+      <% [1, 2, 3, 4, 5].each do |i| %>
+        <%= i * i %>
+      <% end %>
+    `)
+  })
+
+  it("should not allow each blocks with output tags", () => {
+    const html = dedent`
+      <%= [1, 2, 3, 4, 5].each do |i| %>
+        <%= i * i %>
+      <% end %>
+    `
+
+    expectError('Iteration blocks like `each` should not be used with output tags, they return the collection instead of the rendered output. Use `<% [1, 2, 3, 4, 5].each do |i| %>` instead.')
+
+    assertOffenses(html)
+  })
+
+  it("names the iteration method in the message", () => {
+    const html = dedent`
+      <%= 3.times do |i| %>
+        <%= i %>
+      <% end %>
+    `
+
+    expectError('Iteration blocks like `times` should not be used with output tags, they return the collection instead of the rendered output. Use `<% 3.times do |i| %>` instead.')
+
+    assertOffenses(html)
+  })
+
+  it("should flag a nested each block with an output tag", () => {
+    const html = dedent`
+      <% groups.each do |group| %>
+        <%= group.items.each do |item| %>
+          <%= item %>
+        <% end %>
+      <% end %>
+    `
+
+    expectError('Iteration blocks like `each` should not be used with output tags, they return the collection instead of the rendered output. Use `<% group.items.each do |item| %>` instead.')
+
+    assertOffenses(html)
+  })
+
+  it("should not allow brace iteration blocks with output tags", () => {
+    const html = dedent`
+      <%= items.each { |item| %>
+        <%= item %>
+      <% } %>
+    `
+
+    expectError('Iteration blocks like `each` should not be used with output tags, they return the collection instead of the rendered output. Use `<% items.each { |item| %>` instead.')
+
+    assertOffenses(html)
+  })
+
+  it("should allow an output tag inside an iteration block body", () => {
+    expectNoOffenses(dedent`
+      <% items.each do |item| %>
+        <%= item.name %>
+      <% end %>
+    `)
+  })
+
+  it("should flag each iteration block that uses an output tag", () => {
+    const html = dedent`
+      <%= first.each do |item| %>
+        <%= item %>
+      <% end %>
+
+      <%= second.map do |item| %>
+        <%= item %>
+      <% end %>
+    `
+
+    expectError('Iteration blocks like `each` should not be used with output tags, they return the collection instead of the rendered output. Use `<% first.each do |item| %>` instead.')
+    expectError('Iteration blocks like `map` should not be used with output tags, they return the collection instead of the rendered output. Use `<% second.map do |item| %>` instead.')
+
+    assertOffenses(html)
+  })
+
+  it("preserves trim tags in the suggested replacement", () => {
+    const html = dedent`
+      <%= items.each do |item| -%>
+        <%= item %>
+      <% end %>
+    `
+
+    expectError('Iteration blocks like `each` should not be used with output tags, they return the collection instead of the rendered output. Use `<% items.each do |item| -%>` instead.')
+
+    assertOffenses(html)
+  })
+
+  it("collapses a multi-line iteration block onto one line in the suggestion", () => {
+    const html = dedent`
+      <%= [
+        1,
+        2
+      ].each do |i| %>
+        <%= i %>
+      <% end %>
+    `
+
+    expectError('Iteration blocks like `each` should not be used with output tags, they return the collection instead of the rendered output. Use `<% [ 1, 2 ].each do |i| %>` instead.')
+
+    assertOffenses(html)
+  })
+
+  it("suggests the replacement for a call with arguments", () => {
+    const html = dedent`
+      <%= items.each_slice(3) do |group| %>
+        <%= group %>
+      <% end %>
+    `
+
+    expectError('Iteration blocks like `each_slice` should not be used with output tags, they return the collection instead of the rendered output. Use `<% items.each_slice(3) do |group| %>` instead.')
+
+    assertOffenses(html)
+  })
+
+  it("should allow non-iteration blocks with output tags", () => {
+    expectNoOffenses(dedent`
+      <%= content_tag :div do %>
+        <span>content</span>
+      <% end %>
+    `)
+
+    expectNoOffenses(dedent`
+      <%= @user.tap do |user| %>
+        <%= user %>
+      <% end %>
+    `)
+  })
 })


### PR DESCRIPTION
Follow up on #1912 and #1913.

This pull request extends `erb-no-output-control-flow` to flag iteration blocks that are opened with an output tag. 

Iteration methods return the collection they iterated, not the markup their block rendered, so `<%=` prints the collection on top of the block output.

```erb
<% [1, 2, 3, 4, 5].each do |i| %>
  <%= i * i %>
<% end %>
```

```erb
<%= [1, 2, 3, 4, 5].each do |i| %>
  <%= i * i %>
<% end %>
```

```
Iteration blocks like `each` should not be used with output tags, they return the collection instead of the rendered output. Use `<% ... each ... %>` instead.
```

The rule already covered `if`, `unless`, `else` and `end`, so this fits alongside the existing checks rather than warranting a new rule.

#### Why `ERBIterationBlockNode`

Hooking on the iteration node rather than `ERBBlockNode` is what makes this safe. Plenty of blocks legitimately return markup and are correct with an output tag, and none of them become an `ERBIterationBlockNode`:

```erb
<%= form_with model: @user do |form| %>
  <%= form.text_field :name %>
<% end %>

<%= render "card" do %>
  <p>content</p>
<% end %>

<%= content_tag :div do %>
  <span>content</span>
<% end %>
```

The message names the method that was actually used, so `<%= 3.times do %>` reports `times` and `<%= items.map do %>` reports `map`. 

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>