### PR TITLE
Linter: Make more attribute rules Action View Helpers aware

### DIFF
--- a/javascript/packages/core/src/ast-utils.ts
+++ b/javascript/packages/core/src/ast-utils.ts
@@ -12,6 +12,7 @@ import {
   ERBWhileNode,
   ERBForNode,
   ERBBeginNode,
+  ERBOpenTagNode,
   HTMLElementNode,
   HTMLOpenTagNode,
   HTMLConditionalOpenTagNode,
@@ -48,6 +49,12 @@ import { Range } from "./range.js"
 import { Token } from "./token.js"
 
 import type { Position } from "./position.js"
+
+/**
+ * Any node that can hold HTML attributes: an element, its open tag, or the
+ * `ERBOpenTagNode` that ActionView tag helpers are parsed into.
+ */
+export type AttributeContainerNode = HTMLElementNode | HTMLOpenTagNode | HTMLConditionalOpenTagNode | ERBOpenTagNode
 
 export type ERBOutputNode = ERBNode & {
   tag_opening: {
@@ -181,10 +188,9 @@ export function isEffectivelyStatic(nodes: Node[]): boolean {
 
 /**
  * Gets static-validatable content from nodes (ignores control ERB, includes literals)
- * Returns concatenated literal content for validation, or null if contains output ERB
  */
 export function getValidatableStaticContent(nodes: Node[]): string | null {
-  if (hasERBOutput(nodes)) {
+  if (hasDynamicOutput(nodes)) {
     return null
   }
 
@@ -308,7 +314,7 @@ export function isCommentNode(node: Node): node is HTMLCommentNode | ERBCommentN
  * For conditional open tags, returns null.
  * If given an HTMLOpenTagNode directly, returns it as-is.
  */
-export function getOpenTag(node: HTMLElementNode | HTMLOpenTagNode | HTMLConditionalOpenTagNode | null | undefined): HTMLOpenTagNode | null {
+export function getOpenTag(node: AttributeContainerNode | null | undefined): HTMLOpenTagNode | null {
   if (!node) return null
   if (isHTMLOpenTagNode(node)) return node
   if (isHTMLElementNode(node) && isHTMLOpenTagNode(node.open_tag)) return node.open_tag
@@ -320,9 +326,10 @@ export function getOpenTag(node: HTMLElementNode | HTMLOpenTagNode | HTMLConditi
  * Gets the children array from an element's open tag, regardless of whether
  * it's an HTMLOpenTagNode or ERBOpenTagNode (used by action view helpers).
  */
-function getOpenTagChildren(node: HTMLElementNode | HTMLOpenTagNode | HTMLConditionalOpenTagNode | null | undefined): Node[] {
+function getOpenTagChildren(node: AttributeContainerNode | null | undefined): Node[] {
   if (!node) return []
   if (isHTMLOpenTagNode(node)) return node.children
+  if (isERBOpenTagNode(node)) return node.children
 
   if (isHTMLElementNode(node) && node.open_tag) {
     if (isHTMLOpenTagNode(node.open_tag)) return node.open_tag.children
@@ -335,7 +342,7 @@ function getOpenTagChildren(node: HTMLElementNode | HTMLOpenTagNode | HTMLCondit
 /**
  * Gets attributes from an HTMLElementNode or HTMLOpenTagNode
  */
-export function getAttributes(node: HTMLElementNode | HTMLOpenTagNode | HTMLConditionalOpenTagNode | null | undefined): HTMLAttributeNode[] {
+export function getAttributes(node: AttributeContainerNode | null | undefined): HTMLAttributeNode[] {
   return filterHTMLAttributeNodes(getOpenTagChildren(node))
 }
 
@@ -359,10 +366,10 @@ export function getAttributeName(attributeNode: HTMLAttributeNode, lowercase = t
  * Returns false for null/undefined input.
  */
 export function hasStaticAttributeValue(attributeNode: HTMLAttributeNode | null | undefined): boolean
-export function hasStaticAttributeValue(node: HTMLElementNode | HTMLOpenTagNode | HTMLConditionalOpenTagNode | null | undefined, attributeName: string): boolean
-export function hasStaticAttributeValue(nodeOrAttribute: HTMLAttributeNode | HTMLElementNode | HTMLOpenTagNode | HTMLConditionalOpenTagNode | null | undefined, attributeName?: string): boolean {
+export function hasStaticAttributeValue(node: AttributeContainerNode | null | undefined, attributeName: string): boolean
+export function hasStaticAttributeValue(nodeOrAttribute: HTMLAttributeNode | AttributeContainerNode | null | undefined, attributeName?: string): boolean {
   const attributeNode = attributeName
-    ? getAttribute(nodeOrAttribute as HTMLElementNode | HTMLOpenTagNode | HTMLConditionalOpenTagNode, attributeName)
+    ? getAttribute(nodeOrAttribute as AttributeContainerNode, attributeName)
     : nodeOrAttribute as HTMLAttributeNode | null | undefined
 
   if (!attributeNode?.value?.children) return false
@@ -376,10 +383,10 @@ export function hasStaticAttributeValue(nodeOrAttribute: HTMLAttributeNode | HTM
  * Returns null for null/undefined input.
  */
 export function getStaticAttributeValue(attributeNode: HTMLAttributeNode | null | undefined): string | null
-export function getStaticAttributeValue(node: HTMLElementNode | HTMLOpenTagNode | HTMLConditionalOpenTagNode | null | undefined, attributeName: string): string | null
-export function getStaticAttributeValue(nodeOrAttribute: HTMLAttributeNode | HTMLElementNode | HTMLOpenTagNode | HTMLConditionalOpenTagNode | null | undefined, attributeName?: string): string | null {
+export function getStaticAttributeValue(node: AttributeContainerNode | null | undefined, attributeName: string): string | null
+export function getStaticAttributeValue(nodeOrAttribute: HTMLAttributeNode | AttributeContainerNode | null | undefined, attributeName?: string): string | null {
   const attributeNode = attributeName
-    ? getAttribute(nodeOrAttribute as HTMLElementNode | HTMLOpenTagNode | HTMLConditionalOpenTagNode, attributeName)
+    ? getAttribute(nodeOrAttribute as AttributeContainerNode, attributeName)
     : nodeOrAttribute as HTMLAttributeNode | null | undefined
 
   if (!attributeNode) return null
@@ -404,10 +411,10 @@ export const TOKEN_LIST_ATTRIBUTES = new Set([
  * Returns an empty array for null/undefined/empty input.
  */
 export function getTokenList(value: string | null | undefined): string[]
-export function getTokenList(node: HTMLElementNode | HTMLOpenTagNode | HTMLConditionalOpenTagNode | null | undefined, attributeName: string): string[]
-export function getTokenList(valueOrNode: string | HTMLElementNode | HTMLOpenTagNode | HTMLConditionalOpenTagNode | null | undefined, attributeName?: string): string[] {
+export function getTokenList(node: AttributeContainerNode | null | undefined, attributeName: string): string[]
+export function getTokenList(valueOrNode: string | AttributeContainerNode | null | undefined, attributeName?: string): string[] {
   const value = attributeName
-    ? getStaticAttributeValue(valueOrNode as HTMLElementNode | HTMLOpenTagNode | HTMLConditionalOpenTagNode, attributeName)
+    ? getStaticAttributeValue(valueOrNode as AttributeContainerNode, attributeName)
     : valueOrNode as string | null | undefined
 
   if (!value) return []
@@ -433,7 +440,7 @@ export function findAttributeByName(attributes: Node[], attributeName: string): 
 /**
  * Gets a specific attribute from an HTMLElementNode or HTMLOpenTagNode by name
  */
-export function getAttribute(node: HTMLElementNode | HTMLOpenTagNode | HTMLConditionalOpenTagNode | null | undefined, attributeName: string): HTMLAttributeNode | null {
+export function getAttribute(node: AttributeContainerNode | null | undefined, attributeName: string): HTMLAttributeNode | null {
   const attributes = getAttributes(node)
 
   return findAttributeByName(attributes, attributeName)
@@ -442,7 +449,7 @@ export function getAttribute(node: HTMLElementNode | HTMLOpenTagNode | HTMLCondi
 /**
  * Checks if an element or open tag has a specific attribute
  */
-export function hasAttribute(node: HTMLElementNode | HTMLOpenTagNode | HTMLConditionalOpenTagNode | null | undefined, attributeName: string): boolean {
+export function hasAttribute(node: AttributeContainerNode | null | undefined, attributeName: string): boolean {
   if (!node) return false
 
   return getAttribute(node, attributeName) !== null
@@ -560,7 +567,7 @@ export function isAttributeValueQuoted(attributeNode: HTMLAttributeNode): boolea
 /**
  * Iterates over all attributes of an element or open tag node
  */
-export function forEachAttribute(node: HTMLElementNode | HTMLOpenTagNode, callback: (attributeNode: HTMLAttributeNode) => void): void {
+export function forEachAttribute(node: AttributeContainerNode, callback: (attributeNode: HTMLAttributeNode) => void): void {
   for (const attribute of getAttributes(node)) {
     callback(attribute)
   }

--- a/javascript/packages/core/test/ast-utils.test.ts
+++ b/javascript/packages/core/test/ast-utils.test.ts
@@ -21,6 +21,8 @@ import {
   getStaticAttributeName,
   getCombinedAttributeName,
   findParentArray,
+  getAttributes,
+  getAttribute,
   Location,
   HTMLAttributeNameNode
 } from "../src"
@@ -362,6 +364,18 @@ describe("ast-utils", () => {
 
       expect(getValidatableStaticContent(nodes)).toBe("")
     })
+
+    test("returns null when contains a Ruby literal, so a dynamic Action View helper value isn't mistaken for an empty one", () => {
+      const nodes = [createRubyLiteralNode("level")]
+
+      expect(getValidatableStaticContent(nodes)).toBe(null)
+    })
+
+    test("returns null when mixing literals with a Ruby literal", () => {
+      const nodes = [createLiteralNode("btn-"), createRubyLiteralNode("kind")]
+
+      expect(getValidatableStaticContent(nodes)).toBe(null)
+    })
   })
 
   describe("getCombinedStringFromNodes", () => {
@@ -600,4 +614,37 @@ describe("ast-utils", () => {
       expect(findParentArray(document, target)).toBe(null)
     })
   })
+
+  describe("getAttributes", () => {
+    const createAttributeNode = (name: string) => ({
+      type: "AST_HTML_ATTRIBUTE_NODE",
+      location: Location.from(1, 1, 1, 1),
+      errors: [],
+      name: createAttributeNameNode([createLiteralNode(name)]),
+      equals: null,
+      value: null
+    })
+
+    const createERBOpenTagNode = (children: Node[]) => ({
+      type: "AST_ERB_OPEN_TAG_NODE",
+      location: Location.from(1, 1, 1, 1),
+      errors: [],
+      tag_opening: null,
+      content: null,
+      tag_closing: null,
+      tag_name: null,
+      children
+    })
+
+    test("reads attributes off the ERB open tag that Action View tag helpers parse into", () => {
+      const node = createERBOpenTagNode([createAttributeNode("data-turbo-permanent")]) as any
+
+      expect(getAttributes(node)).toHaveLength(1)
+      expect(getAttribute(node, "data-turbo-permanent")).not.toBe(null)
+    })
+
+    test("returns an empty list for an ERB open tag without attributes", () => {
+      expect(getAttributes(createERBOpenTagNode([]) as any)).toEqual([])
+    })
+  })  
 })

--- a/javascript/packages/linter/src/rules/html-aria-attribute-must-be-valid.ts
+++ b/javascript/packages/linter/src/rules/html-aria-attribute-must-be-valid.ts
@@ -2,7 +2,7 @@ import { ParserRule } from "../types.js"
 import { ARIA_ATTRIBUTES, AttributeVisitorMixin, StaticAttributeStaticValueParams, StaticAttributeDynamicValueParams } from "./rule-utils.js"
 
 import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types.js"
-import type { ParseResult, HTMLAttributeNode } from "@herb-tools/core"
+import type { ParseResult, HTMLAttributeNode, ParserOptions } from "@herb-tools/core"
 
 class AriaAttributeMustBeValid extends AttributeVisitorMixin {
   protected checkStaticAttributeStaticValue({ attributeName, attributeNode }: StaticAttributeStaticValueParams) {
@@ -32,6 +32,12 @@ export class HTMLAriaAttributeMustBeValid extends ParserRule {
     return {
       enabled: true,
       severity: "warning"
+    }
+  }
+
+  get parserOptions(): Partial<ParserOptions> {
+    return {
+      action_view_helpers: true,
     }
   }
 

--- a/javascript/packages/linter/src/rules/html-aria-label-is-well-formatted.ts
+++ b/javascript/packages/linter/src/rules/html-aria-label-is-well-formatted.ts
@@ -2,7 +2,7 @@ import { ParserRule } from "../types.js"
 import { AttributeVisitorMixin, StaticAttributeStaticValueParams } from "./rule-utils.js"
 
 import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types.js"
-import type { ParseResult } from "@herb-tools/core"
+import type { ParseResult, ParserOptions } from "@herb-tools/core"
 
 class AriaLabelIsWellFormattedVisitor extends AttributeVisitorMixin {
   protected checkStaticAttributeStaticValue({ attributeName, attributeValue, attributeNode }: StaticAttributeStaticValueParams): void {
@@ -51,6 +51,12 @@ export class HTMLAriaLabelIsWellFormattedRule extends ParserRule {
     return {
       enabled: true,
       severity: "warning"
+    }
+  }
+
+  get parserOptions(): Partial<ParserOptions> {
+    return {
+      action_view_helpers: true,
     }
   }
 

--- a/javascript/packages/linter/src/rules/html-aria-level-must-be-valid.ts
+++ b/javascript/packages/linter/src/rules/html-aria-level-must-be-valid.ts
@@ -3,7 +3,7 @@ import { AttributeVisitorMixin, StaticAttributeStaticValueParams, StaticAttribut
 import { getValidatableStaticContent, hasERBOutput, filterLiteralNodes, filterERBContentNodes, isERBOutputNode } from "@herb-tools/core"
 
 import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types.js"
-import type { ParseResult, HTMLAttributeNode } from "@herb-tools/core"
+import type { ParseResult, HTMLAttributeNode, ParserOptions } from "@herb-tools/core"
 
 class HTMLAriaLevelMustBeValidVisitor extends AttributeVisitorMixin {
   protected checkStaticAttributeStaticValue({ attributeName, attributeValue, attributeNode }: StaticAttributeStaticValueParams) {
@@ -70,6 +70,12 @@ export class HTMLAriaLevelMustBeValidRule extends ParserRule {
     return {
       enabled: true,
       severity: "warning"
+    }
+  }
+
+  get parserOptions(): Partial<ParserOptions> {
+    return {
+      action_view_helpers: true,
     }
   }
 

--- a/javascript/packages/linter/src/rules/html-aria-role-heading-requires-level.ts
+++ b/javascript/packages/linter/src/rules/html-aria-role-heading-requires-level.ts
@@ -3,7 +3,7 @@ import { AttributeVisitorMixin, StaticAttributeStaticValueParams } from "./rule-
 import { getAttributeName, getAttributes } from "@herb-tools/core"
 
 import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types.js"
-import type { ParseResult } from "@herb-tools/core"
+import type { ParseResult, ParserOptions } from "@herb-tools/core"
 
 class AriaRoleHeadingRequiresLevel extends AttributeVisitorMixin {
   protected checkStaticAttributeStaticValue({ attributeName, attributeValue, attributeNode, parentNode }: StaticAttributeStaticValueParams): void {
@@ -28,6 +28,12 @@ export class HTMLAriaRoleHeadingRequiresLevelRule extends ParserRule {
     return {
       enabled: true,
       severity: "warning"
+    }
+  }
+
+  get parserOptions(): Partial<ParserOptions> {
+    return {
+      action_view_helpers: true,
     }
   }
 

--- a/javascript/packages/linter/src/rules/html-aria-role-must-be-valid.ts
+++ b/javascript/packages/linter/src/rules/html-aria-role-must-be-valid.ts
@@ -2,7 +2,7 @@ import { ParserRule } from "../types.js"
 import { AttributeVisitorMixin, VALID_ARIA_ROLES, StaticAttributeStaticValueParams } from "./rule-utils.js"
 
 import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types.js"
-import type { ParseResult } from "@herb-tools/core"
+import type { ParseResult, ParserOptions } from "@herb-tools/core"
 
 class AriaRoleMustBeValid extends AttributeVisitorMixin {
   protected checkStaticAttributeStaticValue({ attributeName, attributeValue, attributeNode }: StaticAttributeStaticValueParams): void {
@@ -25,6 +25,12 @@ export class HTMLAriaRoleMustBeValidRule extends ParserRule {
     return {
       enabled: true,
       severity: "warning"
+    }
+  }
+
+  get parserOptions(): Partial<ParserOptions> {
+    return {
+      action_view_helpers: true,
     }
   }
 

--- a/javascript/packages/linter/src/rules/html-no-abstract-roles.ts
+++ b/javascript/packages/linter/src/rules/html-no-abstract-roles.ts
@@ -2,7 +2,7 @@ import { ParserRule } from "../types.js"
 import { AttributeVisitorMixin, ABSTRACT_ARIA_ROLES, StaticAttributeStaticValueParams } from "./rule-utils.js"
 
 import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types.js"
-import type { ParseResult } from "@herb-tools/core"
+import type { ParseResult, ParserOptions } from "@herb-tools/core"
 
 class NoAbstractRolesVisitor extends AttributeVisitorMixin {
   protected checkStaticAttributeStaticValue({ attributeName, attributeValue, attributeNode }: StaticAttributeStaticValueParams): void {
@@ -28,6 +28,12 @@ export class HTMLNoAbstractRolesRule extends ParserRule {
     return {
       enabled: true,
       severity: "warning"
+    }
+  }
+
+  get parserOptions(): Partial<ParserOptions> {
+    return {
+      action_view_helpers: true,
     }
   }
 

--- a/javascript/packages/linter/src/rules/html-no-empty-attributes.ts
+++ b/javascript/packages/linter/src/rules/html-no-empty-attributes.ts
@@ -4,7 +4,7 @@ import { IdentityPrinter } from "@herb-tools/printer"
 import { Visitor, isERBOutputNode, isERBEscapedNode } from "@herb-tools/core"
 
 import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types.js"
-import type { ParseResult, HTMLAttributeNode, ERBContentNode, LiteralNode, Node } from "@herb-tools/core"
+import type { ParseResult, HTMLAttributeNode, ERBContentNode, LiteralNode, Node, ParserOptions } from "@herb-tools/core"
 
 const RESTRICTED_ATTRIBUTES = new Set([
   'id',
@@ -127,6 +127,12 @@ export class HTMLNoEmptyAttributesRule extends ParserRule {
     return {
       enabled: true,
       severity: "warning"
+    }
+  }
+
+  get parserOptions(): Partial<ParserOptions> {
+    return {
+      action_view_helpers: true,
     }
   }
 

--- a/javascript/packages/linter/src/rules/html-no-positive-tab-index.ts
+++ b/javascript/packages/linter/src/rules/html-no-positive-tab-index.ts
@@ -2,7 +2,7 @@ import { ParserRule } from "../types.js"
 import { AttributeVisitorMixin, StaticAttributeStaticValueParams } from "./rule-utils.js"
 
 import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types.js"
-import type { ParseResult } from "@herb-tools/core"
+import type { ParseResult, ParserOptions } from "@herb-tools/core"
 
 class NoPositiveTabIndexVisitor extends AttributeVisitorMixin {
   protected checkStaticAttributeStaticValue({ attributeName, attributeValue, attributeNode }: StaticAttributeStaticValueParams): void {
@@ -27,6 +27,12 @@ export class HTMLNoPositiveTabIndexRule extends ParserRule {
     return {
       enabled: true,
       severity: "warning"
+    }
+  }
+
+  get parserOptions(): Partial<ParserOptions> {
+    return {
+      action_view_helpers: true,
     }
   }
 

--- a/javascript/packages/linter/src/rules/rule-utils.ts
+++ b/javascript/packages/linter/src/rules/rule-utils.ts
@@ -1,8 +1,7 @@
 import {
   Visitor,
   Location,
-  hasERBOutput,
-  isEffectivelyStatic,
+  hasDynamicOutput,
   getValidatableStaticContent,
   getAttributeName,
   getStaticAttributeValue,
@@ -16,6 +15,7 @@ import {
 } from "@herb-tools/core"
 
 import type {
+  ERBOpenTagNode,
   HTMLAttributeNameNode,
   HTMLAttributeNode,
   HTMLElementNode,
@@ -425,7 +425,7 @@ export interface StaticAttributeStaticValueParams {
   attributeValue: string
   attributeNode: HTMLAttributeNode
   originalAttributeName: string
-  parentNode: HTMLOpenTagNode
+  parentNode: HTMLOpenTagNode | ERBOpenTagNode
 }
 
 export interface StaticAttributeDynamicValueParams {
@@ -433,7 +433,7 @@ export interface StaticAttributeDynamicValueParams {
   valueNodes: Node[]
   attributeNode: HTMLAttributeNode
   originalAttributeName: string
-  parentNode: HTMLOpenTagNode
+  parentNode: HTMLOpenTagNode | ERBOpenTagNode
   combinedValue?: string | null
 }
 
@@ -441,7 +441,7 @@ export interface DynamicAttributeStaticValueParams {
   nameNodes: Node[]
   attributeValue: string
   attributeNode: HTMLAttributeNode
-  parentNode: HTMLOpenTagNode
+  parentNode: HTMLOpenTagNode | ERBOpenTagNode
   combinedName?: string
 }
 
@@ -449,7 +449,7 @@ export interface DynamicAttributeDynamicValueParams {
   nameNodes: Node[]
   valueNodes: Node[]
   attributeNode: HTMLAttributeNode
-  parentNode: HTMLOpenTagNode
+  parentNode: HTMLOpenTagNode | ERBOpenTagNode
   combinedName?: string
   combinedValue?: string | null
 }
@@ -560,15 +560,20 @@ export abstract class AttributeVisitorMixin<TAutofixContext extends BaseAutofixC
     super.visitHTMLOpenTagNode(node)
   }
 
-  private checkAttributesOnNode(node: HTMLOpenTagNode): void {
+  visitERBOpenTagNode(node: ERBOpenTagNode): void {
+    this.checkAttributesOnNode(node)
+    super.visitERBOpenTagNode(node)
+  }
+
+  private checkAttributesOnNode(node: HTMLOpenTagNode | ERBOpenTagNode): void {
     forEachAttribute(node, (attributeNode) => {
       const staticAttributeName = getAttributeName(attributeNode)
       const originalAttributeName = getAttributeName(attributeNode, false) || ""
       const isDynamicName = hasDynamicAttributeName(attributeNode)
       const staticAttributeValue = getStaticAttributeValue(attributeNode)
       const valueNodes = getAttributeValueNodes(attributeNode)
-      const hasOutputERB = hasERBOutput(valueNodes)
-      const isEffectivelyStaticValue = isEffectivelyStatic(valueNodes)
+      const hasOutputERB = hasDynamicOutput(valueNodes)
+      const isEffectivelyStaticValue = !hasDynamicOutput(valueNodes)
 
       if (staticAttributeName && staticAttributeValue !== null) {
         this.checkStaticAttributeStaticValue({

--- a/javascript/packages/linter/src/rules/turbo-permanent-no-misleading-value.ts
+++ b/javascript/packages/linter/src/rules/turbo-permanent-no-misleading-value.ts
@@ -1,9 +1,10 @@
-import { BaseRuleVisitor } from "./rule-utils.js"
+import { AttributeVisitorMixin } from "./rule-utils.js"
 import { IdentityPrinter } from "@herb-tools/printer"
 import { ParserRule, BaseAutofixContext, Mutable } from "../types.js"
 
-import { findAttributeByName, getStaticAttributeValue, hasAttributeValue, hasStaticAttributeValue } from "@herb-tools/core"
+import { getStaticAttributeValue, hasAttributeValue, isERBOpenTagNode } from "@herb-tools/core"
 
+import type { StaticAttributeStaticValueParams, StaticAttributeDynamicValueParams } from "./rule-utils.js"
 import type { UnboundLintOffense, LintOffense, LintContext, FullRuleConfig } from "../types.js"
 import type { HTMLAttributeNode, HTMLOpenTagNode, ERBOpenTagNode, ParseResult, ParserOptions } from "@herb-tools/core"
 
@@ -11,39 +12,31 @@ interface TurboPermanentAutofixContext extends BaseAutofixContext {
   node: Mutable<HTMLAttributeNode>
 }
 
-class TurboPermanentNoMisleadingValueVisitor extends BaseRuleVisitor<TurboPermanentAutofixContext> {
-  visitHTMLOpenTagNode(node: HTMLOpenTagNode): void {
-    const attribute = findAttributeByName(node.children, "data-turbo-permanent")
-
-    if (attribute) {
-      this.checkTurboPermanentAttribute(attribute, { node: attribute })
-    }
-
-    super.visitHTMLOpenTagNode(node)
+class TurboPermanentNoMisleadingValueVisitor extends AttributeVisitorMixin<TurboPermanentAutofixContext> {
+  protected checkStaticAttributeStaticValue({ attributeName, attributeNode, parentNode }: StaticAttributeStaticValueParams): void {
+    this.checkTurboPermanentAttribute(attributeName, attributeNode, parentNode)
   }
 
-  visitERBOpenTagNode(node: ERBOpenTagNode): void {
-    const attribute = findAttributeByName(node.children, "data-turbo-permanent")
+  protected checkStaticAttributeDynamicValue({ attributeName, attributeNode, parentNode }: StaticAttributeDynamicValueParams): void {
+    if (isERBOpenTagNode(parentNode)) return
 
-    if (attribute && hasStaticAttributeValue(attribute)) {
-      this.checkTurboPermanentAttribute(attribute, undefined)
-    }
-
-    super.visitERBOpenTagNode(node)
+    this.checkTurboPermanentAttribute(attributeName, attributeNode, parentNode)
   }
 
-  private checkTurboPermanentAttribute(attribute: HTMLAttributeNode, autofixContext: TurboPermanentAutofixContext | undefined): void {
-    if (!hasAttributeValue(attribute)) return
+  private checkTurboPermanentAttribute(attributeName: string, attributeNode: HTMLAttributeNode, parentNode: HTMLOpenTagNode | ERBOpenTagNode): void {
+    if (attributeName !== "data-turbo-permanent") return
+    if (!hasAttributeValue(attributeNode)) return
 
-    const isTruthyValue = getStaticAttributeValue(attribute)?.trim().toLowerCase() === "true"
+    const autofixContext = isERBOpenTagNode(parentNode) ? undefined : { node: attributeNode }
+    const isTruthyValue = getStaticAttributeValue(attributeNode)?.trim().toLowerCase() === "true"
 
     const explanation = isTruthyValue
       ? `is redundant, because Turbo only checks whether the attribute is present.`
       : `still makes the element permanent, because Turbo only checks whether the attribute is present.`
 
     this.addOffense(
-      `Attribute \`data-turbo-permanent\` should not have a value. \`${IdentityPrinter.print(attribute)}\` ${explanation} Use \`data-turbo-permanent\` instead.`,
-      attribute.value!.location,
+      `Attribute \`data-turbo-permanent\` should not have a value. \`${IdentityPrinter.print(attributeNode)}\` ${explanation} Use \`data-turbo-permanent\` instead.`,
+      attributeNode.value!.location,
       autofixContext
     )
   }

--- a/javascript/packages/linter/src/rules/turbo-permanent-require-id.ts
+++ b/javascript/packages/linter/src/rules/turbo-permanent-require-id.ts
@@ -3,7 +3,7 @@ import { getAttribute } from "@herb-tools/core"
 
 import { ParserRule } from "../types.js"
 import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types.js"
-import type { HTMLOpenTagNode, ParseResult } from "@herb-tools/core"
+import type { HTMLOpenTagNode, ERBOpenTagNode, ParseResult, ParserOptions } from "@herb-tools/core"
 
 class TurboPermanentRequireIdVisitor extends BaseRuleVisitor {
   visitHTMLOpenTagNode(node: HTMLOpenTagNode): void {
@@ -11,7 +11,12 @@ class TurboPermanentRequireIdVisitor extends BaseRuleVisitor {
     super.visitHTMLOpenTagNode(node)
   }
 
-  private checkTurboPermanent(node: HTMLOpenTagNode): void {
+  visitERBOpenTagNode(node: ERBOpenTagNode): void {
+    this.checkTurboPermanent(node)
+    super.visitERBOpenTagNode(node)
+  }
+
+  private checkTurboPermanent(node: HTMLOpenTagNode | ERBOpenTagNode): void {
     const turboPermanentAttribute = getAttribute(node, "data-turbo-permanent")
 
     if (!turboPermanentAttribute) {
@@ -37,6 +42,12 @@ export class TurboPermanentRequireIdRule extends ParserRule {
     return {
       enabled: true,
       severity: "error"
+    }
+  }
+
+  get parserOptions(): Partial<ParserOptions> {
+    return {
+      action_view_helpers: true,
     }
   }
 

--- a/javascript/packages/linter/test/rules/html-aria-attribute-must-be-valid.test.ts
+++ b/javascript/packages/linter/test/rules/html-aria-attribute-must-be-valid.test.ts
@@ -58,4 +58,38 @@ describe("html-aria-attribute-must-be-valid", () => {
     expectWarning('The attribute `aria-described-by` is not a valid ARIA attribute. ARIA attributes must match the WAI-ARIA specification.')
     assertOffenses(html)
   })
+
+  describe("ActionView tag helpers", () => {
+    it("passes for tag.div with a valid ARIA attribute", () => {
+      expectNoOffenses('<%= tag.div aria: { label: "Close" } %>')
+    })
+
+    it("fails for tag.div with an invalid ARIA attribute", () => {
+      expectWarning("The attribute `aria-labl` is not a valid ARIA attribute. ARIA attributes must match the WAI-ARIA specification.")
+
+      assertOffenses('<%= tag.div aria: { labl: "Close" } %>')
+    })
+
+    it("fails for content_tag with an invalid ARIA attribute", () => {
+      expectWarning("The attribute `aria-labl` is not a valid ARIA attribute. ARIA attributes must match the WAI-ARIA specification.")
+
+      assertOffenses('<%= content_tag :div, "content", aria: { labl: "Close" } %>')
+    })
+
+    it("passes for a dynamic aria value", () => {
+      expectNoOffenses('<%= tag.div aria: { label: label_text } %>')
+    })
+
+    it("still fails with a nil value, since the attribute name is what's invalid", () => {
+      expectWarning("The attribute `aria-labl` is not a valid ARIA attribute. ARIA attributes must match the WAI-ARIA specification.")
+
+      assertOffenses('<%= tag.div aria: { labl: nil } %>')
+    })
+
+    it("still fails with a dynamic value, since the attribute name is what's invalid", () => {
+      expectWarning("The attribute `aria-labl` is not a valid ARIA attribute. ARIA attributes must match the WAI-ARIA specification.")
+
+      assertOffenses('<%= tag.div aria: { labl: label_text } %>')
+    })
+  })
 })

--- a/javascript/packages/linter/test/rules/html-aria-label-is-well-formatted.test.ts
+++ b/javascript/packages/linter/test/rules/html-aria-label-is-well-formatted.test.ts
@@ -75,4 +75,34 @@ describe("html-aria-label-is-well-formatted", () => {
   test("passes for mixed case attribute name", () => {
     expectNoOffenses(`<button ARIA-LABEL="Close dialog">X</button>`)
   })
+
+  describe("ActionView tag helpers", () => {
+    test("passes for tag.div with a well-formatted aria-label", () => {
+      expectNoOffenses('<%= tag.div aria: { label: "Close dialog" } %>')
+    })
+
+    test("fails for tag.div with an ID-like aria-label", () => {
+      expectWarning("The `aria-label` attribute value should not be formatted like an ID. Use natural, sentence-case text instead.")
+
+      assertOffenses('<%= tag.div aria: { label: "close_button_label" } %>')
+    })
+
+    test("fails for content_tag with an ID-like aria-label", () => {
+      expectWarning("The `aria-label` attribute value should not be formatted like an ID. Use natural, sentence-case text instead.")
+
+      assertOffenses('<%= content_tag :div, "content", aria: { label: "close_button_label" } %>')
+    })
+
+    test("passes for a dynamic aria-label, which can't be resolved statically", () => {
+      expectNoOffenses('<%= tag.div aria: { label: label_text } %>')
+    })
+
+    test("passes for an interpolated aria-label", () => {
+      expectNoOffenses('<%= tag.div aria: { label: "Close #{name}" } %>')
+    })
+
+    test("passes for a nil aria-label, which ActionView omits entirely", () => {
+      expectNoOffenses('<%= tag.div aria: { label: nil } %>')
+    })
+  })
 })

--- a/javascript/packages/linter/test/rules/html-aria-level-must-be-valid.test.ts
+++ b/javascript/packages/linter/test/rules/html-aria-level-must-be-valid.test.ts
@@ -138,4 +138,34 @@ describe("HTMLAriaLevelMustBeValidRule", () => {
       <div role="heading" aria-level="">Empty value</div>
     `)
   })
+
+  describe("ActionView tag helpers", () => {
+    test("passes for tag.div with a valid aria-level", () => {
+      expectNoOffenses('<%= tag.div role: "heading", aria: { level: 2 } %>')
+    })
+
+    test("fails for tag.div with an out-of-range aria-level", () => {
+      expectWarning("The `aria-level` attribute must be an integer between 1 and 6, got `9`.")
+
+      assertOffenses('<%= tag.div role: "heading", aria: { level: 9 } %>')
+    })
+
+    test("fails for content_tag with an out-of-range aria-level", () => {
+      expectWarning("The `aria-level` attribute must be an integer between 1 and 6, got `9`.")
+
+      assertOffenses('<%= content_tag :div, "Title", role: "heading", aria: { level: 9 } %>')
+    })
+
+    test("passes for a dynamic aria-level, which must not be read as an empty value", () => {
+      expectNoOffenses('<%= tag.div role: "heading", aria: { level: level } %>')
+    })
+
+    test("passes for an interpolated aria-level", () => {
+      expectNoOffenses('<%= tag.div role: "heading", aria: { level: "#{level}" } %>')
+    })
+
+    test("passes for a nil aria-level, which must not be read as an empty value", () => {
+      expectNoOffenses('<%= tag.div aria: { level: nil } %>')
+    })
+  })
 })

--- a/javascript/packages/linter/test/rules/html-aria-role-heading-requires-level.test.ts
+++ b/javascript/packages/linter/test/rules/html-aria-role-heading-requires-level.test.ts
@@ -14,4 +14,39 @@ describe("html-aria-role-heading-requires-level", () => {
 
     assertOffenses('<div role="heading">Section Title</div>')
   })
+
+  describe("ActionView tag helpers", () => {
+    it("passes for tag.div with role heading and an aria-level", () => {
+      expectNoOffenses('<%= tag.div role: "heading", aria: { level: 2 } %>')
+    })
+
+    it("fails for tag.div with role heading and no aria-level", () => {
+      expectWarning("Element with `role=\"heading\"` must have an `aria-level` attribute.")
+
+      assertOffenses('<%= tag.div role: "heading" %>')
+    })
+
+    it("fails for content_tag with role heading and no aria-level", () => {
+      expectWarning("Element with `role=\"heading\"` must have an `aria-level` attribute.")
+
+      assertOffenses('<%= content_tag :div, "Title", role: "heading" %>')
+    })
+
+    it("passes for role heading with a dynamic aria-level", () => {
+      expectNoOffenses('<%= tag.div role: "heading", aria: { level: level } %>')
+    })
+
+    it("passes for role heading with an interpolated aria-level", () => {
+      expectNoOffenses('<%= tag.div role: "heading", aria: { level: "#{level}" } %>')
+    })
+
+    // ActionView drops `aria-level` entirely when the value is nil, so this renders as a
+    // heading with no level at all. The parser still emits the attribute node, so the rule
+    // sees it as present and stays quiet.
+    it.fails("fails for role heading with a nil aria-level, which ActionView omits entirely", () => {
+      expectWarning("Element with `role=\"heading\"` must have an `aria-level` attribute.")
+
+      assertOffenses('<%= tag.div role: "heading", aria: { level: nil } %>')
+    })
+  })
 })

--- a/javascript/packages/linter/test/rules/html-aria-role-must-be-valid.test.ts
+++ b/javascript/packages/linter/test/rules/html-aria-role-must-be-valid.test.ts
@@ -22,4 +22,34 @@ describe("html-aria-role-must-be-valid", () => {
   it("should not show an error for static and ERB content", () => {
     expectNoOffenses(`<div role="invalid-role-<%= role %>"></div>`)
   })
+
+  describe("ActionView tag helpers", () => {
+    it("passes for tag.div with a valid role", () => {
+      expectNoOffenses('<%= tag.div role: "button" %>')
+    })
+
+    it("fails for tag.div with an invalid role", () => {
+      expectWarning("The `role` attribute must be a valid ARIA role. Role `buton` is not recognized.")
+
+      assertOffenses('<%= tag.div role: "buton" %>')
+    })
+
+    it("fails for content_tag with an invalid role", () => {
+      expectWarning("The `role` attribute must be a valid ARIA role. Role `buton` is not recognized.")
+
+      assertOffenses('<%= content_tag :div, "content", role: "buton" %>')
+    })
+
+    it("passes for a dynamic role, which can't be resolved statically", () => {
+      expectNoOffenses('<%= tag.div role: role_name %>')
+    })
+
+    it("passes for a nil role, which ActionView omits entirely", () => {
+      expectNoOffenses('<%= tag.div role: nil %>')
+    })
+
+    it("passes for an interpolated role", () => {
+      expectNoOffenses('<%= tag.div role: "but#{suffix}" %>')
+    })
+  })
 })

--- a/javascript/packages/linter/test/rules/html-no-abstract-roles.test.ts
+++ b/javascript/packages/linter/test/rules/html-no-abstract-roles.test.ts
@@ -104,4 +104,34 @@ describe("html-no-abstract-roles", () => {
 
     assertOffenses('<div role="Widget">Content</div>')
   })
+
+  describe("ActionView tag helpers", () => {
+    test("passes for tag.div with a concrete role", () => {
+      expectNoOffenses('<%= tag.div role: "button" %>')
+    })
+
+    test("fails for tag.div with an abstract role", () => {
+      expectWarning("The `role` attribute must not use abstract ARIA role `widget`. Abstract roles are not meant to be used directly.")
+
+      assertOffenses('<%= tag.div role: "widget" %>')
+    })
+
+    test("fails for content_tag with an abstract role", () => {
+      expectWarning("The `role` attribute must not use abstract ARIA role `widget`. Abstract roles are not meant to be used directly.")
+
+      assertOffenses('<%= content_tag :div, "content", role: "widget" %>')
+    })
+
+    test("passes for a dynamic role, which can't be resolved statically", () => {
+      expectNoOffenses('<%= tag.div role: role_name %>')
+    })
+
+    test("passes for a nil role, which ActionView omits entirely", () => {
+      expectNoOffenses('<%= tag.div role: nil %>')
+    })
+
+    test("passes for an interpolated role", () => {
+      expectNoOffenses('<%= tag.div role: "widg#{suffix}" %>')
+    })
+  })
 })

--- a/javascript/packages/linter/test/rules/html-no-empty-attributes.test.ts
+++ b/javascript/packages/linter/test/rules/html-no-empty-attributes.test.ts
@@ -176,4 +176,44 @@ describe("html-no-empty-attributes", () => {
       <div class="<%%= form_class %>">Content</div>
     `)
   })
+
+  describe("ActionView tag helpers", () => {
+    test("passes for tag.div with a non-empty attribute", () => {
+      expectNoOffenses('<%= tag.div class: "container" %>')
+    })
+
+    test("fails for tag.div with an empty attribute", () => {
+      expectWarning("Attribute `class` must not be empty. Either provide a meaningful value or remove the attribute entirely.")
+
+      assertOffenses('<%= tag.div class: "" %>')
+    })
+
+    test("fails for tag.div with an empty data attribute", () => {
+      expectWarning("Data attribute `data-foo` should not have an empty value. Either provide a meaningful value or use `data-foo` instead of `data-foo: \"\"`.")
+
+      assertOffenses('<%= tag.div data: { foo: "" } %>')
+    })
+
+    test("fails for content_tag with an empty attribute", () => {
+      expectWarning("Attribute `class` must not be empty. Either provide a meaningful value or remove the attribute entirely.")
+
+      assertOffenses('<%= content_tag :div, "content", class: "" %>')
+    })
+
+    test("passes for a dynamic value, which must not be read as an empty one", () => {
+      expectNoOffenses('<%= tag.div class: value %>')
+    })
+
+    test("passes for an interpolated value", () => {
+      expectNoOffenses('<%= tag.div class: "btn-#{kind}" %>')
+    })
+
+    test("passes for a nil value, which ActionView omits entirely", () => {
+      expectNoOffenses('<%= tag.div class: nil %>')
+    })
+
+    test("passes for a nil data value, which ActionView omits entirely", () => {
+      expectNoOffenses('<%= tag.div data: { foo: nil } %>')
+    })
+  })
 })

--- a/javascript/packages/linter/test/rules/html-no-positive-tab-index.test.ts
+++ b/javascript/packages/linter/test/rules/html-no-positive-tab-index.test.ts
@@ -68,4 +68,34 @@ describe("html-no-positive-tab-index", () => {
     expectWarning("Do not use positive `tabindex` values as they are error prone and can severely disrupt navigation experience for keyboard users. Use `tabindex=\"0\"` to make an element focusable or `tabindex=\"-1\"` to remove it from the tab sequence.")
     assertOffenses(`<div tabindex="  1  ">With spaces</div>`)
   })
+
+  describe("ActionView tag helpers", () => {
+    test("passes for tag.div with a zero tabindex", () => {
+      expectNoOffenses('<%= tag.div tabindex: 0 %>')
+    })
+
+    test("fails for tag.div with a positive tabindex", () => {
+      expectWarning("Do not use positive `tabindex` values as they are error prone and can severely disrupt navigation experience for keyboard users. Use `tabindex=\"0\"` to make an element focusable or `tabindex=\"-1\"` to remove it from the tab sequence.")
+
+      assertOffenses('<%= tag.div tabindex: 5 %>')
+    })
+
+    test("fails for content_tag with a positive tabindex", () => {
+      expectWarning("Do not use positive `tabindex` values as they are error prone and can severely disrupt navigation experience for keyboard users. Use `tabindex=\"0\"` to make an element focusable or `tabindex=\"-1\"` to remove it from the tab sequence.")
+
+      assertOffenses('<%= content_tag :div, "content", tabindex: 5 %>')
+    })
+
+    test("passes for a dynamic tabindex, which can't be resolved statically", () => {
+      expectNoOffenses('<%= tag.div tabindex: index %>')
+    })
+
+    test("passes for an interpolated tabindex", () => {
+      expectNoOffenses('<%= tag.div tabindex: "#{index}" %>')
+    })
+
+    test("passes for a nil tabindex, which ActionView omits entirely", () => {
+      expectNoOffenses('<%= tag.div tabindex: nil %>')
+    })
+  })
 })

--- a/javascript/packages/linter/test/rules/turbo-permanent-no-misleading-value.test.ts
+++ b/javascript/packages/linter/test/rules/turbo-permanent-no-misleading-value.test.ts
@@ -43,6 +43,11 @@ describe("turbo-permanent-no-misleading-value", () => {
     assertOffenses('<div id="cart-counter" data-turbo-permanent="">1 item</div>')
   })
 
+  test("fails with an ERB value, since the attribute is present either way", () => {
+    expectError('Attribute `data-turbo-permanent` should not have a value. `data-turbo-permanent="<%= flag %>"` still makes the element permanent, because Turbo only checks whether the attribute is present. Use `data-turbo-permanent` instead.')
+    assertOffenses('<div id="cart-counter" data-turbo-permanent="<%= flag %>">1 item</div>')
+  })
+
   describe("ActionView tag helpers", () => {
     test("passes when no `turbo_permanent` key is given", () => {
       expectNoOffenses('<%= tag.div id: "cart", class: "counter" %>')
@@ -84,6 +89,30 @@ describe("turbo-permanent-no-misleading-value", () => {
 
     test("passes for a dynamic value, which can't be resolved statically", () => {
       expectNoOffenses('<%= tag.div id: "cart", data: { turbo_permanent: permanent? } %>')
+    })
+
+    test("fails for `tag.span`", () => {
+      expectError('Attribute `data-turbo-permanent` should not have a value. `data-turbo-permanent: "false"` still makes the element permanent, because Turbo only checks whether the attribute is present. Use `data-turbo-permanent` instead.')
+      assertOffenses('<%= tag.span id: "cart", data: { turbo_permanent: false } %>')
+    })
+
+    test("fails alongside other attributes", () => {
+      expectError('Attribute `data-turbo-permanent` should not have a value. `data-turbo-permanent: "false"` still makes the element permanent, because Turbo only checks whether the attribute is present. Use `data-turbo-permanent` instead.')
+      assertOffenses('<%= tag.div id: "cart", class: "counter", data: { turbo_permanent: false, controller: "cart" } %>')
+    })
+
+    test("fails for the block form", () => {
+      expectError('Attribute `data-turbo-permanent` should not have a value. `data-turbo-permanent: "false"` still makes the element permanent, because Turbo only checks whether the attribute is present. Use `data-turbo-permanent` instead.')
+      assertOffenses('<%= tag.div(id: "cart", data: { turbo_permanent: false }) do %>1 item<% end %>')
+    })
+
+    test("fails for a dasherized string key", () => {
+      expectError('Attribute `data-turbo-permanent` should not have a value. `data-turbo-permanent: "false"` still makes the element permanent, because Turbo only checks whether the attribute is present. Use `data-turbo-permanent` instead.')
+      assertOffenses('<%= tag.div id: "cart", "data-turbo-permanent": "false" %>')
+    })
+
+    test("passes for an interpolated value, which can't be resolved statically", () => {
+      expectNoOffenses('<%= tag.div id: "cart", data: { turbo_permanent: "#{flag}" } %>')
     })
   })
 })

--- a/javascript/packages/linter/test/rules/turbo-permanent-require-id-rule.test.ts
+++ b/javascript/packages/linter/test/rules/turbo-permanent-require-id-rule.test.ts
@@ -55,4 +55,49 @@ describe("turbo-permanent-require-id", () => {
 
     assertOffenses('<div class="flash" data-turbo-permanent data-controller="flash">Flash</div>')
   })
+
+  describe("ActionView tag helpers", () => {
+    test("passes for tag.div with data-turbo-permanent and an id", () => {
+      expectNoOffenses('<%= tag.div id: "cart", data: { turbo_permanent: true } %>')
+    })
+
+    test("passes when no `turbo_permanent` key is given", () => {
+      expectNoOffenses('<%= tag.div class: "counter" %>')
+    })
+
+    test("fails for tag.div with data-turbo-permanent and no id", () => {
+      expectError(MESSAGE)
+
+      assertOffenses('<%= tag.div data: { turbo_permanent: true } %>')
+    })
+
+    test("fails for content_tag with data-turbo-permanent and no id", () => {
+      expectError(MESSAGE)
+
+      assertOffenses('<%= content_tag :div, "1 item", data: { turbo_permanent: true } %>')
+    })
+
+    test("fails for the block form with data-turbo-permanent and no id", () => {
+      expectError(MESSAGE)
+
+      assertOffenses('<%= tag.div(data: { turbo_permanent: true }) do %>1 item<% end %>')
+    })
+
+    test("passes for a dynamic id, which can't be resolved statically", () => {
+      expectNoOffenses('<%= tag.div id: dom_id(cart), data: { turbo_permanent: true } %>')
+    })
+
+    test("passes for an interpolated id", () => {
+      expectNoOffenses('<%= tag.div id: "cart-#{cart.id}", data: { turbo_permanent: true } %>')
+    })
+
+    // ActionView drops `id` entirely when the value is nil, so this renders a permanent
+    // element with no id at all. The parser still emits the attribute node, so the rule
+    // sees an id and stays quiet.
+    test.fails("fails for a nil id, which ActionView omits entirely", () => {
+      expectError(MESSAGE)
+
+      assertOffenses('<%= tag.div id: nil, data: { turbo_permanent: true } %>')
+    })
+  })
 })


### PR DESCRIPTION
Similar to #2003, this pull request makes another set of attribute rules aware of Action View tag helpers. Instead of teaching each rule individually, it makes the shared `AttributeVisitorMixin` aware of them, so that every rule built on top of it can opt in with a single `parserOptions` getter.

#### Motivation

Action View tag helpers are parsed into an `ERBOpenTagNode` rather than an `HTMLOpenTagNode`, and the two are siblings rather than one extending the other. `AttributeVisitorMixin` only implemented `visitHTMLOpenTagNode`, so attributes written as tag helpers never reached any of its four hooks, no matter which of them a rule implemented.

Adding `visitERBOpenTagNode` alone wasn't enough. `getAttributes()` walks through `getOpenTagChildren()`, which handled an `ERBOpenTagNode` only when it was reached through its `HTMLElementNode`, and silently returned `[]` for a bare one:

```ts
getAttributes(erbOpenTagNode)                               // => []
findAttributeByName(erbOpenTagNode.children, "class")       // => HTMLAttributeNode
```

That is why `turbo-permanent-no-misleading-value` had to reach for `findAttributeByName()` to see helper attributes at all. With `getOpenTagChildren()` handling a bare `ERBOpenTagNode`, that workaround is no longer necessary and the rule now uses the mixin like its siblings.

#### Rules

With that in place, the following rules opt in and now report the same offenses for tag helpers as they already did for HTML:

| Rule                                    | Example                                                |
|-----------------------------------------|--------------------------------------------------------|
| `html-aria-attribute-must-be-valid`     | `<%= tag.div aria: { labl: "Close" } %>`               |
| `html-aria-role-must-be-valid`          | `<%= tag.div role: "buton" %>`                         |
| `html-aria-role-heading-requires-level` | `<%= tag.div role: "heading" %>`                       |
| `html-aria-level-must-be-valid`         | `<%= tag.div role: "heading", aria: { level: 9 } %>`   |
| `html-aria-label-is-well-formatted`     | `<%= tag.div aria: { label: "close_button_label" } %>` |
| `html-no-abstract-roles`                | `<%= tag.div role: "widget" %>`                        |
| `html-no-positive-tab-index`            | `<%= tag.div tabindex: 5 %>`                           |
| `html-no-empty-attributes`              | `<%= tag.div class: "" %>`                             |


