### PR TITLE
Engine: Key a collection whose rows are built by a tag helper

### DIFF
--- a/lib/herb/engine/slot_visitor.rb
+++ b/lib/herb/engine/slot_visitor.rb
@@ -44,7 +44,7 @@ module Herb
 
       ATTRIBUTE_TYPES = [:attribute, :attribute_interpolation].freeze #: Array[Symbol]
       ELEMENT_ANCHORED_TYPES = [*ATTRIBUTE_TYPES, :boolean_attribute, :element, :raw_text].freeze #: Array[Symbol]
-      OPEN_TAG_TYPES = [Herb::AST::HTMLOpenTagNode, Herb::AST::ERBOpenTagNode].freeze #: Array[untyped]
+      OPEN_TAG_TYPES = [Herb::AST::HTMLOpenTagNode, Herb::AST::ERBOpenTagNode].freeze #: Array[Herb::AST::HTMLOpenTagNode|Herb::AST::ERBOpenTagNode]
       BRANCH_BODY_PROPERTIES = [:statements, :body, :children, :conditions].freeze #: Array[Symbol]
       BRANCH_CONTINUATION_PROPERTIES = [:subsequent, :else_clause, :rescue_clause, :ensure_clause].freeze #: Array[Symbol]
 
@@ -540,7 +540,7 @@ module Herb
         }.flatten
       end
 
-      #: (untyped) -> Array[untyped]
+      #: (untyped) -> Array[Herb::AST::HTMLAttributeNode]
       def attributes_for(element)
         open_tag = element.open_tag
         return [] unless OPEN_TAG_TYPES.any? { |type| open_tag.is_a?(type) }

--- a/lib/herb/engine/slot_visitor.rb
+++ b/lib/herb/engine/slot_visitor.rb
@@ -31,6 +31,8 @@ module Herb
 
       recommended_parser_option iteration_nodes: true
 
+      required_parser_option action_view_helpers: true
+
       attr_reader :slots #: Array[Slot]
       attr_reader :warnings #: Array[Herb::Warnings::Warning]
 
@@ -42,6 +44,7 @@ module Herb
 
       ATTRIBUTE_TYPES = [:attribute, :attribute_interpolation].freeze #: Array[Symbol]
       ELEMENT_ANCHORED_TYPES = [*ATTRIBUTE_TYPES, :boolean_attribute, :element, :raw_text].freeze #: Array[Symbol]
+      OPEN_TAG_TYPES = [Herb::AST::HTMLOpenTagNode, Herb::AST::ERBOpenTagNode].freeze #: Array[untyped]
       BRANCH_BODY_PROPERTIES = [:statements, :body, :children, :conditions].freeze #: Array[Symbol]
       BRANCH_CONTINUATION_PROPERTIES = [:subsequent, :else_clause, :rescue_clause, :ensure_clause].freeze #: Array[Symbol]
 
@@ -514,6 +517,11 @@ module Herb
             [:expression, expression]
           when Herb::AST::LiteralNode
             [:literal, child.content.to_s]
+          when Herb::AST::RubyLiteralNode
+            expression = child.content.to_s.strip
+            return nil if expression.empty?
+
+            [:expression, expression]
           else
             return nil
           end
@@ -535,7 +543,7 @@ module Herb
       #: (untyped) -> Array[untyped]
       def attributes_for(element)
         open_tag = element.open_tag
-        return [] unless open_tag.is_a?(Herb::AST::HTMLOpenTagNode)
+        return [] unless OPEN_TAG_TYPES.any? { |type| open_tag.is_a?(type) }
 
         open_tag.children.grep(Herb::AST::HTMLAttributeNode)
       end

--- a/sig/herb/engine/slot_visitor.rbs
+++ b/sig/herb/engine/slot_visitor.rbs
@@ -38,7 +38,7 @@ module Herb
 
       ELEMENT_ANCHORED_TYPES: Array[Symbol]
 
-      OPEN_TAG_TYPES: Array[untyped]
+      OPEN_TAG_TYPES: Array[Herb::AST::HTMLOpenTagNode | Herb::AST::ERBOpenTagNode]
 
       BRANCH_BODY_PROPERTIES: Array[Symbol]
 
@@ -178,8 +178,8 @@ module Herb
       # : (untyped) -> Array[untyped]
       def collection_body: (untyped) -> Array[untyped]
 
-      # : (untyped) -> Array[untyped]
-      def attributes_for: (untyped) -> Array[untyped]
+      # : (untyped) -> Array[Herb::AST::HTMLAttributeNode]
+      def attributes_for: (untyped) -> Array[Herb::AST::HTMLAttributeNode]
 
       # : (untyped) -> String?
       def attribute_name_for: (untyped) -> String?

--- a/sig/herb/engine/slot_visitor.rbs
+++ b/sig/herb/engine/slot_visitor.rbs
@@ -38,6 +38,8 @@ module Herb
 
       ELEMENT_ANCHORED_TYPES: Array[Symbol]
 
+      OPEN_TAG_TYPES: Array[untyped]
+
       BRANCH_BODY_PROPERTIES: Array[Symbol]
 
       BRANCH_CONTINUATION_PROPERTIES: Array[Symbol]
@@ -176,6 +178,8 @@ module Herb
       # : (untyped) -> Array[untyped]
       def collection_body: (untyped) -> Array[untyped]
 
+      # A tag helper is parsed as an element whose open tag is ERB, so an element carries its
+      # attributes the same way whether the template wrote `<li id="...">` or `tag.li id: ...`.
       # : (untyped) -> Array[untyped]
       def attributes_for: (untyped) -> Array[untyped]
 

--- a/sig/herb/engine/slot_visitor.rbs
+++ b/sig/herb/engine/slot_visitor.rbs
@@ -178,8 +178,6 @@ module Herb
       # : (untyped) -> Array[untyped]
       def collection_body: (untyped) -> Array[untyped]
 
-      # A tag helper is parsed as an element whose open tag is ERB, so an element carries its
-      # attributes the same way whether the template wrote `<li id="...">` or `tag.li id: ...`.
       # : (untyped) -> Array[untyped]
       def attributes_for: (untyped) -> Array[untyped]
 


### PR DESCRIPTION
This pull request fixes a collection losing its keying when its rows are built by a tag helper.

```erb
<%= tag.li id: person[:id] do %>
```

produces the same HTML as `<li id="...">`, but the collection fell back to index keying and emitted no row markers at all, so nothing about that collection could be updated a row at a time.

Parsed with `action_view_helpers`, a tag helper is already an element whose open tag is ERB and whose keyword arguments are real attributes, so the key is there to be read:

```js
@ HTMLElementNode
    @ ERBOpenTagNode
        @ HTMLAttributeNode
            @ HTMLAttributeNameNode -> LiteralNode "id"
            @ HTMLAttributeValueNode -> RubyLiteralNode "person[:id]"
```

`SlotVisitor` refused to read it in two places. `attributes_for` bailed unless the open tag was an `HTMLOpenTagNode`, so it found no attributes on a helper's element, and `key_parts_for` knew about `ERBContentNode` and `LiteralNode` but not `RubyLiteralNode`, which is what a keyword argument holds where a written attribute holds ERB.

That parse is also what stops a helper taking a block from being marked as a block with markers inside it, which is a slot whose value is used, so `action_view_helpers` is a required parser option here and not a recommended one.
