### PR TITLE
Linter: Don't flag String literals in `erb-no-unsafe-raw`

### DIFF
--- a/javascript/packages/linter/docs/rules/erb-no-unsafe-raw.md
+++ b/javascript/packages/linter/docs/rules/erb-no-unsafe-raw.md
@@ -12,6 +12,8 @@ Rails automatically escapes ERB output to prevent XSS. Using `raw()` or `.html_s
 
 For example, `<%= raw unsafe.to_json %>` is flagged because `raw()` disables escaping on the entire expression, even though `.to_json` serializes the value safely. The `raw()` wrapper means any future changes to the expression could silently introduce a vulnerability.
 
+Calling `.html_safe` directly on a String literal, like `<%= "<strong>Sale</strong>".html_safe %>`, is not flagged by this rule. The content is static, so there is no value that could ever carry injected input. Those cases are reported by [`actionview-no-unnecessary-html-safe`](./actionview-no-unnecessary-html-safe.md) instead, which points out that the content belongs in the template directly. Anything else, including an interpolated String like `<%= "<strong>#{name}</strong>".html_safe %>`, stays flagged here.
+
 ## Examples
 
 ### ✅ Good

--- a/javascript/packages/linter/src/rules/erb-no-unsafe-raw.ts
+++ b/javascript/packages/linter/src/rules/erb-no-unsafe-raw.ts
@@ -1,6 +1,6 @@
 import { ParserRule } from "../types.js"
 import { ElementStackVisitor } from "./rule-utils.js"
-import { PrismVisitor, isERBOutputNode, locationFromByteOffset } from "@herb-tools/core"
+import { PrismVisitor, isERBOutputNode, isPrismNodeType, locationFromByteOffset } from "@herb-tools/core"
 
 import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types.js"
 import type { ParseResult, ParserOptions, ERBContentNode, PrismNode, Location } from "@herb-tools/core"
@@ -18,6 +18,10 @@ const RAW_TEXT_ELEMENTS = new Set([
   "plaintext",
 ])
 
+function isHTMLSafeOnStringLiteral(node: PrismNode): boolean {
+  return isPrismNodeType(node.receiver, "StringNode")
+}
+
 class UnsafeRawCallCollector extends PrismVisitor {
   public readonly rawCalls: PrismNode[] = []
   public readonly htmlSafeCalls: PrismNode[] = []
@@ -33,7 +37,7 @@ class UnsafeRawCallCollector extends PrismVisitor {
       this.rawCalls.push(node)
     }
 
-    if (node.name === "html_safe") {
+    if (node.name === "html_safe" && !isHTMLSafeOnStringLiteral(node)) {
       this.htmlSafeCalls.push(node)
     }
 

--- a/javascript/packages/linter/test/rules/erb-no-unsafe-raw.test.ts
+++ b/javascript/packages/linter/test/rules/erb-no-unsafe-raw.test.ts
@@ -95,6 +95,46 @@ describe("ERBNoUnsafeRawRule", () => {
         <p><%= user_input.html_safe %></p>
       `)
     })
+
+    test("html_safe on an interpolated String is not allowed", () => {
+      expectError(HTML_SAFE_MESSAGE)
+
+      assertOffenses(dedent`
+        <p><%= "<strong>#{user_input}</strong>".html_safe %></p>
+      `)
+    })
+  })
+
+  describe(".html_safe on String literals", () => {
+    test("html_safe on a String literal is allowed", () => {
+      expectNoOffenses(dedent`
+        <p><%= "<strong>Sale</strong>".html_safe %></p>
+      `)
+    })
+
+    test("html_safe on a String literal in attribute position is allowed", () => {
+      expectNoOffenses(`<div <%= 'style="display: none;"'.html_safe %>></div>`)
+    })
+
+    test("html_safe on a String literal in an attribute value is allowed", () => {
+      expectNoOffenses(dedent`
+        <div class="<%= 'btn btn-primary'.html_safe %>"></div>
+      `)
+    })
+
+    test("html_safe on a String literal argument is allowed", () => {
+      expectNoOffenses(dedent`
+        <p><%= link_to "<strong>Sale</strong>".html_safe, sale_path %></p>
+      `)
+    })
+
+    test("html_safe on a String literal with another call in between is not allowed", () => {
+      expectError(HTML_SAFE_MESSAGE)
+
+      assertOffenses(dedent`
+        <p><%= "<strong>Sale</strong>".dup.html_safe %></p>
+      `)
+    })
   })
 
   describe("raw with to_json", () => {


### PR DESCRIPTION
Follow up on #2007.

`erb-no-unsafe-raw` flags every `.html_safe` call in an ERB output tag with:

```
Avoid `.html_safe` in ERB output. It bypasses HTML escaping and can cause cross-site scripting (XSS) vulnerabilities.
```

That is not true when `.html_safe` is called directly on a String literal. The content is static, so there is no value that escaping could ever apply to and nothing that could carry injected input:

```html+erb
<div <%= 'style="display: none;"'.html_safe %>></div>
<p><%= "<strong>Sale</strong>".html_safe %></p>
```

Since #2007 those templates are already reported by `actionview-no-unnecessary-html-safe`, which points out that the content belongs in the template directly and offers an autocorrection for it. Until now both rules reported the same tag and only one of the two messages was accurate.

This pull request therefore makes `erb-no-unsafe-raw` skip `.html_safe` calls whose receiver is a plain `StringNode`.