### PR TITLE
Ruby: Generate `build` factories for AST nodes

### DIFF
--- a/lib/herb/engine/auto_close_omitted_tags_visitor.rb
+++ b/lib/herb/engine/auto_close_omitted_tags_visitor.rb
@@ -34,14 +34,11 @@ module Herb
 
       #: (Herb::Token, Herb::Location) -> Herb::AST::HTMLCloseTagNode
       def explicit_close_tag(tag_name, location)
-        Herb::AST::HTMLCloseTagNode.new(
-          "HTMLCloseTagNode",
-          location,
-          [],
-          Herb::Token.from("TOKEN_HTML_TAG_START_CLOSE", "</", location: location),
-          tag_name,
-          [],
-          Herb::Token.from("TOKEN_HTML_TAG_END", ">", location: location)
+        Herb::AST::HTMLCloseTagNode.build(
+          location: location,
+          tag_opening: Herb::Token.from("TOKEN_HTML_TAG_START_CLOSE", "</", location: location),
+          tag_name: tag_name,
+          tag_closing: Herb::Token.from("TOKEN_HTML_TAG_END", ">", location: location)
         )
       end
     end

--- a/lib/herb/engine/component_visitor.rb
+++ b/lib/herb/engine/component_visitor.rb
@@ -204,48 +204,34 @@ module Herb
 
       #: (Herb::AST::HTMLElementNode, String) -> Herb::AST::ERBContentNode
       def erb_content_node(element_node, code)
-        Herb::AST::ERBContentNode.new(
-          "ERBContentNode",
-          element_node.location,
-          [],
-          Herb::Token.from("TOKEN_ERB_START", "<%="),
-          Herb::Token.from("TOKEN_ERB_CONTENT", " #{code}"),
-          Herb::Token.from("TOKEN_ERB_END", "%>"),
-          nil,
-          false,
-          true,
-          nil
+        Herb::AST::ERBContentNode.build(
+          location: element_node.location,
+          tag_opening: Herb::Token.from("TOKEN_ERB_START", "<%="),
+          content: Herb::Token.from("TOKEN_ERB_CONTENT", " #{code}"),
+          tag_closing: Herb::Token.from("TOKEN_ERB_END", "%>"),
+          valid: true
         )
       end
 
       #: (Herb::AST::HTMLElementNode, String, Array[Herb::AST::Node]) -> Herb::AST::ERBBlockNode
       def erb_block_node(element_node, code, body)
-        Herb::AST::ERBBlockNode.new(
-          "ERBBlockNode",
-          element_node.location,
-          [],
-          Herb::Token.from("TOKEN_ERB_START", "<%="),
-          Herb::Token.from("TOKEN_ERB_CONTENT", " #{code}"),
-          Herb::Token.from("TOKEN_ERB_END", "%>"),
-          nil,
-          body,
-          [],
-          nil,
-          nil,
-          nil,
-          erb_end_node(element_node)
+        Herb::AST::ERBBlockNode.build(
+          location: element_node.location,
+          tag_opening: Herb::Token.from("TOKEN_ERB_START", "<%="),
+          content: Herb::Token.from("TOKEN_ERB_CONTENT", " #{code}"),
+          tag_closing: Herb::Token.from("TOKEN_ERB_END", "%>"),
+          body: body,
+          end_node: erb_end_node(element_node)
         )
       end
 
       #: (Herb::AST::HTMLElementNode) -> Herb::AST::ERBEndNode
       def erb_end_node(element_node)
-        Herb::AST::ERBEndNode.new(
-          "ERBEndNode",
-          element_node.location,
-          [],
-          Herb::Token.from("TOKEN_ERB_START", "<%"),
-          Herb::Token.from("TOKEN_ERB_CONTENT", " end "),
-          Herb::Token.from("TOKEN_ERB_END", "%>")
+        Herb::AST::ERBEndNode.build(
+          location: element_node.location,
+          tag_opening: Herb::Token.from("TOKEN_ERB_START", "<%"),
+          content: Herb::Token.from("TOKEN_ERB_CONTENT", " end "),
+          tag_closing: Herb::Token.from("TOKEN_ERB_END", "%>")
         )
       end
     end

--- a/lib/herb/engine/debug_visitor.rb
+++ b/lib/herb/engine/debug_visitor.rb
@@ -187,16 +187,22 @@ module Herb
       end
 
       def create_debug_attribute(name, value)
-        name_literal = Herb::AST::LiteralNode.new("LiteralNode", Herb::Location.zero, [], name.dup)
-        name_node = Herb::AST::HTMLAttributeNameNode.new("HTMLAttributeNameNode", Herb::Location.zero, [], [name_literal])
+        name_literal = Herb::AST::LiteralNode.build(content: name.dup)
+        name_node = Herb::AST::HTMLAttributeNameNode.build(children: [name_literal])
 
-        value_literal = Herb::AST::LiteralNode.new("LiteralNode", Herb::Location.zero, [], value.dup)
-        value_node = Herb::AST::HTMLAttributeValueNode.new("HTMLAttributeValueNode", Herb::Location.zero, [], Herb::Token.from(:quote, '"'),
-                                                           [value_literal], Herb::Token.from(:quote, '"'), true)
+        value_literal = Herb::AST::LiteralNode.build(content: value.dup)
+        value_node = Herb::AST::HTMLAttributeValueNode.build(
+          open_quote: Herb::Token.from(:quote, '"'),
+          children: [value_literal],
+          close_quote: Herb::Token.from(:quote, '"'),
+          quoted: true
+        )
 
-        equals_token = Herb::Token.from(:equals, "=")
-
-        Herb::AST::HTMLAttributeNode.new("HTMLAttributeNode", Herb::Location.zero, [], name_node, equals_token, value_node)
+        Herb::AST::HTMLAttributeNode.build(
+          name: name_node,
+          equals: Herb::Token.from(:equals, "="),
+          value: value_node
+        )
       end
 
       def create_debug_span_for_erb(erb_node)
@@ -233,29 +239,26 @@ module Herb
 
         tag_name_token = Herb::Token.from(:tag_name, "span")
 
-        open_tag = Herb::AST::HTMLOpenTagNode.new(
-          "HTMLOpenTagNode",
-          Herb::Location.zero,
-          [],
-          Herb::Token.from(:tag_opening, "<"),
-          tag_name_token,
-          Herb::Token.from(:tag_closing, ">"),
-          debug_attributes,
-          false
+        open_tag = Herb::AST::HTMLOpenTagNode.build(
+          tag_opening: Herb::Token.from(:tag_opening, "<"),
+          tag_name: tag_name_token,
+          tag_closing: Herb::Token.from(:tag_closing, ">"),
+          children: debug_attributes
         )
 
-        close_tag = Herb::AST::HTMLCloseTagNode.new(
-          "HTMLCloseTagNode",
-          Herb::Location.zero,
-          [],
-          Herb::Token.from(:tag_opening, "</"),
-          Herb::Token.from(:tag_name, "span"),
-          [],
-          Herb::Token.from(:tag_closing, ">")
+        close_tag = Herb::AST::HTMLCloseTagNode.build(
+          tag_opening: Herb::Token.from(:tag_opening, "</"),
+          tag_name: Herb::Token.from(:tag_name, "span"),
+          tag_closing: Herb::Token.from(:tag_closing, ">")
         )
 
-        Herb::AST::HTMLElementNode.new("HTMLElementNode", Herb::Location.zero, [], open_tag, tag_name_token, [erb_node], close_tag,
-                                       false, "Debug")
+        Herb::AST::HTMLElementNode.build(
+          open_tag: open_tag,
+          tag_name: tag_name_token,
+          body: [erb_node],
+          close_tag: close_tag,
+          element_source: "Debug"
+        )
       end
 
       def determine_view_type

--- a/sig/herb/ast/nodes.rbs
+++ b/sig/herb/ast/nodes.rbs
@@ -19,6 +19,9 @@ module Herb
       # : (String, Location, Array[Herb::Errors::Error], Array[Herb::AST::Node], nil, String?) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], Array[Herb::AST::Node], nil, String?) -> void
 
+      # : (?children: Array[Herb::AST::Node], ?prism_context: nil, ?prism_node: String?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> DocumentNode
+      def self.build: (?children: Array[Herb::AST::Node], ?prism_context: nil, ?prism_node: String?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> DocumentNode
+
       # : () -> Prism::node?
       def deserialized_prism_node: () -> Prism::node?
 
@@ -51,6 +54,9 @@ module Herb
 
       # : (String, Location, Array[Herb::Errors::Error], String?) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], String?) -> void
+
+      # : (?content: String?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> LiteralNode
+      def self.build: (?content: String?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> LiteralNode
 
       # : () -> serialized_literal_node
       def to_hash: () -> serialized_literal_node
@@ -94,6 +100,9 @@ module Herb
       # : (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, Array[Herb::AST::Node], bool) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, Array[Herb::AST::Node], bool) -> void
 
+      # : (?tag_opening: Herb::Token?, ?tag_name: Herb::Token?, ?tag_closing: Herb::Token?, ?children: Array[Herb::AST::Node], ?is_void: bool, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> HTMLOpenTagNode
+      def self.build: (?tag_opening: Herb::Token?, ?tag_name: Herb::Token?, ?tag_closing: Herb::Token?, ?children: Array[Herb::AST::Node], ?is_void: bool, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> HTMLOpenTagNode
+
       # : () -> serialized_html_open_tag_node
       def to_hash: () -> serialized_html_open_tag_node
 
@@ -129,6 +138,9 @@ module Herb
 
       # : (String, Location, Array[Herb::Errors::Error], (Herb::AST::ERBIfNode | Herb::AST::ERBUnlessNode)?, Herb::Token?, bool) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], (Herb::AST::ERBIfNode | Herb::AST::ERBUnlessNode)?, Herb::Token?, bool) -> void
+
+      # : (?conditional: (Herb::AST::ERBIfNode | Herb::AST::ERBUnlessNode)?, ?tag_name: Herb::Token?, ?is_void: bool, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> HTMLConditionalOpenTagNode
+      def self.build: (?conditional: (Herb::AST::ERBIfNode | Herb::AST::ERBUnlessNode)?, ?tag_name: Herb::Token?, ?is_void: bool, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> HTMLConditionalOpenTagNode
 
       # : () -> serialized_html_conditional_open_tag_node
       def to_hash: () -> serialized_html_conditional_open_tag_node
@@ -169,6 +181,9 @@ module Herb
       # : (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Array[Herb::AST::WhitespaceNode]?, Herb::Token?) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Array[Herb::AST::WhitespaceNode]?, Herb::Token?) -> void
 
+      # : (?tag_opening: Herb::Token?, ?tag_name: Herb::Token?, ?children: Array[Herb::AST::WhitespaceNode]?, ?tag_closing: Herb::Token?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> HTMLCloseTagNode
+      def self.build: (?tag_opening: Herb::Token?, ?tag_name: Herb::Token?, ?children: Array[Herb::AST::WhitespaceNode]?, ?tag_closing: Herb::Token?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> HTMLCloseTagNode
+
       # : () -> serialized_html_close_tag_node
       def to_hash: () -> serialized_html_close_tag_node
 
@@ -199,6 +214,9 @@ module Herb
       # : (String, Location, Array[Herb::Errors::Error], Herb::Token?) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], Herb::Token?) -> void
 
+      # : (?tag_name: Herb::Token?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> HTMLOmittedCloseTagNode
+      def self.build: (?tag_name: Herb::Token?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> HTMLOmittedCloseTagNode
+
       # : () -> serialized_html_omitted_close_tag_node
       def to_hash: () -> serialized_html_omitted_close_tag_node
 
@@ -228,6 +246,9 @@ module Herb
 
       # : (String, Location, Array[Herb::Errors::Error], Herb::Token?) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], Herb::Token?) -> void
+
+      # : (?tag_name: Herb::Token?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> HTMLVirtualCloseTagNode
+      def self.build: (?tag_name: Herb::Token?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> HTMLVirtualCloseTagNode
 
       # : () -> serialized_html_virtual_close_tag_node
       def to_hash: () -> serialized_html_virtual_close_tag_node
@@ -273,6 +294,9 @@ module Herb
 
       # : (String, Location, Array[Herb::Errors::Error], (Herb::AST::HTMLOpenTagNode | Herb::AST::HTMLConditionalOpenTagNode | Herb::AST::ERBOpenTagNode)?, Herb::Token?, Array[Herb::AST::Node], (Herb::AST::HTMLCloseTagNode | Herb::AST::HTMLOmittedCloseTagNode | Herb::AST::HTMLVirtualCloseTagNode | Herb::AST::ERBEndNode)?, bool, String?) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], (Herb::AST::HTMLOpenTagNode | Herb::AST::HTMLConditionalOpenTagNode | Herb::AST::ERBOpenTagNode)?, Herb::Token?, Array[Herb::AST::Node], (Herb::AST::HTMLCloseTagNode | Herb::AST::HTMLOmittedCloseTagNode | Herb::AST::HTMLVirtualCloseTagNode | Herb::AST::ERBEndNode)?, bool, String?) -> void
+
+      # : (?open_tag: (Herb::AST::HTMLOpenTagNode | Herb::AST::HTMLConditionalOpenTagNode | Herb::AST::ERBOpenTagNode)?, ?tag_name: Herb::Token?, ?body: Array[Herb::AST::Node], ?close_tag: (Herb::AST::HTMLCloseTagNode | Herb::AST::HTMLOmittedCloseTagNode | Herb::AST::HTMLVirtualCloseTagNode | Herb::AST::ERBEndNode)?, ?is_void: bool, ?element_source: String?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> HTMLElementNode
+      def self.build: (?open_tag: (Herb::AST::HTMLOpenTagNode | Herb::AST::HTMLConditionalOpenTagNode | Herb::AST::ERBOpenTagNode)?, ?tag_name: Herb::Token?, ?body: Array[Herb::AST::Node], ?close_tag: (Herb::AST::HTMLCloseTagNode | Herb::AST::HTMLOmittedCloseTagNode | Herb::AST::HTMLVirtualCloseTagNode | Herb::AST::ERBEndNode)?, ?is_void: bool, ?element_source: String?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> HTMLElementNode
 
       # : () -> serialized_html_element_node
       def to_hash: () -> serialized_html_element_node
@@ -325,6 +349,9 @@ module Herb
       # : (String, Location, Array[Herb::Errors::Error], String?, (Herb::AST::ERBIfNode | Herb::AST::ERBUnlessNode)?, Herb::AST::HTMLOpenTagNode?, Array[Herb::AST::Node], (Herb::AST::HTMLCloseTagNode | Herb::AST::HTMLOmittedCloseTagNode)?, (Herb::AST::ERBIfNode | Herb::AST::ERBUnlessNode)?, Herb::Token?, String?) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], String?, (Herb::AST::ERBIfNode | Herb::AST::ERBUnlessNode)?, Herb::AST::HTMLOpenTagNode?, Array[Herb::AST::Node], (Herb::AST::HTMLCloseTagNode | Herb::AST::HTMLOmittedCloseTagNode)?, (Herb::AST::ERBIfNode | Herb::AST::ERBUnlessNode)?, Herb::Token?, String?) -> void
 
+      # : (?condition: String?, ?open_conditional: (Herb::AST::ERBIfNode | Herb::AST::ERBUnlessNode)?, ?open_tag: Herb::AST::HTMLOpenTagNode?, ?body: Array[Herb::AST::Node], ?close_tag: (Herb::AST::HTMLCloseTagNode | Herb::AST::HTMLOmittedCloseTagNode)?, ?close_conditional: (Herb::AST::ERBIfNode | Herb::AST::ERBUnlessNode)?, ?tag_name: Herb::Token?, ?element_source: String?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> HTMLConditionalElementNode
+      def self.build: (?condition: String?, ?open_conditional: (Herb::AST::ERBIfNode | Herb::AST::ERBUnlessNode)?, ?open_tag: Herb::AST::HTMLOpenTagNode?, ?body: Array[Herb::AST::Node], ?close_tag: (Herb::AST::HTMLCloseTagNode | Herb::AST::HTMLOmittedCloseTagNode)?, ?close_conditional: (Herb::AST::ERBIfNode | Herb::AST::ERBUnlessNode)?, ?tag_name: Herb::Token?, ?element_source: String?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> HTMLConditionalElementNode
+
       # : () -> serialized_html_conditional_element_node
       def to_hash: () -> serialized_html_conditional_element_node
 
@@ -364,6 +391,9 @@ module Herb
       # : (String, Location, Array[Herb::Errors::Error], Herb::Token?, Array[Herb::AST::Node], Herb::Token?, bool) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], Herb::Token?, Array[Herb::AST::Node], Herb::Token?, bool) -> void
 
+      # : (?open_quote: Herb::Token?, ?children: Array[Herb::AST::Node], ?close_quote: Herb::Token?, ?quoted: bool, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> HTMLAttributeValueNode
+      def self.build: (?open_quote: Herb::Token?, ?children: Array[Herb::AST::Node], ?close_quote: Herb::Token?, ?quoted: bool, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> HTMLAttributeValueNode
+
       # : () -> serialized_html_attribute_value_node
       def to_hash: () -> serialized_html_attribute_value_node
 
@@ -393,6 +423,9 @@ module Herb
 
       # : (String, Location, Array[Herb::Errors::Error], Array[(Herb::AST::LiteralNode | Herb::AST::ERBContentNode)]?) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], Array[Herb::AST::LiteralNode | Herb::AST::ERBContentNode]?) -> void
+
+      # : (?children: Array[(Herb::AST::LiteralNode | Herb::AST::ERBContentNode)]?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> HTMLAttributeNameNode
+      def self.build: (?children: Array[Herb::AST::LiteralNode | Herb::AST::ERBContentNode]?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> HTMLAttributeNameNode
 
       # : () -> serialized_html_attribute_name_node
       def to_hash: () -> serialized_html_attribute_name_node
@@ -430,6 +463,9 @@ module Herb
       # : (String, Location, Array[Herb::Errors::Error], Herb::AST::HTMLAttributeNameNode?, Herb::Token?, Herb::AST::HTMLAttributeValueNode?) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], Herb::AST::HTMLAttributeNameNode?, Herb::Token?, Herb::AST::HTMLAttributeValueNode?) -> void
 
+      # : (?name: Herb::AST::HTMLAttributeNameNode?, ?equals: Herb::Token?, ?value: Herb::AST::HTMLAttributeValueNode?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> HTMLAttributeNode
+      def self.build: (?name: Herb::AST::HTMLAttributeNameNode?, ?equals: Herb::Token?, ?value: Herb::AST::HTMLAttributeValueNode?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> HTMLAttributeNode
+
       # : () -> serialized_html_attribute_node
       def to_hash: () -> serialized_html_attribute_node
 
@@ -459,6 +495,9 @@ module Herb
 
       # : (String, Location, Array[Herb::Errors::Error], String?) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], String?) -> void
+
+      # : (?content: String?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> RubyLiteralNode
+      def self.build: (?content: String?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> RubyLiteralNode
 
       # : () -> serialized_ruby_literal_node
       def to_hash: () -> serialized_ruby_literal_node
@@ -492,6 +531,9 @@ module Herb
 
       # : (String, Location, Array[Herb::Errors::Error], String?, String?) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], String?, String?) -> void
+
+      # : (?content: String?, ?prefix: String?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> RubyHTMLAttributesSplatNode
+      def self.build: (?content: String?, ?prefix: String?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> RubyHTMLAttributesSplatNode
 
       # : () -> serialized_ruby_html_attributes_splat_node
       def to_hash: () -> serialized_ruby_html_attributes_splat_node
@@ -535,6 +577,9 @@ module Herb
       # : (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, Herb::Token?, Array[Herb::AST::Node]) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, Herb::Token?, Array[Herb::AST::Node]) -> void
 
+      # : (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?tag_name: Herb::Token?, ?children: Array[Herb::AST::Node], ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBOpenTagNode
+      def self.build: (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?tag_name: Herb::Token?, ?children: Array[Herb::AST::Node], ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBOpenTagNode
+
       # : () -> serialized_erb_open_tag_node
       def to_hash: () -> serialized_erb_open_tag_node
 
@@ -564,6 +609,9 @@ module Herb
 
       # : (String, Location, Array[Herb::Errors::Error], String?) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], String?) -> void
+
+      # : (?content: String?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> HTMLTextNode
+      def self.build: (?content: String?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> HTMLTextNode
 
       # : () -> serialized_html_text_node
       def to_hash: () -> serialized_html_text_node
@@ -601,6 +649,9 @@ module Herb
       # : (String, Location, Array[Herb::Errors::Error], Herb::Token?, Array[Herb::AST::Node], Herb::Token?) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], Herb::Token?, Array[Herb::AST::Node], Herb::Token?) -> void
 
+      # : (?comment_start: Herb::Token?, ?children: Array[Herb::AST::Node], ?comment_end: Herb::Token?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> HTMLCommentNode
+      def self.build: (?comment_start: Herb::Token?, ?children: Array[Herb::AST::Node], ?comment_end: Herb::Token?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> HTMLCommentNode
+
       # : () -> serialized_html_comment_node
       def to_hash: () -> serialized_html_comment_node
 
@@ -636,6 +687,9 @@ module Herb
 
       # : (String, Location, Array[Herb::Errors::Error], Herb::Token?, Array[Herb::AST::Node], Herb::Token?) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], Herb::Token?, Array[Herb::AST::Node], Herb::Token?) -> void
+
+      # : (?tag_opening: Herb::Token?, ?children: Array[Herb::AST::Node], ?tag_closing: Herb::Token?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> HTMLDoctypeNode
+      def self.build: (?tag_opening: Herb::Token?, ?children: Array[Herb::AST::Node], ?tag_closing: Herb::Token?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> HTMLDoctypeNode
 
       # : () -> serialized_html_doctype_node
       def to_hash: () -> serialized_html_doctype_node
@@ -673,6 +727,9 @@ module Herb
       # : (String, Location, Array[Herb::Errors::Error], Herb::Token?, Array[Herb::AST::Node], Herb::Token?) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], Herb::Token?, Array[Herb::AST::Node], Herb::Token?) -> void
 
+      # : (?tag_opening: Herb::Token?, ?children: Array[Herb::AST::Node], ?tag_closing: Herb::Token?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> XMLDeclarationNode
+      def self.build: (?tag_opening: Herb::Token?, ?children: Array[Herb::AST::Node], ?tag_closing: Herb::Token?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> XMLDeclarationNode
+
       # : () -> serialized_xml_declaration_node
       def to_hash: () -> serialized_xml_declaration_node
 
@@ -709,6 +766,9 @@ module Herb
       # : (String, Location, Array[Herb::Errors::Error], Herb::Token?, Array[Herb::AST::Node], Herb::Token?) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], Herb::Token?, Array[Herb::AST::Node], Herb::Token?) -> void
 
+      # : (?tag_opening: Herb::Token?, ?children: Array[Herb::AST::Node], ?tag_closing: Herb::Token?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> CDATANode
+      def self.build: (?tag_opening: Herb::Token?, ?children: Array[Herb::AST::Node], ?tag_closing: Herb::Token?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> CDATANode
+
       # : () -> serialized_cdata_node
       def to_hash: () -> serialized_cdata_node
 
@@ -738,6 +798,9 @@ module Herb
 
       # : (String, Location, Array[Herb::Errors::Error], Herb::Token?) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], Herb::Token?) -> void
+
+      # : (?value: Herb::Token?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> WhitespaceNode
+      def self.build: (?value: Herb::Token?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> WhitespaceNode
 
       # : () -> serialized_whitespace_node
       def to_hash: () -> serialized_whitespace_node
@@ -787,6 +850,9 @@ module Herb
       # : (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, nil, bool, bool, String?) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, nil, bool, bool, String?) -> void
 
+      # : (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?analyzed_ruby: nil, ?parsed: bool, ?valid: bool, ?prism_node: String?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBContentNode
+      def self.build: (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?analyzed_ruby: nil, ?parsed: bool, ?valid: bool, ?prism_node: String?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBContentNode
+
       # : () -> Prism::node?
       def deserialized_prism_node: () -> Prism::node?
 
@@ -826,6 +892,9 @@ module Herb
       # : (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?) -> void
 
+      # : (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBEndNode
+      def self.build: (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBEndNode
+
       # : () -> serialized_erb_end_node
       def to_hash: () -> serialized_erb_end_node
 
@@ -864,6 +933,9 @@ module Herb
 
       # : (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, Array[Herb::AST::Node]) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, Array[Herb::AST::Node]) -> void
+
+      # : (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?statements: Array[Herb::AST::Node], ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBElseNode
+      def self.build: (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?statements: Array[Herb::AST::Node], ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBElseNode
 
       # : () -> serialized_erb_else_node
       def to_hash: () -> serialized_erb_else_node
@@ -915,6 +987,9 @@ module Herb
 
       # : (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, Herb::Location?, String?, Array[Herb::AST::Node], (Herb::AST::ERBIfNode | Herb::AST::ERBElseNode)?, Herb::AST::ERBEndNode?) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, Herb::Location?, String?, Array[Herb::AST::Node], (Herb::AST::ERBIfNode | Herb::AST::ERBElseNode)?, Herb::AST::ERBEndNode?) -> void
+
+      # : (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?then_keyword: Herb::Location?, ?prism_node: String?, ?statements: Array[Herb::AST::Node], ?subsequent: (Herb::AST::ERBIfNode | Herb::AST::ERBElseNode)?, ?end_node: Herb::AST::ERBEndNode?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBIfNode
+      def self.build: (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?then_keyword: Herb::Location?, ?prism_node: String?, ?statements: Array[Herb::AST::Node], ?subsequent: (Herb::AST::ERBIfNode | Herb::AST::ERBElseNode)?, ?end_node: Herb::AST::ERBEndNode?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBIfNode
 
       # : () -> Prism::node?
       def deserialized_prism_node: () -> Prism::node?
@@ -975,6 +1050,9 @@ module Herb
 
       # : (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, String?, Array[Herb::AST::Node], Array[Herb::AST::RubyParameterNode]?, Herb::AST::ERBRescueNode?, Herb::AST::ERBElseNode?, Herb::AST::ERBEnsureNode?, Herb::AST::ERBEndNode?) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, String?, Array[Herb::AST::Node], Array[Herb::AST::RubyParameterNode]?, Herb::AST::ERBRescueNode?, Herb::AST::ERBElseNode?, Herb::AST::ERBEnsureNode?, Herb::AST::ERBEndNode?) -> void
+
+      # : (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?prism_node: String?, ?body: Array[Herb::AST::Node], ?block_arguments: Array[Herb::AST::RubyParameterNode]?, ?rescue_clause: Herb::AST::ERBRescueNode?, ?else_clause: Herb::AST::ERBElseNode?, ?ensure_clause: Herb::AST::ERBEnsureNode?, ?end_node: Herb::AST::ERBEndNode?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBBlockNode
+      def self.build: (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?prism_node: String?, ?body: Array[Herb::AST::Node], ?block_arguments: Array[Herb::AST::RubyParameterNode]?, ?rescue_clause: Herb::AST::ERBRescueNode?, ?else_clause: Herb::AST::ERBElseNode?, ?ensure_clause: Herb::AST::ERBEnsureNode?, ?end_node: Herb::AST::ERBEndNode?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBBlockNode
 
       # : () -> Prism::node?
       def deserialized_prism_node: () -> Prism::node?
@@ -1051,6 +1129,9 @@ module Herb
       # : (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, String?, Herb::Token?, Herb::Token?, Herb::Token?, Array[Herb::AST::RubyLiteralNode]?, Herb::Token?, Array[Herb::AST::Node], Array[Herb::AST::RubyParameterNode]?, Herb::AST::ERBRescueNode?, Herb::AST::ERBElseNode?, Herb::AST::ERBEnsureNode?, Herb::AST::ERBEndNode?) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, String?, Herb::Token?, Herb::Token?, Herb::Token?, Array[Herb::AST::RubyLiteralNode]?, Herb::Token?, Array[Herb::AST::Node], Array[Herb::AST::RubyParameterNode]?, Herb::AST::ERBRescueNode?, Herb::AST::ERBElseNode?, Herb::AST::ERBEnsureNode?, Herb::AST::ERBEndNode?) -> void
 
+      # : (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?prism_node: String?, ?receiver: Herb::Token?, ?call_operator: Herb::Token?, ?message: Herb::Token?, ?arguments: Array[Herb::AST::RubyLiteralNode]?, ?block_opening: Herb::Token?, ?body: Array[Herb::AST::Node], ?block_arguments: Array[Herb::AST::RubyParameterNode]?, ?rescue_clause: Herb::AST::ERBRescueNode?, ?else_clause: Herb::AST::ERBElseNode?, ?ensure_clause: Herb::AST::ERBEnsureNode?, ?end_node: Herb::AST::ERBEndNode?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBIterationBlockNode
+      def self.build: (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?prism_node: String?, ?receiver: Herb::Token?, ?call_operator: Herb::Token?, ?message: Herb::Token?, ?arguments: Array[Herb::AST::RubyLiteralNode]?, ?block_opening: Herb::Token?, ?body: Array[Herb::AST::Node], ?block_arguments: Array[Herb::AST::RubyParameterNode]?, ?rescue_clause: Herb::AST::ERBRescueNode?, ?else_clause: Herb::AST::ERBElseNode?, ?ensure_clause: Herb::AST::ERBEnsureNode?, ?end_node: Herb::AST::ERBEndNode?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBIterationBlockNode
+
       # : () -> Prism::node?
       def deserialized_prism_node: () -> Prism::node?
 
@@ -1095,6 +1176,9 @@ module Herb
 
       # : (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, Herb::Location?, Array[Herb::AST::Node]) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, Herb::Location?, Array[Herb::AST::Node]) -> void
+
+      # : (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?then_keyword: Herb::Location?, ?statements: Array[Herb::AST::Node], ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBWhenNode
+      def self.build: (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?then_keyword: Herb::Location?, ?statements: Array[Herb::AST::Node], ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBWhenNode
 
       # : () -> serialized_erb_when_node
       def to_hash: () -> serialized_erb_when_node
@@ -1146,6 +1230,9 @@ module Herb
 
       # : (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, Array[Herb::AST::Node], String?, Array[Herb::AST::ERBWhenNode], Herb::AST::ERBElseNode?, Herb::AST::ERBEndNode?) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, Array[Herb::AST::Node], String?, Array[Herb::AST::ERBWhenNode], Herb::AST::ERBElseNode?, Herb::AST::ERBEndNode?) -> void
+
+      # : (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?children: Array[Herb::AST::Node], ?prism_node: String?, ?conditions: Array[Herb::AST::ERBWhenNode], ?else_clause: Herb::AST::ERBElseNode?, ?end_node: Herb::AST::ERBEndNode?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBCaseNode
+      def self.build: (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?children: Array[Herb::AST::Node], ?prism_node: String?, ?conditions: Array[Herb::AST::ERBWhenNode], ?else_clause: Herb::AST::ERBElseNode?, ?end_node: Herb::AST::ERBEndNode?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBCaseNode
 
       # : () -> Prism::node?
       def deserialized_prism_node: () -> Prism::node?
@@ -1201,6 +1288,9 @@ module Herb
       # : (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, Array[Herb::AST::Node], String?, Array[Herb::AST::ERBInNode], Herb::AST::ERBElseNode?, Herb::AST::ERBEndNode?) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, Array[Herb::AST::Node], String?, Array[Herb::AST::ERBInNode], Herb::AST::ERBElseNode?, Herb::AST::ERBEndNode?) -> void
 
+      # : (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?children: Array[Herb::AST::Node], ?prism_node: String?, ?conditions: Array[Herb::AST::ERBInNode], ?else_clause: Herb::AST::ERBElseNode?, ?end_node: Herb::AST::ERBEndNode?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBCaseMatchNode
+      def self.build: (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?children: Array[Herb::AST::Node], ?prism_node: String?, ?conditions: Array[Herb::AST::ERBInNode], ?else_clause: Herb::AST::ERBElseNode?, ?end_node: Herb::AST::ERBEndNode?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBCaseMatchNode
+
       # : () -> Prism::node?
       def deserialized_prism_node: () -> Prism::node?
 
@@ -1248,6 +1338,9 @@ module Herb
 
       # : (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, String?, Array[Herb::AST::Node], Herb::AST::ERBEndNode?) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, String?, Array[Herb::AST::Node], Herb::AST::ERBEndNode?) -> void
+
+      # : (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?prism_node: String?, ?statements: Array[Herb::AST::Node], ?end_node: Herb::AST::ERBEndNode?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBWhileNode
+      def self.build: (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?prism_node: String?, ?statements: Array[Herb::AST::Node], ?end_node: Herb::AST::ERBEndNode?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBWhileNode
 
       # : () -> Prism::node?
       def deserialized_prism_node: () -> Prism::node?
@@ -1297,6 +1390,9 @@ module Herb
       # : (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, String?, Array[Herb::AST::Node], Herb::AST::ERBEndNode?) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, String?, Array[Herb::AST::Node], Herb::AST::ERBEndNode?) -> void
 
+      # : (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?prism_node: String?, ?statements: Array[Herb::AST::Node], ?end_node: Herb::AST::ERBEndNode?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBUntilNode
+      def self.build: (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?prism_node: String?, ?statements: Array[Herb::AST::Node], ?end_node: Herb::AST::ERBEndNode?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBUntilNode
+
       # : () -> Prism::node?
       def deserialized_prism_node: () -> Prism::node?
 
@@ -1345,6 +1441,9 @@ module Herb
       # : (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, String?, Array[Herb::AST::Node], Herb::AST::ERBEndNode?) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, String?, Array[Herb::AST::Node], Herb::AST::ERBEndNode?) -> void
 
+      # : (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?prism_node: String?, ?statements: Array[Herb::AST::Node], ?end_node: Herb::AST::ERBEndNode?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBForNode
+      def self.build: (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?prism_node: String?, ?statements: Array[Herb::AST::Node], ?end_node: Herb::AST::ERBEndNode?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBForNode
+
       # : () -> Prism::node?
       def deserialized_prism_node: () -> Prism::node?
 
@@ -1390,6 +1489,9 @@ module Herb
       # : (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, Array[Herb::AST::Node], Herb::AST::ERBRescueNode?) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, Array[Herb::AST::Node], Herb::AST::ERBRescueNode?) -> void
 
+      # : (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?statements: Array[Herb::AST::Node], ?subsequent: Herb::AST::ERBRescueNode?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBRescueNode
+      def self.build: (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?statements: Array[Herb::AST::Node], ?subsequent: Herb::AST::ERBRescueNode?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBRescueNode
+
       # : () -> serialized_erb_rescue_node
       def to_hash: () -> serialized_erb_rescue_node
 
@@ -1428,6 +1530,9 @@ module Herb
 
       # : (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, Array[Herb::AST::Node]) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, Array[Herb::AST::Node]) -> void
+
+      # : (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?statements: Array[Herb::AST::Node], ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBEnsureNode
+      def self.build: (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?statements: Array[Herb::AST::Node], ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBEnsureNode
 
       # : () -> serialized_erb_ensure_node
       def to_hash: () -> serialized_erb_ensure_node
@@ -1483,6 +1588,9 @@ module Herb
       # : (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, String?, Array[Herb::AST::Node], Herb::AST::ERBRescueNode?, Herb::AST::ERBElseNode?, Herb::AST::ERBEnsureNode?, Herb::AST::ERBEndNode?) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, String?, Array[Herb::AST::Node], Herb::AST::ERBRescueNode?, Herb::AST::ERBElseNode?, Herb::AST::ERBEnsureNode?, Herb::AST::ERBEndNode?) -> void
 
+      # : (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?prism_node: String?, ?statements: Array[Herb::AST::Node], ?rescue_clause: Herb::AST::ERBRescueNode?, ?else_clause: Herb::AST::ERBElseNode?, ?ensure_clause: Herb::AST::ERBEnsureNode?, ?end_node: Herb::AST::ERBEndNode?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBBeginNode
+      def self.build: (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?prism_node: String?, ?statements: Array[Herb::AST::Node], ?rescue_clause: Herb::AST::ERBRescueNode?, ?else_clause: Herb::AST::ERBElseNode?, ?ensure_clause: Herb::AST::ERBEnsureNode?, ?end_node: Herb::AST::ERBEndNode?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBBeginNode
+
       # : () -> Prism::node?
       def deserialized_prism_node: () -> Prism::node?
 
@@ -1537,6 +1645,9 @@ module Herb
       # : (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, Herb::Location?, String?, Array[Herb::AST::Node], Herb::AST::ERBElseNode?, Herb::AST::ERBEndNode?) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, Herb::Location?, String?, Array[Herb::AST::Node], Herb::AST::ERBElseNode?, Herb::AST::ERBEndNode?) -> void
 
+      # : (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?then_keyword: Herb::Location?, ?prism_node: String?, ?statements: Array[Herb::AST::Node], ?else_clause: Herb::AST::ERBElseNode?, ?end_node: Herb::AST::ERBEndNode?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBUnlessNode
+      def self.build: (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?then_keyword: Herb::Location?, ?prism_node: String?, ?statements: Array[Herb::AST::Node], ?else_clause: Herb::AST::ERBElseNode?, ?end_node: Herb::AST::ERBEndNode?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBUnlessNode
+
       # : () -> Prism::node?
       def deserialized_prism_node: () -> Prism::node?
 
@@ -1572,6 +1683,9 @@ module Herb
 
       # : (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::AST::RubyLiteralNode?) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::AST::RubyLiteralNode?) -> void
+
+      # : (?name: Herb::Token?, ?value: Herb::AST::RubyLiteralNode?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> RubyRenderLocalNode
+      def self.build: (?name: Herb::Token?, ?value: Herb::AST::RubyLiteralNode?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> RubyRenderLocalNode
 
       # : () -> serialized_ruby_render_local_node
       def to_hash: () -> serialized_ruby_render_local_node
@@ -1654,6 +1768,9 @@ module Herb
       # : (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, Herb::Token?, Herb::Token?, Herb::Token?, Herb::Token?, Herb::Token?, Herb::Token?, Herb::Token?, Herb::Token?, Herb::Token?, Herb::Token?, Herb::Token?, Herb::Token?, Herb::Token?, Herb::Token?, Array[Herb::AST::RubyRenderLocalNode]?) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, Herb::Token?, Herb::Token?, Herb::Token?, Herb::Token?, Herb::Token?, Herb::Token?, Herb::Token?, Herb::Token?, Herb::Token?, Herb::Token?, Herb::Token?, Herb::Token?, Herb::Token?, Herb::Token?, Array[Herb::AST::RubyRenderLocalNode]?) -> void
 
+      # : (?partial: Herb::Token?, ?template_path: Herb::Token?, ?layout: Herb::Token?, ?file: Herb::Token?, ?inline_template: Herb::Token?, ?body: Herb::Token?, ?plain: Herb::Token?, ?html: Herb::Token?, ?renderable: Herb::Token?, ?collection: Herb::Token?, ?object: Herb::Token?, ?as_name: Herb::Token?, ?spacer_template: Herb::Token?, ?formats: Herb::Token?, ?variants: Herb::Token?, ?handlers: Herb::Token?, ?content_type: Herb::Token?, ?locals: Array[Herb::AST::RubyRenderLocalNode]?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> RubyRenderKeywordsNode
+      def self.build: (?partial: Herb::Token?, ?template_path: Herb::Token?, ?layout: Herb::Token?, ?file: Herb::Token?, ?inline_template: Herb::Token?, ?body: Herb::Token?, ?plain: Herb::Token?, ?html: Herb::Token?, ?renderable: Herb::Token?, ?collection: Herb::Token?, ?object: Herb::Token?, ?as_name: Herb::Token?, ?spacer_template: Herb::Token?, ?formats: Herb::Token?, ?variants: Herb::Token?, ?handlers: Herb::Token?, ?content_type: Herb::Token?, ?locals: Array[Herb::AST::RubyRenderLocalNode]?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> RubyRenderKeywordsNode
+
       # : () -> serialized_ruby_render_keywords_node
       def to_hash: () -> serialized_ruby_render_keywords_node
 
@@ -1717,6 +1834,9 @@ module Herb
       # : (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, nil, String?, Herb::AST::RubyRenderKeywordsNode?, Array[Herb::AST::Node], Array[Herb::AST::RubyParameterNode]?, Herb::AST::ERBRescueNode?, Herb::AST::ERBElseNode?, Herb::AST::ERBEnsureNode?, Herb::AST::ERBEndNode?) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, nil, String?, Herb::AST::RubyRenderKeywordsNode?, Array[Herb::AST::Node], Array[Herb::AST::RubyParameterNode]?, Herb::AST::ERBRescueNode?, Herb::AST::ERBElseNode?, Herb::AST::ERBEnsureNode?, Herb::AST::ERBEndNode?) -> void
 
+      # : (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?analyzed_ruby: nil, ?prism_node: String?, ?keywords: Herb::AST::RubyRenderKeywordsNode?, ?body: Array[Herb::AST::Node], ?block_arguments: Array[Herb::AST::RubyParameterNode]?, ?rescue_clause: Herb::AST::ERBRescueNode?, ?else_clause: Herb::AST::ERBElseNode?, ?ensure_clause: Herb::AST::ERBEnsureNode?, ?end_node: Herb::AST::ERBEndNode?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBRenderNode
+      def self.build: (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?analyzed_ruby: nil, ?prism_node: String?, ?keywords: Herb::AST::RubyRenderKeywordsNode?, ?body: Array[Herb::AST::Node], ?block_arguments: Array[Herb::AST::RubyParameterNode]?, ?rescue_clause: Herb::AST::ERBRescueNode?, ?else_clause: Herb::AST::ERBElseNode?, ?ensure_clause: Herb::AST::ERBEnsureNode?, ?end_node: Herb::AST::ERBEndNode?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBRenderNode
+
       # : () -> Prism::node?
       def deserialized_prism_node: () -> Prism::node?
 
@@ -1758,6 +1878,9 @@ module Herb
 
       # : (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::AST::RubyLiteralNode?, String?, bool) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::AST::RubyLiteralNode?, String?, bool) -> void
+
+      # : (?name: Herb::Token?, ?default_value: Herb::AST::RubyLiteralNode?, ?kind: String?, ?required: bool, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> RubyParameterNode
+      def self.build: (?name: Herb::Token?, ?default_value: Herb::AST::RubyLiteralNode?, ?kind: String?, ?required: bool, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> RubyParameterNode
 
       # : () -> serialized_ruby_parameter_node
       def to_hash: () -> serialized_ruby_parameter_node
@@ -1804,6 +1927,9 @@ module Herb
       # : (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, nil, String?, Array[Herb::AST::RubyParameterNode]?) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, nil, String?, Array[Herb::AST::RubyParameterNode]?) -> void
 
+      # : (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?analyzed_ruby: nil, ?prism_node: String?, ?locals: Array[Herb::AST::RubyParameterNode]?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBStrictLocalsNode
+      def self.build: (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?analyzed_ruby: nil, ?prism_node: String?, ?locals: Array[Herb::AST::RubyParameterNode]?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBStrictLocalsNode
+
       # : () -> Prism::node?
       def deserialized_prism_node: () -> Prism::node?
 
@@ -1842,6 +1968,9 @@ module Herb
 
       # : (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?) -> void
+
+      # : (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBYieldNode
+      def self.build: (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBYieldNode
 
       # : () -> serialized_erb_yield_node
       def to_hash: () -> serialized_erb_yield_node
@@ -1884,6 +2013,9 @@ module Herb
 
       # : (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, Herb::Location?, Array[Herb::AST::Node]) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, Herb::Location?, Array[Herb::AST::Node]) -> void
+
+      # : (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?then_keyword: Herb::Location?, ?statements: Array[Herb::AST::Node], ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBInNode
+      def self.build: (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?then_keyword: Herb::Location?, ?statements: Array[Herb::AST::Node], ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBInNode
 
       # : () -> serialized_erb_in_node
       def to_hash: () -> serialized_erb_in_node

--- a/templates/lib/herb/ast/nodes.rb.erb
+++ b/templates/lib/herb/ast/nodes.rb.erb
@@ -27,6 +27,11 @@ module Herb
         <%- end -%>
       end
 
+      #: (<%= [*node.fields.map { |field| "?#{field.name}: #{field.nilable_ruby_type}" }, "?location: Location", "?errors: Array[Herb::Errors::Error]"].join(", ") %>) -> <%= node.name %>
+      def self.build(<%= [*node.fields.map { |field| "#{field.name}: #{field.default_ruby_value}" }, "location: Location.zero", "errors: []"].join(", ") %>)
+        new(<%= ["\"#{node.name}\"", "location", "errors", *node.fields.map(&:name)].join(", ") %>)
+      end
+
       <%- if node.fields.any? { |f| f.is_a?(Herb::Template::PrismSerializedField) || f.is_a?(Herb::Template::PrismNodeField) } -%>
       <%- prism_field = node.fields.find { |f| f.is_a?(Herb::Template::PrismSerializedField) || f.is_a?(Herb::Template::PrismNodeField) } -%>
       #: () -> Prism::node?

--- a/templates/template.rb
+++ b/templates/template.rb
@@ -49,6 +49,14 @@ module Herb
         nilable? ? "#{ruby_type}?" : ruby_type
       end
 
+      def default_ruby_value
+        case ruby_type
+        when "bool" then "false"
+        when /\AArray\[/ then "[]"
+        else "nil"
+        end
+      end
+
       def writable?
         options.fetch(:writable, false)
       end


### PR DESCRIPTION
Follow up on the recently added `Herb::Location.zero`, `Herb::Range.zero` and `Herb::Token.from` constructors, applying the same idea one level up to AST nodes.

Constructing a node by hand means repeating the node type as a string, passing an empty errors array, and then positionally filling every field, including the ones you don't care about:

```ruby
Herb::AST::ERBContentNode.new(
  "ERBContentNode",
  element_node.location,
  [],
  Herb::Token.from("TOKEN_ERB_START", "<%="),
  Herb::Token.from("TOKEN_ERB_CONTENT", " #{code}"),
  Herb::Token.from("TOKEN_ERB_END", "%>"),
  nil,
  false,
  true,
  nil
)
```

The same `ERBContentNode` from above with this pull request:

```ruby
Herb::AST::ERBContentNode.build(
  location: element_node.location,
  tag_opening: Herb::Token.from("TOKEN_ERB_START", "<%="),
  content: Herb::Token.from("TOKEN_ERB_CONTENT", " #{code}"),
  tag_closing: Herb::Token.from("TOKEN_ERB_END", "%>"),
  valid: true
)
```