### PR TITLE
Formatter: Fix `herb:disable` comment moving after tag

### DIFF
--- a/javascript/packages/formatter/src/format-printer.ts
+++ b/javascript/packages/formatter/src/format-printer.ts
@@ -279,8 +279,13 @@ export class FormatPrinter extends Printer implements TextFlowDelegate, Attribut
             return -1
           }
 
-          for (let forward = index + 1; forward < this.lines.length; forward++) {
-            if (this.lines[forward].trim() === ">") return forward
+          const analysis = this.elementFormattingAnalysis.get(entry.parentNode)
+          const openTagIsMultiline = analysis ? !analysis.openTagInline : true
+
+          if (openTagIsMultiline) {
+            for (let forward = index + 1; forward < this.lines.length; forward++) {
+              if (this.lines[forward].trim() === ">") return forward
+            }
           }
 
           return index

--- a/javascript/packages/formatter/test/herb-disable-comment-formatting.test.ts
+++ b/javascript/packages/formatter/test/herb-disable-comment-formatting.test.ts
@@ -736,4 +736,49 @@ describe("herb:disable comment formatting", () => {
       </pre>
     `, { passes: 2 })
   })
+
+  test("keeps herb:disable on single-line opening tag when a descendant opening tag wraps (#1680)", () => {
+    expectFormattedToMatch(dedent`
+      <mjml> <%# herb:disable html-no-unknown-tag %>
+        <p
+          style="<%= some_very_long_helper_method_name %>"
+          class="<%= another_long_helper_method_name %>"
+          data-x="<%= yet_another_helper %>"
+        >
+          <span></span>
+        </p>
+      </mjml>
+    `)
+  })
+
+  test("keeps herb:disable on a deeply nested single-line ancestor when a descendant opening tag wraps (#1680)", () => {
+    expectFormattedToMatch(dedent`
+      <div> <%# herb:disable some-rule %>
+        <section>
+          <p
+            style="<%= some_very_long_helper_method_name %>"
+            class="<%= another_long_helper_method_name %>"
+          >
+            <span></span>
+          </p>
+        </section>
+      </div>
+    `)
+  })
+
+  test("keeps herb:disable after the element's own wrapped opening tag, not a descendant's (#1680)", () => {
+    expectFormattedToMatch(dedent`
+      <section
+        data-really-long-attribute-name="some-long-value-here-yes"
+        another-long-attribute-name="another-long-value-here-yes"
+      > <%# herb:disable some-rule %>
+        <p
+          style="<%= some_very_long_helper_method_name %>"
+          class="<%= another_long_helper_method_name %>"
+        >
+          <span></span>
+        </p>
+      </section>
+    `)
+  })
 })


### PR DESCRIPTION
This pull request fixes the formatter moving an inline `<%# herb:disable %>` comment off the element it was attached to and onto a descendant element's opening tag.

When a `herb:disable` comment sits right after an element's opening tag, the formatter needs to re-attach it to the correct output line after formatting. To handle multi-line opening tags, it searched forward through the output for a line consisting of a lone `>` (the tag's closing bracket on its own line). 

The problem: when the anchor element's opening tag is short and renders on a single line, that forward search skips straight past it and lands on the first lone `>` it can find, which belongs to a *descendant* whose attributes wrapped across multiple lines.

The practical consequence is that a `herb:disable` directive silently starts suppressing the lint rule on the wrong element, so `herb-format` and `herb-lint` can no longer both pass at the same time.

**Before:**

```erb
<mjml> <%# herb:disable html-no-unknown-tag %>
  <p
    style="<%= some_very_long_helper_method_name %>"
    class="<%= another_long_helper_method_name %>"
    data-x="<%= yet_another_helper %>"
  >
    <span></span>
  </p>
</mjml>
```

formatted to:

```erb
<mjml>
  <p
    style="<%= some_very_long_helper_method_name %>"
    class="<%= another_long_helper_method_name %>"
    data-x="<%= yet_another_helper %>"
  > <%# herb:disable html-no-unknown-tag %>
    <span></span>
  </p>
</mjml>
```

**After:**

```erb
<mjml> <%# herb:disable html-no-unknown-tag %>
  <p
    style="<%= some_very_long_helper_method_name %>"
    class="<%= another_long_helper_method_name %>"
    data-x="<%= yet_another_helper %>"
  >
    <span></span>
  </p>
</mjml>
```

Resolves https://github.com/marcoroth/herb/issues/1680
