### PR TITLE
Client: Bind a form control to the state it renders

### DIFF
--- a/javascript/packages/client/src/state.ts
+++ b/javascript/packages/client/src/state.ts
@@ -24,6 +24,7 @@ export interface StateManifest {
   version: string
   declarations: DeclaredState[]
   reads: Record<string, number[]>
+  bound?: Record<string, number[]>
   conditionals: Record<string, { arms: [string, string | null, number][]; else: number | null }>
 }
 
@@ -172,6 +173,8 @@ export class SlotState {
 
     document.addEventListener(SLOT_EVENT, this.#syncProperty)
     document.addEventListener(SLOT_EVENT, this.#migrateItemState)
+    document.addEventListener("input", this.#onBoundInput)
+    document.addEventListener("change", this.#onBoundInput)
 
     if (typeof window !== "undefined" && this.#persisted()) {
       window.addEventListener("popstate", this.#onPopState)
@@ -202,6 +205,8 @@ export class SlotState {
 
     document.removeEventListener(SLOT_EVENT, this.#syncProperty)
     document.removeEventListener(SLOT_EVENT, this.#migrateItemState)
+    document.removeEventListener("input", this.#onBoundInput)
+    document.removeEventListener("change", this.#onBoundInput)
 
     if (typeof window !== "undefined") {
       window.removeEventListener("popstate", this.#onPopState)
@@ -733,6 +738,35 @@ export class SlotState {
     window.history.replaceState(window.history.state, "", url.toString())
   }
 
+  #onBoundInput = (event: Event): void => {
+    const element = event.target
+
+    if (!(element instanceof Element) || !VALUE_ELEMENTS.includes(element.tagName)) return
+
+    const scope = this.scopeFor(element)
+
+    if (!scope) return
+
+    const manifest = this.manifestFor(scope.region)
+
+    if (!manifest) return
+
+    for (const [name, indices] of Object.entries(manifest.bound ?? {})) {
+      for (const index of indices) {
+        for (const slot of this.#scopedSlots(scope, index)) {
+          if (slot.anchor.kind === "range" || slot.anchor.element !== element) continue
+
+          const declaration = this.#declaration(manifest, scope, name)
+          const value = boundValue(element, declaration?.kind ?? "string")
+
+          this.setState({ [name]: value }, { scope })
+
+          return
+        }
+      }
+    }
+  }
+
   #onPopState = (): void => {
     this.#readLocation()
   }
@@ -894,6 +928,14 @@ function coerce(text: string, kind: StateKind): StateValue {
   if (kind === "nil") return text === "" ? null : text
 
   return text
+}
+
+function boundValue(element: Element, kind: StateKind): StateValue {
+  if (element instanceof HTMLInputElement && element.type === "checkbox") return element.checked
+
+  const raw = (element as HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement).value
+
+  return coerce(raw, kind)
 }
 
 function rubyTruthy(value: StateValue): boolean {

--- a/javascript/packages/client/test/binding.test.ts
+++ b/javascript/packages/client/test/binding.test.ts
@@ -1,0 +1,90 @@
+import { describe, test, expect, beforeEach, afterEach } from "vitest"
+import { SlotIndex } from "../src/slot-index"
+import { SlotState } from "../src/state"
+
+const FILE = "app/views/page/form.html.erb"
+
+const PAGE =
+  `<!--herb-region:${FILE}:aaaaaaaa:0-->` +
+  `<input id="draft" value="" data-herb-slot="0:attribute:value">` +
+  `<input id="agree" type="checkbox" data-herb-slot="1:attribute:checked">` +
+  `<p><!--herb-slot:2--><!--/herb-slot:2--></p>` +
+  `<div><!--herb-slot:3:conditional--><!--herb-branch:3:1-->unagreed<!--/herb-slot:3--></div>` +
+  `<template data-herb-region="${FILE}:aaaaaaaa"><!--herb-branch:3:0-->agreed<!--herb-branch:3:1-->unagreed</template>` +
+  `<!--/herb-region:${FILE}-->` +
+  `<template data-herb-dependencies>${JSON.stringify({
+    state: {},
+    states: {
+      [FILE]: {
+        version: "aaaaaaaa",
+        declarations: [
+          { name: "draft", kind: "string", default: '""', scope: "region" },
+          { name: "agreed", kind: "boolean", default: "false", scope: "region" },
+        ],
+        reads: { draft: [0, 2], agreed: [1] },
+        bound: { draft: [0], agreed: [1] },
+        conditionals: { 3: { arms: [["agreed", null, 0]], else: 1 } },
+      },
+    },
+  })}</template>`
+
+let slots: SlotIndex
+let state: SlotState
+
+beforeEach(() => {
+  document.body.innerHTML = PAGE
+
+  slots = new SlotIndex()
+  slots.scan(document.body)
+
+  state = new SlotState(slots, { persist: "none" })
+  state.adopt()
+  state.observe()
+})
+
+afterEach(() => state.disconnect())
+
+describe("bound slots", () => {
+  test("typing into a bound input sets the state and fans out", () => {
+    const input = document.querySelector<HTMLInputElement>("#draft")!
+
+    input.value = "hello"
+    input.dispatchEvent(new Event("input", { bubbles: true }))
+
+    expect(state.getState("draft")).toBe("hello")
+    expect(document.querySelector("p")?.textContent).toContain("hello")
+  })
+
+  test("the write-back does not re-enter the handler", () => {
+    const input = document.querySelector<HTMLInputElement>("#draft")!
+    let events = 0
+
+    document.addEventListener("input", () => (events += 1))
+
+    input.value = "once"
+    input.dispatchEvent(new Event("input", { bubbles: true }))
+
+    expect(events).toBe(1)
+    expect(input.getAttribute("value")).toBe("once")
+  })
+
+  test("a checkbox binds its boolean and flips the branch it drives", () => {
+    const checkbox = document.querySelector<HTMLInputElement>("#agree")!
+
+    checkbox.checked = true
+    checkbox.dispatchEvent(new Event("change", { bubbles: true }))
+
+    expect(state.getState("agreed")).toBe(true)
+    expect(document.querySelector("div")?.textContent).toContain("agreed")
+  })
+
+  test("an unbound control writes nothing", () => {
+    const loose = document.createElement("input")
+
+    document.body.append(loose)
+    loose.value = "stray"
+    loose.dispatchEvent(new Event("input", { bubbles: true }))
+
+    expect(state.getState("draft")).toBe("")
+  })
+})

--- a/lib/herb/engine/slot_dependencies.rb
+++ b/lib/herb/engine/slot_dependencies.rb
@@ -156,14 +156,18 @@ module Herb
                        declared[:items].flat_map { |index, list| list.map { |declaration| declaration.transform_keys(&:to_s).merge("scope" => index) } }
 
         reads = {} #: Hash[String, Array[Integer]]
+        bound = {} #: Hash[String, Array[Integer]]
 
         visitor.slots.each do |slot|
-          next unless [:child, :attribute, :element].include?(slot.type)
+          next unless [:child, :attribute, :element, :raw_text].include?(slot.type)
 
           expression = slot.expression.to_s.strip
           name = expression.delete_suffix("?")
 
-          (reads[name] ||= []) << slot.index if names.include?(name)
+          next unless names.include?(name)
+
+          (reads[name] ||= []) << slot.index
+          (bound[name] ||= []) << slot.index if bound_slot?(slot)
         end
 
         conditionals = visitor.state_conditional_entries.to_h { |index, info|
@@ -174,8 +178,22 @@ module Herb
           "version" => visitor.schema[:version],
           "declarations" => declarations,
           "reads" => reads,
+          "bound" => bound,
           "conditionals" => conditionals,
         }
+      end
+
+      #: (untyped) -> bool
+      def bound_slot?(slot)
+        return false unless slot.respond_to?(:tag)
+
+        tag = slot.tag.to_s
+
+        if slot.attribute
+          ["value", "checked", "selected"].include?(slot.attribute) && ["input", "textarea", "select", "option"].include?(tag)
+        else
+          tag == "textarea"
+        end
       end
 
       #: (untyped, ?Array[Hash[Symbol, untyped]], ?per_item: bool) -> Array[Hash[Symbol, untyped]]

--- a/lib/herb/engine/slot_visitor.rb
+++ b/lib/herb/engine/slot_visitor.rb
@@ -70,7 +70,8 @@ module Herb
         :attribute,  #: String?
         :key_source, #: Symbol?
         :key_expression, #: String?
-        :name #: String?
+        :name, #: String?
+        :tag #: String?
       )
 
       #: (String) -> bool
@@ -123,6 +124,7 @@ module Herb
 
         slot_nodes = [] #: Array[untyped]
         @slot_nodes = slot_nodes
+        @tag_stack = [] #: Array[String]
         slot_scopes = {} #: Hash[untyped, untyped]
         @slot_scopes = slot_scopes.compare_by_identity
         @named_elements = [] #: Array[Hash[Symbol, untyped]]
@@ -276,6 +278,7 @@ module Herb
 
         previous_open_tag = @current_open_tag
         @current_open_tag = node.open_tag
+        @tag_stack.push(tag_name)
 
         name_attribute = attributes_for(node).find { |attribute| attribute_name_for(attribute)&.downcase == NAME_ATTRIBUTE }
         base = @slot_nodes.size
@@ -288,6 +291,7 @@ module Herb
 
         record_named_element(node, name_attribute, base, base_scope, base_depth) if name_attribute
 
+        @tag_stack.pop
         @current_open_tag = previous_open_tag
 
         @rcdata_depth -= 1 if rcdata
@@ -574,7 +578,8 @@ module Herb
           attribute: attribute_name_for(node),
           key_source: key_source,
           key_expression: key_expression,
-          name: nil
+          name: nil,
+          tag: @tag_stack.last
         )
 
         @slots << slot
@@ -1140,12 +1145,26 @@ module Herb
       end
 
       def expression_for(node)
+        return attribute_expression_for(node) if node.is_a?(Herb::AST::HTMLAttributeNode)
         return nil unless node.respond_to?(:content)
 
         content = node.content
         value = content.respond_to?(:value) ? content.value : content
 
         value&.to_s&.strip
+      end
+
+      #: (untyped) -> String?
+      def attribute_expression_for(node)
+        children = node.value&.children || []
+
+        return nil unless children.one?
+
+        child = children.first
+
+        return nil unless child.is_a?(Herb::AST::ERBContentNode)
+
+        child.content&.value&.strip
       end
 
       def location_for(node)

--- a/sig/herb/engine/slot_dependencies.rbs
+++ b/sig/herb/engine/slot_dependencies.rbs
@@ -61,6 +61,9 @@ module Herb
       # : (untyped) -> Hash[String, untyped]?
       def states_manifest: (untyped) -> Hash[String, untyped]?
 
+      # : (untyped) -> bool
+      def bound_slot?: (untyped) -> bool
+
       # : (untyped, ?Array[Hash[Symbol, untyped]], ?per_item: bool) -> Array[Hash[Symbol, untyped]]
       def reached_slots: (untyped, ?Array[Hash[Symbol, untyped]], ?per_item: bool) -> Array[Hash[Symbol, untyped]]
 

--- a/sig/herb/engine/slot_visitor.rbs
+++ b/sig/herb/engine/slot_visitor.rbs
@@ -79,12 +79,14 @@ module Herb
 
         attr_reader name(): String?
 
-        def self.new: (Integer index, Symbol type, Array[Integer] node_path, String? expression, String? location, String? attribute, Symbol? key_source, String? key_expression, String? name) -> instance
-                    | (index: Integer, type: Symbol, node_path: Array[Integer], expression: String?, location: String?, attribute: String?, key_source: Symbol?, key_expression: String?, name: String?) -> instance
+        attr_reader tag(): String?
 
-        def self.members: () -> [ :index, :type, :node_path, :expression, :location, :attribute, :key_source, :key_expression, :name ]
+        def self.new: (Integer index, Symbol type, Array[Integer] node_path, String? expression, String? location, String? attribute, Symbol? key_source, String? key_expression, String? name, String? tag) -> instance
+                    | (index: Integer, type: Symbol, node_path: Array[Integer], expression: String?, location: String?, attribute: String?, key_source: Symbol?, key_expression: String?, name: String?, tag: String?) -> instance
 
-        def members: () -> [ :index, :type, :node_path, :expression, :location, :attribute, :key_source, :key_expression, :name ]
+        def self.members: () -> [ :index, :type, :node_path, :expression, :location, :attribute, :key_source, :key_expression, :name, :tag ]
+
+        def members: () -> [ :index, :type, :node_path, :expression, :location, :attribute, :key_source, :key_expression, :name, :tag ]
       end
 
       # : (String) -> bool
@@ -301,6 +303,9 @@ module Herb
       def dynamic?: (untyped) -> bool
 
       def expression_for: (untyped node) -> untyped
+
+      # : (untyped) -> String?
+      def attribute_expression_for: (untyped) -> String?
 
       def location_for: (untyped node) -> untyped
 

--- a/test/engine/slots/dependencies_test.rb
+++ b/test/engine/slots/dependencies_test.rb
@@ -447,6 +447,22 @@ module Engine
         assert_equal subject.version_for(path), manifest["version"]
       end
 
+      test "marks a state read into a form control as bound" do
+        path = write("index.html.erb", <<~ERB)
+          <%# herb:state (draft: "", agreed: false) %>
+          <input value="<%= draft %>">
+          <input type="checkbox" checked="<%= agreed %>">
+          <p><%= draft %></p>
+        ERB
+
+        manifest = subject.payload(path)["states"].values.first
+
+        assert_equal 2, manifest["reads"]["draft"].size
+        assert_equal 1, manifest["bound"]["draft"].size
+        assert_equal 1, manifest["bound"]["agreed"].size
+        refute_includes manifest["bound"]["draft"], manifest["reads"]["draft"].last
+      end
+
       test "carries no states section entry for a template that declares none" do
         path = write("index.html.erb", "<div><%= @query %></div>")
 

--- a/test/snapshots/engine/slots/visitor_test/test_0006_classifies_ERB_inside_an_attribute_value_adc0c71bcb9aef1d2e8f649fa5385736-4c591885d0bd22e1b3fcfc215038ec41.txt
+++ b/test/snapshots/engine/slots/visitor_test/test_0006_classifies_ERB_inside_an_attribute_value_adc0c71bcb9aef1d2e8f649fa5385736-4c591885d0bd22e1b3fcfc215038ec41.txt
@@ -7,4 +7,4 @@ file: app/views/test.html.erb
 version: 1028a42b
 
 slots:
-  index=0  type=attribute  node_path=[0]  location=1:5  attribute="class"
+  index=0  type=attribute  node_path=[0]  expression="@klass"  location=1:5  attribute="class"

--- a/test/snapshots/engine/slots/visitor_test/test_0017_detects_an_explicit_herb-key_on_a_collection_ea3407531e5f2a385cb96327a796a028-4c591885d0bd22e1b3fcfc215038ec41.txt
+++ b/test/snapshots/engine/slots/visitor_test/test_0017_detects_an_explicit_herb-key_on_a_collection_ea3407531e5f2a385cb96327a796a028-4c591885d0bd22e1b3fcfc215038ec41.txt
@@ -8,4 +8,4 @@ version: 0cff4095
 
 slots:
   index=0  type=collection  node_path=[0]  expression="@u.each do |u|"  location=1:0  key_source=herb_key  key_expression="u.id"
-  index=1  type=attribute  node_path=[0, 0]  location=1:24  attribute="herb-key"
+  index=1  type=attribute  node_path=[0, 0]  expression="u.id"  location=1:24  attribute="herb-key"

--- a/test/snapshots/engine/slots/visitor_test/test_0018_falls_back_to_an_id,_which_Rails_templates_already_carry_for_Turbo,_and_records_its_expression_be478bdbe5085559abac4a1664139c93-4c591885d0bd22e1b3fcfc215038ec41.txt
+++ b/test/snapshots/engine/slots/visitor_test/test_0018_falls_back_to_an_id,_which_Rails_templates_already_carry_for_Turbo,_and_records_its_expression_be478bdbe5085559abac4a1664139c93-4c591885d0bd22e1b3fcfc215038ec41.txt
@@ -8,4 +8,4 @@ version: 23389387
 
 slots:
   index=0  type=collection  node_path=[0]  expression="@u.each do |u|"  location=1:0  key_source=id  key_expression="dom_id(u)"
-  index=1  type=attribute  node_path=[0, 0]  location=1:24  attribute="id"
+  index=1  type=attribute  node_path=[0, 0]  expression="dom_id(u)"  location=1:24  attribute="id"

--- a/test/snapshots/engine/slots/visitor_test/test_0019_prefers_herb-key_over_an_id_3b22f3584d2b540a1f4bb8ae73ea0098-4c591885d0bd22e1b3fcfc215038ec41.txt
+++ b/test/snapshots/engine/slots/visitor_test/test_0019_prefers_herb-key_over_an_id_3b22f3584d2b540a1f4bb8ae73ea0098-4c591885d0bd22e1b3fcfc215038ec41.txt
@@ -8,4 +8,4 @@ version: 0cff4095
 
 slots:
   index=0  type=collection  node_path=[0]  expression="@u.each do |u|"  location=1:0  key_source=herb_key  key_expression="u.id"
-  index=1  type=attribute  node_path=[0, 0]  location=1:31  attribute="herb-key"
+  index=1  type=attribute  node_path=[0, 0]  expression="u.id"  location=1:31  attribute="herb-key"

--- a/test/snapshots/engine/slots/visitor_test/test_0022_does_not_warn_when_a_collection_carries_a_key_4fbe016d9478791658d0aa0062a2da4e-4c591885d0bd22e1b3fcfc215038ec41.txt
+++ b/test/snapshots/engine/slots/visitor_test/test_0022_does_not_warn_when_a_collection_carries_a_key_4fbe016d9478791658d0aa0062a2da4e-4c591885d0bd22e1b3fcfc215038ec41.txt
@@ -8,4 +8,4 @@ version: 23389387
 
 slots:
   index=0  type=collection  node_path=[0]  expression="@u.each do |u|"  location=1:0  key_source=id  key_expression="u.id"
-  index=1  type=attribute  node_path=[0, 0]  location=1:24  attribute="id"
+  index=1  type=attribute  node_path=[0, 0]  expression="u.id"  location=1:24  attribute="id"

--- a/test/snapshots/engine/slots/visitor_test/test_0025_prefers_a_herbkey_directive_over_an_attribute_418648ed91e5e2e006670f1817ddf9b3-4c591885d0bd22e1b3fcfc215038ec41.txt
+++ b/test/snapshots/engine/slots/visitor_test/test_0025_prefers_a_herbkey_directive_over_an_attribute_418648ed91e5e2e006670f1817ddf9b3-4c591885d0bd22e1b3fcfc215038ec41.txt
@@ -8,4 +8,4 @@ version: 036e96af
 
 slots:
   index=0  type=collection  node_path=[0]  expression="@u.each do |u|"  location=1:0  key_source=directive  key_expression="u.uuid"
-  index=1  type=attribute  node_path=[0, 1]  location=1:46  attribute="id"
+  index=1  type=attribute  node_path=[0, 1]  expression="u.id"  location=1:46  attribute="id"

--- a/test/snapshots/engine/slots/visitor_test/test_0027_records_the_attribute_a_slot_belongs_to_9534bdafb9e42e2b449396c6dc7ee93e-4c591885d0bd22e1b3fcfc215038ec41.txt
+++ b/test/snapshots/engine/slots/visitor_test/test_0027_records_the_attribute_a_slot_belongs_to_9534bdafb9e42e2b449396c6dc7ee93e-4c591885d0bd22e1b3fcfc215038ec41.txt
@@ -7,5 +7,5 @@ file: app/views/test.html.erb
 version: b5b81d11
 
 slots:
-  index=0  type=attribute  node_path=[0]  location=1:5  attribute="class"
-  index=1  type=attribute  node_path=[0]  location=1:23  attribute="id"
+  index=0  type=attribute  node_path=[0]  expression="@c"  location=1:5  attribute="class"
+  index=1  type=attribute  node_path=[0]  expression="@i"  location=1:23  attribute="id"


### PR DESCRIPTION
This pull request makes a declared state read into a form control a two-way binding, with no syntax to learn.

```erb
<input value="<%= draft %>">
<input type="checkbox" checked="<%= agreed %>">
<textarea><%= draft %></textarea>
```

The compiler already knows everything a binding needs, that `draft` is a declared state and that the slot writes a value-shaped position, `value`, `checked` or `selected`, or a textarea's content. It marks those slots bound in the dependency map's `states` section. The client attaches an `input` or `change` listener when it scans a bound control and routes the value through the same scoped `setState`, so every other read of the state updates too.

There is no echo loop because setting `.value` programmatically does not dispatch an `input` event, and the write-back path is guarded so the handler never re-enters. A state read anywhere else stays display only, since there is nothing to bind to.