### PR TITLE
Linter: Don't flag `case` operands in `erb-no-unused-literals`

### DIFF
--- a/javascript/packages/linter/src/rules/erb-no-unused-literals.ts
+++ b/javascript/packages/linter/src/rules/erb-no-unused-literals.ts
@@ -59,6 +59,26 @@ class LiteralCollector extends PrismVisitor {
   visitBreakNode(): void {}
   visitNextNode(): void {}
 
+  visitCaseNode(node: PrismNodes.CaseNode): void {
+    node.conditions.forEach((condition) => this.visit(condition))
+
+    this.visit(node.elseClause)
+  }
+
+  visitCaseMatchNode(node: PrismNodes.CaseMatchNode): void {
+    node.conditions.forEach((condition) => this.visit(condition))
+
+    this.visit(node.elseClause)
+  }
+
+  visitWhenNode(node: PrismNodes.WhenNode): void {
+    this.visit(node.statements)
+  }
+
+  visitInNode(node: PrismNodes.InNode): void {
+    this.visit(node.statements)
+  }
+
   visitArrayNode(node: PrismNodes.ArrayNode): void {
     this.literals.push(node)
   }

--- a/javascript/packages/linter/test/rules/erb-no-unused-literals.test.ts
+++ b/javascript/packages/linter/test/rules/erb-no-unused-literals.test.ts
@@ -389,6 +389,85 @@ describe("ERBNoUnusedLiteralsRule", () => {
     `)
   })
 
+  test("passes for literal `when` conditions", () => {
+    expectNoOffenses(dedent`
+      <% case value
+         when "a"
+           result = 1
+         when 1, :two, /three/
+           result = 2
+         end %>
+    `)
+  })
+
+  test("passes for literal `in` patterns", () => {
+    expectNoOffenses(dedent`
+      <% case value
+         in "a"
+           result = 1
+         in [1, 2]
+           result = 2
+         in { key: "value" }
+           result = 3
+         end %>
+    `)
+  })
+
+  test("passes for a literal `case` subject", () => {
+    expectNoOffenses(dedent`
+      <% case "a"
+         when value
+           result = 1
+         end %>
+    `)
+  })
+
+  test("passes for a literal `case`/`in` subject", () => {
+    expectNoOffenses(dedent`
+      <% case "a"
+         in String
+           result = 1
+         end %>
+    `)
+  })
+
+  test("fails for unused literals in a `when` body", () => {
+    expectError('Avoid using silent ERB tags for literals. `"dead"` is evaluated but never used or output.')
+
+    assertOffenses(dedent`
+      <% case value
+         when "a"
+           "dead"
+           result = 1
+         end %>
+    `)
+  })
+
+  test("fails for unused literals in an `in` body", () => {
+    expectError('Avoid using silent ERB tags for literals. `"dead"` is evaluated but never used or output.')
+
+    assertOffenses(dedent`
+      <% case value
+         in String
+           "dead"
+           result = 1
+         end %>
+    `)
+  })
+
+  test("fails for unused literals in a `case` `else` branch", () => {
+    expectError('Avoid using silent ERB tags for literals. `"dead"` is evaluated but never used or output.')
+
+    assertOffenses(dedent`
+      <% case value
+         when "a"
+           result = 1
+         else
+           "dead"
+         end %>
+    `)
+  })
+
   test("fails for literals in conditional statements", () => {
     expectError('Avoid using silent ERB tags for literals. `"success"` is evaluated but never used or output.')
 


### PR DESCRIPTION
This pull request updates the `LiteralCollector` in `erb-no-unused-literals` to skip the comparison operands of `case`/`when` and `case`/`in` statements, which were being reported as unused literals.

`LiteralCollector` is a blocklist-based visitor. It overrides `visitCallNode` to skip arguments and stops traversal into every assignment node type plus `visitReturnNode`/`visitBreakNode`/`visitNextNode`, but it had no handling for `WhenNode`, `InNode`, `CaseNode` or `CaseMatchNode`. 

The rule bug was always there, it just wasn't reachable before #1885, `PrismVisitor` never descended into node list fields, so `when`/`in` branch conditions never reached the collector. Once that was fixed, every literal condition started landing in `literals`.

```erb
<% case value
   when "a"
     result = 1
   end %>
```

```
a.html.erb:
  2:8  ✗ Avoid using silent ERB tags for literals. `"a"` is evaluated but never used or output. (erb-no-unused-literals)
```

`"a"` isn't unused, it's the operand `value` is compared against. The same applied to `in` patterns and to a literal `case` subject.

Follow up on #1885
Resolves #1972
