### PR TITLE
Highlighter: Link the marked line numbers to the file

### DIFF
--- a/javascript/packages/highlighter/src/diagnostic-renderer.ts
+++ b/javascript/packages/highlighter/src/diagnostic-renderer.ts
@@ -200,7 +200,7 @@ export class DiagnosticRenderer {
       let markerStart = marker ? marker.start : 0
       let markerLength = marker ? Math.max(1, marker.end - marker.start) : 0
 
-      const prefix = showLineNumbers ? gutter.linePrefix(i, isTargetLine, isTargetLine ? color : undefined) : ""
+      const prefix = showLineNumbers ? gutter.linePrefix(i, isTargetLine, isTargetLine ? color : undefined, isTargetLine ? fileUrlOption : undefined) : ""
 
       const displayLine = isTargetLine ? line : dimStyledText(line)
 

--- a/javascript/packages/highlighter/src/file-renderer.ts
+++ b/javascript/packages/highlighter/src/file-renderer.ts
@@ -1,4 +1,4 @@
-import { colorize } from "./color.js"
+import { colorize, hyperlink } from "./color.js"
 import { dimStyledText } from "./util.js"
 import { LineWrapper } from "./line-wrapper.js"
 import * as gutter from "./gutter.js"
@@ -51,6 +51,7 @@ export class FileRenderer {
     maxWidth = LineWrapper.getTerminalWidth(),
     wrapLines = false,
     truncateLines = false,
+    fileUrl?: string,
   ): string {
     const highlightedContent = this.syntaxRenderer.highlight(content)
     const lines = highlightedContent.split("\n")
@@ -58,14 +59,16 @@ export class FileRenderer {
     const startLine = Math.max(1, focusLine - contextLines)
     const endLine = Math.min(lines.length, focusLine + contextLines)
 
-    let output = showLineNumbers ? `${colorize(path, "cyan")}\n\n` : ""
+    const header = fileUrl ? hyperlink(colorize(path, "cyan"), fileUrl) : colorize(path, "cyan")
+
+    let output = showLineNumbers ? `${header}\n\n` : ""
 
     for (let i = startLine; i <= endLine; i++) {
       const line = lines[i - 1] || ""
       const isFocusLine = i === focusLine
 
       if (showLineNumbers) {
-        const prefix = gutter.linePrefix(i, isFocusLine, isFocusLine ? "cyan" : undefined)
+        const prefix = gutter.linePrefix(i, isFocusLine, isFocusLine ? "cyan" : undefined, isFocusLine ? fileUrl : undefined)
 
         let displayLine = line
 

--- a/javascript/packages/highlighter/src/gutter.ts
+++ b/javascript/packages/highlighter/src/gutter.ts
@@ -1,4 +1,4 @@
-import { colorize } from "./color.js"
+import { colorize, hyperlink } from "./color.js"
 
 import type { Color } from "./color.js"
 
@@ -12,9 +12,15 @@ export const GUTTER_WIDTH = 4 + 3 + 1 + 1 + 1;
 export const MIN_CONTENT_WIDTH = 40;
 
 export const separator = (): string => colorize("│", "gray")
-export const lineNumber = (number: number, emphasized: boolean): string => colorize(number.toString().padStart(3, " "), emphasized ? "bold" : "gray")
+
+export const lineNumber = (number: number, emphasized: boolean, url?: string): string => {
+  const label = colorize(number.toString().padStart(3, " "), emphasized ? "bold" : "gray")
+
+  return url ? hyperlink(label, url) : label
+}
+
 export const markerPrefix = (marker?: Color): string => marker ? colorize("  → ", marker) : "    "
-export const linePrefix = (number: number, emphasized: boolean, marker?: Color): string => `${markerPrefix(marker)}${lineNumber(number, emphasized)} ${separator()} `
+export const linePrefix = (number: number, emphasized: boolean, marker?: Color, url?: string): string => `${markerPrefix(marker)}${lineNumber(number, emphasized, url)} ${separator()} `
 export const pointerPrefix = (): string => `        ${separator()}`
 export const continuationPrefix = (): string => `        ${separator()} `
 export const availableWidth = (maxWidth: number): number => Math.max(MIN_CONTENT_WIDTH, maxWidth - GUTTER_WIDTH)

--- a/javascript/packages/highlighter/src/highlighter.ts
+++ b/javascript/packages/highlighter/src/highlighter.ts
@@ -24,6 +24,7 @@ export interface HighlightOptions {
   truncateLines?: boolean
   codeUrlBuilder?: (code: string) => string
   fileUrlBuilder?: (path: string, diagnostic: Diagnostic) => string
+  fileUrl?: string
   suffixBuilder?: (diagnostic: Diagnostic) => string | undefined
 }
 
@@ -87,6 +88,7 @@ export class Highlighter {
    *   - contextLines: Number of context lines around focus/diagnostics
    *   - focusLine: Line number to focus on (shows only that line with dimmed context)
    *   - showLineNumbers: Whether to show line numbers (default: true)
+   *   - fileUrl: URL that the file path and the focused line number link to
    * @returns The highlighted content with optional diagnostics or focused view
    */
   highlight(
@@ -107,6 +109,7 @@ export class Highlighter {
       truncateLines = false,
       codeUrlBuilder,
       fileUrlBuilder,
+      fileUrl: fileUrlOption,
       suffixBuilder,
     } = options
 
@@ -172,6 +175,7 @@ export class Highlighter {
         maxWidth,
         wrapLines,
         truncateLines,
+        fileUrlOption,
       )
     }
 

--- a/javascript/packages/highlighter/test/diagnostic-renderer.test.ts
+++ b/javascript/packages/highlighter/test/diagnostic-renderer.test.ts
@@ -160,6 +160,66 @@ describe("DiagnosticRenderer", () => {
     })
   })
 
+  describe("fileUrl", () => {
+    const content = dedent`
+      line 1
+      line <error> content
+      line 3
+    `
+
+    const hyperlinks = (output: string) => {
+      return [...output.matchAll(/\x1b\]8;;(.*?)\x1b\\(.*?)\x1b\]8;;\x1b\\/g)].map(([, url, text]) => ({
+        url,
+        text: stripAnsiColors(text),
+      }))
+    }
+
+    it("links the marked line number to the file", () => {
+      const result = renderer.renderSingle("/test/file.erb", createDiagnostic(), content, {
+        fileUrl: "file:///test/file.erb",
+      })
+
+      expect(hyperlinks(result)).toEqual([
+        { url: "file:///test/file.erb", text: "/test/file.erb:2:5" },
+        { url: "file:///test/file.erb", text: "  2" },
+      ])
+    })
+
+    it("does not link the line numbers of context lines", () => {
+      const result = renderer.renderSingle("/test/file.erb", createDiagnostic(), content, {
+        fileUrl: "file:///test/file.erb",
+        contextLines: 1,
+      })
+
+      expect(hyperlinks(result).map(({ text }) => text)).not.toContain("  1")
+      expect(hyperlinks(result).map(({ text }) => text)).not.toContain("  3")
+    })
+
+    it("links the line number of every marked line of a multi-line diagnostic", () => {
+      const diagnostic = createDiagnostic({ location: Location.from(1, 1, 3, 7) })
+      const result = renderer.renderSingle("/test/file.erb", diagnostic, content, {
+        fileUrl: "file:///test/file.erb",
+      })
+
+      expect(hyperlinks(result).map(({ text }) => text)).toEqual(["/test/file.erb:1:1", "  1", "  2", "  3"])
+    })
+
+    it("leaves the line numbers unlinked without a fileUrl", () => {
+      const result = renderer.renderSingle("/test/file.erb", createDiagnostic(), content)
+
+      expect(hyperlinks(result)).toEqual([])
+    })
+
+    it("leaves the line numbers unlinked when line numbers are hidden", () => {
+      const result = renderer.renderSingle("/test/file.erb", createDiagnostic(), content, {
+        fileUrl: "file:///test/file.erb",
+        showLineNumbers: false,
+      })
+
+      expect(hyperlinks(result)).toEqual([])
+    })
+  })
+
   describe("error handling", () => {
     it("should handle invalid line numbers gracefully", () => {
       const diagnostic = createDiagnostic({

--- a/javascript/packages/highlighter/test/file-renderer.test.ts
+++ b/javascript/packages/highlighter/test/file-renderer.test.ts
@@ -168,6 +168,36 @@ describe("FileRenderer", () => {
     })
   })
 
+  describe("fileUrl", () => {
+    const content = dedent`
+      line 1
+      line 2
+      line 3
+    `
+
+    const hyperlinks = (output: string) => {
+      return [...output.matchAll(/\x1b\]8;;(.*?)\x1b\\(.*?)\x1b\]8;;\x1b\\/g)].map(([, url, text]) => ({
+        url,
+        text: stripAnsiColors(text),
+      }))
+    }
+
+    it("links the file path and the focused line number to the file", () => {
+      const result = renderer.renderWithFocusLine("/test/file.erb", content, 2, 1, true, 80, false, false, "file:///test/file.erb")
+
+      expect(hyperlinks(result)).toEqual([
+        { url: "file:///test/file.erb", text: "/test/file.erb" },
+        { url: "file:///test/file.erb", text: "  2" },
+      ])
+    })
+
+    it("leaves the file path and the line numbers unlinked without a fileUrl", () => {
+      const result = renderer.renderWithFocusLine("/test/file.erb", content, 2, 1, true)
+
+      expect(hyperlinks(result)).toEqual([])
+    })
+  })
+
   describe("renderPlain", () => {
     it("should render content without line numbers or file headers", () => {
       const content = dedent`

--- a/javascript/packages/linter/src/cli/formatters/detailed-formatter.ts
+++ b/javascript/packages/linter/src/cli/formatters/detailed-formatter.ts
@@ -82,6 +82,7 @@ ${colorize("        Tip: run with ", "gray")}${colorize("--show-fix-diff", "bold
         contextLines: 0,
         wrapLines: this.wrapLines,
         truncateLines: this.truncateLines,
+        fileUrl: fileUrl(this.absolutePath(frame.file)),
       })
 
       const gutterLines = rendered.split("\n").filter(line => line.includes("│"))


### PR DESCRIPTION
This pull request makes the line numbers in the gutter link to the file the same way the filename above them already does.

Until now only the header of a diagnostic carried a hyperlink, so the `→ 2` pointing at the offense was plain text even though the `app/views/index.html.erb:2:9` right above it opened the file. The gutter helpers now take an optional URL and wrap the line number in an OSC 8 hyperlink when one is given.

```
app/views/index.html.erb:2:9    <- already a link

      1 │ <div>
  →   2 │   <span class=''>hi</span>    <- the 2 is now a link too
        │          ~~~~~~~~
      3 │ </div>
```

Only marked lines get linked, so context lines stay plain and a multi-line offense links the number of every line it marks. `DiagnosticRenderer` passes the `fileUrl` it already receives, and passing no URL produces byte-for-byte the same output as before.

`FileRenderer.renderWithFocusLine()` gained a `fileUrl` argument that links both the path header and the focused line number, exposed through `Highlighter.highlight()` as a `fileUrl` option. That is what the linter renders for each frame of a call chain, where the heading was a link while the focused line under it was not.

```
render app/views/_card.html.erb:3:1    <- already a link
  →   3 │   <%= render "card" %>       <- the 3 is now a link too
```

In a browser the sequence survives the trip through `ANSIConverter`, which turns it into an anchor around the styled line number.

```html
<a href="…/index.html.erb#L2" rel="noopener noreferrer"><span style="font-weight:700">  2</span></a>
```