### PR TITLE
Linter: Add `svg-no-deprecated-tags` rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# macOS
+.DS_Store
+
 # Docs
 .vitepress/dist
 .vitepress/cache

--- a/javascript/packages/linter/docs/rules/README.md
+++ b/javascript/packages/linter/docs/rules/README.md
@@ -154,6 +154,7 @@ This page contains documentation for all Herb Linter rules.
 
 #### SVG
 
+- [`svg-no-deprecated-tags`](./svg-no-deprecated-tags.md) - Disallow SVG elements removed from SVG 2
 - [`svg-tag-name-capitalization`](./svg-tag-name-capitalization.md) - Enforces proper camelCase capitalization for SVG elements
 
 

--- a/javascript/packages/linter/docs/rules/svg-no-deprecated-tags.md
+++ b/javascript/packages/linter/docs/rules/svg-no-deprecated-tags.md
@@ -1,0 +1,41 @@
+# Linter Rule: Disallow deprecated SVG tags
+
+**Rule:** `svg-no-deprecated-tags`
+
+## Description
+
+Disallows SVG elements that were removed from SVG 2 and are not supported by modern browsers.
+
+The rule covers the removed alternate-glyph elements (`altGlyph`, `altGlyphDef`, `altGlyphItem`, and `glyphRef`), `tref`, `cursor`, and the SVG Fonts elements (`font`, `glyph`, `missing-glyph`, `hkern`, `vkern`, `font-face`, `font-face-src`, `font-face-uri`, `font-face-format`, and `font-face-name`).
+
+## Rationale
+
+These elements belonged to earlier SVG specifications but have been removed in favor of interoperable web platform features. Use regular SVG text and `<use>` references, CSS cursors, and web fonts instead.
+
+## Examples
+
+### ✅ Good
+
+```erb
+<svg>
+  <text x="0" y="20">Hello, SVG</text>
+  <use href="#glyph" />
+</svg>
+```
+
+### 🚫 Bad
+
+```erb
+<svg>
+  <glyphRef xlink:href="#glyph" />
+  <altGlyphDef>
+    <altGlyphItem xlink:href="#glyph1" />
+    <altGlyphItem xlink:href="#glyph2" />
+  </altGlyphDef>
+</svg>
+```
+
+## References
+
+* [Changes from SVG 1.1 to SVG 2](https://www.w3.org/TR/SVG2/changes.html)
+* [SVG element reference](https://developer.mozilla.org/en-US/docs/Web/SVG/Element)

--- a/javascript/packages/linter/src/rules.ts
+++ b/javascript/packages/linter/src/rules.ts
@@ -28,7 +28,7 @@ import { ActionViewPreferQualifiedPartialPathRule } from "./rules/actionview-pre
 import { ActionViewStrictLocalsFirstLineRule } from "./rules/actionview-strict-locals-first-line.js"
 import { ActionViewStrictLocalsPartialOnlyRule } from "./rules/actionview-strict-locals-partial-only.js"
 
-import { ERBCommentSyntax } from "./rules/erb-comment-syntax.js";
+import { ERBCommentSyntax } from "./rules/erb-comment-syntax.js"
 import { ERBNoCaseNodeChildrenRule } from "./rules/erb-no-case-node-children.js"
 import { ERBNoCommentedOutOutputTagsRule } from "./rules/erb-no-commented-out-output-tags.js"
 import { ERBNoDebugOutputRule } from "./rules/erb-no-debug-output.js"
@@ -129,6 +129,7 @@ import { ParserNoErrorsRule } from "./rules/parser-no-errors.js"
 import { SourceIndentationRule } from "./rules/source-indentation.js"
 
 import { SVGTagNameCapitalizationRule } from "./rules/svg-tag-name-capitalization.js"
+import { SVGNoDeprecatedTagsRule } from "./rules/svg-no-deprecated-tags.js"
 
 import { TurboPermanentNoMisleadingValueRule } from "./rules/turbo-permanent-no-misleading-value.js"
 import { TurboPermanentRequireIdRule } from "./rules/turbo-permanent-require-id.js"
@@ -268,6 +269,7 @@ export const rules: RuleClass[] = [
   SourceIndentationRule,
 
   SVGTagNameCapitalizationRule,
+  SVGNoDeprecatedTagsRule,
 
   TurboPermanentNoMisleadingValueRule,
   TurboPermanentRequireIdRule,

--- a/javascript/packages/linter/src/rules/index.ts
+++ b/javascript/packages/linter/src/rules/index.ts
@@ -135,6 +135,7 @@ export * from "./parser-no-errors.js"
 export * from "./source-indentation.js"
 
 export * from "./svg-tag-name-capitalization.js"
+export * from "./svg-no-deprecated-tags.js"
 
 export * from "./turbo-permanent-no-misleading-value.js"
 export * from "./turbo-permanent-require-id.js"

--- a/javascript/packages/linter/src/rules/svg-no-deprecated-tags.ts
+++ b/javascript/packages/linter/src/rules/svg-no-deprecated-tags.ts
@@ -14,10 +14,10 @@ import type {
   ParserOptions,
 } from "@herb-tools/core"
 
-const DEPRECATED_SVG_ELEMENTS = new Set([
-  "altglyph",
-  "altglyphdef",
-  "altglyphitem",
+export const DEPRECATED_SVG_ELEMENTS = [
+  "altGlyph",
+  "altGlyphDef",
+  "altGlyphItem",
   "cursor",
   "font",
   "font-face",
@@ -26,12 +26,12 @@ const DEPRECATED_SVG_ELEMENTS = new Set([
   "font-face-src",
   "font-face-uri",
   "glyph",
-  "glyphref",
+  "glyphRef",
   "hkern",
   "missing-glyph",
   "tref",
   "vkern",
-])
+] as const
 
 class SVGNoDeprecatedTagsVisitor extends ElementStackVisitor {
   visitHTMLOpenTagNode(node: HTMLOpenTagNode): void {
@@ -48,7 +48,15 @@ class SVGNoDeprecatedTagsVisitor extends ElementStackVisitor {
     if (this.isInsideElementAcrossCallers("svg") !== "always") return
 
     const tagName = tagNameToken?.value
-    if (!tagName || !DEPRECATED_SVG_ELEMENTS.has(tagName.toLowerCase())) return
+    if (
+      !tagName ||
+      !DEPRECATED_SVG_ELEMENTS.some(
+        (deprecatedTagName) =>
+          deprecatedTagName.toLowerCase() === tagName.toLowerCase(),
+      )
+    ) {
+      return
+    }
 
     this.addOffense(
       `SVG element \`<${tagName}>\` is deprecated and no longer supported in modern browsers.`,

--- a/javascript/packages/linter/src/rules/svg-no-deprecated-tags.ts
+++ b/javascript/packages/linter/src/rules/svg-no-deprecated-tags.ts
@@ -1,0 +1,90 @@
+import { ParserRule } from "../types.js"
+import { ElementStackVisitor } from "./rule-utils.js"
+
+import type {
+  UnboundLintOffense,
+  LintContext,
+  FullRuleConfig,
+} from "../types.js"
+import type {
+  HTMLOpenTagNode,
+  ERBOpenTagNode,
+  Token,
+  ParseResult,
+  ParserOptions,
+} from "@herb-tools/core"
+
+const DEPRECATED_SVG_ELEMENTS = new Set([
+  "altglyph",
+  "altglyphdef",
+  "altglyphitem",
+  "cursor",
+  "font",
+  "font-face",
+  "font-face-format",
+  "font-face-name",
+  "font-face-src",
+  "font-face-uri",
+  "glyph",
+  "glyphref",
+  "hkern",
+  "missing-glyph",
+  "tref",
+  "vkern",
+])
+
+class SVGNoDeprecatedTagsVisitor extends ElementStackVisitor {
+  visitHTMLOpenTagNode(node: HTMLOpenTagNode): void {
+    this.checkTagName(node.tag_name)
+    super.visitHTMLOpenTagNode(node)
+  }
+
+  visitERBOpenTagNode(node: ERBOpenTagNode): void {
+    this.checkTagName(node.tag_name)
+    super.visitERBOpenTagNode(node)
+  }
+
+  private checkTagName(tagNameToken: Token | null): void {
+    if (this.isInsideElementAcrossCallers("svg") !== "always") return
+
+    const tagName = tagNameToken?.value
+    if (!tagName || !DEPRECATED_SVG_ELEMENTS.has(tagName.toLowerCase())) return
+
+    this.addOffense(
+      `SVG element \`<${tagName}>\` is deprecated and no longer supported in modern browsers.`,
+      tagNameToken.location,
+      undefined,
+      undefined,
+      ["deprecated"],
+    )
+  }
+}
+
+export class SVGNoDeprecatedTagsRule extends ParserRule {
+  static ruleName = "svg-no-deprecated-tags"
+  static introducedIn = this.version("unreleased")
+
+  get defaultConfig(): FullRuleConfig {
+    return {
+      enabled: true,
+      severity: "error",
+    }
+  }
+
+  get parserOptions(): Partial<ParserOptions> {
+    return {
+      action_view_helpers: true,
+    }
+  }
+
+  check(
+    result: ParseResult,
+    context?: Partial<LintContext>,
+  ): UnboundLintOffense[] {
+    const visitor = new SVGNoDeprecatedTagsVisitor(this.ruleName, context)
+
+    visitor.visit(result.value)
+
+    return visitor.offenses
+  }
+}

--- a/javascript/packages/linter/test/__snapshots__/cli.test.ts.snap
+++ b/javascript/packages/linter/test/__snapshots__/cli.test.ts.snap
@@ -19,7 +19,7 @@ test-file-with-errors.html.erb:
   Failing      2 errors (2 offenses across 1 file)
   Not failing  1 warning (1 offense across 1 file, below --fail-level=error)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        128 enabled | all rules via --all-rules"
+  Rules        129 enabled | all rules via --all-rules"
 `;
 
 exports[`CLI Output Formatting > \`all\` pseudo rule in .herb.yml > \`Rules\` summary line > \`--only\` replaces the counts from a disabled \`all\` 1`] = `
@@ -50,7 +50,7 @@ exports[`CLI Output Formatting > \`all\` pseudo rule in .herb.yml > \`Rules\` su
   Checked      1 file
   Offenses     0 offenses
   Fixable      0 offenses
-  Rules        0 enabled | 128 not enabled
+  Rules        0 enabled | 129 not enabled
 
  No rules enabled:
   Every linter rule is turned off, so no offenses can be reported.
@@ -71,7 +71,7 @@ exports[`CLI Output Formatting > \`all\` pseudo rule in .herb.yml > \`Rules\` su
   Checked      1 file
   Offenses     0 offenses
   Fixable      0 offenses
-  Rules        0 enabled | 128 not enabled
+  Rules        0 enabled | 129 not enabled
 
  No rules enabled:
   Every linter rule is turned off, so no offenses can be reported.
@@ -102,7 +102,7 @@ test-file-with-errors.html.erb:
   Failing      2 errors (2 offenses across 1 file)
   Not failing  1 warning (1 offense across 1 file, below --fail-level=error)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        128 enabled"
+  Rules        129 enabled"
 `;
 
 exports[`CLI Output Formatting > \`all\` pseudo rule in .herb.yml > \`Rules\` summary line > \`all: enabled: true\` reports no version-skipped rules 1`] = `
@@ -124,7 +124,7 @@ test-file-with-errors.html.erb:
   Failing      2 errors (2 offenses across 1 file)
   Not failing  1 warning (1 offense across 1 file, below --fail-level=error)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        128 enabled"
+  Rules        129 enabled"
 `;
 
 exports[`CLI Output Formatting > \`all\` pseudo rule in .herb.yml > \`Rules\` summary line > reports enabled and not-enabled rules when no \`all\` is configured 1`] = `
@@ -146,7 +146,7 @@ test/fixtures/test-file-with-errors.html.erb:
   Failing      2 errors (2 offenses across 1 file)
   Not failing  1 warning (1 offense across 1 file, below --fail-level=error)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        108 enabled | 20 not enabled"
+  Rules        109 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > \`all\` pseudo rule in .herb.yml > \`Rules\` summary line > rules opted back in on top of \`all: enabled: false\` count as enabled 1`] = `
@@ -165,7 +165,7 @@ test-file-with-errors.html.erb:
   Failing      0 offenses
   Not failing  1 warning (1 offense across 1 file, below --fail-level=error)
   Fixable      0 offenses
-  Rules        1 enabled | 127 not enabled"
+  Rules        1 enabled | 128 not enabled"
 `;
 
 exports[`CLI Output Formatting > \`all\` pseudo rule in .herb.yml > \`Rules\` summary line > rules opted out on top of \`all: enabled: true\` count as disabled 1`] = `
@@ -184,7 +184,7 @@ test-file-with-errors.html.erb:
   Checked      1 file
   Offenses     2 errors (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        127 enabled | 1 disabled"
+  Rules        128 enabled | 1 disabled"
 `;
 
 exports[`CLI Output Formatting > --all-rules > reports every offense for the fixture with --all-rules 1`] = `
@@ -214,7 +214,7 @@ test/fixtures/all-rules.html.erb:
   Failing      0 offenses
   Not failing  6 warnings (6 offenses across 1 file, below --fail-level=error)
   Fixable      0 offenses
-  Rules        128 enabled | all rules via --all-rules"
+  Rules        129 enabled | all rules via --all-rules"
 `;
 
 exports[`CLI Output Formatting > --all-rules > reports nothing for the fixture with the default rule set 1`] = `
@@ -226,7 +226,7 @@ exports[`CLI Output Formatting > --all-rules > reports nothing for the fixture w
   Checked      1 file
   Offenses     0 offenses
   Fixable      0 offenses
-  Rules        108 enabled | 20 not enabled"
+  Rules        109 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > --ignore-disable-comments 1`] = `
@@ -377,7 +377,7 @@ test/fixtures/ignored.html.erb:8:8
   Not failing  2 warnings (2 offenses across 1 file, below --fail-level=error)
   Note         3 additional offenses reported (would have been ignored)
   Fixable      7 offenses | 4 autocorrectable using \`--fix\`
-  Rules        108 enabled | 20 not enabled"
+  Rules        109 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > --log-level > counts the hidden offenses and suggests the level that reveals them 1`] = `
@@ -395,7 +395,7 @@ exports[`CLI Output Formatting > --log-level > counts the hidden offenses and su
   Not failing  2 info | 1 hint (3 offenses across 1 file, below --fail-level=error)
   Not shown    3 offenses hidden, show them with --log-level=hint
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        108 enabled | 20 not enabled"
+  Rules        109 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > --log-level > doesn't report offenses below the given level 1`] = `
@@ -412,7 +412,7 @@ exports[`CLI Output Formatting > --log-level > doesn't report offenses below the
   Not failing  1 hint (1 offense across 1 file, below --fail-level=error)
   Not shown    1 offense hidden, show it with --log-level=hint
   Fixable      0 offenses
-  Rules        107 enabled | 20 not enabled | 1 disabled"
+  Rules        108 enabled | 20 not enabled | 1 disabled"
 `;
 
 exports[`CLI Output Formatting > --log-level > prefers the CLI flag over the config file 1`] = `
@@ -431,7 +431,7 @@ test-file-with-errors.html.erb:
   Failing      0 offenses
   Not failing  1 hint (1 offense across 1 file, below --fail-level=error)
   Fixable      0 offenses
-  Rules        107 enabled | 20 not enabled | 1 disabled"
+  Rules        108 enabled | 20 not enabled | 1 disabled"
 `;
 
 exports[`CLI Output Formatting > --log-level > reads logLevel from the config file 1`] = `
@@ -448,7 +448,7 @@ exports[`CLI Output Formatting > --log-level > reads logLevel from the config fi
   Not failing  1 hint (1 offense across 1 file, below --fail-level=error)
   Not shown    1 offense hidden, show it with --log-level=hint
   Fixable      0 offenses
-  Rules        107 enabled | 20 not enabled | 1 disabled"
+  Rules        108 enabled | 20 not enabled | 1 disabled"
 `;
 
 exports[`CLI Output Formatting > --log-level > still counts hidden offenses towards the exit code 1`] = `
@@ -464,7 +464,7 @@ exports[`CLI Output Formatting > --log-level > still counts hidden offenses towa
   Offenses     1 hint (1 offense across 1 file)
   Not shown    1 offense hidden, show it with --log-level=hint
   Fixable      0 offenses
-  Rules        107 enabled | 20 not enabled | 1 disabled"
+  Rules        108 enabled | 20 not enabled | 1 disabled"
 `;
 
 exports[`CLI Output Formatting > --log-level > still reports offenses at or above the given level 1`] = `
@@ -483,7 +483,7 @@ test-file-with-errors.html.erb:
   Failing      0 offenses
   Not failing  1 hint (1 offense across 1 file, below --fail-level=error)
   Fixable      0 offenses
-  Rules        107 enabled | 20 not enabled | 1 disabled"
+  Rules        108 enabled | 20 not enabled | 1 disabled"
 `;
 
 exports[`CLI Output Formatting > --log-level > with --all-rules > keeps the log level when it is passed explicitly 1`] = `
@@ -505,7 +505,7 @@ test-file-with-errors.html.erb:
   Not failing  1 hint (1 offense across 1 file, below --fail-level=error)
   Not shown    1 offense hidden, show it with --log-level=hint
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        128 enabled | all rules via --all-rules"
+  Rules        129 enabled | all rules via --all-rules"
 `;
 
 exports[`CLI Output Formatting > --log-level > with --all-rules > lowers the log level to report the rules it was asked for 1`] = `
@@ -528,7 +528,7 @@ test-file-with-errors.html.erb:
   Not failing  1 hint (1 offense across 1 file, below --fail-level=error)
   Log level    hint | lowered from warning by --all-rules
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        128 enabled | all rules via --all-rules"
+  Rules        129 enabled | all rules via --all-rules"
 `;
 
 exports[`CLI Output Formatting > --log-level > with --only > keeps the log level when it is passed explicitly 1`] = `
@@ -689,7 +689,7 @@ test/fixtures/test-file-with-errors.html.erb:2:22
   Failing      2 errors (2 offenses across 1 file)
   Not failing  1 warning (1 offense across 1 file, below --fail-level=error)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        108 enabled | 20 not enabled"
+  Rules        109 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > GitHub Actions format includes rule codes 1`] = `
@@ -721,7 +721,7 @@ test/fixtures/no-trailing-newline.html.erb:1:29
   Checked      1 file
   Offenses     1 error (1 offense across 1 file)
   Fixable      1 offense | 1 autocorrectable using \`--fix\`
-  Rules        108 enabled | 20 not enabled"
+  Rules        109 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > GitHub Actions format includes rule codes 2`] = `
@@ -826,7 +826,7 @@ test/fixtures/erb-no-extra-whitespace-inside-tags.html.erb:1:4
   Failing      4 errors (4 offenses across 1 file)
   Not failing  1 info (1 offense across 1 file, below --fail-level=error)
   Fixable      5 offenses | 3 autocorrectable using \`--fix\`
-  Rules        108 enabled | 20 not enabled"
+  Rules        109 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > Ignores disabled rules 1`] = `
@@ -886,7 +886,7 @@ test/fixtures/ignored.html.erb:6:14
   Offenses     2 errors (2 offenses across 1 file)
   Ignored      3 offenses suppressed with herb:disable
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        108 enabled | 20 not enabled"
+  Rules        109 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > allows tag.attributes in attribute position 1`] = `
@@ -946,7 +946,7 @@ test/fixtures/tag-attributes.html.erb:5:0
   Failing      0 offenses
   Not failing  2 warnings (2 offenses across 1 file, below --fail-level=error)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        108 enabled | 20 not enabled"
+  Rules        109 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > diplays only parsers errors if one is present 1`] = `
@@ -972,7 +972,7 @@ test/fixtures/parser-errors.html.erb:2:16
   Checked      1 file
   Offenses     1 error (1 offense across 1 file)
   Fixable      0 offenses
-  Rules        108 enabled | 20 not enabled"
+  Rules        109 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > displays most violated rules with multiple offenses 1`] = `
@@ -1224,7 +1224,7 @@ test/fixtures/multiple-rule-offenses.html.erb:4:7
   Failing      8 errors (8 offenses across 1 file)
   Not failing  6 warnings (6 offenses across 1 file, below --fail-level=error)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        108 enabled | 20 not enabled"
+  Rules        109 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > displays rule offenses when showing all rules 1`] = `
@@ -1349,7 +1349,7 @@ test/fixtures/few-rule-offenses.html.erb:6:0
   Failing      4 errors (4 offenses across 1 file)
   Not failing  2 warnings (2 offenses across 1 file, below --fail-level=error)
   Fixable      6 offenses | 3 autocorrectable using \`--fix\`
-  Rules        108 enabled | 20 not enabled"
+  Rules        109 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats GitHub Actions output correctly for bad file 1`] = `
@@ -1404,7 +1404,7 @@ test/fixtures/bad-file.html.erb:1:16
   Checked      1 file
   Offenses     2 errors (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        108 enabled | 20 not enabled"
+  Rules        109 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats GitHub Actions output correctly for clean file 1`] = `
@@ -1416,7 +1416,7 @@ exports[`CLI Output Formatting > formats GitHub Actions output correctly for cle
   Checked      1 file
   Offenses     0 offenses
   Fixable      0 offenses
-  Rules        108 enabled | 20 not enabled"
+  Rules        109 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats GitHub Actions output correctly for file with errors 1`] = `
@@ -1495,7 +1495,7 @@ test/fixtures/test-file-with-errors.html.erb:2:22
   Failing      2 errors (2 offenses across 1 file)
   Not failing  1 warning (1 offense across 1 file, below --fail-level=error)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        108 enabled | 20 not enabled"
+  Rules        109 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats GitHub Actions output with --format=github option 1`] = `
@@ -1552,7 +1552,7 @@ test/fixtures/test-file-simple.html.erb:2:22
   Checked      1 file
   Offenses     2 errors (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        108 enabled | 20 not enabled"
+  Rules        109 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats JSON output correctly for bad file 1`] = `
@@ -1599,7 +1599,7 @@ exports[`CLI Output Formatting > formats JSON output correctly for bad file 1`] 
   "summary": {
     "filesChecked": 1,
     "filesWithOffenses": 1,
-    "ruleCount": 108,
+    "ruleCount": 109,
     "totalErrors": 2,
     "totalHints": 0,
     "totalIgnored": 0,
@@ -1621,7 +1621,7 @@ exports[`CLI Output Formatting > formats JSON output correctly for clean file 1`
   "summary": {
     "filesChecked": 1,
     "filesWithOffenses": 0,
-    "ruleCount": 108,
+    "ruleCount": 109,
     "totalErrors": 0,
     "totalHints": 0,
     "totalIgnored": 0,
@@ -1695,7 +1695,7 @@ exports[`CLI Output Formatting > formats JSON output correctly for file with err
   "summary": {
     "filesChecked": 1,
     "filesWithOffenses": 1,
-    "ruleCount": 108,
+    "ruleCount": 109,
     "totalErrors": 2,
     "totalHints": 0,
     "totalIgnored": 0,
@@ -1778,7 +1778,7 @@ test/fixtures/test-file-with-errors.html.erb:2:22
   Failing      2 errors (2 offenses across 1 file)
   Not failing  1 warning (1 offense across 1 file, below --fail-level=error)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        108 enabled | 20 not enabled"
+  Rules        109 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats simple output correctly 1`] = `
@@ -1797,7 +1797,7 @@ test/fixtures/test-file-simple.html.erb:
   Checked      1 file
   Offenses     2 errors (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        108 enabled | 20 not enabled"
+  Rules        109 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats simple output for bad-file correctly 1`] = `
@@ -1816,7 +1816,7 @@ test/fixtures/bad-file.html.erb:
   Checked      1 file
   Offenses     2 errors (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        108 enabled | 20 not enabled"
+  Rules        109 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats success output correctly 1`] = `
@@ -1828,7 +1828,7 @@ exports[`CLI Output Formatting > formats success output correctly 1`] = `
   Checked      1 file
   Offenses     0 offenses
   Fixable      0 offenses
-  Rules        108 enabled | 20 not enabled"
+  Rules        109 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > handles boolean attributes 1`] = `
@@ -1840,7 +1840,7 @@ exports[`CLI Output Formatting > handles boolean attributes 1`] = `
   Checked      1 file
   Offenses     0 offenses
   Fixable      0 offenses
-  Rules        108 enabled | 20 not enabled"
+  Rules        109 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > handles multiple errors correctly 1`] = `
@@ -1891,7 +1891,7 @@ test/fixtures/bad-file.html.erb:1:16
   Checked      1 file
   Offenses     2 errors (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        108 enabled | 20 not enabled"
+  Rules        109 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > herb:disable rules 1`] = `
@@ -2034,7 +2034,7 @@ test/fixtures/disabled-1.html.erb:14:19
   Not failing  6 warnings (6 offenses across 1 file, below --fail-level=error)
   Ignored      8 offenses suppressed with herb:disable
   Fixable      8 offenses | 1 autocorrectable using \`--fix\`
-  Rules        108 enabled | 20 not enabled"
+  Rules        109 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > herb:disable rules 2`] = `
@@ -2293,7 +2293,7 @@ test/fixtures/disabled-2.html.erb:2:44
   Not failing  7 warnings (7 offenses across 1 file, below --fail-level=error)
   Ignored      5 offenses suppressed with herb:disable
   Fixable      13 offenses | 6 autocorrectable using \`--fix\`
-  Rules        108 enabled | 20 not enabled"
+  Rules        109 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > non-failing offenses tip > points at --log-level when many offenses don't fail the build 1`] = `
@@ -2331,7 +2331,7 @@ multiple-rule-offenses.html.erb:
   Failing      3 errors (3 offenses across 1 file)
   Not failing  1 info | 10 hints (11 offenses across 1 file, below --fail-level=error)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        108 enabled | 20 not enabled
+  Rules        109 enabled | 20 not enabled
 
  TIP: 11 of the logged offenses don't fail the build.
       Run herb-lint --log-level=error to stop logging them, or set linter.logLevel in your .herb.yml.
@@ -2363,7 +2363,7 @@ multiple-rule-offenses.html.erb:
   Not failing  1 info | 10 hints (11 offenses across 1 file, below --fail-level=error)
   Not shown    11 offenses hidden, show them with --log-level=hint
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        108 enabled | 20 not enabled"
+  Rules        109 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > non-failing offenses tip > stays quiet when --log-level is passed explicitly, even when it hides nothing 1`] = `
@@ -2401,7 +2401,7 @@ multiple-rule-offenses.html.erb:
   Failing      3 errors (3 offenses across 1 file)
   Not failing  1 info | 10 hints (11 offenses across 1 file, below --fail-level=error)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        108 enabled | 20 not enabled"
+  Rules        109 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > non-failing offenses tip > stays quiet when logLevel is set in the config file 1`] = `
@@ -2439,7 +2439,7 @@ multiple-rule-offenses.html.erb:
   Failing      3 errors (3 offenses across 1 file)
   Not failing  1 info | 10 hints (11 offenses across 1 file, below --fail-level=error)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        108 enabled | 20 not enabled"
+  Rules        109 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > non-failing offenses tip > stays quiet when only a handful of offenses don't fail the build 1`] = `
@@ -2477,7 +2477,7 @@ multiple-rule-offenses.html.erb:
   Failing      8 errors (8 offenses across 1 file)
   Not failing  6 warnings (6 offenses across 1 file, below --fail-level=error)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        108 enabled | 20 not enabled"
+  Rules        109 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > points at the flag instead of previewing once there are too many corrections 1`] = `
@@ -2573,7 +2573,7 @@ test/fixtures/test-file-simple.html.erb:2:22
   Checked      1 file
   Offenses     2 errors (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        108 enabled | 20 not enabled"
+  Rules        109 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > previews the correction under each correctable offense 1`] = `
@@ -2630,7 +2630,7 @@ test/fixtures/test-file-simple.html.erb:2:22
   Checked      1 file
   Offenses     2 errors (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        108 enabled | 20 not enabled"
+  Rules        109 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > summary offense buckets > groups every severity into one line when --fail-level is hint 1`] = `
@@ -2667,7 +2667,7 @@ test/fixtures/multiple-rule-offenses.html.erb:
   Checked      1 file
   Offenses     8 errors | 6 warnings (14 offenses across 1 file)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        108 enabled | 20 not enabled"
+  Rules        109 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > summary offense buckets > groups every severity into one line when --fail-level is info 1`] = `
@@ -2704,7 +2704,7 @@ test/fixtures/multiple-rule-offenses.html.erb:
   Checked      1 file
   Offenses     8 errors | 6 warnings (14 offenses across 1 file)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        108 enabled | 20 not enabled"
+  Rules        109 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > summary offense buckets > groups every severity into one line when --fail-level is warning 1`] = `
@@ -2741,7 +2741,7 @@ test/fixtures/multiple-rule-offenses.html.erb:
   Checked      1 file
   Offenses     8 errors | 6 warnings (14 offenses across 1 file)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        108 enabled | 20 not enabled"
+  Rules        109 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > summary offense buckets > moves a severity between buckets as --fail-level is lowered 1`] = `
@@ -2779,7 +2779,7 @@ multiple-rule-offenses.html.erb:
   Failing      8 errors | 4 warnings | 1 info (13 offenses across 1 file)
   Not failing  1 hint (1 offense across 1 file, below --fail-level=info)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        108 enabled | 20 not enabled"
+  Rules        109 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > summary offense buckets > splits the buckets when only some severities fail the build 1`] = `
@@ -2817,7 +2817,7 @@ multiple-rule-offenses.html.erb:
   Failing      8 errors | 4 warnings (12 offenses across 1 file)
   Not failing  1 info | 1 hint (2 offenses across 1 file, below --fail-level=warning)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        108 enabled | 20 not enabled"
+  Rules        109 enabled | 20 not enabled"
 `;
 
 exports[`CLI Output Formatting > unsafe autocorrectable offenses > counts and tags them separately from offenses --fix can correct 1`] = `
@@ -2937,5 +2937,5 @@ test/fixtures/test-file-with-errors.html.erb:2:22
   Failing      2 errors (2 offenses across 1 file)
   Not failing  1 warning (1 offense across 1 file, below --fail-level=error)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        108 enabled | 20 not enabled"
+  Rules        109 enabled | 20 not enabled"
 `;

--- a/javascript/packages/linter/test/rules/svg-no-deprecated-tags.test.ts
+++ b/javascript/packages/linter/test/rules/svg-no-deprecated-tags.test.ts
@@ -2,7 +2,10 @@ import { beforeAll, describe, expect, test } from "vitest"
 
 import { Herb } from "@herb-tools/node-wasm"
 
-import { SVGNoDeprecatedTagsRule } from "../../src/rules/svg-no-deprecated-tags.js"
+import {
+  DEPRECATED_SVG_ELEMENTS,
+  SVGNoDeprecatedTagsRule,
+} from "../../src/rules/svg-no-deprecated-tags.js"
 import { Linter } from "../../src/linter.js"
 import { createLinterTest } from "../helpers/linter-test-helper.js"
 import {
@@ -31,32 +34,13 @@ describe("svg-no-deprecated-tags", () => {
   })
 
   test("reports every element removed from SVG 2", () => {
-    const deprecatedElements = [
-      "altGlyph",
-      "altGlyphDef",
-      "altGlyphItem",
-      "cursor",
-      "font",
-      "font-face",
-      "font-face-format",
-      "font-face-name",
-      "font-face-src",
-      "font-face-uri",
-      "glyph",
-      "glyphRef",
-      "hkern",
-      "missing-glyph",
-      "tref",
-      "vkern",
-    ]
-
-    for (const tagName of deprecatedElements) {
+    for (const tagName of DEPRECATED_SVG_ELEMENTS) {
       expectError(message(tagName))
     }
 
     assertOffenses(`
       <svg>
-        ${deprecatedElements.map((tagName) => `<${tagName} />`).join("\n")}
+        ${DEPRECATED_SVG_ELEMENTS.map((tagName) => `<${tagName} />`).join("\n")}
       </svg>
     `)
   })

--- a/javascript/packages/linter/test/rules/svg-no-deprecated-tags.test.ts
+++ b/javascript/packages/linter/test/rules/svg-no-deprecated-tags.test.ts
@@ -1,0 +1,133 @@
+import { beforeAll, describe, expect, test } from "vitest"
+
+import { Herb } from "@herb-tools/node-wasm"
+
+import { SVGNoDeprecatedTagsRule } from "../../src/rules/svg-no-deprecated-tags.js"
+import { Linter } from "../../src/linter.js"
+import { createLinterTest } from "../helpers/linter-test-helper.js"
+import {
+  renderedFrom,
+  renderedFromNowhere,
+} from "../helpers/partial-caller-context.js"
+
+const { expectNoOffenses, expectError, assertOffenses } = createLinterTest(
+  SVGNoDeprecatedTagsRule,
+)
+
+const PARTIAL = "app/views/shared/_icon.html.erb"
+
+const message = (tagName: string) =>
+  `SVG element \`<${tagName}>\` is deprecated and no longer supported in modern browsers.`
+
+describe("svg-no-deprecated-tags", () => {
+  test("passes for supported SVG elements", () => {
+    expectNoOffenses(`
+      <svg>
+        <text x="0" y="20">Hello, SVG</text>
+        <use href="#glyph" />
+        <path d="M 0 0 L 10 10" />
+      </svg>
+    `)
+  })
+
+  test("reports every element removed from SVG 2", () => {
+    const deprecatedElements = [
+      "altGlyph",
+      "altGlyphDef",
+      "altGlyphItem",
+      "cursor",
+      "font",
+      "font-face",
+      "font-face-format",
+      "font-face-name",
+      "font-face-src",
+      "font-face-uri",
+      "glyph",
+      "glyphRef",
+      "hkern",
+      "missing-glyph",
+      "tref",
+      "vkern",
+    ]
+
+    for (const tagName of deprecatedElements) {
+      expectError(message(tagName))
+    }
+
+    assertOffenses(`
+      <svg>
+        ${deprecatedElements.map((tagName) => `<${tagName} />`).join("\n")}
+      </svg>
+    `)
+  })
+
+  test("matches deprecated element names case-insensitively", () => {
+    expectError(message("GLYPHREF"))
+    expectError(message("ALTGLYPH"))
+
+    assertOffenses(`
+      <svg>
+        <GLYPHREF />
+        <ALTGLYPH />
+      </svg>
+    `)
+  })
+
+  test("ignores matching element names outside SVG", () => {
+    expectNoOffenses(`
+      <div>
+        <glyphRef />
+        <altGlyph />
+      </div>
+    `)
+  })
+
+  test("reports deprecated tag helpers inside SVG", () => {
+    expectError(message("glyphRef"))
+    expectError(message("altGlyph"))
+
+    assertOffenses(`
+      <svg>
+        <%= tag.glyphRef xlink_href: "#glyph" %>
+        <%= content_tag :altGlyph, "Fallback" %>
+      </svg>
+    `)
+  })
+
+  describe("with the raw linter", () => {
+    beforeAll(async () => {
+      await Herb.load()
+    })
+
+    test("marks offenses as deprecated", () => {
+      const linter = new Linter(Herb, [SVGNoDeprecatedTagsRule])
+      const result = linter.lint("<svg><glyphRef /></svg>")
+
+      expect(result.offenses).toHaveLength(1)
+      expect(result.offenses[0].tags).toEqual(["deprecated"])
+      expect(result.offenses[0].severity).toBe("error")
+    })
+  })
+
+  describe("across call sites", () => {
+    test("reports deprecated tags when every call site renders the file inside an svg", () => {
+      expectError(message("glyphRef"))
+
+      assertOffenses(
+        `<glyphRef />`,
+        renderedFrom(PARTIAL, ["html", "body", "svg"]),
+      )
+    })
+
+    test("stays quiet when only some call sites supply an svg", () => {
+      expectNoOffenses(
+        `<glyphRef />`,
+        renderedFrom(PARTIAL, ["html", "body", "svg"], ["html", "body", "div"]),
+      )
+    })
+
+    test("stays quiet when nothing renders the file", () => {
+      expectNoOffenses(`<glyphRef />`, renderedFromNowhere(PARTIAL))
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- add the default-enabled `svg-no-deprecated-tags` linter rule
- report all SVG 1.1 elements removed from SVG 2, including Action View tag helpers and partials rendered inside SVG contexts
- tag diagnostics as deprecated, document modern alternatives, and refresh CLI rule-count snapshots
- ignore macOS `.DS_Store` files repository-wide

## Test plan

- `yarn workspace @herb-tools/linter test svg-no-deprecated-tags cli.test.ts` — 149 passed
- `yarn workspace @herb-tools/linter test --exclude test/formatters/detailed-formatter.test.ts` — 3,895 passed, 11 expected failures, 6 skipped, 34 todo
- `yarn workspace @herb-tools/linter build`
- targeted Prettier and Oxlint checks for every changed TypeScript file

The complete linter run was also executed. Its only failures were two terminal-hyperlink assertions in `detailed-formatter.test.ts`; both reproduce unchanged on the current `main` commit in this environment.

Closes #305

Authored and tested with OpenAI Codex assistance.