### PR TITLE
Linter: Don't flag empty `data-*` values in Action View tag helpers

### DIFF
--- a/javascript/packages/linter/src/rules/html-no-empty-attributes.ts
+++ b/javascript/packages/linter/src/rules/html-no-empty-attributes.ts
@@ -1,10 +1,10 @@
 import { ParserRule } from "../types.js"
 import { AttributeVisitorMixin, StaticAttributeStaticValueParams, DynamicAttributeStaticValueParams } from "./rule-utils.js"
 import { IdentityPrinter } from "@herb-tools/printer"
-import { Visitor, isERBOutputNode, isERBEscapedNode } from "@herb-tools/core"
+import { Visitor, isERBOutputNode, isERBEscapedNode, isERBOpenTagNode } from "@herb-tools/core"
 
 import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types.js"
-import type { ParseResult, HTMLAttributeNode, ERBContentNode, LiteralNode, Node, ParserOptions } from "@herb-tools/core"
+import type { ParseResult, HTMLAttributeNode, HTMLOpenTagNode, ERBOpenTagNode, ERBContentNode, LiteralNode, Node, ParserOptions } from "@herb-tools/core"
 
 const RESTRICTED_ATTRIBUTES = new Set([
   'id',
@@ -83,16 +83,16 @@ function containsOutputContent(node: Node): boolean {
 
 
 class NoEmptyAttributesVisitor extends AttributeVisitorMixin {
-  protected checkStaticAttributeStaticValue({ attributeName, attributeValue, attributeNode }: StaticAttributeStaticValueParams): void {
-    this.checkEmptyAttribute(attributeName, attributeValue, attributeNode)
+  protected checkStaticAttributeStaticValue({ attributeName, attributeValue, attributeNode, parentNode }: StaticAttributeStaticValueParams): void {
+    this.checkEmptyAttribute(attributeName, attributeValue, attributeNode, parentNode)
   }
 
-  protected checkDynamicAttributeStaticValue({ combinedName, attributeValue, attributeNode }: DynamicAttributeStaticValueParams): void {
+  protected checkDynamicAttributeStaticValue({ combinedName, attributeValue, attributeNode, parentNode }: DynamicAttributeStaticValueParams): void {
     const name = (combinedName || "").toLowerCase()
-    this.checkEmptyAttribute(name, attributeValue, attributeNode)
+    this.checkEmptyAttribute(name, attributeValue, attributeNode, parentNode)
   }
 
-  private checkEmptyAttribute(attributeName: string, attributeValue: string, attributeNode: HTMLAttributeNode): void {
+  private checkEmptyAttribute(attributeName: string, attributeValue: string, attributeNode: HTMLAttributeNode, parentNode: HTMLOpenTagNode | ERBOpenTagNode): void {
     if (!isRestrictedAttribute(attributeName)) return
     if (attributeValue.trim() !== "") return
 
@@ -102,6 +102,8 @@ class NoEmptyAttributesVisitor extends AttributeVisitorMixin {
     const hasExplicitValue = attributeNode.value !== null
 
     if (isDataAttribute(attributeName)) {
+      if (isERBOpenTagNode(parentNode)) return
+
       if (hasExplicitValue) {
         this.addOffense(
           `Data attribute \`${attributeName}\` should not have an empty value. Either provide a meaningful value or use \`${attributeName}\` instead of \`${IdentityPrinter.print(attributeNode)}\`.`,

--- a/javascript/packages/linter/test/rules/html-no-empty-attributes.test.ts
+++ b/javascript/packages/linter/test/rules/html-no-empty-attributes.test.ts
@@ -188,10 +188,18 @@ describe("html-no-empty-attributes", () => {
       assertOffenses('<%= tag.div class: "" %>')
     })
 
-    test("fails for tag.div with an empty data attribute", () => {
-      expectWarning("Data attribute `data-foo` should not have an empty value. Either provide a meaningful value or use `data-foo` instead of `data-foo: \"\"`.")
+    test("passes for an empty data attribute, which can't be written without a value", () => {
+      expectNoOffenses('<%= tag.div data: { foo: "" } %>')
+    })
 
-      assertOffenses('<%= tag.div data: { foo: "" } %>')
+    test("passes for an empty data attribute written as a dasherized string key", () => {
+      expectNoOffenses('<%= tag.div "data-foo": "" %>')
+    })
+
+    test("fails for an empty aria attribute, which has no valueless form in HTML either", () => {
+      expectWarning("Attribute `aria-label` must not be empty. Either provide a meaningful value or remove the attribute entirely.")
+
+      assertOffenses('<%= tag.div aria: { label: "" } %>')
     })
 
     test("fails for content_tag with an empty attribute", () => {


### PR DESCRIPTION
Follow up on #2004, which made `html-no-empty-attributes` Action View Helpers aware. The rule now sees attributes written as tag helpers, and reports empty `data-*` values in them:

```erb
<%= tag.div data: { transcript_target: "panel", transcript_scroll: "" } do %>
```

```
Data attribute `data-transcript-scroll` should not have an empty value. Either provide a
meaningful value or use `data-transcript-scroll` instead of `data-transcript-scroll: ""`.
```

The suggestion can't be followed. Action View has no syntax for a valueless data attribute, so there is no way to write `data-transcript-scroll` on its own from a tag helper:

Rewriting the value to `true` would satisfy the rule, but it renders `data-x="true"` rather than a bare attribute, and for a marker attribute matched by `[data-transcript-scroll]` that is equivalent to what the empty string already produces. 

Since the offense has no fix that improves the template, the rule now skips empty `data-*` values when the attribute comes from a tag helper. Empty values on other attributes are still reported, because removing the key is a fix that can be applied:

```erb
<%= tag.div class: "" %>
<%= tag.div aria: { label: "" } %>
```

```
Attribute `class` must not be empty. Either provide a meaningful value or remove the attribute entirely.
Attribute `aria-label` must not be empty. Either provide a meaningful value or remove the attribute entirely.
```

`aria-*` is deliberately left alone. 

Resolves #2018
