### PR TITLE
JavaScript: Declare workspace dependencies that packages import

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@herb-tools/browser": "0.10.3",
     "@herb-tools/core": "0.10.3",
+    "@herb-tools/linter": "0.10.3",
     "@herb-tools/node": "0.10.3",
     "medium-zoom": "^1.1.0"
   },

--- a/javascript/packages/formatter/package.json
+++ b/javascript/packages/formatter/package.json
@@ -37,6 +37,8 @@
   "dependencies": {
     "@herb-tools/config": "0.10.3",
     "@herb-tools/core": "0.10.3",
+    "@herb-tools/highlighter": "0.10.3",
+    "@herb-tools/node-wasm": "0.10.3",
     "@herb-tools/printer": "0.10.3",
     "@herb-tools/rewriter": "0.10.3",
     "@ruby/prism": "^1.9.0",

--- a/javascript/packages/formatter/project.json
+++ b/javascript/packages/formatter/project.json
@@ -12,6 +12,7 @@
       "dependsOn": [
         "@herb-tools/config:build",
         "@herb-tools/core:build",
+        "@herb-tools/highlighter:build",
         "@herb-tools/node-wasm:build",
         "@herb-tools/printer:build",
         "@herb-tools/rewriter:build"

--- a/javascript/packages/language-server/package.json
+++ b/javascript/packages/language-server/package.json
@@ -46,6 +46,7 @@
   ],
   "dependencies": {
     "@herb-tools/config": "0.10.3",
+    "@herb-tools/core": "0.10.3",
     "@herb-tools/formatter": "0.10.3",
     "@herb-tools/linter": "0.10.3",
     "@herb-tools/node-wasm": "0.10.3",

--- a/javascript/packages/printer/package.json
+++ b/javascript/packages/printer/package.json
@@ -37,7 +37,9 @@
     "prepublishOnly": "yarn clean && yarn build && yarn test"
   },
   "dependencies": {
+    "@herb-tools/config": "0.10.3",
     "@herb-tools/core": "0.10.3",
+    "@herb-tools/node-wasm": "0.10.3",
     "tinyglobby": "^0.2.15"
   },
   "files": [

--- a/javascript/packages/printer/project.json
+++ b/javascript/packages/printer/project.json
@@ -10,6 +10,7 @@
         "script": "build"
       },
       "dependsOn": [
+        "@herb-tools/config:build",
         "@herb-tools/core:build",
         "@herb-tools/node-wasm:build"
       ]


### PR DESCRIPTION
Follow up on #2116, which fixed the nx build graph. This pull request fixes the matching gap in the package manifests, where four projects import `@herb-tools` packages that they never declare as dependencies.

These imports resolve today only because yarn hoists every workspace package into the root `node_modules`. Nothing in the manifests says they are needed.