### PR TITLE
CLIs: Fix `herb-format` and `herb-lint` when run from git hooks

### DIFF
--- a/docs/docs/integrations/git-hooks.md
+++ b/docs/docs/integrations/git-hooks.md
@@ -55,13 +55,15 @@ node_modules/.bin/herb-format --check
 ```json [package.json]
 {
   "lint-staged": {
-    "*.html.erb": [
+    "*.{erb,herb,html,rhtml}": [
       "herb-format",
       "herb-lint"
     ]
   }
 }
 ```
+
+The pattern only needs to be a rough superset of your templates. Both CLIs check every path they are given against the file patterns from `.herb.yml` and skip anything that doesn't match, so a stray `.js.erb` never reaches the formatter.
 
 Call it from whichever hook you set up above:
 
@@ -84,15 +86,17 @@ bundle add lefthook --group development
 bundle exec lefthook install
 ```
 
-`{staged_files}` expands to the staged paths matching `glob`, and the commands are skipped entirely when nothing matches:
+`{staged_files}` expands to the staged paths matching `glob`, and the commands are skipped entirely when nothing matches. As with lint-staged, the glob only has to be a rough superset, since both CLIs skip paths that don't match the patterns in `.herb.yml`:
 
 ```yaml [lefthook.yml]
 pre-commit:
   parallel: true
   commands:
     herb-lint:
+      glob: ["*.erb", "*.herb", "*.html", "*.rhtml"]
       run: node_modules/.bin/herb-lint {staged_files}
     herb-format:
+      glob: ["*.erb", "*.herb", "*.html", "*.rhtml"]
       run: node_modules/.bin/herb-format --check {staged_files}
 ```
 
@@ -102,6 +106,7 @@ To format instead of checking, drop `--check` and set `stage_fixed` so the rewri
 pre-commit:
   commands:
     herb-format:
+      glob: ["*.erb", "*.herb", "*.html", "*.rhtml"]
       run: node_modules/.bin/herb-format {staged_files}
       stage_fixed: true
 ```

--- a/javascript/packages/config/src/config.ts
+++ b/javascript/packages/config/src/config.ts
@@ -368,14 +368,18 @@ export class Config {
    */
   private normalizeFilePath(filePath: string): string {
     if (path.isAbsolute(filePath)) {
-      const projectDir = this.projectPath + path.sep
+      for (const baseDir of [this.projectPath, process.cwd()]) {
+        const prefix = baseDir + path.sep
 
-      if (filePath.startsWith(projectDir)) {
-        return filePath.slice(projectDir.length)
+        if (filePath.startsWith(prefix)) {
+          return filePath.slice(prefix.length)
+        }
       }
+
+      return filePath
     }
 
-    return filePath
+    return filePath.replace(/^(?:\.\/)+/, "")
   }
 
   private isPathExcluded(filePath: string, excludePatterns?: string[]): boolean {
@@ -400,6 +404,20 @@ export class Config {
 
     const normalized = this.normalizeFilePath(filePath)
     return includePatterns.some(pattern => picomatch.isMatch(normalized, pattern))
+  }
+
+  /**
+   * Check if a file path matches the include patterns of a tool (linter or formatter).
+   * Answers whether the tool recognizes the path as a template it can process at all,
+   * independent of exclude patterns and the tool's enabled state.
+   * @param filePath - The file path to check
+   * @param tool - The tool to check ('linter' or 'formatter')
+   * @returns true if the path matches any include pattern for the tool
+   */
+  public isPathIncludedForTool(filePath: string, tool: 'linter' | 'formatter'): boolean {
+    const filesConfig = this.getFilesConfigForTool(tool)
+
+    return this.isPathIncluded(filePath, filesConfig.include)
   }
 
   /**

--- a/javascript/packages/formatter/src/cli.ts
+++ b/javascript/packages/formatter/src/cli.ts
@@ -68,7 +68,7 @@ export class CLI {
       herb-format templates/                      # Format all configured files within the given directory
       herb-format "templates/**/*.html.erb"       # Format all \`**/*.html.erb\` files in the templates/ directory
       herb-format "**/*.html.erb"                 # Format all \`*.html.erb\` files using glob pattern
-      herb-format "**/*.xml.erb"                  # Format all \`*.xml.erb\` files using glob pattern
+      herb-format --force "**/*.xml.erb"          # Format files not covered by the configured patterns
 
       herb-format --check                         # Check if all configured files are formatted
       herb-format --check templates/              # Check if all configured files in templates/ are formatted
@@ -413,7 +413,7 @@ export class CLI {
           process.exit(1)
         }
 
-        const files = [...new Set(allFiles)]
+        const files = this.rejectUnsupportedFiles([...new Set(allFiles)], config, isForceMode)
 
         if (files.length === 0) {
           console.log(`No files found matching patterns: ${positionals.join(', ')}`)
@@ -497,6 +497,28 @@ export class CLI {
     reporter.displaySummary(data)
 
     process.exit(isCheckMode && changedFiles.length > 0 ? 1 : 0)
+  }
+
+  private rejectUnsupportedFiles(files: string[], config: Config, isForceMode: boolean | undefined): string[] {
+    if (isForceMode) {
+      return files
+    }
+
+    const supported = files.filter(file => config.isPathIncludedForTool(file, 'formatter'))
+    const unsupported = files.filter(file => !config.isPathIncludedForTool(file, 'formatter'))
+
+    if (unsupported.length > 0) {
+      console.error(`⚠️  Skipped ${unsupported.length} ${pluralize(unsupported.length, 'file')} that ${unsupported.length === 1 ? "doesn't" : "don't"} match the configured file patterns:`)
+
+      for (const file of unsupported) {
+        console.error(`  ${colorize(relative(process.cwd(), resolve(file)), "cyan")}`)
+      }
+
+      console.error(`   Use --force to format ${unsupported.length === 1 ? 'it' : 'them'} anyway.`)
+      console.error()
+    }
+
+    return supported
   }
 
   private hasStdinInput(): boolean {

--- a/javascript/packages/formatter/test/cli.test.ts
+++ b/javascript/packages/formatter/test/cli.test.ts
@@ -375,6 +375,126 @@ describe("CLI Binary", () => {
     })
   }
 
+  it("should skip files that don't match the configured file patterns", async () => {
+    const directory = "test-unsupported-files"
+    const script = "function greet(name) {\n  if (name < 3) {\n    return 'hi'\n  }\n}\n"
+
+    await mkdir(directory, { recursive: true })
+    await writeFile(join(directory, "script.js"), script)
+    await writeFile(join(directory, "page.html.erb"), '<div><p>   Not formatted   </p></div>')
+
+    try {
+      const result = await execBinary(["script.js", "page.html.erb"], undefined, { cwd: directory })
+
+      expectExitCode(result, 0)
+      expect(result.stderr).toContain("script.js")
+      expect(result.stderr).toContain("Use --force to format it anyway")
+      expect(result.stdout).toContain("Formatted: page.html.erb")
+
+      expect(await readFile(join(directory, "script.js"), "utf-8")).toBe(script)
+      expect(await readFile(join(directory, "page.html.erb"), "utf-8")).toBe("<div>\n  <p>Not formatted</p>\n</div>\n")
+    } finally {
+      await rm(directory, { recursive: true }).catch(() => {})
+    }
+  })
+
+  it("should format files that don't match the configured file patterns with --force", async () => {
+    const directory = "test-unsupported-files-force"
+    const script = "function greet(name) {\n  if (name < 3) {\n    return 'hi'\n  }\n}\n"
+
+    await mkdir(directory, { recursive: true })
+    await writeFile(join(directory, "script.js"), script)
+
+    try {
+      const result = await execBinary(["--force", "script.js"], undefined, { cwd: directory })
+
+      expectExitCode(result, 0)
+      expect(result.stdout).toContain("Formatted: script.js")
+      expect(await readFile(join(directory, "script.js"), "utf-8")).not.toBe(script)
+    } finally {
+      await rm(directory, { recursive: true }).catch(() => {})
+    }
+  })
+
+  it("should format files added to the include patterns in .herb.yml", async () => {
+    const directory = "test-include-config"
+
+    await mkdir(directory, { recursive: true })
+    await writeFile(join(directory, ".herb.yml"), dedent`
+      version: 0.10.3
+      formatter:
+        enabled: true
+      files:
+        include:
+          - "**/*.xml.erb"
+    `)
+    await writeFile(join(directory, "feed.xml.erb"), '<?xml version="1.0"?><root><item/></root>')
+
+    try {
+      const result = await execBinary(["feed.xml.erb"], undefined, { cwd: directory })
+
+      expectExitCode(result, 0)
+      expect(result.stderr).not.toContain("match the configured file patterns")
+      expect(result.stdout).toContain("Formatted: feed.xml.erb")
+
+      const formatted = await readFile(join(directory, "feed.xml.erb"), "utf-8")
+      expect(formatted).toContain("<item />")
+    } finally {
+      await rm(directory, { recursive: true }).catch(() => {})
+    }
+  })
+
+  it("should still skip files outside the include patterns in .herb.yml", async () => {
+    const directory = "test-include-config-skip"
+    const script = "function greet(name) {\n  if (name < 3) {\n    return 'hi'\n  }\n}\n"
+
+    await mkdir(directory, { recursive: true })
+    await writeFile(join(directory, ".herb.yml"), dedent`
+      version: 0.10.3
+      formatter:
+        enabled: true
+      files:
+        include:
+          - "**/*.xml.erb"
+    `)
+    await writeFile(join(directory, "script.js"), script)
+
+    try {
+      const result = await execBinary(["script.js"], undefined, { cwd: directory })
+
+      expectExitCode(result, 0)
+      expect(result.stderr).toContain("script.js")
+      expect(result.stderr).toContain("Use --force to format it anyway")
+      expect(await readFile(join(directory, "script.js"), "utf-8")).toBe(script)
+    } finally {
+      await rm(directory, { recursive: true }).catch(() => {})
+    }
+  })
+
+  it("should accept every default file pattern", async () => {
+    const directory = "test-default-patterns"
+    const files = ["a.herb", "b.html.erb", "c.html.herb", "d.html", "e.html+phone.erb", "f.rhtml", "g.turbo_stream.erb"]
+
+    await mkdir(directory, { recursive: true })
+
+    for (const file of files) {
+      await writeFile(join(directory, file), '<div><p>   Not formatted   </p></div>')
+    }
+
+    try {
+      const result = await execBinary(["--check", ...files], undefined, { cwd: directory })
+
+      expectExitCode(result, 1)
+      expect(result.stderr).not.toContain("match the configured file patterns")
+
+      for (const file of files) {
+        expect(result.stdout).toContain(file)
+      }
+    } finally {
+      await rm(directory, { recursive: true }).catch(() => {})
+    }
+  })
+
   it("should check configured files with --check from a git pre-commit hook", async () => {
     const directory = "test-git-hook-check"
 
@@ -567,7 +687,7 @@ describe("CLI Binary", () => {
       `
 
       await writeFile("test-fixtures/test.xml.erb", content)
-      const result = await execBinary(["test-fixtures/test.xml.erb"])
+      const result = await execBinary(["--force", "test-fixtures/test.xml.erb"])
 
       expectExitCode(result, 0)
       expect(result.stdout).toContain("Formatted: test-fixtures/test.xml.erb")
@@ -584,7 +704,7 @@ describe("CLI Binary", () => {
       await writeFile("test-fixtures/file2.xml.erb", content2)
       await writeFile("test-fixtures/ignored.html.erb", "<div></div>")
 
-      const result = await execBinary(["test-fixtures/*.xml.erb"])
+      const result = await execBinary(["--force", "test-fixtures/*.xml.erb"])
 
       expectExitCode(result, 0)
       expect(result.stdout).toContain("Formatted: test-fixtures/file1.xml.erb")
@@ -599,7 +719,7 @@ describe("CLI Binary", () => {
       await writeFile("test-fixtures/top.xml.erb", content)
       await writeFile("test-fixtures/nested/deep.xml.erb", content)
 
-      const result = await execBinary(["test-fixtures/**/*.xml.erb"])
+      const result = await execBinary(["--force", "test-fixtures/**/*.xml.erb"])
 
       expectExitCode(result, 0)
       expect(result.stdout).toContain("Formatted: test-fixtures/top.xml.erb")
@@ -614,7 +734,7 @@ describe("CLI Binary", () => {
       await writeFile("test-fixtures/file.xml.erb", xmlContent)
       await writeFile("test-fixtures/file.html.erb", htmlContent)
 
-      const result = await execBinary(["test-fixtures/*.erb"])
+      const result = await execBinary(["--force", "test-fixtures/*.erb"])
 
       expectExitCode(result, 0)
       expect(result.stdout).toContain("Formatted: test-fixtures/file.xml.erb")
@@ -637,7 +757,7 @@ describe("CLI Binary", () => {
       await writeFile("test-fixtures/good.xml.erb", wellFormattedContent + '\n')
       await writeFile("test-fixtures/bad.xml.erb", poorlyFormattedContent)
 
-      const result = await execBinary(["--check", "test-fixtures/*.xml.erb"])
+      const result = await execBinary(["--check", "--force", "test-fixtures/*.xml.erb"])
 
       expectExitCode(result, 1)
       expect(result.stdout).toContain("The following")
@@ -667,7 +787,7 @@ describe("CLI Binary", () => {
 
       await writeFile("test-fixtures/test.xml.erb", content)
 
-      const result = await execBinary(["./test-fixtures/*.xml.erb"])
+      const result = await execBinary(["--force", "./test-fixtures/*.xml.erb"])
 
       expectExitCode(result, 0)
       expect(result.stdout).toContain("Formatted: test-fixtures/test.xml.erb")
@@ -695,7 +815,7 @@ describe("CLI Binary", () => {
       await writeFile("test-advanced/sub2/file3.xml.erb", content)
       await writeFile("test-advanced/sub2/ignore.html.erb", "<div></div>")
 
-      const result = await execBinary(["test-advanced/**/file*.xml.erb"])
+      const result = await execBinary(["--force", "test-advanced/**/file*.xml.erb"])
 
       expectExitCode(result, 0)
       expect(result.stdout).toContain("Formatted: test-advanced/sub1/file1.xml.erb")
@@ -713,7 +833,7 @@ describe("CLI Binary", () => {
       await writeFile("test-advanced/manifest.xml.erb", content)
       await writeFile("test-advanced/other.erb", content)
 
-      const result = await execBinary(["test-advanced/{config,manifest}.xml.erb"])
+      const result = await execBinary(["--force", "test-advanced/{config,manifest}.xml.erb"])
 
       expectExitCode(result, 0)
       expect(result.stdout).toContain("Formatted: test-advanced/config.xml.erb")
@@ -753,7 +873,7 @@ describe("CLI Binary", () => {
       await writeFile("test-advanced/specific.xml.erb", xmlContent)
       await writeFile("test-advanced/another.html.erb", htmlContent)
 
-      const result1 = await execBinary(["test-advanced/specific.xml.erb"])
+      const result1 = await execBinary(["--force", "test-advanced/specific.xml.erb"])
       expectExitCode(result1, 0)
       expect(result1.stdout).toContain("Formatted: test-advanced/specific.xml.erb")
 
@@ -784,7 +904,7 @@ describe("CLI Binary", () => {
       await writeFile("test-advanced/good2.xml.erb", formattedContent + '\n')
       await writeFile("test-advanced/sub1/bad.xml.erb", unformattedContent)
 
-      const result = await execBinary(["--check", "test-advanced/**/*.xml.erb"])
+      const result = await execBinary(["--check", "--force", "test-advanced/**/*.xml.erb"])
 
       expectExitCode(result, 1)
       expect(result.stdout).toContain("The following")
@@ -890,7 +1010,7 @@ describe("CLI Binary", () => {
       await writeFile("test-multi/pattern1.xml.erb", '<?xml version="1.0"?><root></root>')
       await writeFile("test-multi/pattern2.xml.erb", '<?xml version="1.0"?><config></config>')
 
-      const result = await execBinary(["test-multi/specific.html.erb", "test-multi/*.xml.erb"])
+      const result = await execBinary(["--force", "test-multi/specific.html.erb", "test-multi/*.xml.erb"])
 
       expectExitCode(result, 0)
       expect(result.stdout).toContain("Formatted: test-multi/specific.html.erb")

--- a/javascript/packages/linter/src/cli.ts
+++ b/javascript/packages/linter/src/cli.ts
@@ -138,6 +138,27 @@ export class CLI {
     return { files, explicitFile }
   }
 
+  protected rejectUnsupportedFiles(files: string[], config: Config, force: boolean, formatOption: FormatOption): string[] {
+    if (force) {
+      return files
+    }
+
+    const supported = files.filter(file => config.isPathIncludedForTool(file, 'linter'))
+    const unsupported = files.filter(file => !config.isPathIncludedForTool(file, 'linter'))
+
+    if (unsupported.length > 0 && formatOption !== 'json') {
+      console.error(`⚠️  Skipped ${unsupported.length} ${unsupported.length === 1 ? 'file' : 'files'} that ${unsupported.length === 1 ? "doesn't" : "don't"} match the configured file patterns:`)
+
+      for (const file of unsupported) {
+        console.error(`  ${colorize(relative(process.cwd(), resolve(file)), "cyan")}`)
+      }
+
+      console.error(`   Use --force to lint ${unsupported.length === 1 ? 'it' : 'them'} anyway.\n`)
+    }
+
+    return supported
+  }
+
   protected async beforeProcess(): Promise<void> {
     // Hook for subclasses to add custom output before processing
   }
@@ -442,7 +463,7 @@ export class CLI {
           }
         }
 
-        files = [...new Set(allFiles)]
+        files = this.rejectUnsupportedFiles([...new Set(allFiles)], config, force, formatOption)
       }
 
       if (files.length === 0) {

--- a/javascript/packages/linter/test/cli.test.ts
+++ b/javascript/packages/linter/test/cli.test.ts
@@ -278,6 +278,61 @@ describe("CLI Output Formatting", () => {
     expect(exitCode) .toBe(1)
   })
 
+  describe("Unsupported Files", () => {
+    const { writeFileSync, unlinkSync } = require("fs")
+    const scriptPath = "test/fixtures/unsupported-script.js"
+
+    test("warns and skips a file that doesn't match the configured file patterns", () => {
+      try {
+        writeFileSync(scriptPath, "function greet(name) {\n  if (name < 3) {\n    return 'hi'\n  }\n}\n")
+
+        const { output, exitCode } = runLinter("unsupported-script.js")
+
+        expect(output).toContain("match the configured file patterns")
+        expect(output).toContain("unsupported-script.js")
+        expect(output).toContain("Use --force to lint it anyway")
+        expect(exitCode).toBe(0)
+      } finally {
+        try { unlinkSync(scriptPath) } catch {}
+      }
+    })
+
+    test("lints a file outside the configured file patterns with --force", () => {
+      try {
+        writeFileSync(scriptPath, "<img>\n")
+
+        const { output } = runLinter("unsupported-script.js", "--force")
+
+        expect(output).not.toContain("match the configured file patterns")
+        expect(output).toContain("unsupported-script.js")
+      } finally {
+        try { unlinkSync(scriptPath) } catch {}
+      }
+    })
+
+    test("lints a file added to the include patterns in .herb.yml", () => {
+      const configPath = "test/fixtures/.herb.yml"
+      const xmlPath = "test/fixtures/feed.xml.erb"
+
+      try {
+        writeFileSync(configPath, dedent`
+          files:
+            include:
+              - "**/*.xml.erb"
+        `)
+        writeFileSync(xmlPath, '<?xml version="1.0"?>\n<root><img></root>\n')
+
+        const { output } = runLinter("feed.xml.erb")
+
+        expect(output).not.toContain("match the configured file patterns")
+        expect(output).toContain("feed.xml.erb")
+      } finally {
+        try { unlinkSync(configPath) } catch {}
+        try { unlinkSync(xmlPath) } catch {}
+      }
+    })
+  })
+
   describe("Excluded Files", () => {
     const { writeFileSync, unlinkSync } = require("fs")
     const configPath = "test/fixtures/.herb.yml"


### PR DESCRIPTION
This pull request fixes two problems that made the CLIs unusable, and in one case destructive, when they are invoked from a git pre-commit hook, and documents the supported hook setups.

Both CLIs accepted any path handed to them and processed it as HTML+ERB. Passing a JavaScript file to the formatter silently destroyed it, because the parser treats the source as text and the printer reflows it onto one line:

```js
function greet(name) {
  if (name < 3) {
    return "hi"
  }
}
```

```bash
herb-format script.js
```

```js
function greet(name) { if (name < 3) { return "hi"; } }
```

`herb-lint` had the same gap in a quieter form. It reported offenses on that file, and `--fix` would have rewritten it.

This matters most where the file list isn't written by hand. Hook runners like lint-staged and Lefthook pass the staged paths straight through, so one overly broad glob is enough to mangle unrelated sources on commit.

Both CLIs now check every path they resolve against the include patterns from `.herb.yml` and skip anything that doesn't match:

```
⚠️  Skipped 1 file that doesn't match the configured file patterns:
  script.js

   Use --force to format it anyway.
```

This also makes explicit arguments behave like directory arguments already did. Passing a directory has always been filtered through the configured patterns.

Related #300
Follow-up on #2120
Follow-up on #2124 