### PR TITLE
CI: Check for leaks in the allocation gate

### DIFF
--- a/bin/valgrind_check_allocations
+++ b/bin/valgrind_check_allocations
@@ -2,5 +2,5 @@
 
 valgrind \
   --error-exitcode=1 \
-  --leak-check=no \
+  --leak-check=full \
   ./bench_allocs examples/*.html.erb


### PR DESCRIPTION
This pull request turns leak checking on in `bin/valgrind_check_allocations`, which has been running with `--leak-check=no` since it was added.

It was off because the parse cycle leaked. A parse of `examples/` now takes 16,364 allocations and returns all 16,364, under the default options and again with the transforms enabled, so the gate can hold that line instead of only watching for invalid frees.