### PR TITLE
Core: Introduce Action View partial caller index

### DIFF
--- a/javascript/packages/core/src/action-view-partial-callers.ts
+++ b/javascript/packages/core/src/action-view-partial-callers.ts
@@ -1,0 +1,82 @@
+import type { StrictLocal } from "./action-view-partial-index.js"
+
+export interface PartialCallSite {
+  caller: string
+  locals: string[]
+}
+
+export interface InferredSignature {
+  locals: StrictLocal[]
+  callSiteCount: number
+  keywordRest: boolean
+}
+
+export interface SerializedPartialCallerIndex {
+  callSites: Record<string, PartialCallSite[]>
+  unresolvedRenders: number
+  skippedFiles: number
+}
+
+export class PartialCallerIndex {
+  readonly unresolvedRenders: number
+  readonly skippedFiles: number
+
+  private readonly callSites: Map<string, PartialCallSite[]>
+
+  static from(data: SerializedPartialCallerIndex): PartialCallerIndex {
+    return new PartialCallerIndex(new Map(Object.entries(data.callSites)), data.unresolvedRenders, data.skippedFiles)
+  }
+
+  constructor(callSites: Map<string, PartialCallSite[]>, unresolvedRenders: number, skippedFiles: number) {
+    this.callSites = callSites
+    this.unresolvedRenders = unresolvedRenders
+    this.skippedFiles = skippedFiles
+  }
+
+  get isComplete(): boolean {
+    return this.unresolvedRenders === 0 && this.skippedFiles === 0
+  }
+
+  callersOf(partialFile: string): PartialCallSite[] {
+    return this.callSites.get(partialFile) ?? []
+  }
+
+  inferSignature(partialFile: string): InferredSignature {
+    const callers = this.callersOf(partialFile)
+    const names: string[] = []
+
+    for (const callSite of callers) {
+      for (const local of callSite.locals) {
+        if (!names.includes(local)) names.push(local)
+      }
+    }
+
+    names.sort()
+
+    return {
+      locals: names.map(name => ({ name, required: false })),
+      callSiteCount: callers.length,
+      keywordRest: !this.isComplete
+    }
+  }
+
+  get size(): number {
+    return this.callSites.size
+  }
+
+  toJSON(): SerializedPartialCallerIndex {
+    return {
+      callSites: Object.fromEntries(this.callSites),
+      unresolvedRenders: this.unresolvedRenders,
+      skippedFiles: this.skippedFiles
+    }
+  }
+}
+
+export function strictLocalsDeclaration(signature: InferredSignature): string {
+  const parameters = signature.locals.map(local => (local.required ? `${local.name}:` : `${local.name}: nil`))
+
+  if (signature.keywordRest) parameters.push("**")
+
+  return `<%# locals: (${parameters.join(", ")}) %>`
+}

--- a/javascript/packages/core/src/action-view-partial-resolution.ts
+++ b/javascript/packages/core/src/action-view-partial-resolution.ts
@@ -7,7 +7,10 @@ export const PARTIAL_EXTENSIONS = [
   ".turbo_stream.herb",
 ] as const
 
-export const PARTIAL_GLOB_PATTERN = "_*.{html.erb,html.herb,erb,herb,turbo_stream.erb,turbo_stream.herb}"
+const EXTENSION_ALTERNATIVES = PARTIAL_EXTENSIONS.map(extension => extension.slice(1)).join(",")
+
+export const TEMPLATE_GLOB_PATTERN = `*.{${EXTENSION_ALTERNATIVES}}`
+export const PARTIAL_GLOB_PATTERN = `_${TEMPLATE_GLOB_PATTERN}`
 
 const PARTIAL_PREFIX = "_"
 const APPLICATION_DIRECTORY = "application"

--- a/javascript/packages/core/src/index.ts
+++ b/javascript/packages/core/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./action-view-helpers.js"
+export * from "./action-view-partial-callers.js"
 export * from "./action-view-partial-index.js"
 export * from "./action-view-partial-resolution.js"
 export * from "./ast-utils.js"

--- a/javascript/packages/linter/src/partial-caller-builder.ts
+++ b/javascript/packages/linter/src/partial-caller-builder.ts
@@ -1,0 +1,141 @@
+import picomatch from "picomatch"
+
+import { glob } from "tinyglobby"
+import { join } from "node:path"
+import { readFileSync } from "node:fs"
+
+import { TEMPLATE_GLOB_PATTERN, isPrismNodeType, isRubyRenderLocalNode } from "@herb-tools/core"
+import { isOutputRender, renderPartialExpression } from "./rules/prism-rule-utils.js"
+
+import { PartialCallerIndex } from "@herb-tools/core"
+
+import type { ERBRenderNode, HerbBackend, Node, PartialCallSite, PartialIndex, SerializedPartialCallerIndex } from "@herb-tools/core"
+
+const RENDER_MARKER = "render"
+const PARSER_OPTIONS = { render_nodes: true, prism_nodes: true } as const
+
+export interface PartialCallerIndexOptions {
+  include?: string[]
+  exclude?: string[]
+}
+
+function templatePatterns(viewRoot: string, include: string[]): string[] {
+  const base = viewRoot === "." ? `**/${TEMPLATE_GLOB_PATTERN}` : `${viewRoot}/**/${TEMPLATE_GLOB_PATTERN}`
+
+  return [base, ...include]
+}
+
+function templatesIn(projectPath: string, viewRoot: string, include: string[]): Promise<string[]> {
+  return glob(templatePatterns(viewRoot, include), { cwd: projectPath, onlyFiles: true, dot: false, absolute: false })
+}
+
+function renderNodesIn(node: Node): ERBRenderNode[] {
+  const found: ERBRenderNode[] = []
+
+  const walk = (current: Node) => {
+    if (current.type === "AST_ERB_RENDER_NODE") found.push(current as ERBRenderNode)
+
+    for (const child of current.childNodes()) {
+      if (child) walk(child)
+    }
+  }
+
+  walk(node)
+
+  return found
+}
+
+function localsPassedBy(node: ERBRenderNode): string[] {
+  const locals: string[] = []
+
+  for (const local of node.keywords?.locals ?? []) {
+    if (!isRubyRenderLocalNode(local)) continue
+
+    const name = local.name?.value
+
+    if (name) locals.push(name)
+  }
+
+  return locals
+}
+
+function partialNameRenderedBy(node: ERBRenderNode): string | null {
+  const call = node.prismNode
+  if (!call) return null
+
+  if (!isOutputRender(node)) return null
+
+  const expression = renderPartialExpression(call)
+  if (!expression) return null
+
+  if (!isPrismNodeType(expression.node, "StringNode")) return null
+
+  return expression.node.unescaped?.value ?? null
+}
+
+export function collectCallSites(herb: HerbBackend, partials: PartialIndex, file: string, source: string, callSites: Map<string, PartialCallSite[]>): number {
+  if (!source.includes(RENDER_MARKER)) return 0
+
+  let unresolved = 0
+
+  for (const node of renderNodesIn(herb.parse(source, PARSER_OPTIONS).value)) {
+    const name = partialNameRenderedBy(node)
+
+    if (name === null) {
+      unresolved++
+
+      continue
+    }
+
+    const declaration = partials.lookup(name, file)
+
+    if (!declaration) {
+      unresolved++
+
+      continue
+    }
+
+    const existing = callSites.get(declaration.file) ?? []
+
+    existing.push({ caller: file, locals: localsPassedBy(node) })
+    callSites.set(declaration.file, existing)
+  }
+
+  return unresolved
+}
+
+export async function buildPartialCallerIndex(herb: HerbBackend, projectPath: string, partials: PartialIndex, options: PartialCallerIndexOptions = {}): Promise<PartialCallerIndex> {
+  const files = await templatesIn(projectPath, partials.viewRoot, options.include ?? [])
+  const excluded = options.exclude?.length ? picomatch(options.exclude) : null
+  const callSites = new Map<string, PartialCallSite[]>()
+
+  let unresolvedRenders = 0
+  let skippedFiles = 0
+
+  for (const file of files.sort()) {
+    if (excluded?.(file)) {
+      skippedFiles++
+      continue
+    }
+
+    let source: string
+
+    try {
+      source = readFileSync(join(projectPath, file), "utf-8")
+    } catch {
+      continue
+    }
+
+    try {
+      unresolvedRenders += collectCallSites(herb, partials, file, source, callSites)
+    } catch {
+      continue
+    }
+  }
+
+  return new PartialCallerIndex(callSites, unresolvedRenders, skippedFiles)
+}
+
+export function partialCallerIndexFrom(data: SerializedPartialCallerIndex | undefined): PartialCallerIndex | undefined {
+  return data ? PartialCallerIndex.from(data) : undefined
+}

--- a/javascript/packages/linter/test/partial-caller-builder.test.ts
+++ b/javascript/packages/linter/test/partial-caller-builder.test.ts
@@ -1,0 +1,210 @@
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join, dirname } from "node:path"
+
+import { beforeAll, afterEach, describe, expect, test } from "vitest"
+
+import { Herb } from "@herb-tools/node-wasm"
+import { strictLocalsDeclaration } from "@herb-tools/core"
+
+import { buildPartialIndex } from "../src/partial-index-builder.js"
+import { buildPartialCallerIndex } from "../src/partial-caller-builder.js"
+
+const projects: string[] = []
+
+function project(files: Record<string, string>): string {
+  const root = mkdtempSync(join(tmpdir(), "herb-partial-callers-"))
+
+  projects.push(root)
+
+  for (const [path, contents] of Object.entries(files)) {
+    const file = join(root, path)
+
+    mkdirSync(dirname(file), { recursive: true })
+    writeFileSync(file, contents, "utf-8")
+  }
+
+  return root
+}
+
+async function indexFor(files: Record<string, string>) {
+  const root = project(files)
+  const partials = await buildPartialIndex(Herb, root)
+
+  return { callers: await buildPartialCallerIndex(Herb, root, partials), partials }
+}
+
+beforeAll(async () => {
+  await Herb.load()
+})
+
+afterEach(() => {
+  while (projects.length > 0) {
+    rmSync(projects.pop()!, { recursive: true, force: true })
+  }
+})
+
+describe("buildPartialCallerIndex", () => {
+  test("collects the locals every call site passes", async () => {
+    const { callers } = await indexFor({
+      "app/views/posts/_card.html.erb": `<h1><%= title %></h1>`,
+      "app/views/posts/index.html.erb": `<%= render "posts/card", title: @post.title %>`,
+      "app/views/home/show.html.erb": `<%= render "posts/card", title: "Hi", footer: true %>`,
+    })
+
+    const inferred = callers.inferSignature("app/views/posts/_card.html.erb")
+
+    expect(inferred.locals.map(local => local.name)).toEqual(["footer", "title"])
+    expect(inferred.callSiteCount).toBe(2)
+    expect(inferred.keywordRest).toBe(false)
+  })
+
+  test("resolves a partial named relative to the rendering template", async () => {
+    const { callers } = await indexFor({
+      "app/views/posts/_card.html.erb": `<h1><%= title %></h1>`,
+      "app/views/posts/index.html.erb": `<%= render "card", title: @post.title %>`,
+    })
+
+    expect(callers.inferSignature("app/views/posts/_card.html.erb").locals.map(local => local.name)).toEqual(["title"])
+  })
+
+  test("counts a dynamic partial name as unresolved and asks for keyword rest", async () => {
+    const { callers } = await indexFor({
+      "app/views/posts/_card.html.erb": `<h1><%= title %></h1>`,
+      "app/views/posts/index.html.erb": `<%= render "posts/card", title: "Hi" %>\n<%= render "posts/#{@kind}" %>`,
+    })
+
+    const inferred = callers.inferSignature("app/views/posts/_card.html.erb")
+
+    expect(callers.unresolvedRenders).toBe(1)
+    expect(inferred.locals.map(local => local.name)).toEqual(["title"])
+    expect(inferred.keywordRest).toBe(true)
+  })
+
+  test("counts an implicit object render as unresolved", async () => {
+    const { callers } = await indexFor({
+      "app/views/posts/_post.html.erb": `<h1><%= post.title %></h1>`,
+      "app/views/posts/index.html.erb": `<%= render @posts %>`,
+    })
+
+    expect(callers.unresolvedRenders).toBe(1)
+  })
+
+  test("ignores a render whose partial does not exist", async () => {
+    const { callers } = await indexFor({
+      "app/views/posts/_card.html.erb": `<h1><%= title %></h1>`,
+      "app/views/posts/index.html.erb": `<%= render "posts/missing" %>`,
+    })
+
+    expect(callers.callersOf("app/views/posts/_card.html.erb")).toEqual([])
+    expect(callers.unresolvedRenders).toBe(1)
+  })
+
+  test("records a partial rendered with no locals", async () => {
+    const { callers } = await indexFor({
+      "app/views/shared/_footer.html.erb": `<footer>hi</footer>`,
+      "app/views/posts/index.html.erb": `<%= render "shared/footer" %>`,
+    })
+
+    const inferred = callers.inferSignature("app/views/shared/_footer.html.erb")
+
+    expect(inferred.locals).toEqual([])
+    expect(inferred.callSiteCount).toBe(1)
+  })
+
+  test("finds call sites inside other partials", async () => {
+    const { callers } = await indexFor({
+      "app/views/posts/_card.html.erb": `<h1><%= title %></h1>`,
+      "app/views/posts/_list.html.erb": `<%= render "posts/card", title: "Nested" %>`,
+    })
+
+    expect(callers.callersOf("app/views/posts/_card.html.erb").map(site => site.caller)).toEqual([
+      "app/views/posts/_list.html.erb",
+    ])
+  })
+
+  test("reports no call sites for a partial nothing renders", async () => {
+    const { callers } = await indexFor({
+      "app/views/posts/_orphan.html.erb": `<h1><%= title %></h1>`,
+      "app/views/posts/index.html.erb": `<h1>nothing</h1>`,
+    })
+
+    expect(callers.inferSignature("app/views/posts/_orphan.html.erb").callSiteCount).toBe(0)
+  })
+
+  test("survives a round trip through JSON", async () => {
+    const { callers } = await indexFor({
+      "app/views/posts/_card.html.erb": `<h1><%= title %></h1>`,
+      "app/views/posts/index.html.erb": `<%= render "posts/card", title: "Hi" %>`,
+    })
+
+    const restored = await import("@herb-tools/core").then(core => core.PartialCallerIndex.from(JSON.parse(JSON.stringify(callers))))
+
+    expect(restored.inferSignature("app/views/posts/_card.html.erb").locals.map(local => local.name)).toEqual(["title"])
+  })
+
+  test("scans additional templates from include patterns", async () => {
+    const root = project({
+      "app/views/posts/_card.html.erb": `<h1><%= title %></h1>`,
+      "app/views/posts/legacy.rhtml": `<%= render "posts/card", author: "me" %>`,
+    })
+
+    const partials = await buildPartialIndex(Herb, root)
+    const withoutInclude = await buildPartialCallerIndex(Herb, root, partials)
+    const withInclude = await buildPartialCallerIndex(Herb, root, partials, { include: ["**/*.rhtml"] })
+
+    expect(withoutInclude.inferSignature("app/views/posts/_card.html.erb").locals).toEqual([])
+    expect(withInclude.inferSignature("app/views/posts/_card.html.erb").locals.map(local => local.name)).toEqual(["author"])
+  })
+
+  test("treats an excluded template as incompleteness rather than absence", async () => {
+    const root = project({
+      "app/views/posts/_card.html.erb": `<h1><%= title %></h1>`,
+      "app/views/posts/index.html.erb": `<%= render "posts/card", title: "Hi" %>`,
+      "app/views/legacy/old.html.erb": `<%= render "posts/card", legacy: true %>`,
+    })
+
+    const partials = await buildPartialIndex(Herb, root)
+    const callers = await buildPartialCallerIndex(Herb, root, partials, { exclude: ["app/views/legacy/**"] })
+
+    expect(callers.skippedFiles).toBe(1)
+    expect(callers.isComplete).toBe(false)
+    expect(callers.inferSignature("app/views/posts/_card.html.erb").keywordRest).toBe(true)
+  })
+
+  test("is complete when nothing is skipped and every render resolves", async () => {
+    const { callers } = await indexFor({
+      "app/views/posts/_card.html.erb": `<h1><%= title %></h1>`,
+      "app/views/posts/index.html.erb": `<%= render "posts/card", title: "Hi" %>`,
+    })
+
+    expect(callers.isComplete).toBe(true)
+    expect(callers.inferSignature("app/views/posts/_card.html.erb").keywordRest).toBe(false)
+  })
+})
+
+describe("strictLocalsDeclaration", () => {
+  test("names every local as optional", () => {
+    expect(strictLocalsDeclaration({ locals: [{ name: "title", required: false }, { name: "body", required: false }], callSiteCount: 2, keywordRest: false })).toBe(
+      `<%# locals: (title: nil, body: nil) %>`,
+    )
+  })
+
+  test("appends keyword rest when the caller set is incomplete", () => {
+    expect(strictLocalsDeclaration({ locals: [{ name: "title", required: false }], callSiteCount: 1, keywordRest: true })).toBe(
+      `<%# locals: (title: nil, **) %>`,
+    )
+  })
+
+  test("produces an empty declaration when nothing was observed", () => {
+    expect(strictLocalsDeclaration({ locals: [], callSiteCount: 0, keywordRest: false })).toBe(`<%# locals: () %>`)
+  })
+
+  test("renders required locals without a default", () => {
+    expect(strictLocalsDeclaration({
+      locals: [{ name: "title", required: true }, { name: "footer", required: false }],
+      callSiteCount: 1,
+      keywordRest: false,
+    })).toBe(`<%# locals: (title:, footer: nil) %>`)
+  })
+})


### PR DESCRIPTION
Based on the partial index from #2061, this pull request adds the edge pointing the other way. From a partial to the templates that render it, and to the locals each of those call sites passes.

`PartialIndex` answers "which file does this `render` resolve to". Nothing answers "who renders this partial, and what do they pass it". That second question is what a partial's strict locals signature is made of, and it is also what a cross-file rename or a find-all-callers needs.

```ts
const partials = await buildPartialIndex(Herb, projectPath)
const callers = await buildPartialCallerIndex(Herb, projectPath, partials)

callers.callersOf("app/views/posts/_card.html.erb")
// => [{ caller: "app/views/posts/index.html.erb", locals: ["title"] },
//     { caller: "app/views/home/show.html.erb",   locals: ["title", "footer"] }]

callers.inferSignature("app/views/posts/_card.html.erb")
// => { locals: [{ name: "footer", required: false }, { name: "title", required: false }],
//      callSiteCount: 2, keywordRest: true }

strictLocalsDeclaration(callers.inferSignature("app/views/posts/_card.html.erb"))
// => "<%# locals: (footer: nil, title: nil, **) %>"
```

The builder walks every template, resolves each `render` through the existing partial index, and records the locals passed. A `"render"` substring check skips parsing templates that cannot contain one, mirroring the `locals:` prefilter in `buildPartialIndex`.

Enables #2043