### PR TITLE
Linter: Fix `erb-no-unused-local-variable` to resolve names per scope

### DIFF
--- a/javascript/packages/linter/src/rules/erb-no-unused-local-variable.ts
+++ b/javascript/packages/linter/src/rules/erb-no-unused-local-variable.ts
@@ -6,10 +6,50 @@ import type { FullRuleConfig, LintContext, UnboundLintOffense } from "../types.j
 
 const IGNORED_PREFIX = "_"
 
+interface Scope {
+  readonly writes: PrismNodes.LocalVariableWriteNode[]
+  readonly referenced: Set<string>
+}
+
 class LocalVariableCollector extends PrismVisitor {
-  readonly writes: PrismNodes.LocalVariableWriteNode[] = []
-  readonly referenced = new Set<string>()
   readonly argumentWrites = new Set<PrismNodes.LocalVariableWriteNode>()
+
+  private readonly scopes: Scope[] = []
+  private readonly stack: Scope[] = []
+
+  get unusedWrites(): PrismNodes.LocalVariableWriteNode[] {
+    const unused = this.scopes.flatMap(scope => scope.writes.filter(write => !scope.referenced.has(write.name)))
+
+    return unused.sort((first, second) => first.nameLoc.startOffset - second.nameLoc.startOffset)
+  }
+
+  override visitProgramNode(node: PrismNodes.ProgramNode): void {
+    this.withScope(() => this.visitChildNodes(node))
+  }
+
+  override visitBlockNode(node: PrismNodes.BlockNode): void {
+    this.withScope(() => this.visitChildNodes(node))
+  }
+
+  override visitLambdaNode(node: PrismNodes.LambdaNode): void {
+    this.withScope(() => this.visitChildNodes(node))
+  }
+
+  override visitDefNode(node: PrismNodes.DefNode): void {
+    this.withScope(() => this.visitChildNodes(node))
+  }
+
+  override visitClassNode(node: PrismNodes.ClassNode): void {
+    this.withScope(() => this.visitChildNodes(node))
+  }
+
+  override visitModuleNode(node: PrismNodes.ModuleNode): void {
+    this.withScope(() => this.visitChildNodes(node))
+  }
+
+  override visitSingletonClassNode(node: PrismNodes.SingletonClassNode): void {
+    this.withScope(() => this.visitChildNodes(node))
+  }
 
   override visitCallNode(node: PrismNodes.CallNode): void {
     for (const argument of node.arguments_?.arguments_ ?? []) {
@@ -20,33 +60,52 @@ class LocalVariableCollector extends PrismVisitor {
   }
 
   override visitLocalVariableWriteNode(node: PrismNodes.LocalVariableWriteNode): void {
-    this.writes.push(node)
+    if (!node.name.startsWith(IGNORED_PREFIX)) this.scopeAt(node.depth)?.writes.push(node)
 
     this.visitChildNodes(node)
   }
 
   override visitLocalVariableReadNode(node: PrismNodes.LocalVariableReadNode): void {
-    this.referenced.add(node.name)
+    this.reference(node.name, node.depth)
 
     this.visitChildNodes(node)
   }
 
   override visitLocalVariableOperatorWriteNode(node: PrismNodes.LocalVariableOperatorWriteNode): void {
-    this.referenced.add(node.name)
+    this.reference(node.name, node.depth)
 
     this.visitChildNodes(node)
   }
 
   override visitLocalVariableAndWriteNode(node: PrismNodes.LocalVariableAndWriteNode): void {
-    this.referenced.add(node.name)
+    this.reference(node.name, node.depth)
 
     this.visitChildNodes(node)
   }
 
   override visitLocalVariableOrWriteNode(node: PrismNodes.LocalVariableOrWriteNode): void {
-    this.referenced.add(node.name)
+    this.reference(node.name, node.depth)
 
     this.visitChildNodes(node)
+  }
+
+  private withScope(visitChildren: () => void): void {
+    const scope: Scope = { writes: [], referenced: new Set<string>() }
+
+    this.scopes.push(scope)
+    this.stack.push(scope)
+
+    visitChildren()
+
+    this.stack.pop()
+  }
+
+  private reference(name: string, depth: number): void {
+    this.scopeAt(depth)?.referenced.add(name)
+  }
+
+  private scopeAt(depth: number): Scope | null {
+    return this.stack[this.stack.length - 1 - depth] ?? null
   }
 }
 
@@ -81,9 +140,7 @@ export class ERBNoUnusedLocalVariableRule extends ParserRule {
 
     collector.visit(program)
 
-    const unused = collector.writes.filter(write => !write.name.startsWith(IGNORED_PREFIX) && !collector.referenced.has(write.name))
-
-    return unused.map(write => {
+    return collector.unusedWrites.map(write => {
       const { startOffset, length } = write.nameLoc
 
       return this.createOffense(

--- a/javascript/packages/linter/test/rules/erb-no-unused-local-variable.test.ts
+++ b/javascript/packages/linter/test/rules/erb-no-unused-local-variable.test.ts
@@ -355,4 +355,56 @@ describe("erb-no-unused-local-variable", () => {
       <% end %>
     `)
   })
+
+  test("flags a local variable that is only shadowed by a block argument", () => {
+    expectError("Local variable `post` is assigned but never used. Remove the assignment, or prefix it with an underscore as `_post` to show it is intentionally unused.", [1, 3])
+
+    assertOffenses(dedent`
+      <% post = posts.first %>
+
+      <% posts.each do |post| %>
+        <%= post.title %>
+      <% end %>
+    `)
+  })
+
+  test("passes for a local variable used outside the block that shadows it", () => {
+    expectNoOffenses(dedent`
+      <% post = posts.first %>
+
+      <h1><%= post.title %></h1>
+
+      <% posts.each do |post| %>
+        <%= post.title %>
+      <% end %>
+    `)
+  })
+
+  test("flags a block-local variable that is only used in a sibling block", () => {
+    expectError("Local variable `label` is assigned but never used. Remove the assignment, or prefix it with an underscore as `_label` to show it is intentionally unused.", [2, 5])
+
+    assertOffenses(dedent`
+      <% tags.each do |tag| %>
+        <% label = tag.name %>
+        <span>Tag</span>
+      <% end %>
+
+      <% posts.each do |post| %>
+        <% label = post.title %>
+        <%= label %>
+      <% end %>
+    `)
+  })
+
+  test("passes for an outer local variable read from inside a nested block", () => {
+    expectNoOffenses(dedent`
+      <% separator = " / " %>
+
+      <% sections.each do |section| %>
+        <% section.posts.each do |post| %>
+          <%= post.title %><%= separator %>
+        <% end %>
+      <% end %>
+    `)
+  })
 })


### PR DESCRIPTION
Follow up on #2074.

`erb-no-unused-local-variable` collects every referenced name into one flat set and matches writes against it by name alone, without looking at the `depth` Prism puts on each local variable node. 

A template is one Ruby scope and every block opens a nested one, so the same name can stand for two unrelated variables, and matching by name alone conflates them.

The clearest case is a block argument shadowing an outer local. The `post` read inside the block is the block argument, so nothing ever reads the assignment above it, but the read registers the name as used and the assignment goes unreported:

```erb
<% post = posts.first %>

<% posts.each do |post| %>
  <%= post.title %>
<% end %>
```