### PR TITLE
Language Server: Pass the partial caller index to cross-file linter rules

### DIFF
--- a/javascript/packages/language-server/src/autofix_service.ts
+++ b/javascript/packages/language-server/src/autofix_service.ts
@@ -7,15 +7,18 @@ import { Config } from "@herb-tools/config"
 
 import { getFullDocumentRange } from "./range_utils"
 import { PartialIndexService } from "./partial_index_service"
+import { PartialCallerIndexService } from "./partial_caller_index_service"
 
 export class AutofixService {
   private connection: Connection
   private linter: Linter
   private partialIndexService?: PartialIndexService
+  private partialCallerIndexService?: PartialCallerIndexService
 
-  constructor(connection: Connection, config?: Config, partialIndexService?: PartialIndexService) {
+  constructor(connection: Connection, config?: Config, partialIndexService?: PartialIndexService, partialCallerIndexService?: PartialCallerIndexService) {
     this.connection = connection
     this.partialIndexService = partialIndexService
+    this.partialCallerIndexService = partialCallerIndexService
     this.linter = this.buildLinter(config)
   }
 
@@ -31,6 +34,7 @@ export class AutofixService {
     return {
       fileName: this.partialIndexService?.relativePathFor(uri) ?? uri,
       partials: this.partialIndexService?.index,
+      partialCallers: this.partialCallerIndexService?.index,
     }
   }
 

--- a/javascript/packages/language-server/src/code_action_service.ts
+++ b/javascript/packages/language-server/src/code_action_service.ts
@@ -4,6 +4,7 @@ import { TextDocument } from "vscode-languageserver-textdocument"
 import { Config } from "@herb-tools/config"
 import { Project } from "./project"
 import { PartialIndexService } from "./partial_index_service"
+import { PartialCallerIndexService } from "./partial_caller_index_service"
 import { Herb } from "@herb-tools/node-wasm"
 import { Linter } from "@herb-tools/linter"
 
@@ -14,13 +15,15 @@ import type { LintOffense } from "@herb-tools/linter"
 export class CodeActionService {
   private project: Project
   private partialIndexService?: PartialIndexService
+  private partialCallerIndexService?: PartialCallerIndexService
   private config?: Config
   private linter: Linter
 
-  constructor(project: Project, config?: Config, partialIndexService?: PartialIndexService) {
+  constructor(project: Project, config?: Config, partialIndexService?: PartialIndexService, partialCallerIndexService?: PartialCallerIndexService) {
     this.project = project
     this.config = config
     this.partialIndexService = partialIndexService
+    this.partialCallerIndexService = partialCallerIndexService
     this.linter = Linter.from(Herb, config)
   }
 
@@ -90,6 +93,7 @@ export class CodeActionService {
     const lintResult = this.linter.lint(text, {
       fileName: this.partialIndexService?.relativePathFor(document.uri) ?? document.uri,
       partials: this.partialIndexService?.index,
+      partialCallers: this.partialCallerIndexService?.index,
     })
     const offenses = lintResult.offenses
 

--- a/javascript/packages/language-server/src/linter_service.ts
+++ b/javascript/packages/language-server/src/linter_service.ts
@@ -9,6 +9,7 @@ import { Config } from "@herb-tools/config"
 import { Settings } from "./settings"
 import { Project } from "./project"
 import { PartialIndexService } from "./partial_index_service"
+import { PartialCallerIndexService } from "./partial_caller_index_service"
 import { isConfigDocument, lintToDignosticSeverity, lintToDignosticTags } from "./utils"
 import { lspRangeFromLocation } from "./range_utils"
 
@@ -23,6 +24,7 @@ export class LinterService {
   private readonly settings: Settings
   private readonly project: Project
   private readonly partialIndexService: PartialIndexService
+  private readonly partialCallerIndexService?: PartialCallerIndexService
   private readonly source = "Herb Linter "
   private linter?: Linter
   private allRules: RuleClass[] = rules
@@ -31,11 +33,12 @@ export class LinterService {
   private hasShownCustomRuleWarning = false
   private customRulePaths: Map<string, string> = new Map()
 
-  constructor(connection: Connection, settings: Settings, project: Project, partialIndexService: PartialIndexService) {
+  constructor(connection: Connection, settings: Settings, project: Project, partialIndexService: PartialIndexService, partialCallerIndexService?: PartialCallerIndexService) {
     this.connection = connection
     this.settings = settings
     this.project = project
     this.partialIndexService = partialIndexService
+    this.partialCallerIndexService = partialCallerIndexService
   }
 
   /**
@@ -178,6 +181,7 @@ export class LinterService {
     const lintResult = this.linter.lint(content, {
       fileName: this.partialIndexService.relativePathFor(textDocument.uri) ?? textDocument.uri,
       partials: this.partialIndexService.index,
+      partialCallers: this.partialCallerIndexService?.index,
     })
 
     const diagnostics: Diagnostic[] = lintResult.offenses.map(offense => {

--- a/javascript/packages/language-server/src/server.ts
+++ b/javascript/packages/language-server/src/server.ts
@@ -294,10 +294,11 @@ export class Server {
     const callers = this.service.partialCallerIndexService
 
     if (event.type === FileChangeType.Deleted) {
-      callers.remove(event.uri)
+      const stoppedCalling = callers.remove(event.uri)
+
       this.service.diagnostics.clear(event.uri)
 
-      return partials.remove(event.uri)
+      return partials.remove(event.uri) || stoppedCalling
     }
 
     const isOpen = this.service.documentService.get(event.uri) !== undefined
@@ -305,8 +306,12 @@ export class Server {
 
     if (event.type === FileChangeType.Created && isPartialPath(event.uri)) {
       await callers.initialize()
-    } else if (!isOpen) {
-      callers.updateFromDisk(event.uri)
+
+      return true
+    }
+
+    if (!isOpen) {
+      return callers.updateFromDisk(event.uri) || changed
     }
 
     return changed

--- a/javascript/packages/language-server/src/service.ts
+++ b/javascript/packages/language-server/src/service.ts
@@ -61,11 +61,11 @@ export class Service {
     this.parserService = new ParserService()
     this.partialIndexService = new PartialIndexService(this.connection, this.project)
     this.partialCallerIndexService = new PartialCallerIndexService(this.connection, this.project, this.partialIndexService)
-    this.linterService = new LinterService(this.connection, this.settings, this.project, this.partialIndexService)
+    this.linterService = new LinterService(this.connection, this.settings, this.project, this.partialIndexService, this.partialCallerIndexService)
     this.formattingService = new FormattingService(this.connection, this.documentService.documents, this.project, this.settings)
-    this.autofixService = new AutofixService(this.connection, this.config, this.partialIndexService)
+    this.autofixService = new AutofixService(this.connection, this.config, this.partialIndexService, this.partialCallerIndexService)
     this.configService = new ConfigService(this.project.projectPath)
-    this.codeActionService = new CodeActionService(this.project, this.config, this.partialIndexService)
+    this.codeActionService = new CodeActionService(this.project, this.config, this.partialIndexService, this.partialCallerIndexService)
     this.diagnostics = new Diagnostics(this.connection, this.documentService, this.parserService, this.linterService, this.configService, this.settings)
     this.documentSaveService = new DocumentSaveService(this.connection, this.settings, this.autofixService, this.formattingService)
     this.foldingRangeService = new FoldingRangeService(this.parserService)
@@ -127,9 +127,10 @@ export class Service {
     })
 
     this.documentService.onDidChangeContent(async (change) => {
-      this.partialCallerIndexService.updateFromSource(change.document.uri, change.document.getText())
+      const callersChanged = this.partialCallerIndexService.updateFromSource(change.document.uri, change.document.getText())
+      const partialsChanged = this.partialIndexService.updateFromSource(change.document.uri, change.document.getText())
 
-      if (this.partialIndexService.updateFromSource(change.document.uri, change.document.getText())) {
+      if (callersChanged || partialsChanged) {
         await this.diagnostics.refreshAllDocuments()
 
         return

--- a/javascript/packages/language-server/test/linter_service.test.ts
+++ b/javascript/packages/language-server/test/linter_service.test.ts
@@ -6,6 +6,8 @@ import { LinterService } from "../src/linter_service"
 import { Settings } from "../src/settings"
 import { Project } from "../src/project"
 import { PartialIndexService } from "../src/partial_index_service"
+import { PartialCallerIndexService } from "../src/partial_caller_index_service"
+import { PartialCallerIndex } from "@herb-tools/core"
 import { Herb } from "@herb-tools/node-wasm"
 import { Config } from "@herb-tools/config"
 
@@ -256,6 +258,56 @@ describe("LinterService", () => {
       )
 
       expect(lowercaseDiagnostics).toHaveLength(0)
+    })
+  })
+
+  describe("cross-file rules", () => {
+    const PARTIAL = "app/views/shared/_meta.html.erb"
+
+    function callerServiceFor(callers: PartialCallerIndex): PartialCallerIndexService {
+      const service = new PartialCallerIndexService(mockConnection, mockProject, partialIndexService)
+
+      vi.spyOn(service, "index", "get").mockReturnValue(callers)
+
+      return service
+    }
+
+    function settingsWithLinter() {
+      const settings = new Settings(mockParams, mockConnection)
+
+      settings.getDocumentSettings = vi.fn().mockResolvedValue({ linter: { enabled: true } })
+
+      return settings
+    }
+
+    test("reports an offense that only the call sites can justify", async () => {
+      const callers = new PartialCallerIndex(
+        new Map([[PARTIAL, [{ caller: "app/views/layouts/application.html.erb", locals: [], ancestors: ["html", "body"] }]]]),
+        new Set(["app/views/layouts/application.html.erb"]),
+        new Map(),
+        new Set()
+      )
+
+      const service = new LinterService(mockConnection, settingsWithLinter(), mockProject, partialIndexService, callerServiceFor(callers))
+
+      vi.spyOn(partialIndexService, "relativePathFor").mockReturnValue(PARTIAL)
+
+      const document = TextDocument.create(`file:///${PARTIAL}`, "erb", 1, `<meta charset="UTF-8">`)
+      const result = await service.lintDocument(document)
+
+      expect(result.diagnostics.some(diagnostic => diagnostic.code === "html-head-only-elements")).toBe(true)
+    })
+
+    test("stays silent for the same partial when no call site is known", async () => {
+      const empty = new PartialCallerIndex(new Map(), new Set(), new Map(), new Set())
+      const service = new LinterService(mockConnection, settingsWithLinter(), mockProject, partialIndexService, callerServiceFor(empty))
+
+      vi.spyOn(partialIndexService, "relativePathFor").mockReturnValue(PARTIAL)
+
+      const document = TextDocument.create(`file:///${PARTIAL}`, "erb", 1, `<meta charset="UTF-8">`)
+      const result = await service.lintDocument(document)
+
+      expect(result.diagnostics.some(diagnostic => diagnostic.code === "html-head-only-elements")).toBe(false)
     })
   })
 })


### PR DESCRIPTION
Multiple linter rules ask where a file is rendered before deciding whether to report. All of them reach `partialCallers` on the lint context, and the Linter CLI supplies it.

The Language Server does not. It builds the caller index and keeps it current, but that was wired up for `textDocument/references` in #2106, and none of the three places it lints ever passed the index along.

So every cross-file rule silently degrades in the editor. `contextOf` is never consulted, the ancestor verdict comes back `unknown`, and the offense simply does not appear. The strict locals autofix loses the call site half of its inference and falls back to the partial's own body. 

This pull request passes `partialCallers` in all three lint contexts, for diagnostics, code actions, and fix on save.

Follow up on #2095, #2103 and #2106.