### PR TITLE
Linter: Implement `actionview-no-content-argument-with-block` rule

### DIFF
--- a/Yerbafile
+++ b/Yerbafile
@@ -199,6 +199,7 @@ rules:
             - arg_position
             - skip_if_hash
             - to_s_suffix_when_single
+            - positional_arguments_with_block
 
       - sort_keys:
           path: "arguments[]"

--- a/config/action_view_helpers/actionview/form_tag_helper/button_tag.yml
+++ b/config/action_view_helpers/actionview/form_tag_helper/button_tag.yml
@@ -9,6 +9,12 @@ supports_block: true
 signature: "button_tag(content_or_options = nil, options = nil, &block)"
 documentation_url: "https://api.rubyonrails.org/classes/ActionView/Helpers/FormTagHelper.html#method-i-button_tag"
 
+content:
+  source: "block_or_arg"
+  arg_position: 1
+  skip_if_hash: true
+  positional_arguments_with_block: 0
+
 description: |-
   Creates a button element that defines a submit button, reset button, or a generic button which can be used in JavaScript.
 

--- a/config/action_view_helpers/actionview/form_tag_helper/label_tag.yml
+++ b/config/action_view_helpers/actionview/form_tag_helper/label_tag.yml
@@ -9,6 +9,12 @@ supports_block: true
 signature: "label_tag(name = nil, content_or_options = nil, options = nil, &block)"
 documentation_url: "https://api.rubyonrails.org/classes/ActionView/Helpers/FormTagHelper.html#method-i-label_tag"
 
+content:
+  source: "block_or_arg"
+  arg_position: 2
+  skip_if_hash: true
+  positional_arguments_with_block: 1
+
 description: |-
   Creates a label element. Accepts a block.
 

--- a/config/action_view_helpers/actionview/tag_helper/content_tag.yml
+++ b/config/action_view_helpers/actionview/tag_helper/content_tag.yml
@@ -15,6 +15,7 @@ content:
   source: "block_or_arg"
   arg_position: 2
   skip_if_hash: true
+  positional_arguments_with_block: 1
 
 description: |-
   Returns an HTML block tag of type name surrounding the content. Add HTML attributes by passing an attributes hash to options. Instead of passing the content as an argument, you can also use a block. This is legacy syntax; see the `tag` method for the modern equivalent.

--- a/config/action_view_helpers/actionview/tag_helper/tag.yml
+++ b/config/action_view_helpers/actionview/tag_helper/tag.yml
@@ -15,6 +15,7 @@ content:
   source: "block_or_arg"
   arg_position: 1
   skip_if_hash: true
+  positional_arguments_with_block: 0
 
 description: |-
   Returns an HTML5 compliant tag with a tag proxy. Every tag can be built with `tag.<tag name>(optional content, options)`. Supports `data-*` and `aria-*` attributes via nested hashes. Sub-attributes are dasherized. Respects HTML5 void elements.

--- a/config/action_view_helpers/actionview/url_helper/button_to.yml
+++ b/config/action_view_helpers/actionview/url_helper/button_to.yml
@@ -9,6 +9,11 @@ supports_block: true
 signature: "button_to(name = nil, options = nil, html_options = nil, &block)"
 documentation_url: "https://api.rubyonrails.org/classes/ActionView/Helpers/UrlHelper.html#method-i-button_to"
 
+content:
+  source: "block_or_arg"
+  arg_position: 1
+  positional_arguments_with_block: 1
+
 description: |-
   Generates a form containing a single button that submits to the URL created by the set of options. This is the safest method to ensure links that cause changes to your data are not triggered by search bots or accelerators.
 

--- a/config/action_view_helpers/actionview/url_helper/link_to.yml
+++ b/config/action_view_helpers/actionview/url_helper/link_to.yml
@@ -17,6 +17,7 @@ content:
   source: "block_or_arg"
   arg_position: 1
   to_s_suffix_when_single: true
+  positional_arguments_with_block: 1
 
 description: |-
   Creates an anchor element of the given name using a URL created by the set of options. It is also possible to pass a String instead of an options hash, which generates an anchor element that uses the value of the String as the href for the link. If `nil` is passed as the name the value of the link itself will become the name.

--- a/config/action_view_helpers/actionview/url_helper/mail_to.yml
+++ b/config/action_view_helpers/actionview/url_helper/mail_to.yml
@@ -9,6 +9,12 @@ supports_block: true
 signature: "mail_to(email_address, name = nil, html_options = {}, &block)"
 documentation_url: "https://api.rubyonrails.org/classes/ActionView/Helpers/UrlHelper.html#method-i-mail_to"
 
+content:
+  source: "block_or_arg"
+  arg_position: 2
+  skip_if_hash: true
+  positional_arguments_with_block: 1
+
 description: |-
   Creates a mailto link tag to the specified email_address, which is also used as the name of the link unless name is specified. Additional HTML attributes for the link can be passed in html_options.
 

--- a/config/action_view_helpers/actionview/url_helper/phone_to.yml
+++ b/config/action_view_helpers/actionview/url_helper/phone_to.yml
@@ -9,6 +9,12 @@ supports_block: true
 signature: "phone_to(phone_number, name = nil, html_options = {}, &block)"
 documentation_url: "https://api.rubyonrails.org/classes/ActionView/Helpers/UrlHelper.html#method-i-phone_to"
 
+content:
+  source: "block_or_arg"
+  arg_position: 2
+  skip_if_hash: true
+  positional_arguments_with_block: 1
+
 description: |-
   Creates a TEL anchor link tag to the specified phone_number. When the link is clicked, the default app to make phone calls is opened and prepopulated with the phone number.
 

--- a/config/action_view_helpers/actionview/url_helper/sms_to.yml
+++ b/config/action_view_helpers/actionview/url_helper/sms_to.yml
@@ -9,6 +9,12 @@ supports_block: true
 signature: "sms_to(phone_number, name = nil, html_options = {}, &block)"
 documentation_url: "https://api.rubyonrails.org/classes/ActionView/Helpers/UrlHelper.html#method-i-sms_to"
 
+content:
+  source: "block_or_arg"
+  arg_position: 2
+  skip_if_hash: true
+  positional_arguments_with_block: 1
+
 description: |-
   Creates an SMS anchor link tag to the specified phone_number. When the link is clicked, the default SMS messaging app is opened ready to send a message. If the body option is specified, the contents of the message will be preset.
 

--- a/javascript/packages/core/src/ruby-keywords.ts
+++ b/javascript/packages/core/src/ruby-keywords.ts
@@ -45,3 +45,30 @@ export const RUBY_KEYWORDS: ReadonlySet<string> = new Set([
 export function isRubyKeyword(name: string): boolean {
   return RUBY_KEYWORDS.has(name)
 }
+
+export const RUBY_INTROSPECTION_METHODS: ReadonlySet<string> = new Set([
+  "__id__",
+  "__send__",
+  "class",
+  "clone",
+  "dup",
+  "freeze",
+  "frozen",
+  "inspect",
+  "method",
+  "object_id",
+  "public_send",
+  "send",
+  "tap",
+  "then",
+  "to_s",
+  "try",
+  "try!",
+  "yield_self",
+])
+
+export function isRubyIntrospectionMethod(name: string): boolean {
+  if (RUBY_INTROSPECTION_METHODS.has(name)) return true
+
+  return name.endsWith("?") || name.endsWith("!")
+}

--- a/javascript/packages/core/test/ruby-keywords.test.ts
+++ b/javascript/packages/core/test/ruby-keywords.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest"
 
-import { RUBY_KEYWORDS, isRubyKeyword } from "../src/ruby-keywords.js"
+import { RUBY_KEYWORDS, isRubyKeyword, RUBY_INTROSPECTION_METHODS, isRubyIntrospectionMethod } from "../src/ruby-keywords.js"
 
 describe("RUBY_KEYWORDS", () => {
   it("contains the control flow keywords", () => {
@@ -42,5 +42,49 @@ describe("RUBY_KEYWORDS", () => {
   it("exposes the set directly", () => {
     expect(RUBY_KEYWORDS.has("def")).toBe(true)
     expect(RUBY_KEYWORDS.size).toBe(41)
+  })
+})
+
+describe("RUBY_INTROSPECTION_METHODS", () => {
+  it("contains the dynamic dispatch methods", () => {
+    for (const method of ["send", "public_send", "__send__", "try", "try!", "method"]) {
+      expect(isRubyIntrospectionMethod(method)).toBe(true)
+    }
+  })
+
+  it("contains the object identity and copying methods", () => {
+    for (const method of ["class", "object_id", "__id__", "dup", "clone", "freeze", "frozen", "inspect", "to_s"]) {
+      expect(isRubyIntrospectionMethod(method)).toBe(true)
+    }
+  })
+
+  it("contains the chaining methods", () => {
+    for (const method of ["tap", "then", "yield_self"]) {
+      expect(isRubyIntrospectionMethod(method)).toBe(true)
+    }
+  })
+
+  it("treats every predicate and bang method as introspection", () => {
+    for (const method of ["present?", "blank?", "any?", "save!", "update!"]) {
+      expect(isRubyIntrospectionMethod(method)).toBe(true)
+    }
+  })
+
+  it("does not contain ordinary method names", () => {
+    for (const method of ["div", "span", "title", "name", "render", "sender", "to_string", "classes"]) {
+      expect(isRubyIntrospectionMethod(method)).toBe(false)
+    }
+  })
+
+  it("is case sensitive", () => {
+    expect(isRubyIntrospectionMethod("Class")).toBe(false)
+    expect(isRubyIntrospectionMethod("Send")).toBe(false)
+  })
+
+  it("matches the list in `src/util/ruby_util.c`", () => {
+    expect([...RUBY_INTROSPECTION_METHODS].sort()).toEqual([
+      "__id__", "__send__", "class", "clone", "dup", "freeze", "frozen", "inspect", "method",
+      "object_id", "public_send", "send", "tap", "then", "to_s", "try", "try!", "yield_self",
+    ])
   })
 })

--- a/javascript/packages/linter/docs/rules/README.md
+++ b/javascript/packages/linter/docs/rules/README.md
@@ -19,6 +19,7 @@ This page contains documentation for all Herb Linter rules.
 
 #### Action View
 
+- [`actionview-no-content-argument-with-block`](./actionview-no-content-argument-with-block.md) - Disallow passing a content argument to a helper that is given a block
 - [`actionview-no-dynamic-partial-path`](./actionview-no-dynamic-partial-path.md) - Disallow partial paths that are built at runtime
 - [`actionview-no-helper-shadowing`](./actionview-no-helper-shadowing.md) - Disallow shadowing Action View helpers with block variables
 - [`actionview-no-implicit-partial`](./actionview-no-implicit-partial.md) - Disallow `render` calls that infer the partial from an object

--- a/javascript/packages/linter/docs/rules/actionview-no-content-argument-with-block.md
+++ b/javascript/packages/linter/docs/rules/actionview-no-content-argument-with-block.md
@@ -1,0 +1,109 @@
+# Linter Rule: Disallow passing a content argument to a helper that is given a block
+
+**Rule:** `actionview-no-content-argument-with-block`
+
+## Description
+
+Detects Action View helpers that are given both a positional content argument and a block, such as `tag.div "Hello" do`, `content_tag :section, "Intro" do` or `link_to "Go", root_path do`.
+
+## Rationale
+
+An Action View helper that takes its content from either an argument or a block only reads one of them. When a block is given, the block wins and the argument goes somewhere the caller did not intend.
+
+For `tag`, `content_tag`, `button_tag`, `label_tag`, `mail_to`, `phone_to` and `sms_to` the argument is silently discarded:
+
+```ruby
+content_tag(:section, "Intro") { "Welcome" }
+# => "<section>Welcome</section>"
+```
+
+Nothing warns, nothing raises, and `"Intro"` never reaches the page. The template reads as if both strings render.
+
+For `link_to` and `button_to` it is worse. Those helpers shift their arguments when a block is given, so the first argument becomes the URL and the second becomes the HTML attributes hash:
+
+```ruby
+link_to("Go", "/dashboard") { "Go now" }
+# => NoMethodError: undefined method 'stringify_keys' for an instance of String
+```
+
+Both helpers are correct with a block as long as the content argument is left out.
+
+The rule reads which argument holds the content, and how many positional arguments survive a block, from the [Action View helper registry](https://github.com/marcoroth/herb/tree/main/config/action_view_helpers), so a helper that gains the same metadata is covered without a change to the rule.
+
+An argument whose value cannot be determined statically is never reported, because Action View treats a hash in that position as the options hash. `content_tag :div, wrapper_options do` may well be passing options and is left alone. Only literal strings, interpolated strings, symbols and numbers are reported.
+
+Helpers whose first argument is not content are unaffected. `field_set_tag "Account" do` renders the legend and the block body, `link_to_if` only calls its block when the condition fails, and `truncate` appends its block to the truncated text.
+
+## Examples
+
+### ✅ Good
+
+```erb
+<%= tag.div "Hello" %>
+```
+
+```erb
+<%= tag.div do %>
+  Hello
+<% end %>
+```
+
+```erb
+<%= content_tag :div, class: "card" do %>
+  Hello
+<% end %>
+```
+
+```erb
+<%= link_to "Dashboard", root_path %>
+```
+
+```erb
+<%= link_to root_path do %>
+  Dashboard
+<% end %>
+```
+
+```erb
+<%= button_tag class: "primary" do %>
+  Save
+<% end %>
+```
+
+### 🚫 Bad
+
+```erb
+<%= tag.div "Hello" do %>
+  World
+<% end %>
+```
+
+```erb
+<%= content_tag :section, "Intro" do %>
+  Welcome
+<% end %>
+```
+
+```erb
+<%= link_to "Go", root_path do %>
+  Go now
+<% end %>
+```
+
+```erb
+<%= button_tag "Save" do %>
+  Submit
+<% end %>
+```
+
+```erb
+<%= label_tag :email, "Email" do %>
+  Email address
+<% end %>
+```
+
+## References
+
+- [Rails API - `ActionView::Helpers::TagHelper#content_tag`](https://api.rubyonrails.org/classes/ActionView/Helpers/TagHelper.html#method-i-content_tag)
+- [Rails API - `ActionView::Helpers::TagHelper#tag`](https://api.rubyonrails.org/classes/ActionView/Helpers/TagHelper.html#method-i-tag)
+- [Rails API - `ActionView::Helpers::UrlHelper#link_to`](https://api.rubyonrails.org/classes/ActionView/Helpers/UrlHelper.html#method-i-link_to)

--- a/javascript/packages/linter/src/rules.ts
+++ b/javascript/packages/linter/src/rules.ts
@@ -11,6 +11,7 @@ import { A11yNoRedundantImageAltRule } from "./rules/a11y-no-redundant-image-alt
 import { A11yNoVisuallyHiddenInteractiveElementsRule } from "./rules/a11y-no-visually-hidden-interactive-elements.js"
 import { A11ySVGHasAccessibleTextRule } from "./rules/a11y-svg-has-accessible-text.js"
 
+import { ActionViewNoContentArgumentWithBlockRule } from "./rules/actionview-no-content-argument-with-block.js"
 import { ActionViewNoDynamicPartialPathRule } from "./rules/actionview-no-dynamic-partial-path.js"
 import { ActionViewNoHelperShadowingRule } from "./rules/actionview-no-helper-shadowing.js"
 import { ActionViewNoImplicitPartialRule } from "./rules/actionview-no-implicit-partial.js"
@@ -153,6 +154,7 @@ export const rules: RuleClass[] = [
   A11yNoVisuallyHiddenInteractiveElementsRule,
   A11ySVGHasAccessibleTextRule,
 
+  ActionViewNoContentArgumentWithBlockRule,
   ActionViewNoDynamicPartialPathRule,
   ActionViewNoHelperShadowingRule,
   ActionViewNoImplicitPartialRule,

--- a/javascript/packages/linter/src/rules/actionview-no-content-argument-with-block.ts
+++ b/javascript/packages/linter/src/rules/actionview-no-content-argument-with-block.ts
@@ -1,0 +1,134 @@
+import { ParserRule } from "../types.js"
+import { PrismVisitor, getHelper, isPrismNodeType, isRubyIntrospectionMethod, substringFromByteOffset, locationFromByteOffset } from "@herb-tools/core"
+
+import { isActionViewHelperCall, isTagBuilderCall } from "./action-view-utils.js"
+
+import type { HelperEntry, ParseResult, ParserOptions, PrismNode } from "@herb-tools/core"
+import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types.js"
+
+const HASH_ARGUMENT_TYPES = ["HashNode", "KeywordHashNode"] as const
+const CONTENT_LITERAL_TYPES = ["StringNode", "InterpolatedStringNode", "SymbolNode", "InterpolatedSymbolNode", "IntegerNode", "FloatNode"] as const
+
+interface ContentArgumentOffense {
+  helper: HelperEntry
+  helperCallName: string
+  contentArgument: PrismNode
+  ignoredArgument: PrismNode
+  ignoredPosition: number
+}
+
+function isHashArgument(node: PrismNode): boolean {
+  return HASH_ARGUMENT_TYPES.some(type => isPrismNodeType(node, type))
+}
+
+function isContentLiteral(node: PrismNode): boolean {
+  return CONTENT_LITERAL_TYPES.some(type => isPrismNodeType(node, type))
+}
+
+function sourceOf(source: string, node: PrismNode): string {
+  return substringFromByteOffset(source, node.location.startOffset, node.location.length)
+}
+
+function argumentName(helper: HelperEntry, position: number): string {
+  return helper.arguments[position - 1]?.name ?? `argument ${position}`
+}
+
+function contentArgumentOffense(call: PrismNode): ContentArgumentOffense | null {
+  const helperCall = isActionViewHelperCall(call)
+
+  if (!helperCall) return null
+  if (!isPrismNodeType(call.block, "BlockNode")) return null
+  if (isTagBuilderCall(call) && isRubyIntrospectionMethod(call.name)) return null
+
+  const helper = getHelper(helperCall.helperName)
+  const content = helper?.content
+
+  if (!helper || !content) return null
+  if (content.source !== "block_or_arg") return null
+  if (content.argPosition === null) return null
+  if (content.positionalArgumentsWithBlock === null) return null
+
+  const argumentNodes: PrismNode[] = call.arguments_?.arguments_ ?? []
+
+  const contentArgument = argumentNodes[content.argPosition - 1]
+  const ignoredArgument = argumentNodes[content.positionalArgumentsWithBlock]
+
+  if (!contentArgument || !ignoredArgument) return null
+  if (!isContentLiteral(contentArgument)) return null
+  if (isHashArgument(ignoredArgument)) return null
+
+  return {
+    helper,
+    helperCallName: call.receiver ? `${helper.name}.${call.name}` : helper.name,
+    contentArgument,
+    ignoredArgument,
+    ignoredPosition: content.positionalArgumentsWithBlock + 1,
+  }
+}
+
+class ContentArgumentWithBlockCollector extends PrismVisitor {
+  public readonly offenses: ContentArgumentOffense[] = []
+
+  visitCallNode(node: PrismNode): void {
+    const offense = contentArgumentOffense(node)
+
+    if (offense) {
+      this.offenses.push(offense)
+    }
+
+    this.visitChildNodes(node)
+  }
+}
+
+export class ActionViewNoContentArgumentWithBlockRule extends ParserRule {
+  static ruleName = "actionview-no-content-argument-with-block"
+  static introducedIn = this.version("unreleased")
+
+  get defaultConfig(): FullRuleConfig {
+    return {
+      enabled: true,
+      severity: "error",
+    }
+  }
+
+  get parserOptions(): Partial<ParserOptions> {
+    return {
+      prism_program: true,
+    }
+  }
+
+  check(result: ParseResult, _context?: Partial<LintContext>): UnboundLintOffense[] {
+    const source = result.value.source
+    const prismNode = result.value.prismNode
+
+    if (!prismNode || !source) return []
+
+    const collector = new ContentArgumentWithBlockCollector()
+
+    collector.visit(prismNode)
+
+    return collector.offenses.map(({ helper, helperCallName, contentArgument, ignoredArgument, ignoredPosition }) => {
+      const location = locationFromByteOffset(source, contentArgument.location.startOffset, contentArgument.location.length)
+      const content = sourceOf(source, contentArgument)
+      const shiftsArguments = contentArgument !== ignoredArgument
+
+      if (shiftsArguments) {
+        const shiftedInto = argumentName(helper, ignoredPosition)
+        const shiftedAway = argumentName(helper, ignoredPosition + 1)
+
+        return this.createOffense(
+          `The \`${helperCallName}\` helper shifts its arguments when it is given a block, so \`${content}\` is read as \`${shiftedInto}\` and \`${sourceOf(source, ignoredArgument)}\` as \`${shiftedAway}\` instead of as content. Rails expects a Hash in \`${shiftedAway}\` and raises when it is not one. Remove \`${content}\` and let the block render the content.`,
+          location,
+        )
+      }
+
+      return this.createOffense(
+        `The \`${helperCallName}\` helper renders either its content argument or its block, never both, and the block wins, so \`${content}\` is silently discarded and never reaches the page. Remove \`${content}\`, or remove the block and let the argument render the content.`,
+        location,
+        undefined,
+        undefined,
+        ["unnecessary"],
+      )
+    })
+  }
+}

--- a/javascript/packages/linter/src/rules/index.ts
+++ b/javascript/packages/linter/src/rules/index.ts
@@ -17,6 +17,7 @@ export * from "./action-view-utils.js"
 export * from "./herb-disable-comment-base.js"
 export * from "./ujs-base.js"
 
+export * from "./actionview-no-content-argument-with-block.js"
 export * from "./actionview-no-dynamic-partial-path.js"
 export * from "./actionview-no-helper-shadowing.js"
 export * from "./actionview-no-implicit-partial.js"

--- a/javascript/packages/linter/test/__snapshots__/cli.test.ts.snap
+++ b/javascript/packages/linter/test/__snapshots__/cli.test.ts.snap
@@ -19,7 +19,7 @@ test-file-with-errors.html.erb:
   Failing      2 errors (2 offenses across 1 file)
   Not failing  1 warning (1 offense across 1 file, below --fail-level=error)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        131 enabled | all rules via --all-rules"
+  Rules        132 enabled | all rules via --all-rules"
 `;
 
 exports[`CLI Output Formatting > \`all\` pseudo rule in .herb.yml > \`Rules\` summary line > \`--only\` replaces the counts from a disabled \`all\` 1`] = `
@@ -50,7 +50,7 @@ exports[`CLI Output Formatting > \`all\` pseudo rule in .herb.yml > \`Rules\` su
   Checked      1 file
   Offenses     0 offenses
   Fixable      0 offenses
-  Rules        0 enabled | 131 not enabled
+  Rules        0 enabled | 132 not enabled
 
  No rules enabled:
   Every linter rule is turned off, so no offenses can be reported.
@@ -71,7 +71,7 @@ exports[`CLI Output Formatting > \`all\` pseudo rule in .herb.yml > \`Rules\` su
   Checked      1 file
   Offenses     0 offenses
   Fixable      0 offenses
-  Rules        0 enabled | 131 not enabled
+  Rules        0 enabled | 132 not enabled
 
  No rules enabled:
   Every linter rule is turned off, so no offenses can be reported.
@@ -102,7 +102,7 @@ test-file-with-errors.html.erb:
   Failing      2 errors (2 offenses across 1 file)
   Not failing  1 warning (1 offense across 1 file, below --fail-level=error)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        131 enabled"
+  Rules        132 enabled"
 `;
 
 exports[`CLI Output Formatting > \`all\` pseudo rule in .herb.yml > \`Rules\` summary line > \`all: enabled: true\` reports no version-skipped rules 1`] = `
@@ -124,7 +124,7 @@ test-file-with-errors.html.erb:
   Failing      2 errors (2 offenses across 1 file)
   Not failing  1 warning (1 offense across 1 file, below --fail-level=error)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        131 enabled"
+  Rules        132 enabled"
 `;
 
 exports[`CLI Output Formatting > \`all\` pseudo rule in .herb.yml > \`Rules\` summary line > reports enabled and not-enabled rules when no \`all\` is configured 1`] = `
@@ -146,7 +146,7 @@ test/fixtures/test-file-with-errors.html.erb:
   Failing      2 errors (2 offenses across 1 file)
   Not failing  1 warning (1 offense across 1 file, below --fail-level=error)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        110 enabled | 21 not enabled"
+  Rules        111 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > \`all\` pseudo rule in .herb.yml > \`Rules\` summary line > rules opted back in on top of \`all: enabled: false\` count as enabled 1`] = `
@@ -165,7 +165,7 @@ test-file-with-errors.html.erb:
   Failing      0 offenses
   Not failing  1 warning (1 offense across 1 file, below --fail-level=error)
   Fixable      0 offenses
-  Rules        1 enabled | 130 not enabled"
+  Rules        1 enabled | 131 not enabled"
 `;
 
 exports[`CLI Output Formatting > \`all\` pseudo rule in .herb.yml > \`Rules\` summary line > rules opted out on top of \`all: enabled: true\` count as disabled 1`] = `
@@ -184,7 +184,7 @@ test-file-with-errors.html.erb:
   Checked      1 file
   Offenses     2 errors (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        130 enabled | 1 disabled"
+  Rules        131 enabled | 1 disabled"
 `;
 
 exports[`CLI Output Formatting > --all-rules > reports every offense for the fixture with --all-rules 1`] = `
@@ -214,7 +214,7 @@ test/fixtures/all-rules.html.erb:
   Failing      0 offenses
   Not failing  6 warnings (6 offenses across 1 file, below --fail-level=error)
   Fixable      0 offenses
-  Rules        131 enabled | all rules via --all-rules"
+  Rules        132 enabled | all rules via --all-rules"
 `;
 
 exports[`CLI Output Formatting > --all-rules > reports nothing for the fixture with the default rule set 1`] = `
@@ -226,7 +226,7 @@ exports[`CLI Output Formatting > --all-rules > reports nothing for the fixture w
   Checked      1 file
   Offenses     0 offenses
   Fixable      0 offenses
-  Rules        110 enabled | 21 not enabled"
+  Rules        111 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > --ignore-disable-comments 1`] = `
@@ -377,7 +377,7 @@ test/fixtures/ignored.html.erb:8:8
   Not failing  2 warnings (2 offenses across 1 file, below --fail-level=error)
   Note         3 additional offenses reported (would have been ignored)
   Fixable      7 offenses | 4 autocorrectable using \`--fix\`
-  Rules        110 enabled | 21 not enabled"
+  Rules        111 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > --log-level > counts the hidden offenses and suggests the level that reveals them 1`] = `
@@ -395,7 +395,7 @@ exports[`CLI Output Formatting > --log-level > counts the hidden offenses and su
   Not failing  2 info | 1 hint (3 offenses across 1 file, below --fail-level=error)
   Not shown    3 offenses hidden, show them with --log-level=hint
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        110 enabled | 21 not enabled"
+  Rules        111 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > --log-level > doesn't report offenses below the given level 1`] = `
@@ -412,7 +412,7 @@ exports[`CLI Output Formatting > --log-level > doesn't report offenses below the
   Not failing  1 hint (1 offense across 1 file, below --fail-level=error)
   Not shown    1 offense hidden, show it with --log-level=hint
   Fixable      0 offenses
-  Rules        109 enabled | 21 not enabled | 1 disabled"
+  Rules        110 enabled | 21 not enabled | 1 disabled"
 `;
 
 exports[`CLI Output Formatting > --log-level > prefers the CLI flag over the config file 1`] = `
@@ -431,7 +431,7 @@ test-file-with-errors.html.erb:
   Failing      0 offenses
   Not failing  1 hint (1 offense across 1 file, below --fail-level=error)
   Fixable      0 offenses
-  Rules        109 enabled | 21 not enabled | 1 disabled"
+  Rules        110 enabled | 21 not enabled | 1 disabled"
 `;
 
 exports[`CLI Output Formatting > --log-level > reads logLevel from the config file 1`] = `
@@ -448,7 +448,7 @@ exports[`CLI Output Formatting > --log-level > reads logLevel from the config fi
   Not failing  1 hint (1 offense across 1 file, below --fail-level=error)
   Not shown    1 offense hidden, show it with --log-level=hint
   Fixable      0 offenses
-  Rules        109 enabled | 21 not enabled | 1 disabled"
+  Rules        110 enabled | 21 not enabled | 1 disabled"
 `;
 
 exports[`CLI Output Formatting > --log-level > still counts hidden offenses towards the exit code 1`] = `
@@ -464,7 +464,7 @@ exports[`CLI Output Formatting > --log-level > still counts hidden offenses towa
   Offenses     1 hint (1 offense across 1 file)
   Not shown    1 offense hidden, show it with --log-level=hint
   Fixable      0 offenses
-  Rules        109 enabled | 21 not enabled | 1 disabled"
+  Rules        110 enabled | 21 not enabled | 1 disabled"
 `;
 
 exports[`CLI Output Formatting > --log-level > still reports offenses at or above the given level 1`] = `
@@ -483,7 +483,7 @@ test-file-with-errors.html.erb:
   Failing      0 offenses
   Not failing  1 hint (1 offense across 1 file, below --fail-level=error)
   Fixable      0 offenses
-  Rules        109 enabled | 21 not enabled | 1 disabled"
+  Rules        110 enabled | 21 not enabled | 1 disabled"
 `;
 
 exports[`CLI Output Formatting > --log-level > with --all-rules > keeps the log level when it is passed explicitly 1`] = `
@@ -505,7 +505,7 @@ test-file-with-errors.html.erb:
   Not failing  1 hint (1 offense across 1 file, below --fail-level=error)
   Not shown    1 offense hidden, show it with --log-level=hint
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        131 enabled | all rules via --all-rules"
+  Rules        132 enabled | all rules via --all-rules"
 `;
 
 exports[`CLI Output Formatting > --log-level > with --all-rules > lowers the log level to report the rules it was asked for 1`] = `
@@ -528,7 +528,7 @@ test-file-with-errors.html.erb:
   Not failing  1 hint (1 offense across 1 file, below --fail-level=error)
   Log level    hint | lowered from warning by --all-rules
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        131 enabled | all rules via --all-rules"
+  Rules        132 enabled | all rules via --all-rules"
 `;
 
 exports[`CLI Output Formatting > --log-level > with --only > keeps the log level when it is passed explicitly 1`] = `
@@ -689,7 +689,7 @@ test/fixtures/test-file-with-errors.html.erb:2:22
   Failing      2 errors (2 offenses across 1 file)
   Not failing  1 warning (1 offense across 1 file, below --fail-level=error)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        110 enabled | 21 not enabled"
+  Rules        111 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > GitHub Actions format includes rule codes 1`] = `
@@ -721,7 +721,7 @@ test/fixtures/no-trailing-newline.html.erb:1:29
   Checked      1 file
   Offenses     1 error (1 offense across 1 file)
   Fixable      1 offense | 1 autocorrectable using \`--fix\`
-  Rules        110 enabled | 21 not enabled"
+  Rules        111 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > GitHub Actions format includes rule codes 2`] = `
@@ -826,7 +826,7 @@ test/fixtures/erb-no-extra-whitespace-inside-tags.html.erb:1:4
   Failing      4 errors (4 offenses across 1 file)
   Not failing  1 info (1 offense across 1 file, below --fail-level=error)
   Fixable      5 offenses | 3 autocorrectable using \`--fix\`
-  Rules        110 enabled | 21 not enabled"
+  Rules        111 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > Ignores disabled rules 1`] = `
@@ -886,7 +886,7 @@ test/fixtures/ignored.html.erb:6:14
   Offenses     2 errors (2 offenses across 1 file)
   Ignored      3 offenses suppressed with herb:disable
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        110 enabled | 21 not enabled"
+  Rules        111 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > allows tag.attributes in attribute position 1`] = `
@@ -946,7 +946,7 @@ test/fixtures/tag-attributes.html.erb:5:0
   Failing      0 offenses
   Not failing  2 warnings (2 offenses across 1 file, below --fail-level=error)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        110 enabled | 21 not enabled"
+  Rules        111 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > diplays only parsers errors if one is present 1`] = `
@@ -972,7 +972,7 @@ test/fixtures/parser-errors.html.erb:2:16
   Checked      1 file
   Offenses     1 error (1 offense across 1 file)
   Fixable      0 offenses
-  Rules        110 enabled | 21 not enabled"
+  Rules        111 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > displays most violated rules with multiple offenses 1`] = `
@@ -1224,7 +1224,7 @@ test/fixtures/multiple-rule-offenses.html.erb:4:7
   Failing      8 errors (8 offenses across 1 file)
   Not failing  6 warnings (6 offenses across 1 file, below --fail-level=error)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        110 enabled | 21 not enabled"
+  Rules        111 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > displays rule offenses when showing all rules 1`] = `
@@ -1349,7 +1349,7 @@ test/fixtures/few-rule-offenses.html.erb:6:0
   Failing      4 errors (4 offenses across 1 file)
   Not failing  2 warnings (2 offenses across 1 file, below --fail-level=error)
   Fixable      6 offenses | 3 autocorrectable using \`--fix\`
-  Rules        110 enabled | 21 not enabled"
+  Rules        111 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats GitHub Actions output correctly for bad file 1`] = `
@@ -1404,7 +1404,7 @@ test/fixtures/bad-file.html.erb:1:16
   Checked      1 file
   Offenses     2 errors (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        110 enabled | 21 not enabled"
+  Rules        111 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats GitHub Actions output correctly for clean file 1`] = `
@@ -1416,7 +1416,7 @@ exports[`CLI Output Formatting > formats GitHub Actions output correctly for cle
   Checked      1 file
   Offenses     0 offenses
   Fixable      0 offenses
-  Rules        110 enabled | 21 not enabled"
+  Rules        111 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats GitHub Actions output correctly for file with errors 1`] = `
@@ -1495,7 +1495,7 @@ test/fixtures/test-file-with-errors.html.erb:2:22
   Failing      2 errors (2 offenses across 1 file)
   Not failing  1 warning (1 offense across 1 file, below --fail-level=error)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        110 enabled | 21 not enabled"
+  Rules        111 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats GitHub Actions output with --format=github option 1`] = `
@@ -1552,7 +1552,7 @@ test/fixtures/test-file-simple.html.erb:2:22
   Checked      1 file
   Offenses     2 errors (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        110 enabled | 21 not enabled"
+  Rules        111 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats JSON output correctly for bad file 1`] = `
@@ -1599,7 +1599,7 @@ exports[`CLI Output Formatting > formats JSON output correctly for bad file 1`] 
   "summary": {
     "filesChecked": 1,
     "filesWithOffenses": 1,
-    "ruleCount": 110,
+    "ruleCount": 111,
     "totalErrors": 2,
     "totalHints": 0,
     "totalIgnored": 0,
@@ -1621,7 +1621,7 @@ exports[`CLI Output Formatting > formats JSON output correctly for clean file 1`
   "summary": {
     "filesChecked": 1,
     "filesWithOffenses": 0,
-    "ruleCount": 110,
+    "ruleCount": 111,
     "totalErrors": 0,
     "totalHints": 0,
     "totalIgnored": 0,
@@ -1695,7 +1695,7 @@ exports[`CLI Output Formatting > formats JSON output correctly for file with err
   "summary": {
     "filesChecked": 1,
     "filesWithOffenses": 1,
-    "ruleCount": 110,
+    "ruleCount": 111,
     "totalErrors": 2,
     "totalHints": 0,
     "totalIgnored": 0,
@@ -1778,7 +1778,7 @@ test/fixtures/test-file-with-errors.html.erb:2:22
   Failing      2 errors (2 offenses across 1 file)
   Not failing  1 warning (1 offense across 1 file, below --fail-level=error)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        110 enabled | 21 not enabled"
+  Rules        111 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats simple output correctly 1`] = `
@@ -1797,7 +1797,7 @@ test/fixtures/test-file-simple.html.erb:
   Checked      1 file
   Offenses     2 errors (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        110 enabled | 21 not enabled"
+  Rules        111 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats simple output for bad-file correctly 1`] = `
@@ -1816,7 +1816,7 @@ test/fixtures/bad-file.html.erb:
   Checked      1 file
   Offenses     2 errors (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        110 enabled | 21 not enabled"
+  Rules        111 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats success output correctly 1`] = `
@@ -1828,7 +1828,7 @@ exports[`CLI Output Formatting > formats success output correctly 1`] = `
   Checked      1 file
   Offenses     0 offenses
   Fixable      0 offenses
-  Rules        110 enabled | 21 not enabled"
+  Rules        111 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > handles boolean attributes 1`] = `
@@ -1840,7 +1840,7 @@ exports[`CLI Output Formatting > handles boolean attributes 1`] = `
   Checked      1 file
   Offenses     0 offenses
   Fixable      0 offenses
-  Rules        110 enabled | 21 not enabled"
+  Rules        111 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > handles multiple errors correctly 1`] = `
@@ -1891,7 +1891,7 @@ test/fixtures/bad-file.html.erb:1:16
   Checked      1 file
   Offenses     2 errors (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        110 enabled | 21 not enabled"
+  Rules        111 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > herb:disable rules 1`] = `
@@ -2034,7 +2034,7 @@ test/fixtures/disabled-1.html.erb:14:19
   Not failing  6 warnings (6 offenses across 1 file, below --fail-level=error)
   Ignored      8 offenses suppressed with herb:disable
   Fixable      8 offenses | 1 autocorrectable using \`--fix\`
-  Rules        110 enabled | 21 not enabled"
+  Rules        111 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > herb:disable rules 2`] = `
@@ -2293,7 +2293,7 @@ test/fixtures/disabled-2.html.erb:2:44
   Not failing  7 warnings (7 offenses across 1 file, below --fail-level=error)
   Ignored      5 offenses suppressed with herb:disable
   Fixable      13 offenses | 6 autocorrectable using \`--fix\`
-  Rules        110 enabled | 21 not enabled"
+  Rules        111 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > missing \`framework\` option > reports the missing option per template 1`] = `
@@ -2312,7 +2312,7 @@ clean-file.html.erb:
   Failing      0 offenses
   Not failing  1 info (1 offense across 1 file, below --fail-level=error)
   Fixable      0 offenses
-  Rules        1 enabled | 130 not enabled"
+  Rules        1 enabled | 131 not enabled"
 `;
 
 exports[`CLI Output Formatting > non-failing offenses tip > points at --log-level when many offenses don't fail the build 1`] = `
@@ -2350,7 +2350,7 @@ multiple-rule-offenses.html.erb:
   Failing      3 errors (3 offenses across 1 file)
   Not failing  1 info | 10 hints (11 offenses across 1 file, below --fail-level=error)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        110 enabled | 21 not enabled
+  Rules        111 enabled | 21 not enabled
 
  TIP: 11 of the logged offenses don't fail the build.
       Run herb-lint --log-level=error to stop logging them, or set linter.logLevel in your .herb.yml.
@@ -2382,7 +2382,7 @@ multiple-rule-offenses.html.erb:
   Not failing  1 info | 10 hints (11 offenses across 1 file, below --fail-level=error)
   Not shown    11 offenses hidden, show them with --log-level=hint
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        110 enabled | 21 not enabled"
+  Rules        111 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > non-failing offenses tip > stays quiet when --log-level is passed explicitly, even when it hides nothing 1`] = `
@@ -2420,7 +2420,7 @@ multiple-rule-offenses.html.erb:
   Failing      3 errors (3 offenses across 1 file)
   Not failing  1 info | 10 hints (11 offenses across 1 file, below --fail-level=error)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        110 enabled | 21 not enabled"
+  Rules        111 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > non-failing offenses tip > stays quiet when logLevel is set in the config file 1`] = `
@@ -2458,7 +2458,7 @@ multiple-rule-offenses.html.erb:
   Failing      3 errors (3 offenses across 1 file)
   Not failing  1 info | 10 hints (11 offenses across 1 file, below --fail-level=error)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        110 enabled | 21 not enabled"
+  Rules        111 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > non-failing offenses tip > stays quiet when only a handful of offenses don't fail the build 1`] = `
@@ -2496,7 +2496,7 @@ multiple-rule-offenses.html.erb:
   Failing      8 errors (8 offenses across 1 file)
   Not failing  6 warnings (6 offenses across 1 file, below --fail-level=error)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        110 enabled | 21 not enabled"
+  Rules        111 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > points at the flag instead of previewing once there are too many corrections 1`] = `
@@ -2592,7 +2592,7 @@ test/fixtures/test-file-simple.html.erb:2:22
   Checked      1 file
   Offenses     2 errors (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        110 enabled | 21 not enabled"
+  Rules        111 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > previews the correction under each correctable offense 1`] = `
@@ -2649,7 +2649,7 @@ test/fixtures/test-file-simple.html.erb:2:22
   Checked      1 file
   Offenses     2 errors (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        110 enabled | 21 not enabled"
+  Rules        111 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > summary offense buckets > groups every severity into one line when --fail-level is hint 1`] = `
@@ -2686,7 +2686,7 @@ test/fixtures/multiple-rule-offenses.html.erb:
   Checked      1 file
   Offenses     8 errors | 6 warnings (14 offenses across 1 file)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        110 enabled | 21 not enabled"
+  Rules        111 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > summary offense buckets > groups every severity into one line when --fail-level is info 1`] = `
@@ -2723,7 +2723,7 @@ test/fixtures/multiple-rule-offenses.html.erb:
   Checked      1 file
   Offenses     8 errors | 6 warnings (14 offenses across 1 file)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        110 enabled | 21 not enabled"
+  Rules        111 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > summary offense buckets > groups every severity into one line when --fail-level is warning 1`] = `
@@ -2760,7 +2760,7 @@ test/fixtures/multiple-rule-offenses.html.erb:
   Checked      1 file
   Offenses     8 errors | 6 warnings (14 offenses across 1 file)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        110 enabled | 21 not enabled"
+  Rules        111 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > summary offense buckets > moves a severity between buckets as --fail-level is lowered 1`] = `
@@ -2798,7 +2798,7 @@ multiple-rule-offenses.html.erb:
   Failing      8 errors | 4 warnings | 1 info (13 offenses across 1 file)
   Not failing  1 hint (1 offense across 1 file, below --fail-level=info)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        110 enabled | 21 not enabled"
+  Rules        111 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > summary offense buckets > splits the buckets when only some severities fail the build 1`] = `
@@ -2836,7 +2836,7 @@ multiple-rule-offenses.html.erb:
   Failing      8 errors | 4 warnings (12 offenses across 1 file)
   Not failing  1 info | 1 hint (2 offenses across 1 file, below --fail-level=warning)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        110 enabled | 21 not enabled"
+  Rules        111 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > unsafe autocorrectable offenses > counts and tags them separately from offenses --fix can correct 1`] = `
@@ -2956,5 +2956,5 @@ test/fixtures/test-file-with-errors.html.erb:2:22
   Failing      2 errors (2 offenses across 1 file)
   Not failing  1 warning (1 offense across 1 file, below --fail-level=error)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        110 enabled | 21 not enabled"
+  Rules        111 enabled | 21 not enabled"
 `;

--- a/javascript/packages/linter/test/rules/actionview-no-content-argument-with-block.test.ts
+++ b/javascript/packages/linter/test/rules/actionview-no-content-argument-with-block.test.ts
@@ -1,0 +1,529 @@
+import dedent from "dedent"
+import { describe, test } from "vitest"
+import { ActionViewNoContentArgumentWithBlockRule } from "../../src/rules/actionview-no-content-argument-with-block.js"
+import { createLinterTest } from "../helpers/linter-test-helper.js"
+
+const { expectNoOffenses, expectError, assertOffenses } = createLinterTest(ActionViewNoContentArgumentWithBlockRule)
+
+describe("actionview-no-content-argument-with-block", () => {
+  test("passes for `tag` with only a content argument", () => {
+    expectNoOffenses(`<%= tag.div "Hello" %>`)
+  })
+
+  test("passes for `tag` with only a block", () => {
+    expectNoOffenses(dedent`
+      <%= tag.div do %>
+        Hello
+      <% end %>
+    `)
+  })
+
+  test("passes for `tag` with keyword options and a block", () => {
+    expectNoOffenses(dedent`
+      <%= tag.div class: "card" do %>
+        Hello
+      <% end %>
+    `)
+  })
+
+  test("passes for `content_tag` with only a content argument", () => {
+    expectNoOffenses(`<%= content_tag :div, "Hello" %>`)
+  })
+
+  test("passes for `content_tag` with only a block", () => {
+    expectNoOffenses(dedent`
+      <%= content_tag :div do %>
+        Hello
+      <% end %>
+    `)
+  })
+
+  test("passes for `content_tag` with keyword options and a block", () => {
+    expectNoOffenses(dedent`
+      <%= content_tag :div, class: "card" do %>
+        Hello
+      <% end %>
+    `)
+  })
+
+  test("passes for `content_tag` with a literal options hash and a block", () => {
+    expectNoOffenses(dedent`
+      <%= content_tag(:div, { class: "card" }) do %>
+        Hello
+      <% end %>
+    `)
+  })
+
+  test("passes for `content_tag` with an options variable and a block", () => {
+    expectNoOffenses(dedent`
+      <%= content_tag :div, wrapper_options do %>
+        Hello
+      <% end %>
+    `)
+  })
+
+  test("passes for `link_to` with content and URL but no block", () => {
+    expectNoOffenses(`<%= link_to "Dashboard", root_path %>`)
+  })
+
+  test("passes for `link_to` with a URL and a block", () => {
+    expectNoOffenses(dedent`
+      <%= link_to root_path do %>
+        Dashboard
+      <% end %>
+    `)
+  })
+
+  test("passes for `link_to` with a URL, keyword options and a block", () => {
+    expectNoOffenses(dedent`
+      <%= link_to root_path, class: "nav-link" do %>
+        Dashboard
+      <% end %>
+    `)
+  })
+
+  test("passes for `button_to` with a URL and a block", () => {
+    expectNoOffenses(dedent`
+      <%= button_to root_path do %>
+        Delete
+      <% end %>
+    `)
+  })
+
+  test("passes for `mail_to` with only an address and a block", () => {
+    expectNoOffenses(dedent`
+      <%= mail_to "support@example.com" do %>
+        Contact us
+      <% end %>
+    `)
+  })
+
+  test("passes for `button_tag` with only a block", () => {
+    expectNoOffenses(dedent`
+      <%= button_tag do %>
+        Save
+      <% end %>
+    `)
+  })
+
+  test("passes for `button_tag` with keyword options and a block", () => {
+    expectNoOffenses(dedent`
+      <%= button_tag class: "primary" do %>
+        Save
+      <% end %>
+    `)
+  })
+
+  test("passes for `label_tag` with only a name and a block", () => {
+    expectNoOffenses(dedent`
+      <%= label_tag :email do %>
+        Email address
+      <% end %>
+    `)
+  })
+
+  test("passes for `field_set_tag`, whose first argument renders as a legend", () => {
+    expectNoOffenses(dedent`
+      <%= field_set_tag "Account" do %>
+        Body
+      <% end %>
+    `)
+  })
+
+  test("passes for `link_to_if`, whose block only renders when the condition fails", () => {
+    expectNoOffenses(dedent`
+      <%= link_to_if signed_in?, "Profile", profile_path do %>
+        Sign in
+      <% end %>
+    `)
+  })
+
+  test("passes for `truncate`, whose block is appended to the text", () => {
+    expectNoOffenses(dedent`
+      <%= truncate article.body, length: 100 do %>
+        <%= link_to "Read more", article_path(article) %>
+      <% end %>
+    `)
+  })
+
+  test("passes for a form builder `label` with a receiver", () => {
+    expectNoOffenses(dedent`
+      <%= form.label :email, "Email" do %>
+        Email address
+      <% end %>
+    `)
+  })
+
+  test("passes for a block argument instead of a literal block", () => {
+    expectNoOffenses(`<%= content_tag :div, "Hello", &wrapper %>`)
+  })
+
+  test("passes for the call inside an ERB comment", () => {
+    expectNoOffenses(dedent`
+      <%# content_tag :div, "Hello" do %>
+    `)
+  })
+
+  test("passes for the call inside a string", () => {
+    expectNoOffenses(`<%= tag.code 'content_tag :div, "Hello" do' %>`)
+  })
+
+  test("passes for `tag.send`, whose first argument names the tag", () => {
+    expectNoOffenses(dedent`
+      <%= tag.send(:div, class: "card") do %>
+        Hello
+      <% end %>
+    `)
+  })
+
+  test("passes for `tag.public_send`, whose first argument names the tag", () => {
+    expectNoOffenses(dedent`
+      <%= tag.public_send(element, **arguments) do %>
+        Hello
+      <% end %>
+    `)
+  })
+
+  test("fails for `tag` with a content argument and a block", () => {
+    expectError('The `tag.div` helper renders either its content argument or its block, never both, and the block wins, so `"Hello"` is silently discarded and never reaches the page. Remove `"Hello"`, or remove the block and let the argument render the content.', [1, 12])
+
+    assertOffenses(dedent`
+      <%= tag.div "Hello" do %>
+        World
+      <% end %>
+    `)
+  })
+
+  test("fails for `tag` with a content argument, keyword options and a block", () => {
+    expectError('The `tag.div` helper renders either its content argument or its block, never both, and the block wins, so `"Hello"` is silently discarded and never reaches the page. Remove `"Hello"`, or remove the block and let the argument render the content.')
+
+    assertOffenses(dedent`
+      <%= tag.div "Hello", class: "card" do %>
+        World
+      <% end %>
+    `)
+  })
+
+  test("fails for `content_tag` with a content argument and a block", () => {
+    expectError('The `content_tag` helper renders either its content argument or its block, never both, and the block wins, so `"Intro"` is silently discarded and never reaches the page. Remove `"Intro"`, or remove the block and let the argument render the content.')
+
+    assertOffenses(dedent`
+      <%= content_tag :section, "Intro" do %>
+        Welcome
+      <% end %>
+    `)
+  })
+
+  test("fails for `content_tag` with a content argument, keyword options and a block", () => {
+    expectError('The `content_tag` helper renders either its content argument or its block, never both, and the block wins, so `"Hello"` is silently discarded and never reaches the page. Remove `"Hello"`, or remove the block and let the argument render the content.')
+
+    assertOffenses(dedent`
+      <%= content_tag :div, "Hello", class: "card" do %>
+        World
+      <% end %>
+    `)
+  })
+
+  test("fails for a symbol content argument", () => {
+    expectError('The `content_tag` helper renders either its content argument or its block, never both, and the block wins, so `:intro` is silently discarded and never reaches the page. Remove `:intro`, or remove the block and let the argument render the content.')
+
+    assertOffenses(dedent`
+      <%= content_tag :div, :intro do %>
+        World
+      <% end %>
+    `)
+  })
+
+  test("fails for an interpolated content argument", () => {
+    expectError('The `content_tag` helper renders either its content argument or its block, never both, and the block wins, so `"Hi #{user.name}"` is silently discarded and never reaches the page. Remove `"Hi #{user.name}"`, or remove the block and let the argument render the content.')
+
+    assertOffenses(dedent`
+      <%= content_tag :div, "Hi #{user.name}" do %>
+        World
+      <% end %>
+    `)
+  })
+
+  test("fails for `link_to` with content, URL and a block", () => {
+    expectError('The `link_to` helper shifts its arguments when it is given a block, so `"Go"` is read as `options` and `root_path` as `html_options` instead of as content. Rails expects a Hash in `html_options` and raises when it is not one. Remove `"Go"` and let the block render the content.', [1, 12])
+
+    assertOffenses(dedent`
+      <%= link_to "Go", root_path do %>
+        Go now
+      <% end %>
+    `)
+  })
+
+  test("fails for `button_to` with content, URL and a block", () => {
+    expectError('The `button_to` helper shifts its arguments when it is given a block, so `"Delete"` is read as `options` and `article_path(article)` as `html_options` instead of as content. Rails expects a Hash in `html_options` and raises when it is not one. Remove `"Delete"` and let the block render the content.')
+
+    assertOffenses(dedent`
+      <%= button_to "Delete", article_path(article) do %>
+        Delete now
+      <% end %>
+    `)
+  })
+
+  test("fails for `mail_to` with a name argument and a block", () => {
+    expectError('The `mail_to` helper renders either its content argument or its block, never both, and the block wins, so `"Support"` is silently discarded and never reaches the page. Remove `"Support"`, or remove the block and let the argument render the content.')
+
+    assertOffenses(dedent`
+      <%= mail_to "support@example.com", "Support" do %>
+        Contact us
+      <% end %>
+    `)
+  })
+
+  test("fails for `phone_to` with a name argument and a block", () => {
+    expectError('The `phone_to` helper renders either its content argument or its block, never both, and the block wins, so `"Call"` is silently discarded and never reaches the page. Remove `"Call"`, or remove the block and let the argument render the content.')
+
+    assertOffenses(dedent`
+      <%= phone_to "+41000000000", "Call" do %>
+        Call us
+      <% end %>
+    `)
+  })
+
+  test("fails for `sms_to` with a name argument and a block", () => {
+    expectError('The `sms_to` helper renders either its content argument or its block, never both, and the block wins, so `"Text"` is silently discarded and never reaches the page. Remove `"Text"`, or remove the block and let the argument render the content.')
+
+    assertOffenses(dedent`
+      <%= sms_to "+41000000000", "Text" do %>
+        Text us
+      <% end %>
+    `)
+  })
+
+  test("fails for `button_tag` with a content argument and a block", () => {
+    expectError('The `button_tag` helper renders either its content argument or its block, never both, and the block wins, so `"Save"` is silently discarded and never reaches the page. Remove `"Save"`, or remove the block and let the argument render the content.')
+
+    assertOffenses(dedent`
+      <%= button_tag "Save" do %>
+        Submit
+      <% end %>
+    `)
+  })
+
+  test("fails for `label_tag` with a content argument and a block", () => {
+    expectError('The `label_tag` helper renders either its content argument or its block, never both, and the block wins, so `"Email"` is silently discarded and never reaches the page. Remove `"Email"`, or remove the block and let the argument render the content.')
+
+    assertOffenses(dedent`
+      <%= label_tag :email, "Email" do %>
+        Email address
+      <% end %>
+    `)
+  })
+
+  test("fails for an inline brace block", () => {
+    expectError('The `content_tag` helper renders either its content argument or its block, never both, and the block wins, so `"Hello"` is silently discarded and never reaches the page. Remove `"Hello"`, or remove the block and let the argument render the content.')
+
+    assertOffenses(`<%= content_tag(:div, "Hello") { "World" } %>`)
+  })
+
+  test("fails inside a silent ERB tag", () => {
+    expectError('The `content_tag` helper renders either its content argument or its block, never both, and the block wins, so `"Hello"` is silently discarded and never reaches the page. Remove `"Hello"`, or remove the block and let the argument render the content.')
+
+    assertOffenses(dedent`
+      <% content_tag :div, "Hello" do %>
+        World
+      <% end %>
+    `)
+  })
+
+  test("fails inside an HTML attribute value", () => {
+    expectError('The `content_tag` helper renders either its content argument or its block, never both, and the block wins, so `"Hello"` is silently discarded and never reaches the page. Remove `"Hello"`, or remove the block and let the argument render the content.')
+
+    assertOffenses(`<div title="<%= content_tag(:span, "Hello") { "World" } %>"></div>`)
+  })
+
+  test("reports every offending helper in one template", () => {
+    expectError('The `tag.span` helper renders either its content argument or its block, never both, and the block wins, so `"One"` is silently discarded and never reaches the page. Remove `"One"`, or remove the block and let the argument render the content.', [2])
+    expectError('The `content_tag` helper renders either its content argument or its block, never both, and the block wins, so `"Two"` is silently discarded and never reaches the page. Remove `"Two"`, or remove the block and let the argument render the content.', [6])
+    expectError('The `link_to` helper shifts its arguments when it is given a block, so `"Three"` is read as `options` and `root_path` as `html_options` instead of as content. Rails expects a Hash in `html_options` and raises when it is not one. Remove `"Three"` and let the block render the content.', [10])
+
+    assertOffenses(dedent`
+      <div>
+        <%= tag.span "One" do %>
+          <%= one %>
+        <% end %>
+
+        <%= content_tag :p, "Two" do %>
+          <%= two %>
+        <% end %>
+
+        <%= link_to "Three", root_path do %>
+          <%= three %>
+        <% end %>
+      </div>
+    `)
+  })
+
+  test("reports a nested offending helper", () => {
+    expectError('The `tag.span` helper renders either its content argument or its block, never both, and the block wins, so `"Inner"` is silently discarded and never reaches the page. Remove `"Inner"`, or remove the block and let the argument render the content.')
+
+    assertOffenses(`<%= content_tag(:div, tag.span("Inner") { "Nested" }) %>`)
+  })
+
+  describe("real templates from herb-corpus", () => {
+    test("passes for an options hash reaching `content_tag` as a method call", () => {
+      expectNoOffenses(dedent`
+        <%= content_tag(:div, container_attributes) do %>
+          <%= content %>
+        <% end %>
+      `)
+    })
+
+    test("passes for an options hash reaching `content_tag` as an instance variable", () => {
+      expectNoOffenses(dedent`
+        <%= content_tag(list_tag, @system_arguments) do %>
+          <%= content %>
+        <% end %>
+      `)
+    })
+
+    test("passes for an options hash reaching `button_tag` as a local variable", () => {
+      expectNoOffenses(dedent`
+        <%= button_tag opts do %>
+          Save
+        <% end %>
+      `)
+    })
+
+    test("passes for `link_to` given a URL and an options hash as instance variables", () => {
+      expectNoOffenses(dedent`
+        <%= link_to @url, @params do %>
+          <%= content %>
+        <% end %>
+      `)
+    })
+
+    test("passes for `label_tag` given a name and options as instance variables", () => {
+      expectNoOffenses(dedent`
+        <%= label_tag(@name, @label_options) do %>
+          <%= content %>
+        <% end %>
+      `)
+    })
+
+    test("passes for `label_tag` given explicit `nil` arguments", () => {
+      expectNoOffenses(dedent`
+        <%= label_tag(nil, nil, class: radio_label) do %>
+          <%= content %>
+        <% end %>
+      `)
+    })
+
+    test("passes for an options hash built by a trailing conditional", () => {
+      expectNoOffenses(dedent`
+        <%= content_tag "tr", ({ data: { href: donor_path(donor_id) } } if donor_id) do %>
+          <%= content %>
+        <% end %>
+      `)
+    })
+
+    test("passes for `tag.send` and `tag.public_send` with a dynamic tag name", () => {
+      expectNoOffenses(dedent`
+        <%= tag.send(tag_name, **tag_params) do %>
+          <%= content %>
+        <% end %>
+      `)
+    })
+
+    test("fizzy: button label argument next to a block that renders an icon and its own label", () => {
+      expectError('The `button_tag` helper renders either its content argument or its block, never both, and the block wins, so `"Create a new tag"` is silently discarded and never reaches the page. Remove `"Create a new tag"`, or remove the block and let the argument render the content.')
+
+      assertOffenses(dedent`
+        <li class="popup__item" data-navigable-list-target="item">
+          <%= button_tag "Create a new tag", type: "submit", form: dom_id(@card, :tags_form), class: "btn popup__btn", data: { form_target: "submit" } do %>
+            <%= icon_tag "add" %>
+            <span>Create tag</span>
+          <% end %>
+        </li>
+      `)
+    })
+
+    test("workshop.codes: `tag.span` called with a leading symbol as if it were `label_tag`", () => {
+      expectError('The `tag.span` helper renders either its content argument or its block, never both, and the block wins, so `:categories` is silently discarded and never reaches the page. Remove `:categories`, or remove the block and let the argument render the content.')
+
+      assertOffenses(dedent`
+        <div class="form-group">
+          <%= tag.span :categories, class: "form-label" do %>
+            Categories
+            <span class="form-required">(Required)</span>
+          <% end %>
+        </div>
+      `)
+    })
+
+    test("SearchWorks: label text duplicated between the argument and the block", () => {
+      expectError("The `label_tag` helper renders either its content argument or its block, never both, and the block wins, so `'Show collections only'` is silently discarded and never reaches the page. Remove `'Show collections only'`, or remove the block and let the argument render the content.")
+
+      assertOffenses(dedent`
+        <%= label_tag('digital_collection_all', 'Show collections only', class: 'position-relative') do %>
+          <%= link_to(digital_collections_only_path, class: 'ms-1') do %>
+            <%= 'Show collections only' %>
+          <% end %>
+        <% end %>
+      `)
+    })
+
+    test("timeoverflow: label argument dropped in favour of a block", () => {
+      expectError('The `label_tag` helper renders either its content argument or its block, never both, and the block wins, so `"avatar"` is silently discarded and never reaches the page. Remove `"avatar"`, or remove the block and let the argument render the content.')
+
+      assertOffenses(dedent`
+        <%= label_tag "avatar-js", "avatar", class: "form-label" do %>
+          <a class="btn btn-link">
+            <%= t ".change_your_image" %>
+          </a>
+        <% end %>
+      `)
+    })
+
+    test("open-source-billing: an option passed positionally instead of as a keyword", () => {
+      expectError('The `button_tag` helper renders either its content argument or its block, never both, and the block wins, so `:submit` is silently discarded and never reaches the page. Remove `:submit`, or remove the block and let the argument render the content.')
+
+      assertOffenses(dedent`
+        <%= button_tag :submit, name: 'save_as_draft', value: true, title: t('views.common.save'), class: 'invoice_submit_button' do %>
+          <i class="material-icons">done</i>
+        <% end %>
+      `)
+    })
+
+    test("helpy: empty content argument alongside an interpolated class", () => {
+      expectError("The `content_tag` helper renders either its content argument or its block, never both, and the block wins, so `''` is silently discarded and never reaches the page. Remove `''`, or remove the block and let the argument render the content.")
+
+      assertOffenses(dedent`
+        <%= content_tag(:li, '' , class: "click-loader new-discussion #{new_active_class}") do %>
+          <%= navbar_expanding_link(new_admin_topic_path, "fas fa-plus") %>
+        <% end %>
+      `)
+    })
+
+    test("pageflow: empty content argument on a call using a trim marker", () => {
+      expectError("The `content_tag` helper renders either its content argument or its block, never both, and the block wins, so `''` is silently discarded and never reaches the page. Remove `''`, or remove the block and let the argument render the content.")
+
+      assertOffenses(dedent`
+        <%= content_tag(:div, '', data: {widget: name}) do -%>
+          <% if server_rendering -%>
+            <% concat render_widget_react_component(entry, name) %>
+          <% end %>
+        <% end %>
+      `)
+    })
+
+    test("hyrax: empty content argument on a call whose options span several lines", () => {
+      expectError("The `button_tag` helper renders either its content argument or its block, never both, and the block wins, so `''` is silently discarded and never reaches the page. Remove `''`, or remove the block and let the argument render the content.", [1, 15])
+
+      assertOffenses(dedent`
+        <%= button_tag '',
+                      class: 'btn btn-primary add-to-collection',
+                      title: t("hyrax.collection.actions.nested_subcollection.desc"),
+                      type: 'button',
+                      data: { nestable: presenter.collection_type_is_nestable?,
+                              hasaccess: true } do %>
+          <%= t('hyrax.collection.actions.nested_subcollection.button_label') %>
+        <% end %>
+      `)
+    })
+  })
+})

--- a/sig/herb/action_view/helper_registry.rbs
+++ b/sig/herb/action_view/helper_registry.rbs
@@ -573,6 +573,33 @@ module Herb
       def initialize: (String, String, String?, String, Array[String]) -> void
     end
 
+    class HelperContent
+      attr_reader source: Symbol
+
+      attr_reader arg_position: Integer?
+
+      attr_reader skip_if_hash: bool
+
+      attr_reader to_s_suffix_when_single: bool
+
+      attr_reader positional_arguments_with_block: Integer?
+
+      # : (Symbol, Integer?, bool, bool, Integer?) -> void
+      def initialize: (Symbol, Integer?, bool, bool, Integer?) -> void
+
+      # : () -> bool
+      def first_arg?: () -> bool
+
+      # : () -> bool
+      def block_or_arg?: () -> bool
+
+      # : () -> bool
+      def skip_if_hash?: () -> bool
+
+      # : () -> bool
+      def to_s_suffix_when_single?: () -> bool
+    end
+
     class HelperEntry
       attr_reader name: String
 
@@ -598,6 +625,8 @@ module Herb
 
       attr_reader implicit_attribute: HelperImplicitAttribute?
 
+      attr_reader content: HelperContent?
+
       attr_reader arguments: Array[HelperArgument]
 
       attr_reader options: Array[HelperOption]
@@ -608,8 +637,8 @@ module Herb
 
       attr_reader aliases: Array[String]
 
-      # : (name: String, type: Symbol, source: String, gem: String, output: Symbol, visibility: String, tag_name: String?, is_void: bool, supports_block: bool, preferred_for_tag: bool, supported: bool, detect_style: Symbol, description: String, signature: String, documentation_url: String, implicit_attribute: HelperImplicitAttribute?, arguments: Array[HelperArgument], options: Array[HelperOption], block_arguments: Array[HelperBlockArgument], special_behaviors: Array[Symbol], aliases: Array[String]) -> void
-      def initialize: (name: String, type: Symbol, source: String, gem: String, output: Symbol, visibility: String, tag_name: String?, is_void: bool, supports_block: bool, preferred_for_tag: bool, supported: bool, detect_style: Symbol, description: String, signature: String, documentation_url: String, implicit_attribute: HelperImplicitAttribute?, arguments: Array[HelperArgument], options: Array[HelperOption], block_arguments: Array[HelperBlockArgument], special_behaviors: Array[Symbol], aliases: Array[String]) -> void
+      # : (name: String, type: Symbol, source: String, gem: String, output: Symbol, visibility: String, tag_name: String?, is_void: bool, supports_block: bool, preferred_for_tag: bool, supported: bool, detect_style: Symbol, description: String, signature: String, documentation_url: String, implicit_attribute: HelperImplicitAttribute?, content: HelperContent?, arguments: Array[HelperArgument], options: Array[HelperOption], block_arguments: Array[HelperBlockArgument], special_behaviors: Array[Symbol], aliases: Array[String]) -> void
+      def initialize: (name: String, type: Symbol, source: String, gem: String, output: Symbol, visibility: String, tag_name: String?, is_void: bool, supports_block: bool, preferred_for_tag: bool, supported: bool, detect_style: Symbol, description: String, signature: String, documentation_url: String, implicit_attribute: HelperImplicitAttribute?, content: HelperContent?, arguments: Array[HelperArgument], options: Array[HelperOption], block_arguments: Array[HelperBlockArgument], special_behaviors: Array[Symbol], aliases: Array[String]) -> void
 
       # : () -> bool
       def void?: () -> bool
@@ -628,6 +657,9 @@ module Herb
 
       # : () -> bool
       def implicit_attribute?: () -> bool
+
+      # : () -> bool
+      def content?: () -> bool
 
       # : () -> bool
       def call_name_detect?: () -> bool

--- a/templates/java/org/herb/ast/HelperRegistry.java.erb
+++ b/templates/java/org/herb/ast/HelperRegistry.java.erb
@@ -131,6 +131,31 @@ class HelperImplicitAttribute {
 }
 
 /**
+ * Content metadata describing where a helper takes its rendered content from.
+ */
+class HelperContent {
+  private final String source;
+  private final Integer argPosition;
+  private final boolean skipIfHash;
+  private final boolean toSSuffixWhenSingle;
+  private final Integer positionalArgumentsWithBlock;
+
+  HelperContent(String source, Integer argPosition, boolean skipIfHash, boolean toSSuffixWhenSingle, Integer positionalArgumentsWithBlock) {
+    this.source = source;
+    this.argPosition = argPosition;
+    this.skipIfHash = skipIfHash;
+    this.toSSuffixWhenSingle = toSSuffixWhenSingle;
+    this.positionalArgumentsWithBlock = positionalArgumentsWithBlock;
+  }
+
+  public String getSource() { return source; }
+  public Integer getArgPosition() { return argPosition; }
+  public boolean skipIfHash() { return skipIfHash; }
+  public boolean toSSuffixWhenSingle() { return toSSuffixWhenSingle; }
+  public Integer getPositionalArgumentsWithBlock() { return positionalArgumentsWithBlock; }
+}
+
+/**
  * Registry entry containing all metadata for a single tag helper.
  */
 class HelperEntry {
@@ -150,6 +175,7 @@ class HelperEntry {
   private final String signature;
   private final String documentationUrl;
   private final HelperImplicitAttribute implicitAttribute;
+  private final HelperContent content;
   private final List<HelperArgument> arguments;
   private final List<HelperOption> options;
   private final List<HelperBlockArgument> blockArguments;
@@ -159,7 +185,7 @@ class HelperEntry {
   HelperEntry(
     String name, HelperType type, String source, String gem, String output, String visibility, String tagName,
     boolean isVoid, boolean supportsBlock, boolean preferredForTag, boolean supported, String detectStyle, String description,
-    String signature, String documentationUrl, HelperImplicitAttribute implicitAttribute,
+    String signature, String documentationUrl, HelperImplicitAttribute implicitAttribute, HelperContent content,
     List<HelperArgument> arguments, List<HelperOption> options, List<HelperBlockArgument> blockArguments,
     List<String> specialBehaviors, List<String> aliases
   ) {
@@ -179,6 +205,7 @@ class HelperEntry {
     this.signature = signature;
     this.documentationUrl = documentationUrl;
     this.implicitAttribute = implicitAttribute;
+    this.content = content;
     this.arguments = arguments;
     this.options = options;
     this.blockArguments = blockArguments;
@@ -202,6 +229,7 @@ class HelperEntry {
   public String getSignature() { return signature; }
   public String getDocumentationUrl() { return documentationUrl; }
   public HelperImplicitAttribute getImplicitAttribute() { return implicitAttribute; }
+  public HelperContent getContent() { return content; }
   public List<HelperArgument> getArguments() { return arguments; }
   public List<HelperOption> getOptions() { return options; }
   public List<HelperBlockArgument> getBlockArguments() { return blockArguments; }
@@ -247,6 +275,11 @@ public final class HelperRegistry {
         "<%= helper.documentation_url %>",
 <%- if helper.implicit_attribute? -%>
         new HelperImplicitAttribute("<%= helper.implicit_attribute.name %>", "<%= helper.implicit_attribute.source %>", <%= helper.implicit_attribute.source_with_block ? "\"#{helper.implicit_attribute.source_with_block}\"" : "null" %>, "<%= helper.implicit_attribute.wrapper %>"),
+<%- else -%>
+        null,
+<%- end -%>
+<%- if helper.content? -%>
+        new HelperContent("<%= helper.content.source %>", <%= helper.content.arg_position || "null" %>, <%= helper.content.skip_if_hash %>, <%= helper.content.to_s_suffix_when_single %>, <%= helper.content.positional_arguments_with_block || "null" %>),
 <%- else -%>
         null,
 <%- end -%>

--- a/templates/javascript/packages/core/src/action-view-helpers.ts.erb
+++ b/templates/javascript/packages/core/src/action-view-helpers.ts.erb
@@ -40,6 +40,16 @@ export interface HelperImplicitAttribute {
   readonly skipWrappingFor: string[]
 }
 
+export type HelperContentSource = "first_arg" | "block_or_arg"
+
+export interface HelperContent {
+  readonly source: HelperContentSource
+  readonly argPosition: number | null
+  readonly skipIfHash: boolean
+  readonly toSSuffixWhenSingle: boolean
+  readonly positionalArgumentsWithBlock: number | null
+}
+
 export interface HelperEntry {
   readonly name: string
   readonly type: HelperType
@@ -57,6 +67,7 @@ export interface HelperEntry {
   readonly signature: string
   readonly documentationURL: string
   readonly implicitAttribute: HelperImplicitAttribute | null
+  readonly content: HelperContent | null
   readonly arguments: HelperArgument[]
   readonly options: HelperOption[]
   readonly blockArguments: HelperBlockArgument[]
@@ -91,6 +102,17 @@ const <%= helper.lower_camel_case_name %>Entry: HelperEntry = {
   },
   <%- else -%>
   implicitAttribute: null,
+  <%- end -%>
+  <%- if helper.content? -%>
+  content: {
+    source: "<%= helper.content.source %>",
+    argPosition: <%= helper.content.arg_position || "null" %>,
+    skipIfHash: <%= helper.content.skip_if_hash %>,
+    toSSuffixWhenSingle: <%= helper.content.to_s_suffix_when_single %>,
+    positionalArgumentsWithBlock: <%= helper.content.positional_arguments_with_block || "null" %>,
+  },
+  <%- else -%>
+  content: null,
   <%- end -%>
   arguments: [
   <%- helper.arguments.each do |arg| -%>

--- a/templates/lib/herb/action_view/helper_registry.rb.erb
+++ b/templates/lib/herb/action_view/helper_registry.rb.erb
@@ -94,6 +94,35 @@ module Herb
       end
     end
 
+    class HelperContent
+      attr_reader :source #: Symbol
+      attr_reader :arg_position #: Integer?
+      attr_reader :skip_if_hash #: bool
+      attr_reader :to_s_suffix_when_single #: bool
+      attr_reader :positional_arguments_with_block #: Integer?
+
+      #: (Symbol, Integer?, bool, bool, Integer?) -> void
+      def initialize(source, arg_position, skip_if_hash, to_s_suffix_when_single, positional_arguments_with_block)
+        @source = source
+        @arg_position = arg_position
+        @skip_if_hash = skip_if_hash
+        @to_s_suffix_when_single = to_s_suffix_when_single
+        @positional_arguments_with_block = positional_arguments_with_block
+      end
+
+      #: () -> bool
+      def first_arg? = @source == :first_arg
+
+      #: () -> bool
+      def block_or_arg? = @source == :block_or_arg
+
+      #: () -> bool
+      def skip_if_hash? = @skip_if_hash
+
+      #: () -> bool
+      def to_s_suffix_when_single? = @to_s_suffix_when_single
+    end
+
     class HelperEntry
       attr_reader :name #: String
       attr_reader :type #: Symbol
@@ -107,17 +136,18 @@ module Herb
       attr_reader :signature #: String
       attr_reader :documentation_url #: String
       attr_reader :implicit_attribute #: HelperImplicitAttribute?
+      attr_reader :content #: HelperContent?
       attr_reader :arguments #: Array[HelperArgument]
       attr_reader :options #: Array[HelperOption]
       attr_reader :block_arguments #: Array[HelperBlockArgument]
       attr_reader :special_behaviors #: Array[Symbol]
       attr_reader :aliases #: Array[String]
 
-      #: (name: String, type: Symbol, source: String, gem: String, output: Symbol, visibility: String, tag_name: String?, is_void: bool, supports_block: bool, preferred_for_tag: bool, supported: bool, detect_style: Symbol, description: String, signature: String, documentation_url: String, implicit_attribute: HelperImplicitAttribute?, arguments: Array[HelperArgument], options: Array[HelperOption], block_arguments: Array[HelperBlockArgument], special_behaviors: Array[Symbol], aliases: Array[String]) -> void
+      #: (name: String, type: Symbol, source: String, gem: String, output: Symbol, visibility: String, tag_name: String?, is_void: bool, supports_block: bool, preferred_for_tag: bool, supported: bool, detect_style: Symbol, description: String, signature: String, documentation_url: String, implicit_attribute: HelperImplicitAttribute?, content: HelperContent?, arguments: Array[HelperArgument], options: Array[HelperOption], block_arguments: Array[HelperBlockArgument], special_behaviors: Array[Symbol], aliases: Array[String]) -> void
       def initialize( # rubocop:disable Metrics/ParameterLists
         name:, type:, source:, gem:, output:, visibility:, tag_name:, is_void:, supports_block:,
         preferred_for_tag:, supported:, detect_style:, description:, signature:, documentation_url:,
-        implicit_attribute:, arguments:, options:, block_arguments:, special_behaviors:, aliases:
+        implicit_attribute:, content:, arguments:, options:, block_arguments:, special_behaviors:, aliases:
       )
         @name = name
         @type = type
@@ -135,6 +165,7 @@ module Herb
         @signature = signature
         @documentation_url = documentation_url
         @implicit_attribute = implicit_attribute
+        @content = content
         @arguments = arguments
         @options = options
         @block_arguments = block_arguments
@@ -159,6 +190,9 @@ module Herb
 
       #: () -> bool
       def implicit_attribute? = !@implicit_attribute.nil?
+
+      #: () -> bool
+      def content? = !@content.nil?
 
       #: () -> bool
       def call_name_detect? = @detect_style == :call_name
@@ -195,6 +229,17 @@ module Herb
         ),
       <%- else -%>
         implicit_attribute: nil,
+      <%- end -%>
+      <%- if helper.content? -%>
+        content: HelperContent.new(
+          :<%= helper.content.source %>,
+          <%= helper.content.arg_position || "nil" %>,
+          <%= helper.content.skip_if_hash %>,
+          <%= helper.content.to_s_suffix_when_single %>,
+          <%= helper.content.positional_arguments_with_block || "nil" %>
+        ),
+      <%- else -%>
+        content: nil,
       <%- end -%>
         arguments: [
         <%- helper.arguments.each do |arg| -%>

--- a/templates/rust/src/action_view_helpers.rs.erb
+++ b/templates/rust/src/action_view_helpers.rs.erb
@@ -63,6 +63,15 @@ pub struct HelperImplicitAttribute {
 }
 
 #[derive(Debug, Clone)]
+pub struct HelperContent {
+  pub source: &'static str,
+  pub arg_position: Option<usize>,
+  pub skip_if_hash: bool,
+  pub to_s_suffix_when_single: bool,
+  pub positional_arguments_with_block: Option<usize>,
+}
+
+#[derive(Debug, Clone)]
 pub struct HelperEntry {
   pub name: &'static str,
   pub helper_type: HelperType,
@@ -80,6 +89,7 @@ pub struct HelperEntry {
   pub signature: &'static str,
   pub documentation_url: &'static str,
   pub implicit_attribute: Option<&'static HelperImplicitAttribute>,
+  pub content: Option<&'static HelperContent>,
   pub arguments: &'static [HelperArgument],
   pub options: &'static [HelperOption],
   pub block_arguments: &'static [HelperBlockArgument],
@@ -95,6 +105,16 @@ static <%= helper.constant_name %>_IMPLICIT_ATTR: HelperImplicitAttribute = Help
   source_with_block: <%= helper.implicit_attribute.source_with_block ? "Some(\"#{helper.implicit_attribute.source_with_block}\")" : "None" %>,
   wrapper: "<%= helper.implicit_attribute.wrapper %>",
   skip_wrapping_for: &[<%= helper.implicit_attribute.skip_wrapping_for.map { |s| "\"#{s}\"" }.join(", ") %>],
+};
+
+<%- end -%>
+<%- if helper.content? -%>
+static <%= helper.constant_name %>_CONTENT: HelperContent = HelperContent {
+  source: "<%= helper.content.source %>",
+  arg_position: <%= helper.content.arg_position ? "Some(#{helper.content.arg_position})" : "None" %>,
+  skip_if_hash: <%= helper.content.skip_if_hash %>,
+  to_s_suffix_when_single: <%= helper.content.to_s_suffix_when_single %>,
+  positional_arguments_with_block: <%= helper.content.positional_arguments_with_block ? "Some(#{helper.content.positional_arguments_with_block})" : "None" %>,
 };
 
 <%- end -%>
@@ -119,6 +139,7 @@ static REGISTRY: [HelperEntry; <%= helpers.size %>] = [
     signature: "<%= helper.escaped_signature %>",
     documentation_url: "<%= helper.documentation_url %>",
     implicit_attribute: <%= helper.implicit_attribute? ? "Some(&#{helper.constant_name}_IMPLICIT_ATTR)" : "None" %>,
+    content: <%= helper.content? ? "Some(&#{helper.constant_name}_CONTENT)" : "None" %>,
     arguments: &[
     <%- helper.arguments.each do |arg| -%>
       HelperArgument { name: "<%= arg.name %>", position: <%= arg.position %>, argument_type: "<%= arg.type_display %>", optional: <%= arg.optional %>, default: <%= arg.default ? "Some(\"#{arg.escaped_default}\")" : "None" %>, splat: <%= arg.splat %>, description: "<%= arg.escaped_description %>" },

--- a/templates/src/analyze/action_view/helper_registry.c.erb
+++ b/templates/src/analyze/action_view/helper_registry.c.erb
@@ -17,6 +17,16 @@ static const helper_implicit_attribute_T <%= helper.safe_name %>_implicit_attrib
 };
 
 <%- end -%>
+<%- if helper.content? -%>
+static const helper_content_T <%= helper.safe_name %>_content = {
+  .source = "<%= helper.content.source %>",
+  .arg_position = <%= helper.content.arg_position || -1 %>,
+  .skip_if_hash = <%= helper.content.skip_if_hash %>,
+  .to_s_suffix_when_single = <%= helper.content.to_s_suffix_when_single %>,
+  .positional_arguments_with_block = <%= helper.content.positional_arguments_with_block || -1 %>,
+};
+
+<%- end -%>
 <%- if helper.arguments.any? -%>
 static const helper_argument_T <%= helper.safe_name %>_arguments[] = {
 <%- helper.arguments.each do |arg| -%>
@@ -62,6 +72,7 @@ static const helper_registry_entry_T registry_entries[HELPER_COUNT] = {
     .signature = "<%= helper.escaped_signature %>",
     .documentation_url = "<%= helper.documentation_url %>",
     .implicit_attribute = <%= helper.implicit_attribute? ? "&#{helper.safe_name}_implicit_attribute" : "NULL" %>,
+    .content = <%= helper.content? ? "&#{helper.safe_name}_content" : "NULL" %>,
     .arguments = <%= helper.arguments.any? ? "#{helper.safe_name}_arguments" : "NULL" %>,
     .arguments_count = <%= helper.arguments.size %>,
     .options = <%= helper.options.any? ? "#{helper.safe_name}_options" : "NULL" %>,

--- a/templates/src/include/analyze/action_view/helper_registry.h.erb
+++ b/templates/src/include/analyze/action_view/helper_registry.h.erb
@@ -46,6 +46,14 @@ typedef struct {
   const char* wrapper;
 } helper_implicit_attribute_T;
 
+typedef struct {
+  const char* source;
+  int arg_position;
+  bool skip_if_hash;
+  bool to_s_suffix_when_single;
+  int positional_arguments_with_block;
+} helper_content_T;
+
 typedef enum {
   HELPER_OUTPUT_HTML,
   HELPER_OUTPUT_TEXT,
@@ -73,6 +81,7 @@ typedef struct {
   const char* signature;
   const char* documentation_url;
   const helper_implicit_attribute_T* implicit_attribute;
+  const helper_content_T* content;
   const helper_argument_T* arguments;
   size_t arguments_count;
   const helper_option_T* options;

--- a/templates/template.rb
+++ b/templates/template.rb
@@ -575,13 +575,15 @@ module Herb
     end
 
     class HelperContent
-      attr_reader :source, :arg_position, :skip_if_hash, :to_s_suffix_when_single
+      attr_reader :source, :arg_position, :skip_if_hash, :to_s_suffix_when_single,
+                  :positional_arguments_with_block
 
       def initialize(config)
         @source = config.fetch("source")
         @arg_position = config.fetch("arg_position", nil)
         @skip_if_hash = config.fetch("skip_if_hash", false)
         @to_s_suffix_when_single = config.fetch("to_s_suffix_when_single", false)
+        @positional_arguments_with_block = config.fetch("positional_arguments_with_block", nil)
       end
 
       def null?


### PR DESCRIPTION
This pull request implements the `actionview-no-content-argument-with-block` rule that flags Action View helpers given both a positional content argument and a block, where Action View reads only one of them and the argument quietly goes somewhere the caller did not intend.

There are two shapes, and they fail differently.

For `tag`, `content_tag`, `button_tag`, `label_tag`, `mail_to`, `phone_to` and `sms_to` the block wins and the argument is discarded:

```ruby
content_tag(:section, "Intro") { "Welcome" }
# => "<section>Welcome</section>"
```

Nothing warns, nothing raises, and `"Intro"` never reaches the page.

For `link_to` and `button_to` it is worse, because those helpers shift their arguments when a block is given. The first argument becomes the URL and the second becomes the HTML attributes hash:

```ruby
link_to("Go", "/dashboard") { "Go now" }
# => NoMethodError: undefined method 'stringify_keys' for an instance of String
```

Resolves #187
