### PR TITLE
Language Server: Implement hover for `render` partials

### DIFF
--- a/javascript/packages/language-server/src/definition_service.ts
+++ b/javascript/packages/language-server/src/definition_service.ts
@@ -1,25 +1,33 @@
-import { Location, LocationLink, Position, Range } from "vscode-languageserver/node"
+import { Hover, Location, LocationLink, MarkupKind, Position, Range } from "vscode-languageserver/node"
+import { IdentityPrinter } from "@herb-tools/printer"
 import { ParserService } from "./parser_service"
 import { RenderCollector } from "./render_collector"
 
-import { existsSync } from "fs"
+import { existsSync, readFileSync } from "fs"
 import { posix as path } from "path"
 import { pathFromUri, uriFromPath } from "./utils"
 import { isPositionInRange, lspRangeFromLocation } from "./range_utils"
+import { getTagName, isERBStrictLocalsNode, isHTMLElementNode, isPureWhitespaceNode } from "@herb-tools/core"
 
 import type { TextDocument } from "vscode-languageserver-textdocument"
-import type { DocumentNode } from "@herb-tools/core"
+import type { DocumentNode, ERBRenderNode, Node } from "@herb-tools/core"
 
 const VIEWS_DIRECTORY = "/app/views/"
 const APPLICATION_DIRECTORY = "application"
 const TEMPLATE_EXTENSIONS = ["html.erb", "html.herb", "turbo_stream.erb", "turbo_stream.herb", "erb", "herb"]
 const PARTIAL_NAME = /^[a-zA-Z0-9_-]+(\/[a-zA-Z0-9_-]+)*$/
-const PARTIAL_KEYWORD = "partial"
+const PARTIAL_KEYWORDS = ["partial", "layout"]
 const IDENTIFIER_CHARACTER = /[A-Za-z0-9_]/
 const QUOTE = /^["']/
+const SNIPPET_LINES = 6
+const OPEN_TAG_WIDTH = 80
+const PRINT_OPTIONS = { ignoreErrors: true }
 
 interface PartialReference {
   name: string
+  keyword: string
+  quoted: boolean
+  derived: boolean
   triggerRange: Range
   originRange: Range
 }
@@ -27,16 +35,28 @@ interface PartialReference {
 export class DefinitionService {
   private parserService: ParserService
   private exists: (filePath: string) => boolean
+  private read: (filePath: string) => string | null
 
-  constructor(parserService: ParserService, exists: (filePath: string) => boolean = existsSync) {
+  constructor(
+    parserService: ParserService,
+    exists: (filePath: string) => boolean = existsSync,
+    read: (filePath: string) => string | null = filePath => {
+      try {
+        return readFileSync(filePath, "utf-8")
+      } catch {
+        return null
+      }
+    }
+  ) {
     this.parserService = parserService
     this.exists = exists
+    this.read = read
   }
 
   getDefinition(document: TextDocument, position: Position): LocationLink[] {
-    const reference = this.partialAt(document, position)
+    const reference = this.referenceAt(document, position)
 
-    if (!reference) return []
+    if (!reference || !this.isStatic(reference)) return []
 
     const targetRange = Range.create(Position.create(0, 0), Position.create(0, 0))
 
@@ -48,35 +68,216 @@ export class DefinitionService {
     }))
   }
 
+  getHover(document: TextDocument, position: Position): Hover | null {
+    const reference = this.referenceAt(document, position)
+
+    if (!reference) return null
+
+    const documentPath = pathFromUri(document.uri)
+    const lines: string[] = []
+
+    if (!this.isStatic(reference)) {
+      lines.push(`Herb can't resolve this ${reference.keyword} statically.`, "")
+
+      if (reference.derived) {
+        lines.push(
+          `Rails derives the partial from \`to_partial_path\` on \`${reference.name}\` when the template renders.`,
+          "",
+          "Name the partial explicitly, with `object:` for a single record or `collection:` for many, and Herb can take you to it, check the locals you pass against its strict locals, and help you rename them:",
+          "",
+          "```erb",
+          `<%= render partial: "path/to/partial", object: ${reference.name} %>`,
+          "```"
+        )
+      } else if (reference.quoted) {
+        lines.push(
+          "The name is interpolated, so it's only known at runtime.",
+          "",
+          "Use a literal name and Herb can take you to it, check the locals you pass against its strict locals, and help you rename them:",
+          "",
+          "```erb",
+          `<%= render partial: "events/card" %>`,
+          "```"
+        )
+      } else {
+        lines.push(
+          "The name comes from a variable or method call, so it's only known at runtime.",
+          "",
+          "Use a literal name and Herb can take you to it, check the locals you pass against its strict locals, and help you rename them:",
+          "",
+          "```erb",
+          `<%= render partial: "events/card" %>`,
+          "```"
+        )
+      }
+    } else {
+      const resolved = this.resolve(documentPath, reference.name)
+
+      if (resolved.length > 0) {
+        lines.push(...resolved.map(filePath => `[${this.displayPath(filePath)}](${uriFromPath(filePath)})`))
+        lines.push(...this.preview(resolved[0]))
+      } else {
+        lines.push(
+          `No ${reference.keyword} found for \`${reference.name}\`.`,
+          "",
+          "Looked for:",
+          ...this.expected(documentPath, reference.name).map(filePath => `- \`${this.displayPath(filePath)}\``)
+        )
+      }
+    }
+
+    return {
+      contents: { kind: MarkupKind.Markdown, value: lines.join("\n") },
+      range: reference.originRange,
+    }
+  }
+
   static asLocations(links: LocationLink[]): Location[] {
     return links.map(link => Location.create(link.targetUri, link.targetRange))
   }
 
-  private partialAt(document: TextDocument, position: Position): PartialReference | null {
+  private isStatic(reference: PartialReference): boolean {
+    return reference.quoted && PARTIAL_NAME.test(reference.name)
+  }
+
+  private referenceAt(document: TextDocument, position: Position): PartialReference | null {
     const result = this.parserService.parseContent(document.getText(), { render_nodes: true })
-
-    if (result.failed) return null
-
     const collector = new RenderCollector()
 
     collector.visit(result.value as DocumentNode)
 
     for (const render of collector.renders) {
-      const partial = render.keywords?.partial
+      const reference = this.referenceFor(document, render)
 
-      if (!partial) continue
+      if (!reference) continue
+      if (!isPositionInRange(position, reference.triggerRange)) continue
 
-      const range = lspRangeFromLocation(partial.location)
-      const triggerRange = this.withKeyword(document, range)
-
-      if (!isPositionInRange(position, triggerRange)) continue
-      if (!QUOTE.test(document.getText(range))) return null
-      if (!PARTIAL_NAME.test(partial.value)) return null
-
-      return { name: partial.value, triggerRange, originRange: this.withoutQuotes(document, range) }
+      return reference
     }
 
     return null
+  }
+
+  private referenceFor(document: TextDocument, render: ERBRenderNode): PartialReference | null {
+    const keywords = render.keywords
+    const partial = keywords?.partial ?? keywords?.layout
+    const rendered = partial ?? keywords?.object ?? keywords?.collection
+
+    if (!rendered) return null
+
+    const range = lspRangeFromLocation(rendered.location)
+    const quoted = QUOTE.test(rendered.value) || QUOTE.test(document.getText(range))
+    const derived = !partial && !quoted
+
+    const reference = {
+      name: rendered.value,
+      keyword: keywords?.layout && !keywords?.partial ? "layout" : "partial",
+      quoted,
+      derived,
+      triggerRange: this.withKeyword(document, range),
+      originRange: derived ? range : this.withoutQuotes(document, range),
+    }
+
+    if (this.isStatic(reference)) return reference
+
+    const tagRange = this.tagRange(render)
+
+    return { ...reference, triggerRange: tagRange ?? reference.triggerRange, originRange: tagRange ?? reference.originRange }
+  }
+
+  private tagRange(render: ERBRenderNode): Range | null {
+    if (!render.tag_opening || !render.tag_closing) return null
+
+    return Range.create(
+      lspRangeFromLocation(render.tag_opening.location).start,
+      lspRangeFromLocation(render.tag_closing.location).end
+    )
+  }
+
+  private preview(filePath: string): string[] {
+    const source = this.read(filePath)
+
+    if (!source) return []
+
+    const declaration = this.strictLocalsDeclaration(source)
+    const body = this.outline(source)
+    const parts: string[] = []
+
+    if (declaration) parts.push(declaration)
+    if (body.length > 0) parts.push(body.join("\n"))
+
+    if (parts.length === 0) return []
+
+    return ["", "```erb", parts.join("\n\n"), "```"]
+  }
+
+  private strictLocalsDeclaration(source: string): string | null {
+    const result = this.parserService.parseContent(source, { strict_locals: true })
+    const node = result.value.compactChildNodes().find(child => isERBStrictLocalsNode(child))
+
+    if (!node) return null
+
+    const lines = source.split("\n").slice(node.location.start.line - 1, node.location.end.line)
+
+    return lines.join("\n").trim()
+  }
+
+  private outline(source: string): string[] {
+    const result = this.parserService.parseContent(source, { strict_locals: true, track_whitespace: true })
+
+    const nodes = result.value.compactChildNodes()
+      .filter(child => !isERBStrictLocalsNode(child))
+      .filter(child => !isPureWhitespaceNode(child))
+
+    const node = nodes.at(0)
+
+    if (!node) {
+      return []
+    }
+
+    const outline = this.outlineFor(node)
+
+    return nodes.length > 1 ? [...outline, "..."] : outline
+  }
+
+  private outlineFor(node: Node): string[] {
+    const printed = IdentityPrinter.print(node, PRINT_OPTIONS).trimEnd().split("\n")
+
+    if (printed.length <= SNIPPET_LINES) return printed
+
+    const boundaries = this.boundaries(node)
+
+    if (!boundaries) {
+      return [...printed.slice(0, SNIPPET_LINES), "..."]
+    }
+
+    return [...boundaries[0].split("\n"), "  ...", ...boundaries[1].split("\n")]
+  }
+
+  private boundaries(node: Node): [string, string] | null {
+    if (isHTMLElementNode(node)) {
+      if (!node.open_tag || !node.close_tag) return null
+
+      const openTag = IdentityPrinter.print(node.open_tag, PRINT_OPTIONS)
+      const collapsed = openTag.includes("\n") || openTag.length > OPEN_TAG_WIDTH
+
+      return [collapsed ? `<${getTagName(node)} …>` : openTag, IdentityPrinter.print(node.close_tag, PRINT_OPTIONS)]
+    }
+
+    const end = (node as { end_node?: Node }).end_node
+    const tags = node as { tag_opening?: { value: string }, content?: { value: string }, tag_closing?: { value: string } }
+
+    if (!end || !tags.tag_opening || !tags.tag_closing) {
+      return null
+    }
+
+    return [`${tags.tag_opening.value}${tags.content?.value ?? ""}${tags.tag_closing.value}`, IdentityPrinter.print(end, PRINT_OPTIONS)]
+  }
+
+  private displayPath(filePath: string): string {
+    const viewsRoot = this.viewsRoot(filePath)
+
+    return viewsRoot ? path.relative(path.dirname(path.dirname(viewsRoot)), filePath) : path.basename(filePath)
   }
 
   private withKeyword(document: TextDocument, range: Range): Range {
@@ -86,13 +287,18 @@ export class DefinitionService {
     if (!upToColon.endsWith(":")) return range
 
     const upToKeyword = upToColon.slice(0, -1).trimEnd()
+    const keyword = PARTIAL_KEYWORDS.find(candidate => upToKeyword.endsWith(candidate))
 
-    if (!upToKeyword.endsWith(PARTIAL_KEYWORD)) return range
+    if (!keyword) {
+      return range
+    }
 
-    const keywordStart = upToKeyword.length - PARTIAL_KEYWORD.length
+    const keywordStart = upToKeyword.length - keyword.length
     const characterBefore = upToKeyword[keywordStart - 1]
 
-    if (characterBefore && IDENTIFIER_CHARACTER.test(characterBefore)) return range
+    if (characterBefore && IDENTIFIER_CHARACTER.test(characterBefore)) {
+      return range
+    }
 
     return Range.create(Position.create(range.start.line, keywordStart), range.end)
   }
@@ -109,6 +315,16 @@ export class DefinitionService {
   }
 
   private resolve(documentPath: string, name: string): string[] {
+    return this.candidates(documentPath, name).filter(candidate => this.exists(candidate))
+  }
+
+  private expected(documentPath: string, name: string): string[] {
+    const extension = this.templateExtension(documentPath)
+
+    return this.candidates(documentPath, name).filter(candidate => candidate.endsWith(`.${extension}`))
+  }
+
+  private candidates(documentPath: string, name: string): string[] {
     const segments = name.split("/")
     const base = segments.pop()!
     const viewsRoot = this.viewsRoot(documentPath)
@@ -127,11 +343,9 @@ export class DefinitionService {
 
     const extensions = [...new Set([this.templateExtension(documentPath), ...TEMPLATE_EXTENSIONS])]
 
-    const candidates = [...new Set(
+    return [...new Set(
       directories.flatMap(directory => extensions.map(extension => path.join(directory, `_${base}.${extension}`)))
     )]
-
-    return candidates.filter(candidate => this.exists(candidate))
   }
 
   private viewsRoot(documentPath: string): string | null {

--- a/javascript/packages/language-server/src/server.ts
+++ b/javascript/packages/language-server/src/server.ts
@@ -194,7 +194,7 @@ export class Server {
 
       if (!document) return null
 
-      return this.service.hoverService.getHover(document, params.position)
+      return this.service.hoverService.getHover(document, params.position) ?? this.service.definitionService.getHover(document, params.position)
     })
 
     this.connection.onCompletion((params: CompletionParams) => {

--- a/javascript/packages/language-server/test/definition_service.test.ts
+++ b/javascript/packages/language-server/test/definition_service.test.ts
@@ -19,7 +19,15 @@ describe("DefinitionService", () => {
   function createService(...files: string[]) {
     const existing = new Set(files)
 
-    return new DefinitionService(parserService, filePath => existing.has(filePath))
+    return new DefinitionService(parserService, filePath => existing.has(filePath), () => "")
+  }
+
+  function createServiceWith(files: Record<string, string>) {
+    return new DefinitionService(
+      parserService,
+      filePath => filePath in files,
+      filePath => files[filePath] ?? null
+    )
   }
 
   function definitions(service: DefinitionService, content: string, target: string, uri = VIEW_URI) {
@@ -172,6 +180,395 @@ describe("DefinitionService", () => {
     })
   })
 
+  describe("hover", () => {
+    function hover(service: DefinitionService, content: string, target: string, uri = VIEW_URI) {
+      const document = TextDocument.create(uri, "erb", 1, content)
+      const position = document.positionAt(content.indexOf(target) + 1)
+      const result = service.getHover(document, position)
+
+      return result ? (result.contents as { value: string }).value : null
+    }
+
+    it("links the resolved partial", () => {
+      const service = createService("/project/app/views/events/_featured_home.html.erb")
+      const content = `<%= render partial: "events/featured_home" %>`
+
+      expect(hover(service, content, "featured_home")).toBe(
+        "[app/views/events/_featured_home.html.erb](file:///project/app/views/events/_featured_home.html.erb)"
+      )
+    })
+
+    it("shows the strict locals of the resolved partial", () => {
+      const service = createServiceWith({
+        "/project/app/views/events/_card.html.erb": `<%# locals: (event:, size: "sm") %>\n\n<div><%= event.name %></div>`
+      })
+
+      const message = hover(service, `<%= render partial: "events/card" %>`, "events/card")
+
+      expect(message).toContain(`<%# locals: (event:, size: "sm") %>\n\n<div><%= event.name %></div>`)
+      expect(message.match(/```erb/g)).toHaveLength(1)
+    })
+
+    it("shows a snippet when the partial has no strict locals", () => {
+      const service = createServiceWith({
+        "/project/app/views/events/_card.html.erb": `<div class="card">\n  <h1><%= @event.name %></h1>\n</div>`
+      })
+
+      const message = hover(service, `<%= render partial: "events/card" %>`, "events/card")
+
+      expect(message).not.toContain("locals:")
+      expect(message).toContain(`<div class="card">`)
+      expect(message).toContain("<h1><%= @event.name %></h1>")
+    })
+
+    it("collapses the body of a long element", () => {
+      const service = createServiceWith({
+        "/project/app/views/events/_card.html.erb": [
+          `<div class="card">`,
+          ...Array.from({ length: 12 }, (_, index) => `  <p>line ${index}</p>`),
+          `</div>`
+        ].join("\n")
+      })
+
+      const message = hover(service, `<%= render partial: "events/card" %>`, "events/card")
+
+      expect(message).toContain(`<div class="card">`)
+      expect(message).toContain("...")
+      expect(message).toContain("</div>")
+      expect(message).not.toContain("<p>line 5</p>")
+    })
+
+    it("collapses a long element into its outermost tags", () => {
+      const service = createServiceWith({
+        "/project/app/views/events/_card.html.erb": [
+          `<section`,
+          `  class="a-very-long-set-of-utility-classes that-keeps-going and-going and-going"`,
+          `  data-controller="card">`,
+          ...Array.from({ length: 8 }, (_, index) => `  <p>line ${index}</p>`),
+          `</section>`
+        ].join("\n")
+      })
+
+      const message = hover(service, `<%= render partial: "events/card" %>`, "events/card")
+
+      expect(message).toContain("<section …>")
+      expect(message).toContain("</section>")
+      expect(message).not.toContain("data-controller")
+    })
+
+    it("collapses an ERB block into its opening and end tags", () => {
+      const service = createServiceWith({
+        "/project/app/views/events/_card.html.erb": [
+          `<% if event.published? %>`,
+          ...Array.from({ length: 8 }, (_, index) => `  <p>line ${index}</p>`),
+          `<% end %>`
+        ].join("\n")
+      })
+
+      const message = hover(service, `<%= render partial: "events/card" %>`, "events/card")
+
+      expect(message).toContain("<% if event.published? %>")
+      expect(message).toContain("<% end %>")
+      expect(message).not.toContain("<p>line 5</p>")
+    })
+
+    it("links an empty partial without a preview", () => {
+      const service = createServiceWith({ "/project/app/views/events/_card.html.erb": "\n  \n" })
+      const message = hover(service, `<%= render partial: "events/card" %>`, "events/card")
+
+      expect(message).toContain("app/views/events/_card.html.erb")
+      expect(message).not.toContain("```erb")
+    })
+
+    it("truncates content that has no opening and closing to collapse", () => {
+      const service = createServiceWith({
+        "/project/app/views/events/_card.html.erb": Array.from({ length: 10 }, (_, index) => `line ${index}`).join("\n")
+      })
+
+      const message = hover(service, `<%= render partial: "events/card" %>`, "events/card")
+
+      expect(message).toContain("line 0")
+      expect(message).toContain("...")
+      expect(message).not.toContain("line 9")
+    })
+
+    it("previews an element that was never closed", () => {
+      const service = createServiceWith({
+        "/project/app/views/events/_card.html.erb": [`<div class="card">`, ...Array.from({ length: 10 }, (_, index) => `  <p>line ${index}</p>`)].join("\n")
+      })
+
+      const message = hover(service, `<%= render partial: "events/card" %>`, "events/card")
+
+      expect(message).toContain(`<div class="card">`)
+      expect(message).toContain("...")
+      expect(message).not.toContain("<p>line 9</p>")
+    })
+
+    it("signals that a partial has more than one top level node", () => {
+      const service = createServiceWith({
+        "/project/app/views/events/_card.html.erb": `<h1>Title</h1>\n<p>Body</p>`
+      })
+
+      const message = hover(service, `<%= render partial: "events/card" %>`, "events/card")
+
+      expect(message).toContain("<h1>Title</h1>")
+      expect(message).toContain("...")
+      expect(message).not.toContain("<p>Body</p>")
+    })
+
+    it("previews the first match when several partials resolve", () => {
+      const service = createServiceWith({
+        "/project/app/views/events/_card.html.erb": `<div>next to the template</div>`,
+        "/project/app/views/application/_card.html.erb": `<div>the fallback</div>`
+      })
+
+      const message = hover(service, `<%= render partial: "card" %>`, `"card"`)
+
+      expect(message).toContain("app/views/events/_card.html.erb")
+      expect(message).toContain("app/views/application/_card.html.erb")
+      expect(message).toContain("<div>next to the template</div>")
+      expect(message).not.toContain("<div>the fallback</div>")
+    })
+
+    it("still links a partial it can't read", () => {
+      const service = createService("/project/app/views/events/_card.html.erb")
+      const message = hover(service, `<%= render partial: "events/card" %>`, "events/card")
+
+      expect(message).toContain("app/views/events/_card.html.erb")
+    })
+
+    it("links the resolved layout", () => {
+      const service = createService("/project/app/views/profiles/_tab_layout.html.erb")
+      const content = `<%= render layout: "profiles/tab_layout" do %><% end %>`
+
+      expect(hover(service, content, "tab_layout")).toContain("app/views/profiles/_tab_layout.html.erb")
+    })
+
+    it("shows a literal name example for a dynamic partial", () => {
+      const service = createService()
+      const message = hover(service, `<%= render partial: some_variable %>`, "some_variable")
+
+      expect(message).toContain("Use a literal name and Herb can take you to it")
+      expect(message).toContain(`<%= render partial: "events/card" %>`)
+    })
+
+    it("says a dynamic name can't be resolved", () => {
+      const service = createService()
+      const content = `<%= render partial: some_variable %>`
+      const message = hover(service, content, "some_variable")
+
+      expect(message).toContain("can't resolve this partial statically")
+      expect(message).toContain("comes from a variable or method call")
+    })
+
+    it("says an interpolated name can't be resolved", () => {
+      const service = createService()
+      const content = "<%= render partial: \"events/#{kind}\" %>"
+      const message = hover(service, content, "events/")
+
+      expect(message).toContain("can't resolve this partial statically")
+      expect(message).toContain("interpolated")
+    })
+
+    it("lists where it looked when nothing matches", () => {
+      const service = createService()
+      const content = `<%= render partial: "events/missing" %>`
+      const message = hover(service, content, "events/missing")
+
+      expect(message).toContain("No partial found for `events/missing`")
+      expect(message).toContain("app/views/events/_missing.html.erb")
+    })
+
+    it("names the layout keyword when a layout is missing", () => {
+      const service = createService()
+      const content = `<%= render layout: "profiles/missing" do %><% end %>`
+
+      expect(hover(service, content, "profiles/missing")).toContain("No layout found for `profiles/missing`")
+    })
+
+    it("returns nothing away from a render call", () => {
+      const service = createService("/project/app/views/events/_featured_home.html.erb")
+      const content = `<div>text</div>\n<%= render partial: "events/featured_home" %>`
+      const document = TextDocument.create(VIEW_URI, "erb", 1, content)
+
+      expect(service.getHover(document, document.positionAt(2))).toBeNull()
+    })
+  })
+
+  describe("object and collection rendering", () => {
+    function hoverText(service: DefinitionService, content: string, target: string) {
+      const document = TextDocument.create(VIEW_URI, "erb", 1, content)
+      const result = service.getHover(document, document.positionAt(content.indexOf(target) + 1))
+
+      return result ? (result.contents as { value: string }).value : null
+    }
+
+    it("does not offer a definition for a bare object render", () => {
+      const service = createService("/project/app/views/talks/_talk.html.erb")
+      const content = `<%= render talks %>`
+
+      expect(definitions(service, content, "talks")).toEqual([])
+    })
+
+    it("explains that the partial comes from to_partial_path", () => {
+      const service = createService("/project/app/views/talks/_talk.html.erb")
+      const message = hoverText(service, `<%= render talks %>`, "talks")
+
+      expect(message).toContain("can't resolve this partial statically")
+      expect(message).toContain("`to_partial_path` on `talks`")
+    })
+
+    it("covers the whole ERB tag when the partial can't be resolved", () => {
+      const service = createService()
+      const content = `<div>\n  <%= render talks %>\n</div>`
+      const document = TextDocument.create(VIEW_URI, "erb", 1, content)
+
+      for (const target of ["<%= render", "render talks", "talks %>"]) {
+        const hover = service.getHover(document, document.positionAt(content.indexOf(target) + 1))
+
+        expect(document.getText(hover!.range)).toBe("<%= render talks %>")
+      }
+    })
+
+    it("keeps the hover on the name when the partial resolves", () => {
+      const service = createService("/project/app/views/events/_card.html.erb")
+      const content = `<%= render partial: "events/card" %>`
+      const document = TextDocument.create(VIEW_URI, "erb", 1, content)
+      const hover = service.getHover(document, document.positionAt(content.indexOf("events/card") + 1))
+
+      expect(document.getText(hover!.range)).toBe("events/card")
+    })
+
+    it("shows how to name the partial for a collection render", () => {
+      const service = createService("/project/app/views/talks/_talk.html.erb")
+      const message = hoverText(service, `<%= render talks %>`, "talks")
+
+      expect(message).toContain("Name the partial explicitly")
+      expect(message).toContain("`object:` for a single record or `collection:` for many")
+      expect(message).toContain(`<%= render partial: "path/to/partial", object: talks %>`)
+    })
+
+    it("explains an instance variable collection render", () => {
+      const service = createService("/project/app/views/talks/_talk.html.erb")
+      const message = hoverText(service, `<%= render @talks %>`, "@talks")
+
+      expect(message).toContain("`to_partial_path` on `@talks`")
+    })
+
+    it("still resolves an explicit partial with a collection", () => {
+      const service = createService("/project/app/views/talks/_talk.html.erb")
+      const content = `<%= render partial: "talks/talk", collection: talks %>`
+
+      expect(uris(service, content, "talks/talk")).toEqual([
+        "file:///project/app/views/talks/_talk.html.erb"
+      ])
+    })
+  })
+
+  describe("interpolated partial names", () => {
+    function hoverText(service: DefinitionService, content: string, target: string) {
+      const document = TextDocument.create(VIEW_URI, "erb", 1, content)
+      const result = service.getHover(document, document.positionAt(content.indexOf(target) + 1))
+
+      return result ? (result.contents as { value: string }).value : null
+    }
+
+    it("does not offer a definition for a name that starts with interpolation", () => {
+      const service = createService("/project/app/views/events/_card.html.erb")
+      const content = "<%= render partial: \"#{scope}/card\" %>"
+
+      expect(definitions(service, content, "/card")).toEqual([])
+    })
+
+    it("explains that the name is interpolated", () => {
+      const service = createService("/project/app/views/events/_card.html.erb")
+      const content = "<%= render partial: \"#{scope}/card\" %>"
+
+      expect(hoverText(service, content, "/card")).toContain("interpolated")
+    })
+
+    it("treats an interpolated shorthand name as a partial, not an object", () => {
+      const service = createService()
+      const content = `<%= render "talks/#{scope}/card" %>`
+      const document = TextDocument.create(VIEW_URI, "erb", 1, content)
+      const message = (service.getHover(document, document.positionAt(6))!.contents as { value: string }).value
+
+      expect(message).toContain("The name is interpolated")
+      expect(message).not.toContain("to_partial_path")
+      expect(message).not.toContain("collection:")
+    })
+
+    it("explains an interpolated name given to the partial keyword", () => {
+      const service = createService()
+      const content = `<%= render partial: "talks/#{scope}/card" %>`
+      const document = TextDocument.create(VIEW_URI, "erb", 1, content)
+      const message = (service.getHover(document, document.positionAt(6))!.contents as { value: string }).value
+
+      expect(message).toContain("The name is interpolated")
+      expect(message).not.toContain("to_partial_path")
+    })
+
+    it("does not offer a definition for a name that ends with interpolation", () => {
+      const service = createService("/project/app/views/events/_card.html.erb")
+      const content = "<%= render partial: \"events/#{kind}\" %>"
+
+      expect(definitions(service, content, "events/")).toEqual([])
+    })
+  })
+
+  describe("layout rendering", () => {
+    it("resolves a layout partial", () => {
+      const service = createService("/project/app/views/profiles/_tab_layout.html.erb")
+      const content = `<%= render layout: "profiles/tab_layout", locals: { user: user } do %><% end %>`
+
+      expect(uris(service, content, "profiles/tab_layout")).toEqual([
+        "file:///project/app/views/profiles/_tab_layout.html.erb"
+      ])
+    })
+
+    it("resolves from the layout keyword", () => {
+      const service = createService("/project/app/views/profiles/_tab_layout.html.erb")
+      const content = `<%= render layout: "profiles/tab_layout" do %><% end %>`
+
+      expect(uris(service, content, "layout:")).toHaveLength(1)
+    })
+
+    it("resolves a render nested inside a layout block", () => {
+      const service = createService("/project/app/views/profiles/_talks.html.erb")
+      const content = [
+        `<%= render layout: "profiles/tab_layout", locals: {`,
+        `      user: @user`,
+        `    } do %>`,
+        `  <%= render partial: "profiles/talks", locals: { user: @user } %>`,
+        `<% end %>`
+      ].join("\n")
+
+      expect(uris(service, content, "profiles/talks")).toEqual([
+        "file:///project/app/views/profiles/_talks.html.erb"
+      ])
+    })
+  })
+
+  describe("documents with parse errors", () => {
+    it("still resolves when the document has an unrelated error", () => {
+      const service = createService("/project/app/views/events/_featured_home.html.erb")
+      const content = `<div>\n  <%= render partial: "events/featured_home" %>\n`
+
+      expect(uris(service, content, "events/featured_home")).toEqual([
+        "file:///project/app/views/events/_featured_home.html.erb"
+      ])
+    })
+
+    it("still explains a dynamic partial when the document has an error", () => {
+      const service = createService()
+      const content = `<div>\n  <%= render partial: some_variable %>\n`
+      const document = TextDocument.create(VIEW_URI, "erb", 1, content)
+      const hover = service.getHover(document, document.positionAt(content.indexOf("some_variable") + 1))
+
+      expect((hover!.contents as { value: string }).value).toContain("can't resolve this partial statically")
+    })
+  })
+
   describe("unresolvable references", () => {
     it("returns nothing for a partial that doesn't exist", () => {
       const service = createService()
@@ -180,14 +577,14 @@ describe("DefinitionService", () => {
       expect(definitions(service, content, "events/missing")).toEqual([])
     })
 
-    it("returns nothing for a dynamic partial name", () => {
+    it("does not offer a definition for a dynamic partial name", () => {
       const service = createService("/project/app/views/events/_some_variable.html.erb")
       const content = `<%= render partial: some_variable %>`
 
       expect(definitions(service, content, "some_variable")).toEqual([])
     })
 
-    it("returns nothing for an interpolated partial name", () => {
+    it("does not offer a definition for an interpolated partial name", () => {
       const service = createService("/project/app/views/events/_featured_home.html.erb")
       const content = "<%= render partial: \"events/#{kind}\" %>"
 


### PR DESCRIPTION
Follow up on #2045 

This pull request adds a hover to the partial name in a `render` call. When the partial resolves, the hover previews it. 

When it can't be resolved, the hover says why, since that case previously produced nothing at all beyond the editor's own "No definition found".

A resolved partial shows its path, its strict locals, and the shape of its content:

```
[app/views/users/_card.html.erb](file:///…)

<%# locals: (user:, content: "", favorite_user: nil, checked_in: false, stamp: nil) %>

<div class="flex items-center px-2">
  ...
</div>
```

<img width="1990" height="648" alt="CleanShot 2026-08-06 at 20 57 26@2x" src="https://github.com/user-attachments/assets/b50289fb-bb5f-479d-b6df-1b66353991ca" />

<img width="2354" height="676" alt="CleanShot 2026-08-06 at 20 58 47@2x" src="https://github.com/user-attachments/assets/ace10ddf-65ec-4c3a-99eb-b76f7c980755" />

<img width="1918" height="550" alt="CleanShot 2026-08-06 at 20 58 28@2x" src="https://github.com/user-attachments/assets/f447dbc4-e477-46be-8e2f-c29d5dacff37" />

<img width="1242" height="512" alt="CleanShot 2026-08-06 at 20 58 15@2x" src="https://github.com/user-attachments/assets/7bf3cfd9-5cb5-4ee6-b375-1271a3366285" />
