### PR TITLE
Parser: Skip `token_copy()` in AST node constructors

### DIFF
--- a/src/analyze/action_view/tag_helpers.c
+++ b/src/analyze/action_view/tag_helpers.c
@@ -1705,7 +1705,7 @@ static AST_NODE_T* transform_link_to_helper(
     allocator
   );
 
-  AST_HTML_ELEMENT_NODE_T* element = ast_html_element_node_init(
+  return (AST_NODE_T*) ast_html_element_node_init(
     (AST_NODE_T*) open_tag_node,
     token_copy(tag_name_token, allocator),
     body,
@@ -1717,8 +1717,6 @@ static AST_NODE_T* transform_link_to_helper(
     hb_array_init(0, allocator),
     allocator
   );
-
-  return (AST_NODE_T*) element;
 }
 
 void transform_tag_helper_array(hb_array_T* array, analyze_ruby_context_T* context) {

--- a/src/analyze/action_view/tag_helpers.c
+++ b/src/analyze/action_view/tag_helpers.c
@@ -817,9 +817,9 @@ static AST_NODE_T* transform_tag_helper_with_attributes(
   hb_array_T* open_tag_children = attributes ? attributes : hb_array_init(0, allocator);
 
   AST_ERB_OPEN_TAG_NODE_T* open_tag_node = ast_erb_open_tag_node_init(
-    erb_node->tag_opening,
-    erb_node->content,
-    erb_node->tag_closing,
+    token_copy(erb_node->tag_opening, allocator),
+    token_copy(erb_node->content, allocator),
+    token_copy(erb_node->tag_closing, allocator),
     tag_name_token,
     open_tag_children,
     erb_node->base.location.start,
@@ -918,7 +918,7 @@ static AST_NODE_T* transform_tag_helper_with_attributes(
 
   if (!is_void) {
     AST_HTML_VIRTUAL_CLOSE_TAG_NODE_T* virtual_close = ast_html_virtual_close_tag_node_init(
-      tag_name_token,
+      token_copy(tag_name_token, allocator),
       erb_node->base.location.end,
       erb_node->base.location.end,
       hb_array_init(0, allocator),
@@ -929,7 +929,7 @@ static AST_NODE_T* transform_tag_helper_with_attributes(
 
   AST_HTML_ELEMENT_NODE_T* element = ast_html_element_node_init(
     (AST_NODE_T*) open_tag_node,
-    tag_name_token,
+    token_copy(tag_name_token, allocator),
     body,
     close_tag,
     is_void,
@@ -1025,9 +1025,9 @@ static AST_NODE_T* create_javascript_include_tag_element(
   hb_allocator_dealloc(allocator, source_value);
 
   AST_ERB_OPEN_TAG_NODE_T* open_tag_node = ast_erb_open_tag_node_init(
-    erb_node->tag_opening,
-    erb_node->content,
-    erb_node->tag_closing,
+    token_copy(erb_node->tag_opening, allocator),
+    token_copy(erb_node->content, allocator),
+    token_copy(erb_node->tag_closing, allocator),
     tag_name_token,
     attributes,
     erb_node->base.location.start,
@@ -1037,7 +1037,7 @@ static AST_NODE_T* create_javascript_include_tag_element(
   );
 
   AST_HTML_VIRTUAL_CLOSE_TAG_NODE_T* virtual_close = ast_html_virtual_close_tag_node_init(
-    tag_name_token,
+    token_copy(tag_name_token, allocator),
     erb_node->base.location.end,
     erb_node->base.location.end,
     hb_array_init(0, allocator),
@@ -1046,7 +1046,7 @@ static AST_NODE_T* create_javascript_include_tag_element(
 
   return (AST_NODE_T*) ast_html_element_node_init(
     (AST_NODE_T*) open_tag_node,
-    tag_name_token,
+    token_copy(tag_name_token, allocator),
     hb_array_init(0, allocator),
     (AST_NODE_T*) virtual_close,
     false,
@@ -1149,9 +1149,9 @@ static AST_NODE_T* create_stylesheet_link_tag_element(
     prepend_stylesheet_link_tag_attributes(attributes, parse_context, source_argument, path_options, allocator);
 
   AST_ERB_OPEN_TAG_NODE_T* open_tag_node = ast_erb_open_tag_node_init(
-    erb_node->tag_opening,
-    erb_node->content,
-    erb_node->tag_closing,
+    token_copy(erb_node->tag_opening, allocator),
+    token_copy(erb_node->content, allocator),
+    token_copy(erb_node->tag_closing, allocator),
     tag_name_token,
     attributes,
     erb_node->base.location.start,
@@ -1162,7 +1162,7 @@ static AST_NODE_T* create_stylesheet_link_tag_element(
 
   return (AST_NODE_T*) ast_html_element_node_init(
     (AST_NODE_T*) open_tag_node,
-    tag_name_token,
+    token_copy(tag_name_token, allocator),
     hb_array_init(0, allocator),
     NULL,
     true,
@@ -1378,9 +1378,9 @@ static AST_NODE_T* transform_erb_block_to_tag_helper(
   hb_array_T* open_tag_children = attributes ? attributes : hb_array_init(0, allocator);
 
   AST_ERB_OPEN_TAG_NODE_T* open_tag_node = ast_erb_open_tag_node_init(
-    block_node->tag_opening,
-    block_node->content,
-    block_node->tag_closing,
+    token_copy(block_node->tag_opening, allocator),
+    token_copy(block_node->content, allocator),
+    token_copy(block_node->tag_closing, allocator),
     tag_name_token,
     open_tag_children,
     block_node->tag_opening->location.start,
@@ -1441,9 +1441,9 @@ static AST_NODE_T* transform_erb_block_to_tag_helper(
         end_offset = swallowed_end->tag_opening->range.from;
 
         AST_ERB_END_NODE_T* end_node = ast_erb_end_node_init(
-          swallowed_end->tag_opening,
-          swallowed_end->content,
-          swallowed_end->tag_closing,
+          token_copy(swallowed_end->tag_opening, allocator),
+          token_copy(swallowed_end->content, allocator),
+          token_copy(swallowed_end->tag_closing, allocator),
           swallowed_end->base.location.start,
           swallowed_end->base.location.end,
           hb_array_init(0, allocator),
@@ -1475,7 +1475,7 @@ static AST_NODE_T* transform_erb_block_to_tag_helper(
 
   AST_HTML_ELEMENT_NODE_T* element = ast_html_element_node_init(
     (AST_NODE_T*) open_tag_node,
-    tag_name_token,
+    token_copy(tag_name_token, allocator),
     body,
     is_void ? NULL : close_tag,
     is_void,
@@ -1645,9 +1645,9 @@ static AST_NODE_T* transform_link_to_helper(
   token_T* tag_name_token = create_synthetic_token(allocator, "a", TOKEN_IDENTIFIER, tag_name_start, tag_name_end);
 
   AST_ERB_OPEN_TAG_NODE_T* open_tag_node = ast_erb_open_tag_node_init(
-    erb_node->tag_opening,
-    erb_node->content,
-    erb_node->tag_closing,
+    token_copy(erb_node->tag_opening, allocator),
+    token_copy(erb_node->content, allocator),
+    token_copy(erb_node->tag_closing, allocator),
     tag_name_token,
     attributes,
     erb_node->base.location.start,
@@ -1698,7 +1698,7 @@ static AST_NODE_T* transform_link_to_helper(
   }
 
   AST_HTML_VIRTUAL_CLOSE_TAG_NODE_T* virtual_close = ast_html_virtual_close_tag_node_init(
-    tag_name_token,
+    token_copy(tag_name_token, allocator),
     erb_node->base.location.end,
     erb_node->base.location.end,
     hb_array_init(0, allocator),
@@ -1707,7 +1707,7 @@ static AST_NODE_T* transform_link_to_helper(
 
   AST_HTML_ELEMENT_NODE_T* element = ast_html_element_node_init(
     (AST_NODE_T*) open_tag_node,
-    tag_name_token,
+    token_copy(tag_name_token, allocator),
     body,
     (AST_NODE_T*) virtual_close,
     false,

--- a/src/analyze/analyze.c
+++ b/src/analyze/analyze.c
@@ -205,9 +205,9 @@ static AST_ERB_END_NODE_T* build_end_node(AST_ERB_CONTENT_NODE_T* end_erb, hb_al
   end_erb->base.errors = NULL;
 
   AST_ERB_END_NODE_T* end_node = ast_erb_end_node_init(
-    end_erb->tag_opening,
-    end_erb->content,
-    end_erb->tag_closing,
+    token_copy(end_erb->tag_opening, allocator),
+    token_copy(end_erb->content, allocator),
+    token_copy(end_erb->tag_closing, allocator),
     end_erb->tag_opening->location.start,
     erb_content_end_position(end_erb),
     end_errors,
@@ -400,9 +400,9 @@ static size_t process_case_structure(
 
       if (next_type == CONTROL_TYPE_WHEN) {
         condition_node = (AST_NODE_T*) ast_erb_when_node_init(
-          next_erb->tag_opening,
-          next_erb->content,
-          next_erb->tag_closing,
+          token_copy(next_erb->tag_opening, allocator),
+          token_copy(next_erb->content, allocator),
+          token_copy(next_erb->tag_closing, allocator),
           then_keyword,
           statements,
           cond_start,
@@ -412,9 +412,9 @@ static size_t process_case_structure(
         );
       } else {
         condition_node = (AST_NODE_T*) ast_erb_in_node_init(
-          next_erb->tag_opening,
-          next_erb->content,
-          next_erb->tag_closing,
+          token_copy(next_erb->tag_opening, allocator),
+          token_copy(next_erb->content, allocator),
+          token_copy(next_erb->tag_closing, allocator),
           then_keyword,
           statements,
           cond_start,
@@ -449,9 +449,9 @@ static size_t process_case_structure(
     next_erb->base.errors = NULL;
 
     else_clause = ast_erb_else_node_init(
-      next_erb->tag_opening,
-      next_erb->content,
-      next_erb->tag_closing,
+      token_copy(next_erb->tag_opening, allocator),
+      token_copy(next_erb->content, allocator),
+      token_copy(next_erb->tag_closing, allocator),
       else_children,
       next_erb->tag_opening->location.start,
       erb_content_end_position(next_erb),
@@ -486,9 +486,9 @@ static size_t process_case_structure(
 
   if (hb_array_size(in_conditions) > 0) {
     AST_ERB_CASE_MATCH_NODE_T* case_match_node = ast_erb_case_match_node_init(
-      erb_node->tag_opening,
-      erb_node->content,
-      erb_node->tag_closing,
+      token_copy(erb_node->tag_opening, allocator),
+      token_copy(erb_node->content, allocator),
+      token_copy(erb_node->tag_closing, allocator),
       non_when_non_in_children,
       HERB_PRISM_NODE_EMPTY,
       in_conditions,
@@ -507,9 +507,9 @@ static size_t process_case_structure(
   }
 
   AST_ERB_CASE_NODE_T* case_node = ast_erb_case_node_init(
-    erb_node->tag_opening,
-    erb_node->content,
-    erb_node->tag_closing,
+    token_copy(erb_node->tag_opening, allocator),
+    token_copy(erb_node->content, allocator),
+    token_copy(erb_node->tag_closing, allocator),
     non_when_non_in_children,
     HERB_PRISM_NODE_EMPTY,
     when_conditions,
@@ -566,9 +566,9 @@ static size_t process_begin_structure(
     next_erb->base.errors = NULL;
 
     else_clause = ast_erb_else_node_init(
-      next_erb->tag_opening,
-      next_erb->content,
-      next_erb->tag_closing,
+      token_copy(next_erb->tag_opening, allocator),
+      token_copy(next_erb->content, allocator),
+      token_copy(next_erb->tag_closing, allocator),
       else_children,
       next_erb->tag_opening->location.start,
       erb_content_end_position(next_erb),
@@ -590,9 +590,9 @@ static size_t process_begin_structure(
     next_erb->base.errors = NULL;
 
     ensure_clause = ast_erb_ensure_node_init(
-      next_erb->tag_opening,
-      next_erb->content,
-      next_erb->tag_closing,
+      token_copy(next_erb->tag_opening, allocator),
+      token_copy(next_erb->content, allocator),
+      token_copy(next_erb->tag_closing, allocator),
       ensure_children,
       next_erb->tag_opening->location.start,
       erb_content_end_position(next_erb),
@@ -624,9 +624,9 @@ static size_t process_begin_structure(
   erb_node->base.errors = NULL;
 
   AST_ERB_BEGIN_NODE_T* begin_node = ast_erb_begin_node_init(
-    erb_node->tag_opening,
-    erb_node->content,
-    erb_node->tag_closing,
+    token_copy(erb_node->tag_opening, allocator),
+    token_copy(erb_node->content, allocator),
+    token_copy(erb_node->tag_closing, allocator),
     HERB_PRISM_NODE_EMPTY,
     children,
     rescue_clause,
@@ -683,9 +683,9 @@ static size_t process_block_structure(
     next_erb->base.errors = NULL;
 
     else_clause = ast_erb_else_node_init(
-      next_erb->tag_opening,
-      next_erb->content,
-      next_erb->tag_closing,
+      token_copy(next_erb->tag_opening, allocator),
+      token_copy(next_erb->content, allocator),
+      token_copy(next_erb->tag_closing, allocator),
       else_children,
       next_erb->tag_opening->location.start,
       erb_content_end_position(next_erb),
@@ -707,9 +707,9 @@ static size_t process_block_structure(
     next_erb->base.errors = NULL;
 
     ensure_clause = ast_erb_ensure_node_init(
-      next_erb->tag_opening,
-      next_erb->content,
-      next_erb->tag_closing,
+      token_copy(next_erb->tag_opening, allocator),
+      token_copy(next_erb->content, allocator),
+      token_copy(next_erb->tag_closing, allocator),
       ensure_children,
       next_erb->tag_opening->location.start,
       erb_content_end_position(next_erb),
@@ -763,9 +763,9 @@ static size_t process_block_structure(
     extract_block_arguments_from_erb_node(erb_node, context->source, &block_errors, allocator);
 
   AST_ERB_BLOCK_NODE_T* block_node = ast_erb_block_node_init(
-    erb_node->tag_opening,
-    erb_node->content,
-    erb_node->tag_closing,
+    token_copy(erb_node->tag_opening, allocator),
+    token_copy(erb_node->content, allocator),
+    token_copy(erb_node->tag_closing, allocator),
     HERB_PRISM_NODE_EMPTY,
     children,
     block_arguments,

--- a/src/analyze/analyze_helpers.c
+++ b/src/analyze/analyze_helpers.c
@@ -615,8 +615,6 @@ static void append_parameter(
       allocator
     )
   );
-
-  token_free(name_token, allocator);
 }
 
 static void append_required_positional(

--- a/src/analyze/builders.c
+++ b/src/analyze/builders.c
@@ -160,9 +160,9 @@ AST_NODE_T* create_control_node(
 
 static AST_NODE_T* build_if_node(control_builder_context_T* context) {
   return (AST_NODE_T*) ast_erb_if_node_init(
-    context->tag_opening,
-    context->content,
-    context->tag_closing,
+    token_copy(context->tag_opening, context->allocator),
+    token_copy(context->content, context->allocator),
+    token_copy(context->tag_closing, context->allocator),
     context->then_keyword,
     HERB_PRISM_NODE_EMPTY,
     context->children,
@@ -177,9 +177,9 @@ static AST_NODE_T* build_if_node(control_builder_context_T* context) {
 
 static AST_NODE_T* build_else_node(control_builder_context_T* context) {
   return (AST_NODE_T*) ast_erb_else_node_init(
-    context->tag_opening,
-    context->content,
-    context->tag_closing,
+    token_copy(context->tag_opening, context->allocator),
+    token_copy(context->content, context->allocator),
+    token_copy(context->tag_closing, context->allocator),
     context->children,
     context->start_position,
     context->end_position,
@@ -190,9 +190,9 @@ static AST_NODE_T* build_else_node(control_builder_context_T* context) {
 
 static AST_NODE_T* build_when_node(control_builder_context_T* context) {
   return (AST_NODE_T*) ast_erb_when_node_init(
-    context->tag_opening,
-    context->content,
-    context->tag_closing,
+    token_copy(context->tag_opening, context->allocator),
+    token_copy(context->content, context->allocator),
+    token_copy(context->tag_closing, context->allocator),
     context->then_keyword,
     context->children,
     context->start_position,
@@ -204,9 +204,9 @@ static AST_NODE_T* build_when_node(control_builder_context_T* context) {
 
 static AST_NODE_T* build_in_node(control_builder_context_T* context) {
   return (AST_NODE_T*) ast_erb_in_node_init(
-    context->tag_opening,
-    context->content,
-    context->tag_closing,
+    token_copy(context->tag_opening, context->allocator),
+    token_copy(context->content, context->allocator),
+    token_copy(context->tag_closing, context->allocator),
     context->then_keyword,
     context->children,
     context->start_position,
@@ -224,9 +224,9 @@ static AST_NODE_T* build_rescue_node(control_builder_context_T* context) {
   }
 
   return (AST_NODE_T*) ast_erb_rescue_node_init(
-    context->tag_opening,
-    context->content,
-    context->tag_closing,
+    token_copy(context->tag_opening, context->allocator),
+    token_copy(context->content, context->allocator),
+    token_copy(context->tag_closing, context->allocator),
     context->children,
     rescue_node,
     context->start_position,
@@ -238,9 +238,9 @@ static AST_NODE_T* build_rescue_node(control_builder_context_T* context) {
 
 static AST_NODE_T* build_ensure_node(control_builder_context_T* context) {
   return (AST_NODE_T*) ast_erb_ensure_node_init(
-    context->tag_opening,
-    context->content,
-    context->tag_closing,
+    token_copy(context->tag_opening, context->allocator),
+    token_copy(context->content, context->allocator),
+    token_copy(context->tag_closing, context->allocator),
     context->children,
     context->start_position,
     context->end_position,
@@ -257,9 +257,9 @@ static AST_NODE_T* build_unless_node(control_builder_context_T* context) {
   }
 
   return (AST_NODE_T*) ast_erb_unless_node_init(
-    context->tag_opening,
-    context->content,
-    context->tag_closing,
+    token_copy(context->tag_opening, context->allocator),
+    token_copy(context->content, context->allocator),
+    token_copy(context->tag_closing, context->allocator),
     context->then_keyword,
     HERB_PRISM_NODE_EMPTY,
     context->children,
@@ -274,9 +274,9 @@ static AST_NODE_T* build_unless_node(control_builder_context_T* context) {
 
 static AST_NODE_T* build_while_node(control_builder_context_T* context) {
   return (AST_NODE_T*) ast_erb_while_node_init(
-    context->tag_opening,
-    context->content,
-    context->tag_closing,
+    token_copy(context->tag_opening, context->allocator),
+    token_copy(context->content, context->allocator),
+    token_copy(context->tag_closing, context->allocator),
     HERB_PRISM_NODE_EMPTY,
     context->children,
     context->end_node,
@@ -289,9 +289,9 @@ static AST_NODE_T* build_while_node(control_builder_context_T* context) {
 
 static AST_NODE_T* build_until_node(control_builder_context_T* context) {
   return (AST_NODE_T*) ast_erb_until_node_init(
-    context->tag_opening,
-    context->content,
-    context->tag_closing,
+    token_copy(context->tag_opening, context->allocator),
+    token_copy(context->content, context->allocator),
+    token_copy(context->tag_closing, context->allocator),
     HERB_PRISM_NODE_EMPTY,
     context->children,
     context->end_node,
@@ -304,9 +304,9 @@ static AST_NODE_T* build_until_node(control_builder_context_T* context) {
 
 static AST_NODE_T* build_for_node(control_builder_context_T* context) {
   return (AST_NODE_T*) ast_erb_for_node_init(
-    context->tag_opening,
-    context->content,
-    context->tag_closing,
+    token_copy(context->tag_opening, context->allocator),
+    token_copy(context->content, context->allocator),
+    token_copy(context->tag_closing, context->allocator),
     HERB_PRISM_NODE_EMPTY,
     context->children,
     context->end_node,
@@ -319,9 +319,9 @@ static AST_NODE_T* build_for_node(control_builder_context_T* context) {
 
 static AST_NODE_T* build_block_node(control_builder_context_T* context) {
   return (AST_NODE_T*) ast_erb_block_node_init(
-    context->tag_opening,
-    context->content,
-    context->tag_closing,
+    token_copy(context->tag_opening, context->allocator),
+    token_copy(context->content, context->allocator),
+    token_copy(context->tag_closing, context->allocator),
     HERB_PRISM_NODE_EMPTY,
     context->children,
     hb_array_init(0, context->allocator),
@@ -338,9 +338,9 @@ static AST_NODE_T* build_block_node(control_builder_context_T* context) {
 
 static AST_NODE_T* build_yield_node(control_builder_context_T* context) {
   return (AST_NODE_T*) ast_erb_yield_node_init(
-    context->tag_opening,
-    context->content,
-    context->tag_closing,
+    token_copy(context->tag_opening, context->allocator),
+    token_copy(context->content, context->allocator),
+    token_copy(context->tag_closing, context->allocator),
     context->start_position,
     context->end_position,
     context->errors,

--- a/src/analyze/conditional_elements.c
+++ b/src/analyze/conditional_elements.c
@@ -362,7 +362,7 @@ static void rewrite_conditional_elements(hb_array_T* nodes, hb_array_T** documen
       body,
       (AST_NODE_T*) close_tag,
       node,
-      matched_open->open_tag->tag_name,
+      token_copy(matched_open->open_tag->tag_name, allocator),
       hb_string("HTML"),
       start_position,
       end_position,

--- a/src/analyze/conditional_open_tags.c
+++ b/src/analyze/conditional_open_tags.c
@@ -390,7 +390,7 @@ static void rewrite_conditional_open_tags(hb_array_T* nodes, hb_array_T* documen
 
     AST_HTML_CONDITIONAL_OPEN_TAG_NODE_T* conditional_open_tag = ast_html_conditional_open_tag_node_init(
       conditional_node,
-      tag_name_token,
+      token_copy(tag_name_token, allocator),
       false,
       conditional_node->location.start,
       conditional_node->location.end,
@@ -402,7 +402,7 @@ static void rewrite_conditional_open_tags(hb_array_T* nodes, hb_array_T* documen
 
     AST_HTML_ELEMENT_NODE_T* element = ast_html_element_node_init(
       (AST_NODE_T*) conditional_open_tag,
-      tag_name_token,
+      token_copy(tag_name_token, allocator),
       body,
       (AST_NODE_T*) close_tag,
       false,

--- a/src/analyze/iteration_nodes.c
+++ b/src/analyze/iteration_nodes.c
@@ -235,9 +235,9 @@ static AST_ERB_ITERATION_BLOCK_NODE_T* try_transform_block_node(
   block_node->base.errors = NULL;
 
   AST_ERB_ITERATION_BLOCK_NODE_T* iteration_block_node = ast_erb_iteration_block_node_init(
-    block_node->tag_opening,
-    block_node->content,
-    block_node->tag_closing,
+    token_copy(block_node->tag_opening, allocator),
+    token_copy(block_node->content, allocator),
+    token_copy(block_node->tag_closing, allocator),
     block_node->prism_node,
     receiver,
     call_operator,

--- a/src/analyze/postfix_conditionals.c
+++ b/src/analyze/postfix_conditionals.c
@@ -256,7 +256,7 @@ static AST_NODE_T* transform_conditional(
   herb_prism_node_T empty_prism_node = HERB_PRISM_NODE_EMPTY;
 
   if (conditional_node->type == PM_IF_NODE) {
-    AST_ERB_IF_NODE_T* if_node = ast_erb_if_node_init(
+    return (AST_NODE_T*) ast_erb_if_node_init(
       tag_opening,
       content_token,
       tag_closing,
@@ -270,10 +270,8 @@ static AST_NODE_T* transform_conditional(
       hb_array_init(0, allocator),
       allocator
     );
-
-    return (AST_NODE_T*) if_node;
   } else {
-    AST_ERB_UNLESS_NODE_T* unless_node = ast_erb_unless_node_init(
+    return (AST_NODE_T*) ast_erb_unless_node_init(
       tag_opening,
       content_token,
       tag_closing,
@@ -287,8 +285,6 @@ static AST_NODE_T* transform_conditional(
       hb_array_init(0, allocator),
       allocator
     );
-
-    return (AST_NODE_T*) unless_node;
   }
 }
 

--- a/src/analyze/postfix_conditionals.c
+++ b/src/analyze/postfix_conditionals.c
@@ -184,9 +184,9 @@ static bool append_body_statement(
   token_T* content = create_synthetic_token(allocator, info.source, TOKEN_ERB_CONTENT, body_start, body_end);
 
   AST_ERB_CONTENT_NODE_T* body_erb_node = ast_erb_content_node_init(
-    erb_node->tag_opening,
+    token_copy(erb_node->tag_opening, allocator),
     content,
-    erb_node->tag_closing,
+    token_copy(erb_node->tag_closing, allocator),
     NULL,
     false,
     true,

--- a/src/analyze/render_nodes.c
+++ b/src/analyze/render_nodes.c
@@ -770,7 +770,7 @@ static AST_ERB_RENDER_NODE_T* create_render_node_from_call(
     allocator
   );
 
-  AST_ERB_RENDER_NODE_T* render_node = ast_erb_render_node_init(
+  return ast_erb_render_node_init(
     token_copy(erb_node->tag_opening, allocator),
     token_copy(erb_node->content, allocator),
     token_copy(erb_node->tag_closing, allocator),
@@ -788,8 +788,6 @@ static AST_ERB_RENDER_NODE_T* create_render_node_from_call(
     errors,
     allocator
   );
-
-  return render_node;
 }
 
 static size_t calculate_byte_offset_from_pos(const char* source, position_T position) {

--- a/src/analyze/render_nodes.c
+++ b/src/analyze/render_nodes.c
@@ -771,9 +771,9 @@ static AST_ERB_RENDER_NODE_T* create_render_node_from_call(
   );
 
   AST_ERB_RENDER_NODE_T* render_node = ast_erb_render_node_init(
-    erb_node->tag_opening,
-    erb_node->content,
-    erb_node->tag_closing,
+    token_copy(erb_node->tag_opening, allocator),
+    token_copy(erb_node->content, allocator),
+    token_copy(erb_node->tag_closing, allocator),
     erb_node->analyzed_ruby,
     prism_node,
     keywords_node,

--- a/src/analyze/strict_locals.c
+++ b/src/analyze/strict_locals.c
@@ -191,9 +191,9 @@ static AST_ERB_STRICT_LOCALS_NODE_T* create_strict_locals_node(
     hb_allocator_dealloc(allocator, rest);
 
     return ast_erb_strict_locals_node_init(
-      erb_node->tag_opening,
-      erb_node->content,
-      erb_node->tag_closing,
+      token_copy(erb_node->tag_opening, allocator),
+      token_copy(erb_node->content, allocator),
+      token_copy(erb_node->tag_closing, allocator),
       erb_node->analyzed_ruby,
       erb_node->prism_node,
       locals,
@@ -279,9 +279,9 @@ static AST_ERB_STRICT_LOCALS_NODE_T* create_strict_locals_node(
   hb_buffer_free(&synthetic_buffer);
 
   return ast_erb_strict_locals_node_init(
-    erb_node->tag_opening,
-    erb_node->content,
-    erb_node->tag_closing,
+    token_copy(erb_node->tag_opening, allocator),
+    token_copy(erb_node->content, allocator),
+    token_copy(erb_node->tag_closing, allocator),
     erb_node->analyzed_ruby,
     erb_node->prism_node,
     locals,

--- a/src/analyze/ternary_conditionals.c
+++ b/src/analyze/ternary_conditionals.c
@@ -125,9 +125,9 @@ static bool append_branch_statement(
   token_T* content = create_synthetic_token(allocator, info.source, TOKEN_ERB_CONTENT, branch_start, branch_end);
 
   AST_ERB_CONTENT_NODE_T* branch_erb_node = ast_erb_content_node_init(
-    erb_node->tag_opening,
+    token_copy(erb_node->tag_opening, allocator),
     content,
-    erb_node->tag_closing,
+    token_copy(erb_node->tag_closing, allocator),
     NULL,
     false,
     true,

--- a/src/analyze/ternary_conditionals.c
+++ b/src/analyze/ternary_conditionals.c
@@ -207,7 +207,7 @@ AST_NODE_T* transform_ternary_expression(
 
   herb_prism_node_T empty_prism_node = HERB_PRISM_NODE_EMPTY;
 
-  AST_ERB_IF_NODE_T* result_if_node = ast_erb_if_node_init(
+  return (AST_NODE_T*) ast_erb_if_node_init(
     if_opening,
     if_content,
     if_closing,
@@ -221,8 +221,6 @@ AST_NODE_T* transform_ternary_expression(
     hb_array_init(0, allocator),
     allocator
   );
-
-  return (AST_NODE_T*) result_if_node;
 }
 
 static void transform_ternary_array(

--- a/src/parser.c
+++ b/src/parser.c
@@ -511,7 +511,7 @@ static AST_HTML_ATTRIBUTE_VALUE_NODE_T* parser_parse_quoted_html_attribute_value
       parser_append_literal_node_from_buffer(parser, &buffer, children, start);
       hb_buffer_free(&buffer);
 
-      AST_HTML_ATTRIBUTE_VALUE_NODE_T* attribute_value = ast_html_attribute_value_node_init(
+      return ast_html_attribute_value_node_init(
         opening_quote,
         children,
         NULL,
@@ -521,8 +521,6 @@ static AST_HTML_ATTRIBUTE_VALUE_NODE_T* parser_parse_quoted_html_attribute_value
         *errors,
         parser->allocator
       );
-
-      return attribute_value;
     }
 
     bool buffer_ends_with_whitespace = buffer.length > 0 && is_whitespace(buffer.value[buffer.length - 1]);
@@ -557,7 +555,7 @@ static AST_HTML_ATTRIBUTE_VALUE_NODE_T* parser_parse_quoted_html_attribute_value
         parser_append_literal_node_from_buffer(parser, &buffer, children, start);
         hb_buffer_free(&buffer);
 
-        AST_HTML_ATTRIBUTE_VALUE_NODE_T* attribute_value = ast_html_attribute_value_node_init(
+        return ast_html_attribute_value_node_init(
           opening_quote,
           children,
           NULL,
@@ -567,8 +565,6 @@ static AST_HTML_ATTRIBUTE_VALUE_NODE_T* parser_parse_quoted_html_attribute_value
           *errors,
           parser->allocator
         );
-
-        return attribute_value;
       }
     }
 
@@ -649,7 +645,7 @@ static AST_HTML_ATTRIBUTE_VALUE_NODE_T* parser_parse_quoted_html_attribute_value
 
   token_T* closing_quote = parser_consume_expected(parser, TOKEN_QUOTE, errors);
 
-  AST_HTML_ATTRIBUTE_VALUE_NODE_T* attribute_value = ast_html_attribute_value_node_init(
+  return ast_html_attribute_value_node_init(
     opening_quote,
     children,
     closing_quote,
@@ -659,8 +655,6 @@ static AST_HTML_ATTRIBUTE_VALUE_NODE_T* parser_parse_quoted_html_attribute_value
     *errors,
     parser->allocator
   );
-
-  return attribute_value;
 }
 
 static AST_HTML_ATTRIBUTE_VALUE_NODE_T* parser_parse_html_attribute_value(parser_T* parser) {
@@ -746,7 +740,7 @@ static AST_HTML_ATTRIBUTE_VALUE_NODE_T* parser_parse_html_attribute_value(parser
 
   hb_allocator_dealloc(parser->allocator, expected);
 
-  AST_HTML_ATTRIBUTE_VALUE_NODE_T* value = ast_html_attribute_value_node_init(
+  return ast_html_attribute_value_node_init(
     NULL,
     children,
     NULL,
@@ -756,8 +750,6 @@ static AST_HTML_ATTRIBUTE_VALUE_NODE_T* parser_parse_html_attribute_value(parser
     errors,
     parser->allocator
   );
-
-  return value;
 }
 
 static AST_HTML_ATTRIBUTE_NODE_T* parser_parse_html_attribute(parser_T* parser) {
@@ -898,7 +890,7 @@ static AST_HTML_ATTRIBUTE_NODE_T* parser_parse_html_attribute(parser_T* parser) 
         parser->allocator
       );
 
-      AST_HTML_ATTRIBUTE_NODE_T* attribute_node = ast_html_attribute_node_init(
+      return ast_html_attribute_node_init(
         attribute_name,
         equals,
         empty_value,
@@ -907,13 +899,11 @@ static AST_HTML_ATTRIBUTE_NODE_T* parser_parse_html_attribute(parser_T* parser) 
         NULL,
         parser->allocator
       );
-
-      return attribute_node;
     }
 
     AST_HTML_ATTRIBUTE_VALUE_NODE_T* attribute_value = parser_parse_html_attribute_value(parser);
 
-    AST_HTML_ATTRIBUTE_NODE_T* attribute_node = ast_html_attribute_node_init(
+    return ast_html_attribute_node_init(
       attribute_name,
       equals,
       attribute_value,
@@ -922,8 +912,6 @@ static AST_HTML_ATTRIBUTE_NODE_T* parser_parse_html_attribute(parser_T* parser) 
       NULL,
       parser->allocator
     );
-
-    return attribute_node;
   }
 
   return ast_html_attribute_node_init(
@@ -1098,7 +1086,7 @@ static AST_HTML_OPEN_TAG_NODE_T* parser_parse_html_open_tag(parser_T* parser) {
         &parser->options
       );
 
-      AST_HTML_OPEN_TAG_NODE_T* open_tag_node = ast_html_open_tag_node_init(
+      return ast_html_open_tag_node_init(
         tag_start,
         tag_name,
         NULL,
@@ -1109,8 +1097,6 @@ static AST_HTML_OPEN_TAG_NODE_T* parser_parse_html_open_tag(parser_T* parser) {
         errors,
         parser->allocator
       );
-
-      return open_tag_node;
     }
 
     if (token_is_any_of(parser, TOKEN_WHITESPACE, TOKEN_NEWLINE)) {
@@ -1196,7 +1182,7 @@ static AST_HTML_OPEN_TAG_NODE_T* parser_parse_html_open_tag(parser_T* parser) {
       &parser->options
     );
 
-    AST_HTML_OPEN_TAG_NODE_T* open_tag_node = ast_html_open_tag_node_init(
+    return ast_html_open_tag_node_init(
       tag_start,
       tag_name,
       NULL,
@@ -1207,8 +1193,6 @@ static AST_HTML_OPEN_TAG_NODE_T* parser_parse_html_open_tag(parser_T* parser) {
       errors,
       parser->allocator
     );
-
-    return open_tag_node;
   }
 
   bool is_self_closing = false;
@@ -1231,7 +1215,7 @@ static AST_HTML_OPEN_TAG_NODE_T* parser_parse_html_open_tag(parser_T* parser) {
     is_self_closing = true;
   }
 
-  AST_HTML_OPEN_TAG_NODE_T* open_tag_node = ast_html_open_tag_node_init(
+  return ast_html_open_tag_node_init(
     tag_start,
     tag_name,
     tag_end,
@@ -1242,8 +1226,6 @@ static AST_HTML_OPEN_TAG_NODE_T* parser_parse_html_open_tag(parser_T* parser) {
     errors,
     parser->allocator
   );
-
-  return open_tag_node;
 }
 
 static AST_HTML_CLOSE_TAG_NODE_T* parser_parse_html_close_tag(parser_T* parser) {
@@ -1295,7 +1277,7 @@ static AST_HTML_CLOSE_TAG_NODE_T* parser_parse_html_close_tag(parser_T* parser) 
 
   position_T end_position = tag_closing != NULL ? tag_closing->location.end : tag_name->location.end;
 
-  AST_HTML_CLOSE_TAG_NODE_T* close_tag = ast_html_close_tag_node_init(
+  return ast_html_close_tag_node_init(
     tag_opening,
     tag_name,
     children,
@@ -1305,8 +1287,6 @@ static AST_HTML_CLOSE_TAG_NODE_T* parser_parse_html_close_tag(parser_T* parser) 
     errors,
     parser->allocator
   );
-
-  return close_tag;
 }
 
 // TODO: this should probably be AST_HTML_ELEMENT_NODE_T with a AST_HTML_SELF_CLOSING_TAG_NODE_T
@@ -1476,7 +1456,7 @@ static AST_ERB_CONTENT_NODE_T* parser_parse_erb_tag(parser_T* parser) {
     end_position = parser->current_token->location.start;
   }
 
-  AST_ERB_CONTENT_NODE_T* erb_node = ast_erb_content_node_init(
+  return ast_erb_content_node_init(
     opening_tag,
     content,
     closing_tag,
@@ -1489,8 +1469,6 @@ static AST_ERB_CONTENT_NODE_T* parser_parse_erb_tag(parser_T* parser) {
     errors,
     parser->allocator
   );
-
-  return erb_node;
 }
 
 static void parser_parse_foreign_content(parser_T* parser, hb_array_T* children, hb_array_T** errors) {

--- a/src/parser.c
+++ b/src/parser.c
@@ -108,8 +108,6 @@ static AST_CDATA_NODE_T* parser_parse_cdata(parser_T* parser) {
   );
 
   hb_buffer_free(&content);
-  token_free(tag_opening, parser->allocator);
-  token_free(tag_closing, parser->allocator);
 
   return cdata;
 }
@@ -169,8 +167,6 @@ static AST_HTML_COMMENT_NODE_T* parser_parse_html_comment(parser_T* parser) {
   );
 
   hb_buffer_free(&comment);
-  token_free(comment_start, parser->allocator);
-  token_free(comment_end, parser->allocator);
 
   return comment_node;
 }
@@ -214,8 +210,6 @@ static AST_HTML_DOCTYPE_NODE_T* parser_parse_html_doctype(parser_T* parser) {
     parser->allocator
   );
 
-  token_free(tag_opening, parser->allocator);
-  token_free(tag_closing, parser->allocator);
   hb_buffer_free(&content);
 
   return doctype;
@@ -262,8 +256,6 @@ static AST_XML_DECLARATION_NODE_T* parser_parse_xml_declaration(parser_T* parser
     parser->allocator
   );
 
-  token_free(tag_opening, parser->allocator);
-  token_free(tag_closing, parser->allocator);
   hb_buffer_free(&content);
 
   return xml_declaration;
@@ -313,9 +305,6 @@ static AST_XML_PROCESSING_INSTRUCTION_NODE_T* parser_parse_xml_processing_instru
     parser->allocator
   );
 
-  token_free(tag_opening, parser->allocator);
-  token_free(target, parser->allocator);
-  token_free(tag_closing, parser->allocator);
   hb_buffer_free(&content);
 
   return processing_instruction;
@@ -533,8 +522,6 @@ static AST_HTML_ATTRIBUTE_VALUE_NODE_T* parser_parse_quoted_html_attribute_value
         parser->allocator
       );
 
-      token_free(opening_quote, parser->allocator);
-
       return attribute_value;
     }
 
@@ -580,8 +567,6 @@ static AST_HTML_ATTRIBUTE_VALUE_NODE_T* parser_parse_quoted_html_attribute_value
           *errors,
           parser->allocator
         );
-
-        token_free(opening_quote, parser->allocator);
 
         return attribute_value;
       }
@@ -674,9 +659,6 @@ static AST_HTML_ATTRIBUTE_VALUE_NODE_T* parser_parse_quoted_html_attribute_value
     *errors,
     parser->allocator
   );
-
-  token_free(opening_quote, parser->allocator);
-  token_free(closing_quote, parser->allocator);
 
   return attribute_value;
 }
@@ -926,8 +908,6 @@ static AST_HTML_ATTRIBUTE_NODE_T* parser_parse_html_attribute(parser_T* parser) 
         parser->allocator
       );
 
-      token_free(equals, parser->allocator);
-
       return attribute_node;
     }
 
@@ -942,8 +922,6 @@ static AST_HTML_ATTRIBUTE_NODE_T* parser_parse_html_attribute(parser_T* parser) 
       NULL,
       parser->allocator
     );
-
-    token_free(equals, parser->allocator);
 
     return attribute_node;
   }
@@ -1132,9 +1110,6 @@ static AST_HTML_OPEN_TAG_NODE_T* parser_parse_html_open_tag(parser_T* parser) {
         parser->allocator
       );
 
-      token_free(tag_start, parser->allocator);
-      token_free(tag_name, parser->allocator);
-
       return open_tag_node;
     }
 
@@ -1233,9 +1208,6 @@ static AST_HTML_OPEN_TAG_NODE_T* parser_parse_html_open_tag(parser_T* parser) {
       parser->allocator
     );
 
-    token_free(tag_start, parser->allocator);
-    token_free(tag_name, parser->allocator);
-
     return open_tag_node;
   }
 
@@ -1270,10 +1242,6 @@ static AST_HTML_OPEN_TAG_NODE_T* parser_parse_html_open_tag(parser_T* parser) {
     errors,
     parser->allocator
   );
-
-  token_free(tag_start, parser->allocator);
-  token_free(tag_name, parser->allocator);
-  token_free(tag_end, parser->allocator);
 
   return open_tag_node;
 }
@@ -1338,10 +1306,6 @@ static AST_HTML_CLOSE_TAG_NODE_T* parser_parse_html_close_tag(parser_T* parser) 
     parser->allocator
   );
 
-  token_free(tag_opening, parser->allocator);
-  token_free(tag_name, parser->allocator);
-  token_free(tag_closing, parser->allocator);
-
   return close_tag;
 }
 
@@ -1352,7 +1316,7 @@ static AST_HTML_ELEMENT_NODE_T* parser_parse_html_self_closing_element(
 ) {
   return ast_html_element_node_init(
     (AST_NODE_T*) open_tag,
-    open_tag->tag_name,
+    token_copy(open_tag->tag_name, parser->allocator),
     NULL,
     NULL,
     true,
@@ -1425,7 +1389,7 @@ static AST_HTML_ELEMENT_NODE_T* parser_parse_html_regular_element(
 
   return ast_html_element_node_init(
     (AST_NODE_T*) open_tag,
-    open_tag->tag_name,
+    token_copy(open_tag->tag_name, parser->allocator),
     body,
     (AST_NODE_T*) close_tag,
     false,
@@ -1525,10 +1489,6 @@ static AST_ERB_CONTENT_NODE_T* parser_parse_erb_tag(parser_T* parser) {
     errors,
     parser->allocator
   );
-
-  token_free(opening_tag, parser->allocator);
-  token_free(content, parser->allocator);
-  if (closing_tag != NULL) { token_free(closing_tag, parser->allocator); }
 
   return erb_node;
 }
@@ -1864,12 +1824,17 @@ static hb_array_T* parser_build_elements_from_tags(
             );
           }
 
-          AST_HTML_OMITTED_CLOSE_TAG_NODE_T* omitted_close_tag =
-            ast_html_omitted_close_tag_node_init(open_tag->tag_name, end_position, end_position, NULL, allocator);
+          AST_HTML_OMITTED_CLOSE_TAG_NODE_T* omitted_close_tag = ast_html_omitted_close_tag_node_init(
+            token_copy(open_tag->tag_name, allocator),
+            end_position,
+            end_position,
+            NULL,
+            allocator
+          );
 
           AST_HTML_ELEMENT_NODE_T* element = ast_html_element_node_init(
             (AST_NODE_T*) open_tag,
-            open_tag->tag_name,
+            token_copy(open_tag->tag_name, allocator),
             processed_body,
             (AST_NODE_T*) omitted_close_tag,
             false,
@@ -1913,7 +1878,7 @@ static hb_array_T* parser_build_elements_from_tags(
 
         AST_HTML_ELEMENT_NODE_T* element = ast_html_element_node_init(
           (AST_NODE_T*) open_tag,
-          open_tag->tag_name,
+          token_copy(open_tag->tag_name, allocator),
           processed_body,
           (AST_NODE_T*) close_tag,
           false,
@@ -1987,6 +1952,8 @@ static void parser_handle_whitespace(parser_T* parser, token_T* whitespace_token
       parser->allocator
     );
     hb_array_append(children, whitespace_node);
+
+    return;
   }
 
   token_free(whitespace_token, parser->allocator);

--- a/src/parser/parser_helpers.c
+++ b/src/parser/parser_helpers.c
@@ -220,7 +220,7 @@ AST_HTML_ELEMENT_NODE_T* parser_handle_missing_close_tag(
 
   return ast_html_element_node_init(
     (AST_NODE_T*) open_tag,
-    open_tag->tag_name,
+    token_copy(open_tag->tag_name, parser->allocator),
     body,
     NULL,
     false,

--- a/templates/src/ast/ast_nodes.c.erb
+++ b/templates/src/ast/ast_nodes.c.erb
@@ -27,7 +27,7 @@
   <%- node.fields.each do |field| -%>
   <%- case field -%>
   <%- when Herb::Template::TokenField -%>
-  <%= node.human %>-><%= field.name %> = token_copy(<%= field.name %>, allocator);
+  <%= node.human %>-><%= field.name %> = <%= field.name %>;
   <%- when Herb::Template::NodeField -%>
   <%= node.human %>-><%= field.name %> = <%= field.name %>;
   <%- when Herb::Template::ArrayField -%>


### PR DESCRIPTION
This pull request has the generated `ast_*_init` functions take ownership of the tokens they are handed instead of copying each one, so that a token which reaches the AST is only allocated once.

Every constructor used to copy:

```c
erb_ensure_node->tag_opening = token_copy(tag_opening, allocator);
```

and every caller then freed the token it had just handed over. Back when a token owned its value that copy was doing real work. Now that `value` is an `hb_string_T` view into the source, `token_copy` is a 48 byte allocation and a memberwise struct copy, and the caller's `token_free` undoes the only thing it accomplished.

All of the constructors come from one line in `templates/src/ast/ast_nodes.c.erb`, so this is necessarily a single change across every node type:

```diff
-  <%= node.human %>-><%= field.name %> = token_copy(<%= field.name %>, allocator);
+  <%= node.human %>-><%= field.name %> = <%= field.name %>;
```

#### Where the copy went

It did not disappear, it moved out to the call sites that pass a token they do not own. Of the 244 token arguments reaching a constructor, 131 are handed over and the rest now say `token_copy` explicitly. Four kinds of call site need one, and only the first is obvious:

1. A token borrowed from a node that stays alive, `token_copy(erb_node->tag_opening, allocator)`. This is most of them, in the analyze passes that build a replacement node out of the node they are replacing.
2. The same owned token passed to two constructors, where only one of them can own it.
3. A local that looks owned at the call site but is assigned from a helper returning a borrowed token, such as `get_first_branch_tag_name_token` returning `result.tag->tag_name`.
4. A token arriving as a function parameter, which no scan of local declarations will find.

`parser_handle_whitespace` was a case of its own. It built a node only when `track_whitespace` is on but freed the token either way, so the free moved onto the path that does not construct.

#### Results

Measured over `marcoroth/herb-corpus`, 37,010 files, parsed with the default options and again with the transforms enabled:

| | before | after |
|---|---|---|
| allocations | 124,527,866 | 115,630,693 |
| unfreed blocks | 1,236,976 | 935,189 |
| bytes allocated | 11.45 GB | 11.03 GB |

7.1% fewer allocations, and 24.4% fewer unfreed blocks, because a node now owns each synthetic token the analyze passes build instead of leaving it behind. On `examples/` with the default options the token copies executed per parse drop from 1,019 to 282, which is 9.2% of everything a parse allocates.

The allocation count understates it under the arena. `arena_dealloc` is a no-op, so the duplicate token was never reclaimed and sat there for the whole parse. This halves token memory held, not just the calls.

Resolves #1339
