### PR TITLE
Config: Always produce loadable YAML when mutating `.herb.yml`

### DIFF
--- a/rust/herb-config/src/mutation.rs
+++ b/rust/herb-config/src/mutation.rs
@@ -29,6 +29,12 @@ fn apply_mutation_to_document(document: &mut yerba::Document, mutation: &Value, 
       continue;
     }
 
+    if value.is_sequence() {
+      replace_or_insert_value(document, &path, value)?;
+
+      continue;
+    }
+
     set_or_insert(document, &path, &scalar_text(value))?;
   }
 
@@ -47,6 +53,14 @@ fn insert_value(document: &mut yerba::Document, path: &str, value: &Value) -> Re
   document
     .insert_into(path, &text, yerba::InsertPosition::Last)
     .map_err(|error| format!("failed to insert `{}`: {}", path, error))
+}
+
+fn replace_or_insert_value(document: &mut yerba::Document, path: &str, value: &Value) -> Result<(), String> {
+  if document.is_valid_selector(path) {
+    document.delete(path).map_err(|error| format!("failed to replace `{}`: {}", path, error))?;
+  }
+
+  insert_value(document, path, value)
 }
 
 fn set_or_insert(document: &mut yerba::Document, path: &str, value: &str) -> Result<(), String> {
@@ -69,13 +83,20 @@ fn scalar_text(value: &Value) -> String {
   }
 }
 
+fn ensure_loadable(yaml: String) -> Result<String, String> {
+  match serde_yaml::from_str::<serde_yaml::Value>(&yaml) {
+    Ok(_) => Ok(yaml),
+    Err(error) => Err(format!("the mutation produced invalid YAML and was not applied: {}", error)),
+  }
+}
+
 pub fn apply_mutation_to_yaml_string(yaml: &str, mutation: &HerbConfigOptions) -> Result<String, String> {
   let mut document = yerba::parse(yaml).map_err(|error| format!("failed to parse YAML: {}", error))?;
   let mutation = serde_yaml::to_value(mutation).map_err(|error| error.to_string())?;
 
   apply_mutation_to_document(&mut document, &mutation, "")?;
 
-  Ok(document.to_string())
+  ensure_loadable(document.to_string())
 }
 
 pub fn create_config_yaml_string(mutation: &HerbConfigOptions, version: Option<&str>) -> Result<String, String> {
@@ -91,7 +112,7 @@ pub fn create_config_yaml_string(mutation: &HerbConfigOptions, version: Option<&
     apply_mutation_to_document(&mut document, &mutation, "")?;
   }
 
-  Ok(document.to_string())
+  ensure_loadable(document.to_string())
 }
 
 pub fn mutate_config_file(config_path: &Path, mutation: &HerbConfigOptions, version: Option<&str>) -> Result<(), String> {

--- a/rust/herb-config/tests/mutation_test.rs
+++ b/rust/herb-config/tests/mutation_test.rs
@@ -65,3 +65,58 @@ fn mutate_config_file_writes_in_place_and_creates_when_missing() {
   assert!(updated.contains("# This file configures Herb for your project and team."));
   assert!(updated.contains("erb-no-empty-tags:"));
 }
+
+#[test]
+fn mutating_a_sequence_value_produces_loadable_yaml() {
+  let original = "version: 0.10.3\n\nfiles:\n  include:\n    - \"**/*.custom.erb\"\n  exclude:\n    - \"**/*.old.erb\"\n";
+  let mutation: HerbConfigOptions = serde_yaml::from_str("files:\n  include:\n    - \"**/*.new.erb\"\n").unwrap();
+
+  let updated = apply_mutation_to_yaml_string(original, &mutation).unwrap();
+  let parsed: serde_yaml::Value = serde_yaml::from_str(&updated).unwrap();
+
+  let include = parsed["files"]["include"].as_sequence().unwrap();
+
+  assert_eq!(include.len(), 1);
+  assert_eq!(include[0].as_str().unwrap(), "**/*.new.erb");
+  assert_eq!(parsed["files"]["exclude"][0].as_str().unwrap(), "**/*.old.erb");
+}
+
+#[test]
+fn mutating_a_config_with_anchors_and_aliases_keeps_it_loadable() {
+  let original = "version: 0.10.3\n\nlinter:\n  enabled: &flag true\n\nformatter:\n  enabled: *flag\n";
+  let mutation: HerbConfigOptions = serde_yaml::from_str("linter:\n  enabled: false\n").unwrap();
+
+  let updated = apply_mutation_to_yaml_string(original, &mutation).unwrap();
+
+  serde_yaml::from_str::<serde_yaml::Value>(&updated).expect("mutated config must still load");
+}
+
+#[test]
+fn a_mutation_that_would_produce_invalid_yaml_is_rejected() {
+  let original = "version: 0.10.3\n\nfiles:\n  include: &patterns\n    - \"a.erb\"\n  exclude: *patterns\n";
+  let mutation: HerbConfigOptions = serde_yaml::from_str("files:\n  include:\n    - \"b.erb\"\n").unwrap();
+
+  match apply_mutation_to_yaml_string(original, &mutation) {
+    Ok(updated) => {
+      serde_yaml::from_str::<serde_yaml::Value>(&updated).expect("if the mutation is applied the result must load");
+    }
+    Err(error) => assert!(error.contains("invalid YAML"), "unexpected error: {}", error),
+  }
+}
+
+#[test]
+fn a_rejected_mutation_leaves_the_config_file_untouched() {
+  let dir = tempfile::tempdir().unwrap();
+  let config_path = dir.path().join(".herb.yml");
+  let original = "version: 0.10.3\n\nfiles:\n  include: &patterns\n    - \"a.erb\"\n  exclude: *patterns\n";
+
+  fs::write(&config_path, original).unwrap();
+
+  let mutation: HerbConfigOptions = serde_yaml::from_str("files:\n  include:\n    - \"b.erb\"\n").unwrap();
+
+  if mutate_config_file(&config_path, &mutation, None).is_err() {
+    assert_eq!(fs::read_to_string(&config_path).unwrap(), original);
+  }
+
+  serde_yaml::from_str::<serde_yaml::Value>(&fs::read_to_string(&config_path).unwrap()).expect("config file must still load");
+}


### PR DESCRIPTION
This pull request fixes two ways `herb-config` could write a `.herb.yml` that no longer loads, and adds a guard so it cannot happen again.

Found while working on #1632, which enables YAML anchors and aliases in `.herb.yml`. Now that anchors are supported, configs using them flow into the mutation path for the first time, and Yerba has no anchor or alias handling.

Related #1632