### PR TITLE
Core: Track unresolved renders per caller in the partial caller index

### DIFF
--- a/javascript/packages/core/src/action-view-partial-callers.ts
+++ b/javascript/packages/core/src/action-view-partial-callers.ts
@@ -42,8 +42,8 @@ export interface PartialContext {
 export interface SerializedPartialCallerIndex {
   callSites: Record<string, PartialCallSite[]>
   documentRoots: string[]
-  unresolvedRenders: number
-  skippedFiles: number
+  unresolvedRenders: Record<string, number>
+  skippedFiles: string[]
 }
 
 export const MAX_ANCESTOR_CHAINS = 32
@@ -54,18 +54,22 @@ const UNRESOLVED: PartialContext = Object.freeze({ chains: [], resolved: false }
 const DOCUMENT_ROOT: PartialContext = Object.freeze({ chains: [EMPTY_CHAIN], resolved: true })
 
 export class PartialCallerIndex {
-  readonly unresolvedRenders: number
-  readonly skippedFiles: number
-
   private readonly callSites: Map<string, PartialCallSite[]>
   private readonly documentRoots: Set<string>
+  private readonly unresolvedRenders: Map<string, number>
+  private readonly skippedFiles: Set<string>
   private readonly contexts: Map<string, PartialContext>
 
   static from(data: SerializedPartialCallerIndex): PartialCallerIndex {
-    return new PartialCallerIndex(new Map(Object.entries(data.callSites)), new Set(data.documentRoots ?? []), data.unresolvedRenders, data.skippedFiles)
+    return new PartialCallerIndex(
+      new Map(Object.entries(data.callSites)),
+      new Set(data.documentRoots ?? []),
+      new Map(Object.entries(data.unresolvedRenders ?? {})),
+      new Set(data.skippedFiles ?? [])
+    )
   }
 
-  constructor(callSites: Map<string, PartialCallSite[]>, documentRoots: Set<string>, unresolvedRenders: number, skippedFiles: number) {
+  constructor(callSites: Map<string, PartialCallSite[]>, documentRoots: Set<string>, unresolvedRenders: Map<string, number>, skippedFiles: Set<string>) {
     this.callSites = callSites
     this.documentRoots = documentRoots
     this.contexts = new Map()
@@ -73,16 +77,28 @@ export class PartialCallerIndex {
     this.skippedFiles = skippedFiles
   }
 
+  get unresolvedRenderCount(): number {
+    let total = 0
+
+    for (const count of this.unresolvedRenders.values()) total += count
+
+    return total
+  }
+
+  get skippedFileCount(): number {
+    return this.skippedFiles.size
+  }
+
   get isComplete(): boolean {
-    return this.unresolvedRenders === 0 && this.skippedFiles === 0
+    return this.unresolvedRenders.size === 0 && this.skippedFiles.size === 0
   }
 
   callersOf(partialFile: string): PartialCallSite[] {
     return this.callSites.get(partialFile) ?? []
   }
 
-  replaceCallsFrom(caller: string, sites: Map<string, PartialCallSite[]>): boolean {
-    let changed = false
+  replaceCallsFrom(caller: string, sites: Map<string, PartialCallSite[]>, unresolved = 0): boolean {
+    let changed = this.replaceUnresolvedFrom(caller, unresolved)
 
     for (const [partialFile, callSites] of this.callSites) {
       const remaining = callSites.filter(callSite => callSite.caller !== caller)
@@ -109,6 +125,20 @@ export class PartialCallerIndex {
     if (changed) this.contexts.clear()
 
     return changed
+  }
+
+  private replaceUnresolvedFrom(caller: string, unresolved: number): boolean {
+    const previous = this.unresolvedRenders.get(caller) ?? 0
+
+    if (previous === unresolved) return false
+
+    if (unresolved === 0) {
+      this.unresolvedRenders.delete(caller)
+    } else {
+      this.unresolvedRenders.set(caller, unresolved)
+    }
+
+    return true
   }
 
   removeCallsTo(partialFile: string): boolean {
@@ -211,8 +241,8 @@ export class PartialCallerIndex {
     return {
       callSites: Object.fromEntries(this.callSites),
       documentRoots: [...this.documentRoots].sort(),
-      unresolvedRenders: this.unresolvedRenders,
-      skippedFiles: this.skippedFiles
+      unresolvedRenders: Object.fromEntries(this.unresolvedRenders),
+      skippedFiles: [...this.skippedFiles].sort()
     }
   }
 

--- a/javascript/packages/core/test/action-view-partial-callers.test.ts
+++ b/javascript/packages/core/test/action-view-partial-callers.test.ts
@@ -14,11 +14,39 @@ function callSite(caller: string, ancestors: string[] = []): PartialCallSite {
 }
 
 function index(callSites: Record<string, PartialCallSite[]>, documentRoots: string[] = []): PartialCallerIndex {
-  return new PartialCallerIndex(new Map(Object.entries(callSites)), new Set(documentRoots), 0, 0)
+  return new PartialCallerIndex(new Map(Object.entries(callSites)), new Set(documentRoots), new Map(), new Set())
 }
 
 describe("PartialCallerIndex", () => {
   describe("replaceCallsFrom", () => {
+    test("clears the unresolved renders the caller previously contributed", () => {
+      const callers = new PartialCallerIndex(new Map(), new Set(), new Map([[INDEX, 2]]), new Set())
+
+      expect(callers.isComplete).toBe(false)
+      expect(callers.unresolvedRenderCount).toBe(2)
+
+      callers.replaceCallsFrom(INDEX, new Map())
+
+      expect(callers.unresolvedRenderCount).toBe(0)
+      expect(callers.isComplete).toBe(true)
+    })
+
+    test("replaces the unresolved count rather than adding to it", () => {
+      const callers = new PartialCallerIndex(new Map(), new Set(), new Map([[INDEX, 2]]), new Set())
+
+      callers.replaceCallsFrom(INDEX, new Map(), 1)
+
+      expect(callers.unresolvedRenderCount).toBe(1)
+    })
+
+    test("leaves the unresolved renders of other callers alone", () => {
+      const callers = new PartialCallerIndex(new Map(), new Set(), new Map([[INDEX, 2], [SHOW, 3]]), new Set())
+
+      callers.replaceCallsFrom(INDEX, new Map())
+
+      expect(callers.unresolvedRenderCount).toBe(3)
+    })
+
     test("drops the call sites the caller previously contributed", () => {
       const callers = index({ [CARD]: [callSite(INDEX), callSite(SHOW)] })
 

--- a/javascript/packages/linter/src/partial-caller-builder.ts
+++ b/javascript/packages/linter/src/partial-caller-builder.ts
@@ -203,12 +203,12 @@ export async function buildPartialCallerIndex(herb: HerbBackend, projectPath: st
   const layoutYields = new Map<string, YieldSite[]>()
   const scanned: string[] = []
 
-  let unresolvedRenders = 0
-  let skippedFiles = 0
+  const unresolvedRenders = new Map<string, number>()
+  const skippedFiles = new Set<string>()
 
   for (const file of files.sort()) {
     if (excluded?.(file)) {
-      skippedFiles++
+      skippedFiles.add(file)
       continue
     }
 
@@ -223,7 +223,7 @@ export async function buildPartialCallerIndex(herb: HerbBackend, projectPath: st
     try {
       const collected = collectCallSites(herb, partials, file, source, callSites)
 
-      unresolvedRenders += collected.unresolved
+      if (collected.unresolved > 0) unresolvedRenders.set(file, collected.unresolved)
       scanned.push(file)
 
       if (collected.isDocumentRoot) documentRoots.add(file)

--- a/javascript/packages/linter/test/helpers/partial-caller-context.ts
+++ b/javascript/packages/linter/test/helpers/partial-caller-context.ts
@@ -10,7 +10,7 @@ export function callerIndexFor(callSites: Record<string, string[][]>, documentRo
     chains.map(ancestors => ({ caller: LAYOUT, locals: [], ancestors })),
   ])
 
-  return new PartialCallerIndex(new Map(entries), new Set(documentRoots), 0, 0)
+  return new PartialCallerIndex(new Map(entries), new Set(documentRoots), new Map(), new Set())
 }
 
 export function renderedFrom(fileName: string, ...chains: string[][]) {
@@ -29,5 +29,9 @@ export interface CallerLocals {
 export function callerIndexWithLocals(partialFile: string, callers: CallerLocals[], unresolved = 0): PartialCallerIndex {
   const sites: PartialCallSite[] = callers.map(({ caller, locals }) => ({ caller, locals, ancestors: [] }))
 
-  return new PartialCallerIndex(new Map([[partialFile, sites]]), new Set(), unresolved, 0)
+  const unresolvedRenders = new Map<string, number>()
+
+  if (unresolved > 0 && callers.length > 0) unresolvedRenders.set(callers[0].caller, unresolved)
+
+  return new PartialCallerIndex(new Map([[partialFile, sites]]), new Set(), unresolvedRenders, new Set())
 }

--- a/javascript/packages/linter/test/partial-caller-builder.test.ts
+++ b/javascript/packages/linter/test/partial-caller-builder.test.ts
@@ -76,7 +76,7 @@ describe("buildPartialCallerIndex", () => {
 
     const inferred = callers.inferSignature("app/views/posts/_card.html.erb")
 
-    expect(callers.unresolvedRenders).toBe(1)
+    expect(callers.unresolvedRenderCount).toBe(1)
     expect(inferred.locals.map(local => local.name)).toEqual(["title"])
     expect(inferred.keywordRest).toBe(true)
   })
@@ -87,7 +87,7 @@ describe("buildPartialCallerIndex", () => {
       "app/views/posts/index.html.erb": `<%= render @posts %>`,
     })
 
-    expect(callers.unresolvedRenders).toBe(1)
+    expect(callers.unresolvedRenderCount).toBe(1)
   })
 
   test("ignores a render whose partial does not exist", async () => {
@@ -97,7 +97,7 @@ describe("buildPartialCallerIndex", () => {
     })
 
     expect(callers.callersOf("app/views/posts/_card.html.erb")).toEqual([])
-    expect(callers.unresolvedRenders).toBe(1)
+    expect(callers.unresolvedRenderCount).toBe(1)
   })
 
   test("records a partial rendered with no locals", async () => {
@@ -167,7 +167,7 @@ describe("buildPartialCallerIndex", () => {
     const partials = await buildPartialIndex(Herb, root)
     const callers = await buildPartialCallerIndex(Herb, root, partials, { exclude: ["app/views/legacy/**"] })
 
-    expect(callers.skippedFiles).toBe(1)
+    expect(callers.skippedFileCount).toBe(1)
     expect(callers.isComplete).toBe(false)
     expect(callers.inferSignature("app/views/posts/_card.html.erb").keywordRest).toBe(true)
   })

--- a/javascript/packages/linter/test/partial-context-resolution.test.ts
+++ b/javascript/packages/linter/test/partial-context-resolution.test.ts
@@ -301,8 +301,8 @@ describe("call frames", () => {
     const index = new PartialCallerIndex(
       new Map([["app/views/shared/_a.html.erb", [{ caller: "app/views/layouts/application.html.erb", locals: [], ancestors: ["html", "body"] }]]]),
       new Set(["app/views/layouts/application.html.erb"]),
-      0,
-      0,
+      new Map(),
+      new Set(),
     )
 
     expect(index.contextOf("app/views/shared/_a.html.erb").chains[0].frames[0]).toEqual({

--- a/javascript/packages/linter/test/rules/html-body-only-elements.test.ts
+++ b/javascript/packages/linter/test/rules/html-body-only-elements.test.ts
@@ -176,8 +176,8 @@ describe("html-body-only-elements", () => {
         partialCallers: new PartialCallerIndex(
           new Map([[partial, [{ caller: "app/views/posts/index.html.erb", locals: [], ancestors: ["span"] }]]]),
           new Set(),
-          0,
-          0,
+          new Map(),
+          new Set(),
         ),
       })
     })

--- a/javascript/packages/linter/test/rules/html-head-only-elements.test.ts
+++ b/javascript/packages/linter/test/rules/html-head-only-elements.test.ts
@@ -432,8 +432,8 @@ describe("html-head-only-elements", () => {
         partialCallers: new PartialCallerIndex(
           new Map([[partial, [{ caller: "app/views/posts/index.html.erb", locals: [], ancestors: ["div"] }]]]),
           new Set(),
-          0,
-          0,
+          new Map(),
+          new Set(),
         ),
       })
     })


### PR DESCRIPTION
Follow up on #2106, which added `replaceCallsFrom` so the index can be updated a file at a time.

`replaceCallsFrom` rescans one template and swaps out everything it contributed, but a template contributes two kinds of thing. Its call sites are replaced correctly. Its unresolved renders are not, because `unresolvedRenders` is a single running total with no record of which file each one came from:

```ts
readonly unresolvedRenders: number
```

So a template that used to render a partial through a computed name, and no longer does, leaves its count behind permanently. 

The index keeps reporting `isComplete === false`, and since `inferSignature` derives `keywordRest` from exactly that, every declaration it suggests keeps `**` for the rest of the session. The error is in the safe direction, a signature more permissive than it needs to be, but it never clears and it accumulates as more files are edited.

This pull request keys both counters by the file that produced them:

```ts
private readonly unresolvedRenders: Map<string, number>
private readonly skippedFiles: Set<string>
```

which lets `replaceCallsFrom` replace a caller's unresolved count the same way it already replaces its call sites:

```ts
callers.replaceCallsFrom("app/views/posts/index.html.erb", sites, 1)
```

The count is replaced rather than added, so rescanning the same file twice is idempotent, and other callers are untouched. Omitting the argument means the caller now has none, which is the common case after a template stops rendering something dynamically.