### PR TITLE
Formatter: Preserve indentation of nested multi-line HTML comments

### DIFF
--- a/javascript/packages/formatter/src/comment-helpers.ts
+++ b/javascript/packages/formatter/src/comment-helpers.ts
@@ -42,9 +42,11 @@ export function extractHTMLCommentContent(children: Node[]): string {
  *
  * @param rawInner - The joined children content string (may be empty)
  * @param indentWidth - Number of spaces per indent level
+ * @param baseIndent - Indentation of the line the comment starts on, so nested
+ *   comments keep their content and closing `-->` aligned with the `<!--`
  * @returns The formatted inner string, or null if rawInner is empty-ish
  */
-export function formatHTMLCommentInner(rawInner: string, indentWidth: number): string {
+export function formatHTMLCommentInner(rawInner: string, indentWidth: number, baseIndent: string = ""): string {
   if (!rawInner && rawInner !== "") return ""
 
   const trimmedInner = rawInner.trim()
@@ -57,12 +59,12 @@ export function formatHTMLCommentInner(rawInner: string, indentWidth: number): s
 
   if (hasNewlines) {
     const lines = rawInner.split('\n')
-    const childIndent = " ".repeat(indentWidth)
+    const childIndent = baseIndent + " ".repeat(indentWidth)
     const firstLineHasContent = lines[0].trim() !== ''
 
     if (firstLineHasContent && lines.length > 1) {
       const contentLines = lines.map(line => line.trim()).filter(line => line !== '')
-      return '\n' + contentLines.map(line => childIndent + line).join('\n') + '\n'
+      return '\n' + contentLines.map(line => childIndent + line).join('\n') + '\n' + baseIndent
     } else {
       const contentLines = lines.filter((line, index) => {
         return line.trim() !== '' && !(index === 0 || index === lines.length - 1)
@@ -73,8 +75,12 @@ export function formatHTMLCommentInner(rawInner: string, indentWidth: number): s
       const processedLines = lines.map((line, index) => {
         const trimmedLine = line.trim()
 
-        if ((index === 0 || index === lines.length - 1) && trimmedLine === '') {
+        if (index === 0 && trimmedLine === '') {
           return line
+        }
+
+        if (index === lines.length - 1 && trimmedLine === '') {
+          return baseIndent
         }
 
         if (trimmedLine !== '') {

--- a/javascript/packages/formatter/src/format-printer.ts
+++ b/javascript/packages/formatter/src/format-printer.ts
@@ -982,7 +982,7 @@ export class FormatPrinter extends Printer implements TextFlowDelegate, Attribut
     const rawInner = node.children && node.children.length > 0
       ? extractHTMLCommentContent(node.children)
       : ""
-    const inner = rawInner ? formatHTMLCommentInner(rawInner, this.indentWidth) : ""
+    const inner = rawInner ? formatHTMLCommentInner(rawInner, this.indentWidth, this.indent) : ""
 
     this.pushWithIndent(open + inner + close)
   }

--- a/javascript/packages/formatter/test/comment-helpers.test.ts
+++ b/javascript/packages/formatter/test/comment-helpers.test.ts
@@ -86,6 +86,20 @@ describe("comment-helpers", () => {
       expect(result).toBe("\n  line1\n    indented\n  line3\n")
     })
 
+    test("indents multiline content relative to the base indent", () => {
+      const raw = ["", "    line1", "      indented", "    line3", ""].join("\n")
+      const result = formatHTMLCommentInner(raw, 2, "    ")
+
+      expect(result.split("\n")).toEqual(["", "      line1", "        indented", "      line3", "    "])
+    })
+
+    test("aligns the closing line with the base indent", () => {
+      const raw = ["line1", "line2"].join("\n")
+      const result = formatHTMLCommentInner(raw, 2, "  ")
+
+      expect(result.split("\n")).toEqual(["", "    line1", "    line2", "  "])
+    })
+
     test("handles empty inner string", () => {
       const result = formatHTMLCommentInner("", 2)
       expect(result).toBe("  ")

--- a/javascript/packages/formatter/test/html/comments.test.ts
+++ b/javascript/packages/formatter/test/html/comments.test.ts
@@ -204,6 +204,88 @@ describe("@herb-tools/formatter", () => {
     `)
   })
 
+  test("nested multi-line HTML comment keeps its indentation", () => {
+    expectFormattedToMatch(dedent`
+      <div>
+        <div>
+          <div>
+            <!--
+              <p>deep</p>
+            -->
+          </div>
+        </div>
+      </div>
+    `)
+  })
+
+  test("nested multi-line HTML comment preserves relative indentation", () => {
+    expectFormattedToMatch(dedent`
+      <div>
+        <!--
+          <ul>
+            <li>one</li>
+          </ul>
+        -->
+      </div>
+    `)
+  })
+
+  test("nested multi-line HTML comment gets re-indented", () => {
+    const source = dedent`
+      <div>
+        <!--
+      Comment
+          on
+      multiple
+      lines
+        -->
+      </div>
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <div>
+        <!--
+          Comment
+              on
+          multiple
+          lines
+        -->
+      </div>
+    `)
+  })
+
+  test("nested HTML comment with content on the opening line", () => {
+    const source = dedent`
+      <div>
+        <!-- Status: <%= status %> |
+             Updated: <%= updated_at %> -->
+      </div>
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <div>
+        <!--
+          Status: <%= status %> |
+          Updated: <%= updated_at %>
+        -->
+      </div>
+    `)
+  })
+
+  test("HTML comment with content on the opening line aligns the closing tag", () => {
+    const source = dedent`
+      <!-- line1
+      line2 -->
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <!--
+        line1
+        line2
+      -->
+    `)
+  })
+
   describe("Mixed content with comments", () => {
     test("div with comment and another element stays multiline", () => {
       const source = dedent`


### PR DESCRIPTION
This pull request fixes the formatter re-indenting the contents of a multi-line HTML comment to the wrong column whenever the comment isn't at the top level of the document.

**Before:**

```html+erb
<div>
  <div>
    <div>
      <!--
  <p>deep</p>
      -->
    </div>
  </div>
</div>
```

**After:**

```html+erb
<div>
  <div>
    <div>
      <!--
        <p>deep</p>
      -->
    </div>
  </div>
</div>
```

`formatHTMLCommentInner()` re-indented the comment's inner lines with `" ".repeat(indentWidth)`, which is one indent level counted from column 0. The printer emits the whole comment as a single multi-line string through `pushWithIndent()`, and that only prefixes the *first* line with the current indent, so every inner line ended up at column 2 no matter how deeply the comment was nested. The closing `-->` escaped the same fate only because the last line was passed through verbatim, keeping whatever whitespace the author had written.

The helper now takes the indentation of the line the comment starts on (`this.indent`) and uses it as the base for the content lines and for the closing line, on top of which the comment's own relative indentation is still preserved.

Aligning the closing line also fixes a second case, which was broken at every nesting level: when the comment has content on its opening line, the formatter splits it across multiple lines and previously left the generated `-->` at column 0.

**Before:**

```html+erb
<div>
  <!--
  line1
  line2
-->
</div>
```

**After:**

```html+erb
<div>
  <!--
    line1
    line2
  -->
</div>
```

Comments whose contents are indented inconsistently are now normalized to the enclosing element's indentation instead of to column 2:

```html+erb
<div>
  <!--
Comment
    on
multiple
lines
  -->
</div>
```

```html+erb
<div>
  <!--
    Comment
        on
    multiple
    lines
  -->
</div>
```

IE conditional comments are still passed through untouched, and the output is stable across repeated formatting passes.

Resolves https://github.com/marcoroth/herb/issues/1988