### PR TITLE
Parser: Properly handle asset tag helper options and duplicate sources

### DIFF
--- a/javascript/packages/rewriter/test/action-view-tag-helper-to-html.test.ts
+++ b/javascript/packages/rewriter/test/action-view-tag-helper-to-html.test.ts
@@ -655,7 +655,7 @@ describe("ActionViewTagHelperToHTMLRewriter", () => {
 
     test("javascript_include_tag with defer", () => {
       expect(transform(`<%= javascript_include_tag "application", defer: true %>`)).toBe(
-        `<script defer src="<%= javascript_path("application") %>"></script>`
+        `<script src="<%= javascript_path("application") %>" defer></script>`
       )
     })
 
@@ -670,7 +670,7 @@ describe("ActionViewTagHelperToHTMLRewriter", () => {
 
     test("javascript_include_tag with nonce true resolves to content_security_policy_nonce", () => {
       expect(transform(`<%= javascript_include_tag "application", nonce: true %>`)).toBe(
-        `<script nonce="<%= content_security_policy_nonce %>" src="<%= javascript_path("application") %>"></script>`
+        `<script src="<%= javascript_path("application") %>" nonce="<%= content_security_policy_nonce %>"></script>`
       )
     })
 
@@ -682,13 +682,13 @@ describe("ActionViewTagHelperToHTMLRewriter", () => {
 
     test("javascript_include_tag with interpolated nonce", () => {
       expect(transform('<%= javascript_include_tag "application", nonce: "static-#{dynamic}" %>')).toBe(
-        '<script nonce="static-<%= dynamic %>" src="<%= javascript_path("application") %>"></script>'
+        '<script src="<%= javascript_path("application") %>" nonce="static-<%= dynamic %>"></script>'
       )
     })
 
     test("javascript_include_tag with data attributes", () => {
       expect(transform(`<%= javascript_include_tag "application", data: { turbo_track: "reload" } %>`)).toBe(
-        `<script data-turbo-track="reload" src="<%= javascript_path("application") %>"></script>`
+        `<script src="<%= javascript_path("application") %>" data-turbo-track="reload"></script>`
       )
     })
 
@@ -718,25 +718,25 @@ describe("ActionViewTagHelperToHTMLRewriter", () => {
 
     test("javascript_include_tag with URL and nonce", () => {
       expect(transform(`<%= javascript_include_tag "http://www.example.com/xmlhr.js", nonce: true %>`)).toBe(
-        `<script nonce="<%= content_security_policy_nonce %>" src="http://www.example.com/xmlhr.js"></script>`
+        `<script src="http://www.example.com/xmlhr.js" nonce="<%= content_security_policy_nonce %>"></script>`
       )
     })
 
     test("javascript_include_tag with URL and async", () => {
       expect(transform(`<%= javascript_include_tag "http://www.example.com/xmlhr.js", async: true %>`)).toBe(
-        `<script async src="http://www.example.com/xmlhr.js"></script>`
+        `<script src="http://www.example.com/xmlhr.js" async></script>`
       )
     })
 
     test("javascript_include_tag with URL and defer", () => {
       expect(transform(`<%= javascript_include_tag "http://www.example.com/xmlhr.js", defer: true %>`)).toBe(
-        `<script defer src="http://www.example.com/xmlhr.js"></script>`
+        `<script src="http://www.example.com/xmlhr.js" defer></script>`
       )
     })
 
     test("javascript_include_tag with defer as string", () => {
       expect(transform(`<%= javascript_include_tag "application", defer: "true" %>`)).toBe(
-        `<script defer="true" src="<%= javascript_path("application") %>"></script>`
+        `<script src="<%= javascript_path("application") %>" defer="true"></script>`
       )
     })
 

--- a/src/analyze/action_view/tag_helpers.c
+++ b/src/analyze/action_view/tag_helpers.c
@@ -433,11 +433,51 @@ static AST_NODE_T* remove_attribute_by_name(hb_array_T* attributes, const char* 
   return NULL;
 }
 
+static void remove_asset_tag_non_html_options(hb_array_T* attributes) {
+  if (!attributes) { return; }
+
+  remove_attribute_by_name(attributes, "extname");
+  remove_attribute_by_name(attributes, "host");
+  remove_attribute_by_name(attributes, "protocol");
+  remove_attribute_by_name(attributes, "skip-pipeline");
+  remove_attribute_by_name(attributes, "nopush");
+  remove_attribute_by_name(attributes, "preload-links-header");
+}
+
+static AST_NODE_T* extract_crossorigin_attribute(hb_array_T* attributes, hb_allocator_T* allocator) {
+  AST_NODE_T* node = remove_attribute_by_name(attributes, "crossorigin");
+
+  if (!node || node->type != AST_HTML_ATTRIBUTE_NODE) { return node; }
+
+  AST_HTML_ATTRIBUTE_NODE_T* attribute = (AST_HTML_ATTRIBUTE_NODE_T*) node;
+
+  if (!attribute->value || !attribute->value->children || hb_array_size(attribute->value->children) != 1) {
+    return node;
+  }
+
+  AST_NODE_T* value = (AST_NODE_T*) hb_array_get(attribute->value->children, 0);
+
+  if (!value || value->type != AST_LITERAL_NODE) { return node; }
+
+  AST_LITERAL_NODE_T* literal = (AST_LITERAL_NODE_T*) value;
+
+  if (!hb_string_equals(literal->content, hb_string("true"))) { return node; }
+
+  return (AST_NODE_T*) create_html_attribute_node(
+    "crossorigin",
+    "anonymous",
+    attribute->base.location.start,
+    attribute->base.location.end,
+    allocator
+  );
+}
+
 static hb_array_T* prepend_stylesheet_link_tag_attributes(
   hb_array_T* attributes,
   tag_helper_parse_context_T* parse_context,
   pm_node_t* source_argument,
   const char* path_options,
+  AST_NODE_T* crossorigin_attribute,
   hb_allocator_T* allocator
 ) {
   bool source_is_string = (source_argument->type == PM_STRING_NODE);
@@ -485,6 +525,7 @@ static hb_array_T* prepend_stylesheet_link_tag_attributes(
   hb_allocator_dealloc(allocator, source_value);
 
   if (href_attribute) { attributes = prepend_attribute(attributes, (AST_NODE_T*) href_attribute, allocator); }
+  if (crossorigin_attribute) { attributes = prepend_attribute(attributes, crossorigin_attribute, allocator); }
 
   AST_NODE_T* rel_attribute = remove_attribute_by_name(attributes, "rel");
 
@@ -535,6 +576,7 @@ static AST_NODE_T* transform_tag_helper_with_attributes(
   }
 
   char* path_options = NULL;
+  AST_NODE_T* crossorigin_attribute = NULL;
 
   if (attributes && handler->name && strcmp(handler->name, "javascript_include_tag") == 0) {
     path_options = extract_path_options_from_keyword_hash(
@@ -543,10 +585,8 @@ static AST_NODE_T* transform_tag_helper_with_attributes(
       allocator
     );
 
-    remove_attribute_by_name(attributes, "extname");
-    remove_attribute_by_name(attributes, "host");
-    remove_attribute_by_name(attributes, "protocol");
-    remove_attribute_by_name(attributes, "skip-pipeline");
+    remove_asset_tag_non_html_options(attributes);
+    crossorigin_attribute = extract_crossorigin_attribute(attributes, allocator);
   }
 
   if (attributes && handler->name && strcmp(handler->name, "stylesheet_link_tag") == 0) {
@@ -556,10 +596,8 @@ static AST_NODE_T* transform_tag_helper_with_attributes(
       allocator
     );
 
-    remove_attribute_by_name(attributes, "extname");
-    remove_attribute_by_name(attributes, "host");
-    remove_attribute_by_name(attributes, "protocol");
-    remove_attribute_by_name(attributes, "skip-pipeline");
+    remove_asset_tag_non_html_options(attributes);
+    crossorigin_attribute = extract_crossorigin_attribute(attributes, allocator);
   }
 
   if (attributes && handler->name && strcmp(handler->name, "image_tag") == 0) {
@@ -748,7 +786,8 @@ static AST_NODE_T* transform_tag_helper_with_attributes(
           ? create_html_attribute_node("src", source_attribute_value, source_start, source_end, allocator)
           : create_html_attribute_with_ruby_literal("src", source_attribute_value, source_start, source_end, allocator);
 
-      if (source_attribute) { hb_array_append(attributes, (AST_NODE_T*) source_attribute); }
+      if (crossorigin_attribute) { attributes = prepend_attribute(attributes, crossorigin_attribute, allocator); }
+      if (source_attribute) { attributes = prepend_attribute(attributes, (AST_NODE_T*) source_attribute, allocator); }
 
       if (source_attribute_value != source_value) { hb_allocator_dealloc(allocator, source_attribute_value); }
       hb_allocator_dealloc(allocator, source_value);
@@ -806,8 +845,14 @@ static AST_NODE_T* transform_tag_helper_with_attributes(
     if (first_argument->type != PM_KEYWORD_HASH_NODE) {
       if (!attributes) { attributes = hb_array_init(4, allocator); }
 
-      attributes =
-        prepend_stylesheet_link_tag_attributes(attributes, parse_context, first_argument, path_options, allocator);
+      attributes = prepend_stylesheet_link_tag_attributes(
+        attributes,
+        parse_context,
+        first_argument,
+        path_options,
+        crossorigin_attribute,
+        allocator
+      );
     }
   }
 
@@ -958,12 +1003,69 @@ static size_t count_asset_tag_sources(pm_call_node_t* call_node) {
   return count;
 }
 
+static bool asset_tag_sources_are_equal(pm_node_t* left, pm_node_t* right) {
+  bool left_is_string = (left->type == PM_STRING_NODE);
+  bool right_is_string = (right->type == PM_STRING_NODE);
+
+  if (left_is_string != right_is_string) { return false; }
+
+  if (left_is_string) {
+    pm_string_t* left_string = &((pm_string_node_t*) left)->unescaped;
+    pm_string_t* right_string = &((pm_string_node_t*) right)->unescaped;
+    size_t length = pm_string_length(left_string);
+
+    return length == pm_string_length(right_string)
+        && memcmp(pm_string_source(left_string), pm_string_source(right_string), length) == 0;
+  }
+
+  size_t left_length = left->location.end - left->location.start;
+  size_t right_length = right->location.end - right->location.start;
+
+  return left_length == right_length && memcmp(left->location.start, right->location.start, left_length) == 0;
+}
+
+static size_t collect_unique_asset_tag_sources(pm_call_node_t* call_node, pm_node_t** sources, size_t capacity) {
+  size_t total = count_asset_tag_sources(call_node);
+  size_t unique = 0;
+
+  for (size_t i = 0; i < total && unique < capacity; i++) {
+    pm_node_t* source = call_node->arguments->arguments.nodes[i];
+    bool seen = false;
+
+    for (size_t j = 0; j < unique; j++) {
+      if (asset_tag_sources_are_equal(sources[j], source)) {
+        seen = true;
+        break;
+      }
+    }
+
+    if (!seen) { sources[unique++] = source; }
+  }
+
+  return unique;
+}
+
+static size_t count_unique_asset_tag_sources(pm_call_node_t* call_node) {
+  size_t total = count_asset_tag_sources(call_node);
+
+  if (total == 0) { return 0; }
+
+  pm_node_t** sources = malloc(sizeof(pm_node_t*) * total);
+  if (!sources) { return total; }
+
+  size_t unique = collect_unique_asset_tag_sources(call_node, sources, total);
+  free(sources);
+
+  return unique;
+}
+
 static AST_NODE_T* create_javascript_include_tag_element(
   AST_ERB_CONTENT_NODE_T* erb_node,
   tag_helper_parse_context_T* parse_context,
   pm_node_t* source_argument,
   hb_array_T* shared_attributes,
   const char* path_options,
+  AST_NODE_T* crossorigin_attribute,
   hb_allocator_T* allocator
 ) {
   position_T tag_name_start, tag_name_end;
@@ -1008,13 +1110,14 @@ static AST_NODE_T* create_javascript_include_tag_element(
     hb_allocator_dealloc(allocator, quoted_source);
   }
 
-  hb_array_T* attributes = hb_array_init(hb_array_size(shared_attributes) + 1, allocator);
+  hb_array_T* attributes = hb_array_init(hb_array_size(shared_attributes) + 2, allocator);
 
   AST_HTML_ATTRIBUTE_NODE_T* source_attribute =
     is_url
       ? create_html_attribute_node("src", source_attribute_value, source_start, source_end, allocator)
       : create_html_attribute_with_ruby_literal("src", source_attribute_value, source_start, source_end, allocator);
   if (source_attribute) { hb_array_append(attributes, source_attribute); }
+  if (crossorigin_attribute) { hb_array_append(attributes, crossorigin_attribute); }
 
   for (size_t i = 0; i < hb_array_size(shared_attributes); i++) {
     hb_array_append(attributes, hb_array_get(shared_attributes, i));
@@ -1068,6 +1171,11 @@ static hb_array_T* transform_javascript_include_tag_multi_source(
 
   if (source_count == 0) { return NULL; }
 
+  pm_node_t** sources = hb_allocator_alloc(allocator, sizeof(pm_node_t*) * source_count);
+  if (!sources) { return NULL; }
+
+  size_t unique_count = collect_unique_asset_tag_sources(call_node, sources, source_count);
+
   hb_array_T* shared_attributes = extract_html_attributes_from_call_node(
     call_node,
     parse_context->prism_source,
@@ -1081,21 +1189,21 @@ static hb_array_T* transform_javascript_include_tag_multi_source(
 
   char* path_options =
     extract_path_options_from_keyword_hash(call_node, JAVASCRIPT_INCLUDE_TAG_PATH_OPTIONS, allocator);
-  remove_attribute_by_name(shared_attributes, "extname");
-  remove_attribute_by_name(shared_attributes, "host");
-  remove_attribute_by_name(shared_attributes, "protocol");
-  remove_attribute_by_name(shared_attributes, "skip-pipeline");
+  remove_asset_tag_non_html_options(shared_attributes);
 
-  hb_array_T* elements = hb_array_init(source_count * 2, allocator);
+  AST_NODE_T* crossorigin_attribute = extract_crossorigin_attribute(shared_attributes, allocator);
 
-  for (size_t i = 0; i < source_count; i++) {
-    pm_node_t* source_arg = call_node->arguments->arguments.nodes[i];
+  hb_array_T* elements = hb_array_init(unique_count * 2, allocator);
+
+  for (size_t i = 0; i < unique_count; i++) {
+    pm_node_t* source_arg = sources[i];
     AST_NODE_T* element = create_javascript_include_tag_element(
       erb_node,
       parse_context,
       source_arg,
       shared_attributes,
       path_options,
+      crossorigin_attribute,
       allocator
     );
 
@@ -1116,6 +1224,8 @@ static hb_array_T* transform_javascript_include_tag_multi_source(
     }
   }
 
+  hb_allocator_dealloc(allocator, sources);
+
   return elements;
 }
 
@@ -1125,6 +1235,7 @@ static AST_NODE_T* create_stylesheet_link_tag_element(
   pm_node_t* source_argument,
   hb_array_T* shared_attributes,
   const char* path_options,
+  AST_NODE_T* crossorigin_attribute,
   hb_allocator_T* allocator
 ) {
   position_T tag_name_start, tag_name_end;
@@ -1138,14 +1249,20 @@ static AST_NODE_T* create_stylesheet_link_tag_element(
 
   token_T* tag_name_token = create_synthetic_token(allocator, "link", TOKEN_IDENTIFIER, tag_name_start, tag_name_end);
 
-  hb_array_T* attributes = hb_array_init(hb_array_size(shared_attributes) + 2, allocator);
+  hb_array_T* attributes = hb_array_init(hb_array_size(shared_attributes) + 3, allocator);
 
   for (size_t i = 0; i < hb_array_size(shared_attributes); i++) {
     hb_array_append(attributes, hb_array_get(shared_attributes, i));
   }
 
-  attributes =
-    prepend_stylesheet_link_tag_attributes(attributes, parse_context, source_argument, path_options, allocator);
+  attributes = prepend_stylesheet_link_tag_attributes(
+    attributes,
+    parse_context,
+    source_argument,
+    path_options,
+    crossorigin_attribute,
+    allocator
+  );
 
   AST_ERB_OPEN_TAG_NODE_T* open_tag_node = ast_erb_open_tag_node_init(
     erb_node->tag_opening,
@@ -1184,6 +1301,11 @@ static hb_array_T* transform_stylesheet_link_tag_multi_source(
 
   if (source_count == 0) { return NULL; }
 
+  pm_node_t** sources = hb_allocator_alloc(allocator, sizeof(pm_node_t*) * source_count);
+  if (!sources) { return NULL; }
+
+  size_t unique_count = collect_unique_asset_tag_sources(call_node, sources, source_count);
+
   hb_array_T* shared_attributes = extract_html_attributes_from_call_node(
     call_node,
     parse_context->prism_source,
@@ -1196,21 +1318,21 @@ static hb_array_T* transform_stylesheet_link_tag_multi_source(
   resolve_nonce_attribute(shared_attributes, allocator);
 
   char* path_options = extract_path_options_from_keyword_hash(call_node, STYLESHEET_LINK_TAG_PATH_OPTIONS, allocator);
-  remove_attribute_by_name(shared_attributes, "extname");
-  remove_attribute_by_name(shared_attributes, "host");
-  remove_attribute_by_name(shared_attributes, "protocol");
-  remove_attribute_by_name(shared_attributes, "skip-pipeline");
+  remove_asset_tag_non_html_options(shared_attributes);
 
-  hb_array_T* elements = hb_array_init(source_count * 2, allocator);
+  AST_NODE_T* crossorigin_attribute = extract_crossorigin_attribute(shared_attributes, allocator);
 
-  for (size_t i = 0; i < source_count; i++) {
-    pm_node_t* source_arg = call_node->arguments->arguments.nodes[i];
+  hb_array_T* elements = hb_array_init(unique_count * 2, allocator);
+
+  for (size_t i = 0; i < unique_count; i++) {
+    pm_node_t* source_arg = sources[i];
     AST_NODE_T* element = create_stylesheet_link_tag_element(
       erb_node,
       parse_context,
       source_arg,
       shared_attributes,
       path_options,
+      crossorigin_attribute,
       allocator
     );
 
@@ -1230,6 +1352,8 @@ static hb_array_T* transform_stylesheet_link_tag_multi_source(
       hb_array_append(elements, element);
     }
   }
+
+  hb_allocator_dealloc(allocator, sources);
 
   return elements;
 }
@@ -1788,7 +1912,7 @@ void transform_tag_helper_array(hb_array_T* array, analyze_ruby_context_T* conte
           bool is_multi_source_asset_tag = (strcmp(parse_context->matched_handler->name, "javascript_include_tag") == 0
                                             || strcmp(parse_context->matched_handler->name, "stylesheet_link_tag") == 0)
                                         && parse_context->info->call_node
-                                        && count_asset_tag_sources(parse_context->info->call_node) > 1;
+                                        && count_unique_asset_tag_sources(parse_context->info->call_node) > 1;
 
           if (is_multi_source_asset_tag) {
             hb_array_T* multi = strcmp(parse_context->matched_handler->name, "stylesheet_link_tag") == 0

--- a/test/analyze/action_view/asset_tag_helper/javascript_include_tag_test.rb
+++ b/test/analyze/action_view/asset_tag_helper/javascript_include_tag_test.rb
@@ -125,5 +125,29 @@ module Analyze::ActionView::AssetTagHelper
         <%= javascript_include_tag "application", skip_pipeline: true %>
       HTML
     end
+
+    test "javascript_include_tag with duplicate sources" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <%= javascript_include_tag "application", "application" %>
+      HTML
+    end
+
+    test "javascript_include_tag with crossorigin true" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <%= javascript_include_tag "application", crossorigin: true %>
+      HTML
+    end
+
+    test "javascript_include_tag with nopush" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <%= javascript_include_tag "application", nopush: true %>
+      HTML
+    end
+
+    test "javascript_include_tag with preload_links_header" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <%= javascript_include_tag "application", preload_links_header: false %>
+      HTML
+    end
   end
 end

--- a/test/analyze/action_view/asset_tag_helper/stylesheet_link_tag_test.rb
+++ b/test/analyze/action_view/asset_tag_helper/stylesheet_link_tag_test.rb
@@ -113,5 +113,29 @@ module Analyze::ActionView::AssetTagHelper
         <%= stylesheet_link_tag "application", "admin", media: "all" %>
       HTML
     end
+
+    test "stylesheet_link_tag with duplicate sources" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <%= stylesheet_link_tag "application", "application" %>
+      HTML
+    end
+
+    test "stylesheet_link_tag with crossorigin true" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <%= stylesheet_link_tag "application", crossorigin: true %>
+      HTML
+    end
+
+    test "stylesheet_link_tag with nopush" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <%= stylesheet_link_tag "application", nopush: true %>
+      HTML
+    end
+
+    test "stylesheet_link_tag with preload_links_header" do
+      assert_parsed_snapshot(<<~HTML, action_view_helpers: true)
+        <%= stylesheet_link_tag "application", preload_links_header: false %>
+      HTML
+    end
   end
 end

--- a/test/engine/action_view/javascript_include_tag_test.rb
+++ b/test/engine/action_view/javascript_include_tag_test.rb
@@ -11,7 +11,7 @@ module Engine
         assert_optimized_snapshot('<%= javascript_include_tag "application" %>')
       end
 
-      # TODO: Attribute ordering (defer before src) and boolean attribute style (defer vs defer="defer")
+      # TODO: Boolean attribute style (defer vs defer="defer")
       test "javascript_include_tag with defer" do
         assert_optimized_mismatch_snapshot('<%= javascript_include_tag "application", defer: true %>')
       end
@@ -20,14 +20,41 @@ module Engine
         assert_optimized_snapshot('<%= javascript_include_tag "http://www.example.com/xmlhr.js" %>')
       end
 
-      # TODO: Boolean attribute style (async vs async="async") and attribute ordering
+      # TODO: Boolean attribute style (async vs async="async")
       test "javascript_include_tag with URL and async" do
         assert_optimized_mismatch_snapshot('<%= javascript_include_tag "http://www.example.com/xmlhr.js", async: true %>')
       end
 
-      # TODO: Attribute ordering (data-turbo-track before src vs after)
       test "javascript_include_tag with data attributes" do
-        assert_optimized_mismatch_snapshot('<%= javascript_include_tag "application", data: { turbo_track: "reload" } %>')
+        assert_optimized_snapshot('<%= javascript_include_tag "application", data: { turbo_track: "reload" } %>')
+      end
+
+      test "javascript_include_tag with duplicate sources" do
+        assert_optimized_snapshot('<%= javascript_include_tag "application", "application" %>')
+      end
+
+      test "javascript_include_tag with duplicate sources among distinct ones" do
+        assert_optimized_snapshot('<%= javascript_include_tag "application", "vendor", "application" %>')
+      end
+
+      test "javascript_include_tag with crossorigin true" do
+        assert_optimized_snapshot('<%= javascript_include_tag "application", crossorigin: true %>')
+      end
+
+      test "javascript_include_tag with crossorigin string" do
+        assert_optimized_snapshot('<%= javascript_include_tag "application", crossorigin: "use-credentials" %>')
+      end
+
+      test "javascript_include_tag with nopush" do
+        assert_optimized_snapshot('<%= javascript_include_tag "application", nopush: true %>')
+      end
+
+      test "javascript_include_tag with preload_links_header" do
+        assert_optimized_snapshot('<%= javascript_include_tag "application", preload_links_header: false %>')
+      end
+
+      test "javascript_include_tag with integrity" do
+        assert_optimized_snapshot('<%= javascript_include_tag "application", integrity: "sha256-abc" %>')
       end
     end
   end

--- a/test/engine/action_view/stylesheet_link_tag_test.rb
+++ b/test/engine/action_view/stylesheet_link_tag_test.rb
@@ -60,6 +60,34 @@ module Engine
       test "stylesheet_link_tag with multiple sources and media" do
         assert_optimized_snapshot('<%= stylesheet_link_tag "application", "admin", media: "all" %>')
       end
+
+      test "stylesheet_link_tag with duplicate sources" do
+        assert_optimized_snapshot('<%= stylesheet_link_tag "application", "application" %>')
+      end
+
+      test "stylesheet_link_tag with duplicate sources among distinct ones" do
+        assert_optimized_snapshot('<%= stylesheet_link_tag "application", "admin", "application" %>')
+      end
+
+      test "stylesheet_link_tag with crossorigin true" do
+        assert_optimized_snapshot('<%= stylesheet_link_tag "application", crossorigin: true %>')
+      end
+
+      test "stylesheet_link_tag with crossorigin string" do
+        assert_optimized_snapshot('<%= stylesheet_link_tag "application", crossorigin: "use-credentials", media: "all" %>')
+      end
+
+      test "stylesheet_link_tag with nopush" do
+        assert_optimized_snapshot('<%= stylesheet_link_tag "application", nopush: true %>')
+      end
+
+      test "stylesheet_link_tag with preload_links_header" do
+        assert_optimized_snapshot('<%= stylesheet_link_tag "application", preload_links_header: false %>')
+      end
+
+      test "stylesheet_link_tag with integrity" do
+        assert_optimized_snapshot('<%= stylesheet_link_tag "application", integrity: "sha256-abc" %>')
+      end
     end
   end
 end

--- a/test/snapshots/analyze/action_view/asset_tag_helper/java_script_include_tag_test/test_0003_javascript_include_tag_with_defer_3bfdc4f61b770eb2a3dc138c52381ba7-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/asset_tag_helper/java_script_include_tag_test/test_0003_javascript_include_tag_with_defer_3bfdc4f61b770eb2a3dc138c52381ba7-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -14,36 +14,36 @@ options: {action_view_helpers: true}
     │   │       ├── tag_closing: "%>" (location: (1:54)-(1:56))
     │   │       ├── tag_name: "script" (location: (1:4)-(1:26))
     │   │       └── children: (2 items)
-    │   │           ├── @ HTMLAttributeNode (location: (1:42)-(1:47))
+    │   │           ├── @ HTMLAttributeNode (location: (1:27)-(1:40))
     │   │           │   ├── name:
-    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:42)-(1:47))
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:27)-(1:40))
     │   │           │   │       └── children: (1 item)
-    │   │           │   │           └── @ LiteralNode (location: (1:42)-(1:47))
-    │   │           │   │               └── content: "defer"
+    │   │           │   │           └── @ LiteralNode (location: (1:27)-(1:40))
+    │   │           │   │               └── content: "src"
     │   │           │   │
     │   │           │   │
-    │   │           │   ├── equals: ∅
-    │   │           │   └── value: ∅
+    │   │           │   ├── equals: ":" (location: (1:27)-(1:40))
+    │   │           │   └── value:
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:27)-(1:40))
+    │   │           │           ├── open_quote: ∅
+    │   │           │           ├── children: (1 item)
+    │   │           │           │   └── @ RubyLiteralNode (location: (1:27)-(1:40))
+    │   │           │           │       └── content: "javascript_path(\"application\")"
+    │   │           │           │
+    │   │           │           ├── close_quote: ∅
+    │   │           │           └── quoted: true
     │   │           │
-    │   │           └── @ HTMLAttributeNode (location: (1:27)-(1:40))
+    │   │           │
+    │   │           └── @ HTMLAttributeNode (location: (1:42)-(1:47))
     │   │               ├── name:
-    │   │               │   └── @ HTMLAttributeNameNode (location: (1:27)-(1:40))
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:42)-(1:47))
     │   │               │       └── children: (1 item)
-    │   │               │           └── @ LiteralNode (location: (1:27)-(1:40))
-    │   │               │               └── content: "src"
+    │   │               │           └── @ LiteralNode (location: (1:42)-(1:47))
+    │   │               │               └── content: "defer"
     │   │               │
     │   │               │
-    │   │               ├── equals: ":" (location: (1:27)-(1:40))
-    │   │               └── value:
-    │   │                   └── @ HTMLAttributeValueNode (location: (1:27)-(1:40))
-    │   │                       ├── open_quote: ∅
-    │   │                       ├── children: (1 item)
-    │   │                       │   └── @ RubyLiteralNode (location: (1:27)-(1:40))
-    │   │                       │       └── content: "javascript_path(\"application\")"
-    │   │                       │
-    │   │                       ├── close_quote: ∅
-    │   │                       └── quoted: true
-    │   │
+    │   │               ├── equals: ∅
+    │   │               └── value: ∅
     │   │
     │   │
     │   ├── tag_name: "script" (location: (1:4)-(1:26))

--- a/test/snapshots/analyze/action_view/asset_tag_helper/java_script_include_tag_test/test_0004_javascript_include_tag_with_nonce_true_4e9ac675501ab7d7b7f4b9cd0c549e49-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/asset_tag_helper/java_script_include_tag_test/test_0004_javascript_include_tag_with_nonce_true_4e9ac675501ab7d7b7f4b9cd0c549e49-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -14,41 +14,41 @@ options: {action_view_helpers: true}
     │   │       ├── tag_closing: "%>" (location: (1:54)-(1:56))
     │   │       ├── tag_name: "script" (location: (1:4)-(1:26))
     │   │       └── children: (2 items)
-    │   │           ├── @ HTMLAttributeNode (location: (1:42)-(1:53))
+    │   │           ├── @ HTMLAttributeNode (location: (1:27)-(1:40))
     │   │           │   ├── name:
-    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:42)-(1:47))
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:27)-(1:40))
     │   │           │   │       └── children: (1 item)
-    │   │           │   │           └── @ LiteralNode (location: (1:42)-(1:47))
-    │   │           │   │               └── content: "nonce"
+    │   │           │   │           └── @ LiteralNode (location: (1:27)-(1:40))
+    │   │           │   │               └── content: "src"
     │   │           │   │
     │   │           │   │
-    │   │           │   ├── equals: ": " (location: (1:47)-(1:49))
+    │   │           │   ├── equals: ":" (location: (1:27)-(1:40))
     │   │           │   └── value:
-    │   │           │       └── @ HTMLAttributeValueNode (location: (1:49)-(1:53))
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:27)-(1:40))
     │   │           │           ├── open_quote: ∅
     │   │           │           ├── children: (1 item)
-    │   │           │           │   └── @ RubyLiteralNode (location: (1:49)-(1:53))
-    │   │           │           │       └── content: "content_security_policy_nonce"
+    │   │           │           │   └── @ RubyLiteralNode (location: (1:27)-(1:40))
+    │   │           │           │       └── content: "javascript_path(\"application\")"
     │   │           │           │
     │   │           │           ├── close_quote: ∅
     │   │           │           └── quoted: true
     │   │           │
     │   │           │
-    │   │           └── @ HTMLAttributeNode (location: (1:27)-(1:40))
+    │   │           └── @ HTMLAttributeNode (location: (1:42)-(1:53))
     │   │               ├── name:
-    │   │               │   └── @ HTMLAttributeNameNode (location: (1:27)-(1:40))
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:42)-(1:47))
     │   │               │       └── children: (1 item)
-    │   │               │           └── @ LiteralNode (location: (1:27)-(1:40))
-    │   │               │               └── content: "src"
+    │   │               │           └── @ LiteralNode (location: (1:42)-(1:47))
+    │   │               │               └── content: "nonce"
     │   │               │
     │   │               │
-    │   │               ├── equals: ":" (location: (1:27)-(1:40))
+    │   │               ├── equals: ": " (location: (1:47)-(1:49))
     │   │               └── value:
-    │   │                   └── @ HTMLAttributeValueNode (location: (1:27)-(1:40))
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:49)-(1:53))
     │   │                       ├── open_quote: ∅
     │   │                       ├── children: (1 item)
-    │   │                       │   └── @ RubyLiteralNode (location: (1:27)-(1:40))
-    │   │                       │       └── content: "javascript_path(\"application\")"
+    │   │                       │   └── @ RubyLiteralNode (location: (1:49)-(1:53))
+    │   │                       │       └── content: "content_security_policy_nonce"
     │   │                       │
     │   │                       ├── close_quote: ∅
     │   │                       └── quoted: true

--- a/test/snapshots/analyze/action_view/asset_tag_helper/java_script_include_tag_test/test_0011_javascript_include_tag_with_URL_and_nonce_e6e5ca2ea1add00d7447893972171cd4-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/asset_tag_helper/java_script_include_tag_test/test_0011_javascript_include_tag_with_URL_and_nonce_e6e5ca2ea1add00d7447893972171cd4-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -14,43 +14,43 @@ options: {action_view_helpers: true}
     │   │       ├── tag_closing: "%>" (location: (1:74)-(1:76))
     │   │       ├── tag_name: "script" (location: (1:4)-(1:26))
     │   │       └── children: (2 items)
-    │   │           ├── @ HTMLAttributeNode (location: (1:62)-(1:73))
+    │   │           ├── @ HTMLAttributeNode (location: (1:27)-(1:60))
     │   │           │   ├── name:
-    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:62)-(1:67))
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:27)-(1:60))
     │   │           │   │       └── children: (1 item)
-    │   │           │   │           └── @ LiteralNode (location: (1:62)-(1:67))
-    │   │           │   │               └── content: "nonce"
+    │   │           │   │           └── @ LiteralNode (location: (1:27)-(1:60))
+    │   │           │   │               └── content: "src"
     │   │           │   │
     │   │           │   │
-    │   │           │   ├── equals: ": " (location: (1:67)-(1:69))
+    │   │           │   ├── equals: "=" (location: (1:27)-(1:60))
     │   │           │   └── value:
-    │   │           │       └── @ HTMLAttributeValueNode (location: (1:69)-(1:73))
-    │   │           │           ├── open_quote: ∅
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:27)-(1:60))
+    │   │           │           ├── open_quote: """ (location: (1:27)-(1:27))
     │   │           │           ├── children: (1 item)
-    │   │           │           │   └── @ RubyLiteralNode (location: (1:69)-(1:73))
-    │   │           │           │       └── content: "content_security_policy_nonce"
+    │   │           │           │   └── @ LiteralNode (location: (1:27)-(1:60))
+    │   │           │           │       └── content: "http://www.example.com/xmlhr.js"
     │   │           │           │
-    │   │           │           ├── close_quote: ∅
+    │   │           │           ├── close_quote: """ (location: (1:60)-(1:60))
     │   │           │           └── quoted: true
     │   │           │
     │   │           │
-    │   │           └── @ HTMLAttributeNode (location: (1:27)-(1:60))
+    │   │           └── @ HTMLAttributeNode (location: (1:62)-(1:73))
     │   │               ├── name:
-    │   │               │   └── @ HTMLAttributeNameNode (location: (1:27)-(1:60))
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:62)-(1:67))
     │   │               │       └── children: (1 item)
-    │   │               │           └── @ LiteralNode (location: (1:27)-(1:60))
-    │   │               │               └── content: "src"
+    │   │               │           └── @ LiteralNode (location: (1:62)-(1:67))
+    │   │               │               └── content: "nonce"
     │   │               │
     │   │               │
-    │   │               ├── equals: "=" (location: (1:27)-(1:60))
+    │   │               ├── equals: ": " (location: (1:67)-(1:69))
     │   │               └── value:
-    │   │                   └── @ HTMLAttributeValueNode (location: (1:27)-(1:60))
-    │   │                       ├── open_quote: """ (location: (1:27)-(1:27))
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:69)-(1:73))
+    │   │                       ├── open_quote: ∅
     │   │                       ├── children: (1 item)
-    │   │                       │   └── @ LiteralNode (location: (1:27)-(1:60))
-    │   │                       │       └── content: "http://www.example.com/xmlhr.js"
+    │   │                       │   └── @ RubyLiteralNode (location: (1:69)-(1:73))
+    │   │                       │       └── content: "content_security_policy_nonce"
     │   │                       │
-    │   │                       ├── close_quote: """ (location: (1:60)-(1:60))
+    │   │                       ├── close_quote: ∅
     │   │                       └── quoted: true
     │   │
     │   │

--- a/test/snapshots/analyze/action_view/asset_tag_helper/java_script_include_tag_test/test_0012_javascript_include_tag_with_URL_and_async_66c17a6412db1cd30d6f46bdbfc20e71-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/asset_tag_helper/java_script_include_tag_test/test_0012_javascript_include_tag_with_URL_and_async_66c17a6412db1cd30d6f46bdbfc20e71-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -14,36 +14,36 @@ options: {action_view_helpers: true}
     │   │       ├── tag_closing: "%>" (location: (1:74)-(1:76))
     │   │       ├── tag_name: "script" (location: (1:4)-(1:26))
     │   │       └── children: (2 items)
-    │   │           ├── @ HTMLAttributeNode (location: (1:62)-(1:67))
+    │   │           ├── @ HTMLAttributeNode (location: (1:27)-(1:60))
     │   │           │   ├── name:
-    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:62)-(1:67))
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:27)-(1:60))
     │   │           │   │       └── children: (1 item)
-    │   │           │   │           └── @ LiteralNode (location: (1:62)-(1:67))
-    │   │           │   │               └── content: "async"
+    │   │           │   │           └── @ LiteralNode (location: (1:27)-(1:60))
+    │   │           │   │               └── content: "src"
     │   │           │   │
     │   │           │   │
-    │   │           │   ├── equals: ∅
-    │   │           │   └── value: ∅
+    │   │           │   ├── equals: "=" (location: (1:27)-(1:60))
+    │   │           │   └── value:
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:27)-(1:60))
+    │   │           │           ├── open_quote: """ (location: (1:27)-(1:27))
+    │   │           │           ├── children: (1 item)
+    │   │           │           │   └── @ LiteralNode (location: (1:27)-(1:60))
+    │   │           │           │       └── content: "http://www.example.com/xmlhr.js"
+    │   │           │           │
+    │   │           │           ├── close_quote: """ (location: (1:60)-(1:60))
+    │   │           │           └── quoted: true
     │   │           │
-    │   │           └── @ HTMLAttributeNode (location: (1:27)-(1:60))
+    │   │           │
+    │   │           └── @ HTMLAttributeNode (location: (1:62)-(1:67))
     │   │               ├── name:
-    │   │               │   └── @ HTMLAttributeNameNode (location: (1:27)-(1:60))
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:62)-(1:67))
     │   │               │       └── children: (1 item)
-    │   │               │           └── @ LiteralNode (location: (1:27)-(1:60))
-    │   │               │               └── content: "src"
+    │   │               │           └── @ LiteralNode (location: (1:62)-(1:67))
+    │   │               │               └── content: "async"
     │   │               │
     │   │               │
-    │   │               ├── equals: "=" (location: (1:27)-(1:60))
-    │   │               └── value:
-    │   │                   └── @ HTMLAttributeValueNode (location: (1:27)-(1:60))
-    │   │                       ├── open_quote: """ (location: (1:27)-(1:27))
-    │   │                       ├── children: (1 item)
-    │   │                       │   └── @ LiteralNode (location: (1:27)-(1:60))
-    │   │                       │       └── content: "http://www.example.com/xmlhr.js"
-    │   │                       │
-    │   │                       ├── close_quote: """ (location: (1:60)-(1:60))
-    │   │                       └── quoted: true
-    │   │
+    │   │               ├── equals: ∅
+    │   │               └── value: ∅
     │   │
     │   │
     │   ├── tag_name: "script" (location: (1:4)-(1:26))

--- a/test/snapshots/analyze/action_view/asset_tag_helper/java_script_include_tag_test/test_0013_javascript_include_tag_with_URL_and_defer_dd8c527689fccedcd61334018c4747bd-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/asset_tag_helper/java_script_include_tag_test/test_0013_javascript_include_tag_with_URL_and_defer_dd8c527689fccedcd61334018c4747bd-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -14,36 +14,36 @@ options: {action_view_helpers: true}
     │   │       ├── tag_closing: "%>" (location: (1:74)-(1:76))
     │   │       ├── tag_name: "script" (location: (1:4)-(1:26))
     │   │       └── children: (2 items)
-    │   │           ├── @ HTMLAttributeNode (location: (1:62)-(1:67))
+    │   │           ├── @ HTMLAttributeNode (location: (1:27)-(1:60))
     │   │           │   ├── name:
-    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:62)-(1:67))
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:27)-(1:60))
     │   │           │   │       └── children: (1 item)
-    │   │           │   │           └── @ LiteralNode (location: (1:62)-(1:67))
-    │   │           │   │               └── content: "defer"
+    │   │           │   │           └── @ LiteralNode (location: (1:27)-(1:60))
+    │   │           │   │               └── content: "src"
     │   │           │   │
     │   │           │   │
-    │   │           │   ├── equals: ∅
-    │   │           │   └── value: ∅
+    │   │           │   ├── equals: "=" (location: (1:27)-(1:60))
+    │   │           │   └── value:
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:27)-(1:60))
+    │   │           │           ├── open_quote: """ (location: (1:27)-(1:27))
+    │   │           │           ├── children: (1 item)
+    │   │           │           │   └── @ LiteralNode (location: (1:27)-(1:60))
+    │   │           │           │       └── content: "http://www.example.com/xmlhr.js"
+    │   │           │           │
+    │   │           │           ├── close_quote: """ (location: (1:60)-(1:60))
+    │   │           │           └── quoted: true
     │   │           │
-    │   │           └── @ HTMLAttributeNode (location: (1:27)-(1:60))
+    │   │           │
+    │   │           └── @ HTMLAttributeNode (location: (1:62)-(1:67))
     │   │               ├── name:
-    │   │               │   └── @ HTMLAttributeNameNode (location: (1:27)-(1:60))
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:62)-(1:67))
     │   │               │       └── children: (1 item)
-    │   │               │           └── @ LiteralNode (location: (1:27)-(1:60))
-    │   │               │               └── content: "src"
+    │   │               │           └── @ LiteralNode (location: (1:62)-(1:67))
+    │   │               │               └── content: "defer"
     │   │               │
     │   │               │
-    │   │               ├── equals: "=" (location: (1:27)-(1:60))
-    │   │               └── value:
-    │   │                   └── @ HTMLAttributeValueNode (location: (1:27)-(1:60))
-    │   │                       ├── open_quote: """ (location: (1:27)-(1:27))
-    │   │                       ├── children: (1 item)
-    │   │                       │   └── @ LiteralNode (location: (1:27)-(1:60))
-    │   │                       │       └── content: "http://www.example.com/xmlhr.js"
-    │   │                       │
-    │   │                       ├── close_quote: """ (location: (1:60)-(1:60))
-    │   │                       └── quoted: true
-    │   │
+    │   │               ├── equals: ∅
+    │   │               └── value: ∅
     │   │
     │   │
     │   ├── tag_name: "script" (location: (1:4)-(1:26))

--- a/test/snapshots/analyze/action_view/asset_tag_helper/java_script_include_tag_test/test_0017_javascript_include_tag_with_defer_as_string_4c048dd6a94063b7c42f5a763359f534-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/asset_tag_helper/java_script_include_tag_test/test_0017_javascript_include_tag_with_defer_as_string_4c048dd6a94063b7c42f5a763359f534-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -14,43 +14,43 @@ options: {action_view_helpers: true}
     │   │       ├── tag_closing: "%>" (location: (1:56)-(1:58))
     │   │       ├── tag_name: "script" (location: (1:4)-(1:26))
     │   │       └── children: (2 items)
-    │   │           ├── @ HTMLAttributeNode (location: (1:42)-(1:55))
+    │   │           ├── @ HTMLAttributeNode (location: (1:27)-(1:40))
     │   │           │   ├── name:
-    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:42)-(1:47))
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:27)-(1:40))
     │   │           │   │       └── children: (1 item)
-    │   │           │   │           └── @ LiteralNode (location: (1:42)-(1:47))
-    │   │           │   │               └── content: "defer"
+    │   │           │   │           └── @ LiteralNode (location: (1:27)-(1:40))
+    │   │           │   │               └── content: "src"
     │   │           │   │
     │   │           │   │
-    │   │           │   ├── equals: ": " (location: (1:47)-(1:49))
+    │   │           │   ├── equals: ":" (location: (1:27)-(1:40))
     │   │           │   └── value:
-    │   │           │       └── @ HTMLAttributeValueNode (location: (1:49)-(1:55))
-    │   │           │           ├── open_quote: """ (location: (1:49)-(1:50))
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:27)-(1:40))
+    │   │           │           ├── open_quote: ∅
     │   │           │           ├── children: (1 item)
-    │   │           │           │   └── @ LiteralNode (location: (1:50)-(1:54))
-    │   │           │           │       └── content: "true"
+    │   │           │           │   └── @ RubyLiteralNode (location: (1:27)-(1:40))
+    │   │           │           │       └── content: "javascript_path(\"application\")"
     │   │           │           │
-    │   │           │           ├── close_quote: """ (location: (1:54)-(1:55))
+    │   │           │           ├── close_quote: ∅
     │   │           │           └── quoted: true
     │   │           │
     │   │           │
-    │   │           └── @ HTMLAttributeNode (location: (1:27)-(1:40))
+    │   │           └── @ HTMLAttributeNode (location: (1:42)-(1:55))
     │   │               ├── name:
-    │   │               │   └── @ HTMLAttributeNameNode (location: (1:27)-(1:40))
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:42)-(1:47))
     │   │               │       └── children: (1 item)
-    │   │               │           └── @ LiteralNode (location: (1:27)-(1:40))
-    │   │               │               └── content: "src"
+    │   │               │           └── @ LiteralNode (location: (1:42)-(1:47))
+    │   │               │               └── content: "defer"
     │   │               │
     │   │               │
-    │   │               ├── equals: ":" (location: (1:27)-(1:40))
+    │   │               ├── equals: ": " (location: (1:47)-(1:49))
     │   │               └── value:
-    │   │                   └── @ HTMLAttributeValueNode (location: (1:27)-(1:40))
-    │   │                       ├── open_quote: ∅
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:49)-(1:55))
+    │   │                       ├── open_quote: """ (location: (1:49)-(1:50))
     │   │                       ├── children: (1 item)
-    │   │                       │   └── @ RubyLiteralNode (location: (1:27)-(1:40))
-    │   │                       │       └── content: "javascript_path(\"application\")"
+    │   │                       │   └── @ LiteralNode (location: (1:50)-(1:54))
+    │   │                       │       └── content: "true"
     │   │                       │
-    │   │                       ├── close_quote: ∅
+    │   │                       ├── close_quote: """ (location: (1:54)-(1:55))
     │   │                       └── quoted: true
     │   │
     │   │

--- a/test/snapshots/analyze/action_view/asset_tag_helper/java_script_include_tag_test/test_0018_javascript_include_tag_with_interpolated_nonce_648fad9a18f31eddcce31571252a280c-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/asset_tag_helper/java_script_include_tag_test/test_0018_javascript_include_tag_with_interpolated_nonce_648fad9a18f31eddcce31571252a280c-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -14,47 +14,47 @@ options: {action_view_helpers: true}
     │   │       ├── tag_closing: "%>" (location: (1:69)-(1:71))
     │   │       ├── tag_name: "script" (location: (1:4)-(1:26))
     │   │       └── children: (2 items)
-    │   │           ├── @ HTMLAttributeNode (location: (1:42)-(1:68))
+    │   │           ├── @ HTMLAttributeNode (location: (1:27)-(1:40))
     │   │           │   ├── name:
-    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:42)-(1:68))
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:27)-(1:40))
     │   │           │   │       └── children: (1 item)
-    │   │           │   │           └── @ LiteralNode (location: (1:42)-(1:68))
-    │   │           │   │               └── content: "nonce"
+    │   │           │   │           └── @ LiteralNode (location: (1:27)-(1:40))
+    │   │           │   │               └── content: "src"
     │   │           │   │
     │   │           │   │
-    │   │           │   ├── equals: "=" (location: (1:42)-(1:68))
+    │   │           │   ├── equals: ":" (location: (1:27)-(1:40))
     │   │           │   └── value:
-    │   │           │       └── @ HTMLAttributeValueNode (location: (1:42)-(1:68))
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:27)-(1:40))
     │   │           │           ├── open_quote: ∅
-    │   │           │           ├── children: (2 items)
-    │   │           │           │   ├── @ LiteralNode (location: (1:42)-(1:68))
-    │   │           │           │   │   └── content: "static-"
-    │   │           │           │   │
-    │   │           │           │   └── @ RubyLiteralNode (location: (1:42)-(1:68))
-    │   │           │           │       └── content: "dynamic"
+    │   │           │           ├── children: (1 item)
+    │   │           │           │   └── @ RubyLiteralNode (location: (1:27)-(1:40))
+    │   │           │           │       └── content: "javascript_path(\"application\")"
     │   │           │           │
     │   │           │           ├── close_quote: ∅
-    │   │           │           └── quoted: false
+    │   │           │           └── quoted: true
     │   │           │
     │   │           │
-    │   │           └── @ HTMLAttributeNode (location: (1:27)-(1:40))
+    │   │           └── @ HTMLAttributeNode (location: (1:42)-(1:68))
     │   │               ├── name:
-    │   │               │   └── @ HTMLAttributeNameNode (location: (1:27)-(1:40))
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:42)-(1:68))
     │   │               │       └── children: (1 item)
-    │   │               │           └── @ LiteralNode (location: (1:27)-(1:40))
-    │   │               │               └── content: "src"
+    │   │               │           └── @ LiteralNode (location: (1:42)-(1:68))
+    │   │               │               └── content: "nonce"
     │   │               │
     │   │               │
-    │   │               ├── equals: ":" (location: (1:27)-(1:40))
+    │   │               ├── equals: "=" (location: (1:42)-(1:68))
     │   │               └── value:
-    │   │                   └── @ HTMLAttributeValueNode (location: (1:27)-(1:40))
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:42)-(1:68))
     │   │                       ├── open_quote: ∅
-    │   │                       ├── children: (1 item)
-    │   │                       │   └── @ RubyLiteralNode (location: (1:27)-(1:40))
-    │   │                       │       └── content: "javascript_path(\"application\")"
+    │   │                       ├── children: (2 items)
+    │   │                       │   ├── @ LiteralNode (location: (1:42)-(1:68))
+    │   │                       │   │   └── content: "static-"
+    │   │                       │   │
+    │   │                       │   └── @ RubyLiteralNode (location: (1:42)-(1:68))
+    │   │                       │       └── content: "dynamic"
     │   │                       │
     │   │                       ├── close_quote: ∅
-    │   │                       └── quoted: true
+    │   │                       └── quoted: false
     │   │
     │   │
     │   │

--- a/test/snapshots/analyze/action_view/asset_tag_helper/java_script_include_tag_test/test_0021_javascript_include_tag_with_duplicate_sources_bd40c8356f8a8e208dbb85ccdd00636c-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/asset_tag_helper/java_script_include_tag_test/test_0021_javascript_include_tag_with_duplicate_sources_bd40c8356f8a8e208dbb85ccdd00636c-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,48 @@
+---
+source: "Analyze::ActionView::AssetTagHelper::JavaScriptIncludeTagTest#test_0021_javascript_include_tag with duplicate sources"
+input: |2-
+<%= javascript_include_tag "application", "application" %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:58))
+    │   ├── open_tag:
+    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:58))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " javascript_include_tag "application", "application" " (location: (1:3)-(1:56))
+    │   │       ├── tag_closing: "%>" (location: (1:56)-(1:58))
+    │   │       ├── tag_name: "script" (location: (1:4)-(1:26))
+    │   │       └── children: (1 item)
+    │   │           └── @ HTMLAttributeNode (location: (1:27)-(1:40))
+    │   │               ├── name:
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:27)-(1:40))
+    │   │               │       └── children: (1 item)
+    │   │               │           └── @ LiteralNode (location: (1:27)-(1:40))
+    │   │               │               └── content: "src"
+    │   │               │
+    │   │               │
+    │   │               ├── equals: ":" (location: (1:27)-(1:40))
+    │   │               └── value:
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:27)-(1:40))
+    │   │                       ├── open_quote: ∅
+    │   │                       ├── children: (1 item)
+    │   │                       │   └── @ RubyLiteralNode (location: (1:27)-(1:40))
+    │   │                       │       └── content: "javascript_path(\"application\")"
+    │   │                       │
+    │   │                       ├── close_quote: ∅
+    │   │                       └── quoted: true
+    │   │
+    │   │
+    │   │
+    │   ├── tag_name: "script" (location: (1:4)-(1:26))
+    │   ├── body: []
+    │   ├── close_tag:
+    │   │   └── @ HTMLVirtualCloseTagNode (location: (1:58)-(1:58))
+    │   │       └── tag_name: "script" (location: (1:4)-(1:26))
+    │   │
+    │   ├── is_void: false
+    │   └── element_source: "ActionView::Helpers::AssetTagHelper#javascript_include_tag"
+    │
+    └── @ HTMLTextNode (location: (1:58)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/action_view/asset_tag_helper/java_script_include_tag_test/test_0022_javascript_include_tag_with_crossorigin_true_954526241fd342c7d04115eb521b4d94-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/asset_tag_helper/java_script_include_tag_test/test_0022_javascript_include_tag_with_crossorigin_true_954526241fd342c7d04115eb521b4d94-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,17 +1,17 @@
 ---
-source: "Analyze::ActionView::AssetTagHelper::JavaScriptIncludeTagTest#test_0005_javascript_include_tag with data attributes"
+source: "Analyze::ActionView::AssetTagHelper::JavaScriptIncludeTagTest#test_0022_javascript_include_tag with crossorigin true"
 input: |2-
-<%= javascript_include_tag "application", data: { turbo_track: "reload" } %>
+<%= javascript_include_tag "application", crossorigin: true %>
 options: {action_view_helpers: true}
 ---
 @ DocumentNode (location: (1:0)-(2:0))
 └── children: (2 items)
-    ├── @ HTMLElementNode (location: (1:0)-(1:76))
+    ├── @ HTMLElementNode (location: (1:0)-(1:62))
     │   ├── open_tag:
-    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:76))
+    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:62))
     │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
-    │   │       ├── content: " javascript_include_tag "application", data: { turbo_track: "reload" } " (location: (1:3)-(1:74))
-    │   │       ├── tag_closing: "%>" (location: (1:74)-(1:76))
+    │   │       ├── content: " javascript_include_tag "application", crossorigin: true " (location: (1:3)-(1:60))
+    │   │       ├── tag_closing: "%>" (location: (1:60)-(1:62))
     │   │       ├── tag_name: "script" (location: (1:4)-(1:26))
     │   │       └── children: (2 items)
     │   │           ├── @ HTMLAttributeNode (location: (1:27)-(1:40))
@@ -34,23 +34,23 @@ options: {action_view_helpers: true}
     │   │           │           └── quoted: true
     │   │           │
     │   │           │
-    │   │           └── @ HTMLAttributeNode (location: (1:50)-(1:71))
+    │   │           └── @ HTMLAttributeNode (location: (1:42)-(1:59))
     │   │               ├── name:
-    │   │               │   └── @ HTMLAttributeNameNode (location: (1:50)-(1:61))
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:42)-(1:59))
     │   │               │       └── children: (1 item)
-    │   │               │           └── @ LiteralNode (location: (1:50)-(1:61))
-    │   │               │               └── content: "data-turbo-track"
+    │   │               │           └── @ LiteralNode (location: (1:42)-(1:59))
+    │   │               │               └── content: "crossorigin"
     │   │               │
     │   │               │
-    │   │               ├── equals: ": " (location: (1:61)-(1:63))
+    │   │               ├── equals: "=" (location: (1:42)-(1:59))
     │   │               └── value:
-    │   │                   └── @ HTMLAttributeValueNode (location: (1:63)-(1:71))
-    │   │                       ├── open_quote: """ (location: (1:63)-(1:64))
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:42)-(1:59))
+    │   │                       ├── open_quote: """ (location: (1:42)-(1:42))
     │   │                       ├── children: (1 item)
-    │   │                       │   └── @ LiteralNode (location: (1:64)-(1:70))
-    │   │                       │       └── content: "reload"
+    │   │                       │   └── @ LiteralNode (location: (1:42)-(1:59))
+    │   │                       │       └── content: "anonymous"
     │   │                       │
-    │   │                       ├── close_quote: """ (location: (1:70)-(1:71))
+    │   │                       ├── close_quote: """ (location: (1:59)-(1:59))
     │   │                       └── quoted: true
     │   │
     │   │
@@ -58,11 +58,11 @@ options: {action_view_helpers: true}
     │   ├── tag_name: "script" (location: (1:4)-(1:26))
     │   ├── body: []
     │   ├── close_tag:
-    │   │   └── @ HTMLVirtualCloseTagNode (location: (1:76)-(1:76))
+    │   │   └── @ HTMLVirtualCloseTagNode (location: (1:62)-(1:62))
     │   │       └── tag_name: "script" (location: (1:4)-(1:26))
     │   │
     │   ├── is_void: false
     │   └── element_source: "ActionView::Helpers::AssetTagHelper#javascript_include_tag"
     │
-    └── @ HTMLTextNode (location: (1:76)-(2:0))
+    └── @ HTMLTextNode (location: (1:62)-(2:0))
         └── content: "\n"

--- a/test/snapshots/analyze/action_view/asset_tag_helper/java_script_include_tag_test/test_0023_javascript_include_tag_with_nopush_d3d6cc332ae87006b7b58e2d3b233ba1-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/asset_tag_helper/java_script_include_tag_test/test_0023_javascript_include_tag_with_nopush_d3d6cc332ae87006b7b58e2d3b233ba1-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,48 @@
+---
+source: "Analyze::ActionView::AssetTagHelper::JavaScriptIncludeTagTest#test_0023_javascript_include_tag with nopush"
+input: |2-
+<%= javascript_include_tag "application", nopush: true %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:57))
+    │   ├── open_tag:
+    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:57))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " javascript_include_tag "application", nopush: true " (location: (1:3)-(1:55))
+    │   │       ├── tag_closing: "%>" (location: (1:55)-(1:57))
+    │   │       ├── tag_name: "script" (location: (1:4)-(1:26))
+    │   │       └── children: (1 item)
+    │   │           └── @ HTMLAttributeNode (location: (1:27)-(1:40))
+    │   │               ├── name:
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:27)-(1:40))
+    │   │               │       └── children: (1 item)
+    │   │               │           └── @ LiteralNode (location: (1:27)-(1:40))
+    │   │               │               └── content: "src"
+    │   │               │
+    │   │               │
+    │   │               ├── equals: ":" (location: (1:27)-(1:40))
+    │   │               └── value:
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:27)-(1:40))
+    │   │                       ├── open_quote: ∅
+    │   │                       ├── children: (1 item)
+    │   │                       │   └── @ RubyLiteralNode (location: (1:27)-(1:40))
+    │   │                       │       └── content: "javascript_path(\"application\")"
+    │   │                       │
+    │   │                       ├── close_quote: ∅
+    │   │                       └── quoted: true
+    │   │
+    │   │
+    │   │
+    │   ├── tag_name: "script" (location: (1:4)-(1:26))
+    │   ├── body: []
+    │   ├── close_tag:
+    │   │   └── @ HTMLVirtualCloseTagNode (location: (1:57)-(1:57))
+    │   │       └── tag_name: "script" (location: (1:4)-(1:26))
+    │   │
+    │   ├── is_void: false
+    │   └── element_source: "ActionView::Helpers::AssetTagHelper#javascript_include_tag"
+    │
+    └── @ HTMLTextNode (location: (1:57)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/action_view/asset_tag_helper/java_script_include_tag_test/test_0024_javascript_include_tag_with_preload_links_header_c203847d9d6d6a557481aba978b4b840-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/asset_tag_helper/java_script_include_tag_test/test_0024_javascript_include_tag_with_preload_links_header_c203847d9d6d6a557481aba978b4b840-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,48 @@
+---
+source: "Analyze::ActionView::AssetTagHelper::JavaScriptIncludeTagTest#test_0024_javascript_include_tag with preload_links_header"
+input: |2-
+<%= javascript_include_tag "application", preload_links_header: false %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:72))
+    │   ├── open_tag:
+    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:72))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " javascript_include_tag "application", preload_links_header: false " (location: (1:3)-(1:70))
+    │   │       ├── tag_closing: "%>" (location: (1:70)-(1:72))
+    │   │       ├── tag_name: "script" (location: (1:4)-(1:26))
+    │   │       └── children: (1 item)
+    │   │           └── @ HTMLAttributeNode (location: (1:27)-(1:40))
+    │   │               ├── name:
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:27)-(1:40))
+    │   │               │       └── children: (1 item)
+    │   │               │           └── @ LiteralNode (location: (1:27)-(1:40))
+    │   │               │               └── content: "src"
+    │   │               │
+    │   │               │
+    │   │               ├── equals: ":" (location: (1:27)-(1:40))
+    │   │               └── value:
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:27)-(1:40))
+    │   │                       ├── open_quote: ∅
+    │   │                       ├── children: (1 item)
+    │   │                       │   └── @ RubyLiteralNode (location: (1:27)-(1:40))
+    │   │                       │       └── content: "javascript_path(\"application\")"
+    │   │                       │
+    │   │                       ├── close_quote: ∅
+    │   │                       └── quoted: true
+    │   │
+    │   │
+    │   │
+    │   ├── tag_name: "script" (location: (1:4)-(1:26))
+    │   ├── body: []
+    │   ├── close_tag:
+    │   │   └── @ HTMLVirtualCloseTagNode (location: (1:72)-(1:72))
+    │   │       └── tag_name: "script" (location: (1:4)-(1:26))
+    │   │
+    │   ├── is_void: false
+    │   └── element_source: "ActionView::Helpers::AssetTagHelper#javascript_include_tag"
+    │
+    └── @ HTMLTextNode (location: (1:72)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/action_view/asset_tag_helper/stylesheet_link_tag_test/test_0019_stylesheet_link_tag_with_duplicate_sources_0d72493dc769a417fd1c2d448f6c0324-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/asset_tag_helper/stylesheet_link_tag_test/test_0019_stylesheet_link_tag_with_duplicate_sources_0d72493dc769a417fd1c2d448f6c0324-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,65 @@
+---
+source: "Analyze::ActionView::AssetTagHelper::StylesheetLinkTagTest#test_0019_stylesheet_link_tag with duplicate sources"
+input: |2-
+<%= stylesheet_link_tag "application", "application" %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:55))
+    │   ├── open_tag:
+    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:55))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " stylesheet_link_tag "application", "application" " (location: (1:3)-(1:53))
+    │   │       ├── tag_closing: "%>" (location: (1:53)-(1:55))
+    │   │       ├── tag_name: "link" (location: (1:4)-(1:23))
+    │   │       └── children: (2 items)
+    │   │           ├── @ HTMLAttributeNode (location: (1:24)-(1:37))
+    │   │           │   ├── name:
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:24)-(1:37))
+    │   │           │   │       └── children: (1 item)
+    │   │           │   │           └── @ LiteralNode (location: (1:24)-(1:37))
+    │   │           │   │               └── content: "rel"
+    │   │           │   │
+    │   │           │   │
+    │   │           │   ├── equals: "=" (location: (1:24)-(1:37))
+    │   │           │   └── value:
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:24)-(1:37))
+    │   │           │           ├── open_quote: """ (location: (1:24)-(1:24))
+    │   │           │           ├── children: (1 item)
+    │   │           │           │   └── @ LiteralNode (location: (1:24)-(1:37))
+    │   │           │           │       └── content: "stylesheet"
+    │   │           │           │
+    │   │           │           ├── close_quote: """ (location: (1:37)-(1:37))
+    │   │           │           └── quoted: true
+    │   │           │
+    │   │           │
+    │   │           └── @ HTMLAttributeNode (location: (1:24)-(1:37))
+    │   │               ├── name:
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:24)-(1:37))
+    │   │               │       └── children: (1 item)
+    │   │               │           └── @ LiteralNode (location: (1:24)-(1:37))
+    │   │               │               └── content: "href"
+    │   │               │
+    │   │               │
+    │   │               ├── equals: ":" (location: (1:24)-(1:37))
+    │   │               └── value:
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:24)-(1:37))
+    │   │                       ├── open_quote: ∅
+    │   │                       ├── children: (1 item)
+    │   │                       │   └── @ RubyLiteralNode (location: (1:24)-(1:37))
+    │   │                       │       └── content: "stylesheet_path(\"application\")"
+    │   │                       │
+    │   │                       ├── close_quote: ∅
+    │   │                       └── quoted: true
+    │   │
+    │   │
+    │   │
+    │   ├── tag_name: "link" (location: (1:4)-(1:23))
+    │   ├── body: []
+    │   ├── close_tag: ∅
+    │   ├── is_void: true
+    │   └── element_source: "ActionView::Helpers::AssetTagHelper#stylesheet_link_tag"
+    │
+    └── @ HTMLTextNode (location: (1:55)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/action_view/asset_tag_helper/stylesheet_link_tag_test/test_0020_stylesheet_link_tag_with_crossorigin_true_98fa5d1881a2f4df45874ce68bc70db9-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/asset_tag_helper/stylesheet_link_tag_test/test_0020_stylesheet_link_tag_with_crossorigin_true_98fa5d1881a2f4df45874ce68bc70db9-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,85 @@
+---
+source: "Analyze::ActionView::AssetTagHelper::StylesheetLinkTagTest#test_0020_stylesheet_link_tag with crossorigin true"
+input: |2-
+<%= stylesheet_link_tag "application", crossorigin: true %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:59))
+    │   ├── open_tag:
+    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:59))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " stylesheet_link_tag "application", crossorigin: true " (location: (1:3)-(1:57))
+    │   │       ├── tag_closing: "%>" (location: (1:57)-(1:59))
+    │   │       ├── tag_name: "link" (location: (1:4)-(1:23))
+    │   │       └── children: (3 items)
+    │   │           ├── @ HTMLAttributeNode (location: (1:24)-(1:37))
+    │   │           │   ├── name:
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:24)-(1:37))
+    │   │           │   │       └── children: (1 item)
+    │   │           │   │           └── @ LiteralNode (location: (1:24)-(1:37))
+    │   │           │   │               └── content: "rel"
+    │   │           │   │
+    │   │           │   │
+    │   │           │   ├── equals: "=" (location: (1:24)-(1:37))
+    │   │           │   └── value:
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:24)-(1:37))
+    │   │           │           ├── open_quote: """ (location: (1:24)-(1:24))
+    │   │           │           ├── children: (1 item)
+    │   │           │           │   └── @ LiteralNode (location: (1:24)-(1:37))
+    │   │           │           │       └── content: "stylesheet"
+    │   │           │           │
+    │   │           │           ├── close_quote: """ (location: (1:37)-(1:37))
+    │   │           │           └── quoted: true
+    │   │           │
+    │   │           │
+    │   │           ├── @ HTMLAttributeNode (location: (1:39)-(1:56))
+    │   │           │   ├── name:
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:39)-(1:56))
+    │   │           │   │       └── children: (1 item)
+    │   │           │   │           └── @ LiteralNode (location: (1:39)-(1:56))
+    │   │           │   │               └── content: "crossorigin"
+    │   │           │   │
+    │   │           │   │
+    │   │           │   ├── equals: "=" (location: (1:39)-(1:56))
+    │   │           │   └── value:
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:39)-(1:56))
+    │   │           │           ├── open_quote: """ (location: (1:39)-(1:39))
+    │   │           │           ├── children: (1 item)
+    │   │           │           │   └── @ LiteralNode (location: (1:39)-(1:56))
+    │   │           │           │       └── content: "anonymous"
+    │   │           │           │
+    │   │           │           ├── close_quote: """ (location: (1:56)-(1:56))
+    │   │           │           └── quoted: true
+    │   │           │
+    │   │           │
+    │   │           └── @ HTMLAttributeNode (location: (1:24)-(1:37))
+    │   │               ├── name:
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:24)-(1:37))
+    │   │               │       └── children: (1 item)
+    │   │               │           └── @ LiteralNode (location: (1:24)-(1:37))
+    │   │               │               └── content: "href"
+    │   │               │
+    │   │               │
+    │   │               ├── equals: ":" (location: (1:24)-(1:37))
+    │   │               └── value:
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:24)-(1:37))
+    │   │                       ├── open_quote: ∅
+    │   │                       ├── children: (1 item)
+    │   │                       │   └── @ RubyLiteralNode (location: (1:24)-(1:37))
+    │   │                       │       └── content: "stylesheet_path(\"application\")"
+    │   │                       │
+    │   │                       ├── close_quote: ∅
+    │   │                       └── quoted: true
+    │   │
+    │   │
+    │   │
+    │   ├── tag_name: "link" (location: (1:4)-(1:23))
+    │   ├── body: []
+    │   ├── close_tag: ∅
+    │   ├── is_void: true
+    │   └── element_source: "ActionView::Helpers::AssetTagHelper#stylesheet_link_tag"
+    │
+    └── @ HTMLTextNode (location: (1:59)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/action_view/asset_tag_helper/stylesheet_link_tag_test/test_0021_stylesheet_link_tag_with_nopush_19a6168a87c1f7201d8121ffd643b363-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/asset_tag_helper/stylesheet_link_tag_test/test_0021_stylesheet_link_tag_with_nopush_19a6168a87c1f7201d8121ffd643b363-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,65 @@
+---
+source: "Analyze::ActionView::AssetTagHelper::StylesheetLinkTagTest#test_0021_stylesheet_link_tag with nopush"
+input: |2-
+<%= stylesheet_link_tag "application", nopush: true %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:54))
+    │   ├── open_tag:
+    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:54))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " stylesheet_link_tag "application", nopush: true " (location: (1:3)-(1:52))
+    │   │       ├── tag_closing: "%>" (location: (1:52)-(1:54))
+    │   │       ├── tag_name: "link" (location: (1:4)-(1:23))
+    │   │       └── children: (2 items)
+    │   │           ├── @ HTMLAttributeNode (location: (1:24)-(1:37))
+    │   │           │   ├── name:
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:24)-(1:37))
+    │   │           │   │       └── children: (1 item)
+    │   │           │   │           └── @ LiteralNode (location: (1:24)-(1:37))
+    │   │           │   │               └── content: "rel"
+    │   │           │   │
+    │   │           │   │
+    │   │           │   ├── equals: "=" (location: (1:24)-(1:37))
+    │   │           │   └── value:
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:24)-(1:37))
+    │   │           │           ├── open_quote: """ (location: (1:24)-(1:24))
+    │   │           │           ├── children: (1 item)
+    │   │           │           │   └── @ LiteralNode (location: (1:24)-(1:37))
+    │   │           │           │       └── content: "stylesheet"
+    │   │           │           │
+    │   │           │           ├── close_quote: """ (location: (1:37)-(1:37))
+    │   │           │           └── quoted: true
+    │   │           │
+    │   │           │
+    │   │           └── @ HTMLAttributeNode (location: (1:24)-(1:37))
+    │   │               ├── name:
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:24)-(1:37))
+    │   │               │       └── children: (1 item)
+    │   │               │           └── @ LiteralNode (location: (1:24)-(1:37))
+    │   │               │               └── content: "href"
+    │   │               │
+    │   │               │
+    │   │               ├── equals: ":" (location: (1:24)-(1:37))
+    │   │               └── value:
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:24)-(1:37))
+    │   │                       ├── open_quote: ∅
+    │   │                       ├── children: (1 item)
+    │   │                       │   └── @ RubyLiteralNode (location: (1:24)-(1:37))
+    │   │                       │       └── content: "stylesheet_path(\"application\")"
+    │   │                       │
+    │   │                       ├── close_quote: ∅
+    │   │                       └── quoted: true
+    │   │
+    │   │
+    │   │
+    │   ├── tag_name: "link" (location: (1:4)-(1:23))
+    │   ├── body: []
+    │   ├── close_tag: ∅
+    │   ├── is_void: true
+    │   └── element_source: "ActionView::Helpers::AssetTagHelper#stylesheet_link_tag"
+    │
+    └── @ HTMLTextNode (location: (1:54)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/action_view/asset_tag_helper/stylesheet_link_tag_test/test_0022_stylesheet_link_tag_with_preload_links_header_a54b7e3a25033f3babf07aeedcf19776-ef4af315cb33925c38d24ea3c2e8a1cd.txt
+++ b/test/snapshots/analyze/action_view/asset_tag_helper/stylesheet_link_tag_test/test_0022_stylesheet_link_tag_with_preload_links_header_a54b7e3a25033f3babf07aeedcf19776-ef4af315cb33925c38d24ea3c2e8a1cd.txt
@@ -1,0 +1,65 @@
+---
+source: "Analyze::ActionView::AssetTagHelper::StylesheetLinkTagTest#test_0022_stylesheet_link_tag with preload_links_header"
+input: |2-
+<%= stylesheet_link_tag "application", preload_links_header: false %>
+options: {action_view_helpers: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ HTMLElementNode (location: (1:0)-(1:69))
+    │   ├── open_tag:
+    │   │   └── @ ERBOpenTagNode (location: (1:0)-(1:69))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " stylesheet_link_tag "application", preload_links_header: false " (location: (1:3)-(1:67))
+    │   │       ├── tag_closing: "%>" (location: (1:67)-(1:69))
+    │   │       ├── tag_name: "link" (location: (1:4)-(1:23))
+    │   │       └── children: (2 items)
+    │   │           ├── @ HTMLAttributeNode (location: (1:24)-(1:37))
+    │   │           │   ├── name:
+    │   │           │   │   └── @ HTMLAttributeNameNode (location: (1:24)-(1:37))
+    │   │           │   │       └── children: (1 item)
+    │   │           │   │           └── @ LiteralNode (location: (1:24)-(1:37))
+    │   │           │   │               └── content: "rel"
+    │   │           │   │
+    │   │           │   │
+    │   │           │   ├── equals: "=" (location: (1:24)-(1:37))
+    │   │           │   └── value:
+    │   │           │       └── @ HTMLAttributeValueNode (location: (1:24)-(1:37))
+    │   │           │           ├── open_quote: """ (location: (1:24)-(1:24))
+    │   │           │           ├── children: (1 item)
+    │   │           │           │   └── @ LiteralNode (location: (1:24)-(1:37))
+    │   │           │           │       └── content: "stylesheet"
+    │   │           │           │
+    │   │           │           ├── close_quote: """ (location: (1:37)-(1:37))
+    │   │           │           └── quoted: true
+    │   │           │
+    │   │           │
+    │   │           └── @ HTMLAttributeNode (location: (1:24)-(1:37))
+    │   │               ├── name:
+    │   │               │   └── @ HTMLAttributeNameNode (location: (1:24)-(1:37))
+    │   │               │       └── children: (1 item)
+    │   │               │           └── @ LiteralNode (location: (1:24)-(1:37))
+    │   │               │               └── content: "href"
+    │   │               │
+    │   │               │
+    │   │               ├── equals: ":" (location: (1:24)-(1:37))
+    │   │               └── value:
+    │   │                   └── @ HTMLAttributeValueNode (location: (1:24)-(1:37))
+    │   │                       ├── open_quote: ∅
+    │   │                       ├── children: (1 item)
+    │   │                       │   └── @ RubyLiteralNode (location: (1:24)-(1:37))
+    │   │                       │       └── content: "stylesheet_path(\"application\")"
+    │   │                       │
+    │   │                       ├── close_quote: ∅
+    │   │                       └── quoted: true
+    │   │
+    │   │
+    │   │
+    │   ├── tag_name: "link" (location: (1:4)-(1:23))
+    │   ├── body: []
+    │   ├── close_tag: ∅
+    │   ├── is_void: true
+    │   └── element_source: "ActionView::Helpers::AssetTagHelper#stylesheet_link_tag"
+    │
+    └── @ HTMLTextNode (location: (1:69)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/engine/action_view/javascript_include_tag_test/test_0002_javascript_include_tag_with_defer_029a0292ef00e4f77031218e43a2d96c.txt
+++ b/test/snapshots/engine/action_view/javascript_include_tag_test/test_0002_javascript_include_tag_with_defer_029a0292ef00e4f77031218e43a2d96c.txt
@@ -2,4 +2,4 @@
 source: "Engine::ActionView::JavascriptIncludeTagTest#test_0002_javascript_include_tag with defer"
 input: "{source: \"<%= javascript_include_tag \\\"application\\\", defer: true %>\", type: \"herb_output\", action_view_helpers: true}"
 ---
-<script defer src="/javascripts/application.js"></script>
+<script src="/javascripts/application.js" defer></script>

--- a/test/snapshots/engine/action_view/javascript_include_tag_test/test_0002_javascript_include_tag_with_defer_3470ae65cf59f3539cdb4e4982ef6c7b.txt
+++ b/test/snapshots/engine/action_view/javascript_include_tag_test/test_0002_javascript_include_tag_with_defer_3470ae65cf59f3539cdb4e4982ef6c7b.txt
@@ -2,4 +2,4 @@
 source: "Engine::ActionView::JavascriptIncludeTagTest#test_0002_javascript_include_tag with defer"
 input: "{source: \"<%= javascript_include_tag \\\"application\\\", defer: true %>\", locals: {}, options: {action_view_helpers: true}}"
 ---
-<script defer src="/javascripts/application.js"></script>
+<script src="/javascripts/application.js" defer></script>

--- a/test/snapshots/engine/action_view/javascript_include_tag_test/test_0002_javascript_include_tag_with_defer_759aa89680eaaac61604470a941729e2.txt
+++ b/test/snapshots/engine/action_view/javascript_include_tag_test/test_0002_javascript_include_tag_with_defer_759aa89680eaaac61604470a941729e2.txt
@@ -2,5 +2,5 @@
 source: "Engine::ActionView::JavascriptIncludeTagTest#test_0002_javascript_include_tag with defer"
 input: "{source: \"<%= javascript_include_tag \\\"application\\\", defer: true %>\", options: {optimize: true}}"
 ---
-_buf = ::String.new; _buf << '<script defer src="'.freeze; _buf << ::Herb::Engine.attr((javascript_path("application"))); _buf << '"></script>'.freeze;
+_buf = ::String.new; _buf << '<script src="'.freeze; _buf << ::Herb::Engine.attr((javascript_path("application"))); _buf << '" defer></script>'.freeze;
 _buf.to_s

--- a/test/snapshots/engine/action_view/javascript_include_tag_test/test_0004_javascript_include_tag_with_URL_and_async_1f52110d2da9fbf32b149c50db12408b.txt
+++ b/test/snapshots/engine/action_view/javascript_include_tag_test/test_0004_javascript_include_tag_with_URL_and_async_1f52110d2da9fbf32b149c50db12408b.txt
@@ -2,4 +2,4 @@
 source: "Engine::ActionView::JavascriptIncludeTagTest#test_0004_javascript_include_tag with URL and async"
 input: "{source: \"<%= javascript_include_tag \\\"http://www.example.com/xmlhr.js\\\", async: true %>\", type: \"herb_output\", action_view_helpers: true}"
 ---
-<script async src="http://www.example.com/xmlhr.js"></script>
+<script src="http://www.example.com/xmlhr.js" async></script>

--- a/test/snapshots/engine/action_view/javascript_include_tag_test/test_0004_javascript_include_tag_with_URL_and_async_bdfc713b6f85e86ad8f6ea575d2acbfd.txt
+++ b/test/snapshots/engine/action_view/javascript_include_tag_test/test_0004_javascript_include_tag_with_URL_and_async_bdfc713b6f85e86ad8f6ea575d2acbfd.txt
@@ -2,4 +2,4 @@
 source: "Engine::ActionView::JavascriptIncludeTagTest#test_0004_javascript_include_tag with URL and async"
 input: "{source: \"<%= javascript_include_tag \\\"http://www.example.com/xmlhr.js\\\", async: true %>\", locals: {}, options: {action_view_helpers: true}}"
 ---
-<script async src="http://www.example.com/xmlhr.js"></script>
+<script src="http://www.example.com/xmlhr.js" async></script>

--- a/test/snapshots/engine/action_view/javascript_include_tag_test/test_0004_javascript_include_tag_with_URL_and_async_c4decc739101f6bdad8460f628ed7a7b.txt
+++ b/test/snapshots/engine/action_view/javascript_include_tag_test/test_0004_javascript_include_tag_with_URL_and_async_c4decc739101f6bdad8460f628ed7a7b.txt
@@ -2,5 +2,5 @@
 source: "Engine::ActionView::JavascriptIncludeTagTest#test_0004_javascript_include_tag with URL and async"
 input: "{source: \"<%= javascript_include_tag \\\"http://www.example.com/xmlhr.js\\\", async: true %>\", options: {optimize: true}}"
 ---
-_buf = ::String.new; _buf << '<script async src="http://www.example.com/xmlhr.js"></script>'.freeze;
+_buf = ::String.new; _buf << '<script src="http://www.example.com/xmlhr.js" async></script>'.freeze;
 _buf.to_s

--- a/test/snapshots/engine/action_view/javascript_include_tag_test/test_0005_javascript_include_tag_with_data_attributes_6f8ceebe851605e931ec1544027cdea1.txt
+++ b/test/snapshots/engine/action_view/javascript_include_tag_test/test_0005_javascript_include_tag_with_data_attributes_6f8ceebe851605e931ec1544027cdea1.txt
@@ -2,4 +2,4 @@
 source: "Engine::ActionView::JavascriptIncludeTagTest#test_0005_javascript_include_tag with data attributes"
 input: "{source: \"<%= javascript_include_tag \\\"application\\\", data: { turbo_track: \\\"reload\\\" } %>\", locals: {}, options: {action_view_helpers: true}}"
 ---
-<script data-turbo-track="reload" src="/javascripts/application.js"></script>
+<script src="/javascripts/application.js" data-turbo-track="reload"></script>

--- a/test/snapshots/engine/action_view/javascript_include_tag_test/test_0005_javascript_include_tag_with_data_attributes_8b6a4cf69c858a6271afcc41219177ba.txt
+++ b/test/snapshots/engine/action_view/javascript_include_tag_test/test_0005_javascript_include_tag_with_data_attributes_8b6a4cf69c858a6271afcc41219177ba.txt
@@ -2,4 +2,4 @@
 source: "Engine::ActionView::JavascriptIncludeTagTest#test_0005_javascript_include_tag with data attributes"
 input: "{source: \"<%= javascript_include_tag \\\"application\\\", data: { turbo_track: \\\"reload\\\" } %>\", type: \"herb_output\", action_view_helpers: true}"
 ---
-<script data-turbo-track="reload" src="/javascripts/application.js"></script>
+<script src="/javascripts/application.js" data-turbo-track="reload"></script>

--- a/test/snapshots/engine/action_view/javascript_include_tag_test/test_0005_javascript_include_tag_with_data_attributes_e378271c4a150a3fd0e5dbd9207c6653.txt
+++ b/test/snapshots/engine/action_view/javascript_include_tag_test/test_0005_javascript_include_tag_with_data_attributes_e378271c4a150a3fd0e5dbd9207c6653.txt
@@ -2,5 +2,5 @@
 source: "Engine::ActionView::JavascriptIncludeTagTest#test_0005_javascript_include_tag with data attributes"
 input: "{source: \"<%= javascript_include_tag \\\"application\\\", data: { turbo_track: \\\"reload\\\" } %>\", options: {optimize: true}}"
 ---
-_buf = ::String.new; _buf << '<script data-turbo-track="reload" src="'.freeze; _buf << ::Herb::Engine.attr((javascript_path("application"))); _buf << '"></script>'.freeze;
+_buf = ::String.new; _buf << '<script src="'.freeze; _buf << ::Herb::Engine.attr((javascript_path("application"))); _buf << '" data-turbo-track="reload"></script>'.freeze;
 _buf.to_s

--- a/test/snapshots/engine/action_view/javascript_include_tag_test/test_0006_javascript_include_tag_with_duplicate_sources_297808e0744cfd8cd50c54ebff35645b.txt
+++ b/test/snapshots/engine/action_view/javascript_include_tag_test/test_0006_javascript_include_tag_with_duplicate_sources_297808e0744cfd8cd50c54ebff35645b.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::ActionView::JavascriptIncludeTagTest#test_0006_javascript_include_tag with duplicate sources"
+input: "{source: \"<%= javascript_include_tag \\\"application\\\", \\\"application\\\" %>\", options: {optimize: true}}"
+---
+_buf = ::String.new; _buf << '<script src="'.freeze; _buf << ::Herb::Engine.attr((javascript_path("application"))); _buf << '"></script>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/action_view/javascript_include_tag_test/test_0006_javascript_include_tag_with_duplicate_sources_5f26181cc072408061b8194b87cc170d.txt
+++ b/test/snapshots/engine/action_view/javascript_include_tag_test/test_0006_javascript_include_tag_with_duplicate_sources_5f26181cc072408061b8194b87cc170d.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::ActionView::JavascriptIncludeTagTest#test_0006_javascript_include_tag with duplicate sources"
+input: "{source: \"<%= javascript_include_tag \\\"application\\\", \\\"application\\\" %>\", locals: {}, options: {action_view_helpers: true}}"
+---
+<script src="/javascripts/application.js"></script>

--- a/test/snapshots/engine/action_view/javascript_include_tag_test/test_0007_javascript_include_tag_with_duplicate_sources_among_distinct_ones_780d81e6c9ba63735a49327efd4a487d.txt
+++ b/test/snapshots/engine/action_view/javascript_include_tag_test/test_0007_javascript_include_tag_with_duplicate_sources_among_distinct_ones_780d81e6c9ba63735a49327efd4a487d.txt
@@ -1,0 +1,7 @@
+---
+source: "Engine::ActionView::JavascriptIncludeTagTest#test_0007_javascript_include_tag with duplicate sources among distinct ones"
+input: "{source: \"<%= javascript_include_tag \\\"application\\\", \\\"vendor\\\", \\\"application\\\" %>\", options: {optimize: true}}"
+---
+_buf = ::String.new; _buf << '<script src="'.freeze; _buf << ::Herb::Engine.attr((javascript_path("application"))); _buf << '"></script>
+<script src="'.freeze; _buf << ::Herb::Engine.attr((javascript_path("vendor"))); _buf << '"></script>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/action_view/javascript_include_tag_test/test_0007_javascript_include_tag_with_duplicate_sources_among_distinct_ones_bfdfa0cd6aa4b9ef187458313c3da2b0.txt
+++ b/test/snapshots/engine/action_view/javascript_include_tag_test/test_0007_javascript_include_tag_with_duplicate_sources_among_distinct_ones_bfdfa0cd6aa4b9ef187458313c3da2b0.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::ActionView::JavascriptIncludeTagTest#test_0007_javascript_include_tag with duplicate sources among distinct ones"
+input: "{source: \"<%= javascript_include_tag \\\"application\\\", \\\"vendor\\\", \\\"application\\\" %>\", locals: {}, options: {action_view_helpers: true}}"
+---
+<script src="/javascripts/application.js"></script>
+<script src="/javascripts/vendor.js"></script>

--- a/test/snapshots/engine/action_view/javascript_include_tag_test/test_0008_javascript_include_tag_with_crossorigin_true_b09c9fd1a85ea8089378bf46501ac42d.txt
+++ b/test/snapshots/engine/action_view/javascript_include_tag_test/test_0008_javascript_include_tag_with_crossorigin_true_b09c9fd1a85ea8089378bf46501ac42d.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::ActionView::JavascriptIncludeTagTest#test_0008_javascript_include_tag with crossorigin true"
+input: "{source: \"<%= javascript_include_tag \\\"application\\\", crossorigin: true %>\", options: {optimize: true}}"
+---
+_buf = ::String.new; _buf << '<script src="'.freeze; _buf << ::Herb::Engine.attr((javascript_path("application"))); _buf << '" crossorigin="anonymous"></script>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/action_view/javascript_include_tag_test/test_0008_javascript_include_tag_with_crossorigin_true_b1158a1b3e2997a5cbe166c09623dad0.txt
+++ b/test/snapshots/engine/action_view/javascript_include_tag_test/test_0008_javascript_include_tag_with_crossorigin_true_b1158a1b3e2997a5cbe166c09623dad0.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::ActionView::JavascriptIncludeTagTest#test_0008_javascript_include_tag with crossorigin true"
+input: "{source: \"<%= javascript_include_tag \\\"application\\\", crossorigin: true %>\", locals: {}, options: {action_view_helpers: true}}"
+---
+<script src="/javascripts/application.js" crossorigin="anonymous"></script>

--- a/test/snapshots/engine/action_view/javascript_include_tag_test/test_0009_javascript_include_tag_with_crossorigin_string_95b94394816479663347146ca4ed7c02.txt
+++ b/test/snapshots/engine/action_view/javascript_include_tag_test/test_0009_javascript_include_tag_with_crossorigin_string_95b94394816479663347146ca4ed7c02.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::ActionView::JavascriptIncludeTagTest#test_0009_javascript_include_tag with crossorigin string"
+input: "{source: \"<%= javascript_include_tag \\\"application\\\", crossorigin: \\\"use-credentials\\\" %>\", options: {optimize: true}}"
+---
+_buf = ::String.new; _buf << '<script src="'.freeze; _buf << ::Herb::Engine.attr((javascript_path("application"))); _buf << '" crossorigin="use-credentials"></script>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/action_view/javascript_include_tag_test/test_0009_javascript_include_tag_with_crossorigin_string_c31ce0a08dad2574ba699d82cef413bb.txt
+++ b/test/snapshots/engine/action_view/javascript_include_tag_test/test_0009_javascript_include_tag_with_crossorigin_string_c31ce0a08dad2574ba699d82cef413bb.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::ActionView::JavascriptIncludeTagTest#test_0009_javascript_include_tag with crossorigin string"
+input: "{source: \"<%= javascript_include_tag \\\"application\\\", crossorigin: \\\"use-credentials\\\" %>\", locals: {}, options: {action_view_helpers: true}}"
+---
+<script src="/javascripts/application.js" crossorigin="use-credentials"></script>

--- a/test/snapshots/engine/action_view/javascript_include_tag_test/test_0010_javascript_include_tag_with_nopush_00e1c50322c275247ff4a62df930b341.txt
+++ b/test/snapshots/engine/action_view/javascript_include_tag_test/test_0010_javascript_include_tag_with_nopush_00e1c50322c275247ff4a62df930b341.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::ActionView::JavascriptIncludeTagTest#test_0010_javascript_include_tag with nopush"
+input: "{source: \"<%= javascript_include_tag \\\"application\\\", nopush: true %>\", locals: {}, options: {action_view_helpers: true}}"
+---
+<script src="/javascripts/application.js"></script>

--- a/test/snapshots/engine/action_view/javascript_include_tag_test/test_0010_javascript_include_tag_with_nopush_56409a5a06bbd7c6943d5f0509948c26.txt
+++ b/test/snapshots/engine/action_view/javascript_include_tag_test/test_0010_javascript_include_tag_with_nopush_56409a5a06bbd7c6943d5f0509948c26.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::ActionView::JavascriptIncludeTagTest#test_0010_javascript_include_tag with nopush"
+input: "{source: \"<%= javascript_include_tag \\\"application\\\", nopush: true %>\", options: {optimize: true}}"
+---
+_buf = ::String.new; _buf << '<script src="'.freeze; _buf << ::Herb::Engine.attr((javascript_path("application"))); _buf << '"></script>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/action_view/javascript_include_tag_test/test_0011_javascript_include_tag_with_preload_links_header_b540dc522fa7bc7b789ccae7dee27c4d.txt
+++ b/test/snapshots/engine/action_view/javascript_include_tag_test/test_0011_javascript_include_tag_with_preload_links_header_b540dc522fa7bc7b789ccae7dee27c4d.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::ActionView::JavascriptIncludeTagTest#test_0011_javascript_include_tag with preload_links_header"
+input: "{source: \"<%= javascript_include_tag \\\"application\\\", preload_links_header: false %>\", options: {optimize: true}}"
+---
+_buf = ::String.new; _buf << '<script src="'.freeze; _buf << ::Herb::Engine.attr((javascript_path("application"))); _buf << '"></script>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/action_view/javascript_include_tag_test/test_0011_javascript_include_tag_with_preload_links_header_df1d847e85dac73f0c99f93aa725ea7f.txt
+++ b/test/snapshots/engine/action_view/javascript_include_tag_test/test_0011_javascript_include_tag_with_preload_links_header_df1d847e85dac73f0c99f93aa725ea7f.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::ActionView::JavascriptIncludeTagTest#test_0011_javascript_include_tag with preload_links_header"
+input: "{source: \"<%= javascript_include_tag \\\"application\\\", preload_links_header: false %>\", locals: {}, options: {action_view_helpers: true}}"
+---
+<script src="/javascripts/application.js"></script>

--- a/test/snapshots/engine/action_view/javascript_include_tag_test/test_0012_javascript_include_tag_with_integrity_bd834618c20bd1da4c1d9859fe6172c5.txt
+++ b/test/snapshots/engine/action_view/javascript_include_tag_test/test_0012_javascript_include_tag_with_integrity_bd834618c20bd1da4c1d9859fe6172c5.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::ActionView::JavascriptIncludeTagTest#test_0012_javascript_include_tag with integrity"
+input: "{source: \"<%= javascript_include_tag \\\"application\\\", integrity: \\\"sha256-abc\\\" %>\", locals: {}, options: {action_view_helpers: true}}"
+---
+<script src="/javascripts/application.js" integrity="sha256-abc"></script>

--- a/test/snapshots/engine/action_view/javascript_include_tag_test/test_0012_javascript_include_tag_with_integrity_c6c97d325088c5ba7e43fc18f8ac589a.txt
+++ b/test/snapshots/engine/action_view/javascript_include_tag_test/test_0012_javascript_include_tag_with_integrity_c6c97d325088c5ba7e43fc18f8ac589a.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::ActionView::JavascriptIncludeTagTest#test_0012_javascript_include_tag with integrity"
+input: "{source: \"<%= javascript_include_tag \\\"application\\\", integrity: \\\"sha256-abc\\\" %>\", options: {optimize: true}}"
+---
+_buf = ::String.new; _buf << '<script src="'.freeze; _buf << ::Herb::Engine.attr((javascript_path("application"))); _buf << '" integrity="sha256-abc"></script>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0014_stylesheet_link_tag_with_duplicate_sources_371db3cb72f4f4912711db7ffe93ff40.txt
+++ b/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0014_stylesheet_link_tag_with_duplicate_sources_371db3cb72f4f4912711db7ffe93ff40.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::ActionView::StylesheetLinkTagTest#test_0014_stylesheet_link_tag with duplicate sources"
+input: "{source: \"<%= stylesheet_link_tag \\\"application\\\", \\\"application\\\" %>\", locals: {}, options: {action_view_helpers: true}}"
+---
+<link rel="stylesheet" href="/stylesheets/application.css" />

--- a/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0014_stylesheet_link_tag_with_duplicate_sources_a395b7c59b8fd5a5823d78d5cf373fd5.txt
+++ b/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0014_stylesheet_link_tag_with_duplicate_sources_a395b7c59b8fd5a5823d78d5cf373fd5.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::ActionView::StylesheetLinkTagTest#test_0014_stylesheet_link_tag with duplicate sources"
+input: "{source: \"<%= stylesheet_link_tag \\\"application\\\", \\\"application\\\" %>\", options: {optimize: true}}"
+---
+_buf = ::String.new; _buf << '<link rel="stylesheet" href="'.freeze; _buf << ::Herb::Engine.attr((stylesheet_path("application"))); _buf << '" />'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0015_stylesheet_link_tag_with_duplicate_sources_among_distinct_ones_8509b7c2eea45f0df83c3f1347f73b36.txt
+++ b/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0015_stylesheet_link_tag_with_duplicate_sources_among_distinct_ones_8509b7c2eea45f0df83c3f1347f73b36.txt
@@ -1,0 +1,7 @@
+---
+source: "Engine::ActionView::StylesheetLinkTagTest#test_0015_stylesheet_link_tag with duplicate sources among distinct ones"
+input: "{source: \"<%= stylesheet_link_tag \\\"application\\\", \\\"admin\\\", \\\"application\\\" %>\", options: {optimize: true}}"
+---
+_buf = ::String.new; _buf << '<link rel="stylesheet" href="'.freeze; _buf << ::Herb::Engine.attr((stylesheet_path("application"))); _buf << '" />
+<link rel="stylesheet" href="'.freeze; _buf << ::Herb::Engine.attr((stylesheet_path("admin"))); _buf << '" />'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0015_stylesheet_link_tag_with_duplicate_sources_among_distinct_ones_f043e6f814c59c5f832fd8294359e4b5.txt
+++ b/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0015_stylesheet_link_tag_with_duplicate_sources_among_distinct_ones_f043e6f814c59c5f832fd8294359e4b5.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::ActionView::StylesheetLinkTagTest#test_0015_stylesheet_link_tag with duplicate sources among distinct ones"
+input: "{source: \"<%= stylesheet_link_tag \\\"application\\\", \\\"admin\\\", \\\"application\\\" %>\", locals: {}, options: {action_view_helpers: true}}"
+---
+<link rel="stylesheet" href="/stylesheets/application.css" />
+<link rel="stylesheet" href="/stylesheets/admin.css" />

--- a/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0016_stylesheet_link_tag_with_crossorigin_true_8980ef2d58b4e910dff0f20c9e0f08e7.txt
+++ b/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0016_stylesheet_link_tag_with_crossorigin_true_8980ef2d58b4e910dff0f20c9e0f08e7.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::ActionView::StylesheetLinkTagTest#test_0016_stylesheet_link_tag with crossorigin true"
+input: "{source: \"<%= stylesheet_link_tag \\\"application\\\", crossorigin: true %>\", options: {optimize: true}}"
+---
+_buf = ::String.new; _buf << '<link rel="stylesheet" crossorigin="anonymous" href="'.freeze; _buf << ::Herb::Engine.attr((stylesheet_path("application"))); _buf << '" />'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0016_stylesheet_link_tag_with_crossorigin_true_c980a627035e622344f2ca6857ba4b94.txt
+++ b/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0016_stylesheet_link_tag_with_crossorigin_true_c980a627035e622344f2ca6857ba4b94.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::ActionView::StylesheetLinkTagTest#test_0016_stylesheet_link_tag with crossorigin true"
+input: "{source: \"<%= stylesheet_link_tag \\\"application\\\", crossorigin: true %>\", locals: {}, options: {action_view_helpers: true}}"
+---
+<link rel="stylesheet" crossorigin="anonymous" href="/stylesheets/application.css" />

--- a/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0017_stylesheet_link_tag_with_crossorigin_string_02530bb3ad3ffa571f9c972e691aea6d.txt
+++ b/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0017_stylesheet_link_tag_with_crossorigin_string_02530bb3ad3ffa571f9c972e691aea6d.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::ActionView::StylesheetLinkTagTest#test_0017_stylesheet_link_tag with crossorigin string"
+input: "{source: \"<%= stylesheet_link_tag \\\"application\\\", crossorigin: \\\"use-credentials\\\", media: \\\"all\\\" %>\", locals: {}, options: {action_view_helpers: true}}"
+---
+<link rel="stylesheet" crossorigin="use-credentials" href="/stylesheets/application.css" media="all" />

--- a/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0017_stylesheet_link_tag_with_crossorigin_string_479373671786c3252743c239c2fe6c8c.txt
+++ b/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0017_stylesheet_link_tag_with_crossorigin_string_479373671786c3252743c239c2fe6c8c.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::ActionView::StylesheetLinkTagTest#test_0017_stylesheet_link_tag with crossorigin string"
+input: "{source: \"<%= stylesheet_link_tag \\\"application\\\", crossorigin: \\\"use-credentials\\\", media: \\\"all\\\" %>\", options: {optimize: true}}"
+---
+_buf = ::String.new; _buf << '<link rel="stylesheet" crossorigin="use-credentials" href="'.freeze; _buf << ::Herb::Engine.attr((stylesheet_path("application"))); _buf << '" media="all" />'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0018_stylesheet_link_tag_with_nopush_1553578faaa58506899c05d4c5b83e85.txt
+++ b/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0018_stylesheet_link_tag_with_nopush_1553578faaa58506899c05d4c5b83e85.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::ActionView::StylesheetLinkTagTest#test_0018_stylesheet_link_tag with nopush"
+input: "{source: \"<%= stylesheet_link_tag \\\"application\\\", nopush: true %>\", locals: {}, options: {action_view_helpers: true}}"
+---
+<link rel="stylesheet" href="/stylesheets/application.css" />

--- a/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0018_stylesheet_link_tag_with_nopush_4bf6445c2874a60ed4f69417a53fe737.txt
+++ b/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0018_stylesheet_link_tag_with_nopush_4bf6445c2874a60ed4f69417a53fe737.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::ActionView::StylesheetLinkTagTest#test_0018_stylesheet_link_tag with nopush"
+input: "{source: \"<%= stylesheet_link_tag \\\"application\\\", nopush: true %>\", options: {optimize: true}}"
+---
+_buf = ::String.new; _buf << '<link rel="stylesheet" href="'.freeze; _buf << ::Herb::Engine.attr((stylesheet_path("application"))); _buf << '" />'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0019_stylesheet_link_tag_with_preload_links_header_322655a82bcd8ae278767f0a4f0d5973.txt
+++ b/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0019_stylesheet_link_tag_with_preload_links_header_322655a82bcd8ae278767f0a4f0d5973.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::ActionView::StylesheetLinkTagTest#test_0019_stylesheet_link_tag with preload_links_header"
+input: "{source: \"<%= stylesheet_link_tag \\\"application\\\", preload_links_header: false %>\", locals: {}, options: {action_view_helpers: true}}"
+---
+<link rel="stylesheet" href="/stylesheets/application.css" />

--- a/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0019_stylesheet_link_tag_with_preload_links_header_c23089fa44c50fb85848d3870605ec36.txt
+++ b/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0019_stylesheet_link_tag_with_preload_links_header_c23089fa44c50fb85848d3870605ec36.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::ActionView::StylesheetLinkTagTest#test_0019_stylesheet_link_tag with preload_links_header"
+input: "{source: \"<%= stylesheet_link_tag \\\"application\\\", preload_links_header: false %>\", options: {optimize: true}}"
+---
+_buf = ::String.new; _buf << '<link rel="stylesheet" href="'.freeze; _buf << ::Herb::Engine.attr((stylesheet_path("application"))); _buf << '" />'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0020_stylesheet_link_tag_with_integrity_a0b1b93d59d62e2ae3c13f6f7913ad00.txt
+++ b/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0020_stylesheet_link_tag_with_integrity_a0b1b93d59d62e2ae3c13f6f7913ad00.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::ActionView::StylesheetLinkTagTest#test_0020_stylesheet_link_tag with integrity"
+input: "{source: \"<%= stylesheet_link_tag \\\"application\\\", integrity: \\\"sha256-abc\\\" %>\", options: {optimize: true}}"
+---
+_buf = ::String.new; _buf << '<link rel="stylesheet" href="'.freeze; _buf << ::Herb::Engine.attr((stylesheet_path("application"))); _buf << '" integrity="sha256-abc" />'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0020_stylesheet_link_tag_with_integrity_ab1868091f67f212aa3fe9e967954a73.txt
+++ b/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0020_stylesheet_link_tag_with_integrity_ab1868091f67f212aa3fe9e967954a73.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::ActionView::StylesheetLinkTagTest#test_0020_stylesheet_link_tag with integrity"
+input: "{source: \"<%= stylesheet_link_tag \\\"application\\\", integrity: \\\"sha256-abc\\\" %>\", locals: {}, options: {action_view_helpers: true}}"
+---
+<link rel="stylesheet" href="/stylesheets/application.css" integrity="sha256-abc" />


### PR DESCRIPTION
Rails removes several options from the tag attributes before rendering, which neither `javascript_include_tag` nor `stylesheet_link_tag` accounted for.
