### PR TITLE
Linter: Update `erb-no-output-control-flow` message for end tags

### DIFF
--- a/javascript/packages/linter/src/rules/erb-no-output-control-flow.ts
+++ b/javascript/packages/linter/src/rules/erb-no-output-control-flow.ts
@@ -76,8 +76,12 @@ class ERBNoOutputControlFlowRuleVisitor extends BaseRuleVisitor<ERBNoOutputContr
       const tagClosing = controlBlock.tag_closing?.value ?? "%>"
       const suggestion = collapsedContent ? `<%${collapsedContent}${tagClosing}` : `<% ${keyword} ... ${tagClosing}`
 
+      const message = controlBlock.type === "AST_ERB_END_NODE"
+        ? `\`end\` should not be used with an output tag. Use \`${suggestion}\` instead.`
+        : `Control flow statements like \`${keyword}\` should not be used with output tags. Use \`${suggestion}\` instead.`
+
       this.addOffense(
-        `Control flow statements like \`${keyword}\` should not be used with output tags. Use \`${suggestion}\` instead.`,
+        message,
         openTag.location,
         { node: controlBlock as Mutable<OutputControlFlowNode> },
       )

--- a/javascript/packages/linter/test/rules/erb-no-output-control-flow.test.ts
+++ b/javascript/packages/linter/test/rules/erb-no-output-control-flow.test.ts
@@ -50,7 +50,7 @@ describe("erb-no-output-control-flow", () => {
       <%= end %>
     `
 
-    expectError("Control flow statements like `end` should not be used with output tags. Use `<% end %>` instead.")
+    expectError("`end` should not be used with an output tag. Use `<% end %>` instead.")
     assertOffenses(html)
   })
 
@@ -81,7 +81,7 @@ describe("erb-no-output-control-flow", () => {
 
     expectError("Control flow statements like `elsif` should not be used with output tags. Use `<% elsif false %>` instead.")
     expectError("Control flow statements like `else` should not be used with output tags. Use `<% else %>` instead.")
-    expectError("Control flow statements like `end` should not be used with output tags. Use `<% end %>` instead.")
+    expectError("`end` should not be used with an output tag. Use `<% end %>` instead.")
     assertOffenses(html)
   })
 


### PR DESCRIPTION
## Summary

`end` isn't a control flow statement — it's just the closing keyword — so reusing the generic "Control flow statements like `end` should not be used with output tags" phrasing for it was misleading. This gives the `end` case its own message.

Before: `Control flow statements like \`end\` should not be used with output tags. Use \`<% end %>\` instead.`

After: `` `end` should not be used with an output tag. Use `<% end %>` instead. ``

Only the message for the end-tag case changes; `if`/`unless`/`elsif`/`else` keep the existing "Control flow statements like ..." wording.

Fixes #2203

## Testing

- `yarn vitest run` in `javascript/packages/linter` — 193 test files, 4295 passed (9 expected fail, 32 todo), no regressions