### PR TITLE
Linter: Implement `erb-no-commented-out-output-tags` linter rule

### DIFF
--- a/javascript/packages/linter/docs/rules/README.md
+++ b/javascript/packages/linter/docs/rules/README.md
@@ -30,6 +30,7 @@ This page contains documentation for all Herb Linter rules.
 
 - [`erb-comment-syntax`](./erb-comment-syntax.md) - Disallow Ruby comments immediately after ERB tags
 - [`erb-no-case-node-children`](./erb-no-case-node-children.md) - Don't use `children` for `case/when` and `case/in` nodes
+- [`erb-no-commented-out-output-tags`](./erb-no-commented-out-output-tags.md) - Disallow commented-out ERB output tags (`<%#=`, `<%# =`)
 - [`erb-no-debug-output`](./erb-no-debug-output.md) - Disallow debug output methods (`p`, `pp`, `puts`, `print`, `debug`) in ERB templates
 - [`erb-no-conditional-html-element`](./erb-no-conditional-html-element.md) - Disallow conditional HTML elements
 - [`erb-no-conditional-open-tag`](./erb-no-conditional-open-tag.md) - Disallow conditional HTML open tags

--- a/javascript/packages/linter/docs/rules/erb-no-commented-out-output-tags.md
+++ b/javascript/packages/linter/docs/rules/erb-no-commented-out-output-tags.md
@@ -1,0 +1,41 @@
+# Linter Rule: Disallow commented-out ERB output tags
+
+**Rule:** `erb-no-commented-out-output-tags`
+
+## Description
+
+Flag ERB comments that look like a temporarily commented-out output tag, i.e. `<%#=`, `<%# =`, `<%#==`, and `<%# ==`.
+
+## Rationale
+
+Commenting out an ERB output tag by inserting a `#` (which is what most editors do when you toggle a comment on `<%= ... %>`) is a convenient way to disable a tag while debugging, but it is easy to forget and commit. This rule surfaces those leftovers so they can either be removed or restored.
+
+The rule intentionally only recognizes the `=` forms. A comment like `<%# hello world %>` is prose and is never flagged, and neither is a divider such as `<%# === Section === %>`.
+
+This rule is reported at `info` severity and does not fail `herb lint` unless you raise `failLevel`.
+
+## Examples
+
+### ✅ Good
+
+```erb
+<%# This is a regular comment %>
+
+<%# === Section divider === %>
+
+<%= link_to "Home", root_path %>
+```
+
+### 🚫 Bad
+
+```erb
+<%#= link_to "Home", root_path %>
+
+<%# = link_to "Home", root_path %>
+
+<%#== raw_content %>
+```
+
+## References
+
+\-

--- a/javascript/packages/linter/src/rules.ts
+++ b/javascript/packages/linter/src/rules.ts
@@ -19,6 +19,7 @@ import { ActionViewStrictLocalsPartialOnlyRule } from "./rules/actionview-strict
 
 import { ERBCommentSyntax } from "./rules/erb-comment-syntax.js";
 import { ERBNoCaseNodeChildrenRule } from "./rules/erb-no-case-node-children.js"
+import { ERBNoCommentedOutOutputTagsRule } from "./rules/erb-no-commented-out-output-tags.js"
 import { ERBNoDebugOutputRule } from "./rules/erb-no-debug-output.js"
 import { ERBNoConditionalHTMLElementRule } from "./rules/erb-no-conditional-html-element.js"
 import { ERBNoConditionalOpenTagRule } from "./rules/erb-no-conditional-open-tag.js"
@@ -128,6 +129,7 @@ export const rules: RuleClass[] = [
 
   ERBCommentSyntax,
   ERBNoCaseNodeChildrenRule,
+  ERBNoCommentedOutOutputTagsRule,
   ERBNoDebugOutputRule,
   ERBNoEmptyControlFlowRule,
   ERBNoConditionalHTMLElementRule,

--- a/javascript/packages/linter/src/rules/erb-no-commented-out-output-tags.ts
+++ b/javascript/packages/linter/src/rules/erb-no-commented-out-output-tags.ts
@@ -1,0 +1,50 @@
+import { ParserRule } from "../types.js"
+import { BaseRuleVisitor } from "./rule-utils.js"
+
+import type { ParseResult, ERBNode } from "@herb-tools/core"
+import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types.js"
+
+const COMMENTED_OUT_OUTPUT_TAG = /^[ \t]*(={1,2})(?!=)/
+
+class ERBNoCommentedOutOutputTagsVisitor extends BaseRuleVisitor {
+
+  visitERBNode(node: ERBNode): void {
+    const openTag = node.tag_opening
+    const { value } = node.content ?? {}
+
+    if (!openTag || !value) return
+    if (openTag.value !== "<%#") return
+
+    const match = value.match(COMMENTED_OUT_OUTPUT_TAG)
+
+    if (!match) return
+
+    const commentedTag = `<%#${match[0]}`
+    const originalTag = `<%${match[1]}`
+
+    this.addOffense(
+      `\`${commentedTag}\` looks like a temporarily commented ERB output tag. Remove it, or restore it to \`${originalTag}\` if it's still needed.`,
+      openTag.location,
+    )
+  }
+}
+
+export class ERBNoCommentedOutOutputTagsRule extends ParserRule {
+  static ruleName = "erb-no-commented-out-output-tags"
+  static introducedIn = this.version("unreleased")
+
+  get defaultConfig(): FullRuleConfig {
+    return {
+      enabled: true,
+      severity: "info"
+    }
+  }
+
+  check(result: ParseResult, context?: Partial<LintContext>): UnboundLintOffense[] {
+    const visitor = new ERBNoCommentedOutOutputTagsVisitor(this.ruleName, context)
+
+    visitor.visit(result.value)
+
+    return visitor.offenses
+  }
+}

--- a/javascript/packages/linter/src/rules/erb-no-extra-whitespace-inside-tags.ts
+++ b/javascript/packages/linter/src/rules/erb-no-extra-whitespace-inside-tags.ts
@@ -36,13 +36,6 @@ class ERBNoExtraWhitespaceInsideTagsVisitor extends BaseRuleVisitor<ERBNoExtraWh
 
         if (hasExtraWhitespace) {
           this.reportWhitespace(node, openTag, closeTag, value, "start", prefix.length, `Remove extra whitespace after \`${tag}\`. This looks like a temporarily commented ERB tag.`, "after-comment-equals", "info")
-        } else {
-          this.addOffense(
-            `\`${tag}\` looks like a temporarily commented ERB tag.`,
-            openTag.location,
-            { node, openTag, closeTag, content: value, fixType: "after-comment-equals", unsafe: true },
-            "info"
-          )
         }
       }
     }

--- a/javascript/packages/linter/src/rules/index.ts
+++ b/javascript/packages/linter/src/rules/index.ts
@@ -24,6 +24,7 @@ export * from "./actionview-strict-locals-partial-only.js"
 
 export * from "./erb-comment-syntax.js"
 export * from "./erb-no-case-node-children.js"
+export * from "./erb-no-commented-out-output-tags.js"
 export * from "./erb-no-debug-output.js"
 export * from "./erb-no-conditional-open-tag.js"
 export * from "./erb-no-duplicate-branch-elements.js"

--- a/javascript/packages/linter/test/__snapshots__/cli.test.ts.snap
+++ b/javascript/packages/linter/test/__snapshots__/cli.test.ts.snap
@@ -111,7 +111,7 @@ test/fixtures/ignored.html.erb:8:8
   Offenses     5 errors | 2 warnings (7 offenses across 1 file)
   Note         3 additional offenses reported (would have been ignored)
   Fixable      7 offenses | 4 autocorrectable using \`--fix\`
-  Rules        84 enabled | 15 not enabled"
+  Rules        85 enabled | 15 not enabled"
 `;
 
 exports[`CLI Output Formatting > Excluded Files > skips excluded file in subdirectory with README.md project indicator 1`] = `
@@ -177,7 +177,7 @@ test/fixtures/test-file-with-errors.html.erb:2:22
   Checked      1 file
   Offenses     2 errors | 1 warning (3 offenses across 1 file)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        84 enabled | 15 not enabled"
+  Rules        85 enabled | 15 not enabled"
 `;
 
 exports[`CLI Output Formatting > GitHub Actions format includes rule codes 1`] = `
@@ -202,7 +202,7 @@ test/fixtures/no-trailing-newline.html.erb:1:29
   Checked      1 file
   Offenses     1 error | 0 warnings (1 offense across 1 file)
   Fixable      1 offense | 1 autocorrectable using \`--fix\`
-  Rules        84 enabled | 15 not enabled"
+  Rules        85 enabled | 15 not enabled"
 `;
 
 exports[`CLI Output Formatting > GitHub Actions format includes rule codes 2`] = `
@@ -266,7 +266,7 @@ test/fixtures/erb-no-extra-whitespace-inside-tags.html.erb:1:4
   Checked      1 file
   Offenses     4 errors | 0 warnings (4 offenses across 1 file)
   Fixable      4 offenses | 3 autocorrectable using \`--fix\`
-  Rules        84 enabled | 15 not enabled"
+  Rules        85 enabled | 15 not enabled"
 `;
 
 exports[`CLI Output Formatting > Ignores disabled rules 1`] = `
@@ -307,7 +307,7 @@ test/fixtures/ignored.html.erb:6:14
   Checked      1 file
   Offenses     2 errors | 0 warnings | 3 ignored (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        84 enabled | 15 not enabled"
+  Rules        85 enabled | 15 not enabled"
 `;
 
 exports[`CLI Output Formatting > allows tag.attributes in attribute position 1`] = `
@@ -346,7 +346,7 @@ test/fixtures/tag-attributes.html.erb:5:0
   Checked      1 file
   Offenses     2 warnings (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        84 enabled | 15 not enabled"
+  Rules        85 enabled | 15 not enabled"
 `;
 
 exports[`CLI Output Formatting > diplays only parsers errors if one is present 1`] = `
@@ -372,7 +372,7 @@ test/fixtures/parser-errors.html.erb:2:16
   Checked      1 file
   Offenses     1 error | 0 warnings (1 offense across 1 file)
   Fixable      0 offenses
-  Rules        84 enabled | 15 not enabled"
+  Rules        85 enabled | 15 not enabled"
 `;
 
 exports[`CLI Output Formatting > displays most violated rules with multiple offenses 1`] = `
@@ -587,7 +587,7 @@ test/fixtures/multiple-rule-offenses.html.erb:4:7
   Checked      1 file
   Offenses     8 errors | 6 warnings (14 offenses across 1 file)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        84 enabled | 15 not enabled"
+  Rules        85 enabled | 15 not enabled"
 `;
 
 exports[`CLI Output Formatting > displays rule offenses when showing all rules 1`] = `
@@ -684,7 +684,7 @@ test/fixtures/few-rule-offenses.html.erb:6:0
   Checked      1 file
   Offenses     4 errors | 2 warnings (6 offenses across 1 file)
   Fixable      6 offenses | 3 autocorrectable using \`--fix\`
-  Rules        84 enabled | 15 not enabled"
+  Rules        85 enabled | 15 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats GitHub Actions output correctly for bad file 1`] = `
@@ -723,7 +723,7 @@ test/fixtures/bad-file.html.erb:1:16
   Checked      1 file
   Offenses     2 errors | 0 warnings (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        84 enabled | 15 not enabled"
+  Rules        85 enabled | 15 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats GitHub Actions output correctly for clean file 1`] = `
@@ -735,7 +735,7 @@ exports[`CLI Output Formatting > formats GitHub Actions output correctly for cle
   Checked      1 file
   Offenses     0 offenses
   Fixable      0 offenses
-  Rules        84 enabled | 15 not enabled"
+  Rules        85 enabled | 15 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats GitHub Actions output correctly for file with errors 1`] = `
@@ -795,7 +795,7 @@ test/fixtures/test-file-with-errors.html.erb:2:22
   Checked      1 file
   Offenses     2 errors | 1 warning (3 offenses across 1 file)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        84 enabled | 15 not enabled"
+  Rules        85 enabled | 15 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats GitHub Actions output with --format=github option 1`] = `
@@ -834,7 +834,7 @@ test/fixtures/test-file-simple.html.erb:2:22
   Checked      1 file
   Offenses     2 errors | 0 warnings (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        84 enabled | 15 not enabled"
+  Rules        85 enabled | 15 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats JSON output correctly for bad file 1`] = `
@@ -881,7 +881,7 @@ exports[`CLI Output Formatting > formats JSON output correctly for bad file 1`] 
   "summary": {
     "filesChecked": 1,
     "filesWithOffenses": 1,
-    "ruleCount": 84,
+    "ruleCount": 85,
     "totalErrors": 2,
     "totalHints": 0,
     "totalIgnored": 0,
@@ -902,7 +902,7 @@ exports[`CLI Output Formatting > formats JSON output correctly for clean file 1`
   "summary": {
     "filesChecked": 1,
     "filesWithOffenses": 0,
-    "ruleCount": 84,
+    "ruleCount": 85,
     "totalErrors": 0,
     "totalHints": 0,
     "totalIgnored": 0,
@@ -975,7 +975,7 @@ exports[`CLI Output Formatting > formats JSON output correctly for file with err
   "summary": {
     "filesChecked": 1,
     "filesWithOffenses": 1,
-    "ruleCount": 84,
+    "ruleCount": 85,
     "totalErrors": 2,
     "totalHints": 0,
     "totalIgnored": 0,
@@ -1038,7 +1038,7 @@ test/fixtures/test-file-with-errors.html.erb:2:22
   Checked      1 file
   Offenses     2 errors | 1 warning (3 offenses across 1 file)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        84 enabled | 15 not enabled"
+  Rules        85 enabled | 15 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats simple output correctly 1`] = `
@@ -1057,7 +1057,7 @@ test/fixtures/test-file-simple.html.erb:
   Checked      1 file
   Offenses     2 errors | 0 warnings (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        84 enabled | 15 not enabled"
+  Rules        85 enabled | 15 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats simple output for bad-file correctly 1`] = `
@@ -1076,7 +1076,7 @@ test/fixtures/bad-file.html.erb:
   Checked      1 file
   Offenses     2 errors | 0 warnings (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        84 enabled | 15 not enabled"
+  Rules        85 enabled | 15 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats success output correctly 1`] = `
@@ -1088,7 +1088,7 @@ exports[`CLI Output Formatting > formats success output correctly 1`] = `
   Checked      1 file
   Offenses     0 offenses
   Fixable      0 offenses
-  Rules        84 enabled | 15 not enabled"
+  Rules        85 enabled | 15 not enabled"
 `;
 
 exports[`CLI Output Formatting > handles boolean attributes 1`] = `
@@ -1100,7 +1100,7 @@ exports[`CLI Output Formatting > handles boolean attributes 1`] = `
   Checked      1 file
   Offenses     0 offenses
   Fixable      0 offenses
-  Rules        84 enabled | 15 not enabled"
+  Rules        85 enabled | 15 not enabled"
 `;
 
 exports[`CLI Output Formatting > handles multiple errors correctly 1`] = `
@@ -1135,7 +1135,7 @@ test/fixtures/bad-file.html.erb:1:16
   Checked      1 file
   Offenses     2 errors | 0 warnings (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        84 enabled | 15 not enabled"
+  Rules        85 enabled | 15 not enabled"
 `;
 
 exports[`CLI Output Formatting > herb:disable rules 1`] = `
@@ -1267,7 +1267,7 @@ test/fixtures/disabled-1.html.erb:14:19
   Checked      1 file
   Offenses     2 errors | 6 warnings | 8 ignored (8 offenses across 1 file)
   Fixable      8 offenses | 1 autocorrectable using \`--fix\`
-  Rules        84 enabled | 15 not enabled"
+  Rules        85 enabled | 15 not enabled"
 `;
 
 exports[`CLI Output Formatting > herb:disable rules 2`] = `
@@ -1470,7 +1470,7 @@ test/fixtures/disabled-2.html.erb:2:44
   Checked      1 file
   Offenses     6 errors | 7 warnings | 5 ignored (13 offenses across 1 file)
   Fixable      13 offenses | 6 autocorrectable using \`--fix\`
-  Rules        84 enabled | 15 not enabled"
+  Rules        85 enabled | 15 not enabled"
 `;
 
 exports[`CLI Output Formatting > uses GitHub Actions format by default when GITHUB_ACTIONS is true 1`] = `
@@ -1530,5 +1530,5 @@ test/fixtures/test-file-with-errors.html.erb:2:22
   Checked      1 file
   Offenses     2 errors | 1 warning (3 offenses across 1 file)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        84 enabled | 15 not enabled"
+  Rules        85 enabled | 15 not enabled"
 `;

--- a/javascript/packages/linter/test/autofix/erb-no-extra-whitespace-inside-tags.autofix.test.ts
+++ b/javascript/packages/linter/test/autofix/erb-no-extra-whitespace-inside-tags.autofix.test.ts
@@ -76,6 +76,24 @@ describe("erb-no-extra-whitespace-inside-tags autofix", () => {
     expect(result.fixed).toHaveLength(2)
   })
 
+  test("leaves well-formed commented ERB tags untouched, including unsafe fixes", () => {
+    const input = '<%#= link_to "path", path %>'
+
+    const linter = new Linter(Herb, [ERBNoExtraWhitespaceRule])
+
+    expect(linter.autofix(input).source).toBe(input)
+    expect(linter.autofix(input, undefined, undefined, { includeUnsafe: true }).source).toBe(input)
+  })
+
+  test("leaves commented ERB tags with whitespace after the hash untouched", () => {
+    const input = '<%# = link_to "path", path %>'
+
+    const linter = new Linter(Herb, [ERBNoExtraWhitespaceRule])
+
+    expect(linter.autofix(input).source).toBe(input)
+    expect(linter.autofix(input, undefined, undefined, { includeUnsafe: true }).source).toBe(input)
+  })
+
   test("fixes multiple ERB tags with extra spaces", () => {
     const input = dedent`
       <%  if admin  %>

--- a/javascript/packages/linter/test/rules/erb-no-commented-out-output-tags.test.ts
+++ b/javascript/packages/linter/test/rules/erb-no-commented-out-output-tags.test.ts
@@ -1,0 +1,99 @@
+import { describe, it } from "vitest"
+import dedent from "dedent";
+
+import { ERBNoCommentedOutOutputTagsRule } from "../../src/rules/erb-no-commented-out-output-tags";
+import { createLinterTest } from "../helpers/linter-test-helper.js"
+
+const { expectNoOffenses, expectInfo, assertOffenses } = createLinterTest(ERBNoCommentedOutOutputTagsRule)
+
+describe("erb-no-commented-out-output-tags", () => {
+  it("should report a commented out output tag without whitespace", () => {
+    expectInfo("`<%#=` looks like a temporarily commented ERB output tag. Remove it, or restore it to `<%=` if it's still needed.", [1, 0])
+
+    assertOffenses(dedent`
+      <%#= link_to "New watch list", new_watch_list_path %>
+    `)
+  })
+
+  it("should report a commented out output tag with whitespace after the hash", () => {
+    expectInfo("`<%# =` looks like a temporarily commented ERB output tag. Remove it, or restore it to `<%=` if it's still needed.", [1, 0])
+
+    assertOffenses(dedent`
+      <%# = link_to "New watch list", new_watch_list_path %>
+    `)
+  })
+
+  it("should report a commented out raw output tag", () => {
+    expectInfo("`<%#==` looks like a temporarily commented ERB output tag. Remove it, or restore it to `<%==` if it's still needed.", [1, 0])
+
+    assertOffenses(dedent`
+      <%#== raw_content %>
+    `)
+  })
+
+  it("should report a commented out raw output tag with whitespace after the hash", () => {
+    expectInfo("`<%# ==` looks like a temporarily commented ERB output tag. Remove it, or restore it to `<%==` if it's still needed.", [1, 0])
+
+    assertOffenses(dedent`
+      <%# == raw_content %>
+    `)
+  })
+
+  it("should report each commented out tag separately", () => {
+    expectInfo("`<%#=` looks like a temporarily commented ERB output tag. Remove it, or restore it to `<%=` if it's still needed.", [1, 0])
+    expectInfo("`<%# =` looks like a temporarily commented ERB output tag. Remove it, or restore it to `<%=` if it's still needed.", [3, 0])
+
+    assertOffenses(dedent`
+      <%#= user.name %>
+      <%= user.email %>
+      <%# = user.address %>
+    `)
+  })
+
+  it("should not report regular prose comments", () => {
+    expectNoOffenses(dedent`
+      <%# This is a comment %>
+      <%# hello world %>
+      <%# TODO: revisit this %>
+    `)
+  })
+
+  it("should not report comments used as section dividers", () => {
+    expectNoOffenses(dedent`
+      <%# === Section === %>
+      <%# ==== %>
+      <%#=== Section %>
+    `)
+  })
+
+  it("should not report regular ERB tags", () => {
+    expectNoOffenses(dedent`
+      <%= user.name %>
+      <% if admin %>
+        Hello, admin.
+      <% end %>
+      <%== raw_content %>
+    `)
+  })
+
+  it("should not report empty comment tags", () => {
+    expectNoOffenses(dedent`
+      <%# %>
+      <%#%>
+    `)
+  })
+
+  it("should not report a comment where the equals sign is on a later line", () => {
+    expectNoOffenses(dedent`
+      <%#
+        = link_to "New watch list", new_watch_list_path
+      %>
+    `)
+  })
+
+  it("should not report herb:disable directives", () => {
+    expectNoOffenses(dedent`
+      <%# herb:disable erb-no-extra-whitespace-inside-tags %>
+    `)
+  })
+})

--- a/javascript/packages/linter/test/rules/erb-no-extra-whitespace-inside-tags.test.ts
+++ b/javascript/packages/linter/test/rules/erb-no-extra-whitespace-inside-tags.test.ts
@@ -124,11 +124,22 @@ describe("erb-no-extra-whitespace-inside-tags", () => {
     `)
   })
 
-  it("should report info for ERB comment tags with single space after equals", () => {
-    expectInfo("`<%#=` looks like a temporarily commented ERB tag.", [1, 0])
-
-    assertOffenses(dedent`
+  it("should not report ERB comment tags with single space after equals", () => {
+    expectNoOffenses(dedent`
       <%#= link_to "New watch list", new_watch_list_path, class: "btn btn-ghost" %>
+    `)
+  })
+
+  it("should not report commented ERB tags with whitespace after the hash", () => {
+    expectNoOffenses(dedent`
+      <%# = link_to "New watch list", new_watch_list_path %>
+      <%# == raw_content %>
+    `)
+  })
+
+  it("should not report ERB comment tags that look like section dividers", () => {
+    expectNoOffenses(dedent`
+      <%# === Section === %>
     `)
   })
 

--- a/javascript/packages/linter/test/rules/erb-require-whitespace-inside-tags.test.ts
+++ b/javascript/packages/linter/test/rules/erb-require-whitespace-inside-tags.test.ts
@@ -155,6 +155,31 @@ describe("erb-require-whitespace-inside-tags", () => {
     expectNoOffenses(html)
   })
 
+  it("should not report ERB comment tags that look like section dividers", () => {
+    const html = dedent`
+      <%# === Section === %>
+    `
+
+    expectNoOffenses(html)
+  })
+
+  it("should not report ERB comment tags with double equals followed by space", () => {
+    const html = dedent`
+      <%#== raw_content %>
+    `
+
+    expectNoOffenses(html)
+  })
+
+  it("should report ERB comment tags with double equals and no space after", () => {
+    const html = dedent`
+      <%#==raw_content %>
+    `
+
+    expectInfo("Add whitespace after `<%#==`. This looks like a temporarily commented ERB tag.")
+    assertOffenses(html)
+  })
+
   it("should handle multi-line ERB comment tags", () => {
     const html = dedent`
       <%#


### PR DESCRIPTION
This pull request extracts the `"this looks like a temporarily commented ERB tag"` notice out of `erb-no-extra-whitespace-inside-tags` and into a dedicated `erb-no-commented-out-output-tags` rule, so that flagging leftover commented-out code is no longer entangled with whitespace enforcement.

Previously the notice was emitted from the `else` branch of the whitespace rule, meaning it fired specifically when the tag had *no* extra whitespace. A rule named `erb-no-extra-whitespace-inside-tags` reporting on well-formed input is surprising, and the two concerns could not be configured independently: silencing "you left commented-out code here" also disabled real whitespace enforcement, and vice versa.

#### Detection

The new rule only recognizes the `=` forms, since that is the only unambiguous signal that a comment was once an output tag. 

A commented-out *statement* tag (`<% if admin %>` → `<%# if admin %>`) is indistinguishable from prose, so it is deliberately not flagged.

```erb
<%#= link_to "Home", root_path %>
<%# = link_to "Home", root_path %>
<%#== raw_content %>
<%# == raw_content %>
```

Prose comments and section dividers are left alone:

```erb
<%# This is a regular comment %>
<%# === Section divider === %>
<%#=== Section %>
```

This also closes a coverage gap: `<%# = link_to ... %>` was previously flagged by nothing at all, because `getCommentedTagPrefix` returns `null` as soon as the content starts with whitespace. That is exactly the form the formatter used to generate before #1854, so the two changes line up.

#### Offense message

The rule is not autocorrectable. Whether a commented-out tag should be deleted or restored is a decision only the author can make. Instead the message names both options and computes the tag the original would be restored to:

```
`<%#=` looks like a temporarily commented ERB output tag. Remove it, or restore it to `<%=` if it's still needed.
```

#### Fixes a corrupting unsafe autofix

The relocated offense used to carry `fixType: "after-comment-equals"`, whose autofix unconditionally rebuilds the content as `prefix + " " + afterPrefix`. On already-correct input that inserted a second space:

```diff
- <%#= link_to "path", path %>
+ <%#=  link_to "path", path %>
```

The result was then reported by the *other* branch of the same rule as extra whitespace. Dropping the notice from the whitespace rule removes that autofix path. Two new regression tests pin the input as unchanged under both safe and `includeUnsafe` fixing.

Resolves https://github.com/marcoroth/herb/issues/1698
Follow up on #1854