### PR TITLE
Parser: Detect `stylesheet_link_tag` helper

### DIFF
--- a/config/action_view_helpers/actionview/asset_tag_helper/stylesheet_link_tag.yml
+++ b/config/action_view_helpers/actionview/asset_tag_helper/stylesheet_link_tag.yml
@@ -4,10 +4,13 @@ source: "ActionView::Helpers::AssetTagHelper#stylesheet_link_tag"
 gem: "actionview"
 output: "html"
 visibility: "public"
-supported: false
+supported: true
 supports_block: false
 signature: "stylesheet_link_tag(*sources)"
 documentation_url: "https://api.rubyonrails.org/classes/ActionView/Helpers/AssetTagHelper.html#method-i-stylesheet_link_tag"
+attributes_arg: "keywords"
+transform_style: "generic"
+content: null
 
 description: |-
   Returns a stylesheet `<link>` tag for the sources specified as arguments. The .css extension is optional. If the server supports HTTP Early Hints, Rails will push a 103 Early Hints response that links to the assets.
@@ -21,6 +24,7 @@ tag:
     name: "href"
     source: "first_arg"
     wrapper: "stylesheet_path"
+    wrapper_quotes_arg: true
     skip_wrapping_for:
       - "url"
 

--- a/javascript/packages/node/binding.gyp
+++ b/javascript/packages/node/binding.gyp
@@ -18,6 +18,7 @@
         "./extension/libherb/analyze/action_view/javascript_tag.c",
         "./extension/libherb/analyze/action_view/link_to.c",
         "./extension/libherb/analyze/action_view/registry.c",
+        "./extension/libherb/analyze/action_view/stylesheet_link_tag.c",
         "./extension/libherb/analyze/action_view/tag_helper_node_builders.c",
         "./extension/libherb/analyze/action_view/tag_helpers.c",
         "./extension/libherb/analyze/action_view/turbo_frame_tag.c",

--- a/javascript/packages/rewriter/src/built-ins/html-to-action-view-tag-helper.ts
+++ b/javascript/packages/rewriter/src/built-ins/html-to-action-view-tag-helper.ts
@@ -31,20 +31,35 @@ function dashToUnderscore(string: string): string {
   return string.replace(/-/g, "_")
 }
 
+function getStaticAttributeValue(children: Node[], attributeName: string): string | null {
+  for (const child of children) {
+    if (!isHTMLAttributeNode(child)) continue
+    if (getStaticAttributeName(child.name!) !== attributeName) continue
+    if (!child.value) return null
+    if (!child.value.children.every(value => isLiteralNode(value))) return null
+
+    return child.value.children.map(value => isLiteralNode(value) ? value.content : "").join("")
+  }
+
+  return null
+}
+
 interface SerializedAttributes {
   attributes: string
   href: string | null
   id: string | null
   src: string | null
+  rel: string | null
 }
 
-function serializeAttributes(children: Node[], options: { extractHref?: boolean, extractId?: boolean, extractSrc?: boolean } = {}): SerializedAttributes {
+function serializeAttributes(children: Node[], options: { extractHref?: boolean, extractId?: boolean, extractSrc?: boolean, extractRel?: boolean } = {}): SerializedAttributes {
   const regular: string[] = []
   const prefixed: Map<string, string[]> = new Map()
 
   let href: string | null = null
   let id: string | null = null
   let src: string | null = null
+  let rel: string | null = null
 
   for (const child of children) {
     if (!isHTMLAttributeNode(child)) continue
@@ -69,6 +84,11 @@ function serializeAttributes(children: Node[], options: { extractHref?: boolean,
       continue
     }
 
+    if (options.extractRel && name === "rel") {
+      rel = value
+      continue
+    }
+
     const dataMatch = name.match(/^(data|aria)-(.+)$/)
 
     if (dataMatch) {
@@ -90,7 +110,7 @@ function serializeAttributes(children: Node[], options: { extractHref?: boolean,
     parts.push(`${prefix}: { ${entries.join(", ")} }`)
   }
 
-  return { attributes: parts.join(", "), href, id, src }
+  return { attributes: parts.join(", "), href, id, src, rel }
 }
 
 function isTextOnlyBody(body: Node[]): boolean {
@@ -125,10 +145,13 @@ class HTMLToActionViewTagHelperVisitor extends Visitor {
     const attributes = openTag.children.filter(child => !isWhitespaceNode(child))
     const implicitAttrName = preferredHelper?.implicitAttribute?.name
     const hasSrcAttribute = attributes.some(child => isHTMLAttributeNode(child) && getStaticAttributeName(child.name!) === "src")
+    const hasHrefAttribute = attributes.some(child => isHTMLAttributeNode(child) && getStaticAttributeName(child.name!) === "href")
+    const isStylesheetLink = tagName.value === "link" && hasHrefAttribute && getStaticAttributeValue(attributes, "rel") === "stylesheet"
     const { attributes: attributesString, href, id, src } = serializeAttributes(attributes, {
-      extractHref: implicitAttrName === "href",
+      extractHref: implicitAttrName === "href" || isStylesheetLink,
       extractId: implicitAttrName === "id",
       extractSrc: implicitAttrName === "src" || tagName.value === "script",
+      extractRel: isStylesheetLink,
     })
     const hasBody = node.body && node.body.length > 0 && !node.is_void
     const isInlineContent = hasBody && isTextOnlyBody(node.body)
@@ -145,6 +168,9 @@ class HTMLToActionViewTagHelperVisitor extends Visitor {
     } else if (preferredHelper?.name === "image_tag") {
       content = this.buildImageTagContent(attributesString, src)
       elementSource = preferredHelper.source
+    } else if (isStylesheetLink) {
+      content = this.buildStylesheetLinkTagContent(attributesString, href)
+      elementSource = HELPER_REGISTRY["stylesheet_link_tag"].source
     } else if (tagName.value === "script" && hasSrcAttribute) {
       content = this.buildJavascriptIncludeTagContent(attributesString, src)
       elementSource = HELPER_REGISTRY["javascript_include_tag"].source
@@ -281,6 +307,17 @@ class HTMLToActionViewTagHelperVisitor extends Visitor {
     return argString ? ` image_tag ${argString} ` : ` image_tag `
   }
 
+  private buildStylesheetLinkTagContent(attributes: string, source: string | null): string {
+    const args: string[] = []
+
+    if (source) args.push(source)
+    if (attributes) args.push(attributes)
+
+    const argString = args.join(", ")
+
+    return argString ? ` stylesheet_link_tag ${argString} ` : ` stylesheet_link_tag `
+  }
+
   private buildLinkToContent(node: HTMLElementNode, attribute: string, href: string | null, isInlineContent: boolean): string {
     const args: string[] = []
 
@@ -312,7 +349,7 @@ export class HTMLToActionViewTagHelperRewriter extends ASTRewriter {
   }
 
   get description(): string {
-    return "Converts raw HTML elements to ActionView tag helpers (tag.*, turbo_frame_tag, javascript_tag, javascript_include_tag, image_tag)"
+    return "Converts raw HTML elements to ActionView tag helpers (tag.*, turbo_frame_tag, javascript_tag, javascript_include_tag, image_tag, stylesheet_link_tag)"
   }
 
   rewrite<T extends Node>(node: T, _context: RewriteContext): T {

--- a/javascript/packages/rewriter/test/action-view-tag-helper-to-html.test.ts
+++ b/javascript/packages/rewriter/test/action-view-tag-helper-to-html.test.ts
@@ -896,6 +896,128 @@ describe("ActionViewTagHelperToHTMLRewriter", () => {
     })
   })
 
+  describe("stylesheet_link_tag helpers", () => {
+    test("stylesheet_link_tag with source", () => {
+      expect(transform('<%= stylesheet_link_tag "style" %>')).toBe(
+        '<link rel="stylesheet" href="<%= stylesheet_path("style") %>" />'
+      )
+    })
+
+    test("stylesheet_link_tag with source including extension", () => {
+      expect(transform('<%= stylesheet_link_tag "style.css" %>')).toBe(
+        '<link rel="stylesheet" href="<%= stylesheet_path("style.css") %>" />'
+      )
+    })
+
+    test("stylesheet_link_tag with URL", () => {
+      expect(transform('<%= stylesheet_link_tag "http://www.example.com/style.css" %>')).toBe(
+        '<link rel="stylesheet" href="http://www.example.com/style.css" />'
+      )
+    })
+
+    test("stylesheet_link_tag with extname false, skip_pipeline and rel", () => {
+      expect(transform('<%= stylesheet_link_tag "style.less", extname: false, skip_pipeline: true, rel: "stylesheet/less" %>')).toBe(
+        '<link rel="stylesheet/less" href="<%= stylesheet_path("style.less", extname: false, skip_pipeline: true) %>" />'
+      )
+    })
+
+    test("stylesheet_link_tag with media all", () => {
+      expect(transform('<%= stylesheet_link_tag "style", media: "all" %>')).toBe(
+        '<link rel="stylesheet" href="<%= stylesheet_path("style") %>" media="all" />'
+      )
+    })
+
+    test("stylesheet_link_tag with media print", () => {
+      expect(transform('<%= stylesheet_link_tag "style", media: "print" %>')).toBe(
+        '<link rel="stylesheet" href="<%= stylesheet_path("style") %>" media="print" />'
+      )
+    })
+
+    test("stylesheet_link_tag with multiple sources", () => {
+      expect(transform('<%= stylesheet_link_tag "random.styles", "/css/stylish" %>')).toBe(
+        dedent`
+          <link rel="stylesheet" href="<%= stylesheet_path("random.styles") %>" />
+          <link rel="stylesheet" href="<%= stylesheet_path("/css/stylish") %>" />
+        `
+      )
+    })
+
+    test("stylesheet_link_tag with protocol-relative URL", () => {
+      expect(transform('<%= stylesheet_link_tag "//cdn.example.com/style.css" %>')).toBe(
+        '<link rel="stylesheet" href="//cdn.example.com/style.css" />'
+      )
+    })
+
+    test("stylesheet_link_tag with host and protocol forwards to stylesheet_path", () => {
+      expect(transform('<%= stylesheet_link_tag "style", host: "localhost", protocol: "https" %>')).toBe(
+        '<link rel="stylesheet" href="<%= stylesheet_path("style", host: "localhost", protocol: "https") %>" />'
+      )
+    })
+
+    test("stylesheet_link_tag with skip_pipeline forwards to stylesheet_path", () => {
+      expect(transform('<%= stylesheet_link_tag "application", skip_pipeline: true %>')).toBe(
+        '<link rel="stylesheet" href="<%= stylesheet_path("application", skip_pipeline: true) %>" />'
+      )
+    })
+
+    test("stylesheet_link_tag with rel keeps the explicit value in the leading position", () => {
+      expect(transform('<%= stylesheet_link_tag "application", rel: "preload" %>')).toBe(
+        '<link rel="preload" href="<%= stylesheet_path("application") %>" />'
+      )
+    })
+
+    test("stylesheet_link_tag with nonce true resolves to content_security_policy_nonce", () => {
+      expect(transform('<%= stylesheet_link_tag "application", nonce: true %>')).toBe(
+        '<link rel="stylesheet" href="<%= stylesheet_path("application") %>" nonce="<%= content_security_policy_nonce %>" />'
+      )
+    })
+
+    test("stylesheet_link_tag with nonce false omits nonce attribute", () => {
+      expect(transform('<%= stylesheet_link_tag "application", nonce: false %>')).toBe(
+        '<link rel="stylesheet" href="<%= stylesheet_path("application") %>" />'
+      )
+    })
+
+    test("stylesheet_link_tag with interpolated nonce", () => {
+      expect(transform('<%= stylesheet_link_tag "application", nonce: "static-#{dynamic}" %>')).toBe(
+        '<link rel="stylesheet" href="<%= stylesheet_path("application") %>" nonce="static-<%= dynamic %>" />'
+      )
+    })
+
+    test("stylesheet_link_tag with data attributes", () => {
+      expect(transform('<%= stylesheet_link_tag "application", data: { turbo_track: "reload" } %>')).toBe(
+        '<link rel="stylesheet" href="<%= stylesheet_path("application") %>" data-turbo-track="reload" />'
+      )
+    })
+
+    test("stylesheet_link_tag with asset_path source passes through", () => {
+      expect(transform('<%= stylesheet_link_tag asset_path("application.css") %>')).toBe(
+        '<link rel="stylesheet" href="<%= asset_path("application.css") %>" />'
+      )
+    })
+
+    test("stylesheet_link_tag with ruby expression source wraps in stylesheet_path", () => {
+      expect(transform('<%= stylesheet_link_tag stylesheet %>')).toBe(
+        '<link rel="stylesheet" href="<%= stylesheet_path(stylesheet) %>" />'
+      )
+    })
+
+    test("stylesheet_link_tag with splat attributes", () => {
+      expect(transform('<%= stylesheet_link_tag "application", **attributes %>')).toBe(
+        '<link rel="stylesheet" href="<%= stylesheet_path("application") %>" <%= tag.attributes(**attributes) %> />'
+      )
+    })
+
+    test("stylesheet_link_tag with multiple sources and media", () => {
+      expect(transform('<%= stylesheet_link_tag "application", "admin", media: "all" %>')).toBe(
+        dedent`
+          <link rel="stylesheet" href="<%= stylesheet_path("application") %>" media="all" />
+          <link rel="stylesheet" href="<%= stylesheet_path("admin") %>" media="all" />
+        `
+      )
+    })
+  })
+
   describe("class attribute handling", () => {
     test("tag.div with conditional class hash wraps in token_list", () => {
       expect(transform('<%= tag.div class: { active: true, hidden: false } %>')).toBe(

--- a/javascript/packages/rewriter/test/html-to-action-view-tag-helper.test.ts
+++ b/javascript/packages/rewriter/test/html-to-action-view-tag-helper.test.ts
@@ -463,6 +463,76 @@ describe("HTMLToActionViewTagHelperRewriter", () => {
     })
   })
 
+  describe("stylesheet_link_tag for stylesheet link elements", () => {
+    test("stylesheet link", () => {
+      expect(transform('<link rel="stylesheet" href="application.css">')).toBe(
+        '<%= stylesheet_link_tag "application.css" %>'
+      )
+    })
+
+    test("stylesheet link self-closing", () => {
+      expect(transform('<link rel="stylesheet" href="application.css" />')).toBe(
+        '<%= stylesheet_link_tag "application.css" %>'
+      )
+    })
+
+    test("stylesheet link with media", () => {
+      expect(transform('<link rel="stylesheet" href="application.css" media="all">')).toBe(
+        '<%= stylesheet_link_tag "application.css", media: "all" %>'
+      )
+    })
+
+    test("stylesheet link with data attributes", () => {
+      expect(transform('<link rel="stylesheet" href="application.css" data-turbo-track="reload">')).toBe(
+        '<%= stylesheet_link_tag "application.css", data: { turbo_track: "reload" } %>'
+      )
+    })
+
+    test("stylesheet link with ERB href", () => {
+      expect(transform('<link rel="stylesheet" href="<%= stylesheet_path("application") %>">')).toBe(
+        '<%= stylesheet_link_tag stylesheet_path("application") %>'
+      )
+    })
+
+    test("stylesheet link with attribute order preserved", () => {
+      expect(transform('<link href="application.css" media="print" rel="stylesheet">')).toBe(
+        '<%= stylesheet_link_tag "application.css", media: "print" %>'
+      )
+    })
+  })
+
+  describe("tag.link for other link elements", () => {
+    test("non-stylesheet link", () => {
+      expect(transform('<link rel="icon" href="favicon.ico">')).toBe(
+        '<%= tag.link rel: "icon", href: "favicon.ico" %>'
+      )
+    })
+
+    test("preload link", () => {
+      expect(transform('<link rel="preload" href="font.woff2" as="font">')).toBe(
+        '<%= tag.link rel: "preload", href: "font.woff2", as: "font" %>'
+      )
+    })
+
+    test("link without rel", () => {
+      expect(transform('<link href="application.css">')).toBe(
+        '<%= tag.link href: "application.css" %>'
+      )
+    })
+
+    test("stylesheet link without href", () => {
+      expect(transform('<link rel="stylesheet">')).toBe(
+        '<%= tag.link rel: "stylesheet" %>'
+      )
+    })
+
+    test("link with dynamic rel", () => {
+      expect(transform('<link rel="<%= rel %>" href="application.css">')).toBe(
+        '<%= tag.link rel: rel, href: "application.css" %>'
+      )
+    })
+  })
+
   describe("ERB in attribute values", () => {
     test("single ERB expression becomes Ruby variable", () => {
       expect(transform('<div class="<%= class_name %>">Content</div>')).toBe(

--- a/src/analyze/action_view/registry.c
+++ b/src/analyze/action_view/registry.c
@@ -11,8 +11,16 @@ extern const tag_helper_handler_T turbo_frame_tag_handler;
 extern const tag_helper_handler_T javascript_tag_handler;
 extern const tag_helper_handler_T javascript_include_tag_handler;
 extern const tag_helper_handler_T image_tag_handler;
+extern const tag_helper_handler_T stylesheet_link_tag_handler;
 
-static size_t handlers_count = 7;
+static const tag_helper_handler_T* const static_handlers[] = {
+  &content_tag_handler,    &tag_handler,
+  &link_to_handler,        &turbo_frame_tag_handler,
+  &javascript_tag_handler, &javascript_include_tag_handler,
+  &image_tag_handler,      &stylesheet_link_tag_handler,
+};
+
+static const size_t handlers_count = sizeof(static_handlers) / sizeof(static_handlers[0]);
 
 tag_helper_info_T* tag_helper_info_init(hb_allocator_T* allocator) {
   tag_helper_info_T* info = hb_allocator_alloc(allocator, sizeof(tag_helper_info_T));
@@ -43,22 +51,7 @@ void tag_helper_info_free(tag_helper_info_T** info) {
   *info = NULL;
 }
 
-tag_helper_handler_T* get_tag_helper_handlers(void) {
-  static tag_helper_handler_T static_handlers[7];
-  static bool initialized = false;
-
-  if (!initialized) {
-    static_handlers[0] = content_tag_handler;
-    static_handlers[1] = tag_handler;
-    static_handlers[2] = link_to_handler;
-    static_handlers[3] = turbo_frame_tag_handler;
-    static_handlers[4] = javascript_tag_handler;
-    static_handlers[5] = javascript_include_tag_handler;
-    static_handlers[6] = image_tag_handler;
-
-    initialized = true;
-  }
-
+const tag_helper_handler_T* const* get_tag_helper_handlers(void) {
   return static_handlers;
 }
 

--- a/src/analyze/action_view/stylesheet_link_tag.c
+++ b/src/analyze/action_view/stylesheet_link_tag.c
@@ -1,0 +1,40 @@
+#include "../../include/lib/hb_allocator.h"
+#include "../../include/lib/hb_buffer.h"
+
+#include <prism.h>
+#include <stdbool.h>
+#include <string.h>
+
+bool stylesheet_link_tag_source_is_url(const char* source, size_t length) {
+  if (!source || length == 0) { return false; }
+
+  if (length >= 2 && source[0] == '/' && source[1] == '/') { return true; }
+  if (strstr(source, "://") != NULL) { return true; }
+
+  return false;
+}
+
+char* wrap_in_stylesheet_path(
+  const char* source,
+  size_t source_length,
+  const char* path_options,
+  hb_allocator_T* allocator
+) {
+  hb_buffer_T buffer;
+  hb_buffer_init(&buffer, source_length + 32, allocator);
+
+  hb_buffer_append(&buffer, "stylesheet_path(");
+  hb_buffer_append_with_length(&buffer, source, source_length);
+
+  if (path_options && strlen(path_options) > 0) {
+    hb_buffer_append(&buffer, ", ");
+    hb_buffer_append(&buffer, path_options);
+  }
+
+  hb_buffer_append(&buffer, ")");
+
+  char* result = hb_allocator_strdup(allocator, hb_buffer_value(&buffer));
+  hb_buffer_free(&buffer);
+
+  return result;
+}

--- a/src/analyze/action_view/tag_helpers.c
+++ b/src/analyze/action_view/tag_helpers.c
@@ -36,6 +36,9 @@ extern bool detect_image_tag(pm_call_node_t*, pm_parser_t*);
 extern char* extract_image_tag_src(pm_call_node_t*, pm_parser_t*, hb_allocator_T*);
 extern char* wrap_in_image_path(const char*, size_t, const char*, hb_allocator_T*);
 extern bool image_tag_source_is_url(const char*, size_t);
+extern bool detect_stylesheet_link_tag(pm_call_node_t*, pm_parser_t*);
+extern char* wrap_in_stylesheet_path(const char*, size_t, const char*, hb_allocator_T*);
+extern bool stylesheet_link_tag_source_is_url(const char*, size_t);
 
 typedef struct {
   pm_parser_t parser;
@@ -210,22 +213,22 @@ bool search_tag_helper_node(const pm_node_t* node, void* data) {
 
   if (node->type == PM_CALL_NODE) {
     pm_call_node_t* call_node = (pm_call_node_t*) node;
-    tag_helper_handler_T* handlers = get_tag_helper_handlers();
+    const tag_helper_handler_T* const* handlers = get_tag_helper_handlers();
     size_t handlers_count = get_tag_helper_handlers_count();
 
     for (size_t i = 0; i < handlers_count; i++) {
-      if (handlers[i].detect(call_node, search_data->parser)) {
+      if (handlers[i]->detect(call_node, search_data->parser)) {
         search_data->tag_helper_node = node;
-        search_data->matched_handler = &handlers[i];
+        search_data->matched_handler = handlers[i];
         search_data->found = true;
 
         if (search_data->info) {
           search_data->info->call_node = call_node;
           search_data->info->tag_name =
-            handlers[i].extract_tag_name(call_node, search_data->parser, search_data->info->allocator);
+            handlers[i]->extract_tag_name(call_node, search_data->parser, search_data->info->allocator);
           search_data->info->content =
-            handlers[i].extract_content(call_node, search_data->parser, search_data->info->allocator);
-          search_data->info->has_block = handlers[i].supports_block();
+            handlers[i]->extract_content(call_node, search_data->parser, search_data->info->allocator);
+          search_data->info->has_block = handlers[i]->supports_block();
         }
 
         return false;
@@ -337,6 +340,7 @@ static void calculate_tag_name_positions(
 }
 
 static const char* JAVASCRIPT_INCLUDE_TAG_PATH_OPTIONS[] = { "protocol", "extname", "host", "skip_pipeline", NULL };
+static const char* STYLESHEET_LINK_TAG_PATH_OPTIONS[] = { "protocol", "extname", "host", "skip_pipeline", NULL };
 static const char* IMAGE_TAG_PATH_OPTIONS[] = { "skip_pipeline", NULL };
 
 static char* extract_path_options_from_keyword_hash(
@@ -428,6 +432,71 @@ static AST_NODE_T* remove_attribute_by_name(hb_array_T* attributes, const char* 
 
   return NULL;
 }
+
+static hb_array_T* prepend_stylesheet_link_tag_attributes(
+  hb_array_T* attributes,
+  tag_helper_parse_context_T* parse_context,
+  pm_node_t* source_argument,
+  const char* path_options,
+  hb_allocator_T* allocator
+) {
+  bool source_is_string = (source_argument->type == PM_STRING_NODE);
+  char* source_value = NULL;
+
+  if (source_is_string) {
+    pm_string_node_t* string_node = (pm_string_node_t*) source_argument;
+    size_t length = pm_string_length(&string_node->unescaped);
+    source_value = hb_allocator_strndup(allocator, (const char*) pm_string_source(&string_node->unescaped), length);
+  } else {
+    size_t length = source_argument->location.end - source_argument->location.start;
+    source_value = hb_allocator_strndup(allocator, (const char*) source_argument->location.start, length);
+  }
+
+  if (!source_value) { return attributes; }
+
+  position_T source_start, source_end;
+  prism_node_location_to_positions(&source_argument->location, parse_context, &source_start, &source_end);
+
+  size_t source_length = strlen(source_value);
+  bool is_url = stylesheet_link_tag_source_is_url(source_value, source_length);
+  bool source_is_path_helper = is_route_helper_node(source_argument, &parse_context->parser);
+
+  char* href_value = source_value;
+
+  if (source_is_string && !is_url) {
+    size_t quoted_length = source_length + 2;
+    char* quoted_source = hb_allocator_alloc(allocator, quoted_length + 1);
+    quoted_source[0] = '"';
+    memcpy(quoted_source + 1, source_value, source_length);
+    quoted_source[quoted_length - 1] = '"';
+    quoted_source[quoted_length] = '\0';
+
+    href_value = wrap_in_stylesheet_path(quoted_source, quoted_length, path_options, allocator);
+    hb_allocator_dealloc(allocator, quoted_source);
+  } else if (!source_is_string && !is_url && !source_is_path_helper) {
+    href_value = wrap_in_stylesheet_path(source_value, source_length, path_options, allocator);
+  }
+
+  AST_HTML_ATTRIBUTE_NODE_T* href_attribute =
+    is_url ? create_html_attribute_node("href", href_value, source_start, source_end, allocator)
+           : create_html_attribute_with_ruby_literal("href", href_value, source_start, source_end, allocator);
+
+  if (href_value != source_value) { hb_allocator_dealloc(allocator, href_value); }
+  hb_allocator_dealloc(allocator, source_value);
+
+  if (href_attribute) { attributes = prepend_attribute(attributes, (AST_NODE_T*) href_attribute, allocator); }
+
+  AST_NODE_T* rel_attribute = remove_attribute_by_name(attributes, "rel");
+
+  if (!rel_attribute) {
+    rel_attribute = (AST_NODE_T*) create_html_attribute_node("rel", "stylesheet", source_start, source_end, allocator);
+  }
+
+  if (rel_attribute) { attributes = prepend_attribute(attributes, rel_attribute, allocator); }
+
+  return attributes;
+}
+
 static AST_NODE_T* transform_tag_helper_with_attributes(
   AST_ERB_CONTENT_NODE_T* erb_node,
   analyze_ruby_context_T* context,
@@ -460,7 +529,8 @@ static AST_NODE_T* transform_tag_helper_with_attributes(
   }
 
   if (attributes && handler->name
-      && (strcmp(handler->name, "javascript_include_tag") == 0 || strcmp(handler->name, "javascript_tag") == 0)) {
+      && (strcmp(handler->name, "javascript_include_tag") == 0 || strcmp(handler->name, "javascript_tag") == 0
+          || strcmp(handler->name, "stylesheet_link_tag") == 0)) {
     resolve_nonce_attribute(attributes, allocator);
   }
 
@@ -470,6 +540,19 @@ static AST_NODE_T* transform_tag_helper_with_attributes(
     path_options = extract_path_options_from_keyword_hash(
       parse_context->info->call_node,
       JAVASCRIPT_INCLUDE_TAG_PATH_OPTIONS,
+      allocator
+    );
+
+    remove_attribute_by_name(attributes, "extname");
+    remove_attribute_by_name(attributes, "host");
+    remove_attribute_by_name(attributes, "protocol");
+    remove_attribute_by_name(attributes, "skip-pipeline");
+  }
+
+  if (attributes && handler->name && strcmp(handler->name, "stylesheet_link_tag") == 0) {
+    path_options = extract_path_options_from_keyword_hash(
+      parse_context->info->call_node,
+      STYLESHEET_LINK_TAG_PATH_OPTIONS,
       allocator
     );
 
@@ -716,6 +799,18 @@ static AST_NODE_T* transform_tag_helper_with_attributes(
     }
   }
 
+  if (detect_stylesheet_link_tag(parse_context->info->call_node, &parse_context->parser)
+      && parse_context->info->call_node->arguments && parse_context->info->call_node->arguments->arguments.size >= 1) {
+    pm_node_t* first_argument = parse_context->info->call_node->arguments->arguments.nodes[0];
+
+    if (first_argument->type != PM_KEYWORD_HASH_NODE) {
+      if (!attributes) { attributes = hb_array_init(4, allocator); }
+
+      attributes =
+        prepend_stylesheet_link_tag_attributes(attributes, parse_context, first_argument, path_options, allocator);
+    }
+  }
+
   token_T* tag_name_token =
     tag_name ? create_synthetic_token(allocator, tag_name, TOKEN_IDENTIFIER, tag_name_start, tag_name_end) : NULL;
 
@@ -737,7 +832,7 @@ static AST_NODE_T* transform_tag_helper_with_attributes(
   hb_array_T* element_errors = hb_array_init(0, allocator);
   bool is_void = tag_name && is_void_element(hb_string_from_c_string(tag_name))
               && (string_equals(handler->name, "tag") || string_equals(handler->name, "content_tag")
-                  || string_equals(handler->name, "image_tag"));
+                  || string_equals(handler->name, "image_tag") || string_equals(handler->name, "stylesheet_link_tag"));
 
   if (helper_content) {
     if (is_void && tag_name) {
@@ -848,7 +943,7 @@ static AST_NODE_T* transform_tag_helper_with_attributes(
   return (AST_NODE_T*) element;
 }
 
-static size_t count_javascript_include_tag_sources(pm_call_node_t* call_node) {
+static size_t count_asset_tag_sources(pm_call_node_t* call_node) {
   if (!call_node || !call_node->arguments) { return 0; }
 
   size_t count = 0;
@@ -969,7 +1064,7 @@ static hb_array_T* transform_javascript_include_tag_multi_source(
 ) {
   hb_allocator_T* allocator = context->allocator;
   pm_call_node_t* call_node = parse_context->info->call_node;
-  size_t source_count = count_javascript_include_tag_sources(call_node);
+  size_t source_count = count_asset_tag_sources(call_node);
 
   if (source_count == 0) { return NULL; }
 
@@ -996,6 +1091,121 @@ static hb_array_T* transform_javascript_include_tag_multi_source(
   for (size_t i = 0; i < source_count; i++) {
     pm_node_t* source_arg = call_node->arguments->arguments.nodes[i];
     AST_NODE_T* element = create_javascript_include_tag_element(
+      erb_node,
+      parse_context,
+      source_arg,
+      shared_attributes,
+      path_options,
+      allocator
+    );
+
+    if (element) {
+      if (hb_array_size(elements) > 0) {
+        position_T position = erb_node->base.location.start;
+        AST_HTML_TEXT_NODE_T* newline = ast_html_text_node_init(
+          hb_string_from_c_string("\n"),
+          position,
+          position,
+          hb_array_init(0, allocator),
+          allocator
+        );
+        if (newline) { hb_array_append(elements, (AST_NODE_T*) newline); }
+      }
+
+      hb_array_append(elements, element);
+    }
+  }
+
+  return elements;
+}
+
+static AST_NODE_T* create_stylesheet_link_tag_element(
+  AST_ERB_CONTENT_NODE_T* erb_node,
+  tag_helper_parse_context_T* parse_context,
+  pm_node_t* source_argument,
+  hb_array_T* shared_attributes,
+  const char* path_options,
+  hb_allocator_T* allocator
+) {
+  position_T tag_name_start, tag_name_end;
+  calculate_tag_name_positions(
+    parse_context,
+    erb_node->base.location.start,
+    erb_node->base.location.end,
+    &tag_name_start,
+    &tag_name_end
+  );
+
+  token_T* tag_name_token = create_synthetic_token(allocator, "link", TOKEN_IDENTIFIER, tag_name_start, tag_name_end);
+
+  hb_array_T* attributes = hb_array_init(hb_array_size(shared_attributes) + 2, allocator);
+
+  for (size_t i = 0; i < hb_array_size(shared_attributes); i++) {
+    hb_array_append(attributes, hb_array_get(shared_attributes, i));
+  }
+
+  attributes =
+    prepend_stylesheet_link_tag_attributes(attributes, parse_context, source_argument, path_options, allocator);
+
+  AST_ERB_OPEN_TAG_NODE_T* open_tag_node = ast_erb_open_tag_node_init(
+    erb_node->tag_opening,
+    erb_node->content,
+    erb_node->tag_closing,
+    tag_name_token,
+    attributes,
+    erb_node->base.location.start,
+    erb_node->base.location.end,
+    hb_array_init(0, allocator),
+    allocator
+  );
+
+  return (AST_NODE_T*) ast_html_element_node_init(
+    (AST_NODE_T*) open_tag_node,
+    tag_name_token,
+    hb_array_init(0, allocator),
+    NULL,
+    true,
+    parse_context->matched_handler->source,
+    erb_node->base.location.start,
+    erb_node->base.location.end,
+    hb_array_init(0, allocator),
+    allocator
+  );
+}
+
+static hb_array_T* transform_stylesheet_link_tag_multi_source(
+  AST_ERB_CONTENT_NODE_T* erb_node,
+  analyze_ruby_context_T* context,
+  tag_helper_parse_context_T* parse_context
+) {
+  hb_allocator_T* allocator = context->allocator;
+  pm_call_node_t* call_node = parse_context->info->call_node;
+  size_t source_count = count_asset_tag_sources(call_node);
+
+  if (source_count == 0) { return NULL; }
+
+  hb_array_T* shared_attributes = extract_html_attributes_from_call_node(
+    call_node,
+    parse_context->prism_source,
+    parse_context->original_source,
+    parse_context->erb_content_offset,
+    allocator
+  );
+  if (!shared_attributes) { shared_attributes = hb_array_init(0, allocator); }
+
+  resolve_nonce_attribute(shared_attributes, allocator);
+
+  char* path_options = extract_path_options_from_keyword_hash(call_node, STYLESHEET_LINK_TAG_PATH_OPTIONS, allocator);
+  remove_attribute_by_name(shared_attributes, "extname");
+  remove_attribute_by_name(shared_attributes, "host");
+  remove_attribute_by_name(shared_attributes, "protocol");
+  remove_attribute_by_name(shared_attributes, "skip-pipeline");
+
+  hb_array_T* elements = hb_array_init(source_count * 2, allocator);
+
+  for (size_t i = 0; i < source_count; i++) {
+    pm_node_t* source_arg = call_node->arguments->arguments.nodes[i];
+    AST_NODE_T* element = create_stylesheet_link_tag_element(
       erb_node,
       parse_context,
       source_arg,
@@ -1575,10 +1785,15 @@ void transform_tag_helper_array(hb_array_T* array, analyze_ruby_context_T* conte
           parse_tag_helper_content(erb_string, context->source, erb_content_offset, context, context->allocator);
 
         if (parse_context) {
-          if (strcmp(parse_context->matched_handler->name, "javascript_include_tag") == 0
-              && parse_context->info->call_node
-              && count_javascript_include_tag_sources(parse_context->info->call_node) > 1) {
-            hb_array_T* multi = transform_javascript_include_tag_multi_source(erb_node, context, parse_context);
+          bool is_multi_source_asset_tag = (strcmp(parse_context->matched_handler->name, "javascript_include_tag") == 0
+                                            || strcmp(parse_context->matched_handler->name, "stylesheet_link_tag") == 0)
+                                        && parse_context->info->call_node
+                                        && count_asset_tag_sources(parse_context->info->call_node) > 1;
+
+          if (is_multi_source_asset_tag) {
+            hb_array_T* multi = strcmp(parse_context->matched_handler->name, "stylesheet_link_tag") == 0
+                                ? transform_stylesheet_link_tag_multi_source(erb_node, context, parse_context)
+                                : transform_javascript_include_tag_multi_source(erb_node, context, parse_context);
 
             if (multi && hb_array_size(multi) > 0) {
               size_t old_size = hb_array_size(array);

--- a/src/include/analyze/action_view/tag_helper_handler.h
+++ b/src/include/analyze/action_view/tag_helper_handler.h
@@ -35,7 +35,7 @@ typedef struct {
 tag_helper_info_T* tag_helper_info_init(hb_allocator_T* allocator);
 void tag_helper_info_free(tag_helper_info_T** info);
 
-tag_helper_handler_T* get_tag_helper_handlers(void);
+const tag_helper_handler_T* const* get_tag_helper_handlers(void);
 size_t get_tag_helper_handlers_count(void);
 
 char* extract_inline_block_content(pm_call_node_t* call_node, hb_allocator_T* allocator);

--- a/test/analyze/action_view/asset_tag_helper/stylesheet_link_tag_test.rb
+++ b/test/analyze/action_view/asset_tag_helper/stylesheet_link_tag_test.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+require_relative "../../../test_helper"
+
+module Analyze::ActionView::AssetTagHelper
+  class StylesheetLinkTagTest < Minitest::Spec
+    include SnapshotUtils
+
+    test "stylesheet_link_tag with source" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <%= stylesheet_link_tag "style" %>
+      HTML
+    end
+
+    test "stylesheet_link_tag with source including extension" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <%= stylesheet_link_tag "style.css" %>
+      HTML
+    end
+
+    test "stylesheet_link_tag with URL" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <%= stylesheet_link_tag "http://www.example.com/style.css" %>
+      HTML
+    end
+
+    test "stylesheet_link_tag with extname false, skip_pipeline and rel" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <%= stylesheet_link_tag "style.less", extname: false, skip_pipeline: true, rel: "stylesheet/less" %>
+      HTML
+    end
+
+    test "stylesheet_link_tag with media all" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <%= stylesheet_link_tag "style", media: "all" %>
+      HTML
+    end
+
+    test "stylesheet_link_tag with media print" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <%= stylesheet_link_tag "style", media: "print" %>
+      HTML
+    end
+
+    test "stylesheet_link_tag with multiple sources" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <%= stylesheet_link_tag "random.styles", "/css/stylish" %>
+      HTML
+    end
+
+    test "stylesheet_link_tag with protocol-relative URL" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <%= stylesheet_link_tag "//cdn.example.com/style.css" %>
+      HTML
+    end
+
+    test "stylesheet_link_tag with host and protocol" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <%= stylesheet_link_tag "style", host: "localhost", protocol: "https" %>
+      HTML
+    end
+
+    test "stylesheet_link_tag with skip_pipeline" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <%= stylesheet_link_tag "application", skip_pipeline: true %>
+      HTML
+    end
+
+    test "stylesheet_link_tag with rel" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <%= stylesheet_link_tag "application", rel: "preload" %>
+      HTML
+    end
+
+    test "stylesheet_link_tag with nonce true" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <%= stylesheet_link_tag "application", nonce: true %>
+      HTML
+    end
+
+    test "stylesheet_link_tag with nonce false" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <%= stylesheet_link_tag "application", nonce: false %>
+      HTML
+    end
+
+    test "stylesheet_link_tag with interpolated nonce" do
+      assert_parsed_snapshot(<<~'HTML', action_view_helpers: true)
+        <%= stylesheet_link_tag "application", nonce: "static-#{dynamic}" %>
+      HTML
+    end
+
+    test "stylesheet_link_tag with data attributes" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <%= stylesheet_link_tag "application", data: { turbo_track: "reload" } %>
+      HTML
+    end
+
+    test "stylesheet_link_tag with asset_path" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <%= stylesheet_link_tag asset_path("application.css") %>
+      HTML
+    end
+
+    test "stylesheet_link_tag with variable source" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <%= stylesheet_link_tag stylesheet %>
+      HTML
+    end
+
+    test "stylesheet_link_tag with multiple sources and media" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <%= stylesheet_link_tag "application", "admin", media: "all" %>
+      HTML
+    end
+  end
+end

--- a/test/engine/action_view/stylesheet_link_tag_test.rb
+++ b/test/engine/action_view/stylesheet_link_tag_test.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require_relative "action_view_test_helper"
+
+module Engine
+  module ActionView
+    class StylesheetLinkTagTest < Minitest::Spec
+      include ActionViewTestHelper
+
+      test "stylesheet_link_tag with source" do
+        assert_optimized_snapshot('<%= stylesheet_link_tag "style" %>')
+      end
+
+      test "stylesheet_link_tag with source including extension" do
+        assert_optimized_snapshot('<%= stylesheet_link_tag "style.css" %>')
+      end
+
+      test "stylesheet_link_tag with URL" do
+        assert_optimized_snapshot('<%= stylesheet_link_tag "http://www.example.com/style.css" %>')
+      end
+
+      test "stylesheet_link_tag with extname false, skip_pipeline and rel" do
+        assert_optimized_snapshot(
+          '<%= stylesheet_link_tag "style.less", extname: false, skip_pipeline: true, rel: "stylesheet/less" %>'
+        )
+      end
+
+      test "stylesheet_link_tag with media all" do
+        assert_optimized_snapshot('<%= stylesheet_link_tag "style", media: "all" %>')
+      end
+
+      test "stylesheet_link_tag with media print" do
+        assert_optimized_snapshot('<%= stylesheet_link_tag "style", media: "print" %>')
+      end
+
+      test "stylesheet_link_tag with multiple sources" do
+        assert_optimized_snapshot('<%= stylesheet_link_tag "random.styles", "/css/stylish" %>')
+      end
+
+      test "stylesheet_link_tag with protocol-relative URL" do
+        assert_optimized_snapshot('<%= stylesheet_link_tag "//cdn.example.com/style.css" %>')
+      end
+
+      test "stylesheet_link_tag with host and protocol" do
+        assert_optimized_snapshot('<%= stylesheet_link_tag "style", host: "localhost", protocol: "https" %>')
+      end
+
+      test "stylesheet_link_tag with skip_pipeline" do
+        assert_optimized_snapshot('<%= stylesheet_link_tag "application", skip_pipeline: true %>')
+      end
+
+      test "stylesheet_link_tag with rel" do
+        assert_optimized_snapshot('<%= stylesheet_link_tag "application", rel: "preload" %>')
+      end
+
+      test "stylesheet_link_tag with data attributes" do
+        assert_optimized_snapshot('<%= stylesheet_link_tag "application", data: { turbo_track: "reload" } %>')
+      end
+
+      test "stylesheet_link_tag with multiple sources and media" do
+        assert_optimized_snapshot('<%= stylesheet_link_tag "application", "admin", media: "all" %>')
+      end
+    end
+  end
+end

--- a/test/snapshots/analyze/action_view/asset_tag_helper/stylesheet_link_tag_test/test_0001_stylesheet_link_tag_with_source_2ac13311f675f7efe3eefc7ed6202abb-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/asset_tag_helper/stylesheet_link_tag_test/test_0001_stylesheet_link_tag_with_source_2ac13311f675f7efe3eefc7ed6202abb-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,65 @@
+---
+source: "Analyze::ActionView::AssetTagHelper::StylesheetLinkTagTest#test_0001_stylesheet_link_tag with source"
+input: |2-
+<%= stylesheet_link_tag "style" %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:34))
+    │   ├── open_tag:
+    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:34))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " stylesheet_link_tag "style" " (location: (1:3)-(1:32))
+    │   │       ├── tag_closing: "%>" (location: (1:32)-(1:34))
+    │   │       ├── tag_name: "link" (location: (1:4)-(1:23))
+    │   │       └── children: (2 items)
+    │   │           ├── @ HTMLAttributeNode (location: (1:24)-(1:31))
+    │   │           │   ├── name:
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:24)-(1:31))
+    │   │           │   │       └── children: (1 item)
+    │   │           │   │           └── @ LiteralNode (location: (1:24)-(1:31))
+    │   │           │   │               └── content: "rel"
+    │   │           │   │
+    │   │           │   │
+    │   │           │   ├── equals: "=" (location: (1:24)-(1:31))
+    │   │           │   └── value:
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:24)-(1:31))
+    │   │           │           ├── open_quote: """ (location: (1:24)-(1:24))
+    │   │           │           ├── children: (1 item)
+    │   │           │           │   └── @ LiteralNode (location: (1:24)-(1:31))
+    │   │           │           │       └── content: "stylesheet"
+    │   │           │           │
+    │   │           │           ├── close_quote: """ (location: (1:31)-(1:31))
+    │   │           │           └── quoted: true
+    │   │           │
+    │   │           │
+    │   │           └── @ HTMLAttributeNode (location: (1:24)-(1:31))
+    │   │               ├── name:
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:24)-(1:31))
+    │   │               │       └── children: (1 item)
+    │   │               │           └── @ LiteralNode (location: (1:24)-(1:31))
+    │   │               │               └── content: "href"
+    │   │               │
+    │   │               │
+    │   │               ├── equals: ":" (location: (1:24)-(1:31))
+    │   │               └── value:
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:24)-(1:31))
+    │   │                       ├── open_quote: ∅
+    │   │                       ├── children: (1 item)
+    │   │                       │   └── @ RubyLiteralNode (location: (1:24)-(1:31))
+    │   │                       │       └── content: "stylesheet_path(\"style\")"
+    │   │                       │
+    │   │                       ├── close_quote: ∅
+    │   │                       └── quoted: true
+    │   │
+    │   │
+    │   │
+    │   ├── tag_name: "link" (location: (1:4)-(1:23))
+    │   ├── body: []
+    │   ├── close_tag: ∅
+    │   ├── is_void: true
+    │   └── element_source: "ActionView::Helpers::AssetTagHelper#stylesheet_link_tag"
+    │
+    └── @ HTMLTextNode (location: (1:34)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/action_view/asset_tag_helper/stylesheet_link_tag_test/test_0002_stylesheet_link_tag_with_source_including_extension_017994afe9bd5b7fcfc20c05643d8952-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/asset_tag_helper/stylesheet_link_tag_test/test_0002_stylesheet_link_tag_with_source_including_extension_017994afe9bd5b7fcfc20c05643d8952-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,65 @@
+---
+source: "Analyze::ActionView::AssetTagHelper::StylesheetLinkTagTest#test_0002_stylesheet_link_tag with source including extension"
+input: |2-
+<%= stylesheet_link_tag "style.css" %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:38))
+    │   ├── open_tag:
+    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:38))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " stylesheet_link_tag "style.css" " (location: (1:3)-(1:36))
+    │   │       ├── tag_closing: "%>" (location: (1:36)-(1:38))
+    │   │       ├── tag_name: "link" (location: (1:4)-(1:23))
+    │   │       └── children: (2 items)
+    │   │           ├── @ HTMLAttributeNode (location: (1:24)-(1:35))
+    │   │           │   ├── name:
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:24)-(1:35))
+    │   │           │   │       └── children: (1 item)
+    │   │           │   │           └── @ LiteralNode (location: (1:24)-(1:35))
+    │   │           │   │               └── content: "rel"
+    │   │           │   │
+    │   │           │   │
+    │   │           │   ├── equals: "=" (location: (1:24)-(1:35))
+    │   │           │   └── value:
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:24)-(1:35))
+    │   │           │           ├── open_quote: """ (location: (1:24)-(1:24))
+    │   │           │           ├── children: (1 item)
+    │   │           │           │   └── @ LiteralNode (location: (1:24)-(1:35))
+    │   │           │           │       └── content: "stylesheet"
+    │   │           │           │
+    │   │           │           ├── close_quote: """ (location: (1:35)-(1:35))
+    │   │           │           └── quoted: true
+    │   │           │
+    │   │           │
+    │   │           └── @ HTMLAttributeNode (location: (1:24)-(1:35))
+    │   │               ├── name:
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:24)-(1:35))
+    │   │               │       └── children: (1 item)
+    │   │               │           └── @ LiteralNode (location: (1:24)-(1:35))
+    │   │               │               └── content: "href"
+    │   │               │
+    │   │               │
+    │   │               ├── equals: ":" (location: (1:24)-(1:35))
+    │   │               └── value:
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:24)-(1:35))
+    │   │                       ├── open_quote: ∅
+    │   │                       ├── children: (1 item)
+    │   │                       │   └── @ RubyLiteralNode (location: (1:24)-(1:35))
+    │   │                       │       └── content: "stylesheet_path(\"style.css\")"
+    │   │                       │
+    │   │                       ├── close_quote: ∅
+    │   │                       └── quoted: true
+    │   │
+    │   │
+    │   │
+    │   ├── tag_name: "link" (location: (1:4)-(1:23))
+    │   ├── body: []
+    │   ├── close_tag: ∅
+    │   ├── is_void: true
+    │   └── element_source: "ActionView::Helpers::AssetTagHelper#stylesheet_link_tag"
+    │
+    └── @ HTMLTextNode (location: (1:38)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/action_view/asset_tag_helper/stylesheet_link_tag_test/test_0003_stylesheet_link_tag_with_URL_910ebed844045393742c99a9e1d41435-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/asset_tag_helper/stylesheet_link_tag_test/test_0003_stylesheet_link_tag_with_URL_910ebed844045393742c99a9e1d41435-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,65 @@
+---
+source: "Analyze::ActionView::AssetTagHelper::StylesheetLinkTagTest#test_0003_stylesheet_link_tag with URL"
+input: |2-
+<%= stylesheet_link_tag "http://www.example.com/style.css" %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:61))
+    │   ├── open_tag:
+    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:61))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " stylesheet_link_tag "http://www.example.com/style.css" " (location: (1:3)-(1:59))
+    │   │       ├── tag_closing: "%>" (location: (1:59)-(1:61))
+    │   │       ├── tag_name: "link" (location: (1:4)-(1:23))
+    │   │       └── children: (2 items)
+    │   │           ├── @ HTMLAttributeNode (location: (1:24)-(1:58))
+    │   │           │   ├── name:
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:24)-(1:58))
+    │   │           │   │       └── children: (1 item)
+    │   │           │   │           └── @ LiteralNode (location: (1:24)-(1:58))
+    │   │           │   │               └── content: "rel"
+    │   │           │   │
+    │   │           │   │
+    │   │           │   ├── equals: "=" (location: (1:24)-(1:58))
+    │   │           │   └── value:
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:24)-(1:58))
+    │   │           │           ├── open_quote: """ (location: (1:24)-(1:24))
+    │   │           │           ├── children: (1 item)
+    │   │           │           │   └── @ LiteralNode (location: (1:24)-(1:58))
+    │   │           │           │       └── content: "stylesheet"
+    │   │           │           │
+    │   │           │           ├── close_quote: """ (location: (1:58)-(1:58))
+    │   │           │           └── quoted: true
+    │   │           │
+    │   │           │
+    │   │           └── @ HTMLAttributeNode (location: (1:24)-(1:58))
+    │   │               ├── name:
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:24)-(1:58))
+    │   │               │       └── children: (1 item)
+    │   │               │           └── @ LiteralNode (location: (1:24)-(1:58))
+    │   │               │               └── content: "href"
+    │   │               │
+    │   │               │
+    │   │               ├── equals: "=" (location: (1:24)-(1:58))
+    │   │               └── value:
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:24)-(1:58))
+    │   │                       ├── open_quote: """ (location: (1:24)-(1:24))
+    │   │                       ├── children: (1 item)
+    │   │                       │   └── @ LiteralNode (location: (1:24)-(1:58))
+    │   │                       │       └── content: "http://www.example.com/style.css"
+    │   │                       │
+    │   │                       ├── close_quote: """ (location: (1:58)-(1:58))
+    │   │                       └── quoted: true
+    │   │
+    │   │
+    │   │
+    │   ├── tag_name: "link" (location: (1:4)-(1:23))
+    │   ├── body: []
+    │   ├── close_tag: ∅
+    │   ├── is_void: true
+    │   └── element_source: "ActionView::Helpers::AssetTagHelper#stylesheet_link_tag"
+    │
+    └── @ HTMLTextNode (location: (1:61)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/action_view/asset_tag_helper/stylesheet_link_tag_test/test_0004_stylesheet_link_tag_with_extname_false,_skip_pipeline_and_rel_89961256953704d5f10428c92bce88b4-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/asset_tag_helper/stylesheet_link_tag_test/test_0004_stylesheet_link_tag_with_extname_false,_skip_pipeline_and_rel_89961256953704d5f10428c92bce88b4-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,65 @@
+---
+source: "Analyze::ActionView::AssetTagHelper::StylesheetLinkTagTest#test_0004_stylesheet_link_tag with extname false, skip_pipeline and rel"
+input: |2-
+<%= stylesheet_link_tag "style.less", extname: false, skip_pipeline: true, rel: "stylesheet/less" %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:100))
+    │   ├── open_tag:
+    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:100))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " stylesheet_link_tag "style.less", extname: false, skip_pipeline: true, rel: "stylesheet/less" " (location: (1:3)-(1:98))
+    │   │       ├── tag_closing: "%>" (location: (1:98)-(1:100))
+    │   │       ├── tag_name: "link" (location: (1:4)-(1:23))
+    │   │       └── children: (2 items)
+    │   │           ├── @ HTMLAttributeNode (location: (1:75)-(1:97))
+    │   │           │   ├── name:
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:75)-(1:78))
+    │   │           │   │       └── children: (1 item)
+    │   │           │   │           └── @ LiteralNode (location: (1:75)-(1:78))
+    │   │           │   │               └── content: "rel"
+    │   │           │   │
+    │   │           │   │
+    │   │           │   ├── equals: ": " (location: (1:78)-(1:80))
+    │   │           │   └── value:
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:80)-(1:97))
+    │   │           │           ├── open_quote: """ (location: (1:80)-(1:81))
+    │   │           │           ├── children: (1 item)
+    │   │           │           │   └── @ LiteralNode (location: (1:81)-(1:96))
+    │   │           │           │       └── content: "stylesheet/less"
+    │   │           │           │
+    │   │           │           ├── close_quote: """ (location: (1:96)-(1:97))
+    │   │           │           └── quoted: true
+    │   │           │
+    │   │           │
+    │   │           └── @ HTMLAttributeNode (location: (1:24)-(1:36))
+    │   │               ├── name:
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:24)-(1:36))
+    │   │               │       └── children: (1 item)
+    │   │               │           └── @ LiteralNode (location: (1:24)-(1:36))
+    │   │               │               └── content: "href"
+    │   │               │
+    │   │               │
+    │   │               ├── equals: ":" (location: (1:24)-(1:36))
+    │   │               └── value:
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:24)-(1:36))
+    │   │                       ├── open_quote: ∅
+    │   │                       ├── children: (1 item)
+    │   │                       │   └── @ RubyLiteralNode (location: (1:24)-(1:36))
+    │   │                       │       └── content: "stylesheet_path(\"style.less\", extname: false, skip_pipeline: true)"
+    │   │                       │
+    │   │                       ├── close_quote: ∅
+    │   │                       └── quoted: true
+    │   │
+    │   │
+    │   │
+    │   ├── tag_name: "link" (location: (1:4)-(1:23))
+    │   ├── body: []
+    │   ├── close_tag: ∅
+    │   ├── is_void: true
+    │   └── element_source: "ActionView::Helpers::AssetTagHelper#stylesheet_link_tag"
+    │
+    └── @ HTMLTextNode (location: (1:100)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/action_view/asset_tag_helper/stylesheet_link_tag_test/test_0005_stylesheet_link_tag_with_media_all_ebb0b38236d9a10158fdb8920d7e2177-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/asset_tag_helper/stylesheet_link_tag_test/test_0005_stylesheet_link_tag_with_media_all_ebb0b38236d9a10158fdb8920d7e2177-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,85 @@
+---
+source: "Analyze::ActionView::AssetTagHelper::StylesheetLinkTagTest#test_0005_stylesheet_link_tag with media all"
+input: |2-
+<%= stylesheet_link_tag "style", media: "all" %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:48))
+    │   ├── open_tag:
+    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:48))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " stylesheet_link_tag "style", media: "all" " (location: (1:3)-(1:46))
+    │   │       ├── tag_closing: "%>" (location: (1:46)-(1:48))
+    │   │       ├── tag_name: "link" (location: (1:4)-(1:23))
+    │   │       └── children: (3 items)
+    │   │           ├── @ HTMLAttributeNode (location: (1:24)-(1:31))
+    │   │           │   ├── name:
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:24)-(1:31))
+    │   │           │   │       └── children: (1 item)
+    │   │           │   │           └── @ LiteralNode (location: (1:24)-(1:31))
+    │   │           │   │               └── content: "rel"
+    │   │           │   │
+    │   │           │   │
+    │   │           │   ├── equals: "=" (location: (1:24)-(1:31))
+    │   │           │   └── value:
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:24)-(1:31))
+    │   │           │           ├── open_quote: """ (location: (1:24)-(1:24))
+    │   │           │           ├── children: (1 item)
+    │   │           │           │   └── @ LiteralNode (location: (1:24)-(1:31))
+    │   │           │           │       └── content: "stylesheet"
+    │   │           │           │
+    │   │           │           ├── close_quote: """ (location: (1:31)-(1:31))
+    │   │           │           └── quoted: true
+    │   │           │
+    │   │           │
+    │   │           ├── @ HTMLAttributeNode (location: (1:24)-(1:31))
+    │   │           │   ├── name:
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:24)-(1:31))
+    │   │           │   │       └── children: (1 item)
+    │   │           │   │           └── @ LiteralNode (location: (1:24)-(1:31))
+    │   │           │   │               └── content: "href"
+    │   │           │   │
+    │   │           │   │
+    │   │           │   ├── equals: ":" (location: (1:24)-(1:31))
+    │   │           │   └── value:
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:24)-(1:31))
+    │   │           │           ├── open_quote: ∅
+    │   │           │           ├── children: (1 item)
+    │   │           │           │   └── @ RubyLiteralNode (location: (1:24)-(1:31))
+    │   │           │           │       └── content: "stylesheet_path(\"style\")"
+    │   │           │           │
+    │   │           │           ├── close_quote: ∅
+    │   │           │           └── quoted: true
+    │   │           │
+    │   │           │
+    │   │           └── @ HTMLAttributeNode (location: (1:33)-(1:45))
+    │   │               ├── name:
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:33)-(1:38))
+    │   │               │       └── children: (1 item)
+    │   │               │           └── @ LiteralNode (location: (1:33)-(1:38))
+    │   │               │               └── content: "media"
+    │   │               │
+    │   │               │
+    │   │               ├── equals: ": " (location: (1:38)-(1:40))
+    │   │               └── value:
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:40)-(1:45))
+    │   │                       ├── open_quote: """ (location: (1:40)-(1:41))
+    │   │                       ├── children: (1 item)
+    │   │                       │   └── @ LiteralNode (location: (1:41)-(1:44))
+    │   │                       │       └── content: "all"
+    │   │                       │
+    │   │                       ├── close_quote: """ (location: (1:44)-(1:45))
+    │   │                       └── quoted: true
+    │   │
+    │   │
+    │   │
+    │   ├── tag_name: "link" (location: (1:4)-(1:23))
+    │   ├── body: []
+    │   ├── close_tag: ∅
+    │   ├── is_void: true
+    │   └── element_source: "ActionView::Helpers::AssetTagHelper#stylesheet_link_tag"
+    │
+    └── @ HTMLTextNode (location: (1:48)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/action_view/asset_tag_helper/stylesheet_link_tag_test/test_0006_stylesheet_link_tag_with_media_print_b6a47cff8bac6defcdb617634f3da238-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/asset_tag_helper/stylesheet_link_tag_test/test_0006_stylesheet_link_tag_with_media_print_b6a47cff8bac6defcdb617634f3da238-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,85 @@
+---
+source: "Analyze::ActionView::AssetTagHelper::StylesheetLinkTagTest#test_0006_stylesheet_link_tag with media print"
+input: |2-
+<%= stylesheet_link_tag "style", media: "print" %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:50))
+    │   ├── open_tag:
+    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:50))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " stylesheet_link_tag "style", media: "print" " (location: (1:3)-(1:48))
+    │   │       ├── tag_closing: "%>" (location: (1:48)-(1:50))
+    │   │       ├── tag_name: "link" (location: (1:4)-(1:23))
+    │   │       └── children: (3 items)
+    │   │           ├── @ HTMLAttributeNode (location: (1:24)-(1:31))
+    │   │           │   ├── name:
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:24)-(1:31))
+    │   │           │   │       └── children: (1 item)
+    │   │           │   │           └── @ LiteralNode (location: (1:24)-(1:31))
+    │   │           │   │               └── content: "rel"
+    │   │           │   │
+    │   │           │   │
+    │   │           │   ├── equals: "=" (location: (1:24)-(1:31))
+    │   │           │   └── value:
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:24)-(1:31))
+    │   │           │           ├── open_quote: """ (location: (1:24)-(1:24))
+    │   │           │           ├── children: (1 item)
+    │   │           │           │   └── @ LiteralNode (location: (1:24)-(1:31))
+    │   │           │           │       └── content: "stylesheet"
+    │   │           │           │
+    │   │           │           ├── close_quote: """ (location: (1:31)-(1:31))
+    │   │           │           └── quoted: true
+    │   │           │
+    │   │           │
+    │   │           ├── @ HTMLAttributeNode (location: (1:24)-(1:31))
+    │   │           │   ├── name:
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:24)-(1:31))
+    │   │           │   │       └── children: (1 item)
+    │   │           │   │           └── @ LiteralNode (location: (1:24)-(1:31))
+    │   │           │   │               └── content: "href"
+    │   │           │   │
+    │   │           │   │
+    │   │           │   ├── equals: ":" (location: (1:24)-(1:31))
+    │   │           │   └── value:
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:24)-(1:31))
+    │   │           │           ├── open_quote: ∅
+    │   │           │           ├── children: (1 item)
+    │   │           │           │   └── @ RubyLiteralNode (location: (1:24)-(1:31))
+    │   │           │           │       └── content: "stylesheet_path(\"style\")"
+    │   │           │           │
+    │   │           │           ├── close_quote: ∅
+    │   │           │           └── quoted: true
+    │   │           │
+    │   │           │
+    │   │           └── @ HTMLAttributeNode (location: (1:33)-(1:47))
+    │   │               ├── name:
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:33)-(1:38))
+    │   │               │       └── children: (1 item)
+    │   │               │           └── @ LiteralNode (location: (1:33)-(1:38))
+    │   │               │               └── content: "media"
+    │   │               │
+    │   │               │
+    │   │               ├── equals: ": " (location: (1:38)-(1:40))
+    │   │               └── value:
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:40)-(1:47))
+    │   │                       ├── open_quote: """ (location: (1:40)-(1:41))
+    │   │                       ├── children: (1 item)
+    │   │                       │   └── @ LiteralNode (location: (1:41)-(1:46))
+    │   │                       │       └── content: "print"
+    │   │                       │
+    │   │                       ├── close_quote: """ (location: (1:46)-(1:47))
+    │   │                       └── quoted: true
+    │   │
+    │   │
+    │   │
+    │   ├── tag_name: "link" (location: (1:4)-(1:23))
+    │   ├── body: []
+    │   ├── close_tag: ∅
+    │   ├── is_void: true
+    │   └── element_source: "ActionView::Helpers::AssetTagHelper#stylesheet_link_tag"
+    │
+    └── @ HTMLTextNode (location: (1:50)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/action_view/asset_tag_helper/stylesheet_link_tag_test/test_0007_stylesheet_link_tag_with_multiple_sources_c39315bdfb35059511e19ffc2efa3213-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/asset_tag_helper/stylesheet_link_tag_test/test_0007_stylesheet_link_tag_with_multiple_sources_c39315bdfb35059511e19ffc2efa3213-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,123 @@
+---
+source: "Analyze::ActionView::AssetTagHelper::StylesheetLinkTagTest#test_0007_stylesheet_link_tag with multiple sources"
+input: |2-
+<%= stylesheet_link_tag "random.styles", "/css/stylish" %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (4 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:58))
+    │   ├── open_tag:
+    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:58))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " stylesheet_link_tag "random.styles", "/css/stylish" " (location: (1:3)-(1:56))
+    │   │       ├── tag_closing: "%>" (location: (1:56)-(1:58))
+    │   │       ├── tag_name: "link" (location: (1:4)-(1:23))
+    │   │       └── children: (2 items)
+    │   │           ├── @ HTMLAttributeNode (location: (1:24)-(1:39))
+    │   │           │   ├── name:
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:24)-(1:39))
+    │   │           │   │       └── children: (1 item)
+    │   │           │   │           └── @ LiteralNode (location: (1:24)-(1:39))
+    │   │           │   │               └── content: "rel"
+    │   │           │   │
+    │   │           │   │
+    │   │           │   ├── equals: "=" (location: (1:24)-(1:39))
+    │   │           │   └── value:
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:24)-(1:39))
+    │   │           │           ├── open_quote: """ (location: (1:24)-(1:24))
+    │   │           │           ├── children: (1 item)
+    │   │           │           │   └── @ LiteralNode (location: (1:24)-(1:39))
+    │   │           │           │       └── content: "stylesheet"
+    │   │           │           │
+    │   │           │           ├── close_quote: """ (location: (1:39)-(1:39))
+    │   │           │           └── quoted: true
+    │   │           │
+    │   │           │
+    │   │           └── @ HTMLAttributeNode (location: (1:24)-(1:39))
+    │   │               ├── name:
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:24)-(1:39))
+    │   │               │       └── children: (1 item)
+    │   │               │           └── @ LiteralNode (location: (1:24)-(1:39))
+    │   │               │               └── content: "href"
+    │   │               │
+    │   │               │
+    │   │               ├── equals: ":" (location: (1:24)-(1:39))
+    │   │               └── value:
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:24)-(1:39))
+    │   │                       ├── open_quote: ∅
+    │   │                       ├── children: (1 item)
+    │   │                       │   └── @ RubyLiteralNode (location: (1:24)-(1:39))
+    │   │                       │       └── content: "stylesheet_path(\"random.styles\")"
+    │   │                       │
+    │   │                       ├── close_quote: ∅
+    │   │                       └── quoted: true
+    │   │
+    │   │
+    │   │
+    │   ├── tag_name: "link" (location: (1:4)-(1:23))
+    │   ├── body: []
+    │   ├── close_tag: ∅
+    │   ├── is_void: true
+    │   └── element_source: "ActionView::Helpers::AssetTagHelper#stylesheet_link_tag"
+    │
+    ├── @ HTMLTextNode (location: (1:0)-(1:0))
+    │   └── content: "\n"
+    │
+    ├── @ HTMLElementNode (location: (1:0)-(1:58))
+    │   ├── open_tag:
+    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:58))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " stylesheet_link_tag "random.styles", "/css/stylish" " (location: (1:3)-(1:56))
+    │   │       ├── tag_closing: "%>" (location: (1:56)-(1:58))
+    │   │       ├── tag_name: "link" (location: (1:4)-(1:23))
+    │   │       └── children: (2 items)
+    │   │           ├── @ HTMLAttributeNode (location: (1:41)-(1:55))
+    │   │           │   ├── name:
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:41)-(1:55))
+    │   │           │   │       └── children: (1 item)
+    │   │           │   │           └── @ LiteralNode (location: (1:41)-(1:55))
+    │   │           │   │               └── content: "rel"
+    │   │           │   │
+    │   │           │   │
+    │   │           │   ├── equals: "=" (location: (1:41)-(1:55))
+    │   │           │   └── value:
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:41)-(1:55))
+    │   │           │           ├── open_quote: """ (location: (1:41)-(1:41))
+    │   │           │           ├── children: (1 item)
+    │   │           │           │   └── @ LiteralNode (location: (1:41)-(1:55))
+    │   │           │           │       └── content: "stylesheet"
+    │   │           │           │
+    │   │           │           ├── close_quote: """ (location: (1:55)-(1:55))
+    │   │           │           └── quoted: true
+    │   │           │
+    │   │           │
+    │   │           └── @ HTMLAttributeNode (location: (1:41)-(1:55))
+    │   │               ├── name:
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:41)-(1:55))
+    │   │               │       └── children: (1 item)
+    │   │               │           └── @ LiteralNode (location: (1:41)-(1:55))
+    │   │               │               └── content: "href"
+    │   │               │
+    │   │               │
+    │   │               ├── equals: ":" (location: (1:41)-(1:55))
+    │   │               └── value:
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:41)-(1:55))
+    │   │                       ├── open_quote: ∅
+    │   │                       ├── children: (1 item)
+    │   │                       │   └── @ RubyLiteralNode (location: (1:41)-(1:55))
+    │   │                       │       └── content: "stylesheet_path(\"/css/stylish\")"
+    │   │                       │
+    │   │                       ├── close_quote: ∅
+    │   │                       └── quoted: true
+    │   │
+    │   │
+    │   │
+    │   ├── tag_name: "link" (location: (1:4)-(1:23))
+    │   ├── body: []
+    │   ├── close_tag: ∅
+    │   ├── is_void: true
+    │   └── element_source: "ActionView::Helpers::AssetTagHelper#stylesheet_link_tag"
+    │
+    └── @ HTMLTextNode (location: (1:58)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/action_view/asset_tag_helper/stylesheet_link_tag_test/test_0008_stylesheet_link_tag_with_protocol-relative_URL_caed49f44bac6b581915d49dee6346ec-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/asset_tag_helper/stylesheet_link_tag_test/test_0008_stylesheet_link_tag_with_protocol-relative_URL_caed49f44bac6b581915d49dee6346ec-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,65 @@
+---
+source: "Analyze::ActionView::AssetTagHelper::StylesheetLinkTagTest#test_0008_stylesheet_link_tag with protocol-relative URL"
+input: |2-
+<%= stylesheet_link_tag "//cdn.example.com/style.css" %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:56))
+    │   ├── open_tag:
+    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:56))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " stylesheet_link_tag "//cdn.example.com/style.css" " (location: (1:3)-(1:54))
+    │   │       ├── tag_closing: "%>" (location: (1:54)-(1:56))
+    │   │       ├── tag_name: "link" (location: (1:4)-(1:23))
+    │   │       └── children: (2 items)
+    │   │           ├── @ HTMLAttributeNode (location: (1:24)-(1:53))
+    │   │           │   ├── name:
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:24)-(1:53))
+    │   │           │   │       └── children: (1 item)
+    │   │           │   │           └── @ LiteralNode (location: (1:24)-(1:53))
+    │   │           │   │               └── content: "rel"
+    │   │           │   │
+    │   │           │   │
+    │   │           │   ├── equals: "=" (location: (1:24)-(1:53))
+    │   │           │   └── value:
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:24)-(1:53))
+    │   │           │           ├── open_quote: """ (location: (1:24)-(1:24))
+    │   │           │           ├── children: (1 item)
+    │   │           │           │   └── @ LiteralNode (location: (1:24)-(1:53))
+    │   │           │           │       └── content: "stylesheet"
+    │   │           │           │
+    │   │           │           ├── close_quote: """ (location: (1:53)-(1:53))
+    │   │           │           └── quoted: true
+    │   │           │
+    │   │           │
+    │   │           └── @ HTMLAttributeNode (location: (1:24)-(1:53))
+    │   │               ├── name:
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:24)-(1:53))
+    │   │               │       └── children: (1 item)
+    │   │               │           └── @ LiteralNode (location: (1:24)-(1:53))
+    │   │               │               └── content: "href"
+    │   │               │
+    │   │               │
+    │   │               ├── equals: "=" (location: (1:24)-(1:53))
+    │   │               └── value:
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:24)-(1:53))
+    │   │                       ├── open_quote: """ (location: (1:24)-(1:24))
+    │   │                       ├── children: (1 item)
+    │   │                       │   └── @ LiteralNode (location: (1:24)-(1:53))
+    │   │                       │       └── content: "//cdn.example.com/style.css"
+    │   │                       │
+    │   │                       ├── close_quote: """ (location: (1:53)-(1:53))
+    │   │                       └── quoted: true
+    │   │
+    │   │
+    │   │
+    │   ├── tag_name: "link" (location: (1:4)-(1:23))
+    │   ├── body: []
+    │   ├── close_tag: ∅
+    │   ├── is_void: true
+    │   └── element_source: "ActionView::Helpers::AssetTagHelper#stylesheet_link_tag"
+    │
+    └── @ HTMLTextNode (location: (1:56)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/action_view/asset_tag_helper/stylesheet_link_tag_test/test_0009_stylesheet_link_tag_with_host_and_protocol_0879aedf7eb672557c14931d3ce60e85-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/asset_tag_helper/stylesheet_link_tag_test/test_0009_stylesheet_link_tag_with_host_and_protocol_0879aedf7eb672557c14931d3ce60e85-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,65 @@
+---
+source: "Analyze::ActionView::AssetTagHelper::StylesheetLinkTagTest#test_0009_stylesheet_link_tag with host and protocol"
+input: |2-
+<%= stylesheet_link_tag "style", host: "localhost", protocol: "https" %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:72))
+    │   ├── open_tag:
+    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:72))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " stylesheet_link_tag "style", host: "localhost", protocol: "https" " (location: (1:3)-(1:70))
+    │   │       ├── tag_closing: "%>" (location: (1:70)-(1:72))
+    │   │       ├── tag_name: "link" (location: (1:4)-(1:23))
+    │   │       └── children: (2 items)
+    │   │           ├── @ HTMLAttributeNode (location: (1:24)-(1:31))
+    │   │           │   ├── name:
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:24)-(1:31))
+    │   │           │   │       └── children: (1 item)
+    │   │           │   │           └── @ LiteralNode (location: (1:24)-(1:31))
+    │   │           │   │               └── content: "rel"
+    │   │           │   │
+    │   │           │   │
+    │   │           │   ├── equals: "=" (location: (1:24)-(1:31))
+    │   │           │   └── value:
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:24)-(1:31))
+    │   │           │           ├── open_quote: """ (location: (1:24)-(1:24))
+    │   │           │           ├── children: (1 item)
+    │   │           │           │   └── @ LiteralNode (location: (1:24)-(1:31))
+    │   │           │           │       └── content: "stylesheet"
+    │   │           │           │
+    │   │           │           ├── close_quote: """ (location: (1:31)-(1:31))
+    │   │           │           └── quoted: true
+    │   │           │
+    │   │           │
+    │   │           └── @ HTMLAttributeNode (location: (1:24)-(1:31))
+    │   │               ├── name:
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:24)-(1:31))
+    │   │               │       └── children: (1 item)
+    │   │               │           └── @ LiteralNode (location: (1:24)-(1:31))
+    │   │               │               └── content: "href"
+    │   │               │
+    │   │               │
+    │   │               ├── equals: ":" (location: (1:24)-(1:31))
+    │   │               └── value:
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:24)-(1:31))
+    │   │                       ├── open_quote: ∅
+    │   │                       ├── children: (1 item)
+    │   │                       │   └── @ RubyLiteralNode (location: (1:24)-(1:31))
+    │   │                       │       └── content: "stylesheet_path(\"style\", host: \"localhost\", protocol: \"https\")"
+    │   │                       │
+    │   │                       ├── close_quote: ∅
+    │   │                       └── quoted: true
+    │   │
+    │   │
+    │   │
+    │   ├── tag_name: "link" (location: (1:4)-(1:23))
+    │   ├── body: []
+    │   ├── close_tag: ∅
+    │   ├── is_void: true
+    │   └── element_source: "ActionView::Helpers::AssetTagHelper#stylesheet_link_tag"
+    │
+    └── @ HTMLTextNode (location: (1:72)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/action_view/asset_tag_helper/stylesheet_link_tag_test/test_0010_stylesheet_link_tag_with_skip_pipeline_b9a2c27a380852abbccacff4a9f9ab1a-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/asset_tag_helper/stylesheet_link_tag_test/test_0010_stylesheet_link_tag_with_skip_pipeline_b9a2c27a380852abbccacff4a9f9ab1a-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,65 @@
+---
+source: "Analyze::ActionView::AssetTagHelper::StylesheetLinkTagTest#test_0010_stylesheet_link_tag with skip_pipeline"
+input: |2-
+<%= stylesheet_link_tag "application", skip_pipeline: true %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:61))
+    │   ├── open_tag:
+    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:61))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " stylesheet_link_tag "application", skip_pipeline: true " (location: (1:3)-(1:59))
+    │   │       ├── tag_closing: "%>" (location: (1:59)-(1:61))
+    │   │       ├── tag_name: "link" (location: (1:4)-(1:23))
+    │   │       └── children: (2 items)
+    │   │           ├── @ HTMLAttributeNode (location: (1:24)-(1:37))
+    │   │           │   ├── name:
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:24)-(1:37))
+    │   │           │   │       └── children: (1 item)
+    │   │           │   │           └── @ LiteralNode (location: (1:24)-(1:37))
+    │   │           │   │               └── content: "rel"
+    │   │           │   │
+    │   │           │   │
+    │   │           │   ├── equals: "=" (location: (1:24)-(1:37))
+    │   │           │   └── value:
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:24)-(1:37))
+    │   │           │           ├── open_quote: """ (location: (1:24)-(1:24))
+    │   │           │           ├── children: (1 item)
+    │   │           │           │   └── @ LiteralNode (location: (1:24)-(1:37))
+    │   │           │           │       └── content: "stylesheet"
+    │   │           │           │
+    │   │           │           ├── close_quote: """ (location: (1:37)-(1:37))
+    │   │           │           └── quoted: true
+    │   │           │
+    │   │           │
+    │   │           └── @ HTMLAttributeNode (location: (1:24)-(1:37))
+    │   │               ├── name:
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:24)-(1:37))
+    │   │               │       └── children: (1 item)
+    │   │               │           └── @ LiteralNode (location: (1:24)-(1:37))
+    │   │               │               └── content: "href"
+    │   │               │
+    │   │               │
+    │   │               ├── equals: ":" (location: (1:24)-(1:37))
+    │   │               └── value:
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:24)-(1:37))
+    │   │                       ├── open_quote: ∅
+    │   │                       ├── children: (1 item)
+    │   │                       │   └── @ RubyLiteralNode (location: (1:24)-(1:37))
+    │   │                       │       └── content: "stylesheet_path(\"application\", skip_pipeline: true)"
+    │   │                       │
+    │   │                       ├── close_quote: ∅
+    │   │                       └── quoted: true
+    │   │
+    │   │
+    │   │
+    │   ├── tag_name: "link" (location: (1:4)-(1:23))
+    │   ├── body: []
+    │   ├── close_tag: ∅
+    │   ├── is_void: true
+    │   └── element_source: "ActionView::Helpers::AssetTagHelper#stylesheet_link_tag"
+    │
+    └── @ HTMLTextNode (location: (1:61)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/action_view/asset_tag_helper/stylesheet_link_tag_test/test_0011_stylesheet_link_tag_with_rel_aae1c8f1ce3d8353b164d8e23aa47a91-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/asset_tag_helper/stylesheet_link_tag_test/test_0011_stylesheet_link_tag_with_rel_aae1c8f1ce3d8353b164d8e23aa47a91-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,65 @@
+---
+source: "Analyze::ActionView::AssetTagHelper::StylesheetLinkTagTest#test_0011_stylesheet_link_tag with rel"
+input: |2-
+<%= stylesheet_link_tag "application", rel: "preload" %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:56))
+    │   ├── open_tag:
+    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:56))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " stylesheet_link_tag "application", rel: "preload" " (location: (1:3)-(1:54))
+    │   │       ├── tag_closing: "%>" (location: (1:54)-(1:56))
+    │   │       ├── tag_name: "link" (location: (1:4)-(1:23))
+    │   │       └── children: (2 items)
+    │   │           ├── @ HTMLAttributeNode (location: (1:39)-(1:53))
+    │   │           │   ├── name:
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:39)-(1:42))
+    │   │           │   │       └── children: (1 item)
+    │   │           │   │           └── @ LiteralNode (location: (1:39)-(1:42))
+    │   │           │   │               └── content: "rel"
+    │   │           │   │
+    │   │           │   │
+    │   │           │   ├── equals: ": " (location: (1:42)-(1:44))
+    │   │           │   └── value:
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:44)-(1:53))
+    │   │           │           ├── open_quote: """ (location: (1:44)-(1:45))
+    │   │           │           ├── children: (1 item)
+    │   │           │           │   └── @ LiteralNode (location: (1:45)-(1:52))
+    │   │           │           │       └── content: "preload"
+    │   │           │           │
+    │   │           │           ├── close_quote: """ (location: (1:52)-(1:53))
+    │   │           │           └── quoted: true
+    │   │           │
+    │   │           │
+    │   │           └── @ HTMLAttributeNode (location: (1:24)-(1:37))
+    │   │               ├── name:
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:24)-(1:37))
+    │   │               │       └── children: (1 item)
+    │   │               │           └── @ LiteralNode (location: (1:24)-(1:37))
+    │   │               │               └── content: "href"
+    │   │               │
+    │   │               │
+    │   │               ├── equals: ":" (location: (1:24)-(1:37))
+    │   │               └── value:
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:24)-(1:37))
+    │   │                       ├── open_quote: ∅
+    │   │                       ├── children: (1 item)
+    │   │                       │   └── @ RubyLiteralNode (location: (1:24)-(1:37))
+    │   │                       │       └── content: "stylesheet_path(\"application\")"
+    │   │                       │
+    │   │                       ├── close_quote: ∅
+    │   │                       └── quoted: true
+    │   │
+    │   │
+    │   │
+    │   ├── tag_name: "link" (location: (1:4)-(1:23))
+    │   ├── body: []
+    │   ├── close_tag: ∅
+    │   ├── is_void: true
+    │   └── element_source: "ActionView::Helpers::AssetTagHelper#stylesheet_link_tag"
+    │
+    └── @ HTMLTextNode (location: (1:56)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/action_view/asset_tag_helper/stylesheet_link_tag_test/test_0012_stylesheet_link_tag_with_nonce_true_c58b61459cbfd3382b0c304dcc01734d-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/asset_tag_helper/stylesheet_link_tag_test/test_0012_stylesheet_link_tag_with_nonce_true_c58b61459cbfd3382b0c304dcc01734d-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,85 @@
+---
+source: "Analyze::ActionView::AssetTagHelper::StylesheetLinkTagTest#test_0012_stylesheet_link_tag with nonce true"
+input: |2-
+<%= stylesheet_link_tag "application", nonce: true %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:53))
+    │   ├── open_tag:
+    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:53))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " stylesheet_link_tag "application", nonce: true " (location: (1:3)-(1:51))
+    │   │       ├── tag_closing: "%>" (location: (1:51)-(1:53))
+    │   │       ├── tag_name: "link" (location: (1:4)-(1:23))
+    │   │       └── children: (3 items)
+    │   │           ├── @ HTMLAttributeNode (location: (1:24)-(1:37))
+    │   │           │   ├── name:
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:24)-(1:37))
+    │   │           │   │       └── children: (1 item)
+    │   │           │   │           └── @ LiteralNode (location: (1:24)-(1:37))
+    │   │           │   │               └── content: "rel"
+    │   │           │   │
+    │   │           │   │
+    │   │           │   ├── equals: "=" (location: (1:24)-(1:37))
+    │   │           │   └── value:
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:24)-(1:37))
+    │   │           │           ├── open_quote: """ (location: (1:24)-(1:24))
+    │   │           │           ├── children: (1 item)
+    │   │           │           │   └── @ LiteralNode (location: (1:24)-(1:37))
+    │   │           │           │       └── content: "stylesheet"
+    │   │           │           │
+    │   │           │           ├── close_quote: """ (location: (1:37)-(1:37))
+    │   │           │           └── quoted: true
+    │   │           │
+    │   │           │
+    │   │           ├── @ HTMLAttributeNode (location: (1:24)-(1:37))
+    │   │           │   ├── name:
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:24)-(1:37))
+    │   │           │   │       └── children: (1 item)
+    │   │           │   │           └── @ LiteralNode (location: (1:24)-(1:37))
+    │   │           │   │               └── content: "href"
+    │   │           │   │
+    │   │           │   │
+    │   │           │   ├── equals: ":" (location: (1:24)-(1:37))
+    │   │           │   └── value:
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:24)-(1:37))
+    │   │           │           ├── open_quote: ∅
+    │   │           │           ├── children: (1 item)
+    │   │           │           │   └── @ RubyLiteralNode (location: (1:24)-(1:37))
+    │   │           │           │       └── content: "stylesheet_path(\"application\")"
+    │   │           │           │
+    │   │           │           ├── close_quote: ∅
+    │   │           │           └── quoted: true
+    │   │           │
+    │   │           │
+    │   │           └── @ HTMLAttributeNode (location: (1:39)-(1:50))
+    │   │               ├── name:
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:39)-(1:44))
+    │   │               │       └── children: (1 item)
+    │   │               │           └── @ LiteralNode (location: (1:39)-(1:44))
+    │   │               │               └── content: "nonce"
+    │   │               │
+    │   │               │
+    │   │               ├── equals: ": " (location: (1:44)-(1:46))
+    │   │               └── value:
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:46)-(1:50))
+    │   │                       ├── open_quote: ∅
+    │   │                       ├── children: (1 item)
+    │   │                       │   └── @ RubyLiteralNode (location: (1:46)-(1:50))
+    │   │                       │       └── content: "content_security_policy_nonce"
+    │   │                       │
+    │   │                       ├── close_quote: ∅
+    │   │                       └── quoted: true
+    │   │
+    │   │
+    │   │
+    │   ├── tag_name: "link" (location: (1:4)-(1:23))
+    │   ├── body: []
+    │   ├── close_tag: ∅
+    │   ├── is_void: true
+    │   └── element_source: "ActionView::Helpers::AssetTagHelper#stylesheet_link_tag"
+    │
+    └── @ HTMLTextNode (location: (1:53)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/action_view/asset_tag_helper/stylesheet_link_tag_test/test_0013_stylesheet_link_tag_with_nonce_false_36986ea0948d48550d0bc2be6ea62890-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/asset_tag_helper/stylesheet_link_tag_test/test_0013_stylesheet_link_tag_with_nonce_false_36986ea0948d48550d0bc2be6ea62890-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,65 @@
+---
+source: "Analyze::ActionView::AssetTagHelper::StylesheetLinkTagTest#test_0013_stylesheet_link_tag with nonce false"
+input: |2-
+<%= stylesheet_link_tag "application", nonce: false %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:54))
+    │   ├── open_tag:
+    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:54))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " stylesheet_link_tag "application", nonce: false " (location: (1:3)-(1:52))
+    │   │       ├── tag_closing: "%>" (location: (1:52)-(1:54))
+    │   │       ├── tag_name: "link" (location: (1:4)-(1:23))
+    │   │       └── children: (2 items)
+    │   │           ├── @ HTMLAttributeNode (location: (1:24)-(1:37))
+    │   │           │   ├── name:
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:24)-(1:37))
+    │   │           │   │       └── children: (1 item)
+    │   │           │   │           └── @ LiteralNode (location: (1:24)-(1:37))
+    │   │           │   │               └── content: "rel"
+    │   │           │   │
+    │   │           │   │
+    │   │           │   ├── equals: "=" (location: (1:24)-(1:37))
+    │   │           │   └── value:
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:24)-(1:37))
+    │   │           │           ├── open_quote: """ (location: (1:24)-(1:24))
+    │   │           │           ├── children: (1 item)
+    │   │           │           │   └── @ LiteralNode (location: (1:24)-(1:37))
+    │   │           │           │       └── content: "stylesheet"
+    │   │           │           │
+    │   │           │           ├── close_quote: """ (location: (1:37)-(1:37))
+    │   │           │           └── quoted: true
+    │   │           │
+    │   │           │
+    │   │           └── @ HTMLAttributeNode (location: (1:24)-(1:37))
+    │   │               ├── name:
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:24)-(1:37))
+    │   │               │       └── children: (1 item)
+    │   │               │           └── @ LiteralNode (location: (1:24)-(1:37))
+    │   │               │               └── content: "href"
+    │   │               │
+    │   │               │
+    │   │               ├── equals: ":" (location: (1:24)-(1:37))
+    │   │               └── value:
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:24)-(1:37))
+    │   │                       ├── open_quote: ∅
+    │   │                       ├── children: (1 item)
+    │   │                       │   └── @ RubyLiteralNode (location: (1:24)-(1:37))
+    │   │                       │       └── content: "stylesheet_path(\"application\")"
+    │   │                       │
+    │   │                       ├── close_quote: ∅
+    │   │                       └── quoted: true
+    │   │
+    │   │
+    │   │
+    │   ├── tag_name: "link" (location: (1:4)-(1:23))
+    │   ├── body: []
+    │   ├── close_tag: ∅
+    │   ├── is_void: true
+    │   └── element_source: "ActionView::Helpers::AssetTagHelper#stylesheet_link_tag"
+    │
+    └── @ HTMLTextNode (location: (1:54)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/action_view/asset_tag_helper/stylesheet_link_tag_test/test_0014_stylesheet_link_tag_with_interpolated_nonce_11ae9837a90f44d6acf125ccb058c3a2-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/asset_tag_helper/stylesheet_link_tag_test/test_0014_stylesheet_link_tag_with_interpolated_nonce_11ae9837a90f44d6acf125ccb058c3a2-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,88 @@
+---
+source: "Analyze::ActionView::AssetTagHelper::StylesheetLinkTagTest#test_0014_stylesheet_link_tag with interpolated nonce"
+input: |2-
+<%= stylesheet_link_tag "application", nonce: "static-#{dynamic}" %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:68))
+    │   ├── open_tag:
+    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:68))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " stylesheet_link_tag "application", nonce: "static-#{dynamic}" " (location: (1:3)-(1:66))
+    │   │       ├── tag_closing: "%>" (location: (1:66)-(1:68))
+    │   │       ├── tag_name: "link" (location: (1:4)-(1:23))
+    │   │       └── children: (3 items)
+    │   │           ├── @ HTMLAttributeNode (location: (1:24)-(1:37))
+    │   │           │   ├── name:
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:24)-(1:37))
+    │   │           │   │       └── children: (1 item)
+    │   │           │   │           └── @ LiteralNode (location: (1:24)-(1:37))
+    │   │           │   │               └── content: "rel"
+    │   │           │   │
+    │   │           │   │
+    │   │           │   ├── equals: "=" (location: (1:24)-(1:37))
+    │   │           │   └── value:
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:24)-(1:37))
+    │   │           │           ├── open_quote: """ (location: (1:24)-(1:24))
+    │   │           │           ├── children: (1 item)
+    │   │           │           │   └── @ LiteralNode (location: (1:24)-(1:37))
+    │   │           │           │       └── content: "stylesheet"
+    │   │           │           │
+    │   │           │           ├── close_quote: """ (location: (1:37)-(1:37))
+    │   │           │           └── quoted: true
+    │   │           │
+    │   │           │
+    │   │           ├── @ HTMLAttributeNode (location: (1:24)-(1:37))
+    │   │           │   ├── name:
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:24)-(1:37))
+    │   │           │   │       └── children: (1 item)
+    │   │           │   │           └── @ LiteralNode (location: (1:24)-(1:37))
+    │   │           │   │               └── content: "href"
+    │   │           │   │
+    │   │           │   │
+    │   │           │   ├── equals: ":" (location: (1:24)-(1:37))
+    │   │           │   └── value:
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:24)-(1:37))
+    │   │           │           ├── open_quote: ∅
+    │   │           │           ├── children: (1 item)
+    │   │           │           │   └── @ RubyLiteralNode (location: (1:24)-(1:37))
+    │   │           │           │       └── content: "stylesheet_path(\"application\")"
+    │   │           │           │
+    │   │           │           ├── close_quote: ∅
+    │   │           │           └── quoted: true
+    │   │           │
+    │   │           │
+    │   │           └── @ HTMLAttributeNode (location: (1:39)-(1:65))
+    │   │               ├── name:
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:39)-(1:65))
+    │   │               │       └── children: (1 item)
+    │   │               │           └── @ LiteralNode (location: (1:39)-(1:65))
+    │   │               │               └── content: "nonce"
+    │   │               │
+    │   │               │
+    │   │               ├── equals: "=" (location: (1:39)-(1:65))
+    │   │               └── value:
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:39)-(1:65))
+    │   │                       ├── open_quote: ∅
+    │   │                       ├── children: (2 items)
+    │   │                       │   ├── @ LiteralNode (location: (1:39)-(1:65))
+    │   │                       │   │   └── content: "static-"
+    │   │                       │   │
+    │   │                       │   └── @ RubyLiteralNode (location: (1:39)-(1:65))
+    │   │                       │       └── content: "dynamic"
+    │   │                       │
+    │   │                       ├── close_quote: ∅
+    │   │                       └── quoted: false
+    │   │
+    │   │
+    │   │
+    │   ├── tag_name: "link" (location: (1:4)-(1:23))
+    │   ├── body: []
+    │   ├── close_tag: ∅
+    │   ├── is_void: true
+    │   └── element_source: "ActionView::Helpers::AssetTagHelper#stylesheet_link_tag"
+    │
+    └── @ HTMLTextNode (location: (1:68)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/action_view/asset_tag_helper/stylesheet_link_tag_test/test_0015_stylesheet_link_tag_with_data_attributes_ffd1d578d881727a5cfe4bf029c9fe5f-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/asset_tag_helper/stylesheet_link_tag_test/test_0015_stylesheet_link_tag_with_data_attributes_ffd1d578d881727a5cfe4bf029c9fe5f-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,85 @@
+---
+source: "Analyze::ActionView::AssetTagHelper::StylesheetLinkTagTest#test_0015_stylesheet_link_tag with data attributes"
+input: |2-
+<%= stylesheet_link_tag "application", data: { turbo_track: "reload" } %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:73))
+    │   ├── open_tag:
+    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:73))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " stylesheet_link_tag "application", data: { turbo_track: "reload" } " (location: (1:3)-(1:71))
+    │   │       ├── tag_closing: "%>" (location: (1:71)-(1:73))
+    │   │       ├── tag_name: "link" (location: (1:4)-(1:23))
+    │   │       └── children: (3 items)
+    │   │           ├── @ HTMLAttributeNode (location: (1:24)-(1:37))
+    │   │           │   ├── name:
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:24)-(1:37))
+    │   │           │   │       └── children: (1 item)
+    │   │           │   │           └── @ LiteralNode (location: (1:24)-(1:37))
+    │   │           │   │               └── content: "rel"
+    │   │           │   │
+    │   │           │   │
+    │   │           │   ├── equals: "=" (location: (1:24)-(1:37))
+    │   │           │   └── value:
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:24)-(1:37))
+    │   │           │           ├── open_quote: """ (location: (1:24)-(1:24))
+    │   │           │           ├── children: (1 item)
+    │   │           │           │   └── @ LiteralNode (location: (1:24)-(1:37))
+    │   │           │           │       └── content: "stylesheet"
+    │   │           │           │
+    │   │           │           ├── close_quote: """ (location: (1:37)-(1:37))
+    │   │           │           └── quoted: true
+    │   │           │
+    │   │           │
+    │   │           ├── @ HTMLAttributeNode (location: (1:24)-(1:37))
+    │   │           │   ├── name:
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:24)-(1:37))
+    │   │           │   │       └── children: (1 item)
+    │   │           │   │           └── @ LiteralNode (location: (1:24)-(1:37))
+    │   │           │   │               └── content: "href"
+    │   │           │   │
+    │   │           │   │
+    │   │           │   ├── equals: ":" (location: (1:24)-(1:37))
+    │   │           │   └── value:
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:24)-(1:37))
+    │   │           │           ├── open_quote: ∅
+    │   │           │           ├── children: (1 item)
+    │   │           │           │   └── @ RubyLiteralNode (location: (1:24)-(1:37))
+    │   │           │           │       └── content: "stylesheet_path(\"application\")"
+    │   │           │           │
+    │   │           │           ├── close_quote: ∅
+    │   │           │           └── quoted: true
+    │   │           │
+    │   │           │
+    │   │           └── @ HTMLAttributeNode (location: (1:47)-(1:68))
+    │   │               ├── name:
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:47)-(1:58))
+    │   │               │       └── children: (1 item)
+    │   │               │           └── @ LiteralNode (location: (1:47)-(1:58))
+    │   │               │               └── content: "data-turbo-track"
+    │   │               │
+    │   │               │
+    │   │               ├── equals: ": " (location: (1:58)-(1:60))
+    │   │               └── value:
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:60)-(1:68))
+    │   │                       ├── open_quote: """ (location: (1:60)-(1:61))
+    │   │                       ├── children: (1 item)
+    │   │                       │   └── @ LiteralNode (location: (1:61)-(1:67))
+    │   │                       │       └── content: "reload"
+    │   │                       │
+    │   │                       ├── close_quote: """ (location: (1:67)-(1:68))
+    │   │                       └── quoted: true
+    │   │
+    │   │
+    │   │
+    │   ├── tag_name: "link" (location: (1:4)-(1:23))
+    │   ├── body: []
+    │   ├── close_tag: ∅
+    │   ├── is_void: true
+    │   └── element_source: "ActionView::Helpers::AssetTagHelper#stylesheet_link_tag"
+    │
+    └── @ HTMLTextNode (location: (1:73)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/action_view/asset_tag_helper/stylesheet_link_tag_test/test_0016_stylesheet_link_tag_with_asset_path_336f561e9ed1ef89f8371569dc0ea3ec-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/asset_tag_helper/stylesheet_link_tag_test/test_0016_stylesheet_link_tag_with_asset_path_336f561e9ed1ef89f8371569dc0ea3ec-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,65 @@
+---
+source: "Analyze::ActionView::AssetTagHelper::StylesheetLinkTagTest#test_0016_stylesheet_link_tag with asset_path"
+input: |2-
+<%= stylesheet_link_tag asset_path("application.css") %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:56))
+    │   ├── open_tag:
+    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:56))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " stylesheet_link_tag asset_path("application.css") " (location: (1:3)-(1:54))
+    │   │       ├── tag_closing: "%>" (location: (1:54)-(1:56))
+    │   │       ├── tag_name: "link" (location: (1:4)-(1:23))
+    │   │       └── children: (2 items)
+    │   │           ├── @ HTMLAttributeNode (location: (1:24)-(1:53))
+    │   │           │   ├── name:
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:24)-(1:53))
+    │   │           │   │       └── children: (1 item)
+    │   │           │   │           └── @ LiteralNode (location: (1:24)-(1:53))
+    │   │           │   │               └── content: "rel"
+    │   │           │   │
+    │   │           │   │
+    │   │           │   ├── equals: "=" (location: (1:24)-(1:53))
+    │   │           │   └── value:
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:24)-(1:53))
+    │   │           │           ├── open_quote: """ (location: (1:24)-(1:24))
+    │   │           │           ├── children: (1 item)
+    │   │           │           │   └── @ LiteralNode (location: (1:24)-(1:53))
+    │   │           │           │       └── content: "stylesheet"
+    │   │           │           │
+    │   │           │           ├── close_quote: """ (location: (1:53)-(1:53))
+    │   │           │           └── quoted: true
+    │   │           │
+    │   │           │
+    │   │           └── @ HTMLAttributeNode (location: (1:24)-(1:53))
+    │   │               ├── name:
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:24)-(1:53))
+    │   │               │       └── children: (1 item)
+    │   │               │           └── @ LiteralNode (location: (1:24)-(1:53))
+    │   │               │               └── content: "href"
+    │   │               │
+    │   │               │
+    │   │               ├── equals: ":" (location: (1:24)-(1:53))
+    │   │               └── value:
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:24)-(1:53))
+    │   │                       ├── open_quote: ∅
+    │   │                       ├── children: (1 item)
+    │   │                       │   └── @ RubyLiteralNode (location: (1:24)-(1:53))
+    │   │                       │       └── content: "asset_path(\"application.css\")"
+    │   │                       │
+    │   │                       ├── close_quote: ∅
+    │   │                       └── quoted: true
+    │   │
+    │   │
+    │   │
+    │   ├── tag_name: "link" (location: (1:4)-(1:23))
+    │   ├── body: []
+    │   ├── close_tag: ∅
+    │   ├── is_void: true
+    │   └── element_source: "ActionView::Helpers::AssetTagHelper#stylesheet_link_tag"
+    │
+    └── @ HTMLTextNode (location: (1:56)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/action_view/asset_tag_helper/stylesheet_link_tag_test/test_0017_stylesheet_link_tag_with_variable_source_492d3648bdf4da030a53a3b97bc49b9f-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/asset_tag_helper/stylesheet_link_tag_test/test_0017_stylesheet_link_tag_with_variable_source_492d3648bdf4da030a53a3b97bc49b9f-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,65 @@
+---
+source: "Analyze::ActionView::AssetTagHelper::StylesheetLinkTagTest#test_0017_stylesheet_link_tag with variable source"
+input: |2-
+<%= stylesheet_link_tag stylesheet %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:37))
+    │   ├── open_tag:
+    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:37))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " stylesheet_link_tag stylesheet " (location: (1:3)-(1:35))
+    │   │       ├── tag_closing: "%>" (location: (1:35)-(1:37))
+    │   │       ├── tag_name: "link" (location: (1:4)-(1:23))
+    │   │       └── children: (2 items)
+    │   │           ├── @ HTMLAttributeNode (location: (1:24)-(1:34))
+    │   │           │   ├── name:
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:24)-(1:34))
+    │   │           │   │       └── children: (1 item)
+    │   │           │   │           └── @ LiteralNode (location: (1:24)-(1:34))
+    │   │           │   │               └── content: "rel"
+    │   │           │   │
+    │   │           │   │
+    │   │           │   ├── equals: "=" (location: (1:24)-(1:34))
+    │   │           │   └── value:
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:24)-(1:34))
+    │   │           │           ├── open_quote: """ (location: (1:24)-(1:24))
+    │   │           │           ├── children: (1 item)
+    │   │           │           │   └── @ LiteralNode (location: (1:24)-(1:34))
+    │   │           │           │       └── content: "stylesheet"
+    │   │           │           │
+    │   │           │           ├── close_quote: """ (location: (1:34)-(1:34))
+    │   │           │           └── quoted: true
+    │   │           │
+    │   │           │
+    │   │           └── @ HTMLAttributeNode (location: (1:24)-(1:34))
+    │   │               ├── name:
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:24)-(1:34))
+    │   │               │       └── children: (1 item)
+    │   │               │           └── @ LiteralNode (location: (1:24)-(1:34))
+    │   │               │               └── content: "href"
+    │   │               │
+    │   │               │
+    │   │               ├── equals: ":" (location: (1:24)-(1:34))
+    │   │               └── value:
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:24)-(1:34))
+    │   │                       ├── open_quote: ∅
+    │   │                       ├── children: (1 item)
+    │   │                       │   └── @ RubyLiteralNode (location: (1:24)-(1:34))
+    │   │                       │       └── content: "stylesheet_path(stylesheet)"
+    │   │                       │
+    │   │                       ├── close_quote: ∅
+    │   │                       └── quoted: true
+    │   │
+    │   │
+    │   │
+    │   ├── tag_name: "link" (location: (1:4)-(1:23))
+    │   ├── body: []
+    │   ├── close_tag: ∅
+    │   ├── is_void: true
+    │   └── element_source: "ActionView::Helpers::AssetTagHelper#stylesheet_link_tag"
+    │
+    └── @ HTMLTextNode (location: (1:37)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/action_view/asset_tag_helper/stylesheet_link_tag_test/test_0018_stylesheet_link_tag_with_multiple_sources_and_media_c45289aadb417c694c314a9b29262b7e-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/asset_tag_helper/stylesheet_link_tag_test/test_0018_stylesheet_link_tag_with_multiple_sources_and_media_c45289aadb417c694c314a9b29262b7e-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,163 @@
+---
+source: "Analyze::ActionView::AssetTagHelper::StylesheetLinkTagTest#test_0018_stylesheet_link_tag with multiple sources and media"
+input: |2-
+<%= stylesheet_link_tag "application", "admin", media: "all" %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (4 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:63))
+    │   ├── open_tag:
+    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:63))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " stylesheet_link_tag "application", "admin", media: "all" " (location: (1:3)-(1:61))
+    │   │       ├── tag_closing: "%>" (location: (1:61)-(1:63))
+    │   │       ├── tag_name: "link" (location: (1:4)-(1:23))
+    │   │       └── children: (3 items)
+    │   │           ├── @ HTMLAttributeNode (location: (1:24)-(1:37))
+    │   │           │   ├── name:
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:24)-(1:37))
+    │   │           │   │       └── children: (1 item)
+    │   │           │   │           └── @ LiteralNode (location: (1:24)-(1:37))
+    │   │           │   │               └── content: "rel"
+    │   │           │   │
+    │   │           │   │
+    │   │           │   ├── equals: "=" (location: (1:24)-(1:37))
+    │   │           │   └── value:
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:24)-(1:37))
+    │   │           │           ├── open_quote: """ (location: (1:24)-(1:24))
+    │   │           │           ├── children: (1 item)
+    │   │           │           │   └── @ LiteralNode (location: (1:24)-(1:37))
+    │   │           │           │       └── content: "stylesheet"
+    │   │           │           │
+    │   │           │           ├── close_quote: """ (location: (1:37)-(1:37))
+    │   │           │           └── quoted: true
+    │   │           │
+    │   │           │
+    │   │           ├── @ HTMLAttributeNode (location: (1:24)-(1:37))
+    │   │           │   ├── name:
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:24)-(1:37))
+    │   │           │   │       └── children: (1 item)
+    │   │           │   │           └── @ LiteralNode (location: (1:24)-(1:37))
+    │   │           │   │               └── content: "href"
+    │   │           │   │
+    │   │           │   │
+    │   │           │   ├── equals: ":" (location: (1:24)-(1:37))
+    │   │           │   └── value:
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:24)-(1:37))
+    │   │           │           ├── open_quote: ∅
+    │   │           │           ├── children: (1 item)
+    │   │           │           │   └── @ RubyLiteralNode (location: (1:24)-(1:37))
+    │   │           │           │       └── content: "stylesheet_path(\"application\")"
+    │   │           │           │
+    │   │           │           ├── close_quote: ∅
+    │   │           │           └── quoted: true
+    │   │           │
+    │   │           │
+    │   │           └── @ HTMLAttributeNode (location: (1:48)-(1:60))
+    │   │               ├── name:
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:48)-(1:53))
+    │   │               │       └── children: (1 item)
+    │   │               │           └── @ LiteralNode (location: (1:48)-(1:53))
+    │   │               │               └── content: "media"
+    │   │               │
+    │   │               │
+    │   │               ├── equals: ": " (location: (1:53)-(1:55))
+    │   │               └── value:
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:55)-(1:60))
+    │   │                       ├── open_quote: """ (location: (1:55)-(1:56))
+    │   │                       ├── children: (1 item)
+    │   │                       │   └── @ LiteralNode (location: (1:56)-(1:59))
+    │   │                       │       └── content: "all"
+    │   │                       │
+    │   │                       ├── close_quote: """ (location: (1:59)-(1:60))
+    │   │                       └── quoted: true
+    │   │
+    │   │
+    │   │
+    │   ├── tag_name: "link" (location: (1:4)-(1:23))
+    │   ├── body: []
+    │   ├── close_tag: ∅
+    │   ├── is_void: true
+    │   └── element_source: "ActionView::Helpers::AssetTagHelper#stylesheet_link_tag"
+    │
+    ├── @ HTMLTextNode (location: (1:0)-(1:0))
+    │   └── content: "\n"
+    │
+    ├── @ HTMLElementNode (location: (1:0)-(1:63))
+    │   ├── open_tag:
+    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:63))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " stylesheet_link_tag "application", "admin", media: "all" " (location: (1:3)-(1:61))
+    │   │       ├── tag_closing: "%>" (location: (1:61)-(1:63))
+    │   │       ├── tag_name: "link" (location: (1:4)-(1:23))
+    │   │       └── children: (3 items)
+    │   │           ├── @ HTMLAttributeNode (location: (1:39)-(1:46))
+    │   │           │   ├── name:
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:39)-(1:46))
+    │   │           │   │       └── children: (1 item)
+    │   │           │   │           └── @ LiteralNode (location: (1:39)-(1:46))
+    │   │           │   │               └── content: "rel"
+    │   │           │   │
+    │   │           │   │
+    │   │           │   ├── equals: "=" (location: (1:39)-(1:46))
+    │   │           │   └── value:
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:39)-(1:46))
+    │   │           │           ├── open_quote: """ (location: (1:39)-(1:39))
+    │   │           │           ├── children: (1 item)
+    │   │           │           │   └── @ LiteralNode (location: (1:39)-(1:46))
+    │   │           │           │       └── content: "stylesheet"
+    │   │           │           │
+    │   │           │           ├── close_quote: """ (location: (1:46)-(1:46))
+    │   │           │           └── quoted: true
+    │   │           │
+    │   │           │
+    │   │           ├── @ HTMLAttributeNode (location: (1:39)-(1:46))
+    │   │           │   ├── name:
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:39)-(1:46))
+    │   │           │   │       └── children: (1 item)
+    │   │           │   │           └── @ LiteralNode (location: (1:39)-(1:46))
+    │   │           │   │               └── content: "href"
+    │   │           │   │
+    │   │           │   │
+    │   │           │   ├── equals: ":" (location: (1:39)-(1:46))
+    │   │           │   └── value:
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:39)-(1:46))
+    │   │           │           ├── open_quote: ∅
+    │   │           │           ├── children: (1 item)
+    │   │           │           │   └── @ RubyLiteralNode (location: (1:39)-(1:46))
+    │   │           │           │       └── content: "stylesheet_path(\"admin\")"
+    │   │           │           │
+    │   │           │           ├── close_quote: ∅
+    │   │           │           └── quoted: true
+    │   │           │
+    │   │           │
+    │   │           └── @ HTMLAttributeNode (location: (1:48)-(1:60))
+    │   │               ├── name:
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:48)-(1:53))
+    │   │               │       └── children: (1 item)
+    │   │               │           └── @ LiteralNode (location: (1:48)-(1:53))
+    │   │               │               └── content: "media"
+    │   │               │
+    │   │               │
+    │   │               ├── equals: ": " (location: (1:53)-(1:55))
+    │   │               └── value:
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:55)-(1:60))
+    │   │                       ├── open_quote: """ (location: (1:55)-(1:56))
+    │   │                       ├── children: (1 item)
+    │   │                       │   └── @ LiteralNode (location: (1:56)-(1:59))
+    │   │                       │       └── content: "all"
+    │   │                       │
+    │   │                       ├── close_quote: """ (location: (1:59)-(1:60))
+    │   │                       └── quoted: true
+    │   │
+    │   │
+    │   │
+    │   ├── tag_name: "link" (location: (1:4)-(1:23))
+    │   ├── body: []
+    │   ├── close_tag: ∅
+    │   ├── is_void: true
+    │   └── element_source: "ActionView::Helpers::AssetTagHelper#stylesheet_link_tag"
+    │
+    └── @ HTMLTextNode (location: (1:63)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0001_stylesheet_link_tag_with_source_2301c2321c058057c462f62458ded879.txt
+++ b/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0001_stylesheet_link_tag_with_source_2301c2321c058057c462f62458ded879.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::ActionView::StylesheetLinkTagTest#test_0001_stylesheet_link_tag with source"
+input: "{source: \"<%= stylesheet_link_tag \\\"style\\\" %>\", options: {optimize: true}}"
+---
+_buf = ::String.new; _buf << '<link rel="stylesheet" href="'.freeze; _buf << ::Herb::Engine.attr((stylesheet_path("style"))); _buf << '" />'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0001_stylesheet_link_tag_with_source_b8a469a628e41360d22a75e9f90d1ec6.txt
+++ b/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0001_stylesheet_link_tag_with_source_b8a469a628e41360d22a75e9f90d1ec6.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::ActionView::StylesheetLinkTagTest#test_0001_stylesheet_link_tag with source"
+input: "{source: \"<%= stylesheet_link_tag \\\"style\\\" %>\", locals: {}, options: {action_view_helpers: true}}"
+---
+<link rel="stylesheet" href="/stylesheets/style.css" />

--- a/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0002_stylesheet_link_tag_with_source_including_extension_a2f09902ee41c54673ad4bd0dceb184a.txt
+++ b/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0002_stylesheet_link_tag_with_source_including_extension_a2f09902ee41c54673ad4bd0dceb184a.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::ActionView::StylesheetLinkTagTest#test_0002_stylesheet_link_tag with source including extension"
+input: "{source: \"<%= stylesheet_link_tag \\\"style.css\\\" %>\", options: {optimize: true}}"
+---
+_buf = ::String.new; _buf << '<link rel="stylesheet" href="'.freeze; _buf << ::Herb::Engine.attr((stylesheet_path("style.css"))); _buf << '" />'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0002_stylesheet_link_tag_with_source_including_extension_f6c16be87b840f62a6b3b38ddb9ec890.txt
+++ b/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0002_stylesheet_link_tag_with_source_including_extension_f6c16be87b840f62a6b3b38ddb9ec890.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::ActionView::StylesheetLinkTagTest#test_0002_stylesheet_link_tag with source including extension"
+input: "{source: \"<%= stylesheet_link_tag \\\"style.css\\\" %>\", locals: {}, options: {action_view_helpers: true}}"
+---
+<link rel="stylesheet" href="/stylesheets/style.css" />

--- a/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0003_stylesheet_link_tag_with_URL_76e78a06e6b4b82445c10bcea9c1d037.txt
+++ b/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0003_stylesheet_link_tag_with_URL_76e78a06e6b4b82445c10bcea9c1d037.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::ActionView::StylesheetLinkTagTest#test_0003_stylesheet_link_tag with URL"
+input: "{source: \"<%= stylesheet_link_tag \\\"http://www.example.com/style.css\\\" %>\", locals: {}, options: {action_view_helpers: true}}"
+---
+<link rel="stylesheet" href="http://www.example.com/style.css" />

--- a/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0003_stylesheet_link_tag_with_URL_a2e4cdf6ed930eb5ba8f6bbc18951773.txt
+++ b/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0003_stylesheet_link_tag_with_URL_a2e4cdf6ed930eb5ba8f6bbc18951773.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::ActionView::StylesheetLinkTagTest#test_0003_stylesheet_link_tag with URL"
+input: "{source: \"<%= stylesheet_link_tag \\\"http://www.example.com/style.css\\\" %>\", options: {optimize: true}}"
+---
+_buf = ::String.new; _buf << '<link rel="stylesheet" href="http://www.example.com/style.css" />'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0004_stylesheet_link_tag_with_extname_false,_skip_pipeline_and_rel_7dbbc29f8d18618aa5ec6729fca0bc8d.txt
+++ b/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0004_stylesheet_link_tag_with_extname_false,_skip_pipeline_and_rel_7dbbc29f8d18618aa5ec6729fca0bc8d.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::ActionView::StylesheetLinkTagTest#test_0004_stylesheet_link_tag with extname false, skip_pipeline and rel"
+input: "{source: \"<%= stylesheet_link_tag \\\"style.less\\\", extname: false, skip_pipeline: true, rel: \\\"stylesheet/less\\\" %>\", options: {optimize: true}}"
+---
+_buf = ::String.new; _buf << '<link rel="stylesheet/less" href="'.freeze; _buf << ::Herb::Engine.attr((stylesheet_path("style.less", extname: false, skip_pipeline: true))); _buf << '" />'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0004_stylesheet_link_tag_with_extname_false,_skip_pipeline_and_rel_807d3265defa8463adf36d28149581e7.txt
+++ b/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0004_stylesheet_link_tag_with_extname_false,_skip_pipeline_and_rel_807d3265defa8463adf36d28149581e7.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::ActionView::StylesheetLinkTagTest#test_0004_stylesheet_link_tag with extname false, skip_pipeline and rel"
+input: "{source: \"<%= stylesheet_link_tag \\\"style.less\\\", extname: false, skip_pipeline: true, rel: \\\"stylesheet/less\\\" %>\", locals: {}, options: {action_view_helpers: true}}"
+---
+<link rel="stylesheet/less" href="/stylesheets/style.less" />

--- a/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0005_stylesheet_link_tag_with_media_all_274152676c0db787867f9b89d73f261e.txt
+++ b/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0005_stylesheet_link_tag_with_media_all_274152676c0db787867f9b89d73f261e.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::ActionView::StylesheetLinkTagTest#test_0005_stylesheet_link_tag with media all"
+input: "{source: \"<%= stylesheet_link_tag \\\"style\\\", media: \\\"all\\\" %>\", options: {optimize: true}}"
+---
+_buf = ::String.new; _buf << '<link rel="stylesheet" href="'.freeze; _buf << ::Herb::Engine.attr((stylesheet_path("style"))); _buf << '" media="all" />'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0005_stylesheet_link_tag_with_media_all_b8647874eaecf7a8140cdead8c9f5ea8.txt
+++ b/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0005_stylesheet_link_tag_with_media_all_b8647874eaecf7a8140cdead8c9f5ea8.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::ActionView::StylesheetLinkTagTest#test_0005_stylesheet_link_tag with media all"
+input: "{source: \"<%= stylesheet_link_tag \\\"style\\\", media: \\\"all\\\" %>\", locals: {}, options: {action_view_helpers: true}}"
+---
+<link rel="stylesheet" href="/stylesheets/style.css" media="all" />

--- a/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0006_stylesheet_link_tag_with_media_print_89bfa1d9110f75caee1b8ce619e1aa22.txt
+++ b/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0006_stylesheet_link_tag_with_media_print_89bfa1d9110f75caee1b8ce619e1aa22.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::ActionView::StylesheetLinkTagTest#test_0006_stylesheet_link_tag with media print"
+input: "{source: \"<%= stylesheet_link_tag \\\"style\\\", media: \\\"print\\\" %>\", options: {optimize: true}}"
+---
+_buf = ::String.new; _buf << '<link rel="stylesheet" href="'.freeze; _buf << ::Herb::Engine.attr((stylesheet_path("style"))); _buf << '" media="print" />'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0006_stylesheet_link_tag_with_media_print_900cf3f981b78b1d218ab5902023a372.txt
+++ b/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0006_stylesheet_link_tag_with_media_print_900cf3f981b78b1d218ab5902023a372.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::ActionView::StylesheetLinkTagTest#test_0006_stylesheet_link_tag with media print"
+input: "{source: \"<%= stylesheet_link_tag \\\"style\\\", media: \\\"print\\\" %>\", locals: {}, options: {action_view_helpers: true}}"
+---
+<link rel="stylesheet" href="/stylesheets/style.css" media="print" />

--- a/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0007_stylesheet_link_tag_with_multiple_sources_2d5a2e240d6de4739eaf1ccfc23b73e5.txt
+++ b/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0007_stylesheet_link_tag_with_multiple_sources_2d5a2e240d6de4739eaf1ccfc23b73e5.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::ActionView::StylesheetLinkTagTest#test_0007_stylesheet_link_tag with multiple sources"
+input: "{source: \"<%= stylesheet_link_tag \\\"random.styles\\\", \\\"/css/stylish\\\" %>\", locals: {}, options: {action_view_helpers: true}}"
+---
+<link rel="stylesheet" href="/stylesheets/random.styles.css" />
+<link rel="stylesheet" href="/css/stylish.css" />

--- a/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0007_stylesheet_link_tag_with_multiple_sources_b2fed9f6af938da5ade30ab20614ed2a.txt
+++ b/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0007_stylesheet_link_tag_with_multiple_sources_b2fed9f6af938da5ade30ab20614ed2a.txt
@@ -1,0 +1,7 @@
+---
+source: "Engine::ActionView::StylesheetLinkTagTest#test_0007_stylesheet_link_tag with multiple sources"
+input: "{source: \"<%= stylesheet_link_tag \\\"random.styles\\\", \\\"/css/stylish\\\" %>\", options: {optimize: true}}"
+---
+_buf = ::String.new; _buf << '<link rel="stylesheet" href="'.freeze; _buf << ::Herb::Engine.attr((stylesheet_path("random.styles"))); _buf << '" />
+<link rel="stylesheet" href="'.freeze; _buf << ::Herb::Engine.attr((stylesheet_path("/css/stylish"))); _buf << '" />'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0008_stylesheet_link_tag_with_protocol-relative_URL_2438050eb4ab5abe18305db07063d046.txt
+++ b/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0008_stylesheet_link_tag_with_protocol-relative_URL_2438050eb4ab5abe18305db07063d046.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::ActionView::StylesheetLinkTagTest#test_0008_stylesheet_link_tag with protocol-relative URL"
+input: "{source: \"<%= stylesheet_link_tag \\\"//cdn.example.com/style.css\\\" %>\", options: {optimize: true}}"
+---
+_buf = ::String.new; _buf << '<link rel="stylesheet" href="//cdn.example.com/style.css" />'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0008_stylesheet_link_tag_with_protocol-relative_URL_feabd8e5a72775caac6029ff7efdb9f7.txt
+++ b/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0008_stylesheet_link_tag_with_protocol-relative_URL_feabd8e5a72775caac6029ff7efdb9f7.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::ActionView::StylesheetLinkTagTest#test_0008_stylesheet_link_tag with protocol-relative URL"
+input: "{source: \"<%= stylesheet_link_tag \\\"//cdn.example.com/style.css\\\" %>\", locals: {}, options: {action_view_helpers: true}}"
+---
+<link rel="stylesheet" href="//cdn.example.com/style.css" />

--- a/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0009_stylesheet_link_tag_with_host_and_protocol_288da138556a01f97f206fb5afc351b9.txt
+++ b/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0009_stylesheet_link_tag_with_host_and_protocol_288da138556a01f97f206fb5afc351b9.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::ActionView::StylesheetLinkTagTest#test_0009_stylesheet_link_tag with host and protocol"
+input: "{source: \"<%= stylesheet_link_tag \\\"style\\\", host: \\\"localhost\\\", protocol: \\\"https\\\" %>\", options: {optimize: true}}"
+---
+_buf = ::String.new; _buf << '<link rel="stylesheet" href="'.freeze; _buf << ::Herb::Engine.attr((stylesheet_path("style", host: "localhost", protocol: "https"))); _buf << '" />'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0009_stylesheet_link_tag_with_host_and_protocol_3ccdbf5022f92d02b4e1e96663dc11a0.txt
+++ b/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0009_stylesheet_link_tag_with_host_and_protocol_3ccdbf5022f92d02b4e1e96663dc11a0.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::ActionView::StylesheetLinkTagTest#test_0009_stylesheet_link_tag with host and protocol"
+input: "{source: \"<%= stylesheet_link_tag \\\"style\\\", host: \\\"localhost\\\", protocol: \\\"https\\\" %>\", locals: {}, options: {action_view_helpers: true}}"
+---
+<link rel="stylesheet" href="https://localhost/stylesheets/style.css" />

--- a/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0010_stylesheet_link_tag_with_skip_pipeline_493db4371a9ca7e0eeeb44613c4194ed.txt
+++ b/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0010_stylesheet_link_tag_with_skip_pipeline_493db4371a9ca7e0eeeb44613c4194ed.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::ActionView::StylesheetLinkTagTest#test_0010_stylesheet_link_tag with skip_pipeline"
+input: "{source: \"<%= stylesheet_link_tag \\\"application\\\", skip_pipeline: true %>\", locals: {}, options: {action_view_helpers: true}}"
+---
+<link rel="stylesheet" href="/stylesheets/application.css" />

--- a/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0010_stylesheet_link_tag_with_skip_pipeline_b7a247a993ac1af13296e8e04bc3b46c.txt
+++ b/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0010_stylesheet_link_tag_with_skip_pipeline_b7a247a993ac1af13296e8e04bc3b46c.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::ActionView::StylesheetLinkTagTest#test_0010_stylesheet_link_tag with skip_pipeline"
+input: "{source: \"<%= stylesheet_link_tag \\\"application\\\", skip_pipeline: true %>\", options: {optimize: true}}"
+---
+_buf = ::String.new; _buf << '<link rel="stylesheet" href="'.freeze; _buf << ::Herb::Engine.attr((stylesheet_path("application", skip_pipeline: true))); _buf << '" />'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0011_stylesheet_link_tag_with_rel_84ac95223ff17a21fa378e617e15f4b3.txt
+++ b/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0011_stylesheet_link_tag_with_rel_84ac95223ff17a21fa378e617e15f4b3.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::ActionView::StylesheetLinkTagTest#test_0011_stylesheet_link_tag with rel"
+input: "{source: \"<%= stylesheet_link_tag \\\"application\\\", rel: \\\"preload\\\" %>\", locals: {}, options: {action_view_helpers: true}}"
+---
+<link rel="preload" href="/stylesheets/application.css" />

--- a/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0011_stylesheet_link_tag_with_rel_a0e35e9ab428ab09355b52298a03505a.txt
+++ b/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0011_stylesheet_link_tag_with_rel_a0e35e9ab428ab09355b52298a03505a.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::ActionView::StylesheetLinkTagTest#test_0011_stylesheet_link_tag with rel"
+input: "{source: \"<%= stylesheet_link_tag \\\"application\\\", rel: \\\"preload\\\" %>\", options: {optimize: true}}"
+---
+_buf = ::String.new; _buf << '<link rel="preload" href="'.freeze; _buf << ::Herb::Engine.attr((stylesheet_path("application"))); _buf << '" />'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0012_stylesheet_link_tag_with_data_attributes_124e3a21b8f74642ed371c9eb72bb467.txt
+++ b/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0012_stylesheet_link_tag_with_data_attributes_124e3a21b8f74642ed371c9eb72bb467.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::ActionView::StylesheetLinkTagTest#test_0012_stylesheet_link_tag with data attributes"
+input: "{source: \"<%= stylesheet_link_tag \\\"application\\\", data: { turbo_track: \\\"reload\\\" } %>\", locals: {}, options: {action_view_helpers: true}}"
+---
+<link rel="stylesheet" href="/stylesheets/application.css" data-turbo-track="reload" />

--- a/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0012_stylesheet_link_tag_with_data_attributes_7c43bbc882c2e9c46a17bfe82dafe9b7.txt
+++ b/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0012_stylesheet_link_tag_with_data_attributes_7c43bbc882c2e9c46a17bfe82dafe9b7.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::ActionView::StylesheetLinkTagTest#test_0012_stylesheet_link_tag with data attributes"
+input: "{source: \"<%= stylesheet_link_tag \\\"application\\\", data: { turbo_track: \\\"reload\\\" } %>\", options: {optimize: true}}"
+---
+_buf = ::String.new; _buf << '<link rel="stylesheet" href="'.freeze; _buf << ::Herb::Engine.attr((stylesheet_path("application"))); _buf << '" data-turbo-track="reload" />'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0013_stylesheet_link_tag_with_multiple_sources_and_media_2d3e777b5f9456a33f8bd0bfe89ec72c.txt
+++ b/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0013_stylesheet_link_tag_with_multiple_sources_and_media_2d3e777b5f9456a33f8bd0bfe89ec72c.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::ActionView::StylesheetLinkTagTest#test_0013_stylesheet_link_tag with multiple sources and media"
+input: "{source: \"<%= stylesheet_link_tag \\\"application\\\", \\\"admin\\\", media: \\\"all\\\" %>\", locals: {}, options: {action_view_helpers: true}}"
+---
+<link rel="stylesheet" href="/stylesheets/application.css" media="all" />
+<link rel="stylesheet" href="/stylesheets/admin.css" media="all" />

--- a/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0013_stylesheet_link_tag_with_multiple_sources_and_media_2f4f2e2a918212376f10b66cc90951be.txt
+++ b/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0013_stylesheet_link_tag_with_multiple_sources_and_media_2f4f2e2a918212376f10b66cc90951be.txt
@@ -1,0 +1,7 @@
+---
+source: "Engine::ActionView::StylesheetLinkTagTest#test_0013_stylesheet_link_tag with multiple sources and media"
+input: "{source: \"<%= stylesheet_link_tag \\\"application\\\", \\\"admin\\\", media: \\\"all\\\" %>\", options: {optimize: true}}"
+---
+_buf = ::String.new; _buf << '<link rel="stylesheet" href="'.freeze; _buf << ::Herb::Engine.attr((stylesheet_path("application"))); _buf << '" media="all" />
+<link rel="stylesheet" href="'.freeze; _buf << ::Herb::Engine.attr((stylesheet_path("admin"))); _buf << '" media="all" />'.freeze;
+_buf.to_s


### PR DESCRIPTION
This pull request allows the parser to detect and transform the `stylesheet_link_tag` helper using the `action_view_helpers` parser option, and updates the rewriters to convert to and from the helper syntax.

For example:

```html+erb
<%= stylesheet_link_tag "style" %>
```

Gets parsed as:

```js
@ DocumentNode (location: (1:0)-(2:0))
└── children: (2 items)
    ├── @ HTMLElementNode (location: (1:0)-(1:34))
    │   ├── open_tag:
    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:34))
    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
    │   │       ├── content: " stylesheet_link_tag "style" " (location: (1:3)-(1:32))
    │   │       ├── tag_closing: "%>" (location: (1:32)-(1:34))
    │   │       ├── tag_name: "link" (location: (1:4)-(1:23))
    │   │       └── children: (2 items)
    │   │           ├── @ HTMLAttributeNode (location: (1:24)-(1:31))
    │   │           │   ├── name: "rel"
    │   │           │   └── value: "stylesheet"
    │   │           │
    │   │           └── @ HTMLAttributeNode (location: (1:24)-(1:31))
    │   │               ├── name: "href"
    │   │               └── value:
    │   │                   └── @ RubyLiteralNode
    │   │                       └── content: "stylesheet_path(\"style\")"
    │   │
    │   ├── tag_name: "link" (location: (1:4)-(1:23))
    │   ├── body: []
    │   ├── close_tag: ∅
    │   ├── is_void: true
    │   └── element_source: "ActionView::Helpers::AssetTagHelper#stylesheet_link_tag"
    │
    └── @ HTMLTextNode (location: (1:34)-(2:0))
        └── content: "\n"
```

Follow up on #1374
Follow up on #1437
Follow up on #1611

Related #1122