### PR TITLE
Parser: Give a synthetic token's value an owner

### DIFF
--- a/src/analyze/action_view/tag_helper_node_builders.c
+++ b/src/analyze/action_view/tag_helper_node_builders.c
@@ -29,8 +29,10 @@ token_T* create_synthetic_token(
     size_t length = strlen(value);
     char* copied = hb_allocator_strndup(allocator, value, length);
     token->value = hb_string_from_data(copied, length);
+    token->owns_value = true;
   } else {
     token->value = HB_STRING_EMPTY;
+    token->owns_value = false;
   }
 
   token->type = type;

--- a/src/include/lexer/token_struct.h
+++ b/src/include/lexer/token_struct.h
@@ -61,6 +61,7 @@ typedef struct TOKEN_STRUCT {
   range_T range;
   location_T location;
   token_type_T type;
+  bool owns_value;
 } token_T;
 
 #endif

--- a/src/lexer/token.c
+++ b/src/lexer/token.c
@@ -25,6 +25,7 @@ token_T* token_init(hb_string_T value, const token_type_T type, lexer_T* lexer) 
   }
 
   token->value = value;
+  token->owns_value = false;
 
   token->type = type;
   token->range = (range_T) { .from = lexer->previous_position, .to = lexer->current_position };
@@ -217,7 +218,8 @@ token_T* token_copy(token_T* token, hb_allocator_T* allocator) {
 
   if (!new_token) { return NULL; }
 
-  new_token->value = token->value;
+  new_token->value = token->owns_value ? hb_string_copy(token->value, allocator) : token->value;
+  new_token->owns_value = token->owns_value;
 
   new_token->type = token->type;
   new_token->range = token->range;
@@ -238,6 +240,8 @@ bool token_is_escaped_erb_tag_opening(const token_T* token) {
 
 void token_free(token_T* token, hb_allocator_T* allocator) {
   if (!token) { return; }
+
+  if (token->owns_value) { hb_allocator_dealloc(allocator, (void*) token->value.data); }
 
   hb_allocator_dealloc(allocator, token);
 }

--- a/src/parser.c
+++ b/src/parser.c
@@ -822,6 +822,7 @@ static AST_HTML_ATTRIBUTE_NODE_T* parser_parse_html_attribute(parser_T* parser) 
 
       char* arena_copy = hb_allocator_strndup(parser->allocator, equals_buffer.value, equals_buffer.length);
       equals_with_whitespace->value = hb_string_from_data(arena_copy, equals_buffer.length);
+      equals_with_whitespace->owns_value = true;
 
       hb_buffer_free(&equals_buffer);
 


### PR DESCRIPTION
This pull request records on a token whether it owns the buffer behind its value, so that the ones which do can be freed.

A token's `value` has meant two different things. For a token off the lexer it is an `hb_string_T` view into the source, owned by nobody and outliving every token pointing at it, which is why `token_free` has never touched it. For a synthetic token it is a buffer `create_synthetic_token` allocated:

```c
size_t length = strlen(value);
char* copied = hb_allocator_strndup(allocator, value, length);
token->value = hb_string_from_data(copied, length);
```

Nothing could free that buffer. Not the creation site, because the node's token still points at it, and not the node, because `token_free` has to assume the borrowed case. So a token carried the distinction implicitly and no caller could act on it.

Before #2311 the constructors copied every token, so a synthetic token's value was shared between the original and the copy the node held, and marking either one as the owner would have been a guess. Now that a node owns the token it was handed, there is exactly one owner and the flag says something unambiguous.

`token_T` now says which it is, and the two functions that care honor it. `token_copy` deep copies an owned value so the copy owns its own, and `token_free` releases it:

```c
new_token->value = token->owns_value ? hb_string_copy(token->value, allocator) : token->value;
```

#### Results

Measured over `marcoroth/herb-corpus`, 37,010 files, parsed with the default options and again with the transforms enabled:

| | before | after |
|---|---|---|
| unfreed blocks | 935,039 | 582,504 |
| allocations | 115,626,494 | 115,679,459 |

37.7% fewer unfreed blocks, for 0.05% more allocations. That increase is real and is the point of the trade: copying a token that owns its value now duplicates the buffer, which is what makes the copy safe to free.
