### PR TITLE
Formatter: Allow two blank lines as an intentional wider break

### DIFF
--- a/javascript/packages/formatter/src/format-helpers.ts
+++ b/javascript/packages/formatter/src/format-helpers.ts
@@ -303,6 +303,32 @@ export function shouldPreserveUserSpacing(child: Node, siblings: Node[], index: 
   return hasPreviousNonWhitespace && hasNextNonWhitespace && hasMultipleNewlines
 }
 
+/**
+ * Count the blank lines represented by a run of consecutive newlines.
+ * The longest newline run in the content determines the count. Two
+ * newlines separate two lines with one blank line between them.
+ */
+export function countBlankLines(content: string): number {
+  let longestRun = 0
+
+  for (const run of content.match(/\n+/g) || []) {
+    if (run.length > longestRun) longestRun = run.length
+  }
+
+  return Math.max(0, longestRun - 1)
+}
+
+/**
+ * Map a user-authored blank line count to the count the formatter emits.
+ * A single blank line passes through, exactly two are kept as an
+ * intentional wider break, and anything larger collapses back to one.
+ */
+export function normalizeBlankLineCount(count: number): number {
+  if (count === 2) return 2
+
+  return count > 0 ? 1 : 0
+}
+
 
 /**
  * Check if children contain any text content with newlines

--- a/javascript/packages/formatter/src/format-printer.ts
+++ b/javascript/packages/formatter/src/format-printer.ts
@@ -52,6 +52,8 @@ import {
   isNonWhitespaceNode,
   shouldAppendToLastLine,
   shouldPreserveUserSpacing,
+  countBlankLines,
+  normalizeBlankLineCount,
 } from "./format-helpers.js"
 
 import {
@@ -827,7 +829,12 @@ export class FormatPrinter extends Printer implements TextFlowDelegate, Attribut
       const child = body[index]
 
       if (shouldPreserveUserSpacing(child, body, index)) {
-        this.push("")
+        const blankLines = isNode(child, HTMLTextNode) ? normalizeBlankLineCount(countBlankLines(child.content)) : 1
+
+        for (let blankLine = 0; blankLine < blankLines; blankLine++) {
+          this.push("")
+        }
+
         hasHandledSpacing = true
         continue
       }
@@ -877,9 +884,9 @@ export class FormatPrinter extends Printer implements TextFlowDelegate, Attribut
     if (!run) return null
 
     if (lastMeaningfulNode && !hasHandledSpacing) {
-      const hasBlankLineBefore = this.spacingAnalyzer.hasBlankLineBetween(body, index)
+      const blankLinesBefore = normalizeBlankLineCount(this.spacingAnalyzer.blankLinesBetween(body, index))
 
-      if (hasBlankLineBefore) {
+      for (let blankLine = 0; blankLine < blankLinesBefore; blankLine++) {
         this.push("")
       }
     }
@@ -887,17 +894,17 @@ export class FormatPrinter extends Printer implements TextFlowDelegate, Attribut
     this.textFlow.visitTextFlowChildren(run.nodes)
 
     const lastRunNode = run.nodes[run.nodes.length - 1]
-    const hasBlankLineInTrailing = isNode(lastRunNode, HTMLTextNode) && lastRunNode.content.includes('\n\n')
-    const hasBlankLineAfter = hasBlankLineInTrailing || this.spacingAnalyzer.hasBlankLineBetween(body, run.endIndex)
+    const blankLinesInTrailing = isNode(lastRunNode, HTMLTextNode) ? countBlankLines(lastRunNode.content) : 0
+    const blankLinesAfter = normalizeBlankLineCount(Math.max(blankLinesInTrailing, this.spacingAnalyzer.blankLinesBetween(body, run.endIndex)))
 
-    if (hasBlankLineAfter) {
+    for (let blankLine = 0; blankLine < blankLinesAfter; blankLine++) {
       this.push("")
     }
 
     return {
       newIndex: run.endIndex - 1,
       lastMeaningfulNode: run.nodes[run.nodes.length - 1],
-      hasHandledSpacing: hasBlankLineAfter,
+      hasHandledSpacing: blankLinesAfter > 0,
     }
   }
 

--- a/javascript/packages/formatter/src/spacing-analyzer.ts
+++ b/javascript/packages/formatter/src/spacing-analyzer.ts
@@ -1,6 +1,6 @@
 import { Node, HTMLTextNode, HTMLElementNode, HTMLDoctypeNode, ERBContentNode, WhitespaceNode, XMLDeclarationNode } from "@herb-tools/core"
 import { isNode, getTagName, isERBNode, isERBOutputNode, isERBCommentNode, isCommentNode, isERBControlFlowNode } from "@herb-tools/core"
-import { findPreviousMeaningfulSibling, findNextMeaningfulSibling, isBlockLevelNode, isContentPreserving, isNonWhitespaceNode } from "./format-helpers.js"
+import { findPreviousMeaningfulSibling, findNextMeaningfulSibling, isBlockLevelNode, isContentPreserving, isNonWhitespaceNode, countBlankLines } from "./format-helpers.js"
 
 import { INLINE_ELEMENTS, SPACEABLE_CONTAINERS } from "./format-helpers.js"
 
@@ -125,11 +125,22 @@ export class SpacingAnalyzer {
    * Check if there's a blank line (double newline) in the nodes at the given index
    */
   hasBlankLineBetween(body: Node[], index: number): boolean {
+    return this.blankLinesBetween(body, index) > 0
+  }
+
+  /**
+   * Count the user-authored blank lines in the nodes at the given index
+   */
+  blankLinesBetween(body: Node[], index: number): number {
+    let count = 0
+
     for (let lookbackIndex = index - 1; lookbackIndex >= 0 && lookbackIndex >= index - 2; lookbackIndex--) {
       const node = body[lookbackIndex]
 
-      if (isNode(node, HTMLTextNode) && node.content.includes('\n\n')) {
-        return true
+      if (isNode(node, HTMLTextNode)) {
+        count = Math.max(count, countBlankLines(node.content))
+
+        break
       }
 
       if (isNode(node, WhitespaceNode)) {
@@ -142,8 +153,10 @@ export class SpacingAnalyzer {
     for (let lookaheadIndex = index; lookaheadIndex < body.length && lookaheadIndex <= index + 1; lookaheadIndex++) {
       const node = body[lookaheadIndex]
 
-      if (isNode(node, HTMLTextNode) && node.content.includes('\n\n')) {
-        return true
+      if (isNode(node, HTMLTextNode)) {
+        count = Math.max(count, countBlankLines(node.content))
+
+        break
       }
 
       if (isNode(node, WhitespaceNode)) {
@@ -153,7 +166,7 @@ export class SpacingAnalyzer {
       break
     }
 
-    return false
+    return count
   }
 
   /**

--- a/javascript/packages/formatter/test/blank-line-normalization.test.ts
+++ b/javascript/packages/formatter/test/blank-line-normalization.test.ts
@@ -1,0 +1,72 @@
+import { describe, test, expect, beforeAll } from "vitest"
+import { Herb } from "@herb-tools/node-wasm"
+import { Formatter } from "../src"
+
+let formatter: Formatter
+
+describe("Blank line normalization", () => {
+  beforeAll(async () => {
+    await Herb.load()
+
+    formatter = new Formatter(Herb, {
+      indentWidth: 2,
+      maxLineLength: 80
+    })
+  })
+
+  test("keeps a single blank line between elements", () => {
+    const source = `<div>\n  <p>First</p>\n\n  <p>Second</p>\n</div>`
+
+    expect(formatter.format(source)).toEqual(`<div>\n  <p>First</p>\n\n  <p>Second</p>\n</div>`)
+  })
+
+  test("keeps exactly two blank lines as an intentional wider break", () => {
+    const source = `<div>\n  <p>First</p>\n\n\n  <p>Second</p>\n</div>`
+
+    expect(formatter.format(source)).toEqual(`<div>\n  <p>First</p>\n\n\n  <p>Second</p>\n</div>`)
+  })
+
+  test("collapses three or more blank lines down to one", () => {
+    const source = `<div>\n  <p>First</p>\n\n\n\n  <p>Second</p>\n</div>`
+
+    expect(formatter.format(source)).toEqual(`<div>\n  <p>First</p>\n\n  <p>Second</p>\n</div>`)
+  })
+
+  test("collapses many blank lines down to one", () => {
+    const source = `<div>\n  <p>First</p>\n\n\n\n\n\n\n  <p>Second</p>\n</div>`
+
+    expect(formatter.format(source)).toEqual(`<div>\n  <p>First</p>\n\n  <p>Second</p>\n</div>`)
+  })
+
+  test("keeps two blank lines between top-level elements", () => {
+    const source = `<header>\n  <h1>Title</h1>\n</header>\n\n\n<main>\n  <p>Content</p>\n</main>`
+
+    expect(formatter.format(source)).toEqual(`<header>\n  <h1>Title</h1>\n</header>\n\n\n<main>\n  <p>Content</p>\n</main>`)
+  })
+
+  test("collapses three blank lines between top-level elements", () => {
+    const source = `<header>\n  <h1>Title</h1>\n</header>\n\n\n\n<main>\n  <p>Content</p>\n</main>`
+
+    expect(formatter.format(source)).toEqual(`<header>\n  <h1>Title</h1>\n</header>\n\n<main>\n  <p>Content</p>\n</main>`)
+  })
+
+  test("keeps two blank lines inside ERB control-flow bodies", () => {
+    const source = `<% if condition %>\n  <p>First</p>\n\n\n  <p>Second</p>\n<% end %>`
+
+    expect(formatter.format(source)).toEqual(`<% if condition %>\n  <p>First</p>\n\n\n  <p>Second</p>\n<% end %>`)
+  })
+
+  test("collapses excess blank lines inside ERB control-flow bodies", () => {
+    const source = `<% if condition %>\n  <p>First</p>\n\n\n\n\n  <p>Second</p>\n<% end %>`
+
+    expect(formatter.format(source)).toEqual(`<% if condition %>\n  <p>First</p>\n\n  <p>Second</p>\n<% end %>`)
+  })
+
+  test("two-blank-line output is idempotent", () => {
+    const source = `<div>\n  <p>First</p>\n\n\n  <p>Second</p>\n</div>`
+    const once = formatter.format(source)
+    const twice = formatter.format(once)
+
+    expect(twice).toEqual(once)
+  })
+})


### PR DESCRIPTION
This pull request updates the formatter to preserve exactly two blank lines between siblings, so authors can express a second, stronger separator inside large templates, while anything beyond two still collapses back to a single blank line.

Previously every run of blank lines was normalized to one. That kept spacing consistent, but it also meant there was no way to signal a major break between sections versus a minor break between elements. Since exactly two blank lines is something nobody types by accident, while three or more is usually leftover sprawl from deleting code, the two cases can be told apart and treated differently.


Given this input, where the author left two blank lines between the two sections:

```erb
<div>
  <p>First</p>


  <p>Second</p>
</div>
```

**Before** the formatter collapsed it to a single blank line:

```erb
<div>
  <p>First</p>

  <p>Second</p>
</div>
```

**After** the two blank lines survive:

```erb
<div>
  <p>First</p>


  <p>Second</p>
</div>
```

Anything beyond two blank lines still collapses down to one, so this input:

```erb
<div>
  <p>First</p>




  <p>Second</p>
</div>
```

still formats to:

```erb
<div>
  <p>First</p>

  <p>Second</p>
</div>
```

Related #261