### PR TITLE
Linter CLI: Keep partial index current when autofix rewrites a partial

### DIFF
--- a/javascript/packages/linter/src/cli/file-processor.ts
+++ b/javascript/packages/linter/src/cli/file-processor.ts
@@ -12,7 +12,7 @@ import { availableParallelism } from "node:os"
 import { colorize } from "@herb-tools/highlighter"
 import { deserializeDiagnostic, didyoumean } from "@herb-tools/core"
 import { fixabilityFor } from "../fixability.js"
-import { buildPartialIndex } from "../partial-index-builder.js"
+import { buildPartialIndex, refreshPartialAfterFix } from "../partial-index-builder.js"
 
 import type { Diagnostic } from "@herb-tools/core"
 import type { FormatOption } from "./argument-parser.js"
@@ -287,6 +287,8 @@ export class FileProcessor {
 
         if (autofixResult.fixed.length > 0) {
           writeFileSync(filePath, autofixResult.source, "utf-8")
+
+          refreshPartialAfterFix(Herb, this.partials, filename, content, autofixResult.source)
 
           filesFixed++
 

--- a/javascript/packages/linter/src/cli/lint-worker.ts
+++ b/javascript/packages/linter/src/cli/lint-worker.ts
@@ -8,7 +8,7 @@ import { Config } from "@herb-tools/config"
 import { Linter } from "../linter.js"
 import { loadCustomRules } from "../loader.js"
 import { fixabilityFor } from "../fixability.js"
-import { partialIndexFrom } from "../partial-index-builder.js"
+import { partialIndexFrom, refreshPartialAfterFix } from "../partial-index-builder.js"
 
 import type { SerializedDiagnostic } from "@herb-tools/core"
 import type { Fixability } from "../fixability.js"
@@ -117,6 +117,7 @@ async function run() {
 
       if (autofixResult.fixed.length > 0) {
         writeFileSync(filePath, autofixResult.source, "utf-8")
+        refreshPartialAfterFix(Herb, partials, filename, content, autofixResult.source)
         filesFixed++
         fixMessages.push(`${filename}\t${autofixResult.fixed.length}`)
       }

--- a/javascript/packages/linter/src/partial-index-builder.ts
+++ b/javascript/packages/linter/src/partial-index-builder.ts
@@ -1,7 +1,7 @@
 import { join } from "node:path"
 import { glob } from "tinyglobby"
 import { readFileSync } from "node:fs"
-import { PARTIAL_GLOB_PATTERN, PartialIndex, STRICT_LOCALS_MARKER, declarationFromDocument, declarationWithoutStrictLocals, outranksTemplate, partialNameForFile } from "@herb-tools/core"
+import { PARTIAL_GLOB_PATTERN, PartialIndex, STRICT_LOCALS_MARKER, declarationFromDocument, declarationWithoutStrictLocals, isPartialPath, outranksTemplate, partialNameForFile } from "@herb-tools/core"
 
 import type { HerbBackend } from "@herb-tools/core"
 import type { PartialDeclaration, SerializedPartialIndex } from "@herb-tools/core"
@@ -58,4 +58,24 @@ export async function buildPartialIndex(herb: HerbBackend, projectPath: string):
 
 export function partialIndexFrom(data: SerializedPartialIndex | undefined): PartialIndex | undefined {
   return data ? PartialIndex.from(data) : undefined
+}
+
+export function refreshPartialAfterFix(herb: HerbBackend, index: PartialIndex | undefined, file: string, before: string, after: string): boolean {
+  if (!index) return false
+  if (!isPartialPath(file)) return false
+
+  const previous = declarationFromSource(herb, file, before)
+  const current = declarationFromSource(herb, file, after)
+
+  if (declarationsMatch(previous, current)) return false
+
+  return index.update(current) !== null
+}
+
+function declarationsMatch(a: PartialDeclaration, b: PartialDeclaration): boolean {
+  if (a.hasDeclaration !== b.hasDeclaration) return false
+  if (a.hasKeywordRest !== b.hasKeywordRest) return false
+  if (a.locals.length !== b.locals.length) return false
+
+  return a.locals.every((local, index) => local.name === b.locals[index].name && local.required === b.locals[index].required)
 }

--- a/javascript/packages/linter/test/partial-index-builder.test.ts
+++ b/javascript/packages/linter/test/partial-index-builder.test.ts
@@ -6,7 +6,7 @@ import { beforeAll, afterEach, describe, expect, test } from "vitest"
 
 import { Herb } from "@herb-tools/node-wasm"
 
-import { buildPartialIndex, findViewRoot } from "../src/partial-index-builder.js"
+import { buildPartialIndex, findViewRoot, refreshPartialAfterFix } from "../src/partial-index-builder.js"
 
 const projects: string[] = []
 
@@ -171,5 +171,46 @@ describe("findViewRoot", () => {
     const root = project({ "templates/_card.html.erb": `<%# locals: (user:) %>\n` })
 
     expect(await findViewRoot(root)).toBe(".")
+  })
+})
+
+describe("refreshPartialAfterFix", () => {
+  const WITHOUT = `<h1><%= title %></h1>\n`
+  const WITH = `<%# locals: (title:) %>\n<h1><%= title %></h1>\n`
+
+  test("updates the index when a fix adds a strict locals declaration", async () => {
+    const root = project({ "app/views/posts/_card.html.erb": WITHOUT })
+    const index = await buildPartialIndex(Herb, root)
+
+    expect(index.lookup("posts/card", "app/views/posts/index.html.erb")?.hasDeclaration).toBe(false)
+
+    const changed = refreshPartialAfterFix(Herb, index, "app/views/posts/_card.html.erb", WITHOUT, WITH)
+
+    expect(changed).toBe(true)
+
+    const declaration = index.lookup("posts/card", "app/views/posts/index.html.erb")
+
+    expect(declaration?.hasDeclaration).toBe(true)
+    expect(declaration?.locals.map(local => local.name)).toEqual(["title"])
+  })
+
+  test("reports no change when the declaration is untouched", async () => {
+    const root = project({ "app/views/posts/_card.html.erb": WITH })
+    const index = await buildPartialIndex(Herb, root)
+
+    const reformatted = `<%# locals: (title:) %>\n<h1><%= title %></h1>\n<p>extra</p>\n`
+
+    expect(refreshPartialAfterFix(Herb, index, "app/views/posts/_card.html.erb", WITH, reformatted)).toBe(false)
+  })
+
+  test("ignores files that are not partials", async () => {
+    const root = project({ "app/views/posts/_card.html.erb": WITH })
+    const index = await buildPartialIndex(Herb, root)
+
+    expect(refreshPartialAfterFix(Herb, index, "app/views/posts/index.html.erb", WITHOUT, WITH)).toBe(false)
+  })
+
+  test("is a no-op without an index", () => {
+    expect(refreshPartialAfterFix(Herb, undefined, "app/views/posts/_card.html.erb", WITHOUT, WITH)).toBe(false)
   })
 })


### PR DESCRIPTION
The CLI builds the partial index once, before any file is linted:

```ts
await this.buildPartialIndexOnce(context)
```

Under `--fix` it then rewrites files as it goes, and one of those rewrites can invalidate what the index holds. `erb-strict-locals-required` prepends a declaration to a partial that has none:

```erb
<%# locals: () %>

<h1><%= title %></h1>
```

That is not a cosmetic edit. It moves the partial from "no strict locals" to "strict locals declaring nothing", which changes the meaning of every `render` that passes it a local. The index still described the file as it was before the fix, so `actionview-no-strict-locals-error` kept resolving to the stale declaration and stayed silent about calls that had just become errors.

Follow up on #2060, which introduced the partial index in the Linter CLI.