### PR TITLE
Linter CLI: Introduce `--all-rules` flag for running every rule

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -87,6 +87,15 @@ herb-lint --only html-img-require-alt,html-tag-name-lowercase app/views/
 
 Rules passed to `--only` run even when they are disabled, not enabled by default, gated by the `version` in your `.herb.yml`, or excluded through rule-level path patterns. Which files get linted and the configured severities are unaffected.
 
+The `--all-rules` flag <Badge type="info" text="^0.10.3" /> is the counterpart to `--only` and widens the run to every available rule, ignoring the same parts of the rule configuration in `.herb.yml`.
+
+Run every rule, regardless of how it is configured:
+```bash
+herb-lint --all-rules app/views/
+```
+
+Since the two flags pull in opposite directions, `--all-rules` and `--only` can't be combined.
+
 ## Linter Configuration
 
 Configure the linter behavior and rules:

--- a/javascript/packages/linter/README.md
+++ b/javascript/packages/linter/README.md
@@ -249,6 +249,26 @@ Everything else still applies: which files get linted is unchanged, severity ove
 
 Passing an unknown rule name exits with an error, so typos won't silently lint nothing.
 
+**Running Every Rule:** <Badge type="info" text="^0.10.3" />
+
+Run every available rule, regardless of how it is configured:
+```bash
+npx @herb-tools/linter --all-rules
+```
+
+`--all-rules` is the counterpart to `--only`: instead of narrowing the run down to a set of rules, it widens it to all of them. The same parts of the rule configuration in `.herb.yml` are ignored, so rules are run even if they are:
+
+- disabled via `enabled: false`
+- not enabled by default
+- skipped because they were introduced after the `version` in your `.herb.yml`
+- excluded for the linted files via rule-level `only`, `include` or `exclude` patterns
+
+This is useful for seeing everything Herb could report about a codebase, without changing `.herb.yml` first.
+
+Just like with `--only`, everything else still applies: which files get linted is unchanged, severity overrides from `.herb.yml` are respected, and offenses suppressed with `<%# herb:disable %>` comments stay suppressed (use `--ignore-disable-comments` to report them anyway).
+
+Since the two flags pull in opposite directions, `--all-rules` and `--only` can't be combined.
+
 **Autofix:**
 
 Automatically fix auto-correctable offenses:

--- a/javascript/packages/linter/src/cli.ts
+++ b/javascript/packages/linter/src/cli.ts
@@ -151,7 +151,7 @@ export class CLI {
     const startTime = Date.now()
     const startDate = new Date()
 
-    const { patterns, configFile, formatOption, showTiming, theme, wrapLines, truncateLines, useGitHubActions, fix, fixUnsafe, ignoreDisableComments, force, init, upgrade, disableFailing, loadCustomRules, failLevel, jobs, only } = this.argumentParser.parse(process.argv)
+    const { patterns, configFile, formatOption, showTiming, theme, wrapLines, truncateLines, useGitHubActions, fix, fixUnsafe, ignoreDisableComments, force, init, upgrade, disableFailing, loadCustomRules, failLevel, jobs, only, allRules } = this.argumentParser.parse(process.argv)
 
     this.determineProjectPath(patterns)
 
@@ -456,7 +456,8 @@ export class CLI {
         hasConfigFile,
         loadCustomRules,
         jobs,
-        only
+        only,
+        allRules
       }
 
       const results = await this.fileProcessor.processFiles(files, formatOption, context)

--- a/javascript/packages/linter/src/cli/argument-parser.ts
+++ b/javascript/packages/linter/src/cli/argument-parser.ts
@@ -32,6 +32,7 @@ export interface ParsedArguments {
   failLevel?: DiagnosticSeverity
   jobs: number
   only?: string[]
+  allRules: boolean
 }
 
 export class ArgumentParser {
@@ -53,6 +54,9 @@ export class ArgumentParser {
       --only <rules>                only run the given rules, ignoring the rule configuration in .herb.yml
                                     accepts a comma-separated list and can be passed multiple times
                                     (e.g., herb-lint --only html-img-require-alt,html-tag-name-lowercase)
+      --all-rules                   run every rule, ignoring the rule configuration in .herb.yml
+                                    including rules that are disabled, not enabled by default,
+                                    or introduced after the version in .herb.yml
       --fix                         automatically fix auto-correctable offenses
       --fix-unsafely                also apply unsafe auto-fixes (implies --fix)
       --ignore-disable-comments     report offenses even when suppressed with <%# herb:disable %> comments
@@ -84,6 +88,7 @@ export class ArgumentParser {
         "config-file": { type: "string", short: "c" },
         force: { type: "boolean" },
         only: { type: "string", multiple: true },
+        "all-rules": { type: "boolean" },
         fix: { type: "boolean" },
         "fix-unsafely": { type: "boolean" },
         "ignore-disable-comments": { type: "boolean" },
@@ -170,6 +175,8 @@ export class ArgumentParser {
     const disableFailing = values["disable-failing"] || false
     const loadCustomRules = !values["no-custom-rules"]
 
+    const allRules = values["all-rules"] || false
+
     let only: string[] | undefined
 
     if (values.only) {
@@ -177,6 +184,11 @@ export class ArgumentParser {
 
       if (only.length === 0) {
         console.error(`Error: --only requires at least one rule name.`)
+        process.exit(1)
+      }
+
+      if (allRules) {
+        console.error(`Error: --only and --all-rules can't be combined.`)
         process.exit(1)
       }
     }
@@ -205,7 +217,7 @@ export class ArgumentParser {
       jobs = parsed
     }
 
-    return { patterns, configFile, formatOption, showTiming, theme, wrapLines, truncateLines, useGitHubActions, fix, fixUnsafe, ignoreDisableComments, force, init, upgrade, disableFailing, loadCustomRules, failLevel, jobs, only }
+    return { patterns, configFile, formatOption, showTiming, theme, wrapLines, truncateLines, useGitHubActions, fix, fixUnsafe, ignoreDisableComments, force, init, upgrade, disableFailing, loadCustomRules, failLevel, jobs, only, allRules }
   }
 
   private getFilePatterns(positionals: string[]): string[] {

--- a/javascript/packages/linter/src/cli/file-processor.ts
+++ b/javascript/packages/linter/src/cli/file-processor.ts
@@ -39,6 +39,7 @@ export interface ProcessingContext {
   loadCustomRules?: boolean
   jobs?: number
   only?: string[]
+  allRules?: boolean
 }
 
 export interface UnknownRule {
@@ -198,7 +199,7 @@ export class FileProcessor {
     if (!this.linter) {
       const customRules = await this.loadCustomRulesOnce(context, formatOption)
 
-      this.linter = Linter.from(Herb, context?.config, customRules, { only: context?.only })
+      this.linter = Linter.from(Herb, context?.config, customRules, { only: context?.only, all: context?.allRules })
     }
 
     for (const filename of files) {
@@ -314,7 +315,7 @@ export class FileProcessor {
     const workerPath = this.resolveWorkerPath()
 
     const configVersion = context?.config?.configVersion
-    const filterResult = Linter.filterRulesByConfig(rules, context?.config?.linter?.rules, configVersion, { only: context?.only })
+    const filterResult = Linter.filterRulesByConfig(rules, context?.config?.linter?.rules, configVersion, { only: context?.only, all: context?.allRules })
 
     const workerPromises = chunks.map(chunk => this.runWorker(workerPath, chunk, context))
     const workerResults = await Promise.all(workerPromises)
@@ -364,6 +365,7 @@ export class FileProcessor {
         ignoreDisableComments: context?.ignoreDisableComments || false,
         loadCustomRules: context?.loadCustomRules || false,
         only: context?.only,
+        allRules: context?.allRules || false,
       }
 
       const worker = new Worker(workerPath, { workerData })

--- a/javascript/packages/linter/src/cli/lint-worker.ts
+++ b/javascript/packages/linter/src/cli/lint-worker.ts
@@ -19,6 +19,7 @@ export interface WorkerInput {
   ignoreDisableComments: boolean
   loadCustomRules: boolean
   only?: string[]
+  allRules: boolean
 }
 
 export interface WorkerOffense {
@@ -66,7 +67,7 @@ async function run() {
     }
   }
 
-  const linter = Linter.from(Herb, config, customRules, { only: data.only })
+  const linter = Linter.from(Herb, config, customRules, { only: data.only, all: data.allRules })
 
   let totalErrors = 0
   let totalWarnings = 0

--- a/javascript/packages/linter/src/cli/output-manager.ts
+++ b/javascript/packages/linter/src/cli/output-manager.ts
@@ -68,6 +68,7 @@ export class OutputManager {
           hasConfigFile: context?.hasConfigFile,
           toolVersion: options.toolVersion,
           only: context?.only,
+          allRules: context?.allRules,
         })
       }
     } else if (options.formatOption === "json") {
@@ -136,6 +137,7 @@ export class OutputManager {
         hasConfigFile: context?.hasConfigFile,
         toolVersion: options.toolVersion,
         only: context?.only,
+        allRules: context?.allRules,
       })
     }
   }

--- a/javascript/packages/linter/src/cli/summary-reporter.ts
+++ b/javascript/packages/linter/src/cli/summary-reporter.ts
@@ -29,6 +29,7 @@ export interface SummaryData {
   hasConfigFile?: boolean
   toolVersion?: string
   only?: string[]
+  allRules?: boolean
 }
 
 export class SummaryReporter {
@@ -132,6 +133,7 @@ export class SummaryReporter {
     const rulesParts = [colorize(colorize(`${ruleCount} enabled`, "green"), "bold")]
 
     if (data.only && data.only.length > 0) rulesParts.push(colorize(`filtered by --only`, "cyan"))
+    if (data.allRules) rulesParts.push(colorize(`all rules via --all-rules`, "cyan"))
     if (notEnabledCount > 0) rulesParts.push(colorize(`${notEnabledCount} not enabled`, "cyan"))
     if (disabledCount > 0) rulesParts.push(colorize(`${disabledCount} disabled`, "yellow"))
     if (skippedCount > 0) rulesParts.push(colorize(`${skippedCount} skipped (version)`, "gray"))

--- a/javascript/packages/linter/src/linter.ts
+++ b/javascript/packages/linter/src/linter.ts
@@ -63,6 +63,7 @@ export interface FilterRulesResult {
 
 export interface FilterRulesOptions {
   only?: string[]
+  all?: boolean
 }
 
 export class Linter {
@@ -72,6 +73,7 @@ export class Linter {
   public rulesNotEnabledByDefault: number = 0
   public mode: LinterMode = "cli"
   public onlyRules?: string[]
+  public allRules: boolean = false
 
   protected allAvailableRules: RuleClass[]
   protected herb: HerbBackend
@@ -98,6 +100,7 @@ export class Linter {
     linter.rulesDisabledByConfig = filterResult.disabledByConfig
     linter.rulesNotEnabledByDefault = filterResult.notEnabledByDefault
     linter.onlyRules = Linter.normalizeOnlyRules(options?.only)
+    linter.allRules = options?.all ?? false
 
     return linter
   }
@@ -133,6 +136,9 @@ export class Linter {
    * When `options.only` is provided all of the above is bypassed and exactly the
    * requested rules are enabled, regardless of the user configuration.
    *
+   * When `options.all` is provided all of the above is bypassed and every available
+   * rule is enabled, regardless of the user configuration.
+   *
    * @param allRules - All available rule classes to filter from
    * @param userRulesConfig - Optional user configuration for rules
    * @param configVersion - Optional version from the user's .herb.yml for version-gated filtering
@@ -150,6 +156,15 @@ export class Linter {
     if (onlyRules) {
       return {
         enabled: allRules.filter(ruleClass => onlyRules.includes(ruleClass.ruleName)),
+        skippedByVersion: [],
+        disabledByConfig: 0,
+        notEnabledByDefault: 0
+      }
+    }
+
+    if (options?.all) {
+      return {
+        enabled: [...allRules],
         skippedByVersion: [],
         disabledByConfig: 0,
         notEnabledByDefault: 0
@@ -290,7 +305,7 @@ export class Linter {
   ): UnboundLintOffense[] {
     const ruleName = rule.ruleName
 
-    if (this.config && context?.fileName && !this.onlyRules) {
+    if (this.config && context?.fileName && !this.onlyRules && !this.allRules) {
       if (!this.config.isRuleEnabledForPath(ruleName, context.fileName)) {
         return []
       }

--- a/javascript/packages/linter/test/cli.test.ts
+++ b/javascript/packages/linter/test/cli.test.ts
@@ -864,6 +864,137 @@ describe("CLI Output Formatting", () => {
     })
   })
 
+  describe("--all-rules", () => {
+    const { writeFileSync, unlinkSync } = require("fs")
+    const configPath = "test/fixtures/.herb.yml"
+
+    test("runs rules that are not enabled by default", () => {
+      const fixturePath = "test/fixtures/all-rules-not-enabled-by-default.html.erb"
+
+      try {
+        writeFileSync(fixturePath, `<div disabled>Save</div>\n`)
+
+        const withoutAllRules = runLinter("all-rules-not-enabled-by-default.html.erb", "--simple")
+        expect(withoutAllRules.output).not.toContain("a11y-disabled-attribute")
+
+        const { output } = runLinter("all-rules-not-enabled-by-default.html.erb", "--simple", "--all-rules")
+
+        expect(output).toContain("a11y-disabled-attribute")
+        expect(output).toContain("all rules via --all-rules")
+      } finally {
+        try { unlinkSync(fixturePath) } catch {}
+      }
+    })
+
+    test("runs rules that are disabled in .herb.yml", () => {
+      try {
+        writeFileSync(configPath, dedent`
+          linter:
+            rules:
+              html-tag-name-lowercase:
+                enabled: false
+        `)
+
+        const withoutAllRules = runLinter("test-file-with-errors.html.erb", "--simple")
+        expect(withoutAllRules.output).not.toContain("html-tag-name-lowercase")
+
+        const { output, exitCode } = runLinter("test-file-with-errors.html.erb", "--simple", "--all-rules")
+
+        expect(output).toContain("html-tag-name-lowercase")
+        expect(exitCode).toBe(1)
+      } finally {
+        try { unlinkSync(configPath) } catch {}
+      }
+    })
+
+    test("runs rules that are skipped by the version in .herb.yml", () => {
+      const fixturePath = "test/fixtures/all-rules-version-gated.html.erb"
+
+      try {
+        writeFileSync(configPath, dedent`
+          version: 0.4.0
+        `)
+
+        writeFileSync(fixturePath, dedent`
+          <div>
+            <foobar>hi</foobar>
+          </div>
+        ` + "\n")
+
+        const withoutAllRules = runLinter("all-rules-version-gated.html.erb", "--simple")
+        expect(withoutAllRules.output).toContain("New rules available")
+        expect(withoutAllRules.output).not.toContain("Unknown HTML tag")
+
+        const { output } = runLinter("all-rules-version-gated.html.erb", "--simple", "--all-rules")
+
+        expect(output).toContain("html-no-unknown-tag")
+        expect(output).not.toContain("New rules available")
+      } finally {
+        try { unlinkSync(configPath) } catch {}
+        try { unlinkSync(fixturePath) } catch {}
+      }
+    })
+
+    test("ignores rule-level exclude patterns from .herb.yml", () => {
+      try {
+        writeFileSync(configPath, dedent`
+          linter:
+            rules:
+              html-tag-name-lowercase:
+                exclude:
+                  - '**/*.html.erb'
+        `)
+
+        const withoutAllRules = runLinter("test-file-with-errors.html.erb", "--simple")
+        expect(withoutAllRules.output).not.toContain("html-tag-name-lowercase")
+
+        const { output, exitCode } = runLinter("test-file-with-errors.html.erb", "--simple", "--all-rules")
+
+        expect(output).toContain("html-tag-name-lowercase")
+        expect(exitCode).toBe(1)
+      } finally {
+        try { unlinkSync(configPath) } catch {}
+      }
+    })
+
+    test("still respects herb:disable comments", () => {
+      const fixturePath = "test/fixtures/all-rules-disable-comment.html.erb"
+
+      try {
+        writeFileSync(fixturePath, dedent`
+          <DIV>test</DIV> <%# herb:disable html-tag-name-lowercase %>
+        ` + "\n")
+
+        const { output } = runLinter("all-rules-disable-comment.html.erb", "--simple", "--all-rules")
+
+        expect(output).not.toContain("should be lowercase")
+        expect(output).toContain("2 ignored")
+
+        const ignoring = runLinter("all-rules-disable-comment.html.erb", "--simple", "--all-rules", "--ignore-disable-comments")
+
+        expect(ignoring.output).toContain("should be lowercase")
+      } finally {
+        try { unlinkSync(fixturePath) } catch {}
+      }
+    })
+
+    test("applies when the run is split across workers", () => {
+      const withoutAllRules = JSON.parse(runLinter("parallel", "--jobs", "4", "--json").output)
+      const { output, exitCode } = runLinter("parallel", "--jobs", "4", "--json", "--all-rules")
+      const result = JSON.parse(output)
+
+      expect(result.summary.ruleCount).toBeGreaterThan(withoutAllRules.summary.ruleCount)
+      expect(exitCode).toBe(0)
+    })
+
+    test("can't be combined with --only", () => {
+      const { output, exitCode } = runLinter("test-file-with-errors.html.erb", "--simple", "--all-rules", "--only", "html-tag-name-lowercase")
+
+      expect(output).toContain("--only and --all-rules can't be combined")
+      expect(exitCode).toBe(1)
+    })
+  })
+
   describe("Directory Scoping (issue #1045)", () => {
     const { mkdirSync, writeFileSync, rmSync, existsSync } = require("fs")
     const { join } = require("path")

--- a/javascript/packages/linter/test/linter.test.ts
+++ b/javascript/packages/linter/test/linter.test.ts
@@ -770,6 +770,87 @@ describe("@herb-tools/linter", () => {
     })
   })
 
+  describe("`all` rule filtering", () => {
+    class EnabledRule extends ParserRule {
+      static ruleName = "enabled-rule"
+
+      get defaultConfig(): FullRuleConfig {
+        return { enabled: true, severity: "error" }
+      }
+
+      check(): UnboundLintOffense[] { return [] }
+    }
+
+    class DisabledRule extends ParserRule {
+      static ruleName = "disabled-rule"
+
+      get defaultConfig(): FullRuleConfig {
+        return { enabled: false, severity: "error" }
+      }
+
+      check(): UnboundLintOffense[] { return [] }
+    }
+
+    class VersionGatedRule extends ParserRule {
+      static ruleName = "version-gated-rule"
+      static introducedIn = "0.9.0" as const
+
+      get defaultConfig(): FullRuleConfig {
+        return { enabled: true, severity: "error" }
+      }
+
+      check(): UnboundLintOffense[] { return [] }
+    }
+
+    test("enables every rule, regardless of the configuration", () => {
+      const { enabled, skippedByVersion, disabledByConfig, notEnabledByDefault } = Linter.filterRulesByConfig(
+        [EnabledRule, DisabledRule, VersionGatedRule],
+        { "enabled-rule": { enabled: false } },
+        "0.8.0",
+        { all: true }
+      )
+
+      expect(enabled.map(ruleClass => ruleClass.ruleName)).toEqual(["enabled-rule", "disabled-rule", "version-gated-rule"])
+      expect(skippedByVersion).toHaveLength(0)
+      expect(disabledByConfig).toBe(0)
+      expect(notEnabledByDefault).toBe(0)
+    })
+
+    test("falls back to the regular filtering when not requested", () => {
+      const { enabled, notEnabledByDefault } = Linter.filterRulesByConfig([EnabledRule, DisabledRule], undefined, undefined, { all: false })
+
+      expect(enabled.map(ruleClass => ruleClass.ruleName)).toEqual(["enabled-rule"])
+      expect(notEnabledByDefault).toBe(1)
+    })
+
+    test("`only` takes precedence over `all`", () => {
+      const { enabled } = Linter.filterRulesByConfig([EnabledRule, DisabledRule, VersionGatedRule], undefined, undefined, {
+        only: ["disabled-rule"],
+        all: true
+      })
+
+      expect(enabled.map(ruleClass => ruleClass.ruleName)).toEqual(["disabled-rule"])
+    })
+
+    test("Linter.from() runs rules that are disabled in the config", () => {
+      const config = Config.fromObject({
+        linter: {
+          enabled: true,
+          rules: { "html-tag-name-lowercase": { enabled: false } }
+        }
+      })
+
+      const withoutAllRules = Linter.from(Herb, config)
+      expect(withoutAllRules.lint("<DIV></DIV>", { fileName: "template.html.erb" }).offenses.map(offense => offense.rule)).not.toContain("html-tag-name-lowercase")
+
+      const linter = Linter.from(Herb, config, undefined, { all: true })
+      const result = linter.lint("<DIV></DIV>", { fileName: "template.html.erb" })
+
+      expect(linter.allRules).toBe(true)
+      expect(result.offenses.map(offense => offense.rule)).toContain("html-tag-name-lowercase")
+    })
+  })
+
   describe("Version-gated rule filtering", () => {
     class OldRule extends ParserRule {
       static ruleName = "old-rule"


### PR DESCRIPTION
This pull request adds an `--all-rules` flag to the linter CLI, which runs every available rule regardless of how it is configured in `.herb.yml`.

It is the counterpart to the `--only` flag from #1908: where `--only` narrows a run down to a set of rules, `--all-rules` widens it to all of them. 

```bash
herb-lint --all-rules app/views/
```

This is useful for seeing everything Herb could report about a codebase without having to edit `.herb.yml` first, and for comparing linter implementations across a corpus, where the configured rule set would otherwise hide differences between them.

Everything outside of rule selection still applies: which files get linted is unchanged, severity overrides from `.herb.yml` are respected, and offenses suppressed with `<%# herb:disable %>` comments stay suppressed (use `--ignore-disable-comments` to report them anyway).

The summary reports which rules ran, replacing the counts that no longer mean anything when every rule is enabled:

```
  Rules        99 enabled | all rules via --all-rules
```