### PR TITLE
Formatter: Preserve whitespace before outputs after a preceding sibling

### DIFF
--- a/javascript/packages/formatter/src/format-printer.ts
+++ b/javascript/packages/formatter/src/format-printer.ts
@@ -1583,6 +1583,10 @@ export class FormatPrinter extends Printer implements TextFlowDelegate, Attribut
         if (isPureWhitespaceNode(prevSibling) || isNode(prevSibling, WhitespaceNode)) {
           hasSpaceBefore = true
         }
+
+        if (isNode(prevSibling, HTMLTextNode) && endsWithWhitespace(prevSibling.content)) {
+          hasSpaceBefore = true
+        }
       }
 
       const inlineContent = this.withInlineMode(() => this.capture(() => this.visit(child)).join(""))

--- a/javascript/packages/formatter/test/erb/whitespace-preservation.test.ts
+++ b/javascript/packages/formatter/test/erb/whitespace-preservation.test.ts
@@ -397,4 +397,50 @@ describe("whitespace preservation around ERB control flow", () => {
       expectFormattedToMatch(`<p><em><%= name %></em> created an account.</p>`)
     })
   })
+
+  // https://github.com/marcoroth/herb/issues/1922
+  describe("#1922 — space before an output tag preceded by a sibling node", () => {
+    test("keeps the space when a control-flow node precedes the line", () => {
+      expectFormattedToMatch(dedent`
+        <% if @show_x %>
+          x
+        <% end %>
+        y and <%= @z %>
+      `)
+    })
+
+    test("keeps the space when an HTML element precedes the line", () => {
+      expectFormattedToMatch(dedent`
+        <div>x</div>
+        y and <%= @z %>
+      `)
+    })
+
+    test("keeps the space when an output tag precedes the line", () => {
+      expect(formatter.format(dedent`
+        <%= @x %>
+        y and <%= @z %>
+      `)).toEqual(`<%= @x %> y and <%= @z %>`)
+    })
+
+    test("keeps the space inside a block element", () => {
+      expectFormattedToMatch(dedent`
+        <section>
+          <div>x</div>
+          y and <%= @z %>
+        </section>
+      `)
+    })
+
+    test("keeps text glued to the output tag when the source has no space", () => {
+      expectFormattedToMatch(dedent`
+        <div>x</div>
+        y and<%= @z %>
+      `)
+    })
+
+    test("keeps the space with no preceding sibling", () => {
+      expectFormattedToMatch(`y and <%= @z %>`)
+    })
+  })
 })


### PR DESCRIPTION
This pull request fixes the formatter deleting the space before an ERB output tag when the line follows a sibling node that isn't part of the same text flow, like a control-flow block or an HTML element.

**Before**

```erb
<% if @show_x %>
  x
<% end %>
y and <%= @z %>
```

was formatted to

```erb
<% if @show_x %>
  x
<% end %>
y and<%= @z %>
```

gluing `and` to `<%= @z %>` and changing the rendered output. The same happened with an HTML element as the preceding sibling:

```erb
<div>x</div>
y and <%= @z %>
```

**After** this change, both inputs are left unchanged.

Content that is genuinely glued in the source keeps its glue, since that text node doesn't end with whitespace:

```erb
<div>x</div>
y and<%= @z %>
```

Resolves https://github.com/marcoroth/herb/issues/1922