### PR TITLE
Linter: Make `actionview-no-implicit-polymorphic-url` catch Array URLs

### DIFF
--- a/javascript/packages/linter/docs/rules/actionview-no-implicit-polymorphic-url.md
+++ b/javascript/packages/linter/docs/rules/actionview-no-implicit-polymorphic-url.md
@@ -4,11 +4,13 @@
 
 ## Description
 
-Prefer using explicit Rails route helpers (e.g., `profile_path(@profile)`) over passing model objects directly to `link_to`, which relies on implicit polymorphic routing to generate the URL.
+Prefer using explicit Rails route helpers (e.g., `profile_path(@profile)`) over passing model objects, or Arrays of route parts, directly to `link_to`, which relies on implicit polymorphic routing to generate the URL.
 
 ## Rationale
 
 When you pass a model object directly to `link_to` (e.g., `<%= link_to "Profile", @profile %>`), Rails uses `polymorphic_path` behind the scenes to infer the URL. While convenient, this implicit behavior makes it unclear what URL will be generated, a reader must know the model's class and routing conventions to determine the target path.
+
+The same goes for an Array of route parts, as in `<%= link_to "User", [:admin, @user] %>`, which Rails resolves the same way: it joins the parts into a route name and calls it. The route it lands on, `admin_user_path`, is spelled out nowhere in the template, even though every part of the name is right there in the Array.
 
 The template stops describing what it renders. `<%= link_to "Profile", @profile %>` and `<%= link_to "Profile", profile_path(@profile) %>` produce the same `<a href>`, but only the second one says so. With the first, the rendered output depends on a class the template never names, so answering "where does this link go?" means leaving the template and reconstructing the model's class and the routes it maps to.
 
@@ -18,13 +20,31 @@ Using explicit route helpers also enables better static analysis. Tools like Her
 
 ## Notes
 
-This rule only applies when an instance variable is passed as the URL argument to `link_to`, which is the argument Rails resolves through `polymorphic_path`. That is the second argument for `link_to "Profile", @profile`, and the first one for `link_to @profile` and for `link_to @profile do ... end`, where the same argument doubles as the link text or the block supplies it.
+This rule applies to the URL argument of `link_to`, which is the argument Rails resolves through `polymorphic_path`. That is the second argument for `link_to "Profile", @profile`, and the first one for `link_to @profile` and for `link_to @profile do ... end`, where the same argument doubles as the link text or the block supplies it. Three shapes are reported there: a variable, an Array of route parts, and a model read off another object with a method call.
+
+For an Array, the suggested route helper is built from the parts themselves, the same way Rails builds the route name: every part contributes a segment, and the model objects among them become the arguments. `[:admin, @user]` becomes `admin_user_path(@user)`, `[@post, @comment]` becomes `post_comment_path(@post, @comment)`, `[@post, :comments]` becomes `post_comments_path(@post)`, and a Symbol is read the same way wherever it sits, so `[@user, :blog, @post]` becomes `user_blog_post_path(@user, @post)`.
+
+Only Symbols, Strings and plain variables carry a name the route can be built from. An Array holding anything else is still reported, but without a suggested helper, since the alternative would be guessing at the route name: `[:admin, @user.account]` and `[*@parents, @user]` say nothing about where they land, and `[:admin, User]` routes through `User.model_name.route_key`, which means pluralizing a class name. What the report has to offer there is `polymorphic_path`, which at least says in the template that the route is resolved from the model.
+
+A String is reported even though Rails raises an `ArgumentError` for it and asks for a Symbol, since `["admin", @user]` names the same route the working version does, and `admin_user_path(@user)` is the fix for both problems at once. A method call in the URL argument is reported the same way an Array of unnamed parts is, without a suggested helper: `<%= link_to "Account", @user.account %>` says nothing about the route it resolves to beyond the name of the reader, and `account_path` is a guess this rule would rather not make.
+
+Rails compacts the Array before it resolves the route, so `nil` is dropped from it and `[nil, @user]` still routes to `user_path(@user)`. An Array with nothing left after that raises `ArgumentError: Nil location provided. Can't build URI.`, so `<%= link_to "User", [] %>` and `<%= link_to "User", [nil] %>` are reported at the `error` severity: this is not a link that renders a surprising URL, it is a link that takes the page down with it, and the template says so on its own.
+
+The reported method calls are the ones that read like a model: a call on a receiver, taking no arguments and no block, as in `@user.account`, `user.account`, `@user&.account` or `@post.author.profile`. A call taking arguments could be anything, `params[:return_to]` and `request.referer` hold a URL rather than a model, and a bare `current_user` is indistinguishable from a helper that returns a String, so none of those are reported.
+
+Rails routes an unsaved record to the collection instead, so `<%= link_to "Save", [:admin, @user] %>` with a new `@user` goes to `admin_users_path`, not to the `admin_user_path(@user)` the report suggests. Whether a record is persisted is a fact about the request, not about the template, so the suggested helper is the one for a persisted record.
+
+Local variables are reported the same way instance variables are, so `<%= link_to user.name, user %>` inside an `each` block is reported and suggests `user_path(user)`. The URL is just as implicit either way, and where the variable came from does not change what Rails does with it.
+
+A bare method call, on the other hand, is not reported: `<%= link_to "Profile", current_user %>` could be a helper that returns a String, and the name of a helper is not the name of a model, so there is nothing worth suggesting. This is also the one place the rule is inconsistent for a reason it cannot help. A partial that takes a `user` local reads it as a method call, since nothing in the template assigns it, so `<%= link_to user.name, user %>` is reported in an `each` block and skipped in `_user.html.erb`.
 
 Using `link_to` with an explicit named route helper like `articles_path`, with a Hash of URL options, or with a hardcoded String path like `"/articles"` is perfectly fine and will not trigger this rule. Passing a model object to a route helper, as in `post_path(@post)`, is the suggested form and is never reported.
 
 Calling `polymorphic_path(@profile)` or `polymorphic_url(@profile)` yourself is fine too. What this rule is about is the routing being implicit, not polymorphic routing itself, and there are cases where resolving the route from the model is exactly what you want, such as a partial rendered for several model types. Naming the helper says so in the template, keeps the call greppable, and leaves the reader with a route to look up rather than a class to infer.
 
-Instance variables named after a URL are skipped, because they usually hold one already rather than a model to route from. `<%= link_to @url, @url %>` and `<%= link_to "Edit", @edit_card_url %>` are common in mailer templates, where the mailer builds the absolute URL itself and there is no route helper to reach for. The same applies to a Hash of URL options behind a name like `@link_options`. Names are matched per underscore-separated segment, so `@start_url_ial1` is skipped while `@security` and `@burlington` are not. Since only the name is available to the parser, a model genuinely named `@url_shortener` is skipped too, which is the cheaper of the two mistakes.
+Variables named after a URL are skipped, because they usually hold one already rather than a model to route from. `<%= link_to @url, @url %>` and `<%= link_to "Edit", @edit_card_url %>` are common in mailer templates, where the mailer builds the absolute URL itself and there is no route helper to reach for. The same applies to a Hash of URL options behind a name like `@link_options`. Names are matched per underscore-separated segment, so `@start_url_ial1` is skipped while `@security` and `@burlington` are not. Since only the name is available to the parser, a model genuinely named `@url_shortener` is skipped too, which is the cheaper of the two mistakes.
+
+The same name check applies to local variables and to method calls, so `<%= link_to "Link", link_url %>` and `<%= link_to "Avatar", @user.avatar_url %>` are skipped. It does not apply inside an Array: it exists for a value that already holds a URL, and a route part is never that, so `[:admin, @user_url]` is reported like any other Array.
 
 ## Configuration
 
@@ -36,6 +56,8 @@ linter:
     actionview-no-implicit-polymorphic-url:
       severity: warning
 ```
+
+The empty Array is the exception. It reports at `error` whatever the rule is configured to, because it is not a heuristic: that template raises when it renders, and the severity should say so. Turning the rule off turns that report off with it.
 
 ## Examples
 
@@ -66,7 +88,19 @@ linter:
 ```
 
 ```erb
+<%= link_to "User", admin_user_path(@user) %>
+```
+
+```erb
+<%= link_to "Comment", post_comment_path(@post, @comment) %>
+```
+
+```erb
 <%= link_to "Profile", polymorphic_path(@profile) %>
+```
+
+```erb
+<%= link_to "User", polymorphic_path([:admin, @user]) %>
 ```
 
 ```erb
@@ -89,6 +123,36 @@ linter:
 
 ```erb
 <%= link_to "View Post", @post, class: "btn" %>
+```
+
+```erb
+<%= link_to "User", [:admin, @user] %>
+```
+
+```erb
+<%= link_to "Comment", [@post, @comment] %>
+```
+
+```erb
+<%= link_to "Comments", [@post, :comments] %>
+```
+
+```erb
+<%= link_to "Users", [:admin, User] %>
+```
+
+```erb
+<%= link_to "Account", @user.account %>
+```
+
+```erb
+<%= link_to "User", [] %>
+```
+
+```erb
+<% @users.each do |user| %>
+  <%= link_to user.name, user %>
+<% end %>
 ```
 
 ## References

--- a/javascript/packages/linter/src/rules/actionview-no-implicit-polymorphic-url.ts
+++ b/javascript/packages/linter/src/rules/actionview-no-implicit-polymorphic-url.ts
@@ -19,12 +19,18 @@ const URL_FOR_HELPERS = new Map(
     .flatMap(helper => [helper.name, ...helper.aliases].map(name => [name, helper] as const))
 )
 
+const IDENTIFIER = /^[a-z_][a-zA-Z0-9_]*$/
+
+const NON_MODEL_RECEIVERS = new Set(["request", "response", "session", "params", "cookies", "flash", "controller", "helpers", "main_app"])
+
 interface ImplicitPolymorphicURL {
   argument: PrismNode
   helperName: string
+  routeCall: string | null
+  routable: boolean
 }
 
-function urlArgument(node: PrismNode): ImplicitPolymorphicURL | null {
+function urlArgument(node: PrismNode): Omit<ImplicitPolymorphicURL, "routeCall" | "routable"> | null {
   if (!isPrismNodeType(node, "CallNode")) return null
   if (node.receiver) return null
 
@@ -60,14 +66,91 @@ function isURLLikeName(name: string): boolean {
   return last.endsWith("url") || last.endsWith("uri")
 }
 
+function variableName(node: PrismNode): string | null {
+  if (isPrismNodeType(node, "InstanceVariableReadNode")) return node.name
+  if (isPrismNodeType(node, "LocalVariableReadNode")) return node.name
+
+  return null
+}
+
+function literalSegment(node: PrismNode): string | null {
+  if (!isPrismNodeType(node, "SymbolNode") && !isPrismNodeType(node, "StringNode")) return null
+
+  const name = node.unescaped?.value
+
+  if (typeof name !== "string" || !IDENTIFIER.test(name)) return null
+
+  return name
+}
+
+function routeCall(routeHelper: string, routeArguments: string[]): string {
+  return routeArguments.length === 0 ? routeHelper : `${routeHelper}(${routeArguments.join(", ")})`
+}
+
+function isNonModelReceiver(node: PrismNode): boolean {
+  if (!isPrismNodeType(node, "CallNode") || node.receiver) return false
+
+  return NON_MODEL_RECEIVERS.has(node.name)
+}
+
+function isModelReaderCall(node: PrismNode): boolean {
+  if (!isPrismNodeType(node, "CallNode")) return false
+  if (!node.receiver || node.arguments_ || node.block) return false
+  if (!IDENTIFIER.test(node.name) || isURLLikeName(node.name)) return false
+
+  return !isNonModelReceiver(node.receiver)
+}
+
+function routeParts(node: PrismNode): PrismNode[] {
+  const elements: PrismNode[] = node.elements ?? []
+
+  return elements.filter(element => !isPrismNodeType(element, "NilNode"))
+}
+
+function routeCallForArray(elements: PrismNode[]): string | null {
+  const segments: string[] = []
+  const routeArguments: string[] = []
+
+  for (const element of elements) {
+    const literal = literalSegment(element)
+
+    if (literal) {
+      segments.push(literal)
+      continue
+    }
+
+    const name = variableName(element)
+
+    if (!name) return null
+
+    segments.push(name.replace(/^@/, ""))
+    routeArguments.push(name)
+  }
+
+  return routeCall(`${segments.join("_")}_path`, routeArguments)
+}
+
 class ImplicitPolymorphicURLCollector extends PrismVisitor {
   public readonly urls: ImplicitPolymorphicURL[] = []
 
   visitCallNode(node: PrismNode): void {
     const url = urlArgument(node)
+    const argument = url?.argument
 
-    if (url && isPrismNodeType(url.argument, "InstanceVariableReadNode") && !isURLLikeName(url.argument.name)) {
-      this.urls.push(url)
+    const name = url ? variableName(argument) : null
+
+    if (url && name && !isURLLikeName(name)) {
+      this.urls.push({ ...url, routeCall: routeCall(`${name.replace(/^@/, "")}_path`, [name]), routable: true })
+    }
+
+    if (url && isPrismNodeType(argument, "ArrayNode")) {
+      const parts = routeParts(argument)
+
+      this.urls.push({ ...url, routeCall: parts.length === 0 ? null : routeCallForArray(parts), routable: parts.length > 0 })
+    }
+
+    if (url && isModelReaderCall(argument)) {
+      this.urls.push({ ...url, routeCall: null, routable: true })
     }
 
     this.visitChildNodes(node)
@@ -101,14 +184,23 @@ export class ActionViewNoImplicitPolymorphicURLRule extends ParserRule {
 
     collector.visit(prismNode)
 
-    return collector.urls.map(({ argument, helperName }) => {
+    return collector.urls.map(({ argument, helperName, routeCall, routable }) => {
       const { startOffset, length } = argument.location
       const location = locationFromByteOffset(source, startOffset, length)
-      const variable = substringFromByteOffset(source, startOffset, length)
-      const routeHelper = `${variable.replace(/^@/, "")}_path`
+      const value = substringFromByteOffset(source, startOffset, length)
+      const suggestion = routeCall ? `an explicit route helper like \`${routeCall}\`` : "an explicit route helper"
+
+      if (!routable) {
+        return this.createOffense(
+          `Passing \`${value}\` to \`${helperName}\` raises \`ArgumentError: Nil location provided. Can't build URI.\` at runtime. Rails compacts the Array before it resolves the route, and an Array with nothing left in it has no route to resolve. Use an explicit route helper for the route this link points at.`,
+          location,
+          undefined,
+          "error",
+        )
+      }
 
       return this.createOffense(
-        `Avoid passing \`${variable}\` directly to \`${helperName}\`. The URL is resolved implicitly through polymorphic routing, so what actually gets rendered can't be read off the template or traced by tooling. Use an explicit route helper like \`${routeHelper}(${variable})\`, or \`polymorphic_path(${variable})\` when the route has to be resolved from the model.`,
+        `Avoid passing \`${value}\` directly to \`${helperName}\`. The URL is resolved implicitly through polymorphic routing, so what actually gets rendered can't be read off the template or traced by tooling. Use ${suggestion}, or \`polymorphic_path(${value})\` when the route has to be resolved from the model.`,
         location,
       )
     })

--- a/javascript/packages/linter/test/rules/actionview-no-implicit-polymorphic-url.test.ts
+++ b/javascript/packages/linter/test/rules/actionview-no-implicit-polymorphic-url.test.ts
@@ -4,7 +4,7 @@ import dedent from "dedent"
 import { ActionViewNoImplicitPolymorphicURLRule } from "../../src/rules/actionview-no-implicit-polymorphic-url"
 import { createLinterTest } from "../helpers/linter-test-helper.js"
 
-const { expectNoOffenses, expectInfo, assertOffenses } = createLinterTest(ActionViewNoImplicitPolymorphicURLRule)
+const { expectNoOffenses, expectInfo, expectError, assertOffenses } = createLinterTest(ActionViewNoImplicitPolymorphicURLRule)
 
 describe("actionview-no-implicit-polymorphic-url", () => {
   it("flags a model object passed as the only argument", () => {
@@ -73,6 +73,227 @@ describe("actionview-no-implicit-polymorphic-url", () => {
         <%= link_to @user.name, @user %>
       </nav>
     `)
+  })
+
+  it("flags a namespaced Array URL", () => {
+    expectInfo("Avoid passing `[:admin, @user]` directly to `link_to`. The URL is resolved implicitly through polymorphic routing, so what actually gets rendered can't be read off the template or traced by tooling. Use an explicit route helper like `admin_user_path(@user)`, or `polymorphic_path([:admin, @user])` when the route has to be resolved from the model.", { line: 1, column: 20 })
+
+    assertOffenses(`<%= link_to "User", [:admin, @user] %>`)
+  })
+
+  it("flags an Array URL with a leading action", () => {
+    expectInfo("Avoid passing `[:edit, @user]` directly to `link_to`. The URL is resolved implicitly through polymorphic routing, so what actually gets rendered can't be read off the template or traced by tooling. Use an explicit route helper like `edit_user_path(@user)`, or `polymorphic_path([:edit, @user])` when the route has to be resolved from the model.")
+
+    assertOffenses(`<%= link_to "Edit User", [:edit, @user] %>`)
+  })
+
+  it("flags a nested Array URL", () => {
+    expectInfo("Avoid passing `[@post, @comment]` directly to `link_to`. The URL is resolved implicitly through polymorphic routing, so what actually gets rendered can't be read off the template or traced by tooling. Use an explicit route helper like `post_comment_path(@post, @comment)`, or `polymorphic_path([@post, @comment])` when the route has to be resolved from the model.")
+
+    assertOffenses(`<%= link_to "Comment", [@post, @comment] %>`)
+  })
+
+  it("flags a namespaced nested Array URL", () => {
+    expectInfo("Avoid passing `[:admin, @blog, @post]` directly to `link_to`. The URL is resolved implicitly through polymorphic routing, so what actually gets rendered can't be read off the template or traced by tooling. Use an explicit route helper like `admin_blog_post_path(@blog, @post)`, or `polymorphic_path([:admin, @blog, @post])` when the route has to be resolved from the model.")
+
+    assertOffenses(`<%= link_to "Post", [:admin, @blog, @post] %>`)
+  })
+
+  it("flags an Array URL with a Symbol between two model objects", () => {
+    expectInfo("Avoid passing `[@user, :blog, @post]` directly to `link_to`. The URL is resolved implicitly through polymorphic routing, so what actually gets rendered can't be read off the template or traced by tooling. Use an explicit route helper like `user_blog_post_path(@user, @post)`, or `polymorphic_path([@user, :blog, @post])` when the route has to be resolved from the model.")
+
+    assertOffenses(`<%= link_to "Post", [@user, :blog, @post] %>`)
+  })
+
+  it("flags an Array URL for a nested collection", () => {
+    expectInfo("Avoid passing `[@post, :comments]` directly to `link_to`. The URL is resolved implicitly through polymorphic routing, so what actually gets rendered can't be read off the template or traced by tooling. Use an explicit route helper like `post_comments_path(@post)`, or `polymorphic_path([@post, :comments])` when the route has to be resolved from the model.")
+
+    assertOffenses(`<%= link_to "Comments", [@post, :comments] %>`)
+  })
+
+  it("flags an Array URL built from Symbols only", () => {
+    expectInfo("Avoid passing `[:admin, :users]` directly to `link_to`. The URL is resolved implicitly through polymorphic routing, so what actually gets rendered can't be read off the template or traced by tooling. Use an explicit route helper like `admin_users_path`, or `polymorphic_path([:admin, :users])` when the route has to be resolved from the model.")
+
+    assertOffenses(`<%= link_to "Users", [:admin, :users] %>`)
+  })
+
+  it("flags an Array URL written as a Symbol Array literal", () => {
+    expectInfo("Avoid passing `%i[admin users]` directly to `link_to`. The URL is resolved implicitly through polymorphic routing, so what actually gets rendered can't be read off the template or traced by tooling. Use an explicit route helper like `admin_users_path`, or `polymorphic_path(%i[admin users])` when the route has to be resolved from the model.")
+
+    assertOffenses(`<%= link_to "Users", %i[admin users] %>`)
+  })
+
+  it("flags an Array URL holding a single model object", () => {
+    expectInfo("Avoid passing `[@user]` directly to `link_to`. The URL is resolved implicitly through polymorphic routing, so what actually gets rendered can't be read off the template or traced by tooling. Use an explicit route helper like `user_path(@user)`, or `polymorphic_path([@user])` when the route has to be resolved from the model.")
+
+    assertOffenses(`<%= link_to "User", [@user] %>`)
+  })
+
+  it("flags an Array URL passed as the only argument", () => {
+    expectInfo("Avoid passing `[:admin, @user]` directly to `link_to`. The URL is resolved implicitly through polymorphic routing, so what actually gets rendered can't be read off the template or traced by tooling. Use an explicit route helper like `admin_user_path(@user)`, or `polymorphic_path([:admin, @user])` when the route has to be resolved from the model.")
+
+    assertOffenses(`<%= link_to [:admin, @user] %>`)
+  })
+
+  it("flags an Array URL passed to a `link_to` with a block", () => {
+    expectInfo("Avoid passing `[:admin, @user]` directly to `link_to`. The URL is resolved implicitly through polymorphic routing, so what actually gets rendered can't be read off the template or traced by tooling. Use an explicit route helper like `admin_user_path(@user)`, or `polymorphic_path([:admin, @user])` when the route has to be resolved from the model.")
+
+    assertOffenses(dedent`
+      <%= link_to [:admin, @user] do %>
+        User
+      <% end %>
+    `)
+  })
+
+  it("flags an Array URL followed by HTML options", () => {
+    expectInfo("Avoid passing `[:admin, @user]` directly to `link_to`. The URL is resolved implicitly through polymorphic routing, so what actually gets rendered can't be read off the template or traced by tooling. Use an explicit route helper like `admin_user_path(@user)`, or `polymorphic_path([:admin, @user])` when the route has to be resolved from the model.")
+
+    assertOffenses(`<%= link_to "User", [:admin, @user], class: "btn" %>`)
+  })
+
+  it("flags an Array URL holding a block-local record", () => {
+    expectInfo("Avoid passing `[:admin, user]` directly to `link_to`. The URL is resolved implicitly through polymorphic routing, so what actually gets rendered can't be read off the template or traced by tooling. Use an explicit route helper like `admin_user_path(user)`, or `polymorphic_path([:admin, user])` when the route has to be resolved from the model.")
+
+    assertOffenses(dedent`
+      <% @users.each do |user| %>
+        <%= link_to user.name, [:admin, user] %>
+      <% end %>
+    `)
+  })
+
+  it("flags an Array URL holding a method call, without naming a route helper", () => {
+    expectInfo("Avoid passing `[:admin, @user.account]` directly to `link_to`. The URL is resolved implicitly through polymorphic routing, so what actually gets rendered can't be read off the template or traced by tooling. Use an explicit route helper, or `polymorphic_path([:admin, @user.account])` when the route has to be resolved from the model.")
+
+    assertOffenses(`<%= link_to "Account", [:admin, @user.account] %>`)
+  })
+
+  it("flags an Array URL built from a splat, without naming a route helper", () => {
+    expectInfo("Avoid passing `[*@parents, @user]` directly to `link_to`. The URL is resolved implicitly through polymorphic routing, so what actually gets rendered can't be read off the template or traced by tooling. Use an explicit route helper, or `polymorphic_path([*@parents, @user])` when the route has to be resolved from the model.")
+
+    assertOffenses(`<%= link_to "User", [*@parents, @user] %>`)
+  })
+
+  it("flags an Array URL holding a model class, without naming a route helper", () => {
+    expectInfo("Avoid passing `[:admin, User]` directly to `link_to`. The URL is resolved implicitly through polymorphic routing, so what actually gets rendered can't be read off the template or traced by tooling. Use an explicit route helper, or `polymorphic_path([:admin, User])` when the route has to be resolved from the model.")
+
+    assertOffenses(`<%= link_to "Users", [:admin, User] %>`)
+  })
+
+  it("flags an Array URL holding an instance variable named after a URL", () => {
+    expectInfo("Avoid passing `[:admin, @user_url]` directly to `link_to`. The URL is resolved implicitly through polymorphic routing, so what actually gets rendered can't be read off the template or traced by tooling. Use an explicit route helper like `admin_user_url_path(@user_url)`, or `polymorphic_path([:admin, @user_url])` when the route has to be resolved from the model.")
+
+    assertOffenses(`<%= link_to "User", [:admin, @user_url] %>`)
+  })
+
+  it("passes for an explicit route helper built from an Array element", () => {
+    expectNoOffenses(`<%= link_to "User", admin_user_path(@user) %>`)
+  })
+
+  it("passes for an Array URL passed to `polymorphic_path`", () => {
+    expectNoOffenses(`<%= link_to "User", polymorphic_path([:admin, @user]) %>`)
+  })
+
+  it("flags an Array URL holding a String, which Rails rejects in favor of a Symbol", () => {
+    expectInfo("Avoid passing `[\"admin\", @user]` directly to `link_to`. The URL is resolved implicitly through polymorphic routing, so what actually gets rendered can't be read off the template or traced by tooling. Use an explicit route helper like `admin_user_path(@user)`, or `polymorphic_path([\"admin\", @user])` when the route has to be resolved from the model.")
+
+    assertOffenses(`<%= link_to "User", ["admin", @user] %>`)
+  })
+
+  it("flags a model object read off another model", () => {
+    expectInfo("Avoid passing `@user.account` directly to `link_to`. The URL is resolved implicitly through polymorphic routing, so what actually gets rendered can't be read off the template or traced by tooling. Use an explicit route helper, or `polymorphic_path(@user.account)` when the route has to be resolved from the model.", { line: 1, column: 23 })
+
+    assertOffenses(`<%= link_to "Account", @user.account %>`)
+  })
+
+  it("flags a model object read off a block-local record", () => {
+    expectInfo("Avoid passing `user.account` directly to `link_to`. The URL is resolved implicitly through polymorphic routing, so what actually gets rendered can't be read off the template or traced by tooling. Use an explicit route helper, or `polymorphic_path(user.account)` when the route has to be resolved from the model.")
+
+    assertOffenses(dedent`
+      <% @users.each do |user| %>
+        <%= link_to "Account", user.account %>
+      <% end %>
+    `)
+  })
+
+  it("flags a model object read through a safe navigation call", () => {
+    expectInfo("Avoid passing `@user&.account` directly to `link_to`. The URL is resolved implicitly through polymorphic routing, so what actually gets rendered can't be read off the template or traced by tooling. Use an explicit route helper, or `polymorphic_path(@user&.account)` when the route has to be resolved from the model.")
+
+    assertOffenses(`<%= link_to "Account", @user&.account %>`)
+  })
+
+  it("flags a model object read off a chain of models", () => {
+    expectInfo("Avoid passing `@post.author.profile` directly to `link_to`. The URL is resolved implicitly through polymorphic routing, so what actually gets rendered can't be read off the template or traced by tooling. Use an explicit route helper, or `polymorphic_path(@post.author.profile)` when the route has to be resolved from the model.")
+
+    assertOffenses(`<%= link_to "Profile", @post.author.profile %>`)
+  })
+
+  it("passes for a method call named after a URL", () => {
+    expectNoOffenses(`<%= link_to "Avatar", @user.avatar_url %>`)
+  })
+
+  it("passes for a method call reading a URL off the request", () => {
+    expectNoOffenses(`<%= link_to "Back", request.referer %>`)
+  })
+
+  it("passes for a URL read out of a Hash", () => {
+    expectNoOffenses(`<%= link_to "Back", params[:return_to] %>`)
+  })
+
+  it("passes for a method call taking arguments", () => {
+    expectNoOffenses(`<%= link_to "Account", @user.account_for(@company) %>`)
+  })
+
+  it("passes for a predicate method call in a different argument position", () => {
+    expectNoOffenses(`<%= link_to_if @user.admin?, "Profile", profile_path(@profile) %>`)
+  })
+
+  it("flags an empty Array URL, which raises at runtime", () => {
+    expectError("Passing `[]` to `link_to` raises `ArgumentError: Nil location provided. Can't build URI.` at runtime. Rails compacts the Array before it resolves the route, and an Array with nothing left in it has no route to resolve. Use an explicit route helper for the route this link points at.", { line: 1, column: 20 })
+
+    assertOffenses(`<%= link_to "User", [] %>`)
+  })
+
+  it("flags an Array URL holding only `nil`, which raises at runtime", () => {
+    expectError("Passing `[nil]` to `link_to` raises `ArgumentError: Nil location provided. Can't build URI.` at runtime. Rails compacts the Array before it resolves the route, and an Array with nothing left in it has no route to resolve. Use an explicit route helper for the route this link points at.")
+
+    assertOffenses(`<%= link_to "User", [nil] %>`)
+  })
+
+  it("flags an Array URL holding `nil` alongside a model object, which Rails compacts away", () => {
+    expectInfo("Avoid passing `[nil, @user]` directly to `link_to`. The URL is resolved implicitly through polymorphic routing, so what actually gets rendered can't be read off the template or traced by tooling. Use an explicit route helper like `user_path(@user)`, or `polymorphic_path([nil, @user])` when the route has to be resolved from the model.")
+
+    assertOffenses(`<%= link_to "User", [nil, @user] %>`)
+  })
+
+  it("flags a block-local record passed as the URL argument", () => {
+    expectInfo("Avoid passing `user` directly to `link_to`. The URL is resolved implicitly through polymorphic routing, so what actually gets rendered can't be read off the template or traced by tooling. Use an explicit route helper like `user_path(user)`, or `polymorphic_path(user)` when the route has to be resolved from the model.")
+
+    assertOffenses(dedent`
+      <% @users.each do |user| %>
+        <%= link_to user.name, user %>
+      <% end %>
+    `)
+  })
+
+  it("flags a local variable assigned in the template", () => {
+    expectInfo("Avoid passing `record` directly to `link_to`. The URL is resolved implicitly through polymorphic routing, so what actually gets rendered can't be read off the template or traced by tooling. Use an explicit route helper like `record_path(record)`, or `polymorphic_path(record)` when the route has to be resolved from the model.")
+
+    assertOffenses(dedent`
+      <% record = @post %>
+      <%= link_to "Post", record %>
+    `)
+  })
+
+  it("passes for a local variable named after a URL", () => {
+    expectNoOffenses(dedent`
+      <% @links.each do |link_url| %>
+        <%= link_to "Link", link_url %>
+      <% end %>
+    `)
+  })
+
+  it("passes for a receiverless method call, which can't be told apart from a helper returning a URL", () => {
+    expectNoOffenses(`<%= link_to "Profile", current_user %>`)
   })
 
   it("passes for an explicit route helper", () => {


### PR DESCRIPTION
Follow up on #2017, which added `actionview-no-implicit-polymorphic-url` for `<%= link_to "Profile", @profile %>`.

An Array is resolved through the exact same machinery. `<%= link_to "User", [:admin, @user] %>` renders a link to `/admin/users/:id`, but the route it lands on, `admin_user_path`, is spelled out nowhere in the template, even though every part of the name is right there in the Array. 

This pull request reports that too, along with the other shapes that reach `polymorphic_path` without naming a route.

Resolves #2030
