### PR TITLE
Language Service: Complete the arguments a helper yields to its block

### DIFF
--- a/javascript/packages/language-service/src/index.ts
+++ b/javascript/packages/language-service/src/index.ts
@@ -1,4 +1,4 @@
-export { getLanguageService } from "./language-service.js"
+export { getLanguageService, getBlockArgumentCompletions } from "./language-service.js"
 export { findTokenIndex, HerbHTMLNode } from "./herb-html-node.js"
 export { buildHTMLDocument } from "./herb-html-document.js"
 export { buildLineOffsetTable, positionToOffset, locationToOffsets } from "./offset-utils.js"

--- a/javascript/packages/language-service/src/language-service.ts
+++ b/javascript/packages/language-service/src/language-service.ts
@@ -4,7 +4,7 @@ import { CompletionItemKind, InsertTextFormat } from "vscode-html-languageservic
 import { buildHTMLDocument } from "./herb-html-document.js"
 import { getLanguageService as getUpstreamLanguageService } from "vscode-html-languageservice"
 
-import { TOKEN_LIST_ATTRIBUTES } from "@herb-tools/core"
+import { TOKEN_LIST_ATTRIBUTES, getHelper } from "@herb-tools/core"
 
 import type { ParseOptions } from "@herb-tools/core"
 import type { LanguageServiceOptions } from "./types.js"
@@ -23,6 +23,8 @@ export function getLanguageService(options?: LanguageServiceOptions): LanguageSe
   const upstream = getUpstreamLanguageService(options)
   const herb = options?.herb
   const dataProviders = options?.customDataProviders ?? []
+
+  const framework = options?.framework
 
   const tokenListAttributes = new Set([
     ...TOKEN_LIST_ATTRIBUTES,
@@ -60,6 +62,9 @@ export function getLanguageService(options?: LanguageServiceOptions): LanguageSe
       htmlDocument: HTMLDocument,
       options?: CompletionConfiguration,
     ): CompletionList {
+      const blockArgumentResult = getBlockArgumentCompletions(document, position, { framework })
+      if (blockArgumentResult) return blockArgumentResult
+
       const erbResult = tryERBAttributeCompletion(document, position, htmlDocument, dataProviders, tokenListAttributes)
       if (erbResult) return erbResult
 
@@ -147,6 +152,205 @@ export function getLanguageService(options?: LanguageServiceOptions): LanguageSe
       dataProviders.push(...customDataProviders)
     },
   }
+}
+
+function hasClosingPipe(source: string, offset: number): boolean {
+  const newline = source.indexOf("\n", offset)
+  const closing = source.indexOf("%>", offset)
+
+  const ends = [newline, closing].filter(index => index !== -1)
+  const end = ends.length > 0 ? Math.min(...ends) : source.length
+
+  return source.slice(offset, end).includes("|")
+}
+
+function currentERBTag(source: string, offset: number): string | null {
+  const opening = source.lastIndexOf("<%", offset)
+  if (opening === -1) return null
+
+  const closing = source.lastIndexOf("%>", offset - 2)
+  if (closing > opening) return null
+
+  return source.slice(opening, offset)
+}
+
+export function getBlockArgumentCompletions(document: TextDocument, position: Position, options?: { framework?: string }): CompletionList | null {
+  const source = document.getText()
+  const offset = document.offsetAt(position)
+  const tag = currentERBTag(source, offset)
+
+  if (!tag) return null
+
+  const block = tag.match(/\bdo\s*(\|[^|]*)?$/)
+  if (!block) return null
+
+  const typed = block[1] !== undefined
+  const closed = typed && hasClosingPipe(source, offset)
+  const suggestions = helperSuggestions(tag, options?.framework) ?? iterationSuggestions(tag)
+
+  if (!suggestions) return null
+
+  const declared = typed ? block[1].slice(1).split(",").length - 1 : 0
+
+  const items: CompletionItem[] = suggestions.flatMap((suggestion, index) => {
+    const names = suggestion.names.slice(declared)
+
+    if (names.length === 0) return []
+
+    const label = names.join(", ")
+
+    return [{
+      label: typed ? label : `|${label}|`,
+      kind: CompletionItemKind.Variable,
+      detail: suggestion.detail,
+      documentation: suggestion.documentation,
+      insertText: typed ? (closed ? label : `${label}|`) : `|${label}|`,
+      insertTextFormat: InsertTextFormat.PlainText,
+      sortText: String(index),
+    }]
+  })
+
+  if (items.length === 0) return null
+
+  return { isIncomplete: false, items }
+}
+
+interface BlockArgumentSuggestion {
+  names: string[]
+  detail?: string
+  documentation?: string
+}
+
+function helperSuggestions(tag: string, framework?: string): BlockArgumentSuggestion[] | null {
+  if (framework !== "actionview") return null
+
+  const call = tag.match(/^<%=?-?\s*([a-z_][A-Za-z0-9_]*)/)
+  if (!call) return null
+
+  const helper = getHelper(call[1])
+  if (!helper?.supportsBlock) return null
+  if (helper.blockArguments.length === 0) return null
+
+  return helper.blockArguments.map((argument, index) => ({
+    names: helper.blockArguments.slice(0, index + 1).map(blockArgument => blockArgument.name),
+    detail: argument.type,
+    documentation: helper.blockArguments.slice(0, index + 1).map(blockArgument => `\`${blockArgument.name}\`: ${blockArgument.description}`).join("\n\n"),
+  }))
+}
+
+const ITERATION_METHODS = new Set([
+  "each",
+  "each_with_index",
+  "filter_map",
+  "find",
+  "detect",
+  "flat_map",
+  "group_by",
+  "map",
+  "reject",
+  "select",
+  "sort_by",
+])
+
+const COUNTER_METHODS = new Set(["times", "upto", "downto", "step"])
+
+function counterSuggestions(): BlockArgumentSuggestion[] {
+  const detail = "Iteration counter"
+
+  return [
+    { names: ["i"], detail },
+    { names: ["index"], detail },
+  ]
+}
+
+function iterationSuggestions(tag: string): BlockArgumentSuggestion[] | null {
+  const call = tag.match(/\.\s*([a-z_]+)(\([^)]*\))?\s*do\s*(\|[^|]*)?$/)
+  if (!call) return null
+
+  if (COUNTER_METHODS.has(call[1])) return counterSuggestions()
+  if (!ITERATION_METHODS.has(call[1])) return null
+
+  const chain = tag.slice(0, call.index)
+  const element = elementNameFrom(chain)
+
+  if (!element) return null
+
+  const receiver = chain.replace(/^<%=?-?\s*/, "").trim()
+  const detail = `Element of \`${receiver}\``
+
+  if (call[1] === "each_with_index") {
+    return [
+      { names: [element, "index"], detail },
+      { names: [element], detail },
+    ]
+  }
+
+  return [{ names: [element], detail }]
+}
+
+function elementNameFrom(chain: string): string | null {
+  const segments = chain.match(/[A-Za-z_][A-Za-z0-9_]*/g) ?? []
+
+  for (const segment of [...segments].reverse()) {
+    const element = singularize(segment)
+
+    if (element) return element
+  }
+
+  return modelName(chain)
+}
+
+function modelName(chain: string): string | null {
+  const constant = chain.match(/^<%=?-?\s*((?:[A-Z][A-Za-z0-9_]*::)*[A-Z][A-Za-z0-9_]*)\s*\./)
+  if (!constant) return null
+
+  return constant[1]
+    .split("::")
+    .pop()!
+    .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+    .toLowerCase()
+}
+
+const IRREGULAR_PLURALS: Record<string, string> = {
+  children: "child",
+  people: "person",
+  men: "man",
+  women: "woman",
+  feet: "foot",
+  teeth: "tooth",
+  geese: "goose",
+  mice: "mouse",
+  indices: "index",
+  vertices: "vertex",
+  matrices: "matrix",
+}
+
+const UNCOUNTABLE = new Set([
+  "address",
+  "alias",
+  "bus",
+  "class",
+  "data",
+  "gas",
+  "information",
+  "lens",
+  "news",
+  "series",
+  "species",
+  "status",
+])
+
+function singularize(word: string): string | null {
+  const lower = word.toLowerCase()
+
+  if (IRREGULAR_PLURALS[lower]) return IRREGULAR_PLURALS[lower]
+  if (UNCOUNTABLE.has(lower)) return null
+
+  if (/[^aeiou]ies$/.test(word)) return `${word.slice(0, -3)}y`
+  if (/(ch|sh|ss|x|z)es$/.test(word)) return word.slice(0, -2)
+  if (/[^s]s$/.test(word)) return word.slice(0, -1)
+
+  return null
 }
 
 function tryERBAttributeCompletion(document: TextDocument, position: Position, htmlDocument: HTMLDocument, dataProviders: IHTMLDataProvider[], tokenListAttributes: Set<string>): CompletionList | null {

--- a/javascript/packages/language-service/src/types.ts
+++ b/javascript/packages/language-service/src/types.ts
@@ -6,4 +6,5 @@ export interface LanguageServiceOptions extends UpstreamLanguageServiceOptions {
   herb?: HerbBackend
   herbParseOptions?: ParseOptions
   tokenListAttributes?: string[]
+  framework?: string
 }

--- a/javascript/packages/language-service/test/completions.test.ts
+++ b/javascript/packages/language-service/test/completions.test.ts
@@ -117,3 +117,175 @@ describe("doComplete", () => {
     })
   })
 })
+
+describe("block argument completions", () => {
+  setupHerb()
+
+  const actionView = () => createService({ framework: "actionview" })
+
+  test("completes the form builder a `form_with` yields", () => {
+    const service = actionView()
+    const document = createDocument(`<%= form_with model: @user do `)
+    const html = service.parseHTMLDocument(document)
+    const completions = service.doComplete(document, Position.create(0, 30), html)
+
+    expect(completions.items.map(item => item.label)).toEqual(["|form|"])
+    expect(completions.items[0].detail).toBe("ActionView::Helpers::FormBuilder")
+  })
+
+  test("completes without the pipes when they are already typed", () => {
+    const service = actionView()
+    const document = createDocument(`<%= form_with model: @user do |`)
+    const html = service.parseHTMLDocument(document)
+    const completions = service.doComplete(document, Position.create(0, 31), html)
+
+    expect(completions.items.map(item => item.label)).toEqual(["form"])
+  })
+
+  test("offers each arity a helper yields", () => {
+    const service = actionView()
+    const document = createDocument(`<%= link_to_if @ok, "Name", "/path" do `)
+    const html = service.parseHTMLDocument(document)
+    const completions = service.doComplete(document, Position.create(0, 39), html)
+
+    expect(completions.items.map(item => item.label)).toEqual([
+      "|name|",
+      "|name, options|",
+      "|name, options, html_options|",
+    ])
+  })
+
+  test("offers only the remaining arguments after a comma", () => {
+    const service = actionView()
+    const document = createDocument(`<%= link_to_if @ok, "Name", "/path" do |name, `)
+    const html = service.parseHTMLDocument(document)
+    const completions = service.doComplete(document, Position.create(0, 46), html)
+
+    expect(completions.items.map(item => item.label)).toEqual(["options", "options, html_options"])
+  })
+
+  test("completes the tag builder of a `turbo_frame_tag`", () => {
+    const service = actionView()
+    const document = createDocument(`<%= turbo_frame_tag "messages" do `)
+    const html = service.parseHTMLDocument(document)
+    const completions = service.doComplete(document, Position.create(0, 34), html)
+
+    expect(completions.items.map(item => item.label)).toEqual(["|tag|"])
+  })
+
+  test("does not complete a helper that yields nothing", () => {
+    const service = actionView()
+    const document = createDocument(`<% cache @post do `)
+    const html = service.parseHTMLDocument(document)
+    const completions = service.doComplete(document, Position.create(0, 18), html)
+
+    expect(completions.items.map(item => item.label)).not.toContain("|entry|")
+  })
+
+  test("does not complete a helper outside of an Action View project", () => {
+    const service = createService()
+    const document = createDocument(`<%= form_with model: @user do `)
+    const html = service.parseHTMLDocument(document)
+    const completions = service.doComplete(document, Position.create(0, 30), html)
+
+    expect(completions.items.map(item => item.label)).not.toContain("|form|")
+  })
+})
+
+describe("iteration block argument completions", () => {
+  setupHerb()
+
+  function labelsFor(source: string, options?: { framework?: string }) {
+    const service = createService(options)
+    const document = createDocument(source)
+
+    return service.doComplete(document, Position.create(0, source.length), service.parseHTMLDocument(document)).items.map(item => item.label)
+  }
+
+  function insertTextFor(template: string) {
+    const column = template.indexOf("CURSOR")
+    const source = template.replace("CURSOR", "")
+    const service = createService()
+    const document = createDocument(source)
+
+    return service.doComplete(document, Position.create(0, column), service.parseHTMLDocument(document)).items.map(item => item.insertText)
+  }
+
+  test("names the element after an instance variable", () => {
+    expect(labelsFor("<% @speakers.each do ")).toEqual(["|speaker|"])
+  })
+
+  test("names the element after a local variable", () => {
+    expect(labelsFor("<% speakers.each do ")).toEqual(["|speaker|"])
+  })
+
+  test("names the element after the last plural in the chain", () => {
+    expect(labelsFor("<% @event.talks.where(status: \"confirmed\").each do ")).toEqual(["|talk|"])
+  })
+
+  test("names the element after the model when nothing in the chain is plural", () => {
+    expect(labelsFor("<% BlogPost.published.each do ")).toEqual(["|blog_post|"])
+  })
+
+  test("handles plurals that are not just a trailing `s`", () => {
+    expect(labelsFor("<% @categories.each do ")).toEqual(["|category|"])
+    expect(labelsFor("<% @boxes.each do ")).toEqual(["|box|"])
+    expect(labelsFor("<% @people.each do ")).toEqual(["|person|"])
+  })
+
+  test("offers the index for `each_with_index`", () => {
+    expect(labelsFor("<% @speakers.each_with_index do ")).toEqual(["|speaker, index|", "|speaker|"])
+  })
+
+  test("suggests a counter for `times` and friends", () => {
+    expect(labelsFor("<% 10.times do ")).toEqual(["|i|", "|index|"])
+    expect(labelsFor("<% @speakers.count.times do ")).toEqual(["|i|", "|index|"])
+    expect(labelsFor("<% 1.upto(5) do ")).toEqual(["|i|", "|index|"])
+    expect(labelsFor("<% 10.downto(1) do ")).toEqual(["|i|", "|index|"])
+  })
+
+  test("says nothing for a receiver that only looks plural", () => {
+    expect(labelsFor("<% @status.each do ")).toEqual([])
+    expect(labelsFor("<% @news.each do ")).toEqual([])
+  })
+
+  test("says nothing for a singular receiver", () => {
+    expect(labelsFor("<% @speaker.each do ")).toEqual([])
+  })
+
+  test("says nothing for a method that does not yield an element", () => {
+    expect(labelsFor("<% @speakers.each_slice(2) do ")).toEqual([])
+    expect(labelsFor("<% @speakers.each_cons(2) do ")).toEqual([])
+  })
+
+  test("does not need an Action View project", () => {
+    expect(labelsFor("<% @speakers.each do ", { framework: "hanami" })).toEqual(["|speaker|"])
+  })
+
+  test("closes the pipe the completion is accepted into", () => {
+    expect(insertTextFor("<% @speakers.each do |CURSOR %>")).toEqual(["speaker|"])
+  })
+
+  test("closes the pipe with the tag delimiter right behind the cursor", () => {
+    expect(insertTextFor("<% @speakers.each do |CURSOR%>")).toEqual(["speaker|"])
+  })
+
+  test("leaves an already closed pipe alone", () => {
+    expect(insertTextFor("<% @speakers.each do |CURSOR| %>")).toEqual(["speaker"])
+  })
+
+  test("inserts both pipes when neither is typed", () => {
+    expect(insertTextFor("<% @speakers.each do CURSOR %>")).toEqual(["|speaker|"])
+  })
+
+  test("offers only what is left after a comma", () => {
+    expect(insertTextFor("<% @events.each_with_index do |event, CURSOR %>")).toEqual(["index|"])
+    expect(insertTextFor("<% @events.each_with_index do |event,CURSOR| %>")).toEqual(["index"])
+  })
+
+  test("says nothing once every argument is typed", () => {
+    expect(insertTextFor("<% @events.each_with_index do |event, index, CURSOR %>")).toEqual([])
+    expect(insertTextFor("<% @events.each do |event, CURSOR %>")).toEqual([])
+    expect(insertTextFor("<% 10.times do |i, CURSOR %>")).toEqual([])
+  })
+})


### PR DESCRIPTION
Builds on the `block_arguments:` tracking added to the helper configs, so it wants to land after that one.

Knowing that `form_with` hands the block an `ActionView::Helpers::FormBuilder` is worth more while the block is being written than after. 

This pull request completes those arguments in the ERB tag itself:

```erb
<%= form_with model: @user do ▮
```

offers `|form|`, with `ActionView::Helpers::FormBuilder` as the detail and the description from the helper config as the documentation. The pipes are part of the completion when they aren't typed yet, so accepting it leaves `do |form|` behind. Start them yourself and the completion drops them:

```erb
<%= form_with model: @user do |▮        offers `form`
```

`doComplete` looks at the ERB tag the cursor sits in, takes the leading identifier of the call, and requires the text to end at a `do`, optionally followed by a half typed `|`. The identifier goes through `getHelper`, so the completion is offered for exactly the helpers the registry knows, and `tag` covers `tag.div` and friends.

That means the calls with nothing to offer stay quiet. `<% @users.each do ` isn't a helper, and `<% cache @post do ` is one that calls its block without arguments, so neither produces an item.

`link_to_if` yields the link text, and two more arguments to a block that declares three. Each arity is offered separately:

```erb
<%= link_to_if @ok, "Name", "/path" do ▮
```

```
|name|
|name, options|
|name, options, html_options|
```

The second and third are marked `optional: true` in the helper config for that reason, and the documentation on each item lists the arguments it would bind.