### PR TITLE
Linter: Implement `herb-config-framework-option` rule

### DIFF
--- a/javascript/packages/config/src/config.ts
+++ b/javascript/packages/config/src/config.ts
@@ -96,6 +96,8 @@ export type FormatterConfig = {
 export type EngineConfig = Record<string, unknown>
 
 export type HerbConfigOptions = {
+  framework?: Framework
+  template_engine?: TemplateEngine
   files?: FilesConfig
   engine?: EngineConfig
   linter?: LinterConfig
@@ -107,8 +109,6 @@ export type TemplateEngine = z.infer<typeof TemplateEngineSchema>
 
 export type HerbConfig = HerbConfigOptions & {
   version: string
-  framework?: Framework
-  template_engine?: TemplateEngine
 }
 
 export type LoadOptions = {

--- a/javascript/packages/language-server/src/code_action_service.ts
+++ b/javascript/packages/language-server/src/code_action_service.ts
@@ -2,6 +2,7 @@ import { CodeAction, CodeActionKind, CodeActionParams, Diagnostic, Range, TextEd
 import { TextDocument } from "vscode-languageserver-textdocument"
 
 import { Config } from "@herb-tools/config"
+import { VALID_FRAMEWORKS, isValidFramework } from "@herb-tools/core"
 import { Project } from "./project"
 import { PartialIndexService } from "./partial_index_service"
 import { PartialCallerIndexService } from "./partial_caller_index_service"
@@ -10,7 +11,10 @@ import { Linter } from "@herb-tools/linter"
 
 import { getFullDocumentRange, lspRangeFromLocation } from "./range_utils"
 
+import type { Framework, HerbConfigOptions } from "@herb-tools/config"
 import type { LintOffense } from "@herb-tools/linter"
+
+const FRAMEWORK_OPTION_RULE = "herb-config-framework-option"
 
 export class CodeActionService {
   private project: Project
@@ -53,6 +57,8 @@ export class CodeActionService {
       if (disableLineAction) {
         actions.push(disableLineAction)
       }
+
+      actions.push(...this.createSetFrameworkActions(diagnostic, ruleName))
 
       const disableInConfigAction = this.createDisableInConfigAction(
         diagnostic,
@@ -269,7 +275,63 @@ export class CodeActionService {
     return action
   }
 
+  private createSetFrameworkActions(diagnostic: Diagnostic, ruleName: string): CodeAction[] {
+    if (ruleName !== FRAMEWORK_OPTION_RULE) return []
+    if (this.config?.framework) return []
+
+    const projectPath = this.project.projectPath
+
+    if (!projectPath) return []
+
+    const configUri = `file://${Config.configPathFromProjectPath(projectPath)}`
+    const suggested = this.suggestedFramework(diagnostic)
+    const frameworks = suggested ? [suggested] : VALID_FRAMEWORKS
+
+    return frameworks.flatMap(framework => {
+      const edit = this.createConfigMutationEdit({ framework })
+
+      if (!edit) return []
+
+      const action: CodeAction = {
+        title: `Herb Linter: Set \`framework: ${framework}\` in \`.herb.yml\``,
+        kind: CodeActionKind.QuickFix,
+        diagnostics: [diagnostic],
+        edit,
+        command: {
+          title: 'Open .herb.yml',
+          command: 'vscode.open',
+          arguments: [configUri]
+        }
+      }
+
+      return [action]
+    })
+  }
+
+  private suggestedFramework(diagnostic: Diagnostic): Framework | undefined {
+    const message = typeof diagnostic.message === "string" ? diagnostic.message : diagnostic.message.value
+    const match = message.match(/looks like `(\w+)`/)
+
+    if (!match || !isValidFramework(match[1])) return undefined
+
+    return match[1]
+  }
+
   private createConfigDisableEdit(ruleName: string): WorkspaceEdit | null {
+    if (this.config?.isRuleDisabled(ruleName)) {
+      return null
+    }
+
+    return this.createConfigMutationEdit({
+      linter: {
+        rules: {
+          [ruleName]: { enabled: false }
+        }
+      }
+    })
+  }
+
+  private createConfigMutationEdit(mutation: Partial<HerbConfigOptions>): WorkspaceEdit | null {
     try {
       const projectPath = this.project.projectPath
 
@@ -277,20 +339,8 @@ export class CodeActionService {
         return null
       }
 
-      if (this.config?.isRuleDisabled(ruleName)) {
-        return null
-      }
-
       const configPath = Config.configPathFromProjectPath(projectPath)
       const configUri = `file://${configPath}`
-
-      const mutation = {
-        linter: {
-          rules: {
-            [ruleName]: { enabled: false }
-          }
-        }
-      }
 
       const configExists = Config.exists(configPath)
       let newContent = ''

--- a/javascript/packages/language-server/src/linter_service.ts
+++ b/javascript/packages/language-server/src/linter_service.ts
@@ -158,6 +158,8 @@ export class LinterService {
       const linterConfig = projectConfig?.config?.linter || { enabled: true, rules: {} }
 
       const config = Config.fromObject({
+        framework: projectConfig?.config?.framework,
+        template_engine: projectConfig?.config?.template_engine,
         linter: {
           ...linterConfig,
           rules: {

--- a/javascript/packages/language-server/test/code_action_service.test.ts
+++ b/javascript/packages/language-server/test/code_action_service.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, beforeAll, beforeEach, afterEach } from "vitest"
+import { mkdirSync, writeFileSync, rmSync } from "fs"
+import { join } from "path"
+import { tmpdir } from "os"
+
+import { Diagnostic, DiagnosticSeverity, Range } from "vscode-languageserver/node"
+import { Herb } from "@herb-tools/node-wasm"
+import { Config } from "@herb-tools/config"
+
+import { CodeActionService } from "../src/code_action_service"
+import { Project } from "../src/project"
+
+import type { Connection } from "vscode-languageserver/node"
+import type { TextDocumentEdit } from "vscode-languageserver/node"
+
+const RULE = "herb-config-framework-option"
+const URI = "file:///project/app/views/users/show.html.erb"
+
+describe("CodeActionService", () => {
+  let projectPath: string
+
+  beforeAll(async () => {
+    await Herb.load()
+  })
+
+  beforeEach(() => {
+    projectPath = join(tmpdir(), `herb-code-action-test-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+
+    mkdirSync(projectPath, { recursive: true })
+  })
+
+  afterEach(() => {
+    rmSync(projectPath, { recursive: true, force: true })
+  })
+
+  function writeConfig(content: string) {
+    writeFileSync(join(projectPath, ".herb.yml"), content)
+  }
+
+  async function createService() {
+    const project = new Project({} as Connection, projectPath)
+    const config = await Config.loadForEditor(projectPath, "0.10.3")
+
+    return new CodeActionService(project, config)
+  }
+
+  function frameworkDiagnostic(message: string): Diagnostic {
+    return {
+      range: Range.create(0, 0, 0, 0),
+      message,
+      severity: DiagnosticSeverity.Hint,
+      source: "Herb Linter ",
+      data: { rule: RULE }
+    }
+  }
+
+  function setFrameworkActions(actions: Awaited<ReturnType<CodeActionService["createCodeActions"]>>) {
+    return actions.filter(action => action.title.includes("Set `framework"))
+  }
+
+  function configEdit(action: { edit?: { changes?: Record<string, { newText: string }[]>, documentChanges?: unknown[] } }) {
+    const changes = action.edit?.changes
+
+    if (changes) return Object.values(changes)[0][0].newText
+
+    const documentChanges = action.edit?.documentChanges as TextDocumentEdit[]
+
+    return documentChanges[documentChanges.length - 1].edits[0].newText
+  }
+
+  it("offers the suggested framework when the offense names one", async () => {
+    writeConfig("version: 0.10.3\n")
+
+    const service = await createService()
+    const diagnostic = frameworkDiagnostic("No `framework` is set in `.herb.yml`, so Herb assumes plain `ruby` templates. `image_tag` is an Action View helper, so this project looks like `actionview`. Set `framework: actionview` to get the rules, assumptions, and optimizations that come with it.")
+
+    const actions = setFrameworkActions(service.createCodeActions(URI, [diagnostic], "<%= image_tag %>"))
+
+    expect(actions).toHaveLength(1)
+    expect(actions[0].title).toBe("Herb Linter: Set `framework: actionview` in `.herb.yml`")
+    expect(configEdit(actions[0])).toContain("framework: actionview")
+  })
+
+  it("offers every framework when the offense names none", async () => {
+    writeConfig("version: 0.10.3\n")
+
+    const service = await createService()
+    const diagnostic = frameworkDiagnostic("No `framework` is set in `.herb.yml`, so Herb assumes plain `ruby` templates. Set `framework` to one of `ruby`, `actionview`, `hanami`, or `sinatra` so Herb can tailor its assumptions, rules, and optimizations to your framework.")
+
+    const actions = setFrameworkActions(service.createCodeActions(URI, [diagnostic], "<div></div>"))
+
+    expect(actions.map(action => action.title)).toEqual([
+      "Herb Linter: Set `framework: ruby` in `.herb.yml`",
+      "Herb Linter: Set `framework: actionview` in `.herb.yml`",
+      "Herb Linter: Set `framework: hanami` in `.herb.yml`",
+      "Herb Linter: Set `framework: sinatra` in `.herb.yml`"
+    ])
+  })
+
+  it("keeps the comments in an existing config file", async () => {
+    writeConfig("# keep me\nversion: 0.10.3\n\nlinter:\n  enabled: true\n")
+
+    const service = await createService()
+    const diagnostic = frameworkDiagnostic("No `framework` is set in `.herb.yml`, so Herb assumes plain `ruby` templates. `link_to` is an Action View helper, so this project looks like `actionview`. Set `framework: actionview` to get the rules, assumptions, and optimizations that come with it.")
+
+    const actions = setFrameworkActions(service.createCodeActions(URI, [diagnostic], "<%= link_to %>"))
+    const newContent = configEdit(actions[0])
+
+    expect(newContent).toContain("# keep me")
+    expect(newContent).toContain("framework: actionview")
+    expect(newContent).toContain("linter:")
+  })
+
+  it("creates a config file when the project has none", async () => {
+    const service = await createService()
+    const diagnostic = frameworkDiagnostic("No `framework` is set in `.herb.yml`, so Herb assumes plain `ruby` templates. `form_with` is an Action View helper, so this project looks like `actionview`. Set `framework: actionview` to get the rules, assumptions, and optimizations that come with it.")
+
+    const actions = setFrameworkActions(service.createCodeActions(URI, [diagnostic], "<%= form_with %>"))
+
+    expect(actions).toHaveLength(1)
+    expect(actions[0].edit?.documentChanges?.[0]).toMatchObject({ kind: "create" })
+    expect(configEdit(actions[0])).toContain("framework: actionview")
+  })
+
+  it("offers nothing once the project sets a framework", async () => {
+    writeConfig("version: 0.10.3\nframework: actionview\n")
+
+    const service = await createService()
+    const diagnostic = frameworkDiagnostic("No `framework` is set in `.herb.yml`, so Herb assumes plain `ruby` templates. `image_tag` is an Action View helper, so this project looks like `actionview`. Set `framework: actionview` to get the rules, assumptions, and optimizations that come with it.")
+
+    const actions = setFrameworkActions(service.createCodeActions(URI, [diagnostic], "<%= image_tag %>"))
+
+    expect(actions).toHaveLength(0)
+  })
+})

--- a/javascript/packages/language-server/test/linter_service.test.ts
+++ b/javascript/packages/language-server/test/linter_service.test.ts
@@ -136,6 +136,35 @@ describe("LinterService", () => {
       expect(parserErrorDiagnostics).toHaveLength(0)
     })
 
+    test("passes the configured framework through to the rules", async () => {
+      const settings = new Settings(mockParams, mockConnection)
+      settings.getDocumentSettings = vi.fn().mockResolvedValue({ linter: { enabled: true } })
+
+      settings.projectConfig = Config.fromObject({
+        framework: "actionview",
+        linter: { enabled: true, rules: {} }
+      }, { projectPath: process.cwd() })
+
+      const linterService = new LinterService(mockConnection, settings, mockProject, partialIndexService)
+      const result = await linterService.lintDocument(createTestDocument("<div>Test</div>\n"))
+
+      expect(result.diagnostics.map(diagnostic => diagnostic.code)).not.toContain("herb-config-framework-option")
+    })
+
+    test("reports the missing framework option when the project doesn't configure one", async () => {
+      const settings = new Settings(mockParams, mockConnection)
+      settings.getDocumentSettings = vi.fn().mockResolvedValue({ linter: { enabled: true } })
+
+      settings.projectConfig = Config.fromObject({
+        linter: { enabled: true, rules: {} }
+      }, { projectPath: process.cwd() })
+
+      const linterService = new LinterService(mockConnection, settings, mockProject, partialIndexService)
+      const result = await linterService.lintDocument(createTestDocument("<div>Test</div>\n"))
+
+      expect(result.diagnostics.map(diagnostic => diagnostic.code)).toContain("herb-config-framework-option")
+    })
+
     test("respects files.exclude patterns from config", async () => {
       vi.spyOn(Config, "exists").mockReturnValue(true)
 

--- a/javascript/packages/language-server/test/linter_service.test.ts
+++ b/javascript/packages/language-server/test/linter_service.test.ts
@@ -57,7 +57,7 @@ describe("LinterService", () => {
       const result = await linterService.lintDocument(textDocument)
 
       expect(result).toBeDefined()
-      expect(result.diagnostics).toEqual([])
+      expect(result.diagnostics.filter(diagnostic => diagnostic.code !== "herb-config-framework-option")).toEqual([])
     })
 
     test("handles undefined linter settings", async () => {

--- a/javascript/packages/linter/.herb.yml
+++ b/javascript/packages/linter/.herb.yml
@@ -1,1 +1,2 @@
 # This file exists so the linter doesn't try to find another config file outside the herb repository
+framework: ruby

--- a/javascript/packages/linter/docs/rules/README.md
+++ b/javascript/packages/linter/docs/rules/README.md
@@ -87,6 +87,7 @@ This page contains documentation for all Herb Linter rules.
 
 #### Herb
 
+- [`herb-config-framework-option`](./herb-config-framework-option.md) - Require the `framework` option to be set in `.herb.yml`.
 - [`herb-disable-comment-malformed`](./herb-disable-comment-malformed.md) - Detect malformed `herb:disable` comments.
 - [`herb-disable-comment-missing-rules`](./herb-disable-comment-missing-rules.md) - Require rule names in `herb:disable` comments.
 - [`herb-disable-comment-no-duplicate-rules`](./herb-disable-comment-no-duplicate-rules.md) - Disallow duplicate rule names in `herb:disable` comments.

--- a/javascript/packages/linter/docs/rules/herb-config-framework-option.md
+++ b/javascript/packages/linter/docs/rules/herb-config-framework-option.md
@@ -1,0 +1,81 @@
+# Linter Rule: Require the `framework` option
+
+**Rule:** `herb-config-framework-option`
+
+## Description
+
+Reports templates in a project that doesn't set `framework` in its `.herb.yml`. The rule stays quiet as soon as `framework` is set, whichever value it is set to.
+
+When a template shows what it is rendered by, the offense says so and suggests that value. Otherwise it lists the values to choose from.
+
+## Rationale
+
+Herb tailors itself to the `framework` option. It decides what Herb may assume about a template, which rules apply, and which optimizations it can take. Without it Herb falls back to `ruby` and treats every template as plain ERB, which is the most conservative behavior it has.
+
+The option is a project-level setting, and the CLI warns about it once per run, but that warning never reaches an editor. This rule brings it to where templates are actually written.
+
+Two signals tell Herb the project is likely Action View, and both only shape the message:
+
+- a strict locals declaration, which only Action View reads
+- a call to a helper whose name is unmistakably Action View, so `link_to` and `image_tag` count while `render`, `params`, and `t` don't
+
+Neither is a requirement for the offense. A template with no Ruby in it at all still reports, because the option is still missing.
+
+The rule reports once per file, on the first line, and a CLI run collapses those down to a single offense since one missing config key doesn't need one report per template.
+
+## Examples
+
+### ✅ Good
+
+Any value silences the rule, including the `ruby` default when that is what the project means:
+
+```yaml [.herb.yml]
+framework: actionview
+```
+
+```yaml [.herb.yml]
+framework: ruby
+```
+
+### 🚫 Bad
+
+Without the option, every template reports:
+
+```erb
+<div class="card">
+  <h1>Hello</h1>
+</div>
+```
+
+Templates carrying an Action View signal get that value suggested:
+
+```erb
+<%= image_tag "logo.png", alt: "Logo" %>
+```
+
+```erb
+<%# locals: (title:, subtitle: nil) %>
+<h1><%= title %></h1>
+```
+
+## Configuration
+
+Set the framework in your `.herb.yml` to resolve the offense:
+
+```yaml [.herb.yml]
+framework: actionview # Options: ruby (default), actionview, hanami, sinatra
+```
+
+Or disable the rule if you prefer to keep the option unset:
+
+```yaml [.herb.yml]
+linter:
+  rules:
+    herb-config-framework-option:
+      enabled: false
+```
+
+## References
+
+- [Herb Configuration: Framework Configuration](https://herb-tools.dev/configuration#framework-configuration)
+- [Action View Helpers](https://guides.rubyonrails.org/action_view_helpers.html)

--- a/javascript/packages/linter/src/cli/file-processor.ts
+++ b/javascript/packages/linter/src/cli/file-processor.ts
@@ -233,10 +233,62 @@ export class FileProcessor {
     await this.buildPartialIndexOnce(context)
 
     if (shouldParallelize) {
-      return this.processFilesInParallel(files, jobs, formatOption, context)
+      return this.collapseOncePerRunOffenses(await this.processFilesInParallel(files, jobs, formatOption, context))
     }
 
-    return this.processFilesSequentially(files, formatOption, context)
+    return this.collapseOncePerRunOffenses(await this.processFilesSequentially(files, formatOption, context))
+  }
+
+  private collapseOncePerRunOffenses(result: ProcessingResult): ProcessingResult {
+    const oncePerRun = new Set(rules.filter(rule => rule.reportsOncePerRun === true).map(rule => rule.ruleName))
+
+    if (oncePerRun.size === 0) return result
+
+    const seen = new Set<string>()
+    const dropped: ProcessedFile[] = []
+
+    result.allOffenses = result.allOffenses.filter(item => {
+      const rule = (item.offense as LintOffense).rule
+
+      if (!oncePerRun.has(rule)) return true
+      if (!seen.has(rule)) {
+        seen.add(rule)
+
+        return true
+      }
+
+      dropped.push(item)
+
+      return false
+    })
+
+    if (dropped.length === 0) return result
+
+    const remainingFiles = new Set(result.allOffenses.map(item => item.filename))
+
+    for (const item of dropped) {
+      const severity = (item.offense as LintOffense).severity
+
+      if (severity === "error") result.totalErrors--
+      if (severity === "warning") result.totalWarnings--
+      if (severity === "info") result.totalInfo--
+      if (severity === "hint") result.totalHints--
+
+      const ruleData = result.ruleOffenses.get((item.offense as LintOffense).rule)
+
+      if (ruleData) {
+        ruleData.count--
+        ruleData.files.delete(item.filename)
+      }
+    }
+
+    const droppedFiles = new Set(dropped.map(item => item.filename))
+
+    for (const filename of droppedFiles) {
+      if (!remainingFiles.has(filename)) result.filesWithOffenses--
+    }
+
+    return result
   }
 
   private async buildPartialIndexOnce(context?: ProcessingContext): Promise<void> {

--- a/javascript/packages/linter/src/rules.ts
+++ b/javascript/packages/linter/src/rules.ts
@@ -73,6 +73,7 @@ import { ERBRightTrimRule } from "./rules/erb-right-trim.js"
 import { ERBStrictLocalsCommentSyntaxRule } from "./rules/erb-strict-locals-comment-syntax.js"
 import { ERBStrictLocalsRequiredRule } from "./rules/erb-strict-locals-required.js"
 
+import { HerbConfigFrameworkOptionRule } from "./rules/herb-config-framework-option.js"
 import { HerbDisableCommentMalformedRule } from "./rules/herb-disable-comment-malformed.js"
 import { HerbDisableCommentMissingRulesRule } from "./rules/herb-disable-comment-missing-rules.js"
 import { HerbDisableCommentNoDuplicateRulesRule } from "./rules/herb-disable-comment-no-duplicate-rules.js"
@@ -214,6 +215,7 @@ export const rules: RuleClass[] = [
   ERBStrictLocalsCommentSyntaxRule,
   ERBStrictLocalsRequiredRule,
 
+  HerbConfigFrameworkOptionRule,
   HerbDisableCommentMalformedRule,
   HerbDisableCommentMissingRulesRule,
   HerbDisableCommentNoDuplicateRulesRule,

--- a/javascript/packages/linter/src/rules/herb-config-framework-option.ts
+++ b/javascript/packages/linter/src/rules/herb-config-framework-option.ts
@@ -1,0 +1,142 @@
+import { BaseRuleVisitor } from "./rule-utils.js"
+import { ParserRule } from "../types.js"
+import { Location, PrismVisitor, getHelper } from "@herb-tools/core"
+
+import type { ERBStrictLocalsNode, ParseResult, ParserOptions, PrismNode } from "@herb-tools/core"
+import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types.js"
+
+export const AMBIGUOUS_HELPERS = new Set([
+  "button",
+  "cache",
+  "caching?",
+  "capture",
+  "checkbox",
+  "concat",
+  "controller",
+  "cookies",
+  "cycle",
+  "debug",
+  "excerpt",
+  "fields",
+  "flash",
+  "headers",
+  "highlight",
+  "j",
+  "l",
+  "label",
+  "localize",
+  "logger",
+  "logger?",
+  "multipart",
+  "object",
+  "params",
+  "pluralize",
+  "provide",
+  "raw",
+  "render",
+  "request",
+  "response",
+  "sanitize",
+  "select",
+  "session",
+  "submit",
+  "t",
+  "tag",
+  "textarea",
+  "translate",
+  "truncate",
+  "uncacheable!"
+])
+
+const MISSING_OPTION = "No `framework` is set in `.herb.yml`, so Herb assumes plain `ruby` templates."
+const SET_ACTION_VIEW = "Set `framework: actionview` to get the rules, assumptions, and optimizations that come with it."
+const SET_ANY_FRAMEWORK = "Set `framework` to one of `ruby`, `actionview`, `hanami`, or `sinatra` so Herb can tailor its assumptions, rules, and optimizations to your framework."
+
+function isActionViewHelperCall(node: PrismNode): boolean {
+  if (node.receiver) return false
+  if (AMBIGUOUS_HELPERS.has(node.name)) return false
+
+  return getHelper(node.name) !== undefined
+}
+
+class HelperCallCollector extends PrismVisitor {
+  public helperCall: PrismNode | null = null
+
+  visitCallNode(node: PrismNode): void {
+    if (!this.helperCall && isActionViewHelperCall(node)) {
+      this.helperCall = node
+    }
+
+    this.visitChildNodes(node)
+  }
+}
+
+class StrictLocalsCollector extends BaseRuleVisitor {
+  public declaration: ERBStrictLocalsNode | null = null
+
+  visitERBStrictLocalsNode(node: ERBStrictLocalsNode): void {
+    this.declaration ||= node
+  }
+}
+
+export class HerbConfigFrameworkOptionRule extends ParserRule {
+  static ruleName = "herb-config-framework-option"
+  static introducedIn = this.version("unreleased")
+  static reportsOncePerRun = true
+
+  get defaultConfig(): FullRuleConfig {
+    return {
+      enabled: true,
+      severity: "info",
+    }
+  }
+
+  get parserOptions(): Partial<ParserOptions> {
+    return {
+      strict_locals: true,
+      prism_program: true,
+    }
+  }
+
+  check(result: ParseResult, context?: Partial<LintContext>): UnboundLintOffense[] {
+    if (context?.framework) return []
+
+    return [this.createOffense(this.messageFor(result, context), this.firstLineOf(result))]
+  }
+
+  private messageFor(result: ParseResult, context?: Partial<LintContext>): string {
+    const strictLocals = new StrictLocalsCollector(this.ruleName, context)
+
+    strictLocals.visit(result.value)
+
+    if (strictLocals.declaration) {
+      return `${MISSING_OPTION} This template declares strict locals, which only Action View reads, so this project looks like \`actionview\`. ${SET_ACTION_VIEW}`
+    }
+
+    const helperCall = this.findHelperCall(result)
+
+    if (helperCall) {
+      return `${MISSING_OPTION} \`${helperCall.name}\` is an Action View helper, so this project looks like \`actionview\`. ${SET_ACTION_VIEW}`
+    }
+
+    return `${MISSING_OPTION} ${SET_ANY_FRAMEWORK}`
+  }
+
+  private firstLineOf(result: ParseResult): Location {
+    const [firstLine] = (result.value.source ?? "").split("\n")
+
+    return Location.from(1, 0, 1, firstLine?.length ?? 0)
+  }
+
+  private findHelperCall(result: ParseResult): PrismNode | null {
+    const prismNode = result.value.prismNode
+    if (!prismNode || !result.value.source) return null
+
+    const collector = new HelperCallCollector()
+
+    collector.visit(prismNode)
+
+    return collector.helperCall
+  }
+
+}

--- a/javascript/packages/linter/src/rules/index.ts
+++ b/javascript/packages/linter/src/rules/index.ts
@@ -79,6 +79,7 @@ export * from "./erb-right-trim.js"
 export * from "./erb-strict-locals-comment-syntax.js"
 export * from "./erb-strict-locals-required.js"
 
+export * from "./herb-config-framework-option.js"
 export * from "./herb-disable-comment-malformed.js"
 export * from "./herb-disable-comment-missing-rules.js"
 export * from "./herb-disable-comment-no-duplicate-rules.js"

--- a/javascript/packages/linter/src/types.ts
+++ b/javascript/packages/linter/src/types.ts
@@ -115,6 +115,8 @@ export abstract class ParserRule<TAutofixContext extends BaseAutofixContext = Ba
   static autofixRequiresContext = false
   /** Indicates whether this rule consumes parser errors (like parser-no-errors). Rules with this flag are not skipped when parse results contain errors. */
   static consumesParserErrors = false
+  /** Indicates that the rule reports about the project rather than the file, so a CLI run collapses its offenses down to the first one. Defaults to false. */
+  static reportsOncePerRun = false
 
   get ruleName(): string {
     return (this.constructor as typeof ParserRule).ruleName
@@ -243,6 +245,7 @@ export interface LexerRuleConstructor {
   autocorrectable?: boolean
   unsafeAutocorrectable?: boolean
   autofixRequiresContext?: boolean
+  reportsOncePerRun?: boolean
 }
 
 /**
@@ -344,6 +347,7 @@ export interface SourceRuleConstructor {
   autocorrectable?: boolean
   unsafeAutocorrectable?: boolean
   autofixRequiresContext?: boolean
+  reportsOncePerRun?: boolean
 }
 
 /**
@@ -360,6 +364,7 @@ export type ParserRuleClass = (new () => ParserRule) & {
   autofixRequiresContext?: boolean
   reindentAfterAutofix?: boolean
   consumesParserErrors?: boolean
+  reportsOncePerRun?: boolean
 }
 
 export type LexerRuleClass = LexerRuleConstructor

--- a/javascript/packages/linter/test/__snapshots__/cli.test.ts.snap
+++ b/javascript/packages/linter/test/__snapshots__/cli.test.ts.snap
@@ -19,7 +19,7 @@ test-file-with-errors.html.erb:
   Failing      2 errors (2 offenses across 1 file)
   Not failing  1 warning (1 offense across 1 file, below --fail-level=error)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        130 enabled | all rules via --all-rules"
+  Rules        131 enabled | all rules via --all-rules"
 `;
 
 exports[`CLI Output Formatting > \`all\` pseudo rule in .herb.yml > \`Rules\` summary line > \`--only\` replaces the counts from a disabled \`all\` 1`] = `
@@ -50,7 +50,7 @@ exports[`CLI Output Formatting > \`all\` pseudo rule in .herb.yml > \`Rules\` su
   Checked      1 file
   Offenses     0 offenses
   Fixable      0 offenses
-  Rules        0 enabled | 130 not enabled
+  Rules        0 enabled | 131 not enabled
 
  No rules enabled:
   Every linter rule is turned off, so no offenses can be reported.
@@ -71,7 +71,7 @@ exports[`CLI Output Formatting > \`all\` pseudo rule in .herb.yml > \`Rules\` su
   Checked      1 file
   Offenses     0 offenses
   Fixable      0 offenses
-  Rules        0 enabled | 130 not enabled
+  Rules        0 enabled | 131 not enabled
 
  No rules enabled:
   Every linter rule is turned off, so no offenses can be reported.
@@ -102,7 +102,7 @@ test-file-with-errors.html.erb:
   Failing      2 errors (2 offenses across 1 file)
   Not failing  1 warning (1 offense across 1 file, below --fail-level=error)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        130 enabled"
+  Rules        131 enabled"
 `;
 
 exports[`CLI Output Formatting > \`all\` pseudo rule in .herb.yml > \`Rules\` summary line > \`all: enabled: true\` reports no version-skipped rules 1`] = `
@@ -124,7 +124,7 @@ test-file-with-errors.html.erb:
   Failing      2 errors (2 offenses across 1 file)
   Not failing  1 warning (1 offense across 1 file, below --fail-level=error)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        130 enabled"
+  Rules        131 enabled"
 `;
 
 exports[`CLI Output Formatting > \`all\` pseudo rule in .herb.yml > \`Rules\` summary line > reports enabled and not-enabled rules when no \`all\` is configured 1`] = `
@@ -146,7 +146,7 @@ test/fixtures/test-file-with-errors.html.erb:
   Failing      2 errors (2 offenses across 1 file)
   Not failing  1 warning (1 offense across 1 file, below --fail-level=error)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        109 enabled | 21 not enabled"
+  Rules        110 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > \`all\` pseudo rule in .herb.yml > \`Rules\` summary line > rules opted back in on top of \`all: enabled: false\` count as enabled 1`] = `
@@ -165,7 +165,7 @@ test-file-with-errors.html.erb:
   Failing      0 offenses
   Not failing  1 warning (1 offense across 1 file, below --fail-level=error)
   Fixable      0 offenses
-  Rules        1 enabled | 129 not enabled"
+  Rules        1 enabled | 130 not enabled"
 `;
 
 exports[`CLI Output Formatting > \`all\` pseudo rule in .herb.yml > \`Rules\` summary line > rules opted out on top of \`all: enabled: true\` count as disabled 1`] = `
@@ -184,7 +184,7 @@ test-file-with-errors.html.erb:
   Checked      1 file
   Offenses     2 errors (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        129 enabled | 1 disabled"
+  Rules        130 enabled | 1 disabled"
 `;
 
 exports[`CLI Output Formatting > --all-rules > reports every offense for the fixture with --all-rules 1`] = `
@@ -214,7 +214,7 @@ test/fixtures/all-rules.html.erb:
   Failing      0 offenses
   Not failing  6 warnings (6 offenses across 1 file, below --fail-level=error)
   Fixable      0 offenses
-  Rules        130 enabled | all rules via --all-rules"
+  Rules        131 enabled | all rules via --all-rules"
 `;
 
 exports[`CLI Output Formatting > --all-rules > reports nothing for the fixture with the default rule set 1`] = `
@@ -226,7 +226,7 @@ exports[`CLI Output Formatting > --all-rules > reports nothing for the fixture w
   Checked      1 file
   Offenses     0 offenses
   Fixable      0 offenses
-  Rules        109 enabled | 21 not enabled"
+  Rules        110 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > --ignore-disable-comments 1`] = `
@@ -377,7 +377,7 @@ test/fixtures/ignored.html.erb:8:8
   Not failing  2 warnings (2 offenses across 1 file, below --fail-level=error)
   Note         3 additional offenses reported (would have been ignored)
   Fixable      7 offenses | 4 autocorrectable using \`--fix\`
-  Rules        109 enabled | 21 not enabled"
+  Rules        110 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > --log-level > counts the hidden offenses and suggests the level that reveals them 1`] = `
@@ -395,7 +395,7 @@ exports[`CLI Output Formatting > --log-level > counts the hidden offenses and su
   Not failing  2 info | 1 hint (3 offenses across 1 file, below --fail-level=error)
   Not shown    3 offenses hidden, show them with --log-level=hint
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        109 enabled | 21 not enabled"
+  Rules        110 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > --log-level > doesn't report offenses below the given level 1`] = `
@@ -412,7 +412,7 @@ exports[`CLI Output Formatting > --log-level > doesn't report offenses below the
   Not failing  1 hint (1 offense across 1 file, below --fail-level=error)
   Not shown    1 offense hidden, show it with --log-level=hint
   Fixable      0 offenses
-  Rules        108 enabled | 21 not enabled | 1 disabled"
+  Rules        109 enabled | 21 not enabled | 1 disabled"
 `;
 
 exports[`CLI Output Formatting > --log-level > prefers the CLI flag over the config file 1`] = `
@@ -431,7 +431,7 @@ test-file-with-errors.html.erb:
   Failing      0 offenses
   Not failing  1 hint (1 offense across 1 file, below --fail-level=error)
   Fixable      0 offenses
-  Rules        108 enabled | 21 not enabled | 1 disabled"
+  Rules        109 enabled | 21 not enabled | 1 disabled"
 `;
 
 exports[`CLI Output Formatting > --log-level > reads logLevel from the config file 1`] = `
@@ -448,7 +448,7 @@ exports[`CLI Output Formatting > --log-level > reads logLevel from the config fi
   Not failing  1 hint (1 offense across 1 file, below --fail-level=error)
   Not shown    1 offense hidden, show it with --log-level=hint
   Fixable      0 offenses
-  Rules        108 enabled | 21 not enabled | 1 disabled"
+  Rules        109 enabled | 21 not enabled | 1 disabled"
 `;
 
 exports[`CLI Output Formatting > --log-level > still counts hidden offenses towards the exit code 1`] = `
@@ -464,7 +464,7 @@ exports[`CLI Output Formatting > --log-level > still counts hidden offenses towa
   Offenses     1 hint (1 offense across 1 file)
   Not shown    1 offense hidden, show it with --log-level=hint
   Fixable      0 offenses
-  Rules        108 enabled | 21 not enabled | 1 disabled"
+  Rules        109 enabled | 21 not enabled | 1 disabled"
 `;
 
 exports[`CLI Output Formatting > --log-level > still reports offenses at or above the given level 1`] = `
@@ -483,7 +483,7 @@ test-file-with-errors.html.erb:
   Failing      0 offenses
   Not failing  1 hint (1 offense across 1 file, below --fail-level=error)
   Fixable      0 offenses
-  Rules        108 enabled | 21 not enabled | 1 disabled"
+  Rules        109 enabled | 21 not enabled | 1 disabled"
 `;
 
 exports[`CLI Output Formatting > --log-level > with --all-rules > keeps the log level when it is passed explicitly 1`] = `
@@ -505,7 +505,7 @@ test-file-with-errors.html.erb:
   Not failing  1 hint (1 offense across 1 file, below --fail-level=error)
   Not shown    1 offense hidden, show it with --log-level=hint
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        130 enabled | all rules via --all-rules"
+  Rules        131 enabled | all rules via --all-rules"
 `;
 
 exports[`CLI Output Formatting > --log-level > with --all-rules > lowers the log level to report the rules it was asked for 1`] = `
@@ -528,7 +528,7 @@ test-file-with-errors.html.erb:
   Not failing  1 hint (1 offense across 1 file, below --fail-level=error)
   Log level    hint | lowered from warning by --all-rules
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        130 enabled | all rules via --all-rules"
+  Rules        131 enabled | all rules via --all-rules"
 `;
 
 exports[`CLI Output Formatting > --log-level > with --only > keeps the log level when it is passed explicitly 1`] = `
@@ -689,7 +689,7 @@ test/fixtures/test-file-with-errors.html.erb:2:22
   Failing      2 errors (2 offenses across 1 file)
   Not failing  1 warning (1 offense across 1 file, below --fail-level=error)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        109 enabled | 21 not enabled"
+  Rules        110 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > GitHub Actions format includes rule codes 1`] = `
@@ -721,7 +721,7 @@ test/fixtures/no-trailing-newline.html.erb:1:29
   Checked      1 file
   Offenses     1 error (1 offense across 1 file)
   Fixable      1 offense | 1 autocorrectable using \`--fix\`
-  Rules        109 enabled | 21 not enabled"
+  Rules        110 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > GitHub Actions format includes rule codes 2`] = `
@@ -826,7 +826,7 @@ test/fixtures/erb-no-extra-whitespace-inside-tags.html.erb:1:4
   Failing      4 errors (4 offenses across 1 file)
   Not failing  1 info (1 offense across 1 file, below --fail-level=error)
   Fixable      5 offenses | 3 autocorrectable using \`--fix\`
-  Rules        109 enabled | 21 not enabled"
+  Rules        110 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > Ignores disabled rules 1`] = `
@@ -886,7 +886,7 @@ test/fixtures/ignored.html.erb:6:14
   Offenses     2 errors (2 offenses across 1 file)
   Ignored      3 offenses suppressed with herb:disable
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        109 enabled | 21 not enabled"
+  Rules        110 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > allows tag.attributes in attribute position 1`] = `
@@ -946,7 +946,7 @@ test/fixtures/tag-attributes.html.erb:5:0
   Failing      0 offenses
   Not failing  2 warnings (2 offenses across 1 file, below --fail-level=error)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        109 enabled | 21 not enabled"
+  Rules        110 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > diplays only parsers errors if one is present 1`] = `
@@ -972,7 +972,7 @@ test/fixtures/parser-errors.html.erb:2:16
   Checked      1 file
   Offenses     1 error (1 offense across 1 file)
   Fixable      0 offenses
-  Rules        109 enabled | 21 not enabled"
+  Rules        110 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > displays most violated rules with multiple offenses 1`] = `
@@ -1224,7 +1224,7 @@ test/fixtures/multiple-rule-offenses.html.erb:4:7
   Failing      8 errors (8 offenses across 1 file)
   Not failing  6 warnings (6 offenses across 1 file, below --fail-level=error)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        109 enabled | 21 not enabled"
+  Rules        110 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > displays rule offenses when showing all rules 1`] = `
@@ -1349,7 +1349,7 @@ test/fixtures/few-rule-offenses.html.erb:6:0
   Failing      4 errors (4 offenses across 1 file)
   Not failing  2 warnings (2 offenses across 1 file, below --fail-level=error)
   Fixable      6 offenses | 3 autocorrectable using \`--fix\`
-  Rules        109 enabled | 21 not enabled"
+  Rules        110 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats GitHub Actions output correctly for bad file 1`] = `
@@ -1404,7 +1404,7 @@ test/fixtures/bad-file.html.erb:1:16
   Checked      1 file
   Offenses     2 errors (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        109 enabled | 21 not enabled"
+  Rules        110 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats GitHub Actions output correctly for clean file 1`] = `
@@ -1416,7 +1416,7 @@ exports[`CLI Output Formatting > formats GitHub Actions output correctly for cle
   Checked      1 file
   Offenses     0 offenses
   Fixable      0 offenses
-  Rules        109 enabled | 21 not enabled"
+  Rules        110 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats GitHub Actions output correctly for file with errors 1`] = `
@@ -1495,7 +1495,7 @@ test/fixtures/test-file-with-errors.html.erb:2:22
   Failing      2 errors (2 offenses across 1 file)
   Not failing  1 warning (1 offense across 1 file, below --fail-level=error)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        109 enabled | 21 not enabled"
+  Rules        110 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats GitHub Actions output with --format=github option 1`] = `
@@ -1552,7 +1552,7 @@ test/fixtures/test-file-simple.html.erb:2:22
   Checked      1 file
   Offenses     2 errors (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        109 enabled | 21 not enabled"
+  Rules        110 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats JSON output correctly for bad file 1`] = `
@@ -1599,7 +1599,7 @@ exports[`CLI Output Formatting > formats JSON output correctly for bad file 1`] 
   "summary": {
     "filesChecked": 1,
     "filesWithOffenses": 1,
-    "ruleCount": 109,
+    "ruleCount": 110,
     "totalErrors": 2,
     "totalHints": 0,
     "totalIgnored": 0,
@@ -1621,7 +1621,7 @@ exports[`CLI Output Formatting > formats JSON output correctly for clean file 1`
   "summary": {
     "filesChecked": 1,
     "filesWithOffenses": 0,
-    "ruleCount": 109,
+    "ruleCount": 110,
     "totalErrors": 0,
     "totalHints": 0,
     "totalIgnored": 0,
@@ -1695,7 +1695,7 @@ exports[`CLI Output Formatting > formats JSON output correctly for file with err
   "summary": {
     "filesChecked": 1,
     "filesWithOffenses": 1,
-    "ruleCount": 109,
+    "ruleCount": 110,
     "totalErrors": 2,
     "totalHints": 0,
     "totalIgnored": 0,
@@ -1778,7 +1778,7 @@ test/fixtures/test-file-with-errors.html.erb:2:22
   Failing      2 errors (2 offenses across 1 file)
   Not failing  1 warning (1 offense across 1 file, below --fail-level=error)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        109 enabled | 21 not enabled"
+  Rules        110 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats simple output correctly 1`] = `
@@ -1797,7 +1797,7 @@ test/fixtures/test-file-simple.html.erb:
   Checked      1 file
   Offenses     2 errors (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        109 enabled | 21 not enabled"
+  Rules        110 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats simple output for bad-file correctly 1`] = `
@@ -1816,7 +1816,7 @@ test/fixtures/bad-file.html.erb:
   Checked      1 file
   Offenses     2 errors (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        109 enabled | 21 not enabled"
+  Rules        110 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats success output correctly 1`] = `
@@ -1828,7 +1828,7 @@ exports[`CLI Output Formatting > formats success output correctly 1`] = `
   Checked      1 file
   Offenses     0 offenses
   Fixable      0 offenses
-  Rules        109 enabled | 21 not enabled"
+  Rules        110 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > handles boolean attributes 1`] = `
@@ -1840,7 +1840,7 @@ exports[`CLI Output Formatting > handles boolean attributes 1`] = `
   Checked      1 file
   Offenses     0 offenses
   Fixable      0 offenses
-  Rules        109 enabled | 21 not enabled"
+  Rules        110 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > handles multiple errors correctly 1`] = `
@@ -1891,7 +1891,7 @@ test/fixtures/bad-file.html.erb:1:16
   Checked      1 file
   Offenses     2 errors (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        109 enabled | 21 not enabled"
+  Rules        110 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > herb:disable rules 1`] = `
@@ -2034,7 +2034,7 @@ test/fixtures/disabled-1.html.erb:14:19
   Not failing  6 warnings (6 offenses across 1 file, below --fail-level=error)
   Ignored      8 offenses suppressed with herb:disable
   Fixable      8 offenses | 1 autocorrectable using \`--fix\`
-  Rules        109 enabled | 21 not enabled"
+  Rules        110 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > herb:disable rules 2`] = `
@@ -2293,7 +2293,26 @@ test/fixtures/disabled-2.html.erb:2:44
   Not failing  7 warnings (7 offenses across 1 file, below --fail-level=error)
   Ignored      5 offenses suppressed with herb:disable
   Fixable      13 offenses | 6 autocorrectable using \`--fix\`
-  Rules        109 enabled | 21 not enabled"
+  Rules        110 enabled | 21 not enabled"
+`;
+
+exports[`CLI Output Formatting > missing \`framework\` option > reports the missing option per template 1`] = `
+"✓ Using Herb config file at /test/herb/javascript/packages/linter/test/fixtures/.herb.yml
+
+clean-file.html.erb:
+  1:0  ⚠ No \`framework\` is set in \`.herb.yml\`, so Herb assumes plain \`ruby\` templates. Set \`framework\` to one of \`ruby\`, \`actionview\`, \`hanami\`, or \`sinatra\` so Herb can tailor its assumptions, rules, and optimizations to your framework. (herb-config-framework-option)
+
+
+ Rule offenses:
+  herb-config-framework-option (1 offense in 1 file)
+
+
+ Summary:
+  Checked      1 file
+  Failing      0 offenses
+  Not failing  1 info (1 offense across 1 file, below --fail-level=error)
+  Fixable      0 offenses
+  Rules        1 enabled | 130 not enabled"
 `;
 
 exports[`CLI Output Formatting > non-failing offenses tip > points at --log-level when many offenses don't fail the build 1`] = `
@@ -2331,7 +2350,7 @@ multiple-rule-offenses.html.erb:
   Failing      3 errors (3 offenses across 1 file)
   Not failing  1 info | 10 hints (11 offenses across 1 file, below --fail-level=error)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        109 enabled | 21 not enabled
+  Rules        110 enabled | 21 not enabled
 
  TIP: 11 of the logged offenses don't fail the build.
       Run herb-lint --log-level=error to stop logging them, or set linter.logLevel in your .herb.yml.
@@ -2363,7 +2382,7 @@ multiple-rule-offenses.html.erb:
   Not failing  1 info | 10 hints (11 offenses across 1 file, below --fail-level=error)
   Not shown    11 offenses hidden, show them with --log-level=hint
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        109 enabled | 21 not enabled"
+  Rules        110 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > non-failing offenses tip > stays quiet when --log-level is passed explicitly, even when it hides nothing 1`] = `
@@ -2401,7 +2420,7 @@ multiple-rule-offenses.html.erb:
   Failing      3 errors (3 offenses across 1 file)
   Not failing  1 info | 10 hints (11 offenses across 1 file, below --fail-level=error)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        109 enabled | 21 not enabled"
+  Rules        110 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > non-failing offenses tip > stays quiet when logLevel is set in the config file 1`] = `
@@ -2439,7 +2458,7 @@ multiple-rule-offenses.html.erb:
   Failing      3 errors (3 offenses across 1 file)
   Not failing  1 info | 10 hints (11 offenses across 1 file, below --fail-level=error)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        109 enabled | 21 not enabled"
+  Rules        110 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > non-failing offenses tip > stays quiet when only a handful of offenses don't fail the build 1`] = `
@@ -2477,7 +2496,7 @@ multiple-rule-offenses.html.erb:
   Failing      8 errors (8 offenses across 1 file)
   Not failing  6 warnings (6 offenses across 1 file, below --fail-level=error)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        109 enabled | 21 not enabled"
+  Rules        110 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > points at the flag instead of previewing once there are too many corrections 1`] = `
@@ -2573,7 +2592,7 @@ test/fixtures/test-file-simple.html.erb:2:22
   Checked      1 file
   Offenses     2 errors (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        109 enabled | 21 not enabled"
+  Rules        110 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > previews the correction under each correctable offense 1`] = `
@@ -2630,7 +2649,7 @@ test/fixtures/test-file-simple.html.erb:2:22
   Checked      1 file
   Offenses     2 errors (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        109 enabled | 21 not enabled"
+  Rules        110 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > summary offense buckets > groups every severity into one line when --fail-level is hint 1`] = `
@@ -2667,7 +2686,7 @@ test/fixtures/multiple-rule-offenses.html.erb:
   Checked      1 file
   Offenses     8 errors | 6 warnings (14 offenses across 1 file)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        109 enabled | 21 not enabled"
+  Rules        110 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > summary offense buckets > groups every severity into one line when --fail-level is info 1`] = `
@@ -2704,7 +2723,7 @@ test/fixtures/multiple-rule-offenses.html.erb:
   Checked      1 file
   Offenses     8 errors | 6 warnings (14 offenses across 1 file)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        109 enabled | 21 not enabled"
+  Rules        110 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > summary offense buckets > groups every severity into one line when --fail-level is warning 1`] = `
@@ -2741,7 +2760,7 @@ test/fixtures/multiple-rule-offenses.html.erb:
   Checked      1 file
   Offenses     8 errors | 6 warnings (14 offenses across 1 file)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        109 enabled | 21 not enabled"
+  Rules        110 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > summary offense buckets > moves a severity between buckets as --fail-level is lowered 1`] = `
@@ -2779,7 +2798,7 @@ multiple-rule-offenses.html.erb:
   Failing      8 errors | 4 warnings | 1 info (13 offenses across 1 file)
   Not failing  1 hint (1 offense across 1 file, below --fail-level=info)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        109 enabled | 21 not enabled"
+  Rules        110 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > summary offense buckets > splits the buckets when only some severities fail the build 1`] = `
@@ -2817,7 +2836,7 @@ multiple-rule-offenses.html.erb:
   Failing      8 errors | 4 warnings (12 offenses across 1 file)
   Not failing  1 info | 1 hint (2 offenses across 1 file, below --fail-level=warning)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        109 enabled | 21 not enabled"
+  Rules        110 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > unsafe autocorrectable offenses > counts and tags them separately from offenses --fix can correct 1`] = `
@@ -2937,5 +2956,5 @@ test/fixtures/test-file-with-errors.html.erb:2:22
   Failing      2 errors (2 offenses across 1 file)
   Not failing  1 warning (1 offense across 1 file, below --fail-level=error)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        109 enabled | 21 not enabled"
+  Rules        110 enabled | 21 not enabled"
 `;

--- a/javascript/packages/linter/test/autofix/source-indentation.autofix.test.ts
+++ b/javascript/packages/linter/test/autofix/source-indentation.autofix.test.ts
@@ -16,7 +16,7 @@ describe("source-indentation autofix", () => {
     const expected = "  this is a line\n  another line\n"
 
     const linter = new Linter(Herb, [SourceIndentationRule])
-    const result = linter.autofix(input)
+    const result = linter.autofix(input, { framework: "ruby" })
 
     expect(result.source).toBe(expected)
     expect(result.fixed).toHaveLength(2)
@@ -28,7 +28,7 @@ describe("source-indentation autofix", () => {
     const expected = "    this is a line\n"
 
     const linter = new Linter(Herb, [SourceIndentationRule])
-    const result = linter.autofix(input)
+    const result = linter.autofix(input, { framework: "ruby" })
 
     expect(result.source).toBe(expected)
     expect(result.fixed).toHaveLength(1)
@@ -40,7 +40,7 @@ describe("source-indentation autofix", () => {
     const expected = "        this is a line\n      another line\n"
 
     const linter = new Linter(Herb, [SourceIndentationRule])
-    const result = linter.autofix(input)
+    const result = linter.autofix(input, { framework: "ruby" })
 
     expect(result.source).toBe(expected)
     expect(result.fixed).toHaveLength(2)
@@ -51,7 +51,7 @@ describe("source-indentation autofix", () => {
     const input = "   this is a line\n   another line\n"
 
     const linter = new Linter(Herb, [SourceIndentationRule])
-    const result = linter.autofix(input)
+    const result = linter.autofix(input, { framework: "ruby" })
 
     expect(result.source).toBe(input)
     expect(result.fixed).toHaveLength(0)
@@ -62,7 +62,7 @@ describe("source-indentation autofix", () => {
     const input = "this is a line\n"
 
     const linter = new Linter(Herb, [SourceIndentationRule])
-    const result = linter.autofix(input)
+    const result = linter.autofix(input, { framework: "ruby" })
 
     expect(result.source).toBe(input)
     expect(result.fixed).toHaveLength(0)
@@ -73,7 +73,7 @@ describe("source-indentation autofix", () => {
     const input = "hello\tworld\n"
 
     const linter = new Linter(Herb, [SourceIndentationRule])
-    const result = linter.autofix(input)
+    const result = linter.autofix(input, { framework: "ruby" })
 
     expect(result.source).toBe(input)
     expect(result.fixed).toHaveLength(0)
@@ -85,7 +85,7 @@ describe("source-indentation autofix", () => {
     const expected = "<div>\n  <p>hello</p>\n</div>\n"
 
     const linter = new Linter(Herb, [SourceIndentationRule])
-    const result = linter.autofix(input)
+    const result = linter.autofix(input, { framework: "ruby" })
 
     expect(result.source).toBe(expected)
     expect(result.fixed).toHaveLength(1)
@@ -120,7 +120,7 @@ describe("source-indentation autofix", () => {
     })
 
     const linter = Linter.from(Herb, config)
-    const result = linter.autofix(input)
+    const result = linter.autofix(input, { framework: "ruby" })
 
     expect(result.source).toBe(expected)
     expect(result.fixed).toHaveLength(2)
@@ -166,7 +166,7 @@ describe("source-indentation autofix", () => {
     })
 
     const linter = Linter.from(Herb, config)
-    const result = linter.autofix(input)
+    const result = linter.autofix(input, { framework: "ruby" })
 
     expect(result.source).toBe(expected)
     expect(result.fixed).toHaveLength(1)

--- a/javascript/packages/linter/test/cli.test.ts
+++ b/javascript/packages/linter/test/cli.test.ts
@@ -333,6 +333,51 @@ describe("CLI Output Formatting", () => {
     })
   })
 
+  describe("missing `framework` option", () => {
+    const { writeFileSync, unlinkSync } = require("fs")
+    const configPath = "test/fixtures/.herb.yml"
+
+    test("collapses to a single offense across a run", () => {
+      try {
+        writeFileSync(configPath, dedent`
+          linter:
+            rules:
+              all:
+                enabled: false
+              herb-config-framework-option:
+                enabled: true
+        `)
+
+        const { output } = runLinter("*.html.erb", "--simple")
+
+        expect(output.match(/herb-config-framework-option/g)).toHaveLength(2)
+        expect(output).toContain("1 offense")
+      } finally {
+        try { unlinkSync(configPath) } catch {}
+      }
+    })
+
+    test("reports the missing option per template", () => {
+      try {
+        writeFileSync(configPath, dedent`
+          linter:
+            rules:
+              all:
+                enabled: false
+              herb-config-framework-option:
+                enabled: true
+        `)
+
+        const { output, exitCode } = runLinter("clean-file.html.erb", "--simple")
+
+        expect(output).toMatchSnapshot()
+        expect(exitCode).toBe(0)
+      } finally {
+        try { unlinkSync(configPath) } catch {}
+      }
+    })
+  })
+
   describe("Excluded Files", () => {
     const { writeFileSync, unlinkSync } = require("fs")
     const configPath = "test/fixtures/.herb.yml"
@@ -340,6 +385,8 @@ describe("CLI Output Formatting", () => {
     test("warns and skips excluded file without --force", () => {
       try {
         writeFileSync(configPath, dedent`
+          framework: ruby
+
           linter:
             exclude:
               - "test-file-with-errors.html.erb"
@@ -358,6 +405,8 @@ describe("CLI Output Formatting", () => {
     test("processes excluded file with --force", () => {
       try {
         writeFileSync(configPath, dedent`
+          framework: ruby
+
           linter:
             exclude:
               - "test-file-with-errors.html.erb"
@@ -383,6 +432,8 @@ describe("CLI Output Formatting", () => {
         writeFileSync(`${subdir}/excluded.html.erb`, '<img>\n')
 
         writeFileSync(configPath, dedent`
+          framework: ruby
+
           linter:
             exclude:
               - "subdir/**/*.html.erb"
@@ -468,6 +519,8 @@ describe("CLI Output Formatting", () => {
     test("exits with error code when warnings are present with --fail-level warning flag", () => {
       try {
         writeFileSync(configPath, dedent`
+          framework: ruby
+
           linter:
             rules:
               html-img-require-alt:
@@ -488,6 +541,8 @@ describe("CLI Output Formatting", () => {
     test("exits with success when no warnings are present with --fail-level warning flag", () => {
       try {
         writeFileSync(configPath, dedent`
+          framework: ruby
+
           linter:
             rules:
               html-img-require-alt:
@@ -505,6 +560,8 @@ describe("CLI Output Formatting", () => {
     test("exits with error code when failLevel is set in config", () => {
       try {
         writeFileSync(configPath, dedent`
+          framework: ruby
+
           linter:
             failLevel: warning
             rules:
@@ -526,6 +583,8 @@ describe("CLI Output Formatting", () => {
     test("CLI flag overrides config setting", () => {
       try {
         writeFileSync(configPath, dedent`
+          framework: ruby
+
           linter:
             failLevel: error
             rules:
@@ -555,6 +614,8 @@ describe("CLI Output Formatting", () => {
     test("exits with success when warnings present but --fail-level not set", () => {
       try {
         writeFileSync(configPath, dedent`
+          framework: ruby
+
           linter:
             rules:
               html-img-require-alt:
@@ -575,6 +636,8 @@ describe("CLI Output Formatting", () => {
     test("exits with error code when info diagnostics are present with --fail-level info flag", () => {
       try {
         writeFileSync(configPath, dedent`
+          framework: ruby
+
           linter:
             rules:
               html-img-require-alt:
@@ -595,6 +658,8 @@ describe("CLI Output Formatting", () => {
     test("exits with success when info diagnostics present but --fail-level is warning", () => {
       try {
         writeFileSync(configPath, dedent`
+          framework: ruby
+
           linter:
             rules:
               html-img-require-alt:
@@ -615,6 +680,8 @@ describe("CLI Output Formatting", () => {
     test("exits with error code when hint diagnostics are present with --fail-level hint flag", () => {
       try {
         writeFileSync(configPath, dedent`
+          framework: ruby
+
           linter:
             rules:
               html-img-require-alt:
@@ -635,6 +702,8 @@ describe("CLI Output Formatting", () => {
     test("exits with success when hint diagnostics present but --fail-level is info", () => {
       try {
         writeFileSync(configPath, dedent`
+          framework: ruby
+
           linter:
             rules:
               html-img-require-alt:
@@ -660,6 +729,8 @@ describe("CLI Output Formatting", () => {
     const OFFENSE_MESSAGE = "Missing required `alt` attribute"
 
     const hintConfig = dedent`
+      framework: ruby
+
       linter:
         rules:
           html-img-require-alt:
@@ -697,6 +768,8 @@ describe("CLI Output Formatting", () => {
     test("counts the hidden offenses and suggests the level that reveals them", () => {
       try {
         writeFileSync(configPath, dedent`
+          framework: ruby
+
           linter:
             rules:
               html-img-require-alt:
@@ -729,6 +802,8 @@ describe("CLI Output Formatting", () => {
     test("reads logLevel from the config file", () => {
       try {
         writeFileSync(configPath, dedent`
+          framework: ruby
+
           linter:
             logLevel: warning
             rules:
@@ -750,6 +825,8 @@ describe("CLI Output Formatting", () => {
     test("prefers the CLI flag over the config file", () => {
       try {
         writeFileSync(configPath, dedent`
+          framework: ruby
+
           linter:
             logLevel: warning
             rules:
@@ -805,6 +882,8 @@ describe("CLI Output Formatting", () => {
 
     describe("with --only", () => {
       const quietConfig = dedent`
+        framework: ruby
+
         linter:
           logLevel: warning
           rules:
@@ -830,6 +909,8 @@ describe("CLI Output Formatting", () => {
       test("lowers the log level to the lowest severity of the run", () => {
         try {
           writeFileSync(configPath, dedent`
+            framework: ruby
+
             linter:
               logLevel: error
               rules:
@@ -892,6 +973,8 @@ describe("CLI Output Formatting", () => {
 
     describe("with --all-rules", () => {
       const quietConfig = dedent`
+        framework: ruby
+
         linter:
           logLevel: warning
           rules:
@@ -936,6 +1019,8 @@ describe("CLI Output Formatting", () => {
     const configPath = "test/fixtures/.herb.yml"
 
     const noisyConfig = dedent`
+      framework: ruby
+
       linter:
         rules:
           html-anchor-require-href:
@@ -953,6 +1038,8 @@ describe("CLI Output Formatting", () => {
     `
 
     const quietConfig = dedent`
+      framework: ruby
+
       linter:
         rules:
           html-no-empty-headings:
@@ -1041,6 +1128,8 @@ describe("CLI Output Formatting", () => {
     const configPath = "test/fixtures/.herb.yml"
 
     const mixedSeverityConfig = dedent`
+      framework: ruby
+
       linter:
         rules:
           html-img-require-alt:
@@ -1134,6 +1223,8 @@ describe("CLI Output Formatting", () => {
     test("runs rules that are disabled in .herb.yml", () => {
       try {
         writeFileSync(configPath, dedent`
+          framework: ruby
+
           linter:
             rules:
               html-img-require-alt:
@@ -1155,6 +1246,8 @@ describe("CLI Output Formatting", () => {
     test("ignores rule-level exclude patterns from .herb.yml", () => {
       try {
         writeFileSync(configPath, dedent`
+          framework: ruby
+
           linter:
             rules:
               html-tag-name-lowercase:
@@ -1228,6 +1321,8 @@ describe("CLI Output Formatting", () => {
 
       try {
         writeFileSync(configPath, dedent`
+          framework: ruby
+
           linter:
             rules:
               html-tag-name-lowercase:
@@ -1340,6 +1435,7 @@ describe("CLI Output Formatting", () => {
 
       try {
         writeFileSync(configPath, dedent`
+          framework: ruby
           version: 0.4.0
         `)
 
@@ -1435,6 +1531,8 @@ describe("CLI Output Formatting", () => {
     test("runs rules that are disabled in .herb.yml", () => {
       try {
         writeFileSync(configPath, dedent`
+          framework: ruby
+
           linter:
             rules:
               html-tag-name-lowercase:
@@ -1458,6 +1556,7 @@ describe("CLI Output Formatting", () => {
 
       try {
         writeFileSync(configPath, dedent`
+          framework: ruby
           version: 0.4.0
         `)
 
@@ -1484,6 +1583,8 @@ describe("CLI Output Formatting", () => {
     test("ignores rule-level exclude patterns from .herb.yml", () => {
       try {
         writeFileSync(configPath, dedent`
+          framework: ruby
+
           linter:
             rules:
               html-tag-name-lowercase:
@@ -1548,6 +1649,8 @@ describe("CLI Output Formatting", () => {
     test("`all: enabled: false` only runs the rules that are opted back in", () => {
       try {
         writeFileSync(configPath, dedent`
+          framework: ruby
+
           linter:
             rules:
               all:
@@ -1577,6 +1680,8 @@ describe("CLI Output Formatting", () => {
         expect(withoutAll.output).not.toContain("a11y-disabled-attribute")
 
         writeFileSync(configPath, dedent`
+          framework: ruby
+
           linter:
             rules:
               all:
@@ -1603,6 +1708,7 @@ describe("CLI Output Formatting", () => {
         ` + "\n")
 
         writeFileSync(configPath, dedent`
+          framework: ruby
           version: 0.4.0
         `)
 
@@ -1610,6 +1716,7 @@ describe("CLI Output Formatting", () => {
         expect(withoutAll.output).toContain("New rules available")
 
         writeFileSync(configPath, dedent`
+          framework: ruby
           version: 0.4.0
           linter:
             rules:
@@ -1630,6 +1737,8 @@ describe("CLI Output Formatting", () => {
     test("--only takes precedence over a disabled `all`", () => {
       try {
         writeFileSync(configPath, dedent`
+          framework: ruby
+
           linter:
             rules:
               all:
@@ -1648,6 +1757,8 @@ describe("CLI Output Formatting", () => {
     test("--all-rules takes precedence over a disabled `all`", () => {
       try {
         writeFileSync(configPath, dedent`
+          framework: ruby
+
           linter:
             rules:
               all:
@@ -1668,6 +1779,8 @@ describe("CLI Output Formatting", () => {
         const withoutAll = JSON.parse(runLinter("parallel", "--jobs", "4", "--json").output)
 
         writeFileSync(configPath, dedent`
+          framework: ruby
+
           linter:
             rules:
               all:
@@ -1721,6 +1834,8 @@ describe("CLI Output Formatting", () => {
 
         try {
           writeFileSync(configPath, dedent`
+            framework: ruby
+
             linter:
               rules:
                 all:
@@ -1741,6 +1856,8 @@ describe("CLI Output Formatting", () => {
 
         try {
           writeFileSync(configPath, dedent`
+            framework: ruby
+
             linter:
               rules:
                 all:
@@ -1761,6 +1878,8 @@ describe("CLI Output Formatting", () => {
 
         try {
           writeFileSync(configPath, dedent`
+            framework: ruby
+
             linter:
               rules:
                 all:
@@ -1783,6 +1902,8 @@ describe("CLI Output Formatting", () => {
 
         try {
           writeFileSync(configPath, dedent`
+            framework: ruby
+
             linter:
               rules:
                 all:
@@ -1805,6 +1926,7 @@ describe("CLI Output Formatting", () => {
 
         try {
           writeFileSync(configPath, dedent`
+            framework: ruby
             version: 0.4.0
           `)
 
@@ -1814,6 +1936,7 @@ describe("CLI Output Formatting", () => {
           expect(withVersion.output).toContain("New rules available")
 
           writeFileSync(configPath, dedent`
+            framework: ruby
             version: 0.4.0
             linter:
               rules:
@@ -1836,6 +1959,7 @@ describe("CLI Output Formatting", () => {
 
         try {
           writeFileSync(configPath, dedent`
+            framework: ruby
             version: 0.4.0
             linter:
               rules:
@@ -1856,6 +1980,8 @@ describe("CLI Output Formatting", () => {
       test("`0 enabled` explains how to enable rules and links to the docs", () => {
         try {
           writeFileSync(configPath, dedent`
+            framework: ruby
+
             linter:
               rules:
                 all:
@@ -1879,6 +2005,8 @@ describe("CLI Output Formatting", () => {
       test("the hint stays out of the way as soon as a single rule is enabled", () => {
         try {
           writeFileSync(configPath, dedent`
+            framework: ruby
+
             linter:
               rules:
                 all:
@@ -1902,6 +2030,8 @@ describe("CLI Output Formatting", () => {
       test("the hint does not leak into `--json` output", () => {
         try {
           writeFileSync(configPath, dedent`
+            framework: ruby
+
             linter:
               rules:
                 all:
@@ -1921,6 +2051,8 @@ describe("CLI Output Formatting", () => {
       test("`--only` replaces the counts from a disabled `all`", () => {
         try {
           writeFileSync(configPath, dedent`
+            framework: ruby
+
             linter:
               rules:
                 all:
@@ -1941,6 +2073,8 @@ describe("CLI Output Formatting", () => {
 
         try {
           writeFileSync(configPath, dedent`
+            framework: ruby
+
             linter:
               rules:
                 all:

--- a/javascript/packages/linter/test/linter.test.ts
+++ b/javascript/packages/linter/test/linter.test.ts
@@ -50,7 +50,7 @@ describe("@herb-tools/linter", () => {
     test("returns correct error and warning counts", () => {
       const html = '<DIV><SPAN>Hello</SPAN></DIV>\n'
       const linter = new Linter(Herb)
-      const lintResult = linter.lint(html)
+      const lintResult = linter.lint(html, { framework: "ruby" })
 
       expect(lintResult.errors).toBe(4)
       expect(lintResult.warnings).toBe(0)

--- a/javascript/packages/linter/test/rules/herb-config-framework-option.test.ts
+++ b/javascript/packages/linter/test/rules/herb-config-framework-option.test.ts
@@ -1,0 +1,147 @@
+import dedent from "dedent"
+import { describe, test } from "vitest"
+
+import { HerbConfigFrameworkOptionRule } from "../../src/rules/herb-config-framework-option.js"
+import { createLinterTest } from "../helpers/linter-test-helper.js"
+
+const { expectNoOffenses, expectInfo, assertOffenses } = createLinterTest(HerbConfigFrameworkOptionRule)
+
+describe("HerbConfigFrameworkOptionRule", () => {
+  describe("valid cases", () => {
+    test("passes when the project configures a framework", () => {
+      expectNoOffenses('<%= image_tag "logo.png" %>', { framework: "actionview" })
+    })
+
+    test("passes when the project configures `ruby` deliberately", () => {
+      expectNoOffenses('<%= image_tag "logo.png" %>', { framework: "ruby" })
+    })
+
+    test("passes for a template with no Ruby at all once a framework is configured", () => {
+      expectNoOffenses("<div>Hello</div>", { framework: "ruby" })
+    })
+  })
+
+  describe("without any framework signal", () => {
+    test("reports a template with no Ruby", () => {
+      expectInfo("No `framework` is set in `.herb.yml`, so Herb assumes plain `ruby` templates. Set `framework` to one of `ruby`, `actionview`, `hanami`, or `sinatra` so Herb can tailor its assumptions, rules, and optimizations to your framework.")
+
+      assertOffenses(dedent`
+        <div class="card">
+          <h1>Hello</h1>
+        </div>
+      `)
+    })
+
+    test("reports a template whose Ruby says nothing about the framework", () => {
+      expectInfo("No `framework` is set in `.herb.yml`, so Herb assumes plain `ruby` templates. Set `framework` to one of `ruby`, `actionview`, `hanami`, or `sinatra` so Herb can tailor its assumptions, rules, and optimizations to your framework.")
+
+      assertOffenses(dedent`
+        <% user = User.new %>
+        <%= user.name %>
+      `)
+    })
+
+    test("reports helper names that any project could define, without suggesting Action View", () => {
+      expectInfo("No `framework` is set in `.herb.yml`, so Herb assumes plain `ruby` templates. Set `framework` to one of `ruby`, `actionview`, `hanami`, or `sinatra` so Herb can tailor its assumptions, rules, and optimizations to your framework.")
+
+      assertOffenses(dedent`
+        <%= render "header" %>
+        <%= t("hello") %>
+        <%= params[:query] %>
+        <%= truncate(post.body) %>
+      `)
+    })
+
+    test("reports a helper name called on a receiver without suggesting Action View", () => {
+      expectInfo("No `framework` is set in `.herb.yml`, so Herb assumes plain `ruby` templates. Set `framework` to one of `ruby`, `actionview`, `hanami`, or `sinatra` so Herb can tailor its assumptions, rules, and optimizations to your framework.")
+
+      assertOffenses('<%= view.image_tag("logo.png") %>')
+    })
+
+    test("reports a local variable that shares a helper name without suggesting Action View", () => {
+      expectInfo("No `framework` is set in `.herb.yml`, so Herb assumes plain `ruby` templates. Set `framework` to one of `ruby`, `actionview`, `hanami`, or `sinatra` so Herb can tailor its assumptions, rules, and optimizations to your framework.")
+
+      assertOffenses(dedent`
+        <% image_tag = "logo.png" %>
+        <%= image_tag %>
+      `)
+    })
+
+    test("reports a helper name inside a string or a comment without suggesting Action View", () => {
+      expectInfo("No `framework` is set in `.herb.yml`, so Herb assumes plain `ruby` templates. Set `framework` to one of `ruby`, `actionview`, `hanami`, or `sinatra` so Herb can tailor its assumptions, rules, and optimizations to your framework.")
+
+      assertOffenses(dedent`
+        <%# image_tag "logo.png" %>
+        <%= "image_tag" %>
+      `)
+    })
+
+    test("reports a method that merely starts with a helper name without suggesting Action View", () => {
+      expectInfo("No `framework` is set in `.herb.yml`, so Herb assumes plain `ruby` templates. Set `framework` to one of `ruby`, `actionview`, `hanami`, or `sinatra` so Herb can tailor its assumptions, rules, and optimizations to your framework.")
+
+      assertOffenses('<%= image_tag_for(post) %>')
+    })
+  })
+
+  describe("with an Action View signal", () => {
+    test("suggests Action View for a helper call", () => {
+      expectInfo("No `framework` is set in `.herb.yml`, so Herb assumes plain `ruby` templates. `image_tag` is an Action View helper, so this project looks like `actionview`. Set `framework: actionview` to get the rules, assumptions, and optimizations that come with it.")
+
+      assertOffenses('<%= image_tag "logo.png" %>')
+    })
+
+    test("suggests Action View for a helper in a silent tag", () => {
+      expectInfo("No `framework` is set in `.herb.yml`, so Herb assumes plain `ruby` templates. `content_for` is an Action View helper, so this project looks like `actionview`. Set `framework: actionview` to get the rules, assumptions, and optimizations that come with it.")
+
+      assertOffenses('<% content_for :title, "Home" %>')
+    })
+
+    test("suggests Action View for a helper inside a block", () => {
+      expectInfo("No `framework` is set in `.herb.yml`, so Herb assumes plain `ruby` templates. `link_to` is an Action View helper, so this project looks like `actionview`. Set `framework: actionview` to get the rules, assumptions, and optimizations that come with it.")
+
+      assertOffenses(dedent`
+        <% posts.each do |post| %>
+          <%= link_to post.title, post %>
+        <% end %>
+      `)
+    })
+
+    test("suggests Action View for a helper spanning a block", () => {
+      expectInfo("No `framework` is set in `.herb.yml`, so Herb assumes plain `ruby` templates. `form_with` is an Action View helper, so this project looks like `actionview`. Set `framework: actionview` to get the rules, assumptions, and optimizations that come with it.")
+
+      assertOffenses(dedent`
+        <%= form_with model: @user do |form| %>
+          <%= form.text_field :name %>
+        <% end %>
+      `)
+    })
+
+    test("reports once per file, on the first helper", () => {
+      expectInfo("No `framework` is set in `.herb.yml`, so Herb assumes plain `ruby` templates. `stylesheet_link_tag` is an Action View helper, so this project looks like `actionview`. Set `framework: actionview` to get the rules, assumptions, and optimizations that come with it.")
+
+      assertOffenses(dedent`
+        <%= stylesheet_link_tag "application" %>
+        <%= javascript_include_tag "application" %>
+        <%= image_tag "logo.png" %>
+      `)
+    })
+
+    test("suggests Action View for a strict locals declaration", () => {
+      expectInfo("No `framework` is set in `.herb.yml`, so Herb assumes plain `ruby` templates. This template declares strict locals, which only Action View reads, so this project looks like `actionview`. Set `framework: actionview` to get the rules, assumptions, and optimizations that come with it.")
+
+      assertOffenses(dedent`
+        <%# locals: (title:, subtitle: nil) %>
+        <h1><%= title %></h1>
+      `, { fileName: "_header.html.erb" })
+    })
+
+    test("prefers the strict locals declaration over a local that shares a helper name", () => {
+      expectInfo("No `framework` is set in `.herb.yml`, so Herb assumes plain `ruby` templates. This template declares strict locals, which only Action View reads, so this project looks like `actionview`. Set `framework: actionview` to get the rules, assumptions, and optimizations that come with it.")
+
+      assertOffenses(dedent`
+        <%# locals: (image_tag:) %>
+        <%= image_tag %>
+      `, { fileName: "_logo.html.erb" })
+    })
+  })
+})

--- a/javascript/packages/linter/test/xml-erb-linting.test.ts
+++ b/javascript/packages/linter/test/xml-erb-linting.test.ts
@@ -28,7 +28,7 @@ describe("XML+ERB Linting", () => {
       </rss>
     ` + '\n'
 
-    const result = linter.lint(source, { fileName: "test.xml.erb" })
+    const result = linter.lint(source, { fileName: "test.xml.erb", framework: "ruby" })
     expect(result.offenses).toHaveLength(0)
   })
 

--- a/lib/herb/defaults.yml
+++ b/lib/herb/defaults.yml
@@ -1,4 +1,3 @@
-framework: ruby
 template_engine: erubi
 
 files:


### PR DESCRIPTION
This pull request implements the `herb-config-framework-option` rule, which reports templates in a project that doesn't set `framework` in its `.herb.yml`.

The `framework` option decides what Herb may assume about a template, which rules apply, and which optimizations it can take. Without it Herb falls back to `ruby` and treats every template as plain ERB, which is the most conservative behavior it has, and nothing in the project says so. A Rails app silently misses every Action View rule until someone adds one line to their configuration.

The rule reports on the first line of each template. When the template shows what renders it, the offense says so and suggests that value:

```erb
<%= image_tag "logo.png", alt: "Logo" %>
```

> No `framework` is set in `.herb.yml`, so Herb assumes plain `ruby` templates. `image_tag` is an Action View helper, so this project looks like `actionview`. Set `framework: actionview` to get the rules, assumptions, and optimizations that come with it.