### PR TITLE
Playground: Fix parser diagnostic codes in production builds

### DIFF
--- a/playground/src/controllers/playground_controller.js
+++ b/playground/src/controllers/playground_controller.js
@@ -1558,7 +1558,7 @@ export default class extends Controller {
         const diagnostic = error.toMonacoDiagnostic()
 
         diagnostic.source = "Herb Parser"
-        diagnostic.code = diagnostic.code || error.constructor?.name || 'parser-error'
+        diagnostic.code = diagnostic.code || error.code || error.type || 'parser-error'
 
         return diagnostic
       }))


### PR DESCRIPTION
This pull request updates the Diagnostics panel to derive parser diagnostic codes from the error's stable `type` field instead of `error.constructor?.name`.

In production builds, Rolldown renames colliding class identifiers while bundling, so the class-name fallback produced mangled codes like `MissingClosingTagError$1`. The `keepNames` setup from #1607 doesn't prevent these deconflict renames.

**Before**

`MissingClosingTagError$1`

**After**

`MISSING_CLOSING_TAG_ERROR`

