### PR TITLE
Linter: Improve `actionview-no-implicit-partial` offense message

### DIFF
--- a/javascript/packages/linter/src/rules/actionview-no-implicit-partial.ts
+++ b/javascript/packages/linter/src/rules/actionview-no-implicit-partial.ts
@@ -33,7 +33,7 @@ class ActionViewNoImplicitPartialVisitor extends BaseRuleVisitor {
     const object = node.keywords?.object?.value
 
     this.addOffense(
-      `Rails derives the partial from \`to_partial_path\`${object ? ` on \`${object}\`` : ""} when the template renders, so the template this renders is not named in this \`<%= render %>\` call. Name it explicitly, with \`object:\` for a single record or \`collection:\` for many, and Herb can take you to it, check the locals you pass against its strict locals, and help you rename them.`,
+      `Rails derives the partial from \`to_partial_path\`${object ? ` on \`${object}\`` : ""} when the template renders, so the template this renders is not named in this \`<%= render %>\` call. Name it explicitly with \`<%= render partial: "...", object: @post %>\` for a single record or \`<%= render partial: "...", collection: @posts %>\` for many, and Herb can take you to it, check the locals you pass against its strict locals, and help you rename them.`,
       locationFromByteOffset(source, expression.node.location.startOffset, expression.node.location.length),
     )
   }

--- a/javascript/packages/linter/test/rules/actionview-no-implicit-partial.test.ts
+++ b/javascript/packages/linter/test/rules/actionview-no-implicit-partial.test.ts
@@ -7,7 +7,7 @@ import { createLinterTest } from "../helpers/linter-test-helper.js"
 const { expectNoOffenses, expectInfo, assertOffenses } = createLinterTest(ActionViewNoImplicitPartialRule)
 
 function message(object: string): string {
-  return `Rails derives the partial from \`to_partial_path\` on \`${object}\` when the template renders, so the template this renders is not named in this \`<%= render %>\` call. Name it explicitly, with \`object:\` for a single record or \`collection:\` for many, and Herb can take you to it, check the locals you pass against its strict locals, and help you rename them.`
+  return `Rails derives the partial from \`to_partial_path\` on \`${object}\` when the template renders, so the template this renders is not named in this \`<%= render %>\` call. Name it explicitly with \`<%= render partial: "...", object: @post %>\` for a single record or \`<%= render partial: "...", collection: @posts %>\` for many, and Herb can take you to it, check the locals you pass against its strict locals, and help you rename them.`
 }
 
 describe("actionview-no-implicit-partial", () => {


### PR DESCRIPTION
## Summary

The `actionview-no-implicit-partial` offense now shows complete render examples for both a single object and a collection. This makes the suggested fix directly usable instead of mentioning only the `object:` and `collection:` keywords.

## Testing

- focused rule suite: 25 tests passed
- Oxlint passed for both changed files
- the full linter suite produced the same existing failures as the base commit: 23 test files, 368 tests, and 61 snapshots failed in both runs

Closes #2196
