### PR TITLE
Linter: Make `erb-no-unused-block-argument` Action View Helpers aware

### DIFF
--- a/config/action_view_helpers/actionview/rendering_helper/render.yml
+++ b/config/action_view_helpers/actionview/rendering_helper/render.yml
@@ -45,4 +45,6 @@ options:
       Layout to wrap the rendered content.
 
 block_arguments: []
-special_behaviors: []
+
+special_behaviors:
+  - "block_arguments_from_template"

--- a/javascript/packages/config/src/config.ts
+++ b/javascript/packages/config/src/config.ts
@@ -10,8 +10,10 @@ import { promises as fs } from "fs"
 import { fromZodError } from "zod-validation-error"
 import { deepMerge } from "./merge.js"
 
-import { ZodError } from "zod"
+import { ZodError, z } from "zod"
 import { HerbConfigSchema } from "./config-schema.js"
+
+import type { FrameworkSchema, TemplateEngineSchema } from "./config-schema.js"
 
 import type { DiagnosticSeverity } from "@herb-tools/core"
 
@@ -99,8 +101,13 @@ export type HerbConfigOptions = {
   formatter?: FormatterConfig
 }
 
+export type Framework = z.infer<typeof FrameworkSchema>
+export type TemplateEngine = z.infer<typeof TemplateEngineSchema>
+
 export type HerbConfig = HerbConfigOptions & {
   version: string
+  framework?: Framework
+  template_engine?: TemplateEngine
 }
 
 export type LoadOptions = {
@@ -157,6 +164,10 @@ export class Config {
       linter: this.config.linter,
       formatter: this.config.formatter
     }
+  }
+
+  get framework() {
+    return this.config.framework
   }
 
   get linter() {

--- a/javascript/packages/config/src/index.ts
+++ b/javascript/packages/config/src/index.ts
@@ -3,6 +3,8 @@ export { HerbConfigSchema } from "./config-schema.js"
 export { addHerbExtensionRecommendation, getExtensionsJsonRelativePath } from "./vscode.js"
 
 export type {
+  Framework,
+  TemplateEngine,
   HerbConfig,
   HerbConfigOptions,
   LinterConfig,

--- a/javascript/packages/linter/docs/rules/erb-no-unused-block-argument.md
+++ b/javascript/packages/linter/docs/rules/erb-no-unused-block-argument.md
@@ -28,6 +28,18 @@ For helper blocks the signal is often stronger. A `form_with` block that never t
 <% end %>
 ```
 
+With `framework: actionview` configured, the rule knows what each Action View helper hands to its block, so rather than suggesting the builder be dropped, the message names it and leaves the underscore as the way to say the omission is deliberate.
+
+The reverse is stronger still. `cache`, `content_tag` and `link_to` call their block without any arguments, so an argument declared there is bound to `nil` whatever the block does, as is an argument past the end of what the helper yields, like a second one on a `form_with`:
+
+```erb
+<% cache @post do |entry| %>
+  <p>Nothing</p>
+<% end %>
+```
+
+Both of these only apply to a project that sets `framework: actionview` in `.herb.yml`. Anywhere else a `cache` or `form_with` block is whatever the project defines it to be, so the registry says nothing about it and the regular messages are used.
+
 When every argument of a block is unused, the block does not need a parameter list at all, and the message says so with the tag that is already there, minus the `|...|`:
 
 ```erb
@@ -36,7 +48,7 @@ When every argument of a block is unused, the block does not need a parameter li
 <% end %>
 ```
 
-That is not limited to iteration. An unused `form` suggests `<%= form_with model: @user do %>`, an unused index suggests `<% 3.times do %>`. The tag is rewritten from the source, so whatever the block is called on is kept as it is, including trim markers, safe navigation and arguments. The rewrite is skipped when the tag spans multiple lines, when it is long enough to make the message unwieldy, or when an argument the rule does not report would be left behind, and the message falls back to a plain `Remove it`.
+That is not limited to iteration. An unused index suggests `<% 3.times do %>`, an unused row suggests `<% CSV.parse(data).each do %>`. The tag is rewritten from the source, so whatever the block is called on is kept as it is, including trim markers, safe navigation and arguments. The rewrite is skipped when the tag spans multiple lines, when it is long enough to make the message unwieldy, or when an argument the rule does not report would be left behind, and the message falls back to a plain `Remove it`.
 
 Removing one argument out of several is a different edit than removing all of them, because a block destructures what it is yielded based on how many parameters it declares:
 
@@ -174,6 +186,12 @@ An unused argument is worth cleaning up but is not a reason to interrupt someone
 ```erb
 <% pages.each do |page| %>
   <div class="page"></div>
+<% end %>
+```
+
+```erb
+<% cache @post do |entry| %>
+  <p>Nothing</p>
 <% end %>
 ```
 

--- a/javascript/packages/linter/src/linter.ts
+++ b/javascript/packages/linter/src/linter.ts
@@ -484,7 +484,8 @@ export class Linter {
       ...context,
       validRuleNames: this.getAvailableRules().map(ruleClass => ruleClass.ruleName),
       ignoredOffensesByLine,
-      indentWidth: context?.indentWidth ?? this.config?.formatter?.indentWidth
+      indentWidth: context?.indentWidth ?? this.config?.formatter?.indentWidth,
+      framework: context?.framework ?? this.config?.framework
     }
 
     const regularRules = this.rules.filter(ruleClass => ruleClass.ruleName !== "herb-disable-comment-unnecessary")
@@ -601,7 +602,8 @@ export class Linter {
 
     context = {
       ...context,
-      indentWidth: context?.indentWidth ?? this.config?.formatter?.indentWidth
+      indentWidth: context?.indentWidth ?? this.config?.formatter?.indentWidth,
+      framework: context?.framework ?? this.config?.framework
     }
 
     const lintResult = offensesToFix ? { offenses: offensesToFix } : this.lint(source, context)

--- a/javascript/packages/linter/src/rules/erb-no-unused-block-argument.ts
+++ b/javascript/packages/linter/src/rules/erb-no-unused-block-argument.ts
@@ -1,14 +1,16 @@
 import { ParserRule } from "../types.js"
 import { BaseRuleVisitor } from "./rule-utils.js"
 
-import { isRubyLiteralNode, isRubyParameterNode, isPrismNodeType, substringFromByteOffset } from "@herb-tools/core"
+import { isRubyLiteralNode, isRubyParameterNode, isPrismNodeType, substringFromByteOffset, getHelper } from "@herb-tools/core"
 
-import type { ERBBlockNode, Node, ParseResult, ParserOptions, PrismNode, RubyParameterNode } from "@herb-tools/core"
+import type { ERBBlockNode, HelperBlockArgument, HelperEntry, Node, ParseResult, ParserOptions, PrismNode, RubyParameterNode } from "@herb-tools/core"
 import type { FullRuleConfig, LintContext, UnboundLintOffense } from "../types.js"
 
 const IGNORED_PREFIX = "_"
 const REPORTED_KINDS = ["positional", "rest"]
 const MAXIMUM_TAG_SUGGESTION_LENGTH = 60
+
+const TEMPLATE_DRIVEN_BLOCK = "block_arguments_from_template"
 
 class NoUnusedBlockArgumentVisitor extends BaseRuleVisitor {
   visitERBBlockNode(node: ERBBlockNode): void {
@@ -37,10 +39,7 @@ class NoUnusedBlockArgumentVisitor extends BaseRuleVisitor {
       if (this.referencesName(source, name)) continue
 
       const suggestion = removal ?? (name === indexArgument ? `Use \`each\` instead of \`each_with_index\`` : null)
-
-      const advice = suggestion
-        ? `${suggestion}, or prefix it with an underscore as \`_${name}\``
-        : `Prefix it with an underscore as \`_${name}\``
+      const advice = this.adviceFor(node, name, suggestion)
 
       this.addOffense(
         `Block argument \`${name}\` is never used. ${advice} to show it is intentionally unused.`,
@@ -50,6 +49,66 @@ class NoUnusedBlockArgumentVisitor extends BaseRuleVisitor {
         ["unnecessary"],
       )
     }
+  }
+
+  private yieldedArgumentFor(node: ERBBlockNode, name: string): { helper: HelperEntry, argument: HelperBlockArgument | null } | null {
+    if (this.context.framework !== "actionview") return null
+
+    const helper = this.helperFor(node)
+
+    if (!helper) return null
+    if (!helper.supportsBlock) return null
+    if (helper.specialBehaviors.includes(TEMPLATE_DRIVEN_BLOCK)) return null
+
+    const parameters = (node.prismNode?.block as PrismNode)?.parameters?.parameters
+
+    if (!isPrismNodeType(parameters, "ParametersNode")) return null
+    if (parameters.optionals.length > 0) return null
+    if (parameters.posts.length > 0) return null
+    if (parameters.rest) return null
+    if (!parameters.requireds.every((parameter: PrismNode) => isPrismNodeType(parameter, "RequiredParameterNode"))) return null
+
+    const position = parameters.requireds.findIndex((parameter: PrismNode) => parameter.name === name)
+    if (position === -1) return null
+
+    return { helper, argument: helper.blockArguments[position] ?? null }
+  }
+
+  private helperFor(node: ERBBlockNode): HelperEntry | null {
+    const call = node.prismNode
+
+    if (!isPrismNodeType(call, "CallNode")) return null
+
+    if (isPrismNodeType(call.receiver, "CallNode") && call.receiver.name === "tag" && !call.receiver.receiver) {
+      return getHelper("tag") ?? null
+    }
+
+    if (call.receiver) return null
+
+    return getHelper(call.name) ?? null
+  }
+
+  private adviceFor(node: ERBBlockNode, name: string, suggestion: string | null): string {
+    const underscore = `prefix it with an underscore as \`_${name}\``
+    const yielded = this.yieldedArgumentFor(node, name)
+
+    if (yielded?.argument) {
+      return `It is the \`${yielded.argument.type}\` yielded by \`${yielded.helper.name}\`, so ${underscore}`
+    }
+
+    if (yielded) {
+      const count = yielded.helper.blockArguments.length
+
+      const reason = count === 0
+        ? `\`${yielded.helper.name}\` yields nothing to its block, so it is always \`nil\``
+        : `\`${yielded.helper.name}\` yields ${count} argument${count === 1 ? "" : "s"}, so it is always \`nil\``
+
+      return `${reason}. ${suggestion ?? "Remove it"}, or ${underscore}`
+    }
+
+    if (suggestion) return `${suggestion}, or ${underscore}`
+
+    return `Prefix it with an underscore as \`_${name}\``
   }
 
   private isUnused(source: string, parameter: RubyParameterNode): boolean {

--- a/javascript/packages/linter/src/types.ts
+++ b/javascript/packages/linter/src/types.ts
@@ -3,13 +3,13 @@ import { Diagnostic, LexResult, ParseResult, Location } from "@herb-tools/core"
 import type { DiagnosticTag, HerbError } from "@herb-tools/core"
 import type { rules } from "./rules.js"
 import type { Node, ParserOptions } from "@herb-tools/core"
-import type { RuleConfig, SeverityConfig, LinterMode } from "@herb-tools/config"
+import type { Framework, RuleConfig, SeverityConfig, LinterMode } from "@herb-tools/config"
 import type { Mutable } from "@herb-tools/rewriter"
 import type { RuleVersion } from "@herb-tools/core"
 
 export type { Mutable } from "@herb-tools/rewriter"
 export type { RuleVersion } from "@herb-tools/core"
-export type { SeverityConfig, LinterMode } from "@herb-tools/config"
+export type { Framework, SeverityConfig, LinterMode } from "@herb-tools/config"
 
 export type LintSeverity = "error" | "warning" | "info" | "hint"
 
@@ -246,6 +246,7 @@ export interface LintContext {
   ignoredOffensesByLine: Map<number, Set<string>> | undefined
   ignoreDisableComments: boolean | undefined
   indentWidth: number | undefined
+  framework: Framework | undefined
 }
 
 /**
@@ -256,7 +257,8 @@ export const DEFAULT_LINT_CONTEXT: LintContext = {
   validRuleNames: undefined,
   ignoredOffensesByLine: undefined,
   ignoreDisableComments: undefined,
-  indentWidth: undefined
+  indentWidth: undefined,
+  framework: undefined
 } as const
 
 export abstract class SourceRule<TAutofixContext extends BaseAutofixContext = BaseAutofixContext> {

--- a/javascript/packages/linter/test/rules/erb-no-unused-block-argument.test.ts
+++ b/javascript/packages/linter/test/rules/erb-no-unused-block-argument.test.ts
@@ -259,21 +259,21 @@ describe("erb-no-unused-block-argument", () => {
   })
 
   it("does not rewrite a tag that spans multiple lines", () => {
-    expectError('Block argument `form` is never used. Remove it, or prefix it with an underscore as `_form` to show it is intentionally unused.')
+    expectError('Block argument `panel` is never used. Remove it, or prefix it with an underscore as `_panel` to show it is intentionally unused.')
 
     assertOffenses(dedent`
-      <%= form_with model: @user,
-            url: profile_path do |form| %>
+      <%= panel title: "Hello",
+            subtitle: "World" do |panel| %>
         <p>Nothing</p>
       <% end %>
     `)
   })
 
   it("does not rewrite a tag that would make the message unwieldy", () => {
-    expectError('Block argument `form` is never used. Remove it, or prefix it with an underscore as `_form` to show it is intentionally unused.')
+    expectError('Block argument `panel` is never used. Remove it, or prefix it with an underscore as `_panel` to show it is intentionally unused.')
 
     assertOffenses(dedent`
-      <%= form_with model: @user, url: profile_path(@user, @account), html: { class: "form" } do |form| %>
+      <%= panel title: "Hello", subtitle: "World", classes: "border rounded shadow" do |panel| %>
         <p>Nothing</p>
       <% end %>
     `)
@@ -297,14 +297,14 @@ describe("erb-no-unused-block-argument", () => {
     `)
   })
 
-  it("flags an unused builder block argument", () => {
-    expectError('Block argument `form` is never used. Remove it and write `<%= form_with model: @user do %>`, or prefix it with an underscore as `_form` to show it is intentionally unused.')
+  it("names what the helper yields for an unused builder block argument", () => {
+    expectError('Block argument `form` is never used. It is the `ActionView::Helpers::FormBuilder` yielded by `form_with`, so prefix it with an underscore as `_form` to show it is intentionally unused.')
 
     assertOffenses(dedent`
       <%= form_with model: @user do |form| %>
         <p>Nothing</p>
       <% end %>
-    `)
+    `, { framework: "actionview" })
   })
 
   it("does not flag a builder block argument that is used", () => {
@@ -423,6 +423,107 @@ describe("erb-no-unused-block-argument", () => {
     assertOffenses(dedent`
       <% 3.times do |index| %>
         <div class="page"></div>
+      <% end %>
+    `)
+  })
+
+  it("does not use the helper registry without an Action View project", () => {
+    expectError('Block argument `form` is never used. Remove it and write `<%= form_with model: @user do %>`, or prefix it with an underscore as `_form` to show it is intentionally unused.')
+
+    assertOffenses(dedent`
+      <%= form_with model: @user do |form| %>
+        <p>Nothing</p>
+      <% end %>
+    `)
+  })
+
+  it("does not use the helper registry for another framework", () => {
+    expectError('Block argument `entry` is never used. Remove it and write `<% cache @post do %>`, or prefix it with an underscore as `_entry` to show it is intentionally unused.')
+
+    assertOffenses(dedent`
+      <% cache @post do |entry| %>
+        <p>Nothing</p>
+      <% end %>
+    `, { framework: "hanami" })
+  })
+
+  it("names what the helper yields for a nested form builder", () => {
+    expectError('Block argument `fields` is never used. It is the `ActionView::Helpers::FormBuilder` yielded by `fields_for`, so prefix it with an underscore as `_fields` to show it is intentionally unused.')
+
+    assertOffenses(dedent`
+      <%= fields_for :address do |fields| %>
+        <p>Nothing</p>
+      <% end %>
+    `, { framework: "actionview" })
+  })
+
+  it("names what the `tag` builder yields", () => {
+    expectError('Block argument `builder` is never used. It is the `ActionView::Helpers::TagHelper::TagBuilder` yielded by `tag`, so prefix it with an underscore as `_builder` to show it is intentionally unused.')
+
+    assertOffenses(dedent`
+      <%= tag.div do |builder| %>
+        <p>Nothing</p>
+      <% end %>
+    `, { framework: "actionview" })
+  })
+
+  it("reports an argument of a helper that yields nothing as always `nil`", () => {
+    expectError('Block argument `entry` is never used. `cache` yields nothing to its block, so it is always `nil`. Remove it and write `<% cache @post do %>`, or prefix it with an underscore as `_entry` to show it is intentionally unused.')
+
+    assertOffenses(dedent`
+      <% cache @post do |entry| %>
+        <p>Nothing</p>
+      <% end %>
+    `, { framework: "actionview" })
+  })
+
+  it("reports a `content_tag` argument as always `nil`", () => {
+    expectError('Block argument `builder` is never used. `content_tag` yields nothing to its block, so it is always `nil`. Remove it and write `<%= content_tag :div do %>`, or prefix it with an underscore as `_builder` to show it is intentionally unused.')
+
+    assertOffenses(dedent`
+      <%= content_tag :div do |builder| %>
+        <p>Nothing</p>
+      <% end %>
+    `, { framework: "actionview" })
+  })
+
+  it("reports an argument past what the helper yields as always `nil`", () => {
+    expectError('Block argument `extra` is never used. `form_with` yields 1 argument, so it is always `nil`. Remove it, or prefix it with an underscore as `_extra` to show it is intentionally unused.')
+
+    assertOffenses(dedent`
+      <%= form_with model: @user do |form, extra| %>
+        <%= form.text_field :name %>
+      <% end %>
+    `, { framework: "actionview" })
+  })
+
+  it("does not claim anything about a block the rendered template drives", () => {
+    expectError('Block argument `box` is never used. Remove it and write `<%= render layout: "box" do %>`, or prefix it with an underscore as `_box` to show it is intentionally unused.')
+
+    assertOffenses(dedent`
+      <%= render layout: "box" do |box| %>
+        <p>Nothing</p>
+      <% end %>
+    `, { framework: "actionview" })
+  })
+
+  it("does not use the helper registry for a call with a receiver", () => {
+    expectError('Block argument `entry` is never used. Remove it and write `<% @view.cache do %>`, or prefix it with an underscore as `_entry` to show it is intentionally unused.')
+
+    assertOffenses(dedent`
+      <% @view.cache do |entry| %>
+        <p>Nothing</p>
+      <% end %>
+    `)
+  })
+
+  it("does not line a destructured argument up with what the helper yields", () => {
+    expectError('Block argument `key` is never used. Remove it and write `<%= content_tag :div do %>`, or prefix it with an underscore as `_key` to show it is intentionally unused.')
+    expectError('Block argument `value` is never used. Remove it and write `<%= content_tag :div do %>`, or prefix it with an underscore as `_value` to show it is intentionally unused.')
+
+    assertOffenses(dedent`
+      <%= content_tag :div do |(key, value)| %>
+        <p>Nothing</p>
       <% end %>
     `)
   })


### PR DESCRIPTION
Builds on the `block_arguments:` tracking added to the helper configs in #2002.

The rule knew that a block argument was unused. With the registry it also knows what the argument would have been, which turns out to say more than "unused" does.

```erb
<%= form_with model: @user do |form| %>
  <p>Nothing</p>
<% end %>
```

```diff
- Block argument `form` is never used. Remove it and write `<%= form_with model: @user do %>`, or prefix it with an underscore as `_form` to show it is intentionally unused.
+ Block argument `form` is never used. It is the `ActionView::Helpers::FormBuilder` yielded by `form_with`, so prefix it with an underscore as `_form` to show it is intentionally unused.
```

Dropping the builder is no longer suggested. A `form_with` that never touches its builder usually has a missing field rather than a spare argument, and the underscore stays as the way to say the omission is deliberate. The same applies to `fields_for`, to `tag.div` and `turbo_frame_tag` (a `TagBuilder`), and to `link_to_if` (the link text).

#### What the helper does not yield

The reverse case is stronger. A helper that calls its block without arguments binds anything declared there to `nil`, whatever the block does:

```erb
<% cache @post do |entry| %>
  <p>Nothing</p>
<% end %>
```

```
Block argument `entry` is never used. `cache` yields nothing to its block, so it is always `nil`. Remove it and write `<% cache @post do %>`, or prefix it with an underscore as `_entry` to show it is intentionally unused.
```

An argument past the end of what the helper yields gets the same treatment, since it is `nil` for the same reason:

```erb
<%= form_with model: @user do |form, extra| %>
  <%= form.text_field :name %>
<% end %>
```

```
Block argument `extra` is never used. `form_with` yields 1 argument, so it is always `nil`. Remove it, or prefix it with an underscore as `_extra` to show it is intentionally unused.
```


#### Only for Action View projects

All of this needs `framework: actionview` in `.herb.yml`. Anywhere else a `cache` or `form_with` block is whatever the project defines it to be, so the registry stays out of it and the regular messages are used.

Related #1808 