### PR TITLE
Linter: Scope Action View specific rules to `actionview` option

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -80,7 +80,7 @@ Every tool tailors itself to that answer. It decides what Herb may assume about 
 | `hanami` | Hanami views, with their parts and helpers |
 | `sinatra` | Sinatra templates, with their helpers |
 
-Rules that only make sense for one framework check this option and stay quiet otherwise, which is why `erb-prefer-image-tag-helper` never suggests `image_tag` in a project that doesn't render through Action View.
+Rules that only make sense for one framework declare which frameworks they apply to and stay quiet everywhere else. A rule that says nothing about frameworks applies to all of them. See the [`frameworks`](#rule-configuration-options) rule option for widening or narrowing that per rule.
 
 When the option isn't set, Herb falls back to `ruby` and treats every template as plain ERB, which is the most conservative behavior it has. The [`herb-config-framework-option`](/linter/rules/herb-config-framework-option.md) rule reports that, and suggests a value when a template shows what renders it:
 

--- a/javascript/packages/config/src/config-schema.ts
+++ b/javascript/packages/config/src/config-schema.ts
@@ -16,9 +16,19 @@ export const FilesConfigSchema = z.object({
   exclude: z.array(z.string()).optional().describe("Glob patterns to exclude (e.g., ['node_modules/**/*', 'vendor/**/*', '**/*.html.erb'])"),
 }).strict().optional()
 
+export const FRAMEWORKS = {
+  ruby: "Ruby",
+  actionview: "Action View",
+  hanami: "Hanami",
+  sinatra: "Sinatra",
+} as const
+
+export const FRAMEWORK_NAMES = Object.keys(FRAMEWORKS) as (keyof typeof FRAMEWORKS)[]
+
 const RuleConfigBaseSchema = z.object({
   enabled: z.boolean().optional().describe("Whether the rule is enabled"),
   severity: SeverityConfigSchema.optional().describe("Severity level for the rule"),
+  frameworks: z.array(z.enum(FRAMEWORK_NAMES)).optional().describe("Frameworks this rule applies to (defaults to every framework)"),
   include: z.array(z.string()).optional().describe("Additional glob patterns to include for this rule (additive, ignored when 'only' is present)"),
   only: z.array(z.string()).optional().describe("Only apply this rule to files matching these glob patterns (overrides all 'include' patterns)"),
   exclude: z.array(z.string()).optional().describe("Don't apply this rule to files matching these glob patterns"),
@@ -49,15 +59,6 @@ export const FormatterConfigSchema = z.object({
   maxLineLength: z.number().int().positive().optional().describe("Maximum line length before wrapping"),
   rewriter: RewriterConfigSchema.describe("Rewriter configuration for pre and post-format transformations"),
 }).strict().optional()
-
-export const FRAMEWORKS = {
-  ruby: "Ruby",
-  actionview: "Action View",
-  hanami: "Hanami",
-  sinatra: "Sinatra",
-} as const
-
-export const FRAMEWORK_NAMES = Object.keys(FRAMEWORKS) as (keyof typeof FRAMEWORKS)[]
 
 export const FrameworkSchema = z.enum(FRAMEWORK_NAMES).optional()
   .describe("Framework context (default: 'ruby')")

--- a/javascript/packages/config/src/config.ts
+++ b/javascript/packages/config/src/config.ts
@@ -45,6 +45,7 @@ export type { SeverityConfig, LinterMode }
 export type RuleConfig = {
   enabled?: boolean
   severity?: SeverityConfig
+  frameworks?: Framework[]
   autoCorrect?: boolean
   include?: string[]
   only?: string[]

--- a/javascript/packages/language-server/test/autofix_service.test.ts
+++ b/javascript/packages/language-server/test/autofix_service.test.ts
@@ -117,6 +117,36 @@ describe('AutofixService', () => {
       expect(result).toEqual([])
     })
 
+    it('should fix framework-scoped rules when the project configures their framework', async () => {
+      const config = Config.fromObject({
+        framework: 'actionview',
+        linter: { enabled: true }
+      }, { projectPath: '/test', version: '0.10.3' })
+
+      autofixService.setConfig(config)
+
+      const input = '<%= "Sale".html_safe %>\n'
+      const document = TextDocument.create('file:///test/file.erb', 'erb', 1, input)
+      const result = await autofixService.autofix(document)
+
+      expect(result[0].newText).not.toContain('html_safe')
+    })
+
+    it('should leave framework-scoped rules alone when the project configures another framework', async () => {
+      const config = Config.fromObject({
+        framework: 'sinatra',
+        linter: { enabled: true }
+      }, { projectPath: '/test', version: '0.10.3' })
+
+      autofixService.setConfig(config)
+
+      const input = '<%= "Sale".html_safe %>\n'
+      const document = TextDocument.create('file:///test/file.erb', 'erb', 1, input)
+      const result = await autofixService.autofix(document)
+
+      expect(result).toEqual([])
+    })
+
     it('should rebuild linter when config changes', async () => {
       const config1 = Config.fromObject({
         linter: { enabled: true }

--- a/javascript/packages/language-server/test/linter_service.test.ts
+++ b/javascript/packages/language-server/test/linter_service.test.ts
@@ -158,6 +158,40 @@ describe("LinterService", () => {
       expect(result.diagnostics.map(diagnostic => diagnostic.code)).not.toContain("herb-config-framework-option")
     })
 
+    test("runs framework-scoped rules when the project configures their framework", async () => {
+      const userSettings = new UserSettings(mockConnection, capabilities)
+      userSettings.getDocumentSettings = vi.fn().mockResolvedValue({ linter: { enabled: true } })
+
+      const projectConfig = Config.fromObject({
+        framework: "actionview",
+        linter: { enabled: true, rules: {} }
+      }, { projectPath: process.cwd() })
+
+      const linterService = new LinterService(mockConnection, userSettings, capabilities, projectFor(userSettings), index)
+      linterService.setConfig(projectConfig)
+
+      const result = await linterService.lintDocument(createTestDocument(`<% render "shared/error" %>\n`))
+
+      expect(result.diagnostics.map(diagnostic => diagnostic.code)).toContain("actionview-no-silent-render")
+    })
+
+    test("holds framework-scoped rules back when the project configures another framework", async () => {
+      const userSettings = new UserSettings(mockConnection, capabilities)
+      userSettings.getDocumentSettings = vi.fn().mockResolvedValue({ linter: { enabled: true } })
+
+      const projectConfig = Config.fromObject({
+        framework: "sinatra",
+        linter: { enabled: true, rules: {} }
+      }, { projectPath: process.cwd() })
+
+      const linterService = new LinterService(mockConnection, userSettings, capabilities, projectFor(userSettings), index)
+      linterService.setConfig(projectConfig)
+
+      const result = await linterService.lintDocument(createTestDocument(`<% render "shared/error" %>\n`))
+
+      expect(result.diagnostics.map(diagnostic => diagnostic.code)).not.toContain("actionview-no-silent-render")
+    })
+
     test("reports the missing framework option when the project doesn't configure one", async () => {
       const userSettings = new UserSettings(mockConnection, capabilities)
       userSettings.getDocumentSettings = vi.fn().mockResolvedValue({ linter: { enabled: true } })

--- a/javascript/packages/linter/docs/rules/actionview-no-content-argument-with-block.md
+++ b/javascript/packages/linter/docs/rules/actionview-no-content-argument-with-block.md
@@ -102,6 +102,14 @@ Helpers whose first argument is not content are unaffected. `field_set_tag "Acco
 <% end %>
 ```
 
+## Configuration
+
+This rule only applies to Action View projects, so it needs `framework` to be set:
+
+```yaml
+framework: actionview
+```
+
 ## References
 
 - [Rails API - `ActionView::Helpers::TagHelper#content_tag`](https://api.rubyonrails.org/classes/ActionView/Helpers/TagHelper.html#method-i-content_tag)

--- a/javascript/packages/linter/docs/rules/actionview-no-dynamic-partial-path.md
+++ b/javascript/packages/linter/docs/rules/actionview-no-dynamic-partial-path.md
@@ -68,6 +68,12 @@ Only output tags are reported. A `render` in a silent `<% %>` tag discards its o
 
 ## Configuration
 
+This rule only applies to Action View projects, so it needs `framework` to be set:
+
+```yaml
+framework: actionview
+```
+
 Disable it in `.herb.yml` when computed partial paths are deliberate:
 
 ```yaml

--- a/javascript/packages/linter/docs/rules/actionview-no-helper-shadowing.md
+++ b/javascript/packages/linter/docs/rules/actionview-no-helper-shadowing.md
@@ -87,6 +87,14 @@ Helpers that only exist on the form builder are also **not** reported. `button` 
 <%= tag.name %>
 ```
 
+## Configuration
+
+This rule only applies to Action View projects, so it needs `framework` to be set:
+
+```yaml
+framework: actionview
+```
+
 ## References
 
 * [Rails `ActionView::Helpers::TagHelper#tag`](https://api.rubyonrails.org/classes/ActionView/Helpers/TagHelper.html#method-i-tag)

--- a/javascript/packages/linter/docs/rules/actionview-no-implicit-partial.md
+++ b/javascript/packages/linter/docs/rules/actionview-no-implicit-partial.md
@@ -64,6 +64,12 @@ Only output tags are reported. A `render` in a silent `<% %>` tag discards its o
 
 ## Configuration
 
+This rule only applies to Action View projects, so it needs `framework` to be set:
+
+```yaml
+framework: actionview
+```
+
 Disable it in `.herb.yml` when the implicit form is the house style:
 
 ```yaml

--- a/javascript/packages/linter/docs/rules/actionview-no-implicit-polymorphic-url.md
+++ b/javascript/packages/linter/docs/rules/actionview-no-implicit-polymorphic-url.md
@@ -48,6 +48,12 @@ The same name check applies to local variables and to method calls, so `<%= link
 
 ## Configuration
 
+This rule only applies to Action View projects, so it needs `framework` to be set:
+
+```yaml
+framework: actionview
+```
+
 This rule reports at the `info` severity, so it never fails a run under the default `failLevel` of `error`. That reflects what the rule can and cannot see: whether an instance variable holds a model or a String is not knowable from the template, so a small share of reports will be about a value that was already a URL. To raise or lower it, or to turn the rule off, add to your [`.herb.yml`](/configuration):
 
 ```yaml [.herb.yml]

--- a/javascript/packages/linter/docs/rules/actionview-no-redundant-local-assigns.md
+++ b/javascript/packages/linter/docs/rules/actionview-no-redundant-local-assigns.md
@@ -64,6 +64,14 @@ Partials without a strict locals declaration are not checked at all.
 <%= local_assigns.fetch(:size, "large") %>
 ```
 
+## Configuration
+
+This rule only applies to Action View projects, so it needs `framework` to be set:
+
+```yaml
+framework: actionview
+```
+
 ## References
 
 - [Action View - Strict Locals](https://guides.rubyonrails.org/action_view_overview.html#strict-locals)

--- a/javascript/packages/linter/docs/rules/actionview-no-render-option-shadowing.md
+++ b/javascript/packages/linter/docs/rules/actionview-no-render-option-shadowing.md
@@ -63,6 +63,14 @@ Locals already written inside a `locals:` hash are never reported.
 <%= render "card", layout: "wide" %>
 ```
 
+## Configuration
+
+This rule only applies to Action View projects, so it needs `framework` to be set:
+
+```yaml
+framework: actionview
+```
+
 ## References
 
 - [Action View - Rendering partials](https://guides.rubyonrails.org/layouts_and_rendering.html#using-partials)

--- a/javascript/packages/linter/docs/rules/actionview-no-silent-helper.md
+++ b/javascript/packages/linter/docs/rules/actionview-no-silent-helper.md
@@ -68,6 +68,14 @@ A silent tag is fine when the helper's return value is used instead of being dis
 <% content_tag :div, "Hello", class: "greeting" %>
 ```
 
+## Configuration
+
+This rule only applies to Action View projects, so it needs `framework` to be set:
+
+```yaml
+framework: actionview
+```
+
 ## References
 
 * [Rails Action View Helpers documentation](https://api.rubyonrails.org/classes/ActionView/Helpers.html)

--- a/javascript/packages/linter/docs/rules/actionview-no-silent-render.md
+++ b/javascript/packages/linter/docs/rules/actionview-no-silent-render.md
@@ -52,6 +52,14 @@ Escaped ERB tags (`<%%` and `<%%=`) are ignored. They render as the literal text
 <% render @product %>
 ```
 
+## Configuration
+
+This rule only applies to Action View projects, so it needs `framework` to be set:
+
+```yaml
+framework: actionview
+```
+
 ## References
 
 \-

--- a/javascript/packages/linter/docs/rules/actionview-no-strict-locals-error.md
+++ b/javascript/packages/linter/docs/rules/actionview-no-strict-locals-error.md
@@ -70,6 +70,14 @@ Given `app/views/users/_card.html.erb`:
 <%= render "users/card", user: @user, color: "red" %>
 ```
 
+## Configuration
+
+This rule only applies to Action View projects, so it needs `framework` to be set:
+
+```yaml
+framework: actionview
+```
+
 ## References
 
 - [Action View - Strict Locals](https://guides.rubyonrails.org/action_view_overview.html#strict-locals)

--- a/javascript/packages/linter/docs/rules/actionview-no-unnecessary-html-safe.md
+++ b/javascript/packages/linter/docs/rules/actionview-no-unnecessary-html-safe.md
@@ -54,6 +54,14 @@ The third is content containing the quote that encloses the attribute value. Not
 <%= "&copy; 2026".html_safe %>
 ```
 
+## Configuration
+
+This rule only applies to Action View projects, so it needs `framework` to be set:
+
+```yaml
+framework: actionview
+```
+
 ## References
 
 * [Rails `String#html_safe` API](https://api.rubyonrails.org/classes/String.html#method-i-html_safe)

--- a/javascript/packages/linter/docs/rules/actionview-no-unnecessary-tag-attributes.md
+++ b/javascript/packages/linter/docs/rules/actionview-no-unnecessary-tag-attributes.md
@@ -73,6 +73,14 @@ Using `tag.attributes` alongside regular HTML attributes is allowed:
 <img <%= tag.attributes(src: image_path("logo.png"), alt: "Logo") %>>
 ```
 
+## Configuration
+
+This rule only applies to Action View projects, so it needs `framework` to be set:
+
+```yaml
+framework: actionview
+```
+
 ## References
 
 * [Rails `tag` API](https://api.rubyonrails.org/classes/ActionView/Helpers/TagHelper.html#method-i-tag)

--- a/javascript/packages/linter/docs/rules/actionview-no-unused-strict-locals.md
+++ b/javascript/packages/linter/docs/rules/actionview-no-unused-strict-locals.md
@@ -50,6 +50,14 @@ The rule also stops reporting for a template that reads `local_assigns` as a who
 </div>
 ```
 
+## Configuration
+
+This rule only applies to Action View projects, so it needs `framework` to be set:
+
+```yaml
+framework: actionview
+```
+
 ## References
 
 - [Action View - Strict Locals](https://guides.rubyonrails.org/action_view_overview.html#strict-locals)

--- a/javascript/packages/linter/docs/rules/actionview-no-void-element-content.md
+++ b/javascript/packages/linter/docs/rules/actionview-no-void-element-content.md
@@ -50,6 +50,14 @@ The correct way to set attributes on void elements is to use keyword arguments, 
 <%= content_tag :br, "hello" %>
 ```
 
+## Configuration
+
+This rule only applies to Action View projects, so it needs `framework` to be set:
+
+```yaml
+framework: actionview
+```
+
 ## References
 
 * [Rails `ActionView::Helpers::TagHelper#tag`](https://api.rubyonrails.org/classes/ActionView/Helpers/TagHelper.html#method-i-tag)

--- a/javascript/packages/linter/docs/rules/actionview-prefer-collection-render.md
+++ b/javascript/packages/linter/docs/rules/actionview-prefer-collection-render.md
@@ -100,6 +100,14 @@ Loops that do more than render a single partial are not flagged, because collect
 <% end %>
 ```
 
+## Configuration
+
+This rule only applies to Action View projects, so it needs `framework` to be set:
+
+```yaml
+framework: actionview
+```
+
 ## References
 
 - [Action View Partials: Rendering Collections](https://guides.rubyonrails.org/layouts_and_rendering.html#rendering-collections)

--- a/javascript/packages/linter/docs/rules/actionview-prefer-pluralize-helper.md
+++ b/javascript/packages/linter/docs/rules/actionview-prefer-pluralize-helper.md
@@ -52,6 +52,14 @@ A `String#pluralize` call that passes a locale is not reported, because the help
 <%= aliases.size %> Known <%= "Alias".pluralize(aliases.size) %>
 ```
 
+## Configuration
+
+This rule only applies to Action View projects, so it needs `framework` to be set:
+
+```yaml
+framework: actionview
+```
+
 ## References
 
 - [`ActionView::Helpers::TextHelper#pluralize`](https://api.rubyonrails.org/classes/ActionView/Helpers/TextHelper.html#method-i-pluralize)

--- a/javascript/packages/linter/docs/rules/actionview-prefer-qualified-partial-path.md
+++ b/javascript/packages/linter/docs/rules/actionview-prefer-qualified-partial-path.md
@@ -82,6 +82,12 @@ The rewrite is also skipped when the same quoted string appears more than once i
 
 ## Configuration
 
+This rule only applies to Action View projects, so it needs `framework` to be set:
+
+```yaml
+framework: actionview
+```
+
 Disable it in `.herb.yml` when short partial names are the house style:
 
 ```yaml

--- a/javascript/packages/linter/docs/rules/actionview-strict-locals-first-line.md
+++ b/javascript/packages/linter/docs/rules/actionview-strict-locals-first-line.md
@@ -60,6 +60,14 @@ Strict locals on line 1 but no blank line before content:
 </div>
 ```
 
+## Configuration
+
+This rule only applies to Action View projects, so it needs `framework` to be set:
+
+```yaml
+framework: actionview
+```
+
 ## References
 
 - [Action View - Strict Locals](https://guides.rubyonrails.org/action_view_overview.html#strict-locals)

--- a/javascript/packages/linter/docs/rules/actionview-strict-locals-partial-only.md
+++ b/javascript/packages/linter/docs/rules/actionview-strict-locals-partial-only.md
@@ -32,6 +32,14 @@ A `<%# locals: (...) %>` comment in a non-partial file (such as a view or layout
 </div>
 ```
 
+## Configuration
+
+This rule only applies to Action View projects, so it needs `framework` to be set:
+
+```yaml
+framework: actionview
+```
+
 ## References
 
 - [Action View - Strict Locals](https://guides.rubyonrails.org/action_view_overview.html#strict-locals)

--- a/javascript/packages/linter/docs/rules/erb-no-javascript-tag-helper.md
+++ b/javascript/packages/linter/docs/rules/erb-no-javascript-tag-helper.md
@@ -28,6 +28,14 @@ The `javascript_tag` helper renders its block as raw text, which means unsafe ER
 <% end %>
 ```
 
+## Configuration
+
+`javascript_tag` is an Action View helper, so this rule only applies to Action View projects and needs `framework` to be set:
+
+```yaml
+framework: actionview
+```
+
 ## References
 
 - [Shopify/better-html — `NoJavascriptTagHelper`](https://github.com/Shopify/better-html/blob/main/lib/better_html/test_helper/safe_erb/no_javascript_tag_helper.rb)

--- a/javascript/packages/linter/docs/rules/erb-strict-locals-comment-syntax.md
+++ b/javascript/packages/linter/docs/rules/erb-strict-locals-comment-syntax.md
@@ -175,6 +175,14 @@ Only one `locals:` comment is allowed per partial:
 <%# locals: (admin:) %>
 ```
 
+## Configuration
+
+Strict locals is an Action View feature, so this rule only applies to Action View projects and needs `framework` to be set:
+
+```yaml
+framework: actionview
+```
+
 ## References
 
 - [Action View - Strict Locals](https://guides.rubyonrails.org/action_view_overview.html#strict-locals)

--- a/javascript/packages/linter/docs/rules/erb-strict-locals-required.md
+++ b/javascript/packages/linter/docs/rules/erb-strict-locals-required.md
@@ -27,6 +27,12 @@ This rule encourages partials to be explicit about what they expect. Partials th
 
 ## Configuration
 
+Strict locals is an Action View feature, so this rule only applies to Action View projects and needs `framework` to be set:
+
+```yaml
+framework: actionview
+```
+
 This rule is disabled by default. To enable it, add to your [`.herb.yml`](/configuration):
 
 ```yaml [.herb.yml]

--- a/javascript/packages/linter/src/linter.ts
+++ b/javascript/packages/linter/src/linter.ts
@@ -1,6 +1,6 @@
 import picomatch from "picomatch"
 
-import { Location, semverGreaterThan } from "@herb-tools/core"
+import { DEFAULT_FRAMEWORK, Location, semverGreaterThan } from "@herb-tools/core"
 import { IdentityPrinter, IndentPrinter } from "@herb-tools/printer"
 
 import { rules } from "./rules.js"
@@ -14,7 +14,7 @@ import { ParserNoErrorsRule } from "./rules/parser-no-errors.js"
 import { DEFAULT_RULE_CONFIG } from "./types.js"
 import { resolveSeverity, ALL_RULES_KEY } from "@herb-tools/config/schema"
 
-import type { RuleClass, ParserRuleClass, LexerRuleClass, SourceRuleClass, Rule, ParserRule, LexerRule, SourceRule, LintResult, LintOffense, UnboundLintOffense, LintContext, AutofixResult, RuleVersion, LinterMode } from "./types.js"
+import type { RuleClass, ParserRuleClass, LexerRuleClass, SourceRuleClass, Rule, ParserRule, LexerRule, SourceRule, LintResult, LintOffense, UnboundLintOffense, LintContext, AutofixResult, RuleVersion, LinterMode, Framework } from "./types.js"
 import type { ParseResult, LexResult, HerbBackend } from "@herb-tools/core"
 import type { RuleConfig, Config } from "@herb-tools/config"
 
@@ -299,6 +299,31 @@ export class Linter {
   }
 
   /**
+   * Whether a rule applies to the framework the template is linted as.
+   *
+   * A rule that leaves `frameworks` open applies everywhere. One that narrows it
+   * only runs when the framework it is linted against is listed, and since an
+   * unset `framework` means `ruby`, a rule scoped to `actionview` stays quiet
+   * until a project sets `framework: actionview` in its `.herb.yml`.
+   *
+   * `--only` and `--all-rules` skip this the same way they skip the path
+   * filters, since asking for a rule by name is answer enough about whether it
+   * should run.
+   *
+   * @param rule - The rule instance to check
+   * @param framework - The framework from the lint context, if any
+   * @returns true when the rule applies to the framework
+   */
+  protected appliesToFramework(rule: Rule, framework: Framework | undefined): boolean {
+    const userFrameworks = this.config?.linter?.rules?.[rule.ruleName]?.frameworks
+    const frameworks = userFrameworks ?? rule.defaultConfig?.frameworks
+
+    if (!frameworks) return true
+
+    return frameworks.includes(framework ?? DEFAULT_FRAMEWORK)
+  }
+
+  /**
    * Execute a single rule and return its unbound offenses.
    * Handles rule type checking (Lexer/Parser/Source) and isEnabled checks.
    */
@@ -311,6 +336,10 @@ export class Linter {
     context?: Partial<LintContext>
   ): UnboundLintOffense[] {
     const ruleName = rule.ruleName
+
+    if (!this.onlyRules && !this.allRules && !this.appliesToFramework(rule, context?.framework)) {
+      return []
+    }
 
     if (this.config && context?.fileName && !this.onlyRules && !this.allRules) {
       if (!this.config.isRuleEnabledForPath(ruleName, context.fileName)) {

--- a/javascript/packages/linter/src/rules/actionview-no-content-argument-with-block.ts
+++ b/javascript/packages/linter/src/rules/actionview-no-content-argument-with-block.ts
@@ -88,6 +88,7 @@ export class ActionViewNoContentArgumentWithBlockRule extends ParserRule {
     return {
       enabled: true,
       severity: "error",
+      frameworks: ["actionview"],
     }
   }
 

--- a/javascript/packages/linter/src/rules/actionview-no-dynamic-partial-path.ts
+++ b/javascript/packages/linter/src/rules/actionview-no-dynamic-partial-path.ts
@@ -54,6 +54,7 @@ export class ActionViewNoDynamicPartialPathRule extends ParserRule {
     return {
       enabled: true,
       severity: "info",
+      frameworks: ["actionview"],
     }
   }
 

--- a/javascript/packages/linter/src/rules/actionview-no-helper-shadowing.ts
+++ b/javascript/packages/linter/src/rules/actionview-no-helper-shadowing.ts
@@ -130,7 +130,8 @@ export class ActionViewNoHelperShadowingRule extends ParserRule {
   get defaultConfig(): FullRuleConfig {
     return {
       enabled: true,
-      severity: "warning"
+      severity: "warning",
+      frameworks: ["actionview"],
     }
   }
 

--- a/javascript/packages/linter/src/rules/actionview-no-implicit-partial.ts
+++ b/javascript/packages/linter/src/rules/actionview-no-implicit-partial.ts
@@ -55,6 +55,7 @@ export class ActionViewNoImplicitPartialRule extends ParserRule {
     return {
       enabled: true,
       severity: "info",
+      frameworks: ["actionview"],
     }
   }
 

--- a/javascript/packages/linter/src/rules/actionview-no-implicit-polymorphic-url.ts
+++ b/javascript/packages/linter/src/rules/actionview-no-implicit-polymorphic-url.ts
@@ -180,6 +180,7 @@ export class ActionViewNoImplicitPolymorphicURLRule extends ParserRule {
     return {
       enabled: true,
       severity: "info",
+      frameworks: ["actionview"],
     }
   }
 

--- a/javascript/packages/linter/src/rules/actionview-no-redundant-local-assigns.ts
+++ b/javascript/packages/linter/src/rules/actionview-no-redundant-local-assigns.ts
@@ -106,6 +106,7 @@ export class ActionViewNoRedundantLocalAssignsRule extends ParserRule {
         cli: "error",
         editor: "info",
       },
+      frameworks: ["actionview"],
     }
   }
 

--- a/javascript/packages/linter/src/rules/actionview-no-render-option-shadowing.ts
+++ b/javascript/packages/linter/src/rules/actionview-no-render-option-shadowing.ts
@@ -70,6 +70,7 @@ export class ActionViewNoRenderOptionShadowingRule extends ParserRule {
     return {
       enabled: true,
       severity: "info",
+      frameworks: ["actionview"],
     }
   }
 

--- a/javascript/packages/linter/src/rules/actionview-no-silent-helper.ts
+++ b/javascript/packages/linter/src/rules/actionview-no-silent-helper.ts
@@ -102,7 +102,8 @@ export class ActionViewNoSilentHelperRule extends ParserRule<ActionViewNoSilentH
   get defaultConfig(): FullRuleConfig {
     return {
       enabled: true,
-      severity: "error"
+      severity: "error",
+      frameworks: ["actionview"],
     }
   }
 

--- a/javascript/packages/linter/src/rules/actionview-no-silent-render.ts
+++ b/javascript/packages/linter/src/rules/actionview-no-silent-render.ts
@@ -25,7 +25,8 @@ export class ActionViewNoSilentRenderRule extends ParserRule {
   get defaultConfig(): FullRuleConfig {
     return {
       enabled: true,
-      severity: "error"
+      severity: "error",
+      frameworks: ["actionview"],
     }
   }
 

--- a/javascript/packages/linter/src/rules/actionview-no-strict-locals-error.ts
+++ b/javascript/packages/linter/src/rules/actionview-no-strict-locals-error.ts
@@ -141,6 +141,7 @@ export class ActionViewNoStrictLocalsErrorRule extends ParserRule {
     return {
       enabled: true,
       severity: "error",
+      frameworks: ["actionview"],
     }
   }
 

--- a/javascript/packages/linter/src/rules/actionview-no-unnecessary-html-safe.ts
+++ b/javascript/packages/linter/src/rules/actionview-no-unnecessary-html-safe.ts
@@ -99,6 +99,7 @@ export class ActionViewNoUnnecessaryHTMLSafeRule extends ParserRule<UnnecessaryH
     return {
       enabled: true,
       severity: "error",
+      frameworks: ["actionview"],
     }
   }
 

--- a/javascript/packages/linter/src/rules/actionview-no-unnecessary-tag-attributes.ts
+++ b/javascript/packages/linter/src/rules/actionview-no-unnecessary-tag-attributes.ts
@@ -81,6 +81,7 @@ export class ActionViewNoUnnecessaryTagAttributesRule extends ParserRule<Unneces
     return {
       enabled: true,
       severity: "warning",
+      frameworks: ["actionview"],
     }
   }
 

--- a/javascript/packages/linter/src/rules/actionview-no-unused-strict-locals.ts
+++ b/javascript/packages/linter/src/rules/actionview-no-unused-strict-locals.ts
@@ -144,6 +144,7 @@ export class ActionViewNoUnusedStrictLocalsRule extends ParserRule {
         cli: "error",
         editor: "info",
       },
+      frameworks: ["actionview"],
     }
   }
 

--- a/javascript/packages/linter/src/rules/actionview-no-void-element-content.ts
+++ b/javascript/packages/linter/src/rules/actionview-no-void-element-content.ts
@@ -11,7 +11,8 @@ export class ActionViewNoVoidElementContentRule extends ParserRule {
   get defaultConfig(): FullRuleConfig {
     return {
       enabled: true,
-      severity: "error"
+      severity: "error",
+      frameworks: ["actionview"],
     }
   }
 

--- a/javascript/packages/linter/src/rules/actionview-prefer-collection-render.ts
+++ b/javascript/packages/linter/src/rules/actionview-prefer-collection-render.ts
@@ -98,7 +98,8 @@ export class ActionViewPreferCollectionRenderRule extends ParserRule {
   get defaultConfig(): FullRuleConfig {
     return {
       enabled: true,
-      severity: "error"
+      severity: "error",
+      frameworks: ["actionview"],
     }
   }
 

--- a/javascript/packages/linter/src/rules/actionview-prefer-link-to-helper.ts
+++ b/javascript/packages/linter/src/rules/actionview-prefer-link-to-helper.ts
@@ -97,7 +97,6 @@ class ActionViewPreferLinkToHelperVisitor extends BaseRuleVisitor<PreferLinkToHe
   }
 
   private checkAnchor(node: HTMLElementNode): void {
-    if (this.context.framework !== "actionview") return
     if (getTagLocalName(node) !== "a") return
 
     const openTag = node.open_tag
@@ -148,6 +147,7 @@ export class ActionViewPreferLinkToHelperRule extends ParserRule<PreferLinkToHel
     return {
       enabled: true,
       severity: "info",
+      frameworks: ["actionview"],
     }
   }
 

--- a/javascript/packages/linter/src/rules/actionview-prefer-pluralize-helper.ts
+++ b/javascript/packages/linter/src/rules/actionview-prefer-pluralize-helper.ts
@@ -208,6 +208,7 @@ export class ActionViewPreferPluralizeHelperRule extends ParserRule {
     return {
       enabled: true,
       severity: "warning",
+      frameworks: ["actionview"],
     }
   }
 

--- a/javascript/packages/linter/src/rules/actionview-prefer-qualified-partial-path.ts
+++ b/javascript/packages/linter/src/rules/actionview-prefer-qualified-partial-path.ts
@@ -127,6 +127,7 @@ export class ActionViewPreferQualifiedPartialPathRule extends ParserRule<PreferQ
     return {
       enabled: true,
       severity: "info",
+      frameworks: ["actionview"],
     }
   }
 

--- a/javascript/packages/linter/src/rules/actionview-strict-locals-first-line.ts
+++ b/javascript/packages/linter/src/rules/actionview-strict-locals-first-line.ts
@@ -64,6 +64,7 @@ export class ActionViewStrictLocalsFirstLineRule extends ParserRule {
     return {
       enabled: false,
       severity: "error",
+      frameworks: ["actionview"],
     }
   }
 

--- a/javascript/packages/linter/src/rules/actionview-strict-locals-partial-only.ts
+++ b/javascript/packages/linter/src/rules/actionview-strict-locals-partial-only.ts
@@ -29,6 +29,7 @@ export class ActionViewStrictLocalsPartialOnlyRule extends ParserRule {
     return {
       enabled: true,
       severity: "warning",
+      frameworks: ["actionview"],
     }
   }
 

--- a/javascript/packages/linter/src/rules/erb-no-javascript-tag-helper.ts
+++ b/javascript/packages/linter/src/rules/erb-no-javascript-tag-helper.ts
@@ -27,6 +27,7 @@ class ERBNoJavascriptTagHelperVisitor extends BaseRuleVisitor {
   }
 }
 
+// TODO: `javascript_tag` is an Action View helper, so this rule belongs under the `actionview-` prefix. The rename waits on a rule-alias mechanism, since it breaks every `.herb.yml` and `herb:disable` comment naming it.
 export class ERBNoJavascriptTagHelperRule extends ParserRule {
   static ruleName = "erb-no-javascript-tag-helper"
   static introducedIn = this.version("0.9.0")
@@ -34,7 +35,8 @@ export class ERBNoJavascriptTagHelperRule extends ParserRule {
   get defaultConfig(): FullRuleConfig {
     return {
       enabled: true,
-      severity: "warning"
+      severity: "warning",
+      frameworks: ["actionview"],
     }
   }
 

--- a/javascript/packages/linter/src/rules/erb-prefer-image-tag-helper.ts
+++ b/javascript/packages/linter/src/rules/erb-prefer-image-tag-helper.ts
@@ -15,8 +15,6 @@ class ERBPreferImageTagHelperVisitor extends BaseRuleVisitor {
   }
 
   private checkImgTag(openTag: HTMLOpenTagNode): void {
-    if (this.context.framework !== "actionview") return
-
     const tagName = getTagLocalName(openTag)
 
     if (tagName !== "img") return
@@ -92,6 +90,7 @@ class ERBPreferImageTagHelperVisitor extends BaseRuleVisitor {
   }
 }
 
+// TODO: This rule is already scoped to Action View, so it belongs under the `actionview-` prefix. The rename waits on a rule-alias mechanism, since it breaks every `.herb.yml` and `herb:disable` comment naming it.
 export class ERBPreferImageTagHelperRule extends ParserRule {
   static ruleName = "erb-prefer-image-tag-helper"
   static introducedIn = this.version("0.4.3")
@@ -99,7 +98,8 @@ export class ERBPreferImageTagHelperRule extends ParserRule {
   get defaultConfig(): FullRuleConfig {
     return {
       enabled: true,
-      severity: "warning"
+      severity: "warning",
+      frameworks: ["actionview"],
     }
   }
 

--- a/javascript/packages/linter/src/rules/erb-strict-locals-comment-syntax.ts
+++ b/javascript/packages/linter/src/rules/erb-strict-locals-comment-syntax.ts
@@ -465,6 +465,7 @@ class ERBStrictLocalsCommentSyntaxVisitor extends BaseRuleVisitor<ERBStrictLocal
   }
 }
 
+// TODO: Strict locals is an Action View feature, so this rule belongs under the `actionview-` prefix next to the four rules that already validate it. The rename waits on a rule-alias mechanism, since it breaks every `.herb.yml` and `herb:disable` comment naming it.
 export class ERBStrictLocalsCommentSyntaxRule extends ParserRule<ERBStrictLocalsCommentSyntaxAutofixContext> {
   static autocorrectable = true
   static autofixRequiresContext = true
@@ -481,7 +482,8 @@ export class ERBStrictLocalsCommentSyntaxRule extends ParserRule<ERBStrictLocals
   get defaultConfig(): FullRuleConfig {
     return {
       enabled: true,
-      severity: "error"
+      severity: "error",
+      frameworks: ["actionview"],
     }
   }
 

--- a/javascript/packages/linter/src/rules/erb-strict-locals-required.ts
+++ b/javascript/packages/linter/src/rules/erb-strict-locals-required.ts
@@ -76,6 +76,7 @@ function mergeLocals(fromCallSites: StrictLocal[], fromBody: string[]): StrictLo
   return locals.sort((left, right) => left.name.localeCompare(right.name))
 }
 
+// TODO: Strict locals is an Action View feature, so this rule belongs under the `actionview-` prefix next to the four rules that already validate it. The rename waits on a rule-alias mechanism, since it breaks every `.herb.yml` and `herb:disable` comment naming it.
 export class ERBStrictLocalsRequiredRule extends ParserRule<StrictLocalsRequiredAutofixContext> {
   static unsafeAutocorrectable = true
   static ruleName = "erb-strict-locals-required"
@@ -92,6 +93,7 @@ export class ERBStrictLocalsRequiredRule extends ParserRule<StrictLocalsRequired
     return {
       enabled: false,
       severity: "error",
+      frameworks: ["actionview"],
     }
   }
 

--- a/javascript/packages/linter/test/__snapshots__/cli.test.ts.snap
+++ b/javascript/packages/linter/test/__snapshots__/cli.test.ts.snap
@@ -727,20 +727,6 @@ test/fixtures/no-trailing-newline.html.erb:1:29
 exports[`CLI Output Formatting > GitHub Actions format includes rule codes 2`] = `
 "✓ Using Herb config file at /test/herb/javascript/packages/linter/.herb.yml
 
-[info] The partial \`post\` is looked up relative to the directory of the template rendering it. Moving this template changes which file that resolves to, and renaming the partial means hunting for callers that never spell its full name. Write the full path from the view root so it resolves to the same file from any template, and a search for that path finds every caller. (actionview-prefer-qualified-partial-path)
-
-test/fixtures/erb-no-extra-whitespace-inside-tags.html.erb:9:21
-
-      7 │ <% end %>
-      8 │ 
-  →   9 │ <%=  render partial: "post",
-        │                      ~~~~~~
-     10 │            as: :post
-     11 │ %>
-
-
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯  [1/5] ⎯⎯⎯⎯
-
 [error] Remove extra whitespace after \`<%\`. (erb-no-extra-whitespace-inside-tags) [Correctable]
 
 test/fixtures/erb-no-extra-whitespace-inside-tags.html.erb:1:2
@@ -759,7 +745,7 @@ test/fixtures/erb-no-extra-whitespace-inside-tags.html.erb:1:2
               2 │
 
 
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯  [2/5] ⎯⎯⎯⎯
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯  [1/4] ⎯⎯⎯⎯
 
 [error] Remove extra whitespace before \`%>\`. (erb-no-extra-whitespace-inside-tags) [Correctable]
 
@@ -779,7 +765,7 @@ test/fixtures/erb-no-extra-whitespace-inside-tags.html.erb:1:20
               2 │
 
 
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯  [3/5] ⎯⎯⎯⎯
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯  [2/4] ⎯⎯⎯⎯
 
 [error] Remove extra whitespace after \`<%=\`. (erb-no-extra-whitespace-inside-tags) [Correctable]
 
@@ -802,7 +788,7 @@ test/fixtures/erb-no-extra-whitespace-inside-tags.html.erb:9:3
              10 │            as: :post
 
 
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯  [4/5] ⎯⎯⎯⎯
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯  [3/4] ⎯⎯⎯⎯
 
 [error] Avoid unused expressions in silent ERB tags. \`<% extra_whitespace %>\` is evaluated but its return value is discarded. Use \`<%= extra_whitespace %>\` to output the value or remove the expression. (erb-no-unused-expressions)
 
@@ -817,15 +803,13 @@ test/fixtures/erb-no-extra-whitespace-inside-tags.html.erb:1:4
 
  Rule offenses:
   erb-no-extra-whitespace-inside-tags (3 offenses in 1 file)
-  actionview-prefer-qualified-partial-path (1 offense in 1 file)
   erb-no-unused-expressions (1 offense in 1 file)
 
 
  Summary:
   Checked      1 file
-  Failing      4 errors (4 offenses across 1 file)
-  Not failing  1 info (1 offense across 1 file, below --fail-level=error)
-  Fixable      5 offenses | 3 autocorrectable using \`--fix\`
+  Offenses     4 errors (4 offenses across 1 file)
+  Fixable      4 offenses | 3 autocorrectable using \`--fix\`
   Rules        119 enabled | 21 not enabled"
 `;
 
@@ -892,7 +876,7 @@ test/fixtures/ignored.html.erb:6:14
 exports[`CLI Output Formatting > New rules available hint > keeps the space before the version label inside the gray sequence 1`] = `"  ]8;;https://herb-tools.dev/linter/rules/svg-tag-name-capitalization\\[37msvg-tag-name-capitalization[0m]8;;\\[90m (introduced in 0.4.2)[0m"`;
 
 exports[`CLI Output Formatting > allows tag.attributes in attribute position 1`] = `
-"✓ Using Herb config file at /test/herb/javascript/packages/linter/.herb.yml
+"✓ Using Herb config file at /test/herb/javascript/packages/linter/test/fixtures/actionview.herb.yml
 
 [warning] Avoid using \`tag.attributes\` to set all attributes on \`<div>\`. Use \`tag.div\` or add the attributes directly to the \`<div>\` tag instead. (actionview-no-unnecessary-tag-attributes) [Correctable]
 

--- a/javascript/packages/linter/test/autofix/actionview-no-silent-helper.autofix.test.ts
+++ b/javascript/packages/linter/test/autofix/actionview-no-silent-helper.autofix.test.ts
@@ -18,7 +18,7 @@ describe("actionview-no-silent-helper autofix", () => {
     `
 
     const linter = new Linter(Herb, [ActionViewNoSilentHelperRule])
-    const result = linter.autofix(input, { fileName: "test.html.erb" }, undefined, { includeUnsafe: true })
+    const result = linter.autofix(input, { fileName: "test.html.erb", framework: "actionview" }, undefined, { includeUnsafe: true })
 
     expect(result.source).toBe(input)
     expect(result.fixed).toHaveLength(0)
@@ -35,7 +35,7 @@ describe("actionview-no-silent-helper autofix", () => {
     `
 
     const linter = new Linter(Herb, [ActionViewNoSilentHelperRule])
-    const result = linter.autofix(input, { fileName: "test.html.erb" }, undefined, { includeUnsafe: true })
+    const result = linter.autofix(input, { fileName: "test.html.erb", framework: "actionview" }, undefined, { includeUnsafe: true })
 
     expect(result.source).toBe(expected)
     expect(result.fixed).toHaveLength(1)
@@ -52,7 +52,7 @@ describe("actionview-no-silent-helper autofix", () => {
     `
 
     const linter = new Linter(Herb, [ActionViewNoSilentHelperRule])
-    const result = linter.autofix(input, { fileName: "test.html.erb" }, undefined, { includeUnsafe: true })
+    const result = linter.autofix(input, { fileName: "test.html.erb", framework: "actionview" }, undefined, { includeUnsafe: true })
 
     expect(result.source).toBe(expected)
     expect(result.fixed).toHaveLength(1)
@@ -69,7 +69,7 @@ describe("actionview-no-silent-helper autofix", () => {
     `
 
     const linter = new Linter(Herb, [ActionViewNoSilentHelperRule])
-    const result = linter.autofix(input, { fileName: "test.html.erb" }, undefined, { includeUnsafe: true })
+    const result = linter.autofix(input, { fileName: "test.html.erb", framework: "actionview" }, undefined, { includeUnsafe: true })
 
     expect(result.source).toBe(expected)
     expect(result.fixed).toHaveLength(1)
@@ -86,7 +86,7 @@ describe("actionview-no-silent-helper autofix", () => {
     `
 
     const linter = new Linter(Herb, [ActionViewNoSilentHelperRule])
-    const result = linter.autofix(input, { fileName: "test.html.erb" }, undefined, { includeUnsafe: true })
+    const result = linter.autofix(input, { fileName: "test.html.erb", framework: "actionview" }, undefined, { includeUnsafe: true })
 
     expect(result.source).toBe(expected)
     expect(result.fixed).toHaveLength(1)

--- a/javascript/packages/linter/test/autofix/actionview-no-unnecessary-html-safe.autofix.test.ts
+++ b/javascript/packages/linter/test/autofix/actionview-no-unnecessary-html-safe.autofix.test.ts
@@ -9,7 +9,7 @@ describe("actionview-no-unnecessary-html-safe autofix", () => {
     await Herb.load()
   })
 
-  const autofix = (input: string) => new Linter(Herb, [ActionViewNoUnnecessaryHTMLSafeRule]).autofix(input)
+  const autofix = (input: string) => new Linter(Herb, [ActionViewNoUnnecessaryHTMLSafeRule]).autofix(input, { framework: "actionview" })
 
   test("fixes a String literal marked as HTML-safe in attribute position", () => {
     const result = autofix(`<div <%= 'style="display: none;"'.html_safe %>></div>`)

--- a/javascript/packages/linter/test/autofix/actionview-no-unnecessary-tag-attributes.autofix.test.ts
+++ b/javascript/packages/linter/test/autofix/actionview-no-unnecessary-tag-attributes.autofix.test.ts
@@ -14,7 +14,7 @@ describe("actionview-no-unnecessary-tag-attributes autofix", () => {
     const expected = `<%= tag.input(type: :text, aria: { label: "Search" }) %>`
 
     const linter = new Linter(Herb, [ActionViewNoUnnecessaryTagAttributesRule])
-    const result = linter.autofix(input)
+    const result = linter.autofix(input, { framework: "actionview" })
 
     expect(result.source).toBe(expected)
     expect(result.fixed).toHaveLength(1)
@@ -26,7 +26,7 @@ describe("actionview-no-unnecessary-tag-attributes autofix", () => {
     const expected = `<%= tag.img(src: image_path("logo.png"), alt: "Logo") %>`
 
     const linter = new Linter(Herb, [ActionViewNoUnnecessaryTagAttributesRule])
-    const result = linter.autofix(input)
+    const result = linter.autofix(input, { framework: "actionview" })
 
     expect(result.source).toBe(expected)
     expect(result.fixed).toHaveLength(1)
@@ -47,7 +47,7 @@ describe("actionview-no-unnecessary-tag-attributes autofix", () => {
     `
 
     const linter = new Linter(Herb, [ActionViewNoUnnecessaryTagAttributesRule])
-    const result = linter.autofix(input)
+    const result = linter.autofix(input, { framework: "actionview" })
 
     expect(result.source).toBe(expected)
     expect(result.fixed).toHaveLength(1)
@@ -59,7 +59,7 @@ describe("actionview-no-unnecessary-tag-attributes autofix", () => {
     const expected = `<%= tag.div(id: "container", class: "wrapper") %>`
 
     const linter = new Linter(Herb, [ActionViewNoUnnecessaryTagAttributesRule])
-    const result = linter.autofix(input)
+    const result = linter.autofix(input, { framework: "actionview" })
 
     expect(result.source).toBe(expected)
     expect(result.fixed).toHaveLength(1)
@@ -71,7 +71,7 @@ describe("actionview-no-unnecessary-tag-attributes autofix", () => {
     const expected = `<%= tag.div(id: "container", class: "wrapper") do %>   <% end %>`
 
     const linter = new Linter(Herb, [ActionViewNoUnnecessaryTagAttributesRule])
-    const result = linter.autofix(input)
+    const result = linter.autofix(input, { framework: "actionview" })
 
     expect(result.source).toBe(expected)
     expect(result.fixed).toHaveLength(1)
@@ -83,7 +83,7 @@ describe("actionview-no-unnecessary-tag-attributes autofix", () => {
     const expected = `<%= tag.br(class: "spacer") %>`
 
     const linter = new Linter(Herb, [ActionViewNoUnnecessaryTagAttributesRule])
-    const result = linter.autofix(input)
+    const result = linter.autofix(input, { framework: "actionview" })
 
     expect(result.source).toBe(expected)
     expect(result.fixed).toHaveLength(1)
@@ -94,7 +94,7 @@ describe("actionview-no-unnecessary-tag-attributes autofix", () => {
     const input = `<button class="primary" <%= tag.attributes(id: "cta") %>>Click</button>`
 
     const linter = new Linter(Herb, [ActionViewNoUnnecessaryTagAttributesRule])
-    const result = linter.autofix(input)
+    const result = linter.autofix(input, { framework: "actionview" })
 
     expect(result.source).toBe(input)
     expect(result.fixed).toHaveLength(0)

--- a/javascript/packages/linter/test/autofix/actionview-prefer-qualified-partial-path.autofix.test.ts
+++ b/javascript/packages/linter/test/autofix/actionview-prefer-qualified-partial-path.autofix.test.ts
@@ -17,7 +17,7 @@ const partials = new PartialIndex("app/views", new Map([
   ["application/flash", declaration("app/views/application/_flash.html.erb")],
 ]))
 
-const context = { fileName: "app/views/posts/index.html.erb", partials }
+const context = { fileName: "app/views/posts/index.html.erb", framework: "actionview" as const, partials }
 
 function fix(source: string, options: { includeUnsafe?: boolean, context?: any } = {}) {
   const linter = new Linter(Herb, [ActionViewPreferQualifiedPartialPathRule])
@@ -98,7 +98,7 @@ describe("actionview-prefer-qualified-partial-path autofix", () => {
   })
 
   test("qualifies a partial rendered from a partial in the same directory", () => {
-    const result = fix(`<%= render "card" %>`, { context: { fileName: "app/views/posts/_list.html.erb", partials } })
+    const result = fix(`<%= render "card" %>`, { context: { fileName: "app/views/posts/_list.html.erb", framework: "actionview", partials } })
 
     expect(result.source).toBe(`<%= render "posts/card" %>`)
   })

--- a/javascript/packages/linter/test/autofix/actionview-strict-locals-first-line.autofix.test.ts
+++ b/javascript/packages/linter/test/autofix/actionview-strict-locals-first-line.autofix.test.ts
@@ -21,7 +21,7 @@ describe("actionview-strict-locals-first-line autofix", () => {
     `
 
     const linter = new Linter(Herb, [ActionViewStrictLocalsFirstLineRule])
-    const result = linter.autofix(input, { fileName: "_partial.html.erb" })
+    const result = linter.autofix(input, { fileName: "_partial.html.erb", framework: "actionview" })
 
     expect(result.source).toBe(expected)
     expect(result.fixed).toHaveLength(1)
@@ -33,7 +33,7 @@ describe("actionview-strict-locals-first-line autofix", () => {
     const expected = "<%# locals: (user:) %>\n\n<div><%= user.name %></div>\n"
 
     const linter = new Linter(Herb, [ActionViewStrictLocalsFirstLineRule])
-    const result = linter.autofix(input, { fileName: "_partial.html.erb" })
+    const result = linter.autofix(input, { fileName: "_partial.html.erb", framework: "actionview" })
 
     expect(result.source).toBe(expected)
     expect(result.fixed).toHaveLength(1)
@@ -49,7 +49,7 @@ describe("actionview-strict-locals-first-line autofix", () => {
     `
 
     const linter = new Linter(Herb, [ActionViewStrictLocalsFirstLineRule])
-    const result = linter.autofix(input, { fileName: "_partial.html.erb" })
+    const result = linter.autofix(input, { fileName: "_partial.html.erb", framework: "actionview" })
 
     expect(result.source).toContain("<%# locals: (user:) %>")
     expect(result.source).toMatch(/^<%# locals: \(user:\) %>/)
@@ -66,7 +66,7 @@ describe("actionview-strict-locals-first-line autofix", () => {
     `
 
     const linter = new Linter(Herb, [ActionViewStrictLocalsFirstLineRule])
-    const result = linter.autofix(input, { fileName: "_partial.html.erb" })
+    const result = linter.autofix(input, { fileName: "_partial.html.erb", framework: "actionview" })
 
     expect(result.source).toBe(input)
     expect(result.fixed).toHaveLength(0)
@@ -89,7 +89,7 @@ describe("actionview-strict-locals-first-line autofix", () => {
     `
 
     const linter = new Linter(Herb, [ActionViewStrictLocalsFirstLineRule])
-    const result = linter.autofix(input, { fileName: "_partial.html.erb" })
+    const result = linter.autofix(input, { fileName: "_partial.html.erb", framework: "actionview" })
 
     expect(result.source).toBe(expected)
     expect(result.fixed).toHaveLength(1)
@@ -104,7 +104,7 @@ describe("actionview-strict-locals-first-line autofix", () => {
     `
 
     const linter = new Linter(Herb, [ActionViewStrictLocalsFirstLineRule])
-    const result = linter.autofix(input, { fileName: "_partial.html.erb" })
+    const result = linter.autofix(input, { fileName: "_partial.html.erb", framework: "actionview" })
 
     expect(result.source).toBe(input)
     expect(result.fixed).toHaveLength(0)
@@ -118,7 +118,7 @@ describe("actionview-strict-locals-first-line autofix", () => {
     `
 
     const linter = new Linter(Herb, [ActionViewStrictLocalsFirstLineRule])
-    const result = linter.autofix(input, { fileName: "show.html.erb" })
+    const result = linter.autofix(input, { fileName: "show.html.erb", framework: "actionview" })
 
     expect(result.source).toBe(input)
     expect(result.fixed).toHaveLength(0)

--- a/javascript/packages/linter/test/autofix/actionview-strict-locals-partial-only.autofix.test.ts
+++ b/javascript/packages/linter/test/autofix/actionview-strict-locals-partial-only.autofix.test.ts
@@ -18,7 +18,7 @@ describe("actionview-strict-locals-partial-only autofix", () => {
     const expected = `<div><%= user.name %></div>`
 
     const linter = new Linter(Herb, [ActionViewStrictLocalsPartialOnlyRule])
-    const result = linter.autofix(input, { fileName: "show.html.erb" }, undefined, { includeUnsafe: true })
+    const result = linter.autofix(input, { fileName: "show.html.erb", framework: "actionview" }, undefined, { includeUnsafe: true })
 
     expect(result.source).toBe(expected)
     expect(result.fixed).toHaveLength(1)
@@ -33,7 +33,7 @@ describe("actionview-strict-locals-partial-only autofix", () => {
     `
 
     const linter = new Linter(Herb, [ActionViewStrictLocalsPartialOnlyRule])
-    const result = linter.autofix(input, { fileName: "show.html.erb" })
+    const result = linter.autofix(input, { fileName: "show.html.erb", framework: "actionview" })
 
     expect(result.source).toBe(input)
     expect(result.fixed).toHaveLength(0)
@@ -48,7 +48,7 @@ describe("actionview-strict-locals-partial-only autofix", () => {
     `
 
     const linter = new Linter(Herb, [ActionViewStrictLocalsPartialOnlyRule])
-    const result = linter.autofix(input, { fileName: "_partial.html.erb" }, undefined, { includeUnsafe: true })
+    const result = linter.autofix(input, { fileName: "_partial.html.erb", framework: "actionview" }, undefined, { includeUnsafe: true })
 
     expect(result.source).toBe(input)
     expect(result.fixed).toHaveLength(0)
@@ -70,7 +70,7 @@ describe("actionview-strict-locals-partial-only autofix", () => {
     `
 
     const linter = new Linter(Herb, [ActionViewStrictLocalsPartialOnlyRule])
-    const result = linter.autofix(input, { fileName: "application.html.erb" }, undefined, { includeUnsafe: true })
+    const result = linter.autofix(input, { fileName: "application.html.erb", framework: "actionview" }, undefined, { includeUnsafe: true })
 
     expect(result.source).toBe(expected)
     expect(result.fixed).toHaveLength(1)

--- a/javascript/packages/linter/test/autofix/erb-strict-locals-comment-syntax.autofix.test.ts
+++ b/javascript/packages/linter/test/autofix/erb-strict-locals-comment-syntax.autofix.test.ts
@@ -12,7 +12,7 @@ describe("erb-strict-locals-comment-syntax autofix", () => {
   const autofix = (input: string) => {
     const linter = new Linter(Herb, [ERBStrictLocalsCommentSyntaxRule])
 
-    return linter.autofix(input, { fileName: "_partial.html.erb" })
+    return linter.autofix(input, { fileName: "_partial.html.erb", framework: "actionview" })
   }
 
   const expectFix = (input: string, expected: string, count: number = 1) => {

--- a/javascript/packages/linter/test/autofix/erb-strict-locals-required.autofix.test.ts
+++ b/javascript/packages/linter/test/autofix/erb-strict-locals-required.autofix.test.ts
@@ -14,7 +14,7 @@ describe("erb-strict-locals-required autofix", () => {
     const input = '<div>Content</div>'
 
     const linter = new Linter(Herb, [ERBStrictLocalsRequiredRule])
-    const result = linter.autofix(input, { fileName: '_partial.html.erb' })
+    const result = linter.autofix(input, { fileName: '_partial.html.erb', framework: "actionview" })
 
     expect(result.source).toBe(input)
     expect(result.fixed).toHaveLength(0)
@@ -26,7 +26,7 @@ describe("erb-strict-locals-required autofix", () => {
     const expected = '<%# locals: (**) %>\n\n<div>Content</div>'
 
     const linter = new Linter(Herb, [ERBStrictLocalsRequiredRule])
-    const result = linter.autofix(input, { fileName: '_partial.html.erb' }, undefined, { includeUnsafe: true })
+    const result = linter.autofix(input, { fileName: '_partial.html.erb', framework: "actionview" }, undefined, { includeUnsafe: true })
 
     expect(result.source).toBe(expected)
     expect(result.fixed).toHaveLength(1)
@@ -40,7 +40,7 @@ describe("erb-strict-locals-required autofix", () => {
     `
 
     const linter = new Linter(Herb, [ERBStrictLocalsRequiredRule])
-    const result = linter.autofix(input, { fileName: '_partial.html.erb' }, undefined, { includeUnsafe: true })
+    const result = linter.autofix(input, { fileName: '_partial.html.erb', framework: "actionview" }, undefined, { includeUnsafe: true })
 
     expect(result.source).toBe(input)
     expect(result.fixed).toHaveLength(0)
@@ -51,7 +51,7 @@ describe("erb-strict-locals-required autofix", () => {
     const input = '<div>Content</div>'
 
     const linter = new Linter(Herb, [ERBStrictLocalsRequiredRule])
-    const result = linter.autofix(input, { fileName: 'show.html.erb' }, undefined, { includeUnsafe: true })
+    const result = linter.autofix(input, { fileName: 'show.html.erb', framework: "actionview" }, undefined, { includeUnsafe: true })
 
     expect(result.source).toBe(input)
     expect(result.fixed).toHaveLength(0)
@@ -69,7 +69,7 @@ describe("erb-strict-locals-required autofix", () => {
     const expected = `<%# locals: (**) %>\n\n${input}`
 
     const linter = new Linter(Herb, [ERBStrictLocalsRequiredRule])
-    const result = linter.autofix(input, { fileName: '_card.html.erb' }, undefined, { includeUnsafe: true })
+    const result = linter.autofix(input, { fileName: '_card.html.erb', framework: "actionview" }, undefined, { includeUnsafe: true })
 
     expect(result.source).toBe(expected)
     expect(result.fixed).toHaveLength(1)
@@ -84,7 +84,7 @@ describe("erb-strict-locals-required autofix", () => {
       { caller: "app/views/home/show.html.erb", locals: ["title", "footer"] },
     ])
 
-    const result = linter.autofix("<h1><%= title %></h1>", { fileName: partial, partialCallers: callers }, undefined, { includeUnsafe: true })
+    const result = linter.autofix("<h1><%= title %></h1>", { fileName: partial, framework: "actionview", partialCallers: callers }, undefined, { includeUnsafe: true })
 
     expect(result.source).toBe('<%# locals: (footer: nil, title: nil) %>\n\n<h1><%= title %></h1>')
   })
@@ -95,7 +95,7 @@ describe("erb-strict-locals-required autofix", () => {
 
     const callers = callerIndexWithLocals(partial, [{ caller: "app/views/posts/index.html.erb", locals: ["title"] }])
 
-    const result = linter.autofix("<h1><%= title %></h1><p><%= subtitle %></p>", { fileName: partial, partialCallers: callers }, undefined, { includeUnsafe: true })
+    const result = linter.autofix("<h1><%= title %></h1><p><%= subtitle %></p>", { fileName: partial, framework: "actionview", partialCallers: callers }, undefined, { includeUnsafe: true })
 
     expect(result.source).toContain("<%# locals: (subtitle: nil, title: nil) %>")
   })
@@ -107,7 +107,7 @@ describe("erb-strict-locals-required autofix", () => {
     const callers = callerIndexWithLocals(partial, [{ caller: "app/views/posts/index.html.erb", locals: [] }])
 
     const source = '<%= link_to "x", posts_path %><% if admin? %><span><%= title %></span><% end %>'
-    const result = linter.autofix(source, { fileName: partial, partialCallers: callers }, undefined, { includeUnsafe: true })
+    const result = linter.autofix(source, { fileName: partial, framework: "actionview", partialCallers: callers }, undefined, { includeUnsafe: true })
 
     expect(result.source).toContain("<%# locals: (title: nil) %>")
   })
@@ -119,7 +119,7 @@ describe("erb-strict-locals-required autofix", () => {
     const callers = callerIndexWithLocals(partial, [{ caller: "app/views/posts/index.html.erb", locals: [] }])
 
     const source = '<%= link_to button.title, button.path %><%= submit %>'
-    const result = linter.autofix(source, { fileName: partial, partialCallers: callers }, undefined, { includeUnsafe: true })
+    const result = linter.autofix(source, { fileName: partial, framework: "actionview", partialCallers: callers }, undefined, { includeUnsafe: true })
 
     expect(result.source).toContain("<%# locals: (button: nil, submit: nil) %>")
   })
@@ -131,7 +131,7 @@ describe("erb-strict-locals-required autofix", () => {
     const callers = callerIndexWithLocals(partial, [{ caller: "app/views/posts/index.html.erb", locals: [] }])
 
     const source = '<%= button_tag "Save" %><%= submit_tag "Go" %><span><%= title %></span>'
-    const result = linter.autofix(source, { fileName: partial, partialCallers: callers }, undefined, { includeUnsafe: true })
+    const result = linter.autofix(source, { fileName: partial, framework: "actionview", partialCallers: callers }, undefined, { includeUnsafe: true })
 
     expect(result.source).toContain("<%# locals: (title: nil) %>")
   })
@@ -143,7 +143,7 @@ describe("erb-strict-locals-required autofix", () => {
     const callers = callerIndexWithLocals(partial, [{ caller: "app/views/posts/index.html.erb", locals: ["posts"] }])
 
     const source = '<% posts.each do |post| %><span><%= post %></span><% end %>'
-    const result = linter.autofix(source, { fileName: partial, partialCallers: callers }, undefined, { includeUnsafe: true })
+    const result = linter.autofix(source, { fileName: partial, framework: "actionview", partialCallers: callers }, undefined, { includeUnsafe: true })
 
     expect(result.source).toContain("<%# locals: (posts: nil) %>")
   })
@@ -155,7 +155,7 @@ describe("erb-strict-locals-required autofix", () => {
     const callers = callerIndexWithLocals(partial, [{ caller: "app/views/posts/index.html.erb", locals: ["title"] }])
 
     const source = '<%= title %><%= local_assigns[:extra] %>'
-    const result = linter.autofix(source, { fileName: partial, partialCallers: callers }, undefined, { includeUnsafe: true })
+    const result = linter.autofix(source, { fileName: partial, framework: "actionview", partialCallers: callers }, undefined, { includeUnsafe: true })
 
     expect(result.source).toContain("<%# locals: (title: nil, **) %>")
   })
@@ -166,7 +166,7 @@ describe("erb-strict-locals-required autofix", () => {
 
     const callers = callerIndexWithLocals(partial, [{ caller: "app/views/posts/index.html.erb", locals: ["title"] }], 1)
 
-    const result = linter.autofix("<h1><%= title %></h1>", { fileName: partial, partialCallers: callers }, undefined, { includeUnsafe: true })
+    const result = linter.autofix("<h1><%= title %></h1>", { fileName: partial, framework: "actionview", partialCallers: callers }, undefined, { includeUnsafe: true })
 
     expect(result.source).toContain("<%# locals: (title: nil, **) %>")
   })

--- a/javascript/packages/linter/test/cli.test.ts
+++ b/javascript/packages/linter/test/cli.test.ts
@@ -92,7 +92,7 @@ describe("CLI Output Formatting", () => {
   })
 
   test("allows tag.attributes in attribute position", () => {
-    const { output, exitCode } = runLinter("tag-attributes.html.erb", "--no-wrap-lines")
+    const { output, exitCode } = runLinter("tag-attributes.html.erb", "--no-wrap-lines", "--config-file test/fixtures/actionview.herb.yml")
 
     expect(output).toMatchSnapshot()
     expect(output).not.toContain("erb-no-output-in-attribute-position")

--- a/javascript/packages/linter/test/fixtures/actionview.herb.yml
+++ b/javascript/packages/linter/test/fixtures/actionview.herb.yml
@@ -1,0 +1,4 @@
+# Used by tests that need the fixtures linted as an Action View project, since
+# the linter's own .herb.yml sets `framework: ruby` and the `actionview-*` rules
+# only run when the framework is Action View.
+framework: actionview

--- a/javascript/packages/linter/test/framework-scoped-rules.test.ts
+++ b/javascript/packages/linter/test/framework-scoped-rules.test.ts
@@ -1,0 +1,86 @@
+import { describe, test, expect, beforeAll } from "vitest"
+
+import { Herb } from "@herb-tools/node-wasm"
+import { Config } from "@herb-tools/config"
+
+import { Linter } from "../src/linter.js"
+import { rules } from "../src/rules.js"
+
+import { ActionViewNoSilentRenderRule } from "../src/rules/actionview-no-silent-render.js"
+
+const SILENT_RENDER = `<% render "shared/error" %>`
+
+function lint(context?: Record<string, any>, config?: Config) {
+  const linter = new Linter(Herb, [ActionViewNoSilentRenderRule], config)
+
+  return linter.lint(SILENT_RENDER, context).offenses
+}
+
+describe("framework-scoped rules", () => {
+  beforeAll(async () => {
+    await Herb.load()
+  })
+
+  const actionViewRules = rules.filter(ruleClass => ruleClass.ruleName.startsWith("actionview-"))
+
+  test("every actionview rule is scoped to Action View", () => {
+    expect(actionViewRules.length).toBeGreaterThan(0)
+
+    for (const ruleClass of actionViewRules) {
+      expect(
+        new ruleClass().defaultConfig?.frameworks,
+        `${ruleClass.ruleName} must declare 'frameworks: ["actionview"]' in its defaultConfig, otherwise it reports on projects that aren't on Action View`
+      ).toEqual(["actionview"])
+    }
+  })
+
+  test("reports when the framework is Action View", () => {
+    expect(lint({ framework: "actionview" })).toHaveLength(1)
+  })
+
+  test("stays quiet when no framework is configured", () => {
+    expect(lint()).toHaveLength(0)
+  })
+
+  test("stays quiet on another framework", () => {
+    expect(lint({ framework: "hanami" })).toHaveLength(0)
+  })
+
+  test("picks up the framework from the config when the context doesn't name one", () => {
+    const config = Config.fromObject({ framework: "actionview" })
+
+    expect(lint(undefined, config)).toHaveLength(1)
+  })
+
+  test("a rule that leaves frameworks open runs on every framework", () => {
+    const linter = new Linter(Herb)
+
+    expect(linter.lint(`<DIV></DIV>`, { framework: "hanami" }).offenses.some(offense => offense.rule === "html-tag-name-lowercase")).toBe(true)
+  })
+
+  test("runs anyway when the rule was asked for by name", () => {
+    const linter = Linter.from(Herb, undefined, undefined, { only: ["actionview-no-silent-render"] })
+
+    expect(linter.lint(SILENT_RENDER).offenses).toHaveLength(1)
+  })
+
+  test("runs anyway under --all-rules", () => {
+    const linter = Linter.from(Herb, undefined, undefined, { all: true })
+
+    expect(linter.lint(SILENT_RENDER).offenses.some(offense => offense.rule === "actionview-no-silent-render")).toBe(true)
+  })
+
+  test("frameworks can be widened from the config", () => {
+    const config = Config.fromObject({
+      linter: {
+        rules: {
+          "actionview-no-silent-render": {
+            frameworks: ["ruby", "actionview"]
+          }
+        }
+      }
+    })
+
+    expect(lint({ framework: "ruby" }, config)).toHaveLength(1)
+  })
+})

--- a/javascript/packages/linter/test/helpers/linter-test-helper.ts
+++ b/javascript/packages/linter/test/helpers/linter-test-helper.ts
@@ -79,6 +79,16 @@ export function createLinterTest(rules: RuleClass | RuleClass[], configOverride?
   const ruleParserOptions = ruleInstance instanceof ParserRule ? ruleInstance.parserOptions : {}
   const parseCache = new ParseCache(Herb)
   const ruleConfigOverride = configOverride
+  const declaredFrameworks = ruleInstance.defaultConfig?.frameworks
+  const defaultFramework = declaredFrameworks?.[0]
+
+  const resolveContext = (options?: any | TestOptions) => {
+    const context = options?.context ?? options
+
+    if (defaultFramework === undefined) return context
+
+    return { framework: defaultFramework, ...context }
+  }
 
   beforeAll(async () => {
     await Herb.load()
@@ -111,7 +121,7 @@ export function createLinterTest(rules: RuleClass | RuleClass[], configOverride?
 
     hasAsserted = true
 
-    const context = options?.context ?? options
+    const context = resolveContext(options)
     const allowInvalidSyntax = options?.allowInvalidSyntax ?? false
 
     if (!isParserNoErrorsRule) {
@@ -198,7 +208,7 @@ export function createLinterTest(rules: RuleClass | RuleClass[], configOverride?
 
     hasAsserted = true
 
-    const context = options?.context ?? options
+    const context = resolveContext(options)
     const allowInvalidSyntax = options?.allowInvalidSyntax ?? false
 
     if (!isParserNoErrorsRule) {

--- a/javascript/packages/linter/test/rules/actionview-no-strict-locals-error.test.ts
+++ b/javascript/packages/linter/test/rules/actionview-no-strict-locals-error.test.ts
@@ -235,7 +235,7 @@ describe("actionview-no-strict-locals-error", () => {
       ["users/plain", declaration("app/views/users/_plain.html.erb", [{ name: "user", required: true }])],
     ]))
 
-    const locatedContext = { fileName: "app/views/posts/index.html.erb", partials: located }
+    const locatedContext = { fileName: "app/views/posts/index.html.erb", framework: "actionview" as const, partials: located }
 
     beforeAll(async () => {
       await Herb.load()

--- a/javascript/packages/linter/test/rules/actionview-prefer-link-to-helper.test.ts
+++ b/javascript/packages/linter/test/rules/actionview-prefer-link-to-helper.test.ts
@@ -33,7 +33,11 @@ describe("actionview-prefer-link-to-helper", () => {
   })
 
   test("passes when the framework is not Action View", () => {
-    expectNoOffenses('<a href="<%= dashboard_path %>">Dashboard</a>')
+    expectNoOffenses('<a href="<%= dashboard_path %>">Dashboard</a>', { framework: "ruby" })
+  })
+
+  test("passes when no framework is configured", () => {
+    expectNoOffenses('<a href="<%= dashboard_path %>">Dashboard</a>', { framework: undefined })
   })
 
   test("passes for an href that holds more than the expression", () => {

--- a/javascript/packages/linter/test/rules/erb-prefer-image-tag-helper.test.ts
+++ b/javascript/packages/linter/test/rules/erb-prefer-image-tag-helper.test.ts
@@ -158,7 +158,7 @@ describe("erb-prefer-image-tag-helper", () => {
     })
 
     test("passes for img with ERB expression when no framework is configured", () => {
-      expectNoOffenses('<img src="<%= image_path("logo.png") %>" alt="Logo">')
+      expectNoOffenses('<img src="<%= image_path("logo.png") %>" alt="Logo">', { framework: undefined })
     })
   })
 })

--- a/javascript/packages/linter/test/rules/erb-strict-locals-required.test.ts
+++ b/javascript/packages/linter/test/rules/erb-strict-locals-required.test.ts
@@ -117,7 +117,7 @@ describe("ERBStrictLocalsRequiredRule", () => {
       `
 
       const linter = new Linter(Herb, [ERBStrictLocalsRequiredRule], config)
-      const result = linter.lint(html, { fileName: "_user_card.html.erb" })
+      const result = linter.lint(html, { fileName: "_user_card.html.erb", framework: "actionview" })
 
       expect(result.offenses).toHaveLength(1)
 
@@ -131,7 +131,7 @@ describe("ERBStrictLocalsRequiredRule", () => {
 
     test("points at the first line for a single-line partial", () => {
       const linter = new Linter(Herb, [ERBStrictLocalsRequiredRule], config)
-      const result = linter.lint(`<%= user.name %>`, { fileName: "_user.html.erb" })
+      const result = linter.lint(`<%= user.name %>`, { fileName: "_user.html.erb", framework: "actionview" })
 
       expect(result.offenses).toHaveLength(1)
 

--- a/rust/herb-config/src/config_schema.rs
+++ b/rust/herb-config/src/config_schema.rs
@@ -15,13 +15,16 @@ pub struct FilesConfig {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[serde(rename_all = "camelCase")]
 pub struct RuleConfig {
   #[serde(default, skip_serializing_if = "Option::is_none")]
   pub enabled: Option<bool>,
 
   #[serde(default, skip_serializing_if = "Option::is_none")]
   pub severity: Option<SeverityConfig>,
+
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub frameworks: Option<Vec<Framework>>,
 
   #[serde(default, skip_serializing_if = "Option::is_none")]
   pub auto_correct: Option<bool>,

--- a/rust/herb-config/tests/config_test.rs
+++ b/rust/herb-config/tests/config_test.rs
@@ -1,7 +1,7 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use herb_config::{Config, HerbConfig, HerbConfigOptions, IndentStyle, LinterMode, Severity, SeverityConfig, SeverityOverridable, Tool};
+use herb_config::{Config, Framework, HerbConfig, HerbConfigOptions, IndentStyle, LinterMode, Severity, SeverityConfig, SeverityOverridable, Tool};
 
 fn default_include_patterns() -> Vec<String> {
   Config::get_default_file_patterns()
@@ -213,6 +213,15 @@ mod config_from_object {
     let config = Config::from_object(&HerbConfigOptions::default(), Path::new("/project"), Some("1.2.3"), None).unwrap();
 
     assert_eq!(config.version(), "1.2.3");
+  }
+
+  #[test]
+  fn creates_config_with_rule_frameworks() {
+    let config = config_from_yaml("linter:\n  rules:\n    actionview-no-silent-render:\n      frameworks:\n        - ruby\n        - actionview\n");
+
+    let rule = config.get_rule_config("actionview-no-silent-render").unwrap();
+
+    assert_eq!(rule.frameworks, Some(vec![Framework::Ruby, Framework::ActionView]));
   }
 }
 

--- a/rust/herb-config/tests/load_test.rs
+++ b/rust/herb-config/tests/load_test.rs
@@ -96,6 +96,21 @@ engine:
 }
 
 #[test]
+fn load_accepts_rule_options_it_does_not_know_about() {
+  let dir = tempfile::tempdir().unwrap();
+
+  fs::write(
+    dir.path().join(".herb.yml"),
+    "version: 0.10.3\nlinter:\n  rules:\n    html-tag-name-lowercase:\n      enabled: false\n      notARealRuleOption: true\n",
+  )
+  .unwrap();
+
+  let config = Config::load(dir.path(), None).unwrap();
+
+  assert_eq!(config.get_rule_config("html-tag-name-lowercase").unwrap().enabled, Some(false));
+}
+
+#[test]
 fn load_accepts_an_empty_engine_section() {
   let dir = tempfile::tempdir().unwrap();
 


### PR DESCRIPTION
This pull request updates the `actionview-*` linter rules so they only run when the project says it renders through Action View, and adds the `frameworks` rule option that expresses it. Until now every `actionview-*` rule reported on any template it was pointed at. The `framework` option has been in `.herb.yml` since v0.10.0, but only two rules in the whole linter consulted it.

Rules now declare the frameworks they apply to in their own `defaultConfig`:

```ts
get defaultConfig(): FullRuleConfig {
  return {
    enabled: true,
    severity: "error",
    frameworks: ["actionview"],
  }
}
```

An unset `framework` resolves to `ruby`, the fallback Herb already documents, so the Action View rules stay quiet until a project opts in:

```yaml
framework: actionview
```

`--only` and `--all-rules` ignore the gate, the same way they already ignore the per-rule path filters. Naming a rule on the command line is answer enough about whether it should run, and without the bypass `herb-lint --only actionview-no-strict-locals-error` would silently report nothing.

Resolves https://github.com/marcoroth/herb/issues/480
Resolves https://github.com/marcoroth/herb/issues/1808