### PR TITLE
Engine: Introduce `Herb::Diagnostic` and make reporting a visitor mixin

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -80,6 +80,7 @@ Metrics/MethodLength:
     - lib/herb/cli.rb
     - lib/herb/dev/runner.rb
     - lib/herb/dev/server.rb
+    - lib/herb/diagnostic.rb
     - lib/herb/engine.rb
     - lib/herb/engine/**/*.rb
     - lib/herb/prism_inspect.rb
@@ -98,6 +99,7 @@ Metrics/AbcSize:
     - lib/herb/cli.rb
     - lib/herb/dev/runner.rb
     - lib/herb/dev/server.rb
+    - lib/herb/diagnostic.rb
     - lib/herb/engine.rb
     - lib/herb/engine/**/*.rb
     - lib/herb/errors.rb
@@ -119,6 +121,7 @@ Metrics/ClassLength:
     - lib/herb/configuration.rb
     - lib/herb/dev/runner.rb
     - lib/herb/dev/server.rb
+    - lib/herb/diagnostic.rb
     - lib/herb/engine.rb
     - lib/herb/engine/**/*.rb
     - lib/herb/project.rb
@@ -149,8 +152,9 @@ Metrics/ParameterLists:
     - lib/herb/ast/node.rb
     - lib/herb/ast/nodes.rb
     - lib/herb/dev/runner.rb
+    - lib/herb/diagnostic.rb
     - lib/herb/diff_operation.rb
-    - lib/herb/engine/validators/security_validator.rb
+    - lib/herb/engine/diagnostics.rb
     - lib/herb/errors.rb
     - lib/herb/parser_options.rb
     - lib/herb/prism_inspect.rb

--- a/lib/herb.rb
+++ b/lib/herb.rb
@@ -33,6 +33,7 @@ require_relative "herb/ast/erb_render_node"
 
 require_relative "herb/errors"
 require_relative "herb/warnings"
+require_relative "herb/diagnostic"
 
 require_relative "herb/cli"
 require_relative "herb/project"

--- a/lib/herb/diagnostic.rb
+++ b/lib/herb/diagnostic.rb
@@ -148,7 +148,7 @@ module Herb
 
     #: (Herb::Position) -> Hash[Symbol, Integer]
     def serialized_position(position)
-      { line: [position.line, 1].max, column: position.column + 1 }
+      position.to_one_based
     end
   end
 end

--- a/lib/herb/diagnostic.rb
+++ b/lib/herb/diagnostic.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+# typed: true
+
+require_relative "location"
+require_relative "position"
+
+module Herb
+  class Diagnostic
+    UNKNOWN_ORIGIN = "unknown" #: String
+
+    attr_reader :template #: String
+    attr_reader :message #: String
+    attr_reader :node #: String?
+    attr_reader :code #: String?
+    attr_reader :severity #: Symbol?
+    attr_reader :kind #: Symbol
+    attr_reader :origin #: String
+    attr_reader :location #: Herb::Location?
+    attr_reader :suggestion #: String?
+    attr_reader :docs_url #: String?
+    attr_reader :value #: String?
+    attr_reader :phase #: Symbol
+    attr_reader :data #: Hash[Symbol, untyped]
+    attr_reader :error_class #: Class?
+
+    #: (template: String, message: String, ?severity: Symbol?, ?kind: Symbol, ?origin: String, ?node: String?, ?code: String?, ?location: Herb::Location?, ?suggestion: String?, ?docs_url: String?, ?value: String?, ?phase: Symbol, ?data: Hash[Symbol, untyped], ?error_class: Class?) -> void
+    def initialize(template:, message:, severity: :error, kind: :diagnostic, origin: UNKNOWN_ORIGIN, node: nil, code: nil, location: nil, suggestion: nil, docs_url: nil, value: nil, phase: :runtime, data: {}, error_class: nil)
+      @template = template
+      @message = message
+      @node = node
+      @code = code
+      @severity = severity
+      @kind = kind
+      @origin = origin
+      @location = location
+      @suggestion = suggestion
+      @docs_url = docs_url
+      @value = value
+      @phase = phase
+      @data = data
+      @error_class = error_class
+    end
+
+    #: (untyped, template: String, origin: String, ?severity: Symbol, ?phase: Symbol) -> Diagnostic
+    def self.from(error, template:, origin:, severity: :error, phase: :compile)
+      return error if error.is_a?(Diagnostic)
+
+      if error.is_a?(Hash)
+        return new(
+          template: template,
+          message: error[:message].to_s,
+          severity: error[:severity] || severity,
+          origin: error[:source] || origin,
+          code: error[:code],
+          location: error[:location],
+          suggestion: error[:suggestion],
+          phase: phase
+        )
+      end
+
+      new(
+        template: template,
+        message: error.message,
+        severity: severity,
+        origin: origin,
+        code: code_for(error.type),
+        location: error.location,
+        phase: phase,
+        data: { type: error.type }
+      )
+    end
+
+    #: (String) -> String
+    def self.code_for(type)
+      type
+        .gsub(/([A-Z])([A-Z][a-z])/, '\1_\2')
+        .gsub(/([a-z\d])([A-Z])/, '\1_\2')
+        .downcase
+        .sub(/_?error\z/, "")
+        .tr("_", "-")
+    end
+
+    #: () -> bool
+    def error?
+      severity == :error
+    end
+
+    #: () -> bool
+    def warning?
+      severity == :warning
+    end
+
+    #: () -> bool
+    def info?
+      severity == :info
+    end
+
+    #: () -> bool
+    def hint?
+      severity == :hint
+    end
+
+    #: () -> Array[untyped]
+    def key
+      [template, location&.start&.line, code || message]
+    end
+
+    #: () -> Hash[Symbol, untyped]
+    def to_h
+      {
+        template: template,
+        message: message,
+        node: node,
+        code: code,
+        severity: severity,
+        kind: kind,
+        origin: origin,
+        location: location && serialized_location(location),
+        suggestion: suggestion,
+        docs_url: docs_url,
+        value: value,
+      }.compact
+    end
+
+    alias to_hash to_h
+
+    #: (?untyped) -> String
+    def to_json(state = nil)
+      require "json"
+
+      to_h.to_json(state)
+    end
+
+    #: () -> String
+    def to_s
+      position = serialized_position(location.start) if location
+      where = [template, position&.fetch(:line), position&.fetch(:column)].compact.join(":")
+
+      "#{where}: [#{code || origin}] #{message}"
+    end
+
+    private
+
+    #: (Herb::Location) -> Hash[Symbol, untyped]
+    def serialized_location(location)
+      { start: serialized_position(location.start), end: serialized_position(location.end) }
+    end
+
+    #: (Herb::Position) -> Hash[Symbol, Integer]
+    def serialized_position(position)
+      { line: [position.line, 1].max, column: position.column + 1 }
+    end
+  end
+end

--- a/lib/herb/engine.rb
+++ b/lib/herb/engine.rb
@@ -7,6 +7,7 @@ require "pathname"
 
 require_relative "engine/visitor_context"
 require_relative "engine/context_aware"
+require_relative "engine/diagnostics"
 require_relative "engine/debug_visitor"
 require_relative "engine/compiler"
 require_relative "engine/error_formatter"
@@ -20,6 +21,8 @@ require_relative "engine/validators/render_validator"
 
 module Herb
   class Engine
+    SECURITY_VIOLATION_CODE = "security-violation" #: String
+
     attr_reader :src, :context, :bufvar, :debug, :validation_error_template, :visitors, :enabled_validators
 
     #: () -> Pathname?
@@ -173,6 +176,13 @@ module Herb
           visitor.inherit_context(@context) if visitor.is_a?(ContextAware)
 
           ast.accept(visitor)
+        end
+
+        reporting_visitors = @visitors.select { |visitor| visitor.is_a?(Diagnostics) }
+
+        unless reporting_visitors.empty? || @validation_mode == :none
+          handle_validation_errors(reporting_visitors, input) if @validation_mode == :raise
+          add_validation_overlay(reporting_visitors, input) if @validation_mode == :overlay
         end
 
         compiler = Compiler.new(self, properties)
@@ -426,6 +436,8 @@ module Herb
       ]
 
       validators.select(&:enabled?).each do |validator|
+        validator.inherit_context(@context) if validator.is_a?(ContextAware)
+
         ast.accept(validator)
       end
 
@@ -449,19 +461,23 @@ module Herb
       end
     end
 
+    def enabled_reporters(reporters)
+      reporters.reject { |reporter| reporter.respond_to?(:enabled?) && !reporter.enabled? }
+    end
+
     def handle_validation_errors(validators, input)
-      errors = validators.select(&:enabled?).flat_map(&:errors)
+      errors = enabled_reporters(validators).flat_map(&:errors)
       return unless errors.any?
 
-      security_error = errors.find { |error| error[:source] == "SecurityValidator" }
+      security_error = errors.find { |error| error.code == SECURITY_VIOLATION_CODE }
 
       if security_error
         raise SecurityError.new(
-          security_error[:message],
-          line: security_error[:location]&.start&.line,
-          column: security_error[:location]&.start&.column,
+          security_error.message,
+          line: security_error.location&.start&.line,
+          column: security_error.location&.start&.column,
           filename: filename,
-          suggestion: security_error[:suggestion]
+          suggestion: security_error.suggestion
         )
       end
 
@@ -471,11 +487,11 @@ module Herb
     end
 
     def add_validation_overlay(validators, input = nil)
-      errors = validators.select(&:enabled?).flat_map(&:errors)
+      errors = enabled_reporters(validators).flat_map(&:diagnostics)
       return unless errors.any?
 
       templates = errors.map { |error|
-        location = error[:location]
+        location = error.location
         line = location&.start&.line || 0
         column = location&.start&.column || 0
 
@@ -483,26 +499,26 @@ module Herb
         overlay_generator = ValidationErrorOverlay.new(source, error, filename: relative_file_path)
         html_fragment = overlay_generator.generate_fragment
 
-        escaped_message = escape_attr(error[:message])
-        escaped_suggestion = error[:suggestion] ? escape_attr(error[:suggestion]) : ""
+        escaped_message = escape_attr(error.message)
+        escaped_suggestion = error.suggestion ? escape_attr(error.suggestion) : ""
 
         <<~TEMPLATE
           <template
             data-herb-validation-error
-            data-severity="#{error[:severity]}"
-            data-source="#{error[:source]}"
-            data-code="#{error[:code]}"
+            data-severity="#{error.severity}"
+            data-source="#{error.data[:validator]}"
+            data-code="#{error.code}"
             data-line="#{line}"
             data-column="#{column}"
             data-filename="#{escape_attr(relative_file_path)}"
             data-message="#{escaped_message}"
-            #{"data-suggestion=\"#{escaped_suggestion}\"" if error[:suggestion]}
+            #{"data-suggestion=\"#{escaped_suggestion}\"" if error.suggestion}
             data-timestamp="#{Time.now.utc.iso8601}"
           >#{html_fragment}</template>
         TEMPLATE
       }.join
 
-      @validation_error_template = templates
+      @validation_error_template = "#{@validation_error_template}#{templates}"
     end
 
     def escape_attr(text)

--- a/lib/herb/engine/debug_visitor.rb
+++ b/lib/herb/engine/debug_visitor.rb
@@ -212,8 +212,7 @@ module Herb
 
         return erb_node if complex_rails_helper?(code)
 
-        line = erb_node.location&.start&.line
-        column = erb_node.location&.start&.column
+        position = erb_node.location&.start&.to_one_based
 
         escaped_erb = erb_code.gsub("&", "&amp;").gsub("<", "&lt;").gsub(">", "&gt;").gsub('"', "&quot;").gsub("'",
                                                                                                                "&#39;")
@@ -233,8 +232,11 @@ module Herb
           create_debug_attribute("data-herb-debug-inserted", "true")
         ]
 
-        debug_attributes << create_debug_attribute("data-herb-debug-line", line.to_s) if line
-        debug_attributes << create_debug_attribute("data-herb-debug-column", (column + 1).to_s) if column
+        if position
+          debug_attributes << create_debug_attribute("data-herb-debug-line", position[:line].to_s)
+          debug_attributes << create_debug_attribute("data-herb-debug-column", position[:column].to_s)
+        end
+
         debug_attributes << create_debug_attribute("style", "display: contents;")
 
         tag_name_token = Herb::Token.from(:tag_name, "span")

--- a/lib/herb/engine/diagnostics.rb
+++ b/lib/herb/engine/diagnostics.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+# typed: true
+
+require_relative "../diagnostic"
+
+module Herb
+  class Engine
+    # Opt-in for visitors that find something worth telling the developer about.
+    #
+    # A visitor records what it finds and keeps walking. The engine collects from every visitor
+    # afterwards and decides what to do with the result. That split is what lets a visitor that
+    # rewrites the tree also report, which a base class reserved for read-only validators could
+    # never do:
+    #
+    #     class MyVisitor < Herb::Visitor
+    #       include Herb::Engine::ContextAware
+    #       include Herb::Engine::Diagnostics
+    #
+    #       def visit_html_element_node(node)
+    #         warning("This element is suspicious.", node.location, code: "suspicious-element")
+    #
+    #         super
+    #       end
+    #     end
+    #
+    module Diagnostics
+      include Kernel
+
+      #: () -> Array[Herb::Diagnostic]
+      def diagnostics
+        @diagnostics ||= [] #: Array[Herb::Diagnostic]
+      end
+
+      #: (String, Herb::Location?, ?code: String?, ?suggestion: String?, ?docs_url: String?) -> Herb::Diagnostic
+      def error(message, location, code: nil, suggestion: nil, docs_url: nil)
+        add_diagnostic(message, location, :error, code: code, suggestion: suggestion, docs_url: docs_url)
+      end
+
+      #: (String, Herb::Location?, ?code: String?, ?suggestion: String?, ?docs_url: String?) -> Herb::Diagnostic
+      def warning(message, location, code: nil, suggestion: nil, docs_url: nil)
+        add_diagnostic(message, location, :warning, code: code, suggestion: suggestion, docs_url: docs_url)
+      end
+
+      #: (String, Herb::Location?, ?code: String?, ?suggestion: String?, ?docs_url: String?) -> Herb::Diagnostic
+      def info(message, location, code: nil, suggestion: nil, docs_url: nil)
+        add_diagnostic(message, location, :info, code: code, suggestion: suggestion, docs_url: docs_url)
+      end
+
+      #: (String, Herb::Location?, ?code: String?, ?suggestion: String?, ?docs_url: String?) -> Herb::Diagnostic
+      def hint(message, location, code: nil, suggestion: nil, docs_url: nil)
+        add_diagnostic(message, location, :hint, code: code, suggestion: suggestion, docs_url: docs_url)
+      end
+
+      #: () -> Array[Herb::Diagnostic]
+      def errors
+        diagnostics.select(&:error?)
+      end
+
+      #: () -> Array[Herb::Diagnostic]
+      def warnings
+        diagnostics.select(&:warning?)
+      end
+
+      #: () -> bool
+      def errors?
+        diagnostics.any?(&:error?)
+      end
+
+      #: () -> bool
+      def warnings?
+        diagnostics.any?(&:warning?)
+      end
+
+      #: () -> void
+      def clear_diagnostics
+        diagnostics.clear
+      end
+
+      #: (?Symbol?) -> Integer
+      def diagnostic_count(severity = nil)
+        return diagnostics.length unless severity
+
+        diagnostics.count { |diagnostic| diagnostic.severity == severity }
+      end
+
+      private
+
+      #: (String, Herb::Location?, Symbol, ?code: String?, ?suggestion: String?, ?docs_url: String?) -> Herb::Diagnostic
+      def add_diagnostic(message, location, severity, code: nil, suggestion: nil, docs_url: nil)
+        diagnostic = Herb::Diagnostic.new(
+          template: diagnostic_template,
+          message: message,
+          severity: severity,
+          origin: diagnostic_origin,
+          code: code && Herb::Diagnostic.code_for(code),
+          location: location,
+          suggestion: suggestion,
+          docs_url: docs_url,
+          phase: :compile,
+          data: diagnostic_data
+        )
+
+        diagnostics << diagnostic
+
+        diagnostic
+      end
+
+      #: () -> String
+      def diagnostic_origin
+        "Herb Compiler"
+      end
+
+      #: () -> Hash[Symbol, untyped]
+      def diagnostic_data
+        { validator: self.class.name&.split("::")&.last }
+      end
+
+      #: () -> String
+      def diagnostic_template
+        visitor_context = respond_to?(:context) ? send(:context) : nil
+
+        return visitor_context.relative_file_path if visitor_context.is_a?(VisitorContext)
+
+        VisitorContext::UNKNOWN_FILE_PATH
+      end
+    end
+  end
+end

--- a/lib/herb/engine/error_formatter.rb
+++ b/lib/herb/engine/error_formatter.rb
@@ -97,6 +97,7 @@ module Herb
 
       def format_error(error, number)
         output = String.new
+        location = error.location
 
         error_name = if error.is_a?(Herb::Diagnostic)
                        error.code || "UnknownError"
@@ -107,14 +108,12 @@ module Herb
         output << "Error ##{number}: #{error_name}\n"
         output << ("-" * 40) << "\n"
 
-        location = error.location
         if location
           output << "  File: #{@filename}\n"
           output << "  Location: Line #{location.start.line}, Column #{location.start.column}\n"
         end
 
-        error_message = error.message
-        output << "  Message: #{error_message}\n\n"
+        output << "  Message: #{error.message}\n\n"
         output << format_source_context(error) if location
         output << format_error_details(error)
 
@@ -309,6 +308,7 @@ module Herb
         nil
       end
 
+      # TODO: deduplicate this conversion logic
       def herb_error_to_diagnostic(error)
         if error.is_a?(Herb::Diagnostic)
           location = error.location
@@ -363,8 +363,7 @@ module Herb
                     "  #{number}. #{error.class.name.split("::").last.gsub(/Error$/, "")}: #{error.message}\n"
                   end
 
-        location = error.location
-        output << "     Location: Line #{location.start.line}, Column #{location.start.column}\n" if location
+        output << "     Location: Line #{error.location.start.line}, Column #{error.location.start.column}\n" if error.location
 
         output
       end
@@ -385,6 +384,7 @@ module Herb
         format_source_context(error)
       end
 
+      # TODO: move to config.yml definition
       def get_error_suggestion(error)
         case error
         when Herb::Errors::MissingClosingTagError

--- a/lib/herb/engine/error_formatter.rb
+++ b/lib/herb/engine/error_formatter.rb
@@ -44,7 +44,7 @@ module Herb
             output << highlighted_output
           else
             errors_by_line = @errors.group_by do |error|
-              location = error.is_a?(Hash) ? error[:location] : error.location
+              location = error.location
               location&.start&.line
             end.compact
 
@@ -98,8 +98,8 @@ module Herb
       def format_error(error, number)
         output = String.new
 
-        error_name = if error.is_a?(Hash)
-                       error[:code] || "UnknownError"
+        error_name = if error.is_a?(Herb::Diagnostic)
+                       error.code || "UnknownError"
                      else
                        error.class.name.split("::").last.gsub(/Error$/, "")
                      end
@@ -107,13 +107,13 @@ module Herb
         output << "Error ##{number}: #{error_name}\n"
         output << ("-" * 40) << "\n"
 
-        location = error.is_a?(Hash) ? error[:location] : error.location
+        location = error.location
         if location
           output << "  File: #{@filename}\n"
           output << "  Location: Line #{location.start.line}, Column #{location.start.column}\n"
         end
 
-        error_message = error.is_a?(Hash) ? error[:message] : error.message
+        error_message = error.message
         output << "  Message: #{error_message}\n\n"
         output << format_source_context(error) if location
         output << format_error_details(error)
@@ -125,7 +125,7 @@ module Herb
 
       def format_source_context(error)
         output = String.new
-        location = error.is_a?(Hash) ? error[:location] : error.location
+        location = error.location
         line_num = location.start.line
         col_num = location.start.column
 
@@ -310,10 +310,10 @@ module Herb
       end
 
       def herb_error_to_diagnostic(error)
-        if error.is_a?(Hash)
-          location = error[:location]
+        if error.is_a?(Herb::Diagnostic)
+          location = error.location
           {
-            message: error[:message],
+            message: error.message,
             location: {
               start: {
                 line: location&.start&.line || 1,
@@ -324,9 +324,9 @@ module Herb
                 column: location&.end&.column || location&.start&.column || 1,
               },
             },
-            severity: error[:severity] || "error",
-            code: error[:code] || "UnknownError",
-            source: error[:source] || "herb-validator",
+            severity: error.severity || "error",
+            code: error.code || "UnknownError",
+            source: error.origin || "herb-validator",
           }
         else
           severity = case error
@@ -357,13 +357,13 @@ module Herb
 
       def format_error_header(error, number)
         output = String.new
-        output << if error.is_a?(Hash)
-                    "  #{number}. #{error[:code] || "UnknownError"}: #{error[:message]}\n"
+        output << if error.is_a?(Herb::Diagnostic)
+                    "  #{number}. #{error.code || "UnknownError"}: #{error.message}\n"
                   else
                     "  #{number}. #{error.class.name.split("::").last.gsub(/Error$/, "")}: #{error.message}\n"
                   end
 
-        location = error.is_a?(Hash) ? error[:location] : error.location
+        location = error.location
         output << "     Location: Line #{location.start.line}, Column #{location.start.column}\n" if location
 
         output

--- a/lib/herb/engine/html_safe_assertions_visitor.rb
+++ b/lib/herb/engine/html_safe_assertions_visitor.rb
@@ -239,8 +239,10 @@ module Herb
         location = node.location
 
         if location
-          parts << "line: #{location.start.line}"
-          parts << "column: #{location.start.column + 1}"
+          position = location.start.to_one_based
+
+          parts << "line: #{position[:line]}"
+          parts << "column: #{position[:column]}"
         end
 
         parts << "source: #{erb_source(node, code).dump}.freeze"

--- a/lib/herb/engine/validation_error_overlay.rb
+++ b/lib/herb/engine/validation_error_overlay.rb
@@ -25,17 +25,18 @@ module Herb
       end
 
       def generate_fragment
-        location = @error[:location]
+        location = @error.location
         line_num = location&.start&.line || 1
         col_num = location&.start&.column || 1
 
-        validator_info = VALIDATOR_BADGES[@error[:source]] || { label: @error[:source], color: "#6b7280" }
-        severity_color = SEVERITY_COLORS[@error[:severity].to_s] || "#6b7280"
+        validator_name = @error.data[:validator] || @error.origin
+        validator_info = VALIDATOR_BADGES[validator_name] || { label: validator_name, color: "#6b7280" }
+        severity_color = SEVERITY_COLORS[@error.severity.to_s] || "#6b7280"
 
         code_snippet = generate_code_snippet(line_num, col_num)
 
         <<~HTML
-          <div class="herb-validation-item" data-severity="#{escape_attr(@error[:severity].to_s)}">
+          <div class="herb-validation-item" data-severity="#{escape_attr(@error.severity.to_s)}">
             <div class="herb-validation-header">
               <span class="herb-validation-badge" style="background: #{validator_info[:color]}">
                 #{escape_html(validator_info[:label])}
@@ -45,10 +46,10 @@ module Herb
               </span>
             </div>
             <div class="herb-validation-message" style="color: #{severity_color}">
-              #{escape_html(@error[:message])}
+              #{escape_html(@error.message)}
             </div>
             #{code_snippet}
-            #{generate_suggestion_html if @error[:suggestion]}
+            #{generate_suggestion_html if @error.suggestion}
           </div>
         HTML
       end
@@ -101,7 +102,7 @@ module Herb
         <<~HTML
           <div class="herb-validation-suggestion">
             <span class="herb-suggestion-icon">💡</span>
-            #{escape_html(@error[:suggestion])}
+            #{escape_html(@error.suggestion)}
           </div>
         HTML
       end

--- a/lib/herb/engine/validator.rb
+++ b/lib/herb/engine/validator.rb
@@ -1,79 +1,37 @@
 # frozen_string_literal: true
 
+require_relative "context_aware"
+require_relative "diagnostics"
+
 module Herb
   class Engine
+    # A visitor that reads the tree and reports what it finds without rewriting anything.
+    #
+    # Reporting itself lives in `Herb::Engine::Diagnostics` and is available to any visitor, so
+    # this class is only the convenience of the two mixins plus an enabled flag. A validator that
+    # wants to be one of the engine's own is expected to subclass it; a validator that comes from
+    # somewhere else can just include the mixins.
     class Validator < Herb::Visitor
-      attr_reader :diagnostics, :enabled
+      include ContextAware
+      include Diagnostics
 
+      attr_reader :enabled #: bool
+
+      #: (?enabled: bool) -> void
       def initialize(enabled: true)
         super()
 
         @enabled = enabled
-        @diagnostics = []
       end
 
+      #: () -> bool
       def enabled?
         @enabled
       end
 
+      #: (Herb::AST::Node) -> void
       def validate(node)
         visit(node)
-      end
-
-      def error(message, location, code: nil, source: nil)
-        add_diagnostic(message, location, :error, code: code, source: source)
-      end
-
-      def warning(message, location, code: nil, source: nil)
-        add_diagnostic(message, location, :warning, code: code, source: source)
-      end
-
-      def info(message, location, code: nil, source: nil)
-        add_diagnostic(message, location, :info, code: code, source: source)
-      end
-
-      def hint(message, location, code: nil, source: nil)
-        add_diagnostic(message, location, :hint, code: code, source: source)
-      end
-
-      def errors?
-        @diagnostics.any? { |diagnostic| diagnostic[:severity] == :error }
-      end
-
-      def warnings?
-        @diagnostics.any? { |diagnostic| diagnostic[:severity] == :warning }
-      end
-
-      def errors
-        @diagnostics.select { |diagnostic| diagnostic[:severity] == :error }
-      end
-
-      def warnings
-        @diagnostics.select { |diagnostic| diagnostic[:severity] == :warning }
-      end
-
-      def clear_diagnostics
-        @diagnostics.clear
-      end
-
-      def diagnostic_count(severity = nil)
-        return @diagnostics.length unless severity
-
-        @diagnostics.count { |diagnostic| diagnostic[:severity] == severity }
-      end
-
-      private
-
-      def add_diagnostic(message, location, severity, code: nil, source: nil)
-        diagnostic = {
-          message: message,
-          location: location,
-          severity: severity,
-          code: code,
-          source: source || self.class.name,
-        }
-
-        @diagnostics << diagnostic
       end
     end
   end

--- a/lib/herb/engine/validators/accessibility_validator.rb
+++ b/lib/herb/engine/validators/accessibility_validator.rb
@@ -23,7 +23,7 @@ module Herb
         end
 
         def add_validation_error(type, location, message)
-          error(message, location, code: type, source: "AccessibilityValidator")
+          error(message, location, code: type)
         end
       end
     end

--- a/lib/herb/engine/validators/nesting_validator.rb
+++ b/lib/herb/engine/validators/nesting_validator.rb
@@ -87,7 +87,7 @@ module Herb
         end
 
         def add_validation_error(type, location, message)
-          error(message, location, code: type, source: "NestingValidator")
+          error(message, location, code: type)
         end
       end
     end

--- a/lib/herb/engine/validators/render_validator.rb
+++ b/lib/herb/engine/validators/render_validator.rb
@@ -19,8 +19,7 @@ module Herb
             warning(
               "Dynamic render call cannot be statically resolved",
               node.location,
-              code: "RenderDynamic",
-              source: "RenderValidator"
+              code: "RenderDynamic"
             )
           elsif node.static_partial?
             validate_partial_exists(node)
@@ -68,8 +67,7 @@ module Herb
           error(
             message,
             node.location,
-            code: "RenderUnresolved",
-            source: "RenderValidator"
+            code: "RenderUnresolved"
           )
         end
 

--- a/lib/herb/engine/validators/security_validator.rb
+++ b/lib/herb/engine/validators/security_validator.rb
@@ -89,21 +89,7 @@ module Herb
         end
 
         def add_security_error(location, message, suggestion)
-          add_diagnostic(message, location, :error, code: "SecurityViolation", source: "SecurityValidator",
-                                                    suggestion: suggestion)
-        end
-
-        def add_diagnostic(message, location, severity, code: nil, source: nil, suggestion: nil)
-          diagnostic = {
-            message: message,
-            location: location,
-            severity: severity,
-            code: code,
-            source: source || self.class.name,
-            suggestion: suggestion,
-          }
-
-          @diagnostics << diagnostic
+          error(message, location, code: "SecurityViolation", suggestion: suggestion)
         end
       end
     end

--- a/lib/herb/position.rb
+++ b/lib/herb/position.rb
@@ -33,6 +33,11 @@ module Herb
       { line: line, column: column } #: Herb::serialized_position
     end
 
+    #: () -> serialized_position
+    def to_one_based
+      { line: [line, 1].max, column: column + 1 } #: Herb::serialized_position
+    end
+
     #: (?untyped) -> String
     def to_json(state = nil)
       to_hash.to_json(state)

--- a/sig/herb/diagnostic.rbs
+++ b/sig/herb/diagnostic.rbs
@@ -1,0 +1,78 @@
+# Generated from lib/herb/diagnostic.rb with RBS::Inline
+
+module Herb
+  class Diagnostic
+    UNKNOWN_ORIGIN: String
+
+    attr_reader template: String
+
+    attr_reader message: String
+
+    attr_reader node: String?
+
+    attr_reader code: String?
+
+    attr_reader severity: Symbol?
+
+    attr_reader kind: Symbol
+
+    attr_reader origin: String
+
+    attr_reader location: Herb::Location?
+
+    attr_reader suggestion: String?
+
+    attr_reader docs_url: String?
+
+    attr_reader value: String?
+
+    attr_reader phase: Symbol
+
+    attr_reader data: Hash[Symbol, untyped]
+
+    attr_reader error_class: Class?
+
+    # : (template: String, message: String, ?severity: Symbol?, ?kind: Symbol, ?origin: String, ?node: String?, ?code: String?, ?location: Herb::Location?, ?suggestion: String?, ?docs_url: String?, ?value: String?, ?phase: Symbol, ?data: Hash[Symbol, untyped], ?error_class: Class?) -> void
+    def initialize: (template: String, message: String, ?severity: Symbol?, ?kind: Symbol, ?origin: String, ?node: String?, ?code: String?, ?location: Herb::Location?, ?suggestion: String?, ?docs_url: String?, ?value: String?, ?phase: Symbol, ?data: Hash[Symbol, untyped], ?error_class: Class?) -> void
+
+    # : (untyped, template: String, origin: String, ?severity: Symbol, ?phase: Symbol) -> Diagnostic
+    def self.from: (untyped, template: String, origin: String, ?severity: Symbol, ?phase: Symbol) -> Diagnostic
+
+    # : (String) -> String
+    def self.code_for: (String) -> String
+
+    # : () -> bool
+    def error?: () -> bool
+
+    # : () -> bool
+    def warning?: () -> bool
+
+    # : () -> bool
+    def info?: () -> bool
+
+    # : () -> bool
+    def hint?: () -> bool
+
+    # : () -> Array[untyped]
+    def key: () -> Array[untyped]
+
+    # : () -> Hash[Symbol, untyped]
+    def to_h: () -> Hash[Symbol, untyped]
+
+    alias to_hash to_h
+
+    # : (?untyped) -> String
+    def to_json: (?untyped) -> String
+
+    # : () -> String
+    def to_s: () -> String
+
+    private
+
+    # : (Herb::Location) -> Hash[Symbol, untyped]
+    def serialized_location: (Herb::Location) -> Hash[Symbol, untyped]
+
+    # : (Herb::Position) -> Hash[Symbol, Integer]
+    def serialized_position: (Herb::Position) -> Hash[Symbol, Integer]
+  end
+end

--- a/sig/herb/engine.rbs
+++ b/sig/herb/engine.rbs
@@ -2,6 +2,8 @@
 
 module Herb
   class Engine
+    SECURITY_VIOLATION_CODE: String
+
     attr_reader src: untyped
 
     attr_reader context: untyped
@@ -102,6 +104,8 @@ module Herb
     def run_validation: (untyped ast) -> untyped
 
     def handle_parser_errors: (untyped parser_errors, untyped input, untyped _ast) -> untyped
+
+    def enabled_reporters: (untyped reporters) -> untyped
 
     def handle_validation_errors: (untyped validators, untyped input) -> untyped
 

--- a/sig/herb/engine/diagnostics.rbs
+++ b/sig/herb/engine/diagnostics.rbs
@@ -1,0 +1,73 @@
+# Generated from lib/herb/engine/diagnostics.rb with RBS::Inline
+
+module Herb
+  class Engine
+    # Opt-in for visitors that find something worth telling the developer about.
+    #
+    # A visitor records what it finds and keeps walking. The engine collects from every visitor
+    # afterwards and decides what to do with the result. That split is what lets a visitor that
+    # rewrites the tree also report, which a base class reserved for read-only validators could
+    # never do:
+    #
+    #     class MyVisitor < Herb::Visitor
+    #       include Herb::Engine::ContextAware
+    #       include Herb::Engine::Diagnostics
+    #
+    #       def visit_html_element_node(node)
+    #         warning("This element is suspicious.", node.location, code: "suspicious-element")
+    #
+    #         super
+    #       end
+    #     end
+    module Diagnostics
+      include Kernel
+
+      # : () -> Array[Herb::Diagnostic]
+      def diagnostics: () -> Array[Herb::Diagnostic]
+
+      # : (String, Herb::Location?, ?code: String?, ?suggestion: String?, ?docs_url: String?) -> Herb::Diagnostic
+      def error: (String, Herb::Location?, ?code: String?, ?suggestion: String?, ?docs_url: String?) -> Herb::Diagnostic
+
+      # : (String, Herb::Location?, ?code: String?, ?suggestion: String?, ?docs_url: String?) -> Herb::Diagnostic
+      def warning: (String, Herb::Location?, ?code: String?, ?suggestion: String?, ?docs_url: String?) -> Herb::Diagnostic
+
+      # : (String, Herb::Location?, ?code: String?, ?suggestion: String?, ?docs_url: String?) -> Herb::Diagnostic
+      def info: (String, Herb::Location?, ?code: String?, ?suggestion: String?, ?docs_url: String?) -> Herb::Diagnostic
+
+      # : (String, Herb::Location?, ?code: String?, ?suggestion: String?, ?docs_url: String?) -> Herb::Diagnostic
+      def hint: (String, Herb::Location?, ?code: String?, ?suggestion: String?, ?docs_url: String?) -> Herb::Diagnostic
+
+      # : () -> Array[Herb::Diagnostic]
+      def errors: () -> Array[Herb::Diagnostic]
+
+      # : () -> Array[Herb::Diagnostic]
+      def warnings: () -> Array[Herb::Diagnostic]
+
+      # : () -> bool
+      def errors?: () -> bool
+
+      # : () -> bool
+      def warnings?: () -> bool
+
+      # : () -> void
+      def clear_diagnostics: () -> void
+
+      # : (?Symbol?) -> Integer
+      def diagnostic_count: (?Symbol?) -> Integer
+
+      private
+
+      # : (String, Herb::Location?, Symbol, ?code: String?, ?suggestion: String?, ?docs_url: String?) -> Herb::Diagnostic
+      def add_diagnostic: (String, Herb::Location?, Symbol, ?code: String?, ?suggestion: String?, ?docs_url: String?) -> Herb::Diagnostic
+
+      # : () -> String
+      def diagnostic_origin: () -> String
+
+      # : () -> Hash[Symbol, untyped]
+      def diagnostic_data: () -> Hash[Symbol, untyped]
+
+      # : () -> String
+      def diagnostic_template: () -> String
+    end
+  end
+end

--- a/sig/herb/engine/error_formatter.rbs
+++ b/sig/herb/engine/error_formatter.rbs
@@ -33,6 +33,7 @@ module Herb
 
       def run_highlighter_with_diagnostics: (untyped file_path, ?untyped context_lines) -> untyped
 
+      # TODO: deduplicate this conversion logic
       def herb_error_to_diagnostic: (untyped error) -> untyped
 
       def format_error_header: (untyped error, untyped number) -> untyped
@@ -41,6 +42,7 @@ module Herb
 
       def format_source_context_basic: (untyped error) -> untyped
 
+      # TODO: move to config.yml definition
       def get_error_suggestion: (untyped error) -> untyped
     end
   end

--- a/sig/herb/engine/validator.rbs
+++ b/sig/herb/engine/validator.rbs
@@ -2,40 +2,27 @@
 
 module Herb
   class Engine
+    # A visitor that reads the tree and reports what it finds without rewriting anything.
+    #
+    # Reporting itself lives in `Herb::Engine::Diagnostics` and is available to any visitor, so
+    # this class is only the convenience of the two mixins plus an enabled flag. A validator that
+    # wants to be one of the engine's own is expected to subclass it; a validator that comes from
+    # somewhere else can just include the mixins.
     class Validator < Herb::Visitor
-      attr_reader diagnostics: untyped
+      include ContextAware
 
-      attr_reader enabled: untyped
+      include Diagnostics
 
-      def initialize: (?enabled: untyped) -> untyped
+      attr_reader enabled: bool
 
-      def enabled?: () -> untyped
+      # : (?enabled: bool) -> void
+      def initialize: (?enabled: bool) -> void
 
-      def validate: (untyped node) -> untyped
+      # : () -> bool
+      def enabled?: () -> bool
 
-      def error: (untyped message, untyped location, ?code: untyped, ?source: untyped) -> untyped
-
-      def warning: (untyped message, untyped location, ?code: untyped, ?source: untyped) -> untyped
-
-      def info: (untyped message, untyped location, ?code: untyped, ?source: untyped) -> untyped
-
-      def hint: (untyped message, untyped location, ?code: untyped, ?source: untyped) -> untyped
-
-      def errors?: () -> untyped
-
-      def warnings?: () -> untyped
-
-      def errors: () -> untyped
-
-      def warnings: () -> untyped
-
-      def clear_diagnostics: () -> untyped
-
-      def diagnostic_count: (?untyped severity) -> untyped
-
-      private
-
-      def add_diagnostic: (untyped message, untyped location, untyped severity, ?code: untyped, ?source: untyped) -> untyped
+      # : (Herb::AST::Node) -> void
+      def validate: (Herb::AST::Node) -> void
     end
   end
 end

--- a/sig/herb/engine/validators/security_validator.rbs
+++ b/sig/herb/engine/validators/security_validator.rbs
@@ -19,8 +19,6 @@ module Herb
         def conditional_tag_attributes_prism_node?: (untyped prism_node) -> untyped
 
         def add_security_error: (untyped location, untyped message, untyped suggestion) -> untyped
-
-        def add_diagnostic: (untyped message, untyped location, untyped severity, ?code: untyped, ?source: untyped, ?suggestion: untyped) -> untyped
       end
     end
   end

--- a/sig/herb/position.rbs
+++ b/sig/herb/position.rbs
@@ -22,6 +22,9 @@ module Herb
     # : () -> serialized_position
     def to_hash: () -> serialized_position
 
+    # : () -> serialized_position
+    def to_one_based: () -> serialized_position
+
     # : (?untyped) -> String
     def to_json: (?untyped) -> String
 

--- a/test/diagnostic_test.rb
+++ b/test/diagnostic_test.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+class DiagnosticTest < Minitest::Spec
+  test "serializes columns counting from one" do
+    diagnostic = Herb::Diagnostic.new(
+      template: "app/views/posts/show.html.erb",
+      message: "Something is wrong.",
+      location: Herb::Location.from(1, 0, 1, 37)
+    )
+
+    assert_equal({ line: 1, column: 1 }, diagnostic.to_h[:location][:start])
+    assert_equal({ line: 1, column: 38 }, diagnostic.to_h[:location][:end])
+  end
+
+  test "leaves the location it was given counting columns from zero" do
+    diagnostic = Herb::Diagnostic.new(template: "a.html.erb", message: "m", location: Herb::Location.from(1, 0, 1, 37))
+
+    assert_equal 0, diagnostic.location.start.column
+  end
+
+  test "clamps a line below one rather than rejecting it" do
+    diagnostic = Herb::Diagnostic.new(
+      template: "a.html.erb",
+      message: "m",
+      location: Herb::Location.from(0, 0, 0, 0)
+    )
+
+    assert_equal 1, diagnostic.to_h[:location][:start][:line]
+  end
+
+  test "omits what it does not carry" do
+    hash = Herb::Diagnostic.new(template: "a.html.erb", message: "m").to_h
+
+    refute hash.key?(:location)
+    refute hash.key?(:suggestion)
+    refute hash.key?(:docs_url)
+    refute hash.key?(:node)
+  end
+
+  test "names the keys the payload uses" do
+    diagnostic = Herb::Diagnostic.new(
+      template: "a.html.erb",
+      message: "m",
+      docs_url: "https://herb-tools.dev/diagnostics/x"
+    )
+
+    hash = diagnostic.to_h
+
+    assert_equal "https://herb-tools.dev/diagnostics/x", hash[:docs_url]
+    assert_equal :diagnostic, hash[:kind]
+  end
+
+  test "a metric carries a badge rather than a fault" do
+    metric = Herb::Diagnostic.new(
+      template: "a.html.erb",
+      message: "This tag ran 3 queries",
+      kind: :metric,
+      value: "3 SQL queries"
+    )
+
+    assert_equal :metric, metric.to_h[:kind]
+    assert_equal "3 SQL queries", metric.to_h[:value]
+  end
+
+  describe ".code_for" do
+    test "hyphenates and drops the trailing Error" do
+      assert_equal "missing-closing-tag", Herb::Diagnostic.code_for("MissingClosingTagError")
+      assert_equal "render-layout-without-block", Herb::Diagnostic.code_for("RenderLayoutWithoutBlockError")
+    end
+
+    test "keeps a name that does not end in Error" do
+      assert_equal "security-violation", Herb::Diagnostic.code_for("SecurityViolation")
+    end
+
+    test "splits an acronym on the last capital" do
+      assert_equal "html-parse", Herb::Diagnostic.code_for("HTMLParseError")
+      assert_equal "malformed-erb-closing-tag", Herb::Diagnostic.code_for("MalformedERBClosingTagError")
+    end
+  end
+
+  describe ".from" do
+    test "builds one from a parser error without shifting the column" do
+      error = Herb.parse("<div><p></div>").errors.first
+      diagnostic = Herb::Diagnostic.from(error, template: "a.html.erb", origin: "Herb Parser")
+
+      assert_equal "missing-closing-tag", diagnostic.code
+      assert_equal error.location.start.column, diagnostic.location.start.column
+      assert_equal error.location.start.column + 1, diagnostic.to_h[:location][:start][:column]
+      assert_equal :compile, diagnostic.phase
+    end
+
+    test "returns a diagnostic it is handed" do
+      diagnostic = Herb::Diagnostic.new(template: "a.html.erb", message: "m")
+
+      assert_same diagnostic, Herb::Diagnostic.from(diagnostic, template: "b.html.erb", origin: "Herb Parser")
+    end
+
+    test "builds one from the hash shape the validators used to produce" do
+      diagnostic = Herb::Diagnostic.from(
+        { message: "m", severity: :warning, code: "x", location: Herb::Location.from(1, 0, 1, 37), suggestion: "s" },
+        template: "a.html.erb",
+        origin: "Herb Parser"
+      )
+
+      assert_equal :warning, diagnostic.severity
+      assert_equal "s", diagnostic.suggestion
+    end
+  end
+
+  describe "#key" do
+    test "matches on template, line and code, ignoring the column" do
+      first = Herb::Diagnostic.new(template: "a.html.erb", message: "m", code: "c", location: Herb::Location.from(3, 2, 3, 9))
+      second = Herb::Diagnostic.new(template: "a.html.erb", message: "different", code: "c", location: Herb::Location.from(3, 40, 3, 44))
+
+      assert_equal first.key, second.key
+    end
+
+    test "falls back to the message when there is no code" do
+      diagnostic = Herb::Diagnostic.new(template: "a.html.erb", message: "m")
+
+      assert_equal ["a.html.erb", nil, "m"], diagnostic.key
+    end
+  end
+
+  test "reads as a location and a message" do
+    diagnostic = Herb::Diagnostic.new(
+      template: "app/views/a.html.erb",
+      message: "Something is wrong.",
+      code: "something-wrong",
+      location: Herb::Location.from(1, 0, 1, 37)
+    )
+
+    assert_equal "app/views/a.html.erb:1:1: [something-wrong] Something is wrong.", diagnostic.to_s
+  end
+end

--- a/test/engine/debug_mode_test.rb
+++ b/test/engine/debug_mode_test.rb
@@ -8,6 +8,23 @@ module Engine
   class DebugModeTest < Minitest::Spec
     include SnapshotUtils
 
+    class ZeroLocationInjector < Herb::Visitor
+      def visit_document_node(node)
+        super
+
+        node.children << Herb::AST::ERBContentNode.build(
+          tag_opening: Herb::Token.from("TOKEN_ERB_START", "<%="),
+          content: Herb::Token.from("TOKEN_ERB_CONTENT", " generated "),
+          tag_closing: Herb::Token.from("TOKEN_ERB_END", "%>"),
+          valid: true
+        )
+      end
+
+      def inspect
+        "#<ZeroLocationInjector>"
+      end
+    end
+
     test "debug mode disabled by default" do
       template = "<h1>Hello <%= @name %>!</h1>"
 
@@ -615,6 +632,18 @@ module Engine
       assert_compiled_snapshot(<<~ERB, debug: true)
         <title><%= @page_title %></title>
       ERB
+    end
+
+    test "annotates a generated node with the first line rather than line zero" do
+      compiled = Herb::Engine.new(
+        "<div>Hello</div>",
+        filename: "app/views/test.html.erb",
+        visitors: [ZeroLocationInjector.new, Herb::Engine::DebugVisitor.new]
+      ).src
+
+      assert_includes compiled, %(data-herb-debug-line="1")
+      assert_includes compiled, %(data-herb-debug-column="1")
+      refute_includes compiled, %(data-herb-debug-line="0")
     end
   end
 end

--- a/test/engine/diagnostics_test.rb
+++ b/test/engine/diagnostics_test.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+module Engine
+  class DiagnosticsTest < Minitest::Spec
+    class RewritingReporter < Herb::Visitor
+      include Herb::Engine::ContextAware
+      include Herb::Engine::Diagnostics
+
+      def visit_html_element_node(node)
+        if node.open_tag&.tag_name&.value == "marquee"
+          warning("The `<marquee>` element is obsolete.", node.location, code: "ObsoleteElement", suggestion: "Use CSS animations instead.")
+
+          node.open_tag.tag_name.value.replace("div")
+
+          close_tag_name = node.close_tag&.tag_name&.value
+          close_tag_name&.replace("div")
+        end
+
+        super
+      end
+    end
+
+    def compile(source, **)
+      Herb::Engine.new(source, filename: "app/views/test.html.erb", **)
+    end
+
+    test "a visitor that rewrites the tree can also report" do
+      visitor = RewritingReporter.new
+
+      compile("<marquee>Hello</marquee>", visitors: [visitor], validation_mode: :none)
+
+      assert_equal 1, visitor.diagnostics.length
+
+      diagnostic = visitor.diagnostics.first
+
+      assert_equal "obsolete-element", diagnostic.code
+      assert_equal :warning, diagnostic.severity
+      assert_equal "app/views/test.html.erb", diagnostic.template
+      assert_equal "Use CSS animations instead.", diagnostic.suggestion
+    end
+
+    test "the rewrite still reaches the compiled output" do
+      engine = compile("<marquee>Hello</marquee>", visitors: [RewritingReporter.new], validation_mode: :none)
+
+      assert_includes engine.src, "<div>"
+      refute_includes engine.src, "<marquee>"
+    end
+
+    test "the engine surfaces what a visitor reported in overlay mode" do
+      engine = compile("<marquee>Hello</marquee>", visitors: [RewritingReporter.new], validation_mode: :overlay)
+
+      assert_includes engine.validation_error_template, "data-herb-validation-error"
+      assert_includes engine.validation_error_template, 'data-code="obsolete-element"'
+      assert_includes engine.validation_error_template, 'data-severity="warning"'
+    end
+
+    test "a reporting visitor and a validator both reach the overlay" do
+      engine = compile("<p><div><marquee>x</marquee></div></p>", visitors: [RewritingReporter.new], validation_mode: :overlay)
+
+      assert_includes engine.validation_error_template, 'data-code="invalid-nesting"'
+      assert_includes engine.validation_error_template, 'data-code="obsolete-element"'
+    end
+
+    test "a visitor reporting an error raises in raise mode" do
+      visitor = RewritingReporter.new
+
+      def visitor.visit_html_element_node(node)
+        error("Not allowed.", node.location, code: "NotAllowed") if node.open_tag&.tag_name&.value == "marquee"
+
+        Herb::Visitor.instance_method(:visit_html_element_node).bind_call(self, node)
+      end
+
+      assert_raises(Herb::Engine::CompilationError) do
+        compile("<marquee>Hello</marquee>", visitors: [visitor], validation_mode: :raise)
+      end
+    end
+
+    test "a visitor that reports nothing changes nothing" do
+      engine = compile("<div>Hello</div>", visitors: [RewritingReporter.new], validation_mode: :overlay)
+
+      assert_nil engine.validation_error_template
+    end
+
+    test "a visitor without the mixin is left alone" do
+      plain = Class.new(Herb::Visitor).new
+
+      engine = compile("<div>Hello</div>", visitors: [plain], validation_mode: :overlay)
+
+      assert_nil engine.validation_error_template
+    end
+
+    describe "the mixin on its own" do
+      test "collects by severity" do
+        reporter = RewritingReporter.new
+        location = Herb::Location.from(1, 0, 1, 4)
+
+        reporter.error("e", location)
+        reporter.warning("w", location)
+        reporter.info("i", location)
+        reporter.hint("h", location)
+
+        assert_equal 4, reporter.diagnostic_count
+        assert_equal 1, reporter.diagnostic_count(:hint)
+        assert_equal ["e"], reporter.errors.map(&:message)
+        assert_equal ["w"], reporter.warnings.map(&:message)
+        assert_predicate reporter, :errors?
+        assert_predicate reporter, :warnings?
+      end
+
+      test "reports against an unknown template when it has no context" do
+        reporter = RewritingReporter.new
+        reporter.warning("w", nil)
+
+        assert_equal Herb::Engine::VisitorContext::UNKNOWN_FILE_PATH, reporter.diagnostics.first.template
+      end
+
+      test "marks what it finds as found at compile time" do
+        reporter = RewritingReporter.new
+        reporter.warning("w", nil)
+
+        assert_equal :compile, reporter.diagnostics.first.phase
+      end
+    end
+  end
+end

--- a/test/engine/render_nodes_test.rb
+++ b/test/engine/render_nodes_test.rb
@@ -65,18 +65,18 @@ module Engine
       diagnostics = render_diagnostics('<%= render "nonexistent/missing" %>')
 
       assert_equal 1, diagnostics.length
-      assert_equal :error, diagnostics.first[:severity]
-      assert_includes diagnostics.first[:message], "Partial 'nonexistent/missing' could not be resolved"
-      assert_equal "RenderUnresolved", diagnostics.first[:code]
+      assert_equal :error, diagnostics.first.severity
+      assert_includes diagnostics.first.message, "Partial 'nonexistent/missing' could not be resolved"
+      assert_equal "render-unresolved", diagnostics.first.code
     end
 
     test "warns for dynamic render calls" do
       diagnostics = render_diagnostics("<%= render @product %>")
 
       assert_equal 1, diagnostics.length
-      assert_equal :warning, diagnostics.first[:severity]
-      assert_includes diagnostics.first[:message], "Dynamic render call cannot be statically resolved"
-      assert_equal "RenderDynamic", diagnostics.first[:code]
+      assert_equal :warning, diagnostics.first.severity
+      assert_includes diagnostics.first.message, "Dynamic render call cannot be statically resolved"
+      assert_equal "render-dynamic", diagnostics.first.code
     end
 
     test "no diagnostics for keyword partial that exists" do
@@ -89,7 +89,7 @@ module Engine
       diagnostics = render_diagnostics('<%= render partial: "missing/partial" %>')
 
       assert_equal 1, diagnostics.length
-      assert_includes diagnostics.first[:message], "Partial 'missing/partial' could not be resolved"
+      assert_includes diagnostics.first.message, "Partial 'missing/partial' could not be resolved"
     end
 
     test "render validator is not run during normal compilation" do

--- a/test/engine/security_modes_test.rb
+++ b/test/engine/security_modes_test.rb
@@ -35,7 +35,7 @@ module Engine
         Herb::Engine.new(@invalid_nesting_template)
       end
 
-      assert_includes error.message, "InvalidNestingError"
+      assert_includes error.message, "invalid-nesting"
     end
 
     test "nesting validator can be disabled" do
@@ -49,7 +49,7 @@ module Engine
         Herb::Engine.new(@invalid_nesting_template, validators: { security: false })
       end
 
-      assert_includes error.message, "InvalidNestingError"
+      assert_includes error.message, "invalid-nesting"
     end
 
     test "disabling nesting does not disable security" do

--- a/test/engine/validation_modes_test.rb
+++ b/test/engine/validation_modes_test.rb
@@ -35,7 +35,7 @@ module Engine
         Herb::Engine.new(@invalid_nesting_template, validation_mode: :raise)
       end
 
-      assert_includes error.message, "InvalidNestingError"
+      assert_includes error.message, "invalid-nesting"
       assert_includes error.message, "Block element <div> cannot be nested inside <p>"
     end
 

--- a/test/position_test.rb
+++ b/test/position_test.rb
@@ -9,4 +9,22 @@ class PositionTest < Minitest::Spec
     assert_equal({ line: 0, column: 0 }, position.to_hash)
     refute_same position, Herb::Position.zero
   end
+
+  describe "#to_one_based" do
+    test "counts the column from one, the way an editor does" do
+      assert_equal({ line: 3, column: 1 }, Herb::Position.new(3, 0).to_one_based)
+      assert_equal({ line: 3, column: 9 }, Herb::Position.new(3, 8).to_one_based)
+    end
+
+    test "never reports a line before the first one" do
+      assert_equal({ line: 1, column: 1 }, Herb::Position.zero.to_one_based)
+    end
+
+    test "leaves the zero-based serialization alone" do
+      position = Herb::Position.new(3, 8)
+
+      assert_equal({ line: 3, column: 8 }, position.to_hash)
+      assert_equal({ line: 3, column: 8 }, JSON.parse(position.to_json, symbolize_names: true))
+    end
+  end
 end

--- a/test/snapshots/engine/validation_deduplication_test/test_0001_validation_errors_in_ERB_loops_generate_single_template_per_location_527dd13a0a4ec520816dc6bb5f4c7279.txt
+++ b/test/snapshots/engine/validation_deduplication_test/test_0001_validation_errors_in_ERB_loops_generate_single_template_per_location_527dd13a0a4ec520816dc6bb5f4c7279.txt
@@ -7,7 +7,7 @@ _buf = ::String.new; 10.times do |i|
   data-herb-validation-error
   data-severity="error"
   data-source="SecurityValidator"
-  data-code="SecurityViolation"
+  data-code="security-violation"
   data-line="1"
   data-column="26"
   data-filename="loop_test.html.erb"

--- a/test/snapshots/engine/validation_deduplication_test/test_0002_multiple_identical_errors_at_different_locations_generate_separate_templates_3412d8be45b5f990c1e1bff365ae57dc.txt
+++ b/test/snapshots/engine/validation_deduplication_test/test_0002_multiple_identical_errors_at_different_locations_generate_separate_templates_3412d8be45b5f990c1e1bff365ae57dc.txt
@@ -9,7 +9,7 @@ _buf = ::String.new; _buf << '<div '.freeze; _buf << (@bad1).to_s; _buf << '></d
   data-herb-validation-error
   data-severity="error"
   data-source="SecurityValidator"
-  data-code="SecurityViolation"
+  data-code="security-violation"
   data-line="1"
   data-column="5"
   data-filename="multi_test.html.erb"
@@ -56,7 +56,7 @@ _buf = ::String.new; _buf << '<div '.freeze; _buf << (@bad1).to_s; _buf << '></d
   data-herb-validation-error
   data-severity="error"
   data-source="SecurityValidator"
-  data-code="SecurityViolation"
+  data-code="security-violation"
   data-line="2"
   data-column="5"
   data-filename="multi_test.html.erb"
@@ -103,7 +103,7 @@ _buf = ::String.new; _buf << '<div '.freeze; _buf << (@bad1).to_s; _buf << '></d
   data-herb-validation-error
   data-severity="error"
   data-source="SecurityValidator"
-  data-code="SecurityViolation"
+  data-code="security-violation"
   data-line="3"
   data-column="5"
   data-filename="multi_test.html.erb"

--- a/test/snapshots/engine/validation_deduplication_test/test_0003_validation_overlay_includes_deduplication_metadata_617be03c239297032907b0de8f4b03e9.txt
+++ b/test/snapshots/engine/validation_deduplication_test/test_0003_validation_overlay_includes_deduplication_metadata_617be03c239297032907b0de8f4b03e9.txt
@@ -6,7 +6,7 @@ _buf = ::String.new; _buf << '<div '.freeze; _buf << (@test).to_s; _buf << '></d
   data-herb-validation-error
   data-severity="error"
   data-source="SecurityValidator"
-  data-code="SecurityViolation"
+  data-code="security-violation"
   data-line="1"
   data-column="5"
   data-filename="meta_test.html.erb"

--- a/test/snapshots/engine/validation_modes_test/test_0005_overlay_mode_compiles_successfully_with_validation_errors_4546acae1ccf8092d2178e7ce803985e.txt
+++ b/test/snapshots/engine/validation_modes_test/test_0005_overlay_mode_compiles_successfully_with_validation_errors_4546acae1ccf8092d2178e7ce803985e.txt
@@ -6,7 +6,7 @@ _buf = ::String.new; _buf << '<div '.freeze; _buf << (@malicious).to_s; _buf << 
   data-herb-validation-error
   data-severity="error"
   data-source="SecurityValidator"
-  data-code="SecurityViolation"
+  data-code="security-violation"
   data-line="1"
   data-column="5"
   data-filename="unknown"

--- a/test/snapshots/engine/validation_modes_test/test_0008_overlay_mode_includes_filename_in_HTML_f0f5f57b1f0e9b7d0cd2bee98022629a.txt
+++ b/test/snapshots/engine/validation_modes_test/test_0008_overlay_mode_includes_filename_in_HTML_f0f5f57b1f0e9b7d0cd2bee98022629a.txt
@@ -6,7 +6,7 @@ _buf = ::String.new; _buf << '<div '.freeze; _buf << (@malicious).to_s; _buf << 
   data-herb-validation-error
   data-severity="error"
   data-source="SecurityValidator"
-  data-code="SecurityViolation"
+  data-code="security-violation"
   data-line="1"
   data-column="5"
   data-filename="to/template.html.erb"

--- a/test/snapshots/engine/validation_modes_test/test_0009_overlay_mode_with_multiple_validation_errors_e6a7c767c8906df797e04d39ba8f3806.txt
+++ b/test/snapshots/engine/validation_modes_test/test_0009_overlay_mode_with_multiple_validation_errors_e6a7c767c8906df797e04d39ba8f3806.txt
@@ -6,7 +6,7 @@ _buf = ::String.new; _buf << '<div '.freeze; _buf << (@attr).to_s; _buf << ' dat
   data-herb-validation-error
   data-severity="error"
   data-source="SecurityValidator"
-  data-code="SecurityViolation"
+  data-code="security-violation"
   data-line="1"
   data-column="5"
   data-filename="unknown"
@@ -45,7 +45,7 @@ _buf = ::String.new; _buf << '<div '.freeze; _buf << (@attr).to_s; _buf << ' dat
   data-herb-validation-error
   data-severity="error"
   data-source="SecurityValidator"
-  data-code="SecurityViolation"
+  data-code="security-violation"
   data-line="1"
   data-column="23"
   data-filename="unknown"


### PR DESCRIPTION
This pull request introduces `Herb::Diagnostic`, one value object for anything Herb finds worth telling a developer about, and turns reporting into a mixin any visitor can include.

Herb had grown four separate value objects for "a thing that is wrong", each with its own field names and its own way of reaching a reader. A parse error, a security violation, and an accessibility finding had nothing in common at the type level, so every consumer had to know which producer it was talking to. This is the shared layer they can all use:

```ruby
Herb::Diagnostic.new(
  template: "app/views/posts/index.html.erb",
  message: "This element is suspicious.",
  code: "suspicious-element",
  origin: "Herb Compiler",
  severity: :warning,
  location: node.location
)
```

`origin` says who found it and is what a consumer groups by. `severity` is one of `:error`, `:warning`, `:info`, or `:hint`. `kind` is `:diagnostic` by default, or `:metric` for a measurement, which carries a `value` badge instead of a severity.

Reporting used to live on the `Validator` base class, which by definition may not rewrite the tree. That made it impossible for a transforming visitor to report anything, so `ComponentVisitor` could only raise or stay silent. `Herb::Engine::Diagnostics` is a module instead, so any visitor can include it:

```ruby
class SuspiciousElementVisitor < Herb::Visitor
  include Herb::Engine::ContextAware
  include Herb::Engine::Diagnostics

  def visit_html_element_node(node)
    warning("This element is suspicious.", node.location, code: "suspicious-element")

    super
  end
end
```

`error`, `warning`, `info`, and `hint` each record and keep walking. The engine collects from every visitor that responds to `diagnostics` once the visitors have run.
