### PR TITLE
Docs: Document and pin the Erubi behavior `Herb::Engine` targets

### DIFF
--- a/docs/docs/projects/engine.md
+++ b/docs/docs/projects/engine.md
@@ -21,6 +21,12 @@ engine = Herb::Engine.new(source,
 
 ## Erubi Compatibility
 
+`Herb::Engine` targets [`Erubi::Engine`](https://github.com/jeremyevans/erubi) running with its default options. It does not target Ruby's standard-library `ERB`, which uses a different set of trim modes and produces different output for the same template. A template that compiles under Erubi is expected to render the same under Herb. The [Erubi compatibility suite](https://github.com/marcoroth/herb/blob/main/test/engine/engine_erubi_compat_test.rb) holds the cases where the compiled Ruby matches byte for byte, and the [divergence suite](https://github.com/marcoroth/herb/blob/main/test/engine/engine_erubi_divergence_test.rb) pins the cases where it does not.
+
+Rails is not part of that contract. `Herb::Engine` is a plain Ruby class with no Rails dependency, so it works anywhere you can hand a framework its own ERB engine. The Rails-specific pieces (Action View helpers, `content_for`, partial rendering) live in [visitors](#transform-visitors) you opt into, and in [ReActionView](#reactionview-integration).
+
+If a framework renders `.erb` files through the standard-library `ERB` by default, neither Erubi nor Herb applies until it is configured to use the engine. That configuration is the framework's, not Herb's.
+
 `Herb::Engine` accepts all the same options as `Erubi::Engine`:
 
 - `bufvar` / `outvar` — Buffer variable name
@@ -34,6 +40,104 @@ engine = Herb::Engine.new(source,
 - `chain_appends` — Chain `<<` calls for performance
 - `ensure` — Wrap in begin/ensure block
 - `src` — Initial source string
+
+### Whitespace trimming
+
+Erubi's `trim` behavior is always on and is not configurable. A `<% %>` tag that stands alone on its line drops the newline that follows it, and `-%>` drops it wherever the tag sits. `<%-` is accepted and leaves the whitespace in front of the tag alone, which is what Erubi does with it too. Trimming is what makes a `case` written across several tags compile:
+
+```erb
+<% case status %>
+<% when :active %>
+  <span class="badge">Active</span>
+<% when :archived %>
+  <em>Archived</em>
+<% else %>
+  Unknown
+<% end %>
+```
+
+The newline after `<% case status %>` is trimmed, so nothing lands between `case` and its first `when`, and the compiled Ruby is valid. Herb and Erubi emit byte-identical output here. Passing `trim: false` has no effect, whereas Erubi would honor it and emit a buffer append between the two tags.
+
+### Known differences from Erubi
+
+Three things that `Erubi::Engine` accepts are handled differently by `Herb::Engine` on its default settings. Each one is deliberate.
+
+A `case` with its first `when`/`in` in the same ERB tag raises `ERB_CASE_WITH_CONDITIONS_ERROR` under [strict parsing](/parser-options). The AST that pattern produces cannot be formatted or compiled reliably. The [`erb-no-inline-case-conditions`](/linter/rules/erb-no-inline-case-conditions.md) rule reports the same thing.
+
+Escaped tags such as `<%% %>` and `<%%= %>` raise `Herb::Engine::GeneratorTemplateError`. A template that emits literal ERB is a generator template, not a template to render.
+
+`trim: false` is ignored and trimming stays on. Herb's whitespace handling is tied to the parsed AST, not to a scanner mode.
+
+One difference changes what a template renders. Erubi calls `to_s` on every `<%= %>` wherever it sits, because it never looks at the markup around the tag. Herb parses the HTML, so it knows the tag's context and escapes for it:
+
+```erb
+<input name="<%= field_name %>">
+```
+
+```ruby
+_buf << ::Herb::Engine.attr((field_name));
+```
+
+Erubi compiles that same tag to `( field_name ).to_s`, so a value carrying `a" onload="alert(1)` escapes out of the attribute under Erubi and does not under Herb. A tag inside `<script>` gets `::Herb::Engine.js` and one inside `<style>` gets `::Herb::Engine.css` for the same reason. The three come from the `attrfunc`, `jsfunc`, and `cssfunc` options, which take the same shape as Erubi's `escapefunc`.
+
+The rest are formatting differences in output that renders identically. Herb writes `(title)` where Erubi writes `( title )`, escapes through `::Herb::Engine` instead of `::Erubi` and leaves that constant out when no tag in the template escapes, drops the blank line Erubi leaves where an ERB comment was, and inserts the `;` after a `preamble` that does not end in one, which Erubi leaves as a syntax error. Each of those is a test in the divergence suite.
+
+The `case` guard is the one worth knowing about outside Rails, because writing the whole statement in one tag is a common way to sidestep the untrimmed-newline problem in engines that do not trim:
+
+```erb
+<% case status
+when :active %>
+  <span class="badge">Active</span>
+<% end %>
+```
+
+Turning strict parsing off compiles it, byte-identically to Erubi:
+
+```ruby
+Herb::Engine.new(source, parser_options: { strict: false })
+```
+
+Since Herb trims, the conventional form with `case` and `when` in separate tags already works, and it is the form the formatter and the linter are built around.
+
+The linter is configured separately from the engine. Set [`framework`](/configuration#framework-configuration) in `.herb.yml` so rules that assume Action View stay quiet in a project that is not running it.
+
+### Blocks
+
+`<%= %>` with a block compiles so that the block body writes into the buffer directly:
+
+```erb
+<%= wrapper do %>
+  <p>hi</p>
+<% end %>
+```
+
+```ruby
+_buf = ::String.new; _buf << (wrapper do; _buf << '
+  <p>hi</p>
+'.freeze; end )
+_buf.to_s
+```
+
+Plain `Erubi::Engine` compiles this template to invalid Ruby, since it closes the append before the block body. [`Erubi::CaptureBlockEngine`](https://github.com/jeremyevans/erubi#capturing) is the engine that handles it, and Herb generates the same structure it does. The two differ only in the append operator, `<<=` where Herb writes `<<`, and those are equivalent here because `<<=` expands to `buffer = buffer << value` and the buffer returns itself.
+
+What `Erubi::CaptureBlockEngine` really contributes is its buffer. `Erubi::CaptureBlockEngine::Buffer` is a `String` subclass with a `capture` method, which empties the buffer, runs the block, and returns what the block wrote. A helper calls it to get the block's content:
+
+```ruby
+def upcase_form(&block)
+  "<form>#{@bufvar.capture(&block).upcase}</form>"
+end
+```
+
+Herb's default `bufval` is `::String.new`, which has no `capture`. Point it at a capture-aware buffer and helpers written for `Erubi::CaptureBlockEngine` work unchanged:
+
+```ruby
+Herb::Engine.new(source,
+  bufvar: "@bufvar",
+  bufval: "::Erubi::CaptureBlockEngine::Buffer.new",
+)
+```
+
+Rendering then matches `Erubi::CaptureBlockEngine` for nested blocks, escaping tags inside a block, and text around one. Action View supplies its own capture-aware buffer, which is why block helpers work there without any of this. A helper that only calls `yield` and interpolates the result renders the block's content twice, once from the direct write and once from the value it returns.
 
 ## Herb-Specific Options
 

--- a/test/engine/engine_erubi_capture_block_test.rb
+++ b/test/engine/engine_erubi_capture_block_test.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+require_relative "../../lib/herb/engine"
+
+require "erubi"
+require "erubi/capture_block"
+
+module Engine
+  class EngineErubiCaptureBlockTest < Minitest::Spec
+    BUFVAR = "@bufvar"
+    BUFVAL = "::Erubi::CaptureBlockEngine::Buffer.new"
+
+    def render_with_herb(template, options = {})
+      evaluate(Herb::Engine.new(template, options.merge(bufvar: BUFVAR, bufval: BUFVAL)).src)
+    end
+
+    def render_with_capture_block_erubi(template, options = {})
+      evaluate(Erubi::CaptureBlockEngine.new(template, options.merge(bufvar: BUFVAR)).src)
+    end
+
+    def evaluate(source)
+      context = Object.new
+
+      def context.upcase_form(&)
+        "<form>#{@bufvar.capture(&).upcase}</form>"
+      end
+
+      def context.wrap(&)
+        "[#{@bufvar.capture(&)}]"
+      end
+
+      context.instance_eval(source)
+    end
+
+    def assert_matches_capture_block_erubi(template, options = {})
+      herb = render_with_herb(template, options)
+
+      assert_equal render_with_capture_block_erubi(template, options), herb
+
+      herb
+    end
+
+    test "captures a block the way Erubi's capture block engine does" do
+      template = "<%= upcase_form do %><%= \"foo\" %><% end %>"
+
+      assert_equal "<form>FOO</form>", assert_matches_capture_block_erubi(template)
+    end
+
+    test "captures a block with text around it" do
+      assert_equal "a[b]c", assert_matches_capture_block_erubi("a<%= wrap do %>b<% end %>c")
+    end
+
+    test "captures nested blocks" do
+      template = "<%= wrap do %><%= wrap do %>x<% end %><% end %>"
+
+      assert_equal "[[x]]", assert_matches_capture_block_erubi(template)
+    end
+
+    test "captures an escaping tag inside the block" do
+      template = "<%= wrap do %><%= \"<b>\" %><% end %>"
+
+      assert_matches_capture_block_erubi(template, { escape: true })
+    end
+
+    test "captures a raw tag inside the block" do
+      template = "<%= wrap do %><%== \"<b>\" %><% end %>"
+
+      assert_matches_capture_block_erubi(template, { escape: true })
+    end
+
+    test "generates the same append structure, with <<= standing in for <<" do
+      template = "<%= wrap do %>x<% end %>"
+
+      herb = Herb::Engine.new(template, bufvar: BUFVAR, bufval: BUFVAL).src
+      erubi = Erubi::CaptureBlockEngine.new(template, bufvar: BUFVAR).src
+
+      assert_includes herb, "@bufvar << (wrap do;"
+      assert_includes erubi, "@bufvar <<=  wrap do ;"
+    end
+
+    test "needs a capture-aware buffer, which the default bufval is not" do
+      template = "<%= wrap do %>x<% end %>"
+
+      assert_raises(NoMethodError) { evaluate(Herb::Engine.new(template, bufvar: BUFVAR).src) }
+    end
+  end
+end

--- a/test/engine/engine_erubi_compat_test.rb
+++ b/test/engine/engine_erubi_compat_test.rb
@@ -10,7 +10,7 @@ module Engine
     test "handles no tags" do
       template = "a\n"
 
-      assert_compiled_snapshot(template)
+      assert_compiled_snapshot(template, enforce_erubi_equality: true)
     end
 
     test "handles basic erb expressions" do
@@ -35,7 +35,7 @@ module Engine
     test "escapes backslashes and apostrophes in text" do
       template = "<table>\n <tbody>' ' \\\\ \\\\\n</tbody>\n</table>"
 
-      assert_compiled_snapshot(template)
+      assert_compiled_snapshot(template, enforce_erubi_equality: true)
     end
 
     test "strips whitespace with -%> tag" do
@@ -44,7 +44,7 @@ module Engine
         text
       ERB
 
-      assert_compiled_snapshot(template)
+      assert_compiled_snapshot(template, enforce_erubi_equality: true)
     end
 
     test "handles erb comments" do
@@ -73,20 +73,20 @@ module Engine
     test "handles custom bufvar" do
       template = "<div>Test</div>"
 
-      assert_compiled_snapshot(template, { bufvar: "@output" })
+      assert_compiled_snapshot(template, { bufvar: "@output" }, enforce_erubi_equality: true)
     end
 
     test "handles freeze option" do
       template = "<div>Static content</div>"
 
-      assert_compiled_snapshot(template, { freeze: true })
+      assert_compiled_snapshot(template, { freeze: true }, enforce_erubi_equality: true)
     end
 
     test "handles freeze_template_literals option" do
       template = "<div>Content</div>"
 
-      assert_compiled_snapshot(template)
-      assert_compiled_snapshot(template, { freeze_template_literals: false })
+      assert_compiled_snapshot(template, enforce_erubi_equality: true)
+      assert_compiled_snapshot(template, { freeze_template_literals: false }, enforce_erubi_equality: true)
     end
 
     test "handles custom preamble and postamble" do
@@ -98,7 +98,7 @@ module Engine
     test "handles ensure option" do
       template = "<div>Test</div>"
 
-      assert_compiled_snapshot(template, ensure: true)
+      assert_compiled_snapshot(template, { ensure: true }, enforce_erubi_equality: true)
     end
 
     test "handles custom escapefunc" do
@@ -169,13 +169,13 @@ module Engine
     test "handles XML declarations" do
       template = '<?xml version="1.0" encoding="UTF-8"?>'
 
-      assert_compiled_snapshot(template)
+      assert_compiled_snapshot(template, enforce_erubi_equality: true)
     end
 
     test "handles XML processing instructions" do
       template = '<?xml-stylesheet type="text/xsl" href="feed.xsl"?>'
 
-      assert_compiled_snapshot(template)
+      assert_compiled_snapshot(template, enforce_erubi_equality: true)
     end
 
     test "handles XML processing instructions with ERB" do
@@ -190,6 +190,74 @@ module Engine
 
     test "handles empty escaped erb tag surrounded by text" do
       assert_evaluated_snapshot("a <%%> b", {}, enforce_erubi_equality: true)
+    end
+
+    test "leaves whitespace before a <%- tag alone" do
+      template = <<~ERB
+        text
+          <%- a = 1 %>
+        after
+      ERB
+
+      assert_compiled_snapshot(template, enforce_erubi_equality: true)
+    end
+
+    test "handles case with conditions in separate erb tags" do
+      template = <<~ERB
+        <% case animal %>
+        <% when "cat" %>
+          <p>You chose a cat!</p>
+        <% when "dog" %>
+          <p>You chose a dog!</p>
+        <% else %>
+          <p>Unknown animal</p>
+        <% end %>
+      ERB
+
+      assert_compiled_snapshot(template, enforce_erubi_equality: true)
+    end
+
+    test "handles case with a trimming tag before the first condition" do
+      template = <<~ERB
+        <% case animal -%>
+        <% when "cat" %>
+          <p>You chose a cat!</p>
+        <% else %>
+          <p>Unknown animal</p>
+        <% end %>
+      ERB
+
+      assert_compiled_snapshot(template, enforce_erubi_equality: true)
+    end
+
+    test "handles case with its first condition in the same erb tag when not strict" do
+      template = <<~ERB
+        <% case animal
+        when "cat" %>
+          <p>You chose a cat!</p>
+        <% when "dog" %>
+          <p>You chose a dog!</p>
+        <% else %>
+          <p>Unknown animal</p>
+        <% end %>
+      ERB
+
+      assert_compiled_snapshot(template, parser_options: { strict: false }, enforce_erubi_equality: true)
+    end
+
+    test "rejects case with its first condition in the same erb tag when strict" do
+      template = <<~ERB
+        <% case animal
+        when "cat" %>
+          <p>You chose a cat!</p>
+        <% end %>
+      ERB
+
+      error = assert_raises(Herb::Engine::ParseError) do
+        Herb::Engine.new(template)
+      end
+
+      assert_includes error.message, "ERBCaseWithConditions"
     end
   end
 end

--- a/test/engine/engine_erubi_divergence_test.rb
+++ b/test/engine/engine_erubi_divergence_test.rb
@@ -1,0 +1,245 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+require_relative "../../lib/herb/engine"
+
+require "erubi"
+
+module Engine
+  class EngineErubiDivergenceTest < Minitest::Spec
+    def compile_both(template, options = {})
+      [Herb::Engine.new(template, options).src, Erubi::Engine.new(template, options).src]
+    end
+
+    def assert_diverges_from_erubi(template, options = {})
+      herb, erubi = compile_both(template, options)
+
+      refute_equal erubi, herb, "expected Herb::Engine and Erubi::Engine to differ for #{template.inspect}"
+
+      [herb, erubi]
+    end
+
+    def without_expression_padding(source)
+      source.gsub("( ", "(").gsub(" )", ")")
+    end
+
+    def with_herb_escape_module(source)
+      source
+        .gsub("__erubi = ::Erubi;", "__herb = ::Herb::Engine;")
+        .gsub("__erubi.h", "__herb.h")
+        .gsub("::Erubi.h", "::Herb::Engine.h")
+    end
+
+    def without_erb_comment_line(source)
+      source.gsub("\n\n _buf", "\n _buf")
+    end
+
+    def assert_renders_the_same_as_erubi(template, options = {}, **locals)
+      herb = evaluate(Herb::Engine.new(template, options).src, locals)
+
+      assert_equal evaluate(Erubi::Engine.new(template, options).src, locals), herb
+
+      herb
+    end
+
+    def evaluate(source, locals)
+      context = Object.new
+
+      locals.each do |name, value|
+        context.define_singleton_method(name) { value }
+      end
+
+      context.instance_eval(source)
+    end
+
+    test "adds no padding inside expression code" do
+      [
+        ["<div><%= title %></div>", {}],
+        ["<%= content %>", { escape: false }],
+        ["<%== content %>", { escape: false, escapefunc: "CGI.escapeHTML" }],
+        ["<%= a %>\n<%= b %>\n", { chain_appends: true }],
+        ["<%= a %>\n<%= b %>\n", { chain_appends: false }],
+        ['<?xml-stylesheet type="text/xsl" href="<%= path %>"?>', {}]
+      ].each do |template, options|
+        herb, erubi = assert_diverges_from_erubi(template, options)
+
+        assert_equal herb, without_expression_padding(erubi),
+                     "expected padding to be the only difference for #{template.inspect} with #{options.inspect}"
+      end
+    end
+
+    test "escapes through its own module instead of Erubi's" do
+      herb, erubi = assert_diverges_from_erubi("<%= content %>", { escape: true })
+
+      assert_includes herb, "__herb = ::Herb::Engine;"
+      assert_includes herb, "__herb.h((content))"
+
+      assert_includes erubi, "__erubi = ::Erubi;"
+      assert_includes erubi, "__erubi.h(( content ))"
+
+      assert_renders_the_same_as_erubi("<%= content %>", { escape: true }, content: "<b>")
+    end
+
+    test "names its own module in the default escape function" do
+      herb, erubi = assert_diverges_from_erubi("<%== content %>", { escape: false })
+
+      assert_includes herb, "::Herb::Engine.h((content))"
+      assert_includes erubi, "::Erubi.h(( content ))"
+
+      assert_renders_the_same_as_erubi("<%== content %>", { escape: false }, content: "<b>")
+    end
+
+    test "leaves out the escape module when no tag in the template escapes" do
+      herb, erubi = assert_diverges_from_erubi("<%== content %>", { escape: true })
+
+      refute_includes herb, "__herb"
+      assert_includes erubi, "__erubi = ::Erubi;"
+
+      assert_renders_the_same_as_erubi("<%== content %>", { escape: true }, content: "<b>")
+    end
+
+    test "escapes an attribute value by attribute context where Erubi only calls to_s" do
+      template = <<~ERB
+        <img src="photo.jpg" alt="Photo">
+        <br>
+        <input type="text" name="<%= field_name %>">
+      ERB
+
+      herb, erubi = assert_diverges_from_erubi(template)
+
+      assert_includes herb, "::Herb::Engine.attr((field_name))"
+      assert_includes erubi, "( field_name ).to_s"
+
+      injection = 'a" onload="alert(1)'
+
+      assert_includes evaluate(erubi, field_name: injection), injection
+      refute_includes evaluate(herb, field_name: injection), injection
+    end
+
+    test "escapes inside a script element by script context where Erubi only calls to_s" do
+      template = <<~ERB
+        <script>
+        <![CDATA[
+          var data = <%= data %>;
+        ]]>
+        </script>
+      ERB
+
+      herb, erubi = assert_diverges_from_erubi(template)
+
+      assert_includes herb, "::Herb::Engine.js((data))"
+      assert_includes erubi, "( data ).to_s"
+
+      injection = "</script>"
+
+      assert_includes evaluate(erubi, data: injection), "var data = </script>;"
+      refute_includes evaluate(herb, data: injection), "var data = </script>;"
+      assert_includes evaluate(herb, data: injection), "var data = \\x3c/script\\x3e;"
+    end
+
+    test "does not leave a blank line where an ERB comment was" do
+      herb, erubi = assert_diverges_from_erubi("<%# a comment %>\n<div>Content</div>\n")
+
+      assert_equal "_buf = ::String.new; _buf << '<div>Content</div>\n'.freeze;\n_buf.to_s\n", herb
+      assert_equal "_buf = ::String.new;\n _buf << '<div>Content</div>\n'.freeze;\n_buf.to_s\n", erubi
+
+      assert_renders_the_same_as_erubi("<%# a comment %>\n<div>Content</div>\n")
+    end
+
+    test "differs only by padding and the escape module across a whole template" do
+      template = <<~ERB
+        <table>
+         <tbody>
+          <% i = 0
+             list.each_with_index do |item, i| %>
+          <tr>
+           <td><%= i+1 %></td>
+           <td><%== item %></td>
+          </tr>
+         <% end %>
+         </tbody>
+        </table>
+        <%== i+1 %>
+      ERB
+
+      herb, erubi = assert_diverges_from_erubi(template)
+
+      assert_equal herb, with_herb_escape_module(without_expression_padding(erubi))
+    end
+
+    test "differs only by padding and the comment line across a whole template" do
+      template = <<~ERB
+        <!DOCTYPE html>
+        <html>
+        <head>
+          <title><%= @title %></title>
+        </head>
+        <body>
+          <% if @user %>
+            <h1>Welcome <%= @user.name %>!</h1>
+          <% end %>
+          <%# This comment should not appear %>
+        </body>
+        </html>
+      ERB
+
+      herb, erubi = assert_diverges_from_erubi(template)
+
+      assert_equal herb, without_erb_comment_line(without_expression_padding(erubi))
+    end
+
+    test "separates a preamble that Erubi runs into the first append" do
+      options = { preamble: "@buf = []", postamble: "@buf.join" }
+      herb, erubi = assert_diverges_from_erubi("<div><%= title %></div>", options)
+
+      assert_includes herb, "@buf = [];"
+      assert_includes erubi, "@buf = [] _buf"
+
+      RubyVM::InstructionSequence.compile(herb)
+
+      assert_raises(SyntaxError) { RubyVM::InstructionSequence.compile(erubi) }
+    end
+
+    test "ignores trim: false and keeps trimming" do
+      template = "<% a = 1 %>\ntext\n"
+      herb, erubi = assert_diverges_from_erubi(template, { trim: false })
+
+      assert_equal Herb::Engine.new(template).src, herb
+      assert_includes erubi, "_buf << '\n'.freeze;"
+
+      refute_equal evaluate(erubi, {}), evaluate(herb, {})
+    end
+
+    test "refuses an escaped ERB tag that Erubi passes through" do
+      template = "<%% literal %>\n"
+
+      assert_includes Erubi::Engine.new(template).src, "'<% literal %>"
+
+      assert_raises(Herb::Engine::GeneratorTemplateError) { Herb::Engine.new(template) }
+    end
+
+    test "refuses a case with its first condition in the same tag that Erubi compiles" do
+      template = <<~ERB
+        <% case animal
+        when "cat" %>
+          <p>You chose a cat!</p>
+        <% end %>
+      ERB
+
+      assert_includes Erubi::Engine.new(template).src, "case animal\nwhen \"cat\""
+
+      assert_raises(Herb::Engine::ParseError) { Herb::Engine.new(template) }
+
+      assert_equal Erubi::Engine.new(template).src, Herb::Engine.new(template, parser_options: { strict: false }).src
+    end
+
+    test "compiles a block expression that Erubi turns into invalid Ruby" do
+      template = "<%= wrapper do %>\n  <p>hi</p>\n<% end %>\n"
+      herb, erubi = assert_diverges_from_erubi(template)
+
+      RubyVM::InstructionSequence.compile(herb)
+
+      assert_raises(SyntaxError) { RubyVM::InstructionSequence.compile(erubi) }
+    end
+  end
+end

--- a/test/snapshots/engine/engine_erubi_compat_test/test_0023_leaves_whitespace_before_a_lt%-_tag_alone_9c58e17b0b3e5d7b0b44fd951c7606fd.txt
+++ b/test/snapshots/engine/engine_erubi_compat_test/test_0023_leaves_whitespace_before_a_lt%-_tag_alone_9c58e17b0b3e5d7b0b44fd951c7606fd.txt
@@ -1,0 +1,9 @@
+---
+source: "Engine::EngineErubiCompatTest#test_0023_leaves whitespace before a <%- tag alone"
+input: "{source: \"text\\n  <%- a = 1 %>\\nafter\\n\", options: {}}"
+---
+_buf = ::String.new; _buf << 'text
+'.freeze;   a = 1 
+ _buf << 'after
+'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/engine_erubi_compat_test/test_0024_handles_case_with_conditions_in_separate_erb_tags_cc3b84069b5c2f877391c9078f19ec9d.txt
+++ b/test/snapshots/engine/engine_erubi_compat_test/test_0024_handles_case_with_conditions_in_separate_erb_tags_cc3b84069b5c2f877391c9078f19ec9d.txt
@@ -1,0 +1,13 @@
+---
+source: "Engine::EngineErubiCompatTest#test_0024_handles case with conditions in separate erb tags"
+input: "{source: \"<% case animal %>\\n<% when \\\"cat\\\" %>\\n  <p>You chose a cat!</p>\\n<% when \\\"dog\\\" %>\\n  <p>You chose a dog!</p>\\n<% else %>\\n  <p>Unknown animal</p>\\n<% end %>\\n\", options: {}}"
+---
+_buf = ::String.new; case animal 
+ when "cat" 
+ _buf << '  <p>You chose a cat!</p>
+'.freeze; when "dog" 
+ _buf << '  <p>You chose a dog!</p>
+'.freeze; else 
+ _buf << '  <p>Unknown animal</p>
+'.freeze; end 
+_buf.to_s

--- a/test/snapshots/engine/engine_erubi_compat_test/test_0025_handles_case_with_a_trimming_tag_before_the_first_condition_5a287a0b15bd87bbf1e39b0bf70fbc11.txt
+++ b/test/snapshots/engine/engine_erubi_compat_test/test_0025_handles_case_with_a_trimming_tag_before_the_first_condition_5a287a0b15bd87bbf1e39b0bf70fbc11.txt
@@ -1,0 +1,11 @@
+---
+source: "Engine::EngineErubiCompatTest#test_0025_handles case with a trimming tag before the first condition"
+input: "{source: \"<% case animal -%>\\n<% when \\\"cat\\\" %>\\n  <p>You chose a cat!</p>\\n<% else %>\\n  <p>Unknown animal</p>\\n<% end %>\\n\", options: {}}"
+---
+_buf = ::String.new; case animal 
+ when "cat" 
+ _buf << '  <p>You chose a cat!</p>
+'.freeze; else 
+ _buf << '  <p>Unknown animal</p>
+'.freeze; end 
+_buf.to_s

--- a/test/snapshots/engine/engine_erubi_compat_test/test_0026_handles_case_with_its_first_condition_in_the_same_erb_tag_when_not_strict_0782b38efc1756d016f11a720e9bfec9.txt
+++ b/test/snapshots/engine/engine_erubi_compat_test/test_0026_handles_case_with_its_first_condition_in_the_same_erb_tag_when_not_strict_0782b38efc1756d016f11a720e9bfec9.txt
@@ -1,0 +1,13 @@
+---
+source: "Engine::EngineErubiCompatTest#test_0026_handles case with its first condition in the same erb tag when not strict"
+input: "{source: \"<% case animal\\nwhen \\\"cat\\\" %>\\n  <p>You chose a cat!</p>\\n<% when \\\"dog\\\" %>\\n  <p>You chose a dog!</p>\\n<% else %>\\n  <p>Unknown animal</p>\\n<% end %>\\n\", options: {parser_options: {strict: false}}}"
+---
+_buf = ::String.new; case animal
+when "cat" 
+ _buf << '  <p>You chose a cat!</p>
+'.freeze; when "dog" 
+ _buf << '  <p>You chose a dog!</p>
+'.freeze; else 
+ _buf << '  <p>Unknown animal</p>
+'.freeze; end 
+_buf.to_s


### PR DESCRIPTION
This pull request writes down which ERB dialect `Herb::Engine` targets, and backs every claim in that documentation with a test.

The question that started this was whether a `case` written across several ERB tags works outside Rails:

```erb
<% case status %>
<% when :active %>
  <span class="badge">Active</span>
<% else %>
  Unknown
<% end %>
```

It does, and `Herb::Engine` compiles it byte for byte the same as `Erubi::Engine`. Nothing in it is Rails-specific. It works because Erubi's `trim` drops the newline after a `<% %>` tag that stands alone on its line, so nothing lands between `case` and its first `when`. A framework that renders `.erb` through the standard library's `ERB` never gets that far, which is the actual reason the pattern is often described as Rails-only.

#### `Erubi::CaptureBlockEngine`

It turns out to be much closer than it looks. Herb generates the same structure it does, differing only in the append operator, `<<=` where Herb writes `<<`, and those are equivalent because `<<=` expands to `buffer = buffer << value` and the buffer returns itself. What `Erubi::CaptureBlockEngine` really contributes is its `Buffer`, a `String` subclass carrying `capture`. Point `bufval` at it and helpers written for that engine work unchanged, including nested blocks, escaping tags inside a block, and text around one.

```ruby
Herb::Engine.new(source,
  bufvar: "@bufvar",
  bufval: "::Erubi::CaptureBlockEngine::Buffer.new",
)
```

Resolves https://github.com/marcoroth/herb/issues/1059