### PR TITLE
Engine: Name the template the engine is compiling in `.html_safe` assertions

### DIFF
--- a/lib/herb/engine/html_safe_assertions_visitor.rb
+++ b/lib/herb/engine/html_safe_assertions_visitor.rb
@@ -38,6 +38,8 @@ module Herb
     #     Herb.parse(source, prism_program: true)
     #
     class HTMLSafeAssertionsVisitor < Herb::Visitor
+      include ContextAware
+
       RUNTIME = "::Herb::Engine::HTMLSafeAssertions"
 
       MAX_SOURCE_LENGTH = 120
@@ -53,8 +55,9 @@ module Herb
 
         @mode = validated_mode(mode)
         @ignore = validated_ignore(ignore)
-        @file_path = file_path&.to_s
         @erb_nodes = [] #: Array[untyped]
+
+        self.context = VisitorContext.new(file_path: file_path) if file_path
       end
 
       #: (Herb::AST::DocumentNode) -> void
@@ -73,7 +76,7 @@ module Herb
 
       #: () -> String
       def inspect
-        "#<#{self.class.name} mode=#{@mode.inspect} ignore=#{@ignore.inspect} file_path=#{@file_path.inspect}>"
+        "#<#{self.class.name} mode=#{@mode.inspect} ignore=#{@ignore.inspect} file_path=#{context.file_path&.to_s.inspect}>"
       end
 
       private
@@ -254,7 +257,9 @@ module Herb
 
       #: () -> String
       def file_argument
-        @file_path ? "#{@file_path.dump}.freeze" : "__FILE__"
+        return "__FILE__" unless context.file_path
+
+        "#{context.relative_file_path.dump}.freeze"
       end
 
       #: (untyped, String) -> String

--- a/sig/herb/engine/html_safe_assertions_visitor.rbs
+++ b/sig/herb/engine/html_safe_assertions_visitor.rbs
@@ -25,6 +25,8 @@ module Herb
     #
     #     Herb.parse(source, prism_program: true)
     class HTMLSafeAssertionsVisitor < Herb::Visitor
+      include ContextAware
+
       RUNTIME: ::String
 
       MAX_SOURCE_LENGTH: ::Integer

--- a/test/engine/html_safe_assertions_visitor_test.rb
+++ b/test/engine/html_safe_assertions_visitor_test.rb
@@ -317,5 +317,38 @@ module Engine
 
       assert_includes error.message, "unknown check :scripts"
     end
+
+    HTML_SAFE_TEMPLATE = "<%= @user.bio.html_safe %>"
+
+    describe "which file the assertion names" do
+      def file_argument(**properties)
+        visitor = Herb::Engine::HTMLSafeAssertionsVisitor.new(**properties.delete(:visitor).to_h)
+        engine = Herb::Engine.new(
+          HTML_SAFE_TEMPLATE, parser_options: { strict: false }, visitors: [visitor], **properties
+        )
+
+        engine.src.split("file: ", 2).last.split(",", 2).first
+      end
+
+      test "names the template the engine was compiling" do
+        assert_equal %("app/views/users/show.html.erb".freeze),
+                     file_argument(filename: "app/views/users/show.html.erb")
+      end
+
+      test "names it relative to the project rather than absolutely" do
+        assert_equal %("app/views/users/show.html.erb".freeze),
+                     file_argument(filename: File.join(Dir.pwd, "app/views/users/show.html.erb"))
+      end
+
+      test "lets a file path passed to the visitor win over the one the engine has" do
+        assert_equal %("explicit/path.html.erb".freeze),
+                     file_argument(filename: "app/views/engine.html.erb",
+                                   visitor: { file_path: "explicit/path.html.erb" })
+      end
+
+      test "falls back to the compiled file only when nothing knows the template" do
+        assert_equal "__FILE__", file_argument
+      end
+    end
   end
 end


### PR DESCRIPTION
This pull request fixes `HTMLSafeAssertionsVisitor` reporting the wrong file, by giving it the filename the engine was already compiling with.

The visitor emitted `file: __FILE__` unless it was passed a `file_path:` of its own. `__FILE__` in a compiled template is whatever the compiler evaluated the source as, so under Action View it happens to be the template path and everywhere else it is wrong. The engine knew the real path the whole time and was never asked.

```ruby
Herb::Engine.new(
  source,
  filename: "app/views/users/show.html.erb",
  visitors: [Herb::Engine::HTMLSafeAssertionsVisitor.new]
)
```

**Before**

```ruby
::Herb::Engine::HTMLSafeAssertions.check(@user.bio, file: __FILE__, line: 1, column: 1, ...)
```

**After**

```ruby
::Herb::Engine::HTMLSafeAssertions.check(@user.bio, file: "app/views/users/show.html.erb".freeze, line: 1, column: 1, ...)
```
