### PR TITLE
Analysis: Follow state through a block parameter

### DIFF
--- a/javascript/packages/analysis/src/dependency-index.ts
+++ b/javascript/packages/analysis/src/dependency-index.ts
@@ -1,5 +1,5 @@
 import { collectTemplateDependencies } from "./template-dependencies"
-import { isERBBlockNode, isERBCaseNode, isERBContentNode, isERBIfNode, isERBRenderNode, isERBUnlessNode, isHTMLAttributeNode, isHTMLElementNode, isLiteralNode } from "@herb-tools/core"
+import { isERBBlockNode, isERBCaseNode, isERBContentNode, isERBIfNode, isERBRenderNode, isERBUnlessNode, isHTMLAttributeNode, isHTMLElementNode, isLiteralNode, isRubyParameterNode } from "@herb-tools/core"
 
 const PARSER_OPTIONS = { render_nodes: true, strict_locals: true, prism_nodes: true, prism_program: true, track_whitespace: true }
 
@@ -32,6 +32,35 @@ export function referencesState(code: string | undefined, state: string): boolea
 
 function escapeForPattern(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+}
+
+function referencesAny(code: string | undefined, aliases: string[]): boolean {
+  return aliases.some(alias => referencesState(code, alias))
+}
+
+function blockBindings(node: Node, aliases: string[]): string[] {
+  if (!isERBBlockNode(node)) return []
+  if (!referencesAny(expressionOf(node), aliases)) return []
+
+  const names: string[] = []
+
+  const walk = (candidate: Node) => {
+    if (isRubyParameterNode(candidate)) {
+      const name = candidate.name?.value?.trim()
+
+      if (name && !names.includes(name)) names.push(name)
+    }
+
+    for (const child of candidate.childNodes()) {
+      if (child) walk(child)
+    }
+  }
+
+  for (const argument of node.block_arguments) {
+    if (argument) walk(argument)
+  }
+
+  return names.filter(name => !aliases.includes(name))
 }
 
 function childrenOf(node: Node): Node[] {
@@ -94,13 +123,15 @@ export function affectedNodes(backend: HerbBackend, source: string, state: strin
     })
   }
 
+  const aliases = [state]
+
   const inspectAttribute = (node: HTMLAttributeNode) => {
     const attribute = attributeNameOf(node)
 
     for (const value of node.value?.children ?? []) {
       const expression = expressionOf(value)
 
-      if (!referencesState(expression, state)) continue
+      if (!referencesAny(expression, aliases)) continue
 
       affected.push({
         nodePath: [...path],
@@ -122,22 +153,28 @@ export function affectedNodes(backend: HerbBackend, source: string, state: strin
     for (const attribute of attributesOf(node)) inspectAttribute(attribute)
 
     if (isERBIfNode(node) || isERBUnlessNode(node) || isERBCaseNode(node)) {
-      if (expressionsWithin(node).some(code => referencesState(code, state))) {
+      if (expressionsWithin(node).some(code => referencesAny(code, aliases))) {
         record(node, "conditional", expressionOf(node))
       }
-    } else if (isERBContentNode(node) && referencesState(expressionOf(node), state)) {
+    } else if (isERBContentNode(node) && referencesAny(expressionOf(node), aliases)) {
       record(node, "text_content", expressionOf(node))
-    } else if (isERBRenderNode(node) && referencesState(expressionOf(node), state)) {
+    } else if (isERBRenderNode(node) && referencesAny(expressionOf(node), aliases)) {
       record(node, "render", expressionOf(node))
-    } else if (isERBBlockNode(node) && referencesState(expressionOf(node), state)) {
+    } else if (isERBBlockNode(node) && referencesAny(expressionOf(node), aliases)) {
       record(node, "expression", expressionOf(node))
     }
+
+    const bound = blockBindings(node, aliases)
+
+    aliases.push(...bound)
 
     for (const [index, child] of childrenOf(node).entries()) {
       path.push(index)
       walk(child)
       path.pop()
     }
+
+    for (const name of bound) aliases.splice(aliases.indexOf(name), 1)
   }
 
   for (const [index, child] of childrenOf(document).entries()) {

--- a/javascript/packages/analysis/test/dependency-index.test.ts
+++ b/javascript/packages/analysis/test/dependency-index.test.ts
@@ -15,6 +15,43 @@ describe("dependencyIndex", () => {
     return dependencyIndex(Herb, FILE, source)
   }
 
+  test("follows state through a block parameter", () => {
+    const nodes = affectedNodes(Herb, `<ul><% @items.each do |item| %><li><%= item.name %></li><% end %></ul>`, "@items")
+
+    expect(nodes.map(node => node.expression)).toContain("item.name")
+  })
+
+  test("follows state through every parameter a block binds", () => {
+    const nodes = affectedNodes(Herb, `<ul><% @rows.each_with_index do |row, i| %><li><%= i %>: <%= row.title %></li><% end %></ul>`, "@rows")
+    const expressions = nodes.map(node => node.expression)
+
+    expect(expressions).toContain("row.title")
+    expect(expressions).toContain("i")
+  })
+
+  test("leaves an expression a block parameter does not reach", () => {
+    const nodes = affectedNodes(Herb, `<div><% @items.each do |item| %><%= other %><% end %></div>`, "@items")
+
+    expect(nodes.map(node => node.expression)).not.toContain("other")
+  })
+
+  test("stops a block parameter at the end of its block", () => {
+    const nodes = affectedNodes(Herb, `<div><% @items.each do |item| %><%= item.name %><% end %><%= item %></div>`, "@items")
+    const expressions = nodes.map(node => node.expression)
+
+    expect(expressions.filter(code => code === "item.name")).toHaveLength(1)
+    expect(expressions.filter(code => code === "item")).toHaveLength(0)
+  })
+
+  test("reports what the Ruby collector reports", () => {
+    const nodes = affectedNodes(Herb, `<ul><% @items.each do |item| %><li><%= item.name %></li><% end %></ul>`, "@items")
+
+    expect(nodes.map(node => [node.kind, node.nodePath, node.expression])).toEqual([
+      ["expression", [0, 0], "@items.each do |item|"],
+      ["text_content", [0, 0, 0, 0], "item.name"],
+    ])
+  })
+
   test("does not confuse a state name with a longer one", () => {
     const nodes = affectedNodes(Herb, `<div><%= @post.title %></div><div><%= @posts.count %></div>`, "@post")
 

--- a/lib/herb/analysis/template_dependencies.rb
+++ b/lib/herb/analysis/template_dependencies.rb
@@ -35,7 +35,7 @@ module Herb
         file_path = @project_path.join(file_path).to_s unless Pathname.new(file_path).absolute?
         source = File.read(file_path)
 
-        ast = ::Herb.parse(source, render_nodes: true, strict_locals: true, prism_nodes: true, prism_program: true, track_whitespace: true).value
+        ast = ::Herb.parse(source, render_nodes: true, strict_locals: true, prism_nodes: true, prism_program: true, track_whitespace: true, iteration_nodes: true).value
 
         known_helpers = @custom_helpers.dup
         component_methods_for(file_path).each { |m| known_helpers.add(m) }
@@ -404,8 +404,12 @@ module Herb
           result.render_calls.each do |call|
             flowing_locals = {} #: Hash[String, String]
 
+            iterated = iterated_names(call, carrying)
+
             call[:locals].each do |local_name, value_expr|
-              flowing_locals[local_name] = value_expr if carrying.any? { |name| expression_references?(value_expr, name) }
+              next flowing_locals[local_name] = value_expr if carrying.any? { |name| expression_references?(value_expr, name) }
+
+              flowing_locals[local_name] = value_expr if iterated.any? { |name| expression_references?(value_expr, name) }
             end
 
             collection_flows = call[:collection] && carrying.any? { |name| expression_references?(call[:collection], name) }
@@ -498,6 +502,17 @@ module Herb
 
       def partial_index
         @partial_index ||= PartialIndex.build(@project_path)
+      end
+
+      def iterated_names(call, carrying)
+        blocks = call[:within] || [] #: Array[Hash[Symbol, untyped]]
+
+        blocks.flat_map { |enclosing|
+          next [] unless enclosing[:iterating]
+          next [] unless carrying.any? { |name| expression_references?(enclosing[:expression].to_s, name) }
+
+          enclosing[:parameters] || []
+        }
       end
 
       def expression_references?(expression, name)

--- a/lib/herb/analysis/template_dependencies/dependency_collector.rb
+++ b/lib/herb/analysis/template_dependencies/dependency_collector.rb
@@ -22,6 +22,15 @@ module Herb
           @unknown_calls = Set.new
           @known_locals = prescanned_locals.dup
           @render_calls = [] #: Array[Hash[Symbol, untyped]]
+          @blocks = [] #: Array[Hash[Symbol, untyped]]
+        end
+
+        def visit_erb_iteration_block_node(node)
+          within_block(node, iterating: true) { super }
+        end
+
+        def visit_erb_block_node(node)
+          within_block(node, iterating: false) { super }
         end
 
         def visit_erb_node(node)
@@ -51,7 +60,8 @@ module Herb
               partial: node.partial_path,
               locals: locals,
               collection: node.keywords&.collection&.value,
-              as_name: node.keywords&.as_name&.value&.strip&.delete_prefix(":")&.delete_prefix('"')&.delete_suffix('"')
+              as_name: node.keywords&.as_name&.value&.strip&.delete_prefix(":")&.delete_prefix('"')&.delete_suffix('"'),
+              within: @blocks.map(&:dup)
             }
           end
 
@@ -83,6 +93,36 @@ module Herb
           end
         rescue StandardError
           nil
+        end
+
+        #: (untyped, iterating: bool) { () -> void } -> void
+        def within_block(node, iterating:)
+          expression = node.content&.value&.strip
+
+          @blocks.push({ expression: expression, parameters: block_parameters(expression), iterating: iterating })
+
+          yield
+        ensure
+          @blocks.pop
+        end
+
+        def block_parameters(code)
+          return [] unless code
+
+          result = Prism.parse("#{code}\nend")
+
+          return [] if result.errors.any?
+
+          names = [] #: Array[String]
+          collect_parameters(result.value, names)
+
+          names
+        end
+
+        def collect_parameters(node, names)
+          names << node.name.to_s if node.is_a?(Prism::RequiredParameterNode) || node.is_a?(Prism::BlockParameterNode)
+
+          node.child_nodes.compact.each { |child| collect_parameters(child, names) }
         end
 
         def analyze_ruby_expression(code)

--- a/lib/herb/engine/slot_dependencies.rb
+++ b/lib/herb/engine/slot_dependencies.rb
@@ -145,7 +145,11 @@ module Herb
         name = File.basename(child.file).delete_prefix("_").split(".").first
 
         @dependencies.analyze(parent.file).render_calls.any? { |call|
-          call[:collection] && call[:partial] && File.basename(call[:partial].to_s) == name
+          next false unless call[:partial] && File.basename(call[:partial].to_s) == name
+
+          blocks = call[:within] || [] #: Array[Hash[Symbol, untyped]]
+
+          !!call[:collection] || blocks.any? { |enclosing| enclosing[:iterating] }
         }
       end
 

--- a/rust/herb-analysis/src/state_flow.rs
+++ b/rust/herb-analysis/src/state_flow.rs
@@ -100,9 +100,11 @@ impl StateFlow {
     let mut affected = Vec::new();
     let mut path = Vec::new();
 
+    let mut aliases = vec![state.to_string()];
+
     for (index, child) in result.value.children.iter().enumerate() {
       path.push(index);
-      collect_affected(child, state, &mut path, &mut affected);
+      collect_affected(child, &mut aliases, &mut path, &mut affected);
       path.pop();
     }
 
@@ -293,20 +295,22 @@ fn is_word_byte(byte: u8) -> bool {
   byte.is_ascii_alphanumeric() || byte == b'_'
 }
 
-fn collect_affected(node: &AnyNode, state: &str, path: &mut Vec<usize>, affected: &mut Vec<AffectedNode>) {
+fn collect_affected(node: &AnyNode, aliases: &mut Vec<String>, path: &mut Vec<usize>, affected: &mut Vec<AffectedNode>) {
   let kind = match node {
     AnyNode::ERBContentNode(_) => Some("text_content"),
     AnyNode::ERBIfNode(_) => Some("conditional"),
     AnyNode::ERBUnlessNode(_) => Some("conditional"),
     AnyNode::ERBCaseNode(_) => Some("conditional"),
     AnyNode::ERBRenderNode(_) => Some("render"),
+    AnyNode::ERBBlockNode(_) => Some("expression"),
+    AnyNode::ERBIterationBlockNode(_) => Some("expression"),
     _ => None,
   };
 
   if let Some(kind) = kind {
-    let expressions = collect_expressions(node);
+    let expressions = if is_block(node) { own_expression(node) } else { collect_expressions(node) };
 
-    if expressions.iter().any(|code| references_state(code, state)) {
+    if expressions.iter().any(|code| references_any(code, aliases)) {
       let location = node.location();
 
       affected.push(AffectedNode {
@@ -319,17 +323,76 @@ fn collect_affected(node: &AnyNode, state: &str, path: &mut Vec<usize>, affected
   }
 
   if let AnyNode::HTMLElementNode(element) = node {
-    collect_attributes(element, state, path, affected);
+    collect_attributes(element, aliases, path, affected);
   }
+
+  let bound = block_bindings(node, aliases);
+
+  aliases.extend(bound.iter().cloned());
 
   for (index, child) in any_children(node).into_iter().enumerate() {
     path.push(index);
-    collect_affected(child, state, path, affected);
+    collect_affected(child, aliases, path, affected);
     path.pop();
+  }
+
+  aliases.retain(|name| !bound.contains(name));
+}
+
+fn is_block(node: &AnyNode) -> bool {
+  matches!(node, AnyNode::ERBBlockNode(_) | AnyNode::ERBIterationBlockNode(_))
+}
+
+fn own_expression(node: &AnyNode) -> Vec<String> {
+  content_of(node)
+    .map(|content| content.trim().to_string())
+    .filter(|content| !content.is_empty())
+    .into_iter()
+    .collect()
+}
+
+fn block_bindings(node: &AnyNode, aliases: &[String]) -> Vec<String> {
+  let arguments = match node {
+    AnyNode::ERBBlockNode(inner) => &inner.block_arguments,
+    AnyNode::ERBIterationBlockNode(inner) => &inner.block_arguments,
+    _ => return Vec::new(),
+  };
+
+  if !own_expression(node).iter().any(|code| references_any(code, aliases)) {
+    return Vec::new();
+  }
+
+  let mut names = Vec::new();
+
+  for argument in arguments {
+    collect_parameter_names(argument, &mut names);
+  }
+
+  names.retain(|name| !aliases.contains(name));
+  names
+}
+
+fn collect_parameter_names(node: &AnyNode, names: &mut Vec<String>) {
+  if let AnyNode::RubyParameterNode(inner) = node {
+    if let Some(token) = inner.name.as_ref() {
+      let name = token.value.trim().to_string();
+
+      if !name.is_empty() && !names.contains(&name) {
+        names.push(name);
+      }
+    }
+  }
+
+  for child in any_children(node) {
+    collect_parameter_names(child, names);
   }
 }
 
-fn collect_attributes(element: &herb::nodes::HTMLElementNode, state: &str, path: &[usize], affected: &mut Vec<AffectedNode>) {
+fn references_any(code: &str, aliases: &[String]) -> bool {
+  aliases.iter().any(|name| expression_references(code, name))
+}
+
+fn collect_attributes(element: &herb::nodes::HTMLElementNode, aliases: &[String], path: &[usize], affected: &mut Vec<AffectedNode>) {
   let Some(open_tag) = element.open_tag.as_ref() else {
     return;
   };
@@ -355,7 +418,7 @@ fn collect_attributes(element: &herb::nodes::HTMLElementNode, state: &str, path:
 
       let trimmed = code.trim();
 
-      if trimmed.is_empty() || !references_state(trimmed, state) {
+      if trimmed.is_empty() || !references_any(trimmed, aliases) {
         continue;
       }
 
@@ -410,12 +473,10 @@ fn content_of(node: &AnyNode) -> Option<String> {
     AnyNode::ERBUnlessNode(inner) => inner.content.as_ref().map(|token| token.value.clone()),
     AnyNode::ERBCaseNode(inner) => inner.content.as_ref().map(|token| token.value.clone()),
     AnyNode::ERBRenderNode(inner) => inner.content.as_ref().map(|token| token.value.clone()),
+    AnyNode::ERBBlockNode(inner) => inner.content.as_ref().map(|token| token.value.clone()),
+    AnyNode::ERBIterationBlockNode(inner) => inner.content.as_ref().map(|token| token.value.clone()),
     _ => None,
   }
-}
-
-fn references_state(code: &str, state: &str) -> bool {
-  expression_references(code, state)
 }
 
 fn component_methods_for(template: &str) -> std::collections::BTreeSet<String> {

--- a/rust/herb-analysis/tests/state_flow_test.rs
+++ b/rust/herb-analysis/tests/state_flow_test.rs
@@ -241,3 +241,110 @@ fn does_not_confuse_a_state_name_with_a_longer_one() {
 
   assert_eq!(expressions, vec!["@post.title".to_string()]);
 }
+
+#[test]
+fn follows_state_through_a_block_parameter() {
+  let project = Project::new("alias_param");
+  let entry = project.write(
+    "app/views/posts/index.html.erb",
+    "<ul><% @items.each do |item| %><li><%= item.name %></li><% end %></ul>",
+  );
+
+  let expressions: Vec<String> = project
+    .flow()
+    .affected_nodes(&entry, "@items")
+    .into_iter()
+    .filter_map(|node| node.expression)
+    .collect();
+
+  assert!(expressions.iter().any(|code| code == "item.name"), "got {expressions:?}");
+}
+
+#[test]
+fn follows_state_through_every_parameter_a_block_binds() {
+  let project = Project::new("alias_params");
+  let entry = project.write(
+    "app/views/posts/index.html.erb",
+    "<ul><% @rows.each_with_index do |row, i| %><li><%= i %>: <%= row.title %></li><% end %></ul>",
+  );
+
+  let expressions: Vec<String> = project
+    .flow()
+    .affected_nodes(&entry, "@rows")
+    .into_iter()
+    .filter_map(|node| node.expression)
+    .collect();
+
+  assert!(expressions.iter().any(|code| code == "row.title"), "got {expressions:?}");
+  assert!(expressions.iter().any(|code| code == "i"), "got {expressions:?}");
+}
+
+#[test]
+fn leaves_an_expression_a_block_parameter_does_not_reach() {
+  let project = Project::new("alias_unrelated");
+  let entry = project.write("app/views/posts/index.html.erb", "<div><% @items.each do |item| %><%= other %><% end %></div>");
+
+  let expressions: Vec<String> = project
+    .flow()
+    .affected_nodes(&entry, "@items")
+    .into_iter()
+    .filter_map(|node| node.expression)
+    .collect();
+
+  assert!(!expressions.iter().any(|code| code == "other"), "got {expressions:?}");
+}
+
+#[test]
+fn stops_a_block_parameter_at_the_end_of_its_block() {
+  let project = Project::new("alias_scope");
+  let entry = project.write(
+    "app/views/posts/index.html.erb",
+    "<div><% @items.each do |item| %><%= item.name %><% end %><%= item %></div>",
+  );
+
+  let expressions: Vec<String> = project
+    .flow()
+    .affected_nodes(&entry, "@items")
+    .into_iter()
+    .filter_map(|node| node.expression)
+    .collect();
+
+  assert_eq!(1, expressions.iter().filter(|code| *code == "item.name").count(), "got {expressions:?}");
+  assert_eq!(0, expressions.iter().filter(|code| *code == "item").count(), "got {expressions:?}");
+}
+
+#[test]
+fn records_a_block_the_way_ruby_does() {
+  let project = Project::new("alias_block");
+  let entry = project.write("app/views/posts/index.html.erb", "<ul><% @items.each do |item| %><li>x</li><% end %></ul>");
+
+  let nodes = project.flow().affected_nodes(&entry, "@items");
+  let block = nodes.iter().find(|node| node.kind == "expression");
+
+  assert!(block.is_some(), "got {nodes:?}");
+  assert_eq!(vec![0, 0], block.unwrap().node_path);
+}
+
+#[test]
+fn reports_what_the_ruby_collector_reports() {
+  let project = Project::new("alias_parity");
+  let entry = project.write(
+    "app/views/posts/index.html.erb",
+    "<ul><% @items.each do |item| %><li><%= item.name %></li><% end %></ul>",
+  );
+
+  let reported: Vec<(String, Vec<usize>, Option<String>)> = project
+    .flow()
+    .affected_nodes(&entry, "@items")
+    .into_iter()
+    .map(|node| (node.kind, node.node_path, node.expression))
+    .collect();
+
+  assert_eq!(
+    vec![
+      ("expression".to_string(), vec![0, 0], Some("@items.each do |item|".to_string())),
+      ("text_content".to_string(), vec![0, 0, 0, 0], Some("item.name".to_string())),
+    ],
+    reported
+  );
+}

--- a/sig/herb/analysis/template_dependencies.rbs
+++ b/sig/herb/analysis/template_dependencies.rbs
@@ -109,6 +109,8 @@ module Herb
 
       def partial_index: () -> untyped
 
+      def iterated_names: (untyped call, untyped carrying) -> untyped
+
       def expression_references?: (untyped expression, untyped name) -> untyped
 
       def extract_helper_methods: (untyped file) -> untyped

--- a/sig/herb/analysis/template_dependencies/dependency_collector.rbs
+++ b/sig/herb/analysis/template_dependencies/dependency_collector.rbs
@@ -20,6 +20,10 @@ module Herb
 
         def initialize: (untyped helper_registry, untyped custom_helpers, ?untyped prescanned_locals) -> untyped
 
+        def visit_erb_iteration_block_node: (untyped node) -> untyped
+
+        def visit_erb_block_node: (untyped node) -> untyped
+
         def visit_erb_node: (untyped node) -> untyped
 
         def visit_erb_render_node: (untyped node) -> untyped
@@ -29,6 +33,13 @@ module Herb
         private
 
         def analyze_erb_node: (untyped erb_node) -> untyped
+
+        # : (untyped, iterating: bool) { () -> void } -> void
+        def within_block: (untyped, iterating: bool) { () -> void } -> void
+
+        def block_parameters: (untyped code) -> untyped
+
+        def collect_parameters: (untyped node, untyped names) -> untyped
 
         def analyze_ruby_expression: (untyped code) -> untyped
 

--- a/sig/herb_c_extension.rbs
+++ b/sig/herb_c_extension.rbs
@@ -2,7 +2,7 @@
 # This file is manually maintained - not generated
 
 module Herb
-  def self.parse: (String input, ?track_whitespace: bool, ?track_locations: bool, ?analyze: bool, ?strict: bool, ?action_view_helpers: bool, ?transform_conditionals: bool, ?dot_notation_tags: bool, ?render_nodes: bool, ?strict_locals: bool, ?prism_nodes: bool, ?prism_nodes_deep: bool, ?prism_program: bool, ?html: bool, ?arena_stats: bool) -> ParseResult
+  def self.parse: (String input, ?track_whitespace: bool, ?track_locations: bool, ?analyze: bool, ?strict: bool, ?action_view_helpers: bool, ?transform_conditionals: bool, ?dot_notation_tags: bool, ?render_nodes: bool, ?strict_locals: bool, ?iteration_nodes: bool, ?prism_nodes: bool, ?prism_nodes_deep: bool, ?prism_program: bool, ?html: bool, ?arena_stats: bool) -> ParseResult
   def self.lex: (String input, ?arena_stats: bool) -> LexResult
   def self.extract_ruby: (String source, ?semicolons: bool, ?comments: bool, ?preserve_positions: bool) -> String
   def self.extract_html: (String source) -> String

--- a/test/analysis/template_dependencies_test.rb
+++ b/test/analysis/template_dependencies_test.rb
@@ -423,6 +423,44 @@ class TemplateDependenciesTest < Minitest::Spec
     assert_equal "class", attr_node[:attribute]
   end
 
+  test "traces state into a partial rendered inside an each block" do
+    write_template("posts/_card.html.erb", "<div><%= card.title %></div>")
+    entry = write_template("posts/index.html.erb", %(<% @posts.each do |post| %><%= render "posts/card", card: post %><% end %>))
+
+    affected = analyzer.affected_templates(entry, "@posts")
+
+    assert_includes affected, File.join(@view_root, "posts/_card.html.erb")
+  end
+
+  test "names the local an each block's partial received the state as" do
+    write_template("posts/_card.html.erb", "<div><%= card.title %></div>")
+    entry = write_template("posts/index.html.erb", %(<% @posts.each do |post| %><%= render "posts/card", card: post %><% end %>))
+
+    flow = analyzer.state_flow(entry, "@posts")
+    child = flow.children.find { |node| File.basename(node.file) == "_card.html.erb" }
+
+    assert child
+    assert_includes child.names.to_a, "card"
+  end
+
+  test "does not trace a block parameter used after its block closed" do
+    write_template("posts/_card.html.erb", "<div><%= card.title %></div>")
+    entry = write_template("posts/index.html.erb", %(<% @posts.each do |post| %><% end %><%= render "posts/card", card: post %>))
+
+    affected = analyzer.affected_templates(entry, "@posts")
+
+    refute_includes affected, File.join(@view_root, "posts/_card.html.erb")
+  end
+
+  test "does not trace state through a block that runs once" do
+    write_template("posts/_field.html.erb", "<div><%= card %></div>")
+    entry = write_template("posts/index.html.erb", %(<% form_with model: @post do |f| %><%= render "posts/field", card: f %><% end %>))
+
+    affected = analyzer.affected_templates(entry, "@post")
+
+    refute_includes affected, File.join(@view_root, "posts/_field.html.erb")
+  end
+
   test "affected_nodes follows state through a block parameter" do
     path = write_template("posts/index.html.erb", "<ul><% @items.each do |item| %><li><%= item.name %></li><% end %></ul>")
 

--- a/test/engine/slots/dependencies_test.rb
+++ b/test/engine/slots/dependencies_test.rb
@@ -211,6 +211,44 @@ module Engine
         assert_equal subject.payload(entry), JSON.parse(json)
       end
 
+      test "follows state into a partial rendered inside an each block" do
+        write("_card.html.erb", "<div><%= card.title %></div>")
+        entry = write("index.html.erb", %(<% @posts.each do |post| %><%= render "posts/card", card: post %><% end %>))
+
+        files = subject.across(entry)["@posts"].map { |slot| File.basename(slot[:file]) }
+
+        assert_includes files, "_card.html.erb"
+      end
+
+      test "leaves an item template reached through an each block to the server" do
+        write("_card.html.erb", "<div><%= card %></div>")
+        entry = write("index.html.erb", %(<% @posts.each do |post| %><%= render "posts/card", card: post %><% end %>))
+
+        card = subject.across(entry)["@posts"].find { |slot| File.basename(slot[:file]) == "_card.html.erb" }
+
+        assert_equal :derived, card[:mode]
+      end
+
+      test "leaves everything an each block's item template renders to the server" do
+        write("_name.html.erb", "<span><%= card %></span>")
+        write("_card.html.erb", %(<div><%= render "posts/name", card: card %></div>))
+        entry = write("index.html.erb", %(<% @posts.each do |post| %><%= render "posts/card", card: post %><% end %>))
+
+        modes = subject.across(entry)["@posts"].reject { |slot| File.basename(slot[:file]) == "index.html.erb" }.map { |slot| slot[:mode] }
+
+        refute_empty modes
+        assert_equal [:derived], modes.uniq
+      end
+
+      test "keeps writing a partial rendered inside a block that runs once" do
+        write("_field.html.erb", "<div><%= card %></div>")
+        entry = write("index.html.erb", %(<% form_with model: @post do |f| %><%= render "posts/field", card: @post %><% end %>))
+
+        field = subject.across(entry)["@post"].find { |slot| File.basename(slot[:file]) == "_field.html.erb" }
+
+        assert_equal :identity, field[:mode]
+      end
+
       test "leaves a collection's item template to the server" do
         write("_card.html.erb", "<div><%= card %></div>")
         entry = write("index.html.erb", %(<%= render partial: "posts/card", collection: @posts %>))


### PR DESCRIPTION
This pull request teaches the dependency analysis that a block's parameters carry whatever that block iterates, in one template and across a `render` call, and in all three languages that implement it.

```erb
<ul>
  <% @items.each do |item| %>
    <li><%= item.name %></li>
  <% end %>
</ul>
```

`item` is `@items`, one at a time. Matching is by name, so nothing connected the two, and `item.name` was attributed to nothing.

Ruby learned this within a single template in #2280. This finishes it: the two ports learn the same thing, and the Ruby trace learns it across a render boundary, which is where it was answering a user-facing question incorrectly.

`affected_templates` and `state_flow` back `herb dependencies` and `herb actionview flow`, and their whole product is the list of templates a piece of state reaches. One shape was missing from it.

traced:
```erb
<%= render partial: "posts/card", collection: @posts %>
```

not traced:
```erb
<% @posts.each do |post| %>
  <%= render "posts/card", card: post %>
<% end %>
```

For the second, `affected_templates(entry, "@posts")` returned `["index.html.erb"]` and omitted `_card.html.erb`, and `state_flow` returned a tree with no child. `trace_state` asks whether a render call's local carries the state, and `card: post` names a block parameter that nothing tied to the collection that bound it.

The collector now records the blocks open around a render call, with the names each binds, and a local whose value is one of those names carries what its block iterates.

`analyze` now parses with `iteration_nodes`, so a block running per item and a block running once are different node types. Without that, `form_with model: @post do |f|` looks like a collection and `f` carries `@post` into every partial rendered inside the form. 

Once the trace reaches `_card.html.erb`, its slots become addressable, and they came back as an `identity`, which is a client writing one value into every card. A render inside an iterating block is now per item the same way `collection:` is, and the modes below a block that runs once are left alone.

Follow up on #2279, #2280, #2281, #2282 and #2283.

