### PR TITLE
Engine: Add `HTMLSafeAssertionsVisitor` and parser option requirements

### DIFF
--- a/docs/docs/projects/engine.md
+++ b/docs/docs/projects/engine.md
@@ -91,6 +91,7 @@ Herb ships the following transform visitors:
 |-------------------------------|--------------------------------------------------------------|
 | `AutoCloseOmittedTagsVisitor` | Replaces omitted closing tags with explicit ones             |
 | `ContentForVisitor`           | Appends HTML to the end of every matching element            |
+| `HTMLSafeAssertionsVisitor`   | Checks every `.html_safe` call at runtime                    |
 | `ComponentVisitor`            | Rewrites capitalized tags into `render` calls (experimental) |
 
 Transform visitors are not loaded when you `require "herb"`. Require the ones you want and pass them to the engine:
@@ -102,6 +103,37 @@ Herb::Engine.new(source, visitors: [Herb::Engine::AutoCloseOmittedTagsVisitor.ne
 ```
 
 Your own visitors are passed the same way. See [Visitors](/bindings/ruby/reference#visitors) for how to write one.
+
+A visitor that needs the AST to carry more than the defaults can say so with `required_parser_option`, and one that only works better that way with `recommended_parser_option`:
+
+```ruby
+class PrismProgramVisitor < Herb::Visitor
+  required_parser_option prism_program: true
+  recommended_parser_option strict: false
+end
+```
+
+The engine turns both on before it parses, so passing the visitor is all it takes. What differs is how a conflict with the [parser options](/parser-options) passed to the engine is settled:
+
+| Declaration                  | Option not passed to the engine | Passed with the same value | Passed with a different value                |
+|------------------------------|---------------------------------|----------------------------|----------------------------------------------|
+| `required_parser_option`     | The engine turns it on          | Nothing to settle          | Raises `ArgumentError`                       |
+| `recommended_parser_option`  | The engine turns it on          | Nothing to settle          | Warns, and the value passed to the engine wins |
+
+A requirement raises because a visitor that doesn't get it can't do its work, and silently overriding what you asked for would be worse than saying so. Two visitors requiring the same option differently raises for the same reason.
+
+Every declaration adds to the ones a parent class made, and a subclass can override an inherited value by declaring it again. `required_parser_options` and `recommended_parser_options` return what a visitor ends up asking for.
+
+Both declarations come from `Herb::Visitor::ParserOptionRequirements`, which `Herb::Visitor` includes. A class that is passed to the engine as a visitor without inheriting from `Herb::Visitor` can include it as well.
+
+The engine settles this through `Herb::Visitor.parser_options_for`, which takes the visitors and the options to start from and returns what to parse with. Anything else that runs a set of visitors over a document it parses itself can use it the same way:
+
+```ruby
+parser_options = Herb::Visitor.parser_options_for(visitors, strict: false)
+result = Herb.parse(source, **parser_options)
+
+visitors.each { |visitor| result.visit(visitor) }
+```
 
 ### `AutoCloseOmittedTagsVisitor`
 
@@ -179,6 +211,93 @@ The engine renders:
 ```
 
 The content is emitted as a Ruby string literal marked `html_safe`, so it is never escaped, and quotes, backslashes and `#{}` in it are not interpreted.
+
+### `HTMLSafeAssertionsVisitor`
+
+Wraps the receiver of every `.html_safe` call in a template with a runtime assertion, so that marking a value as HTML-safe raises when the value contains HTML that the browser executes.
+
+```ruby
+require "herb/engine/html_safe_assertions_visitor"
+
+Herb::Engine.new(source, visitors: [Herb::Engine::HTMLSafeAssertionsVisitor.new])
+```
+
+This template:
+
+```html+erb
+<div><%= @user.bio.html_safe %></div>
+```
+
+Compiles as if it had been written as:
+
+```html+erb
+<div><%= ::Herb::Engine::HTMLSafeAssertions.check(@user.bio, file: __FILE__, line: 1, column: 6, source: "<%= @user.bio.html_safe %>", mode: :raise).html_safe %></div>
+```
+
+The value keeps flowing through `.html_safe` unchanged, and the assertion runs on every render. A value that is already HTML-safe is never checked, since `.html_safe` is a no-op on it.
+
+The calls are found in the Prism program that the [`prism_program`](/parser-options) parser option attaches to the document, so a call is wrapped wherever it appears, including in control flow such as `<% elsif b.html_safe %>`. Calls inside an ERB comment are not wrapped, since they are not part of the program. The visitor declares the option through `required_parser_option`, which the engine turns on for it. Parsing an AST for this visitor by hand needs the same option:
+
+```ruby
+Herb.parse(source, prism_program: true)
+```
+
+The error surfaces while the template renders, not while it compiles, unlike the ones the [validators](#validators) raise. Rendering the template with a bio of `<script>alert(1)</script>` raises `Herb::Engine::HTMLSafeAssertions::UnsafeHTMLError`:
+
+```
+Unsafe `.html_safe` call in app/views/users/show.html.erb:1:6
+
+    <%= @user.bio.html_safe %>
+
+The value contains a `<script>` element, which the browser executes.
+
+    "<script>alert(1)</script>"
+
+Escape the value or run it through `sanitize` instead of marking it as HTML-safe.
+```
+
+The value is checked against these heuristics:
+
+| Check            | Reports                                                           |
+|------------------|-------------------------------------------------------------------|
+| `script_element` | A `<script>` element                                              |
+| `event_handler`  | An inline event handler attribute, such as `onerror` or `onclick` |
+| `javascript_url` | A `javascript:` or `vbscript:` URL                                |
+| `data_url`       | A `data:text/html` URL                                            |
+| `risky_element`  | An `<iframe>`, `<object>`, `<embed>`, `<base>` or `<portal>`      |
+| `meta_refresh`   | A `<meta http-equiv="refresh">` element                           |
+
+The visitor takes the following options:
+
+| Option      | Default  | Description                                                                             |
+|-------------|----------|-----------------------------------------------------------------------------------------|
+| `mode`      | `:raise` | `:raise` raises on a violation, `:warn` warns and keeps rendering                       |
+| `ignore`    | `[]`     | Checks to skip, given by name                                                           |
+| `file_path` | `nil`    | Path baked into the assertion. Defaults to `__FILE__`, which Rails sets to the template |
+
+```ruby
+Herb::Engine::HTMLSafeAssertionsVisitor.new(mode: :warn, ignore: [:risky_element])
+```
+
+Set `on_violation` to report violations somewhere else instead of raising or warning. It receives the same error object, and is consulted before `mode`:
+
+```ruby
+Herb::Engine::HTMLSafeAssertions.on_violation = ->(error) do
+  ErrorTracking.capture_exception(error)
+end
+```
+
+`.html_safe` passed as a block argument has no receiver to wrap, so the symbol becomes a block that checks every element it is called with:
+
+```html+erb
+<%= items.map(&:html_safe).join %>
+```
+
+```html+erb
+<%= items.map(&proc { |value| ::Herb::Engine::HTMLSafeAssertions.check(value, ...).html_safe }).join %>
+```
+
+Since the assertions run on every render, this visitor is meant for development and test environments. In production, either leave it out or run it with `mode: :warn`.
 
 ### `ComponentVisitor`
 

--- a/lib/herb/engine.rb
+++ b/lib/herb/engine.rb
@@ -99,6 +99,8 @@ module Herb
         @visitors << debug_visitor
       end
 
+      @parser_options = Herb::Visitor.parser_options_for(@visitors, @parser_options)
+
       unless [:raise, :overlay, :none].include?(@validation_mode)
         raise ArgumentError,
               "validation_mode must be one of :raise, :overlay, or :none, got #{@validation_mode.inspect}"

--- a/lib/herb/engine/html_safe_assertions.rb
+++ b/lib/herb/engine/html_safe_assertions.rb
@@ -1,0 +1,226 @@
+# frozen_string_literal: true
+# typed: false
+
+module Herb
+  class Engine
+    # Runtime counterpart of `Herb::Engine::HTMLSafeAssertionsVisitor`.
+    #
+    # `check` inspects the value a template is about to mark as HTML-safe and reports it when
+    # the value contains HTML that the browser executes, such as a `<script>` element, an
+    # inline event handler, or a `javascript:` URL. It returns the value unchanged, so it can
+    # wrap any expression.
+    #
+    # Values that are already HTML-safe are left alone, since `.html_safe` is a no-op on them.
+    #
+    # The checks are heuristics over the string. They catch the payloads that reach templates
+    # through unescaped user input, not every possible way to write HTML that executes.
+    module HTMLSafeAssertions
+      MODES = [:raise, :warn].freeze
+
+      MAX_VALUE_LENGTH = 200
+
+      EVENT_HANDLER_NAMES = [
+        "abort", "animationcancel", "animationend", "animationiteration", "animationstart",
+        "auxclick", "beforeinput", "beforematch", "beforeprint", "beforetoggle", "beforeunload",
+        "blur", "cancel", "canplay", "canplaythrough", "change", "click", "close", "command",
+        "contextmenu", "copy", "cuechange", "cut", "dblclick", "drag", "dragend", "dragenter",
+        "dragleave", "dragover", "dragstart", "drop", "durationchange", "emptied", "ended",
+        "error", "focus", "focusin", "focusout", "formdata", "fullscreenchange",
+        "fullscreenerror", "gotpointercapture", "hashchange", "input", "invalid", "keydown",
+        "keypress", "keyup", "load", "loadeddata", "loadedmetadata", "loadstart",
+        "lostpointercapture", "message", "messageerror", "mousedown", "mouseenter", "mouseleave",
+        "mousemove", "mouseout", "mouseover", "mouseup", "offline", "online", "pagehide",
+        "pageshow", "paste", "pause", "play", "playing", "pointercancel", "pointerdown",
+        "pointerenter", "pointerleave", "pointermove", "pointerout", "pointerover",
+        "pointerrawupdate", "pointerup", "popstate", "progress", "ratechange", "reset", "resize",
+        "scroll", "scrollend", "search", "securitypolicyviolation", "seeked", "seeking", "select",
+        "selectionchange", "selectstart", "show", "slotchange", "stalled", "storage", "submit",
+        "suspend", "timeupdate", "toggle", "touchcancel", "touchend", "touchmove", "touchstart",
+        "transitioncancel", "transitionend", "transitionrun", "transitionstart",
+        "unhandledrejection", "unload", "volumechange", "waiting", "wheel"
+      ].freeze
+
+      EVENT_HANDLER_PATTERN = %r{<[a-z][^<>]*?[\s/](on(?:#{EVENT_HANDLER_NAMES.join("|")}))\s*=}im
+
+      class Violation
+        attr_reader :name #: Symbol
+        attr_reader :message #: String
+        attr_reader :snippet #: String
+
+        #: (Symbol, String, String) -> void
+        def initialize(name, message, snippet)
+          @name = name
+          @message = message
+          @snippet = snippet
+        end
+
+        #: () -> String
+        def inspect
+          "#<#{self.class.name} name=#{@name.inspect} snippet=#{@snippet.inspect}>"
+        end
+      end
+
+      class Check
+        attr_reader :name #: Symbol
+        attr_reader :requires #: Symbol
+        attr_reader :pattern #: Regexp
+        attr_reader :message #: String
+
+        #: (Symbol, Symbol, Regexp, String) -> void
+        def initialize(name, requires, pattern, message)
+          @name = name
+          @requires = requires
+          @pattern = pattern
+          @message = message
+        end
+
+        #: (String) -> Violation?
+        def violation_for(string)
+          return nil unless @pattern.match?(string)
+
+          match = @pattern.match(string)
+
+          return nil unless match
+
+          Violation.new(@name, message_for(match), match[0].to_s)
+        end
+
+        private
+
+        #: (MatchData) -> String
+        def message_for(match)
+          return @message unless @message.include?("%s")
+
+          format(@message, (match[1] || match[0]).to_s.downcase)
+        end
+      end
+
+      CHECKS = [
+        Check.new(:script_element, :markup, /<script\b/i, "a `<script>` element, which the browser executes"),
+        Check.new(:event_handler, :markup, EVENT_HANDLER_PATTERN, "an inline `%s` event handler, which the browser executes"),
+        Check.new(:javascript_url, :scheme, /(?:\A|=|["'])\s*(javascript|vbscript)\s*:/i, "a `%s:` URL, which the browser executes"),
+        Check.new(:data_url, :scheme, %r{(?:\A|=|["'])\s*data\s*:\s*text/html}i, "a `data:text/html` URL, which the browser renders as its own document"),
+        Check.new(:risky_element, :markup, /<(iframe|object|embed|base|portal)\b/i, "an `<%s>` element, which can load and run remote content"),
+        Check.new(:meta_refresh, :markup, /<meta\b[^<>]*http-equiv\s*=\s*(?:["']\s*)?refresh/i, "a `<meta http-equiv=\"refresh\">` element, which redirects the page")
+      ].freeze
+
+      CHECK_NAMES = CHECKS.map(&:name).freeze
+
+      class UnsafeHTMLError < StandardError
+        attr_reader :value #: untyped
+        attr_reader :violations #: Array[Violation]
+        attr_reader :file #: String?
+        attr_reader :line #: Integer?
+        attr_reader :column #: Integer?
+        attr_reader :source #: String?
+
+        #: (value: untyped, violations: Array[Violation], ?file: String?, ?line: Integer?, ?column: Integer?, ?source: String?) -> void
+        def initialize(value:, violations:, file: nil, line: nil, column: nil, source: nil) # rubocop:disable Metrics/ParameterLists
+          @value = value
+          @violations = violations
+          @file = file
+          @line = line
+          @column = column
+          @source = source
+
+          super(build_message)
+        end
+
+        private
+
+        #: () -> String
+        def build_message
+          parts = ["Unsafe `.html_safe` call#{location_suffix}"] #: Array[String]
+          source = @source
+
+          parts << indent(source) if source
+          parts << @violations.map { |violation| "The value contains #{violation.message}." }.join("\n")
+          parts << indent(truncate(@value.inspect))
+          parts << "Escape the value or run it through `sanitize` instead of marking it as HTML-safe."
+
+          parts.join("\n\n")
+        end
+
+        #: () -> String
+        def location_suffix
+          location = [@file, @line, @column].compact.join(":")
+
+          location.empty? ? "" : " in #{location}"
+        end
+
+        #: (String) -> String
+        def indent(string)
+          string.each_line.map { |line| "    #{line}" }.join
+        end
+
+        #: (String) -> String
+        def truncate(string)
+          string.length > MAX_VALUE_LENGTH ? "#{string[0, MAX_VALUE_LENGTH]}..." : string
+        end
+      end
+
+      # @rbs!
+      #   def self.on_violation: () -> (^(UnsafeHTMLError) -> void)?
+      #   def self.on_violation=: ((^(UnsafeHTMLError) -> void)?) -> (^(UnsafeHTMLError) -> void)?
+
+      class << self
+        attr_accessor :on_violation #: (^(UnsafeHTMLError) -> void)?
+      end
+
+      self.on_violation = nil
+
+      #: (untyped, ?file: String?, ?line: Integer?, ?column: Integer?, ?source: String?, ?mode: Symbol, ?ignore: Array[Symbol]) -> untyped
+      def self.check(value, file: nil, line: nil, column: nil, source: nil, mode: :raise, ignore: []) # rubocop:disable Metrics/ParameterLists
+        violations = violations_for(value, ignore: ignore)
+
+        return value if violations.empty?
+
+        error = UnsafeHTMLError.new(
+          value: value,
+          violations: violations,
+          file: file,
+          line: line,
+          column: column,
+          source: source
+        )
+
+        handler = on_violation
+
+        if handler
+          handler.call(error)
+        elsif mode == :warn
+          warn(error.message)
+        else
+          raise error
+        end
+
+        value
+      end
+
+      #: (untyped, ?ignore: Array[Symbol]) -> Array[Violation]
+      def self.violations_for(value, ignore: [])
+        return [] unless value.is_a?(::String)
+        return [] if value.respond_to?(:html_safe?) && value.html_safe?
+
+        markup = value.include?("<")
+        scheme = value.include?(":")
+
+        return [] unless markup || scheme
+
+        ignored = ignore.empty? ? ignore : ignore.map(&:to_sym)
+        violations = [] #: Array[Violation]
+
+        CHECKS.each do |check|
+          next unless check.requires == :markup ? markup : scheme
+          next if ignored.include?(check.name)
+
+          violation = check.violation_for(value)
+
+          violations << violation if violation
+        end
+
+        violations
+      end
+    end
+  end
+end

--- a/lib/herb/engine/html_safe_assertions_visitor.rb
+++ b/lib/herb/engine/html_safe_assertions_visitor.rb
@@ -1,0 +1,272 @@
+# frozen_string_literal: true
+# typed: false
+
+require_relative "../../herb"
+require_relative "html_safe_assertions"
+
+begin
+  require "prism"
+rescue LoadError
+  raise LoadError,
+        "Herb::Engine::HTMLSafeAssertionsVisitor requires the `prism` gem. " \
+        "Add it to your Gemfile or install it with: gem install prism"
+end
+
+module Herb
+  class Engine
+    # Wraps the receiver of every `.html_safe` call in a template with a runtime assertion, so
+    # that marking a value as HTML-safe raises when the value contains HTML that the browser
+    # executes.
+    #
+    # This visitor is not loaded by default. Require it explicitly and pass it to the engine:
+    #
+    #     require "herb/engine/html_safe_assertions_visitor"
+    #
+    #     Herb::Engine.new(source, visitors: [Herb::Engine::HTMLSafeAssertionsVisitor.new])
+    #
+    # `<%= @user.bio.html_safe %>` then compiles as if the template had been written as:
+    #
+    #     <%= ::Herb::Engine::HTMLSafeAssertions.check(@user.bio, file: __FILE__, line: 1, column: 1, source: "<%= @user.bio.html_safe %>", mode: :raise).html_safe %>
+    #
+    # The assertion runs on every render, and the value keeps flowing through `.html_safe`
+    # unchanged. See `Herb::Engine::HTMLSafeAssertions` for what counts as unsafe.
+    #
+    # The calls are found in the Prism program the parser attaches to the document, which the
+    # engine enables through `required_parser_option`. Parsing an AST for this visitor by hand
+    # needs the same option:
+    #
+    #     Herb.parse(source, prism_program: true)
+    #
+    class HTMLSafeAssertionsVisitor < Herb::Visitor
+      RUNTIME = "::Herb::Engine::HTMLSafeAssertions"
+
+      MAX_SOURCE_LENGTH = 120
+
+      required_parser_option prism_program: true
+
+      class MissingPrismProgramError < StandardError
+      end
+
+      #: (?mode: Symbol, ?ignore: Array[Symbol], ?file_path: (String | ::Pathname)?) -> void
+      def initialize(mode: :raise, ignore: [], file_path: nil)
+        super()
+
+        @mode = validated_mode(mode)
+        @ignore = validated_ignore(ignore)
+        @file_path = file_path&.to_s
+        @erb_nodes = [] #: Array[untyped]
+      end
+
+      #: (Herb::AST::DocumentNode) -> void
+      def visit_document_node(node)
+        @erb_nodes = [] #: Array[untyped]
+
+        super
+
+        add_assertions(node)
+      end
+
+      #: (Herb::AST::Node) -> void
+      def visit_erb_node(node)
+        @erb_nodes << node if content_token(node)
+      end
+
+      #: () -> String
+      def inspect
+        "#<#{self.class.name} mode=#{@mode.inspect} ignore=#{@ignore.inspect} file_path=#{@file_path.inspect}>"
+      end
+
+      private
+
+      #: (Symbol) -> Symbol
+      def validated_mode(mode)
+        return mode if HTMLSafeAssertions::MODES.include?(mode)
+
+        raise ArgumentError,
+              "mode must be one of #{HTMLSafeAssertions::MODES.map(&:inspect).join(", ")}, got #{mode.inspect}"
+      end
+
+      #: (Array[Symbol]) -> Array[Symbol]
+      def validated_ignore(ignore)
+        names = ignore.map(&:to_sym)
+        unknown = names - HTMLSafeAssertions::CHECK_NAMES
+
+        return names if unknown.empty?
+
+        raise ArgumentError,
+              "unknown check #{unknown.map(&:inspect).join(", ")}, expected one of #{HTMLSafeAssertions::CHECK_NAMES.map(&:inspect).join(", ")}"
+      end
+
+      #: (Herb::AST::DocumentNode) -> void
+      def add_assertions(document)
+        targets = html_safe_targets(document)
+
+        return if targets.empty?
+
+        @erb_nodes.each { |node| rewrite(node, targets) }
+      end
+
+      #: (Herb::AST::DocumentNode) -> Array[[Symbol, Prism::Location]]
+      def html_safe_targets(document)
+        program = document.deserialized_prism_node
+
+        unless program.is_a?(Prism::ProgramNode)
+          raise MissingPrismProgramError,
+                "#{self.class.name} needs the document to be parsed with the `prism_program` parser option. " \
+                "Pass the visitor to `Herb::Engine`, which enables it, or parse with `Herb.parse(source, prism_program: true)`."
+        end
+
+        targets = [] #: Array[[Symbol, Prism::Location]]
+        queue = [program] #: Array[Prism::Node]
+
+        until queue.empty?
+          current = queue.shift
+
+          queue.concat(current.compact_child_nodes)
+
+          target = target_for(current)
+
+          targets << target if target
+        end
+
+        targets
+      end
+
+      #: (Prism::Node) -> [Symbol, Prism::Location]?
+      def target_for(node)
+        if node.is_a?(Prism::CallNode) && html_safe_call?(node)
+          receiver = node.receiver
+
+          return [:receiver, receiver.location] if receiver
+        end
+
+        if node.is_a?(Prism::BlockArgumentNode) && html_safe_symbol?(node)
+          expression = node.expression
+
+          return [:symbol_to_proc, expression.location] if expression
+        end
+
+        nil
+      end
+
+      #: (Prism::CallNode) -> bool
+      def html_safe_call?(node)
+        return false unless node.name == :html_safe
+        return false unless node.receiver
+        return false if node.arguments || node.block
+
+        true
+      end
+
+      #: (Prism::BlockArgumentNode) -> bool
+      def html_safe_symbol?(node)
+        expression = node.expression
+
+        expression.is_a?(Prism::SymbolNode) && expression.unescaped == "html_safe"
+      end
+
+      #: (untyped, Array[[Symbol, Prism::Location]]) -> void
+      def rewrite(node, targets)
+        token = content_token(node)
+
+        return unless token
+
+        code = token.value
+
+        return unless code.include?("html_safe")
+
+        range = token.range
+
+        return unless range
+        return unless range.to - range.from == code.bytesize
+
+        local = targets.filter_map { |kind, location| local_target(kind, location, range) }
+
+        return if local.empty?
+
+        arguments = check_arguments(node, code)
+        rewritten = code
+
+        edits(local, arguments).each do |start_offset, end_offset, text|
+          rewritten = splice(rewritten, start_offset, end_offset, text)
+        end
+
+        token.value.replace(rewritten)
+      end
+
+      #: (Symbol, Prism::Location, Herb::Range) -> [Symbol, Integer, Integer]?
+      def local_target(kind, location, range)
+        return nil unless location.start_offset >= range.from
+        return nil unless location.end_offset <= range.to
+
+        [kind, location.start_offset - range.from, location.end_offset - range.from]
+      end
+
+      #: (Array[[Symbol, Integer, Integer]], String) -> Array[[Integer, Integer, String]]
+      def edits(targets, arguments)
+        edits = [] #: Array[[Integer, Integer, String]]
+
+        targets.each do |kind, start_offset, end_offset|
+          if kind == :symbol_to_proc
+            edits << [start_offset, end_offset, "->(value, *rest) { #{RUNTIME}.check(value#{arguments}).html_safe(*rest) }"]
+
+            next
+          end
+
+          edits << [end_offset, end_offset, "#{arguments})"]
+          edits << [start_offset, start_offset, "#{RUNTIME}.check("]
+        end
+
+        edits.sort_by { |start_offset, _end_offset, _text| -start_offset }
+      end
+
+      #: (String, Integer, Integer, String) -> String
+      def splice(string, start_offset, end_offset, text)
+        "#{string.byteslice(0, start_offset)}#{text}#{string.byteslice(end_offset..-1)}"
+      end
+
+      #: (untyped) -> Herb::Token?
+      def content_token(node)
+        token = node.respond_to?(:content) ? node.content : nil
+
+        token.is_a?(Herb::Token) ? token : nil
+      end
+
+      #: (untyped, String) -> String
+      def check_arguments(node, code)
+        parts = ["file: #{file_argument}"] #: Array[String]
+
+        location = node.location
+
+        if location
+          parts << "line: #{location.start.line}"
+          parts << "column: #{location.start.column + 1}"
+        end
+
+        parts << "source: #{erb_source(node, code).dump}.freeze"
+        parts << "mode: #{@mode.inspect}"
+        parts << "ignore: #{@ignore.inspect}.freeze" if @ignore.any?
+
+        ", #{parts.join(", ")}"
+      end
+
+      #: () -> String
+      def file_argument
+        @file_path ? "#{@file_path.dump}.freeze" : "__FILE__"
+      end
+
+      #: (untyped, String) -> String
+      def erb_source(node, code)
+        opening = node.respond_to?(:tag_opening) ? node.tag_opening&.value : nil
+        closing = node.respond_to?(:tag_closing) ? node.tag_closing&.value : nil
+
+        truncate("#{opening}#{code}#{closing}")
+      end
+
+      #: (String) -> String
+      def truncate(string)
+        string.length > MAX_SOURCE_LENGTH ? "#{string[0, MAX_SOURCE_LENGTH]}..." : string
+      end
+    end
+  end
+end

--- a/lib/herb/visitor/parser_option_requirements.rb
+++ b/lib/herb/visitor/parser_option_requirements.rb
@@ -1,0 +1,150 @@
+# frozen_string_literal: true
+# typed: true
+
+module Herb
+  class Visitor
+    # Lets a visitor declare the parser options the AST it is handed has to carry, so that
+    # whoever parses can satisfy them before visiting.
+    #
+    #     class PrismProgramVisitor < Herb::Visitor
+    #       required_parser_option prism_program: true
+    #       recommended_parser_option strict: false
+    #     end
+    #
+    # A required option is one the visitor cannot work without, and a recommended one is a soft
+    # requirement it only works better with. `Herb::Visitor.parser_options_for` resolves both for
+    # a set of visitors, raising on a conflicting requirement and warning on a conflicting
+    # recommendation.
+    #
+    # `Herb::Visitor` includes this, so every visitor has it. Anything else that is passed to
+    # `Herb::Engine` as a visitor can include it too.
+    module ParserOptionRequirements
+      #: (untyped) -> void
+      def self.included(base)
+        super
+
+        base.extend(ClassMethods)
+      end
+
+      module ClassMethods
+        #: (**untyped) -> void
+        def required_parser_option(**options)
+          declared_parser_options(:required).merge!(options.transform_keys(&:to_sym))
+        end
+
+        #: (**untyped) -> void
+        def recommended_parser_option(**options)
+          declared_parser_options(:recommended).merge!(options.transform_keys(&:to_sym))
+        end
+
+        #: () -> Hash[Symbol, untyped]
+        def required_parser_options
+          declared_parser_options(:required).dup
+        end
+
+        #: () -> Hash[Symbol, untyped]
+        def recommended_parser_options
+          declared_parser_options(:recommended).dup
+        end
+
+        #: (untyped) -> void
+        def inherited(subclass)
+          super
+
+          subclass.required_parser_option(**required_parser_options)
+          subclass.recommended_parser_option(**recommended_parser_options)
+        end
+
+        #: (Array[untyped], ?Hash[Symbol, untyped]) -> Hash[Symbol, untyped]
+        def parser_options_for(visitors, parser_options = {})
+          options = parser_options.transform_keys(&:to_sym)
+
+          apply_required_parser_options(visitors, options)
+          apply_recommended_parser_options(visitors, options)
+
+          options
+        end
+
+        private
+
+        #: (Array[untyped], Hash[Symbol, untyped]) -> void
+        def apply_required_parser_options(visitors, options)
+          each_declared_parser_option(visitors, :required_parser_options) do |visitor, name, value|
+            current = options[name]
+
+            if options.key?(name) && current != value
+              Kernel.raise(
+                ArgumentError,
+                "#{describe(visitor)} requires the `#{name}` parser option to be #{value.inspect}, but it is set to #{current.inspect}"
+              )
+            end
+
+            options[name] = value
+          end
+        end
+
+        #: (Array[untyped], Hash[Symbol, untyped]) -> void
+        def apply_recommended_parser_options(visitors, options)
+          each_declared_parser_option(visitors, :recommended_parser_options) do |visitor, name, value|
+            current = options[name]
+
+            unless options.key?(name)
+              options[name] = value
+
+              next
+            end
+
+            next if current == value
+
+            Kernel.warn "[Herb] #{describe(visitor)} recommends the `#{name}` parser option to be #{value.inspect}, but it is set to #{current.inspect}"
+          end
+        end
+
+        #: (Symbol) -> Hash[Symbol, untyped]
+        def declared_parser_options(kind)
+          store = @declared_parser_options ||= {} #: Hash[Symbol, Hash[Symbol, untyped]]
+
+          store[kind] ||= {}
+        end
+
+        #: (Array[untyped], Symbol) { (untyped, Symbol, untyped) -> void } -> void
+        def each_declared_parser_option(visitors, reader)
+          visitors.each do |visitor|
+            next unless visitor.respond_to?(reader)
+
+            visitor.public_send(reader).each do |name, value|
+              yield(visitor, name.to_sym, value)
+            end
+          end
+        end
+
+        #: (untyped) -> String
+        def describe(visitor)
+          visitor.class.name || visitor.class.to_s
+        end
+      end
+
+      #: () -> Hash[Symbol, untyped]
+      def required_parser_options
+        declaring_class.required_parser_options
+      end
+
+      #: () -> Hash[Symbol, untyped]
+      def recommended_parser_options
+        declaring_class.recommended_parser_options
+      end
+
+      #: (untyped) -> untyped
+      def self.class_of(object)
+        object.class
+      end
+
+      private
+
+      #: () -> untyped
+      def declaring_class
+        ParserOptionRequirements.class_of(self)
+      end
+    end
+  end
+end

--- a/sig/herb/engine/html_safe_assertions.rbs
+++ b/sig/herb/engine/html_safe_assertions.rbs
@@ -1,0 +1,108 @@
+# Generated from lib/herb/engine/html_safe_assertions.rb with RBS::Inline
+
+module Herb
+  class Engine
+    # Runtime counterpart of `Herb::Engine::HTMLSafeAssertionsVisitor`.
+    #
+    # `check` inspects the value a template is about to mark as HTML-safe and reports it when
+    # the value contains HTML that the browser executes, such as a `<script>` element, an
+    # inline event handler, or a `javascript:` URL. It returns the value unchanged, so it can
+    # wrap any expression.
+    #
+    # Values that are already HTML-safe are left alone, since `.html_safe` is a no-op on them.
+    #
+    # The checks are heuristics over the string. They catch the payloads that reach templates
+    # through unescaped user input, not every possible way to write HTML that executes.
+    module HTMLSafeAssertions
+      MODES: untyped
+
+      MAX_VALUE_LENGTH: ::Integer
+
+      EVENT_HANDLER_NAMES: untyped
+
+      EVENT_HANDLER_PATTERN: ::Regexp
+
+      class Violation
+        attr_reader name: Symbol
+
+        attr_reader message: String
+
+        attr_reader snippet: String
+
+        # : (Symbol, String, String) -> void
+        def initialize: (Symbol, String, String) -> void
+
+        # : () -> String
+        def inspect: () -> String
+      end
+
+      class Check
+        attr_reader name: Symbol
+
+        attr_reader requires: Symbol
+
+        attr_reader pattern: Regexp
+
+        attr_reader message: String
+
+        # : (Symbol, Symbol, Regexp, String) -> void
+        def initialize: (Symbol, Symbol, Regexp, String) -> void
+
+        # : (String) -> Violation?
+        def violation_for: (String) -> Violation?
+
+        private
+
+        # : (MatchData) -> String
+        def message_for: (MatchData) -> String
+      end
+
+      CHECKS: untyped
+
+      CHECK_NAMES: untyped
+
+      class UnsafeHTMLError < StandardError
+        attr_reader value: untyped
+
+        attr_reader violations: Array[Violation]
+
+        attr_reader file: String?
+
+        attr_reader line: Integer?
+
+        attr_reader column: Integer?
+
+        attr_reader source: String?
+
+        # : (value: untyped, violations: Array[Violation], ?file: String?, ?line: Integer?, ?column: Integer?, ?source: String?) -> void
+        def initialize: (value: untyped, violations: Array[Violation], ?file: String?, ?line: Integer?, ?column: Integer?, ?source: String?) -> void
+
+        private
+
+        # : () -> String
+        def build_message: () -> String
+
+        # : () -> String
+        def location_suffix: () -> String
+
+        # : (String) -> String
+        def indent: (String) -> String
+
+        # : (String) -> String
+        def truncate: (String) -> String
+      end
+
+      def self.on_violation: () -> (^(UnsafeHTMLError) -> void)?
+
+      def self.on_violation=: ((^(UnsafeHTMLError) -> void)?) -> (^(UnsafeHTMLError) -> void)?
+
+      attr_accessor on_violation: (^(UnsafeHTMLError) -> void)?
+
+      # : (untyped, ?file: String?, ?line: Integer?, ?column: Integer?, ?source: String?, ?mode: Symbol, ?ignore: Array[Symbol]) -> untyped
+      def self.check: (untyped, ?file: String?, ?line: Integer?, ?column: Integer?, ?source: String?, ?mode: Symbol, ?ignore: Array[Symbol]) -> untyped
+
+      # : (untyped, ?ignore: Array[Symbol]) -> Array[Violation]
+      def self.violations_for: (untyped, ?ignore: Array[Symbol]) -> Array[Violation]
+    end
+  end
+end

--- a/sig/herb/engine/html_safe_assertions_visitor.rbs
+++ b/sig/herb/engine/html_safe_assertions_visitor.rbs
@@ -1,0 +1,98 @@
+# Generated from lib/herb/engine/html_safe_assertions_visitor.rb with RBS::Inline
+
+module Herb
+  class Engine
+    # Wraps the receiver of every `.html_safe` call in a template with a runtime assertion, so
+    # that marking a value as HTML-safe raises when the value contains HTML that the browser
+    # executes.
+    #
+    # This visitor is not loaded by default. Require it explicitly and pass it to the engine:
+    #
+    #     require "herb/engine/html_safe_assertions_visitor"
+    #
+    #     Herb::Engine.new(source, visitors: [Herb::Engine::HTMLSafeAssertionsVisitor.new])
+    #
+    # `<%= @user.bio.html_safe %>` then compiles as if the template had been written as:
+    #
+    #     <%= ::Herb::Engine::HTMLSafeAssertions.check(@user.bio, file: __FILE__, line: 1, column: 1, source: "<%= @user.bio.html_safe %>", mode: :raise).html_safe %>
+    #
+    # The assertion runs on every render, and the value keeps flowing through `.html_safe`
+    # unchanged. See `Herb::Engine::HTMLSafeAssertions` for what counts as unsafe.
+    #
+    # The calls are found in the Prism program the parser attaches to the document, which the
+    # engine enables through `required_parser_option`. Parsing an AST for this visitor by hand
+    # needs the same option:
+    #
+    #     Herb.parse(source, prism_program: true)
+    class HTMLSafeAssertionsVisitor < Herb::Visitor
+      RUNTIME: ::String
+
+      MAX_SOURCE_LENGTH: ::Integer
+
+      class MissingPrismProgramError < StandardError
+      end
+
+      # : (?mode: Symbol, ?ignore: Array[Symbol], ?file_path: (String | ::Pathname)?) -> void
+      def initialize: (?mode: Symbol, ?ignore: Array[Symbol], ?file_path: (String | ::Pathname)?) -> void
+
+      # : (Herb::AST::DocumentNode) -> void
+      def visit_document_node: (Herb::AST::DocumentNode) -> void
+
+      # : (Herb::AST::Node) -> void
+      def visit_erb_node: (Herb::AST::Node) -> void
+
+      # : () -> String
+      def inspect: () -> String
+
+      private
+
+      # : (Symbol) -> Symbol
+      def validated_mode: (Symbol) -> Symbol
+
+      # : (Array[Symbol]) -> Array[Symbol]
+      def validated_ignore: (Array[Symbol]) -> Array[Symbol]
+
+      # : (Herb::AST::DocumentNode) -> void
+      def add_assertions: (Herb::AST::DocumentNode) -> void
+
+      # : (Herb::AST::DocumentNode) -> Array[[Symbol, Prism::Location]]
+      def html_safe_targets: (Herb::AST::DocumentNode) -> Array[[ Symbol, Prism::Location ]]
+
+      # : (Prism::Node) -> [Symbol, Prism::Location]?
+      def target_for: (Prism::Node) -> [ Symbol, Prism::Location ]?
+
+      # : (Prism::CallNode) -> bool
+      def html_safe_call?: (Prism::CallNode) -> bool
+
+      # : (Prism::BlockArgumentNode) -> bool
+      def html_safe_symbol?: (Prism::BlockArgumentNode) -> bool
+
+      # : (untyped, Array[[Symbol, Prism::Location]]) -> void
+      def rewrite: (untyped, Array[[ Symbol, Prism::Location ]]) -> void
+
+      # : (Symbol, Prism::Location, Herb::Range) -> [Symbol, Integer, Integer]?
+      def local_target: (Symbol, Prism::Location, Herb::Range) -> [ Symbol, Integer, Integer ]?
+
+      # : (Array[[Symbol, Integer, Integer]], String) -> Array[[Integer, Integer, String]]
+      def edits: (Array[[ Symbol, Integer, Integer ]], String) -> Array[[ Integer, Integer, String ]]
+
+      # : (String, Integer, Integer, String) -> String
+      def splice: (String, Integer, Integer, String) -> String
+
+      # : (untyped) -> Herb::Token?
+      def content_token: (untyped) -> Herb::Token?
+
+      # : (untyped, String) -> String
+      def check_arguments: (untyped, String) -> String
+
+      # : () -> String
+      def file_argument: () -> String
+
+      # : (untyped, String) -> String
+      def erb_source: (untyped, String) -> String
+
+      # : (String) -> String
+      def truncate: (String) -> String
+    end
+  end
+end

--- a/sig/herb/visitor.rbs
+++ b/sig/herb/visitor.rbs
@@ -4,6 +4,10 @@ module Herb
   class Visitor
     include AST::Helpers
 
+    include ParserOptionRequirements
+
+    extend Herb::Visitor::ParserOptionRequirements::ClassMethods
+
     # : (Herb::AST::Node?) -> void
     def visit: (Herb::AST::Node?) -> void
 

--- a/sig/herb/visitor/parser_option_requirements.rbs
+++ b/sig/herb/visitor/parser_option_requirements.rbs
@@ -1,0 +1,76 @@
+# Generated from lib/herb/visitor/parser_option_requirements.rb with RBS::Inline
+
+module Herb
+  class Visitor
+    # Lets a visitor declare the parser options the AST it is handed has to carry, so that
+    # whoever parses can satisfy them before visiting.
+    #
+    #     class PrismProgramVisitor < Herb::Visitor
+    #       required_parser_option prism_program: true
+    #       recommended_parser_option strict: false
+    #     end
+    #
+    # A required option is one the visitor cannot work without, and a recommended one is a soft
+    # requirement it only works better with. `Herb::Visitor.parser_options_for` resolves both for
+    # a set of visitors, raising on a conflicting requirement and warning on a conflicting
+    # recommendation.
+    #
+    # `Herb::Visitor` includes this, so every visitor has it. Anything else that is passed to
+    # `Herb::Engine` as a visitor can include it too.
+    module ParserOptionRequirements
+      # : (untyped) -> void
+      def self.included: (untyped) -> void
+
+      module ClassMethods
+        # : (**untyped) -> void
+        def required_parser_option: (**untyped) -> void
+
+        # : (**untyped) -> void
+        def recommended_parser_option: (**untyped) -> void
+
+        # : () -> Hash[Symbol, untyped]
+        def required_parser_options: () -> Hash[Symbol, untyped]
+
+        # : () -> Hash[Symbol, untyped]
+        def recommended_parser_options: () -> Hash[Symbol, untyped]
+
+        # : (untyped) -> void
+        def inherited: (untyped) -> void
+
+        # : (Array[untyped], ?Hash[Symbol, untyped]) -> Hash[Symbol, untyped]
+        def parser_options_for: (Array[untyped], ?Hash[Symbol, untyped]) -> Hash[Symbol, untyped]
+
+        private
+
+        # : (Array[untyped], Hash[Symbol, untyped]) -> void
+        def apply_required_parser_options: (Array[untyped], Hash[Symbol, untyped]) -> void
+
+        # : (Array[untyped], Hash[Symbol, untyped]) -> void
+        def apply_recommended_parser_options: (Array[untyped], Hash[Symbol, untyped]) -> void
+
+        # : (Symbol) -> Hash[Symbol, untyped]
+        def declared_parser_options: (Symbol) -> Hash[Symbol, untyped]
+
+        # : (Array[untyped], Symbol) { (untyped, Symbol, untyped) -> void } -> void
+        def each_declared_parser_option: (Array[untyped], Symbol) { (untyped, Symbol, untyped) -> void } -> void
+
+        # : (untyped) -> String
+        def describe: (untyped) -> String
+      end
+
+      # : () -> Hash[Symbol, untyped]
+      def required_parser_options: () -> Hash[Symbol, untyped]
+
+      # : () -> Hash[Symbol, untyped]
+      def recommended_parser_options: () -> Hash[Symbol, untyped]
+
+      # : (untyped) -> untyped
+      def self.class_of: (untyped) -> untyped
+
+      private
+
+      # : () -> untyped
+      def declaring_class: () -> untyped
+    end
+  end
+end

--- a/templates/lib/herb/visitor.rb.erb
+++ b/templates/lib/herb/visitor.rb.erb
@@ -1,6 +1,12 @@
+require_relative "visitor/parser_option_requirements"
+
 module Herb
   class Visitor
     include AST::Helpers
+    include ParserOptionRequirements
+
+    # @rbs!
+    #   extend Herb::Visitor::ParserOptionRequirements::ClassMethods
 
     #: (Herb::AST::Node?) -> void
     def visit(node)

--- a/test/engine/html_safe_assertions_test.rb
+++ b/test/engine/html_safe_assertions_test.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+require_relative "../snapshot_utils"
+require_relative "../../lib/herb/engine"
+require_relative "../../lib/herb/engine/html_safe_assertions"
+
+module Engine
+  class HTMLSafeAssertionsTest < Minitest::Spec
+    def violations(value, **)
+      Herb::Engine::HTMLSafeAssertions.violations_for(value, **).map(&:name)
+    end
+
+    test "reports a script element" do
+      assert_equal [:script_element], violations("<p>hi</p><script>alert(1)</script>")
+    end
+
+    test "reports an inline event handler" do
+      assert_equal [:event_handler], violations(%(<img src="x" onerror="steal()">))
+      assert_equal [:event_handler], violations("<svg/onload=alert(1)>")
+      assert_equal [:event_handler], violations(%(<a ONCLICK="x()">link</a>))
+      assert_equal [:event_handler], violations(%(<video onloadeddata="x()">))
+    end
+
+    test "reports a javascript URL" do
+      assert_equal [:javascript_url], violations(%(<a href="javascript:alert(1)">link</a>))
+      assert_equal [:javascript_url], violations("javascript:alert(1)")
+      assert_equal [:javascript_url], violations(%(<a href="VBScript:msgbox(1)">link</a>))
+    end
+
+    test "reports a data URL that is a document" do
+      assert_equal [:data_url], violations(%(<a href="data:text/html;base64,PHNjcmlwdD4=">link</a>))
+    end
+
+    test "reports elements that load remote content" do
+      assert_equal [:risky_element], violations(%(<iframe src="https://example.com"></iframe>))
+      assert_equal [:risky_element], violations(%(<object data="x.swf"></object>))
+      assert_equal [:risky_element], violations(%(<base href="https://example.com">))
+    end
+
+    test "reports a meta refresh" do
+      assert_equal [:meta_refresh], violations(%(<meta http-equiv="refresh" content="0;url=https://example.com">))
+    end
+
+    test "reports every check that matches" do
+      value = %(<script>alert(1)</script><iframe src="x"></iframe>)
+
+      assert_equal [:script_element, :risky_element], violations(value)
+    end
+
+    test "leaves ordinary markup alone" do
+      assert_empty violations(%(<p class="intro">Hello <b>world</b></p>))
+      assert_empty violations(%(<a href="/posts/1">Post</a>))
+      assert_empty violations(%(<div only="1" data-online="true">safe</div>))
+      assert_empty violations(%(<link rel="stylesheet" href="/app.css">))
+      assert_empty violations(%(<form action="/posts"><input name="title"></form>))
+    end
+
+    test "leaves values that are not strings alone" do
+      assert_empty violations(nil)
+      assert_empty violations(42)
+    end
+
+    test "leaves values that are already html safe alone" do
+      assert_empty violations("<script>alert(1)</script>".html_safe)
+    end
+
+    test "ignored checks are skipped" do
+      value = %(<script>alert(1)</script><iframe src="x"></iframe>)
+
+      assert_equal [:risky_element], violations(value, ignore: [:script_element])
+      assert_empty violations(value, ignore: [:script_element, :risky_element])
+    end
+
+    test "check returns the value it was given" do
+      value = "<p>hi</p>"
+
+      assert_same value, Herb::Engine::HTMLSafeAssertions.check(value)
+    end
+  end
+end

--- a/test/engine/html_safe_assertions_visitor_test.rb
+++ b/test/engine/html_safe_assertions_visitor_test.rb
@@ -1,0 +1,321 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+require_relative "../snapshot_utils"
+require_relative "../../lib/herb/engine"
+require_relative "../../lib/herb/engine/html_safe_assertions_visitor"
+
+module Engine
+  class HTMLSafeAssertionsVisitorTest < Minitest::Spec
+    include SnapshotUtils
+
+    SCRIPT = "<script>alert(1)</script>"
+
+    def assertion_options(visitor_options = {})
+      visitor = Herb::Engine::HTMLSafeAssertionsVisitor.new(file_path: "app/views/test.html.erb", **visitor_options)
+
+      {
+        escape: false,
+        parser_options: { strict: false },
+        visitors: [visitor],
+      }
+    end
+
+    def render(template, locals = {}, visitor_options = {})
+      engine = Herb::Engine.new(template, assertion_options(visitor_options))
+
+      evaluate_herb_source(engine.src, locals)
+    end
+
+    def outcome(template, locals, visitors)
+      engine = Herb::Engine.new(template, escape: false, parser_options: { strict: false }, visitors: visitors)
+
+      evaluate_herb_source(engine.src, locals)
+    rescue StandardError => e
+      "#{e.class}: #{e.message}"
+    end
+
+    def teardown
+      Herb::Engine::HTMLSafeAssertions.on_violation = nil
+    end
+
+    test "visitor is not loaded when only requiring herb" do
+      load_path = $LOAD_PATH.map { |path| "-I#{path}" }.join(" ")
+      output = `#{Gem.ruby} #{load_path} -e 'require "herb"; print defined?(Herb::Engine::HTMLSafeAssertionsVisitor).inspect' 2>&1`
+
+      assert_equal "nil", output
+    end
+
+    test "output tag is wrapped in an assertion - compilation" do
+      template = "<div><%= @user.bio.html_safe %></div>"
+
+      assert_compiled_snapshot(template, assertion_options)
+    end
+
+    test "control tag is wrapped in an assertion - compilation" do
+      template = "<% content = message.html_safe %><div><%= content %></div>"
+
+      assert_compiled_snapshot(template, assertion_options)
+    end
+
+    test "every html_safe call in a template is wrapped - compilation" do
+      template = "<div><%= a.html_safe %> and <%= b.html_safe %></div>"
+
+      assert_compiled_snapshot(template, assertion_options)
+    end
+
+    test "html_safe inside a block tag is wrapped - compilation" do
+      template = %(<%= link_to "Home", root_path(query.html_safe) do %>Home<% end %>)
+
+      assert_compiled_snapshot(template, assertion_options)
+    end
+
+    test "html_safe in a control flow fragment is wrapped - compilation" do
+      template = "<% if a %>A<% elsif b.html_safe %>B<% end %>"
+
+      assert_compiled_snapshot(template, assertion_options)
+    end
+
+    test "template without html_safe is left alone - compilation" do
+      template = "<div><%= @user.bio %></div>"
+
+      assert_compiled_snapshot(template, assertion_options)
+    end
+
+    test "html_safe in an ERB comment is left alone" do
+      template = "<%# @user.bio.html_safe %><div>x</div>"
+
+      engine = Herb::Engine.new(template, assertion_options)
+
+      refute_includes engine.src, "HTMLSafeAssertions"
+    end
+
+    test "every call is wrapped once when the visitor is passed twice" do
+      template = "<div><%= a.html_safe %></div>"
+      visitors = [
+        Herb::Engine::HTMLSafeAssertionsVisitor.new,
+        Herb::Engine::HTMLSafeAssertionsVisitor.new
+      ]
+
+      engine = Herb::Engine.new(template, escape: false, visitors: visitors)
+
+      assert_equal 1, engine.src.scan("HTMLSafeAssertions.check").length
+    end
+
+    test "the engine enables the prism_program parser option" do
+      template = "<div><%= @user.bio.html_safe %></div>"
+
+      engine = Herb::Engine.new(
+        template,
+        escape: false,
+        parser_options: { strict: false },
+        visitors: [Herb::Engine::HTMLSafeAssertionsVisitor.new]
+      )
+
+      assert_includes engine.src, "HTMLSafeAssertions.check"
+    end
+
+    test "a document parsed without the prism_program option raises" do
+      document = Herb.parse("<div><%= @user.bio.html_safe %></div>").value
+
+      error = assert_raises(Herb::Engine::HTMLSafeAssertionsVisitor::MissingPrismProgramError) do
+        document.accept(Herb::Engine::HTMLSafeAssertionsVisitor.new)
+      end
+
+      assert_includes error.message, "`prism_program` parser option"
+    end
+
+    test "ignored checks are baked into the assertion - compilation" do
+      template = "<div><%= @user.bio.html_safe %></div>"
+
+      assert_compiled_snapshot(template, assertion_options({ ignore: [:risky_element, :meta_refresh] }))
+    end
+
+    test "the file is taken from the compiled template when no file path is given" do
+      template = "<div><%= @user.bio.html_safe %></div>"
+
+      engine = Herb::Engine.new(template, escape: false, visitors: [Herb::Engine::HTMLSafeAssertionsVisitor.new])
+
+      assert_includes engine.src, "file: __FILE__"
+    end
+
+    test "safe value passes through unchanged - render" do
+      template = "<div><%= bio.html_safe %></div>"
+
+      assert_evaluated_snapshot(template, { bio: "<p>About me</p>" }, assertion_options)
+    end
+
+    test "value without html_safe is never checked - render" do
+      template = "<div><%= bio %></div>"
+
+      assert_evaluated_snapshot(template, { bio: SCRIPT }, assertion_options)
+    end
+
+    test "value that is already html safe is not checked - render" do
+      template = "<div><%= bio.html_safe %></div>"
+
+      assert_evaluated_snapshot(template, { bio: SCRIPT.html_safe }, assertion_options)
+    end
+
+    test "ignored check renders the value - render" do
+      template = "<div><%= bio.html_safe %></div>"
+      iframe = %(<iframe src="https://example.com"></iframe>)
+
+      assert_evaluated_snapshot(template, { bio: iframe }, assertion_options({ ignore: [:risky_element] }))
+    end
+
+    test "unsafe value raises" do
+      template = "<div><%= bio.html_safe %></div>"
+
+      error = assert_raises(Herb::Engine::HTMLSafeAssertions::UnsafeHTMLError) do
+        render(template, bio: SCRIPT)
+      end
+
+      assert_equal [:script_element], error.violations.map(&:name)
+      assert_equal "app/views/test.html.erb", error.file
+      assert_equal 1, error.line
+      assert_equal 6, error.column
+      assert_equal "<%= bio.html_safe %>", error.source
+      assert_equal SCRIPT, error.value
+    end
+
+    test "error message points at the template and the value" do
+      template = %(<div>\n  <%= bio.html_safe %>\n</div>)
+
+      error = assert_raises(Herb::Engine::HTMLSafeAssertions::UnsafeHTMLError) do
+        render(template, bio: SCRIPT)
+      end
+
+      expected = <<~MESSAGE.strip
+        Unsafe `.html_safe` call in app/views/test.html.erb:2:3
+
+            <%= bio.html_safe %>
+
+        The value contains a `<script>` element, which the browser executes.
+
+            "<script>alert(1)</script>"
+
+        Escape the value or run it through `sanitize` instead of marking it as HTML-safe.
+      MESSAGE
+
+      assert_equal expected, error.message
+    end
+
+    test "warn mode warns and keeps rendering" do
+      template = "<div><%= bio.html_safe %></div>"
+      result = nil
+
+      _out, err = capture_io do
+        result = render(template, { bio: SCRIPT }, mode: :warn)
+      end
+
+      assert_equal "<div>#{SCRIPT}</div>", result
+      assert_includes err, "Unsafe `.html_safe` call in app/views/test.html.erb:1:6"
+    end
+
+    test "on_violation handler replaces raising" do
+      template = "<div><%= bio.html_safe %></div>"
+      reported = []
+
+      Herb::Engine::HTMLSafeAssertions.on_violation = ->(error) { reported << error }
+
+      assert_equal "<div>#{SCRIPT}</div>", render(template, bio: SCRIPT)
+      assert_equal 1, reported.length
+      assert_equal [:script_element], reported.first.violations.map(&:name)
+    end
+
+    test "html_safe passed as a block argument is wrapped - compilation" do
+      template = "<div><%= items.map(&:html_safe).join %></div>"
+
+      assert_compiled_snapshot(template, assertion_options)
+    end
+
+    test "html_safe passed as a block argument checks every element - render" do
+      template = "<div><%= items.map(&:html_safe).join %></div>"
+
+      assert_evaluated_snapshot(template, { items: ["<p>one</p>", "<p>two</p>"] }, assertion_options)
+    end
+
+    test "unsafe element passed as a block argument raises" do
+      template = "<div><%= items.map(&:html_safe).join %></div>"
+
+      error = assert_raises(Herb::Engine::HTMLSafeAssertions::UnsafeHTMLError) do
+        render(template, items: ["<p>fine</p>", SCRIPT])
+      end
+
+      assert_equal [:script_element], error.violations.map(&:name)
+      assert_equal SCRIPT, error.value
+    end
+
+    test "a block argument for another method is left alone" do
+      template = "<div><%= items.map(&:upcase).join %></div>"
+
+      engine = Herb::Engine.new(template, assertion_options)
+
+      refute_includes engine.src, "HTMLSafeAssertions"
+    end
+
+    test "a block argument is wrapped whatever method it is passed to" do
+      templates = [
+        "<%= items.flat_map(&:html_safe) %>",
+        "<%= items.each(&:html_safe) %>",
+        "<%= items.select(&:html_safe) %>",
+        "<%= items.sort_by(&:html_safe) %>",
+        "<%= items.lazy.map(&:html_safe).first(2) %>",
+        "<%= items.map &:html_safe %>",
+        %(<%= items.map(&:"html_safe") %>),
+        "<%= my_helper(items, &:html_safe) %>"
+      ]
+
+      templates.each do |template|
+        engine = Herb::Engine.new(template, assertion_options)
+
+        assert_includes engine.src, "HTMLSafeAssertions.check", template
+      end
+    end
+
+    test "every block argument in a template is wrapped" do
+      template = "<%= items.map(&:html_safe).map(&:html_safe) %>"
+
+      engine = Herb::Engine.new(template, assertion_options)
+
+      assert_equal 2, engine.src.scan("HTMLSafeAssertions.check").length
+    end
+
+    test "a block argument keeps behaving the way the symbol did" do
+      cases = {
+        "flat_map" => ["<%= items.flat_map(&:html_safe).join %>", { items: ["<p>a</p>", "<p>b</p>"] }],
+        "sort_by" => ["<%= items.sort_by(&:html_safe).join %>", { items: ["<p>b</p>", "<p>a</p>"] }],
+        "select" => ["<%= items.select(&:html_safe).join %>", { items: ["<p>a</p>"] }],
+        "empty" => ["<%= items.map(&:html_safe).join %>", { items: [] }],
+        "two yielded values" => ["<%= items.each_with_index.map(&:html_safe) %>", { items: ["<p>a</p>"] }],
+        "yielded pair" => ["<%= items.map(&:html_safe) %>", { items: { "<p>a</p>" => 1 } }],
+        "zipped pair" => ["<%= items.zip([1]).map(&:html_safe) %>", { items: ["<p>a</p>"] }],
+        "not a string" => ["<%= items.map(&:html_safe) %>", { items: [42] }],
+      }
+
+      cases.each do |name, (template, locals)|
+        without = outcome(template, locals, [])
+        with = outcome(template, locals, [Herb::Engine::HTMLSafeAssertionsVisitor.new])
+
+        assert_equal without, with, name
+      end
+    end
+
+    test "unknown mode raises" do
+      error = assert_raises(ArgumentError) do
+        Herb::Engine::HTMLSafeAssertionsVisitor.new(mode: :overlay)
+      end
+
+      assert_equal "mode must be one of :raise, :warn, got :overlay", error.message
+    end
+
+    test "unknown check raises" do
+      error = assert_raises(ArgumentError) do
+        Herb::Engine::HTMLSafeAssertionsVisitor.new(ignore: [:scripts])
+      end
+
+      assert_includes error.message, "unknown check :scripts"
+    end
+  end
+end

--- a/test/engine_visitors_test.rb
+++ b/test/engine_visitors_test.rb
@@ -65,4 +65,101 @@ class EngineVisitorsTest < Minitest::Spec
 
     refute_nil engine.src
   end
+
+  HTML = "<div><%= name %></div>"
+
+  def prism_node_visitor(&declaration)
+    Class.new(Herb::Visitor) do
+      attr_reader :prism_node
+
+      class_eval(&declaration) if declaration
+
+      def visit_document_node(node)
+        @prism_node = node.prism_node
+
+        super
+      end
+    end.new
+  end
+
+  test "a parser option a visitor requires is turned on" do
+    visitor = prism_node_visitor { required_parser_option prism_program: true }
+
+    engine = Herb::Engine.new(HTML, visitors: [visitor])
+
+    refute_nil engine.src
+    refute_nil visitor.prism_node
+  end
+
+  test "a parser option a visitor requires can be passed to the engine as well" do
+    visitor = prism_node_visitor { required_parser_option prism_program: true }
+
+    engine = Herb::Engine.new(HTML, visitors: [visitor], parser_options: { prism_program: true })
+
+    refute_nil engine.src
+    refute_nil visitor.prism_node
+  end
+
+  test "a parser option passed to the engine that a visitor requires otherwise raises" do
+    visitor = prism_node_visitor { required_parser_option prism_program: true }
+
+    error = assert_raises(ArgumentError) do
+      Herb::Engine.new(HTML, visitors: [visitor], parser_options: { prism_program: false })
+    end
+
+    assert_includes error.message, "requires the `prism_program` parser option to be true, but it is set to false"
+  end
+
+  test "two visitors requiring the same parser option differently raises" do
+    visitors = [
+      prism_node_visitor { required_parser_option prism_program: true },
+      prism_node_visitor { required_parser_option prism_program: false }
+    ]
+
+    assert_raises(ArgumentError) do
+      Herb::Engine.new(HTML, visitors: visitors)
+    end
+  end
+
+  test "a parser option a visitor recommends is turned on" do
+    visitor = prism_node_visitor { recommended_parser_option prism_program: true }
+
+    engine = Herb::Engine.new(HTML, visitors: [visitor])
+
+    refute_nil engine.src
+    refute_nil visitor.prism_node
+  end
+
+  test "a parser option passed to the engine that a visitor recommends otherwise warns" do
+    visitor = prism_node_visitor { recommended_parser_option prism_program: true }
+    engine = nil
+
+    _out, err = capture_io do
+      engine = Herb::Engine.new(HTML, visitors: [visitor], parser_options: { prism_program: false })
+    end
+
+    assert_includes err, "recommends the `prism_program` parser option to be true, but it is set to false"
+    refute_nil engine.src
+    assert_nil visitor.prism_node
+  end
+
+  test "a parser option a visitor recommends does not warn when it is already set to it" do
+    visitor = prism_node_visitor { recommended_parser_option prism_program: true }
+
+    _out, err = capture_io do
+      Herb::Engine.new(HTML, visitors: [visitor], parser_options: { prism_program: true })
+    end
+
+    assert_empty err
+    refute_nil visitor.prism_node
+  end
+
+  test "visitors without parser options are left alone" do
+    visitor = prism_node_visitor
+
+    engine = Herb::Engine.new(HTML, visitors: [visitor])
+
+    refute_nil engine.src
+    assert_nil visitor.prism_node
+  end
 end

--- a/test/snapshots/engine/html_safe_assertions_visitor_test/test_0002_output_tag_is_wrapped_in_an_assertion_-_compilation_f3d94521f16492b182f6681e4c1d33d8.txt
+++ b/test/snapshots/engine/html_safe_assertions_visitor_test/test_0002_output_tag_is_wrapped_in_an_assertion_-_compilation_f3d94521f16492b182f6681e4c1d33d8.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::HTMLSafeAssertionsVisitorTest#test_0002_output tag is wrapped in an assertion - compilation"
+input: "{source: \"<div><%= @user.bio.html_safe %></div>\", options: {escape: false, parser_options: {strict: false}, visitors: [#<Herb::Engine::HTMLSafeAssertionsVisitor mode=:raise ignore=[] file_path=\"app/views/test.html.erb\">]}}"
+---
+_buf = ::String.new; _buf << '<div>'.freeze; _buf << (::Herb::Engine::HTMLSafeAssertions.check(@user.bio, file: "app/views/test.html.erb".freeze, line: 1, column: 6, source: "<%= @user.bio.html_safe %>".freeze, mode: :raise).html_safe).to_s; _buf << '</div>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/html_safe_assertions_visitor_test/test_0003_control_tag_is_wrapped_in_an_assertion_-_compilation_10ccdca1b0c256a76b6855b6b840906a.txt
+++ b/test/snapshots/engine/html_safe_assertions_visitor_test/test_0003_control_tag_is_wrapped_in_an_assertion_-_compilation_10ccdca1b0c256a76b6855b6b840906a.txt
@@ -1,0 +1,7 @@
+---
+source: "Engine::HTMLSafeAssertionsVisitorTest#test_0003_control tag is wrapped in an assertion - compilation"
+input: "{source: \"<% content = message.html_safe %><div><%= content %></div>\", options: {escape: false, parser_options: {strict: false}, visitors: [#<Herb::Engine::HTMLSafeAssertionsVisitor mode=:raise ignore=[] file_path=\"app/views/test.html.erb\">]}}"
+---
+_buf = ::String.new; content = ::Herb::Engine::HTMLSafeAssertions.check(message, file: "app/views/test.html.erb".freeze, line: 1, column: 1, source: "<% content = message.html_safe %>".freeze, mode: :raise).html_safe 
+ _buf << '<div>'.freeze; _buf << (content).to_s; _buf << '</div>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/html_safe_assertions_visitor_test/test_0004_every_html_safe_call_in_a_template_is_wrapped_-_compilation_043a7c9d45ac8c7a2deefc7eb7902c2a.txt
+++ b/test/snapshots/engine/html_safe_assertions_visitor_test/test_0004_every_html_safe_call_in_a_template_is_wrapped_-_compilation_043a7c9d45ac8c7a2deefc7eb7902c2a.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::HTMLSafeAssertionsVisitorTest#test_0004_every html_safe call in a template is wrapped - compilation"
+input: "{source: \"<div><%= a.html_safe %> and <%= b.html_safe %></div>\", options: {escape: false, parser_options: {strict: false}, visitors: [#<Herb::Engine::HTMLSafeAssertionsVisitor mode=:raise ignore=[] file_path=\"app/views/test.html.erb\">]}}"
+---
+_buf = ::String.new; _buf << '<div>'.freeze; _buf << (::Herb::Engine::HTMLSafeAssertions.check(a, file: "app/views/test.html.erb".freeze, line: 1, column: 6, source: "<%= a.html_safe %>".freeze, mode: :raise).html_safe).to_s; _buf << ' and '.freeze; _buf << (::Herb::Engine::HTMLSafeAssertions.check(b, file: "app/views/test.html.erb".freeze, line: 1, column: 29, source: "<%= b.html_safe %>".freeze, mode: :raise).html_safe).to_s; _buf << '</div>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/html_safe_assertions_visitor_test/test_0005_html_safe_inside_a_block_tag_is_wrapped_-_compilation_f126e4c39015626be4f8136711c96c3a.txt
+++ b/test/snapshots/engine/html_safe_assertions_visitor_test/test_0005_html_safe_inside_a_block_tag_is_wrapped_-_compilation_f126e4c39015626be4f8136711c96c3a.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::HTMLSafeAssertionsVisitorTest#test_0005_html_safe inside a block tag is wrapped - compilation"
+input: "{source: \"<%= link_to \\\"Home\\\", root_path(query.html_safe) do %>Home<% end %>\", options: {escape: false, parser_options: {strict: false}, visitors: [#<Herb::Engine::HTMLSafeAssertionsVisitor mode=:raise ignore=[] file_path=\"app/views/test.html.erb\">]}}"
+---
+_buf = ::String.new; _buf << (link_to "Home", root_path(::Herb::Engine::HTMLSafeAssertions.check(query, file: "app/views/test.html.erb".freeze, line: 1, column: 1, source: "<%= link_to \"Home\", root_path(query.html_safe) do %>".freeze, mode: :raise).html_safe) do; _buf << 'Home'.freeze; end);
+_buf.to_s

--- a/test/snapshots/engine/html_safe_assertions_visitor_test/test_0006_html_safe_in_a_control_flow_fragment_is_wrapped_-_compilation_a269b8043f6c3dd1014639af4e6d8161.txt
+++ b/test/snapshots/engine/html_safe_assertions_visitor_test/test_0006_html_safe_in_a_control_flow_fragment_is_wrapped_-_compilation_a269b8043f6c3dd1014639af4e6d8161.txt
@@ -1,0 +1,7 @@
+---
+source: "Engine::HTMLSafeAssertionsVisitorTest#test_0006_html_safe in a control flow fragment is wrapped - compilation"
+input: "{source: \"<% if a %>A<% elsif b.html_safe %>B<% end %>\", options: {escape: false, parser_options: {strict: false}, visitors: [#<Herb::Engine::HTMLSafeAssertionsVisitor mode=:raise ignore=[] file_path=\"app/views/test.html.erb\">]}}"
+---
+_buf = ::String.new; if a 
+ _buf << 'A'.freeze; elsif ::Herb::Engine::HTMLSafeAssertions.check(b, file: "app/views/test.html.erb".freeze, line: 1, column: 12, source: "<% elsif b.html_safe %>".freeze, mode: :raise).html_safe; _buf << 'B'.freeze; end;
+_buf.to_s

--- a/test/snapshots/engine/html_safe_assertions_visitor_test/test_0007_template_without_html_safe_is_left_alone_-_compilation_f9736669375c0fb5b89833bfa672fb07.txt
+++ b/test/snapshots/engine/html_safe_assertions_visitor_test/test_0007_template_without_html_safe_is_left_alone_-_compilation_f9736669375c0fb5b89833bfa672fb07.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::HTMLSafeAssertionsVisitorTest#test_0007_template without html_safe is left alone - compilation"
+input: "{source: \"<div><%= @user.bio %></div>\", options: {escape: false, parser_options: {strict: false}, visitors: [#<Herb::Engine::HTMLSafeAssertionsVisitor mode=:raise ignore=[] file_path=\"app/views/test.html.erb\">]}}"
+---
+_buf = ::String.new; _buf << '<div>'.freeze; _buf << (@user.bio).to_s; _buf << '</div>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/html_safe_assertions_visitor_test/test_0012_ignored_checks_are_baked_into_the_assertion_-_compilation_9d20ad503f448ba833a32e1fad96d17e.txt
+++ b/test/snapshots/engine/html_safe_assertions_visitor_test/test_0012_ignored_checks_are_baked_into_the_assertion_-_compilation_9d20ad503f448ba833a32e1fad96d17e.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::HTMLSafeAssertionsVisitorTest#test_0012_ignored checks are baked into the assertion - compilation"
+input: "{source: \"<div><%= @user.bio.html_safe %></div>\", options: {escape: false, parser_options: {strict: false}, visitors: [#<Herb::Engine::HTMLSafeAssertionsVisitor mode=:raise ignore=[:risky_element, :meta_refresh] file_path=\"app/views/test.html.erb\">]}}"
+---
+_buf = ::String.new; _buf << '<div>'.freeze; _buf << (::Herb::Engine::HTMLSafeAssertions.check(@user.bio, file: "app/views/test.html.erb".freeze, line: 1, column: 6, source: "<%= @user.bio.html_safe %>".freeze, mode: :raise, ignore: [:risky_element, :meta_refresh].freeze).html_safe).to_s; _buf << '</div>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/html_safe_assertions_visitor_test/test_0014_safe_value_passes_through_unchanged_-_render_026ae4ee479f9c7e5f1c5c487c20dcb8.txt
+++ b/test/snapshots/engine/html_safe_assertions_visitor_test/test_0014_safe_value_passes_through_unchanged_-_render_026ae4ee479f9c7e5f1c5c487c20dcb8.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::HTMLSafeAssertionsVisitorTest#test_0014_safe value passes through unchanged - render"
+input: "{source: \"<div><%= bio.html_safe %></div>\", locals: {bio: \"<p>About me</p>\"}, options: {escape: false, parser_options: {strict: false}, visitors: [#<Herb::Engine::HTMLSafeAssertionsVisitor mode=:raise ignore=[] file_path=\"app/views/test.html.erb\">]}}"
+---
+<div><p>About me</p></div>

--- a/test/snapshots/engine/html_safe_assertions_visitor_test/test_0015_value_without_html_safe_is_never_checked_-_render_44d8e277418a673ef9fb9b1c4778597b.txt
+++ b/test/snapshots/engine/html_safe_assertions_visitor_test/test_0015_value_without_html_safe_is_never_checked_-_render_44d8e277418a673ef9fb9b1c4778597b.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::HTMLSafeAssertionsVisitorTest#test_0015_value without html_safe is never checked - render"
+input: "{source: \"<div><%= bio %></div>\", locals: {bio: \"<script>alert(1)</script>\"}, options: {escape: false, parser_options: {strict: false}, visitors: [#<Herb::Engine::HTMLSafeAssertionsVisitor mode=:raise ignore=[] file_path=\"app/views/test.html.erb\">]}}"
+---
+<div><script>alert(1)</script></div>

--- a/test/snapshots/engine/html_safe_assertions_visitor_test/test_0016_value_that_is_already_html_safe_is_not_checked_-_render_1cc8c218add6cea9c6cc00a8d37a028d.txt
+++ b/test/snapshots/engine/html_safe_assertions_visitor_test/test_0016_value_that_is_already_html_safe_is_not_checked_-_render_1cc8c218add6cea9c6cc00a8d37a028d.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::HTMLSafeAssertionsVisitorTest#test_0016_value that is already html safe is not checked - render"
+input: "{source: \"<div><%= bio.html_safe %></div>\", locals: {bio: \"<script>alert(1)</script>\"}, options: {escape: false, parser_options: {strict: false}, visitors: [#<Herb::Engine::HTMLSafeAssertionsVisitor mode=:raise ignore=[] file_path=\"app/views/test.html.erb\">]}}"
+---
+<div><script>alert(1)</script></div>

--- a/test/snapshots/engine/html_safe_assertions_visitor_test/test_0017_ignored_check_renders_the_value_-_render_60f9b68722cfbb92de260d5e458d041e.txt
+++ b/test/snapshots/engine/html_safe_assertions_visitor_test/test_0017_ignored_check_renders_the_value_-_render_60f9b68722cfbb92de260d5e458d041e.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::HTMLSafeAssertionsVisitorTest#test_0017_ignored check renders the value - render"
+input: "{source: \"<div><%= bio.html_safe %></div>\", locals: {bio: \"<iframe src=\\\"https://example.com\\\"></iframe>\"}, options: {escape: false, parser_options: {strict: false}, visitors: [#<Herb::Engine::HTMLSafeAssertionsVisitor mode=:raise ignore=[:risky_element] file_path=\"app/views/test.html.erb\">]}}"
+---
+<div><iframe src="https://example.com"></iframe></div>

--- a/test/snapshots/engine/html_safe_assertions_visitor_test/test_0022_html_safe_passed_as_a_block_argument_is_wrapped_-_compilation_abbdd98ae3bb0beddd9ed7df82bc6af1.txt
+++ b/test/snapshots/engine/html_safe_assertions_visitor_test/test_0022_html_safe_passed_as_a_block_argument_is_wrapped_-_compilation_abbdd98ae3bb0beddd9ed7df82bc6af1.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::HTMLSafeAssertionsVisitorTest#test_0022_html_safe passed as a block argument is wrapped - compilation"
+input: "{source: \"<div><%= items.map(&:html_safe).join %></div>\", options: {escape: false, parser_options: {strict: false}, visitors: [#<Herb::Engine::HTMLSafeAssertionsVisitor mode=:raise ignore=[] file_path=\"app/views/test.html.erb\">]}}"
+---
+_buf = ::String.new; _buf << '<div>'.freeze; _buf << (items.map(&->(value, *rest) { ::Herb::Engine::HTMLSafeAssertions.check(value, file: "app/views/test.html.erb".freeze, line: 1, column: 6, source: "<%= items.map(&:html_safe).join %>".freeze, mode: :raise).html_safe(*rest) }).join).to_s; _buf << '</div>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/html_safe_assertions_visitor_test/test_0023_html_safe_passed_as_a_block_argument_checks_every_element_-_render_c01a7b42300581486ee846462b751f06.txt
+++ b/test/snapshots/engine/html_safe_assertions_visitor_test/test_0023_html_safe_passed_as_a_block_argument_checks_every_element_-_render_c01a7b42300581486ee846462b751f06.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::HTMLSafeAssertionsVisitorTest#test_0023_html_safe passed as a block argument checks every element - render"
+input: "{source: \"<div><%= items.map(&:html_safe).join %></div>\", locals: {items: [\"<p>one</p>\", \"<p>two</p>\"]}, options: {escape: false, parser_options: {strict: false}, visitors: [#<Herb::Engine::HTMLSafeAssertionsVisitor mode=:raise ignore=[] file_path=\"app/views/test.html.erb\">]}}"
+---
+<div><p>one</p><p>two</p></div>

--- a/test/visitor_test.rb
+++ b/test/visitor_test.rb
@@ -56,4 +56,170 @@ class VisitorTest < Minitest::Spec
     assert result.failed?
     assert_equal expected_nodes, visitor.visited_nodes.map(&:class).map(&:to_s)
   end
+
+  test "visitor requires and recommends no parser options by default" do
+    assert_empty Herb::Visitor.new.required_parser_options
+    assert_empty Herb::Visitor.new.recommended_parser_options
+    assert_empty VisitedNodesVisitor.new.required_parser_options
+    assert_empty VisitedNodesVisitor.new.recommended_parser_options
+  end
+
+  test "required_parser_option declares an option the visitor needs" do
+    visitor = Class.new(Herb::Visitor) do
+      required_parser_option prism_program: true
+    end
+
+    assert_equal({ prism_program: true }, visitor.new.required_parser_options)
+    assert_equal({ prism_program: true }, visitor.required_parser_options)
+  end
+
+  test "required_parser_option can be called more than once" do
+    visitor = Class.new(Herb::Visitor) do
+      required_parser_option prism_program: true
+      required_parser_option strict: false
+    end
+
+    assert_equal({ prism_program: true, strict: false }, visitor.new.required_parser_options)
+  end
+
+  test "required_parser_option takes string keys as symbols" do
+    visitor = Class.new(Herb::Visitor) do
+      required_parser_option "prism_program" => true
+    end
+
+    assert_equal({ prism_program: true }, visitor.new.required_parser_options)
+  end
+
+  test "required_parser_option is inherited and can be overridden by a subclass" do
+    parent = Class.new(Herb::Visitor) do
+      required_parser_option prism_program: true
+      required_parser_option strict: true
+    end
+
+    child = Class.new(parent) do
+      required_parser_option strict: false
+      required_parser_option analyze: true
+    end
+
+    assert_equal({ prism_program: true, strict: true }, parent.new.required_parser_options)
+    assert_equal({ prism_program: true, strict: false, analyze: true }, child.new.required_parser_options)
+  end
+
+  test "required_parser_option on a subclass leaves the parent alone" do
+    parent = Class.new(Herb::Visitor)
+    child = Class.new(parent) { required_parser_option prism_program: true }
+
+    assert_empty parent.new.required_parser_options
+    assert_equal({ prism_program: true }, child.new.required_parser_options)
+  end
+
+  test "recommended_parser_option declares an option the visitor prefers" do
+    visitor = Class.new(Herb::Visitor) do
+      recommended_parser_option prism_program: true
+      recommended_parser_option strict: false
+    end
+
+    assert_equal({ prism_program: true, strict: false }, visitor.new.recommended_parser_options)
+    assert_equal({ prism_program: true, strict: false }, visitor.recommended_parser_options)
+  end
+
+  test "recommended_parser_option is inherited and can be overridden by a subclass" do
+    parent = Class.new(Herb::Visitor) { recommended_parser_option strict: true }
+    child = Class.new(parent) { recommended_parser_option strict: false }
+
+    assert_equal({ strict: true }, parent.new.recommended_parser_options)
+    assert_equal({ strict: false }, child.new.recommended_parser_options)
+  end
+
+  test "required and recommended parser options are kept apart" do
+    visitor = Class.new(Herb::Visitor) do
+      required_parser_option prism_program: true
+      recommended_parser_option strict: false
+    end
+
+    assert_equal({ prism_program: true }, visitor.new.required_parser_options)
+    assert_equal({ strict: false }, visitor.new.recommended_parser_options)
+  end
+
+  test "declared parser options cannot be changed through the reader" do
+    visitor = Class.new(Herb::Visitor) { required_parser_option prism_program: true }
+
+    visitor.required_parser_options[:strict] = false
+
+    assert_equal({ prism_program: true }, visitor.new.required_parser_options)
+  end
+
+  test "parser_options_for collects what an array of visitors asks for" do
+    visitors = [
+      Class.new(Herb::Visitor) { required_parser_option prism_program: true }.new,
+      Class.new(Herb::Visitor) { recommended_parser_option analyze: true }.new,
+      Class.new(Herb::Visitor).new
+    ]
+
+    assert_equal({ prism_program: true, analyze: true }, Herb::Visitor.parser_options_for(visitors))
+  end
+
+  test "parser_options_for keeps the options it was given" do
+    visitors = [Class.new(Herb::Visitor) { required_parser_option prism_program: true }.new]
+
+    assert_equal({ strict: false, prism_program: true }, Herb::Visitor.parser_options_for(visitors, { strict: false }))
+  end
+
+  test "parser_options_for takes the given options with string keys" do
+    visitors = [Class.new(Herb::Visitor) { required_parser_option prism_program: true }.new]
+
+    assert_equal({ strict: false, prism_program: true }, Herb::Visitor.parser_options_for(visitors, { "strict" => false }))
+  end
+
+  test "parser_options_for does not change the options it was given" do
+    visitors = [Class.new(Herb::Visitor) { required_parser_option prism_program: true }.new]
+    given = { strict: false }
+
+    Herb::Visitor.parser_options_for(visitors, given)
+
+    assert_equal({ strict: false }, given)
+  end
+
+  test "parser_options_for raises when a required option conflicts" do
+    visitors = [Class.new(Herb::Visitor) { required_parser_option prism_program: true }.new]
+
+    error = assert_raises(ArgumentError) do
+      Herb::Visitor.parser_options_for(visitors, { prism_program: false })
+    end
+
+    assert_includes error.message, "requires the `prism_program` parser option to be true, but it is set to false"
+  end
+
+  test "parser_options_for warns and keeps the given value when a recommended option conflicts" do
+    visitors = [Class.new(Herb::Visitor) { recommended_parser_option prism_program: true }.new]
+    options = nil
+
+    _out, err = capture_io do
+      options = Herb::Visitor.parser_options_for(visitors, { prism_program: false })
+    end
+
+    assert_includes err, "recommends the `prism_program` parser option to be true, but it is set to false"
+    assert_equal({ prism_program: false }, options)
+  end
+
+  test "parser_options_for accepts visitors that know nothing about parser options" do
+    assert_empty Herb::Visitor.parser_options_for([Object.new])
+    assert_empty Herb::Visitor.parser_options_for([])
+  end
+
+  test "a class that is not a visitor can declare parser options too" do
+    klass = Class.new do
+      include Herb::Visitor::ParserOptionRequirements
+
+      required_parser_option prism_program: true
+      recommended_parser_option strict: false
+    end
+
+    visitor = klass.new
+
+    assert_equal({ prism_program: true }, visitor.required_parser_options)
+    assert_equal({ strict: false }, visitor.recommended_parser_options)
+    assert_equal({ prism_program: true, strict: false }, Herb::Visitor.parser_options_for([visitor]))
+    assert_equal({ prism_program: true, strict: false }, klass.parser_options_for([visitor]))
+  end
 end


### PR DESCRIPTION
This pull request adds a `Herb::Engine::HTMLSafeAssertionsVisitor`, a transform visitor that wraps the receiver of every `.html_safe` call in a template with a runtime assertion, so that marking a value as HTML-safe raises when the value turns out to contain HTML that the browser executes.

`.html_safe` is the one escape hatch that turns off Action View's escaping entirely. Whether a given call is safe depends on what ends up in the string at render time, which no static check can know. 

The linter can tell you that `"<br>".html_safe` is unnecessary, but it cannot tell you that `@user.bio.html_safe` is about to emit a `<script>` element that came from a form submission. This visitor moves that question to the point where the answer exists.

The visitor is not loaded by default. Require it and pass it to the engine:

```ruby
require "herb/engine/html_safe_assertions_visitor"

Herb::Engine.new(source, visitors: [Herb::Engine::HTMLSafeAssertionsVisitor.new])
```

This template:

```html+erb
<div><%= @user.bio.html_safe %></div>
```

Compiles as if it had been written as:

```html+erb
<div><%= ::Herb::Engine::HTMLSafeAssertions.check(@user.bio, file: __FILE__, line: 1, column: 6, source: "<%= @user.bio.html_safe %>".freeze, mode: :raise).html_safe %></div>
```

`check` returns the value untouched, so the value keeps flowing through `.html_safe` exactly as before and the rendered output is byte for byte identical. Rendering that template with a bio of `<script>alert(1)</script>` raises `Herb::Engine::HTMLSafeAssertions::UnsafeHTMLError`:

```
Unsafe `.html_safe` call in app/views/users/show.html.erb:1:6

    <%= @user.bio.html_safe %>

The value contains a `<script>` element, which the browser executes.

    "<script>alert(1)</script>"

Escape the value or run it through `sanitize` instead of marking it as HTML-safe.
```

The error surfaces while the template renders, not while it compiles, unlike the ones the engine's validators raise. It carries `file`, `line`, `column`, `source`, `value` and `violations`, so it can be reported anywhere.

Calls are found in the Prism program the parser attaches to the document rather than by re-parsing each ERB tag, which means the visitor sees the template's Ruby as one program with positions preserved. A call is wrapped wherever it appears, including in control flow fragments that do not parse on their own:

```html+erb
<% if a %>A<% elsif b.html_safe %>B<% end %>
```