### PR TITLE
Linter: Allow render target names as shorthand locals

### DIFF
--- a/javascript/packages/linter/src/rules/actionview-no-render-option-shadowing.ts
+++ b/javascript/packages/linter/src/rules/actionview-no-render-option-shadowing.ts
@@ -16,7 +16,6 @@ const RENDER_OPTIONS = new Set([
   "layout",
   "object",
   "spacer_template",
-  "template",
   "variants",
 ])
 

--- a/javascript/packages/linter/test/rules/actionview-no-render-option-shadowing.test.ts
+++ b/javascript/packages/linter/test/rules/actionview-no-render-option-shadowing.test.ts
@@ -78,6 +78,10 @@ describe("actionview-no-render-option-shadowing", () => {
     expectNoOffenses(`<%= render "card", title: "Hi", user: @user %>`)
   })
 
+  test("does not flag mutually exclusive render target names", () => {
+    expectNoOffenses(`<%= render "card", template: "page", file: "page", inline: "page", body: "page", plain: "page", html: "page", renderable: page %>`)
+  })
+
   test("does not flag a render without locals", () => {
     expectNoOffenses(`<%= render "card" %>`)
   })


### PR DESCRIPTION
## Summary

- stop treating `template` as a shadowed partial option in shorthand `render` calls
- keep reporting options such as `layout` and `collection`, whose meaning silently changes between render forms
- add regression coverage for all seven mutually exclusive render targets (`template`, `file`, `inline`, `body`, `plain`, `html`, and `renderable`)

## Why

Render-target options are mutually exclusive with `partial:`. Using one while switching to the keyword partial form creates a contradictory call instead of silently changing a local into a valid render option, so reporting only `template` was inconsistent and noisy.

Fixes #2137

## Validation

- focused rule harness: target names produced 0 offenses; `layout` still produced 1 offense
- `oxlint` on the changed rule and regression test
- `git diff --check`

The full linter suite is left to CI because this Windows checkout cannot generate the Ruby/Bundler-backed core artifacts required by the current workspace packages.

## AI assistance

Codex helped identify the issue, implement the focused patch, and run validation. I reviewed the final diff before submission.