### PR TITLE
Highlighter: Add a `linkResolver` option to `ANSIConverter`

### DIFF
--- a/javascript/packages/highlighter/src/ansi-element.ts
+++ b/javascript/packages/highlighter/src/ansi-element.ts
@@ -1,5 +1,7 @@
 import { ANSI_VARIABLE_PREFIX, ANSIConverter } from "./ansi-html.js"
 
+import type { LinkResolver } from "./ansi-html.js"
+
 import { BACKGROUND, FOREGROUND } from "../themes/onedark.json" with { type: "json" }
 
 export const HERB_ANSI_TAG_NAME = "herb-ansi"
@@ -62,6 +64,7 @@ export class HerbANSIElement extends HTMLElementBase {
   private output: HTMLElement
   private observer: MutationObserver | null = null
   private converter = new ANSIConverter()
+  private resolver: LinkResolver | null = null
 
   static define(tagName: string = HerbANSIElement.tagName): boolean {
     if (globals.customElements === undefined || globals.HTMLElement === undefined) return false
@@ -97,6 +100,17 @@ export class HerbANSIElement extends HTMLElementBase {
   disconnectedCallback(): void {
     this.observer?.disconnect()
     this.observer = null
+  }
+
+  get linkResolver(): LinkResolver | null {
+    return this.resolver
+  }
+
+  set linkResolver(resolver: LinkResolver | null) {
+    this.resolver = resolver
+    this.converter = new ANSIConverter(resolver === null ? {} : { linkResolver: resolver })
+
+    this.render()
   }
 
   render(): void {

--- a/javascript/packages/highlighter/src/ansi-html.ts
+++ b/javascript/packages/highlighter/src/ansi-html.ts
@@ -18,15 +18,20 @@ interface OpenTag {
 
 export interface ANSIConverterOptions {
   links?: boolean
+  linkResolver?: LinkResolver
 }
+
+export type LinkResolver = (url: string) => string | null
 
 export const ANSI_PALETTE = ONEDARK_ANSI_PALETTE
 
 export class ANSIConverter {
   private readonly links: boolean
+  private readonly linkResolver: LinkResolver | null
 
   constructor(options: ANSIConverterOptions = {}) {
     this.links = options.links ?? true
+    this.linkResolver = options.linkResolver ?? null
   }
 
   toHTML(text: string): string {
@@ -41,9 +46,10 @@ export class ANSIConverter {
       if (group === "") return
 
       const merged = this.mergeAdjacentSpans(group)
+      const target = url !== null && this.links ? this.resolveUrl(url) : null
 
-      if (url !== null && this.links && this.isLinkableUrl(url)) {
-        output += `<a href="${this.escapeHTML(url)}" rel="noopener noreferrer">${merged}</a>`
+      if (target !== null) {
+        output += `<a href="${this.escapeHTML(target)}" rel="noopener noreferrer">${merged}</a>`
       } else {
         output += merged
       }
@@ -108,6 +114,14 @@ export class ANSIConverter {
       .replaceAll(">", "&gt;")
       .replaceAll('"', "&quot;")
       .replaceAll("'", "&#x27;")
+  }
+
+  private resolveUrl(url: string): string | null {
+    const resolved = this.linkResolver === null ? url : this.linkResolver(url)
+
+    if (resolved === null || resolved === "") return null
+
+    return this.isLinkableUrl(resolved) ? resolved : null
   }
 
   private isLinkableUrl(url: string): boolean {

--- a/javascript/packages/highlighter/test/ansi-html.test.ts
+++ b/javascript/packages/highlighter/test/ansi-html.test.ts
@@ -3,6 +3,7 @@ import { readFileSync } from "fs"
 import { describe, it, expect } from "vitest"
 
 import { colors, colorize, hyperlink } from "../src/color.js"
+import { linePrefix } from "../src/gutter.js"
 import { ANSI_PALETTE, ANSIConverter } from "../src/ansi-html.js"
 
 import type { ANSIColorName } from "../src/ansi-html.js"
@@ -286,6 +287,51 @@ describe("ANSIConverter", () => {
       expect(converter.toHTML(hyperlink("rule", "https://herb-tools.dev/linter/rules/erb-no-empty-tags"))).toBe(
         `<a href="https://herb-tools.dev/linter/rules/erb-no-empty-tags" rel="noopener noreferrer">rule</a>`,
       )
+    })
+
+    it("renders a linked gutter line number as an anchor", () => {
+      const html = converter.toHTML(linePrefix(12, true, "brightRed", "file:///app/views/page.html.erb"))
+
+      expect(html).toContain(
+        `<a href="file:///app/views/page.html.erb" rel="noopener noreferrer"><span style="font-weight:700"> 12</span></a>`,
+      )
+    })
+
+    it("rewrites the target through a link resolver", () => {
+      const resolver = new ANSIConverter({
+        linkResolver: url => url.replace("file:///workspace/", "https://github.com/marcoroth/herb/blob/main/"),
+      })
+
+      expect(resolver.toHTML(hyperlink("page.html.erb", "file:///workspace/app/views/page.html.erb"))).toBe(
+        `<a href="https://github.com/marcoroth/herb/blob/main/app/views/page.html.erb" rel="noopener noreferrer">page.html.erb</a>`,
+      )
+    })
+
+    it("passes the original target to the link resolver", () => {
+      const targets: string[] = []
+      const resolver = new ANSIConverter({ linkResolver: url => { targets.push(url); return url } })
+
+      resolver.toHTML(`${hyperlink("file", "file:///app/page.html.erb")}${hyperlink("rule", "https://herb-tools.dev")}`)
+
+      expect(targets).toEqual(["file:///app/page.html.erb", "https://herb-tools.dev"])
+    })
+
+    it("drops the link when the resolver returns null", () => {
+      const resolver = new ANSIConverter({ linkResolver: () => null })
+
+      expect(resolver.toHTML(hyperlink("page.html.erb", "file:///app/views/page.html.erb"))).toBe("page.html.erb")
+    })
+
+    it("still rejects an unsafe target returned by the resolver", () => {
+      const resolver = new ANSIConverter({ linkResolver: () => "javascript:alert(1)" })
+
+      expect(resolver.toHTML(hyperlink("page.html.erb", "file:///app/views/page.html.erb"))).toBe("page.html.erb")
+    })
+
+    it("ignores the resolver when links are disabled", () => {
+      const resolver = new ANSIConverter({ links: false, linkResolver: () => "https://herb-tools.dev" })
+
+      expect(resolver.toHTML(hyperlink("page.html.erb", "file:///app/views/page.html.erb"))).toBe("page.html.erb")
     })
 
     it("accepts a BEL terminator as well as ST", () => {

--- a/javascript/packages/highlighter/test/browser/ansi-element.test.ts
+++ b/javascript/packages/highlighter/test/browser/ansi-element.test.ts
@@ -161,6 +161,39 @@ describe("HerbANSIElement in a browser", () => {
     })
   })
 
+  describe("linkResolver", () => {
+    it("rewrites a file target into a linkable one", () => {
+      const element = mount(`\x1b]8;;file:///workspace/app/views/page.html.erb\x1b\\page.html.erb\x1b]8;;\x1b\\`)
+
+      element.linkResolver = url => url.replace("file:///workspace/", "https://herb-tools.dev/")
+
+      const anchor = shadowOf(element).querySelector("a") as HTMLAnchorElement
+
+      expect(anchor.href).toBe("https://herb-tools.dev/app/views/page.html.erb")
+    })
+
+    it("restores the original target when the resolver is removed", () => {
+      const element = mount(`\x1b]8;;https://herb-tools.dev\x1b\\docs\x1b]8;;\x1b\\`)
+
+      element.linkResolver = () => "https://example.com"
+
+      expect((shadowOf(element).querySelector("a") as HTMLAnchorElement).href).toBe("https://example.com/")
+
+      element.linkResolver = null
+
+      expect((shadowOf(element).querySelector("a") as HTMLAnchorElement).href).toBe("https://herb-tools.dev/")
+    })
+
+    it("drops the anchor when the resolver returns null", () => {
+      const element = mount(`\x1b]8;;https://herb-tools.dev\x1b\\docs\x1b]8;;\x1b\\`)
+
+      element.linkResolver = () => null
+
+      expect(shadowOf(element).querySelector("a")).toBe(null)
+      expect(shadowOf(element).textContent).toBe("docs")
+    })
+  })
+
   describe("reacting to content", () => {
     it("re-renders when the text changes", async () => {
       const element = mount("\x1b[31mfirst\x1b[0m")


### PR DESCRIPTION
`ANSIConverter` copies the OSC 8 target straight into the `href`, which is what you want in a terminal but leaves a `file://` link inert on a page served over http. A browser had no way to influence the target, since the only option was `links: true | false` and `<herb-ansi>` builds its converter internally.

This pull request adds a `linkResolver` that rewrites the target before it becomes an anchor.

```ts
new ANSIConverter({
  linkResolver: url => url.replace("file:///workspace/", "https://github.com/marcoroth/herb/blob/main/"),
})
```

The resolver runs before the scheme allowlist, which is the ordering that makes it useful. A dead `file://` target can become a live `https://` one, and a resolver that returns something unsafe still produces no anchor. Returning `null` drops the link and keeps the styled text, and the resolver is never consulted when `links` is off.