### PR TITLE
Linter: Don't flag ERB string literals that can't be inlined safely

### DIFF
--- a/javascript/packages/linter/docs/rules/actionview-no-unnecessary-html-safe.md
+++ b/javascript/packages/linter/docs/rules/actionview-no-unnecessary-html-safe.md
@@ -14,6 +14,16 @@ Because the content is static, `.html_safe` is not protecting anything either. T
 
 Note that dropping just the `.html_safe` call is not equivalent, since Action View escapes the remaining literal: `<%= "<strong>Sale</strong>" %>` renders as `&lt;strong&gt;Sale&lt;/strong&gt;`. The content has to move out of the ERB tag for the output to stay the same.
 
+## Autofix
+
+The offense is autocorrectable whenever the content can move into the template unchanged. In three cases it is reported without a fix, because writing the content directly would leave the template unparseable.
+
+The first is content that is not balanced markup on its own, such as `"<div>"`, `"</div>"` or `"<b>a<i>b</i></b>"` with the tags crossed. Inlining it would change the element nesting of the surrounding document, even though the rendered bytes stay the same. The rule parses the content to decide this, so balanced content like `"<strong>Sale</strong>"`, `"<br>"` or `"<div>a</div><div>b</div>"` is still corrected.
+
+The second is a literal inside an unquoted attribute value, such as `<div id=<%= "a b".html_safe %>>`. The value ends at the first ERB tag, so the content would not stay part of it.
+
+The third is content containing the quote that encloses the attribute value. Note that `.html_safe` skips escaping, so unlike a plain `<%= %>` tag the quote is not turned into `&quot;`. Such a template already renders a broken attribute, and the fix is to escape the quote rather than to inline it.
+
 ## Examples
 
 ### ✅ Good

--- a/javascript/packages/linter/docs/rules/erb-prefer-direct-output.md
+++ b/javascript/packages/linter/docs/rules/erb-prefer-direct-output.md
@@ -10,6 +10,24 @@ Flags ERB output tags that contain a string literal, including interpolated stri
 
 Wrapping static text in a string literal inside an ERB output tag is unnecessary. The text can be written directly in the template. For interpolated strings, each dynamic value should use its own ERB output tag, which is more idiomatic, easier to read, and avoids unnecessary string allocation.
 
+## Exceptions
+
+Strings are only flagged when the text can move into the template unchanged. The cases below are left alone, since writing the text directly would change what the page renders or how the template parses.
+
+ERB output escapes `<` and `&` while template text does not, so text containing either is not flagged. Here the ERB renders `Tom &amp; Jerry` and the text on its own would render `Tom & Jerry`:
+
+```erb
+<%= "Tom & Jerry" %>
+```
+
+Escaping also turns `"` into `&quot;`, so text containing the quote that encloses the attribute value is not flagged. Here the ERB renders `title="the &quot;good&quot; kind"`, while the text on its own would end the attribute value at the first inner quote:
+
+```erb
+<div title="<%= "the \"good\" kind" %>"></div>
+```
+
+Strings inside an unquoted attribute value, such as `<div id=<%= "#{prefix}_#{suffix}" %>>`, are not flagged either. The value ends at the first ERB tag, so the replacement would not stay part of it.
+
 ## Examples
 
 ### ✅ Good

--- a/javascript/packages/linter/src/linter.ts
+++ b/javascript/packages/linter/src/linter.ts
@@ -486,7 +486,8 @@ export class Linter {
       ignoredOffensesByLine,
       indentWidth: context?.indentWidth ?? this.config?.formatter?.indentWidth,
       indentStyle: context?.indentStyle ?? this.config?.formatter?.indentStyle,
-      framework: context?.framework ?? this.config?.framework
+      framework: context?.framework ?? this.config?.framework,
+      herb: context?.herb ?? this.herb
     }
 
     const regularRules = this.rules.filter(ruleClass => ruleClass.ruleName !== "herb-disable-comment-unnecessary")

--- a/javascript/packages/linter/src/rules/actionview-no-unnecessary-html-safe.ts
+++ b/javascript/packages/linter/src/rules/actionview-no-unnecessary-html-safe.ts
@@ -1,11 +1,11 @@
 import { ParserRule, BaseAutofixContext, Mutable } from "../types.js"
 import { BaseRuleVisitor } from "./rule-utils.js"
 
-import { ERBStringToDirectOutputRewriter } from "@herb-tools/rewriter"
+import { ERBStringToDirectOutputRewriter, isSafeToInline } from "@herb-tools/rewriter"
 
 import { isERBOutputNode, isPrismNodeType, createLiteral, findParentArray, locationFromByteOffset, substringFromByteOffset } from "@herb-tools/core"
 
-import type { ParseResult, ERBContentNode, ParserOptions, PrismNode, Node } from "@herb-tools/core"
+import type { ParseResult, ERBContentNode, HTMLAttributeValueNode, ParserOptions, PrismNode, Node } from "@herb-tools/core"
 import type { UnboundLintOffense, LintOffense, LintContext, FullRuleConfig } from "../types.js"
 
 interface UnnecessaryHTMLSafeAutofixContext extends BaseAutofixContext {
@@ -28,6 +28,18 @@ function stringLiteralReceiver(prismNode: PrismNode): PrismNode | null {
 }
 
 class ActionViewNoUnnecessaryHTMLSafeVisitor extends BaseRuleVisitor<UnnecessaryHTMLSafeAutofixContext> {
+  private attributeValue: HTMLAttributeValueNode | null = null
+
+  visitHTMLAttributeValueNode(node: HTMLAttributeValueNode): void {
+    const previousAttributeValue = this.attributeValue
+
+    this.attributeValue = node
+
+    super.visitHTMLAttributeValueNode(node)
+
+    this.attributeValue = previousAttributeValue
+  }
+
   visitERBContentNode(node: ERBContentNode): void {
     this.checkUnnecessaryHTMLSafe(node)
 
@@ -50,7 +62,11 @@ class ActionViewNoUnnecessaryHTMLSafeVisitor extends BaseRuleVisitor<Unnecessary
     const literal = substringFromByteOffset(source, receiver.location.startOffset, receiver.location.length)
     const content = ERBStringToDirectOutputRewriter.extractStringContent(receiver, source)
 
-    const autofixContext = content.includes("<%")
+    const inlinable =
+      isSafeToInline([{ type: "text", content }], { attributeValue: this.attributeValue, escaped: false }) &&
+      this.isBalancedMarkup(content)
+
+    const autofixContext = (content.includes("<%") || !inlinable)
       ? undefined
       : { node: node as Mutable<ERBContentNode>, content }
 
@@ -61,6 +77,16 @@ class ActionViewNoUnnecessaryHTMLSafeVisitor extends BaseRuleVisitor<Unnecessary
       undefined,
       ["unnecessary"],
     )
+  }
+
+  private isBalancedMarkup(content: string): boolean {
+    if (!content.includes("<")) return true
+
+    const herb = this.context.herb
+
+    if (!herb) return false
+
+    return herb.parse(content).recursiveErrors().length === 0
   }
 }
 

--- a/javascript/packages/linter/src/rules/erb-prefer-direct-output.ts
+++ b/javascript/packages/linter/src/rules/erb-prefer-direct-output.ts
@@ -1,11 +1,11 @@
 import { BaseRuleVisitor } from "./rule-utils.js"
 import { ParserRule, BaseAutofixContext } from "../types.js"
-import { ERBStringToDirectOutputRewriter } from "@herb-tools/rewriter"
+import { ERBStringToDirectOutputRewriter, isSafeToInline } from "@herb-tools/rewriter"
 
 import { isERBOutputNode, createLiteral, createERBOutputNode, findParentArray, isPrismNodeType , locationFromByteOffset } from "@herb-tools/core"
 
 import type { Mutable, ReplacementPart } from "@herb-tools/rewriter"
-import type { ParseResult, ERBContentNode, ParserOptions, Node } from "@herb-tools/core"
+import type { ParseResult, ERBContentNode, HTMLAttributeValueNode, ParserOptions, Node } from "@herb-tools/core"
 import type { UnboundLintOffense, LintOffense, LintContext, FullRuleConfig } from "../types.js"
 
 interface PreferDirectOutputAutofixContext extends BaseAutofixContext {
@@ -14,6 +14,18 @@ interface PreferDirectOutputAutofixContext extends BaseAutofixContext {
 }
 
 class PreferDirectOutputVisitor extends BaseRuleVisitor<PreferDirectOutputAutofixContext> {
+  private attributeValue: HTMLAttributeValueNode | null = null
+
+  visitHTMLAttributeValueNode(node: HTMLAttributeValueNode): void {
+    const previousAttributeValue = this.attributeValue
+
+    this.attributeValue = node
+
+    super.visitHTMLAttributeValueNode(node)
+
+    this.attributeValue = previousAttributeValue
+  }
+
   visitERBContentNode(node: ERBContentNode): void {
     if (!isERBOutputNode(node)) return
 
@@ -28,6 +40,8 @@ class PreferDirectOutputVisitor extends BaseRuleVisitor<PreferDirectOutputAutofi
     if (!ERBStringToDirectOutputRewriter.isStringOutputNode(prismNode)) return
 
     const replacementParts = ERBStringToDirectOutputRewriter.extractReplacementParts(prismNode, source)
+
+    if (replacementParts && !isSafeToInline(replacementParts, { attributeValue: this.attributeValue })) return
 
     const { startOffset, length } = prismNode.location
     const stringLocation = locationFromByteOffset(source, startOffset, length)

--- a/javascript/packages/linter/src/types.ts
+++ b/javascript/packages/linter/src/types.ts
@@ -2,7 +2,7 @@ import { Diagnostic, LexResult, ParseResult, Location } from "@herb-tools/core"
 
 import type { DiagnosticTag, HerbError } from "@herb-tools/core"
 import type { rules } from "./rules.js"
-import type { AncestorChain, Node, ParserOptions, PartialCallerIndex, PartialIndex } from "@herb-tools/core"
+import type { AncestorChain, HerbBackend, Node, ParserOptions, PartialCallerIndex, PartialIndex } from "@herb-tools/core"
 import type { Framework, RuleConfig, SeverityConfig, LinterMode } from "@herb-tools/config"
 import type { Mutable } from "@herb-tools/rewriter"
 import type { RuleVersion } from "@herb-tools/core"
@@ -260,6 +260,7 @@ export interface LintContext {
   partials: PartialIndex | undefined
   partialCallers: PartialCallerIndex | undefined
   projectPath: string | undefined
+  herb: HerbBackend | undefined
 }
 
 /**
@@ -275,7 +276,8 @@ export const DEFAULT_LINT_CONTEXT: LintContext = {
   framework: undefined,
   partials: undefined,
   partialCallers: undefined,
-  projectPath: undefined
+  projectPath: undefined,
+  herb: undefined
 } as const
 
 export abstract class SourceRule<TAutofixContext extends BaseAutofixContext = BaseAutofixContext> {

--- a/javascript/packages/linter/test/autofix/actionview-no-unnecessary-html-safe.autofix.test.ts
+++ b/javascript/packages/linter/test/autofix/actionview-no-unnecessary-html-safe.autofix.test.ts
@@ -82,4 +82,83 @@ describe("actionview-no-unnecessary-html-safe autofix", () => {
     expect(result.fixed).toHaveLength(0)
     expect(result.unfixed).toHaveLength(1)
   })
+
+  test("reports but does not fix a String literal in an unquoted attribute value", () => {
+    const input = `<div id=<%= "a b".html_safe %>>y</div>`
+
+    const result = autofix(input)
+
+    expect(result.source).toBe(input)
+    expect(result.fixed).toHaveLength(0)
+    expect(result.unfixed).toHaveLength(1)
+  })
+
+  test("reports but does not fix a String literal containing the quote that encloses the attribute value", () => {
+    const input = `<div title="<%= "say \\"hi\\"".html_safe %>">y</div>`
+
+    const result = autofix(input)
+
+    expect(result.source).toBe(input)
+    expect(result.fixed).toHaveLength(0)
+    expect(result.unfixed).toHaveLength(1)
+  })
+
+  test("reports but does not fix a String literal with an unclosed tag", () => {
+    const input = `<p><%= "<div>".html_safe %></p>`
+
+    const result = autofix(input)
+
+    expect(result.source).toBe(input)
+    expect(result.fixed).toHaveLength(0)
+    expect(result.unfixed).toHaveLength(1)
+  })
+
+  test("reports but does not fix a String literal with an unopened tag", () => {
+    const input = `<p><%= "</div>".html_safe %></p>`
+
+    const result = autofix(input)
+
+    expect(result.source).toBe(input)
+    expect(result.fixed).toHaveLength(0)
+    expect(result.unfixed).toHaveLength(1)
+  })
+
+  test("reports but does not fix a String literal with misnested tags", () => {
+    const input = `<p><%= "<b>a<i>b</b></i>".html_safe %></p>`
+
+    const result = autofix(input)
+
+    expect(result.source).toBe(input)
+    expect(result.fixed).toHaveLength(0)
+  })
+
+  test("fixes a String literal with a void element", () => {
+    const input = `<p><%= "<br>".html_safe %></p>`
+    const expected = `<p><br></p>`
+
+    const result = autofix(input)
+
+    expect(result.source).toBe(expected)
+    expect(result.fixed).toHaveLength(1)
+  })
+
+  test("fixes a String literal with several balanced siblings", () => {
+    const input = `<%= "<div>a</div><div>b</div>".html_safe %>`
+    const expected = `<div>a</div><div>b</div>`
+
+    const result = autofix(input)
+
+    expect(result.source).toBe(expected)
+    expect(result.fixed).toHaveLength(1)
+  })
+
+  test("fixes a String literal containing `&`, which `.html_safe` leaves unescaped anyway", () => {
+    const input = `<p><%= "Tom & Jerry".html_safe %></p>`
+    const expected = `<p>Tom & Jerry</p>`
+
+    const result = autofix(input)
+
+    expect(result.source).toBe(expected)
+    expect(result.fixed).toHaveLength(1)
+  })
 })

--- a/javascript/packages/linter/test/autofix/erb-prefer-direct-output.autofix.test.ts
+++ b/javascript/packages/linter/test/autofix/erb-prefer-direct-output.autofix.test.ts
@@ -247,6 +247,79 @@ describe("erb-prefer-direct-output autofix", () => {
     expect(result.fixed).toHaveLength(2)
   })
 
+  test("does not fix an interpolated string in an unquoted attribute value", () => {
+    const input = '<div id=<%= "#{a}_#{b}" %>>y</div>'
+
+    const linter = new Linter(Herb, [ERBPreferDirectOutputRule])
+    const result = linter.autofix(input)
+
+    expect(result.source).toBe(input)
+    expect(result.fixed).toHaveLength(0)
+    expect(result.unfixed).toHaveLength(0)
+  })
+
+  test("does not fix a string literal in an unquoted attribute value", () => {
+    const input = '<button data-target=<%= "##{t}" %>>y</button>'
+
+    const linter = new Linter(Herb, [ERBPreferDirectOutputRule])
+    const result = linter.autofix(input)
+
+    expect(result.source).toBe(input)
+    expect(result.fixed).toHaveLength(0)
+  })
+
+  test("does not fix text that would be parsed as markup", () => {
+    const input = '<p><%= "#{a} <request body> -- #{b}" %></p>'
+
+    const linter = new Linter(Herb, [ERBPreferDirectOutputRule])
+    const result = linter.autofix(input)
+
+    expect(result.source).toBe(input)
+    expect(result.fixed).toHaveLength(0)
+  })
+
+  test("does not fix text that would stop being escaped", () => {
+    const input = '<p><%= "a & b" %></p>'
+
+    const linter = new Linter(Herb, [ERBPreferDirectOutputRule])
+    const result = linter.autofix(input)
+
+    expect(result.source).toBe(input)
+    expect(result.fixed).toHaveLength(0)
+  })
+
+  test("does not fix text containing the quote that encloses the attribute value", () => {
+    const input = `<div title="<%= "say \\"hi\\"" %>">y</div>`
+
+    const linter = new Linter(Herb, [ERBPreferDirectOutputRule])
+    const result = linter.autofix(input)
+
+    expect(result.source).toBe(input)
+    expect(result.fixed).toHaveLength(0)
+  })
+
+  test("fixes text containing a quote the enclosing attribute value does not use", () => {
+    const input = `<div title="<%= "it's" %>">y</div>`
+    const expected = `<div title="it's">y</div>`
+
+    const linter = new Linter(Herb, [ERBPreferDirectOutputRule])
+    const result = linter.autofix(input)
+
+    expect(result.source).toBe(expected)
+    expect(result.fixed).toHaveLength(1)
+  })
+
+  test("fixes an interpolated string in a quoted attribute value", () => {
+    const input = '<div id="<%= "#{a}_#{b}" %>">y</div>'
+    const expected = '<div id="<%= a %>_<%= b %>">y</div>'
+
+    const linter = new Linter(Herb, [ERBPreferDirectOutputRule])
+    const result = linter.autofix(input)
+
+    expect(result.source).toBe(expected)
+    expect(result.fixed).toHaveLength(1)
+  })
+
   test("fixes every offence following a multi-byte character (#1761)", () => {
     const input = dedent`
       <%= "#{a} – ok" %>

--- a/javascript/packages/linter/test/rules/actionview-no-unnecessary-html-safe.test.ts
+++ b/javascript/packages/linter/test/rules/actionview-no-unnecessary-html-safe.test.ts
@@ -97,4 +97,22 @@ describe("actionview-no-unnecessary-html-safe", () => {
   it("passes for plain HTML", () => {
     expectNoOffenses(`<div style="display: none;"></div>`)
   })
+
+  it("flags a String literal in an unquoted attribute value", () => {
+    expectError('Avoid calling `.html_safe` on the String literal `"a b"`. Write the content directly in the template instead.')
+
+    assertOffenses(`<div id=<%= "a b".html_safe %>>y</div>`)
+  })
+
+  it("flags a String literal containing the enclosing double quote", () => {
+    expectError('Avoid calling `.html_safe` on the String literal `"say \\"hi\\""`. Write the content directly in the template instead.')
+
+    assertOffenses(`<div title="<%= "say \\"hi\\"".html_safe %>">y</div>`)
+  })
+
+  it("flags a String literal containing `&` in a quoted attribute value", () => {
+    expectError('Avoid calling `.html_safe` on the String literal `"a & b"`. Write the content directly in the template instead.')
+
+    assertOffenses(`<div title="<%= "a & b".html_safe %>">y</div>`)
+  })
 })

--- a/javascript/packages/linter/test/rules/erb-prefer-direct-output.test.ts
+++ b/javascript/packages/linter/test/rules/erb-prefer-direct-output.test.ts
@@ -220,4 +220,60 @@ describe("erb-prefer-direct-output", () => {
       <% end %>
     `)
   })
+
+  test("passes for string literal containing `<`", () => {
+    expectNoOffenses('<p><%= "a <b> c" %></p>')
+  })
+
+  test("passes for string literal containing `&`", () => {
+    expectNoOffenses('<p><%= "a & b" %></p>')
+  })
+
+  test("passes for interpolated string containing `<`", () => {
+    expectNoOffenses('<p><%= "#{a} <request body> -- #{b}" %></p>')
+  })
+
+  test("passes for interpolated string containing `&`", () => {
+    expectNoOffenses('<p><%= "#{a} & #{b}" %></p>')
+  })
+
+  test("passes for string literal in an unquoted attribute value", () => {
+    expectNoOffenses('<div id=<%= "foo" %>>y</div>')
+  })
+
+  test("passes for interpolated string in an unquoted attribute value", () => {
+    expectNoOffenses('<div id=<%= "#{a}_#{b}" %>>y</div>')
+  })
+
+  test("passes for string literal containing the enclosing double quote", () => {
+    expectNoOffenses(`<div title="<%= "say \\"hi\\"" %>">y</div>`)
+  })
+
+  test("passes for string literal containing the enclosing single quote", () => {
+    expectNoOffenses(`<div title='<%= "it\\'s" %>'>y</div>`)
+  })
+
+  test("fails for string literal containing a quote the enclosing attribute does not use", () => {
+    expectError(
+      `Avoid outputting string literal \`"it's"\`. Write the text directly without wrapping it in an ERB output tag.`,
+    )
+
+    assertOffenses(`<div title="<%= "it's" %>">y</div>`)
+  })
+
+  test("fails for string literal containing `>`", () => {
+    expectError(
+      'Avoid outputting string literal `"a > b"`. Write the text directly without wrapping it in an ERB output tag.',
+    )
+
+    assertOffenses('<p><%= "a > b" %></p>')
+  })
+
+  test("fails for interpolated string in a quoted attribute value", () => {
+    expectError(
+      'Avoid outputting interpolated string `"#{a}_#{b}"`. Use separate `<%= %>` tags for each dynamic value instead.',
+    )
+
+    assertOffenses('<div id="<%= "#{a}_#{b}" %>">y</div>')
+  })
 })

--- a/javascript/packages/rewriter/src/built-ins/erb-string-to-direct-output.ts
+++ b/javascript/packages/rewriter/src/built-ins/erb-string-to-direct-output.ts
@@ -3,7 +3,7 @@ import { Visitor, isERBOutputNode, createLiteral, createERBOutputNode, findParen
 import { ASTRewriter } from "../ast-rewriter.js"
 
 import type { RewriteContext } from "../context.js"
-import type { Node, ERBContentNode, PrismNode } from "@herb-tools/core"
+import type { Node, ERBContentNode, HTMLAttributeValueNode, PrismNode } from "@herb-tools/core"
 
 const STRING_NODE_TYPE = "StringNode"
 const INTERPOLATED_STRING_NODE_TYPE = "InterpolatedStringNode"
@@ -21,12 +21,44 @@ export interface ExpressionPart {
 
 export type ReplacementPart = TextPart | ExpressionPart
 
+export interface InlineSafetyOptions {
+  attributeValue?: HTMLAttributeValueNode | null
+  escaped?: boolean
+}
+
+export function isSafeToInline(parts: ReplacementPart[], options: InlineSafetyOptions = {}): boolean {
+  const { attributeValue = null, escaped = true } = options
+
+  if (attributeValue && !attributeValue.quoted) return false
+
+  const quote = attributeValue?.open_quote?.value ?? null
+
+  return parts.every(part => {
+    if (part.type !== "text") return true
+    if (escaped && (part.content.includes("<") || part.content.includes("&"))) return false
+    if (quote && part.content.includes(quote)) return false
+
+    return true
+  })
+}
+
 class ERBStringToDirectOutputVisitor extends Visitor {
   private root: Node
+  private attributeValue: HTMLAttributeValueNode | null = null
 
   constructor(root: Node) {
     super()
     this.root = root
+  }
+
+  visitHTMLAttributeValueNode(node: HTMLAttributeValueNode): void {
+    const previousAttributeValue = this.attributeValue
+
+    this.attributeValue = node
+
+    super.visitHTMLAttributeValueNode(node)
+
+    this.attributeValue = previousAttributeValue
   }
 
   visitERBContentNode(node: ERBContentNode): void {
@@ -55,6 +87,11 @@ class ERBStringToDirectOutputVisitor extends Visitor {
     const replacementParts = ERBStringToDirectOutputRewriter.extractReplacementParts(prismNode, source)
 
     if (!replacementParts) {
+      this.visitChildNodes(node)
+      return
+    }
+
+    if (!isSafeToInline(replacementParts, { attributeValue: this.attributeValue })) {
       this.visitChildNodes(node)
       return
     }

--- a/javascript/packages/rewriter/src/built-ins/index.ts
+++ b/javascript/packages/rewriter/src/built-ins/index.ts
@@ -38,8 +38,8 @@ export function getBuiltinRewriterNames(): string[] {
 }
 
 export { ActionViewTagHelperToHTMLRewriter } from "./action-view-tag-helper-to-html.js"
-export { ERBStringToDirectOutputRewriter } from "./erb-string-to-direct-output.js"
+export { ERBStringToDirectOutputRewriter, isSafeToInline } from "./erb-string-to-direct-output.js"
 export { HTMLToActionViewTagHelperRewriter } from "./html-to-action-view-tag-helper.js"
 export { TailwindClassSorterRewriter } from "./tailwind-class-sorter.js"
 
-export type { TextPart, ExpressionPart, ReplacementPart } from "./erb-string-to-direct-output.js"
+export type { TextPart, ExpressionPart, ReplacementPart, InlineSafetyOptions } from "./erb-string-to-direct-output.js"

--- a/javascript/packages/rewriter/src/index.ts
+++ b/javascript/packages/rewriter/src/index.ts
@@ -1,6 +1,6 @@
 export { ASTRewriter } from "./ast-rewriter.js"
 export { ActionViewTagHelperToHTMLRewriter } from "./built-ins/action-view-tag-helper-to-html.js"
-export { ERBStringToDirectOutputRewriter } from "./built-ins/erb-string-to-direct-output.js"
+export { ERBStringToDirectOutputRewriter, isSafeToInline } from "./built-ins/erb-string-to-direct-output.js"
 export { HTMLToActionViewTagHelperRewriter } from "./built-ins/html-to-action-view-tag-helper.js"
 export { StringRewriter } from "./string-rewriter.js"
 
@@ -14,4 +14,4 @@ export type { Mutable } from "./mutable.js"
 export type { RewriterClass } from "./type-guards.js"
 export type { Rewriter, RewriteOptions, RewriteResult } from "./rewrite.js"
 export type { TailwindClassSorterOptions } from "./rewriter-factories.js"
-export type { TextPart, ExpressionPart, ReplacementPart } from "./built-ins/erb-string-to-direct-output.js"
+export type { TextPart, ExpressionPart, ReplacementPart, InlineSafetyOptions } from "./built-ins/erb-string-to-direct-output.js"

--- a/javascript/packages/rewriter/test/built-ins/erb-string-to-direct-output.test.ts
+++ b/javascript/packages/rewriter/test/built-ins/erb-string-to-direct-output.test.ts
@@ -1,0 +1,108 @@
+import { describe, test, expect, beforeAll } from "vitest"
+
+import { Herb } from "@herb-tools/node-wasm"
+import { IdentityPrinter } from "@herb-tools/printer"
+
+import { ERBStringToDirectOutputRewriter, isSafeToInline } from "../../src/built-ins/erb-string-to-direct-output.js"
+
+import type { ReplacementPart } from "../../src/built-ins/erb-string-to-direct-output.js"
+import type { HTMLAttributeValueNode } from "@herb-tools/core"
+
+function rewrite(input: string): string {
+  const rewriter = new ERBStringToDirectOutputRewriter()
+  const parseResult = Herb.parse(input, { track_whitespace: true, prism_nodes: true })
+
+  return IdentityPrinter.print(rewriter.rewrite(parseResult.value, { baseDir: process.cwd() }))
+}
+
+function attributeValue(quoted: boolean, quote: string | null): HTMLAttributeValueNode {
+  return { quoted, open_quote: quote === null ? null : { value: quote } } as HTMLAttributeValueNode
+}
+
+function text(content: string): ReplacementPart[] {
+  return [{ type: "text", content }]
+}
+
+describe("erb-string-to-direct-output", () => {
+  beforeAll(async () => {
+    await Herb.load()
+  })
+
+  describe("isSafeToInline", () => {
+    test("accepts plain text", () => {
+      expect(isSafeToInline(text("Title"))).toBe(true)
+    })
+
+    test("accepts expression parts", () => {
+      expect(isSafeToInline([{ type: "expression", expression: "a & b" }])).toBe(true)
+    })
+
+    test("rejects text that would be parsed as markup", () => {
+      expect(isSafeToInline(text("a <b> c"))).toBe(false)
+    })
+
+    test("rejects text that would stop being escaped", () => {
+      expect(isSafeToInline(text("a & b"))).toBe(false)
+    })
+
+    test("rejects an unsafe part among safe ones", () => {
+      expect(isSafeToInline([{ type: "text", content: "ok" }, { type: "expression", expression: "a" }, { type: "text", content: "&" }])).toBe(false)
+    })
+
+    test("accepts `<` and `&` for unescaped output", () => {
+      expect(isSafeToInline(text("<b>a & b</b>"), { escaped: false })).toBe(true)
+    })
+
+    test("rejects any text in an unquoted attribute value", () => {
+      expect(isSafeToInline(text("Title"), { attributeValue: attributeValue(false, null) })).toBe(false)
+      expect(isSafeToInline(text("Title"), { attributeValue: attributeValue(false, null), escaped: false })).toBe(false)
+    })
+
+    test("rejects text containing the quote that encloses the attribute value", () => {
+      expect(isSafeToInline(text(`say "hi"`), { attributeValue: attributeValue(true, `"`) })).toBe(false)
+      expect(isSafeToInline(text("it's"), { attributeValue: attributeValue(true, "'") })).toBe(false)
+    })
+
+    test("accepts text containing a quote the attribute value does not use", () => {
+      expect(isSafeToInline(text("it's"), { attributeValue: attributeValue(true, `"`) })).toBe(true)
+    })
+  })
+
+  describe("rewrite", () => {
+    test("replaces a string literal with text", () => {
+      expect(rewrite('<p><%= "Title" %></p>')).toBe("<p>Title</p>")
+    })
+
+    test("splits an interpolated string into separate tags", () => {
+      expect(rewrite('<p><%= "#{a} and #{b}" %></p>')).toBe("<p><%= a %> and <%= b %></p>")
+    })
+
+    test("keeps a string literal in an unquoted attribute value", () => {
+      const input = '<div id=<%= "#{a}_#{b}" %>>y</div>'
+
+      expect(rewrite(input)).toBe(input)
+    })
+
+    test("keeps text that would be parsed as markup", () => {
+      const input = '<p><%= "#{a} <request body> -- #{b}" %></p>'
+
+      expect(rewrite(input)).toBe(input)
+    })
+
+    test("keeps text that would stop being escaped", () => {
+      const input = '<p><%= "a & b" %></p>'
+
+      expect(rewrite(input)).toBe(input)
+    })
+
+    test("keeps text containing the quote that encloses the attribute value", () => {
+      const input = `<div title="<%= "say \\"hi\\"" %>">y</div>`
+
+      expect(rewrite(input)).toBe(input)
+    })
+
+    test("replaces an interpolated string in a quoted attribute value", () => {
+      expect(rewrite('<div id="<%= "#{a}_#{b}" %>">y</div>')).toBe('<div id="<%= a %>_<%= b %>">y</div>')
+    })
+  })
+})


### PR DESCRIPTION
This pull request updates `erb-prefer-direct-output` and `actionview-no-unnecessary-html-safe` so they only inline a string literal when its content can move into the template unchanged.

Both rules autofix by splicing the string content into the template as text, and `herb-lint --fix` runs that against real files, so producing a template that no longer parses is the worst outcome available to them. Five shapes did exactly that, or quietly changed what the page renders.

```erb
<div id=<%= "#{a}_#{b}" %>>y</div>
<button data-target=<%= "##{t}" %>>y</button>
<p><%= "#{a} <request body> -- #{b}" %></p>
<p><%= "a & b" %></p>
<div title="<%= "say \"hi\"" %>">y</div>
```

autofixed to:

```erb
<div id=<%= a %>_<%= b %>>y</div>
<button data-target=#<%= t %>>y</button>
<p><%= a %> <request body> -- <%= b %></p>
<p>a & b</p>
<div title="say "hi"">y</div>
```

An unquoted attribute value ends at the first ERB tag, so the first two cases drop the rest of the replacement out of the value, and the last ends the value at the inlined quote. The third parses `<request body>` as a tag. The fourth changes what the page renders, since ERB output escapes `<` and `&` while template text does not, so `<%= "a & b" %>` renders `a &amp; b` where the replacement renders `a & b`.