### PR TITLE
Language Service: Resolve partials against the view root the index found

### DIFF
--- a/javascript/packages/language-server/src/session.ts
+++ b/javascript/packages/language-server/src/session.ts
@@ -1,3 +1,4 @@
+import { join } from "node:path"
 import { existsSync, readFileSync } from "node:fs"
 import { Connection, InitializeParams } from "vscode-languageserver/node"
 
@@ -57,7 +58,8 @@ export class Session {
         } catch {
           return null
         }
-      }
+      },
+      documentPath => this.viewRootFor(documentPath),
     )
 
     this.projects = new Projects(this.connection, this.workspaceFolders, {
@@ -100,6 +102,15 @@ export class Session {
         this.connection.window.showDocument({ uri: `file://${warning.configPath}`, takeFocus: true })
       }
     })
+  }
+
+  private viewRootFor(documentPath: string): string | null {
+    const project = this.projects.containing(documentPath)
+    const viewRoot = project?.partialIndexService.index?.viewRoot
+
+    if (!project || viewRoot === undefined) return null
+
+    return viewRoot === "." ? project.root : join(project.root, viewRoot)
   }
 
   async init() {

--- a/javascript/packages/language-service/src/definition_provider.ts
+++ b/javascript/packages/language-service/src/definition_provider.ts
@@ -36,15 +36,18 @@ export class DefinitionProvider {
   private parserService: ParserService
   private exists: (filePath: string) => boolean
   private read: (filePath: string) => string | null
+  private viewRootFor: (documentPath: string) => string | null
 
   constructor(
     parserService: ParserService,
     exists: (filePath: string) => boolean,
-    read: (filePath: string) => string | null
+    read: (filePath: string) => string | null,
+    viewRootFor: (documentPath: string) => string | null = () => null
   ) {
     this.parserService = parserService
     this.exists = exists
     this.read = read
+    this.viewRootFor = viewRootFor
   }
 
   getDefinition(document: TextDocument, position: Position): LocationLink[] {
@@ -374,8 +377,10 @@ export class DefinitionProvider {
   }
 
   private viewsRoot(documentPath: string): string | null {
-    const index = documentPath.lastIndexOf(VIEWS_DIRECTORY)
+    const indexed = this.viewRootFor(documentPath)
+    if (indexed !== null) return indexed
 
+    const index = documentPath.lastIndexOf(VIEWS_DIRECTORY)
     if (index === -1) return null
 
     return documentPath.slice(0, index + VIEWS_DIRECTORY.length - 1)

--- a/javascript/packages/language-service/test/definition_provider.test.ts
+++ b/javascript/packages/language-service/test/definition_provider.test.ts
@@ -667,4 +667,46 @@ describe("DefinitionProvider", () => {
       expect(definitions(service, content, `"card"`, "file:///project/lib/templates/mailer.html.erb")).toEqual([])
     })
   })
+
+  describe("view root from the index", () => {
+    const TEMPLATES_URI = "file:///project/templates/events/show.html.erb"
+
+    function serviceRootedAt(viewRoot: string | null, ...files: string[]) {
+      const existing = new Set(files)
+
+      return new DefinitionProvider(
+        parserService,
+        filePath => existing.has(filePath),
+        () => "",
+        () => viewRoot,
+      )
+    }
+
+    it("resolves a qualified partial against the root the index reports", () => {
+      const service = serviceRootedAt("/project/templates", "/project/templates/shared/_header.html.erb")
+
+      expect(uris(service, `<%= render "shared/header" %>`, "shared/header", TEMPLATES_URI))
+        .toContain("file:///project/templates/shared/_header.html.erb")
+    })
+
+    it("finds nothing under a conventional layout the project does not use", () => {
+      const service = createService("/project/templates/shared/_header.html.erb")
+
+      expect(uris(service, `<%= render "shared/header" %>`, "shared/header", TEMPLATES_URI)).toEqual([])
+    })
+
+    it("treats a project root view root as the project root itself", () => {
+      const service = serviceRootedAt("/project", "/project/shared/_header.html.erb")
+
+      expect(uris(service, `<%= render "shared/header" %>`, "shared/header", "file:///project/events/show.html.erb"))
+        .toContain("file:///project/shared/_header.html.erb")
+    })
+
+    it("falls back to the conventional layout when nothing is indexed", () => {
+      const service = serviceRootedAt(null, "/project/app/views/shared/_header.html.erb")
+
+      expect(uris(service, `<%= render "shared/header" %>`, "shared/header"))
+        .toContain("file:///project/app/views/shared/_header.html.erb")
+    })
+  })
 })


### PR DESCRIPTION
This pull request fixes go to definition for projects that do not keep their templates in `app/views`.

`DefinitionProvider` located a project's view root by looking for a literal string in the document path:

```ts
const VIEWS_DIRECTORY = "/app/views/"
```

A project laid out any other way never matched, so it got no view root at all, and go to definition could only find partials that happen to sit in the same directory as the file being edited:

**`app/templates/events/show.html.erb`**
```erb
<%= render "shared/header" %>
```

Nothing resolves, even though `app/templates/shared/_header.html.erb` is right there.

`buildPartialIndex` does not assume the conventional layout. It looks for `app/views`, falls back to the project root when there is nothing there, and records the answer as `viewRoot`. So what was needed to resolve that render call was already sitting in the project's index, unused by this provider.

Follow up on #2168.
