### PR TITLE
Language Server: Report a misnamed config file in the editor

### DIFF
--- a/javascript/packages/language-server/src/config_service.ts
+++ b/javascript/packages/language-server/src/config_service.ts
@@ -2,7 +2,7 @@ import { Diagnostic, DiagnosticSeverity, Range } from "vscode-languageserver/nod
 import { TextDocument } from "vscode-languageserver-textdocument"
 import { Config } from "@herb-tools/config"
 
-import { lintToDignosticSeverity } from "./utils"
+import { isConfigDocument, lintToDignosticSeverity } from "./utils"
 import { version } from "../package.json"
 
 /**
@@ -15,10 +15,34 @@ export class ConfigService {
     this.projectPath = projectPath
   }
 
+  private wholeDocumentRange(document: TextDocument): Range {
+    const text = document.getText()
+
+    if (text.length === 0) {
+      return Range.create(0, 0, 0, 1)
+    }
+
+    const end = document.positionAt(text.length)
+
+    return Range.create(0, 0, end.line, end.character)
+  }
+
   async validateDocument(document: TextDocument): Promise<Diagnostic[]> {
     const diagnostics: Diagnostic[] = []
 
-    if (!document.uri.endsWith('.herb.yml')) {
+    if (Config.isMisnamedConfigPath(document.uri)) {
+      diagnostics.push({
+        severity: DiagnosticSeverity.Error,
+        range: this.wholeDocumentRange(document),
+        message: `Herb only reads \`${Config.configPath}\`, so this file is ignored. Rename it to \`${Config.configPath}\` to apply it.`,
+        source: 'Herb Config ',
+        code: 'wrong_file_extension'
+      })
+
+      return diagnostics
+    }
+
+    if (!isConfigDocument(document.uri)) {
       return diagnostics
     }
 

--- a/javascript/packages/language-server/src/diagnostics.ts
+++ b/javascript/packages/language-server/src/diagnostics.ts
@@ -5,6 +5,7 @@ import { ParserService } from "./parser_service"
 import { LinterService } from "./linter_service"
 import { DocumentService } from "./document_service"
 import { ConfigService } from "./config_service"
+import { isConfigDocument } from "./utils"
 
 export class Diagnostics {
   private readonly connection: Connection
@@ -31,7 +32,7 @@ export class Diagnostics {
   async validate(textDocument: TextDocument) {
     let allDiagnostics: Diagnostic[] = []
 
-    if (textDocument.uri.endsWith('.herb.yml')) {
+    if (isConfigDocument(textDocument.uri)) {
       allDiagnostics = await this.configService.validateDocument(textDocument)
     } else {
       const parseResult = this.parserService.parseDocument(textDocument)

--- a/javascript/packages/language-server/src/formatting_service.ts
+++ b/javascript/packages/language-server/src/formatting_service.ts
@@ -6,6 +6,7 @@ import { CustomRewriterLoader, builtinRewriters, isASTRewriterClass, isStringRew
 import { Project } from "./project"
 import { Settings } from "./settings"
 import { Config } from "@herb-tools/config"
+import { isConfigDocument } from "./utils"
 import { version } from "../package.json"
 
 const OPEN_CONFIG_ACTION = 'Open .herb.yml'
@@ -207,7 +208,7 @@ export class FormattingService {
   }
 
   private shouldFormatFile(filePath: string): boolean {
-    if (filePath.endsWith('.herb.yml')) return false
+    if (isConfigDocument(filePath)) return false
     if (!this.config) return true
 
     const hasConfigFile = Config.exists(this.config.projectPath)
@@ -295,7 +296,7 @@ export class FormattingService {
   }
 
   async formatDocument(params: DocumentFormattingParams): Promise<TextEdit[]> {
-    if (params.textDocument.uri.endsWith('.herb.yml')) {
+    if (isConfigDocument(params.textDocument.uri)) {
       return []
     }
 
@@ -395,7 +396,7 @@ export class FormattingService {
   }
 
   async formatRange(params: DocumentRangeFormattingParams): Promise<TextEdit[]> {
-    if (params.textDocument.uri.endsWith('.herb.yml')) {
+    if (isConfigDocument(params.textDocument.uri)) {
       return []
     }
 

--- a/javascript/packages/language-server/src/linter_service.ts
+++ b/javascript/packages/language-server/src/linter_service.ts
@@ -8,7 +8,7 @@ import { Config } from "@herb-tools/config"
 
 import { Settings } from "./settings"
 import { Project } from "./project"
-import { lintToDignosticSeverity, lintToDignosticTags } from "./utils"
+import { isConfigDocument, lintToDignosticSeverity, lintToDignosticTags } from "./utils"
 import { lspRangeFromLocation } from "./range_utils"
 
 const OPEN_CONFIG_ACTION = 'Open .herb.yml'
@@ -117,7 +117,7 @@ export class LinterService {
   private shouldLintFile(uri: string): boolean {
     const filePath = uri.replace(/^file:\/\//, '')
 
-    if (filePath.endsWith('.herb.yml')) return false
+    if (isConfigDocument(filePath)) return false
 
     const config = this.settings.projectConfig
     if (!config) return true

--- a/javascript/packages/language-server/src/server.ts
+++ b/javascript/packages/language-server/src/server.ts
@@ -22,6 +22,7 @@ import {
 import { Service } from "./service"
 import { PersonalHerbSettings } from "./settings"
 import { Config } from "@herb-tools/config"
+import { isConfigDocument } from "./utils"
 import { version } from "../package.json"
 
 export class Server {
@@ -98,7 +99,8 @@ export class Server {
       this.connection.client.register(DidChangeWatchedFilesNotification.type, {
         watchers: [
           ...patterns,
-          { globPattern: `**/.herb.yml` },
+          { globPattern: `**/${Config.configPath}` },
+          ...Config.misnamedConfigPaths.map(misnamedPath => ({ globPattern: `**/${misnamedPath}` })),
           { globPattern: `**/.herb/rules/**/*.mjs` },
           { globPattern: `**/.herb/rewriters/**/*.mjs` },
         ],
@@ -128,7 +130,7 @@ export class Server {
 
     this.connection.onDidChangeWatchedFiles(async (params) => {
       for (const event of params.changes) {
-        const isConfigChange = event.uri.endsWith("/.herb.yml")
+        const isConfigChange = isConfigDocument(event.uri)
         const isCustomRuleChange = event.uri.includes("/.herb/rules/")
         const isCustomRewriterChange = event.uri.includes("/.herb/rewriters/")
 

--- a/javascript/packages/language-server/src/utils.ts
+++ b/javascript/packages/language-server/src/utils.ts
@@ -1,6 +1,13 @@
+import * as path from "path"
+
 import { DiagnosticSeverity, DiagnosticTag } from "vscode-languageserver/node"
+import { Config } from "@herb-tools/config"
 import type { LintSeverity } from "@herb-tools/linter"
 import type { DiagnosticSeverity as HerbDiagnosticSeverity, DiagnosticTag as HerbDiagnosticTag } from "@herb-tools/core"
+
+export function isConfigDocument(uriOrPath: string): boolean {
+  return path.basename(uriOrPath) === Config.configPath || Config.isMisnamedConfigPath(uriOrPath)
+}
 
 export function camelize(value: string) {
   return value.replace(/(?:[_-])([a-z0-9])/g, (_, char) => char.toUpperCase())

--- a/javascript/packages/language-server/test/config_service.test.ts
+++ b/javascript/packages/language-server/test/config_service.test.ts
@@ -1,0 +1,92 @@
+import { describe, test, expect } from "vitest"
+
+import { TextDocument } from "vscode-languageserver-textdocument"
+import { DiagnosticSeverity } from "vscode-languageserver/node"
+import { Config } from "@herb-tools/config"
+
+import { ConfigService } from "../src/config_service"
+import { isConfigDocument } from "../src/utils"
+
+function documentFor(fileName: string, content = "") {
+  return TextDocument.create(`file:///project/${fileName}`, "yaml", 1, content)
+}
+
+describe("isConfigDocument", () => {
+  test("recognizes the config file Herb reads", () => {
+    expect(isConfigDocument("file:///project/.herb.yml")).toBe(true)
+  })
+
+  test("recognizes misnamed config files", () => {
+    for (const misnamedPath of Config.misnamedConfigPaths) {
+      expect(isConfigDocument(`file:///project/${misnamedPath}`)).toBe(true)
+    }
+  })
+
+  test("ignores templates and unrelated files", () => {
+    expect(isConfigDocument("file:///project/app/views/index.html.erb")).toBe(false)
+    expect(isConfigDocument("file:///project/config.yml")).toBe(false)
+    expect(isConfigDocument("file:///project/.herb.yml.bak")).toBe(false)
+  })
+})
+
+describe("ConfigService", () => {
+  test("reports a misnamed config file as ignored", async () => {
+    const service = new ConfigService("/project")
+    const diagnostics = await service.validateDocument(documentFor(".herb.yaml", "linter:\n  enabled: false\n"))
+
+    expect(diagnostics).toHaveLength(1)
+    expect(diagnostics[0].code).toBe("wrong_file_extension")
+    expect(diagnostics[0].severity).toBe(DiagnosticSeverity.Error)
+    expect(diagnostics[0].message).toBe(
+      "Herb only reads `.herb.yml`, so this file is ignored. Rename it to `.herb.yml` to apply it."
+    )
+    expect(diagnostics[0].range).toEqual({
+      start: { line: 0, character: 0 },
+      end: { line: 2, character: 0 }
+    })
+  })
+
+  test("spans the whole misnamed config file", async () => {
+    const service = new ConfigService("/project")
+    const diagnostics = await service.validateDocument(documentFor(".herb.yaml", "linter:\n  enabled: false\n  rules: {}"))
+
+    expect(diagnostics[0].range).toEqual({
+      start: { line: 0, character: 0 },
+      end: { line: 2, character: 11 }
+    })
+  })
+
+  test("spans a single character for an empty misnamed config file", async () => {
+    const service = new ConfigService("/project")
+    const diagnostics = await service.validateDocument(documentFor(".herb.yaml", ""))
+
+    expect(diagnostics[0].range).toEqual({
+      start: { line: 0, character: 0 },
+      end: { line: 0, character: 1 }
+    })
+  })
+
+  test("reports every misnamed variant", async () => {
+    const service = new ConfigService("/project")
+
+    for (const misnamedPath of Config.misnamedConfigPaths) {
+      const diagnostics = await service.validateDocument(documentFor(misnamedPath))
+
+      expect(diagnostics.map(diagnostic => diagnostic.code)).toEqual(["wrong_file_extension"])
+    }
+  })
+
+  test("does not validate the contents of a misnamed config file", async () => {
+    const service = new ConfigService("/project")
+    const diagnostics = await service.validateDocument(documentFor(".herb.yaml", "linter: [unclosed\n"))
+
+    expect(diagnostics.map(diagnostic => diagnostic.code)).toEqual(["wrong_file_extension"])
+  })
+
+  test("returns nothing for a document that isn't a config file", async () => {
+    const service = new ConfigService("/project")
+    const document = TextDocument.create("file:///project/app/views/index.html.erb", "erb", 1, "<div></div>")
+
+    expect(await service.validateDocument(document)).toEqual([])
+  })
+})

--- a/javascript/packages/vscode/src/client.ts
+++ b/javascript/packages/vscode/src/client.ts
@@ -152,7 +152,10 @@ export class Client {
       documentSelector: [
         { scheme: "file", language: "erb" },
         { scheme: "file", language: "html" },
-        { scheme: "file", language: "yaml", pattern: "**/.herb.yml" },
+        { scheme: "file", language: "yaml", pattern: `**/${Config.configPath}` },
+        ...Config.misnamedConfigPaths.map(misnamedPath => ({
+          scheme: "file", language: "yaml", pattern: `**/${misnamedPath}`
+        })),
       ],
       synchronize: {
         fileEvents: workspace.createFileSystemWatcher("**/.clientrc"),

--- a/javascript/packages/vscode/src/extension.ts
+++ b/javascript/packages/vscode/src/extension.ts
@@ -1,4 +1,5 @@
 import * as vscode from "vscode"
+import * as path from "path"
 import type { TextEdit } from "vscode-languageclient/node"
 
 import { Config } from "@herb-tools/config"
@@ -32,6 +33,36 @@ function getFileGlobPattern(): string {
   return Config.getDefaultFilePatterns().join(",")
 }
 
+async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    await vscode.workspace.fs.stat(vscode.Uri.file(filePath))
+
+    return true
+  } catch (_error) {
+    return false
+  }
+}
+
+async function findMisnamedConfigPaths(workspaceRoot: string): Promise<string[]> {
+  const misnamedPaths: string[] = []
+
+  for (const misnamedConfigPath of Config.misnamedConfigPaths) {
+    const candidate = path.join(workspaceRoot, misnamedConfigPath)
+
+    if (await fileExists(candidate)) {
+      misnamedPaths.push(candidate)
+    }
+  }
+
+  const activeDocumentPath = vscode.window.activeTextEditor?.document.uri.fsPath
+
+  if (activeDocumentPath && Config.isMisnamedConfigPath(activeDocumentPath) && !misnamedPaths.includes(activeDocumentPath)) {
+    misnamedPaths.unshift(activeDocumentPath)
+  }
+
+  return misnamedPaths
+}
+
 async function updateConfigStatusBarItem() {
   const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath
 
@@ -41,23 +72,43 @@ async function updateConfigStatusBarItem() {
     return
   }
 
+  const misnamedPaths = await findMisnamedConfigPaths(workspaceRoot)
+
+  if (misnamedPaths.length > 0) {
+    const misnamedPath = misnamedPaths[0]
+    const misnamedNames = misnamedPaths.map(misnamedConfigPath => path.basename(misnamedConfigPath)).join(', ')
+    const verb = misnamedPaths.length === 1 ? 'is' : 'are'
+
+    configStatusBarItem.text = `$(warning) ${path.basename(misnamedPath)} (Not Read)`
+    configStatusBarItem.tooltip = `Herb only reads ${Config.configPath}, so ${misnamedNames} ${verb} ignored.\n\nRename to ${Config.configPath} to apply the configuration.\n\nClick to open ${path.basename(misnamedPath)}`
+    configStatusBarItem.backgroundColor = new vscode.ThemeColor('statusBarItem.errorBackground')
+    configStatusBarItem.color = new vscode.ThemeColor('statusBarItem.errorForeground')
+    configStatusBarItem.command = {
+      title: `Open ${path.basename(misnamedPath)}`,
+      command: 'vscode.open',
+      arguments: [vscode.Uri.file(misnamedPath)]
+    }
+
+    configStatusBarItem.show()
+
+    return
+  }
+
   const configPath = Config.configPathFromProjectPath(workspaceRoot)
 
-  try {
-    await vscode.workspace.fs.stat(vscode.Uri.file(configPath))
+  configStatusBarItem.backgroundColor = undefined
+  configStatusBarItem.color = undefined
+  configStatusBarItem.command = 'herb.showConfigDetails'
 
-    configStatusBarItem.text = '$(file-code) .herb.yml (Project Settings)'
-    configStatusBarItem.tooltip = 'Herb configuration loaded from .herb.yml (overrides VS Code settings)\n\nClick to view configuration details'
-    configStatusBarItem.command = 'herb.showConfigDetails'
-
-    configStatusBarItem.show()
-  } catch (_error) {
+  if (await fileExists(configPath)) {
+    configStatusBarItem.text = `$(file-code) ${Config.configPath} (Project Settings)`
+    configStatusBarItem.tooltip = `Herb configuration loaded from ${Config.configPath} (overrides VS Code settings)\n\nClick to view configuration details`
+  } else {
     configStatusBarItem.text = '$(settings-gear) Herb (Personal Settings)'
-    configStatusBarItem.tooltip = 'Herb using personal VS Code settings\n\nClick to view configuration details or create .herb.yml'
-    configStatusBarItem.command = 'herb.showConfigDetails'
-
-    configStatusBarItem.show()
+    configStatusBarItem.tooltip = `Herb using personal VS Code settings\n\nClick to view configuration details or create ${Config.configPath}`
   }
+
+  configStatusBarItem.show()
 }
 
 export async function activate(context: vscode.ExtensionContext) {
@@ -196,7 +247,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
   context.subscriptions.push(fileWatcher)
 
-  const configWatcher = vscode.workspace.createFileSystemWatcher('**/.herb.yml')
+  const configWatcher = vscode.workspace.createFileSystemWatcher(`**/{${Config.configPath},${Config.misnamedConfigPaths.join(",")}}`)
 
   configWatcher.onDidCreate(async () => {
     await updateConfigStatusBarItem()
@@ -211,6 +262,10 @@ export async function activate(context: vscode.ExtensionContext) {
   })
 
   context.subscriptions.push(configWatcher)
+
+  context.subscriptions.push(vscode.window.onDidChangeActiveTextEditor(async () => {
+    await updateConfigStatusBarItem()
+  }))
 
   await updateConfigStatusBarItem()
   await runAutoAnalysis()


### PR DESCRIPTION
Follow up on #1996, which started reporting a config file that Herb doesn't read, but only on the CLI:

```
⚠ Ignoring /your-project/.herb.yaml: Herb only reads `.herb.yml`. Rename it to `.herb.yml` to apply it.
```

In the editor a `.herb.yaml`, `herb.yml`, or `herb.yaml` still showed nothing at all. That is the same impression the file already gives on its own, so the one place where the mistake is most likely to be made was also the one place that stayed quiet about it.

The reason is that these documents never reached the language server. The VS Code document selector and the file watchers on both sides only ever matched `.herb.yml`, so the server was never told the file existed.

This pull request opens that path and reports the file once it arrives. The document gets an error spanning its entire contents:

```
Herb only reads `.herb.yml`, so this file is ignored. Rename it to `.herb.yml` to apply it.
```

The status bar turns red and reads `.herb.yaml (Not Read)`, with a tooltip naming every misnamed file found and what to rename it to. Clicking it opens the file:

<img width="2638" height="1954" alt="CleanShot 2026-08-04 at 21 17 06@2x" src="https://github.com/user-attachments/assets/6cda238c-852b-460d-adcf-fad4831eb0af" />
