### PR TITLE
Engine: Use `Location.zero` and `Token.from` in `DebugVisitor`

### DIFF
--- a/lib/herb/engine/debug_visitor.rb
+++ b/lib/herb/engine/debug_visitor.rb
@@ -116,18 +116,6 @@ module Herb
         replace_erb_nodes_recursive(node)
       end
 
-      # Creates a dummy location for AST nodes that don't need real location info
-      #: () -> Herb::Location
-      def dummy_location
-        @dummy_location ||= Herb::Location.from(0, 0, 0, 0)
-      end
-
-      # Creates a dummy range for tokens that don't need real range info
-      #: () -> Herb::Range
-      def dummy_range
-        @dummy_range ||= Herb::Range.from(0, 0)
-      end
-
       def replace_erb_nodes_recursive(node)
         array_properties = [:children, :body, :statements]
 
@@ -199,23 +187,16 @@ module Herb
       end
 
       def create_debug_attribute(name, value)
-        name_literal = Herb::AST::LiteralNode.new("LiteralNode", dummy_location, [], name.dup)
-        name_node = Herb::AST::HTMLAttributeNameNode.new("HTMLAttributeNameNode", dummy_location, [], [name_literal])
+        name_literal = Herb::AST::LiteralNode.new("LiteralNode", Herb::Location.zero, [], name.dup)
+        name_node = Herb::AST::HTMLAttributeNameNode.new("HTMLAttributeNameNode", Herb::Location.zero, [], [name_literal])
 
-        value_literal = Herb::AST::LiteralNode.new("LiteralNode", dummy_location, [], value.dup)
-        value_node = Herb::AST::HTMLAttributeValueNode.new("HTMLAttributeValueNode", dummy_location, [], create_token(:quote, '"'),
-                                                           [value_literal], create_token(:quote, '"'), true)
+        value_literal = Herb::AST::LiteralNode.new("LiteralNode", Herb::Location.zero, [], value.dup)
+        value_node = Herb::AST::HTMLAttributeValueNode.new("HTMLAttributeValueNode", Herb::Location.zero, [], Herb::Token.from(:quote, '"'),
+                                                           [value_literal], Herb::Token.from(:quote, '"'), true)
 
-        equals_token = create_token(:equals, "=")
+        equals_token = Herb::Token.from(:equals, "=")
 
-        Herb::AST::HTMLAttributeNode.new("HTMLAttributeNode", dummy_location, [], name_node, equals_token, value_node)
-      end
-
-      # TODO: replace all create_token with Herb::Token.from
-      # TODO: replace all dummy_location with Locataion.zero
-      # TODO: replace all dummy_range with Range.zero
-      def create_token(type, value)
-        Herb::Token.from(type, value, location: dummy_location, range: dummy_range)
+        Herb::AST::HTMLAttributeNode.new("HTMLAttributeNode", Herb::Location.zero, [], name_node, equals_token, value_node)
       end
 
       def create_debug_span_for_erb(erb_node)
@@ -250,30 +231,30 @@ module Herb
         debug_attributes << create_debug_attribute("data-herb-debug-column", (column + 1).to_s) if column
         debug_attributes << create_debug_attribute("style", "display: contents;")
 
-        tag_name_token = create_token(:tag_name, "span")
+        tag_name_token = Herb::Token.from(:tag_name, "span")
 
         open_tag = Herb::AST::HTMLOpenTagNode.new(
           "HTMLOpenTagNode",
-          dummy_location,
+          Herb::Location.zero,
           [],
-          create_token(:tag_opening, "<"),
+          Herb::Token.from(:tag_opening, "<"),
           tag_name_token,
-          create_token(:tag_closing, ">"),
+          Herb::Token.from(:tag_closing, ">"),
           debug_attributes,
           false
         )
 
         close_tag = Herb::AST::HTMLCloseTagNode.new(
           "HTMLCloseTagNode",
-          dummy_location,
+          Herb::Location.zero,
           [],
-          create_token(:tag_opening, "</"),
-          create_token(:tag_name, "span"),
+          Herb::Token.from(:tag_opening, "</"),
+          Herb::Token.from(:tag_name, "span"),
           [],
-          create_token(:tag_closing, ">")
+          Herb::Token.from(:tag_closing, ">")
         )
 
-        Herb::AST::HTMLElementNode.new("HTMLElementNode", dummy_location, [], open_tag, tag_name_token, [erb_node], close_tag,
+        Herb::AST::HTMLElementNode.new("HTMLElementNode", Herb::Location.zero, [], open_tag, tag_name_token, [erb_node], close_tag,
                                        false, "Debug")
       end
 

--- a/sig/herb/engine/debug_visitor.rbs
+++ b/sig/herb/engine/debug_visitor.rbs
@@ -29,14 +29,6 @@ module Herb
 
       def wrap_all_erb_nodes: (untyped node) -> untyped
 
-      # Creates a dummy location for AST nodes that don't need real location info
-      # : () -> Herb::Location
-      def dummy_location: () -> Herb::Location
-
-      # Creates a dummy range for tokens that don't need real range info
-      # : () -> Herb::Range
-      def dummy_range: () -> Herb::Range
-
       def replace_erb_nodes_recursive: (untyped node) -> untyped
 
       def find_top_level_elements: (untyped document_node) -> untyped
@@ -48,11 +40,6 @@ module Herb
       def add_debug_attributes_to_element: (untyped open_tag_node) -> untyped
 
       def create_debug_attribute: (untyped name, untyped value) -> untyped
-
-      # TODO: replace all create_token with Herb::Token.from
-      # TODO: replace all dummy_location with Locataion.zero
-      # TODO: replace all dummy_range with Range.zero
-      def create_token: (untyped type, untyped value) -> untyped
 
       def create_debug_span_for_erb: (untyped erb_node) -> untyped
 


### PR DESCRIPTION
This pull request updates `Herb::Engine::DebugVisitor` to use the shared `Herb::Location.zero` and `Herb::Token.from` constructors instead of its own local helpers. `DebugVisitor` predates those constructors, so it carried three private helpers to build the synthetic nodes.