### PR TITLE
Language Server: Respect `formatter.indentStyle` when linting and fixing

### DIFF
--- a/javascript/packages/language-server/src/autofix_service.ts
+++ b/javascript/packages/language-server/src/autofix_service.ts
@@ -6,15 +6,19 @@ import { Linter } from "@herb-tools/linter"
 import { Config } from "@herb-tools/config"
 
 import { getFullDocumentRange } from "@herb-tools/language-service"
+import { Project } from "./project"
+
 import type { ProjectIndex } from "@herb-tools/analysis/node"
 
 export class AutofixService {
   private connection: Connection
+  private project: Project
   private linter: Linter
   private index?: ProjectIndex
 
-  constructor(connection: Connection, config?: Config, index?: ProjectIndex) {
+  constructor(connection: Connection, project: Project, config?: Config, index?: ProjectIndex) {
     this.connection = connection
+    this.project = project
     this.index = index
     this.linter = this.buildLinter(config)
   }
@@ -27,23 +31,28 @@ export class AutofixService {
     return Linter.from(Herb, config)
   }
 
-  private lintContextFor(uri: string) {
+  private async lintContextFor(uri: string) {
+    const settings = await this.project.settingsFor(uri)
+
     return {
       fileName: this.index?.relativePathFor(uri) ?? uri,
       partials: this.index?.partials,
       partialCallers: this.index?.callers,
+      indentWidth: settings?.formatter?.indentWidth,
+      indentStyle: settings?.formatter?.indentStyle,
     }
   }
 
   async autofix(document: TextDocument): Promise<TextEdit[]> {
     try {
       const text = document.getText()
-      const lintResult = this.linter.lint(text, this.lintContextFor(document.uri))
+      const context = await this.lintContextFor(document.uri)
+      const lintResult = this.linter.lint(text, context)
       const offensesToFix = lintResult.offenses
 
       if (offensesToFix.length === 0) return []
 
-      const autofixResult = this.linter.autofix(text, this.lintContextFor(document.uri), offensesToFix)
+      const autofixResult = this.linter.autofix(text, context, offensesToFix)
 
       if (autofixResult.source === text) return []
 

--- a/javascript/packages/language-server/src/code_action_provider.ts
+++ b/javascript/packages/language-server/src/code_action_provider.ts
@@ -86,18 +86,30 @@ export class CodeActionProvider {
     return actions.concat(disableAllActions)
   }
 
-  autofixCodeActions(params: CodeActionParams, document: TextDocument): CodeAction[] {
+  private async formatterContextFor(uri: string) {
+    const settings = await this.project.settingsFor(uri)
+
+    return {
+      indentWidth: settings?.formatter?.indentWidth,
+      indentStyle: settings?.formatter?.indentStyle
+    }
+  }
+
+  async autofixCodeActions(params: CodeActionParams, document: TextDocument): Promise<CodeAction[]> {
     if (this.config && !this.config.isLinterEnabled) {
       return []
     }
 
     const codeActions: CodeAction[] = []
     const text = document.getText()
+    const formatterContext = await this.formatterContextFor(document.uri)
+    const autofixContext = { fileName: document.uri, ...formatterContext }
 
     const lintResult = this.linter.lint(text, {
       fileName: this.index?.relativePathFor(document.uri) ?? document.uri,
       partials: this.index?.partials,
       partialCallers: this.index?.callers,
+      ...formatterContext,
     })
 
     const offenses = lintResult.offenses
@@ -113,7 +125,7 @@ export class CodeActionProvider {
         continue
       }
 
-      const fixResult = this.linter.autofix(text, { fileName: document.uri }, [offense])
+      const fixResult = this.linter.autofix(text, autofixContext, [offense])
 
       if (fixResult.fixed.length > 0 && fixResult.source !== text) {
         const codeAction: CodeAction = {
@@ -125,7 +137,7 @@ export class CodeActionProvider {
 
         codeActions.push(codeAction)
       } else {
-        const unsafeFixResult = this.linter.autofix(text, { fileName: document.uri }, [offense], { includeUnsafe: true })
+        const unsafeFixResult = this.linter.autofix(text, autofixContext, [offense], { includeUnsafe: true })
 
         if (unsafeFixResult.fixed.length > 0 && unsafeFixResult.source !== text) {
           const codeAction: CodeAction = {
@@ -141,13 +153,13 @@ export class CodeActionProvider {
     }
 
     const allFixableOffenses = offenses.filter(offense => {
-      const fixResult = this.linter.autofix(text, { fileName: document.uri }, [offense])
+      const fixResult = this.linter.autofix(text, autofixContext, [offense])
 
       return fixResult.fixed.length > 0
     })
 
     if (allFixableOffenses.length > 0) {
-      const fixAllResult = this.linter.autofix(text, { fileName: document.uri }, allFixableOffenses)
+      const fixAllResult = this.linter.autofix(text, autofixContext, allFixableOffenses)
 
       if (fixAllResult.fixed.length > 0 && fixAllResult.source !== text) {
         const fixAllAction: CodeAction = {

--- a/javascript/packages/language-server/src/linter_service.ts
+++ b/javascript/packages/language-server/src/linter_service.ts
@@ -239,6 +239,8 @@ export class LinterService {
       fileName: this.index.relativePathFor(textDocument.uri) ?? textDocument.uri,
       partials: this.index.partials,
       partialCallers: this.index?.callers,
+      indentWidth: settings?.formatter?.indentWidth,
+      indentStyle: settings?.formatter?.indentStyle,
     })
 
     const diagnostics: Diagnostic[] = lintResult.offenses.map(offense => {

--- a/javascript/packages/language-server/src/project.ts
+++ b/javascript/packages/language-server/src/project.ts
@@ -57,7 +57,7 @@ export class Project {
     this.configService = new ConfigService(root)
     this.index = new ProjectIndex({ root, backend: this.herbBackend, logger: connection.console })
     this.linterService = new LinterService(connection, userSettings, capabilities, this, this.index)
-    this.autofixService = new AutofixService(connection, undefined, this.index)
+    this.autofixService = new AutofixService(connection, this, undefined, this.index)
     this.codeActionProvider = new CodeActionProvider(this, undefined, this.index)
     this.formattingProvider = new FormattingProvider(connection, shared.documents, this, userSettings, capabilities)
 

--- a/javascript/packages/language-server/src/server.ts
+++ b/javascript/packages/language-server/src/server.ts
@@ -223,7 +223,7 @@ export class Server {
       return this.session.projects.get(params.textDocument.uri)?.completionProvider.getCompletions(document, params.position) ?? null
     })
 
-    this.connection.onCodeAction((params: CodeActionParams) => {
+    this.connection.onCodeAction(async (params: CodeActionParams) => {
       const document = this.session.documents.get(params.textDocument.uri)
 
       if (!document) return []
@@ -243,7 +243,7 @@ export class Server {
         documentText
       )
 
-      const autofixCodeActions = project.codeActionProvider.autofixCodeActions(params, document)
+      const autofixCodeActions = await project.codeActionProvider.autofixCodeActions(params, document)
       const rewriteCodeActions = this.session.rewriteCodeActionProvider.getCodeActions(document, params.range)
       const extractCodeActions = this.session.extractCodeActionProvider.getCodeActions(document, params.range)
 

--- a/javascript/packages/language-server/test/autofix_service.test.ts
+++ b/javascript/packages/language-server/test/autofix_service.test.ts
@@ -7,9 +7,16 @@ import { AutofixService } from '../src/autofix_service'
 import { Config } from '@herb-tools/config'
 import { Herb } from '@herb-tools/node-wasm'
 
+import type { Project } from '../src/project'
+import type { PersonalHerbSettings } from '../src/user_settings'
+
 describe('AutofixService', () => {
   let connection: Connection
   let autofixService: AutofixService
+
+  const projectWith = (settings: Partial<PersonalHerbSettings> = {}) => {
+    return { root: '/test', settingsFor: async () => settings } as unknown as Project
+  }
 
   beforeAll(async () => {
     await Herb.load()
@@ -23,7 +30,7 @@ describe('AutofixService', () => {
       }
     } as unknown as Connection
 
-    autofixService = new AutofixService(connection)
+    autofixService = new AutofixService(connection, projectWith())
   })
 
   describe('autofix', () => {
@@ -137,6 +144,29 @@ describe('AutofixService', () => {
       const result2 = await autofixService.autofix(document)
 
       expect(result2).toEqual([])
+    })
+  })
+
+  describe('with a resolved indent style', () => {
+    it('should fix indentation to the style the diagnostics were reported against', async () => {
+      const project = projectWith({ formatter: { indentStyle: 'tab', indentWidth: 2 } })
+      const service = new AutofixService(connection, project)
+
+      const document = TextDocument.create('file:///test/file.erb', 'erb', 1, '<div>\n  <span>test</span>\n</div>\n')
+      const result = await service.autofix(document)
+
+      expect(result).toHaveLength(1)
+      expect(result[0].newText).toBe('<div>\n\t<span>test</span>\n</div>\n')
+    })
+
+    it('should leave indentation alone when the style already matches', async () => {
+      const project = projectWith({ formatter: { indentStyle: 'tab', indentWidth: 2 } })
+      const service = new AutofixService(connection, project)
+
+      const document = TextDocument.create('file:///test/file.erb', 'erb', 1, '<div>\n\t<span>test</span>\n</div>\n')
+      const result = await service.autofix(document)
+
+      expect(result).toEqual([])
     })
   })
 })

--- a/javascript/packages/language-server/test/code_action_provider.test.ts
+++ b/javascript/packages/language-server/test/code_action_provider.test.ts
@@ -3,7 +3,8 @@ import { mkdirSync, writeFileSync, rmSync } from "fs"
 import { join } from "path"
 import { tmpdir } from "os"
 
-import { Diagnostic, DiagnosticSeverity, Range } from "vscode-languageserver/node"
+import { CodeActionParams, Diagnostic, DiagnosticSeverity, Range } from "vscode-languageserver/node"
+import { TextDocument } from "vscode-languageserver-textdocument"
 import { Herb } from "@herb-tools/node-wasm"
 import { Config } from "@herb-tools/config"
 
@@ -11,6 +12,7 @@ import { CodeActionProvider } from "../src/code_action_provider"
 import { Project } from "../src/project"
 
 import type { TextDocumentEdit } from "vscode-languageserver/node"
+import type { PersonalHerbSettings } from "../src/user_settings"
 
 const RULE = "herb-config-framework-option"
 const URI = "file:///project/app/views/users/show.html.erb"
@@ -36,8 +38,8 @@ describe("CodeActionProvider", () => {
     writeFileSync(join(projectPath, ".herb.yml"), content)
   }
 
-  async function createService() {
-    const project = { root: projectPath, herbBackend: Herb } as unknown as Project
+  async function createService(settings: Partial<PersonalHerbSettings> = {}) {
+    const project = { root: projectPath, herbBackend: Herb, settingsFor: async () => settings } as unknown as Project
     const config = await Config.loadForEditor(projectPath, "0.10.3")
 
     return new CodeActionProvider(project, config)
@@ -130,5 +132,31 @@ describe("CodeActionProvider", () => {
     const actions = setFrameworkActions(service.createCodeActions(URI, [diagnostic], "<%= image_tag %>"))
 
     expect(actions).toHaveLength(0)
+  })
+
+  it("fixes indentation to the style the diagnostics were reported against", async () => {
+    const service = await createService({ formatter: { indentStyle: "tab", indentWidth: 2 } })
+    const document = TextDocument.create(URI, "erb", 1, "<div>\n  <span>Hello</span>\n</div>\n")
+
+    const diagnostic: Diagnostic = {
+      range: Range.create(1, 0, 1, 2),
+      message: "Indent with tabs instead of spaces.",
+      severity: DiagnosticSeverity.Error,
+      source: "Herb Linter ",
+      code: "source-indentation",
+      data: { rule: "source-indentation" }
+    }
+
+    const params = {
+      textDocument: { uri: URI },
+      range: diagnostic.range,
+      context: { diagnostics: [diagnostic] }
+    } as CodeActionParams
+
+    const actions = await service.autofixCodeActions(params, document)
+    const fix = actions.find(action => action.title.includes("Indent with tabs"))
+
+    expect(fix).toBeDefined()
+    expect(fix?.edit?.changes?.[URI][0].newText).toBe("<div>\n\t<span>Hello</span>\n</div>\n")
   })
 })

--- a/javascript/packages/language-server/test/linter_service.test.ts
+++ b/javascript/packages/language-server/test/linter_service.test.ts
@@ -174,6 +174,36 @@ describe("LinterService", () => {
       expect(result.diagnostics.map(diagnostic => diagnostic.code)).toContain("herb-config-framework-option")
     })
 
+    test("passes the resolved indent style through to the rules", async () => {
+      const userSettings = new UserSettings(mockConnection, capabilities)
+      userSettings.getDocumentSettings = vi.fn().mockResolvedValue({
+        linter: { enabled: true },
+        formatter: { indentStyle: "tab", indentWidth: 2 }
+      })
+
+      const linterService = new LinterService(mockConnection, userSettings, capabilities, projectFor(userSettings), index)
+
+      const result = await linterService.lintDocument(createTestDocument("<div>\n\t<span>Hello</span>\n</div>\n"))
+
+      expect(result.diagnostics.map(diagnostic => diagnostic.code)).not.toContain("source-indentation")
+    })
+
+    test("flags the other indent character once the indent style is tab", async () => {
+      const userSettings = new UserSettings(mockConnection, capabilities)
+      userSettings.getDocumentSettings = vi.fn().mockResolvedValue({
+        linter: { enabled: true },
+        formatter: { indentStyle: "tab", indentWidth: 2 }
+      })
+
+      const linterService = new LinterService(mockConnection, userSettings, capabilities, projectFor(userSettings), index)
+
+      const result = await linterService.lintDocument(createTestDocument("<div>\n  <span>Hello</span>\n</div>\n"))
+
+      const offense = result.diagnostics.find(diagnostic => diagnostic.code === "source-indentation")
+
+      expect(offense?.message).toBe("Indent with tabs instead of spaces.")
+    })
+
     test("respects files.exclude patterns from config", async () => {
       vi.spyOn(Config, "exists").mockReturnValue(true)
 

--- a/javascript/packages/language-server/test/project.test.ts
+++ b/javascript/packages/language-server/test/project.test.ts
@@ -95,6 +95,35 @@ describe("Project", () => {
       expect(settings.formatter?.maxLineLength).toBe(120)
     })
 
+    test("carries the config's indent style through", async () => {
+      writeFileSync(join(root, ".herb.yml"), "formatter:\n  enabled: true\n  indentStyle: tab\n")
+
+      const project = projectFor()
+      await project.loadConfig()
+
+      const settings = await project.settingsFor(`file://${join(root, "app/views/posts/index.html.erb")}`)
+
+      expect(settings.formatter?.indentStyle).toBe("tab")
+    })
+
+    test("reads an unset indent style as space, not as an opening for the user's preference", async () => {
+      writeFileSync(join(root, ".herb.yml"), "formatter:\n  enabled: true\n")
+
+      const capabilities = new Capabilities(params)
+      const userSettings = new UserSettings(connection, capabilities)
+
+      userSettings.getDocumentSettings = vi.fn().mockResolvedValue({
+        formatter: { indentStyle: "tab" }
+      })
+
+      const project = projectFor(userSettings, capabilities)
+      await project.loadConfig()
+
+      const settings = await project.settingsFor(`file://${join(root, "app/views/posts/index.html.erb")}`)
+
+      expect(settings.formatter?.indentStyle).toBe("space")
+    })
+
     test("leaves personal settings alone, since a project can't have an opinion on them", async () => {
       writeFileSync(join(root, ".herb.yml"), "formatter:\n  enabled: true\n")
 


### PR DESCRIPTION
Follow up on #2114.

`formatter.indentStyle` landed with the `source-indentation` rule reading it off the `Linter`'s own config, which works for the CLI but never reached the language server's diagnostics. Setting `indentStyle: tab` in `.herb.yml` left the editor flagging every tab.

`LinterService` doesn't lint with the project's `Config`. It builds a fresh one from the project's `framework`, `template_engine`, and `linter` sections.

There is no `formatter` key, and `Config.fromObject` merges what it gets over the defaults, so `formatter.indentStyle` came back as `space` from `lib/herb/defaults.yml` no matter what the project had configured. The `settings` object that `Project#settingsFor` had already resolved a few lines earlier was only being read for `linter.enabled`.

The quick fix and fix-on-save paths had the opposite problem. `CodeActionProvider` and `AutofixService` are both constructed with the real project `Config`, so `Linter#autofix` resolved `indentStyle` correctly and wrote tabs. A project on `indentStyle: tab` therefore got an offense saying "Indent with spaces instead of tabs" next to a quick fix that produced tabs, and fix-on-save quietly rewrote correct tabs back to spaces.

All three now take the indent style from `Project#settingsFor`, which layers `.herb.yml` over the user's editor preferences the same way `FormattingProvider#getConfigWithSettings` already does.

`AutofixService` now takes the `Project` so it can resolve settings, and `CodeActionProvider#autofixCodeActions` became async for the same reason, which makes the `onCodeAction` handler async alongside `onDocumentFormatting`. 

An unset key still means `space`. `readAndValidateConfig` merges the defaults before `Project#settingsFor` reads `formatter.indentStyle`, so once a `.herb.yml` exists it always answers, and a personal `languageServerHerb.formatter.indentStyle` only applies to projects without a config file. 