### PR TITLE
Engine: Park a collection's item template on every render

### DIFF
--- a/lib/herb/engine/slot_visitor.rb
+++ b/lib/herb/engine/slot_visitor.rb
@@ -793,8 +793,6 @@ module Herb
           markup,
           @markers.item_close(slot_index)
         ].join
-
-        body.insert(0, erb_code_node(%(#{COVERED}["#{key}"] = true)))
       end
 
       def anchor_attributes(node, content_index = nil)

--- a/test/engine/slots/statics_test.rb
+++ b/test/engine/slots/statics_test.rb
@@ -108,6 +108,28 @@ module Engine
         assert_equal "<!--herb-branch:1:1-->even", parked(template, { "@items" => [1, 3] })
       end
 
+      test "parks a keyed collection's item template even when the collection rendered rows" do
+        template = %(<ul><% @items.each do |item| %><li id="<%= item %>"><%= item %></li><% end %></ul>)
+
+        assert_includes parked(template, { "@items" => ["a", "b"] }), "herb-branch:0:item"
+        assert_includes parked(template, { "@items" => [] }), "herb-branch:0:item"
+      end
+
+      test "parks the item template with its values blanked" do
+        template = %(<ul><% @items.each do |item| %><li id="<%= item %>"><%= item %></li><% end %></ul>)
+        markup = parked(template, { "@items" => ["a", "b"] })
+
+        assert_includes markup, %(<li id="")
+        refute_includes markup, ">a<"
+        refute_includes markup, ">b<"
+      end
+
+      test "parks no item template for an unkeyed collection, which has no addressable items" do
+        template = "<ul><% @items.each do |item| %><li><%= item %></li><% end %></ul>"
+
+        refute_includes render(template, { "@items" => ["a", "b"] }), "herb-branch:0:item"
+      end
+
       test "parks the branches of one conditional and not of another" do
         markup = parked("<% if @a %>a<% end %><% if @b %>b<% end %>", { "@a" => true, "@b" => false })
 


### PR DESCRIPTION
This pull request makes the engine park a keyed collection's item skeleton in the `<template data-herb-region>` on every client-mode render, whether or not the collection rendered any rows.

Previously `park_item` marked the item statics as covered as soon as the first row rendered, so the skeleton only shipped when the collection was empty. A client that wants to build a new row into a non-empty collection had to fall back to cloning its top row, which carries that row's branch state, its client-set attributes, and anything else that happened to it since the render.

With the skeleton always parked, a client-built row starts from a neutral source. This is the foundation for optimistic item insertion, where the client creates a row the server has never rendered and fills its slots itself.

The cost is bounded, one blanked item template per keyed client-mode collection, and only in templates that opted into `herb:slots client`.
