### PR TITLE
Engine: Add `ContentForVisitor` and remove `content_for_head` option

### DIFF
--- a/docs/docs/projects/engine.md
+++ b/docs/docs/projects/engine.md
@@ -39,17 +39,16 @@ engine = Herb::Engine.new(source,
 
 In addition to Erubi options, `Herb::Engine` supports:
 
-| Option | Default | Description |
-|---|---|---|
-| `validation_mode` | `:raise` | How to handle validation errors: `:raise`, `:overlay`, or `:none` |
-| `validators` | `{}` | Per-validator overrides (e.g., `{ security: false }`) |
-| `parser_options` | `{}` | [Parser options](/parser-options) forwarded to the parser (e.g., `{ strict: false }`) |
-| `visitors` | `[]` | AST visitors to run before compilation |
-| `project_path` | `Dir.pwd` | Project root for relative path resolution |
-| `content_for_head` | `nil` | HTML injected before the closing `</head>` tag |
-| `validate_ruby` | `false` | Raise if the compiled output isn't valid Ruby |
-| `optimize` | `false` | Compile-time optimizations for Action View helpers (experimental) |
-| `debug` | `false` | Enable debug mode |
+| Option            | Default   | Description                                                                           |
+|-------------------|-----------|---------------------------------------------------------------------------------------|
+| `validation_mode` | `:raise`  | How to handle validation errors: `:raise`, `:overlay`, or `:none`                     |
+| `validators`      | `{}`      | Per-validator overrides (e.g., `{ security: false }`)                                 |
+| `parser_options`  | `{}`      | [Parser options](/parser-options) forwarded to the parser (e.g., `{ strict: false }`) |
+| `visitors`        | `[]`      | AST visitors to run before compilation                                                |
+| `project_path`    | `Dir.pwd` | Project root for relative path resolution                                             |
+| `validate_ruby`   | `false`   | Raise if the compiled output isn't valid Ruby                                         |
+| `optimize`        | `false`   | Compile-time optimizations for Action View helpers (experimental)                     |
+| `debug`           | `false`   | Enable debug mode                                                                     |
 
 Strict parsing is a parser option rather than an engine option, so it is set through `parser_options`, together with any other [parser option](/parser-options):
 
@@ -61,11 +60,11 @@ Herb::Engine.new(source, parser_options: { strict: false })
 
 The engine runs validators on parsed templates to catch errors before compilation. Each validator can be enabled or disabled via [`.herb.yml` configuration](/configuration#engine-configuration) or per-instance overrides.
 
-| Validator | Description |
-|---|---|
-| Security | Detects ERB output in unsafe positions (attribute names, attribute positions) |
-| Nesting | Validates HTML nesting rules (e.g., no `<div>` inside `<p>`) |
-| Accessibility | Validates accessibility-related attributes |
+| Validator     | Description                                                                   |
+|---------------|-------------------------------------------------------------------------------|
+| Security      | Detects ERB output in unsafe positions (attribute names, attribute positions) |
+| Nesting       | Validates HTML nesting rules (e.g., no `<div>` inside `<p>`)                  |
+| Accessibility | Validates accessibility-related attributes                                    |
 
 Disable security validator for this template:
 ```ruby
@@ -88,10 +87,11 @@ The `visitors` option accepts [visitors](/bindings/ruby/reference#visitors) that
 
 Herb ships the following transform visitors:
 
-| Visitor | Description |
-|---|---|
-| `AutoCloseOmittedTagsVisitor` | Replaces omitted closing tags with explicit ones |
-| `ComponentVisitor` | Rewrites capitalized tags into `render` calls (experimental) |
+| Visitor                       | Description                                                  |
+|-------------------------------|--------------------------------------------------------------|
+| `AutoCloseOmittedTagsVisitor` | Replaces omitted closing tags with explicit ones             |
+| `ContentForVisitor`           | Appends HTML to the end of every matching element            |
+| `ComponentVisitor`            | Rewrites capitalized tags into `render` calls (experimental) |
 
 Transform visitors are not loaded when you `require "herb"`. Require the ones you want and pass them to the engine:
 
@@ -126,6 +126,59 @@ The engine renders:
 ```
 
 The closing tag is inserted where the parser determined the element ends, which keeps the surrounding whitespace (and therefore the rendering of `inline-block` elements) identical to the template without the visitor.
+
+### `ContentForVisitor`
+
+Appends HTML to the end of every element matching a tag name, so that it ends up right before that element's closing tag.
+
+```ruby
+require "herb/engine/content_for_visitor"
+
+Herb::Engine.new(source, visitors: [
+  Herb::Engine::ContentForVisitor.new("<p>Footer</p>", tag_name: "main")
+])
+```
+
+Tag names are matched case-insensitively, and every matching element in the template gets the content, including nested ones.
+
+Pass `attributes` to narrow which elements match. Every condition in the hash has to hold:
+
+```ruby
+Herb::Engine::ContentForVisitor.new(
+  "<p>Footer</p>",
+  tag_name: "main",
+  attributes: { "id" => "content", "data-role" => /page/, "hidden" => false }
+)
+```
+
+| Condition     | Matches when                                 |
+|---------------|----------------------------------------------|
+| `true`        | The attribute is present, whatever its value |
+| `false`       | The attribute is absent                      |
+| A `Regexp`    | The attribute value matches it               |
+| Anything else | The attribute value is equal to it           |
+
+Attribute names are matched case-insensitively, and may be given as strings or symbols. An attribute whose value is built from ERB has no value known at compile time, so it matches `true` but never a string or `Regexp` condition.
+
+Multiple visitors compose, and each appends after the last, in the order you pass them.
+
+Given this template and a visitor for the `head` tag:
+
+```html+erb
+<head>
+  <title>Hello</title>
+</head>
+```
+
+The engine renders:
+
+```html
+<head>
+  <title>Hello</title>
+<meta name="herb" content="1"></head>
+```
+
+The content is emitted as a Ruby string literal marked `html_safe`, so it is never escaped, and quotes, backslashes and `#{}` in it are not interpreted.
 
 ### `ComponentVisitor`
 

--- a/lib/herb/engine.rb
+++ b/lib/herb/engine.rb
@@ -18,7 +18,7 @@ require_relative "engine/validators/render_validator"
 
 module Herb
   class Engine
-    attr_reader :src, :filename, :project_path, :relative_file_path, :bufvar, :debug, :content_for_head,
+    attr_reader :src, :filename, :project_path, :relative_file_path, :bufvar, :debug,
                 :validation_error_template, :visitors, :enabled_validators
 
     # @rbs!
@@ -76,7 +76,6 @@ module Herb
       @chain_appends = properties[:chain_appends]
       @buffer_on_stack = false
       @debug = properties.fetch(:debug, Herb.configuration.engine_option("debug", false))
-      @content_for_head = properties[:content_for_head]
       @validation_error_template = nil
       @validation_mode = properties.fetch(:validation_mode, :raise)
       @enabled_validators = Herb.configuration.enabled_validators(properties[:validators] || {})

--- a/lib/herb/engine/compiler.rb
+++ b/lib/herb/engine/compiler.rb
@@ -157,13 +157,6 @@ module Herb
       end
 
       def visit_html_close_tag_node(node)
-        tag_name = node.tag_name&.value&.downcase
-
-        if @engine.content_for_head && tag_name == "head"
-          escaped_html = @engine.content_for_head.gsub("'", "\\\\'")
-          @tokens << [:expr, "'#{escaped_html}'.html_safe", current_context]
-        end
-
         add_text(node.tag_opening&.value)
         add_text(node.tag_name&.value)
         add_text(node.tag_closing&.value)

--- a/lib/herb/engine/content_for_visitor.rb
+++ b/lib/herb/engine/content_for_visitor.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+# typed: false
+
+require_relative "../../herb"
+
+module Herb
+  class Engine
+    # Appends HTML to the end of every element matching a tag name, and optionally a set of
+    # attribute conditions, so that the compiled output always contains it before the
+    # element's closing tag.
+    #
+    # An attribute condition matches on `true` when the attribute is present, on `false` when
+    # it is absent, on a `Regexp` when the attribute value matches it, and on anything else
+    # when the attribute value is equal to it. An attribute whose value is built from ERB has
+    # no value known at compile time, so it only matches the `true` condition.
+    #
+    # This visitor is not loaded by default. Require it explicitly and pass it to the engine:
+    #
+    #     require "herb/engine/content_for_visitor"
+    #
+    #     Herb::Engine.new(source, visitors: [
+    #       Herb::Engine::ContentForVisitor.new("<p>Footer</p>", tag_name: "main", attributes: { "id" => "content" })
+    #     ])
+    #
+    class ContentForVisitor < Herb::Visitor
+      #: (String?, tag_name: String, ?attributes: Hash[untyped, untyped]) -> void
+      def initialize(content, tag_name:, attributes: {})
+        super()
+
+        @content = content
+        @tag_name = tag_name.downcase
+        @attributes = attributes.transform_keys { |name| name.to_s.downcase }
+      end
+
+      #: (Herb::AST::HTMLElementNode) -> void
+      def visit_html_element_node(node)
+        super
+
+        return if @content.nil? || @content.empty?
+        return unless matches?(node)
+
+        node.body << content_node
+      end
+
+      #: () -> String
+      def inspect
+        "#<#{self.class.name} tag_name=#{@tag_name.inspect} attributes=#{@attributes.inspect} content=#{@content.inspect}>"
+      end
+
+      private
+
+      #: () -> Herb::AST::RubyLiteralNode
+      def content_node
+        Herb::AST::RubyLiteralNode.build(content: "#{@content.dump}.html_safe")
+      end
+
+      #: (Herb::AST::HTMLElementNode) -> bool
+      def matches?(node)
+        return false unless node.tag_name&.value&.downcase == @tag_name
+        return true if @attributes.empty?
+
+        attributes = element_attributes(node)
+
+        @attributes.all? { |name, condition| attribute_matches?(attributes, name, condition) }
+      end
+
+      #: (Hash[String, String?], String, untyped) -> bool
+      def attribute_matches?(attributes, name, condition)
+        present = attributes.key?(name)
+        value = attributes[name]
+
+        case condition
+        when true then present
+        when false then !present
+        when Regexp then !value.nil? && condition.match?(value)
+        else !value.nil? && condition.to_s == value
+        end
+      end
+
+      #: (Herb::AST::HTMLElementNode) -> Hash[String, String?]
+      def element_attributes(node)
+        open_tag = node.open_tag
+        attributes = {} #: Hash[String, String?]
+
+        return attributes unless open_tag.is_a?(Herb::AST::HTMLOpenTagNode)
+
+        (open_tag.children || []).each do |child|
+          next unless child.is_a?(Herb::AST::HTMLAttributeNode)
+
+          name = attribute_name(child)
+
+          next unless name
+          next if attributes.key?(name)
+
+          attributes[name] = attribute_value(child)
+        end
+
+        attributes
+      end
+
+      #: (Herb::AST::HTMLAttributeNode) -> String?
+      def attribute_name(node)
+        children = node.name&.children
+
+        return nil unless children
+
+        name = children.filter_map { |child| child.content if child.is_a?(Herb::AST::LiteralNode) }.join
+
+        name.empty? ? nil : name.downcase
+      end
+
+      #: (Herb::AST::HTMLAttributeNode) -> String?
+      def attribute_value(node)
+        value = node.value
+
+        return nil unless value
+
+        children = value.children || []
+
+        return "" if children.empty?
+        return nil unless children.all?(Herb::AST::LiteralNode)
+
+        children.filter_map { |child| child.content if child.is_a?(Herb::AST::LiteralNode) }.join
+      end
+    end
+  end
+end

--- a/sig/herb/engine.rbs
+++ b/sig/herb/engine.rbs
@@ -14,8 +14,6 @@ module Herb
 
     attr_reader debug: untyped
 
-    attr_reader content_for_head: untyped
-
     attr_reader validation_error_template: untyped
 
     attr_reader visitors: untyped

--- a/sig/herb/engine/content_for_visitor.rbs
+++ b/sig/herb/engine/content_for_visitor.rbs
@@ -1,0 +1,52 @@
+# Generated from lib/herb/engine/content_for_visitor.rb with RBS::Inline
+
+module Herb
+  class Engine
+    # Appends HTML to the end of every element matching a tag name, and optionally a set of
+    # attribute conditions, so that the compiled output always contains it before the
+    # element's closing tag.
+    #
+    # An attribute condition matches on `true` when the attribute is present, on `false` when
+    # it is absent, on a `Regexp` when the attribute value matches it, and on anything else
+    # when the attribute value is equal to it. An attribute whose value is built from ERB has
+    # no value known at compile time, so it only matches the `true` condition.
+    #
+    # This visitor is not loaded by default. Require it explicitly and pass it to the engine:
+    #
+    #     require "herb/engine/content_for_visitor"
+    #
+    #     Herb::Engine.new(source, visitors: [
+    #       Herb::Engine::ContentForVisitor.new("<p>Footer</p>", tag_name: "main", attributes: { "id" => "content" })
+    #     ])
+    class ContentForVisitor < Herb::Visitor
+      # : (String?, tag_name: String, ?attributes: Hash[untyped, untyped]) -> void
+      def initialize: (String?, tag_name: String, ?attributes: Hash[untyped, untyped]) -> void
+
+      # : (Herb::AST::HTMLElementNode) -> void
+      def visit_html_element_node: (Herb::AST::HTMLElementNode) -> void
+
+      # : () -> String
+      def inspect: () -> String
+
+      private
+
+      # : () -> Herb::AST::RubyLiteralNode
+      def content_node: () -> Herb::AST::RubyLiteralNode
+
+      # : (Herb::AST::HTMLElementNode) -> bool
+      def matches?: (Herb::AST::HTMLElementNode) -> bool
+
+      # : (Hash[String, String?], String, untyped) -> bool
+      def attribute_matches?: (Hash[String, String?], String, untyped) -> bool
+
+      # : (Herb::AST::HTMLElementNode) -> Hash[String, String?]
+      def element_attributes: (Herb::AST::HTMLElementNode) -> Hash[String, String?]
+
+      # : (Herb::AST::HTMLAttributeNode) -> String?
+      def attribute_name: (Herb::AST::HTMLAttributeNode) -> String?
+
+      # : (Herb::AST::HTMLAttributeNode) -> String?
+      def attribute_value: (Herb::AST::HTMLAttributeNode) -> String?
+    end
+  end
+end

--- a/test/engine/content_for_visitor_test.rb
+++ b/test/engine/content_for_visitor_test.rb
@@ -1,0 +1,228 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+require_relative "../snapshot_utils"
+require_relative "../../lib/herb/engine"
+require_relative "../../lib/herb/engine/auto_close_omitted_tags_visitor"
+require_relative "../../lib/herb/engine/content_for_visitor"
+
+module Engine
+  class ContentForVisitorTest < Minitest::Spec
+    include SnapshotUtils
+
+    CONTENT = "<p>Appended</p>"
+
+    def content_for_options(tag_name:, attributes: {}, content: CONTENT)
+      {
+        escape: false,
+        parser_options: { strict: false },
+        visitors: [Herb::Engine::ContentForVisitor.new(content, tag_name: tag_name, attributes: attributes)],
+      }
+    end
+
+    def two_visitor_options
+      {
+        escape: false,
+        parser_options: { strict: false },
+        visitors: [
+          Herb::Engine::ContentForVisitor.new(%(<meta name="first" content="1">), tag_name: "head"),
+          Herb::Engine::ContentForVisitor.new(%(<meta name="second" content="2">), tag_name: "head")
+        ],
+      }
+    end
+
+    test "visitor is not loaded when only requiring herb" do
+      load_path = $LOAD_PATH.map { |path| "-I#{path}" }.join(" ")
+      output = `#{Gem.ruby} #{load_path} -e 'require "herb"; print defined?(Herb::Engine::ContentForVisitor).inspect' 2>&1`
+
+      assert_equal "nil", output
+    end
+
+    test "content is appended to an arbitrary tag - compilation" do
+      template = "<body><h1>Title</h1></body>"
+
+      assert_compiled_snapshot(template, content_for_options(tag_name: "body"))
+    end
+
+    test "content is appended to an arbitrary tag - render" do
+      template = "<body><h1>Title</h1></body>"
+
+      assert_evaluated_snapshot(template, {}, content_for_options(tag_name: "body"))
+    end
+
+    test "every matching element gets the content - render" do
+      template = "<section>One</section><section>Two</section>"
+
+      assert_evaluated_snapshot(template, {}, content_for_options(tag_name: "section"))
+    end
+
+    test "nested matching elements each get the content - render" do
+      template = "<div><div>Inner</div></div>"
+
+      assert_evaluated_snapshot(template, {}, content_for_options(tag_name: "div"))
+    end
+
+    test "tag name matching is case insensitive - render" do
+      template = "<SECTION>Content</SECTION>"
+
+      assert_evaluated_snapshot(template, {}, content_for_options(tag_name: "section"))
+    end
+
+    test "a non-matching tag is left alone - render" do
+      template = "<article>Content</article>"
+
+      assert_evaluated_snapshot(template, {}, content_for_options(tag_name: "section"))
+    end
+
+    test "an attribute value condition matches - render" do
+      template = %(<main id="content">One</main><main id="other">Two</main>)
+
+      assert_evaluated_snapshot(template, {}, content_for_options(tag_name: "main", attributes: { "id" => "content" }))
+    end
+
+    test "an attribute value condition that does not match leaves the element alone - render" do
+      template = %(<main id="other">Content</main>)
+
+      assert_evaluated_snapshot(template, {}, content_for_options(tag_name: "main", attributes: { "id" => "content" }))
+    end
+
+    test "a true condition matches on attribute presence - render" do
+      template = %(<main data-role>One</main><main>Two</main>)
+
+      assert_evaluated_snapshot(template, {}, content_for_options(tag_name: "main", attributes: { "data-role" => true }))
+    end
+
+    test "a false condition matches on attribute absence - render" do
+      template = %(<main data-role>One</main><main>Two</main>)
+
+      assert_evaluated_snapshot(template, {}, content_for_options(tag_name: "main", attributes: { "data-role" => false }))
+    end
+
+    test "a regexp condition matches the attribute value - render" do
+      template = %(<main class="a-panel">One</main><main class="a-card">Two</main>)
+
+      assert_evaluated_snapshot(template, {}, content_for_options(tag_name: "main", attributes: { "class" => /panel/ }))
+    end
+
+    test "all attribute conditions have to match - render" do
+      template = %(<main id="content" data-role="page">One</main><main id="content">Two</main>)
+
+      assert_evaluated_snapshot(
+        template,
+        {},
+        content_for_options(tag_name: "main", attributes: { "id" => "content", "data-role" => "page" })
+      )
+    end
+
+    test "attribute name matching is case insensitive - render" do
+      template = %(<main ID="content">Content</main>)
+
+      assert_evaluated_snapshot(template, {}, content_for_options(tag_name: "main", attributes: { "Id" => "content" }))
+    end
+
+    test "a symbol attribute name is matched - render" do
+      template = %(<main id="content">Content</main>)
+
+      assert_evaluated_snapshot(template, {}, content_for_options(tag_name: "main", attributes: { id: "content" }))
+    end
+
+    test "an ERB attribute value has no compile time value so a string condition does not match - render" do
+      template = %(<main id="<%= @id %>">Content</main>)
+
+      assert_evaluated_snapshot(
+        template,
+        { "@id": "content" },
+        content_for_options(tag_name: "main", attributes: { "id" => "content" })
+      )
+    end
+
+    test "an ERB attribute value still matches a presence condition - render" do
+      template = %(<main id="<%= @id %>">Content</main>)
+
+      assert_evaluated_snapshot(
+        template,
+        { "@id": "content" },
+        content_for_options(tag_name: "main", attributes: { "id" => true })
+      )
+    end
+
+    test "an empty attribute value matches an empty string condition - render" do
+      template = %(<main id="">Content</main>)
+
+      assert_evaluated_snapshot(template, {}, content_for_options(tag_name: "main", attributes: { "id" => "" }))
+    end
+
+    test "nil content is a no-op - render" do
+      template = "<section>Content</section>"
+
+      assert_evaluated_snapshot(template, {}, content_for_options(tag_name: "section", content: nil))
+    end
+
+    test "empty content is a no-op - render" do
+      template = "<section>Content</section>"
+
+      assert_evaluated_snapshot(template, {}, content_for_options(tag_name: "section", content: ""))
+    end
+
+    test "ERB in the element body is kept before the content - render" do
+      template = "<main><h1><%= @title %></h1></main>"
+
+      assert_evaluated_snapshot(template, { "@title": "Hello" }, content_for_options(tag_name: "main"))
+    end
+
+    test "an element inside an ERB block gets the content - render" do
+      template = "<% if true %><main>Content</main><% end %>"
+
+      assert_evaluated_snapshot(template, {}, content_for_options(tag_name: "main"))
+    end
+
+    test "single quotes in the content are escaped - render" do
+      template = "<main></main>"
+
+      assert_evaluated_snapshot(template, {}, content_for_options(tag_name: "main", content: %(<p class='single'></p>)))
+    end
+
+    test "double quotes in the content are escaped - render" do
+      template = "<main></main>"
+
+      assert_evaluated_snapshot(template, {}, content_for_options(tag_name: "main", content: %(<p class="double"></p>)))
+    end
+
+    test "a backslash in the content is escaped - render" do
+      template = "<main></main>"
+
+      assert_evaluated_snapshot(template, {}, content_for_options(tag_name: "main", content: %(<p class="back\\slash"></p>)))
+    end
+
+    test "Ruby interpolation in the content is not evaluated - render" do
+      template = "<main></main>"
+
+      assert_evaluated_snapshot(template, {}, content_for_options(tag_name: "main", content: "<p>\#{1 + 1}</p>"))
+    end
+
+    test "two visitors append their content in order - compilation" do
+      template = "<head><title>Hello</title></head>"
+
+      assert_compiled_snapshot(template, two_visitor_options)
+    end
+
+    test "two visitors append their content in order - render" do
+      template = "<head><title>Hello</title></head>"
+
+      assert_evaluated_snapshot(template, {}, two_visitor_options)
+    end
+
+    test "composes with AutoCloseOmittedTagsVisitor - render" do
+      template = "<head><title>Hello</title></head><ul><li>One<li>Two</ul>"
+
+      assert_evaluated_snapshot(template, {}, {
+        escape: false,
+        parser_options: { strict: false },
+        visitors: [
+          Herb::Engine::ContentForVisitor.new(%(<meta name="herb" content="1">), tag_name: "head"),
+          Herb::Engine::AutoCloseOmittedTagsVisitor.new
+        ],
+      })
+    end
+  end
+end

--- a/test/snapshots/engine/content_for_visitor_test/test_0002_content_is_appended_to_an_arbitrary_tag_-_compilation_7a3d41dc69ae726fc1e5c2c59f0219c6.txt
+++ b/test/snapshots/engine/content_for_visitor_test/test_0002_content_is_appended_to_an_arbitrary_tag_-_compilation_7a3d41dc69ae726fc1e5c2c59f0219c6.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::ContentForVisitorTest#test_0002_content is appended to an arbitrary tag - compilation"
+input: "{source: \"<body><h1>Title</h1></body>\", options: {escape: false, parser_options: {strict: false}, visitors: [#<Herb::Engine::ContentForVisitor tag_name=\"body\" attributes={} content=\"<p>Appended</p>\">]}}"
+---
+_buf = ::String.new; _buf << '<body><h1>Title</h1>'.freeze; _buf << ("<p>Appended</p>".html_safe).to_s; _buf << '</body>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/content_for_visitor_test/test_0003_content_is_appended_to_an_arbitrary_tag_-_render_8fb074e6cc265916dafd740a474e9833.txt
+++ b/test/snapshots/engine/content_for_visitor_test/test_0003_content_is_appended_to_an_arbitrary_tag_-_render_8fb074e6cc265916dafd740a474e9833.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::ContentForVisitorTest#test_0003_content is appended to an arbitrary tag - render"
+input: "{source: \"<body><h1>Title</h1></body>\", locals: {}, options: {escape: false, parser_options: {strict: false}, visitors: [#<Herb::Engine::ContentForVisitor tag_name=\"body\" attributes={} content=\"<p>Appended</p>\">]}}"
+---
+<body><h1>Title</h1><p>Appended</p></body>

--- a/test/snapshots/engine/content_for_visitor_test/test_0004_every_matching_element_gets_the_content_-_render_7ca1d510c969fcad537aa2865ceeb3a8.txt
+++ b/test/snapshots/engine/content_for_visitor_test/test_0004_every_matching_element_gets_the_content_-_render_7ca1d510c969fcad537aa2865ceeb3a8.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::ContentForVisitorTest#test_0004_every matching element gets the content - render"
+input: "{source: \"<section>One</section><section>Two</section>\", locals: {}, options: {escape: false, parser_options: {strict: false}, visitors: [#<Herb::Engine::ContentForVisitor tag_name=\"section\" attributes={} content=\"<p>Appended</p>\">]}}"
+---
+<section>One<p>Appended</p></section><section>Two<p>Appended</p></section>

--- a/test/snapshots/engine/content_for_visitor_test/test_0005_nested_matching_elements_each_get_the_content_-_render_89727f84bc185dd7530416c752e1d354.txt
+++ b/test/snapshots/engine/content_for_visitor_test/test_0005_nested_matching_elements_each_get_the_content_-_render_89727f84bc185dd7530416c752e1d354.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::ContentForVisitorTest#test_0005_nested matching elements each get the content - render"
+input: "{source: \"<div><div>Inner</div></div>\", locals: {}, options: {escape: false, parser_options: {strict: false}, visitors: [#<Herb::Engine::ContentForVisitor tag_name=\"div\" attributes={} content=\"<p>Appended</p>\">]}}"
+---
+<div><div>Inner<p>Appended</p></div><p>Appended</p></div>

--- a/test/snapshots/engine/content_for_visitor_test/test_0006_tag_name_matching_is_case_insensitive_-_render_59d9e760e30dfa226c749ea1a9aa8bc5.txt
+++ b/test/snapshots/engine/content_for_visitor_test/test_0006_tag_name_matching_is_case_insensitive_-_render_59d9e760e30dfa226c749ea1a9aa8bc5.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::ContentForVisitorTest#test_0006_tag name matching is case insensitive - render"
+input: "{source: \"<SECTION>Content</SECTION>\", locals: {}, options: {escape: false, parser_options: {strict: false}, visitors: [#<Herb::Engine::ContentForVisitor tag_name=\"section\" attributes={} content=\"<p>Appended</p>\">]}}"
+---
+<SECTION>Content<p>Appended</p></SECTION>

--- a/test/snapshots/engine/content_for_visitor_test/test_0007_a_non-matching_tag_is_left_alone_-_render_e3827d3c3c31239c02e05146f18087a1.txt
+++ b/test/snapshots/engine/content_for_visitor_test/test_0007_a_non-matching_tag_is_left_alone_-_render_e3827d3c3c31239c02e05146f18087a1.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::ContentForVisitorTest#test_0007_a non-matching tag is left alone - render"
+input: "{source: \"<article>Content</article>\", locals: {}, options: {escape: false, parser_options: {strict: false}, visitors: [#<Herb::Engine::ContentForVisitor tag_name=\"section\" attributes={} content=\"<p>Appended</p>\">]}}"
+---
+<article>Content</article>

--- a/test/snapshots/engine/content_for_visitor_test/test_0008_an_attribute_value_condition_matches_-_render_4646d2c05ae36e877818be4558d17d2a.txt
+++ b/test/snapshots/engine/content_for_visitor_test/test_0008_an_attribute_value_condition_matches_-_render_4646d2c05ae36e877818be4558d17d2a.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::ContentForVisitorTest#test_0008_an attribute value condition matches - render"
+input: "{source: \"<main id=\\\"content\\\">One</main><main id=\\\"other\\\">Two</main>\", locals: {}, options: {escape: false, parser_options: {strict: false}, visitors: [#<Herb::Engine::ContentForVisitor tag_name=\"main\" attributes={\"id\" => \"content\"} content=\"<p>Appended</p>\">]}}"
+---
+<main id="content">One<p>Appended</p></main><main id="other">Two</main>

--- a/test/snapshots/engine/content_for_visitor_test/test_0009_an_attribute_value_condition_that_does_not_match_leaves_the_element_alone_-_render_44adb8cd1cbdc31287a7c974f531766d.txt
+++ b/test/snapshots/engine/content_for_visitor_test/test_0009_an_attribute_value_condition_that_does_not_match_leaves_the_element_alone_-_render_44adb8cd1cbdc31287a7c974f531766d.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::ContentForVisitorTest#test_0009_an attribute value condition that does not match leaves the element alone - render"
+input: "{source: \"<main id=\\\"other\\\">Content</main>\", locals: {}, options: {escape: false, parser_options: {strict: false}, visitors: [#<Herb::Engine::ContentForVisitor tag_name=\"main\" attributes={\"id\" => \"content\"} content=\"<p>Appended</p>\">]}}"
+---
+<main id="other">Content</main>

--- a/test/snapshots/engine/content_for_visitor_test/test_0010_a_true_condition_matches_on_attribute_presence_-_render_7599deee7ed07d6504952463cb5ade65.txt
+++ b/test/snapshots/engine/content_for_visitor_test/test_0010_a_true_condition_matches_on_attribute_presence_-_render_7599deee7ed07d6504952463cb5ade65.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::ContentForVisitorTest#test_0010_a true condition matches on attribute presence - render"
+input: "{source: \"<main data-role>One</main><main>Two</main>\", locals: {}, options: {escape: false, parser_options: {strict: false}, visitors: [#<Herb::Engine::ContentForVisitor tag_name=\"main\" attributes={\"data-role\" => true} content=\"<p>Appended</p>\">]}}"
+---
+<main data-role>One<p>Appended</p></main><main>Two</main>

--- a/test/snapshots/engine/content_for_visitor_test/test_0011_a_false_condition_matches_on_attribute_absence_-_render_1a03119516838f0580f8b02cd457cee7.txt
+++ b/test/snapshots/engine/content_for_visitor_test/test_0011_a_false_condition_matches_on_attribute_absence_-_render_1a03119516838f0580f8b02cd457cee7.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::ContentForVisitorTest#test_0011_a false condition matches on attribute absence - render"
+input: "{source: \"<main data-role>One</main><main>Two</main>\", locals: {}, options: {escape: false, parser_options: {strict: false}, visitors: [#<Herb::Engine::ContentForVisitor tag_name=\"main\" attributes={\"data-role\" => false} content=\"<p>Appended</p>\">]}}"
+---
+<main data-role>One</main><main>Two<p>Appended</p></main>

--- a/test/snapshots/engine/content_for_visitor_test/test_0012_a_regexp_condition_matches_the_attribute_value_-_render_8fe5cf75714ac7cc0795d2921b993008.txt
+++ b/test/snapshots/engine/content_for_visitor_test/test_0012_a_regexp_condition_matches_the_attribute_value_-_render_8fe5cf75714ac7cc0795d2921b993008.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::ContentForVisitorTest#test_0012_a regexp condition matches the attribute value - render"
+input: "{source: \"<main class=\\\"a-panel\\\">One</main><main class=\\\"a-card\\\">Two</main>\", locals: {}, options: {escape: false, parser_options: {strict: false}, visitors: [#<Herb::Engine::ContentForVisitor tag_name=\"main\" attributes={\"class\" => /panel/} content=\"<p>Appended</p>\">]}}"
+---
+<main class="a-panel">One<p>Appended</p></main><main class="a-card">Two</main>

--- a/test/snapshots/engine/content_for_visitor_test/test_0013_all_attribute_conditions_have_to_match_-_render_326af512d9063c2378ddabbc11a199ea.txt
+++ b/test/snapshots/engine/content_for_visitor_test/test_0013_all_attribute_conditions_have_to_match_-_render_326af512d9063c2378ddabbc11a199ea.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::ContentForVisitorTest#test_0013_all attribute conditions have to match - render"
+input: "{source: \"<main id=\\\"content\\\" data-role=\\\"page\\\">One</main><main id=\\\"content\\\">Two</main>\", locals: {}, options: {escape: false, parser_options: {strict: false}, visitors: [#<Herb::Engine::ContentForVisitor tag_name=\"main\" attributes={\"id\" => \"content\", \"data-role\" => \"page\"} content=\"<p>Appended</p>\">]}}"
+---
+<main id="content" data-role="page">One<p>Appended</p></main><main id="content">Two</main>

--- a/test/snapshots/engine/content_for_visitor_test/test_0014_attribute_name_matching_is_case_insensitive_-_render_fe83b1d4aa83e2e46c1b42a76f9448a5.txt
+++ b/test/snapshots/engine/content_for_visitor_test/test_0014_attribute_name_matching_is_case_insensitive_-_render_fe83b1d4aa83e2e46c1b42a76f9448a5.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::ContentForVisitorTest#test_0014_attribute name matching is case insensitive - render"
+input: "{source: \"<main ID=\\\"content\\\">Content</main>\", locals: {}, options: {escape: false, parser_options: {strict: false}, visitors: [#<Herb::Engine::ContentForVisitor tag_name=\"main\" attributes={\"id\" => \"content\"} content=\"<p>Appended</p>\">]}}"
+---
+<main ID="content">Content<p>Appended</p></main>

--- a/test/snapshots/engine/content_for_visitor_test/test_0015_a_symbol_attribute_name_is_matched_-_render_ea07a77e07b2ddaab975f1a08d0c186c.txt
+++ b/test/snapshots/engine/content_for_visitor_test/test_0015_a_symbol_attribute_name_is_matched_-_render_ea07a77e07b2ddaab975f1a08d0c186c.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::ContentForVisitorTest#test_0015_a symbol attribute name is matched - render"
+input: "{source: \"<main id=\\\"content\\\">Content</main>\", locals: {}, options: {escape: false, parser_options: {strict: false}, visitors: [#<Herb::Engine::ContentForVisitor tag_name=\"main\" attributes={\"id\" => \"content\"} content=\"<p>Appended</p>\">]}}"
+---
+<main id="content">Content<p>Appended</p></main>

--- a/test/snapshots/engine/content_for_visitor_test/test_0016_an_ERB_attribute_value_has_no_compile_time_value_so_a_string_condition_does_not_match_-_render_d4c2bf61c7383fc4711a00bcb53adc62.txt
+++ b/test/snapshots/engine/content_for_visitor_test/test_0016_an_ERB_attribute_value_has_no_compile_time_value_so_a_string_condition_does_not_match_-_render_d4c2bf61c7383fc4711a00bcb53adc62.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::ContentForVisitorTest#test_0016_an ERB attribute value has no compile time value so a string condition does not match - render"
+input: "{source: \"<main id=\\\"<%= @id %>\\\">Content</main>\", locals: {\"@id\": \"content\"}, options: {escape: false, parser_options: {strict: false}, visitors: [#<Herb::Engine::ContentForVisitor tag_name=\"main\" attributes={\"id\" => \"content\"} content=\"<p>Appended</p>\">]}}"
+---
+<main id="content">Content</main>

--- a/test/snapshots/engine/content_for_visitor_test/test_0017_an_ERB_attribute_value_still_matches_a_presence_condition_-_render_2d5bdcae2612f6d558f67f247c183297.txt
+++ b/test/snapshots/engine/content_for_visitor_test/test_0017_an_ERB_attribute_value_still_matches_a_presence_condition_-_render_2d5bdcae2612f6d558f67f247c183297.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::ContentForVisitorTest#test_0017_an ERB attribute value still matches a presence condition - render"
+input: "{source: \"<main id=\\\"<%= @id %>\\\">Content</main>\", locals: {\"@id\": \"content\"}, options: {escape: false, parser_options: {strict: false}, visitors: [#<Herb::Engine::ContentForVisitor tag_name=\"main\" attributes={\"id\" => true} content=\"<p>Appended</p>\">]}}"
+---
+<main id="content">Content<p>Appended</p></main>

--- a/test/snapshots/engine/content_for_visitor_test/test_0018_an_empty_attribute_value_matches_an_empty_string_condition_-_render_0f9b10559981721c648693a174c23f47.txt
+++ b/test/snapshots/engine/content_for_visitor_test/test_0018_an_empty_attribute_value_matches_an_empty_string_condition_-_render_0f9b10559981721c648693a174c23f47.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::ContentForVisitorTest#test_0018_an empty attribute value matches an empty string condition - render"
+input: "{source: \"<main id=\\\"\\\">Content</main>\", locals: {}, options: {escape: false, parser_options: {strict: false}, visitors: [#<Herb::Engine::ContentForVisitor tag_name=\"main\" attributes={\"id\" => \"\"} content=\"<p>Appended</p>\">]}}"
+---
+<main id="">Content<p>Appended</p></main>

--- a/test/snapshots/engine/content_for_visitor_test/test_0019_nil_content_is_a_no-op_-_render_ce6508b75b5b605f18b7d364d37989e0.txt
+++ b/test/snapshots/engine/content_for_visitor_test/test_0019_nil_content_is_a_no-op_-_render_ce6508b75b5b605f18b7d364d37989e0.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::ContentForVisitorTest#test_0019_nil content is a no-op - render"
+input: "{source: \"<section>Content</section>\", locals: {}, options: {escape: false, parser_options: {strict: false}, visitors: [#<Herb::Engine::ContentForVisitor tag_name=\"section\" attributes={} content=nil>]}}"
+---
+<section>Content</section>

--- a/test/snapshots/engine/content_for_visitor_test/test_0020_empty_content_is_a_no-op_-_render_14ca0571a3c9c1f9fbb09e08feae3cbf.txt
+++ b/test/snapshots/engine/content_for_visitor_test/test_0020_empty_content_is_a_no-op_-_render_14ca0571a3c9c1f9fbb09e08feae3cbf.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::ContentForVisitorTest#test_0020_empty content is a no-op - render"
+input: "{source: \"<section>Content</section>\", locals: {}, options: {escape: false, parser_options: {strict: false}, visitors: [#<Herb::Engine::ContentForVisitor tag_name=\"section\" attributes={} content=\"\">]}}"
+---
+<section>Content</section>

--- a/test/snapshots/engine/content_for_visitor_test/test_0021_ERB_in_the_element_body_is_kept_before_the_content_-_render_fd434427ea47d1328d8ed0ecf34d955a.txt
+++ b/test/snapshots/engine/content_for_visitor_test/test_0021_ERB_in_the_element_body_is_kept_before_the_content_-_render_fd434427ea47d1328d8ed0ecf34d955a.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::ContentForVisitorTest#test_0021_ERB in the element body is kept before the content - render"
+input: "{source: \"<main><h1><%= @title %></h1></main>\", locals: {\"@title\": \"Hello\"}, options: {escape: false, parser_options: {strict: false}, visitors: [#<Herb::Engine::ContentForVisitor tag_name=\"main\" attributes={} content=\"<p>Appended</p>\">]}}"
+---
+<main><h1>Hello</h1><p>Appended</p></main>

--- a/test/snapshots/engine/content_for_visitor_test/test_0022_an_element_inside_an_ERB_block_gets_the_content_-_render_6052061a0e3a7868818f7ba6fec8a281.txt
+++ b/test/snapshots/engine/content_for_visitor_test/test_0022_an_element_inside_an_ERB_block_gets_the_content_-_render_6052061a0e3a7868818f7ba6fec8a281.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::ContentForVisitorTest#test_0022_an element inside an ERB block gets the content - render"
+input: "{source: \"<% if true %><main>Content</main><% end %>\", locals: {}, options: {escape: false, parser_options: {strict: false}, visitors: [#<Herb::Engine::ContentForVisitor tag_name=\"main\" attributes={} content=\"<p>Appended</p>\">]}}"
+---
+<main>Content<p>Appended</p></main>

--- a/test/snapshots/engine/content_for_visitor_test/test_0023_single_quotes_in_the_content_are_escaped_-_render_69e9cd1aac20ac68f3b7584ef63b056a.txt
+++ b/test/snapshots/engine/content_for_visitor_test/test_0023_single_quotes_in_the_content_are_escaped_-_render_69e9cd1aac20ac68f3b7584ef63b056a.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::ContentForVisitorTest#test_0023_single quotes in the content are escaped - render"
+input: "{source: \"<main></main>\", locals: {}, options: {escape: false, parser_options: {strict: false}, visitors: [#<Herb::Engine::ContentForVisitor tag_name=\"main\" attributes={} content=\"<p class='single'></p>\">]}}"
+---
+<main><p class='single'></p></main>

--- a/test/snapshots/engine/content_for_visitor_test/test_0024_double_quotes_in_the_content_are_escaped_-_render_31e4a76f053aa87d75f19979cb70571b.txt
+++ b/test/snapshots/engine/content_for_visitor_test/test_0024_double_quotes_in_the_content_are_escaped_-_render_31e4a76f053aa87d75f19979cb70571b.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::ContentForVisitorTest#test_0024_double quotes in the content are escaped - render"
+input: "{source: \"<main></main>\", locals: {}, options: {escape: false, parser_options: {strict: false}, visitors: [#<Herb::Engine::ContentForVisitor tag_name=\"main\" attributes={} content=\"<p class=\\\"double\\\"></p>\">]}}"
+---
+<main><p class="double"></p></main>

--- a/test/snapshots/engine/content_for_visitor_test/test_0025_a_backslash_in_the_content_is_escaped_-_render_796f424864dd1e56d1a52580fc7c4d1f.txt
+++ b/test/snapshots/engine/content_for_visitor_test/test_0025_a_backslash_in_the_content_is_escaped_-_render_796f424864dd1e56d1a52580fc7c4d1f.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::ContentForVisitorTest#test_0025_a backslash in the content is escaped - render"
+input: "{source: \"<main></main>\", locals: {}, options: {escape: false, parser_options: {strict: false}, visitors: [#<Herb::Engine::ContentForVisitor tag_name=\"main\" attributes={} content=\"<p class=\\\"back\\\\slash\\\"></p>\">]}}"
+---
+<main><p class="back\slash"></p></main>

--- a/test/snapshots/engine/content_for_visitor_test/test_0026_Ruby_interpolation_in_the_content_is_not_evaluated_-_render_184b5c18f745d8e330ee991223278925.txt
+++ b/test/snapshots/engine/content_for_visitor_test/test_0026_Ruby_interpolation_in_the_content_is_not_evaluated_-_render_184b5c18f745d8e330ee991223278925.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::ContentForVisitorTest#test_0026_Ruby interpolation in the content is not evaluated - render"
+input: "{source: \"<main></main>\", locals: {}, options: {escape: false, parser_options: {strict: false}, visitors: [#<Herb::Engine::ContentForVisitor tag_name=\"main\" attributes={} content=\"<p>\\\#{1 + 1}</p>\">]}}"
+---
+<main><p>#{1 + 1}</p></main>

--- a/test/snapshots/engine/content_for_visitor_test/test_0027_two_visitors_append_their_content_in_order_-_compilation_26024c95d25c8ff4562e568a46922b79.txt
+++ b/test/snapshots/engine/content_for_visitor_test/test_0027_two_visitors_append_their_content_in_order_-_compilation_26024c95d25c8ff4562e568a46922b79.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::ContentForVisitorTest#test_0027_two visitors append their content in order - compilation"
+input: "{source: \"<head><title>Hello</title></head>\", options: {escape: false, parser_options: {strict: false}, visitors: [#<Herb::Engine::ContentForVisitor tag_name=\"head\" attributes={} content=\"<meta name=\\\"first\\\" content=\\\"1\\\">\">, #<Herb::Engine::ContentForVisitor tag_name=\"head\" attributes={} content=\"<meta name=\\\"second\\\" content=\\\"2\\\">\">]}}"
+---
+_buf = ::String.new; _buf << '<head><title>Hello</title>'.freeze; _buf << ("<meta name=\"first\" content=\"1\">".html_safe).to_s; _buf << ("<meta name=\"second\" content=\"2\">".html_safe).to_s; _buf << '</head>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/content_for_visitor_test/test_0028_two_visitors_append_their_content_in_order_-_render_243910dbe85c9bb94fadb95592be25fe.txt
+++ b/test/snapshots/engine/content_for_visitor_test/test_0028_two_visitors_append_their_content_in_order_-_render_243910dbe85c9bb94fadb95592be25fe.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::ContentForVisitorTest#test_0028_two visitors append their content in order - render"
+input: "{source: \"<head><title>Hello</title></head>\", locals: {}, options: {escape: false, parser_options: {strict: false}, visitors: [#<Herb::Engine::ContentForVisitor tag_name=\"head\" attributes={} content=\"<meta name=\\\"first\\\" content=\\\"1\\\">\">, #<Herb::Engine::ContentForVisitor tag_name=\"head\" attributes={} content=\"<meta name=\\\"second\\\" content=\\\"2\\\">\">]}}"
+---
+<head><title>Hello</title><meta name="first" content="1"><meta name="second" content="2"></head>

--- a/test/snapshots/engine/content_for_visitor_test/test_0029_composes_with_AutoCloseOmittedTagsVisitor_-_render_b6e0a83a7643702a36101481c21cef1d.txt
+++ b/test/snapshots/engine/content_for_visitor_test/test_0029_composes_with_AutoCloseOmittedTagsVisitor_-_render_b6e0a83a7643702a36101481c21cef1d.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::ContentForVisitorTest#test_0029_composes with AutoCloseOmittedTagsVisitor - render"
+input: "{source: \"<head><title>Hello</title></head><ul><li>One<li>Two</ul>\", locals: {}, options: {escape: false, parser_options: {strict: false}, visitors: [#<Herb::Engine::ContentForVisitor tag_name=\"head\" attributes={} content=\"<meta name=\\\"herb\\\" content=\\\"1\\\">\">, #<Herb::Engine::AutoCloseOmittedTagsVisitor>]}}"
+---
+<head><title>Hello</title><meta name="herb" content="1"></head><ul><li>One</li><li>Two</li></ul>


### PR DESCRIPTION
This pull request introduces a new `Herb::Engine::ContentForVisitor`, a transform visitor that appends HTML to the end of every matching element, and removes the `content_for_head` engine option that it replaces.

`content_for_head` was the last engine option that the compiler special-cased. Though, there might be more engine options we might want to refactor in the same way.

`Herb::Engine::Compiler#visit_html_close_tag_node` reached back into the engine, matched on the tag name, and hand-rolled a token that no AST node corresponded to:

```ruby
def visit_html_close_tag_node(node)
  tag_name = node.tag_name&.value&.downcase

  if @engine.content_for_head && tag_name == "head"
    escaped_html = @engine.content_for_head.gsub("'", "\\\\'")
    @tokens << [:expr, "'#{escaped_html}'.html_safe", current_context]
  end

  add_text(node.tag_opening&.value)
  add_text(node.tag_name&.value)
  add_text(node.tag_closing&.value)
end
```

That is the same shape #1188 removed when `auto_close_omitted_tags` became `AutoCloseOmittedTagsVisitor`.

Usage:

```ruby
require "herb/engine/content_for_visitor"

Herb::Engine.new(source, visitors: [
  Herb::Engine::ContentForVisitor.new(%(<meta name="herb" content="1">), tag_name: "head")
])
```

This template:

```html+erb
<head>
  <title>Hello</title>
</head>
```

Gets rendered as:

```html
<head>
  <title>Hello</title>
<meta name="herb" content="1"></head>
```

Follow up on #1188.