### PR TITLE
Dev Tools: Don't log on every page load when there are no errors

### DIFF
--- a/javascript/packages/dev-tools/src/error-overlay.ts
+++ b/javascript/packages/dev-tools/src/error-overlay.ts
@@ -241,8 +241,6 @@ export class ErrorOverlay {
       this.setupToggleHandler();
     } else if (hasParserErrors) {
       console.log('[ErrorOverlay] Parser error overlay already displayed');
-    } else {
-      console.log('[ErrorOverlay] No errors found, not creating overlay');
     }
   }
 


### PR DESCRIPTION
Follow up on #2081.

`ErrorOverlay#init()` logged `[ErrorOverlay] No errors found, not creating overlay` whenever it found nothing to display, which is the common case for a page in debug mode. Every page load, and every Turbo navigation that constructs an overlay, put a line in the console saying nothing happened.

The `[ErrorOverlay] Parser error overlay already displayed` branch stays, since it only fires when a parser error overlay is actually on the page.