### PR TITLE
Rust: Add `color` and `cli` features

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -33,11 +33,18 @@ crate-type = ["rlib"]
 [[bin]]
 name = "herb-rust"
 path = "src/main.rs"
+required-features = ["cli"]
+
+[features]
+default = []
+color = ["dep:colored"]
+cli = ["color"]
 
 [dependencies]
-colored = "3"
+colored = { version = "3", optional = true }
 
 [dev-dependencies]
+colored = "3"
 insta = "1.40"
 cargo-insta = "1.43.2"
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -14,11 +14,8 @@ pub mod token;
 pub mod union_types;
 pub mod visitor;
 
-pub use errors::{AnyError, ErrorNode, ErrorType};
-pub use herb::{
-  diff, extract_html, extract_ruby, extract_ruby_with_options, herb_version, lex, parse, parse_ruby, parse_with_options, prism_version, version, DiffOperation,
-  DiffResult, ExtractRubyOptions, ParserOptions, RubyParseResult,
-};
+pub(crate) mod style;
+
 pub use lex_result::LexResult;
 pub use location::Location;
 pub use nodes::{AnyNode, ERBNode, Node};
@@ -27,5 +24,12 @@ pub use position::Position;
 pub use range::Range;
 pub use token::Token;
 pub use visitor::Visitor;
+
+pub use errors::{AnyError, ErrorNode, ErrorType};
+
+pub use herb::{
+  diff, extract_html, extract_ruby, extract_ruby_with_options, herb_version, lex, parse, parse_ruby, parse_with_options, prism_version, version, DiffOperation,
+  DiffResult, ExtractRubyOptions, ParserOptions, RubyParseResult,
+};
 
 pub const VERSION: &str = "0.10.3";

--- a/rust/src/style.rs
+++ b/rust/src/style.rs
@@ -1,0 +1,64 @@
+#[cfg(feature = "color")]
+pub(crate) use colored::Colorize;
+
+#[cfg(not(feature = "color"))]
+pub(crate) use passthrough::Colorize;
+
+#[cfg(not(feature = "color"))]
+mod passthrough {
+  macro_rules! passthrough_colorize {
+    ($($name:ident),* $(,)?) => {
+      pub(crate) trait Colorize {
+        $(fn $name(&self) -> String;)*
+      }
+
+      impl<T: AsRef<str> + ?Sized> Colorize for T {
+        $(
+          fn $name(&self) -> String {
+            self.as_ref().to_string()
+          }
+        )*
+      }
+    };
+  }
+
+  passthrough_colorize![
+    black,
+    red,
+    green,
+    yellow,
+    blue,
+    magenta,
+    purple,
+    cyan,
+    white,
+    bright_black,
+    bright_red,
+    bright_green,
+    bright_yellow,
+    bright_blue,
+    bright_magenta,
+    bright_purple,
+    bright_cyan,
+    bright_white,
+    on_black,
+    on_red,
+    on_green,
+    on_yellow,
+    on_blue,
+    on_magenta,
+    on_purple,
+    on_cyan,
+    on_white,
+    normal,
+    bold,
+    dimmed,
+    italic,
+    underline,
+    blink,
+    reversed,
+    hidden,
+    strikethrough,
+    clear,
+  ];
+}

--- a/rust/src/style.rs
+++ b/rust/src/style.rs
@@ -8,6 +8,7 @@ pub(crate) use passthrough::Colorize;
 mod passthrough {
   macro_rules! passthrough_colorize {
     ($($name:ident),* $(,)?) => {
+      #[allow(dead_code)]
       pub(crate) trait Colorize {
         $(fn $name(&self) -> String;)*
       }

--- a/rust/src/token.rs
+++ b/rust/src/token.rs
@@ -1,6 +1,6 @@
 use crate::location::Location;
 use crate::range::Range;
-use colored::*;
+use crate::style::Colorize;
 use std::fmt;
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/templates/rust/src/errors.rs.erb
+++ b/templates/rust/src/errors.rs.erb
@@ -1,5 +1,5 @@
 use crate::{Location, Position, Token};
-use colored::*;
+use crate::style::Colorize;
 
 fn escape_string(s: &str) -> String {
   s.replace('\\', "\\\\")

--- a/templates/rust/src/nodes.rs.erb
+++ b/templates/rust/src/nodes.rs.erb
@@ -1,7 +1,7 @@
 use crate::errors::{AnyError, ErrorNode};
 use crate::{Location, Token};
 use crate::union_types::*;
-use colored::*;
+use crate::style::Colorize;
 
 pub(crate) fn prettify_prism_tree(input: &str) -> String {
   let input = input.replace("+-- ", "├── ").replace("|   ", "│   ");


### PR DESCRIPTION
Follow up on #1948.

This pull request adds two features to the `herb` crate so that consumers who only want the parser don't pay for the parts they don't use. With neither enabled, which is now the default, the crate has an empty runtime dependency graph and doesn't build the `herb-rust` binary.

```toml
[features]
default = []
color = ["dep:colored"]
cli = ["color"]
```

#### `color`

`colored` was the crate's only runtime dependency, and all call sites sit inside `tree_inspect()` and the `format_*_value` helpers that serve it. That is presentation logic living in the AST layer, so the library now emits plain text by default and the `color` feature turns the ANSI escapes back on.

The gate is a small `Colorize` shim in `rust/src/style.rs`. With the feature on it re-exports `colored::Colorize` and nothing changes. With it off, a macro-generated passthrough supplies the same methods returning the string unchanged:

```rust
#[cfg(feature = "color")]
pub(crate) use colored::Colorize;

#[cfg(not(feature = "color"))]
pub(crate) use passthrough::Colorize;
```

This keeps the public API the same shape in both configurations.

#### `cli`

The `herb-rust` binary now declares `required-features = ["cli"]`, so library consumers no longer build it. Installing the binary becomes:

```bash
cargo install herb --features cli
```