### PR TITLE
Linter CLI: Don't lint every file twice when running `--fix`

### DIFF
--- a/javascript/packages/linter/src/cli/file-processor.ts
+++ b/javascript/packages/linter/src/cli/file-processor.ts
@@ -357,7 +357,7 @@ export class FileProcessor {
           partials: this.partials,
           partialCallers: this.partialCallers,
           projectPath: this.projectPath
-        }, undefined, { includeUnsafe: context?.fixUnsafe })
+        }, lintResult.offenses, { includeUnsafe: context?.fixUnsafe })
 
         if (autofixResult.fixed.length > 0) {
           writeFileSync(filePath, autofixResult.source, "utf-8")

--- a/javascript/packages/linter/src/cli/lint-worker.ts
+++ b/javascript/packages/linter/src/cli/lint-worker.ts
@@ -121,7 +121,7 @@ async function run() {
         partials,
         partialCallers,
         projectPath: data.projectPath
-      }, undefined, { includeUnsafe: data.fixUnsafe })
+      }, lintResult.offenses, { includeUnsafe: data.fixUnsafe })
 
       if (autofixResult.fixed.length > 0) {
         writeFileSync(filePath, autofixResult.source, "utf-8")

--- a/javascript/packages/linter/test/autofix-offenses.test.ts
+++ b/javascript/packages/linter/test/autofix-offenses.test.ts
@@ -1,0 +1,90 @@
+import dedent from "dedent"
+
+import { describe, test, expect, beforeAll } from "vitest"
+import { Herb } from "@herb-tools/node-wasm"
+
+import { Linter } from "../src/linter.js"
+
+import type { AutofixResult, LintContext } from "../src/types.js"
+
+describe("Linter#autofix with explicit offenses", () => {
+  beforeAll(async () => {
+    await Herb.load()
+  })
+
+  const context: Partial<LintContext> = { fileName: "app/views/posts/index.html.erb" }
+
+  function ruleNames(offenses: AutofixResult["fixed"]): string[] {
+    return offenses.map(offense => offense.rule).sort()
+  }
+
+  function bothWays(source: string, options?: { includeUnsafe?: boolean }): [AutofixResult, AutofixResult] {
+    const linter = new Linter(Herb)
+    const lintResult = linter.lint(source, context)
+
+    expect(lintResult.offenses.length).toBeGreaterThan(0)
+
+    const reused = linter.autofix(source, context, lintResult.offenses, options)
+    const relinted = linter.autofix(source, context, undefined, options)
+
+    return [reused, relinted]
+  }
+
+  function expectSameResult(source: string, options?: { includeUnsafe?: boolean }) {
+    const [reused, relinted] = bothWays(source, options)
+
+    expect(reused.source).toBe(relinted.source)
+    expect(ruleNames(reused.fixed)).toEqual(ruleNames(relinted.fixed))
+    expect(ruleNames(reused.unfixed)).toEqual(ruleNames(relinted.unfixed))
+
+    return reused
+  }
+
+  test("fixes the same offenses as autofix that lints internally", () => {
+    const source = dedent`
+      <DIV CLASS='card'>
+        <span>Hello</span>
+      </DIV>
+    `
+
+    const result = expectSameResult(source)
+
+    expect(result.fixed.length).toBeGreaterThan(0)
+    expect(result.source).not.toBe(source)
+  })
+
+  test("fixes the same offenses across parser and source rules", () => {
+    const source = "<div class='card'>  \n  <img src='a.png'>\n</div>"
+
+    const result = expectSameResult(source)
+
+    expect(result.fixed.length).toBeGreaterThan(0)
+  })
+
+  test("fixes the same offenses with unsafe fixes included", () => {
+    const source = dedent`
+      <DIV CLASS='card'>
+        <%= "Hello" %>
+      </DIV>
+    `
+
+    expectSameResult(source, { includeUnsafe: true })
+  })
+
+  test("leaves the same offenses unfixed", () => {
+    const source = dedent`
+      <div>
+        <img src="a.png">
+      </div>
+    `
+
+    const linter = new Linter(Herb)
+    const lintResult = linter.lint(source, context)
+
+    const reused = linter.autofix(source, context, lintResult.offenses)
+    const relinted = linter.autofix(source, context, undefined)
+
+    expect(ruleNames(reused.unfixed)).toEqual(ruleNames(relinted.unfixed))
+    expect(reused.unfixed.length).toBeGreaterThan(0)
+  })
+})


### PR DESCRIPTION
This pull request passes the offenses the CLI already has into `autofix()`, so a `--fix` run stops linting each file a second time.

`Linter#autofix()` takes an optional `offensesToFix` argument and starts with:

```ts
const lintResult = offensesToFix ? { offenses: offensesToFix } : this.lint(source, context)
```

Both CLI fix paths passed `undefined` there, right after having linted the very same content one line earlier. Every fixable file therefore went through the full rule set twice, which is a whole lint pass rather than just a second parse.

The same change applies to `lint-worker.ts` for runs with `--jobs`.