### PR TITLE
Ruby: Problem running `bundle console`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gemspec
 
 gem "prism", github: "ruby/prism", tag: "v1.9.0"
 
-gem "actionview", "~> 8.1"
+gem "actionview", "~> 8.1", require: "action_view"
 gem "benchmark"
 gem "charm"
 gem "cruise"
@@ -25,7 +25,7 @@ gem "reactionview", "~> 0.3.0"
 gem "reline", "~> 0.6"
 gem "rubocop", "~> 1.71"
 gem "sorbet"
-gem "turbo-rails", "~> 2.0"
+gem "turbo-rails", "~> 2.0", require: false
 gem "yerba", "~> 0.9"
 
 # TODO: remove once https://github.com/soutaro/steep/pull/2255 ships


### PR DESCRIPTION
## What does this PR do?

Resoles #1862 

While setting up the project, running `bundle console` failed with:

```text
uninitialized constant ReActionView::Template::Handlers::ActionView
```

This happened because the `actionview` gem was installed, but Bundler tried to require it using the gem name instead of its actual entrypoint, `action_view`. As a result, ReActionView was loaded before the `ActionView` constant was available.

`turbo-rails` was also being loaded automatically, even though it expects a fully initialized Rails application.

This PR:

- Configures `actionview` to load through `action_view`.
- Keeps ReActionView loading after Action View.
- Prevents `turbo-rails` from automatically loading in this standalone gem project.

## Verification

After these changes, `bundle console` starts successfully and both `ActionView` and `ReActionView` load as expected.