### PR TITLE
Engine: Introduce `DynamicsCompiler` to compile only dynamic values

### DIFF
--- a/lib/herb/engine/dynamics_compiler.rb
+++ b/lib/herb/engine/dynamics_compiler.rb
@@ -15,7 +15,7 @@ module Herb
     #
     #     source = Herb::Engine::DynamicsCompiler.new(%(<h1><%= @title %></h1>)).src
     #     view.instance_eval(source)
-    #     #=> ["Hello"]
+    #     #=> { 0 => "Hello" }
     #
     # The names follow Phoenix LiveView, which splits a rendered template into its `static` strings
     # and its `dynamic` values for the same reason. A template's statics never change between
@@ -24,28 +24,42 @@ module Herb
     # This is a separate compiler rather than an option on `Herb::Engine` because that class is a
     # drop-in for `Erubi::Engine` and has to keep answering the way Erubi does.
     #
-    # ## One entry per tag, at a fixed index
+    # ## The shape follows the template, not the render
     #
-    # Every `<%= %>` in the template owns an index, decided while compiling and the same on every
-    # render. Control flow contributes no entries of its own, so the length of the result is a fact
-    # about the template rather than about the render:
+    # Every insertion point owns an index, decided while compiling and the same on every render.
+    # Control flow owns one too, because what it decided is itself a value that changes:
     #
     #     <% if admin? %><%= secret %><% else %><%= public %><% end %>
-    #     #=> ["s", nil]   when admin?
-    #     #=> [nil, "p"]   otherwise
+    #     #=> { 0 => { branch: 0, slots: { 1 => "s" } } }   when admin?
+    #     #=> { 0 => { branch: 1, slots: { 2 => "p" } } }   otherwise
     #
-    # A branch that did not run leaves its tags `nil`. Both branches keep their own indices, so a
-    # condition flipping changes which entries are filled and never what the entries mean.
+    # Both branches keep their own indices, so a condition flipping changes which indices are
+    # present and never what an index means.
     #
-    # ## Loops are the exception
+    # ## Absent means it did not run
     #
-    # A tag inside a loop runs once per iteration, and how many iterations there are is only known
-    # at render time. Its entry is therefore a list rather than a value:
+    # A key is missing when the code that would have filled it never ran, which is the same thing
+    # the rendered markup says by not being there. Nothing has to be sent about a branch that was
+    # not taken, and nothing can be learned about one either.
     #
-    #     <% names.each do |name| %><h1><%= name %></h1><% end %>
-    #     #=> [["Marco", "Joe"]]
+    # A conditional and a collection are always present, because both are evaluated on every render
+    # even when they produce nothing. A conditional that matched no branch is `{ branch: nil }` and
+    # an empty collection is `{ rows: {} }`, both of which the client has to be told.
     #
-    # The index still belongs to the tag. Only its shape depends on the render.
+    # ## Collections group by row
+    #
+    # A collection holds its rows in render order, each row carrying the slots inside it:
+    #
+    #     <% users.each do |user| %><%= user.first %> <%= user.last %><% end %>
+    #     #=> { 0 => { rows: { 1 => { 1 => "Marco", 2 => "Roth" },
+    #                          2 => { 1 => "Joe",   2 => "Doe" } } } }
+    #
+    # Grouping the other way would give one list per slot and leave the client to zip them back
+    # together, which it cannot do once a row is inserted rather than appended.
+    #
+    # Rows are keyed by their position for now. Taking the key the template declares, through
+    # `herb-key` or `id` or a `<%# herb:key %>` directive, is what makes a row survive being
+    # reordered, and it belongs to `SlotVisitor` rather than here.
     #
     # ## Escaping
     #
@@ -61,65 +75,150 @@ module Herb
     class DynamicsCompiler < Herb::Engine
       BUFFER = "__herb_dynamics" #: String
       BLOCK_BUFFER = "__herb_block" #: String
+      SLOT_BUFFER = "__herb_slot" #: String
+      SCOPE_BUFFER = "__herb_scope" #: String
+      ROWS_BUFFER = "__herb_rows" #: String
+      KEY_BUFFER = "__herb_key" #: String
 
-      # Records, while walking, which tag each expression belongs to and whether that tag sits
-      # inside a loop. Both are decided by where the tag is written, so both are known here and
-      # neither can be worked out from the token stream alone.
+      BRANCHING_NODES = [
+        "AST_ERB_IF_NODE",
+        "AST_ERB_UNLESS_NODE",
+        "AST_ERB_ELSE_NODE",
+        "AST_ERB_WHEN_NODE",
+        "AST_ERB_IN_NODE"
+      ].freeze #: Array[String]
+
       class Compiler < Herb::Engine::Compiler
         #: (untyped, ?Hash[Symbol, untyped]) -> void
         def initialize(engine, options = {})
           super
 
-          @loop_depth = 0
+          @slots = 0
+          @block_depth = 0
+
+          branch_counts = {} #: Hash[Integer, Integer]
+          branch_owner = {} #: Hash[untyped, Integer]
+
+          @branch_counts = branch_counts
+          @branch_owner = branch_owner.compare_by_identity
+        end
+
+        #: (untyped) { () -> void } -> void
+        def visit_erb_control_node(node, &block)
+          return super unless block
+          return super unless branch?(node)
+
+          index = @branch_owner[node]
+
+          branched = lambda do
+            @tokens << [:scope, "", nil, [:branch, index, next_branch(index)]]
+
+            block.call
+          end
+
+          super(node, &branched)
+        end
+
+        #: (untyped) -> void
+        def visit_erb_if_node(node)
+          conditional(node) { super }
+        end
+
+        #: (untyped) -> void
+        def visit_erb_unless_node(node)
+          conditional(node) { super }
+        end
+
+        #: (untyped) -> void
+        def visit_erb_case_node(node)
+          conditional(node) { super }
+        end
+
+        #: (untyped) -> void
+        def visit_erb_case_match_node(node)
+          conditional(node) { super }
         end
 
         #: (untyped) -> void
         def visit_erb_iteration_block_node(node)
-          within_loop { super }
+          return visit_erb_block_node(node) if output_block?(node)
+
+          collection do |index|
+            visit_erb_control_node(node) do
+              row(index) do
+                visit_all(node.body)
+
+                visit(node.rescue_clause)
+                visit(node.else_clause)
+                visit(node.ensure_clause)
+              end
+
+              visit(node.end_node)
+            end
+          end
         end
 
         #: (untyped) -> void
         def visit_erb_for_node(node)
-          within_loop { super }
+          iteration(node, :statements)
         end
 
         #: (untyped) -> void
         def visit_erb_while_node(node)
-          within_loop { super }
+          iteration(node, :statements)
         end
 
         #: (untyped) -> void
         def visit_erb_until_node(node)
-          within_loop { super }
+          iteration(node, :statements)
         end
 
-        # Dynamics are a token type the base compiler does not know, so the dispatch is repeated
-        # here rather than inherited. Everything else is handed over unchanged.
+        #: (untyped) -> void
+        def visit_erb_block_node(node)
+          return super unless output_block?(node)
+
+          opening = node.tag_opening.value
+
+          check_for_escaped_erb_tag!(opening)
+
+          should_escape = should_escape_output?(opening)
+          index = claim
+
+          @tokens << [
+            should_escape ? :expr_block_escaped : :expr_block,
+            node.content.value.strip,
+            current_context,
+            index
+          ]
+
+          @last_trim_consumed_newline = false
+          @trim_next_whitespace = true if right_trim?(node)
+
+          @block_depth += 1
+
+          begin
+            visit_all(node.body)
+          ensure
+            @block_depth -= 1
+          end
+
+          visit_erb_block_end_node(node.end_node, escaped: should_escape)
+        end
+
         #: () -> void
         def generate_output
-          index = 0
-          depth = 0
-
           optimize_tokens(@tokens).each do |type, value, context, extra|
             case type
             when :text then @engine.send(:add_text, value)
             when :code then @engine.send(:add_code, value)
+            when :scope then @engine.send(:add_scope, *extra)
             when :dynamic
-              escaped, in_loop = extra
+              index, escaped = extra
 
-              @engine.send(:add_dynamic, value, context, index, in_loop, escaped)
-
-              # A tag inside a block writes into the string that block returns, so it is part of
-              # that block's single entry rather than an entry of its own.
-              index += 1 if depth.zero?
+              @engine.send(:add_dynamic, value, context, index, escaped)
             when :expr_block, :expr_block_escaped
-              @engine.send(:add_dynamic_block, value, index, type == :expr_block_escaped)
-
-              index += 1 if depth.zero?
-              depth += 1
+              @engine.send(:add_dynamic_block, value, extra, type == :expr_block_escaped)
             when :expr_block_end
-              depth -= 1
-
               @engine.send(:add_expression_block_end, value, escaped: extra)
             end
           end
@@ -127,42 +226,125 @@ module Herb
 
         private
 
-        # The extras ride in the slot the base compiler already carries through its token
-        # optimization, so nothing here depends on that implementation keeping a wider tuple.
+        #: () -> Integer?
+        def claim
+          return nil if @block_depth.positive?
+
+          index = @slots
+          @slots += 1
+
+          index
+        end
+
         #: (String) -> void
         def add_expression(code)
-          @tokens << [:dynamic, code, current_context, [false, in_loop?]]
+          @tokens << [:dynamic, code, current_context, [claim, false]]
           @last_trim_consumed_newline = false
         end
 
         #: (String) -> void
         def add_expression_escaped(code)
-          @tokens << [:dynamic, code, current_context, [true, in_loop?]]
+          @tokens << [:dynamic, code, current_context, [claim, true]]
           @last_trim_consumed_newline = false
         end
 
-        #: () -> bool
-        def in_loop?
-          @loop_depth.positive?
+        #: (untyped) -> bool
+        def output_block?(node)
+          node.tag_opening.value.include?("=")
         end
 
-        #: [T] () { () -> T } -> T
-        def within_loop
-          @loop_depth += 1
+        #: (untyped) -> bool
+        def branch?(node)
+          @branch_owner.key?(node)
+        end
+
+        #: (Integer) -> Integer
+        def next_branch(index)
+          count = @branch_counts[index] || 0
+          @branch_counts[index] = count + 1
+
+          count
+        end
+
+        #: (untyped) { () -> void } -> void
+        def conditional(node)
+          return yield if branch?(node)
+
+          index = claim
+
+          return yield unless index
+
+          own_branches(node, index)
+
+          @tokens << [:scope, "", nil, [:open_conditional, index]]
 
           yield
-        ensure
-          @loop_depth -= 1
+
+          @tokens << [:scope, "", nil, [:close_conditional, index]]
+        end
+
+        #: (untyped, Integer) -> void
+        def own_branches(node, index)
+          return unless node
+
+          @branch_owner[node] = index if BRANCHING_NODES.include?(node.type.to_s)
+
+          [:subsequent, :else_clause, :conditions].each do |property|
+            next unless node.respond_to?(property)
+
+            value = node.send(property)
+
+            case value
+            when Array then value.each { |child| own_branches(child, index) }
+            when nil then next
+            else own_branches(value, index)
+            end
+          end
+        end
+
+        #: () { (Integer?) -> void } -> void
+        def collection
+          index = claim
+
+          return yield(nil) unless index
+
+          @tokens << [:scope, "", nil, [:open_collection, index]]
+
+          yield(index)
+
+          @tokens << [:scope, "", nil, [:close_collection, index]]
+        end
+
+        #: (Integer?) { () -> void } -> void
+        def row(index)
+          return yield unless index
+
+          @tokens << [:scope, "", nil, [:row_begin, index]]
+
+          yield
+
+          @tokens << [:scope, "", nil, [:row_end, index]]
+        end
+
+        #: (untyped, Symbol) -> void
+        def iteration(node, part)
+          collection do |index|
+            visit_erb_control_node(node) do
+              row(index) do
+                visit_all(node.send(part) || [])
+              end
+
+              visit(node.end_node)
+            end
+          end
         end
       end
 
       #: (String, ?Hash[Symbol, untyped]) -> void
       def initialize(input, properties = {})
         @block_depth = 0
-        @dynamics_size = 0
+        @scopes = [] #: Array[Integer]
 
-        # `.each do` is only its own node, and so only recognisable as a loop, when the parser is
-        # asked for iteration nodes. Without it every loop would look like an ordinary block.
         given = properties[:parser_options] || {} #: Hash[Symbol, untyped]
         parser_options = given.merge(iteration_nodes: true)
 
@@ -170,7 +352,7 @@ module Herb
           input,
           properties.merge(
             bufvar: BUFFER,
-            bufval: "::Array.new",
+            bufval: "::Hash.new",
             postamble: "#{BUFFER}\n",
             parser_options: parser_options
           )
@@ -182,8 +364,6 @@ module Herb
         Compiler
       end
 
-      # Static markup is what this compiler exists to leave out. Inside a block it is kept, because
-      # there the buffer is a String the block returns rather than the list of dynamics.
       #: (String) -> void
       def add_text(text)
         return if @block_depth.zero?
@@ -191,38 +371,32 @@ module Herb
         super
       end
 
-      # A tag writes to the index it was given. Inside a loop it appends there instead, because it
-      # runs once per iteration and the entry holds all of them.
-      #: (String, Symbol?, Integer, bool, bool) -> void
-      def add_dynamic(code, context, index, in_loop, escaped)
+      #: (Symbol, *untyped) -> void
+      def add_scope(kind, *)
+        send(:"scope_#{kind}", *)
+      end
+
+      #: (String, Symbol?, Integer?, bool) -> void
+      def add_dynamic(code, context, index, escaped)
         value = dynamic_value(code, context, escaped)
 
         return add_block_dynamic(value) unless @block_depth.zero?
 
-        claim(index)
-
-        target = in_loop ? "(#{BUFFER}[#{index}] ||= ::Array.new) << " : "#{BUFFER}[#{index}] = "
-
-        @src << "; " << target << value
+        @src << "; " << current_scope << "[" << index.to_s << "] = " << value << ";"
       end
 
-      # A tag that takes a block owns an index like any other, so the tags after it keep theirs.
-      #: (String, Integer, bool) -> void
+      #: (String, Integer?, bool) -> void
       def add_dynamic_block(code, index, escaped)
         @_in_expression_block = true
         @_expression_block_open_paren = true
 
         opening = escaped ? "#{@escapefunc}((" : "("
 
-        # A block inside another block is part of what that one renders, so it goes into its
-        # string rather than taking an entry of its own.
-        if @block_depth.zero?
-          claim(index)
-
-          @src << "; #{BUFFER}[#{index}] = #{opening}#{code}"
-        else
-          @src << "; #{@bufvar} << #{opening}#{code}"
-        end
+        @src << if @block_depth.zero?
+                  "; #{current_scope}[#{index}] = #{opening}#{code}"
+                else
+                  "; #{@bufvar} << #{opening}#{code}"
+                end
 
         open_block
       end
@@ -236,16 +410,6 @@ module Herb
         super
       end
 
-      # Assigning by index only grows the array as far as the tags that ran, so a template whose
-      # last tag sat in a branch that was skipped would come back short. The length is a fact about
-      # the template, so it is set once the walk has counted the tags.
-      #: (String) -> void
-      def add_postamble(postamble)
-        @src << "; #{BUFFER}[#{@dynamics_size - 1}] ||= nil\n" if @dynamics_size.positive?
-
-        super
-      end
-
       #: () -> String
       def inspect
         "#<#{self.class.name}>"
@@ -253,13 +417,61 @@ module Herb
 
       private
 
-      #: (Integer) -> void
-      def claim(index)
-        @dynamics_size = index + 1 if index >= @dynamics_size
+      #: () -> String
+      def current_scope
+        @scopes.empty? ? BUFFER : "#{SCOPE_BUFFER}#{@scopes.last}"
       end
 
-      # Where a tag was written decides how it is escaped, so an attribute, a `<script>`, and
-      # ordinary text each get their own function even for the same expression.
+      #: (Integer) -> void
+      def scope_open_conditional(index)
+        @src << "; #{SLOT_BUFFER}#{index} = nil;"
+      end
+
+      #: (Integer, Integer) -> void
+      def scope_branch(index, branch)
+        leave_scope(index)
+
+        @src << "; #{SLOT_BUFFER}#{index} = { branch: #{branch}, slots: (#{SCOPE_BUFFER}#{index} = ::Hash.new) };"
+
+        @scopes.push(index)
+      end
+
+      #: (Integer) -> void
+      def scope_close_conditional(index)
+        leave_scope(index)
+
+        @src << "; #{current_scope}[#{index}] = (#{SLOT_BUFFER}#{index} || { branch: nil });"
+      end
+
+      #: (Integer) -> void
+      def scope_open_collection(index)
+        @src << "; #{ROWS_BUFFER}#{index} = ::Hash.new; #{KEY_BUFFER}#{index} = 0;"
+      end
+
+      #: (Integer) -> void
+      def scope_row_begin(index)
+        @src << "; #{KEY_BUFFER}#{index} += 1; #{SCOPE_BUFFER}#{index} = ::Hash.new;"
+
+        @scopes.push(index)
+      end
+
+      #: (Integer) -> void
+      def scope_row_end(index)
+        leave_scope(index)
+
+        @src << "; #{ROWS_BUFFER}#{index}[#{KEY_BUFFER}#{index}] = #{SCOPE_BUFFER}#{index};"
+      end
+
+      #: (Integer) -> void
+      def scope_close_collection(index)
+        @src << "; #{current_scope}[#{index}] = { rows: #{ROWS_BUFFER}#{index} };"
+      end
+
+      #: (Integer) -> void
+      def leave_scope(index)
+        @scopes.pop if @scopes.last == index
+      end
+
       #: (String, Symbol?, bool) -> String
       def dynamic_value(code, context, escaped)
         escapefunc = context_escape_function(context)
@@ -270,15 +482,11 @@ module Herb
         "(#{code}).to_s"
       end
 
-      # Inside a block the buffer is a String being assembled, so a tag appends to it the way it
-      # would in a normal template. The block as a whole is what becomes one dynamic.
       #: (String) -> void
       def add_block_dynamic(value)
         @src << "; " << @bufvar << " << " << value << ";"
       end
 
-      # Everything the engine emits goes through `@bufvar`, so a block only has to point it
-      # somewhere else. Every other path, including the escaping ones, then works unchanged.
       #: () -> void
       def open_block
         @block_depth += 1

--- a/lib/herb/engine/dynamics_compiler.rb
+++ b/lib/herb/engine/dynamics_compiler.rb
@@ -1,0 +1,297 @@
+# frozen_string_literal: true
+# typed: false
+
+require_relative "../../herb"
+require_relative "../engine"
+
+module Herb
+  class Engine
+    # Compiles a template into Ruby that returns its dynamic values rather than its HTML.
+    #
+    # `Herb::Engine` answers "what does this template render". This answers "what did the template
+    # evaluate to render it", which is the half that changes when state changes:
+    #
+    #     require "herb/engine/dynamics_compiler"
+    #
+    #     source = Herb::Engine::DynamicsCompiler.new(%(<h1><%= @title %></h1>)).src
+    #     view.instance_eval(source)
+    #     #=> ["Hello"]
+    #
+    # The names follow Phoenix LiveView, which splits a rendered template into its `static` strings
+    # and its `dynamic` values for the same reason. A template's statics never change between
+    # renders, so anything re-rendering on a state change only has to send the dynamics.
+    #
+    # This is a separate compiler rather than an option on `Herb::Engine` because that class is a
+    # drop-in for `Erubi::Engine` and has to keep answering the way Erubi does.
+    #
+    # ## One entry per tag, at a fixed index
+    #
+    # Every `<%= %>` in the template owns an index, decided while compiling and the same on every
+    # render. Control flow contributes no entries of its own, so the length of the result is a fact
+    # about the template rather than about the render:
+    #
+    #     <% if admin? %><%= secret %><% else %><%= public %><% end %>
+    #     #=> ["s", nil]   when admin?
+    #     #=> [nil, "p"]   otherwise
+    #
+    # A branch that did not run leaves its tags `nil`. Both branches keep their own indices, so a
+    # condition flipping changes which entries are filled and never what the entries mean.
+    #
+    # ## Loops are the exception
+    #
+    # A tag inside a loop runs once per iteration, and how many iterations there are is only known
+    # at render time. Its entry is therefore a list rather than a value:
+    #
+    #     <% names.each do |name| %><h1><%= name %></h1><% end %>
+    #     #=> [["Marco", "Joe"]]
+    #
+    # The index still belongs to the tag. Only its shape depends on the render.
+    #
+    # ## Escaping
+    #
+    # A value carries the escaping of the place it was written, because that is where it is going
+    # back to. The same expression is escaped differently in an attribute, in a `<script>`, and in
+    # text, so the tree is left intact and the compiler decides as it normally would.
+    #
+    # ## Blocks
+    #
+    # A tag that takes a block, such as `<%= form_with do |f| %>`, is one entry holding everything
+    # the block rendered. The helper decides where the block's output goes, so there is no position
+    # in the template to attribute the pieces to.
+    class DynamicsCompiler < Herb::Engine
+      BUFFER = "__herb_dynamics" #: String
+      BLOCK_BUFFER = "__herb_block" #: String
+
+      # Records, while walking, which tag each expression belongs to and whether that tag sits
+      # inside a loop. Both are decided by where the tag is written, so both are known here and
+      # neither can be worked out from the token stream alone.
+      class Compiler < Herb::Engine::Compiler
+        #: (untyped, ?Hash[Symbol, untyped]) -> void
+        def initialize(engine, options = {})
+          super
+
+          @loop_depth = 0
+        end
+
+        #: (untyped) -> void
+        def visit_erb_iteration_block_node(node)
+          within_loop { super }
+        end
+
+        #: (untyped) -> void
+        def visit_erb_for_node(node)
+          within_loop { super }
+        end
+
+        #: (untyped) -> void
+        def visit_erb_while_node(node)
+          within_loop { super }
+        end
+
+        #: (untyped) -> void
+        def visit_erb_until_node(node)
+          within_loop { super }
+        end
+
+        # Dynamics are a token type the base compiler does not know, so the dispatch is repeated
+        # here rather than inherited. Everything else is handed over unchanged.
+        #: () -> void
+        def generate_output
+          index = 0
+          depth = 0
+
+          optimize_tokens(@tokens).each do |type, value, context, extra|
+            case type
+            when :text then @engine.send(:add_text, value)
+            when :code then @engine.send(:add_code, value)
+            when :dynamic
+              escaped, in_loop = extra
+
+              @engine.send(:add_dynamic, value, context, index, in_loop, escaped)
+
+              # A tag inside a block writes into the string that block returns, so it is part of
+              # that block's single entry rather than an entry of its own.
+              index += 1 if depth.zero?
+            when :expr_block, :expr_block_escaped
+              @engine.send(:add_dynamic_block, value, index, type == :expr_block_escaped)
+
+              index += 1 if depth.zero?
+              depth += 1
+            when :expr_block_end
+              depth -= 1
+
+              @engine.send(:add_expression_block_end, value, escaped: extra)
+            end
+          end
+        end
+
+        private
+
+        # The extras ride in the slot the base compiler already carries through its token
+        # optimization, so nothing here depends on that implementation keeping a wider tuple.
+        #: (String) -> void
+        def add_expression(code)
+          @tokens << [:dynamic, code, current_context, [false, in_loop?]]
+          @last_trim_consumed_newline = false
+        end
+
+        #: (String) -> void
+        def add_expression_escaped(code)
+          @tokens << [:dynamic, code, current_context, [true, in_loop?]]
+          @last_trim_consumed_newline = false
+        end
+
+        #: () -> bool
+        def in_loop?
+          @loop_depth.positive?
+        end
+
+        #: [T] () { () -> T } -> T
+        def within_loop
+          @loop_depth += 1
+
+          yield
+        ensure
+          @loop_depth -= 1
+        end
+      end
+
+      #: (String, ?Hash[Symbol, untyped]) -> void
+      def initialize(input, properties = {})
+        @block_depth = 0
+        @dynamics_size = 0
+
+        # `.each do` is only its own node, and so only recognisable as a loop, when the parser is
+        # asked for iteration nodes. Without it every loop would look like an ordinary block.
+        given = properties[:parser_options] || {} #: Hash[Symbol, untyped]
+        parser_options = given.merge(iteration_nodes: true)
+
+        super(
+          input,
+          properties.merge(
+            bufvar: BUFFER,
+            bufval: "::Array.new",
+            postamble: "#{BUFFER}\n",
+            parser_options: parser_options
+          )
+        )
+      end
+
+      #: () -> untyped
+      def compiler_class
+        Compiler
+      end
+
+      # Static markup is what this compiler exists to leave out. Inside a block it is kept, because
+      # there the buffer is a String the block returns rather than the list of dynamics.
+      #: (String) -> void
+      def add_text(text)
+        return if @block_depth.zero?
+
+        super
+      end
+
+      # A tag writes to the index it was given. Inside a loop it appends there instead, because it
+      # runs once per iteration and the entry holds all of them.
+      #: (String, Symbol?, Integer, bool, bool) -> void
+      def add_dynamic(code, context, index, in_loop, escaped)
+        value = dynamic_value(code, context, escaped)
+
+        return add_block_dynamic(value) unless @block_depth.zero?
+
+        claim(index)
+
+        target = in_loop ? "(#{BUFFER}[#{index}] ||= ::Array.new) << " : "#{BUFFER}[#{index}] = "
+
+        @src << "; " << target << value
+      end
+
+      # A tag that takes a block owns an index like any other, so the tags after it keep theirs.
+      #: (String, Integer, bool) -> void
+      def add_dynamic_block(code, index, escaped)
+        @_in_expression_block = true
+        @_expression_block_open_paren = true
+
+        opening = escaped ? "#{@escapefunc}((" : "("
+
+        # A block inside another block is part of what that one renders, so it goes into its
+        # string rather than taking an entry of its own.
+        if @block_depth.zero?
+          claim(index)
+
+          @src << "; #{BUFFER}[#{index}] = #{opening}#{code}"
+        else
+          @src << "; #{@bufvar} << #{opening}#{code}"
+        end
+
+        open_block
+      end
+
+      #: (String, ?escaped: bool) -> void
+      def add_expression_block_end(code, escaped: false)
+        @src << "; " << @bufvar
+
+        close_block
+
+        super
+      end
+
+      # Assigning by index only grows the array as far as the tags that ran, so a template whose
+      # last tag sat in a branch that was skipped would come back short. The length is a fact about
+      # the template, so it is set once the walk has counted the tags.
+      #: (String) -> void
+      def add_postamble(postamble)
+        @src << "; #{BUFFER}[#{@dynamics_size - 1}] ||= nil\n" if @dynamics_size.positive?
+
+        super
+      end
+
+      #: () -> String
+      def inspect
+        "#<#{self.class.name}>"
+      end
+
+      private
+
+      #: (Integer) -> void
+      def claim(index)
+        @dynamics_size = index + 1 if index >= @dynamics_size
+      end
+
+      # Where a tag was written decides how it is escaped, so an attribute, a `<script>`, and
+      # ordinary text each get their own function even for the same expression.
+      #: (String, Symbol?, bool) -> String
+      def dynamic_value(code, context, escaped)
+        escapefunc = context_escape_function(context)
+
+        return "#{escapefunc}((#{code}))" if escapefunc
+        return "#{@escapefunc}((#{code}))" if escaped
+
+        "(#{code}).to_s"
+      end
+
+      # Inside a block the buffer is a String being assembled, so a tag appends to it the way it
+      # would in a normal template. The block as a whole is what becomes one dynamic.
+      #: (String) -> void
+      def add_block_dynamic(value)
+        @src << "; " << @bufvar << " << " << value << ";"
+      end
+
+      # Everything the engine emits goes through `@bufvar`, so a block only has to point it
+      # somewhere else. Every other path, including the escaping ones, then works unchanged.
+      #: () -> void
+      def open_block
+        @block_depth += 1
+        @bufvar = "#{BLOCK_BUFFER}#{@block_depth}"
+
+        @src << "; " << @bufvar << " = ::String.new;"
+      end
+
+      #: () -> void
+      def close_block
+        @block_depth -= 1
+        @bufvar = @block_depth.zero? ? BUFFER : "#{BLOCK_BUFFER}#{@block_depth}"
+      end
+    end
+  end
+end

--- a/sig/herb/engine/dynamics_compiler.rbs
+++ b/sig/herb/engine/dynamics_compiler.rbs
@@ -11,7 +11,7 @@ module Herb
     #
     #     source = Herb::Engine::DynamicsCompiler.new(%(<h1><%= @title %></h1>)).src
     #     view.instance_eval(source)
-    #     #=> ["Hello"]
+    #     #=> { 0 => "Hello" }
     #
     # The names follow Phoenix LiveView, which splits a rendered template into its `static` strings
     # and its `dynamic` values for the same reason. A template's statics never change between
@@ -20,28 +20,42 @@ module Herb
     # This is a separate compiler rather than an option on `Herb::Engine` because that class is a
     # drop-in for `Erubi::Engine` and has to keep answering the way Erubi does.
     #
-    # ## One entry per tag, at a fixed index
+    # ## The shape follows the template, not the render
     #
-    # Every `<%= %>` in the template owns an index, decided while compiling and the same on every
-    # render. Control flow contributes no entries of its own, so the length of the result is a fact
-    # about the template rather than about the render:
+    # Every insertion point owns an index, decided while compiling and the same on every render.
+    # Control flow owns one too, because what it decided is itself a value that changes:
     #
     #     <% if admin? %><%= secret %><% else %><%= public %><% end %>
-    #     #=> ["s", nil]   when admin?
-    #     #=> [nil, "p"]   otherwise
+    #     #=> { 0 => { branch: 0, slots: { 1 => "s" } } }   when admin?
+    #     #=> { 0 => { branch: 1, slots: { 2 => "p" } } }   otherwise
     #
-    # A branch that did not run leaves its tags `nil`. Both branches keep their own indices, so a
-    # condition flipping changes which entries are filled and never what the entries mean.
+    # Both branches keep their own indices, so a condition flipping changes which indices are
+    # present and never what an index means.
     #
-    # ## Loops are the exception
+    # ## Absent means it did not run
     #
-    # A tag inside a loop runs once per iteration, and how many iterations there are is only known
-    # at render time. Its entry is therefore a list rather than a value:
+    # A key is missing when the code that would have filled it never ran, which is the same thing
+    # the rendered markup says by not being there. Nothing has to be sent about a branch that was
+    # not taken, and nothing can be learned about one either.
     #
-    #     <% names.each do |name| %><h1><%= name %></h1><% end %>
-    #     #=> [["Marco", "Joe"]]
+    # A conditional and a collection are always present, because both are evaluated on every render
+    # even when they produce nothing. A conditional that matched no branch is `{ branch: nil }` and
+    # an empty collection is `{ rows: {} }`, both of which the client has to be told.
     #
-    # The index still belongs to the tag. Only its shape depends on the render.
+    # ## Collections group by row
+    #
+    # A collection holds its rows in render order, each row carrying the slots inside it:
+    #
+    #     <% users.each do |user| %><%= user.first %> <%= user.last %><% end %>
+    #     #=> { 0 => { rows: { 1 => { 1 => "Marco", 2 => "Roth" },
+    #                          2 => { 1 => "Joe",   2 => "Doe" } } } }
+    #
+    # Grouping the other way would give one list per slot and leave the client to zip them back
+    # together, which it cannot do once a row is inserted rather than appended.
+    #
+    # Rows are keyed by their position for now. Taking the key the template declares, through
+    # `herb-key` or `id` or a `<%# herb:key %>` directive, is what makes a row survive being
+    # reordered, and it belongs to `SlotVisitor` rather than here.
     #
     # ## Escaping
     #
@@ -59,12 +73,34 @@ module Herb
 
       BLOCK_BUFFER: String
 
-      # Records, while walking, which tag each expression belongs to and whether that tag sits
-      # inside a loop. Both are decided by where the tag is written, so both are known here and
-      # neither can be worked out from the token stream alone.
+      SLOT_BUFFER: String
+
+      SCOPE_BUFFER: String
+
+      ROWS_BUFFER: String
+
+      KEY_BUFFER: String
+
+      BRANCHING_NODES: Array[String]
+
       class Compiler < Herb::Engine::Compiler
         # : (untyped, ?Hash[Symbol, untyped]) -> void
         def initialize: (untyped, ?Hash[Symbol, untyped]) -> void
+
+        # : (untyped) { () -> void } -> void
+        def visit_erb_control_node: (untyped) { () -> void } -> void
+
+        # : (untyped) -> void
+        def visit_erb_if_node: (untyped) -> void
+
+        # : (untyped) -> void
+        def visit_erb_unless_node: (untyped) -> void
+
+        # : (untyped) -> void
+        def visit_erb_case_node: (untyped) -> void
+
+        # : (untyped) -> void
+        def visit_erb_case_match_node: (untyped) -> void
 
         # : (untyped) -> void
         def visit_erb_iteration_block_node: (untyped) -> void
@@ -78,26 +114,46 @@ module Herb
         # : (untyped) -> void
         def visit_erb_until_node: (untyped) -> void
 
-        # Dynamics are a token type the base compiler does not know, so the dispatch is repeated
-        # here rather than inherited. Everything else is handed over unchanged.
+        # : (untyped) -> void
+        def visit_erb_block_node: (untyped) -> void
+
         # : () -> void
         def generate_output: () -> void
 
         private
 
-        # The extras ride in the slot the base compiler already carries through its token
-        # optimization, so nothing here depends on that implementation keeping a wider tuple.
+        # : () -> Integer?
+        def claim: () -> Integer?
+
         # : (String) -> void
         def add_expression: (String) -> void
 
         # : (String) -> void
         def add_expression_escaped: (String) -> void
 
-        # : () -> bool
-        def in_loop?: () -> bool
+        # : (untyped) -> bool
+        def output_block?: (untyped) -> bool
 
-        # : [T] () { () -> T } -> T
-        def within_loop: [T] () { () -> T } -> T
+        # : (untyped) -> bool
+        def branch?: (untyped) -> bool
+
+        # : (Integer) -> Integer
+        def next_branch: (Integer) -> Integer
+
+        # : (untyped) { () -> void } -> void
+        def conditional: (untyped) { () -> void } -> void
+
+        # : (untyped, Integer) -> void
+        def own_branches: (untyped, Integer) -> void
+
+        # : () { (Integer?) -> void } -> void
+        def collection: () { (Integer?) -> void } -> void
+
+        # : (Integer?) { () -> void } -> void
+        def row: (Integer?) { () -> void } -> void
+
+        # : (untyped, Symbol) -> void
+        def iteration: (untyped, Symbol) -> void
       end
 
       # : (String, ?Hash[Symbol, untyped]) -> void
@@ -106,49 +162,59 @@ module Herb
       # : () -> untyped
       def compiler_class: () -> untyped
 
-      # Static markup is what this compiler exists to leave out. Inside a block it is kept, because
-      # there the buffer is a String the block returns rather than the list of dynamics.
       # : (String) -> void
       def add_text: (String) -> void
 
-      # A tag writes to the index it was given. Inside a loop it appends there instead, because it
-      # runs once per iteration and the entry holds all of them.
-      # : (String, Symbol?, Integer, bool, bool) -> void
-      def add_dynamic: (String, Symbol?, Integer, bool, bool) -> void
+      # : (Symbol, *untyped) -> void
+      def add_scope: (Symbol, *untyped) -> void
 
-      # A tag that takes a block owns an index like any other, so the tags after it keep theirs.
-      # : (String, Integer, bool) -> void
-      def add_dynamic_block: (String, Integer, bool) -> void
+      # : (String, Symbol?, Integer?, bool) -> void
+      def add_dynamic: (String, Symbol?, Integer?, bool) -> void
+
+      # : (String, Integer?, bool) -> void
+      def add_dynamic_block: (String, Integer?, bool) -> void
 
       # : (String, ?escaped: bool) -> void
       def add_expression_block_end: (String, ?escaped: bool) -> void
-
-      # Assigning by index only grows the array as far as the tags that ran, so a template whose
-      # last tag sat in a branch that was skipped would come back short. The length is a fact about
-      # the template, so it is set once the walk has counted the tags.
-      # : (String) -> void
-      def add_postamble: (String) -> void
 
       # : () -> String
       def inspect: () -> String
 
       private
 
-      # : (Integer) -> void
-      def claim: (Integer) -> void
+      # : () -> String
+      def current_scope: () -> String
 
-      # Where a tag was written decides how it is escaped, so an attribute, a `<script>`, and
-      # ordinary text each get their own function even for the same expression.
+      # : (Integer) -> void
+      def scope_open_conditional: (Integer) -> void
+
+      # : (Integer, Integer) -> void
+      def scope_branch: (Integer, Integer) -> void
+
+      # : (Integer) -> void
+      def scope_close_conditional: (Integer) -> void
+
+      # : (Integer) -> void
+      def scope_open_collection: (Integer) -> void
+
+      # : (Integer) -> void
+      def scope_row_begin: (Integer) -> void
+
+      # : (Integer) -> void
+      def scope_row_end: (Integer) -> void
+
+      # : (Integer) -> void
+      def scope_close_collection: (Integer) -> void
+
+      # : (Integer) -> void
+      def leave_scope: (Integer) -> void
+
       # : (String, Symbol?, bool) -> String
       def dynamic_value: (String, Symbol?, bool) -> String
 
-      # Inside a block the buffer is a String being assembled, so a tag appends to it the way it
-      # would in a normal template. The block as a whole is what becomes one dynamic.
       # : (String) -> void
       def add_block_dynamic: (String) -> void
 
-      # Everything the engine emits goes through `@bufvar`, so a block only has to point it
-      # somewhere else. Every other path, including the escaping ones, then works unchanged.
       # : () -> void
       def open_block: () -> void
 

--- a/sig/herb/engine/dynamics_compiler.rbs
+++ b/sig/herb/engine/dynamics_compiler.rbs
@@ -1,0 +1,159 @@
+# Generated from lib/herb/engine/dynamics_compiler.rb with RBS::Inline
+
+module Herb
+  class Engine
+    # Compiles a template into Ruby that returns its dynamic values rather than its HTML.
+    #
+    # `Herb::Engine` answers "what does this template render". This answers "what did the template
+    # evaluate to render it", which is the half that changes when state changes:
+    #
+    #     require "herb/engine/dynamics_compiler"
+    #
+    #     source = Herb::Engine::DynamicsCompiler.new(%(<h1><%= @title %></h1>)).src
+    #     view.instance_eval(source)
+    #     #=> ["Hello"]
+    #
+    # The names follow Phoenix LiveView, which splits a rendered template into its `static` strings
+    # and its `dynamic` values for the same reason. A template's statics never change between
+    # renders, so anything re-rendering on a state change only has to send the dynamics.
+    #
+    # This is a separate compiler rather than an option on `Herb::Engine` because that class is a
+    # drop-in for `Erubi::Engine` and has to keep answering the way Erubi does.
+    #
+    # ## One entry per tag, at a fixed index
+    #
+    # Every `<%= %>` in the template owns an index, decided while compiling and the same on every
+    # render. Control flow contributes no entries of its own, so the length of the result is a fact
+    # about the template rather than about the render:
+    #
+    #     <% if admin? %><%= secret %><% else %><%= public %><% end %>
+    #     #=> ["s", nil]   when admin?
+    #     #=> [nil, "p"]   otherwise
+    #
+    # A branch that did not run leaves its tags `nil`. Both branches keep their own indices, so a
+    # condition flipping changes which entries are filled and never what the entries mean.
+    #
+    # ## Loops are the exception
+    #
+    # A tag inside a loop runs once per iteration, and how many iterations there are is only known
+    # at render time. Its entry is therefore a list rather than a value:
+    #
+    #     <% names.each do |name| %><h1><%= name %></h1><% end %>
+    #     #=> [["Marco", "Joe"]]
+    #
+    # The index still belongs to the tag. Only its shape depends on the render.
+    #
+    # ## Escaping
+    #
+    # A value carries the escaping of the place it was written, because that is where it is going
+    # back to. The same expression is escaped differently in an attribute, in a `<script>`, and in
+    # text, so the tree is left intact and the compiler decides as it normally would.
+    #
+    # ## Blocks
+    #
+    # A tag that takes a block, such as `<%= form_with do |f| %>`, is one entry holding everything
+    # the block rendered. The helper decides where the block's output goes, so there is no position
+    # in the template to attribute the pieces to.
+    class DynamicsCompiler < Herb::Engine
+      BUFFER: String
+
+      BLOCK_BUFFER: String
+
+      # Records, while walking, which tag each expression belongs to and whether that tag sits
+      # inside a loop. Both are decided by where the tag is written, so both are known here and
+      # neither can be worked out from the token stream alone.
+      class Compiler < Herb::Engine::Compiler
+        # : (untyped, ?Hash[Symbol, untyped]) -> void
+        def initialize: (untyped, ?Hash[Symbol, untyped]) -> void
+
+        # : (untyped) -> void
+        def visit_erb_iteration_block_node: (untyped) -> void
+
+        # : (untyped) -> void
+        def visit_erb_for_node: (untyped) -> void
+
+        # : (untyped) -> void
+        def visit_erb_while_node: (untyped) -> void
+
+        # : (untyped) -> void
+        def visit_erb_until_node: (untyped) -> void
+
+        # Dynamics are a token type the base compiler does not know, so the dispatch is repeated
+        # here rather than inherited. Everything else is handed over unchanged.
+        # : () -> void
+        def generate_output: () -> void
+
+        private
+
+        # The extras ride in the slot the base compiler already carries through its token
+        # optimization, so nothing here depends on that implementation keeping a wider tuple.
+        # : (String) -> void
+        def add_expression: (String) -> void
+
+        # : (String) -> void
+        def add_expression_escaped: (String) -> void
+
+        # : () -> bool
+        def in_loop?: () -> bool
+
+        # : [T] () { () -> T } -> T
+        def within_loop: [T] () { () -> T } -> T
+      end
+
+      # : (String, ?Hash[Symbol, untyped]) -> void
+      def initialize: (String, ?Hash[Symbol, untyped]) -> void
+
+      # : () -> untyped
+      def compiler_class: () -> untyped
+
+      # Static markup is what this compiler exists to leave out. Inside a block it is kept, because
+      # there the buffer is a String the block returns rather than the list of dynamics.
+      # : (String) -> void
+      def add_text: (String) -> void
+
+      # A tag writes to the index it was given. Inside a loop it appends there instead, because it
+      # runs once per iteration and the entry holds all of them.
+      # : (String, Symbol?, Integer, bool, bool) -> void
+      def add_dynamic: (String, Symbol?, Integer, bool, bool) -> void
+
+      # A tag that takes a block owns an index like any other, so the tags after it keep theirs.
+      # : (String, Integer, bool) -> void
+      def add_dynamic_block: (String, Integer, bool) -> void
+
+      # : (String, ?escaped: bool) -> void
+      def add_expression_block_end: (String, ?escaped: bool) -> void
+
+      # Assigning by index only grows the array as far as the tags that ran, so a template whose
+      # last tag sat in a branch that was skipped would come back short. The length is a fact about
+      # the template, so it is set once the walk has counted the tags.
+      # : (String) -> void
+      def add_postamble: (String) -> void
+
+      # : () -> String
+      def inspect: () -> String
+
+      private
+
+      # : (Integer) -> void
+      def claim: (Integer) -> void
+
+      # Where a tag was written decides how it is escaped, so an attribute, a `<script>`, and
+      # ordinary text each get their own function even for the same expression.
+      # : (String, Symbol?, bool) -> String
+      def dynamic_value: (String, Symbol?, bool) -> String
+
+      # Inside a block the buffer is a String being assembled, so a tag appends to it the way it
+      # would in a normal template. The block as a whole is what becomes one dynamic.
+      # : (String) -> void
+      def add_block_dynamic: (String) -> void
+
+      # Everything the engine emits goes through `@bufvar`, so a block only has to point it
+      # somewhere else. Every other path, including the escaping ones, then works unchanged.
+      # : () -> void
+      def open_block: () -> void
+
+      # : () -> void
+      def close_block: () -> void
+    end
+  end
+end

--- a/test/engine/dynamics_compiler_test.rb
+++ b/test/engine/dynamics_compiler_test.rb
@@ -1,0 +1,148 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+require_relative "../../lib/herb/engine/dynamics_compiler"
+
+module Engine
+  class DynamicsCompilerTest < Minitest::Spec
+    class View
+      def initialize(**assigns)
+        assigns.each { |name, value| instance_variable_set(:"@#{name}", value) }
+      end
+
+      def form_with(**) = "<form>#{yield(Field.new)}</form>"
+
+      def wrapper = "[#{yield}]"
+
+      def helper_with_argument(value) = "helper(#{value})"
+
+      User = Struct.new(:name)
+
+      class Field
+        def label = "Name"
+      end
+    end
+
+    def dynamics(source, **assigns)
+      compiled = Herb::Engine::DynamicsCompiler.new(source, filename: "app/views/test.html.erb").src
+
+      View.new(**assigns).instance_eval(compiled)
+    end
+
+    describe "what it collects" do
+      test "one value per expression" do
+        assert_equal ["Hello"], dynamics("<h1><%= @title %></h1>", title: "Hello")
+      end
+
+      test "nothing for a template with no expressions" do
+        assert_empty dynamics("<h1>Static only</h1>")
+      end
+
+      test "the value of an expression that is not written as markup" do
+        assert_equal ["helper(1)"], dynamics("<%= helper_with_argument(1) %>")
+      end
+
+      test "values in the order the template evaluates them" do
+        assert_equal ["a", "b", "c"], dynamics("<%= @a %><p><%= @b %></p><%= @c %>", a: "a", b: "b", c: "c")
+      end
+    end
+
+    describe "what the control flow decides" do
+      # Both branches keep their own index, so flipping the condition changes which entries are
+      # filled and never what an entry means.
+      test "leaves a tag in a branch that did not run empty" do
+        source = "<% if @admin %><%= @secret %><% else %><%= @public %><% end %>"
+
+        assert_equal [nil, "p"], dynamics(source, admin: false, secret: "s", public: "p")
+        assert_equal ["s", nil], dynamics(source, admin: true, secret: "s", public: "p")
+      end
+
+      test "keeps its length whatever the condition decides" do
+        source = "<% if @admin %><%= @secret %><% else %><%= @public %><% end %>"
+
+        assert_equal 2, dynamics(source, admin: false, secret: "s", public: "p").length
+        assert_equal 2, dynamics(source, admin: true, secret: "s", public: "p").length
+      end
+
+      # A loop is the one place the shape depends on the render, because how many iterations there
+      # are is not known until it runs. The index still belongs to the tag.
+      test "collects a tag inside a loop into one entry per iteration" do
+        users = [View::User.new("A"), View::User.new("B"), View::User.new("C")]
+
+        assert_equal [["A", "B", "C"]],
+                     dynamics("<% @users.each do |u| %><li><%= u.name %></li><% end %>", users: users)
+      end
+
+      test "leaves a loop that never ran empty rather than absent" do
+        assert_equal [nil], dynamics("<% @users.each do |u| %><%= u.name %><% end %>", users: [])
+      end
+
+      test "gives each tag in a loop body its own entry" do
+        users = [View::User.new("A"), View::User.new("B")]
+        source = "<% @users.each do |u| %><%= u.name %><%= u.name.downcase %><% end %>"
+
+        assert_equal [["A", "B"], ["a", "b"]], dynamics(source, users: users)
+      end
+
+      test "a statement that assigns is still run" do
+        assert_equal ["42"], dynamics("<% total = 40 + 2 %><span><%= total %></span>")
+      end
+    end
+
+    # A value is going back to the place it was written, so it carries that place's escaping. This
+    # is what is lost if the markup is stripped from the tree before compiling.
+    describe "how values are escaped" do
+      test "escapes an attribute value as an attribute" do
+        assert_equal ["/a?b=1&amp;c=2"], dynamics(%(<a href="<%= @url %>"></a>), url: "/a?b=1&c=2")
+      end
+
+      test "escapes script content as JavaScript" do
+        assert_equal ["\\x3cb\\x3e"], dynamics("<script>var x = <%= @raw %>;</script>", raw: "<b>")
+      end
+
+      test "leaves text content to the engine's own escaping" do
+        assert_equal ["<b>"], dynamics("<p><%= @raw %></p>", raw: "<b>")
+      end
+    end
+
+    describe "tags that take a block" do
+      test "collects the whole block as one value" do
+        source = %(<div><%= form_with(model: @user) do |f| %><span><%= f.label %></span><% end %></div>)
+
+        assert_equal ["<form><span>Name</span></form>"], dynamics(source)
+      end
+
+      # Without a buffer of its own the block would collect into the list of values and return it,
+      # which renders as the array rather than as its own markup.
+      test "keeps the block's markup out of the values" do
+        source = %(<div><%= form_with(model: @user) do |f| %><span><%= f.label %></span><% end %></div>)
+
+        refute_includes dynamics(source), "Name"
+      end
+
+      test "nests" do
+        source = %(<%= wrapper do %>a<%= form_with(model: 1) do |f| %><%= f.label %><% end %><% end %>)
+
+        assert_equal ["[a<form>Name</form>]"], dynamics(source)
+      end
+    end
+
+    describe "what it compiles to" do
+      test "collects into an Array rather than a String" do
+        assert_includes Herb::Engine::DynamicsCompiler.new("<p>x</p>").src, "__herb_dynamics = ::Array.new"
+      end
+
+      test "names its buffers so a template's own locals cannot collide" do
+        source = %(<%= form_with(model: 1) do |f| %><%= f.label %><% end %>)
+        compiled = Herb::Engine::DynamicsCompiler.new(source).src
+
+        assert_includes compiled, "__herb_block1"
+        refute_includes compiled, "_buf"
+      end
+
+      test "leaves the static markup out" do
+        refute_includes Herb::Engine::DynamicsCompiler.new("<p>hello</p>").src, "hello"
+      end
+    end
+  end
+end

--- a/test/engine/dynamics_compiler_test.rb
+++ b/test/engine/dynamics_compiler_test.rb
@@ -16,12 +16,14 @@ module Engine
 
       def helper_with_argument(value) = "helper(#{value})"
 
-      User = Struct.new(:name)
+      User = Struct.new(:firstname, :lastname)
 
       class Field
         def label = "Name"
       end
     end
+
+    CONDITIONAL = "<% if @admin %><%= @secret %><% else %><%= @public %><% end %>"
 
     def dynamics(source, **assigns)
       compiled = Herb::Engine::DynamicsCompiler.new(source, filename: "app/views/test.html.erb").src
@@ -31,7 +33,7 @@ module Engine
 
     describe "what it collects" do
       test "one value per expression" do
-        assert_equal ["Hello"], dynamics("<h1><%= @title %></h1>", title: "Hello")
+        assert_equal({ 0 => "Hello" }, dynamics("<h1><%= @title %></h1>", title: "Hello"))
       end
 
       test "nothing for a template with no expressions" do
@@ -39,69 +41,97 @@ module Engine
       end
 
       test "the value of an expression that is not written as markup" do
-        assert_equal ["helper(1)"], dynamics("<%= helper_with_argument(1) %>")
+        assert_equal({ 0 => "helper(1)" }, dynamics("<%= helper_with_argument(1) %>"))
       end
 
       test "values in the order the template evaluates them" do
-        assert_equal ["a", "b", "c"], dynamics("<%= @a %><p><%= @b %></p><%= @c %>", a: "a", b: "b", c: "c")
-      end
-    end
-
-    describe "what the control flow decides" do
-      # Both branches keep their own index, so flipping the condition changes which entries are
-      # filled and never what an entry means.
-      test "leaves a tag in a branch that did not run empty" do
-        source = "<% if @admin %><%= @secret %><% else %><%= @public %><% end %>"
-
-        assert_equal [nil, "p"], dynamics(source, admin: false, secret: "s", public: "p")
-        assert_equal ["s", nil], dynamics(source, admin: true, secret: "s", public: "p")
-      end
-
-      test "keeps its length whatever the condition decides" do
-        source = "<% if @admin %><%= @secret %><% else %><%= @public %><% end %>"
-
-        assert_equal 2, dynamics(source, admin: false, secret: "s", public: "p").length
-        assert_equal 2, dynamics(source, admin: true, secret: "s", public: "p").length
-      end
-
-      # A loop is the one place the shape depends on the render, because how many iterations there
-      # are is not known until it runs. The index still belongs to the tag.
-      test "collects a tag inside a loop into one entry per iteration" do
-        users = [View::User.new("A"), View::User.new("B"), View::User.new("C")]
-
-        assert_equal [["A", "B", "C"]],
-                     dynamics("<% @users.each do |u| %><li><%= u.name %></li><% end %>", users: users)
-      end
-
-      test "leaves a loop that never ran empty rather than absent" do
-        assert_equal [nil], dynamics("<% @users.each do |u| %><%= u.name %><% end %>", users: [])
-      end
-
-      test "gives each tag in a loop body its own entry" do
-        users = [View::User.new("A"), View::User.new("B")]
-        source = "<% @users.each do |u| %><%= u.name %><%= u.name.downcase %><% end %>"
-
-        assert_equal [["A", "B"], ["a", "b"]], dynamics(source, users: users)
+        assert_equal({ 0 => "a", 1 => "b", 2 => "c" }, dynamics("<%= @a %><p><%= @b %></p><%= @c %>", a: "a", b: "b", c: "c"))
       end
 
       test "a statement that assigns is still run" do
-        assert_equal ["42"], dynamics("<% total = 40 + 2 %><span><%= total %></span>")
+        assert_equal({ 0 => "42" }, dynamics("<% total = 40 + 2 %><span><%= total %></span>"))
       end
     end
 
-    # A value is going back to the place it was written, so it carries that place's escaping. This
-    # is what is lost if the markup is stripped from the tree before compiling.
+    describe "conditionals" do
+      test "names the branch that ran and nests what it rendered" do
+        assert_equal({ 0 => { branch: 0, slots: { 1 => "s" } } },
+                     dynamics(CONDITIONAL, admin: true, secret: "s", public: "p"))
+      end
+
+      test "names the other branch when the condition flips" do
+        assert_equal({ 0 => { branch: 1, slots: { 2 => "p" } } }, dynamics(CONDITIONAL, admin: false, secret: "s", public: "p"))
+      end
+
+      test "counts an elsif as its own branch" do
+        source = "<% if @a %>A<% elsif @b %><%= @y %><% else %><%= @z %><% end %>"
+
+        assert_equal({ 0 => { branch: 1, slots: { 1 => "y" } } }, dynamics(source, a: false, b: true, y: "y", z: "z"))
+      end
+
+      test "counts each when of a case as its own branch" do
+        source = "<% case @n %><% when 1 %><%= @a %><% when 2 %><%= @b %><% end %>"
+
+        assert_equal({ 0 => { branch: 1, slots: { 2 => "b" } } }, dynamics(source, n: 2, a: "a", b: "b"))
+      end
+
+      test "reports a conditional that matched nothing rather than leaving it out" do
+        assert_equal({ 0 => { branch: nil } }, dynamics("<% if @a %><%= @x %><% end %>", a: false, x: "x"))
+      end
+
+      test "leaves out the slots of a branch that did not run" do
+        result = dynamics(CONDITIONAL, admin: true, secret: "s", public: "p")
+
+        refute_includes result[0][:slots].keys, 2
+      end
+    end
+
+    describe "collections" do
+      test "groups by row rather than by slot" do
+        users = [View::User.new("Marco", "Roth"), View::User.new("Joe", "Doe")]
+        source = "<% @users.each do |u| %><li><%= u.firstname %> <%= u.lastname %></li><% end %>"
+
+        assert_equal({ 0 => { rows: { 1 => { 1 => "Marco", 2 => "Roth" }, 2 => { 1 => "Joe", 2 => "Doe" } } } }, dynamics(source, users: users))
+      end
+
+      test "reports a collection that rendered no rows" do
+        assert_equal({ 0 => { rows: {} } }, dynamics("<% @users.each do |u| %><%= u %><% end %>", users: []))
+      end
+
+      test "keeps the rows of a nested collection inside the row that produced them" do
+        source = "<% @rows.each do |r| %><% r.each do |c| %><%= c %><% end %><% end %>"
+
+        assert_equal({ 0 => { rows: { 1 => { 1 => { rows: { 1 => { 2 => "1" }, 2 => { 2 => "2" } } } }, 2 => { 1 => { rows: { 1 => { 2 => "3" } } } } } } }, dynamics(source, rows: [[1, 2], [3]]))
+      end
+
+      test "nests a conditional inside the row it ran in" do
+        source = "<% @xs.each do |x| %><% if x %><%= x %><% end %><% end %>"
+
+        assert_equal({ 0 => { rows: { 1 => { 1 => { branch: 0, slots: { 2 => "a" } } }, 2 => { 1 => { branch: nil } } } } }, dynamics(source, xs: ["a", nil]))
+      end
+
+      test "nests a collection inside the branch it ran in" do
+        source = "<% if @on %><% @xs.each do |x| %><%= x %><% end %><% end %>"
+
+        assert_equal({ 0 => { branch: 0, slots: { 1 => { rows: { 1 => { 2 => "a" }, 2 => { 2 => "b" } } } } } }, dynamics(source, on: true, xs: ["a", "b"]))
+      end
+
+      test "treats a for loop as a collection" do
+        assert_equal({ 0 => { rows: { 1 => { 1 => "a" }, 2 => { 1 => "b" } } } }, dynamics("<% for x in @xs %><%= x %><% end %>", xs: ["a", "b"]))
+      end
+    end
+
     describe "how values are escaped" do
       test "escapes an attribute value as an attribute" do
-        assert_equal ["/a?b=1&amp;c=2"], dynamics(%(<a href="<%= @url %>"></a>), url: "/a?b=1&c=2")
+        assert_equal({ 0 => "/a?b=1&amp;c=2" }, dynamics(%(<a href="<%= @url %>"></a>), url: "/a?b=1&c=2"))
       end
 
       test "escapes script content as JavaScript" do
-        assert_equal ["\\x3cb\\x3e"], dynamics("<script>var x = <%= @raw %>;</script>", raw: "<b>")
+        assert_equal({ 0 => "\\x3cb\\x3e" }, dynamics("<script>var x = <%= @raw %>;</script>", raw: "<b>"))
       end
 
       test "leaves text content to the engine's own escaping" do
-        assert_equal ["<b>"], dynamics("<p><%= @raw %></p>", raw: "<b>")
+        assert_equal({ 0 => "<b>" }, dynamics("<p><%= @raw %></p>", raw: "<b>"))
       end
     end
 
@@ -109,27 +139,31 @@ module Engine
       test "collects the whole block as one value" do
         source = %(<div><%= form_with(model: @user) do |f| %><span><%= f.label %></span><% end %></div>)
 
-        assert_equal ["<form><span>Name</span></form>"], dynamics(source)
+        assert_equal({ 0 => "<form><span>Name</span></form>" }, dynamics(source))
       end
 
-      # Without a buffer of its own the block would collect into the list of values and return it,
-      # which renders as the array rather than as its own markup.
       test "keeps the block's markup out of the values" do
         source = %(<div><%= form_with(model: @user) do |f| %><span><%= f.label %></span><% end %></div>)
 
-        refute_includes dynamics(source), "Name"
+        refute_includes dynamics(source).values, "Name"
       end
 
       test "nests" do
         source = %(<%= wrapper do %>a<%= form_with(model: 1) do |f| %><%= f.label %><% end %><% end %>)
 
-        assert_equal ["[a<form>Name</form>]"], dynamics(source)
+        assert_equal({ 0 => "[a<form>Name</form>]" }, dynamics(source))
+      end
+
+      test "takes an index of its own so the tags after it keep theirs" do
+        source = %(<%= form_with(model: 1) do |f| %><%= f.label %><% end %><%= @after %>)
+
+        assert_equal({ 0 => "<form>Name</form>", 1 => "A" }, dynamics(source, after: "A"))
       end
     end
 
     describe "what it compiles to" do
-      test "collects into an Array rather than a String" do
-        assert_includes Herb::Engine::DynamicsCompiler.new("<p>x</p>").src, "__herb_dynamics = ::Array.new"
+      test "collects into a Hash rather than a String" do
+        assert_includes Herb::Engine::DynamicsCompiler.new("<p>x</p>").src, "__herb_dynamics = ::Hash.new"
       end
 
       test "names its buffers so a template's own locals cannot collide" do


### PR DESCRIPTION
This pull request introduces `Herb::Engine::DynamicsCompiler`, which compiles a template into Ruby that returns its dynamic values rather than its HTML.

`Herb::Engine` answers "what does this template render". This answers "what did the template evaluate to render it", which is the half that changes when state changes. A template's static strings never change between renders, so anything re-rendering on a state change only has to send the dynamics.

```ruby
require "herb/engine/dynamics_compiler"

source = Herb::Engine::DynamicsCompiler.new(%(<h1><%= @title %></h1>)).src
view.instance_eval(source)
#=> { 0 => "Hello" }
```

#### The shape follows the template, not the render

Every insertion point owns an index decided while compiling, the same on every render. Control flow owns one too, because what it decided is itself a value that changes:

```erb
<% if admin? %><%= secret %><% else %><%= public %><% end %>
```

```ruby
{ 0 => { branch: 0, slots: { 1 => "s" } } }   # when admin?
{ 0 => { branch: 1, slots: { 2 => "p" } } }   # otherwise
```

Both branches keep their own indices, so a condition flipping changes which indices are present and never what an index means.

#### Collections group by row

```erb
<% users.each do |user| %>
  <%= user.first %> <%= user.last %>
<% end %>
```

```ruby
{ 0 => { rows: { 1 => { 1 => "Marco", 2 => "Roth" },
                 2 => { 1 => "Joe",   2 => "Doe" } } } }
```

Grouping the other way would give one list per slot and leave the client to zip them back together, which it cannot do once a row is inserted rather than appended.

#### Escaping is why this is a compiler and not a visitor

A value carries the escaping of the place it was written, because that is where it is going back to. The same expression is escaped differently in an attribute, in a `<script>`, and in text.

```erb
<a href="<%= @url %>"></a>          <%# => "/a?b=1&amp;c=2" %>
<script>var x = <%= @raw %>;</script>  <%# => "\x3cb\x3e"      %>
```

Stripping the markup out of the tree first and compiling what is left loses exactly this, because the context the compiler escapes by is the tree shape. Keeping the tree intact and changing where the output goes is what preserves it. The buffer the engine appends through points at a `Hash` of dynamics outside blocks and at a `String` inside them, so every existing emission path, including the escaping ones, works unchanged.