### PR TITLE
Client: Read and write declared state through the existing fan-out

### DIFF
--- a/javascript/packages/client/package.json
+++ b/javascript/packages/client/package.json
@@ -28,6 +28,11 @@
       "types": "./dist/types/index.d.ts",
       "import": "./dist/herb-client.esm.js",
       "default": "./dist/herb-client.esm.js"
+    },
+    "./stimulus": {
+      "types": "./dist/types/stimulus.d.ts",
+      "import": "./dist/herb-client-stimulus.esm.js",
+      "default": "./dist/herb-client-stimulus.esm.js"
     }
   },
   "dependencies": {},

--- a/javascript/packages/client/rolldown.config.mjs
+++ b/javascript/packages/client/rolldown.config.mjs
@@ -1,11 +1,14 @@
-export default [
-  {
-    input: "src/index.ts",
-    output: {
-      file: "dist/herb-client.esm.js",
-      format: "esm",
-      minify: true,
-    },
-    platform: "browser",
-  }
-]
+export default {
+  input: {
+    "herb-client": "src/index.ts",
+    "herb-client-stimulus": "src/stimulus.ts",
+  },
+  output: {
+    dir: "dist",
+    format: "esm",
+    entryFileNames: "[name].esm.js",
+    chunkFileNames: "herb-client-shared-[hash].esm.js",
+    minify: true,
+  },
+  platform: "browser",
+}

--- a/javascript/packages/client/src/index.ts
+++ b/javascript/packages/client/src/index.ts
@@ -1,8 +1,9 @@
-export { HerbRuntime } from "./runtime"
+export { HerbRuntime, stateFor } from "./runtime"
 export { SlotIndex, SLOT_EVENT } from "./slot-index"
-export { SlotState, DEPENDENCIES_ATTRIBUTE, DEPENDENCIES_SELECTOR } from "./state"
+export { SlotState, DEPENDENCIES_ATTRIBUTE, DEPENDENCIES_SELECTOR, STATE_EVENT } from "./state"
 
-export type { RuntimeOptions } from "./runtime"
+export type { RuntimeOptions, ScopedState } from "./runtime"
 export type { Slot, SlotType, SlotAnchor, Region, Item, ScanResult, ItemPlan, RenderMode, ItemValues, AddItemOptions, ApplyOptions, RevertToken } from "./slot-index"
 export type { SlotEventDetail, SlotOperation, Payload, PayloadSlots, PayloadValue, Branched, Collected, ApplyReport, Deferred, DeferredReason } from "./slot-index"
 export type { StateOptions, StateTransport, StateRequest, StateReport, StateSlot, StateMode, StatePersistence, DependencyMap } from "./state"
+export type { StateKind, StateValue, StateScope, StateManifest, DeclaredState, StateChangeDetail, ScopedSetOptions } from "./state"

--- a/javascript/packages/client/src/runtime.ts
+++ b/javascript/packages/client/src/runtime.ts
@@ -1,7 +1,7 @@
 import { SlotIndex } from "./slot-index"
 import { SlotState } from "./state"
 
-import type { StateOptions } from "./state"
+import type { ScopedSetOptions, StateOptions, StateScope, StateValue } from "./state"
 
 const CONSTRUCT = Symbol("HerbRuntime.start")
 
@@ -50,5 +50,44 @@ export class HerbRuntime {
     if (instance === this) {
       instance = null
     }
+  }
+}
+
+
+export interface ScopedState {
+  scope: StateScope | null
+  get(name: string): StateValue
+  set(values: Record<string, StateValue>): boolean
+  toggle(name: string): boolean
+  increment(name: string, by?: number): boolean
+  decrement(name: string, by?: number): boolean
+  reset(name: string): boolean
+  on(name: string, listener: (value: StateValue, previous: StateValue) => void): () => void
+}
+
+export function stateFor(element: Element): ScopedState {
+  const runtime = HerbRuntime.get()
+
+  const resolve = (name: string): ScopedSetOptions => {
+    const scope = runtime?.state.scopeFor(element, name)
+
+    return scope ? { scope } : {}
+  }
+
+  return {
+    get scope() {
+      return runtime?.state.scopeFor(element) ?? null
+    },
+    get: (name) => runtime?.state.getState(name, resolve(name)) ?? null,
+    set: (values) => {
+      const first = Object.keys(values)[0]
+
+      return first ? (runtime?.state.setState(values, resolve(first)) ?? false) : false
+    },
+    toggle: (name) => runtime?.state.toggle(name, resolve(name)) ?? false,
+    increment: (name, by) => runtime?.state.increment(name, { ...resolve(name), by }) ?? false,
+    decrement: (name, by) => runtime?.state.decrement(name, { ...resolve(name), by }) ?? false,
+    reset: (name) => runtime?.state.reset(name, resolve(name)) ?? false,
+    on: (name, listener) => runtime?.state.on(name, listener, resolve(name)) ?? (() => {}),
   }
 }

--- a/javascript/packages/client/src/state.ts
+++ b/javascript/packages/client/src/state.ts
@@ -1,13 +1,49 @@
 import { SLOT_EVENT } from "./slot-index"
 
-import type { ApplyReport, Payload, Slot, SlotEventDetail, SlotIndex } from "./slot-index"
+import type { ApplyReport, Item, Payload, Region, Slot, SlotEventDetail, SlotIndex } from "./slot-index"
 
 const VALUE_ELEMENTS = ["INPUT", "TEXTAREA", "SELECT"]
 
 export const DEPENDENCIES_ATTRIBUTE = "data-herb-dependencies"
 export const DEPENDENCIES_SELECTOR = `template[${DEPENDENCIES_ATTRIBUTE}]`
 
+export const STATE_EVENT = "herb:state-change"
+
 export type StateMode = "identity" | "structural" | "derived"
+export type StateKind = "boolean" | "integer" | "string" | "symbol" | "nil" | "seeded"
+export type StateValue = string | number | boolean | null
+
+export interface DeclaredState {
+  name: string
+  kind: StateKind
+  default: string
+  scope: "region" | number
+}
+
+export interface StateManifest {
+  version: string
+  declarations: DeclaredState[]
+  reads: Record<string, number[]>
+  conditionals: Record<string, { arms: [string, string | null, number][]; else: number | null }>
+}
+
+export interface StateScope {
+  region: Region
+  item: Item | null
+}
+
+export interface StateChangeDetail {
+  name: string
+  value: StateValue
+  previous: StateValue
+  file: string
+  occurrence: number
+  key: string | null
+}
+
+export interface ScopedSetOptions {
+  scope?: StateScope | Element
+}
 export type StatePersistence = "url" | "known" | "none"
 
 export interface StateSlot {
@@ -20,6 +56,7 @@ export interface StateSlot {
 export interface DependencyMap {
   state: Record<string, StateSlot[]>
   params?: Record<string, string>
+  states?: Record<string, StateManifest>
 }
 
 export interface StateRequest {
@@ -55,6 +92,9 @@ export class SlotState {
   readonly #values = new Map<string, string>()
   readonly #dependencies = new Map<string, StateSlot[]>()
   readonly #params = new Map<string, string>()
+  readonly #declared = new Map<string, StateManifest>()
+  readonly #scoped = new Map<Region, Map<string, Map<string, StateValue>>>()
+  readonly #seeds = new Map<Region, Map<string, Map<string, StateValue>>>()
   readonly #sequence = new Map<string, number>()
   readonly #options: Required<Omit<StateOptions, "transport">> & { transport: StateTransport }
 
@@ -115,6 +155,8 @@ export class SlotState {
   }
 
   adopt(root: ParentNode = document): number {
+    if (typeof document !== "undefined") document.addEventListener(SLOT_EVENT, this.#migrateItemState)
+
     const templates = [...root.querySelectorAll<HTMLTemplateElement>(DEPENDENCIES_SELECTOR)]
 
     for (const template of templates) {
@@ -129,6 +171,7 @@ export class SlotState {
     if (typeof document === "undefined") return
 
     document.addEventListener(SLOT_EVENT, this.#syncProperty)
+    document.addEventListener(SLOT_EVENT, this.#migrateItemState)
 
     if (typeof window !== "undefined" && this.#persisted()) {
       window.addEventListener("popstate", this.#onPopState)
@@ -158,6 +201,7 @@ export class SlotState {
     if (typeof document === "undefined") return
 
     document.removeEventListener(SLOT_EVENT, this.#syncProperty)
+    document.removeEventListener(SLOT_EVENT, this.#migrateItemState)
 
     if (typeof window !== "undefined") {
       window.removeEventListener("popstate", this.#onPopState)
@@ -208,16 +252,19 @@ export class SlotState {
     const transient = [...this.#values.keys()].filter((name) => this.#transient(name))
 
     this.#controller?.abort()
-    this.#controller = new AbortController()
+    const controller = new AbortController()
+    this.#controller = controller
 
     let payload: Payload | null = null
 
     try {
-      payload = await this.#options.transport({ state: this.all(), changed }, this.#controller.signal)
+      payload = await this.#options.transport({ state: this.all(), changed }, controller.signal)
     } catch (error) {
       this.#forget(transient)
 
-      if (this.#superseded(taken)) return this.#settle({ ...IDLE, written: restores.length, stale: true })
+      if (controller.signal.aborted || this.#superseded(taken)) {
+        return this.#settle({ ...IDLE, written: restores.length, stale: true })
+      }
 
       this.#restore(restores)
 
@@ -322,6 +369,342 @@ export class SlotState {
     for (const [request, name] of Object.entries(map.params ?? {})) {
       this.#params.set(request, name)
     }
+
+    for (const [file, manifest] of Object.entries(map.states ?? {})) {
+      this.#declared.set(file, manifest)
+    }
+  }
+
+  manifestFor(region: Region): StateManifest | null {
+    const manifest = this.#declared.get(region.file)
+
+    if (!manifest || manifest.version !== region.version) return null
+
+    return manifest
+  }
+
+  scopeFor(target: Element | StateScope, name?: string): StateScope | null {
+    if (!(target instanceof Element)) return target
+
+    for (const region of this.#slots.regions()) {
+      if (!containsNode(region, target)) continue
+
+      const manifest = this.manifestFor(region)
+
+      if (!manifest) continue
+
+      const item = enclosingItem(region, target)
+
+      if (item && (!name || declared(manifest, name, item.collection) !== null)) {
+        return { region, item: item.item }
+      }
+
+      if (!name || declared(manifest, name, null) !== null) return { region, item: null }
+    }
+
+    return null
+  }
+
+  declaredStates(scope: StateScope): DeclaredState[] {
+    const manifest = this.manifestFor(scope.region)
+
+    if (!manifest) return []
+
+    const collection = scope.item ? collectionOf(scope.region, scope.item) : null
+
+    return manifest.declarations.filter((declaration) =>
+      declaration.scope === "region" || (collection !== null && declaration.scope === collection),
+    )
+  }
+
+  getState(name: string, options: ScopedSetOptions = {}): StateValue {
+    const resolved = this.#scope(options.scope, name)
+
+    if (!resolved) return null
+
+    return this.#valueOf(name, resolved)
+  }
+
+  setState(values: Record<string, StateValue>, options: ScopedSetOptions = {}): boolean {
+    const names = Object.keys(values)
+
+    if (names.length === 0) return false
+
+    const resolved = this.#scope(options.scope, names[0])
+
+    if (!resolved) return false
+
+    const manifest = this.manifestFor(resolved.region)
+
+    if (!manifest) return false
+
+    const previous = new Map<string, StateValue>()
+
+    for (const name of names) {
+      if (this.#declaration(manifest, resolved, name) === null) return false
+
+      previous.set(name, this.#valueOf(name, resolved))
+    }
+
+    this.#slots.transaction(() => {
+      for (const [name, value] of Object.entries(values)) {
+        this.#store(resolved, name, value)
+        this.#writeValueSlots(manifest, resolved, name, value)
+      }
+
+      this.#writeConditionals(manifest, resolved, names)
+    })
+
+    for (const [name, value] of Object.entries(values)) {
+      this.#announceState(resolved, name, value, previous.get(name) ?? null)
+    }
+
+    return true
+  }
+
+  toggle(name: string, options: ScopedSetOptions = {}): boolean {
+    this.#requireKind(name, options, "boolean", "toggle")
+
+    const current = this.getState(name, options)
+
+    return this.setState({ [name]: current !== true }, options)
+  }
+
+  increment(name: string, options: ScopedSetOptions & { by?: number } = {}): boolean {
+    this.#requireKind(name, options, "integer", "increment")
+
+    const current = this.getState(name, options)
+    const base = typeof current === "number" ? current : 0
+
+    return this.setState({ [name]: base + (options.by ?? 1) }, options)
+  }
+
+  decrement(name: string, options: ScopedSetOptions & { by?: number } = {}): boolean {
+    return this.increment(name, { ...options, by: -(options.by ?? 1) })
+  }
+
+  reset(name: string, options: ScopedSetOptions = {}): boolean {
+    const resolved = this.#scope(options.scope, name)
+
+    if (!resolved) return false
+
+    const seeded = this.#seeds.get(resolved.region)?.get(resolved.item?.key ?? "")?.get(name)
+
+    return this.setState({ [name]: seeded ?? this.#defaultOf(name, resolved) }, options)
+  }
+
+  on(name: string, listener: (value: StateValue, previous: StateValue) => void, options: ScopedSetOptions = {}): () => void {
+    const scope = options.scope ? this.#scope(options.scope, name) : null
+
+    const handler = (event: Event): void => {
+      const detail = (event as CustomEvent<StateChangeDetail>).detail
+
+      if (detail.name !== name) return
+
+      if (scope) {
+        if (detail.file !== scope.region.file || detail.occurrence !== scope.region.occurrence) return
+        if ((scope.item?.key ?? null) !== detail.key) return
+      }
+
+      listener(detail.value, detail.previous)
+    }
+
+    document.addEventListener(STATE_EVENT, handler)
+
+    return () => document.removeEventListener(STATE_EVENT, handler)
+  }
+
+  #scope(scope: StateScope | Element | undefined, name: string): StateScope | null {
+    if (scope) return this.scopeFor(scope, name)
+
+    for (const region of this.#slots.regions()) {
+      const manifest = this.manifestFor(region)
+
+      if (manifest && declared(manifest, name, null) !== null) return { region, item: null }
+    }
+
+    return null
+  }
+
+  #declaration(manifest: StateManifest, scope: StateScope, name: string): DeclaredState | null {
+    const collection = scope.item ? collectionOf(scope.region, scope.item) : null
+
+    return declared(manifest, name, collection)
+  }
+
+  #requireKind(name: string, options: ScopedSetOptions, kind: StateKind, operation: string): void {
+    const resolved = this.#scope(options.scope, name)
+
+    if (!resolved) return
+
+    const manifest = this.manifestFor(resolved.region)
+    const declaration = manifest ? this.#declaration(manifest, resolved, name) : null
+
+    if (declaration && declaration.kind !== kind && declaration.kind !== "seeded") {
+      throw new TypeError(`${operation} needs a ${kind} state, and \`${name}\` is declared as ${declaration.kind}`)
+    }
+  }
+
+  #valueOf(name: string, scope: StateScope): StateValue {
+    const stored = this.#scoped.get(scope.region)?.get(scope.item?.key ?? "")?.get(name)
+
+    if (stored !== undefined) return stored
+
+    const seeded = this.#seed(name, scope)
+
+    return seeded !== undefined ? seeded : this.#defaultOf(name, scope)
+  }
+
+  #defaultOf(name: string, scope: StateScope): StateValue {
+    const manifest = this.manifestFor(scope.region)
+    const declaration = manifest ? this.#declaration(manifest, scope, name) : null
+
+    if (!declaration) return null
+
+    const parsed = parseLiteral(declaration.default)
+
+    return parsed === undefined ? null : parsed
+  }
+
+  #seed(name: string, scope: StateScope): StateValue | undefined {
+    const bucket = scoped(this.#seeds, scope)
+
+    if (bucket.has(name)) return bucket.get(name)
+
+    const manifest = this.manifestFor(scope.region)
+
+    if (!manifest) return undefined
+
+    let value = this.#seedFromValueSlot(manifest, scope, name)
+
+    if (value === undefined) value = this.#seedFromConditional(manifest, scope, name)
+    if (value === undefined) {
+      const declaration = this.#declaration(manifest, scope, name)
+      const parsed = declaration ? parseLiteral(declaration.default) : undefined
+
+      value = parsed
+    }
+
+    if (value !== undefined) bucket.set(name, value)
+
+    return value
+  }
+
+  #seedFromValueSlot(manifest: StateManifest, scope: StateScope, name: string): StateValue | undefined {
+    const declaration = this.#declaration(manifest, scope, name)
+
+    for (const index of manifest.reads[name] ?? []) {
+      for (const slot of this.#scopedSlots(scope, index)) {
+        const text = slot.attribute && slot.anchor.kind !== "range"
+          ? (slot.anchor.element.getAttribute(slot.attribute) ?? "")
+          : this.#slots.currentText(slot)
+
+        return coerce(text, declaration?.kind ?? "string")
+      }
+    }
+
+    return undefined
+  }
+
+  #seedFromConditional(manifest: StateManifest, scope: StateScope, name: string): StateValue | undefined {
+    for (const [indexKey, conditional] of Object.entries(manifest.conditionals)) {
+      const mentions = conditional.arms.some(([armName]) => armName === name)
+
+      if (!mentions) continue
+
+      for (const slot of this.#scopedSlots(scope, Number(indexKey))) {
+        const arm = conditional.arms.find(([, , branch]) => branch === slot.branch)
+
+        if (arm && arm[0] === name) return arm[1] === null ? true : parseLiteral(arm[1])
+        if (slot.branch === conditional.else || slot.branch === null) {
+          const declaration = this.#declaration(manifest, scope, name)
+
+          return declaration?.kind === "boolean" ? false : undefined
+        }
+      }
+    }
+
+    return undefined
+  }
+
+  #store(scope: StateScope, name: string, value: StateValue): void {
+    this.#seed(name, scope)
+    scoped(this.#scoped, scope).set(name, value)
+  }
+
+  #writeValueSlots(manifest: StateManifest, scope: StateScope, name: string, value: StateValue): void {
+    const text = printValue(value)
+
+    for (const index of manifest.reads[name] ?? []) {
+      for (const slot of this.#scopedSlots(scope, index)) this.#write(slot, text)
+    }
+  }
+
+  #writeConditionals(manifest: StateManifest, scope: StateScope, changed: string[]): void {
+    for (const [indexKey, conditional] of Object.entries(manifest.conditionals)) {
+      const mentions = conditional.arms.some(([name]) => changed.includes(name))
+
+      if (!mentions) continue
+
+      const target = this.#targetBranch(conditional, scope)
+
+      for (const slot of this.#scopedSlots(scope, Number(indexKey))) {
+        this.#slots.switchBranch(slot, target)
+      }
+    }
+  }
+
+  #targetBranch(conditional: StateManifest["conditionals"][string], scope: StateScope): number | null {
+    for (const [name, comparand, branch] of conditional.arms) {
+      const value = this.#valueOf(name, scope)
+
+      if (comparand === null ? rubyTruthy(value) : value === parseLiteral(comparand)) return branch
+    }
+
+    return conditional.else
+  }
+
+  #scopedSlots(scope: StateScope, index: number): Slot[] {
+    if (scope.item) {
+      const slot = scope.item.slots.get(index)
+
+      return slot ? [slot] : []
+    }
+
+    const region = scope.region.slots.get(index)
+
+    if (region) return [region]
+
+    const found: Slot[] = []
+
+    for (const candidate of scope.region.slots.values()) {
+      if (candidate.type !== "collection") continue
+
+      for (const item of candidate.items.values()) {
+        const slot = item.slots.get(index)
+
+        if (slot) found.push(slot)
+      }
+    }
+
+    return found
+  }
+
+  #announceState(scope: StateScope, name: string, value: StateValue, previous: StateValue): void {
+    if (typeof document === "undefined") return
+
+    document.dispatchEvent(
+      new CustomEvent<StateChangeDetail>(STATE_EVENT, {
+        detail: {
+          name,
+          value,
+          previous,
+          file: scope.region.file,
+          occurrence: scope.region.occurrence,
+          key: scope.item?.key ?? null,
+        },
+      }),
+    )
   }
 
   #readLocation(): void {
@@ -352,6 +735,26 @@ export class SlotState {
 
   #onPopState = (): void => {
     this.#readLocation()
+  }
+
+  #migrateItemState = (event: Event): void => {
+    const detail = (event as CustomEvent<SlotEventDetail>).detail
+
+    if (detail.operation !== "item-rekeyed" || !detail.slot || !detail.key || detail.previousKey === null) return
+
+    const region = this.#slots.regionOf(detail.slot)
+
+    if (!region) return
+
+    for (const store of [this.#scoped, this.#seeds]) {
+      const buckets = store.get(region)
+      const bucket = buckets?.get(detail.previousKey)
+
+      if (!buckets || !bucket) continue
+
+      buckets.delete(detail.previousKey)
+      buckets.set(detail.key, bucket)
+    }
   }
 
   #syncProperty = (event: Event): void => {
@@ -389,4 +792,110 @@ export class SlotState {
 
     return (await response.json()) as Payload
   }
+}
+
+
+function scoped(
+  store: Map<Region, Map<string, Map<string, StateValue>>>,
+  scope: StateScope,
+): Map<string, StateValue> {
+  let regionStore = store.get(scope.region)
+
+  if (!regionStore) {
+    regionStore = new Map()
+    store.set(scope.region, regionStore)
+  }
+
+  const key = scope.item?.key ?? ""
+  let bucket = regionStore.get(key)
+
+  if (!bucket) {
+    bucket = new Map()
+    regionStore.set(key, bucket)
+  }
+
+  return bucket
+}
+
+function declared(manifest: StateManifest, name: string, collection: number | null): DeclaredState | null {
+  const scoped_ = manifest.declarations.find(
+    (declaration) => declaration.name === name && (collection !== null ? declaration.scope === collection : declaration.scope === "region"),
+  )
+
+  if (scoped_) return scoped_
+  if (collection === null) return null
+
+  return manifest.declarations.find((declaration) => declaration.name === name && declaration.scope === "region") ?? null
+}
+
+function containsNode(region: Region, target: Node): boolean {
+  for (const range of region.ranges) {
+    if (!range.end) continue
+
+    const afterStart = range.start.compareDocumentPosition(target) & Node.DOCUMENT_POSITION_FOLLOWING
+    const beforeEnd = range.end.compareDocumentPosition(target) & Node.DOCUMENT_POSITION_PRECEDING
+
+    if (afterStart && beforeEnd) return true
+  }
+
+  return false
+}
+
+function enclosingItem(region: Region, target: Node): { item: Item; collection: number } | null {
+  for (const slot of region.slots.values()) {
+    if (slot.type !== "collection") continue
+
+    for (const item of slot.items.values()) {
+      const afterStart = item.start.compareDocumentPosition(target) & Node.DOCUMENT_POSITION_FOLLOWING
+      const beforeEnd = item.end.compareDocumentPosition(target) & Node.DOCUMENT_POSITION_PRECEDING
+
+      if (afterStart && beforeEnd) return { item, collection: slot.index }
+    }
+  }
+
+  return null
+}
+
+function collectionOf(region: Region, item: Item): number | null {
+  for (const slot of region.slots.values()) {
+    if (slot.type !== "collection") continue
+    if ([...slot.items.values()].includes(item)) return slot.index
+  }
+
+  return null
+}
+
+function parseLiteral(source: string): StateValue | undefined {
+  const trimmed = source.trim()
+
+  if (trimmed === "true") return true
+  if (trimmed === "false") return false
+  if (trimmed === "nil") return null
+  if (/^-?\d+$/.test(trimmed)) return Number(trimmed)
+  if (/^:[a-zA-Z_]\w*[?!]?$/.test(trimmed)) return trimmed.slice(1)
+  if (/^"(?:[^"\\]|\\.)*"$/.test(trimmed) || /^'(?:[^'\\]|\\.)*'$/.test(trimmed)) {
+    return trimmed.slice(1, -1).replace(/\\(.)/g, "$1")
+  }
+
+  return undefined
+}
+
+function printValue(value: StateValue): string {
+  if (value === null) return ""
+  if (value === true) return "true"
+  if (value === false) return "false"
+
+  return String(value)
+}
+
+function coerce(text: string, kind: StateKind): StateValue {
+  if (kind === "boolean") return text === "true"
+  if (kind === "integer") return /^-?\d+$/.test(text.trim()) ? Number(text.trim()) : 0
+  if (kind === "nil") return text === "" ? null : text
+
+  return text
+}
+
+function rubyTruthy(value: StateValue): boolean {
+  return value !== false && value !== null
 }

--- a/javascript/packages/client/src/stimulus.ts
+++ b/javascript/packages/client/src/stimulus.ts
@@ -1,0 +1,47 @@
+import { HerbRuntime, stateFor } from "./runtime"
+
+import type { ScopedState } from "./runtime"
+import type { StateScope } from "./state"
+
+export interface StateHost {
+  element: Element
+  state?: ScopedState
+  disconnect?(): void
+}
+
+export function useState(host: StateHost): ScopedState {
+  const state = stateFor(host.element)
+  const unsubscribes: (() => void)[] = []
+
+  host.state = state
+
+  const scope = state.scope
+
+  for (const name of scope ? namesFor(scope) : []) {
+    const method = (host as unknown as Record<string, unknown>)[`${name}Changed`]
+
+    if (typeof method !== "function") continue
+
+    unsubscribes.push(
+      state.on(name, (value, previous) => (method as (value: unknown, previous: unknown) => void).call(host, value, previous)),
+    )
+  }
+
+  const teardown = host.disconnect?.bind(host)
+
+  host.disconnect = () => {
+    for (const unsubscribe of unsubscribes) unsubscribe()
+
+    teardown?.()
+  }
+
+  return state
+}
+
+function namesFor(scope: StateScope): string[] {
+  const runtime = HerbRuntime.get()
+
+  if (!runtime) return []
+
+  return runtime.state.declaredStates(scope).map((declaration) => declaration.name)
+}

--- a/javascript/packages/client/test/state-scoped.test.ts
+++ b/javascript/packages/client/test/state-scoped.test.ts
@@ -1,0 +1,230 @@
+import { describe, test, expect, beforeEach, vi } from "vitest"
+import { SlotIndex } from "../src/slot-index"
+import { SlotState, STATE_EVENT } from "../src/state"
+
+const FILE = "app/views/page/chat.html.erb"
+
+function regionMarkup(occurrence: number): string {
+  return (
+    `<!--herb-region:${FILE}:aaaaaaaa:${occurrence}-->` +
+    `<div><!--herb-slot:0:conditional--><!--herb-branch:0:2-->Sent<!--/herb-slot:0--></div>` +
+    `<p><!--herb-slot:1-->0<!--/herb-slot:1--></p>` +
+    `<ul><!--herb-slot:2:collection-->` +
+    `<!--herb-item:2:a--><li id="a" data-herb-slot="3:attribute:id"><span data-herb-slot="4:conditional"><!--herb-branch:4:1-->plain</span></li><!--/herb-item:2-->` +
+    `<!--herb-item:2:b--><li id="b" data-herb-slot="3:attribute:id"><span data-herb-slot="4:conditional"><!--herb-branch:4:1-->plain</span></li><!--/herb-item:2-->` +
+    `<!--/herb-slot:2--></ul>` +
+    `<template data-herb-region="${FILE}:aaaaaaaa">` +
+    `<!--herb-branch:0:0-->Sending…<!--herb-branch:0:1-->Not sent<!--herb-branch:0:2-->Sent` +
+    `<!--herb-branch:4:0-->starred<!--herb-branch:4:1-->plain` +
+    `</template>` +
+    `<!--/herb-region:${FILE}-->`
+  )
+}
+
+const MANIFEST = {
+  state: {},
+  states: {
+    [FILE]: {
+      version: "aaaaaaaa",
+      declarations: [
+        { name: "pending", kind: "boolean", default: "false", scope: "region" },
+        { name: "failed", kind: "boolean", default: "false", scope: "region" },
+        { name: "attempts", kind: "integer", default: "0", scope: "region" },
+        { name: "starred", kind: "boolean", default: "false", scope: 2 },
+      ],
+      reads: { attempts: [1] },
+      conditionals: {
+        0: { arms: [["pending", null, 0], ["failed", null, 1]], else: 2 },
+        4: { arms: [["starred", null, 0]], else: 1 },
+      },
+    },
+  },
+}
+
+function dependencies(): string {
+  return `<template data-herb-dependencies>${JSON.stringify(MANIFEST)}</template>`
+}
+
+let slots: SlotIndex
+let state: SlotState
+
+function boot(markup: string): void {
+  document.body.innerHTML = markup + dependencies()
+
+  slots = new SlotIndex()
+  slots.scan(document.body)
+
+  state = new SlotState(slots, {
+    persist: "none",
+    transport: () => {
+      throw new Error("a declared state must never reach the transport")
+    },
+  })
+  state.adopt()
+}
+
+beforeEach(() => boot(regionMarkup(0)))
+
+describe("declared state", () => {
+  test("a rekeyed item keeps its scoped state", () => {
+    const first = document.querySelector("#a")!
+    const scope = state.scopeFor(first, "starred")!
+
+    expect(state.setState({ starred: true }, { scope })).toBe(true)
+    expect(first.textContent).toContain("starred")
+
+    const collection = slots.slot(FILE, 2)!
+
+    expect(slots.rekeyItem(collection, "a", "message_9")).toBe(true)
+
+    const rekeyed = state.scopeFor(document.querySelector("#a")!, "starred")!
+
+    expect(state.getState("starred", { scope: rekeyed })).toBe(true)
+  })
+
+
+  test("set flips a parked branch without any request", () => {
+    expect(state.setState({ pending: true })).toBe(true)
+    expect(document.querySelector("div")?.textContent).toContain("Sending…")
+
+    expect(state.setState({ pending: false, failed: true })).toBe(true)
+    expect(document.querySelector("div")?.textContent).toContain("Not sent")
+
+    expect(state.setState({ failed: false })).toBe(true)
+    expect(document.querySelector("div")?.textContent).toContain("Sent")
+  })
+
+  test("a value read is written with setText", () => {
+    state.setState({ attempts: 3 })
+
+    expect(document.querySelector("p")?.textContent).toContain("3")
+    expect(state.getState("attempts")).toBe(3)
+  })
+
+  test("ruby truthiness, not JavaScript's", () => {
+    const manifest = structuredClone(MANIFEST)
+
+    manifest.states[FILE].conditionals[0] = { arms: [["attempts", null, 0]], else: 2 }
+    document.body.innerHTML = regionMarkup(0) + `<template data-herb-dependencies>${JSON.stringify(manifest)}</template>`
+    slots = new SlotIndex()
+    slots.scan(document.body)
+    state = new SlotState(slots, { persist: "none" })
+    state.adopt()
+
+    state.setState({ attempts: 0 })
+
+    expect(document.querySelector("div")?.textContent).toContain("Sending…")
+  })
+
+  test("seeds from what the server rendered, and reset returns to it", () => {
+    expect(state.getState("pending")).toBe(false)
+
+    state.setState({ pending: true })
+    expect(state.getState("pending")).toBe(true)
+
+    state.reset("pending")
+    expect(state.getState("pending")).toBe(false)
+    expect(document.querySelector("div")?.textContent).toContain("Sent")
+  })
+
+  test("toggle refuses a non-boolean and increment refuses a non-integer", () => {
+    expect(() => state.toggle("attempts")).toThrow(TypeError)
+    expect(() => state.increment("pending")).toThrow(TypeError)
+
+    expect(state.toggle("pending")).toBe(true)
+    expect(state.getState("pending")).toBe(true)
+
+    state.increment("attempts", { by: 2 })
+    expect(state.getState("attempts")).toBe(2)
+  })
+
+  test("an item-scoped state moves one row and no other", () => {
+    const first = document.querySelector("#a")!
+    const scope = state.scopeFor(first, "starred")!
+
+    expect(scope.item?.key).toBe("a")
+    expect(state.setState({ starred: true }, { scope })).toBe(true)
+
+    expect(document.querySelector("#a")?.textContent).toContain("starred")
+    expect(document.querySelector("#b")?.textContent).toContain("plain")
+  })
+
+  test("get against two scopes returns two values", () => {
+    const a = state.scopeFor(document.querySelector("#a")!, "starred")!
+    const b = state.scopeFor(document.querySelector("#b")!, "starred")!
+
+    state.setState({ starred: true }, { scope: a })
+
+    expect(state.getState("starred", { scope: a })).toBe(true)
+    expect(state.getState("starred", { scope: b })).toBe(false)
+  })
+
+  test("two renders of a template hold independent values", () => {
+    document.body.innerHTML = regionMarkup(0) + regionMarkup(1) + dependencies()
+    slots = new SlotIndex()
+    slots.scan(document.body)
+    state = new SlotState(slots, { persist: "none" })
+    state.adopt()
+
+    const regions = slots.regionsFor(FILE)
+    const first = { region: regions[0], item: null }
+    const second = { region: regions[1], item: null }
+
+    state.setState({ pending: true }, { scope: first })
+
+    expect(state.getState("pending", { scope: first })).toBe(true)
+    expect(state.getState("pending", { scope: second })).toBe(false)
+
+    const shown = [...document.querySelectorAll("div")].map((div) => div.textContent)
+
+    expect(shown[0]).toContain("Sending…")
+    expect(shown[1]).toContain("Sent")
+  })
+
+  test("a transition is one revert unit and announces each state", () => {
+    const seen: string[] = []
+    const off = state.on("pending", (value) => seen.push(`pending:${value}`))
+    const offFailed = state.on("failed", (value) => seen.push(`failed:${value}`))
+
+    state.setState({ pending: true, failed: false })
+
+    expect(seen).toEqual(["pending:true", "failed:false"])
+
+    off()
+    offFailed()
+  })
+
+  test("a version mismatch declines rather than resolving stale arms", () => {
+    document.body.innerHTML =
+      regionMarkup(0).split("aaaaaaaa").join("bbbbbbbb") + dependencies()
+    slots = new SlotIndex()
+    slots.scan(document.body)
+    state = new SlotState(slots, { persist: "none" })
+    state.adopt()
+
+    expect(state.setState({ pending: true })).toBe(false)
+  })
+
+  test("the transport is never called", () => {
+    const transport = vi.fn()
+
+    state = new SlotState(slots, { persist: "none", transport })
+    state.adopt()
+    state.setState({ pending: true })
+
+    expect(transport).not.toHaveBeenCalled()
+  })
+
+  test("state change events carry the scope", () => {
+    const details: unknown[] = []
+    const handler = (event: Event): void => {
+      details.push((event as CustomEvent).detail)
+    }
+
+    document.addEventListener(STATE_EVENT, handler)
+    state.setState({ pending: true })
+    document.removeEventListener(STATE_EVENT, handler)
+
+    expect(details).toMatchObject([{ name: "pending", value: true, previous: false, file: FILE, occurrence: 0, key: null }])
+  })
+})

--- a/javascript/packages/client/test/state.test.ts
+++ b/javascript/packages/client/test/state.test.ts
@@ -227,6 +227,54 @@ describe("a page that waits for the server", () => {
   })
 })
 
+describe("two flushes racing", () => {
+  const RACE_PAGE =
+    `<!--herb-region:${FILE}:${VERSION}:0-->` +
+    `<p><!--herb-slot:0-->old-a<!--/herb-slot:0--></p>` +
+    `<p><!--herb-slot:1-->old-b<!--/herb-slot:1--></p>` +
+    `<!--/herb-region:${FILE}-->`
+
+  const RACE_MAP = {
+    state: {
+      "@a": [{ file: FILE, version: VERSION, index: 0, mode: "identity" }],
+      "@b": [{ file: FILE, version: VERSION, index: 1, mode: "identity" }],
+    },
+    params: { a: "@a", b: "@b" },
+  }
+
+  test("an aborted flush leaves the newer flush's world alone", async () => {
+    const slots = mounted(RACE_PAGE + `<template data-herb-dependencies>${JSON.stringify(RACE_MAP)}</template>`)
+
+    let calls = 0
+    const transport = async (_request: StateRequest, signal: AbortSignal): Promise<Payload | null> => {
+      calls += 1
+
+      if (calls === 1) {
+        return new Promise((_resolve, reject) => {
+          signal.addEventListener("abort", () => reject(new DOMException("aborted", "AbortError")))
+        })
+      }
+
+      return null
+    }
+
+    const state = new SlotState(slots, { debounce: 0, transport })
+
+    state.adopt()
+
+    const first = state.set("a", "new-a")
+
+    await new Promise((resolve) => setTimeout(resolve, 10))
+
+    const second = state.set("b", "new-b")
+
+    await Promise.all([first, second])
+
+    expect(text(0, slots)).toBe("new-a")
+    expect(state.get("a")).toBe("new-a")
+  })
+})
+
 describe("reconciling with the server", () => {
   beforeEach(() => {
     document.body.innerHTML = ""

--- a/javascript/packages/client/test/stimulus.test.ts
+++ b/javascript/packages/client/test/stimulus.test.ts
@@ -1,0 +1,64 @@
+import { describe, test, expect, beforeEach, afterEach } from "vitest"
+import { HerbRuntime, stateFor } from "../src/runtime"
+import { useState } from "../src/stimulus"
+
+const FILE = "app/views/page/card.html.erb"
+
+const PAGE =
+  `<!--herb-region:${FILE}:aaaaaaaa:0-->` +
+  `<section><div><!--herb-slot:0:conditional--><!--herb-branch:0:1-->closed<!--/herb-slot:0--></div>` +
+  `<button id="go">Details</button></section>` +
+  `<template data-herb-region="${FILE}:aaaaaaaa"><!--herb-branch:0:0-->open<!--herb-branch:0:1-->closed</template>` +
+  `<!--/herb-region:${FILE}-->` +
+  `<template data-herb-dependencies>${JSON.stringify({
+    state: {},
+    states: {
+      [FILE]: {
+        version: "aaaaaaaa",
+        declarations: [{ name: "expanded", kind: "boolean", default: "false", scope: "region" }],
+        reads: {},
+        conditionals: { 0: { arms: [["expanded", null, 0]], else: 1 } },
+      },
+    },
+  })}</template>`
+
+let runtime: HerbRuntime
+
+beforeEach(() => {
+  document.body.innerHTML = PAGE
+  runtime = HerbRuntime.start({ state: { persist: "none" } })
+  runtime.slots.scan(document.body)
+  runtime.state.adopt()
+})
+
+afterEach(() => runtime.stop())
+
+describe("stateFor and useState", () => {
+  test("stateFor binds to the enclosing scope", () => {
+    const state = stateFor(document.querySelector("#go")!)
+
+    expect(state.get("expanded")).toBe(false)
+    expect(state.toggle("expanded")).toBe(true)
+    expect(document.querySelector("div")?.textContent).toContain("open")
+  })
+
+  test("useState wires <name>Changed and tears down on disconnect", () => {
+    const seen: unknown[] = []
+    const host = {
+      element: document.querySelector("#go")!,
+      expandedChanged(value: unknown, previous: unknown) {
+        seen.push([value, previous])
+      },
+      disconnect() {},
+    }
+
+    const state = useState(host)
+
+    state.set({ expanded: true })
+    expect(seen).toEqual([[true, false]])
+
+    host.disconnect()
+    state.set({ expanded: false })
+    expect(seen).toEqual([[true, false]])
+  })
+})

--- a/lib/herb/engine/slot_dependencies.rb
+++ b/lib/herb/engine/slot_dependencies.rb
@@ -67,11 +67,30 @@ module Herb
 
       #: (String, ?params: Hash[String, String]) -> Hash[String, untyped]
       def payload(entry_point, params: {})
-        state = across(entry_point).transform_values { |slots|
+        reached = across(entry_point)
+        state = reached.transform_values { |slots|
           slots.map { |slot| { "file" => identifier_for(slot[:file]), "version" => slot[:version], "index" => slot[:index], "mode" => slot[:mode].to_s } }
         }
 
-        { "state" => state, "params" => request_names(entry_point, state.keys, params) }
+        {
+          "state" => state,
+          "params" => request_names(entry_point, state.keys, params),
+          "states" => declared_states(entry_point, reached),
+        }
+      end
+
+      #: (String, Hash[String, untyped]) -> Hash[String, untyped]
+      def declared_states(entry_point, reached)
+        files = ([absolute(entry_point)] + reached.values.flatten.map { |slot| slot[:file] }).uniq
+        manifests = {} #: Hash[String, untyped]
+
+        files.each do |file|
+          manifest = template(file)[:states]
+
+          manifests[identifier_for(file)] = manifest if manifest
+        end
+
+        manifests
       end
 
       #: (String, ?params: Hash[String, String]) -> String
@@ -120,7 +139,43 @@ module Herb
           index[slot.index] = { state: state, mode: mode_for(slot, state, expressions, settable) }
         end
 
-        { version: visitor.schema[:version], slots: index }
+        { version: visitor.schema[:version], slots: index, states: states_manifest(visitor) }
+      end
+
+      #: (untyped) -> Hash[String, untyped]?
+      def states_manifest(visitor)
+        return nil unless visitor.respond_to?(:state_declarations)
+
+        declared = visitor.state_declarations
+        names = declared[:region].map { |declaration| declaration[:name] } +
+                declared[:items].values.flatten.map { |declaration| declaration[:name] }
+
+        return nil if names.empty?
+
+        declarations = declared[:region].map { |declaration| declaration.transform_keys(&:to_s).merge("scope" => "region") } +
+                       declared[:items].flat_map { |index, list| list.map { |declaration| declaration.transform_keys(&:to_s).merge("scope" => index) } }
+
+        reads = {} #: Hash[String, Array[Integer]]
+
+        visitor.slots.each do |slot|
+          next unless [:child, :attribute, :element].include?(slot.type)
+
+          expression = slot.expression.to_s.strip
+          name = expression.delete_suffix("?")
+
+          (reads[name] ||= []) << slot.index if names.include?(name)
+        end
+
+        conditionals = visitor.state_conditional_entries.to_h { |index, info|
+          [index.to_s, { "arms" => info[:arms], "else" => info[:else] }]
+        }
+
+        {
+          "version" => visitor.schema[:version],
+          "declarations" => declarations,
+          "reads" => reads,
+          "conditionals" => conditionals,
+        }
       end
 
       #: (untyped, ?Array[Hash[Symbol, untyped]], ?per_item: bool) -> Array[Hash[Symbol, untyped]]

--- a/sig/herb/engine/slot_dependencies.rbs
+++ b/sig/herb/engine/slot_dependencies.rbs
@@ -38,6 +38,9 @@ module Herb
       # : (String, ?params: Hash[String, String]) -> Hash[String, untyped]
       def payload: (String, ?params: Hash[String, String]) -> Hash[String, untyped]
 
+      # : (String, Hash[String, untyped]) -> Hash[String, untyped]
+      def declared_states: (String, Hash[String, untyped]) -> Hash[String, untyped]
+
       # : (String, ?params: Hash[String, String]) -> String
       def element: (String, ?params: Hash[String, String]) -> String
 
@@ -54,6 +57,9 @@ module Herb
 
       # : (String, Array[String]?) -> Hash[Symbol, untyped]
       def build: (String, Array[String]?) -> Hash[Symbol, untyped]
+
+      # : (untyped) -> Hash[String, untyped]?
+      def states_manifest: (untyped) -> Hash[String, untyped]?
 
       # : (untyped, ?Array[Hash[Symbol, untyped]], ?per_item: bool) -> Array[Hash[Symbol, untyped]]
       def reached_slots: (untyped, ?Array[Hash[Symbol, untyped]], ?per_item: bool) -> Array[Hash[Symbol, untyped]]

--- a/test/engine/slots/dependencies_test.rb
+++ b/test/engine/slots/dependencies_test.rb
@@ -423,6 +423,35 @@ module Engine
 
         assert_empty subject.across(entry)
       end
+      test "carries the states a template declares" do
+        path = write("index.html.erb", <<~ERB)
+          <%# herb:state (pending: false, attempts: 0) %>
+          <div><%= @query %></div>
+          <p><%= attempts %></p>
+          <span><% if pending? %>wait<% else %>done<% end %></span>
+        ERB
+
+        payload = subject.payload(path)
+        manifest = payload["states"].values.first
+
+        names = manifest["declarations"].map { |declaration| declaration["name"] }
+
+        assert_equal ["pending", "attempts"], names
+        assert_equal ["region"], manifest["declarations"].map { |declaration| declaration["scope"] }.uniq
+        assert_equal 1, manifest["reads"]["attempts"].size
+
+        conditional = manifest["conditionals"].values.first
+
+        assert_equal [["pending", nil, 0]], conditional["arms"]
+        assert_equal 1, conditional["else"]
+        assert_equal subject.version_for(path), manifest["version"]
+      end
+
+      test "carries no states section entry for a template that declares none" do
+        path = write("index.html.erb", "<div><%= @query %></div>")
+
+        assert_empty subject.payload(path)["states"]
+      end
     end
   end
 end


### PR DESCRIPTION
This pull request implements the client half of `herb:state`. Setting a declared state writes every slot that reads it, through the same dependency fan-out server state already uses, and never touches the transport.

`SlotState` grows scoped storage keyed by region identity and item key, so two renders of a partial hold two independent values and a per-row flag stays per row. `scopeFor(element, name)` resolves lexically, walking up from an element to the nearest enclosing scope that declares the name. 

`#write` gains a conditional case that walks the schema's arm table under Ruby truthiness, only `nil` and `false` are falsy, and calls `switchBranch`. Beside the `setState` primitive there are typed operations, `toggle`, `increment`, `decrement` and `reset`, each validated against the declared kind. Every change announces a `herb:state-change` event.

The engine side extends the dependency payload with a `states` section per template, declarations with kind, default and scope, the slots each state is read in, and the conditional arm tables.

Two entry points ship for app code:

```js
import { stateFor } from "@herb-tools/client"

const state = stateFor(button)
state.set({ pending: false, failed: true })
state.on("pending", (value, previous) => { /* … */ })
```

```js
import { useState } from "@herb-tools/client/stimulus"

export default class extends Controller {
  connect() { 
    useState(this) 
  }

  pendingChanged(value, previous) { 
    /* … */ 
  }
}
```

`useState` duck-types `element` and `disconnect`, dispatches `<name>Changed` for the methods the host defines, and patches teardown. It ships behind a `/stimulus` subpath so the root export stays framework-free, and the build emits both entries from one rolldown config with a shared chunk, so the runtime singleton exists once no matter which entry an app imports.
