### PR TITLE
Linter: Improve `erb-unsued-block-argument` offense messages

### DIFF
--- a/javascript/packages/linter/docs/rules/erb-no-unused-block-argument.md
+++ b/javascript/packages/linter/docs/rules/erb-no-unused-block-argument.md
@@ -14,10 +14,6 @@ This applies to every block that spans ERB tags, both iteration blocks and helpe
 <% end %>
 ```
 
-```
-Block argument `user` is never used. Remove it, or prefix it with an underscore as `_user` to show it is intentionally unused.
-```
-
 ## Rationale
 
 An unused block argument is usually one of two things: a leftover from an edit that removed the code using it, or a sign that the wrong variable is being referenced in the body. Both are worth a second look.
@@ -32,16 +28,22 @@ For helper blocks the signal is often stronger. A `form_with` block that never t
 <% end %>
 ```
 
-When the unused argument is the index of an `each_with_index`, the message suggests `each` instead, since that is what the loop is actually doing:
+When the only argument of an `each` is unused, the block is not iterating over anything, it is repeating its body once per element. A block runs just as well without declaring the argument at all, so the message spells that out:
+
+```erb
+<% pages.each do |page| %>
+  <div class="page"></div>
+<% end %>
+```
+
+That wording is only used for a receiver that reads as a plain reference, like `pages`, `@user.pages` or `Page.all`. When the `each` is called on something that takes arguments or a block, or is called with `&.`, the receiver is not worth repeating in the message, so the regular message is used.
+
+When the unused argument is the index of an `each_with_index`, the message suggests `each` instead, for the same reason:
 
 ```erb
 <% @pairs.each_with_index do |(name, data), index| %>
   <%= name %>: <%= data %>
 <% end %>
-```
-
-```
-Block argument `index` is never used. Use `each` instead of `each_with_index`, or prefix it with an underscore as `_index` to show it is intentionally unused.
 ```
 
 That suggestion is only made for the plain `|element, index|` shape. With any other parameter list the index is not simply droppable, so the regular message is used.
@@ -103,6 +105,12 @@ An unused argument is worth cleaning up but is not a reason to interrupt someone
 ```
 
 ```erb
+<% pages.each do %>
+  <div class="page"></div>
+<% end %>
+```
+
+```erb
 <%= form_with model: @user do |form| %>
   <%= form.text_field :name %>
 <% end %>
@@ -145,6 +153,12 @@ An unused argument is worth cleaning up but is not a reason to interrupt someone
 ```erb
 <% @pairs.each_with_index do |(name, data), index| %>
   <%= name %>: <%= data %>
+<% end %>
+```
+
+```erb
+<% pages.each do |page| %>
+  <div class="page"></div>
 <% end %>
 ```
 

--- a/javascript/packages/linter/docs/rules/erb-no-unused-block-argument.md
+++ b/javascript/packages/linter/docs/rules/erb-no-unused-block-argument.md
@@ -28,7 +28,7 @@ For helper blocks the signal is often stronger. A `form_with` block that never t
 <% end %>
 ```
 
-When the only argument of an `each` is unused, the block is not iterating over anything, it is repeating its body once per element. A block runs just as well without declaring the argument at all, so the message spells that out:
+When every argument of a block is unused, the block does not need a parameter list at all, and the message says so with the tag that is already there, minus the `|...|`:
 
 ```erb
 <% pages.each do |page| %>
@@ -36,9 +36,24 @@ When the only argument of an `each` is unused, the block is not iterating over a
 <% end %>
 ```
 
-That wording is only used for a receiver that reads as a plain reference, like `pages`, `@user.pages` or `Page.all`. When the `each` is called on something that takes arguments or a block, or is called with `&.`, the receiver is not worth repeating in the message, so the regular message is used.
+That is not limited to iteration. An unused `form` suggests `<%= form_with model: @user do %>`, an unused index suggests `<% 3.times do %>`. The tag is rewritten from the source, so whatever the block is called on is kept as it is, including trim markers, safe navigation and arguments. The rewrite is skipped when the tag spans multiple lines, when it is long enough to make the message unwieldy, or when an argument the rule does not report would be left behind, and the message falls back to a plain `Remove it`.
 
-When the unused argument is the index of an `each_with_index`, the message suggests `each` instead, for the same reason:
+Removing one argument out of several is a different edit than removing all of them, because a block destructures what it is yielded based on how many parameters it declares:
+
+```ruby
+[[1, 2], [3, 4]].each { |a, b| } # a is 1, b is 2
+[[1, 2], [3, 4]].each { |a| }    # a is [1, 2]
+```
+
+Dropping `value` from `|key, value|` would silently rebind `key` to the whole pair, so when only some of the arguments are unused, the message offers the underscore and nothing else:
+
+```erb
+<% @pairs.each do |key, value| %>
+  <%= key %>
+<% end %>
+```
+
+When the unused argument is the index of an `each_with_index`, the message suggests `each` instead, since that is what the loop is actually doing:
 
 ```erb
 <% @pairs.each_with_index do |(name, data), index| %>
@@ -46,7 +61,7 @@ When the unused argument is the index of an `each_with_index`, the message sugge
 <% end %>
 ```
 
-That suggestion is only made for the plain `|element, index|` shape. With any other parameter list the index is not simply droppable, so the regular message is used.
+That suggestion is only made for the plain `|element, index|` shape. With any other parameter list the index is not simply droppable, so the regular message is used. When neither argument is used, the rewritten tag drops the `_with_index` as well and suggests `<% @pairs.each do %>`.
 
 Ruby's convention for a binding that is deliberately ignored is a leading underscore, so `_user` is treated as intentional and never reported.
 

--- a/javascript/packages/linter/src/rules/erb-no-unused-block-argument.ts
+++ b/javascript/packages/linter/src/rules/erb-no-unused-block-argument.ts
@@ -3,21 +3,12 @@ import { BaseRuleVisitor } from "./rule-utils.js"
 
 import { isRubyLiteralNode, isRubyParameterNode, isPrismNodeType, substringFromByteOffset } from "@herb-tools/core"
 
-import type { ERBBlockNode, Node, ParseResult, ParserOptions, PrismNode } from "@herb-tools/core"
+import type { ERBBlockNode, Node, ParseResult, ParserOptions, PrismNode, RubyParameterNode } from "@herb-tools/core"
 import type { FullRuleConfig, LintContext, UnboundLintOffense } from "../types.js"
 
 const IGNORED_PREFIX = "_"
 const REPORTED_KINDS = ["positional", "rest"]
-
-const SIMPLE_RECEIVER_TYPES = [
-  "ClassVariableReadNode",
-  "ConstantPathNode",
-  "ConstantReadNode",
-  "GlobalVariableReadNode",
-  "InstanceVariableReadNode",
-  "LocalVariableReadNode",
-  "SelfNode",
-] as const
+const MAXIMUM_TAG_SUGGESTION_LENGTH = 60
 
 class NoUnusedBlockArgumentVisitor extends BaseRuleVisitor {
   visitERBBlockNode(node: ERBBlockNode): void {
@@ -31,6 +22,11 @@ class NoUnusedBlockArgumentVisitor extends BaseRuleVisitor {
     if (parameters.length === 0) return
 
     const source = this.rubySourceInBody(node)
+    const reported = parameters.filter(parameter => REPORTED_KINDS.includes(parameter.kind))
+
+    const removable = reported.length > 0 && reported.every(parameter => this.isUnused(source, parameter))
+    const removal = removable ? this.removalSuggestion(node, reported.length === parameters.length) : null
+    const indexArgument = removable ? null : this.eachWithIndexArgumentName(node)
 
     for (const parameter of parameters) {
       const name = parameter.name?.value
@@ -40,10 +36,14 @@ class NoUnusedBlockArgumentVisitor extends BaseRuleVisitor {
       if (!REPORTED_KINDS.includes(parameter.kind)) continue
       if (this.referencesName(source, name)) continue
 
-      const suggestion = this.suggestionFor(node, name)
+      const suggestion = removal ?? (name === indexArgument ? `Use \`each\` instead of \`each_with_index\`` : null)
+
+      const advice = suggestion
+        ? `${suggestion}, or prefix it with an underscore as \`_${name}\``
+        : `Prefix it with an underscore as \`_${name}\``
 
       this.addOffense(
-        `Block argument \`${name}\` is never used. ${suggestion}, or prefix it with an underscore as \`_${name}\` to show it is intentionally unused.`,
+        `Block argument \`${name}\` is never used. ${advice} to show it is intentionally unused.`,
         parameter.location,
         undefined,
         undefined,
@@ -52,21 +52,62 @@ class NoUnusedBlockArgumentVisitor extends BaseRuleVisitor {
     }
   }
 
-  private suggestionFor(node: ERBBlockNode, name: string): string {
-    if (name === this.eachWithIndexArgumentName(node)) {
-      return `Use \`each\` instead of \`each_with_index\``
-    }
+  private isUnused(source: string, parameter: RubyParameterNode): boolean {
+    const name = parameter.name?.value
 
-    const receiver = this.eachReceiverSource(node, name)
+    if (!name) return true
 
-    if (receiver) {
-      const opening = node.tag_opening?.value ?? "<%"
-      const closing = node.tag_closing?.value ?? "%>"
+    return !this.referencesName(source, name)
+  }
 
-      return `Remove it and write \`${opening} ${receiver}.each do ${closing}\``
+  private removalSuggestion(node: ERBBlockNode, dropsEveryArgument: boolean): string {
+    const tag = dropsEveryArgument ? this.tagWithoutBlockArguments(node) : null
+
+    if (tag && tag.length <= MAXIMUM_TAG_SUGGESTION_LENGTH) {
+      return `Remove it and write \`${tag}\``
     }
 
     return `Remove it`
+  }
+
+  private tagWithoutBlockArguments(node: ERBBlockNode): string | null {
+    const call = node.prismNode
+    const source = node.source
+
+    if (!source) return null
+    if (!isPrismNodeType(call, "CallNode")) return null
+
+    const opening = (call.block as PrismNode)?.parameters?.openingLoc
+    if (!opening) return null
+
+    const start = call.location.startOffset
+    const length = opening.startOffset - start
+    if (length <= 0) return null
+
+    const header = this.callHeader(source, call, start, length).trim()
+
+    if (header.includes("\n")) return null
+    if (!header.endsWith("do")) return null
+
+    const tagOpening = node.tag_opening?.value ?? "<%"
+    const tagClosing = node.tag_closing?.value ?? "%>"
+
+    return `${tagOpening} ${header} ${tagClosing}`
+  }
+
+  private callHeader(source: string, call: PrismNode, start: number, length: number): string {
+    const message = call.messageLoc
+
+    if (call.name === "each_with_index" && !call.arguments_ && message) {
+      const messageEnd = message.startOffset + message.length
+
+      const before = substringFromByteOffset(source, start, message.startOffset - start)
+      const after = substringFromByteOffset(source, messageEnd, start + length - messageEnd)
+
+      return `${before}each${after}`
+    }
+
+    return substringFromByteOffset(source, start, length)
   }
 
   private eachWithIndexArgumentName(node: ERBBlockNode): string | null {
@@ -79,27 +120,6 @@ class NoUnusedBlockArgumentVisitor extends BaseRuleVisitor {
     if (!isPrismNodeType(index, "RequiredParameterNode")) return null
 
     return index.name
-  }
-
-  private eachReceiverSource(node: ERBBlockNode, name: string): string | null {
-    const call = node.prismNode
-    const parameters = this.plainBlockParameters(node, "each")
-
-    if (!parameters) return null
-    if (parameters.requireds.length !== 1) return null
-
-    const element = parameters.requireds[0]
-    if (!isPrismNodeType(element, "RequiredParameterNode")) return null
-    if (element.name !== name) return null
-    if (call.isSafeNavigation()) return null
-
-    const receiver = call.receiver
-    if (!this.isSimpleReceiver(receiver)) return null
-
-    const source = node.source
-    if (!source) return null
-
-    return substringFromByteOffset(source, receiver.location.startOffset, receiver.location.length)
   }
 
   private plainBlockParameters(node: ERBBlockNode, method: string): PrismNode | null {
@@ -118,21 +138,6 @@ class NoUnusedBlockArgumentVisitor extends BaseRuleVisitor {
     if (parameters.rest || parameters.keywordRest || parameters.block) return null
 
     return parameters
-  }
-
-  private isSimpleReceiver(node: PrismNode | null | undefined): boolean {
-    if (!node) return false
-    if (SIMPLE_RECEIVER_TYPES.some(type => isPrismNodeType(node, type))) return true
-
-    if (isPrismNodeType(node, "CallNode")) {
-      if (node.arguments_ || node.block) return false
-      if (node.isSafeNavigation()) return false
-      if (!node.receiver) return true
-
-      return this.isSimpleReceiver(node.receiver)
-    }
-
-    return false
   }
 
   private rubySourceInBody(node: ERBBlockNode): string {

--- a/javascript/packages/linter/src/rules/erb-no-unused-block-argument.ts
+++ b/javascript/packages/linter/src/rules/erb-no-unused-block-argument.ts
@@ -1,13 +1,23 @@
 import { ParserRule } from "../types.js"
 import { BaseRuleVisitor } from "./rule-utils.js"
 
-import { isRubyLiteralNode, isRubyParameterNode, isPrismNodeType } from "@herb-tools/core"
+import { isRubyLiteralNode, isRubyParameterNode, isPrismNodeType, substringFromByteOffset } from "@herb-tools/core"
 
 import type { ERBBlockNode, Node, ParseResult, ParserOptions, PrismNode } from "@herb-tools/core"
 import type { FullRuleConfig, LintContext, UnboundLintOffense } from "../types.js"
 
 const IGNORED_PREFIX = "_"
 const REPORTED_KINDS = ["positional", "rest"]
+
+const SIMPLE_RECEIVER_TYPES = [
+  "ClassVariableReadNode",
+  "ConstantPathNode",
+  "ConstantReadNode",
+  "GlobalVariableReadNode",
+  "InstanceVariableReadNode",
+  "LocalVariableReadNode",
+  "SelfNode",
+] as const
 
 class NoUnusedBlockArgumentVisitor extends BaseRuleVisitor {
   visitERBBlockNode(node: ERBBlockNode): void {
@@ -21,7 +31,6 @@ class NoUnusedBlockArgumentVisitor extends BaseRuleVisitor {
     if (parameters.length === 0) return
 
     const source = this.rubySourceInBody(node)
-    const indexArgument = this.eachWithIndexArgumentName(node)
 
     for (const parameter of parameters) {
       const name = parameter.name?.value
@@ -31,9 +40,7 @@ class NoUnusedBlockArgumentVisitor extends BaseRuleVisitor {
       if (!REPORTED_KINDS.includes(parameter.kind)) continue
       if (this.referencesName(source, name)) continue
 
-      const suggestion = name === indexArgument
-        ? `Use \`each\` instead of \`each_with_index\``
-        : `Remove it`
+      const suggestion = this.suggestionFor(node, name)
 
       this.addOffense(
         `Block argument \`${name}\` is never used. ${suggestion}, or prefix it with an underscore as \`_${name}\` to show it is intentionally unused.`,
@@ -45,11 +52,61 @@ class NoUnusedBlockArgumentVisitor extends BaseRuleVisitor {
     }
   }
 
+  private suggestionFor(node: ERBBlockNode, name: string): string {
+    if (name === this.eachWithIndexArgumentName(node)) {
+      return `Use \`each\` instead of \`each_with_index\``
+    }
+
+    const receiver = this.eachReceiverSource(node, name)
+
+    if (receiver) {
+      const opening = node.tag_opening?.value ?? "<%"
+      const closing = node.tag_closing?.value ?? "%>"
+
+      return `Remove it and write \`${opening} ${receiver}.each do ${closing}\``
+    }
+
+    return `Remove it`
+  }
+
   private eachWithIndexArgumentName(node: ERBBlockNode): string | null {
+    const parameters = this.plainBlockParameters(node, "each_with_index")
+
+    if (!parameters) return null
+    if (parameters.requireds.length !== 2) return null
+
+    const index = parameters.requireds[1]
+    if (!isPrismNodeType(index, "RequiredParameterNode")) return null
+
+    return index.name
+  }
+
+  private eachReceiverSource(node: ERBBlockNode, name: string): string | null {
+    const call = node.prismNode
+    const parameters = this.plainBlockParameters(node, "each")
+
+    if (!parameters) return null
+    if (parameters.requireds.length !== 1) return null
+
+    const element = parameters.requireds[0]
+    if (!isPrismNodeType(element, "RequiredParameterNode")) return null
+    if (element.name !== name) return null
+    if (call.isSafeNavigation()) return null
+
+    const receiver = call.receiver
+    if (!this.isSimpleReceiver(receiver)) return null
+
+    const source = node.source
+    if (!source) return null
+
+    return substringFromByteOffset(source, receiver.location.startOffset, receiver.location.length)
+  }
+
+  private plainBlockParameters(node: ERBBlockNode, method: string): PrismNode | null {
     const call = node.prismNode
 
     if (!isPrismNodeType(call, "CallNode")) return null
-    if (call.name !== "each_with_index") return null
+    if (call.name !== method) return null
     if (call.arguments_) return null
 
     const parameters = (call.block as PrismNode)?.parameters?.parameters
@@ -59,12 +116,23 @@ class NoUnusedBlockArgumentVisitor extends BaseRuleVisitor {
     if (parameters.posts.length > 0) return null
     if (parameters.keywords.length > 0) return null
     if (parameters.rest || parameters.keywordRest || parameters.block) return null
-    if (parameters.requireds.length !== 2) return null
 
-    const index = parameters.requireds[1]
-    if (!isPrismNodeType(index, "RequiredParameterNode")) return null
+    return parameters
+  }
 
-    return index.name
+  private isSimpleReceiver(node: PrismNode | null | undefined): boolean {
+    if (!node) return false
+    if (SIMPLE_RECEIVER_TYPES.some(type => isPrismNodeType(node, type))) return true
+
+    if (isPrismNodeType(node, "CallNode")) {
+      if (node.arguments_ || node.block) return false
+      if (node.isSafeNavigation()) return false
+      if (!node.receiver) return true
+
+      return this.isSimpleReceiver(node.receiver)
+    }
+
+    return false
   }
 
   private rubySourceInBody(node: ERBBlockNode): string {

--- a/javascript/packages/linter/test/rules/erb-no-unused-block-argument.test.ts
+++ b/javascript/packages/linter/test/rules/erb-no-unused-block-argument.test.ts
@@ -17,7 +17,7 @@ describe("erb-no-unused-block-argument", () => {
       <% end %>
     `
 
-    expectError('Block argument `user` is never used. Remove it, or prefix it with an underscore as `_user` to show it is intentionally unused.')
+    expectError('Block argument `user` is never used. Remove it and write `<% @users.each do %>`, or prefix it with an underscore as `_user` to show it is intentionally unused.')
 
     assertOffenses(html)
   })
@@ -30,7 +30,7 @@ describe("erb-no-unused-block-argument", () => {
     `
 
     expectError(
-      'Block argument `user` is never used. Remove it, or prefix it with an underscore as `_user` to show it is intentionally unused.',
+      'Block argument `user` is never used. Remove it and write `<% @users.each do %>`, or prefix it with an underscore as `_user` to show it is intentionally unused.',
       [1, 19]
     )
 
@@ -187,7 +187,7 @@ describe("erb-no-unused-block-argument", () => {
       <% end %>
     `
 
-    expectError('Block argument `user` is never used. Remove it, or prefix it with an underscore as `_user` to show it is intentionally unused.')
+    expectError('Block argument `user` is never used. Remove it and write `<% @users.each do %>`, or prefix it with an underscore as `_user` to show it is intentionally unused.')
 
     assertOffenses(html)
   })
@@ -199,7 +199,7 @@ describe("erb-no-unused-block-argument", () => {
       <% end %>
     `
 
-    expectError('Block argument `user` is never used. Remove it, or prefix it with an underscore as `_user` to show it is intentionally unused.')
+    expectError('Block argument `user` is never used. Remove it and write `<% @users.each do %>`, or prefix it with an underscore as `_user` to show it is intentionally unused.')
 
     assertOffenses(html)
   })
@@ -310,7 +310,128 @@ describe("erb-no-unused-block-argument", () => {
       <% end %>
     `
 
-    expectError('Block argument `group` is never used. Remove it, or prefix it with an underscore as `_group` to show it is intentionally unused.')
+    expectError('Block argument `group` is never used. Remove it and write `<% @groups.each do %>`, or prefix it with an underscore as `_group` to show it is intentionally unused.')
+
+    assertOffenses(html)
+  })
+
+  it("suggests `each do` when the only `each` argument is unused", () => {
+    const html = dedent`
+      <% pages.each do |page| %>
+        <div class="page"></div>
+      <% end %>
+    `
+
+    expectError('Block argument `page` is never used. Remove it and write `<% pages.each do %>`, or prefix it with an underscore as `_page` to show it is intentionally unused.')
+
+    assertOffenses(html)
+  })
+
+  it("keeps the trim markers of the ERB tag in the suggestion", () => {
+    const html = dedent`
+      <%- pages.each do |page| -%>
+        <div class="page"></div>
+      <%- end -%>
+    `
+
+    expectError('Block argument `page` is never used. Remove it and write `<%- pages.each do -%>`, or prefix it with an underscore as `_page` to show it is intentionally unused.')
+
+    assertOffenses(html)
+  })
+
+  it("suggests `each do` for a chained receiver", () => {
+    const html = dedent`
+      <% @user.pages.each do |page| %>
+        <div class="page"></div>
+      <% end %>
+    `
+
+    expectError('Block argument `page` is never used. Remove it and write `<% @user.pages.each do %>`, or prefix it with an underscore as `_page` to show it is intentionally unused.')
+
+    assertOffenses(html)
+  })
+
+  it("suggests `each do` for a constant receiver", () => {
+    const html = dedent`
+      <% Page.all.each do |page| %>
+        <div class="page"></div>
+      <% end %>
+    `
+
+    expectError('Block argument `page` is never used. Remove it and write `<% Page.all.each do %>`, or prefix it with an underscore as `_page` to show it is intentionally unused.')
+
+    assertOffenses(html)
+  })
+
+  it("does not suggest `each do` for a receiverless `each`", () => {
+    const html = dedent`
+      <% each do |page| %>
+        <div class="page"></div>
+      <% end %>
+    `
+
+    expectError('Block argument `page` is never used. Remove it, or prefix it with an underscore as `_page` to show it is intentionally unused.')
+
+    assertOffenses(html)
+  })
+
+  it("does not suggest `each do` when the receiver takes arguments", () => {
+    const html = dedent`
+      <% pages.where(published: true).each do |page| %>
+        <div class="page"></div>
+      <% end %>
+    `
+
+    expectError('Block argument `page` is never used. Remove it, or prefix it with an underscore as `_page` to show it is intentionally unused.')
+
+    assertOffenses(html)
+  })
+
+  it("does not suggest `each do` when the receiver takes a block", () => {
+    const html = dedent`
+      <% pages.select { |page| page.published? }.each do |page| %>
+        <div class="page"></div>
+      <% end %>
+    `
+
+    expectError('Block argument `page` is never used. Remove it, or prefix it with an underscore as `_page` to show it is intentionally unused.')
+
+    assertOffenses(html)
+  })
+
+  it("does not suggest `each do` for a safe navigation `each`", () => {
+    const html = dedent`
+      <% pages&.each do |page| %>
+        <div class="page"></div>
+      <% end %>
+    `
+
+    expectError('Block argument `page` is never used. Remove it, or prefix it with an underscore as `_page` to show it is intentionally unused.')
+
+    assertOffenses(html)
+  })
+
+  it("does not suggest `each do` for a destructured `each` argument", () => {
+    const html = dedent`
+      <% pairs.each do |(name, data)| %>
+        <div class="pair"></div>
+      <% end %>
+    `
+
+    expectError('Block argument `name` is never used. Remove it, or prefix it with an underscore as `_name` to show it is intentionally unused.')
+    expectError('Block argument `data` is never used. Remove it, or prefix it with an underscore as `_data` to show it is intentionally unused.')
+
+    assertOffenses(html)
+  })
+
+  it("does not suggest `each do` for another iterator", () => {
+    const html = dedent`
+      <% pages.map do |page| %>
+        <div class="page"></div>
+      <% end %>
+    `
+
+    expectError('Block argument `page` is never used. Remove it, or prefix it with an underscore as `_page` to show it is intentionally unused.')
 
     assertOffenses(html)
   })

--- a/javascript/packages/linter/test/rules/erb-no-unused-block-argument.test.ts
+++ b/javascript/packages/linter/test/rules/erb-no-unused-block-argument.test.ts
@@ -11,30 +11,26 @@ const { expectNoOffenses, expectError, assertOffenses } = createLinterTest(ERBNo
 
 describe("erb-no-unused-block-argument", () => {
   it("flags a block argument that is never referenced", () => {
-    const html = dedent`
+    expectError('Block argument `user` is never used. Remove it and write `<% @users.each do %>`, or prefix it with an underscore as `_user` to show it is intentionally unused.')
+
+    assertOffenses(dedent`
       <% @users.each do |user| %>
         <p>Hello</p>
       <% end %>
-    `
-
-    expectError('Block argument `user` is never used. Remove it and write `<% @users.each do %>`, or prefix it with an underscore as `_user` to show it is intentionally unused.')
-
-    assertOffenses(html)
+    `)
   })
 
   it("reports the offense on the block argument itself", () => {
-    const html = dedent`
-      <% @users.each do |user| %>
-        <p>Hello</p>
-      <% end %>
-    `
-
     expectError(
       'Block argument `user` is never used. Remove it and write `<% @users.each do %>`, or prefix it with an underscore as `_user` to show it is intentionally unused.',
       [1, 19]
     )
 
-    assertOffenses(html)
+    assertOffenses(dedent`
+      <% @users.each do |user| %>
+        <p>Hello</p>
+      <% end %>
+    `)
   })
 
   it("does not flag a block argument used in an output tag", () => {
@@ -181,76 +177,106 @@ describe("erb-no-unused-block-argument", () => {
   })
 
   it("does not treat HTML text as a reference", () => {
-    const html = dedent`
+    expectError('Block argument `user` is never used. Remove it and write `<% @users.each do %>`, or prefix it with an underscore as `_user` to show it is intentionally unused.')
+
+    assertOffenses(dedent`
       <% @users.each do |user| %>
         <div class="user">A user</div>
       <% end %>
-    `
-
-    expectError('Block argument `user` is never used. Remove it and write `<% @users.each do %>`, or prefix it with an underscore as `_user` to show it is intentionally unused.')
-
-    assertOffenses(html)
+    `)
   })
 
   it("does not treat a longer identifier as a reference", () => {
-    const html = dedent`
+    expectError('Block argument `user` is never used. Remove it and write `<% @users.each do %>`, or prefix it with an underscore as `_user` to show it is intentionally unused.')
+
+    assertOffenses(dedent`
       <% @users.each do |user| %>
         <%= users_count %>
       <% end %>
-    `
-
-    expectError('Block argument `user` is never used. Remove it and write `<% @users.each do %>`, or prefix it with an underscore as `_user` to show it is intentionally unused.')
-
-    assertOffenses(html)
+    `)
   })
 
   it("flags each unused argument of a multi-argument block", () => {
-    const html = dedent`
+    expectError('Block argument `key` is never used. Remove it and write `<% @pairs.each do %>`, or prefix it with an underscore as `_key` to show it is intentionally unused.')
+    expectError('Block argument `value` is never used. Remove it and write `<% @pairs.each do %>`, or prefix it with an underscore as `_value` to show it is intentionally unused.')
+
+    assertOffenses(dedent`
       <% @pairs.each do |key, value| %>
         <p>Nothing</p>
       <% end %>
-    `
-
-    expectError('Block argument `key` is never used. Remove it, or prefix it with an underscore as `_key` to show it is intentionally unused.')
-    expectError('Block argument `value` is never used. Remove it, or prefix it with an underscore as `_value` to show it is intentionally unused.')
-
-    assertOffenses(html)
+    `)
   })
 
-  it("flags only the unused argument when another is used", () => {
-    const html = dedent`
+  it("does not suggest removing an argument that another one is used alongside", () => {
+    expectError('Block argument `value` is never used. Prefix it with an underscore as `_value` to show it is intentionally unused.')
+
+    assertOffenses(dedent`
       <% @pairs.each do |key, value| %>
         <%= key %>
       <% end %>
-    `
-
-    expectError('Block argument `value` is never used. Remove it, or prefix it with an underscore as `_value` to show it is intentionally unused.')
-
-    assertOffenses(html)
+    `)
   })
 
-  it("flags an unused destructured argument", () => {
-    const html = dedent`
+  it("does not suggest removing an unused destructured argument", () => {
+    expectError('Block argument `value` is never used. Prefix it with an underscore as `_value` to show it is intentionally unused.')
+
+    assertOffenses(dedent`
       <% @pairs.each do |(key, value)| %>
         <%= key %>
       <% end %>
-    `
+    `)
+  })
 
-    expectError('Block argument `value` is never used. Remove it, or prefix it with an underscore as `_value` to show it is intentionally unused.')
+  it("suggests removing every argument when all of them are destructured and unused", () => {
+    expectError('Block argument `key` is never used. Remove it and write `<% @pairs.each do %>`, or prefix it with an underscore as `_key` to show it is intentionally unused.')
+    expectError('Block argument `value` is never used. Remove it and write `<% @pairs.each do %>`, or prefix it with an underscore as `_value` to show it is intentionally unused.')
 
-    assertOffenses(html)
+    assertOffenses(dedent`
+      <% @pairs.each do |(key, value)| %>
+        <p>Nothing</p>
+      <% end %>
+    `)
   })
 
   it("flags an unused splat argument", () => {
-    const html = dedent`
+    expectError('Block argument `columns` is never used. Remove it and write `<% @rows.each do %>`, or prefix it with an underscore as `_columns` to show it is intentionally unused.')
+
+    assertOffenses(dedent`
       <% @rows.each do |*columns| %>
         <p>Nothing</p>
       <% end %>
-    `
+    `)
+  })
 
-    expectError('Block argument `columns` is never used. Remove it, or prefix it with an underscore as `_columns` to show it is intentionally unused.')
+  it("does not rewrite the tag when a block argument stays behind", () => {
+    expectError('Block argument `user` is never used. Remove it, or prefix it with an underscore as `_user` to show it is intentionally unused.')
 
-    assertOffenses(html)
+    assertOffenses(dedent`
+      <% @users.each do |user, &callback| %>
+        <p>Nothing</p>
+      <% end %>
+    `)
+  })
+
+  it("does not rewrite a tag that spans multiple lines", () => {
+    expectError('Block argument `form` is never used. Remove it, or prefix it with an underscore as `_form` to show it is intentionally unused.')
+
+    assertOffenses(dedent`
+      <%= form_with model: @user,
+            url: profile_path do |form| %>
+        <p>Nothing</p>
+      <% end %>
+    `)
+  })
+
+  it("does not rewrite a tag that would make the message unwieldy", () => {
+    expectError('Block argument `form` is never used. Remove it, or prefix it with an underscore as `_form` to show it is intentionally unused.')
+
+    assertOffenses(dedent`
+      <%= form_with model: @user, url: profile_path(@user, @account), html: { class: "form" } do |form| %>
+        <p>Nothing</p>
+      <% end %>
+    `)
   })
 
   it("does not flag a block without arguments", () => {
@@ -272,15 +298,13 @@ describe("erb-no-unused-block-argument", () => {
   })
 
   it("flags an unused builder block argument", () => {
-    const html = dedent`
+    expectError('Block argument `form` is never used. Remove it and write `<%= form_with model: @user do %>`, or prefix it with an underscore as `_form` to show it is intentionally unused.')
+
+    assertOffenses(dedent`
       <%= form_with model: @user do |form| %>
         <p>Nothing</p>
       <% end %>
-    `
-
-    expectError('Block argument `form` is never used. Remove it, or prefix it with an underscore as `_form` to show it is intentionally unused.')
-
-    assertOffenses(html)
+    `)
   })
 
   it("does not flag a builder block argument that is used", () => {
@@ -302,222 +326,186 @@ describe("erb-no-unused-block-argument", () => {
   })
 
   it("flags the outer argument of nested iteration when only the inner is used", () => {
-    const html = dedent`
+    expectError('Block argument `group` is never used. Remove it and write `<% @groups.each do %>`, or prefix it with an underscore as `_group` to show it is intentionally unused.')
+
+    assertOffenses(dedent`
       <% @groups.each do |group| %>
         <% @users.each do |user| %>
           <%= user.name %>
         <% end %>
       <% end %>
-    `
-
-    expectError('Block argument `group` is never used. Remove it and write `<% @groups.each do %>`, or prefix it with an underscore as `_group` to show it is intentionally unused.')
-
-    assertOffenses(html)
+    `)
   })
 
   it("suggests `each do` when the only `each` argument is unused", () => {
-    const html = dedent`
+    expectError('Block argument `page` is never used. Remove it and write `<% pages.each do %>`, or prefix it with an underscore as `_page` to show it is intentionally unused.')
+
+    assertOffenses(dedent`
       <% pages.each do |page| %>
         <div class="page"></div>
       <% end %>
-    `
-
-    expectError('Block argument `page` is never used. Remove it and write `<% pages.each do %>`, or prefix it with an underscore as `_page` to show it is intentionally unused.')
-
-    assertOffenses(html)
+    `)
   })
 
   it("keeps the trim markers of the ERB tag in the suggestion", () => {
-    const html = dedent`
+    expectError('Block argument `page` is never used. Remove it and write `<%- pages.each do -%>`, or prefix it with an underscore as `_page` to show it is intentionally unused.')
+
+    assertOffenses(dedent`
       <%- pages.each do |page| -%>
         <div class="page"></div>
       <%- end -%>
-    `
-
-    expectError('Block argument `page` is never used. Remove it and write `<%- pages.each do -%>`, or prefix it with an underscore as `_page` to show it is intentionally unused.')
-
-    assertOffenses(html)
+    `)
   })
 
   it("suggests `each do` for a chained receiver", () => {
-    const html = dedent`
+    expectError('Block argument `page` is never used. Remove it and write `<% @user.pages.each do %>`, or prefix it with an underscore as `_page` to show it is intentionally unused.')
+
+    assertOffenses(dedent`
       <% @user.pages.each do |page| %>
         <div class="page"></div>
       <% end %>
-    `
-
-    expectError('Block argument `page` is never used. Remove it and write `<% @user.pages.each do %>`, or prefix it with an underscore as `_page` to show it is intentionally unused.')
-
-    assertOffenses(html)
+    `)
   })
 
   it("suggests `each do` for a constant receiver", () => {
-    const html = dedent`
+    expectError('Block argument `page` is never used. Remove it and write `<% Page.all.each do %>`, or prefix it with an underscore as `_page` to show it is intentionally unused.')
+
+    assertOffenses(dedent`
       <% Page.all.each do |page| %>
         <div class="page"></div>
       <% end %>
-    `
-
-    expectError('Block argument `page` is never used. Remove it and write `<% Page.all.each do %>`, or prefix it with an underscore as `_page` to show it is intentionally unused.')
-
-    assertOffenses(html)
+    `)
   })
 
-  it("does not suggest `each do` for a receiverless `each`", () => {
-    const html = dedent`
+  it("keeps a receiverless call in the suggestion", () => {
+    expectError('Block argument `page` is never used. Remove it and write `<% each do %>`, or prefix it with an underscore as `_page` to show it is intentionally unused.')
+
+    assertOffenses(dedent`
       <% each do |page| %>
         <div class="page"></div>
       <% end %>
-    `
-
-    expectError('Block argument `page` is never used. Remove it, or prefix it with an underscore as `_page` to show it is intentionally unused.')
-
-    assertOffenses(html)
+    `)
   })
 
-  it("does not suggest `each do` when the receiver takes arguments", () => {
-    const html = dedent`
+  it("keeps the arguments of the receiver in the suggestion", () => {
+    expectError('Block argument `page` is never used. Remove it and write `<% pages.where(published: true).each do %>`, or prefix it with an underscore as `_page` to show it is intentionally unused.')
+
+    assertOffenses(dedent`
       <% pages.where(published: true).each do |page| %>
         <div class="page"></div>
       <% end %>
-    `
-
-    expectError('Block argument `page` is never used. Remove it, or prefix it with an underscore as `_page` to show it is intentionally unused.')
-
-    assertOffenses(html)
+    `)
   })
 
-  it("does not suggest `each do` when the receiver takes a block", () => {
-    const html = dedent`
-      <% pages.select { |page| page.published? }.each do |page| %>
-        <div class="page"></div>
-      <% end %>
-    `
+  it("keeps safe navigation in the suggestion", () => {
+    expectError('Block argument `page` is never used. Remove it and write `<% pages&.each do %>`, or prefix it with an underscore as `_page` to show it is intentionally unused.')
 
-    expectError('Block argument `page` is never used. Remove it, or prefix it with an underscore as `_page` to show it is intentionally unused.')
-
-    assertOffenses(html)
-  })
-
-  it("does not suggest `each do` for a safe navigation `each`", () => {
-    const html = dedent`
+    assertOffenses(dedent`
       <% pages&.each do |page| %>
         <div class="page"></div>
       <% end %>
-    `
-
-    expectError('Block argument `page` is never used. Remove it, or prefix it with an underscore as `_page` to show it is intentionally unused.')
-
-    assertOffenses(html)
+    `)
   })
 
-  it("does not suggest `each do` for a destructured `each` argument", () => {
-    const html = dedent`
-      <% pairs.each do |(name, data)| %>
-        <div class="pair"></div>
-      <% end %>
-    `
+  it("suggests the tag for another iterator", () => {
+    expectError('Block argument `page` is never used. Remove it and write `<% pages.map do %>`, or prefix it with an underscore as `_page` to show it is intentionally unused.')
 
-    expectError('Block argument `name` is never used. Remove it, or prefix it with an underscore as `_name` to show it is intentionally unused.')
-    expectError('Block argument `data` is never used. Remove it, or prefix it with an underscore as `_data` to show it is intentionally unused.')
-
-    assertOffenses(html)
-  })
-
-  it("does not suggest `each do` for another iterator", () => {
-    const html = dedent`
+    assertOffenses(dedent`
       <% pages.map do |page| %>
         <div class="page"></div>
       <% end %>
-    `
+    `)
+  })
 
-    expectError('Block argument `page` is never used. Remove it, or prefix it with an underscore as `_page` to show it is intentionally unused.')
+  it("suggests the tag for a block that is not an iteration", () => {
+    expectError('Block argument `index` is never used. Remove it and write `<% 3.times do %>`, or prefix it with an underscore as `_index` to show it is intentionally unused.')
 
-    assertOffenses(html)
+    assertOffenses(dedent`
+      <% 3.times do |index| %>
+        <div class="page"></div>
+      <% end %>
+    `)
   })
 
   it("suggests `each` when the `each_with_index` index is unused", () => {
-    const html = dedent`
+    expectError('Block argument `index` is never used. Use `each` instead of `each_with_index`, or prefix it with an underscore as `_index` to show it is intentionally unused.')
+
+    assertOffenses(dedent`
       <% @users.each_with_index do |user, index| %>
         <%= user.name %>
       <% end %>
-    `
-
-    expectError('Block argument `index` is never used. Use `each` instead of `each_with_index`, or prefix it with an underscore as `_index` to show it is intentionally unused.')
-
-    assertOffenses(html)
+    `)
   })
 
   it("suggests `each` when the index is unused alongside a destructured element", () => {
-    const html = dedent`
+    expectError('Block argument `index` is never used. Use `each` instead of `each_with_index`, or prefix it with an underscore as `_index` to show it is intentionally unused.')
+
+    assertOffenses(dedent`
       <% @pairs.each_with_index do |(name, data), index| %>
         <%= name %>: <%= data %>
       <% end %>
-    `
-
-    expectError('Block argument `index` is never used. Use `each` instead of `each_with_index`, or prefix it with an underscore as `_index` to show it is intentionally unused.')
-
-    assertOffenses(html)
+    `)
   })
 
   it("suggests `each` for a receiverless `each_with_index`", () => {
-    const html = dedent`
+    expectError('Block argument `index` is never used. Use `each` instead of `each_with_index`, or prefix it with an underscore as `_index` to show it is intentionally unused.')
+
+    assertOffenses(dedent`
       <% each_with_index do |user, index| %>
         <%= user.name %>
       <% end %>
-    `
-
-    expectError('Block argument `index` is never used. Use `each` instead of `each_with_index`, or prefix it with an underscore as `_index` to show it is intentionally unused.')
-
-    assertOffenses(html)
+    `)
   })
 
   it("does not suggest `each` for an unused element of `each_with_index`", () => {
-    const html = dedent`
+    expectError('Block argument `user` is never used. Prefix it with an underscore as `_user` to show it is intentionally unused.')
+
+    assertOffenses(dedent`
       <% @users.each_with_index do |user, index| %>
         <%= index %>
       <% end %>
-    `
-
-    expectError('Block argument `user` is never used. Remove it, or prefix it with an underscore as `_user` to show it is intentionally unused.')
-
-    assertOffenses(html)
+    `)
   })
 
-  it("does not suggest `each` when the `each_with_index` block takes a single argument", () => {
-    const html = dedent`
+  it("suggests `each` when the `each_with_index` block takes a single unused argument", () => {
+    expectError('Block argument `user` is never used. Remove it and write `<% @users.each do %>`, or prefix it with an underscore as `_user` to show it is intentionally unused.')
+
+    assertOffenses(dedent`
       <% @users.each_with_index do |user| %>
         <p>Hello</p>
       <% end %>
-    `
+    `)
+  })
 
-    expectError('Block argument `user` is never used. Remove it, or prefix it with an underscore as `_user` to show it is intentionally unused.')
+  it("suggests `each` when neither `each_with_index` argument is used", () => {
+    expectError('Block argument `user` is never used. Remove it and write `<% @users.each do %>`, or prefix it with an underscore as `_user` to show it is intentionally unused.')
+    expectError('Block argument `index` is never used. Remove it and write `<% @users.each do %>`, or prefix it with an underscore as `_index` to show it is intentionally unused.')
 
-    assertOffenses(html)
+    assertOffenses(dedent`
+      <% @users.each_with_index do |user, index| %>
+        <p>Hello</p>
+      <% end %>
+    `)
   })
 
   it("does not suggest `each` when the `each_with_index` block splats its arguments", () => {
-    const html = dedent`
+    expectError('Block argument `rest` is never used. Prefix it with an underscore as `_rest` to show it is intentionally unused.')
+
+    assertOffenses(dedent`
       <% @users.each_with_index do |user, *rest| %>
         <%= user.name %>
       <% end %>
-    `
-
-    expectError('Block argument `rest` is never used. Remove it, or prefix it with an underscore as `_rest` to show it is intentionally unused.')
-
-    assertOffenses(html)
+    `)
   })
 
   it("does not suggest `each` for an unused argument of another iterator", () => {
-    const html = dedent`
+    expectError('Block argument `index` is never used. Prefix it with an underscore as `_index` to show it is intentionally unused.')
+
+    assertOffenses(dedent`
       <% @users.each_with_object([]) do |user, index| %>
         <%= user.name %>
       <% end %>
-    `
-
-    expectError('Block argument `index` is never used. Remove it, or prefix it with an underscore as `_index` to show it is intentionally unused.')
-
-    assertOffenses(html)
+    `)
   })
 
   it("does not flag a used `each_with_index` index", () => {


### PR DESCRIPTION
Follow up on #1958 and #1968.

Every unused block argument that isn't an `each_with_index` index gets the same advice today: "Remove it, or prefix it with an underscore". This pull request makes that concrete where it can be, and stops giving it where it is wrong.

#### Show the tag to write

When every argument of the block is unused, the parameter list can go entirely, so the message now shows the tag the author already wrote, minus the `|...|`:

```erb
<% pages.each do |page| %>
  <div class="stories-progress-bar"></div>
<% end %>
```

```diff
- Block argument `page` is never used. Remove it, or prefix it with an underscore as `_page` to show it is intentionally unused.
+ Block argument `page` is never used. Remove it and write `<% pages.each do %>`, or prefix it with an underscore as `_page` to show it is intentionally unused.
```

This is not limited to `each`, and the tag is rewritten from the source, so whatever the block is called on is kept as it is.


The rewrite is skipped, and the message falls back to the plain `Remove it`, when the tag spans multiple lines, when the rewritten tag would be longer than 60 characters, or when an argument the rule does not report (`&block`, `**options`) would be left behind.

#### Stop suggesting a removal that rebinds the other arguments

A block destructures what it is yielded based on how many parameters it declares, so removing one argument out of several is not the same edit as removing all of them:

```ruby
[[1, 2], [3, 4]].each { |a, b| } # a is 1, b is 2
[[1, 2], [3, 4]].each { |a| }    # a is [1, 2]
```

Following the old advice here would rebind `key` from the key to the whole pair, and the page would start rendering `[:name, "Marco"]`:

```erb
<% @pairs.each do |key, value| %>
  <%= key %>
<% end %>
```

```diff
- Block argument `value` is never used. Remove it, or prefix it with an underscore as `_value` to show it is intentionally unused.
+ Block argument `value` is never used. Prefix it with an underscore as `_value` to show it is intentionally unused.
```

So removal is only offered when every reported argument is unused. When some of them are still in use, the underscore is the only correct fix and the message says just that. The same applies to the element of an `each_with_index` whose index is used, and to an unused argument of a destructured `|(key, value)|`.

The `each_with_index` message from #1968 is unchanged for the shape it was written for. When the element is used and only the index is not, it still suggests `each` instead of `each_with_index`.

