### PR TITLE
Analysis: Never call a constant an identity once the map travels

### DIFF
--- a/lib/herb/engine/slot_dependencies.rb
+++ b/lib/herb/engine/slot_dependencies.rb
@@ -105,7 +105,7 @@ module Herb
         slots = visitor.slots
         wanted = names || state_names(analysis)
         reached = reached_paths(source, wanted)
-        settable = (analysis.instance_variables + analysis.locals_declared + (names || [])).to_set
+        settable = (analysis.instance_variables + analysis.locals_declared + (names || [])).to_set - analysis.constants.to_set
 
         index = {} #: Hash[Integer, Hash[Symbol, untyped]]
 

--- a/test/engine/slots/dependencies_test.rb
+++ b/test/engine/slots/dependencies_test.rb
@@ -304,6 +304,19 @@ module Engine
         assert_empty subject.subtree_slots(entry, ["@nothing"])
       end
 
+      test "never calls a constant an identity once the map travels" do
+        entry = write("index.html.erb", "<div><%= Post.count %></div>")
+
+        assert_equal([:derived], subject.across(entry)["Post.count"].map { |slot| slot[:mode] })
+        assert_equal(["derived"], subject.payload(entry)["state"]["Post.count"].map { |slot| slot["mode"] })
+      end
+
+      test "leaves a constant out of the names a request can set" do
+        entry = write("index.html.erb", "<div><%= Post.count %></div>")
+
+        assert_empty subject.payload(entry)["params"]
+      end
+
       test "leaves a template that reaches nothing out of the map" do
         entry = write("index.html.erb", "<div>static</div>")
 


### PR DESCRIPTION
This pull request fixes a slot dependency map that told a client it could write a value the client has never been given.

`SlotDependencies` classifies each slot by where its next value comes from. `identity` means the slot's expression is the state itself, so a client writes it by copying what it already holds. Everything computed is `derived`, and only the server can answer it.

A constant is a dependency and not something a page can set, so it can never be an identity. `for` had that right and `across` did not, and `across` is the one whose answer is delivered:

```ruby
subject.for(path)      #=> { 0 => { state: ["Post.count"], mode: :derived } }
subject.across(path)   #=> { "Post.count" => [{ …, mode: :identity }] }
subject.payload(path)  #=> { "state" => { "Post.count" => [{ "mode" => "identity" }] } }
```

A partial's incoming locals are not among the names it declares, so #2281 treats the names the trace carries as settable, which is what lets a partial answer in its caller's terms. Constants arrive through the same door and are settable by nothing, so the exclusion `for` applies was lost on the way.

The map already leaves constants out of the request names it publishes, so `payload["params"]` is empty for a template whose only state is `Post.count`, and nothing resolves to it by the name a request would use. Reaching it takes calling `state.set("Post.count", …)` by the state's own name, through the escape hatch meant for state whose request name could not be derived.