### PR TITLE
Language Service: Wire block argument completion in language server

### DIFF
--- a/javascript/packages/language-server/src/project.ts
+++ b/javascript/packages/language-server/src/project.ts
@@ -96,6 +96,7 @@ export class Project {
     this.codeActionProvider.setConfig(this.config)
     this.autofixService.setConfig(this.config)
     this.linterService.setConfig(this.config)
+    this.completionProvider.setFramework(this.config?.config?.framework)
     this.linterService.rebuildLinter()
   }
 

--- a/javascript/packages/language-service/src/completion_provider.ts
+++ b/javascript/packages/language-service/src/completion_provider.ts
@@ -13,6 +13,7 @@ import { TextDocument } from "vscode-languageserver-textdocument"
 
 import { Visitor, RubyReferenceCollector, isERBContentNode, isERBOutputNode, isHTMLOpenTagNode, isHTMLTextNode, isValidLocalName, getHelperEntries, partialNameForFile, strictLocalsDeclaration, templateNameForFile, HELPER_REGISTRY, HTML_NAMED_CHARACTER_REFERENCES, HTML_ELEMENTS } from "@herb-tools/core"
 import { ParserService } from "./parser_service"
+import { getBlockArgumentCompletions } from "./language-service"
 import { nodeToRange, isPositionInRange, rangeSize, lspPosition } from "./range_utils"
 
 import type { PartialIndex, Node, ERBContentNode, HTMLOpenTagNode, HTMLTextNode, HelperEntry, HelperOption, PartialDeclaration, RubyReference } from "@herb-tools/core"
@@ -147,6 +148,7 @@ export class CompletionProvider {
   private parserService: ParserService
   private partials?: PartialIndex
   private relativePathFor: (uri: string) => string | null
+  private framework?: string
 
   constructor(
     parserService: ParserService,
@@ -156,6 +158,10 @@ export class CompletionProvider {
     this.parserService = parserService
     this.partials = partials
     this.relativePathFor = relativePathFor
+  }
+
+  setFramework(framework?: string) {
+    this.framework = framework
   }
 
   getCompletions(document: TextDocument, position: Position): CompletionList | null {
@@ -252,6 +258,10 @@ export class CompletionProvider {
         ? this.getStrictLocalCompletions(argument, position, document)
         : this.getRenderKeywordCompletions(argument, position, document)
     }
+
+    const blockArguments = getBlockArgumentCompletions(document, position, { framework: this.framework })
+
+    if (blockArguments) return blockArguments
 
     const tagDotMatch = textBeforeCursor.match(TAG_DOT_PATTERN)
 

--- a/javascript/packages/language-service/test/completion_provider.test.ts
+++ b/javascript/packages/language-service/test/completion_provider.test.ts
@@ -1329,4 +1329,39 @@ describe("CompletionProvider", () => {
       expect(service.getCompletions(document, document.positionAt(content.length))).toBeNull()
     })
   })
+
+  describe("block arguments", () => {
+    let actionViewService: CompletionProvider
+
+    beforeAll(() => {
+      actionViewService = new CompletionProvider(new ParserService(Herb))
+      actionViewService.setFramework("actionview")
+    })
+
+    function labelsFor(content: string): string[] {
+      const document = createDocument(content)
+      const result = actionViewService.getCompletions(document, Position.create(0, content.length))
+
+      return result ? result.items.map(item => item.label) : []
+    }
+
+    it("offers the arguments a helper yields, with the pipes", () => {
+      expect(labelsFor("<%= form_with model: @user do ")).toContain("|form|")
+    })
+
+    it("drops the pipes once the user has started them", () => {
+      expect(labelsFor("<%= form_with model: @user do |")).toContain("form")
+    })
+
+    it("stays quiet for a call that yields nothing", () => {
+      expect(labelsFor("<% cache @post do ")).toEqual([])
+    })
+
+    it("stays quiet when the project isn't an Action View project", () => {
+      const document = createDocument("<%= form_with model: @user do ")
+      const result = service.getCompletions(document, Position.create(0, 29))
+
+      expect(result ? result.items.map(item => item.label) : []).not.toContain("|form|")
+    })
+  })
 })


### PR DESCRIPTION
This pull request makes the block argument completion from #2156 reachable from an editor.

`doComplete` learned which arguments a helper yields to its block, but `doComplete` belongs to the `vscode-html-languageservice`-compatible facade, and nothing calls it. Editors go through `CompletionProvider`, which knew nothing about blocks, so typing

```erb
<%= form_with model: @user do ▮
```

offered nothing in practice, even though the feature was merged and shipping in the package.

`CompletionProvider` now calls the same exported `getBlockArgumentCompletions` rather than growing its own copy.
