### PR TITLE
Analysis: Number a node the way `SlotVisitor` and `SubtreeCompiler` do

### DIFF
--- a/javascript/packages/analysis/src/dependency-index.ts
+++ b/javascript/packages/analysis/src/dependency-index.ts
@@ -1,12 +1,12 @@
 import { collectTemplateDependencies } from "./template-dependencies"
-import { isERBCaseNode, isERBContentNode, isERBIfNode, isERBRenderNode, isERBUnlessNode, isHTMLAttributeNode, isLiteralNode } from "@herb-tools/core"
+import { isERBBlockNode, isERBCaseNode, isERBContentNode, isERBIfNode, isERBRenderNode, isERBUnlessNode, isHTMLAttributeNode, isHTMLElementNode, isLiteralNode } from "@herb-tools/core"
 
 const PARSER_OPTIONS = { render_nodes: true, strict_locals: true, prism_nodes: true, prism_program: true, track_whitespace: true }
 
 import type { DependencyOptions } from "./template-dependencies"
 import type { DocumentNode, HTMLAttributeNode, HerbBackend, Node, Token } from "@herb-tools/core"
 
-export type AffectedNodeKind = "text_content" | "conditional" | "render" | "attribute_value"
+export type AffectedNodeKind = "text_content" | "conditional" | "render" | "attribute_value" | "expression"
 
 export interface AffectedNode {
   nodePath: number[]
@@ -31,7 +31,21 @@ export function referencesState(code: string | undefined, state: string): boolea
 }
 
 function childrenOf(node: Node): Node[] {
-  return node.childNodes().filter((child): child is Node => child !== null)
+  const indexed = isHTMLElementNode(node)
+    ? node.body
+    : isERBIfNode(node) || isERBUnlessNode(node)
+      ? node.statements
+      : isERBBlockNode(node)
+        ? node.body
+        : node.childNodes()
+
+  return indexed.filter((child): child is Node => child !== null)
+}
+
+function attributesOf(node: Node): HTMLAttributeNode[] {
+  if (!isHTMLElementNode(node) || !node.open_tag) return []
+
+  return node.open_tag.childNodes().filter((child): child is HTMLAttributeNode => child !== null && isHTMLAttributeNode(child))
 }
 
 function locationOf(node: Node): string | undefined {
@@ -101,6 +115,8 @@ export function affectedNodes(backend: HerbBackend, source: string, state: strin
       return
     }
 
+    for (const attribute of attributesOf(node)) inspectAttribute(attribute)
+
     if (isERBIfNode(node) || isERBUnlessNode(node) || isERBCaseNode(node)) {
       if (expressionsWithin(node).some(code => referencesState(code, state))) {
         record(node, "conditional", expressionOf(node))
@@ -109,6 +125,8 @@ export function affectedNodes(backend: HerbBackend, source: string, state: strin
       record(node, "text_content", expressionOf(node))
     } else if (isERBRenderNode(node) && referencesState(expressionOf(node), state)) {
       record(node, "render", expressionOf(node))
+    } else if (isERBBlockNode(node) && referencesState(expressionOf(node), state)) {
+      record(node, "expression", expressionOf(node))
     }
 
     for (const [index, child] of childrenOf(node).entries()) {

--- a/javascript/packages/analysis/test/dependency-index.test.ts
+++ b/javascript/packages/analysis/test/dependency-index.test.ts
@@ -15,6 +15,26 @@ describe("dependencyIndex", () => {
     return dependencyIndex(Herb, FILE, source)
   }
 
+  test("numbers a node the way SlotVisitor and SubtreeCompiler number it", () => {
+    expect(affectedNodes(Herb, `<div><h1><%= @title %></h1></div>`, "@title")[0].nodePath).toEqual([0, 0, 0])
+  })
+
+  test("numbers a conditional by the element body it sits in", () => {
+    expect(affectedNodes(Herb, `<div><% if @admin %><%= @name %><% end %></div>`, "@admin")[0].nodePath).toEqual([0, 0])
+  })
+
+  test("numbers a block by the element body it sits in", () => {
+    expect(affectedNodes(Herb, `<ul><% @items.each do |item| %><li>x</li><% end %></ul>`, "@items")[0].nodePath).toEqual([0, 0])
+  })
+
+  test("gives an attribute the path of the element that carries it", () => {
+    expect(affectedNodes(Herb, `<div class="<%= @klass %>"></div>`, "@klass")[0].nodePath).toEqual([0])
+  })
+
+  test("gives a nested attribute the path of its own element", () => {
+    expect(affectedNodes(Herb, `<div><a href="<%= @url %>">x</a></div>`, "@url")[0].nodePath).toEqual([0, 0])
+  })
+
   test("maps state to the nodes that read it", () => {
     const index = indexOf(`<div><h1><%= @post.title %></h1><p><%= @post.body %></p></div>`)
 

--- a/lib/herb/analysis/template_dependencies/node_dependency_collector.rb
+++ b/lib/herb/analysis/template_dependencies/node_dependency_collector.rb
@@ -6,6 +6,9 @@ module Herb
   module Analysis
     class TemplateDependencies
       class NodeDependencyCollector < ::Herb::Visitor
+        BRANCH_BODY_PROPERTIES = [:statements, :body, :children, :conditions].freeze #: Array[Symbol]
+        BRANCH_CONTINUATION_PROPERTIES = [:subsequent, :else_clause, :rescue_clause, :ensure_clause].freeze #: Array[Symbol]
+
         attr_reader :affected
 
         def initialize(state, helper_registry, custom_helpers)
@@ -20,18 +23,18 @@ module Herb
         end
 
         def visit_document_node(node)
-          visit_children_with_paths(node.child_nodes)
+          visit_children_with_paths(node.children)
         end
 
         def visit_html_element_node(node)
-          visit_children_with_paths(node.child_nodes)
+          visit(node.open_tag) if node.open_tag
+
+          visit_children_with_paths(node.body)
         end
 
         def visit_html_open_tag_node(node)
-          node.child_nodes.each_with_index do |child, i|
-            if child.is_a?(Herb::AST::HTMLAttributeNode)
-              check_attribute(child, @path + [i])
-            end
+          node.child_nodes.each do |child|
+            check_attribute(child, @path.dup) if child.is_a?(Herb::AST::HTMLAttributeNode)
           end
         end
 
@@ -59,10 +62,40 @@ module Herb
           check_erb_expression(node, :render)
         end
 
+        def visit_erb_block_node(node)
+          check_erb_expression(node, :expression)
+
+          visit_branching_node(node)
+        end
+
+        def visit_erb_iteration_block_node(node)
+          check_erb_expression(node, :expression)
+
+          visit_branching_node(node)
+        end
+
+        def visit_erb_while_node(node)
+          check_erb_expression(node, :expression)
+
+          visit_branching_node(node)
+        end
+
+        def visit_erb_until_node(node)
+          check_erb_expression(node, :expression)
+
+          visit_branching_node(node)
+        end
+
+        def visit_erb_for_node(node)
+          check_erb_expression(node, :expression)
+
+          visit_branching_node(node)
+        end
+
         private
 
         def visit_children_with_paths(children)
-          return unless children
+          return unless children.is_a?(Array)
 
           children.each_with_index do |child, index|
             @path.push(index)
@@ -86,7 +119,24 @@ module Herb
             }
           end
 
-          visit_children_with_paths(node.child_nodes)
+          visit_branching_node(node)
+        end
+
+        def visit_branching_node(node)
+          BRANCH_BODY_PROPERTIES.each do |property|
+            next unless node.respond_to?(property)
+
+            visit_children_with_paths(node.send(property))
+          end
+
+          BRANCH_CONTINUATION_PROPERTIES.each do |property|
+            next unless node.respond_to?(property)
+
+            child = node.send(property)
+            next unless child
+
+            visit(child)
+          end
         end
 
         def collect_all_expressions(node)

--- a/rust/herb-analysis/src/state_flow.rs
+++ b/rust/herb-analysis/src/state_flow.rs
@@ -325,19 +325,10 @@ fn collect_affected(node: &AnyNode, state: &str, path: &mut Vec<usize>, affected
     collect_attributes(element, state, path, affected);
   }
 
-  let offset = child_index_offset(node);
-
   for (index, child) in any_children(node).into_iter().enumerate() {
-    path.push(index + offset);
+    path.push(index);
     collect_affected(child, state, path, affected);
     path.pop();
-  }
-}
-
-fn child_index_offset(node: &AnyNode) -> usize {
-  match node {
-    AnyNode::HTMLElementNode(element) => usize::from(element.open_tag.is_some()),
-    _ => 0,
   }
 }
 

--- a/rust/herb-analysis/tests/state_flow_test.rs
+++ b/rust/herb-analysis/tests/state_flow_test.rs
@@ -186,3 +186,43 @@ fn names_erb_output_in_text_the_same_way_ruby_does() {
 
   assert!(nodes.iter().any(|node| node.kind == "text_content"));
 }
+
+#[test]
+fn numbers_a_node_the_way_the_slot_visitor_does() {
+  let project = Project::new("path_nested");
+  let entry = project.write("app/views/posts/show.html.erb", "<div><h1><%= @title %></h1></div>");
+
+  let paths: Vec<Vec<usize>> = project.flow().affected_nodes(&entry, "@title").into_iter().map(|node| node.node_path).collect();
+
+  assert_eq!(paths, vec![vec![0, 0, 0]]);
+}
+
+#[test]
+fn numbers_a_conditional_by_the_element_body_it_sits_in() {
+  let project = Project::new("path_conditional");
+  let entry = project.write("app/views/posts/show.html.erb", "<div><% if @admin %><%= @name %><% end %></div>");
+
+  let paths: Vec<Vec<usize>> = project.flow().affected_nodes(&entry, "@admin").into_iter().map(|node| node.node_path).collect();
+
+  assert_eq!(paths, vec![vec![0, 0]]);
+}
+
+#[test]
+fn gives_an_attribute_the_path_of_the_element_that_carries_it() {
+  let project = Project::new("path_attribute");
+  let entry = project.write("app/views/posts/show.html.erb", "<div class=\"<%= @klass %>\"></div>");
+
+  let paths: Vec<Vec<usize>> = project.flow().affected_nodes(&entry, "@klass").into_iter().map(|node| node.node_path).collect();
+
+  assert_eq!(paths, vec![vec![0]]);
+}
+
+#[test]
+fn gives_a_nested_attribute_the_path_of_its_own_element() {
+  let project = Project::new("path_nested_attribute");
+  let entry = project.write("app/views/posts/show.html.erb", "<div><a href=\"<%= @url %>\">x</a></div>");
+
+  let paths: Vec<Vec<usize>> = project.flow().affected_nodes(&entry, "@url").into_iter().map(|node| node.node_path).collect();
+
+  assert_eq!(paths, vec![vec![0, 0]]);
+}

--- a/sig/herb/analysis/template_dependencies/node_dependency_collector.rbs
+++ b/sig/herb/analysis/template_dependencies/node_dependency_collector.rbs
@@ -4,6 +4,10 @@ module Herb
   module Analysis
     class TemplateDependencies
       class NodeDependencyCollector < ::Herb::Visitor
+        BRANCH_BODY_PROPERTIES: Array[Symbol]
+
+        BRANCH_CONTINUATION_PROPERTIES: Array[Symbol]
+
         attr_reader affected: untyped
 
         def initialize: (untyped state, untyped helper_registry, untyped custom_helpers) -> untyped
@@ -26,11 +30,23 @@ module Herb
 
         def visit_erb_render_node: (untyped node) -> untyped
 
+        def visit_erb_block_node: (untyped node) -> untyped
+
+        def visit_erb_iteration_block_node: (untyped node) -> untyped
+
+        def visit_erb_while_node: (untyped node) -> untyped
+
+        def visit_erb_until_node: (untyped node) -> untyped
+
+        def visit_erb_for_node: (untyped node) -> untyped
+
         private
 
         def visit_children_with_paths: (untyped children) -> untyped
 
         def check_block_for_state: (untyped node, untyped type) -> untyped
+
+        def visit_branching_node: (untyped node) -> untyped
 
         def collect_all_expressions: (untyped node) -> untyped
 

--- a/test/engine/slots/visitor_test.rb
+++ b/test/engine/slots/visitor_test.rb
@@ -4,6 +4,10 @@ require_relative "../../test_helper"
 require_relative "../../snapshot_utils"
 require_relative "../../../lib/herb/engine"
 require_relative "../../../lib/herb/engine/slot_visitor"
+require_relative "../../../lib/herb/analysis/template_dependencies"
+
+require "tmpdir"
+require "fileutils"
 
 module Engine
   module Slots
@@ -24,6 +28,23 @@ module Engine
         assert_snapshot_matches(format_slots(visitor), template, { filename: file_path })
 
         visitor
+      end
+
+      def node_paths_for(template, state)
+        Dir.mktmpdir do |root|
+          file_path = File.join(root, "app", "views", "test.html.erb")
+
+          FileUtils.mkdir_p(File.dirname(file_path))
+          File.write(file_path, template)
+
+          visitor = slots_for(template, file_path: file_path)
+          dependencies = Herb::Analysis::TemplateDependencies.new(root)
+
+          [
+            dependencies.affected_nodes(file_path, state).map { |node| node[:node_path] },
+            visitor.slots.map(&:node_path)
+          ]
+        end
       end
 
       def types_for(template)
@@ -77,8 +98,22 @@ module Engine
         assert_slots_snapshot("<p><%= @a %></p><p><%= @b %></p><p><%= @c %></p>")
       end
 
-      test "records the node_path that TemplateDependencies reports" do
-        assert_slots_snapshot("<div><h1><%= @title %></h1></div>")
+      test "records a node_path for every node TemplateDependencies reports" do
+        {
+          "<div><h1><%= @title %></h1></div>" => "@title",
+          "<div><% if @admin %><%= @name %><% end %></div>" => "@admin",
+          "<ul><% @items.each do |item| %><li><%= item.name %></li><% end %></ul>" => "@items",
+          %(<div class="<%= @klass %>"></div>) => "@klass",
+          %(<div><a href="<%= @url %>">x</a></div>) => "@url",
+        }.each do |template, state|
+          reported, recorded = node_paths_for(template, state)
+
+          refute_empty reported, template
+
+          reported.each do |node_path|
+            assert_includes recorded, node_path, template
+          end
+        end
       end
 
       test "records source location" do

--- a/test/snapshots/cli/action_view_commands_test/test_0008_dependencies_reports_the_manifest_for_a_template_944d779f5014e56350e2b3a6fe7e3c4c.txt
+++ b/test/snapshots/cli/action_view_commands_test/test_0008_dependencies_reports_the_manifest_for_a_template_944d779f5014e56350e2b3a6fe7e3c4c.txt
@@ -22,5 +22,5 @@ exit: 0
  Node index (which DOM nodes are affected by each state change)
 
    @post (1 node)
-     └── [0,1] text_content @post.title
+     └── [0,0] text_content @post.title
 


### PR DESCRIPTION
This pull request makes the three implementations of the dependency analysis number a node the same way, so a `node_path` from any of them names the same node.

`SubtreeCompiler` says the target it renders is named by "the same path `SlotVisitor` records for a slot and `TemplateDependencies` reports for a node, so a caller that has one from either has one that works here". That is the join the slot work depends on.

`SlotVisitor` walks an element's `body` and `SubtreeCompiler` indexes `:body`, while the analysis collector walked `child_nodes`, which is `[open_tag, *body, close_tag]`. Every element level shifted the index by one:

```erb
<div><h1><%= @title %></h1></div>
```

An attribute was addressed by descending into the open tag, where a path does not go, so it reported `[0, 0, 1]` where the visitor recorded `[0]` for the element carrying it. The bodies of blocks and loops were walked without pushing a path at all, so nothing inside a loop was addressable.

