### PR TITLE
Action View: Track what every helper yields to its block

### DIFF
--- a/Yerbafile
+++ b/Yerbafile
@@ -168,6 +168,7 @@ rules:
             - tag
             - arguments
             - options
+            - block_arguments
             - special_behaviors
             - aliases
 
@@ -259,6 +260,7 @@ rules:
             - tag
             - arguments
             - options
+            - block_arguments
             - special_behaviors
 
           after:
@@ -267,6 +269,7 @@ rules:
             - tag
             - arguments
             - options
+            - block_arguments
             - special_behaviors
 
       - blank_lines:
@@ -275,6 +278,10 @@ rules:
 
       - blank_lines:
           path: "options"
+          count: 1
+
+      - blank_lines:
+          path: "block_arguments"
           count: 1
 
       - blank_lines:

--- a/config/action_view_helpers/actioncable/action_cable_helper/action_cable_meta_tag.yml
+++ b/config/action_view_helpers/actioncable/action_cable_helper/action_cable_meta_tag.yml
@@ -20,4 +20,5 @@ tag:
 
 arguments: []
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionpack/content_security_policy/content_security_policy?.yml
+++ b/config/action_view_helpers/actionpack/content_security_policy/content_security_policy?.yml
@@ -15,4 +15,5 @@ description: |-
 tag: null
 arguments: []
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionpack/content_security_policy/content_security_policy_nonce.yml
+++ b/config/action_view_helpers/actionpack/content_security_policy/content_security_policy_nonce.yml
@@ -15,4 +15,5 @@ description: |-
 tag: null
 arguments: []
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionpack/polymorphic_routes/polymorphic_path.yml
+++ b/config/action_view_helpers/actionpack/polymorphic_routes/polymorphic_path.yml
@@ -31,4 +31,5 @@ arguments:
       URL options hash.
 
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionpack/polymorphic_routes/polymorphic_url.yml
+++ b/config/action_view_helpers/actionpack/polymorphic_routes/polymorphic_url.yml
@@ -41,4 +41,5 @@ options:
     description: |-
       Whether to generate `:url` or `:path`. Defaults to `:url`.
 
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionpack/request_forgery_protection/form_authenticity_token.yml
+++ b/config/action_view_helpers/actionpack/request_forgery_protection/form_authenticity_token.yml
@@ -21,4 +21,5 @@ options:
     description: |-
       A hash that may contain `:action` and `:method` keys for per-form CSRF tokens.
 
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionpack/request_forgery_protection/protect_against_forgery?.yml
+++ b/config/action_view_helpers/actionpack/request_forgery_protection/protect_against_forgery?.yml
@@ -15,4 +15,5 @@ description: |-
 tag: null
 arguments: []
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actiontext/content_helper/render_action_text_content.yml
+++ b/config/action_view_helpers/actiontext/content_helper/render_action_text_content.yml
@@ -23,4 +23,5 @@ arguments:
       The Action Text content object to render.
 
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actiontext/content_helper/sanitize_action_text_content.yml
+++ b/config/action_view_helpers/actiontext/content_helper/sanitize_action_text_content.yml
@@ -23,4 +23,5 @@ arguments:
       The Action Text content object to sanitize.
 
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actiontext/tag_helper/rich_textarea_tag.yml
+++ b/config/action_view_helpers/actiontext/tag_helper/rich_textarea_tag.yml
@@ -54,4 +54,5 @@ options:
     description: |-
       Hash of `data-*` attributes. Includes direct_upload_url and blob_url_template by default.
 
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/active_model_helper/error_message.yml
+++ b/config/action_view_helpers/actionview/active_model_helper/error_message.yml
@@ -15,4 +15,5 @@ description: |-
 tag: null
 arguments: []
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/active_model_helper/error_wrapping.yml
+++ b/config/action_view_helpers/actionview/active_model_helper/error_wrapping.yml
@@ -15,4 +15,5 @@ description: |-
 tag: null
 arguments: []
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/active_model_helper/object.yml
+++ b/config/action_view_helpers/actionview/active_model_helper/object.yml
@@ -15,4 +15,5 @@ description: |-
 tag: null
 arguments: []
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/asset_tag_helper/apply_stylesheet_media_default.yml
+++ b/config/action_view_helpers/actionview/asset_tag_helper/apply_stylesheet_media_default.yml
@@ -15,4 +15,5 @@ description: |-
 tag: null
 arguments: []
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/asset_tag_helper/audio_tag.yml
+++ b/config/action_view_helpers/actionview/asset_tag_helper/audio_tag.yml
@@ -54,4 +54,5 @@ options:
     description: |-
       Preload behavior (`"auto"`, `"metadata"`, `"none"`).
 
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/asset_tag_helper/auto_discovery_link_tag.yml
+++ b/config/action_view_helpers/actionview/asset_tag_helper/auto_discovery_link_tag.yml
@@ -54,4 +54,5 @@ options:
     description: |-
       MIME type override.
 
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/asset_tag_helper/auto_include_nonce.yml
+++ b/config/action_view_helpers/actionview/asset_tag_helper/auto_include_nonce.yml
@@ -15,4 +15,5 @@ description: |-
 tag: null
 arguments: []
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/asset_tag_helper/auto_include_nonce_for_scripts.yml
+++ b/config/action_view_helpers/actionview/asset_tag_helper/auto_include_nonce_for_scripts.yml
@@ -15,4 +15,5 @@ description: |-
 tag: null
 arguments: []
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/asset_tag_helper/auto_include_nonce_for_styles.yml
+++ b/config/action_view_helpers/actionview/asset_tag_helper/auto_include_nonce_for_styles.yml
@@ -15,4 +15,5 @@ description: |-
 tag: null
 arguments: []
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/asset_tag_helper/favicon_link_tag.yml
+++ b/config/action_view_helpers/actionview/asset_tag_helper/favicon_link_tag.yml
@@ -52,4 +52,5 @@ options:
     description: |-
       Link relation (defaults to `"icon"`).
 
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/asset_tag_helper/image_decoding.yml
+++ b/config/action_view_helpers/actionview/asset_tag_helper/image_decoding.yml
@@ -15,4 +15,5 @@ description: |-
 tag: null
 arguments: []
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/asset_tag_helper/image_loading.yml
+++ b/config/action_view_helpers/actionview/asset_tag_helper/image_loading.yml
@@ -15,4 +15,5 @@ description: |-
 tag: null
 arguments: []
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/asset_tag_helper/image_tag.yml
+++ b/config/action_view_helpers/actionview/asset_tag_helper/image_tag.yml
@@ -77,6 +77,8 @@ options:
     description: |-
       Hash of `data-*` attributes.
 
+block_arguments: []
+
 special_behaviors:
   - type: "size_to_dimensions"
     attribute: "size"

--- a/config/action_view_helpers/actionview/asset_tag_helper/javascript_include_tag.yml
+++ b/config/action_view_helpers/actionview/asset_tag_helper/javascript_include_tag.yml
@@ -68,6 +68,8 @@ options:
     description: |-
       Specify if the use of server push is not desired. Defaults to `true`.
 
+block_arguments: []
+
 special_behaviors:
   - type: "multiple_elements"
     source: "splat_args"

--- a/config/action_view_helpers/actionview/asset_tag_helper/picture_tag.yml
+++ b/config/action_view_helpers/actionview/asset_tag_helper/picture_tag.yml
@@ -33,4 +33,5 @@ options:
     description: |-
       CSS class name(s).
 
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/asset_tag_helper/preload_link_tag.yml
+++ b/config/action_view_helpers/actionview/asset_tag_helper/preload_link_tag.yml
@@ -61,4 +61,5 @@ options:
     description: |-
       CSP nonce value.
 
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/asset_tag_helper/preload_links_header.yml
+++ b/config/action_view_helpers/actionview/asset_tag_helper/preload_links_header.yml
@@ -15,4 +15,5 @@ description: |-
 tag: null
 arguments: []
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/asset_tag_helper/stylesheet_link_tag.yml
+++ b/config/action_view_helpers/actionview/asset_tag_helper/stylesheet_link_tag.yml
@@ -59,5 +59,7 @@ options:
     description: |-
       Specify if the use of server push is not desired. Defaults to `true`.
 
+block_arguments: []
+
 special_behaviors:
   - "multiple_sources_multiple_elements"

--- a/config/action_view_helpers/actionview/asset_tag_helper/video_tag.yml
+++ b/config/action_view_helpers/actionview/asset_tag_helper/video_tag.yml
@@ -69,4 +69,5 @@ options:
     description: |-
       Preload behavior (`"auto"`, `"metadata"`, `"none"`).
 
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/asset_url_helper/asset_path.yml
+++ b/config/action_view_helpers/actionview/asset_url_helper/asset_path.yml
@@ -23,6 +23,7 @@ arguments:
       Asset file name or path.
 
 options: []
+block_arguments: []
 special_behaviors: []
 aliases:
   - "path_to_asset"

--- a/config/action_view_helpers/actionview/asset_url_helper/asset_url.yml
+++ b/config/action_view_helpers/actionview/asset_url_helper/asset_url.yml
@@ -23,6 +23,7 @@ arguments:
       Asset file name or path.
 
 options: []
+block_arguments: []
 special_behaviors: []
 aliases:
   - "url_to_asset"

--- a/config/action_view_helpers/actionview/asset_url_helper/audio_path.yml
+++ b/config/action_view_helpers/actionview/asset_url_helper/audio_path.yml
@@ -23,6 +23,7 @@ arguments:
       Audio file name or path.
 
 options: []
+block_arguments: []
 special_behaviors: []
 aliases:
   - "path_to_audio"

--- a/config/action_view_helpers/actionview/asset_url_helper/audio_url.yml
+++ b/config/action_view_helpers/actionview/asset_url_helper/audio_url.yml
@@ -23,6 +23,7 @@ arguments:
       Audio file name or path.
 
 options: []
+block_arguments: []
 special_behaviors: []
 aliases:
   - "url_to_audio"

--- a/config/action_view_helpers/actionview/asset_url_helper/compute_asset_extname.yml
+++ b/config/action_view_helpers/actionview/asset_url_helper/compute_asset_extname.yml
@@ -15,4 +15,5 @@ description: |-
 tag: null
 arguments: []
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/asset_url_helper/compute_asset_host.yml
+++ b/config/action_view_helpers/actionview/asset_url_helper/compute_asset_host.yml
@@ -15,4 +15,5 @@ description: |-
 tag: null
 arguments: []
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/asset_url_helper/compute_asset_path.yml
+++ b/config/action_view_helpers/actionview/asset_url_helper/compute_asset_path.yml
@@ -15,4 +15,5 @@ description: |-
 tag: null
 arguments: []
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/asset_url_helper/font_path.yml
+++ b/config/action_view_helpers/actionview/asset_url_helper/font_path.yml
@@ -23,6 +23,7 @@ arguments:
       Font file name or path.
 
 options: []
+block_arguments: []
 special_behaviors: []
 aliases:
   - "path_to_font"

--- a/config/action_view_helpers/actionview/asset_url_helper/font_url.yml
+++ b/config/action_view_helpers/actionview/asset_url_helper/font_url.yml
@@ -23,6 +23,7 @@ arguments:
       Font file name or path.
 
 options: []
+block_arguments: []
 special_behaviors: []
 aliases:
   - "url_to_font"

--- a/config/action_view_helpers/actionview/asset_url_helper/image_path.yml
+++ b/config/action_view_helpers/actionview/asset_url_helper/image_path.yml
@@ -23,6 +23,7 @@ arguments:
       Image file name or path.
 
 options: []
+block_arguments: []
 special_behaviors: []
 aliases:
   - "path_to_image"

--- a/config/action_view_helpers/actionview/asset_url_helper/image_url.yml
+++ b/config/action_view_helpers/actionview/asset_url_helper/image_url.yml
@@ -23,6 +23,7 @@ arguments:
       Image file name or path.
 
 options: []
+block_arguments: []
 special_behaviors: []
 aliases:
   - "url_to_image"

--- a/config/action_view_helpers/actionview/asset_url_helper/javascript_path.yml
+++ b/config/action_view_helpers/actionview/asset_url_helper/javascript_path.yml
@@ -23,6 +23,7 @@ arguments:
       JavaScript file name or path.
 
 options: []
+block_arguments: []
 special_behaviors: []
 aliases:
   - "path_to_javascript"

--- a/config/action_view_helpers/actionview/asset_url_helper/javascript_url.yml
+++ b/config/action_view_helpers/actionview/asset_url_helper/javascript_url.yml
@@ -23,6 +23,7 @@ arguments:
       JavaScript file name or path.
 
 options: []
+block_arguments: []
 special_behaviors: []
 aliases:
   - "url_to_javascript"

--- a/config/action_view_helpers/actionview/asset_url_helper/public_compute_asset_path.yml
+++ b/config/action_view_helpers/actionview/asset_url_helper/public_compute_asset_path.yml
@@ -15,4 +15,5 @@ description: |-
 tag: null
 arguments: []
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/asset_url_helper/stylesheet_path.yml
+++ b/config/action_view_helpers/actionview/asset_url_helper/stylesheet_path.yml
@@ -23,6 +23,7 @@ arguments:
       Stylesheet file name or path.
 
 options: []
+block_arguments: []
 special_behaviors: []
 aliases:
   - "path_to_stylesheet"

--- a/config/action_view_helpers/actionview/asset_url_helper/stylesheet_url.yml
+++ b/config/action_view_helpers/actionview/asset_url_helper/stylesheet_url.yml
@@ -23,6 +23,7 @@ arguments:
       Stylesheet file name or path.
 
 options: []
+block_arguments: []
 special_behaviors: []
 aliases:
   - "url_to_stylesheet"

--- a/config/action_view_helpers/actionview/asset_url_helper/video_path.yml
+++ b/config/action_view_helpers/actionview/asset_url_helper/video_path.yml
@@ -23,6 +23,7 @@ arguments:
       Video file name or path.
 
 options: []
+block_arguments: []
 special_behaviors: []
 aliases:
   - "path_to_video"

--- a/config/action_view_helpers/actionview/asset_url_helper/video_url.yml
+++ b/config/action_view_helpers/actionview/asset_url_helper/video_url.yml
@@ -23,6 +23,7 @@ arguments:
       Video file name or path.
 
 options: []
+block_arguments: []
 special_behaviors: []
 aliases:
   - "url_to_video"

--- a/config/action_view_helpers/actionview/atom_feed_helper/atom_feed.yml
+++ b/config/action_view_helpers/actionview/atom_feed_helper/atom_feed.yml
@@ -54,4 +54,12 @@ options:
     description: |-
       Hash of XML processing instructions.
 
+block_arguments:
+  - name: "feed"
+    position: 1
+    type: "ActionView::Helpers::AtomFeedHelper::AtomFeedBuilder"
+    optional: false
+    description: |-
+      The feed builder the entries are added to.
+
 special_behaviors: []

--- a/config/action_view_helpers/actionview/cache_helper/cache.yml
+++ b/config/action_view_helpers/actionview/cache_helper/cache.yml
@@ -34,4 +34,5 @@ options:
     description: |-
       Cache expiration time.
 
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/cache_helper/cache_fragment_name.yml
+++ b/config/action_view_helpers/actionview/cache_helper/cache_fragment_name.yml
@@ -15,4 +15,5 @@ description: |-
 tag: null
 arguments: []
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/cache_helper/cache_if.yml
+++ b/config/action_view_helpers/actionview/cache_helper/cache_if.yml
@@ -31,4 +31,5 @@ arguments:
       Cache key.
 
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/cache_helper/cache_unless.yml
+++ b/config/action_view_helpers/actionview/cache_helper/cache_unless.yml
@@ -31,4 +31,5 @@ arguments:
       Cache key.
 
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/cache_helper/caching_predicate.yml
+++ b/config/action_view_helpers/actionview/cache_helper/caching_predicate.yml
@@ -15,4 +15,5 @@ description: |-
 tag: null
 arguments: []
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/cache_helper/digest_path_from_template.yml
+++ b/config/action_view_helpers/actionview/cache_helper/digest_path_from_template.yml
@@ -15,4 +15,5 @@ description: |-
 tag: null
 arguments: []
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/cache_helper/fragment_for.yml
+++ b/config/action_view_helpers/actionview/cache_helper/fragment_for.yml
@@ -15,4 +15,5 @@ description: |-
 tag: null
 arguments: []
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/cache_helper/fragment_name_with_digest.yml
+++ b/config/action_view_helpers/actionview/cache_helper/fragment_name_with_digest.yml
@@ -15,4 +15,5 @@ description: |-
 tag: null
 arguments: []
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/cache_helper/read_fragment_for.yml
+++ b/config/action_view_helpers/actionview/cache_helper/read_fragment_for.yml
@@ -15,4 +15,5 @@ description: |-
 tag: null
 arguments: []
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/cache_helper/uncacheable.yml
+++ b/config/action_view_helpers/actionview/cache_helper/uncacheable.yml
@@ -15,4 +15,5 @@ description: |-
 tag: null
 arguments: []
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/cache_helper/write_fragment_for.yml
+++ b/config/action_view_helpers/actionview/cache_helper/write_fragment_for.yml
@@ -15,4 +15,5 @@ description: |-
 tag: null
 arguments: []
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/capture_helper/capture.yml
+++ b/config/action_view_helpers/actionview/capture_helper/capture.yml
@@ -15,4 +15,5 @@ description: |-
 tag: null
 arguments: []
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/capture_helper/content_for.yml
+++ b/config/action_view_helpers/actionview/capture_helper/content_for.yml
@@ -28,4 +28,5 @@ options:
     description: |-
       If `true`, replaces any existing content instead of appending.
 
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/capture_helper/content_for_predicate.yml
+++ b/config/action_view_helpers/actionview/capture_helper/content_for_predicate.yml
@@ -23,4 +23,5 @@ arguments:
       Identifier for the content block to check.
 
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/capture_helper/provide.yml
+++ b/config/action_view_helpers/actionview/capture_helper/provide.yml
@@ -23,4 +23,5 @@ arguments:
       Identifier for the content block.
 
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/capture_helper/with_output_buffer.yml
+++ b/config/action_view_helpers/actionview/capture_helper/with_output_buffer.yml
@@ -15,4 +15,5 @@ description: |-
 tag: null
 arguments: []
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/content_exfiltration_prevention_helper/prepend_content_exfiltration_prevention.yml
+++ b/config/action_view_helpers/actionview/content_exfiltration_prevention_helper/prepend_content_exfiltration_prevention.yml
@@ -15,4 +15,5 @@ description: |-
 tag: null
 arguments: []
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/content_exfiltration_prevention_helper/prevent_content_exfiltration.yml
+++ b/config/action_view_helpers/actionview/content_exfiltration_prevention_helper/prevent_content_exfiltration.yml
@@ -15,4 +15,5 @@ description: |-
 tag: null
 arguments: []
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/controller_helper/action_name.yml
+++ b/config/action_view_helpers/actionview/controller_helper/action_name.yml
@@ -15,4 +15,5 @@ description: |-
 tag: null
 arguments: []
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/controller_helper/assign_controller.yml
+++ b/config/action_view_helpers/actionview/controller_helper/assign_controller.yml
@@ -15,4 +15,5 @@ description: |-
 tag: null
 arguments: []
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/controller_helper/controller.yml
+++ b/config/action_view_helpers/actionview/controller_helper/controller.yml
@@ -15,4 +15,5 @@ description: |-
 tag: null
 arguments: []
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/controller_helper/controller_name.yml
+++ b/config/action_view_helpers/actionview/controller_helper/controller_name.yml
@@ -15,4 +15,5 @@ description: |-
 tag: null
 arguments: []
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/controller_helper/controller_path.yml
+++ b/config/action_view_helpers/actionview/controller_helper/controller_path.yml
@@ -15,4 +15,5 @@ description: |-
 tag: null
 arguments: []
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/controller_helper/cookies.yml
+++ b/config/action_view_helpers/actionview/controller_helper/cookies.yml
@@ -15,4 +15,5 @@ description: |-
 tag: null
 arguments: []
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/controller_helper/flash.yml
+++ b/config/action_view_helpers/actionview/controller_helper/flash.yml
@@ -15,4 +15,5 @@ description: |-
 tag: null
 arguments: []
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/controller_helper/headers.yml
+++ b/config/action_view_helpers/actionview/controller_helper/headers.yml
@@ -15,4 +15,5 @@ description: |-
 tag: null
 arguments: []
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/controller_helper/logger.yml
+++ b/config/action_view_helpers/actionview/controller_helper/logger.yml
@@ -15,6 +15,7 @@ description: |-
 tag: null
 arguments: []
 options: []
+block_arguments: []
 special_behaviors: []
 aliases:
   - "logger?"

--- a/config/action_view_helpers/actionview/controller_helper/params.yml
+++ b/config/action_view_helpers/actionview/controller_helper/params.yml
@@ -15,4 +15,5 @@ description: |-
 tag: null
 arguments: []
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/controller_helper/request.yml
+++ b/config/action_view_helpers/actionview/controller_helper/request.yml
@@ -15,4 +15,5 @@ description: |-
 tag: null
 arguments: []
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/controller_helper/request_forgery_protection_token.yml
+++ b/config/action_view_helpers/actionview/controller_helper/request_forgery_protection_token.yml
@@ -15,4 +15,5 @@ description: |-
 tag: null
 arguments: []
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/controller_helper/response.yml
+++ b/config/action_view_helpers/actionview/controller_helper/response.yml
@@ -15,4 +15,5 @@ description: |-
 tag: null
 arguments: []
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/controller_helper/session.yml
+++ b/config/action_view_helpers/actionview/controller_helper/session.yml
@@ -15,4 +15,5 @@ description: |-
 tag: null
 arguments: []
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/csp_helper/csp_meta_tag.yml
+++ b/config/action_view_helpers/actionview/csp_helper/csp_meta_tag.yml
@@ -26,4 +26,5 @@ options:
     description: |-
       CSP nonce value.
 
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/csrf_helper/csrf_meta_tags.yml
+++ b/config/action_view_helpers/actionview/csrf_helper/csrf_meta_tags.yml
@@ -20,6 +20,7 @@ tag:
 
 arguments: []
 options: []
+block_arguments: []
 
 special_behaviors:
   - "produces_multiple_elements"

--- a/config/action_view_helpers/actionview/date_helper/date_select.yml
+++ b/config/action_view_helpers/actionview/date_helper/date_select.yml
@@ -101,4 +101,5 @@ options:
     description: |-
       If `true`, the select fields are disabled.
 
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/date_helper/datetime_select.yml
+++ b/config/action_view_helpers/actionview/date_helper/datetime_select.yml
@@ -81,4 +81,5 @@ options:
     description: |-
       If `true`, the select fields are disabled.
 
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/date_helper/distance_of_time_in_words.yml
+++ b/config/action_view_helpers/actionview/date_helper/distance_of_time_in_words.yml
@@ -41,4 +41,5 @@ options:
     description: |-
       I18n scope for translations.
 
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/date_helper/relative_time_in_words.yml
+++ b/config/action_view_helpers/actionview/date_helper/relative_time_in_words.yml
@@ -46,4 +46,5 @@ options:
     description: |-
       Locale for the translation.
 
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/date_helper/select_date.yml
+++ b/config/action_view_helpers/actionview/date_helper/select_date.yml
@@ -65,4 +65,5 @@ options:
     description: |-
       Set to `true` for generic prompts, a string for a custom prompt, or a hash for per-field prompts.
 
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/date_helper/select_datetime.yml
+++ b/config/action_view_helpers/actionview/date_helper/select_datetime.yml
@@ -80,4 +80,5 @@ options:
     description: |-
       Set to `true` for generic prompts, a string for a custom prompt, or a hash for per-field prompts.
 
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/date_helper/select_day.yml
+++ b/config/action_view_helpers/actionview/date_helper/select_day.yml
@@ -54,4 +54,5 @@ options:
     description: |-
       Set to `true` for a generic prompt or a string for a custom prompt.
 
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/date_helper/select_hour.yml
+++ b/config/action_view_helpers/actionview/date_helper/select_hour.yml
@@ -64,4 +64,5 @@ options:
     description: |-
       Set to `true` for a generic prompt or a string for a custom prompt.
 
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/date_helper/select_minute.yml
+++ b/config/action_view_helpers/actionview/date_helper/select_minute.yml
@@ -54,4 +54,5 @@ options:
     description: |-
       Set to `true` for a generic prompt or a string for a custom prompt.
 
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/date_helper/select_month.yml
+++ b/config/action_view_helpers/actionview/date_helper/select_month.yml
@@ -74,4 +74,5 @@ options:
     description: |-
       Set to `true` for a generic prompt or a string for a custom prompt.
 
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/date_helper/select_second.yml
+++ b/config/action_view_helpers/actionview/date_helper/select_second.yml
@@ -49,4 +49,5 @@ options:
     description: |-
       Set to `true` for a generic prompt or a string for a custom prompt.
 
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/date_helper/select_time.yml
+++ b/config/action_view_helpers/actionview/date_helper/select_time.yml
@@ -70,4 +70,5 @@ options:
     description: |-
       Set to `true` for generic prompts, a string for a custom prompt, or a hash for per-field prompts.
 
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/date_helper/select_year.yml
+++ b/config/action_view_helpers/actionview/date_helper/select_year.yml
@@ -59,4 +59,5 @@ options:
     description: |-
       Set to `true` for a generic prompt or a string for a custom prompt.
 
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/date_helper/time_ago_in_words.yml
+++ b/config/action_view_helpers/actionview/date_helper/time_ago_in_words.yml
@@ -28,6 +28,7 @@ options:
     description: |-
       Include more detail for distances under 1 minute.
 
+block_arguments: []
 special_behaviors: []
 aliases:
   - "distance_of_time_in_words_to_now"

--- a/config/action_view_helpers/actionview/date_helper/time_select.yml
+++ b/config/action_view_helpers/actionview/date_helper/time_select.yml
@@ -76,4 +76,5 @@ options:
     description: |-
       If `true`, the select fields are disabled.
 
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/date_helper/time_tag.yml
+++ b/config/action_view_helpers/actionview/date_helper/time_tag.yml
@@ -45,4 +45,5 @@ options:
     description: |-
       Override the datetime attribute value.
 
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/debug_helper/debug.yml
+++ b/config/action_view_helpers/actionview/debug_helper/debug.yml
@@ -23,4 +23,5 @@ arguments:
       Object to debug.
 
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/form_builder/button.yml
+++ b/config/action_view_helpers/actionview/form_builder/button.yml
@@ -48,4 +48,12 @@ options:
     description: |-
       Hash of `data-*` attributes.
 
+block_arguments:
+  - name: "value"
+    position: 1
+    type: "String"
+    optional: false
+    description: |-
+      The default button label, so a block can wrap or replace it.
+
 special_behaviors: []

--- a/config/action_view_helpers/actionview/form_builder/submit.yml
+++ b/config/action_view_helpers/actionview/form_builder/submit.yml
@@ -43,4 +43,5 @@ options:
     description: |-
       Hash of `data-*` attributes.
 
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/form_helper/apply_form_for_options.yml
+++ b/config/action_view_helpers/actionview/form_helper/apply_form_for_options.yml
@@ -15,4 +15,5 @@ description: |-
 tag: null
 arguments: []
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/form_helper/checkbox.yml
+++ b/config/action_view_helpers/actionview/form_helper/checkbox.yml
@@ -59,6 +59,7 @@ options:
     description: |-
       If `false`, omits the hidden field for the unchecked value.
 
+block_arguments: []
 special_behaviors: []
 aliases:
   - "check_box"

--- a/config/action_view_helpers/actionview/form_helper/color_field.yml
+++ b/config/action_view_helpers/actionview/form_helper/color_field.yml
@@ -38,4 +38,5 @@ arguments:
       HTML attributes hash.
 
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/form_helper/date_field.yml
+++ b/config/action_view_helpers/actionview/form_helper/date_field.yml
@@ -48,4 +48,5 @@ options:
     description: |-
       Maximum date value (ISO8601 string or Date/Time object).
 
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/form_helper/datetime_field.yml
+++ b/config/action_view_helpers/actionview/form_helper/datetime_field.yml
@@ -53,6 +53,7 @@ options:
     description: |-
       Maximum datetime value (ISO8601 string or Date/Time object).
 
+block_arguments: []
 special_behaviors: []
 aliases:
   - "datetime_local_field"

--- a/config/action_view_helpers/actionview/form_helper/email_field.yml
+++ b/config/action_view_helpers/actionview/form_helper/email_field.yml
@@ -38,4 +38,5 @@ arguments:
       HTML attributes hash.
 
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/form_helper/emitted_hidden_id.yml
+++ b/config/action_view_helpers/actionview/form_helper/emitted_hidden_id.yml
@@ -15,4 +15,5 @@ description: |-
 tag: null
 arguments: []
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/form_helper/fields.yml
+++ b/config/action_view_helpers/actionview/form_helper/fields.yml
@@ -39,4 +39,12 @@ options:
     description: |-
       Custom form builder class.
 
+block_arguments:
+  - name: "form"
+    position: 1
+    type: "ActionView::Helpers::FormBuilder"
+    optional: false
+    description: |-
+      The form builder scoped to the given model.
+
 special_behaviors: []

--- a/config/action_view_helpers/actionview/form_helper/fields_for.yml
+++ b/config/action_view_helpers/actionview/form_helper/fields_for.yml
@@ -39,4 +39,13 @@ arguments:
       Options hash.
 
 options: []
+
+block_arguments:
+  - name: "form"
+    position: 1
+    type: "ActionView::Helpers::FormBuilder"
+    optional: false
+    description: |-
+      The form builder scoped to the nested record.
+
 special_behaviors: []

--- a/config/action_view_helpers/actionview/form_helper/file_field.yml
+++ b/config/action_view_helpers/actionview/form_helper/file_field.yml
@@ -58,4 +58,5 @@ options:
     description: |-
       If `true`, enables Active Storage direct upload.
 
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/form_helper/form_for.yml
+++ b/config/action_view_helpers/actionview/form_helper/form_for.yml
@@ -51,4 +51,12 @@ options:
     description: |-
       Hash of `data-*` attributes.
 
+block_arguments:
+  - name: "form"
+    position: 1
+    type: "ActionView::Helpers::FormBuilder"
+    optional: false
+    description: |-
+      The form builder for the record.
+
 special_behaviors: []

--- a/config/action_view_helpers/actionview/form_helper/form_with.yml
+++ b/config/action_view_helpers/actionview/form_helper/form_with.yml
@@ -57,4 +57,12 @@ options:
     description: |-
       CSS class name(s).
 
+block_arguments:
+  - name: "form"
+    position: 1
+    type: "ActionView::Helpers::FormBuilder"
+    optional: false
+    description: |-
+      The form builder for the model.
+
 special_behaviors: []

--- a/config/action_view_helpers/actionview/form_helper/form_with_generates_ids.yml
+++ b/config/action_view_helpers/actionview/form_helper/form_with_generates_ids.yml
@@ -15,4 +15,5 @@ description: |-
 tag: null
 arguments: []
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/form_helper/form_with_generates_remote_forms.yml
+++ b/config/action_view_helpers/actionview/form_helper/form_with_generates_remote_forms.yml
@@ -15,4 +15,5 @@ description: |-
 tag: null
 arguments: []
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/form_helper/hidden_field.yml
+++ b/config/action_view_helpers/actionview/form_helper/hidden_field.yml
@@ -38,4 +38,5 @@ arguments:
       HTML attributes hash.
 
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/form_helper/label.yml
+++ b/config/action_view_helpers/actionview/form_helper/label.yml
@@ -61,4 +61,12 @@ options:
     description: |-
       Explicit `for` attribute value.
 
+block_arguments:
+  - name: "builder"
+    position: 1
+    type: "ActionView::Helpers::Tags::Label::LabelBuilder"
+    optional: false
+    description: |-
+      The label builder carrying the translated text.
+
 special_behaviors: []

--- a/config/action_view_helpers/actionview/form_helper/month_field.yml
+++ b/config/action_view_helpers/actionview/form_helper/month_field.yml
@@ -38,4 +38,5 @@ arguments:
       HTML attributes hash.
 
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/form_helper/multipart.yml
+++ b/config/action_view_helpers/actionview/form_helper/multipart.yml
@@ -15,4 +15,5 @@ description: |-
 tag: null
 arguments: []
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/form_helper/multiple_file_field_include_hidden.yml
+++ b/config/action_view_helpers/actionview/form_helper/multiple_file_field_include_hidden.yml
@@ -15,4 +15,5 @@ description: |-
 tag: null
 arguments: []
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/form_helper/number_field.yml
+++ b/config/action_view_helpers/actionview/form_helper/number_field.yml
@@ -58,4 +58,5 @@ options:
     description: |-
       Range that sets `min`, `max`, and `step`.
 
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/form_helper/password_field.yml
+++ b/config/action_view_helpers/actionview/form_helper/password_field.yml
@@ -38,4 +38,5 @@ arguments:
       HTML attributes hash.
 
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/form_helper/radio_button.yml
+++ b/config/action_view_helpers/actionview/form_helper/radio_button.yml
@@ -45,4 +45,5 @@ arguments:
       HTML attributes hash.
 
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/form_helper/range_field.yml
+++ b/config/action_view_helpers/actionview/form_helper/range_field.yml
@@ -58,4 +58,5 @@ options:
     description: |-
       Range that sets `min`, `max`, and `step`.
 
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/form_helper/search_field.yml
+++ b/config/action_view_helpers/actionview/form_helper/search_field.yml
@@ -38,4 +38,5 @@ arguments:
       HTML attributes hash.
 
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/form_helper/telephone_field.yml
+++ b/config/action_view_helpers/actionview/form_helper/telephone_field.yml
@@ -38,6 +38,7 @@ arguments:
       HTML attributes hash.
 
 options: []
+block_arguments: []
 special_behaviors: []
 aliases:
   - "phone_field"

--- a/config/action_view_helpers/actionview/form_helper/text_field.yml
+++ b/config/action_view_helpers/actionview/form_helper/text_field.yml
@@ -38,4 +38,5 @@ arguments:
       HTML attributes hash.
 
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/form_helper/textarea.yml
+++ b/config/action_view_helpers/actionview/form_helper/textarea.yml
@@ -43,6 +43,7 @@ options:
     description: |-
       Columns and rows in `"COLSxROWS"` format (e.g. `"20x30"`).
 
+block_arguments: []
 special_behaviors: []
 aliases:
   - "text_area"

--- a/config/action_view_helpers/actionview/form_helper/time_field.yml
+++ b/config/action_view_helpers/actionview/form_helper/time_field.yml
@@ -53,4 +53,5 @@ options:
     description: |-
       Maximum time value (ISO8601 string or Time object).
 
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/form_helper/url_field.yml
+++ b/config/action_view_helpers/actionview/form_helper/url_field.yml
@@ -38,4 +38,5 @@ arguments:
       HTML attributes hash.
 
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/form_helper/week_field.yml
+++ b/config/action_view_helpers/actionview/form_helper/week_field.yml
@@ -38,4 +38,5 @@ arguments:
       HTML attributes hash.
 
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/form_options_helper/collection_checkboxes.yml
+++ b/config/action_view_helpers/actionview/form_options_helper/collection_checkboxes.yml
@@ -72,6 +72,14 @@ options:
     description: |-
       If `false`, prevents the hidden field from being generated.
 
+block_arguments:
+  - name: "builder"
+    position: 1
+    type: "ActionView::Helpers::Tags::CollectionCheckBoxes::CheckBoxBuilder"
+    optional: false
+    description: |-
+      The builder for a single check box in the collection.
+
 special_behaviors: []
 aliases:
   - "collection_check_boxes"

--- a/config/action_view_helpers/actionview/form_options_helper/collection_radio_buttons.yml
+++ b/config/action_view_helpers/actionview/form_options_helper/collection_radio_buttons.yml
@@ -72,4 +72,12 @@ options:
     description: |-
       If `false`, prevents the hidden field from being generated.
 
+block_arguments:
+  - name: "builder"
+    position: 1
+    type: "ActionView::Helpers::Tags::CollectionRadioButtons::RadioButtonBuilder"
+    optional: false
+    description: |-
+      The builder for a single radio button in the collection.
+
 special_behaviors: []

--- a/config/action_view_helpers/actionview/form_options_helper/collection_select.yml
+++ b/config/action_view_helpers/actionview/form_options_helper/collection_select.yml
@@ -87,4 +87,5 @@ options:
     description: |-
       Value, values, or Proc to determine disabled options.
 
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/form_options_helper/grouped_collection_select.yml
+++ b/config/action_view_helpers/actionview/form_options_helper/grouped_collection_select.yml
@@ -91,4 +91,5 @@ options:
     description: |-
       Prepend an option with a generic prompt or the given prompt string.
 
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/form_options_helper/grouped_options_for_select.yml
+++ b/config/action_view_helpers/actionview/form_options_helper/grouped_options_for_select.yml
@@ -49,4 +49,5 @@ options:
     description: |-
       The divider string for option groups.
 
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/form_options_helper/option_groups_from_collection_for_select.yml
+++ b/config/action_view_helpers/actionview/form_options_helper/option_groups_from_collection_for_select.yml
@@ -59,4 +59,5 @@ arguments:
       The selected value, or a hash with `:selected` and `:disabled` keys.
 
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/form_options_helper/options_for_select.yml
+++ b/config/action_view_helpers/actionview/form_options_helper/options_for_select.yml
@@ -31,4 +31,5 @@ arguments:
       The value(s) to be selected, or a hash with `:selected` and `:disabled` keys.
 
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/form_options_helper/options_from_collection_for_select.yml
+++ b/config/action_view_helpers/actionview/form_options_helper/options_from_collection_for_select.yml
@@ -45,4 +45,5 @@ arguments:
       The selected value(s), a Proc, or a hash with `:selected` and `:disabled` keys.
 
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/form_options_helper/select.yml
+++ b/config/action_view_helpers/actionview/form_options_helper/select.yml
@@ -79,4 +79,5 @@ options:
     description: |-
       If `false`, prevents the hidden field from being generated for multiple selects.
 
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/form_options_helper/time_zone_options_for_select.yml
+++ b/config/action_view_helpers/actionview/form_options_helper/time_zone_options_for_select.yml
@@ -40,4 +40,5 @@ arguments:
       The time zone model object. Must respond to `all` and return objects that respond to `name`.
 
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/form_options_helper/time_zone_select.yml
+++ b/config/action_view_helpers/actionview/form_options_helper/time_zone_select.yml
@@ -69,4 +69,5 @@ options:
     description: |-
       Default `ActiveSupport::TimeZone` name if the object's time zone is `nil`.
 
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/form_options_helper/weekday_options_for_select.yml
+++ b/config/action_view_helpers/actionview/form_options_helper/weekday_options_for_select.yml
@@ -39,4 +39,5 @@ options:
     description: |-
       Defaults to `Date.beginning_of_week`.
 
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/form_options_helper/weekday_select.yml
+++ b/config/action_view_helpers/actionview/form_options_helper/weekday_select.yml
@@ -46,4 +46,5 @@ arguments:
       HTML attributes for the `<select>` tag.
 
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/form_tag_helper/button_tag.yml
+++ b/config/action_view_helpers/actionview/form_tag_helper/button_tag.yml
@@ -47,4 +47,5 @@ options:
     description: |-
       Hash of `data-*` attributes.
 
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/form_tag_helper/checkbox_tag.yml
+++ b/config/action_view_helpers/actionview/form_tag_helper/checkbox_tag.yml
@@ -51,6 +51,7 @@ arguments:
       HTML attributes hash.
 
 options: []
+block_arguments: []
 special_behaviors: []
 aliases:
   - "check_box_tag"

--- a/config/action_view_helpers/actionview/form_tag_helper/color_field_tag.yml
+++ b/config/action_view_helpers/actionview/form_tag_helper/color_field_tag.yml
@@ -43,4 +43,5 @@ arguments:
       HTML attributes hash.
 
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/form_tag_helper/date_field_tag.yml
+++ b/config/action_view_helpers/actionview/form_tag_helper/date_field_tag.yml
@@ -43,4 +43,5 @@ arguments:
       HTML attributes hash.
 
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/form_tag_helper/datetime_field_tag.yml
+++ b/config/action_view_helpers/actionview/form_tag_helper/datetime_field_tag.yml
@@ -43,6 +43,7 @@ arguments:
       HTML attributes hash.
 
 options: []
+block_arguments: []
 special_behaviors: []
 aliases:
   - "datetime_local_field_tag"

--- a/config/action_view_helpers/actionview/form_tag_helper/default_enforce_utf8.yml
+++ b/config/action_view_helpers/actionview/form_tag_helper/default_enforce_utf8.yml
@@ -15,4 +15,5 @@ description: |-
 tag: null
 arguments: []
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/form_tag_helper/email_field_tag.yml
+++ b/config/action_view_helpers/actionview/form_tag_helper/email_field_tag.yml
@@ -43,4 +43,5 @@ arguments:
       HTML attributes hash.
 
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/form_tag_helper/embed_authenticity_token_in_remote_forms.yml
+++ b/config/action_view_helpers/actionview/form_tag_helper/embed_authenticity_token_in_remote_forms.yml
@@ -15,4 +15,5 @@ description: |-
 tag: null
 arguments: []
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/form_tag_helper/field_id.yml
+++ b/config/action_view_helpers/actionview/form_tag_helper/field_id.yml
@@ -40,4 +40,5 @@ options:
     description: |-
       Namespace prefix for the id.
 
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/form_tag_helper/field_name.yml
+++ b/config/action_view_helpers/actionview/form_tag_helper/field_name.yml
@@ -40,4 +40,5 @@ options:
     description: |-
       Index for nested fields.
 
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/form_tag_helper/field_set_tag.yml
+++ b/config/action_view_helpers/actionview/form_tag_helper/field_set_tag.yml
@@ -36,6 +36,7 @@ arguments:
       HTML attributes hash.
 
 options: []
+block_arguments: []
 special_behaviors: []
 aliases:
   - "fieldset_tag"

--- a/config/action_view_helpers/actionview/form_tag_helper/file_field_tag.yml
+++ b/config/action_view_helpers/actionview/form_tag_helper/file_field_tag.yml
@@ -50,4 +50,5 @@ options:
     description: |-
       File types to accept (e.g. `"image/*"`).
 
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/form_tag_helper/form_tag.yml
+++ b/config/action_view_helpers/actionview/form_tag_helper/form_tag.yml
@@ -52,4 +52,5 @@ options:
     description: |-
       Hash of `data-*` attributes.
 
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/form_tag_helper/hidden_field_tag.yml
+++ b/config/action_view_helpers/actionview/form_tag_helper/hidden_field_tag.yml
@@ -43,4 +43,5 @@ arguments:
       HTML attributes hash.
 
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/form_tag_helper/image_submit_tag.yml
+++ b/config/action_view_helpers/actionview/form_tag_helper/image_submit_tag.yml
@@ -46,4 +46,5 @@ options:
     description: |-
       If `true`, the submit button is disabled.
 
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/form_tag_helper/label_tag.yml
+++ b/config/action_view_helpers/actionview/form_tag_helper/label_tag.yml
@@ -44,4 +44,5 @@ arguments:
       HTML attributes hash.
 
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/form_tag_helper/month_field_tag.yml
+++ b/config/action_view_helpers/actionview/form_tag_helper/month_field_tag.yml
@@ -43,4 +43,5 @@ arguments:
       HTML attributes hash.
 
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/form_tag_helper/number_field_tag.yml
+++ b/config/action_view_helpers/actionview/form_tag_helper/number_field_tag.yml
@@ -63,4 +63,5 @@ options:
     description: |-
       Range of allowed values (sets min, max, and step).
 
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/form_tag_helper/password_field_tag.yml
+++ b/config/action_view_helpers/actionview/form_tag_helper/password_field_tag.yml
@@ -44,4 +44,5 @@ arguments:
       HTML attributes hash.
 
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/form_tag_helper/radio_button_tag.yml
+++ b/config/action_view_helpers/actionview/form_tag_helper/radio_button_tag.yml
@@ -50,4 +50,5 @@ arguments:
       HTML attributes hash.
 
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/form_tag_helper/range_field_tag.yml
+++ b/config/action_view_helpers/actionview/form_tag_helper/range_field_tag.yml
@@ -63,4 +63,5 @@ options:
     description: |-
       Range of allowed values (sets min, max, and step).
 
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/form_tag_helper/search_field_tag.yml
+++ b/config/action_view_helpers/actionview/form_tag_helper/search_field_tag.yml
@@ -43,4 +43,5 @@ arguments:
       HTML attributes hash.
 
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/form_tag_helper/select_tag.yml
+++ b/config/action_view_helpers/actionview/form_tag_helper/select_tag.yml
@@ -63,4 +63,5 @@ options:
     description: |-
       Prompt text for the first option.
 
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/form_tag_helper/submit_tag.yml
+++ b/config/action_view_helpers/actionview/form_tag_helper/submit_tag.yml
@@ -47,4 +47,5 @@ options:
     description: |-
       Hash of `data-*` attributes.
 
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/form_tag_helper/telephone_field_tag.yml
+++ b/config/action_view_helpers/actionview/form_tag_helper/telephone_field_tag.yml
@@ -43,6 +43,7 @@ arguments:
       HTML attributes hash.
 
 options: []
+block_arguments: []
 special_behaviors: []
 aliases:
   - "phone_field_tag"

--- a/config/action_view_helpers/actionview/form_tag_helper/text_field_tag.yml
+++ b/config/action_view_helpers/actionview/form_tag_helper/text_field_tag.yml
@@ -43,4 +43,5 @@ arguments:
       HTML attributes hash.
 
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/form_tag_helper/textarea_tag.yml
+++ b/config/action_view_helpers/actionview/form_tag_helper/textarea_tag.yml
@@ -48,6 +48,7 @@ options:
     description: |-
       Textarea dimensions as `"COLSxROWS"` (e.g. `"20x40"`).
 
+block_arguments: []
 special_behaviors: []
 aliases:
   - "text_area_tag"

--- a/config/action_view_helpers/actionview/form_tag_helper/time_field_tag.yml
+++ b/config/action_view_helpers/actionview/form_tag_helper/time_field_tag.yml
@@ -43,4 +43,5 @@ arguments:
       HTML attributes hash.
 
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/form_tag_helper/url_field_tag.yml
+++ b/config/action_view_helpers/actionview/form_tag_helper/url_field_tag.yml
@@ -43,4 +43,5 @@ arguments:
       HTML attributes hash.
 
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/form_tag_helper/utf8_enforcer_tag.yml
+++ b/config/action_view_helpers/actionview/form_tag_helper/utf8_enforcer_tag.yml
@@ -15,4 +15,5 @@ description: |-
 tag: null
 arguments: []
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/form_tag_helper/week_field_tag.yml
+++ b/config/action_view_helpers/actionview/form_tag_helper/week_field_tag.yml
@@ -43,4 +43,5 @@ arguments:
       HTML attributes hash.
 
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/javascript_helper/escape_javascript.yml
+++ b/config/action_view_helpers/actionview/javascript_helper/escape_javascript.yml
@@ -23,6 +23,7 @@ arguments:
       JavaScript string to escape.
 
 options: []
+block_arguments: []
 special_behaviors: []
 aliases:
   - "j"

--- a/config/action_view_helpers/actionview/javascript_helper/javascript_cdata_section.yml
+++ b/config/action_view_helpers/actionview/javascript_helper/javascript_cdata_section.yml
@@ -15,4 +15,5 @@ description: |-
 tag: null
 arguments: []
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/javascript_helper/javascript_tag.yml
+++ b/config/action_view_helpers/actionview/javascript_helper/javascript_tag.yml
@@ -52,6 +52,8 @@ options:
     description: |-
       CSS class name(s).
 
+block_arguments: []
+
 special_behaviors:
   - type: "wrap_body"
     wrapper: "cdata"

--- a/config/action_view_helpers/actionview/number_helper/number_to_currency.yml
+++ b/config/action_view_helpers/actionview/number_helper/number_to_currency.yml
@@ -43,4 +43,5 @@ options:
     description: |-
       Decimal separator. Defaults to `"."`.
 
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/number_helper/number_to_human.yml
+++ b/config/action_view_helpers/actionview/number_helper/number_to_human.yml
@@ -33,4 +33,5 @@ options:
     description: |-
       Custom unit labels.
 
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/number_helper/number_to_human_size.yml
+++ b/config/action_view_helpers/actionview/number_helper/number_to_human_size.yml
@@ -28,4 +28,5 @@ options:
     description: |-
       Number of significant digits. Defaults to 3.
 
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/number_helper/number_to_percentage.yml
+++ b/config/action_view_helpers/actionview/number_helper/number_to_percentage.yml
@@ -28,4 +28,5 @@ options:
     description: |-
       Number of decimal places. Defaults to 3.
 
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/number_helper/number_to_phone.yml
+++ b/config/action_view_helpers/actionview/number_helper/number_to_phone.yml
@@ -43,4 +43,5 @@ options:
     description: |-
       Extension to append.
 
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/number_helper/number_with_delimiter.yml
+++ b/config/action_view_helpers/actionview/number_helper/number_with_delimiter.yml
@@ -33,4 +33,5 @@ options:
     description: |-
       Decimal separator. Defaults to `"."`.
 
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/number_helper/number_with_precision.yml
+++ b/config/action_view_helpers/actionview/number_helper/number_with_precision.yml
@@ -33,4 +33,5 @@ options:
     description: |-
       Whether precision means significant digits.
 
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/output_safety_helper/raw.yml
+++ b/config/action_view_helpers/actionview/output_safety_helper/raw.yml
@@ -23,4 +23,5 @@ arguments:
       String to mark as safe.
 
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/output_safety_helper/safe_join.yml
+++ b/config/action_view_helpers/actionview/output_safety_helper/safe_join.yml
@@ -30,4 +30,5 @@ arguments:
       Separator string.
 
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/output_safety_helper/to_sentence.yml
+++ b/config/action_view_helpers/actionview/output_safety_helper/to_sentence.yml
@@ -38,4 +38,5 @@ options:
     description: |-
       Connector before last word. Defaults to `", and "`.
 
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/record_identifier/dom_class.yml
+++ b/config/action_view_helpers/actionview/record_identifier/dom_class.yml
@@ -31,4 +31,5 @@ arguments:
       Optional prefix for the DOM class (e.g. `:edit`).
 
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/record_identifier/dom_id.yml
+++ b/config/action_view_helpers/actionview/record_identifier/dom_id.yml
@@ -31,4 +31,5 @@ arguments:
       Optional prefix for the DOM id (e.g. `:edit`).
 
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/record_identifier/dom_target.yml
+++ b/config/action_view_helpers/actionview/record_identifier/dom_target.yml
@@ -24,4 +24,5 @@ arguments:
       Records, strings, or symbols to concatenate.
 
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/record_identifier/model_name_from_record_or_class.yml
+++ b/config/action_view_helpers/actionview/record_identifier/model_name_from_record_or_class.yml
@@ -15,4 +15,5 @@ description: |-
 tag: null
 arguments: []
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/rendering_helper/render.yml
+++ b/config/action_view_helpers/actionview/rendering_helper/render.yml
@@ -44,4 +44,5 @@ options:
     description: |-
       Layout to wrap the rendered content.
 
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/sanitize_helper/sanitize.yml
+++ b/config/action_view_helpers/actionview/sanitize_helper/sanitize.yml
@@ -33,4 +33,5 @@ options:
     description: |-
       Allowed HTML attributes.
 
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/sanitize_helper/sanitize_css.yml
+++ b/config/action_view_helpers/actionview/sanitize_helper/sanitize_css.yml
@@ -23,4 +23,5 @@ arguments:
       CSS string to sanitize.
 
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/sanitize_helper/sanitizer_vendor.yml
+++ b/config/action_view_helpers/actionview/sanitize_helper/sanitizer_vendor.yml
@@ -15,4 +15,5 @@ description: |-
 tag: null
 arguments: []
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/sanitize_helper/strip_links.yml
+++ b/config/action_view_helpers/actionview/sanitize_helper/strip_links.yml
@@ -23,4 +23,5 @@ arguments:
       HTML string to strip links from.
 
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/sanitize_helper/strip_tags.yml
+++ b/config/action_view_helpers/actionview/sanitize_helper/strip_tags.yml
@@ -23,4 +23,5 @@ arguments:
       HTML string to strip tags from.
 
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/tag_helper/cdata_section.yml
+++ b/config/action_view_helpers/actionview/tag_helper/cdata_section.yml
@@ -23,4 +23,5 @@ arguments:
       Content for the CDATA section.
 
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/tag_helper/content_tag.yml
+++ b/config/action_view_helpers/actionview/tag_helper/content_tag.yml
@@ -80,4 +80,5 @@ options:
     description: |-
       Hash of `aria-*` attributes.
 
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/tag_helper/escape_once.yml
+++ b/config/action_view_helpers/actionview/tag_helper/escape_once.yml
@@ -23,4 +23,5 @@ arguments:
       HTML string to escape.
 
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/tag_helper/tag.yml
+++ b/config/action_view_helpers/actionview/tag_helper/tag.yml
@@ -57,5 +57,13 @@ options:
     description: |-
       Hash of `aria-*` attributes.
 
+block_arguments:
+  - name: "tag"
+    position: 1
+    type: "ActionView::Helpers::TagHelper::TagBuilder"
+    optional: false
+    description: |-
+      The tag builder, for nesting further tags inside the element.
+
 special_behaviors:
   - type: "method_name_underscores_to_dashes"

--- a/config/action_view_helpers/actionview/tag_helper/token_list.yml
+++ b/config/action_view_helpers/actionview/tag_helper/token_list.yml
@@ -24,6 +24,7 @@ arguments:
       Tokens to join. Hashes enable conditional inclusion.
 
 options: []
+block_arguments: []
 special_behaviors: []
 aliases:
   - "class_names"

--- a/config/action_view_helpers/actionview/text_helper/concat.yml
+++ b/config/action_view_helpers/actionview/text_helper/concat.yml
@@ -23,4 +23,5 @@ arguments:
       The text to append to the output buffer.
 
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/text_helper/current_cycle.yml
+++ b/config/action_view_helpers/actionview/text_helper/current_cycle.yml
@@ -24,4 +24,5 @@ arguments:
       Name of the cycle to return the current value for.
 
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/text_helper/cycle.yml
+++ b/config/action_view_helpers/actionview/text_helper/cycle.yml
@@ -36,4 +36,5 @@ options:
     description: |-
       Name for the cycle. Defaults to `"default"`.
 
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/text_helper/excerpt.yml
+++ b/config/action_view_helpers/actionview/text_helper/excerpt.yml
@@ -48,4 +48,5 @@ options:
     description: |-
       Omission string. Defaults to `"..."`.
 
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/text_helper/highlight.yml
+++ b/config/action_view_helpers/actionview/text_helper/highlight.yml
@@ -43,4 +43,12 @@ options:
     description: |-
       HTML tag to wrap highlights in. Defaults to `<mark>`.
 
+block_arguments:
+  - name: "match"
+    position: 1
+    type: "String"
+    optional: false
+    description: |-
+      Each occurrence of the phrase that was found in the text.
+
 special_behaviors: []

--- a/config/action_view_helpers/actionview/text_helper/pluralize.yml
+++ b/config/action_view_helpers/actionview/text_helper/pluralize.yml
@@ -40,4 +40,5 @@ options:
     description: |-
       Locale for pluralization rules.
 
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/text_helper/reset_cycle.yml
+++ b/config/action_view_helpers/actionview/text_helper/reset_cycle.yml
@@ -24,4 +24,5 @@ arguments:
       Name of the cycle to reset.
 
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/text_helper/safe_concat.yml
+++ b/config/action_view_helpers/actionview/text_helper/safe_concat.yml
@@ -15,4 +15,5 @@ description: |-
 tag: null
 arguments: []
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/text_helper/simple_format.yml
+++ b/config/action_view_helpers/actionview/text_helper/simple_format.yml
@@ -49,4 +49,5 @@ options:
     description: |-
       HTML tag to wrap paragraphs in. Defaults to `"p"`.
 
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/text_helper/truncate.yml
+++ b/config/action_view_helpers/actionview/text_helper/truncate.yml
@@ -51,4 +51,5 @@ options:
     description: |-
       Whether to HTML-escape the result. Defaults to `true`.
 
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/text_helper/word_wrap.yml
+++ b/config/action_view_helpers/actionview/text_helper/word_wrap.yml
@@ -33,4 +33,5 @@ options:
     description: |-
       Line break sequence. Defaults to newline.
 
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/translation_helper/debug_missing_translation.yml
+++ b/config/action_view_helpers/actionview/translation_helper/debug_missing_translation.yml
@@ -15,4 +15,5 @@ description: |-
 tag: null
 arguments: []
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/translation_helper/localize.yml
+++ b/config/action_view_helpers/actionview/translation_helper/localize.yml
@@ -33,6 +33,7 @@ options:
     description: |-
       Locale to use.
 
+block_arguments: []
 special_behaviors: []
 aliases:
   - "l"

--- a/config/action_view_helpers/actionview/translation_helper/translate.yml
+++ b/config/action_view_helpers/actionview/translation_helper/translate.yml
@@ -38,6 +38,7 @@ options:
     description: |-
       Count for pluralization.
 
+block_arguments: []
 special_behaviors: []
 aliases:
   - "t"

--- a/config/action_view_helpers/actionview/url_helper/button_to.yml
+++ b/config/action_view_helpers/actionview/url_helper/button_to.yml
@@ -70,4 +70,5 @@ options:
     description: |-
       Hash of `data-*` attributes.
 
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/url_helper/button_to_generates_button_tag.yml
+++ b/config/action_view_helpers/actionview/url_helper/button_to_generates_button_tag.yml
@@ -15,4 +15,5 @@ description: |-
 tag: null
 arguments: []
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/url_helper/current_page?.yml
+++ b/config/action_view_helpers/actionview/url_helper/current_page?.yml
@@ -34,4 +34,5 @@ options:
     description: |-
       HTTP method to check. Defaults to `:get`.
 
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/url_helper/link_to.yml
+++ b/config/action_view_helpers/actionview/url_helper/link_to.yml
@@ -89,6 +89,8 @@ options:
     description: |-
       HTML id attribute.
 
+block_arguments: []
+
 special_behaviors:
   - type: "implied_attribute"
     when_attribute: "data-method"

--- a/config/action_view_helpers/actionview/url_helper/link_to_if.yml
+++ b/config/action_view_helpers/actionview/url_helper/link_to_if.yml
@@ -50,4 +50,27 @@ arguments:
       HTML attributes hash.
 
 options: []
+
+block_arguments:
+  - name: "name"
+    position: 1
+    type: "String"
+    optional: false
+    description: |-
+      The link text, yielded when the condition is false.
+
+  - name: "options"
+    position: 2
+    type: "String, Hash"
+    optional: true
+    description: |-
+      The URL options, only yielded to a block that declares three arguments.
+
+  - name: "html_options"
+    position: 3
+    type: "Hash"
+    optional: true
+    description: |-
+      The HTML attributes, only yielded to a block that declares three arguments.
+
 special_behaviors: []

--- a/config/action_view_helpers/actionview/url_helper/link_to_unless.yml
+++ b/config/action_view_helpers/actionview/url_helper/link_to_unless.yml
@@ -50,4 +50,27 @@ arguments:
       HTML attributes hash.
 
 options: []
+
+block_arguments:
+  - name: "name"
+    position: 1
+    type: "String"
+    optional: false
+    description: |-
+      The link text, yielded when the condition is true.
+
+  - name: "options"
+    position: 2
+    type: "String, Hash"
+    optional: true
+    description: |-
+      The URL options, only yielded to a block that declares three arguments.
+
+  - name: "html_options"
+    position: 3
+    type: "Hash"
+    optional: true
+    description: |-
+      The HTML attributes, only yielded to a block that declares three arguments.
+
 special_behaviors: []

--- a/config/action_view_helpers/actionview/url_helper/link_to_unless_current.yml
+++ b/config/action_view_helpers/actionview/url_helper/link_to_unless_current.yml
@@ -43,4 +43,27 @@ arguments:
       HTML attributes hash.
 
 options: []
+
+block_arguments:
+  - name: "name"
+    position: 1
+    type: "String"
+    optional: false
+    description: |-
+      The link text, yielded when the URL is the current one.
+
+  - name: "options"
+    position: 2
+    type: "String, Hash"
+    optional: true
+    description: |-
+      The URL options, only yielded to a block that declares three arguments.
+
+  - name: "html_options"
+    position: 3
+    type: "Hash"
+    optional: true
+    description: |-
+      The HTML attributes, only yielded to a block that declares three arguments.
+
 special_behaviors: []

--- a/config/action_view_helpers/actionview/url_helper/mail_to.yml
+++ b/config/action_view_helpers/actionview/url_helper/mail_to.yml
@@ -72,4 +72,5 @@ options:
     description: |-
       Preset the Reply-To field of the email.
 
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/url_helper/phone_to.yml
+++ b/config/action_view_helpers/actionview/url_helper/phone_to.yml
@@ -52,4 +52,5 @@ options:
     description: |-
       Prepends a plus sign and the given country code to the phone number.
 
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/url_helper/sms_to.yml
+++ b/config/action_view_helpers/actionview/url_helper/sms_to.yml
@@ -57,4 +57,5 @@ options:
     description: |-
       Preset the body of the SMS message.
 
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/actionview/url_helper/url_for.yml
+++ b/config/action_view_helpers/actionview/url_helper/url_for.yml
@@ -24,4 +24,5 @@ arguments:
       URL string or `url_for` options hash.
 
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/turbo-rails/drive_helper/turbo_exempts_page_from_cache.yml
+++ b/config/action_view_helpers/turbo-rails/drive_helper/turbo_exempts_page_from_cache.yml
@@ -15,4 +15,5 @@ description: |-
 tag: null
 arguments: []
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/turbo-rails/drive_helper/turbo_exempts_page_from_cache_tag.yml
+++ b/config/action_view_helpers/turbo-rails/drive_helper/turbo_exempts_page_from_cache_tag.yml
@@ -20,4 +20,5 @@ tag:
 
 arguments: []
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/turbo-rails/drive_helper/turbo_exempts_page_from_preview.yml
+++ b/config/action_view_helpers/turbo-rails/drive_helper/turbo_exempts_page_from_preview.yml
@@ -15,4 +15,5 @@ description: |-
 tag: null
 arguments: []
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/turbo-rails/drive_helper/turbo_exempts_page_from_preview_tag.yml
+++ b/config/action_view_helpers/turbo-rails/drive_helper/turbo_exempts_page_from_preview_tag.yml
@@ -20,4 +20,5 @@ tag:
 
 arguments: []
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/turbo-rails/drive_helper/turbo_page_requires_reload.yml
+++ b/config/action_view_helpers/turbo-rails/drive_helper/turbo_page_requires_reload.yml
@@ -15,4 +15,5 @@ description: |-
 tag: null
 arguments: []
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/turbo-rails/drive_helper/turbo_page_requires_reload_tag.yml
+++ b/config/action_view_helpers/turbo-rails/drive_helper/turbo_page_requires_reload_tag.yml
@@ -20,4 +20,5 @@ tag:
 
 arguments: []
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/turbo-rails/drive_helper/turbo_refresh_method_tag.yml
+++ b/config/action_view_helpers/turbo-rails/drive_helper/turbo_refresh_method_tag.yml
@@ -28,4 +28,5 @@ arguments:
       Refresh method (`:replace` or `:morph`).
 
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/turbo-rails/drive_helper/turbo_refresh_scroll_tag.yml
+++ b/config/action_view_helpers/turbo-rails/drive_helper/turbo_refresh_scroll_tag.yml
@@ -28,4 +28,5 @@ arguments:
       Scroll strategy (`:reset` or `:preserve`).
 
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/turbo-rails/drive_helper/turbo_refreshes_with.yml
+++ b/config/action_view_helpers/turbo-rails/drive_helper/turbo_refreshes_with.yml
@@ -26,4 +26,5 @@ options:
     description: |-
       Scroll behavior during a page refresh. Can be `:reset` (default) or `:preserve`.
 
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/turbo-rails/frames_helper/turbo_frame_tag.yml
+++ b/config/action_view_helpers/turbo-rails/frames_helper/turbo_frame_tag.yml
@@ -60,4 +60,12 @@ options:
     description: |-
       Hash of `data-*` attributes.
 
+block_arguments:
+  - name: "tag"
+    position: 1
+    type: "ActionView::Helpers::TagHelper::TagBuilder"
+    optional: false
+    description: |-
+      The tag builder for the `<turbo-frame>` element.
+
 special_behaviors: []

--- a/config/action_view_helpers/turbo-rails/includes_helper/turbo_include_tags.yml
+++ b/config/action_view_helpers/turbo-rails/includes_helper/turbo_include_tags.yml
@@ -15,4 +15,5 @@ description: |-
 tag: null
 arguments: []
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/turbo-rails/streams_action_helper/turbo_stream_action_tag.yml
+++ b/config/action_view_helpers/turbo-rails/streams_action_helper/turbo_stream_action_tag.yml
@@ -42,4 +42,5 @@ options:
     description: |-
       The inner HTML content wrapped in a `<template>` element.
 
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/turbo-rails/streams_action_helper/turbo_stream_refresh_tag.yml
+++ b/config/action_view_helpers/turbo-rails/streams_action_helper/turbo_stream_refresh_tag.yml
@@ -26,4 +26,5 @@ options:
     description: |-
       The request ID for the refresh. Defaults to `Turbo.current_request_id`.
 
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/turbo-rails/streams_helper/turbo_stream.yml
+++ b/config/action_view_helpers/turbo-rails/streams_helper/turbo_stream.yml
@@ -15,4 +15,5 @@ description: |-
 tag: null
 arguments: []
 options: []
+block_arguments: []
 special_behaviors: []

--- a/config/action_view_helpers/turbo-rails/streams_helper/turbo_stream_from.yml
+++ b/config/action_view_helpers/turbo-rails/streams_helper/turbo_stream_from.yml
@@ -39,4 +39,5 @@ options:
     description: |-
       Hash of `data-*` attributes.
 
+block_arguments: []
 special_behaviors: []

--- a/sig/herb/action_view/helper_registry.rbs
+++ b/sig/herb/action_view/helper_registry.rbs
@@ -532,6 +532,22 @@ module Herb
       def maps_to_aria_attribute?: () -> bool
     end
 
+    class HelperBlockArgument
+      attr_reader name: String
+
+      attr_reader position: Integer
+
+      attr_reader type: String
+
+      attr_reader description: String
+
+      # : (String, Integer, String, bool, String) -> void
+      def initialize: (String, Integer, String, bool, String) -> void
+
+      # : () -> bool
+      def optional?: () -> bool
+    end
+
     class HelperImplicitAttribute
       attr_reader name: String
 
@@ -576,12 +592,14 @@ module Herb
 
       attr_reader options: Array[HelperOption]
 
+      attr_reader block_arguments: Array[HelperBlockArgument]
+
       attr_reader special_behaviors: Array[Symbol]
 
       attr_reader aliases: Array[String]
 
-      # : (name: String, type: Symbol, source: String, gem: String, output: Symbol, visibility: String, tag_name: String?, is_void: bool, supports_block: bool, preferred_for_tag: bool, supported: bool, detect_style: Symbol, description: String, signature: String, documentation_url: String, implicit_attribute: HelperImplicitAttribute?, arguments: Array[HelperArgument], options: Array[HelperOption], special_behaviors: Array[Symbol], aliases: Array[String]) -> void
-      def initialize: (name: String, type: Symbol, source: String, gem: String, output: Symbol, visibility: String, tag_name: String?, is_void: bool, supports_block: bool, preferred_for_tag: bool, supported: bool, detect_style: Symbol, description: String, signature: String, documentation_url: String, implicit_attribute: HelperImplicitAttribute?, arguments: Array[HelperArgument], options: Array[HelperOption], special_behaviors: Array[Symbol], aliases: Array[String]) -> void
+      # : (name: String, type: Symbol, source: String, gem: String, output: Symbol, visibility: String, tag_name: String?, is_void: bool, supports_block: bool, preferred_for_tag: bool, supported: bool, detect_style: Symbol, description: String, signature: String, documentation_url: String, implicit_attribute: HelperImplicitAttribute?, arguments: Array[HelperArgument], options: Array[HelperOption], block_arguments: Array[HelperBlockArgument], special_behaviors: Array[Symbol], aliases: Array[String]) -> void
+      def initialize: (name: String, type: Symbol, source: String, gem: String, output: Symbol, visibility: String, tag_name: String?, is_void: bool, supports_block: bool, preferred_for_tag: bool, supported: bool, detect_style: Symbol, description: String, signature: String, documentation_url: String, implicit_attribute: HelperImplicitAttribute?, arguments: Array[HelperArgument], options: Array[HelperOption], block_arguments: Array[HelperBlockArgument], special_behaviors: Array[Symbol], aliases: Array[String]) -> void
 
       # : () -> bool
       def void?: () -> bool

--- a/templates/java/org/herb/ast/HelperRegistry.java.erb
+++ b/templates/java/org/herb/ast/HelperRegistry.java.erb
@@ -86,6 +86,28 @@ class HelperOption {
   public String getDescription() { return description; }
 }
 
+class HelperBlockArgument {
+  private final String name;
+  private final int position;
+  private final String type;
+  private final boolean optional;
+  private final String description;
+
+  HelperBlockArgument(String name, int position, String type, boolean optional, String description) {
+    this.name = name;
+    this.position = position;
+    this.type = type;
+    this.optional = optional;
+    this.description = description;
+  }
+
+  public String getName() { return name; }
+  public int getPosition() { return position; }
+  public String getType() { return type; }
+  public boolean isOptional() { return optional; }
+  public String getDescription() { return description; }
+}
+
 /**
  * Implicit attribute metadata for a tag helper.
  */
@@ -130,6 +152,7 @@ class HelperEntry {
   private final HelperImplicitAttribute implicitAttribute;
   private final List<HelperArgument> arguments;
   private final List<HelperOption> options;
+  private final List<HelperBlockArgument> blockArguments;
   private final List<String> specialBehaviors;
   private final List<String> aliases;
 
@@ -137,7 +160,8 @@ class HelperEntry {
     String name, HelperType type, String source, String gem, String output, String visibility, String tagName,
     boolean isVoid, boolean supportsBlock, boolean preferredForTag, boolean supported, String detectStyle, String description,
     String signature, String documentationUrl, HelperImplicitAttribute implicitAttribute,
-    List<HelperArgument> arguments, List<HelperOption> options, List<String> specialBehaviors, List<String> aliases
+    List<HelperArgument> arguments, List<HelperOption> options, List<HelperBlockArgument> blockArguments,
+    List<String> specialBehaviors, List<String> aliases
   ) {
     this.name = name;
     this.type = type;
@@ -157,6 +181,7 @@ class HelperEntry {
     this.implicitAttribute = implicitAttribute;
     this.arguments = arguments;
     this.options = options;
+    this.blockArguments = blockArguments;
     this.specialBehaviors = specialBehaviors;
     this.aliases = aliases;
   }
@@ -179,6 +204,7 @@ class HelperEntry {
   public HelperImplicitAttribute getImplicitAttribute() { return implicitAttribute; }
   public List<HelperArgument> getArguments() { return arguments; }
   public List<HelperOption> getOptions() { return options; }
+  public List<HelperBlockArgument> getBlockArguments() { return blockArguments; }
   public List<String> getSpecialBehaviors() { return specialBehaviors; }
   public List<String> getAliases() { return aliases; }
 }
@@ -226,6 +252,7 @@ public final class HelperRegistry {
 <%- end -%>
         List.of(<%= helper.arguments.map { |arg| "new HelperArgument(\"#{arg.name}\", #{arg.position}, \"#{arg.type_display}\", #{arg.optional}, #{arg.default ? "\"#{arg.escaped_default}\"" : "null"}, #{arg.splat}, \"#{arg.escaped_description}\")" }.join(", ") %>),
         List.of(<%= helper.options.map { |opt| "new HelperOption(\"#{opt.name}\", \"#{opt.type_display}\", #{opt.maps_to ? "\"#{opt.maps_to}\"" : "null"}, \"#{opt.escaped_description}\")" }.join(", ") %>),
+        List.of(<%= helper.block_arguments.map { |arg| "new HelperBlockArgument(\"#{arg.name}\", #{arg.position}, \"#{arg.type_display}\", #{arg.optional}, \"#{arg.escaped_description}\")" }.join(", ") %>),
         List.of(<%= helper.special_behaviors.map { |b| "\"#{b}\"" }.join(", ") %>),
         List.of(<%= helper.aliases.map { |a| "\"#{a}\"" }.join(", ") %>)
       );

--- a/templates/javascript/packages/core/src/action-view-helpers.ts.erb
+++ b/templates/javascript/packages/core/src/action-view-helpers.ts.erb
@@ -24,6 +24,14 @@ export interface HelperOption {
   readonly description: string
 }
 
+export interface HelperBlockArgument {
+  readonly name: string
+  readonly position: number
+  readonly type: string
+  readonly optional: boolean
+  readonly description: string
+}
+
 export interface HelperImplicitAttribute {
   readonly name: string
   readonly source: string
@@ -51,6 +59,7 @@ export interface HelperEntry {
   readonly implicitAttribute: HelperImplicitAttribute | null
   readonly arguments: HelperArgument[]
   readonly options: HelperOption[]
+  readonly blockArguments: HelperBlockArgument[]
   readonly specialBehaviors: string[]
   readonly aliases: string[]
 }
@@ -91,6 +100,11 @@ const <%= helper.lower_camel_case_name %>Entry: HelperEntry = {
   options: [
   <%- helper.options.each do |opt| -%>
     { name: "<%= opt.name %>", type: "<%= opt.type_display %>", mapsTo: <%= opt.maps_to ? "\"#{opt.maps_to}\"" : "null" %>, description: "<%= opt.escaped_description %>" },
+  <%- end -%>
+  ],
+  blockArguments: [
+  <%- helper.block_arguments.each do |arg| -%>
+    { name: "<%= arg.name %>", position: <%= arg.position %>, type: "<%= arg.type_display %>", optional: <%= arg.optional %>, description: "<%= arg.escaped_description %>" },
   <%- end -%>
   ],
   specialBehaviors: [<%= helper.special_behaviors.map { |b| "\"#{b}\"" }.join(", ") %>],

--- a/templates/lib/herb/action_view/helper_registry.rb.erb
+++ b/templates/lib/herb/action_view/helper_registry.rb.erb
@@ -58,6 +58,25 @@ module Herb
       def maps_to_aria_attribute? = maps_to&.start_with?("aria-") || false
     end
 
+    class HelperBlockArgument
+      attr_reader :name #: String
+      attr_reader :position #: Integer
+      attr_reader :type #: String
+      attr_reader :description #: String
+
+      #: (String, Integer, String, bool, String) -> void
+      def initialize(name, position, type, optional, description)
+        @name = name
+        @position = position
+        @type = type
+        @optional = optional
+        @description = description
+      end
+
+      #: () -> bool
+      def optional? = @optional
+    end
+
     class HelperImplicitAttribute
       attr_reader :name #: String
       attr_reader :source #: String
@@ -90,14 +109,15 @@ module Herb
       attr_reader :implicit_attribute #: HelperImplicitAttribute?
       attr_reader :arguments #: Array[HelperArgument]
       attr_reader :options #: Array[HelperOption]
+      attr_reader :block_arguments #: Array[HelperBlockArgument]
       attr_reader :special_behaviors #: Array[Symbol]
       attr_reader :aliases #: Array[String]
 
-      #: (name: String, type: Symbol, source: String, gem: String, output: Symbol, visibility: String, tag_name: String?, is_void: bool, supports_block: bool, preferred_for_tag: bool, supported: bool, detect_style: Symbol, description: String, signature: String, documentation_url: String, implicit_attribute: HelperImplicitAttribute?, arguments: Array[HelperArgument], options: Array[HelperOption], special_behaviors: Array[Symbol], aliases: Array[String]) -> void
+      #: (name: String, type: Symbol, source: String, gem: String, output: Symbol, visibility: String, tag_name: String?, is_void: bool, supports_block: bool, preferred_for_tag: bool, supported: bool, detect_style: Symbol, description: String, signature: String, documentation_url: String, implicit_attribute: HelperImplicitAttribute?, arguments: Array[HelperArgument], options: Array[HelperOption], block_arguments: Array[HelperBlockArgument], special_behaviors: Array[Symbol], aliases: Array[String]) -> void
       def initialize( # rubocop:disable Metrics/ParameterLists
         name:, type:, source:, gem:, output:, visibility:, tag_name:, is_void:, supports_block:,
         preferred_for_tag:, supported:, detect_style:, description:, signature:, documentation_url:,
-        implicit_attribute:, arguments:, options:, special_behaviors:, aliases:
+        implicit_attribute:, arguments:, options:, block_arguments:, special_behaviors:, aliases:
       )
         @name = name
         @type = type
@@ -117,6 +137,7 @@ module Herb
         @implicit_attribute = implicit_attribute
         @arguments = arguments
         @options = options
+        @block_arguments = block_arguments
         @special_behaviors = special_behaviors
         @aliases = aliases
       end
@@ -183,6 +204,11 @@ module Herb
         options: [
         <%- helper.options.each do |opt| -%>
           HelperOption.new("<%= opt.name %>", "<%= opt.type_display %>", <%= opt.maps_to ? "\"#{opt.maps_to}\"" : "nil" %>, "<%= opt.escaped_description %>"),
+        <%- end -%>
+        ],
+        block_arguments: [
+        <%- helper.block_arguments.each do |arg| -%>
+          HelperBlockArgument.new("<%= arg.name %>", <%= arg.position %>, "<%= arg.type_display %>", <%= arg.optional %>, "<%= arg.escaped_description %>"),
         <%- end -%>
         ],
         special_behaviors: [<%= helper.special_behaviors.map { |b| ":#{b}" }.join(", ") %>],

--- a/templates/rust/src/action_view_helpers.rs.erb
+++ b/templates/rust/src/action_view_helpers.rs.erb
@@ -45,6 +45,15 @@ pub struct HelperOption {
 }
 
 #[derive(Debug, Clone)]
+pub struct HelperBlockArgument {
+  pub name: &'static str,
+  pub position: usize,
+  pub argument_type: &'static str,
+  pub optional: bool,
+  pub description: &'static str,
+}
+
+#[derive(Debug, Clone)]
 pub struct HelperImplicitAttribute {
   pub name: &'static str,
   pub source: &'static str,
@@ -73,6 +82,7 @@ pub struct HelperEntry {
   pub implicit_attribute: Option<&'static HelperImplicitAttribute>,
   pub arguments: &'static [HelperArgument],
   pub options: &'static [HelperOption],
+  pub block_arguments: &'static [HelperBlockArgument],
   pub special_behaviors: &'static [&'static str],
   pub aliases: &'static [&'static str],
 }
@@ -117,6 +127,11 @@ static REGISTRY: [HelperEntry; <%= helpers.size %>] = [
     options: &[
     <%- helper.options.each do |opt| -%>
       HelperOption { name: "<%= opt.name %>", option_type: "<%= opt.type_display %>", maps_to: <%= opt.maps_to ? "Some(\"#{opt.maps_to}\")" : "None" %>, description: "<%= opt.escaped_description %>" },
+    <%- end -%>
+    ],
+    block_arguments: &[
+    <%- helper.block_arguments.each do |arg| -%>
+      HelperBlockArgument { name: "<%= arg.name %>", position: <%= arg.position %>, argument_type: "<%= arg.type_display %>", optional: <%= arg.optional %>, description: "<%= arg.escaped_description %>" },
     <%- end -%>
     ],
     special_behaviors: &[<%= helper.special_behaviors.map { |b| "\"#{b}\"" }.join(", ") %>],

--- a/templates/src/analyze/action_view/helper_registry.c.erb
+++ b/templates/src/analyze/action_view/helper_registry.c.erb
@@ -33,6 +33,14 @@ static const helper_option_T <%= helper.safe_name %>_options[] = {
 };
 
 <%- end -%>
+<%- if helper.block_arguments.any? -%>
+static const helper_block_argument_T <%= helper.safe_name %>_block_arguments[] = {
+<%- helper.block_arguments.each do |arg| -%>
+  { .name = "<%= arg.name %>", .type = "<%= arg.type_display %>", .optional = <%= arg.optional %>, .description = "<%= arg.escaped_description %>" },
+<%- end -%>
+};
+
+<%- end -%>
 <%- end -%>
 static const helper_registry_entry_T registry_entries[HELPER_COUNT] = {
 <%- helpers.each do |helper| -%>
@@ -58,6 +66,8 @@ static const helper_registry_entry_T registry_entries[HELPER_COUNT] = {
     .arguments_count = <%= helper.arguments.size %>,
     .options = <%= helper.options.any? ? "#{helper.safe_name}_options" : "NULL" %>,
     .options_count = <%= helper.options.size %>,
+    .block_arguments = <%= helper.block_arguments.any? ? "#{helper.safe_name}_block_arguments" : "NULL" %>,
+    .block_arguments_count = <%= helper.block_arguments.size %>,
   },
 <%- end -%>
 };

--- a/templates/src/include/analyze/action_view/helper_registry.h.erb
+++ b/templates/src/include/analyze/action_view/helper_registry.h.erb
@@ -34,6 +34,13 @@ typedef struct {
 
 typedef struct {
   const char* name;
+  const char* type;
+  bool optional;
+  const char* description;
+} helper_block_argument_T;
+
+typedef struct {
+  const char* name;
   const char* source;
   const char* source_with_block;
   const char* wrapper;
@@ -70,6 +77,8 @@ typedef struct {
   size_t arguments_count;
   const helper_option_T* options;
   size_t options_count;
+  const helper_block_argument_T* block_arguments;
+  size_t block_arguments_count;
 } helper_registry_entry_T;
 
 const helper_registry_entry_T* helper_registry_get(helper_type_T type);

--- a/templates/template.rb
+++ b/templates/template.rb
@@ -485,6 +485,26 @@ module Herb
       end
     end
 
+    class HelperBlockArgument
+      attr_reader :name, :position, :type, :optional, :description
+
+      def initialize(config)
+        @name = config.fetch("name")
+        @position = config.fetch("position")
+        @type = Array(config.fetch("type"))
+        @optional = config.fetch("optional", false)
+        @description = config.fetch("description", "")
+      end
+
+      def type_display
+        @type.join(" | ")
+      end
+
+      def escaped_description
+        Template.escape_string(@description)
+      end
+    end
+
     class HelperOption
       attr_reader :name, :type, :maps_to, :description
 
@@ -618,7 +638,7 @@ module Herb
                   :supported, :description, :signature, :documentation_url, :tag,
                   :content, :attributes_arg, :attributes_arg_with_block,
                   :transform_style, :custom_transform,
-                  :arguments, :options, :special_behaviors, :aliases
+                  :arguments, :options, :block_arguments, :special_behaviors, :aliases
 
       def initialize(config)
         @name = config.fetch("name")
@@ -645,6 +665,7 @@ module Herb
 
         @arguments = (config.fetch("arguments", []) || []).map { |arg| HelperArgument.new(arg) }
         @options = (config.fetch("options", []) || []).map { |opt| HelperOption.new(opt) }
+        @block_arguments = (config.fetch("block_arguments", []) || []).map { |arg| HelperBlockArgument.new(arg) }
 
         raw_behaviors = config.fetch("special_behaviors", []) || []
         @special_behaviors = raw_behaviors.map { |b| HelperSpecialBehavior.new(b) }


### PR DESCRIPTION
The helper configs record that 43 helpers take a block, but nothing about what the block is handed. `form_with` yields a `FormBuilder`, `content_tag` yields nothing at all, and to the tooling those two are indistinguishable.

This pull request adds a `block_arguments:` key to every helper config, generated by calling the helpers, and threads it through all five bindings.
