### PR TITLE
Parser: Don't treat escaped ERB tags as executable Ruby

### DIFF
--- a/javascript/packages/core/src/ast-utils.ts
+++ b/javascript/packages/core/src/ast-utils.ts
@@ -59,6 +59,12 @@ export type ERBCommentNode = ERBNode & {
   }
 }
 
+export type ERBEscapedNode = ERBNode & {
+  tag_opening: {
+    value: "<%%" | "<%%="
+  }
+}
+
 /**
  * Checks if a node is an ERB output node (generates content: <%= %> or <%== %>)
  */
@@ -67,6 +73,16 @@ export function isERBOutputNode(node: Node): node is ERBOutputNode {
   if (!node.tag_opening?.value) return false
 
   return ["<%=", "<%=="].includes(node.tag_opening?.value)
+}
+
+/**
+ * Checks if a node is an escaped ERB node (`<%%` or `<%%=`).
+ */
+export function isERBEscapedNode(node: Node): node is ERBEscapedNode {
+  if (!isERBNode(node)) return false
+  if (!node.tag_opening?.value) return false
+
+  return ["<%%", "<%%="].includes(node.tag_opening.value)
 }
 
 /**

--- a/javascript/packages/formatter/src/scaffold-template-detector.ts
+++ b/javascript/packages/formatter/src/scaffold-template-detector.ts
@@ -1,5 +1,5 @@
-import { Visitor } from "@herb-tools/core"
-import type { ERBContentNode, ParseResult } from "@herb-tools/core"
+import { Visitor, isERBEscapedNode } from "@herb-tools/core"
+import type { ERBNode, ParseResult } from "@herb-tools/core"
 
 export const isScaffoldTemplate = (result: ParseResult): boolean => {
   const detector = new ScaffoldTemplateDetector()
@@ -17,17 +17,9 @@ export const isScaffoldTemplate = (result: ParseResult): boolean => {
 export class ScaffoldTemplateDetector extends Visitor {
   public hasEscapedERB = false
 
-  visitERBContentNode(node: ERBContentNode): void {
-    const opening = node.tag_opening?.value
-
-    if (opening && opening.startsWith("<%%")) {
+  visitERBNode(node: ERBNode): void {
+    if (isERBEscapedNode(node)) {
       this.hasEscapedERB = true
-
-      return
     }
-
-    if (this.hasEscapedERB) return
-
-    this.visitChildNodes(node)
   }
 }

--- a/javascript/packages/linter/docs/rules/actionview-no-silent-render.md
+++ b/javascript/packages/linter/docs/rules/actionview-no-silent-render.md
@@ -28,6 +28,16 @@ This rule catches these silent rendering issues and enforces that `render` is on
 <%= render @product %>
 ```
 
+Escaped ERB tags (`<%%` and `<%%=`) are ignored. They render as the literal text `<%`/`<%=` rather than being executed, so generator and scaffold templates that emit `render` calls into the file they generate are not flagged:
+
+```erb
+<%% cache [menu, @page] do %>
+  <ul class="nav">
+    <%%= render partial: menu.to_partial_path, collection: menu.children %>
+  </ul>
+<%% end %>
+```
+
 ### 🚫 Bad
 
 ```erb

--- a/javascript/packages/linter/src/rules/erb-require-whitespace-inside-tags.ts
+++ b/javascript/packages/linter/src/rules/erb-require-whitespace-inside-tags.ts
@@ -1,5 +1,6 @@
 import { ParserRule, BaseAutofixContext, Mutable } from "../types.js"
 import { BaseRuleVisitor } from "./rule-utils.js"
+import { isERBEscapedNode } from "@herb-tools/core"
 
 import type { ParseResult, Token, ERBNode } from "@herb-tools/core"
 import type { UnboundLintOffense, LintOffense, LintContext, FullRuleConfig } from "../types.js"
@@ -27,6 +28,8 @@ class RequireWhitespaceInsideTags extends BaseRuleVisitor<ERBRequireWhitespaceAu
 
     if (openTag.value === "<%#") {
       this.checkCommentTagWhitespace(node, openTag, closeTag, value)
+    } else if (isERBEscapedNode(node) && value.startsWith("#")) {
+      this.checkCloseTagWhitespace(node, openTag, closeTag, value)
     } else {
       this.checkOpenTagWhitespace(node, openTag, closeTag, value)
       this.checkCloseTagWhitespace(node, openTag, closeTag, value)

--- a/javascript/packages/linter/src/rules/html-no-empty-attributes.ts
+++ b/javascript/packages/linter/src/rules/html-no-empty-attributes.ts
@@ -1,7 +1,7 @@
 import { ParserRule } from "../types.js"
 import { AttributeVisitorMixin, StaticAttributeStaticValueParams, DynamicAttributeStaticValueParams } from "./rule-utils.js"
 import { IdentityPrinter } from "@herb-tools/printer"
-import { Visitor, isERBOutputNode } from "@herb-tools/core"
+import { Visitor, isERBOutputNode, isERBEscapedNode } from "@herb-tools/core"
 
 import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types.js"
 import type { ParseResult, HTMLAttributeNode, ERBContentNode, LiteralNode, Node } from "@herb-tools/core"
@@ -62,7 +62,7 @@ class ContainsOutputContentVisitor extends Visitor {
   visitERBContentNode(node: ERBContentNode): void {
     if (this.hasOutputContent) return
 
-    if (isERBOutputNode(node)) {
+    if (isERBOutputNode(node) || isERBEscapedNode(node)) {
       this.hasOutputContent = true
 
       return

--- a/javascript/packages/linter/test/rules/actionview-no-silent-render.test.ts
+++ b/javascript/packages/linter/test/rules/actionview-no-silent-render.test.ts
@@ -91,4 +91,20 @@ describe("ActionViewNoSilentRenderRule", () => {
       <% render("shared/error") %>
     `)
   })
+
+  test("valid escaped render in a generator template", () => {
+    expectNoOffenses(dedent`
+      <%% cache [menu, @page] do %>
+        <ul class="nav">
+          <%%= render partial: menu.to_partial_path, collection: menu.children %>
+        </ul>
+      <%% end %>
+    `)
+  })
+
+  test("valid escaped silent render", () => {
+    expectNoOffenses(dedent`
+      <%% render "shared/error" %>
+    `)
+  })
 })

--- a/javascript/packages/linter/test/rules/erb-no-empty-control-flow.test.ts
+++ b/javascript/packages/linter/test/rules/erb-no-empty-control-flow.test.ts
@@ -454,4 +454,32 @@ describe("ERBNoEmptyControlFlowRule", () => {
       `)
     })
   })
+
+  describe("escaped ERB tags", () => {
+    test("detects empty escaped if block", () => {
+      expectHint("Empty if block: this control flow statement has no content")
+
+      assertOffenses(dedent`
+        <%% if condition %>
+        <%% end %>
+      `)
+    })
+
+    test("detects empty escaped do block", () => {
+      expectHint("Empty do block: this control flow statement has no content")
+
+      assertOffenses(dedent`
+        <%% items.each do |item| %>
+        <%% end %>
+      `)
+    })
+
+    test("does not flag escaped block with content", () => {
+      expectNoOffenses(dedent`
+        <%% items.each do |item| %>
+          <p>Content</p>
+        <%% end %>
+      `)
+    })
+  })
 })

--- a/javascript/packages/linter/test/rules/erb-no-inline-case-conditions.test.ts
+++ b/javascript/packages/linter/test/rules/erb-no-inline-case-conditions.test.ts
@@ -73,4 +73,12 @@ describe("ERBNoInlineCaseConditionsRule", () => {
       assertOffenses(`<% case value\n   in 1 %>\n  One\n<% in 2 %>\n  Two\n<% end %>`)
     })
   })
+
+  describe("escaped ERB tags", () => {
+    test("reports inline case conditions in escaped tag", () => {
+      expectWarning('A `case` statement with `when` conditions in a single ERB tag cannot be reliably parsed, compiled, and formatted. Use separate ERB tags for `case` and its conditions (e.g., `<% case x %>` followed by `<% when y %>`).')
+
+      assertOffenses(`<%% case value when 1 %>\n  One\n<%% end %>`)
+    })
+  })
 })

--- a/javascript/packages/linter/test/rules/erb-no-then-in-control-flow.test.ts
+++ b/javascript/packages/linter/test/rules/erb-no-then-in-control-flow.test.ts
@@ -157,4 +157,16 @@ describe("ERBNoThenInControlFlowRule", () => {
       `)
     })
   })
+
+  describe("escaped ERB tags", () => {
+    test("reports then in escaped if", () => {
+      expectWarning("Avoid using `then` in `if` expressions inside ERB templates. Use the multiline block form instead.")
+
+      assertOffenses(dedent`
+        <%% if condition then %>
+          yes
+        <%% end %>
+      `)
+    })
+  })
 })

--- a/javascript/packages/linter/test/rules/erb-require-whitespace-inside-tags.test.ts
+++ b/javascript/packages/linter/test/rules/erb-require-whitespace-inside-tags.test.ts
@@ -171,4 +171,11 @@ describe("erb-require-whitespace-inside-tags", () => {
 
     expectNoOffenses(html)
   })
+
+  it("allows escaped comment tag without whitespace after the opening", () => {
+    expectNoOffenses(dedent`
+      <%%# locals: (user:) %>
+      <p><%%= user.name %></p>
+    `)
+  })
 })

--- a/javascript/packages/linter/test/rules/html-no-empty-attributes.test.ts
+++ b/javascript/packages/linter/test/rules/html-no-empty-attributes.test.ts
@@ -170,4 +170,10 @@ describe("html-no-empty-attributes", () => {
       </h1>
     `)
   })
+
+  test("passes for attribute containing an escaped ERB tag", () => {
+    expectNoOffenses(dedent`
+      <div class="<%%= form_class %>">Content</div>
+    `)
+  })
 })

--- a/src/analyze/action_view/tag_helpers.c
+++ b/src/analyze/action_view/tag_helpers.c
@@ -5,6 +5,7 @@
 #include "../../include/analyze/analyze.h"
 #include "../../include/ast/ast_nodes.h"
 #include "../../include/herb.h"
+#include "../../include/lexer/token.h"
 #include "../../include/lib/hb_allocator.h"
 #include "../../include/lib/hb_array.h"
 #include "../../include/lib/hb_buffer.h"
@@ -1426,6 +1427,8 @@ void transform_tag_helper_array(hb_array_T* array, analyze_ruby_context_T* conte
     if (child->type == AST_ERB_BLOCK_NODE) {
       AST_ERB_BLOCK_NODE_T* block_node = (AST_ERB_BLOCK_NODE_T*) child;
 
+      if (token_is_escaped_erb_tag_opening(block_node->tag_opening)) { continue; }
+
       if (block_node->tag_opening && !hb_string_is_empty(block_node->tag_opening->value)) {
         const char* opening_string = block_node->tag_opening->value.data;
         if (opening_string && strstr(opening_string, "=") == NULL) { continue; }
@@ -1454,6 +1457,8 @@ void transform_tag_helper_array(hb_array_T* array, analyze_ruby_context_T* conte
     } else if (child->type == AST_ERB_CONTENT_NODE) {
       AST_ERB_CONTENT_NODE_T* erb_node = (AST_ERB_CONTENT_NODE_T*) child;
       token_T* tag_opening = erb_node->tag_opening;
+
+      if (token_is_escaped_erb_tag_opening(tag_opening)) { continue; }
 
       if (tag_opening && !hb_string_is_empty(tag_opening->value)) {
         const char* opening_string = tag_opening->value.data;

--- a/src/analyze/render_nodes.c
+++ b/src/analyze/render_nodes.c
@@ -5,6 +5,7 @@
 #include "../include/analyze/helpers.h"
 #include "../include/ast/ast_nodes.h"
 #include "../include/errors.h"
+#include "../include/lexer/token.h"
 #include "../include/lib/hb_allocator.h"
 #include "../include/lib/hb_array.h"
 #include "../include/lib/hb_string.h"
@@ -811,6 +812,7 @@ static AST_ERB_RENDER_NODE_T* try_transform_content_node(
 ) {
   if (!erb_node->analyzed_ruby || !erb_node->analyzed_ruby->valid || !erb_node->analyzed_ruby->parsed) { return NULL; }
   if (is_erb_comment_tag(erb_node->tag_opening)) { return NULL; }
+  if (token_is_escaped_erb_tag_opening(erb_node->tag_opening)) { return NULL; }
 
   pm_call_node_t* render_call = find_render_call(erb_node->analyzed_ruby->root, &erb_node->analyzed_ruby->parser);
   if (!render_call) { return NULL; }
@@ -840,6 +842,7 @@ static AST_ERB_RENDER_NODE_T* try_transform_block_node(
   analyze_ruby_context_T* context
 ) {
   if (!block_node->content || hb_string_is_empty(block_node->content->value)) { return NULL; }
+  if (token_is_escaped_erb_tag_opening(block_node->tag_opening)) { return NULL; }
 
   const char* ruby_source = block_node->content->value.data;
   size_t ruby_length = block_node->content->value.length;

--- a/src/include/lexer/token.h
+++ b/src/include/lexer/token.h
@@ -28,4 +28,6 @@ void token_free(token_T* token, hb_allocator_T* allocator);
 
 bool token_value_empty(const token_T* token);
 
+bool token_is_escaped_erb_tag_opening(const token_T* token);
+
 #endif

--- a/src/lexer/token.c
+++ b/src/lexer/token.c
@@ -228,6 +228,12 @@ bool token_value_empty(const token_T* token) {
   return token == NULL || hb_string_is_empty(token->value);
 }
 
+bool token_is_escaped_erb_tag_opening(const token_T* token) {
+  if (token_value_empty(token)) { return false; }
+
+  return hb_string_starts_with(token->value, hb_string("<%%"));
+}
+
 void token_free(token_T* token, hb_allocator_T* allocator) {
   if (!token) { return; }
 

--- a/test/analyze/escape_test.rb
+++ b/test/analyze/escape_test.rb
@@ -23,5 +23,33 @@ module Analyze
       assert_parsed_snapshot("<%% [1, 2, 3].each do |item| %>\n  Hello\n<% end %>")
       assert_parsed_snapshot("<%% [1, 2, 3].each do |item| %>\n  Hello\n<%% end %>")
     end
+
+    test "unbalanced escaped erb tag" do
+      assert_parsed_snapshot("<%% if condition %>")
+      assert_parsed_snapshot("<%% end %>")
+      assert_parsed_snapshot("<%% else %>")
+      assert_parsed_snapshot("<%% elsif other %>")
+      assert_parsed_snapshot("<%% when :value %>")
+      assert_parsed_snapshot("<%% [1, 2].each do |item| %>")
+    end
+
+    test "invalid ruby inside escaped erb tag" do
+      assert_parsed_snapshot("<%%= some ~~ invalid ! syntax %>")
+    end
+
+    test "escaped erb tag with render" do
+      assert_parsed_snapshot(%(<%%= render partial: "menu" %>), render_nodes: true)
+      assert_parsed_snapshot(%(<%= render partial: "menu" %>), render_nodes: true)
+    end
+
+    test "escaped erb tag with action view tag helper" do
+      assert_parsed_snapshot(%(<%%= link_to "Home", root_path %>), action_view_helpers: true)
+      assert_parsed_snapshot(%(<%= link_to "Home", root_path %>), action_view_helpers: true)
+    end
+
+    test "escaped erb tag with inline case conditions" do
+      assert_parsed_snapshot("<%% case x when 1 %>a<%% end %>", strict: true)
+      assert_parsed_snapshot("<% case x when 1 %>a<% end %>", strict: true)
+    end
   end
 end

--- a/test/parser/escaped_erb_test.rb
+++ b/test/parser/escaped_erb_test.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+module Parser
+  class EscapedERBTest < Minitest::Spec
+    include SnapshotUtils
+
+    test "escaped if closed by real end" do
+      assert_parsed_snapshot(<<~ERB)
+        <%% if true %>
+          content
+        <% end %>
+      ERB
+    end
+
+    test "real if closed by escaped end" do
+      assert_parsed_snapshot(<<~ERB)
+        <% if true %>
+          content
+        <%% end %>
+      ERB
+    end
+
+    test "escaped if closed by escaped end" do
+      assert_parsed_snapshot(<<~ERB)
+        <%% if true %>
+          content
+        <%% end %>
+      ERB
+    end
+
+    test "real if closed by real end" do
+      assert_parsed_snapshot(<<~ERB)
+        <% if true %>
+          content
+        <% end %>
+      ERB
+    end
+
+    test "escaped block closed by real end" do
+      assert_parsed_snapshot(<<~ERB)
+        <%% items.each do |item| %>
+          content
+        <% end %>
+      ERB
+    end
+
+    test "real block closed by escaped end" do
+      assert_parsed_snapshot(<<~ERB)
+        <% items.each do |item| %>
+          content
+        <%% end %>
+      ERB
+    end
+
+    test "escaped block closed by escaped end" do
+      assert_parsed_snapshot(<<~ERB)
+        <%% items.each do |item| %>
+          content
+        <%% end %>
+      ERB
+    end
+  end
+end

--- a/test/snapshots/analyze/escape_test/test_0005_unbalanced_escaped_erb_tag_06772c1194302640c9274fe4eb874a1f.txt
+++ b/test/snapshots/analyze/escape_test/test_0005_unbalanced_escaped_erb_tag_06772c1194302640c9274fe4eb874a1f.txt
@@ -1,0 +1,17 @@
+---
+source: "Analyze::EscapeTest#test_0005_unbalanced escaped erb tag"
+input: "<%% else %>"
+---
+@ DocumentNode (location: (1:0)-(1:11))
+└── children: (1 item)
+    └── @ ERBContentNode (location: (1:0)-(1:11))
+        ├── errors: (1 error)
+        │   └── @ ERBControlFlowScopeError (location: (1:0)-(1:11))
+        │       ├── message: "`<% else %>` appears outside its control flow block. Keep ERB control flow statements together within the same HTML scope (tag, attribute, or content)."
+        │       └── keyword: "`<% else %>`"
+        │
+        ├── tag_opening: "<%%" (location: (1:0)-(1:3))
+        ├── content: " else " (location: (1:3)-(1:9))
+        ├── tag_closing: "%>" (location: (1:9)-(1:11))
+        ├── parsed: true
+        └── valid: false

--- a/test/snapshots/analyze/escape_test/test_0005_unbalanced_escaped_erb_tag_29be2fbb60e5d6deef9b446eee95fc09.txt
+++ b/test/snapshots/analyze/escape_test/test_0005_unbalanced_escaped_erb_tag_29be2fbb60e5d6deef9b446eee95fc09.txt
@@ -1,0 +1,27 @@
+---
+source: "Analyze::EscapeTest#test_0005_unbalanced escaped erb tag"
+input: "<%% [1, 2].each do |item| %>"
+---
+@ DocumentNode (location: (1:0)-(1:28))
+└── children: (1 item)
+    └── @ ERBBlockNode (location: (1:0)-(1:28))
+        ├── errors: (1 error)
+        │   └── @ MissingERBEndTagError (location: (1:0)-(1:28))
+        │       ├── message: "ERB block started here but never closed with an end tag. The end tag may be in a different scope."
+        │       └── keyword: "ERB block"
+        │
+        ├── tag_opening: "<%%" (location: (1:0)-(1:3))
+        ├── content: " [1, 2].each do |item| " (location: (1:3)-(1:26))
+        ├── tag_closing: "%>" (location: (1:26)-(1:28))
+        ├── body: []
+        ├── block_arguments: (1 item)
+        │   └── @ RubyParameterNode (location: (1:20)-(1:24))
+        │       ├── name: "item" (location: (1:20)-(1:24))
+        │       ├── default_value: ∅
+        │       ├── kind: "positional"
+        │       └── required: true
+        │
+        ├── rescue_clause: ∅
+        ├── else_clause: ∅
+        ├── ensure_clause: ∅
+        └── end_node: ∅

--- a/test/snapshots/analyze/escape_test/test_0005_unbalanced_escaped_erb_tag_335561cf55663c0d3e61ab9318410f1f.txt
+++ b/test/snapshots/analyze/escape_test/test_0005_unbalanced_escaped_erb_tag_335561cf55663c0d3e61ab9318410f1f.txt
@@ -1,0 +1,19 @@
+---
+source: "Analyze::EscapeTest#test_0005_unbalanced escaped erb tag"
+input: "<%% if condition %>"
+---
+@ DocumentNode (location: (1:0)-(1:19))
+└── children: (1 item)
+    └── @ ERBIfNode (location: (1:0)-(1:19))
+        ├── errors: (1 error)
+        │   └── @ MissingERBEndTagError (location: (1:0)-(1:19))
+        │       ├── message: "`<% if %>` started here but never closed with an end tag. The end tag may be in a different scope."
+        │       └── keyword: "`<% if %>`"
+        │
+        ├── tag_opening: "<%%" (location: (1:0)-(1:3))
+        ├── content: " if condition " (location: (1:3)-(1:17))
+        ├── tag_closing: "%>" (location: (1:17)-(1:19))
+        ├── then_keyword: ∅
+        ├── statements: []
+        ├── subsequent: ∅
+        └── end_node: ∅

--- a/test/snapshots/analyze/escape_test/test_0005_unbalanced_escaped_erb_tag_5aef27dd31d9cfd12b6695831ef5bf44.txt
+++ b/test/snapshots/analyze/escape_test/test_0005_unbalanced_escaped_erb_tag_5aef27dd31d9cfd12b6695831ef5bf44.txt
@@ -1,0 +1,17 @@
+---
+source: "Analyze::EscapeTest#test_0005_unbalanced escaped erb tag"
+input: "<%% when :value %>"
+---
+@ DocumentNode (location: (1:0)-(1:18))
+└── children: (1 item)
+    └── @ ERBContentNode (location: (1:0)-(1:18))
+        ├── errors: (1 error)
+        │   └── @ ERBControlFlowScopeError (location: (1:0)-(1:18))
+        │       ├── message: "`<% when %>` appears outside its control flow block. Keep ERB control flow statements together within the same HTML scope (tag, attribute, or content)."
+        │       └── keyword: "`<% when %>`"
+        │
+        ├── tag_opening: "<%%" (location: (1:0)-(1:3))
+        ├── content: " when :value " (location: (1:3)-(1:16))
+        ├── tag_closing: "%>" (location: (1:16)-(1:18))
+        ├── parsed: true
+        └── valid: false

--- a/test/snapshots/analyze/escape_test/test_0005_unbalanced_escaped_erb_tag_72a0d70f89a5d44f5e2c8612a29e4e37.txt
+++ b/test/snapshots/analyze/escape_test/test_0005_unbalanced_escaped_erb_tag_72a0d70f89a5d44f5e2c8612a29e4e37.txt
@@ -1,0 +1,17 @@
+---
+source: "Analyze::EscapeTest#test_0005_unbalanced escaped erb tag"
+input: "<%% end %>"
+---
+@ DocumentNode (location: (1:0)-(1:10))
+└── children: (1 item)
+    └── @ ERBContentNode (location: (1:0)-(1:10))
+        ├── errors: (1 error)
+        │   └── @ ERBControlFlowScopeError (location: (1:0)-(1:10))
+        │       ├── message: "`<% end %>` appears outside its control flow block. Keep ERB control flow statements together within the same HTML scope (tag, attribute, or content)."
+        │       └── keyword: "`<% end %>`"
+        │
+        ├── tag_opening: "<%%" (location: (1:0)-(1:3))
+        ├── content: " end " (location: (1:3)-(1:8))
+        ├── tag_closing: "%>" (location: (1:8)-(1:10))
+        ├── parsed: true
+        └── valid: false

--- a/test/snapshots/analyze/escape_test/test_0005_unbalanced_escaped_erb_tag_990d2e9445e0e8b112f50d58e4ce67af.txt
+++ b/test/snapshots/analyze/escape_test/test_0005_unbalanced_escaped_erb_tag_990d2e9445e0e8b112f50d58e4ce67af.txt
@@ -1,0 +1,17 @@
+---
+source: "Analyze::EscapeTest#test_0005_unbalanced escaped erb tag"
+input: "<%% elsif other %>"
+---
+@ DocumentNode (location: (1:0)-(1:18))
+└── children: (1 item)
+    └── @ ERBContentNode (location: (1:0)-(1:18))
+        ├── errors: (1 error)
+        │   └── @ ERBControlFlowScopeError (location: (1:0)-(1:18))
+        │       ├── message: "`<% elsif %>` appears outside its control flow block. Keep ERB control flow statements together within the same HTML scope (tag, attribute, or content)."
+        │       └── keyword: "`<% elsif %>`"
+        │
+        ├── tag_opening: "<%%" (location: (1:0)-(1:3))
+        ├── content: " elsif other " (location: (1:3)-(1:16))
+        ├── tag_closing: "%>" (location: (1:16)-(1:18))
+        ├── parsed: true
+        └── valid: false

--- a/test/snapshots/analyze/escape_test/test_0006_invalid_ruby_inside_escaped_erb_tag_73ec7a4e1062311c88d0e6c5cade936d.txt
+++ b/test/snapshots/analyze/escape_test/test_0006_invalid_ruby_inside_escaped_erb_tag_73ec7a4e1062311c88d0e6c5cade936d.txt
@@ -1,0 +1,12 @@
+---
+source: "Analyze::EscapeTest#test_0006_invalid ruby inside escaped erb tag"
+input: "<%%= some ~~ invalid ! syntax %>"
+---
+@ DocumentNode (location: (1:0)-(1:32))
+└── children: (1 item)
+    └── @ ERBContentNode (location: (1:0)-(1:32))
+        ├── tag_opening: "<%%=" (location: (1:0)-(1:4))
+        ├── content: " some ~~ invalid ! syntax " (location: (1:4)-(1:30))
+        ├── tag_closing: "%>" (location: (1:30)-(1:32))
+        ├── parsed: true
+        └── valid: false

--- a/test/snapshots/analyze/escape_test/test_0007_escaped_erb_tag_with_render_5a5723d5e69c5b2a6f41733bf0ef1605-f8009707a6f8814717b65550c888710c.txt
+++ b/test/snapshots/analyze/escape_test/test_0007_escaped_erb_tag_with_render_5a5723d5e69c5b2a6f41733bf0ef1605-f8009707a6f8814717b65550c888710c.txt
@@ -1,0 +1,13 @@
+---
+source: "Analyze::EscapeTest#test_0007_escaped erb tag with render"
+input: "<%%= render partial: \"menu\" %>"
+options: {render_nodes: true}
+---
+@ DocumentNode (location: (1:0)-(1:30))
+└── children: (1 item)
+    └── @ ERBContentNode (location: (1:0)-(1:30))
+        ├── tag_opening: "<%%=" (location: (1:0)-(1:4))
+        ├── content: " render partial: "menu" " (location: (1:4)-(1:28))
+        ├── tag_closing: "%>" (location: (1:28)-(1:30))
+        ├── parsed: true
+        └── valid: true

--- a/test/snapshots/analyze/escape_test/test_0007_escaped_erb_tag_with_render_d722c46fcc2c8169f6517e8c19f5165a-f8009707a6f8814717b65550c888710c.txt
+++ b/test/snapshots/analyze/escape_test/test_0007_escaped_erb_tag_with_render_d722c46fcc2c8169f6517e8c19f5165a-f8009707a6f8814717b65550c888710c.txt
@@ -1,0 +1,38 @@
+---
+source: "Analyze::EscapeTest#test_0007_escaped erb tag with render"
+input: "<%= render partial: \"menu\" %>"
+options: {render_nodes: true}
+---
+@ DocumentNode (location: (1:0)-(1:29))
+└── children: (1 item)
+    └── @ ERBRenderNode (location: (1:0)-(1:29))
+        ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+        ├── content: " render partial: "menu" " (location: (1:3)-(1:27))
+        ├── tag_closing: "%>" (location: (1:27)-(1:29))
+        ├── keywords:
+        │   └── @ RubyRenderKeywordsNode (location: (1:0)-(1:29))
+        │       ├── partial: "menu" (location: (1:20)-(1:26))
+        │       ├── template_path: ∅
+        │       ├── layout: ∅
+        │       ├── file: ∅
+        │       ├── inline_template: ∅
+        │       ├── body: ∅
+        │       ├── plain: ∅
+        │       ├── html: ∅
+        │       ├── renderable: ∅
+        │       ├── collection: ∅
+        │       ├── object: ∅
+        │       ├── as_name: ∅
+        │       ├── spacer_template: ∅
+        │       ├── formats: ∅
+        │       ├── variants: ∅
+        │       ├── handlers: ∅
+        │       ├── content_type: ∅
+        │       └── locals: []
+        │
+        ├── body: []
+        ├── block_arguments: []
+        ├── rescue_clause: ∅
+        ├── else_clause: ∅
+        ├── ensure_clause: ∅
+        └── end_node: ∅

--- a/test/snapshots/analyze/escape_test/test_0008_escaped_erb_tag_with_action_view_tag_helper_9f7ce7568fb6b7a16132734ee2228993-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/escape_test/test_0008_escaped_erb_tag_with_action_view_tag_helper_9f7ce7568fb6b7a16132734ee2228993-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,13 @@
+---
+source: "Analyze::EscapeTest#test_0008_escaped erb tag with action view tag helper"
+input: "<%%= link_to \"Home\", root_path %>"
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(1:33))
+└── children: (1 item)
+    └── @ ERBContentNode (location: (1:0)-(1:33))
+        ├── tag_opening: "<%%=" (location: (1:0)-(1:4))
+        ├── content: " link_to "Home", root_path " (location: (1:4)-(1:31))
+        ├── tag_closing: "%>" (location: (1:31)-(1:33))
+        ├── parsed: true
+        └── valid: true

--- a/test/snapshots/analyze/escape_test/test_0008_escaped_erb_tag_with_action_view_tag_helper_e68887f68f9e99f8c04ec0950009653f-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/escape_test/test_0008_escaped_erb_tag_with_action_view_tag_helper_e68887f68f9e99f8c04ec0950009653f-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,47 @@
+---
+source: "Analyze::EscapeTest#test_0008_escaped erb tag with action view tag helper"
+input: "<%= link_to \"Home\", root_path %>"
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(1:32))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(1:32))
+        ├── open_tag:
+        │   └── @ ERBOpenTagNode (location: (1:0)-(1:32))
+        │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+        │       ├── content: " link_to "Home", root_path " (location: (1:3)-(1:30))
+        │       ├── tag_closing: "%>" (location: (1:30)-(1:32))
+        │       ├── tag_name: "a" (location: (1:4)-(1:11))
+        │       └── children: (1 item)
+        │           └── @ HTMLAttributeNode (location: (1:20)-(1:29))
+        │               ├── name:
+        │               │   └── @ HTMLAttributeNameNode (location: (1:20)-(1:29))
+        │               │       └── children: (1 item)
+        │               │           └── @ LiteralNode (location: (1:20)-(1:29))
+        │               │               └── content: "href"
+        │               │
+        │               │
+        │               ├── equals: ":" (location: (1:20)-(1:29))
+        │               └── value:
+        │                   └── @ HTMLAttributeValueNode (location: (1:20)-(1:29))
+        │                       ├── open_quote: ∅
+        │                       ├── children: (1 item)
+        │                       │   └── @ RubyLiteralNode (location: (1:20)-(1:29))
+        │                       │       └── content: "root_path"
+        │                       │
+        │                       ├── close_quote: ∅
+        │                       └── quoted: true
+        │
+        │
+        │
+        ├── tag_name: "a" (location: (1:4)-(1:11))
+        ├── body: (1 item)
+        │   └── @ HTMLTextNode (location: (1:0)-(1:32))
+        │       └── content: "Home"
+        │
+        ├── close_tag:
+        │   └── @ HTMLVirtualCloseTagNode (location: (1:32)-(1:32))
+        │       └── tag_name: "a" (location: (1:4)-(1:11))
+        │
+        ├── is_void: false
+        └── element_source: "ActionView::Helpers::UrlHelper#link_to"

--- a/test/snapshots/analyze/escape_test/test_0009_escaped_erb_tag_with_inline_case_conditions_131bd77cf2c8b6d63f7eae90a2437b5f-08996694f7ff1e6e34277dc32f646630.txt
+++ b/test/snapshots/analyze/escape_test/test_0009_escaped_erb_tag_with_inline_case_conditions_131bd77cf2c8b6d63f7eae90a2437b5f-08996694f7ff1e6e34277dc32f646630.txt
@@ -1,0 +1,33 @@
+---
+source: "Analyze::EscapeTest#test_0009_escaped erb tag with inline case conditions"
+input: "<% case x when 1 %>a<% end %>"
+options: {strict: true}
+---
+@ DocumentNode (location: (1:0)-(1:29))
+└── children: (1 item)
+    └── @ ERBCaseNode (location: (1:0)-(1:29))
+        ├── errors: (1 error)
+        │   └── @ ERBCaseWithConditionsError (location: (1:0)-(1:19))
+        │       └── message: "A `case` statement with `when`/`in` conditions in a single ERB tag cannot be reliably parsed, compiled, and formatted. Use separate ERB tags for `case` and its conditions (e.g., `<% case x %>` followed by `<% when y %>`)."
+        │
+        ├── tag_opening: "<%" (location: (1:0)-(1:2))
+        ├── content: " case x when 1 " (location: (1:2)-(1:17))
+        ├── tag_closing: "%>" (location: (1:17)-(1:19))
+        ├── children: []
+        ├── conditions: (1 item)
+        │   └── @ ERBWhenNode (location: (1:19)-(1:20))
+        │       ├── tag_opening: ∅
+        │       ├── content: ∅
+        │       ├── tag_closing: ∅
+        │       ├── then_keyword: ∅
+        │       └── statements: (1 item)
+        │           └── @ HTMLTextNode (location: (1:19)-(1:20))
+        │               └── content: "a"
+        │
+        │
+        ├── else_clause: ∅
+        └── end_node:
+            └── @ ERBEndNode (location: (1:20)-(1:29))
+                ├── tag_opening: "<%" (location: (1:20)-(1:22))
+                ├── content: " end " (location: (1:22)-(1:27))
+                └── tag_closing: "%>" (location: (1:27)-(1:29))

--- a/test/snapshots/analyze/escape_test/test_0009_escaped_erb_tag_with_inline_case_conditions_d194f83af1dbe7c59c28ce4809c83112-08996694f7ff1e6e34277dc32f646630.txt
+++ b/test/snapshots/analyze/escape_test/test_0009_escaped_erb_tag_with_inline_case_conditions_d194f83af1dbe7c59c28ce4809c83112-08996694f7ff1e6e34277dc32f646630.txt
@@ -1,0 +1,33 @@
+---
+source: "Analyze::EscapeTest#test_0009_escaped erb tag with inline case conditions"
+input: "<%% case x when 1 %>a<%% end %>"
+options: {strict: true}
+---
+@ DocumentNode (location: (1:0)-(1:31))
+└── children: (1 item)
+    └── @ ERBCaseNode (location: (1:0)-(1:31))
+        ├── errors: (1 error)
+        │   └── @ ERBCaseWithConditionsError (location: (1:0)-(1:20))
+        │       └── message: "A `case` statement with `when`/`in` conditions in a single ERB tag cannot be reliably parsed, compiled, and formatted. Use separate ERB tags for `case` and its conditions (e.g., `<% case x %>` followed by `<% when y %>`)."
+        │
+        ├── tag_opening: "<%%" (location: (1:0)-(1:3))
+        ├── content: " case x when 1 " (location: (1:3)-(1:18))
+        ├── tag_closing: "%>" (location: (1:18)-(1:20))
+        ├── children: []
+        ├── conditions: (1 item)
+        │   └── @ ERBWhenNode (location: (1:20)-(1:21))
+        │       ├── tag_opening: ∅
+        │       ├── content: ∅
+        │       ├── tag_closing: ∅
+        │       ├── then_keyword: ∅
+        │       └── statements: (1 item)
+        │           └── @ HTMLTextNode (location: (1:20)-(1:21))
+        │               └── content: "a"
+        │
+        │
+        ├── else_clause: ∅
+        └── end_node:
+            └── @ ERBEndNode (location: (1:21)-(1:31))
+                ├── tag_opening: "<%%" (location: (1:21)-(1:24))
+                ├── content: " end " (location: (1:24)-(1:29))
+                └── tag_closing: "%>" (location: (1:29)-(1:31))

--- a/test/snapshots/parser/escaped_erb_test/test_0001_escaped_if_closed_by_real_end_2b09faccca365d9fcfd581b60f6af77a.txt
+++ b/test/snapshots/parser/escaped_erb_test/test_0001_escaped_if_closed_by_real_end_2b09faccca365d9fcfd581b60f6af77a.txt
@@ -1,0 +1,35 @@
+---
+source: "Parser::EscapedERBTest#test_0001_escaped if closed by real end"
+input: |2-
+<%% if true %>
+  content
+<% end %>
+---
+@ DocumentNode (location: (1:0)-(4:0))
+├── errors: (1 error)
+│   └── @ RubyParseError (location: (3:3)-(3:6))
+│       ├── message: "unexpected_token_ignore: unexpected 'end', ignoring it"
+│       ├── error_message: "unexpected 'end', ignoring it"
+│       ├── diagnostic_id: "unexpected_token_ignore"
+│       └── level: "syntax"
+│
+└── children: (2 items)
+    ├── @ ERBIfNode (location: (1:0)-(3:9))
+    │   ├── tag_opening: "<%%" (location: (1:0)-(1:3))
+    │   ├── content: " if true " (location: (1:3)-(1:12))
+    │   ├── tag_closing: "%>" (location: (1:12)-(1:14))
+    │   ├── then_keyword: ∅
+    │   ├── statements: (1 item)
+    │   │   └── @ HTMLTextNode (location: (1:14)-(3:0))
+    │   │       └── content: "\n  content\n"
+    │   │
+    │   ├── subsequent: ∅
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (3:0)-(3:9))
+    │           ├── tag_opening: "<%" (location: (3:0)-(3:2))
+    │           ├── content: " end " (location: (3:2)-(3:7))
+    │           └── tag_closing: "%>" (location: (3:7)-(3:9))
+    │
+    │
+    └── @ HTMLTextNode (location: (3:9)-(4:0))
+        └── content: "\n"

--- a/test/snapshots/parser/escaped_erb_test/test_0002_real_if_closed_by_escaped_end_36ac24f3e30a1415899b1b4eef523e4b.txt
+++ b/test/snapshots/parser/escaped_erb_test/test_0002_real_if_closed_by_escaped_end_36ac24f3e30a1415899b1b4eef523e4b.txt
@@ -1,0 +1,41 @@
+---
+source: "Parser::EscapedERBTest#test_0002_real if closed by escaped end"
+input: |2-
+<% if true %>
+  content
+<%% end %>
+---
+@ DocumentNode (location: (1:0)-(4:0))
+├── errors: (2 errors)
+│   ├── @ RubyParseError (location: (3:10)-(4:0))
+│   │   ├── message: "unexpected_token_close_context: unexpected end-of-input, assuming it is closing the parent top level context"
+│   │   ├── error_message: "unexpected end-of-input, assuming it is closing the parent top level context"
+│   │   ├── diagnostic_id: "unexpected_token_close_context"
+│   │   └── level: "syntax"
+│   │
+│   └── @ RubyParseError (location: (1:3)-(1:5))
+│       ├── message: "conditional_term: expected an `end` to close the conditional clause"
+│       ├── error_message: "expected an `end` to close the conditional clause"
+│       ├── diagnostic_id: "conditional_term"
+│       └── level: "syntax"
+│
+└── children: (2 items)
+    ├── @ ERBIfNode (location: (1:0)-(3:10))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
+    │   ├── content: " if true " (location: (1:2)-(1:11))
+    │   ├── tag_closing: "%>" (location: (1:11)-(1:13))
+    │   ├── then_keyword: ∅
+    │   ├── statements: (1 item)
+    │   │   └── @ HTMLTextNode (location: (1:13)-(3:0))
+    │   │       └── content: "\n  content\n"
+    │   │
+    │   ├── subsequent: ∅
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (3:0)-(3:10))
+    │           ├── tag_opening: "<%%" (location: (3:0)-(3:3))
+    │           ├── content: " end " (location: (3:3)-(3:8))
+    │           └── tag_closing: "%>" (location: (3:8)-(3:10))
+    │
+    │
+    └── @ HTMLTextNode (location: (3:10)-(4:0))
+        └── content: "\n"

--- a/test/snapshots/parser/escaped_erb_test/test_0003_escaped_if_closed_by_escaped_end_6e5015c15d4705d03d2df2c4870768bb.txt
+++ b/test/snapshots/parser/escaped_erb_test/test_0003_escaped_if_closed_by_escaped_end_6e5015c15d4705d03d2df2c4870768bb.txt
@@ -1,0 +1,28 @@
+---
+source: "Parser::EscapedERBTest#test_0003_escaped if closed by escaped end"
+input: |2-
+<%% if true %>
+  content
+<%% end %>
+---
+@ DocumentNode (location: (1:0)-(4:0))
+└── children: (2 items)
+    ├── @ ERBIfNode (location: (1:0)-(3:10))
+    │   ├── tag_opening: "<%%" (location: (1:0)-(1:3))
+    │   ├── content: " if true " (location: (1:3)-(1:12))
+    │   ├── tag_closing: "%>" (location: (1:12)-(1:14))
+    │   ├── then_keyword: ∅
+    │   ├── statements: (1 item)
+    │   │   └── @ HTMLTextNode (location: (1:14)-(3:0))
+    │   │       └── content: "\n  content\n"
+    │   │
+    │   ├── subsequent: ∅
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (3:0)-(3:10))
+    │           ├── tag_opening: "<%%" (location: (3:0)-(3:3))
+    │           ├── content: " end " (location: (3:3)-(3:8))
+    │           └── tag_closing: "%>" (location: (3:8)-(3:10))
+    │
+    │
+    └── @ HTMLTextNode (location: (3:10)-(4:0))
+        └── content: "\n"

--- a/test/snapshots/parser/escaped_erb_test/test_0004_real_if_closed_by_real_end_dcc1344e4323279ad9bfb14ac47114cb.txt
+++ b/test/snapshots/parser/escaped_erb_test/test_0004_real_if_closed_by_real_end_dcc1344e4323279ad9bfb14ac47114cb.txt
@@ -1,0 +1,28 @@
+---
+source: "Parser::EscapedERBTest#test_0004_real if closed by real end"
+input: |2-
+<% if true %>
+  content
+<% end %>
+---
+@ DocumentNode (location: (1:0)-(4:0))
+└── children: (2 items)
+    ├── @ ERBIfNode (location: (1:0)-(3:9))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
+    │   ├── content: " if true " (location: (1:2)-(1:11))
+    │   ├── tag_closing: "%>" (location: (1:11)-(1:13))
+    │   ├── then_keyword: ∅
+    │   ├── statements: (1 item)
+    │   │   └── @ HTMLTextNode (location: (1:13)-(3:0))
+    │   │       └── content: "\n  content\n"
+    │   │
+    │   ├── subsequent: ∅
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (3:0)-(3:9))
+    │           ├── tag_opening: "<%" (location: (3:0)-(3:2))
+    │           ├── content: " end " (location: (3:2)-(3:7))
+    │           └── tag_closing: "%>" (location: (3:7)-(3:9))
+    │
+    │
+    └── @ HTMLTextNode (location: (3:9)-(4:0))
+        └── content: "\n"

--- a/test/snapshots/parser/escaped_erb_test/test_0005_escaped_block_closed_by_real_end_44ac9de9cada214f8b93ecb8ce64d382.txt
+++ b/test/snapshots/parser/escaped_erb_test/test_0005_escaped_block_closed_by_real_end_44ac9de9cada214f8b93ecb8ce64d382.txt
@@ -1,0 +1,43 @@
+---
+source: "Parser::EscapedERBTest#test_0005_escaped block closed by real end"
+input: |2-
+<%% items.each do |item| %>
+  content
+<% end %>
+---
+@ DocumentNode (location: (1:0)-(4:0))
+├── errors: (1 error)
+│   └── @ RubyParseError (location: (3:3)-(3:6))
+│       ├── message: "unexpected_token_ignore: unexpected 'end', ignoring it"
+│       ├── error_message: "unexpected 'end', ignoring it"
+│       ├── diagnostic_id: "unexpected_token_ignore"
+│       └── level: "syntax"
+│
+└── children: (2 items)
+    ├── @ ERBBlockNode (location: (1:0)-(3:9))
+    │   ├── tag_opening: "<%%" (location: (1:0)-(1:3))
+    │   ├── content: " items.each do |item| " (location: (1:3)-(1:25))
+    │   ├── tag_closing: "%>" (location: (1:25)-(1:27))
+    │   ├── body: (1 item)
+    │   │   └── @ HTMLTextNode (location: (1:27)-(3:0))
+    │   │       └── content: "\n  content\n"
+    │   │
+    │   ├── block_arguments: (1 item)
+    │   │   └── @ RubyParameterNode (location: (1:19)-(1:23))
+    │   │       ├── name: "item" (location: (1:19)-(1:23))
+    │   │       ├── default_value: ∅
+    │   │       ├── kind: "positional"
+    │   │       └── required: true
+    │   │
+    │   ├── rescue_clause: ∅
+    │   ├── else_clause: ∅
+    │   ├── ensure_clause: ∅
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (3:0)-(3:9))
+    │           ├── tag_opening: "<%" (location: (3:0)-(3:2))
+    │           ├── content: " end " (location: (3:2)-(3:7))
+    │           └── tag_closing: "%>" (location: (3:7)-(3:9))
+    │
+    │
+    └── @ HTMLTextNode (location: (3:9)-(4:0))
+        └── content: "\n"

--- a/test/snapshots/parser/escaped_erb_test/test_0006_real_block_closed_by_escaped_end_387eb302e7f874c4e7af9e632f02275d.txt
+++ b/test/snapshots/parser/escaped_erb_test/test_0006_real_block_closed_by_escaped_end_387eb302e7f874c4e7af9e632f02275d.txt
@@ -1,0 +1,49 @@
+---
+source: "Parser::EscapedERBTest#test_0006_real block closed by escaped end"
+input: |2-
+<% items.each do |item| %>
+  content
+<%% end %>
+---
+@ DocumentNode (location: (1:0)-(4:0))
+├── errors: (2 errors)
+│   ├── @ RubyParseError (location: (3:10)-(4:0))
+│   │   ├── message: "unexpected_token_close_context: unexpected end-of-input, assuming it is closing the parent top level context"
+│   │   ├── error_message: "unexpected end-of-input, assuming it is closing the parent top level context"
+│   │   ├── diagnostic_id: "unexpected_token_close_context"
+│   │   └── level: "syntax"
+│   │
+│   └── @ RubyParseError (location: (1:14)-(1:16))
+│       ├── message: "block_term_end: expected a block beginning with `do` to end with `end`"
+│       ├── error_message: "expected a block beginning with `do` to end with `end`"
+│       ├── diagnostic_id: "block_term_end"
+│       └── level: "syntax"
+│
+└── children: (2 items)
+    ├── @ ERBBlockNode (location: (1:0)-(3:10))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
+    │   ├── content: " items.each do |item| " (location: (1:2)-(1:24))
+    │   ├── tag_closing: "%>" (location: (1:24)-(1:26))
+    │   ├── body: (1 item)
+    │   │   └── @ HTMLTextNode (location: (1:26)-(3:0))
+    │   │       └── content: "\n  content\n"
+    │   │
+    │   ├── block_arguments: (1 item)
+    │   │   └── @ RubyParameterNode (location: (1:18)-(1:22))
+    │   │       ├── name: "item" (location: (1:18)-(1:22))
+    │   │       ├── default_value: ∅
+    │   │       ├── kind: "positional"
+    │   │       └── required: true
+    │   │
+    │   ├── rescue_clause: ∅
+    │   ├── else_clause: ∅
+    │   ├── ensure_clause: ∅
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (3:0)-(3:10))
+    │           ├── tag_opening: "<%%" (location: (3:0)-(3:3))
+    │           ├── content: " end " (location: (3:3)-(3:8))
+    │           └── tag_closing: "%>" (location: (3:8)-(3:10))
+    │
+    │
+    └── @ HTMLTextNode (location: (3:10)-(4:0))
+        └── content: "\n"

--- a/test/snapshots/parser/escaped_erb_test/test_0007_escaped_block_closed_by_escaped_end_79e998abc9d6a7d1f9bb066a703f3cbd.txt
+++ b/test/snapshots/parser/escaped_erb_test/test_0007_escaped_block_closed_by_escaped_end_79e998abc9d6a7d1f9bb066a703f3cbd.txt
@@ -1,0 +1,36 @@
+---
+source: "Parser::EscapedERBTest#test_0007_escaped block closed by escaped end"
+input: |2-
+<%% items.each do |item| %>
+  content
+<%% end %>
+---
+@ DocumentNode (location: (1:0)-(4:0))
+└── children: (2 items)
+    ├── @ ERBBlockNode (location: (1:0)-(3:10))
+    │   ├── tag_opening: "<%%" (location: (1:0)-(1:3))
+    │   ├── content: " items.each do |item| " (location: (1:3)-(1:25))
+    │   ├── tag_closing: "%>" (location: (1:25)-(1:27))
+    │   ├── body: (1 item)
+    │   │   └── @ HTMLTextNode (location: (1:27)-(3:0))
+    │   │       └── content: "\n  content\n"
+    │   │
+    │   ├── block_arguments: (1 item)
+    │   │   └── @ RubyParameterNode (location: (1:19)-(1:23))
+    │   │       ├── name: "item" (location: (1:19)-(1:23))
+    │   │       ├── default_value: ∅
+    │   │       ├── kind: "positional"
+    │   │       └── required: true
+    │   │
+    │   ├── rescue_clause: ∅
+    │   ├── else_clause: ∅
+    │   ├── ensure_clause: ∅
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (3:0)-(3:10))
+    │           ├── tag_opening: "<%%" (location: (3:0)-(3:3))
+    │           ├── content: " end " (location: (3:3)-(3:8))
+    │           └── tag_closing: "%>" (location: (3:8)-(3:10))
+    │
+    │
+    └── @ HTMLTextNode (location: (3:10)-(4:0))
+        └── content: "\n"


### PR DESCRIPTION
This pull request updates the analyzer so escaped ERB tags (`<%%` and `<%%=`) are no longer transformed into `ERBRenderNode`s or Action View tag helper elements, and fixes a handful of linter rules that treated them as if they were executed. Escaped tags render as the literal text `<%`/`<%=` and are never evaluated. 

Since #1562 their contents are analyzed with Prism so that block pairing works (#1533), but nothing downstream distinguished "analyzed for structure" from "this Ruby actually runs". 

As a result `<%%= render … %>` was promoted to an `ERBRenderNode`, and `actionview-no-silent-render` then flagged it because `isERBOutputNode()` only accepts `<%=` and `<%==`:

```
[error] Avoid using `<%%= %>` with `render`. Use `<%= %>` to ensure the rendered content is output.

lib/generators/alchemy/menus/templates/wrapper.html.erb:3:4

      1 │ <%% cache [menu, @page, Alchemy::Current.preview_page?] do %>
      2 │   <ul class="nav">
  →   3 │     <%%= render partial: menu.to_partial_path,
        │     ~~~~~~~~~~~~~~~
      4 │       collection: menu.children.includes(:page, :children),
      5 │       locals: { options: options },
```

Resolves https://github.com/marcoroth/herb/issues/1700