### PR TITLE
Linter: Implement `actionview-no-dynamic-partial-path` rule

### DIFF
--- a/javascript/packages/linter/docs/rules/README.md
+++ b/javascript/packages/linter/docs/rules/README.md
@@ -18,6 +18,7 @@ This page contains documentation for all Herb Linter rules.
 
 #### Action View
 
+- [`actionview-no-dynamic-partial-path`](./actionview-no-dynamic-partial-path.md) - Disallow partial paths that are built at runtime
 - [`actionview-no-helper-shadowing`](./actionview-no-helper-shadowing.md) - Disallow shadowing Action View helpers with block variables
 - [`actionview-no-implicit-polymorphic-url`](./actionview-no-implicit-polymorphic-url.md) - Prefer explicit route helpers over implicit polymorphic URLs
 - [`actionview-no-redundant-local-assigns`](./actionview-no-redundant-local-assigns.md) - Disallow `local_assigns` reads that the strict locals declaration already answers

--- a/javascript/packages/linter/docs/rules/actionview-no-dynamic-partial-path.md
+++ b/javascript/packages/linter/docs/rules/actionview-no-dynamic-partial-path.md
@@ -1,0 +1,82 @@
+# Linter Rule: Disallow partial paths that are built at runtime
+
+**Rule:** `actionview-no-dynamic-partial-path`
+
+## Description
+
+Detects `render` calls whose partial path is interpolated, concatenated, or computed, so the partial being rendered is not known until the template runs.
+
+## Rationale
+
+A literal path says which file it renders:
+
+```erb
+<%= render partial: "users/card" %>
+```
+
+A computed one does not:
+
+```erb
+<%= render partial: to_grid_partial_path(content) %>
+```
+
+Nothing about the second call is wrong, and Rails resolves it happily. What it costs is everything that works by reading the template rather than running it.
+
+Herb keeps an index of the partials in a project, and a literal name is what links a `render` to an entry in it. Given that link the language server can jump from the call to the partial and back to every caller, rename a strict local across all of those call sites at once, complete the locals a partial declares as you type them, and report a call that passes a local the partial does not declare or omits one it requires. A computed name has no entry to point at, so each of those stops at the call.
+
+That trade is worth making in some projects and not in others. A CMS that renders a partial chosen by an editor, or a view that dispatches on a record's type, needs a computed path, and can turn the rule off. It reports at `info` because a computed path is a deliberate choice rather than a mistake.
+
+Branching between literal paths keeps the set of possible partials knowable, so it is not reported:
+
+```erb
+<%= render partial: current_user.admin? ? "admin/header" : "user/header" %>
+```
+
+Renders that pass an object rather than a name, such as `render @products`, are not reported here.
+
+Only output tags are reported. A `render` in a silent `<% %>` tag discards its output and is covered by [`actionview-no-silent-render`](./actionview-no-silent-render.md).
+
+## Examples
+
+### ✅ Good
+
+```erb
+<%= render partial: "users/card" %>
+```
+
+```erb
+<%= render "users/card", user: @user %>
+```
+
+```erb
+<%= render partial: current_user.admin? ? "admin/header" : "user/header" %>
+```
+
+### 🚫 Bad
+
+```erb
+<%= render partial: "users/#{user.role}" %>
+```
+
+```erb
+<%= render "components/#{name}" %>
+```
+
+```erb
+<%= render partial: partial_name %>
+```
+
+## Configuration
+
+Disable it in `.herb.yml` when computed partial paths are deliberate:
+
+```yaml
+linter:
+  rules:
+    actionview-no-dynamic-partial-path:
+      enabled: false
+```
+
+## References
+
+- [Action View - Rendering partials](https://guides.rubyonrails.org/layouts_and_rendering.html#using-partials)

--- a/javascript/packages/linter/src/rules.ts
+++ b/javascript/packages/linter/src/rules.ts
@@ -10,6 +10,7 @@ import { A11yNoAutofocusAttributeRule } from "./rules/a11y-no-autofocus-attribut
 import { A11yNoRedundantImageAltRule } from "./rules/a11y-no-redundant-image-alt.js"
 import { A11ySVGHasAccessibleTextRule } from "./rules/a11y-svg-has-accessible-text.js"
 
+import { ActionViewNoDynamicPartialPathRule } from "./rules/actionview-no-dynamic-partial-path.js"
 import { ActionViewNoHelperShadowingRule } from "./rules/actionview-no-helper-shadowing.js"
 import { ActionViewNoImplicitPolymorphicURLRule } from "./rules/actionview-no-implicit-polymorphic-url.js"
 import { ActionViewNoRedundantLocalAssignsRule } from "./rules/actionview-no-redundant-local-assigns.js"
@@ -140,6 +141,7 @@ export const rules: RuleClass[] = [
   A11yNoRedundantImageAltRule,
   A11ySVGHasAccessibleTextRule,
 
+  ActionViewNoDynamicPartialPathRule,
   ActionViewNoHelperShadowingRule,
   ActionViewNoImplicitPolymorphicURLRule,
   ActionViewNoRedundantLocalAssignsRule,

--- a/javascript/packages/linter/src/rules/actionview-no-dynamic-partial-path.ts
+++ b/javascript/packages/linter/src/rules/actionview-no-dynamic-partial-path.ts
@@ -1,0 +1,73 @@
+import { BaseRuleVisitor } from "./rule-utils.js"
+import { ParserRule } from "../types.js"
+import { isOutputRender, isStaticPartialPath, renderPartialExpression } from "./prism-rule-utils.js"
+
+import { isPrismNodeType, locationFromByteOffset } from "@herb-tools/core"
+
+import type { ERBRenderNode, ParseResult, ParserOptions, PrismNode } from "@herb-tools/core"
+import type { FullRuleConfig, LintContext, UnboundLintOffense } from "../types.js"
+
+class ActionViewNoDynamicPartialPathVisitor extends BaseRuleVisitor {
+  visitERBRenderNode(node: ERBRenderNode): void {
+    this.checkRender(node)
+
+    this.visitChildNodes(node)
+  }
+
+  private checkRender(node: ERBRenderNode): void {
+    const call = node.prismNode
+
+    if (!call) return
+    if (!isOutputRender(node)) return
+
+    const expression = renderPartialExpression(call)
+
+    if (!expression) return
+    if (isStaticPartialPath(expression.node)) return
+    if (!expression.explicit && !isPrismNodeType(expression.node, "InterpolatedStringNode")) return
+
+    const source = node.source
+
+    if (!source) return
+
+    this.addOffense(
+      `${this.describe(expression.node)} Use a literal name, or branch between literal names, and Herb can take you to it, check the locals you pass against its strict locals, and help you rename them.`,
+      locationFromByteOffset(source, expression.node.location.startOffset, expression.node.location.length),
+    )
+  }
+
+  private describe(node: PrismNode): string {
+    if (isPrismNodeType(node, "InterpolatedStringNode")) {
+      return "The partial name is interpolated, so it is only known at runtime."
+    }
+
+    return "The partial name comes from a variable or method call, so it is only known at runtime."
+  }
+}
+
+export class ActionViewNoDynamicPartialPathRule extends ParserRule {
+  static ruleName = "actionview-no-dynamic-partial-path"
+  static introducedIn = this.version("unreleased")
+
+  get defaultConfig(): FullRuleConfig {
+    return {
+      enabled: true,
+      severity: "info",
+    }
+  }
+
+  get parserOptions(): Partial<ParserOptions> {
+    return {
+      render_nodes: true,
+      prism_nodes: true,
+    }
+  }
+
+  check(result: ParseResult, context?: Partial<LintContext>): UnboundLintOffense[] {
+    const visitor = new ActionViewNoDynamicPartialPathVisitor(this.ruleName, context)
+
+    visitor.visit(result.value)
+
+    return visitor.offenses
+  }
+}

--- a/javascript/packages/linter/src/rules/index.ts
+++ b/javascript/packages/linter/src/rules/index.ts
@@ -15,6 +15,7 @@ export * from "./string-utils.js"
 export * from "./action-view-utils.js"
 export * from "./herb-disable-comment-base.js"
 
+export * from "./actionview-no-dynamic-partial-path.js"
 export * from "./actionview-no-helper-shadowing.js"
 export * from "./actionview-no-implicit-polymorphic-url.js"
 export * from "./actionview-no-redundant-local-assigns.js"

--- a/javascript/packages/linter/src/rules/prism-rule-utils.ts
+++ b/javascript/packages/linter/src/rules/prism-rule-utils.ts
@@ -110,3 +110,65 @@ export function isCallOnLocal(node: PrismNode, localNames: Set<string>): boolean
   return false
 }
 
+
+export interface RenderPartialExpression {
+  node: PrismNode
+  explicit: boolean
+}
+
+export function renderPartialExpression(call: PrismNode): RenderPartialExpression | null {
+  if (!isPrismNodeType(call, "CallNode")) return null
+
+  const [first] = call.arguments_?.arguments_ ?? []
+
+  if (!first) return null
+
+  if (!isPrismNodeType(first, "KeywordHashNode")) return { node: first, explicit: false }
+
+  for (const element of first.elements ?? []) {
+    if (!isPrismNodeType(element, "AssocNode")) continue
+    if (!isPrismNodeType(element.key, "SymbolNode")) continue
+    if (element.key.unescaped?.value !== "partial") continue
+
+    return { node: element.value, explicit: true }
+  }
+
+  return null
+}
+
+export function isStaticPartialPath(node: PrismNode): boolean {
+  if (isPrismNodeType(node, "StringNode")) return true
+
+  if (isPrismNodeType(node, "IfNode")) {
+    return branchesOf(node).every(branch => branch !== null && isStaticPartialPath(branch))
+  }
+
+  return false
+}
+
+function branchesOf(node: PrismNode): (PrismNode | null)[] {
+  const branches: (PrismNode | null)[] = [onlyStatement(node.statements)]
+  const subsequent = node.subsequent
+
+  if (!subsequent) return [...branches, null]
+
+  if (isPrismNodeType(subsequent, "ElseNode")) return [...branches, onlyStatement(subsequent.statements)]
+
+  return [...branches, subsequent]
+}
+
+function onlyStatement(statements: PrismNode | null | undefined): PrismNode | null {
+  if (!isPrismNodeType(statements, "StatementsNode")) return null
+
+  const body = statements.body ?? []
+
+  return body.length === 1 ? body[0] : null
+}
+
+const OUTPUT_TAG_OPENINGS = new Set(["<%=", "<%=="])
+
+export function isOutputRender(node: { tag_opening?: { value?: string } | null }): boolean {
+  const opening = node.tag_opening?.value
+
+  return opening !== undefined && OUTPUT_TAG_OPENINGS.has(opening)
+}

--- a/javascript/packages/linter/test/__snapshots__/cli.test.ts.snap
+++ b/javascript/packages/linter/test/__snapshots__/cli.test.ts.snap
@@ -19,7 +19,7 @@ test-file-with-errors.html.erb:
   Failing      2 errors (2 offenses across 1 file)
   Not failing  1 warning (1 offense across 1 file, below --fail-level=error)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        120 enabled | all rules via --all-rules"
+  Rules        121 enabled | all rules via --all-rules"
 `;
 
 exports[`CLI Output Formatting > \`all\` pseudo rule in .herb.yml > \`Rules\` summary line > \`--only\` replaces the counts from a disabled \`all\` 1`] = `
@@ -50,7 +50,7 @@ exports[`CLI Output Formatting > \`all\` pseudo rule in .herb.yml > \`Rules\` su
   Checked      1 file
   Offenses     0 offenses
   Fixable      0 offenses
-  Rules        0 enabled | 120 not enabled
+  Rules        0 enabled | 121 not enabled
 
  No rules enabled:
   Every linter rule is turned off, so no offenses can be reported.
@@ -71,7 +71,7 @@ exports[`CLI Output Formatting > \`all\` pseudo rule in .herb.yml > \`Rules\` su
   Checked      1 file
   Offenses     0 offenses
   Fixable      0 offenses
-  Rules        0 enabled | 120 not enabled
+  Rules        0 enabled | 121 not enabled
 
  No rules enabled:
   Every linter rule is turned off, so no offenses can be reported.
@@ -102,7 +102,7 @@ test-file-with-errors.html.erb:
   Failing      2 errors (2 offenses across 1 file)
   Not failing  1 warning (1 offense across 1 file, below --fail-level=error)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        120 enabled"
+  Rules        121 enabled"
 `;
 
 exports[`CLI Output Formatting > \`all\` pseudo rule in .herb.yml > \`Rules\` summary line > \`all: enabled: true\` reports no version-skipped rules 1`] = `
@@ -124,7 +124,7 @@ test-file-with-errors.html.erb:
   Failing      2 errors (2 offenses across 1 file)
   Not failing  1 warning (1 offense across 1 file, below --fail-level=error)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        120 enabled"
+  Rules        121 enabled"
 `;
 
 exports[`CLI Output Formatting > \`all\` pseudo rule in .herb.yml > \`Rules\` summary line > reports enabled and not-enabled rules when no \`all\` is configured 1`] = `
@@ -146,7 +146,7 @@ test/fixtures/test-file-with-errors.html.erb:
   Failing      2 errors (2 offenses across 1 file)
   Not failing  1 warning (1 offense across 1 file, below --fail-level=error)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        100 enabled | 20 not enabled"
+  Rules        101 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > \`all\` pseudo rule in .herb.yml > \`Rules\` summary line > rules opted back in on top of \`all: enabled: false\` count as enabled 1`] = `
@@ -165,7 +165,7 @@ test-file-with-errors.html.erb:
   Failing      0 offenses
   Not failing  1 warning (1 offense across 1 file, below --fail-level=error)
   Fixable      0 offenses
-  Rules        1 enabled | 119 not enabled"
+  Rules        1 enabled | 120 not enabled"
 `;
 
 exports[`CLI Output Formatting > \`all\` pseudo rule in .herb.yml > \`Rules\` summary line > rules opted out on top of \`all: enabled: true\` count as disabled 1`] = `
@@ -184,7 +184,7 @@ test-file-with-errors.html.erb:
   Checked      1 file
   Offenses     2 errors (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        119 enabled | 1 disabled"
+  Rules        120 enabled | 1 disabled"
 `;
 
 exports[`CLI Output Formatting > --all-rules > reports every offense for the fixture with --all-rules 1`] = `
@@ -214,7 +214,7 @@ test/fixtures/all-rules.html.erb:
   Failing      0 offenses
   Not failing  6 warnings (6 offenses across 1 file, below --fail-level=error)
   Fixable      0 offenses
-  Rules        120 enabled | all rules via --all-rules"
+  Rules        121 enabled | all rules via --all-rules"
 `;
 
 exports[`CLI Output Formatting > --all-rules > reports nothing for the fixture with the default rule set 1`] = `
@@ -226,7 +226,7 @@ exports[`CLI Output Formatting > --all-rules > reports nothing for the fixture w
   Checked      1 file
   Offenses     0 offenses
   Fixable      0 offenses
-  Rules        100 enabled | 20 not enabled"
+  Rules        101 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > --ignore-disable-comments 1`] = `
@@ -377,7 +377,7 @@ test/fixtures/ignored.html.erb:8:8
   Not failing  2 warnings (2 offenses across 1 file, below --fail-level=error)
   Note         3 additional offenses reported (would have been ignored)
   Fixable      7 offenses | 4 autocorrectable using \`--fix\`
-  Rules        100 enabled | 20 not enabled"
+  Rules        101 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > --log-level > counts the hidden offenses and suggests the level that reveals them 1`] = `
@@ -395,7 +395,7 @@ exports[`CLI Output Formatting > --log-level > counts the hidden offenses and su
   Not failing  2 info | 1 hint (3 offenses across 1 file, below --fail-level=error)
   Not shown    3 offenses hidden, show them with --log-level=hint
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        100 enabled | 20 not enabled"
+  Rules        101 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > --log-level > doesn't report offenses below the given level 1`] = `
@@ -412,7 +412,7 @@ exports[`CLI Output Formatting > --log-level > doesn't report offenses below the
   Not failing  1 hint (1 offense across 1 file, below --fail-level=error)
   Not shown    1 offense hidden, show it with --log-level=hint
   Fixable      0 offenses
-  Rules        99 enabled | 20 not enabled | 1 disabled"
+  Rules        100 enabled | 20 not enabled | 1 disabled"
 `;
 
 exports[`CLI Output Formatting > --log-level > prefers the CLI flag over the config file 1`] = `
@@ -431,7 +431,7 @@ test-file-with-errors.html.erb:
   Failing      0 offenses
   Not failing  1 hint (1 offense across 1 file, below --fail-level=error)
   Fixable      0 offenses
-  Rules        99 enabled | 20 not enabled | 1 disabled"
+  Rules        100 enabled | 20 not enabled | 1 disabled"
 `;
 
 exports[`CLI Output Formatting > --log-level > reads logLevel from the config file 1`] = `
@@ -448,7 +448,7 @@ exports[`CLI Output Formatting > --log-level > reads logLevel from the config fi
   Not failing  1 hint (1 offense across 1 file, below --fail-level=error)
   Not shown    1 offense hidden, show it with --log-level=hint
   Fixable      0 offenses
-  Rules        99 enabled | 20 not enabled | 1 disabled"
+  Rules        100 enabled | 20 not enabled | 1 disabled"
 `;
 
 exports[`CLI Output Formatting > --log-level > still counts hidden offenses towards the exit code 1`] = `
@@ -464,7 +464,7 @@ exports[`CLI Output Formatting > --log-level > still counts hidden offenses towa
   Offenses     1 hint (1 offense across 1 file)
   Not shown    1 offense hidden, show it with --log-level=hint
   Fixable      0 offenses
-  Rules        99 enabled | 20 not enabled | 1 disabled"
+  Rules        100 enabled | 20 not enabled | 1 disabled"
 `;
 
 exports[`CLI Output Formatting > --log-level > still reports offenses at or above the given level 1`] = `
@@ -483,7 +483,7 @@ test-file-with-errors.html.erb:
   Failing      0 offenses
   Not failing  1 hint (1 offense across 1 file, below --fail-level=error)
   Fixable      0 offenses
-  Rules        99 enabled | 20 not enabled | 1 disabled"
+  Rules        100 enabled | 20 not enabled | 1 disabled"
 `;
 
 exports[`CLI Output Formatting > --log-level > with --all-rules > keeps the log level when it is passed explicitly 1`] = `
@@ -505,7 +505,7 @@ test-file-with-errors.html.erb:
   Not failing  1 hint (1 offense across 1 file, below --fail-level=error)
   Not shown    1 offense hidden, show it with --log-level=hint
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        120 enabled | all rules via --all-rules"
+  Rules        121 enabled | all rules via --all-rules"
 `;
 
 exports[`CLI Output Formatting > --log-level > with --all-rules > lowers the log level to report the rules it was asked for 1`] = `
@@ -528,7 +528,7 @@ test-file-with-errors.html.erb:
   Not failing  1 hint (1 offense across 1 file, below --fail-level=error)
   Log level    hint | lowered from warning by --all-rules
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        120 enabled | all rules via --all-rules"
+  Rules        121 enabled | all rules via --all-rules"
 `;
 
 exports[`CLI Output Formatting > --log-level > with --only > keeps the log level when it is passed explicitly 1`] = `
@@ -689,7 +689,7 @@ test/fixtures/test-file-with-errors.html.erb:2:22
   Failing      2 errors (2 offenses across 1 file)
   Not failing  1 warning (1 offense across 1 file, below --fail-level=error)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        100 enabled | 20 not enabled"
+  Rules        101 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > GitHub Actions format includes rule codes 1`] = `
@@ -721,7 +721,7 @@ test/fixtures/no-trailing-newline.html.erb:1:29
   Checked      1 file
   Offenses     1 error (1 offense across 1 file)
   Fixable      1 offense | 1 autocorrectable using \`--fix\`
-  Rules        100 enabled | 20 not enabled"
+  Rules        101 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > GitHub Actions format includes rule codes 2`] = `
@@ -810,7 +810,7 @@ test/fixtures/erb-no-extra-whitespace-inside-tags.html.erb:1:4
   Checked      1 file
   Offenses     4 errors (4 offenses across 1 file)
   Fixable      4 offenses | 3 autocorrectable using \`--fix\`
-  Rules        100 enabled | 20 not enabled"
+  Rules        101 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > Ignores disabled rules 1`] = `
@@ -870,7 +870,7 @@ test/fixtures/ignored.html.erb:6:14
   Offenses     2 errors (2 offenses across 1 file)
   Ignored      3 offenses suppressed with herb:disable
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        100 enabled | 20 not enabled"
+  Rules        101 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > allows tag.attributes in attribute position 1`] = `
@@ -930,7 +930,7 @@ test/fixtures/tag-attributes.html.erb:5:0
   Failing      0 offenses
   Not failing  2 warnings (2 offenses across 1 file, below --fail-level=error)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        100 enabled | 20 not enabled"
+  Rules        101 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > diplays only parsers errors if one is present 1`] = `
@@ -956,7 +956,7 @@ test/fixtures/parser-errors.html.erb:2:16
   Checked      1 file
   Offenses     1 error (1 offense across 1 file)
   Fixable      0 offenses
-  Rules        100 enabled | 20 not enabled"
+  Rules        101 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > displays most violated rules with multiple offenses 1`] = `
@@ -1208,7 +1208,7 @@ test/fixtures/multiple-rule-offenses.html.erb:4:7
   Failing      8 errors (8 offenses across 1 file)
   Not failing  6 warnings (6 offenses across 1 file, below --fail-level=error)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        100 enabled | 20 not enabled"
+  Rules        101 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > displays rule offenses when showing all rules 1`] = `
@@ -1333,7 +1333,7 @@ test/fixtures/few-rule-offenses.html.erb:6:0
   Failing      4 errors (4 offenses across 1 file)
   Not failing  2 warnings (2 offenses across 1 file, below --fail-level=error)
   Fixable      6 offenses | 3 autocorrectable using \`--fix\`
-  Rules        100 enabled | 20 not enabled"
+  Rules        101 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats GitHub Actions output correctly for bad file 1`] = `
@@ -1388,7 +1388,7 @@ test/fixtures/bad-file.html.erb:1:16
   Checked      1 file
   Offenses     2 errors (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        100 enabled | 20 not enabled"
+  Rules        101 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats GitHub Actions output correctly for clean file 1`] = `
@@ -1400,7 +1400,7 @@ exports[`CLI Output Formatting > formats GitHub Actions output correctly for cle
   Checked      1 file
   Offenses     0 offenses
   Fixable      0 offenses
-  Rules        100 enabled | 20 not enabled"
+  Rules        101 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats GitHub Actions output correctly for file with errors 1`] = `
@@ -1479,7 +1479,7 @@ test/fixtures/test-file-with-errors.html.erb:2:22
   Failing      2 errors (2 offenses across 1 file)
   Not failing  1 warning (1 offense across 1 file, below --fail-level=error)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        100 enabled | 20 not enabled"
+  Rules        101 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats GitHub Actions output with --format=github option 1`] = `
@@ -1536,7 +1536,7 @@ test/fixtures/test-file-simple.html.erb:2:22
   Checked      1 file
   Offenses     2 errors (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        100 enabled | 20 not enabled"
+  Rules        101 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats JSON output correctly for bad file 1`] = `
@@ -1583,7 +1583,7 @@ exports[`CLI Output Formatting > formats JSON output correctly for bad file 1`] 
   "summary": {
     "filesChecked": 1,
     "filesWithOffenses": 1,
-    "ruleCount": 100,
+    "ruleCount": 101,
     "totalErrors": 2,
     "totalHints": 0,
     "totalIgnored": 0,
@@ -1605,7 +1605,7 @@ exports[`CLI Output Formatting > formats JSON output correctly for clean file 1`
   "summary": {
     "filesChecked": 1,
     "filesWithOffenses": 0,
-    "ruleCount": 100,
+    "ruleCount": 101,
     "totalErrors": 0,
     "totalHints": 0,
     "totalIgnored": 0,
@@ -1679,7 +1679,7 @@ exports[`CLI Output Formatting > formats JSON output correctly for file with err
   "summary": {
     "filesChecked": 1,
     "filesWithOffenses": 1,
-    "ruleCount": 100,
+    "ruleCount": 101,
     "totalErrors": 2,
     "totalHints": 0,
     "totalIgnored": 0,
@@ -1762,7 +1762,7 @@ test/fixtures/test-file-with-errors.html.erb:2:22
   Failing      2 errors (2 offenses across 1 file)
   Not failing  1 warning (1 offense across 1 file, below --fail-level=error)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        100 enabled | 20 not enabled"
+  Rules        101 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats simple output correctly 1`] = `
@@ -1781,7 +1781,7 @@ test/fixtures/test-file-simple.html.erb:
   Checked      1 file
   Offenses     2 errors (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        100 enabled | 20 not enabled"
+  Rules        101 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats simple output for bad-file correctly 1`] = `
@@ -1800,7 +1800,7 @@ test/fixtures/bad-file.html.erb:
   Checked      1 file
   Offenses     2 errors (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        100 enabled | 20 not enabled"
+  Rules        101 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats success output correctly 1`] = `
@@ -1812,7 +1812,7 @@ exports[`CLI Output Formatting > formats success output correctly 1`] = `
   Checked      1 file
   Offenses     0 offenses
   Fixable      0 offenses
-  Rules        100 enabled | 20 not enabled"
+  Rules        101 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > handles boolean attributes 1`] = `
@@ -1824,7 +1824,7 @@ exports[`CLI Output Formatting > handles boolean attributes 1`] = `
   Checked      1 file
   Offenses     0 offenses
   Fixable      0 offenses
-  Rules        100 enabled | 20 not enabled"
+  Rules        101 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > handles multiple errors correctly 1`] = `
@@ -1875,7 +1875,7 @@ test/fixtures/bad-file.html.erb:1:16
   Checked      1 file
   Offenses     2 errors (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        100 enabled | 20 not enabled"
+  Rules        101 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > herb:disable rules 1`] = `
@@ -2018,7 +2018,7 @@ test/fixtures/disabled-1.html.erb:14:19
   Not failing  6 warnings (6 offenses across 1 file, below --fail-level=error)
   Ignored      8 offenses suppressed with herb:disable
   Fixable      8 offenses | 1 autocorrectable using \`--fix\`
-  Rules        100 enabled | 20 not enabled"
+  Rules        101 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > herb:disable rules 2`] = `
@@ -2277,7 +2277,7 @@ test/fixtures/disabled-2.html.erb:2:44
   Not failing  7 warnings (7 offenses across 1 file, below --fail-level=error)
   Ignored      5 offenses suppressed with herb:disable
   Fixable      13 offenses | 6 autocorrectable using \`--fix\`
-  Rules        100 enabled | 20 not enabled"
+  Rules        101 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > non-failing offenses tip > points at --log-level when many offenses don't fail the build 1`] = `
@@ -2315,7 +2315,7 @@ multiple-rule-offenses.html.erb:
   Failing      3 errors (3 offenses across 1 file)
   Not failing  1 info | 10 hints (11 offenses across 1 file, below --fail-level=error)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        100 enabled | 20 not enabled
+  Rules        101 enabled | 20 not enabled
 
  TIP: 11 of the logged offenses don't fail the build.
       Run herb-lint --log-level=error to stop logging them, or set linter.logLevel in your .herb.yml.
@@ -2347,7 +2347,7 @@ multiple-rule-offenses.html.erb:
   Not failing  1 info | 10 hints (11 offenses across 1 file, below --fail-level=error)
   Not shown    11 offenses hidden, show them with --log-level=hint
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        100 enabled | 20 not enabled"
+  Rules        101 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > non-failing offenses tip > stays quiet when --log-level is passed explicitly, even when it hides nothing 1`] = `
@@ -2385,7 +2385,7 @@ multiple-rule-offenses.html.erb:
   Failing      3 errors (3 offenses across 1 file)
   Not failing  1 info | 10 hints (11 offenses across 1 file, below --fail-level=error)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        100 enabled | 20 not enabled"
+  Rules        101 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > non-failing offenses tip > stays quiet when logLevel is set in the config file 1`] = `
@@ -2423,7 +2423,7 @@ multiple-rule-offenses.html.erb:
   Failing      3 errors (3 offenses across 1 file)
   Not failing  1 info | 10 hints (11 offenses across 1 file, below --fail-level=error)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        100 enabled | 20 not enabled"
+  Rules        101 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > non-failing offenses tip > stays quiet when only a handful of offenses don't fail the build 1`] = `
@@ -2461,7 +2461,7 @@ multiple-rule-offenses.html.erb:
   Failing      8 errors (8 offenses across 1 file)
   Not failing  6 warnings (6 offenses across 1 file, below --fail-level=error)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        100 enabled | 20 not enabled"
+  Rules        101 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > points at the flag instead of previewing once there are too many corrections 1`] = `
@@ -2557,7 +2557,7 @@ test/fixtures/test-file-simple.html.erb:2:22
   Checked      1 file
   Offenses     2 errors (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        100 enabled | 20 not enabled"
+  Rules        101 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > previews the correction under each correctable offense 1`] = `
@@ -2614,7 +2614,7 @@ test/fixtures/test-file-simple.html.erb:2:22
   Checked      1 file
   Offenses     2 errors (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        100 enabled | 20 not enabled"
+  Rules        101 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > summary offense buckets > groups every severity into one line when --fail-level is hint 1`] = `
@@ -2651,7 +2651,7 @@ test/fixtures/multiple-rule-offenses.html.erb:
   Checked      1 file
   Offenses     8 errors | 6 warnings (14 offenses across 1 file)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        100 enabled | 20 not enabled"
+  Rules        101 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > summary offense buckets > groups every severity into one line when --fail-level is info 1`] = `
@@ -2688,7 +2688,7 @@ test/fixtures/multiple-rule-offenses.html.erb:
   Checked      1 file
   Offenses     8 errors | 6 warnings (14 offenses across 1 file)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        100 enabled | 20 not enabled"
+  Rules        101 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > summary offense buckets > groups every severity into one line when --fail-level is warning 1`] = `
@@ -2725,7 +2725,7 @@ test/fixtures/multiple-rule-offenses.html.erb:
   Checked      1 file
   Offenses     8 errors | 6 warnings (14 offenses across 1 file)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        100 enabled | 20 not enabled"
+  Rules        101 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > summary offense buckets > moves a severity between buckets as --fail-level is lowered 1`] = `
@@ -2763,7 +2763,7 @@ multiple-rule-offenses.html.erb:
   Failing      8 errors | 4 warnings | 1 info (13 offenses across 1 file)
   Not failing  1 hint (1 offense across 1 file, below --fail-level=info)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        100 enabled | 20 not enabled"
+  Rules        101 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > summary offense buckets > splits the buckets when only some severities fail the build 1`] = `
@@ -2801,7 +2801,7 @@ multiple-rule-offenses.html.erb:
   Failing      8 errors | 4 warnings (12 offenses across 1 file)
   Not failing  1 info | 1 hint (2 offenses across 1 file, below --fail-level=warning)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        100 enabled | 20 not enabled"
+  Rules        101 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > unsafe autocorrectable offenses > counts and tags them separately from offenses --fix can correct 1`] = `
@@ -2921,5 +2921,5 @@ test/fixtures/test-file-with-errors.html.erb:2:22
   Failing      2 errors (2 offenses across 1 file)
   Not failing  1 warning (1 offense across 1 file, below --fail-level=error)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        100 enabled | 20 not enabled"
+  Rules        101 enabled | 20 not enabled"
 `;

--- a/javascript/packages/linter/test/rules/actionview-no-dynamic-partial-path.test.ts
+++ b/javascript/packages/linter/test/rules/actionview-no-dynamic-partial-path.test.ts
@@ -1,0 +1,107 @@
+import dedent from "dedent"
+import { describe, test } from "vitest"
+
+import { ActionViewNoDynamicPartialPathRule } from "../../src/rules/actionview-no-dynamic-partial-path.js"
+import { createLinterTest } from "../helpers/linter-test-helper.js"
+
+const { expectNoOffenses, expectInfo, assertOffenses } = createLinterTest(ActionViewNoDynamicPartialPathRule)
+
+const ACTION = 'Use a literal name, or branch between literal names, and Herb can take you to it, check the locals you pass against its strict locals, and help you rename them.'
+const INTERPOLATED = `The partial name is interpolated, so it is only known at runtime. ${ACTION}`
+const COMPUTED = `The partial name comes from a variable or method call, so it is only known at runtime. ${ACTION}`
+
+describe("actionview-no-dynamic-partial-path", () => {
+  test("flags an interpolated path in the keyword form", () => {
+    expectInfo(INTERPOLATED)
+
+    assertOffenses('<%= render partial: "users/#{user.role}" %>')
+  })
+
+  test("flags an interpolated path in the shorthand form", () => {
+    expectInfo(INTERPOLATED)
+
+    assertOffenses('<%= render "components/#{name}" %>')
+  })
+
+  test("reports the offense on the path expression", () => {
+    expectInfo(INTERPOLATED, [1, 20])
+
+    assertOffenses('<%= render partial: "users/#{user.role}" %>')
+  })
+
+  test("flags a variable used as an explicit partial path", () => {
+    expectInfo(COMPUTED)
+
+    assertOffenses(`<%= render partial: partial_name %>`)
+  })
+
+  test("flags an instance variable used as an explicit partial path", () => {
+    expectInfo(COMPUTED)
+
+    assertOffenses(`<%= render partial: @partial %>`)
+  })
+
+  test("flags a concatenated path", () => {
+    expectInfo(COMPUTED)
+
+    assertOffenses(`<%= render partial: "users/" + kind %>`)
+  })
+
+  test("flags a dynamic path inside markup", () => {
+    expectInfo(INTERPOLATED)
+
+    assertOffenses(dedent`
+      <div class="row">
+        <%= render partial: "users/#{user.role}" %>
+      </div>
+    `)
+  })
+
+  test("does not flag a literal path in the shorthand form", () => {
+    expectNoOffenses(`<%= render "users/card" %>`)
+  })
+
+  test("does not flag a literal path in the keyword form", () => {
+    expectNoOffenses(`<%= render partial: "users/card" %>`)
+  })
+
+  test("does not flag a literal path with locals", () => {
+    expectNoOffenses(`<%= render partial: "users/card", locals: { user: @user } %>`)
+  })
+
+  test("does not flag a ternary between literal paths", () => {
+    expectNoOffenses(`<%= render partial: current_user.admin? ? "admin/header" : "user/header" %>`)
+  })
+
+  test("does not flag a nested ternary between literal paths", () => {
+    expectNoOffenses(`<%= render partial: a? ? "one" : b? ? "two" : "three" %>`)
+  })
+
+  test("does not flag an object render", () => {
+    expectNoOffenses(`<%= render @products %>`)
+  })
+
+  test("does not flag a bare identifier in the shorthand form", () => {
+    expectNoOffenses(`<%= render partial_name %>`)
+  })
+
+  test("does not flag a collection render with a literal path", () => {
+    expectNoOffenses(`<%= render partial: "users/card", collection: @users %>`)
+  })
+
+  test("does not flag a render with no partial keyword", () => {
+    expectNoOffenses(`<%= render template: "layouts/base" %>`)
+  })
+
+  test("does not flag a dynamic value in an unrelated keyword", () => {
+    expectNoOffenses(`<%= render partial: "users/card", collection: @users.where(role: role) %>`)
+  })
+
+  test("does not flag a silent render, which actionview-no-silent-render owns", () => {
+    expectNoOffenses('<% render partial: "users/#{user.role}" %>')
+  })
+
+  test("does not flag a trimmed silent render", () => {
+    expectNoOffenses('<%- render partial: partial_name %>')
+  })
+})


### PR DESCRIPTION
This pull request implements the `actionview-no-dynamic-partial-path` linter rule, which reports `render` calls whose partial name is interpolated, concatenated or computed, so the template being rendered is not known until the call runs.

A literal name says which file it renders:

```erb
<%= render partial: "users/card" %>
```

A computed one does not:

```erb
<%= render partial: "users/#{user.role}" %>
<%= render partial: to_grid_partial_path(content) %>
```

Nothing about the second pair is wrong and Rails resolves both happily. What they cost is everything that works by reading the template rather than running it. 

Herb keeps an index of the partials in a project, and a literal name is what links a `render` to an entry in it. Given that link the language server can jump from the call to the partial and back to every caller, rename a strict local across all of those call sites at once, complete the locals a partial declares as you type them, and report a call that passes a local the partial does not declare or omits one it requires. A computed name has no entry to point at, so each of those stops at the call.

Branching between literal names keeps the set of reachable partials knowable, so it is not reported:

```erb
<%= render partial: current_user.admin? ? "admin/header" : "user/header" %>
```

Resolves #181

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>