### PR TITLE
Engine: Single-pass `optimize_tokens`

### DIFF
--- a/lib/herb/engine/compiler.rb
+++ b/lib/herb/engine/compiler.rb
@@ -476,13 +476,6 @@ module Herb
         current_text = nil #: String?
         current_context = nil
 
-        # Single pass over the raw token stream. Whitespace tokens are resolved
-        # against their neighbours in the ORIGINAL stream (dropped, or turned
-        # into text) and consecutive text is merged into one buffer inline. This
-        # replaces the former two-pass approach (compact_whitespace_tokens built
-        # a whole intermediate array via map.with_index + compact, which this
-        # loop then re-scanned), saving an array allocation and a full pass per
-        # template.
         tokens.each_with_index do |token, index|
           type = token[0]
 
@@ -490,7 +483,6 @@ module Herb
             next if adjacent_whitespace?(tokens, index)
             next if whitespace_before_code_sequence?(tokens, index)
 
-            # Surviving whitespace becomes plain text and joins the text run.
             type = :text
           end
 
@@ -498,14 +490,9 @@ module Herb
             value = token[1]
 
             if current_text
-              # Mutate a single buffer instead of `current_text += value`, which
-              # reallocated and copied the whole accumulated string on every
-              # text token (quadratic for long runs of adjacent text).
               current_text << value
               current_context ||= token[2]
             else
-              # Start a fresh buffer; dup so we never mutate the token's own
-              # (possibly frozen) value string.
               current_text = value.dup
               current_context = token[2]
             end

--- a/lib/herb/engine/compiler.rb
+++ b/lib/herb/engine/compiler.rb
@@ -472,44 +472,58 @@ module Herb
       def optimize_tokens(tokens)
         return tokens if tokens.empty?
 
-        compacted = compact_whitespace_tokens(tokens)
-
         optimized = [] #: Array[untyped]
-        current_text = ""
+        current_text = nil #: String?
         current_context = nil
 
-        compacted.each do |type, value, context, escaped|
+        # Single pass over the raw token stream. Whitespace tokens are resolved
+        # against their neighbours in the ORIGINAL stream (dropped, or turned
+        # into text) and consecutive text is merged into one buffer inline. This
+        # replaces the former two-pass approach (compact_whitespace_tokens built
+        # a whole intermediate array via map.with_index + compact, which this
+        # loop then re-scanned), saving an array allocation and a full pass per
+        # template.
+        tokens.each_with_index do |token, index|
+          type = token[0]
+
+          if type == :whitespace
+            next if adjacent_whitespace?(tokens, index)
+            next if whitespace_before_code_sequence?(tokens, index)
+
+            # Surviving whitespace becomes plain text and joins the text run.
+            type = :text
+          end
+
           if type == :text
-            current_text += value
-            current_context ||= context
+            value = token[1]
+
+            if current_text
+              # Mutate a single buffer instead of `current_text += value`, which
+              # reallocated and copied the whole accumulated string on every
+              # text token (quadratic for long runs of adjacent text).
+              current_text << value
+              current_context ||= token[2]
+            else
+              # Start a fresh buffer; dup so we never mutate the token's own
+              # (possibly frozen) value string.
+              current_text = value.dup
+              current_context = token[2]
+            end
           else
-            unless current_text.empty?
+            if current_text
               optimized << [:text, current_text, current_context]
 
-              current_text = ""
+              current_text = nil
               current_context = nil
             end
 
-            optimized << [type, value, context, escaped]
+            optimized << [type, token[1], token[2], token[3]]
           end
         end
 
-        optimized << [:text, current_text, current_context] unless current_text.empty?
+        optimized << [:text, current_text, current_context] if current_text
 
         optimized
-      end
-
-      def compact_whitespace_tokens(tokens)
-        return tokens if tokens.empty?
-
-        tokens.map.with_index { |token, index|
-          next token unless token[0] == :whitespace
-
-          next nil if adjacent_whitespace?(tokens, index)
-          next nil if whitespace_before_code_sequence?(tokens, index)
-
-          [:text, token[1], token[2]]
-        }.compact
       end
 
       def adjacent_whitespace?(tokens, index)

--- a/sig/herb/engine/compiler.rbs
+++ b/sig/herb/engine/compiler.rbs
@@ -130,8 +130,6 @@ module Herb
 
       def optimize_tokens: (untyped tokens) -> untyped
 
-      def compact_whitespace_tokens: (untyped tokens) -> untyped
-
       def adjacent_whitespace?: (untyped tokens, untyped index) -> untyped
 
       def trailing_whitespace?: (untyped token) -> untyped


### PR DESCRIPTION
### Summary

Collapses the two-pass whitespace/text optimization in `Herb::Engine::Compiler#optimize_tokens` into a single pass over the raw token stream.

Previously `optimize_tokens` did two passes:

1. `compact_whitespace_tokens` built a whole intermediate array (`tokens.map.with_index { ... }.compact`), dropping/relabeling whitespace tokens.
2. `optimize_tokens` re-scanned that array to merge consecutive text tokens, accumulating with `current_text += value`.

This PR folds both into one pass: whitespace tokens are resolved against their neighbours in the *original* stream (dropped, or turned into text) and consecutive text is merged inline. `compact_whitespace_tokens` is removed.

`optimize_tokens` runs once per template compile, so this is on the hot path for any large `ActionView`/ReActionView precompile.

### Implementation notes

- No intermediate array: the `map.with_index + compact` allocation is gone; the surviving whitespace-vs-neighbour checks (`adjacent_whitespace?`, `whitespace_before_code_sequence?`) run against the original `tokens`/`index`, exactly as before.
- Text is accumulated into a single buffer that is mutated with `current_text << value` instead of `current_text += value`, which reallocated and copied the whole accumulated string on every text token.
- The buffer is seeded with `value.dup` so a (possibly frozen) token value is never mutated in place.

### Benchmark

Measured end-to-end through `ViewPrecompiler.precompile` over the github/github monolith template corpus (**6,302 templates**), ReActionView ON (Herb path), Ruby 4.0.5.

Both sides were run against the **same Herb `main` native extension** — only `lib/herb/engine/compiler.rb` differs between them — so the delta isolates this change. 2 boots × 5 timed iterations each.

| Config | Time (median) | Time (min) | Allocated objects (median) |
|---|---|---|---|
| `main` baseline | 19.618s / 19.396s | 19.050s / 19.107s | ~32,044,000 |
| this PR | 18.967s / 19.175s | 18.838s / 18.823s | ~30,988,000 |
| **delta** | ~−1 to −3% | ~−1.2% | **−1,056,000 (−3.3%)** |

The stable, reproducible win is **~1.06M fewer allocated objects per full precompile (−3.3%)**. Wall-clock is consistently favorable but smaller and noisier (~1–3%).

_Benchmark run by Claude Opus 4.8 (GitHub Copilot), acting on behalf of @joelhawksley._

### Correctness

Output is behavior-preserving — the full Herb engine test suite passes unchanged (**1,139 runs, 3,811 assertions, 0 failures, 0 errors**), RuboCop is clean, and `sig/herb/engine/compiler.rbs` is regenerated via `rbs-inline`.

---

Split out of #1872.
