### PR TITLE
Ruby CLI: Support `--slots` on compile and render

### DIFF
--- a/lib/herb/cli.rb
+++ b/lib/herb/cli.rb
@@ -341,8 +341,15 @@ class Herb::CLI
         self.optimize = true
       end
 
-      parser.on("--slots", "Emit slot markers for reactive rendering (for compile/render commands) (default: false)") do
-        self.slots = true
+      parser.on("--slots [MODE]", "Emit slot markers for reactive rendering, server (default) or client (for compile/render commands)") do |mode|
+        self.slots = (mode || "server").to_sym
+
+        unless Herb::Engine::SlotVisitor::MODES.include?(slots)
+          puts "Unknown --slots mode: #{mode}"
+          puts "Expected one of: #{Herb::Engine::SlotVisitor::MODES.join(", ")}"
+
+          exit(1)
+        end
       end
 
       parser.on("--tool TOOL", "Show config for specific tool: linter, formatter (for config command)") do |t|
@@ -1115,7 +1122,8 @@ class Herb::CLI
       source = file_content
       options = {}
 
-      slot_visitor = Herb::Engine::SlotVisitor.new if slots || Herb::Engine::SlotVisitor.directive?(source)
+      slot_mode = slots || Herb::Engine::SlotVisitor.directive_mode(source)
+      slot_visitor = Herb::Engine::SlotVisitor.new(mode: slot_mode) if slot_mode
 
       options[:filename] = @file if @file
       options[:escape] = no_escape ? false : true
@@ -1224,7 +1232,12 @@ class Herb::CLI
     require_relative "engine"
 
     begin
+      source = file_content
       options = {}
+
+      slot_mode = slots || Herb::Engine::SlotVisitor.directive_mode(source)
+      slot_visitor = Herb::Engine::SlotVisitor.new(mode: slot_mode) if slot_mode
+
       options[:filename] = @file if @file
       options[:escape] = no_escape ? false : true
       options[:freeze] = true if freeze
@@ -1237,11 +1250,14 @@ class Herb::CLI
 
       options[:optimize] = true if optimize
       options[:trim] = true if trim
+      options[:visitors] = [slot_visitor] if slot_visitor
 
-      engine = Herb::Engine.new(file_content, options)
+      engine = Herb::Engine.new(source, options)
       compiled_code = engine.src
 
       rendered_output = eval(compiled_code)
+
+      print_warnings(slot_visitor&.warnings || []) unless json
 
       if json
         result = {
@@ -1250,6 +1266,8 @@ class Herb::CLI
           filename: engine.filename,
           strict: options[:strict],
         }
+
+        result[:slots] = slot_visitor.schema if slot_visitor
 
         puts result.to_json
       elsif silent

--- a/test/integration/cli_test.rb
+++ b/test/integration/cli_test.rb
@@ -185,6 +185,83 @@ module Engine
       end
     end
 
+    test "render with slots emits markers around the rendered output" do
+      template = "<div><%= 1 + 1 %></div>"
+
+      with_temp_file(template) do |file_path|
+        assert_raises(SystemExit) do
+          Herb::CLI.new(["render", file_path, "--slots"]).call
+        end
+
+        assert_includes captured_output, "herb-region:"
+        assert_includes captured_output, %(data-herb-child="0")
+      end
+    end
+
+    test "render without slots emits no markers" do
+      template = "<div><%= 1 + 1 %></div>"
+
+      with_temp_file(template) do |file_path|
+        assert_raises(SystemExit) do
+          Herb::CLI.new(["render", file_path]).call
+        end
+
+        refute_includes captured_output, "herb-"
+      end
+    end
+
+    test "render in client mode parks the branch that did not run" do
+      template = "<div><% if false %><b>secret</b><% else %><i>guest</i><% end %></div>"
+
+      with_temp_file(template) do |file_path|
+        assert_raises(SystemExit) do
+          Herb::CLI.new(["render", file_path, "--slots", "client"]).call
+        end
+
+        assert_includes captured_output, "<template data-herb-region="
+        assert_includes captured_output, "<!--herb-branch:0:0--><b>secret</b>"
+      end
+    end
+
+    test "render in server mode parks nothing" do
+      template = "<div><% if false %><b>secret</b><% else %><i>guest</i><% end %></div>"
+
+      with_temp_file(template) do |file_path|
+        assert_raises(SystemExit) do
+          Herb::CLI.new(["render", file_path, "--slots", "server"]).call
+        end
+
+        assert_includes captured_output, "herb-slot:0:conditional"
+        refute_includes captured_output, "<template"
+        refute_includes captured_output, "secret"
+      end
+    end
+
+    test "render picks up a herb:slots directive without the flag" do
+      template = "<%# herb:slots client %>\n<div><% if false %>a<% else %>b<% end %></div>"
+
+      with_temp_file(template) do |file_path|
+        assert_raises(SystemExit) do
+          Herb::CLI.new(["render", file_path]).call
+        end
+
+        assert_includes captured_output, "<template data-herb-region="
+      end
+    end
+
+    test "an unknown slots mode is rejected before anything is compiled" do
+      template = "<div><%= 1 + 1 %></div>"
+
+      with_temp_file(template) do |file_path|
+        assert_raises(SystemExit) do
+          Herb::CLI.new(["render", file_path, "--slots", "nonsense"]).call
+        end
+
+        assert_includes captured_output, "Unknown --slots mode: nonsense"
+        assert_includes captured_output, "Expected one of: server, client"
+      end
+    end
+
     test "compile picks up a herb:slots directive without the flag" do
       template = "<%# herb:slots %>\n<% users.each do |user| %><li><%= user.name %></li><% end %>"
 


### PR DESCRIPTION
`--slots` now takes an optional mode, `server` or `client`, and an unknown one is rejected before anything is compiled:

```bash
herb compile app/views/posts/index.html.erb --slots client
```

`render` ignored `--slots` entirely and never read the `herb:slots` directive, so it could not show what a template actually sends. 

It now builds the visitor the same way `compile` does, and reads its source once, because reading stdin a second time returns nothing.
