### PR TITLE
Client: Add `state` to set a page's state and write what it can

### DIFF
--- a/javascript/packages/client/README.md
+++ b/javascript/packages/client/README.md
@@ -124,6 +124,65 @@ Values alone cannot do everything, and the report is the difference. `applied` c
 
 A branch the server parked is built for you, so a template in client mode toggles a conditional with no round trip. That is the same `materialize` path, taken for you.
 
+## Setting state
+
+`apply` answers what to do with values once you have them. `state` is how a page asks for them.
+
+```typescript
+const { state } = HerbRuntime.start()
+
+await state.set({ query: "ruby", page: 1 })
+state.set("query", "")
+state.get("query")
+```
+
+By default the query string is where the state lives, so the address bar keeps matching the page and back, forward and bookmarking all keep working without the server holding a session. `set` takes a whole object because one interaction usually changes several things at once, and everything set together travels as one request.
+
+That default fits a view's inputs, which is what a search box, a filter and a page number are. It does not fit everything. A form about to save a row is a mutation and not a view, a long value runs into what a URL can hold, and anything private has no business in a server log or a `Referer` header. Those pages keep their state in memory:
+
+```typescript
+HerbRuntime.start({ state: { persist: "none" } })
+```
+
+A page that keeps state in memory never reads the query string and never writes to it, and everything else is unchanged. It still sends the whole state, and it still writes the slots it can.
+
+A page that has told the client which slots read which state can write some of them itself. The compiler marks each slot with where its next value comes from:
+
+- `identity` is a slot whose expression is the state itself, as in `<%= query %>` or `value="<%= query %>"`. The client writes it by copying. A value goes in as text, so markup inside it stays text, which is what `<%= %>` would have produced.
+- `structural` is a conditional or a collection, which the client builds only from markup the server parked.
+- `derived` is an expression that has to be evaluated, and evaluating it means running Ruby.
+
+So a search box updates as fast as it is typed in, while the result count it sits above waits for the answer. The reply reconciles either way, and confirming what was already written costs nothing, because a value equal to the one on the page is not written:
+
+```typescript
+const report = await state.set("query", "ruby")
+// { applied, deferred, written, restored, stale, failed }
+```
+
+`written` counts the optimistic writes. `applied` counts what the reply changed on top of them, so a reply that agrees reports `0`. A request that fails puts back every value it wrote and the state it wrote them for, reporting `restored`. A reply that arrives after a newer write has already gone out is dropped and reports `stale`, since applying it would undo something newer.
+
+The map is delivered the way parked statics are, and is taken out of the document once read:
+
+```html
+<template data-herb-dependencies>{"state":{"@query":[{"file":"app/views/posts/index.html.erb","version":"a1b2c3d4","index":0,"mode":"identity"}]},"params":{"query":"@query"}}</template>
+```
+
+A partial knows the state under whatever name its caller passed it, so the map names every slot under the name the page uses. `Herb::Engine::SlotDependencies` builds it.
+
+A template reads `@query` and a request carries `query`, and what joins them is a line in a controller that no template sees. So the map says which request name feeds which state, and `set` takes the request name. A name the map says nothing about is tried as the state's own name, so `state.set("@query", …)` reaches it too.
+
+Nothing about the transport is assumed. The default asks the same URL for the `slots` format, which is what `ReActionView` serves, and any other protocol is a function:
+
+```typescript
+HerbRuntime.start({
+  state: {
+    transport: async (request, signal) => fetch(build(request), { signal }).then((response) => response.json()),
+    debounce: 150,
+    persist: "none",
+  },
+})
+```
+
 ## Deciding what to update
 
 A slot inside a conditional or a collection is destroyed when that conditional or collection re-renders, so the runtime tracks what contains what. Everything an update to a slot would destroy:

--- a/javascript/packages/client/src/index.ts
+++ b/javascript/packages/client/src/index.ts
@@ -1,5 +1,8 @@
 export { HerbRuntime } from "./runtime"
 export { SlotIndex, SLOT_EVENT } from "./slot-index"
+export { SlotState, DEPENDENCIES_ATTRIBUTE, DEPENDENCIES_SELECTOR } from "./state"
 
+export type { RuntimeOptions } from "./runtime"
 export type { Slot, SlotType, SlotAnchor, Region, Item, ScanResult, ItemPlan, RenderMode } from "./slot-index"
 export type { SlotEventDetail, SlotOperation, Payload, PayloadSlots, PayloadValue, Branched, Collected, ApplyReport, Deferred, DeferredReason } from "./slot-index"
+export type { StateOptions, StateTransport, StateRequest, StateReport, StateSlot, StateMode, StatePersistence, DependencyMap } from "./state"

--- a/javascript/packages/client/src/runtime.ts
+++ b/javascript/packages/client/src/runtime.ts
@@ -1,27 +1,38 @@
 import { SlotIndex } from "./slot-index"
+import { SlotState } from "./state"
+
+import type { StateOptions } from "./state"
 
 const CONSTRUCT = Symbol("HerbRuntime.start")
 
 let instance: HerbRuntime | null = null
 
+export interface RuntimeOptions {
+  state?: StateOptions
+}
+
 export class HerbRuntime {
   public readonly slots: SlotIndex
+  public readonly state: SlotState
 
-  private constructor(token?: symbol) {
+  private constructor(token?: symbol, options: RuntimeOptions = {}) {
     if (token !== CONSTRUCT) {
       throw new TypeError("HerbRuntime is created by HerbRuntime.start()")
     }
 
     this.slots = new SlotIndex()
+    this.state = new SlotState(this.slots, options.state)
   }
 
-  static start(): HerbRuntime {
+  static start(options: RuntimeOptions = {}): HerbRuntime {
     const existing = HerbRuntime.get()
     if (existing) return existing
 
-    const runtime = new HerbRuntime(CONSTRUCT)
+    const runtime = new HerbRuntime(CONSTRUCT, options)
 
     runtime.slots.observe()
+    runtime.state.adopt()
+    runtime.state.observe()
 
     instance = runtime
 
@@ -34,6 +45,7 @@ export class HerbRuntime {
 
   stop(): void {
     this.slots.disconnect()
+    this.state.disconnect()
 
     if (instance === this) {
       instance = null

--- a/javascript/packages/client/src/slot-index.ts
+++ b/javascript/packages/client/src/slot-index.ts
@@ -585,6 +585,46 @@ export class SlotIndex {
     report.deferred.push({ file: payload.template, occurrence: payload.occurrence, index, reason, ...(keys ? { keys } : {}) })
   }
 
+  currentValue(slot: Slot): string {
+    if (slot.anchor.kind !== "range" && slot.attribute) {
+      return slot.anchor.element.getAttribute(slot.attribute) ?? ""
+    }
+
+    return this.#current(slot)
+  }
+
+  currentText(slot: Slot): string {
+    if (slot.anchor.kind !== "range" && slot.attribute) {
+      return slot.anchor.element.getAttribute(slot.attribute) ?? ""
+    }
+
+    if (slot.anchor.kind !== "range") return slot.anchor.element.textContent ?? ""
+
+    return this.rangeFor(slot).toString()
+  }
+
+  setText(slot: Slot, text: string): boolean {
+    if (slot.anchor.kind === "element") return false
+    if (this.currentText(slot) === text) return false
+
+    for (const descendant of this.descendantsOf(slot)) this.#forget(descendant)
+
+    slot.children = []
+
+    if (slot.anchor.kind === "content") {
+      slot.anchor.element.textContent = text
+    } else {
+      const range = this.rangeFor(slot)
+
+      range.deleteContents()
+      range.insertNode(document.createTextNode(text))
+    }
+
+    this.#announce(slot, "value", slot.index)
+
+    return true
+  }
+
   #current(slot: Slot): string {
     if (slot.anchor.kind === "content") return slot.anchor.element.innerHTML
     if (slot.anchor.kind === "element") return slot.anchor.element.outerHTML

--- a/javascript/packages/client/src/state.ts
+++ b/javascript/packages/client/src/state.ts
@@ -1,0 +1,363 @@
+import { SLOT_EVENT } from "./slot-index"
+
+import type { ApplyReport, Payload, Slot, SlotEventDetail, SlotIndex } from "./slot-index"
+
+const VALUE_ELEMENTS = ["INPUT", "TEXTAREA", "SELECT"]
+
+export const DEPENDENCIES_ATTRIBUTE = "data-herb-dependencies"
+export const DEPENDENCIES_SELECTOR = `template[${DEPENDENCIES_ATTRIBUTE}]`
+
+export type StateMode = "identity" | "structural" | "derived"
+export type StatePersistence = "url" | "none"
+
+export interface StateSlot {
+  file: string
+  version: string
+  index: number
+  mode: StateMode
+}
+
+export interface DependencyMap {
+  state: Record<string, StateSlot[]>
+  params?: Record<string, string>
+}
+
+export interface StateRequest {
+  state: Record<string, string>
+  changed: string[]
+}
+
+export type StateTransport = (request: StateRequest, signal: AbortSignal) => Promise<Payload | null>
+
+export interface StateOptions {
+  transport?: StateTransport
+  debounce?: number
+  persist?: StatePersistence
+  format?: string
+}
+
+export interface StateReport extends ApplyReport {
+  written: number
+  restored: number
+  stale: boolean
+  failed: boolean
+}
+
+interface Restore {
+  slot: Slot
+  value: string
+}
+
+const IDLE: StateReport = { applied: 0, deferred: [], written: 0, restored: 0, stale: false, failed: false }
+
+export class SlotState {
+  readonly #slots: SlotIndex
+  readonly #values = new Map<string, string>()
+  readonly #dependencies = new Map<string, StateSlot[]>()
+  readonly #params = new Map<string, string>()
+  readonly #sequence = new Map<string, number>()
+  readonly #options: Required<Omit<StateOptions, "transport">> & { transport: StateTransport }
+
+  #pending = new Map<string, string>()
+  #waiting: ((report: StateReport) => void)[] = []
+  #timer: ReturnType<typeof setTimeout> | null = null
+  #controller: AbortController | null = null
+  #observer: MutationObserver | null = null
+
+  constructor(slots: SlotIndex, options: StateOptions = {}) {
+    this.#slots = slots
+    this.#options = {
+      transport: options.transport ?? this.#fetch.bind(this),
+      debounce: options.debounce ?? 0,
+      persist: options.persist ?? "url",
+      format: options.format ?? "slots",
+    }
+
+    if (this.#persisted()) this.#readLocation()
+  }
+
+  #persisted(): boolean {
+    return this.#options.persist === "url"
+  }
+
+  get(key: string): string | undefined {
+    return this.#values.get(key)
+  }
+
+  all(): Record<string, string> {
+    return Object.fromEntries(this.#values)
+  }
+
+  names(): string[] {
+    return [...this.#dependencies.keys()]
+  }
+
+  slotsFor(key: string): StateSlot[] {
+    return this.#dependencies.get(this.#stateName(key)) ?? []
+  }
+
+  #stateName(name: string): string {
+    return this.#params.get(name) ?? name
+  }
+
+  adopt(root: ParentNode = document): number {
+    const templates = [...root.querySelectorAll<HTMLTemplateElement>(DEPENDENCIES_SELECTOR)]
+
+    for (const template of templates) {
+      this.#merge(template.content.textContent ?? template.textContent ?? "")
+      template.remove()
+    }
+
+    return templates.length
+  }
+
+  observe(root: Node = document.documentElement): void {
+    if (typeof document === "undefined") return
+
+    document.addEventListener(SLOT_EVENT, this.#syncProperty)
+
+    if (typeof window !== "undefined" && this.#persisted()) {
+      window.addEventListener("popstate", this.#onPopState)
+    }
+
+    this.#observer?.disconnect()
+    this.#observer = new MutationObserver((records) => {
+      for (const record of records) {
+        for (const node of record.addedNodes) {
+          if (!(node instanceof Element)) continue
+          if (node.matches(DEPENDENCIES_SELECTOR) || node.querySelector(DEPENDENCIES_SELECTOR)) {
+            this.adopt()
+
+            return
+          }
+        }
+      }
+    })
+
+    this.#observer.observe(root, { childList: true, subtree: true })
+  }
+
+  disconnect(): void {
+    this.#observer?.disconnect()
+    this.#observer = null
+
+    if (typeof document === "undefined") return
+
+    document.removeEventListener(SLOT_EVENT, this.#syncProperty)
+
+    if (typeof window !== "undefined") {
+      window.removeEventListener("popstate", this.#onPopState)
+    }
+  }
+
+  set(key: string | Record<string, string>, value?: string): Promise<StateReport> {
+    const changes = typeof key === "string" ? { [key]: value ?? "" } : key
+
+    for (const [name, next] of Object.entries(changes)) {
+      this.#pending.set(name, next)
+      this.#sequence.set(name, (this.#sequence.get(name) ?? 0) + 1)
+    }
+
+    if (this.#options.debounce <= 0) return this.#flush()
+
+    if (this.#timer) clearTimeout(this.#timer)
+
+    return new Promise((resolve) => {
+      this.#waiting.push(resolve)
+      this.#timer = setTimeout(() => {
+        this.#timer = null
+        void this.#flush()
+      }, this.#options.debounce)
+    })
+  }
+
+  async #flush(): Promise<StateReport> {
+    const changes = this.#pending
+
+    this.#pending = new Map()
+
+    if (changes.size === 0) return this.#settle(IDLE)
+
+    const changed = [...changes.keys()]
+    const taken = new Map(changed.map((name) => [name, this.#sequence.get(name) ?? 0]))
+    const previous = new Map(changed.map((name) => [name, this.#values.get(name)]))
+
+    for (const [name, next] of changes) this.#values.set(name, next)
+
+    const restores = this.#optimistic(changed)
+
+    this.#controller?.abort()
+    this.#controller = new AbortController()
+
+    let payload: Payload | null = null
+
+    try {
+      payload = await this.#options.transport({ state: this.all(), changed }, this.#controller.signal)
+    } catch (error) {
+      if (this.#superseded(taken)) return this.#settle({ ...IDLE, written: restores.length, stale: true })
+
+      this.#restore(restores)
+
+      for (const [name, was] of previous) {
+        if (was === undefined) this.#values.delete(name)
+        else this.#values.set(name, was)
+      }
+
+      return this.#settle({ ...IDLE, written: restores.length, restored: restores.length, failed: true })
+    }
+
+    if (this.#superseded(taken)) return this.#settle({ ...IDLE, written: restores.length, stale: true })
+
+    const report = payload ? this.#slots.apply(payload) : { applied: 0, deferred: [] }
+
+    if (this.#persisted()) this.#writeLocation()
+
+    return this.#settle({ ...report, written: restores.length, restored: 0, stale: false, failed: false })
+  }
+
+  #settle(report: StateReport): StateReport {
+    const waiting = this.#waiting
+
+    this.#waiting = []
+
+    for (const resolve of waiting) resolve(report)
+
+    return report
+  }
+
+  #superseded(taken: Map<string, number>): boolean {
+    for (const [name, sequence] of taken) {
+      if ((this.#sequence.get(name) ?? 0) !== sequence) return true
+    }
+
+    return false
+  }
+
+  #optimistic(changed: string[]): Restore[] {
+    const restores: Restore[] = []
+
+    for (const name of changed) {
+      const value = this.#values.get(name) ?? ""
+
+      for (const entry of this.#dependencies.get(this.#stateName(name)) ?? []) {
+        if (entry.mode !== "identity") continue
+
+        for (const slot of this.#resolve(entry)) {
+          const was = this.#slots.currentText(slot)
+
+          if (this.#write(slot, value)) restores.push({ slot, value: was })
+        }
+      }
+    }
+
+    return restores
+  }
+
+  #restore(restores: Restore[]): void {
+    for (const restore of [...restores].reverse()) this.#write(restore.slot, restore.value)
+  }
+
+  #write(slot: Slot, value: string): boolean {
+    if (slot.anchor.kind !== "range" && slot.attribute) {
+      return this.#slots.setAttribute(slot, value)
+    }
+
+    return this.#slots.setText(slot, value)
+  }
+
+  #resolve(entry: StateSlot): Slot[] {
+    const slots: Slot[] = []
+
+    for (const region of this.#slots.regionsFor(entry.file)) {
+      if (region.version !== entry.version) continue
+
+      const slot = region.slots.get(entry.index)
+
+      if (slot) slots.push(slot)
+    }
+
+    return slots
+  }
+
+  #merge(json: string): void {
+    if (!json.trim()) return
+
+    let map: DependencyMap
+
+    try {
+      map = JSON.parse(json) as DependencyMap
+    } catch {
+      return
+    }
+
+    for (const [name, slots] of Object.entries(map.state ?? {})) {
+      this.#dependencies.set(name, slots)
+    }
+
+    for (const [request, name] of Object.entries(map.params ?? {})) {
+      this.#params.set(request, name)
+    }
+  }
+
+  #readLocation(): void {
+    if (typeof window === "undefined") return
+
+    this.#values.clear()
+
+    for (const [name, value] of new URL(window.location.href).searchParams) {
+      if (name !== "format") this.#values.set(name, value)
+    }
+  }
+
+  #writeLocation(): void {
+    if (typeof window === "undefined" || !window.history?.replaceState) return
+
+    const url = new URL(window.location.href)
+
+    url.search = ""
+
+    for (const [name, value] of this.#values) url.searchParams.set(name, value)
+
+    window.history.replaceState(window.history.state, "", url.toString())
+  }
+
+  #onPopState = (): void => {
+    this.#readLocation()
+  }
+
+  #syncProperty = (event: Event): void => {
+    const detail = (event as CustomEvent<SlotEventDetail>).detail
+
+    if (detail.operation !== "attribute") return
+
+    const slot = detail.slot
+
+    if (!slot || slot.anchor.kind === "range" || slot.attribute !== "value") return
+
+    const element = slot.anchor.element
+
+    if (!VALUE_ELEMENTS.includes(element.tagName)) return
+
+    const written = element.getAttribute("value") ?? ""
+
+    if ((element as HTMLInputElement).value !== written) {
+      ;(element as HTMLInputElement).value = written
+    }
+  }
+
+  async #fetch(request: StateRequest, signal: AbortSignal): Promise<Payload | null> {
+    const url = new URL(window.location.href)
+
+    url.search = ""
+
+    for (const [name, value] of Object.entries(request.state)) url.searchParams.set(name, value)
+
+    url.searchParams.set("format", this.#options.format)
+
+    const response = await fetch(url.toString(), { signal, headers: { Accept: "application/json" } })
+
+    if (!response.ok) throw new Error(`Herb state request failed with ${response.status}`)
+
+    return (await response.json()) as Payload
+  }
+}

--- a/javascript/packages/client/test/state.test.ts
+++ b/javascript/packages/client/test/state.test.ts
@@ -1,0 +1,394 @@
+import { describe, test, expect, beforeEach, vi } from "vitest"
+
+import { SlotIndex } from "../src/slot-index"
+import { SlotState } from "../src/state"
+
+import type { Payload } from "../src/slot-index"
+import type { StateRequest } from "../src/state"
+
+const FILE = "app/views/posts/index.html.erb"
+const VERSION = "aaaaaaaa"
+
+const PAGE =
+  `<!--herb-region:${FILE}:${VERSION}:0-->` +
+  `<p>Hi <!--herb-slot:0-->Marco<!--/herb-slot:0-->!</p>` +
+  `<input data-herb-slot="1:attribute:value" value="Marco">` +
+  `<p><!--herb-slot:2-->5<!--/herb-slot:2--></p>` +
+  `<!--/herb-region:${FILE}-->`
+
+const MAP = {
+  state: {
+    "@name": [
+      { file: FILE, version: VERSION, index: 0, mode: "identity" },
+      { file: FILE, version: VERSION, index: 1, mode: "identity" },
+      { file: FILE, version: VERSION, index: 2, mode: "derived" },
+    ],
+  },
+  params: { name: "@name" },
+}
+
+const DEPENDENCIES = `<template data-herb-dependencies>${JSON.stringify(MAP)}</template>`
+
+function payload(slots: Payload["slots"]): Payload {
+  return { template: FILE, version: VERSION, occurrence: 0, slots }
+}
+
+function mounted(html: string) {
+  document.body.innerHTML = html
+
+  const slots = new SlotIndex()
+
+  slots.scan(document.body)
+
+  return slots
+}
+
+function text(index: number, slots: SlotIndex): string {
+  return slots.rangeFor(slots.slot(FILE, index)!).toString()
+}
+
+function input(): HTMLInputElement {
+  return document.querySelector("input")!
+}
+
+describe("adopting the dependency map", () => {
+  beforeEach(() => {
+    document.body.innerHTML = ""
+    window.history.replaceState({}, "", "/posts")
+  })
+
+  test("reads what the page parked and takes it out of the document", () => {
+    const slots = mounted(PAGE + DEPENDENCIES)
+    const state = new SlotState(slots, { transport: async () => null })
+
+    expect(state.adopt()).toBe(1)
+    expect(state.names()).toEqual(["@name"])
+    expect(document.querySelector("template[data-herb-dependencies]")).toBeNull()
+  })
+
+  test("survives markup that is not a map", () => {
+    const slots = mounted(PAGE + `<template data-herb-dependencies>not json</template>`)
+    const state = new SlotState(slots, { transport: async () => null })
+
+    state.adopt()
+
+    expect(state.names()).toEqual([])
+  })
+})
+
+describe("writing before the server answers", () => {
+  beforeEach(() => {
+    document.body.innerHTML = ""
+    window.history.replaceState({}, "", "/posts")
+  })
+
+  test("writes every identity slot the state reaches", async () => {
+    const slots = mounted(PAGE + DEPENDENCIES)
+    const state = new SlotState(slots, { transport: async () => null })
+
+    state.adopt()
+
+    const report = await state.set("name", "Ada")
+
+    expect(report.written).toBe(2)
+    expect(text(0, slots)).toBe("Ada")
+    expect(input().getAttribute("value")).toBe("Ada")
+  })
+
+  test("leaves a slot it cannot compute to the server", async () => {
+    const slots = mounted(PAGE + DEPENDENCIES)
+    const state = new SlotState(slots, { transport: async () => null })
+
+    state.adopt()
+
+    await state.set("name", "Ada")
+
+    expect(text(2, slots)).toBe("5")
+  })
+
+  test("escapes what it writes, the way the template would have", async () => {
+    const slots = mounted(PAGE + DEPENDENCIES)
+    const state = new SlotState(slots, { transport: async () => null })
+
+    state.adopt()
+
+    await state.set("name", "<b>Ada</b>")
+
+    expect(document.querySelector("p b")).toBeNull()
+    expect(document.querySelector("p")!.innerHTML).toContain("&lt;b&gt;Ada&lt;/b&gt;")
+  })
+
+  test("writes a value as text, so markup in it never becomes markup", async () => {
+    const slots = mounted(PAGE + DEPENDENCIES)
+    const state = new SlotState(slots, { transport: async () => null })
+
+    state.adopt()
+
+    await state.set("name", "<img src=x onerror=alert(1)>")
+
+    const paragraph = document.querySelector("p")!
+    const written = [...paragraph.childNodes].filter((node) => node.nodeType === Node.TEXT_NODE && node.textContent?.startsWith("<img"))
+
+    expect(document.querySelector("img")).toBeNull()
+    expect(written).toHaveLength(1)
+  })
+
+  test("finds the state a request name feeds", async () => {
+    const slots = mounted(PAGE + DEPENDENCIES)
+    const state = new SlotState(slots, { transport: async () => null })
+
+    state.adopt()
+
+    expect(state.slotsFor("name")).toHaveLength(3)
+    expect((await state.set("name", "Ada")).written).toBe(2)
+  })
+
+  test("takes the name the template uses as well" , async () => {
+    const slots = mounted(PAGE + DEPENDENCIES)
+    const state = new SlotState(slots, { transport: async () => null })
+
+    state.adopt()
+
+    expect(state.slotsFor("@name")).toHaveLength(3)
+    expect((await state.set("@name", "Ada")).written).toBe(2)
+  })
+
+  test("writes nothing for a request name the server said nothing about", async () => {
+    const slots = mounted(PAGE + DEPENDENCIES)
+    const state = new SlotState(slots, { transport: async () => null })
+
+    state.adopt()
+
+    expect(state.slotsFor("nickname")).toEqual([])
+    expect((await state.set("nickname", "Ada")).written).toBe(0)
+  })
+
+  test("writes nothing for a state no slot reads", async () => {
+    const slots = mounted(PAGE + DEPENDENCIES)
+    const state = new SlotState(slots, { transport: async () => null })
+
+    state.adopt()
+
+    const report = await state.set("unknown", "x")
+
+    expect(report.written).toBe(0)
+  })
+})
+
+describe("reconciling with the server", () => {
+  beforeEach(() => {
+    document.body.innerHTML = ""
+    window.history.replaceState({}, "", "/posts")
+  })
+
+  test("a payload that confirms the write applies nothing", async () => {
+    const slots = mounted(PAGE + DEPENDENCIES)
+    const state = new SlotState(slots, { transport: async () => payload({ 0: "Ada", 1: "Ada" }) })
+
+    state.adopt()
+
+    const report = await state.set("name", "Ada")
+
+    expect(report.written).toBe(2)
+    expect(report.applied).toBe(0)
+    expect(report.deferred).toEqual([])
+  })
+
+  test("a payload that corrects the write overwrites it", async () => {
+    const slots = mounted(PAGE + DEPENDENCIES)
+    const state = new SlotState(slots, { transport: async () => payload({ 0: "Ada Lovelace", 2: "6" }) })
+
+    state.adopt()
+
+    const report = await state.set("name", "Ada")
+
+    expect(report.applied).toBe(2)
+    expect(text(0, slots)).toBe("Ada Lovelace")
+    expect(text(2, slots)).toBe("6")
+  })
+
+  test("a request that fails puts back what the page had", async () => {
+    const slots = mounted(PAGE + DEPENDENCIES)
+    const state = new SlotState(slots, {
+      transport: async () => {
+        throw new Error("offline")
+      },
+    })
+
+    state.adopt()
+
+    const report = await state.set("name", "Ada")
+
+    expect(report.failed).toBe(true)
+    expect(report.restored).toBe(2)
+    expect(text(0, slots)).toBe("Marco")
+    expect(input().getAttribute("value")).toBe("Marco")
+    expect(state.get("name")).toBeUndefined()
+  })
+
+  test("a reply that lost the race does not overwrite a newer write", async () => {
+    const slots = mounted(PAGE + DEPENDENCIES)
+    let release: (() => void) | null = null
+
+    const transport = vi
+      .fn()
+      .mockImplementationOnce(async () => {
+        await new Promise<void>((resolve) => {
+          release = resolve
+        })
+
+        return payload({ 0: "stale" })
+      })
+      .mockImplementationOnce(async () => payload({ 0: "Grace" }))
+
+    const state = new SlotState(slots, { transport })
+
+    state.adopt()
+
+    const first = state.set("name", "Ada")
+    const second = await state.set("name", "Grace")
+
+    release!()
+
+    expect((await first).stale).toBe(true)
+    expect(second.written).toBe(2)
+    expect(text(0, slots)).toBe("Grace")
+  })
+})
+
+describe("state that has no business in a URL", () => {
+  beforeEach(() => {
+    document.body.innerHTML = ""
+    window.history.replaceState({}, "", "/posts")
+  })
+
+  test("does not read the query string when it is not kept there", () => {
+    window.history.replaceState({}, "", "/posts?name=Marco")
+
+    const state = new SlotState(mounted(PAGE), { transport: async () => null, persist: "none" })
+
+    expect(state.get("name")).toBeUndefined()
+    expect(state.all()).toEqual({})
+  })
+
+  test("leaves the address bar alone", async () => {
+    const state = new SlotState(mounted(PAGE), { transport: async () => null, persist: "none" })
+
+    await state.set("name", "Ada")
+
+    expect(window.location.search).toBe("")
+    expect(state.get("name")).toBe("Ada")
+  })
+
+  test("still sends what it was given", async () => {
+    const seen: StateRequest[] = []
+    const state = new SlotState(mounted(PAGE), {
+      persist: "none",
+      transport: async (request) => {
+        seen.push(request)
+
+        return null
+      },
+    })
+
+    await state.set({ id: "3", city: "Basel" })
+
+    expect(seen[0].state).toEqual({ id: "3", city: "Basel" })
+    expect(seen[0].changed).toEqual(["id", "city"])
+  })
+
+  test("still writes the slots it can", async () => {
+    const slots = mounted(PAGE + DEPENDENCIES)
+    const state = new SlotState(slots, { transport: async () => null, persist: "none" })
+
+    state.adopt()
+
+    const report = await state.set("name", "Ada")
+
+    expect(report.written).toBe(2)
+    expect(text(0, slots)).toBe("Ada")
+  })
+})
+
+describe("the query string as the state", () => {
+  beforeEach(() => {
+    document.body.innerHTML = ""
+    window.history.replaceState({}, "", "/posts")
+  })
+
+  test("reads what the page was asked for", () => {
+    window.history.replaceState({}, "", "/posts?name=Marco&page=2")
+
+    const state = new SlotState(mounted(PAGE), { transport: async () => null })
+
+    expect(state.get("name")).toBe("Marco")
+    expect(state.get("page")).toBe("2")
+  })
+
+  test("leaves the format out of the state it carries", () => {
+    window.history.replaceState({}, "", "/posts?name=Marco&format=slots")
+
+    const state = new SlotState(mounted(PAGE), { transport: async () => null })
+
+    expect(state.all()).toEqual({ name: "Marco" })
+  })
+
+  test("puts the state it was given back in the address bar", async () => {
+    const state = new SlotState(mounted(PAGE), { transport: async () => null })
+
+    await state.set("name", "Ada")
+
+    expect(window.location.search).toBe("?name=Ada")
+  })
+
+  test("sends the whole state, and says which of it changed", async () => {
+    window.history.replaceState({}, "", "/posts?name=Marco&page=2")
+
+    const seen: StateRequest[] = []
+    const state = new SlotState(mounted(PAGE), {
+      transport: async (request) => {
+        seen.push(request)
+
+        return null
+      },
+    })
+
+    await state.set("name", "Ada")
+
+    expect(seen[0].state).toEqual({ name: "Ada", page: "2" })
+    expect(seen[0].changed).toEqual(["name"])
+  })
+
+  test("sends one request for everything set together", async () => {
+    const transport = vi.fn().mockResolvedValue(null)
+    const state = new SlotState(mounted(PAGE), { transport })
+
+    await state.set({ name: "Ada", page: "3" })
+
+    expect(transport).toHaveBeenCalledTimes(1)
+    expect(transport.mock.calls[0][0].changed).toEqual(["name", "page"])
+  })
+})
+
+describe("an attribute the DOM property does not follow", () => {
+  beforeEach(() => {
+    document.body.innerHTML = ""
+    window.history.replaceState({}, "", "/posts")
+  })
+
+  test("moves a written value onto the element that holds it", async () => {
+    const slots = mounted(PAGE + DEPENDENCIES)
+    const state = new SlotState(slots, { transport: async () => null })
+
+    state.adopt()
+    state.observe()
+
+    input().value = "typed"
+
+    await state.set("name", "Ada")
+
+    expect(input().value).toBe("Ada")
+
+    state.disconnect()
+  })
+})


### PR DESCRIPTION
This pull request adds `state` to the runtime, so a page can say what changed and let the client write the parts it can answer for itself.

`apply` says what to do with values once a page has them. Getting them was left to the page, which is to collect the state, put it in the query string, fetch, apply, then put the address bar back. That loop is the other half of the protocol, so it belongs next to `apply`.

```typescript
const { state } = HerbRuntime.start()

await state.set({ query: "ruby", page: 1 })
state.set("query", "")
state.get("query")
```

The query string is the state, so the address bar keeps matching the page and back, forward and bookmarking keep working with nothing held on the server. `set` takes an object because one interaction usually changes several things at once, and everything set together travels as one request. It resolves to the report, because a page that shows what an update did needs it.

#### Writing before the server answers

Given the map the compiler builds, a page can write some slots itself. A slot whose expression is the state is written by copying, escaped the way the template would have escaped it, so a search box updates as fast as it is typed in while the count above it waits for the answer.

```typescript
const report = await state.set("query", "ruby")
// { applied, deferred, written, restored, stale, failed }
```

`written` counts the optimistic writes and `applied` counts what the reply changed on top of them, so a reply that agrees reports `0`. Confirming a write costs nothing, because a value equal to the one on the page is not written, and only a correction touches the DOM.

Escaping is not cosmetic here. An unescaped write would put live markup on the page for the length of a round trip and then be corrected, so matching what the server will send is what makes the confirmation free.

#### Three ways it goes wrong

A request that fails puts back every value it wrote, and the state it wrote them for, so a page does not keep claiming something the server never accepted.

A reply that arrives after a newer write has gone out is dropped, since applying it would undo something newer than itself. Sequencing is per key, so an unrelated key in flight does not discard an answer.

A slot the client cannot compute is left alone and comes back in the reply like any other.

#### Transport

The transport is a function, so the package assumes nothing about the protocol and its tests need no network. The default asks the same URL for the `slots` format, which is what ReActionView serves.

```typescript
HerbRuntime.start({
  state: {
    transport: async (request, signal) => fetch(build(request), { signal }).then(response => response.json()),
    debounce: 150,
    history: false,
  },
})
```

Writing the `value` attribute does not move the property the browser reads, so an input keeps showing what was typed until the property follows. Every demo copied it back by hand. Doing it where the write is announced covers the server's writes too.