### PR TITLE
Client: Introduce `herb:state` for client-owned template state

### DIFF
--- a/lib/herb/analysis/ruby_locals_index.rb
+++ b/lib/herb/analysis/ruby_locals_index.rb
@@ -3,6 +3,7 @@
 require "prism"
 
 require_relative "ruby_locals_index/local"
+require_relative "ruby_locals_index/state_locals"
 require_relative "ruby_locals_index/named_reference"
 require_relative "ruby_locals_index/offset_table"
 require_relative "ruby_locals_index/reference_collector"
@@ -32,7 +33,9 @@ module Herb
         references = ReferenceCollector.new(program)
 
         new(
-          strict_locals(document, references, offsets) + block_locals(document, references, offsets),
+          strict_locals(document, references, offsets) +
+            block_locals(document, references, offsets) +
+            StateLocals.locals(document, references, offsets, declarations(document)),
           references.assignments.to_set(&:name)
         )
       end

--- a/lib/herb/analysis/ruby_locals_index/state_locals.rb
+++ b/lib/herb/analysis/ruby_locals_index/state_locals.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require_relative "../../engine/state_directives"
+
+module Herb
+  module Analysis
+    class RubyLocalsIndex
+      # Finds `herb:state` declarations so a state read indexes like a local instead of an
+      # unknown name.
+      module StateLocals
+        module_function
+
+        def locals(document, references, offsets, declared)
+          known = declared.to_h { |name, _location| [name, :seeded] }
+
+          directives(document).flat_map { |node, signature|
+            declarations_in(signature, known).map do |declaration|
+              Local.new(declaration.name, node.location, usages(declaration.name, references, offsets))
+            end
+          }
+        end
+
+        def directives(document)
+          found = [] #: Array[[untyped, String]]
+
+          walk = lambda do |node|
+            signature = Herb::Engine::StateDirectives.signature_of(node)
+
+            found << [node, signature] if signature
+
+            node.child_nodes.each { |child| walk.call(child) if child } if node.respond_to?(:child_nodes)
+          end
+
+          walk.call(document)
+
+          found
+        end
+
+        def declarations_in(signature, known)
+          Herb::Engine::StateDirectives.parse(signature, known)
+        rescue StandardError
+          []
+        end
+
+        def usages(name, references, offsets)
+          references.bare_calls
+                    .select { |call| call.name == name || call.name == "#{name}?" }
+                    .map { |call| offsets.location_for(call) }
+        end
+      end
+    end
+  end
+end

--- a/lib/herb/engine/slot_visitor.rb
+++ b/lib/herb/engine/slot_visitor.rb
@@ -7,6 +7,7 @@ require_relative "../visitor"
 require_relative "context_aware"
 require_relative "slot_markers"
 require_relative "slot_statics"
+require_relative "state_directives"
 
 module Herb
   class Engine
@@ -29,7 +30,7 @@ module Herb
     class SlotVisitor < Herb::Visitor
       include ContextAware
 
-      recommended_parser_option iteration_nodes: true, render_nodes: true
+      recommended_parser_option iteration_nodes: true, render_nodes: true, strict_locals: true
       required_parser_option action_view_helpers: true, track_locations: true
 
       attr_reader :slots #: Array[Slot]
@@ -52,6 +53,10 @@ module Herb
       OPEN_TAG_TYPES = [Herb::AST::HTMLOpenTagNode, Herb::AST::ERBOpenTagNode].freeze #: Array[Herb::AST::HTMLOpenTagNode|Herb::AST::ERBOpenTagNode]
       BRANCH_BODY_PROPERTIES = [:statements, :body, :children, :conditions].freeze #: Array[Symbol]
       BRANCH_CONTINUATION_PROPERTIES = [:subsequent, :else_clause, :rescue_clause, :ensure_clause].freeze #: Array[Symbol]
+
+      STATE_KEYWORDS = {
+        "if" => :if, "elsif" => :elsif, "unless" => :unless, "case" => :case, "when" => :when,
+      }.freeze #: Hash[String, Symbol]
 
       NAME_ATTRIBUTE = "data-herb-name" #: String
       NAMEABLE_TYPES = [:child, :collection, :conditional, :block].freeze #: Array[Symbol]
@@ -121,6 +126,13 @@ module Herb
         slot_scopes = {} #: Hash[untyped, untyped]
         @slot_scopes = slot_scopes.compare_by_identity
         @named_elements = [] #: Array[Hash[Symbol, untyped]]
+        @strict_locals = {} #: Hash[String, Symbol]
+        @region_states = {} #: Hash[String, StateDirectives::Declaration]
+        item_states = {} #: Hash[untyped, Hash[String, StateDirectives::Declaration]]
+        @item_states = item_states.compare_by_identity
+        @state_directives = [] #: Array[Hash[Symbol, untyped]]
+        state_conditionals = {} #: Hash[untyped, Hash[Symbol, untyped]]
+        @state_conditionals = state_conditionals.compare_by_identity
         @collection_nodes = [] #: Array[untyped]
         @container_depth = 0
 
@@ -136,7 +148,48 @@ module Herb
 
       #: () -> String
       def version
-        @version ||= Digest::SHA256.hexdigest(slot_entries.map(&:inspect).join(",")).slice(0, 8).to_s
+        @version ||= Digest::SHA256.hexdigest(
+          (slot_entries.map(&:inspect) + state_entries.map(&:inspect)).join(",")
+        ).slice(0, 8).to_s
+      end
+
+      #: () -> Hash[Symbol, untyped]
+      def state_declarations
+        items = {} #: Hash[Integer, Array[Hash[Symbol, untyped]]]
+
+        @item_states.each do |scope, declarations|
+          index = @indices[scope]
+
+          items[index] = declarations.values.map(&:to_h) if index
+        end
+
+        { region: @region_states.values.map(&:to_h), items: items }
+      end
+
+      #: () -> Array[Hash[Symbol, untyped]]
+      def state_entries
+        declared = state_declarations
+
+        entries = declared[:region].map { |declaration| declaration.merge(scope: :region) }
+
+        declared[:items].sort.each do |index, declarations|
+          entries += declarations.map { |declaration| declaration.merge(scope: index) }
+        end
+
+        entries
+      end
+
+      #: () -> Hash[Integer, Hash[Symbol, untyped]]
+      def state_conditional_entries
+        resolved = {} #: Hash[Integer, Hash[Symbol, untyped]]
+
+        @state_conditionals.each do |node, info|
+          index = @indices[node]
+
+          resolved[index] = info if index
+        end
+
+        resolved
       end
 
       def inspect
@@ -173,6 +226,10 @@ module Herb
           entry = entry.merge(attribute: slot.attribute) if slot.attribute
           entry = entry.merge(key_source: slot.key_source) if slot.key_source
           entry = entry.merge(name: slot.name) if slot.name
+
+          info = state_conditional_entries[slot.index]
+          entry = entry.merge(state_arms: info[:arms], state_else: info[:else]) if info
+
           entry
         }
       end
@@ -199,6 +256,7 @@ module Herb
 
         collapse_invariant_conditionals
         apply_names
+        apply_states
 
         return unless @mark
 
@@ -234,6 +292,17 @@ module Herb
 
         @rcdata_depth -= 1 if rcdata
         @raw_text_depth -= 1 if raw_text
+      end
+
+      def visit_erb_strict_locals_node(node)
+        (node.locals || []).each do |parameter|
+          name = parameter.name&.value.to_s
+          next if name.empty?
+
+          @strict_locals[name] = local_kind(parameter.default_value&.content)
+        end
+
+        super
       end
 
       def visit_html_open_tag_node(node)
@@ -294,6 +363,28 @@ module Herb
         visit_branching_node(node)
       end
 
+      def visit_erb_else_node(node)
+        register_branch_directives(node)
+        super
+      end
+
+      def visit_erb_when_node(node)
+        register_branch_directives(node)
+        super
+      end
+
+      #: (untyped) -> void
+      def register_branch_directives(node)
+        BRANCH_BODY_PROPERTIES.each do |property|
+          next unless node.respond_to?(property)
+
+          body = node.send(property)
+          next unless body.is_a?(Array)
+
+          body.each { |child| register_state_directive(child, body) }
+        end
+      end
+
       def visit_erb_case_node(node)
         record_slot(node, :conditional) unless continuation?(node)
 
@@ -346,6 +437,8 @@ module Herb
         return unless children.is_a?(Array)
 
         children.each_with_index do |child, index|
+          register_state_directive(child, children)
+
           @path.push(index)
           visit(child)
           @path.pop
@@ -526,6 +619,299 @@ module Herb
         children = node.value&.children || []
 
         children.one? ? :attribute : :attribute_interpolation
+      end
+
+      #: (untyped, Array[untyped]) -> void
+      def register_state_directive(node, parent)
+        signature = StateDirectives.signature_of(node)
+
+        return unless signature
+
+        scope = @collection_nodes.last
+        declared = StateDirectives.parse(signature, @strict_locals)
+        empty = {} #: Hash[String, StateDirectives::Declaration]
+        bucket = scope ? (@item_states[scope] ||= empty) : @region_states
+
+        declared.each do |declaration|
+          if @strict_locals.key?(declaration.name)
+            raise Herb::Engine::CompilationError,
+                  "`#{declaration.name}` is both a strict local and a state; a local comes from the caller and a " \
+                  "state is client-owned, so one name cannot be both"
+          end
+
+          if bucket.key?(declaration.name)
+            raise Herb::Engine::CompilationError, "the state `#{declaration.name}` is declared twice in the same scope"
+          end
+
+          shadowed = scope ? @region_states.key?(declaration.name) : @item_states.values.any? { |declarations| declarations.key?(declaration.name) }
+
+          if shadowed
+            raise Herb::Engine::CompilationError,
+                  "the state `#{declaration.name}` is declared in both an item and its region; a later read would " \
+                  "be ambiguous, so pick two names"
+          end
+
+          bucket[declaration.name] = declaration
+        end
+
+        @state_directives << { node: node, parent: parent, scope: scope }
+      end
+
+      #: (String?) -> Symbol
+      def local_kind(source)
+        return :seeded if source.nil? || source.to_s.strip.empty?
+
+        result = Prism.parse(source.to_s.strip)
+
+        return :seeded if result.failure?
+
+        body = result.value.statements.body
+
+        return :seeded unless body.one?
+
+        StateDirectives::KINDS[body.first.class.name] || :seeded
+      end
+
+      #: (untyped) -> Hash[String, StateDirectives::Declaration]
+      def states_for(scope)
+        scope ? @region_states.merge(@item_states[scope] || {}) : @region_states.dup
+      end
+
+      #: () -> void
+      def apply_states
+        @state_directives.each do |directive|
+          parent = directive[:parent]
+          position = parent.index(directive[:node])
+
+          next unless position
+
+          scope = directive[:scope]
+          bucket = scope ? (@item_states[scope] || {}) : @region_states
+          assignments = bucket.values.map { |declaration| state_assignment(declaration) }.join("; ")
+
+          parent[position] = erb_code_node(assignments)
+        end
+
+        return if @region_states.empty? && @item_states.empty?
+
+        classify_state_conditionals
+        check_state_value_reads
+      end
+
+      #: (StateDirectives::Declaration) -> String
+      def state_assignment(declaration)
+        return "#{declaration.name} = !!(#{declaration.default})" if declaration.kind == :boolean
+
+        "#{declaration.name} = #{declaration.default}"
+      end
+
+      #: () -> void
+      def classify_state_conditionals
+        @slot_nodes.each do |node|
+          index = @indices[node]
+
+          next unless index && @slots[index].type == :conditional
+
+          scope, = @slot_scopes[node]
+          states = states_for(scope)
+
+          next if states.empty?
+
+          info = state_conditional_for(node, states)
+
+          @state_conditionals[node] = info if info
+        end
+      end
+
+      #: (untyped, Hash[String, StateDirectives::Declaration]) -> Hash[Symbol, untyped]?
+      def state_conditional_for(node, states)
+        return state_case_for(node, states) if node.is_a?(Herb::AST::ERBCaseNode)
+
+        refuse_state_unless(node, states) if node.is_a?(Herb::AST::ERBUnlessNode)
+
+        return nil unless node.is_a?(Herb::AST::ERBIfNode)
+
+        chain = conditional_chain(node)
+        else_position = chain.index { |arm| arm.is_a?(Herb::AST::ERBElseNode) }
+        conditions = else_position ? chain.take(else_position) : chain
+
+        arms = [] #: Array[[String, String?, Integer]]
+
+        conditions.each_with_index do |arm, branch|
+          expression = condition_expression(arm)
+          read = StateDirectives.condition_read(expression, states)
+
+          if read == :computed
+            raise Herb::Engine::CompilationError,
+                  "`#{expression}` computes with a state; the client cannot evaluate Ruby, so a state is read bare, " \
+                  "as a predicate, or compared to a literal"
+          end
+
+          unless read.is_a?(StateDirectives::Read)
+            return nil if arms.empty?
+
+            raise Herb::Engine::CompilationError,
+                  "`#{expression}` sits in a state-driven conditional but reads no state; the client resolves every " \
+                  "arm, so each one has to read a state"
+          end
+
+          rewrite_predicate(arm, read.name)
+          arms << [read.name, read.comparand, branch]
+        end
+
+        return nil if arms.empty?
+
+        { arms: arms, else: else_position }
+      end
+
+      #: (untyped, Hash[String, StateDirectives::Declaration]) -> void
+      def refuse_state_unless(node, states)
+        expression = condition_expression(node)
+        read = StateDirectives.condition_read(expression, states)
+
+        return if read.nil?
+
+        raise Herb::Engine::CompilationError,
+              "`unless #{expression}` reads a state; spell it as an `if` so the arms map to branches the client can name"
+      end
+
+      #: (untyped) -> Array[untyped]
+      def conditional_chain(node)
+        chain = [] #: Array[untyped]
+        current = node #: untyped
+
+        while current
+          chain << current
+          current = continuation_of(current)
+        end
+
+        chain
+      end
+
+      #: (untyped, Hash[String, StateDirectives::Declaration]) -> Hash[Symbol, untyped]?
+      def state_case_for(node, states)
+        subject_source = condition_expression(node)
+        read = StateDirectives.condition_read(subject_source, states)
+
+        return nil if read.nil?
+
+        unless read.is_a?(StateDirectives::Read) && read.comparand.nil?
+          raise Herb::Engine::CompilationError,
+                "`case #{subject_source}` must switch on a bare state read"
+        end
+
+        rewrite_predicate(node, read.name)
+
+        declaration = states.fetch(read.name)
+        arms = [] #: Array[[String, String?, Integer]]
+
+        node.conditions.each_with_index do |arm, branch|
+          list = condition_expression(arm)
+          comparands = StateDirectives.when_comparands(list, declaration)
+
+          if comparands == :computed
+            raise Herb::Engine::CompilationError,
+                  "`when #{list}` on the state `#{read.name}` has a comparand that is not a literal; the client " \
+                  "resolves a `when` by lookup, so every comparand has to be one"
+          end
+
+          if comparands == :mismatched
+            raise Herb::Engine::CompilationError,
+                  "`when #{list}` compares the #{declaration.kind.to_s.capitalize} state `#{read.name}` against a " \
+                  "literal of another type"
+          end
+
+          next unless comparands.is_a?(Array)
+
+          comparands.each { |comparand| arms << [read.name, comparand, branch] }
+        end
+
+        else_branch = node.else_clause ? node.conditions.size : nil
+
+        { arms: arms, else: else_branch }
+      end
+
+      #: (untyped) -> String
+      def condition_expression(node)
+        source = node.content&.value.to_s.strip
+        keyword = source[/\A[a-z]+/]
+
+        STATE_KEYWORDS.key?(keyword.to_s) ? source.delete_prefix(keyword.to_s).strip : source
+      end
+
+      #: (untyped, String) -> void
+      def rewrite_predicate(node, name)
+        token = predicate_token_for(node)
+
+        return unless token
+
+        token.value.gsub!(/(?<![\w?!])#{Regexp.escape(name)}\?(?![\w?!])/) { name }
+      rescue FrozenError
+        nil
+      end
+
+      #: (untyped) -> untyped
+      def predicate_token_for(node)
+        content = node.content if node.respond_to?(:content)
+
+        return content if content.is_a?(Herb::Token)
+        return nil unless node.respond_to?(:value)
+
+        outputs = (node.value&.children || []).grep(Herb::AST::ERBContentNode)
+
+        outputs.one? ? outputs.fetch(0).content : nil
+      end
+
+      #: (untyped, Hash[String, StateDirectives::Declaration]) -> void
+      def check_interpolated_state_read(node, states)
+        return unless node.respond_to?(:value)
+
+        outputs = (node.value&.children || []).grep(Herb::AST::ERBContentNode)
+        read = outputs.map { |output| output.content&.value.to_s.strip }.find { |expression| StateDirectives.mentions_any?(expression, states) }
+
+        return unless read
+
+        raise Herb::Engine::CompilationError,
+              "`#{read}` reads a state inside an interpolated attribute; a state write cannot rebuild the mixed value, so give the state its own attribute or compute the whole value in one output tag"
+      end
+
+      #: () -> void
+      def check_state_value_reads
+        @slot_nodes.each do |node|
+          index = @indices[node]
+
+          next unless index
+
+          slot = @slots[index]
+
+          next unless [:child, :attribute, :attribute_interpolation, :boolean_attribute, :element, :raw_text].include?(slot.type)
+
+          scope, = @slot_scopes[node]
+          states = states_for(scope)
+
+          next if states.empty?
+
+          if slot.type == :attribute_interpolation
+            check_interpolated_state_read(node, states)
+            next
+          end
+
+          expression = slot.expression.to_s.strip
+          expression = predicate_token_for(node)&.value.to_s.strip if expression.empty?
+
+          next if expression.empty?
+          next unless StateDirectives.mentions_any?(expression, states)
+
+          bare = states.key?(expression) || states.key?(expression.delete_suffix("?"))
+
+          unless bare
+            raise Herb::Engine::CompilationError,
+                  "`#{expression}` computes with a state; the client cannot evaluate Ruby, so a state is read bare " \
+                  "or compared to a literal inside a conditional"
+          end
+
+          rewrite_predicate(node, expression.delete_suffix("?")) if expression.end_with?("?")
+        end
       end
 
       #: (untyped, untyped, Integer, untyped, Integer) -> void
@@ -820,15 +1206,18 @@ module Herb
         return unless slot_index
         return unless @slots[slot_index].type == :conditional
 
+        always = @state_conditionals.key?(node)
+
         branch_bodies(node).each_with_index do |body, branch_index|
           body.unshift(text_node(@markers.branch(slot_index, branch_index)))
 
-          park_branch("#{slot_index}:#{branch_index}", body)
+          park_branch("#{slot_index}:#{branch_index}", body, always: always)
         end
       end
 
       #: (String, Array[untyped]) -> void
-      def park_branch(key, body)
+      #: (String, Array[untyped], ?always: bool) -> void
+      def park_branch(key, body, always: false)
         statics = @statics
         return unless statics
 
@@ -837,7 +1226,7 @@ module Herb
 
         statics[key] = markup
 
-        body.insert(1, erb_code_node(%(#{COVERED}["#{key}"] = true)))
+        body.insert(1, erb_code_node(%(#{COVERED}["#{key}"] = true))) unless always
       end
 
       #: (untyped) -> void

--- a/lib/herb/engine/state_directives.rb
+++ b/lib/herb/engine/state_directives.rb
@@ -1,0 +1,219 @@
+# frozen_string_literal: true
+# typed: true
+
+require "prism"
+
+module Herb
+  class Engine
+    # Parses `<%# herb:state (name: default, …) %>` directives and classifies how the body
+    # reads the states they declare.
+    class StateDirectives
+      PATTERN = /\A-?\s*herb:state\s*(?<signature>\(.*\))\s*-?\z/m #: Regexp
+      BARE = /\A[a-z_][a-zA-Z0-9_]*\z/ #: Regexp
+
+      KINDS = {
+        "Prism::TrueNode" => :boolean,
+        "Prism::FalseNode" => :boolean,
+        "Prism::IntegerNode" => :integer,
+        "Prism::StringNode" => :string,
+        "Prism::SymbolNode" => :symbol,
+        "Prism::NilNode" => :nil,
+      }.freeze #: Hash[String, Symbol]
+
+      Declaration = Data.define(
+        :name,    #: String
+        :kind,    #: Symbol
+        :default  #: String
+      )
+
+      Read = Data.define(
+        :name,      #: String
+        :comparand, #: String?
+        :kind       #: Symbol?
+      )
+
+      class << self
+        #: (untyped) -> String?
+        def signature_of(node)
+          return nil unless node.is_a?(Herb::AST::ERBContentNode)
+          return nil unless node.tag_opening&.value == "<%#"
+
+          PATTERN.match(node.content&.value.to_s.strip)&.[](:signature)
+        end
+
+        #: (String, Hash[String, Symbol]) -> Array[Declaration]
+        def parse(signature, locals)
+          result = Prism.parse("def __herb_states#{signature}; end")
+
+          raise Herb::Engine::CompilationError, "`herb:state #{signature}` does not parse as a keyword signature" if result.failure?
+
+          definition = result.value.statements.body.first
+          parameters = definition.is_a?(Prism::DefNode) ? definition.parameters : nil
+
+          unless parameters && parameters.requireds.empty? && parameters.optionals.empty? && parameters.rest.nil? &&
+                 parameters.posts.empty? && parameters.keyword_rest.nil? && parameters.block.nil? &&
+                 !parameters.keywords.empty?
+            raise Herb::Engine::CompilationError,
+                  "`herb:state #{signature}` must declare keyword parameters with defaults, like `(pending: false)`"
+          end
+
+          parameters.keywords.map { |keyword| declaration_for(keyword, locals) }
+        end
+
+        #: (String, Hash[String, Declaration]) -> (Read | Symbol)?
+        def condition_read(expression, states)
+          source = expression.strip
+          parsed = expression_node(source)
+
+          return mentions_any?(source, states) ? :computed : nil if parsed.nil?
+
+          read = bare_read(parsed, states)
+          return read if read
+
+          equality = equality_read(parsed, states)
+          return equality if equality
+
+          mentions_any?(source, states) ? :computed : nil
+        end
+
+        #: (String, Declaration) -> (Array[String] | Symbol)
+        def when_comparands(list, subject)
+          result = Prism.parse("[#{list}]")
+
+          return :computed if result.failure?
+
+          array = result.value.statements.body.first
+
+          return :computed unless array.is_a?(Prism::ArrayNode)
+
+          array.elements.map { |element|
+            kind = KINDS[element.class.name]
+
+            return :computed unless kind
+            return :mismatched unless kind == subject.kind || kind == :nil
+
+            element.slice
+          }
+        end
+
+        #: (String, Hash[String, Declaration]) -> bool
+        def mentions_any?(source, states)
+          states.each_key.any? { |name| /(?<![\w?])#{Regexp.escape(name)}\??(?![\w?!])/.match?(source) }
+        end
+
+        private
+
+        #: (untyped, Hash[String, Symbol]) -> Declaration
+        def declaration_for(keyword, locals)
+          name = keyword.name.to_s
+
+          unless keyword.is_a?(Prism::OptionalKeywordParameterNode)
+            raise Herb::Engine::CompilationError,
+                  "the state `#{name}` has no default; a state always has a value, since the server renders it"
+          end
+
+          value = keyword.value
+          kind = KINDS[value.class.name]
+
+          return Declaration.new(name: name, kind: kind, default: value.slice) if kind
+
+          case value
+          when Prism::FloatNode
+            raise Herb::Engine::CompilationError,
+                  "the state `#{name}` has a Float default; Ruby and JavaScript disagree on how to print one, so floats are not supported"
+          when Prism::ArrayNode
+            raise Herb::Engine::CompilationError,
+                  "the state `#{name}` has an Array default; a list on the page is a collection of items, and per-row state is an item-scoped boolean"
+          when Prism::HashNode, Prism::KeywordHashNode
+            raise Herb::Engine::CompilationError,
+                  "the state `#{name}` has a Hash default; declare each leaf as its own state, like `#{name}_title`"
+          when Prism::CallNode
+            bare_default(name, value, locals)
+          else
+            Declaration.new(name: name, kind: :seeded, default: value.slice)
+          end
+        end
+
+        #: (String, untyped, Hash[String, Symbol]) -> Declaration
+        def bare_default(name, value, locals)
+          identifier = value.name.to_s
+
+          unless value.receiver.nil? && value.arguments.nil? && value.block.nil? && BARE.match?(identifier)
+            return Declaration.new(name: name, kind: :seeded, default: value.slice)
+          end
+
+          kind = locals[identifier]
+
+          unless kind
+            raise Herb::Engine::CompilationError,
+                  "the state `#{name}` defaults to `#{identifier}`, which is not a declared strict local; " \
+                  "a bare name that was never passed raises at render, so it has to be declared"
+          end
+
+          Declaration.new(name: name, kind: kind, default: identifier)
+        end
+
+        #: (String) -> untyped
+        def expression_node(source)
+          result = Prism.parse(source)
+
+          return nil if result.failure?
+
+          body = result.value.statements.body
+
+          body.one? ? body.first : nil
+        end
+
+        #: (untyped, Hash[String, Declaration]) -> Read?
+        def bare_read(node, states)
+          return nil unless node.is_a?(Prism::CallNode) && node.receiver.nil? && node.arguments.nil? && node.block.nil?
+
+          spelled = node.name.to_s
+          predicate = spelled.end_with?("?")
+          name = predicate ? spelled.delete_suffix("?") : spelled
+          declaration = states[name]
+
+          return nil unless declaration
+
+          if predicate && declaration.kind != :boolean && declaration.kind != :seeded
+            raise Herb::Engine::CompilationError,
+                  "`#{spelled}` reads the #{declaration.kind.to_s.capitalize} state `#{name}` as a predicate; " \
+                  "only a boolean state can be read with a `?`"
+          end
+
+          Read.new(name: name, comparand: nil, kind: declaration.kind)
+        end
+
+        #: (untyped, Hash[String, Declaration]) -> Read?
+        def equality_read(node, states)
+          return nil unless node.is_a?(Prism::CallNode) && node.name == :==
+
+          left = node.receiver
+          right = node.arguments&.arguments&.first
+
+          return nil unless left && right && node.arguments&.arguments&.one?
+
+          read = bare_read(left, states) || bare_read(right, states)
+
+          return nil unless read
+
+          literal = bare_read(left, states) ? right : left
+          kind = KINDS[literal.class.name]
+
+          unless kind
+            raise Herb::Engine::CompilationError,
+                  "`#{node.slice}` compares the state `#{read.name}` against something that is not a literal; " \
+                  "the client resolves a comparison by lookup, so the comparand has to be one"
+          end
+
+          unless kind == read.kind || kind == :nil || read.kind == :seeded
+            raise Herb::Engine::CompilationError,
+                  "`#{node.slice}` compares the #{read.kind.to_s.capitalize} state `#{read.name}` against a #{kind.to_s.capitalize} literal"
+          end
+
+          Read.new(name: read.name, comparand: literal.slice, kind: read.kind)
+        end
+      end
+    end
+  end
+end

--- a/sig/herb/analysis/ruby_locals_index/state_locals.rbs
+++ b/sig/herb/analysis/ruby_locals_index/state_locals.rbs
@@ -1,0 +1,19 @@
+# Generated from lib/herb/analysis/ruby_locals_index/state_locals.rb with RBS::Inline
+
+module Herb
+  module Analysis
+    class RubyLocalsIndex
+      # Finds `herb:state` declarations so a state read indexes like a local instead of an
+      # unknown name.
+      module StateLocals
+        def self?.locals: (untyped document, untyped references, untyped offsets, untyped declared) -> untyped
+
+        def self?.directives: (untyped document) -> untyped
+
+        def self?.declarations_in: (untyped signature, untyped known) -> untyped
+
+        def self?.usages: (untyped name, untyped references, untyped offsets) -> untyped
+      end
+    end
+  end
+end

--- a/sig/herb/engine/slot_visitor.rbs
+++ b/sig/herb/engine/slot_visitor.rbs
@@ -54,6 +54,8 @@ module Herb
 
       BRANCH_CONTINUATION_PROPERTIES: Array[Symbol]
 
+      STATE_KEYWORDS: Hash[String, Symbol]
+
       NAME_ATTRIBUTE: String
 
       NAMEABLE_TYPES: Array[Symbol]
@@ -100,6 +102,15 @@ module Herb
       # : () -> String
       def version: () -> String
 
+      # : () -> Hash[Symbol, untyped]
+      def state_declarations: () -> Hash[Symbol, untyped]
+
+      # : () -> Array[Hash[Symbol, untyped]]
+      def state_entries: () -> Array[Hash[Symbol, untyped]]
+
+      # : () -> Hash[Integer, Hash[Symbol, untyped]]
+      def state_conditional_entries: () -> Hash[Integer, Hash[Symbol, untyped]]
+
       def inspect: () -> untyped
 
       # : () -> String
@@ -124,6 +135,8 @@ module Herb
 
       def visit_html_element_node: (untyped node) -> untyped
 
+      def visit_erb_strict_locals_node: (untyped node) -> untyped
+
       def visit_html_open_tag_node: (untyped node) -> untyped
 
       def visit_html_attribute_node: (untyped node) -> untyped
@@ -141,6 +154,13 @@ module Herb
       def visit_erb_if_node: (untyped node) -> untyped
 
       def visit_erb_unless_node: (untyped node) -> untyped
+
+      def visit_erb_else_node: (untyped node) -> untyped
+
+      def visit_erb_when_node: (untyped node) -> untyped
+
+      # : (untyped) -> void
+      def register_branch_directives: (untyped) -> void
 
       def visit_erb_case_node: (untyped node) -> untyped
 
@@ -183,6 +203,51 @@ module Herb
 
       # : (untyped) -> Symbol
       def attribute_type_for: (untyped) -> Symbol
+
+      # : (untyped, Array[untyped]) -> void
+      def register_state_directive: (untyped, Array[untyped]) -> void
+
+      # : (String?) -> Symbol
+      def local_kind: (String?) -> Symbol
+
+      # : (untyped) -> Hash[String, StateDirectives::Declaration]
+      def states_for: (untyped) -> Hash[String, StateDirectives::Declaration]
+
+      # : () -> void
+      def apply_states: () -> void
+
+      # : (StateDirectives::Declaration) -> String
+      def state_assignment: (StateDirectives::Declaration) -> String
+
+      # : () -> void
+      def classify_state_conditionals: () -> void
+
+      # : (untyped, Hash[String, StateDirectives::Declaration]) -> Hash[Symbol, untyped]?
+      def state_conditional_for: (untyped, Hash[String, StateDirectives::Declaration]) -> Hash[Symbol, untyped]?
+
+      # : (untyped, Hash[String, StateDirectives::Declaration]) -> void
+      def refuse_state_unless: (untyped, Hash[String, StateDirectives::Declaration]) -> void
+
+      # : (untyped) -> Array[untyped]
+      def conditional_chain: (untyped) -> Array[untyped]
+
+      # : (untyped, Hash[String, StateDirectives::Declaration]) -> Hash[Symbol, untyped]?
+      def state_case_for: (untyped, Hash[String, StateDirectives::Declaration]) -> Hash[Symbol, untyped]?
+
+      # : (untyped) -> String
+      def condition_expression: (untyped) -> String
+
+      # : (untyped, String) -> void
+      def rewrite_predicate: (untyped, String) -> void
+
+      # : (untyped) -> untyped
+      def predicate_token_for: (untyped) -> untyped
+
+      # : (untyped, Hash[String, StateDirectives::Declaration]) -> void
+      def check_interpolated_state_read: (untyped, Hash[String, StateDirectives::Declaration]) -> void
+
+      # : () -> void
+      def check_state_value_reads: () -> void
 
       # : (untyped, untyped, Integer, untyped, Integer) -> void
       def record_named_element: (untyped, untyped, Integer, untyped, Integer) -> void
@@ -250,7 +315,9 @@ module Herb
       def mark_branches: (untyped, Integer?) -> void
 
       # : (String, Array[untyped]) -> void
+      # : (String, Array[untyped], ?always: bool) -> void
       def park_branch: (String, Array[untyped]) -> void
+                     | (String, Array[untyped], ?always: bool) -> void
 
       # : (untyped) -> void
       def append_statics: (untyped) -> void

--- a/sig/herb/engine/state_directives.rbs
+++ b/sig/herb/engine/state_directives.rbs
@@ -1,0 +1,75 @@
+# Generated from lib/herb/engine/state_directives.rb with RBS::Inline
+
+module Herb
+  class Engine
+    # Parses `<%# herb:state (name: default, …) %>` directives and classifies how the body
+    # reads the states they declare.
+    class StateDirectives
+      PATTERN: Regexp
+
+      BARE: Regexp
+
+      KINDS: Hash[String, Symbol]
+
+      class Declaration < Data
+        attr_reader name(): String
+
+        attr_reader kind(): Symbol
+
+        attr_reader default(): String
+
+        def self.new: (String name, Symbol kind, String default) -> instance
+                    | (name: String, kind: Symbol, default: String) -> instance
+
+        def self.members: () -> [ :name, :kind, :default ]
+
+        def members: () -> [ :name, :kind, :default ]
+      end
+
+      class Read < Data
+        attr_reader name(): String
+
+        attr_reader comparand(): String?
+
+        attr_reader kind(): Symbol?
+
+        def self.new: (String name, String? comparand, Symbol? kind) -> instance
+                    | (name: String, comparand: String?, kind: Symbol?) -> instance
+
+        def self.members: () -> [ :name, :comparand, :kind ]
+
+        def members: () -> [ :name, :comparand, :kind ]
+      end
+
+      # : (untyped) -> String?
+      def self.signature_of: (untyped) -> String?
+
+      # : (String, Hash[String, Symbol]) -> Array[Declaration]
+      def self.parse: (String, Hash[String, Symbol]) -> Array[Declaration]
+
+      # : (String, Hash[String, Declaration]) -> (Read | Symbol)?
+      def self.condition_read: (String, Hash[String, Declaration]) -> (Read | Symbol)?
+
+      # : (String, Declaration) -> (Array[String] | Symbol)
+      def self.when_comparands: (String, Declaration) -> (Array[String] | Symbol)
+
+      # : (String, Hash[String, Declaration]) -> bool
+      def self.mentions_any?: (String, Hash[String, Declaration]) -> bool
+
+      # : (untyped, Hash[String, Symbol]) -> Declaration
+      private def self.declaration_for: (untyped, Hash[String, Symbol]) -> Declaration
+
+      # : (String, untyped, Hash[String, Symbol]) -> Declaration
+      private def self.bare_default: (String, untyped, Hash[String, Symbol]) -> Declaration
+
+      # : (String) -> untyped
+      private def self.expression_node: (String) -> untyped
+
+      # : (untyped, Hash[String, Declaration]) -> Read?
+      private def self.bare_read: (untyped, Hash[String, Declaration]) -> Read?
+
+      # : (untyped, Hash[String, Declaration]) -> Read?
+      private def self.equality_read: (untyped, Hash[String, Declaration]) -> Read?
+    end
+  end
+end

--- a/test/analysis/ruby_locals_index_test.rb
+++ b/test/analysis/ruby_locals_index_test.rb
@@ -115,4 +115,21 @@ class RubyLocalsIndexTest < Minitest::Spec
     assert_equal 3, local.usages.first.start.line
     assert_equal "title", text_at(source, local.declaration)
   end
+  test "declares herb:state names, so a state read is not an unknown name" do
+    source = "<%# herb:state (pending: false, attempts: 0) %>\n<p><%= attempts %></p>\n<% if pending? %><b>x</b><% end %>\n"
+    index = index_for(source)
+
+    assert_includes index.names, "pending"
+    assert_includes index.names, "attempts"
+    assert_equal 1, index.locals.find { |local| local.name == "attempts" }.usages.size
+    assert_equal 1, index.locals.find { |local| local.name == "pending" }.usages.size
+  end
+
+  test "a state seeded from a strict local indexes both names" do
+    source = "<%# locals: (open_initially: false) %>\n<%# herb:state (open: open_initially) %>\n<div><% if open %>a<% end %></div>\n"
+    index = index_for(source)
+
+    assert_includes index.names, "open_initially"
+    assert_includes index.names, "open"
+  end
 end

--- a/test/engine/slots/states_test.rb
+++ b/test/engine/slots/states_test.rb
@@ -1,0 +1,249 @@
+# frozen_string_literal: true
+
+require_relative "../../test_helper"
+require_relative "../../snapshot_utils"
+require_relative "../../../lib/herb/engine"
+require_relative "../../../lib/herb/engine/slot_visitor"
+
+module Engine
+  module Slots
+    class StatesTest < Minitest::Spec
+      include SnapshotUtils
+
+      def compile(template)
+        visitor = Herb::Engine::SlotVisitor.new(mode: :client)
+        engine = Herb::Engine.new(template, visitors: [visitor], filename: "app/views/test.html.erb")
+
+        [visitor, engine.src]
+      end
+
+      def render(template, locals = {})
+        _, src = compile(template)
+
+        evaluate_herb_source(src, locals)
+      end
+
+      def parked(template, locals = {})
+        render(template, locals)[%r{<template data-herb-region="[^"]+">(.*)</template>}m, 1].to_s
+      end
+
+      STATUS = <<~ERB
+        <%# herb:state (pending: false, failed: false) %>
+        <div><% if pending? %>Sending…<% elsif failed? %>Not sent<% else %>Sent<% end %></div>
+      ERB
+
+      test "renders every state as its default" do
+        rendered = render("<%# herb:state (attempts: 0, draft: \"hi\") %><p><%= attempts %>-<%= draft %></p>")
+
+        assert_includes rendered, ">0<!--/herb-slot:0-->-<!--herb-slot:1-->hi<"
+      end
+
+      test "rendered rows take the else arm while every arm is parked" do
+        rendered = render(STATUS)
+
+        assert_includes rendered, "Sent"
+        refute_includes rendered.sub(/<template.*template>/m, ""), "Sending…"
+
+        markup = parked(STATUS)
+
+        assert_includes markup, "Sending…"
+        assert_includes markup, "Not sent"
+        assert_includes markup, "Sent"
+      end
+
+      test "a default that selects an arm still parks every arm" do
+        template = <<~ERB
+          <%# herb:state (tab: "profile") %>
+          <div><% if tab == "profile" %>Profile<% elsif tab == "settings" %>Settings<% else %>None<% end %></div>
+        ERB
+
+        rendered = render(template)
+
+        assert_includes rendered, "Profile"
+
+        markup = parked(template)
+
+        assert_includes markup, "Settings"
+        assert_includes markup, "None"
+      end
+
+      test "a conditional with no else parks its one arm" do
+        template = %(<%# herb:state (open: false) %><div><% if open? %><nav>menu</nav><% end %></div>)
+
+        assert_includes parked(template), "menu"
+      end
+
+      test "records the arm table in the schema" do
+        visitor, = compile(STATUS)
+        entry = visitor.slot_entries.find { |candidate| candidate[:state_arms] }
+
+        assert_equal [["pending", nil, 0], ["failed", nil, 1]], entry[:state_arms]
+        assert_equal 2, entry[:state_else]
+      end
+
+      test "if with equality and case produce the same arm table" do
+        equality = <<~ERB
+          <%# herb:state (sort: "name") %>
+          <div><% if sort == "name" %>a<% elsif sort == "date" %>b<% else %>c<% end %></div>
+        ERB
+        cased = <<~ERB
+          <%# herb:state (sort: "name") %>
+          <div><% case sort %><% when "name" %>a<% when "date" %>b<% else %>c<% end %></div>
+        ERB
+
+        arms = lambda { |template|
+          visitor, = compile(template)
+          entry = visitor.slot_entries.find { |candidate| candidate[:state_arms] }
+          [entry[:state_arms], entry[:state_else]]
+        }
+
+        assert_equal arms.call(equality), arms.call(cased)
+      end
+
+      test "the declarations are part of the version" do
+        plain = compile("<div><%= @a %></div>").first.version
+        stated = compile("<%# herb:state (open: false) %><div><%= @a %></div>").first.version
+
+        refute_equal plain, stated
+      end
+
+      test "a state read in an item scope declares per item" do
+        template = <<~ERB
+          <ul><% @items.each do |item| %><%# herb:state (selected: false) %><li id="<%= item %>"><% if selected? %>*<% else %>-<% end %></li><% end %></ul>
+        ERB
+
+        visitor, = compile(template)
+
+        assert_equal(["selected"], visitor.state_declarations[:items].values.flatten.map { |declaration| declaration[:name] })
+        assert_includes render(template, { "@items" => ["a"] }), "-"
+      end
+
+      test "a seeded default from a declared strict local compiles and coerces booleans" do
+        template = <<~ERB
+          <%# locals: (open_initially: false) %>
+          <%# herb:state (open: open_initially) %>
+          <div><% if open? %>yes<% else %>no<% end %></div>
+        ERB
+
+        visitor, src = compile(template)
+
+        assert_equal "!!(open_initially)", src[/= (!!\(open_initially\))/, 1]
+        assert_equal :boolean, visitor.state_declarations[:region].first[:kind]
+      end
+
+      test "an ivar default compiles" do
+        visitor, = compile("<%# herb:state (open: @seed) %><div><% if open %>a<% else %>b<% end %></div>")
+
+        assert_equal :seeded, visitor.state_declarations[:region].first[:kind]
+      end
+
+      def refuse(template, pattern)
+        error = assert_raises(Herb::Engine::CompilationError) { compile(template) }
+
+        assert_match(pattern, error.message)
+      end
+
+      test "compile errors" do
+        refuse("<%# herb:state (open:) %><p><%= open %></p>", /no default/)
+        refuse("<%# herb:state (rate: 1.0) %><p><%= rate %></p>", /Float/)
+        refuse("<%# herb:state (selected: []) %><p><%= selected %></p>", /item-scoped boolean/)
+        refuse("<%# herb:state (draft: { title: \"\" }) %><p><%= draft %></p>", /own state/)
+        refuse("<%# herb:state (open: open_initially) %><p><%= open %></p>", /declared strict local/)
+        refuse("<%# locals: (open: false) %>\n<%# herb:state (open: false) %><p><%= open %></p>", /both a strict local and a state/)
+        refuse("<%# herb:state (open: false) %><%# herb:state (open: true) %><p><%= open %></p>", /declared twice/)
+        refuse("<ul><% @items.each do |item| %><%# herb:state (open: false) %><li id=\"<%= item %>\"><%= open %></li><% end %></ul>" \
+               "<%# herb:state (open: false) %>", /declared in both an item and its region/)
+        refuse("<%# herb:state (attempts: 0) %><p><%= attempts + 1 %></p>", /computes with a state/)
+        refuse("<%# herb:state (attempts: 0) %><div><% if attempts > 3 %>a<% else %>b<% end %></div>", /computes with a state/)
+        refuse("<%# herb:state (sort: \"name\") %><div><% if sort == 3 %>a<% end %></div>", /String state `sort` against a Integer/)
+        refuse("<%# herb:state (attempts: 0) %><div><% if attempts? %>a<% end %></div>", /only a boolean state/)
+        refuse("<%# herb:state (open: false) %><div><% unless open? %>a<% end %></div>", /unless/)
+        refuse("<%# herb:state (sort: \"name\") %><div><% case sort %><% when SORTS %>a<% end %></div>", /not a literal/)
+      end
+
+      test "a mixed conditional refuses the arm that reads no state" do
+        refuse(
+          "<%# herb:state (pending: false) %><div><% if pending? %>a<% elsif @admin %>b<% else %>c<% end %></div>",
+          /reads no state/
+        )
+      end
+
+      test "a template with no states compiles exactly as before" do
+        visitor, = compile("<div><% if @a %>a<% else %>b<% end %></div>")
+
+        assert_empty visitor.state_declarations[:region]
+        assert_empty visitor.state_conditional_entries
+      end
+
+      test "a predicate read in a plain attribute rewrites for the server" do
+        rendered = render(%(<%# herb:state (pending: false) %><div class="<%= pending? %>">x</div>))
+
+        assert_includes rendered, 'class="false"'
+      end
+
+      test "a state declared inside an else arm is registered" do
+        rendered = render(%(<% if @a %>x<% else %><%# herb:state (open: false) %><span><%= open %></span><% end %>), { "@a" => false })
+
+        assert_includes rendered, "<span"
+      end
+
+      test "a state declared inside a when arm is registered" do
+        template = %(<% case @x %><% when 1 %><%# herb:state (open: false) %><span><%= open %></span><% end %>)
+        rendered = render(template, { "@x" => 1 })
+
+        assert_includes rendered, "<span"
+      end
+
+      test "a case on a predicate spelling rewrites its subject" do
+        rendered = render(%(<%# herb:state (pending: false) %><div><% case pending? %><% when true %>a<% else %>b<% end %></div>))
+
+        assert_includes rendered, "b"
+      end
+
+      test "a predicate read in a textarea rewrites for the server" do
+        rendered = render(%(<%# herb:state (pending: false) %><textarea><%= pending? %></textarea>))
+
+        assert_includes rendered, "false</textarea>"
+      end
+
+      test "a computed read in a textarea still raises" do
+        error = assert_raises(Herb::Engine::CompilationError) do
+          compile(%(<%# herb:state (draft: "") %><textarea><%= draft.upcase %></textarea>))
+        end
+
+        assert_match(/computes with a state/, error.message)
+      end
+
+      test "a trim-marker state directive still declares" do
+        rendered = render(%(<%#- herb:state (open: false) -%><span><%= open %></span>))
+
+        assert_includes rendered, "<span"
+      end
+
+      test "a state read inside an interpolated attribute is refused" do
+        error = assert_raises(Herb::Engine::CompilationError) do
+          compile(%(<%# herb:state (status: "") %><div class="row-<%= status %>">x</div>))
+        end
+
+        assert_match(/interpolated attribute/, error.message)
+      end
+
+      test "a negated state read in a conditional is refused" do
+        error = assert_raises(Herb::Engine::CompilationError) do
+          compile(%(<%# herb:state (open: false) %><% if !open %>x<% end %>))
+        end
+
+        assert_match(/computes with a state|reads a state/, error.message)
+      end
+
+      test "a keyed collection with item states still parks its skeleton" do
+        template = <<~ERB
+          <ul><% @items.each do |item| %><%# herb:key item %><%# herb:state (locked: true) %><li id="row_<%= item %>"><%= item %></li><% end %></ul>
+        ERB
+
+        assert_includes parked(template, { "@items" => ["a"] }), "herb-branch:0:item"
+        assert_includes parked(template, { "@items" => [] }), "herb-branch:0:item"
+      end
+    end
+  end
+end


### PR DESCRIPTION
This pull request introduces the `herb:state` directive, which declares state the client owns outright and can change without a server round trip.

```erb
<%# herb:state (pending: false, failed: false, attempts: 0) %>

<% if pending? %>
  Sending… <%= attempts %>
<% elsif failed? %>
  Not sent
<% else %>
  Sent
<% end %>
```

The declaration reuses the strict-locals signature syntax. The parser already turns the parenthesised keyword list into `RubyParameterNode`s with names, defaults and locations, so `herb:state` gets Prism-parsed defaults and precise diagnostics for free. Placement carries the scope, a block inside a keyed collection body declares item-scoped state, one per row, and a block at the top of the template declares region-scoped state. The server renders every state as its default, because the server does not have client state.

A state read compiles to an `identity` slot wherever the client can resolve it exactly, a bare value read, a truthiness test, an equality against a literal, or a `case` over literal `when` arms. A conditional whose subject is a declared state is marked client-driven and parks all of its arms unconditionally, skipping the `COVERED` gate, because the client must be able to flip in both directions. The schema records the ordered arm table per conditional, `(state, comparand, branch)` plus the `else` branch, and a boolean state also reads as a `name?` predicate.

The restrictions are the point. A default is required, its type must be `Boolean`, `Integer`, `String`, `Symbol` or `nil`, a bare-identifier default must name a declared strict local so a caller can seed the initial value through `locals:`, a state may not collide with a local or shadow an enclosing state, and a state read inside a larger expression is a compile error because the client has no Ruby evaluator and no server to ask.

`RubyLocalsIndex` learns about the directive through `StateLocals`, so editors do not report every state read as an unknown name.