### PR TITLE
Engine: Emit only the Ruby a compiled template actually needs

### DIFF
--- a/docs/docs/projects/engine.md
+++ b/docs/docs/projects/engine.md
@@ -581,6 +581,8 @@ Herb::Engine.new(source, visitors: [Herb::Engine::OptimizeVisitor.new])
 
 `<%= tag.div do %>Content<% end %>` compiles to `<div>Content</div>` with no helper call left at all. Only the helpers the registry marks supported are resolved.
 
+Its presence also collapses a template that carries no Ruby into the single string literal it renders, with none of the buffer the compiler would otherwise build up. `<div>Static</div>` compiles to `'<div>Static</div>'`. A template written as HTML qualifies on its own, and one left fully static once its helpers resolved to markup qualifies too, so `<%= tag.br %>` compiles to `'<br>'`. The engine keeps the buffer when the caller drives it through `preamble`, `postamble`, `bufval`, or `ensure`, and when a visitor recorded a diagnostic the compiled template still has to report.
+
 Replacing a helper call with its markup is the same thing as calling it only while the helper is the one it was resolved against. An application that defines its own `content_tag` gets the stock markup everywhere instead of its own, with nothing at the call site to say so. `verify` compiles a check into the template that reports a helper that has since been overwritten:
 
 ```ruby

--- a/lib/herb/engine.rb
+++ b/lib/herb/engine.rb
@@ -34,6 +34,11 @@ module Herb
       @context.relative_file_path
     end
 
+    #: (String) -> String
+    def string_literal(text)
+      "'#{text.gsub(/['\\]/, '\\\\\&')}#{@text_end}"
+    end
+
     ESCAPE_TABLE = {
       "&" => "&amp;",
       "<" => "&lt;",
@@ -76,14 +81,6 @@ module Herb
 
       @src << "# frozen_string_literal: true\n" if @freeze
 
-      if properties[:ensure]
-        @src << "begin; __original_outvar = #{@bufvar}"
-        @src << (/\A@[^@]/ =~ @bufvar ? "; " : " if defined?(#{@bufvar}); ")
-      end
-
-      @src << "__herb = ::Herb::Engine; " if @escape && @escapefunc == "__herb.h"
-      @src << preamble
-
       parse_result = ::Herb.parse(input, **@parser_options, track_whitespace: true)
       parser_errors = parse_result.errors
 
@@ -96,19 +93,29 @@ module Herb
           parse_result.value.accept(visitor)
         end
 
-        report(input)
-
         compiler = compiler_class.new(self, properties)
 
         parse_result.value.accept(compiler)
 
-        compiler.generate_output
+        static_body = buffer_required?(properties) ? nil : compile_static_body(compiler)
+
+        if static_body
+          @src << static_body
+        else
+          write_buffer_prelude(properties, preamble)
+
+          report(input)
+
+          compiler.generate_output
+
+          @src << "\n" unless @src.end_with?("\n")
+          add_postamble(postamble)
+
+          @src << "; ensure\n  #{@bufvar} = __original_outvar\nend\n" if properties[:ensure]
+
+          insert_herb_alias!
+        end
       end
-
-      @src << "\n" unless @src.end_with?("\n")
-      add_postamble(postamble)
-
-      @src << "; ensure\n  #{@bufvar} = __original_outvar\nend\n" if properties[:ensure]
 
       if properties.fetch(:validate_ruby, false)
         ensure_valid_ruby!(@src)
@@ -320,6 +327,50 @@ module Herb
     end
 
     private
+
+    #: (Hash[Symbol, untyped]) -> bool
+    def buffer_required?(properties)
+      return true if properties[:ensure] || properties[:preamble] || properties[:postamble] || properties[:bufval]
+
+      collected_diagnostics.any?
+    end
+
+    #: (untyped) -> String?
+    def compile_static_body(compiler)
+      @visitors.each do |visitor|
+        next unless visitor.respond_to?(:compile_static_body)
+
+        body = visitor.compile_static_body(self, compiler)
+
+        return body if body
+      end
+
+      nil
+    end
+
+    #: () -> Array[Herb::Diagnostic]
+    def collected_diagnostics
+      @visitors.grep(Diagnostics).flat_map(&:diagnostics)
+    end
+
+    #: (Hash[Symbol, untyped], String) -> void
+    def write_buffer_prelude(properties, preamble)
+      if properties[:ensure]
+        @src << "begin; __original_outvar = #{@bufvar}"
+        @src << (/\A@[^@]/ =~ @bufvar ? "; " : " if defined?(#{@bufvar}); ")
+      end
+
+      @herb_alias_index = (@src.length if @escape && @escapefunc == "__herb.h")
+      @src << preamble
+    end
+
+    #: () -> void
+    def insert_herb_alias!
+      return unless @herb_alias_index
+      return unless @src.include?("__herb.")
+
+      @src.insert(@herb_alias_index, "__herb = ::Herb::Engine; ")
+    end
 
     def handle_parser_errors(parser_errors, input, _ast)
       message = ErrorFormatter.new(input, parser_errors, filename: filename).format_all

--- a/lib/herb/engine/compiler.rb
+++ b/lib/herb/engine/compiler.rb
@@ -28,9 +28,17 @@ module Herb
         @current_element_source = nil
       end
 
-      def generate_output
-        optimized_tokens = optimize_tokens(@tokens)
+      def optimized_tokens
+        @optimized_tokens ||= optimize_tokens(@tokens)
+      end
 
+      def static_template_text
+        return unless optimized_tokens.all? { |token| token[0] == :text }
+
+        optimized_tokens.map { |token| token[1] }.join
+      end
+
+      def generate_output
         optimized_tokens.each do |type, value, context, escaped|
           case type
           when :text

--- a/lib/herb/engine/optimize_visitor.rb
+++ b/lib/herb/engine/optimize_visitor.rb
@@ -18,6 +18,13 @@ module Herb
     # Inserting it is the whole opt-in. There is no check first for whether a template looks like
     # it contains helpers, because a caller that added this has already answered that question.
     #
+    # Its presence also lets the engine collapse a template that carries no Ruby into the single
+    # string literal it renders, skipping the buffer the compiler would otherwise build up. A
+    # template that was HTML to begin with qualifies, and so does one left fully static once the
+    # helpers above resolved to markup. The collapse is held back when the caller drives the buffer
+    # itself through `preamble`, `postamble`, `bufval`, or `ensure`, and when a visitor recorded a
+    # diagnostic that the compiled template still needs to report.
+    #
     # Replacing a helper call with its markup is only the same thing as calling it while the helper
     # is the one it was resolved against. An application that defines its own `content_tag` gets the
     # stock markup instead, everywhere, with nothing at the call site to say so. `verify` compiles a
@@ -91,6 +98,15 @@ module Herb
         collect(node.element_source, node.location)
 
         super
+      end
+
+      #: (Herb::Engine, untyped) -> String?
+      def compile_static_body(engine, compiler)
+        text = compiler.static_template_text
+
+        return unless text
+
+        engine.string_literal(text)
       end
 
       #: () -> String

--- a/sig/herb/engine.rbs
+++ b/sig/herb/engine.rbs
@@ -19,6 +19,9 @@ module Herb
     # : () -> String
     def relative_file_path: () -> String
 
+    # : (String) -> String
+    def string_literal: (String) -> String
+
     ESCAPE_TABLE: untyped
 
     def initialize: (untyped input, ?untyped properties) -> untyped
@@ -73,6 +76,21 @@ module Herb
     def terminate_expression: () -> untyped
 
     private
+
+    # : (Hash[Symbol, untyped]) -> bool
+    def buffer_required?: (Hash[Symbol, untyped]) -> bool
+
+    # : (untyped) -> String?
+    def compile_static_body: (untyped) -> String?
+
+    # : () -> Array[Herb::Diagnostic]
+    def collected_diagnostics: () -> Array[Herb::Diagnostic]
+
+    # : (Hash[Symbol, untyped], String) -> void
+    def write_buffer_prelude: (Hash[Symbol, untyped], String) -> void
+
+    # : () -> void
+    def insert_herb_alias!: () -> void
 
     def handle_parser_errors: (untyped parser_errors, untyped input, untyped _ast) -> untyped
 

--- a/sig/herb/engine/compiler.rbs
+++ b/sig/herb/engine/compiler.rbs
@@ -19,6 +19,10 @@ module Herb
 
       def initialize: (untyped engine, ?untyped options) -> untyped
 
+      def optimized_tokens: () -> untyped
+
+      def static_template_text: () -> untyped
+
       def generate_output: () -> untyped
 
       def visit_document_node: (untyped node) -> untyped

--- a/sig/herb/engine/optimize_visitor.rbs
+++ b/sig/herb/engine/optimize_visitor.rbs
@@ -13,6 +13,13 @@ module Herb
     # Inserting it is the whole opt-in. There is no check first for whether a template looks like
     # it contains helpers, because a caller that added this has already answered that question.
     #
+    # Its presence also lets the engine collapse a template that carries no Ruby into the single
+    # string literal it renders, skipping the buffer the compiler would otherwise build up. A
+    # template that was HTML to begin with qualifies, and so does one left fully static once the
+    # helpers above resolved to markup. The collapse is held back when the caller drives the buffer
+    # itself through `preamble`, `postamble`, `bufval`, or `ensure`, and when a visitor recorded a
+    # diagnostic that the compiled template still needs to report.
+    #
     # Replacing a helper call with its markup is only the same thing as calling it while the helper
     # is the one it was resolved against. An application that defines its own `content_tag` gets the
     # stock markup instead, everywhere, with nothing at the call site to say so. `verify` compiles a
@@ -53,6 +60,9 @@ module Herb
 
       # : (Herb::AST::HTMLConditionalElementNode) -> void
       def visit_html_conditional_element_node: (Herb::AST::HTMLConditionalElementNode) -> void
+
+      # : (Herb::Engine, untyped) -> String?
+      def compile_static_body: (Herb::Engine, untyped) -> String?
 
       # : () -> String
       def inspect: () -> String

--- a/test/engine/herb_alias_omission_test.rb
+++ b/test/engine/herb_alias_omission_test.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+require_relative "../../lib/herb/engine"
+
+module Engine
+  class HerbAliasOmissionTest < Minitest::Spec
+    def compile(source, **)
+      Herb::Engine.new(source, escape: true, **).src
+    end
+
+    test "the alias is omitted when the compiled template never calls it" do
+      compiled = compile("<h1><% if a %><div>x</div><% end %></h1>")
+
+      refute_includes compiled, "__herb"
+    end
+
+    test "the alias is kept when an escaped expression calls it" do
+      compiled = compile("<div><%= value %></div>")
+
+      assert_includes compiled, "__herb = ::Herb::Engine;"
+      assert_includes compiled, "__herb.h((value))"
+    end
+
+    test "the alias is kept for an escaped attribute value" do
+      compiled = compile('<div class="<%= value %>">x</div>')
+
+      assert_includes compiled, "__herb = ::Herb::Engine;"
+      assert_includes compiled, "__herb.attr((value))"
+    end
+
+    test "a custom escape function drops the alias it no longer needs" do
+      compiled = compile('<div class="<%= value %>">x</div>', attrfunc: "CustomEscape.attribute")
+
+      refute_includes compiled, "__herb"
+      assert_includes compiled, "CustomEscape.attribute((value))"
+    end
+
+    test "the kept alias evaluates" do
+      compiled = compile("<div><%= value %></div>")
+      render = eval("->(value) { #{compiled} }", binding, __FILE__, __LINE__)
+
+      assert_equal "<div>&lt;b&gt;</div>", render.call("<b>")
+    end
+
+    test "escape false never emits the alias" do
+      refute_includes Herb::Engine.new("<div><%= value %></div>").src, "__herb"
+    end
+  end
+end

--- a/test/engine/static_template_optimization_test.rb
+++ b/test/engine/static_template_optimization_test.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+require_relative "../snapshot_utils"
+require "herb/engine/optimize_visitor"
+
+module Engine
+  class StaticTemplateOptimizationTest < Minitest::Spec
+    include SnapshotUtils
+
+    HTML_ONLY_TEMPLATE = <<~HTML
+      <header class="site-header">
+        <nav class="navbar">
+          <div class="container">
+            <a href="/" class="logo">
+              <img src="/images/logo.svg" alt="Company Name">
+            </a>
+          </div>
+        </nav>
+      </header>
+    HTML
+
+    def optimize(source, **)
+      Herb::Engine.new(source, visitors: [Herb::Engine::OptimizeVisitor.new], **).src
+    end
+
+    class AlwaysWarns < Herb::Visitor
+      include Herb::Engine::Diagnostics
+
+      def visit_html_element_node(node)
+        warning("noticed an element", node.location, code: "noticed-element")
+
+        super
+      end
+    end
+
+    class AlwaysErrors < Herb::Visitor
+      include Herb::Engine::Diagnostics
+
+      def fatal? = true
+
+      def visit_html_element_node(node)
+        error("this element is broken", node.location, code: "broken-element")
+
+        super
+      end
+    end
+
+    test "an HTML-only template compiles to a bare string literal" do
+      assert_compiled_snapshot("<div class=\"a\">Hello</div>", visitors: [Herb::Engine::OptimizeVisitor.new])
+    end
+
+    test "a nested multi-line document collapses to the string it renders" do
+      collapsed = optimize(HTML_ONLY_TEMPLATE)
+
+      refute_includes collapsed, "_buf"
+      assert_equal HTML_ONLY_TEMPLATE, eval(collapsed)
+    end
+
+    test "the collapsed literal renders the same string as the buffered form" do
+      [
+        "<div class=\"a\">Hi</div>",
+        "text with 'quotes' and \\ backslash",
+        "<!DOCTYPE html>\n<p>x</p>\n",
+        ""
+      ].each do |source|
+        buffered = Herb::Engine.new(source).src
+        collapsed = optimize(source)
+
+        assert_equal eval(buffered), eval(collapsed), source.inspect
+        assert_equal source, eval(collapsed), source.inspect
+      end
+    end
+
+    test "an empty template collapses to an empty literal" do
+      assert_equal "''.freeze", optimize("")
+    end
+
+    test "escaping is preserved in the collapsed literal" do
+      collapsed = optimize("it's a \\ backslash")
+
+      assert_equal "'it\\'s a \\\\ backslash'.freeze", collapsed
+    end
+
+    test "the optimization only applies when OptimizeVisitor is present" do
+      source = "<div>Static</div>"
+
+      assert_includes Herb::Engine.new(source).src, "_buf"
+      refute_includes optimize(source), "_buf"
+    end
+
+    test "a template with dynamic ERB stays buffered" do
+      collapsed = optimize("<div><%= name %></div>")
+
+      assert_includes collapsed, "_buf"
+      assert_includes collapsed, "(name).to_s"
+    end
+
+    test "a helper that resolves to static markup collapses too" do
+      collapsed = optimize("<div><%= tag.br %></div>")
+
+      assert_equal "'<div><br></div>'.freeze", collapsed
+    end
+
+    test "a custom preamble keeps the buffer" do
+      assert_includes optimize("<div>hi</div>", preamble: "@output = +''"), "@output"
+    end
+
+    test "a custom postamble keeps the buffer" do
+      assert_includes optimize("<div>hi</div>", postamble: "@output_buffer"), "_buf"
+    end
+
+    test "the ensure wrapper keeps the buffer" do
+      collapsed = optimize("<div>hi</div>", ensure: true)
+
+      assert_includes collapsed, "__original_outvar"
+      assert_includes collapsed, "_buf"
+    end
+
+    test "a recorded diagnostic keeps the buffer so the report survives" do
+      compiled = Herb::Engine.new(
+        "<div>hi</div>",
+        visitors: [Herb::Engine::OptimizeVisitor.new, AlwaysWarns.new]
+      ).src
+
+      assert_includes compiled, "record_compile_diagnostics"
+      assert_includes compiled, "_buf"
+    end
+
+    test "a fatal diagnostic still raises instead of collapsing" do
+      assert_raises(Herb::Engine::CompilationError) do
+        Herb::Engine.new(
+          "<div>hi</div>",
+          visitors: [Herb::Engine::OptimizeVisitor.new, AlwaysErrors.new]
+        )
+      end
+    end
+  end
+end

--- a/test/snapshots/engine/action_view/content_tag_test/test_0001_content_tag_with_block_bbedd47e3fc07d8db2bcfb99e996c757.txt
+++ b/test/snapshots/engine/action_view/content_tag_test/test_0001_content_tag_with_block_bbedd47e3fc07d8db2bcfb99e996c757.txt
@@ -2,7 +2,6 @@
 source: "Engine::ActionView::ContentTagTest#test_0001_content_tag with block"
 input: "{source: \"<%= content_tag :div do %>\\n  Content\\n<% end %>\\n\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
 ---
-_buf = ::String.new; _buf << '<div>
+'<div>
   Content
-</div>'.freeze;
-_buf.to_s
+</div>'.freeze

--- a/test/snapshots/engine/action_view/content_tag_test/test_0002_content_tag_with_content_argument_f8cdc85ed7da58b98a1bea3c9cf53119.txt
+++ b/test/snapshots/engine/action_view/content_tag_test/test_0002_content_tag_with_content_argument_f8cdc85ed7da58b98a1bea3c9cf53119.txt
@@ -2,5 +2,4 @@
 source: "Engine::ActionView::ContentTagTest#test_0002_content_tag with content argument"
 input: "{source: \"<%= content_tag :div, \\\"Content\\\" %>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
 ---
-_buf = ::String.new; _buf << '<div>Content</div>'.freeze;
-_buf.to_s
+'<div>Content</div>'.freeze

--- a/test/snapshots/engine/action_view/content_tag_test/test_0003_content_tag_with_content_and_attributes_19523cc2ea0097198b0019256545f124.txt
+++ b/test/snapshots/engine/action_view/content_tag_test/test_0003_content_tag_with_content_and_attributes_19523cc2ea0097198b0019256545f124.txt
@@ -2,5 +2,4 @@
 source: "Engine::ActionView::ContentTagTest#test_0003_content_tag with content and attributes"
 input: "{source: \"<%= content_tag :div, \\\"Content\\\", class: \\\"example\\\" %>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
 ---
-_buf = ::String.new; _buf << '<div class="example">Content</div>'.freeze;
-_buf.to_s
+'<div class="example">Content</div>'.freeze

--- a/test/snapshots/engine/action_view/content_tag_test/test_0004_content_tag_with_data_attributes_5112c927f6cd98cbc1a179b93d889ecc.txt
+++ b/test/snapshots/engine/action_view/content_tag_test/test_0004_content_tag_with_data_attributes_5112c927f6cd98cbc1a179b93d889ecc.txt
@@ -2,5 +2,4 @@
 source: "Engine::ActionView::ContentTagTest#test_0004_content_tag with data attributes"
 input: "{source: \"<%= content_tag :div, data: { controller: \\\"example\\\" } do %>Content<% end %>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
 ---
-_buf = ::String.new; _buf << '<div data-controller="example">Content</div>'.freeze;
-_buf.to_s
+'<div data-controller="example">Content</div>'.freeze

--- a/test/snapshots/engine/action_view/content_tag_test/test_0005_content_tag_br_void_element_4e85a203e3e0ce6061b056bf26e4c215.txt
+++ b/test/snapshots/engine/action_view/content_tag_test/test_0005_content_tag_br_void_element_4e85a203e3e0ce6061b056bf26e4c215.txt
@@ -2,5 +2,4 @@
 source: "Engine::ActionView::ContentTagTest#test_0005_content_tag br void element"
 input: "{source: \"<%= content_tag :br %>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
 ---
-_buf = ::String.new; _buf << '<br />'.freeze;
-_buf.to_s
+'<br />'.freeze

--- a/test/snapshots/engine/action_view/content_tag_test/test_0006_content_tag_with_inline_block_ad0c10740af65f251b4072a6e0d8d888.txt
+++ b/test/snapshots/engine/action_view/content_tag_test/test_0006_content_tag_with_inline_block_ad0c10740af65f251b4072a6e0d8d888.txt
@@ -2,5 +2,4 @@
 source: "Engine::ActionView::ContentTagTest#test_0006_content_tag with inline block"
 input: "{source: \"<%= content_tag(:details) { \\\"Some content\\\" } %>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
 ---
-_buf = ::String.new; _buf << '<details>Some content</details>'.freeze;
-_buf.to_s
+'<details>Some content</details>'.freeze

--- a/test/snapshots/engine/action_view/content_tag_test/test_0007_content_tag_with_inline_block_and_attributes_b7a3e6546627c5e410f3cb9bbf454eb5.txt
+++ b/test/snapshots/engine/action_view/content_tag_test/test_0007_content_tag_with_inline_block_and_attributes_b7a3e6546627c5e410f3cb9bbf454eb5.txt
@@ -2,5 +2,4 @@
 source: "Engine::ActionView::ContentTagTest#test_0007_content_tag with inline block and attributes"
 input: "{source: \"<%= content_tag(:div, class: \\\"container\\\") { \\\"Hello\\\" } %>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
 ---
-_buf = ::String.new; _buf << '<div class="container">Hello</div>'.freeze;
-_buf.to_s
+'<div class="container">Hello</div>'.freeze

--- a/test/snapshots/engine/action_view/content_tag_test/test_0009_content_tag_script_with_nonce_true_1f736fa9f14a0e30a1f5a40dd94db114.txt
+++ b/test/snapshots/engine/action_view/content_tag_test/test_0009_content_tag_script_with_nonce_true_1f736fa9f14a0e30a1f5a40dd94db114.txt
@@ -2,5 +2,4 @@
 source: "Engine::ActionView::ContentTagTest#test_0009_content_tag :script with nonce true"
 input: "{source: \"<%= content_tag(:script, \\\"alert(1)\\\", nonce: true) %>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
 ---
-_buf = ::String.new; _buf << '<script nonce="true">alert(1)</script>'.freeze;
-_buf.to_s
+'<script nonce="true">alert(1)</script>'.freeze

--- a/test/snapshots/engine/action_view/content_tag_test/test_0010_content_tag_script_with_nonce_false_920f725aab8a4cf212bf17b3028379ca.txt
+++ b/test/snapshots/engine/action_view/content_tag_test/test_0010_content_tag_script_with_nonce_false_920f725aab8a4cf212bf17b3028379ca.txt
@@ -2,5 +2,4 @@
 source: "Engine::ActionView::ContentTagTest#test_0010_content_tag :script with nonce false"
 input: "{source: \"<%= content_tag(:script, \\\"alert(1)\\\", nonce: false) %>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
 ---
-_buf = ::String.new; _buf << '<script nonce="false">alert(1)</script>'.freeze;
-_buf.to_s
+'<script nonce="false">alert(1)</script>'.freeze

--- a/test/snapshots/engine/action_view/image_tag_test/test_0004_image_tag_with_URL_source_4000019580bf6129000e6ea2c7756350.txt
+++ b/test/snapshots/engine/action_view/image_tag_test/test_0004_image_tag_with_URL_source_4000019580bf6129000e6ea2c7756350.txt
@@ -2,5 +2,4 @@
 source: "Engine::ActionView::ImageTagTest#test_0004_image_tag with URL source"
 input: "{source: \"<%= image_tag \\\"http://example.com/icon.png\\\" %>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
 ---
-_buf = ::String.new; _buf << '<img src="http://example.com/icon.png" />'.freeze;
-_buf.to_s
+'<img src="http://example.com/icon.png" />'.freeze

--- a/test/snapshots/engine/action_view/image_tag_test/test_0005_image_tag_with_protocol-relative_URL_fe419664b5850dc96d8ddd06ca9dd1bc.txt
+++ b/test/snapshots/engine/action_view/image_tag_test/test_0005_image_tag_with_protocol-relative_URL_fe419664b5850dc96d8ddd06ca9dd1bc.txt
@@ -2,5 +2,4 @@
 source: "Engine::ActionView::ImageTagTest#test_0005_image_tag with protocol-relative URL"
 input: "{source: \"<%= image_tag \\\"//cdn.example.com/icon.png\\\" %>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
 ---
-_buf = ::String.new; _buf << '<img src="//cdn.example.com/icon.png" />'.freeze;
-_buf.to_s
+'<img src="//cdn.example.com/icon.png" />'.freeze

--- a/test/snapshots/engine/action_view/javascript_include_tag_test/test_0003_javascript_include_tag_with_URL_153116ce642c4dda90fedad009437d62.txt
+++ b/test/snapshots/engine/action_view/javascript_include_tag_test/test_0003_javascript_include_tag_with_URL_153116ce642c4dda90fedad009437d62.txt
@@ -2,5 +2,4 @@
 source: "Engine::ActionView::JavascriptIncludeTagTest#test_0003_javascript_include_tag with URL"
 input: "{source: \"<%= javascript_include_tag \\\"http://www.example.com/xmlhr.js\\\" %>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
 ---
-_buf = ::String.new; _buf << '<script src="http://www.example.com/xmlhr.js"></script>'.freeze;
-_buf.to_s
+'<script src="http://www.example.com/xmlhr.js"></script>'.freeze

--- a/test/snapshots/engine/action_view/javascript_include_tag_test/test_0004_javascript_include_tag_with_URL_and_async_1ba8d43292123ae5eadfaf8b665df005.txt
+++ b/test/snapshots/engine/action_view/javascript_include_tag_test/test_0004_javascript_include_tag_with_URL_and_async_1ba8d43292123ae5eadfaf8b665df005.txt
@@ -2,5 +2,4 @@
 source: "Engine::ActionView::JavascriptIncludeTagTest#test_0004_javascript_include_tag with URL and async"
 input: "{source: \"<%= javascript_include_tag \\\"http://www.example.com/xmlhr.js\\\", async: true %>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
 ---
-_buf = ::String.new; _buf << '<script async src="http://www.example.com/xmlhr.js"></script>'.freeze;
-_buf.to_s
+'<script async src="http://www.example.com/xmlhr.js"></script>'.freeze

--- a/test/snapshots/engine/action_view/javascript_tag_test/test_0001_javascript_tag_with_content_6f137a21d5a4a323f99d02e4ffc3cb63.txt
+++ b/test/snapshots/engine/action_view/javascript_tag_test/test_0001_javascript_tag_with_content_6f137a21d5a4a323f99d02e4ffc3cb63.txt
@@ -2,9 +2,8 @@
 source: "Engine::ActionView::JavascriptTagTest#test_0001_javascript_tag with content"
 input: "{source: \"<%= javascript_tag \\\"alert('Hello')\\\" %>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
 ---
-_buf = ::String.new; _buf << '<script>
+'<script>
 //<![CDATA[
 alert(\'Hello\')
 //]]>
-</script>'.freeze;
-_buf.to_s
+</script>'.freeze

--- a/test/snapshots/engine/action_view/javascript_tag_test/test_0002_javascript_tag_with_block_47ec3152bc00cd43a7e8514b3887317a.txt
+++ b/test/snapshots/engine/action_view/javascript_tag_test/test_0002_javascript_tag_with_block_47ec3152bc00cd43a7e8514b3887317a.txt
@@ -2,11 +2,10 @@
 source: "Engine::ActionView::JavascriptTagTest#test_0002_javascript_tag with block"
 input: "{source: \"<%= javascript_tag do %>\\n  alert('Hello')\\n<% end %>\\n\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
 ---
-_buf = ::String.new; _buf << '<script>
+'<script>
 //<![CDATA[
 
   alert(\'Hello\')
 
 //]]>
-</script>'.freeze;
-_buf.to_s
+</script>'.freeze

--- a/test/snapshots/engine/action_view/javascript_tag_test/test_0003_javascript_tag_with_type_attribute_0bb01f3290b3d6fac50d42d8c4d0fa53.txt
+++ b/test/snapshots/engine/action_view/javascript_tag_test/test_0003_javascript_tag_with_type_attribute_0bb01f3290b3d6fac50d42d8c4d0fa53.txt
@@ -2,9 +2,8 @@
 source: "Engine::ActionView::JavascriptTagTest#test_0003_javascript_tag with type attribute"
 input: "{source: \"<%= javascript_tag \\\"alert('Hello')\\\", type: \\\"application/javascript\\\" %>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
 ---
-_buf = ::String.new; _buf << '<script type="application/javascript">
+'<script type="application/javascript">
 //<![CDATA[
 alert(\'Hello\')
 //]]>
-</script>'.freeze;
-_buf.to_s
+</script>'.freeze

--- a/test/snapshots/engine/action_view/javascript_tag_test/test_0005_javascript_tag_with_nonce_false_3d6f085423bdc3b83b7f6bbf46576572.txt
+++ b/test/snapshots/engine/action_view/javascript_tag_test/test_0005_javascript_tag_with_nonce_false_3d6f085423bdc3b83b7f6bbf46576572.txt
@@ -2,11 +2,10 @@
 source: "Engine::ActionView::JavascriptTagTest#test_0005_javascript_tag with nonce false"
 input: "{source: \"<%= javascript_tag nonce: false do %>\\n  alert('Hello')\\n<% end %>\\n\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
 ---
-_buf = ::String.new; _buf << '<script>
+'<script>
 //<![CDATA[
 
   alert(\'Hello\')
 
 //]]>
-</script>'.freeze;
-_buf.to_s
+</script>'.freeze

--- a/test/snapshots/engine/action_view/link_to_test/test_0001_link_to_with_text_and_url_61f6bb76996c141cc39784e2a25c53ba.txt
+++ b/test/snapshots/engine/action_view/link_to_test/test_0001_link_to_with_text_and_url_61f6bb76996c141cc39784e2a25c53ba.txt
@@ -2,5 +2,4 @@
 source: "Engine::ActionView::LinkToTest#test_0001_link_to with text and url"
 input: "{source: \"<%= link_to \\\"Click me\\\", \\\"#\\\" %>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
 ---
-_buf = ::String.new; _buf << '<a href="#">Click me</a>'.freeze;
-_buf.to_s
+'<a href="#">Click me</a>'.freeze

--- a/test/snapshots/engine/action_view/link_to_test/test_0002_link_to_with_html_options_ea5c0b0f9acca17623d9edfedd89dc15.txt
+++ b/test/snapshots/engine/action_view/link_to_test/test_0002_link_to_with_html_options_ea5c0b0f9acca17623d9edfedd89dc15.txt
@@ -2,5 +2,4 @@
 source: "Engine::ActionView::LinkToTest#test_0002_link_to with html options"
 input: "{source: \"<%= link_to \\\"Click me\\\", \\\"#\\\", class: \\\"example\\\" %>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
 ---
-_buf = ::String.new; _buf << '<a class="example" href="#">Click me</a>'.freeze;
-_buf.to_s
+'<a class="example" href="#">Click me</a>'.freeze

--- a/test/snapshots/engine/action_view/link_to_test/test_0003_link_to_with_block_1876ffd71d165d5521258f75029e6692.txt
+++ b/test/snapshots/engine/action_view/link_to_test/test_0003_link_to_with_block_1876ffd71d165d5521258f75029e6692.txt
@@ -2,5 +2,4 @@
 source: "Engine::ActionView::LinkToTest#test_0003_link_to with block"
 input: "{source: \"<%= link_to \\\"#\\\" do %>Click me<% end %>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
 ---
-_buf = ::String.new; _buf << '<a href="#">Click me</a>'.freeze;
-_buf.to_s
+'<a href="#">Click me</a>'.freeze

--- a/test/snapshots/engine/action_view/link_to_test/test_0004_link_to_with_block_and_class_c2f68734249d87e0b7fa2029b7b0161c.txt
+++ b/test/snapshots/engine/action_view/link_to_test/test_0004_link_to_with_block_and_class_c2f68734249d87e0b7fa2029b7b0161c.txt
@@ -2,5 +2,4 @@
 source: "Engine::ActionView::LinkToTest#test_0004_link_to with block and class"
 input: "{source: \"<%= link_to \\\"#\\\", class: \\\"btn\\\" do %>Click me<% end %>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
 ---
-_buf = ::String.new; _buf << '<a class="btn" href="#">Click me</a>'.freeze;
-_buf.to_s
+'<a class="btn" href="#">Click me</a>'.freeze

--- a/test/snapshots/engine/action_view/link_to_test/test_0006_link_to_with_inline_block_7494537ec2a4392fb147bef3713ce281.txt
+++ b/test/snapshots/engine/action_view/link_to_test/test_0006_link_to_with_inline_block_7494537ec2a4392fb147bef3713ce281.txt
@@ -2,5 +2,4 @@
 source: "Engine::ActionView::LinkToTest#test_0006_link_to with inline block"
 input: "{source: \"<%= link_to(\\\"#\\\") { \\\"Click me\\\" } %>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
 ---
-_buf = ::String.new; _buf << '<a href="#">Click me</a>'.freeze;
-_buf.to_s
+'<a href="#">Click me</a>'.freeze

--- a/test/snapshots/engine/action_view/link_to_test/test_0007_link_to_with_inline_block_and_attributes_ab1dd6db58243944cfff803d911d7fd2.txt
+++ b/test/snapshots/engine/action_view/link_to_test/test_0007_link_to_with_inline_block_and_attributes_ab1dd6db58243944cfff803d911d7fd2.txt
@@ -2,5 +2,4 @@
 source: "Engine::ActionView::LinkToTest#test_0007_link_to with inline block and attributes"
 input: "{source: \"<%= link_to(\\\"/about\\\", class: \\\"btn\\\") { \\\"About\\\" } %>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
 ---
-_buf = ::String.new; _buf << '<a class="btn" href="/about">About</a>'.freeze;
-_buf.to_s
+'<a class="btn" href="/about">About</a>'.freeze

--- a/test/snapshots/engine/action_view/link_to_test/test_0012_link_to_with_aria-label_string_key_10a01227fc726d892e8ceb039ca24d82.txt
+++ b/test/snapshots/engine/action_view/link_to_test/test_0012_link_to_with_aria-label_string_key_10a01227fc726d892e8ceb039ca24d82.txt
@@ -2,5 +2,4 @@
 source: "Engine::ActionView::LinkToTest#test_0012_link_to with aria-label string key"
 input: "{source: \"<%= link_to \\\"More\\\", \\\"#\\\", \\\"aria-label\\\": \\\"Learn more about GitHub\\\" %>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
 ---
-_buf = ::String.new; _buf << '<a aria-label="Learn more about GitHub" href="#">More</a>'.freeze;
-_buf.to_s
+'<a aria-label="Learn more about GitHub" href="#">More</a>'.freeze

--- a/test/snapshots/engine/action_view/link_to_test/test_0013_link_to_with_aria_hash_label_071d3511c1005b226c2d606080e73c58.txt
+++ b/test/snapshots/engine/action_view/link_to_test/test_0013_link_to_with_aria_hash_label_071d3511c1005b226c2d606080e73c58.txt
@@ -2,5 +2,4 @@
 source: "Engine::ActionView::LinkToTest#test_0013_link_to with aria hash label"
 input: "{source: \"<%= link_to \\\"More\\\", \\\"#\\\", aria: { label: \\\"Learn more about GitHub\\\" } %>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
 ---
-_buf = ::String.new; _buf << '<a aria-label="Learn more about GitHub" href="#">More</a>'.freeze;
-_buf.to_s
+'<a aria-label="Learn more about GitHub" href="#">More</a>'.freeze

--- a/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0003_stylesheet_link_tag_with_URL_12b23d41e0ae8b931316511d2a520cb3.txt
+++ b/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0003_stylesheet_link_tag_with_URL_12b23d41e0ae8b931316511d2a520cb3.txt
@@ -2,5 +2,4 @@
 source: "Engine::ActionView::StylesheetLinkTagTest#test_0003_stylesheet_link_tag with URL"
 input: "{source: \"<%= stylesheet_link_tag \\\"http://www.example.com/style.css\\\" %>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
 ---
-_buf = ::String.new; _buf << '<link rel="stylesheet" href="http://www.example.com/style.css" />'.freeze;
-_buf.to_s
+'<link rel="stylesheet" href="http://www.example.com/style.css" />'.freeze

--- a/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0008_stylesheet_link_tag_with_protocol-relative_URL_3543eab13d06d056256b5d39269a75fc.txt
+++ b/test/snapshots/engine/action_view/stylesheet_link_tag_test/test_0008_stylesheet_link_tag_with_protocol-relative_URL_3543eab13d06d056256b5d39269a75fc.txt
@@ -2,5 +2,4 @@
 source: "Engine::ActionView::StylesheetLinkTagTest#test_0008_stylesheet_link_tag with protocol-relative URL"
 input: "{source: \"<%= stylesheet_link_tag \\\"//cdn.example.com/style.css\\\" %>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
 ---
-_buf = ::String.new; _buf << '<link rel="stylesheet" href="//cdn.example.com/style.css" />'.freeze;
-_buf.to_s
+'<link rel="stylesheet" href="//cdn.example.com/style.css" />'.freeze

--- a/test/snapshots/engine/action_view/tag_attributes_test/test_0002_tag.attributes_with_simple_attributes_9b94f7526a85f81a5f26e45438f5c8e2.txt
+++ b/test/snapshots/engine/action_view/tag_attributes_test/test_0002_tag.attributes_with_simple_attributes_9b94f7526a85f81a5f26e45438f5c8e2.txt
@@ -2,5 +2,4 @@
 source: "Engine::ActionView::TagAttributesTest#test_0002_tag.attributes with simple attributes"
 input: "{source: \"<input <%= tag.attributes(type: :text, aria: { label: \\\"Search\\\" }) %>>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
 ---
-_buf = ::String.new; _buf << '<input type="text" aria-label="Search">'.freeze;
-_buf.to_s
+'<input type="text" aria-label="Search">'.freeze

--- a/test/snapshots/engine/action_view/tag_attributes_test/test_0003_tag.attributes_with_attributes_before_and_after_8fa71be1fdc8f64f4a5e88d303193cf4.txt
+++ b/test/snapshots/engine/action_view/tag_attributes_test/test_0003_tag.attributes_with_attributes_before_and_after_8fa71be1fdc8f64f4a5e88d303193cf4.txt
@@ -2,5 +2,4 @@
 source: "Engine::ActionView::TagAttributesTest#test_0003_tag.attributes with attributes before and after"
 input: "{source: \"<button class=\\\"primary\\\" <%= tag.attributes(id: \\\"cta\\\", disabled: false) %> data-action=\\\"click->submit\\\">Go</button>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
 ---
-_buf = ::String.new; _buf << '<button class="primary" id="cta" data-action="click->submit">Go</button>'.freeze;
-_buf.to_s
+'<button class="primary" id="cta" data-action="click->submit">Go</button>'.freeze

--- a/test/snapshots/engine/action_view/tag_attributes_test/test_0004_tag.attributes_with_data_hash_containing_special_characters_3f3584236fd06e98fd5ad021e7e91202.txt
+++ b/test/snapshots/engine/action_view/tag_attributes_test/test_0004_tag.attributes_with_data_hash_containing_special_characters_3f3584236fd06e98fd5ad021e7e91202.txt
@@ -2,5 +2,4 @@
 source: "Engine::ActionView::TagAttributesTest#test_0004_tag.attributes with data hash containing special characters"
 input: "{source: \"<div <%= tag.attributes(data: { controller: \\\"hello\\\", action: \\\"click->hello#greet\\\" }) %>></div>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
 ---
-_buf = ::String.new; _buf << '<div data-controller="hello" data-action="click->hello#greet"></div>'.freeze;
-_buf.to_s
+'<div data-controller="hello" data-action="click->hello#greet"></div>'.freeze

--- a/test/snapshots/engine/action_view/tag_test/test_0001_tag.div_with_block_1e4cf98092717d44a90def6e7b1b7de4.txt
+++ b/test/snapshots/engine/action_view/tag_test/test_0001_tag.div_with_block_1e4cf98092717d44a90def6e7b1b7de4.txt
@@ -2,7 +2,6 @@
 source: "Engine::ActionView::TagTest#test_0001_tag.div with block"
 input: "{source: \"<%= tag.div do %>\\n  Content\\n<% end %>\\n\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
 ---
-_buf = ::String.new; _buf << '<div>
+'<div>
   Content
-</div>'.freeze;
-_buf.to_s
+</div>'.freeze

--- a/test/snapshots/engine/action_view/tag_test/test_0002_tag.div_with_content_as_argument_9d8b82ba7caf5d4a499645ff0cb433f9.txt
+++ b/test/snapshots/engine/action_view/tag_test/test_0002_tag.div_with_content_as_argument_9d8b82ba7caf5d4a499645ff0cb433f9.txt
@@ -2,5 +2,4 @@
 source: "Engine::ActionView::TagTest#test_0002_tag.div with content as argument"
 input: "{source: \"<%= tag.div \\\"Content\\\" %>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
 ---
-_buf = ::String.new; _buf << '<div>Content</div>'.freeze;
-_buf.to_s
+'<div>Content</div>'.freeze

--- a/test/snapshots/engine/action_view/tag_test/test_0003_tag.div_with_attributes_e4a1ad37c60fa65a57b2525b2e96b59a.txt
+++ b/test/snapshots/engine/action_view/tag_test/test_0003_tag.div_with_attributes_e4a1ad37c60fa65a57b2525b2e96b59a.txt
@@ -2,7 +2,6 @@
 source: "Engine::ActionView::TagTest#test_0003_tag.div with attributes"
 input: "{source: \"<%= tag.div class: \\\"content\\\" do %>\\n  Content\\n<% end %>\\n\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
 ---
-_buf = ::String.new; _buf << '<div class="content">
+'<div class="content">
   Content
-</div>'.freeze;
-_buf.to_s
+</div>'.freeze

--- a/test/snapshots/engine/action_view/tag_test/test_0004_tag.div_with_content_and_attributes_3965b88986c71678a27fa0a4b63c37f6.txt
+++ b/test/snapshots/engine/action_view/tag_test/test_0004_tag.div_with_content_and_attributes_3965b88986c71678a27fa0a4b63c37f6.txt
@@ -2,5 +2,4 @@
 source: "Engine::ActionView::TagTest#test_0004_tag.div with content and attributes"
 input: "{source: \"<%= tag.div \\\"Content\\\", class: \\\"content\\\" %>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
 ---
-_buf = ::String.new; _buf << '<div class="content">Content</div>'.freeze;
-_buf.to_s
+'<div class="content">Content</div>'.freeze

--- a/test/snapshots/engine/action_view/tag_test/test_0005_tag.div_with_data_attributes_in_hash_style_31405078615c005d947cb3fbc24eb842.txt
+++ b/test/snapshots/engine/action_view/tag_test/test_0005_tag.div_with_data_attributes_in_hash_style_31405078615c005d947cb3fbc24eb842.txt
@@ -2,5 +2,4 @@
 source: "Engine::ActionView::TagTest#test_0005_tag.div with data attributes in hash style"
 input: "{source: \"<%= tag.div data: { controller: \\\"content\\\" } %>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
 ---
-_buf = ::String.new; _buf << '<div data-controller="content"></div>'.freeze;
-_buf.to_s
+'<div data-controller="content"></div>'.freeze

--- a/test/snapshots/engine/action_view/tag_test/test_0006_tag.br_void_element_c4bbf61c35701d6e008c108f0500f549.txt
+++ b/test/snapshots/engine/action_view/tag_test/test_0006_tag.br_void_element_c4bbf61c35701d6e008c108f0500f549.txt
@@ -2,5 +2,4 @@
 source: "Engine::ActionView::TagTest#test_0006_tag.br void element"
 input: "{source: \"<%= tag.br %>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
 ---
-_buf = ::String.new; _buf << '<br>'.freeze;
-_buf.to_s
+'<br>'.freeze

--- a/test/snapshots/engine/action_view/tag_test/test_0007_tag.img_with_attributes_796c44066b29e10fdc5d52f4e3833c5a.txt
+++ b/test/snapshots/engine/action_view/tag_test/test_0007_tag.img_with_attributes_796c44066b29e10fdc5d52f4e3833c5a.txt
@@ -2,5 +2,4 @@
 source: "Engine::ActionView::TagTest#test_0007_tag.img with attributes"
 input: "{source: \"<%= tag.img src: \\\"image.png\\\", alt: \\\"Photo\\\" %>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
 ---
-_buf = ::String.new; _buf << '<img src="image.png" alt="Photo">'.freeze;
-_buf.to_s
+'<img src="image.png" alt="Photo">'.freeze

--- a/test/snapshots/engine/action_view/tag_test/test_0008_tag.input_with_boolean_attribute_c085c2167cf4bc24c27db170686c0c72.txt
+++ b/test/snapshots/engine/action_view/tag_test/test_0008_tag.input_with_boolean_attribute_c085c2167cf4bc24c27db170686c0c72.txt
@@ -2,5 +2,4 @@
 source: "Engine::ActionView::TagTest#test_0008_tag.input with boolean attribute"
 input: "{source: \"<%= tag.input type: \\\"text\\\", disabled: true %>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
 ---
-_buf = ::String.new; _buf << '<input type="text" disabled>'.freeze;
-_buf.to_s
+'<input type="text" disabled>'.freeze

--- a/test/snapshots/engine/action_view/tag_test/test_0009_tag.div_with_symbol_id_d5bb65992bc7b5b944c625a4af2a81c0.txt
+++ b/test/snapshots/engine/action_view/tag_test/test_0009_tag.div_with_symbol_id_d5bb65992bc7b5b944c625a4af2a81c0.txt
@@ -2,5 +2,4 @@
 source: "Engine::ActionView::TagTest#test_0009_tag.div with symbol id"
 input: "{source: \"<%= tag.div id: :main %>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
 ---
-_buf = ::String.new; _buf << '<div id="main"></div>'.freeze;
-_buf.to_s
+'<div id="main"></div>'.freeze

--- a/test/snapshots/engine/action_view/tag_test/test_0010_tag.div_with_aria_hash_3e90a0cdfd84c229123d7c12dec73e14.txt
+++ b/test/snapshots/engine/action_view/tag_test/test_0010_tag.div_with_aria_hash_3e90a0cdfd84c229123d7c12dec73e14.txt
@@ -2,5 +2,4 @@
 source: "Engine::ActionView::TagTest#test_0010_tag.div with aria hash"
 input: "{source: \"<%= tag.div aria: { label: \\\"hello\\\", hidden: true } %>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
 ---
-_buf = ::String.new; _buf << '<div aria-label="hello" aria-hidden="true"></div>'.freeze;
-_buf.to_s
+'<div aria-label="hello" aria-hidden="true"></div>'.freeze

--- a/test/snapshots/engine/action_view/tag_test/test_0011_tag.section_with_array_class_0ef8a9fd5bf8870f5b6da0d9e1581f25.txt
+++ b/test/snapshots/engine/action_view/tag_test/test_0011_tag.section_with_array_class_0ef8a9fd5bf8870f5b6da0d9e1581f25.txt
@@ -2,5 +2,4 @@
 source: "Engine::ActionView::TagTest#test_0011_tag.section with array class"
 input: "{source: \"<%= tag.section class: [\\\"kitties\\\", \\\"puppies\\\"] %>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
 ---
-_buf = ::String.new; _buf << '<section class="kitties puppies"></section>'.freeze;
-_buf.to_s
+'<section class="kitties puppies"></section>'.freeze

--- a/test/snapshots/engine/action_view/tag_test/test_0012_tag.section_with_%w()_class_2d58c258e7157335c32c1784c225aff5.txt
+++ b/test/snapshots/engine/action_view/tag_test/test_0012_tag.section_with_%w()_class_2d58c258e7157335c32c1784c225aff5.txt
@@ -2,5 +2,4 @@
 source: "Engine::ActionView::TagTest#test_0012_tag.section with %w() class"
 input: "{source: \"<%= tag.section class: %w( kitties puppies ) %>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
 ---
-_buf = ::String.new; _buf << '<section class="kitties puppies"></section>'.freeze;
-_buf.to_s
+'<section class="kitties puppies"></section>'.freeze

--- a/test/snapshots/engine/action_view/tag_test/test_0013_tag.div_with_integer_data_attribute_3f7be695dbd3dbb48308c11da2b5d30b.txt
+++ b/test/snapshots/engine/action_view/tag_test/test_0013_tag.div_with_integer_data_attribute_3f7be695dbd3dbb48308c11da2b5d30b.txt
@@ -2,5 +2,4 @@
 source: "Engine::ActionView::TagTest#test_0013_tag.div with integer data attribute"
 input: "{source: \"<%= tag.div data: { count: 42 } %>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
 ---
-_buf = ::String.new; _buf << '<div data-count="42"></div>'.freeze;
-_buf.to_s
+'<div data-count="42"></div>'.freeze

--- a/test/snapshots/engine/action_view/tag_test/test_0014_tag.div_with_string_style_4f069d49c12e013873ad780b6f24c076.txt
+++ b/test/snapshots/engine/action_view/tag_test/test_0014_tag.div_with_string_style_4f069d49c12e013873ad780b6f24c076.txt
@@ -2,5 +2,4 @@
 source: "Engine::ActionView::TagTest#test_0014_tag.div with string style"
 input: "{source: \"<%= tag.div style: \\\"color: red\\\" %>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
 ---
-_buf = ::String.new; _buf << '<div style="color: red"></div>'.freeze;
-_buf.to_s
+'<div style="color: red"></div>'.freeze

--- a/test/snapshots/engine/action_view/tag_test/test_0015_tag.p_with_content_212c671df358fd94e5aaa2b70e2010af.txt
+++ b/test/snapshots/engine/action_view/tag_test/test_0015_tag.p_with_content_212c671df358fd94e5aaa2b70e2010af.txt
@@ -2,5 +2,4 @@
 source: "Engine::ActionView::TagTest#test_0015_tag.p with content"
 input: "{source: \"<%= tag.p \\\"Hello\\\" %>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
 ---
-_buf = ::String.new; _buf << '<p>Hello</p>'.freeze;
-_buf.to_s
+'<p>Hello</p>'.freeze

--- a/test/snapshots/engine/action_view/tag_test/test_0016_tag.div_with_escape_false_a9091d607d73fdb6bcecdda2bcfefc32.txt
+++ b/test/snapshots/engine/action_view/tag_test/test_0016_tag.div_with_escape_false_a9091d607d73fdb6bcecdda2bcfefc32.txt
@@ -2,5 +2,4 @@
 source: "Engine::ActionView::TagTest#test_0016_tag.div with escape false"
 input: "{source: \"<%= tag.img src: \\\"open & shut.png\\\", escape: false %>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
 ---
-_buf = ::String.new; _buf << '<img src="open & shut.png">'.freeze;
-_buf.to_s
+'<img src="open & shut.png">'.freeze

--- a/test/snapshots/engine/action_view/tag_test/test_0017_tag.details_with_inline_block_2efe6543c00f623b7d9ce5275e0ebd01.txt
+++ b/test/snapshots/engine/action_view/tag_test/test_0017_tag.details_with_inline_block_2efe6543c00f623b7d9ce5275e0ebd01.txt
@@ -2,5 +2,4 @@
 source: "Engine::ActionView::TagTest#test_0017_tag.details with inline block"
 input: "{source: \"<%= tag.details { \\\"Some content\\\" } %>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
 ---
-_buf = ::String.new; _buf << '<details>Some content</details>'.freeze;
-_buf.to_s
+'<details>Some content</details>'.freeze

--- a/test/snapshots/engine/action_view/tag_test/test_0018_tag.div_with_inline_block_and_attributes_9098f63d1d7fa629e81e5af2e74f2e32.txt
+++ b/test/snapshots/engine/action_view/tag_test/test_0018_tag.div_with_inline_block_and_attributes_9098f63d1d7fa629e81e5af2e74f2e32.txt
@@ -2,5 +2,4 @@
 source: "Engine::ActionView::TagTest#test_0018_tag.div with inline block and attributes"
 input: "{source: \"<%= tag.div(class: \\\"container\\\") { \\\"Hello\\\" } %>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
 ---
-_buf = ::String.new; _buf << '<div class="container">Hello</div>'.freeze;
-_buf.to_s
+'<div class="container">Hello</div>'.freeze

--- a/test/snapshots/engine/action_view/tag_test/test_0022_nested_tag_helpers_are_also_converted_e2a5cef70cd215d8d749ce59e3c8d60f.txt
+++ b/test/snapshots/engine/action_view/tag_test/test_0022_nested_tag_helpers_are_also_converted_e2a5cef70cd215d8d749ce59e3c8d60f.txt
@@ -2,7 +2,6 @@
 source: "Engine::ActionView::TagTest#test_0022_nested tag helpers are also converted"
 input: "{source: \"<%= tag.div class: \\\"outer\\\" do %>\\n  <%= tag.span \\\"Inner\\\" %>\\n<% end %>\\n\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
 ---
-_buf = ::String.new; _buf << '<div class="outer">
+'<div class="outer">
   <span>Inner</span>
-</div>'.freeze;
-_buf.to_s
+</div>'.freeze

--- a/test/snapshots/engine/action_view/tag_test/test_0023_tag.div_with_multiple_attributes_555ac86704098220cb70de01bca79ee4.txt
+++ b/test/snapshots/engine/action_view/tag_test/test_0023_tag.div_with_multiple_attributes_555ac86704098220cb70de01bca79ee4.txt
@@ -2,7 +2,6 @@
 source: "Engine::ActionView::TagTest#test_0023_tag.div with multiple attributes"
 input: "{source: \"<%= tag.div class: \\\"content\\\", id: \\\"main\\\" do %>\\n  Content\\n<% end %>\\n\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
 ---
-_buf = ::String.new; _buf << '<div class="content" id="main">
+'<div class="content" id="main">
   Content
-</div>'.freeze;
-_buf.to_s
+</div>'.freeze

--- a/test/snapshots/engine/action_view/tag_test/test_0025_tag.div_with_data_attribute_ruby_literal_value_89ed07af870d572a8f10ee75ce14a4a3.txt
+++ b/test/snapshots/engine/action_view/tag_test/test_0025_tag.div_with_data_attribute_ruby_literal_value_89ed07af870d572a8f10ee75ce14a4a3.txt
@@ -2,5 +2,4 @@
 source: "Engine::ActionView::TagTest#test_0025_tag.div with data attribute ruby literal value"
 input: "{source: \"<%= tag.div data: { controller: \\\"content\\\", user_id: 123 } do %>Content<% end %>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
 ---
-_buf = ::String.new; _buf << '<div data-controller="content" data-user-id="123">Content</div>'.freeze;
-_buf.to_s
+'<div data-controller="content" data-user-id="123">Content</div>'.freeze

--- a/test/snapshots/engine/action_view/tag_test/test_0026_tag.hr_void_element_with_attributes_88221ffb67290d2e66eb3633dc8e014c.txt
+++ b/test/snapshots/engine/action_view/tag_test/test_0026_tag.hr_void_element_with_attributes_88221ffb67290d2e66eb3633dc8e014c.txt
@@ -2,5 +2,4 @@
 source: "Engine::ActionView::TagTest#test_0026_tag.hr void element with attributes"
 input: "{source: \"<%= tag.hr class: \\\"divider\\\" %>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
 ---
-_buf = ::String.new; _buf << '<hr class="divider">'.freeze;
-_buf.to_s
+'<hr class="divider">'.freeze

--- a/test/snapshots/engine/action_view/tag_test/test_0032_tag.p_with_HTML_entity_in_content_eae68ff84ac46ec65e62d34fe8205310.txt
+++ b/test/snapshots/engine/action_view/tag_test/test_0032_tag.p_with_HTML_entity_in_content_eae68ff84ac46ec65e62d34fe8205310.txt
@@ -2,5 +2,4 @@
 source: "Engine::ActionView::TagTest#test_0032_tag.p with HTML entity in content"
 input: "{source: \"<%= tag.p \\\"&copy; 2024 Example Corp\\\" %>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
 ---
-_buf = ::String.new; _buf << '<p>&copy; 2024 Example Corp</p>'.freeze;
-_buf.to_s
+'<p>&copy; 2024 Example Corp</p>'.freeze

--- a/test/snapshots/engine/action_view/tag_test/test_0037_tag.div_with_empty_string_class_efc1d560d43ac21c9e2e4309fe994fad.txt
+++ b/test/snapshots/engine/action_view/tag_test/test_0037_tag.div_with_empty_string_class_efc1d560d43ac21c9e2e4309fe994fad.txt
@@ -2,5 +2,4 @@
 source: "Engine::ActionView::TagTest#test_0037_tag.div with empty string class"
 input: "{source: \"<%= tag.div class: \\\"\\\" %>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
 ---
-_buf = ::String.new; _buf << '<div class=""></div>'.freeze;
-_buf.to_s
+'<div class=""></div>'.freeze

--- a/test/snapshots/engine/action_view/tag_test/test_0038_tag.div_with_false_boolean_attribute_7cf365b9965c2631031b96cb257faced.txt
+++ b/test/snapshots/engine/action_view/tag_test/test_0038_tag.div_with_false_boolean_attribute_7cf365b9965c2631031b96cb257faced.txt
@@ -2,5 +2,4 @@
 source: "Engine::ActionView::TagTest#test_0038_tag.div with false boolean attribute"
 input: "{source: \"<%= tag.div disabled: false %>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
 ---
-_buf = ::String.new; _buf << '<div></div>'.freeze;
-_buf.to_s
+'<div></div>'.freeze

--- a/test/snapshots/engine/action_view/turbo_frame_tag_test/test_0001_turbo_frame_tag_with_block_57791926a0d41a8cf02da1c74b138d7b.txt
+++ b/test/snapshots/engine/action_view/turbo_frame_tag_test/test_0001_turbo_frame_tag_with_block_57791926a0d41a8cf02da1c74b138d7b.txt
@@ -2,7 +2,6 @@
 source: "Engine::ActionView::TurboFrameTagTest#test_0001_turbo_frame_tag with block"
 input: "{source: \"<%= turbo_frame_tag \\\"tray\\\" do %>\\n  Content\\n<% end %>\\n\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
 ---
-_buf = ::String.new; _buf << '<turbo-frame id="tray">
+'<turbo-frame id="tray">
   Content
-</turbo-frame>'.freeze;
-_buf.to_s
+</turbo-frame>'.freeze

--- a/test/snapshots/engine/action_view/turbo_frame_tag_test/test_0002_turbo_frame_tag_without_block_af69a9aeb7a63ac7f56c57abb455a0a4.txt
+++ b/test/snapshots/engine/action_view/turbo_frame_tag_test/test_0002_turbo_frame_tag_without_block_af69a9aeb7a63ac7f56c57abb455a0a4.txt
@@ -2,5 +2,4 @@
 source: "Engine::ActionView::TurboFrameTagTest#test_0002_turbo_frame_tag without block"
 input: "{source: \"<%= turbo_frame_tag \\\"tray\\\" %>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
 ---
-_buf = ::String.new; _buf << '<turbo-frame id="tray"></turbo-frame>'.freeze;
-_buf.to_s
+'<turbo-frame id="tray"></turbo-frame>'.freeze

--- a/test/snapshots/engine/action_view/turbo_frame_tag_test/test_0003_turbo_frame_tag_with_src_36e81f761fc6d36afc19c1d7955f2e21.txt
+++ b/test/snapshots/engine/action_view/turbo_frame_tag_test/test_0003_turbo_frame_tag_with_src_36e81f761fc6d36afc19c1d7955f2e21.txt
@@ -2,5 +2,4 @@
 source: "Engine::ActionView::TurboFrameTagTest#test_0003_turbo_frame_tag with src"
 input: "{source: \"<%= turbo_frame_tag \\\"tray\\\", src: \\\"/path\\\" %>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
 ---
-_buf = ::String.new; _buf << '<turbo-frame id="tray" src="/path"></turbo-frame>'.freeze;
-_buf.to_s
+'<turbo-frame id="tray" src="/path"></turbo-frame>'.freeze

--- a/test/snapshots/engine/action_view/turbo_frame_tag_test/test_0004_turbo_frame_tag_with_src_and_target_c2411cae15d25bec3b826e870008bab6.txt
+++ b/test/snapshots/engine/action_view/turbo_frame_tag_test/test_0004_turbo_frame_tag_with_src_and_target_c2411cae15d25bec3b826e870008bab6.txt
@@ -2,5 +2,4 @@
 source: "Engine::ActionView::TurboFrameTagTest#test_0004_turbo_frame_tag with src and target"
 input: "{source: \"<%= turbo_frame_tag \\\"tray\\\", src: \\\"/path\\\", target: \\\"_top\\\" %>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
 ---
-_buf = ::String.new; _buf << '<turbo-frame id="tray" src="/path" target="_top"></turbo-frame>'.freeze;
-_buf.to_s
+'<turbo-frame id="tray" src="/path" target="_top"></turbo-frame>'.freeze

--- a/test/snapshots/engine/action_view/turbo_frame_tag_test/test_0005_turbo_frame_tag_with_loading_lazy_5d57db5433b9070953b7ddae83d6a04f.txt
+++ b/test/snapshots/engine/action_view/turbo_frame_tag_test/test_0005_turbo_frame_tag_with_loading_lazy_5d57db5433b9070953b7ddae83d6a04f.txt
@@ -2,5 +2,4 @@
 source: "Engine::ActionView::TurboFrameTagTest#test_0005_turbo_frame_tag with loading lazy"
 input: "{source: \"<%= turbo_frame_tag \\\"tray\\\", src: \\\"/path\\\", loading: \\\"lazy\\\" %>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
 ---
-_buf = ::String.new; _buf << '<turbo-frame loading="lazy" id="tray" src="/path"></turbo-frame>'.freeze;
-_buf.to_s
+'<turbo-frame loading="lazy" id="tray" src="/path"></turbo-frame>'.freeze

--- a/test/snapshots/engine/action_view/turbo_frame_tag_test/test_0006_turbo_frame_tag_with_class_and_block_e1da04ee26d521cc0bb3d75612a06db6.txt
+++ b/test/snapshots/engine/action_view/turbo_frame_tag_test/test_0006_turbo_frame_tag_with_class_and_block_e1da04ee26d521cc0bb3d75612a06db6.txt
@@ -2,7 +2,6 @@
 source: "Engine::ActionView::TurboFrameTagTest#test_0006_turbo_frame_tag with class and block"
 input: "{source: \"<%= turbo_frame_tag \\\"tray\\\", class: \\\"frame\\\" do %>\\n  Content\\n<% end %>\\n\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
 ---
-_buf = ::String.new; _buf << '<turbo-frame class="frame" id="tray">
+'<turbo-frame class="frame" id="tray">
   Content
-</turbo-frame>'.freeze;
-_buf.to_s
+</turbo-frame>'.freeze

--- a/test/snapshots/engine/action_view/turbo_frame_tag_test/test_0008_turbo_frame_tag_with_data_attributes_78ca5700aaf3b6d5e898de8025be63f7.txt
+++ b/test/snapshots/engine/action_view/turbo_frame_tag_test/test_0008_turbo_frame_tag_with_data_attributes_78ca5700aaf3b6d5e898de8025be63f7.txt
@@ -2,5 +2,4 @@
 source: "Engine::ActionView::TurboFrameTagTest#test_0008_turbo_frame_tag with data attributes"
 input: "{source: \"<%= turbo_frame_tag \\\"tray\\\", data: { controller: \\\"frame\\\" } do %>Content<% end %>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
 ---
-_buf = ::String.new; _buf << '<turbo-frame data-controller="frame" id="tray">Content</turbo-frame>'.freeze;
-_buf.to_s
+'<turbo-frame data-controller="frame" id="tray">Content</turbo-frame>'.freeze

--- a/test/snapshots/engine/engine_erubi_compat_test/test_0007_handles_double_equals_for_inverse_escaping_031ede7b0d3f38a431bb4e2009e597d2.txt
+++ b/test/snapshots/engine/engine_erubi_compat_test/test_0007_handles_double_equals_for_inverse_escaping_031ede7b0d3f38a431bb4e2009e597d2.txt
@@ -2,5 +2,5 @@
 source: "Engine::EngineErubiCompatTest#test_0007_handles double equals for inverse escaping"
 input: "{source: \"<%== content %>\", options: {escape: true}}"
 ---
-__herb = ::Herb::Engine; _buf = ::String.new; _buf << (content).to_s;
+_buf = ::String.new; _buf << (content).to_s;
 _buf.to_s

--- a/test/snapshots/engine/engine_test/test_0029_compilation_with_optimize_for_tag_helper_71a29f3073997a752b91acb9cd96eaaa.txt
+++ b/test/snapshots/engine/engine_test/test_0029_compilation_with_optimize_for_tag_helper_71a29f3073997a752b91acb9cd96eaaa.txt
@@ -2,5 +2,4 @@
 source: "Engine::EngineTest#test_0029_compilation with optimize for tag helper"
 input: "{source: \"<%= tag.div class: \\\"container\\\" do %>Content<% end %>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
 ---
-_buf = ::String.new; _buf << '<div class="container">Content</div>'.freeze;
-_buf.to_s
+'<div class="container">Content</div>'.freeze

--- a/test/snapshots/engine/engine_test/test_0030_compilation_with_optimize_for_void_element_c4bbf61c35701d6e008c108f0500f549.txt
+++ b/test/snapshots/engine/engine_test/test_0030_compilation_with_optimize_for_void_element_c4bbf61c35701d6e008c108f0500f549.txt
@@ -2,5 +2,4 @@
 source: "Engine::EngineTest#test_0030_compilation with optimize for void element"
 input: "{source: \"<%= tag.br %>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
 ---
-_buf = ::String.new; _buf << '<br>'.freeze;
-_buf.to_s
+'<br>'.freeze

--- a/test/snapshots/engine/engine_test/test_0031_compilation_with_optimize_for_tag_with_data_attributes_5029b65e1f112cd1b0f54d2e1bf1e22d.txt
+++ b/test/snapshots/engine/engine_test/test_0031_compilation_with_optimize_for_tag_with_data_attributes_5029b65e1f112cd1b0f54d2e1bf1e22d.txt
@@ -2,5 +2,4 @@
 source: "Engine::EngineTest#test_0031_compilation with optimize for tag with data attributes"
 input: "{source: \"<%= tag.div data: { controller: \\\"content\\\", count: 42 } %>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
 ---
-_buf = ::String.new; _buf << '<div data-controller="content" data-count="42"></div>'.freeze;
-_buf.to_s
+'<div data-controller="content" data-count="42"></div>'.freeze

--- a/test/snapshots/engine/engine_test/test_0032_compilation_with_optimize_for_nested_tag_helpers_e2a5cef70cd215d8d749ce59e3c8d60f.txt
+++ b/test/snapshots/engine/engine_test/test_0032_compilation_with_optimize_for_nested_tag_helpers_e2a5cef70cd215d8d749ce59e3c8d60f.txt
@@ -2,7 +2,6 @@
 source: "Engine::EngineTest#test_0032_compilation with optimize for nested tag helpers"
 input: "{source: \"<%= tag.div class: \\\"outer\\\" do %>\\n  <%= tag.span \\\"Inner\\\" %>\\n<% end %>\\n\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
 ---
-_buf = ::String.new; _buf << '<div class="outer">
+'<div class="outer">
   <span>Inner</span>
-</div>'.freeze;
-_buf.to_s
+</div>'.freeze

--- a/test/snapshots/engine/engine_test/test_0033_compilation_with_optimize_for_link_to_7a6ebc9eb0d04ae873c524216c223328.txt
+++ b/test/snapshots/engine/engine_test/test_0033_compilation_with_optimize_for_link_to_7a6ebc9eb0d04ae873c524216c223328.txt
@@ -2,5 +2,4 @@
 source: "Engine::EngineTest#test_0033_compilation with optimize for link_to"
 input: "{source: \"<%= link_to \\\"Home\\\", \\\"/\\\" %>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
 ---
-_buf = ::String.new; _buf << '<a href="/">Home</a>'.freeze;
-_buf.to_s
+'<a href="/">Home</a>'.freeze

--- a/test/snapshots/engine/engine_test/test_0035_compilation_with_optimize_for_content_tag_3e84abdce148cd6777f2e6570150c64d.txt
+++ b/test/snapshots/engine/engine_test/test_0035_compilation_with_optimize_for_content_tag_3e84abdce148cd6777f2e6570150c64d.txt
@@ -2,5 +2,4 @@
 source: "Engine::EngineTest#test_0035_compilation with optimize for content_tag"
 input: "{source: \"<%= content_tag :div, \\\"Content\\\", class: \\\"box\\\" %>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
 ---
-_buf = ::String.new; _buf << '<div class="box">Content</div>'.freeze;
-_buf.to_s
+'<div class="box">Content</div>'.freeze

--- a/test/snapshots/engine/erb_tag_variations_test/test_0004_lt%==_expression_%gt_with_escape_e6ca62f68a997f99f72526fc2a1cbdb2.txt
+++ b/test/snapshots/engine/erb_tag_variations_test/test_0004_lt%==_expression_%gt_with_escape_e6ca62f68a997f99f72526fc2a1cbdb2.txt
@@ -2,5 +2,5 @@
 source: "Engine::ERBTagVariationsTest#test_0004_<%== expression %> with escape"
 input: "{source: \"<%== value %>\", options: {escape: true}}"
 ---
-__herb = ::Herb::Engine; _buf = ::String.new; _buf << (value).to_s;
+_buf = ::String.new; _buf << (value).to_s;
 _buf.to_s

--- a/test/snapshots/engine/escape_test/attributes/test_0005_escape_true_and_custom_attrfunc_8f14421c2d93dcbfc8c32ebcd79e356c.txt
+++ b/test/snapshots/engine/escape_test/attributes/test_0005_escape_true_and_custom_attrfunc_8f14421c2d93dcbfc8c32ebcd79e356c.txt
@@ -2,5 +2,5 @@
 source: "Engine::EscapeTest::attributes#test_0005_escape: true and custom attrfunc"
 input: "{source: \"<div class=\\\"<%= value %>\\\"></div>\", options: {escape: true, attrfunc: \"CustomEscape.attribute\"}}"
 ---
-__herb = ::Herb::Engine; _buf = ::String.new; _buf << '<div class="'.freeze; _buf << CustomEscape.attribute((value)); _buf << '"></div>'.freeze;
+_buf = ::String.new; _buf << '<div class="'.freeze; _buf << CustomEscape.attribute((value)); _buf << '"></div>'.freeze;
 _buf.to_s

--- a/test/snapshots/engine/escape_test/attributes/test_0006_escape_true_and_empty_attrfunc_b5195ed0791ce8b7fb7e9957385d0888.txt
+++ b/test/snapshots/engine/escape_test/attributes/test_0006_escape_true_and_empty_attrfunc_b5195ed0791ce8b7fb7e9957385d0888.txt
@@ -2,5 +2,5 @@
 source: "Engine::EscapeTest::attributes#test_0006_escape: true and empty attrfunc"
 input: "{source: \"<div class=\\\"<%= value %>\\\"></div>\", options: {escape: true, attrfunc: \"\"}}"
 ---
-__herb = ::Herb::Engine; _buf = ::String.new; _buf << '<div class="'.freeze; _buf << ((value)); _buf << '"></div>'.freeze;
+_buf = ::String.new; _buf << '<div class="'.freeze; _buf << ((value)); _buf << '"></div>'.freeze;
 _buf.to_s

--- a/test/snapshots/engine/escape_test/escape_erb_raw_output_tag/test_0002_escape_true_a71d7635b10408058ae5f6f8337d1e0c.txt
+++ b/test/snapshots/engine/escape_test/escape_erb_raw_output_tag/test_0002_escape_true_a71d7635b10408058ae5f6f8337d1e0c.txt
@@ -2,5 +2,5 @@
 source: "Engine::EscapeTest::escape ERB raw output tag#test_0002_escape: true"
 input: "{source: \"<h1><%== value %></h1>\", options: {escape: true}}"
 ---
-__herb = ::Herb::Engine; _buf = ::String.new; _buf << '<h1>'.freeze; _buf << (value).to_s; _buf << '</h1>'.freeze;
+_buf = ::String.new; _buf << '<h1>'.freeze; _buf << (value).to_s; _buf << '</h1>'.freeze;
 _buf.to_s

--- a/test/snapshots/engine/escape_test/javascript/test_0005_escape_true_and_custom_jsfunc_efcb50766c5a8f17b97cfd5ad4ca67cd.txt
+++ b/test/snapshots/engine/escape_test/javascript/test_0005_escape_true_and_custom_jsfunc_efcb50766c5a8f17b97cfd5ad4ca67cd.txt
@@ -2,5 +2,5 @@
 source: "Engine::EscapeTest::javascript#test_0005_escape: true and custom jsfunc"
 input: "{source: \"<script><%= value %></script>\", options: {escape: true, jsfunc: \"CustomEscape.js\"}}"
 ---
-__herb = ::Herb::Engine; _buf = ::String.new; _buf << '<script>'.freeze; _buf << CustomEscape.js((value)); _buf << '</script>'.freeze;
+_buf = ::String.new; _buf << '<script>'.freeze; _buf << CustomEscape.js((value)); _buf << '</script>'.freeze;
 _buf.to_s

--- a/test/snapshots/engine/escape_test/javascript/test_0006_escape_true_and_empty_jsfunc_96ece398c40750f59650d0c35f953dd9.txt
+++ b/test/snapshots/engine/escape_test/javascript/test_0006_escape_true_and_empty_jsfunc_96ece398c40750f59650d0c35f953dd9.txt
@@ -2,5 +2,5 @@
 source: "Engine::EscapeTest::javascript#test_0006_escape: true and empty jsfunc"
 input: "{source: \"<script><%= value %></script>\", options: {escape: true, jsfunc: \"\"}}"
 ---
-__herb = ::Herb::Engine; _buf = ::String.new; _buf << '<script>'.freeze; _buf << ((value)); _buf << '</script>'.freeze;
+_buf = ::String.new; _buf << '<script>'.freeze; _buf << ((value)); _buf << '</script>'.freeze;
 _buf.to_s

--- a/test/snapshots/engine/escape_test/style/test_0005_escape_true_and_custom_cssfunc_cd5298d4aac80c862e718692bdf83eab.txt
+++ b/test/snapshots/engine/escape_test/style/test_0005_escape_true_and_custom_cssfunc_cd5298d4aac80c862e718692bdf83eab.txt
@@ -2,5 +2,5 @@
 source: "Engine::EscapeTest::style#test_0005_escape: true and custom cssfunc"
 input: "{source: \"<style><%= value %></style>\", options: {escape: true, cssfunc: \"CustomEscape.css\"}}"
 ---
-__herb = ::Herb::Engine; _buf = ::String.new; _buf << '<style>'.freeze; _buf << CustomEscape.css((value)); _buf << '</style>'.freeze;
+_buf = ::String.new; _buf << '<style>'.freeze; _buf << CustomEscape.css((value)); _buf << '</style>'.freeze;
 _buf.to_s

--- a/test/snapshots/engine/escape_test/style/test_0006_escape_true_and_empty_cssfunc_4d1ec0837eb25b77cd79886db2c4dee6.txt
+++ b/test/snapshots/engine/escape_test/style/test_0006_escape_true_and_empty_cssfunc_4d1ec0837eb25b77cd79886db2c4dee6.txt
@@ -2,5 +2,5 @@
 source: "Engine::EscapeTest::style#test_0006_escape: true and empty cssfunc"
 input: "{source: \"<style><%= value %></style>\", options: {escape: true, cssfunc: \"\"}}"
 ---
-__herb = ::Herb::Engine; _buf = ::String.new; _buf << '<style>'.freeze; _buf << ((value)); _buf << '</style>'.freeze;
+_buf = ::String.new; _buf << '<style>'.freeze; _buf << ((value)); _buf << '</style>'.freeze;
 _buf.to_s

--- a/test/snapshots/engine/optimized_helpers_test/what_it_compiles_in/test_0002_compiles_nothing_in_unless_asked_f6f4cd4ff45f693e8671a4928b9a1d3a.txt
+++ b/test/snapshots/engine/optimized_helpers_test/what_it_compiles_in/test_0002_compiles_nothing_in_unless_asked_f6f4cd4ff45f693e8671a4928b9a1d3a.txt
@@ -2,5 +2,4 @@
 source: "Engine::OptimizedHelpersTest::what it compiles in#test_0002_compiles nothing in unless asked"
 input: "{source: \"<%= tag.div do %>Content<% end %>\", options: {filename: \"app/views/posts/index.html.erb\", visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
 ---
-_buf = ::String.new; _buf << '<div>Content</div>'.freeze;
-_buf.to_s
+'<div>Content</div>'.freeze

--- a/test/snapshots/engine/optimized_helpers_test/what_it_compiles_in/test_0003_compiles_nothing_in_when_the_template_optimized_no_helpers_d062bf6988e3b7f18619cc03a0531099.txt
+++ b/test/snapshots/engine/optimized_helpers_test/what_it_compiles_in/test_0003_compiles_nothing_in_when_the_template_optimized_no_helpers_d062bf6988e3b7f18619cc03a0531099.txt
@@ -2,5 +2,4 @@
 source: "Engine::OptimizedHelpersTest::what it compiles in#test_0003_compiles nothing in when the template optimized no helpers"
 input: "{source: \"<div>Written as HTML</div>\", options: {filename: \"app/views/posts/index.html.erb\", visitors: [#<Herb::Engine::OptimizeVisitor verify=true>]}}"
 ---
-_buf = ::String.new; _buf << '<div>Written as HTML</div>'.freeze;
-_buf.to_s
+'<div>Written as HTML</div>'.freeze

--- a/test/snapshots/engine/static_template_optimization_test/test_0001_an_HTML-only_template_compiles_to_a_bare_string_literal_1205d198bd76270bd761c449a5d23e26.txt
+++ b/test/snapshots/engine/static_template_optimization_test/test_0001_an_HTML-only_template_compiles_to_a_bare_string_literal_1205d198bd76270bd761c449a5d23e26.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::StaticTemplateOptimizationTest#test_0001_an HTML-only template compiles to a bare string literal"
+input: "{source: \"<div class=\\\"a\\\">Hello</div>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
+---
+'<div class="a">Hello</div>'.freeze


### PR DESCRIPTION
This pull request trims two things a compiled template never uses, the string buffer it builds up and the alias it holds the engine under.

#### A template that carries no Ruby

Every template compiles to a buffer, so a page written as plain HTML pays for `::String.new`, an append, and `to_s` to arrive at a string that was already known at compile time. With `OptimizeVisitor` in the stack it now compiles to that string alone.

```ruby
Herb::Engine.new("<div>Hello</div>", visitors: [Herb::Engine::OptimizeVisitor.new]).src
#=> "'<div>Hello</div>'.freeze"
```

A template written as HTML qualifies on its own, and so does one left fully static once the visitor resolved its helpers to markup, so `<%= tag.br %>` compiles to `'<br>'`.

The visitor owns the decision. The engine asks any visitor answering `compile_static_body` for the body to emit, and `OptimizeVisitor` answers with the literal when the compiler reports that every token it emitted is text. Staticness is read off those tokens because they are what the template actually emits. An ERB comment is a node in the tree that outputs nothing, so a visitor counting ERB nodes would call that template dynamic and stop collapsing it.

#### What holds the buffer

The engine keeps the buffer whenever the caller drives its assembly through `preamble`, `postamble`, `bufval`, or `ensure`, since a body replacing the buffer would drop what the caller asked for.

It also keeps it whenever a visitor recorded a diagnostic. The call that carries a warning to the session and the raise that reports a fatal one both live on that path, so a template collapsing past it would render with nothing said about it.

#### An alias nothing calls

`__herb = ::Herb::Engine;` was written for every `escape: true` template, including the ones with nothing to escape. A template that only branches, one that outputs with `<%==`, and one given a custom `attrfunc`, `jsfunc`, or `cssfunc` each assigned it and never called it.

The engine now records where the alias would go, compiles the body, and writes the alias only when that body refers to it.

Closes #651
Closes #652