### PR TITLE
Language Server: Implement `textDocument/references` for partials

### DIFF
--- a/javascript/packages/core/src/action-view-partial-callers.ts
+++ b/javascript/packages/core/src/action-view-partial-callers.ts
@@ -81,6 +81,44 @@ export class PartialCallerIndex {
     return this.callSites.get(partialFile) ?? []
   }
 
+  replaceCallsFrom(caller: string, sites: Map<string, PartialCallSite[]>): boolean {
+    let changed = false
+
+    for (const [partialFile, callSites] of this.callSites) {
+      const remaining = callSites.filter(callSite => callSite.caller !== caller)
+
+      if (remaining.length === callSites.length) continue
+
+      changed = true
+
+      if (remaining.length > 0) {
+        this.callSites.set(partialFile, remaining)
+      } else {
+        this.callSites.delete(partialFile)
+      }
+    }
+
+    for (const [partialFile, callSites] of sites) {
+      if (callSites.length === 0) continue
+
+      changed = true
+
+      this.callSites.set(partialFile, [...this.callersOf(partialFile), ...callSites])
+    }
+
+    if (changed) this.contexts.clear()
+
+    return changed
+  }
+
+  removeCallsTo(partialFile: string): boolean {
+    if (!this.callSites.delete(partialFile)) return false
+
+    this.contexts.clear()
+
+    return true
+  }
+
   inferSignature(partialFile: string): InferredSignature {
     const callers = this.callersOf(partialFile)
     const names: string[] = []

--- a/javascript/packages/core/src/action-view-partial-resolution.ts
+++ b/javascript/packages/core/src/action-view-partial-resolution.ts
@@ -56,6 +56,12 @@ export function projectRelativePath(filePath: string, projectPath: string | unde
   return relativeToViewRoot(filePath, projectPath) ?? normalize(filePath)
 }
 
+export function isTemplatePath(filePath: string): boolean {
+  const name = basename(normalize(filePath))
+
+  return PARTIAL_EXTENSIONS.some(extension => name.endsWith(extension))
+}
+
 export function isPartialPath(filePath: string): boolean {
   const name = basename(normalize(filePath))
 

--- a/javascript/packages/core/test/action-view-partial-callers.test.ts
+++ b/javascript/packages/core/test/action-view-partial-callers.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from "vitest"
+
+import { PartialCallerIndex } from "../src/action-view-partial-callers.js"
+
+import type { PartialCallSite } from "../src/action-view-partial-callers.js"
+
+const CARD = "app/views/posts/_card.html.erb"
+const BADGE = "app/views/posts/_badge.html.erb"
+const INDEX = "app/views/posts/index.html.erb"
+const SHOW = "app/views/posts/show.html.erb"
+
+function callSite(caller: string, ancestors: string[] = []): PartialCallSite {
+  return { caller, locals: [], ancestors, via: "render" }
+}
+
+function index(callSites: Record<string, PartialCallSite[]>, documentRoots: string[] = []): PartialCallerIndex {
+  return new PartialCallerIndex(new Map(Object.entries(callSites)), new Set(documentRoots), 0, 0)
+}
+
+describe("PartialCallerIndex", () => {
+  describe("replaceCallsFrom", () => {
+    test("drops the call sites the caller previously contributed", () => {
+      const callers = index({ [CARD]: [callSite(INDEX), callSite(SHOW)] })
+
+      expect(callers.replaceCallsFrom(INDEX, new Map())).toBe(true)
+      expect(callers.callersOf(CARD)).toEqual([callSite(SHOW)])
+    })
+
+    test("removes the partial entirely once its last caller goes", () => {
+      const callers = index({ [CARD]: [callSite(INDEX)] })
+
+      expect(callers.replaceCallsFrom(INDEX, new Map())).toBe(true)
+      expect(callers.callersOf(CARD)).toEqual([])
+      expect(callers.size).toBe(0)
+    })
+
+    test("adds the call sites the caller now contributes", () => {
+      const callers = index({ [CARD]: [callSite(SHOW)] })
+
+      callers.replaceCallsFrom(INDEX, new Map([[CARD, [callSite(INDEX)]]]))
+
+      expect(callers.callersOf(CARD)).toEqual([callSite(SHOW), callSite(INDEX)])
+    })
+
+    test("moves a caller from one partial to another", () => {
+      const callers = index({ [CARD]: [callSite(INDEX)] })
+
+      callers.replaceCallsFrom(INDEX, new Map([[BADGE, [callSite(INDEX)]]]))
+
+      expect(callers.callersOf(CARD)).toEqual([])
+      expect(callers.callersOf(BADGE)).toEqual([callSite(INDEX)])
+    })
+
+    test("indexes a caller the index had never seen", () => {
+      const callers = index({})
+
+      expect(callers.replaceCallsFrom(INDEX, new Map([[CARD, [callSite(INDEX)]]]))).toBe(true)
+      expect(callers.callersOf(CARD)).toEqual([callSite(INDEX)])
+    })
+
+    test("reports no change when the caller had and has no call sites", () => {
+      const callers = index({ [CARD]: [callSite(SHOW)] })
+
+      expect(callers.replaceCallsFrom(INDEX, new Map())).toBe(false)
+      expect(callers.callersOf(CARD)).toEqual([callSite(SHOW)])
+    })
+
+    test("leaves other callers of the same partial alone", () => {
+      const callers = index({ [CARD]: [callSite(INDEX), callSite(SHOW)] })
+
+      callers.replaceCallsFrom(INDEX, new Map([[CARD, [callSite(INDEX, ["div"])]]]))
+
+      expect(callers.callersOf(CARD)).toEqual([callSite(SHOW), callSite(INDEX, ["div"])])
+    })
+
+    test("invalidates the cached context of the partials it touched", () => {
+      const callers = index({ [CARD]: [callSite(INDEX, ["main"])] }, [INDEX])
+
+      expect(callers.contextOf(CARD).chains[0].tags).toEqual(["main"])
+
+      callers.replaceCallsFrom(INDEX, new Map([[CARD, [callSite(INDEX, ["aside"])]]]))
+
+      expect(callers.contextOf(CARD).chains[0].tags).toEqual(["aside"])
+    })
+  })
+
+  describe("removeCallsTo", () => {
+    test("forgets every caller of a deleted partial", () => {
+      const callers = index({ [CARD]: [callSite(INDEX)], [BADGE]: [callSite(SHOW)] })
+
+      expect(callers.removeCallsTo(CARD)).toBe(true)
+      expect(callers.callersOf(CARD)).toEqual([])
+      expect(callers.callersOf(BADGE)).toEqual([callSite(SHOW)])
+    })
+
+    test("reports no change for a partial it never indexed", () => {
+      const callers = index({ [CARD]: [callSite(INDEX)] })
+
+      expect(callers.removeCallsTo(BADGE)).toBe(false)
+    })
+
+    test("invalidates the cached context of the removed partial", () => {
+      const callers = index({ [CARD]: [callSite(INDEX, ["main"])] }, [INDEX])
+
+      expect(callers.contextOf(CARD).resolved).toBe(true)
+
+      callers.removeCallsTo(CARD)
+
+      expect(callers.contextOf(CARD).resolved).toBe(false)
+    })
+  })
+})

--- a/javascript/packages/language-server/src/definition_service.ts
+++ b/javascript/packages/language-server/src/definition_service.ts
@@ -23,7 +23,7 @@ const SNIPPET_LINES = 6
 const OPEN_TAG_WIDTH = 80
 const PRINT_OPTIONS = { ignoreErrors: true }
 
-interface PartialReference {
+export interface PartialReference {
   name: string
   keyword: string
   quoted: boolean
@@ -136,26 +136,21 @@ export class DefinitionService {
     return links.map(link => Location.create(link.targetUri, link.targetRange))
   }
 
-  private isStatic(reference: PartialReference): boolean {
+  isStatic(reference: PartialReference): boolean {
     return reference.quoted && PARTIAL_NAME.test(reference.name)
   }
 
-  private referenceAt(document: TextDocument, position: Position): PartialReference | null {
+  partialReferences(document: TextDocument): PartialReference[] {
     const result = this.parserService.parseContent(document.getText(), { render_nodes: true })
     const collector = new RenderCollector()
 
     collector.visit(result.value as DocumentNode)
 
-    for (const render of collector.renders) {
-      const reference = this.referenceFor(document, render)
+    return collector.renders.flatMap(render => this.referenceFor(document, render) ?? [])
+  }
 
-      if (!reference) continue
-      if (!isPositionInRange(position, reference.triggerRange)) continue
-
-      return reference
-    }
-
-    return null
+  referenceAt(document: TextDocument, position: Position): PartialReference | null {
+    return this.partialReferences(document).find(reference => isPositionInRange(position, reference.triggerRange)) ?? null
   }
 
   private referenceFor(document: TextDocument, render: ERBRenderNode): PartialReference | null {

--- a/javascript/packages/language-server/src/partial_caller_index_service.ts
+++ b/javascript/packages/language-server/src/partial_caller_index_service.ts
@@ -1,0 +1,102 @@
+import { join } from "node:path"
+import { readFileSync } from "node:fs"
+
+import { isTemplatePath } from "@herb-tools/core"
+import { buildPartialCallerIndex, collectCallSites } from "@herb-tools/linter/partial-caller-builder"
+
+import { PartialIndexService } from "./partial_index_service"
+import { Project } from "./project"
+
+import type { Connection } from "vscode-languageserver/node"
+import type { PartialCallerIndex, PartialCallSite } from "@herb-tools/core"
+
+export class PartialCallerIndexService {
+  private readonly connection: Connection
+  private readonly project: Project
+  private readonly partials: PartialIndexService
+  private callers?: PartialCallerIndex
+
+  constructor(connection: Connection, project: Project, partials: PartialIndexService) {
+    this.connection = connection
+    this.project = project
+    this.partials = partials
+  }
+
+  get index(): PartialCallerIndex | undefined {
+    return this.callers
+  }
+
+  async initialize(): Promise<void> {
+    const partials = this.partials.index
+
+    if (!partials) {
+      this.callers = undefined
+
+      return
+    }
+
+    try {
+      this.callers = await buildPartialCallerIndex(this.project.herbBackend, this.project.projectPath, partials, { resolveLayouts: false })
+
+      this.connection.console.log(`[Partials] Indexed call sites for ${this.callers.size} partials`)
+    } catch (error) {
+      this.connection.console.warn(`[Partials] Failed to index partial call sites: ${error instanceof Error ? error.message : String(error)}`)
+    }
+  }
+
+  updateFromSource(uri: string, source: string): boolean {
+    const file = this.templateFileFor(uri)
+
+    if (!this.callers || !file) {
+      return false
+    }
+
+    const sites = this.callSitesIn(file, source)
+    if (!sites) return false
+
+    return this.callers.replaceCallsFrom(file, sites)
+  }
+
+  updateFromDisk(uri: string): boolean {
+    const file = this.templateFileFor(uri)
+
+    if (!this.callers || !file) return false
+
+    try {
+      return this.updateFromSource(uri, readFileSync(join(this.project.projectPath, file), "utf-8"))
+    } catch {
+      return false
+    }
+  }
+
+  remove(uri: string): boolean {
+    const file = this.templateFileFor(uri)
+
+    if (!this.callers || !file) return false
+
+    const stoppedCalling = this.callers.replaceCallsFrom(file, new Map())
+
+    return this.callers.removeCallsTo(file) || stoppedCalling
+  }
+
+  private callSitesIn(file: string, source: string): Map<string, PartialCallSite[]> | null {
+    const partials = this.partials.index
+    if (!partials) return null
+
+    const sites = new Map<string, PartialCallSite[]>()
+
+    try {
+      collectCallSites(this.project.herbBackend, partials, file, source, sites)
+    } catch {
+      return null
+    }
+
+    return sites
+  }
+
+  private templateFileFor(uri: string): string | null {
+    if (!isTemplatePath(uri)) return null
+
+    return this.partials.relativePathFor(uri)
+  }
+}

--- a/javascript/packages/language-server/src/references_service.ts
+++ b/javascript/packages/language-server/src/references_service.ts
@@ -1,0 +1,112 @@
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+
+import { isPartialPath } from "@herb-tools/core"
+import { uriFromPath } from "./utils"
+
+import { Location, Position, Range } from "vscode-languageserver/node"
+import { TextDocument } from "vscode-languageserver-textdocument"
+
+import { Project } from "./project"
+import { DefinitionService } from "./definition_service"
+import { PartialCallerIndexService } from "./partial_caller_index_service"
+import { PartialIndexService } from "./partial_index_service"
+import { DocumentService } from "./document_service"
+
+import type { PartialReference } from "./definition_service"
+
+const LANGUAGE_ID = "erb"
+const DECLARATION_RANGE = Range.create(Position.create(0, 0), Position.create(0, 0))
+
+export class ReferencesService {
+  private project: Project
+  private definitionService: DefinitionService
+  private partialIndexService: PartialIndexService
+  private partialCallerIndexService: PartialCallerIndexService
+  private documentService: DocumentService
+  private read: (filePath: string) => string | null
+
+  constructor(
+    project: Project,
+    definitionService: DefinitionService,
+    partialIndexService: PartialIndexService,
+    partialCallerIndexService: PartialCallerIndexService,
+    documentService: DocumentService,
+    read: (filePath: string) => string | null = filePath => {
+      try {
+        return readFileSync(filePath, "utf-8")
+      } catch {
+        return null
+      }
+    }
+  ) {
+    this.project = project
+    this.definitionService = definitionService
+    this.partialIndexService = partialIndexService
+    this.partialCallerIndexService = partialCallerIndexService
+    this.documentService = documentService
+    this.read = read
+  }
+
+  getReferences(document: TextDocument, position: Position, includeDeclaration: boolean): Location[] {
+    const callers = this.partialCallerIndexService.index
+    if (!callers) return []
+
+    const partial = this.partialAt(document, position)
+    if (!partial) return []
+
+    const current = this.partialIndexService.relativePathFor(document.uri)
+    const uriFor = (file: string) => file === current ? document.uri : this.uriFor(file)
+
+    const locations = includeDeclaration ? [Location.create(uriFor(partial), DECLARATION_RANGE)] : []
+    const allFiles = callers.callersOf(partial).filter(callSite => (callSite.via ?? "render") === "render").map(callSite => callSite.caller)
+
+    const files = [...new Set(allFiles)].sort()
+
+    for (const file of files) {
+      locations.push(...this.callSitesIn(file, partial, file === current ? document : null))
+    }
+
+    return locations
+  }
+
+  private partialAt(document: TextDocument, position: Position): string | null {
+    const file = this.partialIndexService.relativePathFor(document.uri)
+    const reference = this.definitionService.referenceAt(document, position)
+
+    if (!reference) return file && isPartialPath(document.uri) ? file : null
+    if (!this.definitionService.isStatic(reference)) return null
+
+    return this.resolve(reference, file)
+  }
+
+  private callSitesIn(file: string, partial: string, open: TextDocument | null): Location[] {
+    const document = open ?? this.documentFor(file)
+
+    if (!document) return []
+
+    return this.definitionService.partialReferences(document)
+      .filter(reference => this.definitionService.isStatic(reference))
+      .filter(reference => this.resolve(reference, file) === partial)
+      .map(reference => Location.create(document.uri, reference.originRange))
+  }
+
+  private documentFor(file: string): TextDocument | null {
+    const uri = this.uriFor(file)
+
+    const open = this.documentService.get(uri)
+    if (open) return open
+
+    const source = this.read(join(this.project.projectPath, file))
+
+    return source === null ? null : TextDocument.create(uri, LANGUAGE_ID, 0, source)
+  }
+
+  private resolve(reference: PartialReference, file: string | null): string | null {
+    return this.partialIndexService.index?.lookup(reference.name, file ?? undefined)?.file ?? null
+  }
+
+  private uriFor(file: string): string {
+    return uriFromPath(join(this.project.projectPath, file))
+  }
+}

--- a/javascript/packages/language-server/src/server.ts
+++ b/javascript/packages/language-server/src/server.ts
@@ -17,6 +17,7 @@ import {
   HoverParams,
   CompletionParams,
   DefinitionParams,
+  ReferenceParams,
   TextDocumentIdentifier,
   Range,
   FileChangeType,
@@ -26,6 +27,7 @@ import { Service } from "./service"
 import { DefinitionService } from "./definition_service"
 import { PersonalHerbSettings } from "./settings"
 import { Config } from "@herb-tools/config"
+import { isPartialPath } from "@herb-tools/core"
 import { isConfigDocument } from "./utils"
 import { version } from "../package.json"
 
@@ -78,6 +80,7 @@ export class Server {
             triggerCharacters: [".", ":", "<", "&"],
           },
           definitionProvider: true,
+          referencesProvider: true,
         },
       }
 
@@ -167,7 +170,7 @@ export class Server {
           await Promise.all(documents.map(document =>
             this.service.diagnostics.refreshDocument(document)
           ))
-        } else if (this.updatePartialIndex(event)) {
+        } else if (await this.updatePartialIndex(event)) {
           await this.service.diagnostics.refreshAllDocuments()
         }
       }
@@ -253,6 +256,14 @@ export class Server {
       return DefinitionService.asLocations(links)
     })
 
+    this.connection.onReferences((params: ReferenceParams) => {
+      const document = this.service.documentService.get(params.textDocument.uri)
+
+      if (!document) return []
+
+      return this.service.referencesService.getReferences(document, params.position, params.context.includeDeclaration)
+    })
+
     this.connection.onFoldingRanges((params: FoldingRangeParams) => {
       const document = this.service.documentService.get(params.textDocument.uri)
 
@@ -278,14 +289,26 @@ export class Server {
     })
   }
 
-  private updatePartialIndex(event: FileEvent): boolean {
+  private async updatePartialIndex(event: FileEvent): Promise<boolean> {
     const partials = this.service.partialIndexService
+    const callers = this.service.partialCallerIndexService
 
-    if (event.type === FileChangeType.Deleted) return partials.remove(event.uri)
+    if (event.type === FileChangeType.Deleted) {
+      callers.remove(event.uri)
 
-    if (this.service.documentService.get(event.uri)) return false
+      return partials.remove(event.uri)
+    }
 
-    return partials.updateFromDisk(event.uri)
+    const isOpen = this.service.documentService.get(event.uri) !== undefined
+    const changed = isOpen ? false : partials.updateFromDisk(event.uri)
+
+    if (event.type === FileChangeType.Created && isPartialPath(event.uri)) {
+      await callers.initialize()
+    } else if (!isOpen) {
+      callers.updateFromDisk(event.uri)
+    }
+
+    return changed
   }
 
   listen() {

--- a/javascript/packages/language-server/src/service.ts
+++ b/javascript/packages/language-server/src/service.ts
@@ -21,6 +21,8 @@ import { DefinitionService } from "./definition_service"
 import { CommentService } from "./comment_service"
 import { CompletionService } from "./completion_service"
 import { PartialIndexService } from "./partial_index_service"
+import { PartialCallerIndexService } from "./partial_caller_index_service"
+import { ReferencesService } from "./references_service"
 
 import { version } from "../package.json"
 
@@ -33,6 +35,7 @@ export class Service {
   diagnostics: Diagnostics
   documentService: DocumentService
   partialIndexService: PartialIndexService
+  partialCallerIndexService: PartialCallerIndexService
   parserService: ParserService
   linterService: LinterService
   formattingService: FormattingService
@@ -46,6 +49,7 @@ export class Service {
   rewriteCodeActionService: RewriteCodeActionService
   extractCodeActionService: ExtractCodeActionService
   definitionService: DefinitionService
+  referencesService: ReferencesService
   commentService: CommentService
   completionService: CompletionService
 
@@ -56,6 +60,7 @@ export class Service {
     this.project = new Project(connection, this.settings.projectPath.replace("file://", ""))
     this.parserService = new ParserService()
     this.partialIndexService = new PartialIndexService(this.connection, this.project)
+    this.partialCallerIndexService = new PartialCallerIndexService(this.connection, this.project, this.partialIndexService)
     this.linterService = new LinterService(this.connection, this.settings, this.project, this.partialIndexService)
     this.formattingService = new FormattingService(this.connection, this.documentService.documents, this.project, this.settings)
     this.autofixService = new AutofixService(this.connection, this.config, this.partialIndexService)
@@ -68,6 +73,7 @@ export class Service {
     this.hoverService = new HoverService(this.parserService)
     this.rewriteCodeActionService = new RewriteCodeActionService(this.parserService)
     this.definitionService = new DefinitionService(this.parserService)
+    this.referencesService = new ReferencesService(this.project, this.definitionService, this.partialIndexService, this.partialCallerIndexService, this.documentService)
     this.commentService = new CommentService(this.parserService)
     this.completionService = new CompletionService(this.parserService)
 
@@ -85,6 +91,7 @@ export class Service {
     await this.project.initialize()
     await this.formattingService.initialize()
     await this.partialIndexService.initialize()
+    await this.partialCallerIndexService.initialize()
 
     try {
       this.config = await Config.loadForEditor(this.project.projectPath, version)
@@ -119,6 +126,8 @@ export class Service {
     })
 
     this.documentService.onDidChangeContent(async (change) => {
+      this.partialCallerIndexService.updateFromSource(change.document.uri, change.document.getText())
+
       if (this.partialIndexService.updateFromSource(change.document.uri, change.document.getText())) {
         await this.diagnostics.refreshAllDocuments()
 
@@ -132,6 +141,7 @@ export class Service {
   async refresh() {
     await this.project.refresh()
     await this.partialIndexService.initialize()
+    await this.partialCallerIndexService.initialize()
     await this.formattingService.refreshConfig(this.config)
     await this.diagnostics.refreshAllDocuments()
   }

--- a/javascript/packages/language-server/test/partial_caller_index_service.test.ts
+++ b/javascript/packages/language-server/test/partial_caller_index_service.test.ts
@@ -1,0 +1,149 @@
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join, dirname } from "node:path"
+import { pathToFileURL } from "node:url"
+
+import { beforeAll, afterEach, describe, expect, test, vi } from "vitest"
+
+import { Herb } from "@herb-tools/node-wasm"
+
+import { PartialCallerIndexService } from "../src/partial_caller_index_service"
+import { PartialIndexService } from "../src/partial_index_service"
+import { Project } from "../src/project"
+
+import type { Connection } from "vscode-languageserver/node"
+
+const CARD = "app/views/posts/_card.html.erb"
+const INDEX = "app/views/posts/index.html.erb"
+const SHOW = "app/views/events/show.html.erb"
+
+const roots: string[] = []
+
+const connection = {
+  console: { log: vi.fn(), warn: vi.fn(), error: vi.fn() }
+} as unknown as Connection
+
+const PROJECT = {
+  [CARD]: `<article></article>\n`,
+  [INDEX]: `<%= render "posts/card" %>\n`,
+  [SHOW]: `<div></div>\n`,
+}
+
+function project(files: Record<string, string>): Project {
+  const root = mkdtempSync(join(tmpdir(), "herb-lsp-callers-"))
+
+  roots.push(root)
+
+  for (const [path, contents] of Object.entries(files)) {
+    const file = join(root, path)
+
+    mkdirSync(dirname(file), { recursive: true })
+    writeFileSync(file, contents, "utf-8")
+  }
+
+  return { projectPath: root, herbBackend: Herb } as Project
+}
+
+async function serviceFor(files: Record<string, string>): Promise<{ service: PartialCallerIndexService, project: Project }> {
+  const created = project(files)
+  const partials = new PartialIndexService(connection, created)
+
+  await partials.initialize()
+
+  const service = new PartialCallerIndexService(connection, created, partials)
+
+  await service.initialize()
+
+  return { service, project: created }
+}
+
+function uriFor(project: Project, path: string): string {
+  return pathToFileURL(join(project.projectPath, path)).toString()
+}
+
+function callers(service: PartialCallerIndexService, partial = CARD): string[] {
+  return (service.index?.callersOf(partial) ?? []).map(callSite => callSite.caller)
+}
+
+beforeAll(async () => {
+  await Herb.load()
+})
+
+afterEach(() => {
+  while (roots.length > 0) {
+    rmSync(roots.pop()!, { recursive: true, force: true })
+  }
+})
+
+describe("PartialCallerIndexService", () => {
+  test("indexes the project's render call sites on initialize", async () => {
+    const { service } = await serviceFor(PROJECT)
+
+    expect(callers(service)).toEqual([INDEX])
+  })
+
+  test("records a call site added in an unsaved buffer", async () => {
+    const { service, project } = await serviceFor(PROJECT)
+
+    expect(service.updateFromSource(uriFor(project, SHOW), `<%= render "posts/card" %>\n`)).toBe(true)
+    expect(callers(service).sort()).toEqual([SHOW, INDEX])
+  })
+
+  test("drops a call site removed in an unsaved buffer", async () => {
+    const { service, project } = await serviceFor(PROJECT)
+
+    expect(service.updateFromSource(uriFor(project, INDEX), `<div></div>\n`)).toBe(true)
+    expect(callers(service)).toEqual([])
+  })
+
+  test("reports no change when a buffer's call sites are unchanged", async () => {
+    const { service, project } = await serviceFor(PROJECT)
+
+    expect(service.updateFromSource(uriFor(project, SHOW), `<p></p>\n`)).toBe(false)
+  })
+
+  test("ignores files that are not templates", async () => {
+    const { service, project } = await serviceFor(PROJECT)
+
+    expect(service.updateFromSource(uriFor(project, "app/models/post.rb"), `render "posts/card"\n`)).toBe(false)
+    expect(callers(service)).toEqual([INDEX])
+  })
+
+  test("ignores files outside the project", async () => {
+    const { service } = await serviceFor(PROJECT)
+
+    expect(service.updateFromSource("file:///elsewhere/show.html.erb", `<%= render "posts/card" %>\n`)).toBe(false)
+  })
+
+  test("picks up a call site written to disk", async () => {
+    const { service, project } = await serviceFor(PROJECT)
+
+    writeFileSync(join(project.projectPath, SHOW), `<%= render "posts/card" %>\n`, "utf-8")
+
+    expect(service.updateFromDisk(uriFor(project, SHOW))).toBe(true)
+    expect(callers(service).sort()).toEqual([SHOW, INDEX])
+  })
+
+  test("forgets a deleted caller", async () => {
+    const { service, project } = await serviceFor(PROJECT)
+
+    expect(service.remove(uriFor(project, INDEX))).toBe(true)
+    expect(callers(service)).toEqual([])
+  })
+
+  test("forgets the callers of a deleted partial", async () => {
+    const { service, project } = await serviceFor(PROJECT)
+
+    expect(service.remove(uriFor(project, CARD))).toBe(true)
+    expect(callers(service)).toEqual([])
+  })
+
+  test("keeps the index usable when a buffer does not parse", async () => {
+    const { service, project } = await serviceFor(PROJECT)
+
+    service.updateFromSource(uriFor(project, SHOW), `<%= render "posts/card"\n`)
+
+    expect(service.index).toBeDefined()
+    expect(callers(service)).toContain(INDEX)
+  })
+})

--- a/javascript/packages/language-server/test/references_service.test.ts
+++ b/javascript/packages/language-server/test/references_service.test.ts
@@ -1,0 +1,244 @@
+import { beforeAll, afterEach, describe, expect, test, vi } from "vitest"
+
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join, dirname, relative } from "node:path"
+import { pathToFileURL, fileURLToPath } from "node:url"
+
+import { Herb } from "@herb-tools/node-wasm"
+import { TextDocument } from "vscode-languageserver-textdocument"
+
+import { Project } from "../src/project"
+import { DocumentService } from "../src/document_service"
+import { ReferencesService } from "../src/references_service"
+import { DefinitionService } from "../src/definition_service"
+import { ParserService } from "../src/parser_service"
+import { PartialIndexService } from "../src/partial_index_service"
+import { PartialCallerIndexService } from "../src/partial_caller_index_service"
+
+import type { Connection, Location } from "vscode-languageserver/node"
+
+const roots: string[] = []
+
+const connection = {
+  console: { log: vi.fn(), warn: vi.fn(), error: vi.fn() }
+} as unknown as Connection
+
+const PROJECT = {
+  "app/views/posts/_card.html.erb": `<%# locals: (post:) %>\n<article><%= post.title %></article>\n`,
+  "app/views/posts/_badge.html.erb": `<span>badge</span>\n`,
+  "app/views/posts/index.html.erb": `<% @posts.each do |post| %>\n  <%= render "posts/card", post: post %>\n<% end %>\n\n<%= render partial: "posts/card", locals: { post: @featured } %>\n`,
+  "app/views/events/show.html.erb": `<%= render "posts/card", post: @post %>\n`,
+  "app/views/other/index.html.erb": `<%= render "posts/badge" %>\n`,
+}
+
+let parserService: ParserService
+
+function project(files: Record<string, string>): Project {
+  const root = mkdtempSync(join(tmpdir(), "herb-lsp-references-"))
+
+  roots.push(root)
+
+  for (const [path, contents] of Object.entries(files)) {
+    const file = join(root, path)
+
+    mkdirSync(dirname(file), { recursive: true })
+    writeFileSync(file, contents, "utf-8")
+  }
+
+  return { projectPath: root, herbBackend: Herb } as Project
+}
+
+interface Services {
+  service: ReferencesService
+  callers: PartialCallerIndexService
+  project: Project
+  buffers: Record<string, string>
+}
+
+async function serviceFor(files: Record<string, string>, buffers: Record<string, string> = {}): Promise<Services> {
+  const created = project(files)
+  const partials = new PartialIndexService(connection, created)
+
+  await partials.initialize()
+
+  const callers = new PartialCallerIndexService(connection, created, partials)
+
+  await callers.initialize()
+
+  const open = new Map(Object.entries(buffers).map(([path, contents]) => {
+    const uri = uriFor(created, path)
+
+    return [uri, TextDocument.create(uri, "erb", 2, contents)]
+  }))
+
+  const documents = {
+    get: (uri: string) => open.get(uri)
+  } as unknown as DocumentService
+
+  const service = new ReferencesService(created, new DefinitionService(parserService), partials, callers, documents)
+
+  return { service, callers, project: created, buffers }
+}
+
+function uriFor(project: Project, path: string): string {
+  return pathToFileURL(join(project.projectPath, path)).toString()
+}
+
+function documentFor(services: Services, path: string): TextDocument {
+  const source = services.buffers[path] ?? readFileSync(join(services.project.projectPath, path), "utf-8")
+
+  return TextDocument.create(uriFor(services.project, path), "erb", 1, source)
+}
+
+function referencesAt(services: Services, path: string, target?: string, includeDeclaration = false): string[] {
+  const document = documentFor(services, path)
+  const position = target ? document.positionAt(document.getText().indexOf(target) + 1) : { line: 0, character: 0 }
+
+  return describeAll(services, services.service.getReferences(document, position, includeDeclaration))
+}
+
+function describeAll(services: Services, locations: Location[]): string[] {
+  return locations.map(location => {
+    const path = relative(services.project.projectPath, fileURLToPath(location.uri))
+    const document = documentFor(services, path)
+
+    return `${path}:${location.range.start.line} ${document.getText(location.range)}`
+  })
+}
+
+beforeAll(async () => {
+  await Herb.load()
+
+  parserService = new ParserService()
+})
+
+afterEach(() => {
+  while (roots.length > 0) {
+    rmSync(roots.pop()!, { recursive: true, force: true })
+  }
+})
+
+describe("ReferencesService", () => {
+  test("finds every render call site of the partial the cursor is in", async () => {
+    const services = await serviceFor(PROJECT)
+
+    expect(referencesAt(services, "app/views/posts/_card.html.erb")).toEqual([
+      "app/views/events/show.html.erb:0 posts/card",
+      "app/views/posts/index.html.erb:1 posts/card",
+      "app/views/posts/index.html.erb:4 posts/card",
+    ])
+  })
+
+  test("finds the same call sites from a render call", async () => {
+    const services = await serviceFor(PROJECT)
+
+    expect(referencesAt(services, "app/views/events/show.html.erb", "posts/card")).toEqual([
+      "app/views/events/show.html.erb:0 posts/card",
+      "app/views/posts/index.html.erb:1 posts/card",
+      "app/views/posts/index.html.erb:4 posts/card",
+    ])
+  })
+
+  test("does not report call sites of a different partial", async () => {
+    const services = await serviceFor(PROJECT)
+
+    expect(referencesAt(services, "app/views/posts/_badge.html.erb")).toEqual([
+      "app/views/other/index.html.erb:0 posts/badge",
+    ])
+  })
+
+  test("includes the partial itself when the client asks for the declaration", async () => {
+    const services = await serviceFor(PROJECT)
+
+    expect(referencesAt(services, "app/views/posts/_badge.html.erb", undefined, true)).toEqual([
+      "app/views/posts/_badge.html.erb:0 ",
+      "app/views/other/index.html.erb:0 posts/badge",
+    ])
+  })
+
+  test("resolves a partial rendered by its unqualified name", async () => {
+    const services = await serviceFor({
+      "app/views/posts/_card.html.erb": `<article></article>\n`,
+      "app/views/posts/index.html.erb": `<%= render "card" %>\n`,
+    })
+
+    expect(referencesAt(services, "app/views/posts/_card.html.erb")).toEqual([
+      "app/views/posts/index.html.erb:0 card",
+    ])
+  })
+
+  test("returns nothing for a template that is not a partial", async () => {
+    const services = await serviceFor(PROJECT)
+
+    expect(referencesAt(services, "app/views/posts/index.html.erb", "@posts")).toEqual([])
+  })
+
+  test("returns nothing for a render whose partial name is not a literal", async () => {
+    const services = await serviceFor({
+      "app/views/posts/_card.html.erb": `<article></article>\n`,
+      "app/views/posts/index.html.erb": `<%= render @post %>\n`,
+    })
+
+    expect(referencesAt(services, "app/views/posts/index.html.erb", "@post")).toEqual([])
+  })
+
+  test("takes the range from an unsaved buffer rather than from disk", async () => {
+    const services = await serviceFor(PROJECT, {
+      "app/views/events/show.html.erb": `<div>\n</div>\n<%= render "posts/card", post: @post %>\n`
+    })
+
+    expect(referencesAt(services, "app/views/posts/_card.html.erb")).toEqual([
+      "app/views/events/show.html.erb:2 posts/card",
+      "app/views/posts/index.html.erb:1 posts/card",
+      "app/views/posts/index.html.erb:4 posts/card",
+    ])
+  })
+
+  test("takes the range of the edited document from the request, not from disk", async () => {
+    const services = await serviceFor(PROJECT)
+    const edited = `<div>\n</div>\n<%= render "posts/card", post: @post %>\n`
+    const document = TextDocument.create(uriFor(services.project, "app/views/events/show.html.erb"), "erb", 3, edited)
+    const position = document.positionAt(edited.indexOf("posts/card") + 1)
+
+    const located = services.service.getReferences(document, position, false)
+      .filter(location => location.uri === document.uri)
+      .map(location => `${location.range.start.line} ${document.getText(location.range)}`)
+
+    expect(located).toEqual(["2 posts/card"])
+  })
+
+  test("picks up a call site added to an open buffer", async () => {
+    const buffer = `<%= render "posts/badge" %>\n<%= render "posts/card" %>\n`
+    const services = await serviceFor(PROJECT, { "app/views/other/index.html.erb": buffer })
+
+    services.callers.updateFromSource(uriFor(services.project, "app/views/other/index.html.erb"), buffer)
+
+    expect(referencesAt(services, "app/views/posts/_card.html.erb")).toEqual([
+      "app/views/events/show.html.erb:0 posts/card",
+      "app/views/other/index.html.erb:1 posts/card",
+      "app/views/posts/index.html.erb:1 posts/card",
+      "app/views/posts/index.html.erb:4 posts/card",
+    ])
+  })
+
+  test("drops a call site removed from an open buffer", async () => {
+    const services = await serviceFor(PROJECT, { "app/views/events/show.html.erb": `<div></div>\n` })
+
+    services.callers.updateFromSource(uriFor(services.project, "app/views/events/show.html.erb"), `<div></div>\n`)
+
+    expect(referencesAt(services, "app/views/posts/_card.html.erb")).toEqual([
+      "app/views/posts/index.html.erb:1 posts/card",
+      "app/views/posts/index.html.erb:4 posts/card",
+    ])
+  })
+
+  test("returns nothing when the project has no call sites for the partial", async () => {
+    const services = await serviceFor({
+      "app/views/posts/_card.html.erb": `<article></article>\n`,
+      "app/views/posts/index.html.erb": `<div></div>\n`,
+    })
+
+    expect(referencesAt(services, "app/views/posts/_card.html.erb")).toEqual([])
+  })
+})

--- a/javascript/packages/linter/package.json
+++ b/javascript/packages/linter/package.json
@@ -49,6 +49,11 @@
       "types": "./dist/types/partial-index-builder.d.ts",
       "import": "./dist/partial-index-builder.js",
       "default": "./dist/partial-index-builder.js"
+    },
+    "./partial-caller-builder": {
+      "types": "./dist/types/partial-caller-builder.d.ts",
+      "import": "./dist/partial-caller-builder.js",
+      "default": "./dist/partial-caller-builder.js"
     }
   },
   "dependencies": {

--- a/javascript/packages/linter/rollup.config.mjs
+++ b/javascript/packages/linter/rollup.config.mjs
@@ -137,6 +137,28 @@ export default [
     ],
   },
 
+  // Partial caller builder entry point (node only, used by the language server)
+  {
+    input: "src/partial-caller-builder.ts",
+    output: {
+      file: "dist/partial-caller-builder.js",
+      format: "esm",
+      sourcemap: true,
+    },
+    external: isExternal,
+    plugins: [
+      nodeResolve({ preferBuiltins: true }),
+      commonjs(),
+      json(),
+      typescript({
+        tsconfig: "./tsconfig.json",
+        declaration: true,
+        declarationDir: "./dist/types",
+        rootDir: "src/",
+      }),
+    ],
+  },
+
   // Loader entry point (includes custom rule loader)
   {
     input: "src/loader.ts",


### PR DESCRIPTION
This pull request implements the References Provider, so "Find All References" on a partial lists every `<%= render %>` call site that renders it.


https://github.com/user-attachments/assets/941450e3-54a8-4beb-a1fc-9ff284956b3f



Resolves #1390 