### PR TITLE
Linter: Improve locations for `erb-strict-locals-comment-syntax` 

### DIFF
--- a/javascript/packages/linter/src/rules/erb-strict-locals-comment-syntax.ts
+++ b/javascript/packages/linter/src/rules/erb-strict-locals-comment-syntax.ts
@@ -1,11 +1,11 @@
-import { BaseRuleVisitor } from "./rule-utils.js"
+import { BaseRuleVisitor, locationFromContentOffset } from "./rule-utils.js"
 import { ParserRule } from "../types.js"
 
-import { isRubyParameterNode } from "@herb-tools/core"
+import { isRubyParameterNode, Location } from "@herb-tools/core"
 import { extractRubyCommentContent, looksLikeLocalsDeclaration } from "./strict-locals-utils.js"
 
 import type { BaseAutofixContext, Mutable, UnboundLintOffense, LintOffense, LintContext, FullRuleConfig } from "../types.js"
-import type {ParseResult, ERBContentNode, ERBStrictLocalsNode, RubyParseError, HerbError } from "@herb-tools/core"
+import type { ParseResult, ERBContentNode, ERBStrictLocalsNode, RubyParseError, HerbError } from "@herb-tools/core"
 
 const LOCALS_PREFIX = "locals:"
 
@@ -53,8 +53,26 @@ function detectMissingColonBeforeParens(content: string): boolean {
   return /^locals\s+\(/.test(content)
 }
 
-function hasError(node: { errors: HerbError[] }, type: string): boolean {
-  return node.errors.some((error) => error.type === type)
+function errorOfType(node: { errors: HerbError[] }, type: string): HerbError | undefined {
+  return node.errors.find((error) => error.type === type)
+}
+
+function contentLocation(node: StrictLocalsCommentNode, offset: number, length = 1): Location {
+  const content = node.content
+  if (!content) return node.location
+
+  const base = content.location.start
+
+  const start = locationFromContentOffset(base.line, base.column, content.value, offset).start
+  const end = locationFromContentOffset(base.line, base.column, content.value, offset + length).start
+
+  return new Location(start, end)
+}
+
+function contentMatchLocation(node: StrictLocalsCommentNode, text: string): Location {
+  const offset = node.content?.value.indexOf(text) ?? -1
+
+  return offset === -1 ? node.location : contentLocation(node, offset, text.length)
 }
 
 function skipStringLiteral(content: string, index: number): number {
@@ -154,10 +172,13 @@ function keywordizeParameters(content: string, parameters: Parameters, name?: st
 function suggestedParameters(inner: string): string {
   const parameters = `(${inner})`
 
-  return keywordizeParameters(parameters, scanParameters(parameters, 0)) ?? parameters
+  return (
+    keywordizeParameters(parameters, scanParameters(parameters, 0)) ??
+    parameters
+  )
 }
 
-function removeExtraCommas(content: string, parameters: Parameters): string | null {
+function extraCommaRanges(content: string, parameters: Parameters): Segment[] | null {
   if (parameters.close === null) return null
 
   const ranges: Segment[] = []
@@ -176,7 +197,13 @@ function removeExtraCommas(content: string, parameters: Parameters): string | nu
     }
   }
 
-  if (ranges.length === 0) return null
+  return ranges
+}
+
+function removeExtraCommas(content: string, parameters: Parameters): string | null {
+  const ranges = extraCommaRanges(content, parameters)
+
+  if (!ranges || ranges.length === 0) return null
 
   let result = content
 
@@ -283,10 +310,12 @@ function applyFix(node: Mutable<StrictLocalsCommentNode>, fix: StrictLocalsFix):
 
 class ERBStrictLocalsCommentSyntaxVisitor extends BaseRuleVisitor<ERBStrictLocalsCommentSyntaxAutofixContext> {
   visitERBStrictLocalsNode(node: ERBStrictLocalsNode): void {
-    if (hasError(node, "STRICT_LOCALS_DUPLICATE_DECLARATION_ERROR")) {
+    const duplicateError = errorOfType(node, "STRICT_LOCALS_DUPLICATE_DECLARATION_ERROR")
+
+    if (duplicateError) {
       this.addOffense(
         "Duplicate strict locals declaration. Rails only uses the first `<%# locals: (...) %>` declaration in a partial.",
-        node.location,
+        contentMatchLocation(node, LOCALS_PREFIX),
       )
     }
 
@@ -296,19 +325,24 @@ class ERBStrictLocalsCommentSyntaxVisitor extends BaseRuleVisitor<ERBStrictLocal
     if (afterLocals.length > 0 && !/^\s/.test(afterLocals)) {
       this.addOffense(
         "Missing space after `locals:`. Rails Strict Locals require a space after the colon: `<%# locals: (...) %>`.",
-        node.location,
+        contentLocation(
+          node,
+          content.indexOf(LOCALS_PREFIX) + LOCALS_PREFIX.length,
+        ),
         this.contextFor(node, { type: "space-after-colon" }),
       )
     }
 
-    if (hasError(node, "STRICT_LOCALS_MISSING_PARENTHESIS_ERROR")) {
+    const missingParenthesisError = errorOfType(node, "STRICT_LOCALS_MISSING_PARENTHESIS_ERROR")
+
+    if (missingParenthesisError) {
       const parameters = afterLocals.trim()
 
       this.addOffense(
         parameters.length === 0
           ? "Strict locals declarations always need parentheses. Use `<%# locals: () %>` for a partial without locals."
           : `Strict locals parameters must be wrapped in parentheses. Use \`<%# locals: ${suggestedParameters(parameters)} %>\`.`,
-        node.location,
+        missingParenthesisError.location,
         this.contextFor(node, { type: "wrap-parameters" }),
       )
 
@@ -332,7 +366,7 @@ class ERBStrictLocalsCommentSyntaxVisitor extends BaseRuleVisitor<ERBStrictLocal
       if (rubyComment && looksLikeLocalsDeclaration(rubyComment)) {
         this.addOffense(
           `Use \`<%#\` instead of \`${openingTag} #\` for strict locals comments. Only ERB comment syntax is recognized.`,
-          node.location,
+          node.tag_opening?.location ?? node.location,
           this.contextFor(node, { type: "erb-comment-tag" }),
         )
       }
@@ -350,7 +384,7 @@ class ERBStrictLocalsCommentSyntaxVisitor extends BaseRuleVisitor<ERBStrictLocal
     if (detectSingularLocal(commentContent)) {
       this.addOffense(
         "Use `locals:` (plural), not `local:`.",
-        node.location,
+        contentMatchLocation(node, "local:"),
         this.contextFor(node, { type: "plural-locals" }),
       )
 
@@ -360,7 +394,7 @@ class ERBStrictLocalsCommentSyntaxVisitor extends BaseRuleVisitor<ERBStrictLocal
     if (detectLocalsWithoutColon(commentContent)) {
       this.addOffense(
         "Use `locals:` with a colon, not `locals()`. Correct format: `<%# locals: (...) %>`.",
-        node.location,
+        contentMatchLocation(node, "locals"),
         this.contextFor(node, { type: "colon-after-locals" }),
       )
 
@@ -370,7 +404,7 @@ class ERBStrictLocalsCommentSyntaxVisitor extends BaseRuleVisitor<ERBStrictLocal
     if (detectMissingColonBeforeParens(commentContent)) {
       this.addOffense(
         "Use `locals:` with a colon before the parentheses, not `locals (`.",
-        node.location,
+        contentMatchLocation(node, "locals"),
         this.contextFor(node, { type: "colon-after-locals" }),
       )
 
@@ -379,7 +413,9 @@ class ERBStrictLocalsCommentSyntaxVisitor extends BaseRuleVisitor<ERBStrictLocal
   }
 
   private reportSyntaxErrors(node: ERBStrictLocalsNode, content: string): boolean {
-    const syntaxErrors = node.errors.filter((error): error is RubyParseError => error.type === "RUBY_PARSE_ERROR")
+    const syntaxErrors = node.errors.filter(
+      (error): error is RubyParseError => error.type === "RUBY_PARSE_ERROR",
+    )
     if (syntaxErrors.length === 0) return false
 
     const parameters = findParameters(content)
@@ -387,17 +423,19 @@ class ERBStrictLocalsCommentSyntaxVisitor extends BaseRuleVisitor<ERBStrictLocal
     if (parameters && parameters.close === null) {
       this.addOffense(
         "Unbalanced parentheses in the strict locals declaration. Add the missing closing `)`.",
-        node.location,
+        contentLocation(node, parameters.open),
         this.contextFor(node, { type: "close-parameters" }),
       )
 
       return true
     }
 
-    if (parameters && removeExtraCommas(content, parameters) !== null) {
+    const extraCommas = parameters ? extraCommaRanges(content, parameters) : null
+
+    if (extraCommas && extraCommas.length > 0) {
       this.addOffense(
         "Remove the extra comma from the strict locals parameters.",
-        node.location,
+        contentLocation(node, extraCommas[0].start),
         this.contextFor(node, { type: "remove-extra-commas" }),
       )
 
@@ -406,7 +444,7 @@ class ERBStrictLocalsCommentSyntaxVisitor extends BaseRuleVisitor<ERBStrictLocal
 
     this.addOffense(
       `Invalid Ruby syntax in the strict locals declaration: ${syntaxErrors[0].error_message}.`,
-      node.location,
+      syntaxErrors[0].location,
     )
 
     return true
@@ -422,18 +460,18 @@ class ERBStrictLocalsCommentSyntaxVisitor extends BaseRuleVisitor<ERBStrictLocal
         if (error.type === "STRICT_LOCALS_POSITIONAL_ARGUMENT_ERROR") {
           this.addOffense(
             `Strict locals only support keyword arguments. Use \`${name}:\` instead of the positional argument \`${name}\`.`,
-            local.location,
+            error.location,
             this.contextFor(node, { type: "keyword-argument", name }),
           )
         } else if (error.type === "STRICT_LOCALS_SPLAT_ARGUMENT_ERROR") {
           this.addOffense(
             `Strict locals only support keyword arguments. The splat argument \`*${name}\` is not supported. Use \`**${name}\` to accept arbitrary keyword arguments.`,
-            local.location,
+            error.location,
           )
         } else if (error.type === "STRICT_LOCALS_BLOCK_ARGUMENT_ERROR") {
           this.addOffense(
             `Strict locals only support keyword arguments. The block argument \`&${name}\` is not supported.`,
-            local.location,
+            error.location,
           )
         }
       }
@@ -471,10 +509,7 @@ export class ERBStrictLocalsCommentSyntaxRule extends ParserRule<ERBStrictLocals
     }
   }
 
-  check(
-    result: ParseResult,
-    context?: Partial<LintContext>,
-  ): UnboundLintOffense<ERBStrictLocalsCommentSyntaxAutofixContext>[] {
+  check(result: ParseResult, context?: Partial<LintContext>): UnboundLintOffense<ERBStrictLocalsCommentSyntaxAutofixContext>[] {
     const visitor = new ERBStrictLocalsCommentSyntaxVisitor(
       this.ruleName,
       context,
@@ -485,10 +520,7 @@ export class ERBStrictLocalsCommentSyntaxRule extends ParserRule<ERBStrictLocals
     return visitor.offenses
   }
 
-  autofix(
-    offense: LintOffense<ERBStrictLocalsCommentSyntaxAutofixContext>,
-    result: ParseResult,
-  ): ParseResult | null {
+  autofix(offense: LintOffense<ERBStrictLocalsCommentSyntaxAutofixContext>, result: ParseResult): ParseResult | null {
     if (!offense.autofixContext) return null
 
     const { node, fix } = offense.autofixContext

--- a/javascript/packages/linter/test/helpers/linter-test-helper.ts
+++ b/javascript/packages/linter/test/helpers/linter-test-helper.ts
@@ -11,6 +11,8 @@ import type { RuleClass } from "../../src/types.js"
 interface ExpectedLocation {
   line?: number
   column?: number
+  endLine?: number
+  endColumn?: number
 }
 
 type LocationInput = ExpectedLocation | [number, number] | [number]
@@ -344,6 +346,14 @@ function matchOffenses(
       }
 
       if (exp.location?.column !== undefined && exp.location.column !== actualOffense.location.start.column) {
+        return false
+      }
+
+      if (exp.location?.endLine !== undefined && exp.location.endLine !== actualOffense.location.end.line) {
+        return false
+      }
+
+      if (exp.location?.endColumn !== undefined && exp.location.endColumn !== actualOffense.location.end.column) {
         return false
       }
 

--- a/javascript/packages/linter/test/rules/erb-strict-locals-comment-syntax.test.ts
+++ b/javascript/packages/linter/test/rules/erb-strict-locals-comment-syntax.test.ts
@@ -1,5 +1,6 @@
 import dedent from "dedent"
-import { describe, test } from "vitest"
+import { describe, expect, test } from "vitest"
+import { Herb } from "@herb-tools/node-wasm"
 import { ERBStrictLocalsCommentSyntaxRule } from "../../src/rules/erb-strict-locals-comment-syntax.js"
 import { createLinterTest } from "../helpers/linter-test-helper.js"
 
@@ -55,7 +56,7 @@ describe("ERBStrictLocalsCommentSyntaxRule", () => {
   })
 
   test("flags locals() without colon", () => {
-    expectError("Use `locals:` with a colon, not `locals()`. Correct format: `<%# locals: (...) %>`.")
+    expectError("Use `locals:` with a colon, not `locals()`. Correct format: `<%# locals: (...) %>`.", [1, 4],)
 
     assertOffenses(dedent`
       <%# locals() %>
@@ -63,7 +64,7 @@ describe("ERBStrictLocalsCommentSyntaxRule", () => {
   })
 
   test("flags local: (singular) instead of locals:", () => {
-    expectError("Use `locals:` (plural), not `local:`.")
+    expectError("Use `locals:` (plural), not `local:`.", [1, 4])
 
     assertOffenses(dedent`
       <%# local: (user:) %>
@@ -71,7 +72,7 @@ describe("ERBStrictLocalsCommentSyntaxRule", () => {
   })
 
   test("flags missing colon before parentheses", () => {
-    expectError("Use `locals:` with a colon before the parentheses, not `locals (`.")
+    expectError("Use `locals:` with a colon before the parentheses, not `locals (`.", [1, 4])
 
     assertOffenses(dedent`
       <%# locals (user:) %>
@@ -79,7 +80,7 @@ describe("ERBStrictLocalsCommentSyntaxRule", () => {
   })
 
   test("flags missing space after colon", () => {
-    expectError("Missing space after `locals:`. Rails Strict Locals require a space after the colon: `<%# locals: (...) %>`.")
+    expectError("Missing space after `locals:`. Rails Strict Locals require a space after the colon: `<%# locals: (...) %>`.", [1, 11])
 
     assertOffenses(dedent`
       <%# locals:() %>
@@ -87,7 +88,7 @@ describe("ERBStrictLocalsCommentSyntaxRule", () => {
   })
 
   test("flags missing space after colon with locals", () => {
-    expectError("Missing space after `locals:`. Rails Strict Locals require a space after the colon: `<%# locals: (...) %>`.")
+    expectError("Missing space after `locals:`. Rails Strict Locals require a space after the colon: `<%# locals: (...) %>`.", [1, 11])
 
     assertOffenses(dedent`
       <%# locals:(title:) %>
@@ -95,74 +96,74 @@ describe("ERBStrictLocalsCommentSyntaxRule", () => {
   })
 
   test("flags parameters that are not wrapped in parentheses", () => {
-    expectError("Strict locals parameters must be wrapped in parentheses. Use `<%# locals: (user:) %>`.")
+    expectError("Strict locals parameters must be wrapped in parentheses. Use `<%# locals: (user:) %>`.", [1, 12])
 
     assertOffenses(`<%# locals: user %>`)
   })
 
   test("flags parameters without parentheses and keeps the keyword arguments in the suggestion", () => {
-    expectError("Strict locals parameters must be wrapped in parentheses. Use `<%# locals: (user:, admin: false) %>`.")
+    expectError("Strict locals parameters must be wrapped in parentheses. Use `<%# locals: (user:, admin: false) %>`.", [1, 12])
 
     assertOffenses(`<%# locals: user:, admin: false %>`)
   })
 
   test("flags an empty declaration without parentheses", () => {
-    expectError("Strict locals declarations always need parentheses. Use `<%# locals: () %>` for a partial without locals.")
+    expectError("Strict locals declarations always need parentheses. Use `<%# locals: () %>` for a partial without locals.", [1, 12])
 
     assertOffenses(`<%# locals: %>`)
   })
 
   test("flags unbalanced parentheses", () => {
-    expectError("Unbalanced parentheses in the strict locals declaration. Add the missing closing `)`.")
+    expectError("Unbalanced parentheses in the strict locals declaration. Add the missing closing `)`.", [1, 12])
 
     assertOffenses(`<%# locals: (user: %>`)
   })
 
   test("flags positional arguments", () => {
-    expectError("Strict locals only support keyword arguments. Use `user:` instead of the positional argument `user`.")
+    expectError("Strict locals only support keyword arguments. Use `user:` instead of the positional argument `user`.", [1, 13])
 
     assertOffenses(`<%# locals: (user) %>`)
   })
 
   test("flags every positional argument", () => {
-    expectError("Strict locals only support keyword arguments. Use `user:` instead of the positional argument `user`.")
-    expectError("Strict locals only support keyword arguments. Use `admin:` instead of the positional argument `admin`.")
+    expectError("Strict locals only support keyword arguments. Use `user:` instead of the positional argument `user`.", [1, 13])
+    expectError("Strict locals only support keyword arguments. Use `admin:` instead of the positional argument `admin`.", [1, 19])
 
     assertOffenses(`<%# locals: (user, admin) %>`)
   })
 
   test("flags block arguments", () => {
-    expectError("Strict locals only support keyword arguments. The block argument `&block` is not supported.")
+    expectError("Strict locals only support keyword arguments. The block argument `&block` is not supported.", [1, 13])
 
     assertOffenses(`<%# locals: (&block) %>`)
   })
 
   test("flags splat arguments", () => {
-    expectError("Strict locals only support keyword arguments. The splat argument `*args` is not supported. Use `**args` to accept arbitrary keyword arguments.")
+    expectError("Strict locals only support keyword arguments. The splat argument `*args` is not supported. Use `**args` to accept arbitrary keyword arguments.", [1, 13])
 
     assertOffenses(`<%# locals: (*args) %>`)
   })
 
   test("flags a trailing comma", () => {
-    expectError("Remove the extra comma from the strict locals parameters.")
+    expectError("Remove the extra comma from the strict locals parameters.", [1, 18])
 
     assertOffenses(`<%# locals: (user:,) %>`)
   })
 
   test("flags a leading comma", () => {
-    expectError("Remove the extra comma from the strict locals parameters.")
+    expectError("Remove the extra comma from the strict locals parameters.", [1, 13])
 
     assertOffenses(`<%# locals: (, user:) %>`)
   })
 
   test("flags a double comma", () => {
-    expectError("Remove the extra comma from the strict locals parameters.")
+    expectError("Remove the extra comma from the strict locals parameters.", [1, 19])
 
     assertOffenses(`<%# locals: (user:,, admin:) %>`)
   })
 
   test("flags duplicate declarations", () => {
-    expectError("Duplicate strict locals declaration. Rails only uses the first `<%# locals: (...) %>` declaration in a partial.")
+    expectError("Duplicate strict locals declaration. Rails only uses the first `<%# locals: (...) %>` declaration in a partial.", [3, 4])
 
     assertOffenses(dedent`
       <%# locals: (user:) %>
@@ -172,13 +173,63 @@ describe("ERBStrictLocalsCommentSyntaxRule", () => {
   })
 
   test("flags Ruby comment syntax for strict locals in execution tags", () => {
-    expectError("Use `<%#` instead of `<% #` for strict locals comments. Only ERB comment syntax is recognized.")
-    expectError("Use `<%#` instead of `<%- #` for strict locals comments. Only ERB comment syntax is recognized.")
+    expectError("Use `<%#` instead of `<% #` for strict locals comments. Only ERB comment syntax is recognized.", [1, 0])
+    expectError("Use `<%#` instead of `<%- #` for strict locals comments. Only ERB comment syntax is recognized.", [2, 0])
 
     assertOffenses(dedent`
       <% # locals: (user:) %>
       <%- # locals: (admin: false) %>
     `)
+  })
+
+  test("points invalid Ruby syntax at the parser error", () => {
+    expectError("Invalid Ruby syntax in the strict locals declaration: '@' without identifiers is not allowed as an instance variable name.", [1, 19])
+
+    assertOffenses(`<%# locals: (user: @) %>`)
+  })
+
+  test("uses precise ranges for every offense type", () => {
+    const cases: Array<{
+      source: string
+      start: [line: number, column: number]
+      end: [line: number, column: number]
+    }> = [
+      { source: "<%# locals() %>", start: [1, 4], end: [1, 10] },
+      { source: "<%# local: (user:) %>", start: [1, 4], end: [1, 10] },
+      { source: "<%# locals (user:) %>", start: [1, 4], end: [1, 10] },
+      { source: "<%# locals:() %>", start: [1, 11], end: [1, 12] },
+      { source: "<%# locals: user %>", start: [1, 12], end: [1, 16] },
+      { source: "<%# locals: %>", start: [1, 12], end: [1, 12] },
+      { source: "<%# locals: (user: %>", start: [1, 12], end: [1, 13] },
+      { source: "<%# locals: (user) %>", start: [1, 13], end: [1, 17] },
+      { source: "<%# locals: (*args) %>", start: [1, 13], end: [1, 18] },
+      { source: "<%# locals: (&block) %>", start: [1, 13], end: [1, 19] },
+      { source: "<%# locals: (user:,) %>", start: [1, 18], end: [1, 19] },
+      { source: "<%# locals: (, user:) %>", start: [1, 13], end: [1, 14] },
+      {
+        source: "<%# locals: (user:,, admin:) %>",
+        start: [1, 19],
+        end: [1, 20],
+      },
+      {
+        source: "<%# locals: (user:) %>\n<%# locals: (admin:) %>",
+        start: [2, 4],
+        end: [2, 11],
+      },
+      { source: "<% # locals: (user:) %>", start: [1, 0], end: [1, 2] },
+      { source: "<%# locals: (user: @) %>", start: [1, 19], end: [1, 20] },
+    ]
+
+    const rule = new ERBStrictLocalsCommentSyntaxRule()
+
+    for (const { source, start, end } of cases) {
+      const result = Herb.parse(source, rule.parserOptions)
+      const offenses = rule.check(result)
+
+      expect(offenses, source).toHaveLength(1)
+      expect([offenses[0].location.start.line, offenses[0].location.start.column], source).toEqual(start)
+      expect([offenses[0].location.end.line, offenses[0].location.end.column], source).toEqual(end)
+    }
   })
 
   test("allows single strict locals comment anywhere in partial", () => {


### PR DESCRIPTION
This pull request improves offense locations reported by the `erb-strict-locals-comment-syntax` rule so diagnostics highlight the specific invalid syntax instead of the entire ERB node.

The rule now uses parser-provided error locations when available and derives precise content ranges for malformed declarations, missing whitespace, unmatched parentheses, extra commas, duplicate declarations, and incorrect ERB opening tags. 

Follow up on https://github.com/marcoroth/herb/pull/2252