### PR TITLE
Linter: Improve `turbo-permanent-no-misleading-value` message for `true`

### DIFF
--- a/javascript/packages/linter/src/rules/turbo-permanent-no-misleading-value.ts
+++ b/javascript/packages/linter/src/rules/turbo-permanent-no-misleading-value.ts
@@ -2,7 +2,7 @@ import { BaseRuleVisitor } from "./rule-utils.js"
 import { IdentityPrinter } from "@herb-tools/printer"
 import { ParserRule, BaseAutofixContext, Mutable } from "../types.js"
 
-import { findAttributeByName, hasAttributeValue, hasStaticAttributeValue } from "@herb-tools/core"
+import { findAttributeByName, getStaticAttributeValue, hasAttributeValue, hasStaticAttributeValue } from "@herb-tools/core"
 
 import type { UnboundLintOffense, LintOffense, LintContext, FullRuleConfig } from "../types.js"
 import type { HTMLAttributeNode, HTMLOpenTagNode, ERBOpenTagNode, ParseResult, ParserOptions } from "@herb-tools/core"
@@ -35,8 +35,14 @@ class TurboPermanentNoMisleadingValueVisitor extends BaseRuleVisitor<TurboPerman
   private checkTurboPermanentAttribute(attribute: HTMLAttributeNode, autofixContext: TurboPermanentAutofixContext | undefined): void {
     if (!hasAttributeValue(attribute)) return
 
+    const isTruthyValue = getStaticAttributeValue(attribute)?.trim().toLowerCase() === "true"
+
+    const explanation = isTruthyValue
+      ? `is redundant, because Turbo only checks whether the attribute is present.`
+      : `still makes the element permanent, because Turbo only checks whether the attribute is present.`
+
     this.addOffense(
-      `Attribute \`data-turbo-permanent\` should not have a value. \`${IdentityPrinter.print(attribute)}\` still makes the element permanent, because Turbo only checks whether the attribute is present. Use \`data-turbo-permanent\` instead.`,
+      `Attribute \`data-turbo-permanent\` should not have a value. \`${IdentityPrinter.print(attribute)}\` ${explanation} Use \`data-turbo-permanent\` instead.`,
       attribute.value!.location,
       autofixContext
     )

--- a/javascript/packages/linter/test/rules/turbo-permanent-no-misleading-value.test.ts
+++ b/javascript/packages/linter/test/rules/turbo-permanent-no-misleading-value.test.ts
@@ -4,8 +4,6 @@ import { createLinterTest } from "../helpers/linter-test-helper.js"
 
 const { expectNoOffenses, expectError, assertOffenses } = createLinterTest(TurboPermanentNoMisleadingValueRule)
 
-const message = (attribute: string) => `Attribute \`data-turbo-permanent\` should not have a value. \`${attribute}\` still makes the element permanent, because Turbo only checks whether the attribute is present. Use \`data-turbo-permanent\` instead.`
-
 describe("turbo-permanent-no-misleading-value", () => {
   test("passes when no explicit value is given", () => {
     expectNoOffenses('<div id="cart-counter" data-turbo-permanent>1 item</div>')
@@ -16,22 +14,32 @@ describe("turbo-permanent-no-misleading-value", () => {
   })
 
   test("fails with value `true`", () => {
-    expectError(message('data-turbo-permanent="true"'))
+    expectError('Attribute `data-turbo-permanent` should not have a value. `data-turbo-permanent="true"` is redundant, because Turbo only checks whether the attribute is present. Use `data-turbo-permanent` instead.')
+
     assertOffenses('<div id="cart-counter" data-turbo-permanent="true">1 item</div>')
   })
 
+  test("fails with value `TRUE`", () => {
+    expectError('Attribute `data-turbo-permanent` should not have a value. `data-turbo-permanent="TRUE"` is redundant, because Turbo only checks whether the attribute is present. Use `data-turbo-permanent` instead.')
+
+    assertOffenses('<div id="cart-counter" data-turbo-permanent="TRUE">1 item</div>')
+  })
+
   test("fails with value `false`", () => {
-    expectError(message('data-turbo-permanent="false"'))
+    expectError('Attribute `data-turbo-permanent` should not have a value. `data-turbo-permanent="false"` still makes the element permanent, because Turbo only checks whether the attribute is present. Use `data-turbo-permanent` instead.')
+
     assertOffenses('<div id="cart-counter" data-turbo-permanent="false">1 item</div>')
   })
 
   test("fails with arbitrary value", () => {
-    expectError(message('data-turbo-permanent="foo"'))
+    expectError('Attribute `data-turbo-permanent` should not have a value. `data-turbo-permanent="foo"` still makes the element permanent, because Turbo only checks whether the attribute is present. Use `data-turbo-permanent` instead.')
+
     assertOffenses('<div id="cart-counter" data-turbo-permanent="foo">1 item</div>')
   })
 
   test("fails with empty string value", () => {
-    expectError(message('data-turbo-permanent=""'))
+    expectError('Attribute `data-turbo-permanent` should not have a value. `data-turbo-permanent=""` still makes the element permanent, because Turbo only checks whether the attribute is present. Use `data-turbo-permanent` instead.')
+
     assertOffenses('<div id="cart-counter" data-turbo-permanent="">1 item</div>')
   })
 
@@ -41,31 +49,31 @@ describe("turbo-permanent-no-misleading-value", () => {
     })
 
     test("fails with `turbo_permanent: false`", () => {
-      expectError(message('data-turbo-permanent: "false"'))
+      expectError('Attribute `data-turbo-permanent` should not have a value. `data-turbo-permanent: "false"` still makes the element permanent, because Turbo only checks whether the attribute is present. Use `data-turbo-permanent` instead.')
 
       assertOffenses('<%= tag.div id: "cart", data: { turbo_permanent: false } %>')
     })
 
     test("fails with `turbo_permanent: true`", () => {
-      expectError(message('data-turbo-permanent: "true"'))
+      expectError('Attribute `data-turbo-permanent` should not have a value. `data-turbo-permanent: "true"` is redundant, because Turbo only checks whether the attribute is present. Use `data-turbo-permanent` instead.')
 
       assertOffenses('<%= tag.div id: "cart", data: { turbo_permanent: true } %>')
     })
 
     test("fails with `turbo_permanent: \"false\"`", () => {
-      expectError(message('data-turbo-permanent: "false"'))
+      expectError('Attribute `data-turbo-permanent` should not have a value. `data-turbo-permanent: "false"` still makes the element permanent, because Turbo only checks whether the attribute is present. Use `data-turbo-permanent` instead.')
 
       assertOffenses('<%= tag.div id: "cart", data: { turbo_permanent: "false" } %>')
     })
 
     test("fails with empty string value", () => {
-      expectError(message('data-turbo-permanent: ""'))
+      expectError('Attribute `data-turbo-permanent` should not have a value. `data-turbo-permanent: ""` still makes the element permanent, because Turbo only checks whether the attribute is present. Use `data-turbo-permanent` instead.')
 
       assertOffenses('<%= tag.div id: "cart", data: { turbo_permanent: "" } %>')
     })
 
     test("fails for `content_tag`", () => {
-      expectError(message('data-turbo-permanent: "false"'))
+      expectError('Attribute `data-turbo-permanent` should not have a value. `data-turbo-permanent: "false"` still makes the element permanent, because Turbo only checks whether the attribute is present. Use `data-turbo-permanent` instead.')
 
       assertOffenses('<%= content_tag :div, "1 item", data: { turbo_permanent: false } %>')
     })


### PR DESCRIPTION
Follow up on #677.

The `turbo-permanent-no-misleading-value` rule currently reports the same message for every value, which reads slightly off when the value is `true`:

```
[error] Attribute data-turbo-permanent should not have a value. data-turbo-permanent="true" still
makes the element permanent, because Turbo only checks whether the attribute is present. Use
data-turbo-permanent instead.
```

"still makes the element permanent" is exactly right for `data-turbo-permanent="false"`, where the value suggests the opposite of what Turbo does, but for `data-turbo-permanent="true"` there is nothing misleading to correct. The value simply doesn't do anything, so the message now says that instead:

```
[error] Attribute data-turbo-permanent should not have a value. data-turbo-permanent="true" is
redundant, because Turbo only checks whether the attribute is present. Use data-turbo-permanent
instead.
```

Every other value keeps the original wording.