### PR TITLE
Engine: Instrument every ERB tag and measure what each one observed

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -340,48 +340,44 @@ The engine runs validators on templates during compilation. Each validator can b
 - **`nesting`**: Validates HTML nesting rules, such as block elements inside `<p>`, nested anchors, or interactive elements inside `<button>`. _(default: `true`)_
 - **`accessibility`**: Validates accessibility-related attributes. _(default: `true`)_
 
-When a validator is disabled (`false`), the engine skips it entirely during compilation. This applies regardless of the `validation_mode` used by the engine.
+A validator that is disabled (`false`) is not built into the stack that `Herb::Engine::Validators.all` returns, so it never runs.
 
-### Validation Mode
+### Whether a finding refuses to compile
 
-The `validation_mode` controls how the engine handles validation results. This is set programmatically when creating an `Herb::Engine` instance, not in `.herb.yml`:
+Each validator decides that for itself, through `fatal:`, which is set programmatically rather than in `.herb.yml`. A fatal validator aborts compilation when it reports an error. One that is not fatal reports the same thing and lets the template compile, so the page still renders and the finding reaches the browser instead.
 
-- **`:raise`** (default): Raises an exception when validation errors are found
-- **`:overlay`**: Renders validation errors as an in-browser overlay (used by [ReActionView](https://github.com/marcoroth/reactionview) in development)
-- **`:none`**: Skips validation entirely
-
-**Raises on validation errors (default)**
+**Refuses to compile (default)**
 ```ruby
-Herb::Engine.new(source, validation_mode: :raise)
+Herb::Engine.new(source, visitors: Herb::Engine::Validators.all)
 ```
 
-**Shows errors as in-browser overlay**
+**Reports and lets the template compile**
 ```ruby
-Herb::Engine.new(source, validation_mode: :overlay)
+Herb::Engine.new(source, visitors: Herb::Engine::Validators.all(fatal: false))
 ```
 
-**Skips all validation**
+**Runs no validators at all**
 ```ruby
-Herb::Engine.new(source, validation_mode: :none)
+Herb::Engine.new(source)
 ```
+
+The engine validates nothing on its own, so leaving the validators out is all it takes to skip them.
 
 ### Overriding Validators Programmatically
 
-Validator settings from `.herb.yml` can be overridden when creating an engine instance:
+Validator settings from `.herb.yml` can be overridden when asking for the set:
 
 **Disable security validator for this template only**
 ```ruby
-Herb::Engine.new(source, validators: { security: false })
+Herb::Engine.new(source, visitors: Herb::Engine::Validators.all(security: false))
 ```
 
-**Disable all validators**
+**Pick the validators directly, ignoring `.herb.yml`**
 ```ruby
-Herb::Engine.new(source, validators: {
-  security: false,
-  nesting: false,
-  accessibility: false,
-})
+Herb::Engine.new(source, visitors: [Herb::Engine::Validators::NestingValidator.new])
 ```
+
+See [`Herb::Engine` validators](/projects/engine#validators) for the full set and how to order them.
 
 ## Formatter Configuration
 

--- a/docs/docs/projects/engine.md
+++ b/docs/docs/projects/engine.md
@@ -41,15 +41,13 @@ In addition to Erubi options, `Herb::Engine` supports:
 
 | Option            | Default   | Description                                                                           |
 |-------------------|-----------|---------------------------------------------------------------------------------------|
-| `validation_mode` | `:raise`  | How to handle validation errors: `:raise`, `:overlay`, or `:none`                     |
-| `validators`      | `{}`      | Per-validator overrides (e.g., `{ security: false }`)                                 |
 | `parser_options`  | `{}`      | [Parser options](/parser-options) forwarded to the parser (e.g., `{ strict: false }`) |
 | `visitors`        | `[]`      | AST visitors to run before compilation                                                |
-| `context`         | `{}`      | Extra keys to pass through to the visitors (see [Visitor context](#visitor-context))   |
+| `context`         | `{}`      | Extra keys to pass through to the visitors (see [Visitor context](#visitor-context))  |
 | `project_path`    | `Dir.pwd` | Project root for relative path resolution                                             |
 | `validate_ruby`   | `false`   | Raise if the compiled output isn't valid Ruby                                         |
-| `optimize`        | `false`   | Compile-time optimizations for Action View helpers (experimental)                     |
-| `debug`           | `false`   | Enable debug mode                                                                     |
+
+The engine compiles whatever passes it is given and holds no opinion beyond that. Validation, debug annotations, and Action View optimizations are all visitors you pass in `visitors`, so there is no option to turn any of them on.
 
 Strict parsing is a parser option rather than an engine option, so it is set through `parser_options`, together with any other [parser option](/parser-options):
 
@@ -59,28 +57,70 @@ Herb::Engine.new(source, parser_options: { strict: false })
 
 ## Validators
 
-The engine runs validators on parsed templates to catch errors before compilation. Each validator can be enabled or disabled via [`.herb.yml` configuration](/configuration#engine-configuration) or per-instance overrides.
+Validators check a parsed template and report what they find. They are ordinary visitors, so nothing runs unless you pass it.
 
-| Validator     | Description                                                                   |
-|---------------|-------------------------------------------------------------------------------|
-| Security      | Detects ERB output in unsafe positions (attribute names, attribute positions) |
-| Nesting       | Validates HTML nesting rules (e.g., no `<div>` inside `<p>`)                  |
-| Accessibility | Validates accessibility-related attributes                                    |
+| Validator                | Description                                                                   |
+|--------------------------|-------------------------------------------------------------------------------|
+| `SecurityValidator`      | Detects ERB output in unsafe positions (attribute names, attribute positions) |
+| `NestingValidator`       | Validates HTML nesting rules (e.g., no `<div>` inside `<p>`)                  |
+| `AccessibilityValidator` | Validates accessibility-related attributes                                    |
+| `RenderValidator`        | Validates `render` calls                                                      |
 
-Disable security validator for this template:
+`Validators.all` builds the set a project has switched on in [`.herb.yml`](/configuration#engine-configuration), which is the usual way to ask for them:
+
 ```ruby
-Herb::Engine.new(source, validators: { security: false })
+require "herb/engine/validators"
+
+Herb::Engine.new(source, visitors: Herb::Engine::Validators.all)
 ```
 
-See [Engine Configuration](/configuration#engine-configuration) for `.herb.yml` configuration.
+It takes the same per-validator overrides, so a template can opt out of one:
 
-## Validation Mode
+```ruby
+Herb::Engine.new(source, visitors: Herb::Engine::Validators.all(security: false))
+```
 
-Controls how the engine presents validation results:
+A caller that already knows what it wants can skip the configuration lookup and name them directly.
 
-- **`:raise`** — Raises `SecurityError` or `CompilationError` (default, used in tests and CLI)
-- **`:overlay`** — Renders errors as in-browser overlay (used by [ReActionView](https://github.com/marcoroth/reactionview) in development)
-- **`:none`** — Skips validation entirely
+```ruby
+require "herb/engine/validators/security_validator"
+
+Herb::Engine.new(source, visitors: [Herb::Engine::Validators::SecurityValidator.new])
+```
+
+### Whether a finding refuses to compile
+
+Each validator decides that for itself, through `fatal:`. A fatal validator aborts compilation when it reports an error. One that is not fatal reports the same thing and lets the template compile, so the page still renders and the finding reaches the browser instead.
+
+```ruby
+Herb::Engine::Validators.all(fatal: false)
+```
+
+Validators are fatal by default. Which exception gets raised is the validator's own choice rather than something the engine infers from its class name, so `SecurityValidator` aborts with `Herb::Engine::SecurityError` while a validator that names no exception aborts with `Herb::Engine::CompilationError`.
+
+Because this is decided per validator rather than per engine, one compile can mix the two. Security problems can refuse to compile while accessibility findings only get reported:
+
+```ruby
+Herb::Engine.new(
+  source,
+  visitors: [
+    Herb::Engine::Validators::SecurityValidator.new(fatal: true),
+    Herb::Engine::Validators::AccessibilityValidator.new(fatal: false)
+  ]
+)
+```
+
+### Ordering
+
+`Validators.all` returns a `Herb::Engine::VisitorStack`, an ordered list that also accepts anything else you want to run:
+
+```ruby
+stack = Herb::Engine::Validators.all
+stack.use(MyVisitor.new)
+stack.insert_after(Herb::Engine::Validators::SecurityValidator, MyOtherVisitor.new)
+```
+
+`use` appends, `insert` and `insert_after` place a visitor relative to another one by class, and `include_visitor?` asks whether one is already there. Naming a class that is not in the stack raises `Herb::Engine::VisitorStack::UnknownVisitorError` rather than putting it somewhere arbitrary.
 
 ## Transform Visitors
 
@@ -88,12 +128,15 @@ The `visitors` option accepts [visitors](/bindings/ruby/reference#visitors) that
 
 Herb ships the following transform visitors:
 
-| Visitor                       | Description                                                  |
-|-------------------------------|--------------------------------------------------------------|
-| `AutoCloseOmittedTagsVisitor` | Replaces omitted closing tags with explicit ones             |
-| `ContentForVisitor`           | Appends HTML to the end of every matching element            |
-| `HTMLSafeAssertionsVisitor`   | Checks every `.html_safe` call at runtime                    |
-| `ComponentVisitor`            | Rewrites capitalized tags into `render` calls (experimental) |
+| Visitor                       | Description                                                             |
+|-------------------------------|-------------------------------------------------------------------------|
+| `AutoCloseOmittedTagsVisitor` | Replaces omitted closing tags with explicit ones                        |
+| `ContentForVisitor`           | Appends HTML to the end of every matching element                       |
+| `HTMLSafeAssertionsVisitor`   | Checks every `.html_safe` call at runtime                               |
+| `ComponentVisitor`            | Rewrites capitalized tags into `render` calls (experimental)            |
+| `DebugVisitor`                | Annotates output with the template and position it came from            |
+| `OptimizeVisitor`             | Compile-time optimizations for Action View helpers (experimental)       |
+| `InstrumentationVisitor`      | Frames every ERB tag so a render can be attributed to it (experimental) |
 
 Transform visitors are not loaded when you `require "herb"`. Require the ones you want and pass them to the engine:
 
@@ -436,11 +479,127 @@ A partial with a body is rendered as a layout, so the body reaches the partial t
 <%= render layout: "users/card", locals: { title: "Hello" } do %>Body<% end %>
 ```
 
+## Diagnostics
+
+Anything the engine or a visitor finds is a `Herb::Diagnostic`, whoever found it and whenever they found it. One value object means a parse error, a security violation, and a measurement taken while the page rendered all reach the browser through the same channel, so a new checker gets delivery without inventing one.
+
+```ruby
+Herb::Diagnostic.new(
+  template: "app/views/posts/index.html.erb",
+  message: "This element is suspicious.",
+  code: "suspicious-element",
+  origin: "Herb Compiler",
+  severity: :warning,
+  location: node.location
+)
+```
+
+`origin` says who found it and is what a consumer groups by. `severity` is one of `:error`, `:warning`, `:info`, or `:hint`. `kind` is `:diagnostic` by default, or `:metric` for a measurement, which carries a `value` badge instead of a severity.
+
+Positions are Herb-native, counting lines from one and columns from zero, the same as everywhere else in Herb. The payload counts columns from one, and that shift happens in exactly one place, so a diagnostic built straight from a node needs no adjusting.
+
+### Reporting from a visitor
+
+Any visitor can report by including `Herb::Engine::Diagnostics`. It is a mixin rather than a base class, so a visitor that rewrites the tree can report as well:
+
+```ruby
+class SuspiciousElementVisitor < Herb::Visitor
+  include Herb::Engine::ContextAware
+  include Herb::Engine::Diagnostics
+
+  def visit_html_element_node(node)
+    warning("This element is suspicious.", node.location, code: "suspicious-element")
+
+    super
+  end
+end
+```
+
+`error`, `warning`, `info`, and `hint` each record and keep walking. The engine collects from every visitor that responds to `diagnostics` once the visitors have run, so reporting needs no wiring beyond including the mixin. `ContextAware` is what fills in the template name, because the engine hands every context-aware visitor its `VisitorContext`.
+
+Findings recorded this way are compiled into the template, so they reach the browser when it renders rather than being spliced into the HTML at compile time.
+
+### Delivering them to the browser
+
+A `Herb::Engine::Report::Session` is where everything found while one page renders collects, so findings from separate producers end up in one payload rather than one channel each. `Herb::Engine::Report::Middleware` scopes one to each request and injects the result:
+
+```ruby
+require "herb/engine/report/middleware"
+
+config.middleware.use Herb::Engine::Report::Middleware
+```
+
+It writes a single `data-herb-diagnostics` script before `</body>`. A response it cannot safely touch is returned untouched, and any error while injecting is swallowed in favour of the original response, so nothing here can be the reason a page fails.
+
+The session it used is left in the Rack env, which is how a test reads what a request collected:
+
+```ruby
+get "/posts"
+
+request.env[Herb::Engine::Report::Middleware::ENV_KEY].diagnostics
+```
+
+Wrapping a request works too. A session that is already open is one somebody means to read, so the middleware collects into that one rather than opening its own:
+
+```ruby
+session = Herb::Engine::Report::Session.capture { get "/posts" }
+```
+
+## Instrumentation <Badge type="warning" text="experimental" />
+
+`InstrumentationVisitor` frames every ERB tag with a call saying which tag is rendering, so whatever happens while it renders can be attributed to it rather than to the template as a whole.
+
+It supplies where, and something else has to supply what. A template compiled with it and rendered with nothing watching records nothing at all, and only costs a call per tag. What makes it worth having is anything that calls `Herb::Engine::Report::Session.observe` while a tag is rendering:
+
+```ruby
+require "herb/engine/instrumentation_visitor"
+
+engine = Herb::Engine.new(source, visitors: [Herb::Engine::InstrumentationVisitor.new])
+
+ActiveSupport::Notifications.subscribe("sql.active_record") do |*, payload|
+  Herb::Engine::Report::Session.observe(:queries, payload[:sql]) unless payload[:cached]
+end
+```
+
+Nothing about that subscription belongs to Herb, which is the point. Because what gets watched is decided at render time rather than compiled in, watching something new never means recompiling a template.
+
+`Session#measure` turns what was observed into one diagnostic per tag that saw any:
+
+```ruby
+session.measure(:queries, origin: "Herb Engine", code: "sql-queries") do |queries|
+  "#{queries.size} SQL queries"
+end
+#=> app/views/posts/_card.html.erb:7:9: [sql-queries] 3 SQL queries
+```
+
+A count is a measurement rather than a fault, so what comes out carries a badge and no severity. Three queries at one tag is worth showing every time and worth worrying about only sometimes, and which of those it is depends on what the tag is for.
+
+### The render stack
+
+A tag that renders a partial stays open while that partial renders, so `Session.stack` is a render stack across every instrumented template and not only within one. It reads innermost first, the way `caller` does:
+
+```ruby
+Herb::Engine::Report::Session.stack
+#=> [["app/views/posts/_card.html.erb", 2, 2],
+#    ["app/views/posts/index.html.erb", 4, 4],
+#    ["app/views/layouts/application.html.erb", 2, 2]]
+```
+
+Each frame is `[template, line, column]`, with the column counted from zero as everywhere else in the AST. A template compiled without the visitor contributes no frames, so an uninstrumented partial part-way down a chain is skipped rather than showing as a gap.
+
+An observation is only filed under the innermost frame, so anything wanting the rest has to take it while it still exists, which is one line in the subscriber:
+
+```ruby
+Herb::Engine::Report::Session.observe(:queries, { sql: sql, stack: Herb::Engine::Report::Session.stack })
+```
+
+Instrumentation is experimental as it instruments every ERB tag.
+
 ## ReActionView Integration
 
-[ReActionView](https://github.com/marcoroth/reactionview) registers `Herb::Engine` as the template handler for `.html.erb` and `.html.herb` files in Rails. It uses `validation_mode: :overlay` so validation errors appear as in-browser overlays during development instead of raising exceptions.
+[ReActionView](https://github.com/marcoroth/reactionview) registers `Herb::Engine` as the template handler for `.html.erb` and `.html.herb` files in Rails. It runs the validators with `fatal: false` in development, so problems reach the browser instead of raising and the page still renders.
 
-Validator settings from `.herb.yml` are respected automatically — no ReActionView-specific configuration needed.
+Validator settings from `.herb.yml` are respected automatically, with no ReActionView-specific configuration needed.
 
 ReActionView also lets you run transform visitors on every template it compiles, through `config.transform_visitors`:
 

--- a/lib/herb/engine.rb
+++ b/lib/herb/engine.rb
@@ -7,7 +7,6 @@ require "pathname"
 
 require_relative "engine/visitor_context"
 require_relative "engine/visitor_stack"
-require_relative "engine/report"
 require_relative "engine/report/session"
 require_relative "engine/context_aware"
 require_relative "engine/diagnostics"

--- a/lib/herb/engine/instrumentation_visitor.rb
+++ b/lib/herb/engine/instrumentation_visitor.rb
@@ -1,0 +1,200 @@
+# frozen_string_literal: true
+# typed: false
+
+require_relative "../visitor"
+require_relative "context_aware"
+
+module Herb
+  class Engine
+    # Wraps every ERB tag in a call that says which tag is rendering, so that whatever happens
+    # while it renders can be attributed to it rather than to the template as a whole.
+    #
+    # This is half of a mechanism and does nothing by itself. It supplies where, and something else
+    # has to supply what. A template compiled with it and rendered with nothing watching records no
+    # entries at all, and only costs a call per tag. What makes it worth having is anything that
+    # calls `Herb::Engine::Report::Session.observe` while a tag is rendering:
+    #
+    #     require "herb/engine/instrumentation_visitor"
+    #
+    #     engine = Herb::Engine.new(source, visitors: [Herb::Engine::InstrumentationVisitor.new])
+    #
+    #     ActiveSupport::Notifications.subscribe("sql.active_record") do |*, payload|
+    #       Herb::Engine::Report::Session.observe(:queries, payload[:sql]) unless payload[:cached]
+    #     end
+    #
+    #     session = Herb::Engine::Report::Session.capture { render(engine.src) }
+    #
+    #     session.measure(:queries, origin: "Herb Engine", code: "sql-queries") do |queries|
+    #       "#{queries.size} SQL queries"
+    #     end
+    #     #=> app/views/posts/_card.html.erb:7:8: [sql-queries] 3 SQL queries
+    #
+    # Nothing about that subscription is Herb's, which is the point. Because what gets watched is
+    # decided at render time rather than compiled in, adding a producer never means recompiling a
+    # template, and Herb never has to ship a class per thing worth watching.
+    #
+    # A tag that opens a block, or that assigns to a local, is framed from the outside rather than
+    # wrapped, because wrapping either one would change what the template means: a block would lose
+    # its body, and an assignment would bind inside the wrapper instead of the template.
+    class InstrumentationVisitor < Herb::Visitor
+      include ContextAware
+
+      SESSION = "::Herb::Engine::Report::Session"
+
+      ASSIGNMENT_NODES = [
+        :LocalVariableWriteNode,
+        :LocalVariableOperatorWriteNode,
+        :LocalVariableOrWriteNode,
+        :LocalVariableAndWriteNode,
+        :MultiWriteNode
+      ].freeze
+
+      ARRAY_PROPERTIES = [:children, :body, :statements].freeze
+      NODE_PROPERTIES = [:subsequent, :else_clause, :rescue_clause, :ensure_clause].freeze
+
+      # @rbs!
+      #   def self.experimental_warning_issued: () -> bool
+      #   def self.experimental_warning_issued=: (bool) -> bool
+
+      class << self
+        attr_accessor :experimental_warning_issued #: bool
+      end
+
+      self.experimental_warning_issued = false
+
+      def initialize
+        super
+
+        return if self.class.experimental_warning_issued
+
+        self.class.experimental_warning_issued = true
+
+        warn "[Herb] Instrumentation is experimental. It instruments every ERB tag and is not meant for production."
+      end
+
+      def visit_document_node(node)
+        super
+
+        instrument(node)
+      end
+
+      def inspect
+        "#<#{self.class.name}>"
+      end
+
+      private
+
+      def instrument(node)
+        ARRAY_PROPERTIES.each do |property|
+          next unless node.respond_to?(property) && node.send(property).is_a?(Array)
+
+          rewrite(node.send(property))
+        end
+
+        NODE_PROPERTIES.each do |property|
+          next unless node.respond_to?(property) && node.send(property)
+
+          instrument(node.send(property))
+        end
+      end
+
+      def rewrite(nodes)
+        rewritten = nodes.flat_map { |node|
+          instrument(node)
+
+          if framed?(node)
+            [enter_node(node), node, leave_node(node)]
+          elsif output?(node)
+            [wrapped_output(node)]
+          elsif statement?(node)
+            [wrapped_statement(node)]
+          else
+            [node]
+          end
+        }
+
+        nodes.replace(rewritten)
+      end
+
+      def output?(node)
+        node.is_a?(Herb::AST::ERBContentNode) && opening(node).start_with?("<%=")
+      end
+
+      def statement?(node)
+        return false unless node.is_a?(Herb::AST::ERBContentNode)
+
+        opening = opening(node)
+
+        opening.start_with?("<%") && !opening.start_with?("<%=", "<%#")
+      end
+
+      def framed?(node)
+        block?(node) || (output?(node) && assignment?(node))
+      end
+
+      def assignment?(node)
+        return false unless node.respond_to?(:parsed_prism_node)
+        return false unless defined?(::Prism)
+
+        parsed = node.parsed_prism_node
+
+        return false unless parsed
+
+        ASSIGNMENT_NODES.any? { |name| ::Prism.const_defined?(name) && parsed.is_a?(::Prism.const_get(name)) }
+      rescue StandardError
+        false
+      end
+
+      def block?(node)
+        return false if node.is_a?(Herb::AST::ERBRenderNode)
+        return false unless node.respond_to?(:end_node)
+
+        !node.end_node.nil?
+      end
+
+      def opening(node)
+        return "" unless node.respond_to?(:tag_opening)
+
+        node.tag_opening&.value.to_s
+      end
+
+      def wrapped_output(node)
+        erb_node(node, "<%=", "#{SESSION}.at(#{position(node)}) {\n#{code(node)}\n}")
+      end
+
+      def wrapped_statement(node)
+        erb_node(node, "<%", "#{SESSION}.enter(#{position(node)}); begin\n#{code(node)}\nensure; #{SESSION}.leave; end")
+      end
+
+      def enter_node(node)
+        erb_node(node, "<%", "#{SESSION}.enter(#{position(node)})")
+      end
+
+      def leave_node(node)
+        erb_node(node, "<%", "#{SESSION}.leave")
+      end
+
+      def position(node)
+        location = node.location
+
+        [context.relative_file_path.dump, location.start.line, location.start.column].join(", ")
+      end
+
+      def code(node)
+        return "" unless node.respond_to?(:content)
+
+        node.content&.value.to_s.strip
+      end
+
+      def erb_node(node, opening, code)
+        Herb::AST::ERBContentNode.build(
+          tag_opening: Herb::Token.from("TOKEN_ERB_START", opening),
+          content: Herb::Token.from("TOKEN_ERB_CONTENT", " #{code} "),
+          tag_closing: Herb::Token.from("TOKEN_ERB_END", "%>"),
+          valid: true,
+          location: node.location
+        )
+      end
+    end
+  end
+end

--- a/lib/herb/engine/instrumentation_visitor.rb
+++ b/lib/herb/engine/instrumentation_visitor.rb
@@ -69,7 +69,7 @@ module Herb
 
         self.class.experimental_warning_issued = true
 
-        warn "[Herb] Instrumentation is experimental. It instruments every ERB tag and is not meant for production."
+        warn "[Herb] Instrumentation is experimental as it instruments every ERB tag."
       end
 
       def visit_document_node(node)

--- a/lib/herb/engine/report/entry.rb
+++ b/lib/herb/engine/report/entry.rb
@@ -47,8 +47,9 @@ module Herb
         #: () -> String
         def to_s
           summary = observations.map { |key, values| "#{values.size} #{key}" }.join(", ")
+          position = location.start.to_one_based
 
-          "#{template || "(unknown)"}:#{line}:#{column} (#{summary})"
+          "#{template || "(unknown)"}:#{position[:line]}:#{position[:column]} (#{summary})"
         end
       end
     end

--- a/lib/herb/engine/report/entry.rb
+++ b/lib/herb/engine/report/entry.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+# typed: true
+
+module Herb
+  class Engine
+    class Report
+      # What was observed at one position in one template while it rendered.
+      #
+      # A collector puts things here by name, so several can share a position without knowing about
+      # each other: a query count and a render time sit side by side under different keys.
+      class Entry
+        attr_reader :template #: String?
+        attr_reader :line #: Integer
+        attr_reader :column #: Integer
+        attr_reader :observations #: Hash[Symbol, Array[untyped]]
+
+        #: (String?, Integer, Integer) -> void
+        def initialize(template, line, column)
+          @template = template
+          @line = line
+          @column = column
+          @observations = {} #: Hash[Symbol, Array[untyped]]
+        end
+
+        #: (Symbol, untyped) -> void
+        def observe(key, value)
+          (observations[key] ||= []) << value
+
+          nil
+        end
+
+        #: (Symbol) -> Array[untyped]
+        def [](key)
+          observations.fetch(key, [])
+        end
+
+        #: () -> bool
+        def empty?
+          observations.empty?
+        end
+
+        #: () -> Herb::Location
+        def location
+          Herb::Location.from(line, column, line, column)
+        end
+
+        #: () -> String
+        def to_s
+          summary = observations.map { |key, values| "#{values.size} #{key}" }.join(", ")
+
+          "#{template || "(unknown)"}:#{line}:#{column} (#{summary})"
+        end
+      end
+    end
+  end
+end

--- a/lib/herb/engine/report/middleware.rb
+++ b/lib/herb/engine/report/middleware.rb
@@ -20,6 +20,15 @@ module Herb
         HTML_CONTENT_TYPE = %r{\Atext/html}i #: Regexp
         BODY_END_TAG = %r{</body>}i #: Regexp
 
+        # Where the session for this request is left, so that anything holding the env can read what
+        # the page collected.
+        #
+        #     get "/posts"
+        #
+        #     request.env[Herb::Engine::Report::Middleware::ENV_KEY].entries
+        #
+        ENV_KEY = "herb.report_session" #: String
+
         #: (untyped, ?inject: bool) -> void
         def initialize(app, inject: true)
           @app = app
@@ -28,7 +37,11 @@ module Herb
 
         #: (untyped) -> untyped
         def call(env)
-          session = Session.open
+          borrowed = Session.scoped?
+          session = borrowed ? Session.current : Session.open
+
+          env[ENV_KEY] = session if env.respond_to?(:[]=)
+
           response = @app.call(env)
 
           return response unless @inject
@@ -36,7 +49,7 @@ module Herb
 
           inject(response, session.report)
         ensure
-          Session.close
+          Session.close unless borrowed
         end
 
         private

--- a/lib/herb/engine/report/session.rb
+++ b/lib/herb/engine/report/session.rb
@@ -2,6 +2,7 @@
 # typed: true
 
 require_relative "../report"
+require_relative "entry"
 
 module Herb
   class Engine
@@ -68,6 +69,30 @@ module Herb
           nil
         end
 
+        #: [T] (String?, Integer, Integer) { () -> T } -> T
+        def self.at(template, line, column)
+          enter(template, line, column)
+
+          yield
+        ensure
+          leave
+        end
+
+        #: (String?, Integer, Integer) -> void
+        def self.enter(template, line, column)
+          current.enter(template, line, column)
+        end
+
+        #: () -> void
+        def self.leave
+          current.leave
+        end
+
+        #: (Symbol, untyped) -> void
+        def self.observe(key, value)
+          current.observe(key, value)
+        end
+
         #: (String, String?) -> void
         def self.source(template, source)
           current.source(template, source)
@@ -87,6 +112,8 @@ module Herb
         def initialize(scoped: false, report: nil, previous: nil)
           @scoped = scoped
           @report = report || Report.new
+          @frames = [] #: Array[Array[untyped]]
+          @entries = {} #: Hash[Array[untyped], Herb::Engine::Report::Entry]
           @previous = previous
         end
 
@@ -112,7 +139,38 @@ module Herb
 
         #: () -> bool
         def empty?
-          report.empty?
+          report.empty? && entries.empty?
+        end
+
+        #: (String?, Integer, Integer) -> void
+        def enter(template, line, column)
+          @frames.push([template, line, column])
+
+          nil
+        end
+
+        #: () -> void
+        def leave
+          @frames.pop
+
+          nil
+        end
+
+        #: (Symbol, untyped) -> void
+        def observe(key, value)
+          frame = @frames.last
+
+          return unless frame
+
+          entry = (@entries[frame] ||= Entry.new(frame[0], frame[1], frame[2]))
+          entry.observe(key, value)
+
+          nil
+        end
+
+        #: () -> Array[Herb::Engine::Report::Entry]
+        def entries
+          @entries.values.sort_by { |entry| [entry.template.to_s, entry.line, entry.column] }
         end
       end
     end

--- a/lib/herb/engine/report/session.rb
+++ b/lib/herb/engine/report/session.rb
@@ -172,6 +172,46 @@ module Herb
         def entries
           @entries.values.sort_by { |entry| [entry.template.to_s, entry.line, entry.column] }
         end
+
+        # Turns what was observed under one key into one diagnostic per tag that saw any.
+        #
+        #     ActiveSupport::Notifications.subscribe("sql.active_record") do |*, payload|
+        #       Herb::Engine::Report::Session.observe(:queries, payload[:sql]) unless payload[:cached]
+        #     end
+        #
+        #     session.measure(:queries, origin: "Herb Engine", code: "sql-queries") do |queries|
+        #       "#{queries.size} SQL queries"
+        #     end
+        #
+        # A count is a measurement rather than a fault, so what comes out carries a badge and no
+        # severity. Three queries at one tag is worth showing every time and worth worrying about
+        # only sometimes, and which of those it is depends on what the tag is for. Reporting it as a
+        # warning would make that call on the reader's behalf and get it wrong often enough to train
+        # them to ignore it.
+        #: (Symbol, origin: String, ?code: String?, ?message: String?) { (Array[untyped]) -> String } -> Array[Herb::Diagnostic]
+        def measure(key, origin:, code: nil, message: nil)
+          entries.filter_map { |entry|
+            observed = entry[key]
+
+            next if observed.empty?
+
+            value = yield(observed)
+
+            record(
+              Herb::Diagnostic.new(
+                template: entry.template.to_s,
+                message: message || value,
+                severity: nil,
+                kind: :metric,
+                origin: origin,
+                code: code,
+                location: entry.location,
+                value: value,
+                data: { key => observed }
+              )
+            )
+          }
+        end
       end
     end
   end

--- a/lib/herb/engine/report/session.rb
+++ b/lib/herb/engine/report/session.rb
@@ -93,6 +93,11 @@ module Herb
           current.observe(key, value)
         end
 
+        #: () -> Array[Array[untyped]]
+        def self.stack
+          current.stack
+        end
+
         #: (String, String?) -> void
         def self.source(template, source)
           current.source(template, source)
@@ -154,6 +159,23 @@ module Herb
           @frames.pop
 
           nil
+        end
+
+        # Every tag still rendering, innermost first, the way `caller` reads.
+        #
+        # A tag that renders a partial is still open while the partial renders, so once more than one
+        # template is instrumented this is a render stack across all of them and not just within one.
+        # Only the innermost frame is what an observation is filed under, so anything wanting the rest
+        # has to take it while it still exists:
+        #
+        #     ActiveSupport::Notifications.subscribe("sql.active_record") do |*, payload|
+        #       Herb::Engine::Report::Session.observe(:queries, { sql: payload[:sql], stack: Herb::Engine::Report::Session.stack })
+        #     end
+        #
+        # Taking it costs an array per observation, which is why it is offered rather than recorded.
+        #: () -> Array[Array[untyped]]
+        def stack
+          @frames.reverse.map(&:dup)
         end
 
         #: (Symbol, untyped) -> void

--- a/sig/herb/engine/instrumentation_visitor.rbs
+++ b/sig/herb/engine/instrumentation_visitor.rbs
@@ -1,0 +1,91 @@
+# Generated from lib/herb/engine/instrumentation_visitor.rb with RBS::Inline
+
+module Herb
+  class Engine
+    # Wraps every ERB tag in a call that says which tag is rendering, so that whatever happens
+    # while it renders can be attributed to it rather than to the template as a whole.
+    #
+    # This is half of a mechanism and does nothing by itself. It supplies where, and something else
+    # has to supply what. A template compiled with it and rendered with nothing watching records no
+    # entries at all, and only costs a call per tag. What makes it worth having is anything that
+    # calls `Herb::Engine::Report::Session.observe` while a tag is rendering:
+    #
+    #     require "herb/engine/instrumentation_visitor"
+    #
+    #     engine = Herb::Engine.new(source, visitors: [Herb::Engine::InstrumentationVisitor.new])
+    #
+    #     ActiveSupport::Notifications.subscribe("sql.active_record") do |*, payload|
+    #       Herb::Engine::Report::Session.observe(:queries, payload[:sql]) unless payload[:cached]
+    #     end
+    #
+    #     session = Herb::Engine::Report::Session.capture { render(engine.src) }
+    #
+    #     session.measure(:queries, origin: "Herb Engine", code: "sql-queries") do |queries|
+    #       "#{queries.size} SQL queries"
+    #     end
+    #     #=> app/views/posts/_card.html.erb:7:8: [sql-queries] 3 SQL queries
+    #
+    # Nothing about that subscription is Herb's, which is the point. Because what gets watched is
+    # decided at render time rather than compiled in, adding a producer never means recompiling a
+    # template, and Herb never has to ship a class per thing worth watching.
+    #
+    # A tag that opens a block, or that assigns to a local, is framed from the outside rather than
+    # wrapped, because wrapping either one would change what the template means: a block would lose
+    # its body, and an assignment would bind inside the wrapper instead of the template.
+    class InstrumentationVisitor < Herb::Visitor
+      include ContextAware
+
+      SESSION: ::String
+
+      ASSIGNMENT_NODES: untyped
+
+      ARRAY_PROPERTIES: untyped
+
+      NODE_PROPERTIES: untyped
+
+      def self.experimental_warning_issued: () -> bool
+
+      def self.experimental_warning_issued=: (bool) -> bool
+
+      attr_accessor experimental_warning_issued: bool
+
+      def initialize: () -> untyped
+
+      def visit_document_node: (untyped node) -> untyped
+
+      def inspect: () -> untyped
+
+      private
+
+      def instrument: (untyped node) -> untyped
+
+      def rewrite: (untyped nodes) -> untyped
+
+      def output?: (untyped node) -> untyped
+
+      def statement?: (untyped node) -> untyped
+
+      def framed?: (untyped node) -> untyped
+
+      def assignment?: (untyped node) -> untyped
+
+      def block?: (untyped node) -> untyped
+
+      def opening: (untyped node) -> untyped
+
+      def wrapped_output: (untyped node) -> untyped
+
+      def wrapped_statement: (untyped node) -> untyped
+
+      def enter_node: (untyped node) -> untyped
+
+      def leave_node: (untyped node) -> untyped
+
+      def position: (untyped node) -> untyped
+
+      def code: (untyped node) -> untyped
+
+      def erb_node: (untyped node, untyped opening, untyped code) -> untyped
+    end
+  end
+end

--- a/sig/herb/engine/report/entry.rbs
+++ b/sig/herb/engine/report/entry.rbs
@@ -1,0 +1,39 @@
+# Generated from lib/herb/engine/report/entry.rb with RBS::Inline
+
+module Herb
+  class Engine
+    class Report
+      # What was observed at one position in one template while it rendered.
+      #
+      # A collector puts things here by name, so several can share a position without knowing about
+      # each other: a query count and a render time sit side by side under different keys.
+      class Entry
+        attr_reader template: String?
+
+        attr_reader line: Integer
+
+        attr_reader column: Integer
+
+        attr_reader observations: Hash[Symbol, Array[untyped]]
+
+        # : (String?, Integer, Integer) -> void
+        def initialize: (String?, Integer, Integer) -> void
+
+        # : (Symbol, untyped) -> void
+        def observe: (Symbol, untyped) -> void
+
+        # : (Symbol) -> Array[untyped]
+        def []: (Symbol) -> Array[untyped]
+
+        # : () -> bool
+        def empty?: () -> bool
+
+        # : () -> Herb::Location
+        def location: () -> Herb::Location
+
+        # : () -> String
+        def to_s: () -> String
+      end
+    end
+  end
+end

--- a/sig/herb/engine/report/middleware.rbs
+++ b/sig/herb/engine/report/middleware.rbs
@@ -18,6 +18,14 @@ module Herb
 
         BODY_END_TAG: Regexp
 
+        # Where the session for this request is left, so that anything holding the env can read what
+        # the page collected.
+        #
+        #     get "/posts"
+        #
+        #     request.env[Herb::Engine::Report::Middleware::ENV_KEY].entries
+        ENV_KEY: String
+
         # : (untyped, ?inject: bool) -> void
         def initialize: (untyped, ?inject: bool) -> void
 

--- a/sig/herb/engine/report/session.rbs
+++ b/sig/herb/engine/report/session.rbs
@@ -38,6 +38,18 @@ module Herb
 
         def self.record_compile_diagnostics: (untyped template, untyped entries) -> untyped
 
+        # : [T] (String?, Integer, Integer) { () -> T } -> T
+        def self.at: [T] (String?, Integer, Integer) { () -> T } -> T
+
+        # : (String?, Integer, Integer) -> void
+        def self.enter: (String?, Integer, Integer) -> void
+
+        # : () -> void
+        def self.leave: () -> void
+
+        # : (Symbol, untyped) -> void
+        def self.observe: (Symbol, untyped) -> void
+
         # : (String, String?) -> void
         def self.source: (String, String?) -> void
 
@@ -64,6 +76,18 @@ module Herb
 
         # : () -> bool
         def empty?: () -> bool
+
+        # : (String?, Integer, Integer) -> void
+        def enter: (String?, Integer, Integer) -> void
+
+        # : () -> void
+        def leave: () -> void
+
+        # : (Symbol, untyped) -> void
+        def observe: (Symbol, untyped) -> void
+
+        # : () -> Array[Herb::Engine::Report::Entry]
+        def entries: () -> Array[Herb::Engine::Report::Entry]
       end
     end
   end

--- a/sig/herb/engine/report/session.rbs
+++ b/sig/herb/engine/report/session.rbs
@@ -88,6 +88,24 @@ module Herb
 
         # : () -> Array[Herb::Engine::Report::Entry]
         def entries: () -> Array[Herb::Engine::Report::Entry]
+
+        # Turns what was observed under one key into one diagnostic per tag that saw any.
+        #
+        #     ActiveSupport::Notifications.subscribe("sql.active_record") do |*, payload|
+        #       Herb::Engine::Report::Session.observe(:queries, payload[:sql]) unless payload[:cached]
+        #     end
+        #
+        #     session.measure(:queries, origin: "Herb Engine", code: "sql-queries") do |queries|
+        #       "#{queries.size} SQL queries"
+        #     end
+        #
+        # A count is a measurement rather than a fault, so what comes out carries a badge and no
+        # severity. Three queries at one tag is worth showing every time and worth worrying about
+        # only sometimes, and which of those it is depends on what the tag is for. Reporting it as a
+        # warning would make that call on the reader's behalf and get it wrong often enough to train
+        # them to ignore it.
+        # : (Symbol, origin: String, ?code: String?, ?message: String?) { (Array[untyped]) -> String } -> Array[Herb::Diagnostic]
+        def measure: (Symbol, origin: String, ?code: String?, ?message: String?) { (Array[untyped]) -> String } -> Array[Herb::Diagnostic]
       end
     end
   end

--- a/sig/herb/engine/report/session.rbs
+++ b/sig/herb/engine/report/session.rbs
@@ -50,6 +50,9 @@ module Herb
         # : (Symbol, untyped) -> void
         def self.observe: (Symbol, untyped) -> void
 
+        # : () -> Array[Array[untyped]]
+        def self.stack: () -> Array[Array[untyped]]
+
         # : (String, String?) -> void
         def self.source: (String, String?) -> void
 
@@ -82,6 +85,21 @@ module Herb
 
         # : () -> void
         def leave: () -> void
+
+        # Every tag still rendering, innermost first, the way `caller` reads.
+        #
+        # A tag that renders a partial is still open while the partial renders, so once more than one
+        # template is instrumented this is a render stack across all of them and not just within one.
+        # Only the innermost frame is what an observation is filed under, so anything wanting the rest
+        # has to take it while it still exists:
+        #
+        #     ActiveSupport::Notifications.subscribe("sql.active_record") do |*, payload|
+        #       Herb::Engine::Report::Session.observe(:queries, { sql: payload[:sql], stack: Herb::Engine::Report::Session.stack })
+        #     end
+        #
+        # Taking it costs an array per observation, which is why it is offered rather than recorded.
+        # : () -> Array[Array[untyped]]
+        def stack: () -> Array[Array[untyped]]
 
         # : (Symbol, untyped) -> void
         def observe: (Symbol, untyped) -> void

--- a/test/engine/instrumentation_visitor_test.rb
+++ b/test/engine/instrumentation_visitor_test.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+require "herb/engine/instrumentation_visitor"
+
+module Engine
+  class InstrumentationVisitorTest < Minitest::Spec
+    include SnapshotUtils
+
+    FILENAME = "app/views/test.html.erb"
+
+    SOURCES = {
+      "plain output" => "<div><%= 1 + 1 %></div>",
+      "a block" => "<% [1, 2].each do |n| %><%= n %><% end %>",
+      "an assignment carried to a later tag" => "<% total = 40 + 2 %><%= total %>",
+      "an output assignment" => "<%= total = 7 %>",
+      "a conditional" => "<% if true %>yes<% else %>no<% end %>",
+      "a comment" => "<%# ignored %>ok",
+      "markup around a tag" => "<p>before</p><%= 1 %><p>after</p>",
+    }.freeze
+
+    def instrumented(source)
+      assert_compiled_snapshot(source, filename: FILENAME, visitors: [Herb::Engine::InstrumentationVisitor.new])
+    end
+
+    def compile(source, instrument: true)
+      visitors = instrument ? [Herb::Engine::InstrumentationVisitor.new] : []
+
+      Herb::Engine.new(source, filename: FILENAME, visitors: visitors).src
+    end
+
+    def render(source, instrument: true)
+      Object.new.instance_eval(compile(source, instrument: instrument))
+    end
+
+    describe "what it emits" do
+      test "wraps an output tag" do
+        instrumented("<div><%= title %></div>")
+      end
+
+      test "frames a block rather than wrapping it" do
+        instrumented("<% items.each do |item| %><%= item %><% end %>")
+      end
+
+      test "frames an assignment rather than wrapping it" do
+        instrumented("<%= total = 1 %>")
+      end
+
+      test "opens and closes around a statement" do
+        instrumented("<% total = 1 %>")
+      end
+
+      test "leaves a comment alone" do
+        instrumented("<%# nothing to see %>")
+      end
+
+      test "reaches into a conditional" do
+        instrumented("<% if admin? %><%= secret %><% end %>")
+      end
+    end
+
+    describe "what it must not change" do
+      SOURCES.each do |name, source|
+        test "renders #{name} the same as an uninstrumented template" do
+          assert_equal render(source, instrument: false), render(source)
+        end
+      end
+    end
+
+    describe "what it attributes" do
+      def observed(source)
+        compiled = compile(source)
+
+        session = Herb::Engine::Report::Session.capture do
+          Object.new.instance_eval(compiled)
+        end
+
+        session.entries
+      end
+
+      def self.watching_object
+        Object.new.tap do |object|
+          object.define_singleton_method(:watch) do |value|
+            Herb::Engine::Report::Session.observe(:seen, value)
+            value
+          end
+        end
+      end
+
+      test "puts what happened under the tag that caused it" do
+        source = "<div><%= watch(1) %></div>\n<%= watch(2) %>"
+        compiled = compile(source)
+
+        session = Herb::Engine::Report::Session.capture do
+          self.class.watching_object.instance_eval(compiled)
+        end
+
+        assert_equal([[1, 5], [2, 0]], session.entries.map { |entry| [entry.line, entry.column] })
+        assert_equal([[1], [2]], session.entries.map { |entry| entry[:seen] })
+      end
+
+      test "names the template it came from" do
+        source = "<%= watch(1) %>"
+        compiled = compile(source)
+
+        session = Herb::Engine::Report::Session.capture do
+          self.class.watching_object.instance_eval(compiled)
+        end
+
+        assert_equal [FILENAME], session.entries.map(&:template)
+      end
+
+      test "reaches the payload as a metric naming the tag that caused it" do
+        source = "<ul>\n  <% [1, 2].each do |n| %>\n    <li><%= watch(n) %></li>\n  <% end %>\n</ul>"
+        compiled = compile(source)
+
+        session = Herb::Engine::Report::Session.capture do
+          self.class.watching_object.instance_eval(compiled)
+        end
+
+        session.measure(:seen, origin: "Herb Engine", code: "sql-queries") { |seen|
+          "#{seen.size} SQL queries"
+        }
+
+        diagnostic = session.diagnostics.first
+
+        assert_equal "#{FILENAME}:3:9: [sql-queries] 2 SQL queries", diagnostic.to_s
+        assert_equal :metric, diagnostic.kind
+      end
+
+      test "collects every pass of a loop under the one tag that repeats" do
+        source = "<% [1, 2, 3].each do |n| %><%= watch(n) %><% end %>"
+        compiled = compile(source)
+
+        session = Herb::Engine::Report::Session.capture do
+          self.class.watching_object.instance_eval(compiled)
+        end
+
+        seen = session.entries.find { |entry| entry[:seen].any? }
+
+        assert_equal [1, 2, 3], seen[:seen]
+      end
+    end
+  end
+end

--- a/test/engine/report/middleware_test.rb
+++ b/test/engine/report/middleware_test.rb
@@ -44,6 +44,54 @@ module Engine
       buffer
     end
 
+    describe "handing the session back" do
+      test "leaves the session it used in the env" do
+        env = {}
+
+        Herb::Engine::Report::Middleware.new(app { Herb::Engine::Report::Session.record(diagnostic) }).call(env)
+
+        session = env[Herb::Engine::Report::Middleware::ENV_KEY]
+
+        assert_instance_of Herb::Engine::Report::Session, session
+        assert_equal ["Something is wrong."], session.diagnostics.map(&:message)
+      end
+
+      test "collects into a session that was already open rather than one nobody can reach" do
+        session = Herb::Engine::Report::Session.capture do
+          call(app {
+            Herb::Engine::Report::Session.at("app/views/a.html.erb", 3, 4) do
+              Herb::Engine::Report::Session.observe(:queries, "SELECT 1")
+            end
+          })
+        end
+
+        assert_equal 1, session.entries.length
+        assert_equal ["SELECT 1"], session.entries.first[:queries]
+      end
+
+      test "leaves a borrowed session open for whoever opened it" do
+        Herb::Engine::Report::Session.capture do
+          call(app { Herb::Engine::Report::Session.record(diagnostic) })
+
+          assert_predicate Herb::Engine::Report::Session, :scoped?
+        end
+      end
+
+      test "still opens its own session when nobody else has one" do
+        call(app { Herb::Engine::Report::Session.record(diagnostic) })
+
+        refute_predicate Herb::Engine::Report::Session, :scoped?
+      end
+
+      test "survives an env that cannot be written to" do
+        response = Herb::Engine::Report::Middleware.new(
+          app { Herb::Engine::Report::Session.record(diagnostic) }
+        ).call(nil)
+
+        assert_includes body_of(response), "data-herb-diagnostics"
+      end
+    end
+
     test "injects the payload before the closing body tag" do
       response = call(app { Herb::Engine::Report::Session.record(diagnostic) })
       body = body_of(response)

--- a/test/engine/report/session_test.rb
+++ b/test/engine/report/session_test.rb
@@ -242,6 +242,44 @@ module Engine
         assert_includes session.report.to_json, %("value":"1 SQL query")
       end
 
+      test "reports every tag still rendering, innermost first" do
+        stack = nil
+
+        Herb::Engine::Report::Session.capture do
+          Herb::Engine::Report::Session.at("layouts/application.html.erb", 2, 2) do
+            Herb::Engine::Report::Session.at("posts/index.html.erb", 4, 4) do
+              Herb::Engine::Report::Session.at("posts/_card.html.erb", 1, 2) do
+                stack = Herb::Engine::Report::Session.stack
+              end
+            end
+          end
+        end
+
+        assert_equal [
+          ["posts/_card.html.erb", 1, 2],
+          ["posts/index.html.erb", 4, 4],
+          ["layouts/application.html.erb", 2, 2]
+        ], stack
+      end
+
+      test "reports an empty stack outside of any tag" do
+        assert_empty Herb::Engine::Report::Session.capture { nil }.stack
+      end
+
+      test "hands out a stack that cannot be used to corrupt the live one" do
+        session = Herb::Engine::Report::Session.capture do
+          Herb::Engine::Report::Session.at("a.html.erb", 1, 0) do
+            Herb::Engine::Report::Session.stack.each(&:clear)
+
+            Herb::Engine::Report::Session.observe(:queries, "SELECT 1")
+          end
+        end
+
+        entry = session.entries.first
+
+        assert_equal ["a.html.erb", 1, 0], [entry.template, entry.line, entry.column]
+      end
+
       test "collects the same position across renders into one entry" do
         session = Herb::Engine::Report::Session.capture do
           2.times do

--- a/test/engine/report/session_test.rb
+++ b/test/engine/report/session_test.rb
@@ -262,6 +262,26 @@ module Engine
         ], stack
       end
 
+      test "writes an entry the way an editor would take it" do
+        session = Herb::Engine::Report::Session.capture do
+          Herb::Engine::Report::Session.at("app/views/posts/_card.html.erb", 3, 8) do
+            Herb::Engine::Report::Session.observe(:queries, "SELECT 1")
+          end
+        end
+
+        assert_equal "app/views/posts/_card.html.erb:3:9 (1 queries)", session.entries.first.to_s
+      end
+
+      test "writes a tag with no location of its own as the first line" do
+        session = Herb::Engine::Report::Session.capture do
+          Herb::Engine::Report::Session.at("app/views/posts/_card.html.erb", 0, 0) do
+            Herb::Engine::Report::Session.observe(:queries, "SELECT 1")
+          end
+        end
+
+        assert_equal "app/views/posts/_card.html.erb:1:1 (1 queries)", session.entries.first.to_s
+      end
+
       test "reports an empty stack outside of any tag" do
         assert_empty Herb::Engine::Report::Session.capture { nil }.stack
       end

--- a/test/engine/report/session_test.rb
+++ b/test/engine/report/session_test.rb
@@ -131,5 +131,79 @@ module Engine
       assert_equal 0, other
       assert_equal 1, Herb::Engine::Report::Session.current.diagnostics.length
     end
+
+    describe "attributing what happens to the tag that caused it" do
+      def session_with_frames
+        Herb::Engine::Report::Session.capture do
+          Herb::Engine::Report::Session.at("a.html.erb", 3, 7) do
+            Herb::Engine::Report::Session.observe(:queries, "SELECT 1")
+            Herb::Engine::Report::Session.observe(:queries, "SELECT 2")
+          end
+
+          Herb::Engine::Report::Session.at("a.html.erb", 1, 0) do
+            Herb::Engine::Report::Session.observe(:queries, "SELECT 3")
+          end
+        end
+      end
+
+      test "keeps each position apart" do
+        entries = session_with_frames.entries
+
+        assert_equal([[1, 0], [3, 7]], entries.map { |entry| [entry.line, entry.column] })
+        assert_equal 1, entries.first[:queries].length
+        assert_equal 2, entries.last[:queries].length
+      end
+
+      test "orders them the way they appear in the template" do
+        assert_equal [1, 3], session_with_frames.entries.map(&:line)
+      end
+
+      test "drops what happens outside any tag" do
+        session = Herb::Engine::Report::Session.capture do
+          Herb::Engine::Report::Session.observe(:queries, "SELECT 1")
+        end
+
+        assert_empty session.entries
+      end
+
+      test "attributes to the innermost tag" do
+        session = Herb::Engine::Report::Session.capture do
+          Herb::Engine::Report::Session.at("a.html.erb", 1, 0) do
+            Herb::Engine::Report::Session.at("a.html.erb", 2, 4) do
+              Herb::Engine::Report::Session.observe(:queries, "SELECT 1")
+            end
+          end
+        end
+
+        assert_equal([[2, 4]], session.entries.map { |entry| [entry.line, entry.column] })
+      end
+
+      test "leaves the frame even when the tag raises" do
+        session = Herb::Engine::Report::Session.capture do
+          begin
+            Herb::Engine::Report::Session.at("a.html.erb", 1, 0) { raise "boom" }
+          rescue RuntimeError
+            nil
+          end
+
+          Herb::Engine::Report::Session.observe(:queries, "after the failure")
+        end
+
+        assert_empty session.entries
+      end
+
+      test "collects the same position across renders into one entry" do
+        session = Herb::Engine::Report::Session.capture do
+          2.times do
+            Herb::Engine::Report::Session.at("a.html.erb", 1, 0) do
+              Herb::Engine::Report::Session.observe(:queries, "SELECT 1")
+            end
+          end
+        end
+
+        assert_equal 1, session.entries.length
+        assert_equal 2, session.entries.first[:queries].length
+      end
+    end
   end
 end

--- a/test/engine/report/session_test.rb
+++ b/test/engine/report/session_test.rb
@@ -192,6 +192,56 @@ module Engine
         assert_empty session.entries
       end
 
+      test "turns what one tag observed into a metric carrying a badge and no severity" do
+        session = Herb::Engine::Report::Session.capture do
+          Herb::Engine::Report::Session.at("a.html.erb", 7, 8) do
+            Herb::Engine::Report::Session.observe(:queries, "SELECT 1")
+            Herb::Engine::Report::Session.observe(:queries, "SELECT 2")
+          end
+        end
+
+        diagnostic = session.measure(:queries, origin: "Herb Engine", code: "sql-queries") { |queries|
+          "#{queries.size} SQL queries"
+        }.first
+
+        assert_equal "2 SQL queries", diagnostic.value
+        assert_equal :metric, diagnostic.kind
+        assert_nil diagnostic.severity
+        assert_equal "a.html.erb", diagnostic.template
+        assert_equal 7, diagnostic.location.start.line
+        assert_equal ["SELECT 1", "SELECT 2"], diagnostic.data[:queries]
+      end
+
+      test "measures only the tags that observed something" do
+        session = Herb::Engine::Report::Session.capture do
+          Herb::Engine::Report::Session.at("a.html.erb", 1, 0) do
+            Herb::Engine::Report::Session.observe(:renders, "partial")
+          end
+
+          Herb::Engine::Report::Session.at("a.html.erb", 2, 0) do
+            Herb::Engine::Report::Session.observe(:queries, "SELECT 1")
+          end
+        end
+
+        measured = session.measure(:queries, origin: "Herb Engine") { |queries| queries.size.to_s }
+
+        assert_equal [2], measured.map { |diagnostic| diagnostic.location.start.line }.sort
+      end
+
+      test "puts what it measured into the payload" do
+        session = Herb::Engine::Report::Session.capture do
+          Herb::Engine::Report::Session.at("a.html.erb", 1, 0) do
+            Herb::Engine::Report::Session.observe(:queries, "SELECT 1")
+          end
+        end
+
+        session.measure(:queries, origin: "Herb Engine", code: "sql-queries") { |queries|
+          "#{queries.size} SQL query"
+        }
+
+        assert_includes session.report.to_json, %("value":"1 SQL query")
+      end
+
       test "collects the same position across renders into one entry" do
         session = Herb::Engine::Report::Session.capture do
           2.times do

--- a/test/snapshots/engine/instrumentation_visitor_test/what_it_emits/test_0001_wraps_an_output_tag_3f485f34b69d719d4c02dc0b6385c2f0.txt
+++ b/test/snapshots/engine/instrumentation_visitor_test/what_it_emits/test_0001_wraps_an_output_tag_3f485f34b69d719d4c02dc0b6385c2f0.txt
@@ -1,0 +1,8 @@
+---
+source: "Engine::InstrumentationVisitorTest::what it emits#test_0001_wraps an output tag"
+input: "{source: \"<div><%= title %></div>\", options: {filename: \"app/views/test.html.erb\", visitors: [#<Herb::Engine::InstrumentationVisitor>]}}"
+---
+_buf = ::String.new; _buf << '<div>'.freeze; _buf << (::Herb::Engine::Report::Session.at("app/views/test.html.erb", 1, 5) {
+title
+}).to_s; _buf << '</div>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/instrumentation_visitor_test/what_it_emits/test_0002_frames_a_block_rather_than_wrapping_it_874ac03351d945ea798fe223f1c25144.txt
+++ b/test/snapshots/engine/instrumentation_visitor_test/what_it_emits/test_0002_frames_a_block_rather_than_wrapping_it_874ac03351d945ea798fe223f1c25144.txt
@@ -1,0 +1,10 @@
+---
+source: "Engine::InstrumentationVisitorTest::what it emits#test_0002_frames a block rather than wrapping it"
+input: "{source: \"<% items.each do |item| %><%= item %><% end %>\", options: {filename: \"app/views/test.html.erb\", visitors: [#<Herb::Engine::InstrumentationVisitor>]}}"
+---
+_buf = ::String.new; ::Herb::Engine::Report::Session.enter("app/views/test.html.erb", 1, 0) 
+ items.each do |item| 
+ _buf << (::Herb::Engine::Report::Session.at("app/views/test.html.erb", 1, 26) {
+item
+}).to_s; end; ::Herb::Engine::Report::Session.leave;
+_buf.to_s

--- a/test/snapshots/engine/instrumentation_visitor_test/what_it_emits/test_0003_frames_an_assignment_rather_than_wrapping_it_8b679d4e4ceb746bbb79259f9542c09e.txt
+++ b/test/snapshots/engine/instrumentation_visitor_test/what_it_emits/test_0003_frames_an_assignment_rather_than_wrapping_it_8b679d4e4ceb746bbb79259f9542c09e.txt
@@ -1,0 +1,7 @@
+---
+source: "Engine::InstrumentationVisitorTest::what it emits#test_0003_frames an assignment rather than wrapping it"
+input: "{source: \"<%= total = 1 %>\", options: {filename: \"app/views/test.html.erb\", visitors: [#<Herb::Engine::InstrumentationVisitor>]}}"
+---
+_buf = ::String.new; ::Herb::Engine::Report::Session.enter("app/views/test.html.erb", 1, 0) 
+ _buf << (total = 1).to_s; ::Herb::Engine::Report::Session.leave;
+_buf.to_s

--- a/test/snapshots/engine/instrumentation_visitor_test/what_it_emits/test_0004_opens_and_closes_around_a_statement_bc980552f41dbc8dad2002f151a2a0fd.txt
+++ b/test/snapshots/engine/instrumentation_visitor_test/what_it_emits/test_0004_opens_and_closes_around_a_statement_bc980552f41dbc8dad2002f151a2a0fd.txt
@@ -1,0 +1,8 @@
+---
+source: "Engine::InstrumentationVisitorTest::what it emits#test_0004_opens and closes around a statement"
+input: "{source: \"<% total = 1 %>\", options: {filename: \"app/views/test.html.erb\", visitors: [#<Herb::Engine::InstrumentationVisitor>]}}"
+---
+_buf = ::String.new; ::Herb::Engine::Report::Session.enter("app/views/test.html.erb", 1, 0); begin
+total = 1
+ensure; ::Herb::Engine::Report::Session.leave; end 
+_buf.to_s

--- a/test/snapshots/engine/instrumentation_visitor_test/what_it_emits/test_0005_leaves_a_comment_alone_6ddcbda2d6e149352b931732e54051a6.txt
+++ b/test/snapshots/engine/instrumentation_visitor_test/what_it_emits/test_0005_leaves_a_comment_alone_6ddcbda2d6e149352b931732e54051a6.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::InstrumentationVisitorTest::what it emits#test_0005_leaves a comment alone"
+input: "{source: \"<%# nothing to see %>\", options: {filename: \"app/views/test.html.erb\", visitors: [#<Herb::Engine::InstrumentationVisitor>]}}"
+---
+_buf = ::String.new;
+_buf.to_s

--- a/test/snapshots/engine/instrumentation_visitor_test/what_it_emits/test_0006_reaches_into_a_conditional_7952173aa31f61affb7e29ba58dcd932.txt
+++ b/test/snapshots/engine/instrumentation_visitor_test/what_it_emits/test_0006_reaches_into_a_conditional_7952173aa31f61affb7e29ba58dcd932.txt
@@ -1,0 +1,10 @@
+---
+source: "Engine::InstrumentationVisitorTest::what it emits#test_0006_reaches into a conditional"
+input: "{source: \"<% if admin? %><%= secret %><% end %>\", options: {filename: \"app/views/test.html.erb\", visitors: [#<Herb::Engine::InstrumentationVisitor>]}}"
+---
+_buf = ::String.new; ::Herb::Engine::Report::Session.enter("app/views/test.html.erb", 1, 0) 
+ if admin? 
+ _buf << (::Herb::Engine::Report::Session.at("app/views/test.html.erb", 1, 15) {
+secret
+}).to_s; end; ::Herb::Engine::Report::Session.leave;
+_buf.to_s


### PR DESCRIPTION
This pull request adds `Herb::Engine::InstrumentationVisitor`, which frames every ERB tag so that whatever happens while it renders can be attributed to it rather than to the template as a whole.

The visitor supplies where, and something else has to supply what. A template compiled with it and rendered with nothing watching records nothing at all, and only costs a call per tag. What makes it worth having is anything that calls `Herb::Engine::Report::Session.observe` while a tag is rendering:

```ruby
require "herb/engine/instrumentation_visitor"

engine = Herb::Engine.new(source, visitors: [Herb::Engine::InstrumentationVisitor.new])

ActiveSupport::Notifications.subscribe("sql.active_record") do |*, payload|
  Herb::Engine::Report::Session.observe(:queries, payload[:sql]) unless payload[:cached]
end
```

Nothing about that subscription belongs to Herb, which is the point. Because what gets watched is decided at render time rather than compiled in, watching something new never means recompiling a template, and Herb does not have to ship a class per thing worth watching.

#### Turning observations into findings

`Session#measure` turns what was observed into one diagnostic per tag that saw any:

```ruby
session.measure(:queries, origin: "Herb Engine", code: "sql-queries") do |queries|
  "#{queries.size} SQL queries"
end
#=> app/views/posts/_card.html.erb:7:9: [sql-queries] 3 SQL queries
```

A count is a measurement rather than a fault, so what comes out carries a badge and no severity. Three queries at one tag is worth showing every time and worth worrying about only sometimes, and which of those it is depends on what the tag is for.

#### The render stack

A tag that renders a partial stays open while that partial renders, so `Session.stack` is a render stack across every instrumented template and not only within one. It reads innermost first, the way `caller` does:

```ruby
Herb::Engine::Report::Session.stack
#=> [["app/views/posts/_card.html.erb", 2, 2],
#    ["app/views/posts/index.html.erb", 4, 4],
#    ["app/views/layouts/application.html.erb", 2, 2]]
```

Only the innermost frame is what an observation is filed under, so anything wanting the rest has to take it while it still exists. Taking it costs an array per observation, which is why it is offered rather than recorded.
