### PR TITLE
Client: Properly address a slot inside markup a helper like `content_for` captured

### DIFF
--- a/javascript/packages/client/README.md
+++ b/javascript/packages/client/README.md
@@ -52,6 +52,8 @@ slots.slotsFor("app/views/posts/index.html.erb", 0)
 slots.regionsFor("app/views/posts/index.html.erb")
 ```
 
+A rendering is not always one stretch of the page. `content_for`, `provide` and `capture` run during a rendering and hand their markup to whoever wants it, which is usually somewhere else entirely, so the compiler writes the rendering's own marker around what they captured. Two markers naming the same template, version and occurrence are the same rendering, and the region holds a range for each. Nothing about addressing changes: a slot inside a `content_for` is `slots.slot(file, index)` like any other, however far from the rest of its template it ended up.
+
 The occurrence is the server's own count, carried in the region marker. That count and the order regions sit in are usually the same and sometimes not, because `content_for` renders its content at one point in the template and writes it out at another. A payload naming the second rendering of a template means the second one the server rendered, so reading the number is right where counting regions down the page would be off by exactly the templates that moved.
 
 Every row of a collection repeats the same slot indices, so a row's key is what says which one is meant. The rows of a collection:

--- a/javascript/packages/client/src/slot-index.ts
+++ b/javascript/packages/client/src/slot-index.ts
@@ -77,10 +77,16 @@ export interface Slot {
   children: Slot[]
 }
 
+export interface RegionRange {
+  start: Comment
+  end: Comment | null
+}
+
 export interface Region {
   file: string
   version: string
   occurrence: number
+  ranges: RegionRange[]
   start: Comment | null
   end: Comment | null
   slots: SlotMap
@@ -152,8 +158,13 @@ interface OpenRow {
   row: Row
 }
 
+interface OpenRegion {
+  region: Region
+  range: RegionRange
+}
+
 interface ParseState {
-  openRegions: Region[]
+  openRegions: OpenRegion[]
   openSlots: OpenSlot[]
   openRows: OpenRow[]
 }
@@ -584,18 +595,34 @@ export class SlotIndex {
       const regionOpen = REGION_OPEN.exec(data)
 
       if (regionOpen) {
-        const region: Region = {
-          file: regionOpen[1],
-          version: regionOpen[2],
-          occurrence: Number(regionOpen[3]),
-          start: comment,
-          end: null,
-          slots: new Map(),
+        const file = regionOpen[1]
+        const version = regionOpen[2]
+        const occurrence = Number(regionOpen[3])
+        const range: RegionRange = { start: comment, end: null }
+
+        const existing = this.#regions.find(
+          (candidate) => candidate.file === file && candidate.occurrence === occurrence && candidate.version === version,
+        )
+
+        if (existing) {
+          existing.ranges.push(range)
+          openRegions.push({ region: existing, range })
+        } else {
+          const region: Region = {
+            file,
+            version,
+            occurrence,
+            ranges: [range],
+            start: comment,
+            end: null,
+            slots: new Map(),
+          }
+
+          openRegions.push({ region, range })
+          this.#regions.push(region)
+          result.regions.push(region)
         }
 
-        openRegions.push(region)
-        this.#regions.push(region)
-        result.regions.push(region)
         this.#seen.add(comment)
 
         continue
@@ -604,9 +631,13 @@ export class SlotIndex {
       const regionClose = REGION_CLOSE.exec(data)
 
       if (regionClose) {
-        const region = popMatching(openRegions, (candidate) => candidate.file === regionClose[1])
+        const open = popMatching(openRegions, (candidate) => candidate.region.file === regionClose[1])
 
-        if (region) region.end = comment
+        if (open) {
+          open.range.end = comment
+
+          if (open.range === open.region.ranges[0]) open.region.end = comment
+        }
 
         this.#seen.add(comment)
 
@@ -616,7 +647,7 @@ export class SlotIndex {
       const slotOpen = SLOT_OPEN.exec(data)
 
       if (slotOpen) {
-        const region = openRegions[openRegions.length - 1] ?? this.#enclosingRegion(comment)
+        const region = openRegions[openRegions.length - 1]?.region ?? this.#enclosingRegion(comment)
         const stacked = openSlots[openSlots.length - 1]?.slot ?? null
         const enclosing = stacked ?? (region ? this.#enclosingSlot(region, comment) : null)
 
@@ -655,7 +686,7 @@ export class SlotIndex {
 
       if (rowOpen) {
         const collectionIndex = Number(rowOpen[1])
-        const region = openRegions[openRegions.length - 1] ?? this.#enclosingRegion(comment)
+        const region = openRegions[openRegions.length - 1]?.region ?? this.#enclosingRegion(comment)
         const collection = region?.slots.get(collectionIndex)
         const row: Row = { key: rowOpen[2], start: comment, end: comment, slots: new Map() }
 
@@ -681,7 +712,7 @@ export class SlotIndex {
       const branch = BRANCH.exec(data)
 
       if (branch) {
-        const region = openRegions[openRegions.length - 1] ?? this.#enclosingRegion(comment)
+        const region = openRegions[openRegions.length - 1]?.region ?? this.#enclosingRegion(comment)
         const slot = region?.slots.get(Number(branch[1]))
 
         if (slot) slot.branch = Number(branch[2])
@@ -737,7 +768,7 @@ export class SlotIndex {
 
     this.#anchored.add(element)
 
-    const walked = state.openRegions[state.openRegions.length - 1] ?? null
+    const walked = state.openRegions[state.openRegions.length - 1]?.region ?? null
     const region = walked ?? this.#enclosingRegion(element)
 
     if (!region) return
@@ -825,7 +856,7 @@ export class SlotIndex {
     for (let i = this.#regions.length - 1; i >= 0; i--) {
       const region = this.#regions[i]
 
-      if (region.start && contains(region, node)) return region
+      if (contains(region, node)) return region
     }
 
     return null
@@ -891,7 +922,12 @@ export class SlotIndex {
   }
 
   #regionConnected(region: Region): boolean {
-    return region.start ? region.start.isConnected : false
+    region.ranges = region.ranges.filter((range) => range.start.isConnected)
+
+    region.start = region.ranges[0]?.start ?? null
+    region.end = region.ranges[0]?.end ?? null
+
+    return region.ranges.length > 0
   }
 
   #slotConnected(slot: Slot): boolean {
@@ -1066,14 +1102,16 @@ function anchored(element: Element): boolean {
 }
 
 function contains(region: Region, node: Node): boolean {
-  if (!region.start) return false
+  return region.ranges.some((range) => withinRegionRange(range, node))
+}
 
-  const after = region.start.compareDocumentPosition(node) & Node.DOCUMENT_POSITION_FOLLOWING
+function withinRegionRange(range: RegionRange, node: Node): boolean {
+  const after = range.start.compareDocumentPosition(node) & Node.DOCUMENT_POSITION_FOLLOWING
   if (!after) return false
 
-  if (!region.end) return true
+  if (!range.end) return true
 
-  return Boolean(region.end.compareDocumentPosition(node) & Node.DOCUMENT_POSITION_PRECEDING)
+  return Boolean(range.end.compareDocumentPosition(node) & Node.DOCUMENT_POSITION_PRECEDING)
 }
 
 function withinRange(anchor: { start: Comment; end: Comment }, node: Node): boolean {

--- a/javascript/packages/client/test/branch.test.ts
+++ b/javascript/packages/client/test/branch.test.ts
@@ -1,6 +1,10 @@
 import { describe, test, expect, beforeEach } from "vitest"
 import { SlotIndex } from "../src/slot-index"
 
+function nth(html: string, occurrence: number): string {
+  return html.replace(/(<!--herb-region:[^>]*?:[0-9a-f]{8}):\d+-->/g, `$1:${occurrence}-->`)
+}
+
 const FILE = "app/views/posts/index.html.erb"
 const EMPTY_COND = `<!--herb-region:${FILE}:aaaaaaaa:0--><div><!--herb-slot:0:conditional--><!--/herb-slot:0--></div><!--/herb-region:${FILE}-->`
 
@@ -163,7 +167,7 @@ describe("rendering a branch that never rendered, without a round trip", () => {
 
   test("keeps one copy of a skeleton however many times the template rendered", () => {
     const index = new SlotIndex()
-    document.body.innerHTML = page + page + page
+    document.body.innerHTML = page + nth(page, 1) + nth(page, 2)
     index.scan(document.body)
 
     expect(index.regionsFor(FILE)).toHaveLength(3)
@@ -309,7 +313,7 @@ describe("statics parked once for the page", () => {
 
   test("belongs to the template it names rather than to where it sits", () => {
     const index = new SlotIndex()
-    document.body.innerHTML = rendering + rendering + rendering + bundle
+    document.body.innerHTML = rendering + nth(rendering, 1) + nth(rendering, 2) + bundle
     index.scan(document.body)
 
     expect(index.regionsFor(FILE)).toHaveLength(3)

--- a/javascript/packages/client/test/slot-index.test.ts
+++ b/javascript/packages/client/test/slot-index.test.ts
@@ -11,6 +11,9 @@ const COND_TRUE = `<!--herb-region:${FILE}:a6ef770d:0--><div><!--herb-slot:0:con
 const COND_FALSE = `<!--herb-region:${FILE}:a6ef770d:0--><div><!--herb-slot:0:conditional--><!--/herb-slot:0--></div><!--/herb-region:${FILE}-->`
 const COLLECTION = `<!--herb-region:${FILE}:64652ac4:0--><!--herb-slot:0:collection--><!--herb-row:0:1--><li id="1" data-herb-slot="1:attribute" data-herb-child="2">1</li><!--/herb-row:0--><!--herb-row:0:2--><li id="2" data-herb-slot="1:attribute" data-herb-child="2">2</li><!--/herb-row:0--><!--/herb-slot:0--><!--/herb-region:${FILE}-->`
 const TABLE = `<!--herb-region:${FILE}:c4a38ea8:0--><table><!--herb-slot:0:collection--><!--herb-row:0:1--><tr id="1" data-herb-slot="1:attribute"><td data-herb-child="2">1</td></tr><!--/herb-row:0--><!--/herb-slot:0--></table><!--/herb-region:${FILE}-->`
+const DISPLACED =
+  `<!--herb-region:${FILE}:25c0946e:0--><h1 data-herb-child="5">Title</h1><!--/herb-region:${FILE}-->` +
+  `<!--herb-region:${FILE}:25c0946e:0--><p data-herb-child="0">body</p><!--/herb-region:${FILE}-->`
 const ATTR = `<!--herb-region:${FILE}:55167514:0--><div class="card" id="1" data-herb-slot="0:attribute,1:element">x</div><!--/herb-region:${FILE}-->`
 
 function occurrence(html: string, nth: number): string {
@@ -45,7 +48,7 @@ describe("SlotIndex", () => {
     })
 
     test("keeps one region per time a template was rendered", () => {
-      index.scan(mount(CHILD + CHILD + CHILD))
+      index.scan(mount(CHILD + occurrence(CHILD, 1) + occurrence(CHILD, 2)))
 
       expect(index.regionsFor(FILE)).toHaveLength(3)
       expect(index.files()).toEqual([FILE])
@@ -67,6 +70,32 @@ describe("SlotIndex", () => {
 
       expect(index.region(FILE, 0)).toBe(second)
       expect(index.region(FILE, 1)).toBe(first)
+    })
+
+    test("takes two markers naming the same rendering as one region", () => {
+      index.scan(mount(DISPLACED))
+
+      expect(index.regionsFor(FILE)).toHaveLength(1)
+      expect(index.region(FILE, 0)?.ranges).toHaveLength(2)
+    })
+
+    test("attributes a slot to the rendering its markers name, not the one they sit in", () => {
+      index.scan(mount(DISPLACED))
+
+      expect(index.rangeFor(index.slot(FILE, 5)!).toString()).toBe("Title")
+      expect(index.rangeFor(index.slot(FILE, 0)!).toString()).toBe("body")
+    })
+
+    test("keeps a rendering while any part of it is still on the page", () => {
+      const host = mount(DISPLACED)
+
+      index.scan(host)
+      host.querySelector("h1")!.previousSibling!.remove()
+
+      index.prune()
+
+      expect(index.regionsFor(FILE)).toHaveLength(1)
+      expect(index.slot(FILE, 0)).not.toBeNull()
     })
 
     test("separates the slots of two renderings by their occurrence", () => {
@@ -238,7 +267,7 @@ describe("SlotIndex", () => {
     })
 
     test("drops a partial that was removed", async () => {
-      const host = mount(CHILD + CHILD)
+      const host = mount(CHILD + occurrence(CHILD, 1))
 
       index.observe(host)
       expect(index.regionsFor(FILE)).toHaveLength(2)
@@ -268,7 +297,7 @@ describe("SlotIndex", () => {
   describe("pruning", () => {
     test("drops regions whose markup left the document", () => {
       const first = mount(CHILD)
-      mount(CHILD)
+      mount(occurrence(CHILD, 1))
 
       index.scan(document.body)
       expect(index.regionsFor(FILE)).toHaveLength(2)

--- a/javascript/packages/client/test/turbo.test.ts
+++ b/javascript/packages/client/test/turbo.test.ts
@@ -4,7 +4,8 @@ import { SlotIndex } from "../src/slot-index"
 const FILE = "app/views/posts/index.html.erb"
 const PARTIAL = "app/views/posts/_row.html.erb"
 
-const region = (file: string, body: string) => `<!--herb-region:${file}:aaaaaaaa:0-->${body}<!--/herb-region:${file}-->`
+const region = (file: string, body: string, occurrence = 0) =>
+  `<!--herb-region:${file}:aaaaaaaa:${occurrence}-->${body}<!--/herb-region:${file}-->`
 const page = (name: string) => region(FILE, `<p><!--herb-slot:0-->${name}<!--/herb-slot:0--></p>`)
 const settle = () => new Promise((resolve) => setTimeout(resolve, 0))
 
@@ -70,9 +71,9 @@ describe("page navigation and Turbo", () => {
 
     const list = document.querySelector("#list")!
 
-    for (const name of ["a", "b"]) {
+    for (const [occurrence, name] of ["a", "b"].entries()) {
       const template = document.createElement("template")
-      template.innerHTML = region(PARTIAL, `<li><!--herb-slot:0-->${name}<!--/herb-slot:0--></li>`)
+      template.innerHTML = region(PARTIAL, `<li><!--herb-slot:0-->${name}<!--/herb-slot:0--></li>`, occurrence)
       list.append(template.content)
     }
 

--- a/lib/herb/engine/slot_visitor.rb
+++ b/lib/herb/engine/slot_visitor.rb
@@ -40,6 +40,9 @@ module Herb
       MODES = [:server, :client].freeze #: Array[Symbol]
       COVERED = "_herb_covered_branches" #: String
       OCCURRENCES = "@_herb_region_occurrences" #: String
+      OCCURRENCE = "_herb_occurrence" #: String
+
+      CAPTURING = /\b(?:content_for|provide|capture)\b/ #: Regexp
       BRANCHING_TYPES = [:conditional, :collection, :block].freeze #: Array[Symbol]
 
       ATTRIBUTE_TYPES = [:attribute, :attribute_interpolation].freeze #: Array[Symbol]
@@ -109,6 +112,7 @@ module Herb
 
         @in_attribute = false
         @in_open_tag = false
+        @displaced = [] #: Array[untyped]
         @in_html_comment = false
         @in_html_doctype = false
         @raw_text_depth = 0
@@ -181,6 +185,7 @@ module Herb
         return unless @mark
 
         insert_markers(node)
+        wrap_displaced
         wrap_region(node)
         append_statics(node)
       end
@@ -272,6 +277,8 @@ module Herb
 
       def visit_erb_block_node(node)
         record_slot(node, :block)
+
+        @displaced << node if CAPTURING.match?(expression_for(node).to_s)
 
         visit_branching_node(node)
       end
@@ -820,15 +827,34 @@ module Herb
       end
 
       def wrap_region(document_node)
-        name = identifier
-
         document_node.children.unshift(
-          text_node(@markers.region_open_prefix(name, version)),
-          erb_output_node(occurrence_expression),
-          text_node(@markers.region_open_suffix)
+          erb_code_node("#{OCCURRENCE} = #{occurrence_expression}"),
+          *region_open
         )
 
-        document_node.children.push(comment_node(@markers.region_close(name)))
+        document_node.children.push(comment_node(@markers.region_close(identifier)))
+      end
+
+      def wrap_displaced
+        @displaced.each do |node|
+          BRANCH_BODY_PROPERTIES.each do |property|
+            next unless node.respond_to?(property)
+
+            body = node.send(property)
+            next unless body.is_a?(Array) && !body.empty?
+
+            body.unshift(*region_open)
+            body.push(comment_node(@markers.region_close(identifier)))
+          end
+        end
+      end
+
+      def region_open
+        [
+          text_node(@markers.region_open_prefix(identifier, version)),
+          erb_output_node(OCCURRENCE),
+          text_node(@markers.region_open_suffix)
+        ]
       end
 
       def text_node(content)

--- a/sig/herb/engine/slot_visitor.rbs
+++ b/sig/herb/engine/slot_visitor.rbs
@@ -34,6 +34,10 @@ module Herb
 
       OCCURRENCES: String
 
+      OCCURRENCE: String
+
+      CAPTURING: Regexp
+
       BRANCHING_TYPES: Array[Symbol]
 
       ATTRIBUTE_TYPES: Array[Symbol]
@@ -241,6 +245,10 @@ module Herb
       def each_child_array: (untyped) { (Array[untyped]) -> void } -> void
 
       def wrap_region: (untyped document_node) -> untyped
+
+      def wrap_displaced: () -> untyped
+
+      def region_open: () -> untyped
 
       def text_node: (untyped content) -> untyped
 

--- a/test/engine/slots/displaced_test.rb
+++ b/test/engine/slots/displaced_test.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require_relative "../../test_helper"
+require_relative "../../../lib/herb/engine"
+require_relative "../../../lib/herb/engine/slot_visitor"
+
+module Engine
+  module Slots
+    class DisplacedTest < Minitest::Spec
+      FILE = "app/views/page/show.html.erb"
+
+      class View
+        def initialize(**assigns)
+          assigns.each { |name, value| instance_variable_set(:"@#{name}", value) }
+        end
+
+        def content_for(_name) = yield
+        def capture = yield
+        def provide(_name) = yield
+        def wrapper = yield
+        def capture_panel = yield
+      end
+
+      def compile(source)
+        Herb::Engine.new(source, visitors: [Herb::Engine::SlotVisitor.new], filename: FILE).src
+      end
+
+      def render(source, **assigns)
+        View.new(**assigns).instance_eval(compile(source))
+      end
+
+      def openers(markup)
+        markup.scan(/<!--herb-region:([^:]+):([0-9a-f]+):(\d+)-->/)
+      end
+
+      test "writes a second region marker around what the helper captured" do
+        markup = render("<% content_for :title do %><h1><%= @title %></h1><% end %>", title: "T")
+
+        assert_equal 2, openers(markup).size
+      end
+
+      test "names the rendering it came from, rather than counting a new one" do
+        markup = render("<% content_for :title do %><h1><%= @title %></h1><% end %><p><%= @body %></p>", title: "T", body: "B")
+        outer, inner = openers(markup)
+
+        assert_equal outer, inner
+        assert_equal "0", inner.last
+      end
+
+      test "both halves of a second rendering agree that they are the second" do
+        compiled = compile("<% content_for :title do %><h1><%= @title %></h1><% end %><p><%= @body %></p>")
+        view = View.new(title: "T", body: "B")
+
+        assert_equal [["0", "0"], ["1", "1"]], Array.new(2) { openers(view.instance_eval(compiled)).map(&:last) }
+      end
+
+      test "the slots inside it keep the numbering of the template that wrote them" do
+        markup = render("<% content_for :title do %><h1><%= @title %></h1><% end %><p><%= @body %></p>", title: "T", body: "B")
+
+        assert_includes markup, %(<h1 data-herb-child="1">)
+        assert_includes markup, %(<p data-herb-child="2">)
+      end
+
+      test "capture is wrapped too, being the same displacement by another name" do
+        assert_equal 2, openers(render("<% @held = capture do %><b><%= @name %></b><% end %>", name: "N")).size
+      end
+
+      test "provide is wrapped too" do
+        assert_equal 2, openers(render("<% provide :title do %><b><%= @name %></b><% end %>", name: "N")).size
+      end
+
+      test "a block that captures nothing is left alone" do
+        assert_equal 1, openers(render("<% wrapper do %><b><%= @name %></b><% end %>", name: "N")).size
+      end
+
+      test "a name that merely begins with one of them is not a capture" do
+        assert_equal 1, openers(render("<% capture_panel do %><b><%= @name %></b><% end %>", name: "N")).size
+      end
+    end
+  end
+end

--- a/test/snapshots/engine/slots/markers_test/test_0016_compiles_slot_markers_into_the_generated_source_559531fe8b8d3cfe03195c6e35d25f97.txt
+++ b/test/snapshots/engine/slots/markers_test/test_0016_compiles_slot_markers_into_the_generated_source_559531fe8b8d3cfe03195c6e35d25f97.txt
@@ -2,5 +2,6 @@
 source: "Engine::Slots::MarkersTest#test_0016_compiles slot markers into the generated source"
 input: "{source: \"<p><%= @name %></p>\", options: {visitors: [#<Herb::Engine::SlotVisitor server>], filename: \"app/views/test.html.erb\"}}"
 ---
-_buf = ::String.new; _buf << '<!--herb-region:app/views/test.html.erb:fd3dfd36:'.freeze; _buf << (((@_herb_region_occurrences ||= ::Hash.new(0))["app/views/test.html.erb"] += 1) - 1).to_s; _buf << '--><p data-herb-child="0">'.freeze; _buf << (@name).to_s; _buf << '</p><!--/herb-region:app/views/test.html.erb-->'.freeze;
+_buf = ::String.new; _herb_occurrence = ((@_herb_region_occurrences ||= ::Hash.new(0))["app/views/test.html.erb"] += 1) - 1 
+ _buf << '<!--herb-region:app/views/test.html.erb:fd3dfd36:'.freeze; _buf << (_herb_occurrence).to_s; _buf << '--><p data-herb-child="0">'.freeze; _buf << (@name).to_s; _buf << '</p><!--/herb-region:app/views/test.html.erb-->'.freeze;
 _buf.to_s

--- a/test/snapshots/engine/slots/markers_test/test_0017_compiles_a_conditional_into_the_generated_source_afe220742e3b876f4442d488bcae4d6c.txt
+++ b/test/snapshots/engine/slots/markers_test/test_0017_compiles_a_conditional_into_the_generated_source_afe220742e3b876f4442d488bcae4d6c.txt
@@ -2,5 +2,6 @@
 source: "Engine::Slots::MarkersTest#test_0017_compiles a conditional into the generated source"
 input: "{source: \"<div><% if @admin %><b><%= @secret %></b><% end %></div>\", options: {visitors: [#<Herb::Engine::SlotVisitor server>], filename: \"app/views/test.html.erb\"}}"
 ---
-_buf = ::String.new; _buf << '<!--herb-region:app/views/test.html.erb:8318a878:'.freeze; _buf << (((@_herb_region_occurrences ||= ::Hash.new(0))["app/views/test.html.erb"] += 1) - 1).to_s; _buf << '--><div><!--herb-slot:0:conditional-->'.freeze; if @admin; _buf << '<!--herb-branch:0:0--><b data-herb-child="1">'.freeze; _buf << (@secret).to_s; _buf << '</b>'.freeze; end; _buf << '<!--/herb-slot:0--></div><!--/herb-region:app/views/test.html.erb-->'.freeze;
+_buf = ::String.new; _herb_occurrence = ((@_herb_region_occurrences ||= ::Hash.new(0))["app/views/test.html.erb"] += 1) - 1 
+ _buf << '<!--herb-region:app/views/test.html.erb:8318a878:'.freeze; _buf << (_herb_occurrence).to_s; _buf << '--><div><!--herb-slot:0:conditional-->'.freeze; if @admin; _buf << '<!--herb-branch:0:0--><b data-herb-child="1">'.freeze; _buf << (@secret).to_s; _buf << '</b>'.freeze; end; _buf << '<!--/herb-slot:0--></div><!--/herb-region:app/views/test.html.erb-->'.freeze;
 _buf.to_s

--- a/test/snapshots/engine/slots/markers_test/test_0018_compiles_a_collection_into_the_generated_source_b315f0b9109908ecc239a91b51dac05c.txt
+++ b/test/snapshots/engine/slots/markers_test/test_0018_compiles_a_collection_into_the_generated_source_b315f0b9109908ecc239a91b51dac05c.txt
@@ -2,5 +2,6 @@
 source: "Engine::Slots::MarkersTest#test_0018_compiles a collection into the generated source"
 input: "{source: \"<ul><% @items.each do |item| %><li><%= item %></li><% end %></ul>\", options: {visitors: [#<Herb::Engine::SlotVisitor server>], filename: \"app/views/test.html.erb\"}}"
 ---
-_buf = ::String.new; _buf << '<!--herb-region:app/views/test.html.erb:939caffd:'.freeze; _buf << (((@_herb_region_occurrences ||= ::Hash.new(0))["app/views/test.html.erb"] += 1) - 1).to_s; _buf << '--><ul><!--herb-slot:0:collection-->'.freeze; @items.each do |item|; _buf << '<li data-herb-child="1">'.freeze; _buf << (item).to_s; _buf << '</li>'.freeze; end; _buf << '<!--/herb-slot:0--></ul><!--/herb-region:app/views/test.html.erb-->'.freeze;
+_buf = ::String.new; _herb_occurrence = ((@_herb_region_occurrences ||= ::Hash.new(0))["app/views/test.html.erb"] += 1) - 1 
+ _buf << '<!--herb-region:app/views/test.html.erb:939caffd:'.freeze; _buf << (_herb_occurrence).to_s; _buf << '--><ul><!--herb-slot:0:collection-->'.freeze; @items.each do |item|; _buf << '<li data-herb-child="1">'.freeze; _buf << (item).to_s; _buf << '</li>'.freeze; end; _buf << '<!--/herb-slot:0--></ul><!--/herb-region:app/views/test.html.erb-->'.freeze;
 _buf.to_s

--- a/test/snapshots/engine/slots/markers_test/test_0019_compiles_attribute_slots_into_the_generated_source_31266c1d49d58bdb58f398f8590129ba.txt
+++ b/test/snapshots/engine/slots/markers_test/test_0019_compiles_attribute_slots_into_the_generated_source_31266c1d49d58bdb58f398f8590129ba.txt
@@ -2,5 +2,6 @@
 source: "Engine::Slots::MarkersTest#test_0019_compiles attribute slots into the generated source"
 input: "{source: \"<div class=\\\"<%= @c %>\\\" id=\\\"<%= @i %>\\\"></div>\", options: {visitors: [#<Herb::Engine::SlotVisitor server>], filename: \"app/views/test.html.erb\"}}"
 ---
-_buf = ::String.new; _buf << '<!--herb-region:app/views/test.html.erb:b5b81d11:'.freeze; _buf << (((@_herb_region_occurrences ||= ::Hash.new(0))["app/views/test.html.erb"] += 1) - 1).to_s; _buf << '--><div class="'.freeze; _buf << ::Herb::Engine.attr((@c)); _buf << '" id="'.freeze; _buf << ::Herb::Engine.attr((@i)); _buf << '" data-herb-slot="0:attribute:class,1:attribute:id"></div><!--/herb-region:app/views/test.html.erb-->'.freeze;
+_buf = ::String.new; _herb_occurrence = ((@_herb_region_occurrences ||= ::Hash.new(0))["app/views/test.html.erb"] += 1) - 1 
+ _buf << '<!--herb-region:app/views/test.html.erb:b5b81d11:'.freeze; _buf << (_herb_occurrence).to_s; _buf << '--><div class="'.freeze; _buf << ::Herb::Engine.attr((@c)); _buf << '" id="'.freeze; _buf << ::Herb::Engine.attr((@i)); _buf << '" data-herb-slot="0:attribute:class,1:attribute:id"></div><!--/herb-region:app/views/test.html.erb-->'.freeze;
 _buf.to_s

--- a/test/snapshots/engine/slots/markers_test/test_0036_delimits_a_yield_d6d8d3da946901d8685c429e580d1eb5.txt
+++ b/test/snapshots/engine/slots/markers_test/test_0036_delimits_a_yield_d6d8d3da946901d8685c429e580d1eb5.txt
@@ -2,5 +2,6 @@
 source: "Engine::Slots::MarkersTest#test_0036_delimits a yield"
 input: "{source: \"<main><%= yield %></main>\", options: {visitors: [#<Herb::Engine::SlotVisitor server>], filename: \"app/views/test.html.erb\"}}"
 ---
-_buf = ::String.new; _buf << '<!--herb-region:app/views/test.html.erb:fd3dfd36:'.freeze; _buf << (((@_herb_region_occurrences ||= ::Hash.new(0))["app/views/test.html.erb"] += 1) - 1).to_s; _buf << '--><main data-herb-child="0">'.freeze; _buf << (yield).to_s; _buf << '</main><!--/herb-region:app/views/test.html.erb-->'.freeze;
+_buf = ::String.new; _herb_occurrence = ((@_herb_region_occurrences ||= ::Hash.new(0))["app/views/test.html.erb"] += 1) - 1 
+ _buf << '<!--herb-region:app/views/test.html.erb:fd3dfd36:'.freeze; _buf << (_herb_occurrence).to_s; _buf << '--><main data-herb-child="0">'.freeze; _buf << (yield).to_s; _buf << '</main><!--/herb-region:app/views/test.html.erb-->'.freeze;
 _buf.to_s


### PR DESCRIPTION
This pull request makes a slot addressable when `content_for`, `provide` or `capture` moved it away from the template that numbered it.

Those helpers run during one rendering and hand their markup to whoever wants it, which is usually somewhere else on the page. The markers go with it, so a slot ended up outside the markers of the template that numbered it, and the client, attributing slots by where they sit, gave it to whatever enclosed it instead. The value for it was in the payload the whole time and nothing could find the place to put it.

Captured markup carries its own region marker now, naming the same template, version and rendering as the template around it, so it says where it belongs wherever it is emitted. It reads the number instead of counting again, which is what makes it the same rendering and not another one.

On the client, a region is no longer a stretch of the page between two markers. A rendering is identified by its template, version and number, so two markers naming the same one are the same one. A region holds a list of ranges, is kept while any of them is still on the page, and contains a node that any of them contains. Nothing about addressing changes: a slot inside a `content_for` is `slots.slot(file, index)` like any other, however far from the rest of its template it ended up.

Matching by name only covers the helpers that can be named. A helper that captures its block privately is indistinguishable from one that renders it in place, and no amount of reading the ERB will tell them apart. Matching one that renders in place costs a marker pair saying something true, so this errs towards matching.

On RubyEvents' announcements page the head now carries the action template's marker fifty thousand characters from the rest of it, and the slot inside is addressable as that template's and not as the layout's.
