### PR TITLE
Core: Introduce `build` factories for AST nodes

### DIFF
--- a/javascript/packages/core/src/ast-utils.ts
+++ b/javascript/packages/core/src/ast-utils.ts
@@ -927,7 +927,7 @@ export function createLiteral(content: string): LiteralNode {
 }
 
 export function createSyntheticToken(value: string, type = "TOKEN_SYNTHETIC"): Token {
-  return new Token(value, Range.zero, Location.zero, type)
+  return Token.from(type, value)
 }
 
 export function createWhitespaceNode(): WhitespaceNode {

--- a/javascript/packages/core/src/ast-utils.ts
+++ b/javascript/packages/core/src/ast-utils.ts
@@ -45,7 +45,6 @@ import {
 } from "./node-type-guards.js"
 
 import { Location } from "./location.js"
-import { Range } from "./range.js"
 import { Token } from "./token.js"
 
 import type { Position } from "./position.js"
@@ -926,28 +925,24 @@ export function createLiteral(content: string): LiteralNode {
   return LiteralNode.build({ content })
 }
 
-export function createSyntheticToken(value: string, type = "TOKEN_SYNTHETIC"): Token {
-  return Token.from(type, value)
-}
-
 export function createWhitespaceNode(): WhitespaceNode {
-  return WhitespaceNode.build({ value: createSyntheticToken(" ") })
+  return WhitespaceNode.build({ value: Token.from("TOKEN_WHITESPACE", " ") })
 }
 
 export function createERBOutputNode(expression: string, tagOpening = "<%=", tagClosing = "%>"): ERBContentNode {
   return ERBContentNode.build({
-    tag_opening: createSyntheticToken(tagOpening),
-    content: createSyntheticToken(expression),
-    tag_closing: createSyntheticToken(tagClosing),
+    tag_opening: Token.from("TOKEN_ERB_START", tagOpening),
+    content: Token.from("TOKEN_ERB_CONTENT", expression),
+    tag_closing: Token.from("TOKEN_ERB_END", tagClosing),
     valid: true,
   })
 }
 
 export function createERBSilentNode(expression: string, tagOpening = "<%", tagClosing = "%>"): ERBContentNode {
   return ERBContentNode.build({
-    tag_opening: createSyntheticToken(tagOpening),
-    content: createSyntheticToken(expression),
-    tag_closing: createSyntheticToken(tagClosing),
+    tag_opening: Token.from("TOKEN_ERB_START", tagOpening),
+    content: Token.from("TOKEN_ERB_CONTENT", expression),
+    tag_closing: Token.from("TOKEN_ERB_END", tagClosing),
     valid: true,
   })
 }

--- a/javascript/packages/core/src/ast-utils.ts
+++ b/javascript/packages/core/src/ast-utils.ts
@@ -601,12 +601,7 @@ export function splitLiteralsAtWhitespace(nodes: Node[]): Node[] {
       const parts = node.content.match(/(\S+|\s+)/g) || []
 
       for (const part of parts) {
-        result.push(new LiteralNode({
-          type: "AST_LITERAL_NODE",
-          content: part,
-          errors: [],
-          location: node.location
-        }))
+        result.push(LiteralNode.build({ content: part, location: node.location }))
       }
     } else {
       result.push(node)
@@ -928,12 +923,7 @@ export function replaceNodeWithBody(array: Node[], element: HTMLElementNode): vo
  * Useful for inserting whitespace or newlines during AST mutations.
  */
 export function createLiteral(content: string): LiteralNode {
-  return new LiteralNode({
-    type: "AST_LITERAL_NODE",
-    content,
-    location: Location.zero,
-    errors: [],
-  })
+  return LiteralNode.build({ content })
 }
 
 export function createSyntheticToken(value: string, type = "TOKEN_SYNTHETIC"): Token {
@@ -941,38 +931,23 @@ export function createSyntheticToken(value: string, type = "TOKEN_SYNTHETIC"): T
 }
 
 export function createWhitespaceNode(): WhitespaceNode {
-  return new WhitespaceNode({
-    type: "AST_WHITESPACE_NODE",
-    location: Location.zero,
-    errors: [],
-    value: createSyntheticToken(" "),
-  })
+  return WhitespaceNode.build({ value: createSyntheticToken(" ") })
 }
 
 export function createERBOutputNode(expression: string, tagOpening = "<%=", tagClosing = "%>"): ERBContentNode {
-  return new ERBContentNode({
-    type: "AST_ERB_CONTENT_NODE",
+  return ERBContentNode.build({
     tag_opening: createSyntheticToken(tagOpening),
     content: createSyntheticToken(expression),
     tag_closing: createSyntheticToken(tagClosing),
-    parsed: false,
     valid: true,
-    prism_node: null,
-    location: Location.zero,
-    errors: [],
   })
 }
 
 export function createERBSilentNode(expression: string, tagOpening = "<%", tagClosing = "%>"): ERBContentNode {
-  return new ERBContentNode({
-    type: "AST_ERB_CONTENT_NODE",
+  return ERBContentNode.build({
     tag_opening: createSyntheticToken(tagOpening),
     content: createSyntheticToken(expression),
     tag_closing: createSyntheticToken(tagClosing),
-    parsed: false,
     valid: true,
-    prism_node: null,
-    location: Location.zero,
-    errors: [],
   })
 }

--- a/javascript/packages/core/src/token.ts
+++ b/javascript/packages/core/src/token.ts
@@ -14,21 +14,18 @@ export class Token {
   readonly location: Location
   readonly type: string
 
-  static from(token: SerializedToken) {
-    return new Token(
-      token.value,
-      Range.from(token.range),
-      Location.from(token.location),
-      token.type,
-    )
-  }
+  static from(token: SerializedToken): Token
+  static from(type: string, value: string): Token
+  static from(tokenOrType: SerializedToken | string, value?: string): Token {
+    if (typeof tokenOrType === "string") {
+      return new Token(value!, Range.zero, Location.zero, tokenOrType)
+    }
 
-  static synthetic(value: string, type: string = "SYNTETHIC") {
     return new Token(
-      value,
-      Range.zero,
-      Location.zero,
-      type
+      tokenOrType.value,
+      Range.from(tokenOrType.range),
+      Location.from(tokenOrType.location),
+      tokenOrType.type,
     )
   }
 

--- a/javascript/packages/core/test/ast-utils.test.ts
+++ b/javascript/packages/core/test/ast-utils.test.ts
@@ -34,7 +34,7 @@ import {
   ERBOpenTagNode,
   LiteralNode,
   RubyLiteralNode,
-  createSyntheticToken
+  Token
 } from "../src"
 
 import type { Node } from "../src/nodes.js"
@@ -45,9 +45,9 @@ describe("ast-utils", () => {
 
   const createERBContentNode = (tagOpening: string, content: string = "", tagClosing: string = "%>"): ERBContentNode =>
     ERBContentNode.build({
-      tag_opening: createSyntheticToken(tagOpening),
-      content: content ? createSyntheticToken(content) : null,
-      tag_closing: createSyntheticToken(tagClosing),
+      tag_opening: Token.from("TOKEN_ERB_START", tagOpening),
+      content: content ? Token.from("TOKEN_ERB_CONTENT", content) : null,
+      tag_closing: Token.from("TOKEN_ERB_END", tagClosing),
       location: Location.from(1, 1, 1, 1)
     })
 

--- a/javascript/packages/core/test/ast-utils.test.ts
+++ b/javascript/packages/core/test/ast-utils.test.ts
@@ -24,37 +24,38 @@ import {
   getAttributes,
   getAttribute,
   Location,
-  HTMLAttributeNameNode
+  HTMLAttributeNameNode,
+  HTMLAttributeNode,
+  HTMLAttributeValueNode,
+  HTMLElementNode,
+  HTMLOpenTagNode,
+  DocumentNode,
+  ERBContentNode,
+  ERBOpenTagNode,
+  LiteralNode,
+  RubyLiteralNode,
+  createSyntheticToken
 } from "../src"
 
-import type { Node, LiteralNode, ERBContentNode, RubyLiteralNode } from "../src/nodes.js"
+import type { Node } from "../src/nodes.js"
 
 describe("ast-utils", () => {
-  const createLiteralNode = (content: string): LiteralNode => ({
-    type: "AST_LITERAL_NODE",
-    content,
-    location: Location.from(1, 1, 1, 1)
-  })
+  const createLiteralNode = (content: string): LiteralNode =>
+    LiteralNode.build({ content, location: Location.from(1, 1, 1, 1) })
 
-  const createERBContentNode = (tagOpening: string, content: string = "", tagClosing: string = "%>"): ERBContentNode => ({
-    type: "AST_ERB_CONTENT_NODE",
-    tag_opening: { type: "AST_TOKEN", value: tagOpening, location: Location.from(1, 1, 1, 1) },
-    content: content ? { type: "AST_TOKEN", value: content, location: Location.from(1, 1, 1, 1) } : undefined,
-    tag_closing: { type: "AST_TOKEN", value: tagClosing, location: Location.from(1, 1, 1, 1) },
-    location: Location.from(1, 1, 1, 1)
-  })
+  const createERBContentNode = (tagOpening: string, content: string = "", tagClosing: string = "%>"): ERBContentNode =>
+    ERBContentNode.build({
+      tag_opening: createSyntheticToken(tagOpening),
+      content: content ? createSyntheticToken(content) : null,
+      tag_closing: createSyntheticToken(tagClosing),
+      location: Location.from(1, 1, 1, 1)
+    })
 
-  const createRubyLiteralNode = (content: string): RubyLiteralNode => ({
-    type: "AST_RUBY_LITERAL_NODE",
-    content,
-    location: Location.from(1, 1, 1, 1)
-  })
+  const createRubyLiteralNode = (content: string): RubyLiteralNode =>
+    RubyLiteralNode.build({ content, location: Location.from(1, 1, 1, 1) })
 
-  const createAttributeNameNode = (children: Node[]): HTMLAttributeNameNode => ({
-    type: "AST_HTML_ATTRIBUTE_NAME_NODE",
-    children,
-    location: Location.from(1, 1, 1, 1)
-  })
+  const createAttributeNameNode = (children: Node[]): HTMLAttributeNameNode =>
+    HTMLAttributeNameNode.build({ children, location: Location.from(1, 1, 1, 1) })
 
   describe("isLiteralNode", () => {
     test("returns true for literal nodes", () => {
@@ -519,33 +520,22 @@ describe("ast-utils", () => {
   })
 
   describe("findParentArray", () => {
-    const createDocumentNode = (children: Node[]): Node => ({
-      type: "AST_DOCUMENT_NODE",
-      children,
-      location: Location.from(1, 1, 1, 1)
-    } as any)
+    const createDocumentNode = (children: Node[]): Node =>
+      DocumentNode.build({ children, location: Location.from(1, 1, 1, 1) })
 
-    const createElementNode = (openTagChildren: Node[], body: Node[] = []): any => ({
-      type: "AST_HTML_ELEMENT_NODE",
-      open_tag: {
-        type: "AST_HTML_OPEN_TAG_NODE",
-        children: openTagChildren,
+    const createElementNode = (openTagChildren: Node[], body: Node[] = []) =>
+      HTMLElementNode.build({
+        open_tag: HTMLOpenTagNode.build({ children: openTagChildren, location: Location.from(1, 1, 1, 1) }),
+        body,
         location: Location.from(1, 1, 1, 1)
-      },
-      body,
-      location: Location.from(1, 1, 1, 1)
-    })
+      })
 
-    const createAttributeNode = (valueChildren: Node[]): any => ({
-      type: "AST_HTML_ATTRIBUTE_NODE",
-      name: createAttributeNameNode([createLiteralNode("class")]),
-      value: {
-        type: "AST_HTML_ATTRIBUTE_VALUE_NODE",
-        children: valueChildren,
+    const createAttributeNode = (valueChildren: Node[]) =>
+      HTMLAttributeNode.build({
+        name: createAttributeNameNode([createLiteralNode("class")]),
+        value: HTMLAttributeValueNode.build({ children: valueChildren, location: Location.from(1, 1, 1, 1) }),
         location: Location.from(1, 1, 1, 1)
-      },
-      location: Location.from(1, 1, 1, 1)
-    })
+      })
 
     test("finds a node in the document children", () => {
       const target = createERBContentNode("<%=", "value")
@@ -616,35 +606,24 @@ describe("ast-utils", () => {
   })
 
   describe("getAttributes", () => {
-    const createAttributeNode = (name: string) => ({
-      type: "AST_HTML_ATTRIBUTE_NODE",
-      location: Location.from(1, 1, 1, 1),
-      errors: [],
-      name: createAttributeNameNode([createLiteralNode(name)]),
-      equals: null,
-      value: null
-    })
+    const createAttributeNode = (name: string) =>
+      HTMLAttributeNode.build({
+        name: createAttributeNameNode([createLiteralNode(name)]),
+        location: Location.from(1, 1, 1, 1)
+      })
 
-    const createERBOpenTagNode = (children: Node[]) => ({
-      type: "AST_ERB_OPEN_TAG_NODE",
-      location: Location.from(1, 1, 1, 1),
-      errors: [],
-      tag_opening: null,
-      content: null,
-      tag_closing: null,
-      tag_name: null,
-      children
-    })
+    const createERBOpenTagNode = (children: Node[]) =>
+      ERBOpenTagNode.build({ children, location: Location.from(1, 1, 1, 1) })
 
     test("reads attributes off the ERB open tag that Action View tag helpers parse into", () => {
-      const node = createERBOpenTagNode([createAttributeNode("data-turbo-permanent")]) as any
+      const node = createERBOpenTagNode([createAttributeNode("data-turbo-permanent")])
 
       expect(getAttributes(node)).toHaveLength(1)
       expect(getAttribute(node, "data-turbo-permanent")).not.toBe(null)
     })
 
     test("returns an empty list for an ERB open tag without attributes", () => {
-      expect(getAttributes(createERBOpenTagNode([]) as any)).toEqual([])
+      expect(getAttributes(createERBOpenTagNode([]))).toEqual([])
     })
   })  
 })

--- a/javascript/packages/core/test/visitor.test.ts
+++ b/javascript/packages/core/test/visitor.test.ts
@@ -28,39 +28,20 @@ describe("Visitor", () => {
     const position = new Position(1, 0)
     const location = new Location(position, position)
 
-    const text = new HTMLTextNode({
-      type: "AST_HTML_TEXT_NODE",
+    const text = HTMLTextNode.build({
       location,
-      errors: [],
       content: "Hello",
     })
 
-    const erb = new ERBContentNode({
-      type: "AST_ERB_CONTENT_NODE",
-      location,
-      errors: [],
-      tag_opening: null,
-      content: null,
-      tag_closing: null,
-      parsed: false,
-      valid: false,
-    })
+    const erb = ERBContentNode.build({ location })
 
-    const element = new HTMLElementNode({
-      type: "AST_HTML_ELEMENT_NODE",
+    const element = HTMLElementNode.build({
       location,
-      errors: [],
-      open_tag: null,
-      tag_name: null,
       body: [text, erb],
-      close_tag: null,
-      is_void: false,
     })
 
-    const doc = new DocumentNode({
-      type: "AST_DOCUMENT_NODE",
+    const doc = DocumentNode.build({
       location,
-      errors: [],
       children: [element],
     })
 
@@ -79,12 +60,8 @@ describe("Visitor", () => {
     const position = new Position(1, 0)
     const location = new Location(position, position)
 
-    const node = new RubyParameterNode({
-      type: "AST_RUBY_PARAMETER_NODE",
+    const node = RubyParameterNode.build({
       location,
-      errors: [],
-      name: null,
-      default_value: null,
       kind: "required",
       required: true,
     })
@@ -101,12 +78,8 @@ describe("Visitor", () => {
     const position = new Position(1, 0)
     const location = new Location(position, position)
 
-    const node = new RubyParameterNode({
-      type: "AST_RUBY_PARAMETER_NODE",
+    const node = RubyParameterNode.build({
       location,
-      errors: [],
-      name: null,
-      default_value: null,
       kind: "required",
       required: true,
     })

--- a/javascript/packages/language-server/src/comment_ast_utils.ts
+++ b/javascript/packages/language-server/src/comment_ast_utils.ts
@@ -1,7 +1,7 @@
 import { ParserService } from "./parser_service"
 import { LineContextCollector } from "./line_context_collector"
 
-import { HTMLCommentNode, Location, createSyntheticToken } from "@herb-tools/core"
+import { HTMLCommentNode, createSyntheticToken } from "@herb-tools/core"
 import { IdentityPrinter } from "@herb-tools/printer"
 
 import { isERBCommentNode, isLiteralNode, createLiteral } from "@herb-tools/core"
@@ -156,10 +156,7 @@ export function commentLineContent(content: string, erbNodes: ERBContentNode[], 
         commentERBNode(node)
       }
 
-      const commentNode = new HTMLCommentNode({
-        type: "AST_HTML_COMMENT_NODE",
-        location: Location.zero,
-        errors: [],
+      const commentNode = HTMLCommentNode.build({
         comment_start: createSyntheticToken("<!--", "TOKEN_HTML_COMMENT_START"),
         children: [createLiteral(" "), ...(children.slice() as Node[]), createLiteral(" ")],
         comment_end: createSyntheticToken("-->", "TOKEN_HTML_COMMENT_END"),
@@ -171,10 +168,7 @@ export function commentLineContent(content: string, erbNodes: ERBContentNode[], 
     }
 
     case "html-only": {
-      const commentNode = new HTMLCommentNode({
-        type: "AST_HTML_COMMENT_NODE",
-        location: Location.zero,
-        errors: [],
+      const commentNode = HTMLCommentNode.build({
         comment_start: createSyntheticToken("<!--", "TOKEN_HTML_COMMENT_START"),
         children: [createLiteral(" "), ...(children.slice() as Node[]), createLiteral(" ")],
         comment_end: createSyntheticToken("-->", "TOKEN_HTML_COMMENT_END"),

--- a/javascript/packages/language-server/src/comment_ast_utils.ts
+++ b/javascript/packages/language-server/src/comment_ast_utils.ts
@@ -1,7 +1,7 @@
 import { ParserService } from "./parser_service"
 import { LineContextCollector } from "./line_context_collector"
 
-import { HTMLCommentNode, createSyntheticToken } from "@herb-tools/core"
+import { HTMLCommentNode, Token } from "@herb-tools/core"
 import { IdentityPrinter } from "@herb-tools/printer"
 
 import { isERBCommentNode, isLiteralNode, createLiteral } from "@herb-tools/core"
@@ -31,9 +31,9 @@ export function commentERBNode(node: ERBContentNode): void {
   if (mutable.tag_opening) {
     const currentValue = mutable.tag_opening.value
 
-    mutable.tag_opening = createSyntheticToken(
-      currentValue.substring(0, 2) + "#" + currentValue.substring(2),
-      mutable.tag_opening.type
+    mutable.tag_opening = Token.from(
+      mutable.tag_opening.type,
+      currentValue.substring(0, 2) + "#" + currentValue.substring(2)
     )
   }
 }
@@ -52,10 +52,10 @@ export function uncommentERBNode(node: ERBContentNode): void {
       contentValue.startsWith(" = ") ||
       contentValue.startsWith(" - ")
     ) {
-      mutable.tag_opening = createSyntheticToken("<%", mutable.tag_opening.type)
-      mutable.content = createSyntheticToken(contentValue.substring(1), mutable.content!.type)
+      mutable.tag_opening = Token.from(mutable.tag_opening.type, "<%")
+      mutable.content = Token.from(mutable.content!.type, contentValue.substring(1))
     } else {
-      mutable.tag_opening = createSyntheticToken("<%", mutable.tag_opening.type)
+      mutable.tag_opening = Token.from(mutable.tag_opening.type, "<%")
     }
   }
 }
@@ -157,9 +157,9 @@ export function commentLineContent(content: string, erbNodes: ERBContentNode[], 
       }
 
       const commentNode = HTMLCommentNode.build({
-        comment_start: createSyntheticToken("<!--", "TOKEN_HTML_COMMENT_START"),
+        comment_start: Token.from("TOKEN_HTML_COMMENT_START", "<!--"),
         children: [createLiteral(" "), ...(children.slice() as Node[]), createLiteral(" ")],
-        comment_end: createSyntheticToken("-->", "TOKEN_HTML_COMMENT_END"),
+        comment_end: Token.from("TOKEN_HTML_COMMENT_END", "-->"),
       })
 
       children.length = 0
@@ -169,9 +169,9 @@ export function commentLineContent(content: string, erbNodes: ERBContentNode[], 
 
     case "html-only": {
       const commentNode = HTMLCommentNode.build({
-        comment_start: createSyntheticToken("<!--", "TOKEN_HTML_COMMENT_START"),
+        comment_start: Token.from("TOKEN_HTML_COMMENT_START", "<!--"),
         children: [createLiteral(" "), ...(children.slice() as Node[]), createLiteral(" ")],
-        comment_end: createSyntheticToken("-->", "TOKEN_HTML_COMMENT_END"),
+        comment_end: Token.from("TOKEN_HTML_COMMENT_END", "-->"),
       })
 
       children.length = 0

--- a/javascript/packages/linter/src/rules/erb-no-duplicate-branch-elements.ts
+++ b/javascript/packages/linter/src/rules/erb-no-duplicate-branch-elements.ts
@@ -18,7 +18,6 @@ import {
   replaceNodeWithBody,
   createLiteral,
   HTMLElementNode,
-  Location,
 } from "@herb-tools/core"
 
 import type { BaseAutofixContext, UnboundLintOffense, LintOffense, LintContext, FullRuleConfig } from "../types.js"
@@ -151,16 +150,13 @@ function findCommonSuffixCount(branches: Node[][], minLength: number, prefixCoun
 }
 
 function createWrapper(template: HTMLElementNode, body: Node[]): HTMLElementNode {
-  return new HTMLElementNode({
-    type: "AST_HTML_ELEMENT_NODE",
+  return HTMLElementNode.build({
     open_tag: template.open_tag,
     tag_name: template.tag_name,
     body,
     close_tag: template.close_tag,
     is_void: template.is_void,
     element_source: template.element_source,
-    location: Location.zero,
-    errors: [],
   })
 }
 

--- a/javascript/packages/linter/src/rules/html-no-self-closing.ts
+++ b/javascript/packages/linter/src/rules/html-no-self-closing.ts
@@ -1,6 +1,6 @@
 import { ParserRule, BaseAutofixContext, Mutable } from "../types.js"
 import { isVoidElement, findParent, BaseRuleVisitor } from "./rule-utils.js"
-import { getTagName, getTagLocalName, isWhitespaceNode, createSyntheticToken, HTMLCloseTagNode } from "@herb-tools/core"
+import { getTagName, getTagLocalName, isWhitespaceNode, Token, HTMLCloseTagNode } from "@herb-tools/core"
 
 import type { UnboundLintOffense, LintContext, LintOffense, FullRuleConfig } from "../types.js"
 import type { Node, HTMLOpenTagNode, HTMLElementNode, ParseResult, ParserOptions } from "@herb-tools/core"
@@ -98,9 +98,9 @@ export class HTMLNoSelfClosingRule extends ParserRule<NoSelfClosingAutofixContex
 
       if (parent && parent.type === "AST_HTML_ELEMENT_NODE") {
         parent.close_tag = HTMLCloseTagNode.build({
-          tag_opening: createSyntheticToken("</", "TOKEN_HTML_TAG_START_CLOSE"),
-          tag_name: createSyntheticToken(tagName, "TOKEN_IDENTIFIER"),
-          tag_closing: createSyntheticToken(">", "TOKEN_HTML_TAG_END"),
+          tag_opening: Token.from("TOKEN_HTML_TAG_START_CLOSE", "</"),
+          tag_name: Token.from("TOKEN_IDENTIFIER", tagName),
+          tag_closing: Token.from("TOKEN_HTML_TAG_END", ">"),
         })
       }
     }

--- a/javascript/packages/linter/src/rules/html-no-self-closing.ts
+++ b/javascript/packages/linter/src/rules/html-no-self-closing.ts
@@ -1,9 +1,9 @@
 import { ParserRule, BaseAutofixContext, Mutable } from "../types.js"
 import { isVoidElement, findParent, BaseRuleVisitor } from "./rule-utils.js"
-import { getTagName, getTagLocalName, isWhitespaceNode, Location, HTMLCloseTagNode } from "@herb-tools/core"
+import { getTagName, getTagLocalName, isWhitespaceNode, createSyntheticToken, HTMLCloseTagNode } from "@herb-tools/core"
 
 import type { UnboundLintOffense, LintContext, LintOffense, FullRuleConfig } from "../types.js"
-import type { Node, HTMLOpenTagNode, HTMLElementNode, SerializedToken, ParseResult, ParserOptions } from "@herb-tools/core"
+import type { Node, HTMLOpenTagNode, HTMLElementNode, ParseResult, ParserOptions } from "@herb-tools/core"
 
 interface NoSelfClosingAutofixContext extends BaseAutofixContext {
   node: Mutable<HTMLOpenTagNode>
@@ -97,18 +97,10 @@ export class HTMLNoSelfClosingRule extends ParserRule<NoSelfClosingAutofixContex
       const parent = findParent(result.value, node as any as Node) as Mutable<HTMLElementNode> | null
 
       if (parent && parent.type === "AST_HTML_ELEMENT_NODE") {
-        const tag_opening: SerializedToken = { type: "TOKEN_HTML_TAG_START_CLOSE", value: "</", location: Location.zero, range: [0, 0] }
-        const tag_name: SerializedToken = { type: "TOKEN_IDENTIFIER", value: tagName, location: Location.zero, range: [0, 0] }
-        const tag_closing: SerializedToken = { type: "TOKEN_HTML_TAG_END", value: ">", location: Location.zero, range: [0, 0] }
-
-        parent.close_tag = HTMLCloseTagNode.from({
-          type: "AST_HTML_CLOSE_TAG_NODE",
-          tag_opening,
-          tag_name,
-          tag_closing,
-          children: [],
-          errors: [],
-          location: Location.zero,
+        parent.close_tag = HTMLCloseTagNode.build({
+          tag_opening: createSyntheticToken("</", "TOKEN_HTML_TAG_START_CLOSE"),
+          tag_name: createSyntheticToken(tagName, "TOKEN_IDENTIFIER"),
+          tag_closing: createSyntheticToken(">", "TOKEN_HTML_TAG_END"),
         })
       }
     }

--- a/javascript/packages/printer/test/helpers/printer-test-helpers.ts
+++ b/javascript/packages/printer/test/helpers/printer-test-helpers.ts
@@ -3,53 +3,39 @@ import { expect } from "vitest"
 import { Herb } from "@herb-tools/node-wasm"
 import { IdentityPrinter } from "../../src/index.js"
 
-import { HTMLTextNode, ERBContentNode, ERBEndNode, LiteralNode } from "@herb-tools/core"
+import { HTMLTextNode, ERBContentNode, ERBEndNode, LiteralNode, Location, Range, Token } from "@herb-tools/core"
 
 import type { Node, ParseResult, ParseOptions } from "@herb-tools/core"
 
-export function createLocation(line = 1, column = 1) {
-  return {
-    start: { line, column },
-    end: { line, column }
-  }
+export function createLocation(line = 1, column = 1): Location {
+  return Location.from(line, column, line, column)
 }
 
-export function createRange(start = 1, end = 2): [number, number] {
-  return [start, end]
+export function createRange(start = 1, end = 2): Range {
+  return Range.from(start, end)
 }
 
-export function createToken(type = "", value = "", range = createRange(), location = createLocation()) {
-  return {
-    type,
-    value,
-    range,
-    location
-  }
+export function createToken(type = "", value = "", range = createRange(), location = createLocation()): Token {
+  return new Token(value, range, location, type)
 }
 
 export function createTextNode(content: string): HTMLTextNode {
-  return HTMLTextNode.from({
-    type: "AST_HTML_TEXT_NODE",
+  return HTMLTextNode.build({
     location,
-    errors: [],
     content
   })
 }
 
 export function createLiteralNode(content: string): LiteralNode {
-  return LiteralNode.from({
-    type: "AST_LITERAL_NODE",
+  return LiteralNode.build({
     location,
-    errors: [],
     content
   })
 }
 
 export function createERBContentNode(content: string, opening: string = "<%", closing: string = "%>"): ERBContentNode {
-  return ERBContentNode.from({
-    type: "AST_ERB_CONTENT_NODE",
+  return ERBContentNode.build({
     location,
-    errors: [],
     tag_opening: createToken("TOKEN_ERB_START", opening),
     content: createToken("TOKEN_ERB_CONTENT", content),
     tag_closing: createToken("TOKEN_ERB_END", closing),
@@ -63,10 +49,8 @@ export const range = createRange()
 export const singleQuote = createToken("TOKEN_QUOTE", `'`)
 export const doubleQuote = createToken("TOKEN_QUOTE", `"`)
 
-export const end_node = ERBEndNode.from({
-  type: "AST_ERB_END_NODE",
+export const end_node = ERBEndNode.build({
   location,
-  errors: [],
   tag_opening: createToken("TOKEN_ERB_START", "<%"),
   content: createToken("TOKEN_ERB_CONTENT", " end "),
   tag_closing: createToken("TOKEN_ERB_END", "%>"),

--- a/javascript/packages/printer/test/nodes/cdata-node.test.ts
+++ b/javascript/packages/printer/test/nodes/cdata-node.test.ts
@@ -12,10 +12,8 @@ describe("CDATANode Printing", () => {
   })
 
   test("can print empty CDATA section from node", () => {
-    const node = CDATANode.from({
-      type: "AST_CDATA_NODE",
+    const node = CDATANode.build({
       location: createLocation(),
-      errors: [],
       tag_opening: createToken("TOKEN_CDATA_START", "<![CDATA["),
       children: [],
       tag_closing: createToken("TOKEN_CDATA_END", "]]>")
@@ -25,17 +23,13 @@ describe("CDATANode Printing", () => {
   })
 
   test("can print CDATA with text content from node", () => {
-    const literalNode = LiteralNode.from({
-      type: "AST_LITERAL_NODE",
+    const literalNode = LiteralNode.build({
       location: createLocation(),
-      errors: [],
       content: "Hello World"
     })
 
-    const node = CDATANode.from({
-      type: "AST_CDATA_NODE",
+    const node = CDATANode.build({
       location: createLocation(),
-      errors: [],
       tag_opening: createToken("TOKEN_CDATA_START", "<![CDATA["),
       children: [literalNode],
       tag_closing: createToken("TOKEN_CDATA_END", "]]>")
@@ -45,17 +39,13 @@ describe("CDATANode Printing", () => {
   })
 
   test("can print CDATA with XML-like content from node", () => {
-    const literalNode = LiteralNode.from({
-      type: "AST_LITERAL_NODE",
+    const literalNode = LiteralNode.build({
       location: createLocation(),
-      errors: [],
       content: "<sender>John Smith</sender>"
     })
 
-    const node = CDATANode.from({
-      type: "AST_CDATA_NODE",
+    const node = CDATANode.build({
       location: createLocation(),
-      errors: [],
       tag_opening: createToken("TOKEN_CDATA_START", "<![CDATA["),
       children: [literalNode],
       tag_closing: createToken("TOKEN_CDATA_END", "]]>")

--- a/javascript/packages/printer/test/nodes/document-node.test.ts
+++ b/javascript/packages/printer/test/nodes/document-node.test.ts
@@ -11,10 +11,8 @@ describe("DocumentNode Printing", () => {
   })
 
   test("can print from node", () => {
-    const node = DocumentNode.from({
-      type: "AST_DOCUMENT_NODE",
+    const node = DocumentNode.build({
       location: Location.from(1, 1, 1, 1),
-      errors: [],
       children: []
     })
 

--- a/javascript/packages/printer/test/nodes/erb-begin-node.test.ts
+++ b/javascript/packages/printer/test/nodes/erb-begin-node.test.ts
@@ -12,8 +12,7 @@ describe("ERBBeginNode Printing", () => {
   })
 
   test("can print with begin/end", () => {
-    const node = ERBBeginNode.from({
-      type: "AST_ERB_BEGIN_NODE",
+    const node = ERBBeginNode.build({
       location,
       tag_opening: createToken("TOKEN_ERB_START", "<%"),
       content: createToken("TOKEN_ERB_CONTENT", " begin "),
@@ -30,8 +29,7 @@ describe("ERBBeginNode Printing", () => {
   })
 
   test("can print with begin/end and statements", () => {
-    const node = ERBBeginNode.from({
-      type: "AST_ERB_BEGIN_NODE",
+    const node = ERBBeginNode.build({
       location,
       tag_opening: createToken("TOKEN_ERB_START", "<%"),
       content: createToken("TOKEN_ERB_CONTENT", " begin "),

--- a/javascript/packages/printer/test/nodes/erb-block-node.test.ts
+++ b/javascript/packages/printer/test/nodes/erb-block-node.test.ts
@@ -19,10 +19,8 @@ describe("ERBBlockNode Printing", () => {
   })
 
   test("can print from node", () => {
-    const node = ERBBlockNode.from({
-      type: "AST_ERB_BLOCK_NODE",
+    const node = ERBBlockNode.build({
       location,
-      errors: [],
       tag_opening: createToken("TOKEN_ERB_START", "<%"),
       content: createToken("TOKEN_ERB_CONTENT", " something do "),
       tag_closing: createToken("TOKEN_ERB_END", "%>"),

--- a/javascript/packages/printer/test/nodes/erb-case-match-node.test.ts
+++ b/javascript/packages/printer/test/nodes/erb-case-match-node.test.ts
@@ -12,10 +12,8 @@ describe("ERBCaseNode Printing", () => {
   })
 
   test("can print from node", () => {
-    const node = ERBCaseMatchNode.from({
-      type: "AST_ERB_CASE_MATCH_NODE",
+    const node = ERBCaseMatchNode.build({
       location,
-      errors: [],
       tag_opening: createToken("TOKEN_ERB_START", "<%"),
       content: createToken("TOKEN_ERB_CONTENT", " case variable "),
       tag_closing: createToken("TOKEN_ERB_END", "%>"),

--- a/javascript/packages/printer/test/nodes/erb-case-node.test.ts
+++ b/javascript/packages/printer/test/nodes/erb-case-node.test.ts
@@ -12,10 +12,8 @@ describe("ERBCaseNode Printing", () => {
   })
 
   test("can print from node", () => {
-    const node = ERBCaseNode.from({
-      type: "AST_ERB_CASE_NODE",
+    const node = ERBCaseNode.build({
       location,
-      errors: [],
       tag_opening: createToken("TOKEN_ERB_START", "<%"),
       content: createToken("TOKEN_ERB_CONTENT", " case variable "),
       tag_closing: createToken("TOKEN_ERB_END", "%>"),

--- a/javascript/packages/printer/test/nodes/erb-content-node.test.ts
+++ b/javascript/packages/printer/test/nodes/erb-content-node.test.ts
@@ -12,10 +12,8 @@ describe("ERBContentNode Printing", () => {
   })
 
   test("can print from node", () => {
-    const node = ERBContentNode.from({
-      type: "AST_ERB_CONTENT_NODE",
+    const node = ERBContentNode.build({
       location,
-      errors: [],
       tag_opening: createToken("TOKEN_ERB_START", "<%"),
       content: createToken("TOKEN_ERB_CONTENT", " content "),
       tag_closing: createToken("TOKEN_ERB_END", "%>"),
@@ -27,10 +25,8 @@ describe("ERBContentNode Printing", () => {
   })
 
   test("can print from output node", () => {
-    const node = ERBContentNode.from({
-      type: "AST_ERB_CONTENT_NODE",
+    const node = ERBContentNode.build({
       location,
-      errors: [],
       tag_opening: createToken("TOKEN_ERB_START", "<%="),
       content: createToken("TOKEN_ERB_CONTENT", " content "),
       tag_closing: createToken("TOKEN_ERB_END", "%>"),

--- a/javascript/packages/printer/test/nodes/erb-else-node.test.ts
+++ b/javascript/packages/printer/test/nodes/erb-else-node.test.ts
@@ -12,10 +12,8 @@ describe("ERBElseNode Printing", () => {
   })
 
   test("can print from node", () => {
-    const node = ERBElseNode.from({
-      type: "AST_ERB_ELSE_NODE",
+    const node = ERBElseNode.build({
       location,
-      errors: [],
       tag_opening: createToken("TOKEN_ERB_START", "<%"),
       content: createToken("TOKEN_ERB_CONTENT", " else "),
       tag_closing: createToken("TOKEN_ERB_END", "%>"),

--- a/javascript/packages/printer/test/nodes/erb-end-node.test.ts
+++ b/javascript/packages/printer/test/nodes/erb-end-node.test.ts
@@ -11,10 +11,8 @@ describe("ERBEndNode Printing", () => {
   })
 
   test("can print from node", () => {
-    const node = ERBEndNode.from({
-      type: "AST_ERB_END_NODE",
+    const node = ERBEndNode.build({
       location,
-      errors: [],
       tag_opening: createToken("TOKEN_ERB_START", "<%"),
       content: createToken("TOKEN_ERB_CONTENT", " end "),
       tag_closing: createToken("TOKEN_ERB_END", "%>"),

--- a/javascript/packages/printer/test/nodes/erb-ensure-node.test.ts
+++ b/javascript/packages/printer/test/nodes/erb-ensure-node.test.ts
@@ -12,10 +12,8 @@ describe("ERBEnsureNode Printing", () => {
   })
 
   test("can print from node", () => {
-    const node = ERBEnsureNode.from({
-      type: "AST_ERB_ENSURE_NODE",
+    const node = ERBEnsureNode.build({
       location,
-      errors: [],
       tag_opening: createToken("TOKEN_ERB_START", "<%"),
       content: createToken("TOKEN_ERB_CONTENT", " ensure "),
       tag_closing: createToken("TOKEN_ERB_END", "%>"),

--- a/javascript/packages/printer/test/nodes/erb-for-node.test.ts
+++ b/javascript/packages/printer/test/nodes/erb-for-node.test.ts
@@ -12,10 +12,8 @@ describe("ERBForNode Printing", () => {
   })
 
   test("can print from node", () => {
-    const node = ERBForNode.from({
-      type: "AST_ERB_FOR_NODE",
+    const node = ERBForNode.build({
       location,
-      errors: [],
       tag_opening: createToken("TOKEN_ERB_START", "<%"),
       content: createToken("TOKEN_ERB_CONTENT", " for i in 1..5 "),
       tag_closing: createToken("TOKEN_ERB_END", "%>"),

--- a/javascript/packages/printer/test/nodes/erb-if-node.test.ts
+++ b/javascript/packages/printer/test/nodes/erb-if-node.test.ts
@@ -12,10 +12,8 @@ describe("ERBIfNode Printing", () => {
   })
 
   test("can print from node", () => {
-    const node = ERBIfNode.from({
-      type: "AST_ERB_IF_NODE",
+    const node = ERBIfNode.build({
       location,
-      errors: [],
       tag_opening: createToken("TOKEN_ERB_START", "<%"),
       content: createToken("TOKEN_ERB_CONTENT", " if condition? "),
       tag_closing: createToken("TOKEN_ERB_END", "%>"),
@@ -34,10 +32,8 @@ describe("ERBIfNode Printing", () => {
   })
 
   test("can print from instantiated node with subsequent", () => {
-    const else_node = ERBElseNode.from({
-      type: "AST_ERB_ELSE_NODE",
+    const else_node = ERBElseNode.build({
       location,
-      errors: [],
       tag_opening: createToken("TOKEN_ERB_START", "<%"),
       content: createToken("TOKEN_ERB_CONTENT", " else "),
       tag_closing: createToken("TOKEN_ERB_END", "%>"),
@@ -46,10 +42,8 @@ describe("ERBIfNode Printing", () => {
       ]
     })
 
-    const subsequent = ERBIfNode.from({
-      type: "AST_ERB_IF_NODE",
+    const subsequent = ERBIfNode.build({
       location,
-      errors: [],
       tag_opening: createToken("TOKEN_ERB_START", "<%"),
       content: createToken("TOKEN_ERB_CONTENT", " elsif another_condition? "),
       tag_closing: createToken("TOKEN_ERB_END", "%>"),
@@ -61,10 +55,8 @@ describe("ERBIfNode Printing", () => {
     })
 
 
-    const node = ERBIfNode.from({
-      type: "AST_ERB_IF_NODE",
+    const node = ERBIfNode.build({
       location,
-      errors: [],
       tag_opening: createToken("TOKEN_ERB_START", "<%"),
       content: createToken("TOKEN_ERB_CONTENT", " if condition? "),
       tag_closing: createToken("TOKEN_ERB_END", "%>"),

--- a/javascript/packages/printer/test/nodes/erb-in-node.test.ts
+++ b/javascript/packages/printer/test/nodes/erb-in-node.test.ts
@@ -12,10 +12,8 @@ describe("ERBInNode Printing", () => {
   })
 
   test("can print from node", () => {
-    const node = ERBInNode.from({
-      type: "AST_ERB_IN_NODE",
+    const node = ERBInNode.build({
       location,
-      errors: [],
       tag_opening: createToken("TOKEN_ERB_START", "<%"),
       content: createToken("TOKEN_ERB_CONTENT", " in [Integer] "),
       tag_closing: createToken("TOKEN_ERB_END", "%>"),

--- a/javascript/packages/printer/test/nodes/erb-iteration-block-node.test.ts
+++ b/javascript/packages/printer/test/nodes/erb-iteration-block-node.test.ts
@@ -21,10 +21,8 @@ describe("ERBIterationBlockNode Printing", () => {
   })
 
   test("can print from node", () => {
-    const node = ERBIterationBlockNode.from({
-      type: "AST_ERB_ITERATION_BLOCK_NODE",
+    const node = ERBIterationBlockNode.build({
       location,
-      errors: [],
       tag_opening: createToken("TOKEN_ERB_START", "<%"),
       content: createToken("TOKEN_ERB_CONTENT", " users.each do |user| "),
       tag_closing: createToken("TOKEN_ERB_END", "%>"),

--- a/javascript/packages/printer/test/nodes/erb-open-tag-node.test.ts
+++ b/javascript/packages/printer/test/nodes/erb-open-tag-node.test.ts
@@ -11,10 +11,8 @@ describe("ERBOpenTagNode Printing", () => {
   })
 
   test("can print from node with output tag", () => {
-    const node = ERBOpenTagNode.from({
-      type: "AST_ERB_OPEN_TAG_NODE",
+    const node = ERBOpenTagNode.build({
       location,
-      errors: [],
       tag_opening: createToken("TOKEN_ERB_START", "<%="),
       content: createToken("TOKEN_ERB_CONTENT", " content_tag :div do "),
       tag_closing: createToken("TOKEN_ERB_END", "%>"),
@@ -26,10 +24,8 @@ describe("ERBOpenTagNode Printing", () => {
   })
 
   test("can print from node with silent tag", () => {
-    const node = ERBOpenTagNode.from({
-      type: "AST_ERB_OPEN_TAG_NODE",
+    const node = ERBOpenTagNode.build({
       location,
-      errors: [],
       tag_opening: createToken("TOKEN_ERB_START", "<%"),
       content: createToken("TOKEN_ERB_CONTENT", " content_tag :div do "),
       tag_closing: createToken("TOKEN_ERB_END", "%>"),
@@ -41,10 +37,8 @@ describe("ERBOpenTagNode Printing", () => {
   })
 
   test("can print from node with content_tag and content argument", () => {
-    const node = ERBOpenTagNode.from({
-      type: "AST_ERB_OPEN_TAG_NODE",
+    const node = ERBOpenTagNode.build({
       location,
-      errors: [],
       tag_opening: createToken("TOKEN_ERB_START", "<%="),
       content: createToken("TOKEN_ERB_CONTENT", ' content_tag :div, "Content" '),
       tag_closing: createToken("TOKEN_ERB_END", "%>"),
@@ -56,10 +50,8 @@ describe("ERBOpenTagNode Printing", () => {
   })
 
   test("can print from node with tag.div helper", () => {
-    const node = ERBOpenTagNode.from({
-      type: "AST_ERB_OPEN_TAG_NODE",
+    const node = ERBOpenTagNode.build({
       location,
-      errors: [],
       tag_opening: createToken("TOKEN_ERB_START", "<%="),
       content: createToken("TOKEN_ERB_CONTENT", " tag.div do "),
       tag_closing: createToken("TOKEN_ERB_END", "%>"),
@@ -71,10 +63,8 @@ describe("ERBOpenTagNode Printing", () => {
   })
 
   test("can print from node with null tokens", () => {
-    const node = ERBOpenTagNode.from({
-      type: "AST_ERB_OPEN_TAG_NODE",
+    const node = ERBOpenTagNode.build({
       location,
-      errors: [],
       tag_opening: null,
       content: null,
       tag_closing: null,

--- a/javascript/packages/printer/test/nodes/erb-render-node.test.ts
+++ b/javascript/packages/printer/test/nodes/erb-render-node.test.ts
@@ -12,10 +12,8 @@ describe("ERBRenderNode Printing", () => {
   })
 
   test("can print from node", () => {
-    const keywords = RubyRenderKeywordsNode.from({
-      type: "AST_RUBY_RENDER_KEYWORDS_NODE",
+    const keywords = RubyRenderKeywordsNode.build({
       location: createLocation(),
-      errors: [],
       partial: null,
       template_path: null,
       layout: null,
@@ -36,10 +34,8 @@ describe("ERBRenderNode Printing", () => {
       locals: []
     })
 
-    const node = ERBRenderNode.from({
-      type: "AST_ERB_RENDER_NODE",
+    const node = ERBRenderNode.build({
       location: createLocation(),
-      errors: [],
       tag_opening: createToken("TOKEN_ERB_START", "<%="),
       content: createToken("TOKEN_ERB_CONTENT", ' render "card" '),
       tag_closing: createToken("TOKEN_ERB_END", "%>"),

--- a/javascript/packages/printer/test/nodes/erb-rescue-node.test.ts
+++ b/javascript/packages/printer/test/nodes/erb-rescue-node.test.ts
@@ -12,10 +12,8 @@ describe("ERBRescueNode Printing", () => {
   })
 
   test("can print from node", () => {
-    const node = ERBRescueNode.from({
-      type: "AST_ERB_RESCUE_NODE",
+    const node = ERBRescueNode.build({
       location,
-      errors: [],
       tag_opening: createToken("TOKEN_ERB_START", "<%"),
       content: createToken("TOKEN_ERB_CONTENT", " rescue StandardError => e "),
       tag_closing: createToken("TOKEN_ERB_END", "%>"),

--- a/javascript/packages/printer/test/nodes/erb-strict-locals-node.test.ts
+++ b/javascript/packages/printer/test/nodes/erb-strict-locals-node.test.ts
@@ -12,10 +12,8 @@ describe("ERBStrictLocalsNode Printing", () => {
   })
 
   test("can print from node", () => {
-    const node = ERBStrictLocalsNode.from({
-      type: "AST_ERB_STRICT_LOCALS_NODE",
+    const node = ERBStrictLocalsNode.build({
       location: createLocation(),
-      errors: [],
       tag_opening: createToken(),
       content: createToken(),
       tag_closing: createToken(),

--- a/javascript/packages/printer/test/nodes/erb-unless-node.test.ts
+++ b/javascript/packages/printer/test/nodes/erb-unless-node.test.ts
@@ -12,10 +12,8 @@ describe("ERBUnlessNode Printing", () => {
   })
 
   test("can print from node", () => {
-    const node = ERBUnlessNode.from({
-      type: "AST_ERB_UNLESS_NODE",
+    const node = ERBUnlessNode.build({
       location,
-      errors: [],
       tag_opening: createToken("TOKEN_ERB_START", "<%"),
       content: createToken("TOKEN_ERB_CONTENT", " unless condition? "),
       tag_closing: createToken("TOKEN_ERB_END", "%>"),

--- a/javascript/packages/printer/test/nodes/erb-until-node.test.ts
+++ b/javascript/packages/printer/test/nodes/erb-until-node.test.ts
@@ -12,10 +12,8 @@ describe("ERBUntilNode Printing", () => {
   })
 
   test("can print from node", () => {
-    const node = ERBUntilNode.from({
-      type: "AST_ERB_UNTIL_NODE",
+    const node = ERBUntilNode.build({
       location,
-      errors: [],
       tag_opening: createToken("TOKEN_ERB_START", "<%"),
       content: createToken("TOKEN_ERB_CONTENT", " until true "),
       tag_closing: createToken("TOKEN_ERB_END", "%>"),

--- a/javascript/packages/printer/test/nodes/erb-when-node.test.ts
+++ b/javascript/packages/printer/test/nodes/erb-when-node.test.ts
@@ -11,10 +11,8 @@ describe("ERBWhenNode Printing", () => {
   })
 
   test("can print from node", () => {
-    const node = ERBWhenNode.from({
-      type: "AST_ERB_WHEN_NODE",
+    const node = ERBWhenNode.build({
       location,
-      errors: [],
       tag_opening: createToken("TOKEN_ERB_START", "<%"),
       content: createToken("TOKEN_ERB_CONTENT", " when String "),
       tag_closing: createToken("TOKEN_ERB_END", "%>"),

--- a/javascript/packages/printer/test/nodes/erb-while-node.test.ts
+++ b/javascript/packages/printer/test/nodes/erb-while-node.test.ts
@@ -12,10 +12,8 @@ describe("ERBWhileNode Printing", () => {
   })
 
   test("can print from node", () => {
-    const node = ERBWhileNode.from({
-      type: "AST_ERB_WHILE_NODE",
+    const node = ERBWhileNode.build({
       location,
-      errors: [],
       tag_opening: createToken("TOKEN_ERB_START", "<%"),
       content: createToken("TOKEN_ERB_CONTENT", " while true "),
       tag_closing: createToken("TOKEN_ERB_END", "%>"),

--- a/javascript/packages/printer/test/nodes/erb-yield-node.test.ts
+++ b/javascript/packages/printer/test/nodes/erb-yield-node.test.ts
@@ -11,10 +11,8 @@ describe("ERBYieldNode Printing", () => {
   })
 
   test("can print from node", () => {
-    const node = ERBYieldNode.from({
-      type: "AST_ERB_YIELD_NODE",
+    const node = ERBYieldNode.build({
       location,
-      errors: [],
       tag_opening: createToken("TOKEN_ERB_START", "<%="),
       content: createToken("TOKEN_ERB_CONTENT", " yield "),
       tag_closing: createToken("TOKEN_ERB_END", "%>"),

--- a/javascript/packages/printer/test/nodes/html-attribute-name-node.test.ts
+++ b/javascript/packages/printer/test/nodes/html-attribute-name-node.test.ts
@@ -12,10 +12,8 @@ describe("HTMLAttributeNameNode Printing", () => {
   })
 
   test("can print from node", () => {
-    const node = HTMLAttributeNameNode.from({
-      type: "AST_HTML_ATTRIBUTE_NAME_NODE",
+    const node = HTMLAttributeNameNode.build({
       location,
-      errors: [],
       children: [createLiteralNode("class")]
     })
 

--- a/javascript/packages/printer/test/nodes/html-attribute-node.test.ts
+++ b/javascript/packages/printer/test/nodes/html-attribute-node.test.ts
@@ -5,19 +5,15 @@ import { HTMLAttributeNode, HTMLAttributeNameNode, HTMLAttributeValueNode } from
 
 import { expectNodeToPrint, expectPrintRoundTrip, location, createToken, createLiteralNode } from "../helpers/printer-test-helpers.js"
 
-const name = HTMLAttributeNameNode.from({
-  type: "AST_HTML_ATTRIBUTE_NAME_NODE",
+const name = HTMLAttributeNameNode.build({
   location,
-  errors: [],
   children: [
     createLiteralNode("id")
   ]
 })
 
-const value = HTMLAttributeValueNode.from({
-  type: "AST_HTML_ATTRIBUTE_VALUE_NODE",
+const value = HTMLAttributeValueNode.build({
   location,
-  errors: [],
   open_quote: createToken("TOKEN_QUOTE", `"`),
   close_quote: createToken("TOKEN_QUOTE", `"`),
   children: [
@@ -32,10 +28,8 @@ describe("HTMLAttributeNode Printing", () => {
   })
 
   test("can print from node", () => {
-    const node = HTMLAttributeNode.from({
-      type: "AST_HTML_ATTRIBUTE_NODE",
+    const node = HTMLAttributeNode.build({
       location,
-      errors: [],
       name,
       equals: createToken("TOKEN_EQUALS", "="),
       value

--- a/javascript/packages/printer/test/nodes/html-attribute-value-node.test.ts
+++ b/javascript/packages/printer/test/nodes/html-attribute-value-node.test.ts
@@ -11,10 +11,8 @@ describe("HTMLAttributeValueNode Printing", () => {
   })
 
   test("can print double quoted node", () => {
-    const node = HTMLAttributeValueNode.from({
-      type: "AST_HTML_ATTRIBUTE_VALUE_NODE",
+    const node = HTMLAttributeValueNode.build({
       location,
-      errors: [],
       open_quote: doubleQuote,
       close_quote: doubleQuote,
       children: [
@@ -27,10 +25,8 @@ describe("HTMLAttributeValueNode Printing", () => {
   })
 
   test("can print single quoted node", () => {
-    const node = HTMLAttributeValueNode.from({
-      type: "AST_HTML_ATTRIBUTE_VALUE_NODE",
+    const node = HTMLAttributeValueNode.build({
       location,
-      errors: [],
       open_quote: singleQuote,
       close_quote: singleQuote,
       children: [createLiteralNode("value")],
@@ -41,10 +37,8 @@ describe("HTMLAttributeValueNode Printing", () => {
   })
 
   test("can print unquoted node", () => {
-    const node = HTMLAttributeValueNode.from({
-      type: "AST_HTML_ATTRIBUTE_VALUE_NODE",
+    const node = HTMLAttributeValueNode.build({
       location,
-      errors: [],
       open_quote: null,
       close_quote: null,
       children: [createLiteralNode("value")],
@@ -55,10 +49,8 @@ describe("HTMLAttributeValueNode Printing", () => {
   })
 
   test("can print node with multiple children", () => {
-    const node = HTMLAttributeValueNode.from({
-      type: "AST_HTML_ATTRIBUTE_VALUE_NODE",
+    const node = HTMLAttributeValueNode.build({
       location,
-      errors: [],
       open_quote: doubleQuote,
       close_quote: doubleQuote,
       children: [
@@ -73,10 +65,8 @@ describe("HTMLAttributeValueNode Printing", () => {
   })
 
   test("can print node with multiple children and ERBContentNode", () => {
-    const node = HTMLAttributeValueNode.from({
-      type: "AST_HTML_ATTRIBUTE_VALUE_NODE",
+    const node = HTMLAttributeValueNode.build({
       location,
-      errors: [],
       open_quote: doubleQuote,
       close_quote: doubleQuote,
       children: [

--- a/javascript/packages/printer/test/nodes/html-close-tag-node.test.ts
+++ b/javascript/packages/printer/test/nodes/html-close-tag-node.test.ts
@@ -11,10 +11,8 @@ describe("HTMLCloseTagNode Printing", () => {
   })
 
   test("can print from node", () => {
-    const node = HTMLCloseTagNode.from({
-      type: "AST_HTML_CLOSE_TAG_NODE",
+    const node = HTMLCloseTagNode.build({
       location,
-      errors: [],
       tag_opening: createToken("TOKEN_HTML_TAG_START_CLOSE", "</"),
       tag_name: createToken("TOKEN_IDENTIFIER", "a"),
       tag_closing: createToken("TOKEN_HTML_TAG_END", ">")

--- a/javascript/packages/printer/test/nodes/html-comment-node.test.ts
+++ b/javascript/packages/printer/test/nodes/html-comment-node.test.ts
@@ -11,10 +11,8 @@ describe("HTMLCommentNode Printing", () => {
   })
 
   test("can print from node", () => {
-    const node = HTMLCommentNode.from({
-      type: "AST_HTML_COMMENT_NODE",
+    const node = HTMLCommentNode.build({
       location,
-      errors: [],
       comment_start: createToken("TOKEN_HTML_COMMENT_START", "<!--"),
       children: [
         createLiteralNode(" Content ")
@@ -26,10 +24,8 @@ describe("HTMLCommentNode Printing", () => {
   })
 
   test("can print from node with multiple children", () => {
-    const node = HTMLCommentNode.from({
-      type: "AST_HTML_COMMENT_NODE",
+    const node = HTMLCommentNode.build({
       location,
-      errors: [],
       comment_start: createToken("TOKEN_HTML_COMMENT_START", "<!--"),
       children: [
         createLiteralNode("One"),

--- a/javascript/packages/printer/test/nodes/html-conditional-open-tag-node.test.ts
+++ b/javascript/packages/printer/test/nodes/html-conditional-open-tag-node.test.ts
@@ -13,10 +13,8 @@ describe("HTMLConditionalOpenTagNode Printing", () => {
   })
 
   test("can print from manually constructed node", () => {
-    const open_tag_a = HTMLOpenTagNode.from({
-      type: "AST_HTML_OPEN_TAG_NODE",
+    const open_tag_a = HTMLOpenTagNode.build({
       location,
-      errors: [],
       tag_opening: createToken("TOKEN_HTML_TAG_START", "<"),
       tag_name: createToken("TOKEN_IDENTIFIER", "div"),
       tag_closing: createToken("TOKEN_HTML_TAG_END", ">"),
@@ -24,10 +22,8 @@ describe("HTMLConditionalOpenTagNode Printing", () => {
       is_void: false
     })
 
-    const open_tag_b = HTMLOpenTagNode.from({
-      type: "AST_HTML_OPEN_TAG_NODE",
+    const open_tag_b = HTMLOpenTagNode.build({
       location,
-      errors: [],
       tag_opening: createToken("TOKEN_HTML_TAG_START", "<"),
       tag_name: createToken("TOKEN_IDENTIFIER", "div"),
       tag_closing: createToken("TOKEN_HTML_TAG_END", ">"),
@@ -35,10 +31,8 @@ describe("HTMLConditionalOpenTagNode Printing", () => {
       is_void: false
     })
 
-    const else_node = ERBElseNode.from({
-      type: "AST_ERB_ELSE_NODE",
+    const else_node = ERBElseNode.build({
       location,
-      errors: [],
       tag_opening: createToken("TOKEN_ERB_START", "<%"),
       content: createToken("TOKEN_ERB_CONTENT", " else "),
       tag_closing: createToken("TOKEN_ERB_END", "%>"),
@@ -49,10 +43,8 @@ describe("HTMLConditionalOpenTagNode Printing", () => {
       ]
     })
 
-    const if_node = ERBIfNode.from({
-      type: "AST_ERB_IF_NODE",
+    const if_node = ERBIfNode.build({
       location,
-      errors: [],
       tag_opening: createToken("TOKEN_ERB_START", "<%"),
       content: createToken("TOKEN_ERB_CONTENT", " if condition "),
       tag_closing: createToken("TOKEN_ERB_END", "%>"),
@@ -65,10 +57,8 @@ describe("HTMLConditionalOpenTagNode Printing", () => {
       end_node
     })
 
-    const node = HTMLConditionalOpenTagNode.from({
-      type: "AST_HTML_CONDITIONAL_OPEN_TAG_NODE",
+    const node = HTMLConditionalOpenTagNode.build({
       location,
-      errors: [],
       conditional: if_node,
       tag_name: createToken("TOKEN_IDENTIFIER", "div"),
       is_void: false

--- a/javascript/packages/printer/test/nodes/html-doctype-node.test.ts
+++ b/javascript/packages/printer/test/nodes/html-doctype-node.test.ts
@@ -11,10 +11,8 @@ describe("HTMLDoctypeNode Printing", () => {
   })
 
   test("can print from node", () => {
-    const node = HTMLDoctypeNode.from({
-      type: "AST_HTML_DOCTYPE_NODE",
+    const node = HTMLDoctypeNode.build({
       location,
-      errors: [],
       tag_opening: createToken("TOKEN_HTML_DOCTYPE", "<!DOCTYPE"),
       children: [],
       tag_closing: createToken("TOKEN_HTML_TAG_END", ">")
@@ -24,10 +22,8 @@ describe("HTMLDoctypeNode Printing", () => {
   })
 
   test("can print from node with child", () => {
-    const node = HTMLDoctypeNode.from({
-      type: "AST_HTML_DOCTYPE_NODE",
+    const node = HTMLDoctypeNode.build({
       location,
-      errors: [],
       tag_opening: createToken("TOKEN_HTML_DOCTYPE", "<!doctype"),
       children: [
         createLiteralNode(" html5")

--- a/javascript/packages/printer/test/nodes/html-element-node.test.ts
+++ b/javascript/packages/printer/test/nodes/html-element-node.test.ts
@@ -41,10 +41,8 @@ describe("HTMLElementNode Printing", () => {
   })
 
   test("can print from node", () => {
-    const open_tag = HTMLOpenTagNode.from({
-      type: "AST_HTML_OPEN_TAG_NODE",
+    const open_tag = HTMLOpenTagNode.build({
       location,
-      errors: [],
       tag_opening: createToken("TOKEN_HTML_TAG_START", "<"),
       tag_name: createToken("TOKEN_IDENTIFIER", "a"),
       tag_closing: createToken("TOKEN_HTML_TAG_END", ">"),
@@ -52,19 +50,15 @@ describe("HTMLElementNode Printing", () => {
       is_void: true
     })
 
-    const close_tag = HTMLCloseTagNode.from({
-      type: "AST_HTML_CLOSE_TAG_NODE",
+    const close_tag = HTMLCloseTagNode.build({
       location,
-      errors: [],
       tag_opening: createToken("TOKEN_HTML_TAG_START_CLOSE", "</"),
       tag_name: createToken("TOKEN_IDENTIFIER", "a"),
       tag_closing: createToken("TOKEN_HTML_TAG_END", ">")
     })
 
-    const node = HTMLElementNode.from({
-      type: "AST_HTML_ELEMENT_NODE",
+    const node = HTMLElementNode.build({
       location,
-      errors: [],
       open_tag,
       tag_name: createToken("TOKEN_IDENTIFIER", "a"),
       body: [

--- a/javascript/packages/printer/test/nodes/html-omitted-close-tag-node.test.ts
+++ b/javascript/packages/printer/test/nodes/html-omitted-close-tag-node.test.ts
@@ -22,10 +22,8 @@ describe("HTMLOmittedCloseTagNode Printing", () => {
   })
 
   test("can print from manually constructed node - prints nothing", () => {
-    const node = HTMLOmittedCloseTagNode.from({
-      type: "AST_HTML_OMITTED_CLOSE_TAG_NODE",
+    const node = HTMLOmittedCloseTagNode.build({
       location,
-      errors: [],
       tag_name: createToken("TOKEN_IDENTIFIER", "p"),
     })
 

--- a/javascript/packages/printer/test/nodes/html-open-tag-node.test.ts
+++ b/javascript/packages/printer/test/nodes/html-open-tag-node.test.ts
@@ -11,10 +11,8 @@ describe("HTMLOpenTagNode Printing", () => {
   })
 
   test("can print from node with void=false", () => {
-    const node = HTMLOpenTagNode.from({
-      type: "AST_HTML_OPEN_TAG_NODE",
+    const node = HTMLOpenTagNode.build({
       location,
-      errors: [],
       tag_opening: createToken("TOKEN_HTML_TAG_START", "<"),
       tag_name: createToken("TOKEN_IDENTIFIER", "a"),
       tag_closing: createToken("TOKEN_HTML_TAG_END", ">"),
@@ -26,10 +24,8 @@ describe("HTMLOpenTagNode Printing", () => {
   })
 
   test("can print from node with void=true", () => {
-    const node = HTMLOpenTagNode.from({
-      type: "AST_HTML_OPEN_TAG_NODE",
+    const node = HTMLOpenTagNode.build({
       location,
-      errors: [],
       tag_opening: createToken("TOKEN_HTML_TAG_START", "<"),
       tag_name: createToken("TOKEN_IDENTIFIER", "a"),
       tag_closing: createToken("TOKEN_HTML_TAG_END", "/>"),

--- a/javascript/packages/printer/test/nodes/html-text-node.test.ts
+++ b/javascript/packages/printer/test/nodes/html-text-node.test.ts
@@ -11,10 +11,8 @@ describe("HTMLTextNode Printing", () => {
   })
 
   test("can print from node", () => {
-    const node = HTMLTextNode.from({
-      type: "AST_HTML_TEXT_NODE",
+    const node = HTMLTextNode.build({
       location,
-      errors: [],
       content: "example_content"
     })
 

--- a/javascript/packages/printer/test/nodes/html-virtual-close-tag-node.test.ts
+++ b/javascript/packages/printer/test/nodes/html-virtual-close-tag-node.test.ts
@@ -11,10 +11,8 @@ describe("HTMLVirtualCloseTagNode Printing", () => {
   })
 
   test("can print from node - prints nothing", () => {
-    const node = HTMLVirtualCloseTagNode.from({
-      type: "AST_HTML_VIRTUAL_CLOSE_TAG_NODE",
+    const node = HTMLVirtualCloseTagNode.build({
       location,
-      errors: [],
       tag_name: createToken("TOKEN_IDENTIFIER", "div")
     })
 
@@ -22,10 +20,8 @@ describe("HTMLVirtualCloseTagNode Printing", () => {
   })
 
   test("can print from node with null tag_name - prints nothing", () => {
-    const node = HTMLVirtualCloseTagNode.from({
-      type: "AST_HTML_VIRTUAL_CLOSE_TAG_NODE",
+    const node = HTMLVirtualCloseTagNode.build({
       location,
-      errors: [],
       tag_name: null
     })
 
@@ -33,10 +29,8 @@ describe("HTMLVirtualCloseTagNode Printing", () => {
   })
 
   test("can print from node for a", () => {
-    const node = HTMLVirtualCloseTagNode.from({
-      type: "AST_HTML_VIRTUAL_CLOSE_TAG_NODE",
+    const node = HTMLVirtualCloseTagNode.build({
       location,
-      errors: [],
       tag_name: createToken("TOKEN_IDENTIFIER", "a")
     })
 
@@ -44,10 +38,8 @@ describe("HTMLVirtualCloseTagNode Printing", () => {
   })
 
   test("can print from node for div", () => {
-    const node = HTMLVirtualCloseTagNode.from({
-      type: "AST_HTML_VIRTUAL_CLOSE_TAG_NODE",
+    const node = HTMLVirtualCloseTagNode.build({
       location,
-      errors: [],
       tag_name: createToken("TOKEN_IDENTIFIER", "div")
     })
 

--- a/javascript/packages/printer/test/nodes/literal-node.test.ts
+++ b/javascript/packages/printer/test/nodes/literal-node.test.ts
@@ -11,10 +11,8 @@ describe("LiteralNode Printing", () => {
   })
 
   test("can print from node", () => {
-    const node = LiteralNode.from({
-      type: "AST_LITERAL_NODE",
+    const node = LiteralNode.build({
       location,
-      errors: [],
       content: "example_content"
     })
 

--- a/javascript/packages/printer/test/nodes/ruby-html-attributes-splat-node.test.ts
+++ b/javascript/packages/printer/test/nodes/ruby-html-attributes-splat-node.test.ts
@@ -11,10 +11,8 @@ describe("RubyHTMLAttributesSplatNode Printing", () => {
   })
 
   test("can print double splat", () => {
-    const node = RubyHTMLAttributesSplatNode.from({
-      type: "AST_RUBY_HTML_ATTRIBUTES_SPLAT_NODE",
+    const node = RubyHTMLAttributesSplatNode.build({
       location,
-      errors: [],
       content: "**options",
       prefix: ""
     })
@@ -23,10 +21,8 @@ describe("RubyHTMLAttributesSplatNode Printing", () => {
   })
 
   test("can print splat with variable", () => {
-    const node = RubyHTMLAttributesSplatNode.from({
-      type: "AST_RUBY_HTML_ATTRIBUTES_SPLAT_NODE",
+    const node = RubyHTMLAttributesSplatNode.build({
       location,
-      errors: [],
       content: "**html_attrs",
       prefix: ""
     })
@@ -35,10 +31,8 @@ describe("RubyHTMLAttributesSplatNode Printing", () => {
   })
 
   test("can print splat with method call", () => {
-    const node = RubyHTMLAttributesSplatNode.from({
-      type: "AST_RUBY_HTML_ATTRIBUTES_SPLAT_NODE",
+    const node = RubyHTMLAttributesSplatNode.build({
       location,
-      errors: [],
       content: "**data_attributes(user)",
       prefix: ""
     })
@@ -47,10 +41,8 @@ describe("RubyHTMLAttributesSplatNode Printing", () => {
   })
 
   test("can print with prefix", () => {
-    const node = RubyHTMLAttributesSplatNode.from({
-      type: "AST_RUBY_HTML_ATTRIBUTES_SPLAT_NODE",
+    const node = RubyHTMLAttributesSplatNode.build({
       location,
-      errors: [],
       content: "**options",
       prefix: "data"
     })

--- a/javascript/packages/printer/test/nodes/ruby-literal-node.test.ts
+++ b/javascript/packages/printer/test/nodes/ruby-literal-node.test.ts
@@ -11,10 +11,8 @@ describe("RubyLiteralNode Printing", () => {
   })
 
   test("can print integer content", () => {
-    const node = RubyLiteralNode.from({
-      type: "AST_RUBY_LITERAL_NODE",
+    const node = RubyLiteralNode.build({
       location,
-      errors: [],
       content: "123"
     })
 
@@ -22,10 +20,8 @@ describe("RubyLiteralNode Printing", () => {
   })
 
   test("can print string content", () => {
-    const node = RubyLiteralNode.from({
-      type: "AST_RUBY_LITERAL_NODE",
+    const node = RubyLiteralNode.build({
       location,
-      errors: [],
       content: "hello"
     })
 
@@ -33,10 +29,8 @@ describe("RubyLiteralNode Printing", () => {
   })
 
   test("can print boolean content", () => {
-    const node = RubyLiteralNode.from({
-      type: "AST_RUBY_LITERAL_NODE",
+    const node = RubyLiteralNode.build({
       location,
-      errors: [],
       content: "true"
     })
 
@@ -44,10 +38,8 @@ describe("RubyLiteralNode Printing", () => {
   })
 
   test("can print method call content", () => {
-    const node = RubyLiteralNode.from({
-      type: "AST_RUBY_LITERAL_NODE",
+    const node = RubyLiteralNode.build({
       location,
-      errors: [],
       content: "@user.name"
     })
 
@@ -55,10 +47,8 @@ describe("RubyLiteralNode Printing", () => {
   })
 
   test("can print empty content", () => {
-    const node = RubyLiteralNode.from({
-      type: "AST_RUBY_LITERAL_NODE",
+    const node = RubyLiteralNode.build({
       location,
-      errors: [],
       content: ""
     })
 

--- a/javascript/packages/printer/test/nodes/ruby-parameter-node.test.ts
+++ b/javascript/packages/printer/test/nodes/ruby-parameter-node.test.ts
@@ -12,10 +12,8 @@ describe("RubyParameterNode Printing", () => {
   })
 
   test("prints nothing from constructed node", () => {
-    const node = RubyParameterNode.from({
-      type: "AST_RUBY_PARAMETER_NODE",
+    const node = RubyParameterNode.build({
       location: createLocation(),
-      errors: [],
       name: createToken("TOKEN_IDENTIFIER", "user"),
       default_value: null,
       required: true,

--- a/javascript/packages/printer/test/nodes/ruby-render-keywords-node.test.ts
+++ b/javascript/packages/printer/test/nodes/ruby-render-keywords-node.test.ts
@@ -11,10 +11,8 @@ describe("RubyRenderKeywordsNode Printing", () => {
   })
 
   test("prints nothing from constructed node", () => {
-    const node = RubyRenderKeywordsNode.from({
-      type: "AST_RUBY_RENDER_KEYWORDS_NODE",
+    const node = RubyRenderKeywordsNode.build({
       location: createLocation(),
-      errors: [],
       partial: createToken("TOKEN_IDENTIFIER", "shared/header"),
       template_path: null,
       layout: null,

--- a/javascript/packages/printer/test/nodes/ruby-render-local-node.test.ts
+++ b/javascript/packages/printer/test/nodes/ruby-render-local-node.test.ts
@@ -15,7 +15,7 @@ describe("RubyRenderLocalNode", () => {
       type: "AST_RUBY_RENDER_LOCAL_NODE",
       location: createLocation(),
       errors: [],
-      name: createToken("TOKEN_IDENTIFIER", "title"),
+      name: createToken("TOKEN_IDENTIFIER", "title").toJSON(),
       value: {
         type: "AST_RUBY_LITERAL_NODE",
         location: createLocation(),
@@ -31,17 +31,10 @@ describe("RubyRenderLocalNode", () => {
   })
 
   test("prints nothing (metadata node)", () => {
-    const node = RubyRenderLocalNode.from({
-      type: "AST_RUBY_RENDER_LOCAL_NODE",
+    const node = RubyRenderLocalNode.build({
       location: createLocation(),
-      errors: [],
       name: createToken("TOKEN_IDENTIFIER", "title"),
-      value: {
-        type: "AST_RUBY_LITERAL_NODE",
-        location: createLocation(),
-        errors: [],
-        content: "@title"
-      }
+      value: RubyLiteralNode.build({ location: createLocation(), content: "@title" })
     })
 
     expectNodeToPrint(node, "")

--- a/javascript/packages/printer/test/nodes/whitespace-node.test.ts
+++ b/javascript/packages/printer/test/nodes/whitespace-node.test.ts
@@ -11,10 +11,8 @@ describe("WhitespaceNode Printing", () => {
   })
 
   test("can print from node", () => {
-    const node = WhitespaceNode.from({
-      type: "AST_WHITESPACE_NODE",
+    const node = WhitespaceNode.build({
       location,
-      errors: [],
       value: createToken("TOKEN_WHITESPACE", "")
     })
 

--- a/javascript/packages/printer/test/nodes/xml-declaration-node.test.ts
+++ b/javascript/packages/printer/test/nodes/xml-declaration-node.test.ts
@@ -12,17 +12,13 @@ describe("XMLDeclarationNode Printing", () => {
   })
 
   test("can print basic XML declaration from node", () => {
-    const literalNode = LiteralNode.from({
-      type: "AST_LITERAL_NODE",
+    const literalNode = LiteralNode.build({
       location: createLocation(),
-      errors: [],
       content: " version=\"1.0\""
     })
 
-    const node = XMLDeclarationNode.from({
-      type: "AST_XML_DECLARATION_NODE",
+    const node = XMLDeclarationNode.build({
       location: createLocation(),
-      errors: [],
       tag_opening: createToken("TOKEN_XML_DECLARATION", "<?xml"),
       children: [literalNode],
       tag_closing: createToken("TOKEN_HTML_TAG_END", "?>")
@@ -32,17 +28,13 @@ describe("XMLDeclarationNode Printing", () => {
   })
 
   test("can print XML declaration with encoding from node", () => {
-    const literalNode = LiteralNode.from({
-      type: "AST_LITERAL_NODE",
+    const literalNode = LiteralNode.build({
       location: createLocation(),
-      errors: [],
       content: " version=\"1.0\" encoding=\"UTF-8\""
     })
 
-    const node = XMLDeclarationNode.from({
-      type: "AST_XML_DECLARATION_NODE",
+    const node = XMLDeclarationNode.build({
       location: createLocation(),
-      errors: [],
       tag_opening: createToken("TOKEN_XML_DECLARATION", "<?xml"),
       children: [literalNode],
       tag_closing: createToken("TOKEN_HTML_TAG_END", "?>")

--- a/javascript/packages/rewriter/src/built-ins/action-view-tag-helper-to-html.ts
+++ b/javascript/packages/rewriter/src/built-ins/action-view-tag-helper-to-html.ts
@@ -1,5 +1,5 @@
 import { Visitor, HTMLOpenTagNode, HTMLCloseTagNode, HTMLElementNode, HTMLAttributeValueNode, WhitespaceNode, ERBContentNode } from "@herb-tools/core"
-import { isHTMLAttributeNode, isERBOpenTagNode, isRubyLiteralNode, isRubyHTMLAttributesSplatNode, isWhitespaceNode, createSyntheticToken } from "@herb-tools/core"
+import { isHTMLAttributeNode, isERBOpenTagNode, isRubyLiteralNode, isRubyHTMLAttributesSplatNode, isWhitespaceNode, Token } from "@herb-tools/core"
 
 import { ASTRewriter } from "../ast-rewriter.js"
 import { asMutable } from "../mutable.js"
@@ -8,7 +8,7 @@ import type { RewriteContext } from "../context.js"
 import type { Node } from "@herb-tools/core"
 
 function createWhitespaceNode(): WhitespaceNode {
-  return WhitespaceNode.build({ value: createSyntheticToken(" ") })
+  return WhitespaceNode.build({ value: Token.from("TOKEN_WHITESPACE", " ") })
 }
 
 class ActionViewTagHelperToHTMLVisitor extends Visitor {
@@ -29,7 +29,7 @@ class ActionViewTagHelperToHTMLVisitor extends Visitor {
 
       if (isHTMLAttributeNode(child)) {
         if (child.equals && child.equals.value !== "=") {
-          asMutable(child).equals = createSyntheticToken("=")
+          asMutable(child).equals = Token.from("TOKEN_EQUALS", "=")
         }
 
         if (child.value) {
@@ -78,9 +78,9 @@ class ActionViewTagHelperToHTMLVisitor extends Visitor {
         htmlChildren.push(createWhitespaceNode())
 
         htmlChildren.push(ERBContentNode.build({
-          tag_opening: createSyntheticToken("<%="),
-          content: createSyntheticToken(` ${child.content} `),
-          tag_closing: createSyntheticToken("%>"),
+          tag_opening: Token.from("TOKEN_ERB_START", "<%="),
+          content: Token.from("TOKEN_ERB_CONTENT", ` ${child.content} `),
+          tag_closing: Token.from("TOKEN_ERB_END", "%>"),
           valid: true,
         }))
 
@@ -91,7 +91,7 @@ class ActionViewTagHelperToHTMLVisitor extends Visitor {
 
       if (isHTMLAttributeNode(child)) {
         if (child.equals && child.equals.value !== "=") {
-          asMutable(child).equals = createSyntheticToken("=")
+          asMutable(child).equals = Token.from("TOKEN_EQUALS", "=")
         }
 
         if (child.value) {
@@ -104,9 +104,9 @@ class ActionViewTagHelperToHTMLVisitor extends Visitor {
 
     const htmlOpenTag = HTMLOpenTagNode.build({
       location: openTag.location,
-      tag_opening: createSyntheticToken("<"),
-      tag_name: createSyntheticToken(tagName.value),
-      tag_closing: createSyntheticToken(node.is_void ? " />" : ">"),
+      tag_opening: Token.from("TOKEN_HTML_TAG_START", "<"),
+      tag_name: Token.from("TOKEN_IDENTIFIER", tagName.value),
+      tag_closing: node.is_void ? Token.from("TOKEN_HTML_TAG_SELF_CLOSE", " />") : Token.from("TOKEN_HTML_TAG_END", ">"),
       children: htmlChildren,
       is_void: node.is_void,
     })
@@ -118,9 +118,9 @@ class ActionViewTagHelperToHTMLVisitor extends Visitor {
     } else if (node.close_tag) {
       const htmlCloseTag = HTMLCloseTagNode.build({
         location: node.close_tag.location,
-        tag_opening: createSyntheticToken("</"),
-        tag_name: createSyntheticToken(tagName.value),
-        tag_closing: createSyntheticToken(">"),
+        tag_opening: Token.from("TOKEN_HTML_TAG_START_CLOSE", "</"),
+        tag_name: Token.from("TOKEN_IDENTIFIER", tagName.value),
+        tag_closing: Token.from("TOKEN_HTML_TAG_END", ">"),
       })
 
       asMutable(node).close_tag = htmlCloseTag
@@ -135,9 +135,9 @@ class ActionViewTagHelperToHTMLVisitor extends Visitor {
         if (isRubyLiteralNode(child)) {
           return ERBContentNode.build({
             location: child.location,
-            tag_opening: createSyntheticToken("<%="),
-            content: createSyntheticToken(` ${child.content} `),
-            tag_closing: createSyntheticToken("%>"),
+            tag_opening: Token.from("TOKEN_ERB_START", "<%="),
+            content: Token.from("TOKEN_ERB_CONTENT", ` ${child.content} `),
+            tag_closing: Token.from("TOKEN_ERB_END", "%>"),
             valid: true,
           })
         }
@@ -160,9 +160,9 @@ class ActionViewTagHelperToHTMLVisitor extends Visitor {
         if (isRubyLiteralNode(child)) {
           return ERBContentNode.build({
             location: child.location,
-            tag_opening: createSyntheticToken("<%="),
-            content: createSyntheticToken(` ${child.content} `),
-            tag_closing: createSyntheticToken("%>"),
+            tag_opening: Token.from("TOKEN_ERB_START", "<%="),
+            content: Token.from("TOKEN_ERB_CONTENT", ` ${child.content} `),
+            tag_closing: Token.from("TOKEN_ERB_END", "%>"),
             valid: true,
           })
         }
@@ -175,8 +175,8 @@ class ActionViewTagHelperToHTMLVisitor extends Visitor {
 
     if (!value.quoted) {
       mutableValue.quoted = true
-      mutableValue.open_quote = createSyntheticToken('"')
-      mutableValue.close_quote = createSyntheticToken('"')
+      mutableValue.open_quote = Token.from("TOKEN_QUOTE", '"')
+      mutableValue.close_quote = Token.from("TOKEN_QUOTE", '"')
     }
   }
 }

--- a/javascript/packages/rewriter/src/built-ins/action-view-tag-helper-to-html.ts
+++ b/javascript/packages/rewriter/src/built-ins/action-view-tag-helper-to-html.ts
@@ -1,4 +1,4 @@
-import { Visitor, Location, HTMLOpenTagNode, HTMLCloseTagNode, HTMLElementNode, HTMLAttributeValueNode, WhitespaceNode, ERBContentNode } from "@herb-tools/core"
+import { Visitor, HTMLOpenTagNode, HTMLCloseTagNode, HTMLElementNode, HTMLAttributeValueNode, WhitespaceNode, ERBContentNode } from "@herb-tools/core"
 import { isHTMLAttributeNode, isERBOpenTagNode, isRubyLiteralNode, isRubyHTMLAttributesSplatNode, isWhitespaceNode, createSyntheticToken } from "@herb-tools/core"
 
 import { ASTRewriter } from "../ast-rewriter.js"
@@ -8,12 +8,7 @@ import type { RewriteContext } from "../context.js"
 import type { Node } from "@herb-tools/core"
 
 function createWhitespaceNode(): WhitespaceNode {
-  return new WhitespaceNode({
-    type: "AST_WHITESPACE_NODE",
-    location: Location.zero,
-    errors: [],
-    value: createSyntheticToken(" "),
-  })
+  return WhitespaceNode.build({ value: createSyntheticToken(" ") })
 }
 
 class ActionViewTagHelperToHTMLVisitor extends Visitor {
@@ -82,16 +77,11 @@ class ActionViewTagHelperToHTMLVisitor extends Visitor {
       if (isRubyHTMLAttributesSplatNode(child)) {
         htmlChildren.push(createWhitespaceNode())
 
-        htmlChildren.push(new ERBContentNode({
-          type: "AST_ERB_CONTENT_NODE",
-          location: Location.zero,
-          errors: [],
+        htmlChildren.push(ERBContentNode.build({
           tag_opening: createSyntheticToken("<%="),
           content: createSyntheticToken(` ${child.content} `),
           tag_closing: createSyntheticToken("%>"),
-          parsed: false,
           valid: true,
-          prism_node: null,
         }))
 
         continue
@@ -112,10 +102,8 @@ class ActionViewTagHelperToHTMLVisitor extends Visitor {
       }
     }
 
-    const htmlOpenTag = new HTMLOpenTagNode({
-      type: "AST_HTML_OPEN_TAG_NODE",
+    const htmlOpenTag = HTMLOpenTagNode.build({
       location: openTag.location,
-      errors: [],
       tag_opening: createSyntheticToken("<"),
       tag_name: createSyntheticToken(tagName.value),
       tag_closing: createSyntheticToken(node.is_void ? " />" : ">"),
@@ -128,13 +116,10 @@ class ActionViewTagHelperToHTMLVisitor extends Visitor {
     if (node.is_void) {
       asMutable(node).close_tag = null
     } else if (node.close_tag) {
-      const htmlCloseTag = new HTMLCloseTagNode({
-        type: "AST_HTML_CLOSE_TAG_NODE",
+      const htmlCloseTag = HTMLCloseTagNode.build({
         location: node.close_tag.location,
-        errors: [],
         tag_opening: createSyntheticToken("</"),
         tag_name: createSyntheticToken(tagName.value),
-        children: [],
         tag_closing: createSyntheticToken(">"),
       })
 
@@ -148,16 +133,12 @@ class ActionViewTagHelperToHTMLVisitor extends Visitor {
     } else if (node.body) {
       asMutable(node).body = node.body.map(child => {
         if (isRubyLiteralNode(child)) {
-          return new ERBContentNode({
-            type: "AST_ERB_CONTENT_NODE",
+          return ERBContentNode.build({
             location: child.location,
-            errors: [],
             tag_opening: createSyntheticToken("<%="),
             content: createSyntheticToken(` ${child.content} `),
             tag_closing: createSyntheticToken("%>"),
-            parsed: false,
             valid: true,
-            prism_node: null
           })
         }
 
@@ -177,16 +158,12 @@ class ActionViewTagHelperToHTMLVisitor extends Visitor {
     if (hasRubyLiteral) {
       const newChildren: Node[] = value.children.map(child => {
         if (isRubyLiteralNode(child)) {
-          return new ERBContentNode({
-            type: "AST_ERB_CONTENT_NODE",
+          return ERBContentNode.build({
             location: child.location,
-            errors: [],
             tag_opening: createSyntheticToken("<%="),
             content: createSyntheticToken(` ${child.content} `),
             tag_closing: createSyntheticToken("%>"),
-            parsed: false,
             valid: true,
-            prism_node: null,
           })
         }
 

--- a/javascript/packages/rewriter/src/built-ins/html-to-action-view-tag-helper.ts
+++ b/javascript/packages/rewriter/src/built-ins/html-to-action-view-tag-helper.ts
@@ -1,4 +1,4 @@
-import { Visitor, Location, ERBOpenTagNode, ERBEndNode, HTMLElementNode, HTMLVirtualCloseTagNode, createSyntheticToken, findPreferredHelperForTag, HELPER_REGISTRY } from "@herb-tools/core"
+import { Visitor, ERBOpenTagNode, ERBEndNode, HTMLElementNode, HTMLVirtualCloseTagNode, createSyntheticToken, findPreferredHelperForTag, HELPER_REGISTRY } from "@herb-tools/core"
 import { getStaticAttributeName, isLiteralNode, isHTMLOpenTagNode, isHTMLTextNode, isHTMLAttributeNode, isERBContentNode, isWhitespaceNode } from "@herb-tools/core"
 
 import { ASTRewriter } from "../ast-rewriter.js"
@@ -156,15 +156,12 @@ class HTMLToActionViewTagHelperVisitor extends Visitor {
       elementSource = HELPER_REGISTRY["tag"].source
     }
 
-    const erbOpenTag = new ERBOpenTagNode({
-      type: "AST_ERB_OPEN_TAG_NODE",
+    const erbOpenTag = ERBOpenTagNode.build({
       location: openTag.location,
-      errors: [],
       tag_opening: createSyntheticToken("<%="),
       content: createSyntheticToken(content),
       tag_closing: createSyntheticToken("%>"),
       tag_name: createSyntheticToken(tagName.value),
-      children: [],
     })
 
     asMutable(node).open_tag = erbOpenTag
@@ -180,19 +177,14 @@ class HTMLToActionViewTagHelperVisitor extends Visitor {
     } else if (isInlineForm) {
       asMutable(node).body = []
 
-      const virtualClose = new HTMLVirtualCloseTagNode({
-        type: "AST_HTML_VIRTUAL_CLOSE_TAG_NODE",
-        location: Location.zero,
-        errors: [],
+      const virtualClose = HTMLVirtualCloseTagNode.build({
         tag_name: createSyntheticToken(tagName.value),
       })
 
       asMutable(node).close_tag = virtualClose
     } else if (node.close_tag) {
-      const erbEnd = new ERBEndNode({
-        type: "AST_ERB_END_NODE",
+      const erbEnd = ERBEndNode.build({
         location: node.close_tag.location,
-        errors: [],
         tag_opening: createSyntheticToken("<%"),
         content: createSyntheticToken(" end "),
         tag_closing: createSyntheticToken("%>"),

--- a/javascript/packages/rewriter/src/built-ins/html-to-action-view-tag-helper.ts
+++ b/javascript/packages/rewriter/src/built-ins/html-to-action-view-tag-helper.ts
@@ -1,4 +1,4 @@
-import { Visitor, ERBOpenTagNode, ERBEndNode, HTMLElementNode, HTMLVirtualCloseTagNode, createSyntheticToken, findPreferredHelperForTag, HELPER_REGISTRY } from "@herb-tools/core"
+import { Visitor, ERBOpenTagNode, ERBEndNode, HTMLElementNode, HTMLVirtualCloseTagNode, Token, findPreferredHelperForTag, HELPER_REGISTRY } from "@herb-tools/core"
 import { getStaticAttributeName, isLiteralNode, isHTMLOpenTagNode, isHTMLTextNode, isHTMLAttributeNode, isERBContentNode, isWhitespaceNode } from "@herb-tools/core"
 
 import { ASTRewriter } from "../ast-rewriter.js"
@@ -158,10 +158,10 @@ class HTMLToActionViewTagHelperVisitor extends Visitor {
 
     const erbOpenTag = ERBOpenTagNode.build({
       location: openTag.location,
-      tag_opening: createSyntheticToken("<%="),
-      content: createSyntheticToken(content),
-      tag_closing: createSyntheticToken("%>"),
-      tag_name: createSyntheticToken(tagName.value),
+      tag_opening: Token.from("TOKEN_ERB_START", "<%="),
+      content: Token.from("TOKEN_ERB_CONTENT", content),
+      tag_closing: Token.from("TOKEN_ERB_END", "%>"),
+      tag_name: Token.from("TOKEN_IDENTIFIER", tagName.value),
     })
 
     asMutable(node).open_tag = erbOpenTag
@@ -178,16 +178,16 @@ class HTMLToActionViewTagHelperVisitor extends Visitor {
       asMutable(node).body = []
 
       const virtualClose = HTMLVirtualCloseTagNode.build({
-        tag_name: createSyntheticToken(tagName.value),
+        tag_name: Token.from("TOKEN_IDENTIFIER", tagName.value),
       })
 
       asMutable(node).close_tag = virtualClose
     } else if (node.close_tag) {
       const erbEnd = ERBEndNode.build({
         location: node.close_tag.location,
-        tag_opening: createSyntheticToken("<%"),
-        content: createSyntheticToken(" end "),
-        tag_closing: createSyntheticToken("%>"),
+        tag_opening: Token.from("TOKEN_ERB_START", "<%"),
+        content: Token.from("TOKEN_ERB_CONTENT", " end "),
+        tag_closing: Token.from("TOKEN_ERB_END", "%>"),
       })
 
       asMutable(node).close_tag = erbEnd

--- a/javascript/packages/rewriter/src/built-ins/tailwind-class-sorter.ts
+++ b/javascript/packages/rewriter/src/built-ins/tailwind-class-sorter.ts
@@ -1,5 +1,5 @@
 import { getStaticAttributeName, isLiteralNode, isPureWhitespaceNode, splitLiteralsAtWhitespace, groupNodesByClass } from "@herb-tools/core"
-import { LiteralNode, Location, Visitor } from "@herb-tools/core"
+import { LiteralNode, Visitor } from "@herb-tools/core"
 
 import { TailwindClassSorter } from "@herb-tools/tailwind-class-sorter"
 import { ASTRewriter } from "../ast-rewriter.js"
@@ -140,12 +140,7 @@ class ClassAttributeSorter extends Visitor {
   }
 
   private get spaceLiteral(): LiteralNode {
-    return new LiteralNode({
-      type: "AST_LITERAL_NODE",
-      content: " ",
-      errors: [],
-      location: Location.zero
-    })
+    return LiteralNode.build({ content: " " })
   }
 
   private isInterpolatedGroup(group: Node[]): boolean {
@@ -253,12 +248,7 @@ class ClassAttributeSorter extends Visitor {
     const parts: Node[] = []
 
     if (sortedContent) {
-      parts.push(new LiteralNode({
-        type: "AST_LITERAL_NODE",
-        content: sortedContent,
-        errors: [],
-        location: Location.zero
-      }))
+      parts.push(LiteralNode.build({ content: sortedContent }))
     }
 
     for (const group of interpolationGroups) {
@@ -297,12 +287,7 @@ class ClassAttributeSorter extends Visitor {
       const trimmed = first.content.trimStart()
 
       if (trimmed !== first.content) {
-        result[0] = new LiteralNode({
-          type: "AST_LITERAL_NODE",
-          content: trimmed,
-          errors: [],
-          location: first.location
-        })
+        result[0] = LiteralNode.build({ content: trimmed, location: first.location })
       }
     }
 
@@ -313,12 +298,7 @@ class ClassAttributeSorter extends Visitor {
       const trimmed = last.content.trimEnd()
 
       if (trimmed !== last.content) {
-        result[lastIndex] = new LiteralNode({
-          type: "AST_LITERAL_NODE",
-          content: trimmed,
-          errors: [],
-          location: last.location
-        })
+        result[lastIndex] = LiteralNode.build({ content: trimmed, location: last.location })
       }
     }
 

--- a/templates/javascript/packages/core/src/nodes.ts.erb
+++ b/templates/javascript/packages/core/src/nodes.ts.erb
@@ -289,6 +289,31 @@ export class <%= node.name %> extends Node {
     })
   }
 
+  static build(props: Partial<Omit<<%= node.name %>Props, "type">> = {}): <%= node.name %> {
+    return new <%= node.name %>({
+      type: "<%= node.type %>",
+      location: Location.zero,
+      errors: [],
+      <%- node.fields.each do |field| -%>
+      <%- case field -%>
+      <%- when Herb::Template::StringField, Herb::Template::ElementSourceField -%>
+      <%= field.name %>: "",
+      <%- when Herb::Template::BooleanField -%>
+      <%= field.name %>: false,
+      <%- when Herb::Template::ArrayField -%>
+      <%= field.name %>: [],
+      <%- when Herb::Template::TokenField, Herb::Template::LocationField, Herb::Template::NodeField, Herb::Template::BorrowedNodeField, Herb::Template::PrismSerializedField, Herb::Template::PrismNodeField -%>
+      <%= field.name %>: null,
+      <%- when Herb::Template::AnalyzedRubyField, Herb::Template::PrismContextField -%>
+      // no-op for <%= field.name %>
+      <%- else -%>
+      <% raise "Unhandled class #{field.class}" %>
+      <%- end -%>
+      <%- end -%>
+      ...props,
+    })
+  }
+
   constructor(props: <%= node.name %>Props) {
     super(props.type, props.location, props.errors);
     <%- node.fields.each do |field| -%>


### PR DESCRIPTION
Follow up on #2055, which added generated `build` factories to the Ruby AST nodes. This pull request does the same for the TypeScript nodes in `@herb-tools/core`.

The TypeScript constructors already take a props object, so there was never any positional argument soup to fix here. What they did have is a `type` discriminator restated at every construction site, a mandatory `errors: []`, and a `Props` interface where every field is required, so you have to spell out the nulls you don't care about:

```ts
new ERBContentNode({
  type: "AST_ERB_CONTENT_NODE",
  location: Location.zero,
  errors: [],
  tag_opening: createSyntheticToken("<%="),
  content: createSyntheticToken(` ${child.content} `),
  tag_closing: createSyntheticToken("%>"),
  parsed: false,
  valid: true,
  prism_node: null,
})
```

The example above becomes:

```ts
ERBContentNode.build({
  tag_opening: Token.from("TOKEN_ERB_START", "<%="),
  content: Token.from("TOKEN_ERB_CONTENT", ` ${child.content} `),
  tag_closing: Token.from("TOKEN_ERB_END", "%>"),
  valid: true,
})
```