### PR TITLE
Client: Add, drop and reorder the rows a collection's payload asks for

### DIFF
--- a/javascript/packages/client/README.md
+++ b/javascript/packages/client/README.md
@@ -116,7 +116,7 @@ Values alone cannot do everything, and the report is the difference. `applied` c
 
 - `stale-version` and `no-region` mean nothing was applied at all. A version that does not match says the payload's indices were compiled against a different template, so the values would land in the wrong places, and there is no partial credit to take.
 - `branch` means the conditional took a branch whose markup the page never had and nothing was parked for it. Ask the server for that subtree.
-- `rows` means the collection's rows are not the ones the payload has, and `keys` lists which. The rows both sides agree on are still filled, so what is deferred is the adding, removing and moving.
+- `rows` means the collection had no row to copy a new one from, and `keys` lists the ones it could not build. Removing and moving need no markup, and a row the page has never had is built from one it has, because every row of a collection is the same shape by construction. A collection that rendered nothing has no row to copy, which is why a template in client mode parks one for exactly that case, and why this is only reached when neither exists.
 - `no-slot` means the payload named an index the page has no marker for, which is usually a region that was only partly scanned.
 
 A branch the server parked is built for you, so a template in client mode toggles a conditional with no round trip. That is the same `materialize` path, taken for you.
@@ -135,12 +135,14 @@ And the chain out to the top of its region:
 slots.ancestorsOf(slot)
 ```
 
-For collections, `reconcile` says what has to happen to the rows on the page for them to match the keys the server sent. A reorder reports as moves, not rebuilds, which is the reason to key a collection at all:
+For collections, `reconcile` says what has to happen to the rows on the page for them to match the keys the server sent. A reorder reports as moves, not rebuilds, which is the reason to key a collection at all. `apply` carries the plan out for you; this is for deciding, not doing:
 
 ```typescript
 slots.reconcile(collection, ["3", "1", "2"])
 // { added: [], removed: [], moved: ["3", "1"], kept: [...], unchanged: false }
 ```
+
+One limit worth knowing: JavaScript sorts integer-like object keys numerically, so `JSON.parse` loses the order a payload was written in for a collection keyed by id. Ascending is what an append wants and what most collections already are, so it rarely shows, but a collection whose order the server decides has to be keyed by something that is not a number.
 
 ## Branches that never rendered
 

--- a/javascript/packages/client/src/slot-index.ts
+++ b/javascript/packages/client/src/slot-index.ts
@@ -23,7 +23,7 @@ const SLOT_OPEN = /^herb-slot:(\d+)(?::([a-z_]+))?$/
 const SLOT_CLOSE = /^\/herb-slot:(\d+)$/
 const ROW_OPEN = /^herb-row:(\d+):([\s\S]*)$/
 const ROW_CLOSE = /^\/herb-row:(\d+)$/
-const BRANCH = /^herb-branch:(\d+):(\d+)$/
+const BRANCH = /^herb-branch:(\d+):(\w+)$/
 const MARKER = /^\/?herb-(region|slot|row|branch):/
 const STATICS_REGION = /^(.*):([0-9a-f]+)$/
 const STATICS_SELECTOR = "template[data-herb-region], template[data-herb-statics]"
@@ -368,6 +368,8 @@ export class SlotIndex {
       return
     }
 
+    this.capture(slot)
+
     if (value.branch === null) {
       this.update(slot, "")
       slot.branch = null
@@ -386,16 +388,118 @@ export class SlotIndex {
   }
 
   #applyRows(payload: Payload, slot: Slot, value: Collected, report: ApplyReport): void {
-    const keys = Object.keys(value.rows)
-    const plan = this.reconcile(slot, keys)
+    const wanted = Object.keys(value.rows)
+    const plan = this.reconcile(slot, wanted)
 
-    if (!plan.unchanged) this.#defer(report, payload, slot.index, "rows", [...plan.added, ...plan.removed, ...plan.moved])
+    if (!plan.unchanged) {
+      const unbuilt = this.#reconcileRows(slot, wanted, plan)
 
-    for (const key of plan.kept) {
+      if (unbuilt.length > 0) this.#defer(report, payload, slot.index, "rows", unbuilt)
+    }
+
+    for (const key of wanted) {
       const row = slot.rows.get(key)
 
       if (row) this.#applySlots(payload, row.slots, value.rows[key], report)
     }
+  }
+
+  #reconcileRows(slot: Slot, wanted: string[], plan: RowPlan): string[] {
+    for (const key of plan.removed) {
+      const row = slot.rows.get(key)
+
+      if (!row) continue
+
+      this.#dropRow(slot, row)
+    }
+
+    const template = plan.added.length > 0 ? this.#rowTemplate(slot) : null
+
+    if (!template) {
+      this.#order(slot, wanted.filter((key) => slot.rows.has(key)))
+
+      return plan.added
+    }
+
+    for (const key of plan.added) this.#buildRow(slot, key, template)
+
+    this.#order(slot, wanted)
+
+    return []
+  }
+
+  #rowTemplate(slot: Slot): DocumentFragment | null {
+    const [row] = this.#rowsInDocumentOrder(slot)
+
+    if (!row) {
+      const region = this.#slotRegions.get(slot)
+
+      return region ? this.skeletonFor(region.file, `${slot.index}:row`) : null
+    }
+
+    const fragment = document.createRange().createContextualFragment("")
+    const range = document.createRange()
+
+    range.setStartBefore(row.start)
+    range.setEndAfter(row.end)
+
+    fragment.append(range.cloneContents())
+
+    blankSlots(fragment)
+
+    return fragment
+  }
+
+  #buildRow(slot: Slot, key: string, template: DocumentFragment): void {
+    const copy = template.cloneNode(true) as DocumentFragment
+
+    for (const marker of this.#markers(copy)) {
+      if (marker.nodeType !== Node.COMMENT_NODE) continue
+
+      const comment = marker as Comment
+      const open = ROW_OPEN.exec(comment.data.trim())
+
+      if (open) comment.data = `herb-row:${slot.index}:${key}`
+    }
+
+    const added = [...copy.childNodes]
+    const anchor = this.#rowsInDocumentOrder(slot)[0]?.start ?? (slot.anchor.kind === "range" ? slot.anchor.end : null)
+
+    if (anchor) anchor.parentNode?.insertBefore(copy, anchor)
+    else return
+
+    this.scan(added)
+  }
+
+  #dropRow(slot: Slot, row: Row): void {
+    const range = document.createRange()
+
+    range.setStartBefore(row.start)
+    range.setEndAfter(row.end)
+    range.deleteContents()
+
+    slot.rows.delete(row.key)
+  }
+
+  #order(slot: Slot, keys: string[]): void {
+    if (slot.anchor.kind !== "range") return
+
+    const end = slot.anchor.end
+
+    for (const key of keys) {
+      const row = slot.rows.get(key)
+
+      if (!row) continue
+
+      const range = document.createRange()
+
+      range.setStartBefore(row.start)
+      range.setEndAfter(row.end)
+
+      end.parentNode?.insertBefore(range.extractContents(), end)
+    }
+
+    this.#pruneRows(slot)
   }
 
   #writeFragment(slot: Slot, fragment: DocumentFragment): void {
@@ -502,7 +606,9 @@ export class SlotIndex {
 
     return this.skeletonKeys(file)
       .filter((key) => key.startsWith(prefix))
-      .map((key) => Number(key.slice(prefix.length)))
+      .map((key) => key.slice(prefix.length))
+      .filter((branch) => /^\d+$/.test(branch))
+      .map(Number)
       .sort((a, b) => a - b)
   }
 
@@ -715,7 +821,7 @@ export class SlotIndex {
         const region = openRegions[openRegions.length - 1]?.region ?? this.#enclosingRegion(comment)
         const slot = region?.slots.get(Number(branch[1]))
 
-        if (slot) slot.branch = Number(branch[2])
+        if (slot && /^\d+$/.test(branch[2])) slot.branch = Number(branch[2])
 
         this.#seen.add(comment)
       }

--- a/javascript/packages/client/test/apply.test.ts
+++ b/javascript/packages/client/test/apply.test.ts
@@ -12,6 +12,14 @@ const PARKED = `<template data-herb-region="${FILE}:aaaaaaaa"><!--herb-branch:0:
 
 const ROWS = `<!--herb-region:${FILE}:bbbbbbbb:0--><ul><!--herb-slot:0:collection--><!--herb-row:0:1--><li data-herb-child="1">one</li><!--/herb-row:0--><!--herb-row:0:2--><li data-herb-child="1">two</li><!--/herb-row:0--><!--/herb-slot:0--></ul><!--/herb-region:${FILE}-->`
 
+const NAMED_ROWS = `<!--herb-region:${FILE}:bbbbbbbb:0--><ul><!--herb-slot:0:collection--><!--herb-row:0:ada--><li data-herb-child="1">Ada</li><!--/herb-row:0--><!--herb-row:0:grace--><li data-herb-child="1">Grace</li><!--/herb-row:0--><!--/herb-slot:0--></ul><!--/herb-region:${FILE}-->`
+
+const EMPTY_ROWS = `<!--herb-region:${FILE}:bbbbbbbb:0--><ul><!--herb-slot:0:collection--><!--/herb-slot:0--></ul><!--/herb-region:${FILE}-->`
+
+const PARKED_ROW =
+  `<template data-herb-region="${FILE}:bbbbbbbb"><!--herb-branch:0:row-->` +
+  `<!--herb-row:0:--><li data-herb-child="1"></li><!--/herb-row:0--></template>`
+
 const NESTED =
   `<!--herb-region:${FILE}:cccccccc:0--><div><!--herb-slot:0-->` +
   `<!--herb-region:${CARD}:dddddddd:0--><p data-herb-child="0">inner</p><!--/herb-region:${CARD}-->` +
@@ -65,6 +73,19 @@ describe("applying values to a conditional", () => {
     expect(index.rangeFor(index.slot(FILE, 2)!).toString()).toBe("built")
   })
 
+  test("can put back the branch it replaced, without the server parking it", () => {
+    const index = mounted(COND_TRUE + PARKED)
+
+    index.apply(payload(FILE, { 0: { branch: 1, slots: { 2: "built" } } }))
+    expect(index.slot(FILE, 0)?.branch).toBe(1)
+
+    const report = index.apply(payload(FILE, { 0: { branch: 0, slots: { 1: "back" } } }))
+
+    expect(report.deferred).toEqual([])
+    expect(index.slot(FILE, 0)?.branch).toBe(0)
+    expect(index.rangeFor(index.slot(FILE, 1)!).toString()).toBe("back")
+  })
+
   test("defers a branch it has no markup for, rather than guessing", () => {
     const index = mounted(COND_FALSE)
 
@@ -94,18 +115,74 @@ describe("applying values to a collection", () => {
     expect(document.querySelectorAll("li")[1].textContent).toBe("TWO")
   })
 
-  test("defers the rows it cannot build, and still fills the ones it can", () => {
+  const keys = () => [...document.querySelectorAll("li")].map((li) => li.textContent)
+
+  test("drops a row the payload no longer has", () => {
+    const index = mounted(ROWS)
+
+    const report = index.apply(payload(FILE, { 0: { rows: { 2: { 1: "two" } } } }, "bbbbbbbb"))
+
+    expect(report.deferred).toEqual([])
+    expect(keys()).toEqual(["two"])
+  })
+
+  test("builds a row it has never seen from one it has", () => {
     const index = mounted(ROWS)
 
     const report = index.apply(
-      payload(FILE, { 0: { rows: { 2: { 1: "TWO" }, 3: { 1: "THREE" } } } }, "bbbbbbbb"),
+      payload(FILE, { 0: { rows: { 1: { 1: "one" }, 2: { 1: "two" }, 3: { 1: "three" } } } }, "bbbbbbbb"),
     )
 
-    expect(report.applied).toBe(1)
+    expect(report.deferred).toEqual([])
+    expect(keys()).toEqual(["one", "two", "three"])
+    expect(index.slotInRow(FILE, 0, "3", 1)).not.toBeNull()
+  })
+
+  test("puts the rows in the order the payload asked for", () => {
+    const index = mounted(NAMED_ROWS)
+
+    index.apply(payload(FILE, { 0: { rows: { grace: { 1: "Grace" }, ada: { 1: "Ada" } } } }, "bbbbbbbb"))
+
+    expect(keys()).toEqual(["Grace", "Ada"])
+  })
+
+  test("adds, removes and reorders in one go", () => {
+    const index = mounted(NAMED_ROWS)
+
+    const report = index.apply(
+      payload(FILE, { 0: { rows: { yuki: { 1: "Yukihiro" }, ada: { 1: "Ada" } } } }, "bbbbbbbb"),
+    )
+
+    expect(report.deferred).toEqual([])
+    expect(keys()).toEqual(["Yukihiro", "Ada"])
+  })
+
+  test("cannot be told to reorder rows keyed by a number", () => {
+    const index = mounted(ROWS)
+
+    index.apply(payload(FILE, { 0: { rows: { 2: { 1: "two" }, 1: { 1: "one" } } } }, "bbbbbbbb"))
+
+    expect(keys()).toEqual(["one", "two"])
+  })
+
+  test("builds into an empty collection from the row the server parked", () => {
+    const index = mounted(EMPTY_ROWS + PARKED_ROW)
+
+    const report = index.apply(payload(FILE, { 0: { rows: { 1: { 1: "one" } } } }, "bbbbbbbb"))
+
+    expect(report.deferred).toEqual([])
+    expect(keys()).toEqual(["one"])
+    expect(index.slotInRow(FILE, 0, "1", 1)).not.toBeNull()
+  })
+
+  test("asks for a row when the collection is empty and nothing was parked", () => {
+    const index = mounted(EMPTY_ROWS)
+
+    const report = index.apply(payload(FILE, { 0: { rows: { 1: { 1: "one" } } } }, "bbbbbbbb"))
+
     expect(report.deferred).toEqual([
-      { file: FILE, occurrence: 0, index: 0, reason: "rows", keys: ["3", "1"] },
+      { file: FILE, occurrence: 0, index: 0, reason: "rows", keys: ["1"] },
     ])
-    expect(document.querySelectorAll("li")[1].textContent).toBe("TWO")
   })
 })
 

--- a/lib/herb/engine/slot_visitor.rb
+++ b/lib/herb/engine/slot_visitor.rb
@@ -39,6 +39,7 @@ module Herb
       MODE_OPTION = /\b(server|client)\b/ #: Regexp
       MODES = [:server, :client].freeze #: Array[Symbol]
       COVERED = "_herb_covered_branches" #: String
+      ROW_STATICS = "row" #: String
       OCCURRENCES = "@_herb_region_occurrences" #: String
       OCCURRENCE = "_herb_occurrence" #: String
 
@@ -772,6 +773,8 @@ module Herb
           body = node.send(property)
           next unless body.is_a?(Array) && !body.empty?
 
+          park_row(slot_index, body)
+
           body.unshift(
             text_node(@markers.row_open_prefix(slot_index)),
             erb_output_node(slot.key_expression),
@@ -780,6 +783,26 @@ module Herb
 
           body.push(text_node(@markers.row_close(slot_index)))
         end
+      end
+
+      def park_row(slot_index, body)
+        statics = @statics
+        return unless statics
+
+        markup = SlotStatics.new(@pending).markup(body)
+        return unless markup
+
+        key = "#{slot_index}:#{ROW_STATICS}"
+
+        statics[key] = [
+          @markers.branch(slot_index, ROW_STATICS),
+          @markers.row_open_prefix(slot_index),
+          @markers.row_open_suffix,
+          markup,
+          @markers.row_close(slot_index)
+        ].join
+
+        body.insert(0, erb_code_node(%(#{COVERED}["#{key}"] = true)))
       end
 
       def anchor_attributes(node)

--- a/sig/herb/engine/slot_visitor.rbs
+++ b/sig/herb/engine/slot_visitor.rbs
@@ -32,6 +32,8 @@ module Herb
 
       COVERED: String
 
+      ROW_STATICS: String
+
       OCCURRENCES: String
 
       OCCURRENCE: String
@@ -235,6 +237,8 @@ module Herb
 
       # : (untyped, Integer?) -> void
       def wrap_rows: (untyped, Integer?) -> void
+
+      def park_row: (untyped slot_index, untyped body) -> untyped
 
       def anchor_attributes: (untyped node) -> untyped
 


### PR DESCRIPTION
This pull request lets a collection be edited and not only updated.

`apply` filled the rows both sides already agreed on and deferred every change to which rows there were, so rows could never be added, removed or moved. Two thirds of that was pessimism: removing a row and moving one need no markup at all, only the row's own range.

The third needed something to copy. Every row of a collection is the same shape by construction, so any row on the page is a template for the rest: one is cloned, emptied, given the key it is being built for, and filled from the payload like any other row. Which leaves one case that genuinely cannot be done, a collection with no rows at all, and that is what `deferred` now reports.

```typescript
slots.reconcile(collection, ["3", "1", "2"])
// { added: [], removed: [], moved: ["3", "1"], kept: [...], unchanged: false }
```

So the server parks a row for a collection that rendered none, and `_herb_covered_branches` does the deciding exactly as it does for a branch: a collection with rows on the page marks itself covered and parks nothing, because the page already holds a better copy than the compiler could write. The parked row carries an empty key, since a row's key is an expression and has no static form, and whatever builds a row from it has to say which row it is building anyway.

Parking happens before the key marker goes in and not after, because the statics printer refuses a tree it cannot print, and an expression is exactly what it cannot print. Parking afterwards silently parked nothing at all.

Two notes on the mechanics. The rows sort by moving each one to the end in the order asked for, measured against the collection's own closing marker, which is the one node no row can be inside, and that works in a table where the parser puts the rows in a `tbody` and leaves the markers around them at another depth. And JavaScript sorts integer-like object keys numerically, so `JSON.parse` loses the order the server wrote for a collection keyed by id. Ascending is what an append wants, so it rarely shows, but a collection whose order the server decides has to be keyed by something that is not a number. There is a test saying so.
