### PR TITLE
Linter: Report `actionview-no-helper-shadowing` as a warning

### DIFF
--- a/javascript/packages/linter/src/rules/actionview-no-helper-shadowing.ts
+++ b/javascript/packages/linter/src/rules/actionview-no-helper-shadowing.ts
@@ -130,7 +130,7 @@ export class ActionViewNoHelperShadowingRule extends ParserRule {
   get defaultConfig(): FullRuleConfig {
     return {
       enabled: true,
-      severity: "error"
+      severity: "warning"
     }
   }
 

--- a/javascript/packages/linter/test/rules/actionview-no-helper-shadowing.test.ts
+++ b/javascript/packages/linter/test/rules/actionview-no-helper-shadowing.test.ts
@@ -5,12 +5,12 @@ import { describe, test } from "vitest"
 import { ActionViewNoHelperShadowingRule } from "../../src/rules/actionview-no-helper-shadowing.js"
 import { createLinterTest } from "../helpers/linter-test-helper.js"
 
-const { expectNoOffenses, expectError, expectHint, assertOffenses } = createLinterTest(ActionViewNoHelperShadowingRule)
+const { expectNoOffenses, expectWarning, expectHint, assertOffenses } = createLinterTest(ActionViewNoHelperShadowingRule)
 
 describe("ActionViewNoHelperShadowingRule", () => {
-  describe("transformed helpers (error)", () => {
-    test("block argument named tag is flagged as an error", () => {
-      expectError("Local variable `tag` shadows the Action View `tag` helper. Rename it to avoid confusion (for example `tag_item`).")
+  describe("transformed helpers (warning)", () => {
+    test("block argument named tag is flagged as a warning", () => {
+      expectWarning("Local variable `tag` shadows the Action View `tag` helper. Rename it to avoid confusion (for example `tag_item`).")
 
       assertOffenses(dedent`
         <% @tags.each do |tag| %>
@@ -19,8 +19,8 @@ describe("ActionViewNoHelperShadowingRule", () => {
       `)
     })
 
-    test("block argument named content_tag is flagged as an error", () => {
-      expectError("Local variable `content_tag` shadows the Action View `content_tag` helper. Rename it to avoid confusion (for example `content_tag_item`).")
+    test("block argument named content_tag is flagged as a warning", () => {
+      expectWarning("Local variable `content_tag` shadows the Action View `content_tag` helper. Rename it to avoid confusion (for example `content_tag_item`).")
 
       assertOffenses(dedent`
         <% items.each do |content_tag| %>
@@ -30,7 +30,7 @@ describe("ActionViewNoHelperShadowingRule", () => {
     })
 
     test("only the shadowing argument is flagged in a multi-argument block", () => {
-      expectError("Local variable `tag` shadows the Action View `tag` helper. Rename it to avoid confusion (for example `tag_item`).")
+      expectWarning("Local variable `tag` shadows the Action View `tag` helper. Rename it to avoid confusion (for example `tag_item`).")
 
       assertOffenses(dedent`
         <% pairs.each do |key, tag| %>
@@ -40,7 +40,7 @@ describe("ActionViewNoHelperShadowingRule", () => {
     })
 
     test("nested block shadowing is flagged", () => {
-      expectError("Local variable `tag` shadows the Action View `tag` helper. Rename it to avoid confusion (for example `tag_item`).")
+      expectWarning("Local variable `tag` shadows the Action View `tag` helper. Rename it to avoid confusion (for example `tag_item`).")
 
       assertOffenses(dedent`
         <% groups.each do |group| %>
@@ -52,7 +52,7 @@ describe("ActionViewNoHelperShadowingRule", () => {
     })
 
     test("render block argument named tag is flagged", () => {
-      expectError("Local variable `tag` shadows the Action View `tag` helper. Rename it to avoid confusion (for example `tag_item`).")
+      expectWarning("Local variable `tag` shadows the Action View `tag` helper. Rename it to avoid confusion (for example `tag_item`).")
 
       assertOffenses(dedent`
         <%= render @tags do |tag| %>
@@ -62,7 +62,7 @@ describe("ActionViewNoHelperShadowingRule", () => {
     })
 
     test("for-loop variable named tag is flagged", () => {
-      expectError("Local variable `tag` shadows the Action View `tag` helper. Rename it to avoid confusion (for example `tag_item`).")
+      expectWarning("Local variable `tag` shadows the Action View `tag` helper. Rename it to avoid confusion (for example `tag_item`).")
 
       assertOffenses(dedent`
         <% for tag in @tags %>
@@ -72,7 +72,7 @@ describe("ActionViewNoHelperShadowingRule", () => {
     })
 
     test("local assignment named tag is flagged", () => {
-      expectError("Local variable `tag` shadows the Action View `tag` helper. Rename it to avoid confusion (for example `tag_item`).")
+      expectWarning("Local variable `tag` shadows the Action View `tag` helper. Rename it to avoid confusion (for example `tag_item`).")
 
       assertOffenses(dedent`
         <% tag = @tags.first %>
@@ -81,7 +81,7 @@ describe("ActionViewNoHelperShadowingRule", () => {
     })
 
     test("multiple assignment target named tag is flagged", () => {
-      expectError("Local variable `tag` shadows the Action View `tag` helper. Rename it to avoid confusion (for example `tag_item`).")
+      expectWarning("Local variable `tag` shadows the Action View `tag` helper. Rename it to avoid confusion (for example `tag_item`).")
 
       assertOffenses(dedent`
         <% first, tag = @tags %>
@@ -90,7 +90,7 @@ describe("ActionViewNoHelperShadowingRule", () => {
     })
 
     test("or-assignment named link_to is flagged", () => {
-      expectError("Local variable `link_to` shadows the Action View `link_to` helper. Rename it to avoid confusion (for example `link_to_item`).")
+      expectWarning("Local variable `link_to` shadows the Action View `link_to` helper. Rename it to avoid confusion (for example `link_to_item`).")
 
       assertOffenses(dedent`
         <% link_to ||= default_link %>
@@ -99,7 +99,7 @@ describe("ActionViewNoHelperShadowingRule", () => {
     })
 
     test("and-assignment named tag is flagged", () => {
-      expectError("Local variable `tag` shadows the Action View `tag` helper. Rename it to avoid confusion (for example `tag_item`).")
+      expectWarning("Local variable `tag` shadows the Action View `tag` helper. Rename it to avoid confusion (for example `tag_item`).")
 
       assertOffenses(dedent`
         <% tag &&= @default_tag %>
@@ -108,7 +108,7 @@ describe("ActionViewNoHelperShadowingRule", () => {
     })
 
     test("operator-assignment named tag is flagged", () => {
-      expectError("Local variable `tag` shadows the Action View `tag` helper. Rename it to avoid confusion (for example `tag_item`).")
+      expectWarning("Local variable `tag` shadows the Action View `tag` helper. Rename it to avoid confusion (for example `tag_item`).")
 
       assertOffenses(dedent`
         <% tag += @extra %>
@@ -117,7 +117,7 @@ describe("ActionViewNoHelperShadowingRule", () => {
     })
 
     test("for-loop with multiple targets flags only the shadowing target", () => {
-      expectError("Local variable `tag` shadows the Action View `tag` helper. Rename it to avoid confusion (for example `tag_item`).")
+      expectWarning("Local variable `tag` shadows the Action View `tag` helper. Rename it to avoid confusion (for example `tag_item`).")
 
       assertOffenses(dedent`
         <% for first, tag in @pairs %>
@@ -127,7 +127,7 @@ describe("ActionViewNoHelperShadowingRule", () => {
     })
 
     test("self-assignment flags the written variable once", () => {
-      expectError("Local variable `link_to` shadows the Action View `link_to` helper. Rename it to avoid confusion (for example `link_to_item`).")
+      expectWarning("Local variable `link_to` shadows the Action View `link_to` helper. Rename it to avoid confusion (for example `link_to_item`).")
 
       assertOffenses(dedent`
         <% link_to = link_to("Home", root_path) %>
@@ -136,7 +136,7 @@ describe("ActionViewNoHelperShadowingRule", () => {
     })
 
     test("strict local named tag is flagged", () => {
-      expectError("Local variable `tag` shadows the Action View `tag` helper. Rename it to avoid confusion (for example `tag_item`).")
+      expectWarning("Local variable `tag` shadows the Action View `tag` helper. Rename it to avoid confusion (for example `tag_item`).")
 
       assertOffenses(dedent`
         <%# locals: (tag:) %>
@@ -211,8 +211,8 @@ describe("ActionViewNoHelperShadowingRule", () => {
   })
 
   describe("iteration blocks", () => {
-    test("iteration block argument named tag is flagged as an error", () => {
-      expectError("Local variable `tag` shadows the Action View `tag` helper. Rename it to avoid confusion (for example `tag_item`).")
+    test("iteration block argument named tag is flagged as a warning", () => {
+      expectWarning("Local variable `tag` shadows the Action View `tag` helper. Rename it to avoid confusion (for example `tag_item`).")
 
       assertOffenses(dedent`
         <% @tags.map do |tag| %>
@@ -232,7 +232,7 @@ describe("ActionViewNoHelperShadowingRule", () => {
     })
 
     test("only the shadowing target is flagged in a multi-argument iteration block", () => {
-      expectError("Local variable `tag` shadows the Action View `tag` helper. Rename it to avoid confusion (for example `tag_item`).")
+      expectWarning("Local variable `tag` shadows the Action View `tag` helper. Rename it to avoid confusion (for example `tag_item`).")
 
       assertOffenses(dedent`
         <% @tags.each_with_index do |tag, index| %>


### PR DESCRIPTION
This pull request lowers the default severity of `actionview-no-helper-shadowing` from `error` to `warning` so that shadowing an Action View helper no longer fails the build in the CLI and in CI.

Shadowing a helper is a readability problem rather than a correctness one. A template like the one below renders exactly as its author intended, and the local `tag` simply wins over the `tag` helper for the rest of the block:

```erb
<% @tags.each do |tag| %>
  <%= tag.name %>
<% end %>
```

That is worth pointing out, because a reader scanning the block has to work out which `tag` is meant, and because reaching for the helper further down the same block silently gets the local instead.

Follow up on #1897