### PR TITLE
Parser: Only analyze receiver-less `render` calls as Action View renders

### DIFF
--- a/src/analyze/render_nodes.c
+++ b/src/analyze/render_nodes.c
@@ -45,6 +45,7 @@ static const char* render_keywords[] = {
 
 static bool is_render_call(pm_call_node_t* call_node, pm_parser_t* parser) {
   if (!call_node || !call_node->name) { return false; }
+  if (call_node->receiver && call_node->receiver->type != PM_SELF_NODE) { return false; }
 
   pm_constant_t* constant = pm_constant_pool_id_to_constant(&parser->constant_pool, call_node->name);
 

--- a/test/analyze/render_test.rb
+++ b/test/analyze/render_test.rb
@@ -191,5 +191,29 @@ module Analyze
         <%= render "card", title: @title, body: "Hello", layout: "wide" %>
       HTML
     end
+
+    test "render called on a receiver is not an Action View render" do
+      assert_parsed_snapshot(<<~HTML, render_nodes: true)
+        <%= element.render :headline %>
+      HTML
+    end
+
+    test "render called on a receiver without arguments is not an Action View render" do
+      assert_parsed_snapshot(<<~HTML, render_nodes: true)
+        <%= paginator.render %>
+      HTML
+    end
+
+    test "render called on a receiver with render keywords is not an Action View render" do
+      assert_parsed_snapshot(<<~HTML, render_nodes: true)
+        <%= element.render partial: "card", template: "card" %>
+      HTML
+    end
+
+    test "render called on self is an Action View render" do
+      assert_parsed_snapshot(<<~HTML, render_nodes: true)
+        <%= self.render "shared/header" %>
+      HTML
+    end
   end
 end

--- a/test/snapshots/analyze/render_test/test_0032_render_called_on_a_receiver_is_not_an_Action_View_render_5128ee860c1ee7748f37c5edf3228182-f8009707a6f8814717b65550c888710c.txt
+++ b/test/snapshots/analyze/render_test/test_0032_render_called_on_a_receiver_is_not_an_Action_View_render_5128ee860c1ee7748f37c5edf3228182-f8009707a6f8814717b65550c888710c.txt
@@ -1,0 +1,17 @@
+---
+source: "Analyze::RenderTest#test_0032_render called on a receiver is not an Action View render"
+input: |2-
+<%= element.render :headline %>
+options: {render_nodes: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ ERBContentNode (location: (1:0)-(1:31))
+    │   ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   ├── content: " element.render :headline " (location: (1:3)-(1:29))
+    │   ├── tag_closing: "%>" (location: (1:29)-(1:31))
+    │   ├── parsed: true
+    │   └── valid: true
+    │
+    └── @ HTMLTextNode (location: (1:31)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/render_test/test_0033_render_called_on_a_receiver_without_arguments_is_not_an_Action_View_render_b618aa96e8f235077cfa708f8f1c8c5f-f8009707a6f8814717b65550c888710c.txt
+++ b/test/snapshots/analyze/render_test/test_0033_render_called_on_a_receiver_without_arguments_is_not_an_Action_View_render_b618aa96e8f235077cfa708f8f1c8c5f-f8009707a6f8814717b65550c888710c.txt
@@ -1,0 +1,17 @@
+---
+source: "Analyze::RenderTest#test_0033_render called on a receiver without arguments is not an Action View render"
+input: |2-
+<%= paginator.render %>
+options: {render_nodes: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ ERBContentNode (location: (1:0)-(1:23))
+    │   ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   ├── content: " paginator.render " (location: (1:3)-(1:21))
+    │   ├── tag_closing: "%>" (location: (1:21)-(1:23))
+    │   ├── parsed: true
+    │   └── valid: true
+    │
+    └── @ HTMLTextNode (location: (1:23)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/render_test/test_0034_render_called_on_a_receiver_with_render_keywords_is_not_an_Action_View_render_5b68b5329032ae8b75cd2f95c53f9eb7-f8009707a6f8814717b65550c888710c.txt
+++ b/test/snapshots/analyze/render_test/test_0034_render_called_on_a_receiver_with_render_keywords_is_not_an_Action_View_render_5b68b5329032ae8b75cd2f95c53f9eb7-f8009707a6f8814717b65550c888710c.txt
@@ -1,0 +1,17 @@
+---
+source: "Analyze::RenderTest#test_0034_render called on a receiver with render keywords is not an Action View render"
+input: |2-
+<%= element.render partial: "card", template: "card" %>
+options: {render_nodes: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ ERBContentNode (location: (1:0)-(1:55))
+    │   ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   ├── content: " element.render partial: "card", template: "card" " (location: (1:3)-(1:53))
+    │   ├── tag_closing: "%>" (location: (1:53)-(1:55))
+    │   ├── parsed: true
+    │   └── valid: true
+    │
+    └── @ HTMLTextNode (location: (1:55)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/render_test/test_0035_render_called_on_self_is_an_Action_View_render_dfe9d740f240bfbfcf7352c41750f8aa-f8009707a6f8814717b65550c888710c.txt
+++ b/test/snapshots/analyze/render_test/test_0035_render_called_on_self_is_an_Action_View_render_dfe9d740f240bfbfcf7352c41750f8aa-f8009707a6f8814717b65550c888710c.txt
@@ -1,0 +1,42 @@
+---
+source: "Analyze::RenderTest#test_0035_render called on self is an Action View render"
+input: |2-
+<%= self.render "shared/header" %>
+options: {render_nodes: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ ERBRenderNode (location: (1:0)-(1:34))
+    │   ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   ├── content: " self.render "shared/header" " (location: (1:3)-(1:32))
+    │   ├── tag_closing: "%>" (location: (1:32)-(1:34))
+    │   ├── keywords:
+    │   │   └── @ RubyRenderKeywordsNode (location: (1:0)-(1:34))
+    │   │       ├── partial: "shared/header" (location: (1:16)-(1:31))
+    │   │       ├── template_path: ∅
+    │   │       ├── layout: ∅
+    │   │       ├── file: ∅
+    │   │       ├── inline_template: ∅
+    │   │       ├── body: ∅
+    │   │       ├── plain: ∅
+    │   │       ├── html: ∅
+    │   │       ├── renderable: ∅
+    │   │       ├── collection: ∅
+    │   │       ├── object: ∅
+    │   │       ├── as_name: ∅
+    │   │       ├── spacer_template: ∅
+    │   │       ├── formats: ∅
+    │   │       ├── variants: ∅
+    │   │       ├── handlers: ∅
+    │   │       ├── content_type: ∅
+    │   │       └── locals: []
+    │   │
+    │   ├── body: []
+    │   ├── block_arguments: []
+    │   ├── rescue_clause: ∅
+    │   ├── else_clause: ∅
+    │   ├── ensure_clause: ∅
+    │   └── end_node: ∅
+    │
+    └── @ HTMLTextNode (location: (1:34)-(2:0))
+        └── content: "\n"


### PR DESCRIPTION
This pull request restricts the analysis to calls that have no receiver, which is how Action View's `render` is written in a template.

Previously, `is_render_call` matched on the method name alone, so any call named `render` became an `ERBRenderNode`, whoever the receiver was:

```erb
<%= paginator.render do %>
  <%= link_to_next_page @posts, "Next" %>
<% end %>
```