### PR TITLE
Linter: Point strict locals offenses at the declaration they violate

### DIFF
--- a/javascript/packages/core/src/action-view-partial-callers.ts
+++ b/javascript/packages/core/src/action-view-partial-callers.ts
@@ -1,6 +1,6 @@
 import type { StrictLocal } from "./action-view-partial-index.js"
 
-export type CallSiteKind = "render" | "layout"
+export type CallSiteKind = "render" | "layout" | "declaration"
 
 export interface CallSiteLocation {
   line: number
@@ -47,10 +47,11 @@ export interface SerializedPartialCallerIndex {
 }
 
 export const MAX_ANCESTOR_CHAINS = 32
-export const EMPTY_CHAIN: AncestorChain = Object.freeze({ tags: Object.freeze([]) as string[], frames: Object.freeze([]) as CallFrame[], occurrences: 1 })
 
-const UNRESOLVED: PartialContext = Object.freeze({ chains: Object.freeze([]) as AncestorChain[], resolved: false })
-const DOCUMENT_ROOT: PartialContext = Object.freeze({ chains: Object.freeze([EMPTY_CHAIN]) as AncestorChain[], resolved: true })
+export const EMPTY_CHAIN: AncestorChain = Object.freeze({ tags: [], frames: [], occurrences: 1 })
+
+const UNRESOLVED: PartialContext = Object.freeze({ chains: [], resolved: false })
+const DOCUMENT_ROOT: PartialContext = Object.freeze({ chains: [EMPTY_CHAIN], resolved: true })
 
 export class PartialCallerIndex {
   readonly unresolvedRenders: number

--- a/javascript/packages/core/src/action-view-partial-index.ts
+++ b/javascript/packages/core/src/action-view-partial-index.ts
@@ -3,6 +3,7 @@ import { PARTIAL_EXTENSIONS, partialNameForFile, resolvePartial } from "./action
 
 import type { DocumentNode } from "./nodes.js"
 import type { PartialPaths } from "./action-view-partial-resolution.js"
+import type { CallSiteLocation } from "./action-view-partial-callers.js"
 
 const KEYWORD_KIND = "keyword"
 const KEYWORD_REST_KIND = "keyword_rest"
@@ -18,6 +19,7 @@ export interface PartialDeclaration {
   hasDeclaration: boolean
   hasKeywordRest: boolean
   locals: StrictLocal[]
+  location?: CallSiteLocation
 }
 
 export interface SerializedPartialIndex {
@@ -49,6 +51,12 @@ export function outranksTemplate(candidate: string, incumbent: string): boolean 
 
 export const STRICT_LOCALS_MARKER = "locals"
 
+function locationOf(node: { location?: { start?: { line: number, column: number } } }): CallSiteLocation | undefined {
+  const start = node.location?.start
+
+  return start ? { line: start.line, column: start.column } : undefined
+}
+
 export function declarationWithoutStrictLocals(file: string): PartialDeclaration {
   return { file, hasDeclaration: false, hasKeywordRest: false, locals: [] }
 }
@@ -60,6 +68,7 @@ export function declarationFromDocument(document: DocumentNode, file: string): P
     if (!isERBStrictLocalsNode(child)) continue
 
     declaration.hasDeclaration = true
+    declaration.location = declaration.location ?? locationOf(child)
 
     for (const local of child.locals) {
       if (!isRubyParameterNode(local)) continue

--- a/javascript/packages/core/test/action-view-partial-index.test.ts
+++ b/javascript/packages/core/test/action-view-partial-index.test.ts
@@ -194,7 +194,20 @@ describe("declarationFromDocument", () => {
       hasDeclaration: true,
       hasKeywordRest: false,
       locals: [{ name: "user", required: true }, { name: "size", required: false }],
+      location: { line: 1, column: 0 },
     })
+  })
+
+  test("records where the declaration sits", () => {
+    const result = Herb.parse(`\n<%# locals: (user:) %>\n`, { strict_locals: true })
+
+    expect(declarationFromDocument(result.value, "app/views/users/_card.html.erb").location).toEqual({ line: 2, column: 0 })
+  })
+
+  test("leaves the location unset without a declaration", () => {
+    const result = Herb.parse(`<h1>hi</h1>\n`, { strict_locals: true })
+
+    expect(declarationFromDocument(result.value, "app/views/users/_card.html.erb").location).toBeUndefined()
   })
 
   test("records a keyword rest separately from the locals", () => {

--- a/javascript/packages/linter/src/cli/formatters/detailed-formatter.ts
+++ b/javascript/packages/linter/src/cli/formatters/detailed-formatter.ts
@@ -15,6 +15,12 @@ import type { ThemeInput } from "@herb-tools/highlighter"
 
 import { DEFAULT_THEME } from "@herb-tools/highlighter"
 
+const FRAME_VERBS: Record<string, string> = {
+  render: "rendered from",
+  layout: "rendered into",
+  declaration: "declared at",
+}
+
 export class DetailedFormatter extends BaseFormatter {
   private highlighter: Highlighter | null = null
   private theme: ThemeInput
@@ -61,7 +67,7 @@ ${colorize("        Tip: run with ", "gray")}${colorize("--show-fix-diff", "bold
     for (const frame of [...renderedFrom.frames].reverse()) {
       if (!frame.location) continue
 
-      const verb = frame.via === "layout" ? "rendered into" : "rendered from"
+      const verb = FRAME_VERBS[frame.via] ?? FRAME_VERBS.render
       const nesting = frame.ancestors.length > 0 ? colorize(`  ${frame.ancestors.map(tag => `<${tag}>`).join(" › ")}`, "gray") : ""
       const label = `${frame.file}:${frame.location.line}:${frame.location.column}`
       const target = colorize(hyperlink(label, fileUrl(this.absolutePath(frame.file))), "cyan")

--- a/javascript/packages/linter/src/rules/actionview-no-strict-locals-error.ts
+++ b/javascript/packages/linter/src/rules/actionview-no-strict-locals-error.ts
@@ -45,9 +45,10 @@ class ActionViewNoStrictLocalsErrorVisitor extends BaseRuleVisitor {
 
     const names = missing.map(local => `\`${local.name}:\``)
 
-    this.addOffense(
+    this.addOffenseWithChain(
       `The partial \`${partialName}\` requires the ${this.list(names)} local${missing.length === 1 ? "" : "s"} to be passed. Rails raises an \`ActionView::StrictLocalsError\` when a required local is missing, so add ${missing.length === 1 ? "it" : "them"} to this \`render\` call.`,
       node.keywords!.partial!.location,
+      this.declarationChain(declaration),
     )
   }
 
@@ -61,9 +62,10 @@ class ActionViewNoStrictLocalsErrorVisitor extends BaseRuleVisitor {
 
       if (declared.has(name)) continue
 
-      this.addOffense(
+      this.addOffenseWithChain(
         `The partial \`${partialName}\` does not declare the \`${name}:\` local. Rails raises an \`ActionView::StrictLocalsError\` when a caller passes an undeclared local, so remove it from this \`render\` call, or add it to the partial's \`<%# locals: () %>\` declaration.`,
         local.name!.location,
+        this.declarationChain(declaration),
       )
     }
   }

--- a/javascript/packages/linter/src/rules/rule-utils.ts
+++ b/javascript/packages/linter/src/rules/rule-utils.ts
@@ -22,6 +22,7 @@ import {
 
 import type {
   AncestorChain,
+  PartialDeclaration,
   AncestorVerdict,
   ERBOpenTagNode,
   HTMLAttributeNameNode,
@@ -97,6 +98,31 @@ export abstract class BaseRuleVisitor<TAutofixContext extends BaseAutofixContext
    */
   protected addOffense(message: string, location: Location, autofixContext?: TAutofixContext, severity?: LintSeverity, tags?: DiagnosticTag[]): void {
     this.offenses.push(this.createOffense(message, location, autofixContext, severity, tags))
+  }
+
+  /**
+   * Like `addOffense`, but records the frames that explain the offense, so a
+   * formatter can show why it applies. A chain with no frames is dropped, since
+   * there would be nothing to render.
+   */
+  protected addOffenseWithChain(message: string, location: Location, chain: AncestorChain | null, autofixContext?: TAutofixContext, severity?: LintSeverity, tags?: DiagnosticTag[]): void {
+    const offense = this.createOffense(message, location, autofixContext, severity, tags)
+
+    this.offenses.push(chain && chain.frames.length > 0 ? { ...offense, renderedFrom: chain } : offense)
+  }
+
+  /**
+   * A single frame pointing at a partial's `locals:` declaration, for offenses
+   * that are an argument about a declaration in another file.
+   */
+  protected declarationChain(declaration: PartialDeclaration): AncestorChain | null {
+    if (!declaration.location) return null
+
+    return {
+      tags: [],
+      occurrences: 1,
+      frames: [{ file: declaration.file, ancestors: [], via: "declaration", location: declaration.location }],
+    }
   }
 
   /**
@@ -378,9 +404,7 @@ export abstract class ElementStackVisitor<TAutofixContext extends BaseAutofixCon
    * whole document and a `content_for` body both are.
    */
   protected addOffenseWithCallChain(message: string, location: Location, chain: AncestorChain | null = this.renderedContext.chains[0] ?? null, autofixContext?: TAutofixContext, severity?: LintSeverity, tags?: DiagnosticTag[]): void {
-    const offense = this.createOffense(message, location, autofixContext, severity, tags)
-
-    this.offenses.push(chain && chain.frames.length > 0 ? { ...offense, renderedFrom: chain } : offense)
+    this.addOffenseWithChain(message, location, chain, autofixContext, severity, tags)
   }
 
   /**

--- a/javascript/packages/linter/test/__snapshots__/cli-call-chain.test.ts.snap
+++ b/javascript/packages/linter/test/__snapshots__/cli-call-chain.test.ts.snap
@@ -1,0 +1,262 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`CLI call chain output > labels every path in the output project relative 1`] = `
+"[error] Element \`<style>\` must be placed inside the \`<head>\` tag. (html-head-only-elements)
+
+app/views/posts/_card.html.erb:2:2
+
+      1 │ <div>
+  →   2 │   <style>.card {}</style>
+        │   ~~~~~~~~~~~~~~~~~~~~~~~
+      3 │ </div>
+      4 │
+
+
+        rendered from app/views/posts/index.html.erb:2:2  <section>
+          →   2 │   <%= render "posts/card" %>
+
+        rendered into app/views/layouts/application.html.erb:7:10  <html> › <body> › <main>
+          →   7 │     <main><%= yield %></main>
+
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯  [1/1] ⎯⎯⎯⎯
+
+
+
+ Rule offenses:
+  html-head-only-elements (1 offense in 1 file)
+
+
+ Summary:
+  Checked      3 files
+  Files        1 with offenses | 2 clean (3 total)
+  Offenses     1 error (1 offense across 1 file)
+  Fixable      0 offenses
+  Rules        1 enabled | filtered by --only
+
+ TIP: Run herb-lint --init to create a .herb.yml and lock the version.
+      This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml.
+Found 3 files, linting..."
+`;
+
+exports[`CLI call chain output > points a missing strict local at the declaration it violates 1`] = `
+"[error] The partial \`posts/card\` requires the \`title:\` local to be passed. Rails raises an \`ActionView::StrictLocalsError\` when a required local is missing, so add it to this \`render\` call. (actionview-no-strict-locals-error)
+
+app/views/posts/index.html.erb:4:13
+
+      2 │ 
+      3 │ <section class="list">
+  →   4 │   <%= render "posts/card" %>
+        │              ~~~~~~~~~~~~
+      5 │ </section>
+      6 │
+
+
+        declared at app/views/posts/_card.html.erb:1:0
+          →   1 │ <%# locals: (title:) %>
+
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯  [1/1] ⎯⎯⎯⎯
+
+
+
+ Rule offenses:
+  actionview-no-strict-locals-error (1 offense in 1 file)
+
+
+ Summary:
+  Checked      3 files
+  Files        1 with offenses | 2 clean (3 total)
+  Offenses     1 error (1 offense across 1 file)
+  Fixable      0 offenses
+  Rules        1 enabled | filtered by --only
+
+ TIP: Run herb-lint --init to create a .herb.yml and lock the version.
+      This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml.
+Found 3 files, linting..."
+`;
+
+exports[`CLI call chain output > points an undeclared strict local at the declaration too 1`] = `
+"[error] The partial \`posts/card\` does not declare the \`extra:\` local. Rails raises an \`ActionView::StrictLocalsError\` when a caller passes an undeclared local, so remove it from this \`render\` call, or add it to the partial's \`<%# locals: () %>\` declaration. (actionview-no-strict-locals-error)
+
+app/views/posts/index.html.erb:1:38
+
+  →   1 │ <%= render "posts/card", title: "Hi", extra: true %>
+        │                                       ~~~~~~
+      2 │
+
+
+        declared at app/views/posts/_card.html.erb:1:0
+          →   1 │ <%# locals: (title:) %>
+
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯  [1/1] ⎯⎯⎯⎯
+
+
+
+ Rule offenses:
+  actionview-no-strict-locals-error (1 offense in 1 file)
+
+
+ Summary:
+  Checked      3 files
+  Files        1 with offenses | 2 clean (3 total)
+  Offenses     1 error (1 offense across 1 file)
+  Fixable      0 offenses
+  Rules        1 enabled | filtered by --only
+
+ TIP: Run herb-lint --init to create a .herb.yml and lock the version.
+      This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml.
+Found 3 files, linting..."
+`;
+
+exports[`CLI call chain output > prints no call chain for an offense the file explains on its own 1`] = `
+"[error] Element \`<style>\` must be placed inside the \`<head>\` tag. (html-head-only-elements)
+
+app/views/layouts/application.html.erb:3:4
+
+      1 │ <html>
+      2 │   <body>
+  →   3 │     <style>.x {}</style>
+        │     ~~~~~~~~~~~~~~~~~~~~
+      4 │   </body>
+      5 │ </html>
+
+
+
+ Rule offenses:
+  html-head-only-elements (1 offense in 1 file)
+
+
+ Summary:
+  Checked      1 file
+  Offenses     1 error (1 offense across 1 file)
+  Fixable      0 offenses
+  Rules        1 enabled | filtered by --only
+
+ TIP: Run herb-lint --init to create a .herb.yml and lock the version.
+      This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
+`;
+
+exports[`CLI call chain output > prints no frame for a partial without a strict locals declaration 1`] = `
+"Summary:
+  Checked      3 files
+  Files        3 clean (3 total)
+  Offenses     0 offenses
+  Fixable      0 offenses
+  Rules        1 enabled | filtered by --only
+
+ ✓ All files are clean!
+
+ TIP: Run herb-lint --init to create a .herb.yml and lock the version.
+      This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml."
+`;
+
+exports[`CLI call chain output > prints the call chain under a cross-file offense 1`] = `
+"[error] Element \`<style>\` must be placed inside the \`<head>\` tag. (html-head-only-elements)
+
+app/views/posts/_card.html.erb:2:2
+
+      1 │ <div class="card">
+  →   2 │   <style>.card { color: red }</style>
+        │   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      3 │ </div>
+      4 │
+
+
+        rendered from app/views/posts/index.html.erb:2:2  <section>
+          →   2 │   <%= render "posts/card" %>
+
+        rendered into app/views/layouts/application.html.erb:7:10  <html> › <body> › <main>
+          →   7 │     <main><%= yield %></main>
+
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯  [1/1] ⎯⎯⎯⎯
+
+
+
+ Rule offenses:
+  html-head-only-elements (1 offense in 1 file)
+
+
+ Summary:
+  Checked      3 files
+  Files        1 with offenses | 2 clean (3 total)
+  Offenses     1 error (1 offense across 1 file)
+  Fixable      0 offenses
+  Rules        1 enabled | filtered by --only
+
+ TIP: Run herb-lint --init to create a .herb.yml and lock the version.
+      This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml.
+Found 3 files, linting..."
+`;
+
+exports[`CLI call chain output > reports a partial rendered into both the head and the body 1`] = `
+"[error] Element \`<style>\` must be placed inside the \`<head>\` tag. At least one call site renders this file inside the \`<body>\`. (html-head-only-elements)
+
+app/views/posts/_card.html.erb:2:2
+
+      1 │ <div class="card">
+  →   2 │   <style>.card { color: red }</style>
+        │   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      3 │ </div>
+      4 │
+
+
+        rendered from app/views/posts/index.html.erb:3:2  <section>
+          →   3 │   <%= render "posts/card" %>
+
+        rendered into app/views/layouts/application.html.erb:8:10  <html> › <body> › <main>
+          →   8 │     <main><%= yield %></main>
+
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯  [1/1] ⎯⎯⎯⎯
+
+
+
+ Rule offenses:
+  html-head-only-elements (1 offense in 1 file)
+
+
+ Summary:
+  Checked      3 files
+  Files        1 with offenses | 2 clean (3 total)
+  Offenses     1 error (1 offense across 1 file)
+  Fixable      0 offenses
+  Rules        1 enabled | filtered by --only
+
+ TIP: Run herb-lint --init to create a .herb.yml and lock the version.
+      This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml.
+Found 3 files, linting..."
+`;
+
+exports[`CLI call chain output > reports the offending call site when only one call site nests the file 1`] = `
+"[error] Nested \`<a>\` elements are not allowed. At least one call site renders this file inside an \`<a>\` element. (html-no-nested-links)
+
+app/views/posts/_badge.html.erb:1:1
+
+  →   1 │ <a href="/inner">Inner</a>
+        │  ~
+      2 │
+
+
+        rendered from app/views/posts/show.html.erb:2:2  <a>
+          →   2 │   <%= render "posts/badge" %>
+
+        rendered into app/views/layouts/application.html.erb:7:10  <html> › <body> › <main>
+          →   7 │     <main><%= yield %></main>
+
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯  [1/1] ⎯⎯⎯⎯
+
+
+
+ Rule offenses:
+  html-no-nested-links (1 offense in 1 file)
+
+
+ Summary:
+  Checked      4 files
+  Files        1 with offenses | 3 clean (4 total)
+  Offenses     1 error (1 offense across 1 file)
+  Fixable      0 offenses
+  Rules        1 enabled | filtered by --only
+
+ TIP: Run herb-lint --init to create a .herb.yml and lock the version.
+      This ensures upgrading Herb won't enable new rules until you update the version in .herb.yml.
+Found 4 files, linting..."
+`;

--- a/javascript/packages/linter/test/cli-call-chain.test.ts
+++ b/javascript/packages/linter/test/cli-call-chain.test.ts
@@ -66,14 +66,8 @@ describe("CLI call chain output", () => {
 
     const { output, exitCode } = runLinterIn(root, "--only", "html-head-only-elements")
 
+    expect(output).toMatchSnapshot()
     expect(exitCode).toBe(1)
-    expect(output).toContain("Element `<style>` must be placed inside the `<head>` tag.")
-
-    expect(output).toContain("rendered from app/views/posts/index.html.erb:2:2")
-    expect(output).toContain(`<%= render "posts/card" %>`)
-
-    expect(output).toContain("rendered into app/views/layouts/application.html.erb:7:10")
-    expect(output).toContain("<main><%= yield %></main>")
   })
 
   test("labels every path in the output project relative", () => {
@@ -85,21 +79,8 @@ describe("CLI call chain output", () => {
 
     const { output } = runLinterIn(root, "--only", "html-head-only-elements")
 
-    expect(output).toContain("app/views/posts/_card.html.erb:2:2")
+    expect(output).toMatchSnapshot()
     expect(output).not.toContain(root)
-  })
-
-  test("names the elements each call site nests the file inside", () => {
-    const root = project({
-      "app/views/layouts/application.html.erb": LAYOUT,
-      "app/views/posts/index.html.erb": `<section>\n  <%= render "posts/card" %>\n</section>\n`,
-      "app/views/posts/_card.html.erb": `<div>\n  <style>.card {}</style>\n</div>\n`,
-    })
-
-    const { output } = runLinterIn(root, "--only", "html-head-only-elements")
-
-    expect(output).toContain("<section>")
-    expect(output).toContain("<html> › <body> › <main>")
   })
 
   test("prints no call chain for an offense the file explains on its own", () => {
@@ -109,9 +90,7 @@ describe("CLI call chain output", () => {
 
     const { output } = runLinterIn(root, "--only", "html-head-only-elements")
 
-    expect(output).toContain("Element `<style>` must be placed inside the `<head>` tag.")
-    expect(output).not.toContain("rendered from")
-    expect(output).not.toContain("rendered into")
+    expect(output).toMatchSnapshot()
   })
 
   test("reports the offending call site when only one call site nests the file", () => {
@@ -124,11 +103,9 @@ describe("CLI call chain output", () => {
 
     const { output } = runLinterIn(root, "--only", "html-no-nested-links")
 
-    expect(output).toContain("At least one call site renders this file inside an `<a>` element.")
-    expect(output).toContain("rendered from app/views/posts/show.html.erb:2:2")
+    expect(output).toMatchSnapshot()
     expect(output).not.toContain("rendered from app/views/posts/index.html.erb")
   })
-
 
   test("reports a partial rendered into both the head and the body", () => {
     const root = project({
@@ -139,10 +116,44 @@ describe("CLI call chain output", () => {
 
     const { output } = runLinterIn(root, "--only", "html-head-only-elements")
 
-    expect(output).toContain("At least one call site renders this file inside the `<body>`.")
-
-    // The chain has to name the body path, not the innocent <head> call site.
-    expect(output).toContain("rendered from app/views/posts/index.html.erb:3:2")
+    expect(output).toMatchSnapshot()
     expect(output).not.toContain("rendered from app/views/layouts/application.html.erb:4")
+  })
+
+  test("points a missing strict local at the declaration it violates", () => {
+    const root = project({
+      "app/views/layouts/application.html.erb": LAYOUT,
+      "app/views/posts/index.html.erb": `<h1>Posts</h1>\n\n<section class="list">\n  <%= render "posts/card" %>\n</section>\n`,
+      "app/views/posts/_card.html.erb": `<%# locals: (title:) %>\n<h2><%= title %></h2>\n`,
+    })
+
+    const { output } = runLinterIn(root, "--only", "actionview-no-strict-locals-error")
+
+    expect(output).toMatchSnapshot()
+    expect(output).not.toContain("rendered into")
+  })
+
+  test("points an undeclared strict local at the declaration too", () => {
+    const root = project({
+      "app/views/layouts/application.html.erb": LAYOUT,
+      "app/views/posts/index.html.erb": `<%= render "posts/card", title: "Hi", extra: true %>\n`,
+      "app/views/posts/_card.html.erb": `<%# locals: (title:) %>\n<h2><%= title %></h2>\n`,
+    })
+
+    const { output } = runLinterIn(root, "--only", "actionview-no-strict-locals-error")
+
+    expect(output).toMatchSnapshot()
+  })
+
+  test("prints no frame for a partial without a strict locals declaration", () => {
+    const root = project({
+      "app/views/layouts/application.html.erb": LAYOUT,
+      "app/views/posts/index.html.erb": `<%= render "posts/card" %>\n`,
+      "app/views/posts/_card.html.erb": `<h2>Card</h2>\n`,
+    })
+
+    const { output } = runLinterIn(root, "--only", "actionview-no-strict-locals-error")
+
+    expect(output).toMatchSnapshot()
   })
 })

--- a/javascript/packages/linter/test/partial-index-builder.test.ts
+++ b/javascript/packages/linter/test/partial-index-builder.test.ts
@@ -92,6 +92,7 @@ describe("buildPartialIndex", () => {
       hasDeclaration: true,
       hasKeywordRest: false,
       locals: [{ name: "user", required: true }, { name: "size", required: false }],
+      location: { line: 1, column: 0 },
     })
   })
 
@@ -159,6 +160,26 @@ describe("buildPartialIndex", () => {
     expect(index.size).toBe(0)
   })
 })
+
+  test("records where the strict locals declaration sits", async () => {
+    const root = project({
+      "app/views/users/_card.html.erb": `\n<%# locals: (user:) %>\n<h1>hi</h1>\n`,
+    })
+
+    const index = await buildPartialIndex(Herb, root)
+
+    expect(index.lookup("users/card", "app/views/users/index.html.erb")?.location).toEqual({ line: 2, column: 0 })
+  })
+
+  test("leaves the location unset for a partial without a declaration", async () => {
+    const root = project({
+      "app/views/users/_card.html.erb": `<h1>hi</h1>\n`,
+    })
+
+    const index = await buildPartialIndex(Herb, root)
+
+    expect(index.lookup("users/card", "app/views/users/index.html.erb")?.location).toBeUndefined()
+  })
 
 describe("findViewRoot", () => {
   test("prefers app/views when it holds partials", async () => {

--- a/javascript/packages/linter/test/rules/actionview-no-strict-locals-error.test.ts
+++ b/javascript/packages/linter/test/rules/actionview-no-strict-locals-error.test.ts
@@ -1,7 +1,9 @@
 import dedent from "dedent"
-import { describe, test } from "vitest"
+import { beforeAll, describe, expect, test } from "vitest"
 
 import { PartialIndex } from "@herb-tools/core"
+import { Herb } from "@herb-tools/node-wasm"
+import { Linter } from "../../src/linter.js"
 import { ActionViewNoStrictLocalsErrorRule } from "../../src/rules/actionview-no-strict-locals-error.js"
 import { createLinterTest } from "../helpers/linter-test-helper.js"
 
@@ -224,6 +226,48 @@ describe("actionview-no-strict-locals-error", () => {
       expectError("The partial `users/card` requires the `user:` local to be passed. Rails raises an `ActionView::StrictLocalsError` when a required local is missing, so add it to this `render` call.")
 
       assertOffenses(`<%= render "users/card" %>`, absolute)
+    })
+  })
+
+  describe("declaration frames", () => {
+    const located = new PartialIndex("app/views", new Map([
+      ["users/card", { ...declaration("app/views/users/_card.html.erb", [{ name: "user", required: true }]), location: { line: 1, column: 0 } }],
+      ["users/plain", declaration("app/views/users/_plain.html.erb", [{ name: "user", required: true }])],
+    ]))
+
+    const locatedContext = { fileName: "app/views/posts/index.html.erb", partials: located }
+
+    beforeAll(async () => {
+      await Herb.load()
+    })
+
+    function offensesFor(source: string) {
+      const linter = new Linter(Herb, [ActionViewNoStrictLocalsErrorRule])
+
+      return linter.lint(source, locatedContext).offenses
+    }
+
+    test("points a missing local at the declaration it violates", () => {
+      const [offense] = offensesFor(`<%= render "users/card" %>`)
+
+      expect(offense.renderedFrom?.frames).toEqual([
+        { file: "app/views/users/_card.html.erb", ancestors: [], via: "declaration", location: { line: 1, column: 0 } },
+      ])
+    })
+
+    test("points an undeclared local at the declaration too", () => {
+      const [offense] = offensesFor(`<%= render "users/card", user: @user, extra: 1 %>`)
+
+      expect(offense.message).toContain("does not declare the `extra:` local")
+      expect(offense.renderedFrom?.frames[0].file).toBe("app/views/users/_card.html.erb")
+      expect(offense.renderedFrom?.frames[0].via).toBe("declaration")
+    })
+
+    test("omits the frame when the declaration has no recorded location", () => {
+      const [offense] = offensesFor(`<%= render "users/plain" %>`)
+
+      expect(offense.message).toContain("requires the `user:` local")
+      expect(offense.renderedFrom).toBeUndefined()
     })
   })
 })


### PR DESCRIPTION
Follow up on #2095.

This pull request records where a partial's `<%# locals: %>` declaration sits, so a strict locals offense can point at the declaration it violates instead of leaving the reader to go find it.

#2095 gave offenses a call chain, rendered as a stack of frames under the diagnostic. Every frame there answers the same question, "where is this file rendered", which is what the nesting and placement rules need, since the offense sits in a partial and the explanation lives in its callers.

Strict locals is the other way round. The offense already sits on the render call, in the file that has to change.

#### Example output

```
[error] The partial `posts/card` requires the `title:` local to be passed. Rails raises an
`ActionView::StrictLocalsError` when a required local is missing, so add it to this `render` call.
(actionview-no-strict-locals-error)

app/views/posts/index.html.erb:4:13

      3 │ <section class="list">
  →   4 │   <%= render "posts/card" %>
        │              ~~~~~~~~~~~~
      5 │ </section>

        declared at app/views/posts/_card.html.erb:1:0
          →   1 │ <%# locals: (title:) %>
```

<img width="3065" height="1726" alt="CleanShot 2026-08-08 at 20 08 51@2x" src="https://github.com/user-attachments/assets/4b60e6be-a8cf-4d4d-9ff9-64dac14b62cc" />

