### PR TITLE
Linter: Fix `erb-no-trailing-whitespace` autofix inside HTML tags

### DIFF
--- a/javascript/packages/linter/src/rules/erb-no-trailing-whitespace.ts
+++ b/javascript/packages/linter/src/rules/erb-no-trailing-whitespace.ts
@@ -1,15 +1,43 @@
 import { Location, Visitor } from "@herb-tools/core"
 import { ParserRule, Mutable, BaseAutofixContext } from "../types.js"
 
-import { isHTMLOpenTagNode, isHTMLTextNode, isLiteralNode, getTagLocalName } from "@herb-tools/core"
+import { isHTMLOpenTagNode, isHTMLTextNode, isLiteralNode, isWhitespaceNode, getTagLocalName } from "@herb-tools/core"
 import { findNodeAtPosition } from "./rule-utils.js"
 
 import type { UnboundLintOffense, LintOffense, LintContext, FullRuleConfig } from "../types.js"
-import type { HTMLElementNode, HTMLTextNode, LiteralNode, ParseResult, DocumentNode, ERBNode } from "@herb-tools/core"
+import type { HTMLElementNode, HTMLTextNode, LiteralNode, WhitespaceNode, ParseResult, DocumentNode, ERBNode } from "@herb-tools/core"
 
-const TRAILING_WHITESPACE = /[ \t\r\v\f\u00A0]+$/
-const TRAILING_WHITESPACE_BEFORE_NEWLINE = /[ \t\r\v\f\u00A0]+(?=\n)/g
-const ONLY_WHITESPACE = /^[ \t\r\v\f\u00A0]+$/
+const WHITESPACE_CHARACTERS = new Set([" ", "\t", "\r", "\v", "\f", "\u00A0"])
+
+function trailingWhitespaceStart(value: string): number {
+  let start = value.length
+
+  while (start > 0 && WHITESPACE_CHARACTERS.has(value[start - 1])) start--
+
+  return start
+}
+
+function trimTrailingWhitespace(value: string): string {
+  const start = trailingWhitespaceStart(value)
+
+  return start === value.length ? value : value.slice(0, start)
+}
+
+function trimWhitespaceBeforeNewlines(value: string): string {
+  if (!value.includes("\n")) return value
+
+  const segments = value.split("\n")
+
+  for (let index = 0; index < segments.length - 1; index++) {
+    segments[index] = trimTrailingWhitespace(segments[index])
+  }
+
+  return segments.join("\n")
+}
+
+function isOnlyWhitespace(value: string): boolean {
+  return value.length > 0 && trailingWhitespaceStart(value) === 0
+}
 
 interface SkipZone {
   startLine: number
@@ -25,7 +53,7 @@ interface TrailingWhitespaceCandidate {
 }
 
 interface ERBNoTrailingWhitespaceAutofixContext extends BaseAutofixContext {
-  node: Mutable<HTMLTextNode> | Mutable<LiteralNode>
+  node: Mutable<HTMLTextNode> | Mutable<LiteralNode> | Mutable<WhitespaceNode>
 }
 
 class SkipZoneCollector extends Visitor {
@@ -92,7 +120,7 @@ export class ERBNoTrailingWhitespaceRule extends ParserRule<ERBNoTrailingWhitesp
     for (const candidate of candidates) {
       if (!this.isInSkipZone(candidate, skipZones)) {
         const location = Location.from(candidate.line, candidate.column, candidate.line, candidate.column + candidate.length)
-        const node = findNodeAtPosition(result.value, candidate.line, candidate.column, (n) => isHTMLTextNode(n) || isLiteralNode(n)) as HTMLTextNode | LiteralNode | null
+        const node = findNodeAtPosition(result.value, candidate.line, candidate.column, (n) => isHTMLTextNode(n) || isLiteralNode(n) || isWhitespaceNode(n)) as HTMLTextNode | LiteralNode | WhitespaceNode | null
 
         offenses.push(this.createOffense("Extra whitespace detected at end of line.", location, node ? { node } : undefined))
       }
@@ -106,13 +134,13 @@ export class ERBNoTrailingWhitespaceRule extends ParserRule<ERBNoTrailingWhitesp
 
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i]
-      const match = line.match(TRAILING_WHITESPACE)
+      const start = trailingWhitespaceStart(line)
 
-      if (match && match.index !== undefined) {
+      if (start < line.length) {
         candidates.push({
           line: i + 1,
-          column: match.index,
-          length: match[0].length
+          column: start,
+          length: line.length - start
         })
       }
     }
@@ -145,16 +173,20 @@ export class ERBNoTrailingWhitespaceRule extends ParserRule<ERBNoTrailingWhitesp
 
     const { node } = offense.autofixContext
 
+    if (node.type === "AST_WHITESPACE_NODE") {
+      return this.autofixWhitespaceNode(offense, node, result)
+    }
+
     if (node.type === "AST_HTML_TEXT_NODE" || node.type === "AST_LITERAL_NODE") {
-      let fixedContent = node.content.replace(TRAILING_WHITESPACE_BEFORE_NEWLINE, "")
+      let fixedContent = trimWhitespaceBeforeNewlines(node.content)
       const offenseIsAtEndOfContent = this.isOffenseAtEndOfContent(offense, node)
 
       if (offenseIsAtEndOfContent) {
         if (this.hasTrailingWhitespaceNotIndentation(fixedContent)) {
-          fixedContent = fixedContent.replace(TRAILING_WHITESPACE, "")
+          fixedContent = trimTrailingWhitespace(fixedContent)
         }
 
-        if (ONLY_WHITESPACE.test(fixedContent) && node.location.start.column !== 0) {
+        if (isOnlyWhitespace(fixedContent) && node.location.start.column !== 0) {
           fixedContent = ""
         }
       }
@@ -165,17 +197,32 @@ export class ERBNoTrailingWhitespaceRule extends ParserRule<ERBNoTrailingWhitesp
     return result
   }
 
-  private isOffenseAtEndOfContent(offense: LintOffense<ERBNoTrailingWhitespaceAutofixContext>, node: Mutable<HTMLTextNode> | Mutable<LiteralNode>): boolean {
+  private autofixWhitespaceNode(offense: LintOffense<ERBNoTrailingWhitespaceAutofixContext>, node: Mutable<WhitespaceNode>, result: ParseResult): ParseResult | null {
+    if (!node.value) return null
+
+    const originalValue = node.value.value
+    let fixedValue = trimWhitespaceBeforeNewlines(originalValue)
+
+    if (this.isOffenseAtEndOfContent(offense, node)) {
+      fixedValue = trimTrailingWhitespace(fixedValue)
+    }
+
+    if (fixedValue === originalValue) return null
+
+    node.value.value = fixedValue
+
+    return result
+  }
+
+  private isOffenseAtEndOfContent(offense: LintOffense<ERBNoTrailingWhitespaceAutofixContext>, node: Mutable<HTMLTextNode> | Mutable<LiteralNode> | Mutable<WhitespaceNode>): boolean {
     return offense.location.end.line === node.location.end.line && offense.location.end.column === node.location.end.column
   }
 
   private hasTrailingWhitespaceNotIndentation(content: string): boolean {
     if (content.endsWith("\n")) return false
 
-    const endMatch = content.match(TRAILING_WHITESPACE)
-    if (!endMatch) return false
-
-    const whitespaceStart = content.length - endMatch[0].length
+    const whitespaceStart = trailingWhitespaceStart(content)
+    if (whitespaceStart === content.length) return false
     if (whitespaceStart === 0) return false
 
     const characterBefore = content[whitespaceStart - 1]

--- a/javascript/packages/linter/test/autofix/erb-no-trailing-whitespace.autofix.test.ts
+++ b/javascript/packages/linter/test/autofix/erb-no-trailing-whitespace.autofix.test.ts
@@ -365,4 +365,351 @@ describe("erb-no-trailing-whitespace autofix", () => {
       expect(result.unfixed).toHaveLength(0)
     })
   })
+
+  describe("inside tags", () => {
+    test("removes trailing whitespace between attributes", () => {
+      const input = '<div data-a="foo" \n  data-b="bar">\nlorem\n</div>\n'
+      const expected = '<div data-a="foo"\n  data-b="bar">\nlorem\n</div>\n'
+
+      const linter = new Linter(Herb, [ERBNoTrailingWhitespaceRule])
+      const result = linter.autofix(input, { fileName: "test.html.erb" })
+
+      expect(result.source).toBe(expected)
+      expect(result.fixed).toHaveLength(1)
+      expect(result.unfixed).toHaveLength(0)
+    })
+
+    test("removes trailing whitespace after tag name", () => {
+      const input = '<div \n  data-b="bar">\nlorem\n</div>\n'
+      const expected = '<div\n  data-b="bar">\nlorem\n</div>\n'
+
+      const linter = new Linter(Herb, [ERBNoTrailingWhitespaceRule])
+      const result = linter.autofix(input, { fileName: "test.html.erb" })
+
+      expect(result.source).toBe(expected)
+      expect(result.fixed).toHaveLength(1)
+      expect(result.unfixed).toHaveLength(0)
+    })
+
+    test("removes trailing whitespace before the tag closing", () => {
+      const input = '<div data-a="foo"  \n>\nlorem\n</div>\n'
+      const expected = '<div data-a="foo"\n>\nlorem\n</div>\n'
+
+      const linter = new Linter(Herb, [ERBNoTrailingWhitespaceRule])
+      const result = linter.autofix(input, { fileName: "test.html.erb" })
+
+      expect(result.source).toBe(expected)
+      expect(result.fixed).toHaveLength(1)
+      expect(result.unfixed).toHaveLength(0)
+    })
+
+    test("removes trailing whitespace inside a closing tag", () => {
+      const input = "<div>\nlorem\n</div \n>\n"
+      const expected = "<div>\nlorem\n</div\n>\n"
+
+      const linter = new Linter(Herb, [ERBNoTrailingWhitespaceRule])
+      const result = linter.autofix(input, { fileName: "test.html.erb" })
+
+      expect(result.source).toBe(expected)
+      expect(result.fixed).toHaveLength(1)
+      expect(result.unfixed).toHaveLength(0)
+    })
+
+    test("removes trailing whitespace inside a self-closing tag", () => {
+      const input = '<img src="a.png" \n  alt="x" />\n'
+      const expected = '<img src="a.png"\n  alt="x" />\n'
+
+      const linter = new Linter(Herb, [ERBNoTrailingWhitespaceRule])
+      const result = linter.autofix(input, { fileName: "test.html.erb" })
+
+      expect(result.source).toBe(expected)
+      expect(result.fixed).toHaveLength(1)
+      expect(result.unfixed).toHaveLength(0)
+    })
+
+    test("removes mixed trailing whitespace between attributes", () => {
+      const input = '<div data-a="foo" \t \n  data-b="bar">\nlorem\n</div>\n'
+      const expected = '<div data-a="foo"\n  data-b="bar">\nlorem\n</div>\n'
+
+      const linter = new Linter(Herb, [ERBNoTrailingWhitespaceRule])
+      const result = linter.autofix(input, { fileName: "test.html.erb" })
+
+      expect(result.source).toBe(expected)
+      expect(result.fixed).toHaveLength(1)
+      expect(result.unfixed).toHaveLength(0)
+    })
+
+    test("preserves whitespace between attributes on the same line", () => {
+      const input = '        <div     data-a="foo" \n                   data-b="bar">\n        lorem\n        </div>\n'
+      const expected = '        <div     data-a="foo"\n                   data-b="bar">\n        lorem\n        </div>\n'
+
+      const linter = new Linter(Herb, [ERBNoTrailingWhitespaceRule])
+      const result = linter.autofix(input, { fileName: "test.html.erb" })
+
+      expect(result.source).toBe(expected)
+      expect(result.fixed).toHaveLength(1)
+      expect(result.unfixed).toHaveLength(0)
+    })
+
+    test("does not modify trailing whitespace inside a skipped element's tag", () => {
+      const input = '<pre data-a="foo" \n  data-b="bar">\nlorem\n</pre>\n'
+
+      const linter = new Linter(Herb, [ERBNoTrailingWhitespaceRule])
+      const result = linter.autofix(input, { fileName: "test.html.erb" })
+
+      expect(result.source).toBe(input)
+      expect(result.fixed).toHaveLength(0)
+      expect(result.unfixed).toHaveLength(0)
+    })
+
+    test("fixes every trailing whitespace occurrence inside a multi-line tag", () => {
+      const input = '<div \n  data-a="foo" \n  data-b="bar" \n>\nlorem\n</div>\n'
+      const expected = '<div\n  data-a="foo"\n  data-b="bar"\n>\nlorem\n</div>\n'
+
+      const linter = new Linter(Herb, [ERBNoTrailingWhitespaceRule])
+      const result = linter.autofix(input, { fileName: "test.html.erb" })
+
+      expect(result.source).toBe(expected)
+      expect(result.fixed).toHaveLength(3)
+      expect(result.unfixed).toHaveLength(0)
+    })
+
+    test("leaves no offenses behind after fixing", () => {
+      const input = '<div data-a="foo" \n  data-b="bar">\nlorem  \n</div>\n'
+
+      const linter = new Linter(Herb, [ERBNoTrailingWhitespaceRule])
+      const result = linter.autofix(input, { fileName: "test.html.erb" })
+
+      expect(linter.lint(result.source, { fileName: "test.html.erb" }).offenses).toHaveLength(0)
+    })
+
+    test("removes trailing whitespace after a valueless attribute", () => {
+      const input = "<input disabled \n  required>\n"
+      const expected = "<input disabled\n  required>\n"
+
+      const linter = new Linter(Herb, [ERBNoTrailingWhitespaceRule])
+      const result = linter.autofix(input, { fileName: "test.html.erb" })
+
+      expect(result.source).toBe(expected)
+      expect(result.fixed).toHaveLength(1)
+      expect(result.unfixed).toHaveLength(0)
+    })
+
+    test("removes trailing whitespace after an unquoted attribute value", () => {
+      const input = "<div class=foo \n  id=bar>\ny\n</div>\n"
+      const expected = "<div class=foo\n  id=bar>\ny\n</div>\n"
+
+      const linter = new Linter(Herb, [ERBNoTrailingWhitespaceRule])
+      const result = linter.autofix(input, { fileName: "test.html.erb" })
+
+      expect(result.source).toBe(expected)
+      expect(result.fixed).toHaveLength(1)
+      expect(result.unfixed).toHaveLength(0)
+    })
+
+    test("removes trailing whitespace after a single-quoted attribute value", () => {
+      const input = "<div class='foo' \n  id='bar'>\ny\n</div>\n"
+      const expected = "<div class='foo'\n  id='bar'>\ny\n</div>\n"
+
+      const linter = new Linter(Herb, [ERBNoTrailingWhitespaceRule])
+      const result = linter.autofix(input, { fileName: "test.html.erb" })
+
+      expect(result.source).toBe(expected)
+      expect(result.fixed).toHaveLength(1)
+      expect(result.unfixed).toHaveLength(0)
+    })
+
+    test("removes trailing whitespace inside a void element tag", () => {
+      const input = "<br \n>\n"
+      const expected = "<br\n>\n"
+
+      const linter = new Linter(Herb, [ERBNoTrailingWhitespaceRule])
+      const result = linter.autofix(input, { fileName: "test.html.erb" })
+
+      expect(result.source).toBe(expected)
+      expect(result.fixed).toHaveLength(1)
+      expect(result.unfixed).toHaveLength(0)
+    })
+
+    test("removes trailing whitespace before a self-closing slash", () => {
+      const input = '<img src="a.png" \n/>\n'
+      const expected = '<img src="a.png"\n/>\n'
+
+      const linter = new Linter(Herb, [ERBNoTrailingWhitespaceRule])
+      const result = linter.autofix(input, { fileName: "test.html.erb" })
+
+      expect(result.source).toBe(expected)
+      expect(result.fixed).toHaveLength(1)
+      expect(result.unfixed).toHaveLength(0)
+    })
+
+    test("removes a trailing tab between attributes", () => {
+      const input = '<div data-a="foo"\t\n  data-b="bar">\ny\n</div>\n'
+      const expected = '<div data-a="foo"\n  data-b="bar">\ny\n</div>\n'
+
+      const linter = new Linter(Herb, [ERBNoTrailingWhitespaceRule])
+      const result = linter.autofix(input, { fileName: "test.html.erb" })
+
+      expect(result.source).toBe(expected)
+      expect(result.fixed).toHaveLength(1)
+      expect(result.unfixed).toHaveLength(0)
+    })
+
+    test("removes a trailing vertical tab and form feed between attributes", () => {
+      const input = '<div data-a="foo"\v\n  data-b="bar"\f\n  data-c="baz">\ny\n</div>\n'
+      const expected = '<div data-a="foo"\n  data-b="bar"\n  data-c="baz">\ny\n</div>\n'
+
+      const linter = new Linter(Herb, [ERBNoTrailingWhitespaceRule])
+      const result = linter.autofix(input, { fileName: "test.html.erb" })
+
+      expect(result.source).toBe(expected)
+      expect(result.fixed).toHaveLength(2)
+      expect(result.unfixed).toHaveLength(0)
+    })
+
+    test("fixes nested elements that both have multi-line tags", () => {
+      const input = '<div \n  id="a">\n  <span \n    id="b">x</span>\n</div>\n'
+      const expected = '<div\n  id="a">\n  <span\n    id="b">x</span>\n</div>\n'
+
+      const linter = new Linter(Herb, [ERBNoTrailingWhitespaceRule])
+      const result = linter.autofix(input, { fileName: "test.html.erb" })
+
+      expect(result.source).toBe(expected)
+      expect(result.fixed).toHaveLength(2)
+      expect(result.unfixed).toHaveLength(0)
+    })
+
+    test("fixes trailing whitespace inside a tag and in text content together", () => {
+      const input = '<div id="a" \n  class="b">\nlorem  \n</div>\n'
+      const expected = '<div id="a"\n  class="b">\nlorem\n</div>\n'
+
+      const linter = new Linter(Herb, [ERBNoTrailingWhitespaceRule])
+      const result = linter.autofix(input, { fileName: "test.html.erb" })
+
+      expect(result.source).toBe(expected)
+      expect(result.fixed).toHaveLength(2)
+      expect(result.unfixed).toHaveLength(0)
+    })
+
+    test("does not introduce parse errors", () => {
+      const input = '<div     data-a="foo" \n                   data-b="bar">\n        lorem\n        </div>\n'
+
+      const linter = new Linter(Herb, [ERBNoTrailingWhitespaceRule])
+      const result = linter.autofix(input, { fileName: "test.html.erb" })
+
+      expect(Herb.parse(result.source).value.recursiveErrors()).toHaveLength(0)
+    })
+
+    test("is idempotent", () => {
+      const input = '<div \n  data-a="foo" \n  data-b="bar" \n>\nlorem  \n</div>\n'
+
+      const linter = new Linter(Herb, [ERBNoTrailingWhitespaceRule])
+      const once = linter.autofix(input, { fileName: "test.html.erb" })
+      const twice = linter.autofix(once.source, { fileName: "test.html.erb" })
+
+      expect(twice.source).toBe(once.source)
+      expect(twice.fixed).toHaveLength(0)
+    })
+
+    describe("ERB", () => {
+      test("removes trailing whitespace after an attribute with an ERB value", () => {
+        const input = '<div class="<%= foo %>" \n  id="x">\ny\n</div>\n'
+        const expected = '<div class="<%= foo %>"\n  id="x">\ny\n</div>\n'
+
+        const linter = new Linter(Herb, [ERBNoTrailingWhitespaceRule])
+        const result = linter.autofix(input, { fileName: "test.html.erb" })
+
+        expect(result.source).toBe(expected)
+        expect(result.fixed).toHaveLength(1)
+        expect(result.unfixed).toHaveLength(0)
+      })
+
+      test("removes trailing whitespace after ERB in attribute position", () => {
+        const input = '<div <%= attributes %> \n  data-b="x">\ny\n</div>\n'
+        const expected = '<div <%= attributes %>\n  data-b="x">\ny\n</div>\n'
+
+        const linter = new Linter(Herb, [ERBNoTrailingWhitespaceRule])
+        const result = linter.autofix(input, { fileName: "test.html.erb" })
+
+        expect(result.source).toBe(expected)
+        expect(result.fixed).toHaveLength(1)
+        expect(result.unfixed).toHaveLength(0)
+      })
+
+      test("removes trailing whitespace after ERB control flow inside a tag", () => {
+        const input = '<div <% if condition %> \n  data-a="1" <% end %>>\ny\n</div>\n'
+        const expected = '<div <% if condition %>\n  data-a="1" <% end %>>\ny\n</div>\n'
+
+        const linter = new Linter(Herb, [ERBNoTrailingWhitespaceRule])
+        const result = linter.autofix(input, { fileName: "test.html.erb" })
+
+        expect(result.source).toBe(expected)
+        expect(result.fixed).toHaveLength(1)
+        expect(result.unfixed).toHaveLength(0)
+      })
+    })
+
+    describe("whitespace significant elements", () => {
+      test("does not modify the open tag of a <textarea>", () => {
+        const input = '<textarea rows="2" \n  cols="3">\nx  \n</textarea>\n'
+
+        const linter = new Linter(Herb, [ERBNoTrailingWhitespaceRule])
+        const result = linter.autofix(input, { fileName: "test.html.erb" })
+
+        expect(result.source).toBe(input)
+        expect(result.fixed).toHaveLength(0)
+        expect(result.unfixed).toHaveLength(0)
+      })
+
+      test("does not modify the open tag of a <script>", () => {
+        const input = '<script type="text/javascript" \n  defer>\nvar x = 1;  \n</script>\n'
+
+        const linter = new Linter(Herb, [ERBNoTrailingWhitespaceRule])
+        const result = linter.autofix(input, { fileName: "test.html.erb" })
+
+        expect(result.source).toBe(input)
+        expect(result.fixed).toHaveLength(0)
+        expect(result.unfixed).toHaveLength(0)
+      })
+
+      test("does not modify the open tag of a <style>", () => {
+        const input = '<style media="all" \n  scoped>\n.a { }  \n</style>\n'
+
+        const linter = new Linter(Herb, [ERBNoTrailingWhitespaceRule])
+        const result = linter.autofix(input, { fileName: "test.html.erb" })
+
+        expect(result.source).toBe(input)
+        expect(result.fixed).toHaveLength(0)
+        expect(result.unfixed).toHaveLength(0)
+      })
+    })
+
+    describe("pathological input", () => {
+      test("handles a long run of trailing whitespace inside a tag", () => {
+        const input = '<div data-a="foo"' + "\t".repeat(50_000) + '\n  data-b="bar">\ny\n</div>\n'
+        const expected = '<div data-a="foo"\n  data-b="bar">\ny\n</div>\n'
+
+        const linter = new Linter(Herb, [ERBNoTrailingWhitespaceRule])
+        const result = linter.autofix(input, { fileName: "test.html.erb" })
+
+        expect(result.source).toBe(expected)
+        expect(result.fixed).toHaveLength(1)
+        expect(result.unfixed).toHaveLength(0)
+      })
+    })
+
+    describe("line endings", () => {
+      test("strips carriage returns inside tags and text alike", () => {
+        const input = '<div data-a="foo"\r\n  data-b="bar">\r\nlorem\r\n</div>\r\n'
+        const expected = '<div data-a="foo"\n  data-b="bar">\nlorem\n</div>\n'
+
+        const linter = new Linter(Herb, [ERBNoTrailingWhitespaceRule])
+        const result = linter.autofix(input, { fileName: "test.html.erb" })
+
+        expect(result.source).toBe(expected)
+        expect(result.fixed).toHaveLength(4)
+        expect(result.unfixed).toHaveLength(0)
+      })
+    })
+  })
 })


### PR DESCRIPTION
This pull request updates `erb-no-trailing-whitespace` so its autofix also applies to trailing whitespace inside HTML tags, which it previously reported but could never fix.

The rule flags trailing whitespace anywhere in the source, but the autofix only knew how to rewrite `HTMLTextNode` and `LiteralNode` content. 

Whitespace between attributes, after a tag name, or before a tag closing is tracked as a dedicated `WhitespaceNode`, so `findNodeAtPosition` returned `null` for those offenses, they were created without an `autofixContext`, and `autofix()` bailed on its first line. The offense was reported as `[Correctable]` and counted in `N autocorrectable using --fix`, but running `--fix` changed nothing and printed the same line again.

```html+erb
<div     data-a="foo" 
                   data-b="bar">
        lorem
        </div>
```

Everything inside tag markup was affected, while text content and attribute values already worked:

Related https://github.com/marcoroth/herb/issues/1697 and https://github.com/marcoroth/herb/issues/1909, which is the same class of misleading `[Correctable]` reporting for offenses `--fix` will not apply.