### PR TITLE
Linter: Make cleanup rules less intrusive in the editor

### DIFF
--- a/javascript/packages/linter/docs/rules/erb-no-unused-block-argument.md
+++ b/javascript/packages/linter/docs/rules/erb-no-unused-block-argument.md
@@ -46,7 +46,11 @@ The above is still reported, because nothing in Ruby refers to `user`. Matching 
 
 Only positional and splat arguments are reported. An unused `&block` or `**options` reads differently and is left alone.
 
-Offenses are tagged as `unnecessary`, so an editor greys the argument out the way it does for other unused code, while the severity still fails a lint run in CI.
+Offenses are tagged as `unnecessary`, so an editor greys the argument out the way it does for other unused code.
+
+The severity is also split by mode, reported as `info` in the editor and an `error` on the command line:
+
+An unused argument is worth cleaning up but is not a reason to interrupt someone mid-edit, so it stays quiet in the editor while still failing a lint run in CI.
 
 ## Examples
 

--- a/javascript/packages/linter/src/rules/actionview-no-unnecessary-tag-attributes.ts
+++ b/javascript/packages/linter/src/rules/actionview-no-unnecessary-tag-attributes.ts
@@ -1,5 +1,6 @@
 import { ParserRule, BaseAutofixContext, Mutable } from "../types.js"
 import { BaseRuleVisitor, findParent } from "./rule-utils.js"
+
 import { isTagAttributesCall } from "./action-view-utils.js"
 import { getTagLocalName, isHTMLOpenTagNode, isERBContentNode, isERBOutputNode, isHTMLAttributeNode, isWhitespaceNode, isHTMLElementNode, createERBOutputNode, createERBSilentNode } from "@herb-tools/core"
 
@@ -65,6 +66,8 @@ class ActionViewNoUnnecessaryTagAttributesVisitor extends BaseRuleVisitor<Unnece
         tagName,
         isVoid: node.is_void,
       },
+      undefined,
+      ["unnecessary"],
     )
   }
 }

--- a/javascript/packages/linter/src/rules/erb-no-commented-out-output-tags.ts
+++ b/javascript/packages/linter/src/rules/erb-no-commented-out-output-tags.ts
@@ -24,7 +24,10 @@ class ERBNoCommentedOutOutputTagsVisitor extends BaseRuleVisitor {
 
     this.addOffense(
       `\`${commentedTag}\` looks like a temporarily commented ERB output tag. Remove it, or restore it to \`${originalTag}\` if it's still needed.`,
-      openTag.location,
+      node.location,
+      undefined,
+      undefined,
+      ["unnecessary"],
     )
   }
 }

--- a/javascript/packages/linter/src/rules/erb-no-empty-tags.ts
+++ b/javascript/packages/linter/src/rules/erb-no-empty-tags.ts
@@ -17,6 +17,9 @@ class ERBNoEmptyTagsVisitor extends BaseRuleVisitor {
     this.addOffense(
       "ERB tag should not be empty. Remove empty ERB tags or add content.",
       node.location,
+      undefined,
+      undefined,
+      ["unnecessary"],
     )
   }
 }
@@ -28,7 +31,10 @@ export class ERBNoEmptyTagsRule extends ParserRule {
   get defaultConfig(): FullRuleConfig {
     return {
       enabled: true,
-      severity: "error"
+      severity: {
+        cli: "error",
+        editor: "info",
+      }
     }
   }
 

--- a/javascript/packages/linter/src/rules/erb-no-extra-newline.ts
+++ b/javascript/packages/linter/src/rules/erb-no-extra-newline.ts
@@ -48,7 +48,10 @@ export class ERBNoExtraNewLineRule extends SourceRule {
   get defaultConfig(): FullRuleConfig {
     return {
       enabled: true,
-      severity: "error"
+      severity: {
+        cli: "error",
+        editor: "info",
+      }
     }
   }
 

--- a/javascript/packages/linter/src/rules/erb-no-trailing-whitespace.ts
+++ b/javascript/packages/linter/src/rules/erb-no-trailing-whitespace.ts
@@ -73,7 +73,10 @@ export class ERBNoTrailingWhitespaceRule extends ParserRule<ERBNoTrailingWhitesp
   get defaultConfig(): FullRuleConfig {
     return {
       enabled: true,
-      severity: "error",
+      severity: {
+        cli: "error",
+        editor: "info",
+      },
     }
   }
 

--- a/javascript/packages/linter/src/rules/erb-no-unused-block-argument.ts
+++ b/javascript/packages/linter/src/rules/erb-no-unused-block-argument.ts
@@ -80,7 +80,10 @@ export class ERBNoUnusedBlockArgumentRule extends ParserRule {
   get defaultConfig(): FullRuleConfig {
     return {
       enabled: true,
-      severity: "error"
+      severity: {
+        cli: "error",
+        editor: "info",
+      }
     }
   }
 

--- a/javascript/packages/linter/src/rules/erb-require-trailing-newline.ts
+++ b/javascript/packages/linter/src/rules/erb-require-trailing-newline.ts
@@ -30,7 +30,10 @@ export class ERBRequireTrailingNewlineRule extends SourceRule {
   get defaultConfig(): FullRuleConfig {
     return {
       enabled: true,
-      severity: "error"
+      severity: {
+        cli: "error",
+        editor: "info",
+      }
     }
   }
 

--- a/javascript/packages/linter/test/rules/erb-no-commented-out-output-tags.test.ts
+++ b/javascript/packages/linter/test/rules/erb-no-commented-out-output-tags.test.ts
@@ -1,4 +1,7 @@
-import { describe, it } from "vitest"
+import { describe, it, expect, beforeAll } from "vitest"
+
+import { Herb } from "@herb-tools/node-wasm"
+import { Linter } from "../../src/linter"
 import dedent from "dedent";
 
 import { ERBNoCommentedOutOutputTagsRule } from "../../src/rules/erb-no-commented-out-output-tags";
@@ -95,5 +98,15 @@ describe("erb-no-commented-out-output-tags", () => {
     expectNoOffenses(dedent`
       <%# herb:disable erb-no-extra-whitespace-inside-tags %>
     `)
+  })
+
+  it("reports the whole ERB tag, not just the opening", async () => {
+    await Herb.load()
+
+    const source = `<%#= @conference.name %>`
+    const linter = new Linter(Herb, [ERBNoCommentedOutOutputTagsRule])
+    const { location } = linter.lint(source).offenses[0]
+
+    expect(source.slice(location.start.column, location.end.column)).toBe(source)
   })
 })

--- a/javascript/packages/linter/test/rules/erb-no-unused-block-argument.test.ts
+++ b/javascript/packages/linter/test/rules/erb-no-unused-block-argument.test.ts
@@ -329,4 +329,19 @@ describe("erb-no-unused-block-argument", () => {
     expect(result.offenses[0].tags).toEqual(["unnecessary"])
     expect(result.offenses[0].severity).toBe("error")
   })
+
+  it("reports as info in the editor and an error in CI", () => {
+    const source = dedent`
+      <% @users.each do |user| %>
+        <p>Hello</p>
+      <% end %>
+    `
+
+    const cli = new Linter(Herb, [ERBNoUnusedBlockArgumentRule])
+    expect(cli.lint(source).offenses[0].severity).toBe("error")
+
+    const editor = new Linter(Herb, [ERBNoUnusedBlockArgumentRule])
+    editor.mode = "editor"
+    expect(editor.lint(source).offenses[0].severity).toBe("info")
+  })
 })


### PR DESCRIPTION
Follow up on #1962.

This pull request makes the rules that flag cleanup work quieter while a file is being edited, without changing what fails on the command line. Several of them report on code you legitimately have half-written, so they underline as you type, which trains people to ignore them.

Three rules gain the `unnecessary` diagnostic tag, five report as `info` in the editor while staying `error` on the command line, and `erb-no-commented-out-output-tags` now reports on the whole tag rather than just its opening.

<img width="1530" height="1146" alt="CleanShot 2026-08-02 at 13 19 57@2x" src="https://github.com/user-attachments/assets/df745d8a-0fe1-4cdb-9ba0-3cbf356c050c" />
