### PR TITLE
Linter: Fix `erb-strict-locals-comment-syntax` and implement autofix

### DIFF
--- a/javascript/packages/linter/docs/rules/erb-strict-locals-comment-syntax.md
+++ b/javascript/packages/linter/docs/rules/erb-strict-locals-comment-syntax.md
@@ -18,18 +18,18 @@ This rule catches invalid comment forms and argument types early during developm
 
 Most of these offenses are corrected by `--fix`. The rewrites are safe because the declaration they replace is one Rails rejects outright.
 
-| Before | After |
-| --- | --- |
-| `<%# locals() %>` | `<%# locals: () %>` |
-| `<%# local: (user:) %>` | `<%# locals: (user:) %>` |
-| `<%# locals (user:) %>` | `<%# locals: (user:) %>` |
-| `<%# locals:(user:) %>` | `<%# locals: (user:) %>` |
-| `<%# locals: %>` | `<%# locals: () %>` |
+| Before                               | After                                  |
+|--------------------------------------|----------------------------------------|
+| `<%# locals() %>`                    | `<%# locals: () %>`                    |
+| `<%# local: (user:) %>`              | `<%# locals: (user:) %>`               |
+| `<%# locals (user:) %>`              | `<%# locals: (user:) %>`               |
+| `<%# locals:(user:) %>`              | `<%# locals: (user:) %>`               |
+| `<%# locals: %>`                     | `<%# locals: () %>`                    |
 | `<%# locals: user:, admin: false %>` | `<%# locals: (user:, admin: false) %>` |
-| `<%# locals: (user: %>` | `<%# locals: (user:) %>` |
-| `<% # locals: (user:) %>` | `<%# locals: (user:) %>` |
-| `<%# locals: (user) %>` | `<%# locals: (user:) %>` |
-| `<%# locals: (user:,) %>` | `<%# locals: (user:) %>` |
+| `<%# locals: (user: %>`              | `<%# locals: (user:) %>`               |
+| `<% # locals: (user:) %>`            | `<%# locals: (user:) %>`               |
+| `<%# locals: (user) %>`              | `<%# locals: (user:) %>`               |
+| `<%# locals: (user:,) %>`            | `<%# locals: (user:) %>`               |
 
 A parameter list written without parentheses is wrapped in them, and any bare name in it becomes a required keyword argument, since that is the only form Rails accepts.
 

--- a/javascript/packages/linter/docs/rules/erb-strict-locals-comment-syntax.md
+++ b/javascript/packages/linter/docs/rules/erb-strict-locals-comment-syntax.md
@@ -14,6 +14,27 @@ Additionally, Rails only supports keyword arguments in strict locals declaration
 
 This rule catches invalid comment forms and argument types early during development.
 
+## Autofix
+
+Most of these offenses are corrected by `--fix`. The rewrites are safe because the declaration they replace is one Rails rejects outright.
+
+| Before | After |
+| --- | --- |
+| `<%# locals() %>` | `<%# locals: () %>` |
+| `<%# local: (user:) %>` | `<%# locals: (user:) %>` |
+| `<%# locals (user:) %>` | `<%# locals: (user:) %>` |
+| `<%# locals:(user:) %>` | `<%# locals: (user:) %>` |
+| `<%# locals: %>` | `<%# locals: () %>` |
+| `<%# locals: user:, admin: false %>` | `<%# locals: (user:, admin: false) %>` |
+| `<%# locals: (user: %>` | `<%# locals: (user:) %>` |
+| `<% # locals: (user:) %>` | `<%# locals: (user:) %>` |
+| `<%# locals: (user) %>` | `<%# locals: (user:) %>` |
+| `<%# locals: (user:,) %>` | `<%# locals: (user:) %>` |
+
+A parameter list written without parentheses is wrapped in them, and any bare name in it becomes a required keyword argument, since that is the only form Rails accepts.
+
+Block arguments, splat arguments, and duplicate declarations are reported but not corrected. Each has more than one reasonable rewrite, so the choice is left to you.
+
 ## Examples
 
 ### ✅ Good
@@ -80,6 +101,12 @@ Empty `locals:` without parentheses:
 
 ```erb
 <%# locals: %>
+```
+
+Missing space after the colon:
+
+```erb
+<%# locals:(user:) %>
 ```
 
 Unbalanced parentheses:

--- a/javascript/packages/linter/src/rules/erb-strict-locals-comment-syntax.ts
+++ b/javascript/packages/linter/src/rules/erb-strict-locals-comment-syntax.ts
@@ -1,10 +1,41 @@
 import { BaseRuleVisitor } from "./rule-utils.js"
 import { ParserRule } from "../types.js"
 
+import { isRubyParameterNode } from "@herb-tools/core"
 import { isPartialFile } from "./file-utils.js"
 
-import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types.js"
-import type { ParseResult, ERBContentNode, ERBStrictLocalsNode } from "@herb-tools/core"
+import type { BaseAutofixContext, Mutable, UnboundLintOffense, LintOffense, LintContext, FullRuleConfig } from "../types.js"
+import type { ParseResult, ERBContentNode, ERBStrictLocalsNode, RubyParseError, HerbError } from "@herb-tools/core"
+
+const LOCALS_PREFIX = "locals:"
+
+type StrictLocalsCommentNode = ERBContentNode | ERBStrictLocalsNode
+
+type StrictLocalsFix =
+  | { type: "erb-comment-tag" }
+  | { type: "plural-locals" }
+  | { type: "colon-after-locals" }
+  | { type: "space-after-colon" }
+  | { type: "wrap-parameters" }
+  | { type: "close-parameters" }
+  | { type: "remove-extra-commas" }
+  | { type: "keyword-argument", name: string }
+
+interface ERBStrictLocalsCommentSyntaxAutofixContext extends BaseAutofixContext {
+  node: Mutable<StrictLocalsCommentNode>
+  fix: StrictLocalsFix
+}
+
+interface Parameters {
+  open: number
+  close: number | null
+  commas: number[]
+}
+
+interface Segment {
+  start: number
+  end: number
+}
 
 function extractERBCommentContent(content: string): string {
   return content.trim()
@@ -32,7 +63,232 @@ function detectMissingColonBeforeParens(content: string): boolean {
   return /^locals\s+\(/.test(content)
 }
 
-class ERBStrictLocalsCommentSyntaxVisitor extends BaseRuleVisitor {
+function hasError(node: { errors: HerbError[] }, type: string): boolean {
+  return node.errors.some(error => error.type === type)
+}
+
+function skipStringLiteral(content: string, index: number): number {
+  const quote = content[index]
+  let cursor = index + 1
+
+  while (cursor < content.length) {
+    if (content[cursor] === "\\") {
+      cursor += 2
+
+      continue
+    }
+
+    if (content[cursor] === quote) return cursor + 1
+
+    cursor++
+  }
+
+  return cursor
+}
+
+function scanParameters(content: string, open: number): Parameters {
+  const commas: number[] = []
+
+  let depth = 0
+  let cursor = open
+
+  while (cursor < content.length) {
+    const character = content[cursor]
+
+    if (character === '"' || character === "'") {
+      cursor = skipStringLiteral(content, cursor)
+
+      continue
+    }
+
+    if (character === "(" || character === "[" || character === "{") {
+      depth++
+    } else if (character === ")" || character === "]" || character === "}") {
+      depth--
+
+      if (depth === 0) return { open, close: cursor, commas }
+    } else if (character === "," && depth === 1) {
+      commas.push(cursor)
+    }
+
+    cursor++
+  }
+
+  return { open, close: null, commas }
+}
+
+function findParameters(content: string): Parameters | null {
+  const open = content.indexOf("(")
+
+  if (open === -1) return null
+
+  return scanParameters(content, open)
+}
+
+function segmentsOf(parameters: Parameters): Segment[] {
+  if (parameters.close === null) return []
+
+  const boundaries = [parameters.open, ...parameters.commas, parameters.close]
+
+  return boundaries.slice(0, -1).map((boundary, index) => ({ start: boundary + 1, end: boundaries[index + 1] }))
+}
+
+function isBareIdentifier(text: string): boolean {
+  return /^[a-z_][a-zA-Z0-9_]*$/.test(text)
+}
+
+function keywordizeParameters(content: string, parameters: Parameters, name?: string): string | null {
+  let result = content
+  let changed = false
+
+  for (const segment of segmentsOf(parameters).reverse()) {
+    const text = content.slice(segment.start, segment.end)
+
+    if (!isBareIdentifier(text.trim())) continue
+    if (name !== undefined && text.trim() !== name) continue
+
+    const insertAt = segment.start + text.trimEnd().length
+
+    result = `${result.slice(0, insertAt)}:${result.slice(insertAt)}`
+    changed = true
+
+    if (name !== undefined) break
+  }
+
+  return changed ? result : null
+}
+
+function suggestedParameters(inner: string): string {
+  const parameters = `(${inner})`
+
+  return keywordizeParameters(parameters, scanParameters(parameters, 0)) ?? parameters
+}
+
+function removeExtraCommas(content: string, parameters: Parameters): string | null {
+  if (parameters.close === null) return null
+
+  const ranges: Segment[] = []
+
+  for (const comma of parameters.commas) {
+    let before = comma - 1
+    let after = comma + 1
+
+    while (before > parameters.open && /\s/.test(content[before])) before--
+    while (after < parameters.close && /\s/.test(content[after])) after++
+
+    if (before === parameters.open) {
+      ranges.push({ start: comma, end: after })
+    } else if (after === parameters.close || content[before] === ",") {
+      ranges.push({ start: before + 1, end: comma + 1 })
+    }
+  }
+
+  if (ranges.length === 0) return null
+
+  let result = content
+
+  for (const range of ranges.reverse()) {
+    result = result.slice(0, range.start) + result.slice(range.end)
+  }
+
+  return result
+}
+
+function applyFix(node: Mutable<StrictLocalsCommentNode>, fix: StrictLocalsFix): boolean {
+  if (!node.tag_opening) return false
+  if (!node.content) return false
+
+  const content = node.content.value
+
+  switch (fix.type) {
+    case "erb-comment-tag": {
+      const match = content.match(/^\s*#/)
+      if (!match) return false
+
+      node.tag_opening.value = "<%#"
+      node.content.value = content.slice(match[0].length)
+
+      return true
+    }
+
+    case "plural-locals": {
+      if (!content.includes("local:")) return false
+
+      node.content.value = content.replace("local:", "locals:")
+
+      return true
+    }
+
+    case "colon-after-locals": {
+      if (!/locals?\s*\(/.test(content)) return false
+
+      node.content.value = content.replace(/locals?\s*\(/, "locals: (")
+
+      return true
+    }
+
+    case "space-after-colon": {
+      if (!/locals:\S/.test(content)) return false
+
+      node.content.value = content.replace(/locals:(?=\S)/, "locals: ")
+
+      return true
+    }
+
+    case "wrap-parameters": {
+      const index = content.indexOf(LOCALS_PREFIX)
+      if (index === -1) return false
+
+      const head = content.slice(0, index + LOCALS_PREFIX.length)
+      const rest = content.slice(index + LOCALS_PREFIX.length)
+      const trailing = rest.match(/\s*$/)?.[0] ?? ""
+
+      node.content.value = `${head} ${suggestedParameters(rest.trim())}${trailing}`
+
+      return true
+    }
+
+    case "close-parameters": {
+      const parameters = findParameters(content)
+
+      if (!parameters || parameters.close !== null) {
+        return false
+      }
+
+      const head = content.trimEnd()
+
+      node.content.value = `${head})${content.slice(head.length)}`
+
+      return true
+    }
+
+    case "remove-extra-commas": {
+      const parameters = findParameters(content)
+      if (!parameters) return false
+
+      const fixed = removeExtraCommas(content, parameters)
+      if (fixed === null) return false
+
+      node.content.value = fixed
+
+      return true
+    }
+
+    case "keyword-argument": {
+      const parameters = findParameters(content)
+      if (!parameters) return false
+
+      const fixed = keywordizeParameters(content, parameters, fix.name)
+      if (fixed === null) return false
+
+      node.content.value = fixed
+
+      return true
+    }
+  }
+}
+
+class ERBStrictLocalsCommentSyntaxVisitor extends BaseRuleVisitor<ERBStrictLocalsCommentSyntaxAutofixContext> {
   visitERBStrictLocalsNode(node: ERBStrictLocalsNode): void {
     const isPartial = isPartialFile(this.context.fileName)
 
@@ -43,24 +299,47 @@ class ERBStrictLocalsCommentSyntaxVisitor extends BaseRuleVisitor {
       )
     }
 
-    if (node.errors.length > 0) return
-
-    const content = node.content?.value ?? ""
-    const trimmed = content.trim()
-    const afterLocals = trimmed.slice("locals:".length)
-
-    if (afterLocals.length > 0 && afterLocals[0] !== " ") {
+    if (hasError(node, "STRICT_LOCALS_DUPLICATE_DECLARATION_ERROR")) {
       this.addOffense(
-        "Missing space after `locals:`. Rails Strict Locals require a space after the colon: `<%# locals: (...) %>`.",
+        "Duplicate strict locals declaration. Rails only uses the first `<%# locals: (...) %>` declaration in a partial.",
         node.location
       )
     }
+
+    const content = node.content?.value ?? ""
+    const afterLocals = content.trim().slice(LOCALS_PREFIX.length)
+
+    if (afterLocals.length > 0 && !/^\s/.test(afterLocals)) {
+      this.addOffense(
+        "Missing space after `locals:`. Rails Strict Locals require a space after the colon: `<%# locals: (...) %>`.",
+        node.location,
+        this.contextFor(node, { type: "space-after-colon" })
+      )
+    }
+
+    if (hasError(node, "STRICT_LOCALS_MISSING_PARENTHESIS_ERROR")) {
+      const parameters = afterLocals.trim()
+
+      this.addOffense(
+        parameters.length === 0
+          ? "Strict locals declarations always need parentheses. Use `<%# locals: () %>` for a partial without locals."
+          : `Strict locals parameters must be wrapped in parentheses. Use \`<%# locals: ${suggestedParameters(parameters)} %>\`.`,
+        node.location,
+        this.contextFor(node, { type: "wrap-parameters" })
+      )
+
+      return
+    }
+
+    if (this.reportSyntaxErrors(node, content)) return
+
+    this.reportArgumentErrors(node)
   }
 
   visitERBContentNode(node: ERBContentNode): void {
     const openingTag = node.tag_opening?.value
-    const content = node.content?.value
 
+    const content = node.content?.value
     if (!content) return
 
     if (openingTag === "<%" || openingTag === "<%-") {
@@ -69,7 +348,8 @@ class ERBStrictLocalsCommentSyntaxVisitor extends BaseRuleVisitor {
       if (rubyComment && looksLikeLocalsDeclaration(rubyComment)) {
         this.addOffense(
           `Use \`<%#\` instead of \`${openingTag} #\` for strict locals comments. Only ERB comment syntax is recognized by Rails.`,
-          node.location
+          node.location,
+          this.contextFor(node, { type: "erb-comment-tag" })
         )
       }
 
@@ -84,34 +364,118 @@ class ERBStrictLocalsCommentSyntaxVisitor extends BaseRuleVisitor {
     if (!remainder || !/[(:)]/.test(remainder)) return
 
     if (detectSingularLocal(commentContent)) {
-      this.addOffense("Use `locals:` (plural), not `local:`.", node.location)
+      this.addOffense(
+        "Use `locals:` (plural), not `local:`.",
+        node.location,
+        this.contextFor(node, { type: "plural-locals" })
+      )
+
       return
     }
 
     if (detectLocalsWithoutColon(commentContent)) {
       this.addOffense(
         "Use `locals:` with a colon, not `locals()`. Correct format: `<%# locals: (...) %>`.",
-        node.location
+        node.location,
+        this.contextFor(node, { type: "colon-after-locals" })
       )
+
       return
     }
 
     if (detectMissingColonBeforeParens(commentContent)) {
       this.addOffense(
         "Use `locals:` with a colon before the parentheses, not `locals (`.",
-        node.location
+        node.location,
+        this.contextFor(node, { type: "colon-after-locals" })
       )
+
       return
+    }
+  }
+
+  private reportSyntaxErrors(node: ERBStrictLocalsNode, content: string): boolean {
+    const syntaxErrors = node.errors.filter(error => error.type === "RUBY_PARSE_ERROR")
+    if (syntaxErrors.length === 0) return false
+
+    const parameters = findParameters(content)
+
+    if (parameters && parameters.close === null) {
+      this.addOffense(
+        "Unbalanced parentheses in the strict locals declaration. Add the missing closing `)`.",
+        node.location,
+        this.contextFor(node, { type: "close-parameters" })
+      )
+
+      return true
+    }
+
+    if (parameters && removeExtraCommas(content, parameters) !== null) {
+      this.addOffense(
+        "Remove the extra comma from the strict locals parameters.",
+        node.location,
+        this.contextFor(node, { type: "remove-extra-commas" })
+      )
+
+      return true
+    }
+
+    this.addOffense(
+      `Invalid Ruby syntax in the strict locals declaration: ${syntaxErrors[0].error_message}.`,
+      node.location
+    )
+
+    return true
+  }
+
+  private reportArgumentErrors(node: ERBStrictLocalsNode): void {
+    for (const local of node.locals) {
+      if (!isRubyParameterNode(local)) continue
+
+      const name = local.name?.value ?? ""
+
+      for (const error of local.errors) {
+        if (error.type === "STRICT_LOCALS_POSITIONAL_ARGUMENT_ERROR") {
+          this.addOffense(
+            `Strict locals only support keyword arguments. Use \`${name}:\` instead of the positional argument \`${name}\`.`,
+            local.location,
+            this.contextFor(node, { type: "keyword-argument", name })
+          )
+        } else if (error.type === "STRICT_LOCALS_SPLAT_ARGUMENT_ERROR") {
+          this.addOffense(
+            `Strict locals only support keyword arguments. The splat argument \`*${name}\` is not supported. Use \`**${name}\` to accept arbitrary keyword arguments.`,
+            local.location
+          )
+        } else if (error.type === "STRICT_LOCALS_BLOCK_ARGUMENT_ERROR") {
+          this.addOffense(
+            `Strict locals only support keyword arguments. The block argument \`&${name}\` is not supported.`,
+            local.location
+          )
+        }
+      }
+    }
+  }
+
+  private contextFor(node: StrictLocalsCommentNode, fix: StrictLocalsFix): ERBStrictLocalsCommentSyntaxAutofixContext {
+    return {
+      node: node as Mutable<StrictLocalsCommentNode>,
+      nodeType: "AST_ERB_CONTENT_NODE",
+      fix
     }
   }
 }
 
-export class ERBStrictLocalsCommentSyntaxRule extends ParserRule {
+export class ERBStrictLocalsCommentSyntaxRule extends ParserRule<ERBStrictLocalsCommentSyntaxAutofixContext> {
+  static autocorrectable = true
+  static autofixRequiresContext = true
+  static consumesParserErrors = true
   static ruleName = "erb-strict-locals-comment-syntax"
   static introducedIn = this.version("0.8.8")
 
   get parserOptions() {
-    return { strict_locals: true }
+    return {
+      strict_locals: true
+    }
   }
 
   get defaultConfig(): FullRuleConfig {
@@ -121,11 +485,19 @@ export class ERBStrictLocalsCommentSyntaxRule extends ParserRule {
     }
   }
 
-  check(result: ParseResult, context?: Partial<LintContext>): UnboundLintOffense[] {
+  check(result: ParseResult, context?: Partial<LintContext>): UnboundLintOffense<ERBStrictLocalsCommentSyntaxAutofixContext>[] {
     const visitor = new ERBStrictLocalsCommentSyntaxVisitor(this.ruleName, context)
 
     visitor.visit(result.value)
 
     return visitor.offenses
+  }
+
+  autofix(offense: LintOffense<ERBStrictLocalsCommentSyntaxAutofixContext>, result: ParseResult): ParseResult | null {
+    if (!offense.autofixContext) return null
+
+    const { node, fix } = offense.autofixContext
+
+    return applyFix(node, fix) ? result : null
   }
 }

--- a/javascript/packages/linter/src/rules/erb-strict-locals-comment-syntax.ts
+++ b/javascript/packages/linter/src/rules/erb-strict-locals-comment-syntax.ts
@@ -241,7 +241,7 @@ function applyFix(node: Mutable<StrictLocalsCommentNode>, fix: StrictLocalsFix):
 
       const head = content.slice(0, index + LOCALS_PREFIX.length)
       const rest = content.slice(index + LOCALS_PREFIX.length)
-      const trailing = rest.match(/\s*$/)?.[0] ?? ""
+      const trailing = rest.slice(rest.trimEnd().length)
 
       node.content.value = `${head} ${suggestedParameters(rest.trim())}${trailing}`
 
@@ -395,7 +395,7 @@ class ERBStrictLocalsCommentSyntaxVisitor extends BaseRuleVisitor<ERBStrictLocal
   }
 
   private reportSyntaxErrors(node: ERBStrictLocalsNode, content: string): boolean {
-    const syntaxErrors = node.errors.filter(error => error.type === "RUBY_PARSE_ERROR")
+    const syntaxErrors = node.errors.filter((error): error is RubyParseError => error.type === "RUBY_PARSE_ERROR")
     if (syntaxErrors.length === 0) return false
 
     const parameters = findParameters(content)

--- a/javascript/packages/linter/test/autofix/erb-strict-locals-comment-syntax.autofix.test.ts
+++ b/javascript/packages/linter/test/autofix/erb-strict-locals-comment-syntax.autofix.test.ts
@@ -1,0 +1,121 @@
+import { describe, test, expect, beforeAll } from "vitest"
+import dedent from "dedent"
+import { Herb } from "@herb-tools/node-wasm"
+import { Linter } from "../../src/linter.js"
+import { ERBStrictLocalsCommentSyntaxRule } from "../../src/rules/erb-strict-locals-comment-syntax.js"
+
+describe("erb-strict-locals-comment-syntax autofix", () => {
+  beforeAll(async () => {
+    await Herb.load()
+  })
+
+  const autofix = (input: string) => {
+    const linter = new Linter(Herb, [ERBStrictLocalsCommentSyntaxRule])
+
+    return linter.autofix(input, { fileName: "_partial.html.erb" })
+  }
+
+  const expectFix = (input: string, expected: string, count: number = 1) => {
+    const result = autofix(input)
+
+    expect(result.source).toBe(expected)
+    expect(result.fixed).toHaveLength(count)
+    expect(result.unfixed).toHaveLength(0)
+  }
+
+  const expectNoFix = (input: string) => {
+    const result = autofix(input)
+
+    expect(result.source).toBe(input)
+    expect(result.fixed).toHaveLength(0)
+  }
+
+  test("adds the missing colon after locals", () => {
+    expectFix(`<%# locals() %>`, `<%# locals: () %>`)
+    expectFix(`<%# locals(user:) %>`, `<%# locals: (user:) %>`)
+  })
+
+  test("pluralizes local:", () => {
+    expectFix(`<%# local: (user:) %>`, `<%# locals: (user:) %>`)
+  })
+
+  test("adds the missing colon before the parentheses", () => {
+    expectFix(`<%# locals (user:) %>`, `<%# locals: (user:) %>`)
+  })
+
+  test("adds the missing space after the colon", () => {
+    expectFix(`<%# locals:() %>`, `<%# locals: () %>`)
+    expectFix(`<%# locals:(user:, admin: false) %>`, `<%# locals: (user:, admin: false) %>`)
+  })
+
+  test("switches the Ruby comment to an ERB comment", () => {
+    expectFix(`<% # locals: (user:) %>`, `<%# locals: (user:) %>`)
+    expectFix(`<%- # locals: (user:) %>`, `<%# locals: (user:) %>`)
+  })
+
+  test("wraps parameters in parentheses", () => {
+    expectFix(`<%# locals: user:, admin: false %>`, `<%# locals: (user:, admin: false) %>`)
+  })
+
+  test("wraps parameters in parentheses and turns bare names into keyword arguments", () => {
+    expectFix(`<%# locals: user %>`, `<%# locals: (user:) %>`)
+  })
+
+  test("adds parentheses to an empty declaration", () => {
+    expectFix(`<%# locals: %>`, `<%# locals: () %>`)
+  })
+
+  test("closes unbalanced parentheses", () => {
+    expectFix(`<%# locals: (user: %>`, `<%# locals: (user:) %>`)
+  })
+
+  test("turns positional arguments into keyword arguments", () => {
+    expectFix(`<%# locals: (user) %>`, `<%# locals: (user:) %>`)
+    expectFix(`<%# locals: (user, admin) %>`, `<%# locals: (user:, admin:) %>`, 2)
+    expectFix(`<%# locals: (user, admin: false) %>`, `<%# locals: (user:, admin: false) %>`)
+  })
+
+  test("removes a trailing comma", () => {
+    expectFix(`<%# locals: (user:,) %>`, `<%# locals: (user:) %>`)
+  })
+
+  test("removes a leading comma", () => {
+    expectFix(`<%# locals: (, user:) %>`, `<%# locals: (user:) %>`)
+  })
+
+  test("removes a double comma", () => {
+    expectFix(`<%# locals: (user:,, admin:) %>`, `<%# locals: (user:, admin:) %>`)
+  })
+
+  test("combines the missing space and the missing parentheses", () => {
+    expectFix(`<%# locals:user %>`, `<%# locals: (user:) %>`, 2)
+  })
+
+  test("keeps the surrounding template intact", () => {
+    expectFix(dedent`
+      <%# locals: (user) %>
+
+      <p><%= user.name %></p>
+    `, dedent`
+      <%# locals: (user:) %>
+
+      <p><%= user.name %></p>
+    `)
+  })
+
+  test("does not fix block arguments", () => {
+    expectNoFix(`<%# locals: (&block) %>`)
+  })
+
+  test("does not fix splat arguments", () => {
+    expectNoFix(`<%# locals: (*args) %>`)
+  })
+
+  test("does not fix duplicate declarations", () => {
+    expectNoFix(dedent`
+      <%# locals: (user:) %>
+
+      <%# locals: (admin:) %>
+    `)
+  })
+})

--- a/javascript/packages/linter/test/rules/erb-strict-locals-comment-syntax.test.ts
+++ b/javascript/packages/linter/test/rules/erb-strict-locals-comment-syntax.test.ts
@@ -94,6 +94,83 @@ describe("ERBStrictLocalsCommentSyntaxRule", () => {
     `)
   })
 
+  test("flags parameters that are not wrapped in parentheses", () => {
+    expectError("Strict locals parameters must be wrapped in parentheses. Use `<%# locals: (user:) %>`.")
+
+    assertOffenses(`<%# locals: user %>`)
+  })
+
+  test("flags parameters without parentheses and keeps the keyword arguments in the suggestion", () => {
+    expectError("Strict locals parameters must be wrapped in parentheses. Use `<%# locals: (user:, admin: false) %>`.")
+
+    assertOffenses(`<%# locals: user:, admin: false %>`)
+  })
+
+  test("flags an empty declaration without parentheses", () => {
+    expectError("Strict locals declarations always need parentheses. Use `<%# locals: () %>` for a partial without locals.")
+
+    assertOffenses(`<%# locals: %>`)
+  })
+
+  test("flags unbalanced parentheses", () => {
+    expectError("Unbalanced parentheses in the strict locals declaration. Add the missing closing `)`.")
+
+    assertOffenses(`<%# locals: (user: %>`)
+  })
+
+  test("flags positional arguments", () => {
+    expectError("Strict locals only support keyword arguments. Use `user:` instead of the positional argument `user`.")
+
+    assertOffenses(`<%# locals: (user) %>`)
+  })
+
+  test("flags every positional argument", () => {
+    expectError("Strict locals only support keyword arguments. Use `user:` instead of the positional argument `user`.")
+    expectError("Strict locals only support keyword arguments. Use `admin:` instead of the positional argument `admin`.")
+
+    assertOffenses(`<%# locals: (user, admin) %>`)
+  })
+
+  test("flags block arguments", () => {
+    expectError("Strict locals only support keyword arguments. The block argument `&block` is not supported.")
+
+    assertOffenses(`<%# locals: (&block) %>`)
+  })
+
+  test("flags splat arguments", () => {
+    expectError("Strict locals only support keyword arguments. The splat argument `*args` is not supported. Use `**args` to accept arbitrary keyword arguments.")
+
+    assertOffenses(`<%# locals: (*args) %>`)
+  })
+
+  test("flags a trailing comma", () => {
+    expectError("Remove the extra comma from the strict locals parameters.")
+
+    assertOffenses(`<%# locals: (user:,) %>`)
+  })
+
+  test("flags a leading comma", () => {
+    expectError("Remove the extra comma from the strict locals parameters.")
+
+    assertOffenses(`<%# locals: (, user:) %>`)
+  })
+
+  test("flags a double comma", () => {
+    expectError("Remove the extra comma from the strict locals parameters.")
+
+    assertOffenses(`<%# locals: (user:,, admin:) %>`)
+  })
+
+  test("flags duplicate declarations", () => {
+    expectError("Duplicate strict locals declaration. Rails only uses the first `<%# locals: (...) %>` declaration in a partial.")
+
+    assertOffenses(dedent`
+      <%# locals: (user:) %>
+      <p>Content</p>
+      <%# locals: (admin:) %>
+    `)
+  })
+
   test("flags Ruby comment syntax for strict locals in execution tags", () => {
     expectError("Use `<%#` instead of `<% #` for strict locals comments. Only ERB comment syntax is recognized by Rails.")
     expectError("Use `<%#` instead of `<%- #` for strict locals comments. Only ERB comment syntax is recognized by Rails.")


### PR DESCRIPTION
This pull request fixes `erb-strict-locals-comment-syntax` so it actually reports every invalid form its documentation lists, and adds autofix for the ones that have exactly one sensible correction.

Most of the "Bad" examples on the rule's docs page linted completely clean:

```erb
<%# locals: user %>
<%# locals: %>
<%# locals: (user: %>
<%# locals: (user) %>
<%# locals: (*args) %>
<%# locals: (&block) %>
<%# locals: (user:,) %>
<%# locals: (, user:) %>
<%# locals: (user:,, admin:) %>
```

The rule now sets `consumesParserErrors` and translates the parser's errors into rule-specific messages instead of bailing out, covering missing parentheses, unbalanced parentheses, extra commas, positional, splat and block arguments, and duplicate declarations. 
