### PR TITLE
Parser: Introduce `XMLProcessingInstructionNode`

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -792,6 +792,21 @@ nodes:
         - name: "tag_closing"
           type: "token"
 
+    - name: "XMLProcessingInstructionNode"
+      fields:
+        - name: "tag_opening"
+          type: "token"
+
+        - name: "target"
+          type: "token"
+
+        - name: "children"
+          type: "array"
+          kind: "Node"
+
+        - name: "tag_closing"
+          type: "token"
+
     - name: "CDATANode"
       fields:
         - name: "tag_opening"

--- a/javascript/packages/formatter/src/format-printer.ts
+++ b/javascript/packages/formatter/src/format-printer.ts
@@ -103,6 +103,7 @@ import {
   ERBOpenTagNode,
   HTMLVirtualCloseTagNode,
   XMLDeclarationNode,
+  XMLProcessingInstructionNode,
   CDATANode,
   Token
 } from "@herb-tools/core"
@@ -1063,6 +1064,10 @@ export class FormatPrinter extends Printer implements TextFlowDelegate, Attribut
   }
 
   visitXMLDeclarationNode(node: XMLDeclarationNode) {
+    this.pushWithIndent(IdentityPrinter.print(node))
+  }
+
+  visitXMLProcessingInstructionNode(node: XMLProcessingInstructionNode) {
     this.pushWithIndent(IdentityPrinter.print(node))
   }
 

--- a/javascript/packages/formatter/test/xml/xml.test.ts
+++ b/javascript/packages/formatter/test/xml/xml.test.ts
@@ -729,4 +729,82 @@ describe("XML", () => {
       </Screen>
     `)
   })
+
+  test("XML stylesheet processing instruction", () => {
+    const source = dedent`
+      <?xml version="1.0" encoding="UTF-8"?>
+      <?xml-stylesheet type="text/xsl" href="feed.xsl"?>
+      <rss version="2.0">
+        <channel>
+            <title>Example</title>
+        </channel>
+      </rss>
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <?xml version="1.0" encoding="UTF-8"?>
+
+      <?xml-stylesheet type="text/xsl" href="feed.xsl"?>
+
+      <rss version="2.0">
+        <channel>
+          <title>Example</title>
+        </channel>
+      </rss>
+    `)
+  })
+
+  test("processing instruction with ERB", () => {
+    const source = dedent`
+      <?xml version="1.0" encoding="UTF-8"?>
+      <?xml-stylesheet type="text/xsl" href="<%= stylesheet_path %>"?>
+      <feed>
+        <entry></entry>
+      </feed>
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <?xml version="1.0" encoding="UTF-8"?>
+
+      <?xml-stylesheet type="text/xsl" href="<%= stylesheet_path %>"?>
+
+      <feed>
+        <entry></entry>
+      </feed>
+    `)
+  })
+
+  test("processing instruction nested inside an element", () => {
+    const source = dedent`
+      <document>
+      <?php echo "hello"; ?>
+      <body>
+      <p>Text</p>
+      </body>
+      </document>
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <document>
+        <?php echo "hello"; ?>
+
+        <body>
+          <p>Text</p>
+        </body>
+      </document>
+    `)
+  })
+
+  test("processing instruction terminated with a single angle bracket", () => {
+    const source = dedent`
+      <?target some content>
+      <root></root>
+    `
+    const result = formatter.format(source)
+    expect(result).toEqual(dedent`
+      <?target some content>
+
+      <root></root>
+    `)
+  })
 })

--- a/javascript/packages/printer/src/identity-printer.ts
+++ b/javascript/packages/printer/src/identity-printer.ts
@@ -202,6 +202,22 @@ export class IdentityPrinter extends Printer {
     }
   }
 
+  visitXMLProcessingInstructionNode(node: Nodes.XMLProcessingInstructionNode): void {
+    if (node.tag_opening) {
+      this.write(node.tag_opening.value)
+    }
+
+    if (node.target) {
+      this.write(node.target.value)
+    }
+
+    this.visitChildNodes(node)
+
+    if (node.tag_closing) {
+      this.write(node.tag_closing.value)
+    }
+  }
+
   visitCDATANode(node: Nodes.CDATANode): void {
     if (node.tag_opening) {
       this.write(node.tag_opening.value)

--- a/javascript/packages/printer/test/nodes/xml-processing-instruction-node.test.ts
+++ b/javascript/packages/printer/test/nodes/xml-processing-instruction-node.test.ts
@@ -1,0 +1,70 @@
+import dedent from "dedent"
+import { describe, test, beforeAll } from "vitest"
+
+import { Herb } from "@herb-tools/node-wasm"
+import { XMLProcessingInstructionNode, LiteralNode } from "@herb-tools/core"
+
+import { expectNodeToPrint, expectPrintRoundTrip, createLocation, createToken } from "../helpers/printer-test-helpers.js"
+
+describe("XMLProcessingInstructionNode Printing", () => {
+  beforeAll(async () => {
+    await Herb.load()
+  })
+
+  test("can print processing instruction from node", () => {
+    const literalNode = LiteralNode.build({
+      location: createLocation(),
+      content: " name=\"placeholder\""
+    })
+
+    const node = XMLProcessingInstructionNode.build({
+      location: createLocation(),
+      tag_opening: createToken("TOKEN_XML_PROCESSING_INSTRUCTION_START", "<?"),
+      target: createToken("TOKEN_IDENTIFIER", "marker"),
+      children: [literalNode],
+      tag_closing: createToken("TOKEN_HTML_TAG_END", ">")
+    })
+
+    expectNodeToPrint(node, "<?marker name=\"placeholder\">")
+  })
+
+  test("can print processing instruction without data from node", () => {
+    const node = XMLProcessingInstructionNode.build({
+      location: createLocation(),
+      tag_opening: createToken("TOKEN_XML_PROCESSING_INSTRUCTION_START", "<?"),
+      target: createToken("TOKEN_IDENTIFIER", "end"),
+      children: [],
+      tag_closing: createToken("TOKEN_HTML_TAG_END", ">")
+    })
+
+    expectNodeToPrint(node, "<?end>")
+  })
+
+  test("can print processing instruction from source", () => {
+    expectPrintRoundTrip("<?marker name=\"placeholder\">")
+  })
+
+  test("can print processing instruction without data from source", () => {
+    expectPrintRoundTrip("<?end>")
+  })
+
+  test("can print processing instruction closed with question mark from source", () => {
+    expectPrintRoundTrip("<?xml-stylesheet type=\"text/xsl\" href=\"style.xsl\"?>")
+  })
+
+  test("can print processing instruction with ERB from source", () => {
+    expectPrintRoundTrip("<?marker name=\"<%= placeholder_name %>\">")
+  })
+
+  test("can print processing instructions inside an element from source", () => {
+    expectPrintRoundTrip(dedent`
+      <div>
+        <?marker name="placeholder">
+
+        <?start name="another-placeholder">
+          Loading…
+        <?end>
+      </div>
+    `)
+  })
+})

--- a/lib/herb/engine/compiler.rb
+++ b/lib/herb/engine/compiler.rb
@@ -196,6 +196,13 @@ module Herb
         add_text(node.tag_closing.value)
       end
 
+      def visit_xml_processing_instruction_node(node)
+        add_text(node.tag_opening.value)
+        add_text(node.target.value)
+        visit_all(node.children)
+        add_text(node.tag_closing.value)
+      end
+
       def visit_cdata_node(node)
         add_text(node.tag_opening.value)
         visit_all(node.children)

--- a/rust/herb-printer/src/erb_to_ruby_string_printer.rs
+++ b/rust/herb-printer/src/erb_to_ruby_string_printer.rs
@@ -321,6 +321,10 @@ impl Visitor for ERBToRubyStringPrinter {
     self.emit_xml_declaration(node);
   }
 
+  fn visit_xml_processing_instruction_node(&mut self, node: &XMLProcessingInstructionNode) {
+    self.emit_xml_processing_instruction(node);
+  }
+
   fn visit_cdata_node(&mut self, node: &CDATANode) {
     self.emit_cdata(node);
   }
@@ -434,6 +438,7 @@ fn node_children(node: &AnyNode) -> Option<&[AnyNode]> {
     AnyNode::HTMLCommentNode(n) => Some(&n.children),
     AnyNode::HTMLDoctypeNode(n) => Some(&n.children),
     AnyNode::XMLDeclarationNode(n) => Some(&n.children),
+    AnyNode::XMLProcessingInstructionNode(n) => Some(&n.children),
     AnyNode::CDATANode(n) => Some(&n.children),
     AnyNode::ERBCaseNode(n) => Some(&n.children),
     AnyNode::ERBCaseMatchNode(n) => Some(&n.children),

--- a/rust/herb-printer/src/printer.rs
+++ b/rust/herb-printer/src/printer.rs
@@ -318,6 +318,17 @@ pub trait Printer: Visitor + Default {
     self.write_token(&closing);
   }
 
+  fn emit_xml_processing_instruction(&mut self, node: &XMLProcessingInstructionNode) {
+    let opening = node.tag_opening.clone();
+    let target = node.target.clone();
+    let closing = node.tag_closing.clone();
+
+    self.write_token(&opening);
+    self.write_token(&target);
+    self.visit_all(&node.children);
+    self.write_token(&closing);
+  }
+
   fn emit_cdata(&mut self, node: &CDATANode) {
     let opening = node.tag_opening.clone();
     let closing = node.tag_closing.clone();

--- a/sig/herb/ast/nodes.rbs
+++ b/sig/herb/ast/nodes.rbs
@@ -749,6 +749,48 @@ module Herb
       def tree_inspect: (?indent: Integer, ?depth: Integer, ?depth_limit: Integer) -> String
     end
 
+    # : type serialized_xml_processing_instruction_node = {
+    # |  tag_opening: Herb::Token?,
+    # |  target: Herb::Token?,
+    # |  children: Array[Herb::AST::Node],
+    # |  tag_closing: Herb::Token?,
+    # | }
+    class XMLProcessingInstructionNode < Node
+      include Colors
+
+      attr_reader tag_opening: Herb::Token?
+
+      attr_reader target: Herb::Token?
+
+      attr_reader children: Array[Herb::AST::Node]
+
+      attr_reader tag_closing: Herb::Token?
+
+      # : (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Array[Herb::AST::Node], Herb::Token?) -> void
+      def initialize: (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Array[Herb::AST::Node], Herb::Token?) -> void
+
+      # : (?tag_opening: Herb::Token?, ?target: Herb::Token?, ?children: Array[Herb::AST::Node], ?tag_closing: Herb::Token?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> XMLProcessingInstructionNode
+      def self.build: (?tag_opening: Herb::Token?, ?target: Herb::Token?, ?children: Array[Herb::AST::Node], ?tag_closing: Herb::Token?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> XMLProcessingInstructionNode
+
+      # : () -> serialized_xml_processing_instruction_node
+      def to_hash: () -> serialized_xml_processing_instruction_node
+
+      # : (Visitor) -> void
+      def accept: (Visitor) -> void
+
+      # : () -> Array[Herb::AST::Node?]
+      def child_nodes: () -> Array[Herb::AST::Node?]
+
+      # : () -> Array[Herb::AST::Node]
+      def compact_child_nodes: () -> Array[Herb::AST::Node]
+
+      # : () -> String
+      def inspect: () -> String
+
+      # : (?indent: Integer, ?depth: Integer, ?depth_limit: Integer) -> String
+      def tree_inspect: (?indent: Integer, ?depth: Integer, ?depth_limit: Integer) -> String
+    end
+
     # : type serialized_cdata_node = {
     # |  tag_opening: Herb::Token?,
     # |  children: Array[Herb::AST::Node],

--- a/sig/herb/engine/compiler.rbs
+++ b/sig/herb/engine/compiler.rbs
@@ -57,6 +57,8 @@ module Herb
 
       def visit_xml_declaration_node: (untyped node) -> untyped
 
+      def visit_xml_processing_instruction_node: (untyped node) -> untyped
+
       def visit_cdata_node: (untyped node) -> untyped
 
       def visit_erb_content_node: (untyped node) -> untyped

--- a/sig/herb/visitor.rbs
+++ b/sig/herb/visitor.rbs
@@ -80,6 +80,9 @@ module Herb
     # : (Herb::AST::XMLDeclarationNode) -> void
     def visit_xml_declaration_node: (Herb::AST::XMLDeclarationNode) -> void
 
+    # : (Herb::AST::XMLProcessingInstructionNode) -> void
+    def visit_xml_processing_instruction_node: (Herb::AST::XMLProcessingInstructionNode) -> void
+
     # : (Herb::AST::CDATANode) -> void
     def visit_cdata_node: (Herb::AST::CDATANode) -> void
 

--- a/src/include/lexer/lexer_peek_helpers.h
+++ b/src/include/lexer/lexer_peek_helpers.h
@@ -26,6 +26,7 @@ typedef struct {
 
 bool lexer_peek_for_doctype(const lexer_T* lexer, uint32_t offset);
 bool lexer_peek_for_xml_declaration(const lexer_T* lexer, uint32_t offset);
+bool lexer_peek_for_xml_processing_instruction(const lexer_T* lexer, uint32_t offset);
 bool lexer_peek_for_cdata_start(const lexer_T* lexer, uint32_t offset);
 bool lexer_peek_for_cdata_end(const lexer_T* lexer, uint32_t offset);
 bool lexer_peek_for_html_comment_start(const lexer_T* lexer, uint32_t offset);

--- a/src/include/lexer/token_struct.h
+++ b/src/include/lexer/token_struct.h
@@ -13,11 +13,12 @@ typedef enum {
   TOKEN_NEWLINE,    // \n
   TOKEN_IDENTIFIER,
 
-  TOKEN_HTML_DOCTYPE,        // <!DOCTYPE, <!doctype, <!DoCtYpE, <!dOcTyPe
-  TOKEN_XML_DECLARATION,     // <?xml
-  TOKEN_XML_DECLARATION_END, // ?>
-  TOKEN_CDATA_START,         // <![CDATA[
-  TOKEN_CDATA_END,           // ]]>
+  TOKEN_HTML_DOCTYPE,                     // <!DOCTYPE, <!doctype, <!DoCtYpE, <!dOcTyPe
+  TOKEN_XML_DECLARATION,                  // <?xml
+  TOKEN_XML_DECLARATION_END,              // ?>
+  TOKEN_XML_PROCESSING_INSTRUCTION_START, // <?
+  TOKEN_CDATA_START,                      // <![CDATA[
+  TOKEN_CDATA_END,                        // ]]>
 
   TOKEN_HTML_TAG_START,       // <
   TOKEN_HTML_TAG_START_CLOSE, // </

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -399,6 +399,10 @@ token_T* lexer_next_token(lexer_T* lexer) {
         return lexer_advance_with_next(lexer, strlen("<?xml"), TOKEN_XML_DECLARATION);
       }
 
+      if (lexer_peek_for_xml_processing_instruction(lexer, 0)) {
+        return lexer_advance_with(lexer, hb_string("<?"), TOKEN_XML_PROCESSING_INSTRUCTION_START);
+      }
+
       if (lexer_peek_for_cdata_start(lexer, 0)) {
         return lexer_advance_with_next(lexer, strlen("<![CDATA["), TOKEN_CDATA_START);
       }

--- a/src/lexer/lexer_peek_helpers.c
+++ b/src/lexer/lexer_peek_helpers.c
@@ -19,8 +19,22 @@ bool lexer_peek_for_doctype(const lexer_T* lexer, uint32_t offset) {
   return lexer_peek_for(lexer, offset, hb_string("<!DOCTYPE"), true);
 }
 
+static bool is_xml_name_character(char character) {
+  return isalnum(character) || character == '-' || character == '_' || character == ':' || character == '.';
+}
+
 bool lexer_peek_for_xml_declaration(const lexer_T* lexer, uint32_t offset) {
-  return lexer_peek_for(lexer, offset, hb_string("<?xml"), true);
+  hb_string_T pattern = hb_string("<?xml");
+
+  if (!lexer_peek_for(lexer, offset, pattern, true)) { return false; }
+
+  return !is_xml_name_character(lexer_peek(lexer, offset + pattern.length));
+}
+
+bool lexer_peek_for_xml_processing_instruction(const lexer_T* lexer, uint32_t offset) {
+  if (lexer_peek(lexer, offset) != '<' || lexer_peek(lexer, offset + 1) != '?') { return false; }
+
+  return isalpha(lexer_peek(lexer, offset + 2));
 }
 
 bool lexer_peek_for_cdata_start(const lexer_T* lexer, uint32_t offset) {

--- a/src/lexer/token.c
+++ b/src/lexer/token.c
@@ -53,6 +53,7 @@ hb_string_T token_type_to_string(const token_type_T type) {
     case TOKEN_HTML_DOCTYPE: return hb_string("TOKEN_HTML_DOCTYPE");
     case TOKEN_XML_DECLARATION: return hb_string("TOKEN_XML_DECLARATION");
     case TOKEN_XML_DECLARATION_END: return hb_string("TOKEN_XML_DECLARATION_END");
+    case TOKEN_XML_PROCESSING_INSTRUCTION_START: return hb_string("TOKEN_XML_PROCESSING_INSTRUCTION_START");
     case TOKEN_CDATA_START: return hb_string("TOKEN_CDATA_START");
     case TOKEN_CDATA_END: return hb_string("TOKEN_CDATA_END");
     case TOKEN_HTML_TAG_START: return hb_string("TOKEN_HTML_TAG_START");
@@ -94,6 +95,7 @@ hb_string_T token_type_to_friendly_string(const token_type_T type) {
     case TOKEN_HTML_DOCTYPE: return hb_string("`<!DOCTYPE`");
     case TOKEN_XML_DECLARATION: return hb_string("`<?xml`");
     case TOKEN_XML_DECLARATION_END: return hb_string("`?>`");
+    case TOKEN_XML_PROCESSING_INSTRUCTION_START: return hb_string("`<?`");
     case TOKEN_CDATA_START: return hb_string("`<![CDATA[`");
     case TOKEN_CDATA_END: return hb_string("`]]>`");
     case TOKEN_HTML_TAG_START: return hb_string("`<`");

--- a/src/parser.c
+++ b/src/parser.c
@@ -269,6 +269,58 @@ static AST_XML_DECLARATION_NODE_T* parser_parse_xml_declaration(parser_T* parser
   return xml_declaration;
 }
 
+static AST_XML_PROCESSING_INSTRUCTION_NODE_T* parser_parse_xml_processing_instruction(parser_T* parser) {
+  hb_array_T* errors = NULL;
+  hb_array_T* children = hb_array_init(8, parser->allocator);
+  hb_buffer_T content;
+  hb_buffer_init(&content, 64, parser->allocator);
+
+  token_T* tag_opening = parser_consume_expected(parser, TOKEN_XML_PROCESSING_INSTRUCTION_START, &errors);
+  token_T* target = parser_consume_expected(parser, TOKEN_IDENTIFIER, &errors);
+
+  position_T start = parser->current_token->location.start;
+
+  while (token_is_none_of(parser, TOKEN_XML_DECLARATION_END, TOKEN_HTML_TAG_END, TOKEN_EOF)) {
+    if (token_is(parser, TOKEN_ERB_START)) {
+      parser_append_literal_node_from_buffer(parser, &content, children, start);
+
+      AST_ERB_CONTENT_NODE_T* erb_node = parser_parse_erb_tag(parser);
+      hb_array_append(children, erb_node);
+
+      start = parser->current_token->location.start;
+
+      continue;
+    }
+
+    token_T* token = parser_advance(parser);
+    hb_buffer_append_string(&content, token->value);
+    token_free(token, parser->allocator);
+  }
+
+  parser_append_literal_node_from_buffer(parser, &content, children, start);
+
+  token_type_T closing_type = token_is(parser, TOKEN_HTML_TAG_END) ? TOKEN_HTML_TAG_END : TOKEN_XML_DECLARATION_END;
+  token_T* tag_closing = parser_consume_expected(parser, closing_type, &errors);
+
+  AST_XML_PROCESSING_INSTRUCTION_NODE_T* processing_instruction = ast_xml_processing_instruction_node_init(
+    tag_opening,
+    target,
+    children,
+    tag_closing,
+    tag_opening->location.start,
+    tag_closing->location.end,
+    errors,
+    parser->allocator
+  );
+
+  token_free(tag_opening, parser->allocator);
+  token_free(target, parser->allocator);
+  token_free(tag_closing, parser->allocator);
+  hb_buffer_free(&content);
+
+  return processing_instruction;
+}
+
 static AST_HTML_TEXT_NODE_T* parser_parse_text_content(parser_T* parser, hb_array_T** document_errors) {
   position_T start = parser->current_token->location.start;
 
@@ -281,6 +333,7 @@ static AST_HTML_TEXT_NODE_T* parser_parse_text_content(parser_T* parser, hb_arra
     TOKEN_HTML_TAG_START_CLOSE,
     TOKEN_HTML_DOCTYPE,
     TOKEN_HTML_COMMENT_START,
+    TOKEN_XML_PROCESSING_INSTRUCTION_START,
     TOKEN_ERB_START,
     TOKEN_EOF
   )) {
@@ -1556,6 +1609,12 @@ static void parser_parse_in_data_state(parser_T* parser, hb_array_T* children, h
 
     if (token_is(parser, TOKEN_XML_DECLARATION)) {
       hb_array_append(children, parser_parse_xml_declaration(parser));
+      parser->consecutive_error_count = 0;
+      continue;
+    }
+
+    if (token_is(parser, TOKEN_XML_PROCESSING_INSTRUCTION_START)) {
+      hb_array_append(children, parser_parse_xml_processing_instruction(parser));
       parser->consecutive_error_count = 0;
       continue;
     }

--- a/test/engine/engine_erubi_compat_test.rb
+++ b/test/engine/engine_erubi_compat_test.rb
@@ -172,6 +172,18 @@ module Engine
       assert_compiled_snapshot(template)
     end
 
+    test "handles XML processing instructions" do
+      template = '<?xml-stylesheet type="text/xsl" href="feed.xsl"?>'
+
+      assert_compiled_snapshot(template)
+    end
+
+    test "handles XML processing instructions with ERB" do
+      template = '<?xml-stylesheet type="text/xsl" href="<%= path %>"?>'
+
+      assert_compiled_snapshot(template)
+    end
+
     test "handles empty escaped erb tag" do
       assert_evaluated_snapshot("<%%>", {}, enforce_erubi_equality: true)
     end

--- a/test/lexer/xml_processing_instruction_test.rb
+++ b/test/lexer/xml_processing_instruction_test.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+module Lexer
+  class XMLProcessingInstructionTest < Minitest::Spec
+    include SnapshotUtils
+
+    test "processing instruction without data" do
+      assert_lexed_snapshot("<?end>")
+    end
+
+    test "processing instruction with data" do
+      assert_lexed_snapshot("<?marker name=\"placeholder\">")
+    end
+
+    test "processing instruction closed with question mark" do
+      assert_lexed_snapshot("<?marker name=\"placeholder\"?>")
+    end
+
+    test "processing instruction with dashed target" do
+      assert_lexed_snapshot("<?xml-stylesheet type=\"text/xsl\" href=\"style.xsl\"?>")
+    end
+
+    test "processing instruction with colon in target" do
+      assert_lexed_snapshot("<?soap:envelope?>")
+    end
+
+    test "processing instruction with erb content" do
+      assert_lexed_snapshot("<?marker name=\"<%= placeholder_name %>\">")
+    end
+
+    test "processing instruction inside element" do
+      assert_lexed_snapshot("<div>\n  <?marker name=\"placeholder\">\n</div>")
+    end
+
+    test "processing instructions surrounding content" do
+      assert_lexed_snapshot("<div>\n  <?start name=\"another-placeholder\">\n    Loading\n  <?end>\n</div>")
+    end
+
+    test "processing instruction after text content" do
+      assert_lexed_snapshot("Hello <?marker name=\"placeholder\"> World")
+    end
+
+    test "two processing instructions" do
+      assert_lexed_snapshot("<?start name=\"a\"><?end>")
+    end
+
+    test "unterminated processing instruction" do
+      assert_lexed_snapshot("<?marker")
+    end
+
+    test "question mark without target is not a processing instruction" do
+      assert_lexed_snapshot("<? not a processing instruction>")
+    end
+
+    test "xml declaration is not a processing instruction" do
+      assert_lexed_snapshot("<?xml version=\"1.0\"?>")
+    end
+  end
+end

--- a/test/parser/xml_processing_instruction_test.rb
+++ b/test/parser/xml_processing_instruction_test.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+module Parser
+  class XMLProcessingInstructionTest < Minitest::Spec
+    include SnapshotUtils
+
+    test "processing instruction without data" do
+      assert_parsed_snapshot("<?end>")
+    end
+
+    test "processing instruction with data" do
+      assert_parsed_snapshot("<?marker name=\"placeholder\">")
+    end
+
+    test "processing instruction closed with question mark" do
+      assert_parsed_snapshot("<?marker name=\"placeholder\"?>")
+    end
+
+    test "processing instruction with dashed target" do
+      assert_parsed_snapshot("<?xml-stylesheet type=\"text/xsl\" href=\"style.xsl\"?>")
+    end
+
+    test "processing instruction with colon in target" do
+      assert_parsed_snapshot("<?soap:envelope?>")
+    end
+
+    test "processing instruction with erb content" do
+      assert_parsed_snapshot("<?marker name=\"<%= placeholder_name %>\">")
+    end
+
+    test "processing instruction inside element" do
+      assert_parsed_snapshot("<div>\n  <?marker name=\"placeholder\">\n</div>")
+    end
+
+    test "processing instructions surrounding content" do
+      assert_parsed_snapshot("<div>\n  <?start name=\"another-placeholder\">\n    Loading\n  <?end>\n</div>")
+    end
+
+    test "processing instruction after text content" do
+      assert_parsed_snapshot("Hello <?marker name=\"placeholder\"> World")
+    end
+
+    test "two processing instructions" do
+      assert_parsed_snapshot("<?start name=\"a\"><?end>")
+    end
+
+    test "unterminated processing instruction" do
+      assert_parsed_snapshot("<?marker")
+    end
+
+    test "question mark without target is not a processing instruction" do
+      assert_parsed_snapshot("<? not a processing instruction>")
+    end
+
+    test "xml declaration is not a processing instruction" do
+      assert_parsed_snapshot("<?xml version=\"1.0\"?>")
+    end
+  end
+end

--- a/test/snapshots/engine/engine_erubi_compat_test/test_0019_handles_XML_processing_instructions_fe2da85cf9572413e5f6bd20849dbfd2.txt
+++ b/test/snapshots/engine/engine_erubi_compat_test/test_0019_handles_XML_processing_instructions_fe2da85cf9572413e5f6bd20849dbfd2.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::EngineErubiCompatTest#test_0019_handles XML processing instructions"
+input: "{source: \"<?xml-stylesheet type=\\\"text/xsl\\\" href=\\\"feed.xsl\\\"?>\", options: {}}"
+---
+_buf = ::String.new; _buf << '<?xml-stylesheet type="text/xsl" href="feed.xsl"?>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/engine_erubi_compat_test/test_0019_handles_empty_escaped_erb_tag_2ff51eed9ab5e66d0ba5f4a2fb800dec.txt
+++ b/test/snapshots/engine/engine_erubi_compat_test/test_0019_handles_empty_escaped_erb_tag_2ff51eed9ab5e66d0ba5f4a2fb800dec.txt
@@ -1,4 +1,0 @@
----
-source: "Engine::EngineErubiCompatTest#test_0019_handles empty escaped erb tag"
-input: "{source: \"<%%>\", locals: {}, options: {}}"
----

--- a/test/snapshots/engine/engine_erubi_compat_test/test_0020_handles_XML_processing_instructions_with_ERB_f9ff1ba67315dc4ee3f540194a31df6d.txt
+++ b/test/snapshots/engine/engine_erubi_compat_test/test_0020_handles_XML_processing_instructions_with_ERB_f9ff1ba67315dc4ee3f540194a31df6d.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::EngineErubiCompatTest#test_0020_handles XML processing instructions with ERB"
+input: "{source: \"<?xml-stylesheet type=\\\"text/xsl\\\" href=\\\"<%= path %>\\\"?>\", options: {}}"
+---
+_buf = ::String.new; _buf << '<?xml-stylesheet type="text/xsl" href="'.freeze; _buf << (path).to_s; _buf << '"?>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/engine_erubi_compat_test/test_0020_handles_empty_escaped_erb_tag_surrounded_by_text_cb8e8f4f350c80197c2bb3071aa72239.txt
+++ b/test/snapshots/engine/engine_erubi_compat_test/test_0020_handles_empty_escaped_erb_tag_surrounded_by_text_cb8e8f4f350c80197c2bb3071aa72239.txt
@@ -1,5 +1,0 @@
----
-source: "Engine::EngineErubiCompatTest#test_0020_handles empty escaped erb tag surrounded by text"
-input: "{source: \"a <%%> b\", locals: {}, options: {}}"
----
-a  b

--- a/test/snapshots/engine/engine_erubi_compat_test/test_0021_handles_empty_escaped_erb_tag_2ff51eed9ab5e66d0ba5f4a2fb800dec.txt
+++ b/test/snapshots/engine/engine_erubi_compat_test/test_0021_handles_empty_escaped_erb_tag_2ff51eed9ab5e66d0ba5f4a2fb800dec.txt
@@ -1,0 +1,4 @@
+---
+source: "Engine::EngineErubiCompatTest#test_0021_handles empty escaped erb tag"
+input: "{source: \"<%%>\", locals: {}, options: {}}"
+---

--- a/test/snapshots/engine/engine_erubi_compat_test/test_0022_handles_empty_escaped_erb_tag_surrounded_by_text_cb8e8f4f350c80197c2bb3071aa72239.txt
+++ b/test/snapshots/engine/engine_erubi_compat_test/test_0022_handles_empty_escaped_erb_tag_surrounded_by_text_cb8e8f4f350c80197c2bb3071aa72239.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::EngineErubiCompatTest#test_0022_handles empty escaped erb tag surrounded by text"
+input: "{source: \"a <%%> b\", locals: {}, options: {}}"
+---
+a  b

--- a/test/snapshots/lexer/xml_processing_instruction_test/test_0001_processing_instruction_without_data_2974399d0f2f9db24ffe1eca5d3273c1.txt
+++ b/test/snapshots/lexer/xml_processing_instruction_test/test_0001_processing_instruction_without_data_2974399d0f2f9db24ffe1eca5d3273c1.txt
@@ -1,0 +1,8 @@
+---
+source: "Lexer::XMLProcessingInstructionTest#test_0001_processing instruction without data"
+input: "<?end>"
+---
+#<Herb::Token type="TOKEN_XML_PROCESSING_INSTRUCTION_START" value="<?" range=[0, 2] start=(1:0) end=(1:2)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="end" range=[2, 5] start=(1:2) end=(1:5)>
+#<Herb::Token type="TOKEN_HTML_TAG_END" value=">" range=[5, 6] start=(1:5) end=(1:6)>
+#<Herb::Token type="TOKEN_EOF" value="<EOF>" range=[6, 6] start=(1:6) end=(1:6)>

--- a/test/snapshots/lexer/xml_processing_instruction_test/test_0002_processing_instruction_with_data_f692120bc8059f95af851e6e0154f4dc.txt
+++ b/test/snapshots/lexer/xml_processing_instruction_test/test_0002_processing_instruction_with_data_f692120bc8059f95af851e6e0154f4dc.txt
@@ -1,0 +1,14 @@
+---
+source: "Lexer::XMLProcessingInstructionTest#test_0002_processing instruction with data"
+input: "<?marker name=\"placeholder\">"
+---
+#<Herb::Token type="TOKEN_XML_PROCESSING_INSTRUCTION_START" value="<?" range=[0, 2] start=(1:0) end=(1:2)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="marker" range=[2, 8] start=(1:2) end=(1:8)>
+#<Herb::Token type="TOKEN_WHITESPACE" value=" " range=[8, 9] start=(1:8) end=(1:9)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="name" range=[9, 13] start=(1:9) end=(1:13)>
+#<Herb::Token type="TOKEN_EQUALS" value="=" range=[13, 14] start=(1:13) end=(1:14)>
+#<Herb::Token type="TOKEN_QUOTE" value="\"" range=[14, 15] start=(1:14) end=(1:15)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="placeholder" range=[15, 26] start=(1:15) end=(1:26)>
+#<Herb::Token type="TOKEN_QUOTE" value="\"" range=[26, 27] start=(1:26) end=(1:27)>
+#<Herb::Token type="TOKEN_HTML_TAG_END" value=">" range=[27, 28] start=(1:27) end=(1:28)>
+#<Herb::Token type="TOKEN_EOF" value="<EOF>" range=[28, 28] start=(1:28) end=(1:28)>

--- a/test/snapshots/lexer/xml_processing_instruction_test/test_0003_processing_instruction_closed_with_question_mark_4beec3606abc81eedf0dbcdefb270055.txt
+++ b/test/snapshots/lexer/xml_processing_instruction_test/test_0003_processing_instruction_closed_with_question_mark_4beec3606abc81eedf0dbcdefb270055.txt
@@ -1,0 +1,14 @@
+---
+source: "Lexer::XMLProcessingInstructionTest#test_0003_processing instruction closed with question mark"
+input: "<?marker name=\"placeholder\"?>"
+---
+#<Herb::Token type="TOKEN_XML_PROCESSING_INSTRUCTION_START" value="<?" range=[0, 2] start=(1:0) end=(1:2)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="marker" range=[2, 8] start=(1:2) end=(1:8)>
+#<Herb::Token type="TOKEN_WHITESPACE" value=" " range=[8, 9] start=(1:8) end=(1:9)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="name" range=[9, 13] start=(1:9) end=(1:13)>
+#<Herb::Token type="TOKEN_EQUALS" value="=" range=[13, 14] start=(1:13) end=(1:14)>
+#<Herb::Token type="TOKEN_QUOTE" value="\"" range=[14, 15] start=(1:14) end=(1:15)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="placeholder" range=[15, 26] start=(1:15) end=(1:26)>
+#<Herb::Token type="TOKEN_QUOTE" value="\"" range=[26, 27] start=(1:26) end=(1:27)>
+#<Herb::Token type="TOKEN_XML_DECLARATION_END" value="?>" range=[27, 29] start=(1:27) end=(1:29)>
+#<Herb::Token type="TOKEN_EOF" value="<EOF>" range=[29, 29] start=(1:29) end=(1:29)>

--- a/test/snapshots/lexer/xml_processing_instruction_test/test_0004_processing_instruction_with_dashed_target_87564080d23e70599ceb99859a5c9067.txt
+++ b/test/snapshots/lexer/xml_processing_instruction_test/test_0004_processing_instruction_with_dashed_target_87564080d23e70599ceb99859a5c9067.txt
@@ -1,0 +1,24 @@
+---
+source: "Lexer::XMLProcessingInstructionTest#test_0004_processing instruction with dashed target"
+input: "<?xml-stylesheet type=\"text/xsl\" href=\"style.xsl\"?>"
+---
+#<Herb::Token type="TOKEN_XML_PROCESSING_INSTRUCTION_START" value="<?" range=[0, 2] start=(1:0) end=(1:2)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="xml-stylesheet" range=[2, 16] start=(1:2) end=(1:16)>
+#<Herb::Token type="TOKEN_WHITESPACE" value=" " range=[16, 17] start=(1:16) end=(1:17)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="type" range=[17, 21] start=(1:17) end=(1:21)>
+#<Herb::Token type="TOKEN_EQUALS" value="=" range=[21, 22] start=(1:21) end=(1:22)>
+#<Herb::Token type="TOKEN_QUOTE" value="\"" range=[22, 23] start=(1:22) end=(1:23)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="text" range=[23, 27] start=(1:23) end=(1:27)>
+#<Herb::Token type="TOKEN_SLASH" value="/" range=[27, 28] start=(1:27) end=(1:28)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="xsl" range=[28, 31] start=(1:28) end=(1:31)>
+#<Herb::Token type="TOKEN_QUOTE" value="\"" range=[31, 32] start=(1:31) end=(1:32)>
+#<Herb::Token type="TOKEN_WHITESPACE" value=" " range=[32, 33] start=(1:32) end=(1:33)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="href" range=[33, 37] start=(1:33) end=(1:37)>
+#<Herb::Token type="TOKEN_EQUALS" value="=" range=[37, 38] start=(1:37) end=(1:38)>
+#<Herb::Token type="TOKEN_QUOTE" value="\"" range=[38, 39] start=(1:38) end=(1:39)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="style" range=[39, 44] start=(1:39) end=(1:44)>
+#<Herb::Token type="TOKEN_CHARACTER" value="." range=[44, 45] start=(1:44) end=(1:45)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="xsl" range=[45, 48] start=(1:45) end=(1:48)>
+#<Herb::Token type="TOKEN_QUOTE" value="\"" range=[48, 49] start=(1:48) end=(1:49)>
+#<Herb::Token type="TOKEN_XML_DECLARATION_END" value="?>" range=[49, 51] start=(1:49) end=(1:51)>
+#<Herb::Token type="TOKEN_EOF" value="<EOF>" range=[51, 51] start=(1:51) end=(1:51)>

--- a/test/snapshots/lexer/xml_processing_instruction_test/test_0005_processing_instruction_with_colon_in_target_3d6431d0f0a2ebf9d35b7195fc7f35ef.txt
+++ b/test/snapshots/lexer/xml_processing_instruction_test/test_0005_processing_instruction_with_colon_in_target_3d6431d0f0a2ebf9d35b7195fc7f35ef.txt
@@ -1,0 +1,8 @@
+---
+source: "Lexer::XMLProcessingInstructionTest#test_0005_processing instruction with colon in target"
+input: "<?soap:envelope?>"
+---
+#<Herb::Token type="TOKEN_XML_PROCESSING_INSTRUCTION_START" value="<?" range=[0, 2] start=(1:0) end=(1:2)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="soap:envelope" range=[2, 15] start=(1:2) end=(1:15)>
+#<Herb::Token type="TOKEN_XML_DECLARATION_END" value="?>" range=[15, 17] start=(1:15) end=(1:17)>
+#<Herb::Token type="TOKEN_EOF" value="<EOF>" range=[17, 17] start=(1:17) end=(1:17)>

--- a/test/snapshots/lexer/xml_processing_instruction_test/test_0006_processing_instruction_with_erb_content_dca2241f0b5b6539a6d58f128f081595.txt
+++ b/test/snapshots/lexer/xml_processing_instruction_test/test_0006_processing_instruction_with_erb_content_dca2241f0b5b6539a6d58f128f081595.txt
@@ -1,0 +1,16 @@
+---
+source: "Lexer::XMLProcessingInstructionTest#test_0006_processing instruction with erb content"
+input: "<?marker name=\"<%= placeholder_name %>\">"
+---
+#<Herb::Token type="TOKEN_XML_PROCESSING_INSTRUCTION_START" value="<?" range=[0, 2] start=(1:0) end=(1:2)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="marker" range=[2, 8] start=(1:2) end=(1:8)>
+#<Herb::Token type="TOKEN_WHITESPACE" value=" " range=[8, 9] start=(1:8) end=(1:9)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="name" range=[9, 13] start=(1:9) end=(1:13)>
+#<Herb::Token type="TOKEN_EQUALS" value="=" range=[13, 14] start=(1:13) end=(1:14)>
+#<Herb::Token type="TOKEN_QUOTE" value="\"" range=[14, 15] start=(1:14) end=(1:15)>
+#<Herb::Token type="TOKEN_ERB_START" value="<%=" range=[15, 18] start=(1:15) end=(1:18)>
+#<Herb::Token type="TOKEN_ERB_CONTENT" value=" placeholder_name " range=[18, 36] start=(1:18) end=(1:36)>
+#<Herb::Token type="TOKEN_ERB_END" value="%>" range=[36, 38] start=(1:36) end=(1:38)>
+#<Herb::Token type="TOKEN_QUOTE" value="\"" range=[38, 39] start=(1:38) end=(1:39)>
+#<Herb::Token type="TOKEN_HTML_TAG_END" value=">" range=[39, 40] start=(1:39) end=(1:40)>
+#<Herb::Token type="TOKEN_EOF" value="<EOF>" range=[40, 40] start=(1:40) end=(1:40)>

--- a/test/snapshots/lexer/xml_processing_instruction_test/test_0007_processing_instruction_inside_element_52031cc1a9a737f2f7f668fcc93ecfc7.txt
+++ b/test/snapshots/lexer/xml_processing_instruction_test/test_0007_processing_instruction_inside_element_52031cc1a9a737f2f7f668fcc93ecfc7.txt
@@ -1,0 +1,26 @@
+---
+source: "Lexer::XMLProcessingInstructionTest#test_0007_processing instruction inside element"
+input: |2-
+<div>
+  <?marker name="placeholder">
+</div>
+---
+#<Herb::Token type="TOKEN_HTML_TAG_START" value="<" range=[0, 1] start=(1:0) end=(1:1)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="div" range=[1, 4] start=(1:1) end=(1:4)>
+#<Herb::Token type="TOKEN_HTML_TAG_END" value=">" range=[4, 5] start=(1:4) end=(1:5)>
+#<Herb::Token type="TOKEN_NEWLINE" value="\n" range=[5, 6] start=(1:5) end=(2:0)>
+#<Herb::Token type="TOKEN_WHITESPACE" value="  " range=[6, 8] start=(2:0) end=(2:2)>
+#<Herb::Token type="TOKEN_XML_PROCESSING_INSTRUCTION_START" value="<?" range=[8, 10] start=(2:2) end=(2:4)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="marker" range=[10, 16] start=(2:4) end=(2:10)>
+#<Herb::Token type="TOKEN_WHITESPACE" value=" " range=[16, 17] start=(2:10) end=(2:11)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="name" range=[17, 21] start=(2:11) end=(2:15)>
+#<Herb::Token type="TOKEN_EQUALS" value="=" range=[21, 22] start=(2:15) end=(2:16)>
+#<Herb::Token type="TOKEN_QUOTE" value="\"" range=[22, 23] start=(2:16) end=(2:17)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="placeholder" range=[23, 34] start=(2:17) end=(2:28)>
+#<Herb::Token type="TOKEN_QUOTE" value="\"" range=[34, 35] start=(2:28) end=(2:29)>
+#<Herb::Token type="TOKEN_HTML_TAG_END" value=">" range=[35, 36] start=(2:29) end=(2:30)>
+#<Herb::Token type="TOKEN_NEWLINE" value="\n" range=[36, 37] start=(2:30) end=(3:0)>
+#<Herb::Token type="TOKEN_HTML_TAG_START_CLOSE" value="</" range=[37, 39] start=(3:0) end=(3:2)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="div" range=[39, 42] start=(3:2) end=(3:5)>
+#<Herb::Token type="TOKEN_HTML_TAG_END" value=">" range=[42, 43] start=(3:5) end=(3:6)>
+#<Herb::Token type="TOKEN_EOF" value="<EOF>" range=[43, 43] start=(3:6) end=(3:6)>

--- a/test/snapshots/lexer/xml_processing_instruction_test/test_0008_processing_instructions_surrounding_content_c9016ebbf1a243695296d00a1546f06e.txt
+++ b/test/snapshots/lexer/xml_processing_instruction_test/test_0008_processing_instructions_surrounding_content_c9016ebbf1a243695296d00a1546f06e.txt
@@ -1,0 +1,36 @@
+---
+source: "Lexer::XMLProcessingInstructionTest#test_0008_processing instructions surrounding content"
+input: |2-
+<div>
+  <?start name="another-placeholder">
+    Loading
+  <?end>
+</div>
+---
+#<Herb::Token type="TOKEN_HTML_TAG_START" value="<" range=[0, 1] start=(1:0) end=(1:1)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="div" range=[1, 4] start=(1:1) end=(1:4)>
+#<Herb::Token type="TOKEN_HTML_TAG_END" value=">" range=[4, 5] start=(1:4) end=(1:5)>
+#<Herb::Token type="TOKEN_NEWLINE" value="\n" range=[5, 6] start=(1:5) end=(2:0)>
+#<Herb::Token type="TOKEN_WHITESPACE" value="  " range=[6, 8] start=(2:0) end=(2:2)>
+#<Herb::Token type="TOKEN_XML_PROCESSING_INSTRUCTION_START" value="<?" range=[8, 10] start=(2:2) end=(2:4)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="start" range=[10, 15] start=(2:4) end=(2:9)>
+#<Herb::Token type="TOKEN_WHITESPACE" value=" " range=[15, 16] start=(2:9) end=(2:10)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="name" range=[16, 20] start=(2:10) end=(2:14)>
+#<Herb::Token type="TOKEN_EQUALS" value="=" range=[20, 21] start=(2:14) end=(2:15)>
+#<Herb::Token type="TOKEN_QUOTE" value="\"" range=[21, 22] start=(2:15) end=(2:16)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="another-placeholder" range=[22, 41] start=(2:16) end=(2:35)>
+#<Herb::Token type="TOKEN_QUOTE" value="\"" range=[41, 42] start=(2:35) end=(2:36)>
+#<Herb::Token type="TOKEN_HTML_TAG_END" value=">" range=[42, 43] start=(2:36) end=(2:37)>
+#<Herb::Token type="TOKEN_NEWLINE" value="\n" range=[43, 44] start=(2:37) end=(3:0)>
+#<Herb::Token type="TOKEN_WHITESPACE" value="    " range=[44, 48] start=(3:0) end=(3:4)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="Loading" range=[48, 55] start=(3:4) end=(3:11)>
+#<Herb::Token type="TOKEN_NEWLINE" value="\n" range=[55, 56] start=(3:11) end=(4:0)>
+#<Herb::Token type="TOKEN_WHITESPACE" value="  " range=[56, 58] start=(4:0) end=(4:2)>
+#<Herb::Token type="TOKEN_XML_PROCESSING_INSTRUCTION_START" value="<?" range=[58, 60] start=(4:2) end=(4:4)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="end" range=[60, 63] start=(4:4) end=(4:7)>
+#<Herb::Token type="TOKEN_HTML_TAG_END" value=">" range=[63, 64] start=(4:7) end=(4:8)>
+#<Herb::Token type="TOKEN_NEWLINE" value="\n" range=[64, 65] start=(4:8) end=(5:0)>
+#<Herb::Token type="TOKEN_HTML_TAG_START_CLOSE" value="</" range=[65, 67] start=(5:0) end=(5:2)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="div" range=[67, 70] start=(5:2) end=(5:5)>
+#<Herb::Token type="TOKEN_HTML_TAG_END" value=">" range=[70, 71] start=(5:5) end=(5:6)>
+#<Herb::Token type="TOKEN_EOF" value="<EOF>" range=[71, 71] start=(5:6) end=(5:6)>

--- a/test/snapshots/lexer/xml_processing_instruction_test/test_0009_processing_instruction_after_text_content_4b5fb1f9ba9fc9ce6c742a73475664db.txt
+++ b/test/snapshots/lexer/xml_processing_instruction_test/test_0009_processing_instruction_after_text_content_4b5fb1f9ba9fc9ce6c742a73475664db.txt
@@ -1,0 +1,18 @@
+---
+source: "Lexer::XMLProcessingInstructionTest#test_0009_processing instruction after text content"
+input: "Hello <?marker name=\"placeholder\"> World"
+---
+#<Herb::Token type="TOKEN_IDENTIFIER" value="Hello" range=[0, 5] start=(1:0) end=(1:5)>
+#<Herb::Token type="TOKEN_WHITESPACE" value=" " range=[5, 6] start=(1:5) end=(1:6)>
+#<Herb::Token type="TOKEN_XML_PROCESSING_INSTRUCTION_START" value="<?" range=[6, 8] start=(1:6) end=(1:8)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="marker" range=[8, 14] start=(1:8) end=(1:14)>
+#<Herb::Token type="TOKEN_WHITESPACE" value=" " range=[14, 15] start=(1:14) end=(1:15)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="name" range=[15, 19] start=(1:15) end=(1:19)>
+#<Herb::Token type="TOKEN_EQUALS" value="=" range=[19, 20] start=(1:19) end=(1:20)>
+#<Herb::Token type="TOKEN_QUOTE" value="\"" range=[20, 21] start=(1:20) end=(1:21)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="placeholder" range=[21, 32] start=(1:21) end=(1:32)>
+#<Herb::Token type="TOKEN_QUOTE" value="\"" range=[32, 33] start=(1:32) end=(1:33)>
+#<Herb::Token type="TOKEN_HTML_TAG_END" value=">" range=[33, 34] start=(1:33) end=(1:34)>
+#<Herb::Token type="TOKEN_WHITESPACE" value=" " range=[34, 35] start=(1:34) end=(1:35)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="World" range=[35, 40] start=(1:35) end=(1:40)>
+#<Herb::Token type="TOKEN_EOF" value="<EOF>" range=[40, 40] start=(1:40) end=(1:40)>

--- a/test/snapshots/lexer/xml_processing_instruction_test/test_0010_two_processing_instructions_aeb41a5a42a76877cca4b020d7aa95b8.txt
+++ b/test/snapshots/lexer/xml_processing_instruction_test/test_0010_two_processing_instructions_aeb41a5a42a76877cca4b020d7aa95b8.txt
@@ -1,0 +1,17 @@
+---
+source: "Lexer::XMLProcessingInstructionTest#test_0010_two processing instructions"
+input: "<?start name=\"a\"><?end>"
+---
+#<Herb::Token type="TOKEN_XML_PROCESSING_INSTRUCTION_START" value="<?" range=[0, 2] start=(1:0) end=(1:2)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="start" range=[2, 7] start=(1:2) end=(1:7)>
+#<Herb::Token type="TOKEN_WHITESPACE" value=" " range=[7, 8] start=(1:7) end=(1:8)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="name" range=[8, 12] start=(1:8) end=(1:12)>
+#<Herb::Token type="TOKEN_EQUALS" value="=" range=[12, 13] start=(1:12) end=(1:13)>
+#<Herb::Token type="TOKEN_QUOTE" value="\"" range=[13, 14] start=(1:13) end=(1:14)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="a" range=[14, 15] start=(1:14) end=(1:15)>
+#<Herb::Token type="TOKEN_QUOTE" value="\"" range=[15, 16] start=(1:15) end=(1:16)>
+#<Herb::Token type="TOKEN_HTML_TAG_END" value=">" range=[16, 17] start=(1:16) end=(1:17)>
+#<Herb::Token type="TOKEN_XML_PROCESSING_INSTRUCTION_START" value="<?" range=[17, 19] start=(1:17) end=(1:19)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="end" range=[19, 22] start=(1:19) end=(1:22)>
+#<Herb::Token type="TOKEN_HTML_TAG_END" value=">" range=[22, 23] start=(1:22) end=(1:23)>
+#<Herb::Token type="TOKEN_EOF" value="<EOF>" range=[23, 23] start=(1:23) end=(1:23)>

--- a/test/snapshots/lexer/xml_processing_instruction_test/test_0011_unterminated_processing_instruction_2d341b116f99cab80ef71e89da139061.txt
+++ b/test/snapshots/lexer/xml_processing_instruction_test/test_0011_unterminated_processing_instruction_2d341b116f99cab80ef71e89da139061.txt
@@ -1,0 +1,7 @@
+---
+source: "Lexer::XMLProcessingInstructionTest#test_0011_unterminated processing instruction"
+input: "<?marker"
+---
+#<Herb::Token type="TOKEN_XML_PROCESSING_INSTRUCTION_START" value="<?" range=[0, 2] start=(1:0) end=(1:2)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="marker" range=[2, 8] start=(1:2) end=(1:8)>
+#<Herb::Token type="TOKEN_EOF" value="<EOF>" range=[8, 8] start=(1:8) end=(1:8)>

--- a/test/snapshots/lexer/xml_processing_instruction_test/test_0012_question_mark_without_target_is_not_a_processing_instruction_c88e04af55c8957c73de4af60894e817.txt
+++ b/test/snapshots/lexer/xml_processing_instruction_test/test_0012_question_mark_without_target_is_not_a_processing_instruction_c88e04af55c8957c73de4af60894e817.txt
@@ -1,0 +1,16 @@
+---
+source: "Lexer::XMLProcessingInstructionTest#test_0012_question mark without target is not a processing instruction"
+input: "<? not a processing instruction>"
+---
+#<Herb::Token type="TOKEN_LT" value="<" range=[0, 1] start=(1:0) end=(1:1)>
+#<Herb::Token type="TOKEN_CHARACTER" value="?" range=[1, 2] start=(1:1) end=(1:2)>
+#<Herb::Token type="TOKEN_WHITESPACE" value=" " range=[2, 3] start=(1:2) end=(1:3)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="not" range=[3, 6] start=(1:3) end=(1:6)>
+#<Herb::Token type="TOKEN_WHITESPACE" value=" " range=[6, 7] start=(1:6) end=(1:7)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="a" range=[7, 8] start=(1:7) end=(1:8)>
+#<Herb::Token type="TOKEN_WHITESPACE" value=" " range=[8, 9] start=(1:8) end=(1:9)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="processing" range=[9, 19] start=(1:9) end=(1:19)>
+#<Herb::Token type="TOKEN_WHITESPACE" value=" " range=[19, 20] start=(1:19) end=(1:20)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="instruction" range=[20, 31] start=(1:20) end=(1:31)>
+#<Herb::Token type="TOKEN_HTML_TAG_END" value=">" range=[31, 32] start=(1:31) end=(1:32)>
+#<Herb::Token type="TOKEN_EOF" value="<EOF>" range=[32, 32] start=(1:32) end=(1:32)>

--- a/test/snapshots/lexer/xml_processing_instruction_test/test_0013_xml_declaration_is_not_a_processing_instruction_e4e345519e2b76863647d3351ace49e0.txt
+++ b/test/snapshots/lexer/xml_processing_instruction_test/test_0013_xml_declaration_is_not_a_processing_instruction_e4e345519e2b76863647d3351ace49e0.txt
@@ -1,0 +1,15 @@
+---
+source: "Lexer::XMLProcessingInstructionTest#test_0013_xml declaration is not a processing instruction"
+input: "<?xml version=\"1.0\"?>"
+---
+#<Herb::Token type="TOKEN_XML_DECLARATION" value="<?xml" range=[0, 5] start=(1:0) end=(1:5)>
+#<Herb::Token type="TOKEN_WHITESPACE" value=" " range=[5, 6] start=(1:5) end=(1:6)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="version" range=[6, 13] start=(1:6) end=(1:13)>
+#<Herb::Token type="TOKEN_EQUALS" value="=" range=[13, 14] start=(1:13) end=(1:14)>
+#<Herb::Token type="TOKEN_QUOTE" value="\"" range=[14, 15] start=(1:14) end=(1:15)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="1" range=[15, 16] start=(1:15) end=(1:16)>
+#<Herb::Token type="TOKEN_CHARACTER" value="." range=[16, 17] start=(1:16) end=(1:17)>
+#<Herb::Token type="TOKEN_IDENTIFIER" value="0" range=[17, 18] start=(1:17) end=(1:18)>
+#<Herb::Token type="TOKEN_QUOTE" value="\"" range=[18, 19] start=(1:18) end=(1:19)>
+#<Herb::Token type="TOKEN_XML_DECLARATION_END" value="?>" range=[19, 21] start=(1:19) end=(1:21)>
+#<Herb::Token type="TOKEN_EOF" value="<EOF>" range=[21, 21] start=(1:21) end=(1:21)>

--- a/test/snapshots/parser/xml_processing_instruction_test/test_0001_processing_instruction_without_data_2974399d0f2f9db24ffe1eca5d3273c1.txt
+++ b/test/snapshots/parser/xml_processing_instruction_test/test_0001_processing_instruction_without_data_2974399d0f2f9db24ffe1eca5d3273c1.txt
@@ -1,0 +1,11 @@
+---
+source: "Parser::XMLProcessingInstructionTest#test_0001_processing instruction without data"
+input: "<?end>"
+---
+@ DocumentNode (location: (1:0)-(1:6))
+└── children: (1 item)
+    └── @ XMLProcessingInstructionNode (location: (1:0)-(1:6))
+        ├── tag_opening: "<?" (location: (1:0)-(1:2))
+        ├── target: "end" (location: (1:2)-(1:5))
+        ├── children: []
+        └── tag_closing: ">" (location: (1:5)-(1:6))

--- a/test/snapshots/parser/xml_processing_instruction_test/test_0002_processing_instruction_with_data_f692120bc8059f95af851e6e0154f4dc.txt
+++ b/test/snapshots/parser/xml_processing_instruction_test/test_0002_processing_instruction_with_data_f692120bc8059f95af851e6e0154f4dc.txt
@@ -1,0 +1,14 @@
+---
+source: "Parser::XMLProcessingInstructionTest#test_0002_processing instruction with data"
+input: "<?marker name=\"placeholder\">"
+---
+@ DocumentNode (location: (1:0)-(1:28))
+└── children: (1 item)
+    └── @ XMLProcessingInstructionNode (location: (1:0)-(1:28))
+        ├── tag_opening: "<?" (location: (1:0)-(1:2))
+        ├── target: "marker" (location: (1:2)-(1:8))
+        ├── children: (1 item)
+        │   └── @ LiteralNode (location: (1:8)-(1:27))
+        │       └── content: " name=\"placeholder\""
+        │
+        └── tag_closing: ">" (location: (1:27)-(1:28))

--- a/test/snapshots/parser/xml_processing_instruction_test/test_0003_processing_instruction_closed_with_question_mark_4beec3606abc81eedf0dbcdefb270055.txt
+++ b/test/snapshots/parser/xml_processing_instruction_test/test_0003_processing_instruction_closed_with_question_mark_4beec3606abc81eedf0dbcdefb270055.txt
@@ -1,0 +1,14 @@
+---
+source: "Parser::XMLProcessingInstructionTest#test_0003_processing instruction closed with question mark"
+input: "<?marker name=\"placeholder\"?>"
+---
+@ DocumentNode (location: (1:0)-(1:29))
+└── children: (1 item)
+    └── @ XMLProcessingInstructionNode (location: (1:0)-(1:29))
+        ├── tag_opening: "<?" (location: (1:0)-(1:2))
+        ├── target: "marker" (location: (1:2)-(1:8))
+        ├── children: (1 item)
+        │   └── @ LiteralNode (location: (1:8)-(1:27))
+        │       └── content: " name=\"placeholder\""
+        │
+        └── tag_closing: "?>" (location: (1:27)-(1:29))

--- a/test/snapshots/parser/xml_processing_instruction_test/test_0004_processing_instruction_with_dashed_target_87564080d23e70599ceb99859a5c9067.txt
+++ b/test/snapshots/parser/xml_processing_instruction_test/test_0004_processing_instruction_with_dashed_target_87564080d23e70599ceb99859a5c9067.txt
@@ -1,0 +1,14 @@
+---
+source: "Parser::XMLProcessingInstructionTest#test_0004_processing instruction with dashed target"
+input: "<?xml-stylesheet type=\"text/xsl\" href=\"style.xsl\"?>"
+---
+@ DocumentNode (location: (1:0)-(1:51))
+└── children: (1 item)
+    └── @ XMLProcessingInstructionNode (location: (1:0)-(1:51))
+        ├── tag_opening: "<?" (location: (1:0)-(1:2))
+        ├── target: "xml-stylesheet" (location: (1:2)-(1:16))
+        ├── children: (1 item)
+        │   └── @ LiteralNode (location: (1:16)-(1:49))
+        │       └── content: " type=\"text/xsl\" href=\"style.xsl\""
+        │
+        └── tag_closing: "?>" (location: (1:49)-(1:51))

--- a/test/snapshots/parser/xml_processing_instruction_test/test_0005_processing_instruction_with_colon_in_target_3d6431d0f0a2ebf9d35b7195fc7f35ef.txt
+++ b/test/snapshots/parser/xml_processing_instruction_test/test_0005_processing_instruction_with_colon_in_target_3d6431d0f0a2ebf9d35b7195fc7f35ef.txt
@@ -1,0 +1,11 @@
+---
+source: "Parser::XMLProcessingInstructionTest#test_0005_processing instruction with colon in target"
+input: "<?soap:envelope?>"
+---
+@ DocumentNode (location: (1:0)-(1:17))
+└── children: (1 item)
+    └── @ XMLProcessingInstructionNode (location: (1:0)-(1:17))
+        ├── tag_opening: "<?" (location: (1:0)-(1:2))
+        ├── target: "soap:envelope" (location: (1:2)-(1:15))
+        ├── children: []
+        └── tag_closing: "?>" (location: (1:15)-(1:17))

--- a/test/snapshots/parser/xml_processing_instruction_test/test_0006_processing_instruction_with_erb_content_dca2241f0b5b6539a6d58f128f081595.txt
+++ b/test/snapshots/parser/xml_processing_instruction_test/test_0006_processing_instruction_with_erb_content_dca2241f0b5b6539a6d58f128f081595.txt
@@ -1,0 +1,24 @@
+---
+source: "Parser::XMLProcessingInstructionTest#test_0006_processing instruction with erb content"
+input: "<?marker name=\"<%= placeholder_name %>\">"
+---
+@ DocumentNode (location: (1:0)-(1:40))
+└── children: (1 item)
+    └── @ XMLProcessingInstructionNode (location: (1:0)-(1:40))
+        ├── tag_opening: "<?" (location: (1:0)-(1:2))
+        ├── target: "marker" (location: (1:2)-(1:8))
+        ├── children: (3 items)
+        │   ├── @ LiteralNode (location: (1:8)-(1:15))
+        │   │   └── content: " name=\""
+        │   │
+        │   ├── @ ERBContentNode (location: (1:15)-(1:38))
+        │   │   ├── tag_opening: "<%=" (location: (1:15)-(1:18))
+        │   │   ├── content: " placeholder_name " (location: (1:18)-(1:36))
+        │   │   ├── tag_closing: "%>" (location: (1:36)-(1:38))
+        │   │   ├── parsed: true
+        │   │   └── valid: true
+        │   │
+        │   └── @ LiteralNode (location: (1:38)-(1:39))
+        │       └── content: "\""
+        │
+        └── tag_closing: ">" (location: (1:39)-(1:40))

--- a/test/snapshots/parser/xml_processing_instruction_test/test_0007_processing_instruction_inside_element_52031cc1a9a737f2f7f668fcc93ecfc7.txt
+++ b/test/snapshots/parser/xml_processing_instruction_test/test_0007_processing_instruction_inside_element_52031cc1a9a737f2f7f668fcc93ecfc7.txt
@@ -1,0 +1,44 @@
+---
+source: "Parser::XMLProcessingInstructionTest#test_0007_processing instruction inside element"
+input: |2-
+<div>
+  <?marker name="placeholder">
+</div>
+---
+@ DocumentNode (location: (1:0)-(3:6))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(3:6))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:5))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "div" (location: (1:1)-(1:4))
+        │       ├── tag_closing: ">" (location: (1:4)-(1:5))
+        │       ├── children: []
+        │       └── is_void: false
+        │
+        ├── tag_name: "div" (location: (1:1)-(1:4))
+        ├── body: (3 items)
+        │   ├── @ HTMLTextNode (location: (1:5)-(2:2))
+        │   │   └── content: "\n  "
+        │   │
+        │   ├── @ XMLProcessingInstructionNode (location: (2:2)-(2:30))
+        │   │   ├── tag_opening: "<?" (location: (2:2)-(2:4))
+        │   │   ├── target: "marker" (location: (2:4)-(2:10))
+        │   │   ├── children: (1 item)
+        │   │   │   └── @ LiteralNode (location: (2:10)-(2:29))
+        │   │   │       └── content: " name=\"placeholder\""
+        │   │   │
+        │   │   └── tag_closing: ">" (location: (2:29)-(2:30))
+        │   │
+        │   └── @ HTMLTextNode (location: (2:30)-(3:0))
+        │       └── content: "\n"
+        │
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (3:0)-(3:6))
+        │       ├── tag_opening: "</" (location: (3:0)-(3:2))
+        │       ├── tag_name: "div" (location: (3:2)-(3:5))
+        │       ├── children: []
+        │       └── tag_closing: ">" (location: (3:5)-(3:6))
+        │
+        ├── is_void: false
+        └── element_source: "HTML"

--- a/test/snapshots/parser/xml_processing_instruction_test/test_0008_processing_instructions_surrounding_content_c9016ebbf1a243695296d00a1546f06e.txt
+++ b/test/snapshots/parser/xml_processing_instruction_test/test_0008_processing_instructions_surrounding_content_c9016ebbf1a243695296d00a1546f06e.txt
@@ -1,0 +1,55 @@
+---
+source: "Parser::XMLProcessingInstructionTest#test_0008_processing instructions surrounding content"
+input: |2-
+<div>
+  <?start name="another-placeholder">
+    Loading
+  <?end>
+</div>
+---
+@ DocumentNode (location: (1:0)-(5:6))
+└── children: (1 item)
+    └── @ HTMLElementNode (location: (1:0)-(5:6))
+        ├── open_tag:
+        │   └── @ HTMLOpenTagNode (location: (1:0)-(1:5))
+        │       ├── tag_opening: "<" (location: (1:0)-(1:1))
+        │       ├── tag_name: "div" (location: (1:1)-(1:4))
+        │       ├── tag_closing: ">" (location: (1:4)-(1:5))
+        │       ├── children: []
+        │       └── is_void: false
+        │
+        ├── tag_name: "div" (location: (1:1)-(1:4))
+        ├── body: (5 items)
+        │   ├── @ HTMLTextNode (location: (1:5)-(2:2))
+        │   │   └── content: "\n  "
+        │   │
+        │   ├── @ XMLProcessingInstructionNode (location: (2:2)-(2:37))
+        │   │   ├── tag_opening: "<?" (location: (2:2)-(2:4))
+        │   │   ├── target: "start" (location: (2:4)-(2:9))
+        │   │   ├── children: (1 item)
+        │   │   │   └── @ LiteralNode (location: (2:9)-(2:36))
+        │   │   │       └── content: " name=\"another-placeholder\""
+        │   │   │
+        │   │   └── tag_closing: ">" (location: (2:36)-(2:37))
+        │   │
+        │   ├── @ HTMLTextNode (location: (2:37)-(4:2))
+        │   │   └── content: "\n    Loading\n  "
+        │   │
+        │   ├── @ XMLProcessingInstructionNode (location: (4:2)-(4:8))
+        │   │   ├── tag_opening: "<?" (location: (4:2)-(4:4))
+        │   │   ├── target: "end" (location: (4:4)-(4:7))
+        │   │   ├── children: []
+        │   │   └── tag_closing: ">" (location: (4:7)-(4:8))
+        │   │
+        │   └── @ HTMLTextNode (location: (4:8)-(5:0))
+        │       └── content: "\n"
+        │
+        ├── close_tag:
+        │   └── @ HTMLCloseTagNode (location: (5:0)-(5:6))
+        │       ├── tag_opening: "</" (location: (5:0)-(5:2))
+        │       ├── tag_name: "div" (location: (5:2)-(5:5))
+        │       ├── children: []
+        │       └── tag_closing: ">" (location: (5:5)-(5:6))
+        │
+        ├── is_void: false
+        └── element_source: "HTML"

--- a/test/snapshots/parser/xml_processing_instruction_test/test_0009_processing_instruction_after_text_content_4b5fb1f9ba9fc9ce6c742a73475664db.txt
+++ b/test/snapshots/parser/xml_processing_instruction_test/test_0009_processing_instruction_after_text_content_4b5fb1f9ba9fc9ce6c742a73475664db.txt
@@ -1,0 +1,20 @@
+---
+source: "Parser::XMLProcessingInstructionTest#test_0009_processing instruction after text content"
+input: "Hello <?marker name=\"placeholder\"> World"
+---
+@ DocumentNode (location: (1:0)-(1:40))
+└── children: (3 items)
+    ├── @ HTMLTextNode (location: (1:0)-(1:6))
+    │   └── content: "Hello "
+    │
+    ├── @ XMLProcessingInstructionNode (location: (1:6)-(1:34))
+    │   ├── tag_opening: "<?" (location: (1:6)-(1:8))
+    │   ├── target: "marker" (location: (1:8)-(1:14))
+    │   ├── children: (1 item)
+    │   │   └── @ LiteralNode (location: (1:14)-(1:33))
+    │   │       └── content: " name=\"placeholder\""
+    │   │
+    │   └── tag_closing: ">" (location: (1:33)-(1:34))
+    │
+    └── @ HTMLTextNode (location: (1:34)-(1:40))
+        └── content: " World"

--- a/test/snapshots/parser/xml_processing_instruction_test/test_0010_two_processing_instructions_aeb41a5a42a76877cca4b020d7aa95b8.txt
+++ b/test/snapshots/parser/xml_processing_instruction_test/test_0010_two_processing_instructions_aeb41a5a42a76877cca4b020d7aa95b8.txt
@@ -1,0 +1,20 @@
+---
+source: "Parser::XMLProcessingInstructionTest#test_0010_two processing instructions"
+input: "<?start name=\"a\"><?end>"
+---
+@ DocumentNode (location: (1:0)-(1:23))
+└── children: (2 items)
+    ├── @ XMLProcessingInstructionNode (location: (1:0)-(1:17))
+    │   ├── tag_opening: "<?" (location: (1:0)-(1:2))
+    │   ├── target: "start" (location: (1:2)-(1:7))
+    │   ├── children: (1 item)
+    │   │   └── @ LiteralNode (location: (1:7)-(1:16))
+    │   │       └── content: " name=\"a\""
+    │   │
+    │   └── tag_closing: ">" (location: (1:16)-(1:17))
+    │
+    └── @ XMLProcessingInstructionNode (location: (1:17)-(1:23))
+        ├── tag_opening: "<?" (location: (1:17)-(1:19))
+        ├── target: "end" (location: (1:19)-(1:22))
+        ├── children: []
+        └── tag_closing: ">" (location: (1:22)-(1:23))

--- a/test/snapshots/parser/xml_processing_instruction_test/test_0011_unterminated_processing_instruction_2d341b116f99cab80ef71e89da139061.txt
+++ b/test/snapshots/parser/xml_processing_instruction_test/test_0011_unterminated_processing_instruction_2d341b116f99cab80ef71e89da139061.txt
@@ -1,0 +1,17 @@
+---
+source: "Parser::XMLProcessingInstructionTest#test_0011_unterminated processing instruction"
+input: "<?marker"
+---
+@ DocumentNode (location: (1:0)-(1:8))
+└── children: (1 item)
+    └── @ XMLProcessingInstructionNode (location: (1:0)-(1:8))
+        ├── errors: (1 error)
+        │   └── @ UnexpectedTokenError (location: (1:8)-(1:8))
+        │       ├── message: "Found end of file when expecting `?>` at (1:8)."
+        │       ├── expected_type: "TOKEN_XML_DECLARATION_END"
+        │       └── found: "" (location: (1:8)-(1:8))
+        │
+        ├── tag_opening: "<?" (location: (1:0)-(1:2))
+        ├── target: "marker" (location: (1:2)-(1:8))
+        ├── children: []
+        └── tag_closing: "" (location: (1:8)-(1:8))

--- a/test/snapshots/parser/xml_processing_instruction_test/test_0012_question_mark_without_target_is_not_a_processing_instruction_c88e04af55c8957c73de4af60894e817.txt
+++ b/test/snapshots/parser/xml_processing_instruction_test/test_0012_question_mark_without_target_is_not_a_processing_instruction_c88e04af55c8957c73de4af60894e817.txt
@@ -1,0 +1,8 @@
+---
+source: "Parser::XMLProcessingInstructionTest#test_0012_question mark without target is not a processing instruction"
+input: "<? not a processing instruction>"
+---
+@ DocumentNode (location: (1:0)-(1:32))
+└── children: (1 item)
+    └── @ HTMLTextNode (location: (1:0)-(1:32))
+        └── content: "<? not a processing instruction>"

--- a/test/snapshots/parser/xml_processing_instruction_test/test_0013_xml_declaration_is_not_a_processing_instruction_e4e345519e2b76863647d3351ace49e0.txt
+++ b/test/snapshots/parser/xml_processing_instruction_test/test_0013_xml_declaration_is_not_a_processing_instruction_e4e345519e2b76863647d3351ace49e0.txt
@@ -1,0 +1,13 @@
+---
+source: "Parser::XMLProcessingInstructionTest#test_0013_xml declaration is not a processing instruction"
+input: "<?xml version=\"1.0\"?>"
+---
+@ DocumentNode (location: (1:0)-(1:21))
+└── children: (1 item)
+    └── @ XMLDeclarationNode (location: (1:0)-(1:21))
+        ├── tag_opening: "<?xml" (location: (1:0)-(1:5))
+        ├── children: (1 item)
+        │   └── @ LiteralNode (location: (1:5)-(1:19))
+        │       └── content: " version=\"1.0\""
+        │
+        └── tag_closing: "?>" (location: (1:19)-(1:21))


### PR DESCRIPTION
This pull request introduces `XMLProcessingInstructionNode` so that XML processing instructions get their own node and survive a round trip through the parser, the printers, and the engine.

Herb only recognized the XML declaration, `<?xml version="1.0"?>`. Every other processing instruction fell through to text content, so `<?marker name="placeholder">` came back as an `HTMLTextNode` with no way to tell it apart from the prose around it. 

The `<?xml` check was also a plain prefix match, which meant `<?xml-stylesheet type="text/xsl" href="style.xsl"?>` lexed as an XML declaration with a `-stylesheet ...` literal hanging off it.

```xml
<?marker name="placeholder">
```

```js
@ DocumentNode (location: (1:0)-(1:28))
└── children: (1 item)
    └── @ XMLProcessingInstructionNode (location: (1:0)-(1:28))
        ├── tag_opening: "<?" (location: (1:0)-(1:2))
        ├── target: "marker" (location: (1:2)-(1:8))
        ├── children: (1 item)
        │   └── @ LiteralNode (location: (1:8)-(1:27))
        │       └── content: " name=\"placeholder\""
        │
        └── tag_closing: ">" (location: (1:27)-(1:28))
```

ERB inside an instruction is interpolated into `children`, the same way it already works for comments and doctypes.

```xml
<?marker name="<%= placeholder_name %>">
```

```js
@ DocumentNode (location: (1:0)-(1:40))
└── children: (1 item)
    └── @ XMLProcessingInstructionNode (location: (1:0)-(1:40))
        ├── tag_opening: "<?" (location: (1:0)-(1:2))
        ├── target: "marker" (location: (1:2)-(1:8))
        ├── children: (3 items)
        │   ├── @ LiteralNode (location: (1:8)-(1:15))
        │   │   └── content: " name=\""
        │   │
        │   ├── @ ERBContentNode (location: (1:15)-(1:38))
        │   │   ├── tag_opening: "<%=" (location: (1:15)-(1:18))
        │   │   ├── content: " placeholder_name " (location: (1:18)-(1:36))
        │   │   ├── tag_closing: "%>" (location: (1:36)-(1:38))
        │   │   ├── parsed: true
        │   │   └── valid: true
        │   │
        │   └── @ LiteralNode (location: (1:38)-(1:39))
        │       └── content: "\""
        │
        └── tag_closing: ">" (location: (1:39)-(1:40))
```

Both `?>` and `>` terminate an instruction, so `<?target content>` and `<?target content?>` both parse.

Resolves #2259 