### PR TITLE
Dev Tools: Fix the slot flash never being drawn

### DIFF
--- a/javascript/packages/dev-tools/src/slots/flash.ts
+++ b/javascript/packages/dev-tools/src/slots/flash.ts
@@ -43,9 +43,9 @@ export class SlotFlash {
     overlay.className = 'herb-slot-flash'
     label.className = 'herb-slot-flash'
 
-    overlay.style.cssText = `position:absolutez-index:2147483000pointer-events:nonetop:${rect.top + scrollY}pxleft:${rect.left + scrollX}pxwidth:${rect.width}pxheight:${rect.height}pxbackground:${colour}opacity:0.22outline:1px solid ${colour}transition:opacity ${SlotFlash.DURATION}ms ease-out`
+    overlay.style.cssText = `position:absolute;z-index:2147483000;pointer-events:none;top:${rect.top + scrollY}px;left:${rect.left + scrollX}px;width:${rect.width}px;height:${rect.height}px;background:${colour};opacity:0.22;outline:1px solid ${colour};transition:opacity ${SlotFlash.DURATION}ms ease-out`
 
-    label.style.cssText = `position:absolutez-index:2147483001pointer-events:nonetop:${Math.max(0, rect.top + scrollY - 18)}pxleft:${rect.left + scrollX}pxbackground:${colour}color:#ffffont:600 10px/1.6 ui-monospace,monospacepadding:0 5pxborder-radius:3pxwhite-space:nowraptransition:opacity ${SlotFlash.DURATION}ms ease-out`
+    label.style.cssText = `position:absolute;z-index:2147483001;pointer-events:none;top:${Math.max(0, rect.top + scrollY - 18)}px;left:${rect.left + scrollX}px;background:${colour};color:#fff;font:600 10px/1.6 ui-monospace,monospace;padding:0 5px;border-radius:3px;white-space:nowrap;transition:opacity ${SlotFlash.DURATION}ms ease-out`
     label.textContent = this.describe(detail)
 
     document.body.append(overlay, label)

--- a/javascript/packages/dev-tools/test/slot-flash.test.ts
+++ b/javascript/packages/dev-tools/test/slot-flash.test.ts
@@ -1,0 +1,92 @@
+import { describe, test, expect, beforeEach, afterEach } from "vitest"
+
+import { SlotFlash } from "../src/slots/flash"
+
+const SLOT_EVENT = "herb:slot-update"
+
+let flash: SlotFlash
+let target: HTMLElement
+
+function announce(operation = "value") {
+  document.dispatchEvent(
+    new CustomEvent(SLOT_EVENT, {
+      detail: {
+        file: "app/views/page/ask.html.erb",
+        occurrence: 0,
+        index: 0,
+        operation,
+        key: null,
+        item: null,
+        slot: { index: 0, attribute: null, anchor: { kind: "element", element: target } },
+      },
+    }),
+  )
+}
+
+function drawn() {
+  return [...document.querySelectorAll<HTMLElement>(".herb-slot-flash")]
+}
+
+beforeEach(() => {
+  target = document.createElement("p")
+  target.textContent = "hello"
+  document.body.append(target)
+
+  flash = new SlotFlash()
+  flash.start()
+})
+
+afterEach(() => {
+  flash.stop()
+  target.remove()
+})
+
+describe("SlotFlash", () => {
+  test("draws an overlay and a label for a slot that changed", () => {
+    announce()
+
+    expect(drawn()).toHaveLength(2)
+  })
+
+  test("the overlay it draws carries the styles that make it visible", () => {
+    announce()
+
+    const [overlay] = drawn()
+    const styles = getComputedStyle(overlay)
+
+    expect(overlay.style.length).toBeGreaterThan(0)
+    expect(styles.position).toBe("absolute")
+    expect(styles.backgroundColor).toBe("rgb(59, 130, 246)")
+    expect(styles.pointerEvents).toBe("none")
+    expect(parseFloat(styles.width)).toBeGreaterThan(0)
+  })
+
+  test("the label it draws carries its own styles and says what changed", () => {
+    announce()
+
+    const [, label] = drawn()
+    const styles = getComputedStyle(label)
+
+    expect(label.textContent).toBe("value ask.html.erb #0")
+    expect(label.style.length).toBeGreaterThan(0)
+    expect(styles.position).toBe("absolute")
+    expect(styles.color).toBe("rgb(255, 255, 255)")
+  })
+
+  test("colours the overlay by the operation it reports", () => {
+    announce("item-added")
+
+    expect(getComputedStyle(drawn()[0]).backgroundColor).toBe("rgb(16, 185, 129)")
+  })
+
+  test("stops drawing and clears what it drew", () => {
+    announce()
+    flash.stop()
+
+    expect(drawn()).toHaveLength(0)
+
+    announce()
+
+    expect(drawn()).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
This pull request fixes the slot flash in the dev tools overlay which were added in #2277.

Both `cssText` strings in `SlotFlash` were written without `;` between the declarations, so each one reads as a single malformed declaration and the browser keeps none of it.