### PR TITLE
Linter CLI: Lower `--log-level` for `--only` and `--all-rules` runs

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -104,6 +104,12 @@ herb-lint --all-rules app/views/
 
 Since the two flags pull in opposite directions, `--all-rules` and `--only` can't be combined.
 
+Both flags also lower the [`logLevel`](#linter-options) for that run, down to the lowest severity that came up, so the rules you asked to run always get reported instead of being filtered out of the output. Passing `--log-level` explicitly keeps the level you gave it. The summary says so whenever it happens:
+
+```
+  Log level    hint | lowered from warning by --only
+```
+
 ## Linter Configuration
 
 Configure the linter behavior and rules:
@@ -184,7 +190,7 @@ Both `include` and `exclude` patterns are **additive**, they add to the defaults
 
 - **`enabled`**: `true` or `false` - Enable or disable the linter globally
 - **`failLevel`** <Badge type="info" text="v0.8.7+" />: `error`, `warning`, `info`, or `hint` - Exit with error code when diagnostics of this severity or higher are present (default: `error`). Useful for CI/CD pipelines where you want stricter enforcement. Can also be set via `--fail-level` CLI flag.
-- **`logLevel`** <Badge type="info" text="^0.11.0" />: `error`, `warning`, `info`, or `hint` - Only report diagnostics of this severity or higher (default: `hint`, meaning everything is reported). This affects the CLI output only: lower-severity offenses are still counted in the summary, still respected by `failLevel`, and still shown in your editor, they just aren't printed individually or annotated in CI. Useful for keeping CI output focused on what matters. To hide a rule in the editor as well, use the rule's `severity` option with separate `editor` and `cli` values. Can also be set via `--log-level` CLI flag.
+- **`logLevel`** <Badge type="info" text="^0.11.0" />: `error`, `warning`, `info`, or `hint` - Only report diagnostics of this severity or higher (default: `hint`, meaning everything is reported). This affects the CLI output only: lower-severity offenses are still counted in the summary, still respected by `failLevel`, and still shown in your editor, they just aren't printed individually or annotated in CI. Useful for keeping CI output focused on what matters. To hide a rule in the editor as well, use the rule's `severity` option with separate `editor` and `cli` values. Can also be set via `--log-level` CLI flag. Runs that pick their own rules with `--only` or `--all-rules` lower this level automatically, unless `--log-level` is passed explicitly.
 - **`include`**: Array of glob patterns - Additional file patterns to lint (additive to defaults)
 - **`exclude`**: Array of glob patterns - Additional patterns to exclude from linting (additive to defaults)
 

--- a/javascript/packages/linter/src/cli.ts
+++ b/javascript/packages/linter/src/cli.ts
@@ -17,6 +17,7 @@ import { version } from "../package.json"
 import type { DiagnosticSeverity } from "@herb-tools/core"
 import type { ProcessingContext } from "./cli/file-processor.js"
 import type { FormatOption } from "./cli/argument-parser.js"
+import type { RuleFilterFlag } from "./cli/summary-reporter.js"
 
 export * from "./cli/index.js"
 
@@ -147,6 +148,25 @@ export class CLI {
 
   protected async afterProcess(_results: any, _outputOptions: any): Promise<void> {
     // Hook for subclasses to add custom output after processing
+  }
+
+  /**
+   * Returns the severity `--only` or `--all-rules` should lower the log level to, together with the flag
+   * that asked for it, or `undefined` when the log level stays as configured.
+   */
+  protected loweredLogLevel(counts: Record<DiagnosticSeverity, number>, effectiveLogLevel: DiagnosticSeverity, options: { only?: string[], allRules?: boolean, logLevelFlag?: DiagnosticSeverity }): { severity: DiagnosticSeverity, flag: RuleFilterFlag } | undefined {
+    const { only, allRules, logLevelFlag } = options
+    const flag: RuleFilterFlag | undefined = (only && only.length > 0) ? "--only" : (allRules ? "--all-rules" : undefined)
+
+    if (!flag) return undefined
+    if (logLevelFlag !== undefined) return undefined
+
+    const lowestSeverity = DIAGNOSTIC_SEVERITIES.filter(severity => counts[severity] > 0).pop()
+
+    if (!lowestSeverity) return undefined
+    if (meetsSeverityThreshold(lowestSeverity, effectiveLogLevel)) return undefined
+
+    return { severity: lowestSeverity, flag }
   }
 
   async run() {
@@ -472,14 +492,21 @@ export class CLI {
 
       const results = await this.fileProcessor.processFiles(files, formatOption, context)
 
-      await this.outputManager.outputResults({ ...results, files }, outputOptions)
-
       const counts: Record<DiagnosticSeverity, number> = {
         error: results.totalErrors,
         warning: results.totalWarnings,
         info: results.totalInfo,
         hint: results.totalHints
       }
+
+      const lowered = this.loweredLogLevel(counts, effectiveLogLevel, { only, allRules, logLevelFlag: logLevel })
+
+      await this.outputManager.outputResults({ ...results, files }, {
+        ...outputOptions,
+        logLevel: lowered?.severity ?? effectiveLogLevel,
+        logLevelLoweredFrom: lowered ? effectiveLogLevel : undefined,
+        logLevelLoweredBy: lowered?.flag
+      })
 
       const showTips = formatOption !== 'json' && !useGitHubActions
 

--- a/javascript/packages/linter/src/cli/argument-parser.ts
+++ b/javascript/packages/linter/src/cli/argument-parser.ts
@@ -67,6 +67,7 @@ export class ArgumentParser {
       --log-level <severity>        only report diagnostics of this severity or higher (error|warning|info|hint) [default: hint]
                                     lower-severity offenses are still counted in the summary, but aren't
                                     printed or annotated in CI
+                                    --only and --all-rules lower this level unless it's passed explicitly
       --format                      output format (simple|detailed|json) [default: detailed]
       --simple                      use simple output format (shortcut for --format simple)
       --json                        use JSON output format (shortcut for --format json)

--- a/javascript/packages/linter/src/cli/output-manager.ts
+++ b/javascript/packages/linter/src/cli/output-manager.ts
@@ -7,7 +7,7 @@ import type { DiagnosticSeverity } from "@herb-tools/core"
 import type { ThemeInput } from "@herb-tools/highlighter"
 import type { FormatOption } from "./argument-parser.js"
 import type { ProcessedFile, ProcessingResult } from "./file-processor.js"
-import type { SummaryData } from "./summary-reporter.js"
+import type { SummaryData, RuleFilterFlag } from "./summary-reporter.js"
 
 interface OutputOptions {
   formatOption: FormatOption
@@ -21,6 +21,8 @@ interface OutputOptions {
   toolVersion?: string
   failLevel?: DiagnosticSeverity
   logLevel?: DiagnosticSeverity
+  logLevelLoweredFrom?: DiagnosticSeverity
+  logLevelLoweredBy?: RuleFilterFlag
 }
 
 interface LintResults extends ProcessingResult {
@@ -137,6 +139,8 @@ export class OutputManager {
       filesNotFailing: notFailingFiles.size,
       failLevel,
       logLevel,
+      logLevelLoweredFrom: options.logLevelLoweredFrom,
+      logLevelLoweredBy: options.logLevelLoweredBy,
       ruleCount,
       startTime: options.startTime,
       startDate: options.startDate,

--- a/javascript/packages/linter/src/cli/summary-reporter.ts
+++ b/javascript/packages/linter/src/cli/summary-reporter.ts
@@ -13,6 +13,8 @@ const SEVERITY_COLORS: Record<DiagnosticSeverity, "brightRed" | "brightYellow" |
   hint: "gray"
 }
 
+export type RuleFilterFlag = "--only" | "--all-rules"
+
 export interface SummaryData {
   files: string[]
   totalErrors: number
@@ -26,6 +28,8 @@ export interface SummaryData {
   filesNotFailing?: number
   failLevel?: DiagnosticSeverity
   logLevel?: DiagnosticSeverity
+  logLevelLoweredFrom?: DiagnosticSeverity
+  logLevelLoweredBy?: RuleFilterFlag
   ruleCount: number
   startTime: number
   startDate: Date
@@ -167,6 +171,13 @@ export class SummaryReporter {
       const message = `${notReportedCount} ${this.pluralize(notReportedCount, "offense")} hidden, show ${pronoun} with --log-level=${lowestSeverity}`
 
       console.log(`  ${colorize(pad("Not shown"), "gray")} ${colorize(colorize(message, "gray"), "bold")}`)
+    }
+
+    if (data.logLevelLoweredFrom && data.logLevelLoweredBy) {
+      const level = colorize(colorize(logLevel, SEVERITY_COLORS[logLevel]), "bold")
+      const reason = colorize(`lowered from ${data.logLevelLoweredFrom} by ${data.logLevelLoweredBy}`, "cyan")
+
+      console.log(`  ${colorize(pad("Log level"), "gray")} ${level} | ${reason}`)
     }
 
     if (ignoreDisableComments && totalWouldBeIgnored && totalWouldBeIgnored > 0) {

--- a/javascript/packages/linter/test/__snapshots__/cli.test.ts.snap
+++ b/javascript/packages/linter/test/__snapshots__/cli.test.ts.snap
@@ -450,6 +450,127 @@ test-file-with-errors.html.erb:
   Rules        92 enabled | 16 not enabled | 1 disabled"
 `;
 
+exports[`CLI Output Formatting > --log-level > with --all-rules > keeps the log level when it is passed explicitly 1`] = `
+"✓ Using Herb config file at /test/herb/javascript/packages/linter/test/fixtures/.herb.yml
+
+test-file-with-errors.html.erb:
+  2:3  ✗ Opening tag name \`<SPAN>\` should be lowercase. Use \`<span>\` instead. (html-tag-name-lowercase) [Correctable]
+  2:22 ✗ Closing tag name \`</SPAN>\` should be lowercase. Use \`</span>\` instead. (html-tag-name-lowercase) [Correctable]
+
+
+ Rule offenses:
+  html-tag-name-lowercase (2 offenses in 1 file)
+  html-img-require-alt (1 offense in 1 file)
+
+
+ Summary:
+  Checked      1 file
+  Failing      2 errors (2 offenses across 1 file)
+  Not failing  1 hint (1 offense across 1 file, below --fail-level=error)
+  Not shown    1 offense hidden, show it with --log-level=hint
+  Fixable      3 offenses | 2 autocorrectable using \`--fix\`
+  Rules        109 enabled | all rules via --all-rules"
+`;
+
+exports[`CLI Output Formatting > --log-level > with --all-rules > lowers the log level to report the rules it was asked for 1`] = `
+"✓ Using Herb config file at /test/herb/javascript/packages/linter/test/fixtures/.herb.yml
+
+test-file-with-errors.html.erb:
+  3:3  ⚠ Missing required \`alt\` attribute on \`<img>\` tag. Add \`alt=""\` for decorative images or \`alt="description"\` for informative images. (html-img-require-alt)
+  2:3  ✗ Opening tag name \`<SPAN>\` should be lowercase. Use \`<span>\` instead. (html-tag-name-lowercase) [Correctable]
+  2:22 ✗ Closing tag name \`</SPAN>\` should be lowercase. Use \`</span>\` instead. (html-tag-name-lowercase) [Correctable]
+
+
+ Rule offenses:
+  html-tag-name-lowercase (2 offenses in 1 file)
+  html-img-require-alt (1 offense in 1 file)
+
+
+ Summary:
+  Checked      1 file
+  Failing      2 errors (2 offenses across 1 file)
+  Not failing  1 hint (1 offense across 1 file, below --fail-level=error)
+  Log level    hint | lowered from warning by --all-rules
+  Fixable      3 offenses | 2 autocorrectable using \`--fix\`
+  Rules        109 enabled | all rules via --all-rules"
+`;
+
+exports[`CLI Output Formatting > --log-level > with --only > keeps the log level when it is passed explicitly 1`] = `
+"✓ Using Herb config file at /test/herb/javascript/packages/linter/test/fixtures/.herb.yml
+
+
+ Rule offenses:
+  html-img-require-alt (1 offense in 1 file)
+
+
+ Summary:
+  Checked      1 file
+  Failing      0 offenses
+  Not failing  1 hint (1 offense across 1 file, below --fail-level=error)
+  Not shown    1 offense hidden, show it with --log-level=hint
+  Fixable      0 offenses
+  Rules        1 enabled | filtered by --only"
+`;
+
+exports[`CLI Output Formatting > --log-level > with --only > lowers the log level to report the rules it was asked for 1`] = `
+"✓ Using Herb config file at /test/herb/javascript/packages/linter/test/fixtures/.herb.yml
+
+test-file-with-errors.html.erb:
+  3:3  ⚠ Missing required \`alt\` attribute on \`<img>\` tag. Add \`alt=""\` for decorative images or \`alt="description"\` for informative images. (html-img-require-alt)
+
+
+ Rule offenses:
+  html-img-require-alt (1 offense in 1 file)
+
+
+ Summary:
+  Checked      1 file
+  Failing      0 offenses
+  Not failing  1 hint (1 offense across 1 file, below --fail-level=error)
+  Log level    hint | lowered from warning by --only
+  Fixable      0 offenses
+  Rules        1 enabled | filtered by --only"
+`;
+
+exports[`CLI Output Formatting > --log-level > with --only > lowers the log level to the lowest severity of the run 1`] = `
+"✓ Using Herb config file at /test/herb/javascript/packages/linter/test/fixtures/.herb.yml
+
+test-file-with-errors.html.erb:
+  3:3  ⚠ Missing required \`alt\` attribute on \`<img>\` tag. Add \`alt=""\` for decorative images or \`alt="description"\` for informative images. (html-img-require-alt)
+
+
+ Rule offenses:
+  html-img-require-alt (1 offense in 1 file)
+
+
+ Summary:
+  Checked      1 file
+  Failing      0 offenses
+  Not failing  1 info (1 offense across 1 file, below --fail-level=error)
+  Log level    info | lowered from error by --only
+  Fixable      0 offenses
+  Rules        1 enabled | filtered by --only"
+`;
+
+exports[`CLI Output Formatting > --log-level > with --only > stays quiet when the configured log level hides nothing 1`] = `
+"✓ Using Herb config file at /test/herb/javascript/packages/linter/test/fixtures/.herb.yml
+
+test-file-with-errors.html.erb:
+  2:3  ✗ Opening tag name \`<SPAN>\` should be lowercase. Use \`<span>\` instead. (html-tag-name-lowercase) [Correctable]
+  2:22 ✗ Closing tag name \`</SPAN>\` should be lowercase. Use \`</span>\` instead. (html-tag-name-lowercase) [Correctable]
+
+
+ Rule offenses:
+  html-tag-name-lowercase (2 offenses in 1 file)
+
+
+ Summary:
+  Checked      1 file
+  Offenses     2 errors (2 offenses across 1 file)
+  Fixable      2 offenses | 2 autocorrectable using \`--fix\`
+  Rules        1 enabled | filtered by --only"
+`;
+
 exports[`CLI Output Formatting > Excluded Files > skips excluded file in subdirectory with README.md project indicator 1`] = `
 "✓ Using Herb config file at /test/herb/javascript/packages/linter/test/fixtures/.herb.yml
 ⚠️  File test/fixtures/subdir/excluded.html.erb is excluded by configuration patterns.

--- a/javascript/packages/linter/test/cli.test.ts
+++ b/javascript/packages/linter/test/cli.test.ts
@@ -717,6 +717,133 @@ describe("CLI Output Formatting", () => {
       expect(output).toContain("invalid")
       expect(exitCode).toBe(1)
     })
+
+    describe("with --only", () => {
+      const quietConfig = dedent`
+        linter:
+          logLevel: warning
+          rules:
+            html-img-require-alt:
+              severity: hint
+      `
+
+      test("lowers the log level to report the rules it was asked for", () => {
+        try {
+          writeFileSync(configPath, quietConfig)
+
+          const { output } = runLinter("test-file-with-errors.html.erb", "--simple", "--only", "html-img-require-alt")
+
+          expect(output).toMatchSnapshot()
+          expect(output).toContain(OFFENSE_MESSAGE)
+          expect(output).toContain("Log level    hint | lowered from warning by --only")
+          expect(output).not.toContain("Not shown")
+        } finally {
+          try { unlinkSync(configPath) } catch {}
+        }
+      })
+
+      test("lowers the log level to the lowest severity of the run", () => {
+        try {
+          writeFileSync(configPath, dedent`
+            linter:
+              logLevel: error
+              rules:
+                html-img-require-alt:
+                  severity: info
+          `)
+
+          const { output } = runLinter("test-file-with-errors.html.erb", "--simple", "--only", "html-img-require-alt")
+
+          expect(output).toMatchSnapshot()
+          expect(output).toContain("Log level    info | lowered from error by --only")
+        } finally {
+          try { unlinkSync(configPath) } catch {}
+        }
+      })
+
+      test("keeps the log level when it is passed explicitly", () => {
+        try {
+          writeFileSync(configPath, quietConfig)
+
+          const { output } = runLinter("test-file-with-errors.html.erb", "--simple", "--only", "html-img-require-alt", "--log-level", "warning")
+
+          expect(output).toMatchSnapshot()
+          expect(output).not.toContain(OFFENSE_MESSAGE)
+          expect(output).not.toContain("Log level")
+          expect(output).toContain("Not shown")
+        } finally {
+          try { unlinkSync(configPath) } catch {}
+        }
+      })
+
+      test("stays quiet when the configured log level hides nothing", () => {
+        try {
+          writeFileSync(configPath, quietConfig)
+
+          const { output } = runLinter("test-file-with-errors.html.erb", "--simple", "--only", "html-tag-name-lowercase")
+
+          expect(output).toMatchSnapshot()
+          expect(output).not.toContain("Log level")
+        } finally {
+          try { unlinkSync(configPath) } catch {}
+        }
+      })
+
+      test("reports the offenses in JSON output as well", () => {
+        try {
+          writeFileSync(configPath, quietConfig)
+
+          const { output } = runLinter("test-file-with-errors.html.erb", "--json", "--only", "html-img-require-alt")
+          const result = JSON.parse(output)
+
+          expect(result.offenses).toHaveLength(1)
+          expect(result.summary.totalHints).toBe(1)
+          expect(result.summary.totalNotReported).toBe(0)
+        } finally {
+          try { unlinkSync(configPath) } catch {}
+        }
+      })
+    })
+
+    describe("with --all-rules", () => {
+      const quietConfig = dedent`
+        linter:
+          logLevel: warning
+          rules:
+            html-img-require-alt:
+              severity: hint
+      `
+
+      test("lowers the log level to report the rules it was asked for", () => {
+        try {
+          writeFileSync(configPath, quietConfig)
+
+          const { output } = runLinter("test-file-with-errors.html.erb", "--simple", "--all-rules")
+
+          expect(output).toMatchSnapshot()
+          expect(output).toContain(OFFENSE_MESSAGE)
+          expect(output).toContain("Log level    hint | lowered from warning by --all-rules")
+          expect(output).not.toContain("Not shown")
+        } finally {
+          try { unlinkSync(configPath) } catch {}
+        }
+      })
+
+      test("keeps the log level when it is passed explicitly", () => {
+        try {
+          writeFileSync(configPath, quietConfig)
+
+          const { output } = runLinter("test-file-with-errors.html.erb", "--simple", "--all-rules", "--log-level", "warning")
+
+          expect(output).toMatchSnapshot()
+          expect(output).not.toContain(OFFENSE_MESSAGE)
+          expect(output).not.toContain("Log level")
+          expect(output).toContain("Not shown")
+        } finally {
+          try { unlinkSync(configPath) } catch {}
+        }
+      })
+    })
   })
 
   describe("non-failing offenses tip", () => {


### PR DESCRIPTION
This pull request updates the linter CLI so that `--only` and `--all-rules` lower the effective `logLevel` for that run, down to the lowest severity that actually came up, so the rules you asked to run always get reported.

Both flags already ignore the rule configuration in `.herb.yml` to put a specific set of rules in front of you, but the configured `logLevel` still applied on top of that. Asking for a single rule whose offenses sit below that level produced a run that printed no offenses at all and only accounted for them in the summary:

```
❯ herb-lint --only html-no-duplicate-ids
✓ Using Herb config file at .herb.yml

 Rule offenses:
  html-no-duplicate-ids (1 offense in 1 file)

 Summary:
  Checked      1 file
  Failing      0 offenses
  Not failing  1 hint (1 offense across 1 file, below --fail-level=error)
  Not shown    1 offense hidden, show it with --log-level=hint
  Fixable      0 offenses
  Rules        1 enabled | filtered by --only
```

Naming a rule is a stronger signal than the `logLevel` that keeps everyday runs quiet, so the level now drops to the lowest severity present in the run, and the summary says where that came from:

```
❯ herb-lint --only html-no-duplicate-ids
✓ Using Herb config file at .herb.yml

app/views/events/_event.html.erb:
  2:5  ⚠ Duplicate ID `event-title` found. IDs must be unique within a document. (html-no-duplicate-ids)

 Rule offenses:
  html-no-duplicate-ids (1 offense in 1 file)

 Summary:
  Checked      1 file
  Failing      0 offenses
  Not failing  1 hint (1 offense across 1 file, below --fail-level=error)
  Log level    hint | lowered from warning by --only
  Fixable      0 offenses
  Rules        1 enabled | filtered by --only
```

`--all-rules` gets the same treatment, since the rules it widens the run to are mostly the ones that aren't enabled by default:

```
  Log level    hint | lowered from warning by --all-rules
```

Resolves https://github.com/marcoroth/herb/issues/1980