### PR TITLE
Analysis: Introduce `SlotDependencies` to say which state a slot reads

### DIFF
--- a/javascript/packages/analysis/src/dependency-index.ts
+++ b/javascript/packages/analysis/src/dependency-index.ts
@@ -20,14 +20,18 @@ export function referencesState(code: string | undefined, state: string): boolea
   if (!code || !state) return false
 
   if (state.startsWith("@")) {
-    return code.includes(state)
+    return new RegExp(`${escapeForPattern(state)}\\b`).test(code)
   }
 
   if (state.includes(".")) {
     return code.includes(state.split(".")[0])
   }
 
-  return new RegExp(`\\b${state.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\b`).test(code)
+  return new RegExp(`\\b${escapeForPattern(state)}\\b`).test(code)
+}
+
+function escapeForPattern(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
 }
 
 function childrenOf(node: Node): Node[] {

--- a/javascript/packages/analysis/test/dependency-index.test.ts
+++ b/javascript/packages/analysis/test/dependency-index.test.ts
@@ -15,6 +15,12 @@ describe("dependencyIndex", () => {
     return dependencyIndex(Herb, FILE, source)
   }
 
+  test("does not confuse a state name with a longer one", () => {
+    const nodes = affectedNodes(Herb, `<div><%= @post.title %></div><div><%= @posts.count %></div>`, "@post")
+
+    expect(nodes.map(node => node.expression)).toEqual(["@post.title"])
+  })
+
   test("numbers a node the way SlotVisitor and SubtreeCompiler number it", () => {
     expect(affectedNodes(Herb, `<div><h1><%= @title %></h1></div>`, "@title")[0].nodePath).toEqual([0, 0, 0])
   })

--- a/lib/herb/analysis/template_dependencies.rb
+++ b/lib/herb/analysis/template_dependencies.rb
@@ -73,13 +73,17 @@ module Herb
         flow_node(trace, trace[:entry_point], nil, Set.new)
       end
 
-      def affected_nodes(file_path, state)
+      def affected_nodes(file_path, state, conditions_only: false)
         file_path = @project_path.join(file_path).to_s unless Pathname.new(file_path).absolute?
         source = File.read(file_path)
 
         ast = ::Herb.parse(source, render_nodes: true, strict_locals: true, prism_nodes: true, track_whitespace: true).value
 
-        collector = NodeDependencyCollector.new(state, @helper_registry, @custom_helpers)
+        nodes_in(ast, state, conditions_only: conditions_only)
+      end
+
+      def nodes_in(ast, state, conditions_only: false)
+        collector = NodeDependencyCollector.new(state, @helper_registry, @custom_helpers, conditions_only: conditions_only)
         ast.accept(collector)
 
         collector.affected

--- a/lib/herb/analysis/template_dependencies/node_dependency_collector.rb
+++ b/lib/herb/analysis/template_dependencies/node_dependency_collector.rb
@@ -11,13 +11,15 @@ module Herb
 
         attr_reader :affected
 
-        def initialize(state, helper_registry, custom_helpers)
+        def initialize(state, helper_registry, custom_helpers, conditions_only: false)
           super()
 
           @state = state
+          @conditions_only = conditions_only
           @helper_registry = helper_registry
           @custom_helpers = custom_helpers
           @affected = [] #: Array[Hash[Symbol, untyped]]
+          @aliases = Set[state] #: Set[String]
           @path = [] #: Array[Integer]
           @child_index = [] #: Array[Integer]
         end
@@ -105,7 +107,7 @@ module Herb
         end
 
         def check_block_for_state(node, type)
-          all_content = collect_all_expressions(node)
+          all_content = @conditions_only ? Array(own_expression(node)) : collect_all_expressions(node)
 
           if all_content.any? { |code| references_state?(code) }
             location = node.location
@@ -123,6 +125,9 @@ module Herb
         end
 
         def visit_branching_node(node)
+          bound = bindings_for(node)
+          @aliases.merge(bound)
+
           BRANCH_BODY_PROPERTIES.each do |property|
             next unless node.respond_to?(property)
 
@@ -137,6 +142,42 @@ module Herb
 
             visit(child)
           end
+        ensure
+          @aliases.subtract(bound) if bound
+        end
+
+        def bindings_for(node)
+          code = node.respond_to?(:content) ? node.content&.value&.strip : nil
+
+          return [] unless code
+          return [] unless references_state?(code)
+
+          block_parameters(code) - @aliases.to_a
+        end
+
+        def block_parameters(code)
+          result = Prism.parse("#{code}\nend")
+
+          return [] if result.errors.any?
+
+          names = [] #: Array[String]
+          collect_parameters(result.value, names)
+
+          names
+        end
+
+        def collect_parameters(node, names)
+          names << node.name.to_s if node.is_a?(Prism::RequiredParameterNode) || node.is_a?(Prism::BlockParameterNode)
+
+          node.child_nodes.compact.each { |child| collect_parameters(child, names) }
+        end
+
+        def own_expression(node)
+          return nil unless node.respond_to?(:content)
+
+          value = node.content&.value&.strip
+
+          value unless value.nil? || value.empty?
         end
 
         def collect_all_expressions(node)
@@ -206,13 +247,19 @@ module Herb
         end
 
         def references_state?(code)
-          if @state.start_with?("@")
-            code.include?(@state)
-          elsif @state.include?(".")
-            constant = @state.split(".").first
+          return false unless code
+
+          @aliases.any? { |name| references_name?(code, name) }
+        end
+
+        def references_name?(code, name)
+          if name.start_with?("@")
+            code.match?(/#{Regexp.escape(name)}\b/)
+          elsif name.include?(".")
+            constant = name.split(".").first
             code.include?(constant.to_s)
           else
-            code.match?(/\b#{Regexp.escape(@state)}\b/)
+            code.match?(/\b#{Regexp.escape(name)}\b/)
           end
         end
       end

--- a/lib/herb/engine/slot_dependencies.rb
+++ b/lib/herb/engine/slot_dependencies.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+# typed: false
+
+require_relative "../../herb"
+require_relative "../engine"
+require_relative "slot_visitor"
+require_relative "../analysis/template_dependencies"
+
+module Herb
+  class Engine
+    # Says which state each of a template's slots reads, and where that slot's next value can come
+    # from:
+    #
+    #     Herb::Engine::SlotDependencies.new(project_path).for("app/views/posts/index.html.erb")
+    #     #=> { 0 => { state: ["@items"], mode: :structural },
+    #           1 => { state: ["@items"], mode: :derived } }
+    #
+    # `SlotVisitor` records a `node_path` for every slot and `TemplateDependencies` reports one for
+    # every node a state reaches, so the two are joined on that path.
+    #
+    # A mode says who can produce the next value. `identity` is a slot whose expression is the
+    # state itself, so a client writes it by copying what it was given. `structural` is a
+    # conditional or a collection, which a client can only rebuild from markup the server parked.
+    # `derived` is an expression that has to be evaluated, and evaluating it means running Ruby.
+    #
+    # A conditional is reported against its own condition rather than everything inside it. What
+    # the branches read belongs to the slots in them, which carry their own state.
+    class SlotDependencies
+      STRUCTURAL_TYPES = [:conditional, :collection, :block].freeze #: Array[Symbol]
+      PARTIAL_TYPES = [:attribute_interpolation].freeze #: Array[Symbol]
+
+      #: (String | Pathname) -> void
+      def initialize(project_path)
+        @project_path = Pathname.new(project_path)
+        @dependencies = Herb::Analysis::TemplateDependencies.new(project_path)
+      end
+
+      #: (String) -> Hash[Integer, Hash[Symbol, untyped]]
+      def for(file_path)
+        path = absolute(file_path)
+        source = File.read(path)
+        analysis = @dependencies.analyze(path)
+        slots = slots_for(source, path)
+        reached = reached_paths(source, analysis)
+        settable = (analysis.instance_variables + analysis.locals_declared).to_set
+
+        index = {} #: Hash[Integer, Hash[Symbol, untyped]]
+
+        slots.each do |slot|
+          state = reached.filter_map { |name, paths| name if paths.key?(slot.node_path) }.sort
+          expressions = reached.values.filter_map { |paths| paths[slot.node_path] }.flatten.uniq
+
+          index[slot.index] = { state: state, mode: mode_for(slot, state, expressions, settable) }
+        end
+
+        index
+      end
+
+      private
+
+      #: (String) -> String
+      def absolute(file_path)
+        return file_path if Pathname.new(file_path).absolute?
+
+        @project_path.join(file_path).to_s
+      end
+
+      #: (String, String) -> Array[untyped]
+      def slots_for(source, path)
+        visitor = Herb::Engine::SlotVisitor.new
+
+        Herb::Engine.new(source, visitors: [visitor], filename: path)
+
+        visitor.slots
+      end
+
+      #: (String, untyped) -> Hash[String, Hash[Array[Integer], Array[String?]]]
+      def reached_paths(source, analysis)
+        ast = ::Herb.parse(source, render_nodes: true, strict_locals: true, prism_nodes: true, track_whitespace: true).value
+
+        reached = {} #: Hash[String, Hash[Array[Integer], Array[String?]]]
+
+        state_names(analysis).each do |name|
+          nodes = @dependencies.nodes_in(ast, name, conditions_only: true)
+
+          next if nodes.empty?
+
+          paths = {} #: Hash[Array[Integer], Array[String?]]
+
+          nodes.each do |node|
+            entry = paths[node[:node_path]] ||= [] #: Array[String?]
+            entry << node[:expression]
+          end
+
+          reached[name] = paths
+        end
+
+        reached
+      end
+
+      #: (untyped) -> Array[String]
+      def state_names(analysis)
+        analysis.instance_variables + analysis.constants + analysis.locals_declared
+      end
+
+      #: (untyped, Array[String], Array[String?], Set[String]) -> Symbol
+      def mode_for(slot, state, expressions, settable)
+        return :structural if STRUCTURAL_TYPES.include?(slot.type)
+        return :derived if PARTIAL_TYPES.include?(slot.type)
+        return :derived unless state.one?
+        return :derived unless settable.include?(state.first)
+
+        written = slot.expression ? [slot.expression] : expressions
+
+        written.map { |expression| expression.to_s.strip } == [state.first] ? :identity : :derived
+      end
+    end
+  end
+end

--- a/rust/herb-analysis/src/state_flow.rs
+++ b/rust/herb-analysis/src/state_flow.rs
@@ -265,16 +265,13 @@ impl StateFlow {
 }
 
 fn expression_references(expression: &str, name: &str) -> bool {
-  if name.starts_with('@') {
-    return expression.contains(name);
-  }
-
+  let sigil = name.starts_with('@');
   let bytes = expression.as_bytes();
   let mut start = 0;
 
   while let Some(offset) = expression[start..].find(name) {
     let index = start + offset;
-    let before = index == 0 || !is_word_byte(bytes[index - 1]);
+    let before = sigil || index == 0 || !is_word_byte(bytes[index - 1]);
     let after_index = index + name.len();
     let after = after_index >= bytes.len() || !is_word_byte(bytes[after_index]);
 

--- a/rust/herb-analysis/tests/state_flow_test.rs
+++ b/rust/herb-analysis/tests/state_flow_test.rs
@@ -226,3 +226,18 @@ fn gives_a_nested_attribute_the_path_of_its_own_element() {
 
   assert_eq!(paths, vec![vec![0, 0]]);
 }
+
+#[test]
+fn does_not_confuse_a_state_name_with_a_longer_one() {
+  let project = Project::new("prefix");
+  let entry = project.write("app/views/posts/show.html.erb", "<div><%= @post.title %></div><div><%= @posts.count %></div>");
+
+  let expressions: Vec<String> = project
+    .flow()
+    .affected_nodes(&entry, "@post")
+    .into_iter()
+    .filter_map(|node| node.expression)
+    .collect();
+
+  assert_eq!(expressions, vec!["@post.title".to_string()]);
+}

--- a/sig/herb/analysis/template_dependencies.rbs
+++ b/sig/herb/analysis/template_dependencies.rbs
@@ -55,7 +55,9 @@ module Herb
 
       def state_flow: (untyped entry_point, untyped state) -> untyped
 
-      def affected_nodes: (untyped file_path, untyped state) -> untyped
+      def affected_nodes: (untyped file_path, untyped state, ?conditions_only: untyped) -> untyped
+
+      def nodes_in: (untyped ast, untyped state, ?conditions_only: untyped) -> untyped
 
       def dependency_index: (untyped file_path) -> untyped
 

--- a/sig/herb/analysis/template_dependencies/node_dependency_collector.rbs
+++ b/sig/herb/analysis/template_dependencies/node_dependency_collector.rbs
@@ -10,7 +10,7 @@ module Herb
 
         attr_reader affected: untyped
 
-        def initialize: (untyped state, untyped helper_registry, untyped custom_helpers) -> untyped
+        def initialize: (untyped state, untyped helper_registry, untyped custom_helpers, ?conditions_only: untyped) -> untyped
 
         def visit_document_node: (untyped node) -> untyped
 
@@ -48,6 +48,14 @@ module Herb
 
         def visit_branching_node: (untyped node) -> untyped
 
+        def bindings_for: (untyped node) -> untyped
+
+        def block_parameters: (untyped code) -> untyped
+
+        def collect_parameters: (untyped node, untyped names) -> untyped
+
+        def own_expression: (untyped node) -> untyped
+
         def collect_all_expressions: (untyped node) -> untyped
 
         def check_erb_expression: (untyped node, untyped type) -> untyped
@@ -55,6 +63,8 @@ module Herb
         def check_attribute: (untyped attribute_node, untyped path) -> untyped
 
         def references_state?: (untyped code) -> untyped
+
+        def references_name?: (untyped code, untyped name) -> untyped
       end
     end
   end

--- a/sig/herb/engine/slot_dependencies.rbs
+++ b/sig/herb/engine/slot_dependencies.rbs
@@ -1,0 +1,51 @@
+# Generated from lib/herb/engine/slot_dependencies.rb with RBS::Inline
+
+module Herb
+  class Engine
+    # Says which state each of a template's slots reads, and where that slot's next value can come
+    # from:
+    #
+    #     Herb::Engine::SlotDependencies.new(project_path).for("app/views/posts/index.html.erb")
+    #     #=> { 0 => { state: ["@items"], mode: :structural },
+    #           1 => { state: ["@items"], mode: :derived } }
+    #
+    # `SlotVisitor` records a `node_path` for every slot and `TemplateDependencies` reports one for
+    # every node a state reaches, so the two are joined on that path.
+    #
+    # A mode says who can produce the next value. `identity` is a slot whose expression is the
+    # state itself, so a client writes it by copying what it was given. `structural` is a
+    # conditional or a collection, which a client can only rebuild from markup the server parked.
+    # `derived` is an expression that has to be evaluated, and evaluating it means running Ruby.
+    #
+    # A conditional is reported against its own condition rather than everything inside it. What
+    # the branches read belongs to the slots in them, which carry their own state.
+    class SlotDependencies
+      STRUCTURAL_TYPES: Array[Symbol]
+
+      PARTIAL_TYPES: Array[Symbol]
+
+      # : (String | Pathname) -> void
+      def initialize: (String | Pathname) -> void
+
+      # : (String) -> Hash[Integer, Hash[Symbol, untyped]]
+      def for: (String) -> Hash[Integer, Hash[Symbol, untyped]]
+
+      private
+
+      # : (String) -> String
+      def absolute: (String) -> String
+
+      # : (String, String) -> Array[untyped]
+      def slots_for: (String, String) -> Array[untyped]
+
+      # : (String, untyped) -> Hash[String, Hash[Array[Integer], Array[String?]]]
+      def reached_paths: (String, untyped) -> Hash[String, Hash[Array[Integer], Array[String?]]]
+
+      # : (untyped) -> Array[String]
+      def state_names: (untyped) -> Array[String]
+
+      # : (untyped, Array[String], Array[String?], Set[String]) -> Symbol
+      def mode_for: (untyped, Array[String], Array[String?], Set[String]) -> Symbol
+    end
+  end
+end

--- a/test/analysis/template_dependencies_test.rb
+++ b/test/analysis/template_dependencies_test.rb
@@ -423,6 +423,50 @@ class TemplateDependenciesTest < Minitest::Spec
     assert_equal "class", attr_node[:attribute]
   end
 
+  test "affected_nodes follows state through a block parameter" do
+    path = write_template("posts/index.html.erb", "<ul><% @items.each do |item| %><li><%= item.name %></li><% end %></ul>")
+
+    nodes = analyzer.affected_nodes(path, "@items")
+    expressions = nodes.map { |node| node[:expression] }
+
+    assert_includes expressions, "item.name"
+  end
+
+  test "affected_nodes follows state through every parameter a block binds" do
+    path = write_template("posts/index.html.erb", "<ul><% @rows.each_with_index do |row, i| %><li><%= i %>: <%= row.title %></li><% end %></ul>")
+
+    expressions = analyzer.affected_nodes(path, "@rows").map { |node| node[:expression] }
+
+    assert_includes expressions, "i"
+    assert_includes expressions, "row.title"
+  end
+
+  test "affected_nodes leaves an expression a block parameter does not reach" do
+    path = write_template("posts/index.html.erb", "<div><% @items.each do |item| %><%= other %><% end %></div>")
+
+    expressions = analyzer.affected_nodes(path, "@items").map { |node| node[:expression] }
+
+    refute_includes expressions, "other"
+  end
+
+  test "affected_nodes stops a block parameter at the end of its block" do
+    path = write_template("posts/index.html.erb", "<div><% @items.each do |item| %><%= item.name %><% end %><%= item %></div>")
+
+    nodes = analyzer.affected_nodes(path, "@items")
+
+    assert_equal(1, nodes.count { |node| node[:expression] == "item.name" })
+    assert_equal(0, nodes.count { |node| node[:expression] == "item" })
+  end
+
+  test "affected_nodes does not confuse a state name with a longer one" do
+    path = write_template("posts/show.html.erb", "<div><%= @post.title %></div><div><%= @posts.count %></div>")
+
+    expressions = analyzer.affected_nodes(path, "@post").map { |node| node[:expression] }
+
+    assert_includes expressions, "@post.title"
+    refute_includes expressions, "@posts.count"
+  end
+
   test "dependency_index marks if-blocks containing state as conditional" do
     path = write_template("posts/show.html.erb", "<div><% if @admin %><%= @post.name %><% end %></div>")
 

--- a/test/engine/slots/dependencies_test.rb
+++ b/test/engine/slots/dependencies_test.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+require_relative "../../test_helper"
+require_relative "../../../lib/herb/engine/slot_dependencies"
+
+require "tmpdir"
+require "fileutils"
+
+module Engine
+  module Slots
+    class DependenciesTest < Minitest::Spec
+      def setup
+        @project_path = Dir.mktmpdir("herb_slot_dependencies")
+        @view_root = File.join(@project_path, "app", "views", "posts")
+
+        FileUtils.mkdir_p(@view_root)
+      end
+
+      def teardown
+        FileUtils.rm_rf(@project_path)
+      end
+
+      def dependencies_for(template, name: "index.html.erb")
+        path = File.join(@view_root, name)
+
+        File.write(path, template)
+
+        Herb::Engine::SlotDependencies.new(@project_path).for(path)
+      end
+
+      test "names the state a slot reads" do
+        dependencies = dependencies_for("<div><%= @name %></div>")
+
+        assert_equal ["@name"], dependencies[0][:state]
+      end
+
+      test "calls a slot that is the state itself an identity" do
+        dependencies = dependencies_for("<div><%= @name %></div>")
+
+        assert_equal :identity, dependencies[0][:mode]
+      end
+
+      test "calls a slot that computes from the state derived" do
+        dependencies = dependencies_for("<div><%= @post.title %></div>")
+
+        assert_equal ["@post"], dependencies[0][:state]
+        assert_equal :derived, dependencies[0][:mode]
+      end
+
+      test "reads an attribute a slot writes whole as an identity" do
+        dependencies = dependencies_for(%(<input value="<%= @name %>">))
+
+        assert_equal ["@name"], dependencies[0][:state]
+        assert_equal :identity, dependencies[0][:mode]
+      end
+
+      test "refuses an attribute the template only partly wrote" do
+        dependencies = dependencies_for(%(<div class="card <%= @state %>"></div>))
+
+        assert_equal ["@state"], dependencies[0][:state]
+        assert_equal :derived, dependencies[0][:mode]
+      end
+
+      test "calls a conditional structural and reports only what its condition reads" do
+        dependencies = dependencies_for("<div><% if @admin %><b><%= @name %></b><% end %></div>")
+
+        assert_equal ["@admin"], dependencies[0][:state]
+        assert_equal :structural, dependencies[0][:mode]
+      end
+
+      test "gives a slot inside a branch the state that branch's body reads" do
+        dependencies = dependencies_for("<div><% if @admin %><b><%= @name %></b><% end %></div>")
+
+        assert_equal ["@name"], dependencies[1][:state]
+        assert_equal :identity, dependencies[1][:mode]
+      end
+
+      test "follows a collection into the slots its body renders" do
+        dependencies = dependencies_for("<ul><% @items.each do |item| %><li><%= item.name %></li><% end %></ul>")
+
+        assert_equal ["@items"], dependencies[0][:state]
+        assert_equal :structural, dependencies[0][:mode]
+
+        assert_equal ["@items"], dependencies[1][:state]
+        assert_equal :derived, dependencies[1][:mode]
+      end
+
+      test "gives every slot of a template an entry" do
+        dependencies = dependencies_for(%(<a href="<%= @url %>"><%= @label %></a>))
+
+        assert_equal [0, 1], dependencies.keys.sort
+        assert_equal ["@url"], dependencies[0][:state]
+        assert_equal ["@label"], dependencies[1][:state]
+      end
+
+      test "reports a constant a slot reads, and never as an identity" do
+        dependencies = dependencies_for("<div><%= Time.now %></div>")
+
+        assert_equal ["Time.now"], dependencies[0][:state]
+        assert_equal :derived, dependencies[0][:mode]
+      end
+
+      test "leaves a slot that reads no state without any" do
+        dependencies = dependencies_for(%(<div><%= "hello" %></div>))
+
+        assert_empty dependencies[0][:state]
+        assert_equal :derived, dependencies[0][:mode]
+      end
+    end
+  end
+end


### PR DESCRIPTION
This pull request introduces `Herb::Engine::SlotDependencies`, which answers, for each of a template's slots, which state it reads and where its next value can come from.

A slot knows where it is and the dependency graph knows what a state reaches, but nothing joined them, so a caller holding both still could not answer the only question that matters when state changes, which is what this touches. The two now agree on what a `node_path` means, so the join is a lookup.

```ruby
Herb::Engine::SlotDependencies.new(project_path).for("app/views/posts/index.html.erb")
#=> { 0 => { state: ["@items"], mode: :structural },
#     1 => { state: ["@items"], mode: :derived } }
```

A mode says who can produce the next value.

| Mode | Meaning |
| --- | --- |
| `identity` | The expression is the state itself, as in `<%= query %>` or `value="<%= query %>"`. A client writes it by copying. |
| `structural` | A conditional or a collection. A client rebuilds it only from markup the server parked. |
| `derived` | An expression that has to be evaluated, and evaluating it means running Ruby on the server. |

#### Three things had to be true first

A collection's body was attributed to nothing. `@items.each do |item|` binds `item`, and the matching was textual, so every slot inside the loop subscribed to nothing, which is where slots are densest. Block parameters now alias the state their block iterates, for as long as that block is open.

Matching an instance variable now ends on a word boundary, so `@post` no longer answers for `@posts`. An instance variable already begins on a boundary, since a name cannot run into the sigil, so only the end of it needs checking.

A conditional is reported against its own condition instead of everything inside it. Otherwise every state in a branch would also wake the branch holding it, and the map would say everything depends on everything. That is a second reading of the same question, so it is opt-in through `conditions_only:` and `herb dependencies` keeps the one it had.

#### Two classifications that look wrong until they are not

An interpolated attribute is never an identity. `class="card <%= @state %>"` reads `@state`, but a marker names the attribute and not the stretch of it, so writing the value would drop the `card` the template wrote. That is the same refusal the client already makes with `partial-attribute`, now agreed with at compile time.

A constant is never an identity. `<%= Time.now %>` is a real dependency, but not one a page can set, so there is nothing for a client to copy. Only instance variables and declared locals can be identities.
