### PR TITLE
Linter: Respect `framework` when parsing Action View helpers

### DIFF
--- a/javascript/packages/linter/src/linter.ts
+++ b/javascript/packages/linter/src/linter.ts
@@ -15,7 +15,7 @@ import { DEFAULT_RULE_CONFIG } from "./types.js"
 import { resolveSeverity, ALL_RULES_KEY } from "@herb-tools/config/schema"
 
 import type { RuleClass, ParserRuleClass, LexerRuleClass, SourceRuleClass, Rule, ParserRule, LexerRule, SourceRule, LintResult, LintOffense, UnboundLintOffense, LintContext, AutofixResult, RuleVersion, LinterMode, Framework } from "./types.js"
-import type { ParseResult, LexResult, HerbBackend } from "@herb-tools/core"
+import type { ParseResult, LexResult, HerbBackend, ParserOptions } from "@herb-tools/core"
 import type { RuleConfig, Config } from "@herb-tools/config"
 
 export interface LinterOptions {
@@ -324,6 +324,31 @@ export class Linter {
   }
 
   /**
+   * The parser options a rule is run with.
+   *
+   * A rule asking for `action_view_helpers` is saying it wants to see Action
+   * View helpers as the elements they render, which only makes sense where
+   * those helpers exist. Outside Action View a call like `tag.ubid` is an
+   * ordinary method call, so the transform is turned off and the rule sees the
+   * ERB it was actually given.
+   *
+   * @param ruleClass - The rule class being run
+   * @param rule - The rule instance being run
+   * @param framework - The framework from the lint context, if any
+   * @returns The parser options to parse the source with
+   */
+  protected parserOptionsFor(ruleClass: RuleClass, rule: Rule, framework: Framework | undefined): Partial<ParserOptions> {
+    if (!this.isParserRuleClass(ruleClass)) return {}
+
+    const parserOptions = (rule as ParserRule).parserOptions ?? {}
+
+    if (!parserOptions.action_view_helpers) return parserOptions
+    if ((framework ?? DEFAULT_FRAMEWORK) === "actionview") return parserOptions
+
+    return { ...parserOptions, action_view_helpers: false }
+  }
+
+  /**
    * Execute a single rule and return its unbound offenses.
    * Handles rule type checking (Lexer/Parser/Source) and isEnabled checks.
    */
@@ -523,7 +548,7 @@ export class Linter {
 
     for (const ruleClass of regularRules) {
       const rule = new ruleClass()
-      const parserOptions = this.isParserRuleClass(ruleClass) ? (rule as ParserRule).parserOptions : {}
+      const parserOptions = this.parserOptionsFor(ruleClass, rule, context?.framework)
       const parseResult = this.parseCache.get(source, parserOptions)
 
       if (this.isParserRuleClass(ruleClass)) {

--- a/javascript/packages/linter/test/autofix/svg-tag-name-capitalization.autofix.test.ts
+++ b/javascript/packages/linter/test/autofix/svg-tag-name-capitalization.autofix.test.ts
@@ -90,7 +90,7 @@ describe("svg-tag-name-capitalization autofix", () => {
     const input = `<svg><%= tag.lineargradient id: "grad1" do %><stop offset="0%" /><% end %></svg>`
 
     const linter = new Linter(Herb, [SVGTagNameCapitalizationRule])
-    const result = linter.autofix(input)
+    const result = linter.autofix(input, { framework: "actionview" })
 
     expect(result.source).toBe(input)
     expect(result.fixed).toHaveLength(0)
@@ -101,7 +101,7 @@ describe("svg-tag-name-capitalization autofix", () => {
     const input = `<svg><%= content_tag :lineargradient, id: "grad1" do %><stop offset="0%" /><% end %></svg>`
 
     const linter = new Linter(Herb, [SVGTagNameCapitalizationRule])
-    const result = linter.autofix(input)
+    const result = linter.autofix(input, { framework: "actionview" })
 
     expect(result.source).toBe(input)
     expect(result.fixed).toHaveLength(0)

--- a/javascript/packages/linter/test/autofix/turbo-permanent-no-misleading-value.autofix.test.ts
+++ b/javascript/packages/linter/test/autofix/turbo-permanent-no-misleading-value.autofix.test.ts
@@ -67,7 +67,7 @@ describe("turbo-permanent-no-misleading-value autofix", () => {
     const input = '<%= tag.div id: "cart", data: { turbo_permanent: false } %>'
 
     const linter = new Linter(Herb, [TurboPermanentNoMisleadingValueRule])
-    const result = linter.autofix(input)
+    const result = linter.autofix(input, { framework: "actionview" })
 
     expect(result.source).toBe(input)
     expect(result.fixed).toHaveLength(0)

--- a/javascript/packages/linter/test/framework-scoped-rules.test.ts
+++ b/javascript/packages/linter/test/framework-scoped-rules.test.ts
@@ -84,3 +84,24 @@ describe("framework-scoped rules", () => {
     expect(lint({ framework: "ruby" }, config)).toHaveLength(1)
   })
 })
+
+describe("Action View helper parsing", () => {
+  beforeAll(async () => {
+    await Herb.load()
+  })
+
+  const TAG_PROXY = `<tr id="<%= tag.ubid %>"></tr>`
+
+  function rulesFor(context?: Record<string, any>) {
+    return new Linter(Herb).lint(TAG_PROXY, context).offenses.map(offense => offense.rule)
+  }
+
+  test("does not read `tag.*` as an element outside Action View", () => {
+    expect(rulesFor({ framework: "ruby" })).toEqual([])
+    expect(rulesFor({ framework: "sinatra" })).toEqual([])
+  })
+
+  test("reads `tag.*` as an element for an Action View project", () => {
+    expect(rulesFor({ framework: "actionview" })).toContain("html-no-unknown-tag")
+  })
+})

--- a/javascript/packages/linter/test/helpers/linter-test-helper.ts
+++ b/javascript/packages/linter/test/helpers/linter-test-helper.ts
@@ -80,7 +80,8 @@ export function createLinterTest(rules: RuleClass | RuleClass[], configOverride?
   const parseCache = new ParseCache(Herb)
   const ruleConfigOverride = configOverride
   const declaredFrameworks = ruleInstance.defaultConfig?.frameworks
-  const defaultFramework = declaredFrameworks?.[0]
+  const wantsActionViewHelpers = ruleParserOptions.action_view_helpers === true
+  const defaultFramework = declaredFrameworks?.[0] ?? (wantsActionViewHelpers ? "actionview" : undefined)
 
   const resolveContext = (options?: any | TestOptions) => {
     const context = options?.context ?? options

--- a/javascript/packages/linter/test/rules/html-no-inline-script-elements.test.ts
+++ b/javascript/packages/linter/test/rules/html-no-inline-script-elements.test.ts
@@ -32,19 +32,19 @@ describe("html-no-inline-script-elements", () => {
       <script src="https://example.com/app.js">
         alert("hello")
       </script>
-    `)
+    `, { framework: "ruby" })
   })
 
   test("fails with empty inline script tag", () => {
     expectError("Avoid inline `<script>` tags. Extract the JavaScript into a separate `.js` file and deliver it through your framework's asset pipeline.")
 
-    assertOffenses("<script></script>")
+    assertOffenses("<script></script>", { framework: "ruby" })
   })
 
   test("fails with inline script tag", () => {
     expectError("Avoid inline `<script>` tags. Extract the JavaScript into a separate `.js` file and deliver it through your framework's asset pipeline.")
 
-    assertOffenses("<script>alert('hello')</script>")
+    assertOffenses("<script>alert('hello')</script>", { framework: "ruby" })
   })
 
   test("fails with script tag with unallowed type", () => {
@@ -52,7 +52,7 @@ describe("html-no-inline-script-elements", () => {
 
     assertOffenses(dedent`
       <script type="text/javascript">alert("hello")</script>
-    `)
+    `, { framework: "ruby" })
   })
 
   test("suggests an external JavaScript file for a non-Action View framework", () => {

--- a/javascript/packages/linter/test/rules/html-no-style-elements.test.ts
+++ b/javascript/packages/linter/test/rules/html-no-style-elements.test.ts
@@ -11,7 +11,7 @@ describe("html-no-style-elements", () => {
     test("fails with empty style tag", () => {
       expectError("Avoid inline `<style>` tags. Extract the CSS into a separate `.css` file and deliver it through your framework's asset pipeline.")
 
-      assertOffenses("<style></style>")
+      assertOffenses("<style></style>", { framework: "ruby" })
     })
 
     test("fails with style tag", () => {
@@ -21,7 +21,7 @@ describe("html-no-style-elements", () => {
         <style>
           .danger { color: red; }
         </style>
-      `)
+      `, { framework: "ruby" })
     })
 
     test("fails with style tag containing ERB comment", () => {
@@ -31,7 +31,7 @@ describe("html-no-style-elements", () => {
         <style>
           <%# preflight %>
         </style>
-      `)
+      `, { framework: "ruby" })
     })
 
     test("suggests an external stylesheet for a non-Action View framework", () => {


### PR DESCRIPTION
This pull request stops the linter from reading Action View helpers into a template that isn't rendered by Action View.

On a project configured as `framework: ruby`, this template:

```erb
<tr id="<%= tag.ubid %>"></tr>
```

produced two offenses, neither of which describes anything wrong with the code:

```
Unknown HTML tag `<ubid>`. This is not a standard HTML element.
Attribute `id` must not be empty. Either provide a meaningful value or remove the attribute entirely.
```

Both come from the same cause. A lot of framework-agnostic rules ask for the `action_view_helpers` parser option so they can see a helper as the element it renders, which is what lets `html-img-require-alt` catch an `image_tag` without an `alt`. The option was requested unconditionally, so the Action View tag proxy was applied everywhere.

A rule asking for `action_view_helpers` is saying it wants to see helpers as the elements they render. Whether those helpers exist depends on the project, not the rule configuration. 

So now, `Linter#parserOptionsFor` answers that question once for every rule. Rules keep their Action View awareness on Action View projects, and see the ERB they were actually given anywhere else.

The same fix covers the plainer version of the bug, where `<%= image_tag "logo.png" %>` was reported by `html-img-require-alt` in a project with no Action View at all.

The template from the issue still reports under `framework: actionview`, and deliberately so. In Rails `tag.ubid` really is the tag proxy and really does render `<ubid></ubid>`, so Herb cannot tell that apart from a record that happens to be called `tag`.

Resolves #2258