### PR TITLE
Linter: Implement `actionview-no-redundant-local-assigns` rule

### DIFF
--- a/javascript/packages/linter/docs/rules/README.md
+++ b/javascript/packages/linter/docs/rules/README.md
@@ -19,6 +19,7 @@ This page contains documentation for all Herb Linter rules.
 #### Action View
 
 - [`actionview-no-helper-shadowing`](./actionview-no-helper-shadowing.md) - Disallow shadowing Action View helpers with block variables
+- [`actionview-no-redundant-local-assigns`](./actionview-no-redundant-local-assigns.md) - Disallow `local_assigns` reads that the strict locals declaration already answers
 - [`actionview-no-silent-helper`](./actionview-no-silent-helper.md) - Disallow silent ERB tags for Action View helpers
 - [`actionview-no-silent-render`](./actionview-no-silent-render.md) - Disallow calling `render` without outputting the result
 - [`actionview-no-unnecessary-html-safe`](./actionview-no-unnecessary-html-safe.md) - Disallow calling `.html_safe` on String literals

--- a/javascript/packages/linter/docs/rules/actionview-no-redundant-local-assigns.md
+++ b/javascript/packages/linter/docs/rules/actionview-no-redundant-local-assigns.md
@@ -1,0 +1,70 @@
+# Linter Rule: Disallow `local_assigns` reads that the strict locals declaration already answers
+
+**Rule:** `actionview-no-redundant-local-assigns`
+
+## Description
+
+Detects `local_assigns` lookups in a partial that already has a `<%# locals: (...) %>` declaration, where the declaration makes the lookup either redundant or dead.
+
+## Rationale
+
+`local_assigns` is the documented way to read locals in a partial that has no strict locals declaration, and it stays useful in a partial that has one. Once a declaration exists, though, some of those lookups are answered by the declaration itself and only obscure what the template does.
+
+A required local is already a local variable, so reading it back out of the hash is a longer way to write the name. A required local is also always present, so asking `local_assigns.key?` about it is a condition that can only take one branch. And a name the declaration does not mention can never arrive, because Rails raises `ActionView::StrictLocalsError` for callers that pass an undeclared local, so a lookup for it is dead code.
+
+Optional locals are left alone. `local_assigns.key?(:size)` is the only way to tell "not passed" apart from "passed as `nil`", which a default value cannot express, so that check is a legitimate pattern rather than an offense. Partials with a `**` keyword rest in the declaration are skipped as well, since undeclared locals can legitimately arrive there.
+
+Partials without a strict locals declaration are not checked at all.
+
+## Examples
+
+### ✅ Good
+
+```erb
+<%# locals: (user:) %>
+
+<%= user.name %>
+```
+
+```erb
+<%# locals: (user:, size: nil) %>
+
+<%= user.name %>
+<% if local_assigns.key?(:size) %>
+  <span><%= size %></span>
+<% end %>
+```
+
+```erb
+<%# locals: (user:, **) %>
+
+<%= render "row", **local_assigns %>
+```
+
+### 🚫 Bad
+
+```erb
+<%# locals: (user:) %>
+
+<%= local_assigns[:user].name %>
+```
+
+```erb
+<%# locals: (user:) %>
+
+<% if local_assigns.key?(:user) %>
+  <%= user.name %>
+<% end %>
+```
+
+```erb
+<%# locals: (user:) %>
+
+<%= user.name %>
+<%= local_assigns.fetch(:size, "large") %>
+```
+
+## References
+
+- [Action View - Strict Locals](https://guides.rubyonrails.org/action_view_overview.html#strict-locals)
+- [Action View - Using `local_assigns`](https://guides.rubyonrails.org/action_view_overview.html#using-local-assigns)

--- a/javascript/packages/linter/src/rules.ts
+++ b/javascript/packages/linter/src/rules.ts
@@ -11,6 +11,7 @@ import { A11yNoRedundantImageAltRule } from "./rules/a11y-no-redundant-image-alt
 import { A11ySVGHasAccessibleTextRule } from "./rules/a11y-svg-has-accessible-text.js"
 
 import { ActionViewNoHelperShadowingRule } from "./rules/actionview-no-helper-shadowing.js"
+import { ActionViewNoRedundantLocalAssignsRule } from "./rules/actionview-no-redundant-local-assigns.js"
 import { ActionViewNoSilentHelperRule } from "./rules/actionview-no-silent-helper.js"
 import { ActionViewNoSilentRenderRule } from "./rules/actionview-no-silent-render.js"
 import { ActionViewNoUnnecessaryHTMLSafeRule } from "./rules/actionview-no-unnecessary-html-safe.js"
@@ -132,6 +133,7 @@ export const rules: RuleClass[] = [
   A11ySVGHasAccessibleTextRule,
 
   ActionViewNoHelperShadowingRule,
+  ActionViewNoRedundantLocalAssignsRule,
   ActionViewNoSilentHelperRule,
   ActionViewNoSilentRenderRule,
   ActionViewNoUnnecessaryHTMLSafeRule,

--- a/javascript/packages/linter/src/rules/actionview-no-redundant-local-assigns.ts
+++ b/javascript/packages/linter/src/rules/actionview-no-redundant-local-assigns.ts
@@ -1,0 +1,179 @@
+import { ParserRule } from "../types.js"
+import { PrismVisitor, Visitor } from "@herb-tools/core"
+
+import { isPrismNodeType, isRubyParameterNode, locationFromByteOffset } from "@herb-tools/core"
+import { isPartialFile } from "./file-utils.js"
+
+import type { DocumentNode, ERBStrictLocalsNode, ParseResult, ParserOptions, PrismNodes, RubyParameterNode } from "@herb-tools/core"
+import type { FullRuleConfig, LintContext, UnboundLintOffense } from "../types.js"
+
+const KEYWORD_KIND = "keyword"
+const KEYWORD_REST_KIND = "keyword_rest"
+const LOCAL_ASSIGNS = "local_assigns"
+
+const VALUE_LOOKUPS = ["[]", "fetch", "dig"]
+const PRESENCE_LOOKUPS = ["key?", "has_key?", "include?", "member?"]
+
+interface Lookup {
+  name: string
+  method: string
+  presence: boolean
+  extraArguments: boolean
+  startOffset: number
+  length: number
+}
+
+class StrictLocalsCollector extends Visitor {
+  hasDeclaration = false
+  hasKeywordRest = false
+
+  readonly locals = new Map<string, RubyParameterNode>()
+
+  visitERBStrictLocalsNode(node: ERBStrictLocalsNode): void {
+    this.hasDeclaration = true
+
+    for (const local of node.locals) {
+      if (!isRubyParameterNode(local)) continue
+
+      if (local.kind === KEYWORD_REST_KIND) {
+        this.hasKeywordRest = true
+        continue
+      }
+
+      if (local.kind !== KEYWORD_KIND) continue
+
+      const name = local.name?.value
+
+      if (name) this.locals.set(name, local)
+    }
+  }
+}
+
+class LocalAssignsLookupCollector extends PrismVisitor {
+  readonly lookups: Lookup[] = []
+
+  override visitCallNode(node: PrismNodes.CallNode): void {
+    const lookup = this.lookupFor(node)
+
+    if (lookup) this.lookups.push(lookup)
+
+    this.visitChildNodes(node)
+  }
+
+  private lookupFor(node: PrismNodes.CallNode): Lookup | null {
+    const presence = PRESENCE_LOOKUPS.includes(node.name)
+
+    if (!presence && !VALUE_LOOKUPS.includes(node.name)) return null
+    if (!this.isLocalAssignsRead(node.receiver)) return null
+
+    const argumentNodes = node.arguments_?.arguments_ ?? []
+    const [first, ...rest] = argumentNodes
+
+    if (!isPrismNodeType(first, "SymbolNode")) return null
+    if (rest.length > 0 && node.name !== "fetch") return null
+    if (rest.length > 1) return null
+
+    const name = first.unescaped?.value
+
+    if (!name) return null
+
+    return {
+      name,
+      method: node.name,
+      presence,
+      extraArguments: rest.length > 0,
+      startOffset: node.location.startOffset,
+      length: node.location.length,
+    }
+  }
+
+  private isLocalAssignsRead(node: PrismNodes.Node | null): boolean {
+    if (!isPrismNodeType(node, "CallNode")) return false
+    if (node.receiver !== null) return false
+
+    return node.name === LOCAL_ASSIGNS
+  }
+}
+
+export class ActionViewNoRedundantLocalAssignsRule extends ParserRule {
+  static ruleName = "actionview-no-redundant-local-assigns"
+  static introducedIn = this.version("unreleased")
+
+  get defaultConfig(): FullRuleConfig {
+    return {
+      enabled: true,
+      severity: {
+        cli: "error",
+        editor: "info",
+      },
+    }
+  }
+
+  get parserOptions(): Partial<ParserOptions> {
+    return {
+      strict_locals: true,
+      prism_program: true,
+    }
+  }
+
+  check(result: ParseResult, context?: Partial<LintContext>): UnboundLintOffense[] {
+    if (isPartialFile(context?.fileName) === false) return []
+
+    const document = result.value
+    const source = document.source
+    const program = document.prismNode
+
+    if (!source || !program) return []
+
+    const declaration = this.declarationFor(document)
+
+    if (!declaration.hasDeclaration) return []
+
+    const collector = new LocalAssignsLookupCollector()
+
+    collector.visit(program)
+
+    return collector.lookups.flatMap(lookup => {
+      const message = this.messageFor(lookup, declaration)
+
+      if (!message) return []
+
+      const location = locationFromByteOffset(source, lookup.startOffset, lookup.length)
+
+      return [this.createOffense(message, location, undefined, undefined, ["unnecessary"])]
+    })
+  }
+
+  private declarationFor(document: DocumentNode): StrictLocalsCollector {
+    const collector = new StrictLocalsCollector()
+
+    collector.visit(document)
+
+    return collector
+  }
+
+  private messageFor(lookup: Lookup, declaration: StrictLocalsCollector): string | null {
+    const local = declaration.locals.get(lookup.name)
+    const source = this.lookupSource(lookup)
+
+    if (!local) {
+      if (declaration.hasKeywordRest) return null
+
+      return `\`${lookup.name}\` is not declared in the \`locals:\` declaration, so Rails raises if a caller passes it and \`${source}\` can never find it. Declare \`${lookup.name}:\` in the declaration, or remove the lookup.`
+    }
+
+    if (!local.required) return null
+
+    if (lookup.presence) {
+      return `Strict local \`${lookup.name}\` is required, so \`${source}\` is always \`true\`. Remove the condition, or give \`${lookup.name}\` a default value to make it optional.`
+    }
+
+    return `Strict local \`${lookup.name}\` is already a local variable in this partial, so \`${source}\` reads back a value that is already in scope. Use \`${lookup.name}\` instead.`
+  }
+
+  private lookupSource(lookup: Lookup): string {
+    const argument = lookup.extraArguments ? `:${lookup.name}, ...` : `:${lookup.name}`
+
+    return lookup.method === "[]" ? `${LOCAL_ASSIGNS}[${argument}]` : `${LOCAL_ASSIGNS}.${lookup.method}(${argument})`
+  }
+}

--- a/javascript/packages/linter/src/rules/index.ts
+++ b/javascript/packages/linter/src/rules/index.ts
@@ -16,6 +16,7 @@ export * from "./action-view-utils.js"
 export * from "./herb-disable-comment-base.js"
 
 export * from "./actionview-no-helper-shadowing.js"
+export * from "./actionview-no-redundant-local-assigns.js"
 export * from "./actionview-no-silent-helper.js"
 export * from "./actionview-no-silent-render.js"
 export * from "./actionview-no-unnecessary-html-safe.js"

--- a/javascript/packages/linter/test/__snapshots__/cli.test.ts.snap
+++ b/javascript/packages/linter/test/__snapshots__/cli.test.ts.snap
@@ -19,7 +19,7 @@ test-file-with-errors.html.erb:
   Failing      2 errors (2 offenses across 1 file)
   Not failing  1 warning (1 offense across 1 file, below --fail-level=error)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        111 enabled | all rules via --all-rules"
+  Rules        112 enabled | all rules via --all-rules"
 `;
 
 exports[`CLI Output Formatting > \`all\` pseudo rule in .herb.yml > \`Rules\` summary line > \`--only\` replaces the counts from a disabled \`all\` 1`] = `
@@ -50,7 +50,7 @@ exports[`CLI Output Formatting > \`all\` pseudo rule in .herb.yml > \`Rules\` su
   Checked      1 file
   Offenses     0 offenses
   Fixable      0 offenses
-  Rules        0 enabled | 111 not enabled
+  Rules        0 enabled | 112 not enabled
 
  No rules enabled:
   Every linter rule is turned off, so no offenses can be reported.
@@ -71,7 +71,7 @@ exports[`CLI Output Formatting > \`all\` pseudo rule in .herb.yml > \`Rules\` su
   Checked      1 file
   Offenses     0 offenses
   Fixable      0 offenses
-  Rules        0 enabled | 111 not enabled
+  Rules        0 enabled | 112 not enabled
 
  No rules enabled:
   Every linter rule is turned off, so no offenses can be reported.
@@ -102,7 +102,7 @@ test-file-with-errors.html.erb:
   Failing      2 errors (2 offenses across 1 file)
   Not failing  1 warning (1 offense across 1 file, below --fail-level=error)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        111 enabled"
+  Rules        112 enabled"
 `;
 
 exports[`CLI Output Formatting > \`all\` pseudo rule in .herb.yml > \`Rules\` summary line > \`all: enabled: true\` reports no version-skipped rules 1`] = `
@@ -124,7 +124,7 @@ test-file-with-errors.html.erb:
   Failing      2 errors (2 offenses across 1 file)
   Not failing  1 warning (1 offense across 1 file, below --fail-level=error)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        111 enabled"
+  Rules        112 enabled"
 `;
 
 exports[`CLI Output Formatting > \`all\` pseudo rule in .herb.yml > \`Rules\` summary line > reports enabled and not-enabled rules when no \`all\` is configured 1`] = `
@@ -146,7 +146,7 @@ test/fixtures/test-file-with-errors.html.erb:
   Failing      2 errors (2 offenses across 1 file)
   Not failing  1 warning (1 offense across 1 file, below --fail-level=error)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        95 enabled | 16 not enabled"
+  Rules        96 enabled | 16 not enabled"
 `;
 
 exports[`CLI Output Formatting > \`all\` pseudo rule in .herb.yml > \`Rules\` summary line > rules opted back in on top of \`all: enabled: false\` count as enabled 1`] = `
@@ -165,7 +165,7 @@ test-file-with-errors.html.erb:
   Failing      0 offenses
   Not failing  1 warning (1 offense across 1 file, below --fail-level=error)
   Fixable      0 offenses
-  Rules        1 enabled | 110 not enabled"
+  Rules        1 enabled | 111 not enabled"
 `;
 
 exports[`CLI Output Formatting > \`all\` pseudo rule in .herb.yml > \`Rules\` summary line > rules opted out on top of \`all: enabled: true\` count as disabled 1`] = `
@@ -184,7 +184,7 @@ test-file-with-errors.html.erb:
   Checked      1 file
   Offenses     2 errors (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        110 enabled | 1 disabled"
+  Rules        111 enabled | 1 disabled"
 `;
 
 exports[`CLI Output Formatting > --all-rules > reports every offense for the fixture with --all-rules 1`] = `
@@ -214,7 +214,7 @@ test/fixtures/all-rules.html.erb:
   Failing      0 offenses
   Not failing  6 warnings (6 offenses across 1 file, below --fail-level=error)
   Fixable      0 offenses
-  Rules        111 enabled | all rules via --all-rules"
+  Rules        112 enabled | all rules via --all-rules"
 `;
 
 exports[`CLI Output Formatting > --all-rules > reports nothing for the fixture with the default rule set 1`] = `
@@ -226,7 +226,7 @@ exports[`CLI Output Formatting > --all-rules > reports nothing for the fixture w
   Checked      1 file
   Offenses     0 offenses
   Fixable      0 offenses
-  Rules        95 enabled | 16 not enabled"
+  Rules        96 enabled | 16 not enabled"
 `;
 
 exports[`CLI Output Formatting > --ignore-disable-comments 1`] = `
@@ -341,7 +341,7 @@ test/fixtures/ignored.html.erb:8:8
   Not failing  2 warnings (2 offenses across 1 file, below --fail-level=error)
   Note         3 additional offenses reported (would have been ignored)
   Fixable      7 offenses | 4 autocorrectable using \`--fix\`
-  Rules        95 enabled | 16 not enabled"
+  Rules        96 enabled | 16 not enabled"
 `;
 
 exports[`CLI Output Formatting > --log-level > counts the hidden offenses and suggests the level that reveals them 1`] = `
@@ -359,7 +359,7 @@ exports[`CLI Output Formatting > --log-level > counts the hidden offenses and su
   Not failing  2 info | 1 hint (3 offenses across 1 file, below --fail-level=error)
   Not shown    3 offenses hidden, show them with --log-level=hint
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        95 enabled | 16 not enabled"
+  Rules        96 enabled | 16 not enabled"
 `;
 
 exports[`CLI Output Formatting > --log-level > doesn't report offenses below the given level 1`] = `
@@ -376,7 +376,7 @@ exports[`CLI Output Formatting > --log-level > doesn't report offenses below the
   Not failing  1 hint (1 offense across 1 file, below --fail-level=error)
   Not shown    1 offense hidden, show it with --log-level=hint
   Fixable      0 offenses
-  Rules        94 enabled | 16 not enabled | 1 disabled"
+  Rules        95 enabled | 16 not enabled | 1 disabled"
 `;
 
 exports[`CLI Output Formatting > --log-level > prefers the CLI flag over the config file 1`] = `
@@ -395,7 +395,7 @@ test-file-with-errors.html.erb:
   Failing      0 offenses
   Not failing  1 hint (1 offense across 1 file, below --fail-level=error)
   Fixable      0 offenses
-  Rules        94 enabled | 16 not enabled | 1 disabled"
+  Rules        95 enabled | 16 not enabled | 1 disabled"
 `;
 
 exports[`CLI Output Formatting > --log-level > reads logLevel from the config file 1`] = `
@@ -412,7 +412,7 @@ exports[`CLI Output Formatting > --log-level > reads logLevel from the config fi
   Not failing  1 hint (1 offense across 1 file, below --fail-level=error)
   Not shown    1 offense hidden, show it with --log-level=hint
   Fixable      0 offenses
-  Rules        94 enabled | 16 not enabled | 1 disabled"
+  Rules        95 enabled | 16 not enabled | 1 disabled"
 `;
 
 exports[`CLI Output Formatting > --log-level > still counts hidden offenses towards the exit code 1`] = `
@@ -428,7 +428,7 @@ exports[`CLI Output Formatting > --log-level > still counts hidden offenses towa
   Offenses     1 hint (1 offense across 1 file)
   Not shown    1 offense hidden, show it with --log-level=hint
   Fixable      0 offenses
-  Rules        94 enabled | 16 not enabled | 1 disabled"
+  Rules        95 enabled | 16 not enabled | 1 disabled"
 `;
 
 exports[`CLI Output Formatting > --log-level > still reports offenses at or above the given level 1`] = `
@@ -447,7 +447,7 @@ test-file-with-errors.html.erb:
   Failing      0 offenses
   Not failing  1 hint (1 offense across 1 file, below --fail-level=error)
   Fixable      0 offenses
-  Rules        94 enabled | 16 not enabled | 1 disabled"
+  Rules        95 enabled | 16 not enabled | 1 disabled"
 `;
 
 exports[`CLI Output Formatting > --log-level > with --all-rules > keeps the log level when it is passed explicitly 1`] = `
@@ -469,7 +469,7 @@ test-file-with-errors.html.erb:
   Not failing  1 hint (1 offense across 1 file, below --fail-level=error)
   Not shown    1 offense hidden, show it with --log-level=hint
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        111 enabled | all rules via --all-rules"
+  Rules        112 enabled | all rules via --all-rules"
 `;
 
 exports[`CLI Output Formatting > --log-level > with --all-rules > lowers the log level to report the rules it was asked for 1`] = `
@@ -492,7 +492,7 @@ test-file-with-errors.html.erb:
   Not failing  1 hint (1 offense across 1 file, below --fail-level=error)
   Log level    hint | lowered from warning by --all-rules
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        111 enabled | all rules via --all-rules"
+  Rules        112 enabled | all rules via --all-rules"
 `;
 
 exports[`CLI Output Formatting > --log-level > with --only > keeps the log level when it is passed explicitly 1`] = `
@@ -635,7 +635,7 @@ test/fixtures/test-file-with-errors.html.erb:2:22
   Failing      2 errors (2 offenses across 1 file)
   Not failing  1 warning (1 offense across 1 file, below --fail-level=error)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        95 enabled | 16 not enabled"
+  Rules        96 enabled | 16 not enabled"
 `;
 
 exports[`CLI Output Formatting > GitHub Actions format includes rule codes 1`] = `
@@ -660,7 +660,7 @@ test/fixtures/no-trailing-newline.html.erb:1:29
   Checked      1 file
   Offenses     1 error (1 offense across 1 file)
   Fixable      1 offense | 1 autocorrectable using \`--fix\`
-  Rules        95 enabled | 16 not enabled"
+  Rules        96 enabled | 16 not enabled"
 `;
 
 exports[`CLI Output Formatting > GitHub Actions format includes rule codes 2`] = `
@@ -724,7 +724,7 @@ test/fixtures/erb-no-extra-whitespace-inside-tags.html.erb:1:4
   Checked      1 file
   Offenses     4 errors (4 offenses across 1 file)
   Fixable      4 offenses | 3 autocorrectable using \`--fix\`
-  Rules        95 enabled | 16 not enabled"
+  Rules        96 enabled | 16 not enabled"
 `;
 
 exports[`CLI Output Formatting > Ignores disabled rules 1`] = `
@@ -766,7 +766,7 @@ test/fixtures/ignored.html.erb:6:14
   Offenses     2 errors (2 offenses across 1 file)
   Ignored      3 offenses suppressed with herb:disable
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        95 enabled | 16 not enabled"
+  Rules        96 enabled | 16 not enabled"
 `;
 
 exports[`CLI Output Formatting > allows tag.attributes in attribute position 1`] = `
@@ -806,7 +806,7 @@ test/fixtures/tag-attributes.html.erb:5:0
   Failing      0 offenses
   Not failing  2 warnings (2 offenses across 1 file, below --fail-level=error)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        95 enabled | 16 not enabled"
+  Rules        96 enabled | 16 not enabled"
 `;
 
 exports[`CLI Output Formatting > diplays only parsers errors if one is present 1`] = `
@@ -832,7 +832,7 @@ test/fixtures/parser-errors.html.erb:2:16
   Checked      1 file
   Offenses     1 error (1 offense across 1 file)
   Fixable      0 offenses
-  Rules        95 enabled | 16 not enabled"
+  Rules        96 enabled | 16 not enabled"
 `;
 
 exports[`CLI Output Formatting > displays most violated rules with multiple offenses 1`] = `
@@ -1048,7 +1048,7 @@ test/fixtures/multiple-rule-offenses.html.erb:4:7
   Failing      8 errors (8 offenses across 1 file)
   Not failing  6 warnings (6 offenses across 1 file, below --fail-level=error)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        95 enabled | 16 not enabled"
+  Rules        96 enabled | 16 not enabled"
 `;
 
 exports[`CLI Output Formatting > displays rule offenses when showing all rules 1`] = `
@@ -1146,7 +1146,7 @@ test/fixtures/few-rule-offenses.html.erb:6:0
   Failing      4 errors (4 offenses across 1 file)
   Not failing  2 warnings (2 offenses across 1 file, below --fail-level=error)
   Fixable      6 offenses | 3 autocorrectable using \`--fix\`
-  Rules        95 enabled | 16 not enabled"
+  Rules        96 enabled | 16 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats GitHub Actions output correctly for bad file 1`] = `
@@ -1185,7 +1185,7 @@ test/fixtures/bad-file.html.erb:1:16
   Checked      1 file
   Offenses     2 errors (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        95 enabled | 16 not enabled"
+  Rules        96 enabled | 16 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats GitHub Actions output correctly for clean file 1`] = `
@@ -1197,7 +1197,7 @@ exports[`CLI Output Formatting > formats GitHub Actions output correctly for cle
   Checked      1 file
   Offenses     0 offenses
   Fixable      0 offenses
-  Rules        95 enabled | 16 not enabled"
+  Rules        96 enabled | 16 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats GitHub Actions output correctly for file with errors 1`] = `
@@ -1258,7 +1258,7 @@ test/fixtures/test-file-with-errors.html.erb:2:22
   Failing      2 errors (2 offenses across 1 file)
   Not failing  1 warning (1 offense across 1 file, below --fail-level=error)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        95 enabled | 16 not enabled"
+  Rules        96 enabled | 16 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats GitHub Actions output with --format=github option 1`] = `
@@ -1297,7 +1297,7 @@ test/fixtures/test-file-simple.html.erb:2:22
   Checked      1 file
   Offenses     2 errors (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        95 enabled | 16 not enabled"
+  Rules        96 enabled | 16 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats JSON output correctly for bad file 1`] = `
@@ -1344,7 +1344,7 @@ exports[`CLI Output Formatting > formats JSON output correctly for bad file 1`] 
   "summary": {
     "filesChecked": 1,
     "filesWithOffenses": 1,
-    "ruleCount": 95,
+    "ruleCount": 96,
     "totalErrors": 2,
     "totalHints": 0,
     "totalIgnored": 0,
@@ -1366,7 +1366,7 @@ exports[`CLI Output Formatting > formats JSON output correctly for clean file 1`
   "summary": {
     "filesChecked": 1,
     "filesWithOffenses": 0,
-    "ruleCount": 95,
+    "ruleCount": 96,
     "totalErrors": 0,
     "totalHints": 0,
     "totalIgnored": 0,
@@ -1440,7 +1440,7 @@ exports[`CLI Output Formatting > formats JSON output correctly for file with err
   "summary": {
     "filesChecked": 1,
     "filesWithOffenses": 1,
-    "ruleCount": 95,
+    "ruleCount": 96,
     "totalErrors": 2,
     "totalHints": 0,
     "totalIgnored": 0,
@@ -1505,7 +1505,7 @@ test/fixtures/test-file-with-errors.html.erb:2:22
   Failing      2 errors (2 offenses across 1 file)
   Not failing  1 warning (1 offense across 1 file, below --fail-level=error)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        95 enabled | 16 not enabled"
+  Rules        96 enabled | 16 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats simple output correctly 1`] = `
@@ -1524,7 +1524,7 @@ test/fixtures/test-file-simple.html.erb:
   Checked      1 file
   Offenses     2 errors (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        95 enabled | 16 not enabled"
+  Rules        96 enabled | 16 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats simple output for bad-file correctly 1`] = `
@@ -1543,7 +1543,7 @@ test/fixtures/bad-file.html.erb:
   Checked      1 file
   Offenses     2 errors (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        95 enabled | 16 not enabled"
+  Rules        96 enabled | 16 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats success output correctly 1`] = `
@@ -1555,7 +1555,7 @@ exports[`CLI Output Formatting > formats success output correctly 1`] = `
   Checked      1 file
   Offenses     0 offenses
   Fixable      0 offenses
-  Rules        95 enabled | 16 not enabled"
+  Rules        96 enabled | 16 not enabled"
 `;
 
 exports[`CLI Output Formatting > handles boolean attributes 1`] = `
@@ -1567,7 +1567,7 @@ exports[`CLI Output Formatting > handles boolean attributes 1`] = `
   Checked      1 file
   Offenses     0 offenses
   Fixable      0 offenses
-  Rules        95 enabled | 16 not enabled"
+  Rules        96 enabled | 16 not enabled"
 `;
 
 exports[`CLI Output Formatting > handles multiple errors correctly 1`] = `
@@ -1602,7 +1602,7 @@ test/fixtures/bad-file.html.erb:1:16
   Checked      1 file
   Offenses     2 errors (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        95 enabled | 16 not enabled"
+  Rules        96 enabled | 16 not enabled"
 `;
 
 exports[`CLI Output Formatting > herb:disable rules 1`] = `
@@ -1736,7 +1736,7 @@ test/fixtures/disabled-1.html.erb:14:19
   Not failing  6 warnings (6 offenses across 1 file, below --fail-level=error)
   Ignored      8 offenses suppressed with herb:disable
   Fixable      8 offenses | 1 autocorrectable using \`--fix\`
-  Rules        95 enabled | 16 not enabled"
+  Rules        96 enabled | 16 not enabled"
 `;
 
 exports[`CLI Output Formatting > herb:disable rules 2`] = `
@@ -1941,7 +1941,7 @@ test/fixtures/disabled-2.html.erb:2:44
   Not failing  7 warnings (7 offenses across 1 file, below --fail-level=error)
   Ignored      5 offenses suppressed with herb:disable
   Fixable      13 offenses | 6 autocorrectable using \`--fix\`
-  Rules        95 enabled | 16 not enabled"
+  Rules        96 enabled | 16 not enabled"
 `;
 
 exports[`CLI Output Formatting > non-failing offenses tip > points at --log-level when many offenses don't fail the build 1`] = `
@@ -1979,7 +1979,7 @@ multiple-rule-offenses.html.erb:
   Failing      3 errors (3 offenses across 1 file)
   Not failing  1 info | 10 hints (11 offenses across 1 file, below --fail-level=error)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        95 enabled | 16 not enabled
+  Rules        96 enabled | 16 not enabled
 
  TIP: 11 of the logged offenses don't fail the build.
       Run herb-lint --log-level=error to stop logging them, or set linter.logLevel in your .herb.yml.
@@ -2011,7 +2011,7 @@ multiple-rule-offenses.html.erb:
   Not failing  1 info | 10 hints (11 offenses across 1 file, below --fail-level=error)
   Not shown    11 offenses hidden, show them with --log-level=hint
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        95 enabled | 16 not enabled"
+  Rules        96 enabled | 16 not enabled"
 `;
 
 exports[`CLI Output Formatting > non-failing offenses tip > stays quiet when --log-level is passed explicitly, even when it hides nothing 1`] = `
@@ -2049,7 +2049,7 @@ multiple-rule-offenses.html.erb:
   Failing      3 errors (3 offenses across 1 file)
   Not failing  1 info | 10 hints (11 offenses across 1 file, below --fail-level=error)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        95 enabled | 16 not enabled"
+  Rules        96 enabled | 16 not enabled"
 `;
 
 exports[`CLI Output Formatting > non-failing offenses tip > stays quiet when logLevel is set in the config file 1`] = `
@@ -2087,7 +2087,7 @@ multiple-rule-offenses.html.erb:
   Failing      3 errors (3 offenses across 1 file)
   Not failing  1 info | 10 hints (11 offenses across 1 file, below --fail-level=error)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        95 enabled | 16 not enabled"
+  Rules        96 enabled | 16 not enabled"
 `;
 
 exports[`CLI Output Formatting > non-failing offenses tip > stays quiet when only a handful of offenses don't fail the build 1`] = `
@@ -2125,7 +2125,7 @@ multiple-rule-offenses.html.erb:
   Failing      8 errors (8 offenses across 1 file)
   Not failing  6 warnings (6 offenses across 1 file, below --fail-level=error)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        95 enabled | 16 not enabled"
+  Rules        96 enabled | 16 not enabled"
 `;
 
 exports[`CLI Output Formatting > summary offense buckets > groups every severity into one line when --fail-level is hint 1`] = `
@@ -2162,7 +2162,7 @@ test/fixtures/multiple-rule-offenses.html.erb:
   Checked      1 file
   Offenses     8 errors | 6 warnings (14 offenses across 1 file)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        95 enabled | 16 not enabled"
+  Rules        96 enabled | 16 not enabled"
 `;
 
 exports[`CLI Output Formatting > summary offense buckets > groups every severity into one line when --fail-level is info 1`] = `
@@ -2199,7 +2199,7 @@ test/fixtures/multiple-rule-offenses.html.erb:
   Checked      1 file
   Offenses     8 errors | 6 warnings (14 offenses across 1 file)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        95 enabled | 16 not enabled"
+  Rules        96 enabled | 16 not enabled"
 `;
 
 exports[`CLI Output Formatting > summary offense buckets > groups every severity into one line when --fail-level is warning 1`] = `
@@ -2236,7 +2236,7 @@ test/fixtures/multiple-rule-offenses.html.erb:
   Checked      1 file
   Offenses     8 errors | 6 warnings (14 offenses across 1 file)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        95 enabled | 16 not enabled"
+  Rules        96 enabled | 16 not enabled"
 `;
 
 exports[`CLI Output Formatting > summary offense buckets > moves a severity between buckets as --fail-level is lowered 1`] = `
@@ -2274,7 +2274,7 @@ multiple-rule-offenses.html.erb:
   Failing      8 errors | 4 warnings | 1 info (13 offenses across 1 file)
   Not failing  1 hint (1 offense across 1 file, below --fail-level=info)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        95 enabled | 16 not enabled"
+  Rules        96 enabled | 16 not enabled"
 `;
 
 exports[`CLI Output Formatting > summary offense buckets > splits the buckets when only some severities fail the build 1`] = `
@@ -2312,7 +2312,7 @@ multiple-rule-offenses.html.erb:
   Failing      8 errors | 4 warnings (12 offenses across 1 file)
   Not failing  1 info | 1 hint (2 offenses across 1 file, below --fail-level=warning)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        95 enabled | 16 not enabled"
+  Rules        96 enabled | 16 not enabled"
 `;
 
 exports[`CLI Output Formatting > unsafe autocorrectable offenses > counts and tags them separately from offenses --fix can correct 1`] = `
@@ -2414,5 +2414,5 @@ test/fixtures/test-file-with-errors.html.erb:2:22
   Failing      2 errors (2 offenses across 1 file)
   Not failing  1 warning (1 offense across 1 file, below --fail-level=error)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        95 enabled | 16 not enabled"
+  Rules        96 enabled | 16 not enabled"
 `;

--- a/javascript/packages/linter/test/rules/actionview-no-redundant-local-assigns.test.ts
+++ b/javascript/packages/linter/test/rules/actionview-no-redundant-local-assigns.test.ts
@@ -1,0 +1,227 @@
+import dedent from "dedent"
+import { describe, test } from "vitest"
+
+import { ActionViewNoRedundantLocalAssignsRule } from "../../src/rules/actionview-no-redundant-local-assigns.js"
+import { createLinterTest } from "../helpers/linter-test-helper.js"
+
+const { expectNoOffenses, expectError, assertOffenses } = createLinterTest(ActionViewNoRedundantLocalAssignsRule)
+
+describe("actionview-no-redundant-local-assigns", () => {
+  test("flags reading a required local back out of local_assigns", () => {
+    expectError("Strict local `user` is already a local variable in this partial, so `local_assigns[:user]` reads back a value that is already in scope. Use `user` instead.")
+
+    assertOffenses(dedent`
+      <%# locals: (user:) %>
+
+      <%= local_assigns[:user].name %>
+    `)
+  })
+
+  test("reports the offense on the lookup", () => {
+    expectError("Strict local `user` is already a local variable in this partial, so `local_assigns[:user]` reads back a value that is already in scope. Use `user` instead.", [3, 4])
+
+    assertOffenses(dedent`
+      <%# locals: (user:) %>
+
+      <%= local_assigns[:user].name %>
+    `)
+  })
+
+  test("flags fetching a required local from local_assigns", () => {
+    expectError("Strict local `user` is already a local variable in this partial, so `local_assigns.fetch(:user)` reads back a value that is already in scope. Use `user` instead.")
+
+    assertOffenses(dedent`
+      <%# locals: (user:) %>
+
+      <%= local_assigns.fetch(:user) %>
+    `)
+  })
+
+  test("mentions the extra argument when fetching with a default", () => {
+    expectError("Strict local `user` is already a local variable in this partial, so `local_assigns.fetch(:user, ...)` reads back a value that is already in scope. Use `user` instead.")
+
+    assertOffenses(dedent`
+      <%# locals: (user:) %>
+
+      <%= local_assigns.fetch(:user, "Anonymous") %>
+    `)
+  })
+
+  test("flags digging a required local out of local_assigns", () => {
+    expectError("Strict local `user` is already a local variable in this partial, so `local_assigns.dig(:user)` reads back a value that is already in scope. Use `user` instead.")
+
+    assertOffenses(dedent`
+      <%# locals: (user:) %>
+
+      <%= local_assigns.dig(:user) %>
+    `)
+  })
+
+  test("flags a presence check for a required local", () => {
+    expectError("Strict local `user` is required, so `local_assigns.key?(:user)` is always `true`. Remove the condition, or give `user` a default value to make it optional.")
+
+    assertOffenses(dedent`
+      <%# locals: (user:) %>
+
+      <% if local_assigns.key?(:user) %>
+        <%= user.name %>
+      <% end %>
+    `)
+  })
+
+  test("flags every presence check alias", () => {
+    expectError("Strict local `user` is required, so `local_assigns.has_key?(:user)` is always `true`. Remove the condition, or give `user` a default value to make it optional.")
+    expectError("Strict local `user` is required, so `local_assigns.include?(:user)` is always `true`. Remove the condition, or give `user` a default value to make it optional.")
+    expectError("Strict local `user` is required, so `local_assigns.member?(:user)` is always `true`. Remove the condition, or give `user` a default value to make it optional.")
+
+    assertOffenses(dedent`
+      <%# locals: (user:) %>
+
+      <%= local_assigns.has_key?(:user) %>
+      <%= local_assigns.include?(:user) %>
+      <%= local_assigns.member?(:user) %>
+    `)
+  })
+
+  test("flags a lookup for an undeclared local", () => {
+    expectError("`size` is not declared in the `locals:` declaration, so Rails raises if a caller passes it and `local_assigns.fetch(:size, ...)` can never find it. Declare `size:` in the declaration, or remove the lookup.")
+
+    assertOffenses(dedent`
+      <%# locals: (user:) %>
+
+      <%= local_assigns.fetch(:size, "large") %>
+    `)
+  })
+
+  test("flags a presence check for an undeclared local", () => {
+    expectError("`size` is not declared in the `locals:` declaration, so Rails raises if a caller passes it and `local_assigns.key?(:size)` can never find it. Declare `size:` in the declaration, or remove the lookup.")
+
+    assertOffenses(dedent`
+      <%# locals: (user:) %>
+
+      <% if local_assigns.key?(:size) %>
+        <span>sized</span>
+      <% end %>
+    `)
+  })
+
+  test("flags a lookup against an empty declaration", () => {
+    expectError("`user` is not declared in the `locals:` declaration, so Rails raises if a caller passes it and `local_assigns[:user]` can never find it. Declare `user:` in the declaration, or remove the lookup.")
+
+    assertOffenses(dedent`
+      <%# locals: () %>
+
+      <%= local_assigns[:user] %>
+    `)
+  })
+
+  test("does not flag a partial that reads its locals directly", () => {
+    expectNoOffenses(dedent`
+      <%# locals: (user:) %>
+
+      <%= user.name %>
+    `)
+  })
+
+  test("does not flag a presence check for an optional local", () => {
+    expectNoOffenses(dedent`
+      <%# locals: (user:, size: nil) %>
+
+      <%= user.name %>
+      <% if local_assigns.key?(:size) %>
+        <span><%= size %></span>
+      <% end %>
+    `)
+  })
+
+  test("does not flag reading an optional local from local_assigns", () => {
+    expectNoOffenses(dedent`
+      <%# locals: (user:, size: nil) %>
+
+      <%= user.name %>
+      <%= local_assigns[:size] %>
+    `)
+  })
+
+  test("does not flag forwarding every local", () => {
+    expectNoOffenses(dedent`
+      <%# locals: (user:) %>
+
+      <%= render "row", **local_assigns %>
+    `)
+  })
+
+  test("does not flag any lookup when the declaration has a keyword rest", () => {
+    expectNoOffenses(dedent`
+      <%# locals: (user:, **) %>
+
+      <%= user.name %>
+      <%= local_assigns.fetch(:size, "large") %>
+    `)
+  })
+
+  test("does not flag any lookup when the declaration has a named keyword rest", () => {
+    expectNoOffenses(dedent`
+      <%# locals: (user:, **options) %>
+
+      <%= user.name %>
+      <%= local_assigns.fetch(:size, "large") %>
+    `)
+  })
+
+  test("does not flag partials without a strict locals declaration", () => {
+    expectNoOffenses(dedent`
+      <%= local_assigns[:user] %>
+      <%= local_assigns.fetch(:size, "large") %>
+      <% if local_assigns.key?(:user) %>
+        <span>named</span>
+      <% end %>
+    `)
+  })
+
+  test("does not flag a lookup with a non-symbol key", () => {
+    expectNoOffenses(dedent`
+      <%# locals: (user:, key:) %>
+
+      <%= local_assigns[key] %>
+      <%= user.name %>
+    `)
+  })
+
+  test("does not flag a nested dig through more than one key", () => {
+    expectNoOffenses(dedent`
+      <%# locals: (user:) %>
+
+      <%= user.name %>
+      <%= local_assigns.dig(:user, :name) %>
+    `)
+  })
+
+  test("does not flag lookups on something other than local_assigns", () => {
+    expectNoOffenses(dedent`
+      <%# locals: (user:, options:) %>
+
+      <%= user.name %>
+      <%= options[:user] %>
+      <%= options.fetch(:size, "large") %>
+    `)
+  })
+
+  test("does not run for non-partial files", () => {
+    expectNoOffenses(dedent`
+      <%# locals: (user:) %>
+
+      <%= local_assigns[:user].name %>
+    `, { fileName: "show.html.erb" })
+  })
+
+  test("runs for partial files", () => {
+    expectError("Strict local `user` is already a local variable in this partial, so `local_assigns[:user]` reads back a value that is already in scope. Use `user` instead.")
+
+    assertOffenses(dedent`
+      <%# locals: (user:) %>
+
+      <%= local_assigns[:user].name %>
+    `, { fileName: "app/views/users/_card.html.erb" })
+  })
+})


### PR DESCRIPTION
This pull request implements the `actionview-no-redundant-local-assigns` rule, which reports `local_assigns` lookups in a partial that already has a `<%# locals: (...) %>` declaration, where the declaration makes the lookup either redundant or dead.

`local_assigns` stays useful in a partial that has a strict locals declaration, so this is deliberately not a rule against `local_assigns` itself. What it targets are the lookups the declaration already answers: a required local is a local variable, so reading it back out of the hash is a longer way to write the name, and it is always present, so asking `key?` about it is a condition that can only take one branch. A name the declaration does not mention can never arrive at all, since Rails raises `ActionView::StrictLocalsError` for callers that pass an undeclared local, which makes the lookup dead code.

```erb
<%# locals: (user:) %>

<%= local_assigns[:user].name %>
```

```
Strict local `user` is already a local variable in this partial, so `local_assigns[:user]` reads
back a value that is already in scope. Use `user` instead.
```

```erb
<%# locals: (user:) %>

<% if local_assigns.key?(:user) %>
  <%= user.name %>
<% end %>
```

```
Strict local `user` is required, so `local_assigns.key?(:user)` is always `true`. Remove the
condition, or give `user` a default value to make it optional.
```

```erb
<%# locals: (user:) %>

<%= user.name %>
<%= local_assigns.fetch(:size, "large") %>
```

```
`size` is not declared in the `locals:` declaration, so Rails raises if a caller passes it and
`local_assigns.fetch(:size, ...)` can never find it. Declare `size:` in the declaration, or
remove the lookup.
```

Resolves https://github.com/marcoroth/herb/issues/2011