### PR TITLE
RBS: Update signatures of `lex_file` and `parse_file`

### DIFF
--- a/lib/herb.rb
+++ b/lib/herb.rb
@@ -80,12 +80,12 @@ end
 
 module Herb
   class << self
-    #: (String path, ?arena_stats: bool) -> LexResult
+    #: (String path, ?arena_stats: bool, **untyped) -> LexResult
     def lex_file(path, **)
       lex(File.read(path), **)
     end
 
-    #: (String path, ?track_whitespace: bool, ?analyze: bool, ?strict: bool, ?action_view_helpers: bool, ?transform_conditionals: bool, ?strict_locals: bool, ?prism_nodes: bool, ?prism_nodes_deep: bool, ?prism_program: bool, ?arena_stats: bool) -> ParseResult
+    #: (String path, ?track_whitespace: bool, ?analyze: bool, ?strict: bool, ?action_view_helpers: bool, ?transform_conditionals: bool, ?strict_locals: bool, ?prism_nodes: bool, ?prism_nodes_deep: bool, ?prism_program: bool, ?arena_stats: bool, **untyped) -> ParseResult
     def parse_file(path, **)
       parse(File.read(path), **)
     end

--- a/sig/herb.rbs
+++ b/sig/herb.rbs
@@ -7,11 +7,11 @@ module Herb
 end
 
 module Herb
-  # : (String path, ?arena_stats: bool) -> LexResult
-  def self.lex_file: (String path, ?arena_stats: bool) -> LexResult
+  # : (String path, ?arena_stats: bool, **untyped) -> LexResult
+  def self.lex_file: (String path, ?arena_stats: bool, **untyped) -> LexResult
 
-  # : (String path, ?track_whitespace: bool, ?analyze: bool, ?strict: bool, ?action_view_helpers: bool, ?transform_conditionals: bool, ?strict_locals: bool, ?prism_nodes: bool, ?prism_nodes_deep: bool, ?prism_program: bool, ?arena_stats: bool) -> ParseResult
-  def self.parse_file: (String path, ?track_whitespace: bool, ?analyze: bool, ?strict: bool, ?action_view_helpers: bool, ?transform_conditionals: bool, ?strict_locals: bool, ?prism_nodes: bool, ?prism_nodes_deep: bool, ?prism_program: bool, ?arena_stats: bool) -> ParseResult
+  # : (String path, ?track_whitespace: bool, ?analyze: bool, ?strict: bool, ?action_view_helpers: bool, ?transform_conditionals: bool, ?strict_locals: bool, ?prism_nodes: bool, ?prism_nodes_deep: bool, ?prism_program: bool, ?arena_stats: bool, **untyped) -> ParseResult
+  def self.parse_file: (String path, ?track_whitespace: bool, ?analyze: bool, ?strict: bool, ?action_view_helpers: bool, ?transform_conditionals: bool, ?strict_locals: bool, ?prism_nodes: bool, ?prism_nodes_deep: bool, ?prism_program: bool, ?arena_stats: bool, **untyped) -> ParseResult
 
   # : (String source) -> Prism::ParseResult
   def self.parse_ruby: (String source) -> Prism::ParseResult


### PR DESCRIPTION
Fixes #1989 

With his we prevent having issues with tapioca
rbi generation because of the invalid
RBS for this method omitting the ** argument
