### PR TITLE
Formatter: Improve ERB multiline comment formatting

### DIFF
--- a/javascript/packages/formatter/src/format-helpers.ts
+++ b/javascript/packages/formatter/src/format-helpers.ts
@@ -1,4 +1,4 @@
-import { isNode, isERBNode, getTagName, isAnyOf, isERBControlFlowNode, hasERBOutput, getStaticAttributeValue, getTokenList, isPureWhitespaceNode } from "@herb-tools/core"
+import { isNode, isERBNode, isERBCommentNode, getTagName, isAnyOf, isERBControlFlowNode, hasERBOutput, getStaticAttributeValue, getTokenList, isPureWhitespaceNode } from "@herb-tools/core"
 import { Node, HTMLDoctypeNode, HTMLTextNode, HTMLElementNode, HTMLCommentNode, HTMLOpenTagNode, HTMLCloseTagNode, ERBIfNode, ERBContentNode, WhitespaceNode } from "@herb-tools/core"
 
 // --- Types ---
@@ -234,6 +234,15 @@ export function isAdjacentToPreviousInline(siblings: Node[], index: number): boo
 }
 
 /**
+ * Check if a node is an ERB comment whose content spans multiple lines.
+ * Multiline ERB comments keep their block layout (like multiline HTML comments)
+ * and must never be rendered inline.
+ */
+export function isMultilineERBComment(node: Node): boolean {
+  return isNode(node, ERBContentNode) && isERBCommentNode(node) && (node.content?.value ?? "").includes("\n")
+}
+
+/**
  * Check if a node should be appended to the last line (for adjacent inline elements and punctuation)
  */
 export function shouldAppendToLastLine(child: Node, siblings: Node[], index: number): boolean {
@@ -250,6 +259,8 @@ export function shouldAppendToLastLine(child: Node, siblings: Node[], index: num
   }
 
   if (isNode(child, ERBContentNode)) {
+    if (isMultilineERBComment(child)) return false
+
     for (let i = index - 1; i >= 0; i--) {
       const previousSibling = siblings[i]
 

--- a/javascript/packages/formatter/src/format-helpers.ts
+++ b/javascript/packages/formatter/src/format-helpers.ts
@@ -234,12 +234,10 @@ export function isAdjacentToPreviousInline(siblings: Node[], index: number): boo
 }
 
 /**
- * Check if a node is an ERB comment whose content spans multiple lines.
- * Multiline ERB comments keep their block layout (like multiline HTML comments)
- * and must never be rendered inline.
+ * Check if a node is an ERB comment that renders as a block.
  */
 export function isMultilineERBComment(node: Node): boolean {
-  return isNode(node, ERBContentNode) && isERBCommentNode(node) && (node.content?.value ?? "").includes("\n")
+  return isNode(node, ERBContentNode) && isERBCommentNode(node) && (node.content?.value ?? "").trim().includes("\n")
 }
 
 /**

--- a/javascript/packages/formatter/src/format-printer.ts
+++ b/javascript/packages/formatter/src/format-printer.ts
@@ -46,6 +46,7 @@ import {
   endsWithWhitespace,
   isFrontmatter,
   isInlineElement,
+  isMultilineERBComment,
   setEdgeWhitespace,
   startsWithWhitespace,
   isNonWhitespaceNode,
@@ -998,6 +999,11 @@ export class FormatPrinter extends Printer implements TextFlowDelegate, Attribut
       } else {
         this.pushWithIndent(result.text)
       }
+    } else if (this.inlineMode) {
+      const childIndent = " ".repeat(this.indentWidth)
+      const contentLines = result.contentLines.map(line => line.trim() === "" ? "" : childIndent + line)
+
+      this.push([result.header, ...contentLines, result.footer].join("\n"))
     } else {
       this.pushWithIndent(result.header)
 
@@ -1708,6 +1714,10 @@ export class FormatPrinter extends Printer implements TextFlowDelegate, Attribut
     const trailingWhitespaceIsRendered = edge.after
 
     for (const child of children) {
+      if (isMultilineERBComment(child)) {
+        return null
+      }
+
       if (isNode(child, HTMLTextNode)) {
         const normalizedContent = child.content.replace(ASCII_WHITESPACE, ' ')
         const hasLeadingSpace = startsWithWhitespace(child.content)
@@ -1781,7 +1791,9 @@ export class FormatPrinter extends Printer implements TextFlowDelegate, Attribut
           return null
         }
       } else if (isNode(child, ERBContentNode)) {
-        // ERB content nodes are allowed in inline rendering
+        if (isMultilineERBComment(child)) {
+          return null
+        }
       } else {
         return null
       }

--- a/javascript/packages/formatter/src/text-flow-analyzer.ts
+++ b/javascript/packages/formatter/src/text-flow-analyzer.ts
@@ -7,6 +7,7 @@ import {
   hasWhitespaceBetween,
   isInlineElement,
   isLineBreakingElement,
+  isMultilineERBComment,
 } from "./format-helpers.js"
 
 import {
@@ -90,6 +91,13 @@ export class TextFlowAnalyzer {
             node: child
           })
         }
+
+        lastProcessedIndex = i
+      } else if (isMultilineERBComment(child)) {
+        result.push({
+          unit: { content: '', type: 'block', isAtomic: false, breaksFlow: true },
+          node: child
+        })
 
         lastProcessedIndex = i
       } else if (isNode(child, ERBContentNode)) {

--- a/javascript/packages/formatter/src/text-flow-engine.ts
+++ b/javascript/packages/formatter/src/text-flow-engine.ts
@@ -10,6 +10,7 @@ import {
   isClosingPunctuation,
   isInlineElement,
   isLineBreakingElement,
+  isMultilineERBComment,
   needsSpaceBetween,
 } from "./format-helpers.js"
 
@@ -102,7 +103,7 @@ export class TextFlowEngine {
           this.delegate.pushWithIndent(inlineContent)
           inlineContent = ""
         }
-      } else if (isNode(child, ERBContentNode)) {
+      } else if (isNode(child, ERBContentNode) && !isMultilineERBComment(child)) {
         inlineContent += this.delegate.renderERBAsString(child)
         processedCount++
         lastProcessedIndex = index
@@ -122,7 +123,7 @@ export class TextFlowEngine {
           break
         }
 
-        if (isNode(child, ERBContentNode)) {
+        if (isNode(child, ERBContentNode) && !isMultilineERBComment(child)) {
           inlineContent += this.delegate.renderERBAsString(child)
           processedIndices.add(index)
           lastProcessedIndex = index

--- a/javascript/packages/formatter/src/text-flow-helpers.ts
+++ b/javascript/packages/formatter/src/text-flow-helpers.ts
@@ -7,6 +7,7 @@ import {
   endsWithWhitespace,
   hasWhitespaceBetween,
   isInlineElement,
+  isMultilineERBComment,
   normalizeAndSplitWords,
   startsWithWhitespace,
 } from "./format-helpers.js"
@@ -20,7 +21,7 @@ import {
  * keeps the existing block layout for free-standing control flow.
  */
 export function isTextFlowNode(node: Node, children?: Node[], index?: number): boolean {
-  if (isNode(node, ERBContentNode)) return true
+  if (isNode(node, ERBContentNode)) return !isMultilineERBComment(node)
   if (isNode(node, HTMLTextNode) && node.content.trim() !== "") return true
   if (isNode(node, HTMLElementNode) && isInlineElement(getTagName(node))) return true
 

--- a/javascript/packages/formatter/test/erb/comment.test.ts
+++ b/javascript/packages/formatter/test/erb/comment.test.ts
@@ -357,4 +357,73 @@ describe("@herb-tools/formatter", () => {
       </div>
     `)
   })
+
+  test("keeps block layout for multi-line ERB comment after a preceding sibling in a single pass", () => {
+    const source = dedent`
+      <div>x</div>
+      y and <%# multi
+      line
+      comment %>
+    `
+
+    const result = formatter.format(source)
+
+    expect(result).toEqual(dedent`
+      <div>x</div>
+      y and
+      <%#
+        multi
+        line
+        comment
+      %>
+    `)
+
+    expectFormattedToMatch(result, { passes: 2 })
+  })
+
+  test("keeps block layout for multi-line ERB comment in text flow in a single pass", () => {
+    const source = dedent`
+      hello <%# multi
+      line
+      comment %> world
+    `
+
+    const result = formatter.format(source)
+
+    expect(result).toEqual(dedent`
+      hello
+      <%#
+        multi
+        line
+        comment
+      %>
+      world
+    `)
+
+    expectFormattedToMatch(result, { passes: 2 })
+  })
+
+  test("keeps block layout for multi-line ERB comment inside an element in a single pass", () => {
+    const source = dedent`
+      <p>hello <%# multi
+      line
+      comment %> world</p>
+    `
+
+    const result = formatter.format(source)
+
+    expect(result).toEqual(dedent`
+      <p>
+        hello
+        <%#
+          multi
+          line
+          comment
+        %>
+        world
+      </p>
+    `)
+
+    expectFormattedToMatch(result, { passes: 2 })
+  })
 })

--- a/javascript/packages/formatter/test/erb/comment.test.ts
+++ b/javascript/packages/formatter/test/erb/comment.test.ts
@@ -426,4 +426,157 @@ describe("@herb-tools/formatter", () => {
 
     expectFormattedToMatch(result, { passes: 2 })
   })
+
+  describe("preserves deliberately formatted ERB comments", () => {
+    test("single-line comment on its own line", () => {
+      expectFormattedToMatch(dedent`
+        <%# a standalone comment %>
+      `, { passes: 2 })
+    })
+
+    test("single-line comment indented inside an element", () => {
+      expectFormattedToMatch(dedent`
+        <div>
+          <%# a comment inside a div %>
+          <span>content</span>
+        </div>
+      `, { passes: 2 })
+    })
+
+    test("single-line comment surrounded by text", () => {
+      expectFormattedToMatch(dedent`
+        hello <%# note %> world
+      `, { passes: 2 })
+    })
+
+    test("single-line comment inside an inline element", () => {
+      expectFormattedToMatch(dedent`
+        <p>hello <%# note %> world</p>
+      `, { passes: 2 })
+    })
+
+    test("single-line comment after a preceding sibling", () => {
+      expectFormattedToMatch(dedent`
+        <div>x</div>
+        y and <%# note %>
+      `, { passes: 2 })
+    })
+
+    test("single-line comment separated by blank lines", () => {
+      expectFormattedToMatch(dedent`
+        <div>a</div>
+
+        <%# section divider %>
+
+        <div>b</div>
+      `, { passes: 2 })
+    })
+
+    test("multi-line comment on its own lines", () => {
+      expectFormattedToMatch(dedent`
+        <%#
+          hello
+          this is a
+          multi-line ERB
+          comment
+        %>
+      `, { passes: 2 })
+    })
+
+    test("multi-line comment indented inside an element", () => {
+      expectFormattedToMatch(dedent`
+        <div>
+          <%#
+            hello
+            world
+          %>
+          <span>content</span>
+        </div>
+      `, { passes: 2 })
+    })
+
+    test("multi-line comment indented inside nested elements", () => {
+      expectFormattedToMatch(dedent`
+        <div>
+          <section>
+            <%#
+              hello
+              world
+            %>
+          </section>
+        </div>
+      `, { passes: 2 })
+    })
+
+    test("multi-line comment after a preceding sibling", () => {
+      expectFormattedToMatch(dedent`
+        <div>x</div>
+        y and
+        <%#
+          multi
+          line
+        %>
+      `, { passes: 2 })
+    })
+
+    test("multi-line comment between text", () => {
+      expectFormattedToMatch(dedent`
+        hello
+        <%#
+          multi
+          line
+        %>
+        world
+      `, { passes: 2 })
+    })
+
+    test("multi-line comment inside an inline element", () => {
+      expectFormattedToMatch(dedent`
+        <p>
+          hello
+          <%#
+            multi
+            line
+          %>
+          world
+        </p>
+      `, { passes: 2 })
+    })
+
+    test("multi-line comment with relative indentation in its content", () => {
+      expectFormattedToMatch(dedent`
+        <%#
+          Options:
+            - first
+            - second
+        %>
+      `, { passes: 2 })
+    })
+
+    test("multi-line comment with a blank line in its content", () => {
+      expectFormattedToMatch(dedent`
+        <%#
+          first paragraph
+
+          second paragraph
+        %>
+      `, { passes: 2 })
+    })
+
+    test("multi-line comment wrapping a single line of content collapses and stays in the text flow", () => {
+      const source = dedent`
+        hello <%#
+          note
+        %> world
+      `
+
+      const result = formatter.format(source)
+
+      expect(result).toEqual(dedent`
+        hello <%# note %> world
+      `)
+
+      expectFormattedToMatch(result, { passes: 2 })
+    })
+  })
 })


### PR DESCRIPTION
This pull request updates the formatter to keep multi-line ERB comments in their block layout, so they are never squashed onto a single line when they happen to sit next to other content.

Previously, a multi-line ERB comment was treated as an inline node whenever it followed a sibling on the same line, participated in a text flow run, or lived inside an inline element. 

```erb
<div>x</div>
y and <%# multi
line
comment %>
```

**Before**, the first pass mangled the comment, and because the result is now a single-line comment, the second pass took the single-line branch and added the missing space back, so `format(format(x)) !== format(x)`:

```erb
<div>x</div>
y and <%#  multi  line  comment%>
```

```erb
<div>x</div>
y and <%#  multi  line  comment %>
```

**After**, the comment keeps its lines and the output is stable on the first pass:

```erb
<div>x</div>
y and
<%#
  multi
  line
  comment
%>
```

Discovered while verifying #1923.