### PR TITLE
Client: Let a template name a slot with `data-herb-name`

### DIFF
--- a/javascript/packages/client/src/slot-index.ts
+++ b/javascript/packages/client/src/slot-index.ts
@@ -30,6 +30,8 @@ const ITEM_STATICS = "item"
 const STATICS_SELECTOR = "template[data-herb-region], template[data-herb-statics]"
 const ANCHOR_ATTRIBUTE = "data-herb-slot"
 const ANCHOR_SELECTOR = `[${ANCHOR_ATTRIBUTE}]`
+const NAME_ATTRIBUTE = "data-herb-name"
+const NAME_ENTRY = /^(\d+):(.+)$/
 
 const DEFAULT_SLOT_TYPE: SlotType = "child"
 
@@ -114,6 +116,7 @@ export interface Region {
   start: Comment | null
   end: Comment | null
   slots: SlotMap
+  names: Map<string, number>
 }
 
 export interface ScanResult {
@@ -197,6 +200,7 @@ export class SlotIndex {
   #regions: Region[] = []
   #seen = new WeakSet<Comment>()
   #anchored = new WeakSet<Element>()
+  #named = new WeakSet<Element>()
   #slotRegions = new WeakMap<Slot, Region>()
   #slotOwners = new WeakMap<Slot, SlotMap>()
   #skeletons = new Map<string, Statics>()
@@ -260,16 +264,43 @@ export class SlotIndex {
     return this.regionsFor(file).find((region) => region.occurrence === occurrence) ?? null
   }
 
-  slot(file: string, index: number, occurrence = 0): Slot | null {
-    return this.region(file, occurrence)?.slots.get(index) ?? null
+  slot(file: string, index: number | string, occurrence = 0): Slot | null {
+    const region = this.region(file, occurrence)
+
+    if (!region) return null
+
+    const resolved = this.#slotIndex(region, index, null)
+
+    return resolved === null ? null : (region.slots.get(resolved) ?? null)
   }
 
-  itemsFor(file: string, index: number, occurrence = 0): ItemMap {
+  itemsFor(file: string, index: number | string, occurrence = 0): ItemMap {
     return this.slot(file, index, occurrence)?.items ?? new Map()
   }
 
-  slotInItem(file: string, collection: number, key: string, index: number, occurrence = 0): Slot | null {
-    return this.itemsFor(file, collection, occurrence).get(key)?.slots.get(index) ?? null
+  slotInItem(file: string, collection: number | string, key: string, index: number | string, occurrence = 0): Slot | null {
+    const region = this.region(file, occurrence)
+    const item = this.itemsFor(file, collection, occurrence).get(key)
+
+    if (!region || !item) return null
+
+    const resolved = this.#slotIndex(region, index, item)
+
+    return resolved === null ? null : (item.slots.get(resolved) ?? null)
+  }
+
+  #slotIndex(region: Region, index: number | string, item: Item | null): number | null {
+    if (typeof index === "number") return index
+
+    const name = region.names.get(index)
+
+    if (name !== undefined) return name
+
+    for (const slot of (item?.slots ?? region.slots).values()) {
+      if (slot.attribute === index) return slot.index
+    }
+
+    return null
   }
 
   rangeFor(slot: Slot): Range {
@@ -856,6 +887,7 @@ export class SlotIndex {
     this.#regions = []
     this.#seen = new WeakSet()
     this.#anchored = new WeakSet()
+    this.#named = new WeakSet()
     this.#skeletons = new Map()
   }
 
@@ -869,6 +901,7 @@ export class SlotIndex {
     for (const marker of this.#markers(root)) {
       if (marker.nodeType === Node.ELEMENT_NODE) {
         this.#anchorSlots(marker as Element, result, state)
+        this.#nameSlot(marker as Element, state)
 
         continue
       }
@@ -903,6 +936,7 @@ export class SlotIndex {
             start: comment,
             end: null,
             slots: new Map(),
+            names: new Map(),
           }
 
           openRegions.push({ region, range })
@@ -1048,6 +1082,20 @@ export class SlotIndex {
     const region = this.#enclosingRegion(element)
 
     return region ? { file: region.file, version: region.version } : null
+  }
+
+  #nameSlot(element: Element, state: ParseState): void {
+    if (this.#named.has(element)) return
+
+    const entry = NAME_ENTRY.exec(element.getAttribute(NAME_ATTRIBUTE) ?? "")
+
+    if (!entry) return
+
+    this.#named.add(element)
+
+    const region = state.openRegions[state.openRegions.length - 1]?.region ?? this.#enclosingRegion(element)
+
+    region?.names.set(entry[2], Number(entry[1]))
   }
 
   #anchorSlots(element: Element, result: ScanResult, state: ParseState): void {
@@ -1210,13 +1258,15 @@ export class SlotIndex {
       return
     }
 
-    if (root.nodeType === Node.ELEMENT_NODE && anchored(root as Element)) {
+    if (root.nodeType === Node.ELEMENT_NODE && (anchored(root as Element) || named(root as Element))) {
       yield root as Element
     }
 
     const walker = document.createTreeWalker(root, NodeFilter.SHOW_COMMENT | NodeFilter.SHOW_ELEMENT, {
       acceptNode: (node) =>
-        (node.nodeType === Node.COMMENT_NODE ? MARKER.test((node as Comment).data.trim()) : anchored(node as Element))
+        (node.nodeType === Node.COMMENT_NODE
+          ? MARKER.test((node as Comment).data.trim())
+          : anchored(node as Element) || named(node as Element))
           ? NodeFilter.FILTER_ACCEPT
           : NodeFilter.FILTER_SKIP,
     })
@@ -1361,6 +1411,10 @@ function closingFor(open: Comment, index: number): Comment | null {
 
 function anchorEntries(element: Element): string[] {
   return element.getAttribute(ANCHOR_ATTRIBUTE)?.split(/\s+/).filter(Boolean) ?? []
+}
+
+function named(element: Element): boolean {
+  return element.hasAttribute(NAME_ATTRIBUTE)
 }
 
 function anchored(element: Element): boolean {

--- a/javascript/packages/client/test/names.test.ts
+++ b/javascript/packages/client/test/names.test.ts
@@ -1,0 +1,63 @@
+import { describe, test, expect, beforeEach } from "vitest"
+import { SlotIndex } from "../src/slot-index"
+
+const FILE = "app/views/posts/index.html.erb"
+
+const PAGE =
+  `<!--herb-region:${FILE}:aaaaaaaa:0-->` +
+  `<ul data-herb-name="0:messages"><!--herb-slot:0:collection-->` +
+  `<!--herb-item:0:a--><li id="a" data-herb-slot="1:attribute:id"><span data-herb-name="2:body" data-herb-slot="2:child">first</span></li><!--/herb-item:0-->` +
+  `<!--herb-item:0:b--><li id="b" data-herb-slot="1:attribute:id"><span data-herb-name="2:body" data-herb-slot="2:child">second</span></li><!--/herb-item:0-->` +
+  `<!--/herb-slot:0--></ul>` +
+  `<p data-herb-name="3:summary"><!--herb-slot:3-->two messages<!--/herb-slot:3--></p>` +
+  `<!--/herb-region:${FILE}-->`
+
+let index: SlotIndex
+
+beforeEach(() => {
+  document.body.innerHTML = PAGE
+
+  index = new SlotIndex()
+  index.scan(document.body)
+})
+
+describe("addressing a slot by name", () => {
+  test("resolves a region-level name to its slot", () => {
+    const slot = index.slot(FILE, "summary")
+
+    expect(slot).not.toBeNull()
+    expect(slot!.index).toBe(3)
+  })
+
+  test("resolves a named collection", () => {
+    const slot = index.slot(FILE, "messages")
+
+    expect(slot?.type).toBe("collection")
+    expect(index.itemsFor(FILE, "messages").size).toBe(2)
+  })
+
+  test("resolves an item's slot per row through the item key", () => {
+    const first = index.slotInItem(FILE, "messages", "a", "body")
+    const second = index.slotInItem(FILE, "messages", "b", "body")
+
+    expect(index.currentText(first!)).toBe("first")
+    expect(index.currentText(second!)).toBe("second")
+    expect(first).not.toBe(second)
+  })
+
+  test("resolves an attribute slot by its attribute name with nothing authored", () => {
+    const slot = index.slotInItem(FILE, "messages", "a", "id")
+
+    expect(slot?.attribute).toBe("id")
+  })
+
+  test("answers null for a name nothing declares", () => {
+    expect(index.slot(FILE, "missing")).toBeNull()
+    expect(index.slotInItem(FILE, "messages", "a", "missing")).toBeNull()
+  })
+
+  test("an index keeps working everywhere a name does", () => {
+    expect(index.slot(FILE, "summary")).toBe(index.slot(FILE, 3))
+    expect(index.slotInItem(FILE, 0, "a", 2)).toBe(index.slotInItem(FILE, "messages", "a", "body"))
+  })
+})

--- a/lib/herb/engine/slot_visitor.rb
+++ b/lib/herb/engine/slot_visitor.rb
@@ -53,6 +53,9 @@ module Herb
       BRANCH_BODY_PROPERTIES = [:statements, :body, :children, :conditions].freeze #: Array[Symbol]
       BRANCH_CONTINUATION_PROPERTIES = [:subsequent, :else_clause, :rescue_clause, :ensure_clause].freeze #: Array[Symbol]
 
+      NAME_ATTRIBUTE = "data-herb-name" #: String
+      NAMEABLE_TYPES = [:child, :collection, :conditional, :block].freeze #: Array[Symbol]
+
       Slot = Data.define(
         :index,      #: Integer
         :type,       #: Symbol
@@ -61,7 +64,8 @@ module Herb
         :location,   #: String?
         :attribute,  #: String?
         :key_source, #: Symbol?
-        :key_expression #: String?
+        :key_expression, #: String?
+        :name #: String?
       )
 
       #: (String) -> bool
@@ -112,6 +116,14 @@ module Herb
         @continuations = continuations.compare_by_identity
         @indices = indices.compare_by_identity
 
+        slot_nodes = [] #: Array[untyped]
+        @slot_nodes = slot_nodes
+        slot_scopes = {} #: Hash[untyped, untyped]
+        @slot_scopes = slot_scopes.compare_by_identity
+        @named_elements = [] #: Array[Hash[Symbol, untyped]]
+        @collection_nodes = [] #: Array[untyped]
+        @container_depth = 0
+
         @in_attribute = false
         @in_open_tag = false
         @displaced = [] #: Array[untyped]
@@ -160,6 +172,7 @@ module Herb
           entry = { index: slot.index, type: slot.type, node_path: slot.node_path }
           entry = entry.merge(attribute: slot.attribute) if slot.attribute
           entry = entry.merge(key_source: slot.key_source) if slot.key_source
+          entry = entry.merge(name: slot.name) if slot.name
           entry
         }
       end
@@ -185,6 +198,7 @@ module Herb
         visit_children_with_paths(node.children)
 
         collapse_invariant_conditionals
+        apply_names
 
         return unless @mark
 
@@ -205,9 +219,16 @@ module Herb
         previous_open_tag = @current_open_tag
         @current_open_tag = node.open_tag
 
+        name_attribute = attributes_for(node).find { |attribute| attribute_name_for(attribute)&.downcase == NAME_ATTRIBUTE }
+        base = @slot_nodes.size
+        base_scope = @collection_nodes.last
+        base_depth = @container_depth
+
         visit(node.open_tag) if node.open_tag
         visit_children_with_paths(node.body)
         visit(node.close_tag) if node.close_tag
+
+        record_named_element(node, name_attribute, base, base_scope, base_depth) if name_attribute
 
         @current_open_tag = previous_open_tag
 
@@ -290,25 +311,33 @@ module Herb
       def visit_erb_iteration_block_node(node)
         record_slot(node, :collection)
 
+        @collection_nodes.push(node)
         visit_branching_node(node)
+        @collection_nodes.pop
       end
 
       def visit_erb_while_node(node)
         record_slot(node, :collection)
 
+        @collection_nodes.push(node)
         visit_branching_node(node)
+        @collection_nodes.pop
       end
 
       def visit_erb_until_node(node)
         record_slot(node, :collection)
 
+        @collection_nodes.push(node)
         visit_branching_node(node)
+        @collection_nodes.pop
       end
 
       def visit_erb_for_node(node)
         record_slot(node, :collection)
 
+        @collection_nodes.push(node)
         visit_branching_node(node)
+        @collection_nodes.pop
       end
 
       private
@@ -324,6 +353,8 @@ module Herb
       end
 
       def visit_branching_node(node)
+        @container_depth += 1
+
         BRANCH_BODY_PROPERTIES.each do |property|
           next unless node.respond_to?(property)
 
@@ -339,6 +370,8 @@ module Herb
           @continuations[child] = true
           visit(child)
         end
+
+        @container_depth -= 1
       end
 
       #: (untyped) -> bool
@@ -403,6 +436,7 @@ module Herb
         resolve = ->(index) { moved.fetch(merged.fetch(index, index)) }
 
         @slots = survivors.each_with_index.map { |old, index| @slots[old].with(index: index) }
+        @slot_nodes = survivors.map { |old| @slot_nodes.fetch(old) }
 
         renumbered = {} #: Hash[untyped, Integer]
         pending = renumbered.compare_by_identity
@@ -446,10 +480,13 @@ module Herb
           location: location_for(node),
           attribute: attribute_name_for(node),
           key_source: key_source,
-          key_expression: key_expression
+          key_expression: key_expression,
+          name: nil
         )
 
         @slots << slot
+        @slot_nodes << node
+        @slot_scopes[node] = [@collection_nodes.last, @container_depth]
         @indices[node] = slot.index
 
         if type == :collection && key_source == :index
@@ -489,6 +526,107 @@ module Herb
         children = node.value&.children || []
 
         children.one? ? :attribute : :attribute_interpolation
+      end
+
+      #: (untyped, untyped, Integer, untyped, Integer) -> void
+      def record_named_element(node, name_attribute, base, base_scope, base_depth)
+        name = static_attribute_value(name_attribute)
+
+        unless name && !name.empty?
+          raise Herb::Engine::CompilationError,
+                "`#{NAME_ATTRIBUTE}` on `<#{node.tag_name&.value}>` must be a static, non-empty value; " \
+                "a slot name is an address, so it cannot be computed"
+        end
+
+        candidates = @slot_nodes[base..].to_a.select { |slot_node|
+          scope, depth = @slot_scopes[slot_node]
+          scope.equal?(base_scope) && depth == base_depth &&
+            NAMEABLE_TYPES.include?(@slots[@indices[slot_node]].type)
+        }
+
+        @named_elements << {
+          node: node,
+          open_tag: node.open_tag,
+          attribute: name_attribute,
+          name: name,
+          candidates: candidates,
+          scope: base_scope,
+        }
+      end
+
+      #: (untyped) -> String?
+      def static_attribute_value(attribute)
+        children = attribute.value&.children || []
+
+        return nil unless children.all?(Herb::AST::LiteralNode)
+
+        children.map { |child| child.content.to_s }.join.strip
+      end
+
+      #: () -> void
+      def apply_names
+        taken = {} #: Hash[untyped, Hash[String, Integer]]
+
+        @named_elements.each { |named| bind_name(named, taken[named[:scope]] ||= {}) }
+      end
+
+      #: (Hash[Symbol, untyped], Hash[String, Integer]) -> void
+      def bind_name(named, scope_names)
+        name = named[:name] #: String
+        index = resolve_named_slot(named)
+
+        if scope_names.key?(name)
+          raise Herb::Engine::CompilationError,
+                "two slots in the same scope are both named `#{name}`; a slot name is an address, so it has to be unique"
+        end
+
+        if attribute_conflict?(name, index, named[:scope])
+          raise Herb::Engine::CompilationError,
+                "the name `#{name}` collides with the `#{name}` attribute slot in the same scope; " \
+                "an attribute slot is already addressable by its attribute"
+        end
+
+        scope_names[name] = index
+        @slots[index] = @slots[index].with(name: name)
+
+        rewrite_name_attribute(named, index) if @mark
+      end
+
+      #: (Hash[Symbol, untyped]) -> Integer
+      def resolve_named_slot(named)
+        name = named[:name]
+        tag = named[:node].tag_name&.value
+        candidates = named[:candidates].map { |slot_node| @indices[slot_node] }.compact.uniq
+
+        if candidates.empty?
+          raise Herb::Engine::CompilationError,
+                "`#{NAME_ATTRIBUTE}=\"#{name}\"` on `<#{tag}>` names no slot; the element holds nothing dynamic"
+        end
+
+        unless candidates.one?
+          raise Herb::Engine::CompilationError,
+                "`#{NAME_ATTRIBUTE}=\"#{name}\"` on `<#{tag}>` is ambiguous between #{candidates.size} slots; " \
+                "wrap the one it should name in its own element"
+        end
+
+        candidates.fetch(0)
+      end
+
+      #: (String, Integer, untyped) -> bool
+      def attribute_conflict?(name, index, scope)
+        @slots.each_with_index.any? { |slot, slot_index|
+          slot.attribute == name && slot_index != index &&
+            @slot_scopes[@slot_nodes[slot_index]]&.fetch(0).equal?(scope)
+        }
+      end
+
+      #: (Hash[Symbol, untyped], Integer) -> void
+      def rewrite_name_attribute(named, index)
+        open_tag = named[:open_tag]
+        return unless open_tag.respond_to?(:children)
+
+        open_tag.children.delete(named[:attribute])
+        open_tag.children << attribute_node(NAME_ATTRIBUTE, "#{index}:#{named[:name]}")
       end
 
       #: (untyped) -> [Symbol, String?]

--- a/sig/herb/engine/slot_visitor.rbs
+++ b/sig/herb/engine/slot_visitor.rbs
@@ -54,6 +54,10 @@ module Herb
 
       BRANCH_CONTINUATION_PROPERTIES: Array[Symbol]
 
+      NAME_ATTRIBUTE: String
+
+      NAMEABLE_TYPES: Array[Symbol]
+
       class Slot < Data
         attr_reader index(): Integer
 
@@ -71,12 +75,14 @@ module Herb
 
         attr_reader key_expression(): String?
 
-        def self.new: (Integer index, Symbol type, Array[Integer] node_path, String? expression, String? location, String? attribute, Symbol? key_source, String? key_expression) -> instance
-                    | (index: Integer, type: Symbol, node_path: Array[Integer], expression: String?, location: String?, attribute: String?, key_source: Symbol?, key_expression: String?) -> instance
+        attr_reader name(): String?
 
-        def self.members: () -> [ :index, :type, :node_path, :expression, :location, :attribute, :key_source, :key_expression ]
+        def self.new: (Integer index, Symbol type, Array[Integer] node_path, String? expression, String? location, String? attribute, Symbol? key_source, String? key_expression, String? name) -> instance
+                    | (index: Integer, type: Symbol, node_path: Array[Integer], expression: String?, location: String?, attribute: String?, key_source: Symbol?, key_expression: String?, name: String?) -> instance
 
-        def members: () -> [ :index, :type, :node_path, :expression, :location, :attribute, :key_source, :key_expression ]
+        def self.members: () -> [ :index, :type, :node_path, :expression, :location, :attribute, :key_source, :key_expression, :name ]
+
+        def members: () -> [ :index, :type, :node_path, :expression, :location, :attribute, :key_source, :key_expression, :name ]
       end
 
       # : (String) -> bool
@@ -177,6 +183,27 @@ module Herb
 
       # : (untyped) -> Symbol
       def attribute_type_for: (untyped) -> Symbol
+
+      # : (untyped, untyped, Integer, untyped, Integer) -> void
+      def record_named_element: (untyped, untyped, Integer, untyped, Integer) -> void
+
+      # : (untyped) -> String?
+      def static_attribute_value: (untyped) -> String?
+
+      # : () -> void
+      def apply_names: () -> void
+
+      # : (Hash[Symbol, untyped], Hash[String, Integer]) -> void
+      def bind_name: (Hash[Symbol, untyped], Hash[String, Integer]) -> void
+
+      # : (Hash[Symbol, untyped]) -> Integer
+      def resolve_named_slot: (Hash[Symbol, untyped]) -> Integer
+
+      # : (String, Integer, untyped) -> bool
+      def attribute_conflict?: (String, Integer, untyped) -> bool
+
+      # : (Hash[Symbol, untyped], Integer) -> void
+      def rewrite_name_attribute: (Hash[Symbol, untyped], Integer) -> void
 
       # : (untyped) -> [Symbol, String?]
       def key_for: (untyped) -> [ Symbol, String? ]

--- a/test/engine/slots/names_test.rb
+++ b/test/engine/slots/names_test.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+require_relative "../../test_helper"
+require_relative "../../snapshot_utils"
+require_relative "../../../lib/herb/engine"
+require_relative "../../../lib/herb/engine/slot_visitor"
+
+module Engine
+  module Slots
+    class NamesTest < Minitest::Spec
+      include SnapshotUtils
+
+      def compile(template)
+        visitor = Herb::Engine::SlotVisitor.new(mode: :client)
+        engine = Herb::Engine.new(template, visitors: [visitor], filename: "app/views/test.html.erb")
+
+        [visitor, engine.src]
+      end
+
+      def slots(template)
+        compile(template).first.slots
+      end
+
+      test "records a name against the slot the element holds" do
+        named = slots(%(<p data-herb-name="body"><%= @body %></p>)).find { |slot| slot.name == "body" }
+
+        assert named
+        assert_equal :child, named.type
+      end
+
+      test "rewrites the attribute to carry the slot index" do
+        visitor, src = compile(%(<p data-herb-name="body"><%= @body %></p>))
+        rendered = evaluate_herb_source(src, { "@body" => "hi" })
+        index = visitor.slots.find { |slot| slot.name == "body" }.index
+
+        assert_includes rendered, %(data-herb-name="#{index}:body")
+        refute_includes rendered, %(data-herb-name="body")
+      end
+
+      test "mixed static text around one slot still resolves" do
+        named = slots(%(<p data-herb-name="greeting">Hello <%= @name %>!</p>)).find { |slot| slot.name == "greeting" }
+
+        assert named
+        assert_equal :child, named.type
+      end
+
+      test "names the collection an element holds" do
+        template = %(<ul data-herb-name="messages"><% @messages.each do |m| %><li id="<%= m %>"><%= m %></li><% end %></ul>)
+        named = slots(template).find { |slot| slot.name == "messages" }
+
+        assert named
+        assert_equal :collection, named.type
+      end
+
+      test "an element with two content slots is ambiguous" do
+        error = assert_raises(Herb::Engine::CompilationError) do
+          compile(%(<p data-herb-name="pair"><%= @first %> and <%= @second %></p>))
+        end
+
+        assert_match(/ambiguous/, error.message)
+        assert_match(/wrap/, error.message)
+      end
+
+      test "an element holding nothing dynamic names no slot" do
+        error = assert_raises(Herb::Engine::CompilationError) do
+          compile(%(<p data-herb-name="static">plain text</p>))
+        end
+
+        assert_match(/names no slot/, error.message)
+      end
+
+      test "a computed name is refused" do
+        error = assert_raises(Herb::Engine::CompilationError) do
+          compile(%(<p data-herb-name="<%= @name %>"><%= @body %></p>))
+        end
+
+        assert_match(/static/, error.message)
+      end
+
+      test "two slots in one scope cannot share a name" do
+        error = assert_raises(Herb::Engine::CompilationError) do
+          compile(%(<p data-herb-name="body"><%= @a %></p><div data-herb-name="body"><%= @b %></div>))
+        end
+
+        assert_match(/unique/, error.message)
+      end
+
+      test "a name may repeat between an item and its region" do
+        template = <<~ERB
+          <p data-herb-name="body"><%= @intro %></p>
+          <ul><% @items.each do |item| %><li id="<%= item %>"><span data-herb-name="body"><%= item %></span></li><% end %></ul>
+        ERB
+
+        named = slots(template).select { |slot| slot.name == "body" }
+
+        assert_equal 2, named.size
+      end
+
+      test "a name colliding with an attribute slot in the same scope is refused" do
+        error = assert_raises(Herb::Engine::CompilationError) do
+          compile(%(<div id="<%= @id %>"><p data-herb-name="id"><%= @body %></p></div>))
+        end
+
+        assert_match(/collides/, error.message)
+      end
+
+      test "a collapsed conditional does not shift the collision check" do
+        template = <<~ERB
+          <% if @a %><b><%= @p %></b><% else %><b><%= @q %></b><% end %>
+          <% for item in @items %>
+            <input sel="<%= item.id %>">
+          <% end %>
+          <div data-herb-name="sel"><%= @y %></div>
+        ERB
+
+        named = slots(template).find { |slot| slot.name == "sel" }
+
+        assert named
+        assert_equal :child, named.type
+      end
+
+      test "a nested container's slots do not confuse the count" do
+        template = %(<div data-herb-name="status"><% if @ok %><b><%= @yes %></b><% else %><%= @no %><% end %></div>)
+        named = slots(template).find { |slot| slot.name == "status" }
+
+        assert named
+        assert_equal :conditional, named.type
+      end
+
+      test "the name is part of the version" do
+        plain = compile(%(<p><%= @body %></p>)).first.version
+        named = compile(%(<p data-herb-name="body"><%= @body %></p>)).first.version
+
+        refute_equal plain, named
+      end
+    end
+  end
+end


### PR DESCRIPTION
This pull request lets a template give a slot a name, so client code can address it without counting slot indices.

```erb
<ul data-herb-name="messages">
  <% @messages.each do |message| %>
    <li id="<%= dom_id(message) %>">
      <p data-herb-name="body">
        <%= message.body %>
      </p>
    </li>
  <% end %>
</ul>
```

The engine reads `data-herb-name` off an element and records the name against the single slot that element holds, content or range, the same way `key_for` already reads `herb-key` and `id`. 

At compile time the attribute is rewritten to `INDEX:name`, so the client never searches the document for a name. An attribute slot needs nothing authored because its attribute already is its name, and it takes part in the same per-scope uniqueness check. An element holding two content slots is a compile error naming the wrap-one-in-a-`span` fix, and a duplicate name within one scope is an error too. Across nesting levels a name may repeat, so an item-scoped `body` beside a region-scoped `body` compiles.

On the client, `SlotIndex#slot` and `SlotIndex#slotInItem` accept a name everywhere they accept an index. The index stays the primitive, a name is resolved to one at the edge, and a template that names nothing is unchanged.

Raw indices are fragile in app code because a template edit renumbers them silently. Names make the item and mutation APIs in the layers above this one readable, `values: { body: input.value }` instead of `values: { 4: input.value }`.
