### PR TITLE
Ruby: Add `zero` methods for `Location`, `Position` and `Range`

### DIFF
--- a/lib/herb/location.rb
+++ b/lib/herb/location.rb
@@ -29,6 +29,11 @@ module Herb
       from(start_line, start_column, end_line, end_column)
     end
 
+    #: () -> Location
+    def self.zero
+      new(Position.zero, Position.zero)
+    end
+
     #: () -> serialized_location
     def to_hash
       {

--- a/lib/herb/position.rb
+++ b/lib/herb/position.rb
@@ -23,6 +23,11 @@ module Herb
       new(line, column)
     end
 
+    #: () -> Position
+    def self.zero
+      new(0, 0)
+    end
+
     #: () -> serialized_position
     def to_hash
       { line: line, column: column } #: Herb::serialized_position

--- a/lib/herb/range.rb
+++ b/lib/herb/range.rb
@@ -23,6 +23,11 @@ module Herb
       new(from, to)
     end
 
+    #: () -> Range
+    def self.zero
+      new(0, 0)
+    end
+
     #: () -> serialized_range
     def to_a
       [from, to] #: Herb::serialized_range

--- a/sig/herb/location.rbs
+++ b/sig/herb/location.rbs
@@ -19,6 +19,9 @@ module Herb
     # : (Integer, Integer, Integer, Integer) -> Location
     def self.[]: (Integer, Integer, Integer, Integer) -> Location
 
+    # : () -> Location
+    def self.zero: () -> Location
+
     # : () -> serialized_location
     def to_hash: () -> serialized_location
 

--- a/sig/herb/position.rbs
+++ b/sig/herb/position.rbs
@@ -16,6 +16,9 @@ module Herb
     # : (Integer, Integer) -> Position
     def self.from: (Integer, Integer) -> Position
 
+    # : () -> Position
+    def self.zero: () -> Position
+
     # : () -> serialized_position
     def to_hash: () -> serialized_position
 

--- a/sig/herb/range.rbs
+++ b/sig/herb/range.rbs
@@ -16,6 +16,9 @@ module Herb
     # : (Integer, Integer) -> Range
     def self.from: (Integer, Integer) -> Range
 
+    # : () -> Range
+    def self.zero: () -> Range
+
     # : () -> serialized_range
     def to_a: () -> serialized_range
 

--- a/test/location_test.rb
+++ b/test/location_test.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+class LocationTest < Minitest::Spec
+  test ".zero returns a fresh zero-valued location" do
+    location = Herb::Location.zero
+
+    assert_equal(
+      { start: { line: 0, column: 0 }, end: { line: 0, column: 0 } },
+      location.to_hash
+    )
+
+    refute_same location.start, location.end
+    refute_same location, Herb::Location.zero
+  end
+end

--- a/test/position_test.rb
+++ b/test/position_test.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+class PositionTest < Minitest::Spec
+  test ".zero returns a fresh zero-valued position" do
+    position = Herb::Position.zero
+
+    assert_equal({ line: 0, column: 0 }, position.to_hash)
+    refute_same position, Herb::Position.zero
+  end
+end

--- a/test/range_test.rb
+++ b/test/range_test.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+class RangeTest < Minitest::Spec
+  test ".zero returns a fresh zero-valued range" do
+    range = Herb::Range.zero
+
+    assert_equal [0, 0], range.to_a
+    refute_same range, Herb::Range.zero
+  end
+end


### PR DESCRIPTION
This pull request adds `.zero` factory methods to `Herb::Location`, `Herb::Position`, and `Herb::Range`, matching the existing JavaScript APIs in `@herb-tools/core`.

```ruby
Herb::Position.zero  # => #<Herb::Position (0:0)>
Herb::Location.zero  # => #<Herb::Location (location: (0:0)-(0:0))>
Herb::Range.zero     # => #<Herb::Range [0, 0]>
```
