### PR TITLE
Linter: Don't report duplicate strict locals diagnostics

### DIFF
--- a/javascript/packages/linter/docs/rules/erb-strict-locals-comment-syntax.md
+++ b/javascript/packages/linter/docs/rules/erb-strict-locals-comment-syntax.md
@@ -43,30 +43,43 @@ Required keyword argument:
 
 ```erb
 <%# locals: (user:) %>
+
+<%= user %>
 ```
 
 Keyword argument with default value:
 
 ```erb
 <%# locals: (user:, admin: false) %>
+
+<%= user %>
+<%= admin %>
 ```
 
 Complex default values:
 
 ```erb
 <%# locals: (items: [], config: {}) %>
+
+<%= items %>
+<%= config %>
 ```
 
 No locals (empty):
 
 ```erb
 <%# locals: () %>
+
+<p>Static content only</p>
 ```
 
 Double-splat for optional keyword arguments:
 
 ```erb
 <%# locals: (message: "Hello", **attributes) %>
+
+<%= message %>
+<%= attributes %>
 ```
 
 ### 🚫 Bad
@@ -107,12 +120,16 @@ Missing space after the colon:
 
 ```erb
 <%# locals:(user:) %>
+
+<%= user %>
 ```
 
 Unbalanced parentheses:
 
 ```erb
 <%# locals: (user: %>
+
+<%= user %>
 ```
 
 #### Wrong tag type (must use ERB comment tag)
@@ -167,7 +184,7 @@ Double comma:
 
 #### Duplicate declarations
 
-Only one `locals:` comment is allowed per partial:
+Only one `locals:` comment is allowed per file:
 
 ```erb
 <%# locals: (user:) %>

--- a/javascript/packages/linter/src/rules/a11y-no-autofocus-attribute.ts
+++ b/javascript/packages/linter/src/rules/a11y-no-autofocus-attribute.ts
@@ -1,4 +1,4 @@
-import { hasAttribute, PrismVisitor, getHelpersByModule, helperExists } from "@herb-tools/core"
+import { hasAttribute, PrismVisitor, getHelpersByModule } from "@herb-tools/core"
 
 import { BaseRuleVisitor } from "./rule-utils.js"
 import { ParserRule } from "../types.js"

--- a/javascript/packages/linter/src/rules/erb-comment-syntax.ts
+++ b/javascript/packages/linter/src/rules/erb-comment-syntax.ts
@@ -1,6 +1,8 @@
 import { BaseRuleVisitor } from "./rule-utils.js"
 import { ParserRule, BaseAutofixContext, Mutable } from "../types.js"
 
+import { extractRubyCommentContent, looksLikeLocalsDeclaration } from "./strict-locals-utils.js"
+
 import type { UnboundLintOffense, LintOffense, LintContext, FullRuleConfig } from "../types.js"
 import type { ParseResult, ERBContentNode } from "@herb-tools/core"
 
@@ -13,19 +15,23 @@ class ERBCommentSyntaxVisitor extends BaseRuleVisitor<ERBCommentSyntaxAutofixCon
     const content = node.content?.value || ""
 
     if (content.match(/^ +#/)) {
+      const rubyComment = extractRubyCommentContent(content)
+
+      if (rubyComment && looksLikeLocalsDeclaration(rubyComment)) return
+
       const openingTag = node.tag_opening?.value
 
       if (content.includes("herb:disable")) {
         this.addOffense(
           `Use \`<%#\` instead of \`${openingTag} #\` for \`herb:disable\` directives. Herb directives only work with ERB comment syntax (\`<%# ... %>\`).`,
           node.location,
-          { node }
+          { node },
         )
       } else {
         this.addOffense(
           `Use \`<%#\` instead of \`${openingTag} #\`. Ruby comments immediately after ERB tags can cause parsing issues.`,
           node.location,
-          { node }
+          { node },
         )
       }
     }
@@ -40,7 +46,7 @@ export class ERBCommentSyntax extends ParserRule<ERBCommentSyntaxAutofixContext>
   get defaultConfig(): FullRuleConfig {
     return {
       enabled: true,
-      severity: "error"
+      severity: "error",
     }
   }
 

--- a/javascript/packages/linter/src/rules/erb-strict-locals-comment-syntax.ts
+++ b/javascript/packages/linter/src/rules/erb-strict-locals-comment-syntax.ts
@@ -2,7 +2,6 @@ import { BaseRuleVisitor } from "./rule-utils.js"
 import { ParserRule } from "../types.js"
 
 import { isRubyParameterNode } from "@herb-tools/core"
-import { isPartialFile } from "./file-utils.js"
 
 import type { BaseAutofixContext, Mutable, UnboundLintOffense, LintOffense, LintContext, FullRuleConfig } from "../types.js"
 import type { ParseResult, ERBContentNode, ERBStrictLocalsNode, RubyParseError, HerbError } from "@herb-tools/core"
@@ -290,15 +289,6 @@ function applyFix(node: Mutable<StrictLocalsCommentNode>, fix: StrictLocalsFix):
 
 class ERBStrictLocalsCommentSyntaxVisitor extends BaseRuleVisitor<ERBStrictLocalsCommentSyntaxAutofixContext> {
   visitERBStrictLocalsNode(node: ERBStrictLocalsNode): void {
-    const isPartial = isPartialFile(this.context.fileName)
-
-    if (isPartial === false) {
-      this.addOffense(
-        "Strict locals (`locals:`) only work in partials (files starting with `_`). This declaration will be ignored.",
-        node.location
-      )
-    }
-
     if (hasError(node, "STRICT_LOCALS_DUPLICATE_DECLARATION_ERROR")) {
       this.addOffense(
         "Duplicate strict locals declaration. Rails only uses the first `<%# locals: (...) %>` declaration in a partial.",

--- a/javascript/packages/linter/src/rules/erb-strict-locals-comment-syntax.ts
+++ b/javascript/packages/linter/src/rules/erb-strict-locals-comment-syntax.ts
@@ -2,9 +2,10 @@ import { BaseRuleVisitor } from "./rule-utils.js"
 import { ParserRule } from "../types.js"
 
 import { isRubyParameterNode } from "@herb-tools/core"
+import { extractRubyCommentContent, looksLikeLocalsDeclaration } from "./strict-locals-utils.js"
 
 import type { BaseAutofixContext, Mutable, UnboundLintOffense, LintOffense, LintContext, FullRuleConfig } from "../types.js"
-import type { ParseResult, ERBContentNode, ERBStrictLocalsNode, RubyParseError, HerbError } from "@herb-tools/core"
+import type {ParseResult, ERBContentNode, ERBStrictLocalsNode, RubyParseError, HerbError } from "@herb-tools/core"
 
 const LOCALS_PREFIX = "locals:"
 
@@ -18,7 +19,7 @@ type StrictLocalsFix =
   | { type: "wrap-parameters" }
   | { type: "close-parameters" }
   | { type: "remove-extra-commas" }
-  | { type: "keyword-argument", name: string }
+  | { type: "keyword-argument"; name: string }
 
 interface ERBStrictLocalsCommentSyntaxAutofixContext extends BaseAutofixContext {
   node: Mutable<StrictLocalsCommentNode>
@@ -40,16 +41,6 @@ function extractERBCommentContent(content: string): string {
   return content.trim()
 }
 
-function extractRubyCommentContent(content: string): string | null {
-  const match = content.match(/^\s*#\s*(.*)$/)
-
-  return match ? match[1].trim() : null
-}
-
-function looksLikeLocalsDeclaration(content: string): boolean {
-  return /^locals?\b/.test(content) && /[(:)]/.test(content)
-}
-
 function detectLocalsWithoutColon(content: string): boolean {
   return /^locals?\(/.test(content)
 }
@@ -63,7 +54,7 @@ function detectMissingColonBeforeParens(content: string): boolean {
 }
 
 function hasError(node: { errors: HerbError[] }, type: string): boolean {
-  return node.errors.some(error => error.type === type)
+  return node.errors.some((error) => error.type === type)
 }
 
 function skipStringLiteral(content: string, index: number): number {
@@ -129,7 +120,10 @@ function segmentsOf(parameters: Parameters): Segment[] {
 
   const boundaries = [parameters.open, ...parameters.commas, parameters.close]
 
-  return boundaries.slice(0, -1).map((boundary, index) => ({ start: boundary + 1, end: boundaries[index + 1] }))
+  return boundaries.slice(0, -1).map((boundary, index) => ({
+    start: boundary + 1,
+    end: boundaries[index + 1],
+  }))
 }
 
 function isBareIdentifier(text: string): boolean {
@@ -292,7 +286,7 @@ class ERBStrictLocalsCommentSyntaxVisitor extends BaseRuleVisitor<ERBStrictLocal
     if (hasError(node, "STRICT_LOCALS_DUPLICATE_DECLARATION_ERROR")) {
       this.addOffense(
         "Duplicate strict locals declaration. Rails only uses the first `<%# locals: (...) %>` declaration in a partial.",
-        node.location
+        node.location,
       )
     }
 
@@ -303,7 +297,7 @@ class ERBStrictLocalsCommentSyntaxVisitor extends BaseRuleVisitor<ERBStrictLocal
       this.addOffense(
         "Missing space after `locals:`. Rails Strict Locals require a space after the colon: `<%# locals: (...) %>`.",
         node.location,
-        this.contextFor(node, { type: "space-after-colon" })
+        this.contextFor(node, { type: "space-after-colon" }),
       )
     }
 
@@ -315,7 +309,7 @@ class ERBStrictLocalsCommentSyntaxVisitor extends BaseRuleVisitor<ERBStrictLocal
           ? "Strict locals declarations always need parentheses. Use `<%# locals: () %>` for a partial without locals."
           : `Strict locals parameters must be wrapped in parentheses. Use \`<%# locals: ${suggestedParameters(parameters)} %>\`.`,
         node.location,
-        this.contextFor(node, { type: "wrap-parameters" })
+        this.contextFor(node, { type: "wrap-parameters" }),
       )
 
       return
@@ -337,9 +331,9 @@ class ERBStrictLocalsCommentSyntaxVisitor extends BaseRuleVisitor<ERBStrictLocal
 
       if (rubyComment && looksLikeLocalsDeclaration(rubyComment)) {
         this.addOffense(
-          `Use \`<%#\` instead of \`${openingTag} #\` for strict locals comments. Only ERB comment syntax is recognized by Rails.`,
+          `Use \`<%#\` instead of \`${openingTag} #\` for strict locals comments. Only ERB comment syntax is recognized.`,
           node.location,
-          this.contextFor(node, { type: "erb-comment-tag" })
+          this.contextFor(node, { type: "erb-comment-tag" }),
         )
       }
 
@@ -357,7 +351,7 @@ class ERBStrictLocalsCommentSyntaxVisitor extends BaseRuleVisitor<ERBStrictLocal
       this.addOffense(
         "Use `locals:` (plural), not `local:`.",
         node.location,
-        this.contextFor(node, { type: "plural-locals" })
+        this.contextFor(node, { type: "plural-locals" }),
       )
 
       return
@@ -367,7 +361,7 @@ class ERBStrictLocalsCommentSyntaxVisitor extends BaseRuleVisitor<ERBStrictLocal
       this.addOffense(
         "Use `locals:` with a colon, not `locals()`. Correct format: `<%# locals: (...) %>`.",
         node.location,
-        this.contextFor(node, { type: "colon-after-locals" })
+        this.contextFor(node, { type: "colon-after-locals" }),
       )
 
       return
@@ -377,7 +371,7 @@ class ERBStrictLocalsCommentSyntaxVisitor extends BaseRuleVisitor<ERBStrictLocal
       this.addOffense(
         "Use `locals:` with a colon before the parentheses, not `locals (`.",
         node.location,
-        this.contextFor(node, { type: "colon-after-locals" })
+        this.contextFor(node, { type: "colon-after-locals" }),
       )
 
       return
@@ -394,7 +388,7 @@ class ERBStrictLocalsCommentSyntaxVisitor extends BaseRuleVisitor<ERBStrictLocal
       this.addOffense(
         "Unbalanced parentheses in the strict locals declaration. Add the missing closing `)`.",
         node.location,
-        this.contextFor(node, { type: "close-parameters" })
+        this.contextFor(node, { type: "close-parameters" }),
       )
 
       return true
@@ -404,7 +398,7 @@ class ERBStrictLocalsCommentSyntaxVisitor extends BaseRuleVisitor<ERBStrictLocal
       this.addOffense(
         "Remove the extra comma from the strict locals parameters.",
         node.location,
-        this.contextFor(node, { type: "remove-extra-commas" })
+        this.contextFor(node, { type: "remove-extra-commas" }),
       )
 
       return true
@@ -412,7 +406,7 @@ class ERBStrictLocalsCommentSyntaxVisitor extends BaseRuleVisitor<ERBStrictLocal
 
     this.addOffense(
       `Invalid Ruby syntax in the strict locals declaration: ${syntaxErrors[0].error_message}.`,
-      node.location
+      node.location,
     )
 
     return true
@@ -429,17 +423,17 @@ class ERBStrictLocalsCommentSyntaxVisitor extends BaseRuleVisitor<ERBStrictLocal
           this.addOffense(
             `Strict locals only support keyword arguments. Use \`${name}:\` instead of the positional argument \`${name}\`.`,
             local.location,
-            this.contextFor(node, { type: "keyword-argument", name })
+            this.contextFor(node, { type: "keyword-argument", name }),
           )
         } else if (error.type === "STRICT_LOCALS_SPLAT_ARGUMENT_ERROR") {
           this.addOffense(
             `Strict locals only support keyword arguments. The splat argument \`*${name}\` is not supported. Use \`**${name}\` to accept arbitrary keyword arguments.`,
-            local.location
+            local.location,
           )
         } else if (error.type === "STRICT_LOCALS_BLOCK_ARGUMENT_ERROR") {
           this.addOffense(
             `Strict locals only support keyword arguments. The block argument \`&${name}\` is not supported.`,
-            local.location
+            local.location,
           )
         }
       }
@@ -450,7 +444,7 @@ class ERBStrictLocalsCommentSyntaxVisitor extends BaseRuleVisitor<ERBStrictLocal
     return {
       node: node as Mutable<StrictLocalsCommentNode>,
       nodeType: "AST_ERB_CONTENT_NODE",
-      fix
+      fix,
     }
   }
 }
@@ -465,7 +459,7 @@ export class ERBStrictLocalsCommentSyntaxRule extends ParserRule<ERBStrictLocals
 
   get parserOptions() {
     return {
-      strict_locals: true
+      strict_locals: true,
     }
   }
 
@@ -477,15 +471,24 @@ export class ERBStrictLocalsCommentSyntaxRule extends ParserRule<ERBStrictLocals
     }
   }
 
-  check(result: ParseResult, context?: Partial<LintContext>): UnboundLintOffense<ERBStrictLocalsCommentSyntaxAutofixContext>[] {
-    const visitor = new ERBStrictLocalsCommentSyntaxVisitor(this.ruleName, context)
+  check(
+    result: ParseResult,
+    context?: Partial<LintContext>,
+  ): UnboundLintOffense<ERBStrictLocalsCommentSyntaxAutofixContext>[] {
+    const visitor = new ERBStrictLocalsCommentSyntaxVisitor(
+      this.ruleName,
+      context,
+    )
 
     visitor.visit(result.value)
 
     return visitor.offenses
   }
 
-  autofix(offense: LintOffense<ERBStrictLocalsCommentSyntaxAutofixContext>, result: ParseResult): ParseResult | null {
+  autofix(
+    offense: LintOffense<ERBStrictLocalsCommentSyntaxAutofixContext>,
+    result: ParseResult,
+  ): ParseResult | null {
     if (!offense.autofixContext) return null
 
     const { node, fix } = offense.autofixContext

--- a/javascript/packages/linter/src/rules/erb-strict-locals-required.ts
+++ b/javascript/packages/linter/src/rules/erb-strict-locals-required.ts
@@ -1,13 +1,14 @@
 import { ParserRule } from "../types.js"
-import { Location, ERBStrictLocalsNode, RubyReferenceCollector, createLiteral, isProbableLocal } from "@herb-tools/core"
-import { strictLocalsDeclaration } from "@herb-tools/analysis"
 import { BaseRuleVisitor } from "./rule-utils.js"
+import { Location, ERBStrictLocalsNode, RubyReferenceCollector } from "@herb-tools/core"
 
 import { isPartialFile } from "./file-utils.js"
+import { strictLocalsDeclaration } from "@herb-tools/analysis"
+import { createLiteral, isProbableLocal } from "@herb-tools/core"
 
-import type { BaseAutofixContext, UnboundLintOffense, LintOffense, LintContext, FullRuleConfig } from "../types.js"
 import type { ParseResult, DocumentNode } from "@herb-tools/core"
 import type { InferredSignature, StrictLocal } from "@herb-tools/analysis"
+import type { BaseAutofixContext, UnboundLintOffense, LintOffense, LintContext, FullRuleConfig } from "../types.js"
 
 const LOCAL_ASSIGNS = "local_assigns"
 

--- a/javascript/packages/linter/src/rules/strict-locals-utils.ts
+++ b/javascript/packages/linter/src/rules/strict-locals-utils.ts
@@ -1,0 +1,9 @@
+export function extractRubyCommentContent(content: string): string | null {
+  const match = content.match(/^\s*#\s*(.*)$/)
+
+  return match ? match[1].trim() : null
+}
+
+export function looksLikeLocalsDeclaration(content: string): boolean {
+  return /^locals?\b/.test(content) && /[(:)]/.test(content)
+}

--- a/javascript/packages/linter/test/rules/erb-comment-syntax.test.ts
+++ b/javascript/packages/linter/test/rules/erb-comment-syntax.test.ts
@@ -29,6 +29,15 @@ describe("ERBCommentSyntax", () => {
     `)
   })
 
+  test("shouldn't flag strict locals declaration since erb-strict-locals-comment-syntax covers it", () => {
+    expectNoOffenses(dedent`
+      <% # locals: () %>
+      <% # locals: (user:) %>
+      <% # locals: (user: "default") %>
+      <% # locals: (user: "default", **attributes) %>
+    `)
+  })
+
   test("when the ERB comment syntax is incorrect", () => {
     expectError("Use `<%#` instead of `<% #`. Ruby comments immediately after ERB tags can cause parsing issues.")
 

--- a/javascript/packages/linter/test/rules/erb-strict-locals-comment-syntax.test.ts
+++ b/javascript/packages/linter/test/rules/erb-strict-locals-comment-syntax.test.ts
@@ -172,8 +172,8 @@ describe("ERBStrictLocalsCommentSyntaxRule", () => {
   })
 
   test("flags Ruby comment syntax for strict locals in execution tags", () => {
-    expectError("Use `<%#` instead of `<% #` for strict locals comments. Only ERB comment syntax is recognized by Rails.")
-    expectError("Use `<%#` instead of `<%- #` for strict locals comments. Only ERB comment syntax is recognized by Rails.")
+    expectError("Use `<%#` instead of `<% #` for strict locals comments. Only ERB comment syntax is recognized.")
+    expectError("Use `<%#` instead of `<%- #` for strict locals comments. Only ERB comment syntax is recognized.")
 
     assertOffenses(dedent`
       <% # locals: (user:) %>

--- a/javascript/packages/linter/test/rules/erb-strict-locals-comment-syntax.test.ts
+++ b/javascript/packages/linter/test/rules/erb-strict-locals-comment-syntax.test.ts
@@ -194,16 +194,12 @@ describe("ERBStrictLocalsCommentSyntaxRule", () => {
     expectNoOffenses(`<%# locals: (user:) %>`, { fileName: "_partial.html.erb" })
   })
 
-  test("warns when strict locals used in non-partial files", () => {
-    expectError("Strict locals (`locals:`) only work in partials (files starting with `_`). This declaration will be ignored.")
-
-    assertOffenses(`<%# locals: (user:) %>`, { fileName: "app/views/users/show.html.erb" })
+  test("leaves non-partial enforcement to the Action View rule", () => {
+    expectNoOffenses(`<%# locals: (user:) %>`, { fileName: "app/views/users/show.html.erb" })
   })
 
-  test("warns when strict locals used in layout files", () => {
-    expectError("Strict locals (`locals:`) only work in partials (files starting with `_`). This declaration will be ignored.")
-
-    assertOffenses(`<%# locals: (user:) %>`, { fileName: "app/views/layouts/application.html.erb" })
+  test("leaves layout enforcement to the Action View rule", () => {
+    expectNoOffenses(`<%# locals: (user:) %>`, { fileName: "app/views/layouts/application.html.erb" })
   })
 
   test("does not warn when filename is not provided (unknown context)", () => {


### PR DESCRIPTION
A strict locals declaration in a non-partial file was reported twice. `erb-strict-locals-comment-syntax` carried its own partial-only check, and `actionview-strict-locals-partial-only` reports the same thing for Action View projects, so a single `<%# locals: (user:) %>` in `app/views/users/show.html.erb` produced two offenses that say the same thing in different words.

`erb-strict-locals-comment-syntax` is about the syntax of the declaration, so the partial-only check is dropped from it and the Rails-specific diagnostic stays in `actionview-strict-locals-partial-only`, where it is already framework-gated and autocorrectable.

The same overlap existed one level down. `<% # locals: (user:) %>` was flagged by both `erb-comment-syntax`, for the generic "use `<%#` instead of `<% #`" reason, and by `erb-strict-locals-comment-syntax`, which has a dedicated message explaining that only ERB comment syntax is recognized for strict locals. `erb-comment-syntax` now skips content that looks like a locals declaration and leaves it to the more specific rule. The two helpers that recognize such a declaration, `extractRubyCommentContent` and `looksLikeLocalsDeclaration`, move to a shared `strict-locals-utils.ts` so both rules use the same definition.

Resolves #2236