### PR TITLE
JavaScript: Fix missing nx build dependencies and remove dead targets

### DIFF
--- a/docs/project.json
+++ b/docs/project.json
@@ -22,12 +22,6 @@
       "options": {
         "script": "preview"
       }
-    },
-    "serve": {
-      "executor": "nx:run-script",
-      "options": {
-        "script": "serve"
-      }
     }
   },
   "tags": []

--- a/javascript/packages/language-server/project.json
+++ b/javascript/packages/language-server/project.json
@@ -12,6 +12,7 @@
       "dependsOn": [
         "@herb-tools/config:build",
         "@herb-tools/core:build",
+        "@herb-tools/formatter:build",
         "@herb-tools/linter:build",
         "@herb-tools/node-wasm:build",
         "@herb-tools/node:build",

--- a/javascript/packages/linter/project.json
+++ b/javascript/packages/linter/project.json
@@ -14,6 +14,7 @@
         "@herb-tools/core:build",
         "@herb-tools/browser:build",
         "@herb-tools/highlighter:build",
+        "@herb-tools/node-wasm:build",
         "@herb-tools/printer:build",
         "@herb-tools/rewriter:build"
       ]

--- a/javascript/packages/tailwind-class-sorter/project.json
+++ b/javascript/packages/tailwind-class-sorter/project.json
@@ -22,12 +22,6 @@
         "script": "dev"
       }
     },
-    "format": {
-      "executor": "nx:run-script",
-      "options": {
-        "script": "format"
-      }
-    },
     "clean": {
       "executor": "nx:run-script",
       "options": {


### PR DESCRIPTION
This pull request adds two missing `dependsOn` edges to the nx project graph and removes two targets that point at scripts which no longer exist.

Follow up on #2056