### PR TITLE
Linter: Clear `ParseCache` per pass and read file content lazily

### DIFF
--- a/javascript/packages/linter/src/cli/file-processor.ts
+++ b/javascript/packages/linter/src/cli/file-processor.ts
@@ -21,7 +21,7 @@ import type { VersionSkippedRule } from "../linter.js"
 export interface ProcessedFile {
   filename: string
   offense: Diagnostic
-  content: string
+  content?: string
   autocorrectable?: boolean
 }
 
@@ -153,7 +153,7 @@ export class FileProcessor {
 
     for (const filename of files) {
       const filePath = context?.projectPath ? resolve(context.projectPath, filename) : resolve(filename)
-      let content = readFileSync(filePath, "utf-8")
+      const content = readFileSync(filePath, "utf-8")
 
       const lintResult = this.linter.lint(content, {
         fileName: filename,
@@ -180,13 +180,10 @@ export class FileProcessor {
           }
         }
 
-        content = autofixResult.source
-
         for (const offense of autofixResult.unfixed) {
           allOffenses.push({
             filename,
             offense: offense,
-            content,
             autocorrectable: this.isRuleAutocorrectable(offense.rule)
           })
 
@@ -212,7 +209,6 @@ export class FileProcessor {
           allOffenses.push({
             filename,
             offense: offense,
-            content,
             autocorrectable: this.isRuleAutocorrectable(offense.rule)
           })
 
@@ -365,7 +361,6 @@ export class FileProcessor {
         allOffenses.push({
           filename: offense.filename,
           offense: deserializeDiagnostic(offense.offense),
-          content: offense.content,
           autocorrectable: offense.autocorrectable
         })
       }

--- a/javascript/packages/linter/src/cli/formatters/base-formatter.ts
+++ b/javascript/packages/linter/src/cli/formatters/base-formatter.ts
@@ -1,7 +1,41 @@
+import { readFileSync } from "node:fs"
+import { resolve } from "node:path"
+
 import type { Diagnostic } from "@herb-tools/core"
 import type { ProcessedFile } from "../file-processor.js"
 
 export abstract class BaseFormatter {
+  protected projectPath?: string
+
+  private lastReadFilename?: string
+  private lastReadContent: string = ""
+
+  constructor(projectPath?: string) {
+    this.projectPath = projectPath
+  }
+
+  protected contentFor(processedFile: ProcessedFile): string {
+    if (processedFile.content !== undefined) {
+      return processedFile.content
+    }
+
+    if (processedFile.filename !== this.lastReadFilename) {
+      this.lastReadFilename = processedFile.filename
+
+      try {
+        const filePath = this.projectPath
+          ? resolve(this.projectPath, processedFile.filename)
+          : resolve(processedFile.filename)
+
+        this.lastReadContent = readFileSync(filePath, "utf-8")
+      } catch {
+        this.lastReadContent = ""
+      }
+    }
+
+    return this.lastReadContent
+  }
+
   abstract format(
     allOffenses: ProcessedFile[],
     isSingleFile?: boolean

--- a/javascript/packages/linter/src/cli/formatters/detailed-formatter.ts
+++ b/javascript/packages/linter/src/cli/formatters/detailed-formatter.ts
@@ -1,9 +1,10 @@
 import { colorize, Highlighter, type ThemeInput, DEFAULT_THEME } from "@herb-tools/highlighter"
 
-import { BaseFormatter } from "./base-formatter.js"
-import { LineWrapper } from "@herb-tools/highlighter"
 import { ruleDocumentationUrl } from "../../urls.js"
 import { fileUrl } from "../file-url.js"
+
+import { BaseFormatter } from "./base-formatter.js"
+import { LineWrapper } from "@herb-tools/highlighter"
 
 import type { Diagnostic } from "@herb-tools/core"
 import type { ProcessedFile } from "../file-processor.js"
@@ -14,8 +15,9 @@ export class DetailedFormatter extends BaseFormatter {
   private wrapLines: boolean
   private truncateLines: boolean
 
-  constructor(theme: ThemeInput = DEFAULT_THEME, wrapLines: boolean = true, truncateLines: boolean = false) {
-    super()
+  constructor(theme: ThemeInput = DEFAULT_THEME, wrapLines: boolean = true, truncateLines: boolean = false, projectPath?: string) {
+    super(projectPath)
+
     this.theme = theme
     this.wrapLines = wrapLines
     this.truncateLines = truncateLines
@@ -35,7 +37,8 @@ export class DetailedFormatter extends BaseFormatter {
     )
 
     if (isSingleFile) {
-      const { filename, content } = allOffenses[0]
+      const { filename } = allOffenses[0]
+      const content = this.contentFor(allOffenses[0])
       const diagnostics = allOffenses.map(item => item.offense)
 
       const highlighted = this.highlighter.highlight(filename, content, {
@@ -54,10 +57,11 @@ export class DetailedFormatter extends BaseFormatter {
       const totalMessageCount = allOffenses.length
 
       for (let i = 0; i < allOffenses.length; i++) {
-        const { filename, offense, content, autocorrectable } = allOffenses[i]
-
+        const { filename, offense, autocorrectable } = allOffenses[i]
+        const content = this.contentFor(allOffenses[i])
         const codeUrl = offense.code ? ruleDocumentationUrl(offense.code) : undefined
         const suffix = autocorrectable ? correctableTag : undefined
+
         const formatted = this.highlighter.highlightDiagnostic(filename, offense, content, {
           contextLines: 2,
           wrapLines: this.wrapLines,
@@ -66,6 +70,7 @@ export class DetailedFormatter extends BaseFormatter {
           fileUrl: fileUrl(filename),
           suffix,
         })
+
         console.log(`\n${formatted}`)
 
         const width = LineWrapper.getTerminalWidth()

--- a/javascript/packages/linter/src/cli/formatters/github-actions-formatter.ts
+++ b/javascript/packages/linter/src/cli/formatters/github-actions-formatter.ts
@@ -12,8 +12,9 @@ export class GitHubActionsFormatter extends BaseFormatter {
   private wrapLines: boolean
   private truncateLines: boolean
 
-  constructor(wrapLines: boolean = true, truncateLines: boolean = false) {
-    super()
+  constructor(wrapLines: boolean = true, truncateLines: boolean = false, projectPath?: string) {
+    super(projectPath)
+
     this.wrapLines = wrapLines
     this.truncateLines = truncateLines
     this.highlighter = new Highlighter()
@@ -44,11 +45,15 @@ export class GitHubActionsFormatter extends BaseFormatter {
       await this.highlighter.initialize()
     }
 
-    for (const { filename, offense, content } of allDiagnostics) {
+    for (const processedFile of allDiagnostics) {
+      const { filename, offense } = processedFile
+      const content = this.contentFor(processedFile)
       const originalNoColor = process.env.NO_COLOR
+
       process.env.NO_COLOR = "1"
 
       let plainCodePreview = ""
+
       try {
         const formatted = this.highlighter.highlightDiagnostic(filename, offense, content, {
           contextLines: 2,

--- a/javascript/packages/linter/src/cli/lint-worker.ts
+++ b/javascript/packages/linter/src/cli/lint-worker.ts
@@ -23,7 +23,6 @@ export interface WorkerInput {
 export interface WorkerOffense {
   filename: string
   offense: SerializedDiagnostic
-  content: string
   autocorrectable: boolean
 }
 
@@ -94,7 +93,7 @@ async function run() {
 
   for (const filename of data.files) {
     const filePath = data.projectPath ? resolve(data.projectPath, filename) : resolve(filename)
-    let content = readFileSync(filePath, "utf-8")
+    const content = readFileSync(filePath, "utf-8")
 
     const lintResult = linter.lint(content, {
       fileName: filename,
@@ -113,13 +112,10 @@ async function run() {
         fixMessages.push(`${filename}\t${autofixResult.fixed.length}`)
       }
 
-      content = autofixResult.source
-
       for (const offense of autofixResult.unfixed) {
         allOffenses.push({
           filename,
           offense,
-          content,
           autocorrectable: isRuleAutocorrectable(offense.rule)
         })
 
@@ -141,7 +137,6 @@ async function run() {
         allOffenses.push({
           filename,
           offense,
-          content,
           autocorrectable: isRuleAutocorrectable(offense.rule)
         })
 

--- a/javascript/packages/linter/src/cli/output-manager.ts
+++ b/javascript/packages/linter/src/cli/output-manager.ts
@@ -33,13 +33,13 @@ export class OutputManager {
     const autofixableCount = allOffenses.filter(offense => offense.autocorrectable).length
 
     if (options.useGitHubActions) {
-      const githubFormatter = new GitHubActionsFormatter(options.wrapLines, options.truncateLines)
+      const githubFormatter = new GitHubActionsFormatter(options.wrapLines, options.truncateLines, context?.projectPath)
       await githubFormatter.formatAnnotations(allOffenses)
 
       if (options.formatOption !== "json") {
         const regularFormatter = options.formatOption === "simple"
           ? new SimpleFormatter()
-          : new DetailedFormatter(options.theme, options.wrapLines, options.truncateLines)
+          : new DetailedFormatter(options.theme, options.wrapLines, options.truncateLines, context?.projectPath)
 
         await regularFormatter.format(allOffenses, files.length === 1)
 
@@ -106,7 +106,7 @@ export class OutputManager {
     } else {
       const formatter = options.formatOption === "simple"
         ? new SimpleFormatter()
-        : new DetailedFormatter(options.theme, options.wrapLines, options.truncateLines)
+        : new DetailedFormatter(options.theme, options.wrapLines, options.truncateLines, context?.projectPath)
 
       await formatter.format(allOffenses, files.length === 1)
 

--- a/javascript/packages/linter/src/linter.ts
+++ b/javascript/packages/linter/src/linter.ts
@@ -380,13 +380,13 @@ export class Linter {
    */
   lint(source: string, context?: Partial<LintContext>): LintResult {
     this.offenses = []
+    this.parseCache.clear()
 
     let ignoredCount = 0
     let wouldBeIgnoredCount = 0
 
     const parseResult = this.parseCache.get(source)
 
-    // Check for file-level ignore directive using visitor
     if (hasLinterIgnoreDirective(parseResult)) {
       return {
         offenses: [],
@@ -397,6 +397,7 @@ export class Linter {
         ignored: 0
       }
     }
+
     const lexResult = this.herb.lex(source)
     const hasParserErrors = parseResult.recursiveErrors().length > 0
     const sourceLines = source.split("\n")
@@ -409,6 +410,7 @@ export class Linter {
       if (hasParserRule) {
         const rule = new ParserNoErrorsRule()
         const offenses = rule.check(parseResult)
+
         this.offenses.push(...offenses)
       }
     }
@@ -436,8 +438,6 @@ export class Linter {
       const parserOptions = this.isParserRuleClass(ruleClass) ? (rule as ParserRule).parserOptions : {}
       const parseResult = this.parseCache.get(source, parserOptions)
 
-      // Skip parser rules whose parse result has errors (unless the rule consumes parser errors)
-      // Skip lexer/source rules when the default parse has errors
       if (this.isParserRuleClass(ruleClass)) {
         if (parseResult.recursiveErrors().length > 0 && !ruleClass.consumesParserErrors) continue
       } else if (hasParserErrors) {
@@ -539,6 +539,8 @@ export class Linter {
    * @returns AutofixResult containing the corrected source and lists of fixed/unfixed offenses
    */
   autofix(source: string, context?: Partial<LintContext>, offensesToFix?: LintOffense[], options?: { includeUnsafe?: boolean }): AutofixResult {
+    this.parseCache.clear()
+
     const includeUnsafe = options?.includeUnsafe ?? false
 
     context = {

--- a/javascript/packages/linter/test/file-processor.test.ts
+++ b/javascript/packages/linter/test/file-processor.test.ts
@@ -1,0 +1,21 @@
+import { describe, test, expect, beforeAll } from "vitest"
+import { Herb } from "@herb-tools/node-wasm"
+
+import { FileProcessor } from "../src/cli/file-processor.js"
+
+describe("FileProcessor", () => {
+  beforeAll(async () => {
+    await Herb.load()
+  })
+
+  test("doesn't inline file content into offenses", async () => {
+    const processor = new FileProcessor()
+    const result = await processor.processFiles(["test/fixtures/multiple-rule-offenses.html.erb"], "simple")
+
+    expect(result.allOffenses.length).toBeGreaterThan(0)
+
+    for (const offense of result.allOffenses) {
+      expect(offense.content).toBeUndefined()
+    }
+  })
+})

--- a/javascript/packages/linter/test/formatters/base-formatter.test.ts
+++ b/javascript/packages/linter/test/formatters/base-formatter.test.ts
@@ -1,0 +1,75 @@
+import { describe, test, expect } from "vitest"
+
+import { BaseFormatter } from "../../src/cli/formatters/base-formatter.js"
+
+import type { Diagnostic } from "@herb-tools/core"
+import type { ProcessedFile } from "../../src/cli/file-processor.js"
+
+class TestFormatter extends BaseFormatter {
+  async format(): Promise<void> {}
+  formatFile(): void {}
+
+  read(processedFile: ProcessedFile): string {
+    return this.contentFor(processedFile)
+  }
+}
+
+describe("BaseFormatter", () => {
+  const offense = {} as Diagnostic
+
+  test("reads the file from disk when the offense has no content", () => {
+    const formatter = new TestFormatter()
+
+    const content = formatter.read({
+      filename: "test/fixtures/bad-file.html.erb",
+      offense
+    })
+
+    expect(content).toContain("<SPAN>Bad file</SPAN>")
+  })
+
+  test("resolves filenames against the project path", () => {
+    const formatter = new TestFormatter(`${process.cwd()}/test/fixtures`)
+
+    const content = formatter.read({
+      filename: "bad-file.html.erb",
+      offense
+    })
+
+    expect(content).toContain("<SPAN>Bad file</SPAN>")
+  })
+
+  test("prefers content provided on the offense", () => {
+    const formatter = new TestFormatter()
+
+    const content = formatter.read({
+      filename: "test/fixtures/bad-file.html.erb",
+      offense,
+      content: "<div>provided</div>"
+    })
+
+    expect(content).toBe("<div>provided</div>")
+  })
+
+  test("returns an empty string for unreadable files", () => {
+    const formatter = new TestFormatter()
+
+    const content = formatter.read({
+      filename: "test/fixtures/does-not-exist.html.erb",
+      offense
+    })
+
+    expect(content).toBe("")
+  })
+
+  test("reads each file once when offenses are grouped by file", () => {
+    const formatter = new TestFormatter()
+
+    const first = formatter.read({ filename: "test/fixtures/bad-file.html.erb", offense })
+    const second = formatter.read({ filename: "test/fixtures/bad-file.html.erb", offense })
+    const other = formatter.read({ filename: "test/fixtures/test-file-simple.html.erb", offense })
+
+    expect(second).toBe(first)
+    expect(other).not.toBe(first)
+  })
+})

--- a/javascript/packages/linter/test/parse-cache.test.ts
+++ b/javascript/packages/linter/test/parse-cache.test.ts
@@ -1,6 +1,7 @@
-import { describe, test, expect, beforeAll } from "vitest"
+import { describe, test, expect, beforeAll, vi } from "vitest"
 import { Herb } from "@herb-tools/node-wasm"
 import { ParseCache } from "../src/parse-cache.js"
+import { Linter } from "../src/linter.js"
 import { isWhitespaceNode } from "@herb-tools/core"
 import type { HTMLElementNode } from "@herb-tools/core"
 
@@ -163,5 +164,52 @@ describe("ParseCache", () => {
     expect(div.close_tag).toBeDefined()
     expect(div.close_tag?.childNodes()).toHaveLength(1)
     expect(isWhitespaceNode(div.close_tag?.compactChildNodes()[0])).toBeTruthy()
+  })
+
+  describe("lifetime within a Linter", () => {
+    const first = "<SPAN>first</SPAN>"
+    const second = "<SPAN>second</SPAN>"
+
+    const cacheOf = (linter: Linter) => (linter as any).parseCache as ParseCache
+
+    test("doesn't retain the previous source after another lint()", () => {
+      const linter = new Linter(Herb)
+      const cache = cacheOf(linter)
+
+      linter.lint(first)
+
+      const cachedFirst = cache.get(first)
+
+      linter.lint(second)
+
+      expect(cache.get(first)).not.toBe(cachedFirst)
+    })
+
+    test("doesn't retain the previous source after another autofix()", () => {
+      const linter = new Linter(Herb)
+      const cache = cacheOf(linter)
+
+      linter.autofix(first)
+
+      const cachedFirst = cache.get(first)
+
+      linter.autofix(second)
+
+      expect(cache.get(first)).not.toBe(cachedFirst)
+    })
+
+    test("still reuses parse results across rules within a single lint()", () => {
+      const linter = new Linter(Herb)
+      const parseSpy = vi.spyOn(Herb, "parse")
+
+      try {
+        linter.lint("<div>hello</div>")
+
+        expect(parseSpy.mock.calls.length).toBeGreaterThan(0)
+        expect(parseSpy.mock.calls.length).toBeLessThan(linter.getRuleCount())
+      } finally {
+        parseSpy.mockRestore()
+      }
+    })
   })
 })


### PR DESCRIPTION
This pull request fixes two unbounded memory retentions in the linter that made `herb-lint` abort with `FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory` on larger codebases.

Two separate things kept every linted file alive for the duration of a run:

1. `ParseCache` keys entries by the entire file source and stores the full `ParseResult` as the value. The CLI creates a single `Linter` for the whole run and never cleared the cache between files, so every source string and every AST stayed reachable until the process exited.

2. Every entry in `allOffenses` carried a `content` copy of the file it came from, so the sources of all offending files were retained until output, and copied across the worker thread boundary on top of that.

#### Clearing the parse cache per pass

The cache exists to dedupe parses across rules that request different parser options *within a single pass*. Those entries never need to outlive the pass, so `lint()` and `autofix()` now clear it on entry:

```ts
lint(source: string, context?: Partial<LintContext>): LintResult {
  this.offenses = []
  this.parseCache.clear()

  // ...
}
```

Rules within one pass still share their parse results, so this doesn't cause any extra parsing. Since this lives on `Linter` rather than in the CLI, it also fixes the same slow growth for long-lived Language Server sessions.

#### Reading file content lazily at output time

`ProcessedFile.content` becomes optional and the CLI no longer populates it. `BaseFormatter` gained a `contentFor()` helper that reads the file from disk when it's actually needed for rendering, memoizing only the most recently read file, offenses arrive grouped by file in both the sequential and the worker path:

```ts
protected contentFor(processedFile: ProcessedFile): string {
  if (processedFile.content !== undefined) {
    return processedFile.content
  }

  // ... otherwise read from disk, memoizing the last file
}
```

Keeping the field optional instead of removing it means external `BaseFormatter` subclasses and `stimulus-lint`, which pushes its own offenses with `content` already set, keep working unchanged.

`--fix` output is unaffected: fixed sources are written to disk before formatting runs, so the lazy read observes exactly the content the formatter used to be handed.

Resolves #993