### PR TITLE
Diff Engine: Don't emit a changeset for insignificant whitespace changes

### DIFF
--- a/ext/herb/extension.c
+++ b/ext/herb/extension.c
@@ -511,12 +511,12 @@ static VALUE Herb_diff(int argc, VALUE* argv, VALUE self) {
   herb_diff_options_T diff_options = HERB_DEFAULT_DIFF_OPTIONS;
 
   if (!NIL_P(options)) {
-    VALUE detect_whitespace_changes = rb_hash_lookup(options, rb_utf8_str_new_cstr("detect_whitespace_changes"));
-    if (NIL_P(detect_whitespace_changes)) {
-      detect_whitespace_changes = rb_hash_lookup(options, ID2SYM(rb_intern("detect_whitespace_changes")));
+    VALUE track_whitespace_changes = rb_hash_lookup(options, rb_utf8_str_new_cstr("track_whitespace_changes"));
+    if (NIL_P(track_whitespace_changes)) {
+      track_whitespace_changes = rb_hash_lookup(options, ID2SYM(rb_intern("track_whitespace_changes")));
     }
-    if (!NIL_P(detect_whitespace_changes) && RTEST(detect_whitespace_changes)) {
-      diff_options.detect_whitespace_changes = true;
+    if (!NIL_P(track_whitespace_changes) && RTEST(track_whitespace_changes)) {
+      diff_options.track_whitespace_changes = true;
     }
   }
 

--- a/ext/herb/extension.c
+++ b/ext/herb/extension.c
@@ -499,8 +499,8 @@ static VALUE diff_cleanup(VALUE arg) {
 }
 
 static VALUE Herb_diff(int argc, VALUE* argv, VALUE self) {
-  VALUE old_source, new_source;
-  rb_scan_args(argc, argv, "2", &old_source, &new_source);
+  VALUE old_source, new_source, options;
+  rb_scan_args(argc, argv, "2:", &old_source, &new_source, &options);
 
   char* old_string = (char*) check_string(old_source);
   char* new_string = (char*) check_string(new_source);
@@ -508,6 +508,17 @@ static VALUE Herb_diff(int argc, VALUE* argv, VALUE self) {
   diff_args_T args = { 0 };
 
   parser_options_T parser_options = HERB_DEFAULT_PARSER_OPTIONS;
+  herb_diff_options_T diff_options = HERB_DEFAULT_DIFF_OPTIONS;
+
+  if (!NIL_P(options)) {
+    VALUE detect_whitespace_changes = rb_hash_lookup(options, rb_utf8_str_new_cstr("detect_whitespace_changes"));
+    if (NIL_P(detect_whitespace_changes)) {
+      detect_whitespace_changes = rb_hash_lookup(options, ID2SYM(rb_intern("detect_whitespace_changes")));
+    }
+    if (!NIL_P(detect_whitespace_changes) && RTEST(detect_whitespace_changes)) {
+      diff_options.detect_whitespace_changes = true;
+    }
+  }
 
   if (!hb_allocator_init(&args.old_allocator, HB_ALLOCATOR_ARENA)) { return Qnil; }
 
@@ -533,7 +544,7 @@ static VALUE Herb_diff(int argc, VALUE* argv, VALUE self) {
     return Qnil;
   }
 
-  args.diff_result = herb_diff(args.old_root, args.new_root, &args.diff_allocator);
+  args.diff_result = herb_diff(args.old_root, args.new_root, &diff_options, &args.diff_allocator);
 
   return rb_ensure(diff_convert_body, (VALUE) &args, diff_cleanup, (VALUE) &args);
 }

--- a/java/herb_jni.c
+++ b/java/herb_jni.c
@@ -297,13 +297,13 @@ Java_org_herb_Herb_diff(JNIEnv* env, jclass clazz, jstring old_source, jstring n
   if (options != NULL) {
     jclass optionsClass = (*env)->GetObjectClass(env, options);
     jmethodID getDetectWhitespaceChanges =
-        (*env)->GetMethodID(env, optionsClass, "isDetectWhitespaceChanges", "()Z");
+        (*env)->GetMethodID(env, optionsClass, "isTrackWhitespaceChanges", "()Z");
 
     if (getDetectWhitespaceChanges != NULL) {
-      jboolean detectWhitespaceChanges = (*env)->CallBooleanMethod(env, options, getDetectWhitespaceChanges);
+      jboolean trackWhitespaceChanges = (*env)->CallBooleanMethod(env, options, getDetectWhitespaceChanges);
 
-      if (detectWhitespaceChanges == JNI_TRUE) {
-        diff_options.detect_whitespace_changes = true;
+      if (trackWhitespaceChanges == JNI_TRUE) {
+        diff_options.track_whitespace_changes = true;
       }
     }
   }

--- a/java/herb_jni.c
+++ b/java/herb_jni.c
@@ -288,9 +288,25 @@ Java_org_herb_Herb_parseRuby(JNIEnv* env, jclass clazz, jstring source) {
 }
 
 JNIEXPORT jobject JNICALL
-Java_org_herb_Herb_diff(JNIEnv* env, jclass clazz, jstring old_source, jstring new_source) {
+Java_org_herb_Herb_diff(JNIEnv* env, jclass clazz, jstring old_source, jstring new_source, jobject options) {
   const char* old_src = (*env)->GetStringUTFChars(env, old_source, 0);
   const char* new_src = (*env)->GetStringUTFChars(env, new_source, 0);
+
+  herb_diff_options_T diff_options = HERB_DEFAULT_DIFF_OPTIONS;
+
+  if (options != NULL) {
+    jclass optionsClass = (*env)->GetObjectClass(env, options);
+    jmethodID getDetectWhitespaceChanges =
+        (*env)->GetMethodID(env, optionsClass, "isDetectWhitespaceChanges", "()Z");
+
+    if (getDetectWhitespaceChanges != NULL) {
+      jboolean detectWhitespaceChanges = (*env)->CallBooleanMethod(env, options, getDetectWhitespaceChanges);
+
+      if (detectWhitespaceChanges == JNI_TRUE) {
+        diff_options.detect_whitespace_changes = true;
+      }
+    }
+  }
 
   hb_allocator_T old_allocator;
   hb_allocator_T new_allocator;
@@ -340,7 +356,7 @@ Java_org_herb_Herb_diff(JNIEnv* env, jclass clazz, jstring old_source, jstring n
     return NULL;
   }
 
-  herb_diff_result_T* diff_result = herb_diff(old_root, new_root, &diff_allocator);
+  herb_diff_result_T* diff_result = herb_diff(old_root, new_root, &diff_options, &diff_allocator);
 
   jclass diff_result_class = (*env)->FindClass(env, "org/herb/DiffResult");
   jclass diff_operation_class = (*env)->FindClass(env, "org/herb/DiffOperation");

--- a/java/herb_jni.h
+++ b/java/herb_jni.h
@@ -14,7 +14,7 @@ JNIEXPORT jobject JNICALL Java_org_herb_Herb_lex(JNIEnv*, jclass, jstring);
 JNIEXPORT jstring JNICALL Java_org_herb_Herb_extractRuby(JNIEnv*, jclass, jstring, jobject);
 JNIEXPORT jstring JNICALL Java_org_herb_Herb_extractHTML(JNIEnv*, jclass, jstring);
 JNIEXPORT jbyteArray JNICALL Java_org_herb_Herb_parseRuby(JNIEnv*, jclass, jstring);
-JNIEXPORT jobject JNICALL Java_org_herb_Herb_diff(JNIEnv*, jclass, jstring, jstring);
+JNIEXPORT jobject JNICALL Java_org_herb_Herb_diff(JNIEnv*, jclass, jstring, jstring, jobject);
 
 #ifdef __cplusplus
 }

--- a/java/org/herb/DiffOptions.java
+++ b/java/org/herb/DiffOptions.java
@@ -1,16 +1,16 @@
 package org.herb;
 
 public class DiffOptions {
-  private boolean detectWhitespaceChanges = false;
+  private boolean trackWhitespaceChanges = false;
 
   public DiffOptions() {}
 
-  public DiffOptions detectWhitespaceChanges(boolean value) {
-    this.detectWhitespaceChanges = value;
+  public DiffOptions trackWhitespaceChanges(boolean value) {
+    this.trackWhitespaceChanges = value;
     return this;
   }
 
-  public boolean isDetectWhitespaceChanges() {
-    return detectWhitespaceChanges;
+  public boolean isTrackWhitespaceChanges() {
+    return trackWhitespaceChanges;
   }
 }

--- a/java/org/herb/DiffOptions.java
+++ b/java/org/herb/DiffOptions.java
@@ -1,0 +1,16 @@
+package org.herb;
+
+public class DiffOptions {
+  private boolean detectWhitespaceChanges = false;
+
+  public DiffOptions() {}
+
+  public DiffOptions detectWhitespaceChanges(boolean value) {
+    this.detectWhitespaceChanges = value;
+    return this;
+  }
+
+  public boolean isDetectWhitespaceChanges() {
+    return detectWhitespaceChanges;
+  }
+}

--- a/java/org/herb/Herb.java
+++ b/java/org/herb/Herb.java
@@ -21,10 +21,14 @@ public class Herb {
   public static native String extractRuby(String source, ExtractRubyOptions options);
   public static native String extractHTML(String source);
   public static native byte[] parseRuby(String source);
-  public static native DiffResult diff(String oldSource, String newSource);
+  public static native DiffResult diff(String oldSource, String newSource, DiffOptions options);
 
   public static ParseResult parse(String source) {
     return parse(source, null);
+  }
+
+  public static DiffResult diff(String oldSource, String newSource) {
+    return diff(oldSource, newSource, null);
   }
 
   public static String extractRuby(String source) {

--- a/javascript/packages/client/src/types.ts
+++ b/javascript/packages/client/src/types.ts
@@ -1,5 +1,6 @@
 export type DiffOperationType =
   | "text_changed"
+  | "whitespace_changed"
   | "attribute_value_changed"
   | "attribute_added"
   | "attribute_removed"

--- a/javascript/packages/core/src/backend.ts
+++ b/javascript/packages/core/src/backend.ts
@@ -2,14 +2,14 @@ import type { SerializedParseResult } from "./parse-result.js"
 import type { SerializedLexResult } from "./lex-result.js"
 import type { ParseOptions } from "./parser-options.js"
 import type { ExtractRubyOptions } from "./extract-ruby-options.js"
-import type { DiffResult } from "./diff-result.js"
+import type { DiffOptions, DiffResult } from "./diff-result.js"
 
 interface LibHerbBackendFunctions {
   lex: (source: string) => SerializedLexResult
 
   parse: (source: string, options?: ParseOptions) => SerializedParseResult
 
-  diff: (oldSource: string, newSource: string) => DiffResult
+  diff: (oldSource: string, newSource: string, options?: DiffOptions) => DiffResult
 
   extractRuby: (source: string, options?: ExtractRubyOptions) => string
   extractHTML: (source: string) => string

--- a/javascript/packages/core/src/diff-result.ts
+++ b/javascript/packages/core/src/diff-result.ts
@@ -13,6 +13,7 @@ export type DiffOperationType =
   | "node_wrapped"
   | "tag_name_changed"
   | "text_changed"
+  | "whitespace_changed"
 
 export interface DiffOperation {
   type: DiffOperationType
@@ -26,4 +27,8 @@ export interface DiffOperation {
 export interface DiffResult {
   identical: boolean
   operations: DiffOperation[]
+}
+
+export interface DiffOptions {
+  detect_whitespace_changes?: boolean
 }

--- a/javascript/packages/core/src/diff-result.ts
+++ b/javascript/packages/core/src/diff-result.ts
@@ -30,5 +30,5 @@ export interface DiffResult {
 }
 
 export interface DiffOptions {
-  detect_whitespace_changes?: boolean
+  track_whitespace_changes?: boolean
 }

--- a/javascript/packages/core/src/herb-backend.ts
+++ b/javascript/packages/core/src/herb-backend.ts
@@ -11,7 +11,7 @@ import type { LibHerbBackend, BackendPromise } from "./backend.js"
 import type { ParseOptions } from "./parser-options.js"
 import type { ExtractRubyOptions } from "./extract-ruby-options.js"
 import type { PrismParseResult } from "./prism/index.js"
-import type { DiffResult } from "./diff-result.js"
+import type { DiffOptions, DiffResult } from "./diff-result.js"
 
 /**
  * The main Herb parser interface, providing methods to lex and parse input.
@@ -122,13 +122,14 @@ export abstract class HerbBackend {
    * Diffs two source strings and returns the minimal set of AST differences.
    * @param oldSource - The old source code.
    * @param newSource - The new source code.
+   * @param options - Optional diff options.
    * @returns A DiffResult containing the operations.
    * @throws Error if the backend is not loaded.
    */
-  diff(oldSource: string, newSource: string): DiffResult {
+  diff(oldSource: string, newSource: string, options?: DiffOptions): DiffResult {
     this.ensureBackend()
 
-    return this.backend.diff(ensureString(oldSource), ensureString(newSource))
+    return this.backend.diff(ensureString(oldSource), ensureString(newSource), options)
   }
 
   /**

--- a/javascript/packages/node/extension/herb.cpp
+++ b/javascript/packages/node/extension/herb.cpp
@@ -401,17 +401,17 @@ napi_value Herb_diff(napi_env env, napi_callback_info info) {
     napi_typeof(env, args[2], &valuetype);
 
     if (valuetype == napi_object) {
-      napi_value detect_whitespace_changes_prop;
-      bool has_detect_whitespace_changes_prop;
-      napi_has_named_property(env, args[2], "detect_whitespace_changes", &has_detect_whitespace_changes_prop);
+      napi_value track_whitespace_changes_prop;
+      bool has_track_whitespace_changes_prop;
+      napi_has_named_property(env, args[2], "track_whitespace_changes", &has_track_whitespace_changes_prop);
 
-      if (has_detect_whitespace_changes_prop) {
-        napi_get_named_property(env, args[2], "detect_whitespace_changes", &detect_whitespace_changes_prop);
-        bool detect_whitespace_changes_value;
-        napi_get_value_bool(env, detect_whitespace_changes_prop, &detect_whitespace_changes_value);
+      if (has_track_whitespace_changes_prop) {
+        napi_get_named_property(env, args[2], "track_whitespace_changes", &track_whitespace_changes_prop);
+        bool track_whitespace_changes_value;
+        napi_get_value_bool(env, track_whitespace_changes_prop, &track_whitespace_changes_value);
 
-        if (detect_whitespace_changes_value) {
-          diff_options.detect_whitespace_changes = true;
+        if (track_whitespace_changes_value) {
+          diff_options.track_whitespace_changes = true;
         }
       }
     }

--- a/javascript/packages/node/extension/herb.cpp
+++ b/javascript/packages/node/extension/herb.cpp
@@ -370,8 +370,8 @@ napi_value Herb_version(napi_env env, napi_callback_info info) {
 }
 
 napi_value Herb_diff(napi_env env, napi_callback_info info) {
-  size_t argc = 2;
-  napi_value args[2];
+  size_t argc = 3;
+  napi_value args[3];
   napi_get_cb_info(env, info, &argc, args, nullptr, nullptr);
 
   if (argc < 2) {
@@ -394,6 +394,28 @@ napi_value Herb_diff(napi_env env, napi_callback_info info) {
   if (!hb_allocator_init(&diff_allocator, HB_ALLOCATOR_ARENA)) { free(old_string); free(new_string); hb_allocator_destroy(&old_allocator); hb_allocator_destroy(&new_allocator); return nullptr; }
 
   parser_options_T parser_options = HERB_DEFAULT_PARSER_OPTIONS;
+  herb_diff_options_T diff_options = HERB_DEFAULT_DIFF_OPTIONS;
+
+  if (argc >= 3) {
+    napi_valuetype valuetype;
+    napi_typeof(env, args[2], &valuetype);
+
+    if (valuetype == napi_object) {
+      napi_value detect_whitespace_changes_prop;
+      bool has_detect_whitespace_changes_prop;
+      napi_has_named_property(env, args[2], "detect_whitespace_changes", &has_detect_whitespace_changes_prop);
+
+      if (has_detect_whitespace_changes_prop) {
+        napi_get_named_property(env, args[2], "detect_whitespace_changes", &detect_whitespace_changes_prop);
+        bool detect_whitespace_changes_value;
+        napi_get_value_bool(env, detect_whitespace_changes_prop, &detect_whitespace_changes_value);
+
+        if (detect_whitespace_changes_value) {
+          diff_options.detect_whitespace_changes = true;
+        }
+      }
+    }
+  }
 
   AST_DOCUMENT_NODE_T* old_root = herb_parse(old_string, &parser_options, &old_allocator);
   AST_DOCUMENT_NODE_T* new_root = herb_parse(new_string, &parser_options, &new_allocator);
@@ -414,7 +436,7 @@ napi_value Herb_diff(napi_env env, napi_callback_info info) {
     return nullptr;
   }
 
-  herb_diff_result_T* diff_result = herb_diff(old_root, new_root, &diff_allocator);
+  herb_diff_result_T* diff_result = herb_diff(old_root, new_root, &diff_options, &diff_allocator);
 
   napi_value result;
   napi_create_object(env, &result);

--- a/playground/index.html
+++ b/playground/index.html
@@ -683,7 +683,7 @@
                         data-action="change->playground#onDiffOptionChange"
                         class="rounded border-gray-600 text-green-600 focus:ring-green-500 bg-gray-700"
                       />
-                      <span class="select-none">Detect whitespace changes</span>
+                      <span class="select-none">Track insignificant whitespace changes</span>
                     </label>
                   </div>
 

--- a/playground/index.html
+++ b/playground/index.html
@@ -675,6 +675,16 @@
                       class="px-2 py-1 text-xs rounded font-mono font-medium"
                       style="color: #abb2bf; background: rgba(171, 178, 191, 0.1)"
                     >Checkpoint</button>
+
+                    <label class="flex items-center gap-1.5 text-gray-300 text-sm ml-2" title="Report whitespace changes that HTML collapses away as `whitespace_changed` operations instead of leaving them out">
+                      <input
+                        type="checkbox"
+                        data-playground-target="diffWhitespaceCheckbox"
+                        data-action="change->playground#onDiffOptionChange"
+                        class="rounded border-gray-600 text-green-600 focus:ring-green-500 bg-gray-700"
+                      />
+                      <span class="select-none">Detect whitespace changes</span>
+                    </label>
                   </div>
 
                   <div class="flex items-center gap-2">

--- a/playground/src/controllers/playground_controller.js
+++ b/playground/src/controllers/playground_controller.js
@@ -788,7 +788,7 @@ export default class extends Controller {
 
     try {
       const result = Herb.diff(this.diffSnapshotSource, value, this.diffOptions())
-      this.renderDiffResult(result)
+      this.renderDiffResult(result, this.diffSnapshotSource !== value)
     } catch (error) {
       console.error("Diff error:", error)
       this.updateDiffStatus("Error computing diff")
@@ -798,11 +798,12 @@ export default class extends Controller {
   diffOptions() {
     if (!this.hasDiffWhitespaceCheckboxTarget) return {}
 
-    return { detect_whitespace_changes: this.diffWhitespaceCheckboxTarget.checked }
+    return { track_whitespace_changes: this.diffWhitespaceCheckboxTarget.checked }
   }
 
   onDiffOptionChange(_event) {
     this.updateURL()
+    this.diffNoChangeset = false
 
     if (this.diffMode === "checkpoint") {
       if (this.diffSnapshotSource) { this.diffCheckpoint() }
@@ -827,6 +828,7 @@ export default class extends Controller {
 
   clearDiffFeed() {
     this.diffFeedEntries = []
+    this.diffNoChangeset = false
     this.previousSource = this.editor ? this.editor.getValue() : this.inputTarget.value
 
     if (this.hasDiffOutputTarget) {
@@ -867,7 +869,11 @@ export default class extends Controller {
     try {
       const result = Herb.diff(this.previousSource, value, this.diffOptions())
 
-      if (!result.identical) {
+      if (result.identical) {
+        this.diffNoChangeset = true
+      } else {
+        this.diffNoChangeset = false
+
         if (!this.diffFeedEntries) { this.diffFeedEntries = [] }
 
         this.diffFeedEntries.unshift({
@@ -893,7 +899,10 @@ export default class extends Controller {
     if (!this.hasDiffOutputTarget) return
 
     if (!this.diffFeedEntries || this.diffFeedEntries.length === 0) {
-      if (latestResult && latestResult.identical) {
+      if (this.diffNoChangeset) {
+        this.diffOutputTarget.innerHTML = this.renderNoChangesetNotice()
+        this.updateDiffStatus("No changeset")
+      } else if (latestResult && latestResult.identical) {
         this.diffOutputTarget.innerHTML = '<span class="diff-empty">No changes detected.</span>'
         this.updateDiffStatus("Identical")
       }
@@ -904,7 +913,7 @@ export default class extends Controller {
     const totalOperations = this.diffFeedEntries.reduce((sum, entry) => sum + entry.operations.length, 0)
     this.updateDiffStatus(`${totalOperations} change${totalOperations === 1 ? "" : "s"} in ${this.diffFeedEntries.length} edit${this.diffFeedEntries.length === 1 ? "" : "s"}`)
 
-    let html = ""
+    let html = this.diffNoChangeset ? this.renderNoChangesetNotice() : ""
 
     this.diffFeedEntries.forEach((entry, entryIndex) => {
       const time = entry.timestamp.toLocaleTimeString()
@@ -986,18 +995,39 @@ export default class extends Controller {
     this.analyze()
   }
 
-  renderDiffResult(result) {
+  renderDiffResult(result, sourceChanged = false) {
     if (!this.hasDiffOutputTarget) return
 
     if (result.identical) {
-      this.diffOutputTarget.innerHTML = '<span class="diff-empty">Trees are identical - no differences found.</span>'
-      this.updateDiffStatus("Identical")
+      if (sourceChanged) {
+        this.diffOutputTarget.innerHTML = this.renderNoChangesetNotice()
+        this.updateDiffStatus("No changeset")
+      } else {
+        this.diffOutputTarget.innerHTML = '<span class="diff-empty">Trees are identical - no differences found.</span>'
+        this.updateDiffStatus("Identical")
+      }
+
       return
     }
 
     const operations = result.operations
     this.updateDiffStatus(`${operations.length} difference${operations.length === 1 ? "" : "s"}`)
     this.diffOutputTarget.innerHTML = this.renderOperations(operations)
+  }
+
+  renderNoChangesetNotice() {
+    const tracking = this.diffOptions().track_whitespace_changes
+
+    const hint = tracking
+      ? "The edit does not affect the syntax tree."
+      : "Whitespace that HTML collapses is not reported. Enable \"Track insignificant whitespace changes\" to see it."
+
+    let html = `<div class="diff-no-changeset">`
+    html += `<div class="text-sm font-semibold"><i class="fas fa-circle-info mr-2"></i>Source changed, but no changeset was emitted.</div>`
+    html += `<div class="text-xs diff-no-changeset-hint">${hint}</div>`
+    html += `</div>`
+
+    return html
   }
 
   renderOperations(operations) {

--- a/playground/src/controllers/playground_controller.js
+++ b/playground/src/controllers/playground_controller.js
@@ -140,6 +140,7 @@ export default class extends Controller {
     "diffCheckpointButton",
     "diffSnapshotButton",
     "diffCheckButton",
+    "diffWhitespaceCheckbox",
     "diffParseError",
   ]
 
@@ -786,12 +787,33 @@ export default class extends Controller {
     const value = this.editor ? this.editor.getValue() : this.inputTarget.value
 
     try {
-      const result = Herb.diff(this.diffSnapshotSource, value)
+      const result = Herb.diff(this.diffSnapshotSource, value, this.diffOptions())
       this.renderDiffResult(result)
     } catch (error) {
       console.error("Diff error:", error)
       this.updateDiffStatus("Error computing diff")
     }
+  }
+
+  diffOptions() {
+    if (!this.hasDiffWhitespaceCheckboxTarget) return {}
+
+    return { detect_whitespace_changes: this.diffWhitespaceCheckboxTarget.checked }
+  }
+
+  onDiffOptionChange(_event) {
+    this.updateURL()
+
+    if (this.diffMode === "checkpoint") {
+      if (this.diffSnapshotSource) { this.diffCheckpoint() }
+
+      return
+    }
+
+    this.diffFeedEntries = []
+    this.previousSource = null
+
+    this.updateDiff()
   }
 
   // alias for data-action naming
@@ -843,7 +865,7 @@ export default class extends Controller {
     this.hideDiffParseError()
 
     try {
-      const result = Herb.diff(this.previousSource, value)
+      const result = Herb.diff(this.previousSource, value, this.diffOptions())
 
       if (!result.identical) {
         if (!this.diffFeedEntries) { this.diffFeedEntries = [] }
@@ -984,6 +1006,7 @@ export default class extends Controller {
       node_removed:           { css: "removed",    icon: "fa-minus" },
       node_replaced:          { css: "replaced",   icon: "fa-right-left" },
       text_changed:           { css: "changed",    icon: "fa-pen" },
+      whitespace_changed:     { css: "whitespace", icon: "fa-arrows-left-right-to-line" },
       erb_content_changed:    { css: "erb",        icon: "fa-code" },
       attribute_added:        { css: "attribute",  icon: "fa-plus" },
       attribute_removed:      { css: "removed",    icon: "fa-minus" },
@@ -1068,8 +1091,16 @@ export default class extends Controller {
     return html
   }
 
+  visualizeWhitespace(value) {
+    return value.replace(/\t/g, "\u2192").replace(/\n/g, "\u23ce").replace(/ /g, "\u00b7")
+  }
+
   extractNodeValue(node, operationType) {
     if (!node) return null
+
+    if (operationType === "whitespace_changed") {
+      return node.content ? this.visualizeWhitespace(node.content) : null
+    }
 
     if (operationType === "text_changed" || node.type === "AST_HTML_TEXT_NODE") {
       return node.content || null

--- a/playground/src/style.css
+++ b/playground/src/style.css
@@ -250,6 +250,7 @@ code.language-tree {
 .diff-op-attribute   { border-left-color: #61afef; }
 .diff-op-tag         { border-left-color: #d19a66; }
 .diff-op-moved       { border-left-color: #56b6c2; }
+.diff-op-whitespace  { border-left-color: #abb2bf; }
 
 .diff-label-inserted    { color: #90b874; }
 .diff-label-removed     { color: #e06c75; }
@@ -259,6 +260,7 @@ code.language-tree {
 .diff-label-attribute   { color: #61afef; }
 .diff-label-tag         { color: #d19a66; }
 .diff-label-moved       { color: #56b6c2; }
+.diff-label-whitespace  { color: #abb2bf; }
 
 .diff-value-old {
   color: #e06c75;

--- a/playground/src/style.css
+++ b/playground/src/style.css
@@ -327,6 +327,35 @@ code.language-tree {
   color: #607d8b;
 }
 
+.diff-no-changeset {
+  border-left: 3px solid #abb2bf;
+  border-radius: 4px;
+  padding: 0.5rem 0.625rem;
+  margin-bottom: 1rem;
+  background: rgba(255, 255, 255, 0.03);
+  color: #abb2bf;
+  animation: diff-no-changeset-bob 450ms ease-out;
+}
+
+@keyframes diff-no-changeset-bob {
+  0%   { transform: translateY(0); }
+  30%  { transform: translateY(-5px); }
+  55%  { transform: translateY(2px); }
+  80%  { transform: translateY(-1px); }
+  100% { transform: translateY(0); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .diff-no-changeset {
+    animation: none;
+  }
+}
+
+.diff-no-changeset-hint {
+  color: #607d8b;
+  margin-top: 0.25rem;
+}
+
 .diff-rollback-button {
   color: #abb2bf;
   background: rgba(171, 178, 191, 0.1);

--- a/rust/src/herb.rs
+++ b/rust/src/herb.rs
@@ -314,7 +314,7 @@ pub struct DiffResult {
 
 #[derive(Debug, Clone, Default)]
 pub struct DiffOptions {
-  pub detect_whitespace_changes: bool,
+  pub track_whitespace_changes: bool,
 }
 
 pub fn diff(old_source: &str, new_source: &str) -> Result<DiffResult, String> {
@@ -387,7 +387,7 @@ pub fn diff_with_options(old_source: &str, new_source: &str, options: &DiffOptio
     }
 
     let diff_options = crate::bindings::herb_diff_options_T {
-      detect_whitespace_changes: options.detect_whitespace_changes,
+      track_whitespace_changes: options.track_whitespace_changes,
     };
 
     let diff_result = crate::ffi::herb_diff(old_root, new_root, &diff_options, &mut diff_allocator);

--- a/rust/src/herb.rs
+++ b/rust/src/herb.rs
@@ -312,7 +312,20 @@ pub struct DiffResult {
   pub operations: Vec<DiffOperation>,
 }
 
+#[derive(Debug, Clone, Default)]
+pub struct DiffOptions {
+  pub detect_whitespace_changes: bool,
+}
+
 pub fn diff(old_source: &str, new_source: &str) -> Result<DiffResult, String> {
+  diff_with_options(old_source, new_source, &DiffOptions::default())
+}
+
+pub fn diff_with_options(
+  old_source: &str,
+  new_source: &str,
+  options: &DiffOptions,
+) -> Result<DiffResult, String> {
   unsafe {
     let old_c_source = CString::new(old_source).map_err(|error| error.to_string())?;
     let new_c_source = CString::new(new_source).map_err(|error| error.to_string())?;
@@ -377,7 +390,11 @@ pub fn diff(old_source: &str, new_source: &str) -> Result<DiffResult, String> {
       return Err("Failed to parse source".to_string());
     }
 
-    let diff_result = crate::ffi::herb_diff(old_root, new_root, &mut diff_allocator);
+    let diff_options = crate::bindings::herb_diff_options_T {
+      detect_whitespace_changes: options.detect_whitespace_changes,
+    };
+
+    let diff_result = crate::ffi::herb_diff(old_root, new_root, &diff_options, &mut diff_allocator);
 
     let identical = crate::ffi::herb_diff_trees_identical(diff_result);
     let operation_count = crate::ffi::herb_diff_operation_count(diff_result);

--- a/rust/src/herb.rs
+++ b/rust/src/herb.rs
@@ -321,11 +321,7 @@ pub fn diff(old_source: &str, new_source: &str) -> Result<DiffResult, String> {
   diff_with_options(old_source, new_source, &DiffOptions::default())
 }
 
-pub fn diff_with_options(
-  old_source: &str,
-  new_source: &str,
-  options: &DiffOptions,
-) -> Result<DiffResult, String> {
+pub fn diff_with_options(old_source: &str, new_source: &str, options: &DiffOptions) -> Result<DiffResult, String> {
   unsafe {
     let old_c_source = CString::new(old_source).map_err(|error| error.to_string())?;
     let new_c_source = CString::new(new_source).map_err(|error| error.to_string())?;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -28,8 +28,8 @@ pub use visitor::Visitor;
 pub use errors::{AnyError, ErrorNode, ErrorType};
 
 pub use herb::{
-  diff, extract_html, extract_ruby, extract_ruby_with_options, herb_version, lex, parse, parse_ruby, parse_with_options, prism_version, version, DiffOperation,
-  DiffResult, ExtractRubyOptions, ParserOptions, RubyParseResult,
+  diff, diff_with_options, extract_html, extract_ruby, extract_ruby_with_options, herb_version, lex, parse, parse_ruby, parse_with_options, prism_version, version, DiffOperation,
+  DiffOptions, DiffResult, ExtractRubyOptions, ParserOptions, RubyParseResult,
 };
 
 pub const VERSION: &str = "0.10.3";

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -28,8 +28,8 @@ pub use visitor::Visitor;
 pub use errors::{AnyError, ErrorNode, ErrorType};
 
 pub use herb::{
-  diff, diff_with_options, extract_html, extract_ruby, extract_ruby_with_options, herb_version, lex, parse, parse_ruby, parse_with_options, prism_version, version, DiffOperation,
-  DiffOptions, DiffResult, ExtractRubyOptions, ParserOptions, RubyParseResult,
+  diff, diff_with_options, extract_html, extract_ruby, extract_ruby_with_options, herb_version, lex, parse, parse_ruby, parse_with_options, prism_version,
+  version, DiffOperation, DiffOptions, DiffResult, ExtractRubyOptions, ParserOptions, RubyParseResult,
 };
 
 pub const VERSION: &str = "0.10.3";

--- a/sig/herb_c_extension.rbs
+++ b/sig/herb_c_extension.rbs
@@ -6,6 +6,6 @@ module Herb
   def self.lex: (String input, ?arena_stats: bool) -> LexResult
   def self.extract_ruby: (String source, ?semicolons: bool, ?comments: bool, ?preserve_positions: bool) -> String
   def self.extract_html: (String source) -> String
-  def self.diff: (String old_source, String new_source, ?detect_whitespace_changes: bool) -> DiffResult
+  def self.diff: (String old_source, String new_source, ?track_whitespace_changes: bool) -> DiffResult
   def self.version: () -> String
 end

--- a/sig/herb_c_extension.rbs
+++ b/sig/herb_c_extension.rbs
@@ -6,5 +6,6 @@ module Herb
   def self.lex: (String input, ?arena_stats: bool) -> LexResult
   def self.extract_ruby: (String source, ?semicolons: bool, ?comments: bool, ?preserve_positions: bool) -> String
   def self.extract_html: (String source) -> String
+  def self.diff: (String old_source, String new_source, ?detect_whitespace_changes: bool) -> DiffResult
   def self.version: () -> String
 end

--- a/src/diff/herb_diff.c
+++ b/src/diff/herb_diff.c
@@ -6,6 +6,8 @@
 
 #include <stdio.h>
 
+const herb_diff_options_T HERB_DEFAULT_DIFF_OPTIONS = { .detect_whitespace_changes = false };
+
 herb_diff_path_T herb_diff_path_empty(void) {
   herb_diff_path_T path;
 
@@ -52,12 +54,14 @@ static void emit_operation(
 herb_diff_result_T* herb_diff(
   const AST_DOCUMENT_NODE_T* old_document,
   const AST_DOCUMENT_NODE_T* new_document,
+  const herb_diff_options_T* options,
   hb_allocator_T* allocator
 ) {
   herb_diff_result_T* result = (herb_diff_result_T*) hb_allocator_alloc(allocator, sizeof(herb_diff_result_T));
   result->operations = hb_array_init(16, allocator);
   result->allocator = allocator;
   result->trees_identical = false;
+  result->options = (options != NULL) ? *options : HERB_DEFAULT_DIFF_OPTIONS;
 
   herb_hash_map_T old_hashes;
   herb_hash_map_T new_hashes;
@@ -81,8 +85,11 @@ herb_diff_result_T* herb_diff(
     root_path,
     &old_hashes,
     &new_hashes,
+    false,
     result
   );
+
+  result->trees_identical = hb_array_size(result->operations) == 0;
 
   return result;
 }
@@ -119,6 +126,7 @@ const char* herb_diff_operation_type_to_string(const herb_diff_operation_type_T 
     case HERB_DIFF_NODE_WRAPPED: return "node_wrapped";
     case HERB_DIFF_TAG_NAME_CHANGED: return "tag_name_changed";
     case HERB_DIFF_TEXT_CHANGED: return "text_changed";
+    case HERB_DIFF_WHITESPACE_CHANGED: return "whitespace_changed";
   }
 
   return "unknown";

--- a/src/diff/herb_diff.c
+++ b/src/diff/herb_diff.c
@@ -6,7 +6,7 @@
 
 #include <stdio.h>
 
-const herb_diff_options_T HERB_DEFAULT_DIFF_OPTIONS = { .detect_whitespace_changes = false };
+const herb_diff_options_T HERB_DEFAULT_DIFF_OPTIONS = { .track_whitespace_changes = false };
 
 herb_diff_path_T herb_diff_path_empty(void) {
   herb_diff_path_T path;

--- a/src/diff/herb_diff_attributes.c
+++ b/src/diff/herb_diff_attributes.c
@@ -116,6 +116,7 @@ void herb_diff_attributes(
               herb_diff_path_append(parent_path, (uint32_t) new_index),
               old_hashes,
               new_hashes,
+              false,
               result
             );
           }

--- a/src/diff/herb_diff_children.c
+++ b/src/diff/herb_diff_children.c
@@ -159,6 +159,7 @@ void herb_diff_children(
   const herb_diff_path_T parent_path,
   const herb_hash_map_T* old_hashes,
   const herb_hash_map_T* new_hashes,
+  const bool preserve_whitespace,
   herb_diff_result_T* result
 ) {
   if (old_children == NULL && new_children == NULL) { return; }
@@ -428,7 +429,7 @@ void herb_diff_children(
       const AST_NODE_T* new_child = (const AST_NODE_T*) hb_array_get(new_children, entry->new_index);
 
       herb_diff_path_T child_path = herb_diff_path_append(parent_path, (uint32_t) entry->new_index);
-      herb_diff_node(old_child, new_child, child_path, old_hashes, new_hashes, result);
+      herb_diff_node(old_child, new_child, child_path, old_hashes, new_hashes, preserve_whitespace, result);
     } else if (entry->type == EDIT_INSERT) {
       const AST_NODE_T* new_child = (const AST_NODE_T*) hb_array_get(new_children, entry->new_index);
 
@@ -468,7 +469,7 @@ void herb_diff_children(
       );
 
       herb_diff_path_T child_path = herb_diff_path_append(parent_path, (uint32_t) entry->new_index);
-      herb_diff_node(old_child, new_child, child_path, old_hashes, new_hashes, result);
+      herb_diff_node(old_child, new_child, child_path, old_hashes, new_hashes, preserve_whitespace, result);
     } else if (entry->type == EDIT_COALESCED_KEEP) {
       const AST_NODE_T* old_child = (const AST_NODE_T*) hb_array_get(old_children, entry->old_index);
       const AST_NODE_T* new_child = (const AST_NODE_T*) hb_array_get(new_children, entry->new_index);
@@ -486,7 +487,7 @@ void herb_diff_children(
         );
       }
 
-      herb_diff_node(old_child, new_child, child_path, old_hashes, new_hashes, result);
+      herb_diff_node(old_child, new_child, child_path, old_hashes, new_hashes, preserve_whitespace, result);
     } else if (entry->type == EDIT_WRAP) {
       const AST_NODE_T* old_child = (const AST_NODE_T*) hb_array_get(old_children, entry->old_index);
       const AST_NODE_T* new_child = (const AST_NODE_T*) hb_array_get(new_children, entry->new_index);

--- a/src/include/diff/herb_diff.h
+++ b/src/include/diff/herb_diff.h
@@ -20,6 +20,7 @@ typedef enum {
   HERB_DIFF_NODE_MOVED,
 
   HERB_DIFF_TEXT_CHANGED,
+  HERB_DIFF_WHITESPACE_CHANGED,
   HERB_DIFF_ERB_CONTENT_CHANGED,
 
   HERB_DIFF_ATTRIBUTE_ADDED,
@@ -47,9 +48,16 @@ typedef struct {
 } herb_diff_operation_T;
 
 typedef struct {
+  bool detect_whitespace_changes;
+} herb_diff_options_T;
+
+extern const herb_diff_options_T HERB_DEFAULT_DIFF_OPTIONS;
+
+typedef struct {
   hb_array_T* operations;
   hb_allocator_T* allocator;
   bool trees_identical;
+  herb_diff_options_T options;
 } herb_diff_result_T;
 
 herb_diff_path_T herb_diff_path_empty(void);
@@ -58,6 +66,7 @@ herb_diff_path_T herb_diff_path_append(herb_diff_path_T path, uint32_t index);
 herb_diff_result_T* herb_diff(
   const AST_DOCUMENT_NODE_T* old_document,
   const AST_DOCUMENT_NODE_T* new_document,
+  const herb_diff_options_T* options,
   hb_allocator_T* allocator
 );
 
@@ -72,6 +81,7 @@ void herb_diff_node(
   herb_diff_path_T path,
   const herb_hash_map_T* old_hashes,
   const herb_hash_map_T* new_hashes,
+  bool preserve_whitespace,
   herb_diff_result_T* result
 );
 
@@ -81,6 +91,7 @@ void herb_diff_children(
   herb_diff_path_T parent_path,
   const herb_hash_map_T* old_hashes,
   const herb_hash_map_T* new_hashes,
+  bool preserve_whitespace,
   herb_diff_result_T* result
 );
 

--- a/src/include/diff/herb_diff.h
+++ b/src/include/diff/herb_diff.h
@@ -48,7 +48,7 @@ typedef struct {
 } herb_diff_operation_T;
 
 typedef struct {
-  bool detect_whitespace_changes;
+  bool track_whitespace_changes;
 } herb_diff_options_T;
 
 extern const herb_diff_options_T HERB_DEFAULT_DIFF_OPTIONS;

--- a/src/include/lib/hb_string.h
+++ b/src/include/lib/hb_string.h
@@ -72,6 +72,7 @@ hb_string_T hb_string_trim_start(hb_string_T string);
 hb_string_T hb_string_trim_end(hb_string_T string);
 hb_string_T hb_string_trim(hb_string_T string);
 bool hb_string_is_blank(hb_string_T string);
+bool hb_string_equals_collapsing_whitespace(hb_string_T a, hb_string_T b);
 hb_string_T hb_string_copy(hb_string_T string, hb_allocator_T* allocator);
 
 char* hb_string_to_c_string_using_malloc(hb_string_T string);

--- a/src/include/util/html_util.h
+++ b/src/include/util/html_util.h
@@ -7,6 +7,7 @@
 struct hb_allocator;
 
 bool is_void_element(hb_string_T tag_name);
+bool is_whitespace_preserving_element(hb_string_T tag_name);
 bool is_boolean_attribute(hb_string_T attribute_name);
 bool has_optional_end_tag(hb_string_T tag_name);
 bool should_implicitly_close(hb_string_T open_tag_name, hb_string_T next_tag_name);

--- a/src/lib/hb_string.c
+++ b/src/lib/hb_string.c
@@ -63,6 +63,32 @@ bool hb_string_is_blank(hb_string_T string) {
   return true;
 }
 
+bool hb_string_equals_collapsing_whitespace(hb_string_T a, hb_string_T b) {
+  uint32_t a_offset = 0;
+  uint32_t b_offset = 0;
+
+  while (a_offset < a.length && b_offset < b.length) {
+    if (is_whitespace(a.data[a_offset]) && is_whitespace(b.data[b_offset])) {
+      while (a_offset < a.length && is_whitespace(a.data[a_offset])) {
+        a_offset++;
+      }
+
+      while (b_offset < b.length && is_whitespace(b.data[b_offset])) {
+        b_offset++;
+      }
+
+      continue;
+    }
+
+    if (a.data[a_offset] != b.data[b_offset]) { return false; }
+
+    a_offset++;
+    b_offset++;
+  }
+
+  return a_offset == a.length && b_offset == b.length;
+}
+
 hb_string_T hb_string_copy(hb_string_T string, hb_allocator_T* allocator) {
   if (hb_string_is_null(string)) { return HB_STRING_NULL; }
   if (hb_string_is_empty(string)) { return HB_STRING_EMPTY; }

--- a/src/util/html_util.c
+++ b/src/util/html_util.c
@@ -27,6 +27,9 @@ static hb_string_T void_tags[] = HB_STRING_LIST(
   "wbr"
 );
 
+// https://html.spec.whatwg.org/multipage/rendering.html#the-page
+static hb_string_T whitespace_preserving_tags[] = HB_STRING_LIST("pre", "script", "style", "textarea");
+
 // https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#boolean-attributes
 static hb_string_T boolean_attributes[] = HB_STRING_LIST(
   "allowfullscreen",
@@ -147,6 +150,16 @@ bool is_void_element(hb_string_T tag_name) {
 
   for (size_t i = 0; i < sizeof(void_tags) / sizeof(void_tags[0]); i++) {
     if (hb_string_equals_case_insensitive(tag_name, void_tags[i])) { return true; }
+  }
+
+  return false;
+}
+
+bool is_whitespace_preserving_element(hb_string_T tag_name) {
+  if (hb_string_is_empty(tag_name)) { return false; }
+
+  for (size_t i = 0; i < sizeof(whitespace_preserving_tags) / sizeof(whitespace_preserving_tags[0]); i++) {
+    if (hb_string_equals_case_insensitive(tag_name, whitespace_preserving_tags[i])) { return true; }
   }
 
   return false;

--- a/templates/src/diff/herb_diff_nodes.c.erb
+++ b/templates/src/diff/herb_diff_nodes.c.erb
@@ -1,5 +1,6 @@
 #include "../include/diff/herb_diff.h"
 #include "../include/lib/hb_string.h"
+#include "../include/util/html_util.h"
 
 static bool tokens_equal(const token_T* old_token, const token_T* new_token) {
   if (old_token == NULL && new_token == NULL) { return true; }
@@ -8,14 +9,26 @@ static bool tokens_equal(const token_T* old_token, const token_T* new_token) {
   return hb_string_equals(old_token->value, new_token->value);
 }
 
+static bool body_preserves_whitespace(const token_T* old_tag_name, const token_T* new_tag_name, const bool inherited) {
+  if (inherited) { return true; }
+  if (old_tag_name != NULL && is_whitespace_preserving_element(old_tag_name->value)) { return true; }
+  if (new_tag_name != NULL && is_whitespace_preserving_element(new_tag_name->value)) { return true; }
+
+  return false;
+}
+
 static void diff_element_node(
   const AST_HTML_ELEMENT_NODE_T* old_element,
   const AST_HTML_ELEMENT_NODE_T* new_element,
   const herb_diff_path_T path,
   const herb_hash_map_T* old_hashes,
   const herb_hash_map_T* new_hashes,
+  const bool preserve_whitespace,
   herb_diff_result_T* result
 ) {
+  const bool preserve_body_whitespace =
+    body_preserves_whitespace(old_element->tag_name, new_element->tag_name, preserve_whitespace);
+
   if (!tokens_equal(old_element->tag_name, new_element->tag_name)) {
     herb_diff_emit_operation(result, HERB_DIFF_TAG_NAME_CHANGED, path, (const AST_NODE_T*) old_element, (const AST_NODE_T*) new_element, 0, 0);
   }
@@ -33,7 +46,7 @@ static void diff_element_node(
   }
 
   if (old_element->body != NULL && new_element->body != NULL) {
-    herb_diff_children(old_element->body, new_element->body, path, old_hashes, new_hashes, result);
+    herb_diff_children(old_element->body, new_element->body, path, old_hashes, new_hashes, preserve_body_whitespace, result);
   } else if (old_element->body == NULL && new_element->body != NULL) {
     for (size_t index = 0; index < hb_array_size(new_element->body); index++) {
       const AST_NODE_T* new_child = (const AST_NODE_T*) hb_array_get(new_element->body, index);
@@ -53,8 +66,12 @@ static void diff_conditional_element_node(
   const herb_diff_path_T path,
   const herb_hash_map_T* old_hashes,
   const herb_hash_map_T* new_hashes,
+  const bool preserve_whitespace,
   herb_diff_result_T* result
 ) {
+  const bool preserve_body_whitespace =
+    body_preserves_whitespace(old_element->tag_name, new_element->tag_name, preserve_whitespace);
+
   if (!tokens_equal(old_element->tag_name, new_element->tag_name)) {
     herb_diff_emit_operation(result, HERB_DIFF_TAG_NAME_CHANGED, path, (const AST_NODE_T*) old_element, (const AST_NODE_T*) new_element, 0, 0);
   }
@@ -69,7 +86,7 @@ static void diff_conditional_element_node(
   }
 
   if (old_element->body != NULL && new_element->body != NULL) {
-    herb_diff_children(old_element->body, new_element->body, path, old_hashes, new_hashes, result);
+    herb_diff_children(old_element->body, new_element->body, path, old_hashes, new_hashes, preserve_body_whitespace, result);
   }
 }
 
@@ -79,10 +96,11 @@ static void diff_children_nullable(
   const herb_diff_path_T path,
   const herb_hash_map_T* old_hashes,
   const herb_hash_map_T* new_hashes,
+  const bool preserve_whitespace,
   herb_diff_result_T* result
 ) {
   if (old_children != NULL && new_children != NULL) {
-    herb_diff_children(old_children, new_children, path, old_hashes, new_hashes, result);
+    herb_diff_children(old_children, new_children, path, old_hashes, new_hashes, preserve_whitespace, result);
   } else if (old_children == NULL && new_children != NULL) {
     for (size_t index = 0; index < hb_array_size(new_children); index++) {
       const AST_NODE_T* new_child = (const AST_NODE_T*) hb_array_get(new_children, index);
@@ -102,6 +120,7 @@ void herb_diff_node(
   const herb_diff_path_T path,
   const herb_hash_map_T* old_hashes,
   const herb_hash_map_T* new_hashes,
+  const bool preserve_whitespace,
   herb_diff_result_T* result
 ) {
   if (old_node == NULL && new_node == NULL) { return; }
@@ -134,7 +153,7 @@ void herb_diff_node(
       diff_element_node(
         (const <%= node.struct_type %>*) old_node,
         (const <%= node.struct_type %>*) new_node,
-        path, old_hashes, new_hashes, result
+        path, old_hashes, new_hashes, preserve_whitespace, result
       );
     } break;
 
@@ -143,8 +162,25 @@ void herb_diff_node(
       diff_conditional_element_node(
         (const <%= node.struct_type %>*) old_node,
         (const <%= node.struct_type %>*) new_node,
-        path, old_hashes, new_hashes, result
+        path, old_hashes, new_hashes, preserve_whitespace, result
       );
+    } break;
+
+  <%- elsif node.name == "HTMLTextNode" -%>
+    case <%= node.type %>: {
+      const <%= node.struct_type %>* old_text_node = (const <%= node.struct_type %>*) old_node;
+      const <%= node.struct_type %>* new_text_node = (const <%= node.struct_type %>*) new_node;
+
+      if (preserve_whitespace) {
+        if (!hb_string_equals(old_text_node->content, new_text_node->content)) {
+          herb_diff_emit_operation(result, HERB_DIFF_TEXT_CHANGED, path, old_node, new_node, 0, 0);
+        }
+      } else if (!hb_string_equals_collapsing_whitespace(old_text_node->content, new_text_node->content)) {
+        herb_diff_emit_operation(result, HERB_DIFF_TEXT_CHANGED, path, old_node, new_node, 0, 0);
+      } else if (result->options.detect_whitespace_changes
+                 && !hb_string_equals(old_text_node->content, new_text_node->content)) {
+        herb_diff_emit_operation(result, HERB_DIFF_WHITESPACE_CHANGED, path, old_node, new_node, 0, 0);
+      }
     } break;
 
   <%- elsif node.name == "HTMLAttributeNode" -%>
@@ -209,11 +245,11 @@ void herb_diff_node(
     <%- end -%>
 
     <%- array_fields.each do |field| -%>
-      diff_children_nullable(old_<%= node.human %>-><%= field.name %>, new_<%= node.human %>-><%= field.name %>, path, old_hashes, new_hashes, result);
+      diff_children_nullable(old_<%= node.human %>-><%= field.name %>, new_<%= node.human %>-><%= field.name %>, path, old_hashes, new_hashes, preserve_whitespace, result);
     <%- end -%>
 
     <%- node_fields.each do |field| -%>
-      herb_diff_node((const AST_NODE_T*) old_<%= node.human %>-><%= field.name %>, (const AST_NODE_T*) new_<%= node.human %>-><%= field.name %>, path, old_hashes, new_hashes, result);
+      herb_diff_node((const AST_NODE_T*) old_<%= node.human %>-><%= field.name %>, (const AST_NODE_T*) new_<%= node.human %>-><%= field.name %>, path, old_hashes, new_hashes, preserve_whitespace, result);
     <%- end -%>
     } break;
 

--- a/templates/src/diff/herb_diff_nodes.c.erb
+++ b/templates/src/diff/herb_diff_nodes.c.erb
@@ -177,7 +177,7 @@ void herb_diff_node(
         }
       } else if (!hb_string_equals_collapsing_whitespace(old_text_node->content, new_text_node->content)) {
         herb_diff_emit_operation(result, HERB_DIFF_TEXT_CHANGED, path, old_node, new_node, 0, 0);
-      } else if (result->options.detect_whitespace_changes
+      } else if (result->options.track_whitespace_changes
                  && !hb_string_equals(old_text_node->content, new_text_node->content)) {
         herb_diff_emit_operation(result, HERB_DIFF_WHITESPACE_CHANGED, path, old_node, new_node, 0, 0);
       }

--- a/test/c/test_diff.c
+++ b/test/c/test_diff.c
@@ -18,7 +18,7 @@ static herb_diff_result_T* diff_sources(const char* old_source, const char* new_
   return herb_diff(old_document, new_document, NULL, allocator);
 }
 
-static herb_diff_result_T* diff_sources_detecting_whitespace(
+static herb_diff_result_T* diff_sources_tracking_whitespace(
   const char* old_source,
   const char* new_source,
   hb_allocator_T* allocator
@@ -34,7 +34,7 @@ static herb_diff_result_T* diff_sources_detecting_whitespace(
   AST_DOCUMENT_NODE_T* new_document = herb_parse(new_source, &options, &new_allocator);
 
   herb_diff_options_T diff_options = HERB_DEFAULT_DIFF_OPTIONS;
-  diff_options.detect_whitespace_changes = true;
+  diff_options.track_whitespace_changes = true;
 
   return herb_diff(old_document, new_document, &diff_options, allocator);
 }
@@ -480,7 +480,7 @@ TEST(test_diff_whitespace_change_detected_when_opted_in)
   hb_allocator_init(&allocator, HB_ALLOCATOR_ARENA);
 
   herb_diff_result_T* result =
-    diff_sources_detecting_whitespace("<div>Hello World</div>", "<div>Hello    World</div>", &allocator);
+    diff_sources_tracking_whitespace("<div>Hello World</div>", "<div>Hello    World</div>", &allocator);
 
   ck_assert(!herb_diff_trees_identical(result));
   ck_assert_uint_eq(herb_diff_operation_count(result), 1);
@@ -494,7 +494,7 @@ TEST(test_diff_significant_change_stays_text_changed_when_opted_in)
   hb_allocator_init(&allocator, HB_ALLOCATOR_ARENA);
 
   herb_diff_result_T* result =
-    diff_sources_detecting_whitespace("<div>Hello World</div>", "<div>HelloWorld</div>", &allocator);
+    diff_sources_tracking_whitespace("<div>Hello World</div>", "<div>HelloWorld</div>", &allocator);
 
   ck_assert_uint_eq(herb_diff_operation_count(result), 1);
   ck_assert_uint_eq(herb_diff_operation_at(result, 0)->type, HERB_DIFF_TEXT_CHANGED);
@@ -507,7 +507,7 @@ TEST(test_diff_preserving_element_stays_text_changed_when_opted_in)
   hb_allocator_init(&allocator, HB_ALLOCATOR_ARENA);
 
   herb_diff_result_T* result =
-    diff_sources_detecting_whitespace("<pre>Hello World</pre>", "<pre>Hello    World</pre>", &allocator);
+    diff_sources_tracking_whitespace("<pre>Hello World</pre>", "<pre>Hello    World</pre>", &allocator);
 
   ck_assert_uint_eq(herb_diff_operation_count(result), 1);
   ck_assert_uint_eq(herb_diff_operation_at(result, 0)->type, HERB_DIFF_TEXT_CHANGED);

--- a/test/c/test_diff.c
+++ b/test/c/test_diff.c
@@ -15,7 +15,28 @@ static herb_diff_result_T* diff_sources(const char* old_source, const char* new_
   AST_DOCUMENT_NODE_T* old_document = herb_parse(old_source, &options, &old_allocator);
   AST_DOCUMENT_NODE_T* new_document = herb_parse(new_source, &options, &new_allocator);
 
-  return herb_diff(old_document, new_document, allocator);
+  return herb_diff(old_document, new_document, NULL, allocator);
+}
+
+static herb_diff_result_T* diff_sources_detecting_whitespace(
+  const char* old_source,
+  const char* new_source,
+  hb_allocator_T* allocator
+) {
+  parser_options_T options = HERB_DEFAULT_PARSER_OPTIONS;
+
+  hb_allocator_T old_allocator;
+  hb_allocator_T new_allocator;
+  hb_allocator_init(&old_allocator, HB_ALLOCATOR_ARENA);
+  hb_allocator_init(&new_allocator, HB_ALLOCATOR_ARENA);
+
+  AST_DOCUMENT_NODE_T* old_document = herb_parse(old_source, &options, &old_allocator);
+  AST_DOCUMENT_NODE_T* new_document = herb_parse(new_source, &options, &new_allocator);
+
+  herb_diff_options_T diff_options = HERB_DEFAULT_DIFF_OPTIONS;
+  diff_options.detect_whitespace_changes = true;
+
+  return herb_diff(old_document, new_document, &diff_options, allocator);
 }
 
 TEST(test_diff_identical_documents)
@@ -416,12 +437,91 @@ TEST(test_diff_move_with_unchanged_middle)
   hb_allocator_destroy(&allocator);
 END
 
+TEST(test_diff_insignificant_whitespace_change)
+  hb_allocator_T allocator;
+  hb_allocator_init(&allocator, HB_ALLOCATOR_ARENA);
+
+  herb_diff_result_T* result = diff_sources("<div>Hello World</div>", "<div>Hello    World</div>", &allocator);
+
+  ck_assert(herb_diff_trees_identical(result));
+  ck_assert_uint_eq(herb_diff_operation_count(result), 0);
+
+  hb_allocator_destroy(&allocator);
+END
+
+TEST(test_diff_significant_whitespace_change)
+  hb_allocator_T allocator;
+  hb_allocator_init(&allocator, HB_ALLOCATOR_ARENA);
+
+  herb_diff_result_T* result = diff_sources("<div>Hello World</div>", "<div>HelloWorld</div>", &allocator);
+
+  ck_assert(!herb_diff_trees_identical(result));
+  ck_assert_uint_eq(herb_diff_operation_count(result), 1);
+  ck_assert_uint_eq(herb_diff_operation_at(result, 0)->type, HERB_DIFF_TEXT_CHANGED);
+
+  hb_allocator_destroy(&allocator);
+END
+
+TEST(test_diff_whitespace_change_in_preserving_element)
+  hb_allocator_T allocator;
+  hb_allocator_init(&allocator, HB_ALLOCATOR_ARENA);
+
+  herb_diff_result_T* result = diff_sources("<pre>Hello World</pre>", "<pre>Hello    World</pre>", &allocator);
+
+  ck_assert(!herb_diff_trees_identical(result));
+  ck_assert_uint_eq(herb_diff_operation_count(result), 1);
+  ck_assert_uint_eq(herb_diff_operation_at(result, 0)->type, HERB_DIFF_TEXT_CHANGED);
+
+  hb_allocator_destroy(&allocator);
+END
+
+TEST(test_diff_whitespace_change_detected_when_opted_in)
+  hb_allocator_T allocator;
+  hb_allocator_init(&allocator, HB_ALLOCATOR_ARENA);
+
+  herb_diff_result_T* result =
+    diff_sources_detecting_whitespace("<div>Hello World</div>", "<div>Hello    World</div>", &allocator);
+
+  ck_assert(!herb_diff_trees_identical(result));
+  ck_assert_uint_eq(herb_diff_operation_count(result), 1);
+  ck_assert_uint_eq(herb_diff_operation_at(result, 0)->type, HERB_DIFF_WHITESPACE_CHANGED);
+
+  hb_allocator_destroy(&allocator);
+END
+
+TEST(test_diff_significant_change_stays_text_changed_when_opted_in)
+  hb_allocator_T allocator;
+  hb_allocator_init(&allocator, HB_ALLOCATOR_ARENA);
+
+  herb_diff_result_T* result =
+    diff_sources_detecting_whitespace("<div>Hello World</div>", "<div>HelloWorld</div>", &allocator);
+
+  ck_assert_uint_eq(herb_diff_operation_count(result), 1);
+  ck_assert_uint_eq(herb_diff_operation_at(result, 0)->type, HERB_DIFF_TEXT_CHANGED);
+
+  hb_allocator_destroy(&allocator);
+END
+
+TEST(test_diff_preserving_element_stays_text_changed_when_opted_in)
+  hb_allocator_T allocator;
+  hb_allocator_init(&allocator, HB_ALLOCATOR_ARENA);
+
+  herb_diff_result_T* result =
+    diff_sources_detecting_whitespace("<pre>Hello World</pre>", "<pre>Hello    World</pre>", &allocator);
+
+  ck_assert_uint_eq(herb_diff_operation_count(result), 1);
+  ck_assert_uint_eq(herb_diff_operation_at(result, 0)->type, HERB_DIFF_TEXT_CHANGED);
+
+  hb_allocator_destroy(&allocator);
+END
+
 TEST(test_diff_operation_type_to_string)
   ck_assert_str_eq(herb_diff_operation_type_to_string(HERB_DIFF_NODE_INSERTED), "node_inserted");
   ck_assert_str_eq(herb_diff_operation_type_to_string(HERB_DIFF_NODE_REMOVED), "node_removed");
   ck_assert_str_eq(herb_diff_operation_type_to_string(HERB_DIFF_NODE_REPLACED), "node_replaced");
   ck_assert_str_eq(herb_diff_operation_type_to_string(HERB_DIFF_NODE_MOVED), "node_moved");
   ck_assert_str_eq(herb_diff_operation_type_to_string(HERB_DIFF_TEXT_CHANGED), "text_changed");
+  ck_assert_str_eq(herb_diff_operation_type_to_string(HERB_DIFF_WHITESPACE_CHANGED), "whitespace_changed");
   ck_assert_str_eq(herb_diff_operation_type_to_string(HERB_DIFF_ERB_CONTENT_CHANGED), "erb_content_changed");
   ck_assert_str_eq(herb_diff_operation_type_to_string(HERB_DIFF_ATTRIBUTE_ADDED), "attribute_added");
   ck_assert_str_eq(herb_diff_operation_type_to_string(HERB_DIFF_ATTRIBUTE_REMOVED), "attribute_removed");
@@ -457,6 +557,12 @@ TCase *diff_tests(void) {
   tcase_add_test(diff, test_diff_move_among_other_changes);
   tcase_add_test(diff, test_diff_no_move_without_attributes);
   tcase_add_test(diff, test_diff_move_with_unchanged_middle);
+  tcase_add_test(diff, test_diff_insignificant_whitespace_change);
+  tcase_add_test(diff, test_diff_significant_whitespace_change);
+  tcase_add_test(diff, test_diff_whitespace_change_in_preserving_element);
+  tcase_add_test(diff, test_diff_whitespace_change_detected_when_opted_in);
+  tcase_add_test(diff, test_diff_significant_change_stays_text_changed_when_opted_in);
+  tcase_add_test(diff, test_diff_preserving_element_stays_text_changed_when_opted_in);
   tcase_add_test(diff, test_diff_operation_type_to_string);
 
   return diff;

--- a/test/c/test_hb_string.c
+++ b/test/c/test_hb_string.c
@@ -230,10 +230,27 @@ TEST(hb_string_range_tests)
   }
 END
 
+TEST(hb_string_equals_collapsing_whitespace_tests)
+  ck_assert(hb_string_equals_collapsing_whitespace(hb_string("a b"), hb_string("a b")));
+  ck_assert(hb_string_equals_collapsing_whitespace(hb_string("a  b"), hb_string("a b")));
+  ck_assert(hb_string_equals_collapsing_whitespace(hb_string("a b"), hb_string("a      b")));
+  ck_assert(hb_string_equals_collapsing_whitespace(hb_string("a\n\tb"), hb_string("a b")));
+  ck_assert(hb_string_equals_collapsing_whitespace(hb_string("  a  b  "), hb_string(" a b ")));
+  ck_assert(hb_string_equals_collapsing_whitespace(hb_string("\n  "), hb_string("\n")));
+  ck_assert(hb_string_equals_collapsing_whitespace(hb_string(""), hb_string("")));
+
+  ck_assert(!hb_string_equals_collapsing_whitespace(hb_string("a b"), hb_string("ab")));
+  ck_assert(!hb_string_equals_collapsing_whitespace(hb_string("a"), hb_string("a ")));
+  ck_assert(!hb_string_equals_collapsing_whitespace(hb_string("a"), hb_string(" a")));
+  ck_assert(!hb_string_equals_collapsing_whitespace(hb_string(""), hb_string(" ")));
+  ck_assert(!hb_string_equals_collapsing_whitespace(hb_string("a  b"), hb_string("a  c")));
+END
+
 TCase *hb_string_tests(void) {
   TCase *tags = tcase_create("Herb String");
 
   tcase_add_test(tags, hb_string_equals_tests);
+  tcase_add_test(tags, hb_string_equals_collapsing_whitespace_tests);
   tcase_add_test(tags, hb_string_offset_based_slice_tests);
   tcase_add_test(tags, hb_string_equals_case_insensitive_tests);
   tcase_add_test(tags, hb_string_is_empty_tests);

--- a/test/c/test_html_util.c
+++ b/test/c/test_html_util.c
@@ -26,12 +26,26 @@ TEST(html_util_html_self_closing_tag_string)
   ck_assert(hb_string_equals(html_self_closing_tag_string(hb_string("somelongerstring"), &alloc), hb_string("<somelongerstring />")));
 END
 
+TEST(html_util_is_whitespace_preserving_element)
+  ck_assert(is_whitespace_preserving_element(hb_string("pre")));
+  ck_assert(is_whitespace_preserving_element(hb_string("textarea")));
+  ck_assert(is_whitespace_preserving_element(hb_string("script")));
+  ck_assert(is_whitespace_preserving_element(hb_string("style")));
+  ck_assert(is_whitespace_preserving_element(hb_string("PRE")));
+
+  ck_assert(!is_whitespace_preserving_element((hb_string_T) { .data = NULL, .length = 0 }));
+  ck_assert(!is_whitespace_preserving_element(hb_string("")));
+  ck_assert(!is_whitespace_preserving_element(hb_string("div")));
+  ck_assert(!is_whitespace_preserving_element(hb_string("prefix")));
+END
+
 TCase* html_util_tests(void) {
   TCase* html_util = tcase_create("HTML Util");
 
   tcase_add_test(html_util, html_util_html_closing_tag_string);
   tcase_add_test(html_util, html_util_html_closing_tag_string);
   tcase_add_test(html_util, html_util_html_self_closing_tag_string);
+  tcase_add_test(html_util, html_util_is_whitespace_preserving_element);
 
   return html_util;
 }

--- a/test/diff/diff_test.rb
+++ b/test/diff/diff_test.rb
@@ -550,5 +550,203 @@ module Diff
       assert_kind_of Herb::AST::HTMLElementNode, result.first.old_node
       assert_kind_of Herb::AST::HTMLTextNode, result.first.new_node
     end
+
+    test "growing a whitespace run in text" do
+      result = Herb.diff("<div>Hello World</div>", "<div>Hello     World</div>")
+
+      assert result.identical?
+      assert_equal 0, result.operation_count
+    end
+
+    test "shrinking a whitespace run in text" do
+      result = Herb.diff("<div>Hello     World</div>", "<div>Hello World</div>")
+
+      assert result.identical?
+      assert_equal 0, result.operation_count
+    end
+
+    test "changing which whitespace characters a run is made of" do
+      result = Herb.diff("<div>Hello\n\tWorld</div>", "<div>Hello World</div>")
+
+      assert result.identical?
+      assert_equal 0, result.operation_count
+    end
+
+    test "removing the last whitespace of a run in text" do
+      result = Herb.diff("<div>Hello World</div>", "<div>HelloWorld</div>")
+
+      refute result.identical?
+      assert_equal 1, result.operation_count
+      assert_equal :text_changed, result.first.type
+    end
+
+    test "adding leading whitespace to text" do
+      result = Herb.diff("<div>Hello</div>", "<div> Hello</div>")
+
+      refute result.identical?
+      assert_equal 1, result.operation_count
+      assert_equal :text_changed, result.first.type
+    end
+
+    test "adding trailing whitespace to text" do
+      result = Herb.diff("<div>Hello</div>", "<div>Hello </div>")
+
+      refute result.identical?
+      assert_equal 1, result.operation_count
+      assert_equal :text_changed, result.first.type
+    end
+
+    test "changing the indentation of a nested element" do
+      result = Herb.diff(
+        "<div>\n  <span>Hello</span>\n</div>",
+        "<div>\n      <span>Hello</span>\n</div>"
+      )
+
+      assert result.identical?
+      assert_equal 0, result.operation_count
+    end
+
+    test "removing the whitespace around a nested element" do
+      result = Herb.diff(
+        "<div>\n  <span>Hello</span>\n</div>",
+        "<div><span>Hello</span></div>"
+      )
+
+      refute result.identical?
+      assert_equal 2, result.operation_count
+      assert_equal [:node_removed, :node_removed], result.operations.map(&:type)
+    end
+
+    test "changing a whitespace run inside a pre element" do
+      result = Herb.diff("<pre>Hello World</pre>", "<pre>Hello     World</pre>")
+
+      refute result.identical?
+      assert_equal 1, result.operation_count
+      assert_equal :text_changed, result.first.type
+    end
+
+    test "changing a whitespace run inside a textarea element" do
+      result = Herb.diff("<textarea>Hello World</textarea>", "<textarea>Hello     World</textarea>")
+
+      refute result.identical?
+      assert_equal 1, result.operation_count
+      assert_equal :text_changed, result.first.type
+    end
+
+    test "changing a whitespace run nested inside a pre element" do
+      result = Herb.diff(
+        "<pre><code>Hello World</code></pre>",
+        "<pre><code>Hello     World</code></pre>"
+      )
+
+      refute result.identical?
+      assert_equal 1, result.operation_count
+      assert_equal :text_changed, result.first.type
+    end
+
+    test "changing a whitespace run inside an ERB block inside a pre element" do
+      result = Herb.diff(
+        "<pre><% if condition %>Hello World<% end %></pre>",
+        "<pre><% if condition %>Hello     World<% end %></pre>"
+      )
+
+      refute result.identical?
+      assert_equal 1, result.operation_count
+      assert_equal :text_changed, result.first.type
+    end
+
+    test "changing a whitespace run inside an ERB block outside a pre element" do
+      result = Herb.diff(
+        "<div><% if condition %>Hello World<% end %></div>",
+        "<div><% if condition %>Hello     World<% end %></div>"
+      )
+
+      assert result.identical?
+      assert_equal 0, result.operation_count
+    end
+
+    test "changing a whitespace run inside an uppercase PRE element" do
+      result = Herb.diff("<PRE>Hello World</PRE>", "<PRE>Hello     World</PRE>")
+
+      refute result.identical?
+      assert_equal 1, result.operation_count
+      assert_equal :text_changed, result.first.type
+    end
+
+    test "changing a whitespace run in an attribute value" do
+      result = Herb.diff('<div title="Hello World">Hi</div>', '<div title="Hello     World">Hi</div>')
+
+      refute result.identical?
+      assert_equal 1, result.operation_count
+      assert_equal :attribute_value_changed, result.first.type
+    end
+
+    test "changing a whitespace run in ERB content" do
+      result = Herb.diff("<%= user.name %>", "<%= user.name     %>")
+
+      refute result.identical?
+      assert_equal 1, result.operation_count
+      assert_equal :erb_content_changed, result.first.type
+    end
+
+    test "changing a whitespace run next to a real text change" do
+      result = Herb.diff("<div>Hello World</div>", "<div>Goodbye     World</div>")
+
+      refute result.identical?
+      assert_equal 1, result.operation_count
+      assert_equal :text_changed, result.first.type
+    end
+
+    test "detect_whitespace_changes reports a whitespace_changed operation" do
+      result = Herb.diff("<div>Hello World</div>", "<div>Hello     World</div>", detect_whitespace_changes: true)
+
+      refute result.identical?
+      assert_equal 1, result.operation_count
+      assert_equal :whitespace_changed, result.first.type
+      assert_kind_of Herb::AST::HTMLTextNode, result.first.old_node
+      assert_kind_of Herb::AST::HTMLTextNode, result.first.new_node
+    end
+
+    test "detect_whitespace_changes accepts a string key" do
+      result = Herb.diff("<div>Hello World</div>", "<div>Hello     World</div>", "detect_whitespace_changes" => true)
+
+      assert_equal [:whitespace_changed], result.operations.map(&:type)
+    end
+
+    test "detect_whitespace_changes reports changed indentation" do
+      result = Herb.diff(
+        "<div>\n  <span>Hello</span>\n</div>",
+        "<div>\n      <span>Hello</span>\n</div>",
+        detect_whitespace_changes: true
+      )
+
+      assert_equal [:whitespace_changed], result.operations.map(&:type)
+    end
+
+    test "detect_whitespace_changes leaves identical documents identical" do
+      result = Herb.diff("<div>Hello World</div>", "<div>Hello World</div>", detect_whitespace_changes: true)
+
+      assert result.identical?
+      assert_equal 0, result.operation_count
+    end
+
+    test "detect_whitespace_changes still reports significant changes as text_changed" do
+      result = Herb.diff("<div>Hello World</div>", "<div>HelloWorld</div>", detect_whitespace_changes: true)
+
+      assert_equal [:text_changed], result.operations.map(&:type)
+    end
+
+    test "detect_whitespace_changes still reports pre content as text_changed" do
+      result = Herb.diff("<pre>Hello World</pre>", "<pre>Hello     World</pre>", detect_whitespace_changes: true)
+
+      assert_equal [:text_changed], result.operations.map(&:type)
+    end
+
+    test "detect_whitespace_changes defaults to off" do
+      result = Herb.diff("<div>Hello World</div>", "<div>Hello     World</div>", detect_whitespace_changes: false)
+
+      assert result.identical?
+      assert_equal 0, result.operation_count
+    end
   end
 end

--- a/test/diff/diff_test.rb
+++ b/test/diff/diff_test.rb
@@ -697,8 +697,8 @@ module Diff
       assert_equal :text_changed, result.first.type
     end
 
-    test "detect_whitespace_changes reports a whitespace_changed operation" do
-      result = Herb.diff("<div>Hello World</div>", "<div>Hello     World</div>", detect_whitespace_changes: true)
+    test "track_whitespace_changes reports a whitespace_changed operation" do
+      result = Herb.diff("<div>Hello World</div>", "<div>Hello     World</div>", track_whitespace_changes: true)
 
       refute result.identical?
       assert_equal 1, result.operation_count
@@ -707,43 +707,43 @@ module Diff
       assert_kind_of Herb::AST::HTMLTextNode, result.first.new_node
     end
 
-    test "detect_whitespace_changes accepts a string key" do
-      result = Herb.diff("<div>Hello World</div>", "<div>Hello     World</div>", "detect_whitespace_changes" => true)
+    test "track_whitespace_changes accepts a string key" do
+      result = Herb.diff("<div>Hello World</div>", "<div>Hello     World</div>", "track_whitespace_changes" => true)
 
       assert_equal [:whitespace_changed], result.operations.map(&:type)
     end
 
-    test "detect_whitespace_changes reports changed indentation" do
+    test "track_whitespace_changes reports changed indentation" do
       result = Herb.diff(
         "<div>\n  <span>Hello</span>\n</div>",
         "<div>\n      <span>Hello</span>\n</div>",
-        detect_whitespace_changes: true
+        track_whitespace_changes: true
       )
 
       assert_equal [:whitespace_changed], result.operations.map(&:type)
     end
 
-    test "detect_whitespace_changes leaves identical documents identical" do
-      result = Herb.diff("<div>Hello World</div>", "<div>Hello World</div>", detect_whitespace_changes: true)
+    test "track_whitespace_changes leaves identical documents identical" do
+      result = Herb.diff("<div>Hello World</div>", "<div>Hello World</div>", track_whitespace_changes: true)
 
       assert result.identical?
       assert_equal 0, result.operation_count
     end
 
-    test "detect_whitespace_changes still reports significant changes as text_changed" do
-      result = Herb.diff("<div>Hello World</div>", "<div>HelloWorld</div>", detect_whitespace_changes: true)
+    test "track_whitespace_changes still reports significant changes as text_changed" do
+      result = Herb.diff("<div>Hello World</div>", "<div>HelloWorld</div>", track_whitespace_changes: true)
 
       assert_equal [:text_changed], result.operations.map(&:type)
     end
 
-    test "detect_whitespace_changes still reports pre content as text_changed" do
-      result = Herb.diff("<pre>Hello World</pre>", "<pre>Hello     World</pre>", detect_whitespace_changes: true)
+    test "track_whitespace_changes still reports pre content as text_changed" do
+      result = Herb.diff("<pre>Hello World</pre>", "<pre>Hello     World</pre>", track_whitespace_changes: true)
 
       assert_equal [:text_changed], result.operations.map(&:type)
     end
 
-    test "detect_whitespace_changes defaults to off" do
-      result = Herb.diff("<div>Hello World</div>", "<div>Hello     World</div>", detect_whitespace_changes: false)
+    test "track_whitespace_changes defaults to off" do
+      result = Herb.diff("<div>Hello World</div>", "<div>Hello     World</div>", track_whitespace_changes: false)
 
       assert result.identical?
       assert_equal 0, result.operation_count

--- a/wasm/herb-wasm.cpp
+++ b/wasm/herb-wasm.cpp
@@ -222,8 +222,8 @@ val Herb_diff(const std::string& old_source, const std::string& new_source, val 
   herb_diff_options_T diff_options = HERB_DEFAULT_DIFF_OPTIONS;
 
   if (!options.isUndefined() && !options.isNull() && options.typeOf().as<std::string>() == "object") {
-    if (options.hasOwnProperty("detect_whitespace_changes")) {
-      diff_options.detect_whitespace_changes = options["detect_whitespace_changes"].as<bool>();
+    if (options.hasOwnProperty("track_whitespace_changes")) {
+      diff_options.track_whitespace_changes = options["track_whitespace_changes"].as<bool>();
     }
   }
 

--- a/wasm/herb-wasm.cpp
+++ b/wasm/herb-wasm.cpp
@@ -196,7 +196,7 @@ val Herb_parse_ruby(const std::string& source) {
   return result;
 }
 
-val Herb_diff(const std::string& old_source, const std::string& new_source) {
+val Herb_diff(const std::string& old_source, const std::string& new_source, val options) {
   hb_allocator_T old_allocator;
   hb_allocator_T new_allocator;
   hb_allocator_T diff_allocator;
@@ -219,6 +219,13 @@ val Herb_diff(const std::string& old_source, const std::string& new_source) {
   }
 
   parser_options_T parser_options = HERB_DEFAULT_PARSER_OPTIONS;
+  herb_diff_options_T diff_options = HERB_DEFAULT_DIFF_OPTIONS;
+
+  if (!options.isUndefined() && !options.isNull() && options.typeOf().as<std::string>() == "object") {
+    if (options.hasOwnProperty("detect_whitespace_changes")) {
+      diff_options.detect_whitespace_changes = options["detect_whitespace_changes"].as<bool>();
+    }
+  }
 
   AST_DOCUMENT_NODE_T* old_root = herb_parse(old_source.c_str(), &parser_options, &old_allocator);
   AST_DOCUMENT_NODE_T* new_root = herb_parse(new_source.c_str(), &parser_options, &new_allocator);
@@ -234,7 +241,7 @@ val Herb_diff(const std::string& old_source, const std::string& new_source) {
     return val::null();
   }
 
-  herb_diff_result_T* diff_result = herb_diff(old_root, new_root, &diff_allocator);
+  herb_diff_result_T* diff_result = herb_diff(old_root, new_root, &diff_options, &diff_allocator);
 
   val result = val::object();
   result.set("identical", diff_result->trees_identical);


### PR DESCRIPTION
This pull request updates the Syntax Tree Diff Engine so that whitespace changes HTML collapses away no longer produce a changeset, and adds an opt-in option for callers that do want to see them.

Outside of whitespace preserving elements, HTML collapses every run of whitespace into a single space. Going from `0` to `1` space or from `1` to `0` changes what gets rendered, but going from `1` to `n` does not. The diff engine compared `HTMLTextNode` content byte for byte, so it reported all three the same way:

```ruby
Herb.diff("<div>Hello World</div>", "<div>Hello     World</div>")
# => #<Herb::DiffResult 1 operation>  (:text_changed)
```

Reindenting a template therefore produced a changeset with nothing to apply, and `Herb::Dev::Runner` broadcast a patch for a file that renders identically.

#### How it works

`HTMLTextNode` content is now compared with whitespace runs collapsed, so a run that only grows or shrinks is not a difference:

```ruby
Herb.diff("<div>Hello World</div>", "<div>Hello     World</div>").identical?  # => true
Herb.diff("<div>Hello\n\tWorld</div>", "<div>Hello World</div>").identical?  # => true
Herb.diff("<div>Hello World</div>", "<div>HelloWorld</div>").identical?      # => false
Herb.diff("<div>Hello</div>", "<div>Hello </div>").identical?                # => false
```

The same applies to the whitespace between elements, which the parser also stores as `HTMLTextNode`s, so reindenting a nested element is no longer a change:

```html+erb
<div>
  <span>Hello</span>
</div>
```

```html+erb
<div>
      <span>Hello</span>
</div>
```

Removing that whitespace entirely still is, and comes through as `node_removed`.

Inside `pre`, `textarea`, `script`, and `style` every whitespace change stays significant, so the comparison there remains byte exact. A new `is_whitespace_preserving_element()` predicate in `html_util` drives this, and the flag is inherited by everything nested inside such an element, including ERB blocks:

```html+erb
<pre><% if condition %>Hello     World<% end %></pre>
```

Attribute values and ERB content are untouched, since neither is subject to HTML whitespace collapsing.

One consequence worth calling out: `trees_identical` is now "no operations were emitted" rather than "the root hashes matched". That keeps the existing `identical? == operations.empty?` invariant, which would otherwise break the moment an operation is suppressed, and it means `Herb::Dev::Runner` still returns early on formatting only saves instead of broadcasting an empty patch.

#### Ruby API

```ruby
Herb.diff(old_source, new_source, detect_whitespace_changes: true)
# => #<Herb::DiffResult 1 operation>  (:whitespace_changed)
```

#### JavaScript API

```ts
Herb.diff(oldSource, newSource, { detect_whitespace_changes: true })
```

#### Rust API

```rust
herb::diff_with_options(old_source, new_source, &DiffOptions { detect_whitespace_changes: true })
```

#### Java API

```java
Herb.diff(oldSource, newSource, new DiffOptions().detectWhitespaceChanges(true));
```

Resolves #1983