### PR TITLE
Analysis: Build the slot dependency map the way the host compiled the page

### DIFF
--- a/lib/herb/engine/slot_dependencies.rb
+++ b/lib/herb/engine/slot_dependencies.rb
@@ -32,8 +32,9 @@ module Herb
       STRUCTURAL_TYPES = [:conditional, :collection, :block].freeze #: Array[Symbol]
       PARTIAL_TYPES = [:attribute_interpolation].freeze #: Array[Symbol]
 
-      #: (String | Pathname) -> void
-      def initialize(project_path)
+      #: (String | Pathname, ?compile: ^(String, String) -> untyped) -> void
+      def initialize(project_path, compile: nil)
+        @compile = compile
         @project_path = Pathname.new(project_path)
         @dependencies = Herb::Analysis::TemplateDependencies.new(project_path)
         @templates = {} #: Hash[String, Hash[Symbol, untyped]]
@@ -102,9 +103,12 @@ module Herb
         source = File.read(path)
         analysis = @dependencies.analyze(path)
         visitor = visitor_for(source, path)
+
+        return { version: nil, slots: {} } unless visitor.respond_to?(:slots)
+
         slots = visitor.slots
         wanted = names || state_names(analysis)
-        reached = reached_paths(source, wanted)
+        reached = reached_paths(visitor, source, wanted)
         settable = (analysis.instance_variables + analysis.locals_declared + (names || [])).to_set - analysis.constants.to_set
 
         index = {} #: Hash[Integer, Hash[Symbol, untyped]]
@@ -191,16 +195,18 @@ module Herb
 
       #: (String, String) -> untyped
       def visitor_for(source, path)
-        visitor = Herb::Engine::SlotVisitor.new
+        return @compile.call(source, path) if @compile
+
+        visitor = Herb::Engine::SlotVisitor.new(mark: false)
 
         Herb::Engine.new(source, visitors: [visitor], filename: path)
 
         visitor
       end
 
-      #: (String, Array[String]) -> Hash[String, Hash[Array[Integer], Array[String?]]]
-      def reached_paths(source, names)
-        ast = ::Herb.parse(source, render_nodes: true, strict_locals: true, prism_nodes: true, track_whitespace: true).value
+      #: (untyped, String, Array[String]) -> Hash[String, Hash[Array[Integer], Array[String?]]]
+      def reached_paths(visitor, source, names)
+        ast = visitor.document || ::Herb.parse(source, render_nodes: true, strict_locals: true, prism_nodes: true, track_whitespace: true).value
 
         reached = {} #: Hash[String, Hash[Array[Integer], Array[String?]]]
 

--- a/lib/herb/engine/slot_visitor.rb
+++ b/lib/herb/engine/slot_visitor.rb
@@ -33,6 +33,7 @@ module Herb
       required_parser_option action_view_helpers: true
 
       attr_reader :slots #: Array[Slot]
+      attr_reader :document #: untyped
       attr_reader :warnings #: Array[Herb::Warnings::Warning]
 
       SLOTS_DIRECTIVE = /<%#-?\s*herb:slots\b(?<mode>[^%]*?)-?%>/ #: Regexp
@@ -179,6 +180,8 @@ module Herb
       end
 
       def visit_document_node(node)
+        @document = node
+
         visit_children_with_paths(node.children)
 
         collapse_invariant_conditionals

--- a/sig/herb/engine/slot_dependencies.rbs
+++ b/sig/herb/engine/slot_dependencies.rbs
@@ -26,8 +26,8 @@ module Herb
 
       PARTIAL_TYPES: Array[Symbol]
 
-      # : (String | Pathname) -> void
-      def initialize: (String | Pathname) -> void
+      # : (String | Pathname, ?compile: ^(String, String) -> untyped) -> void
+      def initialize: (String | Pathname, ?compile: ^(String, String) -> untyped) -> void
 
       # : (String) -> Hash[String, Array[Hash[Symbol, untyped]]]
       def across: (String) -> Hash[String, Array[Hash[Symbol, untyped]]]
@@ -76,8 +76,8 @@ module Herb
       # : (String, String) -> untyped
       def visitor_for: (String, String) -> untyped
 
-      # : (String, Array[String]) -> Hash[String, Hash[Array[Integer], Array[String?]]]
-      def reached_paths: (String, Array[String]) -> Hash[String, Hash[Array[Integer], Array[String?]]]
+      # : (untyped, String, Array[String]) -> Hash[String, Hash[Array[Integer], Array[String?]]]
+      def reached_paths: (untyped, String, Array[String]) -> Hash[String, Hash[Array[Integer], Array[String?]]]
 
       # : (untyped) -> Array[String]
       def state_names: (untyped) -> Array[String]

--- a/sig/herb/engine/slot_visitor.rbs
+++ b/sig/herb/engine/slot_visitor.rbs
@@ -22,6 +22,8 @@ module Herb
 
       attr_reader slots: Array[Slot]
 
+      attr_reader document: untyped
+
       attr_reader warnings: Array[Herb::Warnings::Warning]
 
       SLOTS_DIRECTIVE: Regexp

--- a/test/engine/slots/dependencies_test.rb
+++ b/test/engine/slots/dependencies_test.rb
@@ -2,6 +2,7 @@
 
 require_relative "../../test_helper"
 require_relative "../../../lib/herb/engine/slot_dependencies"
+require_relative "../../../lib/herb/engine/debug_visitor"
 
 require "tmpdir"
 require "fileutils"
@@ -43,6 +44,77 @@ module Engine
       def page_with_partial
         write("_search.html.erb", %(<input value="<%= term %>"><p><%= term.upcase %></p>))
         write("index.html.erb", %(<div><%= @query %></div><%= render "posts/search", term: @query %>))
+      end
+
+      test "leaves out a template the host does not compile slots for" do
+        write("_plain.html.erb", "<div><%= card %></div>")
+        entry = write("index.html.erb", %(<div><%= @name %></div><%= render "posts/plain", card: @name %>))
+
+        compile = lambda { |source, file|
+          next nil if File.basename(file).start_with?("_")
+
+          visitor = Herb::Engine::SlotVisitor.new(mark: false)
+          Herb::Engine.new(source, visitors: [visitor], filename: file)
+          visitor
+        }
+
+        reached = Herb::Engine::SlotDependencies.new(@project_path, compile: compile).across(entry)["@name"]
+        files = reached.map { |slot| File.basename(slot[:file]) }.uniq
+
+        assert_includes files, "index.html.erb"
+        refute_includes files, "_plain.html.erb"
+      end
+
+      test "says nothing at all when the host compiles no slots anywhere" do
+        entry = write("index.html.erb", "<div><%= @name %></div>")
+
+        subject = Herb::Engine::SlotDependencies.new(@project_path, compile: ->(_source, _file) {})
+
+        assert_empty subject.across(entry)
+        assert_empty subject.for(entry)
+        assert_nil subject.version_for(entry)
+      end
+
+      test "finds the same state when a visitor rewrote the tree first" do
+        template = %(<div><span><%= @name.presence || "x" %></span><p><%= @name.length %></p></div>)
+        path = File.join(@view_root, "index.html.erb")
+
+        File.write(path, template)
+
+        compile = lambda { |source, file|
+          visitor = Herb::Engine::SlotVisitor.new(mark: false)
+          Herb::Engine.new(source, visitors: [Herb::Engine::DebugVisitor.new, visitor], filename: file)
+          visitor
+        }
+
+        rewritten = Herb::Engine::SlotDependencies.new(@project_path, compile: compile).for(path)
+        plain = Herb::Engine::SlotDependencies.new(@project_path).for(path)
+
+        assert_equal plain.keys.sort, rewritten.keys.sort
+        assert_equal(plain.values.map { |slot| slot[:state] }, rewritten.values.map { |slot| slot[:state] })
+        refute_empty(rewritten.values.flat_map { |slot| slot[:state] })
+      end
+
+      test "builds the map the way the host compiles, so the versions agree" do
+        template = "<div><%= @name %></div>"
+        path = File.join(@view_root, "index.html.erb")
+
+        File.write(path, template)
+
+        marker = Herb::Engine::SlotVisitor.new
+        Herb::Engine.new(template, visitors: [Herb::Engine::DebugVisitor.new, marker], filename: path)
+
+        compile = lambda { |source, file|
+          visitor = Herb::Engine::SlotVisitor.new
+          Herb::Engine.new(source, visitors: [Herb::Engine::DebugVisitor.new, visitor], filename: file)
+          visitor
+        }
+
+        matching = Herb::Engine::SlotDependencies.new(@project_path, compile: compile)
+        bare = Herb::Engine::SlotDependencies.new(@project_path)
+
+        assert_equal marker.schema[:version], matching.version_for(path)
+        refute_equal marker.schema[:version], bare.version_for(path)
       end
 
       test "names the state a slot reads" do


### PR DESCRIPTION
This pull request makes the map a page carries agree with the page, which it did not when anything ran before the slot visitor.

`SlotDependencies` answers which slots a piece of state reaches, and a client uses that to decide what it can write itself. It compiled its own copy of a template with a bare `SlotVisitor` and nothing else, and analysed a fresh parse of the source. A host that compiles differently got a map that agreed with nothing it served.

#### The version named a page nobody had

A version is a digest of the slots a template has, and the slots depend on every visitor that ran before the slot visitor. A client looks a region up by file and version, so a map built from a different compile finds no region and writes nothing at all. The failure is silent: the page keeps working, it just never does anything early.

`compile` takes the source and the path and hands back the `SlotVisitor` the host used, so the map is built from the slots the page was built from.

```ruby
Herb::Engine::SlotDependencies.new(project_path, compile: ->(source, path) { ... })
```

Measured against a real Rails app before and after, the page's region marker, the delivered map and the values payload now all read the same version.

#### The join numbered a different document

A slot's `node_path` names a position in the tree the slot visitor walked. A visitor ahead of it may rewrite that tree, and a debug visitor does, wrapping every ERB output in a span. Analysing a fresh parse of the source then numbers a different document, so the join drops exactly the slots that moved.

In practice a page compiled in development lost most of its state and looked like a page with none. Of four states on a demo page, two survived.

The visitor keeps the document it walked and the map analyses that. Where no host compile is given it still parses the source, which is the same tree in that case.

#### A host does not compile slots for every template

It says so by handing back nothing, and `ReActionView` does exactly that for any template without a slot mode, which is every partial when slots are not turned on globally. Calling `slots` on that was a `NoMethodError`, so one unmarked partial cost a page its whole map.

A template compiled without a slot visitor has no slots. That is an empty entry and not an error, so the templates that were compiled still answer:

```ruby
compile = ->(source, path) { File.basename(path).start_with?("_") ? nil : visitor_for(source, path) }
```

A compile that raises still raises. That is a host getting its own compile wrong, and swallowing it would hide the one case worth knowing about.

#### Markers are nodes

They are inserted after the walk finishes, so a marked tree no longer matches the paths recorded against it. The default compile stops marking, which is what the values compile already does for the same reason: a later pass would number the markers as slots.

This one is easy to get backwards. Reusing the marked tree takes the suite from passing to fourteen failures and twelve errors, which is what the new test guards.
