### PR TITLE
Playground: Fix nx build configuration and declare missing dependencies

### DIFF
--- a/playground/package.json
+++ b/playground/package.json
@@ -20,8 +20,10 @@
   "dependencies": {
     "@alenaksu/json-viewer": "^2.0.1",
     "@herb-tools/browser": "0.10.3",
+    "@herb-tools/core": "0.10.3",
     "@herb-tools/formatter": "0.10.3",
     "@herb-tools/linter": "0.10.3",
+    "@herb-tools/printer": "0.10.3",
     "@herb-tools/rewriter": "0.10.3",
     "@hotwired/stimulus": "^3.2.2",
     "dedent": "^1.7.2",

--- a/playground/project.json
+++ b/playground/project.json
@@ -18,18 +18,10 @@
       "dependsOn": [
         "@herb-tools/core:build",
         "@herb-tools/browser:build",
-        "@herb-tools/linter:build"
-      ]
-    },
-    "build:client": {
-      "executor": "nx:run-script",
-      "options": {
-        "script": "build:client"
-      },
-      "dependsOn": [
-        "@herb-tools/core:build",
-        "@herb-tools/browser:build",
-        "@herb-tools/linter:build"
+        "@herb-tools/formatter:build",
+        "@herb-tools/linter:build",
+        "@herb-tools/printer:build",
+        "@herb-tools/rewriter:build"
       ]
     },
     "preview": {


### PR DESCRIPTION
This pull request fixes the playground's nx target configuration so that `nx build playground` works on its own in a clean tree, and declares two workspace packages the playground imports but never listed as dependencies.