### PR TITLE
Config: Support YAML merge keys in `.herb.yml`

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -440,6 +440,56 @@ Result for linter:
 If you want to include files from a default-excluded directory (e.g., `coverage/**`), add a more specific pattern to `include`. Include patterns are checked before exclude patterns when finding files.
 :::
 
+## Anchors, Aliases, and Merge Keys <Badge type="tip" text="^0.11.0" />
+
+`.herb.yml` supports YAML anchors (`&name`), aliases (`*name`), and merge keys (`<<:`), which are useful when the same block is repeated across rules or tools.
+
+```yaml [.herb.yml]
+linter:
+  rules:
+    html-tag-name-lowercase: &disabled
+      enabled: false
+
+    html-no-self-closing:
+      <<: *disabled
+```
+
+An anchor has to be declared before it can be aliased. To declare one without attaching it to a real setting, use a top-level key prefixed with `x-`. These keys are ignored when the configuration is validated:
+
+```yaml [.herb.yml]
+x-strict: &strict
+  enabled: true
+  severity: error
+
+linter:
+  rules:
+    html-no-event-handlers:
+      <<: *strict
+
+    html-no-duplicate-ids:
+      <<: *strict
+```
+
+Keys declared locally still win over merged ones, so a merged block can be overridden per rule:
+
+```yaml [.herb.yml]
+x-strict: &strict
+  enabled: true
+  severity: error
+
+linter:
+  rules:
+    html-no-event-handlers:
+      <<: *strict
+      severity: warning # overrides the merged `error`
+```
+
+::: warning Editing aliased values
+Commands that write to `.herb.yml`, such as the VS Code settings commands and `herb lint --disable`, change the value in place. If that value carries an anchor, every key aliasing it changes too. Herb reports the affected keys when this happens.
+:::
+
+Top-level keys that are not prefixed with `x-` are still validated, so a typo like `linterr:` is reported rather than silently ignored.
+
 ## Inspecting Configuration
 
 Use the `bundle exec herb config` command to inspect the resolved configuration and see which files will be processed:

--- a/javascript/packages/config/src/config.ts
+++ b/javascript/packages/config/src/config.ts
@@ -1151,7 +1151,7 @@ export class Config {
     let parsed: any
 
     try {
-      parsed = parse(text)
+      parsed = parse(text, { merge: true })
     } catch (error: any) {
       let line: number | undefined
       let column: number | undefined
@@ -1222,7 +1222,7 @@ export class Config {
     let parsed: any
 
     try {
-      parsed = parse(content)
+      parsed = parse(content, { merge: true })
     } catch (error) {
       if (exitOnError) {
         console.error(`\n✗ Invalid YAML syntax in ${configPath}`)

--- a/javascript/packages/config/src/config.ts
+++ b/javascript/packages/config/src/config.ts
@@ -123,6 +123,36 @@ export type FromObjectOptions = {
   configVersion?: string
 }
 
+export const ANCHOR_DEFINITION_PREFIX = "x-"
+
+/**
+ * Remove top-level keys that only exist to hold YAML anchors.
+ *
+ * Anchors have to be declared somewhere before they can be aliased. Keys
+ * prefixed with `x-` are reserved for that and are not validated as config:
+ *
+ * ```yaml
+ * x-defaults: &defaults
+ *   enabled: false
+ *
+ * formatter:
+ *   <<: *defaults
+ * ```
+ */
+function stripAnchorDefinitions(parsed: any): any {
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return parsed
+  }
+
+  for (const key of Object.keys(parsed)) {
+    if (key.startsWith(ANCHOR_DEFINITION_PREFIX)) {
+      delete parsed[key]
+    }
+  }
+
+  return parsed
+}
+
 export class Config {
   static configPath = ".herb.yml"
 
@@ -1151,7 +1181,7 @@ export class Config {
     let parsed: any
 
     try {
-      parsed = parse(text, { merge: true })
+      parsed = stripAnchorDefinitions(parse(text, { merge: true }))
     } catch (error: any) {
       let line: number | undefined
       let column: number | undefined
@@ -1222,7 +1252,7 @@ export class Config {
     let parsed: any
 
     try {
-      parsed = parse(content, { merge: true })
+      parsed = stripAnchorDefinitions(parse(content, { merge: true }))
     } catch (error) {
       if (exitOnError) {
         console.error(`\n✗ Invalid YAML syntax in ${configPath}`)

--- a/javascript/packages/config/test/config.test.ts
+++ b/javascript/packages/config/test/config.test.ts
@@ -1620,6 +1620,26 @@ describe("@herb-tools/config", () => {
     })
   })
 
+  describe("YAML merge keys", () => {
+    test("merges a mapping that uses a merge key", async () => {
+      createTestFile(testDir, ".herb.yml", dedent`
+        version: 0.10.3
+
+        linter:
+          rules:
+            html-tag-name-lowercase: &disabled
+              enabled: false
+            html-no-self-closing:
+              <<: *disabled
+      `)
+
+      const config = await Config.load(testDir, { version: "0.10.3", silent: true })
+
+      expect(config.isRuleDisabled("html-tag-name-lowercase")).toBe(true)
+      expect(config.isRuleDisabled("html-no-self-closing")).toBe(true)
+    })
+  })
+
   describe("version skew", () => {
     const invalidForOlderVersions = dedent`
       version: 0.10.3

--- a/javascript/packages/config/test/config.test.ts
+++ b/javascript/packages/config/test/config.test.ts
@@ -1640,6 +1640,35 @@ describe("@herb-tools/config", () => {
     })
   })
 
+  describe("anchor definition keys", () => {
+    test("ignores `x-` prefixed keys used to declare anchors", async () => {
+      createTestFile(testDir, ".herb.yml", dedent`
+        version: 0.10.3
+
+        x-defaults: &defaults
+          enabled: false
+
+        formatter:
+          <<: *defaults
+          indentWidth: 2
+      `)
+
+      const config = await Config.load(testDir, { version: "0.10.3", silent: true })
+
+      expect(config.isFormatterEnabled).toBe(false)
+      expect(config.config.formatter?.indentWidth).toBe(2)
+      expect((config.config as any)["x-defaults"]).toBeUndefined()
+    })
+
+    test("still rejects unknown top-level keys without the prefix", async () => {
+      createTestFile(testDir, ".herb.yml", "version: 0.10.3\ndefaults: true\n")
+
+      await expect(
+        Config.load(testDir, { version: "0.10.3", silent: true })
+      ).rejects.toThrow()
+    })
+  })
+
   describe("version skew", () => {
     const invalidForOlderVersions = dedent`
       version: 0.10.3

--- a/rust/herb-config/src/config.rs
+++ b/rust/herb-config/src/config.rs
@@ -504,6 +504,8 @@ impl Config {
       .apply_merge()
       .map_err(|error| format!("Invalid merge key in {}: {}", config_path.display(), error))?;
 
+    crate::merge::strip_anchor_definitions(&mut parsed);
+
     if parsed.is_null() {
       parsed = serde_yaml::Value::Mapping(Default::default());
     }

--- a/rust/herb-config/src/config.rs
+++ b/rust/herb-config/src/config.rs
@@ -500,6 +500,10 @@ impl Config {
     let mut parsed: serde_yaml::Value =
       serde_yaml::from_str(&content).map_err(|error| format!("Invalid YAML syntax in {}: {}", config_path.display(), error))?;
 
+    parsed
+      .apply_merge()
+      .map_err(|error| format!("Invalid merge key in {}: {}", config_path.display(), error))?;
+
     if parsed.is_null() {
       parsed = serde_yaml::Value::Mapping(Default::default());
     }

--- a/rust/herb-config/src/merge.rs
+++ b/rust/herb-config/src/merge.rs
@@ -40,3 +40,11 @@ pub fn deep_merge(target: &Value, source: &Value) -> Value {
 
   Value::Mapping(output)
 }
+
+pub const ANCHOR_DEFINITION_PREFIX: &str = "x-";
+
+pub fn strip_anchor_definitions(value: &mut Value) {
+  if let Some(mapping) = value.as_mapping_mut() {
+    mapping.retain(|key, _| !key.as_str().map(|key| key.starts_with(ANCHOR_DEFINITION_PREFIX)).unwrap_or(false));
+  }
+}

--- a/rust/herb-config/src/validation.rs
+++ b/rust/herb-config/src/validation.rs
@@ -69,6 +69,19 @@ pub fn validate_config_text(text: &str, options: &ValidateOptions) -> Vec<Config
     }
   };
 
+  if let Err(error) = parsed.apply_merge() {
+    errors.push(ConfigValidationError {
+      message: error.to_string(),
+      path: Vec::new(),
+      code: "yaml_merge_key_error".to_string(),
+      severity: Some(ValidationSeverity::Error),
+      line: None,
+      column: None,
+    });
+
+    return errors;
+  }
+
   if parsed.is_null() {
     parsed = serde_yaml::Value::Mapping(Default::default());
   }

--- a/rust/herb-config/src/validation.rs
+++ b/rust/herb-config/src/validation.rs
@@ -82,6 +82,8 @@ pub fn validate_config_text(text: &str, options: &ValidateOptions) -> Vec<Config
     return errors;
   }
 
+  crate::merge::strip_anchor_definitions(&mut parsed);
+
   if parsed.is_null() {
     parsed = serde_yaml::Value::Mapping(Default::default());
   }

--- a/rust/herb-config/tests/load_test.rs
+++ b/rust/herb-config/tests/load_test.rs
@@ -291,3 +291,36 @@ linter:
   assert!(config.is_rule_disabled("html-tag-name-lowercase"));
   assert!(config.is_rule_disabled("html-no-self-closing"));
 }
+
+#[test]
+fn load_ignores_anchor_definition_keys() {
+  let dir = tempfile::tempdir().unwrap();
+
+  fs::write(
+    dir.path().join(".herb.yml"),
+    r#"
+version: 0.10.3
+x-defaults: &defaults
+  enabled: false
+formatter:
+  <<: *defaults
+  indentWidth: 2
+"#,
+  )
+  .unwrap();
+
+  let config = Config::load(dir.path(), None).unwrap();
+
+  assert!(!config.is_formatter_enabled());
+  assert_eq!(config.formatter().unwrap().indent_width, Some(2));
+}
+
+#[test]
+fn load_still_rejects_unknown_top_level_keys() {
+  let dir = tempfile::tempdir().unwrap();
+  let config_path = dir.path().join(".herb.yml");
+
+  fs::write(&config_path, "version: 0.10.3\ndefaults: true\n").unwrap();
+
+  assert!(Config::load(&config_path, None).is_err());
+}

--- a/rust/herb-config/tests/load_test.rs
+++ b/rust/herb-config/tests/load_test.rs
@@ -242,3 +242,52 @@ files:
   assert!(files.exclude.as_ref().unwrap().contains(&"**/*.custom.erb".to_string()));
   assert!(files.exclude.as_ref().unwrap().contains(&"**/*.other.erb".to_string()));
 }
+
+#[test]
+fn load_supports_yaml_merge_keys() {
+  let dir = tempfile::tempdir().unwrap();
+
+  fs::write(
+    dir.path().join(".herb.yml"),
+    r#"
+version: 0.10.3
+linter:
+  rules: &rules
+    html-tag-name-lowercase:
+      enabled: false
+formatter:
+  enabled: false
+  indentWidth: 4
+"#,
+  )
+  .unwrap();
+
+  let config = Config::load(dir.path(), None).unwrap();
+
+  assert!(config.is_rule_disabled("html-tag-name-lowercase"));
+  assert!(!config.is_formatter_enabled());
+}
+
+#[test]
+fn load_merges_a_mapping_that_uses_a_merge_key() {
+  let dir = tempfile::tempdir().unwrap();
+
+  fs::write(
+    dir.path().join(".herb.yml"),
+    r#"
+version: 0.10.3
+linter:
+  rules:
+    html-tag-name-lowercase: &disabled
+      enabled: false
+    html-no-self-closing:
+      <<: *disabled
+"#,
+  )
+  .unwrap();
+
+  let config = Config::load(dir.path(), None).unwrap();
+
+  assert!(config.is_rule_disabled("html-tag-name-lowercase"));
+  assert!(config.is_rule_disabled("html-no-self-closing"));
+}


### PR DESCRIPTION
This pull request brings the JavaScript and Rust config loaders in line with Ruby on YAML merge keys, and adds a place to declare anchors so the pattern is actually usable.

Follow up on #1632, which enabled anchors and aliases in `.herb.yml`. Aliases worked in all three implementations after that, but merge keys did not.

Psych applies `<<:` when loading, so Ruby resolved merge keys for free. The JavaScript and Rust loaders left `<<` in place as a literal key, which then failed schema validation:

```
Unrecognized key: "<<" at "formatter"
```

A config that loaded fine under the Ruby tools failed in the VS Code extension and the Rust CLI.

The JavaScript loader now parses with `merge: true` and the Rust loader calls `apply_merge` before deserializing. Merge keys resolve recursively, and locally declared keys still win over merged ones, matching Psych:

```yaml
linter:
  rules:
    html-tag-name-lowercase: &disabled
      enabled: false

    html-no-self-closing:
      <<: *disabled
```