### PR TITLE
Client: Make every slot write reversible

### DIFF
--- a/javascript/packages/client/src/index.ts
+++ b/javascript/packages/client/src/index.ts
@@ -3,6 +3,6 @@ export { SlotIndex, SLOT_EVENT } from "./slot-index"
 export { SlotState, DEPENDENCIES_ATTRIBUTE, DEPENDENCIES_SELECTOR } from "./state"
 
 export type { RuntimeOptions } from "./runtime"
-export type { Slot, SlotType, SlotAnchor, Region, Item, ScanResult, ItemPlan, RenderMode, ItemValues, AddItemOptions, ApplyOptions } from "./slot-index"
+export type { Slot, SlotType, SlotAnchor, Region, Item, ScanResult, ItemPlan, RenderMode, ItemValues, AddItemOptions, ApplyOptions, RevertToken } from "./slot-index"
 export type { SlotEventDetail, SlotOperation, Payload, PayloadSlots, PayloadValue, Branched, Collected, ApplyReport, Deferred, DeferredReason } from "./slot-index"
 export type { StateOptions, StateTransport, StateRequest, StateReport, StateSlot, StateMode, StatePersistence, DependencyMap } from "./state"

--- a/javascript/packages/client/src/slot-index.ts
+++ b/javascript/packages/client/src/slot-index.ts
@@ -28,6 +28,8 @@ const MARKER = /^\/?herb-(region|slot|item|branch):/
 const STATICS_REGION = /^(.*):([0-9a-f]+)$/
 const ITEM_STATICS = "item"
 const STATICS_SELECTOR = "template[data-herb-region], template[data-herb-statics]"
+const MAX_JOURNAL = 50
+
 const ANCHOR_ATTRIBUTE = "data-herb-slot"
 const ANCHOR_SELECTOR = `[${ANCHOR_ATTRIBUTE}]`
 const NAME_ATTRIBUTE = "data-herb-name"
@@ -68,6 +70,17 @@ export interface AddItemOptions {
 export interface ApplyOptions {
   items?: "replace" | "merge"
 }
+
+export type RevertToken = number
+
+interface SlotAddress {
+  region: Region | null
+  collection: number | null
+  key: string | null
+  index: number
+}
+
+type Inverse = () => void
 
 export interface StaticsIdentity {
   file: string
@@ -171,6 +184,7 @@ export interface Deferred {
 export interface ApplyReport {
   applied: number
   deferred: Deferred[]
+  token?: RevertToken
 }
 
 export interface ItemPlan {
@@ -213,6 +227,9 @@ export class SlotIndex {
   #seen = new WeakSet<Comment>()
   #anchored = new WeakSet<Element>()
   #named = new WeakSet<Element>()
+  #journal = new Map<RevertToken, Inverse[]>()
+  #recording: Inverse[] | null = null
+  #nextToken = 1
   #slotRegions = new WeakMap<Slot, Region>()
   #slotOwners = new WeakMap<Slot, SlotMap>()
   #skeletons = new Map<string, Statics>()
@@ -386,9 +403,95 @@ export class SlotIndex {
   apply(payload: Payload, options: ApplyOptions = {}): ApplyReport {
     const report: ApplyReport = { applied: 0, deferred: [] }
 
-    this.#applyPayload(payload, report, options.items ?? "replace")
+    const { token } = this.transaction(() => {
+      this.#applyPayload(payload, report, options.items ?? "replace")
+    })
+
+    if (token !== null) report.token = token
 
     return report
+  }
+
+  transaction<T>(work: () => T): { token: RevertToken | null; result: T } {
+    if (this.#recording) return { token: null, result: work() }
+
+    const inverses: Inverse[] = []
+
+    this.#recording = inverses
+
+    let result: T
+
+    try {
+      result = work()
+    } finally {
+      this.#recording = null
+    }
+
+    if (inverses.length === 0) return { token: null, result }
+
+    const token = this.#nextToken++
+
+    this.#journal.set(token, inverses)
+
+    if (this.#journal.size > MAX_JOURNAL) {
+      const oldest = this.#journal.keys().next().value
+
+      if (oldest !== undefined) this.#journal.delete(oldest)
+    }
+
+    return { token, result }
+  }
+
+  revert(token: RevertToken): boolean {
+    const inverses = this.#journal.get(token)
+
+    if (!inverses) return false
+
+    this.#journal.delete(token)
+
+    for (let position = inverses.length - 1; position >= 0; position -= 1) inverses[position]()
+
+    return true
+  }
+
+  #record(make: () => Inverse): void {
+    if (!this.#recording) return
+
+    this.#recording.push(make())
+  }
+
+  #addressOf(slot: Slot): SlotAddress {
+    const region = this.#slotRegions.get(slot) ?? null
+    const owner = this.#owner(slot)
+    let collection: number | null = null
+    let key: string | null = null
+
+    if (region && owner !== region.slots) {
+      for (const candidate of region.slots.values()) {
+        if (candidate.type !== "collection") continue
+
+        for (const item of candidate.items.values()) {
+          if (item.slots === owner) {
+            collection = candidate.index
+            key = item.key
+            break
+          }
+        }
+
+        if (key !== null) break
+      }
+    }
+
+    return { region, collection, key, index: slot.index }
+  }
+
+  #slotAt(address: SlotAddress): Slot | null {
+    const { region, collection, key, index } = address
+
+    if (!region) return null
+    if (collection === null || key === null) return region.slots.get(index) ?? null
+
+    return region.slots.get(collection)?.items.get(key)?.slots.get(index) ?? null
   }
 
   #applyPayload(payload: Payload, report: ApplyReport, mode: "replace" | "merge"): void {
@@ -454,6 +557,21 @@ export class SlotIndex {
     const built = this.materialize(payload.template, `${slot.index}:${value.branch}`, leaves(value.slots))
 
     if (!built) return this.#defer(report, payload, slot.index, "branch")
+
+    this.#record(() => {
+      const before = this.#current(slot)
+      const beforeBranch = slot.branch
+      const address = this.#addressOf(slot)
+
+      return () => {
+        const live = this.#slotAt(address)
+
+        if (!live) return
+
+        this.update(live, before)
+        live.branch = beforeBranch
+      }
+    })
 
     this.#writeFragment(slot, built)
 
@@ -597,10 +715,47 @@ export class SlotIndex {
 
     this.scan(added)
 
+    this.#record(() => {
+      const address = this.#addressOf(slot)
+
+      return () => {
+        const live = this.#slotAt(address)
+        const built = live?.items.get(key)
+
+        if (live && built) this.#dropItem(live, built)
+      }
+    })
+
     this.#announce(slot, "item-added", slot.index, key, slot.items.get(key) ?? null)
   }
 
   #dropItem(slot: Slot, item: Item): void {
+    this.#record(() => {
+      const keep = document.createRange()
+
+      keep.setStartBefore(item.start)
+      keep.setEndAfter(item.end)
+
+      const fragment = keep.cloneContents()
+      const address = this.#addressOf(slot)
+      const following = this.#itemsInDocumentOrder(slot)
+      const nextKey = following[following.indexOf(item) + 1]?.key ?? null
+
+      return () => {
+        const live = this.#slotAt(address)
+
+        if (!live || live.anchor.kind !== "range" || live.items.has(item.key)) return
+
+        const target = (nextKey !== null ? live.items.get(nextKey)?.start : null) ?? live.anchor.end
+        const copy = fragment.cloneNode(true) as DocumentFragment
+        const added = [...copy.childNodes]
+
+        target.parentNode?.insertBefore(copy, target)
+        this.scan(added)
+        this.#announce(live, "item-added", live.index, item.key, live.items.get(item.key) ?? null)
+      }
+    })
+
     this.#keepItem(slot, item)
     this.#announce(slot, "item-removed", slot.index, item.key, item)
 
@@ -615,6 +770,17 @@ export class SlotIndex {
 
   #order(slot: Slot, keys: string[]): void {
     if (slot.anchor.kind !== "range") return
+
+    this.#record(() => {
+      const before = this.#itemsInDocumentOrder(slot).map((item) => item.key)
+      const address = this.#addressOf(slot)
+
+      return () => {
+        const live = this.#slotAt(address)
+
+        if (live) this.#order(live, before)
+      }
+    })
 
     const end = slot.anchor.end
 
@@ -682,6 +848,17 @@ export class SlotIndex {
     if (slot.anchor.kind === "element") return false
     if (this.currentText(slot) === text) return false
 
+    this.#record(() => {
+      const before = this.#current(slot)
+      const address = this.#addressOf(slot)
+
+      return () => {
+        const live = this.#slotAt(address)
+
+        if (live) this.update(live, before)
+      }
+    })
+
     for (const descendant of this.descendantsOf(slot)) this.#forget(descendant)
 
     slot.children = []
@@ -747,6 +924,17 @@ export class SlotIndex {
       return { regions: [], slots: [] }
     }
 
+    this.#record(() => {
+      const before = this.#current(slot)
+      const address = this.#addressOf(slot)
+
+      return () => {
+        const live = this.#slotAt(address)
+
+        if (live) this.update(live, before)
+      }
+    })
+
     for (const descendant of this.descendantsOf(slot)) this.#forget(descendant)
 
     slot.children = []
@@ -754,11 +942,12 @@ export class SlotIndex {
     if (slot.anchor.kind === "element") {
       const replacement = this.rangeFor(slot).createContextualFragment(html)
       const element = slot.anchor.element
+      const parent = element.parentNode
 
       element.replaceWith(replacement)
       this.#forget(slot)
 
-      return this.scan([...(element.parentNode?.childNodes ?? [])])
+      return this.scan(parent ? [...parent.childNodes] : [])
     }
 
     const range = this.rangeFor(slot)
@@ -780,6 +969,21 @@ export class SlotIndex {
   updateItem(slot: Slot, key: string, html: string): ScanResult | null {
     const item = slot.items.get(key)
     if (!item) return null
+
+    this.#record(() => {
+      const holder = document.createElement("div")
+
+      holder.append(this.rangeForItem(item).cloneContents())
+
+      const before = holder.innerHTML
+      const address = this.#addressOf(slot)
+
+      return () => {
+        const live = this.#slotAt(address)
+
+        if (live) this.updateItem(live, key, before)
+      }
+    })
 
     const range = this.rangeForItem(item)
 
@@ -835,6 +1039,16 @@ export class SlotIndex {
     slot.items.delete(from)
     slot.items.set(to, item)
 
+    this.#record(() => {
+      const address = this.#addressOf(slot)
+
+      return () => {
+        const live = this.#slotAt(address)
+
+        if (live) this.rekeyItem(live, to, from)
+      }
+    })
+
     this.#announce(slot, "item-rekeyed", slot.index, to, item, from)
 
     return true
@@ -864,6 +1078,17 @@ export class SlotIndex {
     if (slot.anchor.kind === "range" || name === null) return false
     if (slot.type === "attribute_interpolation") return false
     if (slot.anchor.element.getAttribute(name) === value) return true
+
+    this.#record(() => {
+      const before = slot.anchor.kind === "range" ? null : slot.anchor.element.getAttribute(name)
+      const address = this.#addressOf(slot)
+
+      return () => {
+        const live = this.#slotAt(address)
+
+        if (live) this.setAttribute(live, before, name)
+      }
+    })
 
     if (value === null) {
       slot.anchor.element.removeAttribute(name)
@@ -932,6 +1157,17 @@ export class SlotIndex {
     const region = this.regionOf(slot)
 
     if (!region) return false
+
+    this.#record(() => {
+      const before = slot.branch
+      const address = this.#addressOf(slot)
+
+      return () => {
+        const live = this.#slotAt(address)
+
+        if (live) this.switchBranch(live, before)
+      }
+    })
 
     this.capture(slot)
 

--- a/javascript/packages/client/test/revert.test.ts
+++ b/javascript/packages/client/test/revert.test.ts
@@ -1,0 +1,200 @@
+import { describe, test, expect, beforeEach } from "vitest"
+import { SlotIndex } from "../src/slot-index"
+import type { Payload } from "../src/slot-index"
+
+const FILE = "app/views/posts/index.html.erb"
+
+const PAGE =
+  `<!--herb-region:${FILE}:aaaaaaaa:0-->` +
+  `<p><!--herb-slot:3--><b>bold</b> text<!--/herb-slot:3--></p>` +
+  `<ul><!--herb-slot:0:collection-->` +
+  `<!--herb-item:0:a--><li id="a" data-herb-slot="1:attribute:id"><span data-herb-slot="2:child">first</span></li><!--/herb-item:0-->` +
+  `<!--herb-item:0:b--><li id="b" data-herb-slot="1:attribute:id"><span data-herb-slot="2:child">second</span></li><!--/herb-item:0-->` +
+  `<!--/herb-slot:0--></ul>` +
+  `<div><!--herb-slot:4:conditional--><!--herb-branch:4:1--><i>shown</i><!--/herb-slot:4--></div>` +
+  `<section data-herb-slot="5:element">original</section>` +
+  `<template data-herb-statics="4:0"><!--herb-branch:4:0--><em>hidden</em></template>` +
+  `<!--/herb-region:${FILE}-->`
+
+let index: SlotIndex
+
+function ids(): string[] {
+  return [...document.querySelectorAll("li")].map((li) => li.id)
+}
+
+beforeEach(() => {
+  document.body.innerHTML = PAGE
+
+  index = new SlotIndex()
+  index.scan(document.body)
+})
+
+describe("transaction and revert", () => {
+  test("reverts an applied branch switch to the previous markup", () => {
+    const report = index.apply({ template: FILE, version: "aaaaaaaa", occurrence: 0, slots: { 4: { branch: 0 } } })
+
+    expect(document.querySelector("div em")?.textContent).toBe("hidden")
+
+    index.revert(report.token!)
+
+    expect(document.querySelector("div i")?.textContent).toBe("shown")
+    expect(index.slot(FILE, 4)!.branch).toBe(1)
+  })
+
+  test("reverts an element slot update through the rescanned parent", () => {
+    const slot = index.slot(FILE, 5)!
+
+    const { token } = index.transaction(() =>
+      index.update(slot, `<section data-herb-slot="5:element">changed</section>`),
+    )
+
+    expect(document.querySelector("section")?.textContent).toBe("changed")
+
+    index.revert(token!)
+
+    expect(document.querySelector("section")?.textContent).toBe("original")
+  })
+
+  test("restores markup rather than flattening it", () => {
+    const slot = index.slot(FILE, 3)!
+
+    const { token } = index.transaction(() => index.setText(slot, "plain"))
+
+    expect(document.querySelector("p b")).toBeNull()
+    expect(index.revert(token!)).toBe(true)
+    expect(document.querySelector("p b")?.textContent).toBe("bold")
+  })
+
+  test("reverts an addItem by removing the row", () => {
+    const collection = index.slot(FILE, 0)!
+
+    const { token } = index.transaction(() => index.addItem(collection, "c", { values: { 2: "third", 1: "c" } }))
+
+    expect(ids()).toEqual(["a", "b", "c"])
+    index.revert(token!)
+    expect(ids()).toEqual(["a", "b"])
+    expect(index.itemsFor(FILE, 0).has("c")).toBe(false)
+  })
+
+  test("reverts a removeItem by rebuilding the row with its values", () => {
+    const collection = index.slot(FILE, 0)!
+
+    const { token } = index.transaction(() => index.removeItem(collection, "a"))
+
+    expect(ids()).toEqual(["b"])
+    index.revert(token!)
+    expect(ids()).toEqual(["a", "b"])
+    expect(index.currentText(index.slotInItem(FILE, 0, "a", 2)!)).toBe("first")
+  })
+
+  test("reverts a rekey back to the old key on the same node", () => {
+    const collection = index.slot(FILE, 0)!
+    const node = document.querySelector("#a")!
+
+    const { token } = index.transaction(() => index.rekeyItem(collection, "a", "z"))
+
+    index.revert(token!)
+
+    expect(index.itemsFor(FILE, 0).has("a")).toBe(true)
+    expect(index.itemsFor(FILE, 0).has("z")).toBe(false)
+    expect(document.querySelector("#a")).toBe(node)
+  })
+
+  test("reverts a branch switch", () => {
+    const slot = index.slot(FILE, 4)!
+
+    const { token } = index.transaction(() => index.switchBranch(slot, 0))
+
+    expect(document.querySelector("em")).not.toBeNull()
+    index.revert(token!)
+    expect(index.slot(FILE, 4)?.branch).toBe(1)
+    expect(document.querySelector("i")?.textContent).toBe("shown")
+  })
+
+  test("reverts an attribute write, including one that was absent", () => {
+    const slot = index.slotInItem(FILE, 0, "a", 1)!
+
+    const { token } = index.transaction(() => {
+      index.setAttribute(slot, "renamed")
+      index.setAttribute(slot, "on", "data-flag")
+    })
+
+    index.revert(token!)
+
+    const li = document.querySelector("li")!
+
+    expect(li.id).toBe("a")
+    expect(li.hasAttribute("data-flag")).toBe(false)
+  })
+
+  test("a transaction reverts as a unit, in reverse order", () => {
+    const collection = index.slot(FILE, 0)!
+    const text = index.slot(FILE, 3)!
+
+    const { token } = index.transaction(() => {
+      index.setText(text, "changed")
+      index.addItem(collection, "c", { values: { 1: "c" } })
+      index.rekeyItem(collection, "c", "d")
+    })
+
+    index.revert(token!)
+
+    expect(document.querySelector("p b")?.textContent).toBe("bold")
+    expect(ids()).toEqual(["a", "b"])
+  })
+
+  test("a nested transaction merges into the outer one", () => {
+    const text = index.slot(FILE, 3)!
+
+    const { token } = index.transaction(() => {
+      const inner = index.transaction(() => index.setText(text, "inner"))
+
+      expect(inner.token).toBeNull()
+    })
+
+    index.revert(token!)
+
+    expect(document.querySelector("p b")?.textContent).toBe("bold")
+  })
+
+  test("apply carries a token that reverts the whole payload", () => {
+    const payload: Payload = {
+      template: FILE,
+      version: "aaaaaaaa",
+      occurrence: 0,
+      slots: { 3: "replaced", 0: { items: { a: { 2: "rewritten" } } } },
+    }
+
+    const report = index.apply(payload, { items: "merge" })
+
+    expect(report.token).toBeDefined()
+    expect(index.revert(report.token!)).toBe(true)
+    expect(document.querySelector("p b")?.textContent).toBe("bold")
+    expect(index.currentText(index.slotInItem(FILE, 0, "a", 2)!)).toBe("first")
+  })
+
+  test("an unchanged transaction yields no token, and a token reverts once", () => {
+    const text = index.slot(FILE, 3)!
+    const empty = index.transaction(() => index.setText(text, index.currentText(text)))
+
+    expect(empty.token).toBeNull()
+
+    const { token } = index.transaction(() => index.setText(text, "changed"))
+
+    expect(index.revert(token!)).toBe(true)
+    expect(index.revert(token!)).toBe(false)
+    expect(index.revert(999)).toBe(false)
+  })
+
+  test("nothing is journalled outside a transaction", () => {
+    const text = index.slot(FILE, 3)!
+
+    index.setText(text, "changed")
+
+    const { token } = index.transaction(() => index.setText(text, "again"))
+
+    index.revert(token!)
+
+    expect(index.currentText(text)).toBe("changed")
+  })
+})


### PR DESCRIPTION
This pull request gives `SlotIndex` a reversal journal, so a batch of writes can be undone as a unit.

Each mutating operation records its inverse. `setText` and `update` capture the previous HTML, `setAttribute` the previous value or its absence, `switchBranch` the previous branch, `addItem` reverses to `removeItem`, and `removeItem` reverses to a rebuild from the blanked clone `#keepItem` already parks plus the values it held. `apply` opens a transaction and its report carries a token, and `revert(token)` replays the inverses in reverse order.

This is what lets a failed optimistic send undo cleanly, the row it added and every slot it touched disappear in one call. It also fixes a real bug in the previous ad-hoc rollback, which snapshotted `currentText` and replayed it through `setText`, flattening a slot that held markup down to text. The journal captures HTML, so `revert` restores what was actually there.

The journal is bounded, so a page that never reverts pays a fixed memory cost.