### PR TITLE
CI: Check parser allocations under valgrind

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,3 +93,6 @@ jobs:
 
       - name: Run valgrind on examples/
         run: ./bin/valgrind_check_examples
+
+      - name: Run valgrind on examples/ with the tracking allocator
+        run: ./bin/valgrind_check_allocations

--- a/bench/bench_allocs.c
+++ b/bench/bench_allocs.c
@@ -1,6 +1,9 @@
 #include "../src/include/herb.h"
 #include "../src/include/lib/hb_allocator.h"
+#include "../src/include/parser/parser.h"
+#include "../src/include/util/io.h"
 
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -128,7 +131,20 @@ typedef struct {
   const char* source;
 } test_case_T;
 
-static void run_lex_benchmark(const char* name, const char* source) {
+static bool no_untracked_deallocations(const char* phase, const char* name, hb_allocator_tracking_stats_T* stats) {
+  if (stats->untracked_deallocation_count == 0) { return true; }
+
+  printf(
+    "  %-5s %-9s  FAILED: %zu deallocation(s) of untracked pointers\n",
+    phase,
+    name,
+    stats->untracked_deallocation_count
+  );
+
+  return false;
+}
+
+static bool run_lex_benchmark(const char* name, const char* source) {
   hb_allocator_T allocator = hb_allocator_with_tracking();
 
   hb_array_T* tokens = herb_lex(source, &allocator);
@@ -139,10 +155,15 @@ static void run_lex_benchmark(const char* name, const char* source) {
     name, stats->allocation_count, stats->deallocation_count, stats->bytes_allocated, tokens->size);
 
   herb_free_tokens(&tokens, &allocator);
+
+  bool ok = no_untracked_deallocations("lex", name, stats);
+
   hb_allocator_destroy(&allocator);
+
+  return ok;
 }
 
-static void run_parse_benchmark(const char* name, const char* source) {
+static bool run_parse_benchmark(const char* name, const char* source) {
   hb_allocator_T allocator = hb_allocator_with_tracking();
 
   AST_DOCUMENT_NODE_T* root = herb_parse(source, NULL, &allocator);
@@ -153,10 +174,80 @@ static void run_parse_benchmark(const char* name, const char* source) {
     name, stats->allocation_count, stats->deallocation_count, stats->bytes_allocated);
 
   ast_node_free((AST_NODE_T*) root, &allocator);
+
+  bool ok = no_untracked_deallocations("parse", name, stats);
+
   hb_allocator_destroy(&allocator);
+
+  return ok;
 }
 
-int main(void) {
+static bool run_source_check(
+  const char* path,
+  const char* label,
+  const char* source,
+  const parser_options_T* options
+) {
+  hb_allocator_T allocator = hb_allocator_with_tracking();
+
+  AST_DOCUMENT_NODE_T* root = herb_parse(source, options, &allocator);
+
+  ast_node_free((AST_NODE_T*) root, &allocator);
+
+  hb_allocator_tracking_stats_T* stats = hb_allocator_tracking_stats(&allocator);
+
+  printf("  %-44s  %-10s  allocs: %-6zu  deallocs: %-6zu  bytes_alloc: %-8zu\n",
+    path, label, stats->allocation_count, stats->deallocation_count, stats->bytes_allocated);
+
+  bool ok = no_untracked_deallocations(label, path, stats);
+
+  hb_allocator_destroy(&allocator);
+
+  return ok;
+}
+
+static bool run_file_check(const char* path) {
+  hb_allocator_T file_allocator = hb_allocator_with_malloc();
+  char* source = herb_read_file(path, &file_allocator);
+
+  if (!source) {
+    printf("  %-44s  FAILED: could not read file\n", path);
+
+    return false;
+  }
+
+  parser_options_T transforms = HERB_DEFAULT_PARSER_OPTIONS;
+  transforms.action_view_helpers = true;
+  transforms.transform_conditionals = true;
+  transforms.render_nodes = true;
+  transforms.iteration_nodes = true;
+  transforms.strict_locals = true;
+
+  bool ok = run_source_check(path, "default", source, NULL);
+  ok = run_source_check(path, "transforms", source, &transforms) && ok;
+
+  hb_allocator_dealloc(&file_allocator, source);
+
+  return ok;
+}
+
+static int run_file_checks(int count, char** paths) {
+  printf("=== Allocation Check ===\n\n");
+
+  bool ok = true;
+
+  for (int i = 0; i < count; i++) { ok = run_file_check(paths[i]) && ok; }
+
+  printf("\n");
+
+  if (!ok) { return 1; }
+
+  return 0;
+}
+
+int main(int argc, char** argv) {
+  if (argc > 1) { return run_file_checks(argc - 1, argv + 1); }
+
   test_case_T cases[] = {
     { "small",  SMALL_INPUT },
     { "medium", MEDIUM_INPUT },
@@ -167,12 +258,16 @@ int main(void) {
 
   printf("=== Allocation Benchmark ===\n\n");
 
+  bool ok = true;
+
   for (size_t i = 0; i < num_cases; i++) {
     printf("[%s] (%zu bytes input)\n", cases[i].name, strlen(cases[i].source));
-    run_lex_benchmark(cases[i].name, cases[i].source);
-    run_parse_benchmark(cases[i].name, cases[i].source);
+    ok = run_lex_benchmark(cases[i].name, cases[i].source) && ok;
+    ok = run_parse_benchmark(cases[i].name, cases[i].source) && ok;
     printf("\n");
   }
+
+  if (!ok) { return 1; }
 
   return 0;
 }

--- a/bin/valgrind_check_allocations
+++ b/bin/valgrind_check_allocations
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+valgrind \
+  --error-exitcode=1 \
+  --leak-check=no \
+  ./bench_allocs examples/*.html.erb

--- a/src/lib/hb_allocator.c
+++ b/src/lib/hb_allocator.c
@@ -238,6 +238,8 @@ static void* tracking_realloc(hb_allocator_T* self, void* pointer, size_t _old_s
 }
 
 static void tracking_dealloc(hb_allocator_T* self, void* pointer) {
+  if (!pointer) { return; }
+
   hb_allocator_tracking_stats_T* stats = (hb_allocator_tracking_stats_T*) self->context;
   tracking_unrecord(stats, pointer);
   free(pointer);


### PR DESCRIPTION
This pull request adds a second valgrind gate that parses `examples/` through a malloc-backed allocator, so that CI can see the AST and token lifetimes the existing gate is structurally blind to.

`bin/valgrind_check_examples` drives `./herb parse`, and the CLI allocates from an arena. `arena_dealloc` is an empty function and nothing is released until `hb_allocator_destroy`, so a double `token_free` calls a no-op twice and a use-after-free reads memory that is still live inside the arena. Valgrind sees neither. That is not specific to the CLI either, since every other parse entry point is arena-backed too.

The tracking allocator is the one that calls real `malloc` and `free`, and `bench_allocs` is the only thing that parses through it. So `bench_allocs` now takes file arguments and checks each one, and `bin/valgrind_check_allocations` runs it under valgrind over `examples/`.

```c
./bench_allocs examples/*.html.erb
```

Each file is parsed twice, once with the default options and once with `action_view_helpers`, `transform_conditionals`, `render_nodes`, `iteration_nodes` and `strict_locals` enabled. Those transforms are all off by default, and they hold the analyze passes that construct nodes from tokens borrowed from other nodes, which is exactly the code most likely to break under a change to node ownership.

```
=== Allocation Check ===

  examples/begin.html.erb        default     allocs: 304   deallocs: 281   bytes_alloc: 35923
  examples/begin.html.erb        transforms  allocs: 352   deallocs: 329   bytes_alloc: 40068
  examples/case_when.html.erb    default     allocs: 870   deallocs: 801   bytes_alloc: 97528
  examples/case_when.html.erb    transforms  allocs: 1030  deallocs: 961   bytes_alloc: 109292
```

`bench_allocs` also fails now when the tracking allocator records a deallocation of a pointer it never handed out, which is what a double free looks like when `free` is intercepted and does not abort the process.

Leak checking stays off in the new script for now. The parse cycle still leaks, and the fixes are in the pull request stacked on top of this one. Turning `--leak-check=full` on is the last step of #1339.