### PR TITLE
Language Server: Add workspace and multi-project support

### DIFF
--- a/javascript/packages/language-server/src/diagnostics.ts
+++ b/javascript/packages/language-server/src/diagnostics.ts
@@ -3,34 +3,34 @@ import { Connection, Diagnostic } from "vscode-languageserver/node"
 
 import { Settings } from "./settings"
 import { ParserService } from "./parser_service"
-import { LinterService } from "./linter_service"
 import { DocumentService } from "./document_service"
 import { ConfigService } from "./config_service"
+import { Workspaces } from "./workspaces"
 import { isConfigDocument } from "./utils"
 
 export class Diagnostics {
   private readonly connection: Connection
   private readonly documentService: DocumentService
   private readonly parserService: ParserService
-  private readonly linterService: LinterService
   private readonly configService: ConfigService
   private readonly settings: Settings
+  private readonly workspaces: Workspaces
   private diagnostics: Map<TextDocument, Diagnostic[]> = new Map()
 
   constructor(
     connection: Connection,
     documentService: DocumentService,
     parserService: ParserService,
-    linterService: LinterService,
     configService: ConfigService,
     settings: Settings,
+    workspaces: Workspaces,
   ) {
     this.connection = connection
     this.documentService = documentService
     this.parserService = parserService
-    this.linterService = linterService
     this.configService = configService
     this.settings = settings
+    this.workspaces = workspaces
   }
 
   clear(uri: string) {
@@ -44,13 +44,14 @@ export class Diagnostics {
       return
     }
 
+    const workspace = await this.workspaces.ensure(textDocument.uri)
     let allDiagnostics: Diagnostic[] = []
 
     if (isConfigDocument(textDocument.uri)) {
-      allDiagnostics = await this.configService.validateDocument(textDocument)
+      allDiagnostics = await (workspace?.configService ?? this.configService).validateDocument(textDocument)
     } else {
       const parseResult = this.parserService.parseDocument(textDocument)
-      const lintResult = await this.linterService.lintDocument(textDocument)
+      const lintResult = workspace ? await workspace.linterService.lintDocument(textDocument) : { diagnostics: [] }
 
       allDiagnostics = [
         ...parseResult.diagnostics,

--- a/javascript/packages/language-server/src/document_save_service.ts
+++ b/javascript/packages/language-server/src/document_save_service.ts
@@ -2,14 +2,12 @@ import { Connection, TextEdit, TextDocumentSaveReason } from "vscode-languageser
 import { TextDocument } from "vscode-languageserver-textdocument"
 
 import { Settings } from "./settings"
-import { AutofixService } from "./autofix_service"
-import { FormattingService } from "./formatting_service"
+import { Workspaces } from "./workspaces"
 
 export class DocumentSaveService {
   private connection: Connection
   private settings: Settings
-  private autofixService: AutofixService
-  private formattingService: FormattingService
+  private workspaces: Workspaces
 
   /**
    * Tracks documents that were recently autofixed via applyFixesAndFormatting
@@ -20,11 +18,10 @@ export class DocumentSaveService {
    */
   private recentlyAutofixedViaFormatting = new Set<string>()
 
-  constructor(connection: Connection, settings: Settings, autofixService: AutofixService, formattingService: FormattingService) {
+  constructor(connection: Connection, settings: Settings, workspaces: Workspaces) {
     this.connection = connection
     this.settings = settings
-    this.autofixService = autofixService
-    this.formattingService = formattingService
+    this.workspaces = workspaces
   }
 
   /**
@@ -32,6 +29,10 @@ export class DocumentSaveService {
    * Called by willSaveWaitUntil - formatting is handled separately by editor.formatOnSave
    */
   async applyFixes(document: TextDocument): Promise<TextEdit[]> {
+    const workspace = await this.workspaces.ensure(document.uri)
+
+    if (!workspace) return []
+
     const settings = await this.settings.getDocumentSettings(document.uri)
     const fixOnSave = settings?.linter?.fixOnSave !== false
 
@@ -44,7 +45,7 @@ export class DocumentSaveService {
       return []
     }
 
-    return this.autofixService.autofix(document)
+    return workspace.autofixService.autofix(document)
   }
 
   /**
@@ -52,6 +53,10 @@ export class DocumentSaveService {
    * Called by onDocumentFormatting (manual format or editor.formatOnSave)
    */
   async applyFixesAndFormatting(document: TextDocument, reason: TextDocumentSaveReason): Promise<TextEdit[]> {
+    const workspace = await this.workspaces.ensure(document.uri)
+
+    if (!workspace) return []
+
     const settings = await this.settings.getDocumentSettings(document.uri)
     const fixOnSave = settings?.linter?.fixOnSave !== false
     const formatterEnabled = settings?.formatter?.enabled ?? false
@@ -61,7 +66,7 @@ export class DocumentSaveService {
     let autofixEdits: TextEdit[] = []
 
     if (fixOnSave) {
-      autofixEdits = await this.autofixService.autofix(document)
+      autofixEdits = await workspace.autofixService.autofix(document)
 
       if (autofixEdits.length > 0) {
         this.recentlyAutofixedViaFormatting.add(document.uri)
@@ -71,9 +76,9 @@ export class DocumentSaveService {
     if (!formatterEnabled) return autofixEdits
 
     if (autofixEdits.length === 0) {
-      return this.formattingService.formatOnSave(document, reason)
+      return workspace.formattingService.formatOnSave(document, reason)
     }
 
-    return this.formattingService.formatOnSave(document, reason, autofixEdits[0].newText)
+    return workspace.formattingService.formatOnSave(document, reason, autofixEdits[0].newText)
   }
 }

--- a/javascript/packages/language-server/src/linter_service.ts
+++ b/javascript/packages/language-server/src/linter_service.ts
@@ -35,6 +35,7 @@ export class LinterService {
   private readonly partialIndexService: PartialIndexService
   private readonly partialCallerIndexService?: PartialCallerIndexService
   private readonly source = "Herb Linter "
+  private config?: Config
   private linter?: Linter
   private allRules: RuleClass[] = rules
   private customRulesLoaded = false
@@ -48,6 +49,10 @@ export class LinterService {
     this.project = project
     this.partialIndexService = partialIndexService
     this.partialCallerIndexService = partialCallerIndexService
+  }
+
+  setConfig(config: Config): void {
+    this.config = config
   }
 
   /**
@@ -134,7 +139,7 @@ export class LinterService {
 
     if (isConfigDocument(filePath)) return false
 
-    const config = this.settings.projectConfig
+    const config = this.config
     if (!config) return true
 
     const hasConfigFile = Config.exists(config.projectPath)
@@ -193,7 +198,7 @@ export class LinterService {
       return { diagnostics: [] }
     }
 
-    const projectConfig = this.settings.projectConfig
+    const projectConfig = this.config
 
     if (!this.linter) {
       await this.loadCustomRules()

--- a/javascript/packages/language-server/src/server.ts
+++ b/javascript/packages/language-server/src/server.ts
@@ -90,6 +90,7 @@ export class Server {
         result.capabilities.workspace = {
           workspaceFolders: {
             supported: true,
+            changeNotifications: true,
           },
         }
       }
@@ -103,8 +104,14 @@ export class Server {
       }
 
       if (this.service.settings.hasWorkspaceFolderCapability) {
-        this.connection.workspace.onDidChangeWorkspaceFolders((_event) => {
-          this.connection.console.log("Workspace folder change event received.")
+        this.connection.workspace.onDidChangeWorkspaceFolders(async (event) => {
+          this.service.settings.updateWorkspaceFolders(event)
+
+          const dropped = this.service.workspaces.prune()
+
+          this.connection.console.log(`[Workspace] Folders changed, dropped ${dropped.length} project(s)`)
+
+          await this.service.diagnostics.refreshAllDocuments()
         })
       }
 
@@ -160,12 +167,12 @@ export class Server {
         } else if (isCustomRuleChange || isCustomRewriterChange) {
           if (isCustomRuleChange) {
             this.connection.console.log(`[Linter] Custom rule changed: ${event.uri}`)
-            this.service.linterService.rebuildLinter()
+            for (const workspace of this.service.workspaces.all()) workspace.linterService.rebuildLinter()
           }
 
           if (isCustomRewriterChange) {
             this.connection.console.log(`[Rewriter] Custom rewriter changed: ${event.uri}`)
-            await this.service.formattingService.refreshConfig(this.service.config)
+            for (const workspace of this.service.workspaces.all()) await workspace.formattingService.refreshConfig(workspace.config)
           }
 
           const documents = this.service.documentService.getAll()
@@ -187,7 +194,7 @@ export class Server {
     })
 
     this.connection.onDocumentRangeFormatting((params: DocumentRangeFormattingParams) => {
-      return this.service.formattingService.formatRange(params)
+      return this.service.workspaces.get(params.textDocument.uri)?.formattingService.formatRange(params) ?? []
     })
 
     this.connection.onDocumentHighlight((params: DocumentHighlightParams) => {
@@ -211,7 +218,7 @@ export class Server {
 
       if (!document) return null
 
-      return this.service.completionService.getCompletions(document, params.position)
+      return this.service.workspaces.get(params.textDocument.uri)?.completionService.getCompletions(document, params.position) ?? null
     })
 
     this.connection.onCodeAction((params: CodeActionParams) => {
@@ -219,19 +226,22 @@ export class Server {
 
       if (!document) return []
 
+      const workspace = this.service.workspaces.get(params.textDocument.uri)
+      if (!workspace) return []
+
       const parseResult = this.service.parserService.parseDocument(document)
       if (parseResult.diagnostics.length > 0) return []
 
       const diagnostics = params.context.diagnostics
       const documentText = document.getText()
 
-      const linterDisableCodeActions = this.service.codeActionService.createCodeActions(
+      const linterDisableCodeActions = workspace.codeActionService.createCodeActions(
         params.textDocument.uri,
         diagnostics,
         documentText
       )
 
-      const autofixCodeActions = this.service.codeActionService.autofixCodeActions(params, document)
+      const autofixCodeActions = workspace.codeActionService.autofixCodeActions(params, document)
       const rewriteCodeActions = this.service.rewriteCodeActionService.getCodeActions(document, params.range)
       const extractCodeActions = this.service.extractCodeActionService.getCodeActions(document, params.range)
 
@@ -263,7 +273,7 @@ export class Server {
 
       if (!document) return []
 
-      return this.service.referencesService.getReferences(document, params.position, params.context.includeDeclaration)
+      return this.service.workspaces.get(params.textDocument.uri)?.referencesService.getReferences(document, params.position, params.context.includeDeclaration) ?? []
     })
 
     this.connection.onDocumentSymbol((params: DocumentSymbolParams) => {
@@ -300,8 +310,16 @@ export class Server {
   }
 
   private async updatePartialIndex(event: FileEvent): Promise<boolean> {
-    const partials = this.service.partialIndexService
-    const callers = this.service.partialCallerIndexService
+    const workspace = this.service.workspaces.get(event.uri)
+
+    if (!workspace) {
+      this.service.diagnostics.clear(event.uri)
+
+      return false
+    }
+
+    const partials = workspace.partialIndexService
+    const callers = workspace.partialCallerIndexService
 
     if (event.type === FileChangeType.Deleted) {
       const stoppedCalling = callers.remove(event.uri)

--- a/javascript/packages/language-server/src/service.ts
+++ b/javascript/packages/language-server/src/service.ts
@@ -1,16 +1,12 @@
 import { Connection, InitializeParams } from "vscode-languageserver/node"
 
+import { Herb } from "@herb-tools/node-wasm"
+
 import { Settings, PersonalHerbSettings } from "./settings"
 import { DocumentService } from "./document_service"
 import { Diagnostics } from "./diagnostics"
 import { ParserService } from "./parser_service"
-import { LinterService } from "./linter_service"
-import { Config } from "@herb-tools/config"
-import { Project } from "./project"
-import { FormattingService } from "./formatting_service"
 import { ConfigService } from "./config_service"
-import { AutofixService } from "./autofix_service"
-import { CodeActionService } from "./code_action_service"
 import { DocumentSaveService } from "./document_save_service"
 import { FoldingRangeService } from "./folding_range_service"
 import { DocumentHighlightService } from "./document_highlight_service"
@@ -19,30 +15,18 @@ import { RewriteCodeActionService } from "./rewrite_code_action_service"
 import { ExtractCodeActionService } from "./extract_code_action_service"
 import { DefinitionService } from "./definition_service"
 import { CommentService } from "./comment_service"
-import { CompletionService } from "./completion_service"
 import { DocumentSymbolService } from "./document_symbol_service"
-import { PartialIndexService } from "./partial_index_service"
-import { PartialCallerIndexService } from "./partial_caller_index_service"
-import { ReferencesService } from "./references_service"
-
-import { version } from "../package.json"
+import { Workspaces } from "./workspaces"
 
 export class Service {
   connection: Connection
   settings: Settings
-  project: Project
-  config?: Config
+  workspaces: Workspaces
 
   diagnostics: Diagnostics
   documentService: DocumentService
-  partialIndexService: PartialIndexService
-  partialCallerIndexService: PartialCallerIndexService
   parserService: ParserService
-  linterService: LinterService
-  formattingService: FormattingService
-  autofixService: AutofixService
   configService: ConfigService
-  codeActionService: CodeActionService
   documentSaveService: DocumentSaveService
   foldingRangeService: FoldingRangeService
   documentHighlightService: DocumentHighlightService
@@ -50,35 +34,31 @@ export class Service {
   rewriteCodeActionService: RewriteCodeActionService
   extractCodeActionService: ExtractCodeActionService
   definitionService: DefinitionService
-  referencesService: ReferencesService
   commentService: CommentService
-  completionService: CompletionService
   documentSymbolService: DocumentSymbolService
 
   constructor(connection: Connection, params: InitializeParams) {
     this.connection = connection
     this.settings = new Settings(params, this.connection)
     this.documentService = new DocumentService(this.connection)
-    this.project = new Project(connection, this.settings.projectPath.replace("file://", ""))
     this.parserService = new ParserService()
-    this.partialIndexService = new PartialIndexService(this.connection, this.project)
-    this.partialCallerIndexService = new PartialCallerIndexService(this.connection, this.project, this.partialIndexService)
-    this.linterService = new LinterService(this.connection, this.settings, this.project, this.partialIndexService, this.partialCallerIndexService)
-    this.formattingService = new FormattingService(this.connection, this.documentService.documents, this.project, this.settings)
-    this.autofixService = new AutofixService(this.connection, this.config, this.partialIndexService, this.partialCallerIndexService)
-    this.configService = new ConfigService(this.project.projectPath)
-    this.codeActionService = new CodeActionService(this.project, this.config, this.partialIndexService, this.partialCallerIndexService)
-    this.diagnostics = new Diagnostics(this.connection, this.documentService, this.parserService, this.linterService, this.configService, this.settings)
-    this.documentSaveService = new DocumentSaveService(this.connection, this.settings, this.autofixService, this.formattingService)
+    this.configService = new ConfigService(this.settings.projectPath)
+    this.definitionService = new DefinitionService(this.parserService)
+
+    this.workspaces = new Workspaces(this.connection, this.settings, {
+      documentService: this.documentService,
+      parserService: this.parserService,
+      definitionService: this.definitionService,
+    })
+
+    this.diagnostics = new Diagnostics(this.connection, this.documentService, this.parserService, this.configService, this.settings, this.workspaces)
+    this.documentSaveService = new DocumentSaveService(this.connection, this.settings, this.workspaces)
     this.foldingRangeService = new FoldingRangeService(this.parserService)
     this.documentHighlightService = new DocumentHighlightService(this.parserService)
     this.hoverService = new HoverService(this.parserService)
     this.rewriteCodeActionService = new RewriteCodeActionService(this.parserService)
-    this.definitionService = new DefinitionService(this.parserService)
-    this.referencesService = new ReferencesService(this.project, this.definitionService, this.partialIndexService, this.partialCallerIndexService, this.documentService)
     this.commentService = new CommentService(this.parserService)
     this.documentSymbolService = new DocumentSymbolService(this.parserService)
-    this.completionService = new CompletionService(this.parserService, this.partialIndexService)
 
     this.extractCodeActionService = new ExtractCodeActionService(this.parserService, {
       supportsCreateFile: this.settings.supportsResourceCreation,
@@ -93,38 +73,7 @@ export class Service {
   async init() {
     this.connection.console.log(`[Client] Diagnostic related information: ${this.settings.hasDiagnosticRelatedInformationCapability ? "supported" : "not supported"}`)
 
-    await this.project.initialize()
-    await this.formattingService.initialize()
-    await this.partialIndexService.initialize()
-    await this.partialCallerIndexService.initialize()
-
-    try {
-      this.config = await Config.loadForEditor(this.project.projectPath, version)
-      this.codeActionService.setConfig(this.config)
-      this.autofixService.setConfig(this.config)
-
-      if (this.config.version && this.config.version !== version) {
-        this.connection.console.warn(
-          `Config file version (${this.config.version}) does not match current version (${version}). ` +
-          `Consider updating your .herb.yml file.`
-        )
-      }
-    } catch (error) {
-      this.connection.console.warn(
-        `Failed to load config: ${error instanceof Error ? error.message : String(error)}. Using personal settings with defaults.`
-      )
-      this.config = Config.fromObject({
-        linter: this.settings.globalSettings.linter,
-        formatter: this.settings.globalSettings.formatter
-      }, { projectPath: this.project.projectPath, version })
-
-      this.codeActionService.setConfig(this.config)
-      this.autofixService.setConfig(this.config)
-    }
-
-    await this.settings.initializeProjectConfig(this.config)
-    await this.formattingService.refreshConfig(this.config)
-    this.linterService.rebuildLinter()
+    await Herb.load()
 
     this.documentService.onDidClose((change) => {
       this.settings.documentSettings.delete(change.document.uri)
@@ -132,13 +81,17 @@ export class Service {
     })
 
     this.documentService.onDidChangeContent(async (change) => {
-      const callersChanged = this.partialCallerIndexService.updateFromSource(change.document.uri, change.document.getText())
-      const partialsChanged = this.partialIndexService.updateFromSource(change.document.uri, change.document.getText())
+      const workspace = await this.workspaces.ensure(change.document.uri)
 
-      if (callersChanged || partialsChanged) {
-        await this.diagnostics.refreshAllDocuments()
+      if (workspace) {
+        const callersChanged = workspace.partialCallerIndexService.updateFromSource(change.document.uri, change.document.getText())
+        const partialsChanged = workspace.partialIndexService.updateFromSource(change.document.uri, change.document.getText())
 
-        return
+        if (callersChanged || partialsChanged) {
+          await this.diagnostics.refreshAllDocuments()
+
+          return
+        }
       }
 
       await this.diagnostics.refreshDocument(change.document)
@@ -146,43 +99,20 @@ export class Service {
   }
 
   async refresh() {
-    await this.project.refresh()
-    await this.partialIndexService.initialize()
-    await this.partialCallerIndexService.initialize()
-    await this.formattingService.refreshConfig(this.config)
+    this.workspaces.forget()
+
+    for (const workspace of this.workspaces.all()) {
+      await workspace.reindex()
+    }
+
     await this.diagnostics.refreshAllDocuments()
   }
 
   async refreshConfig() {
-    try {
-      this.config = await Config.loadForEditor(this.project.projectPath, version)
+    this.workspaces.forget()
 
-      this.codeActionService.setConfig(this.config)
-      this.autofixService.setConfig(this.config)
-
-      if (this.config.version && this.config.version !== version) {
-        this.connection.console.warn(
-          `Config file version (${this.config.version}) does not match current version (${version}). ` +
-          `Consider updating your .herb.yml file.`
-        )
-      }
-    } catch (error) {
-      this.connection.console.warn(
-        `Failed to load config: ${error instanceof Error ? error.message : String(error)}. Using personal settings with defaults.`
-      )
-
-      this.config = Config.fromObject({
-        linter: this.settings.globalSettings.linter,
-        formatter: this.settings.globalSettings.formatter
-      }, { projectPath: this.project.projectPath, version })
-
-      this.codeActionService.setConfig(this.config)
-      this.autofixService.setConfig(this.config)
+    for (const workspace of this.workspaces.all()) {
+      await workspace.refreshConfig()
     }
-
-    await this.settings.refreshProjectConfig(this.config)
-    await this.formattingService.refreshConfig(this.config)
-
-    this.linterService.rebuildLinter()
   }
 }

--- a/javascript/packages/language-server/src/settings.ts
+++ b/javascript/packages/language-server/src/settings.ts
@@ -1,4 +1,4 @@
-import { ClientCapabilities, Connection, InitializeParams, ResourceOperationKind } from "vscode-languageserver/node"
+import { ClientCapabilities, Connection, InitializeParams, ResourceOperationKind, WorkspaceFoldersChangeEvent } from "vscode-languageserver/node"
 import { Config } from "@herb-tools/config"
 
 import { defaultFormatOptions } from "@herb-tools/formatter"
@@ -56,10 +56,16 @@ export class Settings {
   capabilities: ClientCapabilities
   connection: Connection
 
+  private folders: string[]
+
   constructor(params: InitializeParams, connection: Connection) {
     this.params = params
     this.capabilities = params.capabilities
     this.connection = connection
+
+    const opened = params.workspaceFolders?.map(folder => folder.uri) ?? []
+
+    this.folders = this.folderPaths(opened.length > 0 ? opened : [params.rootUri ?? params.rootPath ?? ""])
 
     this.hasConfigurationCapability = !!(this.capabilities.workspace && !!this.capabilities.workspace.configuration)
     this.hasShowDocumentCapability = !!(this.capabilities.window?.showDocument)
@@ -152,22 +158,31 @@ export class Settings {
   }
 
   get workspacePaths(): string[] {
-    const folders = this.params.workspaceFolders?.map(folder => folder.uri) ?? []
-    const roots = folders.length > 0 ? folders : [this.params.rootUri ?? this.params.rootPath ?? ""]
+    return this.folders
+  }
 
-    return roots.filter(root => root !== "").map(root => pathFromUri(root).replace(/\/$/, ""))
+  updateWorkspaceFolders(event: WorkspaceFoldersChangeEvent) {
+    const removed = new Set(this.folderPaths(event.removed.map(folder => folder.uri)))
+
+    this.folders = [
+      ...this.folders.filter(path => !removed.has(path)),
+      ...this.folderPaths(event.added.map(folder => folder.uri)),
+    ]
   }
 
   includes(uri: string): boolean {
     if (!uri.startsWith(FILE_SCHEME)) return true
+    if (this.folders.length === 0) return true
 
-    const roots = this.workspacePaths
+    return this.containsPath(pathFromUri(uri))
+  }
 
-    if (roots.length === 0) return true
+  containsPath(path: string): boolean {
+    return this.folders.some(root => path === root || path.startsWith(`${root}/`))
+  }
 
-    const path = pathFromUri(uri)
-
-    return roots.some(root => path === root || path.startsWith(`${root}/`))
+  private folderPaths(uris: string[]): string[] {
+    return uris.filter(uri => uri !== "").map(uri => pathFromUri(uri).replace(/\/$/, ""))
   }
 
   getDocumentSettings(resource: string): Thenable<PersonalHerbSettings> {

--- a/javascript/packages/language-server/src/workspace.ts
+++ b/javascript/packages/language-server/src/workspace.ts
@@ -1,0 +1,128 @@
+import { Config } from "@herb-tools/config"
+
+import { Project } from "./project"
+import { ConfigService } from "./config_service"
+import { LinterService } from "./linter_service"
+import { AutofixService } from "./autofix_service"
+import { CodeActionService } from "./code_action_service"
+import { FormattingService } from "./formatting_service"
+import { ReferencesService } from "./references_service"
+import { CompletionService } from "./completion_service"
+import { PartialIndexService } from "./partial_index_service"
+import { PartialCallerIndexService } from "./partial_caller_index_service"
+
+import { version } from "../package.json"
+
+import type { Connection } from "vscode-languageserver/node"
+import type { Settings, PersonalHerbSettings } from "./settings"
+import type { DocumentService } from "./document_service"
+import type { ParserService } from "./parser_service"
+import type { DefinitionService } from "./definition_service"
+
+export interface SharedServices {
+  documentService: DocumentService
+  parserService: ParserService
+  definitionService: DefinitionService
+}
+
+export class Workspace {
+  readonly root: string
+  readonly project: Project
+
+  public config?: Config
+
+  readonly configService: ConfigService
+  readonly partialIndexService: PartialIndexService
+  readonly partialCallerIndexService: PartialCallerIndexService
+  readonly linterService: LinterService
+  readonly autofixService: AutofixService
+  readonly codeActionService: CodeActionService
+  readonly formattingService: FormattingService
+  readonly referencesService: ReferencesService
+  readonly completionService: CompletionService
+
+  private readonly connection: Connection
+  private readonly settings: Settings
+
+  constructor(connection: Connection, settings: Settings, root: string, shared: SharedServices) {
+    this.connection = connection
+    this.settings = settings
+    this.root = root
+
+    this.project = new Project(connection, root)
+    this.configService = new ConfigService(root)
+    this.partialIndexService = new PartialIndexService(connection, this.project)
+    this.partialCallerIndexService = new PartialCallerIndexService(connection, this.project, this.partialIndexService)
+    this.linterService = new LinterService(connection, settings, this.project, this.partialIndexService, this.partialCallerIndexService)
+    this.autofixService = new AutofixService(connection, undefined, this.partialIndexService, this.partialCallerIndexService)
+    this.codeActionService = new CodeActionService(this.project, undefined, this.partialIndexService, this.partialCallerIndexService)
+    this.formattingService = new FormattingService(connection, shared.documentService.documents, this.project, settings)
+    this.completionService = new CompletionService(shared.parserService, this.partialIndexService)
+
+    this.referencesService = new ReferencesService(
+      this.project,
+      shared.definitionService,
+      this.partialIndexService,
+      this.partialCallerIndexService,
+      shared.documentService,
+    )
+  }
+
+  async initialize() {
+    await this.project.initialize()
+    await this.loadConfig()
+    await this.formattingService.initialize()
+    await this.formattingService.refreshConfig(this.config)
+    await this.partialIndexService.initialize()
+    await this.partialCallerIndexService.initialize()
+  }
+
+  async reindex() {
+    await this.project.refresh()
+    await this.partialIndexService.initialize()
+    await this.partialCallerIndexService.initialize()
+  }
+
+  async loadConfig() {
+    this.config = await this.readConfig()
+
+    this.codeActionService.setConfig(this.config)
+    this.autofixService.setConfig(this.config)
+    this.linterService.setConfig(this.config)
+    this.linterService.rebuildLinter()
+  }
+
+  async refreshConfig() {
+    await this.loadConfig()
+    await this.formattingService.refreshConfig(this.config)
+
+    this.settings.documentSettings.clear()
+  }
+
+  contains(path: string): boolean {
+    return path === this.root || path.startsWith(`${this.root}/`)
+  }
+
+  private async readConfig(): Promise<Config> {
+    try {
+      const config = await Config.loadForEditor(this.root, version)
+
+      if (config.version && config.version !== version) {
+        this.connection.console.warn(
+          `Config file version (${config.version}) does not match current version (${version}). ` +
+          `Consider updating your .herb.yml file.`
+        )
+      }
+
+      return config
+    } catch (error) {
+      this.connection.console.warn(
+        `Failed to load config for ${this.root}: ${error instanceof Error ? error.message : String(error)}. Using personal settings with defaults.`
+      )
+
+      const globals: PersonalHerbSettings = this.settings.globalSettings
+
+      return Config.fromObject({ linter: globals.linter, formatter: globals.formatter }, { projectPath: this.root, version })
+    }
+  }
+}

--- a/javascript/packages/language-server/src/workspaces.ts
+++ b/javascript/packages/language-server/src/workspaces.ts
@@ -1,0 +1,116 @@
+import { dirname } from "node:path"
+import { pathFromUri } from "./utils"
+
+import { Config } from "@herb-tools/config"
+import { Workspace } from "./workspace"
+
+import type { Connection } from "vscode-languageserver/node"
+import type { Settings } from "./settings"
+import type { SharedServices } from "./workspace"
+
+const FILE_SCHEME = "file://"
+
+/**
+ * Herb resolves a project by walking up for a `.herb.yml`, so a workspace
+ * folder is a boundary rather than a unit. One folder can hold several projects
+ * and each of them gets its own config, linter and partial index, keyed by the
+ * root that `Config` itself would pick for a file.
+ */
+export class Workspaces {
+  private readonly connection: Connection
+  private readonly settings: Settings
+  private readonly shared: SharedServices
+
+  private readonly byRoot: Map<string, Workspace> = new Map()
+  private readonly rootByDirectory: Map<string, string> = new Map()
+
+  constructor(connection: Connection, settings: Settings, shared: SharedServices) {
+    this.connection = connection
+    this.settings = settings
+    this.shared = shared
+  }
+
+  all(): Workspace[] {
+    return [...this.byRoot.values()]
+  }
+
+  get(uri: string): Workspace | null {
+    const root = this.rootFor(uri)
+
+    return root === null ? null : this.byRoot.get(root) ?? null
+  }
+
+  async ensure(uri: string): Promise<Workspace | null> {
+    const root = this.rootFor(uri)
+    if (root === null) return null
+
+    const existing = this.byRoot.get(root)
+    if (existing) return existing
+
+    const workspace = new Workspace(this.connection, this.settings, root, this.shared)
+
+    this.byRoot.set(root, workspace)
+
+    await workspace.initialize()
+
+    this.connection.console.log(`[Workspace] Indexed ${root}`)
+
+    return workspace
+  }
+
+  containing(path: string): Workspace | null {
+    let best: Workspace | null = null
+
+    for (const workspace of this.byRoot.values()) {
+      if (!workspace.contains(path)) {
+        continue
+      }
+
+      if (best === null || workspace.root.length > best.root.length) {
+        best = workspace
+      }
+    }
+
+    return best
+  }
+
+  prune(): string[] {
+    const dropped = this.all().filter(workspace => !this.settings.containsPath(workspace.root))
+
+    for (const workspace of dropped) {
+      this.remove(workspace.root)
+    }
+
+    this.forget()
+
+    return dropped.map(workspace => workspace.root)
+  }
+
+  remove(root: string): boolean {
+    for (const [directory, cached] of this.rootByDirectory) {
+      if (cached === root) this.rootByDirectory.delete(directory)
+    }
+
+    return this.byRoot.delete(root)
+  }
+
+  forget() {
+    this.rootByDirectory.clear()
+  }
+
+  private rootFor(uri: string): string | null {
+    if (!uri.startsWith(FILE_SCHEME)) return null
+    if (!this.settings.includes(uri)) return null
+
+    const directory = dirname(pathFromUri(uri))
+
+    const cached = this.rootByDirectory.get(directory)
+    if (cached !== undefined) return cached
+
+    const root = Config.findProjectRootSync(directory)
+
+    this.rootByDirectory.set(directory, root)
+
+    return root
+  }
+}

--- a/javascript/packages/language-server/test/diagnostics.test.ts
+++ b/javascript/packages/language-server/test/diagnostics.test.ts
@@ -6,6 +6,7 @@ import { TextDocument } from "vscode-languageserver-textdocument"
 import { Settings } from "../src/settings"
 import { Diagnostics } from "../src/diagnostics"
 import { ParserService } from "../src/parser_service"
+import { Workspaces } from "../src/workspaces"
 
 import type { Connection, InitializeParams, PublishDiagnosticsParams } from "vscode-languageserver/node"
 import type { ConfigService } from "../src/config_service"
@@ -46,13 +47,19 @@ describe("Diagnostics", () => {
     const linterService = { lintDocument: async () => ({ diagnostics: [] }) } as unknown as LinterService
     const configService = { validateDocument: async () => [] } as unknown as ConfigService
 
+    const settings = new Settings(params, connection)
+
+    const workspaces = {
+      ensure: async (uri: string) => settings.includes(uri) ? { linterService, configService } : null
+    } as unknown as Workspaces
+
     const diagnostics = new Diagnostics(
       connection,
       documentService,
       parserService,
-      linterService,
       configService,
-      new Settings(params, connection),
+      settings,
+      workspaces,
     )
 
     return { diagnostics, published }

--- a/javascript/packages/language-server/test/document_save_service.test.ts
+++ b/javascript/packages/language-server/test/document_save_service.test.ts
@@ -7,6 +7,7 @@ import { DocumentSaveService } from '../src/document_save_service'
 import { Settings } from '../src/settings'
 import { AutofixService } from '../src/autofix_service'
 import { FormattingService } from '../src/formatting_service'
+import { Workspaces } from '../src/workspaces'
 import { Herb } from '@herb-tools/node-wasm'
 
 describe('DocumentSaveService', () => {
@@ -41,12 +42,11 @@ describe('DocumentSaveService', () => {
       formatText: vi.fn()
     } as unknown as FormattingService
 
-    documentSaveService = new DocumentSaveService(
-      connection,
-      settings,
-      autofixService,
-      formattingService
-    )
+    const workspaces = {
+      ensure: async () => ({ autofixService, formattingService })
+    } as unknown as Workspaces
+
+    documentSaveService = new DocumentSaveService(connection, settings, workspaces)
   })
 
   describe('applyFixesAndFormatting', () => {

--- a/javascript/packages/language-server/test/linter_service.test.ts
+++ b/javascript/packages/language-server/test/linter_service.test.ts
@@ -146,6 +146,8 @@ describe("LinterService", () => {
       }, { projectPath: process.cwd() })
 
       const linterService = new LinterService(mockConnection, settings, mockProject, partialIndexService)
+      linterService.setConfig(settings.projectConfig!)
+
       const result = await linterService.lintDocument(createTestDocument("<div>Test</div>\n"))
 
       expect(result.diagnostics.map(diagnostic => diagnostic.code)).not.toContain("herb-config-framework-option")
@@ -160,6 +162,8 @@ describe("LinterService", () => {
       }, { projectPath: process.cwd() })
 
       const linterService = new LinterService(mockConnection, settings, mockProject, partialIndexService)
+      linterService.setConfig(settings.projectConfig!)
+
       const result = await linterService.lintDocument(createTestDocument("<div>Test</div>\n"))
 
       expect(result.diagnostics.map(diagnostic => diagnostic.code)).toContain("herb-config-framework-option")
@@ -188,6 +192,7 @@ describe("LinterService", () => {
       } as Project
 
       const linterService = new LinterService(mockConnection, settings, mockProjectWithPath, new PartialIndexService(mockConnection, mockProjectWithPath))
+      linterService.setConfig(settings.projectConfig!)
       const textDocument = TextDocument.create("file:///test/project/vendor/cache/file.html.erb", "erb", 1, "<DIV>Content</DIV>")
       const result = await linterService.lintDocument(textDocument)
 
@@ -217,6 +222,7 @@ describe("LinterService", () => {
       } as Project
 
       const linterService = new LinterService(mockConnection, settings, mockProjectWithPath, new PartialIndexService(mockConnection, mockProjectWithPath))
+      linterService.setConfig(settings.projectConfig!)
       const textDocument = TextDocument.create("file:///test/project/something/file.html.erb", "erb", 1, "<DIV>Content</DIV>")
       const result = await linterService.lintDocument(textDocument)
 
@@ -248,6 +254,7 @@ describe("LinterService", () => {
       } as Project
 
       const linterService = new LinterService(mockConnection, settings, mockProjectWithPath, new PartialIndexService(mockConnection, mockProjectWithPath))
+      linterService.setConfig(settings.projectConfig!)
       const textDocument = TextDocument.create("file:///test/project/app/views/file.html.erb", "erb", 1, "<DIV>Content</DIV>")
       const result = await linterService.lintDocument(textDocument)
 
@@ -279,6 +286,8 @@ describe("LinterService", () => {
       } as any
 
       const linterService = new LinterService(mockConnection, settings, mockProject, partialIndexService)
+      linterService.setConfig(settings.projectConfig!)
+
       const textDocument = createTestDocument("<DIV>Content</DIV>")
       const result = await linterService.lintDocument(textDocument)
 

--- a/javascript/packages/language-server/test/workspaces.test.ts
+++ b/javascript/packages/language-server/test/workspaces.test.ts
@@ -1,0 +1,212 @@
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join, dirname } from "node:path"
+import { pathToFileURL } from "node:url"
+
+import { beforeAll, afterEach, describe, expect, test, vi } from "vitest"
+
+import { Herb } from "@herb-tools/node-wasm"
+
+import { Workspaces } from "../src/workspaces"
+import { Settings } from "../src/settings"
+import { ParserService } from "../src/parser_service"
+import { DefinitionService } from "../src/definition_service"
+
+import type { Connection, InitializeParams } from "vscode-languageserver/node"
+import type { DocumentService } from "../src/document_service"
+
+const roots: string[] = []
+
+const connection = {
+  console: { log: vi.fn(), warn: vi.fn(), error: vi.fn() }
+} as unknown as Connection
+
+const OUTER_CONFIG = `linter:\n  enabled: true\n  rules:\n    html-tag-name-lowercase:\n      enabled: false\n`
+const NESTED_CONFIG = `linter:\n  enabled: true\n  rules:\n    html-tag-name-lowercase:\n      enabled: true\n`
+
+const FILES = {
+  ".herb.yml": OUTER_CONFIG,
+  "app/views/posts/_outer.html.erb": `<article></article>\n`,
+  "app/views/posts/index.html.erb": `<div></div>\n`,
+  "nested/.herb.yml": NESTED_CONFIG,
+  "nested/app/views/posts/_inner.html.erb": `<section></section>\n`,
+  "nested/app/views/posts/index.html.erb": `<div></div>\n`,
+}
+
+function project(files: Record<string, string>): string {
+  const root = mkdtempSync(join(tmpdir(), "herb-lsp-workspaces-"))
+
+  roots.push(root)
+
+  for (const [path, contents] of Object.entries(files)) {
+    const file = join(root, path)
+
+    mkdirSync(dirname(file), { recursive: true })
+    writeFileSync(file, contents, "utf-8")
+  }
+
+  return root
+}
+
+function settingsFor(folder: string): Settings {
+  const params = {
+    processId: null,
+    rootUri: null,
+    capabilities: {},
+    workspaceFolders: [{ uri: pathToFileURL(folder).toString(), name: "outer" }],
+  } as unknown as InitializeParams
+
+  return new Settings(params, connection)
+}
+
+function registryWith(_folder: string, settings: Settings): Workspaces {
+  const parserService = new ParserService()
+
+  return new Workspaces(connection, settings, {
+    documentService: { documents: {}, get: () => undefined } as unknown as DocumentService,
+    parserService,
+    definitionService: new DefinitionService(parserService),
+  })
+}
+
+function registryFor(folder: string): Workspaces {
+  return registryWith(folder, settingsFor(folder))
+}
+
+function uriFor(folder: string, path: string): string {
+  return pathToFileURL(join(folder, path)).toString()
+}
+
+beforeAll(async () => {
+  await Herb.load()
+})
+
+afterEach(() => {
+  while (roots.length > 0) {
+    rmSync(roots.pop()!, { recursive: true, force: true })
+  }
+})
+
+describe("Workspaces", () => {
+  test("resolves a document to the directory holding its `.herb.yml`", async () => {
+    const folder = project(FILES)
+    const workspaces = registryFor(folder)
+
+    const workspace = await workspaces.ensure(uriFor(folder, "app/views/posts/index.html.erb"))
+
+    expect(workspace?.root).toBe(folder)
+  })
+
+  test("gives a nested project its own workspace", async () => {
+    const folder = project(FILES)
+    const workspaces = registryFor(folder)
+
+    const outer = await workspaces.ensure(uriFor(folder, "app/views/posts/index.html.erb"))
+    const inner = await workspaces.ensure(uriFor(folder, "nested/app/views/posts/index.html.erb"))
+
+    expect(inner?.root).toBe(join(folder, "nested"))
+    expect(inner).not.toBe(outer)
+    expect(workspaces.all()).toHaveLength(2)
+  })
+
+  test("reuses the workspace for another document under the same root", async () => {
+    const folder = project(FILES)
+    const workspaces = registryFor(folder)
+
+    const first = await workspaces.ensure(uriFor(folder, "app/views/posts/index.html.erb"))
+    const second = await workspaces.ensure(uriFor(folder, "app/views/posts/_outer.html.erb"))
+
+    expect(second).toBe(first)
+    expect(workspaces.all()).toHaveLength(1)
+  })
+
+  test("loads each project's own config", async () => {
+    const folder = project(FILES)
+    const workspaces = registryFor(folder)
+
+    const outer = await workspaces.ensure(uriFor(folder, "app/views/posts/index.html.erb"))
+    const inner = await workspaces.ensure(uriFor(folder, "nested/app/views/posts/index.html.erb"))
+
+    expect(outer?.config?.config?.linter?.rules?.["html-tag-name-lowercase"]).toEqual({ enabled: false })
+    expect(inner?.config?.config?.linter?.rules?.["html-tag-name-lowercase"]).toEqual({ enabled: true })
+  })
+
+  test("indexes only the partials belonging to each project", async () => {
+    const folder = project(FILES)
+    const workspaces = registryFor(folder)
+
+    const outer = await workspaces.ensure(uriFor(folder, "app/views/posts/index.html.erb"))
+    const inner = await workspaces.ensure(uriFor(folder, "nested/app/views/posts/index.html.erb"))
+
+    expect(outer?.partialIndexService.index?.lookup("posts/outer", undefined)).not.toBeNull()
+    expect(outer?.partialIndexService.index?.lookup("posts/inner", undefined)).toBeNull()
+
+    expect(inner?.partialIndexService.index?.lookup("posts/inner", undefined)).not.toBeNull()
+    expect(inner?.partialIndexService.index?.lookup("posts/outer", undefined)).toBeNull()
+  })
+
+  test("refuses a document outside every workspace folder", async () => {
+    const folder = project(FILES)
+    const workspaces = registryFor(folder)
+
+    expect(await workspaces.ensure("file:///somewhere/else/a.html.erb")).toBeNull()
+  })
+
+  test("refuses a document that does not live on disk", async () => {
+    const folder = project(FILES)
+    const workspaces = registryFor(folder)
+
+    expect(await workspaces.ensure("untitled:Untitled-1")).toBeNull()
+  })
+
+  test("drops the projects of a folder the client closed", async () => {
+    const folder = project(FILES)
+    const settings = settingsFor(folder)
+    const workspaces = registryWith(folder, settings)
+
+    await workspaces.ensure(uriFor(folder, "app/views/posts/index.html.erb"))
+    await workspaces.ensure(uriFor(folder, "nested/app/views/posts/index.html.erb"))
+
+    expect(workspaces.all()).toHaveLength(2)
+
+    settings.updateWorkspaceFolders({ added: [], removed: [{ uri: pathToFileURL(folder).toString(), name: "outer" }] })
+
+    expect(workspaces.prune()).toHaveLength(2)
+    expect(workspaces.all()).toHaveLength(0)
+  })
+
+  test("keeps the projects of a folder that stayed open", async () => {
+    const folder = project(FILES)
+    const settings = settingsFor(folder)
+    const workspaces = registryWith(folder, settings)
+
+    await workspaces.ensure(uriFor(folder, "app/views/posts/index.html.erb"))
+
+    settings.updateWorkspaceFolders({ added: [{ uri: "file:///elsewhere", name: "other" }], removed: [] })
+
+    expect(workspaces.prune()).toEqual([])
+    expect(workspaces.all()).toHaveLength(1)
+  })
+
+  test("resolves a document in a folder added after initialize", async () => {
+    const folder = project(FILES)
+    const settings = settingsFor("/nowhere")
+    const workspaces = registryWith(folder, settings)
+
+    expect(await workspaces.ensure(uriFor(folder, "app/views/posts/index.html.erb"))).toBeNull()
+
+    settings.updateWorkspaceFolders({ added: [{ uri: pathToFileURL(folder).toString(), name: "outer" }], removed: [] })
+
+    expect((await workspaces.ensure(uriFor(folder, "app/views/posts/index.html.erb")))?.root).toBe(folder)
+  })
+
+  test("resolves the innermost project for a path under both", async () => {
+    const folder = project(FILES)
+    const workspaces = registryFor(folder)
+
+    await workspaces.ensure(uriFor(folder, "app/views/posts/index.html.erb"))
+    await workspaces.ensure(uriFor(folder, "nested/app/views/posts/index.html.erb"))
+
+    expect(workspaces.containing(join(folder, "nested/app/views/posts/index.html.erb"))?.root).toBe(join(folder, "nested"))
+  })
+})

--- a/javascript/packages/vscode/package.json
+++ b/javascript/packages/vscode/package.json
@@ -14,9 +14,7 @@
   "engines": {
     "vscode": "^1.100.0"
   },
-  "extensionDependencies": [
-    "Shopify.ruby-lsp"
-  ],
+  "extensionDependencies": [],
   "categories": [
     "Programming Languages",
     "Linters",

--- a/javascript/packages/vscode/package.json
+++ b/javascript/packages/vscode/package.json
@@ -114,6 +114,13 @@
           ],
           "default": "verbose",
           "description": "Traces the communication between Visual Studio Code and the Herb language server (for debugging)."
+        },
+        "languageServerHerb.workspace.suggestAddingProjects": {
+          "scope": "window",
+          "type": "boolean",
+          "default": true,
+          "description": "Suggest adding a file's project folder to the workspace when an HTML+ERB file outside the current workspace folders is opened. Herb only analyzes files inside workspace folders.",
+          "markdownDescription": "Suggest adding a file's project folder to the workspace when an HTML+ERB file outside the current workspace folders is opened. Herb only analyzes files inside workspace folders."
         }
       }
     },

--- a/javascript/packages/vscode/src/extension.ts
+++ b/javascript/packages/vscode/src/extension.ts
@@ -148,10 +148,36 @@ export async function activate(context: vscode.ExtensionContext) {
   settingsCommands = new HerbSettingsCommands(context, configProvider)
   void settingsCommands
 
-  vscode.window.createTreeView('herbFileStatus', { treeDataProvider: analysisProvider })
-  vscode.window.createTreeView('herbConfiguration', { treeDataProvider: configProvider })
+  const fileStatusView = vscode.window.createTreeView('herbFileStatus', { treeDataProvider: analysisProvider })
+  const configurationView = vscode.window.createTreeView('herbConfiguration', { treeDataProvider: configProvider })
+
   vscode.window.createTreeView('herbInformation', { treeDataProvider: informationProvider })
   vscode.window.createTreeView('herbSupport', { treeDataProvider: supportProvider })
+
+  const describeScopedFolder = () => {
+    const folders = vscode.workspace.workspaceFolders ?? []
+    // These views read the first folder only, so say which one it is and how
+    // many are being left out once the choice stops being obvious.
+    const multiRoot = folders.length > 1
+    const others = folders.length - 1
+    const description = multiRoot ? folders[0].name : undefined
+    const message = multiRoot
+      ? `Showing ${folders[0].name}. ${others} other workspace ${others === 1 ? 'folder is' : 'folders are'} not included.`
+      : undefined
+
+    fileStatusView.description = description
+    fileStatusView.message = message
+    configurationView.description = description
+    configurationView.message = message
+  }
+
+  describeScopedFolder()
+
+  context.subscriptions.push(
+    fileStatusView,
+    configurationView,
+    vscode.workspace.onDidChangeWorkspaceFolders(describeScopedFolder)
+  )
 
   const codeActionProvider = new HerbCodeActionProvider()
 

--- a/javascript/packages/vscode/src/extension.ts
+++ b/javascript/packages/vscode/src/extension.ts
@@ -4,6 +4,8 @@ import type { TextEdit } from "vscode-languageclient/node"
 
 import { Config } from "@herb-tools/config"
 
+import { registerWorkspaceSuggestion } from "./workspace-suggestion"
+
 import { Client } from "./client"
 import { HerbAnalysisProvider } from "./herb-analysis-provider"
 import { HerbCodeActionProvider } from "./code-action-provider"
@@ -274,6 +276,8 @@ export async function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(vscode.window.onDidChangeActiveTextEditor(async () => {
     await updateConfigStatusBarItem()
   }))
+
+  registerWorkspaceSuggestion(context)
 
   await updateConfigStatusBarItem()
   await runAutoAnalysis()

--- a/javascript/packages/vscode/src/herb-analysis-provider.ts
+++ b/javascript/packages/vscode/src/herb-analysis-provider.ts
@@ -3,7 +3,7 @@ import { TreeChildrenProvider } from './tree-children-provider'
 import { AnalysisService } from './analysis-service'
 import { VersionService } from './version-service'
 
-import { workspace, window, commands, EventEmitter, ProgressLocation } from 'vscode'
+import { workspace, window, commands, EventEmitter, ProgressLocation, RelativePattern } from 'vscode'
 
 import { Config } from "@herb-tools/config"
 
@@ -90,7 +90,13 @@ export class HerbAnalysisProvider implements TreeDataProvider<TreeNode> {
       includePattern = Config.getDefaultFilePatterns().join(",")
     }
 
-    const uris = await workspace.findFiles(includePattern, excludePattern)
+    // Scoped to the folder the config came from. An unscoped glob searches
+    // every workspace folder, which in a multi-root window would list files
+    // from projects this config says nothing about.
+    const uris = await workspace.findFiles(
+      workspaceRoot ? new RelativePattern(workspaceRoot, includePattern) : includePattern,
+      excludePattern
+    )
 
     this.lastAnalysisTime = new Date()
 

--- a/javascript/packages/vscode/src/test/workspace-suggestion.test.ts
+++ b/javascript/packages/vscode/src/test/workspace-suggestion.test.ts
@@ -1,0 +1,89 @@
+import * as assert from 'assert'
+import * as path from 'path'
+
+import { outsideWorkspaceRoot } from '../workspace-suggestion'
+
+suite('outsideWorkspaceRoot', () => {
+  const workspace = path.join(path.sep, 'work', 'store')
+  const outside = path.join(path.sep, 'elsewhere', 'blog')
+
+  function erb(fsPath: string, overrides: { scheme?: string, languageId?: string } = {}) {
+    return { fsPath, scheme: 'file', languageId: 'erb', ...overrides }
+  }
+
+  const findsRoot = (root: string) => () => root
+
+  test('offers nothing for a document inside a workspace folder', () => {
+    const file = path.join(workspace, 'app', 'views', 'a.html.erb')
+
+    assert.strictEqual(outsideWorkspaceRoot(erb(file), [workspace], findsRoot(workspace)), null)
+  })
+
+  test('offers nothing when the folder path has a trailing separator', () => {
+    const file = path.join(workspace, 'app', 'views', 'a.html.erb')
+
+    assert.strictEqual(outsideWorkspaceRoot(erb(file), [workspace + path.sep], findsRoot(workspace)), null)
+  })
+
+  test('offers the project root for a document outside every folder', () => {
+    const file = path.join(outside, 'app', 'views', 'a.html.erb')
+
+    assert.strictEqual(outsideWorkspaceRoot(erb(file), [workspace], findsRoot(outside)), outside)
+  })
+
+  test('offers nothing when no folder is open at all', () => {
+    const file = path.join(outside, 'app', 'views', 'a.html.erb')
+
+    assert.strictEqual(outsideWorkspaceRoot(erb(file), [], findsRoot(outside)), null)
+  })
+
+  test('offers nothing for a document that does not live on disk', () => {
+    const file = path.join(outside, 'a.html.erb')
+
+    assert.strictEqual(outsideWorkspaceRoot(erb(file, { scheme: 'git' }), [workspace], findsRoot(outside)), null)
+  })
+
+  test('offers nothing for a language Herb does not handle', () => {
+    const file = path.join(outside, 'a.rb')
+
+    assert.strictEqual(outsideWorkspaceRoot(erb(file, { languageId: 'ruby' }), [workspace], findsRoot(outside)), null)
+  })
+
+  test('falls back to the file directory when the root does not contain it', () => {
+    const file = path.join(outside, 'app', 'views', 'a.html.erb')
+    const cwd = path.join(path.sep, 'somewhere', 'unrelated')
+
+    assert.strictEqual(
+      outsideWorkspaceRoot(erb(file), [workspace], findsRoot(cwd)),
+      path.join(outside, 'app', 'views')
+    )
+  })
+
+  test('does not treat a folder that merely shares a prefix as containing', () => {
+    const sibling = `${workspace}-admin`
+    const file = path.join(sibling, 'app', 'views', 'a.html.erb')
+
+    assert.strictEqual(outsideWorkspaceRoot(erb(file), [workspace], findsRoot(sibling)), sibling)
+  })
+
+  test('offers a root that is an ancestor of an open folder', () => {
+    const nested = path.join(workspace, 'admin')
+    const file = path.join(workspace, 'app', 'views', 'a.html.erb')
+
+    assert.strictEqual(outsideWorkspaceRoot(erb(file), [nested], findsRoot(workspace)), workspace)
+  })
+
+  test('falls back to the file directory when finding the root throws', () => {
+    const file = path.join(outside, 'app', 'views', 'a.html.erb')
+    const throws = () => { throw new Error('Cannot read properties of undefined (reading \'configPath\')') }
+
+    assert.strictEqual(outsideWorkspaceRoot(erb(file), [workspace], throws), path.join(outside, 'app', 'views'))
+  })
+
+  test('checks every open folder, not just the first', () => {
+    const second = path.join(path.sep, 'work', 'blog')
+    const file = path.join(second, 'app', 'views', 'a.html.erb')
+
+    assert.strictEqual(outsideWorkspaceRoot(erb(file), [workspace, second], findsRoot(second)), null)
+  })
+})

--- a/javascript/packages/vscode/src/workspace-suggestion.ts
+++ b/javascript/packages/vscode/src/workspace-suggestion.ts
@@ -1,0 +1,126 @@
+import * as vscode from "vscode"
+import * as path from "path"
+import * as os from "os"
+
+import { Config } from "@herb-tools/config"
+
+const SETTING = "languageServerHerb.workspace.suggestAddingProjects"
+const FILE_SCHEME = "file"
+const LANGUAGES = new Set(["erb", "html"])
+const ADD_FOLDER = "Add Folder to Workspace"
+const OPEN_WINDOW = "Open in New Window"
+const DONT_ASK = "Don't Ask Again"
+
+export interface SuggestionDocument {
+  fsPath: string
+  scheme: string
+  languageId: string
+}
+
+/**
+ * The language server only reports on files inside a workspace folder, so a
+ * file opened from somewhere else is silently unlinted. This answers which
+ * project folder would have to be added to fix that, or null when there is
+ * nothing to offer.
+ */
+export function outsideWorkspaceRoot(
+  document: SuggestionDocument,
+  folderPaths: readonly string[],
+  findRoot: (startPath: string) => string
+): string | null {
+  if (document.scheme !== FILE_SCHEME) return null
+  if (!LANGUAGES.has(document.languageId)) return null
+
+  const folders = folderPaths.map(folder => folder.replace(/[\\/]+$/, ""))
+
+  if (folders.length === 0) return null
+  if (folders.some(folder => contains(folder, document.fsPath))) return null
+
+  const directory = path.dirname(document.fsPath)
+  const root = rootOf(directory, findRoot)
+
+  // `findProjectRootSync` falls back to the process working directory when it
+  // finds no marker, which in an extension host points at neither the file nor
+  // anything the author would recognise.
+  return contains(root, document.fsPath) ? root : directory
+}
+
+export function registerWorkspaceSuggestion(context: vscode.ExtensionContext) {
+  const promptedRoots = new Set<string>()
+
+  const maybePrompt = (document: vscode.TextDocument) => {
+    if (!vscode.workspace.getConfiguration().get<boolean>(SETTING, true)) return
+
+    const folders = (vscode.workspace.workspaceFolders ?? []).map(folder => folder.uri.fsPath)
+
+    const root = outsideWorkspaceRoot(
+      { fsPath: document.uri.fsPath, scheme: document.uri.scheme, languageId: document.languageId },
+      folders,
+      startPath => Config.findProjectRootSync(startPath)
+    )
+
+    if (root === null || promptedRoots.has(root)) return
+
+    // Claimed before awaiting, so a burst of restored tabs from one project
+    // asks once rather than once per tab.
+    promptedRoots.add(root)
+
+    prompt(document, root)
+  }
+
+  context.subscriptions.push(vscode.workspace.onDidOpenTextDocument(maybePrompt))
+
+  vscode.workspace.textDocuments.forEach(maybePrompt)
+}
+
+async function prompt(document: vscode.TextDocument, root: string) {
+  const action = await vscode.window.showInformationMessage(
+    `${path.basename(document.uri.fsPath)} is outside your workspace, so Herb isn't analyzing it. Add ${display(root)} to the workspace?`,
+    ADD_FOLDER,
+    OPEN_WINDOW,
+    DONT_ASK
+  )
+
+  if (action === ADD_FOLDER) {
+    const folders = vscode.workspace.workspaceFolders ?? []
+
+    // Adding a folder to a single-folder window turns it into an untitled
+    // multi-root workspace, which reloads the window and restarts this
+    // extension, so nothing may run after a successful call.
+    const added = vscode.workspace.updateWorkspaceFolders(folders.length, 0, { uri: vscode.Uri.file(root) })
+
+    if (!added) {
+      vscode.window.showErrorMessage(`Herb: could not add ${display(root)} to the workspace.`)
+    }
+
+    return
+  }
+
+  if (action === OPEN_WINDOW) {
+    await vscode.commands.executeCommand("vscode.openFolder", vscode.Uri.file(root), { forceNewWindow: true })
+
+    return
+  }
+
+  if (action === DONT_ASK) {
+    await vscode.workspace.getConfiguration().update(SETTING, false, vscode.ConfigurationTarget.Global)
+  }
+}
+
+function rootOf(directory: string, findRoot: (startPath: string) => string): string {
+  try {
+    return findRoot(directory)
+  } catch {
+    return directory
+  }
+}
+
+function contains(directory: string, filePath: string): boolean {
+  return filePath === directory || filePath.startsWith(`${directory}${path.sep}`)
+}
+
+function display(directory: string): string {
+  const home = os.homedir()
+
+  return contains(home, directory) ? `~${directory.slice(home.length)}` : directory
+}

--- a/javascript/packages/vscode/src/workspace-suggestion.ts
+++ b/javascript/packages/vscode/src/workspace-suggestion.ts
@@ -56,6 +56,8 @@ export function registerWorkspaceSuggestion(context: vscode.ExtensionContext) {
     const root = outsideWorkspaceRoot(
       { fsPath: document.uri.fsPath, scheme: document.uri.scheme, languageId: document.languageId },
       folders,
+      // Bound rather than passed bare: it reads `this.configPath` and
+      // `this.PROJECT_INDICATORS`, so an unbound reference throws.
       startPath => Config.findProjectRootSync(startPath)
     )
 


### PR DESCRIPTION
Follow up on #2110, which stopped the server reporting on files outside the workspace. This pull request goes the other way and lets the files inside it belong to more than one project.

Everything the server knows about a project came from a single path, the first workspace folder the client opened. That one path fed the config, the linter, the formatter, the autofixer, the code actions, the references and both partial indexes. A second folder was measured against the first folder's `.herb.yml`, and its partials resolved against the first folder's index.

A `Workspace` now owns all of that for one project, and a `Workspaces` registry hands a document the one it belongs to. Nothing is created up front. A workspace is built the first time a document resolves into it, so a project nobody opens costs nothing.

Projects are keyed by the root `Config.findProjectRoot` picks for a file, which is the directory holding its `.herb.yml`, rather than by the workspace folder. This is how gopls, rust-analyzer and tsserver scope their equivalents, and for good reason. A folder is not a project. One folder can hold several, and keying by folder would merge them and apply the outermost config to all of them:

```bash
app/.herb.yml            # one project
app/admin/.herb.yml      # another, inside the first
```

Workspace folders keep the role #2110 gave them. They are the boundary, so a document outside all of them still resolves to nothing, and they are what `workspace/didChangeWorkspaceFolders` adds to and removes from. 

The extension closes the loop for the case #2110 left silent. Opening an HTML+ERB file that belongs to no open folder now offers to add its project rather than saying nothing:

> `card.html.erb` is outside your workspace, so Herb isn't analyzing it. Add `~/projects/store` to the workspace? **[Add Folder to Workspace] [Open in New Window] [Don't Ask Again]**

<img width="1154" height="396" alt="CleanShot 2026-08-10 at 20 06 26@2x" src="https://github.com/user-attachments/assets/29b4c57c-bd9d-4c45-b266-263db352b0e2" />


The folder it offers is the project root, found the same way the server finds it, so accepting adds the project rather than whichever directory the file happened to sit in. A root is offered once per session, claimed before the notification is shown so a window restoring several tabs from one project asks once. Documents that do not live on disk are left alone, and `Don't Ask Again` turns `languageServerHerb.workspace.suggestAddingProjects` off for the user.


The extension's own views still read the first workspace folder:

<img width="25%" alt="CleanShot 2026-08-10 at 20 05 12@2x" src="https://github.com/user-attachments/assets/d52d3c8f-7e0b-4584-94cb-9420da006e0a" />




Resolves https://github.com/marcoroth/herb/issues/748
