### PR TITLE
Client: Tell a page's own state from a command

### DIFF
--- a/javascript/packages/client/src/state.ts
+++ b/javascript/packages/client/src/state.ts
@@ -8,7 +8,7 @@ export const DEPENDENCIES_ATTRIBUTE = "data-herb-dependencies"
 export const DEPENDENCIES_SELECTOR = `template[${DEPENDENCIES_ATTRIBUTE}]`
 
 export type StateMode = "identity" | "structural" | "derived"
-export type StatePersistence = "url" | "none"
+export type StatePersistence = "url" | "known" | "none"
 
 export interface StateSlot {
   file: string
@@ -79,7 +79,19 @@ export class SlotState {
   }
 
   #persisted(): boolean {
-    return this.#options.persist === "url"
+    return this.#options.persist !== "none"
+  }
+
+  #known(name: string): boolean {
+    return this.#params.has(name) || this.#dependencies.has(name)
+  }
+
+  #transient(name: string): boolean {
+    return this.#options.persist === "known" && !this.#known(name)
+  }
+
+  #forget(names: string[]): void {
+    for (const name of names) this.#values.delete(name)
   }
 
   get(key: string): string | undefined {
@@ -193,6 +205,7 @@ export class SlotState {
 
     const changed = [...changes.keys()]
     const taken = new Map(changed.map((name) => [name, this.#sequence.get(name) ?? 0]))
+    const transient = [...this.#values.keys()].filter((name) => this.#transient(name))
 
     this.#controller?.abort()
     this.#controller = new AbortController()
@@ -202,6 +215,8 @@ export class SlotState {
     try {
       payload = await this.#options.transport({ state: this.all(), changed }, this.#controller.signal)
     } catch (error) {
+      this.#forget(transient)
+
       if (this.#superseded(taken)) return this.#settle({ ...IDLE, written: restores.length, stale: true })
 
       this.#restore(restores)
@@ -213,6 +228,8 @@ export class SlotState {
 
       return this.#settle({ ...IDLE, written: restores.length, restored: restores.length, failed: true })
     }
+
+    this.#forget(transient)
 
     if (this.#superseded(taken)) return this.#settle({ ...IDLE, written: restores.length, stale: true })
 
@@ -324,7 +341,11 @@ export class SlotState {
 
     url.search = ""
 
-    for (const [name, value] of this.#values) url.searchParams.set(name, value)
+    for (const [name, value] of this.#values) {
+      if (this.#options.persist === "known" && !this.#known(name)) continue
+
+      url.searchParams.set(name, value)
+    }
 
     window.history.replaceState(window.history.state, "", url.toString())
   }

--- a/javascript/packages/client/test/state.test.ts
+++ b/javascript/packages/client/test/state.test.ts
@@ -308,6 +308,112 @@ describe("reconciling with the server", () => {
   })
 })
 
+describe("keeping commands out of the address bar", () => {
+  beforeEach(() => {
+    document.body.innerHTML = ""
+    window.history.replaceState({}, "", "/posts")
+  })
+
+  test("persists a key the map names", async () => {
+    const slots = mounted(PAGE + DEPENDENCIES)
+    const state = new SlotState(slots, { persist: "known", transport: async () => null })
+
+    state.adopt()
+
+    await state.set("name", "Ada")
+
+    expect(window.location.search).toBe("?name=Ada")
+  })
+
+  test("leaves out a key the map says nothing about", async () => {
+    const slots = mounted(PAGE + DEPENDENCIES)
+    const state = new SlotState(slots, { persist: "known", transport: async () => null })
+
+    state.adopt()
+
+    await state.set({ name: "Ada", remove: "3" })
+
+    expect(window.location.search).toBe("?name=Ada")
+    expect(state.get("name")).toBe("Ada")
+  })
+
+  test("forgets a command that arrived in the address bar, once it has been sent", async () => {
+    window.history.replaceState({}, "", "/posts?name=Marco&reset=1")
+
+    const slots = mounted(PAGE + DEPENDENCIES)
+    const seen: StateRequest[] = []
+    const state = new SlotState(slots, {
+      persist: "known",
+      transport: async (request) => {
+        seen.push(request)
+
+        return null
+      },
+    })
+
+    state.adopt()
+
+    await state.set("name", "Ada")
+    await state.set("name", "Grace")
+
+    expect(seen[0].state).toEqual({ name: "Ada", reset: "1" })
+    expect(seen[1].state).toEqual({ name: "Grace" })
+    expect(state.get("reset")).toBeUndefined()
+    expect(window.location.search).toBe("?name=Grace")
+  })
+
+  test("forgets a command once it has been sent, so the next ask does not repeat it", async () => {
+    const slots = mounted(PAGE + DEPENDENCIES)
+    const seen: StateRequest[] = []
+    const state = new SlotState(slots, {
+      persist: "known",
+      transport: async (request) => {
+        seen.push(request)
+
+        return null
+      },
+    })
+
+    state.adopt()
+
+    await state.set({ add: "1" })
+    await state.set("name", "Ada")
+
+    expect(seen[0].state).toEqual({ add: "1" })
+    expect(seen[1].state).toEqual({ name: "Ada" })
+    expect(state.get("add")).toBeUndefined()
+  })
+
+  test("still sends what it leaves out", async () => {
+    const slots = mounted(PAGE + DEPENDENCIES)
+    const seen: StateRequest[] = []
+    const state = new SlotState(slots, {
+      persist: "known",
+      transport: async (request) => {
+        seen.push(request)
+
+        return null
+      },
+    })
+
+    state.adopt()
+
+    await state.set({ add: "1" })
+
+    expect(seen[0].state).toEqual({ add: "1" })
+    expect(window.location.search).toBe("")
+  })
+
+  test("writes nothing to the address bar when the page has no map", async () => {
+    const slots = mounted(PAGE)
+    const state = new SlotState(slots, { persist: "known", transport: async () => null })
+
+    await state.set("name", "Ada")
+
+    expect(window.location.search).toBe("")
+  })
+})
+
 describe("state that has no business in a URL", () => {
   beforeEach(() => {
     document.body.innerHTML = ""


### PR DESCRIPTION
This pull request stops the state layer from treating a command as if it were part of the page.

A page's inputs belong in the address bar. A command does not: it is asked for once, it is not what the page is, and a link to it is a link that does the thing again. `state` treated everything it was given the same way, so a table sending `add` put a command in the query string and then kept it.