### PR TITLE
Language Server: Point diagnostics at the call sites that caused them

### DIFF
--- a/javascript/packages/language-server/src/linter_service.ts
+++ b/javascript/packages/language-server/src/linter_service.ts
@@ -1,4 +1,5 @@
-import { Diagnostic, CodeDescription, Connection } from "vscode-languageserver/node"
+import { Diagnostic, DiagnosticRelatedInformation, CodeDescription, Connection, Position, Range } from "vscode-languageserver/node"
+import { join } from "node:path"
 import { TextDocument } from "vscode-languageserver-textdocument"
 
 import { Linter, rules, ruleDocumentationUrl, type RuleClass } from "@herb-tools/linter"
@@ -8,6 +9,14 @@ import { Config } from "@herb-tools/config"
 
 import { Settings } from "./settings"
 import { Project } from "./project"
+
+import type { AncestorChain } from "@herb-tools/core"
+
+const FRAME_VERBS: Record<string, string> = {
+  render: "rendered from",
+  layout: "rendered into",
+  declaration: "declared at",
+}
 import { PartialIndexService } from "./partial_index_service"
 import { PartialCallerIndexService } from "./partial_caller_index_service"
 import { isConfigDocument, lintToDignosticSeverity, lintToDignosticTags } from "./utils"
@@ -136,6 +145,42 @@ export class LinterService {
     return config.isLinterEnabledForPath(relativePath)
   }
 
+  private messageFor(offense: { message: string, renderedFrom?: AncestorChain }): string {
+    if (this.settings.hasDiagnosticRelatedInformationCapability) return offense.message
+
+    const frames = (offense.renderedFrom?.frames ?? []).filter(frame => frame.location !== null)
+
+    if (frames.length === 0) return offense.message
+
+    const caller = frames[frames.length - 1]
+
+    const verb = FRAME_VERBS[caller.via] ?? FRAME_VERBS.render
+
+    return `${offense.message} ${verb.charAt(0).toUpperCase()}${verb.slice(1)} \`${caller.file}:${caller.location!.line}:${caller.location!.column}\`.`
+  }
+
+  private callChainFor(offense: { renderedFrom?: AncestorChain }): DiagnosticRelatedInformation[] {
+    const frames = offense.renderedFrom?.frames ?? []
+    const information: DiagnosticRelatedInformation[] = []
+
+    for (const frame of [...frames].reverse()) {
+      if (!frame.location) continue
+
+      const position = Position.create(Math.max(frame.location.line - 1, 0), frame.location.column)
+      const nesting = frame.ancestors.length > 0 ? ` inside ${frame.ancestors.map(tag => `<${tag}>`).join(" › ")}` : ""
+
+      information.push({
+        location: {
+          uri: `file://${join(this.project.projectPath, frame.file)}`,
+          range: Range.create(position, position)
+        },
+        message: `${FRAME_VERBS[frame.via] ?? FRAME_VERBS.render} here${nesting}`
+      })
+    }
+
+    return information
+  }
+
   async lintDocument(textDocument: TextDocument): Promise<LintServiceResult> {
     if (!this.shouldLintFile(textDocument.uri)) {
       return { diagnostics: [] }
@@ -200,7 +245,7 @@ export class LinterService {
         source: this.source,
         severity: lintToDignosticSeverity(offense.severity),
         range,
-        message: offense.message,
+        message: this.messageFor(offense),
         code: offense.rule,
         data: { rule: offense.rule },
         codeDescription
@@ -210,6 +255,14 @@ export class LinterService {
 
       if (tags.length > 0) {
         diagnostic.tags = tags
+      }
+
+      if (this.settings.hasDiagnosticRelatedInformationCapability) {
+        const relatedInformation = this.callChainFor(offense)
+
+        if (relatedInformation.length > 0) {
+          diagnostic.relatedInformation = relatedInformation
+        }
       }
 
       return diagnostic

--- a/javascript/packages/language-server/src/service.ts
+++ b/javascript/packages/language-server/src/service.ts
@@ -91,6 +91,8 @@ export class Service {
   }
 
   async init() {
+    this.connection.console.log(`[Client] Diagnostic related information: ${this.settings.hasDiagnosticRelatedInformationCapability ? "supported" : "not supported"}`)
+
     await this.project.initialize()
     await this.formattingService.initialize()
     await this.partialIndexService.initialize()

--- a/javascript/packages/language-server/test/linter_service.test.ts
+++ b/javascript/packages/language-server/test/linter_service.test.ts
@@ -301,10 +301,11 @@ describe("LinterService", () => {
       return service
     }
 
-    function settingsWithLinter() {
+    function settingsWithLinter(relatedInformation = true) {
       const settings = new Settings(mockParams, mockConnection)
 
       settings.getDocumentSettings = vi.fn().mockResolvedValue({ linter: { enabled: true } })
+      settings.hasDiagnosticRelatedInformationCapability = relatedInformation
 
       return settings
     }
@@ -337,6 +338,76 @@ describe("LinterService", () => {
       const result = await service.lintDocument(document)
 
       expect(result.diagnostics.some(diagnostic => diagnostic.code === "html-head-only-elements")).toBe(false)
+    })
+
+    test("points at the call site that renders the file inside the element", async () => {
+      const callers = new PartialCallerIndex(
+        new Map([[PARTIAL, [{
+          caller: "app/views/posts/index.html.erb",
+          locals: [],
+          ancestors: ["a"],
+          via: "render" as const,
+          location: { line: 12, column: 4 }
+        }]]]),
+        new Set(),
+        new Map(),
+        new Set()
+      )
+
+      const service = new LinterService(mockConnection, settingsWithLinter(), mockProject, partialIndexService, callerServiceFor(callers))
+
+      vi.spyOn(partialIndexService, "relativePathFor").mockReturnValue(PARTIAL)
+
+      const document = TextDocument.create(`file:///${PARTIAL}`, "erb", 1, `<a href="/">link</a>`)
+      const result = await service.lintDocument(document)
+
+      const nested = result.diagnostics.find(diagnostic => diagnostic.code === "html-no-nested-links")
+
+      expect(nested).toBeDefined()
+      expect(nested?.relatedInformation).toHaveLength(1)
+      expect(nested?.relatedInformation?.[0].location.uri).toContain("app/views/posts/index.html.erb")
+      expect(nested?.relatedInformation?.[0].location.range.start.line).toBe(11)
+      expect(nested?.relatedInformation?.[0].message).toBe("rendered from here inside <a>")
+      expect(nested?.message).not.toContain("Rendered from")
+    })
+
+    test("omits related information when nothing rendered the file", async () => {
+      const empty = new PartialCallerIndex(new Map(), new Set(), new Map(), new Set())
+      const service = new LinterService(mockConnection, settingsWithLinter(), mockProject, partialIndexService, callerServiceFor(empty))
+
+      vi.spyOn(partialIndexService, "relativePathFor").mockReturnValue(PARTIAL)
+
+      const document = TextDocument.create(`file:///${PARTIAL}`, "erb", 1, `<meta charset="UTF-8">`)
+      const result = await service.lintDocument(document)
+
+      expect(result.diagnostics.every(diagnostic => diagnostic.relatedInformation === undefined)).toBe(true)
+    })
+
+    test("names the call site in the message when the client cannot show related information", async () => {
+      const callers = new PartialCallerIndex(
+        new Map([[PARTIAL, [{
+          caller: "app/views/posts/index.html.erb",
+          locals: [],
+          ancestors: ["a"],
+          via: "render" as const,
+          location: { line: 12, column: 4 }
+        }]]]),
+        new Set(),
+        new Map(),
+        new Set()
+      )
+
+      const service = new LinterService(mockConnection, settingsWithLinter(false), mockProject, partialIndexService, callerServiceFor(callers))
+
+      vi.spyOn(partialIndexService, "relativePathFor").mockReturnValue(PARTIAL)
+
+      const document = TextDocument.create(`file:///${PARTIAL}`, "erb", 1, `<a href="/">link</a>`)
+      const result = await service.lintDocument(document)
+
+      const nested = result.diagnostics.find(diagnostic => diagnostic.code === "html-no-nested-links")
+
+      expect(nested?.message).toContain("Rendered from `app/views/posts/index.html.erb:12:4`.")
+      expect(nested?.relatedInformation).toBeUndefined()
     })
   })
 })


### PR DESCRIPTION
This pull request attaches the render call chain to diagnostics as `relatedInformation`, so an offense reported because of where a partial is rendered can point back at the call sites that caused it.

Several linter rules decide whether to report by looking at where a file is rendered rather than at the file itself. That makes the offense hard to act on, because the line it lands on is usually fine and the reason lives somewhere else entirely:

```html+erb
<%# app/views/posts/_a.html.erb %>
<a href="/index.html">Home</a>
```

Nothing there is wrong on its own. `html-no-nested-links` reports it because `_content_row.html.erb` renders that partial inside an `<a>`, and `index.html.erb` renders `_content_row.html.erb` in turn. Until now the diagnostic said only that nested `<a>` elements are not allowed, leaving the reader to find the two files responsible.

Every frame of the chain now becomes a related information entry, innermost caller first, carrying the file, the position, and what the partial was nested in at that point:

```
_content_row.html.erb:6    rendered from here inside <a>
index.html.erb:11          rendered from here inside <div>
```

VS Code renders related information natively. Zed discarded every entry whose URI differed from the file being diagnosed, so the chain never reached the editor at all. zed-industries/zed#62400 fixes that upstream and renders each frame beneath the diagnostic with a link to the call site:

| VS Code | Zed (after https://github.com/zed-industries/zed/pull/62400 merges) |
| ---- | --- |
| <img width="2232" height="690" alt="CleanShot 2026-08-10 at 04 24 28@2x" src="https://github.com/user-attachments/assets/730a0315-31ed-48d6-952f-66bb5256a428" /> |  <img width="2048" height="744" alt="CleanShot 2026-08-10 at 03 44 01@2x" src="https://github.com/user-attachments/assets/9def6c19-bc1e-4cfb-8618-efb9d19b8343" /> |

The verb reflects how the file was reached, so a layout reads `rendered into here` and a strict locals declaration reads `declared at here`.

#### Clients without related information support

Entries pointing at another file are useless to a client that cannot render them, so they are only attached when the client advertises `textDocument.publishDiagnostics.relatedInformation`. For every other client the nearest call site is appended to the message instead, which is the only place they can show it:

```
Nested `<a>` elements are not allowed. Rendered from `app/views/posts/index.html.erb:12:4`.
```

The two forms are mutually exclusive, so a client that renders the entries gets an unmodified message and never sees the call site twice.


---

Related https://github.com/marcoroth/herb/issues/2094

