### PR TITLE
Engine: Emit render tags when `render_nodes` is enabled

### DIFF
--- a/lib/herb/engine/compiler.rb
+++ b/lib/herb/engine/compiler.rb
@@ -321,6 +321,12 @@ module Herb
         visit_erb_block_node(node)
       end
 
+      def visit_erb_render_node(node)
+        return process_erb_tag(node) unless node.end_node
+
+        visit_erb_block_node(node)
+      end
+
       def visit_erb_block_end_node(node, escaped: false)
         remove_trailing_whitespace_from_last_token! if left_trim?(node)
 

--- a/sig/herb/engine/compiler.rbs
+++ b/sig/herb/engine/compiler.rbs
@@ -97,6 +97,8 @@ module Herb
 
       def visit_erb_iteration_block_node: (untyped node) -> untyped
 
+      def visit_erb_render_node: (untyped node) -> untyped
+
       def visit_erb_block_end_node: (untyped node, ?escaped: untyped) -> untyped
 
       def visit_erb_control_with_parts: (untyped node, *untyped parts) -> untyped

--- a/test/engine/render_node_compilation_test.rb
+++ b/test/engine/render_node_compilation_test.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+module Engine
+  class RenderNodeCompilationTest < Minitest::Spec
+    include SnapshotUtils
+
+    RENDER_NODES = { render_nodes: true }.freeze
+
+    def assert_render_node_snapshot(source)
+      assert_compiled_snapshot(source, parser_options: RENDER_NODES)
+    end
+
+    test "emits an inline render" do
+      assert_render_node_snapshot(%(<div><%= render "shared/header" %></div>))
+    end
+
+    test "emits a render with keyword arguments" do
+      assert_render_node_snapshot(%(<%= render partial: "x", locals: { a: 1 } %>))
+    end
+
+    test "emits a render of a model" do
+      assert_render_node_snapshot("<%= render @post %>")
+    end
+
+    test "emits a render that takes a block" do
+      assert_render_node_snapshot(%(<%= render layout: "box" do %>inner<% end %>))
+    end
+
+    test "emits a render in statement position" do
+      assert_render_node_snapshot(%(<% render "silent" %>))
+    end
+
+    test "emits a render inside a loop" do
+      assert_render_node_snapshot(%(<% posts.each do |post| %><%= render post %><% end %>))
+    end
+
+    test "compiles the same whether or not render nodes are on" do
+      source = %(<div><%= render "shared/header" %></div>)
+
+      assert_equal Herb::Engine.new(source).src, Herb::Engine.new(source, parser_options: RENDER_NODES).src
+    end
+  end
+end

--- a/test/snapshots/engine/render_node_compilation_test/test_0001_emits_an_inline_render_8130fb8e2553281495f5740c4d7af765.txt
+++ b/test/snapshots/engine/render_node_compilation_test/test_0001_emits_an_inline_render_8130fb8e2553281495f5740c4d7af765.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::RenderNodeCompilationTest#test_0001_emits an inline render"
+input: "{source: \"<div><%= render \\\"shared/header\\\" %></div>\", options: {parser_options: {render_nodes: true}}}"
+---
+_buf = ::String.new; _buf << '<div>'.freeze; _buf << (render "shared/header").to_s; _buf << '</div>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/render_node_compilation_test/test_0002_emits_a_render_with_keyword_arguments_da4c1dd724deff945b70ed6e1888e1a1.txt
+++ b/test/snapshots/engine/render_node_compilation_test/test_0002_emits_a_render_with_keyword_arguments_da4c1dd724deff945b70ed6e1888e1a1.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::RenderNodeCompilationTest#test_0002_emits a render with keyword arguments"
+input: "{source: \"<%= render partial: \\\"x\\\", locals: { a: 1 } %>\", options: {parser_options: {render_nodes: true}}}"
+---
+_buf = ::String.new; _buf << (render partial: "x", locals: { a: 1 }).to_s;
+_buf.to_s

--- a/test/snapshots/engine/render_node_compilation_test/test_0003_emits_a_render_of_a_model_ee4ba0e38ba24baddcc3241b20dae711.txt
+++ b/test/snapshots/engine/render_node_compilation_test/test_0003_emits_a_render_of_a_model_ee4ba0e38ba24baddcc3241b20dae711.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::RenderNodeCompilationTest#test_0003_emits a render of a model"
+input: "{source: \"<%= render @post %>\", options: {parser_options: {render_nodes: true}}}"
+---
+_buf = ::String.new; _buf << (render @post).to_s;
+_buf.to_s

--- a/test/snapshots/engine/render_node_compilation_test/test_0004_emits_a_render_that_takes_a_block_1c69a75f2e41067ecb1f3af5e4ede0b2.txt
+++ b/test/snapshots/engine/render_node_compilation_test/test_0004_emits_a_render_that_takes_a_block_1c69a75f2e41067ecb1f3af5e4ede0b2.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::RenderNodeCompilationTest#test_0004_emits a render that takes a block"
+input: "{source: \"<%= render layout: \\\"box\\\" do %>inner<% end %>\", options: {parser_options: {render_nodes: true}}}"
+---
+_buf = ::String.new; _buf << (render layout: "box" do; _buf << 'inner'.freeze; end);
+_buf.to_s

--- a/test/snapshots/engine/render_node_compilation_test/test_0005_emits_a_render_in_statement_position_a4a4d5c4b1863281dd707eaf850cf938.txt
+++ b/test/snapshots/engine/render_node_compilation_test/test_0005_emits_a_render_in_statement_position_a4a4d5c4b1863281dd707eaf850cf938.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::RenderNodeCompilationTest#test_0005_emits a render in statement position"
+input: "{source: \"<% render \\\"silent\\\" %>\", options: {parser_options: {render_nodes: true}}}"
+---
+_buf = ::String.new; render "silent" 
+_buf.to_s

--- a/test/snapshots/engine/render_node_compilation_test/test_0006_emits_a_render_inside_a_loop_c7982b2e84a425d4431fa1f6da900e98.txt
+++ b/test/snapshots/engine/render_node_compilation_test/test_0006_emits_a_render_inside_a_loop_c7982b2e84a425d4431fa1f6da900e98.txt
@@ -1,0 +1,7 @@
+---
+source: "Engine::RenderNodeCompilationTest#test_0006_emits a render inside a loop"
+input: "{source: \"<% posts.each do |post| %><%= render post %><% end %>\", options: {parser_options: {render_nodes: true}}}"
+---
+_buf = ::String.new; posts.each do |post| 
+ _buf << (render post).to_s; end;
+_buf.to_s


### PR DESCRIPTION
This pull request fixes `Herb::Engine` dropping every `render` tag when the `render_nodes` parser option is enabled.

With `render_nodes: true` the parser returns `ERBRenderNode` rather than `ERBContentNode` for a render call.

The compiler only handled the case where that node opened a block, so a plain `<%= render %>` compiled to nothing at all and the call disappeared from the output.

```erb
<div><%= render "shared/header" %></div>
```

**Before**

```ruby
_buf = ::String.new; _buf << '<div></div>'.freeze;
_buf.to_s
```

**After**

```ruby
_buf = ::String.new; _buf << '<div>'.freeze; _buf << (render "shared/header").to_s; _buf << '</div>'.freeze;
_buf.to_s
```
