### PR TITLE
Rust: Remove unused `libc` dependency

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -34,7 +34,6 @@ name = "herb-rust"
 path = "src/main.rs"
 
 [dependencies]
-libc = "0.2"
 colored = "3"
 
 [dev-dependencies]


### PR DESCRIPTION
This pull request removes the `libc` dependency from the `herb` crate, since nothing in the crate ever referenced it.

`libc` has been declared in `rust/Cargo.toml` since the bindings were first added in #767, but no Rust source file, test, or build script mentions it. 

After the change, the runtime dependency graph is down to a single crate:

```
$ cargo tree --edges normal --depth 1 -p herb
herb v0.10.3
└── colored v3.1.1
```