### PR TITLE
Client: Apply payload and report what values alone could not do

### DIFF
--- a/javascript/packages/client/README.md
+++ b/javascript/packages/client/README.md
@@ -95,6 +95,30 @@ slots.rangeFor(slot)
 slots.rangeForRow(row)
 ```
 
+## Applying a whole payload
+
+The compiler's other half, `Herb::Engine::DynamicsCompiler`, answers what a template's slots evaluated to. Its output goes in as it comes:
+
+```typescript
+const report = slots.apply(payload)
+// { applied: 7, deferred: [] }
+```
+
+A payload names the template, the version and which rendering it is, so nothing has to be said about where it goes. A partial's values arrive nested inside the slot that rendered it and are handed to that partial's own region, so one call covers a page however many templates it was built from.
+
+Values alone cannot do everything, and the report is the difference. `applied` counts what was written and `deferred` says what was not, with enough to act on:
+
+```typescript
+// { file, occurrence, index, reason, keys? }
+```
+
+- `stale-version` and `no-region` mean nothing was applied at all. A version that does not match says the payload's indices were compiled against a different template, so the values would land in the wrong places, and there is no partial credit to take.
+- `branch` means the conditional took a branch whose markup the page never had and nothing was parked for it. Ask the server for that subtree.
+- `rows` means the collection's rows are not the ones the payload has, and `keys` lists which. The rows both sides agree on are still filled, so what is deferred is the adding, removing and moving.
+- `no-slot` means the payload named an index the page has no marker for, which is usually a region that was only partly scanned.
+
+A branch the server parked is built for you, so a template in client mode toggles a conditional with no round trip. That is the same `materialize` path, taken for you.
+
 ## Deciding what to update
 
 A slot inside a conditional or a collection is destroyed when that conditional or collection re-renders, so the runtime tracks what contains what. Everything an update to a slot would destroy:

--- a/javascript/packages/client/src/index.ts
+++ b/javascript/packages/client/src/index.ts
@@ -2,3 +2,4 @@ export { HerbRuntime } from "./runtime"
 export { SlotIndex } from "./slot-index"
 
 export type { Slot, SlotType, SlotAnchor, Region, Row, ScanResult, RowPlan, RenderMode } from "./slot-index"
+export type { Payload, PayloadSlots, PayloadValue, Branched, Collected, ApplyReport, Deferred, DeferredReason } from "./slot-index"

--- a/javascript/packages/client/src/slot-index.ts
+++ b/javascript/packages/client/src/slot-index.ts
@@ -91,6 +91,43 @@ export interface ScanResult {
   slots: Slot[]
 }
 
+export interface Payload {
+  template: string
+  version: string
+  occurrence: number
+  slots: PayloadSlots
+}
+
+export interface PayloadSlots {
+  [index: string]: PayloadValue
+}
+
+export interface Branched {
+  branch: number | null
+  slots?: PayloadSlots
+}
+
+export interface Collected {
+  rows: { [key: string]: PayloadSlots }
+}
+
+export type PayloadValue = string | Payload | Branched | Collected
+
+export type DeferredReason = "no-region" | "stale-version" | "no-slot" | "branch" | "rows"
+
+export interface Deferred {
+  file: string
+  occurrence: number
+  index: number | null
+  reason: DeferredReason
+  keys?: string[]
+}
+
+export interface ApplyReport {
+  applied: number
+  deferred: Deferred[]
+}
+
 export interface RowPlan {
   added: string[]
   removed: string[]
@@ -256,16 +293,122 @@ export class SlotIndex {
   }
 
   reconcile(slot: Slot, keys: string[]): RowPlan {
-    const present = [...slot.rows.keys()]
+    const present = this.#rowsInDocumentOrder(slot).map((row) => row.key)
     const wanted = new Set(keys)
 
     const removed = present.filter((key) => !wanted.has(key))
-    const added = keys.filter((key) => !slot.rows.has(key))
-    const kept = keys.filter((key) => slot.rows.has(key))
+    const added = keys.filter((key) => !present.includes(key))
+    const kept = keys.filter((key) => present.includes(key))
     const order = present.filter((key) => wanted.has(key))
     const moved = kept.filter((key, position) => order[position] !== key)
 
     return { added, removed, moved, kept, unchanged: added.length === 0 && removed.length === 0 && moved.length === 0 }
+  }
+
+  apply(payload: Payload): ApplyReport {
+    const report: ApplyReport = { applied: 0, deferred: [] }
+
+    this.#applyPayload(payload, report)
+
+    return report
+  }
+
+  #applyPayload(payload: Payload, report: ApplyReport): void {
+    const region = this.region(payload.template, payload.occurrence)
+
+    if (!region) return this.#defer(report, payload, null, "no-region")
+    if (region.version !== payload.version) return this.#defer(report, payload, null, "stale-version")
+
+    this.#applySlots(payload, region.slots, payload.slots, report)
+  }
+
+  #applySlots(payload: Payload, owner: SlotMap, values: PayloadSlots, report: ApplyReport): void {
+    for (const [key, value] of Object.entries(values)) {
+      if (isPayload(value)) {
+        this.#applyPayload(value, report)
+        continue
+      }
+
+      const index = Number(key)
+      const slot = owner.get(index)
+
+      if (!slot) {
+        this.#defer(report, payload, index, "no-slot")
+        continue
+      }
+
+      if (typeof value === "string") {
+        if (slot.attribute) this.setAttribute(slot, value)
+        else this.update(slot, value)
+
+        report.applied += 1
+        continue
+      }
+
+      if ("rows" in value) this.#applyRows(payload, slot, value, report)
+      else this.#applyBranch(payload, slot, value, report)
+    }
+  }
+
+  #applyBranch(payload: Payload, slot: Slot, value: Branched, report: ApplyReport): void {
+    if (value.branch === slot.branch) {
+      if (value.slots) this.#applySlots(payload, this.#owner(slot), value.slots, report)
+
+      return
+    }
+
+    if (value.branch === null) {
+      this.update(slot, "")
+      slot.branch = null
+      report.applied += 1
+
+      return
+    }
+
+    const built = this.materialize(payload.template, `${slot.index}:${value.branch}`, leaves(value.slots))
+
+    if (!built) return this.#defer(report, payload, slot.index, "branch")
+
+    this.#writeFragment(slot, built)
+
+    report.applied += 1
+  }
+
+  #applyRows(payload: Payload, slot: Slot, value: Collected, report: ApplyReport): void {
+    const keys = Object.keys(value.rows)
+    const plan = this.reconcile(slot, keys)
+
+    if (!plan.unchanged) this.#defer(report, payload, slot.index, "rows", [...plan.added, ...plan.removed, ...plan.moved])
+
+    for (const key of plan.kept) {
+      const row = slot.rows.get(key)
+
+      if (row) this.#applySlots(payload, row.slots, value.rows[key], report)
+    }
+  }
+
+  #writeFragment(slot: Slot, fragment: DocumentFragment): void {
+    for (const descendant of this.descendantsOf(slot)) this.#forget(descendant)
+
+    slot.children = []
+
+    const range = this.rangeFor(slot)
+
+    range.deleteContents()
+
+    const added = [...fragment.childNodes]
+
+    range.insertNode(fragment)
+
+    this.scan(added)
+  }
+
+  #owner(slot: Slot): SlotMap {
+    return this.#slotOwners.get(slot) ?? this.#slotRegions.get(slot)?.slots ?? new Map()
+  }
+
+  #defer(report: ApplyReport, payload: Payload, index: number | null, reason: DeferredReason, keys?: string[]): void {
+    report.deferred.push({ file: payload.template, occurrence: payload.occurrence, index, reason, ...(keys ? { keys } : {}) })
   }
 
   update(slot: Slot, html: string): ScanResult {
@@ -378,11 +521,37 @@ export class SlotIndex {
 
     for (const region of this.#regions) {
       for (const [index, slot] of region.slots) {
-        if (!this.#slotConnected(slot)) region.slots.delete(index)
+        if (this.#slotConnected(slot)) this.#pruneRows(slot)
+        else region.slots.delete(index)
       }
     }
 
     return before - this.#regions.length
+  }
+
+  #pruneRows(slot: Slot): void {
+    if (slot.rows.size === 0) return
+
+    const live = this.#rowsInDocumentOrder(slot)
+
+    slot.rows.clear()
+
+    for (const row of live) {
+      for (const [index, nested] of row.slots) {
+        if (!this.#slotConnected(nested)) row.slots.delete(index)
+        else this.#pruneRows(nested)
+      }
+
+      slot.rows.set(row.key, row)
+    }
+  }
+
+  #rowsInDocumentOrder(slot: Slot): Row[] {
+    return [...slot.rows.values()]
+      .filter((row) => row.start.isConnected)
+      .sort((left, right) =>
+        left.start.compareDocumentPosition(right.start) & Node.DOCUMENT_POSITION_FOLLOWING ? -1 : 1,
+      )
   }
 
   clear(): void {
@@ -815,6 +984,20 @@ function fillSlots(fragment: DocumentFragment, dynamics: SlotValues): void {
     range.deleteContents()
     range.insertNode(range.createContextualFragment(value))
   }
+
+  for (const element of fragment.querySelectorAll("[data-herb-slot], [data-herb-child]")) {
+    for (const entry of element.getAttribute("data-herb-slot")?.split(",") ?? []) {
+      const [index, , ...name] = entry.split(":")
+      const value = dynamics[Number(index)]
+
+      if (value !== undefined && name.length > 0) element.setAttribute(name.join(":"), value)
+    }
+
+    const child = element.getAttribute("data-herb-child")
+    const value = child === null ? undefined : dynamics[Number(child)]
+
+    if (value !== undefined) element.innerHTML = value
+  }
 }
 
 function blankSlots(fragment: DocumentFragment): void {
@@ -908,6 +1091,20 @@ function link(parent: Slot | null, child: Slot): void {
   if (!parent.children.includes(child)) {
     parent.children.push(child)
   }
+}
+
+function isPayload(value: PayloadValue): value is Payload {
+  return typeof value === "object" && "template" in value
+}
+
+function leaves(values: PayloadSlots | undefined): SlotValues {
+  const filled: SlotValues = {}
+
+  for (const [key, value] of Object.entries(values ?? {})) {
+    if (typeof value === "string") filled[Number(key)] = value
+  }
+
+  return filled
 }
 
 function popMatching<T>(open: T[], matches: (candidate: T) => boolean): T | null {

--- a/javascript/packages/client/test/apply.test.ts
+++ b/javascript/packages/client/test/apply.test.ts
@@ -1,0 +1,154 @@
+import { describe, test, expect, beforeEach } from "vitest"
+
+import { SlotIndex } from "../src/slot-index"
+import type { Payload } from "../src/slot-index"
+
+const FILE = "app/views/posts/index.html.erb"
+const CARD = "app/views/posts/_card.html.erb"
+
+const COND_FALSE = `<!--herb-region:${FILE}:aaaaaaaa:0--><div><!--herb-slot:0:conditional--><!--/herb-slot:0--></div><!--/herb-region:${FILE}-->`
+const COND_TRUE = `<!--herb-region:${FILE}:aaaaaaaa:0--><div><!--herb-slot:0:conditional--><!--herb-branch:0:0--><b data-herb-child="1">yes</b><!--/herb-slot:0--></div><!--/herb-region:${FILE}-->`
+const PARKED = `<template data-herb-region="${FILE}:aaaaaaaa"><!--herb-branch:0:1--><i data-herb-child="2">no</i></template>`
+
+const ROWS = `<!--herb-region:${FILE}:bbbbbbbb:0--><ul><!--herb-slot:0:collection--><!--herb-row:0:1--><li data-herb-child="1">one</li><!--/herb-row:0--><!--herb-row:0:2--><li data-herb-child="1">two</li><!--/herb-row:0--><!--/herb-slot:0--></ul><!--/herb-region:${FILE}-->`
+
+const NESTED =
+  `<!--herb-region:${FILE}:cccccccc:0--><div><!--herb-slot:0-->` +
+  `<!--herb-region:${CARD}:dddddddd:0--><p data-herb-child="0">inner</p><!--/herb-region:${CARD}-->` +
+  `<!--/herb-slot:0--></div><!--/herb-region:${FILE}-->`
+
+function mounted(html: string): SlotIndex {
+  document.body.innerHTML = html
+
+  const index = new SlotIndex()
+  index.scan(document.body)
+
+  return index
+}
+
+function payload(template: string, slots: Payload["slots"], version = "aaaaaaaa", occurrence = 0): Payload {
+  return { template, version, occurrence, slots }
+}
+
+describe("applying values to a conditional", () => {
+  beforeEach(() => {
+    document.body.innerHTML = ""
+  })
+
+  test("fills the branch that is already on the page", () => {
+    const index = mounted(COND_TRUE)
+
+    const report = index.apply(payload(FILE, { 0: { branch: 0, slots: { 1: "still yes" } } }))
+
+    expect(report.applied).toBe(1)
+    expect(index.rangeFor(index.slot(FILE, 1)!).toString()).toBe("still yes")
+  })
+
+  test("empties the position when the payload says no branch ran", () => {
+    const index = mounted(COND_TRUE)
+
+    const report = index.apply(payload(FILE, { 0: { branch: null } }))
+
+    expect(report.applied).toBe(1)
+    expect(index.slot(FILE, 0)?.branch).toBeNull()
+    expect(index.rangeFor(index.slot(FILE, 0)!).toString()).toBe("")
+  })
+
+  test("builds a branch the page never had when its markup was parked", () => {
+    const index = mounted(COND_FALSE + PARKED)
+
+    const report = index.apply(payload(FILE, { 0: { branch: 1, slots: { 2: "built" } } }))
+
+    expect(report.applied).toBe(1)
+    expect(report.deferred).toEqual([])
+    expect(index.slot(FILE, 0)?.branch).toBe(1)
+    expect(index.rangeFor(index.slot(FILE, 2)!).toString()).toBe("built")
+  })
+
+  test("defers a branch it has no markup for, rather than guessing", () => {
+    const index = mounted(COND_FALSE)
+
+    const report = index.apply(payload(FILE, { 0: { branch: 1, slots: { 2: "built" } } }))
+
+    expect(report.applied).toBe(0)
+    expect(report.deferred).toEqual([{ file: FILE, occurrence: 0, index: 0, reason: "branch" }])
+    expect(index.rangeFor(index.slot(FILE, 0)!).toString()).toBe("")
+  })
+})
+
+describe("applying values to a collection", () => {
+  beforeEach(() => {
+    document.body.innerHTML = ""
+  })
+
+  test("writes into the rows the page already has", () => {
+    const index = mounted(ROWS)
+
+    const report = index.apply(
+      payload(FILE, { 0: { rows: { 1: { 1: "ONE" }, 2: { 1: "TWO" } } } }, "bbbbbbbb"),
+    )
+
+    expect(report.applied).toBe(2)
+    expect(report.deferred).toEqual([])
+    expect(document.querySelectorAll("li")[0].textContent).toBe("ONE")
+    expect(document.querySelectorAll("li")[1].textContent).toBe("TWO")
+  })
+
+  test("defers the rows it cannot build, and still fills the ones it can", () => {
+    const index = mounted(ROWS)
+
+    const report = index.apply(
+      payload(FILE, { 0: { rows: { 2: { 1: "TWO" }, 3: { 1: "THREE" } } } }, "bbbbbbbb"),
+    )
+
+    expect(report.applied).toBe(1)
+    expect(report.deferred).toEqual([
+      { file: FILE, occurrence: 0, index: 0, reason: "rows", keys: ["3", "1"] },
+    ])
+    expect(document.querySelectorAll("li")[1].textContent).toBe("TWO")
+  })
+})
+
+describe("applying values that came from more than one template", () => {
+  beforeEach(() => {
+    document.body.innerHTML = ""
+  })
+
+  test("hands a partial's values to the partial's own region", () => {
+    const index = mounted(NESTED)
+
+    const report = index.apply(
+      payload(FILE, { 0: payload(CARD, { 0: "replaced" }, "dddddddd") }, "cccccccc"),
+    )
+
+    expect(report.applied).toBe(1)
+    expect(index.rangeFor(index.slot(CARD, 0)!).toString()).toBe("replaced")
+  })
+
+  test("defers a partial whose version the page no longer carries", () => {
+    const index = mounted(NESTED)
+
+    const report = index.apply(
+      payload(FILE, { 0: payload(CARD, { 0: "replaced" }, "eeeeeeee") }, "cccccccc"),
+    )
+
+    expect(report.applied).toBe(0)
+    expect(report.deferred).toEqual([{ file: CARD, occurrence: 0, index: null, reason: "stale-version" }])
+    expect(index.rangeFor(index.slot(CARD, 0)!).toString()).toBe("inner")
+  })
+})
+
+describe("applying values the page has no place for", () => {
+  beforeEach(() => {
+    document.body.innerHTML = ""
+  })
+
+  test("names the slot it could not find and keeps going", () => {
+    const index = mounted(COND_TRUE)
+
+    const report = index.apply(payload(FILE, { 1: "written", 9: "nowhere" }))
+
+    expect(report.applied).toBe(1)
+    expect(report.deferred).toEqual([{ file: FILE, occurrence: 0, index: 9, reason: "no-slot" }])
+  })
+})

--- a/javascript/packages/client/test/fixtures/round-trip.json
+++ b/javascript/packages/client/test/fixtures/round-trip.json
@@ -5,6 +5,7 @@
   "values": {
     "template": "app/views/greet.html.erb",
     "version": "bd48f9a6",
+    "occurrence": 0,
     "slots": {
       "0": "loud",
       "1": "Goodbye",

--- a/javascript/packages/client/test/round-trip.test.ts
+++ b/javascript/packages/client/test/round-trip.test.ts
@@ -1,43 +1,11 @@
 import { describe, test, expect, beforeEach } from "vitest"
 
 import { SlotIndex } from "../src/slot-index"
+import type { Payload } from "../src/slot-index"
 
 import fixture from "./fixtures/round-trip.json"
 
-type Values = { [index: string]: Value }
-type Value = string | { branch?: number | null; slots?: Values; rows?: { [key: string]: Values } }
-
-function applyValues(index: SlotIndex, file: string, values: Values, occurrence = 0): void {
-  for (const [key, value] of Object.entries(values)) {
-    const slotIndex = Number(key)
-
-    if (typeof value === "string") {
-      const slot = index.slot(file, slotIndex, occurrence)
-
-      if (!slot) continue
-      if (slot.attribute) index.setAttribute(slot, value)
-      else index.update(slot, value)
-
-      continue
-    }
-
-    if (value.rows) {
-      for (const [rowKey, rowValues] of Object.entries(value.rows)) {
-        for (const [innerKey, innerValue] of Object.entries(rowValues)) {
-          const slot = index.slotInRow(file, slotIndex, rowKey, Number(innerKey), occurrence)
-
-          if (!slot || typeof innerValue !== "string") continue
-          if (slot.attribute) index.setAttribute(slot, innerValue)
-          else index.update(slot, innerValue)
-        }
-      }
-
-      continue
-    }
-
-    if (value.slots) applyValues(index, file, value.slots, occurrence)
-  }
-}
+const values = fixture.values as Payload
 
 describe("a page given the values of a later render", () => {
   let host: HTMLElement
@@ -55,7 +23,7 @@ describe("a page given the values of a later render", () => {
   })
 
   test("becomes the page the server would have rendered from them", () => {
-    applyValues(index, fixture.file, fixture.values.slots as Values)
+    index.apply(values)
 
     expect(host.innerHTML).toBe(fixture.expected)
   })
@@ -64,16 +32,36 @@ describe("a page given the values of a later render", () => {
     expect(fixture.rendered).not.toBe(fixture.expected)
   })
 
-  test("names the version the markers on the page were compiled with", () => {
-    expect(index.region(fixture.file)?.version).toBe(fixture.values.version)
+  test("writes every value it was given and defers nothing", () => {
+    const report = index.apply(values)
+
+    expect(report.applied).toBe(7)
+    expect(report.deferred).toEqual([])
   })
 
   test("leaves every marker where it was, so the next update has the same page to work on", () => {
-    applyValues(index, fixture.file, fixture.values.slots as Values)
+    index.apply(values)
 
     const reindexed = new SlotIndex()
     reindexed.scan(host)
 
     expect(reindexed.size).toBe(index.size)
+  })
+
+  test("refuses a payload compiled from a version the page does not carry", () => {
+    const report = index.apply({ ...values, version: "deadbeef" })
+
+    expect(report.applied).toBe(0)
+    expect(report.deferred).toEqual([
+      { file: fixture.file, occurrence: 0, index: null, reason: "stale-version" },
+    ])
+    expect(host.innerHTML).toBe(fixture.rendered)
+  })
+
+  test("refuses a payload for a rendering that is not on the page", () => {
+    const report = index.apply({ ...values, occurrence: 3 })
+
+    expect(report.deferred[0].reason).toBe("no-region")
+    expect(host.innerHTML).toBe(fixture.rendered)
   })
 })

--- a/javascript/packages/client/test/slot-index.test.ts
+++ b/javascript/packages/client/test/slot-index.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect, beforeEach } from "vitest"
 import { SlotIndex } from "../src/slot-index"
+import type { Row } from "../src/slot-index"
 import { HerbRuntime } from "../src/runtime"
 
 const FILE = "app/views/posts/index.html.erb"
@@ -380,7 +381,70 @@ describe("collection reconciliation", () => {
     expect(plan.removed).toEqual([])
     expect(plan.moved).toEqual(["2", "1"])
   })
+
+  test("reads the order the rows are in now, not the order they were first scanned in", () => {
+    const index = mounted(COLLECTION)
+    const slot = index.slot(FILE, 0)!
+    const [first, second] = [...slot.rows.values()]
+
+    move(second, first)
+    index.prune()
+
+    expect(index.reconcile(slot, ["2", "1"]).unchanged).toBe(true)
+    expect(index.reconcile(slot, ["1", "2"]).moved).toEqual(["1", "2"])
+  })
+
+  test("iterates its rows in the order the page has them", () => {
+    const index = mounted(COLLECTION)
+    const slot = index.slot(FILE, 0)!
+    const [first, second] = [...slot.rows.values()]
+
+    move(second, first)
+    index.prune()
+
+    expect([...index.rowsFor(FILE, 0).keys()]).toEqual(["2", "1"])
+  })
+
+  test("forgets a row whose markers have left the page", () => {
+    const index = mounted(COLLECTION)
+    const slot = index.slot(FILE, 0)!
+
+    remove(slot.rows.get("1")!)
+    index.prune()
+
+    expect([...slot.rows.keys()]).toEqual(["2"])
+    expect(index.slotInRow(FILE, 0, "1", 2)).toBeNull()
+  })
+
+  test("stops asking for a row already gone from the page to be removed", () => {
+    const index = mounted(COLLECTION)
+    const slot = index.slot(FILE, 0)!
+
+    remove(slot.rows.get("1")!)
+    index.prune()
+
+    expect(index.reconcile(slot, ["2"]).unchanged).toBe(true)
+  })
 })
+
+function rowNodes(row: Row): Node[] {
+  const range = document.createRange()
+
+  range.setStartBefore(row.start)
+  range.setEndAfter(row.end)
+
+  return [...range.extractContents().childNodes]
+}
+
+function move(row: Row, before: Row): void {
+  const nodes = rowNodes(row)
+
+  for (const node of nodes) before.start.parentNode!.insertBefore(node, before.start)
+}
+
+function remove(row: Row): void {
+  rowNodes(row)
+}
 
 describe("reflecting updates", () => {
   beforeEach(() => {

--- a/lib/herb/engine/dynamics_compiler.rb
+++ b/lib/herb/engine/dynamics_compiler.rb
@@ -426,7 +426,7 @@ module Herb
         @block_depth = 0
         @scopes = [] #: Array[Integer]
         @slot_visitor = properties[:slot_visitor] || SlotVisitor.new(mode: :server, mark: false)
-        visitors = [@slot_visitor, *properties[:visitors]]
+        visitors = [*properties[:visitors], @slot_visitor]
 
         super(
           input,

--- a/lib/herb/engine/dynamics_compiler.rb
+++ b/lib/herb/engine/dynamics_compiler.rb
@@ -113,6 +113,7 @@ module Herb
       SCOPE_BUFFER = "__herb_scope" #: String
       ROWS_BUFFER = "__herb_rows" #: String
       KEY_BUFFER = "__herb_key" #: String
+      OCCURRENCE_BUFFER = "__herb_occurrence" #: String
 
       BRANCHING_NODES = [
         "AST_ERB_IF_NODE",
@@ -284,6 +285,8 @@ module Herb
 
         #: () -> void
         def generate_output
+          @engine.send(:capture_occurrence)
+
           optimize_tokens(@tokens).each do |type, value, context, extra|
             case type
             when :text then @engine.send(:add_text, value)
@@ -499,7 +502,15 @@ module Herb
       def add_postamble(_postamble)
         super("{ template: #{@slot_visitor.identifier.inspect}, " \
               "version: #{@slot_visitor.version.inspect}, " \
+              "occurrence: #{OCCURRENCE_BUFFER}, " \
               "slots: #{BUFFER} }\n")
+      end
+
+      # Counted where the region marker counts it, at the start of the rendering rather than the end,
+      # so a template rendering itself numbers its renderings the same way both compilers do.
+      #: () -> void
+      def capture_occurrence
+        @src << "; #{OCCURRENCE_BUFFER} = #{@slot_visitor.occurrence_expression};"
       end
 
       #: () -> String

--- a/lib/herb/engine/slot_visitor.rb
+++ b/lib/herb/engine/slot_visitor.rb
@@ -163,6 +163,11 @@ module Herb
         @indices[node]
       end
 
+      #: () -> String
+      def occurrence_expression
+        "((#{OCCURRENCES} ||= ::Hash.new(0))[#{identifier.inspect}] += 1) - 1"
+      end
+
       #: (untyped) -> Array[Integer]
       def anchored_indices_for(open_tag)
         @element_anchored[open_tag] || []
@@ -819,15 +824,11 @@ module Herb
 
         document_node.children.unshift(
           text_node(@markers.region_open_prefix(name, version)),
-          erb_output_node(occurrence_expression(name)),
+          erb_output_node(occurrence_expression),
           text_node(@markers.region_open_suffix)
         )
 
         document_node.children.push(comment_node(@markers.region_close(name)))
-      end
-
-      def occurrence_expression(name)
-        "((#{OCCURRENCES} ||= ::Hash.new(0))[#{name.inspect}] += 1) - 1"
       end
 
       def text_node(content)

--- a/sig/herb/engine/dynamics_compiler.rbs
+++ b/sig/herb/engine/dynamics_compiler.rbs
@@ -114,6 +114,8 @@ module Herb
 
       KEY_BUFFER: String
 
+      OCCURRENCE_BUFFER: String
+
       BRANCHING_NODES: Array[String]
 
       class Compiler < Herb::Engine::Compiler
@@ -234,6 +236,11 @@ module Herb
 
       # : (String) -> void
       def add_postamble: (String) -> void
+
+      # Counted where the region marker counts it, at the start of the rendering rather than the end,
+      # so a template rendering itself numbers its renderings the same way both compilers do.
+      # : () -> void
+      def capture_occurrence: () -> void
 
       # : () -> String
       def current_scope: () -> String

--- a/sig/herb/engine/slot_visitor.rbs
+++ b/sig/herb/engine/slot_visitor.rbs
@@ -100,6 +100,9 @@ module Herb
       # : (untyped) -> Integer?
       def index_for: (untyped) -> Integer?
 
+      # : () -> String
+      def occurrence_expression: () -> String
+
       # : (untyped) -> Array[Integer]
       def anchored_indices_for: (untyped) -> Array[Integer]
 
@@ -238,8 +241,6 @@ module Herb
       def each_child_array: (untyped) { (Array[untyped]) -> void } -> void
 
       def wrap_region: (untyped document_node) -> untyped
-
-      def occurrence_expression: (untyped name) -> untyped
 
       def text_node: (untyped content) -> untyped
 

--- a/test/engine/dynamics_compiler_test.rb
+++ b/test/engine/dynamics_compiler_test.rb
@@ -211,7 +211,7 @@ module Engine
 
     describe "rendering another template" do
       test "keeps the partial's own values rather than flattening them into a string" do
-        assert_equal({ template: "app/views/card.html.erb", version: PARTIAL_VERSION, slots: { 0 => "inner" } },
+        assert_equal({ template: "app/views/card.html.erb", version: PARTIAL_VERSION, occurrence: 0, slots: { 0 => "inner" } },
                      dynamics(%(<div><%= render "card" %></div>))[0])
       end
 


### PR DESCRIPTION
This pull request adds `apply`, which takes what `DynamicsCompiler` produces as it comes, and reports what values alone could not do.

```typescript
const report = slots.apply(payload)
// { applied: 7, deferred: [] }
```

`SlotIndex` could write one slot at a time and nothing more, so every caller with a payload wrote the same walk over it, and the three that did each got it wrong differently first. A payload names its template, its version and which rendering it is, so nothing has to be said about where it goes, and a partial's values nest inside the slot that rendered it and are handed to that partial's own region. One call covers a page however many templates it was built from.

What values cannot do is the other half of the answer. A version that does not match applies nothing, since indices compiled against another template would land somewhere plausible and wrong. A branch the page never had is built when the server parked its markup, and deferred when it did not. A collection whose rows have changed still fills the rows both sides agree on and reports the rest. A caller reads `deferred` to know what to fetch.

`DynamicsCompiler` also put its slot visitor at the front of the visitor stack while a handler compiling the same template to markup puts it at the back. Every visitor in between saw a different tree in each case, and one that adds a dynamic node to one and not the other moves every index after it, which is the whole failure the visitor was made the source of indices to prevent. Whatever the caller passes runs first now, and the slot visitor last, so the two compiles number the same tree.

Two row bugs had to go first, both of them `slot.rows` being built at scan time and never maintained. `prune()` walked a region's slots but never its rows, so a row whose markers had left the page stayed indexed and `reconcile` kept asking for it to be removed. And `reconcile` read its order from Map insertion order, fixed at first scan, so asked for the order the page was already in it reported every row as needing a move. `prune()` rebuilds each collection from the rows still connected, in document order, and `reconcile` reads the document.
