### PR TITLE
Config: Move the editor setting defaults out of the language server

### DIFF
--- a/javascript/packages/config/src/config.ts
+++ b/javascript/packages/config/src/config.ts
@@ -20,6 +20,54 @@ import type { DiagnosticSeverity } from "@herb-tools/core"
 const DEFAULT_VERSION = packageJson.version
 const PARSED_DEFAULTS = parse(defaultsYaml) as Omit<HerbConfig, 'version'>
 
+/**
+ * The preferences an editor owns rather than the project. Whether the linter
+ * runs is a decision a team makes in `.herb.yml`, but whether fixes apply on
+ * save, or how far apart two tags have to be before a hint appears, is nobody's
+ * business but the person typing.
+ *
+ * They live here so that an editor integration can read them without depending
+ * on the language server, which would pull the whole server into its bundle.
+ */
+export interface PersonalHerbSettings {
+  trace?: {
+    server?: string
+  }
+  linter?: {
+    enabled?: boolean
+    fixOnSave?: boolean
+  }
+  formatter?: {
+    enabled?: boolean
+    indentWidth?: number
+    indentStyle?: "space" | "tab"
+    maxLineLength?: number
+  }
+  inlayHints?: {
+    enabled?: boolean
+    minimumLines?: number
+    maximumClasses?: number
+  }
+}
+
+export const defaultPersonalSettings: PersonalHerbSettings = {
+  linter: {
+    enabled: PARSED_DEFAULTS.linter?.enabled ?? true,
+    fixOnSave: true
+  },
+  formatter: {
+    enabled: PARSED_DEFAULTS.formatter?.enabled ?? false,
+    indentWidth: PARSED_DEFAULTS.formatter?.indentWidth ?? 2,
+    indentStyle: PARSED_DEFAULTS.formatter?.indentStyle ?? "space",
+    maxLineLength: PARSED_DEFAULTS.formatter?.maxLineLength ?? 80
+  },
+  inlayHints: {
+    enabled: true,
+    minimumLines: 10,
+    maximumClasses: 2
+  }
+}
+
 export interface ConfigValidationError {
   message: string
   path: (string | number | symbol)[]

--- a/javascript/packages/config/src/index.ts
+++ b/javascript/packages/config/src/index.ts
@@ -1,4 +1,4 @@
-export { Config, resolveSeverity, ALL_RULES_KEY } from "./config.js"
+export { Config, resolveSeverity, ALL_RULES_KEY, defaultPersonalSettings } from "./config.js"
 export { HerbConfigSchema, FRAMEWORKS, FRAMEWORK_NAMES } from "./config-schema.js"
 export { addHerbExtensionRecommendation, getExtensionsJsonRelativePath } from "./vscode.js"
 
@@ -16,7 +16,8 @@ export type {
   FromObjectOptions,
   ConfigValidationError,
   SeverityConfig,
-  LinterMode
+  LinterMode,
+  PersonalHerbSettings
 } from "./config.js"
 
 export type { VSCodeExtensionsJson } from "./vscode.js"

--- a/javascript/packages/language-server/src/user_settings.ts
+++ b/javascript/packages/language-server/src/user_settings.ts
@@ -1,53 +1,11 @@
-import { defaultFormatOptions } from "@herb-tools/formatter"
-import { defaultInlayHintOptions } from "@herb-tools/language-service"
+import { defaultPersonalSettings } from "@herb-tools/config"
 
+import type { PersonalHerbSettings } from "@herb-tools/config"
 import type { Connection } from "vscode-languageserver/node"
 import type { Capabilities } from "./capabilities"
 
-// TODO: ideally we could just Config all the way through
-export interface PersonalHerbSettings {
-  trace?: {
-    server?: string
-  }
-  linter?: {
-    enabled?: boolean
-    fixOnSave?: boolean
-  }
-  formatter?: {
-    enabled?: boolean
-    indentWidth?: number
-    indentStyle?: "space" | "tab"
-    maxLineLength?: number
-  }
-  inlayHints?: {
-    enabled?: boolean
-    minimumLines?: number
-    maximumClasses?: number
-  }
-}
-
-/**
- * What every one of these settings falls back to. Editors that surface them as
- * their own preferences read from here rather than restating the values, so
- * there is one place to change a default.
- */
-export const defaultPersonalSettings: PersonalHerbSettings = {
-  linter: {
-    enabled: true,
-    fixOnSave: true
-  },
-  formatter: {
-    enabled: false,
-    indentWidth: defaultFormatOptions.indentWidth,
-    indentStyle: defaultFormatOptions.indentStyle,
-    maxLineLength: defaultFormatOptions.maxLineLength
-  },
-  inlayHints: {
-    enabled: true,
-    minimumLines: defaultInlayHintOptions.minimumLines,
-    maximumClasses: defaultInlayHintOptions.maximumClasses
-  }
-}
+export { defaultPersonalSettings }
+export type { PersonalHerbSettings }
 
 /**
  * The editor-level preferences a user sets for themselves, which are per-document

--- a/javascript/packages/language-server/test/user_settings.test.ts
+++ b/javascript/packages/language-server/test/user_settings.test.ts
@@ -1,6 +1,9 @@
 import { describe, test, expect, vi } from "vitest"
 
 import { UserSettings } from "../src/user_settings"
+import { defaultPersonalSettings } from "@herb-tools/config"
+import { defaultFormatOptions } from "@herb-tools/formatter"
+import { defaultInlayHintOptions } from "@herb-tools/language-service"
 import { Capabilities } from "../src/capabilities"
 
 import type { Connection, InitializeParams } from "vscode-languageserver/node"
@@ -29,6 +32,17 @@ describe("UserSettings", () => {
   }
 
   describe("defaults", () => {
+    test("agree with the formatter's own defaults", () => {
+      expect(defaultPersonalSettings.formatter?.indentWidth).toBe(defaultFormatOptions.indentWidth)
+      expect(defaultPersonalSettings.formatter?.indentStyle).toBe(defaultFormatOptions.indentStyle)
+      expect(defaultPersonalSettings.formatter?.maxLineLength).toBe(defaultFormatOptions.maxLineLength)
+    })
+
+    test("agree with the inlay hint provider's own defaults", () => {
+      expect(defaultPersonalSettings.inlayHints?.minimumLines).toBe(defaultInlayHintOptions.minimumLines)
+      expect(defaultPersonalSettings.inlayHints?.maximumClasses).toBe(defaultInlayHintOptions.maximumClasses)
+    })
+
     test("enable the linter and fixing on save", () => {
       const settings = settingsFor(mockParams)
 

--- a/javascript/packages/vscode/src/client.ts
+++ b/javascript/packages/vscode/src/client.ts
@@ -2,8 +2,7 @@ import * as path from "path"
 
 import { workspace, ExtensionContext, Disposable, window } from "vscode"
 import { LanguageClient, LanguageClientOptions, ServerOptions, TransportKind, WorkspaceEdit } from "vscode-languageclient/node"
-import { Config } from "@herb-tools/config"
-import { defaultPersonalSettings } from "@herb-tools/language-server"
+import { Config, defaultPersonalSettings } from "@herb-tools/config"
 
 const inlayHintDefaults = defaultPersonalSettings.inlayHints!
 


### PR DESCRIPTION
The VS Code extension imported `defaultPersonalSettings` from `@herb-tools/language-server` so that the extension and the server agreed on one set of defaults instead of each restating them. That turned out to be an expensive way to share an object literal.

The extension never runs the language server in-process, it spawns `dist/herb-language-server.js` as a separate process, so that one import dragged in code the extension has no use for. `@herb-tools/language-server` reaches `@herb-tools/language-service`, which depends on `vscode-html-languageservice`, and all of it ended up in `dist/extension.js`.

| | `dist/extension.js` |
|---|---|
| importing from `@herb-tools/language-server` | 5.7 MB |
| importing from `@herb-tools/config` | 1.6 MB |

`defaultPersonalSettings` now lives in `@herb-tools/config`. That is where it belongs regardless of the bundle size, since config is the package everything already depends on and it already owns the project defaults parsed out of `lib/herb/defaults.yml`. 

The settings an editor owns instead of a project stay as literals, because `fixOnSave` and the inlay hint options have no place in a checked-in `.herb.yml`. The language server re-exports both the constant and the `PersonalHerbSettings` type, so nothing that imported them has to change.

Follow up on #2321
