### PR TITLE
Dev Tools: Fix `document` event listener leaks across Turbo navigations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,6 +172,7 @@ vitest.config.*.timestamp*
 
 # Vitest
 **/test/__screenshots__/**/*
+**/.vitest-attachments/**/*
 
 # Doxygen
 docs/docs/public/c-reference

--- a/javascript/packages/dev-tools/package.json
+++ b/javascript/packages/dev-tools/package.json
@@ -18,7 +18,7 @@
     "build": "yarn clean && rollup -c",
     "dev": "rollup -c -w",
     "clean": "rimraf dist",
-    "test": "echo 'TODO: add tests'",
+    "test": "vitest run",
     "prepublishOnly": "yarn clean && yarn build && yarn test"
   },
   "exports": {

--- a/javascript/packages/dev-tools/src/error-overlay.ts
+++ b/javascript/packages/dev-tools/src/error-overlay.ts
@@ -206,9 +206,28 @@ export class ErrorOverlay {
   private overlay: HTMLElement | null = null;
   private allValidationData: ValidationData[] = [];
   private isVisible = false;
+  private destroyed = false;
 
   constructor() {
     this.init();
+  }
+
+  public destroy() {
+    if (this.destroyed) {
+      return;
+    }
+
+    this.destroyed = true;
+
+    document.removeEventListener('keydown', this.handleEscapeKey);
+    document.removeEventListener('keydown', this.handleToggleShortcut);
+
+    if (this.overlay) {
+      this.overlay.remove();
+      this.overlay = null;
+    }
+
+    this.isVisible = false;
   }
 
   private init() {
@@ -494,20 +513,26 @@ export class ErrorOverlay {
       }
     });
 
-    document.addEventListener('keydown', (e) => {
-      if (e.key === 'Escape' && this.isVisible) {
-        this.hide();
-      }
-    });
+    document.removeEventListener('keydown', this.handleEscapeKey);
+    document.addEventListener('keydown', this.handleEscapeKey);
+  }
+
+  private handleEscapeKey = (event: KeyboardEvent) => {
+    if (event.key === 'Escape' && this.isVisible) {
+      this.hide();
+    }
+  }
+
+  private handleToggleShortcut = (event: KeyboardEvent) => {
+    if ((event.ctrlKey || event.metaKey) && event.shiftKey && event.key === 'E') {
+      event.preventDefault();
+      this.toggle();
+    }
   }
 
   private setupToggleHandler() {
-    document.addEventListener('keydown', (e) => {
-      if ((e.ctrlKey || e.metaKey) && e.shiftKey && e.key === 'E') {
-        e.preventDefault();
-        this.toggle();
-      }
-    });
+    document.removeEventListener('keydown', this.handleToggleShortcut);
+    document.addEventListener('keydown', this.handleToggleShortcut);
 
     if (this.hasErrorSeverity()) {
       setTimeout(() => this.show(), 100);

--- a/javascript/packages/dev-tools/src/herb-overlay.ts
+++ b/javascript/packages/dev-tools/src/herb-overlay.ts
@@ -19,6 +19,7 @@ export class HerbOverlay {
   private defaultEditorFromServer = 'vscode';
   private currentlyHoveredERBElement: HTMLElement | null = null;
   private errorOverlay: ErrorOverlay | null = null;
+  private destroyed = false;
 
   private static readonly SETTINGS_KEY = 'herb-dev-tools-settings';
   private static readonly EDITOR_OPTIONS = [
@@ -65,6 +66,26 @@ export class HerbOverlay {
     this.initializeErrorOverlay();
     this.setupTurboListeners();
     this.applySettings();
+
+    document.addEventListener('click', this.handleDocumentClick);
+  }
+
+  public destroy() {
+    if (this.destroyed) {
+      return;
+    }
+
+    this.destroyed = true;
+
+    document.removeEventListener('click', this.handleDocumentClick);
+    document.removeEventListener('turbo:load', this.handleTurboNavigation);
+    document.removeEventListener('turbo:render', this.handleTurboNavigation);
+    document.removeEventListener('turbo:visit', this.handleTurboNavigation);
+
+    this.errorOverlay?.destroy();
+    this.errorOverlay = null;
+
+    document.querySelector('.herb-floating-menu')?.remove();
   }
 
   private loadProjectPath() {
@@ -279,33 +300,39 @@ export class HerbOverlay {
 
         this.saveSettings();
       });
-
-      document.addEventListener('click', (e) => {
-        const target = e.target as HTMLElement;
-        const floatingMenu = document.querySelector('.herb-floating-menu');
-
-        if (floatingMenu && !floatingMenu.contains(target) && this.menuOpen) {
-          this.menuOpen = false;
-          menuTrigger.classList.remove('active');
-          menuPanel.classList.remove('open');
-          this.saveSettings();
-        }
-      });
     }
   }
 
+  private handleDocumentClick = (event: MouseEvent) => {
+    if (!this.menuOpen) {
+      return;
+    }
+
+    const target = event.target as HTMLElement;
+    const floatingMenu = document.querySelector('.herb-floating-menu');
+
+    if (floatingMenu && !floatingMenu.contains(target)) {
+      this.closeMenu();
+    }
+  }
+
+  private closeMenu() {
+    this.menuOpen = false;
+
+    document.getElementById('herbMenuTrigger')?.classList.remove('active');
+    document.getElementById('herbMenuPanel')?.classList.remove('open');
+
+    this.saveSettings();
+  }
+
+  private handleTurboNavigation = () => {
+    this.reinitializeAfterNavigation();
+  }
+
   private setupTurboListeners() {
-    document.addEventListener('turbo:load', () => {
-      this.reinitializeAfterNavigation();
-    });
-
-    document.addEventListener('turbo:render', () => {
-      this.reinitializeAfterNavigation();
-    });
-
-    document.addEventListener('turbo:visit', () => {
-      this.reinitializeAfterNavigation();
-    });
+    document.addEventListener('turbo:load', this.handleTurboNavigation);
+    document.addEventListener('turbo:render', this.handleTurboNavigation);
+    document.addEventListener('turbo:visit', this.handleTurboNavigation);
   }
 
   private reinitializeAfterNavigation() {

--- a/javascript/packages/dev-tools/src/index.ts
+++ b/javascript/packages/dev-tools/src/index.ts
@@ -6,6 +6,12 @@ export { HerbOverlay, ErrorOverlay };
 export type { HerbDevToolsOptions, ValidationError, ValidationData };
 
 export function initHerbDevTools(options: HerbDevToolsOptions = {}): HerbOverlay {
+  if (typeof window !== 'undefined') {
+    const existingOverlay = (window as any).HerbDevTools?._overlay as HerbOverlay | undefined;
+
+    existingOverlay?.destroy();
+  }
+
   const overlay = new HerbOverlay(options);
 
   if (typeof window !== 'undefined') {

--- a/javascript/packages/dev-tools/test/listener-lifecycle.test.ts
+++ b/javascript/packages/dev-tools/test/listener-lifecycle.test.ts
@@ -1,0 +1,176 @@
+import { describe, test, expect, beforeEach, afterEach, vi } from "vitest"
+import type { MockInstance } from "vitest"
+
+import { HerbOverlay } from "../src/herb-overlay"
+import { initHerbDevTools } from "../src/index"
+
+const DOCUMENT_EVENTS = ["click", "turbo:load", "turbo:render", "turbo:visit"]
+
+let addSpy: MockInstance
+let removeSpy: MockInstance
+let overlays: HerbOverlay[]
+
+function callCountFor(spy: MockInstance, type: string) {
+  return spy.mock.calls.filter(call => call[0] === type).length
+}
+
+function netDocumentListeners() {
+  return Object.fromEntries(
+    DOCUMENT_EVENTS.map(type => [type, callCountFor(addSpy, type) - callCountFor(removeSpy, type)])
+  )
+}
+
+function createOverlay() {
+  const overlay = new HerbOverlay()
+
+  overlays.push(overlay)
+
+  return overlay
+}
+
+function navigate() {
+  document.querySelector(".herb-floating-menu")?.remove()
+  document.dispatchEvent(new Event("turbo:load"))
+}
+
+beforeEach(() => {
+  localStorage.clear()
+  document.body.innerHTML = ""
+
+  overlays = []
+  addSpy = vi.spyOn(document, "addEventListener")
+  removeSpy = vi.spyOn(document, "removeEventListener")
+})
+
+afterEach(() => {
+  overlays.forEach(overlay => overlay.destroy())
+  ;((window as any).HerbDevTools?._overlay as HerbOverlay | undefined)?.destroy()
+
+  vi.restoreAllMocks()
+
+  document.body.innerHTML = ""
+  localStorage.clear()
+})
+
+describe("HerbOverlay", () => {
+  test("binds each document-level listener exactly once", () => {
+    createOverlay()
+
+    expect(netDocumentListeners()).toEqual({
+      "click": 1,
+      "turbo:load": 1,
+      "turbo:render": 1,
+      "turbo:visit": 1,
+    })
+  })
+
+  test("does not accumulate document listeners across Turbo navigations", () => {
+    createOverlay()
+
+    const afterInit = netDocumentListeners()
+
+    for (let index = 0; index < 20; index++) {
+      navigate()
+
+      expect(document.querySelectorAll(".herb-floating-menu")).toHaveLength(1)
+    }
+
+    expect(netDocumentListeners()).toEqual(afterInit)
+  })
+
+  test("closes the menu on an outside click after a navigation", () => {
+    createOverlay()
+
+    navigate()
+
+    const trigger = document.getElementById("herbMenuTrigger") as HTMLElement
+    const panel = document.getElementById("herbMenuPanel") as HTMLElement
+
+    trigger.click()
+
+    expect(trigger.classList.contains("active")).toBe(true)
+    expect(panel.classList.contains("open")).toBe(true)
+
+    document.body.click()
+
+    expect(trigger.classList.contains("active")).toBe(false)
+    expect(panel.classList.contains("open")).toBe(false)
+  })
+
+  test("keeps the menu open when clicking inside it after a navigation", () => {
+    createOverlay()
+
+    navigate()
+
+    const trigger = document.getElementById("herbMenuTrigger") as HTMLElement
+    const panel = document.getElementById("herbMenuPanel") as HTMLElement
+
+    trigger.click()
+    panel.click()
+
+    expect(panel.classList.contains("open")).toBe(true)
+  })
+
+  test("destroy() unbinds every document listener and removes the menu", () => {
+    const overlay = createOverlay()
+
+    overlay.destroy()
+
+    expect(netDocumentListeners()).toEqual({
+      "click": 0,
+      "turbo:load": 0,
+      "turbo:render": 0,
+      "turbo:visit": 0,
+    })
+
+    expect(document.querySelector(".herb-floating-menu")).toBeNull()
+  })
+
+  test("destroy() stops the overlay from reacting to Turbo navigations", () => {
+    const overlay = createOverlay()
+
+    overlay.destroy()
+
+    document.dispatchEvent(new Event("turbo:load"))
+
+    expect(document.querySelector(".herb-floating-menu")).toBeNull()
+  })
+
+  test("destroy() is safe to call more than once", () => {
+    const overlay = createOverlay()
+
+    overlay.destroy()
+
+    const afterFirstDestroy = netDocumentListeners()
+
+    overlay.destroy()
+    overlay.destroy()
+
+    expect(netDocumentListeners()).toEqual(afterFirstDestroy)
+  })
+})
+
+describe("initHerbDevTools", () => {
+  test("leaves exactly one live overlay when called repeatedly", () => {
+    overlays.push(initHerbDevTools())
+
+    const afterFirstInit = netDocumentListeners()
+
+    for (let index = 0; index < 5; index++) {
+      overlays.push(initHerbDevTools())
+    }
+
+    expect(netDocumentListeners()).toEqual(afterFirstInit)
+    expect(document.querySelectorAll(".herb-floating-menu")).toHaveLength(1)
+  })
+
+  test("exposes the most recent overlay on the global", () => {
+    initHerbDevTools()
+
+    const overlay = initHerbDevTools()
+
+    overlays.push(overlay)
+
+    expect((window as any).HerbDevTools._overlay).toBe(overlay)
+  })
+})

--- a/javascript/packages/dev-tools/vitest.config.ts
+++ b/javascript/packages/dev-tools/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "vitest/config"
+import { playwright } from "@vitest/browser-playwright"
+
+export default defineConfig({
+  test: {
+    browser: {
+      enabled: true,
+      headless: true,
+      provider: playwright(),
+      instances: [{ browser: "chromium" }],
+    },
+  },
+})


### PR DESCRIPTION
This pull request fixes two listener-lifecycle problems in `@herb-tools/dev-tools` that made a browser performance degradation in ReActionView debug mode unrecoverable rather than merely wasteful.

The dominant cause of marcoroth/reactionview#108 was on the ReActionView side, which constructed a new `HerbOverlay` on every `turbo:load`, `turbo:render` and `turbo:visit`, and is fixed there. What turned that into a permanent leak is that this package gave it no way out.

Partly resolves marcoroth/reactionview#108