### PR TITLE
Parser: Free every block a parse allocates

### DIFF
--- a/bench/bench_allocs.c
+++ b/bench/bench_allocs.c
@@ -210,25 +210,30 @@ static bool run_source_check(
 typedef struct {
   const char* label;
   size_t offset;
+  bool value;
 } option_toggle_T;
 
 static const option_toggle_T OPTION_TOGGLES[] = {
-  {          "whitespace",     offsetof(parser_options_T, track_whitespace) },
-  {         "action-view",  offsetof(parser_options_T, action_view_helpers) },
-  {        "conditionals", offsetof(parser_options_T, transform_conditionals) },
-  {        "render-nodes",          offsetof(parser_options_T, render_nodes) },
-  {       "strict-locals",         offsetof(parser_options_T, strict_locals) },
-  {     "iteration-nodes",       offsetof(parser_options_T, iteration_nodes) },
-  {         "prism-nodes",           offsetof(parser_options_T, prism_nodes) },
-  {    "prism-nodes-deep",      offsetof(parser_options_T, prism_nodes_deep) },
-  {       "prism-program",         offsetof(parser_options_T, prism_program) },
-  {   "dot-notation-tags",     offsetof(parser_options_T, dot_notation_tags) },
+  {          "whitespace",     offsetof(parser_options_T, track_whitespace), true },
+  {         "action-view",  offsetof(parser_options_T, action_view_helpers), true },
+  {        "conditionals", offsetof(parser_options_T, transform_conditionals), true },
+  {        "render-nodes",          offsetof(parser_options_T, render_nodes), true },
+  {       "strict-locals",         offsetof(parser_options_T, strict_locals), true },
+  {     "iteration-nodes",       offsetof(parser_options_T, iteration_nodes), true },
+  {         "prism-nodes",           offsetof(parser_options_T, prism_nodes), true },
+  {    "prism-nodes-deep",      offsetof(parser_options_T, prism_nodes_deep), true },
+  {       "prism-program",         offsetof(parser_options_T, prism_program), true },
+  {   "dot-notation-tags",     offsetof(parser_options_T, dot_notation_tags), true },
+  {          "no-analyze",             offsetof(parser_options_T, analyze), false },
+  {           "no-strict",              offsetof(parser_options_T, strict), false },
+  {             "no-html",                offsetof(parser_options_T, html), false },
+  {        "no-locations",     offsetof(parser_options_T, track_locations), false },
 };
 
 static const size_t OPTION_TOGGLES_COUNT = sizeof(OPTION_TOGGLES) / sizeof(OPTION_TOGGLES[0]);
 
-static void set_toggle(parser_options_T* options, size_t offset) {
-  *(bool*) ((char*) options + offset) = true;
+static void set_toggle(parser_options_T* options, size_t offset, bool value) {
+  *(bool*) ((char*) options + offset) = value;
 }
 
 static bool run_file_check(const char* path) {
@@ -245,7 +250,7 @@ static bool run_file_check(const char* path) {
 
   for (size_t i = 0; i < OPTION_TOGGLES_COUNT; i++) {
     parser_options_T options = HERB_DEFAULT_PARSER_OPTIONS;
-    set_toggle(&options, OPTION_TOGGLES[i].offset);
+    set_toggle(&options, OPTION_TOGGLES[i].offset, OPTION_TOGGLES[i].value);
 
     ok = run_source_check(path, OPTION_TOGGLES[i].label, source, &options) && ok;
   }
@@ -253,10 +258,17 @@ static bool run_file_check(const char* path) {
   parser_options_T everything = HERB_DEFAULT_PARSER_OPTIONS;
 
   for (size_t i = 0; i < OPTION_TOGGLES_COUNT; i++) {
-    set_toggle(&everything, OPTION_TOGGLES[i].offset);
+    if (OPTION_TOGGLES[i].value) { set_toggle(&everything, OPTION_TOGGLES[i].offset, true); }
   }
 
   ok = run_source_check(path, "all", source, &everything) && ok;
+
+  uint32_t error_count = 0;
+  parser_options_T capped = HERB_DEFAULT_PARSER_OPTIONS;
+  capped.max_errors = 1;
+  capped.error_count = &error_count;
+
+  ok = run_source_check(path, "max-errors", source, &capped) && ok;
 
   hb_allocator_dealloc(&file_allocator, source);
 

--- a/bench/bench_allocs.c
+++ b/bench/bench_allocs.c
@@ -4,6 +4,7 @@
 #include "../src/include/util/io.h"
 
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -206,6 +207,30 @@ static bool run_source_check(
   return ok;
 }
 
+typedef struct {
+  const char* label;
+  size_t offset;
+} option_toggle_T;
+
+static const option_toggle_T OPTION_TOGGLES[] = {
+  {          "whitespace",     offsetof(parser_options_T, track_whitespace) },
+  {         "action-view",  offsetof(parser_options_T, action_view_helpers) },
+  {        "conditionals", offsetof(parser_options_T, transform_conditionals) },
+  {        "render-nodes",          offsetof(parser_options_T, render_nodes) },
+  {       "strict-locals",         offsetof(parser_options_T, strict_locals) },
+  {     "iteration-nodes",       offsetof(parser_options_T, iteration_nodes) },
+  {         "prism-nodes",           offsetof(parser_options_T, prism_nodes) },
+  {    "prism-nodes-deep",      offsetof(parser_options_T, prism_nodes_deep) },
+  {       "prism-program",         offsetof(parser_options_T, prism_program) },
+  {   "dot-notation-tags",     offsetof(parser_options_T, dot_notation_tags) },
+};
+
+static const size_t OPTION_TOGGLES_COUNT = sizeof(OPTION_TOGGLES) / sizeof(OPTION_TOGGLES[0]);
+
+static void set_toggle(parser_options_T* options, size_t offset) {
+  *(bool*) ((char*) options + offset) = true;
+}
+
 static bool run_file_check(const char* path) {
   hb_allocator_T file_allocator = hb_allocator_with_malloc();
   char* source = herb_read_file(path, &file_allocator);
@@ -216,15 +241,22 @@ static bool run_file_check(const char* path) {
     return false;
   }
 
-  parser_options_T transforms = HERB_DEFAULT_PARSER_OPTIONS;
-  transforms.action_view_helpers = true;
-  transforms.transform_conditionals = true;
-  transforms.render_nodes = true;
-  transforms.iteration_nodes = true;
-  transforms.strict_locals = true;
-
   bool ok = run_source_check(path, "default", source, NULL);
-  ok = run_source_check(path, "transforms", source, &transforms) && ok;
+
+  for (size_t i = 0; i < OPTION_TOGGLES_COUNT; i++) {
+    parser_options_T options = HERB_DEFAULT_PARSER_OPTIONS;
+    set_toggle(&options, OPTION_TOGGLES[i].offset);
+
+    ok = run_source_check(path, OPTION_TOGGLES[i].label, source, &options) && ok;
+  }
+
+  parser_options_T everything = HERB_DEFAULT_PARSER_OPTIONS;
+
+  for (size_t i = 0; i < OPTION_TOGGLES_COUNT; i++) {
+    set_toggle(&everything, OPTION_TOGGLES[i].offset);
+  }
+
+  ok = run_source_check(path, "all", source, &everything) && ok;
 
   hb_allocator_dealloc(&file_allocator, source);
 

--- a/src/analyze/action_view/attribute_extraction_helpers.c
+++ b/src/analyze/action_view/attribute_extraction_helpers.c
@@ -302,6 +302,8 @@ static AST_NODE_T* create_attribute_from_value(
 
     if (raw_content && value_node->location.start) {
       char* ruby_content = raw_content;
+      hb_buffer_T wrapper;
+      bool wrapped = false;
 
       if (!is_nested && is_boolean_attribute(hb_string((char*) name_string))) {
         AST_NODE_T* conditional_attribute =
@@ -314,28 +316,31 @@ static AST_NODE_T* create_attribute_from_value(
 
       if (!is_nested && strcmp(name_string, "class") == 0
           && (value_node->type == PM_HASH_NODE || value_node->type == PM_ARRAY_NODE)) {
-        hb_buffer_T class_buffer;
-        hb_buffer_init(&class_buffer, value_length + 16, allocator);
-        hb_buffer_append(&class_buffer, "token_list(");
-        hb_buffer_append(&class_buffer, raw_content);
-        hb_buffer_append(&class_buffer, ")");
+        hb_buffer_init(&wrapper, value_length + 16, allocator);
+        hb_buffer_append(&wrapper, "token_list(");
+        hb_buffer_append(&wrapper, raw_content);
+        hb_buffer_append(&wrapper, ")");
 
-        ruby_content = hb_buffer_value(&class_buffer);
+        ruby_content = hb_buffer_value(&wrapper);
+        wrapped = true;
       }
 
       // Rails calls .to_json on non-string/symbol values inside data:/aria: hashes
       if (is_nested) {
-        hb_buffer_T json_buffer;
-        hb_buffer_init(&json_buffer, value_length + 64, allocator);
-        hb_buffer_append(&json_buffer, "::Herb::Engine.nested_attribute_value(");
-        hb_buffer_append(&json_buffer, raw_content);
-        hb_buffer_append(&json_buffer, ")");
+        hb_buffer_init(&wrapper, value_length + 64, allocator);
+        hb_buffer_append(&wrapper, "::Herb::Engine.nested_attribute_value(");
+        hb_buffer_append(&wrapper, raw_content);
+        hb_buffer_append(&wrapper, ")");
 
-        ruby_content = hb_buffer_value(&json_buffer);
+        ruby_content = hb_buffer_value(&wrapper);
+        wrapped = true;
       }
 
       AST_HTML_ATTRIBUTE_NODE_T* attribute =
         create_html_attribute_with_ruby_literal_precise(name_string, ruby_content, positions, allocator);
+
+      if (wrapped) { hb_buffer_free(&wrapper); }
+
       hb_allocator_dealloc(allocator, raw_content);
 
       return (AST_NODE_T*) attribute;
@@ -386,12 +391,15 @@ void resolve_nonce_attribute(hb_array_T* attributes, hb_allocator_T* allocator) 
 
       hb_array_T* new_children = hb_array_init(1, allocator);
       hb_array_append(new_children, (AST_NODE_T*) ruby_node);
+
       attribute->value->children = new_children;
+
       return;
     }
 
     if (hb_string_equals(literal->content, hb_string("false"))) {
       hb_array_remove(attributes, index);
+
       return;
     }
   }

--- a/src/analyze/action_view/attribute_extraction_helpers.c
+++ b/src/analyze/action_view/attribute_extraction_helpers.c
@@ -238,6 +238,8 @@ static char* join_static_string_array(pm_array_node_t* array, hb_allocator_T* al
 
   char* result = hb_allocator_strdup(allocator, hb_buffer_value(&buffer));
 
+  hb_buffer_free(&buffer);
+
   return result;
 }
 
@@ -389,10 +391,12 @@ void resolve_nonce_attribute(hb_array_T* attributes, hb_allocator_T* allocator) 
         allocator
       );
 
-      hb_array_T* new_children = hb_array_init(1, allocator);
-      hb_array_append(new_children, (AST_NODE_T*) ruby_node);
+      for (size_t child = 0; child < hb_array_size(attribute->value->children); child++) {
+        ast_node_free(hb_array_get(attribute->value->children, child), allocator);
+      }
 
-      attribute->value->children = new_children;
+      attribute->value->children->size = 0;
+      hb_array_append(attribute->value->children, (AST_NODE_T*) ruby_node);
 
       return;
     }

--- a/src/analyze/action_view/tag_helpers.c
+++ b/src/analyze/action_view/tag_helpers.c
@@ -436,6 +436,10 @@ static AST_NODE_T* remove_attribute_by_name(hb_array_T* attributes, const char* 
   return NULL;
 }
 
+static void discard_attribute_by_name(hb_array_T* attributes, const char* name, hb_allocator_T* allocator) {
+  ast_node_free(remove_attribute_by_name(attributes, name), allocator);
+}
+
 static hb_array_T* prepend_stylesheet_link_tag_attributes(
   hb_array_T* attributes,
   tag_helper_parse_context_T* parse_context,
@@ -546,10 +550,10 @@ static AST_NODE_T* transform_tag_helper_with_attributes(
       allocator
     );
 
-    remove_attribute_by_name(attributes, "extname");
-    remove_attribute_by_name(attributes, "host");
-    remove_attribute_by_name(attributes, "protocol");
-    remove_attribute_by_name(attributes, "skip-pipeline");
+    discard_attribute_by_name(attributes, "extname", allocator);
+    discard_attribute_by_name(attributes, "host", allocator);
+    discard_attribute_by_name(attributes, "protocol", allocator);
+    discard_attribute_by_name(attributes, "skip-pipeline", allocator);
   }
 
   if (attributes && handler->name && strcmp(handler->name, "stylesheet_link_tag") == 0) {
@@ -559,16 +563,16 @@ static AST_NODE_T* transform_tag_helper_with_attributes(
       allocator
     );
 
-    remove_attribute_by_name(attributes, "extname");
-    remove_attribute_by_name(attributes, "host");
-    remove_attribute_by_name(attributes, "protocol");
-    remove_attribute_by_name(attributes, "skip-pipeline");
+    discard_attribute_by_name(attributes, "extname", allocator);
+    discard_attribute_by_name(attributes, "host", allocator);
+    discard_attribute_by_name(attributes, "protocol", allocator);
+    discard_attribute_by_name(attributes, "skip-pipeline", allocator);
   }
 
   if (attributes && handler->name && strcmp(handler->name, "image_tag") == 0) {
     path_options =
       extract_path_options_from_keyword_hash(parse_context->info->call_node, IMAGE_TAG_PATH_OPTIONS, allocator);
-    remove_attribute_by_name(attributes, "skip-pipeline");
+    discard_attribute_by_name(attributes, "skip-pipeline", allocator);
 
     AST_NODE_T* size_node = remove_attribute_by_name(attributes, "size");
 
@@ -1078,10 +1082,10 @@ static hb_array_T* build_asset_tag_attributes(
 
   resolve_nonce_attribute(attributes, allocator);
 
-  remove_attribute_by_name(attributes, "extname");
-  remove_attribute_by_name(attributes, "host");
-  remove_attribute_by_name(attributes, "protocol");
-  remove_attribute_by_name(attributes, "skip-pipeline");
+  discard_attribute_by_name(attributes, "extname", allocator);
+  discard_attribute_by_name(attributes, "host", allocator);
+  discard_attribute_by_name(attributes, "protocol", allocator);
+  discard_attribute_by_name(attributes, "skip-pipeline", allocator);
 
   return attributes;
 }

--- a/src/analyze/action_view/tag_helpers.c
+++ b/src/analyze/action_view/tag_helpers.c
@@ -823,6 +823,8 @@ static AST_NODE_T* transform_tag_helper_with_attributes(
   token_T* tag_name_token =
     tag_name ? create_synthetic_token(allocator, tag_name, TOKEN_IDENTIFIER, tag_name_start, tag_name_end) : NULL;
 
+  hb_allocator_dealloc(allocator, path_options);
+
   hb_array_T* open_tag_children = attributes ? attributes : hb_array_init(0, allocator);
 
   AST_ERB_OPEN_TAG_NODE_T* open_tag_node = ast_erb_open_tag_node_init(
@@ -887,6 +889,8 @@ static AST_NODE_T* transform_tag_helper_with_attributes(
         &element_errors,
         context->options
       );
+
+      hb_buffer_free(&helper_name_buffer);
     }
 
     if (string_equals(handler->name, "javascript_tag")) {
@@ -1133,6 +1137,8 @@ static hb_array_T* transform_javascript_include_tag_multi_source(
     }
   }
 
+  hb_allocator_dealloc(allocator, path_options);
+
   return elements;
 }
 
@@ -1229,6 +1235,8 @@ static hb_array_T* transform_stylesheet_link_tag_multi_source(
       hb_array_append(elements, element);
     }
   }
+
+  hb_allocator_dealloc(allocator, path_options);
 
   return elements;
 }
@@ -1472,6 +1480,12 @@ static AST_NODE_T* transform_erb_block_to_tag_helper(
       body_document->children = NULL;
 
       ast_node_free((AST_NODE_T*) body_document, allocator);
+
+      for (size_t index = 0; index < hb_array_size(body); index++) {
+        ast_node_rebase_tokens(hb_array_get(body, index), raw_copy, context->source + start_offset, content_length);
+      }
+
+      hb_allocator_dealloc(allocator, raw_copy);
     }
   }
 

--- a/src/analyze/action_view/tag_helpers.c
+++ b/src/analyze/action_view/tag_helpers.c
@@ -656,6 +656,8 @@ static AST_NODE_T* transform_tag_helper_with_attributes(
           }
         }
       }
+
+      ast_node_free(size_node, allocator);
     }
   }
 

--- a/src/analyze/conditional_open_tags.c
+++ b/src/analyze/conditional_open_tags.c
@@ -423,6 +423,8 @@ static void rewrite_conditional_open_tags(hb_array_T* nodes, hb_array_T* documen
         hb_array_append(consumed_indices, index);
       }
     }
+
+    i = close_index;
   }
 
   if (hb_array_size(consumed_indices) > 0) {

--- a/src/analyze/postfix_conditionals.c
+++ b/src/analyze/postfix_conditionals.c
@@ -244,6 +244,9 @@ static AST_NODE_T* transform_conditional(
 
   token_T* tag_opening = create_synthetic_token(allocator, "<%", TOKEN_ERB_START, start, start);
   token_T* content_token = create_synthetic_token(allocator, condition_content, TOKEN_ERB_CONTENT, start, end);
+
+  hb_buffer_free(&condition_buffer);
+  hb_allocator_dealloc(allocator, condition_source);
   token_T* tag_closing = create_synthetic_token(allocator, "%>", TOKEN_ERB_END, end, end);
 
   token_T* end_opening = create_synthetic_token(allocator, "<%", TOKEN_ERB_START, end, end);
@@ -308,7 +311,10 @@ static void transform_conditional_array(
     if (!conditional_node) { continue; }
 
     AST_NODE_T* replacement = transform_conditional(erb_node, conditional_node, static_node_type, context->allocator);
-    if (replacement) { hb_array_set(array, i, replacement); }
+    if (replacement) {
+      hb_array_set(array, i, replacement);
+      ast_node_free(child, context->allocator);
+    }
   }
 }
 

--- a/src/analyze/postfix_conditionals.c
+++ b/src/analyze/postfix_conditionals.c
@@ -95,6 +95,9 @@ static body_info_T extract_body_info(
   if (info.source) {
     info.length = info.offset_in_content + info.length;
     info.offset_in_content = 0;
+
+    hb_allocator_dealloc(allocator, (void*) info.source);
+
     info.source = hb_allocator_strndup(allocator, (const char*) analyzed->parser.start, info.length);
   }
 

--- a/src/analyze/postfix_conditionals.c
+++ b/src/analyze/postfix_conditionals.c
@@ -183,6 +183,8 @@ static bool append_body_statement(
 
   token_T* content = create_synthetic_token(allocator, info.source, TOKEN_ERB_CONTENT, body_start, body_end);
 
+  hb_allocator_dealloc(allocator, (void*) info.source);
+
   AST_ERB_CONTENT_NODE_T* body_erb_node = ast_erb_content_node_init(
     token_copy(erb_node->tag_opening, allocator),
     content,

--- a/src/analyze/render_nodes.c
+++ b/src/analyze/render_nodes.c
@@ -692,9 +692,6 @@ static AST_ERB_RENDER_NODE_T* create_render_node_from_call(
   AST_ERB_ENSURE_NODE_T* render_ensure_clause = block_fields ? block_fields->ensure_clause : NULL;
   AST_ERB_END_NODE_T* render_end_node = block_fields ? block_fields->end_node : NULL;
 
-  if (!render_block_body) { render_block_body = hb_array_init(0, allocator); }
-  if (!render_block_arguments) { render_block_arguments = hb_array_init(0, allocator); }
-
   if (!block_fields) {
     pm_block_node_t* inline_block = find_block_on_render_call(call_node);
 
@@ -703,6 +700,8 @@ static AST_ERB_RENDER_NODE_T* create_render_node_from_call(
 
       if (inline_block->parameters && inline_block->parameters->type == PM_BLOCK_PARAMETERS_NODE) {
         pm_block_parameters_node_t* block_parameters = (pm_block_parameters_node_t*) inline_block->parameters;
+
+        hb_array_free(&render_block_arguments);
 
         render_block_arguments = extract_parameters_from_prism(
           block_parameters->parameters,
@@ -737,6 +736,8 @@ static AST_ERB_RENDER_NODE_T* create_render_node_from_call(
           allocator
         );
 
+        hb_array_free(&render_block_body);
+
         render_block_body = hb_array_init(1, allocator);
         hb_array_append(render_block_body, body_node);
 
@@ -769,6 +770,9 @@ static AST_ERB_RENDER_NODE_T* create_render_node_from_call(
     hb_array_init(0, allocator),
     allocator
   );
+
+  if (!render_block_body) { render_block_body = hb_array_init(0, allocator); }
+  if (!render_block_arguments) { render_block_arguments = hb_array_init(0, allocator); }
 
   return ast_erb_render_node_init(
     token_copy(erb_node->tag_opening, allocator),

--- a/src/analyze/render_nodes.c
+++ b/src/analyze/render_nodes.c
@@ -920,6 +920,25 @@ static AST_ERB_RENDER_NODE_T* try_transform_block_node(
   return render_node;
 }
 
+static void release_replaced_node(AST_NODE_T* child, AST_ERB_RENDER_NODE_T* render_node, hb_allocator_T* allocator) {
+  if (child->type == AST_ERB_CONTENT_NODE) {
+    AST_ERB_CONTENT_NODE_T* erb_node = (AST_ERB_CONTENT_NODE_T*) child;
+
+    if (render_node->analyzed_ruby == erb_node->analyzed_ruby) { erb_node->analyzed_ruby = NULL; }
+  } else if (child->type == AST_ERB_BLOCK_NODE) {
+    AST_ERB_BLOCK_NODE_T* block_node = (AST_ERB_BLOCK_NODE_T*) child;
+
+    if (render_node->body == block_node->body) { block_node->body = NULL; }
+    if (render_node->block_arguments == block_node->block_arguments) { block_node->block_arguments = NULL; }
+    if (render_node->rescue_clause == block_node->rescue_clause) { block_node->rescue_clause = NULL; }
+    if (render_node->else_clause == block_node->else_clause) { block_node->else_clause = NULL; }
+    if (render_node->ensure_clause == block_node->ensure_clause) { block_node->ensure_clause = NULL; }
+    if (render_node->end_node == block_node->end_node) { block_node->end_node = NULL; }
+  }
+
+  ast_node_free(child, allocator);
+}
+
 static void transform_render_nodes_in_array(hb_array_T* array, analyze_ruby_context_T* context) {
   if (!array) { return; }
 
@@ -935,7 +954,10 @@ static void transform_render_nodes_in_array(hb_array_T* array, analyze_ruby_cont
       render_node = try_transform_block_node((AST_ERB_BLOCK_NODE_T*) child, context);
     }
 
-    if (render_node) { hb_array_set(array, index, render_node); }
+    if (render_node) {
+      hb_array_set(array, index, render_node);
+      release_replaced_node(child, render_node, context->allocator);
+    }
   }
 }
 

--- a/src/analyze/render_nodes.c
+++ b/src/analyze/render_nodes.c
@@ -489,7 +489,7 @@ static AST_ERB_RENDER_NODE_T* create_render_node_from_call(
       };
 
       for (size_t index = 0; index < sizeof(keyword_fields) / sizeof(keyword_fields[0]); index++) {
-        *keyword_fields[index].target = extract_keyword_token(
+        token_T* keyword_token = extract_keyword_token(
           keyword_hash,
           keyword_fields[index].name,
           source,
@@ -497,6 +497,11 @@ static AST_ERB_RENDER_NODE_T* create_render_node_from_call(
           erb_content_source,
           allocator
         );
+
+        if (keyword_token) {
+          token_free(*keyword_fields[index].target, allocator);
+          *keyword_fields[index].target = keyword_token;
+        }
       }
 
       if (partial) { has_keyword_partial = true; }

--- a/src/analyze/strict_locals.c
+++ b/src/analyze/strict_locals.c
@@ -320,6 +320,10 @@ static void transform_strict_locals_in_array(hb_array_T* array, analyze_ruby_con
 
     context->found_strict_locals = true;
     hb_array_set(array, index, strict_locals_node);
+
+    if (strict_locals_node->analyzed_ruby == erb_node->analyzed_ruby) { erb_node->analyzed_ruby = NULL; }
+
+    ast_node_free(child, context->allocator);
   }
 }
 

--- a/src/analyze/ternary_conditionals.c
+++ b/src/analyze/ternary_conditionals.c
@@ -124,6 +124,8 @@ static bool append_branch_statement(
 
   token_T* content = create_synthetic_token(allocator, info.source, TOKEN_ERB_CONTENT, branch_start, branch_end);
 
+  hb_allocator_dealloc(allocator, (void*) info.source);
+
   AST_ERB_CONTENT_NODE_T* branch_erb_node = ast_erb_content_node_init(
     token_copy(erb_node->tag_opening, allocator),
     content,
@@ -196,6 +198,9 @@ AST_NODE_T* transform_ternary_expression(
 
   token_T* if_opening = create_synthetic_token(allocator, "<%", TOKEN_ERB_START, start, start);
   token_T* if_content = create_synthetic_token(allocator, condition_content, TOKEN_ERB_CONTENT, start, end);
+
+  hb_buffer_free(&condition_buffer);
+  hb_allocator_dealloc(allocator, condition_source);
   token_T* if_closing = create_synthetic_token(allocator, "%>", TOKEN_ERB_END, end, end);
 
   token_T* end_opening = create_synthetic_token(allocator, "<%", TOKEN_ERB_START, end, end);
@@ -244,7 +249,10 @@ static void transform_ternary_array(
 
     AST_NODE_T* replacement =
       transform_ternary_expression(erb_node, (pm_if_node_t*) ternary_node, static_node_type, context->allocator);
-    if (replacement) { hb_array_set(array, i, replacement); }
+    if (replacement) {
+      hb_array_set(array, i, replacement);
+      ast_node_free(child, context->allocator);
+    }
   }
 }
 

--- a/src/include/ast/ast_node.h
+++ b/src/include/ast/ast_node.h
@@ -16,6 +16,7 @@ void ast_node_init(
   hb_allocator_T* allocator
 );
 void ast_node_free(AST_NODE_T* node, hb_allocator_T* allocator);
+void ast_node_rebase_tokens(AST_NODE_T* node, const char* from, const char* to, size_t length);
 
 AST_LITERAL_NODE_T* ast_literal_node_init_from_token(const token_T* token, hb_allocator_T* allocator);
 

--- a/templates/src/ast/ast_nodes.c.erb
+++ b/templates/src/ast/ast_nodes.c.erb
@@ -144,6 +144,45 @@ static void ast_free_<%= node.human %>(<%= node.struct_type %>* <%= node.human %
 }
 <%- end -%>
 
+static void ast_rebase_token(token_T* token, const char* from, const char* to, size_t length) {
+  if (token == NULL || token->value.data == NULL) { return; }
+  if (token->value.data < from || token->value.data >= from + length) { return; }
+
+  token->value.data = (char*) to + (token->value.data - from);
+}
+
+void ast_node_rebase_tokens(AST_NODE_T* node, const char* from, const char* to, size_t length) {
+  if (!node) { return; }
+
+  switch (node->type) {
+    <%- nodes.each do |node| -%>
+    case <%= node.type %>: {
+      <%- if node.fields.none? { |f| [Herb::Template::TokenField, Herb::Template::NodeField, Herb::Template::ArrayField].include?(f.class) } -%>
+      break;
+      <%- else -%>
+      <%= node.struct_type %>* typed = (<%= node.struct_type %>*) node;
+      <%- node.fields.each do |field| -%>
+      <%- case field -%>
+      <%- when Herb::Template::TokenField -%>
+      ast_rebase_token(typed-><%= field.name %>, from, to, length);
+      <%- when Herb::Template::BorrowedNodeField -%>
+      <%- when Herb::Template::NodeField -%>
+      ast_node_rebase_tokens((AST_NODE_T*) typed-><%= field.name %>, from, to, length);
+      <%- when Herb::Template::ArrayField -%>
+      if (typed-><%= field.name %> != NULL) {
+        for (size_t i = 0; i < hb_array_size(typed-><%= field.name %>); i++) {
+          ast_node_rebase_tokens((AST_NODE_T*) hb_array_get(typed-><%= field.name %>, i), from, to, length);
+        }
+      }
+      <%- end -%>
+      <%- end -%>
+      break;
+      <%- end -%>
+    }
+    <%- end -%>
+  }
+}
+
 void ast_node_free(AST_NODE_T* node, hb_allocator_T* allocator) {
   if (!node) { return; }
 


### PR DESCRIPTION
This pull request takes the corpus from 217,842 unfreed blocks to none, and widens the check that measures it from 2 option profiles to 17 along the way.

```
629170 parses, 873750400 allocations, 873750400 deallocations, 0 not freed
```

Every parser option is now exercised on every file: the ten that default to off turned on one at a time, the four that default to on turned off, one run with everything enabled, and one with `max_errors` capped so the early exit gets walked as well.

#### The leaks

Most of them are one of two shapes.

A transform builds a replacement, writes it over the node it replaces, and leaves that node with no owner. It cannot simply be freed, because the replacement adopts parts of it, and which parts depends on the branch. Each of these disclaims what it hands on by comparing the node it produced against the one it replaced, so the caller can free without restating the conditions:

```c
if (render_node->body == block_node->body) { block_node->body = NULL; }
```

Or a buffer is filled, its value handed to something that copies it, and the buffer left behind. That was `extract_condition_source` and the condition buffers in both conditional transforms, the body source behind `info.source`, `join_static_string_array`, the void element helper name, and `path_options`.

Four did not fit either shape:

- `extract_body_info` duplicated the body, then duplicated a longer span over the top and kept only the second
- `resolve_nonce_attribute` gave a `nonce: true` attribute a fresh children array and dropped the one it displaced, along with the literal inside it
- the render keyword loop assigned all seventeen fields unconditionally, so a `partial` or `object` taken from a positional argument was overwritten with NULL when no keyword matched
- `rewrite_conditional_open_tags` never advanced past the nodes it had just consumed, so it walked back over them and built elements at indices it then discarded

#### The one that looked impossible

A tag helper block body is parsed from a copy of the source, and the tokens that parse produces hold `hb_string_T` views into that copy, so it could not be freed while the AST referred to it. I had written it up as a property of the design rather than a leak.

It is not. The copy is byte for byte the span it was taken from, so the views can be pointed back at the original source and the copy released. `ast_node_rebase_tokens` walks a subtree doing that, generated from the node definitions alongside the other per-node walkers.