### PR TITLE
CI: Check allocations over the corpus

### DIFF
--- a/.github/workflows/corpus.yml
+++ b/.github/workflows/corpus.yml
@@ -195,6 +195,68 @@ jobs:
           path: corpus/runs/*.json
           retention-days: 30
 
+  allocations:
+    name: Allocations
+    runs-on: ubicloud-standard-2
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Clone corpus
+        id: corpus
+        background: true
+        run: |-
+          git clone --depth 1 https://github.com/marcoroth/herb-corpus corpus
+
+      - name: Add LLVM apt Repo
+        run: |-
+          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+          sudo add-apt-repository "deb http://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-21 main"
+          sudo apt update
+
+      - name: Install APT dependencies
+        run: xargs sudo apt-get install -y --no-install-recommends < Aptfile
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Render Templates
+        run: bundle exec rake templates
+
+      - name: Build the allocation benchmark
+        run: make bench_allocs
+
+      - name: Wait for the corpus clone
+        wait: [corpus]
+
+      - name: Check allocations over the corpus
+        id: check
+        run: ./bin/check_corpus_allocations corpus/erb
+
+      - name: Job summary
+        if: always()
+        run: |-
+          {
+            echo "### Allocations"
+            echo
+            echo '```'
+            tail -n 3 corpus-allocations.txt 2>/dev/null || echo "the check did not run"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload the report
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: corpus-allocations
+          path: corpus-allocations.txt
+          if-no-files-found: ignore
+          retention-days: 30
+
   printer:
     name: Printer Roundtrip
     runs-on: ubicloud-standard-2

--- a/.github/workflows/corpus.yml
+++ b/.github/workflows/corpus.yml
@@ -227,6 +227,9 @@ jobs:
       - name: Render Templates
         run: bundle exec rake templates
 
+      - name: Compile Herb
+        run: bundle exec rake make
+
       - name: Build the allocation benchmark
         run: make bench_allocs
 

--- a/bin/check_corpus_allocations
+++ b/bin/check_corpus_allocations
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+corpus="${1:-corpus/erb}"
+report="${2:-corpus-allocations.txt}"
+
+find "$corpus" -name '*.erb' -type f -print0 | xargs -0 ./bench_allocs > "$report"
+status=$?
+
+grep "FAILED" "$report" | head -n 50
+
+if [ "$status" -ne 0 ]; then
+  echo "The last files checked before the failure were:"
+  tail -n 5 "$report"
+fi
+
+awk '/allocs:/ {
+  parses++
+  allocs += $4
+  deallocs += $6
+} END {
+  printf "%d parses, %d allocations, %d deallocations, %d not freed\n", parses, allocs, deallocs, allocs - deallocs
+}' "$report"
+
+exit "$status"


### PR DESCRIPTION
This pull request adds a job to the corpus workflow that parses every file in `marcoroth/herb-corpus` through the tracking allocator and fails when a parse aborts or frees a pointer the allocator never handed out.

The gate in `build.yml` runs over `examples/`, which is 33 files picked to cover parser features rather than to look like templates people write. That turned out to matter. While moving token ownership into the AST constructors, `examples/` was green while seven corpus files had a token owned twice, in three shapes it had no example of. The corpus found all seven in half a minute.

Each file is parsed twice, once with the default options and once with the transforms enabled, the same pairing the `examples/` gate uses.

```
74020 parses, 117184916 allocations, 116967074 deallocations, 217842 not freed
```