### PR TITLE
Client: Let a branch be switched from the client

### DIFF
--- a/javascript/packages/client/src/slot-index.ts
+++ b/javascript/packages/client/src/slot-index.ts
@@ -787,6 +787,31 @@ export class SlotIndex {
     return copy
   }
 
+  switchBranch(slot: Slot, branch: number | null, dynamics: SlotValues = {}): boolean {
+    if (branch === slot.branch) return false
+
+    const region = this.regionOf(slot)
+
+    if (!region) return false
+
+    this.capture(slot)
+
+    if (branch === null) {
+      this.update(slot, "")
+      slot.branch = null
+
+      return true
+    }
+
+    const built = this.materialize(region.file, `${slot.index}:${branch}`, dynamics)
+
+    if (!built) return false
+
+    this.#writeFragment(slot, built)
+
+    return true
+  }
+
   prune(): number {
     const before = this.#regions.length
 

--- a/javascript/packages/client/test/branch.test.ts
+++ b/javascript/packages/client/test/branch.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect, beforeEach } from "vitest"
-import { SlotIndex } from "../src/slot-index"
+import { SlotIndex, SLOT_EVENT } from "../src/slot-index"
+import type { SlotEventDetail } from "../src/slot-index"
 
 function nth(html: string, occurrence: number): string {
   return html.replace(/(<!--herb-region:[^>]*?:[0-9a-f]{8}):\d+-->/g, `$1:${occurrence}-->`)
@@ -523,5 +524,67 @@ describe("keeping a branch that rendered", () => {
 
     expect(index.capture(index.slot(FILE, 0)!)).toBe(false)
     expect(index.skeletonKeys(FILE)).toEqual([])
+  })
+})
+
+describe("switching a branch from the client", () => {
+  beforeEach(() => { document.body.innerHTML = "" })
+
+  const page = `<!--herb-region:${FILE}:aaaaaaaa:0--><div><!--herb-slot:0:conditional--><!--herb-branch:0:1--><b>under</b><!--/herb-slot:0--></div><template data-herb-statics="0:0"><!--herb-branch:0:0--><i>over</i></template><!--/herb-region:${FILE}-->`
+
+  function watch(): SlotEventDetail[] {
+    const seen: SlotEventDetail[] = []
+
+    document.addEventListener(SLOT_EVENT, (event) => seen.push((event as CustomEvent<SlotEventDetail>).detail))
+
+    return seen
+  }
+
+  test("builds the parked branch and says it was a branch that changed", () => {
+    const index = new SlotIndex()
+    document.body.innerHTML = page
+    index.scan(document.body)
+
+    const slot = index.slot(FILE, 0)!
+    const seen = watch()
+
+    expect(index.switchBranch(slot, 0)).toBe(true)
+
+    expect(index.rangeFor(index.slot(FILE, 0)!).toString()).toBe("over")
+    expect(index.slot(FILE, 0)?.branch).toBe(0)
+    expect(seen).toHaveLength(1)
+    expect(seen[0]).toMatchObject({ file: FILE, index: 0, operation: "branch" })
+  })
+
+  test("parks what it replaces, so switching back needs nothing new", () => {
+    const index = new SlotIndex()
+    document.body.innerHTML = page
+    index.scan(document.body)
+
+    index.switchBranch(index.slot(FILE, 0)!, 0)
+
+    expect(index.branchesFor(FILE, 0).sort()).toEqual([0, 1])
+    expect(index.switchBranch(index.slot(FILE, 0)!, 1)).toBe(true)
+    expect(index.rangeFor(index.slot(FILE, 0)!).toString()).toBe("under")
+  })
+
+  test("does nothing when the branch it is asked for is the one already shown", () => {
+    const index = new SlotIndex()
+    document.body.innerHTML = page
+    index.scan(document.body)
+
+    const seen = watch()
+
+    expect(index.switchBranch(index.slot(FILE, 0)!, 1)).toBe(false)
+    expect(seen).toHaveLength(0)
+  })
+
+  test("reports that it could not, when the branch was never parked", () => {
+    const index = new SlotIndex()
+    document.body.innerHTML = page
+    index.scan(document.body)
+
+    expect(index.switchBranch(index.slot(FILE, 0)!, 7)).toBe(false)
+    expect(index.rangeFor(index.slot(FILE, 0)!).toString()).toBe("under")
   })
 })

--- a/javascript/packages/dev-tools/src/overlay/overlay.ts
+++ b/javascript/packages/dev-tools/src/overlay/overlay.ts
@@ -83,6 +83,8 @@ export class HerbOverlay {
     document.removeEventListener('turbo:render', this.handleTurboNavigation);
     document.removeEventListener('turbo:visit', this.handleTurboNavigation);
 
+    this.slotFlash.stop();
+
     this.errorOverlay?.destroy();
     this.errorOverlay = null;
 

--- a/javascript/packages/dev-tools/test/slot-flash.test.ts
+++ b/javascript/packages/dev-tools/test/slot-flash.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect, beforeEach, afterEach } from "vitest"
 
 import { SlotFlash } from "../src/slots/flash"
+import { HerbOverlay } from "../src/overlay/overlay"
 
 const SLOT_EVENT = "herb:slot-update"
 
@@ -88,5 +89,48 @@ describe("SlotFlash", () => {
     announce()
 
     expect(drawn()).toHaveLength(0)
+  })
+})
+
+describe("an overlay that goes away", () => {
+  let overlays: HerbOverlay[]
+
+  beforeEach(() => {
+    flash.stop()
+
+    overlays = []
+    localStorage.setItem("herb-dev-tools-settings", JSON.stringify({ showingSlotUpdates: true }))
+  })
+
+  afterEach(() => {
+    overlays.forEach(overlay => overlay.destroy())
+    localStorage.clear()
+    document.querySelectorAll(".herb-slot-flash").forEach(node => node.remove())
+  })
+
+  function overlay() {
+    const created = new HerbOverlay()
+
+    overlays.push(created)
+
+    return created
+  }
+
+  test("takes its flash with it, so a destroyed overlay draws nothing", () => {
+    overlay().destroy()
+
+    announce()
+
+    expect(drawn()).toHaveLength(0)
+  })
+
+  test("leaves one overlay drawing once, however many came before it", () => {
+    overlay().destroy()
+    overlay().destroy()
+    overlay()
+
+    announce()
+
+    expect(drawn()).toHaveLength(2)
   })
 })


### PR DESCRIPTION
Follow up on #2299, which fixed the slot flash drawing nothing. With it drawing again, two things it was hiding became visible.

The first is that a branch swap never reports itself as one. `#writeFragment` is the only code that announces a `branch` operation, and its one caller is `apply`, so a server payload is the only thing that has ever reached it. `materialize` hands back a fragment and there was nothing public to install one, so a page that flips a branch on its own has to do the work by hand.

`switchBranch` is what `#applyBranch` does with the payload taken away.