### PR TITLE
Client: Write what the page owns now, and debounce only the request

### DIFF
--- a/javascript/packages/client/src/state.ts
+++ b/javascript/packages/client/src/state.ts
@@ -59,6 +59,8 @@ export class SlotState {
   readonly #options: Required<Omit<StateOptions, "transport">> & { transport: StateTransport }
 
   #pending = new Map<string, string>()
+  #restores: Restore[] = []
+  #previous = new Map<string, string | undefined>()
   #waiting: ((report: StateReport) => void)[] = []
   #timer: ReturnType<typeof setTimeout> | null = null
   #controller: AbortController | null = null
@@ -152,11 +154,18 @@ export class SlotState {
 
   set(key: string | Record<string, string>, value?: string): Promise<StateReport> {
     const changes = typeof key === "string" ? { [key]: value ?? "" } : key
+    const changed = Object.keys(changes)
 
     for (const [name, next] of Object.entries(changes)) {
       this.#pending.set(name, next)
       this.#sequence.set(name, (this.#sequence.get(name) ?? 0) + 1)
+
+      if (!this.#previous.has(name)) this.#previous.set(name, this.#values.get(name))
+
+      this.#values.set(name, next)
     }
+
+    this.#restores.push(...this.#optimistic(changed))
 
     if (this.#options.debounce <= 0) return this.#flush()
 
@@ -173,18 +182,17 @@ export class SlotState {
 
   async #flush(): Promise<StateReport> {
     const changes = this.#pending
+    const restores = this.#restores
+    const previous = this.#previous
 
     this.#pending = new Map()
+    this.#restores = []
+    this.#previous = new Map()
 
     if (changes.size === 0) return this.#settle(IDLE)
 
     const changed = [...changes.keys()]
     const taken = new Map(changed.map((name) => [name, this.#sequence.get(name) ?? 0]))
-    const previous = new Map(changed.map((name) => [name, this.#values.get(name)]))
-
-    for (const [name, next] of changes) this.#values.set(name, next)
-
-    const restores = this.#optimistic(changed)
 
     this.#controller?.abort()
     this.#controller = new AbortController()

--- a/javascript/packages/client/test/state.test.ts
+++ b/javascript/packages/client/test/state.test.ts
@@ -175,6 +175,58 @@ describe("writing before the server answers", () => {
   })
 })
 
+describe("a page that waits for the server", () => {
+  beforeEach(() => {
+    document.body.innerHTML = ""
+    window.history.replaceState({}, "", "/posts")
+  })
+
+  test("writes what it can before the debounce, not after it", async () => {
+    const slots = mounted(PAGE + DEPENDENCIES)
+    const state = new SlotState(slots, { debounce: 50, transport: async () => null })
+
+    state.adopt()
+
+    const pending = state.set("name", "Ada")
+
+    expect(text(0, slots)).toBe("Ada")
+
+    await pending
+  })
+
+  test("counts every write it made across a debounced burst" , async () => {
+    const slots = mounted(PAGE + DEPENDENCIES)
+    const state = new SlotState(slots, { debounce: 50, transport: async () => null })
+
+    state.adopt()
+
+    state.set("name", "A")
+    const report = await state.set("name", "Ada")
+
+    expect(text(0, slots)).toBe("Ada")
+    expect(report.written).toBeGreaterThan(0)
+  })
+
+  test("puts back the value the page had before the burst, not the one mid-burst", async () => {
+    const slots = mounted(PAGE + DEPENDENCIES)
+    const state = new SlotState(slots, {
+      debounce: 20,
+      transport: async () => {
+        throw new Error("offline")
+      },
+    })
+
+    state.adopt()
+
+    state.set("name", "A")
+    const report = await state.set("name", "Ada")
+
+    expect(report.failed).toBe(true)
+    expect(text(0, slots)).toBe("Marco")
+    expect(state.get("name")).toBeUndefined()
+  })
+})
+
 describe("reconciling with the server", () => {
   beforeEach(() => {
     document.body.innerHTML = ""


### PR DESCRIPTION
This pull request stops the debounce from delaying the one thing that does not need to wait.

A slot whose expression is the state itself is written by copying, because the client already holds the value. That write was being scheduled along with the request, so a page typing into a search box saw nothing for the length of the debounce. A slot the client owns was as slow as one only the server can answer, which is the delay the write exists to avoid.

```typescript
const report = await state.set("query", "ruby")
```

The write now happens in `set`, before anything is scheduled. Debouncing still applies to the request, since a burst of typing should cost one of them.