### PR TITLE
Language Server: Auto-complete partial names and `<%= render %>` options

### DIFF
--- a/config/action_view_helpers/actionview/rendering_helper/render.yml
+++ b/config/action_view_helpers/actionview/rendering_helper/render.yml
@@ -44,6 +44,76 @@ options:
     description: |-
       Layout to wrap the rendered content.
 
+  - name: "object"
+    type: "object"
+    description: |-
+      Object to render the partial with, available as a local named after the partial.
+
+  - name: "as"
+    type: "symbol"
+    description: |-
+      Name of the local the object or each collection item is assigned to.
+
+  - name: "spacer_template"
+    type: "string"
+    description: |-
+      Partial rendered between the items of a collection.
+
+  - name: "cached"
+    type: "boolean"
+    description: |-
+      Render a collection through the cache, reading and writing each item in one multi-fetch.
+
+  - name: "template"
+    type: "string"
+    description: |-
+      Template to render instead of a partial.
+
+  - name: "file"
+    type: "string"
+    description: |-
+      Absolute path of a file to render.
+
+  - name: "inline"
+    type: "string"
+    description: |-
+      Template source to render inline.
+
+  - name: "plain"
+    type: "string"
+    description: |-
+      Plain text to render without a template.
+
+  - name: "html"
+    type: "string"
+    description: |-
+      HTML-safe string to render without a template.
+
+  - name: "body"
+    type: "string"
+    description: |-
+      Raw body to render without a template.
+
+  - name: "renderable"
+    type: "object"
+    description: |-
+      Object responding to `render_in` to render.
+
+  - name: "formats"
+    type: "array"
+    description: |-
+      Formats to look the template up in.
+
+  - name: "variants"
+    type: "array"
+    description: |-
+      Variants to look the template up in.
+
+  - name: "handlers"
+    type: "array"
+    description: |-
+      Template handlers to look the template up in.
+
 block_arguments: []
 
 special_behaviors:

--- a/javascript/packages/core/src/action-view-partial-index.ts
+++ b/javascript/packages/core/src/action-view-partial-index.ts
@@ -112,6 +112,10 @@ export class PartialIndex {
     }
   }
 
+  entries(): [string, PartialDeclaration][] {
+    return [...this.declarations]
+  }
+
   lookup(partialName: string, sourceFile: string | undefined): PartialDeclaration | null {
     const file = resolvePartial(partialName, sourceFile ?? "", this.files, this.viewRoot)
 

--- a/javascript/packages/language-server/src/completion_service.ts
+++ b/javascript/packages/language-server/src/completion_service.ts
@@ -1,19 +1,22 @@
 import {
+  Command,
   CompletionItem,
   CompletionItemKind,
   CompletionList,
   InsertTextFormat,
   MarkupKind,
   Position,
+  Range,
+  TextEdit,
 } from "vscode-languageserver/node"
 import { TextDocument } from "vscode-languageserver-textdocument"
 
-import { Visitor, isERBContentNode, isERBOutputNode, isHTMLOpenTagNode, isHTMLTextNode, getHelperEntries, HTML_NAMED_CHARACTER_REFERENCES, HTML_ELEMENTS } from "@herb-tools/core"
+import { Visitor, RubyReferenceCollector, isERBContentNode, isERBOutputNode, isHTMLOpenTagNode, isHTMLTextNode, isValidLocalName, getHelperEntries, partialNameForFile, strictLocalsDeclaration, templateNameForFile, HELPER_REGISTRY, HTML_NAMED_CHARACTER_REFERENCES, HTML_ELEMENTS } from "@herb-tools/core"
 import { ParserService } from "./parser_service"
+import { PartialIndexService } from "./partial_index_service"
 import { nodeToRange, isPositionInRange, rangeSize, lspPosition } from "./range_utils"
 
-import type { Node, ERBContentNode, HTMLOpenTagNode, HTMLTextNode, HelperEntry } from "@herb-tools/core"
-import type { Range } from "vscode-languageserver/node"
+import type { Node, ERBContentNode, HTMLOpenTagNode, HTMLTextNode, HelperEntry, HelperOption, PartialDeclaration, RubyReference } from "@herb-tools/core"
 
 const HTML_OPEN_TAG_PATTERN = /<(\w*)$/
 const CHARACTER_REFERENCE_PATTERN = /&([a-zA-Z]*)$/
@@ -21,12 +24,57 @@ const CHARACTER_REFERENCE_PATTERN = /&([a-zA-Z]*)$/
 const TAG_DOT_PATTERN = /tag\.(\w*)$/
 const CONTENT_TAG_SYMBOL_PATTERN = /content_tag\s+:(\w*)$/
 const ERB_EXPRESSION_PATTERN = /^(\w*)$/
+const RENDER_KEYWORD_PATTERN = /\brender\b[\s\S]*?:?\b(partial|layout|spacer_template)\s*(?::|=>)\s*(["'])([^"']*)$/
+const RENDER_POSITIONAL_PATTERN = /\brender\b\s*\(?\s*(["'])([^"']*)$/
+const RENDER_CALL_PATTERN = /\brender\b(?:\s*\(|\s)([\s\S]*)$/
+const RENDER_PARTIAL_ARGUMENT = /\bpartial\s*(?::|=>)\s*["']([^"']+)["']/
+const RENDER_POSITIONAL_ARGUMENT = /^\s*\(?\s*["']([^"']+)["']/
+const LOCALS_HASH = /\blocals\s*(?::|=>)\s*$/
+const KEY_POSITION = /(?:^|,)\s*(\w*)$/
+const VALUE_POSITION = /(?:^|,)\s*(\w+)\s*(?::(?!:)|=>)\s*(@?\w*)$/
+const EXPRESSION_TYPES = new Set(["array", "object"])
+const WRITTEN_KEY = /\b(\w+)\s*(?::(?!:)|=>)/g
+const SPACER_KEYWORD = "spacer_template"
+const LOCALS_KEYWORD = "locals"
+const RENDER_HELPER = "render"
+const RENDER_SORT = "!!"
+
+const OPTION_SNIPPETS: Record<string, string> = {
+  string: `"$0"`,
+  array: `\${1:[]}`,
+  object: `\${1:nil}`,
+  symbol: `:$0`,
+}
+
+const SUGGESTS_AFTER_INSERT = new Set(["partial", "layout", SPACER_KEYWORD, LOCALS_KEYWORD])
+const TRIGGER_SUGGEST: Command = { title: "Suggest", command: "editor.action.triggerSuggest" }
+
+const APPLICATION_DIRECTORY = "application"
+
+const SAME_DIRECTORY_RANK = 0
+const APPLICATION_RANK = 1
+const DISTANCE_RANK_OFFSET = 1
 
 const COMMON_TAGS = new Set([
   "div", "span", "p", "a", "button", "form", "input", "label",
   "ul", "ol", "li", "h1", "h2", "h3", "section", "header",
   "footer", "nav", "main", "article", "aside", "table", "img",
 ])
+
+interface RenderCall {
+  keyword: string | undefined
+  quote: string
+  after: string
+  closed: boolean
+}
+
+interface RenderArgument {
+  prefix: string
+  locals: boolean
+  written: Set<string>
+  partial: string | null
+  valueFor: string | null
+}
 
 function publicHelpers(): HelperEntry[] {
   const helpers = new Map<string, HelperEntry>()
@@ -97,9 +145,11 @@ class NodeAtPositionCollector extends Visitor {
 
 export class CompletionService {
   private parserService: ParserService
+  private partialIndexService?: PartialIndexService
 
-  constructor(parserService: ParserService) {
+  constructor(parserService: ParserService, partialIndexService?: PartialIndexService) {
     this.parserService = parserService
+    this.partialIndexService = partialIndexService
   }
 
   getCompletions(document: TextDocument, position: Position): CompletionList | null {
@@ -174,6 +224,29 @@ export class CompletionService {
 
     const textBeforeCursor = contentText.substring(0, cursorOffset).trimStart()
 
+    const keywordMatch = textBeforeCursor.match(RENDER_KEYWORD_PATTERN)
+    const positionalMatch = keywordMatch ? null : textBeforeCursor.match(RENDER_POSITIONAL_PATTERN)
+
+    if (keywordMatch || positionalMatch) {
+      const [keyword, quote, prefix] = keywordMatch
+        ? [keywordMatch[1], keywordMatch[2], keywordMatch[3]]
+        : [undefined, positionalMatch![1], positionalMatch![2]]
+
+      const call = { keyword, quote, after: contentText.substring(cursorOffset), closed: !!node.tag_closing }
+
+      return this.getPartialNameCompletions(prefix, call, position, document)
+    }
+
+    const argument = this.renderArgumentAt(textBeforeCursor)
+
+    if (argument) {
+      if (argument.valueFor) return this.getVariableCompletions(argument, contentStart, position, document)
+
+      return argument.locals
+        ? this.getStrictLocalCompletions(argument, position, document)
+        : this.getRenderKeywordCompletions(argument, position, document)
+    }
+
     const tagDotMatch = textBeforeCursor.match(TAG_DOT_PATTERN)
 
     if (tagDotMatch) {
@@ -195,7 +268,7 @@ export class CompletionService {
 
       if (prefix === "" && !isERBOutputNode(node)) return null
 
-      return this.getHelperCompletions(prefix)
+      return this.getHelperCompletions(prefix, !!node.tag_closing)
     }
 
     return null
@@ -367,7 +440,342 @@ export class CompletionService {
     return CompletionList.create(items, true)
   }
 
-  private getHelperCompletions(prefix: string): CompletionList | null {
+  private getPartialNameCompletions(prefix: string, call: RenderCall, position: Position, document: TextDocument): CompletionList | null {
+    const service = this.partialIndexService
+    const partials = service?.index
+
+    if (!service || !partials) return null
+
+    const file = service.relativePathFor(document.uri)
+    const directory = file === null ? null : this.directoryOf(file, partials.viewRoot)
+    const lowercasePrefix = prefix.toLowerCase()
+
+    const nameRange = Range.create(document.positionAt(document.offsetAt(position) - prefix.length), position)
+    const scope = call.closed ? call.after : call.after.split("\n")[0]
+    const closes = scope.startsWith(call.quote)
+    const remainder = closes ? scope.slice(call.quote.length) : scope
+    const argumentsFollow = remainder.trim() !== ""
+    const padding = remainder === "" ? " " : ""
+    const callRange = Range.create(nameRange.start, closes ? document.positionAt(document.offsetAt(position) + call.quote.length) : position)
+
+    const spellsOutPartial = !call.keyword && !argumentsFollow
+    const opening = spellsOutPartial ? `partial: ${call.quote}` : ""
+    const start = spellsOutPartial ? document.positionAt(document.offsetAt(nameRange.start) - call.quote.length) : nameRange.start
+
+    const items: CompletionItem[] = partials.entries()
+      .map(([name, declaration]) => ({ name, declaration, ...this.placementOf(name, directory) }))
+      .filter(partial => partial.names.some(name => name.toLowerCase().startsWith(lowercasePrefix)))
+      .sort((a, b) => a.rank - b.rank || a.name.localeCompare(b.name))
+      .map((partial, index) => {
+        const locals = argumentsFollow || call.keyword === SPACER_KEYWORD ? "" : this.requiredLocalsSnippet(partial.declaration)
+        const completesCall = !argumentsFollow && (locals !== "" || !call.closed)
+
+        const item = {
+          label: partial.name,
+          kind: CompletionItemKind.File,
+          detail: partial.declaration.file,
+          documentation: this.partialDocumentation(partial.declaration),
+          sortText: `${RENDER_SORT}${String(index).padStart(4, "0")}`,
+          filterText: partial.name,
+        }
+
+        if (!completesCall) {
+          return {
+            ...item,
+            insertTextFormat: InsertTextFormat.PlainText,
+            textEdit: TextEdit.replace(Range.create(start, position), `${opening}${partial.name}`),
+          }
+        }
+
+        const tail = call.closed ? `${padding}$0` : ` $0%>`
+
+        return {
+          ...item,
+          insertTextFormat: InsertTextFormat.Snippet,
+          textEdit: TextEdit.replace(Range.create(start, callRange.end), `${opening}${partial.name}${call.quote}${locals}${tail}`),
+          command: locals ? TRIGGER_SUGGEST : undefined,
+        }
+      })
+
+    if (items.length === 0) return null
+
+    return CompletionList.create(preselectBest(items), false)
+  }
+
+  private renderArgumentAt(textBeforeCursor: string): RenderArgument | null {
+    const match = textBeforeCursor.match(RENDER_CALL_PATTERN)
+
+    if (!match) return null
+
+    const args = match[1]
+    const scan = this.scanArguments(args)
+
+    if (scan.quoted) return null
+
+    const shorthand = args.match(RENDER_POSITIONAL_ARGUMENT)?.[1] ?? null
+    const partial = args.match(RENDER_PARTIAL_ARGUMENT)?.[1] ?? shorthand
+
+    if (scan.openBrace === -1) {
+      const key = args.match(KEY_POSITION)
+      const locals = shorthand !== null
+
+      if (key) return { prefix: key[1], locals, written: this.writtenKeys(args), partial, valueFor: null }
+
+      const value = args.match(VALUE_POSITION)
+
+      if (!value) return null
+      if (!locals && !this.takesExpression(value[1])) return null
+
+      return { prefix: value[2], locals, written: this.writtenKeys(args), partial, valueFor: value[1] }
+    }
+
+    if (!LOCALS_HASH.test(args.slice(0, scan.openBrace))) return null
+
+    const inside = args.slice(scan.openBrace + 1)
+    const key = inside.match(KEY_POSITION)
+
+    if (key) return { prefix: key[1], locals: true, written: this.writtenKeys(inside), partial, valueFor: null }
+
+    const value = inside.match(VALUE_POSITION)
+
+    if (!value) return null
+
+    return { prefix: value[2], locals: true, written: this.writtenKeys(inside), partial, valueFor: value[1] }
+  }
+
+  private takesExpression(option: string): boolean {
+    const type = HELPER_REGISTRY[RENDER_HELPER]?.options?.find(candidate => candidate.name === option)?.type
+
+    return typeof type === "string" && EXPRESSION_TYPES.has(type)
+  }
+
+  private scanArguments(text: string): { quoted: boolean, openBrace: number } {
+    const open: number[] = []
+
+    let quote: string | null = null
+
+    for (let index = 0; index < text.length; index++) {
+      const character = text[index]
+
+      if (quote) {
+        if (character === "\\") index++
+        else if (character === quote) quote = null
+
+        continue
+      }
+
+      if (character === `"` || character === `'`) quote = character
+      else if (character === "{") open.push(index)
+      else if (character === "}") open.pop()
+    }
+
+    return { quoted: quote !== null, openBrace: open.at(-1) ?? -1 }
+  }
+
+  private writtenKeys(text: string): Set<string> {
+    return new Set([...text.matchAll(WRITTEN_KEY)].map(match => match[1]))
+  }
+
+  private getRenderKeywordCompletions(argument: RenderArgument, position: Position, document: TextDocument): CompletionList | null {
+    const options = HELPER_REGISTRY[RENDER_HELPER]?.options ?? []
+    const range = this.prefixRange(argument.prefix, position, document)
+    const separator = this.separatorBefore(range.start, document)
+
+    const items: CompletionItem[] = options
+      .filter(option => !argument.written.has(option.name))
+      .filter(option => option.name.startsWith(argument.prefix))
+      .map((option, index) => ({
+        label: option.name,
+        kind: CompletionItemKind.Property,
+        detail: Array.isArray(option.type) ? option.type.join(" | ") : String(option.type),
+        documentation: { kind: MarkupKind.Markdown, value: option.description },
+        sortText: `${RENDER_SORT}${String(index).padStart(3, "0")}`,
+        insertTextFormat: InsertTextFormat.Snippet,
+        textEdit: TextEdit.replace(range, `${separator}${this.optionSnippet(option)}`),
+        command: SUGGESTS_AFTER_INSERT.has(option.name) ? TRIGGER_SUGGEST : undefined,
+      }))
+
+    if (items.length === 0) return null
+
+    return CompletionList.create(preselectBest(items), false)
+  }
+
+  private getStrictLocalCompletions(argument: RenderArgument, position: Position, document: TextDocument): CompletionList | null {
+    const partials = this.partialIndexService?.index
+
+    if (!partials || !argument.partial) return null
+
+    const file = this.partialIndexService!.relativePathFor(document.uri)
+    const declaration = partials.lookup(argument.partial, file ?? undefined)
+
+    if (!declaration?.hasDeclaration) return null
+
+    const range = this.prefixRange(argument.prefix, position, document)
+    const separator = this.separatorBefore(range.start, document)
+
+    const items: CompletionItem[] = declaration.locals
+      .filter(local => !argument.written.has(local.name))
+      .filter(local => local.name.startsWith(argument.prefix))
+      .sort((a, b) => Number(b.required) - Number(a.required) || a.name.localeCompare(b.name))
+      .map((local, index) => ({
+        label: local.name,
+        kind: CompletionItemKind.Variable,
+        detail: local.required ? "required" : "optional",
+        sortText: `${RENDER_SORT}${String(index).padStart(3, "0")}`,
+        insertTextFormat: InsertTextFormat.Snippet,
+        textEdit: TextEdit.replace(range, `${separator}${local.name}: \${1:${local.name}}$0`),
+        command: TRIGGER_SUGGEST,
+      }))
+
+    if (items.length === 0) return null
+
+    return CompletionList.create(preselectBest(items), false)
+  }
+
+  private optionSnippet(option: HelperOption): string {
+    if (option.name === LOCALS_KEYWORD) return `${LOCALS_KEYWORD}: { $0 }`
+
+    const value = typeof option.type === "string" ? OPTION_SNIPPETS[option.type] : undefined
+
+    return `${option.name}: ${value ?? "$0"}`
+  }
+
+  private getVariableCompletions(argument: RenderArgument, contentStart: Position, position: Position, document: TextDocument): CompletionList | null {
+    const names = this.variablesIn(document, contentStart)
+
+    if (names.length === 0) return null
+
+    const range = this.prefixRange(argument.prefix, position, document)
+    const separator = this.separatorBefore(range.start, document)
+    const wanted = argument.valueFor
+
+    const items: CompletionItem[] = names
+      .filter(name => name.startsWith(argument.prefix) || name.replace(/^@/, "").startsWith(argument.prefix))
+      .sort((a, b) => Number(this.namesLocal(b, wanted)) - Number(this.namesLocal(a, wanted)) || a.localeCompare(b))
+      .map((name, index) => ({
+        label: name,
+        kind: name.startsWith("@") ? CompletionItemKind.Field : CompletionItemKind.Variable,
+        detail: name.startsWith("@") ? "instance variable" : "local variable",
+        sortText: `${RENDER_SORT}${String(index).padStart(3, "0")}`,
+        insertTextFormat: InsertTextFormat.PlainText,
+        textEdit: TextEdit.replace(range, `${separator}${name}`),
+      }))
+
+    if (items.length === 0) return null
+
+    return CompletionList.create(preselectBest(items), false)
+  }
+
+  private namesLocal(name: string, wanted: string | null): boolean {
+    return wanted !== null && name.replace(/^@/, "") === wanted
+  }
+
+  private variablesIn(document: TextDocument, contentStart: Position): string[] {
+    const text = document.getText()
+    const result = this.parserService.parseContent(text, { prism_program: true })
+
+    if (!result.value.prismNode) return []
+
+    const collector = new RubyReferenceCollector()
+
+    collector.visit(result.value.prismNode)
+
+    const limit = new TextEncoder().encode(text.slice(0, document.offsetAt(contentStart))).length
+    const written = (reference: RubyReference) => reference.startOffset < limit
+    const names = new Set<string>()
+
+    for (const reference of [...collector.instanceVariableReads, ...collector.instanceVariableWrites]) {
+      if (written(reference) && isValidLocalName(reference.name.slice(1))) names.add(reference.name)
+    }
+
+    for (const reference of [...collector.localBindings, ...collector.localReads]) {
+      if (written(reference) && isValidLocalName(reference.name)) names.add(reference.name)
+    }
+
+    return [...names]
+  }
+
+  private prefixRange(prefix: string, position: Position, document: TextDocument): Range {
+    return Range.create(document.positionAt(document.offsetAt(position) - prefix.length), position)
+  }
+
+  private separatorBefore(start: Position, document: TextDocument): string {
+    const offset = document.offsetAt(start)
+
+    if (offset === 0) return ""
+
+    return /\s/.test(document.getText(Range.create(document.positionAt(offset - 1), start))) ? "" : " "
+  }
+
+  private requiredLocalsSnippet(declaration: PartialDeclaration): string {
+    const required = declaration.locals.filter(local => local.required)
+
+    if (required.length === 0) return ""
+
+    const assignments = required
+      .map((local, index) => `${local.name}: \${${index + 1}:${local.name}}`)
+      .join(", ")
+
+    return `, locals: { ${assignments} }`
+  }
+
+  private placementOf(name: string, directory: string | null): { names: string[], rank: number } {
+    const separator = name.lastIndexOf("/")
+    const partialDirectory = separator === -1 ? "" : name.slice(0, separator)
+    const base = separator === -1 ? name : name.slice(separator + 1)
+
+    if (directory !== null && partialDirectory === directory) {
+      return { names: [name, base], rank: SAME_DIRECTORY_RANK }
+    }
+
+    if (partialDirectory === APPLICATION_DIRECTORY) {
+      return { names: [name, base], rank: APPLICATION_RANK }
+    }
+
+    return { names: [name], rank: DISTANCE_RANK_OFFSET + this.distanceBetween(directory, partialDirectory) }
+  }
+
+  private distanceBetween(from: string | null, to: string): number {
+    if (from === null) return 0
+
+    const fromSegments = from === "" ? [] : from.split("/")
+    const toSegments = to === "" ? [] : to.split("/")
+
+    let shared = 0
+
+    while (shared < fromSegments.length && shared < toSegments.length && fromSegments[shared] === toSegments[shared]) {
+      shared++
+    }
+
+    return (fromSegments.length - shared) + (toSegments.length - shared)
+  }
+
+  private directoryOf(file: string, viewRoot: string): string | null {
+    const name = partialNameForFile(file, viewRoot) ?? templateNameForFile(file, viewRoot)
+
+    if (name === null) return null
+
+    const separator = name.lastIndexOf("/")
+
+    return separator === -1 ? "" : name.slice(0, separator)
+  }
+
+  private partialDocumentation(declaration: PartialDeclaration) {
+    if (!declaration.hasDeclaration) return undefined
+
+    const signature = strictLocalsDeclaration({
+      locals: declaration.locals,
+      callSiteCount: 0,
+      keywordRest: declaration.hasKeywordRest,
+    })
+
+    return {
+      kind: MarkupKind.Markdown,
+      value: ["```erb", signature, "```"].join("\n"),
+    }
+  }
+
+  private getHelperCompletions(prefix: string, closed: boolean): CompletionList | null {
     const items: CompletionItem[] = HELPERS
       .filter(helper => helper.name.startsWith(prefix))
       .map((helper, index) => {
@@ -375,6 +783,8 @@ export class CompletionService {
           helper.description,
           helper.documentationURL ? `[Documentation](${helper.documentationURL})` : null,
         ].filter(Boolean).join("\n\n")
+
+        const rendersPartial = helper.name === RENDER_HELPER
 
         return {
           label: helper.name,
@@ -385,8 +795,9 @@ export class CompletionService {
             value: documentation,
           },
           sortText: `!00${String(index).padStart(3, "0")}`,
-          insertTextFormat: InsertTextFormat.PlainText,
-          insertText: helper.name,
+          insertTextFormat: rendersPartial ? InsertTextFormat.Snippet : InsertTextFormat.PlainText,
+          insertText: rendersPartial ? `${RENDER_HELPER} partial: "$0"${closed ? "" : " %>"}` : helper.name,
+          command: rendersPartial ? TRIGGER_SUGGEST : undefined,
         }
       })
 

--- a/javascript/packages/language-server/src/definition_service.ts
+++ b/javascript/packages/language-server/src/definition_service.ts
@@ -16,7 +16,7 @@ const VIEWS_DIRECTORY = "/app/views/"
 const APPLICATION_DIRECTORY = "application"
 const TEMPLATE_EXTENSIONS = ["html.erb", "html.herb", "turbo_stream.erb", "turbo_stream.herb", "erb", "herb"]
 const PARTIAL_NAME = /^[a-zA-Z0-9_-]+(\/[a-zA-Z0-9_-]+)*$/
-const PARTIAL_KEYWORDS = ["partial", "layout"]
+const PARTIAL_KEYWORDS = ["partial", "layout", "spacer_template"]
 const IDENTIFIER_CHARACTER = /[A-Za-z0-9_]/
 const QUOTE = /^["']/
 const SNIPPET_LINES = 6
@@ -146,11 +146,47 @@ export class DefinitionService {
 
     collector.visit(result.value as DocumentNode)
 
-    return collector.renders.flatMap(render => this.referenceFor(document, render) ?? [])
+    return collector.renders.flatMap(render => this.referencesFor(document, render))
   }
 
   referenceAt(document: TextDocument, position: Position): PartialReference | null {
-    return this.partialReferences(document).find(reference => isPositionInRange(position, reference.triggerRange)) ?? null
+    const matches = this.partialReferences(document).filter(reference => isPositionInRange(position, reference.triggerRange))
+
+    if (matches.length === 0) return null
+
+    return matches.reduce((narrowest, reference) => (
+      this.rangeSize(document, reference.triggerRange) < this.rangeSize(document, narrowest.triggerRange) ? reference : narrowest
+    ))
+  }
+
+  private rangeSize(document: TextDocument, range: Range): number {
+    return document.offsetAt(range.end) - document.offsetAt(range.start)
+  }
+
+  private referencesFor(document: TextDocument, render: ERBRenderNode): PartialReference[] {
+    const rendered = this.referenceFor(document, render)
+    const spacer = this.spacerReferenceFor(document, render)
+
+    return [rendered, spacer].filter(reference => reference !== null)
+  }
+
+  private spacerReferenceFor(document: TextDocument, render: ERBRenderNode): PartialReference | null {
+    const spacer = render.keywords?.spacer_template
+
+    if (!spacer) return null
+
+    const range = lspRangeFromLocation(spacer.location)
+
+    const reference = {
+      name: spacer.value,
+      keyword: "partial",
+      quoted: QUOTE.test(spacer.value) || QUOTE.test(document.getText(range)),
+      derived: false,
+      triggerRange: this.withKeyword(document, range),
+      originRange: this.withoutQuotes(document, range),
+    }
+
+    return this.isStatic(reference) ? reference : null
   }
 
   private referenceFor(document: TextDocument, render: ERBRenderNode): PartialReference | null {

--- a/javascript/packages/language-server/src/server.ts
+++ b/javascript/packages/language-server/src/server.ts
@@ -77,7 +77,7 @@ export class Server {
           documentHighlightProvider: true,
           hoverProvider: true,
           completionProvider: {
-            triggerCharacters: [".", ":", "<", "&"],
+            triggerCharacters: [".", ":", "<", "&", "\"", "'", "/", ",", " ", "@"],
           },
           definitionProvider: true,
           referencesProvider: true,

--- a/javascript/packages/language-server/src/service.ts
+++ b/javascript/packages/language-server/src/service.ts
@@ -75,7 +75,7 @@ export class Service {
     this.definitionService = new DefinitionService(this.parserService)
     this.referencesService = new ReferencesService(this.project, this.definitionService, this.partialIndexService, this.partialCallerIndexService, this.documentService)
     this.commentService = new CommentService(this.parserService)
-    this.completionService = new CompletionService(this.parserService)
+    this.completionService = new CompletionService(this.parserService, this.partialIndexService)
 
     this.extractCodeActionService = new ExtractCodeActionService(this.parserService, {
       supportsCreateFile: this.settings.supportsResourceCreation,

--- a/javascript/packages/language-server/test/completion_service.test.ts
+++ b/javascript/packages/language-server/test/completion_service.test.ts
@@ -1,10 +1,19 @@
-import { describe, it, expect, beforeAll } from "vitest"
-import { CompletionItemKind, InsertTextFormat, MarkupKind, Position } from "vscode-languageserver/node"
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest"
+import { CompletionItemKind, InsertTextFormat, MarkupKind, Position, Range } from "vscode-languageserver/node"
 import { TextDocument } from "vscode-languageserver-textdocument"
+
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join, dirname } from "node:path"
+import { pathToFileURL } from "node:url"
 
 import { Herb } from "@herb-tools/node-wasm"
 import { CompletionService } from "../src/completion_service"
 import { ParserService } from "../src/parser_service"
+import { PartialIndexService } from "../src/partial_index_service"
+import { Project } from "../src/project"
+
+import type { Connection } from "vscode-languageserver/node"
 
 describe("CompletionService", () => {
   let service: CompletionService
@@ -587,6 +596,738 @@ describe("CompletionService", () => {
       const labels = result!.items.map(item => item.label)
       expect(labels).toContain("tag")
       expect(labels).not.toContain("div")
+    })
+  })
+
+  describe("partial name completions", () => {
+    let partialService: CompletionService
+    let root: string
+
+    const connection = {
+      console: { log: vi.fn(), warn: vi.fn(), error: vi.fn() }
+    } as unknown as Connection
+
+    const FILES = {
+      "app/views/posts/_card.html.erb": `<%# locals: (post:) %>\n`,
+      "app/views/posts/_byline.html.erb": `<span></span>\n`,
+      "app/views/posts/comments/_comment.html.erb": `<%# locals: (body:, author: nil) %>\n<p></p>\n`,
+      "app/views/users/_avatar.html.erb": `<img>\n`,
+      "app/views/application/_flash.html.erb": `<div></div>\n`,
+      "app/views/_header.html.erb": `<header></header>\n`,
+      "app/views/posts/index.html.erb": `<div></div>\n`,
+      "app/views/posts/comments/index.html.erb": `<div></div>\n`,
+    }
+
+    beforeAll(async () => {
+      root = mkdtempSync(join(tmpdir(), "herb-lsp-completion-"))
+
+      for (const [path, contents] of Object.entries(FILES)) {
+        const file = join(root, path)
+
+        mkdirSync(dirname(file), { recursive: true })
+        writeFileSync(file, contents, "utf-8")
+      }
+
+      const project = { projectPath: root, herbBackend: Herb } as Project
+      const partials = new PartialIndexService(connection, project)
+
+      await partials.initialize()
+
+      partialService = new CompletionService(new ParserService(), partials)
+    })
+
+    afterAll(() => {
+      rmSync(root, { recursive: true, force: true })
+    })
+
+    function completeIn(content: string, path = "app/views/posts/index.html.erb", anchor?: string) {
+      const uri = pathToFileURL(join(root, path)).toString()
+      const document = TextDocument.create(uri, "erb", 1, content)
+      const offset = anchor ? content.indexOf(anchor) + anchor.length : content.length
+
+      return partialService.getCompletions(document, document.positionAt(offset))
+    }
+
+    function labelsIn(content: string, path?: string, anchor?: string): string[] {
+      return (completeIn(content, path, anchor)?.items ?? []).map(item => item.label)
+    }
+
+    it("lists every partial inside `render partial: \"`", () => {
+      expect(labelsIn(`<%= render partial: "`).sort()).toEqual([
+        "application/flash",
+        "header",
+        "posts/byline",
+        "posts/card",
+        "posts/comments/comment",
+        "users/avatar",
+      ])
+    })
+
+    it("lists partials for a positional `render \"`", () => {
+      expect(labelsIn(`<%= render "`)).toEqual([
+        "posts/byline",
+        "posts/card",
+        "application/flash",
+        "header",
+        "posts/comments/comment",
+        "users/avatar",
+      ])
+    })
+
+    it("lists partials between the quotes of a closed positional call", () => {
+      expect(labelsIn(`<%= render "" %>`, undefined, `render "`)).toContain("posts/card")
+    })
+
+    it("lists partials between the quotes of a closed keyword call", () => {
+      expect(labelsIn(`<%= render partial: "" %>`, undefined, `partial: "`)).toContain("posts/card")
+    })
+
+    it("filters a positional `render \"` by a qualified prefix", () => {
+      expect(labelsIn(`<%= render "posts/`)).toEqual([
+        "posts/byline",
+        "posts/card",
+        "posts/comments/comment",
+      ])
+    })
+
+    it("matches a positional `render \"` by a relative name", () => {
+      expect(labelsIn(`<%= render "car`)).toEqual(["posts/card"])
+    })
+
+    it("supports a positional `render '` in single quotes", () => {
+      expect(labelsIn(`<%= render 'car`)).toEqual(["posts/card"])
+    })
+
+    it("supports a positional `render(\"`", () => {
+      expect(labelsIn(`<%= render("car`)).toEqual(["posts/card"])
+    })
+
+    it("does not complete a non-partial keyword such as `collection:`", () => {
+      expect(labelsIn(`<%= render collection: "`)).toEqual([])
+    })
+
+    it("supports single quotes", () => {
+      expect(labelsIn(`<%= render partial: '`)).toContain("posts/card")
+    })
+
+    it("supports a parenthesized call", () => {
+      expect(labelsIn(`<%= render(partial: "`)).toContain("posts/card")
+    })
+
+    it("supports the hash rocket form", () => {
+      expect(labelsIn(`<%= render :partial => "`)).toContain("posts/card")
+    })
+
+    it("supports `layout:`", () => {
+      expect(labelsIn(`<%= render layout: "`)).toContain("posts/card")
+    })
+
+    it("supports `spacer_template:` later in the argument list", () => {
+      expect(labelsIn(`<%= render partial: "posts/card", collection: @posts, spacer_template: "`)).toContain("posts/byline")
+    })
+
+    it("supports `layout:` later in the argument list", () => {
+      expect(labelsIn(`<%= render partial: "posts/card", layout: "`)).toContain("posts/byline")
+    })
+
+    it("supports a keyword split across lines", () => {
+      expect(labelsIn(`<%= render partial: "posts/card",\n      spacer_template: "`)).toContain("posts/byline")
+    })
+
+    it("does not complete inside a `locals:` hash value", () => {
+      expect(labelsIn(`<%= render partial: "posts/card", locals: { title: "`)).toEqual([])
+    })
+
+    it("does not prefill locals when completing a `spacer_template:`", () => {
+      const content = `<%= render partial: "posts/card", spacer_template: "card" %>`
+      const uri = pathToFileURL(join(root, "app/views/posts/index.html.erb")).toString()
+      const document = TextDocument.create(uri, "erb", 1, content)
+      const [item] = partialService.getCompletions(document, document.positionAt(content.lastIndexOf(`card"`) + 4))!.items
+
+      expect(item.textEdit).toHaveProperty("newText", "posts/card")
+    })
+
+    it("filters by a qualified prefix", () => {
+      expect(labelsIn(`<%= render partial: "users/`)).toEqual(["users/avatar"])
+    })
+
+    it("matches a partial in the same directory by its relative name", () => {
+      expect(labelsIn(`<%= render partial: "car`)).toEqual(["posts/card"])
+    })
+
+    it("matches an `application/` partial by its relative name", () => {
+      expect(labelsIn(`<%= render partial: "fla`)).toEqual(["application/flash"])
+    })
+
+    it("ranks partials in the same directory ahead of the rest", () => {
+      expect(labelsIn(`<%= render partial: "`)).toEqual([
+        "posts/byline",
+        "posts/card",
+        "application/flash",
+        "header",
+        "posts/comments/comment",
+        "users/avatar",
+      ])
+    })
+
+    it("ranks by how far the partial sits from the current file", () => {
+      expect(labelsIn(`<%= render partial: "`, "app/views/posts/comments/index.html.erb")).toEqual([
+        "posts/comments/comment",
+        "application/flash",
+        "posts/byline",
+        "posts/card",
+        "header",
+        "users/avatar",
+      ])
+    })
+
+    it("inserts the fully qualified name over a relative prefix", () => {
+      const content = `<%= render partial: "byl" %>`
+      const uri = pathToFileURL(join(root, "app/views/posts/index.html.erb")).toString()
+      const document = TextDocument.create(uri, "erb", 1, content)
+      const [item] = partialService.getCompletions(document, document.positionAt(content.indexOf(`byl"`) + 3))!.items
+
+      expect(item.textEdit).toEqual({
+        range: {
+          start: { line: 0, character: content.indexOf("byl") },
+          end: { line: 0, character: content.indexOf(`" %>`) },
+        },
+        newText: "posts/byline",
+      })
+    })
+
+    it("prefills required locals as tab stops for the `partial:` form", () => {
+      const content = `<%= render partial: "card" %>`
+      const uri = pathToFileURL(join(root, "app/views/posts/index.html.erb")).toString()
+      const document = TextDocument.create(uri, "erb", 1, content)
+      const [item] = partialService.getCompletions(document, document.positionAt(content.indexOf(`card"`) + 4))!.items
+
+      expect(item.insertTextFormat).toBe(InsertTextFormat.Snippet)
+      expect(item.textEdit).toEqual({
+        range: {
+          start: { line: 0, character: content.indexOf("card") },
+          end: { line: 0, character: content.indexOf(`" %>`) + 1 },
+        },
+        newText: `posts/card", locals: { post: \${1:post} }$0`,
+      })
+    })
+
+    it("spells out `partial:` when completing the positional form", () => {
+      expect(applyFirst(`<%= render "card" %>`)).toBe(`<%= render partial: "posts/card", locals: { post: \${1:post} }$0 %>`)
+    })
+
+    it("spells out `partial:` even when the partial has no required locals", () => {
+      expect(applyFirst(`<%= render "byl" %>`, "byl")).toBe(`<%= render partial: "posts/byline" %>`)
+    })
+
+    it("leaves the positional form alone when other arguments follow", () => {
+      expect(applyFirst(`<%= render "card", post: @post %>`)).toBe(`<%= render "posts/card", post: @post %>`)
+    })
+
+    it("leaves bare locals unwrapped when completing into an empty name", () => {
+      expect(applyFirst(`<%= render "", posts: @posts %>`, `render "`)).toBe(`<%= render "posts/byline", posts: @posts %>`)
+    })
+
+    describe("render keywords", () => {
+      it("expands the `render` helper straight into a partial call", () => {
+        const [item] = (completeIn(`<%= ren %>`, undefined, `<%= ren`)?.items ?? []).filter(candidate => candidate.label === "render")
+
+        expect(item.insertTextFormat).toBe(InsertTextFormat.Snippet)
+        expect(item.insertText).toBe(`render partial: "$0"`)
+        expect(item.command).toEqual({ title: "Suggest", command: "editor.action.triggerSuggest" })
+      })
+
+      it("closes the ERB tag when expanding `render` into an unterminated tag", () => {
+        const [item] = (completeIn(`<%= ren`)?.items ?? []).filter(candidate => candidate.label === "render")
+
+        expect(item.insertText).toBe(`render partial: "$0" %>`)
+      })
+
+      it("leaves other helpers as plain text", () => {
+        const [item] = (completeIn(`<%= link_t`)?.items ?? []).filter(candidate => candidate.label === "link_to")
+
+        expect(item.insertTextFormat).toBe(InsertTextFormat.PlainText)
+        expect(item.insertText).toBe("link_to")
+      })
+
+      it("offers every render option Action View accepts in a view", () => {
+        expect(labelsIn(`<%= render `).sort()).toEqual([
+          "as",
+          "body",
+          "cached",
+          "collection",
+          "file",
+          "formats",
+          "handlers",
+          "html",
+          "inline",
+          "layout",
+          "locals",
+          "object",
+          "partial",
+          "plain",
+          "renderable",
+          "spacer_template",
+          "template",
+          "variants",
+        ])
+      })
+
+      it("gives every option a value shaped like its type", () => {
+        const expected: Record<string, string> = {
+          partial: `partial: "$0"`,
+          template: `template: "$0"`,
+          layout: `layout: "$0"`,
+          spacer_template: `spacer_template: "$0"`,
+          file: `file: "$0"`,
+          inline: `inline: "$0"`,
+          plain: `plain: "$0"`,
+          html: `html: "$0"`,
+          body: `body: "$0"`,
+          collection: `collection: \${1:[]}`,
+          formats: `formats: \${1:[]}`,
+          variants: `variants: \${1:[]}`,
+          handlers: `handlers: \${1:[]}`,
+          object: `object: \${1:nil}`,
+          renderable: `renderable: \${1:nil}`,
+          as: `as: :$0`,
+          cached: `cached: $0`,
+          locals: `locals: { $0 }`,
+        }
+
+        const snippets = Object.fromEntries(
+          (completeIn(`<%= render `)?.items ?? []).map(item => [item.label, (item.textEdit as { newText: string }).newText])
+        )
+
+        expect(snippets).toEqual(expected)
+      })
+
+      it("sorts render suggestions ahead of the general purpose ones", () => {
+        const insideRender = (completeIn(`<%= render `)?.items ?? []).map(item => item.sortText!)
+        const [helper] = (completeIn(`<%= link_t`)?.items ?? []).map(item => item.sortText!)
+
+        expect(insideRender.every(sortText => sortText < helper)).toBe(true)
+      })
+
+      it("offers locals rather than render options in the shorthand form", () => {
+        const labels = labelsIn(`<%= render "posts/comments/comment", `)
+
+        expect(labels).toEqual(["body", "author"])
+        expect(labels).not.toContain("collection")
+      })
+
+      it("offers variables for any shorthand local's value", () => {
+        const content = `<% @body = 1 %>\n<%= render "posts/comments/comment", body: `
+
+        expect(labelsIn(content)).toContain("@body")
+      })
+
+      it("still offers render options once `partial:` names the partial", () => {
+        expect(labelsIn(`<%= render partial: "posts/comments/comment", `)).toContain("collection")
+      })
+
+      it("offers the render options after a comma", () => {
+        const labels = labelsIn(`<%= render partial: "posts/card", `)
+
+        expect(labels).toContain("collection")
+        expect(labels).toContain("spacer_template")
+        expect(labels).toContain("locals")
+        expect(labels).toContain("as")
+        expect(labels).toContain("cached")
+      })
+
+      it("offers the render options after a trailing comma before `%>`", () => {
+        const content = `<%= render partial: "browse/kind_row", %>`
+        const uri = pathToFileURL(join(root, "app/views/posts/index.html.erb")).toString()
+        const document = TextDocument.create(uri, "erb", 1, content)
+        const labels = (partialService.getCompletions(document, document.positionAt(content.indexOf(`, %>`) + 2))?.items ?? []).map(item => item.label)
+
+        expect(labels).toContain("collection")
+        expect(labels).toContain("locals")
+      })
+
+      it("offers the render options directly after `render`", () => {
+        expect(labelsIn(`<%= render `)).toContain("partial")
+      })
+
+      it("does not offer a keyword that is already written", () => {
+        const labels = labelsIn(`<%= render partial: "posts/card", collection: @posts, `)
+
+        expect(labels).not.toContain("partial")
+        expect(labels).not.toContain("collection")
+        expect(labels).toContain("spacer_template")
+      })
+
+      it("filters the options by prefix", () => {
+        expect(labelsIn(`<%= render partial: "posts/card", spa`)).toEqual(["spacer_template"])
+      })
+
+      it("expands `locals` into an empty hash", () => {
+        const [item] = completeIn(`<%= render partial: "posts/card", loc`)!.items
+
+        expect(item.textEdit).toHaveProperty("newText", "locals: { $0 }")
+      })
+
+      it("expands an option with no known shape to a bare keyword", () => {
+        const [item] = completeIn(`<%= render partial: "posts/card", cach`)!.items
+
+        expect(item.textEdit).toHaveProperty("newText", "cached: $0")
+      })
+
+      it("expands `object` to a selectable nil", () => {
+        const [item] = completeIn(`<%= render partial: "posts/card", obj`)!.items
+
+        expect(item.textEdit).toHaveProperty("newText", `object: \${1:nil}`)
+      })
+
+      it("expands a symbol option with a leading colon", () => {
+        const [item] = completeIn(`<%= render partial: "posts/card", as`)!.items
+
+        expect(item.label).toBe("as")
+        expect(item.textEdit).toHaveProperty("newText", "as: :$0")
+      })
+
+      it("expands `collection` to a selectable empty array", () => {
+        const [item] = completeIn(`<%= render partial: "posts/card", collec`)!.items
+
+        expect(item.insertTextFormat).toBe(InsertTextFormat.Snippet)
+        expect(item.textEdit).toHaveProperty("newText", `collection: \${1:[]}`)
+      })
+
+      it("expands every array option the same way", () => {
+        for (const [typed, label] of [["form", "formats"], ["vari", "variants"], ["hand", "handlers"]]) {
+          const [item] = completeIn(`<%= render partial: "posts/card", ${typed}`)!.items
+
+          expect([label, item.label]).toEqual([label, label])
+          expect(item.textEdit).toHaveProperty("newText", `${label}: \${1:[]}`)
+        }
+      })
+
+      it("puts the cursor between the quotes of a string option", () => {
+        const [item] = completeIn(`<%= render partial: "posts/card", tem`)!.items
+
+        expect(item.textEdit).toHaveProperty("newText", `template: "$0"`)
+      })
+
+      it("expands a string option with the quotes and the cursor between them", () => {
+        const [item] = completeIn(`<%= render par`)!.items
+
+        expect(item.label).toBe("partial")
+        expect(item.textEdit).toHaveProperty("newText", `partial: "$0"`)
+      })
+
+      it("expands `spacer_template` with quotes too", () => {
+        const [item] = completeIn(`<%= render partial: "posts/card", spa`)!.items
+
+        expect(item.textEdit).toHaveProperty("newText", `spacer_template: "$0"`)
+      })
+
+      it("reopens the suggestions after an option that has a list", () => {
+        for (const [typed, label] of [["par", "partial"], ["lay", "layout"], ["spa", "spacer_template"], ["loc", "locals"]]) {
+          const [item] = completeIn(`<%= render ${typed}`)!.items
+
+          expect([label, item.label]).toEqual([label, label])
+          expect(item.command).toEqual({ title: "Suggest", command: "editor.action.triggerSuggest" })
+        }
+      })
+
+      it("does not reopen the suggestions for an option with nothing to list", () => {
+        const [item] = completeIn(`<%= render partial: "posts/card", collec`)!.items
+
+        expect(item.command).toBeUndefined()
+      })
+
+      it("offers the partial list once the quotes are in place", () => {
+        expect(labelsIn(`<%= render partial: "`)).toContain("posts/card")
+      })
+
+      it("documents the option", () => {
+        const [item] = completeIn(`<%= render partial: "posts/card", spa`)!.items
+
+        expect(item.detail).toBe("string")
+        expect(item.documentation).toEqual({
+          kind: MarkupKind.Markdown,
+          value: "Partial rendered between the items of a collection.",
+        })
+      })
+
+      it("offers nothing inside an unterminated string argument", () => {
+        expect(labelsIn(`<%= render partial: "posts/card", spacer_template: "unclosed`)).not.toContain("collection")
+      })
+    })
+
+    describe("strict locals", () => {
+      it("offers the strict locals of the rendered partial", () => {
+        expect(labelsIn(`<%= render partial: "posts/comments/comment", locals: { `)).toEqual(["body", "author"])
+      })
+
+      it("offers them for the positional form too", () => {
+        expect(labelsIn(`<%= render "posts/comments/comment", locals: { `)).toEqual(["body", "author"])
+      })
+
+      it("does not offer a local that is already passed", () => {
+        expect(labelsIn(`<%= render partial: "posts/comments/comment", locals: { body: @body, `)).toEqual(["author"])
+      })
+
+      it("filters the locals by prefix", () => {
+        expect(labelsIn(`<%= render partial: "posts/comments/comment", locals: { aut`)).toEqual(["author"])
+      })
+
+      it("marks whether the local is required", () => {
+        const items = completeIn(`<%= render partial: "posts/comments/comment", locals: { `)!.items
+
+        expect(items.map(item => [item.label, item.detail])).toEqual([["body", "required"], ["author", "optional"]])
+      })
+
+      it("inserts the local as a tab stop", () => {
+        const [item] = completeIn(`<%= render partial: "posts/comments/comment", locals: { aut`)!.items
+
+        expect(item.textEdit).toHaveProperty("newText", `author: \${1:author}$0`)
+      })
+
+      it("offers nothing when the partial declares no strict locals", () => {
+        expect(completeIn(`<%= render partial: "posts/byline", locals: { `)).toBeNull()
+      })
+
+      it("offers nothing when the partial cannot be resolved", () => {
+        expect(completeIn(`<%= render partial: "nope/missing", locals: { `)).toBeNull()
+      })
+
+      it("does not offer render options inside the locals hash", () => {
+        expect(labelsIn(`<%= render partial: "posts/comments/comment", locals: { `)).not.toContain("collection")
+      })
+
+      it("offers the template's variables as a local's value", () => {
+        const content = `<% @posts.each do |post| %>\n<%= render partial: "posts/comments/comment", locals: { body: `
+        const labels = labelsIn(content)
+
+        expect(labels).toContain("@posts")
+        expect(labels).toContain("post")
+      })
+
+      it("ranks the variable that matches the local being assigned first", () => {
+        const content = `<% @body = 1 %>\n<% other = 2 %>\n<%= render partial: "posts/comments/comment", locals: { body: `
+
+        expect(labelsIn(content)[0]).toBe("@body")
+      })
+
+      it("filters the variables by prefix", () => {
+        const content = `<% @posts = 1 %>\n<% author = 2 %>\n<%= render partial: "posts/comments/comment", locals: { body: @po`
+
+        expect(labelsIn(content)).toEqual(["@posts"])
+      })
+
+      it("labels instance variables and locals distinctly", () => {
+        const content = `<% @posts.each do |post| %>\n<%= render partial: "posts/comments/comment", locals: { body: `
+        const items = completeIn(content)!.items
+        const kinds = Object.fromEntries(items.map(item => [item.label, item.detail]))
+
+        expect(kinds["@posts"]).toBe("instance variable")
+        expect(kinds["post"]).toBe("local variable")
+      })
+
+      it("offers variables for `collection:` too", () => {
+        const content = `<% @posts = 1 %>\n<%= render partial: "posts/card", collection: `
+
+        expect(labelsIn(content)).toContain("@posts")
+      })
+
+      it("does not offer variables for a string option", () => {
+        const content = `<% @posts = 1 %>\n<%= render partial: "posts/card", template: `
+
+        expect(labelsIn(content)).not.toContain("@posts")
+      })
+
+      it("reopens the suggestions on the tab stop a strict local inserts", () => {
+        const [item] = completeIn(`<%= render partial: "posts/comments/comment", locals: { bod`)!.items
+
+        expect(item.textEdit).toHaveProperty("newText", `body: \${1:body}$0`)
+        expect(item.command).toEqual({ title: "Suggest", command: "editor.action.triggerSuggest" })
+      })
+
+      it("offers the matching instance variable on the tab stop the prefill leaves selected", () => {
+        const content = `<% @body = 1 %>\n<%= render partial: "posts/comments/comment", locals: { body: body`
+
+        expect(labelsIn(content)).toEqual(["@body"])
+      })
+
+      it("matches an instance variable from a prefix without the sigil", () => {
+        const content = `<% @body = 1 %>\n<% @other = 2 %>\n<%= render partial: "posts/comments/comment", locals: { body: bod`
+
+        expect(labelsIn(content)).toEqual(["@body"])
+      })
+
+      it("brings its own space when the cursor sits right after the colon", () => {
+        const content = `<% @user = 1 %>\n<%= render partial: "users/card", locals: { user: } %>`
+        const uri = pathToFileURL(join(root, "app/views/posts/index.html.erb")).toString()
+        const document = TextDocument.create(uri, "erb", 1, content)
+        const [item] = partialService.getCompletions(document, document.positionAt(content.indexOf("user: }") + 5))!.items
+
+        expect(item.textEdit).toHaveProperty("newText", " @user")
+      })
+
+      it("does not double the space when one is already there", () => {
+        const content = `<% @user = 1 %>\n<%= render partial: "users/card", locals: { user: } %>`
+        const uri = pathToFileURL(join(root, "app/views/posts/index.html.erb")).toString()
+        const document = TextDocument.create(uri, "erb", 1, content)
+        const [item] = partialService.getCompletions(document, document.positionAt(content.indexOf("user: }") + 6))!.items
+
+        expect(item.textEdit).toHaveProperty("newText", "@user")
+      })
+
+      it("offers instance variables from a bare `@`", () => {
+        const content = `<% @user = 1 %>\n<% other = 2 %>\n<%= render partial: "users/card", locals: { user: @`
+
+        expect(labelsIn(content)).toEqual(["@user"])
+      })
+
+      it("spaces a strict local inserted right after a comma", () => {
+        const [item] = completeIn(`<%= render partial: "posts/comments/comment", locals: { body: @b,`)!.items
+
+        expect(item.textEdit).toHaveProperty("newText", ` author: \${1:author}$0`)
+      })
+
+      it("spaces a render keyword inserted right after a comma", () => {
+        const [item] = completeIn(`<%= render partial: "posts/card",`)!.items
+
+        expect((item.textEdit as { newText: string }).newText.startsWith(" ")).toBe(true)
+      })
+
+      it("offers nothing inside a local's string value", () => {
+        expect(completeIn(`<%= render partial: "posts/comments/comment", locals: { body: "unclosed`)).toBeNull()
+      })
+
+      it("offers nothing inside a nested hash value", () => {
+        expect(completeIn(`<%= render partial: "posts/comments/comment", locals: { body: { nested: `)).toBeNull()
+      })
+    })
+
+    it("offers nothing inside a `render ... do` block, which is not supported yet", () => {
+      const content = `<%= render "card" do %>`
+      const uri = pathToFileURL(join(root, "app/views/posts/index.html.erb")).toString()
+      const document = TextDocument.create(uri, "erb", 1, content)
+
+      expect(partialService.getCompletions(document, document.positionAt(content.indexOf(`card"`) + 4))).toBeNull()
+    })
+
+    it("does not rewrite `layout:` into `partial:`", () => {
+      expect(applyFirst(`<%= render layout: "card" %>`)).toBe(`<%= render layout: "posts/card", locals: { post: \${1:post} }$0 %>`)
+    })
+
+    it("keeps the hash rocket form as written", () => {
+      expect(applyFirst(`<%= render :partial => "card" %>`)).toBe(`<%= render :partial => "posts/card", locals: { post: \${1:post} }$0 %>`)
+    })
+
+    it("completes the closing quote when the string is still open", () => {
+      const content = `<%= render partial: "card %>`
+      const uri = pathToFileURL(join(root, "app/views/posts/index.html.erb")).toString()
+      const document = TextDocument.create(uri, "erb", 1, content)
+      const [item] = partialService.getCompletions(document, document.positionAt(content.indexOf(" %>")))!.items
+
+      expect(item.textEdit).toHaveProperty("newText", `posts/card", locals: { post: \${1:post} }$0`)
+    })
+
+    function applyFirst(content: string, typed = "card"): string {
+      const uri = pathToFileURL(join(root, "app/views/posts/index.html.erb")).toString()
+      const document = TextDocument.create(uri, "erb", 1, content)
+      const position = document.positionAt(content.indexOf(typed) + typed.length)
+      const [item] = partialService.getCompletions(document, position)!.items
+      const edit = item.textEdit as { range: Range, newText: string }
+
+      return content.slice(0, document.offsetAt(edit.range.start)) + edit.newText + content.slice(document.offsetAt(edit.range.end))
+    }
+
+    it("keeps a space before `%>` when nothing separates it from the name", () => {
+      expect(applyFirst(`<%= render partial: "card"%>`)).toBe(`<%= render partial: "posts/card", locals: { post: \${1:post} } $0%>`)
+    })
+
+    it("does not add a second space when one already precedes `%>`", () => {
+      expect(applyFirst(`<%= render partial: "card" %>`)).toBe(`<%= render partial: "posts/card", locals: { post: \${1:post} }$0 %>`)
+    })
+
+    it("closes an unterminated ERB tag", () => {
+      expect(applyFirst(`<%= render partial: "card`)).toBe(`<%= render partial: "posts/card", locals: { post: \${1:post} } $0%>`)
+    })
+
+    it("closes an unterminated ERB tag for the positional form", () => {
+      expect(applyFirst(`<%= render "card`)).toBe(`<%= render partial: "posts/card", locals: { post: \${1:post} } $0%>`)
+    })
+
+    it("closes an unterminated ERB tag for a partial with no required locals", () => {
+      expect(applyFirst(`<%= render partial: "byl`, "byl")).toBe(`<%= render partial: "posts/byline" $0%>`)
+    })
+
+    it("closes an unterminated ERB tag without swallowing the lines below it", () => {
+      expect(applyFirst(`<div>\n  <%= render "card\n</div>`)).toBe(`<div>\n  <%= render partial: "posts/card", locals: { post: \${1:post} } $0%>\n</div>`)
+    })
+
+    it("does not add a second `%>` when the tag closes on a later line", () => {
+      expect(applyFirst(`<%= render partial: "card"\n%>`)).toBe(`<%= render partial: "posts/card", locals: { post: \${1:post} }$0\n%>`)
+    })
+
+    it("leaves locals written for another partial untouched", () => {
+      const content = `<%= render partial: "posts/comments/com", locals: { layers: user } %>`
+      const uri = pathToFileURL(join(root, "app/views/posts/index.html.erb")).toString()
+      const document = TextDocument.create(uri, "erb", 1, content)
+      const [item] = partialService.getCompletions(document, document.positionAt(content.indexOf(`com"`) + 3))!.items
+      const edit = item.textEdit as { range: Range, newText: string }
+      const applied = content.slice(0, document.offsetAt(edit.range.start)) + edit.newText + content.slice(document.offsetAt(edit.range.end))
+
+      expect(applied).toBe(`<%= render partial: "posts/comments/comment", locals: { layers: user } %>`)
+    })
+
+    it("leaves an already closed tag with arguments untouched", () => {
+      expect(applyFirst(`<%= render partial: "card", locals: { post: @post } %>`)).toBe(`<%= render partial: "posts/card", locals: { post: @post } %>`)
+    })
+
+    it("does not prefill locals when the partial has none required", () => {
+      const content = `<%= render partial: "byline" %>`
+      const uri = pathToFileURL(join(root, "app/views/posts/index.html.erb")).toString()
+      const document = TextDocument.create(uri, "erb", 1, content)
+      const [item] = partialService.getCompletions(document, document.positionAt(content.indexOf(`" %>`)))!.items
+
+      expect(item.insertTextFormat).toBe(InsertTextFormat.PlainText)
+      expect(item.textEdit).toHaveProperty("newText", "posts/byline")
+    })
+
+    it("does not prefill locals when the call already passes arguments", () => {
+      const content = `<%= render partial: "card", locals: { post: @post } %>`
+      const uri = pathToFileURL(join(root, "app/views/posts/index.html.erb")).toString()
+      const document = TextDocument.create(uri, "erb", 1, content)
+      const [item] = partialService.getCompletions(document, document.positionAt(content.indexOf(`card"`) + 4))!.items
+
+      expect(item.textEdit).toHaveProperty("newText", "posts/card")
+    })
+
+    it("documents the strict locals of the partial", () => {
+      const item = completeIn(`<%= render partial: "posts/card`)!.items[0]
+
+      expect(item.documentation).toEqual({
+        kind: MarkupKind.Markdown,
+        value: "```erb\n<%# locals: (post:) %>\n```",
+      })
+    })
+
+    it("reports the partial's file as the detail", () => {
+      const item = completeIn(`<%= render partial: "posts/card`)!.items[0]
+
+      expect(item.detail).toBe("app/views/posts/_card.html.erb")
+    })
+
+    it("does not complete once the partial name is closed", () => {
+      expect(completeIn(`<%= render partial: "posts/card"`)).toBeNull()
+    })
+
+    it("does not complete in a later string argument", () => {
+      expect(labelsIn(`<%= render partial: "posts/card", locals: { title: "`)).toEqual([])
+    })
+
+    it("returns nothing when no partial index is available", () => {
+      const uri = pathToFileURL(join(root, "app/views/posts/index.html.erb")).toString()
+      const content = `<%= render partial: "`
+      const document = TextDocument.create(uri, "erb", 1, content)
+
+      expect(service.getCompletions(document, document.positionAt(content.length))).toBeNull()
     })
   })
 })

--- a/javascript/packages/language-server/test/definition_service.test.ts
+++ b/javascript/packages/language-server/test/definition_service.test.ts
@@ -516,6 +516,62 @@ describe("DefinitionService", () => {
     })
   })
 
+  describe("spacer template rendering", () => {
+    it("resolves a spacer template", () => {
+      const service = createService("/project/app/views/events/_separator.html.erb")
+      const content = `<%= render partial: "events/card", collection: @events, spacer_template: "events/separator" %>`
+
+      expect(uris(service, content, "events/separator")).toEqual([
+        "file:///project/app/views/events/_separator.html.erb"
+      ])
+    })
+
+    it("resolves the partial and the spacer independently in the same call", () => {
+      const service = createService(
+        "/project/app/views/events/_card.html.erb",
+        "/project/app/views/events/_separator.html.erb"
+      )
+      const content = `<%= render partial: "events/card", spacer_template: "events/separator" %>`
+
+      expect(uris(service, content, "events/card")).toEqual(["file:///project/app/views/events/_card.html.erb"])
+      expect(uris(service, content, "events/separator")).toEqual(["file:///project/app/views/events/_separator.html.erb"])
+    })
+
+    it("selects the spacer name rather than the whole tag", () => {
+      const service = createService("/project/app/views/events/_separator.html.erb")
+      const content = `<%= render partial: "events/card", spacer_template: "events/separator" %>`
+
+      expect(selection(service, content, "events/separator")).toBe("events/separator")
+    })
+
+    it("resolves a spacer named relative to the current directory", () => {
+      const service = createService("/project/app/views/events/_separator.html.erb")
+      const content = `<%= render partial: "card", spacer_template: "separator" %>`
+
+      expect(uris(service, content, `"separator"`)).toEqual([
+        "file:///project/app/views/events/_separator.html.erb"
+      ])
+    })
+
+    it("hovers the spacer with a link to the partial", () => {
+      const service = createService("/project/app/views/events/_separator.html.erb")
+      const content = `<%= render partial: "events/card", spacer_template: "events/separator" %>`
+      const document = TextDocument.create(VIEW_URI, "erb", 1, content)
+      const result = service.getHover(document, document.positionAt(content.indexOf("events/separator") + 1))
+
+      expect((result!.contents as { value: string }).value).toBe(
+        "[app/views/events/_separator.html.erb](file:///project/app/views/events/_separator.html.erb)"
+      )
+    })
+
+    it("returns nothing for a spacer that is not a literal", () => {
+      const service = createService("/project/app/views/events/_separator.html.erb")
+      const content = `<%= render partial: "card", spacer_template: separator %>`
+
+      expect(definitions(service, content, "separator %>")).toEqual([])
+    })
+  })
+
   describe("layout rendering", () => {
     it("resolves a layout partial", () => {
       const service = createService("/project/app/views/profiles/_tab_layout.html.erb")

--- a/javascript/packages/language-server/test/references_service.test.ts
+++ b/javascript/packages/language-server/test/references_service.test.ts
@@ -233,6 +233,29 @@ describe("ReferencesService", () => {
     ])
   })
 
+  test("reports a spacer_template alongside the render that pulls the file into the index", async () => {
+    const services = await serviceFor({
+      "app/views/posts/_card.html.erb": `<article></article>\n`,
+      "app/views/posts/index.html.erb": `<%= render partial: "posts/card" %>\n<%= render partial: "posts/list", spacer_template: "posts/card" %>\n`,
+      "app/views/posts/_list.html.erb": `<ul></ul>\n`,
+    })
+
+    expect(referencesAt(services, "app/views/posts/_card.html.erb")).toEqual([
+      "app/views/posts/index.html.erb:0 posts/card",
+      "app/views/posts/index.html.erb:1 posts/card",
+    ])
+  })
+
+  test("misses a partial that is only ever used as a spacer_template", async () => {
+    const services = await serviceFor({
+      "app/views/posts/_separator.html.erb": `<hr>\n`,
+      "app/views/posts/_card.html.erb": `<article></article>\n`,
+      "app/views/posts/index.html.erb": `<%= render partial: "posts/card", spacer_template: "posts/separator" %>\n`,
+    })
+
+    expect(referencesAt(services, "app/views/posts/_separator.html.erb")).toEqual([])
+  })
+
   test("returns nothing when the project has no call sites for the partial", async () => {
     const services = await serviceFor({
       "app/views/posts/_card.html.erb": `<article></article>\n`,

--- a/javascript/packages/vscode/package.json
+++ b/javascript/packages/vscode/package.json
@@ -45,6 +45,15 @@
   ],
   "main": "./dist/extension.js",
   "contributes": {
+    "configurationDefaults": {
+      "[erb]": {
+        "editor.quickSuggestions": {
+          "other": true,
+          "comments": false,
+          "strings": true
+        }
+      }
+    },
     "configuration": {
       "type": "object",
       "title": "Herb (HTML+ERB)",

--- a/src/analyze/render_nodes.c
+++ b/src/analyze/render_nodes.c
@@ -36,11 +36,13 @@ typedef struct {
   token_T** target;
 } keyword_field_T;
 
-// actionview/lib/action_view/render_parser.rb
+// A superset of ALL_KNOWN_KEYS in actionview/lib/action_view/render_parser.rb,
+// which only lists the keys Rails' dependency tracker will not bail out on. The
+// rendering modes and the collection options are recognized here as well.
 static const char* render_keywords[] = {
-  "partial", "template",   "layout",   "file",       "inline",       "body",     "plain",
-  "html",    "renderable", "locals",   "collection", "object",       "as",       "spacer_template",
-  "formats", "variants",   "handlers", "status",     "content_type", "location", NULL
+  "partial",      "template",   "layout", "file", "inline",          "body",    "plain",    "html",     "renderable",
+  "locals",       "collection", "object", "as",   "spacer_template", "formats", "variants", "handlers", "status",
+  "content_type", "location",   "cached", NULL
 };
 
 static bool is_render_call(pm_call_node_t* call_node, pm_parser_t* parser) {

--- a/test/analyze/render_test.rb
+++ b/test/analyze/render_test.rb
@@ -215,5 +215,11 @@ module Analyze
         <%= self.render "shared/header" %>
       HTML
     end
+
+    test "render with a cached collection" do
+      assert_parsed_snapshot(<<~HTML, render_nodes: true)
+        <%= render partial: "product", collection: @products, cached: true %>
+      HTML
+    end
   end
 end

--- a/test/snapshots/analyze/render_test/test_0036_render_with_a_cached_collection_fab09ef698ef3c4ac5f3be020ee6d0bd-f8009707a6f8814717b65550c888710c.txt
+++ b/test/snapshots/analyze/render_test/test_0036_render_with_a_cached_collection_fab09ef698ef3c4ac5f3be020ee6d0bd-f8009707a6f8814717b65550c888710c.txt
@@ -1,0 +1,42 @@
+---
+source: "Analyze::RenderTest#test_0036_render with a cached collection"
+input: |2-
+<%= render partial: "product", collection: @products, cached: true %>
+options: {render_nodes: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ ERBRenderNode (location: (1:0)-(1:69))
+    │   ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   ├── content: " render partial: "product", collection: @products, cached: true " (location: (1:3)-(1:67))
+    │   ├── tag_closing: "%>" (location: (1:67)-(1:69))
+    │   ├── keywords:
+    │   │   └── @ RubyRenderKeywordsNode (location: (1:0)-(1:69))
+    │   │       ├── partial: "product" (location: (1:20)-(1:29))
+    │   │       ├── template_path: ∅
+    │   │       ├── layout: ∅
+    │   │       ├── file: ∅
+    │   │       ├── inline_template: ∅
+    │   │       ├── body: ∅
+    │   │       ├── plain: ∅
+    │   │       ├── html: ∅
+    │   │       ├── renderable: ∅
+    │   │       ├── collection: "@products" (location: (1:43)-(1:52))
+    │   │       ├── object: ∅
+    │   │       ├── as_name: ∅
+    │   │       ├── spacer_template: ∅
+    │   │       ├── formats: ∅
+    │   │       ├── variants: ∅
+    │   │       ├── handlers: ∅
+    │   │       ├── content_type: ∅
+    │   │       └── locals: []
+    │   │
+    │   ├── body: []
+    │   ├── block_arguments: []
+    │   ├── rescue_clause: ∅
+    │   ├── else_clause: ∅
+    │   ├── ensure_clause: ∅
+    │   └── end_node: ∅
+    │
+    └── @ HTMLTextNode (location: (1:69)-(2:0))
+        └── content: "\n"


### PR DESCRIPTION
This pull request implements completion inside `<%= render %>` calls, covering the partial name, the render options, the strict locals and the values they take.

```erb
<%= render partial: "posts/card", locals: { post: @post } %>
```

Completing `render` expands it to `render partial: "…"` and opens the list of partials. Names are ranked by how far the partial sits from the current file, matched relative to it, and always inserted fully qualified. 

Picking one that declares strict locals fills the required ones in as tab stops, and each tab stop offers the instance variables and locals the template already has. After a comma the render options are offered, each with a value shaped like its type, and inside a `locals:` hash the partial's own declared locals are.

A call that already passes arguments only gets its name replaced. Completion never rewrites what is already written, and `actionview-no-strict-locals-error` already reports the mismatch when a partial is swapped for one with different locals.


https://github.com/user-attachments/assets/9e984243-c9df-441e-a72d-f5812f0a76e7




Resolves https://github.com/marcoroth/herb/issues/1389