### PR TITLE
Language Server: Clear stale diagnostics and skip files outside workspace

### DIFF
--- a/javascript/packages/language-server/src/diagnostics.ts
+++ b/javascript/packages/language-server/src/diagnostics.ts
@@ -1,6 +1,7 @@
 import { TextDocument } from "vscode-languageserver-textdocument"
 import { Connection, Diagnostic } from "vscode-languageserver/node"
 
+import { Settings } from "./settings"
 import { ParserService } from "./parser_service"
 import { LinterService } from "./linter_service"
 import { DocumentService } from "./document_service"
@@ -13,6 +14,7 @@ export class Diagnostics {
   private readonly parserService: ParserService
   private readonly linterService: LinterService
   private readonly configService: ConfigService
+  private readonly settings: Settings
   private diagnostics: Map<TextDocument, Diagnostic[]> = new Map()
 
   constructor(
@@ -21,15 +23,27 @@ export class Diagnostics {
     parserService: ParserService,
     linterService: LinterService,
     configService: ConfigService,
+    settings: Settings,
   ) {
     this.connection = connection
     this.documentService = documentService
     this.parserService = parserService
     this.linterService = linterService
     this.configService = configService
+    this.settings = settings
+  }
+
+  clear(uri: string) {
+    this.connection.sendDiagnostics({ uri, diagnostics: [] })
   }
 
   async validate(textDocument: TextDocument) {
+    if (!this.settings.includes(textDocument.uri)) {
+      this.clear(textDocument.uri)
+
+      return
+    }
+
     let allDiagnostics: Diagnostic[] = []
 
     if (isConfigDocument(textDocument.uri)) {

--- a/javascript/packages/language-server/src/server.ts
+++ b/javascript/packages/language-server/src/server.ts
@@ -295,6 +295,7 @@ export class Server {
 
     if (event.type === FileChangeType.Deleted) {
       callers.remove(event.uri)
+      this.service.diagnostics.clear(event.uri)
 
       return partials.remove(event.uri)
     }

--- a/javascript/packages/language-server/src/service.ts
+++ b/javascript/packages/language-server/src/service.ts
@@ -66,7 +66,7 @@ export class Service {
     this.autofixService = new AutofixService(this.connection, this.config, this.partialIndexService)
     this.configService = new ConfigService(this.project.projectPath)
     this.codeActionService = new CodeActionService(this.project, this.config, this.partialIndexService)
-    this.diagnostics = new Diagnostics(this.connection, this.documentService, this.parserService, this.linterService, this.configService)
+    this.diagnostics = new Diagnostics(this.connection, this.documentService, this.parserService, this.linterService, this.configService, this.settings)
     this.documentSaveService = new DocumentSaveService(this.connection, this.settings, this.autofixService, this.formattingService)
     this.foldingRangeService = new FoldingRangeService(this.parserService)
     this.documentHighlightService = new DocumentHighlightService(this.parserService)
@@ -123,6 +123,7 @@ export class Service {
 
     this.documentService.onDidClose((change) => {
       this.settings.documentSettings.delete(change.document.uri)
+      this.diagnostics.clear(change.document.uri)
     })
 
     this.documentService.onDidChangeContent(async (change) => {

--- a/javascript/packages/language-server/src/settings.ts
+++ b/javascript/packages/language-server/src/settings.ts
@@ -5,6 +5,8 @@ import { defaultFormatOptions } from "@herb-tools/formatter"
 import { pathFromUri } from "./utils"
 import { version } from "../package.json"
 
+const FILE_SCHEME = "file://"
+
 // TODO: ideally we could just Config all the way through
 export interface PersonalHerbSettings {
   trace?: {
@@ -153,6 +155,8 @@ export class Settings {
   }
 
   includes(uri: string): boolean {
+    if (!uri.startsWith(FILE_SCHEME)) return true
+
     const roots = this.workspacePaths
 
     if (roots.length === 0) return true

--- a/javascript/packages/language-server/src/settings.ts
+++ b/javascript/packages/language-server/src/settings.ts
@@ -2,6 +2,7 @@ import { ClientCapabilities, Connection, InitializeParams, ResourceOperationKind
 import { Config } from "@herb-tools/config"
 
 import { defaultFormatOptions } from "@herb-tools/formatter"
+import { pathFromUri } from "./utils"
 import { version } from "../package.json"
 
 // TODO: ideally we could just Config all the way through
@@ -142,6 +143,23 @@ export class Settings {
     const uri = this.params.workspaceFolders?.at(0)?.uri ?? this.params.rootUri ?? this.params.rootPath ?? ""
 
     return uri.replace(/^file:\/\//, "")
+  }
+
+  get workspacePaths(): string[] {
+    const folders = this.params.workspaceFolders?.map(folder => folder.uri) ?? []
+    const roots = folders.length > 0 ? folders : [this.params.rootUri ?? this.params.rootPath ?? ""]
+
+    return roots.filter(root => root !== "").map(root => pathFromUri(root).replace(/\/$/, ""))
+  }
+
+  includes(uri: string): boolean {
+    const roots = this.workspacePaths
+
+    if (roots.length === 0) return true
+
+    const path = pathFromUri(uri)
+
+    return roots.some(root => path === root || path.startsWith(`${root}/`))
   }
 
   getDocumentSettings(resource: string): Thenable<PersonalHerbSettings> {

--- a/javascript/packages/language-server/test/diagnostics.test.ts
+++ b/javascript/packages/language-server/test/diagnostics.test.ts
@@ -88,6 +88,14 @@ describe("Diagnostics", () => {
     expect(published[0].diagnostics.length).toBeGreaterThan(0)
   })
 
+  test("still reports on an untitled buffer", async () => {
+    const { diagnostics, published } = diagnosticsFor([WORKSPACE])
+
+    await diagnostics.validate(documentFor("untitled:Untitled-1"))
+
+    expect(published[0].diagnostics.length).toBeGreaterThan(0)
+  })
+
   test("clear retracts the diagnostics of a document", () => {
     const { diagnostics, published } = diagnosticsFor([WORKSPACE])
 

--- a/javascript/packages/language-server/test/diagnostics.test.ts
+++ b/javascript/packages/language-server/test/diagnostics.test.ts
@@ -1,0 +1,108 @@
+import { beforeAll, describe, expect, test, vi } from "vitest"
+
+import { Herb } from "@herb-tools/node-wasm"
+import { TextDocument } from "vscode-languageserver-textdocument"
+
+import { Settings } from "../src/settings"
+import { Diagnostics } from "../src/diagnostics"
+import { ParserService } from "../src/parser_service"
+
+import type { Connection, InitializeParams, PublishDiagnosticsParams } from "vscode-languageserver/node"
+import type { ConfigService } from "../src/config_service"
+import type { LinterService } from "../src/linter_service"
+import type { DocumentService } from "../src/document_service"
+
+const WORKSPACE = "file:///work/foo"
+const INSIDE = `${WORKSPACE}/app/views/broken.html.erb`
+const OUTSIDE = "file:///work/bar/example.html"
+
+const BROKEN = `<div><span></div>\n`
+
+describe("Diagnostics", () => {
+  let parserService: ParserService
+
+  beforeAll(async () => {
+    await Herb.load()
+
+    parserService = new ParserService()
+  })
+
+  function diagnosticsFor(folders: string[] | null) {
+    const published: PublishDiagnosticsParams[] = []
+
+    const connection = {
+      console: { log: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      sendDiagnostics: (params: PublishDiagnosticsParams) => published.push(params),
+    } as unknown as Connection
+
+    const params = {
+      processId: null,
+      rootUri: null,
+      capabilities: {},
+      workspaceFolders: folders?.map(uri => ({ uri, name: uri })) ?? null,
+    } as InitializeParams
+
+    const documentService = { getAll: () => [] } as unknown as DocumentService
+    const linterService = { lintDocument: async () => ({ diagnostics: [] }) } as unknown as LinterService
+    const configService = { validateDocument: async () => [] } as unknown as ConfigService
+
+    const diagnostics = new Diagnostics(
+      connection,
+      documentService,
+      parserService,
+      linterService,
+      configService,
+      new Settings(params, connection),
+    )
+
+    return { diagnostics, published }
+  }
+
+  function documentFor(uri: string): TextDocument {
+    return TextDocument.create(uri, "erb", 1, BROKEN)
+  }
+
+  test("publishes diagnostics for a document inside the workspace", async () => {
+    const { diagnostics, published } = diagnosticsFor([WORKSPACE])
+
+    await diagnostics.validate(documentFor(INSIDE))
+
+    expect(published).toHaveLength(1)
+    expect(published[0].uri).toBe(INSIDE)
+    expect(published[0].diagnostics.length).toBeGreaterThan(0)
+  })
+
+  test("publishes nothing but a retraction for a document outside the workspace", async () => {
+    const { diagnostics, published } = diagnosticsFor([WORKSPACE])
+
+    await diagnostics.validate(documentFor(OUTSIDE))
+
+    expect(published).toEqual([{ uri: OUTSIDE, diagnostics: [] }])
+  })
+
+  test("still reports when the client opened no folder", async () => {
+    const { diagnostics, published } = diagnosticsFor(null)
+
+    await diagnostics.validate(documentFor(OUTSIDE))
+
+    expect(published[0].diagnostics.length).toBeGreaterThan(0)
+  })
+
+  test("clear retracts the diagnostics of a document", () => {
+    const { diagnostics, published } = diagnosticsFor([WORKSPACE])
+
+    diagnostics.clear(INSIDE)
+
+    expect(published).toEqual([{ uri: INSIDE, diagnostics: [] }])
+  })
+
+  test("clear retracts a document that was reported on earlier", async () => {
+    const { diagnostics, published } = diagnosticsFor([WORKSPACE])
+
+    await diagnostics.validate(documentFor(INSIDE))
+    diagnostics.clear(INSIDE)
+
+    expect(published).toHaveLength(2)
+    expect(published[1]).toEqual({ uri: INSIDE, diagnostics: [] })
+  })
+})

--- a/javascript/packages/language-server/test/settings.test.ts
+++ b/javascript/packages/language-server/test/settings.test.ts
@@ -42,6 +42,53 @@ describe("Settings", () => {
     })
   })
 
+  describe("includes", () => {
+    function settingsFor(folders: string[] | null, rootUri: string | null = null): Settings {
+      return new Settings({
+        ...mockParams,
+        rootUri,
+        workspaceFolders: folders?.map(uri => ({ uri, name: uri })) ?? null,
+      }, mockConnection)
+    }
+
+    test("accepts a document inside the only workspace folder", () => {
+      expect(settingsFor(["file:///work/foo"]).includes("file:///work/foo/app/views/a.html.erb")).toBe(true)
+    })
+
+    test("accepts a document inside any workspace folder", () => {
+      const settings = settingsFor(["file:///work/foo", "file:///work/bar"])
+
+      expect(settings.includes("file:///work/bar/app/views/a.html.erb")).toBe(true)
+    })
+
+    test("rejects a document saved outside every workspace folder", () => {
+      expect(settingsFor(["file:///work/foo"]).includes("file:///work/bar/example.html")).toBe(false)
+    })
+
+    test("rejects a sibling folder that merely shares a prefix", () => {
+      expect(settingsFor(["file:///work/foo"]).includes("file:///work/foobar/example.html")).toBe(false)
+    })
+
+    test("accepts the workspace folder itself", () => {
+      expect(settingsFor(["file:///work/foo"]).includes("file:///work/foo")).toBe(true)
+    })
+
+    test("falls back to rootUri when no folders are given", () => {
+      const settings = settingsFor(null, "file:///work/foo")
+
+      expect(settings.includes("file:///work/foo/a.html.erb")).toBe(true)
+      expect(settings.includes("file:///work/bar/a.html.erb")).toBe(false)
+    })
+
+    test("accepts everything when the client opened no folder at all", () => {
+      expect(settingsFor(null).includes("file:///anywhere/a.html.erb")).toBe(true)
+    })
+
+    test("handles a percent encoded path", () => {
+      expect(settingsFor(["file:///work/my%20app"]).includes("file:///work/my%20app/a.html.erb")).toBe(true)
+    })
+  })
+
   describe("getDocumentSettings", () => {
     test("returns defaultSettings when hasConfigurationCapability is false", async () => {
       const settings = new Settings(mockParams, mockConnection)

--- a/javascript/packages/language-server/test/settings.test.ts
+++ b/javascript/packages/language-server/test/settings.test.ts
@@ -84,6 +84,14 @@ describe("Settings", () => {
       expect(settingsFor(null).includes("file:///anywhere/a.html.erb")).toBe(true)
     })
 
+    test("accepts an untitled buffer, which has nowhere to live", () => {
+      expect(settingsFor(["file:///work/foo"]).includes("untitled:Untitled-1")).toBe(true)
+    })
+
+    test("accepts a document served by a virtual filesystem", () => {
+      expect(settingsFor(["file:///work/foo"]).includes("vscode-vfs://github/marcoroth/herb/a.html.erb")).toBe(true)
+    })
+
     test("handles a percent encoded path", () => {
       expect(settingsFor(["file:///work/my%20app"]).includes("file:///work/my%20app/a.html.erb")).toBe(true)
     })


### PR DESCRIPTION
This pull request stops the language server from reporting on files that are outside of its workspace, and lets it take back the reports it has already made.

Diagnostics belong to the server until it retracts them, and the server never did. Nothing published an empty set for a document, so once a file had been reported on its entries stayed in the client's problem list for the rest of the session, whether the file was closed, deleted, or gone from disk entirely. `Diagnostics#clear` now publishes that empty set, and it runs when a document closes and when a watched file is deleted. Closing is the right moment because only open documents are ever validated, so a closed file could never have its verdict updated.

The delete half only reaches files the client watches, which means files inside the workspace folders. That covers the ordinary case of deleting a template and finding its warnings left behind. A file outside those folders is never watched, so no delete event arrives for it, and it is the scoping below that clears it instead.

The other half is which files get a verdict at all. `Settings#projectPath` reads the first workspace folder, and nothing checked a document against it, so a file saved through `File > Save As` into a directory the workspace never opened was still linted against that workspace's rules. `Settings#includes` now checks a document against every workspace folder rather than the first, and `Diagnostics#validate` clears and returns for anything outside them.

Only documents that live on disk are scoped this way. An untitled buffer or a document served over a virtual filesystem such as `vscode-vfs://` has no location to compare against a folder, so it is reported on as before. A client that opened no folder at all is likewise left alone, since the file it was pointed at is the whole session.

This does not make the server multi-root aware. The config, the linter and both partial indexes still come from the first workspace folder, so a second folder is still measured against the first folder's rules. What changes is that files belonging to no folder are no longer measured against anything, and that a report can now be withdrawn.

Resolves https://github.com/marcoroth/herb/issues/748
