### PR TITLE
Core: Implement Action View Partial Resolution

### DIFF
--- a/javascript/packages/core/src/action-view-partial-resolution.ts
+++ b/javascript/packages/core/src/action-view-partial-resolution.ts
@@ -1,0 +1,89 @@
+export const PARTIAL_EXTENSIONS = [
+  ".html.erb",
+  ".html.herb",
+  ".erb",
+  ".herb",
+  ".turbo_stream.erb",
+  ".turbo_stream.herb",
+] as const
+
+export const PARTIAL_GLOB_PATTERN = "_*.{html.erb,html.herb,erb,herb,turbo_stream.erb,turbo_stream.herb}"
+
+const PARTIAL_PREFIX = "_"
+const APPLICATION_DIRECTORY = "application"
+
+export type PartialPaths = Map<string, string>
+
+function normalize(path: string): string {
+  return path.replace(/\\/g, "/").replace(/\/+$/, "")
+}
+
+function basename(path: string): string {
+  const index = path.lastIndexOf("/")
+
+  return index === -1 ? path : path.slice(index + 1)
+}
+
+function dirname(path: string): string {
+  const index = path.lastIndexOf("/")
+
+  return index === -1 ? "." : path.slice(0, index) || "/"
+}
+
+function relativeToViewRoot(path: string, viewRoot: string): string | null {
+  const normalizedPath = normalize(path)
+  const normalizedRoot = normalize(viewRoot)
+
+  if (normalizedRoot === "" || normalizedRoot === ".") return normalizedPath
+  if (normalizedPath === normalizedRoot) return "."
+  if (!normalizedPath.startsWith(`${normalizedRoot}/`)) return null
+
+  return normalizedPath.slice(normalizedRoot.length + 1)
+}
+
+export function isPartialPath(filePath: string): boolean {
+  const name = basename(normalize(filePath))
+
+  if (!name.startsWith(PARTIAL_PREFIX)) return false
+
+  return PARTIAL_EXTENSIONS.some(extension => name.endsWith(extension))
+}
+
+export function partialNameForFile(filePath: string, viewRoot: string): string | null {
+  const relative = relativeToViewRoot(filePath, viewRoot)
+
+  if (relative === null || relative === ".") return null
+
+  const directory = dirname(relative)
+  const name = basename(relative)
+
+  if (!name.startsWith(PARTIAL_PREFIX)) return null
+
+  const withoutExtension = name.slice(PARTIAL_PREFIX.length).replace(/\..*$/, "")
+
+  if (withoutExtension === "") return null
+
+  return directory === "." ? withoutExtension : `${directory}/${withoutExtension}`
+}
+
+export function resolvePartial(partialName: string, sourceFile: string, index: PartialPaths, viewRoot: string): string | null {
+  const exact = index.get(partialName)
+
+  if (exact !== undefined) return exact
+
+  const sourceDirectory = relativeToViewRoot(dirname(normalize(sourceFile)), viewRoot)
+
+  if (sourceDirectory !== null && sourceDirectory !== ".") {
+    const relative = index.get(`${sourceDirectory}/${partialName}`)
+
+    if (relative !== undefined) return relative
+  }
+
+  if (!partialName.includes("/")) {
+    const application = index.get(`${APPLICATION_DIRECTORY}/${partialName}`)
+
+    if (application !== undefined) return application
+  }
+
+  return null
+}

--- a/javascript/packages/core/src/action-view-partial-resolution.ts
+++ b/javascript/packages/core/src/action-view-partial-resolution.ts
@@ -15,7 +15,13 @@ const APPLICATION_DIRECTORY = "application"
 export type PartialPaths = Map<string, string>
 
 function normalize(path: string): string {
-  return path.replace(/\\/g, "/").replace(/\/+$/, "")
+  const separated = path.replace(/\\/g, "/")
+
+  let end = separated.length
+
+  while (end > 0 && separated[end - 1] === "/") end--
+
+  return separated.slice(0, end)
 }
 
 function basename(path: string): string {
@@ -59,7 +65,9 @@ export function partialNameForFile(filePath: string, viewRoot: string): string |
 
   if (!name.startsWith(PARTIAL_PREFIX)) return null
 
-  const withoutExtension = name.slice(PARTIAL_PREFIX.length).replace(/\..*$/, "")
+  const withoutPrefix = name.slice(PARTIAL_PREFIX.length)
+  const extension = withoutPrefix.indexOf(".")
+  const withoutExtension = extension === -1 ? withoutPrefix : withoutPrefix.slice(0, extension)
 
   if (withoutExtension === "") return null
 

--- a/javascript/packages/core/src/index.ts
+++ b/javascript/packages/core/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./action-view-helpers.js"
+export * from "./action-view-partial-resolution.js"
 export * from "./ast-utils.js"
 export * from "./backend.js"
 export * from "./config.js"

--- a/javascript/packages/core/test/action-view-partial-resolution.test.ts
+++ b/javascript/packages/core/test/action-view-partial-resolution.test.ts
@@ -24,6 +24,13 @@ function paths(files: string[]): PartialPaths {
 
 describe("@herb-tools/core", () => {
   describe("isPartialPath", () => {
+    test("accepts variants of a partial", () => {
+      expect(isPartialPath("app/views/users/_card.html+phone.erb")).toBe(true)
+      expect(isPartialPath("app/views/users/_card.html+tablet.herb")).toBe(true)
+      expect(isPartialPath("app/views/users/_card.en.html.erb")).toBe(true)
+      expect(isPartialPath("app/views/users/_card.json.erb")).toBe(true)
+    })
+
     test("accepts every partial extension", () => {
       expect(isPartialPath("app/views/users/_card.html.erb")).toBe(true)
       expect(isPartialPath("app/views/users/_card.html.herb")).toBe(true)
@@ -90,6 +97,23 @@ describe("@herb-tools/core", () => {
 
     test("resolves against a project root view root", () => {
       expect(partialNameForFile("users/_card.html.erb", ".")).toBe("users/card")
+    })
+
+    test("collapses every variant of a partial onto the same name", () => {
+      expect(partialNameForFile("app/views/users/_card.html.erb", VIEW_ROOT)).toBe("users/card")
+      expect(partialNameForFile("app/views/users/_card.html+phone.erb", VIEW_ROOT)).toBe("users/card")
+      expect(partialNameForFile("app/views/users/_card.html+tablet.herb", VIEW_ROOT)).toBe("users/card")
+      expect(partialNameForFile("app/views/users/_card.en.html.erb", VIEW_ROOT)).toBe("users/card")
+      expect(partialNameForFile("app/views/users/_card.json.erb", VIEW_ROOT)).toBe("users/card")
+      expect(partialNameForFile("app/views/users/_card.turbo_stream.erb", VIEW_ROOT)).toBe("users/card")
+    })
+
+    test("returns null for a partial with no name before the extension", () => {
+      expect(partialNameForFile("app/views/users/_.html.erb", VIEW_ROOT)).toBeNull()
+    })
+
+    test("keeps a name that has no extension at all", () => {
+      expect(partialNameForFile("app/views/users/_card", VIEW_ROOT)).toBe("users/card")
     })
   })
 

--- a/javascript/packages/core/test/action-view-partial-resolution.test.ts
+++ b/javascript/packages/core/test/action-view-partial-resolution.test.ts
@@ -1,0 +1,146 @@
+import { describe, test, expect } from "vitest"
+
+import {
+  isPartialPath,
+  partialNameForFile,
+  resolvePartial,
+} from "../src/action-view-partial-resolution.js"
+
+import type { PartialPaths } from "../src/action-view-partial-resolution.js"
+
+const VIEW_ROOT = "app/views"
+
+function paths(files: string[]): PartialPaths {
+  const index: PartialPaths = new Map()
+
+  for (const file of files) {
+    const name = partialNameForFile(file, VIEW_ROOT)
+
+    if (name !== null && !index.has(name)) index.set(name, file)
+  }
+
+  return index
+}
+
+describe("@herb-tools/core", () => {
+  describe("isPartialPath", () => {
+    test("accepts every partial extension", () => {
+      expect(isPartialPath("app/views/users/_card.html.erb")).toBe(true)
+      expect(isPartialPath("app/views/users/_card.html.herb")).toBe(true)
+      expect(isPartialPath("app/views/users/_card.erb")).toBe(true)
+      expect(isPartialPath("app/views/users/_card.herb")).toBe(true)
+      expect(isPartialPath("app/views/users/_card.turbo_stream.erb")).toBe(true)
+      expect(isPartialPath("app/views/users/_card.turbo_stream.herb")).toBe(true)
+    })
+
+    test("rejects templates that are not partials", () => {
+      expect(isPartialPath("app/views/users/show.html.erb")).toBe(false)
+    })
+
+    test("rejects unrelated extensions", () => {
+      expect(isPartialPath("app/views/users/_card.html.haml")).toBe(false)
+    })
+
+    test("does not care where the file lives", () => {
+      expect(isPartialPath("app/components/_card.html.erb")).toBe(true)
+      expect(isPartialPath("_card.html.erb")).toBe(true)
+    })
+
+    test("normalizes backslash separators", () => {
+      expect(isPartialPath("app\\views\\users\\_card.html.erb")).toBe(true)
+    })
+  })
+
+  describe("partialNameForFile", () => {
+    test("builds a name from the directory and the basename", () => {
+      expect(partialNameForFile("app/views/users/_card.html.erb", VIEW_ROOT)).toBe("users/card")
+    })
+
+    test("builds a name for a partial at the view root", () => {
+      expect(partialNameForFile("app/views/_card.html.erb", VIEW_ROOT)).toBe("card")
+    })
+
+    test("keeps nested directories in the name", () => {
+      expect(partialNameForFile("app/views/admin/users/_card.html.erb", VIEW_ROOT)).toBe("admin/users/card")
+    })
+
+    test("strips every extension segment", () => {
+      expect(partialNameForFile("app/views/users/_card.turbo_stream.erb", VIEW_ROOT)).toBe("users/card")
+    })
+
+    test("returns null for a template that is not a partial", () => {
+      expect(partialNameForFile("app/views/users/show.html.erb", VIEW_ROOT)).toBeNull()
+    })
+
+    test("returns null for a file outside the view root", () => {
+      expect(partialNameForFile("app/components/_card.html.erb", VIEW_ROOT)).toBeNull()
+    })
+
+    test("does not treat a sibling directory as inside the view root", () => {
+      expect(partialNameForFile("app/views_old/users/_card.html.erb", VIEW_ROOT)).toBeNull()
+    })
+
+    test("ignores a trailing slash on the view root", () => {
+      expect(partialNameForFile("app/views/users/_card.html.erb", "app/views/")).toBe("users/card")
+    })
+
+    test("normalizes backslash separators", () => {
+      expect(partialNameForFile("app\\views\\users\\_card.html.erb", "app\\views")).toBe("users/card")
+    })
+
+    test("resolves against a project root view root", () => {
+      expect(partialNameForFile("users/_card.html.erb", ".")).toBe("users/card")
+    })
+  })
+
+  describe("resolvePartial", () => {
+    const index = paths([
+      "app/views/users/_card.html.erb",
+      "app/views/users/_avatar.html.erb",
+      "app/views/application/_flash.html.erb",
+      "app/views/admin/users/_card.html.erb",
+    ])
+
+    test("resolves a fully qualified name", () => {
+      expect(resolvePartial("users/card", "app/views/posts/index.html.erb", index, VIEW_ROOT)).toBe("app/views/users/_card.html.erb")
+    })
+
+    test("resolves a bare name against the rendering template's directory", () => {
+      expect(resolvePartial("avatar", "app/views/users/show.html.erb", index, VIEW_ROOT)).toBe("app/views/users/_avatar.html.erb")
+    })
+
+    test("falls back to the application directory for a bare name", () => {
+      expect(resolvePartial("flash", "app/views/posts/index.html.erb", index, VIEW_ROOT)).toBe("app/views/application/_flash.html.erb")
+    })
+
+    test("prefers the exact name over the relative one", () => {
+      expect(resolvePartial("users/card", "app/views/admin/index.html.erb", index, VIEW_ROOT)).toBe("app/views/users/_card.html.erb")
+    })
+
+    test("resolves a qualified name relative to the rendering template's directory", () => {
+      const nested = paths(["app/views/admin/users/_card.html.erb"])
+
+      expect(resolvePartial("users/card", "app/views/admin/index.html.erb", nested, VIEW_ROOT)).toBe("app/views/admin/users/_card.html.erb")
+    })
+
+    test("does not fall back to the application directory for a qualified name", () => {
+      expect(resolvePartial("users/flash", "app/views/posts/index.html.erb", index, VIEW_ROOT)).toBeNull()
+    })
+
+    test("returns null for an unknown partial", () => {
+      expect(resolvePartial("users/missing", "app/views/posts/index.html.erb", index, VIEW_ROOT)).toBeNull()
+    })
+
+    test("resolves from a template at the view root", () => {
+      expect(resolvePartial("flash", "app/views/index.html.erb", index, VIEW_ROOT)).toBe("app/views/application/_flash.html.erb")
+    })
+
+    test("resolves from a source file outside the view root", () => {
+      expect(resolvePartial("users/card", "app/components/card_component.html.erb", index, VIEW_ROOT)).toBe("app/views/users/_card.html.erb")
+    })
+
+    test("resolves without a known source file", () => {
+      expect(resolvePartial("users/card", "", index, VIEW_ROOT)).toBe("app/views/users/_card.html.erb")
+    })
+  })
+})


### PR DESCRIPTION
This pull request ports the partial name resolution from `Herb::ActionView::RenderAnalyzer` to `@herb-tools/core`, so JavaScript tooling can go from a partial name in a `render` call to the file that defines it.

```ts
import { partialNameForFile, resolvePartial } from "@herb-tools/core"

partialNameForFile("app/views/users/_card.html.erb", "app/views")
// => "users/card"

const partials = new Map([["users/card", "app/views/users/_card.html.erb"]])

resolvePartial("card", "app/views/users/show.html.erb", partials, "app/views")
// => "app/views/users/_card.html.erb"
```

`resolvePartial` follows the Action View lookup order:
*  the name exactly as written
* relative to the directory of the template doing the rendering
* the `application/` fallback for names without a directory

Related #639, #1387 and #160, which all need to resolve a `render` call to a partial before they can be written.