### PR TITLE
Linter: Show `erb-prefer-direct-output` rewrite in offense message

### DIFF
--- a/javascript/packages/linter/src/rules/erb-prefer-direct-output.ts
+++ b/javascript/packages/linter/src/rules/erb-prefer-direct-output.ts
@@ -13,20 +13,37 @@ interface PreferDirectOutputAutofixContext extends BaseAutofixContext {
   replacementParts: ReplacementPart[]
 }
 
+function mapReplacementParts<T>(
+  node: ERBContentNode,
+  replacementParts: ReplacementPart[],
+  mapText: (content: string) => T,
+  mapExpression: (
+    expression: string,
+    tagOpening: string,
+    tagClosing: string,
+  ) => T,
+): T[] {
+  const tagOpening = node.tag_opening?.value ?? "<%="
+  const tagClosing = node.tag_closing?.value ?? "%>"
+
+  return replacementParts.map((part) =>
+    part.type === "text"
+      ? mapText(part.content)
+      : mapExpression(part.expression.trim(), tagOpening, tagClosing),
+  )
+}
+
 function formatReplacement(
   node: ERBContentNode,
   replacementParts: ReplacementPart[],
 ): string {
-  const tagOpening = node.tag_opening?.value ?? "<%="
-  const tagClosing = node.tag_closing?.value ?? "%>"
-
-  return replacementParts
-    .map((part) =>
-      part.type === "text"
-        ? part.content
-        : `${tagOpening} ${part.expression.trim()} ${tagClosing}`,
-    )
-    .join("")
+  return mapReplacementParts(
+    node,
+    replacementParts,
+    (content) => content,
+    (expression, tagOpening, tagClosing) =>
+      `${tagOpening} ${expression} ${tagClosing}`,
+  ).join("")
 }
 
 class PreferDirectOutputVisitor extends BaseRuleVisitor<PreferDirectOutputAutofixContext> {
@@ -137,19 +154,14 @@ export class ERBPreferDirectOutputRule extends ParserRule<PreferDirectOutputAuto
 
     if (!parentInfo) return null
 
-    const tagOpening = erbNode.tag_opening?.value ?? "<%="
-    const tagClosing = erbNode.tag_closing?.value ?? "%>"
-
     const { array: parentArray, index: nodeIndex } = parentInfo
-    const replacementNodes: Node[] = []
-
-    for (const part of replacementParts) {
-      if (part.type === "text") {
-        replacementNodes.push(createLiteral(part.content))
-      } else {
-        replacementNodes.push(createERBOutputNode(` ${part.expression.trim()} `, tagOpening, tagClosing))
-      }
-    }
+    const replacementNodes = mapReplacementParts<Node>(
+      erbNode,
+      replacementParts,
+      (content) => createLiteral(content),
+      (expression, tagOpening, tagClosing) =>
+        createERBOutputNode(` ${expression} `, tagOpening, tagClosing),
+    )
 
     parentArray.splice(nodeIndex, 1, ...replacementNodes)
 

--- a/javascript/packages/linter/src/rules/erb-prefer-direct-output.ts
+++ b/javascript/packages/linter/src/rules/erb-prefer-direct-output.ts
@@ -13,6 +13,22 @@ interface PreferDirectOutputAutofixContext extends BaseAutofixContext {
   replacementParts: ReplacementPart[]
 }
 
+function formatReplacement(
+  node: ERBContentNode,
+  replacementParts: ReplacementPart[],
+): string {
+  const tagOpening = node.tag_opening?.value ?? "<%="
+  const tagClosing = node.tag_closing?.value ?? "%>"
+
+  return replacementParts
+    .map((part) =>
+      part.type === "text"
+        ? part.content
+        : `${tagOpening} ${part.expression.trim()} ${tagClosing}`,
+    )
+    .join("")
+}
+
 class PreferDirectOutputVisitor extends BaseRuleVisitor<PreferDirectOutputAutofixContext> {
   private attributeValue: HTMLAttributeValueNode | null = null
 
@@ -50,17 +66,33 @@ class PreferDirectOutputVisitor extends BaseRuleVisitor<PreferDirectOutputAutofi
       ? { node: node as Mutable<ERBContentNode>, replacementParts }
       : undefined
 
+    const replacement = replacementParts
+      ? formatReplacement(node, replacementParts)
+      : null
+
     if (isPrismNodeType(prismNode, "StringNode")) {
+      const recommendation =
+        replacement === null
+          ? "Write the text directly without wrapping it in an ERB output tag."
+          : replacement.length === 0
+            ? "Remove the empty output tag instead."
+            : `Use \`${replacement}\` instead.`
+
       this.addOffense(
-        `Avoid outputting string literal \`${content}\`. Write the text directly without wrapping it in an ERB output tag.`,
+        `Avoid outputting string literal \`${content}\`. ${recommendation}`,
         stringLocation,
         autofixContext,
       )
     }
 
     if (isPrismNodeType(prismNode, "InterpolatedStringNode")) {
+      const recommendation =
+        replacement === null
+          ? "Use separate `<%= %>` tags for each dynamic value instead."
+          : `Use \`${replacement}\` instead.`
+
       this.addOffense(
-        `Avoid outputting interpolated string \`${content}\`. Use separate \`<%= %>\` tags for each dynamic value instead.`,
+        `Avoid outputting interpolated string \`${content}\`. ${recommendation}`,
         stringLocation,
         autofixContext,
       )

--- a/javascript/packages/linter/test/rules/erb-prefer-direct-output.test.ts
+++ b/javascript/packages/linter/test/rules/erb-prefer-direct-output.test.ts
@@ -86,7 +86,7 @@ describe("erb-prefer-direct-output", () => {
 
   test("fails for double-quoted string literal", () => {
     expectError(
-      'Avoid outputting string literal `"Title"`. Write the text directly without wrapping it in an ERB output tag.',
+      'Avoid outputting string literal `"Title"`. Use `Title` instead.',
     )
 
     assertOffenses('<%= "Title" %>')
@@ -94,7 +94,7 @@ describe("erb-prefer-direct-output", () => {
 
   test("fails for single-quoted string literal", () => {
     expectError(
-      "Avoid outputting string literal `'Title'`. Write the text directly without wrapping it in an ERB output tag.",
+      "Avoid outputting string literal `'Title'`. Use `Title` instead.",
     )
 
     assertOffenses("<%= 'Title' %>")
@@ -102,7 +102,7 @@ describe("erb-prefer-direct-output", () => {
 
   test("fails for empty string literal", () => {
     expectError(
-      'Avoid outputting string literal `""`. Write the text directly without wrapping it in an ERB output tag.',
+      'Avoid outputting string literal `""`. Remove the empty output tag instead.',
     )
 
     assertOffenses('<%= "" %>')
@@ -110,7 +110,7 @@ describe("erb-prefer-direct-output", () => {
 
   test("fails for interpolated string with single expression", () => {
     expectError(
-      'Avoid outputting interpolated string `"#{key}"`. Use separate `<%= %>` tags for each dynamic value instead.',
+      'Avoid outputting interpolated string `"#{key}"`. Use `<%= key %>` instead.',
     )
 
     assertOffenses('<%= "#{key}" %>')
@@ -118,7 +118,7 @@ describe("erb-prefer-direct-output", () => {
 
   test("fails for interpolated string with multiple expressions", () => {
     expectError(
-      'Avoid outputting interpolated string `"#{key} (#{participants.size})"`. Use separate `<%= %>` tags for each dynamic value instead.',
+      'Avoid outputting interpolated string `"#{key} (#{participants.size})"`. Use `<%= key %> (<%= participants.size %>)` instead.',
     )
 
     assertOffenses('<%= "#{key} (#{participants.size})" %>')
@@ -126,15 +126,23 @@ describe("erb-prefer-direct-output", () => {
 
   test("fails for interpolated string with text and expression", () => {
     expectError(
-      'Avoid outputting interpolated string `"Hello #{name}"`. Use separate `<%= %>` tags for each dynamic value instead.',
+      'Avoid outputting interpolated string `"Hello #{name}"`. Use `Hello <%= name %>` instead.',
     )
 
     assertOffenses('<%= "Hello #{name}" %>')
   })
 
+  test("shows the exact rewrite for trailing text", () => {
+    expectError(
+      'Avoid outputting interpolated string `"#{i + 1}."`. Use `<%= i + 1 %>.` instead.',
+    )
+
+    assertOffenses('<%= "#{i + 1}." %>')
+  })
+
   test("fails for raw output with string literal", () => {
     expectError(
-      'Avoid outputting string literal `"Title"`. Write the text directly without wrapping it in an ERB output tag.',
+      'Avoid outputting string literal `"Title"`. Use `Title` instead.',
     )
 
     assertOffenses('<%== "Title" %>')
@@ -142,7 +150,7 @@ describe("erb-prefer-direct-output", () => {
 
   test("fails for raw output with interpolated string", () => {
     expectError(
-      'Avoid outputting interpolated string `"#{key}"`. Use separate `<%= %>` tags for each dynamic value instead.',
+      'Avoid outputting interpolated string `"#{key}"`. Use `<%== key %>` instead.',
     )
 
     assertOffenses('<%== "#{key}" %>')
@@ -150,7 +158,7 @@ describe("erb-prefer-direct-output", () => {
 
   test("fails for string literal inside element", () => {
     expectError(
-      'Avoid outputting string literal `"Title"`. Write the text directly without wrapping it in an ERB output tag.',
+      'Avoid outputting string literal `"Title"`. Use `Title` instead.',
     )
 
     assertOffenses('<h1><%= "Title" %></h1>')
@@ -158,7 +166,7 @@ describe("erb-prefer-direct-output", () => {
 
   test("fails for string literal in attribute value", () => {
     expectError(
-      'Avoid outputting string literal `"active"`. Write the text directly without wrapping it in an ERB output tag.',
+      'Avoid outputting string literal `"active"`. Use `active` instead.',
     )
 
     assertOffenses('<div class="<%= "active" %>">content</div>')
@@ -166,10 +174,10 @@ describe("erb-prefer-direct-output", () => {
 
   test("reports multiple offenses", () => {
     expectError(
-      'Avoid outputting string literal `"Hello"`. Write the text directly without wrapping it in an ERB output tag.',
+      'Avoid outputting string literal `"Hello"`. Use `Hello` instead.',
     )
     expectError(
-      'Avoid outputting string literal `"World"`. Write the text directly without wrapping it in an ERB output tag.',
+      'Avoid outputting string literal `"World"`. Use `World` instead.',
     )
 
     assertOffenses(dedent`
@@ -182,7 +190,7 @@ describe("erb-prefer-direct-output", () => {
 
   test("reports offense at correct location", () => {
     expectError(
-      'Avoid outputting string literal `"Title"`. Write the text directly without wrapping it in an ERB output tag.',
+      'Avoid outputting string literal `"Title"`. Use `Title` instead.',
       [2, 6],
     )
 
@@ -195,10 +203,10 @@ describe("erb-prefer-direct-output", () => {
 
   test("reports mixed string and interpolated string offenses", () => {
     expectError(
-      'Avoid outputting string literal `"Title"`. Write the text directly without wrapping it in an ERB output tag.',
+      'Avoid outputting string literal `"Title"`. Use `Title` instead.',
     )
     expectError(
-      'Avoid outputting interpolated string `"#{key}"`. Use separate `<%= %>` tags for each dynamic value instead.',
+      'Avoid outputting interpolated string `"#{key}"`. Use `<%= key %>` instead.',
     )
 
     assertOffenses(dedent`
@@ -211,7 +219,7 @@ describe("erb-prefer-direct-output", () => {
 
   test("fails for string literal inside control flow", () => {
     expectError(
-      'Avoid outputting string literal `"Admin"`. Write the text directly without wrapping it in an ERB output tag.',
+      'Avoid outputting string literal `"Admin"`. Use `Admin` instead.',
     )
 
     assertOffenses(dedent`
@@ -255,7 +263,7 @@ describe("erb-prefer-direct-output", () => {
 
   test("fails for string literal containing a quote the enclosing attribute does not use", () => {
     expectError(
-      `Avoid outputting string literal \`"it's"\`. Write the text directly without wrapping it in an ERB output tag.`,
+      `Avoid outputting string literal \`"it's"\`. Use \`it's\` instead.`,
     )
 
     assertOffenses(`<div title="<%= "it's" %>">y</div>`)
@@ -263,7 +271,7 @@ describe("erb-prefer-direct-output", () => {
 
   test("fails for string literal containing `>`", () => {
     expectError(
-      'Avoid outputting string literal `"a > b"`. Write the text directly without wrapping it in an ERB output tag.',
+      'Avoid outputting string literal `"a > b"`. Use `a > b` instead.',
     )
 
     assertOffenses('<p><%= "a > b" %></p>')
@@ -271,7 +279,7 @@ describe("erb-prefer-direct-output", () => {
 
   test("fails for interpolated string in a quoted attribute value", () => {
     expectError(
-      'Avoid outputting interpolated string `"#{a}_#{b}"`. Use separate `<%= %>` tags for each dynamic value instead.',
+      'Avoid outputting interpolated string `"#{a}_#{b}"`. Use `<%= a %>_<%= b %>` instead.',
     )
 
     assertOffenses('<div id="<%= "#{a}_#{b}" %>">y</div>')


### PR DESCRIPTION
## Summary

- build each offense recommendation from the same replacement parts used by autocorrect
- show the exact direct-output rewrite while preserving raw `<%==` tags
- give empty string output a clear removal recommendation
- cover the reported trailing-text case and the existing interpolation variants

Closes #2192.

## Validation

- focused `erb-prefer-direct-output` rule suite: 44 passed
- Oxlint on both changed TypeScript files
- `git diff --check`

## AI disclosure

This patch was prepared and validated with OpenAI Codex assistance.
