### PR TITLE
Language Server: Retract diagnostics for projects that leave the workspace

### DIFF
--- a/javascript/packages/config/src/config.ts
+++ b/javascript/packages/config/src/config.ts
@@ -669,17 +669,8 @@ export class Config {
         // Config not in this directory, continue
       }
 
-      if (!firstIndicatorMatch) {
-        for (const indicator of this.PROJECT_INDICATORS) {
-          try {
-            fsSync.accessSync(path.join(currentPath, indicator))
-
-            firstIndicatorMatch = currentPath
-            break
-          } catch {
-            // Indicator not found, continue checking
-          }
-        }
+      if (!firstIndicatorMatch && this.isProjectRootSync(currentPath)) {
+        firstIndicatorMatch = currentPath
       }
 
       const parentPath = path.dirname(currentPath)
@@ -1123,6 +1114,18 @@ export class Config {
    */
   private static async isProjectRoot(dirPath: string): Promise<boolean> {
     for (const indicator of this.PROJECT_INDICATORS) {
+      if (indicator.startsWith("*")) {
+        try {
+          const entries = await fs.readdir(dirPath)
+
+          if (entries.some(entry => entry.endsWith(indicator.slice(1)))) return true
+        } catch {
+          // Directory not readable, continue checking
+        }
+
+        continue
+      }
+
       try {
         await fs.access(path.join(dirPath, indicator))
 
@@ -1131,6 +1134,39 @@ export class Config {
         // Indicator not found, continue checking
       }
     }
+    return false
+  }
+
+  /**
+   * Synchronous twin of `isProjectRoot`. An indicator starting with `*` is a
+   * suffix pattern and is matched against the directory listing, where passing
+   * it to `access` would look for a file named `*.gemspec` literally.
+   */
+  private static isProjectRootSync(dirPath: string): boolean {
+    const fsSync = require('fs')
+
+    for (const indicator of this.PROJECT_INDICATORS) {
+      if (indicator.startsWith("*")) {
+        try {
+          const entries: string[] = fsSync.readdirSync(dirPath)
+
+          if (entries.some(entry => entry.endsWith(indicator.slice(1)))) return true
+        } catch {
+          // Directory not readable, continue checking
+        }
+
+        continue
+      }
+
+      try {
+        fsSync.accessSync(path.join(dirPath, indicator))
+
+        return true
+      } catch {
+        // Indicator not found, continue checking
+      }
+    }
+
     return false
   }
 

--- a/javascript/packages/config/test/find-project-root.test.ts
+++ b/javascript/packages/config/test/find-project-root.test.ts
@@ -42,3 +42,26 @@ describe("findProjectRootSync", () => {
     expect(projectRoot).toBe(tempDir)
   })
 })
+
+describe("findProjectRootSync without a .herb.yml", () => {
+  const tempDir = join(process.cwd(), "tmp-test-find-project-root-gemspec")
+  const gem = join(tempDir, "some_gem")
+
+  beforeAll(() => {
+    mkdirSync(join(gem, "app", "views"), { recursive: true })
+
+    writeFileSync(join(tempDir, "Gemfile"), "source 'https://rubygems.org'\n")
+    writeFileSync(join(gem, "some_gem.gemspec"), "Gem::Specification.new\n")
+    writeFileSync(join(gem, "app", "views", "index.html.erb"), "<div></div>\n")
+  })
+
+  afterAll(() => {
+    rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  test("recognizes a gemspec as a project indicator", () => {
+    const projectRoot = Config.findProjectRootSync(join(gem, "app", "views", "index.html.erb"))
+
+    expect(projectRoot).toBe(gem)
+  })
+})

--- a/javascript/packages/language-server/src/config_service.ts
+++ b/javascript/packages/language-server/src/config_service.ts
@@ -2,7 +2,7 @@ import { Diagnostic, DiagnosticSeverity, Range } from "vscode-languageserver/nod
 import { TextDocument } from "vscode-languageserver-textdocument"
 import { Config } from "@herb-tools/config"
 
-import { isConfigDocument, lintToDignosticSeverity } from "./utils"
+import { isConfigDocument, lintToDiagnosticSeverity } from "./utils"
 import { version } from "../package.json"
 
 /**
@@ -72,7 +72,7 @@ export class ConfigService {
 
       const path = error.path.join('.')
       const message = path ? `${path}: ${error.message}` : error.message
-      const severity = error.severity ? lintToDignosticSeverity(error.severity) : DiagnosticSeverity.Error
+      const severity = error.severity ? lintToDiagnosticSeverity(error.severity) : DiagnosticSeverity.Error
 
       diagnostics.push({
         severity,

--- a/javascript/packages/language-server/src/diagnostics.ts
+++ b/javascript/packages/language-server/src/diagnostics.ts
@@ -15,7 +15,7 @@ export class Diagnostics {
   private readonly configService: ConfigService
   private readonly settings: Settings
   private readonly workspaces: Workspaces
-  private diagnostics: Map<TextDocument, Diagnostic[]> = new Map()
+  private readonly published: Set<string> = new Set()
 
   constructor(
     connection: Connection,
@@ -34,7 +34,19 @@ export class Diagnostics {
   }
 
   clear(uri: string) {
-    this.connection.sendDiagnostics({ uri, diagnostics: [] })
+    this.publish(uri, [])
+  }
+
+  clearWhere(matches: (uri: string) => boolean) {
+    const stale: string[] = []
+
+    for (const uri of this.published) {
+      if (matches(uri)) stale.push(uri)
+    }
+
+    for (const uri of stale) {
+      this.clear(uri)
+    }
   }
 
   async validate(textDocument: TextDocument) {
@@ -59,8 +71,7 @@ export class Diagnostics {
       ]
     }
 
-    this.diagnostics.set(textDocument, allDiagnostics)
-    this.sendDiagnosticsFor(textDocument)
+    this.publish(textDocument.uri, allDiagnostics)
   }
 
   async refreshDocument(document: TextDocument) {
@@ -72,14 +83,13 @@ export class Diagnostics {
     await Promise.all(documents.map(document => this.refreshDocument(document)))
   }
 
-  private sendDiagnosticsFor(textDocument: TextDocument) {
-    const diagnostics = this.diagnostics.get(textDocument) || []
+  private publish(uri: string, diagnostics: Diagnostic[]) {
+    this.connection.sendDiagnostics({ uri, diagnostics })
 
-    this.connection.sendDiagnostics({
-      uri: textDocument.uri,
-      diagnostics,
-    })
-
-    this.diagnostics.delete(textDocument)
+    if (diagnostics.length > 0) {
+      this.published.add(uri)
+    } else {
+      this.published.delete(uri)
+    }
   }
 }

--- a/javascript/packages/language-server/src/linter_service.ts
+++ b/javascript/packages/language-server/src/linter_service.ts
@@ -19,7 +19,7 @@ const FRAME_VERBS: Record<string, string> = {
 }
 import { PartialIndexService } from "./partial_index_service"
 import { PartialCallerIndexService } from "./partial_caller_index_service"
-import { isConfigDocument, lintToDignosticSeverity, lintToDignosticTags } from "./utils"
+import { isConfigDocument, lintToDiagnosticSeverity, lintToDiagnosticTags } from "./utils"
 import { lspRangeFromLocation } from "./range_utils"
 
 const OPEN_CONFIG_ACTION = 'Open .herb.yml'
@@ -248,7 +248,7 @@ export class LinterService {
 
       const diagnostic: Diagnostic = {
         source: this.source,
-        severity: lintToDignosticSeverity(offense.severity),
+        severity: lintToDiagnosticSeverity(offense.severity),
         range,
         message: this.messageFor(offense),
         code: offense.rule,
@@ -256,7 +256,7 @@ export class LinterService {
         codeDescription
       }
 
-      const tags = lintToDignosticTags(offense.tags)
+      const tags = lintToDiagnosticTags(offense.tags)
 
       if (tags.length > 0) {
         diagnostic.tags = tags

--- a/javascript/packages/language-server/src/server.ts
+++ b/javascript/packages/language-server/src/server.ts
@@ -29,7 +29,7 @@ import { DefinitionService } from "./definition_service"
 import { PersonalHerbSettings } from "./settings"
 import { Config } from "@herb-tools/config"
 import { isPartialPath } from "@herb-tools/core"
-import { isConfigDocument } from "./utils"
+import { isConfigDocument, isPathInside, pathFromUri } from "./utils"
 import { version } from "../package.json"
 
 import type { FileEvent } from "vscode-languageserver/node"
@@ -111,6 +111,8 @@ export class Server {
 
           this.connection.console.log(`[Workspace] Folders changed, dropped ${dropped.length} project(s)`)
 
+          this.service.diagnostics.clearWhere(uri => dropped.some(root => isPathInside(pathFromUri(uri), root)))
+
           await this.service.diagnostics.refreshAllDocuments()
         })
       }
@@ -141,14 +143,6 @@ export class Server {
       }
 
       await this.service.refresh()
-    })
-
-    this.connection.onDidOpenTextDocument(async (params) => {
-      const document = this.service.documentService.get(params.textDocument.uri)
-
-      if (document) {
-        await this.service.diagnostics.refreshDocument(document)
-      }
     })
 
     this.connection.onDidChangeWatchedFiles(async (params) => {

--- a/javascript/packages/language-server/src/utils.ts
+++ b/javascript/packages/language-server/src/utils.ts
@@ -17,6 +17,13 @@ export function uriFromPath(filePath: string): string {
   return `file://${filePath.split("/").map(segment => encodeURIComponent(segment)).join("/")}`
 }
 
+/**
+ * Compares whole path segments, so `/app/foo` does not claim `/app/foo-bar`.
+ */
+export function isPathInside(filePath: string, root: string): boolean {
+  return filePath === root || filePath.startsWith(`${root}/`)
+}
+
 export function camelize(value: string) {
   return value.replace(/(?:[_-])([a-z0-9])/g, (_, char) => char.toUpperCase())
 }
@@ -29,7 +36,7 @@ export function capitalize(value: string) {
   return value.charAt(0).toUpperCase() + value.slice(1)
 }
 
-export function lintToDignosticSeverity(severity: LintSeverity | HerbDiagnosticSeverity): DiagnosticSeverity {
+export function lintToDiagnosticSeverity(severity: LintSeverity | HerbDiagnosticSeverity): DiagnosticSeverity {
   switch (severity) {
     case "error": return DiagnosticSeverity.Error
     case "warning": return DiagnosticSeverity.Warning
@@ -38,7 +45,7 @@ export function lintToDignosticSeverity(severity: LintSeverity | HerbDiagnosticS
   }
 }
 
-export function lintToDignosticTags(tags?: HerbDiagnosticTag[]): DiagnosticTag[] {
+export function lintToDiagnosticTags(tags?: HerbDiagnosticTag[]): DiagnosticTag[] {
   if (!tags) return []
 
   return tags.flatMap(tag => {

--- a/javascript/packages/language-server/test/diagnostics.test.ts
+++ b/javascript/packages/language-server/test/diagnostics.test.ts
@@ -103,6 +103,40 @@ describe("Diagnostics", () => {
     expect(published[0].diagnostics.length).toBeGreaterThan(0)
   })
 
+  test("clearWhere retracts every published document the predicate matches", async () => {
+    const { diagnostics, published } = diagnosticsFor([WORKSPACE])
+    const other = `${WORKSPACE}/app/views/other.html.erb`
+
+    await diagnostics.validate(documentFor(INSIDE))
+    await diagnostics.validate(documentFor(other))
+
+    published.length = 0
+    diagnostics.clearWhere(uri => uri === INSIDE)
+
+    expect(published).toEqual([{ uri: INSIDE, diagnostics: [] }])
+  })
+
+  test("clearWhere leaves documents the server never reported on alone", async () => {
+    const { diagnostics, published } = diagnosticsFor([WORKSPACE])
+
+    published.length = 0
+    diagnostics.clearWhere(() => true)
+
+    expect(published).toEqual([])
+  })
+
+  test("clearWhere does not retract the same document twice", async () => {
+    const { diagnostics, published } = diagnosticsFor([WORKSPACE])
+
+    await diagnostics.validate(documentFor(INSIDE))
+
+    published.length = 0
+    diagnostics.clearWhere(() => true)
+    diagnostics.clearWhere(() => true)
+
+    expect(published).toHaveLength(1)
+  })
+
   test("clear retracts the diagnostics of a document", () => {
     const { diagnostics, published } = diagnosticsFor([WORKSPACE])
 


### PR DESCRIPTION
This pull request fixes four independent correctness problems in the language server, each small enough to review on its own.

Closing a workspace folder left its diagnostics on screen forever. `Workspaces.prune()` dropped the projects, but nothing retracted what had already been published, and the existing `refreshAllDocuments()` only reaches documents that are still open. `Diagnostics` now tracks which URIs it has published and gains `clearWhere(predicate)`, which the prune path uses to clear everything under a dropped root.

The `connection.onDidOpenTextDocument` handler in `Server` was dead. `TextDocuments.listen()` registers its own handler for that method, and vscode-jsonrpc keeps one handler per method, so the later registration silently replaced ours. Diagnostics still publish on open through the `onDidChangeContent` path.

`lintToDignosticSeverity` and `lintToDignosticTags` were misspelled at seven sites. Both are exported from the package entrypoint, so the corrected names ship alongside deprecated aliases for one release.

`Config.findProjectRootSync` could never match its own `*.gemspec` indicator, because it passed the glob to `accessSync` literally. It now reads the directory and compares suffixes, the same way the async path does.