### PR TITLE
JavaScript: Externalize declared dependencies instead of inlining them

### DIFF
--- a/javascript/packages/formatter/rollup.config.mjs
+++ b/javascript/packages/formatter/rollup.config.mjs
@@ -2,19 +2,21 @@ import typescript from "@rollup/plugin-typescript"
 import { nodeResolve } from "@rollup/plugin-node-resolve"
 import commonjs from "@rollup/plugin-commonjs"
 import json from "@rollup/plugin-json"
+import { createRequire } from "module"
 
 const external = [
   "path",
   "url",
   "fs",
   "module",
-  "@herb-tools/rewriter"
 ]
 
+const { dependencies } = createRequire(import.meta.url)("./package.json")
+const runtimeDependencies = Object.keys(dependencies ?? {})
+
 function isExternal(id) {
-  return (
-    external.includes(id) ||
-    external.some((pkg) => id === pkg || id.startsWith(pkg + "/"))
+  return [...external, ...runtimeDependencies].some(
+    (pkg) => id === pkg || id.startsWith(pkg + "/")
   )
 }
 
@@ -46,7 +48,7 @@ export default [
       format: "esm",
       sourcemap: true,
     },
-    external: [...external, /@ruby\/prism/],
+    external: isExternal,
     plugins: [
       nodeResolve({ preferBuiltins: true }),
       commonjs(),
@@ -66,7 +68,7 @@ export default [
       format: "cjs",
       sourcemap: true,
     },
-    external: [...external, /@ruby\/prism/],
+    external: isExternal,
     plugins: [
       nodeResolve({ preferBuiltins: true }),
       commonjs(),

--- a/javascript/packages/highlighter/rollup.config.mjs
+++ b/javascript/packages/highlighter/rollup.config.mjs
@@ -2,15 +2,18 @@ import typescript from "@rollup/plugin-typescript"
 import { nodeResolve } from "@rollup/plugin-node-resolve"
 import json from "@rollup/plugin-json"
 import commonjs from "@rollup/plugin-commonjs"
+import { createRequire } from "module"
 
 // Bundle the CLI entry point into a single CommonJS file.
 // Exclude Node built-in so they remain as externals.
 const external = ["path", "url", "fs", "module"]
 
+const { dependencies } = createRequire(import.meta.url)("./package.json")
+const runtimeDependencies = Object.keys(dependencies ?? {})
+
 function isExternal(id) {
-  return (
-    external.includes(id) ||
-    external.some((pkg) => id === pkg || id.startsWith(pkg + "/"))
+  return [...external, ...runtimeDependencies].some(
+    (pkg) => id === pkg || id.startsWith(pkg + "/")
   )
 }
 
@@ -44,7 +47,7 @@ export default [
       format: "esm",
       sourcemap: true,
     },
-    external: ["@herb-tools/core", "@herb-tools/node-wasm", /@ruby\/prism/],
+    external: isExternal,
     plugins: [
       nodeResolve(),
       json(),
@@ -65,7 +68,7 @@ export default [
       format: "cjs",
       sourcemap: true,
     },
-    external: ["@herb-tools/core", "@herb-tools/node-wasm", /@ruby\/prism/],
+    external: isExternal,
     plugins: [
       nodeResolve(),
       commonjs(),

--- a/javascript/packages/linter/rollup.config.mjs
+++ b/javascript/packages/linter/rollup.config.mjs
@@ -3,6 +3,8 @@ import { nodeResolve } from "@rollup/plugin-node-resolve"
 import json from "@rollup/plugin-json"
 import commonjs from "@rollup/plugin-commonjs"
 
+import { createRequire } from "module"
+
 // Bundle the CLI entry point into a single CommonJS file.
 // Exclude Node built-in so they remain as externals.
 const external = [
@@ -19,10 +21,12 @@ const external = [
   "node:worker_threads",
 ]
 
+const { dependencies } = createRequire(import.meta.url)("./package.json")
+const runtimeDependencies = Object.keys(dependencies ?? {})
+
 function isExternal(id) {
-  return (
-    external.includes(id) ||
-    external.some((pkg) => id === pkg || id.startsWith(pkg + "/"))
+  return [...external, ...runtimeDependencies].some(
+    (pkg) => id === pkg || id.startsWith(pkg + "/")
   )
 }
 
@@ -77,7 +81,7 @@ export default [
       format: "esm",
       sourcemap: true,
     },
-    external: ["@herb-tools/core", "@herb-tools/node-wasm", "picomatch", "tinyglobby", /@ruby\/prism/],
+    external: isExternal,
     plugins: [
       nodeResolve(),
       json(),
@@ -98,7 +102,7 @@ export default [
       format: "cjs",
       sourcemap: true,
     },
-    external: ["@herb-tools/core", "@herb-tools/node-wasm", "picomatch", "tinyglobby", /@ruby\/prism/],
+    external: isExternal,
     plugins: [
       nodeResolve(),
       commonjs(),
@@ -119,7 +123,7 @@ export default [
       format: "esm",
       sourcemap: true,
     },
-    external,
+    external: isExternal,
     plugins: [
       nodeResolve({ preferBuiltins: true }),
       commonjs(),
@@ -141,7 +145,7 @@ export default [
       format: "esm",
       sourcemap: true,
     },
-    external,
+    external: isExternal,
     plugins: [
       nodeResolve({ preferBuiltins: true }),
       commonjs(),
@@ -161,7 +165,7 @@ export default [
       format: "cjs",
       sourcemap: true,
     },
-    external,
+    external: isExternal,
     plugins: [
       nodeResolve({ preferBuiltins: true }),
       commonjs(),

--- a/javascript/packages/printer/rollup.config.mjs
+++ b/javascript/packages/printer/rollup.config.mjs
@@ -2,6 +2,7 @@ import typescript from "@rollup/plugin-typescript"
 import { nodeResolve } from "@rollup/plugin-node-resolve"
 import json from "@rollup/plugin-json"
 import commonjs from "@rollup/plugin-commonjs"
+import { createRequire } from "module"
 
 // Bundle the CLI entry point into a single CommonJS file.
 // Exclude Node built-in so they remain as externals.
@@ -12,10 +13,12 @@ const external = [
   "module",
 ]
 
+const { dependencies } = createRequire(import.meta.url)("./package.json")
+const runtimeDependencies = Object.keys(dependencies ?? {})
+
 function isExternal(id) {
-  return (
-    external.includes(id) ||
-    external.some((pkg) => id === pkg || id.startsWith(pkg + "/"))
+  return [...external, ...runtimeDependencies].some(
+    (pkg) => id === pkg || id.startsWith(pkg + "/")
   )
 }
 
@@ -49,7 +52,7 @@ export default [
       format: "esm",
       sourcemap: true,
     },
-    external: ["@herb-tools/core", "@herb-tools/node-wasm", /@ruby\/prism/],
+    external: isExternal,
     plugins: [
       nodeResolve(),
       json(),
@@ -70,7 +73,7 @@ export default [
       format: "cjs",
       sourcemap: true,
     },
-    external: ["@herb-tools/core", "@herb-tools/node-wasm", /@ruby\/prism/],
+    external: isExternal,
     plugins: [
       nodeResolve(),
       commonjs(),

--- a/javascript/packages/rewriter/rollup.config.mjs
+++ b/javascript/packages/rewriter/rollup.config.mjs
@@ -2,15 +2,23 @@ import typescript from "@rollup/plugin-typescript"
 import { nodeResolve } from "@rollup/plugin-node-resolve"
 import commonjs from "@rollup/plugin-commonjs"
 import json from "@rollup/plugin-json"
+import { createRequire } from "module"
 
 const external = [
   "path",
   "url",
   "fs",
   "module",
-  "@herb-tools/tailwind-class-sorter",
-  "tinyglobby"
 ]
+
+const { dependencies } = createRequire(import.meta.url)("./package.json")
+const runtimeDependencies = Object.keys(dependencies ?? {})
+
+function isExternal(id) {
+  return [...external, ...runtimeDependencies].some(
+    (pkg) => id === pkg || id.startsWith(pkg + "/")
+  )
+}
 
 export default [
   // Browser-compatible entry point (core APIs only)
@@ -21,7 +29,7 @@ export default [
       format: "esm",
       sourcemap: true,
     },
-    external: [/@ruby\/prism/],
+    external: isExternal,
     plugins: [
       nodeResolve({ preferBuiltins: true }),
       commonjs(),
@@ -41,7 +49,7 @@ export default [
       format: "cjs",
       sourcemap: true,
     },
-    external: [/@ruby\/prism/],
+    external: isExternal,
     plugins: [
       nodeResolve({ preferBuiltins: true }),
       commonjs(),
@@ -61,7 +69,7 @@ export default [
       format: "esm",
       sourcemap: true,
     },
-    external,
+    external: isExternal,
     plugins: [
       nodeResolve({ preferBuiltins: true }),
       commonjs(),
@@ -81,7 +89,7 @@ export default [
       format: "cjs",
       sourcemap: true,
     },
-    external,
+    external: isExternal,
     plugins: [
       nodeResolve({ preferBuiltins: true }),
       commonjs(),


### PR DESCRIPTION
Every package's CLI, worker and loader bundles externalized only Node builtins, so each one inlined a full copy of its `@herb-tools/*` and `@ruby/prism` dependencies. 

Those same packages are declared as runtime dependencies and get installed anyway. So consumers paid for them once per bundle plus once in `node_modules/`.

Each config now derives its externals from its own `package.json` `dependencies`, which keeps the two from drifting apart and avoids re-introducing the phantom dependencies that broke v0.10.2. Installed size of `@herb-tools/linter` and its dependency tree drops from 92 MB to 53 MB.