### PR TITLE
Ruby: Find files through `Configuration` in `Project`/`RenderAnalyzer`

### DIFF
--- a/lib/herb/analysis/render_analyzer.rb
+++ b/lib/herb/analysis/render_analyzer.rb
@@ -751,15 +751,7 @@ module Herb
       end
 
       def find_erb_files
-        patterns = configuration.file_include_patterns
-        exclude = configuration.file_exclude_patterns
-
-        files = patterns.flat_map { |pattern| Dir[File.join(@project_path, pattern)] }.uniq
-
-        files.reject do |file|
-          relative = Pathname.new(file).relative_path_from(@project_path).to_s
-          exclude.any? { |pattern| File.fnmatch?(pattern, relative, File::FNM_PATHNAME) }
-        end.sort
+        configuration.find_files(@project_path)
       end
 
       def find_view_root

--- a/lib/herb/project.rb
+++ b/lib/herb/project.rb
@@ -155,16 +155,7 @@ module Herb
     private
 
     def find_files
-      included = include_patterns.flat_map do |pattern|
-        Dir[File.join(@project_path, pattern)]
-      end.uniq
-
-      return included if exclude_patterns.empty?
-
-      included.reject do |file|
-        relative_path = file.sub("#{@project_path}/", "")
-        exclude_patterns.any? { |pattern| File.fnmatch?(pattern, relative_path, File::FNM_PATHNAME) }
-      end
+      configuration.find_files(@project_path)
     end
 
     public

--- a/test/project_test.rb
+++ b/test/project_test.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+require "tmpdir"
+require "fileutils"
+
+class ProjectTest < Minitest::Spec
+  def setup
+    @project_path = Dir.mktmpdir("herb_project_test")
+  end
+
+  def teardown
+    FileUtils.rm_rf(@project_path)
+    Herb.reset_configuration!
+  end
+
+  def write(relative_path, content = "<p>hello</p>")
+    path = File.join(@project_path, relative_path)
+    FileUtils.mkdir_p(File.dirname(path))
+    File.write(path, content)
+    path
+  end
+
+  def write_config(content)
+    File.write(File.join(@project_path, ".herb.yml"), content)
+  end
+
+  def files_for(project_path)
+    Herb::Project.new(project_path).files.map { |file| File.basename(file) }
+  end
+
+  test "finds the templates the include patterns match" do
+    write("app/views/posts/index.html.erb")
+    write("README.md")
+
+    assert_equal ["index.html.erb"], files_for(@project_path)
+  end
+
+  test "leaves out the templates the exclude patterns match" do
+    write_config("files:\n  exclude:\n    - \"vendor/**\"\n")
+    write("app/views/posts/index.html.erb")
+    write("vendor/bundled.html.erb")
+
+    assert_equal ["index.html.erb"], files_for(@project_path)
+  end
+
+  test "normalizes a project path given with a trailing slash" do
+    write_config("files:\n  exclude:\n    - \"vendor/**\"\n")
+    write("app/views/posts/index.html.erb")
+    write("vendor/bundled.html.erb")
+
+    assert_equal ["index.html.erb"], files_for("#{@project_path}/")
+  end
+
+  test "returns the templates in a stable order" do
+    write("app/views/posts/b.html.erb")
+    write("app/views/posts/a.html.erb")
+    write("app/views/posts/c.html.erb")
+
+    assert_equal ["a.html.erb", "b.html.erb", "c.html.erb"], files_for(@project_path)
+  end
+
+  test "uses the file paths it was given instead of searching" do
+    write("app/views/posts/index.html.erb")
+    only = write("app/views/posts/show.html.erb")
+
+    project = Herb::Project.new(@project_path)
+    project.file_paths = [only]
+
+    assert_equal [only], project.files
+  end
+
+  test "finds no templates in an empty project" do
+    assert_empty files_for(@project_path)
+  end
+end


### PR DESCRIPTION
Multiple places in the gem walked a project looking for templates, and all three implemented the same thing:
* glob every `files.include` pattern relative to the project path
* drop whatever matches a `files.exclude` pattern
* and return the rest.

`Herb::Configuration#find_files` is the one that already had callers outside itself, `herb config` and the dev server's runner both use it. `Herb::Project#find_files` and `Herb::Analysis::RenderAnalyzer#find_erb_files` each carried their own copy. 

This pull request points both of them at `Configuration` and deletes the copies.