### PR TITLE
Formatter: Add `indentStyle` to allow formatting using tabs

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -381,6 +381,7 @@ formatter:
 
 - **`enabled`**: `true` or `false` - Enable or disable the formatter
 - **`indentWidth`**: Number (default: `2`) - Spaces per indent level
+- **`indentType`**: `"spaces"` or `"tabs"` (default: `"spaces"`) - Indentation character expected by the `source-indentation` linter rule
 - **`maxLineLength`**: Number (default: `80`) - Maximum line length
 - **`include`**: Array of glob patterns - Additional patterns to format (additive to defaults)
 - **`exclude`**: Array of glob patterns - Additional patterns to exclude from formatting (additive to defaults)

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -363,10 +363,10 @@ Configure the formatter behavior:
 
 ```yaml [.herb.yml]
 formatter:
-  enabled: false     # Disabled by default (experimental)
-  indentWidth: 2     # Number of spaces for indentation
-  indentType: spaces # "spaces" or "tabs"
-  maxLineLength: 80  # Maximum line length before wrapping
+  enabled: false       # Disabled by default (experimental)
+  indentWidth: 2       # Number of spaces for indentation
+  indentStyle: spaces  # "spaces" or "tabs"
+  maxLineLength: 80    # Maximum line length before wrapping
 
   # Additional glob patterns to include (additive to defaults)
   include:
@@ -382,7 +382,7 @@ formatter:
 
 - **`enabled`**: `true` or `false` - Enable or disable the formatter
 - **`indentWidth`**: Number (default: `2`) - Spaces per indent level
-- **`indentType`**: `"spaces"` or `"tabs"` (default: `"spaces"`) <Badge type="tip" text="^0.11.0" /> - Character used for indentation
+- **`indentStyle`**: `"spaces"` or `"tabs"` (default: `"spaces"`) <Badge type="tip" text="^0.11.0" /> - Character used for indentation
 - **`maxLineLength`**: Number (default: `80`) - Maximum line length
 - **`include`**: Array of glob patterns - Additional patterns to format (additive to defaults)
 - **`exclude`**: Array of glob patterns - Additional patterns to exclude from formatting (additive to defaults)

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -365,7 +365,7 @@ Configure the formatter behavior:
 formatter:
   enabled: false       # Disabled by default (experimental)
   indentWidth: 2       # Number of spaces for indentation
-  indentStyle: spaces  # "spaces" or "tabs"
+  indentStyle: space   # "space" or "tab"
   maxLineLength: 80    # Maximum line length before wrapping
 
   # Additional glob patterns to include (additive to defaults)
@@ -382,7 +382,7 @@ formatter:
 
 - **`enabled`**: `true` or `false` - Enable or disable the formatter
 - **`indentWidth`**: Number (default: `2`) - Spaces per indent level
-- **`indentStyle`**: `"spaces"` or `"tabs"` (default: `"spaces"`) <Badge type="tip" text="^0.11.0" /> - Character used for indentation
+- **`indentStyle`**: `"space"` or `"tab"` (default: `"space"`) <Badge type="tip" text="^0.11.0" /> - Character used for indentation
 - **`maxLineLength`**: Number (default: `80`) - Maximum line length
 - **`include`**: Array of glob patterns - Additional patterns to format (additive to defaults)
 - **`exclude`**: Array of glob patterns - Additional patterns to exclude from formatting (additive to defaults)

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -365,6 +365,7 @@ Configure the formatter behavior:
 formatter:
   enabled: false     # Disabled by default (experimental)
   indentWidth: 2     # Number of spaces for indentation
+  indentType: spaces # "spaces" or "tabs"
   maxLineLength: 80  # Maximum line length before wrapping
 
   # Additional glob patterns to include (additive to defaults)
@@ -381,7 +382,7 @@ formatter:
 
 - **`enabled`**: `true` or `false` - Enable or disable the formatter
 - **`indentWidth`**: Number (default: `2`) - Spaces per indent level
-- **`indentType`**: `"spaces"` or `"tabs"` (default: `"spaces"`) <Badge type="tip" text="^0.11.0" /> - Indentation character expected by the `source-indentation` linter rule
+- **`indentType`**: `"spaces"` or `"tabs"` (default: `"spaces"`) <Badge type="tip" text="^0.11.0" /> - Character used for indentation
 - **`maxLineLength`**: Number (default: `80`) - Maximum line length
 - **`include`**: Array of glob patterns - Additional patterns to format (additive to defaults)
 - **`exclude`**: Array of glob patterns - Additional patterns to exclude from formatting (additive to defaults)

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -381,7 +381,7 @@ formatter:
 
 - **`enabled`**: `true` or `false` - Enable or disable the formatter
 - **`indentWidth`**: Number (default: `2`) - Spaces per indent level
-- **`indentType`**: `"spaces"` or `"tabs"` (default: `"spaces"`) - Indentation character expected by the `source-indentation` linter rule
+- **`indentType`**: `"spaces"` or `"tabs"` (default: `"spaces"`) <Badge type="tip" text="^0.11.0" /> - Indentation character expected by the `source-indentation` linter rule
 - **`maxLineLength`**: Number (default: `80`) - Maximum line length
 - **`include`**: Array of glob patterns - Additional patterns to format (additive to defaults)
 - **`exclude`**: Array of glob patterns - Additional patterns to exclude from formatting (additive to defaults)

--- a/javascript/packages/config/src/config-schema.ts
+++ b/javascript/packages/config/src/config-schema.ts
@@ -43,7 +43,7 @@ export const FormatterConfigSchema = z.object({
   include: z.array(z.string()).optional().describe("Additional glob patterns to include beyond defaults (e.g., ['**/*.xml.erb', 'custom/**/*.html'])"),
   exclude: z.array(z.string()).optional().describe("Glob patterns to exclude from formatting"),
   indentWidth: z.number().int().positive().optional().describe("Number of spaces per indentation level"),
-  indentStyle: z.enum(["spaces", "tabs"]).optional().describe("Indentation character to use ('spaces' or 'tabs')"),
+  indentStyle: z.enum(["space", "tab"]).optional().describe("Indentation character to use ('space' or 'tab')"),
   maxLineLength: z.number().int().positive().optional().describe("Maximum line length before wrapping"),
   rewriter: RewriterConfigSchema.describe("Rewriter configuration for pre and post-format transformations"),
 }).strict().optional()

--- a/javascript/packages/config/src/config-schema.ts
+++ b/javascript/packages/config/src/config-schema.ts
@@ -43,7 +43,7 @@ export const FormatterConfigSchema = z.object({
   include: z.array(z.string()).optional().describe("Additional glob patterns to include beyond defaults (e.g., ['**/*.xml.erb', 'custom/**/*.html'])"),
   exclude: z.array(z.string()).optional().describe("Glob patterns to exclude from formatting"),
   indentWidth: z.number().int().positive().optional().describe("Number of spaces per indentation level"),
-  indentType: z.enum(["spaces", "tabs"]).optional().describe("Indentation character to use ('spaces' or 'tabs')"),
+  indentStyle: z.enum(["spaces", "tabs"]).optional().describe("Indentation character to use ('spaces' or 'tabs')"),
   maxLineLength: z.number().int().positive().optional().describe("Maximum line length before wrapping"),
   rewriter: RewriterConfigSchema.describe("Rewriter configuration for pre and post-format transformations"),
 }).strict().optional()

--- a/javascript/packages/config/src/config-schema.ts
+++ b/javascript/packages/config/src/config-schema.ts
@@ -43,6 +43,7 @@ export const FormatterConfigSchema = z.object({
   include: z.array(z.string()).optional().describe("Additional glob patterns to include beyond defaults (e.g., ['**/*.xml.erb', 'custom/**/*.html'])"),
   exclude: z.array(z.string()).optional().describe("Glob patterns to exclude from formatting"),
   indentWidth: z.number().int().positive().optional().describe("Number of spaces per indentation level"),
+  indentType: z.enum(["spaces", "tabs"]).optional().describe("Indentation character to use ('spaces' or 'tabs')"),
   maxLineLength: z.number().int().positive().optional().describe("Maximum line length before wrapping"),
   rewriter: RewriterConfigSchema.describe("Rewriter configuration for pre and post-format transformations"),
 }).strict().optional()

--- a/javascript/packages/config/src/config-template.yml
+++ b/javascript/packages/config/src/config-template.yml
@@ -89,6 +89,7 @@ linter:
 formatter:
   enabled: false
   indentWidth: 2
+  # indentType: spaces  # 'spaces' or 'tabs' (used by the source-indentation linter rule)
   maxLineLength: 80
 
   # # Additional patterns beyond the defaults for formatting

--- a/javascript/packages/config/src/config-template.yml
+++ b/javascript/packages/config/src/config-template.yml
@@ -89,7 +89,7 @@ linter:
 formatter:
   enabled: false
   indentWidth: 2
-  indentType: spaces # "spaces" or "tabs"
+  indentStyle: spaces
   maxLineLength: 80
 
   # # Additional patterns beyond the defaults for formatting

--- a/javascript/packages/config/src/config-template.yml
+++ b/javascript/packages/config/src/config-template.yml
@@ -89,7 +89,7 @@ linter:
 formatter:
   enabled: false
   indentWidth: 2
-  # indentType: spaces  # "spaces" or "tabs"
+  indentType: spaces # "spaces" or "tabs"
   maxLineLength: 80
 
   # # Additional patterns beyond the defaults for formatting

--- a/javascript/packages/config/src/config-template.yml
+++ b/javascript/packages/config/src/config-template.yml
@@ -89,7 +89,7 @@ linter:
 formatter:
   enabled: false
   indentWidth: 2
-  indentStyle: spaces
+  indentStyle: space
   maxLineLength: 80
 
   # # Additional patterns beyond the defaults for formatting

--- a/javascript/packages/config/src/config-template.yml
+++ b/javascript/packages/config/src/config-template.yml
@@ -89,7 +89,7 @@ linter:
 formatter:
   enabled: false
   indentWidth: 2
-  # indentType: spaces  # 'spaces' or 'tabs' (used by the source-indentation linter rule)
+  # indentType: spaces  # "spaces" or "tabs"
   maxLineLength: 80
 
   # # Additional patterns beyond the defaults for formatting

--- a/javascript/packages/config/src/config.ts
+++ b/javascript/packages/config/src/config.ts
@@ -85,6 +85,7 @@ export type FormatterConfig = {
   include?: string[]
   exclude?: string[]
   indentWidth?: number
+  indentType?: "spaces" | "tabs"
   maxLineLength?: number
   rewriter?: {
     pre?: string[]

--- a/javascript/packages/config/src/config.ts
+++ b/javascript/packages/config/src/config.ts
@@ -85,7 +85,7 @@ export type FormatterConfig = {
   include?: string[]
   exclude?: string[]
   indentWidth?: number
-  indentType?: "spaces" | "tabs"
+  indentStyle?: "spaces" | "tabs"
   maxLineLength?: number
   rewriter?: {
     pre?: string[]

--- a/javascript/packages/config/src/config.ts
+++ b/javascript/packages/config/src/config.ts
@@ -85,7 +85,7 @@ export type FormatterConfig = {
   include?: string[]
   exclude?: string[]
   indentWidth?: number
-  indentStyle?: "spaces" | "tabs"
+  indentStyle?: "space" | "tab"
   maxLineLength?: number
   rewriter?: {
     pre?: string[]

--- a/javascript/packages/config/test/config.test.ts
+++ b/javascript/packages/config/test/config.test.ts
@@ -146,6 +146,18 @@ describe("@herb-tools/config", () => {
       expect(config.config.formatter?.maxLineLength).toBe(120)
     })
 
+    test("creates config with formatter indentType", () => {
+      const configOptions: HerbConfigOptions = {
+        formatter: {
+          indentType: "tabs"
+        }
+      }
+
+      const config = Config.fromObject(configOptions, { projectPath: testDir })
+
+      expect(config.config.formatter?.indentType).toBe("tabs")
+    })
+
     test("uses custom version when provided", () => {
       const config = Config.fromObject({}, { projectPath: testDir, version: "1.0.0" })
 

--- a/javascript/packages/config/test/config.test.ts
+++ b/javascript/packages/config/test/config.test.ts
@@ -149,13 +149,13 @@ describe("@herb-tools/config", () => {
     test("creates config with formatter indentStyle", () => {
       const configOptions: HerbConfigOptions = {
         formatter: {
-          indentStyle: "tabs"
+          indentStyle: "tab"
         }
       }
 
       const config = Config.fromObject(configOptions, { projectPath: testDir })
 
-      expect(config.config.formatter?.indentStyle).toBe("tabs")
+      expect(config.config.formatter?.indentStyle).toBe("tab")
     })
 
     test("uses custom version when provided", () => {

--- a/javascript/packages/config/test/config.test.ts
+++ b/javascript/packages/config/test/config.test.ts
@@ -146,16 +146,16 @@ describe("@herb-tools/config", () => {
       expect(config.config.formatter?.maxLineLength).toBe(120)
     })
 
-    test("creates config with formatter indentType", () => {
+    test("creates config with formatter indentStyle", () => {
       const configOptions: HerbConfigOptions = {
         formatter: {
-          indentType: "tabs"
+          indentStyle: "tabs"
         }
       }
 
       const config = Config.fromObject(configOptions, { projectPath: testDir })
 
-      expect(config.config.formatter?.indentType).toBe("tabs")
+      expect(config.config.formatter?.indentStyle).toBe("tabs")
     })
 
     test("uses custom version when provided", () => {

--- a/javascript/packages/formatter/README.md
+++ b/javascript/packages/formatter/README.md
@@ -202,6 +202,7 @@ herb-format --init
 formatter:
   enabled: true  # Must be enabled for formatting to work
   indentWidth: 2
+  indentType: spaces  # "spaces" or "tabs"
   maxLineLength: 80
 
   # Additional glob patterns to include (additive to defaults)
@@ -230,6 +231,7 @@ The `include` patterns are **additive** - they add to the defaults.
 
 - **`enabled`**: `true` or `false` - Must be `true` to enable formatting
 - **`indentWidth`**: Number (default: `2`) - Spaces per indentation level
+- **`indentType`**: `"spaces"` or `"tabs"` (default: `"spaces"`) - Character used for indentation
 - **`maxLineLength`**: Number (default: `80`) - Maximum line length before wrapping. Tags whose attributes would exceed this length are wrapped one-per-line.
 - **`include`**: Array of glob patterns - Additional patterns to format (additive to defaults)
 - **`exclude`**: Array of glob patterns - Patterns to exclude from formatting

--- a/javascript/packages/formatter/README.md
+++ b/javascript/packages/formatter/README.md
@@ -202,7 +202,7 @@ herb-format --init
 formatter:
   enabled: true  # Must be enabled for formatting to work
   indentWidth: 2
-  indentStyle: spaces
+  indentStyle: space
   maxLineLength: 80
 
   # Additional glob patterns to include (additive to defaults)
@@ -231,7 +231,7 @@ The `include` patterns are **additive** - they add to the defaults.
 
 - **`enabled`**: `true` or `false` - Must be `true` to enable formatting
 - **`indentWidth`**: Number (default: `2`) - Spaces per indentation level
-- **`indentStyle`**: `"spaces"` or `"tabs"` (default: `"spaces"`) - Character used for indentation
+- **`indentStyle`**: `"space"` or `"tab"` (default: `"space"`) - Character used for indentation
 - **`maxLineLength`**: Number (default: `80`) - Maximum line length before wrapping. Tags whose attributes would exceed this length are wrapped one-per-line.
 - **`include`**: Array of glob patterns - Additional patterns to format (additive to defaults)
 - **`exclude`**: Array of glob patterns - Patterns to exclude from formatting

--- a/javascript/packages/formatter/README.md
+++ b/javascript/packages/formatter/README.md
@@ -202,7 +202,7 @@ herb-format --init
 formatter:
   enabled: true  # Must be enabled for formatting to work
   indentWidth: 2
-  indentType: spaces  # "spaces" or "tabs"
+  indentStyle: spaces
   maxLineLength: 80
 
   # Additional glob patterns to include (additive to defaults)
@@ -231,7 +231,7 @@ The `include` patterns are **additive** - they add to the defaults.
 
 - **`enabled`**: `true` or `false` - Must be `true` to enable formatting
 - **`indentWidth`**: Number (default: `2`) - Spaces per indentation level
-- **`indentType`**: `"spaces"` or `"tabs"` (default: `"spaces"`) - Character used for indentation
+- **`indentStyle`**: `"spaces"` or `"tabs"` (default: `"spaces"`) - Character used for indentation
 - **`maxLineLength`**: Number (default: `80`) - Maximum line length before wrapping. Tags whose attributes would exceed this length are wrapped one-per-line.
 - **`include`**: Array of glob patterns - Additional patterns to format (additive to defaults)
 - **`exclude`**: Array of glob patterns - Patterns to exclude from formatting

--- a/javascript/packages/formatter/src/cli.ts
+++ b/javascript/packages/formatter/src/cli.ts
@@ -59,7 +59,7 @@ export class CLI {
       --config-file <path>            explicitly specify path to .herb.yml config file
       --force                         force formatting even if disabled in .herb.yml
       --indent-width <number>         number of spaces per indentation level (default: 2)
-      --indent-type <spaces|tabs>     character used for indentation (default: spaces)
+      --indent-style <spaces|tabs>    character used for indentation (default: spaces)
       --max-line-length <number>      maximum line length before wrapping (default: 80)
 
     Examples:
@@ -76,7 +76,7 @@ export class CLI {
 
       herb-format --force                         # Format even if disabled in project config
       herb-format --indent-width 4                # Format with 4-space indentation
-      herb-format --indent-type tabs              # Format with tab indentation
+      herb-format --indent-style tabs             # Format with tab indentation
       herb-format --max-line-length 100           # Format with 100-character line limit
       cat template.html.erb | herb-format         # Format from stdin to stdout
   `
@@ -92,7 +92,7 @@ export class CLI {
         init: { type: "boolean" },
         "config-file": { type: "string" },
         "indent-width": { type: "string" },
-        "indent-type": { type: "string" },
+        "indent-style": { type: "string" },
         "max-line-length": { type: "string" }
       },
       allowPositionals: true
@@ -116,16 +116,16 @@ export class CLI {
       indentWidth = parsed
     }
 
-    let indentType: "spaces" | "tabs" | undefined
+    let indentStyle: "spaces" | "tabs" | undefined
 
-    if (values["indent-type"]) {
-      if (values["indent-type"] !== "spaces" && values["indent-type"] !== "tabs") {
+    if (values["indent-style"]) {
+      if (values["indent-style"] !== "spaces" && values["indent-style"] !== "tabs") {
         console.error(
-          `Invalid indent-type: ${values["indent-type"]}. Must be "spaces" or "tabs".`,
+          `Invalid indent-style: ${values["indent-style"]}. Must be "spaces" or "tabs".`,
         )
         process.exit(1)
       }
-      indentType = values["indent-type"]
+      indentStyle = values["indent-style"]
     }
 
     let maxLineLength: number | undefined
@@ -149,13 +149,13 @@ export class CLI {
       isInitMode: values.init,
       configFile: values["config-file"],
       indentWidth,
-      indentType,
+      indentStyle,
       maxLineLength
     }
   }
 
   async run() {
-    const { positionals, isCheckMode, isVersionMode, isForceMode, isInitMode, configFile, indentWidth, indentType, maxLineLength } = this.parseArguments()
+    const { positionals, isCheckMode, isVersionMode, isForceMode, isInitMode, configFile, indentWidth, indentStyle, maxLineLength } = this.parseArguments()
 
     const startTime = Date.now()
     const startDate = new Date()
@@ -245,8 +245,8 @@ export class CLI {
         formatterConfig.indentWidth = indentWidth
       }
 
-      if (indentType !== undefined) {
-        formatterConfig.indentType = indentType
+      if (indentStyle !== undefined) {
+        formatterConfig.indentStyle = indentStyle
       }
 
       if (maxLineLength !== undefined) {

--- a/javascript/packages/formatter/src/cli.ts
+++ b/javascript/packages/formatter/src/cli.ts
@@ -59,7 +59,7 @@ export class CLI {
       --config-file <path>            explicitly specify path to .herb.yml config file
       --force                         force formatting even if disabled in .herb.yml
       --indent-width <number>         number of spaces per indentation level (default: 2)
-      --indent-style <spaces|tabs>    character used for indentation (default: spaces)
+      --indent-style <space|tab>      character used for indentation (default: space)
       --max-line-length <number>      maximum line length before wrapping (default: 80)
 
     Examples:
@@ -76,7 +76,7 @@ export class CLI {
 
       herb-format --force                         # Format even if disabled in project config
       herb-format --indent-width 4                # Format with 4-space indentation
-      herb-format --indent-style tabs             # Format with tab indentation
+      herb-format --indent-style tab              # Format with tab indentation
       herb-format --max-line-length 100           # Format with 100-character line limit
       cat template.html.erb | herb-format         # Format from stdin to stdout
   `
@@ -116,12 +116,12 @@ export class CLI {
       indentWidth = parsed
     }
 
-    let indentStyle: "spaces" | "tabs" | undefined
+    let indentStyle: "space" | "tab" | undefined
 
     if (values["indent-style"]) {
-      if (values["indent-style"] !== "spaces" && values["indent-style"] !== "tabs") {
+      if (values["indent-style"] !== "space" && values["indent-style"] !== "tab") {
         console.error(
-          `Invalid indent-style: ${values["indent-style"]}. Must be "spaces" or "tabs".`,
+          `Invalid indent-style: ${values["indent-style"]}. Must be "space" or "tab".`,
         )
         process.exit(1)
       }

--- a/javascript/packages/formatter/src/cli.ts
+++ b/javascript/packages/formatter/src/cli.ts
@@ -59,6 +59,7 @@ export class CLI {
       --config-file <path>            explicitly specify path to .herb.yml config file
       --force                         force formatting even if disabled in .herb.yml
       --indent-width <number>         number of spaces per indentation level (default: 2)
+      --indent-type <spaces|tabs>     character used for indentation (default: spaces)
       --max-line-length <number>      maximum line length before wrapping (default: 80)
 
     Examples:
@@ -75,6 +76,7 @@ export class CLI {
 
       herb-format --force                         # Format even if disabled in project config
       herb-format --indent-width 4                # Format with 4-space indentation
+      herb-format --indent-type tabs              # Format with tab indentation
       herb-format --max-line-length 100           # Format with 100-character line limit
       cat template.html.erb | herb-format         # Format from stdin to stdout
   `
@@ -90,6 +92,7 @@ export class CLI {
         init: { type: "boolean" },
         "config-file": { type: "string" },
         "indent-width": { type: "string" },
+        "indent-type": { type: "string" },
         "max-line-length": { type: "string" }
       },
       allowPositionals: true
@@ -113,6 +116,18 @@ export class CLI {
       indentWidth = parsed
     }
 
+    let indentType: "spaces" | "tabs" | undefined
+
+    if (values["indent-type"]) {
+      if (values["indent-type"] !== "spaces" && values["indent-type"] !== "tabs") {
+        console.error(
+          `Invalid indent-type: ${values["indent-type"]}. Must be "spaces" or "tabs".`,
+        )
+        process.exit(1)
+      }
+      indentType = values["indent-type"]
+    }
+
     let maxLineLength: number | undefined
 
     if (values["max-line-length"]) {
@@ -134,12 +149,13 @@ export class CLI {
       isInitMode: values.init,
       configFile: values["config-file"],
       indentWidth,
+      indentType,
       maxLineLength
     }
   }
 
   async run() {
-    const { positionals, isCheckMode, isVersionMode, isForceMode, isInitMode, configFile, indentWidth, maxLineLength } = this.parseArguments()
+    const { positionals, isCheckMode, isVersionMode, isForceMode, isInitMode, configFile, indentWidth, indentType, maxLineLength } = this.parseArguments()
 
     const startTime = Date.now()
     const startDate = new Date()
@@ -227,6 +243,10 @@ export class CLI {
 
       if (indentWidth !== undefined) {
         formatterConfig.indentWidth = indentWidth
+      }
+
+      if (indentType !== undefined) {
+        formatterConfig.indentType = indentType
       }
 
       if (maxLineLength !== undefined) {

--- a/javascript/packages/formatter/src/formatter.ts
+++ b/javascript/packages/formatter/src/formatter.ts
@@ -121,8 +121,8 @@ export class Formatter {
       }
     }
 
-    if (resolvedOptions.indentStyle === "tabs") {
-      formatted = convertIndentation(formatted, resolvedOptions.indentWidth, "tabs")
+    if (resolvedOptions.indentStyle === "tab") {
+      formatted = convertIndentation(formatted, resolvedOptions.indentWidth, "tab")
     }
 
     return { output: formatted, skipped: null, errorCount: 0 }

--- a/javascript/packages/formatter/src/formatter.ts
+++ b/javascript/packages/formatter/src/formatter.ts
@@ -44,7 +44,7 @@ export class Formatter {
 
     const mergedOptions: FormatOptions = {
       indentWidth: options.indentWidth ?? formatterConfig.indentWidth,
-      indentType: options.indentType ?? formatterConfig.indentType,
+      indentStyle: options.indentStyle ?? formatterConfig.indentStyle,
       maxLineLength: options.maxLineLength ?? formatterConfig.maxLineLength,
       preRewriters: options.preRewriters,
       postRewriters: options.postRewriters,
@@ -121,7 +121,7 @@ export class Formatter {
       }
     }
 
-    if (resolvedOptions.indentType === "tabs") {
+    if (resolvedOptions.indentStyle === "tabs") {
       formatted = convertIndentation(formatted, resolvedOptions.indentWidth, "tabs")
     }
 

--- a/javascript/packages/formatter/src/formatter.ts
+++ b/javascript/packages/formatter/src/formatter.ts
@@ -1,4 +1,5 @@
 import { FormatPrinter } from "./format-printer.js"
+import { convertIndentation } from "@herb-tools/printer"
 
 import { isScaffoldTemplate } from "./scaffold-template-detector.js"
 import { resolveFormatOptions } from "./options.js"
@@ -43,6 +44,7 @@ export class Formatter {
 
     const mergedOptions: FormatOptions = {
       indentWidth: options.indentWidth ?? formatterConfig.indentWidth,
+      indentType: options.indentType ?? formatterConfig.indentType,
       maxLineLength: options.maxLineLength ?? formatterConfig.maxLineLength,
       preRewriters: options.preRewriters,
       postRewriters: options.postRewriters,
@@ -117,6 +119,10 @@ export class Formatter {
           console.error(`Post-format rewriter "${rewriter.name}" failed:`, error)
         }
       }
+    }
+
+    if (resolvedOptions.indentType === "tabs") {
+      formatted = convertIndentation(formatted, resolvedOptions.indentWidth, "tabs")
     }
 
     return { output: formatted, skipped: null, errorCount: 0 }

--- a/javascript/packages/formatter/src/options.ts
+++ b/javascript/packages/formatter/src/options.ts
@@ -5,7 +5,7 @@ import type { IndentStyle } from "@herb-tools/printer"
  * Formatting options for the Herb formatter.
  *
  * indentWidth: number of spaces per indentation level.
- * indentStyle: character used for indentation, "spaces" or "tabs".
+ * indentStyle: character used for indentation, "space" or "tab".
  * maxLineLength: maximum line length before wrapping text or attributes.
  * preRewriters: AST rewriters to run before formatting.
  * postRewriters: String rewriters to run after formatting.
@@ -13,7 +13,7 @@ import type { IndentStyle } from "@herb-tools/printer"
 export interface FormatOptions {
   /** number of spaces per indentation level; defaults to 2 */
   indentWidth?: number
-  /** character used for indentation; defaults to "spaces" */
+  /** character used for indentation; defaults to "space" */
   indentStyle?: IndentStyle
   /** maximum line length before wrapping; defaults to 80 */
   maxLineLength?: number
@@ -28,7 +28,7 @@ export interface FormatOptions {
  */
 export const defaultFormatOptions: Required<FormatOptions> = {
   indentWidth: 2,
-  indentStyle: "spaces",
+  indentStyle: "space",
   maxLineLength: 80,
   preRewriters: [],
   postRewriters: [],

--- a/javascript/packages/formatter/src/options.ts
+++ b/javascript/packages/formatter/src/options.ts
@@ -1,9 +1,11 @@
 import type { ASTRewriter, StringRewriter } from "@herb-tools/rewriter"
+import type { IndentType } from "@herb-tools/printer"
 
 /**
  * Formatting options for the Herb formatter.
  *
  * indentWidth: number of spaces per indentation level.
+ * indentType: character used for indentation, "spaces" or "tabs".
  * maxLineLength: maximum line length before wrapping text or attributes.
  * preRewriters: AST rewriters to run before formatting.
  * postRewriters: String rewriters to run after formatting.
@@ -11,6 +13,8 @@ import type { ASTRewriter, StringRewriter } from "@herb-tools/rewriter"
 export interface FormatOptions {
   /** number of spaces per indentation level; defaults to 2 */
   indentWidth?: number
+  /** character used for indentation; defaults to "spaces" */
+  indentType?: IndentType
   /** maximum line length before wrapping; defaults to 80 */
   maxLineLength?: number
   /** Pre-format rewriters (transform AST before formatting); defaults to [] */
@@ -24,6 +28,7 @@ export interface FormatOptions {
  */
 export const defaultFormatOptions: Required<FormatOptions> = {
   indentWidth: 2,
+  indentType: "spaces",
   maxLineLength: 80,
   preRewriters: [],
   postRewriters: [],
@@ -39,6 +44,7 @@ export function resolveFormatOptions(
 ): Required<FormatOptions> {
   return {
     indentWidth: options.indentWidth ?? defaultFormatOptions.indentWidth,
+    indentType: options.indentType ?? defaultFormatOptions.indentType,
     maxLineLength: options.maxLineLength ?? defaultFormatOptions.maxLineLength,
     preRewriters: options.preRewriters ?? defaultFormatOptions.preRewriters,
     postRewriters: options.postRewriters ?? defaultFormatOptions.postRewriters,

--- a/javascript/packages/formatter/src/options.ts
+++ b/javascript/packages/formatter/src/options.ts
@@ -1,11 +1,11 @@
 import type { ASTRewriter, StringRewriter } from "@herb-tools/rewriter"
-import type { IndentType } from "@herb-tools/printer"
+import type { IndentStyle } from "@herb-tools/printer"
 
 /**
  * Formatting options for the Herb formatter.
  *
  * indentWidth: number of spaces per indentation level.
- * indentType: character used for indentation, "spaces" or "tabs".
+ * indentStyle: character used for indentation, "spaces" or "tabs".
  * maxLineLength: maximum line length before wrapping text or attributes.
  * preRewriters: AST rewriters to run before formatting.
  * postRewriters: String rewriters to run after formatting.
@@ -14,7 +14,7 @@ export interface FormatOptions {
   /** number of spaces per indentation level; defaults to 2 */
   indentWidth?: number
   /** character used for indentation; defaults to "spaces" */
-  indentType?: IndentType
+  indentStyle?: IndentStyle
   /** maximum line length before wrapping; defaults to 80 */
   maxLineLength?: number
   /** Pre-format rewriters (transform AST before formatting); defaults to [] */
@@ -28,7 +28,7 @@ export interface FormatOptions {
  */
 export const defaultFormatOptions: Required<FormatOptions> = {
   indentWidth: 2,
-  indentType: "spaces",
+  indentStyle: "spaces",
   maxLineLength: 80,
   preRewriters: [],
   postRewriters: [],
@@ -44,7 +44,7 @@ export function resolveFormatOptions(
 ): Required<FormatOptions> {
   return {
     indentWidth: options.indentWidth ?? defaultFormatOptions.indentWidth,
-    indentType: options.indentType ?? defaultFormatOptions.indentType,
+    indentStyle: options.indentStyle ?? defaultFormatOptions.indentStyle,
     maxLineLength: options.maxLineLength ?? defaultFormatOptions.maxLineLength,
     preRewriters: options.preRewriters ?? defaultFormatOptions.preRewriters,
     postRewriters: options.postRewriters ?? defaultFormatOptions.postRewriters,

--- a/javascript/packages/formatter/test/cli.test.ts
+++ b/javascript/packages/formatter/test/cli.test.ts
@@ -427,27 +427,27 @@ describe("CLI Binary", () => {
     expect(result.stdout).toContain("    <p>Test</p>") // 4 spaces instead of 2
   })
 
-  it("should show --indent-type option in help", async () => {
+  it("should show --indent-style option in help", async () => {
     const result = await execBinary(["--help"])
 
     expectExitCode(result, 0)
-    expect(result.stdout).toContain("herb-format --indent-type")
+    expect(result.stdout).toContain("herb-format --indent-style")
     expect(result.stdout).toContain("character used for indentation")
   })
 
-  it("should accept valid --indent-type", async () => {
+  it("should accept valid --indent-style", async () => {
     const input = '<div>\n<p>Test</p>\n</div>'
-    const result = await execBinary(["--indent-type", "tabs"], input)
+    const result = await execBinary(["--indent-style", "tabs"], input)
 
     expectExitCode(result, 0)
     expect(result.stdout).toContain("\t<p>Test</p>")
   })
 
-  it("should reject invalid --indent-type", async () => {
-    const result = await execBinary(["--indent-type", "nope"], '<div></div>')
+  it("should reject invalid --indent-style", async () => {
+    const result = await execBinary(["--indent-style", "nope"], '<div></div>')
 
     expectExitCode(result, 1)
-    expect(result.stderr).toContain("Invalid indent-type")
+    expect(result.stderr).toContain("Invalid indent-style")
   })
 
   it("should show --max-line-length option in help", async () => {

--- a/javascript/packages/formatter/test/cli.test.ts
+++ b/javascript/packages/formatter/test/cli.test.ts
@@ -427,6 +427,29 @@ describe("CLI Binary", () => {
     expect(result.stdout).toContain("    <p>Test</p>") // 4 spaces instead of 2
   })
 
+  it("should show --indent-type option in help", async () => {
+    const result = await execBinary(["--help"])
+
+    expectExitCode(result, 0)
+    expect(result.stdout).toContain("herb-format --indent-type")
+    expect(result.stdout).toContain("character used for indentation")
+  })
+
+  it("should accept valid --indent-type", async () => {
+    const input = '<div>\n<p>Test</p>\n</div>'
+    const result = await execBinary(["--indent-type", "tabs"], input)
+
+    expectExitCode(result, 0)
+    expect(result.stdout).toContain("\t<p>Test</p>")
+  })
+
+  it("should reject invalid --indent-type", async () => {
+    const result = await execBinary(["--indent-type", "nope"], '<div></div>')
+
+    expectExitCode(result, 1)
+    expect(result.stderr).toContain("Invalid indent-type")
+  })
+
   it("should show --max-line-length option in help", async () => {
     const result = await execBinary(["--help"])
 

--- a/javascript/packages/formatter/test/cli.test.ts
+++ b/javascript/packages/formatter/test/cli.test.ts
@@ -437,7 +437,7 @@ describe("CLI Binary", () => {
 
   it("should accept valid --indent-style", async () => {
     const input = '<div>\n<p>Test</p>\n</div>'
-    const result = await execBinary(["--indent-style", "tabs"], input)
+    const result = await execBinary(["--indent-style", "tab"], input)
 
     expectExitCode(result, 0)
     expect(result.stdout).toContain("\t<p>Test</p>")

--- a/javascript/packages/formatter/test/options.test.ts
+++ b/javascript/packages/formatter/test/options.test.ts
@@ -63,7 +63,7 @@ describe("@herb-tools/formatter", () => {
         <span>World</span>
       </div>
     `
-    const result = formatter.format(source, { indentStyle: "tabs" })
+    const result = formatter.format(source, { indentStyle: "tab" })
 
     expect(result).toEqual("<div>\n\t<p>Hello</p>\n\t<span>World</span>\n</div>")
   })
@@ -76,7 +76,7 @@ describe("@herb-tools/formatter", () => {
         </section>
       </div>
     `
-    const result = formatter.format(source, { indentStyle: "tabs", indentWidth: 4 })
+    const result = formatter.format(source, { indentStyle: "tab", indentWidth: 4 })
 
     expect(result).toEqual("<div>\n\t<section>\n\t\t<p>Hello</p>\n\t</section>\n</div>")
   })

--- a/javascript/packages/formatter/test/options.test.ts
+++ b/javascript/packages/formatter/test/options.test.ts
@@ -55,4 +55,29 @@ describe("@herb-tools/formatter", () => {
       </p>
     `)
   })
+
+  test("respects indentType option", () => {
+    const source = dedent`
+      <div>
+        <p>Hello</p>
+        <span>World</span>
+      </div>
+    `
+    const result = formatter.format(source, { indentType: "tabs" })
+
+    expect(result).toEqual("<div>\n\t<p>Hello</p>\n\t<span>World</span>\n</div>")
+  })
+
+  test("indentType tabs respects a custom indentWidth for level width", () => {
+    const source = dedent`
+      <div>
+        <section>
+          <p>Hello</p>
+        </section>
+      </div>
+    `
+    const result = formatter.format(source, { indentType: "tabs", indentWidth: 4 })
+
+    expect(result).toEqual("<div>\n\t<section>\n\t\t<p>Hello</p>\n\t</section>\n</div>")
+  })
 })

--- a/javascript/packages/formatter/test/options.test.ts
+++ b/javascript/packages/formatter/test/options.test.ts
@@ -56,19 +56,19 @@ describe("@herb-tools/formatter", () => {
     `)
   })
 
-  test("respects indentType option", () => {
+  test("respects indentStyle option", () => {
     const source = dedent`
       <div>
         <p>Hello</p>
         <span>World</span>
       </div>
     `
-    const result = formatter.format(source, { indentType: "tabs" })
+    const result = formatter.format(source, { indentStyle: "tabs" })
 
     expect(result).toEqual("<div>\n\t<p>Hello</p>\n\t<span>World</span>\n</div>")
   })
 
-  test("indentType tabs respects a custom indentWidth for level width", () => {
+  test("indentStyle tabs respects a custom indentWidth for level width", () => {
     const source = dedent`
       <div>
         <section>
@@ -76,7 +76,7 @@ describe("@herb-tools/formatter", () => {
         </section>
       </div>
     `
-    const result = formatter.format(source, { indentType: "tabs", indentWidth: 4 })
+    const result = formatter.format(source, { indentStyle: "tabs", indentWidth: 4 })
 
     expect(result).toEqual("<div>\n\t<section>\n\t\t<p>Hello</p>\n\t</section>\n</div>")
   })

--- a/javascript/packages/language-server/README.md
+++ b/javascript/packages/language-server/README.md
@@ -131,7 +131,7 @@ linter:
 formatter:
   enabled: true
   indentWidth: 2
-  indentStyle: spaces
+  indentStyle: space
   maxLineLength: 80
 ```
 

--- a/javascript/packages/language-server/README.md
+++ b/javascript/packages/language-server/README.md
@@ -124,15 +124,14 @@ See the [Configuration documentation](https://herb-tools.dev/configuration) for 
 
 ### Example Configuration
 
-```yaml
-# .herb.yml
+```yaml [.herb.yml]
 linter:
   enabled: true
 
 formatter:
   enabled: true
   indentWidth: 2
-  indentType: spaces  # "spaces" or "tabs"
+  indentStyle: spaces
   maxLineLength: 80
 ```
 

--- a/javascript/packages/language-server/README.md
+++ b/javascript/packages/language-server/README.md
@@ -132,6 +132,7 @@ linter:
 formatter:
   enabled: true
   indentWidth: 2
+  indentType: spaces  # "spaces" or "tabs"
   maxLineLength: 80
 ```
 

--- a/javascript/packages/language-server/src/formatting_service.ts
+++ b/javascript/packages/language-server/src/formatting_service.ts
@@ -231,7 +231,7 @@ export class FormattingService {
       formatter: {
         ...projectFormatter,
         indentWidth: settings?.formatter?.indentWidth ?? projectFormatter.indentWidth,
-        indentType: settings?.formatter?.indentType ?? projectFormatter.indentType,
+        indentStyle: settings?.formatter?.indentStyle ?? projectFormatter.indentStyle,
         maxLineLength: settings?.formatter?.maxLineLength ?? projectFormatter.maxLineLength
       }
     } as Config
@@ -339,13 +339,13 @@ export class FormattingService {
 
       let minIndentLevel = Infinity
       const indentWidth = config?.formatter?.indentWidth ?? defaultFormatOptions.indentWidth
-      const indentType = config?.formatter?.indentType ?? defaultFormatOptions.indentType
+      const indentStyle = config?.formatter?.indentStyle ?? defaultFormatOptions.indentStyle
 
       const indentLevelOf = (indent: string): number =>
-        indentType === 'tabs' ? indent.replace(/ /g, '').length : Math.floor(indent.length / indentWidth)
+        indentStyle === 'tabs' ? indent.replace(/ /g, '').length : Math.floor(indent.length / indentWidth)
 
       const indentStringFor = (level: number): string =>
-        indentType === 'tabs' ? '\t'.repeat(level) : ' '.repeat(level * indentWidth)
+        indentStyle === 'tabs' ? '\t'.repeat(level) : ' '.repeat(level * indentWidth)
 
       for (const line of lines) {
         const trimmedLine = line.trim()

--- a/javascript/packages/language-server/src/formatting_service.ts
+++ b/javascript/packages/language-server/src/formatting_service.ts
@@ -342,10 +342,10 @@ export class FormattingService {
       const indentStyle = config?.formatter?.indentStyle ?? defaultFormatOptions.indentStyle
 
       const indentLevelOf = (indent: string): number =>
-        indentStyle === 'tabs' ? indent.replace(/ /g, '').length : Math.floor(indent.length / indentWidth)
+        indentStyle === 'tab' ? indent.replace(/ /g, '').length : Math.floor(indent.length / indentWidth)
 
       const indentStringFor = (level: number): string =>
-        indentStyle === 'tabs' ? '\t'.repeat(level) : ' '.repeat(level * indentWidth)
+        indentStyle === 'tab' ? '\t'.repeat(level) : ' '.repeat(level * indentWidth)
 
       for (const line of lines) {
         const trimmedLine = line.trim()

--- a/javascript/packages/language-server/src/formatting_service.ts
+++ b/javascript/packages/language-server/src/formatting_service.ts
@@ -231,6 +231,7 @@ export class FormattingService {
       formatter: {
         ...projectFormatter,
         indentWidth: settings?.formatter?.indentWidth ?? projectFormatter.indentWidth,
+        indentType: settings?.formatter?.indentType ?? projectFormatter.indentType,
         maxLineLength: settings?.formatter?.maxLineLength ?? projectFormatter.maxLineLength
       }
     } as Config
@@ -338,13 +339,20 @@ export class FormattingService {
 
       let minIndentLevel = Infinity
       const indentWidth = config?.formatter?.indentWidth ?? defaultFormatOptions.indentWidth
+      const indentType = config?.formatter?.indentType ?? defaultFormatOptions.indentType
+
+      const indentLevelOf = (indent: string): number =>
+        indentType === 'tabs' ? indent.replace(/ /g, '').length : Math.floor(indent.length / indentWidth)
+
+      const indentStringFor = (level: number): string =>
+        indentType === 'tabs' ? '\t'.repeat(level) : ' '.repeat(level * indentWidth)
 
       for (const line of lines) {
         const trimmedLine = line.trim()
 
         if (trimmedLine !== '') {
           const indent = line.match(/^\s*/)?.[0] || ''
-          const indentLevel = Math.floor(indent.length / indentWidth)
+          const indentLevel = indentLevelOf(indent)
 
           minIndentLevel = Math.min(minIndentLevel, indentLevel)
         }
@@ -357,7 +365,7 @@ export class FormattingService {
       let textToFormat = rangeText
 
       if (minIndentLevel > 0) {
-        const minIndentString = ' '.repeat(minIndentLevel * indentWidth)
+        const minIndentString = indentStringFor(minIndentLevel)
 
         textToFormat = lines.map(line => {
           if (line.trim() === '') {
@@ -372,7 +380,7 @@ export class FormattingService {
 
       if (minIndentLevel > 0) {
         const formattedLines = formattedText.split('\n')
-        const indentString = ' '.repeat(minIndentLevel * indentWidth)
+        const indentString = indentStringFor(minIndentLevel)
 
         formattedText = formattedLines.map((line: string, _index: number) => {
           if (line.trim() === '') {

--- a/javascript/packages/language-server/src/settings.ts
+++ b/javascript/packages/language-server/src/settings.ts
@@ -19,7 +19,7 @@ export interface PersonalHerbSettings {
   formatter?: {
     enabled?: boolean
     indentWidth?: number
-    indentStyle?: "spaces" | "tabs"
+    indentStyle?: "space" | "tab"
     maxLineLength?: number
   }
 }

--- a/javascript/packages/language-server/src/settings.ts
+++ b/javascript/packages/language-server/src/settings.ts
@@ -19,6 +19,7 @@ export interface PersonalHerbSettings {
   formatter?: {
     enabled?: boolean
     indentWidth?: number
+    indentType?: "spaces" | "tabs"
     maxLineLength?: number
   }
 }
@@ -38,6 +39,7 @@ export class Settings {
     formatter: {
       enabled: false,
       indentWidth: defaultFormatOptions.indentWidth,
+      indentType: defaultFormatOptions.indentType,
       maxLineLength: defaultFormatOptions.maxLineLength
     }
   }
@@ -108,6 +110,7 @@ export class Settings {
         formatter: {
           enabled: settings.formatter?.enabled ?? this.defaultSettings.formatter!.enabled!,
           indentWidth: settings.formatter?.indentWidth ?? this.defaultSettings.formatter!.indentWidth!,
+          indentType: settings.formatter?.indentType ?? this.defaultSettings.formatter!.indentType!,
           maxLineLength: settings.formatter?.maxLineLength ?? this.defaultSettings.formatter!.maxLineLength!
         }
       }
@@ -122,6 +125,7 @@ export class Settings {
       formatter: {
         enabled: projectConfig.isFormatterEnabled,
         indentWidth: projectConfig.formatter?.indentWidth ?? this.defaultSettings.formatter!.indentWidth!,
+        indentType: projectConfig.formatter?.indentType ?? this.defaultSettings.formatter!.indentType!,
         maxLineLength: projectConfig.formatter?.maxLineLength ?? this.defaultSettings.formatter!.maxLineLength!
       }
     }

--- a/javascript/packages/language-server/src/settings.ts
+++ b/javascript/packages/language-server/src/settings.ts
@@ -19,7 +19,7 @@ export interface PersonalHerbSettings {
   formatter?: {
     enabled?: boolean
     indentWidth?: number
-    indentType?: "spaces" | "tabs"
+    indentStyle?: "spaces" | "tabs"
     maxLineLength?: number
   }
 }
@@ -39,7 +39,7 @@ export class Settings {
     formatter: {
       enabled: false,
       indentWidth: defaultFormatOptions.indentWidth,
-      indentType: defaultFormatOptions.indentType,
+      indentStyle: defaultFormatOptions.indentStyle,
       maxLineLength: defaultFormatOptions.maxLineLength
     }
   }
@@ -110,7 +110,7 @@ export class Settings {
         formatter: {
           enabled: settings.formatter?.enabled ?? this.defaultSettings.formatter!.enabled!,
           indentWidth: settings.formatter?.indentWidth ?? this.defaultSettings.formatter!.indentWidth!,
-          indentType: settings.formatter?.indentType ?? this.defaultSettings.formatter!.indentType!,
+          indentStyle: settings.formatter?.indentStyle ?? this.defaultSettings.formatter!.indentStyle!,
           maxLineLength: settings.formatter?.maxLineLength ?? this.defaultSettings.formatter!.maxLineLength!
         }
       }
@@ -125,7 +125,7 @@ export class Settings {
       formatter: {
         enabled: projectConfig.isFormatterEnabled,
         indentWidth: projectConfig.formatter?.indentWidth ?? this.defaultSettings.formatter!.indentWidth!,
-        indentType: projectConfig.formatter?.indentType ?? this.defaultSettings.formatter!.indentType!,
+        indentStyle: projectConfig.formatter?.indentStyle ?? this.defaultSettings.formatter!.indentStyle!,
         maxLineLength: projectConfig.formatter?.maxLineLength ?? this.defaultSettings.formatter!.maxLineLength!
       }
     }

--- a/javascript/packages/language-server/test/settings.test.ts
+++ b/javascript/packages/language-server/test/settings.test.ts
@@ -135,7 +135,7 @@ describe("Settings", () => {
         formatter: {
           enabled: true,
           indentWidth: 2,
-          indentStyle: "spaces",
+          indentStyle: "space",
           maxLineLength: 80
         }
       })
@@ -166,7 +166,7 @@ describe("Settings", () => {
         formatter: {
           enabled: false,
           indentWidth: 2,
-          indentStyle: "spaces",
+          indentStyle: "space",
           maxLineLength: 80
         }
       })

--- a/javascript/packages/language-server/test/settings.test.ts
+++ b/javascript/packages/language-server/test/settings.test.ts
@@ -38,7 +38,7 @@ describe("Settings", () => {
       expect(settings.defaultSettings.formatter).toBeDefined()
       expect(settings.defaultSettings.formatter?.enabled).toBe(false)
       expect(settings.defaultSettings.formatter?.indentWidth).toBeDefined()
-      expect(settings.defaultSettings.formatter?.indentType).toBeDefined()
+      expect(settings.defaultSettings.formatter?.indentStyle).toBeDefined()
       expect(settings.defaultSettings.formatter?.maxLineLength).toBeDefined()
     })
   })
@@ -135,7 +135,7 @@ describe("Settings", () => {
         formatter: {
           enabled: true,
           indentWidth: 2,
-          indentType: "spaces",
+          indentStyle: "spaces",
           maxLineLength: 80
         }
       })
@@ -166,7 +166,7 @@ describe("Settings", () => {
         formatter: {
           enabled: false,
           indentWidth: 2,
-          indentType: "spaces",
+          indentStyle: "spaces",
           maxLineLength: 80
         }
       })

--- a/javascript/packages/language-server/test/settings.test.ts
+++ b/javascript/packages/language-server/test/settings.test.ts
@@ -38,6 +38,7 @@ describe("Settings", () => {
       expect(settings.defaultSettings.formatter).toBeDefined()
       expect(settings.defaultSettings.formatter?.enabled).toBe(false)
       expect(settings.defaultSettings.formatter?.indentWidth).toBeDefined()
+      expect(settings.defaultSettings.formatter?.indentType).toBeDefined()
       expect(settings.defaultSettings.formatter?.maxLineLength).toBeDefined()
     })
   })
@@ -134,6 +135,7 @@ describe("Settings", () => {
         formatter: {
           enabled: true,
           indentWidth: 2,
+          indentType: "spaces",
           maxLineLength: 80
         }
       })
@@ -164,6 +166,7 @@ describe("Settings", () => {
         formatter: {
           enabled: false,
           indentWidth: 2,
+          indentType: "spaces",
           maxLineLength: 80
         }
       })

--- a/javascript/packages/linter/docs/rules/source-indentation.md
+++ b/javascript/packages/linter/docs/rules/source-indentation.md
@@ -8,7 +8,7 @@ Detects indentation that doesn't match the configured indentation style. By defa
 
 ## Configuration
 
-Set `formatter.indentType` in your Herb config to `"spaces"` (default) or `"tabs"` to control which character this rule expects and which one `--fix` writes:
+Set `formatter.indentType` in your Herb config to `"spaces"` (default) or `"tabs"` to control which character this rule expects and which one `--fix` writes. The same option also controls the indentation the [formatter](/projects/formatter) writes.
 
 ```yaml
 formatter:

--- a/javascript/packages/linter/docs/rules/source-indentation.md
+++ b/javascript/packages/linter/docs/rules/source-indentation.md
@@ -8,11 +8,11 @@ Detects indentation that doesn't match the configured indentation style. By defa
 
 ## Configuration
 
-Set `formatter.indentType` in your Herb config to `"spaces"` (default) or `"tabs"` to control which character this rule expects and which one `--fix` writes. The same option also controls the indentation the [formatter](/projects/formatter) writes.
+Set `formatter.indentStyle` in your Herb config to `"spaces"` (default) or `"tabs"` to control which character this rule expects and which one `--fix` writes. The same option also controls the indentation the [formatter](/projects/formatter) writes.
 
 ```yaml
 formatter:
-  indentType: tabs
+  indentStyle: tabs
 ```
 
 ## Rationale
@@ -37,7 +37,7 @@ Mixing tabs and spaces for indentation causes inconsistent visual formatting acr
 </div>
 ```
 
-### ✅ Good (`indentType: tabs`)
+### ✅ Good (`indentStyle: tabs`)
 
 ```erb
 <div>
@@ -45,7 +45,7 @@ Mixing tabs and spaces for indentation causes inconsistent visual formatting acr
 </div>
 ```
 
-### 🚫 Bad (`indentType: tabs`)
+### 🚫 Bad (`indentStyle: tabs`)
 
 ```erb
 <div>

--- a/javascript/packages/linter/docs/rules/source-indentation.md
+++ b/javascript/packages/linter/docs/rules/source-indentation.md
@@ -8,11 +8,11 @@ Detects indentation that doesn't match the configured indentation style. By defa
 
 ## Configuration
 
-Set `formatter.indentStyle` in your Herb config to `"spaces"` (default) or `"tabs"` to control which character this rule expects and which one `--fix` writes. The same option also controls the indentation the [formatter](/projects/formatter) writes.
+Set `formatter.indentStyle` in your Herb config to `"space"` (default) or `"tab"` to control which character this rule expects and which one `--fix` writes. The same option also controls the indentation the [formatter](/projects/formatter) writes.
 
 ```yaml
 formatter:
-  indentStyle: tabs
+  indentStyle: tab
 ```
 
 ## Rationale
@@ -21,7 +21,7 @@ Mixing tabs and spaces for indentation causes inconsistent visual formatting acr
 
 ## Examples
 
-### ✅ Good (default: spaces)
+### ✅ Good (default: space)
 
 ```erb
 <div>
@@ -29,7 +29,7 @@ Mixing tabs and spaces for indentation causes inconsistent visual formatting acr
 </div>
 ```
 
-### 🚫 Bad (default: spaces)
+### 🚫 Bad (default: space)
 
 ```erb
 <div>
@@ -37,7 +37,7 @@ Mixing tabs and spaces for indentation causes inconsistent visual formatting acr
 </div>
 ```
 
-### ✅ Good (`indentStyle: tabs`)
+### ✅ Good (`indentStyle: tab`)
 
 ```erb
 <div>
@@ -45,7 +45,7 @@ Mixing tabs and spaces for indentation causes inconsistent visual formatting acr
 </div>
 ```
 
-### 🚫 Bad (`indentStyle: tabs`)
+### 🚫 Bad (`indentStyle: tab`)
 
 ```erb
 <div>

--- a/javascript/packages/linter/docs/rules/source-indentation.md
+++ b/javascript/packages/linter/docs/rules/source-indentation.md
@@ -4,15 +4,24 @@
 
 ## Description
 
-Detects indentation with tabs. Consistent use of spaces for indentation improves readability and avoids alignment issues across editors and tools.
+Detects indentation that doesn't match the configured indentation style. By default, spaces are expected and tabs are flagged. Consistent use of a single indentation character improves readability and avoids alignment issues across editors and tools.
+
+## Configuration
+
+Set `formatter.indentType` in your Herb config to `"spaces"` (default) or `"tabs"` to control which character this rule expects and which one `--fix` writes:
+
+```yaml
+formatter:
+  indentType: tabs
+```
 
 ## Rationale
 
-Mixing tabs and spaces for indentation causes inconsistent visual formatting across different editors, tools, and environments. Tabs render at different widths depending on the viewer's settings, which can make code appear misaligned or harder to read. Standardizing on space indentation ensures that code appears the same regardless of editor or tool, diffs and code reviews display consistently, and the codebase maintains a uniform visual style.
+Mixing tabs and spaces for indentation causes inconsistent visual formatting across different editors, tools, and environments. Tabs render at different widths depending on the viewer's settings, which can make code appear misaligned or harder to read. Standardizing on a single indentation character ensures that code appears the same regardless of editor or tool, diffs and code reviews display consistently, and the codebase maintains a uniform visual style.
 
 ## Examples
 
-### ✅ Good
+### ✅ Good (default: spaces)
 
 ```erb
 <div>
@@ -20,11 +29,27 @@ Mixing tabs and spaces for indentation causes inconsistent visual formatting acr
 </div>
 ```
 
-### 🚫 Bad
+### 🚫 Bad (default: spaces)
 
 ```erb
 <div>
 	<p>Hello</p>
+</div>
+```
+
+### ✅ Good (`indentType: tabs`)
+
+```erb
+<div>
+	<p>Hello</p>
+</div>
+```
+
+### 🚫 Bad (`indentType: tabs`)
+
+```erb
+<div>
+  <p>Hello</p>
 </div>
 ```
 

--- a/javascript/packages/linter/src/linter.ts
+++ b/javascript/packages/linter/src/linter.ts
@@ -485,7 +485,7 @@ export class Linter {
       validRuleNames: this.getAvailableRules().map(ruleClass => ruleClass.ruleName),
       ignoredOffensesByLine,
       indentWidth: context?.indentWidth ?? this.config?.formatter?.indentWidth,
-      indentType: context?.indentType ?? this.config?.formatter?.indentType,
+      indentStyle: context?.indentStyle ?? this.config?.formatter?.indentStyle,
       framework: context?.framework ?? this.config?.framework
     }
 
@@ -604,7 +604,7 @@ export class Linter {
     context = {
       ...context,
       indentWidth: context?.indentWidth ?? this.config?.formatter?.indentWidth,
-      indentType: context?.indentType ?? this.config?.formatter?.indentType,
+      indentStyle: context?.indentStyle ?? this.config?.formatter?.indentStyle,
       framework: context?.framework ?? this.config?.framework
     }
 

--- a/javascript/packages/linter/src/linter.ts
+++ b/javascript/packages/linter/src/linter.ts
@@ -485,6 +485,7 @@ export class Linter {
       validRuleNames: this.getAvailableRules().map(ruleClass => ruleClass.ruleName),
       ignoredOffensesByLine,
       indentWidth: context?.indentWidth ?? this.config?.formatter?.indentWidth,
+      indentType: context?.indentType ?? this.config?.formatter?.indentType,
       framework: context?.framework ?? this.config?.framework
     }
 
@@ -603,6 +604,7 @@ export class Linter {
     context = {
       ...context,
       indentWidth: context?.indentWidth ?? this.config?.formatter?.indentWidth,
+      indentType: context?.indentType ?? this.config?.formatter?.indentType,
       framework: context?.framework ?? this.config?.framework
     }
 

--- a/javascript/packages/linter/src/rules/source-indentation.ts
+++ b/javascript/packages/linter/src/rules/source-indentation.ts
@@ -2,11 +2,9 @@ import { Location } from "@herb-tools/core"
 
 import { BaseSourceRuleVisitor } from "./rule-utils.js"
 import { positionFromOffset } from "@herb-tools/core"
-import { convertIndentation } from "@herb-tools/printer"
+import { convertIndentation, LEADING_BLANKS } from "@herb-tools/printer"
 import { SourceRule } from "../types.js"
 import type { UnboundLintOffense, LintOffense, LintContext, FullRuleConfig } from "../types.js"
-
-const LEADING_BLANKS = /^[^\S\n]*/
 
 class SourceIndentationVisitor extends BaseSourceRuleVisitor {
   protected visitSource(source: string): void {

--- a/javascript/packages/linter/src/rules/source-indentation.ts
+++ b/javascript/packages/linter/src/rules/source-indentation.ts
@@ -2,6 +2,7 @@ import { Location } from "@herb-tools/core"
 
 import { BaseSourceRuleVisitor } from "./rule-utils.js"
 import { positionFromOffset } from "@herb-tools/core"
+import { convertIndentation } from "@herb-tools/printer"
 import { SourceRule } from "../types.js"
 import type { UnboundLintOffense, LintOffense, LintContext, FullRuleConfig } from "../types.js"
 
@@ -56,25 +57,7 @@ export class SourceIndentationRule extends SourceRule {
   autofix(_offense: LintOffense, source: string, context?: Partial<LintContext>): string | null {
     const indentWidth = context?.indentWidth ?? 2
     const indentType = context?.indentType ?? "spaces"
-    const lines = source.split("\n")
 
-    const result = lines.map((line) => {
-      const match = line.match(LEADING_BLANKS)
-
-      if (match && match[0].length > 0) {
-        const leading = match[0]
-        const normalized = leading.replace(/\t/g, " ".repeat(indentWidth))
-
-        const replaced = indentType === "tabs"
-          ? "\t".repeat(Math.floor(normalized.length / indentWidth)) + " ".repeat(normalized.length % indentWidth)
-          : normalized
-
-        return replaced + line.substring(leading.length)
-      }
-
-      return line
-    })
-
-    return result.join("\n")
+    return convertIndentation(source, indentWidth, indentType)
   }
 }

--- a/javascript/packages/linter/src/rules/source-indentation.ts
+++ b/javascript/packages/linter/src/rules/source-indentation.ts
@@ -5,25 +5,27 @@ import { positionFromOffset } from "@herb-tools/core"
 import { SourceRule } from "../types.js"
 import type { UnboundLintOffense, LintOffense, LintContext, FullRuleConfig } from "../types.js"
 
-const START_BLANKS = /^[^\S\n]*\t[^\S\n]*/
+const LEADING_BLANKS = /^[^\S\n]*/
 
 class SourceIndentationVisitor extends BaseSourceRuleVisitor {
   protected visitSource(source: string): void {
+    const indentType = this.context.indentType ?? "spaces"
+    const disallowedChar = indentType === "tabs" ? " " : "\t"
+    const message = indentType === "tabs" ? "Indent with tabs instead of spaces." : "Indent with spaces instead of tabs."
+
     const lines = source.split("\n")
     let offset = 0
 
     lines.forEach((line) => {
-      const match = line.match(START_BLANKS)
+      const match = line.match(LEADING_BLANKS)
+      const leading = match ? match[0] : ""
 
-      if (match) {
+      if (leading.includes(disallowedChar)) {
         const start = positionFromOffset(source, offset)
-        const end = positionFromOffset(source, offset + match[0].length)
+        const end = positionFromOffset(source, offset + leading.length)
         const location = new Location(start, end)
 
-        this.addOffense(
-          "Indent with spaces instead of tabs.",
-          location,
-        )
+        this.addOffense(message, location)
       }
 
       offset += line.length + 1
@@ -53,13 +55,21 @@ export class SourceIndentationRule extends SourceRule {
 
   autofix(_offense: LintOffense, source: string, context?: Partial<LintContext>): string | null {
     const indentWidth = context?.indentWidth ?? 2
+    const indentType = context?.indentType ?? "spaces"
     const lines = source.split("\n")
-    const result = lines.map((line) => {
-      const match = line.match(START_BLANKS)
 
-      if (match) {
-        const replaced = match[0].replace(/\t/g, " ".repeat(indentWidth))
-        return replaced + line.substring(match[0].length)
+    const result = lines.map((line) => {
+      const match = line.match(LEADING_BLANKS)
+
+      if (match && match[0].length > 0) {
+        const leading = match[0]
+        const normalized = leading.replace(/\t/g, " ".repeat(indentWidth))
+
+        const replaced = indentType === "tabs"
+          ? "\t".repeat(Math.floor(normalized.length / indentWidth)) + " ".repeat(normalized.length % indentWidth)
+          : normalized
+
+        return replaced + line.substring(leading.length)
       }
 
       return line

--- a/javascript/packages/linter/src/rules/source-indentation.ts
+++ b/javascript/packages/linter/src/rules/source-indentation.ts
@@ -8,9 +8,9 @@ import type { UnboundLintOffense, LintOffense, LintContext, FullRuleConfig } fro
 
 class SourceIndentationVisitor extends BaseSourceRuleVisitor {
   protected visitSource(source: string): void {
-    const indentStyle = this.context.indentStyle ?? "spaces"
-    const disallowedChar = indentStyle === "tabs" ? " " : "\t"
-    const message = indentStyle === "tabs" ? "Indent with tabs instead of spaces." : "Indent with spaces instead of tabs."
+    const indentStyle = this.context.indentStyle ?? "space"
+    const disallowedChar = indentStyle === "tab" ? " " : "\t"
+    const message = indentStyle === "tab" ? "Indent with tabs instead of spaces." : "Indent with spaces instead of tabs."
 
     const lines = source.split("\n")
     let offset = 0
@@ -54,7 +54,7 @@ export class SourceIndentationRule extends SourceRule {
 
   autofix(_offense: LintOffense, source: string, context?: Partial<LintContext>): string | null {
     const indentWidth = context?.indentWidth ?? 2
-    const indentStyle = context?.indentStyle ?? "spaces"
+    const indentStyle = context?.indentStyle ?? "space"
 
     return convertIndentation(source, indentWidth, indentStyle)
   }

--- a/javascript/packages/linter/src/rules/source-indentation.ts
+++ b/javascript/packages/linter/src/rules/source-indentation.ts
@@ -8,9 +8,9 @@ import type { UnboundLintOffense, LintOffense, LintContext, FullRuleConfig } fro
 
 class SourceIndentationVisitor extends BaseSourceRuleVisitor {
   protected visitSource(source: string): void {
-    const indentType = this.context.indentType ?? "spaces"
-    const disallowedChar = indentType === "tabs" ? " " : "\t"
-    const message = indentType === "tabs" ? "Indent with tabs instead of spaces." : "Indent with spaces instead of tabs."
+    const indentStyle = this.context.indentStyle ?? "spaces"
+    const disallowedChar = indentStyle === "tabs" ? " " : "\t"
+    const message = indentStyle === "tabs" ? "Indent with tabs instead of spaces." : "Indent with spaces instead of tabs."
 
     const lines = source.split("\n")
     let offset = 0
@@ -54,8 +54,8 @@ export class SourceIndentationRule extends SourceRule {
 
   autofix(_offense: LintOffense, source: string, context?: Partial<LintContext>): string | null {
     const indentWidth = context?.indentWidth ?? 2
-    const indentType = context?.indentType ?? "spaces"
+    const indentStyle = context?.indentStyle ?? "spaces"
 
-    return convertIndentation(source, indentWidth, indentType)
+    return convertIndentation(source, indentWidth, indentStyle)
   }
 }

--- a/javascript/packages/linter/src/types.ts
+++ b/javascript/packages/linter/src/types.ts
@@ -255,7 +255,7 @@ export interface LintContext {
   ignoredOffensesByLine: Map<number, Set<string>> | undefined
   ignoreDisableComments: boolean | undefined
   indentWidth: number | undefined
-  indentStyle: "spaces" | "tabs" | undefined
+  indentStyle: "space" | "tab" | undefined
   framework: Framework | undefined
   partials: PartialIndex | undefined
   partialCallers: PartialCallerIndex | undefined

--- a/javascript/packages/linter/src/types.ts
+++ b/javascript/packages/linter/src/types.ts
@@ -255,7 +255,7 @@ export interface LintContext {
   ignoredOffensesByLine: Map<number, Set<string>> | undefined
   ignoreDisableComments: boolean | undefined
   indentWidth: number | undefined
-  indentType: "spaces" | "tabs" | undefined
+  indentStyle: "spaces" | "tabs" | undefined
   framework: Framework | undefined
   partials: PartialIndex | undefined
   partialCallers: PartialCallerIndex | undefined
@@ -271,7 +271,7 @@ export const DEFAULT_LINT_CONTEXT: LintContext = {
   ignoredOffensesByLine: undefined,
   ignoreDisableComments: undefined,
   indentWidth: undefined,
-  indentType: undefined,
+  indentStyle: undefined,
   framework: undefined,
   partials: undefined,
   partialCallers: undefined,

--- a/javascript/packages/linter/src/types.ts
+++ b/javascript/packages/linter/src/types.ts
@@ -255,6 +255,7 @@ export interface LintContext {
   ignoredOffensesByLine: Map<number, Set<string>> | undefined
   ignoreDisableComments: boolean | undefined
   indentWidth: number | undefined
+  indentType: "spaces" | "tabs" | undefined
   framework: Framework | undefined
   partials: PartialIndex | undefined
   partialCallers: PartialCallerIndex | undefined
@@ -270,6 +271,7 @@ export const DEFAULT_LINT_CONTEXT: LintContext = {
   ignoredOffensesByLine: undefined,
   ignoreDisableComments: undefined,
   indentWidth: undefined,
+  indentType: undefined,
   framework: undefined,
   partials: undefined,
   partialCallers: undefined,

--- a/javascript/packages/linter/test/autofix/source-indentation.autofix.test.ts
+++ b/javascript/packages/linter/test/autofix/source-indentation.autofix.test.ts
@@ -132,7 +132,7 @@ describe("source-indentation autofix", () => {
     const expected = "\tthis is a line\n\t\tindented twice\n"
 
     const linter = new Linter(Herb, [SourceIndentationRule])
-    const result = linter.autofix(input, { indentStyle: "tabs" })
+    const result = linter.autofix(input, { indentStyle: "tab" })
 
     expect(result.source).toBe(expected)
     expect(result.fixed).toHaveLength(2)
@@ -143,7 +143,7 @@ describe("source-indentation autofix", () => {
     const input = "\tthis is a line\n\t\tanother line\n"
 
     const linter = new Linter(Herb, [SourceIndentationRule])
-    const result = linter.autofix(input, { indentStyle: "tabs" })
+    const result = linter.autofix(input, { indentStyle: "tab" })
 
     expect(result.source).toBe(input)
     expect(result.fixed).toHaveLength(0)
@@ -156,7 +156,7 @@ describe("source-indentation autofix", () => {
 
     const config = Config.fromObject({
       formatter: {
-        indentStyle: "tabs"
+        indentStyle: "tab"
       },
       linter: {
         rules: {

--- a/javascript/packages/linter/test/autofix/source-indentation.autofix.test.ts
+++ b/javascript/packages/linter/test/autofix/source-indentation.autofix.test.ts
@@ -127,36 +127,36 @@ describe("source-indentation autofix", () => {
     expect(result.unfixed).toHaveLength(0)
   })
 
-  test("replaces space indentation with tabs when indentType is tabs", () => {
+  test("replaces space indentation with tabs when indentStyle is tabs", () => {
     const input = "  this is a line\n    indented twice\n"
     const expected = "\tthis is a line\n\t\tindented twice\n"
 
     const linter = new Linter(Herb, [SourceIndentationRule])
-    const result = linter.autofix(input, { indentType: "tabs" })
+    const result = linter.autofix(input, { indentStyle: "tabs" })
 
     expect(result.source).toBe(expected)
     expect(result.fixed).toHaveLength(2)
     expect(result.unfixed).toHaveLength(0)
   })
 
-  test("ignores tab-only indentation when indentType is tabs", () => {
+  test("ignores tab-only indentation when indentStyle is tabs", () => {
     const input = "\tthis is a line\n\t\tanother line\n"
 
     const linter = new Linter(Herb, [SourceIndentationRule])
-    const result = linter.autofix(input, { indentType: "tabs" })
+    const result = linter.autofix(input, { indentStyle: "tabs" })
 
     expect(result.source).toBe(input)
     expect(result.fixed).toHaveLength(0)
     expect(result.unfixed).toHaveLength(0)
   })
 
-  test("defaults to indentType from formatter config", () => {
+  test("defaults to indentStyle from formatter config", () => {
     const input = "  this is a line\n"
     const expected = "\tthis is a line\n"
 
     const config = Config.fromObject({
       formatter: {
-        indentType: "tabs"
+        indentStyle: "tabs"
       },
       linter: {
         rules: {

--- a/javascript/packages/linter/test/autofix/source-indentation.autofix.test.ts
+++ b/javascript/packages/linter/test/autofix/source-indentation.autofix.test.ts
@@ -126,4 +126,50 @@ describe("source-indentation autofix", () => {
     expect(result.fixed).toHaveLength(2)
     expect(result.unfixed).toHaveLength(0)
   })
+
+  test("replaces space indentation with tabs when indentType is tabs", () => {
+    const input = "  this is a line\n    indented twice\n"
+    const expected = "\tthis is a line\n\t\tindented twice\n"
+
+    const linter = new Linter(Herb, [SourceIndentationRule])
+    const result = linter.autofix(input, { indentType: "tabs" })
+
+    expect(result.source).toBe(expected)
+    expect(result.fixed).toHaveLength(2)
+    expect(result.unfixed).toHaveLength(0)
+  })
+
+  test("ignores tab-only indentation when indentType is tabs", () => {
+    const input = "\tthis is a line\n\t\tanother line\n"
+
+    const linter = new Linter(Herb, [SourceIndentationRule])
+    const result = linter.autofix(input, { indentType: "tabs" })
+
+    expect(result.source).toBe(input)
+    expect(result.fixed).toHaveLength(0)
+    expect(result.unfixed).toHaveLength(0)
+  })
+
+  test("defaults to indentType from formatter config", () => {
+    const input = "  this is a line\n"
+    const expected = "\tthis is a line\n"
+
+    const config = Config.fromObject({
+      formatter: {
+        indentType: "tabs"
+      },
+      linter: {
+        rules: {
+          "source-indentation": { enabled: true }
+        }
+      }
+    })
+
+    const linter = Linter.from(Herb, config)
+    const result = linter.autofix(input)
+
+    expect(result.source).toBe(expected)
+    expect(result.fixed).toHaveLength(1)
+    expect(result.unfixed).toHaveLength(0)
+  })
 })

--- a/javascript/packages/linter/test/rules/source-indentation.test.ts
+++ b/javascript/packages/linter/test/rules/source-indentation.test.ts
@@ -43,4 +43,21 @@ describe("SourceIndentationRule", () => {
 
     assertOffenses("<div>\n\t<%= hello %>\n</div>\n")
   })
+
+  test("passes with tab indentation when indentType is tabs", () => {
+    expectNoOffenses("\t\tthis is a line\n\t\tanother line\n", { indentType: "tabs" })
+  })
+
+  test("fails with space indentation when indentType is tabs", () => {
+    expectError("Indent with tabs instead of spaces.", [1])
+    expectError("Indent with tabs instead of spaces.", [2])
+
+    assertOffenses("  this is a line\n  another line\n", { indentType: "tabs" })
+  })
+
+  test("fails with mixed indentation when indentType is tabs", () => {
+    expectError("Indent with tabs instead of spaces.", [1])
+
+    assertOffenses("\t  this is a line\n", { indentType: "tabs" })
+  })
 })

--- a/javascript/packages/linter/test/rules/source-indentation.test.ts
+++ b/javascript/packages/linter/test/rules/source-indentation.test.ts
@@ -44,20 +44,20 @@ describe("SourceIndentationRule", () => {
     assertOffenses("<div>\n\t<%= hello %>\n</div>\n")
   })
 
-  test("passes with tab indentation when indentType is tabs", () => {
-    expectNoOffenses("\t\tthis is a line\n\t\tanother line\n", { indentType: "tabs" })
+  test("passes with tab indentation when indentStyle is tabs", () => {
+    expectNoOffenses("\t\tthis is a line\n\t\tanother line\n", { indentStyle: "tabs" })
   })
 
-  test("fails with space indentation when indentType is tabs", () => {
+  test("fails with space indentation when indentStyle is tabs", () => {
     expectError("Indent with tabs instead of spaces.", [1])
     expectError("Indent with tabs instead of spaces.", [2])
 
-    assertOffenses("  this is a line\n  another line\n", { indentType: "tabs" })
+    assertOffenses("  this is a line\n  another line\n", { indentStyle: "tabs" })
   })
 
-  test("fails with mixed indentation when indentType is tabs", () => {
+  test("fails with mixed indentation when indentStyle is tabs", () => {
     expectError("Indent with tabs instead of spaces.", [1])
 
-    assertOffenses("\t  this is a line\n", { indentType: "tabs" })
+    assertOffenses("\t  this is a line\n", { indentStyle: "tabs" })
   })
 })

--- a/javascript/packages/linter/test/rules/source-indentation.test.ts
+++ b/javascript/packages/linter/test/rules/source-indentation.test.ts
@@ -45,19 +45,19 @@ describe("SourceIndentationRule", () => {
   })
 
   test("passes with tab indentation when indentStyle is tabs", () => {
-    expectNoOffenses("\t\tthis is a line\n\t\tanother line\n", { indentStyle: "tabs" })
+    expectNoOffenses("\t\tthis is a line\n\t\tanother line\n", { indentStyle: "tab" })
   })
 
   test("fails with space indentation when indentStyle is tabs", () => {
     expectError("Indent with tabs instead of spaces.", [1])
     expectError("Indent with tabs instead of spaces.", [2])
 
-    assertOffenses("  this is a line\n  another line\n", { indentStyle: "tabs" })
+    assertOffenses("  this is a line\n  another line\n", { indentStyle: "tab" })
   })
 
   test("fails with mixed indentation when indentStyle is tabs", () => {
     expectError("Indent with tabs instead of spaces.", [1])
 
-    assertOffenses("\t  this is a line\n", { indentStyle: "tabs" })
+    assertOffenses("\t  this is a line\n", { indentStyle: "tab" })
   })
 })

--- a/javascript/packages/printer/src/indentation.ts
+++ b/javascript/packages/printer/src/indentation.ts
@@ -1,6 +1,6 @@
 export type IndentType = "spaces" | "tabs"
 
-const LEADING_BLANKS = /^[^\S\n]*/
+export const LEADING_BLANKS = /^[^\S\n]*/
 
 /**
  * Convert the leading indentation of every line in `source` between spaces and tabs.

--- a/javascript/packages/printer/src/indentation.ts
+++ b/javascript/packages/printer/src/indentation.ts
@@ -1,4 +1,4 @@
-export type IndentStyle = "spaces" | "tabs"
+export type IndentStyle = "space" | "tab"
 
 export const LEADING_BLANKS = /^[^\S\n]*/
 
@@ -21,7 +21,7 @@ export function convertIndentation(source: string, indentWidth: number, indentSt
     const leading = match[0]
     const normalized = leading.replace(/\t/g, " ".repeat(indentWidth))
 
-    const replaced = indentStyle === "tabs"
+    const replaced = indentStyle === "tab"
       ? "\t".repeat(Math.floor(normalized.length / indentWidth)) + " ".repeat(normalized.length % indentWidth)
       : normalized
 

--- a/javascript/packages/printer/src/indentation.ts
+++ b/javascript/packages/printer/src/indentation.ts
@@ -1,0 +1,32 @@
+export type IndentType = "spaces" | "tabs"
+
+const LEADING_BLANKS = /^[^\S\n]*/
+
+/**
+ * Convert the leading indentation of every line in `source` between spaces and tabs.
+ *
+ * Only whole `indentWidth`-space groups are converted to tabs; any remainder
+ * (e.g. alignment padding that isn't a full indent level) is left as spaces.
+ * Existing tabs are expanded to `indentWidth` spaces before conversion, so
+ * mixed indentation is normalized regardless of the target `indentType`.
+ */
+export function convertIndentation(source: string, indentWidth: number, indentType: IndentType): string {
+  const lines = source.split("\n")
+
+  const result = lines.map((line) => {
+    const match = line.match(LEADING_BLANKS)
+
+    if (!match || match[0].length === 0) return line
+
+    const leading = match[0]
+    const normalized = leading.replace(/\t/g, " ".repeat(indentWidth))
+
+    const replaced = indentType === "tabs"
+      ? "\t".repeat(Math.floor(normalized.length / indentWidth)) + " ".repeat(normalized.length % indentWidth)
+      : normalized
+
+    return replaced + line.substring(leading.length)
+  })
+
+  return result.join("\n")
+}

--- a/javascript/packages/printer/src/indentation.ts
+++ b/javascript/packages/printer/src/indentation.ts
@@ -1,4 +1,4 @@
-export type IndentType = "spaces" | "tabs"
+export type IndentStyle = "spaces" | "tabs"
 
 export const LEADING_BLANKS = /^[^\S\n]*/
 
@@ -8,9 +8,9 @@ export const LEADING_BLANKS = /^[^\S\n]*/
  * Only whole `indentWidth`-space groups are converted to tabs; any remainder
  * (e.g. alignment padding that isn't a full indent level) is left as spaces.
  * Existing tabs are expanded to `indentWidth` spaces before conversion, so
- * mixed indentation is normalized regardless of the target `indentType`.
+ * mixed indentation is normalized regardless of the target `indentStyle`.
  */
-export function convertIndentation(source: string, indentWidth: number, indentType: IndentType): string {
+export function convertIndentation(source: string, indentWidth: number, indentStyle: IndentStyle): string {
   const lines = source.split("\n")
 
   const result = lines.map((line) => {
@@ -21,7 +21,7 @@ export function convertIndentation(source: string, indentWidth: number, indentTy
     const leading = match[0]
     const normalized = leading.replace(/\t/g, " ".repeat(indentWidth))
 
-    const replaced = indentType === "tabs"
+    const replaced = indentStyle === "tabs"
       ? "\t".repeat(Math.floor(normalized.length / indentWidth)) + " ".repeat(normalized.length % indentWidth)
       : normalized
 

--- a/javascript/packages/printer/src/index.ts
+++ b/javascript/packages/printer/src/index.ts
@@ -1,6 +1,6 @@
 export { IdentityPrinter } from "./identity-printer.js"
 export { convertIndentation, LEADING_BLANKS } from "./indentation.js"
-export type { IndentType } from "./indentation.js"
+export type { IndentStyle } from "./indentation.js"
 export { IndentPrinter } from "./indent-printer.js"
 export { ERBToRubyStringPrinter } from "./erb-to-ruby-string-printer.js"
 export { PrintContext } from "./print-context.js"

--- a/javascript/packages/printer/src/index.ts
+++ b/javascript/packages/printer/src/index.ts
@@ -1,5 +1,5 @@
 export { IdentityPrinter } from "./identity-printer.js"
-export { convertIndentation } from "./indentation.js"
+export { convertIndentation, LEADING_BLANKS } from "./indentation.js"
 export type { IndentType } from "./indentation.js"
 export { IndentPrinter } from "./indent-printer.js"
 export { ERBToRubyStringPrinter } from "./erb-to-ruby-string-printer.js"

--- a/javascript/packages/printer/src/index.ts
+++ b/javascript/packages/printer/src/index.ts
@@ -1,4 +1,6 @@
 export { IdentityPrinter } from "./identity-printer.js"
+export { convertIndentation } from "./indentation.js"
+export type { IndentType } from "./indentation.js"
 export { IndentPrinter } from "./indent-printer.js"
 export { ERBToRubyStringPrinter } from "./erb-to-ruby-string-printer.js"
 export { PrintContext } from "./print-context.js"

--- a/javascript/packages/printer/test/indentation.test.ts
+++ b/javascript/packages/printer/test/indentation.test.ts
@@ -6,42 +6,42 @@ describe("convertIndentation", () => {
   test("converts leading spaces to tabs", () => {
     const source = "  this is a line\n    indented twice\n"
 
-    expect(convertIndentation(source, 2, "tabs")).toBe("\tthis is a line\n\t\tindented twice\n")
+    expect(convertIndentation(source, 2, "tab")).toBe("\tthis is a line\n\t\tindented twice\n")
   })
 
   test("converts leading tabs to spaces", () => {
     const source = "\tthis is a line\n\t\tindented twice\n"
 
-    expect(convertIndentation(source, 2, "spaces")).toBe("  this is a line\n    indented twice\n")
+    expect(convertIndentation(source, 2, "space")).toBe("  this is a line\n    indented twice\n")
   })
 
   test("leaves tabs-only source unchanged when converting to tabs", () => {
     const source = "\tthis is a line\n\t\tanother line\n"
 
-    expect(convertIndentation(source, 2, "tabs")).toBe(source)
+    expect(convertIndentation(source, 2, "tab")).toBe(source)
   })
 
   test("leaves spaces-only source unchanged when converting to spaces", () => {
     const source = "  this is a line\n    another line\n"
 
-    expect(convertIndentation(source, 2, "spaces")).toBe(source)
+    expect(convertIndentation(source, 2, "space")).toBe(source)
   })
 
   test("leaves remainder spaces after converting a non-multiple indent to tabs", () => {
     const source = "   this is a line\n"
 
-    expect(convertIndentation(source, 2, "tabs")).toBe("\t this is a line\n")
+    expect(convertIndentation(source, 2, "tab")).toBe("\t this is a line\n")
   })
 
   test("ignores whitespace in the middle of a line", () => {
     const source = "hello\tworld\n"
 
-    expect(convertIndentation(source, 2, "tabs")).toBe(source)
+    expect(convertIndentation(source, 2, "tab")).toBe(source)
   })
 
   test("respects a custom indentWidth", () => {
     const source = "    this is a line\n        indented twice\n"
 
-    expect(convertIndentation(source, 4, "tabs")).toBe("\tthis is a line\n\t\tindented twice\n")
+    expect(convertIndentation(source, 4, "tab")).toBe("\tthis is a line\n\t\tindented twice\n")
   })
 })

--- a/javascript/packages/printer/test/indentation.test.ts
+++ b/javascript/packages/printer/test/indentation.test.ts
@@ -1,0 +1,47 @@
+import { describe, test, expect } from "vitest"
+
+import { convertIndentation } from "../src/indentation.js"
+
+describe("convertIndentation", () => {
+  test("converts leading spaces to tabs", () => {
+    const source = "  this is a line\n    indented twice\n"
+
+    expect(convertIndentation(source, 2, "tabs")).toBe("\tthis is a line\n\t\tindented twice\n")
+  })
+
+  test("converts leading tabs to spaces", () => {
+    const source = "\tthis is a line\n\t\tindented twice\n"
+
+    expect(convertIndentation(source, 2, "spaces")).toBe("  this is a line\n    indented twice\n")
+  })
+
+  test("leaves tabs-only source unchanged when converting to tabs", () => {
+    const source = "\tthis is a line\n\t\tanother line\n"
+
+    expect(convertIndentation(source, 2, "tabs")).toBe(source)
+  })
+
+  test("leaves spaces-only source unchanged when converting to spaces", () => {
+    const source = "  this is a line\n    another line\n"
+
+    expect(convertIndentation(source, 2, "spaces")).toBe(source)
+  })
+
+  test("leaves remainder spaces after converting a non-multiple indent to tabs", () => {
+    const source = "   this is a line\n"
+
+    expect(convertIndentation(source, 2, "tabs")).toBe("\t this is a line\n")
+  })
+
+  test("ignores whitespace in the middle of a line", () => {
+    const source = "hello\tworld\n"
+
+    expect(convertIndentation(source, 2, "tabs")).toBe(source)
+  })
+
+  test("respects a custom indentWidth", () => {
+    const source = "    this is a line\n        indented twice\n"
+
+    expect(convertIndentation(source, 4, "tabs")).toBe("\tthis is a line\n\t\tindented twice\n")
+  })
+})

--- a/javascript/packages/vscode/README.md
+++ b/javascript/packages/vscode/README.md
@@ -66,6 +66,7 @@ linter:
 formatter:
   enabled: true
   indentWidth: 2
+  indentType: spaces  # "spaces" or "tabs"
   maxLineLength: 80
 ```
 
@@ -121,6 +122,7 @@ If a `.herb.yml` exists in the project root, its configuration always takes prec
 | `languageServerHerb.linter.fixOnSave`        | `true`    | Automatically apply autocorrectable fixes on save                |
 | `languageServerHerb.formatter.enabled`       | `false`   | Enable/disable the formatter (experimental)                      |
 | `languageServerHerb.formatter.indentWidth`   | `2`       | Number of spaces per indentation level                           |
+| `languageServerHerb.formatter.indentType`    | `spaces`  | Character used for indentation (`spaces` or `tabs`)              |
 | `languageServerHerb.formatter.maxLineLength` | `80`      | Maximum line length before wrapping                              |
 | `languageServerHerb.trace.server`            | `verbose` | Trace the communication with the language server (for debugging) |
 

--- a/javascript/packages/vscode/README.md
+++ b/javascript/packages/vscode/README.md
@@ -66,7 +66,7 @@ linter:
 formatter:
   enabled: true
   indentWidth: 2
-  indentStyle: spaces
+  indentStyle: space
   maxLineLength: 80
 ```
 
@@ -122,7 +122,7 @@ If a `.herb.yml` exists in the project root, its configuration always takes prec
 | `languageServerHerb.linter.fixOnSave`        | `true`    | Automatically apply autocorrectable fixes on save                |
 | `languageServerHerb.formatter.enabled`       | `false`   | Enable/disable the formatter (experimental)                      |
 | `languageServerHerb.formatter.indentWidth`   | `2`       | Number of spaces per indentation level                           |
-| `languageServerHerb.formatter.indentStyle`   | `spaces`  | Character used for indentation (`spaces` or `tabs`)              |
+| `languageServerHerb.formatter.indentStyle`   | `space`   | Character used for indentation (`space` or `tab`)                |
 | `languageServerHerb.formatter.maxLineLength` | `80`      | Maximum line length before wrapping                              |
 | `languageServerHerb.trace.server`            | `verbose` | Trace the communication with the language server (for debugging) |
 

--- a/javascript/packages/vscode/README.md
+++ b/javascript/packages/vscode/README.md
@@ -66,7 +66,7 @@ linter:
 formatter:
   enabled: true
   indentWidth: 2
-  indentType: spaces  # "spaces" or "tabs"
+  indentStyle: spaces
   maxLineLength: 80
 ```
 
@@ -122,7 +122,7 @@ If a `.herb.yml` exists in the project root, its configuration always takes prec
 | `languageServerHerb.linter.fixOnSave`        | `true`    | Automatically apply autocorrectable fixes on save                |
 | `languageServerHerb.formatter.enabled`       | `false`   | Enable/disable the formatter (experimental)                      |
 | `languageServerHerb.formatter.indentWidth`   | `2`       | Number of spaces per indentation level                           |
-| `languageServerHerb.formatter.indentType`    | `spaces`  | Character used for indentation (`spaces` or `tabs`)              |
+| `languageServerHerb.formatter.indentStyle`   | `spaces`  | Character used for indentation (`spaces` or `tabs`)              |
 | `languageServerHerb.formatter.maxLineLength` | `80`      | Maximum line length before wrapping                              |
 | `languageServerHerb.trace.server`            | `verbose` | Trace the communication with the language server (for debugging) |
 

--- a/javascript/packages/vscode/package.json
+++ b/javascript/packages/vscode/package.json
@@ -86,7 +86,7 @@
           "description": "Number of spaces for each indentation level.",
           "markdownDescription": "Number of spaces for each indentation level.\n\n**Note**: This is a personal default. If a `.herb.yml` file exists in your project, its configuration takes precedence."
         },
-        "languageServerHerb.formatter.indentType": {
+        "languageServerHerb.formatter.indentStyle": {
           "scope": "resource",
           "type": "string",
           "enum": ["spaces", "tabs"],
@@ -187,8 +187,8 @@
         "icon": "$(symbol-numeric)"
       },
       {
-        "command": "herb.setIndentType",
-        "title": "Herb: Set Indent Type",
+        "command": "herb.setIndentStyle",
+        "title": "Herb: Set Indent Style",
         "icon": "$(symbol-enum)"
       },
       {

--- a/javascript/packages/vscode/package.json
+++ b/javascript/packages/vscode/package.json
@@ -86,6 +86,14 @@
           "description": "Number of spaces for each indentation level.",
           "markdownDescription": "Number of spaces for each indentation level.\n\n**Note**: This is a personal default. If a `.herb.yml` file exists in your project, its configuration takes precedence."
         },
+        "languageServerHerb.formatter.indentType": {
+          "scope": "resource",
+          "type": "string",
+          "enum": ["spaces", "tabs"],
+          "default": "spaces",
+          "description": "Character used for indentation.",
+          "markdownDescription": "Character used for indentation.\n\n**Note**: This is a personal default. If a `.herb.yml` file exists in your project, its configuration takes precedence."
+        },
         "languageServerHerb.formatter.maxLineLength": {
           "scope": "resource",
           "type": "number",
@@ -177,6 +185,11 @@
         "command": "herb.setIndentWidth",
         "title": "Herb: Set Indent Width",
         "icon": "$(symbol-numeric)"
+      },
+      {
+        "command": "herb.setIndentType",
+        "title": "Herb: Set Indent Type",
+        "icon": "$(symbol-enum)"
       },
       {
         "command": "herb.setMaxLineLength",

--- a/javascript/packages/vscode/package.json
+++ b/javascript/packages/vscode/package.json
@@ -89,8 +89,11 @@
         "languageServerHerb.formatter.indentStyle": {
           "scope": "resource",
           "type": "string",
-          "enum": ["spaces", "tabs"],
-          "default": "spaces",
+          "enum": [
+            "space",
+            "tab"
+          ],
+          "default": "space",
           "description": "Character used for indentation.",
           "markdownDescription": "Character used for indentation.\n\n**Note**: This is a personal default. If a `.herb.yml` file exists in your project, its configuration takes precedence."
         },

--- a/javascript/packages/vscode/package.json
+++ b/javascript/packages/vscode/package.json
@@ -267,6 +267,16 @@
       ],
       "view/item/context": [
         {
+          "command": "herb.toggleLinter",
+          "when": "view == herbConfiguration && (viewItem == linterSetting || viewItem == personalLinterSetting)",
+          "group": "inline"
+        },
+        {
+          "command": "herb.toggleFormatter",
+          "when": "view == herbConfiguration && (viewItem == formatterSetting || viewItem == personalFormatterSetting)",
+          "group": "inline"
+        },
+        {
           "command": "herb.reprocessFile",
           "when": "view == herbFileStatus && (viewItem == herbFileWithIssues || viewItem == herbFileOk)",
           "group": "inline"

--- a/javascript/packages/vscode/scripts/sync-defaults.js
+++ b/javascript/packages/vscode/scripts/sync-defaults.js
@@ -15,6 +15,10 @@ if (config['languageServerHerb.formatter.indentWidth']) {
   config['languageServerHerb.formatter.indentWidth'].default = defaults.formatter.indentWidth;
 }
 
+if (config['languageServerHerb.formatter.indentStyle']) {
+  config['languageServerHerb.formatter.indentStyle'].default = defaults.formatter.indentStyle;
+}
+
 if (config['languageServerHerb.formatter.maxLineLength']) {
   config['languageServerHerb.formatter.maxLineLength'].default = defaults.formatter.maxLineLength;
 }

--- a/javascript/packages/vscode/src/analysis-service.ts
+++ b/javascript/packages/vscode/src/analysis-service.ts
@@ -22,7 +22,7 @@ export class AnalysisService {
       let linterEnabled = true
       let formatterEnabled = false
       let formatterIndentWidth = 2
-      let formatterIndentStyle = 'spaces'
+      let formatterIndentStyle = 'space'
       let formatterMaxLineLength = 80
       let linterRules = {}
       const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || process.cwd()
@@ -33,7 +33,7 @@ export class AnalysisService {
           linterEnabled = projectConfig.linter?.enabled ?? true
           formatterEnabled = projectConfig.formatter?.enabled ?? false
           formatterIndentWidth = projectConfig.formatter?.indentWidth ?? 2
-          formatterIndentStyle = projectConfig.formatter?.indentStyle ?? 'spaces'
+          formatterIndentStyle = projectConfig.formatter?.indentStyle ?? 'space'
           formatterMaxLineLength = projectConfig.formatter?.maxLineLength ?? 80
           linterRules = projectConfig.linter?.rules ?? {}
         }
@@ -42,7 +42,7 @@ export class AnalysisService {
         linterEnabled = vscodeConfig.get('linter.enabled', true)
         formatterEnabled = vscodeConfig.get('formatter.enabled', false)
         formatterIndentWidth = vscodeConfig.get('formatter.indentWidth', 2)
-        formatterIndentStyle = vscodeConfig.get('formatter.indentStyle', 'spaces')
+        formatterIndentStyle = vscodeConfig.get('formatter.indentStyle', 'space')
         formatterMaxLineLength = vscodeConfig.get('formatter.maxLineLength', 80)
       }
 

--- a/javascript/packages/vscode/src/analysis-service.ts
+++ b/javascript/packages/vscode/src/analysis-service.ts
@@ -22,6 +22,7 @@ export class AnalysisService {
       let linterEnabled = true
       let formatterEnabled = false
       let formatterIndentWidth = 2
+      let formatterIndentType = 'spaces'
       let formatterMaxLineLength = 80
       let linterRules = {}
       const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || process.cwd()
@@ -32,6 +33,7 @@ export class AnalysisService {
           linterEnabled = projectConfig.linter?.enabled ?? true
           formatterEnabled = projectConfig.formatter?.enabled ?? false
           formatterIndentWidth = projectConfig.formatter?.indentWidth ?? 2
+          formatterIndentType = projectConfig.formatter?.indentType ?? 'spaces'
           formatterMaxLineLength = projectConfig.formatter?.maxLineLength ?? 80
           linterRules = projectConfig.linter?.rules ?? {}
         }
@@ -40,6 +42,7 @@ export class AnalysisService {
         linterEnabled = vscodeConfig.get('linter.enabled', true)
         formatterEnabled = vscodeConfig.get('formatter.enabled', false)
         formatterIndentWidth = vscodeConfig.get('formatter.indentWidth', 2)
+        formatterIndentType = vscodeConfig.get('formatter.indentType', 'spaces')
         formatterMaxLineLength = vscodeConfig.get('formatter.maxLineLength', 80)
       }
 
@@ -51,7 +54,8 @@ export class AnalysisService {
         formatterIndentWidth.toString(),
         formatterMaxLineLength.toString(),
         JSON.stringify(linterRules),
-        workspaceRoot
+        workspaceRoot,
+        formatterIndentType
       ], { timeout: 1000 })
 
       const result = JSON.parse(stdout.trim())

--- a/javascript/packages/vscode/src/analysis-service.ts
+++ b/javascript/packages/vscode/src/analysis-service.ts
@@ -22,7 +22,7 @@ export class AnalysisService {
       let linterEnabled = true
       let formatterEnabled = false
       let formatterIndentWidth = 2
-      let formatterIndentType = 'spaces'
+      let formatterIndentStyle = 'spaces'
       let formatterMaxLineLength = 80
       let linterRules = {}
       const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || process.cwd()
@@ -33,7 +33,7 @@ export class AnalysisService {
           linterEnabled = projectConfig.linter?.enabled ?? true
           formatterEnabled = projectConfig.formatter?.enabled ?? false
           formatterIndentWidth = projectConfig.formatter?.indentWidth ?? 2
-          formatterIndentType = projectConfig.formatter?.indentType ?? 'spaces'
+          formatterIndentStyle = projectConfig.formatter?.indentStyle ?? 'spaces'
           formatterMaxLineLength = projectConfig.formatter?.maxLineLength ?? 80
           linterRules = projectConfig.linter?.rules ?? {}
         }
@@ -42,7 +42,7 @@ export class AnalysisService {
         linterEnabled = vscodeConfig.get('linter.enabled', true)
         formatterEnabled = vscodeConfig.get('formatter.enabled', false)
         formatterIndentWidth = vscodeConfig.get('formatter.indentWidth', 2)
-        formatterIndentType = vscodeConfig.get('formatter.indentType', 'spaces')
+        formatterIndentStyle = vscodeConfig.get('formatter.indentStyle', 'spaces')
         formatterMaxLineLength = vscodeConfig.get('formatter.maxLineLength', 80)
       }
 
@@ -55,7 +55,7 @@ export class AnalysisService {
         formatterMaxLineLength.toString(),
         JSON.stringify(linterRules),
         workspaceRoot,
-        formatterIndentType
+        formatterIndentStyle
       ], { timeout: 1000 })
 
       const result = JSON.parse(stdout.trim())

--- a/javascript/packages/vscode/src/client.ts
+++ b/javascript/packages/vscode/src/client.ts
@@ -91,6 +91,7 @@ export class Client {
           formatter: {
             enabled: projectConfig.formatter?.enabled ?? vscodeConfig.get('formatter.enabled', false),
             indentWidth: projectConfig.formatter?.indentWidth ?? 2,
+            indentType: projectConfig.formatter?.indentType ?? 'spaces',
             maxLineLength: projectConfig.formatter?.maxLineLength ?? 80,
             exclude: projectConfig.formatter?.exclude,
             rewriter: projectConfig.formatter?.rewriter,
@@ -109,6 +110,7 @@ export class Client {
           formatter: {
             enabled: vscodeConfig.get('formatter.enabled', false),
             indentWidth: vscodeConfig.get('formatter.indentWidth', 2),
+            indentType: vscodeConfig.get('formatter.indentType', 'spaces'),
             maxLineLength: vscodeConfig.get('formatter.maxLineLength', 80),
           },
           trace: {
@@ -119,7 +121,7 @@ export class Client {
     } else {
       settings = {
         linter: { enabled: true },
-        formatter: { enabled: false, indentWidth: 2, maxLineLength: 80 },
+        formatter: { enabled: false, indentWidth: 2, indentType: 'spaces', maxLineLength: 80 },
         trace: { server: 'verbose' },
       }
     }
@@ -193,6 +195,7 @@ export class Client {
           formatter: {
             enabled: projectConfig.formatter?.enabled ?? vscodeConfig.get('formatter.enabled', false),
             indentWidth: projectConfig.formatter?.indentWidth ?? 2,
+            indentType: projectConfig.formatter?.indentType ?? 'spaces',
             maxLineLength: projectConfig.formatter?.maxLineLength ?? 80,
             exclude: projectConfig.formatter?.exclude,
             rewriter: projectConfig.formatter?.rewriter,
@@ -212,6 +215,7 @@ export class Client {
           formatter: {
             enabled: vscodeConfig.get('formatter.enabled', false),
             indentWidth: vscodeConfig.get('formatter.indentWidth', 2),
+            indentType: vscodeConfig.get('formatter.indentType', 'spaces'),
             maxLineLength: vscodeConfig.get('formatter.maxLineLength', 80),
           },
           trace: {
@@ -223,7 +227,7 @@ export class Client {
     } else {
       return {
         linter: { enabled: true },
-        formatter: { enabled: false, indentWidth: 2, maxLineLength: 80 },
+        formatter: { enabled: false, indentWidth: 2, indentType: 'spaces', maxLineLength: 80 },
         trace: { server: 'verbose' },
         experimental: this.experimentalCapabilities,
       }

--- a/javascript/packages/vscode/src/client.ts
+++ b/javascript/packages/vscode/src/client.ts
@@ -91,7 +91,7 @@ export class Client {
           formatter: {
             enabled: projectConfig.formatter?.enabled ?? vscodeConfig.get('formatter.enabled', false),
             indentWidth: projectConfig.formatter?.indentWidth ?? 2,
-            indentStyle: projectConfig.formatter?.indentStyle ?? 'spaces',
+            indentStyle: projectConfig.formatter?.indentStyle ?? 'space',
             maxLineLength: projectConfig.formatter?.maxLineLength ?? 80,
             exclude: projectConfig.formatter?.exclude,
             rewriter: projectConfig.formatter?.rewriter,
@@ -110,7 +110,7 @@ export class Client {
           formatter: {
             enabled: vscodeConfig.get('formatter.enabled', false),
             indentWidth: vscodeConfig.get('formatter.indentWidth', 2),
-            indentStyle: vscodeConfig.get('formatter.indentStyle', 'spaces'),
+            indentStyle: vscodeConfig.get('formatter.indentStyle', 'space'),
             maxLineLength: vscodeConfig.get('formatter.maxLineLength', 80),
           },
           trace: {
@@ -121,7 +121,7 @@ export class Client {
     } else {
       settings = {
         linter: { enabled: true },
-        formatter: { enabled: false, indentWidth: 2, indentStyle: 'spaces', maxLineLength: 80 },
+        formatter: { enabled: false, indentWidth: 2, indentStyle: 'space', maxLineLength: 80 },
         trace: { server: 'verbose' },
       }
     }
@@ -195,7 +195,7 @@ export class Client {
           formatter: {
             enabled: projectConfig.formatter?.enabled ?? vscodeConfig.get('formatter.enabled', false),
             indentWidth: projectConfig.formatter?.indentWidth ?? 2,
-            indentStyle: projectConfig.formatter?.indentStyle ?? 'spaces',
+            indentStyle: projectConfig.formatter?.indentStyle ?? 'space',
             maxLineLength: projectConfig.formatter?.maxLineLength ?? 80,
             exclude: projectConfig.formatter?.exclude,
             rewriter: projectConfig.formatter?.rewriter,
@@ -215,7 +215,7 @@ export class Client {
           formatter: {
             enabled: vscodeConfig.get('formatter.enabled', false),
             indentWidth: vscodeConfig.get('formatter.indentWidth', 2),
-            indentStyle: vscodeConfig.get('formatter.indentStyle', 'spaces'),
+            indentStyle: vscodeConfig.get('formatter.indentStyle', 'space'),
             maxLineLength: vscodeConfig.get('formatter.maxLineLength', 80),
           },
           trace: {
@@ -227,7 +227,7 @@ export class Client {
     } else {
       return {
         linter: { enabled: true },
-        formatter: { enabled: false, indentWidth: 2, indentStyle: 'spaces', maxLineLength: 80 },
+        formatter: { enabled: false, indentWidth: 2, indentStyle: 'space', maxLineLength: 80 },
         trace: { server: 'verbose' },
         experimental: this.experimentalCapabilities,
       }

--- a/javascript/packages/vscode/src/client.ts
+++ b/javascript/packages/vscode/src/client.ts
@@ -91,7 +91,7 @@ export class Client {
           formatter: {
             enabled: projectConfig.formatter?.enabled ?? vscodeConfig.get('formatter.enabled', false),
             indentWidth: projectConfig.formatter?.indentWidth ?? 2,
-            indentType: projectConfig.formatter?.indentType ?? 'spaces',
+            indentStyle: projectConfig.formatter?.indentStyle ?? 'spaces',
             maxLineLength: projectConfig.formatter?.maxLineLength ?? 80,
             exclude: projectConfig.formatter?.exclude,
             rewriter: projectConfig.formatter?.rewriter,
@@ -110,7 +110,7 @@ export class Client {
           formatter: {
             enabled: vscodeConfig.get('formatter.enabled', false),
             indentWidth: vscodeConfig.get('formatter.indentWidth', 2),
-            indentType: vscodeConfig.get('formatter.indentType', 'spaces'),
+            indentStyle: vscodeConfig.get('formatter.indentStyle', 'spaces'),
             maxLineLength: vscodeConfig.get('formatter.maxLineLength', 80),
           },
           trace: {
@@ -121,7 +121,7 @@ export class Client {
     } else {
       settings = {
         linter: { enabled: true },
-        formatter: { enabled: false, indentWidth: 2, indentType: 'spaces', maxLineLength: 80 },
+        formatter: { enabled: false, indentWidth: 2, indentStyle: 'spaces', maxLineLength: 80 },
         trace: { server: 'verbose' },
       }
     }
@@ -195,7 +195,7 @@ export class Client {
           formatter: {
             enabled: projectConfig.formatter?.enabled ?? vscodeConfig.get('formatter.enabled', false),
             indentWidth: projectConfig.formatter?.indentWidth ?? 2,
-            indentType: projectConfig.formatter?.indentType ?? 'spaces',
+            indentStyle: projectConfig.formatter?.indentStyle ?? 'spaces',
             maxLineLength: projectConfig.formatter?.maxLineLength ?? 80,
             exclude: projectConfig.formatter?.exclude,
             rewriter: projectConfig.formatter?.rewriter,
@@ -215,7 +215,7 @@ export class Client {
           formatter: {
             enabled: vscodeConfig.get('formatter.enabled', false),
             indentWidth: vscodeConfig.get('formatter.indentWidth', 2),
-            indentType: vscodeConfig.get('formatter.indentType', 'spaces'),
+            indentStyle: vscodeConfig.get('formatter.indentStyle', 'spaces'),
             maxLineLength: vscodeConfig.get('formatter.maxLineLength', 80),
           },
           trace: {
@@ -227,7 +227,7 @@ export class Client {
     } else {
       return {
         linter: { enabled: true },
-        formatter: { enabled: false, indentWidth: 2, indentType: 'spaces', maxLineLength: 80 },
+        formatter: { enabled: false, indentWidth: 2, indentStyle: 'spaces', maxLineLength: 80 },
         trace: { server: 'verbose' },
         experimental: this.experimentalCapabilities,
       }

--- a/javascript/packages/vscode/src/config-details-provider.ts
+++ b/javascript/packages/vscode/src/config-details-provider.ts
@@ -88,12 +88,12 @@ export async function showConfigDetails() {
 
   const formatterEnabled = config?.formatter?.enabled ?? vscodeConfig.get('formatter.enabled', false)
   const indentWidth = config?.formatter?.indentWidth ?? vscodeConfig.get('formatter.indentWidth', 2)
-  const indentType = config?.formatter?.indentType ?? vscodeConfig.get('formatter.indentType', 'spaces')
+  const indentStyle = config?.formatter?.indentStyle ?? vscodeConfig.get('formatter.indentStyle', 'spaces')
   const maxLineLength = config?.formatter?.maxLineLength ?? vscodeConfig.get('formatter.maxLineLength', 80)
 
   const formatterIcon = formatterEnabled ? "$(check)" : "$(x)"
   const formatterStatus = formatterEnabled ? "Enabled" : "Disabled"
-  const formatterDetail = indentType === 'tabs'
+  const formatterDetail = indentStyle === 'tabs'
     ? `Indent: tabs, Max length: ${maxLineLength}`
     : `Indent: ${indentWidth} spaces, Max length: ${maxLineLength}`
 

--- a/javascript/packages/vscode/src/config-details-provider.ts
+++ b/javascript/packages/vscode/src/config-details-provider.ts
@@ -88,11 +88,14 @@ export async function showConfigDetails() {
 
   const formatterEnabled = config?.formatter?.enabled ?? vscodeConfig.get('formatter.enabled', false)
   const indentWidth = config?.formatter?.indentWidth ?? vscodeConfig.get('formatter.indentWidth', 2)
+  const indentType = config?.formatter?.indentType ?? vscodeConfig.get('formatter.indentType', 'spaces')
   const maxLineLength = config?.formatter?.maxLineLength ?? vscodeConfig.get('formatter.maxLineLength', 80)
 
   const formatterIcon = formatterEnabled ? "$(check)" : "$(x)"
   const formatterStatus = formatterEnabled ? "Enabled" : "Disabled"
-  const formatterDetail = `Indent: ${indentWidth} spaces, Max length: ${maxLineLength}`
+  const formatterDetail = indentType === 'tabs'
+    ? `Indent: tabs, Max length: ${maxLineLength}`
+    : `Indent: ${indentWidth} spaces, Max length: ${maxLineLength}`
 
   const formatterItem: ConfigQuickPickItem = {
     label: `${formatterIcon} Herb Formatter: ${formatterStatus}`,

--- a/javascript/packages/vscode/src/config-details-provider.ts
+++ b/javascript/packages/vscode/src/config-details-provider.ts
@@ -88,12 +88,12 @@ export async function showConfigDetails() {
 
   const formatterEnabled = config?.formatter?.enabled ?? vscodeConfig.get('formatter.enabled', false)
   const indentWidth = config?.formatter?.indentWidth ?? vscodeConfig.get('formatter.indentWidth', 2)
-  const indentStyle = config?.formatter?.indentStyle ?? vscodeConfig.get('formatter.indentStyle', 'spaces')
+  const indentStyle = config?.formatter?.indentStyle ?? vscodeConfig.get('formatter.indentStyle', 'space')
   const maxLineLength = config?.formatter?.maxLineLength ?? vscodeConfig.get('formatter.maxLineLength', 80)
 
   const formatterIcon = formatterEnabled ? "$(check)" : "$(x)"
   const formatterStatus = formatterEnabled ? "Enabled" : "Disabled"
-  const formatterDetail = indentStyle === 'tabs'
+  const formatterDetail = indentStyle === 'tab'
     ? `Indent: tabs, Max length: ${maxLineLength}`
     : `Indent: ${indentWidth} spaces, Max length: ${maxLineLength}`
 

--- a/javascript/packages/vscode/src/config-provider.ts
+++ b/javascript/packages/vscode/src/config-provider.ts
@@ -165,7 +165,7 @@ export class HerbConfigProvider implements vscode.TreeDataProvider<ConfigItem> {
       items.push(linterItem)
 
       const formatterEnabled = this.config.isFormatterEnabled
-      const formatterIndentDetail = this.config.formatter?.indentType === 'tabs'
+      const formatterIndentDetail = this.config.formatter?.indentStyle === 'tabs'
         ? 'tabs'
         : `${this.config.formatter?.indentWidth ?? 2} spaces`
       const formatterItem = new ConfigItem(

--- a/javascript/packages/vscode/src/config-provider.ts
+++ b/javascript/packages/vscode/src/config-provider.ts
@@ -165,7 +165,7 @@ export class HerbConfigProvider implements vscode.TreeDataProvider<ConfigItem> {
       items.push(linterItem)
 
       const formatterEnabled = this.config.isFormatterEnabled
-      const formatterIndentDetail = this.config.formatter?.indentStyle === 'tabs'
+      const formatterIndentDetail = this.config.formatter?.indentStyle === 'tab'
         ? 'tabs'
         : `${this.config.formatter?.indentWidth ?? 2} spaces`
       const formatterItem = new ConfigItem(

--- a/javascript/packages/vscode/src/config-provider.ts
+++ b/javascript/packages/vscode/src/config-provider.ts
@@ -69,6 +69,14 @@ export class HerbConfigProvider implements vscode.TreeDataProvider<ConfigItem> {
     }
 
     if (element) {
+      if (element.contextValue === 'formatterSetting') {
+        return Promise.resolve(this.getFormatterSettingItems())
+      }
+
+      if (element.contextValue === 'personalFormatterSetting') {
+        return Promise.resolve(this.getPersonalFormatterSettingItems())
+      }
+
       return Promise.resolve([])
     } else {
       return Promise.resolve(this.getConfigItems())
@@ -173,17 +181,12 @@ export class HerbConfigProvider implements vscode.TreeDataProvider<ConfigItem> {
         formatterEnabled
           ? `Indent: ${formatterIndentDetail}, Max length: ${this.config.formatter?.maxLineLength ?? 80}`
           : "Experimental feature",
-        vscode.TreeItemCollapsibleState.None,
+        vscode.TreeItemCollapsibleState.Expanded,
         'formatterSetting'
       )
       formatterItem.iconPath = formatterEnabled
         ? new vscode.ThemeIcon('check', new vscode.ThemeColor('charts.green'))
         : new vscode.ThemeIcon('x', new vscode.ThemeColor('charts.red'))
-      formatterItem.command = {
-        command: 'herb.toggleFormatter',
-        title: 'Toggle Formatter',
-        arguments: []
-      }
       items.push(formatterItem)
     } else if (this.configError) {
       const errorItem = new ConfigItem(
@@ -246,17 +249,12 @@ export class HerbConfigProvider implements vscode.TreeDataProvider<ConfigItem> {
       const formatterItem = new ConfigItem(
         `Herb Formatter: ${formatterEnabled ? 'Enabled' : 'Disabled'}`,
         "From VS Code settings",
-        vscode.TreeItemCollapsibleState.None,
+        vscode.TreeItemCollapsibleState.Expanded,
         'personalFormatterSetting'
       )
       formatterItem.iconPath = formatterEnabled
         ? new vscode.ThemeIcon('check', new vscode.ThemeColor('charts.green'))
         : new vscode.ThemeIcon('x', new vscode.ThemeColor('charts.red'))
-      formatterItem.command = {
-        command: 'workbench.action.openSettings',
-        title: 'Open Formatter Settings',
-        arguments: ['languageServerHerb.formatter']
-      }
       items.push(formatterItem)
 
       const createConfigItem = new ConfigItem(
@@ -275,6 +273,98 @@ export class HerbConfigProvider implements vscode.TreeDataProvider<ConfigItem> {
     }
 
     return items
+  }
+
+  private getFormatterSettingItems(): ConfigItem[] {
+    const indentStyle = this.config?.formatter?.indentStyle ?? 'space'
+    const indentWidth = this.config?.formatter?.indentWidth ?? 2
+    const maxLineLength = this.config?.formatter?.maxLineLength ?? 80
+
+    const indentStyleItem = new ConfigItem(
+      "Indent Style",
+      indentStyle,
+      vscode.TreeItemCollapsibleState.None,
+      'formatterIndentStyle'
+    )
+    indentStyleItem.iconPath = new vscode.ThemeIcon('symbol-enum')
+    indentStyleItem.command = {
+      command: 'herb.setIndentStyle',
+      title: 'Set Indent Style',
+      arguments: []
+    }
+
+    const indentWidthItem = new ConfigItem(
+      "Indent Width",
+      `${indentWidth}`,
+      vscode.TreeItemCollapsibleState.None,
+      'formatterIndentWidth'
+    )
+    indentWidthItem.iconPath = new vscode.ThemeIcon('symbol-numeric')
+    indentWidthItem.command = {
+      command: 'herb.setIndentWidth',
+      title: 'Set Indent Width',
+      arguments: []
+    }
+
+    const maxLineLengthItem = new ConfigItem(
+      "Max Line Length",
+      `${maxLineLength}`,
+      vscode.TreeItemCollapsibleState.None,
+      'formatterMaxLineLength'
+    )
+    maxLineLengthItem.iconPath = new vscode.ThemeIcon('symbol-numeric')
+    maxLineLengthItem.command = {
+      command: 'herb.setMaxLineLength',
+      title: 'Set Max Line Length',
+      arguments: []
+    }
+
+    return [indentStyleItem, indentWidthItem, maxLineLengthItem]
+  }
+
+  private getPersonalFormatterSettingItems(): ConfigItem[] {
+    const vscodeConfig = vscode.workspace.getConfiguration('languageServerHerb')
+
+    const indentStyleItem = new ConfigItem(
+      "Indent Style",
+      vscodeConfig.get('formatter.indentStyle', 'space'),
+      vscode.TreeItemCollapsibleState.None,
+      'personalFormatterIndentStyle'
+    )
+    indentStyleItem.iconPath = new vscode.ThemeIcon('symbol-enum')
+    indentStyleItem.command = {
+      command: 'workbench.action.openSettings',
+      title: 'Open Indent Style Setting',
+      arguments: ['languageServerHerb.formatter.indentStyle']
+    }
+
+    const indentWidthItem = new ConfigItem(
+      "Indent Width",
+      `${vscodeConfig.get('formatter.indentWidth', 2)}`,
+      vscode.TreeItemCollapsibleState.None,
+      'personalFormatterIndentWidth'
+    )
+    indentWidthItem.iconPath = new vscode.ThemeIcon('symbol-numeric')
+    indentWidthItem.command = {
+      command: 'workbench.action.openSettings',
+      title: 'Open Indent Width Setting',
+      arguments: ['languageServerHerb.formatter.indentWidth']
+    }
+
+    const maxLineLengthItem = new ConfigItem(
+      "Max Line Length",
+      `${vscodeConfig.get('formatter.maxLineLength', 80)}`,
+      vscode.TreeItemCollapsibleState.None,
+      'personalFormatterMaxLineLength'
+    )
+    maxLineLengthItem.iconPath = new vscode.ThemeIcon('symbol-numeric')
+    maxLineLengthItem.command = {
+      command: 'workbench.action.openSettings',
+      title: 'Open Max Line Length Setting',
+      arguments: ['languageServerHerb.formatter.maxLineLength']
+    }
+
+    return [indentStyleItem, indentWidthItem, maxLineLengthItem]
   }
 
   async createConfig(): Promise<void> {

--- a/javascript/packages/vscode/src/config-provider.ts
+++ b/javascript/packages/vscode/src/config-provider.ts
@@ -165,10 +165,13 @@ export class HerbConfigProvider implements vscode.TreeDataProvider<ConfigItem> {
       items.push(linterItem)
 
       const formatterEnabled = this.config.isFormatterEnabled
+      const formatterIndentDetail = this.config.formatter?.indentType === 'tabs'
+        ? 'tabs'
+        : `${this.config.formatter?.indentWidth ?? 2} spaces`
       const formatterItem = new ConfigItem(
         `Herb Formatter: ${formatterEnabled ? 'Enabled' : 'Disabled'}`,
         formatterEnabled
-          ? `Indent: ${this.config.formatter?.indentWidth ?? 2}, Max length: ${this.config.formatter?.maxLineLength ?? 80}`
+          ? `Indent: ${formatterIndentDetail}, Max length: ${this.config.formatter?.maxLineLength ?? 80}`
           : "Experimental feature",
         vscode.TreeItemCollapsibleState.None,
         'formatterSetting'

--- a/javascript/packages/vscode/src/herb-settings-commands.ts
+++ b/javascript/packages/vscode/src/herb-settings-commands.ts
@@ -25,6 +25,7 @@ export class HerbSettingsCommands {
       vscode.commands.registerCommand('herb.toggleLinter', () => this.toggleLinter()),
       vscode.commands.registerCommand('herb.toggleFormatter', () => this.toggleFormatter()),
       vscode.commands.registerCommand('herb.setIndentWidth', () => this.setIndentWidth()),
+      vscode.commands.registerCommand('herb.setIndentType', () => this.setIndentType()),
       vscode.commands.registerCommand('herb.setMaxLineLength', () => this.setMaxLineLength()),
     )
   }
@@ -187,6 +188,53 @@ export class HerbSettingsCommands {
 
       vscode.window.showInformationMessage(
         `Herb formatter indent width set to ${indentWidth} spaces`
+      )
+
+      warnAboutAliasedTargets(aliasedTargets)
+
+      vscode.commands.executeCommand('herb.refreshLanguageServer')
+
+      if (this.configProvider) {
+        await this.configProvider.refresh()
+      }
+    } catch (error) {
+      vscode.window.showErrorMessage(`Failed to update Herb config: ${error}`)
+    }
+  }
+
+  private async setIndentType() {
+    const config = await this.getOrCreateConfig()
+    if (!config) {return}
+
+    const configPath = await this.getConfigPath()
+    if (!configPath) {return}
+
+    const currentType = config.config.formatter?.indentType ?? "spaces"
+
+    const choice = await vscode.window.showQuickPick([
+      {
+        label: 'Spaces',
+        description: currentType === 'spaces' ? '(current)' : '',
+        value: 'spaces' as const
+      },
+      {
+        label: 'Tabs',
+        description: currentType === 'tabs' ? '(current)' : '',
+        value: 'tabs' as const
+      }
+    ], {
+      placeHolder: 'Select indentation character for Herb formatter'
+    })
+
+    if (choice === undefined) {return}
+
+    try {
+      const aliasedTargets = await Config.mutateConfigFile(configPath, {
+        formatter: { indentType: choice.value }
+      })
+
+      vscode.window.showInformationMessage(
+        `Herb formatter indent type set to ${choice.value}`
       )
 
       warnAboutAliasedTargets(aliasedTargets)

--- a/javascript/packages/vscode/src/herb-settings-commands.ts
+++ b/javascript/packages/vscode/src/herb-settings-commands.ts
@@ -209,18 +209,18 @@ export class HerbSettingsCommands {
     const configPath = await this.getConfigPath()
     if (!configPath) {return}
 
-    const currentType = config.config.formatter?.indentStyle ?? "spaces"
+    const currentType = config.config.formatter?.indentStyle ?? "space"
 
     const choice = await vscode.window.showQuickPick([
       {
         label: 'Spaces',
-        description: currentType === 'spaces' ? '(current)' : '',
-        value: 'spaces' as const
+        description: currentType === 'space' ? '(current)' : '',
+        value: 'space' as const
       },
       {
         label: 'Tabs',
-        description: currentType === 'tabs' ? '(current)' : '',
-        value: 'tabs' as const
+        description: currentType === 'tab' ? '(current)' : '',
+        value: 'tab' as const
       }
     ], {
       placeHolder: 'Select indentation character for Herb formatter'

--- a/javascript/packages/vscode/src/herb-settings-commands.ts
+++ b/javascript/packages/vscode/src/herb-settings-commands.ts
@@ -25,7 +25,7 @@ export class HerbSettingsCommands {
       vscode.commands.registerCommand('herb.toggleLinter', () => this.toggleLinter()),
       vscode.commands.registerCommand('herb.toggleFormatter', () => this.toggleFormatter()),
       vscode.commands.registerCommand('herb.setIndentWidth', () => this.setIndentWidth()),
-      vscode.commands.registerCommand('herb.setIndentType', () => this.setIndentType()),
+      vscode.commands.registerCommand('herb.setIndentStyle', () => this.setIndentStyle()),
       vscode.commands.registerCommand('herb.setMaxLineLength', () => this.setMaxLineLength()),
     )
   }
@@ -202,14 +202,14 @@ export class HerbSettingsCommands {
     }
   }
 
-  private async setIndentType() {
+  private async setIndentStyle() {
     const config = await this.getOrCreateConfig()
     if (!config) {return}
 
     const configPath = await this.getConfigPath()
     if (!configPath) {return}
 
-    const currentType = config.config.formatter?.indentType ?? "spaces"
+    const currentType = config.config.formatter?.indentStyle ?? "spaces"
 
     const choice = await vscode.window.showQuickPick([
       {
@@ -230,11 +230,11 @@ export class HerbSettingsCommands {
 
     try {
       const aliasedTargets = await Config.mutateConfigFile(configPath, {
-        formatter: { indentType: choice.value }
+        formatter: { indentStyle: choice.value }
       })
 
       vscode.window.showInformationMessage(
-        `Herb formatter indent type set to ${choice.value}`
+        `Herb formatter indent style set to ${choice.value}`
       )
 
       warnAboutAliasedTargets(aliasedTargets)

--- a/javascript/packages/vscode/src/parse-worker.js
+++ b/javascript/packages/vscode/src/parse-worker.js
@@ -12,7 +12,7 @@ const { Config } = require('@herb-tools/config');
   const formatterMaxLineLength = parseInt(process.argv[6]) || 80;
   const linterRulesJson = process.argv[7] || '{}';
   const workspaceRoot = process.argv[8] || process.cwd();
-  const formatterIndentStyle = process.argv[9] === 'tabs' ? 'tabs' : 'spaces';
+  const formatterIndentStyle = process.argv[9] === 'tab' ? 'tab' : 'space';
 
   let linterRules = {};
   try {

--- a/javascript/packages/vscode/src/parse-worker.js
+++ b/javascript/packages/vscode/src/parse-worker.js
@@ -12,6 +12,7 @@ const { Config } = require('@herb-tools/config');
   const formatterMaxLineLength = parseInt(process.argv[6]) || 80;
   const linterRulesJson = process.argv[7] || '{}';
   const workspaceRoot = process.argv[8] || process.cwd();
+  const formatterIndentType = process.argv[9] === 'tabs' ? 'tabs' : 'spaces';
 
   let linterRules = {};
   try {
@@ -89,6 +90,7 @@ const { Config } = require('@herb-tools/config');
       try {
         const formatter = new Formatter(Herb, {
           indentWidth: formatterIndentWidth,
+          indentType: formatterIndentType,
           maxLineLength: formatterMaxLineLength
         });
         const formattedContent = formatter.format(content);

--- a/javascript/packages/vscode/src/parse-worker.js
+++ b/javascript/packages/vscode/src/parse-worker.js
@@ -12,7 +12,7 @@ const { Config } = require('@herb-tools/config');
   const formatterMaxLineLength = parseInt(process.argv[6]) || 80;
   const linterRulesJson = process.argv[7] || '{}';
   const workspaceRoot = process.argv[8] || process.cwd();
-  const formatterIndentType = process.argv[9] === 'tabs' ? 'tabs' : 'spaces';
+  const formatterIndentStyle = process.argv[9] === 'tabs' ? 'tabs' : 'spaces';
 
   let linterRules = {};
   try {
@@ -90,7 +90,7 @@ const { Config } = require('@herb-tools/config');
       try {
         const formatter = new Formatter(Herb, {
           indentWidth: formatterIndentWidth,
-          indentType: formatterIndentType,
+          indentStyle: formatterIndentStyle,
           maxLineLength: formatterMaxLineLength
         });
         const formattedContent = formatter.format(content);

--- a/lib/herb/defaults.yml
+++ b/lib/herb/defaults.yml
@@ -32,5 +32,5 @@ linter:
 formatter:
   enabled: false
   indentWidth: 2
-  indentType: spaces
+  indentStyle: spaces
   maxLineLength: 80

--- a/lib/herb/defaults.yml
+++ b/lib/herb/defaults.yml
@@ -32,5 +32,5 @@ linter:
 formatter:
   enabled: false
   indentWidth: 2
-  indentStyle: spaces
+  indentStyle: space
   maxLineLength: 80

--- a/lib/herb/defaults.yml
+++ b/lib/herb/defaults.yml
@@ -32,4 +32,5 @@ linter:
 formatter:
   enabled: false
   indentWidth: 2
+  indentType: spaces
   maxLineLength: 80

--- a/rust/herb-config/src/config_schema.rs
+++ b/rust/herb-config/src/config_schema.rs
@@ -84,10 +84,20 @@ pub struct FormatterConfig {
   pub indent_width: Option<usize>,
 
   #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub indent_type: Option<IndentType>,
+
+  #[serde(default, skip_serializing_if = "Option::is_none")]
   pub max_line_length: Option<usize>,
 
   #[serde(default, skip_serializing_if = "Option::is_none")]
   pub rewriter: Option<RewriterConfig>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum IndentType {
+  Spaces,
+  Tabs,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/rust/herb-config/src/config_schema.rs
+++ b/rust/herb-config/src/config_schema.rs
@@ -84,7 +84,7 @@ pub struct FormatterConfig {
   pub indent_width: Option<usize>,
 
   #[serde(default, skip_serializing_if = "Option::is_none")]
-  pub indent_type: Option<IndentType>,
+  pub indent_style: Option<IndentStyle>,
 
   #[serde(default, skip_serializing_if = "Option::is_none")]
   pub max_line_length: Option<usize>,
@@ -95,7 +95,7 @@ pub struct FormatterConfig {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
-pub enum IndentType {
+pub enum IndentStyle {
   Spaces,
   Tabs,
 }

--- a/rust/herb-config/src/config_schema.rs
+++ b/rust/herb-config/src/config_schema.rs
@@ -96,8 +96,8 @@ pub struct FormatterConfig {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum IndentStyle {
-  Spaces,
-  Tabs,
+  Space,
+  Tab,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/rust/herb-config/src/lib.rs
+++ b/rust/herb-config/src/lib.rs
@@ -14,7 +14,7 @@ mod severity;
 pub use config::{Config, FoundConfigFile, FromObjectOptions, LoadOptions, SeverityOverridable, Tool, ALL_RULES_KEY, CONFIG_PATH, MISNAMED_CONFIG_PATHS};
 
 pub use config_schema::{
-  EngineConfig, FilesConfig, FormatterConfig, Framework, HerbConfig, HerbConfigOptions, IndentType, LinterConfig, RewriterConfig, RuleConfig, TemplateEngine,
+  EngineConfig, FilesConfig, FormatterConfig, Framework, HerbConfig, HerbConfigOptions, IndentStyle, LinterConfig, RewriterConfig, RuleConfig, TemplateEngine,
 };
 
 pub use defaults::DEFAULT_VERSION;

--- a/rust/herb-config/src/lib.rs
+++ b/rust/herb-config/src/lib.rs
@@ -14,7 +14,8 @@ mod severity;
 pub use config::{Config, FoundConfigFile, FromObjectOptions, LoadOptions, SeverityOverridable, Tool, ALL_RULES_KEY, CONFIG_PATH, MISNAMED_CONFIG_PATHS};
 
 pub use config_schema::{
-  EngineConfig, FilesConfig, FormatterConfig, Framework, HerbConfig, HerbConfigOptions, LinterConfig, RewriterConfig, RuleConfig, TemplateEngine,
+  EngineConfig, FilesConfig, FormatterConfig, Framework, HerbConfig, HerbConfigOptions, IndentType, LinterConfig, RewriterConfig, RuleConfig,
+  TemplateEngine,
 };
 
 pub use defaults::DEFAULT_VERSION;

--- a/rust/herb-config/src/lib.rs
+++ b/rust/herb-config/src/lib.rs
@@ -14,8 +14,7 @@ mod severity;
 pub use config::{Config, FoundConfigFile, FromObjectOptions, LoadOptions, SeverityOverridable, Tool, ALL_RULES_KEY, CONFIG_PATH, MISNAMED_CONFIG_PATHS};
 
 pub use config_schema::{
-  EngineConfig, FilesConfig, FormatterConfig, Framework, HerbConfig, HerbConfigOptions, IndentType, LinterConfig, RewriterConfig, RuleConfig,
-  TemplateEngine,
+  EngineConfig, FilesConfig, FormatterConfig, Framework, HerbConfig, HerbConfigOptions, IndentType, LinterConfig, RewriterConfig, RuleConfig, TemplateEngine,
 };
 
 pub use defaults::DEFAULT_VERSION;

--- a/rust/herb-config/tests/config_test.rs
+++ b/rust/herb-config/tests/config_test.rs
@@ -1,7 +1,7 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use herb_config::{Config, HerbConfig, HerbConfigOptions, LinterMode, Severity, SeverityConfig, SeverityOverridable, Tool};
+use herb_config::{Config, HerbConfig, HerbConfigOptions, IndentType, LinterMode, Severity, SeverityConfig, SeverityOverridable, Tool};
 
 fn default_include_patterns() -> Vec<String> {
   Config::get_default_file_patterns()
@@ -199,6 +199,13 @@ mod config_from_object {
 
     assert!(config.is_formatter_enabled());
     assert_eq!(config.formatter().unwrap().indent_width, Some(4));
+  }
+
+  #[test]
+  fn creates_config_with_indent_type_tabs() {
+    let config = config_from_yaml("formatter:\n  indentType: tabs\n");
+
+    assert_eq!(config.formatter().unwrap().indent_type, Some(IndentType::Tabs));
   }
 
   #[test]

--- a/rust/herb-config/tests/config_test.rs
+++ b/rust/herb-config/tests/config_test.rs
@@ -202,10 +202,10 @@ mod config_from_object {
   }
 
   #[test]
-  fn creates_config_with_indent_style_tabs() {
-    let config = config_from_yaml("formatter:\n  indentStyle: tabs\n");
+  fn creates_config_with_indent_style_tab() {
+    let config = config_from_yaml("formatter:\n  indentStyle: tab\n");
 
-    assert_eq!(config.formatter().unwrap().indent_style, Some(IndentStyle::Tabs));
+    assert_eq!(config.formatter().unwrap().indent_style, Some(IndentStyle::Tab));
   }
 
   #[test]

--- a/rust/herb-config/tests/config_test.rs
+++ b/rust/herb-config/tests/config_test.rs
@@ -1,7 +1,7 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use herb_config::{Config, HerbConfig, HerbConfigOptions, IndentType, LinterMode, Severity, SeverityConfig, SeverityOverridable, Tool};
+use herb_config::{Config, HerbConfig, HerbConfigOptions, IndentStyle, LinterMode, Severity, SeverityConfig, SeverityOverridable, Tool};
 
 fn default_include_patterns() -> Vec<String> {
   Config::get_default_file_patterns()
@@ -202,10 +202,10 @@ mod config_from_object {
   }
 
   #[test]
-  fn creates_config_with_indent_type_tabs() {
-    let config = config_from_yaml("formatter:\n  indentType: tabs\n");
+  fn creates_config_with_indent_style_tabs() {
+    let config = config_from_yaml("formatter:\n  indentStyle: tabs\n");
 
-    assert_eq!(config.formatter().unwrap().indent_type, Some(IndentType::Tabs));
+    assert_eq!(config.formatter().unwrap().indent_style, Some(IndentStyle::Tabs));
   }
 
   #[test]

--- a/rust/herb-config/tests/defaults_test.rs
+++ b/rust/herb-config/tests/defaults_test.rs
@@ -27,7 +27,7 @@ fn default_config_has_default_formatter_settings() {
   let formatter = config.formatter().unwrap();
 
   assert_eq!(formatter.indent_width, Some(2));
-  assert_eq!(formatter.indent_style, Some(IndentStyle::Spaces));
+  assert_eq!(formatter.indent_style, Some(IndentStyle::Space));
   assert_eq!(formatter.max_line_length, Some(80));
 }
 

--- a/rust/herb-config/tests/defaults_test.rs
+++ b/rust/herb-config/tests/defaults_test.rs
@@ -1,7 +1,7 @@
 use std::fs;
 use std::path::Path;
 
-use herb_config::{Config, HerbConfigOptions, IndentType, Severity, Tool};
+use herb_config::{Config, HerbConfigOptions, IndentStyle, Severity, Tool};
 
 fn config_from_yaml(yaml: &str) -> Config {
   let options: HerbConfigOptions = serde_yaml::from_str(yaml).unwrap();
@@ -27,7 +27,7 @@ fn default_config_has_default_formatter_settings() {
   let formatter = config.formatter().unwrap();
 
   assert_eq!(formatter.indent_width, Some(2));
-  assert_eq!(formatter.indent_type, Some(IndentType::Spaces));
+  assert_eq!(formatter.indent_style, Some(IndentStyle::Spaces));
   assert_eq!(formatter.max_line_length, Some(80));
 }
 

--- a/rust/herb-config/tests/defaults_test.rs
+++ b/rust/herb-config/tests/defaults_test.rs
@@ -1,7 +1,7 @@
 use std::fs;
 use std::path::Path;
 
-use herb_config::{Config, HerbConfigOptions, Severity, Tool};
+use herb_config::{Config, HerbConfigOptions, IndentType, Severity, Tool};
 
 fn config_from_yaml(yaml: &str) -> Config {
   let options: HerbConfigOptions = serde_yaml::from_str(yaml).unwrap();
@@ -27,6 +27,7 @@ fn default_config_has_default_formatter_settings() {
   let formatter = config.formatter().unwrap();
 
   assert_eq!(formatter.indent_width, Some(2));
+  assert_eq!(formatter.indent_type, Some(IndentType::Spaces));
   assert_eq!(formatter.max_line_length, Some(80));
 }
 


### PR DESCRIPTION
Added a `formatter.indentStyle` config option (`"space"`, the default, or `"tab"`) that the `source-indentation` rule uses to decide which character to flag and which one autofix writes.

Resolves #159