### PR TITLE
Parser: Don't treat the ternary `?` as a `then` keyword

### DIFF
--- a/javascript/packages/linter/test/rules/erb-no-empty-control-flow.test.ts
+++ b/javascript/packages/linter/test/rules/erb-no-empty-control-flow.test.ts
@@ -274,6 +274,18 @@ describe("ERBNoEmptyControlFlowRule", () => {
         <% end %>
       `)
     })
+
+    test("detects empty when block with a ternary condition containing then in a string", () => {
+      expectHint("Empty when block: this control flow statement has no content")
+
+      assertOffenses(dedent`
+        <% case value %>
+        <% when a == "then" ? 1 : 2 %>
+        <% when "b" %>
+          <p>B</p>
+        <% end %>
+      `)
+    })
   })
 
   describe("in statements", () => {
@@ -302,6 +314,18 @@ describe("ERBNoEmptyControlFlowRule", () => {
       expectNoOffenses(dedent`
         <% case value %>
         <% in { then: x } then x %>
+        <% end %>
+      `)
+    })
+
+    test("detects empty in block with a ternary guard containing then in a string", () => {
+      expectHint("Empty in block: this control flow statement has no content")
+
+      assertOffenses(dedent`
+        <% case value %>
+        <% in Integer if x == "then" ? a : b %>
+        <% in String %>
+          <p>String</p>
         <% end %>
       `)
     })

--- a/javascript/packages/linter/test/rules/erb-no-then-in-control-flow.test.ts
+++ b/javascript/packages/linter/test/rules/erb-no-then-in-control-flow.test.ts
@@ -158,6 +158,65 @@ describe("ERBNoThenInControlFlowRule", () => {
     })
   })
 
+  describe("ternary operators", () => {
+    test("valid if with ternary in condition", () => {
+      expectNoOffenses(dedent`
+        <% if v2 = (@smart_values[k] || {})[v.nil? ? v : v.to_s] %>
+          <div class="text-muted"><%= v2 %></div>
+        <% end %>
+      `)
+    })
+
+    test("valid unless with ternary in condition", () => {
+      expectNoOffenses(dedent`
+        <% unless (admin? ? user.active? : user.confirmed?) %>
+          content
+        <% end %>
+      `)
+    })
+
+    test("valid elsif with ternary in condition", () => {
+      expectNoOffenses(dedent`
+        <% if a %>
+          A
+        <% elsif b ? c : d %>
+          B
+        <% end %>
+      `)
+    })
+
+    test("invalid if with ternary in condition and then", () => {
+      expectWarning("Avoid using `then` in `if` expressions inside ERB templates. Use the multiline block form instead.")
+
+      assertOffenses(dedent`
+        <% if a ? b : c then %>
+          content
+        <% end %>
+      `)
+    })
+
+    test("invalid elsif with ternary in condition and then", () => {
+      expectWarning("Avoid using `then` in `elsif` expressions inside ERB templates. Use the multiline block form instead.")
+
+      assertOffenses(dedent`
+        <% if a %>
+          A
+        <% elsif b ? c : d then %>
+          B
+        <% end %>
+      `)
+    })
+
+    test("valid when with ternary containing then in a string", () => {
+      expectNoOffenses(dedent`
+        <% case value %>
+        <% when a == "then" ? 1 : 2 %>
+          content
+        <% end %>
+      `)
+    })
+  })
+
   describe("escaped ERB tags", () => {
     test("reports then in escaped if", () => {
       expectWarning("Avoid using `then` in `if` expressions inside ERB templates. Use the multiline block form instead.")

--- a/src/prism/prism_helpers.c
+++ b/src/prism/prism_helpers.c
@@ -74,6 +74,9 @@ static bool search_then_keyword_location(const pm_node_t* node, void* data) {
   switch (node->type) {
     case PM_IF_NODE: {
       const pm_if_node_t* if_node = (const pm_if_node_t*) node;
+
+      if (!has_pm_location(if_node->if_keyword_loc)) { break; }
+
       if (has_pm_location(if_node->then_keyword_loc)) {
         context->then_keyword_loc = if_node->then_keyword_loc;
         context->found = true;

--- a/test/analyze/then_test.rb
+++ b/test/analyze/then_test.rb
@@ -287,5 +287,58 @@ module Analyze
         <% end %>
       HTML
     end
+
+    test "if with ternary in condition" do
+      assert_parsed_snapshot(<<~HTML)
+        <% if v2 = (@smart_values[k] || {})[v.nil? ? v : v.to_s] %>
+          <div class="text-muted"><%= v2 %></div>
+        <% end %>
+      HTML
+    end
+
+    test "unless with ternary in condition" do
+      assert_parsed_snapshot(<<~HTML)
+        <% unless (admin? ? user.active? : user.confirmed?) %>
+          content
+        <% end %>
+      HTML
+    end
+
+    test "elsif with ternary in condition" do
+      assert_parsed_snapshot(<<~HTML)
+        <% if a %>
+          A
+        <% elsif b ? c : d %>
+          B
+        <% end %>
+      HTML
+    end
+
+    test "if with ternary in condition and then keyword" do
+      assert_parsed_snapshot(<<~HTML)
+        <% if a ? b : c then %>
+          content
+        <% end %>
+      HTML
+    end
+
+    test "elsif with ternary in condition and then keyword" do
+      assert_parsed_snapshot(<<~HTML)
+        <% if a %>
+          A
+        <% elsif b ? c : d then %>
+          B
+        <% end %>
+      HTML
+    end
+
+    test "when with ternary containing then in a string" do
+      assert_parsed_snapshot(<<~HTML)
+        <% case value %>
+        <% when a == "then" ? 1 : 2 %>
+          content
+        <% end %>
+      HTML
+    end
   end
 end

--- a/test/snapshots/analyze/then_test/test_0031_if_with_ternary_in_condition_a2c2f5d4b8ea59e0a4709cd2bfda6ff8.txt
+++ b/test/snapshots/analyze/then_test/test_0031_if_with_ternary_in_condition_a2c2f5d4b8ea59e0a4709cd2bfda6ff8.txt
@@ -1,0 +1,79 @@
+---
+source: "Analyze::ThenTest#test_0031_if with ternary in condition"
+input: |2-
+<% if v2 = (@smart_values[k] || {})[v.nil? ? v : v.to_s] %>
+  <div class="text-muted"><%= v2 %></div>
+<% end %>
+---
+@ DocumentNode (location: (1:0)-(4:0))
+└── children: (2 items)
+    ├── @ ERBIfNode (location: (1:0)-(3:9))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
+    │   ├── content: " if v2 = (@smart_values[k] || {})[v.nil? ? v : v.to_s] " (location: (1:2)-(1:57))
+    │   ├── tag_closing: "%>" (location: (1:57)-(1:59))
+    │   ├── then_keyword: ∅
+    │   ├── statements: (3 items)
+    │   │   ├── @ HTMLTextNode (location: (1:59)-(2:2))
+    │   │   │   └── content: "\n  "
+    │   │   │
+    │   │   ├── @ HTMLElementNode (location: (2:2)-(2:41))
+    │   │   │   ├── open_tag:
+    │   │   │   │   └── @ HTMLOpenTagNode (location: (2:2)-(2:26))
+    │   │   │   │       ├── tag_opening: "<" (location: (2:2)-(2:3))
+    │   │   │   │       ├── tag_name: "div" (location: (2:3)-(2:6))
+    │   │   │   │       ├── tag_closing: ">" (location: (2:25)-(2:26))
+    │   │   │   │       ├── children: (1 item)
+    │   │   │   │       │   └── @ HTMLAttributeNode (location: (2:7)-(2:25))
+    │   │   │   │       │       ├── name:
+    │   │   │   │       │       │   └── @ HTMLAttributeNameNode (location: (2:7)-(2:12))
+    │   │   │   │       │       │       └── children: (1 item)
+    │   │   │   │       │       │           └── @ LiteralNode (location: (2:7)-(2:12))
+    │   │   │   │       │       │               └── content: "class"
+    │   │   │   │       │       │
+    │   │   │   │       │       │
+    │   │   │   │       │       ├── equals: "=" (location: (2:12)-(2:13))
+    │   │   │   │       │       └── value:
+    │   │   │   │       │           └── @ HTMLAttributeValueNode (location: (2:13)-(2:25))
+    │   │   │   │       │               ├── open_quote: """ (location: (2:13)-(2:14))
+    │   │   │   │       │               ├── children: (1 item)
+    │   │   │   │       │               │   └── @ LiteralNode (location: (2:14)-(2:24))
+    │   │   │   │       │               │       └── content: "text-muted"
+    │   │   │   │       │               │
+    │   │   │   │       │               ├── close_quote: """ (location: (2:24)-(2:25))
+    │   │   │   │       │               └── quoted: true
+    │   │   │   │       │
+    │   │   │   │       │
+    │   │   │   │       └── is_void: false
+    │   │   │   │
+    │   │   │   ├── tag_name: "div" (location: (2:3)-(2:6))
+    │   │   │   ├── body: (1 item)
+    │   │   │   │   └── @ ERBContentNode (location: (2:26)-(2:35))
+    │   │   │   │       ├── tag_opening: "<%=" (location: (2:26)-(2:29))
+    │   │   │   │       ├── content: " v2 " (location: (2:29)-(2:33))
+    │   │   │   │       ├── tag_closing: "%>" (location: (2:33)-(2:35))
+    │   │   │   │       ├── parsed: true
+    │   │   │   │       └── valid: true
+    │   │   │   │
+    │   │   │   ├── close_tag:
+    │   │   │   │   └── @ HTMLCloseTagNode (location: (2:35)-(2:41))
+    │   │   │   │       ├── tag_opening: "</" (location: (2:35)-(2:37))
+    │   │   │   │       ├── tag_name: "div" (location: (2:37)-(2:40))
+    │   │   │   │       ├── children: []
+    │   │   │   │       └── tag_closing: ">" (location: (2:40)-(2:41))
+    │   │   │   │
+    │   │   │   ├── is_void: false
+    │   │   │   └── element_source: "HTML"
+    │   │   │
+    │   │   └── @ HTMLTextNode (location: (2:41)-(3:0))
+    │   │       └── content: "\n"
+    │   │
+    │   ├── subsequent: ∅
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (3:0)-(3:9))
+    │           ├── tag_opening: "<%" (location: (3:0)-(3:2))
+    │           ├── content: " end " (location: (3:2)-(3:7))
+    │           └── tag_closing: "%>" (location: (3:7)-(3:9))
+    │
+    │
+    └── @ HTMLTextNode (location: (3:9)-(4:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/then_test/test_0032_unless_with_ternary_in_condition_ce41a311d629f94e6fa02d5b4c165361.txt
+++ b/test/snapshots/analyze/then_test/test_0032_unless_with_ternary_in_condition_ce41a311d629f94e6fa02d5b4c165361.txt
@@ -1,0 +1,28 @@
+---
+source: "Analyze::ThenTest#test_0032_unless with ternary in condition"
+input: |2-
+<% unless (admin? ? user.active? : user.confirmed?) %>
+  content
+<% end %>
+---
+@ DocumentNode (location: (1:0)-(4:0))
+└── children: (2 items)
+    ├── @ ERBUnlessNode (location: (1:0)-(3:9))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
+    │   ├── content: " unless (admin? ? user.active? : user.confirmed?) " (location: (1:2)-(1:52))
+    │   ├── tag_closing: "%>" (location: (1:52)-(1:54))
+    │   ├── then_keyword: ∅
+    │   ├── statements: (1 item)
+    │   │   └── @ HTMLTextNode (location: (1:54)-(3:0))
+    │   │       └── content: "\n  content\n"
+    │   │
+    │   ├── else_clause: ∅
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (3:0)-(3:9))
+    │           ├── tag_opening: "<%" (location: (3:0)-(3:2))
+    │           ├── content: " end " (location: (3:2)-(3:7))
+    │           └── tag_closing: "%>" (location: (3:7)-(3:9))
+    │
+    │
+    └── @ HTMLTextNode (location: (3:9)-(4:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/then_test/test_0033_elsif_with_ternary_in_condition_e59b2d8a41622f56584d29f3c836d7dc.txt
+++ b/test/snapshots/analyze/then_test/test_0033_elsif_with_ternary_in_condition_e59b2d8a41622f56584d29f3c836d7dc.txt
@@ -1,0 +1,42 @@
+---
+source: "Analyze::ThenTest#test_0033_elsif with ternary in condition"
+input: |2-
+<% if a %>
+  A
+<% elsif b ? c : d %>
+  B
+<% end %>
+---
+@ DocumentNode (location: (1:0)-(6:0))
+└── children: (2 items)
+    ├── @ ERBIfNode (location: (1:0)-(5:9))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
+    │   ├── content: " if a " (location: (1:2)-(1:8))
+    │   ├── tag_closing: "%>" (location: (1:8)-(1:10))
+    │   ├── then_keyword: ∅
+    │   ├── statements: (1 item)
+    │   │   └── @ HTMLTextNode (location: (1:10)-(3:0))
+    │   │       └── content: "\n  A\n"
+    │   │
+    │   ├── subsequent:
+    │   │   └── @ ERBIfNode (location: (3:0)-(5:0))
+    │   │       ├── tag_opening: "<%" (location: (3:0)-(3:2))
+    │   │       ├── content: " elsif b ? c : d " (location: (3:2)-(3:19))
+    │   │       ├── tag_closing: "%>" (location: (3:19)-(3:21))
+    │   │       ├── then_keyword: ∅
+    │   │       ├── statements: (1 item)
+    │   │       │   └── @ HTMLTextNode (location: (3:21)-(5:0))
+    │   │       │       └── content: "\n  B\n"
+    │   │       │
+    │   │       ├── subsequent: ∅
+    │   │       └── end_node: ∅
+    │   │
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (5:0)-(5:9))
+    │           ├── tag_opening: "<%" (location: (5:0)-(5:2))
+    │           ├── content: " end " (location: (5:2)-(5:7))
+    │           └── tag_closing: "%>" (location: (5:7)-(5:9))
+    │
+    │
+    └── @ HTMLTextNode (location: (5:9)-(6:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/then_test/test_0034_if_with_ternary_in_condition_and_then_keyword_62ce7e17fc0ba4aa07021fef9c6c09bb.txt
+++ b/test/snapshots/analyze/then_test/test_0034_if_with_ternary_in_condition_and_then_keyword_62ce7e17fc0ba4aa07021fef9c6c09bb.txt
@@ -1,0 +1,28 @@
+---
+source: "Analyze::ThenTest#test_0034_if with ternary in condition and then keyword"
+input: |2-
+<% if a ? b : c then %>
+  content
+<% end %>
+---
+@ DocumentNode (location: (1:0)-(4:0))
+└── children: (2 items)
+    ├── @ ERBIfNode (location: (1:0)-(3:9))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
+    │   ├── content: " if a ? b : c then " (location: (1:2)-(1:21))
+    │   ├── tag_closing: "%>" (location: (1:21)-(1:23))
+    │   ├── then_keyword: (location: (1:16)-(1:20))
+    │   ├── statements: (1 item)
+    │   │   └── @ HTMLTextNode (location: (1:23)-(3:0))
+    │   │       └── content: "\n  content\n"
+    │   │
+    │   ├── subsequent: ∅
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (3:0)-(3:9))
+    │           ├── tag_opening: "<%" (location: (3:0)-(3:2))
+    │           ├── content: " end " (location: (3:2)-(3:7))
+    │           └── tag_closing: "%>" (location: (3:7)-(3:9))
+    │
+    │
+    └── @ HTMLTextNode (location: (3:9)-(4:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/then_test/test_0035_elsif_with_ternary_in_condition_and_then_keyword_4514ed715faae53b0bff74bbf7955a38.txt
+++ b/test/snapshots/analyze/then_test/test_0035_elsif_with_ternary_in_condition_and_then_keyword_4514ed715faae53b0bff74bbf7955a38.txt
@@ -1,0 +1,42 @@
+---
+source: "Analyze::ThenTest#test_0035_elsif with ternary in condition and then keyword"
+input: |2-
+<% if a %>
+  A
+<% elsif b ? c : d then %>
+  B
+<% end %>
+---
+@ DocumentNode (location: (1:0)-(6:0))
+└── children: (2 items)
+    ├── @ ERBIfNode (location: (1:0)-(5:9))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
+    │   ├── content: " if a " (location: (1:2)-(1:8))
+    │   ├── tag_closing: "%>" (location: (1:8)-(1:10))
+    │   ├── then_keyword: ∅
+    │   ├── statements: (1 item)
+    │   │   └── @ HTMLTextNode (location: (1:10)-(3:0))
+    │   │       └── content: "\n  A\n"
+    │   │
+    │   ├── subsequent:
+    │   │   └── @ ERBIfNode (location: (3:0)-(5:0))
+    │   │       ├── tag_opening: "<%" (location: (3:0)-(3:2))
+    │   │       ├── content: " elsif b ? c : d then " (location: (3:2)-(3:24))
+    │   │       ├── tag_closing: "%>" (location: (3:24)-(3:26))
+    │   │       ├── then_keyword: (location: (3:19)-(3:23))
+    │   │       ├── statements: (1 item)
+    │   │       │   └── @ HTMLTextNode (location: (3:26)-(5:0))
+    │   │       │       └── content: "\n  B\n"
+    │   │       │
+    │   │       ├── subsequent: ∅
+    │   │       └── end_node: ∅
+    │   │
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (5:0)-(5:9))
+    │           ├── tag_opening: "<%" (location: (5:0)-(5:2))
+    │           ├── content: " end " (location: (5:2)-(5:7))
+    │           └── tag_closing: "%>" (location: (5:7)-(5:9))
+    │
+    │
+    └── @ HTMLTextNode (location: (5:9)-(6:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/then_test/test_0036_when_with_ternary_containing_then_in_a_string_2794b9355638c24ca47c640b1b107573.txt
+++ b/test/snapshots/analyze/then_test/test_0036_when_with_ternary_containing_then_in_a_string_2794b9355638c24ca47c640b1b107573.txt
@@ -1,0 +1,39 @@
+---
+source: "Analyze::ThenTest#test_0036_when with ternary containing then in a string"
+input: |2-
+<% case value %>
+<% when a == "then" ? 1 : 2 %>
+  content
+<% end %>
+---
+@ DocumentNode (location: (1:0)-(5:0))
+└── children: (2 items)
+    ├── @ ERBCaseNode (location: (1:0)-(4:9))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:2))
+    │   ├── content: " case value " (location: (1:2)-(1:14))
+    │   ├── tag_closing: "%>" (location: (1:14)-(1:16))
+    │   ├── children: (1 item)
+    │   │   └── @ HTMLTextNode (location: (1:16)-(2:0))
+    │   │       └── content: "\n"
+    │   │
+    │   ├── conditions: (1 item)
+    │   │   └── @ ERBWhenNode (location: (2:0)-(2:30))
+    │   │       ├── tag_opening: "<%" (location: (2:0)-(2:2))
+    │   │       ├── content: " when a == "then" ? 1 : 2 " (location: (2:2)-(2:28))
+    │   │       ├── tag_closing: "%>" (location: (2:28)-(2:30))
+    │   │       ├── then_keyword: ∅
+    │   │       └── statements: (1 item)
+    │   │           └── @ HTMLTextNode (location: (2:30)-(4:0))
+    │   │               └── content: "\n  content\n"
+    │   │
+    │   │
+    │   ├── else_clause: ∅
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (4:0)-(4:9))
+    │           ├── tag_opening: "<%" (location: (4:0)-(4:2))
+    │           ├── content: " end " (location: (4:2)-(4:7))
+    │           └── tag_closing: "%>" (location: (4:7)-(4:9))
+    │
+    │
+    └── @ HTMLTextNode (location: (4:9)-(5:0))
+        └── content: "\n"


### PR DESCRIPTION
This pull request fixes the parser reporting a `then_keyword` location on control flow nodes whose condition contains a ternary expression, which made `erb-no-then-in-control-flow` flag templates that don't contain a `then` at all.

Prism represents a ternary as an `IfNode` without an `if` keyword, where `then_keyword_loc` points at the `?` and `else_keyword_loc` points at the `:`. 

Since `search_then_keyword_location()` walks the whole Prism tree looking for the first control flow node that has a `then` location, it descended into the condition of the ERB `if` and picked up the `?` of the nested ternary:

```html+erb
<% if v2 = (@smart_values[k] || {})[v.nil? ? v : v.to_s] %>
  <div class="text-muted"><%= v2 %></div>
<% end %>
```


```diff
  @ ERBIfNode (location: (1:0)-(3:9))
  ├── tag_opening: "<%" (location: (1:0)-(1:2))
  ├── content: " if v2 = (@smart_values[k] || {})[v.nil? ? v : v.to_s] " (location: (1:2)-(1:57))
  ├── tag_closing: "%>" (location: (1:57)-(1:59))
- ├── then_keyword: (location: (1:43)-(1:44))
+ ├── then_keyword: ∅
```

The search now skips `if` nodes that have no `if` keyword location, which is the shape Prism uses for ternaries.

Resolves #1668