### PR TITLE
Linter: Tag `erb-no-unused-block-argument` offenses as unnecessary

### DIFF
--- a/javascript/packages/linter/docs/rules/erb-no-unused-block-argument.md
+++ b/javascript/packages/linter/docs/rules/erb-no-unused-block-argument.md
@@ -46,6 +46,8 @@ The above is still reported, because nothing in Ruby refers to `user`. Matching 
 
 Only positional and splat arguments are reported. An unused `&block` or `**options` reads differently and is left alone.
 
+Offenses are tagged as `unnecessary`, so an editor greys the argument out the way it does for other unused code, while the severity still fails a lint run in CI.
+
 ## Examples
 
 ### ✅ Good

--- a/javascript/packages/linter/src/rules/erb-no-unused-block-argument.ts
+++ b/javascript/packages/linter/src/rules/erb-no-unused-block-argument.ts
@@ -33,6 +33,9 @@ class NoUnusedBlockArgumentVisitor extends BaseRuleVisitor {
       this.addOffense(
         `Block argument \`${name}\` is never used. Remove it, or prefix it with an underscore as \`_${name}\` to show it is intentionally unused.`,
         parameter.location,
+        undefined,
+        undefined,
+        ["unnecessary"],
       )
     }
   }

--- a/javascript/packages/linter/test/rules/erb-no-shadowed-block-argument.test.ts
+++ b/javascript/packages/linter/test/rules/erb-no-shadowed-block-argument.test.ts
@@ -152,6 +152,81 @@ describe("erb-no-shadowed-block-argument", () => {
     assertOffenses(html)
   })
 
+  it("flags shadowing across a while loop boundary", () => {
+    const html = dedent`
+      <% @groups.each do |item| %>
+        <% while condition %>
+          <% @items.each do |item| %>
+            <%= item %>
+          <% end %>
+        <% end %>
+      <% end %>
+    `
+
+    expectError(shadows("item"))
+
+    assertOffenses(html)
+  })
+
+  it("flags shadowing across an until loop boundary", () => {
+    const html = dedent`
+      <% @groups.each do |item| %>
+        <% until condition %>
+          <% @items.each do |item| %>
+            <%= item %>
+          <% end %>
+        <% end %>
+      <% end %>
+    `
+
+    expectError(shadows("item"))
+
+    assertOffenses(html)
+  })
+
+  it("flags shadowing across an if boundary", () => {
+    const html = dedent`
+      <% @groups.each do |item| %>
+        <% if condition %>
+          <% @items.each do |item| %>
+            <%= item %>
+          <% end %>
+        <% end %>
+      <% end %>
+    `
+
+    expectError(shadows("item"))
+
+    assertOffenses(html)
+  })
+
+  it("flags shadowing across a case boundary", () => {
+    const html = dedent`
+      <% @groups.each do |item| %>
+        <% case value %>
+        <% when 1 %>
+          <% @items.each do |item| %>
+            <%= item %>
+          <% end %>
+        <% end %>
+      <% end %>
+    `
+
+    expectError(shadows("item"))
+
+    assertOffenses(html)
+  })
+
+  it("does not flag a while loop, which binds nothing", () => {
+    expectNoOffenses(dedent`
+      <% @groups.each do |item| %>
+        <% while item.pending? %>
+          <%= item %>
+        <% end %>
+      <% end %>
+    `)
+  })
+
   it("does not flag distinct names", () => {
     expectNoOffenses(dedent`
       <% @groups.each do |group| %>

--- a/javascript/packages/linter/test/rules/erb-no-unused-block-argument.test.ts
+++ b/javascript/packages/linter/test/rules/erb-no-unused-block-argument.test.ts
@@ -1,5 +1,8 @@
-import { describe, it } from "vitest"
+import { describe, it, expect } from "vitest"
 import dedent from "dedent"
+
+import { Herb } from "@herb-tools/node-wasm"
+import { Linter } from "../../src/linter"
 
 import { ERBNoUnusedBlockArgumentRule } from "../../src/rules/erb-no-unused-block-argument"
 import { createLinterTest } from "../helpers/linter-test-helper.js"
@@ -57,6 +60,47 @@ describe("erb-no-unused-block-argument", () => {
       <% @users.each do |user| %>
         <% if user.admin? %>
           <p>admin</p>
+        <% end %>
+      <% end %>
+    `)
+  })
+
+  it("does not flag a block argument used inside a while loop", () => {
+    expectNoOffenses(dedent`
+      <% @users.each do |user| %>
+        <% while user.pending? %>
+          <p>waiting</p>
+        <% end %>
+      <% end %>
+    `)
+  })
+
+  it("does not flag a block argument used inside an until loop", () => {
+    expectNoOffenses(dedent`
+      <% @users.each do |user| %>
+        <% until user.ready? %>
+          <p>waiting</p>
+        <% end %>
+      <% end %>
+    `)
+  })
+
+  it("does not flag a block argument used inside a case statement", () => {
+    expectNoOffenses(dedent`
+      <% @users.each do |user| %>
+        <% case user.role %>
+        <% when "admin" %>
+          <p>admin</p>
+        <% end %>
+      <% end %>
+    `)
+  })
+
+  it("does not flag a block argument used inside a for loop", () => {
+    expectNoOffenses(dedent`
+      <% @users.each do |user| %>
+        <% for role in user.roles %>
+          <%= role %>
         <% end %>
       <% end %>
     `)
@@ -269,5 +313,20 @@ describe("erb-no-unused-block-argument", () => {
     expectError('Block argument `group` is never used. Remove it, or prefix it with an underscore as `_group` to show it is intentionally unused.')
 
     assertOffenses(html)
+  })
+
+  it("tags the offense as unnecessary so editors grey the argument out", async () => {
+    await Herb.load()
+
+    const linter = new Linter(Herb, [ERBNoUnusedBlockArgumentRule])
+    const result = linter.lint(dedent`
+      <% @users.each do |user| %>
+        <p>Hello</p>
+      <% end %>
+    `)
+
+    expect(result.offenses).toHaveLength(1)
+    expect(result.offenses[0].tags).toEqual(["unnecessary"])
+    expect(result.offenses[0].severity).toBe("error")
   })
 })


### PR DESCRIPTION
Follow up on #1958

This pull request tags `erb-no-unused-block-argument` offenses with the `unnecessary` diagnostic tag, so an unused block argument renders in an editor the way other unused code does.

<img width="635" height="279" alt="CleanShot 2026-08-02 at 11 51 44@2x" src="https://github.com/user-attachments/assets/a2345d6e-a7d3-4c11-9984-1c5c7b830771" />
