### PR TITLE
Linter: Handle ancestors in `a11y-no-visually-hidden-interactive-elements` 

### DIFF
--- a/javascript/packages/core/src/action-view-partial-callers.ts
+++ b/javascript/packages/core/src/action-view-partial-callers.ts
@@ -11,9 +11,12 @@ export interface PartialCallSite {
   caller: string
   locals: string[]
   ancestors: string[]
+  ancestorAttributes?: StaticAttributeMap[]
   via?: CallSiteKind
   location?: CallSiteLocation
 }
+
+export type StaticAttributeMap = Record<string, string>
 
 export interface InferredSignature {
   locals: StrictLocal[]
@@ -24,12 +27,14 @@ export interface InferredSignature {
 export interface CallFrame {
   file: string
   ancestors: string[]
+  ancestorAttributes?: StaticAttributeMap[]
   via: CallSiteKind
   location: CallSiteLocation | null
 }
 
 export interface AncestorChain {
   tags: string[]
+  attributes?: StaticAttributeMap[]
   frames: CallFrame[]
   occurrences: number
 }
@@ -202,7 +207,11 @@ export class PartialCallerIndex {
 
       for (const prefix of prefixes) {
         const tags = [...prefix.tags, ...callSite.ancestors]
-        const key = tags.join(">")
+        const attributes = [
+          ...(prefix.attributes ?? prefix.tags.map(() => ({}))),
+          ...(callSite.ancestorAttributes ?? callSite.ancestors.map(() => ({}))),
+        ]
+        const key = JSON.stringify([tags, attributes])
         const existing = byKey.get(key)
 
         if (existing) {
@@ -219,6 +228,7 @@ export class PartialCallerIndex {
 
         const chain: AncestorChain = {
           tags,
+          ...(attributes.some(attribute => Object.keys(attribute).length > 0) ? { attributes } : {}),
           frames: [...prefix.frames, frame],
           occurrences: prefix.occurrences,
         }
@@ -250,6 +260,7 @@ export class PartialCallerIndex {
     return {
       file: callSite.caller,
       ancestors: callSite.ancestors,
+      ...(callSite.ancestorAttributes ? { ancestorAttributes: callSite.ancestorAttributes } : {}),
       via: callSite.via ?? "render",
       location: callSite.location ?? null,
     }

--- a/javascript/packages/core/test/action-view-partial-callers.test.ts
+++ b/javascript/packages/core/test/action-view-partial-callers.test.ts
@@ -137,4 +137,36 @@ describe("PartialCallerIndex", () => {
       expect(callers.contextOf(CARD).resolved).toBe(false)
     })
   })
+
+  describe("ancestor class context", () => {
+    test("preserves ancestor classes through serialization", () => {
+      const callers = index({
+        [CARD]: [{
+          caller: INDEX,
+          locals: [],
+          ancestors: ["main", "div"],
+          ancestorAttributes: [{}, { class: "sr-only" }],
+          via: "render",
+        }],
+      }, [INDEX])
+
+      const restored = PartialCallerIndex.from(structuredClone(callers.toJSON()))
+      const [chain] = restored.contextOf(CARD).chains
+
+      expect(chain.tags).toEqual(["main", "div"])
+      expect(chain.attributes).toEqual([{}, { class: "sr-only" }])
+      expect(chain.frames[0].ancestorAttributes).toEqual([{}, { class: "sr-only" }])
+    })
+
+    test("keeps call sites with the same tags but different classes distinct", () => {
+      const callers = index({
+        [CARD]: [
+          { caller: INDEX, locals: [], ancestors: ["div"], ancestorAttributes: [{ class: "sr-only" }] },
+          { caller: INDEX, locals: [], ancestors: ["div"] },
+        ],
+      }, [INDEX])
+
+      expect(callers.contextOf(CARD).chains).toHaveLength(2)
+    })
+  })
 })

--- a/javascript/packages/linter/docs/rules/a11y-no-visually-hidden-interactive-elements.md
+++ b/javascript/packages/linter/docs/rules/a11y-no-visually-hidden-interactive-elements.md
@@ -22,6 +22,8 @@ This rule recognizes an `sr-only` class like the one Tailwind defines. It allows
 
 Responsive and other prefixes are supported, such as `md:focus:not-sr-only` and `dark:lg:focus-visible:not-sr-only`. Hover- and active-only variants are not considered focus reveals because they can leave the element hidden when keyboard focus first reaches it.
 
+The rule also detects focusable elements inside an ancestor with `sr-only`. A hidden ancestor must use `not-sr-only` or a `focus-within:not-sr-only` variant to reveal its descendants. A plain `focus:not-sr-only` on the ancestor is not sufficient because focusing a descendant does not focus the ancestor itself.
+
 The rule does not inspect CSS or detect arbitrary visually hidden classes. Class attributes containing ERB are skipped because a dynamic value could add one of the reveal classes.
 
 ::: info Configurability
@@ -75,6 +77,12 @@ With this definition, the visually hidden styles stop applying when the element 
 <button class="sr-only" disabled>Unavailable</button>
 ```
 
+```erb
+<div class="sr-only focus-within:not-sr-only">
+  <button>Submit</button>
+</div>
+```
+
 ### 🚫 Bad
 
 ```erb
@@ -89,13 +97,21 @@ With this definition, the visually hidden styles stop applying when the element 
 <div class="sr-only" tabindex="0">Open menu</div>
 ```
 
+```erb
+<div class="sr-only">
+  <button>Submit</button>
+</div>
+```
+
 ## Across call sites
 
-When an offense is found in a partial, the detailed formatter includes a call chain showing where the partial is rendered. The chain follows `render` calls and each template's conventional layout `yield`, making it possible to trace the hidden control back to the page that includes it.
+This rule considers the classes on ancestors at each call site. A focusable element in a partial is reported when every call site, or at least one call site, renders it inside an ancestor hidden with `sr-only`.
+
+When callers disagree, the detailed formatter includes a call chain pointing to one that hides the element. The chain follows `render` calls and each template's conventional layout `yield`, making it possible to trace the hidden control back to the responsible ancestor.
 
 Action View helpers such as `content_tag`, `tag.div`, and block-form `link_to` calls are included in the element context shown for each call site.
 
-Call-site context does not change whether the rule reports an offense: the hidden class and keyboard focusability belong to the element itself. A file that is not rendered anywhere is still linted normally, but no call chain is attached.
+A file with no known callers or only unresolved render chains is left alone when its local markup does not establish an offense. Dynamic ancestor class values are also skipped because the rule cannot know whether they hide or reveal the element.
 
 Layout resolution follows Rails' naming convention and cannot see a controller declaring `layout "..."` or `layout false`.
 

--- a/javascript/packages/linter/src/ancestor-attributes.ts
+++ b/javascript/packages/linter/src/ancestor-attributes.ts
@@ -1,0 +1,27 @@
+import { getAttribute, getStaticAttributeValue } from "@herb-tools/core"
+
+import type { HTMLElementNode, StaticAttributeMap } from "@herb-tools/core"
+
+export const ANCESTOR_CONTEXT_ATTRIBUTES = [
+  "class",
+] as const
+
+export function staticAncestorAttributes(element: HTMLElementNode): StaticAttributeMap {
+  const attributes: StaticAttributeMap = {}
+
+  for (const name of ANCESTOR_CONTEXT_ATTRIBUTES) {
+    const attribute = getAttribute(element, name)
+
+    if (!attribute) continue
+
+    if (!attribute.value) {
+      attributes[name] = ""
+      continue
+    }
+
+    const value = getStaticAttributeValue(attribute)
+    if (value !== null) attributes[name] = value
+  }
+
+  return attributes
+}

--- a/javascript/packages/linter/src/partial-caller-builder.ts
+++ b/javascript/packages/linter/src/partial-caller-builder.ts
@@ -6,12 +6,13 @@ import { readFileSync } from "node:fs"
 
 import { getTagLocalName, isHTMLElementNode, isPrismNodeType, isRubyRenderLocalNode, layoutCandidatesFor, outranksTemplate, templateNameForFile } from "@herb-tools/core"
 import { isOutputRender, renderPartialExpression } from "./rules/prism-rule-utils.js"
+import { staticAncestorAttributes } from "./ancestor-attributes.js"
 
 import { PartialCallerIndex } from "@herb-tools/core"
 
 import { TEMPLATE_GLOB_PATTERN } from "@herb-tools/core"
 
-import type { CallSiteLocation, ERBRenderNode, ERBYieldNode, HerbBackend, Node, PartialCallSite, PartialIndex, SerializedPartialCallerIndex } from "@herb-tools/core"
+import type { CallSiteLocation, ERBRenderNode, ERBYieldNode, HerbBackend, Node, PartialCallSite, PartialIndex, SerializedPartialCallerIndex, StaticAttributeMap } from "@herb-tools/core"
 
 const RENDER_MARKER = "render"
 const YIELD_MARKER = "yield"
@@ -37,10 +38,12 @@ function templatesIn(projectPath: string, viewRoot: string, include: string[]): 
 interface RenderSite {
   node: ERBRenderNode
   ancestors: string[]
+  ancestorAttributes?: StaticAttributeMap[]
 }
 
 export interface YieldSite {
   ancestors: string[]
+  ancestorAttributes?: StaticAttributeMap[]
   location?: CallSiteLocation
 }
 
@@ -67,18 +70,25 @@ function callSiteLocation(node: Node): CallSiteLocation | undefined {
 function scanTemplate(node: Node): ScannedTemplate {
   const sites: RenderSite[] = []
   const yields: YieldSite[] = []
-  const stack: string[] = []
+  const stack: { tagName: string, attributes: StaticAttributeMap }[] = []
 
   let isDocumentRoot = false
 
   const walk = (current: Node) => {
-    const tagName = isHTMLElementNode(current) ? getTagLocalName(current) : null
+    const element = isHTMLElementNode(current) ? current : null
+    const tagName = element ? getTagLocalName(element) : null
 
     if (tagName === "html") isDocumentRoot = true
-    if (tagName) stack.push(tagName)
+    if (tagName) {
+      stack.push({ tagName, attributes: staticAncestorAttributes(element!) })
+    }
 
-    if (current.type === "AST_ERB_RENDER_NODE") sites.push({ node: current as ERBRenderNode, ancestors: [...stack] })
-    if (isBareYield(current)) yields.push({ ancestors: [...stack], location: callSiteLocation(current) })
+    const ancestors = stack.map(ancestor => ancestor.tagName)
+    const attributes = stack.map(ancestor => ancestor.attributes)
+    const ancestorAttributes = attributes.some(attribute => Object.keys(attribute).length > 0) ? attributes : undefined
+
+    if (current.type === "AST_ERB_RENDER_NODE") sites.push({ node: current as ERBRenderNode, ancestors, ancestorAttributes })
+    if (isBareYield(current)) yields.push({ ancestors, ancestorAttributes, location: callSiteLocation(current) })
 
     for (const child of current.childNodes()) {
       if (child) walk(child)
@@ -135,7 +145,7 @@ export function collectCallSites(herb: HerbBackend, partials: PartialIndex, file
 
   const { sites, yields, isDocumentRoot } = scanTemplate(herb.parse(source, PARSER_OPTIONS).value)
 
-  for (const { node, ancestors } of sites) {
+  for (const { node, ancestors, ancestorAttributes } of sites) {
     const name = partialNameRenderedBy(node)
 
     if (name === null) {
@@ -154,7 +164,7 @@ export function collectCallSites(herb: HerbBackend, partials: PartialIndex, file
 
     const existing = callSites.get(declaration.file) ?? []
 
-    existing.push({ caller: file, locals: localsPassedBy(node), ancestors, via: "render", location: callSiteLocation(node) })
+    existing.push({ caller: file, locals: localsPassedBy(node), ancestors, ancestorAttributes, via: "render", location: callSiteLocation(node) })
     callSites.set(declaration.file, existing)
   }
 
@@ -184,8 +194,8 @@ function addLayoutCallSites(files: string[], layoutYields: Map<string, YieldSite
 
       const existing = callSites.get(file) ?? []
 
-      for (const { ancestors, location } of layoutYields.get(layout) ?? []) {
-        existing.push({ caller: layout, locals: [], ancestors, via: "layout", location })
+      for (const { ancestors, ancestorAttributes, location } of layoutYields.get(layout) ?? []) {
+        existing.push({ caller: layout, locals: [], ancestors, ancestorAttributes, via: "layout", location })
       }
 
       callSites.set(file, existing)

--- a/javascript/packages/linter/src/rules/a11y-no-visually-hidden-interactive-elements.ts
+++ b/javascript/packages/linter/src/rules/a11y-no-visually-hidden-interactive-elements.ts
@@ -5,29 +5,95 @@ import { isKeyboardFocusableElement } from "./rule-utils.js"
 import { getStaticAttributeValue, getTagLocalName } from "@herb-tools/core"
 
 import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types.js"
-import type { ParseResult, ParserOptions, HTMLElementNode } from "@herb-tools/core"
+import type { AncestorChain, ParseResult, ParserOptions, HTMLElementNode } from "@herb-tools/core"
 
 // TODO: make these classes configurable once https://github.com/marcoroth/herb/issues/1204 lands
 const VISUALLY_HIDDEN_CLASSES = ["sr-only"]
 const VISUALLY_SHOWN_ON_FOCUS = /(?:^|:)(?:group-)?focus(?:-visible|-within)?:not-sr-only$/
+const VISUALLY_SHOWN_ON_DESCENDANT_FOCUS = /(?:^|:)(?:group-)?focus-within:not-sr-only$/
 
 const isUndoClass = (className: string): boolean =>
   className === "not-sr-only" || VISUALLY_SHOWN_ON_FOCUS.test(className)
+
+const isDescendantUndoClass = (className: string): boolean =>
+  className === "not-sr-only" || VISUALLY_SHOWN_ON_DESCENDANT_FOCUS.test(className)
+
+function hiddenAncestorIndex(attributes: Record<string, string>[]): number {
+  for (let index = attributes.length - 1; index >= 0; index--) {
+    const classes = attributes[index].class?.split(/\s+/).filter(Boolean) ?? []
+
+    if (classes.includes("sr-only") && !classes.some(isDescendantUndoClass)) return index
+  }
+
+  return -1
+}
+
+function hiddenAncestorInChain(chain: AncestorChain | null): { tagName: string, file: string } | null {
+  if (!chain) return null
+
+  const index = hiddenAncestorIndex(chain.attributes ?? chain.tags.map(() => ({})))
+  if (index < 0) return null
+
+  let frameStart = 0
+
+  for (const frame of chain.frames) {
+    const frameEnd = frameStart + frame.ancestors.length
+
+    if (index < frameEnd) {
+      return { tagName: chain.tags[index], file: frame.file }
+    }
+
+    frameStart = frameEnd
+  }
+
+  return null
+}
 
 class NoVisuallyHiddenInteractiveElementsVisitor extends ElementStackVisitor {
   visitHTMLElementNode(node: HTMLElementNode): void {
     const tagName = getTagLocalName(node)
 
-    if (tagName !== "input" && isKeyboardFocusableElement(node)) {
-      const classValue = getStaticAttributeValue(node, "class")
+    if (tagName === "input" || !isKeyboardFocusableElement(node)) {
+      super.visitHTMLElementNode(node)
+      return
+    }
 
-      if (classValue) {
-        const classes = classValue.split(/\s+/)
+    const classValue = getStaticAttributeValue(node, "class")
+    const classes = classValue ? classValue.split(/\s+/) : []
 
-        if (VISUALLY_HIDDEN_CLASSES.some((cls) => classes.includes(cls)) && !classes.some(isUndoClass)) {
+    if (VISUALLY_HIDDEN_CLASSES.some((cls) => classes.includes(cls)) && !classes.some(isUndoClass)) {
+      this.addOffense(
+        `The keyboard-focusable \`<${tagName}>\` element uses \`sr-only\` without a focus reveal class, so sighted keyboard users may think focus was lost. Remove \`sr-only\` or add a class such as \`focus:not-sr-only\` to reveal the element when it receives focus.`,
+        node.tag_name!.location,
+      )
+    } else {
+      const localHiddenIndex = hiddenAncestorIndex(this.ancestorAttributes)
+
+      if (localHiddenIndex >= 0) {
+        const ancestorTagName = this.ancestorTagNames[localHiddenIndex]
+
+        this.addOffense(
+          `The keyboard-focusable \`<${tagName}>\` element is inside a \`<${ancestorTagName}>\` hidden by \`sr-only\`, so sighted keyboard users may think focus was lost. Remove \`sr-only\` from the ancestor or add \`focus-within:not-sr-only\` to reveal its contents when they receive focus.`,
+          node.tag_name!.location,
+        )
+      } else {
+        const placement = this.placementAcrossCallers((_ancestors, ancestorAttributes) =>
+          hiddenAncestorIndex(ancestorAttributes) >= 0
+        )
+
+        if (placement.verdict === "always" || placement.verdict === "mixed") {
+          const reach = placement.verdict === "always"
+            ? "Every call site renders"
+            : "At least one call site renders"
+          const hiddenAncestor = hiddenAncestorInChain(placement.chain)
+          const source = hiddenAncestor
+            ? ` The displayed call chain identifies the hidden \`<${hiddenAncestor.tagName}>\` in \`${hiddenAncestor.file}\`.`
+            : ""
+
           this.addOffenseWithCallChain(
-            `The keyboard-focusable \`<${tagName}>\` element uses \`sr-only\` without a focus reveal class, so sighted keyboard users may think focus was lost. Remove \`sr-only\` or add a class such as \`focus:not-sr-only\` to reveal the element when it receives focus.`,
+            `${reach} the keyboard-focusable \`<${tagName}>\` element inside an ancestor hidden by \`sr-only\`, so sighted keyboard users may think focus was lost.${source} Remove \`sr-only\` from the ancestor or add \`focus-within:not-sr-only\` to reveal its contents when they receive focus.`,
             node.tag_name!.location,
+            placement.chain,
           )
         }
       }

--- a/javascript/packages/linter/src/rules/rule-utils.ts
+++ b/javascript/packages/linter/src/rules/rule-utils.ts
@@ -32,11 +32,13 @@ import type {
   HTMLOpenTagNode,
   LexResult,
   PartialContext,
+  StaticAttributeMap,
   Token,
   Node
 } from "@herb-tools/core"
 
 import { DEFAULT_LINT_CONTEXT } from "../types.js"
+import { staticAncestorAttributes } from "../ancestor-attributes.js"
 
 import type * as Nodes from "@herb-tools/core"
 import type { DiagnosticTag } from "@herb-tools/core"
@@ -359,6 +361,16 @@ export abstract class ElementStackVisitor<TAutofixContext extends BaseAutofixCon
   }
 
   /**
+   * Selected static attributes for each local ancestor, aligned with `ancestorTagNames`.
+   */
+  protected get ancestorAttributes(): StaticAttributeMap[] {
+    return this.elementStack.flatMap(element => {
+      if (getTagLocalName(element) === null) return []
+      return [staticAncestorAttributes(element)]
+    })
+  }
+
+  /**
    * Like `isInsideElement`, but also considers the ancestors this file renders
    * into at every call site, so a partial can be judged by the context its
    * callers place it in.
@@ -418,13 +430,17 @@ export abstract class ElementStackVisitor<TAutofixContext extends BaseAutofixCon
    * Returns an offending chain alongside the verdict, so a `mixed` report can
    * point at a call site that is actually at fault.
    */
-  protected placementAcrossCallers(misplaced: (ancestors: string[]) => boolean): { verdict: AncestorVerdict, chain: AncestorChain | null } {
+  protected placementAcrossCallers(misplaced: (ancestors: string[], attributes: StaticAttributeMap[]) => boolean): { verdict: AncestorVerdict, chain: AncestorChain | null } {
     const { chains } = this.renderedContext
     const local = this.ancestorTagNames
 
     if (chains.length === 0) return { verdict: "unknown", chain: null }
 
-    const offending = chains.filter(chain => misplaced([...chain.tags, ...local]))
+    const localAttributes = this.ancestorAttributes
+    const offending = chains.filter(chain => misplaced(
+      [...chain.tags, ...local],
+      [...(chain.attributes ?? chain.tags.map(() => ({}))), ...localAttributes],
+    ))
 
     if (offending.length === chains.length) return { verdict: "always", chain: offending[0] }
     if (offending.length > 0) return { verdict: "mixed", chain: offending[0] }

--- a/javascript/packages/linter/test/cross-file-rules.test.ts
+++ b/javascript/packages/linter/test/cross-file-rules.test.ts
@@ -14,6 +14,7 @@ import { buildPartialIndex } from "../src/partial-index-builder.js"
 import { buildPartialCallerIndex } from "../src/partial-caller-builder.js"
 
 import { A11yNestedInteractiveElementsRule } from "../src/rules/a11y-nested-interactive-elements.js"
+import { A11yNoVisuallyHiddenInteractiveElementsRule } from "../src/rules/a11y-no-visually-hidden-interactive-elements.js"
 import { ERBNoUnsafeRawRule } from "../src/rules/erb-no-unsafe-raw.js"
 import { HTMLBodyOnlyElementsRule } from "../src/rules/html-body-only-elements.js"
 import { HTMLHeadOnlyElementsRule } from "../src/rules/html-head-only-elements.js"
@@ -99,6 +100,81 @@ afterEach(() => {
   while (projects.length > 0) {
     rmSync(projects.pop()!, { recursive: true, force: true })
   }
+})
+
+describe("a11y-no-visually-hidden-interactive-elements across files", () => {
+  const partial = "app/views/shared/_control.html.erb"
+  const control = `<button>Save</button>`
+
+  test("reports a control rendered inside a visually hidden ancestor", async () => {
+    const offenses = await offensesInProject({
+      [partial]: control,
+      "app/views/settings/show.html.erb": `<div class="sr-only"><%= render "shared/control" %></div>`,
+    }, A11yNoVisuallyHiddenInteractiveElementsRule, partial, { enabled: true })
+
+    expect(offenses).toHaveLength(1)
+    expect(offenses[0].message).toContain("Every call site renders the keyboard-focusable `<button>` element inside an ancestor hidden by `sr-only`")
+    expect(offenses[0].message).toContain("The displayed call chain identifies the hidden `<div>` in `app/views/settings/show.html.erb`.")
+    expect(offenses[0].renderedFrom?.frames[0].file).toBe("app/views/settings/show.html.erb")
+  })
+
+  test("reports the offending chain when only some callers are visually hidden", async () => {
+    const offenses = await offensesInProject({
+      [partial]: control,
+      "app/views/settings/show.html.erb": `<div class="sr-only"><%= render "shared/control" %></div>`,
+      "app/views/settings/edit.html.erb": `<div><%= render "shared/control" %></div>`,
+    }, A11yNoVisuallyHiddenInteractiveElementsRule, partial, { enabled: true })
+
+    expect(offenses).toHaveLength(1)
+    expect(offenses[0].message).toContain("At least one call site renders the keyboard-focusable `<button>` element inside an ancestor hidden by `sr-only`")
+    expect(offenses[0].message).toContain("The displayed call chain identifies the hidden `<div>` in `app/views/settings/show.html.erb`.")
+    expect(offenses[0].renderedFrom?.frames[0].file).toBe("app/views/settings/show.html.erb")
+  })
+
+  test("resolves visually hidden ancestors transitively", async () => {
+    const wrapper = "app/views/shared/_wrapper.html.erb"
+    const offenses = await offensesInProject({
+      [partial]: control,
+      [wrapper]: `<%= render "shared/control" %>`,
+      "app/views/settings/show.html.erb": `<section class="sr-only"><%= render "shared/wrapper" %></section>`,
+    }, A11yNoVisuallyHiddenInteractiveElementsRule, partial, { enabled: true })
+
+    expect(offenses).toHaveLength(1)
+    expect(offenses[0].message).toContain("The displayed call chain identifies the hidden `<section>` in `app/views/settings/show.html.erb`.")
+    expect(offenses[0].renderedFrom?.frames.map(frame => frame.file)).toEqual([
+      "app/views/settings/show.html.erb",
+      wrapper,
+    ])
+  })
+
+  test("reports a control hidden by an ancestor around a layout yield", async () => {
+    const view = "app/views/settings/show.html.erb"
+    const offenses = await offensesInProject({
+      "app/views/layouts/application.html.erb": `<html><body><main class="sr-only"><%= yield %></main></body></html>`,
+      [view]: control,
+    }, A11yNoVisuallyHiddenInteractiveElementsRule, view, { enabled: true })
+
+    expect(offenses).toHaveLength(1)
+    expect(offenses[0].message).toContain("The displayed call chain identifies the hidden `<main>` in `app/views/layouts/application.html.erb`.")
+    expect(offenses[0].renderedFrom?.frames[0].via).toBe("layout")
+  })
+
+  test("passes when focus-within reveals the caller ancestor", async () => {
+    const offenses = await lintInProject({
+      [partial]: control,
+      "app/views/settings/show.html.erb": `<div class="sr-only focus-within:not-sr-only"><%= render "shared/control" %></div>`,
+    }, A11yNoVisuallyHiddenInteractiveElementsRule, partial, { enabled: true })
+
+    expect(offenses).toEqual([])
+  })
+
+  test("stays quiet when caller context is unknown", async () => {
+    const offenses = await lintInProject({
+      [partial]: control,
+    }, A11yNoVisuallyHiddenInteractiveElementsRule, partial, { enabled: true })
+
+    expect(offenses).toEqual([])
+  })
 })
 
 describe("html-head-only-elements across files", () => {
@@ -415,4 +491,3 @@ describe("Action View helper call sites", () => {
     expect(offenses).toEqual(["Found `<a>` nested inside of `<button>`. Every call site renders this file inside a `<button>`. Nesting interactive elements produces invalid HTML, and assistive technologies, such as screen readers, might ignore or respond unexpectedly to such nested controls."])
   })
 })
-

--- a/javascript/packages/linter/test/partial-context-resolution.test.ts
+++ b/javascript/packages/linter/test/partial-context-resolution.test.ts
@@ -86,6 +86,45 @@ describe("call site ancestors", () => {
 
     expect(callers.callersOf("app/views/posts/_card.html.erb")[0].ancestors).toEqual([])
   })
+
+  test("records selected static attributes on ancestors enclosing a render", async () => {
+    const callers = await indexFor({
+      "app/views/posts/_card.html.erb": `<h1>hi</h1>`,
+      "app/views/posts/index.html.erb": `<main class="page"><div class="sr-only focus-within:not-sr-only"><%= render "posts/card" %></div></main>`,
+    })
+
+    const [callSite] = callers.callersOf("app/views/posts/_card.html.erb")
+
+    expect(callSite.ancestors).toEqual(["main", "div"])
+    expect(callSite.ancestorAttributes).toEqual([
+      { class: "page" },
+      { class: "sr-only focus-within:not-sr-only" },
+    ])
+  })
+
+  test("carries ancestor attributes through transitive render chains", async () => {
+    const callers = await indexFor({
+      "app/views/shared/_control.html.erb": `<button>Save</button>`,
+      "app/views/shared/_wrapper.html.erb": `<section class="wrapper"><%= render "shared/control" %></section>`,
+      "app/views/posts/index.html.erb": `<main class="sr-only"><%= render "shared/wrapper" %></main>`,
+    })
+
+    const [chain] = callers.contextOf("app/views/shared/_control.html.erb").chains
+
+    expect(chain.tags).toEqual(["main", "section"])
+    expect(chain.attributes).toEqual([{ class: "sr-only" }, { class: "wrapper" }])
+  })
+
+  test("omits dynamic class values", async () => {
+    const callers = await indexFor({
+      "app/views/posts/_card.html.erb": `<h1>hi</h1>`,
+      "app/views/posts/index.html.erb": `<main class="<%= classes %>"><%= render "posts/card" %></main>`,
+    })
+
+    const [callSite] = callers.callersOf("app/views/posts/_card.html.erb")
+
+    expect(callSite.ancestorAttributes).toBeUndefined()
+  })
 })
 
 describe("contextOf", () => {
@@ -511,4 +550,3 @@ describe("Action View helper ancestors", () => {
     expect(tagsOf(callers.contextOf("app/views/posts/_badge.html.erb"))).toEqual([["html", "body", "main", "a"]])
   })
 })
-

--- a/javascript/packages/linter/test/rules/a11y-no-visually-hidden-interactive-elements.test.ts
+++ b/javascript/packages/linter/test/rules/a11y-no-visually-hidden-interactive-elements.test.ts
@@ -12,6 +12,7 @@ import { renderedFrom, renderedFromNowhere } from "../helpers/partial-caller-con
 const { expectNoOffenses, expectWarning, assertOffenses } = createLinterTest(A11yNoVisuallyHiddenInteractiveElementsRule)
 
 const message = (tagName: string) => `The keyboard-focusable \`<${tagName}>\` element uses \`sr-only\` without a focus reveal class, so sighted keyboard users may think focus was lost. Remove \`sr-only\` or add a class such as \`focus:not-sr-only\` to reveal the element when it receives focus.`
+const ancestorMessage = (tagName: string, ancestorTagName: string) => `The keyboard-focusable \`<${tagName}>\` element is inside a \`<${ancestorTagName}>\` hidden by \`sr-only\`, so sighted keyboard users may think focus was lost. Remove \`sr-only\` from the ancestor or add \`focus-within:not-sr-only\` to reveal its contents when they receive focus.`
 
 describe("a11y-no-visually-hidden-interactive-elements", () => {
   test("passes for non-interactive element with sr-only", () => {
@@ -194,6 +195,44 @@ describe("a11y-no-visually-hidden-interactive-elements", () => {
     expectNoOffenses('<button class="sr-only <%= additional_classes %>">Submit</button>')
   })
 
+  describe("inside visually hidden ancestors", () => {
+    test("fails for a button inside a visually hidden div", () => {
+      expectWarning(ancestorMessage("button", "div"))
+
+      assertOffenses('<div class="sr-only"><button>Submit</button></div>')
+    })
+
+    test("reports the innermost visually hidden ancestor", () => {
+      expectWarning(ancestorMessage("button", "section"))
+
+      assertOffenses('<div class="sr-only"><section class="sr-only"><button>Submit</button></section></div>')
+    })
+
+    test("passes when focus-within reveals the hidden ancestor", () => {
+      expectNoOffenses('<div class="sr-only focus-within:not-sr-only"><button>Submit</button></div>')
+    })
+
+    test("passes when a prefixed focus-within variant reveals the hidden ancestor", () => {
+      expectNoOffenses('<div class="sr-only md:focus-within:not-sr-only"><button>Submit</button></div>')
+    })
+
+    test("fails when focus only reveals the ancestor on its own focus", () => {
+      expectWarning(ancestorMessage("button", "div"))
+
+      assertOffenses('<div class="sr-only focus:not-sr-only"><button>Submit</button></div>')
+    })
+
+    test("still fails when an outer hidden ancestor is not revealed", () => {
+      expectWarning(ancestorMessage("button", "div"))
+
+      assertOffenses('<div class="sr-only"><section class="sr-only focus-within:not-sr-only"><button>Submit</button></section></div>')
+    })
+
+    test("continues to exclude inputs inside a hidden ancestor", () => {
+      expectNoOffenses('<div class="sr-only"><input type="text"></div>')
+    })
+  })
+
   describe("across call sites", () => {
     const partial = "app/views/shared/_hidden_control.html.erb"
 
@@ -215,21 +254,16 @@ describe("a11y-no-visually-hidden-interactive-elements", () => {
       return linter.lint(source, context).offenses
     }
 
-    test("attaches the call chain to an offense in a rendered partial", () => {
+    test("omits the call chain when the element itself establishes the offense", () => {
       const [offense] = offensesFor(
         renderedFrom(partial, ["html", "body", "main"]),
       )
 
-      expect(offense.renderedFrom?.frames).toHaveLength(1)
-      expect(offense.renderedFrom?.frames[0].ancestors).toEqual([
-        "html",
-        "body",
-        "main",
-      ])
+      expect(offense.renderedFrom).toBeUndefined()
       expect(offense.message).toBe(message("button"))
     })
 
-    test("attaches one resolved chain when the partial has multiple call sites", () => {
+    test("omits the call chain when direct offenses have multiple call sites", () => {
       const [offense] = offensesFor(
         renderedFrom(
           partial,
@@ -238,12 +272,7 @@ describe("a11y-no-visually-hidden-interactive-elements", () => {
         ),
       )
 
-      expect(offense.renderedFrom?.frames).toHaveLength(1)
-      expect(offense.renderedFrom?.frames[0].ancestors).toEqual([
-        "html",
-        "body",
-        "main",
-      ])
+      expect(offense.renderedFrom).toBeUndefined()
       expect(offense.message).toBe(message("button"))
     })
 
@@ -271,14 +300,14 @@ describe("a11y-no-visually-hidden-interactive-elements", () => {
       expect(offense.renderedFrom).toBeUndefined()
     })
 
-    test("attaches the call chain to every offense in the partial", () => {
+    test("omits the call chain from every direct offense in the partial", () => {
       const offenses = offensesFor(
         renderedFrom(partial, ["html", "body", "main"]),
         '<button class="sr-only">Save</button><a class="sr-only" href="/cancel">Cancel</a>',
       )
 
       expect(offenses).toHaveLength(2)
-      expect(offenses.every((offense) => offense.renderedFrom?.frames.length === 1)).toBe(true)
+      expect(offenses.every((offense) => offense.renderedFrom === undefined)).toBe(true)
     })
   })
 })


### PR DESCRIPTION
Follow up on #1671.

This pull request makes `a11y-no-visually-hidden-interactive-elements` detect keyboard-focusable elements whose ancestors are hidden with `sr-only`. This covers both ancestors in the same template and ancestors contributed by partial render calls or conventional layout yields.

For example, this is now reported:

```erb
<div class="sr-only">
  <button>Submit</button>
</div>
```

An ancestor can reveal its contents with `focus-within:not-sr-only`:

```erb
<div class="sr-only focus-within:not-sr-only">
  <button>Submit</button>
</div>
```

A plain `focus:not-sr-only` does not suppress the offense because focusing the descendant does not focus its ancestor.

The partial caller index now preserves static ancestor `class` attributes across nested render calls and layout yields. It records only `class`, the attribute this rule needs, rather than collecting every attribute from the ancestor elements. 

This lets the rule report a control in a partial when all or only some known call sites place it inside a hidden ancestor. Dynamic class values and unresolved caller contexts remain unreported because the rule cannot determine whether those ancestors hide or reveal their contents.

When caller context establishes the offense, the detailed formatter includes an offending call chain and the message names the hidden ancestor and its source file. Direct offenses on the focusable element, and offenses established by an ancestor in the same file, do not include an unrelated render chain.