### PR TITLE
Linter: Implement `actionview-prefer-collection-render` rule

### DIFF
--- a/javascript/packages/linter/docs/rules/README.md
+++ b/javascript/packages/linter/docs/rules/README.md
@@ -23,6 +23,7 @@ This page contains documentation for all Herb Linter rules.
 - [`actionview-no-silent-render`](./actionview-no-silent-render.md) - Disallow calling `render` without outputting the result
 - [`actionview-no-unnecessary-tag-attributes`](./actionview-no-unnecessary-tag-attributes.md) - Disallow unnecessary attributes on Action View tag helpers
 - [`actionview-no-void-element-content`](./actionview-no-void-element-content.md) - Disallow content arguments for void Action View elements
+- [`actionview-prefer-collection-render`](./actionview-prefer-collection-render.md) - Prefer collection rendering over rendering a partial in a loop
 - [`actionview-strict-locals-first-line`](./actionview-strict-locals-first-line.md) - Require strict locals on the first line of partials with a blank line after.
 - [`actionview-strict-locals-partial-only`](./actionview-strict-locals-partial-only.md) - Only allow strict local definitions in partial files.
 

--- a/javascript/packages/linter/docs/rules/actionview-prefer-collection-render.md
+++ b/javascript/packages/linter/docs/rules/actionview-prefer-collection-render.md
@@ -6,6 +6,30 @@
 
 Prefer `render partial: "...", collection: ...` over calling `render` for a single partial inside an `each` loop.
 
+The reported message contains the exact replacement tag, built from the loop's receiver and the partial being rendered, so it can be pasted over the loop:
+
+```erb
+<% @users.each do |user| %>
+  <%= render "user", user: user %>
+<% end %>
+```
+
+```
+Prefer `<%= render partial: "user", collection: @users %>` over rendering a partial once per iteration. Collection rendering builds the partial once instead of for every item.
+```
+
+Rendering an object directly reports the shorthand collection form instead:
+
+```erb
+<% @users.each do |user| %>
+  <%= render user %>
+<% end %>
+```
+
+```
+Prefer `<%= render @users %>` over rendering a partial once per iteration. Collection rendering builds the partial once instead of for every item.
+```
+
 ## Rationale
 
 When a partial is rendered inside a loop, Action View looks the template up and sets up a fresh local scope on every iteration. Collection rendering does that work once and then reuses it for every element, so it is meaningfully faster for anything but the shortest collections.

--- a/javascript/packages/linter/docs/rules/actionview-prefer-collection-render.md
+++ b/javascript/packages/linter/docs/rules/actionview-prefer-collection-render.md
@@ -1,0 +1,71 @@
+# Linter Rule: Prefer collection rendering over rendering a partial in a loop
+
+**Rule:** `actionview-prefer-collection-render`
+
+## Description
+
+Prefer `render partial: "...", collection: ...` over calling `render` for a single partial inside an `each` loop.
+
+## Rationale
+
+When a partial is rendered inside a loop, Action View looks the template up and sets up a fresh local scope on every iteration. Collection rendering does that work once and then reuses it for every element, so it is meaningfully faster for anything but the shortest collections.
+
+Collection rendering also passes each element as a local named after the partial, and provides a `<partial>_counter` local, which removes the need to thread the loop variable through by hand.
+
+Because the rewrite emits the partial and nothing else, this rule only fires when the loop body is exactly one output `render` and the only local passed is the block argument. Loops that wrap the partial in markup, pass extra locals, or use a block argument the partial doesn't receive are left alone, since collection rendering cannot express them.
+
+## Examples
+
+### ✅ Good
+
+```erb
+<%= render partial: "user", collection: @users %>
+```
+
+```erb
+<%= render @users %>
+```
+
+Loops that do more than render a single partial are not flagged, because collection rendering cannot express them:
+
+```erb
+<% @users.each do |user| %>
+  <li><%= render "user", user: user %></li>
+<% end %>
+```
+
+```erb
+<% @users.each do |user| %>
+  <%= render "user", user: user, admin: true %>
+<% end %>
+```
+
+```erb
+<% @users.each_with_index do |user, index| %>
+  <%= render "user", user: user %>
+<% end %>
+```
+
+### 🚫 Bad
+
+```erb
+<% @users.each do |user| %>
+  <%= render "user", user: user %>
+<% end %>
+```
+
+```erb
+<% @users.each do |user| %>
+  <%= render partial: "user", locals: { user: user } %>
+<% end %>
+```
+
+```erb
+<% @users.each do |user| %>
+  <%= render user %>
+<% end %>
+```
+
+## References
+
+- [Action View Partials: Rendering Collections](https://guides.rubyonrails.org/layouts_and_rendering.html#rendering-collections)

--- a/javascript/packages/linter/src/rules.ts
+++ b/javascript/packages/linter/src/rules.ts
@@ -15,6 +15,7 @@ import { ActionViewNoSilentHelperRule } from "./rules/actionview-no-silent-helpe
 import { ActionViewNoSilentRenderRule } from "./rules/actionview-no-silent-render.js"
 import { ActionViewNoUnnecessaryTagAttributesRule } from "./rules/actionview-no-unnecessary-tag-attributes.js"
 import { ActionViewNoVoidElementContentRule } from "./rules/actionview-no-void-element-content.js"
+import { ActionViewPreferCollectionRenderRule } from "./rules/actionview-prefer-collection-render.js"
 import { ActionViewStrictLocalsFirstLineRule } from "./rules/actionview-strict-locals-first-line.js"
 import { ActionViewStrictLocalsPartialOnlyRule } from "./rules/actionview-strict-locals-partial-only.js"
 
@@ -128,6 +129,7 @@ export const rules: RuleClass[] = [
   ActionViewNoSilentRenderRule,
   ActionViewNoUnnecessaryTagAttributesRule,
   ActionViewNoVoidElementContentRule,
+  ActionViewPreferCollectionRenderRule,
   ActionViewStrictLocalsFirstLineRule,
   ActionViewStrictLocalsPartialOnlyRule,
 

--- a/javascript/packages/linter/src/rules/actionview-prefer-collection-render.ts
+++ b/javascript/packages/linter/src/rules/actionview-prefer-collection-render.ts
@@ -1,0 +1,108 @@
+import { ParserRule } from "../types.js"
+import { BaseRuleVisitor } from "./rule-utils.js"
+import { isERBOutputNode, isNode, HTMLTextNode } from "@herb-tools/core"
+
+import type { ERBIterationBlockNode, ERBRenderNode, Node, ParseResult, ParserOptions } from "@herb-tools/core"
+import type { FullRuleConfig, LintContext, UnboundLintOffense } from "../types.js"
+
+class PreferCollectionRenderVisitor extends BaseRuleVisitor {
+  visitERBIterationBlockNode(node: ERBIterationBlockNode): void {
+    this.checkIterationBlock(node)
+
+    this.visitChildNodes(node)
+  }
+
+  private checkIterationBlock(node: ERBIterationBlockNode): void {
+    if (node.message?.value !== "each") return
+
+    const receiver = node.receiver?.value
+    if (!receiver) return
+
+    const blockArgument = this.singleBlockArgumentName(node)
+    if (!blockArgument) return
+
+    const render = this.singleRenderNodeInBody(node)
+    if (!render) return
+
+    const suggestion = this.collectionRenderFor(render, receiver, blockArgument)
+    if (!suggestion) return
+
+    this.addOffense(
+      `Prefer \`${suggestion}\` over rendering a partial once per iteration. Collection rendering builds the partial once instead of for every item.`,
+      node.location,
+    )
+  }
+
+  private singleBlockArgumentName(node: ERBIterationBlockNode): string | null {
+    if (node.block_arguments.length !== 1) return null
+
+    const argument = node.block_arguments[0] as { kind?: string; name?: { value?: string } }
+
+    if (argument.kind !== "positional") return null
+
+    return argument.name?.value ?? null
+  }
+
+  private singleRenderNodeInBody(node: ERBIterationBlockNode): ERBRenderNode | null {
+    const body = node.body.filter(child => !this.isWhitespaceOnlyText(child))
+
+    if (body.length !== 1) return null
+
+    const [child] = body
+
+    if (child.type !== "AST_ERB_RENDER_NODE") return null
+
+    const render = child as ERBRenderNode
+
+    return isERBOutputNode(render) ? render : null
+  }
+
+  private isWhitespaceOnlyText(node: Node): boolean {
+    return isNode(node, HTMLTextNode) && node.content.trim() === ""
+  }
+
+  private collectionRenderFor(render: ERBRenderNode, receiver: string, blockArgument: string): string | null {
+    const keywords = render.keywords
+
+    if (!keywords) return null
+    if (keywords.object?.value === blockArgument) return `<%= render ${receiver} %>`
+
+    const partial = keywords.partial?.value
+    if (!partial) return null
+
+    const locals = keywords.locals ?? []
+    if (locals.length !== 1) return null
+
+    const [local] = locals as Array<{ value?: { content?: string } }>
+    if (local.value?.content !== blockArgument) return null
+
+    return `<%= render partial: "${partial}", collection: ${receiver} %>`
+  }
+}
+
+export class ActionViewPreferCollectionRenderRule extends ParserRule {
+  static ruleName = "actionview-prefer-collection-render"
+  static introducedIn = this.version("unreleased")
+
+  get defaultConfig(): FullRuleConfig {
+    return {
+      enabled: true,
+      severity: "error"
+    }
+  }
+
+  get parserOptions(): Partial<ParserOptions> {
+    return {
+      iteration_nodes: true,
+      render_nodes: true,
+    }
+  }
+
+  check(result: ParseResult, context?: Partial<LintContext>): UnboundLintOffense[] {
+    const visitor = new PreferCollectionRenderVisitor(this.ruleName, context)
+
+    visitor.visit(result.value)
+
+    return visitor.offenses
+  }
+}

--- a/javascript/packages/linter/src/rules/index.ts
+++ b/javascript/packages/linter/src/rules/index.ts
@@ -20,6 +20,7 @@ export * from "./actionview-no-silent-helper.js"
 export * from "./actionview-no-silent-render.js"
 export * from "./actionview-no-unnecessary-tag-attributes.js"
 export * from "./actionview-no-void-element-content.js"
+export * from "./actionview-prefer-collection-render.js"
 export * from "./actionview-strict-locals-first-line.js"
 export * from "./actionview-strict-locals-partial-only.js"
 

--- a/javascript/packages/linter/test/__snapshots__/cli.test.ts.snap
+++ b/javascript/packages/linter/test/__snapshots__/cli.test.ts.snap
@@ -26,7 +26,7 @@ test/fixtures/all-rules.html.erb:
   Checked      1 file
   Offenses     6 warnings (6 offenses across 1 file)
   Fixable      0 offenses
-  Rules        103 enabled | all rules via --all-rules"
+  Rules        104 enabled | all rules via --all-rules"
 `;
 
 exports[`CLI Output Formatting > --all-rules > reports nothing for the fixture with the default rule set 1`] = `
@@ -38,7 +38,7 @@ exports[`CLI Output Formatting > --all-rules > reports nothing for the fixture w
   Checked      1 file
   Offenses     0 offenses
   Fixable      0 offenses
-  Rules        88 enabled | 15 not enabled"
+  Rules        89 enabled | 15 not enabled"
 `;
 
 exports[`CLI Output Formatting > --ignore-disable-comments 1`] = `
@@ -152,7 +152,7 @@ test/fixtures/ignored.html.erb:8:8
   Offenses     5 errors | 2 warnings (7 offenses across 1 file)
   Note         3 additional offenses reported (would have been ignored)
   Fixable      7 offenses | 4 autocorrectable using \`--fix\`
-  Rules        88 enabled | 15 not enabled"
+  Rules        89 enabled | 15 not enabled"
 `;
 
 exports[`CLI Output Formatting > Excluded Files > skips excluded file in subdirectory with README.md project indicator 1`] = `
@@ -218,7 +218,7 @@ test/fixtures/test-file-with-errors.html.erb:2:22
   Checked      1 file
   Offenses     2 errors | 1 warning (3 offenses across 1 file)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        88 enabled | 15 not enabled"
+  Rules        89 enabled | 15 not enabled"
 `;
 
 exports[`CLI Output Formatting > GitHub Actions format includes rule codes 1`] = `
@@ -243,7 +243,7 @@ test/fixtures/no-trailing-newline.html.erb:1:29
   Checked      1 file
   Offenses     1 error | 0 warnings (1 offense across 1 file)
   Fixable      1 offense | 1 autocorrectable using \`--fix\`
-  Rules        88 enabled | 15 not enabled"
+  Rules        89 enabled | 15 not enabled"
 `;
 
 exports[`CLI Output Formatting > GitHub Actions format includes rule codes 2`] = `
@@ -307,7 +307,7 @@ test/fixtures/erb-no-extra-whitespace-inside-tags.html.erb:1:4
   Checked      1 file
   Offenses     4 errors | 0 warnings (4 offenses across 1 file)
   Fixable      4 offenses | 3 autocorrectable using \`--fix\`
-  Rules        88 enabled | 15 not enabled"
+  Rules        89 enabled | 15 not enabled"
 `;
 
 exports[`CLI Output Formatting > Ignores disabled rules 1`] = `
@@ -348,7 +348,7 @@ test/fixtures/ignored.html.erb:6:14
   Checked      1 file
   Offenses     2 errors | 0 warnings | 3 ignored (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        88 enabled | 15 not enabled"
+  Rules        89 enabled | 15 not enabled"
 `;
 
 exports[`CLI Output Formatting > allows tag.attributes in attribute position 1`] = `
@@ -387,7 +387,7 @@ test/fixtures/tag-attributes.html.erb:5:0
   Checked      1 file
   Offenses     2 warnings (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        88 enabled | 15 not enabled"
+  Rules        89 enabled | 15 not enabled"
 `;
 
 exports[`CLI Output Formatting > diplays only parsers errors if one is present 1`] = `
@@ -413,7 +413,7 @@ test/fixtures/parser-errors.html.erb:2:16
   Checked      1 file
   Offenses     1 error | 0 warnings (1 offense across 1 file)
   Fixable      0 offenses
-  Rules        88 enabled | 15 not enabled"
+  Rules        89 enabled | 15 not enabled"
 `;
 
 exports[`CLI Output Formatting > displays most violated rules with multiple offenses 1`] = `
@@ -628,7 +628,7 @@ test/fixtures/multiple-rule-offenses.html.erb:4:7
   Checked      1 file
   Offenses     8 errors | 6 warnings (14 offenses across 1 file)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        88 enabled | 15 not enabled"
+  Rules        89 enabled | 15 not enabled"
 `;
 
 exports[`CLI Output Formatting > displays rule offenses when showing all rules 1`] = `
@@ -725,7 +725,7 @@ test/fixtures/few-rule-offenses.html.erb:6:0
   Checked      1 file
   Offenses     4 errors | 2 warnings (6 offenses across 1 file)
   Fixable      6 offenses | 3 autocorrectable using \`--fix\`
-  Rules        88 enabled | 15 not enabled"
+  Rules        89 enabled | 15 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats GitHub Actions output correctly for bad file 1`] = `
@@ -764,7 +764,7 @@ test/fixtures/bad-file.html.erb:1:16
   Checked      1 file
   Offenses     2 errors | 0 warnings (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        88 enabled | 15 not enabled"
+  Rules        89 enabled | 15 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats GitHub Actions output correctly for clean file 1`] = `
@@ -776,7 +776,7 @@ exports[`CLI Output Formatting > formats GitHub Actions output correctly for cle
   Checked      1 file
   Offenses     0 offenses
   Fixable      0 offenses
-  Rules        88 enabled | 15 not enabled"
+  Rules        89 enabled | 15 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats GitHub Actions output correctly for file with errors 1`] = `
@@ -836,7 +836,7 @@ test/fixtures/test-file-with-errors.html.erb:2:22
   Checked      1 file
   Offenses     2 errors | 1 warning (3 offenses across 1 file)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        88 enabled | 15 not enabled"
+  Rules        89 enabled | 15 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats GitHub Actions output with --format=github option 1`] = `
@@ -875,7 +875,7 @@ test/fixtures/test-file-simple.html.erb:2:22
   Checked      1 file
   Offenses     2 errors | 0 warnings (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        88 enabled | 15 not enabled"
+  Rules        89 enabled | 15 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats JSON output correctly for bad file 1`] = `
@@ -922,7 +922,7 @@ exports[`CLI Output Formatting > formats JSON output correctly for bad file 1`] 
   "summary": {
     "filesChecked": 1,
     "filesWithOffenses": 1,
-    "ruleCount": 88,
+    "ruleCount": 89,
     "totalErrors": 2,
     "totalHints": 0,
     "totalIgnored": 0,
@@ -943,7 +943,7 @@ exports[`CLI Output Formatting > formats JSON output correctly for clean file 1`
   "summary": {
     "filesChecked": 1,
     "filesWithOffenses": 0,
-    "ruleCount": 88,
+    "ruleCount": 89,
     "totalErrors": 0,
     "totalHints": 0,
     "totalIgnored": 0,
@@ -1016,7 +1016,7 @@ exports[`CLI Output Formatting > formats JSON output correctly for file with err
   "summary": {
     "filesChecked": 1,
     "filesWithOffenses": 1,
-    "ruleCount": 88,
+    "ruleCount": 89,
     "totalErrors": 2,
     "totalHints": 0,
     "totalIgnored": 0,
@@ -1079,7 +1079,7 @@ test/fixtures/test-file-with-errors.html.erb:2:22
   Checked      1 file
   Offenses     2 errors | 1 warning (3 offenses across 1 file)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        88 enabled | 15 not enabled"
+  Rules        89 enabled | 15 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats simple output correctly 1`] = `
@@ -1098,7 +1098,7 @@ test/fixtures/test-file-simple.html.erb:
   Checked      1 file
   Offenses     2 errors | 0 warnings (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        88 enabled | 15 not enabled"
+  Rules        89 enabled | 15 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats simple output for bad-file correctly 1`] = `
@@ -1117,7 +1117,7 @@ test/fixtures/bad-file.html.erb:
   Checked      1 file
   Offenses     2 errors | 0 warnings (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        88 enabled | 15 not enabled"
+  Rules        89 enabled | 15 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats success output correctly 1`] = `
@@ -1129,7 +1129,7 @@ exports[`CLI Output Formatting > formats success output correctly 1`] = `
   Checked      1 file
   Offenses     0 offenses
   Fixable      0 offenses
-  Rules        88 enabled | 15 not enabled"
+  Rules        89 enabled | 15 not enabled"
 `;
 
 exports[`CLI Output Formatting > handles boolean attributes 1`] = `
@@ -1141,7 +1141,7 @@ exports[`CLI Output Formatting > handles boolean attributes 1`] = `
   Checked      1 file
   Offenses     0 offenses
   Fixable      0 offenses
-  Rules        88 enabled | 15 not enabled"
+  Rules        89 enabled | 15 not enabled"
 `;
 
 exports[`CLI Output Formatting > handles multiple errors correctly 1`] = `
@@ -1176,7 +1176,7 @@ test/fixtures/bad-file.html.erb:1:16
   Checked      1 file
   Offenses     2 errors | 0 warnings (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        88 enabled | 15 not enabled"
+  Rules        89 enabled | 15 not enabled"
 `;
 
 exports[`CLI Output Formatting > herb:disable rules 1`] = `
@@ -1308,7 +1308,7 @@ test/fixtures/disabled-1.html.erb:14:19
   Checked      1 file
   Offenses     2 errors | 6 warnings | 8 ignored (8 offenses across 1 file)
   Fixable      8 offenses | 1 autocorrectable using \`--fix\`
-  Rules        88 enabled | 15 not enabled"
+  Rules        89 enabled | 15 not enabled"
 `;
 
 exports[`CLI Output Formatting > herb:disable rules 2`] = `
@@ -1511,7 +1511,7 @@ test/fixtures/disabled-2.html.erb:2:44
   Checked      1 file
   Offenses     6 errors | 7 warnings | 5 ignored (13 offenses across 1 file)
   Fixable      13 offenses | 6 autocorrectable using \`--fix\`
-  Rules        88 enabled | 15 not enabled"
+  Rules        89 enabled | 15 not enabled"
 `;
 
 exports[`CLI Output Formatting > uses GitHub Actions format by default when GITHUB_ACTIONS is true 1`] = `
@@ -1571,5 +1571,5 @@ test/fixtures/test-file-with-errors.html.erb:2:22
   Checked      1 file
   Offenses     2 errors | 1 warning (3 offenses across 1 file)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        88 enabled | 15 not enabled"
+  Rules        89 enabled | 15 not enabled"
 `;

--- a/javascript/packages/linter/test/rules/actionview-prefer-collection-render.test.ts
+++ b/javascript/packages/linter/test/rules/actionview-prefer-collection-render.test.ts
@@ -1,0 +1,152 @@
+import { describe, it } from "vitest"
+import dedent from "dedent"
+
+import { ActionViewPreferCollectionRenderRule } from "../../src/rules/actionview-prefer-collection-render"
+import { createLinterTest } from "../helpers/linter-test-helper.js"
+
+const { expectNoOffenses, expectError, assertOffenses } = createLinterTest(ActionViewPreferCollectionRenderRule)
+
+describe("actionview-prefer-collection-render", () => {
+  it("flags a partial rendered once per iteration with an implicit local", () => {
+    const html = dedent`
+      <% @users.each do |user| %>
+        <%= render "user", user: user %>
+      <% end %>
+    `
+
+    expectError('Prefer `<%= render partial: "user", collection: @users %>` over rendering a partial once per iteration. Collection rendering builds the partial once instead of for every item.')
+
+    assertOffenses(html)
+  })
+
+  it("flags a partial rendered with an explicit locals hash", () => {
+    const html = dedent`
+      <% @users.each do |user| %>
+        <%= render partial: "user", locals: { user: user } %>
+      <% end %>
+    `
+
+    expectError('Prefer `<%= render partial: "user", collection: @users %>` over rendering a partial once per iteration. Collection rendering builds the partial once instead of for every item.')
+
+    assertOffenses(html)
+  })
+
+  it("flags the object shorthand and suggests the shorthand collection form", () => {
+    const html = dedent`
+      <% @users.each do |user| %>
+        <%= render user %>
+      <% end %>
+    `
+
+    expectError('Prefer `<%= render @users %>` over rendering a partial once per iteration. Collection rendering builds the partial once instead of for every item.')
+
+    assertOffenses(html)
+  })
+
+  it("uses the full receiver expression in the suggestion", () => {
+    const html = dedent`
+      <% current_user.posts.each do |post| %>
+        <%= render "post", post: post %>
+      <% end %>
+    `
+
+    expectError('Prefer `<%= render partial: "post", collection: current_user.posts %>` over rendering a partial once per iteration. Collection rendering builds the partial once instead of for every item.')
+
+    assertOffenses(html)
+  })
+
+  it("does not flag a loop that already uses collection rendering", () => {
+    expectNoOffenses(dedent`
+      <%= render partial: "user", collection: @users %>
+    `)
+  })
+
+  it("does not flag when the body has markup around the render", () => {
+    expectNoOffenses(dedent`
+      <% @users.each do |user| %>
+        <li><%= render "user", user: user %></li>
+      <% end %>
+    `)
+  })
+
+  it("does not flag when the body renders more than the partial", () => {
+    expectNoOffenses(dedent`
+      <% @users.each do |user| %>
+        <%= render "user", user: user %>
+        <%= user.email %>
+      <% end %>
+    `)
+  })
+
+  it("does not flag when the local is not the block argument", () => {
+    expectNoOffenses(dedent`
+      <% @users.each do |user| %>
+        <%= render "user", user: current_user %>
+      <% end %>
+    `)
+  })
+
+  it("does not flag when extra locals are passed", () => {
+    expectNoOffenses(dedent`
+      <% @users.each do |user| %>
+        <%= render "user", user: user, admin: true %>
+      <% end %>
+    `)
+  })
+
+  it("does not flag when the block takes more than one argument", () => {
+    expectNoOffenses(dedent`
+      <% @users.each_with_index do |user, index| %>
+        <%= render "user", user: user %>
+      <% end %>
+    `)
+  })
+
+  it("does not flag iteration methods other than each", () => {
+    expectNoOffenses(dedent`
+      <% @users.map do |user| %>
+        <%= render "user", user: user %>
+      <% end %>
+    `)
+  })
+
+  it("does not flag a silent render", () => {
+    expectNoOffenses(dedent`
+      <% @users.each do |user| %>
+        <% render "user", user: user %>
+      <% end %>
+    `)
+  })
+
+  it("does not flag a loop without a render", () => {
+    expectNoOffenses(dedent`
+      <% @users.each do |user| %>
+        <%= user.name %>
+      <% end %>
+    `)
+  })
+
+  it("does not flag a block that is not an iteration", () => {
+    expectNoOffenses(dedent`
+      <%= form_with model: @user do |form| %>
+        <%= render "field", field: form %>
+      <% end %>
+    `)
+  })
+
+  it("flags the inner loop of nested iteration", () => {
+    const html = dedent`
+      <% @groups.each do |group| %>
+        <h2><%= group.name %></h2>
+
+        <% group.users.each do |user| %>
+          <%= render "user", user: user %>
+        <% end %>
+      <% end %>
+    `
+
+    expectError('Prefer `<%= render partial: "user", collection: group.users %>` over rendering a partial once per iteration. Collection rendering builds the partial once instead of for every item.')
+
+    assertOffenses(html)
+  })
+})


### PR DESCRIPTION
This pull request implements a new `actionview-prefer-collection-render` rule that flags a partial rendered once per iteration and suggests the collection rendering form instead.

```erb
<% @users.each do |user| %>
  <%= render "user", user: user %>
<% end %>
```

```
Prefer `<%= render partial: "user", collection: @users %>` over rendering a partial once per iteration. Collection rendering builds the partial once instead of for every item.
```

Rendering a partial inside a loop makes Action View look the template up and set up a fresh local scope on every iteration. Collection rendering does that work once and reuses it for every element, so this is a performance difference rather than a stylistic preference. 


Follow up on #1912.