### PR TITLE
Client: Merge a collection payload instead of replacing it

### DIFF
--- a/javascript/packages/client/src/index.ts
+++ b/javascript/packages/client/src/index.ts
@@ -3,6 +3,6 @@ export { SlotIndex, SLOT_EVENT } from "./slot-index"
 export { SlotState, DEPENDENCIES_ATTRIBUTE, DEPENDENCIES_SELECTOR } from "./state"
 
 export type { RuntimeOptions } from "./runtime"
-export type { Slot, SlotType, SlotAnchor, Region, Item, ScanResult, ItemPlan, RenderMode, ItemValues, AddItemOptions } from "./slot-index"
+export type { Slot, SlotType, SlotAnchor, Region, Item, ScanResult, ItemPlan, RenderMode, ItemValues, AddItemOptions, ApplyOptions } from "./slot-index"
 export type { SlotEventDetail, SlotOperation, Payload, PayloadSlots, PayloadValue, Branched, Collected, ApplyReport, Deferred, DeferredReason } from "./slot-index"
 export type { StateOptions, StateTransport, StateRequest, StateReport, StateSlot, StateMode, StatePersistence, DependencyMap } from "./state"

--- a/javascript/packages/client/src/slot-index.ts
+++ b/javascript/packages/client/src/slot-index.ts
@@ -65,6 +65,10 @@ export interface AddItemOptions {
   before?: string
 }
 
+export interface ApplyOptions {
+  items?: "replace" | "merge"
+}
+
 export interface StaticsIdentity {
   file: string
   version: string
@@ -379,27 +383,27 @@ export class SlotIndex {
     return { added, removed, moved, kept, unchanged: added.length === 0 && removed.length === 0 && moved.length === 0 }
   }
 
-  apply(payload: Payload): ApplyReport {
+  apply(payload: Payload, options: ApplyOptions = {}): ApplyReport {
     const report: ApplyReport = { applied: 0, deferred: [] }
 
-    this.#applyPayload(payload, report)
+    this.#applyPayload(payload, report, options.items ?? "replace")
 
     return report
   }
 
-  #applyPayload(payload: Payload, report: ApplyReport): void {
+  #applyPayload(payload: Payload, report: ApplyReport, mode: "replace" | "merge"): void {
     const region = this.region(payload.template, payload.occurrence)
 
     if (!region) return this.#defer(report, payload, null, "no-region")
     if (region.version !== payload.version) return this.#defer(report, payload, null, "stale-version")
 
-    this.#applySlots(payload, region.slots, payload.slots, report)
+    this.#applySlots(payload, region.slots, payload.slots, report, mode)
   }
 
-  #applySlots(payload: Payload, owner: SlotMap, values: PayloadSlots, report: ApplyReport): void {
+  #applySlots(payload: Payload, owner: SlotMap, values: PayloadSlots, report: ApplyReport, mode: "replace" | "merge"): void {
     for (const [key, value] of Object.entries(values)) {
       if (isPayload(value)) {
-        this.#applyPayload(value, report)
+        this.#applyPayload(value, report, mode)
         continue
       }
 
@@ -425,14 +429,14 @@ export class SlotIndex {
         continue
       }
 
-      if ("items" in value) this.#applyItems(payload, slot, value, report)
-      else this.#applyBranch(payload, slot, value, report)
+      if ("items" in value) this.#applyItems(payload, slot, value, report, mode)
+      else this.#applyBranch(payload, slot, value, report, mode)
     }
   }
 
-  #applyBranch(payload: Payload, slot: Slot, value: Branched, report: ApplyReport): void {
+  #applyBranch(payload: Payload, slot: Slot, value: Branched, report: ApplyReport, mode: "replace" | "merge"): void {
     if (value.branch === slot.branch) {
-      if (value.slots) this.#applySlots(payload, this.#owner(slot), value.slots, report)
+      if (value.slots) this.#applySlots(payload, this.#owner(slot), value.slots, report, mode)
 
       return
     }
@@ -456,19 +460,24 @@ export class SlotIndex {
     report.applied += 1
 
     if (value.slots) {
-      this.#applySlots(payload, this.#owner(slot), value.slots, report)
+      this.#applySlots(payload, this.#owner(slot), value.slots, report, mode)
     }
   }
 
-  #applyItems(payload: Payload, slot: Slot, value: Collected, report: ApplyReport): void {
+  #applyItems(payload: Payload, slot: Slot, value: Collected, report: ApplyReport, mode: "replace" | "merge"): void {
     const wanted = Object.keys(value.items)
-    const plan = this.reconcile(slot, wanted)
 
-    if (!plan.unchanged) {
-      const unbuilt = this.#reconcileItems(slot, wanted, plan)
+    if (mode === "merge") {
+      this.#mergeItems(payload, slot, wanted, report)
+    } else {
+      const plan = this.reconcile(slot, wanted)
 
-      if (unbuilt.length > 0) {
-        this.#defer(report, payload, slot.index, "items", unbuilt)
+      if (!plan.unchanged) {
+        const unbuilt = this.#reconcileItems(slot, wanted, plan)
+
+        if (unbuilt.length > 0) {
+          this.#defer(report, payload, slot.index, "items", unbuilt)
+        }
       }
     }
 
@@ -476,9 +485,26 @@ export class SlotIndex {
       const item = slot.items.get(key)
 
       if (item) {
-        this.#applySlots(payload, item.slots, value.items[key], report)
+        this.#applySlots(payload, item.slots, value.items[key], report, mode)
       }
     }
+  }
+
+  #mergeItems(payload: Payload, slot: Slot, wanted: string[], report: ApplyReport): void {
+    const added = wanted.filter((key) => !slot.items.has(key))
+
+    if (added.length === 0) return
+
+    const template = this.#rowTemplate(slot)
+    const anchor = slot.anchor.kind === "range" ? slot.anchor.end : null
+
+    if (!template || !anchor) {
+      this.#defer(report, payload, slot.index, "items", added)
+
+      return
+    }
+
+    for (const key of added) this.#buildItem(slot, key, template, anchor)
   }
 
   #reconcileItems(slot: Slot, wanted: string[], plan: ItemPlan): string[] {

--- a/javascript/packages/client/test/merge.test.ts
+++ b/javascript/packages/client/test/merge.test.ts
@@ -1,0 +1,111 @@
+import { describe, test, expect, beforeEach } from "vitest"
+import { SlotIndex } from "../src/slot-index"
+import type { Payload } from "../src/slot-index"
+
+const FILE = "app/views/posts/index.html.erb"
+
+const PAGE =
+  `<!--herb-region:${FILE}:aaaaaaaa:0-->` +
+  `<ul><!--herb-slot:0:collection-->` +
+  `<!--herb-item:0:a--><li id="a" data-herb-slot="1:attribute:id"><span data-herb-slot="2:child">first</span></li><!--/herb-item:0-->` +
+  `<!--herb-item:0:b--><li id="b" data-herb-slot="1:attribute:id"><span data-herb-slot="2:child">second</span></li><!--/herb-item:0-->` +
+  `<!--/herb-slot:0--></ul>` +
+  `<!--/herb-region:${FILE}-->`
+
+function payload(items: Record<string, Record<number, string>>): Payload {
+  return { template: FILE, version: "aaaaaaaa", occurrence: 0, slots: { 0: { items } } }
+}
+
+let index: SlotIndex
+
+function ids(): string[] {
+  return [...document.querySelectorAll("li")].map((li) => li.id)
+}
+
+beforeEach(() => {
+  document.body.innerHTML = PAGE
+
+  index = new SlotIndex()
+  index.scan(document.body)
+})
+
+describe("apply with merge", () => {
+  test("keeps the rows the payload omits", () => {
+    const report = index.apply(payload({ c: { 1: "c", 2: "third" } }), { items: "merge" })
+
+    expect(report.deferred).toEqual([])
+    expect(ids()).toEqual(["a", "b", "c"])
+    expect(index.currentText(index.slotInItem(FILE, 0, "c", 2)!)).toBe("third")
+  })
+
+  test("updates a mentioned row in place without moving it", () => {
+    const node = document.querySelector("#a")!
+
+    index.apply(payload({ a: { 2: "rewritten" } }), { items: "merge" })
+
+    expect(ids()).toEqual(["a", "b"])
+    expect(document.querySelector("#a")).toBe(node)
+    expect(index.currentText(index.slotInItem(FILE, 0, "a", 2)!)).toBe("rewritten")
+  })
+
+  test("appends several new rows in payload order", () => {
+    index.apply(payload({ d: { 1: "d", 2: "four" }, c: { 1: "c", 2: "three" } }), { items: "merge" })
+
+    expect(ids()).toEqual(["a", "b", "d", "c"])
+  })
+
+  test("replace still deletes what the payload omits", () => {
+    index.apply(payload({ b: { 2: "only" } }), { items: "replace" })
+
+    expect(ids()).toEqual(["b"])
+  })
+
+  test("replace is the default", () => {
+    index.apply(payload({ b: { 2: "only" } }))
+
+    expect(ids()).toEqual(["b"])
+  })
+
+  test("merge inside a nested payload inherits the mode", () => {
+    const nested: Payload = {
+      template: FILE,
+      version: "aaaaaaaa",
+      occurrence: 0,
+      slots: { 0: { items: { c: { 1: "c", 2: "third" } } } },
+    }
+    const outer: Payload = { template: FILE, version: "aaaaaaaa", occurrence: 0, slots: { 3: nested } }
+
+    index.apply(outer, { items: "merge" })
+
+    expect(ids()).toEqual(["a", "b", "c"])
+  })
+
+  test("defers the adds when nothing can build them", () => {
+    document.body.innerHTML =
+      `<!--herb-region:${FILE}:aaaaaaaa:0-->` +
+      `<ul><!--herb-slot:0:collection--><!--/herb-slot:0--></ul>` +
+      `<!--/herb-region:${FILE}-->`
+    index = new SlotIndex()
+    index.scan(document.body)
+
+    const report = index.apply(payload({ c: { 2: "third" } }), { items: "merge" })
+
+    expect(report.deferred).toEqual([
+      { file: FILE, occurrence: 0, index: 0, reason: "items", keys: ["c"] },
+    ])
+  })
+
+  test("merge after a rekey confirms the row it renamed", () => {
+    const collection = index.slot(FILE, 0)!
+    const node = document.querySelector("#b")!
+
+    index.rekeyItem(collection, "b", "message_42")
+
+    const report = index.apply(payload({ message_42: { 1: "message_42", 2: "stored" } }), { items: "merge" })
+
+    expect(report.deferred).toEqual([])
+    expect(document.querySelector("#message_42")).toBe(node)
+    expect(ids()).toEqual(["a", "message_42"])
+    expect(index.currentText(index.slotInItem(FILE, 0, "message_42", 2)!)).toBe("stored")
+  })
+})


### PR DESCRIPTION
This pull request adds `apply(payload, { items: "merge" })`, so a payload can update the items it names without deleting the ones it does not.

Collection payloads are whole-list today. `#applyItems` removes every key absent from the payload, which is correct for a full re-render but wrong for a confirm that carries only the row it confirms. Applying a one-message payload to a chat would delete the rest of the conversation.

With `items: "merge"` the plan skips removals and orders only the keys present in the payload. The option threads through `#applyPayload`, `#applySlots` and `#applyItems`, and nested payloads inherit it. The default stays `replace` because the caller knows which semantics it meant and the wire format cannot say.