### PR TITLE
Linter: Fix `html-no-duplicate-ids` for interpolated helper IDs

### DIFF
--- a/javascript/packages/core/src/ast-utils.ts
+++ b/javascript/packages/core/src/ast-utils.ts
@@ -35,6 +35,7 @@ import {
   isWhitespaceNode,
   isHTMLAttributeNameNode,
   isHTMLAttributeValueNode,
+  isRubyLiteralNode,
   areAllOfType,
   filterLiteralNodes,
   filterHTMLTextNodes,
@@ -115,6 +116,24 @@ export function hasERBContent(nodes: Node[]): boolean {
  */
 export function hasERBOutput(nodes: Node[]): boolean {
   return nodes.some(isERBOutputNode)
+}
+
+/**
+ * Checks if a node outputs a dynamic value
+ *
+ * Covers both ERB output (`<%= %>`) and the Ruby expressions that Action View
+ * helper attribute values are made of, where `id: "#{user.name}-pending"`
+ * becomes a `RubyLiteralNode` next to a `LiteralNode` instead of an ERB node.
+ */
+export function isDynamicOutputNode(node: Node): boolean {
+  return isERBOutputNode(node) || isRubyLiteralNode(node)
+}
+
+/**
+ * Checks if an array of nodes contains any dynamic output nodes
+ */
+export function hasDynamicOutput(nodes: Node[]): boolean {
+  return nodes.some(isDynamicOutputNode)
 }
 
 

--- a/javascript/packages/core/test/ast-utils.test.ts
+++ b/javascript/packages/core/test/ast-utils.test.ts
@@ -7,6 +7,8 @@ import {
   isERBControlFlowNode,
   hasERBContent,
   hasERBOutput,
+  isDynamicOutputNode,
+  hasDynamicOutput,
   filterERBContentNodes,
   getStaticStringFromNodes,
   getStaticContentFromNodes,
@@ -22,7 +24,7 @@ import {
   HTMLAttributeNameNode
 } from "../src"
 
-import type { Node, LiteralNode, ERBContentNode } from "../src/nodes.js"
+import type { Node, LiteralNode, ERBContentNode, RubyLiteralNode } from "../src/nodes.js"
 
 describe("ast-utils", () => {
   const createLiteralNode = (content: string): LiteralNode => ({
@@ -36,6 +38,12 @@ describe("ast-utils", () => {
     tag_opening: { type: "AST_TOKEN", value: tagOpening, location: Location.from(1, 1, 1, 1) },
     content: content ? { type: "AST_TOKEN", value: content, location: Location.from(1, 1, 1, 1) } : undefined,
     tag_closing: { type: "AST_TOKEN", value: tagClosing, location: Location.from(1, 1, 1, 1) },
+    location: Location.from(1, 1, 1, 1)
+  })
+
+  const createRubyLiteralNode = (content: string): RubyLiteralNode => ({
+    type: "AST_RUBY_LITERAL_NODE",
+    content,
     location: Location.from(1, 1, 1, 1)
   })
 
@@ -178,6 +186,60 @@ describe("ast-utils", () => {
       const nodes = [createLiteralNode("hello"), createLiteralNode(" world")]
 
       expect(hasERBOutput(nodes)).toBe(false)
+    })
+
+    test("returns false for Ruby literals from Action View helper attributes", () => {
+      const nodes = [createRubyLiteralNode("user.name"), createLiteralNode("-pending")]
+
+      expect(hasERBOutput(nodes)).toBe(false)
+    })
+  })
+
+  describe("isDynamicOutputNode", () => {
+    test("returns true for output ERB nodes", () => {
+      expect(isDynamicOutputNode(createERBContentNode("<%=", "name"))).toBe(true)
+    })
+
+    test("returns true for Ruby literal nodes", () => {
+      expect(isDynamicOutputNode(createRubyLiteralNode("user.name"))).toBe(true)
+    })
+
+    test("returns false for control ERB nodes", () => {
+      expect(isDynamicOutputNode(createERBContentNode("<%", "if condition"))).toBe(false)
+    })
+
+    test("returns false for literal nodes", () => {
+      expect(isDynamicOutputNode(createLiteralNode("hello"))).toBe(false)
+    })
+  })
+
+  describe("hasDynamicOutput", () => {
+    test("returns true when array contains output ERB nodes", () => {
+      const nodes = [createLiteralNode("hello"), createERBContentNode("<%=", "name")]
+
+      expect(hasDynamicOutput(nodes)).toBe(true)
+    })
+
+    test("returns true when array contains Ruby literal nodes", () => {
+      const nodes = [createRubyLiteralNode("user.name"), createLiteralNode("-pending")]
+
+      expect(hasDynamicOutput(nodes)).toBe(true)
+    })
+
+    test("returns false when array contains only control ERB", () => {
+      const nodes = [createLiteralNode("hello"), createERBContentNode("<%", "if condition")]
+
+      expect(hasDynamicOutput(nodes)).toBe(false)
+    })
+
+    test("returns false when array contains only literals", () => {
+      const nodes = [createLiteralNode("hello"), createLiteralNode(" world")]
+
+      expect(hasDynamicOutput(nodes)).toBe(false)
+    })
+
+    test("returns false for empty array", () => {
+      expect(hasDynamicOutput([])).toBe(false)
     })
   })
 

--- a/javascript/packages/linter/docs/rules/html-no-duplicate-ids.md
+++ b/javascript/packages/linter/docs/rules/html-no-duplicate-ids.md
@@ -65,6 +65,18 @@ The same dynamic expression repeated within the same scope (same document level,
 
 Hints do not fail a lint run unless you opt in with `failLevel: hint` (or `--fail-level hint`), which is how you enforce potential duplicates in CI when you know your IDs are deterministic.
 
+Ruby interpolation inside an Action View helper attribute counts as dynamic in exactly the same way, so these two IDs are compared as `#{event["name"]}-pending` and `#{talk["title"]}-pending` rather than as the shared literal `-pending`:
+
+```erb
+<%= link_to event["url"], id: "#{event["name"]}-pending" do %>
+  <%= event["name"] %>
+<% end %>
+
+<%= link_to talk["url"], id: "#{talk["title"]}-pending" do %>
+  <%= talk["title"] %>
+<% end %>
+```
+
 ## `<template>` elements
 
 A `<template>` is an inert document fragment — its contents only enter the document once the template is cloned/inflated. Each `<template>` body therefore gets its **own ID context**: IDs inside it don't compete with IDs elsewhere in the document, or with IDs in other templates.

--- a/javascript/packages/linter/src/rules/html-no-duplicate-ids.ts
+++ b/javascript/packages/linter/src/rules/html-no-duplicate-ids.ts
@@ -1,11 +1,10 @@
 import { ParserRule, BaseAutofixContext } from "../types"
 import { ControlFlowTrackingVisitor, ControlFlowType } from "./rule-utils"
-import { LiteralNode } from "@herb-tools/core"
 import { Printer, IdentityPrinter } from "@herb-tools/printer"
 
-import { hasERBOutput, getValidatableStaticContent, isEffectivelyStatic, isNode, getStaticAttributeName, isERBOutputNode, getTagLocalName } from "@herb-tools/core"
+import { hasDynamicOutput, getValidatableStaticContent, getStaticAttributeName, isERBOutputNode, getTagLocalName } from "@herb-tools/core"
 
-import type { ParseResult, HTMLAttributeNode, HTMLElementNode, ERBContentNode, ParserOptions } from "@herb-tools/core"
+import type { ParseResult, HTMLAttributeNode, HTMLElementNode, LiteralNode, ERBContentNode, RubyLiteralNode, ParserOptions } from "@herb-tools/core"
 import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types"
 
 interface ControlFlowState {
@@ -26,6 +25,10 @@ class OutputPrinter extends Printer {
     if (isERBOutputNode(node)) {
       this.write(IdentityPrinter.print(node))
     }
+  }
+
+  visitRubyLiteralNode(node: RubyLiteralNode) {
+    this.write(`#{${IdentityPrinter.print(node)}}`)
   }
 }
 
@@ -127,13 +130,13 @@ class NoDuplicateIdsVisitor extends ControlFlowTrackingVisitor<BaseAutofixContex
 
   private extractIdValue(attributeNode: HTMLAttributeNode): { identifier: string; shouldTrackDuplicates: boolean; isDynamic: boolean } | null {
     const valueNodes = attributeNode.value?.children || []
-    const isDynamic = hasERBOutput(valueNodes)
+    const isDynamic = hasDynamicOutput(valueNodes)
 
     if (isDynamic && this.isInControlFlow && this.currentControlFlowType === ControlFlowType.LOOP) {
       return null
     }
 
-    const identifier = isEffectivelyStatic(valueNodes) ? getValidatableStaticContent(valueNodes) : OutputPrinter.print(valueNodes)
+    const identifier = isDynamic ? OutputPrinter.print(valueNodes) : getValidatableStaticContent(valueNodes)
     if (!identifier) return null
 
     return { identifier, shouldTrackDuplicates: true, isDynamic }
@@ -157,7 +160,7 @@ class NoDuplicateIdsVisitor extends ControlFlowTrackingVisitor<BaseAutofixContex
 
   private handleControlFlowId(identifier: string, attributeNode: HTMLAttributeNode, isDynamic: boolean): void {
     if (this.currentControlFlowType === ControlFlowType.LOOP) {
-      this.handleLoopId(identifier, attributeNode)
+      this.handleLoopId(identifier, attributeNode, isDynamic)
     } else {
       this.handleConditionalId(identifier, attributeNode, isDynamic)
     }
@@ -165,10 +168,8 @@ class NoDuplicateIdsVisitor extends ControlFlowTrackingVisitor<BaseAutofixContex
     this.currentBranchIds.add(identifier)
   }
 
-  private handleLoopId(identifier: string, attributeNode: HTMLAttributeNode): void {
-    const isStaticId = this.isStaticId(attributeNode)
-
-    if (isStaticId) {
+  private handleLoopId(identifier: string, attributeNode: HTMLAttributeNode, isDynamic: boolean): void {
+    if (!isDynamic) {
       this.addDuplicateIdOffense(identifier, attributeNode.location)
       return
     }
@@ -205,14 +206,6 @@ class NoDuplicateIdsVisitor extends ControlFlowTrackingVisitor<BaseAutofixContex
     }
 
     this.documentIds.add(identifier)
-  }
-
-  private isStaticId(attributeNode: HTMLAttributeNode): boolean {
-    const valueNodes = attributeNode.value!.children
-    const isCompletelyStatic = valueNodes.every(child => isNode(child, LiteralNode))
-    const isEffectivelyStaticValue = isEffectivelyStatic(valueNodes)
-
-    return isCompletelyStatic || isEffectivelyStaticValue
   }
 
   private addDuplicateIdOffense(identifier: string, location: any): void {

--- a/javascript/packages/linter/test/rules/html-no-duplicate-ids.test.ts
+++ b/javascript/packages/linter/test/rules/html-no-duplicate-ids.test.ts
@@ -587,6 +587,94 @@ describe("html-no-duplicate-ids", () => {
     `)
   })
 
+  describe("Ruby interpolation in Action View helper attributes", () => {
+    test("passes for interpolated helper IDs that only share a static suffix", () => {
+      expectNoOffenses(dedent`
+        <%= link_to event["url"], id: "#{event["name"]}-pending" do %>
+          <div></div>
+        <% end %>
+
+        <%= link_to talk["url"], id: "#{talk["title"]}-pending" do %>
+          <div></div>
+        <% end %>
+      `)
+    })
+
+    test("hints for the same interpolated helper ID across two helpers", () => {
+      expectHint('Potential duplicate ID `#{event["name"]}-pending` found. If this expression evaluates to the same value, IDs must be unique within a document.')
+
+      assertOffenses(dedent`
+        <%= link_to event["url"], id: "#{event["name"]}-pending" do %>
+          <div></div>
+        <% end %>
+
+        <%= link_to event["url"], id: "#{event["name"]}-pending" do %>
+          <div></div>
+        <% end %>
+      `)
+    })
+
+    test("passes for interpolated helper IDs in separate loops", () => {
+      expectNoOffenses(dedent`
+        <% @with_video_link.each do |event| %>
+          <%= link_to event["url"], id: "#{event["name"]}-published" do %>
+            <div></div>
+          <% end %>
+        <% end %>
+
+        <% @without_video_link.each do |event| %>
+          <%= link_to event["url"], id: "#{event["name"]}-pending" do %>
+            <div></div>
+          <% end %>
+        <% end %>
+      `)
+    })
+
+    test("passes for an interpolated helper ID and a static ID matching its literal part", () => {
+      expectNoOffenses(dedent`
+        <%= tag.div id: "#{user.name}-pending" %>
+        <div id="-pending"></div>
+      `)
+    })
+
+    test("hints for the same interpolated helper ID twice", () => {
+      expectHint('Potential duplicate ID `#{user.id}-pending` found. If this expression evaluates to the same value, IDs must be unique within a document.')
+
+      assertOffenses(dedent`
+        <%= tag.div id: "#{user.id}-pending" %>
+        <%= tag.span id: "#{user.id}-pending" %>
+      `)
+    })
+
+    test("hints for the same Ruby expression helper ID twice", () => {
+      expectHint('Potential duplicate ID `#{dom_id(user)}` found. If this expression evaluates to the same value, IDs must be unique within a document.')
+
+      assertOffenses(dedent`
+        <%= tag.div id: dom_id(user) %>
+        <%= tag.span id: dom_id(user) %>
+      `)
+    })
+
+    test("passes for interpolated helper IDs in mutually exclusive branches", () => {
+      expectNoOffenses(dedent`
+        <% if condition? %>
+          <%= tag.div id: "#{user.id}-pending" %>
+        <% else %>
+          <%= tag.span id: "#{user.id}-pending" %>
+        <% end %>
+      `)
+    })
+
+    test("still fails for the same static helper ID twice", () => {
+      expectError('Duplicate ID `pending` found. IDs must be unique within a document.')
+
+      assertOffenses(dedent`
+        <%= tag.div id: "pending" %>
+        <%= tag.span id: "pending" %>
+      `)
+    })
+  })
+
   describe("<template> elements (issue #1728)", () => {
     describe("isolation from the surrounding document", () => {
       test("passes for ID inside <template> matching an ID outside it", () => {


### PR DESCRIPTION
Follow up on #1904 and #1448.

This pull request updates `html-no-duplicate-ids` to recognize Ruby interpolation inside Action View helper attributes as dynamic content, so helper IDs are compared the same way ERB output IDs already are.

An `id` on an Action View helper is a Ruby string, so `id: "#{event["name"]}-pending"` parses into a `RubyLiteralNode` next to a `LiteralNode` rather than into an ERB node:

```
@ HTMLAttributeValueNode
├── @ RubyLiteralNode  content: "event[\"name\"]"
└── @ LiteralNode      content: "-pending"
```

The rule decided whether an `id` was dynamic with `hasERBOutput()`, which only looks for `<%= %>`. A `RubyLiteralNode` is invisible to it, and `getValidatableStaticContent()` keeps only the literal parts, so the rule saw the *static* ID `-pending` and reported a hard `error`.

Because only the literal parts survived, any two helper IDs sharing a literal suffix collided, even when they can never produce the same value:

```erb
<%= link_to event["url"], id: "#{event["name"]}-pending" do %>
  <%= event["name"] %>
<% end %>

<%= link_to talk["url"], id: "#{talk["title"]}-pending" do %>
  <%= talk["title"] %>
<% end %>
```

```
[error] Duplicate ID `-pending` found. IDs must be unique within a document.
```

The two IDs are now compared as `#{event["name"]}-pending` and `#{talk["title"]}-pending`, so nothing is reported. For the same reason, an interpolated helper ID no longer collides with a static `id="-pending"` elsewhere in the document.

#### Possible collisions were errors instead of hints

Where a collision genuinely is possible, the helper path now lands on the `hint` severity #1904 established for IDs that cannot be statically proven to collide:

```diff
- [error] Duplicate ID `-pending` found. IDs must be unique within a document.
+ [hint]  Potential duplicate ID `#{user.id}-pending` found. If this expression evaluates to the same value, IDs must be unique within a document.
```

A helper attribute whose value is a whole Ruby expression rather than an interpolated string behaves the same way, and is printed with the same `#{...}` marker so it reads unambiguously as dynamic:

```erb
<%= tag.div id: dom_id(user) %>
<%= tag.span id: dom_id(user) %>
```

```
[hint] Potential duplicate ID `#{dom_id(user)}` found. If this expression evaluates to the same value, IDs must be unique within a document.
```

Static helper IDs are unaffected and keep the rule's configured `severity`, since two identical static IDs are unconditionally a duplicate:

```erb
<%= tag.div id: "pending" %>
<%= tag.span id: "pending" %>
```

```
[error] Duplicate ID `pending` found. IDs must be unique within a document.
```

