### PR TITLE
Formatter: Fix `<br>` tags alternating between glued/split form

### DIFF
--- a/javascript/packages/formatter/src/text-flow-engine.ts
+++ b/javascript/packages/formatter/src/text-flow-engine.ts
@@ -219,7 +219,11 @@ export class TextFlowEngine {
         this.flushWords(words)
 
         if (node) {
-          this.delegate.visit(node)
+          if (isNode(node, HTMLElementNode) && isLineBreakingElement(node)) {
+            this.delegate.pushWithIndent(this.delegate.renderInlineElementAsString(node))
+          } else {
+            this.delegate.visit(node)
+          }
         }
       } else if (unit.isAtomic) {
         words.push(unit.content)

--- a/javascript/packages/formatter/test/html/line-breaking-text-flow.test.ts
+++ b/javascript/packages/formatter/test/html/line-breaking-text-flow.test.ts
@@ -1,0 +1,110 @@
+import { describe, test, expect, beforeAll } from "vitest"
+import { Herb } from "@herb-tools/node-wasm"
+import { Formatter } from "../../src"
+import { createExpectFormattedToMatch } from "../helpers"
+
+import dedent from "dedent"
+
+let formatter: Formatter
+let expectFormattedToMatch: ReturnType<typeof createExpectFormattedToMatch>
+
+describe("line-breaking elements in text flow", () => {
+  beforeAll(async () => {
+    await Herb.load()
+
+    formatter = new Formatter(Herb, {
+      indentWidth: 2,
+      maxLineLength: 80
+    })
+
+    expectFormattedToMatch = createExpectFormattedToMatch(formatter)
+  })
+
+  test("keeps consecutive <br> tags on their own lines before text with ERB", () => {
+    const source = dedent`
+      <br>
+      <br>
+      y and <%= @z %>
+    `
+
+    expectFormattedToMatch(source, { passes: 2 })
+  })
+
+  test("splits glued <br> tags before text with ERB and stays stable", () => {
+    const source = dedent`
+      <br><br>
+      y and <%= @z %>
+    `
+
+    const expected = dedent`
+      <br>
+      <br>
+      y and <%= @z %>
+    `
+
+    expect(formatter.format(source)).toEqual(expected)
+    expectFormattedToMatch(expected, { passes: 2 })
+  })
+
+  test("keeps consecutive <br> tags on their own lines without following text", () => {
+    const source = dedent`
+      <br>
+      <br>
+    `
+
+    expectFormattedToMatch(source, { passes: 2 })
+  })
+
+  test("preserves the line break between text with ERB and a following <br>", () => {
+    const source = dedent`
+      y and <%= @z %>
+      <br>
+    `
+
+    expectFormattedToMatch(source, { passes: 2 })
+  })
+
+  test("keeps a <br> glued to preceding ERB output when the source has no whitespace", () => {
+    const source = dedent`
+      y and <%= @z %><br>
+    `
+
+    expectFormattedToMatch(source, { passes: 2 })
+  })
+
+  test("preserves the line break between text and a following <hr>", () => {
+    const source = dedent`
+      x
+      <hr>
+      y and <%= @z %>
+    `
+
+    expectFormattedToMatch(source, { passes: 2 })
+  })
+
+  test("keeps consecutive <br> tags on their own lines inside an element", () => {
+    const source = dedent`
+      <p>
+        <br>
+        <br>
+        y and <%= @z %>
+      </p>
+    `
+
+    expectFormattedToMatch(source, { passes: 2 })
+  })
+
+  test("breaks the line after a <br> glued between text", () => {
+    const source = dedent`
+      a<br>b and <%= @z %>
+    `
+
+    const expected = dedent`
+      a<br>
+      b and <%= @z %>
+    `
+
+    expect(formatter.format(source)).toEqual(expected)
+    expectFormattedToMatch(expected, { passes: 2 })
+  })
+})


### PR DESCRIPTION
This pull request fixes an idempotency bug in the text flow engine where consecutive `<br>` tags followed by a "text with ERB" line would flip-flop between glued and split forms on every formatting pass, so `format(format(x))` never settled:

**Input:**

```html+erb
<br>
<br>
y and <%= @z %>
```

**Pass 1:**

```html+erb
<br><br>
y and <%= @z %>
```

**Pass 2:**

```html+erb
<br>
<br>
y and <%= @z %>
```

The two forms alternate forever. Starting from the glued form produces the same back-and-forth in the opposite phase.

The root cause is a disagreement between two rendering paths about where a line-breaking element belongs. 

When a `<br>`/`<hr>` is separated from its neighbours by whitespace, `TextFlowAnalyzer` keeps it out of the flow as a `block` unit and `buildAndWrapTextFlow` delegated it back to `visit()`. 

In root-level inline mode, `visitHTMLElementNode` appends void elements to the previous line via `pushToLastLine`, gluing the tags together. On the next pass the now-adjacent tags take the `renderAdjacentInlineElements` path instead, which deliberately flushes every line-breaking element onto its own line, splitting them apart again. Nested (indented) contexts always used the split form and were already stable.

The fix makes `buildAndWrapTextFlow` render line-breaking elements on their own line via `pushWithIndent`, matching what `renderAdjacentInlineElements` and nested contexts already do. This also stops the formatter from deleting the user's newline before a following `<br>`:

```html+erb
y and <%= @z %>
<br>
```

Discovered while verifying the fix for #1922.