### PR TITLE
Engine: Skip location tracking when nothing asks for it

### DIFF
--- a/lib/herb/engine.rb
+++ b/lib/herb/engine.rb
@@ -81,7 +81,7 @@ module Herb
 
       @src << "# frozen_string_literal: true\n" if @freeze
 
-      parse_result = ::Herb.parse(input, **@parser_options, track_whitespace: true)
+      parse_result = ::Herb.parse(input, **parse_options, track_whitespace: true)
       parser_errors = parse_result.errors
 
       if parser_errors.any?
@@ -430,6 +430,14 @@ module Herb
 
     def context_options(properties)
       properties.except(:visitors, :src, :context)
+    end
+
+    #: () -> Hash[Symbol, untyped]
+    def parse_options
+      return @parser_options unless @visitors.empty?
+      return @parser_options if @parser_options.key?(:track_locations)
+
+      @parser_options.merge(track_locations: false)
     end
 
     #: () -> Hash[Symbol, untyped]

--- a/lib/herb/engine.rb
+++ b/lib/herb/engine.rb
@@ -434,7 +434,6 @@ module Herb
 
     #: () -> Hash[Symbol, untyped]
     def parse_options
-      return @parser_options unless @visitors.empty?
       return @parser_options if @parser_options.key?(:track_locations)
 
       @parser_options.merge(track_locations: false)

--- a/lib/herb/engine/auto_close_omitted_tags_visitor.rb
+++ b/lib/herb/engine/auto_close_omitted_tags_visitor.rb
@@ -15,6 +15,8 @@ module Herb
     #     Herb::Engine.new(source, visitors: [Herb::Engine::AutoCloseOmittedTagsVisitor.new])
     #
     class AutoCloseOmittedTagsVisitor < Herb::Visitor
+      required_parser_option track_locations: true
+
       #: (Herb::AST::HTMLElementNode) -> void
       def visit_html_element_node(node)
         omitted = omitted_close_tag(node)

--- a/lib/herb/engine/compiler.rb
+++ b/lib/herb/engine/compiler.rb
@@ -11,6 +11,8 @@ module Herb
       WHITESPACE_ONLY = /\A[ \t]+\z/
       WHITESPACE_ONLY_CAPTURE = /\A([ \t]+)\z/
 
+      RAW_TEXT_ELEMENTS = ["script", "style"].freeze
+
       attr_reader :tokens
 
       def initialize(engine, options = {})
@@ -66,11 +68,9 @@ module Herb
       end
 
       def visit_html_element_node(node)
-        with_element_context(node) do
+        with_element_context(node) do |tag_name|
           visit(node.open_tag)
           visit_all(node.body)
-
-          tag_name = node.tag_name&.value&.downcase
 
           if node.open_tag.is_a?(Herb::AST::ERBOpenTagNode) && tag_name && node.close_tag
             if node.close_tag.is_a?(Herb::AST::ERBEndNode)
@@ -397,7 +397,7 @@ module Herb
         @context_stack.pop
       end
 
-      #: (untyped node) { () -> untyped } -> untyped
+      #: (untyped node) { (String?) -> untyped } -> untyped
       def with_element_context(node)
         tag_name = node.tag_name&.value&.downcase
         previous_element_source = @current_element_source
@@ -411,9 +411,9 @@ module Herb
           push_context(:style_content)
         end
 
-        yield
+        yield(tag_name)
 
-        pop_context if ["script", "style"].include?(tag_name)
+        pop_context if RAW_TEXT_ELEMENTS.include?(tag_name)
 
         @element_stack.pop if tag_name
         @current_element_source = previous_element_source

--- a/lib/herb/engine/component_visitor.rb
+++ b/lib/herb/engine/component_visitor.rb
@@ -13,6 +13,8 @@ module Herb
       ARRAY_PROPERTIES = [:children, :body, :statements].freeze
       NODE_PROPERTIES = [:subsequent, :else_clause, :end_node, :rescue_clause, :ensure_clause].freeze
 
+      required_parser_option track_locations: true
+
       # @rbs!
       #   def self.experimental_warning_issued: () -> bool
       #   def self.experimental_warning_issued=: (bool) -> bool

--- a/lib/herb/engine/debug_visitor.rb
+++ b/lib/herb/engine/debug_visitor.rb
@@ -9,6 +9,8 @@ module Herb
     class DebugVisitor < Herb::Visitor
       include ContextAware
 
+      required_parser_option track_locations: true
+
       #: () -> bool
       def self.reads_erb_source?
         true

--- a/lib/herb/engine/diagnostics.rb
+++ b/lib/herb/engine/diagnostics.rb
@@ -26,6 +26,13 @@ module Herb
     module Diagnostics
       include Kernel
 
+      #: (untyped) -> void
+      def self.included(base)
+        super
+
+        base.required_parser_option(track_locations: true) if base.respond_to?(:required_parser_option)
+      end
+
       #: () -> Array[Herb::Diagnostic]
       def diagnostics
         @diagnostics ||= [] #: Array[Herb::Diagnostic]

--- a/lib/herb/engine/html_safe_assertions_visitor.rb
+++ b/lib/herb/engine/html_safe_assertions_visitor.rb
@@ -40,6 +40,8 @@ module Herb
     class HTMLSafeAssertionsVisitor < Herb::Visitor
       include ContextAware
 
+      required_parser_option track_locations: true
+
       RUNTIME = "::Herb::Engine::HTMLSafeAssertions"
 
       MAX_SOURCE_LENGTH = 120

--- a/lib/herb/engine/inline_render_visitor.rb
+++ b/lib/herb/engine/inline_render_visitor.rb
@@ -42,6 +42,7 @@ module Herb
         :LocalVariableAndWriteNode
       ].freeze #: Array[Symbol]
 
+      required_parser_option track_locations: true
       recommended_parser_option render_nodes: true
 
       #: () -> bool

--- a/lib/herb/engine/instrumentation_visitor.rb
+++ b/lib/herb/engine/instrumentation_visitor.rb
@@ -41,6 +41,7 @@ module Herb
       include ContextAware
 
       recommended_parser_option render_nodes: true
+      required_parser_option track_locations: true
 
       #: () -> bool
       def self.rewrites_erb_source?

--- a/lib/herb/engine/optimize_visitor.rb
+++ b/lib/herb/engine/optimize_visitor.rb
@@ -39,7 +39,7 @@ module Herb
     class OptimizeVisitor < Herb::Visitor
       include ContextAware
 
-      required_parser_option action_view_helpers: true, transform_conditionals: true
+      required_parser_option action_view_helpers: true, transform_conditionals: true, track_locations: true
 
       SESSION = "::Herb::Engine::Report::Session" #: String
       CODE = "overwritten-helper" #: String

--- a/lib/herb/engine/optimize_visitor.rb
+++ b/lib/herb/engine/optimize_visitor.rb
@@ -39,7 +39,7 @@ module Herb
     class OptimizeVisitor < Herb::Visitor
       include ContextAware
 
-      required_parser_option action_view_helpers: true, transform_conditionals: true, track_locations: true
+      required_parser_option action_view_helpers: true, transform_conditionals: true
 
       SESSION = "::Herb::Engine::Report::Session" #: String
       CODE = "overwritten-helper" #: String
@@ -72,6 +72,13 @@ module Herb
         self.class.experimental_warning_issued = true
 
         warn "[Herb] Compile-time optimizations are experimental. Output may differ from standard ActionView rendering."
+      end
+
+      #: () -> Hash[Symbol, untyped]
+      def required_parser_options
+        return super unless @verify
+
+        super.merge(track_locations: true)
       end
 
       #: (Herb::AST::DocumentNode) -> void

--- a/lib/herb/engine/slot_visitor.rb
+++ b/lib/herb/engine/slot_visitor.rb
@@ -30,7 +30,7 @@ module Herb
       include ContextAware
 
       recommended_parser_option iteration_nodes: true, render_nodes: true
-      required_parser_option action_view_helpers: true
+      required_parser_option action_view_helpers: true, track_locations: true
 
       attr_reader :slots #: Array[Slot]
       attr_reader :document #: untyped

--- a/sig/herb/engine.rbs
+++ b/sig/herb/engine.rbs
@@ -106,7 +106,9 @@ module Herb
     def context_options: (untyped properties) -> untyped
 
     # : () -> Hash[Symbol, untyped]
-    def default_parser_options: () -> Hash[Symbol, untyped]
+    def parse_options: () -> Hash[Symbol, untyped]
+
+  def default_parser_options: () -> Hash[Symbol, untyped]
 
     def ensure_valid_ruby!: (untyped source) -> untyped
   end

--- a/sig/herb/engine.rbs
+++ b/sig/herb/engine.rbs
@@ -108,7 +108,8 @@ module Herb
     # : () -> Hash[Symbol, untyped]
     def parse_options: () -> Hash[Symbol, untyped]
 
-  def default_parser_options: () -> Hash[Symbol, untyped]
+    # : () -> Hash[Symbol, untyped]
+    def default_parser_options: () -> Hash[Symbol, untyped]
 
     def ensure_valid_ruby!: (untyped source) -> untyped
   end

--- a/sig/herb/engine/compiler.rbs
+++ b/sig/herb/engine/compiler.rbs
@@ -15,7 +15,7 @@ module Herb
 
       WHITESPACE_ONLY_CAPTURE: ::Regexp
 
-      RAW_TEXT_ELEMENTS: Array[String]
+      RAW_TEXT_ELEMENTS: untyped
 
       attr_reader tokens: untyped
 
@@ -121,7 +121,7 @@ module Herb
 
       def pop_context: () -> untyped
 
-      # : (untyped node) { () -> untyped } -> untyped
+      # : (untyped node) { (String?) -> untyped } -> untyped
       def with_element_context: (untyped node) { (String?) -> untyped } -> untyped
 
       def process_erb_tag: (untyped node, ?skip_comment_check: untyped) -> untyped

--- a/sig/herb/engine/compiler.rbs
+++ b/sig/herb/engine/compiler.rbs
@@ -15,6 +15,8 @@ module Herb
 
       WHITESPACE_ONLY_CAPTURE: ::Regexp
 
+      RAW_TEXT_ELEMENTS: Array[String]
+
       attr_reader tokens: untyped
 
       def initialize: (untyped engine, ?untyped options) -> untyped
@@ -120,7 +122,7 @@ module Herb
       def pop_context: () -> untyped
 
       # : (untyped node) { () -> untyped } -> untyped
-      def with_element_context: (untyped node) { () -> untyped } -> untyped
+      def with_element_context: (untyped node) { (String?) -> untyped } -> untyped
 
       def process_erb_tag: (untyped node, ?skip_comment_check: untyped) -> untyped
 

--- a/sig/herb/engine/diagnostics.rbs
+++ b/sig/herb/engine/diagnostics.rbs
@@ -22,6 +22,9 @@ module Herb
     module Diagnostics
       include Kernel
 
+      # : (untyped) -> void
+      def self.included: (untyped) -> void
+
       # : () -> Array[Herb::Diagnostic]
       def diagnostics: () -> Array[Herb::Diagnostic]
 

--- a/sig/herb/engine/optimize_visitor.rbs
+++ b/sig/herb/engine/optimize_visitor.rbs
@@ -52,6 +52,9 @@ module Herb
       # : (?verify: bool) -> void
       def initialize: (?verify: bool) -> void
 
+      # : () -> Hash[Symbol, untyped]
+      def required_parser_options: () -> Hash[Symbol, untyped]
+
       # : (Herb::AST::DocumentNode) -> void
       def visit_document_node: (Herb::AST::DocumentNode) -> void
 

--- a/test/engine/parse_options_test.rb
+++ b/test/engine/parse_options_test.rb
@@ -81,8 +81,11 @@ module Engine
         Herb::Engine.new("<div><span></div>")
       end
 
-      assert_match(/\d+ \|/, error.message)
-      assert error.diagnostics.any?
+      location = error.diagnostics.first&.location
+
+      refute_nil location
+      assert_equal 1, location.start.line
+      assert_equal 5, location.start.column
     end
   end
 end

--- a/test/engine/parse_options_test.rb
+++ b/test/engine/parse_options_test.rb
@@ -6,6 +6,8 @@ require_relative "../../lib/herb/engine"
 module Engine
   class ParseOptionsTest < Minitest::Spec
     class LocationSpy < Herb::Visitor
+      required_parser_option track_locations: true
+
       attr_reader :elements, :missing_locations
 
       def initialize
@@ -31,10 +33,26 @@ module Engine
       assert_equal false, parse_options_for("<div></div>")[:track_locations]
     end
 
-    test "location tracking is left alone when a visitor is present" do
+    test "a visitor that needs locations turns tracking back on" do
       options = parse_options_for("<div></div>", visitors: [LocationSpy.new])
 
-      assert_nil options[:track_locations]
+      assert_equal true, options[:track_locations]
+    end
+
+    test "a visitor that never reads a location leaves tracking off" do
+      options = parse_options_for("<div></div>", visitors: [Class.new(Herb::Visitor).new])
+
+      assert_equal false, options[:track_locations]
+    end
+
+    test "reporting diagnostics is enough to need locations" do
+      reporter = Class.new(Herb::Visitor) do
+        include Herb::Engine::Diagnostics
+      end
+
+      options = parse_options_for("<div></div>", visitors: [reporter.new])
+
+      assert_equal true, options[:track_locations]
     end
 
     test "an explicitly requested track_locations is honoured" do
@@ -43,14 +61,14 @@ module Engine
       assert_equal true, options[:track_locations]
     end
 
-    test "an explicitly disabled track_locations is honoured with a visitor present" do
-      options = parse_options_for(
-        "<div></div>",
-        visitors: [LocationSpy.new],
-        parser_options: { track_locations: false }
-      )
-
-      assert_equal false, options[:track_locations]
+    test "a visitor requiring locations conflicts with disabling them" do
+      assert_raises(ArgumentError) do
+        parse_options_for(
+          "<div></div>",
+          visitors: [LocationSpy.new],
+          parser_options: { track_locations: false }
+        )
+      end
     end
 
     test "a visitor still receives node locations" do

--- a/test/engine/parse_options_test.rb
+++ b/test/engine/parse_options_test.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+require_relative "../../lib/herb/engine"
+
+module Engine
+  class ParseOptionsTest < Minitest::Spec
+    class LocationSpy < Herb::Visitor
+      attr_reader :elements, :missing_locations
+
+      def initialize
+        super
+
+        @elements = 0
+        @missing_locations = 0
+      end
+
+      def visit_html_element_node(node)
+        @elements += 1
+        @missing_locations += 1 if node.location.nil?
+
+        super
+      end
+    end
+
+    def parse_options_for(source, **properties)
+      Herb::Engine.new(source, **properties).send(:parse_options)
+    end
+
+    test "location tracking is skipped when no visitor can observe it" do
+      assert_equal false, parse_options_for("<div></div>")[:track_locations]
+    end
+
+    test "location tracking is left alone when a visitor is present" do
+      options = parse_options_for("<div></div>", visitors: [LocationSpy.new])
+
+      assert_nil options[:track_locations]
+    end
+
+    test "an explicitly requested track_locations is honoured" do
+      options = parse_options_for("<div></div>", parser_options: { track_locations: true })
+
+      assert_equal true, options[:track_locations]
+    end
+
+    test "an explicitly disabled track_locations is honoured with a visitor present" do
+      options = parse_options_for(
+        "<div></div>",
+        visitors: [LocationSpy.new],
+        parser_options: { track_locations: false }
+      )
+
+      assert_equal false, options[:track_locations]
+    end
+
+    test "a visitor still receives node locations" do
+      spy = LocationSpy.new
+
+      Herb::Engine.new("<div><p>Content</p></div>", visitors: [spy])
+
+      assert_equal 2, spy.elements
+      assert_equal 0, spy.missing_locations
+    end
+
+    test "compiled output does not depend on location tracking" do
+      source = <<~ERB
+        <div class="foo">
+          <% if condition %>
+            <%= value %>
+          <% end %>
+        </div>
+      ERB
+
+      tracked = Herb::Engine.new(source, parser_options: { track_locations: true }).src
+
+      assert_equal tracked, Herb::Engine.new(source).src
+    end
+
+    test "a parse error still reports its location" do
+      error = assert_raises(Herb::Engine::ParseError) do
+        Herb::Engine.new("<div><span></div>")
+      end
+
+      assert_match(/\d+ \|/, error.message)
+      assert error.diagnostics.any?
+    end
+  end
+end


### PR DESCRIPTION
This pull request stops the engine from building a `Location`, two `Position`s and a `Range` for every node and token when nothing is going to read them.

`Herb.parse` attaches source locations to the whole tree. Profiling `Herb::Engine.new` with `ObjectSpace` allocation tracing showed those objects are the single largest allocation source in a compile, well ahead of anything in the compiler itself:

| class | objects | share of a compile |
| --- | ---: | ---: |
| `Herb::Position` | 27,124 | 23.2% |
| `Herb::Location` | 13,562 | 11.6% |
| `Herb::Range` | 7,308 | 6.3% |
| **total** | **47,994** | **41.1%** |

Locations are now off unless something asks for them. `Compiler` never reads `node.location`, so a template compiled without a visitor never needs one.

#### Letting a visitor say what it needs

Every built-in visitor that reads `node.location` declares `required_parser_option track_locations: true`, and `Herb::Visitor.parser_options_for` already folds those declarations into the options the engine parses with, so the engine needs no list of its own.

`Herb::Engine::Diagnostics` declares it on include. Any visitor that reports a diagnostic keeps its locations without knowing this option exists, including visitors from outside this repository, since reporting is the usual reason to want a location at all. The engine's own `DiagnosticsTest` caught this before the declaration was added.

A visitor that reads locations, reports nothing, and declares nothing gets `nil`. That is the one behaviour this trades away.

#### Building on #2199

#2199 added `track_locations` for callers that never read source locations, naming "rendering a template with validation disabled" as the case it had in mind. This turns that case on automatically, since the engine can tell when it applies without the caller having to know.

That pull request also did the work that makes this safe. `Herb::AST::Helpers#inline_ruby_comment?` used to compare `node.location.start.line` against `node.location.end.line`, and it runs on the compiler's happy path through `Compiler#visit_erb_content_node`, so it raised as soon as a location was nil. #2199 replaced that with an equivalent newline check on the node content. Without it, every template containing an inline `<% # comment %>` would fail to compile here.

#### Errors keep their locations

A parse error carries its own location and `track_locations` does not touch it, so the error path needs no second parse. Error messages are byte-identical with tracking off, carets and all.


#### Results

Measured over [`marcoroth/herb-corpus`](https://github.com/marcoroth/herb-corpus) at `12cced87`, the 35,881 templates of 36,989 that compile cleanly, Ruby 4.0.2. Samples interleaved with `main`:

| metric | `main` | this branch | delta |
| --- | ---: | ---: | ---: |
| allocated objects | 77,459,989 | 45,354,443 | **-32,105,546 (-41.4%)** |
| objects per template | 2,158 | 1,264 | **-41.4%** |
| wall time | 9.75s | 8.10s | **-16.9%** |

Compiled output is byte-identical across the corpus: one SHA256 over all 35,881 compiled sources matches `main` exactly (`3b3f9279…`).