### PR TITLE
Playground: Wire in the Language Service

### DIFF
--- a/javascript/packages/language-service/src/hover_provider.ts
+++ b/javascript/packages/language-service/src/hover_provider.ts
@@ -6,7 +6,7 @@ import { IdentityPrinter } from "@herb-tools/printer"
 import { ActionViewTagHelperToHTMLRewriter } from "@herb-tools/rewriter"
 import { isERBOpenTagNode, isHTMLElementNode, isERBContentNode, getNamedCharacterReference, HELPER_BY_SOURCE, HELPER_REGISTRY, CHARACTER_REFERENCE_PATTERN } from "@herb-tools/core"
 import { ParserService } from "./parser_service"
-import { lspPosition, isPositionInRange, rangeSize } from "./range_utils"
+import { lspPosition, isPositionInRange, rangeSize, hasSourceLocation } from "./range_utils"
 
 import type { Node, HTMLElementNode, ERBOpenTagNode, ERBContentNode, HTMLCharacterReference, HelperEntry } from "@herb-tools/core"
 
@@ -18,7 +18,7 @@ class ActionViewElementCollector extends Visitor {
       const content = node.open_tag.content
       const tagName = node.open_tag.tag_name
 
-      if (content && tagName) {
+      if (content && tagName && hasSourceLocation(content.location)) {
         const isTagHelper = node.element_source === "ActionView::Helpers::TagHelper#tag"
         const methodName = isTagHelper ? `tag.${tagName.value}` : node.element_source.split("#").pop()!
 
@@ -67,6 +67,7 @@ class ERBHelperCollector extends Visitor {
 
   private scanContentToken(node: ERBContentNode | ERBOpenTagNode, contentToken: { value: string; location: { start: { line: number; column: number } } } | null | undefined): void {
     if (!contentToken?.value) return
+    if (!hasSourceLocation(contentToken.location)) return
 
     const value = contentToken.value
     const contentStart = lspPosition(contentToken.location.start)

--- a/javascript/packages/language-service/src/range_utils.ts
+++ b/javascript/packages/language-service/src/range_utils.ts
@@ -10,6 +10,10 @@ export function lspLine(herbPosition: SerializedPosition): number {
   return herbPosition.line - 1
 }
 
+export function hasSourceLocation(herbLocation: { start: { line: number } } | null | undefined): boolean {
+  return !!herbLocation && herbLocation.start.line > 0
+}
+
 export function lspRangeFromLocation(herbLocation: SerializedLocation): Range {
   return Range.create(lspPosition(herbLocation.start), lspPosition(herbLocation.end))
 }

--- a/javascript/packages/language-service/test/hover_provider.test.ts
+++ b/javascript/packages/language-service/test/hover_provider.test.ts
@@ -656,6 +656,30 @@ describe("HoverProvider", () => {
       })
     })
 
+    describe("synthesized Action View helper nodes", () => {
+      it("does not throw when a helper expands to a node without a source location", () => {
+        const content = dedent`
+          <div class='x'>
+            <% if user.admin? %>
+              <%= link_to "E", p %>
+            <% end %>
+          </div>
+        `
+
+        const lines = content.split("\n")
+
+        for (let line = 0; line < lines.length; line++) {
+          for (let character = 0; character <= lines[line].length; character++) {
+            expect(() => getHover(content, line, character)).not.toThrow()
+          }
+        }
+      })
+
+      it("still resolves the helper the user actually wrote", () => {
+        expect(hoverValue('<%= link_to "E", p %>', 0, 6)).toContain("link_to")
+      })
+    })
+
     describe("no hover for non-entities", () => {
       it("returns null for bare ampersand", () => {
         expect(getHover("<div>Tom & Jerry</div>", 0, 10)).toBeNull()

--- a/playground/package.json
+++ b/playground/package.json
@@ -22,6 +22,7 @@
     "@herb-tools/browser": "0.10.3",
     "@herb-tools/core": "0.10.3",
     "@herb-tools/formatter": "0.10.3",
+    "@herb-tools/language-service": "0.10.3",
     "@herb-tools/linter": "0.10.3",
     "@herb-tools/printer": "0.10.3",
     "@herb-tools/rewriter": "0.10.3",

--- a/playground/project.json
+++ b/playground/project.json
@@ -19,6 +19,7 @@
         "@herb-tools/core:build",
         "@herb-tools/browser:build",
         "@herb-tools/formatter:build",
+        "@herb-tools/language-service:build",
         "@herb-tools/linter:build",
         "@herb-tools/printer:build",
         "@herb-tools/rewriter:build"

--- a/playground/src/analyze.ts
+++ b/playground/src/analyze.ts
@@ -26,54 +26,97 @@ export type LinterOptions = {
   framework?: Framework
 }
 
-export async function analyze(herb: HerbBackend, source: string, options: ParserOptions = {}, printerOptions: PrintOptions = DEFAULT_PRINT_OPTIONS, formatterOptions: FormatOptions = {}, autofixOptions: AutofixOptions = {}, linterOptions: LinterOptions = {}) {
+export type AnalyzeJob =
+  | "parse"
+  | "full"
+  | "lex"
+  | "ruby"
+  | "html"
+  | "format"
+  | "printer"
+  | "rewrite"
+  | "lint"
+  | "autofix"
+
+export const ALL_ANALYZE_JOBS: AnalyzeJob[] = [
+  "parse",
+  "full",
+  "lex",
+  "ruby",
+  "html",
+  "format",
+  "printer",
+  "rewrite",
+  "lint",
+  "autofix",
+]
+
+export async function analyze(herb: HerbBackend, source: string, options: ParserOptions = {}, printerOptions: PrintOptions = DEFAULT_PRINT_OPTIONS, formatterOptions: FormatOptions = {}, autofixOptions: AutofixOptions = {}, linterOptions: LinterOptions = {}, jobs: Iterable<AnalyzeJob> = ALL_ANALYZE_JOBS) {
   const startTime = performance.now()
+  const requested = new Set(jobs)
+  const wants = (job: AnalyzeJob) => requested.has(job)
 
   const parseResult = await safeExecute<ParseResult>(
     new Promise((resolve) => resolve(herb.parse(source, options))),
   )
 
-  const string = await safeExecute<string>(
-    new Promise((resolve) => resolve(parseResult.value.inspect())),
-  )
+  const parsed = parseResult && parseResult.value
 
-  const json = await safeExecute<string>(
-    new Promise((resolve) =>
-      resolve(JSON.stringify(parseResult.value, null, 2)),
-    ),
-  )
+  const string = wants("parse")
+    ? await safeExecute<string>(
+        new Promise((resolve) => resolve(parseResult.value.inspect())),
+      )
+    : undefined
 
-  const lexResult = await safeExecute<LexResult>(
-    new Promise((resolve) => resolve(herb.lex(source))),
-  )
+  const json = wants("full")
+    ? await safeExecute<string>(
+        new Promise((resolve) => resolve(JSON.stringify(parseResult.value, null, 2))),
+      )
+    : undefined
 
-  const lex = await safeExecute<string>(
-    new Promise((resolve) => resolve(lexResult.value.inspect())),
-  )
+  const lexResult = wants("lex")
+    ? await safeExecute<LexResult>(
+        new Promise((resolve) => resolve(herb.lex(source))),
+      )
+    : undefined
 
-  const ruby = await safeExecute<string>(
-    new Promise((resolve) => resolve(herb.extractRuby(source))),
-  )
+  const lex = wants("lex")
+    ? await safeExecute<string>(
+        new Promise((resolve) => resolve(lexResult!.value.inspect())),
+      )
+    : undefined
 
-  const html = await safeExecute<string>(
-    new Promise((resolve) => resolve(herb.extractHTML(source))),
-  )
+  const ruby = wants("ruby")
+    ? await safeExecute<string>(
+        new Promise((resolve) => resolve(herb.extractRuby(source))),
+      )
+    : undefined
+
+  const html = wants("html")
+    ? await safeExecute<string>(
+        new Promise((resolve) => resolve(herb.extractHTML(source))),
+      )
+    : undefined
 
   const version = await safeExecute<string>(
     new Promise((resolve) => resolve(herb.version)),
   )
 
-  const formatted = await safeExecute<string>(
-    new Promise((resolve) => resolve((new Formatter(herb, formatterOptions)).format(source))),
-  )
+  const formatted = wants("format")
+    ? await safeExecute<string>(
+        new Promise((resolve) => resolve((new Formatter(herb, formatterOptions)).format(source))),
+      )
+    : undefined
 
-  const printed = await safeExecute<string>(
-    new Promise((resolve) => resolve((new IdentityPrinter()).print(parseResult.value, printerOptions))),
-  )
+  const printed = wants("printer")
+    ? await safeExecute<string>(
+        new Promise((resolve) => resolve((new IdentityPrinter()).print(parseResult.value, printerOptions))),
+      )
+    : undefined
 
-  let rewritten: string | null = null
+  let rewritten: string | null | undefined = undefined
 
-  if (parseResult && parseResult.value) {
+  if (parsed && wants("rewrite")) {
     rewritten = await safeExecute<string>(
       new Promise((resolve) => {
         const rewriteParseResult = herb.parse(source, { ...options, track_whitespace: true })
@@ -84,23 +127,26 @@ export async function analyze(herb: HerbBackend, source: string, options: Parser
     )
   }
 
-  let lintResult: LintResult | null = null
-  let autofixResult: AutofixResult | null = null
+  let lintResult: LintResult | null | undefined = undefined
+  let autofixResult: AutofixResult | null | undefined = undefined
 
-  if (parseResult && parseResult.value) {
-    const linter = new Linter(herb)
+  if (parsed) {
     const lintContext = { framework: linterOptions.framework }
 
-    lintResult = await safeExecute<LintResult>(
-      new Promise((resolve) => resolve(linter.lint(source, lintContext))),
-    )
+    if (wants("lint")) {
+      lintResult = await safeExecute<LintResult>(
+        new Promise((resolve) => resolve(new Linter(herb).lint(source, lintContext))),
+      )
+    }
 
-    try {
-      autofixResult = new Linter(herb).autofix(source, lintContext, undefined, { includeUnsafe: autofixOptions.includeUnsafe === true })
-    } catch (error) {
-      console.error(error)
+    if (wants("autofix")) {
+      try {
+        autofixResult = new Linter(herb).autofix(source, lintContext, undefined, { includeUnsafe: autofixOptions.includeUnsafe === true })
+      } catch (error) {
+        console.error(error)
 
-      autofixResult = null
+        autofixResult = null
+      }
     }
   }
 

--- a/playground/src/controllers/playground_controller.js
+++ b/playground/src/controllers/playground_controller.js
@@ -9,8 +9,9 @@ import Prism from "prismjs"
 
 import { Controller } from "@hotwired/stimulus"
 import { replaceTextareaWithMonaco } from "../monaco"
+import { registerLanguageService } from "../language-service"
 import { findTreeLocationItemWithSmallestRangeFromPosition } from "../ranges"
-import { makeTreeCollapsible, expandAllNodes as expandAll, collapseAllNodes as collapseAll, revealTreeLine } from "../tree-collapse"
+import { makeTreeCollapsible, buildCollapsibleTreeHTML, decorateTreeNodeTokens, attachTreeToggles, expandAllNodes as expandAll, collapseAllNodes as collapseAll, revealTreeLine } from "../tree-collapse"
 
 import { Herb } from "@herb-tools/browser"
 import { Linter, rules, fixabilityFor, FRAMEWORKS } from "@herb-tools/linter"
@@ -21,6 +22,7 @@ window.Herb = Herb
 window.analyze = analyze
 
 const URL_UPDATE_THROTTLE = 100
+const ANALYZE_DEBOUNCE = 250
 const DEFAULT_FRAMEWORK = "actionview"
 
 const exampleFile = dedent`
@@ -193,7 +195,9 @@ export default class extends Controller {
     this.inputTarget.focus()
     this.load()
 
-    this.urlUpdatedFromChangeEvent = false
+    this.lastWrittenHash = null
+    this.analyzeTimeout = null
+    this.renderedParseTree = null
 
     this.editor = replaceTextareaWithMonaco("input", this.inputTarget, {
       language: this.isRubyMode ? "ruby" : "erb",
@@ -299,6 +303,14 @@ export default class extends Controller {
   disconnect() {
     window.removeEventListener("popstate", this.handlePopState)
 
+    this.languageService?.dispose()
+    this.languageService = null
+
+    if (this.analyzeTimeout !== null) {
+      clearTimeout(this.analyzeTimeout)
+      this.analyzeTimeout = null
+    }
+
     if (this.urlUpdateTimeout !== null) {
       clearTimeout(this.urlUpdateTimeout)
       this.urlUpdateTimeout = null
@@ -317,14 +329,25 @@ export default class extends Controller {
   }
 
   handlePopState = async (_event) => {
-    if (this.urlUpdatedFromChangeEvent === false) {
-      this.editor.setValue(this.decompressedValue)
-    }
+    if (window.parent.location.hash.slice(1) === this.lastWrittenHash) return
+
+    this.editor.setValue(this.decompressedValue)
   }
 
   async load() {
     await Herb.load()
+    this.setupLanguageService()
     this.analyze()
+  }
+
+  setupLanguageService() {
+    if (this.isRubyMode) return
+    if (this.languageService) return
+
+    this.languageService = registerLanguageService(Herb)
+    this.languageService.setFramework(this.getLinterOptions().framework)
+
+    window.languageService = this.languageService
   }
 
   updateURL() {
@@ -388,6 +411,7 @@ export default class extends Controller {
     this.lastURLUpdateAt = Date.now()
 
     if (hash !== null && hash !== location.hash.slice(1)) {
+      this.lastWrittenHash = hash
       location.hash = hash
     }
 
@@ -682,6 +706,21 @@ export default class extends Controller {
     }
   }
 
+  get activeTab() {
+    return this.activeViewerButton?.dataset?.viewer ?? "parse"
+  }
+
+  get analyzeJobs() {
+    const jobs = ["lint"]
+    const tab = this.activeTab
+
+    if (this.isValidTab(tab) && tab !== "diagnostics" && tab !== "diff") {
+      jobs.push(tab)
+    }
+
+    return jobs
+  }
+
   isValidTab(tab) {
     const validTabs = ['parse', 'lex', 'ruby', 'html', 'format', 'autofix', 'printer', 'diagnostics', 'rewrite', 'diff', 'full']
     return validTabs.includes(tab)
@@ -749,6 +788,7 @@ export default class extends Controller {
 
     this.setActiveTab(tabName)
     this.updateTabInURL(tabName)
+    this.analyze()
   }
 
   showDiagnostics(_event) {
@@ -1381,10 +1421,42 @@ export default class extends Controller {
     })
   }
 
-  async input() {
-    this.urlUpdatedFromChangeEvent = true
-    await this.analyze()
-    this.urlUpdatedFromChangeEvent = false
+  renderParseTree(tree) {
+    if (!this.hasParseOutputTarget) return
+    if (this.renderedParseTree === tree) return
+
+    this.renderedParseTree = tree
+
+    this.parseOutputTarget.classList.add("language-tree")
+
+    const highlighted = Prism.highlight(tree, Prism.languages.tree, "tree")
+
+    this.parseOutputTarget.innerHTML = buildCollapsibleTreeHTML(highlighted, tree)
+
+    decorateTreeNodeTokens(this.parseOutputTarget)
+    attachTreeToggles(this.parseOutputTarget)
+
+    this.treeLocations.forEach(({ element, locationElement, location }) => {
+      this.setupHoverListener(locationElement, location)
+      this.setupHoverListener(element, location)
+
+      if (element.classList.contains("string")) {
+        this.setupHoverListener(element.previousElementSibling, location)
+      }
+    })
+  }
+
+  input() {
+    this.scheduleAnalyze()
+  }
+
+  scheduleAnalyze() {
+    if (this.analyzeTimeout !== null) clearTimeout(this.analyzeTimeout)
+
+    this.analyzeTimeout = setTimeout(() => {
+      this.analyzeTimeout = null
+      this.analyze()
+    }, ANALYZE_DEBOUNCE)
   }
 
   async formatEditor(event) {
@@ -1399,7 +1471,7 @@ export default class extends Controller {
     try {
       const value = this.editor ? this.editor.getValue() : this.inputTarget.value
       const formatterOptions = this.getFormatterOptions()
-      const result = await analyze(Herb, value, {}, {}, formatterOptions)
+      const result = await analyze(Herb, value, {}, {}, formatterOptions, {}, {}, ["format"])
 
       if (result.formatted) {
         if (this.editor) {
@@ -1544,7 +1616,7 @@ export default class extends Controller {
     const formatterOptions = this.getFormatterOptions()
     const autofixOptions = this.getAutofixOptions()
     const linterOptions = this.getLinterOptions()
-    const result = await analyze(Herb, value, options, printerOptions, formatterOptions, autofixOptions, linterOptions)
+    const result = await analyze(Herb, value, options, printerOptions, formatterOptions, autofixOptions, linterOptions, this.analyzeJobs)
 
     this.updatePosition(1, 0, value.length)
 
@@ -1664,31 +1736,18 @@ export default class extends Controller {
       }
     }
 
-    if (this.hasParseOutputTarget) {
-      this.parseOutputTarget.classList.add("language-tree")
-      this.parseOutputTarget.textContent = result.string
-
-      Prism.highlightElement(this.parseOutputTarget)
-      makeTreeCollapsible(this.parseOutputTarget)
-
-      this.treeLocations.forEach(({ element, locationElement, location }) => {
-        this.setupHoverListener(locationElement, location)
-        this.setupHoverListener(element, location)
-
-        if (element.classList.contains("string")) {
-          this.setupHoverListener(element.previousElementSibling, location)
-        }
-      })
+    if (result.string !== undefined) {
+      this.renderParseTree(result.string)
     }
 
-    if (this.hasHtmlViewerTarget) {
+    if (this.hasHtmlViewerTarget && result.html !== undefined) {
       this.htmlViewerTarget.classList.add("language-html")
       this.htmlViewerTarget.textContent = result.html
 
       Prism.highlightElement(this.htmlViewerTarget)
     }
 
-    if (this.hasRewriteViewerTarget) {
+    if (this.hasRewriteViewerTarget && result.rewritten !== undefined) {
       const options = this.getParserOptions()
 
       if (this.hasRewriteActionViewHelpersTarget) {
@@ -1714,7 +1773,7 @@ export default class extends Controller {
     const currentSource = this.editor ? this.editor.getValue() : this.inputTarget.value
     const isWellFormatted = currentSource === result.formatted
 
-    if (this.hasFormatViewerTarget) {
+    if (this.hasFormatViewerTarget && result.formatted !== undefined) {
       if (hasParserErrors) {
         this.formatSuccessTarget.classList.add('hidden')
         this.formatErrorTarget.classList.remove('hidden')
@@ -1748,7 +1807,7 @@ export default class extends Controller {
       }
     }
 
-    if (this.hasAutofixViewerTarget) {
+    if (this.hasAutofixViewerTarget && result.autofixResult !== undefined) {
       const autofixResult = result.autofixResult
       const autofixedSource = autofixResult && typeof autofixResult.source === "string" ? autofixResult.source : null
       const fixedCount = autofixResult && Array.isArray(autofixResult.fixed) ? autofixResult.fixed.length : 0
@@ -1841,21 +1900,21 @@ export default class extends Controller {
       }
     }
 
-    if (this.hasRubyViewerTarget) {
+    if (this.hasRubyViewerTarget && result.ruby !== undefined) {
       this.rubyViewerTarget.classList.add("language-ruby")
       this.rubyViewerTarget.textContent = result.ruby
 
       Prism.highlightElement(this.rubyViewerTarget)
     }
 
-    if (this.hasLexViewerTarget) {
+    if (this.hasLexViewerTarget && result.lex !== undefined) {
       this.lexViewerTarget.classList.add("language-tree")
       this.lexViewerTarget.textContent = result.lex
 
       Prism.highlightElement(this.lexViewerTarget)
     }
 
-    if (this.hasPrinterViewerTarget) {
+    if (this.hasPrinterViewerTarget && result.printed !== undefined) {
       const printedContent = result.printed || 'No printed output available'
 
       if (typeof printedContent === 'string' && printedContent.startsWith('Error: Cannot print')) {
@@ -2091,6 +2150,7 @@ export default class extends Controller {
   }
 
   onLinterOptionChange(_event) {
+    this.languageService?.setFramework(this.getLinterOptions().framework)
     this.updateURL()
     this.analyze()
   }
@@ -2360,14 +2420,12 @@ export default class extends Controller {
     )
 
     if (filteredDiagnostics.length === 0) {
-      console.log('No diagnostics, showing message')
       this.diagnosticsListTarget.classList.add('hidden')
       this.noDiagnosticsTarget.classList.remove('hidden')
       this.updateNoDiagnosticsMessage()
       return
     }
 
-    console.log('Has diagnostics, showing list')
     this.noDiagnosticsTarget.classList.add('hidden')
     this.diagnosticsListTarget.classList.remove('hidden')
 
@@ -2900,14 +2958,7 @@ export default class extends Controller {
   }
 
   updateNoDiagnosticsMessage() {
-    console.log('updateNoDiagnosticsMessage called', {
-      hasTarget: !!this.noDiagnosticsTarget,
-      filter: this.currentDiagnosticsFilter,
-      allDiagnosticsCount: this.allDiagnostics?.length || 0
-    })
-
     if (!this.hasNoDiagnosticsTarget) {
-      console.log('No noDiagnosticsTarget found')
       return
     }
 

--- a/playground/src/language-service.js
+++ b/playground/src/language-service.js
@@ -1,0 +1,258 @@
+import {
+  languages,
+  Range as MonacoRange,
+} from "monaco-editor/esm/vs/editor/edcore.main.js"
+
+import {
+  ParserService,
+  HoverProvider,
+  CompletionProvider,
+  FoldingRangeProvider,
+  DocumentSymbolProvider,
+  DocumentHighlightProvider,
+  TextDocument,
+  CompletionItemKind,
+  SymbolKind,
+  DocumentHighlightKind,
+  InsertTextFormat,
+} from "@herb-tools/language-service"
+
+const LANGUAGE_ID = "erb"
+const DOCUMENT_URI = "file:///playground.html.erb"
+const BASE_DIR = "/"
+const PARSE_CACHE_LIMIT = 12
+
+const TRIGGER_CHARACTERS = [".", ":", "<", "&", '"', "'", "/", ",", " ", "@"]
+
+function kindsByName(lspKind, monacoKind) {
+  const mapping = new Map()
+
+  for (const [name, value] of Object.entries(lspKind)) {
+    if (typeof value !== "number") continue
+    if (typeof monacoKind[name] !== "number") continue
+
+    mapping.set(value, monacoKind[name])
+  }
+
+  return mapping
+}
+
+const COMPLETION_KINDS = kindsByName(CompletionItemKind, languages.CompletionItemKind)
+const SYMBOL_KINDS = kindsByName(SymbolKind, languages.SymbolKind)
+const HIGHLIGHT_KINDS = kindsByName(DocumentHighlightKind, languages.DocumentHighlightKind)
+
+const FOLDING_KINDS = {
+  comment: languages.FoldingRangeKind.Comment,
+  imports: languages.FoldingRangeKind.Imports,
+  region: languages.FoldingRangeKind.Region,
+}
+
+function lspPosition(position) {
+  return { line: position.lineNumber - 1, character: position.column - 1 }
+}
+
+function monacoRange(range) {
+  return new MonacoRange(
+    range.start.line + 1,
+    range.start.character + 1,
+    range.end.line + 1,
+    range.end.character + 1,
+  )
+}
+
+function documentFor(model) {
+  return TextDocument.create(
+    DOCUMENT_URI,
+    LANGUAGE_ID,
+    model.getVersionId(),
+    model.getValue(),
+  )
+}
+
+function markdownFor(contents) {
+  if (contents === null || contents === undefined) return []
+  if (typeof contents === "string") return [{ value: contents }]
+  if (Array.isArray(contents)) return contents.flatMap(markdownFor)
+  if (typeof contents.kind === "string") return [{ value: contents.value }]
+
+  return [{ value: `\`\`\`${contents.language}\n${contents.value}\n\`\`\`` }]
+}
+
+function completionItemFor(item, fallbackRange) {
+  const edit = item.textEdit
+
+  return {
+    label: item.label,
+    kind: COMPLETION_KINDS.get(item.kind) ?? languages.CompletionItemKind.Text,
+    detail: item.detail,
+    documentation: markdownFor(item.documentation)[0],
+    insertText: edit?.newText ?? item.insertText ?? item.label,
+    insertTextRules:
+      item.insertTextFormat === InsertTextFormat.Snippet
+        ? languages.CompletionItemInsertTextRule.InsertAsSnippet
+        : undefined,
+    filterText: item.filterText,
+    sortText: item.sortText,
+    range: edit ? monacoRange(edit.range ?? edit.replace) : fallbackRange,
+  }
+}
+
+function documentSymbolFor(symbol) {
+  return {
+    name: symbol.name,
+    detail: symbol.detail ?? "",
+    kind: SYMBOL_KINDS.get(symbol.kind) ?? languages.SymbolKind.Variable,
+    tags: symbol.tags ?? [],
+    range: monacoRange(symbol.range),
+    selectionRange: monacoRange(symbol.selectionRange),
+    children: (symbol.children ?? []).map(documentSymbolFor),
+  }
+}
+
+function safely(operation, fallback) {
+  try {
+    return operation()
+  } catch (error) {
+    console.error("[herb language service]", error)
+
+    return fallback
+  }
+}
+
+class CachingParserService extends ParserService {
+  #cache = new Map()
+
+  #remember(key, compute) {
+    if (this.#cache.has(key)) {
+      const cached = this.#cache.get(key)
+
+      this.#cache.delete(key)
+      this.#cache.set(key, cached)
+
+      return cached
+    }
+
+    const value = compute()
+
+    this.#cache.set(key, value)
+
+    if (this.#cache.size > PARSE_CACHE_LIMIT) {
+      this.#cache.delete(this.#cache.keys().next().value)
+    }
+
+    return value
+  }
+
+  parseDocument(textDocument) {
+    return this.#remember(
+      `document ${textDocument.getText()}`,
+      () => super.parseDocument(textDocument),
+    )
+  }
+}
+
+export function createLanguageService(herb) {
+  const parserService = new CachingParserService(herb)
+
+  return {
+    hover: new HoverProvider(parserService, BASE_DIR),
+    completion: new CompletionProvider(parserService),
+    folding: new FoldingRangeProvider(parserService),
+    symbols: new DocumentSymbolProvider(parserService),
+    highlights: new DocumentHighlightProvider(parserService),
+  }
+}
+
+export function registerLanguageService(herb) {
+  const service = createLanguageService(herb)
+
+  const disposables = [
+    languages.registerHoverProvider(LANGUAGE_ID, {
+      provideHover(model, position) {
+        return safely(() => {
+          const hover = service.hover.getHover(documentFor(model), lspPosition(position))
+
+          if (!hover) return null
+
+          return {
+            contents: markdownFor(hover.contents),
+            range: hover.range ? monacoRange(hover.range) : undefined,
+          }
+        }, null)
+      },
+    }),
+
+    languages.registerCompletionItemProvider(LANGUAGE_ID, {
+      triggerCharacters: TRIGGER_CHARACTERS,
+
+      provideCompletionItems(model, position) {
+        return safely(() => {
+          const list = service.completion.getCompletions(
+            documentFor(model),
+            lspPosition(position),
+          )
+
+          if (!list) return { suggestions: [] }
+
+          const word = model.getWordUntilPosition(position)
+
+          const fallbackRange = new MonacoRange(
+            position.lineNumber,
+            word.startColumn,
+            position.lineNumber,
+            word.endColumn,
+          )
+
+          return {
+            incomplete: list.isIncomplete,
+            suggestions: list.items.map(item => completionItemFor(item, fallbackRange)),
+          }
+        }, { suggestions: [] })
+      },
+    }),
+
+    languages.registerFoldingRangeProvider(LANGUAGE_ID, {
+      provideFoldingRanges(model) {
+        return safely(() =>
+          service.folding.getFoldingRanges(documentFor(model)).map(range => ({
+            start: range.startLine + 1,
+            end: range.endLine + 1,
+            kind: FOLDING_KINDS[range.kind],
+          })), [])
+      },
+    }),
+
+    languages.registerDocumentSymbolProvider(LANGUAGE_ID, {
+      displayName: "Herb",
+
+      provideDocumentSymbols(model) {
+        return safely(() =>
+          service.symbols.getDocumentSymbols(documentFor(model)).map(documentSymbolFor), [])
+      },
+    }),
+
+    languages.registerDocumentHighlightProvider(LANGUAGE_ID, {
+      provideDocumentHighlights(model, position) {
+        return safely(() =>
+          service.highlights
+            .getDocumentHighlights(documentFor(model), lspPosition(position))
+            .map(highlight => ({
+              range: monacoRange(highlight.range),
+              kind: HIGHLIGHT_KINDS.get(highlight.kind),
+            })), [])
+      },
+    }),
+  ]
+
+  return {
+    providers: service,
+
+    setFramework(framework) {
+      service.completion.setFramework(framework)
+    },
+
+    dispose() {
+      disposables.forEach(disposable => disposable.dispose())
+    },
+  }
+}

--- a/playground/src/language-service.js
+++ b/playground/src/language-service.js
@@ -10,6 +10,7 @@ import {
   FoldingRangeProvider,
   DocumentSymbolProvider,
   DocumentHighlightProvider,
+  RewriteCodeActionProvider,
   TextDocument,
   CompletionItemKind,
   SymbolKind,
@@ -23,6 +24,7 @@ const BASE_DIR = "/"
 const PARSE_CACHE_LIMIT = 12
 
 const TRIGGER_CHARACTERS = [".", ":", "<", "&", '"', "'", "/", ",", " ", "@"]
+const REWRITE_CODE_ACTION_KIND = "refactor.rewrite"
 
 function kindsByName(lspKind, monacoKind) {
   const mapping = new Map()
@@ -58,6 +60,30 @@ function monacoRange(range) {
     range.end.line + 1,
     range.end.character + 1,
   )
+}
+
+function lspRange(range) {
+  return {
+    start: { line: range.startLineNumber - 1, character: range.startColumn - 1 },
+    end: { line: range.endLineNumber - 1, character: range.endColumn - 1 },
+  }
+}
+
+function codeActionFor(action, model) {
+  const changes = action.edit?.changes ?? {}
+
+  const edits = Object.values(changes).flat().map(edit => ({
+    resource: model.uri,
+    versionId: undefined,
+    textEdit: { range: monacoRange(edit.range), text: edit.newText },
+  }))
+
+  return {
+    title: action.title,
+    kind: action.kind,
+    isPreferred: action.isPreferred,
+    edit: { edits },
+  }
 }
 
 function documentFor(model) {
@@ -160,6 +186,7 @@ export function createLanguageService(herb) {
     folding: new FoldingRangeProvider(parserService),
     symbols: new DocumentSymbolProvider(parserService),
     highlights: new DocumentHighlightProvider(parserService),
+    rewriteCodeActions: new RewriteCodeActionProvider(parserService, BASE_DIR),
   }
 }
 
@@ -228,6 +255,24 @@ export function registerLanguageService(herb) {
       provideDocumentSymbols(model) {
         return safely(() =>
           service.symbols.getDocumentSymbols(documentFor(model)).map(documentSymbolFor), [])
+      },
+    }),
+
+    languages.registerCodeActionProvider(LANGUAGE_ID, {
+      providedCodeActionKinds: [REWRITE_CODE_ACTION_KIND],
+
+      provideCodeActions(model, range) {
+        return safely(() => {
+          const actions = service.rewriteCodeActions.getCodeActions(
+            documentFor(model),
+            lspRange(range),
+          )
+
+          return {
+            actions: actions.map(action => codeActionFor(action, model)),
+            dispose() {},
+          }
+        }, { actions: [], dispose() {} })
       },
     }),
 

--- a/playground/src/monaco-environment.js
+++ b/playground/src/monaco-environment.js
@@ -1,0 +1,7 @@
+import EditorWorker from "monaco-editor/esm/vs/editor/editor.worker.js?worker"
+
+self.MonacoEnvironment = {
+  getWorker() {
+    return new EditorWorker()
+  },
+}

--- a/playground/src/monaco.js
+++ b/playground/src/monaco.js
@@ -1,3 +1,5 @@
+import "./monaco-environment.js"
+
 import {
   editor as MonacoEditor,
   Selection,
@@ -10,6 +12,28 @@ import {
 
 import "monaco-editor/esm/vs/basic-languages/ruby/ruby.contribution.js"
 
+const OVERFLOW_WIDGETS_ROOT_ID = "monaco-overflow-widgets-root"
+
+/**
+ * Returns the shared body-level node Monaco renders overflow widgets into
+ *
+ * @returns {HTMLElement} - The overflow widgets root
+ */
+function overflowWidgetsRoot() {
+  const existing = document.getElementById(OVERFLOW_WIDGETS_ROOT_ID)
+
+  if (existing) return existing
+
+  const root = document.createElement("div")
+
+  root.id = OVERFLOW_WIDGETS_ROOT_ID
+  root.classList.add("monaco-editor")
+
+  document.body.appendChild(root)
+
+  return root
+}
+
 /**
  * Replaces a textarea with a Monaco editor instance
  *
@@ -18,11 +42,7 @@ import "monaco-editor/esm/vs/basic-languages/ruby/ruby.contribution.js"
  * @param {Object} options - Monaco editor options
  * @returns {Object} - The Monaco editor instance
  */
-export function replaceTextareaWithMonaco(
-  textareaId,
-  textareaElement = null,
-  options = {},
-) {
+export function replaceTextareaWithMonaco(textareaId, textareaElement = null, options = {}) {
   const textarea =
     textareaElement ||
     document.getElementById(textareaId) ||
@@ -71,6 +91,8 @@ export function replaceTextareaWithMonaco(
     fontSize: 14,
     suggestFontSize: 14,
     lineHeight: 21,
+    fixedOverflowWidgets: true,
+    overflowWidgetsDomNode: overflowWidgetsRoot(),
   }
 
   const editor = MonacoEditor.create(container, {

--- a/playground/src/tree-collapse.js
+++ b/playground/src/tree-collapse.js
@@ -1,46 +1,78 @@
-export function makeTreeCollapsible(element) {
-  const html = element.innerHTML
-  const lines = html.split("\n")
+export function buildCollapsibleTreeHTML(highlightedHTML, plainSource = null) {
+  const lines = highlightedHTML.split("\n")
+  const plainLines = plainSource === null ? null : plainSource.split("\n")
+  const depthsMatch = plainLines !== null && plainLines.length === lines.length
 
-  const processedLines = lines.map((lineHtml, index) => {
-    const tempElement = document.createElement("span")
-    tempElement.innerHTML = lineHtml
-    const plainText = tempElement.textContent || ""
-    const depth = getLineDepth(plainText)
+  let html = ""
+
+  for (let index = 0; index < lines.length; index++) {
+    const lineHtml = lines[index]
+
+    const depth = depthsMatch
+      ? getLineDepth(plainLines[index])
+      : getLineDepth(plainTextOf(lineHtml))
+
     const isNodeLine = lineHtml.includes('class="token node"') || lineHtml.includes('class="token error-class"')
 
     const toggleHtml = isNodeLine
       ? '<span class="tree-toggle" data-collapsed="false"></span>'
       : ""
 
-    const classes = ["tree-line"]
-    if (isNodeLine) classes.push("tree-collapsible")
+    const classes = isNodeLine ? "tree-line tree-collapsible" : "tree-line"
 
-    return `<span class="${classes.join(" ")}" data-depth="${depth}" data-line-index="${index}">${toggleHtml}${lineHtml}</span>`
+    html += `<span class="${classes}" data-depth="${depth}" data-line-index="${index}">${toggleHtml}${lineHtml}</span>`
+  }
+
+  return html
+}
+
+export function decorateTreeNodeTokens(element) {
+  element.querySelectorAll(".tree-collapsible .token.node, .tree-collapsible .token.error-class").forEach((token) => {
+    token.dataset.name = token.textContent.replace(/^@ /, "")
+    token.dataset.prefix = "@"
   })
+}
 
-  element.innerHTML = processedLines.join("")
+export function attachTreeToggles(element) {
+  if (element.dataset.treeTogglesAttached === "true") return
 
-  element.querySelectorAll(".tree-toggle").forEach((toggle) => {
-    toggle.addEventListener("click", (event) => {
+  element.dataset.treeTogglesAttached = "true"
+
+  element.addEventListener("click", (event) => {
+    const toggle = event.target.closest(".tree-toggle")
+
+    if (toggle && element.contains(toggle)) {
       event.preventDefault()
       event.stopPropagation()
       toggleTreeNode(toggle)
-    })
-  })
 
-  element.querySelectorAll(".tree-collapsible .token.node, .tree-collapsible .token.error-class").forEach((token) => {
-    const name = token.textContent.replace(/^@ /, "")
-    token.dataset.name = name
-    token.dataset.prefix = "@"
+      return
+    }
 
-    token.addEventListener("click", (event) => {
+    const token = event.target.closest(".tree-collapsible .token.node, .tree-collapsible .token.error-class")
+
+    if (token && element.contains(token)) {
       event.preventDefault()
       event.stopPropagation()
-      const toggle = token.closest(".tree-collapsible").querySelector(".tree-toggle")
-      if (toggle) toggleTreeNode(toggle)
-    })
+
+      const lineToggle = token.closest(".tree-collapsible").querySelector(".tree-toggle")
+      if (lineToggle) toggleTreeNode(lineToggle)
+    }
   })
+}
+
+export function makeTreeCollapsible(element, plainSource = null) {
+  element.innerHTML = buildCollapsibleTreeHTML(element.innerHTML, plainSource)
+
+  decorateTreeNodeTokens(element)
+  attachTreeToggles(element)
+}
+
+function plainTextOf(lineHtml) {
+  const tempElement = document.createElement("span")
+  tempElement.innerHTML = lineHtml
+
+  return tempElement.textContent || ""
 }
 
 export function expandAllNodes(element) {


### PR DESCRIPTION
This pull request wires `@herb-tools/language-service` into the Playground, so the Monaco editor gains the same hover, completion, folding, document symbol and document highlight support the language server already offers. 

It also reworks how the Playground schedules its analysis, because registering those providers made an existing performance problem much more visible.

So `playground/src/language-service.js` mirrors `Session` from the language server, swapping the Node.js pieces for browser equivalents, and registers a Monaco adapter per provider.

**`HoverProvider`**:

<img width="2230" height="886" alt="CleanShot 2026-08-12 at 23 08 03@2x" src="https://github.com/user-attachments/assets/38f68652-f8e8-4dd4-aab9-49f2e7f90dd0" />

**`CompletionProvider`**:

<img width="1720" height="932" alt="CleanShot 2026-08-12 at 23 06 13@2x" src="https://github.com/user-attachments/assets/e6089957-25e1-455d-94c2-87744a6158f5" />

**`CompletionProvider `** for `render`:

<img width="1788" height="1102" alt="CleanShot 2026-08-12 at 23 06 23@2x" src="https://github.com/user-attachments/assets/63ae8a8c-4f78-4b7a-9afb-3ce1f2168b85" />

**`DocumentHighlightProvider`**:

<img width="1508" height="636" alt="CleanShot 2026-08-12 at 23 06 34@2x" src="https://github.com/user-attachments/assets/f120d289-5d77-4a82-9a5f-022241cf830c" />

**`FoldingRangeProvider`**:

<img width="1586" height="596" alt="CleanShot 2026-08-12 at 23 06 40@2x" src="https://github.com/user-attachments/assets/85090c1f-3568-45a8-b469-29904e2b4ca8" />

**`DocumentSymbolProvider`**:

<img width="1980" height="640" alt="CleanShot 2026-08-12 at 23 11 02@2x" src="https://github.com/user-attachments/assets/6014ec8e-985f-4455-8ebb-ac7f0c98dbc0" />


**`RewriteCodeActionProvider`**:

<img width="1320" height="762" alt="CleanShot 2026-08-12 at 23 21 31@2x" src="https://github.com/user-attachments/assets/91771a71-f404-4915-8bcb-ee7b04b5da01" />

