### PR TITLE
Dev Tools: Draw the slot flash where the item ended up

### DIFF
--- a/javascript/packages/dev-tools/src/slots/flash.ts
+++ b/javascript/packages/dev-tools/src/slots/flash.ts
@@ -1,5 +1,5 @@
 import { SLOT_EVENT } from '@herb-tools/client'
-import type { SlotEventDetail, SlotOperation } from '@herb-tools/client'
+import type { Slot, SlotEventDetail, SlotOperation } from '@herb-tools/client'
 
 const COLORS: Record<SlotOperation, string> = {
   value: '#3b82f6',
@@ -63,15 +63,22 @@ export class SlotFlash {
 
     document.body.append(overlay, label)
 
-    requestAnimationFrame(() => {
-      overlay.style.opacity = '0'
-      label.style.opacity = '0'
-    })
+    const drawn = [overlay, label]
+    const around = detail.item ? this.measureSlot(detail.slot) : null
 
-    setTimeout(() => {
-      overlay.remove()
-      label.remove()
-    }, SlotFlash.DURATION)
+    if (around) {
+      const box = document.createElement('div')
+
+      box.className = 'herb-slot-flash herb-slot-flash-collection'
+      box.style.cssText = `position:absolute;z-index:2147482999;pointer-events:none;top:${around.top + scrollY}px;left:${around.left + scrollX}px;width:${around.width}px;height:${around.height}px;background:transparent;outline:2px dashed ${colour};outline-offset:3px;transition:opacity ${SlotFlash.DURATION}ms ease-out`
+
+      document.body.append(box)
+      drawn.push(box)
+    }
+
+    requestAnimationFrame(() => drawn.forEach((node) => (node.style.opacity = '0')))
+
+    setTimeout(() => drawn.forEach((node) => node.remove()), SlotFlash.DURATION)
   }
 
   private measure(detail: SlotEventDetail): DOMRect | null {
@@ -84,7 +91,10 @@ export class SlotFlash {
       return this.biggest(range.getBoundingClientRect())
     }
 
-    const slot = detail.slot
+    return this.measureSlot(detail.slot)
+  }
+
+  private measureSlot(slot: Slot | null): DOMRect | null {
     if (!slot) return null
 
     if (slot.anchor.kind === 'range') {

--- a/javascript/packages/dev-tools/src/slots/flash.ts
+++ b/javascript/packages/dev-tools/src/slots/flash.ts
@@ -32,6 +32,19 @@ export class SlotFlash {
 
   private draw = (event: Event) => {
     const detail = (event as CustomEvent<SlotEventDetail>).detail
+
+    if (detail.operation === 'item-removed') {
+      this.paint(detail)
+
+      return
+    }
+
+    setTimeout(() => this.paint(detail), 0)
+  }
+
+  private paint(detail: SlotEventDetail): void {
+    if (!this.enabled) return
+
     const rect = this.measure(detail)
 
     if (!rect) return

--- a/javascript/packages/dev-tools/test/slot-flash.test.ts
+++ b/javascript/packages/dev-tools/test/slot-flash.test.ts
@@ -140,6 +140,47 @@ describe("an item the index moves after announcing it", () => {
     expect(Math.round(parseFloat(overlay.style.top))).toBe(Math.round(final + scrollY))
   })
 
+  test("outlines the collection it belongs to, without filling it", async () => {
+    const one = item("one")
+    const two = item("two")
+
+    list.append(...one.nodes, ...two.nodes)
+
+    dispatch({ operation: "item-added", key: "two", item: two, slot: { index: 0, attribute: null, anchor: { kind: "range", start: list.firstChild, end: list.lastChild } } })
+
+    await settle()
+
+    const box = document.querySelector<HTMLElement>(".herb-slot-flash-collection")!
+    const styles = getComputedStyle(box)
+
+    expect(box).not.toBeNull()
+    expect(styles.outlineStyle).toBe("dashed")
+    expect(styles.outlineColor).toBe("rgb(16, 185, 129)")
+    expect(styles.backgroundColor).toBe("rgba(0, 0, 0, 0)")
+    expect(drawn()).toHaveLength(3)
+  })
+
+  test("outlines the collection in the colour of the operation, so a removal reads as one", async () => {
+    const leaving = item("leaving")
+
+    list.append(...leaving.nodes)
+
+    dispatch({ operation: "item-removed", key: "leaving", item: leaving, slot: { index: 0, attribute: null, anchor: { kind: "range", start: list.firstChild, end: list.lastChild } } })
+
+    const box = document.querySelector<HTMLElement>(".herb-slot-flash-collection")!
+
+    expect(getComputedStyle(box).outlineColor).toBe("rgb(239, 68, 68)")
+    expect(getComputedStyle(box).outlineStyle).toBe("dashed")
+  })
+
+  test("leaves a slot that is not part of a collection with no outline around it", async () => {
+    announce()
+    await settle()
+
+    expect(document.querySelector(".herb-slot-flash-collection")).toBeNull()
+    expect(drawn()).toHaveLength(2)
+  })
+
   test("still draws an item that is on its way out, before it goes", async () => {
     const leaving = item("leaving")
 
@@ -151,8 +192,10 @@ describe("an item the index moves after announcing it", () => {
 
     leaving.nodes.forEach(node => node.remove())
 
-    expect(drawn()).toHaveLength(2)
-    expect(Math.round(parseFloat(drawn()[0].style.top))).toBe(Math.round(where + scrollY))
+    const overlay = drawn().find(node => !node.textContent && !node.classList.contains("herb-slot-flash-collection"))!
+
+    expect(drawn()).toHaveLength(3)
+    expect(Math.round(parseFloat(overlay.style.top))).toBe(Math.round(where + scrollY))
   })
 })
 

--- a/javascript/packages/dev-tools/test/slot-flash.test.ts
+++ b/javascript/packages/dev-tools/test/slot-flash.test.ts
@@ -4,28 +4,25 @@ import { SlotFlash } from "../src/slots/flash"
 import { HerbOverlay } from "../src/overlay/overlay"
 
 const SLOT_EVENT = "herb:slot-update"
+const FILE = "app/views/page/ask.html.erb"
 
 let flash: SlotFlash
 let target: HTMLElement
 
+function dispatch(detail: Record<string, unknown>) {
+  document.dispatchEvent(new CustomEvent(SLOT_EVENT, { detail: { file: FILE, occurrence: 0, index: 0, key: null, item: null, ...detail } }))
+}
+
 function announce(operation = "value") {
-  document.dispatchEvent(
-    new CustomEvent(SLOT_EVENT, {
-      detail: {
-        file: "app/views/page/ask.html.erb",
-        occurrence: 0,
-        index: 0,
-        operation,
-        key: null,
-        item: null,
-        slot: { index: 0, attribute: null, anchor: { kind: "element", element: target } },
-      },
-    }),
-  )
+  dispatch({ operation, slot: { index: 0, attribute: null, anchor: { kind: "element", element: target } } })
 }
 
 function drawn() {
   return [...document.querySelectorAll<HTMLElement>(".herb-slot-flash")]
+}
+
+function settle() {
+  return new Promise(resolve => setTimeout(resolve, 0))
 }
 
 beforeEach(() => {
@@ -40,17 +37,20 @@ beforeEach(() => {
 afterEach(() => {
   flash.stop()
   target.remove()
+  document.querySelectorAll(".herb-slot-flash").forEach(node => node.remove())
 })
 
 describe("SlotFlash", () => {
-  test("draws an overlay and a label for a slot that changed", () => {
+  test("draws an overlay and a label for a slot that changed", async () => {
     announce()
+    await settle()
 
     expect(drawn()).toHaveLength(2)
   })
 
-  test("the overlay it draws carries the styles that make it visible", () => {
+  test("the overlay it draws carries the styles that make it visible", async () => {
     announce()
+    await settle()
 
     const [overlay] = drawn()
     const styles = getComputedStyle(overlay)
@@ -62,8 +62,9 @@ describe("SlotFlash", () => {
     expect(parseFloat(styles.width)).toBeGreaterThan(0)
   })
 
-  test("the label it draws carries its own styles and says what changed", () => {
+  test("the label it draws carries its own styles and says what changed", async () => {
     announce()
+    await settle()
 
     const [, label] = drawn()
     const styles = getComputedStyle(label)
@@ -74,21 +75,84 @@ describe("SlotFlash", () => {
     expect(styles.color).toBe("rgb(255, 255, 255)")
   })
 
-  test("colours the overlay by the operation it reports", () => {
+  test("colours the overlay by the operation it reports", async () => {
     announce("item-added")
+    await settle()
 
     expect(getComputedStyle(drawn()[0]).backgroundColor).toBe("rgb(16, 185, 129)")
   })
 
-  test("stops drawing and clears what it drew", () => {
+  test("stops drawing and clears what it drew", async () => {
     announce()
+    await settle()
     flash.stop()
 
     expect(drawn()).toHaveLength(0)
 
     announce()
+    await settle()
 
     expect(drawn()).toHaveLength(0)
+  })
+})
+
+describe("an item the index moves after announcing it", () => {
+  let list: HTMLElement
+
+  function item(text: string) {
+    const start = document.createComment(`herb-item:0:${text}`)
+    const element = document.createElement("div")
+    const end = document.createComment("/herb-item:0")
+
+    element.textContent = text
+    element.style.cssText = "height:40px"
+
+    return { start, element, end, nodes: [start, element, end] }
+  }
+
+  beforeEach(() => {
+    list = document.createElement("div")
+    document.body.append(list)
+  })
+
+  afterEach(() => list.remove())
+
+  test("draws where the item ended up, not where it was first inserted", async () => {
+    const moved = item("moved")
+    const settled = item("settled")
+
+    list.append(...moved.nodes, ...settled.nodes)
+
+    const inserted = moved.element.getBoundingClientRect().top
+
+    dispatch({ operation: "item-added", key: "moved", item: moved, slot: { index: 0, attribute: null, anchor: { kind: "range", start: list.firstChild, end: list.lastChild } } })
+
+    list.append(...moved.nodes)
+
+    const final = moved.element.getBoundingClientRect().top
+
+    expect(final, "the item has to actually move for this to prove anything").not.toBe(inserted)
+
+    await settle()
+
+    const [overlay] = drawn()
+
+    expect(Math.round(parseFloat(overlay.style.top))).toBe(Math.round(final + scrollY))
+  })
+
+  test("still draws an item that is on its way out, before it goes", async () => {
+    const leaving = item("leaving")
+
+    list.append(...leaving.nodes)
+
+    const where = leaving.element.getBoundingClientRect().top
+
+    dispatch({ operation: "item-removed", key: "leaving", item: leaving, slot: { index: 0, attribute: null, anchor: { kind: "range", start: list.firstChild, end: list.lastChild } } })
+
+    leaving.nodes.forEach(node => node.remove())
+
+    expect(drawn()).toHaveLength(2)
+    expect(Math.round(parseFloat(drawn()[0].style.top))).toBe(Math.round(where + scrollY))
   })
 })
 
@@ -116,20 +180,22 @@ describe("an overlay that goes away", () => {
     return created
   }
 
-  test("takes its flash with it, so a destroyed overlay draws nothing", () => {
+  test("takes its flash with it, so a destroyed overlay draws nothing", async () => {
     overlay().destroy()
 
     announce()
+    await settle()
 
     expect(drawn()).toHaveLength(0)
   })
 
-  test("leaves one overlay drawing once, however many came before it", () => {
+  test("leaves one overlay drawing once, however many came before it", async () => {
     overlay().destroy()
     overlay().destroy()
     overlay()
 
     announce()
+    await settle()
 
     expect(drawn()).toHaveLength(2)
   })


### PR DESCRIPTION
Follow up on #2299 and #2300. With the flash drawing again, and telling a branch swap apart from a value write, what it says about collections is the part still worth fixing.

An `item-added` drew over the wrong row. `#buildItem` inserts a new item in front of the first one already there and announces it from that position, and the index puts it in its real place afterwards, so the flash was drawing where the item was at that instant instead of where it ended up. On the inline-edit table that is the first row every time, whichever row was actually added.

Measuring on the next task reads the position after the whole batch has settled, ordering included. A microtask is not enough, since the reordering runs in the same task as the announcement.

An item on its way out is the one case that cannot wait. `#dropItem` announces before it deletes the range, so a removal is still measured while its markers are in the document. That is the only operation left drawing synchronously.

This also gets a nested slot inside a freshly built row off measuring zero by zero, since a slot in a row that has not been placed yet has no box.

An item update now also outlines the collection it belongs to, dashed and unfilled so it never competes with what is drawn inside it, in the color of the operation.