### PR TITLE
Engine: Let a subclass choose which compiler walks the AST

### DIFF
--- a/lib/herb/engine.rb
+++ b/lib/herb/engine.rb
@@ -98,7 +98,7 @@ module Herb
 
         report(input)
 
-        compiler = Compiler.new(self, properties)
+        compiler = compiler_class.new(self, properties)
 
         parse_result.value.accept(compiler)
 
@@ -167,6 +167,11 @@ module Herb
     end
 
     protected
+
+    #: () -> untyped
+    def compiler_class
+      Compiler
+    end
 
     def add_text(text)
       return if text.empty?

--- a/sig/herb/engine.rbs
+++ b/sig/herb/engine.rbs
@@ -37,6 +37,9 @@ module Herb
 
     def self.heredoc?: (untyped code) -> untyped
 
+    # : () -> untyped
+    def compiler_class: () -> untyped
+
     def add_text: (untyped text) -> untyped
 
     def add_code: (untyped code) -> untyped

--- a/test/engine/compiler_class_test.rb
+++ b/test/engine/compiler_class_test.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+require_relative "../../lib/herb/engine"
+
+module Engine
+  class CompilerClassTest < Minitest::Spec
+    class TextlessCompiler < Herb::Engine::Compiler
+      private
+
+      def add_text(text); end
+    end
+
+    class TextlessEngine < Herb::Engine
+      def compiler_class
+        TextlessCompiler
+      end
+    end
+
+    class CountingEngine < Herb::Engine
+      def self.asked
+        @asked ||= 0
+      end
+
+      class << self
+        attr_writer :asked
+      end
+
+      def compiler_class
+        self.class.asked += 1
+
+        super
+      end
+    end
+
+    describe "which compiler walks the AST" do
+      test "the engine's own one by default" do
+        assert_equal Herb::Engine.new("<p>hello</p>").src, %(_buf = ::String.new; _buf << '<p>hello</p>'.freeze;\n_buf.to_s\n)
+      end
+
+      test "asks for it rather than naming it" do
+        CountingEngine.asked = 0
+        CountingEngine.new("<p>hello</p>")
+
+        assert_equal 1, CountingEngine.asked
+      end
+
+      test "the one a subclass names" do
+        assert_equal TextlessEngine.new("<p>hello</p>").src, %(_buf = ::String.new;\n_buf.to_s\n)
+      end
+
+      test "the replacement drives the whole walk, not only the part it changed" do
+        assert_equal TextlessEngine.new("<p><%= @title %></p>").src, %(_buf = ::String.new; _buf << (@title).to_s;\n_buf.to_s\n)
+      end
+
+      test "leaves the engine's own compiler alone for everything else" do
+        TextlessEngine.new("<p>hello</p>")
+
+        assert_equal Herb::Engine.new("<p>hello</p>").src, %(_buf = ::String.new; _buf << '<p>hello</p>'.freeze;\n_buf.to_s\n)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This pull request extracts the compiler `Herb::Engine` walks the AST with into a `compiler_class` method, so a subclass can replace it without reimplementing the walk.

```diff
- compiler = Compiler.new(self, properties)
+ compiler = compiler_class.new(self, properties)
```

A subclass now answers with its own:

```ruby
class TextlessEngine < Herb::Engine
  def compiler_class
    TextlessCompiler
  end
end
```