### PR TITLE
Linter: Point `erb-strict-locals-required` at the first line of the file

### DIFF
--- a/javascript/packages/linter/src/rules/erb-strict-locals-required.ts
+++ b/javascript/packages/linter/src/rules/erb-strict-locals-required.ts
@@ -102,13 +102,11 @@ export class ERBStrictLocalsRequiredRule extends ParserRule<StrictLocalsRequired
     if (visitor.foundStrictLocals) return []
 
     const document = result.value
-    const firstChild = document.children[0]
-    const end = firstChild ? firstChild.location.end : Location.zero.end
 
     return [
       this.createOffense(
         "Partial is missing a strict locals declaration. Add `<%# locals: (...) %>` at the top of the file.",
-        Location.from(1, 0, end.line, end.column),
+        this.firstLineOf(document),
         { node: document, declaration: this.declarationFor(document, context), unsafe: true }
       )
     ]
@@ -121,6 +119,12 @@ export class ERBStrictLocalsRequiredRule extends ParserRule<StrictLocalsRequired
     result.value.children.unshift(createLiteral(`${declaration}\n\n`))
 
     return result
+  }
+
+  private firstLineOf(document: DocumentNode): Location {
+    const [firstLine] = (document.source ?? "").split("\n")
+
+    return Location.from(1, 0, 1, firstLine?.length ?? 0)
   }
 
   private declarationFor(document: DocumentNode, context?: Partial<LintContext>): string {

--- a/javascript/packages/linter/test/rules/erb-strict-locals-required.test.ts
+++ b/javascript/packages/linter/test/rules/erb-strict-locals-required.test.ts
@@ -1,9 +1,22 @@
 import dedent from "dedent"
-import { describe, test } from "vitest"
+import { describe, test, beforeAll, expect } from "vitest"
+
+import { Herb } from "@herb-tools/node-wasm"
+import { Config } from "@herb-tools/config"
+
+import { Linter } from "../../src/linter.js"
 import { ERBStrictLocalsRequiredRule } from "../../src/rules/erb-strict-locals-required.js"
 import { createLinterTest } from "../helpers/linter-test-helper.js"
 
 const { expectNoOffenses, expectError, assertOffenses } = createLinterTest(ERBStrictLocalsRequiredRule, { enabled: true })
+
+const config = Config.fromObject({
+  linter: {
+    rules: {
+      "erb-strict-locals-required": { enabled: true, severity: "error" }
+    }
+  }
+})
 
 describe("ERBStrictLocalsRequiredRule", () => {
   test("allows partials with strict locals declaration", () => {
@@ -89,5 +102,45 @@ describe("ERBStrictLocalsRequiredRule", () => {
 
   test("allows strict locals with no space after #", () => {
     expectNoOffenses(`<%#locals: (user:) %>`, { fileName: "_partial.html.erb" })
+  })
+
+  describe("offense location", () => {
+    beforeAll(async () => {
+      await Herb.load()
+    })
+
+    test("points at the first line instead of the whole file", () => {
+      const html = dedent`
+        <div class="user-card">
+          <%= user.name %>
+        </div>
+      `
+
+      const linter = new Linter(Herb, [ERBStrictLocalsRequiredRule], config)
+      const result = linter.lint(html, { fileName: "_user_card.html.erb" })
+
+      expect(result.offenses).toHaveLength(1)
+
+      const { location } = result.offenses[0]
+
+      expect(location.start.line).toBe(1)
+      expect(location.start.column).toBe(0)
+      expect(location.end.line).toBe(1)
+      expect(location.end.column).toBe(`<div class="user-card">`.length)
+    })
+
+    test("points at the first line for a single-line partial", () => {
+      const linter = new Linter(Herb, [ERBStrictLocalsRequiredRule], config)
+      const result = linter.lint(`<%= user.name %>`, { fileName: "_user.html.erb" })
+
+      expect(result.offenses).toHaveLength(1)
+
+      const { location } = result.offenses[0]
+
+      expect(location.start.line).toBe(1)
+      expect(location.start.column).toBe(0)
+      expect(location.end.line).toBe(1)
+      expect(location.end.column).toBe(`<%= user.name %>`.length)
+    })
   })
 })


### PR DESCRIPTION
This pull request updates the `erb-strict-locals-required` linter rule so the offense spans only the first line of the partial instead of the entire first top-level node.

The rule reported a location that started at `1:0` and ended wherever the document's first child ended. For a partial wrapped in a single root element, that first child is the whole template, so the offense covered the entire file.

Resolves https://github.com/marcoroth/herb/issues/2122