### PR TITLE
Client: Send a mutation without cancelling the one before it

### DIFF
--- a/javascript/packages/client/src/index.ts
+++ b/javascript/packages/client/src/index.ts
@@ -1,6 +1,8 @@
 export { HerbRuntime, stateFor } from "./runtime"
 export { SlotIndex, SLOT_EVENT } from "./slot-index"
 export { SlotState, DEPENDENCIES_ATTRIBUTE, DEPENDENCIES_SELECTOR, STATE_EVENT } from "./state"
+export { SlotMutations } from "./mutations"
+export type { MutationTarget, SubmitOptions, MutationStatus, MutationResult, MutationRequest, MutationTransport, MutationsOptions } from "./mutations"
 
 export type { RuntimeOptions, ScopedState } from "./runtime"
 export type { Slot, SlotType, SlotAnchor, Region, Item, ScanResult, ItemPlan, RenderMode, ItemValues, AddItemOptions, ApplyOptions, RevertToken } from "./slot-index"

--- a/javascript/packages/client/src/mutations.ts
+++ b/javascript/packages/client/src/mutations.ts
@@ -1,0 +1,268 @@
+import type { ApplyReport, Collected, Item, ItemValues, Payload, Slot, SlotIndex } from "./slot-index"
+import type { SlotState, StateScope } from "./state"
+
+export interface MutationTarget {
+  file: string
+  index?: number
+  name?: string
+  occurrence?: number
+}
+
+export interface SubmitOptions {
+  url: string
+  method?: string
+  body?: FormData | Record<string, string>
+  into: MutationTarget
+  values?: ItemValues
+  key?: string
+  confirmKey?: (payload: Payload, temp: string) => string | null
+  scope?: "collection" | "payload"
+}
+
+export type MutationStatus = "confirmed" | "failed" | "stale" | "detached"
+
+export interface MutationResult {
+  status: MutationStatus
+  key: string
+  report?: ApplyReport
+  error?: Error
+}
+
+export interface MutationRequest {
+  url: string
+  method: string
+  body: FormData | Record<string, string> | undefined
+  headers: Record<string, string>
+}
+
+export type MutationTransport = (request: MutationRequest, signal: AbortSignal) => Promise<Payload | null>
+
+export interface MutationsOptions {
+  transport?: MutationTransport
+  headers?: () => Record<string, string>
+  format?: string
+}
+
+interface Sending {
+  options: SubmitOptions
+  key: string
+  slot: Slot | null
+}
+
+export class SlotMutations {
+  readonly #slots: SlotIndex
+  readonly #state: SlotState
+  readonly #options: MutationsOptions
+  readonly #records = new Map<string, Sending>()
+
+  #queue: Promise<unknown> = Promise.resolve()
+  #controller = new AbortController()
+  #minted = 0
+
+  constructor(slots: SlotIndex, state: SlotState, options: MutationsOptions = {}) {
+    this.#slots = slots
+    this.#state = state
+    this.#options = options
+  }
+
+  submit(options: SubmitOptions): Promise<MutationResult> {
+    const key = options.key ?? `herb-pending-${(this.#minted += 1)}`
+    const slot = this.#collection(options.into)
+    const item = slot ? this.#slots.addItem(slot, key, { values: options.values, text: true }) : null
+
+    if (slot && item) this.#setStates(slot, item, { pending: true, failed: false })
+
+    const record: Sending = { options, key, slot: item ? slot : null }
+
+    this.#records.set(key, record)
+
+    return this.#enqueue(record)
+  }
+
+  retry(key: string): Promise<MutationResult> | null {
+    const record = this.#records.get(key)
+
+    if (!record) return null
+
+    const item = record.slot?.items.get(key) ?? null
+
+    if (record.slot && item) this.#setStates(record.slot, item, { pending: true, failed: false })
+
+    return this.#enqueue(record)
+  }
+
+  discard(key: string): boolean {
+    const record = this.#records.get(key)
+
+    if (!record) return false
+
+    this.#records.delete(key)
+
+    if (record.slot) return this.#slots.removeItem(record.slot, key)
+
+    return true
+  }
+
+  abort(): void {
+    this.#controller.abort()
+    this.#controller = new AbortController()
+  }
+
+  #enqueue(record: Sending): Promise<MutationResult> {
+    const result = this.#queue.then(() => this.#send(record))
+
+    this.#queue = result.catch(() => undefined)
+
+    return result
+  }
+
+  async #send(record: Sending): Promise<MutationResult> {
+    const { options, key } = record
+    let payload: Payload | null = null
+
+    try {
+      payload = await this.#transport()(this.#request(options), this.#controller.signal)
+    } catch (error) {
+      this.#fail(record)
+
+      return { status: record.slot ? "failed" : "detached", key, error: error as Error }
+    }
+
+    return this.#confirm(record, payload)
+  }
+
+  #confirm(record: Sending, payload: Payload | null): MutationResult {
+    const { options, key } = record
+    const slot = record.slot
+
+    if (!payload) {
+      this.#settle(record)
+
+      return { status: slot ? "confirmed" : "detached", key }
+    }
+
+    let confirmed = key
+
+    if (slot) {
+      const real = (options.confirmKey ?? this.#realKey.bind(this))(payload, key)
+
+      if (real && real !== key) {
+        if (this.#slots.rekeyItem(slot, key, real)) confirmed = real
+        else this.#slots.removeItem(slot, key)
+      }
+    }
+
+    const narrowed = slot && (options.scope ?? "collection") === "collection" ? this.#narrow(payload, slot) : payload
+    const report = this.#slots.apply(narrowed, { items: "merge" })
+
+    if (report.applied === 0 && report.deferred.some((deferred) => deferred.reason === "stale-version")) {
+      this.#settle(record, confirmed)
+      this.#records.delete(key)
+
+      return { status: "stale", key: confirmed, report }
+    }
+
+    this.#settle(record, confirmed)
+    this.#records.delete(key)
+
+    return { status: slot ? "confirmed" : "detached", key: confirmed, report }
+  }
+
+  #settle(record: Sending, confirmed?: string): void {
+    const slot = record.slot
+    const item = slot?.items.get(confirmed ?? record.key) ?? null
+
+    if (slot && item) this.#setStates(slot, item, { pending: false, failed: false })
+  }
+
+  #fail(record: Sending): void {
+    const slot = record.slot
+    const item = slot?.items.get(record.key) ?? null
+
+    if (slot && item) this.#setStates(slot, item, { pending: false, failed: true })
+  }
+
+  #setStates(slot: Slot, item: Item, values: Record<string, boolean>): void {
+    const region = this.#slots.regionOf(slot)
+
+    if (!region) return
+
+    const scope: StateScope = { region, item }
+
+    this.#state.setState(values, { scope })
+  }
+
+  #collection(target: MutationTarget): Slot | null {
+    const index = target.name ?? target.index
+
+    if (index === undefined) return null
+
+    const slot = this.#slots.slot(target.file, index, target.occurrence ?? 0)
+
+    return slot?.type === "collection" ? slot : null
+  }
+
+  #realKey(payload: Payload, temp: string): string | null {
+    for (const value of Object.values(payload.slots)) {
+      if (typeof value !== "object" || value === null || !("items" in value)) continue
+
+      const keys = Object.keys((value as Collected).items).filter((key) => key !== temp)
+
+      if (keys.length === 1) return keys[0]
+    }
+
+    return null
+  }
+
+  #narrow(payload: Payload, slot: Slot): Payload {
+    const value = payload.slots[slot.index]
+
+    if (value === undefined) return payload
+
+    return { ...payload, slots: { [slot.index]: value } }
+  }
+
+  #request(options: SubmitOptions): MutationRequest {
+    const headers: Record<string, string> = {
+      Accept: "application/vnd.herb.slots+json",
+      ...this.#options.headers?.(),
+    }
+
+    const token = typeof document === "undefined" ? null : document.querySelector<HTMLMetaElement>('meta[name="csrf-token"]')?.content
+
+    if (token && !headers["X-CSRF-Token"]) headers["X-CSRF-Token"] = token
+
+    return {
+      url: options.url,
+      method: (options.method ?? "post").toUpperCase(),
+      body: options.body,
+      headers,
+    }
+  }
+
+  #transport(): MutationTransport {
+    return this.#options.transport ?? defaultTransport(this.#options.format ?? "slots")
+  }
+}
+
+function defaultTransport(format: string): MutationTransport {
+  return async (request, signal) => {
+    const url = new URL(request.url, window.location.href)
+
+    url.searchParams.set("format", format)
+
+    const body =
+      request.body instanceof FormData ? request.body : request.body ? new URLSearchParams(request.body) : undefined
+
+    const response = await fetch(url.toString(), {
+      method: request.method,
+      body,
+      headers: request.headers,
+      signal,
+    })
+
+    if (!response.ok) throw new Error(`Herb mutation failed with ${response.status}`)
+
+    return (await response.json()) as Payload
+  }
+}

--- a/javascript/packages/client/src/runtime.ts
+++ b/javascript/packages/client/src/runtime.ts
@@ -1,6 +1,8 @@
 import { SlotIndex } from "./slot-index"
+import { SlotMutations } from "./mutations"
 import { SlotState } from "./state"
 
+import type { MutationsOptions } from "./mutations"
 import type { ScopedSetOptions, StateOptions, StateScope, StateValue } from "./state"
 
 const CONSTRUCT = Symbol("HerbRuntime.start")
@@ -9,11 +11,13 @@ let instance: HerbRuntime | null = null
 
 export interface RuntimeOptions {
   state?: StateOptions
+  mutations?: MutationsOptions
 }
 
 export class HerbRuntime {
   public readonly slots: SlotIndex
   public readonly state: SlotState
+  public readonly mutations: SlotMutations
 
   private constructor(token?: symbol, options: RuntimeOptions = {}) {
     if (token !== CONSTRUCT) {
@@ -22,6 +26,7 @@ export class HerbRuntime {
 
     this.slots = new SlotIndex()
     this.state = new SlotState(this.slots, options.state)
+    this.mutations = new SlotMutations(this.slots, this.state, options.mutations)
   }
 
   static start(options: RuntimeOptions = {}): HerbRuntime {
@@ -46,6 +51,7 @@ export class HerbRuntime {
   stop(): void {
     this.slots.disconnect()
     this.state.disconnect()
+    this.mutations.abort()
 
     if (instance === this) {
       instance = null

--- a/javascript/packages/client/src/slot-index.ts
+++ b/javascript/packages/client/src/slot-index.ts
@@ -65,6 +65,7 @@ export type ItemValues = Record<number | string, string>
 export interface AddItemOptions {
   values?: ItemValues
   before?: string
+  text?: boolean
 }
 
 export interface ApplyOptions {
@@ -684,7 +685,7 @@ export class SlotIndex {
     this.#park(region, `${slot.index}:${ITEM_STATICS}`, this.#rowFragment(item))
   }
 
-  #buildItem(slot: Slot, key: string, template: DocumentFragment, anchor?: Node | null, values: SlotValues = {}): void {
+  #buildItem(slot: Slot, key: string, template: DocumentFragment, anchor?: Node | null, values: SlotValues = {}, text = false): void {
     const copy = template.cloneNode(true) as DocumentFragment
 
     for (const marker of this.#markers(copy)) {
@@ -704,7 +705,7 @@ export class SlotIndex {
       if (branch && branch[2] === ITEM_STATICS) node.remove()
     }
 
-    fillSlots(copy, values)
+    fillSlots(copy, values, text)
 
     const added = [...copy.childNodes]
     const target =
@@ -1012,7 +1013,7 @@ export class SlotIndex {
     const anchor =
       options.before !== undefined ? (slot.items.get(options.before)?.start ?? slot.anchor.end) : slot.anchor.end
 
-    this.#buildItem(slot, key, template, anchor, this.#itemValues(slot, template, options.values ?? {}))
+    this.#buildItem(slot, key, template, anchor, this.#itemValues(slot, template, options.values ?? {}), options.text === true)
 
     return slot.items.get(key) ?? null
   }
@@ -1684,7 +1685,7 @@ function templateNames(template: DocumentFragment): Map<string, number> {
   return names
 }
 
-function fillSlots(fragment: DocumentFragment, dynamics: SlotValues): void {
+function fillSlots(fragment: DocumentFragment, dynamics: SlotValues, text = false): void {
   for (const open of slotOpeners(fragment)) {
     const index = Number(SLOT_OPEN.exec(open.data.trim())?.[1])
     const value = dynamics[index]
@@ -1699,7 +1700,7 @@ function fillSlots(fragment: DocumentFragment, dynamics: SlotValues): void {
     range.setStartAfter(open)
     range.setEndBefore(close)
     range.deleteContents()
-    range.insertNode(range.createContextualFragment(value))
+    range.insertNode(range.createContextualFragment(text ? escapeText(value) : value))
   }
 
   for (const element of fragment.querySelectorAll(ANCHOR_SELECTOR)) {
@@ -1710,9 +1711,13 @@ function fillSlots(fragment: DocumentFragment, dynamics: SlotValues): void {
       if (value === undefined) continue
 
       if (name.length > 0) element.setAttribute(name.join(":"), value)
-      else if ((type ?? DEFAULT_SLOT_TYPE) === DEFAULT_SLOT_TYPE) element.innerHTML = value
+      else if ((type ?? DEFAULT_SLOT_TYPE) === DEFAULT_SLOT_TYPE) element.innerHTML = text ? escapeText(value) : value
     }
   }
+}
+
+function escapeText(value: string): string {
+  return value.replace(/[&<>]/g, (match) => (match === "&" ? "&amp;" : match === "<" ? "&lt;" : "&gt;"))
 }
 
 function blankSlots(fragment: DocumentFragment): void {

--- a/javascript/packages/client/test/mutations.test.ts
+++ b/javascript/packages/client/test/mutations.test.ts
@@ -1,0 +1,226 @@
+import { describe, test, expect, beforeEach } from "vitest"
+import { SlotIndex } from "../src/slot-index"
+import { SlotMutations } from "../src/mutations"
+import { SlotState } from "../src/state"
+
+import type { Payload } from "../src/slot-index"
+import type { MutationRequest } from "../src/mutations"
+
+const FILE = "app/views/conversations/show.html.erb"
+
+const PAGE =
+  `<!--herb-region:${FILE}:aaaaaaaa:0-->` +
+  `<ul data-herb-name="0:messages"><!--herb-slot:0:collection-->` +
+  `<!--herb-item:0:message_1--><li id="message_1" data-herb-slot="1:attribute:id">` +
+  `<span data-herb-name="2:body" data-herb-slot="2:child">hello</span>` +
+  `<em><!--herb-slot:3:conditional--><!--herb-branch:3:2-->Sent<!--/herb-slot:3--></em></li><!--/herb-item:0-->` +
+  `<!--/herb-slot:0--></ul>` +
+  `<template data-herb-region="${FILE}:aaaaaaaa">` +
+  `<!--herb-branch:3:0-->Sending…<!--herb-branch:3:1-->Not sent<!--herb-branch:3:2-->Sent` +
+  `</template>` +
+  `<!--/herb-region:${FILE}-->` +
+  `<template data-herb-dependencies>${JSON.stringify({
+    state: {},
+    states: {
+      [FILE]: {
+        version: "aaaaaaaa",
+        declarations: [
+          { name: "pending", kind: "boolean", default: "false", scope: 0 },
+          { name: "failed", kind: "boolean", default: "false", scope: 0 },
+        ],
+        reads: {},
+        conditionals: { 3: { arms: [["pending", null, 0], ["failed", null, 1]], else: 2 } },
+      },
+    },
+  })}</template>`
+
+function confirmPayload(key: string, body: string): Payload {
+  return {
+    template: FILE,
+    version: "aaaaaaaa",
+    occurrence: 0,
+    slots: { 0: { items: { [key]: { 1: key, 2: body } } }, 9: "unrelated" },
+  }
+}
+
+let slots: SlotIndex
+let state: SlotState
+
+function build(transport: (request: MutationRequest, signal: AbortSignal) => Promise<Payload | null>): SlotMutations {
+  return new SlotMutations(slots, state, { transport })
+}
+
+beforeEach(() => {
+  document.body.innerHTML = PAGE
+
+  slots = new SlotIndex()
+  slots.scan(document.body)
+
+  state = new SlotState(slots, { persist: "none" })
+  state.adopt()
+})
+
+describe("SlotMutations", () => {
+  test("the row appears pending before the request resolves, and the node survives the confirm", async () => {
+    let release!: (payload: Payload) => void
+    const mutations = build(() => new Promise((resolve) => (release = resolve)))
+
+    const result = mutations.submit({
+      url: "/messages",
+      body: { body: "typed" },
+      into: { file: FILE, name: "messages" },
+      values: { body: "typed" },
+    })
+
+    await Promise.resolve()
+
+    const pendingRow = document.querySelectorAll("li")[1]
+
+    expect(pendingRow.textContent).toContain("typed")
+    expect(pendingRow.textContent).toContain("Sending…")
+
+    release(confirmPayload("message_42", "stored"))
+
+    const outcome = await result
+
+    expect(outcome.status).toBe("confirmed")
+    expect(outcome.key).toBe("message_42")
+    expect(document.querySelector("#message_42")).toBe(pendingRow)
+    expect(pendingRow.textContent).toContain("stored")
+    expect(pendingRow.textContent).toContain("Sent")
+    expect(document.querySelectorAll("li")).toHaveLength(2)
+  })
+
+  test("two rapid sends both land, in order, with neither aborted", async () => {
+    const seen: string[] = []
+    const mutations = build((request) => {
+      const body = (request.body as Record<string, string>).body
+
+      seen.push(body)
+
+      return Promise.resolve(confirmPayload(`message_${body}`, body))
+    })
+
+    const first = mutations.submit({ url: "/messages", body: { body: "one" }, into: { file: FILE, name: "messages" }, values: { body: "one" } })
+    const second = mutations.submit({ url: "/messages", body: { body: "two" }, into: { file: FILE, name: "messages" }, values: { body: "two" } })
+
+    const outcomes = await Promise.all([first, second])
+
+    expect(outcomes.map((outcome) => outcome.status)).toEqual(["confirmed", "confirmed"])
+    expect(seen).toEqual(["one", "two"])
+    expect(document.querySelectorAll("li")).toHaveLength(3)
+  })
+
+  test("a failed send keeps the row, marks it, and retry recovers it", async () => {
+    let attempts = 0
+    const mutations = build(() => {
+      attempts += 1
+
+      if (attempts === 1) return Promise.reject(new Error("boom"))
+
+      return Promise.resolve(confirmPayload("message_9", "recovered"))
+    })
+
+    const failed = await mutations.submit({
+      url: "/messages",
+      body: { body: "flaky" },
+      into: { file: FILE, name: "messages" },
+      values: { body: "flaky" },
+    })
+
+    expect(failed.status).toBe("failed")
+
+    const rows = document.querySelectorAll("li")
+
+    expect(rows).toHaveLength(2)
+    expect(rows[1].textContent).toContain("Not sent")
+
+    const retried = await mutations.retry(failed.key)!
+
+    expect(retried.status).toBe("confirmed")
+    expect(document.querySelector("#message_9")?.textContent).toContain("Sent")
+  })
+
+  test("discard reverts the optimistic row", async () => {
+    const mutations = build(() => Promise.reject(new Error("down")))
+    const failed = await mutations.submit({
+      url: "/messages",
+      body: {},
+      into: { file: FILE, name: "messages" },
+      values: { body: "gone" },
+    })
+
+    expect(mutations.discard(failed.key)).toBe(true)
+    expect(document.querySelectorAll("li")).toHaveLength(1)
+  })
+
+  test("the confirm is narrowed to the collection", async () => {
+    const mutations = build(() => Promise.resolve(confirmPayload("message_5", "narrow")))
+
+    const outcome = await mutations.submit({
+      url: "/messages",
+      body: {},
+      into: { file: FILE, name: "messages" },
+      values: { body: "narrow" },
+    })
+
+    expect(outcome.report?.deferred).toEqual([])
+  })
+
+  test("a stale version surfaces as its own status", async () => {
+    const stale: Payload = { ...confirmPayload("message_6", "old"), version: "bbbbbbbb" }
+    const mutations = build(() => Promise.resolve(stale))
+
+    const outcome = await mutations.submit({
+      url: "/messages",
+      body: {},
+      into: { file: FILE, name: "messages" },
+      values: { body: "old" },
+    })
+
+    expect(outcome.status).toBe("stale")
+    expect(document.querySelectorAll("li")[1]?.textContent).not.toContain("Sending…")
+  })
+
+  test("an optimistic value renders as text, never as markup", async () => {
+    const mutations = build(() => Promise.resolve(null))
+
+    await mutations.submit({
+      url: "/messages",
+      body: {},
+      into: { file: FILE, name: "messages" },
+      values: { body: '<img src="x" onerror="window.__pwned = true">' },
+    })
+
+    const fresh = document.querySelectorAll("li")[1]
+
+    expect(fresh.querySelector("img")).toBeNull()
+    expect(fresh.textContent).toContain('<img src="x"')
+  })
+
+  test("a submit with no reachable collection is detached but still sends", async () => {
+    const mutations = build(() => Promise.resolve(null))
+
+    const outcome = await mutations.submit({ url: "/messages", body: {}, into: { file: "missing.html.erb", index: 0 } })
+
+    expect(outcome.status).toBe("detached")
+    expect(document.querySelectorAll("li")).toHaveLength(1)
+  })
+
+  test("the request carries the verb, the accept header, and the csrf token", async () => {
+    document.head.innerHTML = `<meta name="csrf-token" content="tok123">`
+
+    let captured: MutationRequest | null = null
+    const mutations = build((request) => {
+      captured = request
+
+      return Promise.resolve(null)
+    })
+
+    await mutations.submit({ url: "/messages", body: {}, into: { file: FILE, name: "messages" } })
+
+    expect(captured!.method).toBe("POST")
+    expect(captured!.headers.Accept).toBe("application/vnd.herb.slots+json")
+    expect(captured!.headers["X-CSRF-Token"]).toBe("tok123")
+  })
+})


### PR DESCRIPTION
This pull request adds `SlotMutations`, the optimistic send path, exposed as `runtime.mutations`.

`SlotState` is the wrong vehicle for sends because it is read-through and latest-wins, its flush aborts the in-flight request, which would cancel the first of two quickly sent messages. `SlotMutations` is a FIFO queue with a concurrency of one that never aborts an earlier send.

```js
mutations.submit({
  url: form.action,
  body: new FormData(form),
  into: { file: "app/views/conversations/show.html.erb", name: "messages" },
  values: { body: input.value },
})
```

`submit` mints a temporary key, builds the row into the named collection from the parked item skeleton, fills the given values, and enqueues a POST carrying the CSRF token from the page's meta tag. On confirm it re-keys the row to the server's id, so the DOM node the user is looking at survives, and applies the payload with `items: "merge"` so the confirm cannot delete sibling rows. On failure the row stays, `retry(key)` re-enqueues it and `discard(key)` reverts the transaction that added it. A payload deferred on a stale version surfaces as its own `stale` status instead of leaving the row silently unconfirmed.