### PR TITLE
Core: Rename `Range` fields from `start`/`end` to `from`/`to`

### DIFF
--- a/javascript/packages/core/src/range.ts
+++ b/javascript/packages/core/src/range.ts
@@ -1,16 +1,16 @@
 export type SerializedRange = [number, number]
 
 export class Range {
-  readonly start: number
-  readonly end: number
+  readonly from: number
+  readonly to: number
 
   static from(range: SerializedRange): Range
-  static from(start: number, end: number): Range
-  static from(rangeOrStart: SerializedRange | number, end?: number): Range {
-    if (typeof rangeOrStart === "number") {
-      return new Range(rangeOrStart, end!)
+  static from(from: number, to: number): Range
+  static from(rangeOrFrom: SerializedRange | number, to?: number): Range {
+    if (typeof rangeOrFrom === "number") {
+      return new Range(rangeOrFrom, to!)
     } else {
-      return new Range(rangeOrStart[0], rangeOrStart[1])
+      return new Range(rangeOrFrom[0], rangeOrFrom[1])
     }
   }
 
@@ -22,13 +22,13 @@ export class Range {
     return new Range(0, 0)
   }
 
-  constructor(start: number, end: number) {
-    this.start = start
-    this.end = end
+  constructor(from: number, to: number) {
+    this.from = from
+    this.to = to
   }
 
   toArray(): SerializedRange {
-    return [this.start, this.end]
+    return [this.from, this.to]
   }
 
   toJSON(): SerializedRange {
@@ -36,7 +36,7 @@ export class Range {
   }
 
   treeInspect(): string {
-    return `[${this.start}, ${this.end}]`
+    return `[${this.from}, ${this.to}]`
   }
 
   inspect(): string {

--- a/javascript/packages/highlighter/src/syntax-renderer.ts
+++ b/javascript/packages/highlighter/src/syntax-renderer.ts
@@ -104,11 +104,11 @@ export class SyntaxRenderer {
       const nextToken = tokens[i + 1]
       const prevToken = tokens[i - 1]
 
-      if (token.range.start > lastEnd) {
-        highlighted += content.slice(lastEnd, token.range.start)
+      if (token.range.from > lastEnd) {
+        highlighted += content.slice(lastEnd, token.range.from)
       }
 
-      const tokenText = content.slice(token.range.start, token.range.end)
+      const tokenText = content.slice(token.range.from, token.range.to)
 
       this.updateState(state, token, tokenText, nextToken, prevToken)
 
@@ -123,7 +123,7 @@ export class SyntaxRenderer {
         highlighted += tokenText
       }
 
-      lastEnd = token.range.end
+      lastEnd = token.range.to
     }
 
     if (lastEnd < content.length) {

--- a/javascript/packages/printer/test/helpers/printer-test-helpers.ts
+++ b/javascript/packages/printer/test/helpers/printer-test-helpers.ts
@@ -11,8 +11,8 @@ export function createLocation(line = 1, column = 1): Location {
   return Location.from(line, column, line, column)
 }
 
-export function createRange(start = 1, end = 2): Range {
-  return Range.from(start, end)
+export function createRange(from = 1, to = 2): Range {
+  return Range.from(from, to)
 }
 
 export function createToken(type = "", value = "", range = createRange(), location = createLocation()): Token {


### PR DESCRIPTION
This pull request renames the two fields on the `Range` class in `@herb-tools/core` from `start`/`end` to `from`/`to`, so that the TypeScript implementation matches every other implementation in the repository.