### PR TITLE
VS Code: Lock `@types/vscode` to `^1.100.0`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "tailwindcss"
+      - dependency-name: "@types/vscode"
 
   - package-ecosystem: "npm"
     directories:

--- a/javascript/packages/vscode/package.json
+++ b/javascript/packages/vscode/package.json
@@ -290,7 +290,7 @@
     "@herb-tools/node-wasm": "0.10.3",
     "@types/mocha": "^10.0.10",
     "@types/node": "26.x",
-    "@types/vscode": "^1.125.0",
+    "@types/vscode": "^1.100.0",
     "@vscode/test-cli": "^0.0.15",
     "@vscode/test-electron": "^3.0.0",
     "@vscode/vsce": "^3.9.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2323,7 +2323,7 @@
     "@types/expect" "^1.20.4"
     "@types/node" "*"
 
-"@types/vscode@^1.125.0":
+"@types/vscode@^1.100.0":
   version "1.125.0"
   resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.125.0.tgz#944755fe16fcaf15060899bf214556c7549e4cd6"
   integrity sha512-0icm/ZQAaism87P0ekHqi4/Ju9du+Tm0RUW+y7vqRsxY2cY0FNRX1nAnaW7nT6npPt2tfHiheZ55Zm9UhqonFA==


### PR DESCRIPTION
Publishing the extension for `v0.10.3` failed because `vsce` refuses to package a manifest whose `@types/vscode` range is newer than `engines.vscode`:

```
ERROR  @types/vscode ^1.125.0 greater than engines.vscode ^1.100.0.
       Either upgrade engines.vscode or use an older @types/vscode version
```

Follow up on #1932