### PR TITLE
Formatter: Keep text flow intact on lines after a block sibling

### DIFF
--- a/javascript/packages/formatter/src/format-printer.ts
+++ b/javascript/packages/formatter/src/format-printer.ts
@@ -590,46 +590,7 @@ export class FormatPrinter extends Printer implements TextFlowDelegate, Attribut
       return
     }
 
-    let lastMeaningfulNode: Node | null = null
-    let hasHandledSpacing = false
-
-    for (let i = 0; i < children.length; i++) {
-      const child = children[i]
-
-      if (shouldPreserveUserSpacing(child, children, i)) {
-        this.push("")
-        hasHandledSpacing = true
-        continue
-      }
-
-      if (isPureWhitespaceNode(child)) {
-        continue
-      }
-
-      if (shouldAppendToLastLine(child, children, i)) {
-        this.appendChildToLastLine(child, children, i)
-        lastMeaningfulNode = child
-        hasHandledSpacing = false
-        continue
-      }
-
-      if (!isNonWhitespaceNode(child)) continue
-
-      const childStartLine = this.stringLineCount
-      this.visit(child)
-
-      if (lastMeaningfulNode && !hasHandledSpacing) {
-        const shouldAddSpacing = this.spacingAnalyzer.shouldAddSpacingBetweenSiblings( null, children, i)
-
-        if (shouldAddSpacing) {
-          this.lines.splice(childStartLine, 0, "")
-          this.stringLineCount++
-        }
-      }
-
-      lastMeaningfulNode = child
-      hasHandledSpacing = false
-    }
+    this.visitElementChildren(children, null)
   }
 
   visitHTMLElementNode(node: HTMLElementNode) {
@@ -828,19 +789,10 @@ export class FormatPrinter extends Printer implements TextFlowDelegate, Attribut
     for (let index = 0; index < body.length; index++) {
       const child = body[index]
 
-      if (isNode(child, HTMLTextNode)) {
-        if (isPureWhitespaceNode(child)) {
-          const hasPreviousNonWhitespace = index > 0 && isNonWhitespaceNode(body[index - 1])
-          const hasNextNonWhitespace = index < body.length - 1 && isNonWhitespaceNode(body[index + 1])
-          const hasMultipleNewlines = child.content.includes('\n\n')
-
-          if (hasPreviousNonWhitespace && hasNextNonWhitespace && hasMultipleNewlines) {
-            this.push("")
-            hasHandledSpacing = true
-          }
-
-          continue
-        }
+      if (shouldPreserveUserSpacing(child, body, index)) {
+        this.push("")
+        hasHandledSpacing = true
+        continue
       }
 
       if (!isNonWhitespaceNode(child)) continue

--- a/javascript/packages/formatter/test/document-formatting.test.ts
+++ b/javascript/packages/formatter/test/document-formatting.test.ts
@@ -966,4 +966,67 @@ describe("Document-level formatting", () => {
       </pre>
     `)
   })
+
+  describe("text-flow run on a line after a block sibling", () => {
+    test("keeps an inline element glued to text after a block element", () => {
+      expectFormattedToMatch(dedent`
+        <div>x</div>
+        y and<span>z</span>
+      `)
+    })
+
+    test("keeps an inline element glued inside punctuation after a block element", () => {
+      expectFormattedToMatch(dedent`
+        <div>x</div>
+        y (<span>z</span>) done
+      `)
+    })
+
+    test("keeps an inline element glued after a control-flow block sibling", () => {
+      expectFormattedToMatch(dedent`
+        <% if @a %>
+          <div>x</div>
+        <% end %>
+        y and<span>z</span>
+      `)
+    })
+
+    test("keeps a short line with a trailing word intact", () => {
+      expectFormattedToMatch(dedent`
+        <div>x</div>
+        y and <%= @z %> tail
+      `)
+    })
+
+    test("keeps a short line with multiple output tags intact", () => {
+      expectFormattedToMatch(dedent`
+        <div>x</div>
+        y and <%= @z %> plus <%= @w %>
+      `)
+    })
+
+    test("keeps a line starting with an output tag intact", () => {
+      expectFormattedToMatch(dedent`
+        <div>x</div>
+        <%= @z %> trailing text
+      `)
+    })
+
+    test("keeps a blank line between the block element and the run", () => {
+      expectFormattedToMatch(dedent`
+        <div>x</div>
+
+        y and <%= @z %> tail
+      `)
+    })
+
+    test("lays out runs between block siblings independently", () => {
+      expectFormattedToMatch(dedent`
+        <div>x</div>
+        y and<span>z</span>
+        <div>w</div>
+        a<% if @b %>c<% end %>d
+      `)
+    })
+  })
 })

--- a/javascript/packages/formatter/test/erb/whitespace-preservation.test.ts
+++ b/javascript/packages/formatter/test/erb/whitespace-preservation.test.ts
@@ -443,4 +443,36 @@ describe("whitespace preservation around ERB control flow", () => {
       expectFormattedToMatch(`y and <%= @z %>`)
     })
   })
+
+  describe("glued control flow on a line after a non-text-flow sibling", () => {
+    test("keeps an if glued on both sides after a block element", () => {
+      expectFormattedToMatch(dedent`
+        <div>x</div>
+        a<% if @b %>c<% end %>d
+      `)
+    })
+
+    test("keeps an unless glued on both sides after a block element", () => {
+      expectFormattedToMatch(dedent`
+        <div>x</div>
+        a<% unless @b %>c<% end %>d
+      `)
+    })
+
+    test("keeps glued punctuation after a block element", () => {
+      expectFormattedToMatch(dedent`
+        <div>x</div>
+        Hello<% if owner %> <%= owner.name %><% end %>!
+      `)
+    })
+
+    test("keeps an if glued after a control-flow block sibling", () => {
+      expectFormattedToMatch(dedent`
+        <% if @a %>
+          <div>x</div>
+        <% end %>
+        a<% if @b %>c<% end %>d
+      `)
+    })
+  })
 })

--- a/javascript/packages/formatter/test/html/attribute-erb-spacing.test.ts
+++ b/javascript/packages/formatter/test/html/attribute-erb-spacing.test.ts
@@ -282,11 +282,19 @@ describe("Attribute ERB Spacing", () => {
     })
 
     test("keeps the ERB when the element is followed by a block element", () => {
-      expectFormattedToMatch(dedent`
+      const source = dedent`
         <strong <%= call(:me) %>>0</strong>
         / 2048 character limit
         <div></div>
-      `)
+      `
+
+      const expected = dedent`
+        <strong <%= call(:me) %>>0</strong> / 2048 character limit
+        <div></div>
+      `
+
+      expect(formatter.format(source)).toEqual(expected)
+      expectFormattedToMatch(expected)
     })
 
     test("keeps the ERB when the element is nested in a block element", () => {


### PR DESCRIPTION
This pull request fixes the formatter breaking a line of mixed text, ERB, and inline elements into one node per line when that line follows a sibling that is not part of the same text flow, such as an HTML block element or an ERB control-flow block.

Two of the three shapes below change what the template renders, the third only makes the output worse to read.

#### Glued control flow is exploded into block layout

**Before**

```html+erb
<div>x</div>
a<% if @b %>c<% end %>d
```

was formatted to

```html+erb
<div>x</div>
a
<% if @b %>
  c
<% end %>d
```

The `<% %>` tags emit no characters of their own, so they cannot keep `a`, `c`, and `d` apart. The newlines placed around them land between the visible characters instead, and `acd` renders as `a c d`. The same happened with `unless`, and with glued trailing punctuation:

```html+erb
<div>x</div>
Hello<% if owner %> <%= owner.name %><% end %>!
```

which rendered `Hello!` before formatting and `Hello !` after.

#### A glued inline element gains a newline

**Before**

```html+erb
<div>x</div>
y and<span>z</span>
```

was formatted to

```html+erb
<div>x</div>
y and
<span>z</span>
```

turning `andz` into `and z`. `y (<span>z</span>) done` broke after the `(` for the same reason.

#### Short lines are split for no reason

**Before**

```html+erb
<div>x</div>
y and <%= @z %> tail
```

was formatted to

```html+erb
<div>x</div>
y and <%= @z %>
tail
```

with `y and <%= @z %> plus <%= @w %>` and `<%= @z %> trailing text` splitting the same way. This one does not change the rendered output.

**After** this change, every input above is left exactly as written.

#### Why only after a block sibling

Each of these lines already formatted correctly on its own, and correctly inside a block element, so the same content wrapped in a `<section>` was never affected. Only the document root got it wrong, and only once a block sibling appeared ahead of the line.

`visitDocumentNode` walked the document's children with its own copy of the loop in `visitElementChildren`, and that copy never called `visitTextFlowRunInChildren`. Collecting a run of adjacent text-flow nodes and handing it to the `TextFlowEngine` is what keeps glued content on one line, including the glued control-flow handling added in #1729. Without it the document root fell through to `shouldAppendToLastLine`, which rescues only the *first* node following the text. Everything after that was visited as a standalone child and got a line of its own, which is why the failure always started one node late.

`visitDocumentNode` now delegates to `visitElementChildren` so the document root and element bodies share a single implementation. The removed loop was otherwise identical to the one it duplicated, since `isNonWhitespaceNode` is defined as `!isPureWhitespaceNode` and the blank-line and sibling-spacing logic matched line for line. The one place the two copies had drifted, an inlined blank-line check in `visitElementChildren`, now calls the existing `shouldPreserveUserSpacing` helper that the document loop was already using, so that logic lives in one place.

#### Test expectation change

One existing expectation from #1771 in `attribute-erb-spacing.test.ts` changed:

```html+erb
<strong <%= call(:me) %>>0</strong>
/ 2048 character limit
<div></div>
```

now fills onto a single line as `<strong <%= call(:me) %>>0</strong> / 2048 character limit`. That layout only survived because the document root skipped text flow. The identical content inside a block element already merged those two lines before this change, so the previous expectation was documenting the bug rather than the intended behaviour. The test's actual subject, the ERB surviving in attribute position, is unaffected, and it now asserts the merged output and that the result is a fixed point.

New regression tests cover all three shapes after both an HTML element and an ERB control-flow block, plus a preserved blank line between the block and the run, and several runs interleaved between block siblings. Each is asserted as its own fixed point, so a second formatting pass is covered too.

Related https://github.com/marcoroth/herb/issues/1729
Related https://github.com/marcoroth/herb/issues/1922
Related https://github.com/marcoroth/herb/issues/1721
Related https://github.com/marcoroth/herb/issues/1883
Related https://github.com/marcoroth/herb/issues/469
