### PR TITLE
Analysis: Carry a page's state into the partials that render it

### DIFF
--- a/lib/herb/engine/slot_dependencies.rb
+++ b/lib/herb/engine/slot_dependencies.rb
@@ -6,6 +6,8 @@ require_relative "../engine"
 require_relative "slot_visitor"
 require_relative "../analysis/template_dependencies"
 
+require "json"
+
 module Herb
   class Engine
     # Says which state each of a template's slots reads, and where that slot's next value can come
@@ -26,6 +28,7 @@ module Herb
     # A conditional is reported against its own condition rather than everything inside it. What
     # the branches read belongs to the slots in them, which carry their own state.
     class SlotDependencies
+      ATTRIBUTE = "data-herb-dependencies" #: String
       STRUCTURAL_TYPES = [:conditional, :collection, :block].freeze #: Array[Symbol]
       PARTIAL_TYPES = [:attribute_interpolation].freeze #: Array[Symbol]
 
@@ -33,16 +36,69 @@ module Herb
       def initialize(project_path)
         @project_path = Pathname.new(project_path)
         @dependencies = Herb::Analysis::TemplateDependencies.new(project_path)
+        @templates = {} #: Hash[String, Hash[Symbol, untyped]]
+      end
+
+      #: (String) -> Hash[String, Array[Hash[Symbol, untyped]]]
+      def across(entry_point)
+        path = absolute(entry_point)
+        index = {} #: Hash[String, Array[Hash[Symbol, untyped]]]
+
+        state_names(@dependencies.analyze(path)).each do |name|
+          flow = @dependencies.state_flow(path, name)
+
+          next unless flow
+
+          reached = reached_slots(flow)
+
+          index[name] = reached if reached.any?
+        end
+
+        index
+      end
+
+      #: (String, ?params: Hash[String, String]) -> Hash[String, untyped]
+      def payload(entry_point, params: {})
+        state = across(entry_point).transform_values { |slots|
+          slots.map { |slot| { "file" => identifier_for(slot[:file]), "version" => slot[:version], "index" => slot[:index], "mode" => slot[:mode].to_s } }
+        }
+
+        { "state" => state, "params" => request_names(entry_point, state.keys, params) }
+      end
+
+      #: (String, ?params: Hash[String, String]) -> String
+      def element(entry_point, params: {})
+        json = JSON.generate(payload(entry_point, params: params), script_safe: true)
+
+        %(<template #{ATTRIBUTE}>#{json}</template>)
       end
 
       #: (String) -> Hash[Integer, Hash[Symbol, untyped]]
       def for(file_path)
-        path = absolute(file_path)
+        template(absolute(file_path))[:slots]
+      end
+
+      #: (String) -> String
+      def version_for(file_path)
+        template(absolute(file_path))[:version]
+      end
+
+      private
+
+      #: (String, ?Array[String]?) -> Hash[Symbol, untyped]
+      def template(path, names = nil)
+        @templates[[path, names]] ||= build(path, names)
+      end
+
+      #: (String, Array[String]?) -> Hash[Symbol, untyped]
+      def build(path, names)
         source = File.read(path)
         analysis = @dependencies.analyze(path)
-        slots = slots_for(source, path)
-        reached = reached_paths(source, analysis)
-        settable = (analysis.instance_variables + analysis.locals_declared).to_set
+        visitor = visitor_for(source, path)
+        slots = visitor.slots
+        wanted = names || state_names(analysis)
+        reached = reached_paths(source, wanted)
+        settable = (analysis.instance_variables + analysis.locals_declared + (names || [])).to_set
 
         index = {} #: Hash[Integer, Hash[Symbol, untyped]]
 
@@ -53,10 +109,67 @@ module Herb
           index[slot.index] = { state: state, mode: mode_for(slot, state, expressions, settable) }
         end
 
-        index
+        { version: visitor.schema[:version], slots: index }
       end
 
-      private
+      #: (untyped, ?Array[Hash[Symbol, untyped]], ?per_item: bool) -> Array[Hash[Symbol, untyped]]
+      def reached_slots(flow, reached = [], per_item: false)
+        carried = flow.names.to_a.sort
+        compiled = template(flow.file, carried)
+
+        compiled[:slots].each do |index, info|
+          next unless info[:state].intersect?(carried)
+
+          reached << { file: flow.file, version: compiled[:version], index: index, mode: mode_within(info[:mode], per_item) }
+        end
+
+        flow.children.each { |child| reached_slots(child, reached, per_item: per_item || per_item?(flow, child)) }
+
+        reached
+      end
+
+      #: (Symbol, bool) -> Symbol
+      def mode_within(mode, per_item)
+        per_item && mode == :identity ? :derived : mode
+      end
+
+      #: (untyped, untyped) -> bool
+      def per_item?(parent, child)
+        name = File.basename(child.file).delete_prefix("_").split(".").first
+
+        @dependencies.analyze(parent.file).render_calls.any? { |call|
+          call[:collection] && call[:partial] && File.basename(call[:partial].to_s) == name
+        }
+      end
+
+      #: (String, Array[String], Hash[String, String]) -> Hash[String, String]
+      def request_names(entry_point, names, declared)
+        analysis = @dependencies.analyze(absolute(entry_point))
+        settable = (analysis.instance_variables + analysis.locals_declared).to_set
+        counts = Hash.new(0) #: Hash[String, Integer]
+        defaults = {} #: Hash[String, String]
+
+        names.each { |name|
+          counts[name.delete_prefix("@")] += 1 if settable.include?(name)
+          request_name = name.delete_prefix("@")
+
+          next unless settable.include?(name)
+          next unless counts[request_name] == 1
+
+          defaults[request_name] = name
+        }
+
+        defaults.reject { |_, name| declared.value?(name) }.merge(declared)
+      end
+
+      #: (String) -> String
+      def identifier_for(path)
+        relative = Pathname.new(path).relative_path_from(@project_path).to_s
+
+        relative.start_with?("..") ? path : relative
+      rescue ArgumentError
+        path
+      end
 
       #: (String) -> String
       def absolute(file_path)
@@ -65,22 +178,22 @@ module Herb
         @project_path.join(file_path).to_s
       end
 
-      #: (String, String) -> Array[untyped]
-      def slots_for(source, path)
+      #: (String, String) -> untyped
+      def visitor_for(source, path)
         visitor = Herb::Engine::SlotVisitor.new
 
         Herb::Engine.new(source, visitors: [visitor], filename: path)
 
-        visitor.slots
+        visitor
       end
 
-      #: (String, untyped) -> Hash[String, Hash[Array[Integer], Array[String?]]]
-      def reached_paths(source, analysis)
+      #: (String, Array[String]) -> Hash[String, Hash[Array[Integer], Array[String?]]]
+      def reached_paths(source, names)
         ast = ::Herb.parse(source, render_nodes: true, strict_locals: true, prism_nodes: true, track_whitespace: true).value
 
         reached = {} #: Hash[String, Hash[Array[Integer], Array[String?]]]
 
-        state_names(analysis).each do |name|
+        names.each do |name|
           nodes = @dependencies.nodes_in(ast, name, conditions_only: true)
 
           next if nodes.empty?

--- a/sig/herb/engine/slot_dependencies.rbs
+++ b/sig/herb/engine/slot_dependencies.rbs
@@ -20,6 +20,8 @@ module Herb
     # A conditional is reported against its own condition rather than everything inside it. What
     # the branches read belongs to the slots in them, which carry their own state.
     class SlotDependencies
+      ATTRIBUTE: String
+
       STRUCTURAL_TYPES: Array[Symbol]
 
       PARTIAL_TYPES: Array[Symbol]
@@ -27,19 +29,52 @@ module Herb
       # : (String | Pathname) -> void
       def initialize: (String | Pathname) -> void
 
+      # : (String) -> Hash[String, Array[Hash[Symbol, untyped]]]
+      def across: (String) -> Hash[String, Array[Hash[Symbol, untyped]]]
+
+      # : (String, ?params: Hash[String, String]) -> Hash[String, untyped]
+      def payload: (String, ?params: Hash[String, String]) -> Hash[String, untyped]
+
+      # : (String, ?params: Hash[String, String]) -> String
+      def element: (String, ?params: Hash[String, String]) -> String
+
       # : (String) -> Hash[Integer, Hash[Symbol, untyped]]
       def for: (String) -> Hash[Integer, Hash[Symbol, untyped]]
 
+      # : (String) -> String
+      def version_for: (String) -> String
+
       private
+
+      # : (String, ?Array[String]?) -> Hash[Symbol, untyped]
+      def template: (String, ?Array[String]?) -> Hash[Symbol, untyped]
+
+      # : (String, Array[String]?) -> Hash[Symbol, untyped]
+      def build: (String, Array[String]?) -> Hash[Symbol, untyped]
+
+      # : (untyped, ?Array[Hash[Symbol, untyped]], ?per_item: bool) -> Array[Hash[Symbol, untyped]]
+      def reached_slots: (untyped, ?Array[Hash[Symbol, untyped]], ?per_item: bool) -> Array[Hash[Symbol, untyped]]
+
+      # : (Symbol, bool) -> Symbol
+      def mode_within: (Symbol, bool) -> Symbol
+
+      # : (untyped, untyped) -> bool
+      def per_item?: (untyped, untyped) -> bool
+
+      # : (String, Array[String], Hash[String, String]) -> Hash[String, String]
+      def request_names: (String, Array[String], Hash[String, String]) -> Hash[String, String]
+
+      # : (String) -> String
+      def identifier_for: (String) -> String
 
       # : (String) -> String
       def absolute: (String) -> String
 
-      # : (String, String) -> Array[untyped]
-      def slots_for: (String, String) -> Array[untyped]
+      # : (String, String) -> untyped
+      def visitor_for: (String, String) -> untyped
 
-      # : (String, untyped) -> Hash[String, Hash[Array[Integer], Array[String?]]]
-      def reached_paths: (String, untyped) -> Hash[String, Hash[Array[Integer], Array[String?]]]
+      # : (String, Array[String]) -> Hash[String, Hash[Array[Integer], Array[String?]]]
+      def reached_paths: (String, Array[String]) -> Hash[String, Hash[Array[Integer], Array[String?]]]
 
       # : (untyped) -> Array[String]
       def state_names: (untyped) -> Array[String]

--- a/test/engine/slots/dependencies_test.rb
+++ b/test/engine/slots/dependencies_test.rb
@@ -28,6 +28,23 @@ module Engine
         Herb::Engine::SlotDependencies.new(@project_path).for(path)
       end
 
+      def write(name, template)
+        path = File.join(@view_root, name)
+
+        File.write(path, template)
+
+        path
+      end
+
+      def subject
+        Herb::Engine::SlotDependencies.new(@project_path)
+      end
+
+      def page_with_partial
+        write("_search.html.erb", %(<input value="<%= term %>"><p><%= term.upcase %></p>))
+        write("index.html.erb", %(<div><%= @query %></div><%= render "posts/search", term: @query %>))
+      end
+
       test "names the state a slot reads" do
         dependencies = dependencies_for("<div><%= @name %></div>")
 
@@ -105,6 +122,128 @@ module Engine
 
         assert_empty dependencies[0][:state]
         assert_equal :derived, dependencies[0][:mode]
+      end
+
+      test "follows state into a partial that was passed it under another name" do
+        entry = page_with_partial
+
+        reached = subject.across(entry)["@query"].map { |slot| [File.basename(slot[:file]), slot[:index], slot[:mode]] }
+
+        assert_includes reached, ["_search.html.erb", 0, :identity]
+        assert_includes reached, ["_search.html.erb", 1, :derived]
+      end
+
+      test "keys what it reaches by the name the page knows, not the partial's" do
+        entry = page_with_partial
+
+        across = subject.across(entry)
+
+        assert_includes across.keys, "@query"
+        refute_includes across.keys, "term"
+      end
+
+      test "gives every slot the version of the template it came from" do
+        entry = page_with_partial
+
+        versions = subject.across(entry)["@query"].group_by { |slot| File.basename(slot[:file]) }.transform_values { |slots| slots.map { |slot| slot[:version] }.uniq }
+
+        assert_equal 1, versions["index.html.erb"].size
+        assert_equal 1, versions["_search.html.erb"].size
+        refute_equal versions["index.html.erb"], versions["_search.html.erb"]
+      end
+
+      test "names a template the way the page does" do
+        entry = page_with_partial
+
+        files = subject.payload(entry)["state"]["@query"].map { |slot| slot["file"] }.uniq
+
+        assert_includes files, "app/views/posts/index.html.erb"
+        assert_includes files, "app/views/posts/_search.html.erb"
+      end
+
+      test "reports a mode as a string once it travels" do
+        entry = page_with_partial
+
+        modes = subject.payload(entry)["state"]["@query"].map { |slot| slot["mode"] }.uniq.sort
+
+        assert_equal ["derived", "identity"], modes
+      end
+
+      test "says what a request calls a template's state" do
+        entry = write("index.html.erb", %(<input value="<%= @query %>">))
+
+        assert_equal({ "query" => "@query" }, subject.payload(entry)["params"])
+      end
+
+      test "takes the name a caller declares for state a request spells differently" do
+        entry = write("index.html.erb", "<ul><% @posts.each do |post| %><li><%= post %></li><% end %></ul>")
+
+        params = subject.payload(entry, params: { "p" => "@posts" })["params"]
+
+        assert_equal({ "p" => "@posts" }, params)
+      end
+
+      test "leaves out state a request cannot set" do
+        entry = write("index.html.erb", "<div><%= Time.now %></div>")
+
+        assert_empty subject.payload(entry)["params"]
+      end
+
+      test "carries the declared names into the parked map" do
+        entry = write("index.html.erb", "<ul><% @posts.each do |post| %><li><%= post %></li><% end %></ul>")
+
+        element = subject.element(entry, params: { "p" => "@posts" })
+        json = element.sub(/\A<template data-herb-dependencies>/, "").sub(%r{</template>\z}, "")
+
+        assert_equal({ "p" => "@posts" }, JSON.parse(json)["params"])
+      end
+
+      test "parks the map the way statics are parked" do
+        entry = page_with_partial
+
+        element = subject.element(entry)
+
+        assert_match(/\A<template data-herb-dependencies>/, element)
+        assert_match(%r{</template>\z}, element)
+
+        json = element.sub(/\A<template data-herb-dependencies>/, "").sub(%r{</template>\z}, "")
+
+        assert_equal subject.payload(entry), JSON.parse(json)
+      end
+
+      test "leaves a collection's item template to the server" do
+        write("_card.html.erb", "<div><%= card %></div>")
+        entry = write("index.html.erb", %(<%= render partial: "posts/card", collection: @posts %>))
+
+        card = subject.across(entry)["@posts"].find { |slot| File.basename(slot[:file]) == "_card.html.erb" }
+
+        assert_equal :derived, card[:mode]
+      end
+
+      test "keeps writing a partial that was rendered once" do
+        write("_card.html.erb", "<div><%= card %></div>")
+        entry = write("index.html.erb", %(<%= render "posts/card", card: @post %>))
+
+        card = subject.across(entry)["@post"].find { |slot| File.basename(slot[:file]) == "_card.html.erb" }
+
+        assert_equal :identity, card[:mode]
+      end
+
+      test "leaves everything below a collection to the server" do
+        write("_name.html.erb", "<span><%= card %></span>")
+        write("_card.html.erb", %(<div><%= render "posts/name", card: card %></div>))
+        entry = write("index.html.erb", %(<%= render partial: "posts/card", collection: @posts %>))
+
+        modes = subject.across(entry)["@posts"].reject { |slot| File.basename(slot[:file]) == "index.html.erb" }.map { |slot| slot[:mode] }
+
+        refute_empty modes
+        assert_equal [:derived], modes.uniq
+      end
+
+      test "leaves a template that reaches nothing out of the map" do
+        entry = write("index.html.erb", "<div>static</div>")
+
+        assert_empty subject.across(entry)
       end
     end
   end


### PR DESCRIPTION
This pull request adds `SlotDependencies#across`, which reports every slot a page's state reaches, under the name the page knows that state by.

A slot map in one template's vocabulary cannot answer what a page changing `@query` should update, because the partial it renders knows that state as `term`. `trace_state` already renames state at each render call, so the walk follows it and the entry point's name is the one that comes back out.

```ruby
Herb::Engine::SlotDependencies.new(project_path).across("app/views/posts/index.html.erb")
#=> { "@query" => [
#      { file: ".../index.html.erb",   version: "f6775c02", index: 0, mode: :identity },
#      { file: ".../_search.html.erb", version: "edd6ae13", index: 0, mode: :identity },
#      { file: ".../_search.html.erb", version: "edd6ae13", index: 1, mode: :derived },
#    ] }
```

A partial's incoming locals are not among the names it declares unless it declares them, so the names to look for come from the trace and not from the file. Reading a partial in its caller's terms is what makes the same template answer differently for two callers, which is also why the result is computed per set of carried names instead of once per file.

Every slot carries the version of the template it came from, since a page is built from several and a partial's version moves without its caller's.

#### A collection's item template is left to the server

A page names its state once. A template rendered for each of a collection's items renders once per item, so that name says nothing about which of them is meant, and a client writing the slot from the page would put the same value into every one of them.

`render partial: "posts/card", collection: @posts` reported the item template's slots as an identity, which is the one reading that is unsafe. Crossing a collection now downgrades an identity to derived, for that template and everything it renders in turn.

Rendering a partial inside an `each` block is the other shape this takes and needs nothing here. The trace does not follow a block parameter across a render call, so the item template is never reached and its slots subscribe to nothing. That is a missing subscription and not a wrong write, and a slot nobody wrote asks the server like any other.

Matching a render call to the template it reached is by name, so two partials sharing one under different directories both count as a collection's. That errs towards the server, which is the direction that cannot be wrong.

#### Delivery

The map describes a render tree and not one rendering of one template, so it names the file and version of every slot it lists and travels once for the page, parked the way statics are:

```html
<template data-herb-dependencies>{"state":{"@query":[{"file":"app/views/posts/index.html.erb","version":"f6775c02","index":0,"mode":"identity"}]}}</template>
```
