### PR TITLE
Linter: Improve `erb-no-unused-block-argument` for `each_with_index`

### DIFF
--- a/javascript/packages/linter/docs/rules/erb-no-unused-block-argument.md
+++ b/javascript/packages/linter/docs/rules/erb-no-unused-block-argument.md
@@ -32,6 +32,20 @@ For helper blocks the signal is often stronger. A `form_with` block that never t
 <% end %>
 ```
 
+When the unused argument is the index of an `each_with_index`, the message suggests `each` instead, since that is what the loop is actually doing:
+
+```erb
+<% @pairs.each_with_index do |(name, data), index| %>
+  <%= name %>: <%= data %>
+<% end %>
+```
+
+```
+Block argument `index` is never used. Use `each` instead of `each_with_index`, or prefix it with an underscore as `_index` to show it is intentionally unused.
+```
+
+That suggestion is only made for the plain `|element, index|` shape. With any other parameter list the index is not simply droppable, so the regular message is used.
+
 Ruby's convention for a binding that is deliberately ignored is a leading underscore, so `_user` is treated as intentional and never reported.
 
 Only the Ruby inside ERB tags and interpolation is searched, never the surrounding HTML, so markup that happens to contain the same word does not count as a use:
@@ -94,6 +108,12 @@ An unused argument is worth cleaning up but is not a reason to interrupt someone
 <% end %>
 ```
 
+```erb
+<% @pairs.each do |(name, data)| %>
+  <%= name %>: <%= data %>
+<% end %>
+```
+
 ### 🚫 Bad
 
 ```erb
@@ -119,6 +139,12 @@ An unused argument is worth cleaning up but is not a reason to interrupt someone
 ```erb
 <%= form_with model: @user do |form| %>
   <p>Nothing</p>
+<% end %>
+```
+
+```erb
+<% @pairs.each_with_index do |(name, data), index| %>
+  <%= name %>: <%= data %>
 <% end %>
 ```
 

--- a/javascript/packages/linter/src/rules/erb-no-unused-block-argument.ts
+++ b/javascript/packages/linter/src/rules/erb-no-unused-block-argument.ts
@@ -1,9 +1,9 @@
 import { ParserRule } from "../types.js"
 import { BaseRuleVisitor } from "./rule-utils.js"
 
-import { isRubyLiteralNode, isRubyParameterNode } from "@herb-tools/core"
+import { isRubyLiteralNode, isRubyParameterNode, isPrismNodeType } from "@herb-tools/core"
 
-import type { ERBBlockNode, Node, ParseResult } from "@herb-tools/core"
+import type { ERBBlockNode, Node, ParseResult, ParserOptions, PrismNode } from "@herb-tools/core"
 import type { FullRuleConfig, LintContext, UnboundLintOffense } from "../types.js"
 
 const IGNORED_PREFIX = "_"
@@ -21,6 +21,7 @@ class NoUnusedBlockArgumentVisitor extends BaseRuleVisitor {
     if (parameters.length === 0) return
 
     const source = this.rubySourceInBody(node)
+    const indexArgument = this.eachWithIndexArgumentName(node)
 
     for (const parameter of parameters) {
       const name = parameter.name?.value
@@ -30,14 +31,40 @@ class NoUnusedBlockArgumentVisitor extends BaseRuleVisitor {
       if (!REPORTED_KINDS.includes(parameter.kind)) continue
       if (this.referencesName(source, name)) continue
 
+      const suggestion = name === indexArgument
+        ? `Use \`each\` instead of \`each_with_index\``
+        : `Remove it`
+
       this.addOffense(
-        `Block argument \`${name}\` is never used. Remove it, or prefix it with an underscore as \`_${name}\` to show it is intentionally unused.`,
+        `Block argument \`${name}\` is never used. ${suggestion}, or prefix it with an underscore as \`_${name}\` to show it is intentionally unused.`,
         parameter.location,
         undefined,
         undefined,
         ["unnecessary"],
       )
     }
+  }
+
+  private eachWithIndexArgumentName(node: ERBBlockNode): string | null {
+    const call = node.prismNode
+
+    if (!isPrismNodeType(call, "CallNode")) return null
+    if (call.name !== "each_with_index") return null
+    if (call.arguments_) return null
+
+    const parameters = (call.block as PrismNode)?.parameters?.parameters
+    if (!isPrismNodeType(parameters, "ParametersNode")) return null
+
+    if (parameters.optionals.length > 0) return null
+    if (parameters.posts.length > 0) return null
+    if (parameters.keywords.length > 0) return null
+    if (parameters.rest || parameters.keywordRest || parameters.block) return null
+    if (parameters.requireds.length !== 2) return null
+
+    const index = parameters.requireds[1]
+    if (!isPrismNodeType(index, "RequiredParameterNode")) return null
+
+    return index.name
   }
 
   private rubySourceInBody(node: ERBBlockNode): string {
@@ -87,6 +114,11 @@ export class ERBNoUnusedBlockArgumentRule extends ParserRule {
     }
   }
 
+  get parserOptions(): Partial<ParserOptions> {
+    return {
+      prism_nodes: true,
+    }
+  }
 
   check(result: ParseResult, context?: Partial<LintContext>): UnboundLintOffense[] {
     const visitor = new NoUnusedBlockArgumentVisitor(this.ruleName, context)

--- a/javascript/packages/linter/test/rules/erb-no-unused-block-argument.test.ts
+++ b/javascript/packages/linter/test/rules/erb-no-unused-block-argument.test.ts
@@ -315,6 +315,106 @@ describe("erb-no-unused-block-argument", () => {
     assertOffenses(html)
   })
 
+  it("suggests `each` when the `each_with_index` index is unused", () => {
+    const html = dedent`
+      <% @users.each_with_index do |user, index| %>
+        <%= user.name %>
+      <% end %>
+    `
+
+    expectError('Block argument `index` is never used. Use `each` instead of `each_with_index`, or prefix it with an underscore as `_index` to show it is intentionally unused.')
+
+    assertOffenses(html)
+  })
+
+  it("suggests `each` when the index is unused alongside a destructured element", () => {
+    const html = dedent`
+      <% @pairs.each_with_index do |(name, data), index| %>
+        <%= name %>: <%= data %>
+      <% end %>
+    `
+
+    expectError('Block argument `index` is never used. Use `each` instead of `each_with_index`, or prefix it with an underscore as `_index` to show it is intentionally unused.')
+
+    assertOffenses(html)
+  })
+
+  it("suggests `each` for a receiverless `each_with_index`", () => {
+    const html = dedent`
+      <% each_with_index do |user, index| %>
+        <%= user.name %>
+      <% end %>
+    `
+
+    expectError('Block argument `index` is never used. Use `each` instead of `each_with_index`, or prefix it with an underscore as `_index` to show it is intentionally unused.')
+
+    assertOffenses(html)
+  })
+
+  it("does not suggest `each` for an unused element of `each_with_index`", () => {
+    const html = dedent`
+      <% @users.each_with_index do |user, index| %>
+        <%= index %>
+      <% end %>
+    `
+
+    expectError('Block argument `user` is never used. Remove it, or prefix it with an underscore as `_user` to show it is intentionally unused.')
+
+    assertOffenses(html)
+  })
+
+  it("does not suggest `each` when the `each_with_index` block takes a single argument", () => {
+    const html = dedent`
+      <% @users.each_with_index do |user| %>
+        <p>Hello</p>
+      <% end %>
+    `
+
+    expectError('Block argument `user` is never used. Remove it, or prefix it with an underscore as `_user` to show it is intentionally unused.')
+
+    assertOffenses(html)
+  })
+
+  it("does not suggest `each` when the `each_with_index` block splats its arguments", () => {
+    const html = dedent`
+      <% @users.each_with_index do |user, *rest| %>
+        <%= user.name %>
+      <% end %>
+    `
+
+    expectError('Block argument `rest` is never used. Remove it, or prefix it with an underscore as `_rest` to show it is intentionally unused.')
+
+    assertOffenses(html)
+  })
+
+  it("does not suggest `each` for an unused argument of another iterator", () => {
+    const html = dedent`
+      <% @users.each_with_object([]) do |user, index| %>
+        <%= user.name %>
+      <% end %>
+    `
+
+    expectError('Block argument `index` is never used. Remove it, or prefix it with an underscore as `_index` to show it is intentionally unused.')
+
+    assertOffenses(html)
+  })
+
+  it("does not flag a used `each_with_index` index", () => {
+    expectNoOffenses(dedent`
+      <% @users.each_with_index do |user, index| %>
+        <%= index %>: <%= user.name %>
+      <% end %>
+    `)
+  })
+
+  it("does not flag an underscored `each_with_index` index", () => {
+    expectNoOffenses(dedent`
+      <% @users.each_with_index do |user, _index| %>
+        <%= user.name %>
+      <% end %>
+    `)
+  })
+
   it("tags the offense as unnecessary so editors grey the argument out", async () => {
     await Herb.load()
 


### PR DESCRIPTION
Follow up on #1958.

When the unused block argument is the index of an `each_with_index`, telling someone to remove it or prefix it with an underscore isn't the most useful advice. The loop isn't using the index at all, so it isn't an `each_with_index` anymore:

```erb
<% @pairs.each_with_index do |(name, data), index| %>
  <%= name %>: <%= data %>
<% end %>
```

This pull request updates `erb-no-unused-block-argument` to recognize that case and suggest the method that matches what the block actually does:

```
Block argument `index` is never used. Use `each` instead of `each_with_index`, or prefix it with an underscore as `_index` to show it is intentionally unused.
```

Every other offense keeps the existing `Remove it, or prefix it with an underscore …` message.