### PR TITLE
Engine: Introduce `VisitorContext` for transform visitors

### DIFF
--- a/docs/docs/projects/engine.md
+++ b/docs/docs/projects/engine.md
@@ -45,6 +45,7 @@ In addition to Erubi options, `Herb::Engine` supports:
 | `validators`      | `{}`      | Per-validator overrides (e.g., `{ security: false }`)                                 |
 | `parser_options`  | `{}`      | [Parser options](/parser-options) forwarded to the parser (e.g., `{ strict: false }`) |
 | `visitors`        | `[]`      | AST visitors to run before compilation                                                |
+| `context`         | `{}`      | Extra keys to pass through to the visitors (see [Visitor context](#visitor-context))   |
 | `project_path`    | `Dir.pwd` | Project root for relative path resolution                                             |
 | `validate_ruby`   | `false`   | Raise if the compiled output isn't valid Ruby                                         |
 | `optimize`        | `false`   | Compile-time optimizations for Action View helpers (experimental)                     |
@@ -133,6 +134,48 @@ parser_options = Herb::Visitor.parser_options_for(visitors, strict: false)
 result = Herb.parse(source, **parser_options)
 
 visitors.each { |visitor| result.visit(visitor) }
+```
+
+### Visitor context
+
+A visitor that includes `Herb::Engine::ContextAware` is handed a `Herb::Engine::VisitorContext` before the engine walks the AST, so it doesn't have to be told things the engine already knows:
+
+```ruby
+class MyVisitor < Herb::Visitor
+  include Herb::Engine::ContextAware
+
+  def visit_html_element_node(node)
+    context.relative_file_path #=> "app/views/users/show.html.erb"
+    context.file_path          #=> #<Pathname:app/views/users/show.html.erb>
+    context.project_path       #=> #<Pathname:/my/project>
+    context.options[:escape]   #=> true
+
+    super
+  end
+end
+
+Herb::Engine.new(source, filename: "app/views/users/show.html.erb", visitors: [MyVisitor.new])
+```
+
+`relative_file_path` is the file path resolved against `project_path`, and is `"unknown"` when there is no file path. `file_path` stays exactly as it was given, so a visitor can still match on how the path was written. It is named `file_path` rather than `filename` because it holds a path, not a base name. The engine option keeps the name `filename` for [Erubi compatibility](#erubi-compatibility). `options` holds the options the engine was built with, without `visitors` and `src`.
+
+Pass `context` to the engine to add your own keys, reachable with `#[]` and `#fetch`:
+
+```ruby
+Herb::Engine.new(source, context: { theme: "dark" }, visitors: [MyVisitor.new])
+
+# inside the visitor
+context[:theme]              #=> "dark"
+context.fetch(:missing, 1)   #=> 1
+```
+
+A context is immutable, and `#merge` returns a new one. Setting `context=` yourself always wins over the engine, which is what lets a visitor run standalone against any AST:
+
+```ruby
+visitor = MyVisitor.new
+visitor.context = Herb::Engine::VisitorContext.new(file_path: "app/views/users/show.html.erb")
+
+Herb.parse(source).value.accept(visitor)
 ```
 
 ### `AutoCloseOmittedTagsVisitor`

--- a/lib/herb/engine.rb
+++ b/lib/herb/engine.rb
@@ -5,6 +5,8 @@ require "json"
 require "time"
 require "pathname"
 
+require_relative "engine/visitor_context"
+require_relative "engine/context_aware"
 require_relative "engine/debug_visitor"
 require_relative "engine/compiler"
 require_relative "engine/error_formatter"
@@ -18,8 +20,22 @@ require_relative "engine/validators/render_validator"
 
 module Herb
   class Engine
-    attr_reader :src, :filename, :project_path, :relative_file_path, :bufvar, :debug,
-                :validation_error_template, :visitors, :enabled_validators
+    attr_reader :src, :context, :bufvar, :debug, :validation_error_template, :visitors, :enabled_validators
+
+    #: () -> Pathname?
+    def filename
+      @context.file_path
+    end
+
+    #: () -> Pathname
+    def project_path
+      @context.project_path
+    end
+
+    #: () -> String
+    def relative_file_path
+      @context.relative_file_path
+    end
 
     # @rbs!
     #   def self.optimize_warning_issued: () -> bool
@@ -56,15 +72,12 @@ module Herb
     end
 
     def initialize(input, properties = {})
-      @filename = properties[:filename] ? ::Pathname.new(properties[:filename]) : nil
-      @project_path = ::Pathname.new(properties[:project_path] || Dir.pwd)
-
-      if @filename
-        absolute_filename = @filename.absolute? ? @filename : @project_path + @filename
-        @relative_file_path = absolute_filename.relative_path_from(@project_path).to_s
-      else
-        @relative_file_path = "unknown"
-      end
+      @context = VisitorContext.new(
+        file_path: properties[:filename],
+        project_path: properties[:project_path],
+        options: context_options(properties),
+        **(properties[:context] || {})
+      )
 
       @bufvar = properties[:bufvar] || properties[:outvar] || "_buf"
       @escape = properties.fetch(:escape) { properties.fetch(:escape_html, false) }
@@ -92,8 +105,8 @@ module Herb
 
       if @debug && @visitors.empty?
         debug_visitor = DebugVisitor.new(
-          file_path: @filename,
-          project_path: @project_path
+          file_path: filename,
+          project_path: project_path
         )
 
         @visitors << debug_visitor
@@ -157,6 +170,8 @@ module Herb
         end
 
         @visitors.each do |visitor|
+          visitor.inherit_context(@context) if visitor.is_a?(ContextAware)
+
           ast.accept(visitor)
         end
 
@@ -420,7 +435,7 @@ module Herb
     def handle_parser_errors(parser_errors, input, _ast)
       case @validation_mode
       when :raise
-        formatter = ErrorFormatter.new(input, parser_errors, filename: @filename)
+        formatter = ErrorFormatter.new(input, parser_errors, filename: filename)
         message = formatter.format_all
 
         raise CompilationError, "\n#{message}"
@@ -445,12 +460,12 @@ module Herb
           security_error[:message],
           line: security_error[:location]&.start&.line,
           column: security_error[:location]&.start&.column,
-          filename: @filename,
+          filename: filename,
           suggestion: security_error[:suggestion]
         )
       end
 
-      formatter = ErrorFormatter.new(input, errors, filename: @filename)
+      formatter = ErrorFormatter.new(input, errors, filename: filename)
       message = formatter.format_all
       raise CompilationError, "\n#{message}"
     end
@@ -465,7 +480,7 @@ module Herb
         column = location&.start&.column || 0
 
         source = input || @src
-        overlay_generator = ValidationErrorOverlay.new(source, error, filename: @relative_file_path)
+        overlay_generator = ValidationErrorOverlay.new(source, error, filename: relative_file_path)
         html_fragment = overlay_generator.generate_fragment
 
         escaped_message = escape_attr(error[:message])
@@ -479,7 +494,7 @@ module Herb
             data-code="#{error[:code]}"
             data-line="#{line}"
             data-column="#{column}"
-            data-filename="#{escape_attr(@relative_file_path)}"
+            data-filename="#{escape_attr(relative_file_path)}"
             data-message="#{escaped_message}"
             #{"data-suggestion=\"#{escaped_suggestion}\"" if error[:suggestion]}
             data-timestamp="#{Time.now.utc.iso8601}"
@@ -508,7 +523,7 @@ module Herb
       overlay_generator = ParserErrorOverlay.new(
         input,
         parser_errors,
-        filename: @relative_file_path
+        filename: relative_file_path
       )
 
       error_html = overlay_generator.generate_html
@@ -518,6 +533,11 @@ module Herb
     #: () -> Array[Herb::Visitor]
     def default_visitors
       []
+    end
+
+    #: (Hash[Symbol, untyped]) -> Hash[Symbol, untyped]
+    def context_options(properties)
+      properties.except(:visitors, :src, :context)
     end
 
     #: () -> Hash[Symbol, untyped]

--- a/lib/herb/engine/context_aware.rb
+++ b/lib/herb/engine/context_aware.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+# typed: false
+
+require_relative "visitor_context"
+
+module Herb
+  class Engine
+    # Opt-in for visitors that want the template information the engine was built with.
+    #
+    # `Herb::Visitor` is generated and holds no state, so a visitor asks for a context by
+    # including this module. The engine then hands it one before it walks the AST:
+    #
+    #     class MyVisitor < Herb::Visitor
+    #       include Herb::Engine::ContextAware
+    #     end
+    #
+    #     Herb::Engine.new(source, filename: path, visitors: [MyVisitor.new])
+    #
+    # A context passed by the caller always wins over the one the engine supplies, so a
+    # visitor can also be used on its own, without an engine.
+    #
+    module ContextAware
+      #: () -> Herb::Engine::VisitorContext
+      def context
+        @context ||= VisitorContext.new
+      end
+
+      #: (Herb::Engine::VisitorContext) -> void
+      def context=(context)
+        @context = context
+        @context_explicit = true
+      end
+
+      #: (Herb::Engine::VisitorContext) -> void
+      def inherit_context(context)
+        @context = context unless @context_explicit
+      end
+    end
+  end
+end

--- a/lib/herb/engine/visitor_context.rb
+++ b/lib/herb/engine/visitor_context.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+# typed: false
+
+require "pathname"
+
+module Herb
+  class Engine
+    # Per-template information the engine hands to the visitors it runs before compilation.
+    #
+    # Alongside the template path, it carries the options the engine was built with, and any
+    # additional keys the caller wants to pass through to its own visitors:
+    #
+    #     Herb::Engine.new(source, filename: path, context: { theme: "dark" }, visitors: [MyVisitor.new])
+    #
+    #     class MyVisitor < Herb::Visitor
+    #       include Herb::Engine::ContextAware
+    #
+    #       def visit_html_element_node(node)
+    #         context.relative_file_path #=> "app/views/users/show.html.erb"
+    #         context.options[:escape]   #=> true
+    #         context[:theme]            #=> "dark"
+    #
+    #         super
+    #       end
+    #     end
+    #
+    class VisitorContext
+      UNKNOWN_FILE_PATH = "unknown" #: String
+
+      attr_reader :file_path #: Pathname?
+      attr_reader :project_path #: Pathname
+      attr_reader :relative_file_path #: String
+      attr_reader :options #: Hash[Symbol, untyped]
+      attr_reader :data #: Hash[Symbol, untyped]
+
+      #: (?file_path: (String | Pathname)?, ?project_path: (String | Pathname)?, ?options: Hash[Symbol, untyped], **untyped) -> void
+      def initialize(file_path: nil, project_path: nil, options: {}, **data)
+        @file_path = self.class.coerce_file_path(file_path)
+        @project_path = self.class.coerce_project_path(project_path)
+        @relative_file_path = self.class.derive_relative_file_path(@file_path, @project_path)
+        @options = options.dup.freeze
+        @data = data.freeze
+
+        freeze
+      end
+
+      #: (Symbol) -> untyped
+      def [](key)
+        case key
+        when :file_path then file_path
+        when :project_path then project_path
+        when :relative_file_path then relative_file_path
+        when :options then options
+        else data[key]
+        end
+      end
+
+      #: (Symbol) -> bool
+      def key?(key)
+        [:file_path, :project_path, :relative_file_path, :options].include?(key) || data.key?(key)
+      end
+
+      #: (Symbol, ?untyped) -> untyped
+      def fetch(key, *default)
+        return self[key] if key?(key)
+        return default.first unless default.empty?
+
+        raise KeyError, "key not found: #{key.inspect}"
+      end
+
+      #: (**untyped) -> Herb::Engine::VisitorContext
+      def merge(**extra)
+        self.class.new(
+          file_path: extra.fetch(:file_path, file_path),
+          project_path: extra.fetch(:project_path, project_path),
+          options: extra.fetch(:options, options),
+          **data.merge(extra.except(:file_path, :project_path, :options))
+        )
+      end
+
+      #: () -> Hash[Symbol, untyped]
+      def to_hash
+        {
+          file_path: file_path,
+          project_path: project_path,
+          relative_file_path: relative_file_path,
+          options: options,
+          data: data,
+        }
+      end
+
+      alias to_h to_hash
+
+      #: () -> String
+      def inspect
+        "#<#{self.class.name} file_path=#{file_path.to_s.inspect} relative_file_path=#{relative_file_path.inspect}>"
+      end
+
+      #: ((String | Pathname)?) -> Pathname?
+      def self.coerce_file_path(file_path)
+        case file_path
+        when ::Pathname then file_path
+        when String then file_path.empty? ? nil : ::Pathname.new(file_path)
+        end
+      end
+
+      #: ((String | Pathname)?) -> Pathname
+      def self.coerce_project_path(project_path)
+        case project_path
+        when ::Pathname then project_path
+        when String then ::Pathname.new(project_path)
+        else ::Pathname.new(Dir.pwd)
+        end
+      end
+
+      #: (Pathname?, Pathname) -> String
+      def self.derive_relative_file_path(file_path, project_path)
+        return UNKNOWN_FILE_PATH unless file_path
+
+        absolute = file_path.absolute? ? file_path : project_path + file_path
+
+        absolute.relative_path_from(project_path).to_s
+      rescue ArgumentError
+        file_path.to_s
+      end
+    end
+  end
+end

--- a/sig/herb/engine.rbs
+++ b/sig/herb/engine.rbs
@@ -4,11 +4,7 @@ module Herb
   class Engine
     attr_reader src: untyped
 
-    attr_reader filename: untyped
-
-    attr_reader project_path: untyped
-
-    attr_reader relative_file_path: untyped
+    attr_reader context: untyped
 
     attr_reader bufvar: untyped
 
@@ -19,6 +15,15 @@ module Herb
     attr_reader visitors: untyped
 
     attr_reader enabled_validators: untyped
+
+    # : () -> Pathname?
+    def filename: () -> Pathname?
+
+    # : () -> Pathname
+    def project_path: () -> Pathname
+
+    # : () -> String
+    def relative_file_path: () -> String
 
     def self.optimize_warning_issued: () -> bool
 
@@ -108,6 +113,9 @@ module Herb
 
     # : () -> Array[Herb::Visitor]
     def default_visitors: () -> Array[Herb::Visitor]
+
+    # : (Hash[Symbol, untyped]) -> Hash[Symbol, untyped]
+    def context_options: (Hash[Symbol, untyped]) -> Hash[Symbol, untyped]
 
     # : () -> Hash[Symbol, untyped]
     def default_parser_options: () -> Hash[Symbol, untyped]

--- a/sig/herb/engine/context_aware.rbs
+++ b/sig/herb/engine/context_aware.rbs
@@ -1,0 +1,29 @@
+# Generated from lib/herb/engine/context_aware.rb with RBS::Inline
+
+module Herb
+  class Engine
+    # Opt-in for visitors that want the template information the engine was built with.
+    #
+    # `Herb::Visitor` is generated and holds no state, so a visitor asks for a context by
+    # including this module. The engine then hands it one before it walks the AST:
+    #
+    #     class MyVisitor < Herb::Visitor
+    #       include Herb::Engine::ContextAware
+    #     end
+    #
+    #     Herb::Engine.new(source, filename: path, visitors: [MyVisitor.new])
+    #
+    # A context passed by the caller always wins over the one the engine supplies, so a
+    # visitor can also be used on its own, without an engine.
+    module ContextAware
+      # : () -> Herb::Engine::VisitorContext
+      def context: () -> Herb::Engine::VisitorContext
+
+      # : (Herb::Engine::VisitorContext) -> void
+      def context=: (Herb::Engine::VisitorContext) -> void
+
+      # : (Herb::Engine::VisitorContext) -> void
+      def inherit_context: (Herb::Engine::VisitorContext) -> void
+    end
+  end
+end

--- a/sig/herb/engine/visitor_context.rbs
+++ b/sig/herb/engine/visitor_context.rbs
@@ -1,0 +1,69 @@
+# Generated from lib/herb/engine/visitor_context.rb with RBS::Inline
+
+module Herb
+  class Engine
+    # Per-template information the engine hands to the visitors it runs before compilation.
+    #
+    # Alongside the template path, it carries the options the engine was built with, and any
+    # additional keys the caller wants to pass through to its own visitors:
+    #
+    #     Herb::Engine.new(source, filename: path, context: { theme: "dark" }, visitors: [MyVisitor.new])
+    #
+    #     class MyVisitor < Herb::Visitor
+    #       include Herb::Engine::ContextAware
+    #
+    #       def visit_html_element_node(node)
+    #         context.relative_file_path #=> "app/views/users/show.html.erb"
+    #         context.options[:escape]   #=> true
+    #         context[:theme]            #=> "dark"
+    #
+    #         super
+    #       end
+    #     end
+    class VisitorContext
+      UNKNOWN_FILE_PATH: String
+
+      attr_reader file_path: Pathname?
+
+      attr_reader project_path: Pathname
+
+      attr_reader relative_file_path: String
+
+      attr_reader options: Hash[Symbol, untyped]
+
+      attr_reader data: Hash[Symbol, untyped]
+
+      # : (?file_path: (String | Pathname)?, ?project_path: (String | Pathname)?, ?options: Hash[Symbol, untyped], **untyped) -> void
+      def initialize: (?file_path: (String | Pathname)?, ?project_path: (String | Pathname)?, ?options: Hash[Symbol, untyped], **untyped) -> void
+
+      # : (Symbol) -> untyped
+      def []: (Symbol) -> untyped
+
+      # : (Symbol) -> bool
+      def key?: (Symbol) -> bool
+
+      # : (Symbol, ?untyped) -> untyped
+      def fetch: (Symbol, ?untyped) -> untyped
+
+      # : (**untyped) -> Herb::Engine::VisitorContext
+      def merge: (**untyped) -> Herb::Engine::VisitorContext
+
+      # : () -> Hash[Symbol, untyped]
+      def to_hash: () -> Hash[Symbol, untyped]
+
+      alias to_h to_hash
+
+      # : () -> String
+      def inspect: () -> String
+
+      # : ((String | Pathname)?) -> Pathname?
+      def self.coerce_file_path: ((String | Pathname)?) -> Pathname?
+
+      # : ((String | Pathname)?) -> Pathname
+      def self.coerce_project_path: ((String | Pathname)?) -> Pathname
+
+      # : (Pathname?, Pathname) -> String
+      def self.derive_relative_file_path: (Pathname?, Pathname) -> String
+    end
+  end
+end

--- a/test/engine/visitor_context_test.rb
+++ b/test/engine/visitor_context_test.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+require_relative "../../lib/herb/engine"
+
+module Engine
+  class VisitorContextTest < Minitest::Spec
+    def context(**)
+      Herb::Engine::VisitorContext.new(**)
+    end
+
+    test "a relative file path is kept as given" do
+      assert_equal "app/views/users/show.html.erb",
+                   context(file_path: "app/views/users/show.html.erb", project_path: "/proj").relative_file_path
+    end
+
+    test "a dot slash prefix is normalized away" do
+      assert_equal "app/x.erb", context(file_path: "./app/x.erb", project_path: "/proj").relative_file_path
+    end
+
+    test "parent directory segments are resolved" do
+      assert_equal "x.erb", context(file_path: "app/../x.erb", project_path: "/proj").relative_file_path
+    end
+
+    test "an empty file path has no path at all" do
+      subject = context(file_path: "", project_path: "/proj")
+
+      assert_nil subject.file_path
+      assert_equal "unknown", subject.relative_file_path
+    end
+
+    test "a missing file path has no path at all" do
+      subject = context(project_path: "/proj")
+
+      assert_nil subject.file_path
+      assert_equal "unknown", subject.relative_file_path
+    end
+
+    test "an absolute file path is made relative to the project" do
+      assert_equal "app/x.erb", context(file_path: "/proj/app/x.erb", project_path: "/proj").relative_file_path
+    end
+
+    test "an absolute file path with a relative project path falls back instead of raising" do
+      assert_equal "/abs/x.erb", context(file_path: "/abs/x.erb", project_path: "relative").relative_file_path
+    end
+
+    test "the file path is not absolutized" do
+      assert_equal "test.erb", context(file_path: "test.erb").file_path.to_s
+    end
+
+    test "a Pathname file path is accepted" do
+      assert_equal "test.erb", context(file_path: Pathname.new("test.erb")).file_path.to_s
+    end
+
+    test "the project path defaults to the working directory" do
+      assert_equal Dir.pwd, context.project_path.to_s
+    end
+
+    test "a Pathname project path is accepted" do
+      assert_equal "/proj", context(project_path: Pathname.new("/proj")).project_path.to_s
+    end
+
+    test "the context is frozen" do
+      assert_predicate context(file_path: "x.erb"), :frozen?
+    end
+
+    test "arbitrary data is readable through the bag" do
+      subject = context(file_path: "x.erb", theme: "dark", level: 2)
+
+      assert_equal "dark", subject[:theme]
+      assert_equal 2, subject[:level]
+      assert_equal({ theme: "dark", level: 2 }, subject.data)
+    end
+
+    test "well known keys are readable through the bag" do
+      subject = context(file_path: "app/x.erb", project_path: "/proj")
+
+      assert_equal "app/x.erb", subject[:relative_file_path]
+      assert_equal "/proj", subject[:project_path].to_s
+    end
+
+    test "an unknown key reads as nil" do
+      assert_nil context[:nope]
+    end
+
+    test "key? covers well known keys and arbitrary data" do
+      subject = context(theme: "dark")
+
+      assert subject.key?(:file_path)
+      assert subject.key?(:theme)
+      refute subject.key?(:nope)
+    end
+
+    test "fetch returns a default for a missing key" do
+      assert_equal "fallback", context.fetch(:nope, "fallback")
+    end
+
+    test "fetch raises for a missing key without a default" do
+      assert_raises(KeyError) { context.fetch(:nope) }
+    end
+
+    test "engine options are exposed" do
+      assert_equal true, context(options: { escape: true })[:options][:escape]
+    end
+
+    test "merge recomputes the relative file path" do
+      merged = context(file_path: "a.erb", project_path: "/proj").merge(file_path: "./b/c.erb")
+
+      assert_equal "b/c.erb", merged.relative_file_path
+      assert_equal "./b/c.erb", merged.file_path.to_s
+    end
+
+    test "merge keeps arbitrary data and adds to it" do
+      merged = context(theme: "dark").merge(level: 2)
+
+      assert_equal "dark", merged[:theme]
+      assert_equal 2, merged[:level]
+    end
+
+    test "merge does not mutate the original" do
+      subject = context(file_path: "a.erb")
+      subject.merge(file_path: "b.erb")
+
+      assert_equal "a.erb", subject.file_path.to_s
+    end
+
+    test "inspect omits the project path so it stays machine independent" do
+      subject = context(file_path: "app/x.erb", project_path: "/proj")
+
+      assert_equal %(#<Herb::Engine::VisitorContext file_path="app/x.erb" relative_file_path="app/x.erb">), subject.inspect
+      refute_includes subject.inspect, "/proj"
+    end
+
+    test "to_hash exposes every part" do
+      assert_equal [:file_path, :project_path, :relative_file_path, :options, :data], context.to_hash.keys
+    end
+  end
+end

--- a/test/engine_visitors_test.rb
+++ b/test/engine_visitors_test.rb
@@ -162,4 +162,81 @@ class EngineVisitorsTest < Minitest::Spec
     refute_nil engine.src
     assert_nil visitor.prism_node
   end
+
+  class ContextCapturingVisitor < Herb::Visitor
+    include Herb::Engine::ContextAware
+
+    attr_reader :seen
+
+    def visit_document_node(node)
+      @seen = context
+
+      super
+    end
+  end
+
+  test "the engine hands its context to a context aware visitor" do
+    visitor = ContextCapturingVisitor.new
+
+    Herb::Engine.new("<div>Hi</div>", filename: "app/views/x.html.erb", project_path: "/proj", visitors: [visitor])
+
+    assert_equal "app/views/x.html.erb", visitor.seen.relative_file_path
+    assert_equal "/proj", visitor.seen.project_path.to_s
+  end
+
+  test "the engine options are reachable from the context" do
+    visitor = ContextCapturingVisitor.new
+
+    Herb::Engine.new("<div>Hi</div>", escape: false, visitors: [visitor])
+
+    assert_equal false, visitor.seen.options[:escape]
+  end
+
+  test "the visitors option is kept out of the context to avoid a cycle" do
+    visitor = ContextCapturingVisitor.new
+
+    Herb::Engine.new("<div>Hi</div>", visitors: [visitor])
+
+    refute visitor.seen.options.key?(:visitors)
+  end
+
+  test "caller supplied data reaches the visitor" do
+    visitor = ContextCapturingVisitor.new
+
+    Herb::Engine.new("<div>Hi</div>", context: { theme: "dark" }, visitors: [visitor])
+
+    assert_equal "dark", visitor.seen[:theme]
+  end
+
+  test "an explicitly set context is not overwritten by the engine" do
+    visitor = ContextCapturingVisitor.new
+    visitor.context = Herb::Engine::VisitorContext.new(file_path: "explicit.html.erb")
+
+    Herb::Engine.new("<div>Hi</div>", filename: "engine.html.erb", visitors: [visitor])
+
+    assert_equal "explicit.html.erb", visitor.seen.relative_file_path
+  end
+
+  test "a reused visitor picks up the second engine's context" do
+    visitor = ContextCapturingVisitor.new
+
+    Herb::Engine.new("<div>Hi</div>", filename: "first.html.erb", visitors: [visitor])
+    assert_equal "first.html.erb", visitor.seen.relative_file_path
+
+    Herb::Engine.new("<div>Hi</div>", filename: "second.html.erb", visitors: [visitor])
+    assert_equal "second.html.erb", visitor.seen.relative_file_path
+  end
+
+  test "a visitor that is not context aware is left alone" do
+    visitor = Class.new(Herb::Visitor).new
+
+    engine = Herb::Engine.new("<div>Hi</div>", filename: "x.html.erb", visitors: [visitor])
+
+    refute_nil engine.src
+    refute_respond_to visitor, :context
+  end
+
+  test "a context aware visitor used without an engine still has a context" do
+    assert_equal "unknown", ContextCapturingVisitor.new.context.relative_file_path
+  end
 end


### PR DESCRIPTION
This pull request introduces `Herb::Engine::VisitorContext`, a per-template value object the engine hands to the visitors it runs before compilation, so that a visitor no longer has to be told things the engine already knows.

A transform visitor that cares about where the template lives currently has to be given that separately, even though the engine derived it a moment earlier. `DebugVisitor` is the clearest case, taking `file_path:` and `project_path:` and deriving its own relative path from them:

```ruby
Herb::Engine.new(
  source,
  filename: "app/views/users/show.html.erb",
  project_path: Rails.root.to_s,
  visitors: [
    Herb::Engine::DebugVisitor.new(
      file_path: "app/views/users/show.html.erb",
      project_path: Rails.root.to_s
    )
  ]
)
```

A visitor can now ask for a context by including `Herb::Engine::ContextAware`. The engine hands it one before it walks the tree:

```ruby
class MyVisitor < Herb::Visitor
  include Herb::Engine::ContextAware

  def visit_html_element_node(node)
    context.relative_file_path   #=> "app/views/users/show.html.erb"
    context.file_path            #=> #<Pathname:app/views/users/show.html.erb>
    context.project_path         #=> #<Pathname:/my/project>
    context.options[:escape]     #=> true

    super
  end
end

Herb::Engine.new(source, filename: "app/views/users/show.html.erb", visitors: [MyVisitor.new])
```

`Herb::Visitor` is generated and holds no state, so this is a module a visitor opts into rather than something every visitor inherits. A visitor that doesn't include it is left alone.

The context is an open bag. Pass `context` to the engine to add keys, reachable with `#[]` and `#fetch`:

```ruby
Herb::Engine.new(source, context: { theme: "dark" }, visitors: [MyVisitor.new])
```

and inside the visitor:
```ruby
context[:theme]              #=> "dark"
context.fetch(:missing, 1)   #=> 1
```