### PR TITLE
Language Server: Implement Document Symbol Provider

### DIFF
--- a/javascript/packages/language-server/src/document_symbol_service.ts
+++ b/javascript/packages/language-server/src/document_symbol_service.ts
@@ -1,0 +1,164 @@
+import { Visitor } from "@herb-tools/core"
+import { ParserService } from "./parser_service"
+import { DocumentSymbol, SymbolKind } from "vscode-languageserver/node"
+
+import { getAttributes, getAttributeName, getStaticAttributeValue, getTagName, getTokenList } from "@herb-tools/core"
+import { nodeToRange, lspRangeFromLocation, erbTagToRange } from "./range_utils"
+
+import type { Range } from "vscode-languageserver/node"
+import type { TextDocument } from "vscode-languageserver-textdocument"
+import type { DocumentNode, ERBContentNode, ERBNode, ERBRenderNode, HTMLAttributeNode, HTMLElementNode, Node } from "@herb-tools/core"
+
+const PARSER_OPTIONS = { render_nodes: true, action_view_helpers: true } as const
+const UNNAMED_ELEMENT = "element"
+const QUOTE = /^["']|["']$/g
+const SEMANTIC_CLASS_LIMIT = 2
+const ERB_LABEL_LIMIT = 32
+
+class DocumentSymbolCollector extends Visitor {
+  readonly symbols: DocumentSymbol[] = []
+
+  private stack: DocumentSymbol[][] = [this.symbols]
+  private attributes = 0
+
+  visitHTMLElementNode(node: HTMLElementNode): void {
+    this.nest(this.symbolFor(this.elementName(node), SymbolKind.Field, nodeToRange(node), this.tagNameRange(node)), node)
+  }
+
+  visitERBRenderNode(node: ERBRenderNode): void {
+    this.nest(this.symbolFor(this.renderName(node), SymbolKind.Module, nodeToRange(node), null), node)
+  }
+
+  visitHTMLAttributeNode(node: HTMLAttributeNode): void {
+    const name = getAttributeName(node)
+
+    if (!name) return
+
+    this.attributes += 1
+
+    this.nest(this.symbolFor(`[${name}]`, SymbolKind.Property, nodeToRange(node), this.rangeOf(node.name)), node)
+
+    this.attributes -= 1
+  }
+
+  visitERBContentNode(node: ERBContentNode): void {
+    if (this.attributes === 0) {
+      this.visitChildNodes(node)
+
+      return
+    }
+
+    this.nest(this.symbolFor(this.erbLabel(node), SymbolKind.Variable, nodeToRange(node), erbTagToRange(node)), node)
+  }
+
+  visitERBIfNode(node: ERBNode): void { this.control(node) }
+  visitERBUnlessNode(node: ERBNode): void { this.control(node) }
+  visitERBElseNode(node: ERBNode): void { this.control(node) }
+  visitERBCaseNode(node: ERBNode): void { this.control(node) }
+  visitERBCaseMatchNode(node: ERBNode): void { this.control(node) }
+  visitERBWhenNode(node: ERBNode): void { this.control(node) }
+  visitERBInNode(node: ERBNode): void { this.control(node) }
+  visitERBBlockNode(node: ERBNode): void { this.control(node) }
+  visitERBIterationBlockNode(node: ERBNode): void { this.control(node) }
+  visitERBForNode(node: ERBNode): void { this.control(node) }
+  visitERBWhileNode(node: ERBNode): void { this.control(node) }
+  visitERBUntilNode(node: ERBNode): void { this.control(node) }
+  visitERBBeginNode(node: ERBNode): void { this.control(node) }
+  visitERBRescueNode(node: ERBNode): void { this.control(node) }
+  visitERBEnsureNode(node: ERBNode): void { this.control(node) }
+
+  private control(node: ERBNode): void {
+    const name = this.erbLabel(node)
+
+    if (!name) {
+      this.visitChildNodes(node)
+
+      return
+    }
+
+    const symbol = this.symbolFor(name, SymbolKind.Namespace, nodeToRange(node), erbTagToRange(node))
+    const subsequent = (node as { subsequent?: Node | null }).subsequent ?? null
+
+    this.stack.at(-1)!.push(symbol)
+    this.stack.push(symbol.children!)
+
+    for (const child of node.childNodes()) {
+      if (child && child !== subsequent) this.visit(child)
+    }
+
+    this.stack.pop()
+
+    if (subsequent) this.visit(subsequent)
+  }
+
+  private nest(symbol: DocumentSymbol, node: Node): void {
+    this.stack.at(-1)!.push(symbol)
+    this.stack.push(symbol.children!)
+
+    this.visitChildNodes(node)
+
+    this.stack.pop()
+  }
+
+  private symbolFor(name: string, kind: SymbolKind, range: Range, selectionRange: Range | null): DocumentSymbol {
+    return { name, kind, range, selectionRange: selectionRange ?? range, children: [] }
+  }
+
+  private erbLabel(node: ERBNode): string {
+    const content = (node.content?.value ?? "").trim()
+
+    return content.length > ERB_LABEL_LIMIT ? `${content.slice(0, ERB_LABEL_LIMIT)}…` : content
+  }
+
+  private rangeOf(node: Node | null): Range | null {
+    return node ? nodeToRange(node) : null
+  }
+
+  private tagNameRange(node: HTMLElementNode): Range | null {
+    const location = node.open_tag?.tag_name?.location
+
+    return location ? lspRangeFromLocation(location) : null
+  }
+
+  private elementName(node: HTMLElementNode): string {
+    const tag = getTagName(node) || UNNAMED_ELEMENT
+    const id = getStaticAttributeValue(node, "id")
+    const classes = this.classNames(node)
+    return `${tag}${id ? `#${id}` : ""}${classes.map(name => `.${name}`).join("")}`
+  }
+
+  private classNames(node: HTMLElementNode): string[] {
+    const attribute = getAttributes(node).find(candidate => getAttributeName(candidate) === "class")
+
+    if (!attribute) return []
+
+    const classes = getTokenList(getStaticAttributeValue(attribute))
+
+    return classes.length > SEMANTIC_CLASS_LIMIT ? [] : classes
+  }
+
+  private renderName(node: ERBRenderNode): string {
+    const rendered = node.keywords?.partial ?? node.keywords?.layout ?? node.keywords?.template_path
+
+    if (!rendered) return "render"
+
+    return `render ${rendered.value.replace(QUOTE, "")}`
+  }
+}
+
+export class DocumentSymbolService {
+  private parserService: ParserService
+
+  constructor(parserService: ParserService) {
+    this.parserService = parserService
+  }
+
+  getDocumentSymbols(document: TextDocument): DocumentSymbol[] {
+    const result = this.parserService.parseContent(document.getText(), PARSER_OPTIONS)
+    const collector = new DocumentSymbolCollector()
+
+    collector.visit(result.value as DocumentNode)
+
+    return collector.symbols
+  }
+}

--- a/javascript/packages/language-server/src/server.ts
+++ b/javascript/packages/language-server/src/server.ts
@@ -14,6 +14,7 @@ import {
   CodeActionKind,
   FoldingRangeParams,
   DocumentHighlightParams,
+  DocumentSymbolParams,
   HoverParams,
   CompletionParams,
   DefinitionParams,
@@ -81,6 +82,7 @@ export class Server {
           },
           definitionProvider: true,
           referencesProvider: true,
+          documentSymbolProvider: true,
         },
       }
 
@@ -262,6 +264,14 @@ export class Server {
       if (!document) return []
 
       return this.service.referencesService.getReferences(document, params.position, params.context.includeDeclaration)
+    })
+
+    this.connection.onDocumentSymbol((params: DocumentSymbolParams) => {
+      const document = this.service.documentService.get(params.textDocument.uri)
+
+      if (!document) return []
+
+      return this.service.documentSymbolService.getDocumentSymbols(document)
     })
 
     this.connection.onFoldingRanges((params: FoldingRangeParams) => {

--- a/javascript/packages/language-server/src/service.ts
+++ b/javascript/packages/language-server/src/service.ts
@@ -20,6 +20,7 @@ import { ExtractCodeActionService } from "./extract_code_action_service"
 import { DefinitionService } from "./definition_service"
 import { CommentService } from "./comment_service"
 import { CompletionService } from "./completion_service"
+import { DocumentSymbolService } from "./document_symbol_service"
 import { PartialIndexService } from "./partial_index_service"
 import { PartialCallerIndexService } from "./partial_caller_index_service"
 import { ReferencesService } from "./references_service"
@@ -52,6 +53,7 @@ export class Service {
   referencesService: ReferencesService
   commentService: CommentService
   completionService: CompletionService
+  documentSymbolService: DocumentSymbolService
 
   constructor(connection: Connection, params: InitializeParams) {
     this.connection = connection
@@ -75,6 +77,7 @@ export class Service {
     this.definitionService = new DefinitionService(this.parserService)
     this.referencesService = new ReferencesService(this.project, this.definitionService, this.partialIndexService, this.partialCallerIndexService, this.documentService)
     this.commentService = new CommentService(this.parserService)
+    this.documentSymbolService = new DocumentSymbolService(this.parserService)
     this.completionService = new CompletionService(this.parserService, this.partialIndexService)
 
     this.extractCodeActionService = new ExtractCodeActionService(this.parserService, {

--- a/javascript/packages/language-server/test/document_symbol_service.test.ts
+++ b/javascript/packages/language-server/test/document_symbol_service.test.ts
@@ -1,0 +1,305 @@
+import { describe, it, expect, beforeAll } from "vitest"
+
+import { SymbolKind } from "vscode-languageserver/node"
+import { TextDocument } from "vscode-languageserver-textdocument"
+
+import { Herb } from "@herb-tools/node-wasm"
+
+import { DocumentSymbolService } from "../src/document_symbol_service"
+import { ParserService } from "../src/parser_service"
+
+import type { DocumentSymbol } from "vscode-languageserver/node"
+
+describe("DocumentSymbolService", () => {
+  let service: DocumentSymbolService
+
+  beforeAll(async () => {
+    await Herb.load()
+
+    service = new DocumentSymbolService(new ParserService())
+  })
+
+  function symbols(content: string): DocumentSymbol[] {
+    return service.getDocumentSymbols(TextDocument.create("file:///test.html.erb", "erb", 1, content))
+  }
+
+  function outline(content: string): string[] {
+    const lines: string[] = []
+
+    const walk = (nodes: DocumentSymbol[], depth: number) => {
+      for (const node of nodes) {
+        lines.push(`${"  ".repeat(depth)}${node.name}`)
+
+        walk(node.children ?? [], depth + 1)
+      }
+    }
+
+    walk(symbols(content), 0)
+
+    return lines
+  }
+
+  it("returns nothing for a document without elements", () => {
+    expect(symbols("just some text\n")).toEqual([])
+  })
+
+  it("reports a single element", () => {
+    expect(outline("<div></div>")).toEqual(["div"])
+  })
+
+  it("nests elements", () => {
+    expect(outline("<div><span><a></a></span></div>")).toEqual(["div", "  span", "    a"])
+  })
+
+  it("keeps siblings flat", () => {
+    expect(outline("<div></div>\n<span></span>")).toEqual(["div", "span"])
+  })
+
+  it("qualifies an element by its id", () => {
+    expect(outline(`<div id="main"></div>`)).toEqual(["div#main", "  [id]"])
+  })
+
+  it("qualifies an element by its classes", () => {
+    expect(outline(`<div class="card featured"></div>`)).toEqual(["div.card.featured", "  [class]"])
+  })
+
+  it("combines the id and the classes", () => {
+    expect(outline(`<div id="main" class="card"></div>`)).toEqual(["div#main.card", "  [id]", "  [class]"])
+  })
+
+  it("drops utility classes rather than burying the name", () => {
+    const content = `<div class="flex items-center justify-between rounded-lg bg-white p-4"></div>`
+
+    expect(outline(content)).toEqual(["div", "  [class]"])
+  })
+
+  it("keeps the id when the classes are dropped", () => {
+    const content = `<div id="main" class="flex items-center justify-between p-4"></div>`
+
+    expect(outline(content)).toEqual(["div#main", "  [id]", "  [class]"])
+  })
+
+  it("keeps classes right up to the limit", () => {
+    expect(outline(`<div class="card featured"></div>`)).toEqual(["div.card.featured", "  [class]"])
+    expect(outline(`<div class="card featured wide"></div>`)).toEqual(["div", "  [class]"])
+  })
+
+  it("ignores an id it cannot read statically", () => {
+    expect(outline(`<div id="<%= dom_id(post) %>"></div>`)).toEqual(["div", "  [id]", "    dom_id(post)"])
+  })
+
+  it("reports a render call by the partial it renders", () => {
+    expect(outline(`<%= render partial: "posts/card" %>`)).toEqual([`render posts/card`])
+  })
+
+  it("reports a positional render call", () => {
+    expect(outline(`<%= render "posts/card" %>`)).toEqual([`render posts/card`])
+  })
+
+  it("reports a layout render", () => {
+    expect(outline(`<%= render layout: "shared/wrapper" do %><% end %>`)).toEqual([`render shared/wrapper`])
+  })
+
+  it("falls back to a bare name for a render it cannot read", () => {
+    expect(outline(`<%= render @post %>`)).toEqual(["render"])
+  })
+
+  it("nests a render inside the markup around it", () => {
+    const content = `<ul class="list">\n  <li><%= render "posts/card" %></li>\n</ul>`
+
+    expect(outline(content)).toEqual(["ul.list", "  [class]", "  li", "    render posts/card"])
+  })
+
+  it("uses Field for elements and Module for renders", () => {
+    const [element] = symbols(`<div><%= render "posts/card" %></div>`)
+
+    expect(element.kind).toBe(SymbolKind.Field)
+    expect(element.children![0].kind).toBe(SymbolKind.Module)
+  })
+
+  it("selects the tag name rather than the whole element", () => {
+    const content = `<div class="card">text</div>`
+    const [element] = symbols(content)
+    const document = TextDocument.create("file:///test.html.erb", "erb", 1, content)
+
+    expect(document.getText(element.selectionRange)).toBe("div")
+    expect(document.getText(element.range)).toBe(content)
+  })
+
+  it("spans the whole element including its children", () => {
+    const content = `<div>\n  <span></span>\n</div>`
+    const [element] = symbols(content)
+    const document = TextDocument.create("file:///test.html.erb", "erb", 1, content)
+
+    expect(document.getText(element.range)).toBe(content)
+  })
+
+  describe("attributes", () => {
+    it("reports an attribute under the element that carries it", () => {
+      expect(outline(`<div class="bg-white"></div>`)).toEqual(["div.bg-white", "  [class]"])
+    })
+
+    it("reports the ERB inside an attribute value", () => {
+      const content = `<div class="bg-white <%= class_names(a, b) %>"></div>`
+
+      expect(outline(content)).toEqual(["div", "  [class]", "    class_names(a, b)"])
+    })
+
+    it("reports every attribute in document order", () => {
+      const content = `<a href="/posts" class="link" data-turbo="false"></a>`
+
+      expect(outline(content)).toEqual(["a.link", "  [href]", "  [class]", "  [data-turbo]"])
+    })
+
+    it("keeps the attribute name out of the value", () => {
+      expect(outline(`<div data-controller="dropdown"></div>`)).toEqual(["div", "  [data-controller]"])
+    })
+
+    it("reports an attribute on a tag helper", () => {
+      expect(outline(`<%= tag.div data: { controller: "dropdown" } %>`)).toEqual(["div", "  [data-controller]"])
+    })
+
+    it("shortens a long ERB expression", () => {
+      const content = `<div class="<%= class_names(a_very_long_helper_call_name, and_another_one) %>"></div>`
+      const [, attribute] = outline(content)
+      const [erb] = outline(content).slice(2)
+
+      expect(attribute).toBe("  [class]")
+      expect(erb.length).toBeLessThan(45)
+      expect(erb).toContain("…")
+    })
+
+    it("selects the attribute name rather than the whole attribute", () => {
+      const content = `<div class="bg-white"></div>`
+      const [element] = symbols(content)
+      const [attribute] = element.children!
+      const document = TextDocument.create("file:///test.html.erb", "erb", 1, content)
+
+      expect(document.getText(attribute.selectionRange)).toBe("class")
+      expect(document.getText(attribute.range)).toBe(`class="bg-white"`)
+    })
+
+    it("uses Property for attributes and Variable for the ERB inside them", () => {
+      const [element] = symbols(`<div class="<%= x %>"></div>`)
+      const [attribute] = element.children!
+
+      expect(attribute.kind).toBe(SymbolKind.Property)
+      expect(attribute.children![0].kind).toBe(SymbolKind.Variable)
+    })
+
+    it("leaves ERB outside an attribute out of the tree", () => {
+      expect(outline(`<div><%= post.title %></div>`)).toEqual(["div"])
+    })
+  })
+
+  it("keeps a void element in the tree", () => {
+    expect(outline(`<div><img></div>`)).toEqual(["div", "  img"])
+  })
+
+  describe("Action View tag helpers", () => {
+    it("treats `tag.div` as an element", () => {
+      expect(outline(`<%= tag.div do %>x<% end %>`)).toEqual(["div"])
+    })
+
+    it("treats `content_tag` as an element", () => {
+      expect(outline(`<%= content_tag :section do %>x<% end %>`)).toEqual(["section"])
+    })
+
+    it("reads the classes off a tag helper", () => {
+      expect(outline(`<%= tag.div class: "card" %>`)).toEqual(["div.card", "  [class]"])
+    })
+
+    it("reads an id off a tag helper", () => {
+      expect(outline(`<%= content_tag :section, id: "main" do %>x<% end %>`)).toEqual(["section#main", "  [id]"])
+    })
+
+    it("nests markup inside a tag helper block", () => {
+      const content = `<%= tag.div class: "card" do %>\n  <span></span>\n<% end %>`
+
+      expect(outline(content)).toEqual(["div.card", "  [class]", "  span"])
+    })
+
+    it("nests a tag helper inside regular markup", () => {
+      const content = `<ul>\n  <%= tag.li class: "row" %>\n</ul>`
+
+      expect(outline(content)).toEqual(["ul", "  li.row", "    [class]"])
+    })
+
+    it("keeps a void tag helper in the tree", () => {
+      expect(outline(`<%= tag.br %>`)).toEqual(["br"])
+    })
+
+    it("drops utility classes from a tag helper too", () => {
+      expect(outline(`<%= tag.div class: "flex items-center p-4" %>`)).toEqual(["div", "  [class]"])
+    })
+  })
+
+  it("nests markup under the conditional that guards it", () => {
+    const content = `<% if signed_in? %>\n  <div></div>\n<% end %>`
+
+    expect(outline(content)).toEqual(["if signed_in?", "  div"])
+  })
+
+  it("reports each branch of a conditional", () => {
+    const content = `<% if a %>\n  <p></p>\n<% elsif b %>\n  <span></span>\n<% else %>\n  <em></em>\n<% end %>`
+
+    expect(outline(content)).toEqual([
+      "if a",
+      "  p",
+      "elsif b",
+      "  span",
+      "else",
+      "  em",
+    ])
+  })
+
+  it("reports an iteration block with its parameters", () => {
+    const content = `<% posts.each do |post| %>\n  <li></li>\n<% end %>`
+
+    expect(outline(content)).toEqual(["posts.each do |post|", "  li"])
+  })
+
+  it("reports a case with its branches", () => {
+    const content = `<% case status %>\n<% when :active %>\n  <b></b>\n<% else %>\n  <i></i>\n<% end %>`
+
+    expect(outline(content)).toEqual([
+      "case status",
+      "  when :active",
+      "    b",
+      "  else",
+      "    i",
+    ])
+  })
+
+  it("reports unless", () => {
+    expect(outline(`<% unless hidden? %>\n  <div></div>\n<% end %>`)).toEqual(["unless hidden?", "  div"])
+  })
+
+  it("reports begin and rescue", () => {
+    const content = `<% begin %>\n  <a></a>\n<% rescue => error %>\n  <b></b>\n<% end %>`
+
+    expect(outline(content)).toEqual(["begin", "  a", "  rescue => error", "    b"])
+  })
+
+  it("uses Namespace for control flow", () => {
+    const [conditional] = symbols(`<% if a %><div></div><% end %>`)
+
+    expect(conditional.kind).toBe(SymbolKind.Namespace)
+    expect(conditional.children![0].kind).toBe(SymbolKind.Field)
+  })
+
+  it("selects the ERB tag rather than the whole block", () => {
+    const content = `<% if signed_in? %>\n  <div></div>\n<% end %>`
+    const [conditional] = symbols(content)
+    const document = TextDocument.create("file:///test.html.erb", "erb", 1, content)
+
+    expect(document.getText(conditional.selectionRange)).toBe("<% if signed_in? %>")
+    expect(document.getText(conditional.range)).toBe(content)
+  })
+
+  it("nests a render inside the loop that repeats it", () => {
+    const content = `<% posts.each do |post| %>\n  <%= render "posts/card", post: post %>\n<% end %>`
+
+    expect(outline(content)).toEqual(["posts.each do |post|", "  render posts/card"])
+  })
+})


### PR DESCRIPTION
This pull request implements `textDocument/documentSymbol`, which fills the breadcrumb bar, the Outline view and Go to Symbol in File. Until now an ERB file showed nothing past its path.

```erb
<% posts.each do |post| %>              posts.each do |post|
  <li class="row">                      li.row
    <%= render "posts/card" %>          render posts/card
  </li>
<% end %>
```



Elements are named the way the HTML outline names them, so `div#main.card` reads the same as it does in a plain HTML file. 

Classes are only spelled out while there are at most two of them, since past that an element is wearing utility classes rather than a name and the breadcrumb turns into `div.flex.items-center.justify-between.rounded-lg.bg-white`. 

Render calls appear under the markup they sit in, named after the partial. Control flow appears as well, named after the Ruby that opens it, so a branch reads `elsif b` or `rescue => error`. Ruby nests `elsif` inside the preceding `if`, which indents a branch further for every condition in the chain, so the branches are flattened into siblings and a `case` and an `if` end up shaped the same way.

Tag helpers are parsed with `action_view_helpers`, which turns them into the same element nodes as literal markup. `<%= tag.div class: "card" %>` reports `div.card`, and `<%= tag.div data: { controller: "dropdown" } %>` reports `div[data-controller=dropdown]` because the parser resolves the nested hash into a real attribute.

<img width="3600" height="1862" alt="CleanShot 2026-08-09 at 16 40 32@2x" src="https://github.com/user-attachments/assets/e604e888-cfa4-4257-8f9d-25e46a92d8ce" />


Related https://github.com/marcoroth/herb/issues/1282
