### PR TITLE
Docs: Add Nova editor integration page

### DIFF
--- a/docs/.vitepress/config/theme.mts
+++ b/docs/.vitepress/config/theme.mts
@@ -53,6 +53,7 @@ const defaultSidebar = [
       { text: "Cursor", link: "/integrations/editors/cursor" },
       { text: "Helix", link: "/integrations/editors/helix" },
       { text: "Neovim", link: "/integrations/editors/neovim" },
+      { text: "Nova", link: "/integrations/editors/nova" },
       { text: "RubyMine", link: "/integrations/editors/rubymine" },
       { text: "Sublime Text", link: "/integrations/editors/sublime" },
       { text: "Vim", link: "/integrations/editors/vim" },

--- a/docs/docs/integrations/editors.md
+++ b/docs/docs/integrations/editors.md
@@ -16,6 +16,7 @@ The Herb Language Server provides intelligent language features for HTML+ERB fil
 - **[Cursor](/integrations/editors/cursor)** - Available through the Open VSX Registry
 - **[Helix](/integrations/editors/helix)** - Terminal-based modal editor with built-in LSP support
 - **[Neovim](/integrations/editors/neovim)** - LSP configuration with multiple setup options
+- **[Nova](/integrations/editors/nova)** - Community plugin available in the Nova Extension Library
 - **[Sublime Text](/integrations/editors/sublime)** - LSP configuration using Sublime LSP
 - **[Vim](/integrations/editors/vim)** - Traditional Vim integration
 - **[Visual Studio Code](/integrations/editors/vscode)** - Full-featured extension available on the Visual Studio Marketplace

--- a/docs/docs/integrations/editors/nova.md
+++ b/docs/docs/integrations/editors/nova.md
@@ -1,0 +1,78 @@
+---
+title: Using Herb with Nova
+---
+
+# {{ $frontmatter.title }}
+
+Use the Herb Language Server in [Nova](https://nova.app) via the [Herb LSP extension](https://extensions.panic.com/extensions/com.freelancing-gods/com.freelancing-gods.herb-lsp/).
+
+::: info Community Plugin
+The Nova extension is a community plugin built and maintained by [Pat Allan](https://github.com/pat). It is developed at [pat/herb-lsp.novaextension](https://github.com/pat/herb-lsp.novaextension) and is not part of the Herb project.
+:::
+
+## Installation
+
+First, install the Herb Language Server (v0.4.3 or newer) globally:
+
+:::code-group
+
+```bash [npm]
+npm install -g @herb-tools/language-server
+```
+
+```bash [yarn 1]
+yarn global add @herb-tools/language-server
+```
+
+```bash [yarn 4]
+yarn dlx -q @herb-tools/language-server --stdio
+```
+
+```bash [pnpm]
+pnpm add -g @herb-tools/language-server
+```
+
+```bash [bun]
+bun add -g @herb-tools/language-server
+```
+:::
+
+Then install the **Herb LSP** extension in Nova. Open **Extensions → Extension Library...**, search for "Herb LSP", and install it. Alternatively, install it directly from the [Nova Extension Library](https://extensions.panic.com/extensions/com.freelancing-gods/com.freelancing-gods.herb-lsp/).
+
+## Configuration
+
+The extension works out of the box once the `herb-language-server` executable is found. Two settings are available, both at a global level and at a per-project level.
+
+- Additional `PATH` directories, so the extension can reliably detect the `herb-language-server` executable
+- Auto-formatting of ERB files when they're saved
+
+To configure global preferences, open **Extensions → Extension Library...** and select the **Preferences** tab of the Herb LSP extension. Per-project preferences are available under **Project → Project Settings...**.
+
+If you use a version manager like `mise`, `asdf`, or `nvm`, add the directory containing the `herb-language-server` executable (or its shims) to the extension's `PATH` setting. For example, with `mise`:
+
+```
+/Users/[username]/.local/share/mise/shims
+```
+
+## Troubleshooting
+
+Ensure the language server is installed and in your PATH:
+
+```bash
+which herb-language-server
+```
+
+If the executable can't be found, add its directory to the extension's `PATH` setting as described above.
+
+If the language server crashes or stops responding, run the `Restart Herb LSP` command from Nova's command palette.
+
+## Other editors
+
+If you are looking to use Herb in another editor, check out the instructions on the [editor integrations page](/integrations/editors).
+
+## Resources
+
+- [Herb LSP extension in the Nova Extension Library](https://extensions.panic.com/extensions/com.freelancing-gods/com.freelancing-gods.herb-lsp/)
+- [Extension source on GitHub](https://github.com/pat/herb-lsp.novaextension)
+- [Report extension-specific issues](https://github.com/pat/herb-lsp.novaextension/issues)
+- [Report Herb-specific issues](https://github.com/marcoroth/herb/issues)

--- a/javascript/packages/language-server/README.md
+++ b/javascript/packages/language-server/README.md
@@ -33,6 +33,10 @@ require('lspconfig')
 vim.lsp.enable('herb_ls')
 ```
 
+#### Nova
+
+After installing the Herb Language Server (see below), install the [Herb LSP extension](https://extensions.panic.com/extensions/com.freelancing-gods/com.freelancing-gods.herb-lsp/) from the Nova Extension Library. The extension is a community plugin maintained at [pat/herb-lsp.novaextension](https://github.com/pat/herb-lsp.novaextension).
+
 #### Sublime Text (using Sublime LSP)
 
 After installing the Herb Language Server (see below) and [Sublime LSP](http://lsp.sublimetext.io), update the preferences for the `LSP` package:


### PR DESCRIPTION
This pull request adds an editor integration page for [Nova](https://nova.app), so it sits alongside the existing pages for VS Code, Zed, Neovim, Sublime Text and the others on [herb-tools.dev/integrations/editors](https://herb-tools.dev/integrations/editors).

Nova support comes from the [Herb LSP extension](https://extensions.panic.com/extensions/com.freelancing-gods/com.freelancing-gods.herb-lsp/), a community plugin built and maintained by [Pat Allan](https://github.com/pat) at [pat/herb-lsp.novaextension](https://github.com/pat/herb-lsp.novaextension)

Resolves https://github.com/marcoroth/herb/issues/318
