### PR TITLE
Engine: Introduce `SlotSubtree` to render the markup a slot covers


### DIFF
--- a/lib/herb/engine/slot_dependencies.rb
+++ b/lib/herb/engine/slot_dependencies.rb
@@ -57,6 +57,13 @@ module Herb
         index
       end
 
+      #: (String, Array[String]) -> Array[Hash[Symbol, untyped]]
+      def subtree_slots(entry_point, changed)
+        reached = across(entry_point).filter_map { |name, slots| slots if changed.include?(name) }
+
+        reached.flatten.select { |slot| slot[:mode] == :structural }.uniq { |slot| [slot[:file], slot[:index]] }
+      end
+
       #: (String, ?params: Hash[String, String]) -> Hash[String, untyped]
       def payload(entry_point, params: {})
         state = across(entry_point).transform_values { |slots|

--- a/lib/herb/engine/slot_subtree.rb
+++ b/lib/herb/engine/slot_subtree.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+# typed: false
+
+require_relative "../../herb"
+require_relative "../engine"
+require_relative "slot_visitor"
+require_relative "subtree_compiler"
+
+module Herb
+  class Engine
+    # Compiles the markup behind one slot, for the cases a client cannot answer for itself.
+    #
+    #     subtree = Herb::Engine::SlotSubtree.new(source, filename: "app/views/posts/index.html.erb")
+    #     view.instance_eval(subtree.source_for(0))
+    #     #=> "<li>one</li><li>two</li>"
+    #
+    # Values carry a page most of the way. What they cannot carry is markup the page never had:
+    # a conditional taking a branch that did not render, or a collection gaining its first item.
+    # Both come back from `SlotIndex#apply` as a deferred entry naming the slot, and this is what
+    # answers one.
+    #
+    # A slot is addressed by its index, which is what the payload and the deferred entry both use.
+    # `SlotVisitor` records the `node_path` of each slot and `SubtreeCompiler` renders the node at
+    # a path, so the index is resolved through the schema.
+    #
+    # An attribute is not addressable. A path indexes an element's body and does not descend into
+    # its open tag, so the path of an attribute slot names the element holding it, and compiling
+    # that would return the whole element where the caller asked for one attribute. Those slots
+    # are values, and values is how they come back.
+    class SlotSubtree
+      ATTRIBUTE_TYPES = [:attribute, :attribute_interpolation, :boolean_attribute].freeze #: Array[Symbol]
+
+      attr_reader :slots, :version #: Array[untyped]
+
+      #: (String, ?filename: String?) -> void
+      def initialize(source, filename: nil)
+        @source = source
+        @filename = filename
+
+        visitor = Herb::Engine::SlotVisitor.new
+
+        Herb::Engine.new(source, visitors: [visitor], filename: filename)
+
+        @slots = visitor.slots
+        @version = visitor.schema[:version]
+      end #: String
+
+      #: (Integer) -> Array[Integer]?
+      def node_path_for(index)
+        slot_for(index)&.node_path
+      end
+
+      #: (Integer) -> bool
+      def addressable?(index)
+        slot = slot_for(index)
+
+        return false unless slot
+
+        !ATTRIBUTE_TYPES.include?(slot.type)
+      end
+
+      #: (Integer) -> String?
+      def source_for(index)
+        return nil unless addressable?(index)
+
+        path = node_path_for(index)
+
+        return nil unless path
+
+        Herb::Engine::SubtreeCompiler.new(@source, node_path: path, filename: @filename).src
+      end
+
+      private
+
+      #: (Integer) -> untyped
+      def slot_for(index)
+        @slots.find { |slot| slot.index == index }
+      end
+    end
+  end
+end

--- a/sig/herb/engine/slot_dependencies.rbs
+++ b/sig/herb/engine/slot_dependencies.rbs
@@ -32,6 +32,9 @@ module Herb
       # : (String) -> Hash[String, Array[Hash[Symbol, untyped]]]
       def across: (String) -> Hash[String, Array[Hash[Symbol, untyped]]]
 
+      # : (String, Array[String]) -> Array[Hash[Symbol, untyped]]
+      def subtree_slots: (String, Array[String]) -> Array[Hash[Symbol, untyped]]
+
       # : (String, ?params: Hash[String, String]) -> Hash[String, untyped]
       def payload: (String, ?params: Hash[String, String]) -> Hash[String, untyped]
 

--- a/sig/herb/engine/slot_subtree.rbs
+++ b/sig/herb/engine/slot_subtree.rbs
@@ -1,0 +1,49 @@
+# Generated from lib/herb/engine/slot_subtree.rb with RBS::Inline
+
+module Herb
+  class Engine
+    # Compiles the markup behind one slot, for the cases a client cannot answer for itself.
+    #
+    #     subtree = Herb::Engine::SlotSubtree.new(source, filename: "app/views/posts/index.html.erb")
+    #     view.instance_eval(subtree.source_for(0))
+    #     #=> "<li>one</li><li>two</li>"
+    #
+    # Values carry a page most of the way. What they cannot carry is markup the page never had:
+    # a conditional taking a branch that did not render, or a collection gaining its first item.
+    # Both come back from `SlotIndex#apply` as a deferred entry naming the slot, and this is what
+    # answers one.
+    #
+    # A slot is addressed by its index, which is what the payload and the deferred entry both use.
+    # `SlotVisitor` records the `node_path` of each slot and `SubtreeCompiler` renders the node at
+    # a path, so the index is resolved through the schema.
+    #
+    # An attribute is not addressable. A path indexes an element's body and does not descend into
+    # its open tag, so the path of an attribute slot names the element holding it, and compiling
+    # that would return the whole element where the caller asked for one attribute. Those slots
+    # are values, and values is how they come back.
+    class SlotSubtree
+      ATTRIBUTE_TYPES: Array[Symbol]
+
+      attr_reader slots: Array[untyped]
+
+      attr_reader version: Array[untyped]
+
+      # : (String, ?filename: String?) -> void
+      def initialize: (String, ?filename: String?) -> void
+
+      # : (Integer) -> Array[Integer]?
+      def node_path_for: (Integer) -> Array[Integer]?
+
+      # : (Integer) -> bool
+      def addressable?: (Integer) -> bool
+
+      # : (Integer) -> String?
+      def source_for: (Integer) -> String?
+
+      private
+
+      # : (Integer) -> untyped
+      def slot_for: (Integer) -> untyped
+    end
+  end
+end

--- a/test/engine/slots/dependencies_test.rb
+++ b/test/engine/slots/dependencies_test.rb
@@ -240,6 +240,32 @@ module Engine
         assert_equal [:derived], modes.uniq
       end
 
+      test "asks for markup only where values cannot answer" do
+        entry = write("index.html.erb", "<div><% if @admin %><b><%= @name %></b><% end %></div>")
+
+        assert_equal([0], subject.subtree_slots(entry, ["@admin"]).map { |slot| slot[:index] })
+      end
+
+      test "leaves a value change to the values" do
+        entry = write("index.html.erb", "<div><% if @admin %><b><%= @name %></b><% end %></div>")
+
+        assert_empty subject.subtree_slots(entry, ["@name"])
+      end
+
+      test "asks for a collection that changed" do
+        entry = write("index.html.erb", "<ul><% @items.each do |item| %><li><%= item %></li><% end %></ul>")
+
+        slots = subject.subtree_slots(entry, ["@items"])
+
+        assert_equal [:structural], slots.map { |slot| slot[:mode] }.uniq
+      end
+
+      test "says nothing about state the page does not read" do
+        entry = write("index.html.erb", "<div><% if @admin %><b>x</b><% end %></div>")
+
+        assert_empty subject.subtree_slots(entry, ["@nothing"])
+      end
+
       test "leaves a template that reaches nothing out of the map" do
         entry = write("index.html.erb", "<div>static</div>")
 

--- a/test/engine/slots/subtree_test.rb
+++ b/test/engine/slots/subtree_test.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require_relative "../../test_helper"
+require_relative "../../../lib/herb/engine/slot_subtree"
+
+module Engine
+  module Slots
+    class SubtreeTest < Minitest::Spec
+      class View
+        def initialize(**assigns)
+          assigns.each { |name, value| instance_variable_set(:"@#{name}", value) }
+        end
+      end
+
+      CONDITIONAL = "<div><% if @admin %><b>yes</b><% else %><i>no</i><% end %></div>"
+      COLLECTION = "<ul><% @items.each do |item| %><li><%= item %></li><% end %></ul>"
+
+      def subtree(source)
+        Herb::Engine::SlotSubtree.new(source, filename: "app/views/posts/index.html.erb")
+      end
+
+      def render(source, index, **assigns)
+        View.new(**assigns).instance_eval(subtree(source).source_for(index))
+      end
+
+      test "renders the branch the page is showing" do
+        assert_equal "<i>no</i>", render(CONDITIONAL, 0, admin: false)
+      end
+
+      test "renders a branch the page never had" do
+        assert_equal "<b>yes</b>", render(CONDITIONAL, 0, admin: true)
+      end
+
+      test "renders every item a collection has" do
+        assert_equal "<li>a</li><li>b</li>", render(COLLECTION, 0, items: ["a", "b"])
+      end
+
+      test "renders the first item a collection has ever had" do
+        assert_equal "<li>only</li>", render(COLLECTION, 0, items: ["only"])
+      end
+
+      test "renders nothing for a collection that lost every item" do
+        assert_equal "", render(COLLECTION, 0, items: [])
+      end
+
+      test "refuses an attribute, which the path cannot name on its own" do
+        source = %(<div class="<%= @klass %>">x</div>)
+
+        refute subtree(source).addressable?(0)
+        assert_nil subtree(source).source_for(0)
+      end
+
+      test "refuses a slot the template does not have" do
+        assert_nil subtree(CONDITIONAL).source_for(99)
+        refute subtree(CONDITIONAL).addressable?(99)
+      end
+
+      test "names each slot by the path the visitor recorded" do
+        visitor = Herb::Engine::SlotVisitor.new
+
+        Herb::Engine.new(COLLECTION, visitors: [visitor], filename: "app/views/posts/index.html.erb")
+
+        subject = subtree(COLLECTION)
+
+        visitor.slots.each do |slot|
+          assert_equal slot.node_path, subject.node_path_for(slot.index)
+        end
+      end
+
+      test "carries the version the markers were written with" do
+        visitor = Herb::Engine::SlotVisitor.new
+
+        Herb::Engine.new(COLLECTION, visitors: [visitor], filename: "app/views/posts/index.html.erb")
+
+        assert_equal visitor.schema[:version], subtree(COLLECTION).version
+      end
+    end
+  end
+end


### PR DESCRIPTION
This pull request introduces `Herb::Engine::SlotSubtree`, which compiles the markup behind one slot, for the two cases a payload of values cannot carry.

`SlotIndex#apply` reports a deferred entry when the page is asked for something values cannot express, which is a conditional taking a branch that never rendered, and a collection gaining an item there is no row to copy. Both name a slot, and nothing on the server answered one.

```ruby
subtree = Herb::Engine::SlotSubtree.new(source, filename: "app/views/posts/index.html.erb")

view.instance_eval(subtree.source_for(0))
#=> "<li>one</li><li>two</li>"
```

`SubtreeCompiler` renders the node at a `node_path` and `SlotVisitor` records the `node_path` of every slot, so a slot index is all that is needed to reach its markup. The two agreeing on what a `node_path` means is what makes this a lookup.

#### An attribute is refused

A path indexes an element's body and does not descend into its open tag, so an attribute slot's path names the element holding it. Compiling that would hand back `<div class="card">x</div>` where the caller asked for `card`. Those slots are values, and values is how they come back.

#### Asking for only what changed

`subtree_slots` says which slots a change needs markup for, so a request naming what changed can be answered without asking the page.

```ruby
dependencies.subtree_slots("app/views/posts/index.html.erb", ["@admin"])
#=> [{ file: ".../index.html.erb", version: "a1b2c3d4", index: 0, mode: :structural }]
```

Only structural slots appear, because that is the whole of what values cannot say. Changing something a branch merely displays asks for nothing.

#### What this does not do

It does not make the render cheaper. `SubtreeCompiler` runs the whole template and keeps one node's output, which its own documentation says is the answer that is correct without knowing which expressions the target depends on:

> Pruning the work that only fed discarded output is a separate question, and answering it needs to know which expressions the target actually depends on. Running everything is the answer that is correct without that analysis.

That analysis now exists, so the question can be asked. It is not asked here, because answering it means changing what the compiler emits and taking on the side effects that come with skipping work.
