### PR TITLE
Playground: Throttle URL updates to avoid `replaceState` limit

### DIFF
--- a/playground/src/controllers/playground_controller.js
+++ b/playground/src/controllers/playground_controller.js
@@ -20,6 +20,8 @@ import { analyzeRuby } from "../analyze-ruby"
 window.Herb = Herb
 window.analyze = analyze
 
+const URL_UPDATE_THROTTLE = 100
+
 const exampleFile = dedent`
   <!-- Example HTML+ERB File -->
 
@@ -142,6 +144,11 @@ export default class extends Controller {
     "diffCheckButton",
     "diffParseError",
   ]
+
+  pendingHash = null
+  pendingSearch = null
+  urlUpdateTimeout = null
+  lastURLUpdateAt = 0
 
   get isRubyMode() {
     return this.modeValue === "ruby"
@@ -286,6 +293,13 @@ export default class extends Controller {
 
   disconnect() {
     window.removeEventListener("popstate", this.handlePopState)
+
+    if (this.urlUpdateTimeout !== null) {
+      clearTimeout(this.urlUpdateTimeout)
+      this.urlUpdateTimeout = null
+      this.flushURLUpdate()
+    }
+
     this.removeTooltip()
     this.removeAutofixTooltip()
     this.removeAutofixUnsafeTooltip()
@@ -309,7 +323,7 @@ export default class extends Controller {
   }
 
   updateURL() {
-    window.parent.location.hash = this.compressedValue
+    this.queueURLUpdate({ hash: this.compressedValue })
 
     if (!this.isRubyMode) {
       const options = this.getParserOptions()
@@ -321,6 +335,61 @@ export default class extends Controller {
       this.setFormatterOptionsInURL(formatterOptions)
       this.setAutofixOptionsInURL(autofixOptions)
     }
+  }
+
+  updateSearchParams(update) {
+    const params = new URLSearchParams(
+      this.pendingSearch !== null ? this.pendingSearch : window.parent.location.search,
+    )
+
+    update(params)
+
+    this.queueURLUpdate({ search: params.toString() })
+  }
+
+  queueURLUpdate({ hash, search }) {
+    if (hash !== undefined) this.pendingHash = hash
+    if (search !== undefined) this.pendingSearch = search
+
+    if (this.urlUpdateTimeout !== null) return
+    if (!this.hasPendingURLUpdate) return
+
+    const elapsed = Date.now() - this.lastURLUpdateAt
+
+    this.urlUpdateTimeout = setTimeout(() => {
+      this.urlUpdateTimeout = null
+      this.flushURLUpdate()
+    }, Math.max(0, URL_UPDATE_THROTTLE - elapsed))
+  }
+
+  get hasPendingURLUpdate() {
+    const location = window.parent.location
+
+    if (this.pendingHash !== null && this.pendingHash !== location.hash.slice(1)) return true
+    if (this.pendingSearch !== null && this.pendingSearch !== new URLSearchParams(location.search).toString()) return true
+
+    return false
+  }
+
+  flushURLUpdate() {
+    const location = window.parent.location
+    const hash = this.pendingHash
+    const search = this.pendingSearch
+
+    this.pendingHash = null
+    this.pendingSearch = null
+    this.lastURLUpdateAt = Date.now()
+
+    if (hash !== null && hash !== location.hash.slice(1)) {
+      location.hash = hash
+    }
+
+    if (search === null || search === new URLSearchParams(location.search).toString()) return
+
+    const url = new URL(location)
+    url.search = search
+
+    window.parent.history.replaceState({}, '', url)
   }
 
   async insert(event) {
@@ -606,19 +675,17 @@ export default class extends Controller {
   }
 
   updateTabInURL(tabName) {
-    const url = new URL(window.parent.location)
+    this.updateSearchParams((params) => {
+      if (tabName && tabName !== 'parse') {
+        params.set('tab', tabName)
+      } else {
+        params.delete('tab')
+      }
 
-    if (tabName && tabName !== 'parse') {
-      url.searchParams.set('tab', tabName)
-    } else {
-      url.searchParams.delete('tab')
-    }
-
-    if (tabName !== 'diagnostics') {
-      url.searchParams.delete('diagnosticsFilter')
-    }
-
-    window.parent.history.replaceState({}, '', url)
+      if (tabName !== 'diagnostics') {
+        params.delete('diagnosticsFilter')
+      }
+    })
   }
 
   getClosestButton(element) {
@@ -1973,8 +2040,6 @@ export default class extends Controller {
   }
 
   setOptionsInURL(options) {
-    const url = new URL(window.parent.location)
-
     const defaults = {
       track_whitespace: false,
       analyze: true,
@@ -2002,18 +2067,16 @@ export default class extends Controller {
       }
     })
 
-    if (Object.keys(nonDefaultOptions).length > 0) {
-      url.searchParams.set('options', JSON.stringify(nonDefaultOptions))
-    } else {
-      url.searchParams.delete('options')
-    }
-
-    window.parent.history.replaceState({}, '', url)
+    this.updateSearchParams((params) => {
+      if (Object.keys(nonDefaultOptions).length > 0) {
+        params.set('options', JSON.stringify(nonDefaultOptions))
+      } else {
+        params.delete('options')
+      }
+    })
   }
 
   setPrinterOptionsInURL(printerOptions) {
-    const url = new URL(window.parent.location)
-
     const defaults = {
       ignoreErrors: false,
     }
@@ -2029,13 +2092,13 @@ export default class extends Controller {
       }
     })
 
-    if (Object.keys(nonDefaultPrinterOptions).length > 0) {
-      url.searchParams.set('printerOptions', JSON.stringify(nonDefaultPrinterOptions))
-    } else {
-      url.searchParams.delete('printerOptions')
-    }
-
-    window.parent.history.replaceState({}, '', url)
+    this.updateSearchParams((params) => {
+      if (Object.keys(nonDefaultPrinterOptions).length > 0) {
+        params.set('printerOptions', JSON.stringify(nonDefaultPrinterOptions))
+      } else {
+        params.delete('printerOptions')
+      }
+    })
   }
 
   getPrinterOptionsFromURL() {
@@ -2054,8 +2117,6 @@ export default class extends Controller {
   }
 
   setFormatterOptionsInURL(formatterOptions) {
-    const url = new URL(window.parent.location)
-
     const nonDefaultFormatterOptions = {}
 
     Object.keys(formatterOptions).forEach(key => {
@@ -2064,13 +2125,13 @@ export default class extends Controller {
       }
     })
 
-    if (Object.keys(nonDefaultFormatterOptions).length > 0) {
-      url.searchParams.set('formatterOptions', JSON.stringify(nonDefaultFormatterOptions))
-    } else {
-      url.searchParams.delete('formatterOptions')
-    }
-
-    window.parent.history.replaceState({}, '', url)
+    this.updateSearchParams((params) => {
+      if (Object.keys(nonDefaultFormatterOptions).length > 0) {
+        params.set('formatterOptions', JSON.stringify(nonDefaultFormatterOptions))
+      } else {
+        params.delete('formatterOptions')
+      }
+    })
   }
 
   getFormatterOptionsFromURL() {
@@ -2089,8 +2150,6 @@ export default class extends Controller {
   }
 
   setAutofixOptionsInURL(autofixOptions) {
-    const url = new URL(window.parent.location)
-
     const defaults = {
       includeUnsafe: false,
     }
@@ -2106,13 +2165,13 @@ export default class extends Controller {
       }
     })
 
-    if (Object.keys(nonDefaultAutofixOptions).length > 0) {
-      url.searchParams.set('autofixOptions', JSON.stringify(nonDefaultAutofixOptions))
-    } else {
-      url.searchParams.delete('autofixOptions')
-    }
-
-    window.parent.history.replaceState({}, '', url)
+    this.updateSearchParams((params) => {
+      if (Object.keys(nonDefaultAutofixOptions).length > 0) {
+        params.set('autofixOptions', JSON.stringify(nonDefaultAutofixOptions))
+      } else {
+        params.delete('autofixOptions')
+      }
+    })
   }
 
   getAutofixOptionsFromURL() {
@@ -2142,15 +2201,13 @@ export default class extends Controller {
   }
 
   updateDiagnosticsFilterInURL(filter) {
-    const url = new URL(window.parent.location)
-
-    if (filter && filter !== 'all') {
-      url.searchParams.set('diagnosticsFilter', filter)
-    } else {
-      url.searchParams.delete('diagnosticsFilter')
-    }
-
-    window.parent.history.replaceState({}, '', url)
+    this.updateSearchParams((params) => {
+      if (filter && filter !== 'all') {
+        params.set('diagnosticsFilter', filter)
+      } else {
+        params.delete('diagnosticsFilter')
+      }
+    })
   }
 
   updateDiagnosticsViewer(diagnostics) {


### PR DESCRIPTION
This pull request updates the playground to throttle its URL updates so that typing quickly in the editor no longer trips the browser's `history.replaceState()` rate limit.

Every keystroke called four separate URL writers. Each of them built its own `URL` and unconditionally called `window.parent.history.replaceState()`, even when the search params were already identical to what was in the URL. That adds up to four `replaceState()` calls per keystroke, so Safari's limit of 100 calls per 10 seconds is reached after roughly 25 characters of fast typing:

```
Unhandled Promise Rejection: SecurityError: Attempt to use history.replaceState() more than 100 times per 10 seconds
```

Because the `SecurityError` is thrown from inside `updateURL()`, which is the first thing `analyze()` does, the rejection aborts the whole analysis and the playground stops responding to further input.