### PR TITLE
Language Service: Don't mutate the parse tree when hovering or commenting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -196,3 +196,5 @@ compile_flags.txt
 .envrc.local
 
 .github/pull_request.md
+javascript/packages/formatter/test-explicit-config/
+javascript/packages/formatter/test-no-config/

--- a/javascript/packages/language-service/src/comment_ast_utils.ts
+++ b/javascript/packages/language-service/src/comment_ast_utils.ts
@@ -5,7 +5,7 @@ import { HTMLCommentNode, Token } from "@herb-tools/core"
 import { IdentityPrinter } from "@herb-tools/printer"
 
 import { isERBCommentNode, isLiteralNode, createLiteral } from "@herb-tools/core"
-import { asMutable } from "@herb-tools/rewriter"
+import { asMutable, cloneNode } from "@herb-tools/rewriter"
 
 import type { Node, ERBContentNode } from "@herb-tools/core"
 
@@ -137,11 +137,12 @@ export function commentLineContent(content: string, erbNodes: ERBContentNode[], 
   }
 
   const parseResult = parserService.parseContent(content, { track_whitespace: true })
+  const document = cloneNode(parseResult.value)
   const lineCollector = new LineContextCollector()
-  parseResult.visit(lineCollector)
+
+  lineCollector.visit(document)
 
   const lineERBNodes = lineCollector.erbNodesPerLine.get(0) || []
-  const document = parseResult.value
   const children = asMutable(document).children
 
   switch (strategy) {
@@ -203,12 +204,12 @@ function commentPerSegment(content: string, erbNodes: ERBContentNode[]): string 
 
 export function uncommentLineContent(content: string, parserService: ParserService): string {
   const parseResult = parserService.parseContent(content, { track_whitespace: true })
+  const document = cloneNode(parseResult.value)
   const lineCollector = new LineContextCollector()
 
-  parseResult.visit(lineCollector)
+  lineCollector.visit(document)
 
   const lineERBNodes = lineCollector.erbNodesPerLine.get(0) || []
-  const document = parseResult.value
   const children = asMutable(document).children
 
   for (const node of lineERBNodes) {

--- a/javascript/packages/language-service/src/hover_provider.ts
+++ b/javascript/packages/language-service/src/hover_provider.ts
@@ -3,7 +3,7 @@ import { TextDocument } from "vscode-languageserver-textdocument"
 
 import { Visitor } from "@herb-tools/core"
 import { IdentityPrinter } from "@herb-tools/printer"
-import { ActionViewTagHelperToHTMLRewriter } from "@herb-tools/rewriter"
+import { ActionViewTagHelperToHTMLRewriter, cloneNode } from "@herb-tools/rewriter"
 import { isERBOpenTagNode, isHTMLElementNode, isERBContentNode, getNamedCharacterReference, HELPER_BY_SOURCE, HELPER_REGISTRY, CHARACTER_REFERENCE_PATTERN } from "@herb-tools/core"
 import { ParserService } from "./parser_service"
 import { lspPosition, isPositionInRange, rangeSize } from "./range_utils"
@@ -185,7 +185,7 @@ export class HoverProvider {
 
     if (isLeaf) {
       const rewriter = new ActionViewTagHelperToHTMLRewriter()
-      const rewrittenNode = rewriter.rewrite(bestElement.node, { baseDir: this.baseDir, shallow: true })
+      const rewrittenNode = rewriter.rewrite(cloneNode(bestElement.node), { baseDir: this.baseDir, shallow: true })
       const htmlOutput = IdentityPrinter.print(rewrittenNode)
 
       parts.push(`**HTML equivalent**\n\`\`\`erb\n${dedent(htmlOutput.trim())}\n\`\`\``)
@@ -278,15 +278,15 @@ export class HoverProvider {
 
     if (!match) return ""
 
-    const rewrittenNode = rewriter.rewrite(match.node, {
+    const rewrittenNode = rewriter.rewrite(cloneNode(match.node), {
       baseDir: this.baseDir,
       shallow: true,
       includeBody: options.includeBody,
     })
 
     if (!options.includeBody) {
-      const openTag = match.node.open_tag ? IdentityPrinter.print(match.node.open_tag) : ""
-      const closeTag = match.node.close_tag ? IdentityPrinter.print(match.node.close_tag) : ""
+      const openTag = rewrittenNode.open_tag ? IdentityPrinter.print(rewrittenNode.open_tag) : ""
+      const closeTag = rewrittenNode.close_tag ? IdentityPrinter.print(rewrittenNode.close_tag) : ""
       return `${openTag}\n  ...\n${closeTag}`
     }
 

--- a/javascript/packages/language-service/src/rewrite_code_action_provider.ts
+++ b/javascript/packages/language-service/src/rewrite_code_action_provider.ts
@@ -94,9 +94,9 @@ export class RewriteCodeActionProvider {
     if (parseResult.failed) return null
 
     const rewriter = new ActionViewTagHelperToHTMLRewriter()
-    rewriter.rewrite(parseResult.value as Node, { baseDir: this.baseDir })
+    const rewrittenNode = rewriter.rewrite(parseResult.value as Node, { baseDir: this.baseDir })
 
-    const rewrittenText = IdentityPrinter.print(parseResult.value)
+    const rewrittenText = IdentityPrinter.print(rewrittenNode)
 
     if (rewrittenText === originalText) return null
 
@@ -130,9 +130,9 @@ export class RewriteCodeActionProvider {
     if (parseResult.failed) return null
 
     const rewriter = new HTMLToActionViewTagHelperRewriter()
-    rewriter.rewrite(parseResult.value as Node, { baseDir: this.baseDir })
+    const rewrittenNode = rewriter.rewrite(parseResult.value as Node, { baseDir: this.baseDir })
 
-    const rewrittenText = IdentityPrinter.print(parseResult.value)
+    const rewrittenText = IdentityPrinter.print(rewrittenNode)
 
     if (rewrittenText === originalText) return null
 

--- a/javascript/packages/language-service/test/comment_ast_utils.test.ts
+++ b/javascript/packages/language-service/test/comment_ast_utils.test.ts
@@ -14,6 +14,8 @@ import {
   uncommentLineContent,
 } from "../src/comment_ast_utils"
 
+import type { ParseOptions, ParseResult } from "@herb-tools/core"
+
 describe("comment_ast_utils", () => {
   let parserService: ParserService
 
@@ -338,6 +340,50 @@ describe("comment_ast_utils", () => {
       const result = uncommentLineContent(`<%# a %><%# b %><%# c %>`, parserService)
 
       expect(result).toBe("<% a %><% b %><% c %>")
+    })
+  })
+
+  describe("with a caching parser service", () => {
+    class CachingParserService extends ParserService {
+      private cache = new Map<string, ParseResult>()
+
+      parseContent(content: string, options?: ParseOptions): ParseResult {
+        const key = `${JSON.stringify(options ?? {})}:${content}`
+
+        if (!this.cache.has(key)) {
+          this.cache.set(key, super.parseContent(content, options))
+        }
+
+        return this.cache.get(key)!
+      }
+    }
+
+    function erbNodes(content: string) {
+      const collector = new LineContextCollector()
+
+      Herb.parse(content, { track_whitespace: true }).visit(collector)
+
+      return collector.erbNodesPerLine.get(0) || []
+    }
+
+    it("comments the same line content twice", () => {
+      const caching = new CachingParserService(Herb)
+      const content = `<%= link_to "Edit", edit_path %> text`
+
+      const first = commentLineContent(content, erbNodes(content), "whole-line", caching)
+      const second = commentLineContent(content, erbNodes(content), "whole-line", caching)
+
+      expect(first).toBe(`<!-- <%#= link_to "Edit", edit_path %> text -->`)
+      expect(second).toBe(first)
+    })
+
+    it("uncomments a line that was commented before", () => {
+      const caching = new CachingParserService(Herb)
+      const content = `<%# a %>`
+
+      commentLineContent(content, erbNodes(content), "all-erb", caching)
+
+      expect(uncommentLineContent(content, caching)).toBe(`<% a %>`)
     })
   })
 })

--- a/javascript/packages/language-service/test/hover_provider.test.ts
+++ b/javascript/packages/language-service/test/hover_provider.test.ts
@@ -8,6 +8,8 @@ import { HoverProvider } from "../src/hover_provider"
 import { ParserService } from "../src/parser_service"
 import { Herb } from "@herb-tools/node-wasm"
 
+import type { ParseOptions, ParseResult } from "@herb-tools/core"
+
 describe("HoverProvider", () => {
   let parserService: ParserService
   let service: HoverProvider
@@ -668,6 +670,60 @@ describe("HoverProvider", () => {
       it("returns null for invalid named reference", () => {
         expect(getHover("<div>&notarealentity;</div>", 0, 10)).toBeNull()
       })
+    })
+  })
+
+  describe("with a caching parser service", () => {
+    class CachingParserService extends ParserService {
+      private cache = new Map<string, ParseResult>()
+
+      parseContent(content: string, options?: ParseOptions): ParseResult {
+        const key = `${JSON.stringify(options ?? {})}:${content}`
+
+        if (!this.cache.has(key)) {
+          this.cache.set(key, super.parseContent(content, options))
+        }
+
+        return this.cache.get(key)!
+      }
+    }
+
+    it("keeps returning the same hover when the parse result is reused", () => {
+      const content = dedent`
+        <div class='x'>
+          <% if user.admin? %>
+            <%= link_to "E", p %>
+          <% end %>
+        </div>
+      `
+
+      const provider = new HoverProvider(new CachingParserService(Herb))
+      const document = createDocument(content)
+      const position = Position.create(2, 9)
+
+      const first = provider.getHover(document, position)
+      const second = provider.getHover(document, position)
+
+      expect(first).not.toBeNull()
+      expect(second).toEqual(first)
+    })
+
+    it("keeps returning the same hover for an element with a body", () => {
+      const content = dedent`
+        <%= tag.div class: "x" do %>
+          <span>Content</span>
+        <% end %>
+      `
+
+      const provider = new HoverProvider(new CachingParserService(Herb))
+      const document = createDocument(content)
+      const position = Position.create(0, 5)
+
+      const first = provider.getHover(document, position)
+      const second = provider.getHover(document, position)
+
+      expect(first).not.toBeNull()
+      expect(second).toEqual(first)
     })
   })
 })

--- a/javascript/packages/rewriter/README.md
+++ b/javascript/packages/rewriter/README.md
@@ -272,6 +272,22 @@ function rewrite<T extends Node>(
 - `output`: The rewritten template string
 - `node`: The transformed AST node (preserves input type)
 
+> [!NOTE]
+> Rewriters transform the node in place, so `rewrite()` takes ownership of the node it is given. Pass a `cloneNode()` copy when the tree has to stay intact, for example when it comes from a shared or cached parse result.
+
+#### `cloneNode()`
+
+Deep-copy an AST node, so it can be handed to a rewriter without the rewrite reaching the original tree.
+
+```typescript
+function cloneNode<T extends Node>(node: T): T
+```
+
+**Parameters:**
+- `node`: The AST node to copy
+
+**Returns:** An independent copy of the node. Every reachable node is copied, while tokens and locations are shared with the original.
+
 #### `rewriteString()`
 
 Convenience wrapper around `rewrite()` that parses the template string first and returns just the output string.

--- a/javascript/packages/rewriter/src/ast-rewriter.ts
+++ b/javascript/packages/rewriter/src/ast-rewriter.ts
@@ -62,6 +62,10 @@ export abstract class ASTRewriter {
    * This method is called synchronously for each file being formatted.
    * Modify the AST in place or return a new Node.
    *
+   * Rewriters take ownership of the node they are given, so a caller that
+   * keeps using its tree afterwards, such as one holding a shared or cached
+   * parse result, has to pass a `cloneNode()` copy instead.
+   *
    * @param node - The AST node from @herb-tools/core
    * @param context - Context with filePath and baseDir
    * @returns The modified Node (can be the same object mutated in place)

--- a/javascript/packages/rewriter/src/clone.ts
+++ b/javascript/packages/rewriter/src/clone.ts
@@ -1,0 +1,53 @@
+import { Node } from "@herb-tools/core"
+
+/**
+ * Deep-copy an AST node, so it can be handed to a rewriter that mutates in
+ * place while the original tree stays intact.
+ *
+ * Every `Node` reachable from the given node is copied, which covers everything
+ * a rewriter can reassign. `Token`, `Location` and `Position` are value objects
+ * that rewriters replace rather than modify, so they are shared with the
+ * original. Node identity is preserved within a single copy, so a node
+ * reachable through more than one path is copied once.
+ *
+ * @example
+ * const rewritten = rewriter.rewrite(cloneNode(node), context)
+ */
+export function cloneNode<T extends Node>(node: T): T {
+  return copyNode(node, new Map())
+}
+
+function copyNode<T extends Node>(node: T, copies: Map<Node, Node>): T {
+  const existing = copies.get(node)
+
+  if (existing) return existing as T
+
+  const copy = Object.create(Object.getPrototypeOf(node)) as T
+
+  copies.set(node, copy)
+
+  for (const key of Object.keys(node)) {
+    (copy as any)[key] = copyValue((node as any)[key], copies)
+  }
+
+  return copy
+}
+
+function copyValue(value: unknown, copies: Map<Node, Node>): unknown {
+  if (Array.isArray(value)) return value.map(entry => copyValue(entry, copies))
+  if (isNodeInstance(value)) return copyNode(value, copies)
+
+  return value
+}
+
+/**
+ * A backend can bundle its own copy of `@herb-tools/core`, which makes the
+ * nodes it produces fail `instanceof Node` here, so fall back to the shape
+ * every node has.
+ */
+function isNodeInstance(value: unknown): value is Node {
+  if (value instanceof Node) return true
+  if (typeof value !== "object" || value === null) return false
+
+  return typeof (value as any).accept === "function" && typeof (value as any).compactChildNodes === "function"
+}

--- a/javascript/packages/rewriter/src/index.ts
+++ b/javascript/packages/rewriter/src/index.ts
@@ -5,6 +5,7 @@ export { HTMLToActionViewTagHelperRewriter, serializeTagHelperAttributes } from 
 export { StringRewriter } from "./string-rewriter.js"
 
 export { asMutable } from "./mutable.js"
+export { cloneNode } from "./clone.js"
 export { isASTRewriterClass, isStringRewriterClass, isRewriterClass } from "./type-guards.js"
 
 export { rewrite, rewriteString } from "./rewrite.js"

--- a/javascript/packages/rewriter/test/clone.test.ts
+++ b/javascript/packages/rewriter/test/clone.test.ts
@@ -1,0 +1,151 @@
+import dedent from "dedent"
+import { describe, test, expect, beforeAll } from "vitest"
+
+import { Herb } from "@herb-tools/node-wasm"
+import { IdentityPrinter } from "@herb-tools/printer"
+
+import { cloneNode, ActionViewTagHelperToHTMLRewriter, HTMLToActionViewTagHelperRewriter, ERBStringToDirectOutputRewriter } from "../src/index.js"
+
+import type { Node, HTMLElementNode } from "@herb-tools/core"
+import type { ASTRewriter, RewriteContext } from "../src/index.js"
+
+function parse(source: string, options = {}): Node {
+  const parseResult = Herb.parse(source, { track_whitespace: true, ...options })
+
+  if (parseResult.failed) {
+    throw new Error(
+      `Parser errors:\n${parseResult.recursiveErrors().map(error => `  - ${error.message}`).join("\n")}`
+    )
+  }
+
+  return parseResult.value
+}
+
+function rewriteCopy(rewriter: ASTRewriter, node: Node, context: RewriteContext = { baseDir: process.cwd() }): Node {
+  const source = IdentityPrinter.print(node)
+  const tree = node.inspect()
+
+  const rewritten = rewriter.rewrite(cloneNode(node), context)
+
+  expect(IdentityPrinter.print(node)).toBe(source)
+  expect(node.inspect()).toBe(tree)
+  expect(rewritten).not.toBe(node)
+
+  return rewritten
+}
+
+describe("cloneNode", () => {
+  beforeAll(async () => {
+    await Herb.load()
+  })
+
+  test("returns an equivalent tree", () => {
+    const node = parse('<div class="one two"><span>Content</span></div>')
+    const copy = cloneNode(node)
+
+    expect(copy).not.toBe(node)
+    expect(copy.constructor).toBe(node.constructor)
+    expect(copy.type).toBe(node.type)
+    expect(IdentityPrinter.print(copy)).toBe(IdentityPrinter.print(node))
+    expect(copy.inspect()).toBe(node.inspect())
+  })
+
+  test("copies nested nodes and arrays", () => {
+    const node = parse("<div><span>Content</span></div>")
+    const copy = cloneNode(node)
+
+    expect(copy.compactChildNodes()[0]).not.toBe(node.compactChildNodes()[0])
+    expect((copy as any).children).not.toBe((node as any).children)
+
+    const element = node.compactChildNodes()[0] as HTMLElementNode
+    const copiedElement = copy.compactChildNodes()[0] as HTMLElementNode
+
+    expect(copiedElement.open_tag).not.toBe(element.open_tag)
+    expect(copiedElement.body[0]).not.toBe(element.body[0])
+  })
+
+  test("shares tokens and locations with the original", () => {
+    const node = parse("<div>Content</div>")
+    const copy = cloneNode(node)
+
+    const element = node.compactChildNodes()[0] as HTMLElementNode
+    const copiedElement = copy.compactChildNodes()[0] as HTMLElementNode
+
+    expect(copiedElement.location).toBe(element.location)
+    expect(copiedElement.open_tag!.tag_name).toBe(element.open_tag!.tag_name)
+  })
+
+  test("keeps the source available on copied nodes", () => {
+    const node = parse('<div><%= "Content" %></div>', { prism_nodes: true })
+    const copy = cloneNode(node)
+
+    expect(node.source).not.toBeNull()
+    expect(copy.source).toBe(node.source)
+    expect(copy.compactChildNodes()[0].source).toBe(node.compactChildNodes()[0].source)
+  })
+
+  test("mutating the copy leaves the original untouched", () => {
+    const node = parse("<div>Content</div>")
+    const copy = cloneNode(node)
+
+    const element = copy.compactChildNodes()[0] as HTMLElementNode
+
+    ;(element as any).element_source = "MUTATED"
+    ;(element as any).body = []
+
+    expect((node.compactChildNodes()[0] as HTMLElementNode).element_source).not.toBe("MUTATED")
+    expect((node.compactChildNodes()[0] as HTMLElementNode).body.length).toBe(1)
+  })
+})
+
+describe("rewriting a copy leaves the input node untouched", () => {
+  beforeAll(async () => {
+    await Herb.load()
+  })
+
+  test("ActionViewTagHelperToHTMLRewriter", () => {
+    const node = parse('<%= link_to "Edit", edit_path %>', { action_view_helpers: true })
+    const rewritten = rewriteCopy(new ActionViewTagHelperToHTMLRewriter(), node)
+
+    expect(IdentityPrinter.print(rewritten)).toBe('<a href="<%= edit_path %>">Edit</a>')
+  })
+
+  test("ActionViewTagHelperToHTMLRewriter with shallow", () => {
+    const source = dedent`
+      <div class='x'>
+        <% if user.admin? %>
+          <%= link_to "E", p %>
+        <% end %>
+      </div>
+    `
+
+    const node = parse(source, { action_view_helpers: true })
+
+    rewriteCopy(new ActionViewTagHelperToHTMLRewriter(), node, { baseDir: process.cwd(), shallow: true })
+  })
+
+  test("ActionViewTagHelperToHTMLRewriter can be run repeatedly on the same tree", () => {
+    const node = parse('<%= tag.div class: "one" do %>Content<% end %>', { action_view_helpers: true })
+    const rewriter = new ActionViewTagHelperToHTMLRewriter()
+    const context = { baseDir: process.cwd(), shallow: true }
+
+    const first = IdentityPrinter.print(rewriter.rewrite(cloneNode(node), context))
+    const second = IdentityPrinter.print(rewriter.rewrite(cloneNode(node), context))
+
+    expect(second).toBe(first)
+  })
+
+  test("HTMLToActionViewTagHelperRewriter", () => {
+    const node = parse('<div class="one">Content</div>')
+    const rewritten = rewriteCopy(new HTMLToActionViewTagHelperRewriter(), node)
+
+    expect(IdentityPrinter.print(rewritten)).toBe('<%= tag.div "Content", class: "one" %>')
+  })
+
+  test("ERBStringToDirectOutputRewriter", () => {
+    const node = parse('<p><%= "Title" %></p>', { prism_nodes: true })
+    const rewritten = rewriteCopy(new ERBStringToDirectOutputRewriter(), node)
+
+    expect(IdentityPrinter.print(rewritten)).toBe("<p>Title</p>")
+  })
+})


### PR DESCRIPTION
This pull request updates `HoverProvider` and the comment utilities to work on a copy of the tree they were handed, so neither one rewrites a parse result its caller still needs.

AST rewriters transform the node they receive in place, which is what the formatter wants, since it parses the template itself and throws the tree away afterwards. Two spots in the language service do not own the tree they mutate. `HoverProvider` takes an element out of a parse result and passes it straight to `ActionViewTagHelperToHTMLRewriter`, and `commentLineContent()` / `uncommentLineContent()` rewrite `tag_opening` tokens and splice `document.children` on whatever `parserService.parseContent()` returned.

Both stay invisible today because every request re-parses and the mutated tree is discarded. They break as soon as a parse result is cached and reused, which is the obvious next step for the language service, since it currently re-parses the whole document for every hover, completion and document symbol request.