### PR TITLE
Formatter: Preserve user newlines for inline elements

### DIFF
--- a/javascript/packages/formatter/src/format-printer.ts
+++ b/javascript/packages/formatter/src/format-printer.ts
@@ -136,6 +136,8 @@ export class FormatPrinter extends Printer implements TextFlowDelegate, Attribut
    */
   maxLineLength: number
 
+  public source: string
+
   /**
    * @deprecated refactor to use @herb-tools/printer infrastructre (or rework printer use push and this.lines)
    */
@@ -154,9 +156,7 @@ export class FormatPrinter extends Printer implements TextFlowDelegate, Attribut
   private attributeRenderer: AttributeRenderer
   private spacingAnalyzer: SpacingAnalyzer
   private collectedHerbDisable: CollectedHerbDisable[] = []
-
-  public source: string
-
+  private sourceLines: string[] | null = null
   private herb?: HerbBackend
   private erbBlockTagNameCache = new Map<Node, string | null>()
 
@@ -1419,6 +1419,16 @@ export class FormatPrinter extends Printer implements TextFlowDelegate, Attribut
 
     if (hasNonInlineChildElements) return false
 
+    if (openTagClosing && this.startsItsOwnLine(node)) {
+      const first = children[0]
+      const startsOnNewLine = first.location.start.line > openTagClosing.location.end.line
+      const hasLeadingNewline = isNode(first, HTMLTextNode) && /^\s*\n/.test(first.content)
+
+      if (startsOnNewLine || hasLeadingNewline) {
+        return false
+      }
+    }
+
     if (isInlineElement(tagName)) {
       const fullInlineResult = this.tryRenderInlineFull(node, tagName, filterNodes(getOpenTagChildren(node), HTMLAttributeNode), node.body)
 
@@ -1510,6 +1520,18 @@ export class FormatPrinter extends Printer implements TextFlowDelegate, Attribut
     const gluedEnd = !isPureWhitespaceNode(last) && !(isNode(last, HTMLTextNode) && endsWithWhitespace(last.content))
 
     return gluedStart || gluedEnd
+  }
+
+  private startsItsOwnLine(node: HTMLElementNode): boolean {
+    const start = node.open_tag?.location.start
+    if (!start) return false
+
+    this.sourceLines ||= this.source.split("\n")
+
+    const line = this.sourceLines[start.line - 1]
+    if (line === undefined) return false
+
+    return /^\s*$/.test(line.slice(0, start.column))
   }
 
   private fitsOnCurrentLine(content: string): boolean {

--- a/javascript/packages/formatter/test/erb/if.test.ts
+++ b/javascript/packages/formatter/test/erb/if.test.ts
@@ -273,7 +273,13 @@ describe("@herb-tools/formatter", () => {
       `
 
       const expected = dedent`
-        <span><% if valid? %>Valid<% else %>Invalid<% end %></span>
+        <span>
+          <% if valid? %>
+            Valid
+          <% else %>
+            Invalid
+          <% end %>
+        </span>
       `
 
       const output = formatter.format(input)
@@ -321,7 +327,13 @@ describe("@herb-tools/formatter", () => {
       `
 
       const expected = dedent`
-        <span><% if valid? %>Valid<% elsif invalid? %>Invalid<% end %></span>
+        <span>
+          <% if valid? %>
+            Valid
+          <% elsif invalid? %>
+            Invalid
+          <% end %>
+        </span>
       `
 
       const output = formatter.format(input)

--- a/javascript/packages/formatter/test/herb-disable-comment-formatting.test.ts
+++ b/javascript/packages/formatter/test/herb-disable-comment-formatting.test.ts
@@ -381,9 +381,11 @@ describe("herb:disable comment formatting", () => {
 
     const result = formatter.format(source)
 
-    expect(result).toBe(
-      `<a class="btn btn-secondary" aria-label="Close"> Close </a> <%# herb:disable html-anchor-require-href %>`
-    )
+    expect(result).toBe(dedent`
+      <a class="btn btn-secondary" aria-label="Close"> <%# herb:disable html-anchor-require-href %>
+        Close
+      </a>
+    `)
   })
 
   test("keeps herb:disable comment on the attribute line in a loop", () => {

--- a/javascript/packages/formatter/test/html/comments.test.ts
+++ b/javascript/packages/formatter/test/html/comments.test.ts
@@ -326,10 +326,23 @@ describe("@herb-tools/formatter", () => {
       `)
     })
 
-    test("span with only a comment becomes inline (acceptable for inline elements)", () => {
+    test("span with only a comment keeps the author's newlines", () => {
       const source = dedent`
         <span>
           <!-- Even in inline elements -->
+        </span>
+      `
+      const result = formatter.format(source)
+      expect(result).toEqual(dedent`
+        <span>
+          <!-- Even in inline elements -->
+        </span>
+      `)
+    })
+
+    test("span with a comment glued to the open tag still collapses", () => {
+      const source = dedent`
+        <span><!-- Even in inline elements -->
         </span>
       `
       const result = formatter.format(source)

--- a/javascript/packages/formatter/test/html/inline-element-newlines.test.ts
+++ b/javascript/packages/formatter/test/html/inline-element-newlines.test.ts
@@ -1,0 +1,131 @@
+import { describe, test, expect, beforeAll } from "vitest"
+import { Herb } from "@herb-tools/node-wasm"
+import { Formatter } from "../../src"
+import { createExpectFormattedToMatch } from "../helpers"
+
+import dedent from "dedent"
+
+let formatter: Formatter
+let wideFormatter: Formatter
+let expectFormattedToMatch: ReturnType<typeof createExpectFormattedToMatch>
+let expectWideFormattedToMatch: ReturnType<typeof createExpectFormattedToMatch>
+
+describe("@herb-tools/formatter", () => {
+  beforeAll(async () => {
+    await Herb.load()
+
+    formatter = new Formatter(Herb, {
+      indentWidth: 2,
+      maxLineLength: 80
+    })
+
+    wideFormatter = new Formatter(Herb, {
+      indentWidth: 2,
+      maxLineLength: 120
+    })
+
+    expectFormattedToMatch = createExpectFormattedToMatch(formatter)
+    expectWideFormattedToMatch = createExpectFormattedToMatch(wideFormatter)
+  })
+
+  describe("newlines inside inline elements that start their own line", () => {
+    test("keeps an inline element expanded when the author broke out its content", () => {
+      expectWideFormattedToMatch(dedent`
+        <div class="flex flex-col w-full flex-1 self-center">
+          <span class="text-lg font-semibold sm:text-md">
+            <%= upcoming_event.name %> is coming up!
+          </span>
+        </div>
+      `)
+    })
+
+    test("keeps an inline element expanded even when it would fit on one line", () => {
+      expectWideFormattedToMatch(dedent`
+        <nav>
+          <a href="/events" class="underline">
+            All events
+          </a>
+        </nav>
+      `)
+    })
+
+    test("keeps nested inline elements expanded", () => {
+      expectWideFormattedToMatch(dedent`
+        <div class="outer">
+          <span class="a">
+            <strong>
+              <%= user.name %>
+            </strong>
+          </span>
+        </div>
+      `)
+    })
+
+    test("keeps an inline element expanded around ERB control flow", () => {
+      expectWideFormattedToMatch(dedent`
+        <span>
+          <% if valid? %>
+            Valid
+          <% else %>
+            Invalid
+          <% end %>
+        </span>
+      `)
+    })
+
+    test("still collapses an inline element the author wrote on one line", () => {
+      expectWideFormattedToMatch(dedent`
+        <div class="outer">
+          <span class="text-lg"><%= upcoming_event.name %> is coming up!</span>
+        </div>
+      `)
+    })
+
+    test("still collapses an inline element glued to its siblings", () => {
+      const source = dedent`
+        <div><span>
+          <em>a</em>
+          <em>b</em>
+        </span></div>
+      `
+
+      expect(wideFormatter.format(source)).toEqual(`<div><span><em>a</em> <em>b</em></span></div>`)
+    })
+
+    test("still collapses an inline element inside a running text flow", () => {
+      const source = dedent`
+        <p>
+          Some leading text <span class="badge">
+            <%= count %>
+          </span> and some trailing text.
+        </p>
+      `
+
+      expect(wideFormatter.format(source)).toEqual(dedent`
+        <p>
+          Some leading text <span class="badge"><%= count %></span> and some trailing text.
+        </p>
+      `)
+    })
+
+    test("keeps content that does not fit expanded, as before", () => {
+      expectFormattedToMatch(dedent`
+        <div class="outer">
+          <span class="opacity-80 text-sm mt-1">
+            <%= upcoming_event.location %> &bull; <%= upcoming_event.formatted_dates %>
+          </span>
+        </div>
+      `)
+    })
+
+    test("matches the behaviour block elements already had", () => {
+      expectWideFormattedToMatch(dedent`
+        <div class="outer">
+          <div class="text-lg font-semibold sm:text-md">
+            <%= upcoming_event.name %> is coming up!
+          </div>
+        </div>
+      `)
+    })
+  })
+})

--- a/javascript/packages/formatter/test/html/text-content.test.ts
+++ b/javascript/packages/formatter/test/html/text-content.test.ts
@@ -419,11 +419,24 @@ describe("@herb-tools/formatter", () => {
     `)
   })
 
-  test("multiline span with text collapses to inline with spaces", () => {
+  test("multiline span with text keeps the author's newlines", () => {
     const source = dedent`
       <span>
         And on the other hand one can not remove whitespace entirely
       </span>
+    `
+
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <span>
+        And on the other hand one can not remove whitespace entirely
+      </span>
+    `)
+  })
+
+  test("single-line span with text keeps the author's single line", () => {
+    const source = dedent`
+      <span> And on the other hand one can not remove whitespace entirely </span>
     `
 
     const result = formatter.format(source)


### PR DESCRIPTION
This pull request updates the formatter to keep the newlines an author wrote inside an inline element, instead of collapsing the element onto a single line whenever it happens to fit within `maxLineLength`.

Previously, block elements already respected the author's line breaks, but inline elements (`span`, `a`, `strong`, ...) were collapsed purely based on whether the result fit on one line. That made formatting depend on how close the content happened to be to the limit:

```html+erb
<div class="flex flex-col w-full flex-1 self-center">
  <span class="text-lg font-semibold sm:text-md">
    <%= upcoming_event.name %> is coming up!
  </span>

  <span class="opacity-80 text-sm mt-1">
    <%= upcoming_event.location %> &bull; <%= upcoming_event.formatted_dates %>
  </span>
</div>
```

With `maxLineLength: 120`, the first `<span>` collapsed to 98 characters while the second stayed expanded at 124, so two identically written elements ended up formatted differently:

```diff
   <div class="flex flex-col w-full flex-1 self-center">
-    <span class="text-lg font-semibold sm:text-md">
-      <%= upcoming_event.name %> is coming up!
-    </span>
+    <span class="text-lg font-semibold sm:text-md"><%= upcoming_event.name %> is coming up!</span>
```

`shouldRenderElementContentInline` now applies the same `contentStartsOnNewLine` check that block elements already used, gated by a new `startsItsOwnLine` helper. The element keeps its newlines only when its open tag is the first thing on its source line, meaning the author deliberately gave the element its own lines rather than gluing it to surrounding inline content.

That gate is what keeps whitespace-sensitive inline content working. An inline element glued to its siblings still collapses, so the space between children is preserved rather than turned into a line break:

```html+erb
<div><span>
  <em>a</em>
  <em>b</em>
</span></div>
```

```html+erb
<div><span><em>a</em> <em>b</em></span></div>
```

The same applies to an inline element sitting inside a running text flow, which continues to reflow as before:

```html+erb
<p>
  Some leading text <span class="badge"><%= count %></span> and some trailing text.
</p>
```