### PR TITLE
Language Server: Give each project ownership of its own config

### DIFF
--- a/javascript/packages/language-server/src/diagnostics_publisher.ts
+++ b/javascript/packages/language-server/src/diagnostics_publisher.ts
@@ -2,6 +2,9 @@ import { TextDocument } from "vscode-languageserver-textdocument"
 import { Connection, Diagnostic } from "vscode-languageserver/node"
 
 import { WorkspaceFolders } from "./workspace_folders"
+
+import type { Project } from "./project"
+import type { LinterWarning } from "./linter_service"
 import { ParserService } from "./parser_service"
 import { Documents } from "./documents"
 import { ConfigService } from "./config_service"
@@ -16,6 +19,7 @@ export class DiagnosticsPublisher {
   private readonly workspaceFolders: WorkspaceFolders
   private readonly projects: Projects
   private readonly published: Set<string> = new Set()
+  private readonly presentWarning?: (warning: LinterWarning) => void
 
   constructor(
     connection: Connection,
@@ -24,6 +28,7 @@ export class DiagnosticsPublisher {
     configService: ConfigService,
     workspaceFolders: WorkspaceFolders,
     projects: Projects,
+    presentWarning?: (warning: LinterWarning) => void,
   ) {
     this.connection = connection
     this.documents = documents
@@ -31,6 +36,7 @@ export class DiagnosticsPublisher {
     this.configService = configService
     this.workspaceFolders = workspaceFolders
     this.projects = projects
+    this.presentWarning = presentWarning
   }
 
   clear(uri: string) {
@@ -49,21 +55,24 @@ export class DiagnosticsPublisher {
     }
   }
 
-  async validate(textDocument: TextDocument) {
+  async validate(textDocument: TextDocument, project: Project | null) {
     if (!this.workspaceFolders.includes(textDocument.uri)) {
       this.clear(textDocument.uri)
 
       return
     }
 
-    const project = await this.projects.ensure(textDocument.uri)
     let allDiagnostics: Diagnostic[] = []
 
     if (isConfigDocument(textDocument.uri)) {
       allDiagnostics = await (project?.configService ?? this.configService).validateDocument(textDocument)
     } else {
       const parseResult = this.parserService.parseDocument(textDocument)
-      const lintResult = project ? await project.linterService.lintDocument(textDocument) : { diagnostics: [] }
+      const lintResult = project ? await project.linterService.lintDocument(textDocument) : { diagnostics: [], warnings: [] }
+
+      for (const warning of lintResult.warnings) {
+        this.presentWarning?.(warning)
+      }
 
       allDiagnostics = [
         ...parseResult.diagnostics,
@@ -75,7 +84,7 @@ export class DiagnosticsPublisher {
   }
 
   async refreshDocument(document: TextDocument) {
-    await this.validate(document)
+    await this.validate(document, await this.projects.ensure(document.uri))
   }
 
   async refreshAllDocuments() {

--- a/javascript/packages/language-server/src/extract_code_action_provider.ts
+++ b/javascript/packages/language-server/src/extract_code_action_provider.ts
@@ -15,9 +15,14 @@ const DEFAULT_TEMPLATE_EXTENSION = "html.erb"
 const EXTRACT_TO_PARTIAL_COMMAND = "herb.extractToPartial"
 const SEGMENT_NAME = /^[a-zA-Z0-9_-]+$/
 
+/**
+ * The two client abilities this provider needs. Reading them off `Capabilities`
+ * keeps the answer live, rather than freezing whatever was true when the
+ * provider happened to be constructed.
+ */
 export interface ExtractCodeActionCapabilities {
-  supportsCreateFile: boolean
-  supportsPromptCommand: boolean
+  readonly supportsResourceCreation: boolean
+  readonly supportsExtractToPartialCommand: boolean
 }
 
 export interface ExtractToPartialArguments {
@@ -59,14 +64,14 @@ export class ExtractCodeActionProvider {
   }
 
   getCodeActions(document: TextDocument, requestedRange: Range): CodeAction[] {
-    if (!this.capabilities.supportsCreateFile) return []
+    if (!this.capabilities.supportsResourceCreation) return []
     if (!this.isTemplate(document.uri)) return []
 
     const analysis = this.analyzer.analyze(document, requestedRange)
 
     if (!analysis) return []
 
-    if (this.capabilities.supportsPromptCommand) {
+    if (this.capabilities.supportsExtractToPartialCommand) {
       const argument: ExtractToPartialArguments = {
         uri: document.uri,
         range: analysis.range,

--- a/javascript/packages/language-server/src/formatting_provider.ts
+++ b/javascript/packages/language-server/src/formatting_provider.ts
@@ -310,9 +310,6 @@ export class FormattingProvider {
     return this.performFormatting(params)
   }
 
-  async formatDocumentIgnoreConfig(params: DocumentFormattingParams): Promise<TextEdit[]> {
-    return this.performFormatting(params)
-  }
 
   private async performRangeFormatting(params: DocumentRangeFormattingParams): Promise<TextEdit[]> {
     const document = this.documents.get(params.textDocument.uri)
@@ -411,7 +408,4 @@ export class FormattingProvider {
     return this.performRangeFormatting(params)
   }
 
-  async formatRangeIgnoreConfig(params: DocumentRangeFormattingParams): Promise<TextEdit[]> {
-    return this.performRangeFormatting(params)
-  }
 }

--- a/javascript/packages/language-server/src/formatting_provider.ts
+++ b/javascript/packages/language-server/src/formatting_provider.ts
@@ -8,7 +8,6 @@ import { UserSettings } from "./user_settings"
 import { Capabilities } from "./capabilities"
 import { Config } from "@herb-tools/config"
 import { isConfigDocument } from "./utils"
-import { version } from "../package.json"
 
 const OPEN_CONFIG_ACTION = 'Open .herb.yml'
 
@@ -31,11 +30,9 @@ export class FormattingProvider {
     this.capabilities = capabilities
   }
 
-  async initialize() {
+  async initialize(config?: Config) {
     try {
-      this.config = await Config.loadForEditor(this.project.root, version)
-      this.connection.console.log(`[Formatting] Config loaded, formatter config: ${JSON.stringify(this.config?.formatter || 'none')}`)
-      await this.loadConfiguredRewriters()
+      await this.refreshConfig(config)
       this.connection.console.log("Herb formatter initialized successfully")
     } catch (error) {
       this.connection.console.error(`Failed to initialize Herb formatter: ${error}`)
@@ -43,15 +40,9 @@ export class FormattingProvider {
   }
 
   async refreshConfig(config?: Config) {
-    if (config) {
-      this.config = config
-    } else {
-      try {
-        this.config = await Config.loadForEditor(this.project.root, version)
-      } catch (error) {
-        this.connection.console.error(`Failed to refresh Herb formatter config: ${error}`)
-      }
-    }
+    this.config = config
+
+    this.connection.console.log(`[Formatting] Config loaded, formatter config: ${JSON.stringify(this.config?.formatter || 'none')}`)
 
     await this.loadConfiguredRewriters()
   }
@@ -223,7 +214,7 @@ export class FormattingProvider {
   }
 
   private async getConfigWithSettings(uri: string): Promise<Config | undefined> {
-    const settings = await this.userSettings.getDocumentSettings(uri)
+    const settings = await this.project.settingsFor(uri)
 
     if (!this.config) return undefined
 
@@ -304,7 +295,7 @@ export class FormattingProvider {
       return []
     }
 
-    const settings = await this.userSettings.getDocumentSettings(params.textDocument.uri)
+    const settings = await this.project.settingsFor(params.textDocument.uri)
 
     if (settings?.formatter?.enabled === false) {
       return []

--- a/javascript/packages/language-server/src/formatting_provider.ts
+++ b/javascript/packages/language-server/src/formatting_provider.ts
@@ -1,8 +1,9 @@
-import { Connection, TextDocuments, DocumentFormattingParams, DocumentRangeFormattingParams, TextEdit, Range, Position, TextDocumentSaveReason } from "vscode-languageserver/node"
+import { Connection, DocumentFormattingParams, DocumentRangeFormattingParams, TextEdit, Range, Position, TextDocumentSaveReason } from "vscode-languageserver/node"
 import { TextDocument } from "vscode-languageserver-textdocument"
 import { Formatter, defaultFormatOptions } from "@herb-tools/formatter"
 import { ASTRewriter, StringRewriter } from "@herb-tools/rewriter"
 import { CustomRewriterLoader, builtinRewriters, isASTRewriterClass, isStringRewriterClass } from "@herb-tools/rewriter/loader"
+import { Documents } from "./documents"
 import { Project } from "./project"
 import { UserSettings } from "./user_settings"
 import { Capabilities } from "./capabilities"
@@ -13,7 +14,7 @@ const OPEN_CONFIG_ACTION = 'Open .herb.yml'
 
 export class FormattingProvider {
   private connection: Connection
-  private documents: TextDocuments<TextDocument>
+  private documents: Documents
   private project: Project
   private userSettings: UserSettings
   private capabilities: Capabilities
@@ -22,7 +23,7 @@ export class FormattingProvider {
   private postRewriters: StringRewriter[] = []
   private failedRewriters: Map<string, string> = new Map()
 
-  constructor(connection: Connection, documents: TextDocuments<TextDocument>, project: Project, userSettings: UserSettings, capabilities: Capabilities) {
+  constructor(connection: Connection, documents: Documents, project: Project, userSettings: UserSettings, capabilities: Capabilities) {
     this.connection = connection
     this.documents = documents
     this.project = project

--- a/javascript/packages/language-server/src/linter_service.ts
+++ b/javascript/packages/language-server/src/linter_service.ts
@@ -23,10 +23,20 @@ import { PartialCallerIndexService } from "./partial_caller_index_service"
 import { isConfigDocument, lintToDiagnosticSeverity, lintToDiagnosticTags } from "./utils"
 import { lspRangeFromLocation } from "./range_utils"
 
-const OPEN_CONFIG_ACTION = 'Open .herb.yml'
 
 export interface LintServiceResult {
   diagnostics: Diagnostic[]
+  warnings: LinterWarning[]
+}
+
+/**
+ * Something the user should be told about their linter setup. The service
+ * reports these rather than talking to the client itself, so that what it does
+ * is decided by whoever owns the connection.
+ */
+export interface LinterWarning {
+  message: string
+  configPath: string
 }
 
 export class LinterService {
@@ -111,11 +121,12 @@ export class LinterService {
   }
 
   /**
-   * Show warning message to user about failed custom rules
+   * Reports each custom-rule failure once, so a broken config does not nag on
+   * every keystroke.
    */
-  private showCustomRuleWarnings(): void {
+  private takeCustomRuleWarnings(): LinterWarning[] {
     if (this.failedCustomRules.size === 0 || this.hasShownCustomRuleWarning) {
-      return
+      return []
     }
 
     this.hasShownCustomRuleWarning = true
@@ -125,16 +136,7 @@ export class LinterService {
       ? `Failed to load custom linter rules: ${failures[0][1]}`
       : `Failed to load custom linter rules:\n${failures.map(([_, error], i) => `${i + 1}. ${error}`).join('\n')}`
 
-    if (this.capabilities.hasShowDocument) {
-      this.connection.window.showWarningMessage(message, { title: OPEN_CONFIG_ACTION }).then(action => {
-        if (action?.title === OPEN_CONFIG_ACTION) {
-          const configPath = `${this.project.root}/.herb.yml`
-          this.connection.window.showDocument({ uri: `file://${configPath}`, takeFocus: true })
-        }
-      })
-    } else {
-      this.connection.window.showWarningMessage(message)
-    }
+    return [{ message, configPath: `${this.project.root}/.herb.yml` }]
   }
 
   private shouldLintFile(uri: string): boolean {
@@ -191,22 +193,23 @@ export class LinterService {
 
   async lintDocument(textDocument: TextDocument): Promise<LintServiceResult> {
     if (!this.shouldLintFile(textDocument.uri)) {
-      return { diagnostics: [] }
+      return { diagnostics: [], warnings: [] }
     }
 
     const settings = await this.project.settingsFor(textDocument.uri)
     const linterEnabled = settings?.linter?.enabled ?? true
 
     if (!linterEnabled) {
-      return { diagnostics: [] }
+      return { diagnostics: [], warnings: [] }
     }
 
     const projectConfig = this.config
+    const warnings: LinterWarning[] = []
 
     if (!this.linter) {
       await this.loadCustomRules()
 
-      this.showCustomRuleWarnings()
+      warnings.push(...this.takeCustomRuleWarnings())
 
       const linterConfig = projectConfig?.config?.linter || { enabled: true, rules: {} }
 
@@ -276,6 +279,6 @@ export class LinterService {
       return diagnostic
     })
 
-    return { diagnostics }
+    return { diagnostics, warnings }
   }
 }

--- a/javascript/packages/language-server/src/linter_service.ts
+++ b/javascript/packages/language-server/src/linter_service.ts
@@ -194,7 +194,7 @@ export class LinterService {
       return { diagnostics: [] }
     }
 
-    const settings = await this.userSettings.getDocumentSettings(textDocument.uri)
+    const settings = await this.project.settingsFor(textDocument.uri)
     const linterEnabled = settings?.linter?.enabled ?? true
 
     if (!linterEnabled) {

--- a/javascript/packages/language-server/src/project.ts
+++ b/javascript/packages/language-server/src/project.ts
@@ -76,8 +76,7 @@ export class Project {
   async initialize() {
     await this.herbBackend.load()
     await this.loadConfig()
-    await this.formattingProvider.initialize()
-    await this.formattingProvider.refreshConfig(this.config)
+    await this.formattingProvider.initialize(this.config)
     await this.partialIndexService.initialize()
     await this.partialCallerIndexService.initialize()
   }
@@ -105,6 +104,34 @@ export class Project {
 
   contains(path: string): boolean {
     return path === this.root || path.startsWith(`${this.root}/`)
+  }
+
+  /**
+   * What a document in this project should actually be treated as, which is the
+   * user's editor preferences with this project's `.herb.yml` layered over them.
+   * A checked-in config is a decision the whole team made, so it wins over a
+   * personal default for whether the linter and formatter run at all. Settings
+   * that are only ever personal, like `fixOnSave`, stay with the user.
+   */
+  async settingsFor(uri: string): Promise<PersonalHerbSettings> {
+    const settings = await this.userSettings.getDocumentSettings(uri)
+
+    if (!this.config || !Config.exists(this.config.projectPath)) return settings
+
+    return {
+      ...settings,
+      linter: {
+        ...settings.linter,
+        enabled: this.config.isLinterEnabled
+      },
+      formatter: {
+        ...settings.formatter,
+        enabled: this.config.isFormatterEnabled,
+        indentWidth: this.config.formatter?.indentWidth ?? settings.formatter?.indentWidth,
+        indentStyle: this.config.formatter?.indentStyle ?? settings.formatter?.indentStyle,
+        maxLineLength: this.config.formatter?.maxLineLength ?? settings.formatter?.maxLineLength
+      }
+    }
   }
 
   private async readConfig(): Promise<Config> {

--- a/javascript/packages/language-server/src/project.ts
+++ b/javascript/packages/language-server/src/project.ts
@@ -61,7 +61,7 @@ export class Project {
     this.linterService = new LinterService(connection, userSettings, capabilities, this, this.partialIndexService, this.partialCallerIndexService)
     this.autofixService = new AutofixService(connection, undefined, this.partialIndexService, this.partialCallerIndexService)
     this.codeActionProvider = new CodeActionProvider(this, undefined, this.partialIndexService, this.partialCallerIndexService)
-    this.formattingProvider = new FormattingProvider(connection, shared.documents.documents, this, userSettings, capabilities)
+    this.formattingProvider = new FormattingProvider(connection, shared.documents, this, userSettings, capabilities)
     this.completionProvider = new CompletionProvider(shared.parserService, this.partialIndexService)
 
     this.referencesProvider = new ReferencesProvider(

--- a/javascript/packages/language-server/src/save_orchestrator.ts
+++ b/javascript/packages/language-server/src/save_orchestrator.ts
@@ -1,12 +1,10 @@
 import { Connection, TextEdit, TextDocumentSaveReason } from "vscode-languageserver/node"
 import { TextDocument } from "vscode-languageserver-textdocument"
 
-import { UserSettings } from "./user_settings"
 import { Projects } from "./projects"
 
 export class SaveOrchestrator {
   private connection: Connection
-  private userSettings: UserSettings
   private projects: Projects
 
   /**
@@ -18,10 +16,17 @@ export class SaveOrchestrator {
    */
   private recentlyAutofixedViaFormatting = new Set<string>()
 
-  constructor(connection: Connection, userSettings: UserSettings, projects: Projects) {
+  constructor(connection: Connection, projects: Projects) {
     this.connection = connection
-    this.userSettings = userSettings
     this.projects = projects
+  }
+
+  /**
+   * A closed document can't be mid-save, so anything remembered about its last
+   * save would only be able to suppress a later, unrelated autofix.
+   */
+  forget(uri: string) {
+    this.recentlyAutofixedViaFormatting.delete(uri)
   }
 
   /**
@@ -33,7 +38,7 @@ export class SaveOrchestrator {
 
     if (!project) return []
 
-    const settings = await this.userSettings.getDocumentSettings(document.uri)
+    const settings = await project.settingsFor(document.uri)
     const fixOnSave = settings?.linter?.fixOnSave !== false
 
     this.connection.console.log(`[DocumentSave] applyFixes fixOnSave=${fixOnSave}`)
@@ -57,7 +62,7 @@ export class SaveOrchestrator {
 
     if (!project) return []
 
-    const settings = await this.userSettings.getDocumentSettings(document.uri)
+    const settings = await project.settingsFor(document.uri)
     const fixOnSave = settings?.linter?.fixOnSave !== false
     const formatterEnabled = settings?.formatter?.enabled ?? false
 

--- a/javascript/packages/language-server/src/session.ts
+++ b/javascript/packages/language-server/src/session.ts
@@ -20,6 +20,10 @@ import { CommentProvider } from "./comment_provider"
 import { DocumentSymbolProvider } from "./document_symbol_provider"
 import { Projects } from "./projects"
 
+import type { LinterWarning } from "./linter_service"
+
+const OPEN_CONFIG_ACTION = "Open .herb.yml"
+
 export class Session {
   connection: Connection
   capabilities: Capabilities
@@ -59,7 +63,7 @@ export class Session {
       capabilities: this.capabilities,
     })
 
-    this.diagnostics = new DiagnosticsPublisher(this.connection, this.documents, this.parserService, this.configService, this.workspaceFolders, this.projects)
+    this.diagnostics = new DiagnosticsPublisher(this.connection, this.documents, this.parserService, this.configService, this.workspaceFolders, this.projects, warning => this.showWarning(warning))
     this.saveOrchestrator = new SaveOrchestrator(this.connection, this.projects)
     this.foldingRangeProvider = new FoldingRangeProvider(this.parserService)
     this.documentHighlightProvider = new DocumentHighlightProvider(this.parserService)
@@ -73,6 +77,24 @@ export class Session {
     if (params.initializationOptions) {
       this.userSettings.global = params.initializationOptions as PersonalHerbSettings
     }
+  }
+
+  /**
+   * Surfaces a linter warning, offering to open the config that caused it when
+   * the client can navigate there.
+   */
+  private showWarning(warning: LinterWarning) {
+    if (!this.capabilities.hasShowDocument) {
+      this.connection.window.showWarningMessage(warning.message)
+
+      return
+    }
+
+    this.connection.window.showWarningMessage(warning.message, { title: OPEN_CONFIG_ACTION }).then(action => {
+      if (action?.title === OPEN_CONFIG_ACTION) {
+        this.connection.window.showDocument({ uri: `file://${warning.configPath}`, takeFocus: true })
+      }
+    })
   }
 
   async init() {

--- a/javascript/packages/language-server/src/session.ts
+++ b/javascript/packages/language-server/src/session.ts
@@ -68,10 +68,7 @@ export class Session {
     this.commentProvider = new CommentProvider(this.parserService)
     this.documentSymbolProvider = new DocumentSymbolProvider(this.parserService)
 
-    this.extractCodeActionProvider = new ExtractCodeActionProvider(this.parserService, {
-      supportsCreateFile: this.capabilities.supportsResourceCreation,
-      supportsPromptCommand: this.capabilities.supportsExtractToPartialCommand,
-    })
+    this.extractCodeActionProvider = new ExtractCodeActionProvider(this.parserService, this.capabilities)
 
     if (params.initializationOptions) {
       this.userSettings.global = params.initializationOptions as PersonalHerbSettings

--- a/javascript/packages/language-server/src/session.ts
+++ b/javascript/packages/language-server/src/session.ts
@@ -60,7 +60,7 @@ export class Session {
     })
 
     this.diagnostics = new DiagnosticsPublisher(this.connection, this.documents, this.parserService, this.configService, this.workspaceFolders, this.projects)
-    this.saveOrchestrator = new SaveOrchestrator(this.connection, this.userSettings, this.projects)
+    this.saveOrchestrator = new SaveOrchestrator(this.connection, this.projects)
     this.foldingRangeProvider = new FoldingRangeProvider(this.parserService)
     this.documentHighlightProvider = new DocumentHighlightProvider(this.parserService)
     this.hoverProvider = new HoverProvider(this.parserService)
@@ -85,6 +85,7 @@ export class Session {
 
     this.documents.onDidClose((change) => {
       this.userSettings.forget(change.document.uri)
+      this.saveOrchestrator.forget(change.document.uri)
       this.diagnostics.clear(change.document.uri)
     })
 

--- a/javascript/packages/language-server/test/extract_code_action_provider.test.ts
+++ b/javascript/packages/language-server/test/extract_code_action_provider.test.ts
@@ -21,10 +21,10 @@ describe("ExtractCodeActionProvider", () => {
     parserService = new ParserService()
   })
 
-  function createService(supportsPromptCommand = false) {
+  function createService(supportsExtractToPartialCommand = false) {
     return new ExtractCodeActionProvider(parserService, {
-      supportsCreateFile: true,
-      supportsPromptCommand
+      supportsResourceCreation: true,
+      supportsExtractToPartialCommand
     })
   }
 
@@ -115,7 +115,7 @@ describe("ExtractCodeActionProvider", () => {
     it("does not offer an action when the client can't create files", () => {
       const content = `<div>Hello</div>`
 
-      const service = new ExtractCodeActionProvider(parserService, { supportsCreateFile: false, supportsPromptCommand: false })
+      const service = new ExtractCodeActionProvider(parserService, { supportsResourceCreation: false, supportsExtractToPartialCommand: false })
 
       expect(service.getCodeActions(createDocument(content), selectionOf(content, content))).toHaveLength(0)
     })

--- a/javascript/packages/language-server/test/formatting_provider.test.ts
+++ b/javascript/packages/language-server/test/formatting_provider.test.ts
@@ -235,7 +235,7 @@ describe('FormattingProvider', () => {
     })
   })
 
-  describe('formatDocumentIgnoreConfig', () => {
+  describe('formatDocument with no settings', () => {
     it('should format even with null settings', async () => {
       const params: DocumentFormattingParams = {
         textDocument: { uri: 'file:///test/file.erb' },
@@ -247,7 +247,7 @@ describe('FormattingProvider', () => {
       const document = TextDocument.create('file:///test/file.erb', 'erb', 1, '<div>test</div>')
       vi.mocked(documents.get).mockReturnValue(document)
 
-      const result = await formattingProvider.formatDocumentIgnoreConfig(params)
+      const result = await formattingProvider.formatDocument(params)
 
       expect(result).toBeDefined()
       expect(result.length).toBeGreaterThan(0)
@@ -450,7 +450,7 @@ describe('FormattingProvider', () => {
     })
   })
 
-  describe('formatRangeIgnoreConfig', () => {
+  describe('formatRange with no settings', () => {
     it('should format range even with null settings', async () => {
       vi.mocked(userSettings.getDocumentSettings).mockResolvedValue(null as any)
 
@@ -470,7 +470,7 @@ describe('FormattingProvider', () => {
         options: { tabSize: 2, insertSpaces: true }
       }
 
-      const result = await formattingProvider.formatRangeIgnoreConfig(params)
+      const result = await formattingProvider.formatRange(params)
 
       expect(result).toBeDefined()
     })

--- a/javascript/packages/language-server/test/formatting_provider.test.ts
+++ b/javascript/packages/language-server/test/formatting_provider.test.ts
@@ -7,6 +7,7 @@ import { TextDocument } from 'vscode-languageserver-textdocument'
 
 import { FormattingProvider } from '../src/formatting_provider'
 import { Project } from '../src/project'
+import { Documents } from '../src/documents'
 import { UserSettings } from '../src/user_settings'
 import { Capabilities } from '../src/capabilities'
 
@@ -15,7 +16,7 @@ import { Config } from '@herb-tools/config'
 
 describe('FormattingProvider', () => {
   let connection: Connection
-  let documents: TextDocuments<TextDocument>
+  let documents: Documents
   let project: Project
   let userSettings: UserSettings
   let formattingProvider: FormattingProvider
@@ -34,7 +35,7 @@ describe('FormattingProvider', () => {
 
     documents = {
       get: vi.fn()
-    } as unknown as TextDocuments<TextDocument>
+    } as unknown as Documents
 
     project = {
       root: '/test/project',

--- a/javascript/packages/language-server/test/formatting_provider.test.ts
+++ b/javascript/packages/language-server/test/formatting_provider.test.ts
@@ -38,7 +38,8 @@ describe('FormattingProvider', () => {
 
     project = {
       root: '/test/project',
-      herbBackend: Herb
+      herbBackend: Herb,
+      settingsFor: (uri: string) => userSettings.getDocumentSettings(uri)
     } as unknown as Project
 
     userSettings = {

--- a/javascript/packages/language-server/test/linter_service.test.ts
+++ b/javascript/packages/language-server/test/linter_service.test.ts
@@ -305,6 +305,40 @@ describe("LinterService", () => {
     })
   })
 
+  describe("custom rule warnings", () => {
+    test("reports a broken custom rule as data instead of talking to the client", async () => {
+      const userSettings = new UserSettings(mockConnection, capabilities)
+      userSettings.getDocumentSettings = vi.fn().mockResolvedValue({ linter: { enabled: true } })
+
+      const linterService = new LinterService(mockConnection, userSettings, capabilities, projectFor(userSettings), partialIndexService)
+
+      linterService["failedCustomRules"].set("custom-rules", "boom")
+
+      const result = await linterService.lintDocument(createTestDocument("<div>Test</div>\n"))
+
+      expect(result.warnings).toHaveLength(1)
+      expect(result.warnings[0].message).toContain("boom")
+      expect(result.warnings[0].configPath).toContain(".herb.yml")
+    })
+
+    test("reports the same failure only once", async () => {
+      const userSettings = new UserSettings(mockConnection, capabilities)
+      userSettings.getDocumentSettings = vi.fn().mockResolvedValue({ linter: { enabled: true } })
+
+      const linterService = new LinterService(mockConnection, userSettings, capabilities, projectFor(userSettings), partialIndexService)
+
+      linterService["failedCustomRules"].set("custom-rules", "boom")
+
+      await linterService.lintDocument(createTestDocument("<div>Test</div>\n"))
+
+      linterService["linter"] = undefined
+
+      const second = await linterService.lintDocument(createTestDocument("<div>Test</div>\n"))
+
+      expect(second.warnings).toEqual([])
+    })
+  })
+
   describe("cross-file rules", () => {
     const PARTIAL = "app/views/shared/_meta.html.erb"
 

--- a/javascript/packages/language-server/test/linter_service.test.ts
+++ b/javascript/packages/language-server/test/linter_service.test.ts
@@ -41,6 +41,10 @@ describe("LinterService", () => {
     root: process.cwd()
   } as Project
 
+  function projectFor(userSettings: UserSettings, root = process.cwd()): Project {
+    return { root, settingsFor: (uri: string) => userSettings.getDocumentSettings(uri) } as unknown as Project
+  }
+
   const capabilities = new Capabilities(mockParams)
 
   const partialIndexService = new PartialIndexService(mockConnection, mockProject)
@@ -54,7 +58,7 @@ describe("LinterService", () => {
       const userSettings = new UserSettings(mockConnection, capabilities)
       userSettings.getDocumentSettings = vi.fn().mockResolvedValue(null)
 
-      const linterService = new LinterService(mockConnection, userSettings, capabilities, mockProject, partialIndexService)
+      const linterService = new LinterService(mockConnection, userSettings, capabilities, projectFor(userSettings), partialIndexService)
       const textDocument = createTestDocument("<div>Test</div>\n")
 
       const result = await linterService.lintDocument(textDocument)
@@ -70,7 +74,7 @@ describe("LinterService", () => {
         // linter is undefined
       })
 
-      const linterService = new LinterService(mockConnection, userSettings, capabilities, mockProject, partialIndexService)
+      const linterService = new LinterService(mockConnection, userSettings, capabilities, projectFor(userSettings), partialIndexService)
       const textDocument = createTestDocument("<div>Test</div>\n")
 
       const result = await linterService.lintDocument(textDocument)
@@ -85,7 +89,7 @@ describe("LinterService", () => {
         linter: { enabled: false }
       })
 
-      const linterService = new LinterService(mockConnection, userSettings, capabilities, mockProject, partialIndexService)
+      const linterService = new LinterService(mockConnection, userSettings, capabilities, projectFor(userSettings), partialIndexService)
       const textDocument = createTestDocument("<DIV>Test</DIV>\n")
 
       const result = await linterService.lintDocument(textDocument)
@@ -99,7 +103,7 @@ describe("LinterService", () => {
         linter: { enabled: true }
       })
 
-      const linterService = new LinterService(mockConnection, userSettings, capabilities, mockProject, partialIndexService)
+      const linterService = new LinterService(mockConnection, userSettings, capabilities, projectFor(userSettings), partialIndexService)
       const textDocument = createTestDocument("<DIV><SPAN>Hello</SPAN></DIV>")
 
       const result = await linterService.lintDocument(textDocument)
@@ -110,7 +114,7 @@ describe("LinterService", () => {
     test("uses default settings when no configuration is provided", async () => {
       const userSettings = new UserSettings(mockConnection, capabilities)
 
-      const linterService = new LinterService(mockConnection, userSettings, capabilities, mockProject, partialIndexService)
+      const linterService = new LinterService(mockConnection, userSettings, capabilities, projectFor(userSettings), partialIndexService)
       const textDocument = createTestDocument("<DIV>Test</DIV>")
 
       const result = await linterService.lintDocument(textDocument)
@@ -124,7 +128,7 @@ describe("LinterService", () => {
         linter: { enabled: true }
       })
 
-      const linterService = new LinterService(mockConnection, userSettings, capabilities, mockProject, partialIndexService)
+      const linterService = new LinterService(mockConnection, userSettings, capabilities, projectFor(userSettings), partialIndexService)
       const textDocument = createTestDocument("<h2>Content<h3>")
 
       const result = await linterService.lintDocument(textDocument)
@@ -147,7 +151,7 @@ describe("LinterService", () => {
         linter: { enabled: true, rules: {} }
       }, { projectPath: process.cwd() })
 
-      const linterService = new LinterService(mockConnection, userSettings, capabilities, mockProject, partialIndexService)
+      const linterService = new LinterService(mockConnection, userSettings, capabilities, projectFor(userSettings), partialIndexService)
       linterService.setConfig(projectConfig)
 
       const result = await linterService.lintDocument(createTestDocument("<div>Test</div>\n"))
@@ -163,7 +167,7 @@ describe("LinterService", () => {
         linter: { enabled: true, rules: {} }
       }, { projectPath: process.cwd() })
 
-      const linterService = new LinterService(mockConnection, userSettings, capabilities, mockProject, partialIndexService)
+      const linterService = new LinterService(mockConnection, userSettings, capabilities, projectFor(userSettings), partialIndexService)
       linterService.setConfig(projectConfig)
 
       const result = await linterService.lintDocument(createTestDocument("<div>Test</div>\n"))
@@ -193,7 +197,7 @@ describe("LinterService", () => {
         root: "/test/project"
       } as Project
 
-      const linterService = new LinterService(mockConnection, userSettings, capabilities, mockProjectWithPath, new PartialIndexService(mockConnection, mockProjectWithPath))
+      const linterService = new LinterService(mockConnection, userSettings, capabilities, projectFor(userSettings, "/test/project"), new PartialIndexService(mockConnection, mockProjectWithPath))
       linterService.setConfig(projectConfig)
       const textDocument = TextDocument.create("file:///test/project/vendor/cache/file.html.erb", "erb", 1, "<DIV>Content</DIV>")
       const result = await linterService.lintDocument(textDocument)
@@ -223,7 +227,7 @@ describe("LinterService", () => {
         root: "/test/project"
       } as Project
 
-      const linterService = new LinterService(mockConnection, userSettings, capabilities, mockProjectWithPath, new PartialIndexService(mockConnection, mockProjectWithPath))
+      const linterService = new LinterService(mockConnection, userSettings, capabilities, projectFor(userSettings, "/test/project"), new PartialIndexService(mockConnection, mockProjectWithPath))
       linterService.setConfig(projectConfig)
       const textDocument = TextDocument.create("file:///test/project/something/file.html.erb", "erb", 1, "<DIV>Content</DIV>")
       const result = await linterService.lintDocument(textDocument)
@@ -255,7 +259,7 @@ describe("LinterService", () => {
         root: "/test/project"
       } as Project
 
-      const linterService = new LinterService(mockConnection, userSettings, capabilities, mockProjectWithPath, new PartialIndexService(mockConnection, mockProjectWithPath))
+      const linterService = new LinterService(mockConnection, userSettings, capabilities, projectFor(userSettings, "/test/project"), new PartialIndexService(mockConnection, mockProjectWithPath))
       linterService.setConfig(projectConfig)
       const textDocument = TextDocument.create("file:///test/project/app/views/file.html.erb", "erb", 1, "<DIV>Content</DIV>")
       const result = await linterService.lintDocument(textDocument)
@@ -287,7 +291,7 @@ describe("LinterService", () => {
         applySeverityOverrides: (offenses: any) => offenses
       } as any
 
-      const linterService = new LinterService(mockConnection, userSettings, capabilities, mockProject, partialIndexService)
+      const linterService = new LinterService(mockConnection, userSettings, capabilities, projectFor(userSettings), partialIndexService)
       linterService.setConfig(projectConfig)
 
       const textDocument = createTestDocument("<DIV>Content</DIV>")
@@ -335,7 +339,7 @@ describe("LinterService", () => {
 
       const client = clientWith()
 
-      const service = new LinterService(mockConnection, client.userSettings, client.capabilities, mockProject, partialIndexService, callerServiceFor(callers))
+      const service = new LinterService(mockConnection, client.userSettings, client.capabilities, projectFor(client.userSettings), partialIndexService, callerServiceFor(callers))
 
       vi.spyOn(partialIndexService, "relativePathFor").mockReturnValue(PARTIAL)
 
@@ -348,7 +352,7 @@ describe("LinterService", () => {
     test("stays silent for the same partial when no call site is known", async () => {
       const empty = new PartialCallerIndex(new Map(), new Set(), new Map(), new Set())
       const client = clientWith()
-      const service = new LinterService(mockConnection, client.userSettings, client.capabilities, mockProject, partialIndexService, callerServiceFor(empty))
+      const service = new LinterService(mockConnection, client.userSettings, client.capabilities, projectFor(client.userSettings), partialIndexService, callerServiceFor(empty))
 
       vi.spyOn(partialIndexService, "relativePathFor").mockReturnValue(PARTIAL)
 
@@ -374,7 +378,7 @@ describe("LinterService", () => {
 
       const client = clientWith()
 
-      const service = new LinterService(mockConnection, client.userSettings, client.capabilities, mockProject, partialIndexService, callerServiceFor(callers))
+      const service = new LinterService(mockConnection, client.userSettings, client.capabilities, projectFor(client.userSettings), partialIndexService, callerServiceFor(callers))
 
       vi.spyOn(partialIndexService, "relativePathFor").mockReturnValue(PARTIAL)
 
@@ -394,7 +398,7 @@ describe("LinterService", () => {
     test("omits related information when nothing rendered the file", async () => {
       const empty = new PartialCallerIndex(new Map(), new Set(), new Map(), new Set())
       const client = clientWith()
-      const service = new LinterService(mockConnection, client.userSettings, client.capabilities, mockProject, partialIndexService, callerServiceFor(empty))
+      const service = new LinterService(mockConnection, client.userSettings, client.capabilities, projectFor(client.userSettings), partialIndexService, callerServiceFor(empty))
 
       vi.spyOn(partialIndexService, "relativePathFor").mockReturnValue(PARTIAL)
 
@@ -420,7 +424,7 @@ describe("LinterService", () => {
 
       const client = clientWith(false)
 
-      const service = new LinterService(mockConnection, client.userSettings, client.capabilities, mockProject, partialIndexService, callerServiceFor(callers))
+      const service = new LinterService(mockConnection, client.userSettings, client.capabilities, projectFor(client.userSettings), partialIndexService, callerServiceFor(callers))
 
       vi.spyOn(partialIndexService, "relativePathFor").mockReturnValue(PARTIAL)
 

--- a/javascript/packages/language-server/test/project.test.ts
+++ b/javascript/packages/language-server/test/project.test.ts
@@ -1,0 +1,119 @@
+import { describe, test, expect, beforeAll, beforeEach, afterEach, vi } from "vitest"
+import { mkdirSync, writeFileSync, rmSync, mkdtempSync } from "fs"
+import { join } from "path"
+import { tmpdir } from "os"
+
+import { Herb } from "@herb-tools/node-wasm"
+
+import { Project } from "../src/project"
+import { Capabilities } from "../src/capabilities"
+import { UserSettings } from "../src/user_settings"
+import { ParserService } from "../src/parser_service"
+import { DefinitionProvider } from "../src/definition_provider"
+
+import type { Connection, InitializeParams } from "vscode-languageserver/node"
+import type { Documents } from "../src/documents"
+import type { SharedServices } from "../src/project"
+
+describe("Project", () => {
+  let root: string
+
+  beforeAll(async () => {
+    await Herb.load()
+  })
+
+  const connection = {
+    console: { log: vi.fn(), warn: vi.fn(), error: vi.fn() }
+  } as unknown as Connection
+
+  const params = {
+    processId: null,
+    rootUri: null,
+    capabilities: {},
+    workspaceFolders: null
+  } as InitializeParams
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "herb-project-"))
+    mkdirSync(join(root, "app/views/posts"), { recursive: true })
+  })
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true })
+  })
+
+  function projectFor(userSettings?: UserSettings, capabilities = new Capabilities(params)): Project {
+    const parserService = new ParserService()
+
+    const shared: SharedServices = {
+      documents: { documents: {}, get: () => undefined } as unknown as Documents,
+      parserService,
+      definitionProvider: new DefinitionProvider(parserService),
+      userSettings: userSettings ?? new UserSettings(connection, capabilities),
+      capabilities,
+    }
+
+    return new Project(connection, root, shared)
+  }
+
+  describe("settingsFor", () => {
+    test("lets a checked-in config turn the formatter on when the user never opted in", async () => {
+      writeFileSync(join(root, ".herb.yml"), "formatter:\n  enabled: true\n")
+
+      const capabilities = new Capabilities(params)
+      const userSettings = new UserSettings(connection, capabilities)
+
+      const project = projectFor(userSettings, capabilities)
+      await project.loadConfig()
+
+      const uri = `file://${join(root, "app/views/posts/index.html.erb")}`
+
+      expect((await userSettings.getDocumentSettings(uri)).formatter?.enabled).toBe(false)
+      expect((await project.settingsFor(uri)).formatter?.enabled).toBe(true)
+    })
+
+    test("lets a checked-in config turn the linter off", async () => {
+      writeFileSync(join(root, ".herb.yml"), "linter:\n  enabled: false\n")
+
+      const project = projectFor()
+      await project.loadConfig()
+
+      const settings = await project.settingsFor(`file://${join(root, "app/views/posts/index.html.erb")}`)
+
+      expect(settings.linter?.enabled).toBe(false)
+    })
+
+    test("carries the config's formatter dimensions through", async () => {
+      writeFileSync(join(root, ".herb.yml"), "formatter:\n  enabled: true\n  indentWidth: 8\n  maxLineLength: 120\n")
+
+      const project = projectFor()
+      await project.loadConfig()
+
+      const settings = await project.settingsFor(`file://${join(root, "app/views/posts/index.html.erb")}`)
+
+      expect(settings.formatter?.indentWidth).toBe(8)
+      expect(settings.formatter?.maxLineLength).toBe(120)
+    })
+
+    test("leaves personal settings alone, since a project can't have an opinion on them", async () => {
+      writeFileSync(join(root, ".herb.yml"), "formatter:\n  enabled: true\n")
+
+      const project = projectFor()
+      await project.loadConfig()
+
+      const settings = await project.settingsFor(`file://${join(root, "app/views/posts/index.html.erb")}`)
+
+      expect(settings.linter?.fixOnSave).toBe(true)
+    })
+
+    test("falls back to the user's settings when the project has no config file", async () => {
+      const project = projectFor()
+      await project.loadConfig()
+
+      const settings = await project.settingsFor(`file://${join(root, "app/views/posts/index.html.erb")}`)
+
+      expect(settings.formatter?.enabled).toBe(false)
+      expect(settings.linter?.enabled).toBe(true)
+    })
+  })
+})

--- a/javascript/packages/language-server/test/save_orchestrator.test.ts
+++ b/javascript/packages/language-server/test/save_orchestrator.test.ts
@@ -43,10 +43,10 @@ describe('SaveOrchestrator', () => {
     } as unknown as FormattingProvider
 
     const projects = {
-      ensure: async () => ({ autofixService, formattingProvider })
+      ensure: async () => ({ autofixService, formattingProvider, settingsFor: (uri: string) => userSettings.getDocumentSettings(uri) })
     } as unknown as Projects
 
-    saveOrchestrator = new SaveOrchestrator(connection, userSettings, projects)
+    saveOrchestrator = new SaveOrchestrator(connection, projects)
   })
 
   describe('applyFixesAndFormatting', () => {


### PR DESCRIPTION
This pull request fixes a `.herb.yml` setting that never took effect, and moves config ownership to the project it belongs to.

A project setting `formatter.enabled: true` did not turn the formatter on. The save path asked `UserSettings` for a document's settings, and `UserSettings` only knows the user's editor preferences, so a checked-in config could not opt a team in. The code meant to merge the two existed but was unreachable, since the config it merged was never populated outside a test.

Settings for a document now resolve through the project that owns it. `Project.settingsFor` layers the project's config over the user's preferences, so a checked-in config decides whether the linter and formatter run and supplies the formatter's dimensions, while settings that are only ever personal, like `fixOnSave`, stay with the user. 

A project with no config file behaves exactly as before. `Project` is also the only thing that loads `Config` now. 