### PR TITLE
Linter: Implement autofix for `erb-no-output-control-flow`

### DIFF
--- a/javascript/packages/linter/src/linter.ts
+++ b/javascript/packages/linter/src/linter.ts
@@ -659,7 +659,7 @@ export class Linter {
         }
 
         if (offense.autofixContext) {
-          const originalNodeType = offense.autofixContext.node.type
+          const originalNodeType = offense.autofixContext.nodeType ?? offense.autofixContext.node.type
           const location: Location = offense.autofixContext.node.location ? Location.from(offense.autofixContext.node.location) : offense.location
 
           const freshNode = findNodeByLocation(

--- a/javascript/packages/linter/src/rules/erb-no-output-control-flow.ts
+++ b/javascript/packages/linter/src/rules/erb-no-output-control-flow.ts
@@ -1,10 +1,16 @@
 import { BaseRuleVisitor } from "./rule-utils.js"
-import { ParserRule } from "../types.js"
+import { ParserRule, BaseAutofixContext, Mutable } from "../types.js"
 
-import type { ParseResult, ERBIfNode, ERBUnlessNode, ERBElseNode, ERBEndNode, ERBIterationBlockNode, ParserOptions } from "@herb-tools/core"
-import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types.js"
+import type { ParseResult, ERBIfNode, ERBUnlessNode, ERBElseNode, ERBEndNode, ERBIterationBlockNode, ERBBlockNode, ParserOptions } from "@herb-tools/core"
+import type { UnboundLintOffense, LintOffense, LintContext, FullRuleConfig } from "../types.js"
 
-class ERBNoOutputControlFlowRuleVisitor extends BaseRuleVisitor {
+type OutputControlFlowNode = ERBIfNode | ERBUnlessNode | ERBElseNode | ERBEndNode | ERBIterationBlockNode | ERBBlockNode
+
+interface ERBNoOutputControlFlowAutofixContext extends BaseAutofixContext {
+  node: Mutable<OutputControlFlowNode>
+}
+
+class ERBNoOutputControlFlowRuleVisitor extends BaseRuleVisitor<ERBNoOutputControlFlowAutofixContext> {
   visitERBIfNode(node: ERBIfNode): void {
     this.checkOutputControlFlow(node)
     this.visitChildNodes(node)
@@ -45,6 +51,7 @@ class ERBNoOutputControlFlowRuleVisitor extends BaseRuleVisitor {
     this.addOffense(
       `Iteration blocks like \`${method}\` should not be used with output tags, they return the collection instead of the rendered output. Use \`${suggestion}\` instead.`,
       openTag.location,
+      { node: node as Mutable<ERBIterationBlockNode>, nodeType: "AST_ERB_BLOCK_NODE" },
     )
   }
 
@@ -72,14 +79,16 @@ class ERBNoOutputControlFlowRuleVisitor extends BaseRuleVisitor {
       this.addOffense(
         `Control flow statements like \`${keyword}\` should not be used with output tags. Use \`${suggestion}\` instead.`,
         openTag.location,
+        { node: controlBlock as Mutable<OutputControlFlowNode> },
       )
     }
   }
 }
 
-export class ERBNoOutputControlFlowRule extends ParserRule {
+export class ERBNoOutputControlFlowRule extends ParserRule<ERBNoOutputControlFlowAutofixContext> {
   static ruleName = "erb-no-output-control-flow"
   static introducedIn = this.version("0.4.0")
+  static autocorrectable = true
 
   get defaultConfig(): FullRuleConfig {
     return {
@@ -94,11 +103,24 @@ export class ERBNoOutputControlFlowRule extends ParserRule {
     }
   }
 
-  check(result: ParseResult, context?: Partial<LintContext>): UnboundLintOffense[] {
+  check(result: ParseResult, context?: Partial<LintContext>): UnboundLintOffense<ERBNoOutputControlFlowAutofixContext>[] {
     const visitor = new ERBNoOutputControlFlowRuleVisitor(this.ruleName, context)
 
     visitor.visit(result.value)
 
     return visitor.offenses
+  }
+
+  autofix(offense: LintOffense<ERBNoOutputControlFlowAutofixContext>, result: ParseResult, _context?: Partial<LintContext>): ParseResult | null {
+    if (!offense.autofixContext) return null
+
+    const { node } = offense.autofixContext
+
+    if (!node.tag_opening) return null
+    if (node.tag_opening.value !== "<%=") return null
+
+    node.tag_opening.value = "<%"
+
+    return result
   }
 }

--- a/javascript/packages/linter/src/types.ts
+++ b/javascript/packages/linter/src/types.ts
@@ -37,6 +37,8 @@ export interface BaseAutofixContext {
   node: Mutable<Node>
   /** If true, this fix requires --fix-unsafely to be applied */
   unsafe?: boolean
+  /** Node type to match when re-finding the node in the re-parsed tree. Defaults to the type of `node` */
+  nodeType?: string
 }
 
 /**

--- a/javascript/packages/linter/test/autofix/erb-no-output-control-flow.autofix.test.ts
+++ b/javascript/packages/linter/test/autofix/erb-no-output-control-flow.autofix.test.ts
@@ -1,0 +1,187 @@
+import dedent from "dedent"
+
+import { describe, test, expect, beforeAll } from "vitest"
+
+import { Herb } from "@herb-tools/node-wasm"
+import { Linter } from "../../src/linter.js"
+
+import { ERBNoOutputControlFlowRule } from "../../src/rules/erb-no-output-control-flow.js"
+
+describe("erb-no-output-control-flow autofix", () => {
+  beforeAll(async () => {
+    await Herb.load()
+  })
+
+  test("when control flow already uses non-output tags", () => {
+    const input = dedent`
+      <% if condition? %>
+        <p>Content</p>
+      <% elsif other_condition? %>
+        <p>Content</p>
+      <% else %>
+        <p>Content</p>
+      <% end %>
+    `
+
+    const linter = new Linter(Herb, [ERBNoOutputControlFlowRule])
+    const result = linter.autofix(input, { fileName: 'test.html.erb' })
+
+    expect(result.source).toBe(input)
+    expect(result.fixed).toHaveLength(0)
+    expect(result.unfixed).toHaveLength(0)
+  })
+
+  test("when an if block uses an output tag", () => {
+    const input = dedent`
+      <%= if condition? %>
+        <p>Content</p>
+      <% end %>
+    `
+
+    const expected = dedent`
+      <% if condition? %>
+        <p>Content</p>
+      <% end %>
+    `
+
+    const linter = new Linter(Herb, [ERBNoOutputControlFlowRule])
+    const result = linter.autofix(input, { fileName: 'test.html.erb' })
+
+    expect(result.source).toBe(expected)
+    expect(result.fixed).toHaveLength(1)
+    expect(result.unfixed).toHaveLength(0)
+  })
+
+  test("when an unless block uses an output tag", () => {
+    const input = dedent`
+      <%= unless condition? %>
+        <p>Content</p>
+      <% end %>
+    `
+
+    const expected = dedent`
+      <% unless condition? %>
+        <p>Content</p>
+      <% end %>
+    `
+
+    const linter = new Linter(Herb, [ERBNoOutputControlFlowRule])
+    const result = linter.autofix(input, { fileName: 'test.html.erb' })
+
+    expect(result.source).toBe(expected)
+    expect(result.fixed).toHaveLength(1)
+    expect(result.unfixed).toHaveLength(0)
+  })
+
+  test("when elsif, else and end use output tags", () => {
+    const input = dedent`
+      <% if condition? %>
+        <p>Content</p>
+      <%= elsif another_condition? %>
+        <p>Content</p>
+      <%= else %>
+        <p>Content</p>
+      <%= end %>
+    `
+
+    const expected = dedent`
+      <% if condition? %>
+        <p>Content</p>
+      <% elsif another_condition? %>
+        <p>Content</p>
+      <% else %>
+        <p>Content</p>
+      <% end %>
+    `
+
+    const linter = new Linter(Herb, [ERBNoOutputControlFlowRule])
+    const result = linter.autofix(input, { fileName: 'test.html.erb' })
+
+    expect(result.source).toBe(expected)
+    expect(result.fixed).toHaveLength(3)
+    expect(result.unfixed).toHaveLength(0)
+  })
+
+  test("when an iteration block uses an output tag", () => {
+    const input = dedent`
+      <%= items.each do |item| %>
+        <li><%= item %></li>
+      <% end %>
+    `
+
+    const expected = dedent`
+      <% items.each do |item| %>
+        <li><%= item %></li>
+      <% end %>
+    `
+
+    const linter = new Linter(Herb, [ERBNoOutputControlFlowRule])
+    const result = linter.autofix(input, { fileName: 'test.html.erb' })
+
+    expect(result.source).toBe(expected)
+    expect(result.fixed).toHaveLength(1)
+    expect(result.unfixed).toHaveLength(0)
+  })
+
+  test("preserves trim tags when fixing", () => {
+    const input = dedent`
+      <%= if condition? -%>
+        <p>Content</p>
+      <% end %>
+    `
+
+    const expected = dedent`
+      <% if condition? -%>
+        <p>Content</p>
+      <% end %>
+    `
+
+    const linter = new Linter(Herb, [ERBNoOutputControlFlowRule])
+    const result = linter.autofix(input, { fileName: 'test.html.erb' })
+
+    expect(result.source).toBe(expected)
+    expect(result.fixed).toHaveLength(1)
+    expect(result.unfixed).toHaveLength(0)
+  })
+
+  test("fixes nested control flow blocks", () => {
+    const input = dedent`
+      <% unless something? %>
+        <%= if condition? %>
+          <p>Content</p>
+        <% end %>
+      <% end %>
+    `
+
+    const expected = dedent`
+      <% unless something? %>
+        <% if condition? %>
+          <p>Content</p>
+        <% end %>
+      <% end %>
+    `
+
+    const linter = new Linter(Herb, [ERBNoOutputControlFlowRule])
+    const result = linter.autofix(input, { fileName: 'test.html.erb' })
+
+    expect(result.source).toBe(expected)
+    expect(result.fixed).toHaveLength(1)
+    expect(result.unfixed).toHaveLength(0)
+  })
+
+  test("does not touch output tags that are not control flow", () => {
+    const input = dedent`
+      <%= yield(:header) if content_for?(:header) %>
+      <%= content_tag :div do %>
+        <span>content</span>
+      <% end %>
+    `
+
+    const linter = new Linter(Herb, [ERBNoOutputControlFlowRule])
+    const result = linter.autofix(input, { fileName: 'test.html.erb' })
+
+    expect(result.source).toBe(input)
+    expect(result.fixed).toHaveLength(0)
+    expect(result.unfixed).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
Follow up on #2008.

This pull request makes `erb-no-output-control-flow` autocorrectable. Now that the offense message spells out the exact replacement, the rule can also apply it. The fix is a single token mutation, `<%=` becomes `<%`, which covers every shape the rule reports: `if`, `unless`, `elsif`, `else`, `end` and iteration blocks.

```diff
- <%= if condition? %>
+ <% if condition? %>
    <p>Content</p>
- <%= elsif another_condition? %>
+ <% elsif another_condition? %>
    <p>Content</p>
- <%= end %>
+ <% end %>
```