### PR TITLE
Linter: Improve `erb-no-output-control-flow` offense message

### DIFF
--- a/javascript/packages/linter/src/rules/erb-no-output-control-flow.ts
+++ b/javascript/packages/linter/src/rules/erb-no-output-control-flow.ts
@@ -62,10 +62,15 @@ class ERBNoOutputControlFlowRuleVisitor extends BaseRuleVisitor {
     }
 
     if (openTag.value === "<%="){
-      const controlBlockType = ERBNoOutputControlFlowRuleVisitor.CONTROL_BLOCK_NAMES[controlBlock.type] || controlBlock.type
+      const content = controlBlock.content?.value ?? ""
+      const collapsedContent = content.replace(/\s*\n\s*/g, " ")
+      const keyword = collapsedContent.trim().split(/\s+/)[0] || ERBNoOutputControlFlowRuleVisitor.CONTROL_BLOCK_NAMES[controlBlock.type] || controlBlock.type
+
+      const tagClosing = controlBlock.tag_closing?.value ?? "%>"
+      const suggestion = collapsedContent ? `<%${collapsedContent}${tagClosing}` : `<% ${keyword} ... ${tagClosing}`
 
       this.addOffense(
-        `Control flow statements like \`${controlBlockType}\` should not be used with output tags. Use \`<% ${controlBlockType} ... %>\` instead.`,
+        `Control flow statements like \`${keyword}\` should not be used with output tags. Use \`${suggestion}\` instead.`,
         openTag.location,
       )
     }

--- a/javascript/packages/linter/test/rules/erb-no-output-control-flow.test.ts
+++ b/javascript/packages/linter/test/rules/erb-no-output-control-flow.test.ts
@@ -28,7 +28,7 @@ describe("erb-no-output-control-flow", () => {
       <% end %>
     `
 
-    expectError("Control flow statements like `if` should not be used with output tags. Use `<% if ... %>` instead.")
+    expectError("Control flow statements like `if` should not be used with output tags. Use `<% if true %>` instead.")
     assertOffenses(html)
   })
 
@@ -39,7 +39,7 @@ describe("erb-no-output-control-flow", () => {
       <% end %>
     `
 
-    expectError("Control flow statements like `unless` should not be used with output tags. Use `<% unless ... %>` instead.")
+    expectError("Control flow statements like `unless` should not be used with output tags. Use `<% unless false %>` instead.")
     assertOffenses(html)
   })
 
@@ -50,7 +50,7 @@ describe("erb-no-output-control-flow", () => {
       <%= end %>
     `
 
-    expectError("Control flow statements like `end` should not be used with output tags. Use `<% end ... %>` instead.")
+    expectError("Control flow statements like `end` should not be used with output tags. Use `<% end %>` instead.")
     assertOffenses(html)
   })
 
@@ -64,7 +64,7 @@ describe("erb-no-output-control-flow", () => {
       <% end %>
     `
 
-    expectError("Control flow statements like `if` should not be used with output tags. Use `<% if ... %>` instead.")
+    expectError("Control flow statements like `if` should not be used with output tags. Use `<% if true %>` instead.")
     assertOffenses(html)
   })
 
@@ -79,9 +79,9 @@ describe("erb-no-output-control-flow", () => {
       <%= end %>
     `
 
-    expectError("Control flow statements like `if` should not be used with output tags. Use `<% if ... %>` instead.")
-    expectError("Control flow statements like `else` should not be used with output tags. Use `<% else ... %>` instead.")
-    expectError("Control flow statements like `end` should not be used with output tags. Use `<% end ... %>` instead.")
+    expectError("Control flow statements like `elsif` should not be used with output tags. Use `<% elsif false %>` instead.")
+    expectError("Control flow statements like `else` should not be used with output tags. Use `<% else %>` instead.")
+    expectError("Control flow statements like `end` should not be used with output tags. Use `<% end %>` instead.")
     assertOffenses(html)
   })
 
@@ -94,7 +94,46 @@ describe("erb-no-output-control-flow", () => {
       <% end %>
     `
 
-    expectError("Control flow statements like `if` should not be used with output tags. Use `<% if ... %>` instead.")
+    expectError("Control flow statements like `if` should not be used with output tags. Use `<% if true %>` instead.")
+    assertOffenses(html)
+  })
+
+  it("names `elsif` instead of `if` and suggests the actual condition", () => {
+    const html = dedent`
+      <% if condition? %>
+        ...
+      <%= elsif another_condition? %>
+        ...
+      <% end %>
+    `
+
+    expectError("Control flow statements like `elsif` should not be used with output tags. Use `<% elsif another_condition? %>` instead.")
+
+    assertOffenses(html)
+  })
+
+  it("preserves trim tags in the suggested control flow replacement", () => {
+    const html = dedent`
+      <%= if condition? -%>
+        ...
+      <% end %>
+    `
+
+    expectError("Control flow statements like `if` should not be used with output tags. Use `<% if condition? -%>` instead.")
+
+    assertOffenses(html)
+  })
+
+  it("collapses a multi-line condition onto one line in the suggestion", () => {
+    const html = dedent`
+      <%= if first_condition? &&
+            second_condition? %>
+        ...
+      <% end %>
+    `
+
+    expectError("Control flow statements like `if` should not be used with output tags. Use `<% if first_condition? && second_condition? %>` instead.")
+
     assertOffenses(html)
   })
 


### PR DESCRIPTION
This pull request updates the offense message of `erb-no-output-control-flow` so that it names the keyword that was actually used and suggests the actual corrected tag, instead of a generic placeholder.

Previously the keyword came from a static node type to name mapping, which meant `elsif` was reported as `if`, since `elsif` is parsed as an `ERBIfNode`:

```html+erb
<% if condition? %>
  ...
<%= elsif another_condition? %>
  ...
<% end %>
```

```
Control flow statements like `if` should not be used with output tags. Use `<% if ... %>` instead.
```

The keyword and the suggested replacement are now both derived from the content of the reported tag, the same way the iteration block branch of this rule already builds its suggestion:

```
Control flow statements like `elsif` should not be used with output tags. Use `<% elsif another_condition? %>` instead.
```