### PR TITLE
Linter: Implement `actionview-no-implicit-partial` rule

### DIFF
--- a/javascript/packages/linter/docs/rules/README.md
+++ b/javascript/packages/linter/docs/rules/README.md
@@ -20,6 +20,7 @@ This page contains documentation for all Herb Linter rules.
 
 - [`actionview-no-dynamic-partial-path`](./actionview-no-dynamic-partial-path.md) - Disallow partial paths that are built at runtime
 - [`actionview-no-helper-shadowing`](./actionview-no-helper-shadowing.md) - Disallow shadowing Action View helpers with block variables
+- [`actionview-no-implicit-partial`](./actionview-no-implicit-partial.md) - Disallow `render` calls that infer the partial from an object
 - [`actionview-no-implicit-polymorphic-url`](./actionview-no-implicit-polymorphic-url.md) - Prefer explicit route helpers over implicit polymorphic URLs
 - [`actionview-no-redundant-local-assigns`](./actionview-no-redundant-local-assigns.md) - Disallow `local_assigns` reads that the strict locals declaration already answers
 - [`actionview-no-render-option-shadowing`](./actionview-no-render-option-shadowing.md) - Disallow locals that shadow a `render` option name

--- a/javascript/packages/linter/docs/rules/actionview-no-dynamic-partial-path.md
+++ b/javascript/packages/linter/docs/rules/actionview-no-dynamic-partial-path.md
@@ -32,7 +32,7 @@ Branching between literal paths keeps the set of possible partials knowable, so 
 <%= render partial: current_user.admin? ? "admin/header" : "user/header" %>
 ```
 
-Renders that pass an object rather than a name, such as `render @products`, are not reported here.
+Renders that pass an object rather than a name, such as `render @products`, are not reported here. See [`actionview-no-implicit-partial`](./actionview-no-implicit-partial.md).
 
 Only output tags are reported. A `render` in a silent `<% %>` tag discards its output and is covered by [`actionview-no-silent-render`](./actionview-no-silent-render.md).
 

--- a/javascript/packages/linter/docs/rules/actionview-no-implicit-partial.md
+++ b/javascript/packages/linter/docs/rules/actionview-no-implicit-partial.md
@@ -1,0 +1,78 @@
+# Linter Rule: Disallow `render` calls that infer the partial from an object
+
+**Rule:** `actionview-no-implicit-partial`
+
+## Description
+
+Detects `render` calls that pass an object or collection without naming a partial, such as `render @products`, where Rails derives the template name from the class of each item.
+
+## Rationale
+
+`render @products` renders `_product.html.erb` once per item, choosing the template from each item's class at runtime. Nothing in the call says so:
+
+```erb
+<%= render @products %>
+```
+
+Naming the partial says it:
+
+```erb
+<%= render partial: "products/product", collection: @products %>
+```
+
+The implicit form is compact and idiomatic, and it costs the same things every unnamed dependency costs. Searching for the templates that render `_product.html.erb` misses these calls. Changing or subclassing the model changes which template renders, silently.
+
+Naming the partial also turns the call into an edge Herb can follow. Once the template is written down it matches an entry in the partial index, and the language server can jump from the call to the partial and back to every caller, rename a strict local across all of those call sites at once, complete the locals the partial declares as you type them, and report a call that passes a local the partial does not declare or omits one it requires. A derived name matches no entry, which is why the language server says the same thing when you ask it to jump to a partial it cannot resolve.
+
+The implicit form is common Rails, so this reports at `info`: it is guidance for codebases that want template dependencies written down rather than derived, not a defect report.
+
+### Notes
+
+::: tip Component renders are not reported
+`render FlashComponent.new(...)` and `render Primer::Alpha::Banner.new(...)` call `render_in` on the object rather than looking up a partial, so there is no partial name to write. Any render whose object is built from a constant is left alone, and so is any render whose call chain constructs an object with `.new`, which covers the factory helpers component libraries use: `render component("ui/modal").new(title: t(".title"))`.
+:::
+
+Renders that name a partial, including with a dynamic name, are not reported here. See [`actionview-no-dynamic-partial-path`](./actionview-no-dynamic-partial-path.md).
+
+Only output tags are reported. A `render` in a silent `<% %>` tag discards its output and is covered by [`actionview-no-silent-render`](./actionview-no-silent-render.md).
+
+## Examples
+
+### ✅ Good
+
+```erb
+<%= render partial: "products/product", collection: @products %>
+```
+
+```erb
+<%= render @products, partial: "product" %>
+```
+
+```erb
+<%= render partial: "products/product", object: @product %>
+```
+
+### 🚫 Bad
+
+```erb
+<%= render @products %>
+```
+
+```erb
+<%= render @product %>
+```
+
+## Configuration
+
+Disable it in `.herb.yml` when the implicit form is the house style:
+
+```yaml
+linter:
+  rules:
+    actionview-no-implicit-partial:
+      enabled: false
+```
+
+## References
+
+- [Action View - Rendering collections](https://guides.rubyonrails.org/layouts_and_rendering.html#rendering-collections)

--- a/javascript/packages/linter/src/rules.ts
+++ b/javascript/packages/linter/src/rules.ts
@@ -12,6 +12,7 @@ import { A11ySVGHasAccessibleTextRule } from "./rules/a11y-svg-has-accessible-te
 
 import { ActionViewNoDynamicPartialPathRule } from "./rules/actionview-no-dynamic-partial-path.js"
 import { ActionViewNoHelperShadowingRule } from "./rules/actionview-no-helper-shadowing.js"
+import { ActionViewNoImplicitPartialRule } from "./rules/actionview-no-implicit-partial.js"
 import { ActionViewNoImplicitPolymorphicURLRule } from "./rules/actionview-no-implicit-polymorphic-url.js"
 import { ActionViewNoRedundantLocalAssignsRule } from "./rules/actionview-no-redundant-local-assigns.js"
 import { ActionViewNoRenderOptionShadowingRule } from "./rules/actionview-no-render-option-shadowing.js"
@@ -144,6 +145,7 @@ export const rules: RuleClass[] = [
 
   ActionViewNoDynamicPartialPathRule,
   ActionViewNoHelperShadowingRule,
+  ActionViewNoImplicitPartialRule,
   ActionViewNoImplicitPolymorphicURLRule,
   ActionViewNoRedundantLocalAssignsRule,
   ActionViewNoRenderOptionShadowingRule,

--- a/javascript/packages/linter/src/rules/actionview-no-implicit-partial.ts
+++ b/javascript/packages/linter/src/rules/actionview-no-implicit-partial.ts
@@ -1,0 +1,74 @@
+import { BaseRuleVisitor } from "./rule-utils.js"
+import { ParserRule } from "../types.js"
+import { constructsObject, isOutputRender, isStaticPartialPath, renderPartialExpression, rootReceiver } from "./prism-rule-utils.js"
+
+import { isPrismNodeType, locationFromByteOffset } from "@herb-tools/core"
+
+import type { ERBRenderNode, ParseResult, ParserOptions, PrismNode } from "@herb-tools/core"
+import type { FullRuleConfig, LintContext, UnboundLintOffense } from "../types.js"
+
+class ActionViewNoImplicitPartialVisitor extends BaseRuleVisitor {
+  visitERBRenderNode(node: ERBRenderNode): void {
+    this.checkRender(node)
+
+    this.visitChildNodes(node)
+  }
+
+  private checkRender(node: ERBRenderNode): void {
+    const call = node.prismNode
+    const source = node.source
+
+    if (!call || !source) return
+    if (!isOutputRender(node)) return
+
+    const expression = renderPartialExpression(call)
+
+    if (!expression) return
+    if (expression.explicit) return
+    if (isStaticPartialPath(expression.node)) return
+    if (isPrismNodeType(expression.node, "InterpolatedStringNode")) return
+    if (this.isRenderableObject(expression.node)) return
+
+    const object = node.keywords?.object?.value
+
+    this.addOffense(
+      `Rails derives the partial from \`to_partial_path\`${object ? ` on \`${object}\`` : ""} when the template renders, so the template this renders is not named in this \`<%= render %>\` call. Name it explicitly, with \`object:\` for a single record or \`collection:\` for many, and Herb can take you to it, check the locals you pass against its strict locals, and help you rename them.`,
+      locationFromByteOffset(source, expression.node.location.startOffset, expression.node.location.length),
+    )
+  }
+
+  private isRenderableObject(node: PrismNode): boolean {
+    if (constructsObject(node)) return true
+
+    const root = rootReceiver(node)
+
+    return isPrismNodeType(root, "ConstantReadNode") || isPrismNodeType(root, "ConstantPathNode")
+  }
+}
+
+export class ActionViewNoImplicitPartialRule extends ParserRule {
+  static ruleName = "actionview-no-implicit-partial"
+  static introducedIn = this.version("unreleased")
+
+  get defaultConfig(): FullRuleConfig {
+    return {
+      enabled: true,
+      severity: "info",
+    }
+  }
+
+  get parserOptions(): Partial<ParserOptions> {
+    return {
+      render_nodes: true,
+      prism_nodes: true,
+    }
+  }
+
+  check(result: ParseResult, context?: Partial<LintContext>): UnboundLintOffense[] {
+    const visitor = new ActionViewNoImplicitPartialVisitor(this.ruleName, context)
+
+    visitor.visit(result.value)
+
+    return visitor.offenses
+  }
+}

--- a/javascript/packages/linter/src/rules/index.ts
+++ b/javascript/packages/linter/src/rules/index.ts
@@ -17,6 +17,7 @@ export * from "./herb-disable-comment-base.js"
 
 export * from "./actionview-no-dynamic-partial-path.js"
 export * from "./actionview-no-helper-shadowing.js"
+export * from "./actionview-no-implicit-partial.js"
 export * from "./actionview-no-implicit-polymorphic-url.js"
 export * from "./actionview-no-redundant-local-assigns.js"
 export * from "./actionview-no-render-option-shadowing.js"

--- a/javascript/packages/linter/src/rules/prism-rule-utils.ts
+++ b/javascript/packages/linter/src/rules/prism-rule-utils.ts
@@ -119,18 +119,31 @@ export interface RenderPartialExpression {
 export function renderPartialExpression(call: PrismNode): RenderPartialExpression | null {
   if (!isPrismNodeType(call, "CallNode")) return null
 
-  const [first] = call.arguments_?.arguments_ ?? []
+  const args = call.arguments_?.arguments_ ?? []
+  const [first] = args
 
   if (!first) return null
 
-  if (!isPrismNodeType(first, "KeywordHashNode")) return { node: first, explicit: false }
+  const named = namedPartialArgument(args)
 
-  for (const element of first.elements ?? []) {
-    if (!isPrismNodeType(element, "AssocNode")) continue
-    if (!isPrismNodeType(element.key, "SymbolNode")) continue
-    if (element.key.unescaped?.value !== "partial") continue
+  if (named) return { node: named, explicit: true }
 
-    return { node: element.value, explicit: true }
+  if (isPrismNodeType(first, "KeywordHashNode")) return null
+
+  return { node: first, explicit: false }
+}
+
+function namedPartialArgument(args: PrismNode[]): PrismNode | null {
+  for (const argument of args) {
+    if (!isPrismNodeType(argument, "KeywordHashNode")) continue
+
+    for (const element of argument.elements ?? []) {
+      if (!isPrismNodeType(element, "AssocNode")) continue
+      if (!isPrismNodeType(element.key, "SymbolNode")) continue
+      if (element.key.unescaped?.value !== "partial") continue
+
+      return element.value
+    }
   }
 
   return null
@@ -171,4 +184,16 @@ export function isOutputRender(node: { tag_opening?: { value?: string } | null }
   const opening = node.tag_opening?.value
 
   return opening !== undefined && OUTPUT_TAG_OPENINGS.has(opening)
+}
+
+export function constructsObject(node: PrismNode): boolean {
+  let current: PrismNode | undefined = node
+
+  while (current) {
+    if (isPrismNodeType(current, "CallNode") && current.name === "new") return true
+
+    current = current.receiver ?? undefined
+  }
+
+  return false
 }

--- a/javascript/packages/linter/test/__snapshots__/cli.test.ts.snap
+++ b/javascript/packages/linter/test/__snapshots__/cli.test.ts.snap
@@ -19,7 +19,7 @@ test-file-with-errors.html.erb:
   Failing      2 errors (2 offenses across 1 file)
   Not failing  1 warning (1 offense across 1 file, below --fail-level=error)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        122 enabled | all rules via --all-rules"
+  Rules        123 enabled | all rules via --all-rules"
 `;
 
 exports[`CLI Output Formatting > \`all\` pseudo rule in .herb.yml > \`Rules\` summary line > \`--only\` replaces the counts from a disabled \`all\` 1`] = `
@@ -50,7 +50,7 @@ exports[`CLI Output Formatting > \`all\` pseudo rule in .herb.yml > \`Rules\` su
   Checked      1 file
   Offenses     0 offenses
   Fixable      0 offenses
-  Rules        0 enabled | 122 not enabled
+  Rules        0 enabled | 123 not enabled
 
  No rules enabled:
   Every linter rule is turned off, so no offenses can be reported.
@@ -71,7 +71,7 @@ exports[`CLI Output Formatting > \`all\` pseudo rule in .herb.yml > \`Rules\` su
   Checked      1 file
   Offenses     0 offenses
   Fixable      0 offenses
-  Rules        0 enabled | 122 not enabled
+  Rules        0 enabled | 123 not enabled
 
  No rules enabled:
   Every linter rule is turned off, so no offenses can be reported.
@@ -102,7 +102,7 @@ test-file-with-errors.html.erb:
   Failing      2 errors (2 offenses across 1 file)
   Not failing  1 warning (1 offense across 1 file, below --fail-level=error)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        122 enabled"
+  Rules        123 enabled"
 `;
 
 exports[`CLI Output Formatting > \`all\` pseudo rule in .herb.yml > \`Rules\` summary line > \`all: enabled: true\` reports no version-skipped rules 1`] = `
@@ -124,7 +124,7 @@ test-file-with-errors.html.erb:
   Failing      2 errors (2 offenses across 1 file)
   Not failing  1 warning (1 offense across 1 file, below --fail-level=error)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        122 enabled"
+  Rules        123 enabled"
 `;
 
 exports[`CLI Output Formatting > \`all\` pseudo rule in .herb.yml > \`Rules\` summary line > reports enabled and not-enabled rules when no \`all\` is configured 1`] = `
@@ -146,7 +146,7 @@ test/fixtures/test-file-with-errors.html.erb:
   Failing      2 errors (2 offenses across 1 file)
   Not failing  1 warning (1 offense across 1 file, below --fail-level=error)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        102 enabled | 20 not enabled"
+  Rules        103 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > \`all\` pseudo rule in .herb.yml > \`Rules\` summary line > rules opted back in on top of \`all: enabled: false\` count as enabled 1`] = `
@@ -165,7 +165,7 @@ test-file-with-errors.html.erb:
   Failing      0 offenses
   Not failing  1 warning (1 offense across 1 file, below --fail-level=error)
   Fixable      0 offenses
-  Rules        1 enabled | 121 not enabled"
+  Rules        1 enabled | 122 not enabled"
 `;
 
 exports[`CLI Output Formatting > \`all\` pseudo rule in .herb.yml > \`Rules\` summary line > rules opted out on top of \`all: enabled: true\` count as disabled 1`] = `
@@ -184,7 +184,7 @@ test-file-with-errors.html.erb:
   Checked      1 file
   Offenses     2 errors (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        121 enabled | 1 disabled"
+  Rules        122 enabled | 1 disabled"
 `;
 
 exports[`CLI Output Formatting > --all-rules > reports every offense for the fixture with --all-rules 1`] = `
@@ -214,7 +214,7 @@ test/fixtures/all-rules.html.erb:
   Failing      0 offenses
   Not failing  6 warnings (6 offenses across 1 file, below --fail-level=error)
   Fixable      0 offenses
-  Rules        122 enabled | all rules via --all-rules"
+  Rules        123 enabled | all rules via --all-rules"
 `;
 
 exports[`CLI Output Formatting > --all-rules > reports nothing for the fixture with the default rule set 1`] = `
@@ -226,7 +226,7 @@ exports[`CLI Output Formatting > --all-rules > reports nothing for the fixture w
   Checked      1 file
   Offenses     0 offenses
   Fixable      0 offenses
-  Rules        102 enabled | 20 not enabled"
+  Rules        103 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > --ignore-disable-comments 1`] = `
@@ -377,7 +377,7 @@ test/fixtures/ignored.html.erb:8:8
   Not failing  2 warnings (2 offenses across 1 file, below --fail-level=error)
   Note         3 additional offenses reported (would have been ignored)
   Fixable      7 offenses | 4 autocorrectable using \`--fix\`
-  Rules        102 enabled | 20 not enabled"
+  Rules        103 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > --log-level > counts the hidden offenses and suggests the level that reveals them 1`] = `
@@ -395,7 +395,7 @@ exports[`CLI Output Formatting > --log-level > counts the hidden offenses and su
   Not failing  2 info | 1 hint (3 offenses across 1 file, below --fail-level=error)
   Not shown    3 offenses hidden, show them with --log-level=hint
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        102 enabled | 20 not enabled"
+  Rules        103 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > --log-level > doesn't report offenses below the given level 1`] = `
@@ -412,7 +412,7 @@ exports[`CLI Output Formatting > --log-level > doesn't report offenses below the
   Not failing  1 hint (1 offense across 1 file, below --fail-level=error)
   Not shown    1 offense hidden, show it with --log-level=hint
   Fixable      0 offenses
-  Rules        101 enabled | 20 not enabled | 1 disabled"
+  Rules        102 enabled | 20 not enabled | 1 disabled"
 `;
 
 exports[`CLI Output Formatting > --log-level > prefers the CLI flag over the config file 1`] = `
@@ -431,7 +431,7 @@ test-file-with-errors.html.erb:
   Failing      0 offenses
   Not failing  1 hint (1 offense across 1 file, below --fail-level=error)
   Fixable      0 offenses
-  Rules        101 enabled | 20 not enabled | 1 disabled"
+  Rules        102 enabled | 20 not enabled | 1 disabled"
 `;
 
 exports[`CLI Output Formatting > --log-level > reads logLevel from the config file 1`] = `
@@ -448,7 +448,7 @@ exports[`CLI Output Formatting > --log-level > reads logLevel from the config fi
   Not failing  1 hint (1 offense across 1 file, below --fail-level=error)
   Not shown    1 offense hidden, show it with --log-level=hint
   Fixable      0 offenses
-  Rules        101 enabled | 20 not enabled | 1 disabled"
+  Rules        102 enabled | 20 not enabled | 1 disabled"
 `;
 
 exports[`CLI Output Formatting > --log-level > still counts hidden offenses towards the exit code 1`] = `
@@ -464,7 +464,7 @@ exports[`CLI Output Formatting > --log-level > still counts hidden offenses towa
   Offenses     1 hint (1 offense across 1 file)
   Not shown    1 offense hidden, show it with --log-level=hint
   Fixable      0 offenses
-  Rules        101 enabled | 20 not enabled | 1 disabled"
+  Rules        102 enabled | 20 not enabled | 1 disabled"
 `;
 
 exports[`CLI Output Formatting > --log-level > still reports offenses at or above the given level 1`] = `
@@ -483,7 +483,7 @@ test-file-with-errors.html.erb:
   Failing      0 offenses
   Not failing  1 hint (1 offense across 1 file, below --fail-level=error)
   Fixable      0 offenses
-  Rules        101 enabled | 20 not enabled | 1 disabled"
+  Rules        102 enabled | 20 not enabled | 1 disabled"
 `;
 
 exports[`CLI Output Formatting > --log-level > with --all-rules > keeps the log level when it is passed explicitly 1`] = `
@@ -505,7 +505,7 @@ test-file-with-errors.html.erb:
   Not failing  1 hint (1 offense across 1 file, below --fail-level=error)
   Not shown    1 offense hidden, show it with --log-level=hint
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        122 enabled | all rules via --all-rules"
+  Rules        123 enabled | all rules via --all-rules"
 `;
 
 exports[`CLI Output Formatting > --log-level > with --all-rules > lowers the log level to report the rules it was asked for 1`] = `
@@ -528,7 +528,7 @@ test-file-with-errors.html.erb:
   Not failing  1 hint (1 offense across 1 file, below --fail-level=error)
   Log level    hint | lowered from warning by --all-rules
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        122 enabled | all rules via --all-rules"
+  Rules        123 enabled | all rules via --all-rules"
 `;
 
 exports[`CLI Output Formatting > --log-level > with --only > keeps the log level when it is passed explicitly 1`] = `
@@ -689,7 +689,7 @@ test/fixtures/test-file-with-errors.html.erb:2:22
   Failing      2 errors (2 offenses across 1 file)
   Not failing  1 warning (1 offense across 1 file, below --fail-level=error)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        102 enabled | 20 not enabled"
+  Rules        103 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > GitHub Actions format includes rule codes 1`] = `
@@ -721,7 +721,7 @@ test/fixtures/no-trailing-newline.html.erb:1:29
   Checked      1 file
   Offenses     1 error (1 offense across 1 file)
   Fixable      1 offense | 1 autocorrectable using \`--fix\`
-  Rules        102 enabled | 20 not enabled"
+  Rules        103 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > GitHub Actions format includes rule codes 2`] = `
@@ -826,7 +826,7 @@ test/fixtures/erb-no-extra-whitespace-inside-tags.html.erb:1:4
   Failing      4 errors (4 offenses across 1 file)
   Not failing  1 info (1 offense across 1 file, below --fail-level=error)
   Fixable      5 offenses | 3 autocorrectable using \`--fix\`
-  Rules        102 enabled | 20 not enabled"
+  Rules        103 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > Ignores disabled rules 1`] = `
@@ -886,7 +886,7 @@ test/fixtures/ignored.html.erb:6:14
   Offenses     2 errors (2 offenses across 1 file)
   Ignored      3 offenses suppressed with herb:disable
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        102 enabled | 20 not enabled"
+  Rules        103 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > allows tag.attributes in attribute position 1`] = `
@@ -946,7 +946,7 @@ test/fixtures/tag-attributes.html.erb:5:0
   Failing      0 offenses
   Not failing  2 warnings (2 offenses across 1 file, below --fail-level=error)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        102 enabled | 20 not enabled"
+  Rules        103 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > diplays only parsers errors if one is present 1`] = `
@@ -972,7 +972,7 @@ test/fixtures/parser-errors.html.erb:2:16
   Checked      1 file
   Offenses     1 error (1 offense across 1 file)
   Fixable      0 offenses
-  Rules        102 enabled | 20 not enabled"
+  Rules        103 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > displays most violated rules with multiple offenses 1`] = `
@@ -1224,7 +1224,7 @@ test/fixtures/multiple-rule-offenses.html.erb:4:7
   Failing      8 errors (8 offenses across 1 file)
   Not failing  6 warnings (6 offenses across 1 file, below --fail-level=error)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        102 enabled | 20 not enabled"
+  Rules        103 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > displays rule offenses when showing all rules 1`] = `
@@ -1349,7 +1349,7 @@ test/fixtures/few-rule-offenses.html.erb:6:0
   Failing      4 errors (4 offenses across 1 file)
   Not failing  2 warnings (2 offenses across 1 file, below --fail-level=error)
   Fixable      6 offenses | 3 autocorrectable using \`--fix\`
-  Rules        102 enabled | 20 not enabled"
+  Rules        103 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats GitHub Actions output correctly for bad file 1`] = `
@@ -1404,7 +1404,7 @@ test/fixtures/bad-file.html.erb:1:16
   Checked      1 file
   Offenses     2 errors (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        102 enabled | 20 not enabled"
+  Rules        103 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats GitHub Actions output correctly for clean file 1`] = `
@@ -1416,7 +1416,7 @@ exports[`CLI Output Formatting > formats GitHub Actions output correctly for cle
   Checked      1 file
   Offenses     0 offenses
   Fixable      0 offenses
-  Rules        102 enabled | 20 not enabled"
+  Rules        103 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats GitHub Actions output correctly for file with errors 1`] = `
@@ -1495,7 +1495,7 @@ test/fixtures/test-file-with-errors.html.erb:2:22
   Failing      2 errors (2 offenses across 1 file)
   Not failing  1 warning (1 offense across 1 file, below --fail-level=error)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        102 enabled | 20 not enabled"
+  Rules        103 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats GitHub Actions output with --format=github option 1`] = `
@@ -1552,7 +1552,7 @@ test/fixtures/test-file-simple.html.erb:2:22
   Checked      1 file
   Offenses     2 errors (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        102 enabled | 20 not enabled"
+  Rules        103 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats JSON output correctly for bad file 1`] = `
@@ -1599,7 +1599,7 @@ exports[`CLI Output Formatting > formats JSON output correctly for bad file 1`] 
   "summary": {
     "filesChecked": 1,
     "filesWithOffenses": 1,
-    "ruleCount": 102,
+    "ruleCount": 103,
     "totalErrors": 2,
     "totalHints": 0,
     "totalIgnored": 0,
@@ -1621,7 +1621,7 @@ exports[`CLI Output Formatting > formats JSON output correctly for clean file 1`
   "summary": {
     "filesChecked": 1,
     "filesWithOffenses": 0,
-    "ruleCount": 102,
+    "ruleCount": 103,
     "totalErrors": 0,
     "totalHints": 0,
     "totalIgnored": 0,
@@ -1695,7 +1695,7 @@ exports[`CLI Output Formatting > formats JSON output correctly for file with err
   "summary": {
     "filesChecked": 1,
     "filesWithOffenses": 1,
-    "ruleCount": 102,
+    "ruleCount": 103,
     "totalErrors": 2,
     "totalHints": 0,
     "totalIgnored": 0,
@@ -1778,7 +1778,7 @@ test/fixtures/test-file-with-errors.html.erb:2:22
   Failing      2 errors (2 offenses across 1 file)
   Not failing  1 warning (1 offense across 1 file, below --fail-level=error)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        102 enabled | 20 not enabled"
+  Rules        103 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats simple output correctly 1`] = `
@@ -1797,7 +1797,7 @@ test/fixtures/test-file-simple.html.erb:
   Checked      1 file
   Offenses     2 errors (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        102 enabled | 20 not enabled"
+  Rules        103 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats simple output for bad-file correctly 1`] = `
@@ -1816,7 +1816,7 @@ test/fixtures/bad-file.html.erb:
   Checked      1 file
   Offenses     2 errors (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        102 enabled | 20 not enabled"
+  Rules        103 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats success output correctly 1`] = `
@@ -1828,7 +1828,7 @@ exports[`CLI Output Formatting > formats success output correctly 1`] = `
   Checked      1 file
   Offenses     0 offenses
   Fixable      0 offenses
-  Rules        102 enabled | 20 not enabled"
+  Rules        103 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > handles boolean attributes 1`] = `
@@ -1840,7 +1840,7 @@ exports[`CLI Output Formatting > handles boolean attributes 1`] = `
   Checked      1 file
   Offenses     0 offenses
   Fixable      0 offenses
-  Rules        102 enabled | 20 not enabled"
+  Rules        103 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > handles multiple errors correctly 1`] = `
@@ -1891,7 +1891,7 @@ test/fixtures/bad-file.html.erb:1:16
   Checked      1 file
   Offenses     2 errors (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        102 enabled | 20 not enabled"
+  Rules        103 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > herb:disable rules 1`] = `
@@ -2034,7 +2034,7 @@ test/fixtures/disabled-1.html.erb:14:19
   Not failing  6 warnings (6 offenses across 1 file, below --fail-level=error)
   Ignored      8 offenses suppressed with herb:disable
   Fixable      8 offenses | 1 autocorrectable using \`--fix\`
-  Rules        102 enabled | 20 not enabled"
+  Rules        103 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > herb:disable rules 2`] = `
@@ -2293,7 +2293,7 @@ test/fixtures/disabled-2.html.erb:2:44
   Not failing  7 warnings (7 offenses across 1 file, below --fail-level=error)
   Ignored      5 offenses suppressed with herb:disable
   Fixable      13 offenses | 6 autocorrectable using \`--fix\`
-  Rules        102 enabled | 20 not enabled"
+  Rules        103 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > non-failing offenses tip > points at --log-level when many offenses don't fail the build 1`] = `
@@ -2331,7 +2331,7 @@ multiple-rule-offenses.html.erb:
   Failing      3 errors (3 offenses across 1 file)
   Not failing  1 info | 10 hints (11 offenses across 1 file, below --fail-level=error)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        102 enabled | 20 not enabled
+  Rules        103 enabled | 20 not enabled
 
  TIP: 11 of the logged offenses don't fail the build.
       Run herb-lint --log-level=error to stop logging them, or set linter.logLevel in your .herb.yml.
@@ -2363,7 +2363,7 @@ multiple-rule-offenses.html.erb:
   Not failing  1 info | 10 hints (11 offenses across 1 file, below --fail-level=error)
   Not shown    11 offenses hidden, show them with --log-level=hint
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        102 enabled | 20 not enabled"
+  Rules        103 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > non-failing offenses tip > stays quiet when --log-level is passed explicitly, even when it hides nothing 1`] = `
@@ -2401,7 +2401,7 @@ multiple-rule-offenses.html.erb:
   Failing      3 errors (3 offenses across 1 file)
   Not failing  1 info | 10 hints (11 offenses across 1 file, below --fail-level=error)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        102 enabled | 20 not enabled"
+  Rules        103 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > non-failing offenses tip > stays quiet when logLevel is set in the config file 1`] = `
@@ -2439,7 +2439,7 @@ multiple-rule-offenses.html.erb:
   Failing      3 errors (3 offenses across 1 file)
   Not failing  1 info | 10 hints (11 offenses across 1 file, below --fail-level=error)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        102 enabled | 20 not enabled"
+  Rules        103 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > non-failing offenses tip > stays quiet when only a handful of offenses don't fail the build 1`] = `
@@ -2477,7 +2477,7 @@ multiple-rule-offenses.html.erb:
   Failing      8 errors (8 offenses across 1 file)
   Not failing  6 warnings (6 offenses across 1 file, below --fail-level=error)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        102 enabled | 20 not enabled"
+  Rules        103 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > points at the flag instead of previewing once there are too many corrections 1`] = `
@@ -2573,7 +2573,7 @@ test/fixtures/test-file-simple.html.erb:2:22
   Checked      1 file
   Offenses     2 errors (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        102 enabled | 20 not enabled"
+  Rules        103 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > previews the correction under each correctable offense 1`] = `
@@ -2630,7 +2630,7 @@ test/fixtures/test-file-simple.html.erb:2:22
   Checked      1 file
   Offenses     2 errors (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        102 enabled | 20 not enabled"
+  Rules        103 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > summary offense buckets > groups every severity into one line when --fail-level is hint 1`] = `
@@ -2667,7 +2667,7 @@ test/fixtures/multiple-rule-offenses.html.erb:
   Checked      1 file
   Offenses     8 errors | 6 warnings (14 offenses across 1 file)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        102 enabled | 20 not enabled"
+  Rules        103 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > summary offense buckets > groups every severity into one line when --fail-level is info 1`] = `
@@ -2704,7 +2704,7 @@ test/fixtures/multiple-rule-offenses.html.erb:
   Checked      1 file
   Offenses     8 errors | 6 warnings (14 offenses across 1 file)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        102 enabled | 20 not enabled"
+  Rules        103 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > summary offense buckets > groups every severity into one line when --fail-level is warning 1`] = `
@@ -2741,7 +2741,7 @@ test/fixtures/multiple-rule-offenses.html.erb:
   Checked      1 file
   Offenses     8 errors | 6 warnings (14 offenses across 1 file)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        102 enabled | 20 not enabled"
+  Rules        103 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > summary offense buckets > moves a severity between buckets as --fail-level is lowered 1`] = `
@@ -2779,7 +2779,7 @@ multiple-rule-offenses.html.erb:
   Failing      8 errors | 4 warnings | 1 info (13 offenses across 1 file)
   Not failing  1 hint (1 offense across 1 file, below --fail-level=info)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        102 enabled | 20 not enabled"
+  Rules        103 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > summary offense buckets > splits the buckets when only some severities fail the build 1`] = `
@@ -2817,7 +2817,7 @@ multiple-rule-offenses.html.erb:
   Failing      8 errors | 4 warnings (12 offenses across 1 file)
   Not failing  1 info | 1 hint (2 offenses across 1 file, below --fail-level=warning)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        102 enabled | 20 not enabled"
+  Rules        103 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > unsafe autocorrectable offenses > counts and tags them separately from offenses --fix can correct 1`] = `
@@ -2937,5 +2937,5 @@ test/fixtures/test-file-with-errors.html.erb:2:22
   Failing      2 errors (2 offenses across 1 file)
   Not failing  1 warning (1 offense across 1 file, below --fail-level=error)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        102 enabled | 20 not enabled"
+  Rules        103 enabled | 20 not enabled"
 `;

--- a/javascript/packages/linter/test/rules/actionview-no-implicit-partial.test.ts
+++ b/javascript/packages/linter/test/rules/actionview-no-implicit-partial.test.ts
@@ -1,0 +1,129 @@
+import dedent from "dedent"
+import { describe, test } from "vitest"
+
+import { ActionViewNoImplicitPartialRule } from "../../src/rules/actionview-no-implicit-partial.js"
+import { createLinterTest } from "../helpers/linter-test-helper.js"
+
+const { expectNoOffenses, expectInfo, assertOffenses } = createLinterTest(ActionViewNoImplicitPartialRule)
+
+function message(object: string): string {
+  return `Rails derives the partial from \`to_partial_path\` on \`${object}\` when the template renders, so the template this renders is not named in this \`<%= render %>\` call. Name it explicitly, with \`object:\` for a single record or \`collection:\` for many, and Herb can take you to it, check the locals you pass against its strict locals, and help you rename them.`
+}
+
+describe("actionview-no-implicit-partial", () => {
+  test("flags a collection render that infers the partial", () => {
+    expectInfo(message("@products"))
+
+    assertOffenses(`<%= render @products %>`)
+  })
+
+  test("reports the offense on the object", () => {
+    expectInfo(message("@products"), [1, 11])
+
+    assertOffenses(`<%= render @products %>`)
+  })
+
+  test("flags a single object render", () => {
+    expectInfo(message("@product"))
+
+    assertOffenses(`<%= render @product %>`)
+  })
+
+  test("flags a local used as the object", () => {
+    expectInfo(message("product"))
+
+    assertOffenses(`<%= render product %>`)
+  })
+
+  test("flags a method call used as the object", () => {
+    expectInfo(message("current_user.notifications"))
+
+    assertOffenses(`<%= render current_user.notifications %>`)
+  })
+
+  test("flags an implicit render inside markup", () => {
+    expectInfo(message("@products"))
+
+    assertOffenses(dedent`
+      <ul class="list">
+        <%= render @products %>
+      </ul>
+    `)
+  })
+
+  test("does not flag an object render that names the partial", () => {
+    expectNoOffenses(`<%= render @products, partial: "product" %>`)
+  })
+
+  test("does not flag the keyword form", () => {
+    expectNoOffenses(`<%= render partial: "product", collection: @products %>`)
+  })
+
+  test("does not flag the keyword form with as:", () => {
+    expectNoOffenses(`<%= render partial: "product", collection: @products, as: :item %>`)
+  })
+
+  test("does not flag a literal partial path", () => {
+    expectNoOffenses(`<%= render "products/product" %>`)
+  })
+
+  test("does not flag an unqualified literal path", () => {
+    expectNoOffenses(`<%= render "product" %>`)
+  })
+
+  test("does not flag an interpolated path", () => {
+    expectNoOffenses('<%= render "products/#{kind}" %>')
+  })
+
+  test("does not flag a dynamic path named with partial:", () => {
+    expectNoOffenses(`<%= render partial: partial_name %>`)
+  })
+
+  test("does not flag a ViewComponent render", () => {
+    expectNoOffenses(`<%= render FlashComponent.new(flash: flash) %>`)
+  })
+
+  test("does not flag a namespaced component render", () => {
+    expectNoOffenses(`<%= render Primer::Alpha::Banner.new(type: :warning) %>`)
+  })
+
+  test("does not flag a component render with a chained call", () => {
+    expectNoOffenses(`<%= render Primer::Beta::Flash.new(scheme: :danger).with_content("x") %>`)
+  })
+
+  test("does not flag a component render without arguments", () => {
+    expectNoOffenses(`<%= render LoadingSpinner::Component.new %>`)
+  })
+
+  test("does not flag a silent render, which actionview-no-silent-render owns", () => {
+    expectNoOffenses(`<% render @products %>`)
+  })
+
+  test("does not flag a trimmed silent render", () => {
+    expectNoOffenses(`<%- render @products %>`)
+  })
+
+  test("does not flag a template render", () => {
+    expectNoOffenses(`<%= render template: "layouts/base" %>`)
+  })
+
+  test("does not flag a literal path with locals", () => {
+    expectNoOffenses(`<%= render "products/product", product: @product %>`)
+  })
+
+  test("does not flag a component built by a factory helper", () => {
+    expectNoOffenses(`<%= render component("ui/modal").new(title: "Hi") %>`)
+  })
+
+  test("does not flag a component built from a method receiver", () => {
+    expectNoOffenses(`<%= render current_component.new(title: "SEO") %>`)
+  })
+
+  test("does not flag a component built from an instance variable", () => {
+    expectNoOffenses(`<%= render @layout.new(facet_field: @facet_field) %>`)
+  })
+
+  test("does not flag a ternary between literal partial names", () => {
+    expectNoOffenses(`<%= render card_view? ? "card_view" : "table_view" %>`)
+  })
+})


### PR DESCRIPTION
This pull request implements the `actionview-no-implicit-partial` linter rule, which reports `render` calls that pass an object or a collection without naming a partial, where Rails derives the template name from the class of each item at runtime.

`render @products` renders `_product.html.erb` once per item, choosing the template from each item's class. Nothing in the call says so:

```erb
<%= render @products %>
```

Naming the partial says it:

```erb
<%= render partial: "products/product", collection: @products %>
```

The implicit form is compact and idiomatic, and it costs the same things every unnamed dependency costs. Searching for the templates that render `_product.html.erb` misses these calls, and changing or subclassing the model changes which template renders, silently.

Naming the partial also turns the call into an edge Herb can follow. Once the template is written down it matches an entry in the partial index, and the language server can jump from the call to the partial and back to every caller, rename a strict local across all of those call sites at once, complete the locals the partial declares as you type them, and report a call that passes a local the partial does not declare or omits one it requires. A derived name matches no entry, which is why the language server says the same thing when you ask it to jump to a partial it cannot resolve.

Resolves #160

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>