### PR TITLE
Language Server: Fix opening `.herb.yml` in remote workspaces

### DIFF
--- a/javascript/packages/language-server/src/code_action_provider.ts
+++ b/javascript/packages/language-server/src/code_action_provider.ts
@@ -1,10 +1,11 @@
-import { CodeAction, CodeActionKind, CodeActionParams, Diagnostic, Range, TextEdit, WorkspaceEdit, CreateFile, TextDocumentEdit, OptionalVersionedTextDocumentIdentifier } from "vscode-languageserver/node"
+import { CodeAction, CodeActionKind, CodeActionParams, Command, Diagnostic, Range, TextEdit, WorkspaceEdit, CreateFile, TextDocumentEdit, OptionalVersionedTextDocumentIdentifier } from "vscode-languageserver/node"
 import { TextDocument } from "vscode-languageserver-textdocument"
 
 import { Herb } from "@herb-tools/node-wasm"
 import { Config } from "@herb-tools/config"
 import { Linter } from "@herb-tools/linter"
 import { Project } from "./project"
+import { OPEN_DOCUMENT_COMMAND } from "./commands"
 
 import { isValidFramework } from "@herb-tools/core"
 import { getFullDocumentRange, lspRangeFromLocation } from "@herb-tools/language-service"
@@ -275,11 +276,7 @@ export class CodeActionProvider {
       kind: CodeActionKind.QuickFix,
       diagnostics: [diagnostic],
       edit,
-      command: {
-        title: 'Open .herb.yml',
-        command: 'vscode.open',
-        arguments: [configUri]
-      }
+      command: this.openDocumentCommand(configUri)
     }
 
     return action
@@ -307,15 +304,19 @@ export class CodeActionProvider {
         kind: CodeActionKind.QuickFix,
         diagnostics: [diagnostic],
         edit,
-        command: {
-          title: 'Open .herb.yml',
-          command: 'vscode.open',
-          arguments: [configUri]
-        }
+        command: this.openDocumentCommand(configUri)
       }
 
       return [action]
     })
+  }
+
+  private openDocumentCommand(uri: string): Command {
+    return {
+      title: 'Open .herb.yml',
+      command: OPEN_DOCUMENT_COMMAND,
+      arguments: [uri]
+    }
   }
 
   private suggestedFramework(diagnostic: Diagnostic): Framework | undefined {

--- a/javascript/packages/language-server/src/commands.ts
+++ b/javascript/packages/language-server/src/commands.ts
@@ -1,0 +1,3 @@
+export const OPEN_DOCUMENT_COMMAND = "herb.openDocument"
+
+export const SERVER_COMMANDS = [OPEN_DOCUMENT_COMMAND]

--- a/javascript/packages/language-server/src/server.ts
+++ b/javascript/packages/language-server/src/server.ts
@@ -24,6 +24,7 @@ import {
   TextDocumentIdentifier,
   Range,
   FileChangeType,
+  ExecuteCommandParams,
 } from "vscode-languageserver/node"
 
 import { Session } from "./session"
@@ -31,6 +32,7 @@ import { PersonalHerbSettings } from "./user_settings"
 import { Config } from "@herb-tools/config"
 import { isPartialPath } from "@herb-tools/analysis"
 import { isConfigDocument, isPathInside } from "./utils"
+import { OPEN_DOCUMENT_COMMAND, SERVER_COMMANDS } from "./commands"
 import { serverVersion } from "./build_info"
 
 import type { FileEvent } from "vscode-languageserver/node"
@@ -75,6 +77,9 @@ export class Server {
           documentRangeFormattingProvider: true,
           codeActionProvider: {
             codeActionKinds: [CodeActionKind.QuickFix, CodeActionKind.SourceFixAll, CodeActionKind.RefactorRewrite, CodeActionKind.RefactorExtract]
+          },
+          executeCommandProvider: {
+            commands: SERVER_COMMANDS
           },
           foldingRangeProvider: true,
           documentHighlightProvider: true,
@@ -250,6 +255,22 @@ export class Server {
       const extractCodeActions = this.session.extractCodeActionProvider.getCodeActions(document, params.range, { framework: project.framework })
 
       return autofixCodeActions.concat(linterDisableCodeActions).concat(rewriteCodeActions).concat(extractCodeActions)
+    })
+
+    this.connection.onExecuteCommand(async (params: ExecuteCommandParams) => {
+      if (params.command !== OPEN_DOCUMENT_COMMAND) return
+
+      const [uri] = params.arguments ?? []
+
+      if (typeof uri !== "string") return
+
+      const shown = this.session.capabilities.hasShowDocument
+        ? await this.connection.window.showDocument({ uri, takeFocus: true })
+        : undefined
+
+      if (shown?.success) return
+
+      this.connection.window.showInformationMessage(`Herb updated ${pathFromUri(uri)}`)
     })
 
     this.connection.onRequest<ExtractToPartialResult, void>('herb/extractToPartial', (params: { textDocument: TextDocumentIdentifier, range: Range, name: string }) => {

--- a/javascript/packages/language-server/test/code_action_provider.test.ts
+++ b/javascript/packages/language-server/test/code_action_provider.test.ts
@@ -55,6 +55,16 @@ describe("CodeActionProvider", () => {
     }
   }
 
+  function disableDiagnostic(rule: string): Diagnostic {
+    return {
+      range: Range.create(0, 0, 0, 0),
+      message: `Offense from ${rule}.`,
+      severity: DiagnosticSeverity.Error,
+      source: "Herb Linter ",
+      data: { rule }
+    }
+  }
+
   function setFrameworkActions(actions: Awaited<ReturnType<CodeActionProvider["createCodeActions"]>>) {
     return actions.filter(action => action.title.includes("Set `framework"))
   }
@@ -132,6 +142,22 @@ describe("CodeActionProvider", () => {
     const actions = setFrameworkActions(service.createCodeActions(URI, [diagnostic], "<%= image_tag %>"))
 
     expect(actions).toHaveLength(0)
+  })
+
+  it("asks the client to open the config with a server command", async () => {
+    writeConfig("version: 0.10.3\n")
+
+    const service = await createService()
+    const diagnostic = disableDiagnostic("html-tag-name-lowercase")
+
+    const actions = service.createCodeActions(URI, [diagnostic], "<DIV></DIV>")
+    const action = actions.find(action => action.title.includes("in `.herb.yml`"))
+
+    expect(action?.command).toEqual({
+      title: "Open .herb.yml",
+      command: "herb.openDocument",
+      arguments: [`file://${join(projectPath, ".herb.yml")}`]
+    })
   })
 
   it("fixes indentation to the style the diagnostics were reported against", async () => {


### PR DESCRIPTION
This pull request fixes the `.herb.yml` quick fixes opening a file that does not exist whenever the editor is attached to a remote workspace, like a devcontainer, an SSH host, or WSL.

Picking "Disable `<rule>` in `.herb.yml`" wrote the change correctly and then opened a second tab reporting "The editor could not be opened because the file was not found", pointing at the same config file that was already open in another tab.

The code action carried a `vscode.open` command with the config URI as a plain string:

```ts
command: {
  title: 'Open .herb.yml',
  command: 'vscode.open',
  arguments: [`file://${configPath}`]
}
```

In a remote window the extension host works in `file://` paths, and VS Code rewrites them to `vscode-remote://` on the way to the UI. That rewrite only reaches real `Uri` objects. Command arguments travel as raw JSON, so the string passed through untouched and the UI went looking for `/workspaces/<project>/.herb.yml` on the local machine, where nothing of the sort exists.

The edit half of the same code action landed on the right file, because `vscode-languageclient` runs workspace edits through `Uri.parse` before applying them. One path converted the URI, the other handed it over as a string.

The action now carries `herb.openDocument`, a server command declared through `executeCommandProvider`. Its handler asks the client to open the file with `window/showDocument`, which runs the URI through the same converter the workspace edit was already using.

`vscode.open` was also a VS Code command sitting in a server that ships to eight editors, so this affordance never did anything in Neovim, Helix, Zed, or Sublime. `window/showDocument` is part of the protocol, so those clients get it now as well.

Clients that cannot open a document are no longer left with nothing. When the client does not advertise `window/showDocument`, or tries to open the file and reports back that it failed, the server falls back to an information message naming the file it changed.

Resolves https://github.com/marcoroth/herb/issues/1414