### PR TITLE
Engine: Compute the project path lazily

### DIFF
--- a/lib/herb/engine/visitor_context.rb
+++ b/lib/herb/engine/visitor_context.rb
@@ -30,19 +30,24 @@ module Herb
       UNKNOWN_FILE_PATH = "unknown" #: String
 
       attr_reader :file_path #: Pathname?
-      attr_reader :project_path #: Pathname
       attr_reader :options #: Hash[Symbol, untyped]
       attr_reader :data #: Hash[Symbol, untyped]
 
       #: (?file_path: (String | Pathname)?, ?project_path: (String | Pathname)?, ?options: Hash[Symbol, untyped], **untyped) -> void
       def initialize(file_path: nil, project_path: nil, options: {}, **data)
         @file_path = self.class.coerce_file_path(file_path)
-        @project_path = self.class.coerce_project_path(project_path)
+        @project_path_cache = [] #: Array[Pathname]
+        @project_path_cache << self.class.coerce_project_path(project_path) if project_path
         @relative_file_path_cache = [] #: Array[String]
         @options = options.dup.freeze
         @data = data.tap { |values| values[:origin] ||= Origin.new }.freeze
 
         freeze
+      end
+
+      #: () -> Pathname
+      def project_path
+        @project_path_cache[0] ||= self.class.coerce_project_path(nil)
       end
 
       #: () -> String

--- a/sig/herb/engine/visitor_context.rbs
+++ b/sig/herb/engine/visitor_context.rbs
@@ -25,14 +25,15 @@ module Herb
 
       attr_reader file_path: Pathname?
 
-      attr_reader project_path: Pathname
-
       attr_reader options: Hash[Symbol, untyped]
 
       attr_reader data: Hash[Symbol, untyped]
 
       # : (?file_path: (String | Pathname)?, ?project_path: (String | Pathname)?, ?options: Hash[Symbol, untyped], **untyped) -> void
       def initialize: (?file_path: (String | Pathname)?, ?project_path: (String | Pathname)?, ?options: Hash[Symbol, untyped], **untyped) -> void
+
+      # : () -> Pathname
+      def project_path: () -> Pathname
 
       # : () -> String
       def relative_file_path: () -> String


### PR DESCRIPTION
This pull request stops `VisitorContext` from asking the operating system where it is for every template it builds a context for.

`coerce_project_path` falls back to `Pathname.new(Dir.pwd)` when no project path is given, and it ran during construction. The project path is only read when a visitor, a diagnostic, an overlay or the relative file path asks for it, so a template compiled without any of those still paid for a `getcwd` and two allocations.

Deriving it on demand takes about 7% off compile time over the `examples/` corpus.

The value is unchanged. `coerce_project_path` keeps its behavior for a caller that passes a path, and the derived one is cached through the same mutable holder #2262 introduced for the relative file path, so the context can stay frozen.

Follow-up to #2262.