### PR TITLE
C: Fix `bench_allocs` include path and run it in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,5 +88,8 @@ jobs:
       - name: Run C tests
         run: ./run_herb_tests
 
+      - name: Run allocation benchmark
+        run: make bench_allocs
+
       - name: Run valgrind on examples/
         run: ./bin/valgrind_check_examples

--- a/bench/bench_allocs.c
+++ b/bench/bench_allocs.c
@@ -1,5 +1,5 @@
 #include "../src/include/herb.h"
-#include "../src/include/util/hb_allocator.h"
+#include "../src/include/lib/hb_allocator.h"
 
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
This pull request fixes the `bench_allocs` target, which has not compiled since the `src/` reorganization, and adds it to the build workflow so that it does not silently break again.

`bench/bench_allocs.c` still included `../src/include/util/hb_allocator.h`, but #1439 moved `src/util/` to `src/lib/`, so the target failed to build:

```
bench/bench_allocs.c:2:10: fatal error: '../src/include/util/hb_allocator.h' file not found
    2 | #include "../src/include/util/hb_allocator.h"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```

Discovered while working on #1292.
