### PR TITLE
Linter: Add unsafe autofix to `actionview-prefer-qualified-partial-path`

### DIFF
--- a/javascript/packages/linter/docs/rules/actionview-prefer-qualified-partial-path.md
+++ b/javascript/packages/linter/docs/rules/actionview-prefer-qualified-partial-path.md
@@ -33,6 +33,27 @@ When the project's partials are known, the message names the path to write. Othe
 
 Only output tags are reported. A `render` in a silent `<% %>` tag discards its output and is covered by [`actionview-no-silent-render`](./actionview-no-silent-render.md).
 
+## Autofix
+
+`--fix-unsafely` rewrites the name to the path from the view root, but only when the partial resolves to a file sitting in the same directory as the template that renders it:
+
+```erb
+<%# app/views/posts/index.html.erb, next to app/views/posts/_card.html.erb %>
+<%= render "card" %>
+```
+
+becomes
+
+```erb
+<%= render "posts/card" %>
+```
+
+Everywhere else the rewrite is not offered, and the offense reports the path to write without correcting it. A name resolved out of `app/views/application` is left alone, because a template that inherits from another controller may resolve it somewhere closer at runtime.
+
+The fix stays unsafe even for a co-located partial. Rails resolves an unqualified name against the prefixes of the controller doing the rendering, not against the directory the calling template happens to live in. Those agree for a template under the controller's own view directory, which is the convention this rule assumes, but a template rendered by a different controller resolves the name somewhere else, and writing the path from the view root pins it to the file next door.
+
+The rewrite is also skipped when the same quoted string appears more than once in the ERB tag, since the one to rewrite cannot be told apart from the rest.
+
 ## Examples
 
 ### ✅ Good

--- a/javascript/packages/linter/src/rules/actionview-prefer-qualified-partial-path.ts
+++ b/javascript/packages/linter/src/rules/actionview-prefer-qualified-partial-path.ts
@@ -2,12 +2,39 @@ import { BaseRuleVisitor } from "./rule-utils.js"
 import { ParserRule } from "../types.js"
 import { isOutputRender, renderPartialExpression } from "./prism-rule-utils.js"
 
-import { isPrismNodeType, locationFromByteOffset, partialNameForFile } from "@herb-tools/core"
+import { isPrismNodeType, locationFromByteOffset, partialNameForFile, substringFromByteOffset } from "@herb-tools/core"
 
-import type { ERBRenderNode, ParseResult, ParserOptions } from "@herb-tools/core"
-import type { FullRuleConfig, LintContext, UnboundLintOffense } from "../types.js"
+import type { ERBRenderNode, ParseResult, ParserOptions, PrismNode } from "@herb-tools/core"
+import type { BaseAutofixContext, FullRuleConfig, LintContext, LintOffense, Mutable, UnboundLintOffense } from "../types.js"
 
-class ActionViewPreferQualifiedPartialPathVisitor extends BaseRuleVisitor {
+const QUOTES = ["\"", "'"]
+
+interface PreferQualifiedPartialPathAutofixContext extends BaseAutofixContext {
+  node: Mutable<ERBRenderNode>
+  literal: string
+  replacement: string
+}
+
+interface ResolvedPartial {
+  qualified: string
+  colocated: boolean
+}
+
+function directoryOf(file: string): string {
+  const index = file.replace(/\\/g, "/").lastIndexOf("/")
+
+  return index === -1 ? "" : file.slice(0, index)
+}
+
+function quotedText(source: string, location: PrismNode["location"] | null | undefined): string | null {
+  if (!location) return null
+
+  const text = substringFromByteOffset(source, location.startOffset, location.length)
+
+  return QUOTES.includes(text) ? text : null
+}
+
+class ActionViewPreferQualifiedPartialPathVisitor extends BaseRuleVisitor<PreferQualifiedPartialPathAutofixContext> {
   visitERBRenderNode(node: ERBRenderNode): void {
     this.checkRender(node)
 
@@ -31,38 +58,69 @@ class ActionViewPreferQualifiedPartialPathVisitor extends BaseRuleVisitor {
     if (!name) return
     if (name.includes("/")) return
 
+    const resolved = this.resolve(name)
+
     this.addOffense(
-      `The partial \`${name}\` is looked up relative to the directory of the template rendering it. Moving this template changes which file that resolves to, and renaming the partial means hunting for callers that never spell its full name. ${this.advice(name)}`,
+      `The partial \`${name}\` is looked up relative to the directory of the template rendering it. Moving this template changes which file that resolves to, and renaming the partial means hunting for callers that never spell its full name. ${this.advice(resolved)}`,
       locationFromByteOffset(source, expression.node.location.startOffset, expression.node.location.length),
+      this.autofixContextFor(node, expression.node, source, name, resolved),
     )
   }
 
-  private advice(name: string): string {
-    const qualified = this.qualifiedNameFor(name)
-
-    if (qualified) {
-      return `Write it as \`${qualified}\` so it resolves to the same file from any template, and a search for \`${qualified}\` finds every caller.`
+  private advice(resolved: ResolvedPartial | null): string {
+    if (resolved) {
+      return `Write it as \`${resolved.qualified}\` so it resolves to the same file from any template, and a search for \`${resolved.qualified}\` finds every caller.`
     }
 
     return `Write the full path from the view root so it resolves to the same file from any template, and a search for that path finds every caller.`
   }
 
-  private qualifiedNameFor(name: string): string | null {
+  private autofixContextFor(node: ERBRenderNode, string: PrismNode, source: string, name: string, resolved: ResolvedPartial | null): PreferQualifiedPartialPathAutofixContext | undefined {
+    if (!resolved?.colocated) return undefined
+
+    const opening = quotedText(source, string.openingLoc)
+    const closing = quotedText(source, string.closingLoc)
+
+    if (opening === null || opening !== closing) return undefined
+
+    const content = substringFromByteOffset(source, string.contentLoc.startOffset, string.contentLoc.length)
+
+    if (content !== name) return undefined
+
+    return {
+      node: node as Mutable<ERBRenderNode>,
+      nodeType: node.end_node ? "AST_ERB_BLOCK_NODE" : "AST_ERB_CONTENT_NODE",
+      literal: `${opening}${content}${closing}`,
+      replacement: `${opening}${resolved.qualified}${closing}`,
+    }
+  }
+
+  private resolve(name: string): ResolvedPartial | null {
     const partials = this.context.partials
 
     if (!partials) return null
 
-    const declaration = partials.lookup(name, this.sourceFile)
+    const sourceFile = this.sourceFile
+    const declaration = partials.lookup(name, sourceFile)
 
     if (!declaration) return null
 
-    return partialNameForFile(declaration.file, partials.viewRoot)
+    const qualified = partialNameForFile(declaration.file, partials.viewRoot)
+
+    if (!qualified) return null
+
+    return {
+      qualified,
+      colocated: sourceFile !== undefined && directoryOf(declaration.file) === directoryOf(sourceFile),
+    }
   }
 }
 
-export class ActionViewPreferQualifiedPartialPathRule extends ParserRule {
+export class ActionViewPreferQualifiedPartialPathRule extends ParserRule<PreferQualifiedPartialPathAutofixContext> {
   static ruleName = "actionview-prefer-qualified-partial-path"
   static introducedIn = this.version("unreleased")
+  static unsafeAutocorrectable = true
+  static autofixRequiresContext = true
 
   get defaultConfig(): FullRuleConfig {
     return {
@@ -78,11 +136,29 @@ export class ActionViewPreferQualifiedPartialPathRule extends ParserRule {
     }
   }
 
-  check(result: ParseResult, context?: Partial<LintContext>): UnboundLintOffense[] {
+  check(result: ParseResult, context?: Partial<LintContext>): UnboundLintOffense<PreferQualifiedPartialPathAutofixContext>[] {
     const visitor = new ActionViewPreferQualifiedPartialPathVisitor(this.ruleName, context)
 
     visitor.visit(result.value)
 
     return visitor.offenses
+  }
+
+  autofix(offense: LintOffense<PreferQualifiedPartialPathAutofixContext>, result: ParseResult): ParseResult | null {
+    if (!offense.autofixContext) return null
+
+    const { node, literal, replacement } = offense.autofixContext
+    const content = node.content
+
+    if (!content) return null
+
+    const index = content.value.indexOf(literal)
+
+    if (index === -1) return null
+    if (content.value.indexOf(literal, index + 1) !== -1) return null
+
+    content.value = content.value.slice(0, index) + replacement + content.value.slice(index + literal.length)
+
+    return result
   }
 }

--- a/javascript/packages/linter/test/autofix/actionview-prefer-qualified-partial-path.autofix.test.ts
+++ b/javascript/packages/linter/test/autofix/actionview-prefer-qualified-partial-path.autofix.test.ts
@@ -1,0 +1,150 @@
+import dedent from "dedent"
+import { describe, test, expect, beforeAll } from "vitest"
+import { Herb } from "@herb-tools/node-wasm"
+import { PartialIndex } from "@herb-tools/core"
+import { Linter } from "../../src/linter.js"
+import { ActionViewPreferQualifiedPartialPathRule } from "../../src/rules/actionview-prefer-qualified-partial-path.js"
+
+import type { PartialDeclaration } from "@herb-tools/core"
+
+function declaration(file: string): PartialDeclaration {
+  return { file, hasDeclaration: false, hasKeywordRest: false, locals: [] }
+}
+
+const partials = new PartialIndex("app/views", new Map([
+  ["posts/card", declaration("app/views/posts/_card.html.erb")],
+  ["posts/row", declaration("app/views/posts/_row.html.erb")],
+  ["application/flash", declaration("app/views/application/_flash.html.erb")],
+]))
+
+const context = { fileName: "app/views/posts/index.html.erb", partials }
+
+function fix(source: string, options: { includeUnsafe?: boolean, context?: any } = {}) {
+  const linter = new Linter(Herb, [ActionViewPreferQualifiedPartialPathRule])
+
+  return linter.autofix(source, options.context ?? context, undefined, { includeUnsafe: options.includeUnsafe ?? true })
+}
+
+describe("actionview-prefer-qualified-partial-path autofix", () => {
+  beforeAll(async () => {
+    await Herb.load()
+  })
+
+  test("qualifies a partial sitting next to the template", () => {
+    const result = fix(`<%= render "card" %>`)
+
+    expect(result.source).toBe(`<%= render "posts/card" %>`)
+    expect(result.fixed).toHaveLength(1)
+    expect(result.unfixed).toHaveLength(0)
+  })
+
+  test("qualifies the keyword form", () => {
+    const result = fix(`<%= render partial: "card", locals: { post: @post } %>`)
+
+    expect(result.source).toBe(`<%= render partial: "posts/card", locals: { post: @post } %>`)
+  })
+
+  test("qualifies the hash rocket form", () => {
+    const result = fix(`<%= render :partial => "card" %>`)
+
+    expect(result.source).toBe(`<%= render :partial => "posts/card" %>`)
+  })
+
+  test("keeps single quotes", () => {
+    const result = fix(`<%= render 'card' %>`)
+
+    expect(result.source).toBe(`<%= render 'posts/card' %>`)
+  })
+
+  test("qualifies a render that takes a block", () => {
+    const result = fix(dedent`
+      <%= render "card" do %>
+        <p>body</p>
+      <% end %>
+    `)
+
+    expect(result.source).toBe(dedent`
+      <%= render "posts/card" do %>
+        <p>body</p>
+      <% end %>
+    `)
+  })
+
+  test("qualifies a render nested in markup", () => {
+    const result = fix(dedent`
+      <div class="row">
+        <%= render "card" %>
+      </div>
+    `)
+
+    expect(result.source).toBe(dedent`
+      <div class="row">
+        <%= render "posts/card" %>
+      </div>
+    `)
+  })
+
+  test("qualifies every render in the file", () => {
+    const result = fix(dedent`
+      <%= render "card" %>
+      <%= render "row" %>
+    `)
+
+    expect(result.source).toBe(dedent`
+      <%= render "posts/card" %>
+      <%= render "posts/row" %>
+    `)
+    expect(result.fixed).toHaveLength(2)
+  })
+
+  test("qualifies a partial rendered from a partial in the same directory", () => {
+    const result = fix(`<%= render "card" %>`, { context: { fileName: "app/views/posts/_list.html.erb", partials } })
+
+    expect(result.source).toBe(`<%= render "posts/card" %>`)
+  })
+
+  test("does not fix without includeUnsafe", () => {
+    const result = fix(`<%= render "card" %>`, { includeUnsafe: false })
+
+    expect(result.source).toBe(`<%= render "card" %>`)
+    expect(result.fixed).toHaveLength(0)
+    expect(result.unfixed).toHaveLength(1)
+  })
+
+  test("does not fix a partial resolved from the application directory", () => {
+    const result = fix(`<%= render "flash" %>`)
+
+    expect(result.source).toBe(`<%= render "flash" %>`)
+    expect(result.fixed).toHaveLength(0)
+    expect(result.unfixed).toHaveLength(1)
+  })
+
+  test("does not fix when the partial does not resolve", () => {
+    const result = fix(`<%= render "missing" %>`)
+
+    expect(result.source).toBe(`<%= render "missing" %>`)
+    expect(result.fixed).toHaveLength(0)
+  })
+
+  test("does not fix without a partial index", () => {
+    const result = fix(`<%= render "card" %>`, { context: { fileName: "app/views/posts/index.html.erb" } })
+
+    expect(result.source).toBe(`<%= render "card" %>`)
+    expect(result.fixed).toHaveLength(0)
+  })
+
+  test("does not fix without a file name", () => {
+    const result = fix(`<%= render "card" %>`, { context: { partials } })
+
+    expect(result.source).toBe(`<%= render "card" %>`)
+    expect(result.fixed).toHaveLength(0)
+  })
+
+  test("does not fix when the name appears twice in the same tag", () => {
+    const result = fix(`<%= render "card", kind: "card" %>`)
+
+    expect(result.source).toBe(`<%= render "card", kind: "card" %>`)
+    expect(result.fixed).toHaveLength(0)
+    expect(result.unfixed).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
This pull request adds an unsafe autofix to `actionview-prefer-qualified-partial-path`, so the rule can write the path it already names in its message instead of only asking for it.

The offense currently resolves the partial through the project's partial index to tell you what to write:

```
[info] The partial `messages_table` is looked up relative to the directory of the template rendering it. […]
       Write it as `messages/messages_table` so it resolves to the same file from any template, […]

app/views/messages/_index.html.erb:9:23
```

Now `--fix-unsafely` performs that rewrite, but only when the partial resolves to a file sitting in the same directory as the template rendering it:

```erb
<%# app/views/posts/index.html.erb, next to app/views/posts/_card.html.erb %>
<%= render "card" %>
<%= render :partial => "card", :locals => { :post => @post } %>
```

```erb
<%= render "posts/card" %>
<%= render :partial => "posts/card", :locals => { :post => @post } %>
```

#### Why the fix stays unsafe

Rails resolves an unqualified partial name against the prefixes of the controller doing the rendering, not against the directory the calling template happens to live in. 

The two agree for a template under its own controller's view directory, which is the convention this rule already assumes when it names a path, but a template rendered by a different controller resolves the name somewhere else. Co-location is a very strong signal, not a proof, so the rewrite goes behind `--fix-unsafely` rather than `--fix`.