### PR TITLE
Linter: Add support for `as:` in `actionview-prefer-collection-render`

### DIFF
--- a/javascript/packages/linter/docs/rules/actionview-prefer-collection-render.md
+++ b/javascript/packages/linter/docs/rules/actionview-prefer-collection-render.md
@@ -14,8 +14,12 @@ The reported message contains the exact replacement tag, built from the loop's r
 <% end %>
 ```
 
-```
-Prefer `<%= render partial: "user", collection: @users %>` over rendering a partial once per iteration. Collection rendering builds the partial once instead of for every item.
+Collection rendering names the local after the partial, so when the loop passes the element under a different name the replacement carries an `as:` to keep the partial working:
+
+```erb
+<% @gems.each do |topic_gem| %>
+  <%= render partial: "gem_card", locals: { topic_gem: topic_gem } %>
+<% end %>
 ```
 
 Rendering an object directly reports the shorthand collection form instead:
@@ -26,15 +30,11 @@ Rendering an object directly reports the shorthand collection form instead:
 <% end %>
 ```
 
-```
-Prefer `<%= render @users %>` over rendering a partial once per iteration. Collection rendering builds the partial once instead of for every item.
-```
-
 ## Rationale
 
 When a partial is rendered inside a loop, Action View looks the template up and sets up a fresh local scope on every iteration. Collection rendering does that work once and then reuses it for every element, so it is meaningfully faster for anything but the shortest collections.
 
-Collection rendering also passes each element as a local named after the partial, and provides a `<partial>_counter` local, which removes the need to thread the loop variable through by hand.
+Collection rendering also passes each element as a local named after the partial, and provides a `<partial>_counter` local, which removes the need to thread the loop variable through by hand. When the loop passes the element under a name that isn't the partial name, the suggestion adds `as:` so the partial keeps receiving the local it expects.
 
 Because the rewrite emits the partial and nothing else, this rule only fires when the loop body is exactly one output `render` and the only local passed is the block argument. Loops that wrap the partial in markup, pass extra locals, or use a block argument the partial doesn't receive are left alone, since collection rendering cannot express them.
 
@@ -44,6 +44,10 @@ Because the rewrite emits the partial and nothing else, this rule only fires whe
 
 ```erb
 <%= render partial: "user", collection: @users %>
+```
+
+```erb
+<%= render partial: "gem_card", collection: @gems, as: :topic_gem %>
 ```
 
 ```erb
@@ -87,6 +91,12 @@ Loops that do more than render a single partial are not flagged, because collect
 ```erb
 <% @users.each do |user| %>
   <%= render user %>
+<% end %>
+```
+
+```erb
+<% @gems.each do |topic_gem| %>
+  <%= render partial: "gem_card", locals: { topic_gem: topic_gem } %>
 <% end %>
 ```
 

--- a/javascript/packages/linter/src/rules/actionview-prefer-collection-render.ts
+++ b/javascript/packages/linter/src/rules/actionview-prefer-collection-render.ts
@@ -73,10 +73,21 @@ class PreferCollectionRenderVisitor extends BaseRuleVisitor {
     const locals = keywords.locals ?? []
     if (locals.length !== 1) return null
 
-    const [local] = locals as Array<{ value?: { content?: string } }>
+    const [local] = locals as Array<{ name?: { value?: string }, value?: { content?: string } }>
     if (local.value?.content !== blockArgument) return null
 
-    return `<%= render partial: "${partial}", collection: ${receiver} %>`
+    const localName = local.name?.value
+    if (!localName) return null
+
+    const as = localName === this.collectionLocalNameFor(partial) ? "" : `, as: :${localName}`
+
+    return `<%= render partial: "${partial}", collection: ${receiver}${as} %>`
+  }
+
+  private collectionLocalNameFor(partial: string): string {
+    const name = partial.split("/").pop() ?? partial
+
+    return name.startsWith("_") ? name.slice(1) : name
   }
 }
 

--- a/javascript/packages/linter/test/rules/actionview-prefer-collection-render.test.ts
+++ b/javascript/packages/linter/test/rules/actionview-prefer-collection-render.test.ts
@@ -31,6 +31,54 @@ describe("actionview-prefer-collection-render", () => {
     assertOffenses(html)
   })
 
+  it("suggests `as:` when the local is not named after the partial", () => {
+    const html = dedent`
+      <% @gems.each do |topic_gem| %>
+        <%= render partial: "gem_card", locals: { topic_gem: topic_gem } %>
+      <% end %>
+    `
+
+    expectError('Prefer `<%= render partial: "gem_card", collection: @gems, as: :topic_gem %>` over rendering a partial once per iteration. Collection rendering builds the partial once instead of for every item.')
+
+    assertOffenses(html)
+  })
+
+  it("suggests `as:` when the local is not named after the partial in the shorthand form", () => {
+    const html = dedent`
+      <% @gems.each do |topic_gem| %>
+        <%= render "gem_card", topic_gem: topic_gem %>
+      <% end %>
+    `
+
+    expectError('Prefer `<%= render partial: "gem_card", collection: @gems, as: :topic_gem %>` over rendering a partial once per iteration. Collection rendering builds the partial once instead of for every item.')
+
+    assertOffenses(html)
+  })
+
+  it("does not suggest `as:` when the local matches the partial name in a nested path", () => {
+    const html = dedent`
+      <% @gems.each do |gem_card| %>
+        <%= render partial: "gems/gem_card", locals: { gem_card: gem_card } %>
+      <% end %>
+    `
+
+    expectError('Prefer `<%= render partial: "gems/gem_card", collection: @gems %>` over rendering a partial once per iteration. Collection rendering builds the partial once instead of for every item.')
+
+    assertOffenses(html)
+  })
+
+  it("suggests `as:` when the local does not match the partial name in a nested path", () => {
+    const html = dedent`
+      <% @gems.each do |topic_gem| %>
+        <%= render partial: "gems/gem_card", locals: { topic_gem: topic_gem } %>
+      <% end %>
+    `
+
+    expectError('Prefer `<%= render partial: "gems/gem_card", collection: @gems, as: :topic_gem %>` over rendering a partial once per iteration. Collection rendering builds the partial once instead of for every item.')
+
+    assertOffenses(html)
+  })
+
   it("flags the object shorthand and suggests the shorthand collection form", () => {
     const html = dedent`
       <% @users.each do |user| %>


### PR DESCRIPTION
This pull request updates the `actionview-prefer-collection-render` linter rule so the replacement it reports keeps working when the loop passes the element under a name that isn't the partial name.

The rule reports the exact tag to paste over the loop, and it built that tag from the receiver and the partial alone. Collection rendering names the local after the partial, so any local named something else was silently dropped from the suggestion:

```erb
<% @gems.each do |topic_gem| %>
  <%= render partial: "gem_card", locals: { topic_gem: topic_gem } %>
<% end %>
```

```
Prefer `<%= render partial: "gem_card", collection: @gems %>` over rendering a partial once per iteration.
```

Following that advice hands `_gem_card.html.erb` a `gem_card` local, while the partial still reads `topic_gem`, so the page raises `undefined local variable or method 'topic_gem'`. The suggestion now compares the local's key against the name collection rendering would use and appends `as:` when the two differ:

```diff
- Prefer `<%= render partial: "gem_card", collection: @gems %>` over rendering a partial once per iteration.
+ Prefer `<%= render partial: "gem_card", collection: @gems, as: :topic_gem %>` over rendering a partial once per iteration.
```

That implicit name is the last path segment of the partial, so a nested partial whose local already matches keeps the shorter form and doesn't grow a redundant `as:`:

```erb
<% @gems.each do |gem_card| %>
  <%= render partial: "gems/gem_card", locals: { gem_card: gem_card } %>
<% end %>
```

Both spellings of the local are covered, the explicit `locals:` hash and the shorthand `render "gem_card", topic_gem: topic_gem`. The object shorthand (`render user` inside the loop) is unaffected, since `render @users` carries no local name to rename.

When the parser reports a local without a name, the rule now stays silent instead of reporting a replacement it can't verify.

Resolves #1981
