### PR TITLE
Core: Introduce Action View Partial Index

### DIFF
--- a/javascript/packages/core/src/action-view-partial-index.ts
+++ b/javascript/packages/core/src/action-view-partial-index.ts
@@ -1,0 +1,154 @@
+import { isERBStrictLocalsNode, isRubyParameterNode } from "./node-type-guards.js"
+import { PARTIAL_EXTENSIONS, partialNameForFile, resolvePartial } from "./action-view-partial-resolution.js"
+
+import type { DocumentNode } from "./nodes.js"
+import type { PartialPaths } from "./action-view-partial-resolution.js"
+
+const KEYWORD_KIND = "keyword"
+const KEYWORD_REST_KIND = "keyword_rest"
+const VARIANT_RANK = PARTIAL_EXTENSIONS.length
+
+export interface StrictLocal {
+  name: string
+  required: boolean
+}
+
+export interface PartialDeclaration {
+  file: string
+  hasDeclaration: boolean
+  hasKeywordRest: boolean
+  locals: StrictLocal[]
+}
+
+export interface SerializedPartialIndex {
+  viewRoot: string
+  partials: Record<string, PartialDeclaration>
+}
+
+export function templateRank(file: string): number {
+  const separated = file.replace(/\\/g, "/")
+  const separator = separated.lastIndexOf("/")
+  const base = separator === -1 ? separated : separated.slice(separator + 1)
+
+  const dot = base.indexOf(".")
+  if (dot === -1) return VARIANT_RANK
+
+  const rank = PARTIAL_EXTENSIONS.indexOf(base.slice(dot) as typeof PARTIAL_EXTENSIONS[number])
+
+  return rank === -1 ? VARIANT_RANK : rank
+}
+
+export function outranksTemplate(candidate: string, incumbent: string): boolean {
+  const candidateRank = templateRank(candidate)
+  const incumbentRank = templateRank(incumbent)
+
+  if (candidateRank !== incumbentRank) return candidateRank < incumbentRank
+
+  return candidate < incumbent
+}
+
+export const STRICT_LOCALS_MARKER = "locals"
+
+export function declarationWithoutStrictLocals(file: string): PartialDeclaration {
+  return { file, hasDeclaration: false, hasKeywordRest: false, locals: [] }
+}
+
+export function declarationFromDocument(document: DocumentNode, file: string): PartialDeclaration {
+  const declaration = declarationWithoutStrictLocals(file)
+
+  for (const child of document.children) {
+    if (!isERBStrictLocalsNode(child)) continue
+
+    declaration.hasDeclaration = true
+
+    for (const local of child.locals) {
+      if (!isRubyParameterNode(local)) continue
+
+      if (local.kind === KEYWORD_REST_KIND) {
+        declaration.hasKeywordRest = true
+        continue
+      }
+
+      if (local.kind !== KEYWORD_KIND) continue
+
+      const name = local.name?.value
+
+      if (name) declaration.locals.push({ name, required: local.required })
+    }
+  }
+
+  return declaration
+}
+
+export class PartialIndex {
+  readonly viewRoot: string
+
+  private readonly declarations: Map<string, PartialDeclaration>
+  private readonly files: PartialPaths
+  private readonly byFile: Map<string, PartialDeclaration>
+
+  static from(data: SerializedPartialIndex): PartialIndex {
+    return new PartialIndex(data.viewRoot, new Map(Object.entries(data.partials)))
+  }
+
+  constructor(viewRoot: string, declarations: Map<string, PartialDeclaration>) {
+    this.viewRoot = viewRoot
+    this.declarations = declarations
+    this.files = new Map()
+    this.byFile = new Map()
+
+    for (const [name, declaration] of declarations) {
+      this.files.set(name, declaration.file)
+      this.byFile.set(declaration.file, declaration)
+    }
+  }
+
+  lookup(partialName: string, sourceFile: string | undefined): PartialDeclaration | null {
+    const file = resolvePartial(partialName, sourceFile ?? "", this.files, this.viewRoot)
+
+    if (file === null) return null
+
+    return this.byFile.get(file) ?? null
+  }
+
+  update(declaration: PartialDeclaration): string | null {
+    const name = partialNameForFile(declaration.file, this.viewRoot)
+    if (name === null) return null
+
+    const existing = this.declarations.get(name)
+
+    if (existing && existing.file !== declaration.file) {
+      if (!outranksTemplate(declaration.file, existing.file)) return null
+
+      this.byFile.delete(existing.file)
+    }
+
+    this.declarations.set(name, declaration)
+    this.files.set(name, declaration.file)
+    this.byFile.set(declaration.file, declaration)
+
+    return name
+  }
+
+  remove(file: string): string | null {
+    const name = partialNameForFile(file, this.viewRoot)
+    if (name === null) return null
+
+    const existing = this.declarations.get(name)
+    if (!existing || existing.file !== file) return null
+
+    this.declarations.delete(name)
+    this.files.delete(name)
+    this.byFile.delete(file)
+
+    return name
+  }
+
+  get size(): number {
+    return this.declarations.size
+  }
+
+  toJSON(): SerializedPartialIndex {
+    return { viewRoot: this.viewRoot, partials: Object.fromEntries(this.declarations) }
+  }
+}

--- a/javascript/packages/core/src/index.ts
+++ b/javascript/packages/core/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./action-view-helpers.js"
+export * from "./action-view-partial-index.js"
 export * from "./action-view-partial-resolution.js"
 export * from "./ast-utils.js"
 export * from "./backend.js"

--- a/javascript/packages/core/test/action-view-partial-index.test.ts
+++ b/javascript/packages/core/test/action-view-partial-index.test.ts
@@ -1,0 +1,223 @@
+import { beforeAll, describe, expect, test } from "vitest"
+
+import { Herb } from "@herb-tools/node-wasm"
+
+import { PartialIndex, declarationFromDocument } from "../src/action-view-partial-index.js"
+
+import type { PartialDeclaration } from "../src/action-view-partial-index.js"
+
+function declaration(file: string, locals: PartialDeclaration["locals"]): PartialDeclaration {
+  return { file, hasDeclaration: true, hasKeywordRest: false, locals }
+}
+
+beforeAll(async () => {
+  await Herb.load()
+})
+
+describe("PartialIndex", () => {
+  const index = new PartialIndex("app/views", new Map([
+    ["users/card", declaration("app/views/users/_card.html.erb", [{ name: "user", required: true }])],
+    ["application/flash", declaration("app/views/application/_flash.html.erb", [{ name: "message", required: true }])],
+  ]))
+
+  test("looks a partial up by its fully qualified name", () => {
+    expect(index.lookup("users/card", "app/views/posts/index.html.erb")?.file).toBe("app/views/users/_card.html.erb")
+  })
+
+  test("looks a partial up relative to the rendering template", () => {
+    expect(index.lookup("card", "app/views/users/show.html.erb")?.file).toBe("app/views/users/_card.html.erb")
+  })
+
+  test("falls back to the application directory", () => {
+    expect(index.lookup("flash", "app/views/posts/index.html.erb")?.file).toBe("app/views/application/_flash.html.erb")
+  })
+
+  test("returns null for an unknown partial", () => {
+    expect(index.lookup("users/missing", "app/views/posts/index.html.erb")).toBeNull()
+  })
+
+  test("tolerates an unknown source file", () => {
+    expect(index.lookup("users/card", undefined)?.file).toBe("app/views/users/_card.html.erb")
+  })
+
+  test("round trips through its serialized form", () => {
+    const restored = PartialIndex.from(index.toJSON())
+
+    expect(restored.viewRoot).toBe("app/views")
+    expect(restored.size).toBe(2)
+    expect(restored.lookup("users/card", "app/views/posts/index.html.erb")?.locals).toEqual([{ name: "user", required: true }])
+  })
+
+  test("survives structuredClone on its way into a worker", () => {
+    const restored = PartialIndex.from(structuredClone(index.toJSON()))
+
+    expect(restored.lookup("flash", "app/views/posts/index.html.erb")?.file).toBe("app/views/application/_flash.html.erb")
+  })
+})
+
+describe("PartialIndex updates", () => {
+  function index(): PartialIndex {
+    return new PartialIndex("app/views", new Map([
+      ["users/card", declaration("app/views/users/_card.html.erb", [{ name: "user", required: true }])],
+    ]))
+  }
+
+  test("replaces the declaration of an indexed partial", () => {
+    const partials = index()
+
+    expect(partials.update(declaration("app/views/users/_card.html.erb", [
+      { name: "user", required: true },
+      { name: "size", required: true },
+    ]))).toBe("users/card")
+
+    expect(partials.lookup("users/card", "app/views/posts/index.html.erb")?.locals).toHaveLength(2)
+    expect(partials.size).toBe(1)
+  })
+
+  test("adds a partial that was not indexed yet", () => {
+    const partials = index()
+
+    expect(partials.update(declaration("app/views/users/_avatar.html.erb", [{ name: "user", required: true }]))).toBe("users/avatar")
+    expect(partials.lookup("users/avatar", "app/views/posts/index.html.erb")?.file).toBe("app/views/users/_avatar.html.erb")
+    expect(partials.size).toBe(2)
+  })
+
+  test("indexes an added partial for relative and application lookups", () => {
+    const partials = index()
+
+    partials.update(declaration("app/views/application/_flash.html.erb", [{ name: "message", required: true }]))
+
+    expect(partials.lookup("flash", "app/views/posts/index.html.erb")?.file).toBe("app/views/application/_flash.html.erb")
+  })
+
+  test("ignores a file that is not a partial", () => {
+    const partials = index()
+
+    expect(partials.update(declaration("app/views/users/show.html.erb", []))).toBeNull()
+    expect(partials.size).toBe(1)
+  })
+
+  test("ignores a file outside the view root", () => {
+    const partials = index()
+
+    expect(partials.update(declaration("app/components/_card.html.erb", []))).toBeNull()
+    expect(partials.size).toBe(1)
+  })
+
+  test("does not let a lower ranked template take over an indexed name", () => {
+    const partials = index()
+
+    expect(partials.update(declaration("app/views/users/_card.turbo_stream.erb", []))).toBeNull()
+    expect(partials.lookup("users/card", "app/views/posts/index.html.erb")?.file).toBe("app/views/users/_card.html.erb")
+  })
+
+  test("does not let a variant take over from the base template", () => {
+    const partials = index()
+
+    expect(partials.update(declaration("app/views/users/_card.html+phone.erb", []))).toBeNull()
+    expect(partials.update(declaration("app/views/users/_card.en.html.erb", []))).toBeNull()
+    expect(partials.lookup("users/card", "app/views/posts/index.html.erb")?.file).toBe("app/views/users/_card.html.erb")
+  })
+
+  test("lets the base template take over from a variant", () => {
+    const partials = new PartialIndex("app/views", new Map([
+      ["users/card", declaration("app/views/users/_card.en.html.erb", [{ name: "user", required: true }])],
+    ]))
+
+    expect(partials.update(declaration("app/views/users/_card.html.erb", [{ name: "user", required: true }]))).toBe("users/card")
+    expect(partials.lookup("users/card", "app/views/posts/index.html.erb")?.file).toBe("app/views/users/_card.html.erb")
+    expect(partials.size).toBe(1)
+  })
+
+  test("forgets the displaced variant when the base template takes over", () => {
+    const partials = new PartialIndex("app/views", new Map([
+      ["users/card", declaration("app/views/users/_card.html+phone.erb", [])],
+    ]))
+
+    partials.update(declaration("app/views/users/_card.html.erb", []))
+
+    expect(partials.remove("app/views/users/_card.html+phone.erb")).toBeNull()
+    expect(partials.lookup("users/card", "app/views/posts/index.html.erb")?.file).toBe("app/views/users/_card.html.erb")
+  })
+
+  test("removes an indexed partial", () => {
+    const partials = index()
+
+    expect(partials.remove("app/views/users/_card.html.erb")).toBe("users/card")
+    expect(partials.lookup("users/card", "app/views/posts/index.html.erb")).toBeNull()
+    expect(partials.size).toBe(0)
+  })
+
+  test("ignores removing a file that does not hold the name", () => {
+    const partials = index()
+
+    expect(partials.remove("app/views/users/_card.turbo_stream.erb")).toBeNull()
+    expect(partials.size).toBe(1)
+  })
+
+  test("ignores removing an unknown partial", () => {
+    const partials = index()
+
+    expect(partials.remove("app/views/users/_avatar.html.erb")).toBeNull()
+    expect(partials.size).toBe(1)
+  })
+
+  test("handles a rename as a remove and an update", () => {
+    const partials = index()
+
+    partials.remove("app/views/users/_card.html.erb")
+    partials.update(declaration("app/views/users/_tile.html.erb", [{ name: "user", required: true }]))
+
+    expect(partials.lookup("users/card", "app/views/posts/index.html.erb")).toBeNull()
+    expect(partials.lookup("users/tile", "app/views/posts/index.html.erb")?.file).toBe("app/views/users/_tile.html.erb")
+  })
+
+  test("carries updates into the serialized form", () => {
+    const partials = index()
+
+    partials.update(declaration("app/views/users/_avatar.html.erb", [{ name: "user", required: true }]))
+    partials.remove("app/views/users/_card.html.erb")
+
+    const restored = PartialIndex.from(structuredClone(partials.toJSON()))
+
+    expect(restored.size).toBe(1)
+    expect(restored.lookup("users/avatar", "app/views/posts/index.html.erb")?.file).toBe("app/views/users/_avatar.html.erb")
+  })
+})
+
+describe("declarationFromDocument", () => {
+  test("reads required and optional locals", () => {
+    const result = Herb.parse(`<%# locals: (user:, size: "large") %>\n`, { strict_locals: true })
+
+    expect(declarationFromDocument(result.value, "app/views/users/_card.html.erb")).toEqual({
+      file: "app/views/users/_card.html.erb",
+      hasDeclaration: true,
+      hasKeywordRest: false,
+      locals: [{ name: "user", required: true }, { name: "size", required: false }],
+    })
+  })
+
+  test("records a keyword rest separately from the locals", () => {
+    const result = Herb.parse(`<%# locals: (user:, **) %>\n`, { strict_locals: true })
+    const declaration = declarationFromDocument(result.value, "app/views/users/_card.html.erb")
+
+    expect(declaration.hasKeywordRest).toBe(true)
+    expect(declaration.locals).toEqual([{ name: "user", required: true }])
+  })
+
+  test("reports a partial without a declaration", () => {
+    const result = Herb.parse(`<div>Hello</div>\n`, { strict_locals: true })
+    const declaration = declarationFromDocument(result.value, "app/views/users/_card.html.erb")
+
+    expect(declaration.hasDeclaration).toBe(false)
+    expect(declaration.locals).toEqual([])
+  })
+
+  test("reports an empty declaration as a declaration", () => {
+    const result = Herb.parse(`<%# locals: () %>\n`, { strict_locals: true })
+    const declaration = declarationFromDocument(result.value, "app/views/users/_card.html.erb")
+
+    expect(declaration.hasDeclaration).toBe(true)
+    expect(declaration.locals).toEqual([])
+  })
+})


### PR DESCRIPTION
This pull request introduces `PartialIndex`, which holds what a `render` call needs to know about the partial it renders, the file that defines it, whether that file declares strict locals, and what those locals are.

#2058 ported the name resolution, so `resolvePartial("users/card", ...)` already answers *which file* a partial name points at. That is only half of what a tool needs. Anything reasoning about a `render` call also needs the declaration inside that file, and it needs to look it up by the name written at the call site rather than by path.

```ts
import { PartialIndex, declarationFromDocument } from "@herb-tools/core"

const index = new PartialIndex("app/views", new Map([
  ["users/card", declarationFromDocument(document, "app/views/users/_card.html.erb")],
]))

index.lookup("card", "app/views/users/show.html.erb")
// => { file: "app/views/users/_card.html.erb", hasDeclaration: true, hasKeywordRest: false,
//      locals: [{ name: "user", required: true }, { name: "size", required: false }] }
```

`lookup` takes the name as it appears in the `render` call together with the template doing the rendering, so the Action View lookup order from #2058 applies.

Related #639, #1387, #160 and #2043.

Enables https://github.com/marcoroth/herb/pull/2060