### PR TITLE
Analysis: Tell a loop apart from a block that runs once

### DIFF
--- a/javascript/packages/analysis/src/dependency-index.ts
+++ b/javascript/packages/analysis/src/dependency-index.ts
@@ -1,12 +1,12 @@
 import { collectTemplateDependencies } from "./template-dependencies"
-import { isERBBlockNode, isERBCaseNode, isERBContentNode, isERBIfNode, isERBRenderNode, isERBUnlessNode, isHTMLAttributeNode, isHTMLElementNode, isLiteralNode, isRubyParameterNode } from "@herb-tools/core"
+import { isERBBlockNode, isERBCaseNode, isERBContentNode, isERBIfNode, isERBIterationBlockNode, isERBRenderNode, isERBUnlessNode, isHTMLAttributeNode, isHTMLElementNode, isLiteralNode, isRubyParameterNode } from "@herb-tools/core"
 
-const PARSER_OPTIONS = { render_nodes: true, strict_locals: true, prism_nodes: true, prism_program: true, track_whitespace: true }
+const PARSER_OPTIONS = { render_nodes: true, strict_locals: true, prism_nodes: true, prism_program: true, track_whitespace: true, iteration_nodes: true }
 
 import type { DependencyOptions } from "./template-dependencies"
 import type { DocumentNode, HTMLAttributeNode, HerbBackend, Node, Token } from "@herb-tools/core"
 
-export type AffectedNodeKind = "text_content" | "conditional" | "render" | "attribute_value" | "expression"
+export type AffectedNodeKind = "text_content" | "conditional" | "render" | "attribute_value" | "expression" | "iteration"
 
 export interface AffectedNode {
   nodePath: number[]
@@ -72,7 +72,7 @@ function assignedNames(node: Node, source: string, aliases: string[]): string[] 
 }
 
 function blockBindings(node: Node, aliases: string[]): string[] {
-  if (!isERBBlockNode(node)) return []
+  if (!isERBBlockNode(node) && !isERBIterationBlockNode(node)) return []
   if (!referencesAny(expressionOf(node), aliases)) return []
 
   const names: string[] = []
@@ -101,7 +101,7 @@ function childrenOf(node: Node): Node[] {
     ? node.body
     : isERBIfNode(node) || isERBUnlessNode(node)
       ? node.statements
-      : isERBBlockNode(node)
+      : isERBBlockNode(node) || isERBIterationBlockNode(node)
         ? node.body
         : node.childNodes()
 
@@ -193,6 +193,8 @@ export function affectedNodes(backend: HerbBackend, source: string, state: strin
       record(node, "text_content", expressionOf(node))
     } else if (isERBRenderNode(node) && referencesAny(expressionOf(node), aliases)) {
       record(node, "render", expressionOf(node))
+    } else if (isERBIterationBlockNode(node) && referencesAny(expressionOf(node), aliases)) {
+      record(node, "iteration", expressionOf(node))
     } else if (isERBBlockNode(node) && referencesAny(expressionOf(node), aliases)) {
       record(node, "expression", expressionOf(node))
     }

--- a/javascript/packages/analysis/test/dependency-index.test.ts
+++ b/javascript/packages/analysis/test/dependency-index.test.ts
@@ -43,6 +43,14 @@ describe("dependencyIndex", () => {
     expect(nodes.map(node => node.expression)).toEqual(["@rows.each do |r|", "inner = r.x", "inner"])
   })
 
+  test("tells a loop apart from a block that runs once", () => {
+    const loops = affectedNodes(Herb, `<ul><% @items.each do |i| %><li><%= i %></li><% end %></ul>`, "@items")
+    const form = affectedNodes(Herb, `<% form_with model: @post do |f| %><%= f.label %><% end %>`, "@post")
+
+    expect(loops[0].kind).toBe("iteration")
+    expect(form[0].kind).toBe("expression")
+  })
+
   test("follows state through a block parameter", () => {
     const nodes = affectedNodes(Herb, `<ul><% @items.each do |item| %><li><%= item.name %></li><% end %></ul>`, "@items")
 
@@ -75,7 +83,7 @@ describe("dependencyIndex", () => {
     const nodes = affectedNodes(Herb, `<ul><% @items.each do |item| %><li><%= item.name %></li><% end %></ul>`, "@items")
 
     expect(nodes.map(node => [node.kind, node.nodePath, node.expression])).toEqual([
-      ["expression", [0, 0], "@items.each do |item|"],
+      ["iteration", [0, 0], "@items.each do |item|"],
       ["text_content", [0, 0, 0, 0], "item.name"],
     ])
   })

--- a/lib/herb/analysis/template_dependencies.rb
+++ b/lib/herb/analysis/template_dependencies.rb
@@ -77,7 +77,7 @@ module Herb
         file_path = @project_path.join(file_path).to_s unless Pathname.new(file_path).absolute?
         source = File.read(file_path)
 
-        ast = ::Herb.parse(source, render_nodes: true, strict_locals: true, prism_nodes: true, track_whitespace: true).value
+        ast = ::Herb.parse(source, render_nodes: true, strict_locals: true, prism_nodes: true, track_whitespace: true, iteration_nodes: true).value
 
         nodes_in(ast, state, conditions_only: conditions_only)
       end

--- a/lib/herb/analysis/template_dependencies/node_dependency_collector.rb
+++ b/lib/herb/analysis/template_dependencies/node_dependency_collector.rb
@@ -79,7 +79,7 @@ module Herb
         end
 
         def visit_erb_iteration_block_node(node)
-          check_erb_expression(node, :expression)
+          check_erb_expression(node, :iteration)
 
           visit_branching_node(node)
         end

--- a/rust/herb-analysis/src/state_flow.rs
+++ b/rust/herb-analysis/src/state_flow.rs
@@ -90,6 +90,7 @@ impl StateFlow {
       strict_locals: true,
       prism_nodes: true,
       track_whitespace: true,
+      iteration_nodes: true,
       ..Default::default()
     };
 
@@ -308,7 +309,7 @@ fn collect_affected(node: &AnyNode, source: &str, aliases: &mut Vec<String>, pat
     AnyNode::ERBCaseNode(_) => Some("conditional"),
     AnyNode::ERBRenderNode(_) => Some("render"),
     AnyNode::ERBBlockNode(_) => Some("expression"),
-    AnyNode::ERBIterationBlockNode(_) => Some("expression"),
+    AnyNode::ERBIterationBlockNode(_) => Some("iteration"),
     _ => None,
   };
 
@@ -500,6 +501,7 @@ fn any_children(node: &AnyNode) -> Vec<&AnyNode> {
     AnyNode::ERBUnlessNode(inner) => inner.statements.iter().collect(),
     AnyNode::ERBCaseNode(inner) => inner.children.iter().collect(),
     AnyNode::ERBBlockNode(inner) => inner.body.iter().collect(),
+    AnyNode::ERBIterationBlockNode(inner) => inner.body.iter().collect(),
     AnyNode::ERBRenderNode(inner) => inner.body.iter().collect(),
     _ => Vec::new(),
   }

--- a/rust/herb-analysis/tests/state_flow_test.rs
+++ b/rust/herb-analysis/tests/state_flow_test.rs
@@ -319,7 +319,7 @@ fn records_a_block_the_way_ruby_does() {
   let entry = project.write("app/views/posts/index.html.erb", "<ul><% @items.each do |item| %><li>x</li><% end %></ul>");
 
   let nodes = project.flow().affected_nodes(&entry, "@items");
-  let block = nodes.iter().find(|node| node.kind == "expression");
+  let block = nodes.iter().find(|node| node.kind == "iteration");
 
   assert!(block.is_some(), "got {nodes:?}");
   assert_eq!(vec![0, 0], block.unwrap().node_path);
@@ -342,7 +342,7 @@ fn reports_what_the_ruby_collector_reports() {
 
   assert_eq!(
     vec![
-      ("expression".to_string(), vec![0, 0], Some("@items.each do |item|".to_string())),
+      ("iteration".to_string(), vec![0, 0], Some("@items.each do |item|".to_string())),
       ("text_content".to_string(), vec![0, 0, 0, 0], Some("item.name".to_string())),
     ],
     reported
@@ -400,4 +400,14 @@ fn stops_a_local_assigned_inside_a_block_at_the_end_of_it() {
       "@rows"
     )
   );
+}
+
+#[test]
+fn tells_a_loop_apart_from_a_block_that_runs_once() {
+  let project = Project::new("iteration_kind");
+  let loops = project.write("app/views/posts/index.html.erb", "<ul><% @items.each do |i| %><li><%= i %></li><% end %></ul>");
+  let form = project.write("app/views/posts/form.html.erb", "<% form_with model: @post do |f| %><%= f.label %><% end %>");
+
+  assert_eq!("iteration", project.flow().affected_nodes(&loops, "@items")[0].kind);
+  assert_eq!("expression", project.flow().affected_nodes(&form, "@post")[0].kind);
 }

--- a/test/analysis/template_dependencies_test.rb
+++ b/test/analysis/template_dependencies_test.rb
@@ -461,6 +461,14 @@ class TemplateDependenciesTest < Minitest::Spec
     refute_includes affected, File.join(@view_root, "posts/_field.html.erb")
   end
 
+  test "affected_nodes tells a loop apart from a block that runs once" do
+    loop_path = write_template("posts/index.html.erb", "<ul><% @items.each do |i| %><li><%= i %></li><% end %></ul>")
+    form_path = write_template("posts/form.html.erb", "<% form_with model: @post do |f| %><%= f.label %><% end %>")
+
+    assert_equal :iteration, analyzer.affected_nodes(loop_path, "@items").first[:type]
+    assert_equal :expression, analyzer.affected_nodes(form_path, "@post").first[:type]
+  end
+
   test "affected_nodes follows state into a local assigned from it" do
     path = write_template("posts/index.html.erb", "<% total = @items.size %><p><%= total %></p>")
 

--- a/test/engine/slots/dependencies_test.rb
+++ b/test/engine/slots/dependencies_test.rb
@@ -79,7 +79,7 @@ module Engine
         write("_plain.html.erb", "<div><%= card %></div>")
         entry = write("index.html.erb", %(<div><%= @name %></div><%= render "posts/plain", card: @name %>))
 
-        compile = ->(source, file) {
+        compile = lambda { |source, file|
           next nil if File.basename(file).start_with?("_")
 
           visitor = Herb::Engine::SlotVisitor.new(mark: false)
@@ -97,7 +97,7 @@ module Engine
       test "says nothing at all when the host compiles no slots anywhere" do
         entry = write("index.html.erb", "<div><%= @name %></div>")
 
-        subject = Herb::Engine::SlotDependencies.new(@project_path, compile: ->(_source, _file) { nil })
+        subject = Herb::Engine::SlotDependencies.new(@project_path, compile: ->(_source, _file) {})
 
         assert_empty subject.across(entry)
         assert_empty subject.for(entry)

--- a/test/engine/slots/dependencies_test.rb
+++ b/test/engine/slots/dependencies_test.rb
@@ -75,6 +75,35 @@ module Engine
         assert_nil subject.version_for(entry)
       end
 
+      test "leaves out a template the host does not compile slots for" do
+        write("_plain.html.erb", "<div><%= card %></div>")
+        entry = write("index.html.erb", %(<div><%= @name %></div><%= render "posts/plain", card: @name %>))
+
+        compile = ->(source, file) {
+          next nil if File.basename(file).start_with?("_")
+
+          visitor = Herb::Engine::SlotVisitor.new(mark: false)
+          Herb::Engine.new(source, visitors: [visitor], filename: file)
+          visitor
+        }
+
+        reached = Herb::Engine::SlotDependencies.new(@project_path, compile: compile).across(entry)["@name"]
+        files = reached.map { |slot| File.basename(slot[:file]) }.uniq
+
+        assert_includes files, "index.html.erb"
+        refute_includes files, "_plain.html.erb"
+      end
+
+      test "says nothing at all when the host compiles no slots anywhere" do
+        entry = write("index.html.erb", "<div><%= @name %></div>")
+
+        subject = Herb::Engine::SlotDependencies.new(@project_path, compile: ->(_source, _file) { nil })
+
+        assert_empty subject.across(entry)
+        assert_empty subject.for(entry)
+        assert_nil subject.version_for(entry)
+      end
+
       test "finds the same state when a visitor rewrote the tree first" do
         template = %(<div><span><%= @name.presence || "x" %></span><p><%= @name.length %></p></div>)
         path = File.join(@view_root, "index.html.erb")


### PR DESCRIPTION
This pull request reports an iteration as an iteration, so a body that renders once per item can be told apart from one that renders once.

```erb
<% @items.each do |item| %>  <%# renders its body per item %>

<% form_with model: @post do |f| %>  <%# renders its body once %>
```

Both came back from `affected_nodes` as an `expression`, so nothing downstream could distinguish them. A form builder's `f` looked exactly like a collection's `item`, and anything reasoning about per-item rendering had to guess from the method name.