### PR TITLE
Client: Report what the runtime declined to do

### DIFF
--- a/javascript/packages/client/src/index.ts
+++ b/javascript/packages/client/src/index.ts
@@ -2,6 +2,8 @@ export { HerbRuntime, stateFor } from "./runtime"
 export { SlotIndex, SLOT_EVENT } from "./slot-index"
 export { SlotState, DEPENDENCIES_ATTRIBUTE, DEPENDENCIES_SELECTOR, STATE_EVENT } from "./state"
 export { SlotMutations } from "./mutations"
+export { report, RUNTIME_ORIGIN } from "./report"
+export type { RuntimeDiagnostic } from "./report"
 export type { MutationTarget, SubmitOptions, MutationStatus, MutationResult, MutationRequest, MutationTransport, MutationsOptions } from "./mutations"
 
 export type { RuntimeOptions, ScopedState } from "./runtime"

--- a/javascript/packages/client/src/index.ts
+++ b/javascript/packages/client/src/index.ts
@@ -2,7 +2,7 @@ export { HerbRuntime, stateFor } from "./runtime"
 export { SlotIndex, SLOT_EVENT } from "./slot-index"
 export { SlotState, DEPENDENCIES_ATTRIBUTE, DEPENDENCIES_SELECTOR, STATE_EVENT } from "./state"
 export { SlotMutations } from "./mutations"
-export { report, RUNTIME_ORIGIN } from "./report"
+export { report, clearOnNavigation, RUNTIME_ORIGIN } from "./report"
 export type { RuntimeDiagnostic } from "./report"
 export type { MutationTarget, SubmitOptions, MutationStatus, MutationResult, MutationRequest, MutationTransport, MutationsOptions } from "./mutations"
 

--- a/javascript/packages/client/src/report.ts
+++ b/javascript/packages/client/src/report.ts
@@ -1,0 +1,45 @@
+export interface RuntimeDiagnostic {
+  template: string
+  message: string
+  code?: string
+  severity?: "error" | "warning" | "info" | "hint"
+  origin?: string
+  location?: { start: { line: number; column: number } }
+  suggestion?: string
+  value?: string
+}
+
+interface DevToolsGlobal {
+  report?(input: RuntimeDiagnostic | RuntimeDiagnostic[]): unknown
+}
+
+export const RUNTIME_ORIGIN = "Herb Client Runtime"
+
+const MAX_QUEUED = 50
+
+const queued: RuntimeDiagnostic[] = []
+
+export function report(diagnostic: RuntimeDiagnostic): void {
+  const entry = { origin: RUNTIME_ORIGIN, ...diagnostic }
+  const devTools = globalThis.window && (window as { HerbDevTools?: DevToolsGlobal }).HerbDevTools
+
+  if (devTools?.report) {
+    if (queued.length > 0) devTools.report(queued.splice(0))
+
+    devTools.report(entry)
+
+    return
+  }
+
+  if (!debugging()) return
+
+  queued.push(entry)
+
+  if (queued.length > MAX_QUEUED) queued.shift()
+}
+
+function debugging(): boolean {
+  if (typeof document === "undefined") return false
+
+  return document.querySelector('meta[name="herb-debug-mode"][content="true"]') !== null
+}

--- a/javascript/packages/client/src/report.ts
+++ b/javascript/packages/client/src/report.ts
@@ -11,6 +11,7 @@ export interface RuntimeDiagnostic {
 
 interface DevToolsGlobal {
   report?(input: RuntimeDiagnostic | RuntimeDiagnostic[]): unknown
+  clear?(origin?: string): void
 }
 
 export const RUNTIME_ORIGIN = "Herb Client Runtime"
@@ -36,6 +37,22 @@ export function report(diagnostic: RuntimeDiagnostic): void {
   queued.push(entry)
 
   if (queued.length > MAX_QUEUED) queued.shift()
+}
+
+export function clearOnNavigation(): () => void {
+  if (typeof document === "undefined") return () => {}
+
+  const clear = (): void => {
+    queued.length = 0
+
+    const devTools = globalThis.window && (window as { HerbDevTools?: DevToolsGlobal }).HerbDevTools
+
+    devTools?.clear?.(RUNTIME_ORIGIN)
+  }
+
+  document.addEventListener("turbo:load", clear)
+
+  return () => document.removeEventListener("turbo:load", clear)
 }
 
 function debugging(): boolean {

--- a/javascript/packages/client/src/runtime.ts
+++ b/javascript/packages/client/src/runtime.ts
@@ -1,3 +1,4 @@
+import { clearOnNavigation } from "./report"
 import { SlotIndex } from "./slot-index"
 import { SlotMutations } from "./mutations"
 import { SlotState } from "./state"
@@ -19,6 +20,8 @@ export class HerbRuntime {
   public readonly state: SlotState
   public readonly mutations: SlotMutations
 
+  private stopClearing: (() => void) | null = null
+
   private constructor(token?: symbol, options: RuntimeOptions = {}) {
     if (token !== CONSTRUCT) {
       throw new TypeError("HerbRuntime is created by HerbRuntime.start()")
@@ -38,6 +41,7 @@ export class HerbRuntime {
     runtime.slots.observe()
     runtime.state.adopt()
     runtime.state.observe()
+    runtime.stopClearing = clearOnNavigation()
 
     instance = runtime
 
@@ -52,6 +56,8 @@ export class HerbRuntime {
     this.slots.disconnect()
     this.state.disconnect()
     this.mutations.abort()
+    this.stopClearing?.()
+    this.stopClearing = null
 
     if (instance === this) {
       instance = null

--- a/javascript/packages/client/src/state.ts
+++ b/javascript/packages/client/src/state.ts
@@ -1,3 +1,4 @@
+import { report } from "./report"
 import { SLOT_EVENT } from "./slot-index"
 
 import type { ApplyReport, Item, Payload, Region, Slot, SlotEventDetail, SlotIndex } from "./slot-index"
@@ -18,6 +19,8 @@ export interface DeclaredState {
   kind: StateKind
   default: string
   scope: "region" | number
+  line?: number | null
+  column?: number | null
 }
 
 export interface StateManifest {
@@ -437,16 +440,34 @@ export class SlotState {
 
     const resolved = this.#scope(options.scope, names[0])
 
-    if (!resolved) return false
+    if (!resolved) {
+      this.#reportUnknown(names[0], null)
+
+      return false
+    }
 
     const manifest = this.manifestFor(resolved.region)
 
-    if (!manifest) return false
+    if (!manifest) {
+      report({
+        template: resolved.region.file,
+        message: `the page was rendered by a different version of \`${resolved.region.file}\`, so its states cannot be resolved`,
+        code: "herb-stale-version",
+        severity: "warning",
+        suggestion: "reload the page",
+      })
+
+      return false
+    }
 
     const previous = new Map<string, StateValue>()
 
     for (const name of names) {
-      if (this.#declaration(manifest, resolved, name) === null) return false
+      if (this.#declaration(manifest, resolved, name) === null) {
+        this.#reportUnknown(name, resolved)
+
+        return false
+      }
 
       previous.set(name, this.#valueOf(name, resolved))
     }
@@ -519,6 +540,19 @@ export class SlotState {
     return () => document.removeEventListener(STATE_EVENT, handler)
   }
 
+  #reportUnknown(name: string, scope: StateScope | null): void {
+    const known = scope ? this.declaredStates(scope).map((declaration) => declaration.name) : []
+    const listed = known.length > 0 ? `the states in scope are ${known.join(", ")}` : "no scope on this page declares it"
+
+    report({
+      template: scope?.region.file ?? "",
+      message: `nothing here declares the state \`${name}\`; ${listed}`,
+      code: "herb-unknown-state",
+      severity: "error",
+      value: name,
+    })
+  }
+
   #scope(scope: StateScope | Element | undefined, name: string): StateScope | null {
     if (scope) return this.scopeFor(scope, name)
 
@@ -526,6 +560,10 @@ export class SlotState {
       const manifest = this.manifestFor(region)
 
       if (manifest && declared(manifest, name, null) !== null) return { region, item: null }
+    }
+
+    for (const region of this.#slots.regions()) {
+      if (this.#declared.has(region.file) && !this.manifestFor(region)) return { region, item: null }
     }
 
     return null
@@ -546,6 +584,19 @@ export class SlotState {
     const declaration = manifest ? this.#declaration(manifest, resolved, name) : null
 
     if (declaration && declaration.kind !== kind && declaration.kind !== "seeded") {
+      const spot = declaration.line !== undefined && declaration.line !== null
+        ? { location: { start: { line: declaration.line, column: declaration.column ?? 0 } } }
+        : {}
+
+      report({
+        template: resolved.region.file,
+        message: `${operation} on \`${name}\` did nothing, because \`${name}\` is a ${declaration.kind} and ${operation} needs a ${kind}`,
+        code: "herb-state-type",
+        severity: "error",
+        value: name,
+        suggestion: kind === "boolean" ? `set a value instead, or declare a boolean flag` : `use set with a ${kind} value`,
+        ...spot,
+      })
       throw new TypeError(`${operation} needs a ${kind} state, and \`${name}\` is declared as ${declaration.kind}`)
     }
   }
@@ -654,7 +705,15 @@ export class SlotState {
       const target = this.#targetBranch(conditional, scope)
 
       for (const slot of this.#scopedSlots(scope, Number(indexKey))) {
-        this.#slots.switchBranch(slot, target)
+        if (!this.#slots.switchBranch(slot, target) && slot.branch !== target) {
+          report({
+            template: scope.region.file,
+            message: `branch ${target ?? "else"} of slot ${slot.index} was never parked, so it cannot be shown`,
+            code: "herb-no-parked-branch",
+            severity: "warning",
+            suggestion: "the template renders in server mode; compile it with `herb:slots client`",
+          })
+        }
       }
     }
   }

--- a/javascript/packages/client/test/report.test.ts
+++ b/javascript/packages/client/test/report.test.ts
@@ -2,6 +2,8 @@ import { describe, test, expect, beforeEach, afterEach } from "vitest"
 import { SlotIndex } from "../src/slot-index"
 import { SlotState } from "../src/state"
 
+import { clearOnNavigation } from "../src/report"
+
 import type { RuntimeDiagnostic } from "../src/report"
 
 const FILE = "app/views/page/chat.html.erb"
@@ -87,7 +89,7 @@ describe("runtime diagnostics", () => {
   })
 
   test("a version mismatch reports and declines", () => {
-    document.body.innerHTML = PAGE.replaceAll(`${FILE}:aaaaaaaa:0`, `${FILE}:bbbbbbbb:0`).replace(
+    document.body.innerHTML = PAGE.split(`${FILE}:aaaaaaaa:0`).join(`${FILE}:bbbbbbbb:0`).replace(
       `data-herb-region="${FILE}:aaaaaaaa"`,
       `data-herb-region="${FILE}:bbbbbbbb"`,
     )
@@ -112,6 +114,28 @@ describe("runtime diagnostics", () => {
     state.setState({ also_missing: true })
 
     expect(devTools.entries.map((entry) => entry.code)).toEqual(["herb-unknown-state", "herb-unknown-state"])
+  })
+
+  test("a navigation clears the runtime's own findings and the queue", () => {
+    document.head.innerHTML = `<meta name="herb-debug-mode" content="true">`
+
+    const stop = clearOnNavigation()
+
+    state.setState({ missing: true })
+    document.dispatchEvent(new Event("turbo:load"))
+
+    const devTools = installDevTools()
+    const cleared: (string | undefined)[] = []
+
+    ;(devTools as unknown as { clear(origin?: string): void }).clear = (origin) => cleared.push(origin)
+
+    state.setState({ also_missing: true })
+    expect(devTools.entries.map((entry) => entry.value)).toEqual(["also_missing"])
+
+    document.dispatchEvent(new Event("turbo:load"))
+    expect(cleared).toEqual(["Herb Client Runtime"])
+
+    stop()
   })
 
   test("without the debug signal nothing is retained", () => {

--- a/javascript/packages/client/test/report.test.ts
+++ b/javascript/packages/client/test/report.test.ts
@@ -1,0 +1,126 @@
+import { describe, test, expect, beforeEach, afterEach } from "vitest"
+import { SlotIndex } from "../src/slot-index"
+import { SlotState } from "../src/state"
+
+import type { RuntimeDiagnostic } from "../src/report"
+
+const FILE = "app/views/page/chat.html.erb"
+
+const PAGE =
+  `<!--herb-region:${FILE}:aaaaaaaa:0-->` +
+  `<div><!--herb-slot:0:conditional--><!--herb-branch:0:1-->done<!--/herb-slot:0--></div>` +
+  `<template data-herb-region="${FILE}:aaaaaaaa"><!--herb-branch:0:0-->busy<!--herb-branch:0:1-->done</template>` +
+  `<!--/herb-region:${FILE}-->` +
+  `<template data-herb-dependencies>${JSON.stringify({
+    state: {},
+    states: {
+      [FILE]: {
+        version: "aaaaaaaa",
+        declarations: [
+          { name: "busy", kind: "boolean", default: "false", scope: "region", line: 1, column: 4 },
+          { name: "sort", kind: "string", default: '"name"', scope: "region", line: 1, column: 4 },
+        ],
+        reads: {},
+        conditionals: { 0: { arms: [["busy", null, 0]], else: 1 } },
+      },
+    },
+  })}</template>`
+
+interface FakeDevTools {
+  report(input: RuntimeDiagnostic | RuntimeDiagnostic[]): void
+  entries: RuntimeDiagnostic[]
+}
+
+function installDevTools(): FakeDevTools {
+  const devTools: FakeDevTools = {
+    entries: [],
+    report(input) {
+      devTools.entries.push(...(Array.isArray(input) ? input : [input]))
+    },
+  }
+
+  ;(window as unknown as { HerbDevTools?: FakeDevTools }).HerbDevTools = devTools
+
+  return devTools
+}
+
+let slots: SlotIndex
+let state: SlotState
+
+beforeEach(() => {
+  document.body.innerHTML = PAGE
+  document.head.innerHTML = ""
+
+  slots = new SlotIndex()
+  slots.scan(document.body)
+
+  state = new SlotState(slots, { persist: "none" })
+  state.adopt()
+})
+
+afterEach(() => {
+  delete (window as unknown as { HerbDevTools?: unknown }).HerbDevTools
+})
+
+describe("runtime diagnostics", () => {
+  test("toggle on a non-boolean reports the declaration and still throws", () => {
+    const devTools = installDevTools()
+
+    expect(() => state.toggle("sort")).toThrow(TypeError)
+
+    expect(devTools.entries).toHaveLength(1)
+    expect(devTools.entries[0]).toMatchObject({
+      template: FILE,
+      code: "herb-state-type",
+      origin: "Herb Client Runtime",
+      location: { start: { line: 1, column: 4 } },
+    })
+    expect(state.getState("sort")).toBe("name")
+  })
+
+  test("an unknown state lists what is in scope", () => {
+    const devTools = installDevTools()
+
+    expect(state.setState({ missing: true })).toBe(false)
+
+    expect(devTools.entries[0].code).toBe("herb-unknown-state")
+  })
+
+  test("a version mismatch reports and declines", () => {
+    document.body.innerHTML = PAGE.replaceAll(`${FILE}:aaaaaaaa:0`, `${FILE}:bbbbbbbb:0`).replace(
+      `data-herb-region="${FILE}:aaaaaaaa"`,
+      `data-herb-region="${FILE}:bbbbbbbb"`,
+    )
+    slots = new SlotIndex()
+    slots.scan(document.body)
+    state = new SlotState(slots, { persist: "none" })
+    state.adopt()
+
+    const devTools = installDevTools()
+
+    expect(state.setState({ busy: true })).toBe(false)
+    expect(devTools.entries[0].code).toBe("herb-stale-version")
+  })
+
+  test("diagnostics raised before the dev tools start are queued when debugging", () => {
+    document.head.innerHTML = `<meta name="herb-debug-mode" content="true">`
+
+    state.setState({ missing: true })
+
+    const devTools = installDevTools()
+
+    state.setState({ also_missing: true })
+
+    expect(devTools.entries.map((entry) => entry.code)).toEqual(["herb-unknown-state", "herb-unknown-state"])
+  })
+
+  test("without the debug signal nothing is retained", () => {
+    state.setState({ missing: true })
+
+    const devTools = installDevTools()
+
+    state.setState({ busy: true })
+
+    expect(devTools.entries).toHaveLength(0)
+  })
+})

--- a/javascript/packages/dev-tools/test/runtime-report-integration.test.ts
+++ b/javascript/packages/dev-tools/test/runtime-report-integration.test.ts
@@ -1,0 +1,64 @@
+import { describe, test, expect, beforeEach, afterEach } from "vitest"
+import { report, clearOnNavigation, RUNTIME_ORIGIN } from "@herb-tools/client"
+
+import { HerbDevTools } from "../src/index"
+
+let devTools: HerbDevTools | null = null
+let stopClearing: (() => void) | null = null
+
+beforeEach(() => {
+  localStorage.clear()
+  document.body.innerHTML = ""
+  document.head.innerHTML = `<meta name="herb-debug-mode" content="true">`
+})
+
+afterEach(() => {
+  stopClearing?.()
+  stopClearing = null
+  devTools?.stop()
+  devTools = null
+  document.head.innerHTML = ""
+})
+
+describe("the client runtime reporting into the panel", () => {
+  test("a diagnostic raised before start is delivered with the next one after it", () => {
+    report({ template: "app/views/a.html.erb", message: "raised before the panel existed" })
+
+    const instance = HerbDevTools.start({ devServer: false })!
+    devTools = instance
+
+    expect(instance.runtimePanel?.count).toBe(0)
+
+    report({ template: "app/views/a.html.erb", message: "raised after", code: "herb-unknown-state" })
+
+    expect(instance.runtimePanel?.count).toBe(2)
+  })
+
+  test("a navigation clears only the runtime's own findings", () => {
+    const instance = HerbDevTools.start({ devServer: false })!
+    devTools = instance
+    stopClearing = clearOnNavigation()
+
+    report({ template: "app/views/a.html.erb", message: "from the runtime" })
+    instance.report({ template: "app/views/a.html.erb", message: "from the linter", origin: "Herb Linter" })
+
+    expect(instance.runtimePanel?.count).toBe(2)
+
+    document.dispatchEvent(new Event("turbo:load"))
+
+    expect(instance.runtimePanel?.count).toBe(1)
+  })
+
+  test("entries carry the runtime origin the panel groups by", () => {
+    const instance = HerbDevTools.start({ devServer: false })!
+    devTools = instance
+
+    const handle = instance.report({ template: "app/views/a.html.erb", message: "direct", origin: RUNTIME_ORIGIN })
+
+    expect(instance.runtimePanel?.count).toBe(1)
+
+    handle.dismiss()
+
+    expect(instance.runtimePanel?.count).toBe(0)
+  })
+})

--- a/lib/herb/engine/slot_visitor.rb
+++ b/lib/herb/engine/slot_visitor.rb
@@ -637,6 +637,12 @@ module Herb
         empty = {} #: Hash[String, StateDirectives::Declaration]
         bucket = scope ? (@item_states[scope] ||= empty) : @region_states
 
+        location = node.location&.start
+
+        declared = declared.map { |declaration|
+          declaration.with(line: location&.line, column: location&.column)
+        }
+
         declared.each do |declaration|
           if @strict_locals.key?(declaration.name)
             raise Herb::Engine::CompilationError,

--- a/lib/herb/engine/state_directives.rb
+++ b/lib/herb/engine/state_directives.rb
@@ -23,7 +23,9 @@ module Herb
       Declaration = Data.define(
         :name,    #: String
         :kind,    #: Symbol
-        :default  #: String
+        :default, #: String
+        :line,    #: Integer?
+        :column   #: Integer?
       )
 
       Read = Data.define(
@@ -115,7 +117,7 @@ module Herb
           value = keyword.value
           kind = KINDS[value.class.name]
 
-          return Declaration.new(name: name, kind: kind, default: value.slice) if kind
+          return Declaration.new(name: name, kind: kind, default: value.slice, line: nil, column: nil) if kind
 
           case value
           when Prism::FloatNode
@@ -130,7 +132,7 @@ module Herb
           when Prism::CallNode
             bare_default(name, value, locals)
           else
-            Declaration.new(name: name, kind: :seeded, default: value.slice)
+            Declaration.new(name: name, kind: :seeded, default: value.slice, line: nil, column: nil)
           end
         end
 
@@ -139,7 +141,7 @@ module Herb
           identifier = value.name.to_s
 
           unless value.receiver.nil? && value.arguments.nil? && value.block.nil? && BARE.match?(identifier)
-            return Declaration.new(name: name, kind: :seeded, default: value.slice)
+            return Declaration.new(name: name, kind: :seeded, default: value.slice, line: nil, column: nil)
           end
 
           kind = locals[identifier]
@@ -150,7 +152,7 @@ module Herb
                   "a bare name that was never passed raises at render, so it has to be declared"
           end
 
-          Declaration.new(name: name, kind: kind, default: identifier)
+          Declaration.new(name: name, kind: kind, default: identifier, line: nil, column: nil)
         end
 
         #: (String) -> untyped

--- a/sig/herb/engine/state_directives.rbs
+++ b/sig/herb/engine/state_directives.rbs
@@ -18,12 +18,16 @@ module Herb
 
         attr_reader default(): String
 
-        def self.new: (String name, Symbol kind, String default) -> instance
-                    | (name: String, kind: Symbol, default: String) -> instance
+        attr_reader line(): Integer?
 
-        def self.members: () -> [ :name, :kind, :default ]
+        attr_reader column(): Integer?
 
-        def members: () -> [ :name, :kind, :default ]
+        def self.new: (String name, Symbol kind, String default, Integer? line, Integer? column) -> instance
+                    | (name: String, kind: Symbol, default: String, line: Integer?, column: Integer?) -> instance
+
+        def self.members: () -> [ :name, :kind, :default, :line, :column ]
+
+        def members: () -> [ :name, :kind, :default, :line, :column ]
       end
 
       class Read < Data


### PR DESCRIPTION
This pull request makes the client runtime report its deliberate silences as structured diagnostics through the `HerbDevTools.report()` API from #2327.

The slots design declines silently on purpose. A `setState` against a version-mismatched region is a no-op, `switchBranch` returns `false` when an arm was never parked, and a typed operation against the wrong kind does nothing. All of that is right in production and invisible in development, where a developer cannot tell the feature is off.

Each case now reports with a stable code, `herb-unknown-state`, `herb-state-type`, `herb-no-parked-branch` and `herb-stale-version`, with a message saying what happened and a suggestion saying what to do. The engine ships each declaration's line and column in the dependency map, so a state diagnostic points at the declaration that makes it wrong. Behavior is identical with and without the panel, report never means throw.

Delivery is dev-tools' job, so the client's `report()` is a thin producer. It forwards to `window.HerbDevTools.report()` when the panel is running, holds a bounded queue for diagnostics raised before `start()`, gated on the `herb-debug-mode` meta so production pages retain nothing, falls back to `console.warn` on debug pages without the panel, and clears its own findings on navigation under a `"Herb Client Runtime"` origin so stale cards do not accumulate across pages. An integration test drives the real dev-tools panel against the client's producer to prove the wiring.
