### PR TITLE
Config: Add `all` pseudo rule to set the default for every linter rule

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -185,6 +185,52 @@ Each rule can be configured with the following options:
 - **`only`**: Array of glob patterns - Restrict rule to ONLY these files (can override parent excludes, overrides `include`)
 - **`exclude`**: Array of glob patterns - Exclude files from this rule (always applied)
 
+### Setting the Default for All Rules <Badge type="tip" text="^0.11.0" />
+
+The `all` pseudo rule sets the default `enabled` state for every rule you don't list explicitly. It's the way to opt into a fully explicit rule set without having to know (and repeat) which rules are on by default:
+
+```yaml [.herb.yml]
+linter:
+  enabled: true
+
+  rules:
+    # Turn every rule off ...
+    all:
+      enabled: false
+
+    # ... and opt back in to exactly the ones you want
+    html-no-event-handlers:
+      enabled: true
+
+    html-img-require-alt:
+      enabled: true
+```
+
+Setting `all: enabled: true` does the opposite and turns on every rule, including the ones that are off by default:
+
+```yaml [.herb.yml]
+linter:
+  rules:
+    all:
+      enabled: true
+
+    # Individual rules can still be turned back off
+    html-no-title-attribute:
+      enabled: false
+```
+
+A few details worth knowing:
+
+- **Explicit configuration always wins.** A rule that appears in `rules` follows its own `enabled` setting, no matter what `all` says.
+- **Listing a rule without `enabled` enables it.** `html-img-require-alt: { severity: warning }` under `all: enabled: false` turns the rule on, the same way it would without `all`.
+- **`all: enabled: true` bypasses version gating.** Normally the `version` in your `.herb.yml` holds back rules introduced in later releases. Enabling everything means exactly that, so nothing gets held back. Under `all: enabled: false` version gating makes no difference either way, since those rules are off regardless.
+- **`--only` and `--all-rules` still take precedence**, since both flags ignore the rule configuration entirely.
+- Only `enabled` is meaningful on `all`. Other rule options like `severity` or `exclude` aren't inherited by the individual rules.
+
+::: warning
+`all` is a reserved name inside `rules`, it's never treated as an actual rule.
+:::
+
 #### Pattern Precedence
 
 When configuring rule-level file patterns:

--- a/javascript/packages/config/src/config-template.yml
+++ b/javascript/packages/config/src/config-template.yml
@@ -54,6 +54,12 @@ linter:
   #   - 'app/views/admin/**/*'
 
   # rules:
+  #   # The 'all' pseudo rule sets the default for every rule you don't list.
+  #   #   false: start from an empty set and opt back in explicitly
+  #   #   true:  start from every rule, including the ones off by default
+  #   all:
+  #     enabled: false
+  #
   #   erb-no-extra-newline:
   #     enabled: false
   #

--- a/javascript/packages/config/src/config.ts
+++ b/javascript/packages/config/src/config.ts
@@ -42,6 +42,22 @@ export function resolveSeverity(severity: SeverityConfig, mode: LinterMode): Dia
   return severity[mode]
 }
 
+/**
+ * Pseudo rule name used inside `linter.rules` to set the default `enabled`
+ * state for every rule that isn't explicitly configured.
+ *
+ * ```yaml
+ * linter:
+ *   rules:
+ *     all:
+ *       enabled: false
+ *
+ *     html-no-event-handlers:
+ *       enabled: true
+ * ```
+ */
+export const ALL_RULES_KEY = "all"
+
 export type RuleConfig = {
   enabled?: boolean
   severity?: SeverityConfig
@@ -175,12 +191,38 @@ export class Config {
   }
 
   /**
+   * The default `enabled` state for rules that aren't explicitly configured,
+   * set via the `all` pseudo rule in `linter.rules`.
+   *
+   * `false` disables every rule that isn't explicitly listed, `true` enables
+   * every rule that isn't explicitly listed (including rules that are off by
+   * default). Returns `undefined` when `all` isn't configured, in which case
+   * each rule falls back to its own default.
+   *
+   * @returns The configured default, or undefined when `all` isn't configured
+   */
+  public get defaultRuleEnabled(): boolean | undefined {
+    return this.config.linter?.rules?.[ALL_RULES_KEY]?.enabled
+  }
+
+  /**
    * Check if a specific rule is disabled.
+   *
+   * A rule that appears in `linter.rules` is disabled only when it sets
+   * `enabled: false`. A rule that doesn't appear falls back to the `all`
+   * pseudo rule, if configured.
+   *
    * @param ruleName - The name of the rule to check
-   * @returns true if the rule is explicitly disabled, false otherwise
+   * @returns true if the rule is disabled, false otherwise
    */
   public isRuleDisabled(ruleName: string): boolean {
-    return this.config.linter?.rules?.[ruleName]?.enabled === false
+    const ruleConfig = this.config.linter?.rules?.[ruleName]
+
+    if (ruleConfig !== undefined) {
+      return ruleConfig.enabled === false
+    }
+
+    return this.defaultRuleEnabled === false
   }
 
   /**

--- a/javascript/packages/config/src/index.ts
+++ b/javascript/packages/config/src/index.ts
@@ -1,4 +1,4 @@
-export { Config, resolveSeverity } from "./config.js"
+export { Config, resolveSeverity, ALL_RULES_KEY } from "./config.js"
 export { HerbConfigSchema } from "./config-schema.js"
 export { addHerbExtensionRecommendation, getExtensionsJsonRelativePath } from "./vscode.js"
 

--- a/javascript/packages/config/test/config.test.ts
+++ b/javascript/packages/config/test/config.test.ts
@@ -535,6 +535,111 @@ describe("@herb-tools/config", () => {
       expect(config.isRuleEnabled("html-tag-name-lowercase")).toBe(true)
     })
 
+    test("defaultRuleEnabled returns undefined when 'all' is not configured", () => {
+      const configOptions: HerbConfigOptions = {
+        linter: {
+          rules: {
+            "html-tag-name-lowercase": { enabled: false }
+          }
+        }
+      }
+      const config = Config.fromObject(configOptions, { projectPath: testDir })
+
+      expect(config.defaultRuleEnabled).toBeUndefined()
+    })
+
+    test("defaultRuleEnabled returns the 'all' pseudo rule setting", () => {
+      const disabled = Config.fromObject({ linter: { rules: { all: { enabled: false } } } }, { projectPath: testDir })
+      const enabled = Config.fromObject({ linter: { rules: { all: { enabled: true } } } }, { projectPath: testDir })
+
+      expect(disabled.defaultRuleEnabled).toBe(false)
+      expect(enabled.defaultRuleEnabled).toBe(true)
+    })
+
+    test("isRuleDisabled returns true for unconfigured rules when 'all' is disabled", () => {
+      const configOptions: HerbConfigOptions = {
+        linter: {
+          rules: {
+            all: { enabled: false }
+          }
+        }
+      }
+      const config = Config.fromObject(configOptions, { projectPath: testDir })
+
+      expect(config.isRuleDisabled("html-tag-name-lowercase")).toBe(true)
+    })
+
+    test("isRuleDisabled returns false for rules re-enabled over a disabled 'all'", () => {
+      const configOptions: HerbConfigOptions = {
+        linter: {
+          rules: {
+            all: { enabled: false },
+            "html-img-require-alt": { enabled: true }
+          }
+        }
+      }
+      const config = Config.fromObject(configOptions, { projectPath: testDir })
+
+      expect(config.isRuleDisabled("html-img-require-alt")).toBe(false)
+      expect(config.isRuleDisabled("html-tag-name-lowercase")).toBe(true)
+    })
+
+    test("isRuleDisabled returns false for rules configured without 'enabled' when 'all' is disabled", () => {
+      const configOptions: HerbConfigOptions = {
+        linter: {
+          rules: {
+            all: { enabled: false },
+            "html-img-require-alt": { severity: "warning" }
+          }
+        }
+      }
+      const config = Config.fromObject(configOptions, { projectPath: testDir })
+
+      expect(config.isRuleDisabled("html-img-require-alt")).toBe(false)
+    })
+
+    test("isRuleDisabled returns false for unconfigured rules when 'all' is enabled", () => {
+      const configOptions: HerbConfigOptions = {
+        linter: {
+          rules: {
+            all: { enabled: true }
+          }
+        }
+      }
+      const config = Config.fromObject(configOptions, { projectPath: testDir })
+
+      expect(config.isRuleDisabled("html-tag-name-lowercase")).toBe(false)
+    })
+
+    test("isRuleDisabled still honors explicit disables when 'all' is enabled", () => {
+      const configOptions: HerbConfigOptions = {
+        linter: {
+          rules: {
+            all: { enabled: true },
+            "html-tag-name-lowercase": { enabled: false }
+          }
+        }
+      }
+      const config = Config.fromObject(configOptions, { projectPath: testDir })
+
+      expect(config.isRuleDisabled("html-tag-name-lowercase")).toBe(true)
+    })
+
+    test("isRuleEnabledForPath returns false for unconfigured rules when 'all' is disabled", () => {
+      const configOptions: HerbConfigOptions = {
+        linter: {
+          rules: {
+            all: { enabled: false },
+            "html-img-require-alt": { enabled: true }
+          }
+        }
+      }
+      const config = Config.fromObject(configOptions, { projectPath: testDir })
+
+      expect(config.isRuleEnabledForPath("html-tag-name-lowercase", "app/views/home/index.html.erb")).toBe(false)
+      expect(config.isRuleEnabledForPath("html-img-require-alt", "app/views/home/index.html.erb")).toBe(true)
+    })
+
     test("isLinterEnabledForPath returns true when no exclude patterns", () => {
       const config = Config.fromObject({}, { projectPath: testDir })
 

--- a/javascript/packages/linter/src/linter.ts
+++ b/javascript/packages/linter/src/linter.ts
@@ -12,7 +12,7 @@ import { ParseCache } from "./parse-cache.js"
 import { ParserNoErrorsRule } from "./rules/parser-no-errors.js"
 
 import { DEFAULT_RULE_CONFIG } from "./types.js"
-import { resolveSeverity } from "@herb-tools/config"
+import { resolveSeverity, ALL_RULES_KEY } from "@herb-tools/config"
 
 import type { RuleClass, ParserRuleClass, LexerRuleClass, SourceRuleClass, Rule, ParserRule, LexerRule, SourceRule, LintResult, LintOffense, UnboundLintOffense, LintContext, AutofixResult, RuleVersion, LinterMode } from "./types.js"
 import type { ParseResult, LexResult, HerbBackend } from "@herb-tools/core"
@@ -130,7 +130,13 @@ export class Linter {
    * Priority:
    * 1. User explicitly enabled/disabled (if rule config exists in userRulesConfig)
    * 2. Version gating (if rule.introducedIn > configVersion, skip unless explicitly enabled)
-   * 3. Default config from rule's defaultConfig getter
+   * 3. The `all` pseudo rule in userRulesConfig, if configured
+   * 4. Default config from rule's defaultConfig getter
+   *
+   * The `all` pseudo rule replaces every rule's own default. When it enables
+   * everything, version gating is bypassed as well, since holding rules back
+   * would contradict the setting. When it disables everything, gating stays in
+   * place but can't change the outcome: the rule ends up disabled either way.
    *
    * When `options.only` is provided all of the above is bypassed and exactly the
    * requested rules are enabled, regardless of the user configuration.
@@ -175,9 +181,11 @@ export class Linter {
     let disabledByConfig = 0
     let notEnabledByDefault = 0
 
+    const allRulesDefault = userRulesConfig?.[ALL_RULES_KEY]?.enabled
+
     for (const ruleClass of allRules) {
       const instance = new ruleClass()
-      const defaultEnabled = instance.defaultConfig?.enabled ?? DEFAULT_RULE_CONFIG.enabled
+      const defaultEnabled = allRulesDefault ?? instance.defaultConfig?.enabled ?? DEFAULT_RULE_CONFIG.enabled
       const userRuleConfig = userRulesConfig?.[ruleClass.ruleName]
 
       if (userRuleConfig !== undefined) {
@@ -190,7 +198,7 @@ export class Linter {
         continue
       }
 
-      if (configVersion && ruleClass.introducedIn) {
+      if (allRulesDefault !== true && configVersion && ruleClass.introducedIn) {
         if (semverGreaterThan(ruleClass.introducedIn, configVersion)) {
           if (defaultEnabled) {
             skippedByVersion.push({

--- a/javascript/packages/linter/test/cli.test.ts
+++ b/javascript/packages/linter/test/cli.test.ts
@@ -1009,6 +1009,151 @@ describe("CLI Output Formatting", () => {
     })
   })
 
+  describe("`all` pseudo rule in .herb.yml", () => {
+    const { writeFileSync, unlinkSync } = require("fs")
+    const configPath = "test/fixtures/.herb.yml"
+
+    test("`all: enabled: false` only runs the rules that are opted back in", () => {
+      try {
+        writeFileSync(configPath, dedent`
+          linter:
+            rules:
+              all:
+                enabled: false
+              html-img-require-alt:
+                enabled: true
+        `)
+
+        const { output, exitCode } = runLinter("test-file-with-errors.html.erb", "--simple")
+
+        expect(output).toContain("html-img-require-alt")
+        expect(output).not.toContain("html-tag-name-lowercase")
+        expect(output).toContain("1 enabled")
+        expect(exitCode).toBe(0)
+      } finally {
+        try { unlinkSync(configPath) } catch {}
+      }
+    })
+
+    test("`all: enabled: true` runs rules that are not enabled by default", () => {
+      const fixturePath = "test/fixtures/all-pseudo-rule-not-enabled-by-default.html.erb"
+
+      try {
+        writeFileSync(fixturePath, `<div disabled>Save</div>\n`)
+
+        const withoutAll = runLinter("all-pseudo-rule-not-enabled-by-default.html.erb", "--simple")
+        expect(withoutAll.output).not.toContain("a11y-disabled-attribute")
+
+        writeFileSync(configPath, dedent`
+          linter:
+            rules:
+              all:
+                enabled: true
+        `)
+
+        const { output } = runLinter("all-pseudo-rule-not-enabled-by-default.html.erb", "--simple")
+
+        expect(output).toContain("a11y-disabled-attribute")
+      } finally {
+        try { unlinkSync(configPath) } catch {}
+        try { unlinkSync(fixturePath) } catch {}
+      }
+    })
+
+    test("does not hold back rules gated by the version in .herb.yml", () => {
+      const fixturePath = "test/fixtures/all-pseudo-rule-version-gated.html.erb"
+
+      try {
+        writeFileSync(fixturePath, dedent`
+          <div>
+            <foobar>hi</foobar>
+          </div>
+        ` + "\n")
+
+        writeFileSync(configPath, dedent`
+          version: 0.4.0
+        `)
+
+        const withoutAll = runLinter("all-pseudo-rule-version-gated.html.erb", "--simple")
+        expect(withoutAll.output).toContain("New rules available")
+
+        writeFileSync(configPath, dedent`
+          version: 0.4.0
+          linter:
+            rules:
+              all:
+                enabled: true
+        `)
+
+        const { output } = runLinter("all-pseudo-rule-version-gated.html.erb", "--simple")
+
+        expect(output).toContain("html-no-unknown-tag")
+        expect(output).not.toContain("New rules available")
+      } finally {
+        try { unlinkSync(configPath) } catch {}
+        try { unlinkSync(fixturePath) } catch {}
+      }
+    })
+
+    test("--only takes precedence over a disabled `all`", () => {
+      try {
+        writeFileSync(configPath, dedent`
+          linter:
+            rules:
+              all:
+                enabled: false
+        `)
+
+        const { output } = runLinter("test-file-with-errors.html.erb", "--simple", "--only", "html-tag-name-lowercase")
+
+        expect(output).toContain("html-tag-name-lowercase")
+        expect(output).toContain("1 enabled | filtered by --only")
+      } finally {
+        try { unlinkSync(configPath) } catch {}
+      }
+    })
+
+    test("--all-rules takes precedence over a disabled `all`", () => {
+      try {
+        writeFileSync(configPath, dedent`
+          linter:
+            rules:
+              all:
+                enabled: false
+        `)
+
+        const { output } = runLinter("test-file-with-errors.html.erb", "--simple", "--all-rules")
+
+        expect(output).toContain("html-tag-name-lowercase")
+        expect(output).toContain("all rules via --all-rules")
+      } finally {
+        try { unlinkSync(configPath) } catch {}
+      }
+    })
+
+    test("applies when the run is split across workers", () => {
+      try {
+        const withoutAll = JSON.parse(runLinter("parallel", "--jobs", "4", "--json").output)
+
+        writeFileSync(configPath, dedent`
+          linter:
+            rules:
+              all:
+                enabled: false
+              html-img-require-alt:
+                enabled: true
+        `)
+
+        const result = JSON.parse(runLinter("parallel", "--jobs", "4", "--json").output)
+
+        expect(withoutAll.summary.ruleCount).toBeGreaterThan(1)
+        expect(result.summary.ruleCount).toBe(1)
+      } finally {
+        try { unlinkSync(configPath) } catch {}
+      }
+    })
+  })
+
   describe("Directory Scoping (issue #1045)", () => {
     const { mkdirSync, writeFileSync, rmSync, existsSync } = require("fs")
     const { join } = require("path")

--- a/javascript/packages/linter/test/linter.test.ts
+++ b/javascript/packages/linter/test/linter.test.ts
@@ -868,6 +868,163 @@ describe("@herb-tools/linter", () => {
     })
   })
 
+  describe("`all` pseudo rule in the config", () => {
+    class EnabledRule extends ParserRule {
+      static ruleName = "enabled-rule"
+
+      get defaultConfig(): FullRuleConfig {
+        return { enabled: true, severity: "error" }
+      }
+
+      check(): UnboundLintOffense[] { return [] }
+    }
+
+    class DisabledRule extends ParserRule {
+      static ruleName = "disabled-rule"
+
+      get defaultConfig(): FullRuleConfig {
+        return { enabled: false, severity: "error" }
+      }
+
+      check(): UnboundLintOffense[] { return [] }
+    }
+
+    class VersionGatedRule extends ParserRule {
+      static ruleName = "version-gated-rule"
+      static introducedIn = "0.9.0" as const
+
+      get defaultConfig(): FullRuleConfig {
+        return { enabled: true, severity: "error" }
+      }
+
+      check(): UnboundLintOffense[] { return [] }
+    }
+
+    test("`all: enabled: false` disables every rule that isn't explicitly configured", () => {
+      const { enabled, disabledByConfig, notEnabledByDefault } = Linter.filterRulesByConfig(
+        [EnabledRule, DisabledRule, VersionGatedRule],
+        { all: { enabled: false } }
+      )
+
+      expect(enabled).toHaveLength(0)
+      expect(disabledByConfig).toBe(0)
+      expect(notEnabledByDefault).toBe(3)
+    })
+
+    test("`all: enabled: false` keeps explicitly enabled rules", () => {
+      const { enabled, notEnabledByDefault } = Linter.filterRulesByConfig(
+        [EnabledRule, DisabledRule, VersionGatedRule],
+        { all: { enabled: false }, "disabled-rule": { enabled: true } }
+      )
+
+      expect(enabled.map(ruleClass => ruleClass.ruleName)).toEqual(["disabled-rule"])
+      expect(notEnabledByDefault).toBe(2)
+    })
+
+    test("`all: enabled: false` treats a rule listed without `enabled` as enabled", () => {
+      const { enabled } = Linter.filterRulesByConfig(
+        [EnabledRule, DisabledRule],
+        { all: { enabled: false }, "disabled-rule": { severity: "warning" } }
+      )
+
+      expect(enabled.map(ruleClass => ruleClass.ruleName)).toEqual(["disabled-rule"])
+    })
+
+    test("`all: enabled: true` enables rules that are off by default", () => {
+      const { enabled, notEnabledByDefault } = Linter.filterRulesByConfig(
+        [EnabledRule, DisabledRule],
+        { all: { enabled: true } }
+      )
+
+      expect(enabled.map(ruleClass => ruleClass.ruleName)).toEqual(["enabled-rule", "disabled-rule"])
+      expect(notEnabledByDefault).toBe(0)
+    })
+
+    test("`all: enabled: true` keeps explicitly disabled rules disabled", () => {
+      const { enabled, disabledByConfig } = Linter.filterRulesByConfig(
+        [EnabledRule, DisabledRule],
+        { all: { enabled: true }, "enabled-rule": { enabled: false } }
+      )
+
+      expect(enabled.map(ruleClass => ruleClass.ruleName)).toEqual(["disabled-rule"])
+      expect(disabledByConfig).toBe(1)
+    })
+
+    test("`all: enabled: true` bypasses version gating", () => {
+      const { enabled, skippedByVersion } = Linter.filterRulesByConfig(
+        [EnabledRule, VersionGatedRule],
+        { all: { enabled: true } },
+        "0.8.0"
+      )
+
+      expect(enabled.map(ruleClass => ruleClass.ruleName)).toEqual(["enabled-rule", "version-gated-rule"])
+      expect(skippedByVersion).toHaveLength(0)
+    })
+
+    test("`all: enabled: false` leaves nothing for version gating to report", () => {
+      const { enabled, skippedByVersion, notEnabledByDefault } = Linter.filterRulesByConfig(
+        [EnabledRule, VersionGatedRule],
+        { all: { enabled: false } },
+        "0.8.0"
+      )
+
+      expect(enabled).toHaveLength(0)
+      expect(skippedByVersion).toHaveLength(0)
+      expect(notEnabledByDefault).toBe(2)
+    })
+
+    test("still applies version gating when `all` is not configured", () => {
+      const { enabled, skippedByVersion } = Linter.filterRulesByConfig(
+        [EnabledRule, VersionGatedRule],
+        undefined,
+        "0.8.0"
+      )
+
+      expect(enabled.map(ruleClass => ruleClass.ruleName)).toEqual(["enabled-rule"])
+      expect(skippedByVersion.map(rule => rule.ruleName)).toEqual(["version-gated-rule"])
+    })
+
+    test("`--only` takes precedence over the `all` pseudo rule", () => {
+      const { enabled } = Linter.filterRulesByConfig(
+        [EnabledRule, DisabledRule],
+        { all: { enabled: false } },
+        undefined,
+        { only: ["disabled-rule"] }
+      )
+
+      expect(enabled.map(ruleClass => ruleClass.ruleName)).toEqual(["disabled-rule"])
+    })
+
+    test("`--all-rules` takes precedence over the `all` pseudo rule", () => {
+      const { enabled } = Linter.filterRulesByConfig(
+        [EnabledRule, DisabledRule],
+        { all: { enabled: false } },
+        undefined,
+        { all: true }
+      )
+
+      expect(enabled.map(ruleClass => ruleClass.ruleName)).toEqual(["enabled-rule", "disabled-rule"])
+    })
+
+    test("Linter.from() only runs the rules opted back in", () => {
+      const config = Config.fromObject({
+        linter: {
+          enabled: true,
+          rules: {
+            all: { enabled: false },
+            "html-tag-name-lowercase": { enabled: true }
+          }
+        }
+      })
+
+      const linter = Linter.from(Herb, config)
+      const result = linter.lint("<DIV><img></DIV>", { fileName: "template.html.erb" })
+
+      expect(linter.getRuleCount()).toBe(1)
+      expect([...new Set(result.offenses.map(offense => offense.rule))]).toEqual(["html-tag-name-lowercase"])
+    })
+  })
+
   describe("Version-gated rule filtering", () => {
     class OldRule extends ParserRule {
       static ruleName = "old-rule"

--- a/javascript/packages/vscode/src/config-details-provider.ts
+++ b/javascript/packages/vscode/src/config-details-provider.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode"
-import { Config } from "@herb-tools/config"
+import { Config, ALL_RULES_KEY } from "@herb-tools/config"
 
 interface ConfigQuickPickItem extends vscode.QuickPickItem {
   action?: () => Promise<void>
@@ -49,15 +49,24 @@ export async function showConfigDetails() {
   const linterEnabled = config?.linter?.enabled ?? vscodeConfig.get('linter.enabled', true)
   const disabledRules = config?.linter?.rules
     ? Object.entries(config.linter.rules)
-        .filter(([_, ruleConfig]) => ruleConfig.enabled === false)
+        .filter(([name, ruleConfig]) => name !== ALL_RULES_KEY && ruleConfig.enabled === false)
         .map(([name, _]) => name)
     : []
 
+  const rulesDisabledByDefault = config?.linter?.rules?.[ALL_RULES_KEY]?.enabled === false
+
   const linterIcon = linterEnabled ? "$(check)" : "$(x)"
   const linterStatus = linterEnabled ? "Enabled" : "Disabled"
-  const linterDetail = disabledRules.length > 0
-    ? `${disabledRules.length} rule${disabledRules.length === 1 ? '' : 's'} disabled: ${disabledRules.slice(0, 3).join(', ')}${disabledRules.length > 3 ? '...' : ''}`
-    : "All rules enabled"
+
+  let linterDetail: string
+
+  if (rulesDisabledByDefault) {
+    linterDetail = "All rules disabled by default"
+  } else if (disabledRules.length > 0) {
+    linterDetail = `${disabledRules.length} rule${disabledRules.length === 1 ? '' : 's'} disabled: ${disabledRules.slice(0, 3).join(', ')}${disabledRules.length > 3 ? '...' : ''}`
+  } else {
+    linterDetail = "All rules enabled"
+  }
 
   const linterItem: ConfigQuickPickItem = {
     label: `${linterIcon} Herb Linter: ${linterStatus}`,

--- a/javascript/packages/vscode/src/config-provider.ts
+++ b/javascript/packages/vscode/src/config-provider.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode"
-import { Config } from "@herb-tools/config"
+import { Config, ALL_RULES_KEY } from "@herb-tools/config"
 
 export class HerbConfigProvider implements vscode.TreeDataProvider<ConfigItem> {
   private _onDidChangeTreeData: vscode.EventEmitter<ConfigItem | undefined | null | void> = new vscode.EventEmitter<ConfigItem | undefined | null | void>()
@@ -139,14 +139,18 @@ export class HerbConfigProvider implements vscode.TreeDataProvider<ConfigItem> {
 
       const linterEnabled = this.config.isLinterEnabled
       const disabledRulesCount = this.config.linter?.rules
-        ? Object.values(this.config.linter.rules).filter(r => r.enabled === false).length
+        ? Object.entries(this.config.linter.rules).filter(([name, rule]) => name !== ALL_RULES_KEY && rule.enabled === false).length
         : 0
+
+      const rulesDisabledByDefault = this.config.defaultRuleEnabled === false
 
       const linterItem = new ConfigItem(
         `Herb Linter: ${linterEnabled ? 'Enabled' : 'Disabled'}`,
-        disabledRulesCount
-          ? `${disabledRulesCount} rules disabled`
-          : "All rules enabled",
+        rulesDisabledByDefault
+          ? "All rules disabled by default"
+          : disabledRulesCount
+            ? `${disabledRulesCount} rules disabled`
+            : "All rules enabled",
         vscode.TreeItemCollapsibleState.None,
         'linterSetting'
       )

--- a/rust/herb-config/src/config.rs
+++ b/rust/herb-config/src/config.rs
@@ -19,6 +19,7 @@ pub trait SeverityOverridable {
 }
 
 pub const CONFIG_PATH: &str = ".herb.yml";
+pub const ALL_RULES_KEY: &str = "all";
 
 const PROJECT_INDICATORS: &[&str] = &[
   ".git",
@@ -118,8 +119,15 @@ impl Config {
     self.linter()?.rules.as_ref()?.get(rule_name)
   }
 
+  pub fn default_rule_enabled(&self) -> Option<bool> {
+    self.get_rule_config(ALL_RULES_KEY).and_then(|rule| rule.enabled)
+  }
+
   pub fn is_rule_disabled(&self, rule_name: &str) -> bool {
-    self.get_rule_config(rule_name).and_then(|rule| rule.enabled) == Some(false)
+    match self.get_rule_config(rule_name) {
+      Some(rule) => rule.enabled == Some(false),
+      None => self.default_rule_enabled() == Some(false),
+    }
   }
 
   pub fn is_rule_enabled(&self, rule_name: &str) -> bool {

--- a/rust/herb-config/src/lib.rs
+++ b/rust/herb-config/src/lib.rs
@@ -11,7 +11,7 @@ mod merge;
 mod mutation;
 mod severity;
 
-pub use config::{Config, FoundConfigFile, FromObjectOptions, LoadOptions, SeverityOverridable, Tool, CONFIG_PATH};
+pub use config::{Config, FoundConfigFile, FromObjectOptions, LoadOptions, SeverityOverridable, Tool, ALL_RULES_KEY, CONFIG_PATH};
 
 pub use config_schema::{
   EngineConfig, FilesConfig, FormatterConfig, Framework, HerbConfig, HerbConfigOptions, LinterConfig, ParserOptionsConfig, RewriterConfig, RuleConfig,

--- a/rust/herb-config/tests/config_test.rs
+++ b/rust/herb-config/tests/config_test.rs
@@ -454,6 +454,66 @@ mod config_instance_methods {
   }
 
   #[test]
+  fn default_rule_enabled_returns_none_when_all_is_not_configured() {
+    assert_eq!(
+      config_from_yaml("linter:\n  rules:\n    html-tag-name-lowercase:\n      enabled: false\n").default_rule_enabled(),
+      None
+    );
+  }
+
+  #[test]
+  fn default_rule_enabled_returns_the_all_pseudo_rule_setting() {
+    assert_eq!(
+      config_from_yaml("linter:\n  rules:\n    all:\n      enabled: false\n").default_rule_enabled(),
+      Some(false)
+    );
+    assert_eq!(
+      config_from_yaml("linter:\n  rules:\n    all:\n      enabled: true\n").default_rule_enabled(),
+      Some(true)
+    );
+  }
+
+  #[test]
+  fn is_rule_disabled_returns_true_for_unconfigured_rules_when_all_is_disabled() {
+    assert!(config_from_yaml("linter:\n  rules:\n    all:\n      enabled: false\n").is_rule_disabled("html-img-require-alt"));
+  }
+
+  #[test]
+  fn is_rule_disabled_returns_false_for_rules_re_enabled_over_a_disabled_all() {
+    let config = config_from_yaml("linter:\n  rules:\n    all:\n      enabled: false\n    html-img-require-alt:\n      enabled: true\n");
+
+    assert!(!config.is_rule_disabled("html-img-require-alt"));
+    assert!(config.is_rule_disabled("html-tag-name-lowercase"));
+  }
+
+  #[test]
+  fn is_rule_disabled_returns_false_for_rules_configured_without_enabled_when_all_is_disabled() {
+    let config = config_from_yaml("linter:\n  rules:\n    all:\n      enabled: false\n    html-img-require-alt:\n      severity: warning\n");
+
+    assert!(!config.is_rule_disabled("html-img-require-alt"));
+  }
+
+  #[test]
+  fn is_rule_disabled_returns_false_for_unconfigured_rules_when_all_is_enabled() {
+    assert!(!config_from_yaml("linter:\n  rules:\n    all:\n      enabled: true\n").is_rule_disabled("html-img-require-alt"));
+  }
+
+  #[test]
+  fn is_rule_disabled_still_honors_explicit_disables_when_all_is_enabled() {
+    let config = config_from_yaml("linter:\n  rules:\n    all:\n      enabled: true\n    html-img-require-alt:\n      enabled: false\n");
+
+    assert!(config.is_rule_disabled("html-img-require-alt"));
+  }
+
+  #[test]
+  fn is_rule_enabled_for_path_returns_false_for_unconfigured_rules_when_all_is_disabled() {
+    let config = config_from_yaml("linter:\n  rules:\n    all:\n      enabled: false\n    html-img-require-alt:\n      enabled: true\n");
+
+    assert!(!config.is_rule_enabled_for_path("html-tag-name-lowercase", "app/views/home/index.html.erb"));
+    assert!(config.is_rule_enabled_for_path("html-img-require-alt", "app/views/home/index.html.erb"));
+  }
+
+  #[test]
   fn is_linter_enabled_for_path_returns_true_when_no_exclude_patterns() {
     assert!(Config::default().is_linter_enabled_for_path("app/views/home/index.html.erb"));
   }


### PR DESCRIPTION
This pull request adds an `all` pseudo rule to `linter.rules` in `.herb.yml` that sets the default `enabled` state for every rule you don't list explicitly.

Verifying a small set of rules against a codebase currently means disabling everything else by hand, which requires knowing which rules are on by default in the first place, and then keeping that list up to date as new rules land. With `all` you can start from an empty set and opt back in:

```yaml
linter:
  enabled: true

  rules:
    all:
      enabled: false

    html-no-event-handlers:
      enabled: true
```

Setting `all: enabled: true` does the opposite and turns on every rule, including the ones that are off by default:

```yaml
linter:
  rules:
    all:
      enabled: true

    html-no-title-attribute:
      enabled: false
```

Resolves https://github.com/marcoroth/herb/issues/1643