### PR TITLE
Engine: Use `String#match?` for boolean-context regexp guards in the compiler

### DIFF
--- a/lib/herb/engine/compiler.rb
+++ b/lib/herb/engine/compiler.rb
@@ -522,11 +522,11 @@ module Herb
       def trailing_whitespace?(token)
         return false unless token
 
-        token[0] == :whitespace || (token[0] == :text && token[1] =~ /\s\z/)
+        token[0] == :whitespace || (token[0] == :text && token[1].match?(/\s\z/))
       end
 
       def leading_whitespace?(token)
-        token && token[0] == :text && token[1] =~ /\A\s/
+        token && token[0] == :text && token[1].match?(/\A\s/)
       end
 
       def whitespace_before_code_sequence?(tokens, current_index)
@@ -592,7 +592,7 @@ module Herb
         last_value = @tokens.last[1]
 
         if last_type == :text
-          last_value.empty? || last_value.end_with?("\n") || (last_value =~ WHITESPACE_ONLY && preceding_token_ends_with_newline?) || last_value =~ TRAILING_INDENTATION
+          last_value.empty? || last_value.end_with?("\n") || (last_value.match?(WHITESPACE_ONLY) && preceding_token_ends_with_newline?) || last_value.match?(TRAILING_INDENTATION)
         elsif EXPRESSION_TOKEN_TYPES.include?(last_type)
           @last_trim_consumed_newline
         else


### PR DESCRIPTION
## What

Switch three boolean-context regexp guards in `Engine::Compiler` from `=~` to
`String#match?`:

- `trailing_whitespace?` — `token[1] =~ /\s\z/`
- `leading_whitespace?` — `token[1] =~ /\A\s/`
- `at_line_start?` — `last_value =~ WHITESPACE_ONLY` and
  `last_value =~ TRAILING_INDENTATION`

## Why

These match a token value against a regexp purely for a truthy/falsy result, but
`=~` allocates a `MatchData` and assigns `$~` on every call. They run in hot
paths while scanning and optimizing the token stream, so `String#match?` returns
the same boolean without allocating.

The `=~` sites that actually consume `Regexp.last_match` (e.g.
`extract_leading_space`) are intentionally left as-is.

## Benchmark

Compiling a large real-world `.erb` view corpus (~6,000 templates, from the
github.com monolith) with `Herb::Engine` on Ruby 4.0.5: about **−0.7%**
(−152,875) total objects allocated per full-corpus compile. Small but free.

Full test suite passes (`2386 runs, 5462 assertions, 0 failures, 0 errors`).
