### PR TITLE
Parser: Fix leaks in the parse and free cycle

### DIFF
--- a/src/analyze/analyze_helpers.c
+++ b/src/analyze/analyze_helpers.c
@@ -7,6 +7,7 @@
 #include "../include/analyze/analyzed_ruby.h"
 #include "../include/analyze/helpers.h"
 #include "../include/ast/ast_nodes.h"
+#include "../include/lexer/token.h"
 #include "../include/lib/hb_array.h"
 #include "../include/lib/string.h"
 #include "../include/prism/prism_helpers.h"
@@ -614,6 +615,8 @@ static void append_parameter(
       allocator
     )
   );
+
+  token_free(name_token, allocator);
 }
 
 static void append_required_positional(

--- a/src/analyze/builders.c
+++ b/src/analyze/builders.c
@@ -33,9 +33,9 @@ location_T* compute_then_keyword(
   }
 
   token_T* content = erb_node->content;
-  const char* source = (content && !hb_string_is_empty(content->value))
-                       ? hb_allocator_strndup(allocator, content->value.data, content->value.length)
-                       : NULL;
+  char* source = (content && !hb_string_is_empty(content->value))
+                 ? hb_allocator_strndup(allocator, content->value.data, content->value.length)
+                 : NULL;
   location_T* then_keyword = NULL;
 
   if (control_type == CONTROL_TYPE_WHEN || control_type == CONTROL_TYPE_IN) {
@@ -58,6 +58,8 @@ location_T* compute_then_keyword(
     then_keyword->end.line = content_start.line + then_keyword->end.line - 1;
     then_keyword->end.column = content_start.column + then_keyword->end.column;
   }
+
+  hb_allocator_dealloc(allocator, source);
 
   return then_keyword;
 }

--- a/src/parser.c
+++ b/src/parser.c
@@ -1793,6 +1793,17 @@ static hb_array_T* collect_close_tag_names(hb_array_T* nodes, hb_allocator_T* al
   return close_tag_names;
 }
 
+static void free_close_tag_names(hb_array_T** close_tag_names, hb_allocator_T* allocator) {
+  if (close_tag_names == NULL || *close_tag_names == NULL) { return; }
+
+  for (size_t i = 0; i < hb_array_size(*close_tag_names); i++) {
+    hb_string_T* name = (hb_string_T*) hb_array_get(*close_tag_names, i);
+    if (name != NULL) { hb_allocator_dealloc(allocator, name); }
+  }
+
+  hb_array_free(close_tag_names);
+}
+
 static hb_array_T* parser_build_elements_from_tags(
   hb_array_T* nodes,
   hb_array_T* errors,
@@ -1938,6 +1949,8 @@ static hb_array_T* parser_build_elements_from_tags(
       hb_array_append(result, node);
     }
   }
+
+  free_close_tag_names(&close_tag_names, allocator);
 
   return result;
 }


### PR DESCRIPTION
This pull request frees three allocations that a parse makes and never releases, so that a full parse followed by `ast_node_free` returns every block it took.

None of this is observable in production today, because every parse entry point allocates from an arena and the arena is destroyed in one go. It becomes visible the moment the parser is run through a malloc-backed allocator, which is what the gate added in the pull request below this one does.

Together these take a default-options parse from 569 unfreed blocks to 2:

```
  examples/begin.html.erb        default     allocs: 304   deallocs: 304
  examples/begin.html.erb        transforms  allocs: 352   deallocs: 352
  examples/case_when.html.erb    default     allocs: 870   deallocs: 870
  examples/case_when.html.erb    transforms  allocs: 1030  deallocs: 1030
```

Found while working on #1339.