### PR TITLE
Rust: Also run `make test` without `--all-features`

### DIFF
--- a/rust/Makefile
+++ b/rust/Makefile
@@ -26,6 +26,7 @@ cli: build
 	@./bin/$(BIN_NAME) || true
 
 test: build
+	NO_COLOR=1 cargo +stable test --verbose --workspace
 	NO_COLOR=1 cargo +stable test --verbose --workspace --all-features
 
 format:


### PR DESCRIPTION
Follow up on #1952.

That pull request left the crate with two meaningfully different library builds: the default one, where `style::Colorize` is a macro-generated passthrough, and the `color` one, where it re-exports `colored::Colorize`. `make test` only ever ran the second.