### PR TITLE
Formatter: Don't fall back to stdin for `--check`

### DIFF
--- a/javascript/packages/formatter/src/cli.ts
+++ b/javascript/packages/formatter/src/cli.ts
@@ -1,5 +1,5 @@
 import dedent from "dedent"
-import { readFileSync, writeFileSync, statSync, existsSync, fstatSync } from "fs"
+import { readFileSync, writeFileSync, statSync, existsSync } from "fs"
 import { glob } from "tinyglobby"
 import { resolve, relative } from "path"
 
@@ -156,7 +156,7 @@ export class CLI {
       this.determineProjectPath(positionals)
 
       const file = positionals[0]
-      const isUsingStdin = (!file && this.hasStdinInput()) || file === "-"
+      const isUsingStdin = (!file && !isCheckMode && !process.stdin.isTTY) || file === "-"
 
       if (isInitMode) {
         const configPath = configFile || this.projectPath
@@ -502,18 +502,6 @@ export class CLI {
       console.error(error)
 
       process.exit(1)
-    }
-  }
-
-  private hasStdinInput(): boolean {
-    if (process.stdin.isTTY) return false
-
-    try {
-      const stats = fstatSync(0)
-
-      return stats.isFIFO() || stats.isSocket() || stats.isFile()
-    } catch {
-      return false
     }
   }
 

--- a/javascript/packages/formatter/src/cli.ts
+++ b/javascript/packages/formatter/src/cli.ts
@@ -1,5 +1,5 @@
 import dedent from "dedent"
-import { readFileSync, writeFileSync, statSync, existsSync } from "fs"
+import { readFileSync, writeFileSync, statSync, existsSync, fstatSync } from "fs"
 import { glob } from "tinyglobby"
 import { resolve, relative } from "path"
 
@@ -156,7 +156,7 @@ export class CLI {
       this.determineProjectPath(positionals)
 
       const file = positionals[0]
-      const isUsingStdin = (!file && !process.stdin.isTTY) || file === "-"
+      const isUsingStdin = (!file && this.hasStdinInput()) || file === "-"
 
       if (isInitMode) {
         const configPath = configFile || this.projectPath
@@ -359,19 +359,7 @@ export class CLI {
 
       const formatter = Formatter.from(Herb, config, { preRewriters, postRewriters })
 
-      if (!file && !process.stdin.isTTY) {
-        if (isCheckMode) {
-          console.error("Error: --check mode is not supported with stdin")
-
-          process.exit(1)
-        }
-
-        const source = await this.readStdin()
-        const result = formatter.format(source)
-        const output = result.endsWith('\n') ? result : result + '\n'
-
-        process.stdout.write(output)
-      } else if (file === "-") {
+      if (isUsingStdin) {
         if (isCheckMode) {
           console.error("Error: --check mode is not supported with stdin")
 
@@ -514,6 +502,18 @@ export class CLI {
       console.error(error)
 
       process.exit(1)
+    }
+  }
+
+  private hasStdinInput(): boolean {
+    if (process.stdin.isTTY) return false
+
+    try {
+      const stats = fstatSync(0)
+
+      return stats.isFIFO() || stats.isSocket() || stats.isFile()
+    } catch {
+      return false
     }
   }
 

--- a/javascript/packages/formatter/test/cli.test.ts
+++ b/javascript/packages/formatter/test/cli.test.ts
@@ -278,37 +278,39 @@ describe("CLI Binary", () => {
   })
 
   it("should reject --check with stdin", async () => {
-    const result = await execBinary(["--check"], "<div>test</div>")
+    const result = await execBinary(["--check", "-"], "<div>test</div>")
 
     expectExitCode(result, 1)
     expect(result.stderr).toContain("Error: --check mode is not supported with stdin")
   })
 
   it("should reject -c with stdin", async () => {
-    const result = await execBinary(["-c"], "<div>test</div>")
+    const result = await execBinary(["-c", "-"], "<div>test</div>")
 
     expectExitCode(result, 1)
     expect(result.stderr).toContain("Error: --check mode is not supported with stdin")
   })
 
-  it("should not treat a non-TTY stdin without piped input as stdin", async () => {
-    const directory = "test-non-tty-stdin"
-    const input = '<div><p>   Not formatted   </p></div>'
+  for (const stdin of ["pipe", "ignore"] as const)  {
+    it(`should check configured files with --check when stdin is a non-TTY ${stdin}`, async () => {
+      const directory = `test-non-tty-${stdin}`
+      const input = '<div><p>   Not formatted   </p></div>'
 
-    await mkdir(directory, { recursive: true })
-    await writeFile(join(directory, "unformatted.html.erb"), input)
+      await mkdir(directory, { recursive: true })
+      await writeFile(join(directory, "unformatted.html.erb"), input)
 
-    try {
-      const result = await execBinary(["--check"], undefined, { cwd: directory, stdin: "ignore" })
+      try {
+        const result = await execBinary(["--check"], undefined, { cwd: directory, stdin })
 
-      expect(result.stderr).not.toContain("--check mode is not supported with stdin")
-      expectExitCode(result, 1)
-      expect(result.stdout).toContain("unformatted.html.erb")
-      expect(result.stdout).toContain("not formatted")
-    } finally {
-      await rm(directory, { recursive: true }).catch(() => {})
-    }
-  })
+        expect(result.stderr).not.toContain("--check mode is not supported with stdin")
+        expectExitCode(result, 1)
+        expect(result.stdout).toContain("unformatted.html.erb")
+        expect(result.stdout).toContain("not formatted")
+      } finally {
+        await rm(directory, { recursive: true }).catch(() => {})
+      }
+    })
+  }
 
   it("should pass --check with a non-TTY stdin when all files are formatted", async () => {
     const directory = "test-non-tty-stdin-formatted"
@@ -318,7 +320,7 @@ describe("CLI Binary", () => {
     await writeFile(join(directory, "formatted.html.erb"), input)
 
     try {
-      const result = await execBinary(["--check"], undefined, { cwd: directory, stdin: "ignore" })
+      const result = await execBinary(["--check"], undefined, { cwd: directory, stdin: "pipe" })
 
       expectExitCode(result, 0)
       expect(result.stdout).toContain("all files are properly formatted")

--- a/javascript/packages/formatter/test/cli.test.ts
+++ b/javascript/packages/formatter/test/cli.test.ts
@@ -291,6 +291,42 @@ describe("CLI Binary", () => {
     expect(result.stderr).toContain("Error: --check mode is not supported with stdin")
   })
 
+  it("should not treat a non-TTY stdin without piped input as stdin", async () => {
+    const directory = "test-non-tty-stdin"
+    const input = '<div><p>   Not formatted   </p></div>'
+
+    await mkdir(directory, { recursive: true })
+    await writeFile(join(directory, "unformatted.html.erb"), input)
+
+    try {
+      const result = await execBinary(["--check"], undefined, { cwd: directory, stdin: "ignore" })
+
+      expect(result.stderr).not.toContain("--check mode is not supported with stdin")
+      expectExitCode(result, 1)
+      expect(result.stdout).toContain("unformatted.html.erb")
+      expect(result.stdout).toContain("not formatted")
+    } finally {
+      await rm(directory, { recursive: true }).catch(() => {})
+    }
+  })
+
+  it("should pass --check with a non-TTY stdin when all files are formatted", async () => {
+    const directory = "test-non-tty-stdin-formatted"
+    const input = '<div>\n  <p>Already formatted</p>\n</div>\n'
+
+    await mkdir(directory, { recursive: true })
+    await writeFile(join(directory, "formatted.html.erb"), input)
+
+    try {
+      const result = await execBinary(["--check"], undefined, { cwd: directory, stdin: "ignore" })
+
+      expectExitCode(result, 0)
+      expect(result.stdout).toContain("all files are properly formatted")
+    } finally {
+      await rm(directory, { recursive: true }).catch(() => {})
+    }
+  })
+
   it("should pass --check when file is already formatted", async () => {
     const testFile = "test-formatted.html.erb"
     const input = '<div>\n  <p>Already formatted</p>\n</div>\n'

--- a/javascript/packages/formatter/test/cli/cli-helpers.ts
+++ b/javascript/packages/formatter/test/cli/cli-helpers.ts
@@ -1,10 +1,16 @@
 import { expect } from "vitest"
 import { spawn } from "child_process"
+import { resolve } from "path"
 
 export type ExecResult = {
   stdout: string
   stderr: string
   exitCode: number
+}
+
+export type ExecOptions = {
+  cwd?: string
+  stdin?: "pipe" | "ignore"
 }
 
 export const expectExitCode = (result: ExecResult, expectedCode: number) => {
@@ -20,10 +26,13 @@ export const expectExitCode = (result: ExecResult, expectedCode: number) => {
   }
 }
 
-export const execBinary = (args: string[] = [], input?: string): Promise<ExecResult> => {
-  return new Promise((resolve) => {
-    const child = spawn("node", ["bin/herb-format", ...args], {
-      stdio: ["pipe", "pipe", "pipe"]
+export const execBinary = (args: string[] = [], input?: string, options: ExecOptions = {}): Promise<ExecResult> => {
+  const binary = resolve(process.cwd(), "bin/herb-format")
+
+  return new Promise((resolvePromise) => {
+    const child = spawn("node", [binary, ...args], {
+      cwd: options.cwd,
+      stdio: [options.stdin || "pipe", "pipe", "pipe"]
     })
 
     let stdout = ""
@@ -31,7 +40,7 @@ export const execBinary = (args: string[] = [], input?: string): Promise<ExecRes
 
     const timeout = setTimeout(() => {
       child.kill()
-      resolve({ stdout, stderr, exitCode: 1 })
+      resolvePromise({ stdout, stderr, exitCode: 1 })
     }, 5000)
 
     child.stdout.on("data", (data) => {
@@ -44,13 +53,15 @@ export const execBinary = (args: string[] = [], input?: string): Promise<ExecRes
 
     child.on("close", (code) => {
       clearTimeout(timeout)
-      resolve({ stdout, stderr, exitCode: code || 0 })
+      resolvePromise({ stdout, stderr, exitCode: code || 0 })
     })
 
-    if (input) {
-      child.stdin.write(input)
-    }
+    if (child.stdin) {
+      if (input) {
+        child.stdin.write(input)
+      }
 
-    child.stdin.end()
+      child.stdin.end()
+    }
   })
 }


### PR DESCRIPTION
Running `herb-format --check` with no file arguments works locally but fails on every CI runner:

```
⚠️  Experimental Preview: The formatter is in early development.

Using 1 pre-format rewriter:
  • tailwind-class-sorter (built-in)

Error: --check mode is not supported with stdin
```

The CLI decided it was reading from stdin based on `!process.stdin.isTTY`:

```ts
const isUsingStdin = (!file && !process.stdin.isTTY) || file === "-"
```

Found while running the formatter in CI on [rubyevents/rubyevents](https://github.com/rubyevents/rubyevents/actions/runs/30719954644/job/91421981242).