### PR TITLE
Parser: Count errors in `error_count` so binding can skip the error walk

### DIFF
--- a/.github/workflows/corpus.yml
+++ b/.github/workflows/corpus.yml
@@ -152,7 +152,17 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NUMBER: ${{ github.event.pull_request.number }}
+          FROM_FORK: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
         run: |-
+          if [ "$FROM_FORK" = "true" ]; then
+            echo "Pull request comes from a fork, so the token cannot comment. Report follows."
+            echo
+
+            cat comment.md
+
+            exit 0
+          fi
+
           existing=$(gh api "repos/${{ github.repository }}/issues/$NUMBER/comments" \
             --jq 'map(select(.body | contains("<!-- corpus-report -->"))) | .[0].id // empty')
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -163,6 +163,7 @@ Metrics/ParameterLists:
     - lib/herb/diff_operation.rb
     - lib/herb/engine/diagnostics.rb
     - lib/herb/errors.rb
+    - lib/herb/parse_result.rb
     - lib/herb/parser_options.rb
     - lib/herb/prism_inspect.rb
 

--- a/ext/herb/extension.c
+++ b/ext/herb/extension.c
@@ -39,7 +39,15 @@ typedef struct {
 static VALUE parse_convert_body(VALUE arg) {
   parse_args_T* args = (parse_args_T*) arg;
 
-  return create_parse_result(args->root, args->source, args->parser_options);
+  // Reset the per-parse error counter, then record the total on the result so
+  // Ruby can skip the recursive error walk when the template parsed cleanly.
+  herb_ext_error_count = 0;
+
+  VALUE result = create_parse_result(args->root, args->source, args->parser_options);
+
+  rb_ivar_set(result, rb_intern("@total_error_count"), UINT2NUM(herb_ext_error_count));
+
+  return result;
 }
 
 static VALUE parse_cleanup(VALUE arg) {

--- a/ext/herb/extension.c
+++ b/ext/herb/extension.c
@@ -39,15 +39,7 @@ typedef struct {
 static VALUE parse_convert_body(VALUE arg) {
   parse_args_T* args = (parse_args_T*) arg;
 
-  // Reset the per-parse error counter, then record the total on the result so
-  // Ruby can skip the recursive error walk when the template parsed cleanly.
-  herb_ext_error_count = 0;
-
-  VALUE result = create_parse_result(args->root, args->source, args->parser_options);
-
-  rb_ivar_set(result, rb_intern("@total_error_count"), UINT2NUM(herb_ext_error_count));
-
-  return result;
+  return create_parse_result(args->root, args->source, args->parser_options);
 }
 
 static VALUE parse_cleanup(VALUE arg) {
@@ -209,6 +201,9 @@ static VALUE Herb_parse(int argc, VALUE* argv, VALUE self) {
       parser_options.max_errors = NIL_P(max_errors) ? 0 : (uint32_t) NUM2UINT(max_errors);
     }
   }
+
+  uint32_t error_count = 0;
+  parser_options.error_count = &error_count;
 
   parse_args_T args = { 0 };
   args.source = source;

--- a/ext/herb/extension_helpers.c
+++ b/ext/herb/extension_helpers.c
@@ -23,10 +23,6 @@ const char* check_string(VALUE value) {
   return RSTRING_PTR(value);
 }
 
-// Accumulates the number of errors attached to AST nodes during the current
-// parse's materialization (see rb_errors_array_from_c_array). Reset per parse.
-uint32_t herb_ext_error_count = 0;
-
 static ID id_line, id_column, id_start, id_end, id_from, id_to, id_value, id_range, id_location, id_type;
 static bool ast_value_ivar_ids_initialized = false;
 
@@ -141,7 +137,9 @@ VALUE create_parse_result(AST_DOCUMENT_NODE_T* root, VALUE source, const parser_
   VALUE parser_options_args[1] = { kwargs };
   VALUE parser_options = rb_class_new_instance_kw(1, parser_options_args, cParserOptions, RB_PASS_KEYWORDS);
 
-  VALUE args[5] = { value, source, warnings, errors, parser_options };
+  VALUE error_count = options->error_count != NULL ? UINT2NUM(*options->error_count) : Qnil;
 
-  return rb_class_new_instance(5, args, cParseResult);
+  VALUE args[6] = { value, source, warnings, errors, parser_options, error_count };
+
+  return rb_class_new_instance(6, args, cParseResult);
 }

--- a/ext/herb/extension_helpers.c
+++ b/ext/herb/extension_helpers.c
@@ -23,6 +23,10 @@ const char* check_string(VALUE value) {
   return RSTRING_PTR(value);
 }
 
+// Accumulates the number of errors attached to AST nodes during the current
+// parse's materialization (see rb_errors_array_from_c_array). Reset per parse.
+uint32_t herb_ext_error_count = 0;
+
 static ID id_line, id_column, id_start, id_end, id_from, id_to, id_value, id_range, id_location, id_type;
 static bool ast_value_ivar_ids_initialized = false;
 

--- a/ext/herb/extension_helpers.h
+++ b/ext/herb/extension_helpers.h
@@ -11,6 +11,12 @@
 #include "../../src/include/location/position.h"
 #include "../../src/include/location/range.h"
 
+// Total number of errors materialized onto AST nodes during the current parse.
+// Accumulated by rb_errors_array_from_c_array as the tree is built and read by
+// Herb_parse to record a total on the ParseResult, letting Ruby skip the full
+// recursive error walk when a template parsed cleanly.
+extern uint32_t herb_ext_error_count;
+
 const char* check_string(VALUE value);
 VALUE rb_string_from_hb_string(hb_string_T string);
 

--- a/ext/herb/extension_helpers.h
+++ b/ext/herb/extension_helpers.h
@@ -11,12 +11,6 @@
 #include "../../src/include/location/position.h"
 #include "../../src/include/location/range.h"
 
-// Total number of errors materialized onto AST nodes during the current parse.
-// Accumulated by rb_errors_array_from_c_array as the tree is built and read by
-// Herb_parse to record a total on the ParseResult, letting Ruby skip the full
-// recursive error walk when a template parsed cleanly.
-extern uint32_t herb_ext_error_count;
-
 const char* check_string(VALUE value);
 VALUE rb_string_from_hb_string(hb_string_T string);
 

--- a/java/extension_helpers.c
+++ b/java/extension_helpers.c
@@ -92,21 +92,24 @@ jobject CreateParseResult(JNIEnv* env, AST_DOCUMENT_NODE_T* root, jstring source
 
   jclass arrayListClass = (*env)->FindClass(env, "java/util/ArrayList");
   jmethodID arrayListConstructor = (*env)->GetMethodID(env, arrayListClass, "<init>", "()V");
-  jmethodID addMethod = (*env)->GetMethodID(env, arrayListClass, "add", "(Ljava/lang/Object;)Z");
 
   jobject errorsList = (*env)->NewObject(env, arrayListClass, arrayListConstructor);
 
-  if (root->base.errors) {
-    for (size_t i = 0; i < hb_array_size(root->base.errors); i++) {
-      AST_NODE_T* error_node = (AST_NODE_T*) hb_array_get(root->base.errors, i);
-      jobject errorObj = CreateErrorNode(env, error_node);
-      (*env)->CallBooleanMethod(env, errorsList, addMethod, errorObj);
-    }
+  jobject errorCount = NULL;
+
+  if (options->error_count != NULL) {
+    jclass integerClass = (*env)->FindClass(env, "java/lang/Integer");
+    jmethodID valueOf = (*env)->GetStaticMethodID(env, integerClass, "valueOf", "(I)Ljava/lang/Integer;");
+    errorCount = (*env)->CallStaticObjectMethod(env, integerClass, valueOf, (jint) *options->error_count);
   }
 
   jclass parseResultClass = (*env)->FindClass(env, "org/herb/ParseResult");
   jmethodID constructor = (*env)->GetMethodID(
-      env, parseResultClass, "<init>", "(Lorg/herb/ast/Node;Ljava/util/List;Ljava/lang/String;)V");
+      env,
+      parseResultClass,
+      "<init>",
+      "(Lorg/herb/ast/Node;Ljava/util/List;Ljava/lang/String;Ljava/lang/Integer;)V"
+  );
 
-  return (*env)->NewObject(env, parseResultClass, constructor, value, errorsList, source);
+  return (*env)->NewObject(env, parseResultClass, constructor, value, errorsList, source, errorCount);
 }

--- a/java/herb_jni.c
+++ b/java/herb_jni.c
@@ -181,6 +181,9 @@ Java_org_herb_Herb_parse(JNIEnv* env, jclass clazz, jstring source, jobject opti
     return NULL;
   }
 
+  uint32_t error_count = 0;
+  parser_options.error_count = &error_count;
+
   AST_DOCUMENT_NODE_T* ast = herb_parse(src, &parser_options, &allocator);
 
   jobject result = CreateParseResult(env, ast, source, &parser_options);

--- a/java/org/herb/HerbTest.java
+++ b/java/org/herb/HerbTest.java
@@ -103,6 +103,22 @@ public class HerbTest {
   }
 
   @Test
+  void testErrorCount() {
+    ParseResult clean = Herb.parse("<div class=\"example\">content</div>");
+    ParseResult unclosed = Herb.parse("<div>");
+    ParseResult rubyError = Herb.parse("<% if condition without end %>");
+
+    assertEquals(Integer.valueOf(0), clean.errorCount);
+    assertEquals(0, clean.recursiveErrors().size());
+
+    assertEquals(Integer.valueOf(1), unclosed.errorCount);
+    assertEquals(unclosed.errorCount.intValue(), unclosed.recursiveErrors().size());
+
+    assertEquals(Integer.valueOf(1), rubyError.errorCount);
+    assertEquals(rubyError.errorCount.intValue(), rubyError.recursiveErrors().size());
+  }
+
+  @Test
   void testParserOptionsTrackLocations() {
     String source = "<div class=\"example\">content</div>";
 

--- a/java/org/herb/ParseResult.java
+++ b/java/org/herb/ParseResult.java
@@ -7,20 +7,31 @@ import java.util.Collections;
 import java.util.List;
 
 public class ParseResult {
-  public final Node value;
   private final List<Node> errors;
+
+  public final Node value;
   public final String source;
+  public final Integer errorCount;
 
   public ParseResult(Node value, List<Node> errors, String source) {
+    this(value, errors, source, null);
+  }
+
+  public ParseResult(Node value, List<Node> errors, String source, Integer errorCount) {
     this.value = value;
     this.errors = Collections.unmodifiableList(errors);
     this.source = source;
+    this.errorCount = errorCount;
   }
 
   public List<Node> recursiveErrors() {
     List<Node> result = new ArrayList<>();
 
     result.addAll(errors);
+
+    if (errorCount != null && errorCount == 0) {
+      return result;
+    }
 
     if (value != null) {
       result.addAll(value.recursiveErrors());

--- a/java/org/herb/ast/BaseNode.java
+++ b/java/org/herb/ast/BaseNode.java
@@ -6,6 +6,8 @@ import org.herb.Location;
  * Abstract base class for all AST nodes.
  */
 public abstract class BaseNode implements Node {
+  protected abstract void collectErrors(java.util.List<Node> accumulator);
+
   protected final String type;
   protected final Location location;
   protected final java.util.List<Node> errors;

--- a/java/org/herb/ast/ErrorNode.java
+++ b/java/org/herb/ast/ErrorNode.java
@@ -32,11 +32,17 @@ public class ErrorNode extends BaseNode {
 
   @Override
   public List<Node> recursiveErrors() {
-    if (errors != null && !errors.isEmpty()) {
-      return new ArrayList<>(errors);
-    }
+    List<Node> accumulator = new ArrayList<>();
+    collectErrors(accumulator);
 
-    return Collections.emptyList();
+    return accumulator;
+  }
+
+  @Override
+  protected void collectErrors(List<Node> accumulator) {
+    if (errors != null && !errors.isEmpty()) {
+      accumulator.addAll(errors);
+    }
   }
 
   @Override

--- a/javascript/packages/core/src/parse-result.ts
+++ b/javascript/packages/core/src/parse-result.ts
@@ -18,6 +18,7 @@ export type SerializedParseResult = {
   warnings: SerializedHerbWarning[]
   errors: SerializedHerbError[]
   options: SerializedParserOptions
+  error_count: number | null
 }
 
 declare const locationless: unique symbol
@@ -61,6 +62,9 @@ export class ParseResult extends Result {
   /** The parser options used during parsing. */
   readonly options: ParserOptions
 
+  /** Total number of errors attached to the tree, counted by the parser. */
+  readonly errorCount: number | null
+
   /**
    * Creates a `ParseResult` instance from a serialized result.
    * @param result - The serialized parse result containing the value and source.
@@ -73,6 +77,7 @@ export class ParseResult extends Result {
       result.warnings.map((warning) => HerbWarning.from(warning)),
       result.errors.map((error) => HerbError.from(error)),
       ParserOptions.from(result.options),
+      result.error_count,
     )
   }
 
@@ -90,10 +95,12 @@ export class ParseResult extends Result {
     warnings: HerbWarning[] = [],
     errors: HerbError[] = [],
     options: ParserOptions = new ParserOptions(),
+    errorCount: number | null = null,
   ) {
     super(source, warnings, errors)
     this.value = value
     this.options = options
+    this.errorCount = errorCount
     this.value.setSource(source)
   }
 
@@ -123,6 +130,8 @@ export class ParseResult extends Result {
   }
 
   recursiveErrors(): HerbError[] {
+    if (this.errorCount === 0) return [...this.errors]
+
     return [...this.errors, ...this.value.recursiveErrors()]
   }
 

--- a/javascript/packages/node-wasm/test/node-wasm.test.ts
+++ b/javascript/packages/node-wasm/test/node-wasm.test.ts
@@ -140,6 +140,34 @@ describe("@herb-tools/node-wasm", () => {
     expect(result.value.inspect()).toContain('"   "')
   })
 
+  test("parse() reports the total error count", () => {
+    expect(Herb.parse('<div class="example">content</div>').errorCount).toBe(0)
+    expect(Herb.parse("<div>").errorCount).toBe(1)
+    expect(Herb.parse("<% if condition without end %>").errorCount).toBe(1)
+  })
+
+  test("the error count matches the errors attached to the tree", () => {
+    for (const source of ["<div>", "<div><span>hello</div>", "<% if x %>", "</div>".repeat(30)]) {
+      const result = Herb.parse(source)
+
+      expect(result.errorCount).toBe(result.value.recursiveErrors().length)
+      expect(result.errorCount).toBe(result.recursiveErrors().length)
+    }
+  })
+
+  test("a zero error count skips the recursive walk without losing errors", () => {
+    const result = Herb.parse("<div>ok</div>")
+
+    expect(result.errorCount).toBe(0)
+    expect(result.recursiveErrors()).toHaveLength(0)
+    expect(result.failed).toBe(false)
+  })
+
+  test("the error count respects max_errors", () => {
+    expect(Herb.parse("<div>".repeat(1000)).errorCount).toBe(25)
+    expect(Herb.parse("<div>".repeat(1000), { max_errors: 5 }).errorCount).toBe(5)
+  })
+
   test("parse() tracks locations by default", () => {
     const result = Herb.parse('<div class="example">content</div>')
     const element = result.value.children[0] as any

--- a/javascript/packages/node/extension/extension_helpers.cpp
+++ b/javascript/packages/node/extension/extension_helpers.cpp
@@ -205,5 +205,15 @@ napi_value CreateParseResult(napi_env env, AST_DOCUMENT_NODE_T* root, napi_value
 
   napi_set_named_property(env, result, "options", options_object);
 
+  napi_value error_count_value;
+
+  if (options->error_count != nullptr) {
+    napi_create_uint32(env, *options->error_count, &error_count_value);
+  } else {
+    napi_get_null(env, &error_count_value);
+  }
+
+  napi_set_named_property(env, result, "error_count", error_count_value);
+
   return result;
 }

--- a/javascript/packages/node/extension/herb.cpp
+++ b/javascript/packages/node/extension/herb.cpp
@@ -84,6 +84,25 @@ napi_value Herb_parse(napi_env env, napi_callback_info info) {
         }
       }
 
+      napi_value max_errors_prop;
+      bool has_max_errors_prop;
+      napi_has_named_property(env, args[1], "max_errors", &has_max_errors_prop);
+
+      if (has_max_errors_prop) {
+        napi_get_named_property(env, args[1], "max_errors", &max_errors_prop);
+
+        napi_valuetype max_errors_type;
+        napi_typeof(env, max_errors_prop, &max_errors_type);
+
+        if (max_errors_type == napi_number) {
+          uint32_t max_errors_value;
+          napi_get_value_uint32(env, max_errors_prop, &max_errors_value);
+          parser_options.max_errors = max_errors_value;
+        } else {
+          parser_options.max_errors = 0;
+        }
+      }
+
       napi_value track_locations_prop;
       bool has_track_locations_prop;
       napi_has_named_property(env, args[1], "track_locations", &has_track_locations_prop);
@@ -198,6 +217,9 @@ napi_value Herb_parse(napi_env env, napi_callback_info info) {
       }
     }
   }
+
+  uint32_t error_count = 0;
+  parser_options.error_count = &error_count;
 
   hb_allocator_T allocator;
   if (!hb_allocator_init(&allocator, HB_ALLOCATOR_ARENA)) {

--- a/javascript/packages/node/test/node.test.ts
+++ b/javascript/packages/node/test/node.test.ts
@@ -138,6 +138,34 @@ describe("@herb-tools/node", () => {
     expect(result.value.inspect()).toContain('"   "')
   })
 
+  test("parse() reports the total error count", () => {
+    expect(Herb.parse('<div class="example">content</div>').errorCount).toBe(0)
+    expect(Herb.parse("<div>").errorCount).toBe(1)
+    expect(Herb.parse("<% if condition without end %>").errorCount).toBe(1)
+  })
+
+  test("the error count matches the errors attached to the tree", () => {
+    for (const source of ["<div>", "<div><span>hello</div>", "<% if x %>", "</div>".repeat(30)]) {
+      const result = Herb.parse(source)
+
+      expect(result.errorCount).toBe(result.value.recursiveErrors().length)
+      expect(result.errorCount).toBe(result.recursiveErrors().length)
+    }
+  })
+
+  test("a zero error count skips the recursive walk without losing errors", () => {
+    const result = Herb.parse("<div>ok</div>")
+
+    expect(result.errorCount).toBe(0)
+    expect(result.recursiveErrors()).toHaveLength(0)
+    expect(result.failed).toBe(false)
+  })
+
+  test("the error count respects max_errors", () => {
+    expect(Herb.parse("<div>".repeat(1000)).errorCount).toBe(25)
+    expect(Herb.parse("<div>".repeat(1000), { max_errors: 5 }).errorCount).toBe(5)
+  })
+
   test("parse() tracks locations by default", () => {
     const result = Herb.parse('<div class="example">content</div>')
     const element = result.value.children[0] as any

--- a/javascript/packages/printer/src/printer.ts
+++ b/javascript/packages/printer/src/printer.ts
@@ -70,7 +70,9 @@ export abstract class Printer extends Visitor {
       throw new Error(`Cannot print the node (${node.type}) since it was parsed with \`track_locations: false\`. The printer needs source locations, so re-parse the source with \`track_locations: true\`.`)
     }
 
-    if (options.ignoreErrors === false && node.recursiveErrors().length > 0) {
+    const hasErrors = isParseResult(input) ? input.errorCount !== 0 : true
+
+    if (options.ignoreErrors === false && hasErrors && node.recursiveErrors().length > 0) {
       throw new Error(`Cannot print the node (${node.type}) since it or any of its children has parse errors. Either pass in a valid Node or call \`print()\` using \`print(node, { ignoreErrors: true })\``)
     }
 

--- a/lib/herb/ast/helpers.rb
+++ b/lib/herb/ast/helpers.rb
@@ -71,11 +71,6 @@ module Herb
         content = node.content&.value || ""
         stripped = content.lstrip
 
-        # An inline `# comment` spans exactly one source line iff its Ruby
-        # content contains no newline. This is equivalent to comparing the
-        # node's start and end location lines, but does not depend on source
-        # locations being materialized, so it also works when the AST was built
-        # with `track_locations: false`.
         stripped.start_with?("#") && !content.include?("\n")
       end
     end

--- a/lib/herb/ast/node.rb
+++ b/lib/herb/ast/node.rb
@@ -119,11 +119,6 @@ module Herb
       def recursive_errors(accumulator = [])
         accumulator.concat(errors) unless errors.empty?
 
-        # Walk children iteratively into a single shared accumulator rather than
-        # allocating an intermediate array at every node (compact + flat_map +
-        # concat). This is a hot path: it runs for every node on every parse, so
-        # for large error-free trees the previous approach allocated several
-        # throwaway arrays per node.
         children = child_nodes
         index = 0
         count = children.size

--- a/lib/herb/ast/node.rb
+++ b/lib/herb/ast/node.rb
@@ -115,8 +115,17 @@ module Herb
         child_nodes.compact
       end
 
-      #: (?Array[Herb::Errors::Error] accumulator) -> Array[Herb::Errors::Error]
-      def recursive_errors(accumulator = [])
+      #: () -> Array[Herb::Errors::Error]
+      def recursive_errors
+        accumulator = [] #: Array[Herb::Errors::Error]
+        collect_errors(accumulator)
+        accumulator
+      end
+
+      protected
+
+      #: (Array[Herb::Errors::Error] accumulator) -> void
+      def collect_errors(accumulator)
         accumulator.concat(errors) unless errors.empty?
 
         children = child_nodes
@@ -124,12 +133,9 @@ module Herb
         count = children.size
 
         while index < count
-          child = children[index]
-          child&.recursive_errors(accumulator)
+          children[index]&.collect_errors(accumulator)
           index += 1
         end
-
-        accumulator
       end
     end
   end

--- a/lib/herb/ast/node.rb
+++ b/lib/herb/ast/node.rb
@@ -115,9 +115,26 @@ module Herb
         child_nodes.compact
       end
 
-      #: () -> Array[Herb::Errors::Error]
-      def recursive_errors
-        errors + compact_child_nodes.flat_map(&:recursive_errors)
+      #: (?Array[Herb::Errors::Error] accumulator) -> Array[Herb::Errors::Error]
+      def recursive_errors(accumulator = [])
+        accumulator.concat(errors) unless errors.empty?
+
+        # Walk children iteratively into a single shared accumulator rather than
+        # allocating an intermediate array at every node (compact + flat_map +
+        # concat). This is a hot path: it runs for every node on every parse, so
+        # for large error-free trees the previous approach allocated several
+        # throwaway arrays per node.
+        children = child_nodes
+        index = 0
+        count = children.size
+
+        while index < count
+          child = children[index]
+          child&.recursive_errors(accumulator)
+          index += 1
+        end
+
+        accumulator
       end
     end
   end

--- a/lib/herb/parse_result.rb
+++ b/lib/herb/parse_result.rb
@@ -24,6 +24,11 @@ module Herb
 
     #: () -> Array[Herb::Errors::Error]
     def errors
+      # The native extension records the total number of errors materialized
+      # onto the AST during parsing. When it is zero we can skip the recursive
+      # walk of every node entirely — the common case for valid templates.
+      return super if defined?(@total_error_count) && @total_error_count.zero?
+
       super + value.recursive_errors
     end
 

--- a/lib/herb/parse_result.rb
+++ b/lib/herb/parse_result.rb
@@ -7,11 +7,13 @@ module Herb
   class ParseResult < Result
     attr_reader :value #: Herb::AST::DocumentNode
     attr_reader :options #: Herb::ParserOptions
+    attr_reader :error_count #: Integer?
 
-    #: (Herb::AST::DocumentNode, String, Array[Herb::Warnings::Warning], Array[Herb::Errors::Error], Herb::ParserOptions) -> void
-    def initialize(value, source, warnings, errors, options)
+    #: (Herb::AST::DocumentNode, String, Array[Herb::Warnings::Warning], Array[Herb::Errors::Error], Herb::ParserOptions, ?Integer?) -> void
+    def initialize(value, source, warnings, errors, options, error_count = nil)
       @value = value
       @options = options
+      @error_count = error_count
       super(source, warnings, errors)
 
       if options.prism_nodes || options.prism_nodes_deep
@@ -24,10 +26,7 @@ module Herb
 
     #: () -> Array[Herb::Errors::Error]
     def errors
-      # The native extension records the total number of errors materialized
-      # onto the AST during parsing. When it is zero we can skip the recursive
-      # walk of every node entirely — the common case for valid templates.
-      return super if defined?(@total_error_count) && @total_error_count.zero?
+      return super if error_count&.zero?
 
       super + value.recursive_errors
     end

--- a/rust/src/herb.rs
+++ b/rust/src/herb.rs
@@ -108,6 +108,7 @@ pub fn parse_with_options(source: &str, options: &ParserOptions) -> Result<Parse
     let c_source = CString::new(source).map_err(|e| e.to_string())?;
 
     let mut allocator: crate::ffi::hb_allocator_T = std::mem::zeroed();
+    let mut error_count: u32 = 0;
 
     if !crate::ffi::hb_allocator_init(&mut allocator, crate::ffi::HB_ALLOCATOR_ARENA) {
       return Err("Failed to initialize allocator".to_string());
@@ -132,7 +133,7 @@ pub fn parse_with_options(source: &str, options: &ParserOptions) -> Result<Parse
       start_column: 0,
       timeout_ms: options.timeout,
       max_errors: options.max_errors.unwrap_or(0),
-      error_count: std::ptr::null_mut(),
+      error_count: &mut error_count,
       deadline_ms: 0,
     };
 
@@ -151,7 +152,7 @@ pub fn parse_with_options(source: &str, options: &ParserOptions) -> Result<Parse
       "Failed to convert AST".to_string()
     })?;
 
-    let result = ParseResult::new(document_node, source.to_string(), Vec::new(), options);
+    let result = ParseResult::with_error_count(document_node, source.to_string(), Vec::new(), options, Some(error_count));
 
     crate::ffi::ast_node_free(ast as *mut crate::bindings::AST_NODE_T, &mut allocator);
     crate::ffi::hb_allocator_destroy(&mut allocator);

--- a/rust/src/parse_result.rs
+++ b/rust/src/parse_result.rs
@@ -8,15 +8,27 @@ pub struct ParseResult {
   pub source: String,
   pub errors: Vec<AnyError>,
   pub options: ParserOptions,
+  pub error_count: Option<u32>,
 }
 
 impl ParseResult {
   pub fn new(value: DocumentNode, source: String, errors: Vec<AnyError>, options: &ParserOptions) -> Self {
+    Self::with_error_count(value, source, errors, options, None)
+  }
+
+  pub fn with_error_count(
+    value: DocumentNode,
+    source: String,
+    errors: Vec<AnyError>,
+    options: &ParserOptions,
+    error_count: Option<u32>,
+  ) -> Self {
     Self {
       value,
       source,
       errors,
       options: options.clone(),
+      error_count,
     }
   }
 
@@ -31,6 +43,11 @@ impl ParseResult {
   pub fn recursive_errors(&self) -> Vec<&dyn ErrorNode> {
     let mut all_errors: Vec<&dyn ErrorNode> = Vec::new();
     all_errors.extend(self.errors.iter().map(|e| e as &dyn ErrorNode));
+
+    if self.error_count == Some(0) {
+      return all_errors;
+    }
+
     all_errors.extend(self.value.recursive_errors());
     all_errors
   }

--- a/rust/src/parse_result.rs
+++ b/rust/src/parse_result.rs
@@ -16,13 +16,7 @@ impl ParseResult {
     Self::with_error_count(value, source, errors, options, None)
   }
 
-  pub fn with_error_count(
-    value: DocumentNode,
-    source: String,
-    errors: Vec<AnyError>,
-    options: &ParserOptions,
-    error_count: Option<u32>,
-  ) -> Self {
+  pub fn with_error_count(value: DocumentNode, source: String, errors: Vec<AnyError>, options: &ParserOptions, error_count: Option<u32>) -> Self {
     Self {
       value,
       source,

--- a/rust/tests/error_count_test.rs
+++ b/rust/tests/error_count_test.rs
@@ -1,0 +1,25 @@
+use herb::Node;
+
+#[test]
+fn error_count_is_exposed_and_short_circuits() {
+  let clean = herb::parse("<div class=\"a\">hello</div>").unwrap();
+  let dirty = herb::parse("<div><span>hello</div>").unwrap();
+
+  assert_eq!(clean.error_count, Some(0));
+  assert_eq!(clean.recursive_errors().len(), 0);
+  assert_eq!(dirty.error_count, Some(1));
+  assert_eq!(dirty.recursive_errors().len(), 1);
+}
+
+#[test]
+fn error_count_matches_the_tree_across_error_paths() {
+  for source in ["<div>", "<div><span>hello</div>", "<% if condition without end %>", "<% if x %>"] {
+    let result = herb::parse(source).unwrap();
+
+    assert_eq!(
+      result.error_count,
+      Some(result.value.recursive_errors().len() as u32),
+      "count mismatch for {source:?}"
+    );
+  }
+}

--- a/sig/herb/ast/node.rbs
+++ b/sig/herb/ast/node.rbs
@@ -61,8 +61,11 @@ module Herb
       # : () -> Array[Herb::AST::Node]
       def compact_child_nodes: () -> Array[Herb::AST::Node]
 
-      # : (?Array[Herb::Errors::Error] accumulator) -> Array[Herb::Errors::Error]
-      def recursive_errors: (?Array[Herb::Errors::Error] accumulator) -> Array[Herb::Errors::Error]
+      # : () -> Array[Herb::Errors::Error]
+      def recursive_errors: () -> Array[Herb::Errors::Error]
+
+      # : (Array[Herb::Errors::Error] accumulator) -> void
+      def collect_errors: (Array[Herb::Errors::Error] accumulator) -> void
     end
   end
 end

--- a/sig/herb/ast/node.rbs
+++ b/sig/herb/ast/node.rbs
@@ -61,8 +61,8 @@ module Herb
       # : () -> Array[Herb::AST::Node]
       def compact_child_nodes: () -> Array[Herb::AST::Node]
 
-      # : () -> Array[Herb::Errors::Error]
-      def recursive_errors: () -> Array[Herb::Errors::Error]
+      # : (?Array[Herb::Errors::Error] accumulator) -> Array[Herb::Errors::Error]
+      def recursive_errors: (?Array[Herb::Errors::Error] accumulator) -> Array[Herb::Errors::Error]
     end
   end
 end

--- a/sig/herb/parse_result.rbs
+++ b/sig/herb/parse_result.rbs
@@ -6,8 +6,10 @@ module Herb
 
     attr_reader options: Herb::ParserOptions
 
-    # : (Herb::AST::DocumentNode, String, Array[Herb::Warnings::Warning], Array[Herb::Errors::Error], Herb::ParserOptions) -> void
-    def initialize: (Herb::AST::DocumentNode, String, Array[Herb::Warnings::Warning], Array[Herb::Errors::Error], Herb::ParserOptions) -> void
+    attr_reader error_count: Integer?
+
+    # : (Herb::AST::DocumentNode, String, Array[Herb::Warnings::Warning], Array[Herb::Errors::Error], Herb::ParserOptions, ?Integer?) -> void
+    def initialize: (Herb::AST::DocumentNode, String, Array[Herb::Warnings::Warning], Array[Herb::Errors::Error], Herb::ParserOptions, ?Integer?) -> void
 
     # : () -> Array[Herb::Errors::Error]
     def errors: () -> Array[Herb::Errors::Error]

--- a/src/analyze/action_view/tag_helpers.c
+++ b/src/analyze/action_view/tag_helpers.c
@@ -875,7 +875,8 @@ static AST_NODE_T* transform_tag_helper_with_attributes(
         content_start,
         content_end,
         allocator,
-        &element_errors
+        &element_errors,
+        context->options
       );
     }
 
@@ -1421,7 +1422,8 @@ static AST_NODE_T* transform_erb_block_to_tag_helper(
       block_node->base.location.start,
       block_node->base.location.end,
       allocator,
-      &element_errors
+      &element_errors,
+      context->options
     );
   }
 

--- a/src/analyze/analyze.c
+++ b/src/analyze/analyze.c
@@ -92,7 +92,8 @@ static bool analyze_erb_content(const AST_NODE_T* node, void* data) {
           erb_content_node->base.location.start,
           erb_content_node->base.location.end,
           allocator,
-          &erb_content_node->base.errors
+          &erb_content_node->base.errors,
+          options
         );
       }
 
@@ -101,7 +102,8 @@ static bool analyze_erb_content(const AST_NODE_T* node, void* data) {
           erb_content_node->base.location.start,
           erb_content_node->base.location.end,
           allocator,
-          &erb_content_node->base.errors
+          &erb_content_node->base.errors,
+          options
         );
       }
     } else {
@@ -1091,6 +1093,7 @@ void herb_analyze_parse_tree(
     .tag_helper_scope = NULL,
     .allocator = allocator,
     .source = source,
+    .options = options,
   };
 
   if (options && (options->transform_conditionals || options->action_view_helpers)) {
@@ -1125,6 +1128,7 @@ void herb_analyze_parse_tree(
     .loop_depth = 0,
     .rescue_depth = 0,
     .allocator = allocator,
+    .options = options,
   };
 
   herb_visit_node((AST_NODE_T*) document, detect_invalid_erb_structures, &invalid_context);

--- a/src/analyze/invalid_structures.c
+++ b/src/analyze/invalid_structures.c
@@ -89,7 +89,8 @@ bool detect_invalid_erb_structures(const AST_NODE_T* node, void* data) {
           node->location.start,
           node->location.end,
           context->allocator,
-          &((AST_NODE_T*) node)->errors
+          &((AST_NODE_T*) node)->errors,
+          context->options
         );
       }
     }
@@ -98,7 +99,7 @@ bool detect_invalid_erb_structures(const AST_NODE_T* node, void* data) {
   if (node->type == AST_ERB_IF_NODE) {
     const AST_ERB_IF_NODE_T* if_node = (const AST_ERB_IF_NODE_T*) node;
 
-    if (if_node->end_node == NULL) { check_erb_node_for_missing_end(node, context->allocator); }
+    if (if_node->end_node == NULL) { check_erb_node_for_missing_end(node, context->allocator, context->options); }
 
     if (if_node->statements != NULL) {
       for (size_t i = 0; i < hb_array_size(if_node->statements); i++) {
@@ -124,7 +125,8 @@ bool detect_invalid_erb_structures(const AST_NODE_T* node, void* data) {
               subsequent->location.start,
               subsequent->location.end,
               context->allocator,
-              &((AST_NODE_T*) subsequent)->errors
+              &((AST_NODE_T*) subsequent)->errors,
+              context->options
             );
           }
         }
@@ -171,7 +173,7 @@ bool detect_invalid_erb_structures(const AST_NODE_T* node, void* data) {
       || node->type == AST_ERB_FOR_NODE || node->type == AST_ERB_CASE_NODE || node->type == AST_ERB_CASE_MATCH_NODE
       || node->type == AST_ERB_BEGIN_NODE || node->type == AST_ERB_BLOCK_NODE
       || node->type == AST_ERB_ITERATION_BLOCK_NODE || node->type == AST_ERB_ELSE_NODE) {
-    check_erb_node_for_missing_end(node, context->allocator);
+    check_erb_node_for_missing_end(node, context->allocator, context->options);
 
     if (is_loop_node) { context->loop_depth--; }
     if (is_begin_node) { context->rescue_depth--; }

--- a/src/analyze/render_nodes.c
+++ b/src/analyze/render_nodes.c
@@ -327,7 +327,8 @@ static AST_ERB_RENDER_NODE_T* create_render_node_from_call(
   size_t erb_content_offset,
   const uint8_t* erb_content_source,
   render_block_fields_T* block_fields,
-  hb_allocator_T* allocator
+  hb_allocator_T* allocator,
+  const parser_options_T* options
 ) {
 
   pm_arguments_node_t* arguments = call_node->arguments;
@@ -523,7 +524,8 @@ static AST_ERB_RENDER_NODE_T* create_render_node_from_call(
         erb_node->base.location.start,
         erb_node->base.location.end,
         allocator,
-        &errors
+        &errors,
+        options
       );
 
       hb_allocator_dealloc(allocator, locals_keyword.value);
@@ -596,7 +598,8 @@ static AST_ERB_RENDER_NODE_T* create_render_node_from_call(
         erb_node->base.location.start,
         erb_node->base.location.end,
         allocator,
-        &errors
+        &errors,
+        options
       );
 
       hb_allocator_dealloc(allocator, keywords_buffer);
@@ -605,7 +608,13 @@ static AST_ERB_RENDER_NODE_T* create_render_node_from_call(
 
   if (!partial && !template_path && !layout && !file && !inline_template && !body && !plain && !html && !renderable
       && !has_positional_partial && !object) {
-    append_render_no_arguments_error(erb_node->base.location.start, erb_node->base.location.end, allocator, &errors);
+    append_render_no_arguments_error(
+      erb_node->base.location.start,
+      erb_node->base.location.end,
+      allocator,
+      &errors,
+      options
+    );
   }
 
   if (has_positional_partial && has_keyword_partial && keyword_hash) {
@@ -617,7 +626,8 @@ static AST_ERB_RENDER_NODE_T* create_render_node_from_call(
       erb_node->base.location.start,
       erb_node->base.location.end,
       allocator,
-      &errors
+      &errors,
+      options
     );
 
     if (keyword_partial.value) { hb_allocator_dealloc(allocator, keyword_partial.value); }
@@ -645,7 +655,8 @@ static AST_ERB_RENDER_NODE_T* create_render_node_from_call(
         erb_node->base.location.start,
         erb_node->base.location.end,
         allocator,
-        &errors
+        &errors,
+        options
       );
     }
   }
@@ -655,7 +666,8 @@ static AST_ERB_RENDER_NODE_T* create_render_node_from_call(
       erb_node->base.location.start,
       erb_node->base.location.end,
       allocator,
-      &errors
+      &errors,
+      options
     );
   }
 
@@ -665,7 +677,8 @@ static AST_ERB_RENDER_NODE_T* create_render_node_from_call(
       erb_node->base.location.start,
       erb_node->base.location.end,
       allocator,
-      &errors
+      &errors,
+      options
     );
   }
 
@@ -836,7 +849,8 @@ static AST_ERB_RENDER_NODE_T* try_transform_content_node(
     erb_content_offset,
     erb_content_source,
     NULL,
-    context->allocator
+    context->allocator,
+    context->options
   );
 }
 
@@ -898,7 +912,8 @@ static AST_ERB_RENDER_NODE_T* try_transform_block_node(
     erb_content_offset,
     erb_content_source,
     &block_fields,
-    context->allocator
+    context->allocator,
+    context->options
   );
 
   pm_node_destroy(&parser, root);

--- a/src/analyze/strict_locals.c
+++ b/src/analyze/strict_locals.c
@@ -112,7 +112,8 @@ static hb_array_T* extract_strict_locals(
   const char* params_open,
   const uint8_t* synthetic_start,
   hb_array_T* errors,
-  hb_allocator_T* allocator
+  hb_allocator_T* allocator,
+  const parser_options_T* parser_options
 ) {
   if (!params) { return hb_array_init(0, allocator); }
 
@@ -132,11 +133,11 @@ static hb_array_T* extract_strict_locals(
     hb_string_T name = local->name ? local->name->value : hb_string("");
 
     if (string_equals(local->kind.data, "positional")) {
-      append_strict_locals_positional_argument_error(name, start, end, allocator, &local->base.errors);
+      append_strict_locals_positional_argument_error(name, start, end, allocator, &local->base.errors, parser_options);
     } else if (string_equals(local->kind.data, "rest")) {
-      append_strict_locals_splat_argument_error(name, start, end, allocator, &local->base.errors);
+      append_strict_locals_splat_argument_error(name, start, end, allocator, &local->base.errors, parser_options);
     } else if (string_equals(local->kind.data, "block")) {
-      append_strict_locals_block_argument_error(name, start, end, allocator, &local->base.errors);
+      append_strict_locals_block_argument_error(name, start, end, allocator, &local->base.errors, parser_options);
     }
   }
 
@@ -146,7 +147,8 @@ static hb_array_T* extract_strict_locals(
 static AST_ERB_STRICT_LOCALS_NODE_T* create_strict_locals_node(
   AST_ERB_CONTENT_NODE_T* erb_node,
   const char* source,
-  hb_allocator_T* allocator
+  hb_allocator_T* allocator,
+  const parser_options_T* parser_options
 ) {
   const char* content_bytes = erb_node->content->value.data;
   const char* params_open = find_params_open(content_bytes);
@@ -183,7 +185,8 @@ static AST_ERB_STRICT_LOCALS_NODE_T* create_strict_locals_node(
       error_start,
       error_end,
       allocator,
-      &errors
+      &errors,
+      parser_options
     );
     hb_allocator_dealloc(allocator, rest);
 
@@ -265,7 +268,8 @@ static AST_ERB_STRICT_LOCALS_NODE_T* create_strict_locals_node(
       params_open,
       synthetic_start,
       errors,
-      allocator
+      allocator,
+      parser_options
     );
   }
 
@@ -300,7 +304,7 @@ static void transform_strict_locals_in_array(hb_array_T* array, analyze_ruby_con
     if (!is_strict_locals_node(erb_node)) { continue; }
 
     AST_ERB_STRICT_LOCALS_NODE_T* strict_locals_node =
-      create_strict_locals_node(erb_node, context->source, context->allocator);
+      create_strict_locals_node(erb_node, context->source, context->allocator, context->options);
 
     if (!strict_locals_node) { continue; }
 
@@ -309,7 +313,8 @@ static void transform_strict_locals_in_array(hb_array_T* array, analyze_ruby_con
         strict_locals_node->base.location.start,
         strict_locals_node->base.location.end,
         context->allocator,
-        &strict_locals_node->base.errors
+        &strict_locals_node->base.errors,
+        context->options
       );
     }
 

--- a/src/herb.c
+++ b/src/herb.c
@@ -40,7 +40,11 @@ static bool herb_count_node_errors(const AST_NODE_T* node, void* data) {
   return true;
 }
 
-HERB_EXPORTED_FUNCTION AST_DOCUMENT_NODE_T* herb_parse(const char* source, const parser_options_T* options, hb_allocator_T* allocator) {
+HERB_EXPORTED_FUNCTION AST_DOCUMENT_NODE_T* herb_parse(
+  const char* source,
+  const parser_options_T* options,
+  hb_allocator_T* allocator
+) {
   if (!source) { source = ""; }
 
   lexer_T lexer = { 0 };

--- a/src/herb.c
+++ b/src/herb.c
@@ -32,7 +32,7 @@ HERB_EXPORTED_FUNCTION hb_array_T* herb_lex(const char* source, hb_allocator_T* 
   return tokens;
 }
 
-HERB_EXPORTED_FUNCTION static bool herb_count_node_errors(const AST_NODE_T* node, void* data) {
+static bool herb_count_node_errors(const AST_NODE_T* node, void* data) {
   if (node == NULL) { return false; }
 
   if (node->errors != NULL) { *((uint32_t*) data) += (uint32_t) hb_array_size(node->errors); }
@@ -40,7 +40,7 @@ HERB_EXPORTED_FUNCTION static bool herb_count_node_errors(const AST_NODE_T* node
   return true;
 }
 
-AST_DOCUMENT_NODE_T* herb_parse(const char* source, const parser_options_T* options, hb_allocator_T* allocator) {
+HERB_EXPORTED_FUNCTION AST_DOCUMENT_NODE_T* herb_parse(const char* source, const parser_options_T* options, hb_allocator_T* allocator) {
   if (!source) { source = ""; }
 
   lexer_T lexer = { 0 };

--- a/src/herb.c
+++ b/src/herb.c
@@ -8,6 +8,7 @@
 #include "include/lib/hb_array.h"
 #include "include/parser/parser.h"
 #include "include/version.h"
+#include "include/visitor.h"
 
 #include <prism.h>
 #include <stdlib.h>
@@ -31,11 +32,15 @@ HERB_EXPORTED_FUNCTION hb_array_T* herb_lex(const char* source, hb_allocator_T* 
   return tokens;
 }
 
-HERB_EXPORTED_FUNCTION AST_DOCUMENT_NODE_T* herb_parse(
-  const char* source,
-  const parser_options_T* options,
-  hb_allocator_T* allocator
-) {
+HERB_EXPORTED_FUNCTION static bool herb_count_node_errors(const AST_NODE_T* node, void* data) {
+  if (node == NULL) { return false; }
+
+  if (node->errors != NULL) { *((uint32_t*) data) += (uint32_t) hb_array_size(node->errors); }
+
+  return true;
+}
+
+AST_DOCUMENT_NODE_T* herb_parse(const char* source, const parser_options_T* options, hb_allocator_T* allocator) {
   if (!source) { source = ""; }
 
   lexer_T lexer = { 0 };
@@ -46,7 +51,7 @@ HERB_EXPORTED_FUNCTION AST_DOCUMENT_NODE_T* herb_parse(
   if (options != NULL) { parser_options = *options; }
 
   uint32_t error_count = 0;
-  parser_options.error_count = &error_count;
+  if (parser_options.error_count == NULL) { parser_options.error_count = &error_count; }
 
   parser_options_set_deadline(&parser_options);
 
@@ -68,6 +73,11 @@ HERB_EXPORTED_FUNCTION AST_DOCUMENT_NODE_T* herb_parse(
 
   if (parser_options.analyze) { herb_analyze_parse_tree(document, source, &parser_options, allocator); }
 
+  if (parser_options.error_count != NULL) {
+    *parser_options.error_count = 0;
+    herb_visit_node((AST_NODE_T*) document, herb_count_node_errors, parser_options.error_count);
+  }
+
   if (parser_options.prism_nodes || parser_options.prism_program) {
     herb_annotate_prism_nodes(
       document,
@@ -85,7 +95,8 @@ HERB_EXPORTED_FUNCTION AST_DOCUMENT_NODE_T* herb_parse(
       document->base.location.start,
       document->base.location.end,
       allocator,
-      &document->base.errors
+      &document->base.errors,
+      options
     );
   }
 

--- a/src/include/analyze/analyze.h
+++ b/src/include/analyze/analyze.h
@@ -23,6 +23,7 @@ typedef struct ANALYZE_RUBY_CONTEXT_STRUCT {
   hb_allocator_T* allocator;
   const char* source;
   bool found_strict_locals;
+  const parser_options_T* options;
 } analyze_ruby_context_T;
 
 typedef enum {
@@ -51,6 +52,7 @@ typedef struct {
   int loop_depth;
   int rescue_depth;
   hb_allocator_T* allocator;
+  const parser_options_T* options;
 } invalid_erb_context_T;
 
 void herb_analyze_parse_errors(

--- a/src/include/analyze/helpers.h
+++ b/src/include/analyze/helpers.h
@@ -8,6 +8,7 @@
 #include "../ast/ast_nodes.h"
 #include "../lib/hb_allocator.h"
 #include "../lib/hb_array.h"
+#include "../parser/parser.h"
 #include "analyzed_ruby.h"
 
 bool has_if_node(analyzed_ruby_T* analyzed);
@@ -62,7 +63,7 @@ bool search_unexpected_in_nodes(analyzed_ruby_T* analyzed);
 bool search_unexpected_rescue_nodes(analyzed_ruby_T* analyzed);
 bool search_unexpected_when_nodes(analyzed_ruby_T* analyzed);
 
-void check_erb_node_for_missing_end(const AST_NODE_T* node, hb_allocator_T* allocator);
+void check_erb_node_for_missing_end(const AST_NODE_T* node, hb_allocator_T* allocator, const parser_options_T* options);
 
 hb_array_T* extract_parameters_from_prism(
   pm_parameters_node_t* parameters,

--- a/src/parser.c
+++ b/src/parser.c
@@ -52,6 +52,7 @@ const parser_options_T HERB_DEFAULT_PARSER_OPTIONS = { .track_whitespace = false
                                                        .start_column = 0,
                                                        .timeout_ms = 1000,
                                                        .max_errors = 25,
+                                                       .error_count = NULL,
                                                        .deadline_ms = 0 };
 
 size_t parser_sizeof(void) {
@@ -150,7 +151,8 @@ static AST_HTML_COMMENT_NODE_T* parser_parse_html_comment(parser_T* parser) {
       comment_end->location.start,
       comment_end->location.end,
       parser->allocator,
-      &errors
+      &errors,
+      &parser->options
     );
   } else {
     comment_end = parser_consume_expected(parser, TOKEN_HTML_COMMENT_END, &errors);
@@ -299,7 +301,13 @@ static AST_HTML_TEXT_NODE_T* parser_parse_text_content(parser_T* parser, hb_arra
         position_T stray_end = peek_token->location.end;
         token_free(peek_token, parser->allocator);
 
-        append_stray_erb_closing_tag_error(stray_start, stray_end, parser->allocator, document_errors);
+        append_stray_erb_closing_tag_error(
+          stray_start,
+          stray_end,
+          parser->allocator,
+          document_errors,
+          &parser->options
+        );
 
         token_T* percent = parser_advance(parser);
         hb_buffer_append_string(&content, percent->value);
@@ -454,7 +462,8 @@ static AST_HTML_ATTRIBUTE_VALUE_NODE_T* parser_parse_quoted_html_attribute_value
         opening_quote->location.start,
         parser->current_token->location.start,
         parser->allocator,
-        errors
+        errors,
+        &parser->options
       );
 
       parser_append_literal_node_from_buffer(parser, &buffer, children, start);
@@ -501,7 +510,8 @@ static AST_HTML_ATTRIBUTE_VALUE_NODE_T* parser_parse_quoted_html_attribute_value
           opening_quote->location.start,
           parser->current_token->location.start,
           parser->allocator,
-          errors
+          errors,
+          &parser->options
         );
 
         parser_append_literal_node_from_buffer(parser, &buffer, children, start);
@@ -555,7 +565,8 @@ static AST_HTML_ATTRIBUTE_VALUE_NODE_T* parser_parse_quoted_html_attribute_value
         potential_closing->location.start,
         potential_closing->location.end,
         parser->allocator,
-        errors
+        errors,
+        &parser->options
       );
 
       lexer_restore_state(parser->lexer, saved_state);
@@ -673,7 +684,8 @@ static AST_HTML_ATTRIBUTE_VALUE_NODE_T* parser_parse_html_attribute_value(parser
       start,
       end,
       parser->allocator,
-      &errors
+      &errors,
+      &parser->options
     );
 
     AST_HTML_ATTRIBUTE_VALUE_NODE_T* value =
@@ -693,7 +705,8 @@ static AST_HTML_ATTRIBUTE_VALUE_NODE_T* parser_parse_html_attribute_value(parser
     parser->current_token->location.start,
     parser->current_token->location.end,
     parser->allocator,
-    &errors
+    &errors,
+    &parser->options
   );
 
   hb_allocator_dealloc(parser->allocator, expected);
@@ -835,7 +848,8 @@ static AST_HTML_ATTRIBUTE_NODE_T* parser_parse_html_attribute(parser_T* parser) 
         equals->location.start,
         parser->current_token->location.start,
         parser->allocator,
-        &errors
+        &errors,
+        &parser->options
       );
 
       AST_HTML_ATTRIBUTE_VALUE_NODE_T* empty_value = ast_html_attribute_value_node_init(
@@ -1049,7 +1063,8 @@ static AST_HTML_OPEN_TAG_NODE_T* parser_parse_html_open_tag(parser_T* parser) {
         tag_name->location.start,
         parser->current_token->location.start,
         parser->allocator,
-        &errors
+        &errors,
+        &parser->options
       );
 
       AST_HTML_OPEN_TAG_NODE_T* open_tag_node = ast_html_open_tag_node_init(
@@ -1113,7 +1128,7 @@ static AST_HTML_OPEN_TAG_NODE_T* parser_parse_html_open_tag(parser_T* parser) {
         position_T stray_end = peek_token->location.end;
         token_free(peek_token, parser->allocator);
 
-        append_stray_erb_closing_tag_error(stray_start, stray_end, parser->allocator, &errors);
+        append_stray_erb_closing_tag_error(stray_start, stray_end, parser->allocator, &errors, &parser->options);
 
         token_T* percent = parser_advance(parser);
         token_T* gt = parser_advance(parser);
@@ -1149,7 +1164,8 @@ static AST_HTML_OPEN_TAG_NODE_T* parser_parse_html_open_tag(parser_T* parser) {
       tag_name->location.start,
       parser->current_token->location.start,
       parser->allocator,
-      &errors
+      &errors,
+      &parser->options
     );
 
     AST_HTML_OPEN_TAG_NODE_T* open_tag_node = ast_html_open_tag_node_init(
@@ -1231,7 +1247,8 @@ static AST_HTML_CLOSE_TAG_NODE_T* parser_parse_html_close_tag(parser_T* parser) 
       tag_opening->location.start,
       tag_name->location.end,
       parser->allocator,
-      &errors
+      &errors,
+      &parser->options
     );
   }
 
@@ -1247,7 +1264,8 @@ static AST_HTML_CLOSE_TAG_NODE_T* parser_parse_html_close_tag(parser_T* parser) 
       tag_opening->location.start,
       tag_closing->location.end,
       parser->allocator,
-      &errors
+      &errors,
+      &parser->options
     );
 
     hb_allocator_dealloc(parser->allocator, expected.data);
@@ -1339,7 +1357,8 @@ static AST_HTML_ELEMENT_NODE_T* parser_parse_html_regular_element(
           unclosed->location.start,
           unclosed->location.end,
           parser->allocator,
-          &errors
+          &errors,
+          &parser->options
         );
         token_free(unclosed, parser->allocator);
       }
@@ -1412,7 +1431,8 @@ static AST_ERB_CONTENT_NODE_T* parser_parse_erb_tag(parser_T* parser) {
         opening_tag->location.start,
         closing_tag->location.end,
         parser->allocator,
-        &errors
+        &errors,
+        &parser->options
       );
     }
   } else if (token_is(parser, TOKEN_ERB_START)) {
@@ -1423,7 +1443,8 @@ static AST_ERB_CONTENT_NODE_T* parser_parse_erb_tag(parser_T* parser) {
       parser->current_token->location.start,
       parser->current_token->location.end,
       parser->allocator,
-      &errors
+      &errors,
+      &parser->options
     );
     end_position = parser->current_token->location.start;
   } else {
@@ -1432,7 +1453,8 @@ static AST_ERB_CONTENT_NODE_T* parser_parse_erb_tag(parser_T* parser) {
       opening_tag->location.start,
       parser->current_token->location.start,
       parser->allocator,
-      &errors
+      &errors,
+      &parser->options
     );
     end_position = parser->current_token->location.start;
   }
@@ -1767,7 +1789,8 @@ static hb_array_T* parser_build_elements_from_tags(
               open_tag->base.location.start,
               open_tag->base.location.end,
               allocator,
-              &element_errors
+              &element_errors,
+              options
             );
           }
 
@@ -1791,16 +1814,15 @@ static hb_array_T* parser_build_elements_from_tags(
 
           index = implicit_close_index - 1;
         } else {
-          if (hb_array_size(open_tag->base.errors) == 0 && !parser_options_errors_exceeded(options)) {
+          if (hb_array_size(open_tag->base.errors) == 0) {
             append_missing_closing_tag_error(
               open_tag->tag_name,
               open_tag->base.location.start,
               open_tag->base.location.end,
               allocator,
-              &open_tag->base.errors
+              &open_tag->base.errors,
+              options
             );
-
-            parser_options_increment_error_count(options);
           }
 
           hb_array_append(result, node);
@@ -1840,16 +1862,15 @@ static hb_array_T* parser_build_elements_from_tags(
       AST_HTML_CLOSE_TAG_NODE_T* close_tag = (AST_HTML_CLOSE_TAG_NODE_T*) node;
 
       if (!is_void_element(close_tag->tag_name->value)) {
-        if (hb_array_size(close_tag->base.errors) == 0 && !parser_options_errors_exceeded(options)) {
+        if (hb_array_size(close_tag->base.errors) == 0) {
           append_missing_opening_tag_error(
             close_tag->tag_name,
             close_tag->base.location.start,
             close_tag->base.location.end,
             allocator,
-            &close_tag->base.errors
+            &close_tag->base.errors,
+            options
           );
-
-          parser_options_increment_error_count(options);
         }
       }
 

--- a/src/parser/dot_notation.c
+++ b/src/parser/dot_notation.c
@@ -92,7 +92,8 @@ void parser_consume_dot_notation_segments(parser_T* parser, token_T* tag_name, h
       tag_name->location.start,
       tag_name->location.end,
       parser->allocator,
-      errors
+      errors,
+      &parser->options
     );
   }
 

--- a/src/parser/parser_helpers.c
+++ b/src/parser/parser_helpers.c
@@ -111,7 +111,8 @@ void parser_append_unexpected_error_impl(
     token->location.start,
     token->location.end,
     parser->allocator,
-    errors
+    errors,
+    &parser->options
   );
 
   hb_allocator_dealloc(parser->allocator, expected);
@@ -133,7 +134,8 @@ void parser_append_unexpected_error_string(
     token->location.start,
     token->location.end,
     parser->allocator,
-    errors
+    errors,
+    &parser->options
   );
 
   token_free(token, parser->allocator);
@@ -146,7 +148,8 @@ void parser_append_unexpected_token_error(parser_T* parser, token_type_T expecte
     parser->current_token->location.start,
     parser->current_token->location.end,
     parser->allocator,
-    errors
+    errors,
+    &parser->options
   );
 }
 
@@ -192,7 +195,8 @@ token_T* parser_consume_expected(parser_T* parser, const token_type_T expected_t
       token->location.start,
       token->location.end,
       parser->allocator,
-      array
+      array,
+      &parser->options
     );
   }
 
@@ -210,7 +214,8 @@ AST_HTML_ELEMENT_NODE_T* parser_handle_missing_close_tag(
     open_tag->tag_name->location.start,
     open_tag->tag_name->location.end,
     parser->allocator,
-    errors
+    errors,
+    &parser->options
   );
 
   return ast_html_element_node_init(
@@ -242,7 +247,8 @@ void parser_handle_mismatched_tags(
       actual_tag->location.start,
       actual_tag->location.end,
       parser->allocator,
-      errors
+      errors,
+      &parser->options
     );
   } else {
     append_missing_opening_tag_error(
@@ -250,7 +256,8 @@ void parser_handle_mismatched_tags(
       close_tag->tag_name->location.start,
       close_tag->tag_name->location.end,
       parser->allocator,
-      errors
+      errors,
+      &parser->options
     );
   }
 }

--- a/templates/ext/herb/error_helpers.c.erb
+++ b/templates/ext/herb/error_helpers.c.erb
@@ -90,6 +90,9 @@ VALUE rb_errors_array_from_c_array(hb_array_T* array) {
       if (child_node) {
         VALUE rb_child = rb_error_from_c_struct(child_node);
         rb_ary_push(rb_array, rb_child);
+        // Track total errors materialized so callers can skip the recursive
+        // error walk when a template parsed cleanly.
+        herb_ext_error_count++;
       }
     }
   }

--- a/templates/ext/herb/error_helpers.c.erb
+++ b/templates/ext/herb/error_helpers.c.erb
@@ -90,9 +90,6 @@ VALUE rb_errors_array_from_c_array(hb_array_T* array) {
       if (child_node) {
         VALUE rb_child = rb_error_from_c_struct(child_node);
         rb_ary_push(rb_array, rb_child);
-        // Track total errors materialized so callers can skip the recursive
-        // error walk when a template parsed cleanly.
-        herb_ext_error_count++;
       }
     }
   }

--- a/templates/java/org/herb/ast/Nodes.java.erb
+++ b/templates/java/org/herb/ast/Nodes.java.erb
@@ -250,10 +250,16 @@ class <%= node.name %> extends BaseNode {
 
   @Override
   public List<Node> recursiveErrors() {
-    List<Node> result = new ArrayList<>();
+    List<Node> accumulator = new ArrayList<>();
+    collectErrors(accumulator);
 
+    return accumulator;
+  }
+
+  @Override
+  protected void collectErrors(List<Node> accumulator) {
     if (errors != null) {
-      result.addAll(errors);
+      accumulator.addAll(errors);
     }
 
     <%- if node.fields.any? -%>
@@ -263,21 +269,19 @@ class <%= node.name %> extends BaseNode {
     if (<%= field.name %> != null) {
       for (Node child : <%= field.name %>) {
         if (child != null) {
-          result.addAll(child.recursiveErrors());
+          ((BaseNode) child).collectErrors(accumulator);
         }
       }
     }
 
     <%- elsif field.is_a?(Herb::Template::NodeField) || field.is_a?(Herb::Template::BorrowedNodeField) -%>
     if (<%= field.name %> != null) {
-      result.addAll(<%= field.name %>.recursiveErrors());
+      ((BaseNode) <%= field.name %>).collectErrors(accumulator);
     }
 
     <%- end -%>
     <%- end -%>
     <%- end -%>
-
-    return result;
   }
 
   @Override

--- a/templates/javascript/packages/core/src/nodes.ts.erb
+++ b/templates/javascript/packages/core/src/nodes.ts.erb
@@ -72,7 +72,13 @@ export abstract class Node implements BaseNodeProps {
   }
 
   abstract treeInspect(indent?: number): string
-  abstract recursiveErrors(): HerbError[]
+  recursiveErrors(): HerbError[] {
+    const accumulator: HerbError[] = []
+    this.collectErrors(accumulator)
+    return accumulator
+  }
+
+  abstract collectErrors(accumulator: HerbError[]): void
   abstract accept(visitor: Visitor): void
   abstract childNodes(): (Node | null | undefined)[]
   abstract compactChildNodes(): Node[]
@@ -375,18 +381,16 @@ export class <%= node.name %> extends Node {
   }
   <%- end -%>
 
-  recursiveErrors(): HerbError[] {
-    return [
-      ...this.errors,
-      <%- node.fields.each do |field| -%>
-      <%- case field -%>
-      <%- when Herb::Template::NodeField, Herb::Template::BorrowedNodeField -%>
-      this.<%= field.name %> ? this.<%= field.name %>.recursiveErrors() : [],
-      <%- when Herb::Template::ArrayField -%>
-      ...this.<%= field.name %>.map(node => node.recursiveErrors()),
-      <%- end -%>
-      <%- end -%>
-    ].flat();
+  collectErrors(accumulator: HerbError[]): void {
+    if (this.errors.length > 0) accumulator.push(...this.errors);
+    <%- node.fields.each do |field| -%>
+    <%- case field -%>
+    <%- when Herb::Template::NodeField, Herb::Template::BorrowedNodeField -%>
+    this.<%= field.name %>?.collectErrors(accumulator);
+    <%- when Herb::Template::ArrayField -%>
+    for (const node of this.<%= field.name %>) node.collectErrors(accumulator);
+    <%- end -%>
+    <%- end -%>
   }
 
   toJSON(): Serialized<%= node.name %> {

--- a/templates/rust/src/nodes.rs.erb
+++ b/templates/rust/src/nodes.rs.erb
@@ -197,6 +197,7 @@ pub trait Node {
   fn errors(&self) -> &[AnyError];
   fn child_nodes(&self) -> Vec<&dyn Node>;
   fn recursive_errors(&self) -> Vec<&dyn ErrorNode>;
+  fn collect_errors<'a>(&'a self, accumulator: &mut Vec<&'a dyn ErrorNode>);
   fn tree_inspect(&self) -> String;
 }
 
@@ -256,9 +257,15 @@ impl AnyNode {
   }
 
   pub fn recursive_errors(&self) -> Vec<&dyn ErrorNode> {
+    let mut accumulator: Vec<&dyn ErrorNode> = Vec::new();
+    self.collect_errors(&mut accumulator);
+    accumulator
+  }
+
+  pub fn collect_errors<'a>(&'a self, accumulator: &mut Vec<&'a dyn ErrorNode>) {
     match self {
       <%- nodes.each do |node| -%>
-      AnyNode::<%= node.name %>(n) => n.recursive_errors(),
+      AnyNode::<%= node.name %>(n) => n.collect_errors(accumulator),
       <%- end -%>
     }
   }
@@ -283,6 +290,10 @@ impl Node for AnyNode {
 
   fn recursive_errors(&self) -> Vec<&dyn ErrorNode> {
     self.recursive_errors()
+  }
+
+  fn collect_errors<'a>(&'a self, accumulator: &mut Vec<&'a dyn ErrorNode>) {
+    self.collect_errors(accumulator)
   }
 
   fn tree_inspect(&self) -> String {
@@ -399,36 +410,24 @@ impl Node for <%= node.name %> {
   }
 
   fn recursive_errors(&self) -> Vec<&dyn ErrorNode> {
-    <%- has_children = node.fields.any? { |field|
-      case field
-      when Herb::Template::ArrayField
-        true
-      when Herb::Template::BorrowedNodeField, Herb::Template::NodeField
-        true
-      else
-        false
-      end
-    } -%>
-    <%- if has_children -%>
-    let mut all_errors: Vec<&dyn ErrorNode> = Vec::new();
-    all_errors.extend(self.errors.iter().map(|e| e as &dyn ErrorNode));
+    let mut accumulator: Vec<&dyn ErrorNode> = Vec::new();
+    self.collect_errors(&mut accumulator);
+    accumulator
+  }
 
+  fn collect_errors<'a>(&'a self, accumulator: &mut Vec<&'a dyn ErrorNode>) {
+    accumulator.extend(self.errors.iter().map(|e| e as &dyn ErrorNode));
     <%- node.fields.each do |field| -%>
     <%- case field -%>
     <%- when Herb::Template::ArrayField -%>
     for child in &self.<%= field.name %> {
-      all_errors.extend(child.recursive_errors());
+      child.collect_errors(accumulator);
     }
     <%- when Herb::Template::NodeField, Herb::Template::BorrowedNodeField -%>
     if let Some(ref node) = self.<%= field.name %> {
-      all_errors.extend(node.recursive_errors());
+      node.collect_errors(accumulator);
     }
     <%- end -%>
-    <%- end -%>
-
-    all_errors
-    <%- else -%>
-    self.errors.iter().map(|e| e as &dyn ErrorNode).collect()
     <%- end -%>
   }
 

--- a/templates/rust/src/union_types.rs.erb
+++ b/templates/rust/src/union_types.rs.erb
@@ -49,9 +49,15 @@ impl <%= enum_name %> {
   }
 
   pub fn recursive_errors(&self) -> Vec<&dyn ErrorNode> {
+    let mut accumulator: Vec<&dyn ErrorNode> = Vec::new();
+    self.collect_errors(&mut accumulator);
+    accumulator
+  }
+
+  pub fn collect_errors<'a>(&'a self, accumulator: &mut Vec<&'a dyn ErrorNode>) {
     match self {
       <%- kinds.each do |kind| -%>
-      <%= enum_name %>::<%= kind %>(n) => n.recursive_errors(),
+      <%= enum_name %>::<%= kind %>(n) => n.collect_errors(accumulator),
       <%- end -%>
     }
   }

--- a/templates/src/analyze/missing_end.c.erb
+++ b/templates/src/analyze/missing_end.c.erb
@@ -1,5 +1,6 @@
 #include "../include/analyze/helpers.h"
 #include "../include/errors.h"
+#include "../include/parser/parser.h"
 #include "../include/lib/hb_allocator.h"
 #include "../include/lib/hb_string.h"
 
@@ -9,7 +10,7 @@
   end
 -%>
 
-void check_erb_node_for_missing_end(const AST_NODE_T* node, hb_allocator_T* allocator) {
+void check_erb_node_for_missing_end(const AST_NODE_T* node, hb_allocator_T* allocator, const parser_options_T* options) {
   switch (node->type) {
     <%- nodes_with_end_node.each do |node| -%>
     <%- keyword = node.name.gsub(/^ERB/, '').gsub(/Match|Node$/, '').downcase -%>
@@ -26,7 +27,8 @@ void check_erb_node_for_missing_end(const AST_NODE_T* node, hb_allocator_T* allo
           <%= node.human %>->tag_opening->location.start,
           <%= node.human %>->tag_closing->location.end,
           allocator,
-          &((AST_NODE_T*) node)->errors
+          &((AST_NODE_T*) node)->errors,
+          options
         );
       }
 

--- a/templates/src/errors.c.erb
+++ b/templates/src/errors.c.erb
@@ -1,4 +1,5 @@
 #include "include/errors.h"
+#include "include/parser/parser.h"
 #include "include/location/location.h"
 #include "include/location/position.h"
 #include "include/ast/pretty_print.h"
@@ -90,8 +91,12 @@ void error_init(ERROR_T* error, const error_type_T type, position_T start, posit
   return <%= error.human %>;
 }
 
-void append_<%= error.human %>(<%= (arguments + ["hb_array_T** errors"]).join(", ") %>) {
+void append_<%= error.human %>(<%= (arguments + ["hb_array_T** errors", "const struct PARSER_OPTIONS_STRUCT* options"]).join(", ") %>) {
+  if (parser_options_errors_exceeded(options)) { return; }
+
   hb_array_append_lazy(errors, <%= error.human %>_init(<%= arguments.map { |argument| argument.split(" ").last.strip }.join(", ") %>), allocator);
+
+  parser_options_increment_error_count(options);
 }
 <%- end -%>
 

--- a/templates/src/include/errors.h.erb
+++ b/templates/src/include/errors.h.erb
@@ -10,6 +10,8 @@
 #include "lib/hb_buffer.h"
 #include "lib/hb_string.h"
 
+struct PARSER_OPTIONS_STRUCT;
+
 typedef enum {
 <%- errors.each do |error| -%>
   <%= error.type.upcase %>,
@@ -35,7 +37,7 @@ typedef struct {
 <%- error_arguments = error.fields.any? ? error.fields.map { |field| [field.c_type, " ", field.name].join } : [] -%>
 <%- arguments = error_arguments + ["position_T start", "position_T end", "hb_allocator_T* allocator"] -%>
 <%= error.struct_type %>* <%= error.human %>_init(<%= arguments.join(", ") %>);
-void append_<%= error.human %>(<%= (arguments << "hb_array_T** errors").join(", ") %>);
+void append_<%= error.human %>(<%= (arguments + ["hb_array_T** errors", "const struct PARSER_OPTIONS_STRUCT* options"]).join(", ") %>);
 <%- end -%>
 
 void error_init(ERROR_T* error, error_type_T type, position_T start, position_T end);

--- a/test/parser/error_count_test.rb
+++ b/test/parser/error_count_test.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+module Parser
+  class ErrorCountTest < Minitest::Spec
+    test "clean templates report a zero count" do
+      result = Herb.parse(%(<div class="hello">content</div>\n))
+
+      assert_equal 0, result.error_count
+      assert_empty result.errors
+    end
+
+    test "the count matches the errors actually attached to the tree" do
+      [
+        "<div>",
+        "<div><span>hello</div>",
+        "<% if condition without end %>",
+        "<% if x %>",
+        "</div>" * 30,
+      ].each do |source|
+        result = Herb.parse(source)
+
+        assert_equal result.value.recursive_errors.size, result.error_count, "count mismatch for #{source.inspect}"
+        assert_equal result.error_count, result.errors.size
+      end
+    end
+
+    test "the count includes Ruby parse errors that are attached outside the parser" do
+      result = Herb.parse("<% if condition without end %>")
+
+      assert_equal 1, result.error_count
+      assert_instance_of Herb::Errors::RubyParseError, result.errors.first
+    end
+
+    test "the count respects max_errors" do
+      assert_equal 25, Herb.parse("<div>" * 1000).error_count
+      assert_equal 5, Herb.parse("<div>" * 1000, max_errors: 5).error_count
+      assert_equal 100, Herb.parse("<div>" * 100, max_errors: nil).error_count
+    end
+
+    test "a zero count skips the recursive walk without losing errors" do
+      clean = Herb.parse("<div>ok</div>")
+
+      refute_predicate clean, :failed?
+      assert_empty clean.errors
+    end
+  end
+end

--- a/test/parser/error_count_test.rb
+++ b/test/parser/error_count_test.rb
@@ -17,7 +17,7 @@ module Parser
         "<div><span>hello</div>",
         "<% if condition without end %>",
         "<% if x %>",
-        "</div>" * 30,
+        "</div>" * 30
       ].each do |source|
         result = Herb.parse(source)
 

--- a/wasm/extension_helpers.cpp
+++ b/wasm/extension_helpers.cpp
@@ -139,6 +139,7 @@ val CreateParseResult(AST_DOCUMENT_NODE_T *root, const std::string& source, pars
   options_object.set("html", val(options->html));
 
   result.set("options", options_object);
+  result.set("error_count", options->error_count != nullptr ? val(*options->error_count) : val::null());
 
   return result;
 }

--- a/wasm/herb-wasm.cpp
+++ b/wasm/herb-wasm.cpp
@@ -118,6 +118,9 @@ val Herb_parse(const std::string& source, val options) {
     }
   }
 
+  uint32_t error_count = 0;
+  parser_options.error_count = &error_count;
+
   hb_allocator_T allocator;
   if (!hb_allocator_init(&allocator, HB_ALLOCATOR_ARENA)) {
     return val::null();


### PR DESCRIPTION
## Summary

`ParseResult#errors` collects errors by walking the **entire AST** on every call, allocating an intermediate array at every node, even when the template parsed with **no errors**, which is the overwhelmingly common case. Every `Herb::Engine` compile calls `parse_result.errors`, so this walk runs once per template.

This PR makes the clean-template path free, and does it once for every binding:

1. **Count the errors in `libherb`, not in a binding.** `parser_options_T` already carried an `error_count` field for the `max_errors` cap. `herb_parse` now fills it with the exact total and hands it back to the caller, so Ruby, JavaScript, WASM, Java and Rust all get the count instead of Ruby alone.
2. **Skip the recursive walk when the count is zero.** Each binding exposes the count on its parse result and returns the top-level errors directly when it is zero.
3. **Collect recursive errors into a shared accumulator.** `recursive_errors` was `errors + compact_child_nodes.flat_map(&:recursive_errors)`, allocating throwaway arrays at every node. It now walks children iteratively into a single accumulator, in all four language bindings.

Split out of #1872 so it can be reviewed and benchmarked on its own.

## Implementation notes

The total comes from one allocation-free visitor walk at the end of `herb_parse` instead of counting as errors are constructed. Six sites attach errors directly instead of going through the generated `append_*` helper, including the Ruby parse errors in `analyze/parse_errors.c`, so counting at construction time reported zero errors for a template like `<% if condition without end %>` while the tree held one. The walk is exact regardless of how an error was attached.

`herb_parse` only installs its own counter when the caller leaves `error_count` NULL. A binding that supplies one reads the total back, and a binding that does not gets `nil` and simply walks, so the fallback is safe by construction.

`max_errors` now caps every error type instead of only the two tag-matching sites it reached before, which is what the option has always been documented to do. This is a behavior change. The corpus run reports 129 fewer diagnostics across 36,976 files with no file changing verdict.

## Benchmark

Measured end-to-end through the `github/github` monolith's `ViewPrecompiler.precompile`, which compiles the full template set through the Herb engine (so `ParseResult#errors` is exercised once per template). Numbers are the full-precompile pass (`bin/rails runner`), comparing the vendored gem built from `main` vs. built with this change:

| variant | wall clock | allocations |
| --- | --- | --- |
| baseline (`main`) | 34.254s | 63,842,961 |
| this PR | 32.264s | 54,098,228 |

**≈9.74M fewer allocations (−15.3%)** and **≈2.0s faster (−5.8%)** across the whole precompile.

## Correctness

- Clean template → `error_count == 0`, the fast path returns the top-level errors and skips the walk.
- Template with errors → the count matches the tree exactly, including Ruby parse errors and errors suppressed by `max_errors`.
- New tests assert `error_count == recursive_errors.size` across every error path in Ruby, both JavaScript bindings, Java and Rust.
- Two pre-existing bugs fixed along the way. The Node binding never read `max_errors`, so the cap silently did nothing there while WASM honoured it. Java seeded the parse result's error list from the document node, which the recursive walk then visited again, double counting every document-level error.
- Ruby, C, Java, Rust and every JavaScript package suite passes. RuboCop and `cargo +nightly fmt --check` clean.

---

*This change was produced by Claude Opus 4.8 (GitHub Copilot), acting on behalf of @joelhawksley.*