### PR TITLE
Language Server: Maintain partial index for cross-file diagnostics

### DIFF
--- a/javascript/packages/language-server/src/autofix_service.ts
+++ b/javascript/packages/language-server/src/autofix_service.ts
@@ -6,13 +6,16 @@ import { Linter } from "@herb-tools/linter"
 import { Config } from "@herb-tools/config"
 
 import { getFullDocumentRange } from "./range_utils"
+import { PartialIndexService } from "./partial_index_service"
 
 export class AutofixService {
   private connection: Connection
   private linter: Linter
+  private partialIndexService?: PartialIndexService
 
-  constructor(connection: Connection, config?: Config) {
+  constructor(connection: Connection, config?: Config, partialIndexService?: PartialIndexService) {
     this.connection = connection
+    this.partialIndexService = partialIndexService
     this.linter = this.buildLinter(config)
   }
 
@@ -24,15 +27,22 @@ export class AutofixService {
     return Linter.from(Herb, config)
   }
 
+  private lintContextFor(uri: string) {
+    return {
+      fileName: this.partialIndexService?.relativePathFor(uri) ?? uri,
+      partials: this.partialIndexService?.index,
+    }
+  }
+
   async autofix(document: TextDocument): Promise<TextEdit[]> {
     try {
       const text = document.getText()
-      const lintResult = this.linter.lint(text, { fileName: document.uri })
+      const lintResult = this.linter.lint(text, this.lintContextFor(document.uri))
       const offensesToFix = lintResult.offenses
 
       if (offensesToFix.length === 0) return []
 
-      const autofixResult = this.linter.autofix(text, { fileName: document.uri }, offensesToFix)
+      const autofixResult = this.linter.autofix(text, this.lintContextFor(document.uri), offensesToFix)
 
       if (autofixResult.source === text) return []
 

--- a/javascript/packages/language-server/src/code_action_service.ts
+++ b/javascript/packages/language-server/src/code_action_service.ts
@@ -3,6 +3,7 @@ import { TextDocument } from "vscode-languageserver-textdocument"
 
 import { Config } from "@herb-tools/config"
 import { Project } from "./project"
+import { PartialIndexService } from "./partial_index_service"
 import { Herb } from "@herb-tools/node-wasm"
 import { Linter } from "@herb-tools/linter"
 
@@ -12,12 +13,14 @@ import type { LintOffense } from "@herb-tools/linter"
 
 export class CodeActionService {
   private project: Project
+  private partialIndexService?: PartialIndexService
   private config?: Config
   private linter: Linter
 
-  constructor(project: Project, config?: Config) {
+  constructor(project: Project, config?: Config, partialIndexService?: PartialIndexService) {
     this.project = project
     this.config = config
+    this.partialIndexService = partialIndexService
     this.linter = Linter.from(Herb, config)
   }
 
@@ -84,7 +87,10 @@ export class CodeActionService {
     const codeActions: CodeAction[] = []
     const text = document.getText()
 
-    const lintResult = this.linter.lint(text, { fileName: document.uri })
+    const lintResult = this.linter.lint(text, {
+      fileName: this.partialIndexService?.relativePathFor(document.uri) ?? document.uri,
+      partials: this.partialIndexService?.index,
+    })
     const offenses = lintResult.offenses
 
     const relevantDiagnostics = params.context.diagnostics.filter(diagnostic => {

--- a/javascript/packages/language-server/src/linter_service.ts
+++ b/javascript/packages/language-server/src/linter_service.ts
@@ -8,6 +8,7 @@ import { Config } from "@herb-tools/config"
 
 import { Settings } from "./settings"
 import { Project } from "./project"
+import { PartialIndexService } from "./partial_index_service"
 import { isConfigDocument, lintToDignosticSeverity, lintToDignosticTags } from "./utils"
 import { lspRangeFromLocation } from "./range_utils"
 
@@ -21,6 +22,7 @@ export class LinterService {
   private readonly connection: Connection
   private readonly settings: Settings
   private readonly project: Project
+  private readonly partialIndexService: PartialIndexService
   private readonly source = "Herb Linter "
   private linter?: Linter
   private allRules: RuleClass[] = rules
@@ -29,10 +31,11 @@ export class LinterService {
   private hasShownCustomRuleWarning = false
   private customRulePaths: Map<string, string> = new Map()
 
-  constructor(connection: Connection, settings: Settings, project: Project) {
+  constructor(connection: Connection, settings: Settings, project: Project, partialIndexService: PartialIndexService) {
     this.connection = connection
     this.settings = settings
     this.project = project
+    this.partialIndexService = partialIndexService
   }
 
   /**
@@ -171,7 +174,11 @@ export class LinterService {
     }
 
     const content = textDocument.getText()
-    const lintResult = this.linter.lint(content, { fileName: textDocument.uri })
+
+    const lintResult = this.linter.lint(content, {
+      fileName: this.partialIndexService.relativePathFor(textDocument.uri) ?? textDocument.uri,
+      partials: this.partialIndexService.index,
+    })
 
     const diagnostics: Diagnostic[] = lintResult.offenses.map(offense => {
       const range = lspRangeFromLocation(offense.location)

--- a/javascript/packages/language-server/src/partial_index_service.ts
+++ b/javascript/packages/language-server/src/partial_index_service.ts
@@ -1,0 +1,81 @@
+import { relative } from "node:path"
+import { fileURLToPath } from "node:url"
+
+import { isPartialPath } from "@herb-tools/core"
+import { buildPartialIndex, declarationFromFile, declarationFromSource } from "@herb-tools/linter/partial-index-builder"
+
+import { Project } from "./project"
+
+import type { Connection } from "vscode-languageserver/node"
+import type { PartialIndex } from "@herb-tools/core"
+
+export class PartialIndexService {
+  private readonly connection: Connection
+  private readonly project: Project
+  private partials?: PartialIndex
+
+  constructor(connection: Connection, project: Project) {
+    this.connection = connection
+    this.project = project
+  }
+
+  get index(): PartialIndex | undefined {
+    return this.partials
+  }
+
+  async initialize(): Promise<void> {
+    try {
+      this.partials = await buildPartialIndex(this.project.herbBackend, this.project.projectPath)
+
+      this.connection.console.log(`[Partials] Indexed ${this.partials.size} partials under ${this.partials.viewRoot}`)
+    } catch (error) {
+      this.connection.console.warn(`[Partials] Failed to index partials: ${error instanceof Error ? error.message : String(error)}`)
+    }
+  }
+
+  relativePathFor(uri: string): string | null {
+    if (!uri.startsWith("file://")) return null
+
+    try {
+      const path = relative(this.project.projectPath, fileURLToPath(uri))
+
+      return path.startsWith("..") ? null : path
+    } catch {
+      return null
+    }
+  }
+
+  updateFromSource(uri: string, source: string): boolean {
+    const file = this.partialFileFor(uri)
+
+    if (!this.partials || !file) return false
+
+    return this.partials.update(declarationFromSource(this.project.herbBackend, file, source)) !== null
+  }
+
+  updateFromDisk(uri: string): boolean {
+    const file = this.partialFileFor(uri)
+
+    if (!this.partials || !file) return false
+
+    const declaration = declarationFromFile(this.project.herbBackend, this.project.projectPath, file)
+
+    if (!declaration) return false
+
+    return this.partials.update(declaration) !== null
+  }
+
+  remove(uri: string): boolean {
+    const file = this.partialFileFor(uri)
+
+    if (!this.partials || !file) return false
+
+    return this.partials.remove(file) !== null
+  }
+
+  private partialFileFor(uri: string): string | null {
+    if (!isPartialPath(uri)) return null
+
+    return this.relativePathFor(uri)
+  }
+}

--- a/javascript/packages/language-server/src/server.ts
+++ b/javascript/packages/language-server/src/server.ts
@@ -19,6 +19,7 @@ import {
   DefinitionParams,
   TextDocumentIdentifier,
   Range,
+  FileChangeType,
 } from "vscode-languageserver/node"
 
 import { Service } from "./service"
@@ -28,6 +29,7 @@ import { Config } from "@herb-tools/config"
 import { isConfigDocument } from "./utils"
 import { version } from "../package.json"
 
+import type { FileEvent } from "vscode-languageserver/node"
 import type { ExtractToPartialResult } from "./extract_code_action_service"
 
 export class Server {
@@ -165,6 +167,8 @@ export class Server {
           await Promise.all(documents.map(document =>
             this.service.diagnostics.refreshDocument(document)
           ))
+        } else if (this.updatePartialIndex(event)) {
+          await this.service.diagnostics.refreshAllDocuments()
         }
       }
     })
@@ -272,6 +276,16 @@ export class Server {
 
       return this.service.commentService.toggleBlockComment(document, params.range)
     })
+  }
+
+  private updatePartialIndex(event: FileEvent): boolean {
+    const partials = this.service.partialIndexService
+
+    if (event.type === FileChangeType.Deleted) return partials.remove(event.uri)
+
+    if (this.service.documentService.get(event.uri)) return false
+
+    return partials.updateFromDisk(event.uri)
   }
 
   listen() {

--- a/javascript/packages/language-server/src/service.ts
+++ b/javascript/packages/language-server/src/service.ts
@@ -20,6 +20,7 @@ import { ExtractCodeActionService } from "./extract_code_action_service"
 import { DefinitionService } from "./definition_service"
 import { CommentService } from "./comment_service"
 import { CompletionService } from "./completion_service"
+import { PartialIndexService } from "./partial_index_service"
 
 import { version } from "../package.json"
 
@@ -31,6 +32,7 @@ export class Service {
 
   diagnostics: Diagnostics
   documentService: DocumentService
+  partialIndexService: PartialIndexService
   parserService: ParserService
   linterService: LinterService
   formattingService: FormattingService
@@ -53,11 +55,12 @@ export class Service {
     this.documentService = new DocumentService(this.connection)
     this.project = new Project(connection, this.settings.projectPath.replace("file://", ""))
     this.parserService = new ParserService()
-    this.linterService = new LinterService(this.connection, this.settings, this.project)
+    this.partialIndexService = new PartialIndexService(this.connection, this.project)
+    this.linterService = new LinterService(this.connection, this.settings, this.project, this.partialIndexService)
     this.formattingService = new FormattingService(this.connection, this.documentService.documents, this.project, this.settings)
-    this.autofixService = new AutofixService(this.connection, this.config)
+    this.autofixService = new AutofixService(this.connection, this.config, this.partialIndexService)
     this.configService = new ConfigService(this.project.projectPath)
-    this.codeActionService = new CodeActionService(this.project, this.config)
+    this.codeActionService = new CodeActionService(this.project, this.config, this.partialIndexService)
     this.diagnostics = new Diagnostics(this.connection, this.documentService, this.parserService, this.linterService, this.configService)
     this.documentSaveService = new DocumentSaveService(this.connection, this.settings, this.autofixService, this.formattingService)
     this.foldingRangeService = new FoldingRangeService(this.parserService)
@@ -81,6 +84,7 @@ export class Service {
   async init() {
     await this.project.initialize()
     await this.formattingService.initialize()
+    await this.partialIndexService.initialize()
 
     try {
       this.config = await Config.loadForEditor(this.project.projectPath, version)
@@ -115,12 +119,19 @@ export class Service {
     })
 
     this.documentService.onDidChangeContent(async (change) => {
+      if (this.partialIndexService.updateFromSource(change.document.uri, change.document.getText())) {
+        await this.diagnostics.refreshAllDocuments()
+
+        return
+      }
+
       await this.diagnostics.refreshDocument(change.document)
     })
   }
 
   async refresh() {
     await this.project.refresh()
+    await this.partialIndexService.initialize()
     await this.formattingService.refreshConfig(this.config)
     await this.diagnostics.refreshAllDocuments()
   }

--- a/javascript/packages/language-server/test/linter_service.test.ts
+++ b/javascript/packages/language-server/test/linter_service.test.ts
@@ -5,6 +5,7 @@ import { TextDocument } from "vscode-languageserver-textdocument"
 import { LinterService } from "../src/linter_service"
 import { Settings } from "../src/settings"
 import { Project } from "../src/project"
+import { PartialIndexService } from "../src/partial_index_service"
 import { Herb } from "@herb-tools/node-wasm"
 import { Config } from "@herb-tools/config"
 
@@ -37,6 +38,8 @@ describe("LinterService", () => {
     projectPath: process.cwd()
   } as Project
 
+  const partialIndexService = new PartialIndexService(mockConnection, mockProject)
+
   const createTestDocument = (content: string) => {
     return TextDocument.create("file:///test.html.erb", "erb", 1, content)
   }
@@ -46,7 +49,7 @@ describe("LinterService", () => {
       const settings = new Settings(mockParams, mockConnection)
       settings.getDocumentSettings = vi.fn().mockResolvedValue(null)
 
-      const linterService = new LinterService(mockConnection, settings, mockProject)
+      const linterService = new LinterService(mockConnection, settings, mockProject, partialIndexService)
       const textDocument = createTestDocument("<div>Test</div>\n")
 
       const result = await linterService.lintDocument(textDocument)
@@ -62,7 +65,7 @@ describe("LinterService", () => {
         // linter is undefined
       })
 
-      const linterService = new LinterService(mockConnection, settings, mockProject)
+      const linterService = new LinterService(mockConnection, settings, mockProject, partialIndexService)
       const textDocument = createTestDocument("<div>Test</div>\n")
 
       const result = await linterService.lintDocument(textDocument)
@@ -77,7 +80,7 @@ describe("LinterService", () => {
         linter: { enabled: false }
       })
 
-      const linterService = new LinterService(mockConnection, settings, mockProject)
+      const linterService = new LinterService(mockConnection, settings, mockProject, partialIndexService)
       const textDocument = createTestDocument("<DIV>Test</DIV>\n")
 
       const result = await linterService.lintDocument(textDocument)
@@ -91,7 +94,7 @@ describe("LinterService", () => {
         linter: { enabled: true }
       })
 
-      const linterService = new LinterService(mockConnection, settings, mockProject)
+      const linterService = new LinterService(mockConnection, settings, mockProject, partialIndexService)
       const textDocument = createTestDocument("<DIV><SPAN>Hello</SPAN></DIV>")
 
       const result = await linterService.lintDocument(textDocument)
@@ -103,7 +106,7 @@ describe("LinterService", () => {
       const settings = new Settings(mockParams, mockConnection)
       settings.hasConfigurationCapability = false
 
-      const linterService = new LinterService(mockConnection, settings, mockProject)
+      const linterService = new LinterService(mockConnection, settings, mockProject, partialIndexService)
       const textDocument = createTestDocument("<DIV>Test</DIV>")
 
       const result = await linterService.lintDocument(textDocument)
@@ -117,7 +120,7 @@ describe("LinterService", () => {
         linter: { enabled: true }
       })
 
-      const linterService = new LinterService(mockConnection, settings, mockProject)
+      const linterService = new LinterService(mockConnection, settings, mockProject, partialIndexService)
       const textDocument = createTestDocument("<h2>Content<h3>")
 
       const result = await linterService.lintDocument(textDocument)
@@ -153,7 +156,7 @@ describe("LinterService", () => {
         projectPath: "/test/project"
       } as Project
 
-      const linterService = new LinterService(mockConnection, settings, mockProjectWithPath)
+      const linterService = new LinterService(mockConnection, settings, mockProjectWithPath, new PartialIndexService(mockConnection, mockProjectWithPath))
       const textDocument = TextDocument.create("file:///test/project/vendor/cache/file.html.erb", "erb", 1, "<DIV>Content</DIV>")
       const result = await linterService.lintDocument(textDocument)
 
@@ -182,7 +185,7 @@ describe("LinterService", () => {
         projectPath: "/test/project"
       } as Project
 
-      const linterService = new LinterService(mockConnection, settings, mockProjectWithPath)
+      const linterService = new LinterService(mockConnection, settings, mockProjectWithPath, new PartialIndexService(mockConnection, mockProjectWithPath))
       const textDocument = TextDocument.create("file:///test/project/something/file.html.erb", "erb", 1, "<DIV>Content</DIV>")
       const result = await linterService.lintDocument(textDocument)
 
@@ -213,7 +216,7 @@ describe("LinterService", () => {
         projectPath: "/test/project"
       } as Project
 
-      const linterService = new LinterService(mockConnection, settings, mockProjectWithPath)
+      const linterService = new LinterService(mockConnection, settings, mockProjectWithPath, new PartialIndexService(mockConnection, mockProjectWithPath))
       const textDocument = TextDocument.create("file:///test/project/app/views/file.html.erb", "erb", 1, "<DIV>Content</DIV>")
       const result = await linterService.lintDocument(textDocument)
 
@@ -244,7 +247,7 @@ describe("LinterService", () => {
         applySeverityOverrides: (offenses: any) => offenses
       } as any
 
-      const linterService = new LinterService(mockConnection, settings, mockProject)
+      const linterService = new LinterService(mockConnection, settings, mockProject, partialIndexService)
       const textDocument = createTestDocument("<DIV>Content</DIV>")
       const result = await linterService.lintDocument(textDocument)
 

--- a/javascript/packages/language-server/test/partial_index_service.test.ts
+++ b/javascript/packages/language-server/test/partial_index_service.test.ts
@@ -1,0 +1,140 @@
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join, dirname } from "node:path"
+import { pathToFileURL } from "node:url"
+
+import { beforeAll, afterEach, describe, expect, test, vi } from "vitest"
+
+import { Herb } from "@herb-tools/node-wasm"
+
+import { PartialIndexService } from "../src/partial_index_service"
+import { Project } from "../src/project"
+
+import type { Connection } from "vscode-languageserver/node"
+
+const roots: string[] = []
+
+const connection = {
+  console: { log: vi.fn(), warn: vi.fn(), error: vi.fn() }
+} as unknown as Connection
+
+function project(files: Record<string, string>): Project {
+  const root = mkdtempSync(join(tmpdir(), "herb-lsp-partials-"))
+
+  roots.push(root)
+
+  for (const [path, contents] of Object.entries(files)) {
+    const file = join(root, path)
+
+    mkdirSync(dirname(file), { recursive: true })
+    writeFileSync(file, contents, "utf-8")
+  }
+
+  return { projectPath: root, herbBackend: Herb } as Project
+}
+
+function uriFor(project: Project, path: string): string {
+  return pathToFileURL(join(project.projectPath, path)).toString()
+}
+
+async function serviceFor(files: Record<string, string>): Promise<{ service: PartialIndexService, project: Project }> {
+  const created = project(files)
+  const service = new PartialIndexService(connection, created)
+
+  await service.initialize()
+
+  return { service, project: created }
+}
+
+beforeAll(async () => {
+  await Herb.load()
+})
+
+afterEach(() => {
+  while (roots.length > 0) {
+    rmSync(roots.pop()!, { recursive: true, force: true })
+  }
+})
+
+describe("PartialIndexService", () => {
+  test("indexes the project's partials on initialize", async () => {
+    const { service } = await serviceFor({
+      "app/views/users/_card.html.erb": `<%# locals: (user:) %>\n`,
+      "app/views/posts/index.html.erb": `<div></div>\n`,
+    })
+
+    expect(service.index?.size).toBe(1)
+    expect(service.index?.lookup("users/card", "app/views/posts/index.html.erb")?.locals).toEqual([{ name: "user", required: true }])
+  })
+
+  test("converts a document URI to a project relative path", async () => {
+    const { service, project } = await serviceFor({ "app/views/users/_card.html.erb": `<%# locals: (user:) %>\n` })
+
+    expect(service.relativePathFor(uriFor(project, "app/views/posts/index.html.erb"))).toBe("app/views/posts/index.html.erb")
+  })
+
+  test("returns null for a URI outside the project", async () => {
+    const { service } = await serviceFor({ "app/views/users/_card.html.erb": `<%# locals: (user:) %>\n` })
+
+    expect(service.relativePathFor("file:///somewhere/else/_card.html.erb")).toBeNull()
+  })
+
+  test("returns null for a non file URI", async () => {
+    const { service } = await serviceFor({ "app/views/users/_card.html.erb": `<%# locals: (user:) %>\n` })
+
+    expect(service.relativePathFor("untitled:Untitled-1")).toBeNull()
+  })
+
+  test("updates a declaration from unsaved buffer contents", async () => {
+    const { service, project } = await serviceFor({ "app/views/users/_card.html.erb": `<%# locals: (user:) %>\n` })
+
+    expect(service.updateFromSource(uriFor(project, "app/views/users/_card.html.erb"), `<%# locals: (user:, size:) %>\n`)).toBe(true)
+
+    expect(service.index?.lookup("users/card", "app/views/posts/index.html.erb")?.locals).toEqual([
+      { name: "user", required: true },
+      { name: "size", required: true },
+    ])
+  })
+
+  test("ignores changes to templates that are not partials", async () => {
+    const { service, project } = await serviceFor({ "app/views/users/_card.html.erb": `<%# locals: (user:) %>\n` })
+
+    expect(service.updateFromSource(uriFor(project, "app/views/posts/index.html.erb"), `<div></div>\n`)).toBe(false)
+    expect(service.index?.size).toBe(1)
+  })
+
+  test("ignores changes to files outside the project", async () => {
+    const { service } = await serviceFor({ "app/views/users/_card.html.erb": `<%# locals: (user:) %>\n` })
+
+    expect(service.updateFromSource("file:///elsewhere/_card.html.erb", `<%# locals: (user:) %>\n`)).toBe(false)
+  })
+
+  test("picks up a partial created on disk", async () => {
+    const { service, project } = await serviceFor({ "app/views/users/_card.html.erb": `<%# locals: (user:) %>\n` })
+
+    writeFileSync(join(project.projectPath, "app/views/users/_avatar.html.erb"), `<%# locals: (user:) %>\n`, "utf-8")
+
+    expect(service.updateFromDisk(uriFor(project, "app/views/users/_avatar.html.erb"))).toBe(true)
+    expect(service.index?.size).toBe(2)
+  })
+
+  test("drops a partial deleted from disk", async () => {
+    const { service, project } = await serviceFor({ "app/views/users/_card.html.erb": `<%# locals: (user:) %>\n` })
+
+    expect(service.remove(uriFor(project, "app/views/users/_card.html.erb"))).toBe(true)
+    expect(service.index?.lookup("users/card", "app/views/posts/index.html.erb")).toBeNull()
+  })
+
+  test("reports no change when removing something it never indexed", async () => {
+    const { service, project } = await serviceFor({ "app/views/users/_card.html.erb": `<%# locals: (user:) %>\n` })
+
+    expect(service.remove(uriFor(project, "app/views/users/_avatar.html.erb"))).toBe(false)
+  })
+
+  test("stays usable when the project has no partials", async () => {
+    const { service, project } = await serviceFor({ "app/views/posts/index.html.erb": `<div></div>\n` })
+
+    expect(service.index?.size).toBe(0)
+    expect(service.updateFromSource(uriFor(project, "app/views/posts/index.html.erb"), `<div></div>\n`)).toBe(false)
+  })
+})

--- a/javascript/packages/linter/package.json
+++ b/javascript/packages/linter/package.json
@@ -22,7 +22,7 @@
     "watch": "tsc -b -w",
     "test": "vitest run",
     "test:watch": "vitest --watch",
-    "check:rule-versions": "! grep -rl 'static introducedIn = \"unreleased\"' src/rules/ 2>/dev/null || (echo '\\n✗ Found linter rules with introducedIn = \"unreleased\". Update them to a release version before publishing.\\n' && exit 1)",
+    "check:rule-versions": "! grep -rl 'static introducedIn = \"unreleased\"' src/rules/ 2>/dev/null || (echo '\\n\u2717 Found linter rules with introducedIn = \"unreleased\". Update them to a release version before publishing.\\n' && exit 1)",
     "prepublishOnly": "yarn check:rule-versions && yarn clean && yarn build && yarn test"
   },
   "exports": {
@@ -44,6 +44,11 @@
       "import": "./dist/loader.js",
       "require": "./dist/loader.cjs",
       "default": "./dist/loader.js"
+    },
+    "./partial-index-builder": {
+      "types": "./dist/types/partial-index-builder.d.ts",
+      "import": "./dist/partial-index-builder.js",
+      "default": "./dist/partial-index-builder.js"
     }
   },
   "dependencies": {

--- a/javascript/packages/linter/rollup.config.mjs
+++ b/javascript/packages/linter/rollup.config.mjs
@@ -111,6 +111,28 @@ export default [
     ],
   },
 
+  // Partial index builder entry point (node only, used by the language server)
+  {
+    input: "src/partial-index-builder.ts",
+    output: {
+      file: "dist/partial-index-builder.js",
+      format: "esm",
+      sourcemap: true,
+    },
+    external,
+    plugins: [
+      nodeResolve({ preferBuiltins: true }),
+      commonjs(),
+      json(),
+      typescript({
+        tsconfig: "./tsconfig.json",
+        declaration: true,
+        declarationDir: "./dist/types",
+        rootDir: "src/",
+      }),
+    ],
+  },
+
   // Loader entry point (includes custom rule loader)
   {
     input: "src/loader.ts",

--- a/javascript/packages/linter/src/cli/file-processor.ts
+++ b/javascript/packages/linter/src/cli/file-processor.ts
@@ -12,7 +12,7 @@ import { availableParallelism } from "node:os"
 import { colorize } from "@herb-tools/highlighter"
 import { deserializeDiagnostic, didyoumean } from "@herb-tools/core"
 import { fixabilityFor } from "../fixability.js"
-import { buildPartialIndex } from "./partial-index-builder.js"
+import { buildPartialIndex } from "../partial-index-builder.js"
 
 import type { Diagnostic } from "@herb-tools/core"
 import type { FormatOption } from "./argument-parser.js"

--- a/javascript/packages/linter/src/cli/lint-worker.ts
+++ b/javascript/packages/linter/src/cli/lint-worker.ts
@@ -8,7 +8,7 @@ import { Config } from "@herb-tools/config"
 import { Linter } from "../linter.js"
 import { loadCustomRules } from "../loader.js"
 import { fixabilityFor } from "../fixability.js"
-import { partialIndexFrom } from "./partial-index-builder.js"
+import { partialIndexFrom } from "../partial-index-builder.js"
 
 import type { SerializedDiagnostic } from "@herb-tools/core"
 import type { Fixability } from "../fixability.js"

--- a/javascript/packages/linter/src/partial-index-builder.ts
+++ b/javascript/packages/linter/src/partial-index-builder.ts
@@ -22,6 +22,20 @@ export async function findViewRoot(projectPath: string): Promise<string> {
   return matches.length > 0 ? VIEW_ROOT_CANDIDATE : PROJECT_ROOT
 }
 
+export function declarationFromSource(herb: HerbBackend, file: string, source: string): PartialDeclaration {
+  if (!source.includes(STRICT_LOCALS_MARKER)) return declarationWithoutStrictLocals(file)
+
+  return declarationFromDocument(herb.parse(source, PARSER_OPTIONS).value, file)
+}
+
+export function declarationFromFile(herb: HerbBackend, projectPath: string, file: string): PartialDeclaration | null {
+  try {
+    return declarationFromSource(herb, file, readFileSync(join(projectPath, file), "utf-8"))
+  } catch {
+    return null
+  }
+}
+
 export async function buildPartialIndex(herb: HerbBackend, projectPath: string): Promise<PartialIndex> {
   const viewRoot = await findViewRoot(projectPath)
   const files = await partialsIn(projectPath, viewRoot)
@@ -34,18 +48,9 @@ export async function buildPartialIndex(herb: HerbBackend, projectPath: string):
     const existing = declarations.get(name)
     if (existing && !outranksTemplate(file, existing.file)) continue
 
-    try {
-      const source = readFileSync(join(projectPath, file), "utf-8")
+    const declaration = declarationFromFile(herb, projectPath, file)
 
-      if (!source.includes(STRICT_LOCALS_MARKER)) {
-        declarations.set(name, declarationWithoutStrictLocals(file))
-        continue
-      }
-
-      declarations.set(name, declarationFromDocument(herb.parse(source, PARSER_OPTIONS).value, file))
-    } catch {
-      continue
-    }
+    if (declaration) declarations.set(name, declaration)
   }
 
   return new PartialIndex(viewRoot, declarations)

--- a/javascript/packages/linter/test/partial-index-builder.test.ts
+++ b/javascript/packages/linter/test/partial-index-builder.test.ts
@@ -6,7 +6,7 @@ import { beforeAll, afterEach, describe, expect, test } from "vitest"
 
 import { Herb } from "@herb-tools/node-wasm"
 
-import { buildPartialIndex, findViewRoot } from "../src/cli/partial-index-builder.js"
+import { buildPartialIndex, findViewRoot } from "../src/partial-index-builder.js"
 
 const projects: string[] = []
 


### PR DESCRIPTION
This pull request gives the language server a partial index and keeps it current as you edit, so `actionview-no-strict-locals-error` reports in the editor instead of only in the CLI.

The rule needs to know what the partial on the other end of a `render` call declares, which it gets from a `PartialIndex` handed to it through `LintContext`. The CLI builds one per run and throws it away. An editor cannot do that: it has to build the index once, keep it current as files change, and re-check the templates that a changed partial affects. Until now the language server passed no index at all, so the rule was silent there.

Resolves the language server half of https://github.com/marcoroth/herb/issues/639.

Enables #2043, which needs an index that is current while the editor is open.