### PR TITLE
Linter: Clarify that the `ujs-*` rules require a migration to Turbo

### DIFF
--- a/javascript/packages/linter/docs/rules/ujs-no-remote-attribute.md
+++ b/javascript/packages/linter/docs/rules/ujs-no-remote-attribute.md
@@ -55,5 +55,6 @@ This is the one deprecated `@rails/ujs` attribute whose removal is not always a 
 ## References
 
 * [Rails Guides: Working with JavaScript in Rails](https://guides.rubyonrails.org/working_with_javascript_in_rails.html)
+* [turbo-rails: Upgrading from Rails UJS / Turbolinks to Turbo](https://github.com/hotwired/turbo-rails/blob/main/UPGRADING.md#upgrading-from-rails-ujs--turbolinks-to-turbo)
 * [Turbo Handbook: Drive](https://turbo.hotwired.dev/handbook/drive)
 * [Turbo Handbook: Streams](https://turbo.hotwired.dev/handbook/streams)

--- a/javascript/packages/linter/docs/rules/ujs-prefer-turbo-confirm.md
+++ b/javascript/packages/linter/docs/rules/ujs-prefer-turbo-confirm.md
@@ -10,7 +10,7 @@ Disallow the `data-confirm` attribute and the Action View helper option that ren
 
 Before Rails 7, Rails shipped `@rails/ujs` by default, which added JavaScript behavior to elements through helper options and `data-*` attributes. Rails 7 stopped including it, and Turbo covers the same behavior with its own attributes.
 
-`data-confirm` made `@rails/ujs` prompt the user with the given question before proceeding, and cancel the action if the user declined. `data-turbo-confirm` is a drop-in replacement, so the migration is mechanical.
+`data-confirm` made `@rails/ujs` prompt the user with the given question before proceeding, and cancel the action if the user declined. `data-turbo-confirm` is a drop-in replacement, so the migration is mechanical. The attribute is handled by Turbo, though, so the swap only takes effect once the app has migrated from `@rails/ujs` to Turbo.
 
 Once `@rails/ujs` is gone the attribute is inert, and the failure is silent rather than loud: the link or button still works, but the confirmation prompt simply stops appearing. A destructive action that was guarded now fires on the first click.
 
@@ -54,4 +54,5 @@ Once `@rails/ujs` is gone the attribute is inert, and the failure is silent rath
 
 * [Rails `link_to` API](https://api.rubyonrails.org/classes/ActionView/Helpers/UrlHelper.html#method-i-link_to)
 * [Rails Guides: Working with JavaScript in Rails](https://guides.rubyonrails.org/working_with_javascript_in_rails.html)
+* [turbo-rails: Upgrading from Rails UJS / Turbolinks to Turbo](https://github.com/hotwired/turbo-rails/blob/main/UPGRADING.md#upgrading-from-rails-ujs--turbolinks-to-turbo)
 * [Turbo Handbook: Drive](https://turbo.hotwired.dev/handbook/drive)

--- a/javascript/packages/linter/docs/rules/ujs-prefer-turbo-method.md
+++ b/javascript/packages/linter/docs/rules/ujs-prefer-turbo-method.md
@@ -10,7 +10,7 @@ Disallow the `data-method` attribute and the Action View link helper options tha
 
 Before Rails 7, Rails shipped `@rails/ujs` by default, which added JavaScript behavior to elements through helper options and `data-*` attributes. Rails 7 stopped including it, and Turbo covers the same behavior with its own attributes.
 
-`data-method` made `@rails/ujs` build a hidden form and submit it with the given verb, so that a plain link could issue a `DELETE`, `PATCH`, `POST` or `PUT` request. `data-turbo-method` is a drop-in replacement, so the migration is mechanical.
+`data-method` made `@rails/ujs` build a hidden form and submit it with the given verb, so that a plain link could issue a `DELETE`, `PATCH`, `POST` or `PUT` request. `data-turbo-method` is a drop-in replacement, so the migration is mechanical. The attribute is handled by Turbo, though, so the swap only takes effect once the app has migrated from `@rails/ujs` to Turbo.
 
 Once `@rails/ujs` is gone the attribute is inert, and the failure is silent rather than loud: the link still works, but it issues a `GET` to the same URL. A "Delete" link quietly turns into a link that shows the record instead of destroying it.
 
@@ -56,4 +56,5 @@ Note that `method:` on `button_to` and the `form_*` helpers is unaffected. Those
 
 * [Rails `link_to` API](https://api.rubyonrails.org/classes/ActionView/Helpers/UrlHelper.html#method-i-link_to)
 * [Rails Guides: Working with JavaScript in Rails](https://guides.rubyonrails.org/working_with_javascript_in_rails.html)
+* [turbo-rails: Upgrading from Rails UJS / Turbolinks to Turbo](https://github.com/hotwired/turbo-rails/blob/main/UPGRADING.md#upgrading-from-rails-ujs--turbolinks-to-turbo)
 * [Turbo Handbook: Drive](https://turbo.hotwired.dev/handbook/drive)

--- a/javascript/packages/linter/docs/rules/ujs-prefer-turbo-submits-with.md
+++ b/javascript/packages/linter/docs/rules/ujs-prefer-turbo-submits-with.md
@@ -10,7 +10,7 @@ Disallow the `data-disable-with` attribute and the Action View helper option tha
 
 Before Rails 7, Rails shipped `@rails/ujs` by default, which added JavaScript behavior to elements through helper options and `data-*` attributes. Rails 7 stopped including it, and Turbo covers the same behavior with its own attributes.
 
-`data-disable-with` made `@rails/ujs` disable the submit button and swap its label for the given text while the request was in flight, which is what stopped users from double submitting a form. `data-turbo-submits-with` is a drop-in replacement, so the migration is mechanical.
+`data-disable-with` made `@rails/ujs` disable the submit button and swap its label for the given text while the request was in flight, which is what stopped users from double submitting a form. `data-turbo-submits-with` is a drop-in replacement, so the migration is mechanical. The attribute is handled by Turbo, though, so the swap only takes effect once the app has migrated from `@rails/ujs` to Turbo.
 
 Once `@rails/ujs` is gone the attribute is inert, and the failure is silent rather than loud: the form still submits, but the button stays live and keeps its original label. Double submissions become possible again on exactly the forms that were annotated to prevent them.
 
@@ -54,4 +54,5 @@ Once `@rails/ujs` is gone the attribute is inert, and the failure is silent rath
 
 * [Rails `submit_tag` API](https://api.rubyonrails.org/classes/ActionView/Helpers/FormTagHelper.html#method-i-submit_tag)
 * [Rails Guides: Working with JavaScript in Rails](https://guides.rubyonrails.org/working_with_javascript_in_rails.html)
+* [turbo-rails: Upgrading from Rails UJS / Turbolinks to Turbo](https://github.com/hotwired/turbo-rails/blob/main/UPGRADING.md#upgrading-from-rails-ujs--turbolinks-to-turbo)
 * [Turbo Handbook: Drive](https://turbo.hotwired.dev/handbook/drive)

--- a/javascript/packages/linter/src/rules/ujs-base.ts
+++ b/javascript/packages/linter/src/rules/ujs-base.ts
@@ -14,18 +14,18 @@ export interface UJSAttributeDescriptor {
 
 function attributeMessage({ attribute, replacement }: UJSAttributeDescriptor): string {
   if (!replacement) {
-    return `Avoid the deprecated \`@rails/ujs\` attribute \`${attribute}\`. Turbo handles links and form submissions by default, so it can be removed.`
+    return `\`${attribute}\` is a deprecated \`@rails/ujs\` attribute. Turbo handles links and form submissions by default, so remove it once the app has migrated from \`@rails/ujs\` to Turbo.`
   }
 
-  return `Avoid the deprecated \`@rails/ujs\` attribute \`${attribute}\`. Use \`${replacement.attribute}\` instead.`
+  return `\`${attribute}\` is a deprecated \`@rails/ujs\` attribute. Use \`${replacement.attribute}\` instead, which only works once the app has migrated from \`@rails/ujs\` to Turbo.`
 }
 
 function optionMessage({ attribute, replacement }: UJSAttributeDescriptor): string {
   if (!replacement) {
-    return `Avoid the deprecated \`@rails/ujs\` option, which renders \`${attribute}\`. Turbo handles links and form submissions by default, so it can be removed.`
+    return `This option renders \`${attribute}\`, a deprecated \`@rails/ujs\` attribute. Turbo handles links and form submissions by default, so remove it once the app has migrated from \`@rails/ujs\` to Turbo.`
   }
 
-  return `Avoid the deprecated \`@rails/ujs\` option, which renders \`${attribute}\`. Use \`${replacement.option}\` instead.`
+  return `This option renders \`${attribute}\`, a deprecated \`@rails/ujs\` attribute. Use \`${replacement.option}\` instead, which renders \`${replacement.attribute}\` and only works once the app has migrated from \`@rails/ujs\` to Turbo.`
 }
 
 function symbolKey(node: PrismNode): string | null {

--- a/javascript/packages/linter/test/rules/ujs-no-remote-attribute.test.ts
+++ b/javascript/packages/linter/test/rules/ujs-no-remote-attribute.test.ts
@@ -8,8 +8,8 @@ import { createLinterTest } from "../helpers/linter-test-helper.js"
 
 const { expectNoOffenses, expectWarning, assertOffenses } = createLinterTest(UJSNoRemoteAttributeRule)
 
-const ATTRIBUTE_MESSAGE = "Avoid the deprecated `@rails/ujs` attribute `data-remote`. Turbo handles links and form submissions by default, so it can be removed."
-const OPTION_MESSAGE = "Avoid the deprecated `@rails/ujs` option, which renders `data-remote`. Turbo handles links and form submissions by default, so it can be removed."
+const ATTRIBUTE_MESSAGE = "`data-remote` is a deprecated `@rails/ujs` attribute. Turbo handles links and form submissions by default, so remove it once the app has migrated from `@rails/ujs` to Turbo."
+const OPTION_MESSAGE = "This option renders `data-remote`, a deprecated `@rails/ujs` attribute. Turbo handles links and form submissions by default, so remove it once the app has migrated from `@rails/ujs` to Turbo."
 
 describe("ujs-no-remote-attribute", () => {
   describe("HTML attributes", () => {

--- a/javascript/packages/linter/test/rules/ujs-prefer-turbo-confirm.test.ts
+++ b/javascript/packages/linter/test/rules/ujs-prefer-turbo-confirm.test.ts
@@ -8,8 +8,8 @@ import { createLinterTest } from "../helpers/linter-test-helper.js"
 
 const { expectNoOffenses, expectWarning, assertOffenses } = createLinterTest(UJSPreferTurboConfirmRule)
 
-const ATTRIBUTE_MESSAGE = "Avoid the deprecated `@rails/ujs` attribute `data-confirm`. Use `data-turbo-confirm` instead."
-const OPTION_MESSAGE = "Avoid the deprecated `@rails/ujs` option, which renders `data-confirm`. Use `data: { turbo_confirm: ... }` instead."
+const ATTRIBUTE_MESSAGE = "`data-confirm` is a deprecated `@rails/ujs` attribute. Use `data-turbo-confirm` instead, which only works once the app has migrated from `@rails/ujs` to Turbo."
+const OPTION_MESSAGE = "This option renders `data-confirm`, a deprecated `@rails/ujs` attribute. Use `data: { turbo_confirm: ... }` instead, which renders `data-turbo-confirm` and only works once the app has migrated from `@rails/ujs` to Turbo."
 
 describe("ujs-prefer-turbo-confirm", () => {
   describe("HTML attributes", () => {

--- a/javascript/packages/linter/test/rules/ujs-prefer-turbo-method.test.ts
+++ b/javascript/packages/linter/test/rules/ujs-prefer-turbo-method.test.ts
@@ -9,8 +9,8 @@ import { createLinterTest } from "../helpers/linter-test-helper.js"
 
 const { expectNoOffenses, expectWarning, assertOffenses } = createLinterTest(UJSPreferTurboMethodRule)
 
-const ATTRIBUTE_MESSAGE = "Avoid the deprecated `@rails/ujs` attribute `data-method`. Use `data-turbo-method` instead."
-const OPTION_MESSAGE = "Avoid the deprecated `@rails/ujs` option, which renders `data-method`. Use `data: { turbo_method: ... }` instead."
+const ATTRIBUTE_MESSAGE = "`data-method` is a deprecated `@rails/ujs` attribute. Use `data-turbo-method` instead, which only works once the app has migrated from `@rails/ujs` to Turbo."
+const OPTION_MESSAGE = "This option renders `data-method`, a deprecated `@rails/ujs` attribute. Use `data: { turbo_method: ... }` instead, which renders `data-turbo-method` and only works once the app has migrated from `@rails/ujs` to Turbo."
 
 describe("ujs-prefer-turbo-method", () => {
   describe("HTML attributes", () => {

--- a/javascript/packages/linter/test/rules/ujs-prefer-turbo-submits-with.test.ts
+++ b/javascript/packages/linter/test/rules/ujs-prefer-turbo-submits-with.test.ts
@@ -8,8 +8,8 @@ import { createLinterTest } from "../helpers/linter-test-helper.js"
 
 const { expectNoOffenses, expectWarning, assertOffenses } = createLinterTest(UJSPreferTurboSubmitsWithRule)
 
-const ATTRIBUTE_MESSAGE = "Avoid the deprecated `@rails/ujs` attribute `data-disable-with`. Use `data-turbo-submits-with` instead."
-const OPTION_MESSAGE = "Avoid the deprecated `@rails/ujs` option, which renders `data-disable-with`. Use `data: { turbo_submits_with: ... }` instead."
+const ATTRIBUTE_MESSAGE = "`data-disable-with` is a deprecated `@rails/ujs` attribute. Use `data-turbo-submits-with` instead, which only works once the app has migrated from `@rails/ujs` to Turbo."
+const OPTION_MESSAGE = "This option renders `data-disable-with`, a deprecated `@rails/ujs` attribute. Use `data: { turbo_submits_with: ... }` instead, which renders `data-turbo-submits-with` and only works once the app has migrated from `@rails/ujs` to Turbo."
 
 describe("ujs-prefer-turbo-submits-with", () => {
   describe("HTML attributes", () => {


### PR DESCRIPTION
Follow up on #2057.

The four `ujs-*` rules told you what to stop writing, but not what applying the fix actually depends on. The suggested replacements are Turbo attributes, and Turbo attributes do nothing on an app that is still running `@rails/ujs`. Someone who reads the offense as a rename can swap `method: :delete` for `data: { turbo_method: :delete }`, see the linter go quiet, and ship a "Delete" link that now issues a `GET`. That is the same silent failure the rules exist to prevent.

The messages now say that the replacement is a Turbo attribute and that it only takes effect after the app has moved off `@rails/ujs`.

```diff
- Avoid the deprecated `@rails/ujs` attribute `data-method`. Use `data-turbo-method` instead.
+ " `data-method` is a deprecated `@rails/ujs` attribute. Use `data-turbo-method` instead, which only works once the app has migrated from `@rails/ujs` to Turbo.
```

```diff
- Avoid the deprecated `@rails/ujs` option, which renders `data-method`. Use `data: { turbo_method: ... }` instead.
+ This option renders `data-method`, a deprecated `@rails/ujs` attribute. Use `data: { turbo_method: ... }` instead, which renders `data-turbo-method` and only works once the app has migrated from `@rails/ujs` to Turbo.
```