### PR TITLE
Client: Add, remove and re-key a collection's items

### DIFF
--- a/javascript/packages/client/src/index.ts
+++ b/javascript/packages/client/src/index.ts
@@ -3,6 +3,6 @@ export { SlotIndex, SLOT_EVENT } from "./slot-index"
 export { SlotState, DEPENDENCIES_ATTRIBUTE, DEPENDENCIES_SELECTOR } from "./state"
 
 export type { RuntimeOptions } from "./runtime"
-export type { Slot, SlotType, SlotAnchor, Region, Item, ScanResult, ItemPlan, RenderMode } from "./slot-index"
+export type { Slot, SlotType, SlotAnchor, Region, Item, ScanResult, ItemPlan, RenderMode, ItemValues, AddItemOptions } from "./slot-index"
 export type { SlotEventDetail, SlotOperation, Payload, PayloadSlots, PayloadValue, Branched, Collected, ApplyReport, Deferred, DeferredReason } from "./slot-index"
 export type { StateOptions, StateTransport, StateRequest, StateReport, StateSlot, StateMode, StatePersistence, DependencyMap } from "./state"

--- a/javascript/packages/client/src/slot-index.ts
+++ b/javascript/packages/client/src/slot-index.ts
@@ -58,6 +58,12 @@ export type SlotMap = Map<number, Slot>
 export type ItemMap = Map<string, Item>
 export type FragmentMap = Map<string, DocumentFragment>
 export type SlotValues = Record<number, string>
+export type ItemValues = Record<number | string, string>
+
+export interface AddItemOptions {
+  values?: ItemValues
+  before?: string
+}
 
 export interface StaticsIdentity {
   file: string
@@ -85,6 +91,7 @@ export interface Slot {
 export type SlotOperation =
   | "value"
   | "attribute"
+  | "item-rekeyed"
   | "markup"
   | "branch"
   | "item-added"
@@ -97,6 +104,7 @@ export interface SlotEventDetail {
   index: number
   operation: SlotOperation
   key: string | null
+  previousKey: string | null
   slot: Slot | null
   item: Item | null
 }
@@ -497,16 +505,15 @@ export class SlotIndex {
     return []
   }
 
-  #rowTemplate(slot: Slot): DocumentFragment | null {
+  #rowTemplate(slot: Slot, prefer: "live" | "skeleton" = "live"): DocumentFragment | null {
+    const region = this.#slotRegions.get(slot)
+    const skeleton = region ? this.skeletonFor(region.file, `${slot.index}:${ITEM_STATICS}`) : null
+
+    if (prefer === "skeleton" && skeleton) return skeleton
+
     const [item] = this.#itemsInDocumentOrder(slot)
 
-    if (!item) {
-      const region = this.#slotRegions.get(slot)
-
-      return region ? this.skeletonFor(region.file, `${slot.index}:${ITEM_STATICS}`) : null
-    }
-
-    return this.#rowFragment(item)
+    return item ? this.#rowFragment(item) : skeleton
   }
 
   #rowFragment(item: Item): DocumentFragment {
@@ -533,7 +540,7 @@ export class SlotIndex {
     this.#park(region, `${slot.index}:${ITEM_STATICS}`, this.#rowFragment(item))
   }
 
-  #buildItem(slot: Slot, key: string, template: DocumentFragment): void {
+  #buildItem(slot: Slot, key: string, template: DocumentFragment, anchor?: Node | null, values: SlotValues = {}): void {
     const copy = template.cloneNode(true) as DocumentFragment
 
     for (const marker of this.#markers(copy)) {
@@ -545,10 +552,21 @@ export class SlotIndex {
       if (open) comment.data = `herb-item:${slot.index}:${key}`
     }
 
-    const added = [...copy.childNodes]
-    const anchor = this.#itemsInDocumentOrder(slot)[0]?.start ?? (slot.anchor.kind === "range" ? slot.anchor.end : null)
+    for (const node of [...copy.childNodes]) {
+      if (node.nodeType !== Node.COMMENT_NODE) continue
 
-    if (anchor) anchor.parentNode?.insertBefore(copy, anchor)
+      const branch = BRANCH.exec((node as Comment).data.trim())
+
+      if (branch && branch[2] === ITEM_STATICS) node.remove()
+    }
+
+    fillSlots(copy, values)
+
+    const added = [...copy.childNodes]
+    const target =
+      anchor ?? this.#itemsInDocumentOrder(slot)[0]?.start ?? (slot.anchor.kind === "range" ? slot.anchor.end : null)
+
+    if (target) target.parentNode?.insertBefore(copy, target)
     else return
 
     this.scan(added)
@@ -677,7 +695,7 @@ export class SlotIndex {
     return this.#current(slot) === value
   }
 
-  #announce(slot: Slot | null, operation: SlotOperation, index: number, key: string | null = null, item: Item | null = null): void {
+  #announce(slot: Slot | null, operation: SlotOperation, index: number, key: string | null = null, item: Item | null = null, previousKey: string | null = null): void {
     if (typeof document === "undefined") return
 
     const region = slot ? this.#slotRegions.get(slot) : null
@@ -690,6 +708,7 @@ export class SlotIndex {
           index,
           operation,
           key,
+          previousKey,
           slot,
           item,
         },
@@ -750,6 +769,69 @@ export class SlotIndex {
     this.#announce(slot, "item-updated", slot.index, key, slot.items.get(key) ?? null)
 
     return result
+  }
+
+  addItem(slot: Slot, key: string, options: AddItemOptions = {}): Item | null {
+    if (slot.type !== "collection" || slot.anchor.kind !== "range") return null
+    if (slot.items.has(key)) return null
+
+    const template = this.#rowTemplate(slot, "skeleton")
+
+    if (!template) return null
+
+    const anchor =
+      options.before !== undefined ? (slot.items.get(options.before)?.start ?? slot.anchor.end) : slot.anchor.end
+
+    this.#buildItem(slot, key, template, anchor, this.#itemValues(slot, template, options.values ?? {}))
+
+    return slot.items.get(key) ?? null
+  }
+
+  removeItem(slot: Slot, key: string): boolean {
+    const item = slot.items.get(key)
+
+    if (!item) return false
+
+    this.#dropItem(slot, item)
+
+    return true
+  }
+
+  rekeyItem(slot: Slot, from: string, to: string): boolean {
+    if (from === to || slot.items.has(to)) return false
+
+    const item = slot.items.get(from)
+
+    if (!item) return false
+
+    item.start.data = `herb-item:${slot.index}:${to}`
+    item.key = to
+    slot.items.delete(from)
+    slot.items.set(to, item)
+
+    this.#announce(slot, "item-rekeyed", slot.index, to, item, from)
+
+    return true
+  }
+
+  #itemValues(slot: Slot, template: DocumentFragment, values: ItemValues): SlotValues {
+    const region = this.#slotRegions.get(slot)
+    const names = templateNames(template)
+    const resolved: SlotValues = {}
+
+    for (const [given, value] of Object.entries(values)) {
+      if (/^\d+$/.test(given)) {
+        resolved[Number(given)] = value
+
+        continue
+      }
+
+      const index = names.get(given) ?? region?.names.get(given)
+
+      if (index !== undefined) resolved[index] = value
+    }
+
+    return resolved
   }
 
   setAttribute(slot: Slot, value: string | null, name = slot.attribute): boolean {
@@ -1318,6 +1400,26 @@ function parkedBranches(element: HTMLTemplateElement): FragmentMap {
   }
 
   return branches
+}
+
+function templateNames(template: DocumentFragment): Map<string, number> {
+  const names = new Map<string, number>()
+
+  for (const element of template.querySelectorAll(ANCHOR_SELECTOR)) {
+    for (const entry of anchorEntries(element)) {
+      const [index, , ...name] = entry.split(":")
+
+      if (name.length > 0) names.set(name.join(":"), Number(index))
+    }
+  }
+
+  for (const element of template.querySelectorAll(`[${NAME_ATTRIBUTE}]`)) {
+    const entry = NAME_ENTRY.exec(element.getAttribute(NAME_ATTRIBUTE) ?? "")
+
+    if (entry) names.set(entry[2], Number(entry[1]))
+  }
+
+  return names
 }
 
 function fillSlots(fragment: DocumentFragment, dynamics: SlotValues): void {

--- a/javascript/packages/client/test/items.test.ts
+++ b/javascript/packages/client/test/items.test.ts
@@ -1,0 +1,190 @@
+import { describe, test, expect, beforeEach } from "vitest"
+import { SlotIndex, SLOT_EVENT } from "../src/slot-index"
+import type { SlotEventDetail } from "../src/slot-index"
+
+const FILE = "app/views/posts/index.html.erb"
+
+const ROWS =
+  `<!--herb-region:${FILE}:aaaaaaaa:0-->` +
+  `<ul><!--herb-slot:0:collection-->` +
+  `<!--herb-item:0:a--><li id="a" data-herb-slot="1:attribute:id"><span data-herb-name="2:body" data-herb-slot="2:child">first</span></li><!--/herb-item:0-->` +
+  `<!--herb-item:0:b--><li id="b" data-herb-slot="1:attribute:id"><span data-herb-name="2:body" data-herb-slot="2:child">second</span></li><!--/herb-item:0-->` +
+  `<!--/herb-slot:0--></ul>` +
+  `<!--/herb-region:${FILE}-->`
+
+const EMPTY =
+  `<!--herb-region:${FILE}:aaaaaaaa:0-->` +
+  `<ul><!--herb-slot:0:collection--><!--/herb-slot:0--></ul>` +
+  `<template data-herb-region="${FILE}:aaaaaaaa"><!--herb-branch:0:item-->` +
+  `<!--herb-item:0:--><li id="" data-herb-slot="1:attribute:id"><span data-herb-name="2:body" data-herb-slot="2:child"></span></li><!--/herb-item:0--></template>` +
+  `<!--/herb-region:${FILE}-->`
+
+let index: SlotIndex
+
+function watch(): SlotEventDetail[] {
+  const seen: SlotEventDetail[] = []
+
+  document.addEventListener(SLOT_EVENT, (event) => seen.push((event as CustomEvent<SlotEventDetail>).detail))
+
+  return seen
+}
+
+function keys(): string[] {
+  return [...document.querySelectorAll("#a, #b, li")].map((li) => li.id)
+}
+
+beforeEach(() => {
+  document.body.innerHTML = ROWS
+
+  index = new SlotIndex()
+  index.scan(document.body)
+})
+
+describe("addItem", () => {
+  test("appends at the end of the collection", () => {
+    const collection = index.slot(FILE, 0)!
+    const item = index.addItem(collection, "c", { values: { body: "third", id: "c" } })
+
+    expect(item).not.toBeNull()
+    expect(keys()).toEqual(["a", "b", "c"])
+    expect(index.currentText(index.slotInItem(FILE, 0, "c", "body")!)).toBe("third")
+  })
+
+  test("inserts before a named sibling", () => {
+    const collection = index.slot(FILE, 0)!
+
+    index.addItem(collection, "c", { before: "b", values: { body: "between", id: "c" } })
+
+    expect(keys()).toEqual(["a", "c", "b"])
+  })
+
+  test("builds from the parked skeleton into an empty collection", () => {
+    document.body.innerHTML = EMPTY
+    index = new SlotIndex()
+    index.scan(document.body)
+
+    const collection = index.slot(FILE, 0)!
+    const item = index.addItem(collection, "x", { values: { body: "hello", id: "x" } })
+
+    expect(item).not.toBeNull()
+    expect(index.currentText(index.slotInItem(FILE, 0, "x", "body")!)).toBe("hello")
+    expect(document.querySelector("#x")).not.toBeNull()
+  })
+
+  test("prefers the skeleton over cloning a live row", () => {
+    document.querySelector("#a")!.setAttribute("data-decorated", "yes")
+
+    const parked = document.createElement("template")
+
+    parked.setAttribute("data-herb-statics", "0:item")
+    parked.innerHTML =
+      `<!--herb-item:0:--><li id="" data-herb-slot="1:attribute:id"><span data-herb-name="2:body" data-herb-slot="2:child"></span></li><!--/herb-item:0-->`
+    document.querySelector("ul")!.append(parked)
+    index.scan(parked)
+
+    const collection = index.slot(FILE, 0)!
+
+    index.addItem(collection, "c")
+
+    const added = [...document.querySelectorAll("li")].find((li) => li.id === "")
+
+    expect(added?.hasAttribute("data-decorated")).toBe(false)
+  })
+
+  test("leaves no stray item branch comment in the built row", () => {
+    document.body.innerHTML = EMPTY
+    index = new SlotIndex()
+    index.scan(document.body)
+
+    index.addItem(index.slot(FILE, 0)!, "x")
+
+    const ul = document.querySelector("ul")!
+
+    expect(ul.innerHTML).not.toContain("herb-branch:0:item")
+  })
+
+  test("refuses an existing key and a non-collection slot", () => {
+    const collection = index.slot(FILE, 0)!
+
+    expect(index.addItem(collection, "a")).toBeNull()
+    expect(index.addItem(index.slotInItem(FILE, 0, "a", "body")!, "x")).toBeNull()
+  })
+
+  test("announces item-added", () => {
+    const seen = watch()
+
+    index.addItem(index.slot(FILE, 0)!, "c")
+
+    expect(seen.map((event) => event.operation)).toEqual(["item-added"])
+    expect(seen[0].key).toBe("c")
+  })
+})
+
+describe("rekeyItem", () => {
+  test("preserves node identity", () => {
+    const collection = index.slot(FILE, 0)!
+    const node = document.querySelector("#a")!
+
+    expect(index.rekeyItem(collection, "a", "message_42")).toBe(true)
+    expect(index.itemsFor(FILE, 0).get("message_42")!.start.nextSibling).toBe(node)
+    expect(index.slotInItem(FILE, 0, "message_42", "body")).not.toBeNull()
+    expect(index.itemsFor(FILE, 0).has("a")).toBe(false)
+  })
+
+  test("leaves siblings untouched", () => {
+    const collection = index.slot(FILE, 0)!
+    const sibling = document.querySelector("#b")!
+
+    index.rekeyItem(collection, "a", "z")
+
+    expect(document.querySelector("#b")).toBe(sibling)
+    expect(index.itemsFor(FILE, 0).has("b")).toBe(true)
+  })
+
+  test("survives a rescan", () => {
+    index.rekeyItem(index.slot(FILE, 0)!, "a", "z")
+    index.scan(document.body)
+
+    expect(index.itemsFor(FILE, 0).has("z")).toBe(true)
+    expect(index.itemsFor(FILE, 0).has("a")).toBe(false)
+  })
+
+  test("refuses a taken target and a missing source", () => {
+    const collection = index.slot(FILE, 0)!
+
+    expect(index.rekeyItem(collection, "a", "b")).toBe(false)
+    expect(index.rekeyItem(collection, "missing", "x")).toBe(false)
+    expect(index.rekeyItem(collection, "a", "a")).toBe(false)
+  })
+
+  test("announces item-rekeyed with the previous key", () => {
+    const seen = watch()
+
+    index.rekeyItem(index.slot(FILE, 0)!, "a", "z")
+
+    expect(seen).toHaveLength(1)
+    expect(seen[0].operation).toBe("item-rekeyed")
+    expect(seen[0].key).toBe("z")
+    expect(seen[0].previousKey).toBe("a")
+  })
+})
+
+describe("removeItem", () => {
+  test("removes the row and reports a missing key", () => {
+    const collection = index.slot(FILE, 0)!
+
+    expect(index.removeItem(collection, "a")).toBe(true)
+    expect(document.querySelector("#a")).toBeNull()
+    expect(index.removeItem(collection, "a")).toBe(false)
+  })
+
+  test("parks the last row's shape before deleting it", () => {
+    const collection = index.slot(FILE, 0)!
+
+    index.removeItem(collection, "a")
+    index.removeItem(collection, "b")
+
+    expect(index.addItem(collection, "again", { values: { body: "back" } })).not.toBeNull()
+    expect(index.currentText(index.slotInItem(FILE, 0, "again", "body")!)).toBe("back")
+  })
+})

--- a/javascript/packages/dev-tools/src/slots/flash.ts
+++ b/javascript/packages/dev-tools/src/slots/flash.ts
@@ -8,7 +8,8 @@ const COLORS: Record<SlotOperation, string> = {
   branch: '#f59e0b',
   'item-added': '#10b981',
   'item-removed': '#ef4444',
-  'item-updated': '#0ea5e9'
+  'item-updated': '#0ea5e9',
+  'item-rekeyed': '#14b8a6'
 }
 
 export class SlotFlash {


### PR DESCRIPTION
This pull request adds the item mutation primitives to `SlotIndex`, so a client can change a keyed collection's membership without a server render.

`addItem(slot, key, { values, before })` builds a row from the parked item skeleton, fills its slots through the existing `fillSlots` path, and inserts it directly at its final position, appended at the collection's closing marker by default or before a given key. `values` accepts slot names or indices. `removeItem(slot, key)` drops a row. Both announce themselves on `herb:slot-update` like every other operation.

`rekeyItem(slot, from, to)` renames a row in place by rewriting its item marker comment and re-keying the collection's item map. It touches no DOM structure, so node identity, focus, and running transitions survive. This is the operation an optimistic UI needs when the server confirms a temporary row under its real id, and it announces a new `item-rekeyed` operation carrying `previousKey`.

`#buildItem` also learns an anchor argument. It used to insert new rows in front of the first existing item and rely on a later ordering pass to move them into place, which is the same defect that made the dev tools flash highlight a row at a position it was about to leave. Inserting at the final position removes that pass for appends.
