### PR TITLE
Dev Tools: Show what a slot update changed, and where

### DIFF
--- a/javascript/packages/client/README.md
+++ b/javascript/packages/client/README.md
@@ -106,6 +106,8 @@ const report = slots.apply(payload)
 // { applied: 7, deferred: [] }
 ```
 
+`applied` counts what was written, not what arrived. A value equal to the one already there is not written, since writing it would cost a re-parse, destroy whatever the slot contained, and announce a change that did not happen, so a payload matching the page reports `{ applied: 0, deferred: [] }` and touches nothing.
+
 A payload names the template, the version and which rendering it is, so nothing has to be said about where it goes. A partial's values arrive nested inside the slot that rendered it and are handed to that partial's own region, so one call covers a page however many templates it was built from.
 
 Values alone cannot do everything, and the report is the difference. `applied` counts what was written and `deferred` says what was not, with enough to act on:
@@ -116,7 +118,8 @@ Values alone cannot do everything, and the report is the difference. `applied` c
 
 - `stale-version` and `no-region` mean nothing was applied at all. A version that does not match says the payload's indices were compiled against a different template, so the values would land in the wrong places, and there is no partial credit to take.
 - `branch` means the conditional took a branch whose markup the page never had and nothing was parked for it. Ask the server for that subtree.
-- `rows` means the collection had no row to copy a new one from, and `keys` lists the ones it could not build. Removing and moving need no markup, and a row the page has never had is built from one it has, because every row of a collection is the same shape by construction. A collection that rendered nothing has no row to copy, which is why a template in client mode parks one for exactly that case, and why this is only reached when neither exists.
+- `rows` means the collection had no row to copy a new one from, and `keys` lists the ones it could not build. Removing and moving need no markup, and a row the page has never had is built from one it has, because every row of a collection is the same shape by construction. A collection that rendered nothing has no row to copy, which is why a template in client mode parks one for exactly that case. Emptying a collection on the page reaches the same state, so the last row out leaves its shape behind, and this is only reached when neither exists.
+- `partial-attribute` means the slot is a word interpolated into an attribute, as in `class="card <%= state %>"`. A marker says which attribute a slot is and not which stretch of it, so writing the value would drop what the template wrote around it, and refusing is the only honest answer.
 - `no-slot` means the payload named an index the page has no marker for, which is usually a region that was only partly scanned.
 
 A branch the server parked is built for you, so a template in client mode toggles a conditional with no round trip. That is the same `materialize` path, taken for you.

--- a/javascript/packages/client/src/index.ts
+++ b/javascript/packages/client/src/index.ts
@@ -1,5 +1,5 @@
 export { HerbRuntime } from "./runtime"
-export { SlotIndex } from "./slot-index"
+export { SlotIndex, SLOT_EVENT } from "./slot-index"
 
 export type { Slot, SlotType, SlotAnchor, Region, Row, ScanResult, RowPlan, RenderMode } from "./slot-index"
-export type { Payload, PayloadSlots, PayloadValue, Branched, Collected, ApplyReport, Deferred, DeferredReason } from "./slot-index"
+export type { SlotEventDetail, SlotOperation, Payload, PayloadSlots, PayloadValue, Branched, Collected, ApplyReport, Deferred, DeferredReason } from "./slot-index"

--- a/javascript/packages/client/src/slot-index.ts
+++ b/javascript/packages/client/src/slot-index.ts
@@ -26,6 +26,7 @@ const ROW_CLOSE = /^\/herb-row:(\d+)$/
 const BRANCH = /^herb-branch:(\d+):(\w+)$/
 const MARKER = /^\/?herb-(region|slot|row|branch):/
 const STATICS_REGION = /^(.*):([0-9a-f]+)$/
+const ROW_STATICS = "row"
 const STATICS_SELECTOR = "template[data-herb-region], template[data-herb-statics]"
 
 const DEFAULT_SLOT_TYPE: SlotType = "child"
@@ -77,6 +78,20 @@ export interface Slot {
   children: Slot[]
 }
 
+export type SlotOperation = "value" | "attribute" | "markup" | "branch" | "row-added" | "row-removed"
+
+export interface SlotEventDetail {
+  file: string
+  occurrence: number
+  index: number
+  operation: SlotOperation
+  key: string | null
+  slot: Slot | null
+  row: Row | null
+}
+
+export const SLOT_EVENT = "herb:slot-update"
+
 export interface RegionRange {
   start: Comment
   end: Comment | null
@@ -119,7 +134,7 @@ export interface Collected {
 
 export type PayloadValue = string | Payload | Branched | Collected
 
-export type DeferredReason = "no-region" | "stale-version" | "no-slot" | "branch" | "rows"
+export type DeferredReason = "no-region" | "stale-version" | "no-slot" | "branch" | "rows" | "partial-attribute"
 
 export interface Deferred {
   file: string
@@ -349,8 +364,14 @@ export class SlotIndex {
       }
 
       if (typeof value === "string") {
-        if (slot.attribute) this.setAttribute(slot, value)
-        else this.update(slot, value)
+        if (this.#same(slot, value)) continue
+
+        if (slot.attribute && !this.setAttribute(slot, value)) {
+          this.#defer(report, payload, index, "partial-attribute")
+          continue
+        }
+
+        if (!slot.attribute) this.update(slot, value)
 
         report.applied += 1
         continue
@@ -385,6 +406,10 @@ export class SlotIndex {
     this.#writeFragment(slot, built)
 
     report.applied += 1
+
+    if (value.slots) {
+      this.#applySlots(payload, this.#owner(slot), value.slots, report)
+    }
   }
 
   #applyRows(payload: Payload, slot: Slot, value: Collected, report: ApplyReport): void {
@@ -394,17 +419,23 @@ export class SlotIndex {
     if (!plan.unchanged) {
       const unbuilt = this.#reconcileRows(slot, wanted, plan)
 
-      if (unbuilt.length > 0) this.#defer(report, payload, slot.index, "rows", unbuilt)
+      if (unbuilt.length > 0) {
+        this.#defer(report, payload, slot.index, "rows", unbuilt)
+      }
     }
 
     for (const key of wanted) {
       const row = slot.rows.get(key)
 
-      if (row) this.#applySlots(payload, row.slots, value.rows[key], report)
+      if (row) {
+        this.#applySlots(payload, row.slots, value.rows[key], report)
+      }
     }
   }
 
   #reconcileRows(slot: Slot, wanted: string[], plan: RowPlan): string[] {
+    const template = plan.added.length > 0 ? this.#rowTemplate(slot) : null
+
     for (const key of plan.removed) {
       const row = slot.rows.get(key)
 
@@ -412,8 +443,6 @@ export class SlotIndex {
 
       this.#dropRow(slot, row)
     }
-
-    const template = plan.added.length > 0 ? this.#rowTemplate(slot) : null
 
     if (!template) {
       this.#order(slot, wanted.filter((key) => slot.rows.has(key)))
@@ -434,9 +463,13 @@ export class SlotIndex {
     if (!row) {
       const region = this.#slotRegions.get(slot)
 
-      return region ? this.skeletonFor(region.file, `${slot.index}:row`) : null
+      return region ? this.skeletonFor(region.file, `${slot.index}:${ROW_STATICS}`) : null
     }
 
+    return this.#rowFragment(row)
+  }
+
+  #rowFragment(row: Row): DocumentFragment {
     const fragment = document.createRange().createContextualFragment("")
     const range = document.createRange()
 
@@ -448,6 +481,16 @@ export class SlotIndex {
     blankSlots(fragment)
 
     return fragment
+  }
+
+  #keepRow(slot: Slot, row: Row): void {
+    if (slot.rows.size > 1) return
+
+    const region = this.#slotRegions.get(slot)
+
+    if (!region) return
+
+    this.#park(region, `${slot.index}:${ROW_STATICS}`, this.#rowFragment(row))
   }
 
   #buildRow(slot: Slot, key: string, template: DocumentFragment): void {
@@ -469,9 +512,14 @@ export class SlotIndex {
     else return
 
     this.scan(added)
+
+    this.#announce(slot, "row-added", slot.index, key, slot.rows.get(key) ?? null)
   }
 
   #dropRow(slot: Slot, row: Row): void {
+    this.#keepRow(slot, row)
+    this.#announce(slot, "row-removed", slot.index, row.key, row)
+
     const range = document.createRange()
 
     range.setStartBefore(row.start)
@@ -516,6 +564,8 @@ export class SlotIndex {
     range.insertNode(fragment)
 
     this.scan(added)
+
+    this.#announce(slot, "branch", slot.index)
   }
 
   #owner(slot: Slot): SlotMap {
@@ -526,7 +576,52 @@ export class SlotIndex {
     report.deferred.push({ file: payload.template, occurrence: payload.occurrence, index, reason, ...(keys ? { keys } : {}) })
   }
 
+  #current(slot: Slot): string {
+    if (slot.anchor.kind === "content") return slot.anchor.element.innerHTML
+    if (slot.anchor.kind === "element") return slot.anchor.element.outerHTML
+
+    const holder = document.createElement("div")
+
+    holder.append(this.rangeFor(slot).cloneContents())
+
+    return holder.innerHTML
+  }
+
+  #same(slot: Slot, value: string): boolean {
+    if (slot.type === "attribute_interpolation") return false
+
+    if (slot.attribute && slot.anchor.kind !== "range") {
+      return slot.anchor.element.getAttribute(slot.attribute) === value
+    }
+
+    return this.#current(slot) === value
+  }
+
+  #announce(slot: Slot | null, operation: SlotOperation, index: number, key: string | null = null, row: Row | null = null): void {
+    if (typeof document === "undefined") return
+
+    const region = slot ? this.#slotRegions.get(slot) : null
+
+    document.dispatchEvent(
+      new CustomEvent<SlotEventDetail>(SLOT_EVENT, {
+        detail: {
+          file: region?.file ?? "",
+          occurrence: region?.occurrence ?? 0,
+          index,
+          operation,
+          key,
+          slot,
+          row,
+        },
+      }),
+    )
+  }
+
   update(slot: Slot, html: string): ScanResult {
+    if (this.#current(slot) === html) {
+      return { regions: [], slots: [] }
+    }
+
     for (const descendant of this.descendantsOf(slot)) this.#forget(descendant)
 
     slot.children = []
@@ -550,7 +645,11 @@ export class SlotIndex {
 
     range.insertNode(fragment)
 
-    return this.scan(added)
+    const result = this.scan(added)
+
+    this.#announce(slot, "value", slot.index)
+
+    return result
   }
 
   updateRow(slot: Slot, key: string, html: string): ScanResult | null {
@@ -566,17 +665,25 @@ export class SlotIndex {
 
     range.insertNode(fragment)
 
-    return this.scan(added)
+    const result = this.scan(added)
+
+    this.#announce(slot, "markup", slot.index, key, slot.rows.get(key) ?? null)
+
+    return result
   }
 
   setAttribute(slot: Slot, value: string | null, name = slot.attribute): boolean {
     if (slot.anchor.kind === "range" || name === null) return false
+    if (slot.type === "attribute_interpolation") return false
+    if (slot.anchor.element.getAttribute(name) === value) return true
 
     if (value === null) {
       slot.anchor.element.removeAttribute(name)
     } else {
       slot.anchor.element.setAttribute(name, value)
     }
+
+    this.#announce(slot, "attribute", slot.index)
 
     return true
   }

--- a/javascript/packages/client/test/apply.test.ts
+++ b/javascript/packages/client/test/apply.test.ts
@@ -175,6 +175,19 @@ describe("applying values to a collection", () => {
     expect(index.slotInRow(FILE, 0, "1", 1)).not.toBeNull()
   })
 
+  test("builds again after every row has been deleted", () => {
+    const index = mounted(ROWS)
+    const empty = payload(FILE, { 0: { rows: {} } }, "bbbbbbbb")
+
+    expect(index.apply(empty).deferred).toEqual([])
+    expect(keys()).toEqual([])
+
+    const report = index.apply(payload(FILE, { 0: { rows: { 9: { 1: "again" } } } }, "bbbbbbbb"))
+
+    expect(report.deferred).toEqual([])
+    expect(keys()).toEqual(["again"])
+  })
+
   test("asks for a row when the collection is empty and nothing was parked", () => {
     const index = mounted(EMPTY_ROWS)
 
@@ -212,6 +225,24 @@ describe("applying values that came from more than one template", () => {
     expect(report.applied).toBe(0)
     expect(report.deferred).toEqual([{ file: CARD, occurrence: 0, index: null, reason: "stale-version" }])
     expect(index.rangeFor(index.slot(CARD, 0)!).toString()).toBe("inner")
+  })
+})
+
+describe("an attribute a template only partly wrote", () => {
+  const PARTIAL = `<!--herb-region:${FILE}:aaaaaaaa:0--><div class="card active" data-herb-slot="0:attribute_interpolation:class"></div><!--/herb-region:${FILE}-->`
+
+  beforeEach(() => {
+    document.body.innerHTML = ""
+  })
+
+  test("is refused rather than written over", () => {
+    const index = mounted(PARTIAL)
+
+    const report = index.apply(payload(FILE, { 0: "" }))
+
+    expect(report.applied).toBe(0)
+    expect(report.deferred).toEqual([{ file: FILE, occurrence: 0, index: 0, reason: "partial-attribute" }])
+    expect(document.querySelector("div")?.getAttribute("class")).toBe("card active")
   })
 })
 

--- a/javascript/packages/client/test/events.test.ts
+++ b/javascript/packages/client/test/events.test.ts
@@ -1,0 +1,108 @@
+import { describe, test, expect, beforeEach } from "vitest"
+
+import { SlotIndex, SLOT_EVENT } from "../src/slot-index"
+import type { Payload, SlotEventDetail } from "../src/slot-index"
+
+const FILE = "app/views/posts/index.html.erb"
+const ROWS = `<!--herb-region:${FILE}:bbbbbbbb:0--><ul><!--herb-slot:0:collection--><!--herb-row:0:a--><li data-herb-child="1">one</li><!--/herb-row:0--><!--/herb-slot:0--></ul><!--/herb-region:${FILE}-->`
+const CHILD = `<!--herb-region:${FILE}:aaaaaaaa:0--><p><!--herb-slot:0-->hi<!--/herb-slot:0--></p><!--/herb-region:${FILE}-->`
+
+function watch(): SlotEventDetail[] {
+  const seen: SlotEventDetail[] = []
+
+  document.addEventListener(SLOT_EVENT, (event) => seen.push((event as CustomEvent<SlotEventDetail>).detail))
+
+  return seen
+}
+
+describe("saying what changed", () => {
+  beforeEach(() => {
+    document.body.innerHTML = ""
+  })
+
+  test("announces a value, naming the template it belongs to", () => {
+    document.body.innerHTML = CHILD
+
+    const index = new SlotIndex()
+    index.scan(document.body)
+
+    const seen = watch()
+
+    index.update(index.slot(FILE, 0)!, "there")
+
+    expect(seen).toHaveLength(1)
+    expect(seen[0]).toMatchObject({ file: FILE, occurrence: 0, index: 0, operation: "value" })
+  })
+
+  test("announces a row it built and a row it dropped, with the key", () => {
+    document.body.innerHTML = ROWS
+
+    const index = new SlotIndex()
+    index.scan(document.body)
+
+    const seen = watch()
+
+    index.apply({
+      template: FILE,
+      version: "bbbbbbbb",
+      occurrence: 0,
+      slots: { 0: { rows: { b: { 1: "two" } } } },
+    } as Payload)
+
+    expect(seen.map((detail) => [detail.operation, detail.key])).toEqual([
+      ["row-removed", "a"],
+      ["row-added", "b"],
+      ["value", null],
+    ])
+  })
+
+  test("says nothing when the value written is the value already there", () => {
+    document.body.innerHTML = CHILD
+
+    const index = new SlotIndex()
+    index.scan(document.body)
+
+    const seen = watch()
+
+    index.update(index.slot(FILE, 0)!, "hi")
+
+    expect(seen).toEqual([])
+  })
+
+  test("a row still exists when its removal is announced, so it can be pointed at", () => {
+    document.body.innerHTML = ROWS
+
+    const index = new SlotIndex()
+    index.scan(document.body)
+
+    const seen: Array<{ key: string | null; connected: boolean }> = []
+
+    document.addEventListener(SLOT_EVENT, (event) => {
+      const detail = (event as CustomEvent<SlotEventDetail>).detail
+
+      if (detail.operation === "row-removed") seen.push({ key: detail.key, connected: detail.row!.start.isConnected })
+    })
+
+    index.apply({
+      template: FILE,
+      version: "bbbbbbbb",
+      occurrence: 0,
+      slots: { 0: { rows: {} } },
+    } as Payload)
+
+    expect(seen).toEqual([{ key: "a", connected: true }])
+  })
+
+  test("hands over the slot rather than measuring it, since measuring costs a layout", () => {
+    document.body.innerHTML = CHILD
+
+    const index = new SlotIndex()
+    index.scan(document.body)
+
+    const seen = watch()
+
+    index.update(index.slot(FILE, 0)!, "there")
+
+    expect(index.rangeFor(seen[0].slot!).toString()).toBe("there")
+  })
+})

--- a/javascript/packages/client/test/round-trip.test.ts
+++ b/javascript/packages/client/test/round-trip.test.ts
@@ -32,11 +32,17 @@ describe("a page given the values of a later render", () => {
     expect(fixture.rendered).not.toBe(fixture.expected)
   })
 
-  test("writes every value it was given and defers nothing", () => {
+  test("writes every value that differs and defers nothing", () => {
     const report = index.apply(values)
 
-    expect(report.applied).toBe(7)
+    expect(report.applied).toBe(5)
     expect(report.deferred).toEqual([])
+  })
+
+  test("applying the same values twice writes nothing the second time", () => {
+    index.apply(values)
+
+    expect(index.apply(values)).toEqual({ applied: 0, deferred: [] })
   })
 
   test("leaves every marker where it was, so the next update has the same page to work on", () => {

--- a/javascript/packages/dev-tools/src/overlay/overlay.ts
+++ b/javascript/packages/dev-tools/src/overlay/overlay.ts
@@ -1,3 +1,4 @@
+import { SlotFlash } from '../slots/flash';
 import { ErrorOverlay } from './error-overlay';
 
 export interface HerbOverlayOptions {
@@ -23,6 +24,8 @@ export class HerbOverlay {
   private destroyed = false;
 
   private static readonly SETTINGS_KEY = 'herb-dev-tools-settings';
+  private slotFlash = new SlotFlash();
+  private showingSlotUpdates = false;
   private static readonly EDITOR_OPTIONS = [
     { value: 'auto', label: 'Auto (from server via RAILS_EDITOR or EDITOR)' },
     { value: 'atom', label: 'Atom' },
@@ -124,6 +127,7 @@ export class HerbOverlay {
         this.showingViewOutlines = settings.showingViewOutlines || false;
         this.showingPartialOutlines = settings.showingPartialOutlines || false;
         this.showingComponentOutlines = settings.showingComponentOutlines || false;
+        this.showingSlotUpdates = settings.showingSlotUpdates || false;
         this.menuOpen = settings.menuOpen || false;
         if (settings.preferredEditor) {
           this.preferredEditor = settings.preferredEditor;
@@ -143,6 +147,7 @@ export class HerbOverlay {
       showingViewOutlines: this.showingViewOutlines,
       showingPartialOutlines: this.showingPartialOutlines,
       showingComponentOutlines: this.showingComponentOutlines,
+      showingSlotUpdates: this.showingSlotUpdates,
       menuOpen: this.menuOpen,
       preferredEditor: this.preferredEditor
     };
@@ -243,6 +248,14 @@ export class HerbOverlay {
             </label>
           </div>
 
+          <div class="herb-toggle-item">
+            <label class="herb-toggle-label">
+              <input type="checkbox" id="herbToggleSlotUpdates" class="herb-toggle-input">
+              <span class="herb-toggle-switch"></span>
+              <span class="herb-toggle-text">Flash Slot Updates</span>
+            </label>
+          </div>
+
           <div class="herb-editor-section">
             <label class="herb-editor-label">
               <span class="herb-editor-text">Editor</span>
@@ -270,6 +283,7 @@ export class HerbOverlay {
     this.toggleComponentOutlines(this.showingComponentOutlines);
     this.toggleERBTags(this.showingERB);
     this.toggleERBOutlines(this.showingERBOutlines);
+    this.toggleSlotUpdates(this.showingSlotUpdates);
 
     const menuTrigger = document.getElementById('herbMenuTrigger');
     const menuPanel = document.getElementById('herbMenuPanel');
@@ -382,6 +396,15 @@ export class HerbOverlay {
           this.toggleERBOutlines(false);
         }
         this.toggleERBTags(toggleERBSwitch.checked);
+      });
+    }
+
+    const toggleSlotUpdatesSwitch = document.getElementById('herbToggleSlotUpdates') as HTMLInputElement;
+
+    if (toggleSlotUpdatesSwitch) {
+      toggleSlotUpdatesSwitch.checked = this.showingSlotUpdates;
+      toggleSlotUpdatesSwitch.addEventListener('change', () => {
+        this.toggleSlotUpdates(toggleSlotUpdatesSwitch.checked);
       });
     }
 
@@ -672,6 +695,15 @@ export class HerbOverlay {
         this.removeHoverTooltip(element);
       }
     });
+
+    this.saveSettings();
+  }
+
+  private toggleSlotUpdates(show?: boolean) {
+    this.showingSlotUpdates = show !== undefined ? show : !this.showingSlotUpdates;
+
+    if (this.showingSlotUpdates) this.slotFlash.start();
+    else this.slotFlash.stop();
 
     this.saveSettings();
   }

--- a/javascript/packages/dev-tools/src/slots/flash.ts
+++ b/javascript/packages/dev-tools/src/slots/flash.ts
@@ -1,0 +1,110 @@
+import { SLOT_EVENT } from '@herb-tools/client'
+import type { SlotEventDetail, SlotOperation } from '@herb-tools/client'
+
+const COLORS: Record<SlotOperation, string> = {
+  value: '#3b82f6',
+  markup: '#3b82f6',
+  attribute: '#a855f7',
+  branch: '#f59e0b',
+  'row-added': '#10b981',
+  'row-removed': '#ef4444'
+}
+
+export class SlotFlash {
+  private static readonly DURATION = 1600
+
+  private enabled = false
+
+  start() {
+    if (this.enabled) return
+
+    this.enabled = true
+    document.addEventListener(SLOT_EVENT, this.draw)
+  }
+
+  stop() {
+    this.enabled = false
+
+    document.removeEventListener(SLOT_EVENT, this.draw)
+    document.querySelectorAll('.herb-slot-flash').forEach((node) => node.remove())
+  }
+
+  private draw = (event: Event) => {
+    const detail = (event as CustomEvent<SlotEventDetail>).detail
+    const rect = this.measure(detail)
+
+    if (!rect) return
+
+    const colour = COLORS[detail.operation] ?? '#3b82f6'
+    const overlay = document.createElement('div')
+    const label = document.createElement('div')
+
+    overlay.className = 'herb-slot-flash'
+    label.className = 'herb-slot-flash'
+
+    overlay.style.cssText = `position:absolutez-index:2147483000pointer-events:nonetop:${rect.top + scrollY}pxleft:${rect.left + scrollX}pxwidth:${rect.width}pxheight:${rect.height}pxbackground:${colour}opacity:0.22outline:1px solid ${colour}transition:opacity ${SlotFlash.DURATION}ms ease-out`
+
+    label.style.cssText = `position:absolutez-index:2147483001pointer-events:nonetop:${Math.max(0, rect.top + scrollY - 18)}pxleft:${rect.left + scrollX}pxbackground:${colour}color:#ffffont:600 10px/1.6 ui-monospace,monospacepadding:0 5pxborder-radius:3pxwhite-space:nowraptransition:opacity ${SlotFlash.DURATION}ms ease-out`
+    label.textContent = this.describe(detail)
+
+    document.body.append(overlay, label)
+
+    requestAnimationFrame(() => {
+      overlay.style.opacity = '0'
+      label.style.opacity = '0'
+    })
+
+    setTimeout(() => {
+      overlay.remove()
+      label.remove()
+    }, SlotFlash.DURATION)
+  }
+
+  private measure(detail: SlotEventDetail): DOMRect | null {
+    if (detail.row) {
+      const range = document.createRange()
+
+      range.setStartBefore(detail.row.start)
+      range.setEndAfter(detail.row.end)
+
+      return this.biggest(range.getBoundingClientRect())
+    }
+
+    const slot = detail.slot
+    if (!slot) return null
+
+    if (slot.anchor.kind === 'range') {
+      const range = document.createRange()
+
+      range.setStartAfter(slot.anchor.start)
+      range.setEndBefore(slot.anchor.end)
+
+      return this.biggest(range.getBoundingClientRect())
+    }
+
+    const element = slot.anchor.element
+    const rect = this.biggest(element.getBoundingClientRect())
+
+    if (rect) return rect
+
+    const contents = document.createRange()
+
+    contents.selectNodeContents(element)
+
+    return this.biggest(contents.getBoundingClientRect()) ?? this.biggest(element.parentElement?.getBoundingClientRect())
+  }
+
+  private biggest(rect: DOMRect | undefined): DOMRect | null {
+    if (!rect) return null
+
+    return rect.width > 0 || rect.height > 0 ? rect : null
+  }
+
+  private describe(detail: SlotEventDetail): string {
+    const name = detail.file.split('/').pop() ?? detail.file
+    const key = detail.key === null ? '' : ` (${detail.key})`
+    const attribute = detail.slot?.attribute ? ` [${detail.slot.attribute}]` : ''
+
+    return `${detail.operation} ${name} #${detail.index}${key}${attribute}`
+  }
+}


### PR DESCRIPTION
This pull request announces every write the slot index makes, and draws it in the browser.

```typescript
document.addEventListener("herb:slot-update", (event) => event.detail)
// { file, occurrence, index, operation, key, slot, row }
```

The event carries the slot and not a rectangle, because measuring costs a layout and only a listener knows whether it wants one. Dev Tools uses it to flash what changed, coloured by operation, labelled with the file, the index, the row key and, for an attribute slot, which attribute was written. An element can carry several, and an attribute is the hardest kind of slot to tell apart by looking at the page, since nothing about a class or an id changing is visible in the way text changing is.

Four fixes came out of using it.

A removal was announced after the row had gone, so there was nothing left to measure and nothing to draw a box around, and it reported the collection instead of the row. Removing the only row made both faults visible at once. The event carries the row now, and is said before the row is taken out.

A slot given the value it already has is left alone. Writing it would cost a re-parse, destroy whatever the slot contained, and announce a change that did not happen, so a payload matching the page reports `{ applied: 0, deferred: [] }` and touches nothing.

`class="card <%= state %>"` marks the interpolated word while `setAttribute` writes the whole attribute, so applying the value dropped the `card` the template wrote beside it. A demo put its whole footer on one line the first time its layout was updated. A marker says which attribute a slot is, not which stretch of it, so refusing and saying so is the only honest answer until a marker carries the statics around the value.

And the last row out of a collection leaves its shape behind. The server parks a row only for a collection that rendered empty, so emptying one in the browser left neither a row to copy nor a parked one, and a table with one row in it deleted is two clicks away from needing another.


https://github.com/user-attachments/assets/011b040d-acb5-40aa-ba81-7ceefacdeeda


