### PR TITLE
Linter:  Add `dedent` as an explicit dependency

### DIFF
--- a/javascript/packages/linter/package.json
+++ b/javascript/packages/linter/package.json
@@ -4,7 +4,7 @@
   "description": "HTML+ERB linter for validating HTML structure and enforcing best practices",
   "license": "MIT",
   "homepage": "https://herb-tools.dev",
-  "bugs": "https://github.com/marcoroth/herb/issues/new?title=Package%20%60@herb-tools/linter%60:%20",
+  "bugs": "https://github.com/marcoroth/herb/issues/new?title=Package%20%64@herb-tools/linter%60:%20",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/marcoroth/herb.git",
@@ -55,6 +55,7 @@
     "@herb-tools/printer": "0.10.3",
     "@herb-tools/rewriter": "0.10.3",
     "@ruby/prism": "^1.9.0",
+    "dedent": "^1.7.2",
     "picomatch": "^4.0.5",
     "tinyglobby": "^0.2.15"
   },

--- a/javascript/packages/linter/package.json
+++ b/javascript/packages/linter/package.json
@@ -4,7 +4,7 @@
   "description": "HTML+ERB linter for validating HTML structure and enforcing best practices",
   "license": "MIT",
   "homepage": "https://herb-tools.dev",
-  "bugs": "https://github.com/marcoroth/herb/issues/new?title=Package%20%64@herb-tools/linter%60:%20",
+  "bugs": "https://github.com/marcoroth/herb/issues/new?title=Package%20%60@herb-tools/linter%60:%20",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/marcoroth/herb.git",


### PR DESCRIPTION
Fixes #2213.

`dedent` is imported in `src/rules/erb-no-conditional-html-element.ts` and `src/cli/argument-parser.ts` but was missing from `dependencies` in `javascript/packages/linter/package.json`. This causes `ERR_MODULE_NOT_FOUND` for anyone importing the unbundled `dist/` modules directly.

## Change

Add `"dedent": "^1.7.2"` to `dependencies` (version already present in `yarn.lock`).

## Why it was invisible

`bin/herb-lint` loads the pre-bundled `dist/herb-lint.js` which already inlines `dedent`, so the CLI path is unaffected. The missing declaration only surfaces when importing `dist/rules.js` or individual rule modules directly.