### PR TITLE
Rust: Upgrade rubydex to v0.3.0

### DIFF
--- a/rust/herb-analysis/Cargo.toml
+++ b/rust/herb-analysis/Cargo.toml
@@ -25,7 +25,7 @@ cli = ["dep:colored"]
 colored = { version = "3", optional = true }
 herb = { path = ".." }
 herb-config = { path = "../herb-config" }
-rubydex = "=0.2.5"
+rubydex = { git = "https://github.com/Shopify/rubydex", tag = "v0.3.0" }
 
 [dev-dependencies]
 insta = "1.40"

--- a/rust/herb-analysis/src/analysis.rs
+++ b/rust/herb-analysis/src/analysis.rs
@@ -1,5 +1,4 @@
 use std::collections::{BTreeMap, BTreeSet, HashSet};
-use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
 use rubydex::indexing::{self, IndexerBackend, LanguageId};
@@ -57,7 +56,7 @@ impl Analysis {
     }
   }
 
-  pub fn index_paths(paths: &[String], excluded: &HashSet<PathBuf>) -> Self {
+  pub fn index_paths(paths: &[String], excluded: &HashSet<Box<str>>) -> Self {
     let mut graph = Graph::new();
     let mut timings = Vec::new();
     let mut index_errors = Vec::new();

--- a/rust/herb-analysis/src/ruby_render_references.rs
+++ b/rust/herb-analysis/src/ruby_render_references.rs
@@ -1,6 +1,6 @@
 use std::collections::{BTreeSet, HashSet};
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use herb::herb::{parse_with_options, ParserOptions};
 use herb::prism::PrismNode;
@@ -44,7 +44,7 @@ pub fn collect(project_path: &Path) -> RubyRenderReferences {
     return RubyRenderReferences::default();
   }
 
-  let excluded: HashSet<PathBuf> = HashSet::new();
+  let excluded: HashSet<Box<str>> = HashSet::new();
   let (files, _) = listing::collect_file_paths(roots, &excluded);
 
   let mut references = RubyRenderReferences::default();


### PR DESCRIPTION
This pull request upgrades rubydex from `v0.2.5` to `v0.3.0`, which fixes a panic that made every rubydex-backed subcommand unusable on some Rails applications.

Running any rubydex-backed command against a large application could abort the whole process:

```
thread 'main' panicked at rubydex-0.2.5/src/resolution.rs:381:42:
SelfReceiver definition should have a declaration
```

`handle_remaining_definitions` assumed a `SelfReceiver` always maps to a declaration and called `.expect()` on the lookup. When it didn't, `Analysis::resolve` unwound and took `actionview check`, `helpers`, and `stats` down with it. Nothing degraded, the command simply died.

The trigger is ordinary code. Three ingredients are needed, and all three are common:

`report.rb`: superclass not defined in the indexed set
```ruby
class Report < ApplicationRecord  
end
```

`report/entry.rb`
```ruby
class Report::Entry < ApplicationRecord
end
```

`report/entry/store/client.rb` compact name, Store namespace never defined + class-level ivar written inside `def self.`
```ruby
class Report::Entry::Store::Client  
  def self.client
    @client ||= 1                
  end
end
```
