### PR TITLE
Linter: Make `html-no-inline-script-elements` framework aware

### DIFF
--- a/javascript/packages/linter/src/rules/html-no-inline-script-elements.ts
+++ b/javascript/packages/linter/src/rules/html-no-inline-script-elements.ts
@@ -18,12 +18,20 @@ class HTMLNoInlineScriptElementsVisitor extends BaseRuleVisitor {
   visitHTMLElementNode(node: HTMLElementNode): void {
     if (this.isInlineScript(node)) {
       this.addOffense(
-        "Avoid inline `<script>` tags. Use `javascript_include_tag` to include external JavaScript files instead.",
+        `Avoid inline \`<script>\` tags. ${this.suggestion()}`,
         node.open_tag!.location,
       )
     }
 
     super.visitHTMLElementNode(node)
+  }
+
+  private suggestion(): string {
+    if (this.context.framework === "actionview") {
+      return "Extract the JavaScript into a separate `.js` file and include it with `javascript_include_tag`."
+    }
+
+    return "Extract the JavaScript into a separate `.js` file and deliver it through your framework's asset pipeline."
   }
 
   private isInlineScript(node: HTMLElementNode): boolean {

--- a/javascript/packages/linter/test/rules/html-no-inline-script-elements.test.ts
+++ b/javascript/packages/linter/test/rules/html-no-inline-script-elements.test.ts
@@ -26,7 +26,7 @@ describe("html-no-inline-script-elements", () => {
   })
 
   test("fails with script tag with src and inline body", () => {
-    expectError("Avoid inline `<script>` tags. Use `javascript_include_tag` to include external JavaScript files instead.")
+    expectError("Avoid inline `<script>` tags. Extract the JavaScript into a separate `.js` file and deliver it through your framework's asset pipeline.")
 
     assertOffenses(dedent`
       <script src="https://example.com/app.js">
@@ -36,23 +36,29 @@ describe("html-no-inline-script-elements", () => {
   })
 
   test("fails with empty inline script tag", () => {
-    expectError("Avoid inline `<script>` tags. Use `javascript_include_tag` to include external JavaScript files instead.")
+    expectError("Avoid inline `<script>` tags. Extract the JavaScript into a separate `.js` file and deliver it through your framework's asset pipeline.")
 
     assertOffenses("<script></script>")
   })
 
   test("fails with inline script tag", () => {
-    expectError("Avoid inline `<script>` tags. Use `javascript_include_tag` to include external JavaScript files instead.")
+    expectError("Avoid inline `<script>` tags. Extract the JavaScript into a separate `.js` file and deliver it through your framework's asset pipeline.")
 
     assertOffenses("<script>alert('hello')</script>")
   })
 
   test("fails with script tag with unallowed type", () => {
-    expectError("Avoid inline `<script>` tags. Use `javascript_include_tag` to include external JavaScript files instead.")
+    expectError("Avoid inline `<script>` tags. Extract the JavaScript into a separate `.js` file and deliver it through your framework's asset pipeline.")
 
     assertOffenses(dedent`
       <script type="text/javascript">alert("hello")</script>
     `)
+  })
+
+  test("suggests an external JavaScript file for a non-Action View framework", () => {
+    expectError("Avoid inline `<script>` tags. Extract the JavaScript into a separate `.js` file and deliver it through your framework's asset pipeline.")
+
+    assertOffenses("<script>alert('hello')</script>", { framework: "hanami" })
   })
 
   describe("ActionView tag helpers", () => {
@@ -61,29 +67,35 @@ describe("html-no-inline-script-elements", () => {
         <%= javascript_tag do %>
           alert("hello")
         <% end %>
-      `)
+      `, { framework: "actionview" })
     })
 
     test("ignores javascript_include_tag", () => {
       expectNoOffenses(dedent`
         <%= javascript_include_tag "application" %>
-      `)
+      `, { framework: "actionview" })
+    })
+
+    test("suggests javascript_include_tag for an inline script tag", () => {
+      expectError("Avoid inline `<script>` tags. Extract the JavaScript into a separate `.js` file and include it with `javascript_include_tag`.")
+
+      assertOffenses("<script>alert('hello')</script>", { framework: "actionview" })
     })
 
     test("fails with tag.script helper", () => {
-      expectError("Avoid inline `<script>` tags. Use `javascript_include_tag` to include external JavaScript files instead.")
+      expectError("Avoid inline `<script>` tags. Extract the JavaScript into a separate `.js` file and include it with `javascript_include_tag`.")
 
       assertOffenses(dedent`
         <%= tag.script %>
-      `)
+      `, { framework: "actionview" })
     })
 
     test("fails with content_tag :script helper", () => {
-      expectError("Avoid inline `<script>` tags. Use `javascript_include_tag` to include external JavaScript files instead.")
+      expectError("Avoid inline `<script>` tags. Extract the JavaScript into a separate `.js` file and include it with `javascript_include_tag`.")
 
       assertOffenses(dedent`
         <%= content_tag(:script, "alert(1)") %>
-      `)
+      `, { framework: "actionview" })
     })
   })
 })


### PR DESCRIPTION
Follow up on #1536 and #1539.

`html-no-inline-script-elements` always pointed at `javascript_include_tag`, which only exists in Action View. Projects using Hanami, Sinatra, or plain ERB got told to reach for a helper their framework doesn't have.

`html-no-style-elements` already tailors its suggestion in #1539, so this brings the script rule in line with its sibling. 

**Before**

```
Avoid inline `<script>` tags. Use `javascript_include_tag` to include external JavaScript files instead.
```

**After**

For `actionview`:
```
Avoid inline `<script>` tags. Extract the JavaScript into a separate `.js` file and include it with `javascript_include_tag`.
```

Non-`actionview`:
```
Avoid inline `<script>` tags. Extract the JavaScript into a separate `.js` file and deliver it through your framework's asset pipeline.
```

Related #1808