### PR TITLE
Engine: Compute relative file paths lazily

### DIFF
--- a/lib/herb/engine/visitor_context.rb
+++ b/lib/herb/engine/visitor_context.rb
@@ -31,7 +31,6 @@ module Herb
 
       attr_reader :file_path #: Pathname?
       attr_reader :project_path #: Pathname
-      attr_reader :relative_file_path #: String
       attr_reader :options #: Hash[Symbol, untyped]
       attr_reader :data #: Hash[Symbol, untyped]
 
@@ -39,11 +38,15 @@ module Herb
       def initialize(file_path: nil, project_path: nil, options: {}, **data)
         @file_path = self.class.coerce_file_path(file_path)
         @project_path = self.class.coerce_project_path(project_path)
-        @relative_file_path = self.class.derive_relative_file_path(@file_path, @project_path)
         @options = options.dup.freeze
         @data = data.tap { |values| values[:origin] ||= Origin.new }.freeze
 
         freeze
+      end
+
+      #: () -> String
+      def relative_file_path
+        self.class.derive_relative_file_path(file_path, project_path)
       end
 
       #: () -> Herb::Engine::Origin

--- a/lib/herb/engine/visitor_context.rb
+++ b/lib/herb/engine/visitor_context.rb
@@ -38,6 +38,7 @@ module Herb
       def initialize(file_path: nil, project_path: nil, options: {}, **data)
         @file_path = self.class.coerce_file_path(file_path)
         @project_path = self.class.coerce_project_path(project_path)
+        @relative_file_path_cache = [] #: Array[String]
         @options = options.dup.freeze
         @data = data.tap { |values| values[:origin] ||= Origin.new }.freeze
 
@@ -46,7 +47,7 @@ module Herb
 
       #: () -> String
       def relative_file_path
-        self.class.derive_relative_file_path(file_path, project_path)
+        @relative_file_path_cache[0] ||= self.class.derive_relative_file_path(file_path, project_path)
       end
 
       #: () -> Herb::Engine::Origin

--- a/sig/herb/engine/visitor_context.rbs
+++ b/sig/herb/engine/visitor_context.rbs
@@ -27,14 +27,15 @@ module Herb
 
       attr_reader project_path: Pathname
 
-      attr_reader relative_file_path: String
-
       attr_reader options: Hash[Symbol, untyped]
 
       attr_reader data: Hash[Symbol, untyped]
 
       # : (?file_path: (String | Pathname)?, ?project_path: (String | Pathname)?, ?options: Hash[Symbol, untyped], **untyped) -> void
       def initialize: (?file_path: (String | Pathname)?, ?project_path: (String | Pathname)?, ?options: Hash[Symbol, untyped], **untyped) -> void
+
+      # : () -> String
+      def relative_file_path: () -> String
 
       # : () -> Herb::Engine::Origin
       def origin: () -> Herb::Engine::Origin

--- a/test/engine/visitor_context_test.rb
+++ b/test/engine/visitor_context_test.rb
@@ -44,6 +44,26 @@ module Engine
       assert_equal "/abs/x.erb", context(file_path: "/abs/x.erb", project_path: "relative").relative_file_path
     end
 
+    test "the relative file path is derived lazily" do
+      context_class = Class.new(Herb::Engine::VisitorContext) do
+        class << self
+          attr_accessor :derivations
+
+          def derive_relative_file_path(...)
+            self.derivations += 1
+            super
+          end
+        end
+      end
+      context_class.derivations = 0
+
+      subject = context_class.new(file_path: "app/x.erb", project_path: "/proj")
+
+      assert_equal 0, context_class.derivations
+      assert_equal "app/x.erb", subject.relative_file_path
+      assert_equal 1, context_class.derivations
+    end
+
     test "the file path is not absolutized" do
       assert_equal "test.erb", context(file_path: "test.erb").file_path.to_s
     end

--- a/test/engine/visitor_context_test.rb
+++ b/test/engine/visitor_context_test.rb
@@ -61,6 +61,7 @@ module Engine
 
       assert_equal 0, context_class.derivations
       assert_equal "app/x.erb", subject.relative_file_path
+      assert_equal "app/x.erb", subject.relative_file_path
       assert_equal 1, context_class.derivations
     end
 


### PR DESCRIPTION
## What

Compute `VisitorContext#relative_file_path` on demand instead of eagerly during
context construction.

`Herb::Engine` creates a context for every template, but the relative path is
primarily consumed by diagnostics, overlays, debug output, and visitors that
explicitly request it. Valid templates compiled without those features
previously still paid for `Pathname#absolute?`, path joining,
`Pathname#relative_path_from`, and `#to_s`.

The public behavior is unchanged: `relative_file_path`, context hash access,
merging, inspection, and serialization still return the same value. A
regression test verifies that derivation does not happen during initialization.

Split out of #1872.

## Benchmark

Measured `Herb::Engine` compilation over
[`marcoroth/herb-corpus`](https://github.com/marcoroth/herb-corpus) at
`5560d823`, using Ruby 4.0.2.

The benchmark compiled the 36,046 corpus templates accepted by both variants
with a filename and project path, `escape: true`, no visitors, non-strict
parsing, and Ruby validation disabled. Results are medians of three full-corpus
runs:

| metric | `main` (`cc3eb8bc`) | this branch | delta |
| --- | ---: | ---: | ---: |
| allocated objects | 88,907,732 | 79,115,256 | **-9,792,476 (-11.0%)** |
| wall time | 9.21s | 7.94s | **-13.8%** |

Generated Ruby was byte-identical in every run
(`aee36910bcd428792272440a7d39cabcd14c641544c6e35e2b610a14fbd9892b`).
