### PR TITLE
JavaScript: Include generated templates in the nx build cache key

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -10,7 +10,10 @@
     "sharedGlobals": [
       "{workspaceRoot}/.github/workflows/javascript.yml",
       "{workspaceRoot}/src/**/*",
-      "{workspaceRoot}/wasm/**/*"
+      "{workspaceRoot}/wasm/**/*",
+      "{workspaceRoot}/config.yml",
+      "{workspaceRoot}/config/**/*",
+      "{workspaceRoot}/templates/**/*"
     ]
   },
   "plugins": [],
@@ -26,6 +29,7 @@
   "targetDefaults": {
     "build": {
       "dependsOn": ["^build"],
+      "inputs": ["default", "^default"],
       "options": {
         "parallel": false
       }

--- a/templates/project.json
+++ b/templates/project.json
@@ -9,7 +9,12 @@
       "options": {
         "command": "bundle exec rake templates"
       },
-      "inputs": ["{projectRoot}/**/*", "{workspaceRoot}/Rakefile", "{workspaceRoot}/config.yml"],
+      "inputs": [
+        "{projectRoot}/**/*",
+        "{workspaceRoot}/Rakefile",
+        "{workspaceRoot}/config.yml",
+        "{workspaceRoot}/config/**/*"
+      ],
       "dependsOn": ["prism:build"]
     }
   },


### PR DESCRIPTION
Editing `config.yml` or a file under `config/action_view_helpers/` regenerates `core/src/nodes.ts`, `errors.ts` and `action-view-helpers.ts`, but `@herb-tools/core:build` kept serving the bundle it had built before the change. The generated files are gitignored and nx skips gitignored files when it hashes a task, so nothing in the cache key ever moved.