### PR TITLE
Language Server: Include build time in local dev build version

### DIFF
--- a/javascript/packages/language-server/rolldown.config.mjs
+++ b/javascript/packages/language-server/rolldown.config.mjs
@@ -1,3 +1,5 @@
+import { execSync } from "node:child_process"
+
 // Bundle the LSP server entry point into a single CommonJS file.
 // Exclude Node built-in so they remain as externals.
 const external = [
@@ -13,6 +15,47 @@ const external = [
 const isCI = process.env.CI === "true"
 const isReleaseBuild = process.env.RELEASE_BUILD === "true"
 const enableSourcemaps = !isCI || isReleaseBuild
+const isDevBuild = !isCI && !isReleaseBuild
+
+function git(command) {
+  try {
+    const output = execSync(`git ${command}`, { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }).trim()
+
+    return output === "" ? null : output
+  } catch {
+    return null
+  }
+}
+
+function buildRef() {
+  const branch = git("rev-parse --abbrev-ref HEAD")
+
+  if (branch && branch !== "HEAD") return branch
+
+  return git("rev-parse --short HEAD")
+}
+
+function buildTimestamp() {
+  const now = new Date()
+  const pad = (value) => String(value).padStart(2, "0")
+
+  const date = `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}`
+  const time = `${pad(now.getHours())}:${pad(now.getMinutes())}:${pad(now.getSeconds())}`
+
+  return `${date} ${time}`
+}
+
+function buildMetadata() {
+  if (!isDevBuild) return null
+
+  return [buildRef(), buildTimestamp()].filter(Boolean).join(", ")
+}
+
+const transform = {
+  define: {
+    __HERB_BUILD_METADATA__: JSON.stringify(buildMetadata()),
+  },
+}
 
 function isExternal(id) {
   return (
@@ -36,6 +79,7 @@ export default [
       format: "cjs",
       sourcemap: enableSourcemaps,
     },
+    transform,
     external: isExternal,
     platform: "node",
     resolve: { conditionNames: ["node", "import", "require", "default"] },
@@ -49,6 +93,7 @@ export default [
       format: "cjs",
       sourcemap: enableSourcemaps,
     },
+    transform,
     external: allExternal,
   },
 ]

--- a/javascript/packages/language-server/src/build_info.ts
+++ b/javascript/packages/language-server/src/build_info.ts
@@ -1,0 +1,7 @@
+import { version } from "../package.json"
+
+declare const __HERB_BUILD_METADATA__: string | null | undefined
+
+export const buildMetadata = typeof __HERB_BUILD_METADATA__ === "string" && __HERB_BUILD_METADATA__ !== "" ? __HERB_BUILD_METADATA__ : null
+
+export const serverVersion = buildMetadata ? `${version} (${buildMetadata})` : version

--- a/javascript/packages/language-server/src/server.ts
+++ b/javascript/packages/language-server/src/server.ts
@@ -29,7 +29,7 @@ import { PersonalHerbSettings } from "./user_settings"
 import { Config } from "@herb-tools/config"
 import { isPartialPath } from "@herb-tools/core"
 import { isConfigDocument, isPathInside } from "./utils"
-import { version } from "../package.json"
+import { serverVersion } from "./build_info"
 
 import type { FileEvent } from "vscode-languageserver/node"
 import type { ExtractToPartialResult } from "@herb-tools/language-service"
@@ -57,7 +57,7 @@ export class Server {
       const result: InitializeResult = {
         serverInfo: {
           name: "Herb Language Server",
-          version,
+          version: serverVersion,
         },
         capabilities: {
           textDocumentSync: {


### PR DESCRIPTION
Follow up on #1622.

Since the language server reports its version through `serverInfo`, editors show it in their summary card. For a released install that version is exactly what you want, but when running a locally built server the bare `0.10.3` doesn't say much.

This pull request stamps local dev builds with the branch they were built from and when they were built, so the reported version looks like this:

```
v0.10.3 (language-server-dev-build-version, 2026-08-11 03:56:16)
```

<img width="1496" height="384" alt="CleanShot 2026-08-11 at 03 56 27@2x" src="https://github.com/user-attachments/assets/f78c4232-624e-4312-9848-e63f1660fa15" />

