### PR TITLE
Parser: Convert dynamic boolean attributes to conditional attributes

### DIFF
--- a/javascript/packages/rewriter/src/built-ins/action-view-tag-helper-to-html.ts
+++ b/javascript/packages/rewriter/src/built-ins/action-view-tag-helper-to-html.ts
@@ -97,9 +97,9 @@ class ActionViewTagHelperToHTMLVisitor extends Visitor {
         if (child.value) {
           this.transformAttributeValue(child.value)
         }
-
-        htmlChildren.push(child)
       }
+
+      htmlChildren.push(child)
     }
 
     const htmlOpenTag = HTMLOpenTagNode.build({

--- a/javascript/packages/rewriter/test/action-view-tag-helper-to-html.test.ts
+++ b/javascript/packages/rewriter/test/action-view-tag-helper-to-html.test.ts
@@ -119,6 +119,24 @@ describe("ActionViewTagHelperToHTMLRewriter", () => {
       )
     })
 
+    test("tag.div with a dynamic boolean attribute becomes a conditional attribute", () => {
+      expect(transform('<%= tag.div hidden: a != b %>')).toBe(
+        '<div <% if (a != b) %>hidden<% end %>></div>'
+      )
+    })
+
+    test("tag.div with a shorthand boolean attribute becomes a conditional attribute", () => {
+      expect(transform('<%= tag.div(hidden:) %>')).toBe(
+        '<div <% if (hidden) %>hidden<% end %>></div>'
+      )
+    })
+
+    test("tag.div with a dynamic boolean attribute inside a data hash keeps its value", () => {
+      expect(transform('<%= tag.div data: { hidden: a != b } %>')).toBe(
+        '<div data-hidden="<%= ::Herb::Engine.nested_attribute_value(a != b) %>"></div>'
+      )
+    })
+
     test("tag.div with variable attribute value wraps in ERB", () => {
       const input = dedent`
         <%= tag.div class: class_name do %>
@@ -1092,6 +1110,12 @@ describe("ActionViewTagHelperToHTMLRewriter", () => {
     test("tag.attributes with attributes before", () => {
       expect(transform('<button class="primary" <%= tag.attributes(id: "cta") %>>Click</button>')).toBe(
         '<button class="primary" id="cta">Click</button>'
+      )
+    })
+
+    test("tag.attributes with a dynamic boolean attribute", () => {
+      expect(transform('<option <%= tag.attributes(selected: option == current) %>>One</option>')).toBe(
+        '<option <% if (option == current) %>selected<% end %>>One</option>'
       )
     })
 

--- a/src/analyze/action_view/attribute_extraction_helpers.c
+++ b/src/analyze/action_view/attribute_extraction_helpers.c
@@ -241,7 +241,7 @@ static char* join_static_string_array(pm_array_node_t* array, hb_allocator_T* al
   return result;
 }
 
-static AST_HTML_ATTRIBUTE_NODE_T* create_attribute_from_value(
+static AST_NODE_T* create_attribute_from_value(
   const char* name_string,
   pm_node_t* value_node,
   attribute_positions_T* positions,
@@ -256,7 +256,7 @@ static AST_HTML_ATTRIBUTE_NODE_T* create_attribute_from_value(
       create_html_attribute_node_precise(name_string, joined, positions, allocator);
     hb_allocator_dealloc(allocator, joined);
 
-    return attribute;
+    return (AST_NODE_T*) attribute;
   }
 
   if (value_node->type == PM_SYMBOL_NODE || value_node->type == PM_STRING_NODE) {
@@ -267,17 +267,17 @@ static AST_HTML_ATTRIBUTE_NODE_T* create_attribute_from_value(
       create_html_attribute_node_precise(name_string, value_string, positions, allocator);
     hb_allocator_dealloc(allocator, value_string);
 
-    return attribute;
+    return (AST_NODE_T*) attribute;
   } else if (value_node->type == PM_TRUE_NODE) {
     if (is_boolean_attribute(hb_string((char*) name_string))) {
-      return create_html_attribute_node_precise(name_string, NULL, positions, allocator);
+      return (AST_NODE_T*) create_html_attribute_node_precise(name_string, NULL, positions, allocator);
     }
 
-    return create_html_attribute_node_precise(name_string, "true", positions, allocator);
+    return (AST_NODE_T*) create_html_attribute_node_precise(name_string, "true", positions, allocator);
   } else if (value_node->type == PM_FALSE_NODE) {
     if (is_boolean_attribute(hb_string((char*) name_string))) { return NULL; }
 
-    return create_html_attribute_node_precise(name_string, "false", positions, allocator);
+    return (AST_NODE_T*) create_html_attribute_node_precise(name_string, "false", positions, allocator);
   } else if (value_node->type == PM_INTEGER_NODE) {
     size_t value_length = value_node->location.end - value_node->location.start;
     char* value_string = hb_allocator_strndup(allocator, (const char*) value_node->location.start, value_length);
@@ -287,9 +287,9 @@ static AST_HTML_ATTRIBUTE_NODE_T* create_attribute_from_value(
       create_html_attribute_node_precise(name_string, value_string, positions, allocator);
     hb_allocator_dealloc(allocator, value_string);
 
-    return attribute;
+    return (AST_NODE_T*) attribute;
   } else if (value_node->type == PM_INTERPOLATED_STRING_NODE) {
-    return create_html_attribute_with_interpolated_value(
+    return (AST_NODE_T*) create_html_attribute_with_interpolated_value(
       name_string,
       (pm_interpolated_string_node_t*) value_node,
       positions->name_start,
@@ -302,6 +302,15 @@ static AST_HTML_ATTRIBUTE_NODE_T* create_attribute_from_value(
 
     if (raw_content && value_node->location.start) {
       char* ruby_content = raw_content;
+
+      if (!is_nested && is_boolean_attribute(hb_string((char*) name_string))) {
+        AST_NODE_T* conditional_attribute =
+          create_conditional_boolean_attribute(name_string, raw_content, positions, allocator);
+
+        hb_allocator_dealloc(allocator, raw_content);
+
+        return conditional_attribute;
+      }
 
       if (!is_nested && strcmp(name_string, "class") == 0
           && (value_node->type == PM_HASH_NODE || value_node->type == PM_ARRAY_NODE)) {
@@ -329,7 +338,7 @@ static AST_HTML_ATTRIBUTE_NODE_T* create_attribute_from_value(
         create_html_attribute_with_ruby_literal_precise(name_string, ruby_content, positions, allocator);
       hb_allocator_dealloc(allocator, raw_content);
 
-      return attribute;
+      return (AST_NODE_T*) attribute;
     }
 
     return NULL;
@@ -388,7 +397,7 @@ void resolve_nonce_attribute(hb_array_T* attributes, hb_allocator_T* allocator) 
   }
 }
 
-AST_HTML_ATTRIBUTE_NODE_T* extract_html_attribute_from_assoc(
+AST_NODE_T* extract_html_attribute_from_assoc(
   pm_assoc_node_t* assoc,
   const uint8_t* source,
   const char* original_source,
@@ -417,14 +426,30 @@ AST_HTML_ATTRIBUTE_NODE_T* extract_html_attribute_from_assoc(
     compute_position_pair(&name_loc, source, original_source, erb_content_offset, &name_start, &name_end);
 
     char* dashed_name = convert_underscores_to_dashes(name_string);
+    const char* attribute_name = dashed_name ? dashed_name : name_string;
 
-    AST_HTML_ATTRIBUTE_NODE_T* attribute = create_html_attribute_with_ruby_literal(
-      dashed_name ? dashed_name : name_string,
-      name_string,
-      name_start,
-      name_start,
-      allocator
-    );
+    AST_NODE_T* attribute;
+
+    if (is_boolean_attribute(hb_string((char*) attribute_name))) {
+      attribute_positions_T positions = {
+        .name_start = name_start,
+        .name_end = name_end,
+        .separator_string = ":",
+        .separator_type = TOKEN_COLON,
+        .separator_start = name_end,
+        .separator_end = name_end,
+        .value_start = name_end,
+        .value_end = name_end,
+        .content_start = name_end,
+        .content_end = name_end,
+        .quoted = false,
+      };
+
+      attribute = create_conditional_boolean_attribute(attribute_name, name_string, &positions, allocator);
+    } else {
+      attribute = (AST_NODE_T*)
+        create_html_attribute_with_ruby_literal(attribute_name, name_string, name_start, name_start, allocator);
+    }
 
     if (dashed_name) { free(dashed_name); }
     hb_allocator_dealloc(allocator, name_string);
@@ -451,7 +476,7 @@ AST_HTML_ATTRIBUTE_NODE_T* extract_html_attribute_from_assoc(
   fill_attribute_positions(assoc, source, original_source, erb_content_offset, &positions);
 
   char* dashed_name = convert_underscores_to_dashes(name_string);
-  AST_HTML_ATTRIBUTE_NODE_T* attribute_node =
+  AST_NODE_T* attribute_node =
     create_attribute_from_value(dashed_name ? dashed_name : name_string, assoc->value, &positions, allocator, false);
 
   if (dashed_name) { free(dashed_name); }
@@ -575,7 +600,7 @@ hb_array_T* extract_html_attributes_from_keyword_hash(
             attribute_positions_T hash_positions;
             fill_attribute_positions(hash_assoc, source, original_source, erb_content_offset, &hash_positions);
 
-            AST_HTML_ATTRIBUTE_NODE_T* attribute =
+            AST_NODE_T* attribute =
               create_attribute_from_value(attribute_key_string, hash_assoc->value, &hash_positions, allocator, true);
 
             if (attribute) { hb_array_append(attributes, attribute); }
@@ -583,7 +608,7 @@ hb_array_T* extract_html_attributes_from_keyword_hash(
           }
         }
       } else {
-        AST_HTML_ATTRIBUTE_NODE_T* attribute =
+        AST_NODE_T* attribute =
           extract_html_attribute_from_assoc(assoc, source, original_source, erb_content_offset, allocator);
 
         if (attribute) { hb_array_append(attributes, attribute); }

--- a/src/analyze/action_view/tag_helper_node_builders.c
+++ b/src/analyze/action_view/tag_helper_node_builders.c
@@ -3,10 +3,12 @@
 #include "../../include/lexer/token_struct.h"
 #include "../../include/lib/hb_allocator.h"
 #include "../../include/lib/hb_array.h"
+#include "../../include/lib/hb_buffer.h"
 #include "../../include/lib/hb_string.h"
 #include "../../include/location/location.h"
 #include "../../include/location/position.h"
 #include "../../include/location/range.h"
+#include "../../include/prism/herb_prism_node.h"
 
 #include <prism.h>
 #include <stdbool.h>
@@ -195,6 +197,59 @@ AST_HTML_ATTRIBUTE_NODE_T* create_html_attribute_with_ruby_literal_precise(
     hb_array_init(0, allocator),
     allocator
   );
+}
+
+AST_NODE_T* create_conditional_boolean_attribute(
+  const char* name_string,
+  const char* condition_source,
+  attribute_positions_T* positions,
+  hb_allocator_T* allocator
+) {
+  if (!name_string || !condition_source) { return NULL; }
+
+  AST_HTML_ATTRIBUTE_NODE_T* attribute = create_html_attribute_node_precise(name_string, NULL, positions, allocator);
+  if (!attribute) { return NULL; }
+
+  hb_array_T* statements = hb_array_init(1, allocator);
+  hb_array_append(statements, (AST_NODE_T*) attribute);
+
+  position_T start = positions->name_start;
+  position_T end = positions->content_end;
+
+  hb_buffer_T condition_buffer;
+  hb_buffer_init(&condition_buffer, strlen(condition_source) + 16, allocator);
+  hb_buffer_append(&condition_buffer, " if (");
+  hb_buffer_append(&condition_buffer, condition_source);
+  hb_buffer_append(&condition_buffer, ") ");
+
+  AST_ERB_END_NODE_T* end_node = ast_erb_end_node_init(
+    create_synthetic_token(allocator, "<%", TOKEN_ERB_START, end, end),
+    create_synthetic_token(allocator, " end ", TOKEN_ERB_CONTENT, end, end),
+    create_synthetic_token(allocator, "%>", TOKEN_ERB_END, end, end),
+    end,
+    end,
+    hb_array_init(0, allocator),
+    allocator
+  );
+
+  AST_ERB_IF_NODE_T* if_node = ast_erb_if_node_init(
+    create_synthetic_token(allocator, "<%", TOKEN_ERB_START, start, start),
+    create_synthetic_token(allocator, hb_buffer_value(&condition_buffer), TOKEN_ERB_CONTENT, start, end),
+    create_synthetic_token(allocator, "%>", TOKEN_ERB_END, end, end),
+    NULL,
+    HERB_PRISM_NODE_EMPTY,
+    statements,
+    NULL,
+    end_node,
+    start,
+    end,
+    hb_array_init(0, allocator),
+    allocator
+  );
+
+  hb_buffer_free(&condition_buffer);
+
+  return (AST_NODE_T*) if_node;
 }
 
 AST_HTML_ATTRIBUTE_NODE_T* create_html_attribute_node(

--- a/src/include/analyze/action_view/attribute_extraction_helpers.h
+++ b/src/include/analyze/action_view/attribute_extraction_helpers.h
@@ -7,7 +7,7 @@
 
 #include <prism.h>
 
-AST_HTML_ATTRIBUTE_NODE_T* extract_html_attribute_from_assoc(
+AST_NODE_T* extract_html_attribute_from_assoc(
   pm_assoc_node_t* assoc,
   const uint8_t* source,
   const char* original_source,

--- a/src/include/analyze/action_view/tag_helper_node_builders.h
+++ b/src/include/analyze/action_view/tag_helper_node_builders.h
@@ -77,6 +77,13 @@ AST_HTML_ATTRIBUTE_NODE_T* create_html_attribute_with_ruby_literal_precise(
   hb_allocator_T* allocator
 );
 
+AST_NODE_T* create_conditional_boolean_attribute(
+  const char* name_string,
+  const char* condition_source,
+  attribute_positions_T* positions,
+  hb_allocator_T* allocator
+);
+
 hb_array_T* prepend_attribute(hb_array_T* attributes, AST_NODE_T* attribute, hb_allocator_T* allocator);
 
 AST_HTML_ATTRIBUTE_NODE_T* create_href_attribute(

--- a/test/analyze/action_view/tag_helper/tag_test.rb
+++ b/test/analyze/action_view/tag_helper/tag_test.rb
@@ -748,5 +748,31 @@ module Analyze::ActionView::TagHelper
         <%= tag.hr %>
       HTML
     end
+
+    test "tag.input with boolean attribute from a dynamic expression" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <%= tag.input type: "text", disabled: user.admin? %>
+      HTML
+    end
+
+    test "tag.div with boolean attribute from a dynamic expression and block" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <%= tag.div hidden: a != b do %>
+          Content
+        <% end %>
+      HTML
+    end
+
+    test "tag.div with boolean attribute shorthand" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <%= tag.div(hidden:) %>
+      HTML
+    end
+
+    test "tag.div with boolean attribute inside data hash stays a valued attribute" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <%= tag.div data: { hidden: a != b } %>
+      HTML
+    end
   end
 end

--- a/test/engine/action_view/tag_attributes_test.rb
+++ b/test/engine/action_view/tag_attributes_test.rb
@@ -46,6 +46,13 @@ module Engine
 
         assert_optimized_mismatch_snapshot(template, { dom_id: "post_1" })
       end
+
+      test "tag.attributes with dynamic boolean attribute" do
+        assert_optimized_snapshot(
+          '<option <%= tag.attributes(selected: option == current) %>>One</option>',
+          { option: "one", current: "two" }
+        )
+      end
     end
   end
 end

--- a/test/engine/action_view/tag_attributes_test.rb
+++ b/test/engine/action_view/tag_attributes_test.rb
@@ -49,7 +49,7 @@ module Engine
 
       test "tag.attributes with dynamic boolean attribute" do
         assert_optimized_snapshot(
-          '<option <%= tag.attributes(selected: option == current) %>>One</option>',
+          "<option <%= tag.attributes(selected: option == current) %>>One</option>",
           { option: "one", current: "two" }
         )
       end

--- a/test/engine/action_view/tag_test.rb
+++ b/test/engine/action_view/tag_test.rb
@@ -217,6 +217,24 @@ module Engine
         assert_equal "<div>\n  Content\n</div>", result
         refute result.end_with?("\n"), "Optimized output should not have trailing newline"
       end
+
+      # TODO: Rails renders `hidden="hidden"`. We render `hidden` (boolean attribute without value).
+      test "tag.div with dynamic boolean attribute that is truthy" do
+        assert_optimized_mismatch_snapshot("<%= tag.div hidden: a != b %>", { a: 1, b: 2 })
+      end
+
+      test "tag.div with dynamic boolean attribute that is falsy" do
+        assert_optimized_snapshot("<%= tag.div hidden: a == b %>", { a: 1, b: 2 })
+      end
+
+      test "tag.div with dynamic boolean attribute that is nil" do
+        assert_optimized_snapshot("<%= tag.div hidden: maybe %>", { maybe: nil })
+      end
+
+      # TODO: Rails renders `hidden="hidden"`. We render `hidden` (boolean attribute without value).
+      test "tag.div with boolean attribute shorthand" do
+        assert_optimized_mismatch_snapshot("<%= tag.div(hidden:) %>", { hidden: true })
+      end
     end
   end
 end

--- a/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0102_tag.input_with_boolean_attribute_from_a_dynamic_expression_f443ad3c5e496d118d5e894475121396-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0102_tag.input_with_boolean_attribute_from_a_dynamic_expression_f443ad3c5e496d118d5e894475121396-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,70 @@
+---
+source: "Analyze::ActionView::TagHelper::TagTest#test_0102_tag.input with boolean attribute from a dynamic expression"
+input: |2-
+<%= tag.input type: "text", disabled: user.admin? %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:52))
+    │   ├── open_tag:
+    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:52))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " tag.input type: "text", disabled: user.admin? " (location: (1:3)-(1:50))
+    │   │       ├── tag_closing: "%>" (location: (1:50)-(1:52))
+    │   │       ├── tag_name: "input" (location: (1:8)-(1:13))
+    │   │       └── children: (2 items)
+    │   │           ├── @ HTMLAttributeNode (location: (1:14)-(1:26))
+    │   │           │   ├── name:
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:14)-(1:18))
+    │   │           │   │       └── children: (1 item)
+    │   │           │   │           └── @ LiteralNode (location: (1:14)-(1:18))
+    │   │           │   │               └── content: "type"
+    │   │           │   │
+    │   │           │   │
+    │   │           │   ├── equals: ": " (location: (1:18)-(1:20))
+    │   │           │   └── value:
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:20)-(1:26))
+    │   │           │           ├── open_quote: """ (location: (1:20)-(1:21))
+    │   │           │           ├── children: (1 item)
+    │   │           │           │   └── @ LiteralNode (location: (1:21)-(1:25))
+    │   │           │           │       └── content: "text"
+    │   │           │           │
+    │   │           │           ├── close_quote: """ (location: (1:25)-(1:26))
+    │   │           │           └── quoted: true
+    │   │           │
+    │   │           │
+    │   │           └── @ ERBIfNode (location: (1:28)-(1:49))
+    │   │               ├── tag_opening: "<%" (location: (1:28)-(1:28))
+    │   │               ├── content: " if (user.admin?) " (location: (1:28)-(1:49))
+    │   │               ├── tag_closing: "%>" (location: (1:49)-(1:49))
+    │   │               ├── then_keyword: ∅
+    │   │               ├── statements: (1 item)
+    │   │               │   └── @ HTMLAttributeNode (location: (1:28)-(1:36))
+    │   │               │       ├── name:
+    │   │               │       │   └── @ HTMLAttributeNameNode (location: (1:28)-(1:36))
+    │   │               │       │       └── children: (1 item)
+    │   │               │       │           └── @ LiteralNode (location: (1:28)-(1:36))
+    │   │               │       │               └── content: "disabled"
+    │   │               │       │
+    │   │               │       │
+    │   │               │       ├── equals: ∅
+    │   │               │       └── value: ∅
+    │   │               │
+    │   │               ├── subsequent: ∅
+    │   │               └── end_node:
+    │   │                   └── @ ERBEndNode (location: (1:49)-(1:49))
+    │   │                       ├── tag_opening: "<%" (location: (1:49)-(1:49))
+    │   │                       ├── content: " end " (location: (1:49)-(1:49))
+    │   │                       └── tag_closing: "%>" (location: (1:49)-(1:49))
+    │   │
+    │   │
+    │   │
+    │   ├── tag_name: "input" (location: (1:8)-(1:13))
+    │   ├── body: []
+    │   ├── close_tag: ∅
+    │   ├── is_void: true
+    │   └── element_source: "ActionView::Helpers::TagHelper#tag"
+    │
+    └── @ HTMLTextNode (location: (1:52)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0103_tag.div_with_boolean_attribute_from_a_dynamic_expression_and_block_43859e18831fbdd1cb0d578fc52d02e3-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0103_tag.div_with_boolean_attribute_from_a_dynamic_expression_and_block_43859e18831fbdd1cb0d578fc52d02e3-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,60 @@
+---
+source: "Analyze::ActionView::TagHelper::TagTest#test_0103_tag.div with boolean attribute from a dynamic expression and block"
+input: |2-
+<%= tag.div hidden: a != b do %>
+  Content
+<% end %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(4:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(3:9))
+    │   ├── open_tag:
+    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:32))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " tag.div hidden: a != b do " (location: (1:3)-(1:30))
+    │   │       ├── tag_closing: "%>" (location: (1:30)-(1:32))
+    │   │       ├── tag_name: "div" (location: (1:8)-(1:11))
+    │   │       └── children: (1 item)
+    │   │           └── @ ERBIfNode (location: (1:12)-(1:26))
+    │   │               ├── tag_opening: "<%" (location: (1:12)-(1:12))
+    │   │               ├── content: " if (a != b) " (location: (1:12)-(1:26))
+    │   │               ├── tag_closing: "%>" (location: (1:26)-(1:26))
+    │   │               ├── then_keyword: ∅
+    │   │               ├── statements: (1 item)
+    │   │               │   └── @ HTMLAttributeNode (location: (1:12)-(1:18))
+    │   │               │       ├── name:
+    │   │               │       │   └── @ HTMLAttributeNameNode (location: (1:12)-(1:18))
+    │   │               │       │       └── children: (1 item)
+    │   │               │       │           └── @ LiteralNode (location: (1:12)-(1:18))
+    │   │               │       │               └── content: "hidden"
+    │   │               │       │
+    │   │               │       │
+    │   │               │       ├── equals: ∅
+    │   │               │       └── value: ∅
+    │   │               │
+    │   │               ├── subsequent: ∅
+    │   │               └── end_node:
+    │   │                   └── @ ERBEndNode (location: (1:26)-(1:26))
+    │   │                       ├── tag_opening: "<%" (location: (1:26)-(1:26))
+    │   │                       ├── content: " end " (location: (1:26)-(1:26))
+    │   │                       └── tag_closing: "%>" (location: (1:26)-(1:26))
+    │   │
+    │   │
+    │   │
+    │   ├── tag_name: "div" (location: (1:8)-(1:11))
+    │   ├── body: (1 item)
+    │   │   └── @ HTMLTextNode (location: (1:32)-(3:0))
+    │   │       └── content: "\n  Content\n"
+    │   │
+    │   ├── close_tag:
+    │   │   └── @ ERBEndNode (location: (3:0)-(3:9))
+    │   │       ├── tag_opening: "<%" (location: (3:0)-(3:2))
+    │   │       ├── content: " end " (location: (3:2)-(3:7))
+    │   │       └── tag_closing: "%>" (location: (3:7)-(3:9))
+    │   │
+    │   ├── is_void: false
+    │   └── element_source: "ActionView::Helpers::TagHelper#tag"
+    │
+    └── @ HTMLTextNode (location: (3:9)-(4:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0104_tag.div_with_boolean_attribute_shorthand_4594e6b8ae168644a58288b1acec57dc-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0104_tag.div_with_boolean_attribute_shorthand_4594e6b8ae168644a58288b1acec57dc-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,53 @@
+---
+source: "Analyze::ActionView::TagHelper::TagTest#test_0104_tag.div with boolean attribute shorthand"
+input: |2-
+<%= tag.div(hidden:) %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:23))
+    │   ├── open_tag:
+    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:23))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " tag.div(hidden:) " (location: (1:3)-(1:21))
+    │   │       ├── tag_closing: "%>" (location: (1:21)-(1:23))
+    │   │       ├── tag_name: "div" (location: (1:8)-(1:11))
+    │   │       └── children: (1 item)
+    │   │           └── @ ERBIfNode (location: (1:12)-(1:18))
+    │   │               ├── tag_opening: "<%" (location: (1:12)-(1:12))
+    │   │               ├── content: " if (hidden) " (location: (1:12)-(1:18))
+    │   │               ├── tag_closing: "%>" (location: (1:18)-(1:18))
+    │   │               ├── then_keyword: ∅
+    │   │               ├── statements: (1 item)
+    │   │               │   └── @ HTMLAttributeNode (location: (1:12)-(1:18))
+    │   │               │       ├── name:
+    │   │               │       │   └── @ HTMLAttributeNameNode (location: (1:12)-(1:18))
+    │   │               │       │       └── children: (1 item)
+    │   │               │       │           └── @ LiteralNode (location: (1:12)-(1:18))
+    │   │               │       │               └── content: "hidden"
+    │   │               │       │
+    │   │               │       │
+    │   │               │       ├── equals: ∅
+    │   │               │       └── value: ∅
+    │   │               │
+    │   │               ├── subsequent: ∅
+    │   │               └── end_node:
+    │   │                   └── @ ERBEndNode (location: (1:18)-(1:18))
+    │   │                       ├── tag_opening: "<%" (location: (1:18)-(1:18))
+    │   │                       ├── content: " end " (location: (1:18)-(1:18))
+    │   │                       └── tag_closing: "%>" (location: (1:18)-(1:18))
+    │   │
+    │   │
+    │   │
+    │   ├── tag_name: "div" (location: (1:8)-(1:11))
+    │   ├── body: []
+    │   ├── close_tag:
+    │   │   └── @ HTMLVirtualCloseTagNode (location: (1:23)-(1:23))
+    │   │       └── tag_name: "div" (location: (1:8)-(1:11))
+    │   │
+    │   ├── is_void: false
+    │   └── element_source: "ActionView::Helpers::TagHelper#tag"
+    │
+    └── @ HTMLTextNode (location: (1:23)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0105_tag.div_with_boolean_attribute_inside_data_hash_stays_a_valued_attribute_bf910df2e1b05af520d233c9251c37b9-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/tag_helper/tag_test/test_0105_tag.div_with_boolean_attribute_inside_data_hash_stays_a_valued_attribute_bf910df2e1b05af520d233c9251c37b9-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,48 @@
+---
+source: "Analyze::ActionView::TagHelper::TagTest#test_0105_tag.div with boolean attribute inside data hash stays a valued attribute"
+input: |2-
+<%= tag.div data: { hidden: a != b } %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:39))
+    │   ├── open_tag:
+    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:39))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " tag.div data: { hidden: a != b } " (location: (1:3)-(1:37))
+    │   │       ├── tag_closing: "%>" (location: (1:37)-(1:39))
+    │   │       ├── tag_name: "div" (location: (1:8)-(1:11))
+    │   │       └── children: (1 item)
+    │   │           └── @ HTMLAttributeNode (location: (1:20)-(1:34))
+    │   │               ├── name:
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:20)-(1:26))
+    │   │               │       └── children: (1 item)
+    │   │               │           └── @ LiteralNode (location: (1:20)-(1:26))
+    │   │               │               └── content: "data-hidden"
+    │   │               │
+    │   │               │
+    │   │               ├── equals: ": " (location: (1:26)-(1:28))
+    │   │               └── value:
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:28)-(1:34))
+    │   │                       ├── open_quote: ∅
+    │   │                       ├── children: (1 item)
+    │   │                       │   └── @ RubyLiteralNode (location: (1:28)-(1:34))
+    │   │                       │       └── content: "::Herb::Engine.nested_attribute_value(a != b)"
+    │   │                       │
+    │   │                       ├── close_quote: ∅
+    │   │                       └── quoted: true
+    │   │
+    │   │
+    │   │
+    │   ├── tag_name: "div" (location: (1:8)-(1:11))
+    │   ├── body: []
+    │   ├── close_tag:
+    │   │   └── @ HTMLVirtualCloseTagNode (location: (1:39)-(1:39))
+    │   │       └── tag_name: "div" (location: (1:8)-(1:11))
+    │   │
+    │   ├── is_void: false
+    │   └── element_source: "ActionView::Helpers::TagHelper#tag"
+    │
+    └── @ HTMLTextNode (location: (1:39)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/engine/action_view/tag_attributes_test/test_0006_tag.attributes_with_dynamic_boolean_attribute_26c41ef4d3aa1e002fa0b82e55a28d26.txt
+++ b/test/snapshots/engine/action_view/tag_attributes_test/test_0006_tag.attributes_with_dynamic_boolean_attribute_26c41ef4d3aa1e002fa0b82e55a28d26.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::ActionView::TagAttributesTest#test_0006_tag.attributes with dynamic boolean attribute"
+input: "{source: \"<option <%= tag.attributes(selected: option == current) %>>One</option>\", options: {optimize: true, locals: {option: \"one\", current: \"two\"}}}"
+---
+_buf = ::String.new; _buf << '<option '.freeze; if (option == current); _buf << 'selected'.freeze; end; _buf << '>One</option>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/action_view/tag_attributes_test/test_0006_tag.attributes_with_dynamic_boolean_attribute_ba7339b5e4aa6d3385d7c86dd97aea7c.txt
+++ b/test/snapshots/engine/action_view/tag_attributes_test/test_0006_tag.attributes_with_dynamic_boolean_attribute_ba7339b5e4aa6d3385d7c86dd97aea7c.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::ActionView::TagAttributesTest#test_0006_tag.attributes with dynamic boolean attribute"
+input: "{source: \"<option <%= tag.attributes(selected: option == current) %>>One</option>\", locals: {option: \"one\", current: \"two\"}, options: {action_view_helpers: true}}"
+---
+<option >One</option>

--- a/test/snapshots/engine/action_view/tag_test/test_0040_tag.div_with_dynamic_boolean_attribute_that_is_truthy_148c16b3912a27ddaf7b7c7c0f9c2534.txt
+++ b/test/snapshots/engine/action_view/tag_test/test_0040_tag.div_with_dynamic_boolean_attribute_that_is_truthy_148c16b3912a27ddaf7b7c7c0f9c2534.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::ActionView::TagTest#test_0040_tag.div with dynamic boolean attribute that is truthy"
+input: "{source: \"<%= tag.div hidden: a != b %>\", type: \"herb_output\", action_view_helpers: true}"
+---
+<div hidden></div>

--- a/test/snapshots/engine/action_view/tag_test/test_0040_tag.div_with_dynamic_boolean_attribute_that_is_truthy_2e0d73ce0d422961e0f51b13062d47a7.txt
+++ b/test/snapshots/engine/action_view/tag_test/test_0040_tag.div_with_dynamic_boolean_attribute_that_is_truthy_2e0d73ce0d422961e0f51b13062d47a7.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::ActionView::TagTest#test_0040_tag.div with dynamic boolean attribute that is truthy"
+input: "{source: \"<%= tag.div hidden: a != b %>\", locals: {a: 1, b: 2}, options: {action_view_helpers: true}}"
+---
+<div hidden></div>

--- a/test/snapshots/engine/action_view/tag_test/test_0040_tag.div_with_dynamic_boolean_attribute_that_is_truthy_9e0172f08152b95ce432b22b1223f099.txt
+++ b/test/snapshots/engine/action_view/tag_test/test_0040_tag.div_with_dynamic_boolean_attribute_that_is_truthy_9e0172f08152b95ce432b22b1223f099.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::ActionView::TagTest#test_0040_tag.div with dynamic boolean attribute that is truthy"
+input: "{source: \"<%= tag.div hidden: a != b %>\", options: {optimize: true}}"
+---
+_buf = ::String.new; _buf << '<div'.freeze; if (a != b); _buf << ' hidden'.freeze; end; _buf << '></div>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/action_view/tag_test/test_0040_tag.div_with_dynamic_boolean_attribute_that_is_truthy_c9775cffee47676ecf220972ddfda3f7.txt
+++ b/test/snapshots/engine/action_view/tag_test/test_0040_tag.div_with_dynamic_boolean_attribute_that_is_truthy_c9775cffee47676ecf220972ddfda3f7.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::ActionView::TagTest#test_0040_tag.div with dynamic boolean attribute that is truthy"
+input: "{source: \"<%= tag.div hidden: a != b %>\", type: \"rails_output\", action_view_helpers: true}"
+---
+<div hidden="hidden"></div>

--- a/test/snapshots/engine/action_view/tag_test/test_0041_tag.div_with_dynamic_boolean_attribute_that_is_falsy_74a29f4380f57e9d1a85a5d09d0aeb81.txt
+++ b/test/snapshots/engine/action_view/tag_test/test_0041_tag.div_with_dynamic_boolean_attribute_that_is_falsy_74a29f4380f57e9d1a85a5d09d0aeb81.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::ActionView::TagTest#test_0041_tag.div with dynamic boolean attribute that is falsy"
+input: "{source: \"<%= tag.div hidden: a == b %>\", locals: {a: 1, b: 2}, options: {action_view_helpers: true}}"
+---
+<div></div>

--- a/test/snapshots/engine/action_view/tag_test/test_0041_tag.div_with_dynamic_boolean_attribute_that_is_falsy_dc7f2e73782269987c9afbeb4db293f9.txt
+++ b/test/snapshots/engine/action_view/tag_test/test_0041_tag.div_with_dynamic_boolean_attribute_that_is_falsy_dc7f2e73782269987c9afbeb4db293f9.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::ActionView::TagTest#test_0041_tag.div with dynamic boolean attribute that is falsy"
+input: "{source: \"<%= tag.div hidden: a == b %>\", options: {optimize: true, locals: {a: 1, b: 2}}}"
+---
+_buf = ::String.new; _buf << '<div'.freeze; if (a == b); _buf << ' hidden'.freeze; end; _buf << '></div>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/action_view/tag_test/test_0042_tag.div_with_dynamic_boolean_attribute_that_is_nil_3f5365730efbe181bcde166e302b1175.txt
+++ b/test/snapshots/engine/action_view/tag_test/test_0042_tag.div_with_dynamic_boolean_attribute_that_is_nil_3f5365730efbe181bcde166e302b1175.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::ActionView::TagTest#test_0042_tag.div with dynamic boolean attribute that is nil"
+input: "{source: \"<%= tag.div hidden: maybe %>\", locals: {maybe: nil}, options: {action_view_helpers: true}}"
+---
+<div></div>

--- a/test/snapshots/engine/action_view/tag_test/test_0042_tag.div_with_dynamic_boolean_attribute_that_is_nil_5693333a8d500eeb3582ed68d857a7e0.txt
+++ b/test/snapshots/engine/action_view/tag_test/test_0042_tag.div_with_dynamic_boolean_attribute_that_is_nil_5693333a8d500eeb3582ed68d857a7e0.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::ActionView::TagTest#test_0042_tag.div with dynamic boolean attribute that is nil"
+input: "{source: \"<%= tag.div hidden: maybe %>\", options: {optimize: true, locals: {maybe: nil}}}"
+---
+_buf = ::String.new; _buf << '<div'.freeze; if (maybe); _buf << ' hidden'.freeze; end; _buf << '></div>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/action_view/tag_test/test_0043_tag.div_with_boolean_attribute_shorthand_008e64a8fad3c13b20a30b6686467362.txt
+++ b/test/snapshots/engine/action_view/tag_test/test_0043_tag.div_with_boolean_attribute_shorthand_008e64a8fad3c13b20a30b6686467362.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::ActionView::TagTest#test_0043_tag.div with boolean attribute shorthand"
+input: "{source: \"<%= tag.div(hidden:) %>\", options: {optimize: true}}"
+---
+_buf = ::String.new; _buf << '<div'.freeze; if (hidden); _buf << ' hidden'.freeze; end; _buf << '></div>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/action_view/tag_test/test_0043_tag.div_with_boolean_attribute_shorthand_2ae02008c353dbed568bba40e6e96609.txt
+++ b/test/snapshots/engine/action_view/tag_test/test_0043_tag.div_with_boolean_attribute_shorthand_2ae02008c353dbed568bba40e6e96609.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::ActionView::TagTest#test_0043_tag.div with boolean attribute shorthand"
+input: "{source: \"<%= tag.div(hidden:) %>\", type: \"herb_output\", action_view_helpers: true}"
+---
+<div hidden></div>

--- a/test/snapshots/engine/action_view/tag_test/test_0043_tag.div_with_boolean_attribute_shorthand_4cf9cf2f4ebada85e9e1f9032ffaf449.txt
+++ b/test/snapshots/engine/action_view/tag_test/test_0043_tag.div_with_boolean_attribute_shorthand_4cf9cf2f4ebada85e9e1f9032ffaf449.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::ActionView::TagTest#test_0043_tag.div with boolean attribute shorthand"
+input: "{source: \"<%= tag.div(hidden:) %>\", type: \"rails_output\", action_view_helpers: true}"
+---
+<div hidden="hidden"></div>

--- a/test/snapshots/engine/action_view/tag_test/test_0043_tag.div_with_boolean_attribute_shorthand_c1d5eb624507daf0a8ceb6966db4766a.txt
+++ b/test/snapshots/engine/action_view/tag_test/test_0043_tag.div_with_boolean_attribute_shorthand_c1d5eb624507daf0a8ceb6966db4766a.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::ActionView::TagTest#test_0043_tag.div with boolean attribute shorthand"
+input: "{source: \"<%= tag.div(hidden:) %>\", locals: {hidden: true}, options: {action_view_helpers: true}}"
+---
+<div hidden></div>


### PR DESCRIPTION
This pull request updates the `action_view_helpers` analyze pass to render boolean attributes conditionally when their value is a dynamic Ruby expression, instead of turning them into a valued attribute.

Boolean attributes only carry meaning through their presence, so `tag.div hidden: a != b` has to either emit `hidden` or omit it entirely. Until now only `true` and `false` literals were recognized as boolean values. Every other value fell through to the generic "wrap the expression in a Ruby literal" branch, which produced an attribute that is always present:

```html+erb
<%= tag.div hidden: a != b do %>
  Content
<% end %>
```

```html+erb
<div hidden="<%= a != b %>">
  Content
</div>
```

That element stays hidden even when `a == b`, because the browser only looks at whether the attribute exists. The conversion now emits an `ERBIfNode` wrapping a valueless attribute:

```html+erb
<div <% if (a != b) %>hidden<% end %>>
  Content
</div>
```

```js
@ ERBOpenTagNode (location: (1:0)-(1:32))
├── tag_name: "div" (location: (1:8)-(1:11))
└── children: (1 item)
    └── @ ERBIfNode (location: (1:12)-(1:26))
        ├── content: " if (a != b) " (location: (1:12)-(1:26))
        ├── statements: (1 item)
        │   └── @ HTMLAttributeNode (location: (1:12)-(1:18))
        │       ├── name: "hidden"
        │       ├── equals: ∅
        │       └── value: ∅
        └── end_node:
            └── @ ERBEndNode (location: (1:26)-(1:26))
```

Which `Herb::Engine` compiles down to a plain branch around the attribute:

```ruby
_buf = ::String.new; _buf << '<div'.freeze; if (a != b); _buf << ' hidden'.freeze; end; _buf << '></div>'.freeze;
```

Resolves https://github.com/marcoroth/herb/issues/2019