### PR TITLE
Language Service: Respect configured `framework` in Action View features

### DIFF
--- a/javascript/packages/language-server/src/project.ts
+++ b/javascript/packages/language-server/src/project.ts
@@ -1,4 +1,5 @@
 import { Config } from "@herb-tools/config"
+
 import { Herb, HerbBackend } from "@herb-tools/node-wasm"
 import { ProjectIndex } from "@herb-tools/analysis/node"
 
@@ -12,6 +13,7 @@ import { CompletionProvider, ReferencesProvider } from "@herb-tools/language-ser
 
 import { version } from "../package.json"
 
+import type { Framework } from "@herb-tools/config"
 import type { Connection } from "vscode-languageserver/node"
 import type { UserSettings, PersonalHerbSettings } from "./user_settings"
 import type { Capabilities } from "./capabilities"
@@ -86,13 +88,19 @@ export class Project {
     await this.index.indexAll()
   }
 
+  get framework(): Framework | undefined {
+    return this.config?.config?.framework
+  }
+
   async loadConfig() {
     this.config = await this.readConfig()
 
     this.codeActionProvider.setConfig(this.config)
     this.autofixService.setConfig(this.config)
     this.linterService.setConfig(this.config)
-    this.completionProvider.setFramework(this.config?.config?.framework)
+    this.completionProvider.setConfig(this.config)
+    this.referencesProvider.setConfig(this.config)
+
     this.linterService.rebuildLinter()
   }
 

--- a/javascript/packages/language-server/src/server.ts
+++ b/javascript/packages/language-server/src/server.ts
@@ -212,7 +212,9 @@ export class Server {
 
       if (!document) return null
 
-      return this.session.hoverProvider.getHover(document, params.position) ?? this.session.definitionProvider.getHover(document, params.position)
+      const framework = this.session.projects.get(params.textDocument.uri)?.framework
+
+      return this.session.hoverProvider.getHover(document, params.position, { framework }) ?? this.session.definitionProvider.getHover(document, params.position, { framework })
     })
 
     this.connection.onCompletion((params: CompletionParams) => {
@@ -244,8 +246,8 @@ export class Server {
       )
 
       const autofixCodeActions = await project.codeActionProvider.autofixCodeActions(params, document)
-      const rewriteCodeActions = this.session.rewriteCodeActionProvider.getCodeActions(document, params.range)
-      const extractCodeActions = this.session.extractCodeActionProvider.getCodeActions(document, params.range)
+      const rewriteCodeActions = this.session.rewriteCodeActionProvider.getCodeActions(document, params.range, { framework: project.framework })
+      const extractCodeActions = this.session.extractCodeActionProvider.getCodeActions(document, params.range, { framework: project.framework })
 
       return autofixCodeActions.concat(linterDisableCodeActions).concat(rewriteCodeActions).concat(extractCodeActions)
     })
@@ -263,7 +265,8 @@ export class Server {
 
       if (!document) return []
 
-      const links = this.session.definitionProvider.getDefinition(document, params.position)
+      const framework = this.session.projects.get(params.textDocument.uri)?.framework
+      const links = this.session.definitionProvider.getDefinition(document, params.position, { framework })
 
       if (this.session.capabilities.supportsDefinitionLinks) return links
 
@@ -283,7 +286,9 @@ export class Server {
 
       if (!document) return []
 
-      return this.session.documentSymbolProvider.getDocumentSymbols(document)
+      const framework = this.session.projects.get(params.textDocument.uri)?.framework
+
+      return this.session.documentSymbolProvider.getDocumentSymbols(document, { framework })
     })
 
     this.connection.onFoldingRanges((params: FoldingRangeParams) => {

--- a/javascript/packages/language-server/test/project.test.ts
+++ b/javascript/packages/language-server/test/project.test.ts
@@ -56,6 +56,50 @@ describe("Project", () => {
     return new Project(connection, root, shared)
   }
 
+  describe("framework", () => {
+    test("exposes the framework a checked-in config sets", async () => {
+      writeFileSync(join(root, ".herb.yml"), "framework: actionview\n")
+
+      const project = projectFor()
+      await project.loadConfig()
+
+      expect(project.framework).toBe("actionview")
+    })
+
+    test("is undefined when the project has no config file", async () => {
+      const project = projectFor()
+      await project.loadConfig()
+
+      expect(project.framework).toBeUndefined()
+    })
+
+    test("picks up a framework that is added to the config while the server runs", async () => {
+      const project = projectFor()
+      await project.loadConfig()
+
+      expect(project.framework).toBeUndefined()
+
+      writeFileSync(join(root, ".herb.yml"), "framework: actionview\n")
+      await project.refreshConfig()
+
+      expect(project.framework).toBe("actionview")
+    })
+
+    test("picks up a framework that changes while the server runs", async () => {
+      writeFileSync(join(root, ".herb.yml"), "framework: actionview\n")
+
+      const project = projectFor()
+      await project.loadConfig()
+
+      expect(project.framework).toBe("actionview")
+
+      writeFileSync(join(root, ".herb.yml"), "framework: sinatra\n")
+      await project.refreshConfig()
+
+      expect(project.framework).toBe("sinatra")
+    })
+  })
+
   describe("settingsFor", () => {
     test("lets a checked-in config turn the formatter on when the user never opted in", async () => {
       writeFileSync(join(root, ".herb.yml"), "formatter:\n  enabled: true\n")

--- a/javascript/packages/language-service/package.json
+++ b/javascript/packages/language-service/package.json
@@ -31,6 +31,7 @@
   },
   "dependencies": {
     "@herb-tools/analysis": "0.10.3",
+    "@herb-tools/config": "0.10.3",
     "@herb-tools/core": "0.10.3",
     "@herb-tools/printer": "0.10.3",
     "@herb-tools/rewriter": "0.10.3",

--- a/javascript/packages/language-service/src/completion_provider.ts
+++ b/javascript/packages/language-service/src/completion_provider.ts
@@ -1,24 +1,18 @@
-import {
-  Command,
-  CompletionItem,
-  CompletionItemKind,
-  CompletionList,
-  InsertTextFormat,
-  MarkupKind,
-  Position,
-  Range,
-  TextEdit,
-} from "vscode-languageserver-types"
 import { TextDocument } from "vscode-languageserver-textdocument"
-
-import { Visitor, RubyReferenceCollector, isERBContentNode, isERBOutputNode, isHTMLOpenTagNode, isHTMLTextNode, isValidLocalName, getHelperEntries, HELPER_REGISTRY, HTML_NAMED_CHARACTER_REFERENCES, HTML_ELEMENTS } from "@herb-tools/core"
-import { partialNameForFile, strictLocalsDeclaration, templateNameForFile } from "@herb-tools/analysis"
 import { ParserService } from "./parser_service"
+import { Visitor, RubyReferenceCollector } from "@herb-tools/core"
+import { Command, CompletionItem, CompletionItemKind, CompletionList, InsertTextFormat, MarkupKind, Position, Range, TextEdit } from "vscode-languageserver-types"
+
 import { getBlockArgumentCompletions } from "./language-service"
 import { nodeToRange, isPositionInRange, rangeSize, lspPosition } from "./range_utils"
+import { partialNameForFile, strictLocalsDeclaration, templateNameForFile } from "@herb-tools/analysis"
+import { isERBContentNode, isERBOutputNode, isHTMLOpenTagNode, isHTMLTextNode, isValidLocalName, getHelperEntries } from "@herb-tools/core"
 
+import type { ProjectConfig } from "./types.js"
 import type { Node, ERBContentNode, HTMLOpenTagNode, HTMLTextNode, HelperEntry, HelperOption, RubyReference } from "@herb-tools/core"
 import type { PartialIndex, PartialDeclaration } from "@herb-tools/analysis"
+
+import { HELPER_REGISTRY, HTML_NAMED_CHARACTER_REFERENCES, HTML_ELEMENTS } from "@herb-tools/core"
 
 const HTML_OPEN_TAG_PATTERN = /<(\w*)$/
 const CHARACTER_REFERENCE_PATTERN = /&([a-zA-Z]*)$/
@@ -150,7 +144,7 @@ export class CompletionProvider {
   private parserService: ParserService
   private partials?: PartialIndex
   private relativePathFor: (uri: string) => string | null
-  private framework?: string
+  private config?: ProjectConfig
 
   constructor(
     parserService: ParserService,
@@ -162,8 +156,8 @@ export class CompletionProvider {
     this.relativePathFor = relativePathFor
   }
 
-  setFramework(framework?: string) {
-    this.framework = framework
+  setConfig(config?: ProjectConfig) {
+    this.config = config
   }
 
   getCompletions(document: TextDocument, position: Position): CompletionList | null {
@@ -228,6 +222,7 @@ export class CompletionProvider {
   }
 
   private getERBCompletions(node: ERBContentNode, position: Position, textAfterCursor: string, document: TextDocument): CompletionList | null {
+    if (this.config?.framework !== "actionview") return null
     if (!node.content) return null
 
     const contentText = node.content.value
@@ -261,8 +256,7 @@ export class CompletionProvider {
         : this.getRenderKeywordCompletions(argument, position, document)
     }
 
-    const blockArguments = getBlockArgumentCompletions(document, position, { framework: this.framework })
-
+    const blockArguments = getBlockArgumentCompletions(document, position, this.config)
     if (blockArguments) return blockArguments
 
     const tagDotMatch = textBeforeCursor.match(TAG_DOT_PATTERN)

--- a/javascript/packages/language-service/src/definition_provider.ts
+++ b/javascript/packages/language-service/src/definition_provider.ts
@@ -10,6 +10,7 @@ import * as path from "./posix_path"
 import { getTagName, isERBStrictLocalsNode, isHTMLElementNode, isPureWhitespaceNode } from "@herb-tools/core"
 
 import type { TextDocument } from "vscode-languageserver-textdocument"
+import type { FrameworkOptions } from "./types.js"
 import type { DocumentNode, ERBRenderNode, Node } from "@herb-tools/core"
 
 const VIEWS_DIRECTORY = "/app/views/"
@@ -50,7 +51,9 @@ export class DefinitionProvider {
     this.viewRootFor = viewRootFor
   }
 
-  getDefinition(document: TextDocument, position: Position): LocationLink[] {
+  getDefinition(document: TextDocument, position: Position, options?: FrameworkOptions): LocationLink[] {
+    if (options?.framework !== "actionview") return []
+
     const reference = this.referenceAt(document, position)
 
     if (!reference || !this.isStatic(reference)) return []
@@ -65,7 +68,9 @@ export class DefinitionProvider {
     }))
   }
 
-  getHover(document: TextDocument, position: Position): Hover | null {
+  getHover(document: TextDocument, position: Position, options?: FrameworkOptions): Hover | null {
+    if (options?.framework !== "actionview") return null
+
     const reference = this.referenceAt(document, position)
 
     if (!reference) return null

--- a/javascript/packages/language-service/src/document_symbol_provider.ts
+++ b/javascript/packages/language-service/src/document_symbol_provider.ts
@@ -7,12 +7,14 @@ import { getAttributeName } from "@herb-tools/core"
 import { elementName, erbLabel } from "./node_labels"
 
 import type { NodeLabelOptions } from "./node_labels"
+import type { FrameworkOptions } from "./types.js"
 
 import type { Range } from "vscode-languageserver-types"
 import type { TextDocument } from "vscode-languageserver-textdocument"
 import type { DocumentNode, ERBContentNode, ERBNode, ERBRenderNode, HTMLAttributeNode, HTMLElementNode, Node } from "@herb-tools/core"
 
 const PARSER_OPTIONS = { render_nodes: true, action_view_helpers: true } as const
+const PLAIN_PARSER_OPTIONS = { render_nodes: true } as const
 const QUOTE = /^["']|["']$/g
 
 const LABEL_OPTIONS: NodeLabelOptions = {
@@ -146,8 +148,9 @@ export class DocumentSymbolProvider {
     this.parserService = parserService
   }
 
-  getDocumentSymbols(document: TextDocument, options: NodeLabelOptions = {}): DocumentSymbol[] {
-    const result = this.parserService.parseContent(document.getText(), PARSER_OPTIONS)
+  getDocumentSymbols(document: TextDocument, options: NodeLabelOptions & FrameworkOptions = {}): DocumentSymbol[] {
+    const parserOptions = options.framework === "actionview" ? PARSER_OPTIONS : PLAIN_PARSER_OPTIONS
+    const result = this.parserService.parseContent(document.getText(), parserOptions)
     const collector = new DocumentSymbolCollector({ ...LABEL_OPTIONS, ...options })
 
     collector.visit(result.value as DocumentNode)

--- a/javascript/packages/language-service/src/extract_code_action_provider.ts
+++ b/javascript/packages/language-service/src/extract_code_action_provider.ts
@@ -3,6 +3,8 @@ import * as path from "./posix_path"
 import { CodeAction, CodeActionKind, CreateFile, OptionalVersionedTextDocumentIdentifier, Range, TextDocumentEdit, TextEdit, WorkspaceEdit } from "vscode-languageserver-types"
 
 import { ExtractPartialAnalyzer } from "./extract_partial_analyzer"
+
+import type { FrameworkOptions } from "./types.js"
 import { ParserService } from "./parser_service"
 import type { ExtractedLocal } from "./extract_partial_analyzer"
 import { pathFromUri, uriFromPath } from "./uri"
@@ -64,7 +66,8 @@ export class ExtractCodeActionProvider {
     this.fileExists = fileExists
   }
 
-  getCodeActions(document: TextDocument, requestedRange: Range): CodeAction[] {
+  getCodeActions(document: TextDocument, requestedRange: Range, options?: FrameworkOptions): CodeAction[] {
+    if (options?.framework !== "actionview") return []
     if (!this.capabilities.supportsResourceCreation) return []
     if (!this.isTemplate(document.uri)) return []
 

--- a/javascript/packages/language-service/src/hover_provider.ts
+++ b/javascript/packages/language-service/src/hover_provider.ts
@@ -9,6 +9,7 @@ import { ParserService } from "./parser_service"
 import { lspPosition, isPositionInRange, rangeSize, hasSourceLocation } from "./range_utils"
 
 import type { Node, HTMLElementNode, ERBOpenTagNode, ERBContentNode, HTMLCharacterReference, HelperEntry } from "@herb-tools/core"
+import type { FrameworkOptions } from "./types.js"
 
 class ActionViewElementCollector extends Visitor {
   public elements: { node: HTMLElementNode; openTag: ERBOpenTagNode; range: Range }[] = []
@@ -133,7 +134,11 @@ export class HoverProvider {
     this.baseDir = baseDir
   }
 
-  getHover(textDocument: TextDocument, position: Position): Hover | null {
+  getHover(textDocument: TextDocument, position: Position, options?: FrameworkOptions): Hover | null {
+    if (options?.framework !== "actionview") {
+      return this.getEntityHover(textDocument, position)
+    }
+
     const parseResult = this.parserService.parseContent(textDocument.getText(), {
       action_view_helpers: true,
       track_whitespace: true,

--- a/javascript/packages/language-service/src/language-service.ts
+++ b/javascript/packages/language-service/src/language-service.ts
@@ -7,7 +7,8 @@ import { getLanguageService as getUpstreamLanguageService } from "vscode-html-la
 import { TOKEN_LIST_ATTRIBUTES, getHelper } from "@herb-tools/core"
 
 import type { ParseOptions } from "@herb-tools/core"
-import type { LanguageServiceOptions } from "./types.js"
+import type { LanguageServiceOptions, ProjectConfig } from "./types.js"
+import type { Framework } from "@herb-tools/config"
 import type { TextDocument } from "vscode-languageserver-textdocument"
 import type { Position, Range, CompletionList, CompletionItem, Hover, TextEdit, DocumentHighlight, DocumentLink, SymbolInformation, DocumentSymbol, FoldingRange, SelectionRange, WorkspaceEdit, IHTMLDataProvider } from "vscode-html-languageservice"
 import type { LanguageService, HTMLDocument, HTMLFormatConfiguration, CompletionConfiguration, HoverSettings, DocumentContext } from "vscode-html-languageservice"
@@ -174,7 +175,7 @@ function currentERBTag(source: string, offset: number): string | null {
   return source.slice(opening, offset)
 }
 
-export function getBlockArgumentCompletions(document: TextDocument, position: Position, options?: { framework?: string }): CompletionList | null {
+export function getBlockArgumentCompletions(document: TextDocument, position: Position, config?: ProjectConfig): CompletionList | null {
   const source = document.getText()
   const offset = document.offsetAt(position)
   const tag = currentERBTag(source, offset)
@@ -186,7 +187,7 @@ export function getBlockArgumentCompletions(document: TextDocument, position: Po
 
   const typed = block[1] !== undefined
   const closed = typed && hasClosingPipe(source, offset)
-  const suggestions = helperSuggestions(tag, options?.framework) ?? iterationSuggestions(tag)
+  const suggestions = helperSuggestions(tag, config?.framework) ?? iterationSuggestions(tag)
 
   if (!suggestions) return null
 
@@ -221,7 +222,7 @@ interface BlockArgumentSuggestion {
   documentation?: string
 }
 
-function helperSuggestions(tag: string, framework?: string): BlockArgumentSuggestion[] | null {
+function helperSuggestions(tag: string, framework?: Framework): BlockArgumentSuggestion[] | null {
   if (framework !== "actionview") return null
 
   const call = tag.match(/^<%=?-?\s*([a-z_][A-Za-z0-9_]*)/)

--- a/javascript/packages/language-service/src/references_provider.ts
+++ b/javascript/packages/language-service/src/references_provider.ts
@@ -1,4 +1,5 @@
 import { isPartialPath } from "@herb-tools/analysis"
+
 import { join } from "./posix_path"
 import { uriFromPath } from "./uri"
 
@@ -6,6 +7,7 @@ import { Location, Position, Range } from "vscode-languageserver-types"
 import { TextDocument } from "vscode-languageserver-textdocument"
 import { DefinitionProvider } from "./definition_provider"
 
+import type { ProjectConfig } from "./types.js"
 import type { PartialReference } from "@herb-tools/language-service"
 import type { ProjectIndex } from "@herb-tools/analysis/node"
 
@@ -21,6 +23,7 @@ export class ReferencesProvider {
   private index: ProjectIndex
   private documents: OpenDocuments
   private read: (filePath: string) => string | null
+  private config?: ProjectConfig
 
   constructor(
     definitionProvider: DefinitionProvider,
@@ -34,7 +37,13 @@ export class ReferencesProvider {
     this.read = read
   }
 
+  setConfig(config?: ProjectConfig) {
+    this.config = config
+  }
+
   getReferences(document: TextDocument, position: Position, includeDeclaration: boolean): Location[] {
+    if (this.config?.framework !== "actionview") return []
+
     const callers = this.index.callers
     if (!callers) return []
 

--- a/javascript/packages/language-service/src/rewrite_code_action_provider.ts
+++ b/javascript/packages/language-service/src/rewrite_code_action_provider.ts
@@ -3,12 +3,13 @@ import { TextDocument } from "vscode-languageserver-textdocument"
 
 import { Visitor } from "@herb-tools/core"
 import { IdentityPrinter } from "@herb-tools/printer"
-import { ActionViewTagHelperToHTMLRewriter, HTMLToActionViewTagHelperRewriter } from "@herb-tools/rewriter"
+import { ActionViewTagHelperToHTMLRewriter, HTMLToActionViewTagHelperRewriter, cloneNode } from "@herb-tools/rewriter"
 import { isERBOpenTagNode, isHTMLOpenTagNode, HELPER_BY_SOURCE, findPreferredHelperForTag } from "@herb-tools/core"
 import { ParserService } from "./parser_service"
 import { nodeToRange } from "./range_utils"
 
 import type { Node, HTMLElementNode } from "@herb-tools/core"
+import type { FrameworkOptions } from "./types.js"
 
 interface CollectedElement {
   node: HTMLElementNode
@@ -49,7 +50,9 @@ export class RewriteCodeActionProvider {
     this.baseDir = baseDir
   }
 
-  getCodeActions(document: TextDocument, requestedRange: Range): CodeAction[] {
+  getCodeActions(document: TextDocument, requestedRange: Range, options?: FrameworkOptions): CodeAction[] {
+    if (options?.framework !== "actionview") return []
+
     const parseResult = this.parserService.parseContent(document.getText(), {
       action_view_helpers: true,
       track_whitespace: true,
@@ -94,7 +97,7 @@ export class RewriteCodeActionProvider {
     if (parseResult.failed) return null
 
     const rewriter = new ActionViewTagHelperToHTMLRewriter()
-    const rewrittenNode = rewriter.rewrite(parseResult.value as Node, { baseDir: this.baseDir, shallow: true })
+    const rewrittenNode = rewriter.rewrite(cloneNode(parseResult.value as Node), { baseDir: this.baseDir, shallow: true })
 
     const rewrittenText = IdentityPrinter.print(rewrittenNode)
 
@@ -130,7 +133,7 @@ export class RewriteCodeActionProvider {
     if (parseResult.failed) return null
 
     const rewriter = new HTMLToActionViewTagHelperRewriter()
-    const rewrittenNode = rewriter.rewrite(parseResult.value as Node, { baseDir: this.baseDir, shallow: true })
+    const rewrittenNode = rewriter.rewrite(cloneNode(parseResult.value as Node), { baseDir: this.baseDir, shallow: true })
 
     const rewrittenText = IdentityPrinter.print(rewrittenNode)
 

--- a/javascript/packages/language-service/src/types.ts
+++ b/javascript/packages/language-service/src/types.ts
@@ -1,10 +1,17 @@
 import type { HerbBackend } from "@herb-tools/core"
 import type { ParseOptions } from "@herb-tools/core"
 import type { LanguageServiceOptions as UpstreamLanguageServiceOptions } from "vscode-html-languageservice"
+import type { Config, Framework } from "@herb-tools/config"
+
+export type ProjectConfig = Pick<Config, "framework">
+
+export interface FrameworkOptions {
+  framework?: Framework
+}
 
 export interface LanguageServiceOptions extends UpstreamLanguageServiceOptions {
   herb?: HerbBackend
   herbParseOptions?: ParseOptions
   tokenListAttributes?: string[]
-  framework?: string
+  framework?: Framework
 }

--- a/javascript/packages/language-service/test/completion_provider.test.ts
+++ b/javascript/packages/language-service/test/completion_provider.test.ts
@@ -22,6 +22,7 @@ describe("CompletionProvider", () => {
     await Herb.load()
     const parserService = new ParserService(Herb)
     service = new CompletionProvider(parserService)
+    service.setConfig({ framework: "actionview" })
   })
 
   function createDocument(content: string): TextDocument {
@@ -633,6 +634,8 @@ describe("CompletionProvider", () => {
 
         return path.startsWith("..") ? null : path
       })
+
+      partialService.setConfig({ framework: "actionview" })
     })
 
     afterAll(() => {
@@ -1335,7 +1338,7 @@ describe("CompletionProvider", () => {
 
     beforeAll(() => {
       actionViewService = new CompletionProvider(new ParserService(Herb))
-      actionViewService.setFramework("actionview")
+      actionViewService.setConfig({ framework: "actionview" })
     })
 
     function labelsFor(content: string): string[] {
@@ -1358,10 +1361,37 @@ describe("CompletionProvider", () => {
     })
 
     it("stays quiet when the project isn't an Action View project", () => {
+      const plainService = new CompletionProvider(new ParserService(Herb))
       const document = createDocument("<%= form_with model: @user do ")
-      const result = service.getCompletions(document, Position.create(0, 29))
+      const result = plainService.getCompletions(document, Position.create(0, 29))
 
       expect(result ? result.items.map(item => item.label) : []).not.toContain("|form|")
+    })
+  })
+  describe("framework scoping", () => {
+    function labelsFrom(provider: CompletionProvider, content: string): string[] {
+      const document = createDocument(content)
+      const result = provider.getCompletions(document, Position.create(0, content.length))
+
+      return result ? result.items.map(item => item.label) : []
+    }
+
+    it("offers helper completions for an Action View project", () => {
+      expect(labelsFrom(service, "<%= link").length).toBeGreaterThan(0)
+    })
+
+    it("offers no helper completions when the framework is not Action View", () => {
+      const provider = new CompletionProvider(new ParserService(Herb))
+      provider.setConfig({ framework: "sinatra" })
+
+      expect(labelsFrom(provider, "<%= link")).toEqual([])
+    })
+
+    it("still completes HTML elements when the framework is not Action View", () => {
+      const provider = new CompletionProvider(new ParserService(Herb))
+      provider.setConfig({ framework: "sinatra" })
+
+      expect(labelsFrom(provider, "<di").length).toBeGreaterThan(0)
     })
   })
 })

--- a/javascript/packages/language-service/test/definition_provider.test.ts
+++ b/javascript/packages/language-service/test/definition_provider.test.ts
@@ -5,6 +5,8 @@ import { Herb } from "@herb-tools/node-wasm"
 
 import { DefinitionProvider } from "../src/definition_provider"
 import { ParserService } from "@herb-tools/language-service"
+
+import type { FrameworkOptions } from "../src/types"
 const VIEW_URI = "file:///project/app/views/events/show.html.erb"
 
 describe("DefinitionProvider", () => {
@@ -29,11 +31,11 @@ describe("DefinitionProvider", () => {
     )
   }
 
-  function definitions(service: DefinitionProvider, content: string, target: string, uri = VIEW_URI) {
+  function definitions(service: DefinitionProvider, content: string, target: string, uri = VIEW_URI, options: FrameworkOptions = { framework: "actionview" }) {
     const document = TextDocument.create(uri, "erb", 1, content)
     const position = document.positionAt(content.indexOf(target) + 1)
 
-    return service.getDefinition(document, position)
+    return service.getDefinition(document, position, options)
   }
 
   function uris(service: DefinitionProvider, content: string, target: string, uri = VIEW_URI) {
@@ -183,7 +185,7 @@ describe("DefinitionProvider", () => {
     function hover(service: DefinitionProvider, content: string, target: string, uri = VIEW_URI) {
       const document = TextDocument.create(uri, "erb", 1, content)
       const position = document.positionAt(content.indexOf(target) + 1)
-      const result = service.getHover(document, position)
+      const result = service.getHover(document, position, { framework: "actionview" })
 
       return result ? (result.contents as { value: string }).value : null
     }
@@ -390,14 +392,34 @@ describe("DefinitionProvider", () => {
       const content = `<div>text</div>\n<%= render partial: "events/featured_home" %>`
       const document = TextDocument.create(VIEW_URI, "erb", 1, content)
 
-      expect(service.getHover(document, document.positionAt(2))).toBeNull()
+      expect(service.getHover(document, document.positionAt(2), { framework: "actionview" })).toBeNull()
+    })
+
+    it("does not resolve a definition when the framework is not Action View", () => {
+      const service = createService("/project/app/views/events/_featured_home.html.erb")
+      const content = `<%= render partial: "events/featured_home" %>`
+
+      expect(definitions(service, content, "events/featured_home").length).toBeGreaterThan(0)
+      expect(definitions(service, content, "events/featured_home", VIEW_URI, { framework: "sinatra" })).toEqual([])
+      expect(definitions(service, content, "events/featured_home", VIEW_URI, {})).toEqual([])
+    })
+
+    it("returns nothing when the framework is not Action View", () => {
+      const service = createService("/project/app/views/events/_featured_home.html.erb")
+      const content = `<%= render partial: "events/featured_home" %>`
+      const document = TextDocument.create(VIEW_URI, "erb", 1, content)
+      const position = document.positionAt(content.indexOf("events/featured_home") + 1)
+
+      expect(service.getHover(document, position, { framework: "actionview" })).not.toBeNull()
+      expect(service.getHover(document, position, { framework: "sinatra" })).toBeNull()
+      expect(service.getHover(document, position, {})).toBeNull()
     })
   })
 
   describe("object and collection rendering", () => {
     function hoverText(service: DefinitionProvider, content: string, target: string) {
       const document = TextDocument.create(VIEW_URI, "erb", 1, content)
-      const result = service.getHover(document, document.positionAt(content.indexOf(target) + 1))
+      const result = service.getHover(document, document.positionAt(content.indexOf(target) + 1), { framework: "actionview" })
 
       return result ? (result.contents as { value: string }).value : null
     }
@@ -423,7 +445,7 @@ describe("DefinitionProvider", () => {
       const document = TextDocument.create(VIEW_URI, "erb", 1, content)
 
       for (const target of ["<%= render", "render talks", "talks %>"]) {
-        const hover = service.getHover(document, document.positionAt(content.indexOf(target) + 1))
+        const hover = service.getHover(document, document.positionAt(content.indexOf(target) + 1), { framework: "actionview" })
 
         expect(document.getText(hover!.range)).toBe("<%= render talks %>")
       }
@@ -433,7 +455,7 @@ describe("DefinitionProvider", () => {
       const service = createService("/project/app/views/events/_card.html.erb")
       const content = `<%= render partial: "events/card" %>`
       const document = TextDocument.create(VIEW_URI, "erb", 1, content)
-      const hover = service.getHover(document, document.positionAt(content.indexOf("events/card") + 1))
+      const hover = service.getHover(document, document.positionAt(content.indexOf("events/card") + 1), { framework: "actionview" })
 
       expect(document.getText(hover!.range)).toBe("events/card")
     })
@@ -467,7 +489,7 @@ describe("DefinitionProvider", () => {
   describe("interpolated partial names", () => {
     function hoverText(service: DefinitionProvider, content: string, target: string) {
       const document = TextDocument.create(VIEW_URI, "erb", 1, content)
-      const result = service.getHover(document, document.positionAt(content.indexOf(target) + 1))
+      const result = service.getHover(document, document.positionAt(content.indexOf(target) + 1), { framework: "actionview" })
 
       return result ? (result.contents as { value: string }).value : null
     }
@@ -490,7 +512,7 @@ describe("DefinitionProvider", () => {
       const service = createService()
       const content = `<%= render "talks/#{scope}/card" %>`
       const document = TextDocument.create(VIEW_URI, "erb", 1, content)
-      const message = (service.getHover(document, document.positionAt(6))!.contents as { value: string }).value
+      const message = (service.getHover(document, document.positionAt(6), { framework: "actionview" })!.contents as { value: string }).value
 
       expect(message).toContain("The name is interpolated")
       expect(message).not.toContain("to_partial_path")
@@ -501,7 +523,7 @@ describe("DefinitionProvider", () => {
       const service = createService()
       const content = `<%= render partial: "talks/#{scope}/card" %>`
       const document = TextDocument.create(VIEW_URI, "erb", 1, content)
-      const message = (service.getHover(document, document.positionAt(6))!.contents as { value: string }).value
+      const message = (service.getHover(document, document.positionAt(6), { framework: "actionview" })!.contents as { value: string }).value
 
       expect(message).toContain("The name is interpolated")
       expect(message).not.toContain("to_partial_path")
@@ -556,7 +578,7 @@ describe("DefinitionProvider", () => {
       const service = createService("/project/app/views/events/_separator.html.erb")
       const content = `<%= render partial: "events/card", spacer_template: "events/separator" %>`
       const document = TextDocument.create(VIEW_URI, "erb", 1, content)
-      const result = service.getHover(document, document.positionAt(content.indexOf("events/separator") + 1))
+      const result = service.getHover(document, document.positionAt(content.indexOf("events/separator") + 1), { framework: "actionview" })
 
       expect((result!.contents as { value: string }).value).toBe(
         "[app/views/events/_separator.html.erb](file:///project/app/views/events/_separator.html.erb)"
@@ -618,7 +640,7 @@ describe("DefinitionProvider", () => {
       const service = createService()
       const content = `<div>\n  <%= render partial: some_variable %>\n`
       const document = TextDocument.create(VIEW_URI, "erb", 1, content)
-      const hover = service.getHover(document, document.positionAt(content.indexOf("some_variable") + 1))
+      const hover = service.getHover(document, document.positionAt(content.indexOf("some_variable") + 1), { framework: "actionview" })
 
       expect((hover!.contents as { value: string }).value).toContain("can't resolve this partial statically")
     })

--- a/javascript/packages/language-service/test/document_symbol_provider.test.ts
+++ b/javascript/packages/language-service/test/document_symbol_provider.test.ts
@@ -19,7 +19,7 @@ describe("DocumentSymbolProvider", () => {
   })
 
   function symbols(content: string): DocumentSymbol[] {
-    return service.getDocumentSymbols(TextDocument.create("file:///test.html.erb", "erb", 1, content))
+    return service.getDocumentSymbols(TextDocument.create("file:///test.html.erb", "erb", 1, content), { framework: "actionview" })
   }
 
   function outline(content: string): string[] {
@@ -300,5 +300,23 @@ describe("DocumentSymbolProvider", () => {
     const content = `<% posts.each do |post| %>\n  <%= render "posts/card", post: post %>\n<% end %>`
 
     expect(outline(content)).toEqual(["posts.each do |post|", "  render posts/card"])
+  })
+  describe("framework scoping", () => {
+    const content = '<%= tag.div class: "x" %>'
+
+    function symbolsFor(framework?: string) {
+      const document = TextDocument.create("file:///test.html.erb", "erb", 1, content)
+
+      return service.getDocumentSymbols(document, { framework })
+    }
+
+    it("labels a tag helper as its rendered element for an Action View project", () => {
+      expect(JSON.stringify(symbolsFor("actionview"))).toContain("div")
+    })
+
+    it("does not treat a tag helper as an element when the framework is not Action View", () => {
+      expect(JSON.stringify(symbolsFor("sinatra"))).not.toContain("div")
+      expect(JSON.stringify(symbolsFor(undefined))).not.toContain("div")
+    })
   })
 })

--- a/javascript/packages/language-service/test/extract_code_action_provider.test.ts
+++ b/javascript/packages/language-service/test/extract_code_action_provider.test.ts
@@ -71,7 +71,7 @@ describe("ExtractCodeActionProvider", () => {
         </div>
       `
 
-      const actions = createService().getCodeActions(createDocument(content), selectionOf(content, content))
+      const actions = createService().getCodeActions(createDocument(content), selectionOf(content, content), { framework: "actionview" })
 
       expect(actions).toHaveLength(1)
       expect(actions[0].kind).toBe(CodeActionKind.RefactorExtract)
@@ -82,7 +82,7 @@ describe("ExtractCodeActionProvider", () => {
     it("offers a prompting action when the client supports the command", () => {
       const content = `<div id="banner">Hello</div>`
 
-      const actions = createService(true).getCodeActions(createDocument(content), selectionOf(content, content))
+      const actions = createService(true).getCodeActions(createDocument(content), selectionOf(content, content), { framework: "actionview" })
 
       expect(actions).toHaveLength(1)
       expect(actions[0].title).toBe("Herb: Extract to partial…")
@@ -94,7 +94,7 @@ describe("ExtractCodeActionProvider", () => {
     it("does not offer an action without a selection", () => {
       const content = `<div>Hello</div>`
 
-      const actions = createService().getCodeActions(createDocument(content), Range.create(0, 3, 0, 3))
+      const actions = createService().getCodeActions(createDocument(content), Range.create(0, 3, 0, 3), { framework: "actionview" })
 
       expect(actions).toHaveLength(0)
     })
@@ -106,7 +106,7 @@ describe("ExtractCodeActionProvider", () => {
         </div>
       `
 
-      const actions = createService().getCodeActions(createDocument(content), selectionOf(content, "<div>\n  <span>Hello</span>"))
+      const actions = createService().getCodeActions(createDocument(content), selectionOf(content, "<div>\n  <span>Hello</span>"), { framework: "actionview" })
 
       expect(actions).toHaveLength(0)
     })
@@ -116,7 +116,7 @@ describe("ExtractCodeActionProvider", () => {
 
       const service = new ExtractCodeActionProvider(parserService, { supportsResourceCreation: false, supportsExtractToPartialCommand: false }, () => false)
 
-      expect(service.getCodeActions(createDocument(content), selectionOf(content, content))).toHaveLength(0)
+      expect(service.getCodeActions(createDocument(content), selectionOf(content, content), { framework: "actionview" })).toHaveLength(0)
     })
   })
 
@@ -735,37 +735,48 @@ describe("ExtractCodeActionProvider", () => {
   describe("suggested name", () => {
     it("uses the id attribute", () => {
       const content = `<div id="user-card">Hello</div>`
-      const actions = createService(true).getCodeActions(createDocument(content), selectionOf(content, content))
+      const actions = createService(true).getCodeActions(createDocument(content), selectionOf(content, content), { framework: "actionview" })
 
       expect(actions[0].command?.arguments?.[0]).toMatchObject({ suggestedName: "user_card" })
     })
 
     it("falls back to the first class name", () => {
       const content = `<div class="user-card highlighted">Hello</div>`
-      const actions = createService(true).getCodeActions(createDocument(content), selectionOf(content, content))
+      const actions = createService(true).getCodeActions(createDocument(content), selectionOf(content, content), { framework: "actionview" })
 
       expect(actions[0].command?.arguments?.[0]).toMatchObject({ suggestedName: "user_card" })
     })
 
     it("ignores utility class lists", () => {
       const content = `<section class="rounded-lg border bg-white p-6 shadow-sm">Hello</section>`
-      const actions = createService(true).getCodeActions(createDocument(content), selectionOf(content, content))
+      const actions = createService(true).getCodeActions(createDocument(content), selectionOf(content, content), { framework: "actionview" })
 
       expect(actions[0].command?.arguments?.[0]).toMatchObject({ suggestedName: "section" })
     })
 
     it("falls back to the tag name", () => {
       const content = `<article>Hello</article>`
-      const actions = createService(true).getCodeActions(createDocument(content), selectionOf(content, content))
+      const actions = createService(true).getCodeActions(createDocument(content), selectionOf(content, content), { framework: "actionview" })
 
       expect(actions[0].command?.arguments?.[0]).toMatchObject({ suggestedName: "article" })
     })
 
     it("falls back to a generic name", () => {
       const content = `<%= @user.name %>`
-      const actions = createService(true).getCodeActions(createDocument(content), selectionOf(content, content))
+      const actions = createService(true).getCodeActions(createDocument(content), selectionOf(content, content), { framework: "actionview" })
 
       expect(actions[0].command?.arguments?.[0]).toMatchObject({ suggestedName: "partial" })
+    })
+  })
+  describe("framework scoping", () => {
+    it("offers nothing when the framework is not Action View", () => {
+      const content = "<div>\n  <span>Extract me</span>\n</div>"
+      const document = createDocument(content)
+      const range = selectionOf(content, "<span>Extract me</span>")
+
+      expect(createService().getCodeActions(document, range, { framework: "actionview" }).length).toBeGreaterThan(0)
+      expect(createService().getCodeActions(document, range, { framework: "sinatra" })).toEqual([])
+      expect(createService().getCodeActions(document, range, {})).toEqual([])
     })
   })
 })

--- a/javascript/packages/language-service/test/hover_provider.test.ts
+++ b/javascript/packages/language-service/test/hover_provider.test.ts
@@ -5,6 +5,8 @@ import { Position, MarkupKind, Range } from "vscode-languageserver/node"
 import { TextDocument } from "vscode-languageserver-textdocument"
 
 import { HoverProvider } from "../src/hover_provider"
+
+import type { FrameworkOptions } from "../src/types"
 import { ParserService } from "../src/parser_service"
 import { Herb } from "@herb-tools/node-wasm"
 
@@ -24,10 +26,10 @@ describe("HoverProvider", () => {
     return TextDocument.create("file:///test.html.erb", "erb", 1, content)
   }
 
-  function getHover(content: string, line: number, character: number) {
+  function getHover(content: string, line: number, character: number, options: FrameworkOptions = { framework: "actionview" }) {
     const document = createDocument(content)
 
-    return service.getHover(document, Position.create(line, character))
+    return service.getHover(document, Position.create(line, character), options)
   }
 
   function hoverValue(content: string, line: number, character: number): string {
@@ -496,6 +498,26 @@ describe("HoverProvider", () => {
     })
   })
 
+  describe("non-ActionView frameworks", () => {
+    it("returns null for a tag helper when the framework is not Action View", () => {
+      expect(getHover(`<%= tag.div class: "x" %>`, 0, 8, { framework: "sinatra" })).toBeNull()
+    })
+
+    it("returns null for a tag helper when no framework is configured", () => {
+      expect(getHover(`<%= tag.div class: "x" %>`, 0, 8, {})).toBeNull()
+    })
+
+    it("returns null for an ERB helper call when the framework is not Action View", () => {
+      expect(getHover(`<%= link_to "Home", root_path %>`, 0, 6, { framework: "hanami" })).toBeNull()
+    })
+
+    it("still hovers character references when the framework is not Action View", () => {
+      const hover = getHover("<p>&amp;</p>", 0, 5, { framework: "sinatra" })
+
+      expect((hover!.contents as { value: string }).value).toContain("Named character reference")
+    })
+  })
+
   describe("character references", () => {
     describe("named character references", () => {
       it("shows hover for &lt;", () => {
@@ -725,8 +747,8 @@ describe("HoverProvider", () => {
       const document = createDocument(content)
       const position = Position.create(2, 9)
 
-      const first = provider.getHover(document, position)
-      const second = provider.getHover(document, position)
+      const first = provider.getHover(document, position, { framework: "actionview" })
+      const second = provider.getHover(document, position, { framework: "actionview" })
 
       expect(first).not.toBeNull()
       expect(second).toEqual(first)
@@ -743,8 +765,8 @@ describe("HoverProvider", () => {
       const document = createDocument(content)
       const position = Position.create(0, 5)
 
-      const first = provider.getHover(document, position)
-      const second = provider.getHover(document, position)
+      const first = provider.getHover(document, position, { framework: "actionview" })
+      const second = provider.getHover(document, position, { framework: "actionview" })
 
       expect(first).not.toBeNull()
       expect(second).toEqual(first)

--- a/javascript/packages/language-service/test/references_provider.test.ts
+++ b/javascript/packages/language-service/test/references_provider.test.ts
@@ -80,6 +80,7 @@ async function serviceFor(files: Record<string, string>, buffers: Record<string,
   } as OpenDocuments
 
   const service = new ReferencesProvider(new DefinitionProvider(parserService, existsSync, readFile), index, documents, readFile)
+  service.setConfig({ framework: "actionview" })
 
   return { service, index, project: created, buffers }
 }
@@ -264,6 +265,15 @@ describe("ReferencesProvider", () => {
       "app/views/posts/_card.html.erb": `<article></article>\n`,
       "app/views/posts/index.html.erb": `<div></div>\n`,
     })
+
+    expect(referencesAt(services, "app/views/posts/_card.html.erb")).toEqual([])
+  })
+  test("finds nothing when the framework is not Action View", async () => {
+    const services = await serviceFor(PROJECT)
+
+    expect(referencesAt(services, "app/views/posts/_card.html.erb").length).toBeGreaterThan(0)
+
+    services.service.setConfig({ framework: "sinatra" })
 
     expect(referencesAt(services, "app/views/posts/_card.html.erb")).toEqual([])
   })

--- a/javascript/packages/language-service/test/rewrite_code_action_provider.test.ts
+++ b/javascript/packages/language-service/test/rewrite_code_action_provider.test.ts
@@ -5,8 +5,12 @@ import { Range, CodeActionKind } from "vscode-languageserver/node"
 import { TextDocument } from "vscode-languageserver-textdocument"
 
 import { RewriteCodeActionProvider } from "../src/rewrite_code_action_provider"
+
+import type { FrameworkOptions } from "../src/types"
 import { ParserService } from "../src/parser_service"
 import { Herb } from "@herb-tools/node-wasm"
+
+import type { ParseOptions, ParseResult } from "@herb-tools/core"
 
 describe("RewriteCodeActionProvider", () => {
   let parserService: ParserService
@@ -22,10 +26,10 @@ describe("RewriteCodeActionProvider", () => {
     return TextDocument.create("file:///test.html.erb", "erb", 1, content)
   }
 
-  function getCodeActions(content: string, startLine: number, startChar: number, endLine: number, endChar: number) {
+  function getCodeActions(content: string, startLine: number, startChar: number, endLine: number, endChar: number, options: FrameworkOptions = { framework: "actionview" }) {
     const document = createDocument(content)
     const range = Range.create(startLine, startChar, endLine, endChar)
-    return service.getCodeActions(document, range)
+    return service.getCodeActions(document, range, options)
   }
 
   describe("ActionView to HTML", () => {
@@ -233,6 +237,53 @@ describe("RewriteCodeActionProvider", () => {
 
       const divAction = actions.find(a => a.title.includes("<div>"))
       expect(divAction).toBeUndefined()
+    })
+  })
+  describe("framework scoping", () => {
+    const content = '<%= tag.div class: "x" %>'
+
+    it("offers conversions for an Action View project", () => {
+      expect(getCodeActions(content, 0, 0, 0, 11).length).toBeGreaterThan(0)
+    })
+
+    it("offers nothing when the framework is not Action View", () => {
+      expect(getCodeActions(content, 0, 0, 0, 11, { framework: "sinatra" })).toEqual([])
+    })
+
+    it("offers nothing when no framework is configured", () => {
+      expect(getCodeActions(content, 0, 0, 0, 11, {})).toEqual([])
+    })
+  })
+
+  describe("parse result reuse", () => {
+    class CachingParserService extends ParserService {
+      private cache = new Map<string, ParseResult>()
+
+      parseContent(content: string, options?: ParseOptions): ParseResult {
+        const key = `${JSON.stringify(options ?? null)} ${content}`
+        const cached = this.cache.get(key)
+
+        if (cached) return cached
+
+        const result = super.parseContent(content, options)
+        this.cache.set(key, result)
+
+        return result
+      }
+    }
+
+    it("leaves a shared parse result alone, so later requests still see the helper", () => {
+      const content = '<%= tag.div class: "x" %>'
+      const document = createDocument(content)
+      const caching = new CachingParserService(Herb)
+      const provider = new RewriteCodeActionProvider(caching)
+      const options = { action_view_helpers: true, track_whitespace: true }
+
+      expect((caching.parseContent(content, options).value.children[0] as any).element_source).toBe("ActionView::Helpers::TagHelper#tag")
+
+      provider.getCodeActions(document, Range.create(0, 0, 0, 11), { framework: "actionview" })
+
+      expect((caching.parseContent(content, options).value.children[0] as any).element_source).toBe("ActionView::Helpers::TagHelper#tag")
     })
   })
 })

--- a/playground/src/language-service.js
+++ b/playground/src/language-service.js
@@ -200,11 +200,13 @@ export function createLanguageService(herb) {
 export function registerLanguageService(herb) {
   const service = createLanguageService(herb)
 
+  let framework = undefined
+
   const disposables = [
     languages.registerHoverProvider(LANGUAGE_ID, {
       provideHover(model, position) {
         return safely(() => {
-          const hover = service.hover.getHover(documentFor(model), lspPosition(position))
+          const hover = service.hover.getHover(documentFor(model), lspPosition(position), { framework })
 
           if (!hover) return null
 
@@ -261,7 +263,7 @@ export function registerLanguageService(herb) {
 
       provideDocumentSymbols(model) {
         return safely(() =>
-          service.symbols.getDocumentSymbols(documentFor(model)).map(documentSymbolFor), [])
+          service.symbols.getDocumentSymbols(documentFor(model), { framework }).map(documentSymbolFor), [])
       },
     }),
 
@@ -273,6 +275,7 @@ export function registerLanguageService(herb) {
           const actions = service.rewriteCodeActions.getCodeActions(
             documentFor(model),
             lspRange(range),
+            { framework },
           )
 
           return {
@@ -299,8 +302,9 @@ export function registerLanguageService(herb) {
   return {
     providers: service,
 
-    setFramework(framework) {
-      service.completion.setFramework(framework)
+    setFramework(value) {
+      framework = value
+      service.completion.setConfig({ framework: value })
     },
 
     dispose() {


### PR DESCRIPTION
This pull request updates every provider that offers Action View knowledge so it only does so for projects that render through Action View.

A Sinatra, Hanami or plain ERB project got the full Rails treatment from the editor. Hovering `<%= tag.div class: "x" %>` returned an Action View helper signature, its documentation, and an "HTML equivalent" preview. 

Hovering `<%= render "posts/card" %>` explained how Rails derives a partial from `to_partial_path`, go-to-definition navigated to the partial, find-references listed its call sites, `<%= link` completed to `link_to`, and the editor offered to convert markup into a tag helper or extract it into a partial with a strict locals header. None of that exists outside Action View.

| Entry point                                 | Behavior without Action View                                  |
|---------------------------------------------|---------------------------------------------------------------|
| `HoverProvider#getHover`                    | Falls through to the character reference hover                |
| `DefinitionProvider#getHover`               | Returns nothing                                               |
| `DefinitionProvider#getDefinition`          | Returns no locations                                          |
| `ReferencesProvider#getReferences`          | Returns no call sites                                         |
| `CompletionProvider#getERBCompletions`      | Offers no helper, `tag.`, `content_tag` or render completions |
| `RewriteCodeActionProvider#getCodeActions`  | Offers no conversions                                         |
| `ExtractCodeActionProvider#getCodeActions`  | Offers no extraction                                          |
| `DocumentSymbolProvider#getDocumentSymbols` | Parses without `action_view_helpers`                          |


`CommentProvider`, `FoldingRangeProvider`, `SelectionRangeProvider`, `InlayHintProvider` and `DocumentHighlightProvider` carry no Action View knowledge, so they are untouched. 

Resolves #2221