### PR TITLE
Config: Report when a wrongly named config file is present

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -14,6 +14,14 @@ your-project/
 └── ...
 ```
 
+::: warning Only `.herb.yml` is read
+`.herb.yml` is the only filename Herb reads, following the convention used by Rails and most other Ruby tooling. A file named `.herb.yaml`, `herb.yml`, or `herb.yaml` is ignored, and every Herb tool warns about it so it doesn't look like your configuration is being applied:
+
+```
+⚠ Ignoring /your-project/.herb.yaml: Herb only reads `.herb.yml`. Rename it to `.herb.yml` to apply it.
+```
+:::
+
 ## Configuration Priority
 
 Configuration settings are applied in the following order (highest to lowest priority):

--- a/javascript/packages/config/src/config.ts
+++ b/javascript/packages/config/src/config.ts
@@ -1,17 +1,19 @@
 import path from "path"
-
-import { promises as fs } from "fs"
-import { stringify, parse, parseDocument, isMap } from "yaml"
-import { ZodError } from "zod"
-import { fromZodError } from "zod-validation-error"
 import picomatch from "picomatch"
-import { DiagnosticSeverity, semverGreaterThan } from "@herb-tools/core"
-import { HerbConfigSchema } from "./config-schema.js"
-import { deepMerge } from "./merge.js"
-
 import packageJson from "../package.json"
 import configTemplate from "./config-template.yml"
 import defaultsYaml from "../../../../lib/herb/defaults.yml"
+
+import { stringify, parse, parseDocument, isMap } from "yaml"
+import { semverGreaterThan } from "@herb-tools/core"
+import { promises as fs } from "fs"
+import { fromZodError } from "zod-validation-error"
+import { deepMerge } from "./merge.js"
+
+import { ZodError } from "zod"
+import { HerbConfigSchema } from "./config-schema.js"
+
+import type { DiagnosticSeverity } from "@herb-tools/core"
 
 const DEFAULT_VERSION = packageJson.version
 const PARSED_DEFAULTS = parse(defaultsYaml) as Omit<HerbConfig, 'version'>
@@ -124,6 +126,8 @@ export type FromObjectOptions = {
 
 export class Config {
   static configPath = ".herb.yml"
+
+  static misnamedConfigPaths = [".herb.yaml", "herb.yml", "herb.yaml"]
 
   private static PROJECT_INDICATORS = [
     '.git',
@@ -526,6 +530,46 @@ export class Config {
     }
   }
 
+  static isMisnamedConfigPath(pathOrFile: string): boolean {
+    return this.misnamedConfigPaths.includes(path.basename(pathOrFile))
+  }
+
+  static async findMisnamedConfigPaths(projectPath: string): Promise<string[]> {
+    const candidates = await Promise.all(
+      this.misnamedConfigPaths.map(async filename => {
+        const candidate = path.join(projectPath, filename)
+
+        try {
+          await fs.access(candidate)
+
+          return candidate
+        } catch {
+          return null
+        }
+      })
+    )
+
+    return candidates.filter((candidate): candidate is string => candidate !== null)
+  }
+
+  static misnamedConfigWarning(misnamedPath: string): string {
+    return `⚠ Ignoring ${misnamedPath}: Herb only reads \`${this.configPath}\`. Rename it to \`${this.configPath}\` to apply it.`
+  }
+
+  private static async warnAboutMisnamedConfigFiles(projectPath: string, additionalPaths: string[] = []) {
+    const misnamedPaths = new Set(await this.findMisnamedConfigPaths(projectPath))
+
+    for (const additionalPath of additionalPaths) {
+      if (this.isMisnamedConfigPath(additionalPath)) {
+        misnamedPaths.add(path.resolve(additionalPath))
+      }
+    }
+
+    for (const misnamedPath of misnamedPaths) {
+      console.error(this.misnamedConfigWarning(misnamedPath))
+    }
+  }
+
   /**
    * Find the project root by walking up from a given path.
    * Looks for .herb.yml first, then falls back to project indicators
@@ -637,6 +681,10 @@ export class Config {
       }
 
       const { configPath, projectRoot } = await this.findConfigFile(pathOrFile)
+
+      if (!silent) {
+        await this.warnAboutMisnamedConfigFiles(projectRoot, [pathOrFile])
+      }
 
       if (configPath) {
         return await this.loadFromPath(configPath, projectRoot, silent, version, exitOnError)
@@ -1014,6 +1062,8 @@ export class Config {
     const config = await this.readAndValidateConfig(resolvedPath, projectRoot, version, exitOnError)
 
     if (!silent) {
+      await this.warnAboutMisnamedConfigFiles(projectRoot)
+
       console.error(`✓ Using Herb config file at ${resolvedPath}`)
     }
 
@@ -1047,19 +1097,6 @@ export class Config {
     silent: boolean,
     version: string
   ): Promise<Config> {
-    const yamlPath = path.join(projectRoot, '.herb.yaml')
-
-    try {
-      await fs.access(yamlPath)
-
-      console.error(`\n✗ Found \`.herb.yaml\` file at ${yamlPath}`)
-      console.error(`  Please rename it to \`.herb.yml\`\n`)
-
-      process.exit(1)
-    } catch {
-      // File doesn't exist
-    }
-
     const configPath = this.configPathFromProjectPath(projectRoot)
 
     try {
@@ -1096,20 +1133,15 @@ export class Config {
     const projectPath = options?.projectPath
 
     if (projectPath) {
-      try {
-        const yamlPath = path.join(projectPath, '.herb.yaml')
-        await fs.access(yamlPath)
-
+      for (const misnamedPath of await this.findMisnamedConfigPaths(projectPath)) {
         errors.push({
-          message: 'Found .herb.yaml file. Please rename to .herb.yml',
+          message: `Found ${path.basename(misnamedPath)} file. Please rename to ${this.configPath}`,
           path: [],
           code: 'wrong_file_extension',
           severity: 'warning',
           line: 0,
           column: 0
         })
-      } catch {
-        // .herb.yaml doesn't exist
       }
     }
 

--- a/javascript/packages/config/test/misnamed-config.test.ts
+++ b/javascript/packages/config/test/misnamed-config.test.ts
@@ -1,0 +1,229 @@
+import { describe, test, expect, beforeEach, afterEach, vi } from "vitest"
+import { mkdirSync, writeFileSync, rmSync, existsSync } from "fs"
+import { join } from "path"
+import { tmpdir } from "os"
+
+import { Config } from "../src/config.js"
+
+describe("misnamed config files", () => {
+  let testDir: string
+
+  beforeEach(() => {
+    testDir = join(tmpdir(), `herb-misnamed-config-test-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+    mkdirSync(join(testDir, ".git"), { recursive: true })
+    writeFileSync(join(testDir, ".git", "HEAD"), "ref: refs/heads/main\n")
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+
+    if (existsSync(testDir)) {
+      rmSync(testDir, { recursive: true, force: true })
+    }
+  })
+
+  function captureStderr() {
+    const messages: string[] = []
+
+    vi.spyOn(console, "error").mockImplementation((...args: any[]) => {
+      messages.push(args.join(" "))
+    })
+
+    return messages
+  }
+
+  describe("Config.misnamedConfigPaths", () => {
+    test("covers the wrong extension and the missing leading dot", () => {
+      expect(Config.misnamedConfigPaths).toEqual([".herb.yaml", "herb.yml", "herb.yaml"])
+    })
+  })
+
+  describe("Config.isMisnamedConfigPath", () => {
+    test("recognizes misnamed config files", () => {
+      expect(Config.isMisnamedConfigPath(".herb.yaml")).toBe(true)
+      expect(Config.isMisnamedConfigPath("herb.yml")).toBe(true)
+      expect(Config.isMisnamedConfigPath("herb.yaml")).toBe(true)
+      expect(Config.isMisnamedConfigPath("/project/.herb.yaml")).toBe(true)
+    })
+
+    test("ignores the config file Herb reads", () => {
+      expect(Config.isMisnamedConfigPath(".herb.yml")).toBe(false)
+      expect(Config.isMisnamedConfigPath("/project/.herb.yml")).toBe(false)
+    })
+
+    test("ignores unrelated files", () => {
+      expect(Config.isMisnamedConfigPath("config.yml")).toBe(false)
+      expect(Config.isMisnamedConfigPath("myherb.yml")).toBe(false)
+      expect(Config.isMisnamedConfigPath(".herb.yml.bak")).toBe(false)
+      expect(Config.isMisnamedConfigPath("/project")).toBe(false)
+    })
+  })
+
+  describe("Config.findMisnamedConfigPaths", () => {
+    test("returns every misnamed config file", async () => {
+      writeFileSync(join(testDir, ".herb.yaml"), "")
+      writeFileSync(join(testDir, "herb.yaml"), "")
+
+      expect(await Config.findMisnamedConfigPaths(testDir)).toEqual([
+        join(testDir, ".herb.yaml"),
+        join(testDir, "herb.yaml")
+      ])
+    })
+
+    test("ignores the config file Herb reads", async () => {
+      writeFileSync(join(testDir, ".herb.yml"), "")
+
+      expect(await Config.findMisnamedConfigPaths(testDir)).toEqual([])
+    })
+
+  })
+
+  describe("Config.misnamedConfigWarning", () => {
+    test("names the file and the fix", () => {
+      expect(Config.misnamedConfigWarning("/project/.herb.yaml")).toBe(
+        "⚠ Ignoring /project/.herb.yaml: Herb only reads `.herb.yml`. Rename it to `.herb.yml` to apply it."
+      )
+    })
+  })
+
+  describe("Config.load", () => {
+    test("warns about a config file with the wrong extension", async () => {
+      writeFileSync(join(testDir, ".herb.yaml"), "linter:\n  enabled: false\n")
+
+      const messages = captureStderr()
+
+      await Config.load(testDir, { version: "0.10.3" })
+
+      expect(messages).toContain(Config.misnamedConfigWarning(join(testDir, ".herb.yaml")))
+    })
+
+    test("warns about a config file missing the leading dot", async () => {
+      writeFileSync(join(testDir, "herb.yml"), "linter:\n  enabled: false\n")
+
+      const messages = captureStderr()
+
+      await Config.load(testDir, { version: "0.10.3" })
+
+      expect(messages).toContain(Config.misnamedConfigWarning(join(testDir, "herb.yml")))
+    })
+
+    test("warns once about every misnamed config file", async () => {
+      for (const filename of Config.misnamedConfigPaths) {
+        writeFileSync(join(testDir, filename), "")
+      }
+
+      const messages = captureStderr()
+
+      await Config.load(testDir, { version: "0.10.3" })
+
+      const warnings = messages.filter(message => message.includes("Herb only reads"))
+
+      expect(warnings).toEqual(Config.misnamedConfigPaths.map(filename => Config.misnamedConfigWarning(join(testDir, filename))))
+    })
+
+    test("warns when a misnamed config file is passed explicitly", async () => {
+      const misnamedPath = join(testDir, ".herb.yaml")
+
+      writeFileSync(misnamedPath, "linter:\n  enabled: false\n")
+
+      const messages = captureStderr()
+
+      await Config.load(misnamedPath, { version: "0.10.3" })
+
+      expect(messages.filter(message => message.includes("Herb only reads"))).toEqual([Config.misnamedConfigWarning(misnamedPath)])
+    })
+
+    test("does not warn when only the config file Herb reads exists", async () => {
+      writeFileSync(join(testDir, ".herb.yml"), "linter:\n  enabled: false\n")
+
+      const messages = captureStderr()
+
+      await Config.load(testDir, { version: "0.10.3" })
+
+      expect(messages.filter(message => message.includes("Herb only reads"))).toEqual([])
+    })
+
+    test("does not warn in silent mode", async () => {
+      writeFileSync(join(testDir, ".herb.yaml"), "")
+
+      const messages = captureStderr()
+
+      await Config.load(testDir, { version: "0.10.3", silent: true })
+
+      expect(messages).toEqual([])
+    })
+
+    test("does not read a misnamed config file", async () => {
+      writeFileSync(join(testDir, ".herb.yaml"), "version: 0.8.0\nformatter:\n  indentWidth: 8\n")
+
+      const config = await Config.load(testDir, { version: "0.10.3", silent: true })
+
+      expect(config.configVersion).toBeUndefined()
+      expect(config.formatter?.indentWidth).not.toBe(8)
+    })
+
+    test("still reads the config file next to a misnamed one", async () => {
+      writeFileSync(join(testDir, ".herb.yml"), "version: 0.8.0\nformatter:\n  indentWidth: 4\n")
+      writeFileSync(join(testDir, ".herb.yaml"), "version: 0.9.0\nformatter:\n  indentWidth: 8\n")
+
+      const messages = captureStderr()
+
+      const config = await Config.load(testDir, { version: "0.10.3" })
+
+      expect(config.path).toBe(join(testDir, ".herb.yml"))
+      expect(config.configVersion).toBe("0.8.0")
+      expect(config.formatter?.indentWidth).toBe(4)
+      expect(messages).toContain(Config.misnamedConfigWarning(join(testDir, ".herb.yaml")))
+    })
+
+    test("creates the default config next to a misnamed one instead of exiting", async () => {
+      writeFileSync(join(testDir, ".herb.yaml"), "linter:\n  enabled: false\n")
+
+      const messages = captureStderr()
+
+      await Config.load(testDir, { version: "0.10.3", createIfMissing: true })
+
+      expect(existsSync(join(testDir, ".herb.yml"))).toBe(true)
+      expect(messages).toContain(Config.misnamedConfigWarning(join(testDir, ".herb.yaml")))
+    })
+  })
+
+  describe("Config.validateConfigText", () => {
+    test("reports a config file with the wrong extension", async () => {
+      writeFileSync(join(testDir, ".herb.yaml"), "")
+
+      const errors = await Config.validateConfigText("version: 0.10.3\n", { version: "0.10.3", projectPath: testDir })
+      const warning = errors.find(error => error.code === "wrong_file_extension")
+
+      expect(warning?.message).toBe("Found .herb.yaml file. Please rename to .herb.yml")
+      expect(warning?.severity).toBe("warning")
+    })
+
+    test("reports a config file missing the leading dot", async () => {
+      writeFileSync(join(testDir, "herb.yml"), "")
+
+      const errors = await Config.validateConfigText("version: 0.10.3\n", { version: "0.10.3", projectPath: testDir })
+      const warning = errors.find(error => error.code === "wrong_file_extension")
+
+      expect(warning?.message).toBe("Found herb.yml file. Please rename to .herb.yml")
+    })
+
+    test("reports every misnamed config file", async () => {
+      for (const filename of Config.misnamedConfigPaths) {
+        writeFileSync(join(testDir, filename), "")
+      }
+
+      const errors = await Config.validateConfigText("version: 0.10.3\n", { version: "0.10.3", projectPath: testDir })
+
+      expect(errors.filter(error => error.code === "wrong_file_extension")).toHaveLength(3)
+    })
+
+    test("does not report anything when only the config file Herb reads exists", async () => {
+      writeFileSync(join(testDir, ".herb.yml"), "")
+
+      const errors = await Config.validateConfigText("version: 0.10.3\n", { version: "0.10.3", projectPath: testDir })
+
+      expect(errors.filter(error => error.code === "wrong_file_extension")).toEqual([])
+    })
+  })
+})

--- a/lib/herb/configuration.rb
+++ b/lib/herb/configuration.rb
@@ -11,7 +11,8 @@ module Herb
     VALID_FRAMEWORKS = OPTIONS["framework"]["values"].freeze #: Array[String]
     VALID_TEMPLATE_ENGINES = OPTIONS["template_engine"]["values"].freeze #: Array[String]
 
-    CONFIG_FILENAMES = [".herb.yml"].freeze
+    CONFIG_FILENAMES = [".herb.yml"].freeze #: Array[String]
+    MISNAMED_CONFIG_FILENAMES = [".herb.yaml", "herb.yml", "herb.yaml"].freeze #: Array[String]
 
     PROJECT_INDICATORS = [
       ".git",
@@ -23,18 +24,21 @@ module Herb
       "README.md",
       "*.gemspec",
       "config/application.rb"
-    ].freeze
+    ].freeze #: Array[String]
 
     DEFAULTS_PATH = File.expand_path("defaults.yml", __dir__ || __FILE__).freeze
     DEFAULTS = YAML.safe_load_file(DEFAULTS_PATH).freeze
 
-    attr_reader :config, :user_config, :config_path, :project_root
+    attr_reader :config, :user_config, :config_path, :project_root, :misnamed_config_paths
 
     def initialize(project_path = nil)
       @start_path = project_path ? Pathname.new(project_path) : Pathname.pwd
       @config_path, @project_root = find_config_file
+      @misnamed_config_paths = find_misnamed_config_paths
       @user_config = load_user_config
       @config = deep_merge(DEFAULTS, @user_config)
+
+      warn_about_misnamed_config_files
     end
 
     def [](key)
@@ -245,6 +249,20 @@ module Herb
       end
 
       [nil, @start_path]
+    end
+
+    def find_misnamed_config_paths
+      search_path = @project_root || @start_path
+      search_path = search_path.parent if search_path.file?
+
+      MISNAMED_CONFIG_FILENAMES.map { |filename| search_path / filename }.select(&:exist?)
+    end
+
+    def warn_about_misnamed_config_files
+      @misnamed_config_paths.each do |misnamed_path|
+        warn "[Herb] Ignoring #{misnamed_path}: Herb only reads `#{CONFIG_FILENAMES.first}`. " \
+             "Rename it to `#{CONFIG_FILENAMES.first}` to apply it."
+      end
     end
 
     def project_root?(path)

--- a/rust/herb-config/src/config.rs
+++ b/rust/herb-config/src/config.rs
@@ -19,6 +19,7 @@ pub trait SeverityOverridable {
 }
 
 pub const CONFIG_PATH: &str = ".herb.yml";
+pub const MISNAMED_CONFIG_PATHS: &[&str] = &[".herb.yaml", "herb.yml", "herb.yaml"];
 pub const ALL_RULES_KEY: &str = "all";
 
 const PROJECT_INDICATORS: &[&str] = &[
@@ -328,6 +329,54 @@ impl Config {
     config_path.exists()
   }
 
+  pub fn is_misnamed_config_path(path_or_file: &Path) -> bool {
+    path_or_file
+      .file_name()
+      .and_then(|file_name| file_name.to_str())
+      .is_some_and(|file_name| MISNAMED_CONFIG_PATHS.contains(&file_name))
+  }
+
+  pub fn find_misnamed_config_paths(project_path: &Path) -> Vec<PathBuf> {
+    MISNAMED_CONFIG_PATHS
+      .iter()
+      .map(|file_name| project_path.join(file_name))
+      .filter(|candidate| candidate.exists())
+      .collect()
+  }
+
+  pub fn misnamed_config_warning(misnamed_path: &Path) -> String {
+    format!(
+      "\u{26a0} Ignoring {}: Herb only reads `{}`. Rename it to `{}` to apply it.",
+      misnamed_path.display(),
+      CONFIG_PATH,
+      CONFIG_PATH
+    )
+  }
+
+  fn warn_about_misnamed_config_files(project_path: &Path, additional_paths: &[&Path]) {
+    let mut candidates = Self::find_misnamed_config_paths(project_path);
+
+    for additional_path in additional_paths {
+      if Self::is_misnamed_config_path(additional_path) && additional_path.exists() {
+        candidates.push(additional_path.to_path_buf());
+      }
+    }
+
+    let mut seen: Vec<PathBuf> = Vec::new();
+
+    for candidate in candidates {
+      let key = candidate.canonicalize().unwrap_or_else(|_| candidate.clone());
+
+      if seen.contains(&key) {
+        continue;
+      }
+
+      seen.push(key);
+
+      eprintln!("{}", Self::misnamed_config_warning(&candidate));
+    }
+  }
+
   pub fn find_project_root(start_path: &Path) -> PathBuf {
     Self::find_config_file(start_path).project_root
   }
@@ -364,10 +413,18 @@ impl Config {
     let version = options.version.unwrap_or(DEFAULT_VERSION);
 
     if path_or_file.ends_with(CONFIG_PATH) {
+      if !options.silent {
+        Self::warn_about_misnamed_config_files(path_or_file.parent().unwrap_or(Path::new(".")), &[]);
+      }
+
       return Self::load_from_explicit_path(path_or_file, version);
     }
 
     let FoundConfigFile { config_path, project_root } = Self::find_config_file(path_or_file);
+
+    if !options.silent {
+      Self::warn_about_misnamed_config_files(&project_root, &[path_or_file]);
+    }
 
     if let Some(config_path) = config_path {
       let config = Self::load_from_path(&config_path, &project_root, version)?;
@@ -529,15 +586,6 @@ impl Config {
 
   #[cfg(feature = "yerba")]
   fn create_default_config(project_root: &Path, silent: bool, version: &str) -> Result<Self, String> {
-    let stray_yaml_path = project_root.join(".herb.yaml");
-
-    if stray_yaml_path.exists() {
-      return Err(format!(
-        "Found `.herb.yaml` file at {}\n  Please rename it to `.herb.yml`",
-        stray_yaml_path.display()
-      ));
-    }
-
     let config_path = Self::config_path_from_project_path(project_root);
 
     match crate::mutation::mutate_config_file(&config_path, &HerbConfigOptions::default(), Some(version)) {

--- a/rust/herb-config/src/lib.rs
+++ b/rust/herb-config/src/lib.rs
@@ -11,7 +11,7 @@ mod merge;
 mod mutation;
 mod severity;
 
-pub use config::{Config, FoundConfigFile, FromObjectOptions, LoadOptions, SeverityOverridable, Tool, ALL_RULES_KEY, CONFIG_PATH};
+pub use config::{Config, FoundConfigFile, FromObjectOptions, LoadOptions, SeverityOverridable, Tool, ALL_RULES_KEY, CONFIG_PATH, MISNAMED_CONFIG_PATHS};
 
 pub use config_schema::{
   EngineConfig, FilesConfig, FormatterConfig, Framework, HerbConfig, HerbConfigOptions, LinterConfig, ParserOptionsConfig, RewriterConfig, RuleConfig,

--- a/rust/herb-config/src/validation.rs
+++ b/rust/herb-config/src/validation.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 
 use serde::{Deserialize, Serialize};
 
+use crate::config::{Config, CONFIG_PATH};
 use crate::config_schema::HerbConfig;
 use crate::defaults::DEFAULT_VERSION;
 
@@ -35,9 +36,11 @@ pub fn validate_config_text(text: &str, options: &ValidateOptions) -> Vec<Config
   let mut errors = Vec::new();
 
   if let Some(project_path) = options.project_path {
-    if project_path.join(".herb.yaml").exists() {
+    for misnamed_path in Config::find_misnamed_config_paths(project_path) {
+      let file_name = misnamed_path.file_name().and_then(|file_name| file_name.to_str()).unwrap_or_default();
+
       errors.push(ConfigValidationError {
-        message: "Found .herb.yaml file. Please rename to .herb.yml".to_string(),
+        message: format!("Found {} file. Please rename to {}", file_name, CONFIG_PATH),
         path: Vec::new(),
         code: "wrong_file_extension".to_string(),
         severity: Some(ValidationSeverity::Warning),

--- a/rust/herb-config/tests/misnamed_config_test.rs
+++ b/rust/herb-config/tests/misnamed_config_test.rs
@@ -1,0 +1,101 @@
+use std::fs;
+use std::path::Path;
+
+use herb_config::{Config, MISNAMED_CONFIG_PATHS};
+
+#[test]
+fn misnamed_config_paths_covers_the_extension_and_the_missing_leading_dot() {
+  assert_eq!(MISNAMED_CONFIG_PATHS, &[".herb.yaml", "herb.yml", "herb.yaml"]);
+}
+
+#[test]
+fn is_misnamed_config_path_recognizes_misnamed_config_files() {
+  assert!(Config::is_misnamed_config_path(Path::new(".herb.yaml")));
+  assert!(Config::is_misnamed_config_path(Path::new("herb.yml")));
+  assert!(Config::is_misnamed_config_path(Path::new("herb.yaml")));
+  assert!(Config::is_misnamed_config_path(Path::new("/project/.herb.yaml")));
+}
+
+#[test]
+fn is_misnamed_config_path_ignores_the_real_config_file() {
+  assert!(!Config::is_misnamed_config_path(Path::new(".herb.yml")));
+  assert!(!Config::is_misnamed_config_path(Path::new("/project/.herb.yml")));
+}
+
+#[test]
+fn is_misnamed_config_path_ignores_unrelated_yaml_files() {
+  assert!(!Config::is_misnamed_config_path(Path::new("config.yml")));
+  assert!(!Config::is_misnamed_config_path(Path::new("myherb.yml")));
+  assert!(!Config::is_misnamed_config_path(Path::new(".herb.yml.bak")));
+}
+
+#[test]
+fn find_misnamed_config_paths_returns_every_misnamed_config_file() {
+  let dir = tempfile::tempdir().unwrap();
+
+  fs::write(dir.path().join(".herb.yaml"), "").unwrap();
+  fs::write(dir.path().join("herb.yaml"), "").unwrap();
+
+  let found = Config::find_misnamed_config_paths(dir.path());
+
+  assert_eq!(found, vec![dir.path().join(".herb.yaml"), dir.path().join("herb.yaml")]);
+}
+
+#[test]
+fn find_misnamed_config_paths_ignores_the_real_config_file() {
+  let dir = tempfile::tempdir().unwrap();
+
+  fs::write(dir.path().join(".herb.yml"), "").unwrap();
+
+  assert!(Config::find_misnamed_config_paths(dir.path()).is_empty());
+}
+
+#[test]
+fn misnamed_config_warning_names_the_file_and_the_fix() {
+  let warning = Config::misnamed_config_warning(Path::new("/project/.herb.yaml"));
+
+  assert_eq!(
+    warning,
+    "\u{26a0} Ignoring /project/.herb.yaml: Herb only reads `.herb.yml`. Rename it to `.herb.yml` to apply it."
+  );
+}
+
+#[test]
+fn load_still_uses_the_real_config_file_next_to_a_misnamed_one() {
+  let dir = tempfile::tempdir().unwrap();
+
+  fs::write(dir.path().join(".herb.yml"), "version: 0.10.3\nformatter:\n  indentWidth: 4\n").unwrap();
+  fs::write(dir.path().join(".herb.yaml"), "version: 0.10.3\nformatter:\n  indentWidth: 8\n").unwrap();
+
+  let config = Config::load(dir.path(), None).unwrap();
+
+  assert_eq!(config.path.file_name().unwrap(), ".herb.yml");
+  assert_eq!(config.formatter().unwrap().indent_width, Some(4));
+}
+
+#[test]
+fn load_ignores_a_misnamed_config_file_and_falls_back_to_defaults() {
+  let dir = tempfile::tempdir().unwrap();
+
+  fs::write(dir.path().join("Gemfile"), "").unwrap();
+  fs::write(dir.path().join(".herb.yaml"), "version: 0.10.3\nformatter:\n  indentWidth: 8\n").unwrap();
+
+  let config = Config::load(dir.path(), None).unwrap();
+
+  assert_eq!(config.config_version, None);
+  assert_ne!(config.formatter().unwrap().indent_width, Some(8));
+}
+
+#[cfg(feature = "yerba")]
+#[test]
+fn load_for_cli_creates_the_default_config_next_to_a_misnamed_one() {
+  let dir = tempfile::tempdir().unwrap();
+
+  fs::write(dir.path().join("Gemfile"), "").unwrap();
+  fs::write(dir.path().join(".herb.yaml"), "version: 0.10.3\n").unwrap();
+
+  let config = Config::load_for_cli(dir.path(), None, true).unwrap();
+
+  assert_eq!(config.path.file_name().unwrap(), ".herb.yml");
+  assert!(dir.path().join(".herb.yml").exists());
+}

--- a/rust/herb-config/tests/validation_test.rs
+++ b/rust/herb-config/tests/validation_test.rs
@@ -56,3 +56,62 @@ fn validate_config_text_warns_about_a_stray_herb_yaml() {
 
   assert!(errors.iter().any(|error| error.code == "wrong_file_extension"));
 }
+
+#[test]
+fn validate_config_text_warns_about_a_config_file_missing_the_leading_dot() {
+  let dir = tempfile::tempdir().unwrap();
+
+  fs::write(dir.path().join("herb.yml"), "version: 0.10.3\n").unwrap();
+
+  let errors = validate_config_text(
+    "version: 0.10.3\n",
+    &ValidateOptions {
+      version: Some("0.10.3"),
+      project_path: Some(dir.path()),
+    },
+  );
+
+  let warning = errors
+    .iter()
+    .find(|error| error.code == "wrong_file_extension")
+    .expect("expected a wrong_file_extension");
+
+  assert_eq!(warning.message, "Found herb.yml file. Please rename to .herb.yml");
+  assert_eq!(warning.severity, Some(ValidationSeverity::Warning));
+}
+
+#[test]
+fn validate_config_text_warns_once_per_misnamed_config_file() {
+  let dir = tempfile::tempdir().unwrap();
+
+  fs::write(dir.path().join(".herb.yaml"), "version: 0.10.3\n").unwrap();
+  fs::write(dir.path().join("herb.yml"), "version: 0.10.3\n").unwrap();
+  fs::write(dir.path().join("herb.yaml"), "version: 0.10.3\n").unwrap();
+
+  let errors = validate_config_text(
+    "version: 0.10.3\n",
+    &ValidateOptions {
+      version: Some("0.10.3"),
+      project_path: Some(dir.path()),
+    },
+  );
+
+  assert_eq!(errors.iter().filter(|error| error.code == "wrong_file_extension").count(), 3);
+}
+
+#[test]
+fn validate_config_text_does_not_warn_without_a_misnamed_config_file() {
+  let dir = tempfile::tempdir().unwrap();
+
+  fs::write(dir.path().join(".herb.yml"), "version: 0.10.3\n").unwrap();
+
+  let errors = validate_config_text(
+    "version: 0.10.3\n",
+    &ValidateOptions {
+      version: Some("0.10.3"),
+      project_path: Some(dir.path()),
+    },
+  );
+
+  assert!(!errors.iter().any(|error| error.code == "wrong_file_extension"));
+}

--- a/sig/herb/configuration.rbs
+++ b/sig/herb/configuration.rbs
@@ -10,9 +10,11 @@ module Herb
 
     VALID_TEMPLATE_ENGINES: Array[String]
 
-    CONFIG_FILENAMES: untyped
+    CONFIG_FILENAMES: Array[String]
 
-    PROJECT_INDICATORS: untyped
+    MISNAMED_CONFIG_FILENAMES: Array[String]
+
+    PROJECT_INDICATORS: Array[String]
 
     DEFAULTS_PATH: untyped
 
@@ -25,6 +27,8 @@ module Herb
     attr_reader config_path: untyped
 
     attr_reader project_root: untyped
+
+    attr_reader misnamed_config_paths: untyped
 
     def initialize: (?untyped project_path) -> untyped
 
@@ -98,6 +102,10 @@ module Herb
     private
 
     def find_config_file: () -> untyped
+
+    def find_misnamed_config_paths: () -> untyped
+
+    def warn_about_misnamed_config_files: () -> untyped
 
     def project_root?: (untyped path) -> untyped
 

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -18,6 +18,14 @@ class ConfigurationTest < Minitest::Spec
     File.write(File.join(@temp_dir, filename), content)
   end
 
+  def load_config_silently
+    config = nil
+
+    capture_io { config = Herb::Configuration.load(@temp_dir) }
+
+    config
+  end
+
   test "loads default configuration when no config file exists" do
     config = Herb::Configuration.load(@temp_dir)
 
@@ -826,5 +834,78 @@ class ConfigurationTest < Minitest::Spec
 
     assert_equal "ruby", config.framework
     assert_equal "erubi", config.template_engine
+  end
+
+  test "does not read a misnamed config file" do
+    write_config(<<~YAML, ".herb.yaml")
+      files:
+        include:
+          - "**/*.custom.erb"
+    YAML
+
+    config = load_config_silently
+
+    assert_nil config.config_path
+    assert_equal Herb::Configuration::DEFAULTS["files"]["include"], config.file_include_patterns
+  end
+
+  test "warns about a config file with the wrong extension" do
+    write_config("framework: actionview", ".herb.yaml")
+
+    assert_output(nil, /Ignoring #{Regexp.escape(File.join(@temp_dir, ".herb.yaml"))}: Herb only reads `\.herb\.yml`/) do
+      Herb::Configuration.load(@temp_dir)
+    end
+  end
+
+  test "warns about a config file missing the leading dot" do
+    write_config("framework: actionview", "herb.yml")
+
+    assert_output(nil, /Ignoring #{Regexp.escape(File.join(@temp_dir, "herb.yml"))}: Herb only reads `\.herb\.yml`/) do
+      Herb::Configuration.load(@temp_dir)
+    end
+  end
+
+  test "warns about every misnamed config file" do
+    Herb::Configuration::MISNAMED_CONFIG_FILENAMES.each { |filename| write_config("framework: actionview", filename) }
+
+    config = load_config_silently
+
+    assert_equal(
+      Herb::Configuration::MISNAMED_CONFIG_FILENAMES.map { |filename| File.join(@temp_dir, filename) },
+      config.misnamed_config_paths.map(&:to_s)
+    )
+  end
+
+  test "warns about a misnamed config file next to the real one" do
+    write_config("framework: actionview")
+    write_config("framework: actionview", ".herb.yaml")
+
+    config = nil
+
+    assert_output(nil, /Ignoring .*\.herb\.yaml/) do
+      config = Herb::Configuration.load(@temp_dir)
+    end
+
+    assert_equal File.join(@temp_dir, ".herb.yml"), config.config_path.to_s
+    assert_equal "actionview", config.framework
+  end
+
+  test "does not warn when only the real config file exists" do
+    write_config("framework: actionview")
+
+    assert_silent do
+      config = Herb::Configuration.load(@temp_dir)
+
+      assert_empty config.misnamed_config_paths
+    end
+  end
+
+  test "does not warn about unrelated YAML files" do
+    write_config("framework: actionview", "config.yml")
+    write_config("framework: actionview", ".herb.yml.bak")
+
+    assert_silent do
+      assert_empty Herb::Configuration.load(@temp_dir).misnamed_config_paths
+    end
   end
 end


### PR DESCRIPTION
Inspired by #1678, which ran into a real friction point: creating `.herb.yaml` instead of `.herb.yml` didn't work, and the way it didn't work was unhelpful.

`.herb.yml` stays the only configuration filename Herb reads, following the convention used by Rails and most other Ruby tooling. Supporting both extensions at the same time would mean two places a setting can live, and it isn't obvious which one wins. The problem worth fixing isn't the filename, it's that a misnamed file looks like it should work.

So `herb-lint` would hard fail in one situation, and in Ruby a `.herb.yaml` full of carefully written excludes was silently doing nothing. The Ruby case is almost certainly how this gets discovered in the first place.

This pull request replaces all of that with a warning at config discovery time, in every runtime:

```
⚠ Ignoring /your-project/.herb.yaml: Herb only reads `.herb.yml`. Rename it to `.herb.yml` to apply it.
```

The run continues instead of aborting, so a stray file can't block linting or formatting. Ruby prefixes it with `[Herb]`, matching the other warnings there.

Detection also covers a missing leading dot, not just the wrong extension:

```
.herb.yaml
herb.yml
herb.yaml
```

The warning fires whether or not a valid config exists, which covers the case a hard error never reached. With both files present, `.herb.yml` is still read and the `.herb.yaml` is reported as ignored:

```
⚠ Ignoring /your-project/.herb.yaml: Herb only reads `.herb.yml`. Rename it to `.herb.yml` to apply it.
✓ Using Herb config file at /your-project/.herb.yml
```

Passing a misnamed file explicitly is reported too, since `--config-file .herb.yaml` previously fell back to discovery without saying so.

#### Language Server

The `wrong_file_extension` diagnostic already existed but only looked for `.herb.yaml`. It now reports every variant and derives the filename from the file it found:

```
Found herb.yml file. Please rename to .herb.yml
```

Supersedes #1678

