### PR TITLE
Engine: Use `String#match?` for the remaining compiler regexp guards

### DIFF
--- a/lib/herb/engine/compiler.rb
+++ b/lib/herb/engine/compiler.rb
@@ -655,9 +655,9 @@ module Herb
 
         text = @tokens.last[1]
 
-        if text =~ TRAILING_INDENTATION
+        if text.match?(TRAILING_INDENTATION)
           text.sub!(TRAILING_WHITESPACE, "")
-        elsif text =~ WHITESPACE_ONLY
+        elsif text.match?(WHITESPACE_ONLY)
           text.replace("")
         end
 
@@ -702,10 +702,10 @@ module Herb
         text = token[1]
         removed = text[TRAILING_WHITESPACE] || ""
 
-        if text =~ TRAILING_INDENTATION
+        if text.match?(TRAILING_INDENTATION)
           text.sub!(TRAILING_WHITESPACE, "")
           token[1] = text
-        elsif text =~ WHITESPACE_ONLY
+        elsif text.match?(WHITESPACE_ONLY)
           text.replace("")
           token[1] = text
         end


### PR DESCRIPTION
Follow up on #2235, which switched the boolean guards in `trailing_whitespace?`, `leading_whitespace?` and `at_line_start?` from `=~` to `String#match?`.

That pull request deliberately left the other `=~` calls alone, on the grounds that they consume `Regexp.last_match`. That is true for `extract_leading_space`, but four more call sites are also pure boolean guards that never read `$~`, in `extract_and_remove_leading_space!` and `remove_trailing_whitespace_from_last_token!`.

After this change the only remaining `=~` in the compiler is the one in `extract_leading_space`, which genuinely consumes `Regexp.last_match(1)`.

#### Benchmark

Compiling `marcoroth/herb-corpus` of 36,284 templates with `Herb::Engine` on Ruby 4.0.2, counting `GC.stat(:total_allocated_objects)`:

| | objects allocated |
|---|---|
| `=~` | 84,704,561 |
| `match?` | 84,535,243 |

That is about **−0.20%**, roughly 169,000 fewer objects per full-corpus compile. Repeating both sides put the delta at 169,318 and 169,235, so the measurement is stable well inside the effect.

Noticeably smaller than the −0.7% in #2235, which is expected. These two methods only run on explicit trim markers and line-start handling rather than once per token, so they fire far less often.

/cc @joelhawksley 