### PR TITLE
Ruby: Don't load `bundler/inline` when gems are already installed

### DIFF
--- a/lib/herb.rb
+++ b/lib/herb.rb
@@ -119,18 +119,30 @@ module Herb
       nil
     end
 
-    def ensure_installed(&block)
+    #: (*String gems) -> void
+    def ensure_installed(*gems)
+      missing = gems.reject do |name|
+        require name
+        true
+      rescue LoadError
+        false
+      end
+
+      return if missing.empty?
+
       require "bundler/inline"
 
       verbose = $VERBOSE
       $VERBOSE = nil
 
-      gemfile(true, quiet: true) do # steep:ignore
-        source "https://rubygems.org" # steep:ignore
-        instance_eval(&block) # steep:ignore
+      begin
+        gemfile(true, quiet: true) do # steep:ignore
+          source "https://rubygems.org" # steep:ignore
+          missing.each { |name| gem name }
+        end
+      ensure
+        $VERBOSE = verbose
       end
-    ensure
-      $VERBOSE = verbose
     end
   end
 end

--- a/lib/herb/action_view/render_analyzer.rb
+++ b/lib/herb/action_view/render_analyzer.rb
@@ -784,7 +784,7 @@ module Herb
       def ensure_parallel!
         return if defined?(Parallel)
 
-        Herb.ensure_installed { gem "parallel" }
+        Herb.ensure_installed("parallel")
       end
 
       def collect_ruby_render_references

--- a/lib/herb/cli.rb
+++ b/lib/herb/cli.rb
@@ -181,12 +181,7 @@ class Herb::CLI
                   puts Herb.extract_html(file_content)
                   exit(0)
                 when "playground"
-                  require "bundler/inline"
-
-                  gemfile do
-                    source "https://rubygems.org"
-                    gem "lz_string"
-                  end
+                  Herb.ensure_installed("lz_string")
 
                   hash = LZString::UriSafe.compress(file_content)
                   local_url = "http://localhost:5173"

--- a/lib/herb/dev/runner.rb
+++ b/lib/herb/dev/runner.rb
@@ -119,8 +119,8 @@ module Herb
       end
 
       def require_cruise
-        require "cruise"
-      rescue LoadError
+        Herb.ensure_installed("cruise")
+      rescue StandardError
         abort <<~MESSAGE
           The 'cruise' gem is required for the Herb Dev Server.
 

--- a/lib/herb/project.rb
+++ b/lib/herb/project.rb
@@ -907,7 +907,7 @@ module Herb
     def ensure_parallel!
       return if defined?(Parallel)
 
-      Herb.ensure_installed { gem "parallel" } # steep:ignore
+      Herb.ensure_installed("parallel")
     end
 
     def separator

--- a/sig/herb.rbs
+++ b/sig/herb.rbs
@@ -24,5 +24,6 @@ module Herb
 
   def self.dev_server_port: (?untyped project_path) -> untyped
 
-  def self.ensure_installed: () ?{ (?) -> untyped } -> untyped
+  # : (*String gems) -> void
+  def self.ensure_installed: (*String gems) -> void
 end

--- a/test/herb_test.rb
+++ b/test/herb_test.rb
@@ -6,4 +6,14 @@ class HerbTest < Minitest::Spec
   test "version" do
     assert_equal "herb gem v0.10.3, libprism v1.9.0, libherb v0.10.3 (Ruby C native extension)", Herb.version
   end
+
+  test "ensure_installed requires available gems without loading bundler/inline" do
+    bundler_inline_loaded = -> { $LOADED_FEATURES.any? { |feature| feature.end_with?("bundler/inline.rb") } }
+    already_loaded = bundler_inline_loaded.call
+
+    Herb.ensure_installed("parallel")
+
+    assert defined?(Parallel)
+    assert_equal already_loaded, bundler_inline_loaded.call
+  end
 end


### PR DESCRIPTION
This pull request updates `Herb.ensure_installed` to require gems directly and only fall back to `bundler/inline` for gems that are actually missing. Previously, `ensure_installed` ran `gemfile(true)` on every call. 

With `install: true`, Bundler performs a full resolve and install pass even when nothing needs installing, and that pass loads RubyGems plugin files and rdoc as a side effect. Running the old code path with `parallel` already installed confirms this. It loads six rdoc files (including `rdoc/rubygems_hook`) plus a RubyGems plugin file, while the new path loads none of them.

On machines where two rdoc versions are visible, for example a newer rdoc in `GEM_HOME` alongside the bundled default gem, loading rdoc this way produces the `already initialized constant RDoc::VERSION` warnings reported in #1435. 

Resolves #1435