### PR TITLE
Linter: Fix rule gaps behind skipped and failing tests

### DIFF
--- a/javascript/packages/linter/docs/rules/html-head-only-elements.md
+++ b/javascript/packages/linter/docs/rules/html-head-only-elements.md
@@ -104,9 +104,29 @@ A partial holding `<meta>` or `<link>` tags is reported when every call site ren
 
 Action View helpers that render an element count as ancestors, so a `content_tag`, `tag.div` or `link_to` block nests what it wraps just like the equivalent HTML would.
 
-The rule stays quiet whenever there is not enough information to be sure. A file nothing renders, and a chain that never reaches a layout, are both left alone. When only some call sites place the file in the wrong section, the offense is still reported and the call chain points at one that does.
+The rule stays quiet whenever there is not enough information to be sure, unless the template contradicts itself. A file nothing renders, and a chain that never reaches a layout, are both left alone. When only some call sites place the file in the wrong section, the offense is still reported and the call chain points at one that does.
 
 Layout resolution follows Rails' naming convention and cannot see a controller declaring `layout "..."` or `layout false`.
+
+## Templates that contradict themselves
+
+A template with no resolved call site is normally left alone, because nothing says which section it renders into. One case still gives an answer. When a template holds both a head-only element and a body-only element that always render together, wherever it ends up one of the two is in the wrong section, so the head-only elements are reported.
+
+```erb
+<meta name="description" content="Page description">
+
+<div>Body content</div>
+```
+
+Elements only count when they are guaranteed to render alongside each other. Branches of a conditional are mutually exclusive, a `content_for` block renders somewhere else entirely, a `<template>` is not rendered where it sits, and an element already inside an explicit `<head>` or `<body>` has an answer of its own. None of these are counted.
+
+```erb
+<% content_for :head do %>
+  <meta name="description" content="Page description">
+<% end %>
+
+<div>Body content</div>
+```
 
 ## References
 

--- a/javascript/packages/linter/src/rules/actionview-no-silent-helper.ts
+++ b/javascript/packages/linter/src/rules/actionview-no-silent-helper.ts
@@ -4,8 +4,12 @@ import { BaseRuleVisitor } from "./rule-utils.js"
 import { isERBOutputNode, isPrismNodeType } from "@herb-tools/core"
 import { isActionViewHelperCall } from "./action-view-utils.js"
 
-import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types.js"
+import type { UnboundLintOffense, LintOffense, LintContext, FullRuleConfig, BaseAutofixContext, Mutable } from "../types.js"
 import type { ParseResult, ERBContentNode, ParserOptions, PrismNode } from "@herb-tools/core"
+
+interface ActionViewNoSilentHelperAutofixContext extends BaseAutofixContext {
+  node: Mutable<ERBContentNode>
+}
 
 function collectDiscardedHelperCalls(prismNode: PrismNode): { helperName: string }[] {
   const matches: { helperName: string }[] = []
@@ -63,7 +67,7 @@ function collectDiscardedHelperCalls(prismNode: PrismNode): { helperName: string
   return matches
 }
 
-class ActionViewNoSilentHelperVisitor extends BaseRuleVisitor {
+class ActionViewNoSilentHelperVisitor extends BaseRuleVisitor<ActionViewNoSilentHelperAutofixContext> {
   visitERBContentNode(node: ERBContentNode): void {
     this.checkSilentHelper(node)
     super.visitERBContentNode(node)
@@ -83,12 +87,15 @@ class ActionViewNoSilentHelperVisitor extends BaseRuleVisitor {
       this.addOffense(
         `Avoid using \`${tagOpening} %>\` with \`${match.helperName}\`. Use \`<%= %>\` to ensure the helper's output is rendered.`,
         node.location,
+        { node: node as Mutable<ERBContentNode> },
       )
     }
   }
 }
 
-export class ActionViewNoSilentHelperRule extends ParserRule {
+export class ActionViewNoSilentHelperRule extends ParserRule<ActionViewNoSilentHelperAutofixContext> {
+  static unsafeAutocorrectable = true
+  static autofixRequiresContext = true
   static ruleName = "actionview-no-silent-helper"
   static introducedIn = this.version("0.9.0")
 
@@ -106,11 +113,24 @@ export class ActionViewNoSilentHelperRule extends ParserRule {
     }
   }
 
-  check(result: ParseResult, context?: Partial<LintContext>): UnboundLintOffense[] {
+  check(result: ParseResult, context?: Partial<LintContext>): UnboundLintOffense<ActionViewNoSilentHelperAutofixContext>[] {
     const visitor = new ActionViewNoSilentHelperVisitor(this.ruleName, context)
 
     visitor.visit(result.value)
 
     return visitor.offenses
+  }
+
+  autofix(offense: LintOffense<ActionViewNoSilentHelperAutofixContext>, result: ParseResult): ParseResult | null {
+    if (!offense.autofixContext) return null
+
+    const { node } = offense.autofixContext
+
+    if (!node.tag_opening) return null
+    if (node.tag_opening.value === "<%=") return null
+
+    node.tag_opening.value = "<%="
+
+    return result
   }
 }

--- a/javascript/packages/linter/src/rules/html-aria-role-heading-requires-level.ts
+++ b/javascript/packages/linter/src/rules/html-aria-role-heading-requires-level.ts
@@ -1,5 +1,5 @@
 import { ParserRule } from "../types.js"
-import { AttributeVisitorMixin, StaticAttributeStaticValueParams } from "./rule-utils.js"
+import { AttributeVisitorMixin, StaticAttributeStaticValueParams, isNilAttributeValue } from "./rule-utils.js"
 import { getAttributeName, getAttributes } from "@herb-tools/core"
 
 import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types.js"
@@ -9,9 +9,9 @@ class AriaRoleHeadingRequiresLevel extends AttributeVisitorMixin {
   protected checkStaticAttributeStaticValue({ attributeName, attributeValue, attributeNode, parentNode }: StaticAttributeStaticValueParams): void {
     if (!(attributeName === "role" && attributeValue === "heading")) return
 
-    const ariaLevelAttributes = getAttributes(parentNode).find(attribute => getAttributeName(attribute) === "aria-level")
+    const ariaLevelAttribute = getAttributes(parentNode).find(attribute => getAttributeName(attribute) === "aria-level")
 
-    if (ariaLevelAttributes) return
+    if (ariaLevelAttribute && !isNilAttributeValue(ariaLevelAttribute)) return
 
     this.addOffense(
       `Element with \`role="heading"\` must have an \`aria-level\` attribute.`,

--- a/javascript/packages/linter/src/rules/html-head-only-elements.ts
+++ b/javascript/packages/linter/src/rules/html-head-only-elements.ts
@@ -1,13 +1,39 @@
 import { ParserRule } from "../types"
-import { ElementStackVisitor, isHeadOnlyTag } from "./rule-utils"
+import { ElementStackVisitor, isHeadOnlyTag, isBodyOnlyTag } from "./rule-utils"
 import { hasAttribute, getTagLocalName } from "@herb-tools/core"
 
 import type { ParseResult, HTMLElementNode, ParserOptions } from "@herb-tools/core"
+import type * as Nodes from "@herb-tools/core"
 import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types"
 
 const inTheBodyNotTheHead = (ancestors: string[]) => ancestors.includes("body") && !ancestors.includes("head")
 
+interface UndecidedElement {
+  tagName: string
+  node: HTMLElementNode
+}
+
 class HeadOnlyElementsVisitor extends ElementStackVisitor {
+  private undecided: UndecidedElement[] = []
+  private bodyOnlyTagName: string | null = null
+  private conditionalDepth = 0
+
+  visitERBIfNode(node: Nodes.ERBIfNode): void {
+    this.withinConditional(() => super.visitERBIfNode(node))
+  }
+
+  visitERBUnlessNode(node: Nodes.ERBUnlessNode): void {
+    this.withinConditional(() => super.visitERBUnlessNode(node))
+  }
+
+  visitERBCaseNode(node: Nodes.ERBCaseNode): void {
+    this.withinConditional(() => super.visitERBCaseNode(node))
+  }
+
+  visitERBCaseMatchNode(node: Nodes.ERBCaseMatchNode): void {
+    this.withinConditional(() => super.visitERBCaseMatchNode(node))
+  }
+
   visitHTMLElementNode(node: HTMLElementNode): void {
     const tagName = getTagLocalName(node)
 
@@ -23,11 +49,40 @@ class HeadOnlyElementsVisitor extends ElementStackVisitor {
           this.addOffenseWithCallChain(message, node.location, chain)
         } else if (verdict === "mixed") {
           this.addOffenseWithCallChain(`${message} At least one call site renders this file inside the \`<body>\`.`, node.location, chain)
+        } else if (verdict === "unknown" && this.alwaysRenders) {
+          this.undecided.push({ tagName, node })
         }
       }
+    } else if (tagName && isBodyOnlyTag(tagName) && this.alwaysRenders && !this.bodyOnlyTagName) {
+      this.bodyOnlyTagName = tagName
     }
 
     super.visitHTMLElementNode(node)
+  }
+
+  reportContradictions(): void {
+    if (!this.bodyOnlyTagName) return
+
+    for (const { tagName, node } of this.undecided) {
+      this.addOffense(
+        `Element \`<${tagName}>\` must be placed inside the \`<head>\` tag. This template also renders the body-only element \`<${this.bodyOnlyTagName}>\`, so one of the two is misplaced.`,
+        node.location,
+      )
+    }
+  }
+
+  private get alwaysRenders(): boolean {
+    if (this.conditionalDepth > 0) return false
+    if (this.isInsideDetachedBlock) return false
+    if (this.isInsideElement("template")) return false
+
+    return !this.isInsideElement("html", "head", "body")
+  }
+
+  private withinConditional(visit: () => void): void {
+    this.conditionalDepth++
+    visit()
+    this.conditionalDepth--
   }
 }
 
@@ -54,6 +109,7 @@ export class HTMLHeadOnlyElementsRule extends ParserRule {
     const visitor = new HeadOnlyElementsVisitor(this.ruleName, context)
 
     visitor.visit(result.value)
+    visitor.reportContradictions()
 
     return visitor.offenses
   }

--- a/javascript/packages/linter/src/rules/rule-utils.ts
+++ b/javascript/packages/linter/src/rules/rule-utils.ts
@@ -19,6 +19,7 @@ import {
   findAttributeByName,
   hasAttribute,
   isERBOpenTagNode,
+  isRubyLiteralNode,
 } from "@herb-tools/core"
 
 import type {
@@ -344,6 +345,15 @@ export abstract class ElementStackVisitor<TAutofixContext extends BaseAutofixCon
       const name = getTagLocalName(element)
       return name !== null && tagNames.includes(name)
     })
+  }
+
+  /**
+   * Whether the current position sits inside a block whose contents render
+   * somewhere else, such as `content_for`. The surrounding markup says nothing
+   * about where these nodes end up.
+   */
+  protected get isInsideDetachedBlock(): boolean {
+    return this.detachedBlockDepth > 0
   }
 
   /**
@@ -1286,6 +1296,32 @@ export function findElementAttribute(node: HTMLElementNode, name: string): HTMLA
   }
 
   return getAttribute(node, name)
+}
+
+const NESTED_ATTRIBUTE_VALUE_PREFIX = "::Herb::Engine.nested_attribute_value("
+
+/**
+ * Whether an Action View helper option resolves to `nil`. Action View drops
+ * these attributes when it renders the element, so rules that require an
+ * attribute to be present should treat them as absent.
+ */
+export function isNilAttributeValue(attributeNode: HTMLAttributeNode): boolean {
+  const value = attributeNode.value
+
+  if (!value) return false
+  if (value.children.length !== 1) return false
+
+  const child = value.children[0]
+
+  if (!isRubyLiteralNode(child)) return false
+
+  let content = child.content.trim()
+
+  if (content.startsWith(NESTED_ATTRIBUTE_VALUE_PREFIX) && content.endsWith(")")) {
+    content = content.slice(NESTED_ATTRIBUTE_VALUE_PREFIX.length, -1).trim()
+  }
+
+  return content === "nil"
 }
 
 const NON_JS_SCRIPT_TYPES = new Set([

--- a/javascript/packages/linter/src/rules/turbo-permanent-require-id.ts
+++ b/javascript/packages/linter/src/rules/turbo-permanent-require-id.ts
@@ -1,4 +1,4 @@
-import { BaseRuleVisitor } from "./rule-utils.js"
+import { BaseRuleVisitor, isNilAttributeValue } from "./rule-utils.js"
 import { getAttribute } from "@herb-tools/core"
 
 import { ParserRule } from "../types.js"
@@ -25,7 +25,7 @@ class TurboPermanentRequireIdVisitor extends BaseRuleVisitor {
 
     const idAttribute = getAttribute(node, "id")
 
-    if (!idAttribute) {
+    if (!idAttribute || isNilAttributeValue(idAttribute)) {
       this.addOffense(
         "Elements with `data-turbo-permanent` must have an `id` attribute. Without an `id`, Turbo can't track the element across page changes and the permanent behavior won't work as expected.",
         turboPermanentAttribute.location,

--- a/javascript/packages/linter/test/autofix/actionview-no-silent-helper.autofix.test.ts
+++ b/javascript/packages/linter/test/autofix/actionview-no-silent-helper.autofix.test.ts
@@ -12,7 +12,7 @@ describe("actionview-no-silent-helper autofix", () => {
     await Herb.load()
   })
 
-  test.skip("output tag is not modified", () => {
+  test("output tag is not modified", () => {
     const input = dedent`
       <%= link_to "Home", root_path %>
     `
@@ -25,7 +25,7 @@ describe("actionview-no-silent-helper autofix", () => {
     expect(result.unfixed).toHaveLength(0)
   })
 
-  test.skip("fixes silent tag to output tag for link_to", () => {
+  test("fixes silent tag to output tag for link_to", () => {
     const input = dedent`
       <% link_to "Home", root_path %>
     `
@@ -42,7 +42,7 @@ describe("actionview-no-silent-helper autofix", () => {
     expect(result.unfixed).toHaveLength(0)
   })
 
-  test.skip("fixes silent tag to output tag for content_tag", () => {
+  test("fixes silent tag to output tag for content_tag", () => {
     const input = dedent`
       <% content_tag :div, "Hello", class: "greeting" %>
     `
@@ -59,7 +59,7 @@ describe("actionview-no-silent-helper autofix", () => {
     expect(result.unfixed).toHaveLength(0)
   })
 
-  test.skip("fixes trimmed silent tag to output tag", () => {
+  test("fixes trimmed silent tag to output tag", () => {
     const input = dedent`
       <%- link_to "Home", root_path %>
     `
@@ -76,7 +76,7 @@ describe("actionview-no-silent-helper autofix", () => {
     expect(result.unfixed).toHaveLength(0)
   })
 
-  test.skip("fixes silent tag for turbo_frame_tag", () => {
+  test("fixes silent tag for turbo_frame_tag", () => {
     const input = dedent`
       <% turbo_frame_tag "test" %>
     `

--- a/javascript/packages/linter/test/rules/html-aria-role-heading-requires-level.test.ts
+++ b/javascript/packages/linter/test/rules/html-aria-role-heading-requires-level.test.ts
@@ -40,10 +40,7 @@ describe("html-aria-role-heading-requires-level", () => {
       expectNoOffenses('<%= tag.div role: "heading", aria: { level: "#{level}" } %>')
     })
 
-    // ActionView drops `aria-level` entirely when the value is nil, so this renders as a
-    // heading with no level at all. The parser still emits the attribute node, so the rule
-    // sees it as present and stays quiet.
-    it.fails("fails for role heading with a nil aria-level, which ActionView omits entirely", () => {
+    it("fails for role heading with a nil aria-level, which ActionView omits entirely", () => {
       expectWarning("Element with `role=\"heading\"` must have an `aria-level` attribute.")
 
       assertOffenses('<%= tag.div role: "heading", aria: { level: nil } %>')

--- a/javascript/packages/linter/test/rules/html-head-only-elements.test.ts
+++ b/javascript/packages/linter/test/rules/html-head-only-elements.test.ts
@@ -69,8 +69,14 @@ describe("html-head-only-elements", () => {
     `)
   })
 
-  test.todo("fails for head-only elements on the top-level when other body-elements are present", () => {
-    expectNoOffenses(dedent`
+  test("fails for head-only elements on the top-level when other body-elements are present", () => {
+    expectError("Element `<meta>` must be placed inside the `<head>` tag. This template also renders the body-only element `<div>`, so one of the two is misplaced.")
+    expectError("Element `<link>` must be placed inside the `<head>` tag. This template also renders the body-only element `<div>`, so one of the two is misplaced.")
+    expectError("Element `<base>` must be placed inside the `<head>` tag. This template also renders the body-only element `<div>`, so one of the two is misplaced.")
+    expectError("Element `<title>` must be placed inside the `<head>` tag. This template also renders the body-only element `<div>`, so one of the two is misplaced.")
+    expectError("Element `<style>` must be placed inside the `<head>` tag. This template also renders the body-only element `<div>`, so one of the two is misplaced.")
+
+    assertOffenses(dedent`
       <meta>
       <link>
       <base>
@@ -78,6 +84,56 @@ describe("html-head-only-elements", () => {
       <style></style>
 
       <div></div>
+    `)
+  })
+
+  test("fails when a head-only element follows top-level body content", () => {
+    expectError("Element `<meta>` must be placed inside the `<head>` tag. This template also renders the body-only element `<div>`, so one of the two is misplaced.")
+
+    assertOffenses(dedent`
+      <div></div>
+      <meta>
+    `)
+  })
+
+  test("passes when the body-only element is in a mutually exclusive branch", () => {
+    expectNoOffenses(dedent`
+      <% if head_context? %>
+        <meta>
+      <% else %>
+        <div></div>
+      <% end %>
+    `)
+  })
+
+  test("passes when the head-only elements render into a detached block", () => {
+    expectNoOffenses(dedent`
+      <% content_for :head do %>
+        <title>Posts</title>
+        <meta name="robots" content="noindex">
+      <% end %>
+
+      <div></div>
+    `)
+  })
+
+  test("passes when the only body-only element already sits inside an explicit body", () => {
+    expectNoOffenses(dedent`
+      <meta>
+
+      <html>
+        <body>
+          <div></div>
+        </body>
+      </html>
+    `)
+  })
+
+  test("passes when the body-only element only appears inside a template element", () => {
+    expectNoOffenses(dedent`
+      <meta>
+
+      <template><div></div></template>
     `)
   })
 

--- a/javascript/packages/linter/test/rules/html-tag-name-lowercase.test.ts
+++ b/javascript/packages/linter/test/rules/html-tag-name-lowercase.test.ts
@@ -41,7 +41,7 @@ describe("html-tag-name-lowercase", () => {
     expectNoOffenses('<img src="photo.jpg" />')
   })
 
-  test.skip("handles ERB templates", () => {
+  test("handles ERB templates", () => {
     expectNoOffenses('<div class="container"><%= content_tag(:DIV, "Hello world!") %></div>')
   })
 

--- a/javascript/packages/linter/test/rules/turbo-permanent-require-id-rule.test.ts
+++ b/javascript/packages/linter/test/rules/turbo-permanent-require-id-rule.test.ts
@@ -91,10 +91,7 @@ describe("turbo-permanent-require-id", () => {
       expectNoOffenses('<%= tag.div id: "cart-#{cart.id}", data: { turbo_permanent: true } %>')
     })
 
-    // ActionView drops `id` entirely when the value is nil, so this renders a permanent
-    // element with no id at all. The parser still emits the attribute node, so the rule
-    // sees an id and stays quiet.
-    test.fails("fails for a nil id, which ActionView omits entirely", () => {
+    test("fails for a nil id, which ActionView omits entirely", () => {
       expectError(MESSAGE)
 
       assertOffenses('<%= tag.div id: nil, data: { turbo_permanent: true } %>')

--- a/javascript/packages/linter/test/xml-erb-linting.test.ts
+++ b/javascript/packages/linter/test/xml-erb-linting.test.ts
@@ -71,7 +71,7 @@ describe("XML+ERB Linting", () => {
     expect(selfClosingErrors.length).toBeGreaterThanOrEqual(1)
   })
 
-  test.todo("should handle XML with CDATA sections", () => {
+  test("should handle XML with CDATA sections", () => {
     const source = dedent`
       <?xml version="1.0" encoding="UTF-8"?>
       <document>
@@ -85,8 +85,12 @@ describe("XML+ERB Linting", () => {
       </document>
     ` + '\n'
 
-    const result = linter.lint(source, { fileName: "document.xml.erb" })
-    expect(result.offenses).toEqual(expect.any(Array))
+    const result = linter.lint(source, { fileName: "document.xml.erb", framework: "ruby" })
+
+    const statementErrors = result.offenses.filter(offense =>
+      offense.code === "erb-no-statement-in-script"
+    )
+    expect(statementErrors).toHaveLength(1)
   })
 
   test("should handle self-closing XML tags appropriately", () => {


### PR DESCRIPTION
This pull request works through the linter suite's disabled tests, the `test.skip`, `test.todo` and `test.fails` markers that had accumulated across the rule specs, and retires the ones whose underlying gap was worth closing.

#### `actionview-no-silent-helper` gains an unsafe autofix

The rule shipped with a full autofix spec where every case was skipped, because the rule had no `autofix` method at all. It has one now, following the same node-mutating shape as `erb-strict-locals-comment-syntax`.

```erb
<% link_to "Home", root_path %>
```

```erb
<%= link_to "Home", root_path %>
```

It is registered as `unsafeAutocorrectable`. Turning a silent tag into an output tag changes what the template renders, so it should only apply under `--fix-unsafely`.

#### `nil` helper options count as absent attributes

Action View drops an attribute whose value is `nil`, so `tag.div id: nil` renders a permanent element with no `id` at all, and `aria: { level: nil }` renders a heading with no level. The parser still emits an attribute node for both, so rules that only checked whether the attribute existed stayed quiet on exactly the templates that were broken.

```erb
<%= tag.div id: nil, data: { turbo_permanent: true } %>
<%= tag.div role: "heading", aria: { level: nil } %>
```

#### `html-head-only-elements` reports templates that contradict themselves

The rule resolves where a file renders by walking its call sites, and stays quiet when nothing resolves. That left a real case unreported. A template holding both a head-only element and a body-only element cannot be right either way, because wherever it ends up it is either a `<head>` and the body-only element is misplaced, or a `<body>` and the head-only elements are. That conclusion needs no caller information at all.

```erb
<meta name="description" content="Page description">

<div>Body content</div>
```
