### PR TITLE
VS Code: Bundle `vscode-html-languageservice` from its ESM entry

### DIFF
--- a/javascript/packages/vscode/esbuild.js
+++ b/javascript/packages/vscode/esbuild.js
@@ -43,6 +43,7 @@ async function main() {
     sourcemap: !production,
     sourcesContent: false,
     platform: 'node',
+    mainFields: ['module', 'main'],
     outfile: 'dist/extension.js',
     external: ['vscode'],
     logLevel: 'silent',


### PR DESCRIPTION
This pull request fixes the extension failing to activate.

```
Activating extension 'marcoroth.herb-lsp' failed: Cannot find module './parser/htmlScanner'
Require stack:
- .../javascript/packages/vscode/dist/extension.js
- /Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js
```

`vscode-html-languageservice` has no `exports` map and points `main` at a UMD build. esbuild cannot follow the relative requires inside a UMD factory, so they survive verbatim into the bundle:

```js
const htmlScanner_1 = require2("./parser/htmlScanner");
```

Nothing resolves that path at runtime, and the extension host gives up before the extension starts. Preferring the `module` field picks the package's ESM build, which esbuild bundles cleanly.

```diff
     platform: 'node',
+    mainFields: ['module', 'main'],
     outfile: 'dist/extension.js',
```

The package has no `exports` map, so `mainFields` is what decides here. A package that ships one would ignore the setting, since conditions take precedence.