### PR TITLE
Parser: Convert literals to static text in `transform_conditionals`

### DIFF
--- a/javascript/packages/linter/docs/rules/erb-prefer-explicit-conditionals.md
+++ b/javascript/packages/linter/docs/rules/erb-prefer-explicit-conditionals.md
@@ -34,6 +34,18 @@ This rule provides a safe autofix that replaces the tag with the explicit form t
 
 The fix stays on one line; run the formatter afterwards to break it up.
 
+An output that is a string, symbol, or number literal loses its output tag and becomes static text:
+
+```erb
+<%= "Saved" if notice? %>
+```
+
+```erb
+<% if notice? %>Saved<% end %>
+```
+
+A literal that HTML escaping would change keeps its output tag, so the rendered output stays the same. That covers any literal containing `&`, `<`, `>`, `"`, or `'`.
+
 Two cases are reported but not fixed:
 
 - A trimming tag closing (`<%= value if condition -%>`), because the `-%>` would end up mid-line, where it no longer trims the same whitespace.

--- a/javascript/packages/linter/src/rules/erb-prefer-explicit-conditionals.ts
+++ b/javascript/packages/linter/src/rules/erb-prefer-explicit-conditionals.ts
@@ -2,14 +2,14 @@ import { ParserRule, BaseAutofixContext } from "../types.js"
 import { BaseRuleVisitor } from "./rule-utils.js"
 import { IdentityPrinter } from "@herb-tools/printer"
 
-import { findParentArray, isERBContentNode, isERBIfNode } from "@herb-tools/core"
+import { findParentArray, isERBContentNode, isERBIfNode, isHTMLTextNode, isLiteralNode } from "@herb-tools/core"
 
 import type { Mutable } from "@herb-tools/rewriter"
 import type { ERBContentNode, ERBIfNode, ERBUnlessNode, Node, ParseResult, ParserOptions } from "@herb-tools/core"
 import type { FullRuleConfig, LintContext, LintOffense, UnboundLintOffense } from "../types.js"
 
 interface PreferExplicitConditionalsAutofixContext extends BaseAutofixContext {
-  node: Mutable<ERBContentNode>
+  node: Mutable<ERBIfNode> | Mutable<ERBUnlessNode>
   replacement: ERBIfNode | ERBUnlessNode
 }
 
@@ -30,15 +30,14 @@ function isInlineConditional(node: ERBIfNode | ERBUnlessNode): boolean {
   return true
 }
 
-function autofixableBody(node: ERBIfNode | ERBUnlessNode): ERBContentNode | null {
-  if (node.statements.length !== 1) return null
+function isAutofixable(node: ERBIfNode | ERBUnlessNode): boolean {
+  if (node.statements.length > 1) return false
 
   const [body] = node.statements
 
-  if (!isERBContentNode(body)) return null
-  if (body.tag_closing?.value !== "%>") return null
+  if (body === undefined) return true
 
-  return body
+  return isERBContentNode(body) || isLiteralNode(body) || isHTMLTextNode(body)
 }
 
 class PreferExplicitConditionalsVisitor extends BaseRuleVisitor<PreferExplicitConditionalsAutofixContext> {
@@ -58,10 +57,9 @@ class PreferExplicitConditionalsVisitor extends BaseRuleVisitor<PreferExplicitCo
     if (!isInlineConditional(node)) return
 
     const suggestion = IdentityPrinter.print(node).replace(/\s*\n\s*/g, " ")
-    const body = autofixableBody(node)
 
-    const autofixContext = body
-      ? { node: body as Mutable<ERBContentNode>, replacement: node }
+    const autofixContext = isAutofixable(node)
+      ? { node: node as Mutable<ERBIfNode | ERBUnlessNode>, nodeType: "AST_ERB_CONTENT_NODE", replacement: node }
       : undefined
 
     this.addOffense(
@@ -102,7 +100,12 @@ export class ERBPreferExplicitConditionalsRule extends ParserRule<PreferExplicit
     if (!offense.autofixContext) return null
 
     const { node, replacement } = offense.autofixContext
-    const parentInfo = findParentArray(result.value, node as unknown as ERBContentNode)
+    const original = node as unknown as ERBContentNode
+
+    if (!isERBContentNode(original)) return null
+    if (original.tag_closing?.value !== "%>") return null
+
+    const parentInfo = findParentArray(result.value, original)
 
     if (!parentInfo) return null
 

--- a/javascript/packages/linter/test/autofix/erb-prefer-explicit-conditionals.autofix.test.ts
+++ b/javascript/packages/linter/test/autofix/erb-prefer-explicit-conditionals.autofix.test.ts
@@ -105,13 +105,57 @@ describe("erb-prefer-explicit-conditionals autofix", () => {
 
   test("fixes an inline `if` inside an attribute value", () => {
     const input = `<div class="<%= "active" if selected %>"></div>`
-    const expected = `<div class="<% if selected %><%= "active" %><% end %>"></div>`
+    const expected = `<div class="<% if selected %>active<% end %>"></div>`
 
     const linter = new Linter(Herb, [ERBPreferExplicitConditionalsRule])
     const result = linter.autofix(input)
 
     expect(result.source).toBe(expected)
     expect(result.fixed).toHaveLength(1)
+  })
+
+  test("inlines a string literal as static text", () => {
+    const input = `<%= "Saved" if notice? %>`
+    const expected = `<% if notice? %>Saved<% end %>`
+
+    const linter = new Linter(Herb, [ERBPreferExplicitConditionalsRule])
+    const result = linter.autofix(input)
+
+    expect(result.source).toBe(expected)
+    expect(result.fixed).toHaveLength(1)
+  })
+
+  test("keeps the output tag when the string is interpolated", () => {
+    const input = '<%= "Hello #{name}" if greeting? %>'
+    const expected = '<% if greeting? %><%= "Hello #{name}" %><% end %>'
+
+    const linter = new Linter(Herb, [ERBPreferExplicitConditionalsRule])
+    const result = linter.autofix(input)
+
+    expect(result.source).toBe(expected)
+    expect(result.fixed).toHaveLength(1)
+  })
+
+  test("keeps the output tag when the literal would be HTML-escaped", () => {
+    const input = `<%= "5 > 3" if comparison? %>`
+    const expected = `<% if comparison? %><%= "5 > 3" %><% end %>`
+
+    const linter = new Linter(Herb, [ERBPreferExplicitConditionalsRule])
+    const result = linter.autofix(input)
+
+    expect(result.source).toBe(expected)
+    expect(result.fixed).toHaveLength(1)
+  })
+
+  test("leaves a trimming tag closing around a literal unfixed", () => {
+    const input = `<%= "Saved" if notice? -%>`
+
+    const linter = new Linter(Herb, [ERBPreferExplicitConditionalsRule])
+    const result = linter.autofix(input)
+
+    expect(result.source).toBe(input)
+    expect(result.fixed).toHaveLength(0)
+    expect(result.unfixed).toHaveLength(1)
   })
 
   test("fixes an inline `if` in attribute position", () => {

--- a/javascript/packages/linter/test/rules/erb-prefer-explicit-conditionals.test.ts
+++ b/javascript/packages/linter/test/rules/erb-prefer-explicit-conditionals.test.ts
@@ -65,7 +65,43 @@ describe("erb-prefer-explicit-conditionals", () => {
     `
 
     expectError(
-      'Prefer an explicit `<% if %>` block over an inline `if` condition. Use `<% if selected %><%= "active" %><% end %>` instead.'
+      "Prefer an explicit `<% if %>` block over an inline `if` condition. Use `<% if selected %>active<% end %>` instead."
+    )
+
+    assertOffenses(html)
+  })
+
+  it("suggests the literal as static text when the output is a string literal", () => {
+    const html = dedent`
+      <%= "Saved" if notice? %>
+    `
+
+    expectError(
+      "Prefer an explicit `<% if %>` block over an inline `if` condition. Use `<% if notice? %>Saved<% end %>` instead."
+    )
+
+    assertOffenses(html)
+  })
+
+  it("keeps the output tag when the string is interpolated", () => {
+    const html = dedent`
+      <%= "Hello #{name}" if greeting? %>
+    `
+
+    expectError(
+      'Prefer an explicit `<% if %>` block over an inline `if` condition. Use `<% if greeting? %><%= "Hello #{name}" %><% end %>` instead.'
+    )
+
+    assertOffenses(html)
+  })
+
+  it("keeps the output tag when the literal would be HTML-escaped", () => {
+    const html = dedent`
+      <%= "5 > 3" if comparison? %>
+    `
+
+    expectError(
+      'Prefer an explicit `<% if %>` block over an inline `if` condition. Use `<% if comparison? %><%= "5 > 3" %><% end %>` instead.'
     )
 
     assertOffenses(html)

--- a/src/analyze/analyze_helpers.c
+++ b/src/analyze/analyze_helpers.c
@@ -1076,6 +1076,14 @@ hb_array_T* extract_block_arguments_from_erb_node(
   );
 }
 
+bool is_erb_output_tag(const AST_ERB_CONTENT_NODE_T* erb_node) {
+  if (!erb_node || !erb_node->tag_opening) { return false; }
+
+  hb_string_T opening = erb_node->tag_opening->value;
+
+  return opening.length >= 3 && opening.data[0] == '<' && opening.data[1] == '%' && opening.data[2] == '=';
+}
+
 static bool is_escape_neutral(hb_string_T content) {
   for (uint32_t index = 0; index < content.length; index++) {
     switch (content.data[index]) {
@@ -1165,19 +1173,19 @@ static AST_NODE_T* create_static_output_node(
   }
 }
 
-bool build_static_output_node(
-  const pm_statements_node_t* statements,
+bool append_static_output_node(
+  hb_array_T* statements,
+  const pm_statements_node_t* body,
   const analyzed_ruby_T* analyzed,
   position_T content_start,
   static_output_node_type_T node_type,
-  hb_allocator_T* allocator,
-  AST_NODE_T** node
+  hb_allocator_T* allocator
 ) {
-  if (!statements || !analyzed || !node) { return false; }
+  if (!statements || !body || !analyzed) { return false; }
   if (node_type == STATIC_OUTPUT_NODE_NONE) { return false; }
-  if (statements->body.size != 1) { return false; }
+  if (body->body.size != 1) { return false; }
 
-  const pm_node_t* literal = statements->body.nodes[0];
+  const pm_node_t* literal = body->body.nodes[0];
   const uint8_t* parser_start = analyzed->parser.start;
 
   if (literal->location.start < parser_start || literal->location.end > analyzed->parser.end) { return false; }
@@ -1185,9 +1193,6 @@ bool build_static_output_node(
   hb_string_T content;
 
   if (!prism_node_static_output(literal, &content)) { return false; }
-
-  *node = NULL;
-
   if (content.length == 0) { return true; }
 
   size_t offset = (size_t) (literal->location.start - parser_start);
@@ -1197,7 +1202,11 @@ bool build_static_output_node(
   position_T end_position = { .line = content_start.line,
                               .column = content_start.column + (uint32_t) (offset + length) };
 
-  *node = create_static_output_node(content, node_type, start_position, end_position, allocator);
+  AST_NODE_T* node = create_static_output_node(content, node_type, start_position, end_position, allocator);
 
-  return *node != NULL;
+  if (!node) { return false; }
+
+  hb_array_append(statements, node);
+
+  return true;
 }

--- a/src/analyze/analyze_helpers.c
+++ b/src/analyze/analyze_helpers.c
@@ -1075,3 +1075,129 @@ hb_array_T* extract_block_arguments_from_erb_node(
     allocator
   );
 }
+
+static bool is_escape_neutral(hb_string_T content) {
+  for (uint32_t index = 0; index < content.length; index++) {
+    switch (content.data[index]) {
+      case '&':
+      case '<':
+      case '>':
+      case '"':
+      case '\'': return false;
+
+      default: break;
+    }
+  }
+
+  return true;
+}
+
+static bool is_plain_decimal_integer(hb_string_T source) {
+  uint32_t index = (source.length > 0 && source.data[0] == '-') ? 1 : 0;
+
+  if (index >= source.length) { return false; }
+  if (source.data[index] == '0' && (source.length - index) > 1) { return false; }
+
+  for (uint32_t position = index; position < source.length; position++) {
+    if (source.data[position] < '0' || source.data[position] > '9') { return false; }
+  }
+
+  return true;
+}
+
+static bool prism_node_static_output(const pm_node_t* node, hb_string_T* output) {
+  if (!node || !output) { return false; }
+
+  switch (node->type) {
+    case PM_STRING_NODE: {
+      const pm_string_t* unescaped = &((const pm_string_node_t*) node)->unescaped;
+
+      *output = hb_string_from_data((const char*) pm_string_source(unescaped), pm_string_length(unescaped));
+      break;
+    }
+
+    case PM_SYMBOL_NODE: {
+      const pm_string_t* unescaped = &((const pm_symbol_node_t*) node)->unescaped;
+
+      *output = hb_string_from_data((const char*) pm_string_source(unescaped), pm_string_length(unescaped));
+      break;
+    }
+
+    case PM_INTEGER_NODE: {
+      hb_string_T source =
+        hb_string_from_data((const char*) node->location.start, (size_t) (node->location.end - node->location.start));
+
+      if (!is_plain_decimal_integer(source)) { return false; }
+
+      *output = source;
+      break;
+    }
+
+    case PM_TRUE_NODE: *output = hb_string("true"); break;
+    case PM_FALSE_NODE: *output = hb_string("false"); break;
+    case PM_NIL_NODE: *output = HB_STRING_EMPTY; break;
+
+    default: return false;
+  }
+
+  return is_escape_neutral(*output);
+}
+
+static AST_NODE_T* create_static_output_node(
+  hb_string_T content,
+  static_output_node_type_T node_type,
+  position_T start_position,
+  position_T end_position,
+  hb_allocator_T* allocator
+) {
+  switch (node_type) {
+    case STATIC_OUTPUT_NODE_HTML_TEXT:
+      return (
+        AST_NODE_T*
+      ) ast_html_text_node_init(content, start_position, end_position, hb_array_init(0, allocator), allocator);
+
+    case STATIC_OUTPUT_NODE_LITERAL:
+      return (
+        AST_NODE_T*
+      ) ast_literal_node_init(content, start_position, end_position, hb_array_init(0, allocator), allocator);
+
+    default: return NULL;
+  }
+}
+
+bool build_static_output_node(
+  const pm_statements_node_t* statements,
+  const analyzed_ruby_T* analyzed,
+  position_T content_start,
+  static_output_node_type_T node_type,
+  hb_allocator_T* allocator,
+  AST_NODE_T** node
+) {
+  if (!statements || !analyzed || !node) { return false; }
+  if (node_type == STATIC_OUTPUT_NODE_NONE) { return false; }
+  if (statements->body.size != 1) { return false; }
+
+  const pm_node_t* literal = statements->body.nodes[0];
+  const uint8_t* parser_start = analyzed->parser.start;
+
+  if (literal->location.start < parser_start || literal->location.end > analyzed->parser.end) { return false; }
+
+  hb_string_T content;
+
+  if (!prism_node_static_output(literal, &content)) { return false; }
+
+  *node = NULL;
+
+  if (content.length == 0) { return true; }
+
+  size_t offset = (size_t) (literal->location.start - parser_start);
+  size_t length = (size_t) (literal->location.end - literal->location.start);
+
+  position_T start_position = { .line = content_start.line, .column = content_start.column + (uint32_t) offset };
+  position_T end_position = { .line = content_start.line,
+                              .column = content_start.column + (uint32_t) (offset + length) };
+
+  *node = create_static_output_node(content, node_type, start_position, end_position, allocator);
+
+  return *node != NULL;
+}

--- a/src/analyze/postfix_conditionals.c
+++ b/src/analyze/postfix_conditionals.c
@@ -2,6 +2,7 @@
 #include "../include/analyze/action_view/tag_helper_node_builders.h"
 #include "../include/analyze/analyze.h"
 #include "../include/analyze/analyzed_ruby.h"
+#include "../include/analyze/helpers.h"
 #include "../include/analyze/ternary_conditionals.h"
 #include "../include/ast/ast_nodes.h"
 #include "../include/lib/hb_allocator.h"
@@ -83,18 +84,19 @@ static body_info_T extract_statements_body_info(
   return info;
 }
 
+static pm_statements_node_t* conditional_statements(pm_node_t* conditional_node) {
+  if (conditional_node->type == PM_IF_NODE) { return ((pm_if_node_t*) conditional_node)->statements; }
+  if (conditional_node->type == PM_UNLESS_NODE) { return ((pm_unless_node_t*) conditional_node)->statements; }
+
+  return NULL;
+}
+
 static body_info_T extract_body_info(
   pm_node_t* conditional_node,
   analyzed_ruby_T* analyzed,
   hb_allocator_T* allocator
 ) {
-  pm_statements_node_t* statements = NULL;
-
-  if (conditional_node->type == PM_IF_NODE) {
-    statements = ((pm_if_node_t*) conditional_node)->statements;
-  } else if (conditional_node->type == PM_UNLESS_NODE) {
-    statements = ((pm_unless_node_t*) conditional_node)->statements;
-  }
+  pm_statements_node_t* statements = conditional_statements(conditional_node);
 
   body_info_T info = extract_statements_body_info(statements, analyzed, allocator);
 
@@ -131,13 +133,7 @@ static const char* condition_keyword(pm_node_t* conditional_node) {
 }
 
 static pm_if_node_t* find_nested_ternary(pm_node_t* conditional_node) {
-  pm_statements_node_t* statements = NULL;
-
-  if (conditional_node->type == PM_IF_NODE) {
-    statements = ((pm_if_node_t*) conditional_node)->statements;
-  } else if (conditional_node->type == PM_UNLESS_NODE) {
-    statements = ((pm_unless_node_t*) conditional_node)->statements;
-  }
+  pm_statements_node_t* statements = conditional_statements(conditional_node);
 
   if (!statements || statements->body.size != 1) { return NULL; }
 
@@ -167,6 +163,7 @@ static pm_if_node_t* find_nested_ternary(pm_node_t* conditional_node) {
 static AST_NODE_T* transform_conditional(
   AST_ERB_CONTENT_NODE_T* erb_node,
   pm_node_t* conditional_node,
+  static_output_node_type_T static_node_type,
   hb_allocator_T* allocator
 ) {
   body_info_T body_info = extract_body_info(conditional_node, erb_node->analyzed_ruby, allocator);
@@ -209,14 +206,31 @@ static AST_NODE_T* transform_conditional(
   if (!body_erb_node) { return NULL; }
 
   hb_array_T* statements = hb_array_init(1, allocator);
-  hb_array_append(statements, (AST_NODE_T*) body_erb_node);
 
   pm_if_node_t* nested_ternary = find_nested_ternary(conditional_node);
 
   if (nested_ternary) {
-    AST_NODE_T* ternary_replacement = transform_ternary_expression(erb_node, nested_ternary, allocator);
+    AST_NODE_T* ternary_replacement =
+      transform_ternary_expression(erb_node, nested_ternary, static_node_type, allocator);
 
-    if (ternary_replacement) { hb_array_set(statements, 0, ternary_replacement); }
+    hb_array_append(statements, ternary_replacement ? ternary_replacement : (AST_NODE_T*) body_erb_node);
+  } else {
+    AST_NODE_T* static_node = NULL;
+
+    bool is_static = build_static_output_node(
+      conditional_statements(conditional_node),
+      erb_node->analyzed_ruby,
+      content_start,
+      static_node_type,
+      allocator,
+      &static_node
+    );
+
+    if (!is_static) {
+      hb_array_append(statements, (AST_NODE_T*) body_erb_node);
+    } else if (static_node) {
+      hb_array_append(statements, static_node);
+    }
   }
 
   hb_buffer_T condition_buffer;
@@ -279,7 +293,11 @@ static AST_NODE_T* transform_conditional(
   }
 }
 
-static void transform_conditional_array(hb_array_T* array, analyze_ruby_context_T* context) {
+static void transform_conditional_array(
+  hb_array_T* array,
+  analyze_ruby_context_T* context,
+  static_output_node_type_T static_node_type
+) {
   if (!array || !context) { return; }
 
   for (size_t i = 0; i < hb_array_size(array); i++) {
@@ -294,7 +312,7 @@ static void transform_conditional_array(hb_array_T* array, analyze_ruby_context_
     pm_node_t* conditional_node = find_postfix_conditional_statement(erb_node->analyzed_ruby);
     if (!conditional_node) { continue; }
 
-    AST_NODE_T* replacement = transform_conditional(erb_node, conditional_node, context->allocator);
+    AST_NODE_T* replacement = transform_conditional(erb_node, conditional_node, static_node_type, context->allocator);
     if (replacement) { hb_array_set(array, i, replacement); }
   }
 }
@@ -303,13 +321,24 @@ static void transform_conditional_blocks(const AST_NODE_T* node, analyze_ruby_co
   if (!node || !context) { return; }
 
   switch (node->type) {
-    case AST_DOCUMENT_NODE: transform_conditional_array(((AST_DOCUMENT_NODE_T*) node)->children, context); break;
-    case AST_HTML_ELEMENT_NODE: transform_conditional_array(((AST_HTML_ELEMENT_NODE_T*) node)->body, context); break;
-    case AST_HTML_OPEN_TAG_NODE:
-      transform_conditional_array(((AST_HTML_OPEN_TAG_NODE_T*) node)->children, context);
+    case AST_DOCUMENT_NODE:
+      transform_conditional_array(((AST_DOCUMENT_NODE_T*) node)->children, context, STATIC_OUTPUT_NODE_HTML_TEXT);
       break;
+
+    case AST_HTML_ELEMENT_NODE:
+      transform_conditional_array(((AST_HTML_ELEMENT_NODE_T*) node)->body, context, STATIC_OUTPUT_NODE_HTML_TEXT);
+      break;
+
+    case AST_HTML_OPEN_TAG_NODE:
+      transform_conditional_array(((AST_HTML_OPEN_TAG_NODE_T*) node)->children, context, STATIC_OUTPUT_NODE_NONE);
+      break;
+
     case AST_HTML_ATTRIBUTE_VALUE_NODE:
-      transform_conditional_array(((AST_HTML_ATTRIBUTE_VALUE_NODE_T*) node)->children, context);
+      transform_conditional_array(
+        ((AST_HTML_ATTRIBUTE_VALUE_NODE_T*) node)->children,
+        context,
+        STATIC_OUTPUT_NODE_LITERAL
+      );
       break;
     default: break;
   }

--- a/src/analyze/postfix_conditionals.c
+++ b/src/analyze/postfix_conditionals.c
@@ -15,14 +15,6 @@
 #include <stdbool.h>
 #include <string.h>
 
-static bool is_erb_output_tag(AST_ERB_CONTENT_NODE_T* erb_node) {
-  if (!erb_node || !erb_node->tag_opening) { return false; }
-
-  hb_string_T opening = erb_node->tag_opening->value;
-
-  return opening.length >= 3 && opening.data[0] == '<' && opening.data[1] == '%' && opening.data[2] == '=';
-}
-
 static pm_node_t* find_postfix_conditional_statement(analyzed_ruby_T* analyzed) {
   if (!analyzed || !analyzed->valid || !analyzed->root) { return NULL; }
 
@@ -160,15 +152,64 @@ static pm_if_node_t* find_nested_ternary(pm_node_t* conditional_node) {
   return NULL;
 }
 
+static bool append_body_statement(
+  hb_array_T* statements,
+  pm_node_t* conditional_node,
+  AST_ERB_CONTENT_NODE_T* erb_node,
+  static_output_node_type_T static_node_type,
+  hb_allocator_T* allocator
+) {
+  position_T content_start = erb_node->content->location.start;
+
+  if (append_static_output_node(
+        statements,
+        conditional_statements(conditional_node),
+        erb_node->analyzed_ruby,
+        content_start,
+        static_node_type,
+        allocator
+      )) {
+    return true;
+  }
+
+  body_info_T info = extract_body_info(conditional_node, erb_node->analyzed_ruby, allocator);
+  if (!info.source) { return false; }
+
+  position_T body_start = { .line = content_start.line,
+                            .column = content_start.column + (uint32_t) info.offset_in_content };
+
+  position_T body_end = { .line = content_start.line,
+                          .column = content_start.column + (uint32_t) (info.offset_in_content + info.length) };
+
+  token_T* content = create_synthetic_token(allocator, info.source, TOKEN_ERB_CONTENT, body_start, body_end);
+
+  AST_ERB_CONTENT_NODE_T* body_erb_node = ast_erb_content_node_init(
+    erb_node->tag_opening,
+    content,
+    erb_node->tag_closing,
+    NULL,
+    false,
+    true,
+    HERB_PRISM_NODE_EMPTY,
+    erb_node->base.location.start,
+    erb_node->base.location.end,
+    hb_array_init(0, allocator),
+    allocator
+  );
+
+  if (!body_erb_node) { return false; }
+
+  hb_array_append(statements, (AST_NODE_T*) body_erb_node);
+
+  return true;
+}
+
 static AST_NODE_T* transform_conditional(
   AST_ERB_CONTENT_NODE_T* erb_node,
   pm_node_t* conditional_node,
   static_output_node_type_T static_node_type,
   hb_allocator_T* allocator
 ) {
-  body_info_T body_info = extract_body_info(conditional_node, erb_node->analyzed_ruby, allocator);
-  if (!body_info.source) { return NULL; }
-
   char* condition_source = extract_condition_source(conditional_node, allocator);
   if (!condition_source) { return NULL; }
 
@@ -177,60 +218,18 @@ static AST_NODE_T* transform_conditional(
 
   position_T start = erb_node->base.location.start;
   position_T end = erb_node->base.location.end;
-  position_T content_start = erb_node->content->location.start;
-
-  position_T body_content_start = { .line = content_start.line,
-                                    .column = content_start.column + (uint32_t) body_info.offset_in_content };
-
-  position_T body_content_end = { .line = content_start.line,
-                                  .column = content_start.column
-                                          + (uint32_t) (body_info.offset_in_content + body_info.length) };
-
-  token_T* body_content =
-    create_synthetic_token(allocator, body_info.source, TOKEN_ERB_CONTENT, body_content_start, body_content_end);
-
-  AST_ERB_CONTENT_NODE_T* body_erb_node = ast_erb_content_node_init(
-    erb_node->tag_opening,
-    body_content,
-    erb_node->tag_closing,
-    NULL,
-    false,
-    true,
-    HERB_PRISM_NODE_EMPTY,
-    start,
-    end,
-    hb_array_init(0, allocator),
-    allocator
-  );
-
-  if (!body_erb_node) { return NULL; }
 
   hb_array_T* statements = hb_array_init(1, allocator);
 
   pm_if_node_t* nested_ternary = find_nested_ternary(conditional_node);
 
-  if (nested_ternary) {
-    AST_NODE_T* ternary_replacement =
-      transform_ternary_expression(erb_node, nested_ternary, static_node_type, allocator);
+  AST_NODE_T* ternary_replacement =
+    nested_ternary ? transform_ternary_expression(erb_node, nested_ternary, static_node_type, allocator) : NULL;
 
-    hb_array_append(statements, ternary_replacement ? ternary_replacement : (AST_NODE_T*) body_erb_node);
-  } else {
-    AST_NODE_T* static_node = NULL;
-
-    bool is_static = build_static_output_node(
-      conditional_statements(conditional_node),
-      erb_node->analyzed_ruby,
-      content_start,
-      static_node_type,
-      allocator,
-      &static_node
-    );
-
-    if (!is_static) {
-      hb_array_append(statements, (AST_NODE_T*) body_erb_node);
-    } else if (static_node) {
-      hb_array_append(statements, static_node);
-    }
+  if (ternary_replacement) {
+    hb_array_append(statements, ternary_replacement);
+  } else if (!append_body_statement(statements, conditional_node, erb_node, static_node_type, allocator)) {
+    return NULL;
   }
 
   hb_buffer_T condition_buffer;

--- a/src/analyze/ternary_conditionals.c
+++ b/src/analyze/ternary_conditionals.c
@@ -2,6 +2,7 @@
 #include "../include/analyze/action_view/tag_helper_node_builders.h"
 #include "../include/analyze/analyze.h"
 #include "../include/analyze/analyzed_ruby.h"
+#include "../include/analyze/helpers.h"
 #include "../include/ast/ast_nodes.h"
 #include "../include/lib/hb_allocator.h"
 #include "../include/lib/hb_array.h"
@@ -100,9 +101,37 @@ static char* extract_condition_source(pm_if_node_t* if_node, hb_allocator_T* all
   return hb_allocator_strndup(allocator, (const char*) predicate->location.start, length);
 }
 
+static void append_branch_statement(
+  hb_array_T* statements,
+  const pm_statements_node_t* branch,
+  AST_ERB_CONTENT_NODE_T* erb_node,
+  AST_ERB_CONTENT_NODE_T* branch_erb_node,
+  static_output_node_type_T static_node_type,
+  hb_allocator_T* allocator
+) {
+  AST_NODE_T* static_node = NULL;
+
+  bool is_static = build_static_output_node(
+    branch,
+    erb_node->analyzed_ruby,
+    erb_node->content->location.start,
+    static_node_type,
+    allocator,
+    &static_node
+  );
+
+  if (!is_static) {
+    hb_array_append(statements, (AST_NODE_T*) branch_erb_node);
+    return;
+  }
+
+  if (static_node) { hb_array_append(statements, static_node); }
+}
+
 AST_NODE_T* transform_ternary_expression(
   AST_ERB_CONTENT_NODE_T* erb_node,
   pm_if_node_t* if_node,
+  static_output_node_type_T static_node_type,
   hb_allocator_T* allocator
 ) {
   body_info_T true_info = extract_statements_body_info(if_node->statements, erb_node->analyzed_ruby, allocator);
@@ -176,8 +205,16 @@ AST_NODE_T* transform_ternary_expression(
   hb_array_T* true_statements = hb_array_init(1, allocator);
   hb_array_T* false_statements = hb_array_init(1, allocator);
 
-  hb_array_append(true_statements, (AST_NODE_T*) true_erb_node);
-  hb_array_append(false_statements, (AST_NODE_T*) false_erb_node);
+  append_branch_statement(true_statements, if_node->statements, erb_node, true_erb_node, static_node_type, allocator);
+
+  append_branch_statement(
+    false_statements,
+    else_node->statements,
+    erb_node,
+    false_erb_node,
+    static_node_type,
+    allocator
+  );
 
   token_T* else_opening = create_synthetic_token(allocator, "<%", TOKEN_ERB_START, end, end);
   token_T* else_content_token = create_synthetic_token(allocator, " else ", TOKEN_ERB_CONTENT, end, end);
@@ -233,7 +270,11 @@ AST_NODE_T* transform_ternary_expression(
   return (AST_NODE_T*) result_if_node;
 }
 
-static void transform_ternary_array(hb_array_T* array, analyze_ruby_context_T* context) {
+static void transform_ternary_array(
+  hb_array_T* array,
+  analyze_ruby_context_T* context,
+  static_output_node_type_T static_node_type
+) {
   if (!array || !context) { return; }
 
   for (size_t i = 0; i < hb_array_size(array); i++) {
@@ -248,7 +289,8 @@ static void transform_ternary_array(hb_array_T* array, analyze_ruby_context_T* c
     pm_node_t* ternary_node = find_ternary_statement(erb_node->analyzed_ruby);
     if (!ternary_node) { continue; }
 
-    AST_NODE_T* replacement = transform_ternary_expression(erb_node, (pm_if_node_t*) ternary_node, context->allocator);
+    AST_NODE_T* replacement =
+      transform_ternary_expression(erb_node, (pm_if_node_t*) ternary_node, static_node_type, context->allocator);
     if (replacement) { hb_array_set(array, i, replacement); }
   }
 }
@@ -257,11 +299,20 @@ static void transform_ternary_blocks(const AST_NODE_T* node, analyze_ruby_contex
   if (!node || !context) { return; }
 
   switch (node->type) {
-    case AST_DOCUMENT_NODE: transform_ternary_array(((AST_DOCUMENT_NODE_T*) node)->children, context); break;
-    case AST_HTML_ELEMENT_NODE: transform_ternary_array(((AST_HTML_ELEMENT_NODE_T*) node)->body, context); break;
-    case AST_HTML_OPEN_TAG_NODE: transform_ternary_array(((AST_HTML_OPEN_TAG_NODE_T*) node)->children, context); break;
+    case AST_DOCUMENT_NODE:
+      transform_ternary_array(((AST_DOCUMENT_NODE_T*) node)->children, context, STATIC_OUTPUT_NODE_HTML_TEXT);
+      break;
+
+    case AST_HTML_ELEMENT_NODE:
+      transform_ternary_array(((AST_HTML_ELEMENT_NODE_T*) node)->body, context, STATIC_OUTPUT_NODE_HTML_TEXT);
+      break;
+
+    case AST_HTML_OPEN_TAG_NODE:
+      transform_ternary_array(((AST_HTML_OPEN_TAG_NODE_T*) node)->children, context, STATIC_OUTPUT_NODE_NONE);
+      break;
+
     case AST_HTML_ATTRIBUTE_VALUE_NODE:
-      transform_ternary_array(((AST_HTML_ATTRIBUTE_VALUE_NODE_T*) node)->children, context);
+      transform_ternary_array(((AST_HTML_ATTRIBUTE_VALUE_NODE_T*) node)->children, context, STATIC_OUTPUT_NODE_LITERAL);
       break;
     default: break;
   }

--- a/src/analyze/ternary_conditionals.c
+++ b/src/analyze/ternary_conditionals.c
@@ -14,14 +14,6 @@
 #include <stdbool.h>
 #include <string.h>
 
-static bool is_erb_output_tag(AST_ERB_CONTENT_NODE_T* erb_node) {
-  if (!erb_node || !erb_node->tag_opening) { return false; }
-
-  hb_string_T opening = erb_node->tag_opening->value;
-
-  return opening.length >= 3 && opening.data[0] == '<' && opening.data[1] == '%' && opening.data[2] == '=';
-}
-
 static pm_node_t* find_ternary_statement(analyzed_ruby_T* analyzed) {
   if (!analyzed || !analyzed->valid || !analyzed->root) { return NULL; }
 
@@ -101,31 +93,56 @@ static char* extract_condition_source(pm_if_node_t* if_node, hb_allocator_T* all
   return hb_allocator_strndup(allocator, (const char*) predicate->location.start, length);
 }
 
-static void append_branch_statement(
+static bool append_branch_statement(
   hb_array_T* statements,
-  const pm_statements_node_t* branch,
+  pm_statements_node_t* branch,
   AST_ERB_CONTENT_NODE_T* erb_node,
-  AST_ERB_CONTENT_NODE_T* branch_erb_node,
   static_output_node_type_T static_node_type,
   hb_allocator_T* allocator
 ) {
-  AST_NODE_T* static_node = NULL;
+  position_T content_start = erb_node->content->location.start;
 
-  bool is_static = build_static_output_node(
-    branch,
-    erb_node->analyzed_ruby,
-    erb_node->content->location.start,
-    static_node_type,
-    allocator,
-    &static_node
-  );
-
-  if (!is_static) {
-    hb_array_append(statements, (AST_NODE_T*) branch_erb_node);
-    return;
+  if (append_static_output_node(
+        statements,
+        branch,
+        erb_node->analyzed_ruby,
+        content_start,
+        static_node_type,
+        allocator
+      )) {
+    return true;
   }
 
-  if (static_node) { hb_array_append(statements, static_node); }
+  body_info_T info = extract_statements_body_info(branch, erb_node->analyzed_ruby, allocator);
+  if (!info.source) { return false; }
+
+  position_T branch_start = { .line = content_start.line,
+                              .column = content_start.column + (uint32_t) info.offset_in_content };
+
+  position_T branch_end = { .line = content_start.line,
+                            .column = content_start.column + (uint32_t) (info.offset_in_content + info.length) };
+
+  token_T* content = create_synthetic_token(allocator, info.source, TOKEN_ERB_CONTENT, branch_start, branch_end);
+
+  AST_ERB_CONTENT_NODE_T* branch_erb_node = ast_erb_content_node_init(
+    erb_node->tag_opening,
+    content,
+    erb_node->tag_closing,
+    NULL,
+    false,
+    true,
+    HERB_PRISM_NODE_EMPTY,
+    erb_node->base.location.start,
+    erb_node->base.location.end,
+    hb_array_init(0, allocator),
+    allocator
+  );
+
+  if (!branch_erb_node) { return false; }
+
+  hb_array_append(statements, (AST_NODE_T*) branch_erb_node);
+
+  return true;
 }
 
 AST_NODE_T* transform_ternary_expression(
@@ -134,87 +151,25 @@ AST_NODE_T* transform_ternary_expression(
   static_output_node_type_T static_node_type,
   hb_allocator_T* allocator
 ) {
-  body_info_T true_info = extract_statements_body_info(if_node->statements, erb_node->analyzed_ruby, allocator);
-  if (!true_info.source) { return NULL; }
-
   pm_else_node_t* else_node = (pm_else_node_t*) if_node->subsequent;
   if (!else_node) { return NULL; }
-
-  body_info_T false_info = extract_statements_body_info(else_node->statements, erb_node->analyzed_ruby, allocator);
-  if (!false_info.source) { return NULL; }
 
   char* condition_source = extract_condition_source(if_node, allocator);
   if (!condition_source) { return NULL; }
 
   position_T start = erb_node->base.location.start;
   position_T end = erb_node->base.location.end;
-  position_T content_start = erb_node->content->location.start;
-
-  position_T true_content_start = { .line = content_start.line,
-                                    .column = content_start.column + (uint32_t) true_info.offset_in_content };
-
-  position_T true_content_end = { .line = content_start.line,
-                                  .column = content_start.column
-                                          + (uint32_t) (true_info.offset_in_content + true_info.length) };
-
-  token_T* true_content =
-    create_synthetic_token(allocator, true_info.source, TOKEN_ERB_CONTENT, true_content_start, true_content_end);
-
-  AST_ERB_CONTENT_NODE_T* true_erb_node = ast_erb_content_node_init(
-    erb_node->tag_opening,
-    true_content,
-    erb_node->tag_closing,
-    NULL,
-    false,
-    true,
-    HERB_PRISM_NODE_EMPTY,
-    start,
-    end,
-    hb_array_init(0, allocator),
-    allocator
-  );
-
-  if (!true_erb_node) { return NULL; }
-
-  position_T false_content_start = { .line = content_start.line,
-                                     .column = content_start.column + (uint32_t) false_info.offset_in_content };
-
-  position_T false_content_end = { .line = content_start.line,
-                                   .column = content_start.column
-                                           + (uint32_t) (false_info.offset_in_content + false_info.length) };
-
-  token_T* false_content =
-    create_synthetic_token(allocator, false_info.source, TOKEN_ERB_CONTENT, false_content_start, false_content_end);
-
-  AST_ERB_CONTENT_NODE_T* false_erb_node = ast_erb_content_node_init(
-    erb_node->tag_opening,
-    false_content,
-    erb_node->tag_closing,
-    NULL,
-    false,
-    true,
-    HERB_PRISM_NODE_EMPTY,
-    start,
-    end,
-    hb_array_init(0, allocator),
-    allocator
-  );
-
-  if (!false_erb_node) { return NULL; }
 
   hb_array_T* true_statements = hb_array_init(1, allocator);
   hb_array_T* false_statements = hb_array_init(1, allocator);
 
-  append_branch_statement(true_statements, if_node->statements, erb_node, true_erb_node, static_node_type, allocator);
+  if (!append_branch_statement(true_statements, if_node->statements, erb_node, static_node_type, allocator)) {
+    return NULL;
+  }
 
-  append_branch_statement(
-    false_statements,
-    else_node->statements,
-    erb_node,
-    false_erb_node,
-    static_node_type,
-    allocator
-  );
+  if (!append_branch_statement(false_statements, else_node->statements, erb_node, static_node_type, allocator)) {
+    return NULL;
+  }
 
   token_T* else_opening = create_synthetic_token(allocator, "<%", TOKEN_ERB_START, end, end);
   token_T* else_content_token = create_synthetic_token(allocator, " else ", TOKEN_ERB_CONTENT, end, end);

--- a/src/include/analyze/helpers.h
+++ b/src/include/analyze/helpers.h
@@ -74,6 +74,21 @@ hb_array_T* extract_parameters_from_prism(
   hb_allocator_T* allocator
 );
 
+typedef enum {
+  STATIC_OUTPUT_NODE_NONE,
+  STATIC_OUTPUT_NODE_HTML_TEXT,
+  STATIC_OUTPUT_NODE_LITERAL,
+} static_output_node_type_T;
+
+bool build_static_output_node(
+  const pm_statements_node_t* statements,
+  const analyzed_ruby_T* analyzed,
+  position_T content_start,
+  static_output_node_type_T node_type,
+  hb_allocator_T* allocator,
+  AST_NODE_T** node
+);
+
 hb_array_T* extract_block_arguments_from_erb_node(
   const AST_ERB_CONTENT_NODE_T* erb_node,
   const char* source,

--- a/src/include/analyze/helpers.h
+++ b/src/include/analyze/helpers.h
@@ -74,19 +74,21 @@ hb_array_T* extract_parameters_from_prism(
   hb_allocator_T* allocator
 );
 
+bool is_erb_output_tag(const AST_ERB_CONTENT_NODE_T* erb_node);
+
 typedef enum {
   STATIC_OUTPUT_NODE_NONE,
   STATIC_OUTPUT_NODE_HTML_TEXT,
   STATIC_OUTPUT_NODE_LITERAL,
 } static_output_node_type_T;
 
-bool build_static_output_node(
-  const pm_statements_node_t* statements,
+bool append_static_output_node(
+  hb_array_T* statements,
+  const pm_statements_node_t* body,
   const analyzed_ruby_T* analyzed,
   position_T content_start,
   static_output_node_type_T node_type,
-  hb_allocator_T* allocator,
-  AST_NODE_T** node
+  hb_allocator_T* allocator
 );
 
 hb_array_T* extract_block_arguments_from_erb_node(

--- a/src/include/analyze/ternary_conditionals.h
+++ b/src/include/analyze/ternary_conditionals.h
@@ -3,10 +3,12 @@
 
 #include "../ast/ast_nodes.h"
 #include "analyze.h"
+#include "helpers.h"
 
 AST_NODE_T* transform_ternary_expression(
   AST_ERB_CONTENT_NODE_T* erb_node,
   pm_if_node_t* if_node,
+  static_output_node_type_T static_node_type,
   hb_allocator_T* allocator
 );
 

--- a/test/analyze/postfix_conditional_test.rb
+++ b/test/analyze/postfix_conditional_test.rb
@@ -192,5 +192,11 @@ module Analyze
         <%= (condition? ? "true":"false") if another_condition? %>
       HTML
     end
+
+    test "postfix with a body that would be HTML-escaped" do
+      assert_parsed_snapshot(<<~HTML, transform_conditionals: true)
+        <%= '<b>' if selected %>
+      HTML
+    end
   end
 end

--- a/test/analyze/ternary_conditional_test.rb
+++ b/test/analyze/ternary_conditional_test.rb
@@ -96,5 +96,23 @@ module Analyze
         <%= condition ? 'yes' : 'no' %>
       HTML
     end
+
+    test "ternary with symbol branches" do
+      assert_parsed_snapshot(<<~HTML, transform_conditionals: true)
+        <%= cond ? :active : :inactive %>
+      HTML
+    end
+
+    test "ternary with branches that would be HTML-escaped" do
+      assert_parsed_snapshot(<<~HTML, transform_conditionals: true)
+        <%= cond ? '<b>' : 'a & b' %>
+      HTML
+    end
+
+    test "ternary with numeric branches that render differently than they are written" do
+      assert_parsed_snapshot(<<~HTML, transform_conditionals: true)
+        <%= cond ? 1_000 : 0x1f %>
+      HTML
+    end
   end
 end

--- a/test/engine/action_view/postfix_conditional_test.rb
+++ b/test/engine/action_view/postfix_conditional_test.rb
@@ -41,6 +41,21 @@ module Engine
           { condition: false }
         )
       end
+
+      test "string literal with postfix if condition" do
+        assert_optimized_snapshot(
+          '<%= "Notice" if condition %>',
+          { condition: true }
+        )
+      end
+
+      test "string literal that would be HTML-escaped with postfix if condition" do
+        assert_compiled_snapshot(
+          '<%= "5 > 3" if condition %>',
+          escape: true,
+          visitors: [Herb::Engine::OptimizeVisitor.new]
+        )
+      end
     end
   end
 end

--- a/test/engine/action_view/ternary_conditional_test.rb
+++ b/test/engine/action_view/ternary_conditional_test.rb
@@ -41,6 +41,28 @@ module Engine
           { admin: true }
         )
       end
+
+      test "ternary with string literals in both branches" do
+        assert_optimized_snapshot(
+          '<%= active ? "On" : "Off" %>',
+          { active: true }
+        )
+      end
+
+      test "ternary with string literals inside an attribute value" do
+        assert_optimized_snapshot(
+          '<div class="<%= active ? "on" : "off" %>">Body</div>',
+          { active: true }
+        )
+      end
+
+      test "ternary with literals that would be HTML-escaped" do
+        assert_compiled_snapshot(
+          '<%= active ? "5 > 3" : "a & b" %>',
+          escape: true,
+          visitors: [Herb::Engine::OptimizeVisitor.new]
+        )
+      end
     end
   end
 end

--- a/test/snapshots/analyze/postfix_conditional_test/test_0001_string_literal_with_postfix_if_2ce76059718e2a1b23dd554c490728f2-4661ff3a6866fa9b1c7c564c651dfe75.txt
+++ b/test/snapshots/analyze/postfix_conditional_test/test_0001_string_literal_with_postfix_if_2ce76059718e2a1b23dd554c490728f2-4661ff3a6866fa9b1c7c564c651dfe75.txt
@@ -12,12 +12,8 @@ options: {transform_conditionals: true}
     │   ├── tag_closing: "%>" (location: (1:38)-(1:38))
     │   ├── then_keyword: ∅
     │   ├── statements: (1 item)
-    │   │   └── @ ERBContentNode (location: (1:0)-(1:38))
-    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
-    │   │       ├── content: " 'aria-current=page' " (location: (1:3)-(1:24))
-    │   │       ├── tag_closing: "%>" (location: (1:36)-(1:38))
-    │   │       ├── parsed: false
-    │   │       └── valid: true
+    │   │   └── @ HTMLTextNode (location: (1:4)-(1:23))
+    │   │       └── content: "aria-current=page"
     │   │
     │   ├── subsequent: ∅
     │   └── end_node:

--- a/test/snapshots/analyze/postfix_conditional_test/test_0002_string_literal_with_postfix_unless_6ef88110880088ad1268c6379a763169-4661ff3a6866fa9b1c7c564c651dfe75.txt
+++ b/test/snapshots/analyze/postfix_conditional_test/test_0002_string_literal_with_postfix_unless_6ef88110880088ad1268c6379a763169-4661ff3a6866fa9b1c7c564c651dfe75.txt
@@ -12,12 +12,8 @@ options: {transform_conditionals: true}
     │   ├── tag_closing: "%>" (location: (1:28)-(1:28))
     │   ├── then_keyword: ∅
     │   ├── statements: (1 item)
-    │   │   └── @ ERBContentNode (location: (1:0)-(1:28))
-    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
-    │   │       ├── content: " 'text' " (location: (1:3)-(1:11))
-    │   │       ├── tag_closing: "%>" (location: (1:26)-(1:28))
-    │   │       ├── parsed: false
-    │   │       └── valid: true
+    │   │   └── @ HTMLTextNode (location: (1:4)-(1:10))
+    │   │       └── content: "text"
     │   │
     │   ├── else_clause: ∅
     │   └── end_node:

--- a/test/snapshots/analyze/postfix_conditional_test/test_0003_symbol_with_postfix_if_9a5324fd5643a11486e00cb3c5f2efbc-4661ff3a6866fa9b1c7c564c651dfe75.txt
+++ b/test/snapshots/analyze/postfix_conditional_test/test_0003_symbol_with_postfix_if_9a5324fd5643a11486e00cb3c5f2efbc-4661ff3a6866fa9b1c7c564c651dfe75.txt
@@ -12,12 +12,8 @@ options: {transform_conditionals: true}
     │   ├── tag_closing: "%>" (location: (1:26)-(1:26))
     │   ├── then_keyword: ∅
     │   ├── statements: (1 item)
-    │   │   └── @ ERBContentNode (location: (1:0)-(1:26))
-    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
-    │   │       ├── content: " :active " (location: (1:3)-(1:12))
-    │   │       ├── tag_closing: "%>" (location: (1:24)-(1:26))
-    │   │       ├── parsed: false
-    │   │       └── valid: true
+    │   │   └── @ HTMLTextNode (location: (1:4)-(1:11))
+    │   │       └── content: "active"
     │   │
     │   ├── subsequent: ∅
     │   └── end_node:

--- a/test/snapshots/analyze/postfix_conditional_test/test_0013_inside_attribute_value_1edec9d74ba1ed141a80146a9e83e9b3-4661ff3a6866fa9b1c7c564c651dfe75.txt
+++ b/test/snapshots/analyze/postfix_conditional_test/test_0013_inside_attribute_value_1edec9d74ba1ed141a80146a9e83e9b3-4661ff3a6866fa9b1c7c564c651dfe75.txt
@@ -32,12 +32,8 @@ options: {transform_conditionals: true}
     │   │       │               │       ├── tag_closing: "%>" (location: (1:39)-(1:39))
     │   │       │               │       ├── then_keyword: ∅
     │   │       │               │       ├── statements: (1 item)
-    │   │       │               │       │   └── @ ERBContentNode (location: (1:12)-(1:39))
-    │   │       │               │       │       ├── tag_opening: "<%=" (location: (1:12)-(1:15))
-    │   │       │               │       │       ├── content: " 'active' " (location: (1:15)-(1:25))
-    │   │       │               │       │       ├── tag_closing: "%>" (location: (1:37)-(1:39))
-    │   │       │               │       │       ├── parsed: false
-    │   │       │               │       │       └── valid: true
+    │   │       │               │       │   └── @ LiteralNode (location: (1:16)-(1:24))
+    │   │       │               │       │       └── content: "active"
     │   │       │               │       │
     │   │       │               │       ├── subsequent: ∅
     │   │       │               │       └── end_node:

--- a/test/snapshots/analyze/postfix_conditional_test/test_0015_compound_condition_with_postfix_if_4cda3a8d56b2fc1032928b2967d965ec-4661ff3a6866fa9b1c7c564c651dfe75.txt
+++ b/test/snapshots/analyze/postfix_conditional_test/test_0015_compound_condition_with_postfix_if_4cda3a8d56b2fc1032928b2967d965ec-4661ff3a6866fa9b1c7c564c651dfe75.txt
@@ -12,12 +12,8 @@ options: {transform_conditionals: true}
     │   ├── tag_closing: "%>" (location: (1:45)-(1:45))
     │   ├── then_keyword: ∅
     │   ├── statements: (1 item)
-    │   │   └── @ ERBContentNode (location: (1:0)-(1:45))
-    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
-    │   │       ├── content: " 'admin' " (location: (1:3)-(1:12))
-    │   │       ├── tag_closing: "%>" (location: (1:43)-(1:45))
-    │   │       ├── parsed: false
-    │   │       └── valid: true
+    │   │   └── @ HTMLTextNode (location: (1:4)-(1:11))
+    │   │       └── content: "admin"
     │   │
     │   ├── subsequent: ∅
     │   └── end_node:

--- a/test/snapshots/analyze/postfix_conditional_test/test_0016_multiple_postfix_tags_in_document_37508ec5c501bfce7b1c39fc159cccb1-4661ff3a6866fa9b1c7c564c651dfe75.txt
+++ b/test/snapshots/analyze/postfix_conditional_test/test_0016_multiple_postfix_tags_in_document_37508ec5c501bfce7b1c39fc159cccb1-4661ff3a6866fa9b1c7c564c651dfe75.txt
@@ -13,12 +13,8 @@ options: {transform_conditionals: true}
     │   ├── tag_closing: "%>" (location: (1:29)-(1:29))
     │   ├── then_keyword: ∅
     │   ├── statements: (1 item)
-    │   │   └── @ ERBContentNode (location: (1:0)-(1:29))
-    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
-    │   │       ├── content: " 'first' " (location: (1:3)-(1:12))
-    │   │       ├── tag_closing: "%>" (location: (1:27)-(1:29))
-    │   │       ├── parsed: false
-    │   │       └── valid: true
+    │   │   └── @ HTMLTextNode (location: (1:4)-(1:11))
+    │   │       └── content: "first"
     │   │
     │   ├── subsequent: ∅
     │   └── end_node:
@@ -37,12 +33,8 @@ options: {transform_conditionals: true}
     │   ├── tag_closing: "%>" (location: (2:35)-(2:35))
     │   ├── then_keyword: ∅
     │   ├── statements: (1 item)
-    │   │   └── @ ERBContentNode (location: (2:0)-(2:35))
-    │   │       ├── tag_opening: "<%=" (location: (2:0)-(2:3))
-    │   │       ├── content: " 'second' " (location: (2:3)-(2:13))
-    │   │       ├── tag_closing: "%>" (location: (2:33)-(2:35))
-    │   │       ├── parsed: false
-    │   │       └── valid: true
+    │   │   └── @ HTMLTextNode (location: (2:4)-(2:12))
+    │   │       └── content: "second"
     │   │
     │   ├── else_clause: ∅
     │   └── end_node:

--- a/test/snapshots/analyze/postfix_conditional_test/test_0017_postfix_inside_html_element_body_5b5c268618da0a5335f9e83a075187eb-4661ff3a6866fa9b1c7c564c651dfe75.txt
+++ b/test/snapshots/analyze/postfix_conditional_test/test_0017_postfix_inside_html_element_body_5b5c268618da0a5335f9e83a075187eb-4661ff3a6866fa9b1c7c564c651dfe75.txt
@@ -23,12 +23,8 @@ options: {transform_conditionals: true}
     │   │       ├── tag_closing: "%>" (location: (1:30)-(1:30))
     │   │       ├── then_keyword: ∅
     │   │       ├── statements: (1 item)
-    │   │       │   └── @ ERBContentNode (location: (1:5)-(1:30))
-    │   │       │       ├── tag_opening: "<%=" (location: (1:5)-(1:8))
-    │   │       │       ├── content: " 'text' " (location: (1:8)-(1:16))
-    │   │       │       ├── tag_closing: "%>" (location: (1:28)-(1:30))
-    │   │       │       ├── parsed: false
-    │   │       │       └── valid: true
+    │   │       │   └── @ HTMLTextNode (location: (1:9)-(1:15))
+    │   │       │       └── content: "text"
     │   │       │
     │   │       ├── subsequent: ∅
     │   │       └── end_node:

--- a/test/snapshots/analyze/postfix_conditional_test/test_0020_numeric_literal_with_postfix_if_fdd1d4c587ddf39e07f5a0d8db305959-4661ff3a6866fa9b1c7c564c651dfe75.txt
+++ b/test/snapshots/analyze/postfix_conditional_test/test_0020_numeric_literal_with_postfix_if_fdd1d4c587ddf39e07f5a0d8db305959-4661ff3a6866fa9b1c7c564c651dfe75.txt
@@ -12,12 +12,8 @@ options: {transform_conditionals: true}
     │   ├── tag_closing: "%>" (location: (1:24)-(1:24))
     │   ├── then_keyword: ∅
     │   ├── statements: (1 item)
-    │   │   └── @ ERBContentNode (location: (1:0)-(1:24))
-    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
-    │   │       ├── content: " 42 " (location: (1:3)-(1:7))
-    │   │       ├── tag_closing: "%>" (location: (1:22)-(1:24))
-    │   │       ├── parsed: false
-    │   │       └── valid: true
+    │   │   └── @ HTMLTextNode (location: (1:4)-(1:6))
+    │   │       └── content: "42"
     │   │
     │   ├── subsequent: ∅
     │   └── end_node:

--- a/test/snapshots/analyze/postfix_conditional_test/test_0029_ternary_with_postfix_if_d783f47a069f199ce614b565525bf4ee-4661ff3a6866fa9b1c7c564c651dfe75.txt
+++ b/test/snapshots/analyze/postfix_conditional_test/test_0029_ternary_with_postfix_if_d783f47a069f199ce614b565525bf4ee-4661ff3a6866fa9b1c7c564c651dfe75.txt
@@ -18,12 +18,8 @@ options: {transform_conditionals: true}
     │   │       ├── tag_closing: "%>" (location: (1:60)-(1:60))
     │   │       ├── then_keyword: ∅
     │   │       ├── statements: (1 item)
-    │   │       │   └── @ ERBContentNode (location: (1:0)-(1:60))
-    │   │       │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
-    │   │       │       ├── content: " "true" " (location: (1:17)-(1:25))
-    │   │       │       ├── tag_closing: "%>" (location: (1:58)-(1:60))
-    │   │       │       ├── parsed: false
-    │   │       │       └── valid: true
+    │   │       │   └── @ HTMLTextNode (location: (1:18)-(1:24))
+    │   │       │       └── content: "true"
     │   │       │
     │   │       ├── subsequent:
     │   │       │   └── @ ERBElseNode (location: (1:60)-(1:60))
@@ -31,12 +27,8 @@ options: {transform_conditionals: true}
     │   │       │       ├── content: " else " (location: (1:60)-(1:60))
     │   │       │       ├── tag_closing: "%>" (location: (1:60)-(1:60))
     │   │       │       └── statements: (1 item)
-    │   │       │           └── @ ERBContentNode (location: (1:0)-(1:60))
-    │   │       │               ├── tag_opening: "<%=" (location: (1:0)-(1:3))
-    │   │       │               ├── content: " "false" " (location: (1:26)-(1:34))
-    │   │       │               ├── tag_closing: "%>" (location: (1:58)-(1:60))
-    │   │       │               ├── parsed: false
-    │   │       │               └── valid: true
+    │   │       │           └── @ HTMLTextNode (location: (1:27)-(1:34))
+    │   │       │               └── content: "false"
     │   │       │
     │   │       │
     │   │       └── end_node:

--- a/test/snapshots/analyze/postfix_conditional_test/test_0030_ternary_with_postfix_unless_2b59dd97f76a7e716bbdcb153f134069-4661ff3a6866fa9b1c7c564c651dfe75.txt
+++ b/test/snapshots/analyze/postfix_conditional_test/test_0030_ternary_with_postfix_unless_2b59dd97f76a7e716bbdcb153f134069-4661ff3a6866fa9b1c7c564c651dfe75.txt
@@ -18,12 +18,8 @@ options: {transform_conditionals: true}
     │   │       ├── tag_closing: "%>" (location: (1:53)-(1:53))
     │   │       ├── then_keyword: ∅
     │   │       ├── statements: (1 item)
-    │   │       │   └── @ ERBContentNode (location: (1:0)-(1:53))
-    │   │       │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
-    │   │       │       ├── content: " "true" " (location: (1:17)-(1:25))
-    │   │       │       ├── tag_closing: "%>" (location: (1:51)-(1:53))
-    │   │       │       ├── parsed: false
-    │   │       │       └── valid: true
+    │   │       │   └── @ HTMLTextNode (location: (1:18)-(1:24))
+    │   │       │       └── content: "true"
     │   │       │
     │   │       ├── subsequent:
     │   │       │   └── @ ERBElseNode (location: (1:53)-(1:53))
@@ -31,12 +27,8 @@ options: {transform_conditionals: true}
     │   │       │       ├── content: " else " (location: (1:53)-(1:53))
     │   │       │       ├── tag_closing: "%>" (location: (1:53)-(1:53))
     │   │       │       └── statements: (1 item)
-    │   │       │           └── @ ERBContentNode (location: (1:0)-(1:53))
-    │   │       │               ├── tag_opening: "<%=" (location: (1:0)-(1:3))
-    │   │       │               ├── content: " "false" " (location: (1:26)-(1:34))
-    │   │       │               ├── tag_closing: "%>" (location: (1:51)-(1:53))
-    │   │       │               ├── parsed: false
-    │   │       │               └── valid: true
+    │   │       │           └── @ HTMLTextNode (location: (1:27)-(1:34))
+    │   │       │               └── content: "false"
     │   │       │
     │   │       │
     │   │       └── end_node:

--- a/test/snapshots/analyze/postfix_conditional_test/test_0031_ternary_without_spaces_around_branches_with_postfix_if_1efea1d2ac3f3bc9014f9d3a94ec6860-4661ff3a6866fa9b1c7c564c651dfe75.txt
+++ b/test/snapshots/analyze/postfix_conditional_test/test_0031_ternary_without_spaces_around_branches_with_postfix_if_1efea1d2ac3f3bc9014f9d3a94ec6860-4661ff3a6866fa9b1c7c564c651dfe75.txt
@@ -18,12 +18,8 @@ options: {transform_conditionals: true}
     │   │       ├── tag_closing: "%>" (location: (1:58)-(1:58))
     │   │       ├── then_keyword: ∅
     │   │       ├── statements: (1 item)
-    │   │       │   └── @ ERBContentNode (location: (1:0)-(1:58))
-    │   │       │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
-    │   │       │       ├── content: " "true" " (location: (1:17)-(1:24))
-    │   │       │       ├── tag_closing: "%>" (location: (1:56)-(1:58))
-    │   │       │       ├── parsed: false
-    │   │       │       └── valid: true
+    │   │       │   └── @ HTMLTextNode (location: (1:18)-(1:24))
+    │   │       │       └── content: "true"
     │   │       │
     │   │       ├── subsequent:
     │   │       │   └── @ ERBElseNode (location: (1:58)-(1:58))
@@ -31,12 +27,8 @@ options: {transform_conditionals: true}
     │   │       │       ├── content: " else " (location: (1:58)-(1:58))
     │   │       │       ├── tag_closing: "%>" (location: (1:58)-(1:58))
     │   │       │       └── statements: (1 item)
-    │   │       │           └── @ ERBContentNode (location: (1:0)-(1:58))
-    │   │       │               ├── tag_opening: "<%=" (location: (1:0)-(1:3))
-    │   │       │               ├── content: " "false" " (location: (1:25)-(1:32))
-    │   │       │               ├── tag_closing: "%>" (location: (1:56)-(1:58))
-    │   │       │               ├── parsed: false
-    │   │       │               └── valid: true
+    │   │       │           └── @ HTMLTextNode (location: (1:25)-(1:32))
+    │   │       │               └── content: "false"
     │   │       │
     │   │       │
     │   │       └── end_node:

--- a/test/snapshots/analyze/postfix_conditional_test/test_0032_postfix_with_a_body_that_would_be_HTML-escaped_6568dc9165b54095b0986ae77b45187b-4661ff3a6866fa9b1c7c564c651dfe75.txt
+++ b/test/snapshots/analyze/postfix_conditional_test/test_0032_postfix_with_a_body_that_would_be_HTML-escaped_6568dc9165b54095b0986ae77b45187b-4661ff3a6866fa9b1c7c564c651dfe75.txt
@@ -1,19 +1,23 @@
 ---
-source: "Analyze::PostfixConditionalTest#test_0023_postfix with negated condition"
+source: "Analyze::PostfixConditionalTest#test_0032_postfix with a body that would be HTML-escaped"
 input: |2-
-<%= 'text' if !hidden %>
+<%= '<b>' if selected %>
 options: {transform_conditionals: true}
 ---
 @ DocumentNode (location: (1:0)-(2:0))
 └── children: (2 items)
     ├── @ ERBIfNode (location: (1:0)-(1:24))
     │   ├── tag_opening: "<%" (location: (1:0)-(1:0))
-    │   ├── content: " if !hidden " (location: (1:0)-(1:24))
+    │   ├── content: " if selected " (location: (1:0)-(1:24))
     │   ├── tag_closing: "%>" (location: (1:24)-(1:24))
     │   ├── then_keyword: ∅
     │   ├── statements: (1 item)
-    │   │   └── @ HTMLTextNode (location: (1:4)-(1:10))
-    │   │       └── content: "text"
+    │   │   └── @ ERBContentNode (location: (1:0)-(1:24))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " '<b>' " (location: (1:3)-(1:10))
+    │   │       ├── tag_closing: "%>" (location: (1:22)-(1:24))
+    │   │       ├── parsed: false
+    │   │       └── valid: true
     │   │
     │   ├── subsequent: ∅
     │   └── end_node:

--- a/test/snapshots/analyze/ternary_conditional_test/test_0001_simple_ternary_0456807342f1cd4590a2b861e84524ba-4661ff3a6866fa9b1c7c564c651dfe75.txt
+++ b/test/snapshots/analyze/ternary_conditional_test/test_0001_simple_ternary_0456807342f1cd4590a2b861e84524ba-4661ff3a6866fa9b1c7c564c651dfe75.txt
@@ -12,12 +12,8 @@ options: {transform_conditionals: true}
     │   ├── tag_closing: "%>" (location: (1:31)-(1:31))
     │   ├── then_keyword: ∅
     │   ├── statements: (1 item)
-    │   │   └── @ ERBContentNode (location: (1:0)-(1:31))
-    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
-    │   │       ├── content: " 'yes' " (location: (1:15)-(1:22))
-    │   │       ├── tag_closing: "%>" (location: (1:29)-(1:31))
-    │   │       ├── parsed: false
-    │   │       └── valid: true
+    │   │   └── @ HTMLTextNode (location: (1:16)-(1:21))
+    │   │       └── content: "yes"
     │   │
     │   ├── subsequent:
     │   │   └── @ ERBElseNode (location: (1:31)-(1:31))
@@ -25,12 +21,8 @@ options: {transform_conditionals: true}
     │   │       ├── content: " else " (location: (1:31)-(1:31))
     │   │       ├── tag_closing: "%>" (location: (1:31)-(1:31))
     │   │       └── statements: (1 item)
-    │   │           └── @ ERBContentNode (location: (1:0)-(1:31))
-    │   │               ├── tag_opening: "<%=" (location: (1:0)-(1:3))
-    │   │               ├── content: " 'no' " (location: (1:23)-(1:29))
-    │   │               ├── tag_closing: "%>" (location: (1:29)-(1:31))
-    │   │               ├── parsed: false
-    │   │               └── valid: true
+    │   │           └── @ HTMLTextNode (location: (1:24)-(1:28))
+    │   │               └── content: "no"
     │   │
     │   │
     │   └── end_node:

--- a/test/snapshots/analyze/ternary_conditional_test/test_0002_ternary_with_method_calls_c35527fbcc0423896f2190d25c9c7cef-4661ff3a6866fa9b1c7c564c651dfe75.txt
+++ b/test/snapshots/analyze/ternary_conditional_test/test_0002_ternary_with_method_calls_c35527fbcc0423896f2190d25c9c7cef-4661ff3a6866fa9b1c7c564c651dfe75.txt
@@ -12,12 +12,8 @@ options: {transform_conditionals: true}
     │   ├── tag_closing: "%>" (location: (1:43)-(1:43))
     │   ├── then_keyword: ∅
     │   ├── statements: (1 item)
-    │   │   └── @ ERBContentNode (location: (1:0)-(1:43))
-    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
-    │   │       ├── content: " 'active' " (location: (1:18)-(1:28))
-    │   │       ├── tag_closing: "%>" (location: (1:41)-(1:43))
-    │   │       ├── parsed: false
-    │   │       └── valid: true
+    │   │   └── @ HTMLTextNode (location: (1:19)-(1:27))
+    │   │       └── content: "active"
     │   │
     │   ├── subsequent:
     │   │   └── @ ERBElseNode (location: (1:43)-(1:43))
@@ -25,12 +21,8 @@ options: {transform_conditionals: true}
     │   │       ├── content: " else " (location: (1:43)-(1:43))
     │   │       ├── tag_closing: "%>" (location: (1:43)-(1:43))
     │   │       └── statements: (1 item)
-    │   │           └── @ ERBContentNode (location: (1:0)-(1:43))
-    │   │               ├── tag_opening: "<%=" (location: (1:0)-(1:3))
-    │   │               ├── content: " 'inactive' " (location: (1:29)-(1:41))
-    │   │               ├── tag_closing: "%>" (location: (1:41)-(1:43))
-    │   │               ├── parsed: false
-    │   │               └── valid: true
+    │   │           └── @ HTMLTextNode (location: (1:30)-(1:40))
+    │   │               └── content: "inactive"
     │   │
     │   │
     │   └── end_node:

--- a/test/snapshots/analyze/ternary_conditional_test/test_0003_ternary_inside_html_element_393e19a88309ca36d6da3f60550ad69e-4661ff3a6866fa9b1c7c564c651dfe75.txt
+++ b/test/snapshots/analyze/ternary_conditional_test/test_0003_ternary_inside_html_element_393e19a88309ca36d6da3f60550ad69e-4661ff3a6866fa9b1c7c564c651dfe75.txt
@@ -23,12 +23,8 @@ options: {transform_conditionals: true}
     │   │       ├── tag_closing: "%>" (location: (1:28)-(1:28))
     │   │       ├── then_keyword: ∅
     │   │       ├── statements: (1 item)
-    │   │       │   └── @ ERBContentNode (location: (1:5)-(1:28))
-    │   │       │       ├── tag_opening: "<%=" (location: (1:5)-(1:8))
-    │   │       │       ├── content: " 'a' " (location: (1:15)-(1:20))
-    │   │       │       ├── tag_closing: "%>" (location: (1:26)-(1:28))
-    │   │       │       ├── parsed: false
-    │   │       │       └── valid: true
+    │   │       │   └── @ HTMLTextNode (location: (1:16)-(1:19))
+    │   │       │       └── content: "a"
     │   │       │
     │   │       ├── subsequent:
     │   │       │   └── @ ERBElseNode (location: (1:28)-(1:28))
@@ -36,12 +32,8 @@ options: {transform_conditionals: true}
     │   │       │       ├── content: " else " (location: (1:28)-(1:28))
     │   │       │       ├── tag_closing: "%>" (location: (1:28)-(1:28))
     │   │       │       └── statements: (1 item)
-    │   │       │           └── @ ERBContentNode (location: (1:5)-(1:28))
-    │   │       │               ├── tag_opening: "<%=" (location: (1:5)-(1:8))
-    │   │       │               ├── content: " 'b' " (location: (1:21)-(1:26))
-    │   │       │               ├── tag_closing: "%>" (location: (1:26)-(1:28))
-    │   │       │               ├── parsed: false
-    │   │       │               └── valid: true
+    │   │       │           └── @ HTMLTextNode (location: (1:22)-(1:25))
+    │   │       │               └── content: "b"
     │   │       │
     │   │       │
     │   │       └── end_node:

--- a/test/snapshots/analyze/ternary_conditional_test/test_0004_ternary_inside_attribute_value_b2ba513f39e98a391b5087d75f7aa27d-4661ff3a6866fa9b1c7c564c651dfe75.txt
+++ b/test/snapshots/analyze/ternary_conditional_test/test_0004_ternary_inside_attribute_value_b2ba513f39e98a391b5087d75f7aa27d-4661ff3a6866fa9b1c7c564c651dfe75.txt
@@ -32,12 +32,8 @@ options: {transform_conditionals: true}
     │   │       │               │       ├── tag_closing: "%>" (location: (1:35)-(1:35))
     │   │       │               │       ├── then_keyword: ∅
     │   │       │               │       ├── statements: (1 item)
-    │   │       │               │       │   └── @ ERBContentNode (location: (1:12)-(1:35))
-    │   │       │               │       │       ├── tag_opening: "<%=" (location: (1:12)-(1:15))
-    │   │       │               │       │       ├── content: " 'a' " (location: (1:22)-(1:27))
-    │   │       │               │       │       ├── tag_closing: "%>" (location: (1:33)-(1:35))
-    │   │       │               │       │       ├── parsed: false
-    │   │       │               │       │       └── valid: true
+    │   │       │               │       │   └── @ LiteralNode (location: (1:23)-(1:26))
+    │   │       │               │       │       └── content: "a"
     │   │       │               │       │
     │   │       │               │       ├── subsequent:
     │   │       │               │       │   └── @ ERBElseNode (location: (1:35)-(1:35))
@@ -45,12 +41,8 @@ options: {transform_conditionals: true}
     │   │       │               │       │       ├── content: " else " (location: (1:35)-(1:35))
     │   │       │               │       │       ├── tag_closing: "%>" (location: (1:35)-(1:35))
     │   │       │               │       │       └── statements: (1 item)
-    │   │       │               │       │           └── @ ERBContentNode (location: (1:12)-(1:35))
-    │   │       │               │       │               ├── tag_opening: "<%=" (location: (1:12)-(1:15))
-    │   │       │               │       │               ├── content: " 'b' " (location: (1:28)-(1:33))
-    │   │       │               │       │               ├── tag_closing: "%>" (location: (1:33)-(1:35))
-    │   │       │               │       │               ├── parsed: false
-    │   │       │               │       │               └── valid: true
+    │   │       │               │       │           └── @ LiteralNode (location: (1:29)-(1:32))
+    │   │       │               │       │               └── content: "b"
     │   │       │               │       │
     │   │       │               │       │
     │   │       │               │       └── end_node:

--- a/test/snapshots/analyze/ternary_conditional_test/test_0006_ternary_inside_attribute_value_with_static_prefix_9bde6a87bcc66aa6b821229779e6bb7e-4661ff3a6866fa9b1c7c564c651dfe75.txt
+++ b/test/snapshots/analyze/ternary_conditional_test/test_0006_ternary_inside_attribute_value_with_static_prefix_9bde6a87bcc66aa6b821229779e6bb7e-4661ff3a6866fa9b1c7c564c651dfe75.txt
@@ -35,12 +35,8 @@ options: {transform_conditionals: true}
     │   │       │               │       ├── tag_closing: "%>" (location: (1:57)-(1:57))
     │   │       │               │       ├── then_keyword: ∅
     │   │       │               │       ├── statements: (1 item)
-    │   │       │               │       │   └── @ ERBContentNode (location: (1:22)-(1:57))
-    │   │       │               │       │       ├── tag_opening: "<%=" (location: (1:22)-(1:25))
-    │   │       │               │       │       ├── content: " 'active' " (location: (1:32)-(1:42))
-    │   │       │               │       │       ├── tag_closing: "%>" (location: (1:55)-(1:57))
-    │   │       │               │       │       ├── parsed: false
-    │   │       │               │       │       └── valid: true
+    │   │       │               │       │   └── @ LiteralNode (location: (1:33)-(1:41))
+    │   │       │               │       │       └── content: "active"
     │   │       │               │       │
     │   │       │               │       ├── subsequent:
     │   │       │               │       │   └── @ ERBElseNode (location: (1:57)-(1:57))
@@ -48,12 +44,8 @@ options: {transform_conditionals: true}
     │   │       │               │       │       ├── content: " else " (location: (1:57)-(1:57))
     │   │       │               │       │       ├── tag_closing: "%>" (location: (1:57)-(1:57))
     │   │       │               │       │       └── statements: (1 item)
-    │   │       │               │       │           └── @ ERBContentNode (location: (1:22)-(1:57))
-    │   │       │               │       │               ├── tag_opening: "<%=" (location: (1:22)-(1:25))
-    │   │       │               │       │               ├── content: " 'inactive' " (location: (1:43)-(1:55))
-    │   │       │               │       │               ├── tag_closing: "%>" (location: (1:55)-(1:57))
-    │   │       │               │       │               ├── parsed: false
-    │   │       │               │       │               └── valid: true
+    │   │       │               │       │           └── @ LiteralNode (location: (1:44)-(1:54))
+    │   │       │               │       │               └── content: "inactive"
     │   │       │               │       │
     │   │       │               │       │
     │   │       │               │       └── end_node:

--- a/test/snapshots/analyze/ternary_conditional_test/test_0007_ternary_inside_attribute_value_with_static_suffix_8570a49ab541970c51d122b9644f3de4-4661ff3a6866fa9b1c7c564c651dfe75.txt
+++ b/test/snapshots/analyze/ternary_conditional_test/test_0007_ternary_inside_attribute_value_with_static_suffix_8570a49ab541970c51d122b9644f3de4-4661ff3a6866fa9b1c7c564c651dfe75.txt
@@ -32,12 +32,8 @@ options: {transform_conditionals: true}
     │   │       │               │   │   ├── tag_closing: "%>" (location: (1:43)-(1:43))
     │   │       │               │   │   ├── then_keyword: ∅
     │   │       │               │   │   ├── statements: (1 item)
-    │   │       │               │   │   │   └── @ ERBContentNode (location: (1:12)-(1:43))
-    │   │       │               │   │   │       ├── tag_opening: "<%=" (location: (1:12)-(1:15))
-    │   │       │               │   │   │       ├── content: " 'text' " (location: (1:22)-(1:30))
-    │   │       │               │   │   │       ├── tag_closing: "%>" (location: (1:41)-(1:43))
-    │   │       │               │   │   │       ├── parsed: false
-    │   │       │               │   │   │       └── valid: true
+    │   │       │               │   │   │   └── @ LiteralNode (location: (1:23)-(1:29))
+    │   │       │               │   │   │       └── content: "text"
     │   │       │               │   │   │
     │   │       │               │   │   ├── subsequent:
     │   │       │               │   │   │   └── @ ERBElseNode (location: (1:43)-(1:43))
@@ -45,12 +41,8 @@ options: {transform_conditionals: true}
     │   │       │               │   │   │       ├── content: " else " (location: (1:43)-(1:43))
     │   │       │               │   │   │       ├── tag_closing: "%>" (location: (1:43)-(1:43))
     │   │       │               │   │   │       └── statements: (1 item)
-    │   │       │               │   │   │           └── @ ERBContentNode (location: (1:12)-(1:43))
-    │   │       │               │   │   │               ├── tag_opening: "<%=" (location: (1:12)-(1:15))
-    │   │       │               │   │   │               ├── content: " 'hidden' " (location: (1:31)-(1:41))
-    │   │       │               │   │   │               ├── tag_closing: "%>" (location: (1:41)-(1:43))
-    │   │       │               │   │   │               ├── parsed: false
-    │   │       │               │   │   │               └── valid: true
+    │   │       │               │   │   │           └── @ LiteralNode (location: (1:32)-(1:40))
+    │   │       │               │   │   │               └── content: "hidden"
     │   │       │               │   │   │
     │   │       │               │   │   │
     │   │       │               │   │   └── end_node:

--- a/test/snapshots/analyze/ternary_conditional_test/test_0008_ternary_inside_attribute_value_with_static_prefix_and_suffix_d1966767adb51027f12426c4ce1c3544-4661ff3a6866fa9b1c7c564c651dfe75.txt
+++ b/test/snapshots/analyze/ternary_conditional_test/test_0008_ternary_inside_attribute_value_with_static_prefix_and_suffix_d1966767adb51027f12426c4ce1c3544-4661ff3a6866fa9b1c7c564c651dfe75.txt
@@ -35,12 +35,8 @@ options: {transform_conditionals: true}
     │   │       │               │   │   ├── tag_closing: "%>" (location: (1:57)-(1:57))
     │   │       │               │   │   ├── then_keyword: ∅
     │   │       │               │   │   ├── statements: (1 item)
-    │   │       │               │   │   │   └── @ ERBContentNode (location: (1:22)-(1:57))
-    │   │       │               │   │   │       ├── tag_opening: "<%=" (location: (1:22)-(1:25))
-    │   │       │               │   │   │       ├── content: " 'active' " (location: (1:32)-(1:42))
-    │   │       │               │   │   │       ├── tag_closing: "%>" (location: (1:55)-(1:57))
-    │   │       │               │   │   │       ├── parsed: false
-    │   │       │               │   │   │       └── valid: true
+    │   │       │               │   │   │   └── @ LiteralNode (location: (1:33)-(1:41))
+    │   │       │               │   │   │       └── content: "active"
     │   │       │               │   │   │
     │   │       │               │   │   ├── subsequent:
     │   │       │               │   │   │   └── @ ERBElseNode (location: (1:57)-(1:57))
@@ -48,12 +44,8 @@ options: {transform_conditionals: true}
     │   │       │               │   │   │       ├── content: " else " (location: (1:57)-(1:57))
     │   │       │               │   │   │       ├── tag_closing: "%>" (location: (1:57)-(1:57))
     │   │       │               │   │   │       └── statements: (1 item)
-    │   │       │               │   │   │           └── @ ERBContentNode (location: (1:22)-(1:57))
-    │   │       │               │   │   │               ├── tag_opening: "<%=" (location: (1:22)-(1:25))
-    │   │       │               │   │   │               ├── content: " 'inactive' " (location: (1:43)-(1:55))
-    │   │       │               │   │   │               ├── tag_closing: "%>" (location: (1:55)-(1:57))
-    │   │       │               │   │   │               ├── parsed: false
-    │   │       │               │   │   │               └── valid: true
+    │   │       │               │   │   │           └── @ LiteralNode (location: (1:44)-(1:54))
+    │   │       │               │   │   │               └── content: "inactive"
     │   │       │               │   │   │
     │   │       │               │   │   │
     │   │       │               │   │   └── end_node:

--- a/test/snapshots/analyze/ternary_conditional_test/test_0009_multiple_ternaries_in_document_2b2fc9fe503dfc05a69de9173cfbabe7-4661ff3a6866fa9b1c7c564c651dfe75.txt
+++ b/test/snapshots/analyze/ternary_conditional_test/test_0009_multiple_ternaries_in_document_2b2fc9fe503dfc05a69de9173cfbabe7-4661ff3a6866fa9b1c7c564c651dfe75.txt
@@ -13,12 +13,8 @@ options: {transform_conditionals: true}
     │   ├── tag_closing: "%>" (location: (1:24)-(1:24))
     │   ├── then_keyword: ∅
     │   ├── statements: (1 item)
-    │   │   └── @ ERBContentNode (location: (1:0)-(1:24))
-    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
-    │   │       ├── content: " 'a' " (location: (1:11)-(1:16))
-    │   │       ├── tag_closing: "%>" (location: (1:22)-(1:24))
-    │   │       ├── parsed: false
-    │   │       └── valid: true
+    │   │   └── @ HTMLTextNode (location: (1:12)-(1:15))
+    │   │       └── content: "a"
     │   │
     │   ├── subsequent:
     │   │   └── @ ERBElseNode (location: (1:24)-(1:24))
@@ -26,12 +22,8 @@ options: {transform_conditionals: true}
     │   │       ├── content: " else " (location: (1:24)-(1:24))
     │   │       ├── tag_closing: "%>" (location: (1:24)-(1:24))
     │   │       └── statements: (1 item)
-    │   │           └── @ ERBContentNode (location: (1:0)-(1:24))
-    │   │               ├── tag_opening: "<%=" (location: (1:0)-(1:3))
-    │   │               ├── content: " 'b' " (location: (1:17)-(1:22))
-    │   │               ├── tag_closing: "%>" (location: (1:22)-(1:24))
-    │   │               ├── parsed: false
-    │   │               └── valid: true
+    │   │           └── @ HTMLTextNode (location: (1:18)-(1:21))
+    │   │               └── content: "b"
     │   │
     │   │
     │   └── end_node:
@@ -50,12 +42,8 @@ options: {transform_conditionals: true}
     │   ├── tag_closing: "%>" (location: (2:25)-(2:25))
     │   ├── then_keyword: ∅
     │   ├── statements: (1 item)
-    │   │   └── @ ERBContentNode (location: (2:0)-(2:25))
-    │   │       ├── tag_opening: "<%=" (location: (2:0)-(2:3))
-    │   │       ├── content: " 'c' " (location: (2:12)-(2:17))
-    │   │       ├── tag_closing: "%>" (location: (2:23)-(2:25))
-    │   │       ├── parsed: false
-    │   │       └── valid: true
+    │   │   └── @ HTMLTextNode (location: (2:13)-(2:16))
+    │   │       └── content: "c"
     │   │
     │   ├── subsequent:
     │   │   └── @ ERBElseNode (location: (2:25)-(2:25))
@@ -63,12 +51,8 @@ options: {transform_conditionals: true}
     │   │       ├── content: " else " (location: (2:25)-(2:25))
     │   │       ├── tag_closing: "%>" (location: (2:25)-(2:25))
     │   │       └── statements: (1 item)
-    │   │           └── @ ERBContentNode (location: (2:0)-(2:25))
-    │   │               ├── tag_opening: "<%=" (location: (2:0)-(2:3))
-    │   │               ├── content: " 'd' " (location: (2:18)-(2:23))
-    │   │               ├── tag_closing: "%>" (location: (2:23)-(2:25))
-    │   │               ├── parsed: false
-    │   │               └── valid: true
+    │   │           └── @ HTMLTextNode (location: (2:19)-(2:22))
+    │   │               └── content: "d"
     │   │
     │   │
     │   └── end_node:

--- a/test/snapshots/analyze/ternary_conditional_test/test_0010_ternary_with_string_interpolation_3808c83f7e22aec6c37db565eadeffaf-4661ff3a6866fa9b1c7c564c651dfe75.txt
+++ b/test/snapshots/analyze/ternary_conditional_test/test_0010_ternary_with_string_interpolation_3808c83f7e22aec6c37db565eadeffaf-4661ff3a6866fa9b1c7c564c651dfe75.txt
@@ -25,12 +25,8 @@ options: {transform_conditionals: true}
     │   │       ├── content: " else " (location: (1:41)-(1:41))
     │   │       ├── tag_closing: "%>" (location: (1:41)-(1:41))
     │   │       └── statements: (1 item)
-    │   │           └── @ ERBContentNode (location: (1:0)-(1:41))
-    │   │               ├── tag_opening: "<%=" (location: (1:0)-(1:3))
-    │   │               ├── content: " "goodbye" " (location: (1:28)-(1:39))
-    │   │               ├── tag_closing: "%>" (location: (1:39)-(1:41))
-    │   │               ├── parsed: false
-    │   │               └── valid: true
+    │   │           └── @ HTMLTextNode (location: (1:29)-(1:38))
+    │   │               └── content: "goodbye"
     │   │
     │   │
     │   └── end_node:

--- a/test/snapshots/analyze/ternary_conditional_test/test_0011_ternary_with_numeric_values_0121ea6fbc0bda01fd316956e0e29c0b-4661ff3a6866fa9b1c7c564c651dfe75.txt
+++ b/test/snapshots/analyze/ternary_conditional_test/test_0011_ternary_with_numeric_values_0121ea6fbc0bda01fd316956e0e29c0b-4661ff3a6866fa9b1c7c564c651dfe75.txt
@@ -12,12 +12,8 @@ options: {transform_conditionals: true}
     │   ├── tag_closing: "%>" (location: (1:21)-(1:21))
     │   ├── then_keyword: ∅
     │   ├── statements: (1 item)
-    │   │   └── @ ERBContentNode (location: (1:0)-(1:21))
-    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
-    │   │       ├── content: " 1 " (location: (1:12)-(1:15))
-    │   │       ├── tag_closing: "%>" (location: (1:19)-(1:21))
-    │   │       ├── parsed: false
-    │   │       └── valid: true
+    │   │   └── @ HTMLTextNode (location: (1:13)-(1:14))
+    │   │       └── content: "1"
     │   │
     │   ├── subsequent:
     │   │   └── @ ERBElseNode (location: (1:21)-(1:21))
@@ -25,12 +21,8 @@ options: {transform_conditionals: true}
     │   │       ├── content: " else " (location: (1:21)-(1:21))
     │   │       ├── tag_closing: "%>" (location: (1:21)-(1:21))
     │   │       └── statements: (1 item)
-    │   │           └── @ ERBContentNode (location: (1:0)-(1:21))
-    │   │               ├── tag_opening: "<%=" (location: (1:0)-(1:3))
-    │   │               ├── content: " 0 " (location: (1:16)-(1:19))
-    │   │               ├── tag_closing: "%>" (location: (1:19)-(1:21))
-    │   │               ├── parsed: false
-    │   │               └── valid: true
+    │   │           └── @ HTMLTextNode (location: (1:17)-(1:18))
+    │   │               └── content: "0"
     │   │
     │   │
     │   └── end_node:

--- a/test/snapshots/analyze/ternary_conditional_test/test_0012_ternary_with_nil_false_branch_9111d49ce644c302ffb7d5b6358e7a00-4661ff3a6866fa9b1c7c564c651dfe75.txt
+++ b/test/snapshots/analyze/ternary_conditional_test/test_0012_ternary_with_nil_false_branch_9111d49ce644c302ffb7d5b6358e7a00-4661ff3a6866fa9b1c7c564c651dfe75.txt
@@ -12,26 +12,15 @@ options: {transform_conditionals: true}
     │   ├── tag_closing: "%>" (location: (1:27)-(1:27))
     │   ├── then_keyword: ∅
     │   ├── statements: (1 item)
-    │   │   └── @ ERBContentNode (location: (1:0)-(1:27))
-    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
-    │   │       ├── content: " 'value' " (location: (1:10)-(1:19))
-    │   │       ├── tag_closing: "%>" (location: (1:25)-(1:27))
-    │   │       ├── parsed: false
-    │   │       └── valid: true
+    │   │   └── @ HTMLTextNode (location: (1:11)-(1:18))
+    │   │       └── content: "value"
     │   │
     │   ├── subsequent:
     │   │   └── @ ERBElseNode (location: (1:27)-(1:27))
     │   │       ├── tag_opening: "<%" (location: (1:27)-(1:27))
     │   │       ├── content: " else " (location: (1:27)-(1:27))
     │   │       ├── tag_closing: "%>" (location: (1:27)-(1:27))
-    │   │       └── statements: (1 item)
-    │   │           └── @ ERBContentNode (location: (1:0)-(1:27))
-    │   │               ├── tag_opening: "<%=" (location: (1:0)-(1:3))
-    │   │               ├── content: " nil " (location: (1:20)-(1:25))
-    │   │               ├── tag_closing: "%>" (location: (1:25)-(1:27))
-    │   │               ├── parsed: false
-    │   │               └── valid: true
-    │   │
+    │   │       └── statements: []
     │   │
     │   └── end_node:
     │       └── @ ERBEndNode (location: (1:27)-(1:27))

--- a/test/snapshots/analyze/ternary_conditional_test/test_0013_ternary_with_compound_condition_779ddbe917108a5975326943b7b89a47-4661ff3a6866fa9b1c7c564c651dfe75.txt
+++ b/test/snapshots/analyze/ternary_conditional_test/test_0013_ternary_with_compound_condition_779ddbe917108a5975326943b7b89a47-4661ff3a6866fa9b1c7c564c651dfe75.txt
@@ -12,12 +12,8 @@ options: {transform_conditionals: true}
     │   ├── tag_closing: "%>" (location: (1:53)-(1:53))
     │   ├── then_keyword: ∅
     │   ├── statements: (1 item)
-    │   │   └── @ ERBContentNode (location: (1:0)-(1:53))
-    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
-    │   │       ├── content: " 'admin' " (location: (1:33)-(1:42))
-    │   │       ├── tag_closing: "%>" (location: (1:51)-(1:53))
-    │   │       ├── parsed: false
-    │   │       └── valid: true
+    │   │   └── @ HTMLTextNode (location: (1:34)-(1:41))
+    │   │       └── content: "admin"
     │   │
     │   ├── subsequent:
     │   │   └── @ ERBElseNode (location: (1:53)-(1:53))
@@ -25,12 +21,8 @@ options: {transform_conditionals: true}
     │   │       ├── content: " else " (location: (1:53)-(1:53))
     │   │       ├── tag_closing: "%>" (location: (1:53)-(1:53))
     │   │       └── statements: (1 item)
-    │   │           └── @ ERBContentNode (location: (1:0)-(1:53))
-    │   │               ├── tag_opening: "<%=" (location: (1:0)-(1:3))
-    │   │               ├── content: " 'user' " (location: (1:43)-(1:51))
-    │   │               ├── tag_closing: "%>" (location: (1:51)-(1:53))
-    │   │               ├── parsed: false
-    │   │               └── valid: true
+    │   │           └── @ HTMLTextNode (location: (1:44)-(1:50))
+    │   │               └── content: "user"
     │   │
     │   │
     │   └── end_node:

--- a/test/snapshots/analyze/ternary_conditional_test/test_0016_ternary_with_symbol_branches_9a3d23f43ace44621542119906187e0c-4661ff3a6866fa9b1c7c564c651dfe75.txt
+++ b/test/snapshots/analyze/ternary_conditional_test/test_0016_ternary_with_symbol_branches_9a3d23f43ace44621542119906187e0c-4661ff3a6866fa9b1c7c564c651dfe75.txt
@@ -1,0 +1,36 @@
+---
+source: "Analyze::TernaryConditionalTest#test_0016_ternary with symbol branches"
+input: |2-
+<%= cond ? :active : :inactive %>
+options: {transform_conditionals: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ ERBIfNode (location: (1:0)-(1:33))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:0))
+    │   ├── content: " if cond " (location: (1:0)-(1:33))
+    │   ├── tag_closing: "%>" (location: (1:33)-(1:33))
+    │   ├── then_keyword: ∅
+    │   ├── statements: (1 item)
+    │   │   └── @ HTMLTextNode (location: (1:11)-(1:18))
+    │   │       └── content: "active"
+    │   │
+    │   ├── subsequent:
+    │   │   └── @ ERBElseNode (location: (1:33)-(1:33))
+    │   │       ├── tag_opening: "<%" (location: (1:33)-(1:33))
+    │   │       ├── content: " else " (location: (1:33)-(1:33))
+    │   │       ├── tag_closing: "%>" (location: (1:33)-(1:33))
+    │   │       └── statements: (1 item)
+    │   │           └── @ HTMLTextNode (location: (1:21)-(1:30))
+    │   │               └── content: "inactive"
+    │   │
+    │   │
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (1:33)-(1:33))
+    │           ├── tag_opening: "<%" (location: (1:33)-(1:33))
+    │           ├── content: " end " (location: (1:33)-(1:33))
+    │           └── tag_closing: "%>" (location: (1:33)-(1:33))
+    │
+    │
+    └── @ HTMLTextNode (location: (1:33)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/ternary_conditional_test/test_0017_ternary_with_branches_that_would_be_HTML-escaped_19ac47e873bc8dc12e7cd457dc091295-4661ff3a6866fa9b1c7c564c651dfe75.txt
+++ b/test/snapshots/analyze/ternary_conditional_test/test_0017_ternary_with_branches_that_would_be_HTML-escaped_19ac47e873bc8dc12e7cd457dc091295-4661ff3a6866fa9b1c7c564c651dfe75.txt
@@ -1,0 +1,44 @@
+---
+source: "Analyze::TernaryConditionalTest#test_0017_ternary with branches that would be HTML-escaped"
+input: |2-
+<%= cond ? '<b>' : 'a & b' %>
+options: {transform_conditionals: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ ERBIfNode (location: (1:0)-(1:29))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:0))
+    │   ├── content: " if cond " (location: (1:0)-(1:29))
+    │   ├── tag_closing: "%>" (location: (1:29)-(1:29))
+    │   ├── then_keyword: ∅
+    │   ├── statements: (1 item)
+    │   │   └── @ ERBContentNode (location: (1:0)-(1:29))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " '<b>' " (location: (1:10)-(1:17))
+    │   │       ├── tag_closing: "%>" (location: (1:27)-(1:29))
+    │   │       ├── parsed: false
+    │   │       └── valid: true
+    │   │
+    │   ├── subsequent:
+    │   │   └── @ ERBElseNode (location: (1:29)-(1:29))
+    │   │       ├── tag_opening: "<%" (location: (1:29)-(1:29))
+    │   │       ├── content: " else " (location: (1:29)-(1:29))
+    │   │       ├── tag_closing: "%>" (location: (1:29)-(1:29))
+    │   │       └── statements: (1 item)
+    │   │           └── @ ERBContentNode (location: (1:0)-(1:29))
+    │   │               ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │               ├── content: " 'a & b' " (location: (1:18)-(1:27))
+    │   │               ├── tag_closing: "%>" (location: (1:27)-(1:29))
+    │   │               ├── parsed: false
+    │   │               └── valid: true
+    │   │
+    │   │
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (1:29)-(1:29))
+    │           ├── tag_opening: "<%" (location: (1:29)-(1:29))
+    │           ├── content: " end " (location: (1:29)-(1:29))
+    │           └── tag_closing: "%>" (location: (1:29)-(1:29))
+    │
+    │
+    └── @ HTMLTextNode (location: (1:29)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/analyze/ternary_conditional_test/test_0018_ternary_with_numeric_branches_that_render_differently_than_they_are_written_a8a4988ac6e8971c4449190bc8bc11f7-4661ff3a6866fa9b1c7c564c651dfe75.txt
+++ b/test/snapshots/analyze/ternary_conditional_test/test_0018_ternary_with_numeric_branches_that_render_differently_than_they_are_written_a8a4988ac6e8971c4449190bc8bc11f7-4661ff3a6866fa9b1c7c564c651dfe75.txt
@@ -1,0 +1,44 @@
+---
+source: "Analyze::TernaryConditionalTest#test_0018_ternary with numeric branches that render differently than they are written"
+input: |2-
+<%= cond ? 1_000 : 0x1f %>
+options: {transform_conditionals: true}
+---
+@ DocumentNode (location: (1:0)-(2:0))
+└── children: (2 items)
+    ├── @ ERBIfNode (location: (1:0)-(1:26))
+    │   ├── tag_opening: "<%" (location: (1:0)-(1:0))
+    │   ├── content: " if cond " (location: (1:0)-(1:26))
+    │   ├── tag_closing: "%>" (location: (1:26)-(1:26))
+    │   ├── then_keyword: ∅
+    │   ├── statements: (1 item)
+    │   │   └── @ ERBContentNode (location: (1:0)-(1:26))
+    │   │       ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │       ├── content: " 1_000 " (location: (1:10)-(1:17))
+    │   │       ├── tag_closing: "%>" (location: (1:24)-(1:26))
+    │   │       ├── parsed: false
+    │   │       └── valid: true
+    │   │
+    │   ├── subsequent:
+    │   │   └── @ ERBElseNode (location: (1:26)-(1:26))
+    │   │       ├── tag_opening: "<%" (location: (1:26)-(1:26))
+    │   │       ├── content: " else " (location: (1:26)-(1:26))
+    │   │       ├── tag_closing: "%>" (location: (1:26)-(1:26))
+    │   │       └── statements: (1 item)
+    │   │           └── @ ERBContentNode (location: (1:0)-(1:26))
+    │   │               ├── tag_opening: "<%=" (location: (1:0)-(1:3))
+    │   │               ├── content: " 0x1f " (location: (1:18)-(1:24))
+    │   │               ├── tag_closing: "%>" (location: (1:24)-(1:26))
+    │   │               ├── parsed: false
+    │   │               └── valid: true
+    │   │
+    │   │
+    │   └── end_node:
+    │       └── @ ERBEndNode (location: (1:26)-(1:26))
+    │           ├── tag_opening: "<%" (location: (1:26)-(1:26))
+    │           ├── content: " end " (location: (1:26)-(1:26))
+    │           └── tag_closing: "%>" (location: (1:26)-(1:26))
+    │
+    │
+    └── @ HTMLTextNode (location: (1:26)-(2:0))
+        └── content: "\n"

--- a/test/snapshots/engine/action_view/postfix_conditional_test/test_0006_string_literal_with_postfix_if_condition_b1e5385473231e7f93cfaf46b82319af.txt
+++ b/test/snapshots/engine/action_view/postfix_conditional_test/test_0006_string_literal_with_postfix_if_condition_b1e5385473231e7f93cfaf46b82319af.txt
@@ -1,0 +1,7 @@
+---
+source: "Engine::ActionView::PostfixConditionalTest#test_0006_string literal with postfix if condition"
+input: "{source: \"<%= \\\"Notice\\\" if condition %>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>], locals: {condition: true}}}"
+---
+_buf = ::String.new; if condition 
+ _buf << 'Notice'.freeze; end;
+_buf.to_s

--- a/test/snapshots/engine/action_view/postfix_conditional_test/test_0006_string_literal_with_postfix_if_condition_e36a2c8a8f50c37fd3c8bbb691573fc6.txt
+++ b/test/snapshots/engine/action_view/postfix_conditional_test/test_0006_string_literal_with_postfix_if_condition_e36a2c8a8f50c37fd3c8bbb691573fc6.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::ActionView::PostfixConditionalTest#test_0006_string literal with postfix if condition"
+input: "{source: \"<%= \\\"Notice\\\" if condition %>\", locals: {condition: true}, options: {action_view_helpers: true}}"
+---
+Notice

--- a/test/snapshots/engine/action_view/postfix_conditional_test/test_0007_string_literal_that_would_be_HTML-escaped_with_postfix_if_condition_639727d9a71015c2fb9b57f5503a29cf.txt
+++ b/test/snapshots/engine/action_view/postfix_conditional_test/test_0007_string_literal_that_would_be_HTML-escaped_with_postfix_if_condition_639727d9a71015c2fb9b57f5503a29cf.txt
@@ -1,0 +1,7 @@
+---
+source: "Engine::ActionView::PostfixConditionalTest#test_0007_string literal that would be HTML-escaped with postfix if condition"
+input: "{source: \"<%= \\\"5 > 3\\\" if condition %>\", options: {escape: true, visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
+---
+__herb = ::Herb::Engine; _buf = ::String.new; if condition 
+ _buf << __herb.h(("5 > 3")); end;
+_buf.to_s

--- a/test/snapshots/engine/action_view/ternary_conditional_test/test_0006_ternary_with_string_literals_in_both_branches_3e349e7023511957e3dde4296f5a79f2.txt
+++ b/test/snapshots/engine/action_view/ternary_conditional_test/test_0006_ternary_with_string_literals_in_both_branches_3e349e7023511957e3dde4296f5a79f2.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::ActionView::TernaryConditionalTest#test_0006_ternary with string literals in both branches"
+input: "{source: \"<%= active ? \\\"On\\\" : \\\"Off\\\" %>\", locals: {active: true}, options: {action_view_helpers: true}}"
+---
+On

--- a/test/snapshots/engine/action_view/ternary_conditional_test/test_0006_ternary_with_string_literals_in_both_branches_63be512684ea85ff233351e9bbd251f4.txt
+++ b/test/snapshots/engine/action_view/ternary_conditional_test/test_0006_ternary_with_string_literals_in_both_branches_63be512684ea85ff233351e9bbd251f4.txt
@@ -1,0 +1,7 @@
+---
+source: "Engine::ActionView::TernaryConditionalTest#test_0006_ternary with string literals in both branches"
+input: "{source: \"<%= active ? \\\"On\\\" : \\\"Off\\\" %>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>], locals: {active: true}}}"
+---
+_buf = ::String.new; if active 
+ _buf << 'On'.freeze; else; _buf << 'Off'.freeze; end;
+_buf.to_s

--- a/test/snapshots/engine/action_view/ternary_conditional_test/test_0007_ternary_with_string_literals_inside_an_attribute_value_8718c3b89459c9b775f8602546b9e9d1.txt
+++ b/test/snapshots/engine/action_view/ternary_conditional_test/test_0007_ternary_with_string_literals_inside_an_attribute_value_8718c3b89459c9b775f8602546b9e9d1.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::ActionView::TernaryConditionalTest#test_0007_ternary with string literals inside an attribute value"
+input: "{source: \"<div class=\\\"<%= active ? \\\"on\\\" : \\\"off\\\" %>\\\">Body</div>\", options: {visitors: [#<Herb::Engine::OptimizeVisitor>], locals: {active: true}}}"
+---
+_buf = ::String.new; _buf << '<div class="'.freeze; if active; _buf << 'on'.freeze; else; _buf << 'off'.freeze; end; _buf << '">Body</div>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/action_view/ternary_conditional_test/test_0007_ternary_with_string_literals_inside_an_attribute_value_b7d3e0bbfafb2a68753d0300fcc42300.txt
+++ b/test/snapshots/engine/action_view/ternary_conditional_test/test_0007_ternary_with_string_literals_inside_an_attribute_value_b7d3e0bbfafb2a68753d0300fcc42300.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::ActionView::TernaryConditionalTest#test_0007_ternary with string literals inside an attribute value"
+input: "{source: \"<div class=\\\"<%= active ? \\\"on\\\" : \\\"off\\\" %>\\\">Body</div>\", locals: {active: true}, options: {action_view_helpers: true}}"
+---
+<div class="on">Body</div>

--- a/test/snapshots/engine/action_view/ternary_conditional_test/test_0008_ternary_with_literals_that_would_be_HTML-escaped_8321c6d088528bc271f6ae3d11a80181.txt
+++ b/test/snapshots/engine/action_view/ternary_conditional_test/test_0008_ternary_with_literals_that_would_be_HTML-escaped_8321c6d088528bc271f6ae3d11a80181.txt
@@ -1,0 +1,7 @@
+---
+source: "Engine::ActionView::TernaryConditionalTest#test_0008_ternary with literals that would be HTML-escaped"
+input: "{source: \"<%= active ? \\\"5 > 3\\\" : \\\"a & b\\\" %>\", options: {escape: true, visitors: [#<Herb::Engine::OptimizeVisitor>]}}"
+---
+__herb = ::Herb::Engine; _buf = ::String.new; if active 
+ _buf << __herb.h(("5 > 3")); else; _buf << __herb.h(("a & b")); end;
+_buf.to_s


### PR DESCRIPTION
This pull request updates `transform_conditionals` so that a postfix or ternary branch whose body is a single Ruby literal becomes static text instead of another output tag. A conditional over literals then carries no Ruby at all, which is what the engine needs to fold it into the surrounding static run.

```erb
<%= condition ? 'yes' : 'no' %>
```

```diff
- <% if condition %><%= 'yes' %><% else %><%= 'no' %><% end %>
+ <% if condition %>yes<% else %>no<% end %>
```

The `ERBContentNode` that used to hold each branch is gone from the tree:

```js
@ DocumentNode (location: (1:0)-(2:0))
└── children: (2 items)
    ├── @ ERBIfNode (location: (1:0)-(1:31))
    │   ├── tag_opening: "<%" (location: (1:0)-(1:0))
    │   ├── content: " if condition " (location: (1:0)-(1:31))
    │   ├── tag_closing: "%>" (location: (1:31)-(1:31))
    │   ├── then_keyword: ∅
    │   ├── statements: (1 item)
    │   │   └── @ HTMLTextNode (location: (1:16)-(1:21))
    │   │       └── content: "yes"
    │   │
    │   ├── subsequent:
    │   │   └── @ ERBElseNode (location: (1:31)-(1:31))
    │   │       ├── tag_opening: "<%" (location: (1:31)-(1:31))
    │   │       ├── content: " else " (location: (1:31)-(1:31))
    │   │       ├── tag_closing: "%>" (location: (1:31)-(1:31))
    │   │       └── statements: (1 item)
    │   │           └── @ HTMLTextNode (location: (1:24)-(1:28))
    │   │               └── content: "no"
```

Strings, symbols, plain decimal integers, `true`, `false`, and `nil` qualify. A numeric literal whose source text differs from what it renders is left alone, so `1_000` and `0x1f` keep their output tag rather than becoming the wrong digits. A branch that renders nothing, from `nil` or `''`, produces an empty `statements` array, which is exactly what `<% if x %>a<% else %><% end %>` parses to on its own.

A literal containing `&`, `<`, `>`, `"`, or `'` keeps its output tag. Whether `<%= %>` escapes is not knowable at parse time. 

`OptimizeVisitor` already asks for `transform_conditionals`, so the branches now join the static text run instead of going through `.to_s`:

before:
```ruby
_buf = ::String.new; if active
 _buf << ("On").to_s; else; _buf << ("Off").to_s; end;
```

after:
```ruby
_buf = ::String.new; if active
 _buf << 'On'.freeze; else; _buf << 'Off'.freeze; end;
```

The `erb-prefer-explicit-conditionals` rule also consumes this transform, and its autofix anchored on the body `ERBContentNode` to re-find the original tag in the re-parsed tree. With a literal body there is no such node, so it now anchors on the conditional itself, which carries the same location. 

The suggestion and the fix now follow the parser:

```erb
<%= "Saved" if notice? %>
```

```erb
<% if notice? %>Saved<% end %>
```

Resolves https://github.com/marcoroth/herb/issues/1608

