### PR TITLE
Tailwind Class Sorter: Make `tailwindcss` peer dependency optional

### DIFF
--- a/javascript/packages/tailwind-class-sorter/package.json
+++ b/javascript/packages/tailwind-class-sorter/package.json
@@ -52,6 +52,11 @@
   "peerDependencies": {
     "tailwindcss": "^3.0 || ^4.0"
   },
+  "peerDependenciesMeta": {
+    "tailwindcss": {
+      "optional": true
+    }
+  },
   "engines": {
     "node": ">=14.21.3"
   }


### PR DESCRIPTION
This means those of us that are not using Tailwind won't have to have `tailwindcss` installed, while those that are using the framework should not have to change anything as they'll very likely already have `tailwindcss` installed for their own use

Ideally I would prefer not having `@herb-tools/tailwind-class-sorter` installed either, but that's a larger change since people would have to explicitly start installing that.

Resolves #1722 (though technically that is already resolved 😄)