### PR TITLE
Linter: Fix `erb-no-duplicate-branch-elements` autofixes 

### DIFF
--- a/javascript/packages/linter/docs/rules/erb-no-duplicate-branch-elements.md
+++ b/javascript/packages/linter/docs/rules/erb-no-duplicate-branch-elements.md
@@ -8,6 +8,26 @@ Disallow the same HTML elements wrapping content in every branch of an ERB condi
 
 Elements that are byte-for-byte identical in every branch can always be moved out, and are reported as warnings. A shared tag whose *content* differs between branches can only be extracted by wrapping the entire conditional in it, so it is reported as a hint, and only when that rewrite is available: every branch must consist of nothing but shared elements, and only one of them may differ in content. Anything else would require splitting the conditional into several, which duplicates the condition instead of the markup, so it is not reported.
 
+`pre`, `textarea`, `script`, and `style` are never used as the wrapper. Moving the conditional inside them would put the branch markup on its own indented lines, which changes the text they render or submit. They are still hoisted out of the conditional when they are identical in every branch, since that moves the element whole and leaves its content untouched.
+
+## Autofix
+
+Hoisting an identical element out of the conditional, and wrapping the conditional in a shared tag, are both safe and are applied by `--fix`.
+
+When *every* branch is identical the whole conditional is redundant, and removing it deletes the condition along with it. That fix is only applied by `--fix-unsafely`, because the condition may do more than pick a branch:
+
+```erb
+<% if (result = compute) %>
+  <div>Same</div>
+<% else %>
+  <div>Same</div>
+<% end %>
+
+<%= result %>
+```
+
+Removing the conditional here drops the assignment and leaves `result` undefined. The same applies to a condition that calls a method for its side effects.
+
 ## Rationale
 
 Duplicated wrapper elements across all branches of a conditional are unnecessary repetition. Moving them outside the conditional reduces template size, makes the structure clearer, and avoids the risk of branches getting out of sync when one is updated but others are forgotten.
@@ -77,6 +97,16 @@ More than one shared tag with differing content, where no single tag can wrap th
 <% else %>
   <h1>Goodbye</h1>
   <p>Goodbye World</p>
+<% end %>
+```
+
+A shared tag whose content is whitespace-sensitive. Wrapping the conditional in `<pre>` would change the text it renders:
+
+```erb
+<% if condition %>
+  <pre>Hello World</pre>
+<% else %>
+  <pre>Goodbye World</pre>
 <% end %>
 ```
 

--- a/javascript/packages/linter/src/rules/erb-no-duplicate-branch-elements.ts
+++ b/javascript/packages/linter/src/rules/erb-no-duplicate-branch-elements.ts
@@ -12,6 +12,7 @@ import {
   isERBWhenNode,
   isEquivalentElement,
   isPureWhitespaceNode,
+  getTagLocalName,
   findParentArray,
   removeNodeFromArray,
   replaceNodeWithBody,
@@ -25,6 +26,8 @@ import type { ParseResult, Node, ERBIfNode, ERBUnlessNode, ERBCaseNode, ERBElseN
 import type { Mutable } from "@herb-tools/rewriter"
 
 type ConditionalNode = ERBIfNode | ERBUnlessNode | ERBCaseNode
+
+const CONTENT_PRESERVING_TAGS = new Set(["pre", "textarea", "script", "style"])
 
 interface DuplicateBranchAutofixContext extends BaseAutofixContext {
   node: Mutable<ConditionalNode>
@@ -41,6 +44,12 @@ function trimWhitespaceNodes(nodes: Node[]): Node[] {
   while (start < end && isPureWhitespaceNode(nodes[start])) start++
   while (end > start && isPureWhitespaceNode(nodes[end - 1])) end--
   return nodes.slice(start, end)
+}
+
+function isContentPreserving(element: HTMLElementNode): boolean {
+  const tagName = getTagLocalName(element)
+
+  return tagName !== null && CONTENT_PRESERVING_TAGS.has(tagName)
 }
 
 function haveIdenticalBodies(elements: HTMLElementNode[]): boolean {
@@ -190,7 +199,7 @@ class ERBNoDuplicateBranchElementsVisitor extends BaseRuleVisitor<DuplicateBranc
       this.addOffense(
         "All branches of this conditional have identical content. The conditional can be removed.",
         node.location,
-        { node: node as Mutable<ConditionalNode>, allIdentical: true },
+        { node: node as Mutable<ConditionalNode>, allIdentical: true, unsafe: true },
         "warning",
       )
 
@@ -243,8 +252,8 @@ class ERBNoDuplicateBranchElementsVisitor extends BaseRuleVisitor<DuplicateBranc
     }
 
     const sharedElementsSpanBranches = significantBranches.every(branch => branch.length === prefixCount + suffixCount)
-    const divergingGroupCount = groups.filter(elements => !haveIdenticalBodies(elements)).length
-    const canWrapConditional = sharedElementsSpanBranches && divergingGroupCount === 1
+    const divergingGroups = groups.filter(elements => !haveIdenticalBodies(elements))
+    const canWrapConditional = sharedElementsSpanBranches && divergingGroups.length === 1 && !isContentPreserving(divergingGroups[0][0])
 
     for (const elements of groups) {
       this.reportAndRecurse(elements, conditionalNode, state, canWrapConditional)
@@ -387,7 +396,7 @@ export class ERBNoDuplicateBranchElementsRule extends ParserRule<DuplicateBranch
       } else {
         if (hasWrapped) return
 
-        const canWrap = branches.every((branch, index) => {
+        const canWrap = !isContentPreserving(elements[0]) && branches.every((branch, index) => {
           const remaining = getSignificantNodes(branch)
 
           return remaining.length === 1 && remaining[0] === elements[index]
@@ -429,7 +438,7 @@ export class ERBNoDuplicateBranchElementsRule extends ParserRule<DuplicateBranch
         const elements = remaining.map(b => b[0] as HTMLElementNode)
         const bodiesMatch = elements.every(el => IdentityPrinter.print(el) === IdentityPrinter.print(elements[0]))
 
-        if (!bodiesMatch && elements.every(el => el.body.length > 0)) {
+        if (!bodiesMatch && !isContentPreserving(elements[0]) && elements.every(el => el.body.length > 0)) {
           for (let i = 0; i < branches.length; i++) {
             replaceNodeWithBody(branches[i] as Node[], elements[i])
           }

--- a/javascript/packages/linter/test/autofix/erb-no-duplicate-branch-elements.autofix.test.ts
+++ b/javascript/packages/linter/test/autofix/erb-no-duplicate-branch-elements.autofix.test.ts
@@ -14,6 +14,11 @@ describe("erb-no-duplicate-branch-elements autofix", () => {
     return linter.autofix(input)
   }
 
+  function autofixUnsafe(input: string) {
+    const linter = new Linter(Herb, [ERBNoDuplicateBranchElementsRule])
+    return linter.autofix(input, undefined, undefined, { includeUnsafe: true })
+  }
+
   describe("wrapping element (bodies differ, single element per branch)", () => {
     test("basic if/else with same wrapping div", () => {
       const input = dedent`
@@ -482,7 +487,7 @@ describe("erb-no-duplicate-branch-elements autofix", () => {
         <% end %>
       `
 
-      const result = autofix(input)
+      const result = autofixUnsafe(input)
 
       expect(result.source).toBe("\n123\n")
       expect(result.fixed).toHaveLength(1)
@@ -498,7 +503,7 @@ describe("erb-no-duplicate-branch-elements autofix", () => {
         <% end %>
       `
 
-      const result = autofix(input)
+      const result = autofixUnsafe(input)
 
       expect(result.source).toBe("<div><%= hello %></div>")
       expect(result.fixed).toHaveLength(1)
@@ -518,7 +523,7 @@ describe("erb-no-duplicate-branch-elements autofix", () => {
         <% end %>
       `
 
-      const result = autofix(input)
+      const result = autofixUnsafe(input)
 
       expect(result.source).toBe(dedent`
         <h1>Hello</h1>
@@ -527,6 +532,80 @@ describe("erb-no-duplicate-branch-elements autofix", () => {
       `)
       expect(result.fixed).toHaveLength(1)
       expect(result.unfixed).toHaveLength(0)
+    })
+
+    test("is not applied without includeUnsafe, because the condition would be dropped", () => {
+      const input = dedent`
+        <% if (result = compute) %>
+          <div>Same</div>
+        <% else %>
+          <div>Same</div>
+        <% end %>
+      `
+
+      const result = autofix(input)
+
+      expect(result.source).toBe(input)
+      expect(result.fixed).toHaveLength(0)
+      expect(result.unfixed).toHaveLength(1)
+    })
+  })
+
+  describe("content-preserving elements", () => {
+    test("does not wrap the conditional in a `pre`", () => {
+      const input = dedent`
+        <% if condition %>
+          <pre>Hello</pre>
+        <% else %>
+          <pre>World</pre>
+        <% end %>
+      `
+
+      const result = autofix(input)
+
+      expect(result.source).toBe(input)
+      expect(result.fixed).toHaveLength(0)
+      expect(result.unfixed).toHaveLength(0)
+    })
+
+    test("does not wrap the conditional in a `textarea`", () => {
+      const input = dedent`
+        <% if condition %>
+          <textarea>Hello</textarea>
+        <% else %>
+          <textarea>World</textarea>
+        <% end %>
+      `
+
+      const result = autofix(input)
+
+      expect(result.source).toBe(input)
+      expect(result.fixed).toHaveLength(0)
+      expect(result.unfixed).toHaveLength(0)
+    })
+
+    test("still hoists an identical `pre` out of the conditional", () => {
+      const input = dedent`
+        <% if condition %>
+          <pre>Same</pre>
+          Hello
+        <% else %>
+          <pre>Same</pre>
+          World
+        <% end %>
+      `
+
+      const result = autofix(input)
+
+      expect(result.source).toBe(dedent`
+        <pre>Same</pre>
+        <% if condition %>
+          Hello
+        <% else %>
+          World
+        <% end %>
+      `)
+      expect(result.fixed).toHaveLength(1)
     })
   })
 })


### PR DESCRIPTION
Removing a conditional whose branches are all identical also deletes the condition, which drops any assignment or side effect it performs. That fix now requires `--fix-unsafely`.

Wrapping the conditional in a shared tag is never offered for `pre`, `textarea`, `script`, or `style`, because the reindent puts the branch markup on its own indented lines and changes the text they render or submit. Those tags are still hoisted out when identical in every branch, which leaves their content untouched.