### PR TITLE
Config: Report when a mutation writes through a YAML alias

### DIFF
--- a/javascript/packages/config/src/config.ts
+++ b/javascript/packages/config/src/config.ts
@@ -4,7 +4,7 @@ import packageJson from "../package.json"
 import configTemplate from "./config-template.yml"
 import defaultsYaml from "../../../../lib/herb/defaults.yml"
 
-import { stringify, parse, parseDocument, isMap } from "yaml"
+import { stringify, parse, parseDocument, isMap, isScalar, isAlias, visit } from "yaml"
 import { semverGreaterThan } from "@herb-tools/core"
 import { promises as fs } from "fs"
 import { fromZodError } from "zod-validation-error"
@@ -793,16 +793,75 @@ export class Config {
    *   }
    * })
    */
+  /**
+   * Find mutation targets whose value carries a YAML anchor that is aliased
+   * elsewhere in the config.
+   *
+   * Writing to such a value also changes every key aliasing it. That is what
+   * the alias asks for, but it is easy to miss, so callers can surface it.
+   *
+   * @param yamlContent - The raw YAML content of the config file
+   * @param mutation - The mutation about to be applied
+   * @returns The affected paths, as dot-separated strings
+   */
+  static aliasedMutationTargets(
+    yamlContent: string,
+    mutation: Partial<HerbConfigOptions>
+  ): string[] {
+    let document
+
+    try {
+      document = parseDocument(yamlContent, { merge: true })
+    } catch {
+      return []
+    }
+
+    const aliased = new Set<string>()
+
+    visit(document, {
+      Alias(_key, node) {
+        if (node.source) aliased.add(node.source)
+      }
+    })
+
+    if (aliased.size === 0) return []
+
+    const affected: string[] = []
+
+    const walk = (value: any, pathParts: string[]) => {
+      if (value === null || typeof value !== "object" || Array.isArray(value)) {
+        const node = document.getIn(pathParts, true)
+
+        if (isScalar(node) && node.anchor && aliased.has(node.anchor)) {
+          affected.push(pathParts.join("."))
+        }
+
+        return
+      }
+
+      for (const [key, nested] of Object.entries(value)) {
+        walk(nested, [...pathParts, key])
+      }
+    }
+
+    walk(mutation, [])
+
+    return affected
+  }
+
   static async mutateConfigFile(
     configPath: string,
     mutation: Partial<HerbConfigOptions>
-  ): Promise<void> {
+  ): Promise<string[]> {
     let yamlContent: string
+    let aliasedTargets: string[] = []
 
     try {
       const existingContent = await fs.readFile(configPath, 'utf-8')
 
       if (Object.keys(mutation).length > 0) {
+        aliasedTargets = this.aliasedMutationTargets(existingContent, mutation)
+
         const document = parseDocument(existingContent)
 
         const validation = HerbConfigSchema.safeParse(document.toJSON())
@@ -849,6 +908,8 @@ export class Config {
     }
 
     await fs.writeFile(configPath, yamlContent, 'utf-8')
+
+    return aliasedTargets
   }
 
   /**

--- a/javascript/packages/config/test/config.test.ts
+++ b/javascript/packages/config/test/config.test.ts
@@ -1669,6 +1669,55 @@ describe("@herb-tools/config", () => {
     })
   })
 
+  describe("Config.aliasedMutationTargets", () => {
+    const shared = dedent`
+      version: 0.10.3
+
+      linter:
+        enabled: &flag true
+
+      formatter:
+        enabled: *flag
+    `
+
+    test("reports a mutation target whose value is aliased elsewhere", () => {
+      const targets = Config.aliasedMutationTargets(shared, { linter: { enabled: false } })
+
+      expect(targets).toEqual(["linter.enabled"])
+    })
+
+    test("reports nothing when the mutation target is not anchored", () => {
+      const targets = Config.aliasedMutationTargets(shared, { formatter: { indentWidth: 4 } })
+
+      expect(targets).toEqual([])
+    })
+
+    test("reports nothing when the anchor is never aliased", () => {
+      const unaliased = dedent`
+        version: 0.10.3
+
+        linter:
+          enabled: &flag true
+      `
+
+      expect(Config.aliasedMutationTargets(unaliased, { linter: { enabled: false } })).toEqual([])
+    })
+
+    test("reports nothing for a config without anchors", () => {
+      const plain = "version: 0.10.3\n\nlinter:\n  enabled: true\n"
+
+      expect(Config.aliasedMutationTargets(plain, { linter: { enabled: false } })).toEqual([])
+    })
+
+    test("mutateConfigFile returns the affected paths", async () => {
+      const configPath = createTestFile(testDir, ".herb.yml", shared)
+
+      const targets = await Config.mutateConfigFile(configPath, { linter: { enabled: false } })
+
+      expect(targets).toEqual(["linter.enabled"])
+    })
+  })
+
   describe("version skew", () => {
     const invalidForOlderVersions = dedent`
       version: 0.10.3

--- a/javascript/packages/vscode/src/herb-settings-commands.ts
+++ b/javascript/packages/vscode/src/herb-settings-commands.ts
@@ -4,6 +4,14 @@ import * as path from "path"
 import { Config } from "@herb-tools/config"
 import { HerbConfigProvider } from "./config-provider"
 
+function warnAboutAliasedTargets(targets: string[]) {
+  if (targets.length === 0) return
+
+  vscode.window.showWarningMessage(
+    `This also changed every key aliasing ${targets.join(', ')} in your Herb configuration.`
+  )
+}
+
 /**
  * Commands to modify .herb.yml settings directly through VS Code
  */
@@ -78,13 +86,15 @@ export class HerbSettingsCommands {
     if (choice === undefined) {return}
 
     try {
-      await Config.mutateConfigFile(configPath, {
+      const aliasedTargets = await Config.mutateConfigFile(configPath, {
         linter: { enabled: choice.value }
       })
 
       vscode.window.showInformationMessage(
         `Herb Linter ${choice.value ? 'enabled' : 'disabled'} in Herb configuration`
       )
+
+      warnAboutAliasedTargets(aliasedTargets)
 
       vscode.commands.executeCommand('herb.refreshLanguageServer')
       if (this.configProvider) {
@@ -124,13 +134,15 @@ export class HerbSettingsCommands {
     if (choice === undefined) {return}
 
     try {
-      await Config.mutateConfigFile(configPath, {
+      const aliasedTargets = await Config.mutateConfigFile(configPath, {
         formatter: { enabled: choice.value }
       })
 
       vscode.window.showInformationMessage(
         `Herb Formatter ${choice.value ? 'enabled' : 'disabled'} in Herb configuration`
       )
+
+      warnAboutAliasedTargets(aliasedTargets)
 
       vscode.commands.executeCommand('herb.refreshLanguageServer')
       if (this.configProvider) {
@@ -169,13 +181,15 @@ export class HerbSettingsCommands {
     const indentWidth = parseInt(input)
 
     try {
-      await Config.mutateConfigFile(configPath, {
+      const aliasedTargets = await Config.mutateConfigFile(configPath, {
         formatter: { indentWidth }
       })
 
       vscode.window.showInformationMessage(
         `Herb formatter indent width set to ${indentWidth} spaces`
       )
+
+      warnAboutAliasedTargets(aliasedTargets)
 
       vscode.commands.executeCommand('herb.refreshLanguageServer')
 
@@ -213,13 +227,15 @@ export class HerbSettingsCommands {
     const maxLineLength = parseInt(input)
 
     try {
-      await Config.mutateConfigFile(configPath, {
+      const aliasedTargets = await Config.mutateConfigFile(configPath, {
         formatter: { maxLineLength }
       })
 
       vscode.window.showInformationMessage(
         `Herb formatter max line length set to ${maxLineLength} characters`
       )
+
+      warnAboutAliasedTargets(aliasedTargets)
 
       vscode.commands.executeCommand('herb.refreshLanguageServer')
 


### PR DESCRIPTION
This pull request makes the commands that write to `.herb.yml` report when the value they changed is aliased elsewhere in the file.

Based on #2034, which stops mutations from writing invalid YAML. This one covers the case where the write succeeds and the file stays valid, but changes more than the user asked for.

#### The problem

Writing to a value that carries an anchor also changes every key aliasing it:

```yaml
version: 0.10.3

linter:
  enabled: &flag true

formatter:
  enabled: *flag
```

Running "Disable Herb Linter" in VS Code writes `enabled: &flag false`, which disables the formatter too. The file is valid and the result is what the alias asks for, so the behaviour is left alone. The problem was that nothing said so, and the effect is invisible unless you reread the config.


Related #1632