### PR TITLE
Linter: Improve unextractable tags in `erb-no-duplicate-branch-elements`

### DIFF
--- a/javascript/packages/linter/docs/rules/erb-no-duplicate-branch-elements.md
+++ b/javascript/packages/linter/docs/rules/erb-no-duplicate-branch-elements.md
@@ -6,6 +6,8 @@
 
 Disallow the same HTML elements wrapping content in every branch of an ERB conditional (`if/elsif/else`, `unless/else`, `case/when/else`). When all branches share identical wrapper elements, those elements should be hoisted outside the conditional. Only flags when all branches are covered (i.e., an `else` clause is present).
 
+Elements that are byte-for-byte identical in every branch can always be moved out, and are reported as warnings. A shared tag whose *content* differs between branches can only be extracted by wrapping the entire conditional in it, so it is reported as a hint, and only when that rewrite is available: every branch must consist of nothing but shared elements, and only one of them may differ in content. Anything else would require splitting the conditional into several, which duplicates the condition instead of the markup, so it is not reported.
+
 ## Rationale
 
 Duplicated wrapper elements across all branches of a conditional are unnecessary repetition. Moving them outside the conditional reduces template size, makes the structure clearer, and avoids the risk of branches getting out of sync when one is updated but others are forgotten.
@@ -51,6 +53,30 @@ Incomplete branch coverage:
 ```erb
 <% if condition %>
   <div>Hello World</div>
+<% end %>
+```
+
+A shared tag with differing content alongside a sibling that has to stay inside the conditional. Wrapping the conditional in `<p>` would move the links inside it too:
+
+```erb
+<% if condition %>
+  <p class="mt-3">Hello World</p>
+  <%= link_to "Hello", hello_path %>
+<% else %>
+  <p class="mt-3">Goodbye World</p>
+  <%= link_to "Goodbye", goodbye_path %>
+<% end %>
+```
+
+More than one shared tag with differing content, where no single tag can wrap the conditional:
+
+```erb
+<% if condition %>
+  <h1>Hello</h1>
+  <p>Hello World</p>
+<% else %>
+  <h1>Goodbye</h1>
+  <p>Goodbye World</p>
 <% end %>
 ```
 

--- a/javascript/packages/linter/src/cli/fixability.ts
+++ b/javascript/packages/linter/src/cli/fixability.ts
@@ -9,6 +9,7 @@ const NOT_FIXABLE: Fixability = { autocorrectable: false, unsafeAutocorrectable:
 
 export function fixabilityFor(offense: LintOffense, ruleClass: RuleClass | undefined): Fixability {
   if (!ruleClass) return NOT_FIXABLE
+  if (ruleClass.autofixRequiresContext === true && !offense.autofixContext) return NOT_FIXABLE
 
   const correctable = ruleClass.autocorrectable === true
   const unsafe = ruleClass.unsafeAutocorrectable === true || offense.autofixContext?.unsafe === true

--- a/javascript/packages/linter/src/rules/erb-no-duplicate-branch-elements.ts
+++ b/javascript/packages/linter/src/rules/erb-no-duplicate-branch-elements.ts
@@ -43,6 +43,10 @@ function trimWhitespaceNodes(nodes: Node[]): Node[] {
   return nodes.slice(start, end)
 }
 
+function haveIdenticalBodies(elements: HTMLElementNode[]): boolean {
+  return elements.every(element => IdentityPrinter.print(element) === IdentityPrinter.print(elements[0]))
+}
+
 function allEquivalentElements(nodes: Node[]): nodes is HTMLElementNode[] {
   if (nodes.length < 2) return false
   if (!nodes.every(node => isHTMLElementNode(node))) return false
@@ -228,51 +232,55 @@ class ERBNoDuplicateBranchElementsVisitor extends BaseRuleVisitor<DuplicateBranc
     const prefixCount = findCommonPrefixCount(significantBranches, minLength)
     const suffixCount = findCommonSuffixCount(significantBranches, minLength, prefixCount)
 
+    const groups: HTMLElementNode[][] = []
+
     for (let index = 0; index < prefixCount; index++) {
-      const elements = significantBranches.map(branch => branch[index] as HTMLElementNode)
-      this.reportAndRecurse(elements, conditionalNode, state)
+      groups.push(significantBranches.map(branch => branch[index] as HTMLElementNode))
     }
 
     for (let offset = 0; offset < suffixCount; offset++) {
-      const elements = significantBranches.map(branch => branch[branch.length - 1 - offset] as HTMLElementNode)
-      this.reportAndRecurse(elements, conditionalNode, state)
+      groups.push(significantBranches.map(branch => branch[branch.length - 1 - offset] as HTMLElementNode))
+    }
+
+    const sharedElementsSpanBranches = significantBranches.every(branch => branch.length === prefixCount + suffixCount)
+    const divergingGroupCount = groups.filter(elements => !haveIdenticalBodies(elements)).length
+    const canWrapConditional = sharedElementsSpanBranches && divergingGroupCount === 1
+
+    for (const elements of groups) {
+      this.reportAndRecurse(elements, conditionalNode, state, canWrapConditional)
     }
   }
 
-  private reportAndRecurse(elements: HTMLElementNode[], conditionalNode: ConditionalNode, state: { isFirstOffense: boolean }): void {
+  private reportAndRecurse(elements: HTMLElementNode[], conditionalNode: ConditionalNode, state: { isFirstOffense: boolean }, canWrapConditional: boolean): void {
     const bodies = elements.map(element => element.body)
-    const bodiesMatch = elements.every(element => IdentityPrinter.print(element) === IdentityPrinter.print(elements[0]))
+    const bodiesMatch = haveIdenticalBodies(elements)
 
-    for (const element of elements) {
-      const printed = IdentityPrinter.print(element.open_tag)
+    if (bodiesMatch || canWrapConditional) {
+      for (const element of elements) {
+        const printed = IdentityPrinter.print(element.open_tag)
 
-      if (bodiesMatch) {
         const autofixContext = state.isFirstOffense
           ? { node: conditionalNode as Mutable<ConditionalNode> }
           : undefined
 
-        this.addOffense(
-          `The \`${printed}\` element is duplicated across all branches of this conditional and can be moved outside.`,
-          element.location,
-          autofixContext,
-        )
+        if (bodiesMatch) {
+          this.addOffense(
+            `The \`${printed}\` element is duplicated across all branches of this conditional and can be moved outside.`,
+            element.location,
+            autofixContext,
+          )
+        } else {
+          const tagNameLocation = isHTMLOpenTagNode(element.open_tag) && element.open_tag.tag_name?.location
+            ? element.open_tag.tag_name.location
+            : element?.open_tag?.location || element.location
 
-        state.isFirstOffense = false
-      } else {
-        const autofixContext = state.isFirstOffense
-          ? { node: conditionalNode as Mutable<ConditionalNode> }
-          : undefined
-
-        const tagNameLocation = isHTMLOpenTagNode(element.open_tag) && element.open_tag.tag_name?.location
-          ? element.open_tag.tag_name.location
-          : element?.open_tag?.location || element.location
-
-        this.addOffense(
-          `The \`${printed}\` tag is repeated across all branches with different content. Consider extracting the shared tag outside the conditional.`,
-          tagNameLocation,
-          autofixContext,
-          "hint",
-        )
+          this.addOffense(
+            `The \`${printed}\` tag is repeated across all branches with different content. Consider extracting the shared tag outside the conditional.`,
+            tagNameLocation,
+            autofixContext,
+            "hint",
+          )
+        }
 
         state.isFirstOffense = false
       }
@@ -288,6 +296,7 @@ export class ERBNoDuplicateBranchElementsRule extends ParserRule<DuplicateBranch
   static ruleName = "erb-no-duplicate-branch-elements"
   static introducedIn = this.version("0.9.0")
   static autocorrectable = true
+  static autofixRequiresContext = true
   static reindentAfterAutofix = true
 
   get defaultConfig(): FullRuleConfig {

--- a/javascript/packages/linter/src/types.ts
+++ b/javascript/packages/linter/src/types.ts
@@ -109,6 +109,8 @@ export abstract class ParserRule<TAutofixContext extends BaseAutofixContext = Ba
   static unsafeAutocorrectable = false
   /** Indicates whether the source should be re-indented after autofix. Defaults to false. */
   static reindentAfterAutofix = false
+  /** Indicates that `autofix` can only fix offenses that carry an `autofixContext`. Offenses without one are reported as not correctable. Defaults to false. */
+  static autofixRequiresContext = false
   /** Indicates whether this rule consumes parser errors (like parser-no-errors). Rules with this flag are not skipped when parse results contain errors. */
   static consumesParserErrors = false
 
@@ -185,6 +187,8 @@ export abstract class LexerRule<TAutofixContext extends BaseAutofixContext = Bas
   static autocorrectable = false
   /** Indicates whether this rule supports unsafe autofix (requires --fix-unsafely). Defaults to false. */
   static unsafeAutocorrectable = false
+  /** Indicates that `autofix` can only fix offenses that carry an `autofixContext`. Offenses without one are reported as not correctable. Defaults to false. */
+  static autofixRequiresContext = false
 
   get ruleName(): string {
     return (this.constructor as typeof LexerRule).ruleName
@@ -236,6 +240,7 @@ export interface LexerRuleConstructor {
   introducedIn: RuleVersion
   autocorrectable?: boolean
   unsafeAutocorrectable?: boolean
+  autofixRequiresContext?: boolean
 }
 
 /**
@@ -275,6 +280,8 @@ export abstract class SourceRule<TAutofixContext extends BaseAutofixContext = Ba
   static autocorrectable = false
   /** Indicates whether this rule supports unsafe autofix (requires --fix-unsafely). Defaults to false. */
   static unsafeAutocorrectable = false
+  /** Indicates that `autofix` can only fix offenses that carry an `autofixContext`. Offenses without one are reported as not correctable. Defaults to false. */
+  static autofixRequiresContext = false
 
   get ruleName(): string {
     return (this.constructor as typeof SourceRule).ruleName
@@ -326,6 +333,7 @@ export interface SourceRuleConstructor {
   introducedIn: RuleVersion
   autocorrectable?: boolean
   unsafeAutocorrectable?: boolean
+  autofixRequiresContext?: boolean
 }
 
 /**
@@ -339,6 +347,7 @@ export type ParserRuleClass = (new () => ParserRule) & {
   introducedIn: RuleVersion
   autocorrectable?: boolean
   unsafeAutocorrectable?: boolean
+  autofixRequiresContext?: boolean
   reindentAfterAutofix?: boolean
   consumesParserErrors?: boolean
 }

--- a/javascript/packages/linter/test/fixability.test.ts
+++ b/javascript/packages/linter/test/fixability.test.ts
@@ -1,0 +1,48 @@
+import { describe, test, expect } from "vitest"
+import { Location } from "@herb-tools/core"
+
+import { fixabilityFor } from "../src/cli/fixability.js"
+
+import type { BaseAutofixContext, LintOffense, RuleClass } from "../src/types.js"
+
+function offense(autofixContext?: BaseAutofixContext): LintOffense {
+  return {
+    rule: "test-rule",
+    code: "test-rule",
+    source: "Herb Linter",
+    message: "message",
+    location: Location.zero,
+    severity: "warning",
+    autofixContext,
+  } as LintOffense
+}
+
+function ruleClass(properties: Partial<RuleClass>): RuleClass {
+  return { ruleName: "test-rule", ...properties } as RuleClass
+}
+
+const context = { node: { type: "AST_HTML_ELEMENT_NODE" } } as unknown as BaseAutofixContext
+
+describe("fixabilityFor", () => {
+  test("offenses of rules that are not autocorrectable are not fixable", () => {
+    expect(fixabilityFor(offense(), ruleClass({}))).toEqual({ autocorrectable: false, unsafeAutocorrectable: false })
+  })
+
+  test("offenses of autocorrectable rules are fixable without an autofix context", () => {
+    expect(fixabilityFor(offense(), ruleClass({ autocorrectable: true }))).toEqual({ autocorrectable: true, unsafeAutocorrectable: false })
+  })
+
+  test("offenses without an autofix context are not fixable when the rule requires one", () => {
+    const rule = ruleClass({ autocorrectable: true, autofixRequiresContext: true })
+
+    expect(fixabilityFor(offense(), rule)).toEqual({ autocorrectable: false, unsafeAutocorrectable: false })
+    expect(fixabilityFor(offense(context), rule)).toEqual({ autocorrectable: true, unsafeAutocorrectable: false })
+  })
+
+  test("offenses without an autofix context are not unsafely fixable when the rule requires one", () => {
+    const rule = ruleClass({ unsafeAutocorrectable: true, autofixRequiresContext: true })
+
+    expect(fixabilityFor(offense(), rule)).toEqual({ autocorrectable: false, unsafeAutocorrectable: false })
+    expect(fixabilityFor(offense(context), rule)).toEqual({ autocorrectable: false, unsafeAutocorrectable: true })
+  })
+})

--- a/javascript/packages/linter/test/rules/erb-no-duplicate-branch-elements.test.ts
+++ b/javascript/packages/linter/test/rules/erb-no-duplicate-branch-elements.test.ts
@@ -176,6 +176,30 @@ describe("erb-no-duplicate-branch-elements", () => {
         <% end %>
       `)
     })
+
+    it("shared tag with different content next to a sibling that cannot be hoisted", () => {
+      expectNoOffenses(dedent`
+        <% if condition? %>
+          <p class="mt-3 text-balance">Content</p>
+          <%= link_to "Link", other_path %>
+        <% else %>
+          <p class="mt-3 text-balance">Other content</p>
+          <%= link_to "Other link", other_path %>
+        <% end %>
+      `)
+    })
+
+    it("more than one shared tag with different content", () => {
+      expectNoOffenses(dedent`
+        <% if condition? %>
+          <p>One</p>
+          <div>Two</div>
+        <% else %>
+          <p>Three</p>
+          <div>Four</div>
+        <% end %>
+      `)
+    })
   })
 
   describe("offense: if/else", () => {


### PR DESCRIPTION
This pull request updates `erb-no-duplicate-branch-elements` to stop reporting shared tags that cannot actually be extracted, and makes the linter CLI stop advertising those offenses as autocorrectable.

```erb
<% if foo %>
  <p class="mt-3 text-balance">
    Content
  </p>

  <%= link_to "Link", other_path %>
<% else %>
  <p class="mt-3 text-balance">
    Other content
  </p>

  <%= link_to "Other link", other_path %>
<% end %>
```

which produced two hints plus `Fixable 2 offenses | 2 autocorrectable using --fix`, while `--fix` left the file untouched.

When the content of a shared tag differs between branches, the only way to extract it is to wrap the whole conditional in that tag. 

The rule reported the hint without checking that this rewrite was available. In the template above the `<p>` has a sibling `link_to` that has to stay inside the conditional, so wrapping would swallow the links too. The only remaining "fix" is to split the conditional into several, which duplicates the condition instead of the markup.

Resolves #1570
