### PR TITLE
Java: Fix the build so it actually compiles and runs the tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,6 +103,7 @@ java/nodes.c
 java/nodes.h
 java/org/herb/ast/Errors.java
 java/org/herb/ast/HelperRegistry.java
+java/org/herb/ast/HelperType.java
 java/org/herb/ast/Nodes.java
 java/org/herb/ast/NodeVisitor.java
 java/org/herb/ast/Visitor.java

--- a/java/Makefile
+++ b/java/Makefile
@@ -16,6 +16,7 @@ else ifeq ($(os),Linux)
   JNI_LIB_EXT = so
   JNI_LIB_PREFIX = lib
   CC = clang
+  LD_UNDEFINED_FLAGS = -Wl,--no-undefined
 else
   JNI_LIB_EXT = dll
   JNI_LIB_PREFIX =
@@ -32,7 +33,7 @@ JAVAC = $(JAVA_HOME)/bin/javac
 JAVA_CMD = $(JAVA_HOME)/bin/java
 CFLAGS = -std=gnu99 -Wall -Wextra -fPIC -O2 -DHERB_EXCLUDE_PRETTYPRINT -DPRISM_EXCLUDE_PRETTYPRINT -DPRISM_EXCLUDE_JSON -DPRISM_EXCLUDE_PACK
 INCLUDES = -I. -I$(SRC_DIR)/include -I$(PRISM_INCLUDE) $(JNI_INCLUDES)
-LDFLAGS = -shared
+LDFLAGS = -shared $(LD_UNDEFINED_FLAGS)
 LIBS = $(PRISM_BUILD)/libprism.a
 
 HERB_SOURCES = $(shell find $(SRC_DIR) -name '*.c')
@@ -94,11 +95,9 @@ java: $(JAVA_TIMESTAMP)
 
 $(JAVA_TIMESTAMP): $(JAVA_SOURCES) $(JUNIT_JAR)
 	@mkdir -p target/classes
-	@if [ -n "$(JAVA_SOURCES)" ]; then \
-		$(JAVAC) -cp $(JUNIT_JAR) -d target/classes $(JAVA_SOURCES); \
-		touch $(JAVA_TIMESTAMP); \
-		echo "Compiled Java classes"; \
-	fi
+	$(JAVAC) -cp $(JUNIT_JAR) -d target/classes $(JAVA_SOURCES)
+	@touch $(JAVA_TIMESTAMP)
+	@echo "Compiled Java classes"
 
 .PHONY: test
 test: jni java
@@ -106,7 +105,8 @@ test: jni java
 		-Djava.library.path=$(BUILD_DIR) \
 		-jar $(JUNIT_JAR) execute \
 		--class-path target/classes \
-		--select-package org.herb
+		--select-package org.herb \
+		--fail-if-no-tests
 
 .PHONY: cli
 cli: all

--- a/templates/java/nodes.c.erb
+++ b/templates/java/nodes.c.erb
@@ -113,6 +113,10 @@ jobject NodesArrayFromCArray(JNIEnv* env, hb_array_T* array) {
   return javaList;
 }
 
+jobject CreateASTNode(JNIEnv* env, AST_NODE_T* node) {
+  return NodeFromCStruct(env, node);
+}
+
 <%- nodes.each do |node| -%>
 jobject Create<%= node.name %>(JNIEnv* env, <%= node.struct_type %>* <%= node.human %>) {
   return <%= node.name %>FromCStruct(env, <%= node.human %>);

--- a/templates/java/org/herb/ast/HelperRegistry.java.erb
+++ b/templates/java/org/herb/ast/HelperRegistry.java.erb
@@ -6,34 +6,6 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Type enum for all supported Action View tag helpers.
- */
-public enum HelperType {
-<%- helpers.each_with_index do |helper, index| -%>
-  <%= helper.constant_name %>("<%= helper.name %>")<%= index < helpers.size - 1 ? "," : ";" %>
-<%- end -%>
-
-  private final String name;
-
-  HelperType(String name) {
-    this.name = name;
-  }
-
-  public String getName() {
-    return name;
-  }
-
-  public static HelperType fromName(String name) {
-    for (HelperType type : values()) {
-      if (type.name.equals(name)) {
-        return type;
-      }
-    }
-    return null;
-  }
-}
-
-/**
  * Argument metadata for a tag helper.
  */
 class HelperArgument {

--- a/templates/java/org/herb/ast/HelperType.java.erb
+++ b/templates/java/org/herb/ast/HelperType.java.erb
@@ -1,0 +1,29 @@
+package org.herb.ast;
+
+/**
+ * Type enum for all supported Action View tag helpers.
+ */
+public enum HelperType {
+<%- helpers.each_with_index do |helper, index| -%>
+  <%= helper.constant_name %>("<%= helper.name %>")<%= index < helpers.size - 1 ? "," : ";" %>
+<%- end -%>
+
+  private final String name;
+
+  HelperType(String name) {
+    this.name = name;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public static HelperType fromName(String name) {
+    for (HelperType type : values()) {
+      if (type.name.equals(name)) {
+        return type;
+      }
+    }
+    return null;
+  }
+}


### PR DESCRIPTION
This pull request fixes the Java CI job, which was reporting success while compiling nothing and running zero tests.

The `java` target swallowed `javac`'s exit status, so a compile error left `target/classes` empty, touched the timestamp file anyway, and printed `Compiled Java classes`:

```make
@if [ -n "$(JAVA_SOURCES)" ]; then \
    $(JAVAC) -cp $(JUNIT_JAR) -d target/classes $(JAVA_SOURCES); \
    touch $(JAVA_TIMESTAMP); \
    echo "Compiled Java classes"; \
fi
```

The commands are separated by `;` rather than `&&`, so only the last one decides the recipe's exit code. `make test` then pointed the JUnit console launcher at that empty directory, and without `--fail-if-no-tests` an empty run is a passing run. The CI log for the most recent build on `main` shows the whole story:

```
[ 0 tests found      ]
[ 0 tests successful ]
```