### PR TITLE
Parser: Fix double frees and leaks in the analyze transforms

### DIFF
--- a/src/analyze/action_view/tag_helpers.c
+++ b/src/analyze/action_view/tag_helpers.c
@@ -1058,6 +1058,31 @@ static AST_NODE_T* create_javascript_include_tag_element(
   );
 }
 
+static hb_array_T* build_asset_tag_attributes(
+  pm_call_node_t* call_node,
+  tag_helper_parse_context_T* parse_context,
+  hb_allocator_T* allocator
+) {
+  hb_array_T* attributes = extract_html_attributes_from_call_node(
+    call_node,
+    parse_context->prism_source,
+    parse_context->original_source,
+    parse_context->erb_content_offset,
+    allocator
+  );
+
+  if (!attributes) { attributes = hb_array_init(0, allocator); }
+
+  resolve_nonce_attribute(attributes, allocator);
+
+  remove_attribute_by_name(attributes, "extname");
+  remove_attribute_by_name(attributes, "host");
+  remove_attribute_by_name(attributes, "protocol");
+  remove_attribute_by_name(attributes, "skip-pipeline");
+
+  return attributes;
+}
+
 static hb_array_T* transform_javascript_include_tag_multi_source(
   AST_ERB_CONTENT_NODE_T* erb_node,
   analyze_ruby_context_T* context,
@@ -1069,36 +1094,18 @@ static hb_array_T* transform_javascript_include_tag_multi_source(
 
   if (source_count == 0) { return NULL; }
 
-  hb_array_T* shared_attributes = extract_html_attributes_from_call_node(
-    call_node,
-    parse_context->prism_source,
-    parse_context->original_source,
-    parse_context->erb_content_offset,
-    allocator
-  );
-  if (!shared_attributes) { shared_attributes = hb_array_init(0, allocator); }
-
-  resolve_nonce_attribute(shared_attributes, allocator);
-
   char* path_options =
     extract_path_options_from_keyword_hash(call_node, JAVASCRIPT_INCLUDE_TAG_PATH_OPTIONS, allocator);
-  remove_attribute_by_name(shared_attributes, "extname");
-  remove_attribute_by_name(shared_attributes, "host");
-  remove_attribute_by_name(shared_attributes, "protocol");
-  remove_attribute_by_name(shared_attributes, "skip-pipeline");
-
   hb_array_T* elements = hb_array_init(source_count * 2, allocator);
 
   for (size_t i = 0; i < source_count; i++) {
     pm_node_t* source_arg = call_node->arguments->arguments.nodes[i];
-    AST_NODE_T* element = create_javascript_include_tag_element(
-      erb_node,
-      parse_context,
-      source_arg,
-      shared_attributes,
-      path_options,
-      allocator
-    );
+    hb_array_T* attributes = build_asset_tag_attributes(call_node, parse_context, allocator);
+
+    AST_NODE_T* element =
+      create_javascript_include_tag_element(erb_node, parse_context, source_arg, attributes, path_options, allocator);
+
+    hb_array_free(&attributes);
 
     if (element) {
       if (hb_array_size(elements) > 0) {
@@ -1185,35 +1192,17 @@ static hb_array_T* transform_stylesheet_link_tag_multi_source(
 
   if (source_count == 0) { return NULL; }
 
-  hb_array_T* shared_attributes = extract_html_attributes_from_call_node(
-    call_node,
-    parse_context->prism_source,
-    parse_context->original_source,
-    parse_context->erb_content_offset,
-    allocator
-  );
-  if (!shared_attributes) { shared_attributes = hb_array_init(0, allocator); }
-
-  resolve_nonce_attribute(shared_attributes, allocator);
-
   char* path_options = extract_path_options_from_keyword_hash(call_node, STYLESHEET_LINK_TAG_PATH_OPTIONS, allocator);
-  remove_attribute_by_name(shared_attributes, "extname");
-  remove_attribute_by_name(shared_attributes, "host");
-  remove_attribute_by_name(shared_attributes, "protocol");
-  remove_attribute_by_name(shared_attributes, "skip-pipeline");
-
   hb_array_T* elements = hb_array_init(source_count * 2, allocator);
 
   for (size_t i = 0; i < source_count; i++) {
     pm_node_t* source_arg = call_node->arguments->arguments.nodes[i];
-    AST_NODE_T* element = create_stylesheet_link_tag_element(
-      erb_node,
-      parse_context,
-      source_arg,
-      shared_attributes,
-      path_options,
-      allocator
-    );
+    hb_array_T* attributes = build_asset_tag_attributes(call_node, parse_context, allocator);
+
+    AST_NODE_T* element =
+      create_stylesheet_link_tag_element(erb_node, parse_context, source_arg, attributes, path_options, allocator);
+
+    hb_array_free(&attributes);
 
     if (element) {
       if (hb_array_size(elements) > 0) {

--- a/src/analyze/iteration_nodes.c
+++ b/src/analyze/iteration_nodes.c
@@ -32,7 +32,11 @@ static token_T* create_token_from_prism_location(
   position_T start = byte_offset_to_position(source, total_start);
   position_T end = byte_offset_to_position(source, total_end);
 
-  return create_synthetic_token(allocator, value, type, start, end);
+  token_T* token = create_synthetic_token(allocator, value, type, start, end);
+
+  hb_allocator_dealloc(allocator, value);
+
+  return token;
 }
 
 /**
@@ -262,6 +266,17 @@ static AST_ERB_ITERATION_BLOCK_NODE_T* try_transform_block_node(
   return iteration_block_node;
 }
 
+static void free_transformed_block_node(AST_ERB_BLOCK_NODE_T* block_node, hb_allocator_T* allocator) {
+  block_node->body = NULL;
+  block_node->block_arguments = NULL;
+  block_node->rescue_clause = NULL;
+  block_node->else_clause = NULL;
+  block_node->ensure_clause = NULL;
+  block_node->end_node = NULL;
+
+  ast_node_free((AST_NODE_T*) block_node, allocator);
+}
+
 static void transform_iteration_nodes_in_array(hb_array_T* array, analyze_ruby_context_T* context) {
   if (!array) { return; }
 
@@ -273,7 +288,10 @@ static void transform_iteration_nodes_in_array(hb_array_T* array, analyze_ruby_c
     AST_ERB_ITERATION_BLOCK_NODE_T* iteration_block_node =
       try_transform_block_node((AST_ERB_BLOCK_NODE_T*) child, context);
 
-    if (iteration_block_node) { hb_array_set(array, index, iteration_block_node); }
+    if (iteration_block_node) {
+      hb_array_set(array, index, iteration_block_node);
+      free_transformed_block_node((AST_ERB_BLOCK_NODE_T*) child, context->allocator);
+    }
   }
 }
 

--- a/templates/src/ast/ast_nodes.c.erb
+++ b/templates/src/ast/ast_nodes.c.erb
@@ -118,7 +118,7 @@ static void ast_free_<%= node.human %>(<%= node.struct_type %>* <%= node.human %
     hb_array_free(&<%= node.human %>-><%= field.name %>);
   }
   <%- when Herb::Template::StringField -%>
-  if (<%= node.human %>-><%= field.name %>.data != NULL) { hb_allocator_dealloc(allocator, <%= node.human %>-><%= field.name %>.data); }
+  if (!hb_string_is_empty(<%= node.human %>-><%= field.name %>)) { hb_allocator_dealloc(allocator, <%= node.human %>-><%= field.name %>.data); }
   <%- when Herb::Template::PrismNodeField -%>
   /* prism_node is a borrowed reference into the prism context, not freed here */
   <%- when Herb::Template::AnalyzedRubyField -%>


### PR DESCRIPTION
This pull request fixes four ownership bugs in the analyze passes, two where something is freed that the code does not own and two where something with no owner is never freed.

Every one of them is invisible in production. Each parse entry point in the repository allocates from an arena, `arena_dealloc` is an empty function, and the whole arena is released in one go, so freeing a pointer twice costs nothing and never freeing it costs nothing either. Run the same parses through a malloc backed allocator and 476 of the 37,010 files in `marcoroth/herb-corpus` abort or double free. After this they all parse and free cleanly.

#### Freeing a string literal

`hb_string_copy` hands back a constant when it is given an empty string:

```c
#define HB_STRING_EMPTY ((hb_string_T) { .data = (char*) "", .length = 0 })
```

`.data` points into read only memory, but the generated free path only checked it against NULL, so any node whose string field came back empty tried to free the literal. The guard now tests `hb_string_is_empty`, which is exactly the condition `hb_string_copy` allocates under, so the two agree on what there is to release.

This one accounted for **442 of the 476 files**, in three shapes that had looked like three separate bugs:

```erb
<%= content_tag :div, "" %>
<%= image_tag "x.gif", alt:"" %>
<%= link_to('#', **tag_options) { content } %>
```

What gave it away was that all three freed the same address, and that address was nowhere near the heap the rest of the run was using.

#### One attribute node, several owners

`stylesheet_link_tag` and `javascript_include_tag` extract the attributes off the call node once and hand the same array to every element they build. Each element copies the pointers into its own attribute array, so with more than one source the same attribute node is owned by every element and freed once per element.

It needs a second source and something to put in the attributes, which is why the first of these is fine and the second is not:

```erb
<%= stylesheet_link_tag 'a', 'b' %>
<%= stylesheet_link_tag 'a', 'b', media: 'all' %>
```

The attributes are now built inside the loop, and the array that carried them is released since the element does not keep it.

#### The block node an iteration node replaces

`transform_iteration_nodes_in_array` builds an `AST_ERB_ITERATION_BLOCK_NODE_T` out of a block node and writes it over that node's slot, which leaves the block node with no owner. It cannot simply be freed, because the iteration node adopts its body, its block arguments and its four clause pointers and goes on using them. Releasing those first lets the block node be freed as the husk it has become, and its own tokens go with it.

`create_token_from_prism_location` had a smaller version of the same thing. It duplicates the source text to pass to `create_synthetic_token`, which duplicates it again, and the first copy had no owner.

#### Results

| | before | after |
|---|---|---|
| corpus files failing | 476 | 0 |
| corpus unfreed blocks | 605,428 | 512,268 |
| `examples/` unfreed blocks | 38 | 22 |