### PR TITLE
 Linter: Implement `erb-no-byte-order-mark` rule

### DIFF
--- a/javascript/packages/core/src/util.ts
+++ b/javascript/packages/core/src/util.ts
@@ -1,3 +1,8 @@
+/**
+ * The UTF-8 byte order mark, `U+FEFF`, encoded as the bytes `EF BB BF`.
+ */
+export const BYTE_ORDER_MARK = "\uFEFF"
+
 export function ensureString(object: any): string {
   if (typeof object === "string") {
     return object

--- a/javascript/packages/formatter/src/formatter.ts
+++ b/javascript/packages/formatter/src/formatter.ts
@@ -1,5 +1,6 @@
 import { FormatPrinter } from "./format-printer.js"
 import { convertIndentation } from "@herb-tools/printer"
+import { BYTE_ORDER_MARK } from "@herb-tools/core"
 
 import { isScaffoldTemplate } from "./scaffold-template-detector.js"
 import { resolveFormatOptions } from "./options.js"
@@ -73,7 +74,8 @@ export class Formatter {
   }
 
   formatWithResult(source: string, options: FormatOptions = {}, filePath?: string): FormatResult {
-    const result = this.parse(source)
+    const input = source.startsWith(BYTE_ORDER_MARK) ? source.slice(BYTE_ORDER_MARK.length) : source
+    const result = this.parse(input)
 
     if (result.options.action_view_helpers) {
       console.warn("[Herb Formatter] Warning: Formatting a document parsed with `action_view_helpers: true`. The result may not be 100% accurate.")
@@ -104,7 +106,7 @@ export class Formatter {
       }
     }
 
-    let formatted = new FormatPrinter(source, resolvedOptions, this.herb).print(node)
+    let formatted = new FormatPrinter(input, resolvedOptions, this.herb).print(node)
 
     if (resolvedOptions.postRewriters.length > 0) {
       const context: RewriteContext = {

--- a/javascript/packages/formatter/test/byte-order-mark.test.ts
+++ b/javascript/packages/formatter/test/byte-order-mark.test.ts
@@ -1,0 +1,63 @@
+import { describe, test, expect, beforeAll } from "vitest"
+import { Herb } from "@herb-tools/node-wasm"
+import { Formatter } from "../src"
+import { BYTE_ORDER_MARK as BOM } from "@herb-tools/core"
+
+let formatter: Formatter
+
+describe("byte order mark", () => {
+  beforeAll(async () => {
+    await Herb.load()
+
+    formatter = new Formatter(Herb, { indentWidth: 2, maxLineLength: 80 })
+  })
+
+  test("removes a leading byte order mark", () => {
+    expect(formatter.format(`${BOM}<div>hello</div>`)).toEqual("<div>hello</div>")
+  })
+
+  test("removes a leading byte order mark ahead of a doctype", () => {
+    expect(formatter.format(`${BOM}<!DOCTYPE html>\n<html></html>`)).toEqual(formatter.format("<!DOCTYPE html>\n<html></html>"))
+    expect(formatter.format(`${BOM}<!DOCTYPE html>\n<html></html>`).startsWith("<!DOCTYPE")).toBe(true)
+  })
+
+  test("formats the rest of the document as if the byte order mark was not there", () => {
+    expect(formatter.format(`${BOM}<div>\n<span>hello</span>\n</div>`)).toEqual(formatter.format(`<div>\n<span>hello</span>\n</div>`))
+  })
+
+  test("removes a byte order mark from a document that is otherwise empty", () => {
+    expect(formatter.format(BOM)).toEqual("")
+  })
+
+  test("leaves a document without a byte order mark untouched", () => {
+    expect(formatter.format("<div>hello</div>")).toEqual("<div>hello</div>")
+  })
+
+  test("keeps a byte order mark that isn't at the start of the document", () => {
+    expect(formatter.format(`<div>a${BOM}b</div>`)).toEqual(`<div>a${BOM}b</div>`)
+  })
+
+  test("keeps a byte order mark inside an attribute value", () => {
+    expect(formatter.format(`<div title="a${BOM}b">hello</div>`)).toEqual(`<div title="a${BOM}b">hello</div>`)
+  })
+
+  test("keeps a byte order mark inside an ERB String literal", () => {
+    expect(formatter.format(`<div><%= "a${BOM}b" %></div>`)).toEqual(`<div><%= "a${BOM}b" %></div>`)
+  })
+
+  test("keeps the byte order mark when the document is skipped for parse errors", () => {
+    const source = `${BOM}<div>unclosed`
+    const result = formatter.formatWithResult(source)
+
+    expect(result.skipped).toEqual("parse-errors")
+    expect(result.output).toEqual(source)
+  })
+
+  test("keeps the byte order mark when the document is skipped for an ignore directive", () => {
+    const source = `${BOM}<%# herb:formatter ignore %>\n<div   >hello</div>\n`
+    const result = formatter.formatWithResult(source)
+
+    expect(result.skipped).toEqual("ignore-directive")
+    expect(result.output).toEqual(source)
+  })
+})

--- a/javascript/packages/linter/docs/rules/README.md
+++ b/javascript/packages/linter/docs/rules/README.md
@@ -44,6 +44,7 @@ This page contains documentation for all Herb Linter rules.
 #### ERB
 
 - [`erb-comment-syntax`](./erb-comment-syntax.md) - Disallow Ruby comments immediately after ERB tags
+- [`erb-no-byte-order-mark`](./erb-no-byte-order-mark.md) - Disallow a byte order mark at the start of a template
 - [`erb-no-case-node-children`](./erb-no-case-node-children.md) - Don't use `children` for `case/when` and `case/in` nodes
 - [`erb-no-commented-out-output-tags`](./erb-no-commented-out-output-tags.md) - Disallow commented-out ERB output tags (`<%#=`, `<%# =`)
 - [`erb-no-debug-output`](./erb-no-debug-output.md) - Disallow debug output methods (`p`, `pp`, `puts`, `print`, `debug`) in ERB templates

--- a/javascript/packages/linter/docs/rules/erb-no-byte-order-mark.md
+++ b/javascript/packages/linter/docs/rules/erb-no-byte-order-mark.md
@@ -1,0 +1,44 @@
+# Linter Rule: Disallow a byte order mark at the start of a template
+
+**Rule:** `erb-no-byte-order-mark`
+
+## Description
+
+Reports a UTF-8 byte order mark (`U+FEFF`, the bytes `EF BB BF`) at the very start of a template.
+
+## Rationale
+
+A byte order mark exists to record the endianness of UTF-16 and UTF-32 text. UTF-8 is a sequence of single bytes and has no endianness, so the mark carries no information there. Windows editors write it anyway as an encoding signature, and it survives in templates for years because it is zero width and nothing displays it.
+
+In a template it is not metadata, it is content. ERB copies it into the response ahead of everything else, so the document starts with an invisible character before the doctype. That can push a browser into quirks mode, break code that checks whether a response begins with `<`, and show up as unexplained whitespace at the top of a page.
+
+It also confuses tooling that pairs byte offsets with source text, because a leading `U+FEFF` is stripped by default in most UTF-8 decoders while the bytes are still counted everywhere else.
+
+The formatter removes a leading byte order mark, so `herb format` fixes this too.
+
+## Examples
+
+### ✅ Good
+
+```erb
+<!DOCTYPE html>
+<html></html>
+```
+
+A byte order mark that is genuinely part of the content is left alone:
+
+```erb
+<div>a﻿b</div>
+```
+
+### 🚫 Bad
+
+```erb
+﻿<!DOCTYPE html>
+<html></html>
+```
+
+## References
+
+- [Unicode FAQ: Byte Order Mark](https://www.unicode.org/faq/utf_bom.html#bom1)
+- [Encoding Standard: decode](https://encoding.spec.whatwg.org/#decode)

--- a/javascript/packages/linter/src/rules.ts
+++ b/javascript/packages/linter/src/rules.ts
@@ -33,6 +33,7 @@ import { ActionViewStrictLocalsFirstLineRule } from "./rules/actionview-strict-l
 import { ActionViewStrictLocalsPartialOnlyRule } from "./rules/actionview-strict-locals-partial-only.js"
 
 import { ERBCommentSyntax } from "./rules/erb-comment-syntax.js"
+import { ERBNoByteOrderMarkRule } from "./rules/erb-no-byte-order-mark.js"
 import { ERBNoCaseNodeChildrenRule } from "./rules/erb-no-case-node-children.js"
 import { ERBNoCommentedOutOutputTagsRule } from "./rules/erb-no-commented-out-output-tags.js"
 import { ERBNoDebugOutputRule } from "./rules/erb-no-debug-output.js"
@@ -178,6 +179,7 @@ export const rules: RuleClass[] = [
   ActionViewStrictLocalsPartialOnlyRule,
 
   ERBCommentSyntax,
+  ERBNoByteOrderMarkRule,
   ERBNoCaseNodeChildrenRule,
   ERBNoCommentedOutOutputTagsRule,
   ERBNoDebugOutputRule,

--- a/javascript/packages/linter/src/rules/erb-no-byte-order-mark.ts
+++ b/javascript/packages/linter/src/rules/erb-no-byte-order-mark.ts
@@ -1,0 +1,50 @@
+import { BYTE_ORDER_MARK, Location, positionFromOffset } from "@herb-tools/core"
+
+import { BaseSourceRuleVisitor } from "./rule-utils.js"
+import { SourceRule } from "../types.js"
+
+import type { UnboundLintOffense, LintOffense, LintContext, FullRuleConfig } from "../types.js"
+
+class ERBNoByteOrderMarkVisitor extends BaseSourceRuleVisitor {
+  protected visitSource(source: string): void {
+    if (!source.startsWith(BYTE_ORDER_MARK)) return
+
+    const start = positionFromOffset(source, 0)
+    const end = positionFromOffset(source, BYTE_ORDER_MARK.length)
+
+    this.addOffense(
+      "Remove the byte order mark from the start of the file. It is an encoding signature, not template content, so it renders as an invisible character ahead of everything else and can push browsers into quirks mode. Save the file as UTF-8 without a BOM.",
+      new Location(start, end),
+    )
+  }
+}
+
+export class ERBNoByteOrderMarkRule extends SourceRule {
+  static autocorrectable = true
+  static ruleName = "erb-no-byte-order-mark"
+  static introducedIn = this.version("unreleased")
+
+  get defaultConfig(): FullRuleConfig {
+    return {
+      enabled: true,
+      severity: {
+        cli: "error",
+        editor: "info",
+      }
+    }
+  }
+
+  check(source: string, context?: Partial<LintContext>): UnboundLintOffense[] {
+    const visitor = new ERBNoByteOrderMarkVisitor(this.ruleName, context)
+
+    visitor.visit(source)
+
+    return visitor.offenses
+  }
+
+  autofix(_offense: LintOffense, source: string, _context?: Partial<LintContext>): string | null {
+    if (!source.startsWith(BYTE_ORDER_MARK)) return null
+
+    return source.slice(BYTE_ORDER_MARK.length)
+  }
+}

--- a/javascript/packages/linter/src/rules/index.ts
+++ b/javascript/packages/linter/src/rules/index.ts
@@ -39,6 +39,7 @@ export * from "./actionview-strict-locals-first-line.js"
 export * from "./actionview-strict-locals-partial-only.js"
 
 export * from "./erb-comment-syntax.js"
+export * from "./erb-no-byte-order-mark.js"
 export * from "./erb-no-case-node-children.js"
 export * from "./erb-no-commented-out-output-tags.js"
 export * from "./erb-no-debug-output.js"

--- a/javascript/packages/linter/test/__snapshots__/cli.test.ts.snap
+++ b/javascript/packages/linter/test/__snapshots__/cli.test.ts.snap
@@ -19,7 +19,7 @@ test-file-with-errors.html.erb:
   Failing      2 errors (2 offenses across 1 file)
   Not failing  1 warning (1 offense across 1 file, below --fail-level=error)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        134 enabled | all rules via --all-rules"
+  Rules        135 enabled | all rules via --all-rules"
 `;
 
 exports[`CLI Output Formatting > \`all\` pseudo rule in .herb.yml > \`Rules\` summary line > \`--only\` replaces the counts from a disabled \`all\` 1`] = `
@@ -50,7 +50,7 @@ exports[`CLI Output Formatting > \`all\` pseudo rule in .herb.yml > \`Rules\` su
   Checked      1 file
   Offenses     0 offenses
   Fixable      0 offenses
-  Rules        0 enabled | 134 not enabled
+  Rules        0 enabled | 135 not enabled
 
  No rules enabled:
   Every linter rule is turned off, so no offenses can be reported.
@@ -71,7 +71,7 @@ exports[`CLI Output Formatting > \`all\` pseudo rule in .herb.yml > \`Rules\` su
   Checked      1 file
   Offenses     0 offenses
   Fixable      0 offenses
-  Rules        0 enabled | 134 not enabled
+  Rules        0 enabled | 135 not enabled
 
  No rules enabled:
   Every linter rule is turned off, so no offenses can be reported.
@@ -102,7 +102,7 @@ test-file-with-errors.html.erb:
   Failing      2 errors (2 offenses across 1 file)
   Not failing  1 warning (1 offense across 1 file, below --fail-level=error)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        134 enabled"
+  Rules        135 enabled"
 `;
 
 exports[`CLI Output Formatting > \`all\` pseudo rule in .herb.yml > \`Rules\` summary line > \`all: enabled: true\` reports no version-skipped rules 1`] = `
@@ -124,7 +124,7 @@ test-file-with-errors.html.erb:
   Failing      2 errors (2 offenses across 1 file)
   Not failing  1 warning (1 offense across 1 file, below --fail-level=error)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        134 enabled"
+  Rules        135 enabled"
 `;
 
 exports[`CLI Output Formatting > \`all\` pseudo rule in .herb.yml > \`Rules\` summary line > reports enabled and not-enabled rules when no \`all\` is configured 1`] = `
@@ -146,7 +146,7 @@ test/fixtures/test-file-with-errors.html.erb:
   Failing      2 errors (2 offenses across 1 file)
   Not failing  1 warning (1 offense across 1 file, below --fail-level=error)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        113 enabled | 21 not enabled"
+  Rules        114 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > \`all\` pseudo rule in .herb.yml > \`Rules\` summary line > rules opted back in on top of \`all: enabled: false\` count as enabled 1`] = `
@@ -165,7 +165,7 @@ test-file-with-errors.html.erb:
   Failing      0 offenses
   Not failing  1 warning (1 offense across 1 file, below --fail-level=error)
   Fixable      0 offenses
-  Rules        1 enabled | 133 not enabled"
+  Rules        1 enabled | 134 not enabled"
 `;
 
 exports[`CLI Output Formatting > \`all\` pseudo rule in .herb.yml > \`Rules\` summary line > rules opted out on top of \`all: enabled: true\` count as disabled 1`] = `
@@ -184,7 +184,7 @@ test-file-with-errors.html.erb:
   Checked      1 file
   Offenses     2 errors (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        133 enabled | 1 disabled"
+  Rules        134 enabled | 1 disabled"
 `;
 
 exports[`CLI Output Formatting > --all-rules > reports every offense for the fixture with --all-rules 1`] = `
@@ -214,7 +214,7 @@ test/fixtures/all-rules.html.erb:
   Failing      0 offenses
   Not failing  6 warnings (6 offenses across 1 file, below --fail-level=error)
   Fixable      0 offenses
-  Rules        134 enabled | all rules via --all-rules"
+  Rules        135 enabled | all rules via --all-rules"
 `;
 
 exports[`CLI Output Formatting > --all-rules > reports nothing for the fixture with the default rule set 1`] = `
@@ -226,7 +226,7 @@ exports[`CLI Output Formatting > --all-rules > reports nothing for the fixture w
   Checked      1 file
   Offenses     0 offenses
   Fixable      0 offenses
-  Rules        113 enabled | 21 not enabled"
+  Rules        114 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > --ignore-disable-comments 1`] = `
@@ -377,7 +377,7 @@ test/fixtures/ignored.html.erb:8:8
   Not failing  2 warnings (2 offenses across 1 file, below --fail-level=error)
   Note         3 additional offenses reported (would have been ignored)
   Fixable      7 offenses | 4 autocorrectable using \`--fix\`
-  Rules        113 enabled | 21 not enabled"
+  Rules        114 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > --log-level > counts the hidden offenses and suggests the level that reveals them 1`] = `
@@ -395,7 +395,7 @@ exports[`CLI Output Formatting > --log-level > counts the hidden offenses and su
   Not failing  2 info | 1 hint (3 offenses across 1 file, below --fail-level=error)
   Not shown    3 offenses hidden, show them with --log-level=hint
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        113 enabled | 21 not enabled"
+  Rules        114 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > --log-level > doesn't report offenses below the given level 1`] = `
@@ -412,7 +412,7 @@ exports[`CLI Output Formatting > --log-level > doesn't report offenses below the
   Not failing  1 hint (1 offense across 1 file, below --fail-level=error)
   Not shown    1 offense hidden, show it with --log-level=hint
   Fixable      0 offenses
-  Rules        112 enabled | 21 not enabled | 1 disabled"
+  Rules        113 enabled | 21 not enabled | 1 disabled"
 `;
 
 exports[`CLI Output Formatting > --log-level > prefers the CLI flag over the config file 1`] = `
@@ -431,7 +431,7 @@ test-file-with-errors.html.erb:
   Failing      0 offenses
   Not failing  1 hint (1 offense across 1 file, below --fail-level=error)
   Fixable      0 offenses
-  Rules        112 enabled | 21 not enabled | 1 disabled"
+  Rules        113 enabled | 21 not enabled | 1 disabled"
 `;
 
 exports[`CLI Output Formatting > --log-level > reads logLevel from the config file 1`] = `
@@ -448,7 +448,7 @@ exports[`CLI Output Formatting > --log-level > reads logLevel from the config fi
   Not failing  1 hint (1 offense across 1 file, below --fail-level=error)
   Not shown    1 offense hidden, show it with --log-level=hint
   Fixable      0 offenses
-  Rules        112 enabled | 21 not enabled | 1 disabled"
+  Rules        113 enabled | 21 not enabled | 1 disabled"
 `;
 
 exports[`CLI Output Formatting > --log-level > still counts hidden offenses towards the exit code 1`] = `
@@ -464,7 +464,7 @@ exports[`CLI Output Formatting > --log-level > still counts hidden offenses towa
   Offenses     1 hint (1 offense across 1 file)
   Not shown    1 offense hidden, show it with --log-level=hint
   Fixable      0 offenses
-  Rules        112 enabled | 21 not enabled | 1 disabled"
+  Rules        113 enabled | 21 not enabled | 1 disabled"
 `;
 
 exports[`CLI Output Formatting > --log-level > still reports offenses at or above the given level 1`] = `
@@ -483,7 +483,7 @@ test-file-with-errors.html.erb:
   Failing      0 offenses
   Not failing  1 hint (1 offense across 1 file, below --fail-level=error)
   Fixable      0 offenses
-  Rules        112 enabled | 21 not enabled | 1 disabled"
+  Rules        113 enabled | 21 not enabled | 1 disabled"
 `;
 
 exports[`CLI Output Formatting > --log-level > with --all-rules > keeps the log level when it is passed explicitly 1`] = `
@@ -505,7 +505,7 @@ test-file-with-errors.html.erb:
   Not failing  1 hint (1 offense across 1 file, below --fail-level=error)
   Not shown    1 offense hidden, show it with --log-level=hint
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        134 enabled | all rules via --all-rules"
+  Rules        135 enabled | all rules via --all-rules"
 `;
 
 exports[`CLI Output Formatting > --log-level > with --all-rules > lowers the log level to report the rules it was asked for 1`] = `
@@ -528,7 +528,7 @@ test-file-with-errors.html.erb:
   Not failing  1 hint (1 offense across 1 file, below --fail-level=error)
   Log level    hint | lowered from warning by --all-rules
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        134 enabled | all rules via --all-rules"
+  Rules        135 enabled | all rules via --all-rules"
 `;
 
 exports[`CLI Output Formatting > --log-level > with --only > keeps the log level when it is passed explicitly 1`] = `
@@ -689,7 +689,7 @@ test/fixtures/test-file-with-errors.html.erb:2:22
   Failing      2 errors (2 offenses across 1 file)
   Not failing  1 warning (1 offense across 1 file, below --fail-level=error)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        113 enabled | 21 not enabled"
+  Rules        114 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > GitHub Actions format includes rule codes 1`] = `
@@ -721,7 +721,7 @@ test/fixtures/no-trailing-newline.html.erb:1:29
   Checked      1 file
   Offenses     1 error (1 offense across 1 file)
   Fixable      1 offense | 1 autocorrectable using \`--fix\`
-  Rules        113 enabled | 21 not enabled"
+  Rules        114 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > GitHub Actions format includes rule codes 2`] = `
@@ -826,7 +826,7 @@ test/fixtures/erb-no-extra-whitespace-inside-tags.html.erb:1:4
   Failing      4 errors (4 offenses across 1 file)
   Not failing  1 info (1 offense across 1 file, below --fail-level=error)
   Fixable      5 offenses | 3 autocorrectable using \`--fix\`
-  Rules        113 enabled | 21 not enabled"
+  Rules        114 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > Ignores disabled rules 1`] = `
@@ -886,7 +886,7 @@ test/fixtures/ignored.html.erb:6:14
   Offenses     2 errors (2 offenses across 1 file)
   Ignored      3 offenses suppressed with herb:disable
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        113 enabled | 21 not enabled"
+  Rules        114 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > allows tag.attributes in attribute position 1`] = `
@@ -946,7 +946,7 @@ test/fixtures/tag-attributes.html.erb:5:0
   Failing      0 offenses
   Not failing  2 warnings (2 offenses across 1 file, below --fail-level=error)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        113 enabled | 21 not enabled"
+  Rules        114 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > diplays only parsers errors if one is present 1`] = `
@@ -972,7 +972,7 @@ test/fixtures/parser-errors.html.erb:2:16
   Checked      1 file
   Offenses     1 error (1 offense across 1 file)
   Fixable      0 offenses
-  Rules        113 enabled | 21 not enabled"
+  Rules        114 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > displays most violated rules with multiple offenses 1`] = `
@@ -1224,7 +1224,7 @@ test/fixtures/multiple-rule-offenses.html.erb:4:7
   Failing      8 errors (8 offenses across 1 file)
   Not failing  6 warnings (6 offenses across 1 file, below --fail-level=error)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        113 enabled | 21 not enabled"
+  Rules        114 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > displays rule offenses when showing all rules 1`] = `
@@ -1349,7 +1349,7 @@ test/fixtures/few-rule-offenses.html.erb:6:0
   Failing      4 errors (4 offenses across 1 file)
   Not failing  2 warnings (2 offenses across 1 file, below --fail-level=error)
   Fixable      6 offenses | 3 autocorrectable using \`--fix\`
-  Rules        113 enabled | 21 not enabled"
+  Rules        114 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats GitHub Actions output correctly for bad file 1`] = `
@@ -1404,7 +1404,7 @@ test/fixtures/bad-file.html.erb:1:16
   Checked      1 file
   Offenses     2 errors (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        113 enabled | 21 not enabled"
+  Rules        114 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats GitHub Actions output correctly for clean file 1`] = `
@@ -1416,7 +1416,7 @@ exports[`CLI Output Formatting > formats GitHub Actions output correctly for cle
   Checked      1 file
   Offenses     0 offenses
   Fixable      0 offenses
-  Rules        113 enabled | 21 not enabled"
+  Rules        114 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats GitHub Actions output correctly for file with errors 1`] = `
@@ -1495,7 +1495,7 @@ test/fixtures/test-file-with-errors.html.erb:2:22
   Failing      2 errors (2 offenses across 1 file)
   Not failing  1 warning (1 offense across 1 file, below --fail-level=error)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        113 enabled | 21 not enabled"
+  Rules        114 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats GitHub Actions output with --format=github option 1`] = `
@@ -1552,7 +1552,7 @@ test/fixtures/test-file-simple.html.erb:2:22
   Checked      1 file
   Offenses     2 errors (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        113 enabled | 21 not enabled"
+  Rules        114 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats JSON output correctly for bad file 1`] = `
@@ -1599,7 +1599,7 @@ exports[`CLI Output Formatting > formats JSON output correctly for bad file 1`] 
   "summary": {
     "filesChecked": 1,
     "filesWithOffenses": 1,
-    "ruleCount": 113,
+    "ruleCount": 114,
     "totalErrors": 2,
     "totalHints": 0,
     "totalIgnored": 0,
@@ -1621,7 +1621,7 @@ exports[`CLI Output Formatting > formats JSON output correctly for clean file 1`
   "summary": {
     "filesChecked": 1,
     "filesWithOffenses": 0,
-    "ruleCount": 113,
+    "ruleCount": 114,
     "totalErrors": 0,
     "totalHints": 0,
     "totalIgnored": 0,
@@ -1695,7 +1695,7 @@ exports[`CLI Output Formatting > formats JSON output correctly for file with err
   "summary": {
     "filesChecked": 1,
     "filesWithOffenses": 1,
-    "ruleCount": 113,
+    "ruleCount": 114,
     "totalErrors": 2,
     "totalHints": 0,
     "totalIgnored": 0,
@@ -1778,7 +1778,7 @@ test/fixtures/test-file-with-errors.html.erb:2:22
   Failing      2 errors (2 offenses across 1 file)
   Not failing  1 warning (1 offense across 1 file, below --fail-level=error)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        113 enabled | 21 not enabled"
+  Rules        114 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats simple output correctly 1`] = `
@@ -1797,7 +1797,7 @@ test/fixtures/test-file-simple.html.erb:
   Checked      1 file
   Offenses     2 errors (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        113 enabled | 21 not enabled"
+  Rules        114 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats simple output for bad-file correctly 1`] = `
@@ -1816,7 +1816,7 @@ test/fixtures/bad-file.html.erb:
   Checked      1 file
   Offenses     2 errors (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        113 enabled | 21 not enabled"
+  Rules        114 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > formats success output correctly 1`] = `
@@ -1828,7 +1828,7 @@ exports[`CLI Output Formatting > formats success output correctly 1`] = `
   Checked      1 file
   Offenses     0 offenses
   Fixable      0 offenses
-  Rules        113 enabled | 21 not enabled"
+  Rules        114 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > handles boolean attributes 1`] = `
@@ -1840,7 +1840,7 @@ exports[`CLI Output Formatting > handles boolean attributes 1`] = `
   Checked      1 file
   Offenses     0 offenses
   Fixable      0 offenses
-  Rules        113 enabled | 21 not enabled"
+  Rules        114 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > handles multiple errors correctly 1`] = `
@@ -1891,7 +1891,7 @@ test/fixtures/bad-file.html.erb:1:16
   Checked      1 file
   Offenses     2 errors (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        113 enabled | 21 not enabled"
+  Rules        114 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > herb:disable rules 1`] = `
@@ -2034,7 +2034,7 @@ test/fixtures/disabled-1.html.erb:14:19
   Not failing  6 warnings (6 offenses across 1 file, below --fail-level=error)
   Ignored      8 offenses suppressed with herb:disable
   Fixable      8 offenses | 1 autocorrectable using \`--fix\`
-  Rules        113 enabled | 21 not enabled"
+  Rules        114 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > herb:disable rules 2`] = `
@@ -2293,7 +2293,7 @@ test/fixtures/disabled-2.html.erb:2:44
   Not failing  7 warnings (7 offenses across 1 file, below --fail-level=error)
   Ignored      5 offenses suppressed with herb:disable
   Fixable      13 offenses | 6 autocorrectable using \`--fix\`
-  Rules        113 enabled | 21 not enabled"
+  Rules        114 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > missing \`framework\` option > reports the missing option per template 1`] = `
@@ -2312,7 +2312,7 @@ clean-file.html.erb:
   Failing      0 offenses
   Not failing  1 info (1 offense across 1 file, below --fail-level=error)
   Fixable      0 offenses
-  Rules        1 enabled | 133 not enabled"
+  Rules        1 enabled | 134 not enabled"
 `;
 
 exports[`CLI Output Formatting > non-failing offenses tip > points at --log-level when many offenses don't fail the build 1`] = `
@@ -2350,7 +2350,7 @@ multiple-rule-offenses.html.erb:
   Failing      3 errors (3 offenses across 1 file)
   Not failing  1 info | 10 hints (11 offenses across 1 file, below --fail-level=error)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        113 enabled | 21 not enabled
+  Rules        114 enabled | 21 not enabled
 
  TIP: 11 of the logged offenses don't fail the build.
       Run herb-lint --log-level=error to stop logging them, or set linter.logLevel in your .herb.yml.
@@ -2382,7 +2382,7 @@ multiple-rule-offenses.html.erb:
   Not failing  1 info | 10 hints (11 offenses across 1 file, below --fail-level=error)
   Not shown    11 offenses hidden, show them with --log-level=hint
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        113 enabled | 21 not enabled"
+  Rules        114 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > non-failing offenses tip > stays quiet when --log-level is passed explicitly, even when it hides nothing 1`] = `
@@ -2420,7 +2420,7 @@ multiple-rule-offenses.html.erb:
   Failing      3 errors (3 offenses across 1 file)
   Not failing  1 info | 10 hints (11 offenses across 1 file, below --fail-level=error)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        113 enabled | 21 not enabled"
+  Rules        114 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > non-failing offenses tip > stays quiet when logLevel is set in the config file 1`] = `
@@ -2458,7 +2458,7 @@ multiple-rule-offenses.html.erb:
   Failing      3 errors (3 offenses across 1 file)
   Not failing  1 info | 10 hints (11 offenses across 1 file, below --fail-level=error)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        113 enabled | 21 not enabled"
+  Rules        114 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > non-failing offenses tip > stays quiet when only a handful of offenses don't fail the build 1`] = `
@@ -2496,7 +2496,7 @@ multiple-rule-offenses.html.erb:
   Failing      8 errors (8 offenses across 1 file)
   Not failing  6 warnings (6 offenses across 1 file, below --fail-level=error)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        113 enabled | 21 not enabled"
+  Rules        114 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > points at the flag instead of previewing once there are too many corrections 1`] = `
@@ -2592,7 +2592,7 @@ test/fixtures/test-file-simple.html.erb:2:22
   Checked      1 file
   Offenses     2 errors (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        113 enabled | 21 not enabled"
+  Rules        114 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > previews the correction under each correctable offense 1`] = `
@@ -2649,7 +2649,7 @@ test/fixtures/test-file-simple.html.erb:2:22
   Checked      1 file
   Offenses     2 errors (2 offenses across 1 file)
   Fixable      2 offenses | 2 autocorrectable using \`--fix\`
-  Rules        113 enabled | 21 not enabled"
+  Rules        114 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > summary offense buckets > groups every severity into one line when --fail-level is hint 1`] = `
@@ -2686,7 +2686,7 @@ test/fixtures/multiple-rule-offenses.html.erb:
   Checked      1 file
   Offenses     8 errors | 6 warnings (14 offenses across 1 file)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        113 enabled | 21 not enabled"
+  Rules        114 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > summary offense buckets > groups every severity into one line when --fail-level is info 1`] = `
@@ -2723,7 +2723,7 @@ test/fixtures/multiple-rule-offenses.html.erb:
   Checked      1 file
   Offenses     8 errors | 6 warnings (14 offenses across 1 file)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        113 enabled | 21 not enabled"
+  Rules        114 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > summary offense buckets > groups every severity into one line when --fail-level is warning 1`] = `
@@ -2760,7 +2760,7 @@ test/fixtures/multiple-rule-offenses.html.erb:
   Checked      1 file
   Offenses     8 errors | 6 warnings (14 offenses across 1 file)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        113 enabled | 21 not enabled"
+  Rules        114 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > summary offense buckets > moves a severity between buckets as --fail-level is lowered 1`] = `
@@ -2798,7 +2798,7 @@ multiple-rule-offenses.html.erb:
   Failing      8 errors | 4 warnings | 1 info (13 offenses across 1 file)
   Not failing  1 hint (1 offense across 1 file, below --fail-level=info)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        113 enabled | 21 not enabled"
+  Rules        114 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > summary offense buckets > splits the buckets when only some severities fail the build 1`] = `
@@ -2836,7 +2836,7 @@ multiple-rule-offenses.html.erb:
   Failing      8 errors | 4 warnings (12 offenses across 1 file)
   Not failing  1 info | 1 hint (2 offenses across 1 file, below --fail-level=warning)
   Fixable      14 offenses | 4 autocorrectable using \`--fix\`
-  Rules        113 enabled | 21 not enabled"
+  Rules        114 enabled | 21 not enabled"
 `;
 
 exports[`CLI Output Formatting > unsafe autocorrectable offenses > counts and tags them separately from offenses --fix can correct 1`] = `
@@ -2956,5 +2956,5 @@ test/fixtures/test-file-with-errors.html.erb:2:22
   Failing      2 errors (2 offenses across 1 file)
   Not failing  1 warning (1 offense across 1 file, below --fail-level=error)
   Fixable      3 offenses | 2 autocorrectable using \`--fix\`
-  Rules        113 enabled | 21 not enabled"
+  Rules        114 enabled | 21 not enabled"
 `;

--- a/javascript/packages/linter/test/autofix/erb-no-byte-order-mark.autofix.test.ts
+++ b/javascript/packages/linter/test/autofix/erb-no-byte-order-mark.autofix.test.ts
@@ -1,0 +1,47 @@
+import { describe, test, expect, beforeAll } from "vitest"
+
+import { Herb } from "@herb-tools/node-wasm"
+import { Linter } from "../../src/linter.js"
+
+import { ERBNoByteOrderMarkRule } from "../../src/rules/erb-no-byte-order-mark.js"
+import { BYTE_ORDER_MARK as BOM } from "@herb-tools/core"
+
+describe("erb-no-byte-order-mark autofix", () => {
+  beforeAll(async () => {
+    await Herb.load()
+  })
+
+  test("removes a leading byte order mark", () => {
+    const linter = new Linter(Herb, [ERBNoByteOrderMarkRule])
+    const result = linter.autofix(`${BOM}<div>hello</div>\n`, { fileName: "test.html.erb" })
+
+    expect(result.source).toBe("<div>hello</div>\n")
+    expect(result.fixed).toHaveLength(1)
+    expect(result.unfixed).toHaveLength(0)
+  })
+
+  test("leaves the rest of the document untouched", () => {
+    const linter = new Linter(Herb, [ERBNoByteOrderMarkRule])
+    const result = linter.autofix(`${BOM}<div>a${BOM}b</div>\n`, { fileName: "test.html.erb" })
+
+    expect(result.source).toBe(`<div>a${BOM}b</div>\n`)
+    expect(result.fixed).toHaveLength(1)
+  })
+
+  test("removes only one byte order mark per pass", () => {
+    const linter = new Linter(Herb, [ERBNoByteOrderMarkRule])
+    const result = linter.autofix(`${BOM}${BOM}<div>hello</div>\n`, { fileName: "test.html.erb" })
+
+    expect(result.source).toBe(`${BOM}<div>hello</div>\n`)
+    expect(result.fixed).toHaveLength(1)
+  })
+
+  test("does not modify a document without a byte order mark", () => {
+    const linter = new Linter(Herb, [ERBNoByteOrderMarkRule])
+    const result = linter.autofix("<div>hello</div>\n", { fileName: "test.html.erb" })
+
+    expect(result.source).toBe("<div>hello</div>\n")
+    expect(result.fixed).toHaveLength(0)
+    expect(result.unfixed).toHaveLength(0)
+  })
+})

--- a/javascript/packages/linter/test/rules/erb-no-byte-order-mark.test.ts
+++ b/javascript/packages/linter/test/rules/erb-no-byte-order-mark.test.ts
@@ -1,0 +1,70 @@
+import dedent from "dedent"
+
+import { describe, test } from "vitest"
+
+import { ERBNoByteOrderMarkRule } from "../../src/rules/erb-no-byte-order-mark.js"
+import { createLinterTest } from "../helpers/linter-test-helper.js"
+import { BYTE_ORDER_MARK as BOM } from "@herb-tools/core"
+
+const { expectNoOffenses, expectError, assertOffenses } = createLinterTest(ERBNoByteOrderMarkRule)
+const MESSAGE = "Remove the byte order mark from the start of the file. It is an encoding signature, not template content, so it renders as an invisible character ahead of everything else and can push browsers into quirks mode. Save the file as UTF-8 without a BOM."
+
+describe("ERBNoByteOrderMarkRule", () => {
+  test("should not report errors for a file without a byte order mark", () => {
+    expectNoOffenses(dedent`
+      <div>
+        <%= title %>
+      </div>
+    ` + "\n")
+  })
+
+  test("should not report errors for an empty file", () => {
+    expectNoOffenses("")
+  })
+
+  test("should not report errors for a byte order mark that is not at the start of the file", () => {
+    expectNoOffenses(`<div>a${BOM}b</div>\n`)
+  })
+
+  test("should not report errors for a byte order mark inside an attribute value", () => {
+    expectNoOffenses(`<div title="a${BOM}b">hello</div>\n`)
+  })
+
+  test("should not report errors for a byte order mark inside an ERB String literal", () => {
+    expectNoOffenses(`<div><%= "a${BOM}b" %></div>\n`)
+  })
+
+  test("should not report errors for a leading non-breaking space", () => {
+    expectNoOffenses(` <div>hello</div>\n`)
+  })
+
+  test("should report an error for a leading byte order mark", () => {
+    expectError(MESSAGE, { line: 1, column: 0 })
+
+    assertOffenses(`${BOM}<div>hello</div>\n`)
+  })
+
+  test("should report an error for a byte order mark ahead of a doctype", () => {
+    expectError(MESSAGE, { line: 1, column: 0 })
+
+    assertOffenses(`${BOM}<!DOCTYPE html>\n<html></html>\n`)
+  })
+
+  test("should report an error for a byte order mark ahead of an ERB tag", () => {
+    expectError(MESSAGE, { line: 1, column: 0 })
+
+    assertOffenses(`${BOM}<%= render "header" %>\n`)
+  })
+
+  test("should report a single error for a file with two leading byte order marks", () => {
+    expectError(MESSAGE, { line: 1, column: 0 })
+
+    assertOffenses(`${BOM}${BOM}<div>hello</div>\n`)
+  })
+
+  test("should report an error for a file containing only a byte order mark", () => {
+    expectError(MESSAGE, { line: 1, column: 0 })
+
+    assertOffenses(BOM)
+  })
+})


### PR DESCRIPTION
This pull request implements `erb-no-byte-order-mark`, which reports a UTF-8 byte order mark at the start of a template and removes it with `--fix`.

The mark is invisible, so it is easiest to show as bytes. This is a real file from `marcoroth/herb-corpus`:

```
$ xxd -l 16 app/views/pages/funding_partners.html.erb
00000000: efbb bf3c 6469 7620 636c 6173 733d 2263  ...<div class="c
```

Those first three bytes are `U+FEFF`. In a template it is not metadata, it is content. ERB copies it into the response ahead of everything else, so the document starts with an invisible character before the doctype. That can push a browser into quirks mode and breaks code that checks whether a response begins with `<`.

The formatter is updated to match the behavior the rule asks for.