### PR TITLE
JavaScript: Add missing `actions/checkout` for trusted publishing

### DIFF
--- a/.github/workflows/javascript.yml
+++ b/.github/workflows/javascript.yml
@@ -96,6 +96,7 @@ jobs:
         with:
           name: npm-packages
           path: javascript/packages/*/
+          include-hidden-files: true
           if-no-files-found: error
           retention-days: 1
 
@@ -129,6 +130,8 @@ jobs:
       id-token: write
 
     steps:
+      - uses: actions/checkout@v7
+
       - uses: actions/setup-node@v7
         with:
           node-version-file: ".node-version"
@@ -139,21 +142,41 @@ jobs:
           name: npm-packages
           path: javascript/packages/
 
-      - name: Publish packages with provenance
+      - name: Publish packages
         run: |
+          failed=()
+
           for package_dir in javascript/packages/*; do
-            if [ -d "$package_dir" ] && [ -f "$package_dir/package.json" ]; then
-              package=$(basename "$package_dir")
+            [ -f "$package_dir/package.json" ] || continue
 
-              if [ "$package" = "vscode" ]; then
-                echo "Skipping vscode package..."
-                continue
-              fi
+            name=$(jq -r '.name' "$package_dir/package.json")
+            version=$(jq -r '.version' "$package_dir/package.json")
 
-              echo "Publishing $package..."
-              (cd "$package_dir" && npm publish --provenance --access public --ignore-scripts)
+            if [ "$(jq -r '.private // false' "$package_dir/package.json")" = "true" ]; then
+              echo "Skipping $name (private)"
+              continue
             fi
+
+            if npm view "$name@$version" version > /dev/null 2>&1; then
+              echo "Skipping $name@$version (already published)"
+              continue
+            fi
+
+            echo "::group::Publishing $name@$version"
+
+            if (cd "$package_dir" && npm publish --access public --ignore-scripts); then
+              echo "Published $name@$version"
+            else
+              failed+=("$name@$version")
+            fi
+
+            echo "::endgroup::"
           done
+
+          if [ ${#failed[@]} -gt 0 ]; then
+            echo "::error::Failed to publish: ${failed[*]}"
+            exit 1
+          fi
 
   preview-check:
     if: |
@@ -215,6 +238,8 @@ jobs:
     permissions:
       contents: read
     steps:
+      - uses: actions/checkout@v7
+
       - uses: actions/setup-node@v7
         with:
           node-version-file: ".node-version"


### PR DESCRIPTION
Publishing to npm has never succeeded from CI. The most recent attempt ([run 29217508323](https://github.com/marcoroth/herb/actions/runs/29217508323), for `v0.10.2`) failed after two seconds, and it wasn't trusted publishing that broke:

```
##[error]The specified node version file at: /home/runner/work/herb/herb/.node-version does not exist
```

Both `publish` and `publish-vscode` use `node-version-file: ".node-version"`, but neither job ever checked out the repository, so `setup-node` had nothing to read. `f761465` added the missing `actions/checkout` step to `preview`, but the other two jobs were left as they were.

This means trusted publishing has never actually been reached. `9ed7acd` and everything since it have been untestable, and `0.10.2` on the registry was published by hand.


Related #1647