### PR TITLE
Engine: Run validators as visitors on an ordered `VisitorStack`

### DIFF
--- a/lib/herb/engine.rb
+++ b/lib/herb/engine.rb
@@ -6,6 +6,7 @@ require "time"
 require "pathname"
 
 require_relative "engine/visitor_context"
+require_relative "engine/visitor_stack"
 require_relative "engine/context_aware"
 require_relative "engine/diagnostics"
 require_relative "engine/debug_visitor"
@@ -104,23 +105,16 @@ module Herb
         warn "[Herb] Compile-time optimizations are experimental. Output may differ from standard ActionView rendering."
       end
 
-      @visitors = properties.fetch(:visitors, default_visitors)
-
-      if @debug && @visitors.empty?
-        debug_visitor = DebugVisitor.new(
-          file_path: filename,
-          project_path: project_path
-        )
-
-        @visitors << debug_visitor
-      end
-
-      @parser_options = Herb::Visitor.parser_options_for(@visitors, @parser_options)
-
       unless [:raise, :overlay, :none].include?(@validation_mode)
         raise ArgumentError,
               "validation_mode must be one of :raise, :overlay, or :none, got #{@validation_mode.inspect}"
       end
+
+      @visitors = VisitorStack.build(validation_visitors)
+      @visitors.concat(Array(properties.fetch(:visitors, default_visitors)))
+      @visitors.use(DebugVisitor.new(file_path: filename, project_path: project_path)) if @debug
+
+      @parser_options = Herb::Visitor.parser_options_for(@visitors, @parser_options)
 
       @freeze = properties[:freeze]
       @freeze_template_literals = properties.fetch(:freeze_template_literals, true)
@@ -165,25 +159,13 @@ module Herb
           # Skip both errors and compilation, but still need minimal Ruby code
         end
       else
-        validators = run_validation(ast) unless @validation_mode == :none
-
-        if validators
-          handle_validation_errors(validators, input) if @validation_mode == :raise
-          add_validation_overlay(validators, input) if @validation_mode == :overlay
-        end
-
         @visitors.each do |visitor|
           visitor.inherit_context(@context) if visitor.is_a?(ContextAware)
 
           ast.accept(visitor)
         end
 
-        reporting_visitors = @visitors.select { |visitor| visitor.is_a?(Diagnostics) }
-
-        unless reporting_visitors.empty? || @validation_mode == :none
-          handle_validation_errors(reporting_visitors, input) if @validation_mode == :raise
-          add_validation_overlay(reporting_visitors, input) if @validation_mode == :overlay
-        end
+        report(@visitors.grep(Diagnostics).flat_map(&:diagnostics), input)
 
         compiler = Compiler.new(self, properties)
 
@@ -428,20 +410,15 @@ module Herb
 
     private
 
-    def run_validation(ast)
-      validators = [
+    #: () -> Array[Herb::Engine::Validator]
+    def validation_visitors
+      return [] if @validation_mode == :none
+
+      [
         Validators::SecurityValidator.new(enabled: @enabled_validators[:security]),
         Validators::NestingValidator.new(enabled: @enabled_validators[:nesting]),
         Validators::AccessibilityValidator.new(enabled: @enabled_validators[:accessibility])
-      ]
-
-      validators.select(&:enabled?).each do |validator|
-        validator.inherit_context(@context) if validator.is_a?(ContextAware)
-
-        ast.accept(validator)
-      end
-
-      validators
+      ].select(&:enabled?)
     end
 
     def handle_parser_errors(parser_errors, input, _ast)
@@ -461,13 +438,19 @@ module Herb
       end
     end
 
-    def enabled_reporters(reporters)
-      reporters.reject { |reporter| reporter.respond_to?(:enabled?) && !reporter.enabled? }
+    #: (Array[Herb::Diagnostic], String) -> void
+    def report(diagnostics, input)
+      return if diagnostics.empty?
+
+      case @validation_mode
+      when :raise then raise_for(diagnostics.select(&:error?), input)
+      when :overlay then add_validation_overlay(diagnostics, input)
+      end
     end
 
-    def handle_validation_errors(validators, input)
-      errors = enabled_reporters(validators).flat_map(&:errors)
-      return unless errors.any?
+    #: (Array[Herb::Diagnostic], String) -> void
+    def raise_for(errors, input)
+      return if errors.empty?
 
       security_error = errors.find { |error| error.code == SECURITY_VIOLATION_CODE }
 
@@ -486,8 +469,7 @@ module Herb
       raise CompilationError, "\n#{message}"
     end
 
-    def add_validation_overlay(validators, input = nil)
-      errors = enabled_reporters(validators).flat_map(&:diagnostics)
+    def add_validation_overlay(errors, input = nil)
       return unless errors.any?
 
       templates = errors.map { |error|

--- a/lib/herb/engine/visitor_stack.rb
+++ b/lib/herb/engine/visitor_stack.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+# typed: true
+
+module Herb
+  class Engine
+    # The ordered list of passes the engine runs over a template before it compiles.
+    #
+    # Order is part of the contract rather than an implementation detail. A pass that injects nodes
+    # has to run after one that assigns positions to the nodes already there, and a pass that
+    # annotates the final tree has to run last. An array expresses that only by luck, so this adds
+    # the vocabulary to say it:
+    #
+    #     stack.insert_after(Herb::Engine::SlotVisitor, MyVisitor.new)
+    #
+    # @rbs inherits Array[untyped]
+    class VisitorStack < Array
+      class UnknownVisitorError < ArgumentError; end
+
+      #: (untyped) -> VisitorStack
+      def self.build(visitors)
+        stack = new
+        stack.replace(Array(visitors))
+        stack
+      end
+
+      #: (untyped) -> VisitorStack
+      def use(visitor)
+        push(visitor)
+
+        self
+      end
+
+      # Takes an index, the way `Array#insert` does, or a visitor class to place against.
+      #: ((Integer | Module), *untyped) -> VisitorStack
+      def insert(anchor, *visitors)
+        index = position_of(anchor)
+
+        visitors.reverse_each { |visitor| super(index, visitor) }
+
+        self
+      end
+
+      alias insert_before insert
+
+      #: ((Integer | Module), *untyped) -> VisitorStack
+      def insert_after(anchor, *visitors)
+        index = position_of(anchor) + 1
+
+        visitors.reverse_each { |visitor| insert(index, visitor) }
+
+        self
+      end
+
+      #: (Module) -> bool
+      def include_visitor?(anchor)
+        any? { |visitor| visitor.is_a?(anchor) }
+      end
+
+      private
+
+      #: ((Integer | Module)) -> Integer
+      def position_of(anchor)
+        return anchor if anchor.is_a?(Integer)
+
+        index_of(anchor)
+      end
+
+      #: (Module) -> Integer
+      def index_of(anchor)
+        index = find_index { |visitor| visitor.is_a?(anchor) }
+
+        raise UnknownVisitorError, "no visitor in the stack is a #{anchor}" unless index
+
+        index
+      end
+    end
+  end
+end

--- a/sig/herb/engine.rbs
+++ b/sig/herb/engine.rbs
@@ -101,15 +101,18 @@ module Herb
 
     private
 
-    def run_validation: (untyped ast) -> untyped
+    # : () -> Array[Herb::Engine::Validator]
+    def validation_visitors: () -> Array[Herb::Engine::Validator]
 
     def handle_parser_errors: (untyped parser_errors, untyped input, untyped _ast) -> untyped
 
-    def enabled_reporters: (untyped reporters) -> untyped
+    # : (Array[Herb::Diagnostic], String) -> void
+    def report: (Array[Herb::Diagnostic], String) -> void
 
-    def handle_validation_errors: (untyped validators, untyped input) -> untyped
+    # : (Array[Herb::Diagnostic], String) -> void
+    def raise_for: (Array[Herb::Diagnostic], String) -> void
 
-    def add_validation_overlay: (untyped validators, ?untyped input) -> untyped
+    def add_validation_overlay: (untyped errors, ?untyped input) -> untyped
 
     def escape_attr: (untyped text) -> untyped
 

--- a/sig/herb/engine/visitor_stack.rbs
+++ b/sig/herb/engine/visitor_stack.rbs
@@ -1,0 +1,46 @@
+# Generated from lib/herb/engine/visitor_stack.rb with RBS::Inline
+
+module Herb
+  class Engine
+    # The ordered list of passes the engine runs over a template before it compiles.
+    #
+    # Order is part of the contract rather than an implementation detail. A pass that injects nodes
+    # has to run after one that assigns positions to the nodes already there, and a pass that
+    # annotates the final tree has to run last. An array expresses that only by luck, so this adds
+    # the vocabulary to say it:
+    #
+    #     stack.insert_after(Herb::Engine::SlotVisitor, MyVisitor.new)
+    #
+    # @rbs inherits Array[untyped]
+    class VisitorStack < Array[untyped]
+      class UnknownVisitorError < ArgumentError
+      end
+
+      # : (untyped) -> VisitorStack
+      def self.build: (untyped) -> VisitorStack
+
+      # : (untyped) -> VisitorStack
+      def use: (untyped) -> VisitorStack
+
+      # Takes an index, the way `Array#insert` does, or a visitor class to place against.
+      # : ((Integer | Module), *untyped) -> VisitorStack
+      def insert: (Integer | Module, *untyped) -> VisitorStack
+
+      alias insert_before insert
+
+      # : ((Integer | Module), *untyped) -> VisitorStack
+      def insert_after: (Integer | Module, *untyped) -> VisitorStack
+
+      # : (Module) -> bool
+      def include_visitor?: (Module) -> bool
+
+      private
+
+      # : ((Integer | Module)) -> Integer
+      def position_of: (Integer | Module) -> Integer
+
+      # : (Module) -> Integer
+      def index_of: (Module) -> Integer
+    end
+  end
+end

--- a/test/engine/visitor_stack_test.rb
+++ b/test/engine/visitor_stack_test.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+module Engine
+  class VisitorStackTest < Minitest::Spec
+    class FirstVisitor < Herb::Visitor; end
+    class SecondVisitor < Herb::Visitor; end
+    class ThirdVisitor < Herb::Visitor; end
+
+    def stack
+      @stack ||= Herb::Engine::VisitorStack.build([FirstVisitor.new, SecondVisitor.new])
+    end
+
+    def classes(stack)
+      stack.map(&:class)
+    end
+
+    test "is an Array, because callers already treat it as one" do
+      assert_kind_of Array, stack
+    end
+
+    test "builds from a plain array" do
+      assert_equal [FirstVisitor, SecondVisitor], classes(stack)
+    end
+
+    test "appends with use" do
+      stack.use(ThirdVisitor.new)
+
+      assert_equal [FirstVisitor, SecondVisitor, ThirdVisitor], classes(stack)
+    end
+
+    test "places one before an anchor" do
+      stack.insert_before(SecondVisitor, ThirdVisitor.new)
+
+      assert_equal [FirstVisitor, ThirdVisitor, SecondVisitor], classes(stack)
+    end
+
+    test "places one after an anchor" do
+      stack.insert_after(FirstVisitor, ThirdVisitor.new)
+
+      assert_equal [FirstVisitor, ThirdVisitor, SecondVisitor], classes(stack)
+    end
+
+    test "insert takes an anchor, the way the Rails middleware stack does" do
+      stack.insert(SecondVisitor, ThirdVisitor.new)
+
+      assert_equal [FirstVisitor, ThirdVisitor, SecondVisitor], classes(stack)
+    end
+
+    test "insert still takes an index, the way Array does" do
+      stack.insert(0, ThirdVisitor.new)
+
+      assert_equal [ThirdVisitor, FirstVisitor, SecondVisitor], classes(stack)
+    end
+
+    test "insert still takes several at once, the way Array does" do
+      stack.insert(0, ThirdVisitor.new, ThirdVisitor.new)
+
+      assert_equal [ThirdVisitor, ThirdVisitor, FirstVisitor, SecondVisitor], classes(stack)
+    end
+
+    test "insert_after takes an index too" do
+      stack.insert_after(0, ThirdVisitor.new)
+
+      assert_equal [FirstVisitor, ThirdVisitor, SecondVisitor], classes(stack)
+    end
+
+    test "anchors on the first match" do
+      stack.use(FirstVisitor.new)
+      stack.insert_after(FirstVisitor, ThirdVisitor.new)
+
+      assert_equal [FirstVisitor, ThirdVisitor, SecondVisitor, FirstVisitor], classes(stack)
+    end
+
+    test "anchors on a superclass" do
+      stack.insert_before(Herb::Visitor, ThirdVisitor.new)
+
+      assert_equal [ThirdVisitor, FirstVisitor, SecondVisitor], classes(stack)
+    end
+
+    test "refuses to place against an anchor that is not there" do
+      error = assert_raises(Herb::Engine::VisitorStack::UnknownVisitorError) do
+        stack.insert_after(ThirdVisitor, FirstVisitor.new)
+      end
+
+      assert_includes error.message, "ThirdVisitor"
+    end
+
+    test "reports whether an anchor is present" do
+      assert stack.include_visitor?(FirstVisitor)
+      refute stack.include_visitor?(ThirdVisitor)
+    end
+
+    describe "how the engine composes it" do
+      def compile(**)
+        Herb::Engine.new("<div>Hello</div>", filename: "app/views/test.html.erb", **)
+      end
+
+      test "runs the validators first" do
+        visitors = [
+          Herb::Engine::Validators::SecurityValidator,
+          Herb::Engine::Validators::NestingValidator,
+          Herb::Engine::Validators::AccessibilityValidator
+        ]
+
+        assert_equal(visitors, classes(compile.visitors))
+      end
+
+      test "keeps the validators when the caller passes its own visitors" do
+        engine = compile(visitors: [ThirdVisitor.new])
+
+        assert_equal(3, engine.visitors.count { |visitor| visitor.is_a?(Herb::Engine::Validator) })
+        assert_equal ThirdVisitor, classes(engine.visitors).last
+      end
+
+      test "drops the validators when there is nothing to report to" do
+        assert_empty compile(validation_mode: :none).visitors
+      end
+
+      test "honours a validator turned off in configuration" do
+        engine = compile(validators: { security: false })
+
+        refute engine.visitors.include_visitor?(Herb::Engine::Validators::SecurityValidator)
+        assert engine.visitors.include_visitor?(Herb::Engine::Validators::NestingValidator)
+      end
+
+      test "runs the debug visitor last, so it annotates the finished tree" do
+        engine = compile(visitors: [ThirdVisitor.new], debug: true)
+
+        assert_equal Herb::Engine::DebugVisitor, classes(engine.visitors).last
+      end
+
+      test "adds the debug visitor even when the caller passed its own" do
+        engine = compile(visitors: [ThirdVisitor.new], debug: true)
+
+        assert engine.visitors.include_visitor?(Herb::Engine::DebugVisitor)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This pull request introduces `Herb::Engine::VisitorStack`, an ordered list of visitors that the engine runs, so that validators stop being a separate concept from visitors.

Validators were a parallel mechanism. The engine held a list of them, ran them separately from `visitors:`, and decided on their behalf when they ran. Now they are ordinary visitors in one ordered list, and where they run is something the caller can see and change.

```ruby
stack = Herb::Engine::VisitorStack.new
stack.use(MyVisitor.new)
stack.insert_after(Herb::Engine::Validators::SecurityValidator, MyOtherVisitor.new)
```

`use` appends, `insert` and `insert_after` place a visitor relative to another one by class, and `include_visitor?` asks whether one is already there.
