### PR TITLE
Client: Drive state from `data-herb-*` action attributes

### DIFF
--- a/javascript/packages/client/src/actions.ts
+++ b/javascript/packages/client/src/actions.ts
@@ -1,0 +1,507 @@
+import { ACTION_NAMES, ACTION_SCHEMA, ACTION_SELECTOR, HERB_ATTRIBUTES } from "./attributes"
+import { report } from "./report"
+import { boundValue, coerceState } from "./state"
+
+import type { ActionName, ActionSchema } from "./attributes"
+import type { DeclaredState, SlotState, StateScope, StateValue } from "./state"
+
+const DIRECT_EVENTS = ["mouseenter", "mouseleave"]
+
+const DEFAULT_EVENTS: Record<string, string> = {
+  form: "submit",
+  input: "input",
+  textarea: "input",
+  select: "change",
+  details: "toggle",
+}
+
+interface Clause {
+  event: string | null
+  rest: string
+}
+
+function defaultEventFor(element: Element): string {
+  if (element instanceof HTMLInputElement && ["submit", "button", "reset"].includes(element.type)) {
+    return "click"
+  }
+
+  return DEFAULT_EVENTS[element.localName] ?? "click"
+}
+
+export class SlotActions {
+  readonly #state: SlotState
+
+  #events = new Set<string>()
+  #direct = new Map<Element, () => void>()
+  #validated = new WeakSet<Element>()
+  #observer: MutationObserver | null = null
+  #listeners: [string, (event: Event) => void][] = []
+
+  constructor(state: SlotState) {
+    this.#state = state
+  }
+
+  start(root: ParentNode = document): void {
+    this.scan(root)
+
+    this.#observer?.disconnect()
+    this.#observer = new MutationObserver((records) => {
+      for (const record of records) {
+        for (const node of record.addedNodes) {
+          if (node instanceof Element) this.scan(node)
+        }
+      }
+    })
+
+    this.#observer.observe(root instanceof Element ? root : document.documentElement, {
+      childList: true,
+      subtree: true,
+    })
+  }
+
+  stop(): void {
+    this.#observer?.disconnect()
+    this.#observer = null
+
+    for (const [event, listener] of this.#listeners) document.removeEventListener(event, listener, true)
+
+    for (const detach of this.#direct.values()) detach()
+
+    this.#listeners = []
+    this.#events = new Set()
+    this.#direct = new Map()
+  }
+
+  scan(root: ParentNode | Element): void {
+    const elements = [
+      ...(root instanceof Element && root.matches(ACTION_SELECTOR) ? [root] : []),
+      ...root.querySelectorAll(ACTION_SELECTOR),
+    ]
+
+    for (const element of elements) {
+      for (const name of ACTION_NAMES) {
+        const value = element.getAttribute(HERB_ATTRIBUTES[name])
+
+        if (value === null) continue
+
+        for (const clause of clauses(value)) {
+          const event = clause.event ?? defaultEventFor(element)
+
+          if (DIRECT_EVENTS.includes(event)) {
+            this.#attach(element, event)
+          } else {
+            this.#delegate(event)
+          }
+        }
+      }
+
+      this.#validate(element)
+    }
+  }
+
+  #validate(element: Element): void {
+    if (this.#validated.has(element)) return
+
+    this.#validated.add(element)
+
+    for (const name of ACTION_NAMES) {
+      const attribute = HERB_ATTRIBUTES[name]
+      const value = element.getAttribute(attribute)
+
+      if (value === null) continue
+
+      if (!balancedQuotes(value)) {
+        report({
+          template: this.#templateOf(element),
+          message: `\`${attribute}="${value}"\` has an unbalanced quote`,
+          code: "herb-invalid-action",
+          severity: "error",
+        })
+
+        continue
+      }
+
+      for (const clause of clauses(value)) {
+        this.#validateClause(element, name, clause)
+      }
+    }
+  }
+
+  #validateClause(element: Element, action: ActionName, clause: Clause): void {
+    const schema: ActionSchema = ACTION_SCHEMA[action]
+    const attribute = HERB_ATTRIBUTES[action]
+
+    if (clause.event === "" || (clause.rest.trim() === "" && !schema.bare)) {
+      report({
+        template: this.#templateOf(element),
+        message: `\`${attribute}\` has a clause with ${clause.event === "" ? "no event before the arrow" : "nothing after the event"}`,
+        code: "herb-invalid-action",
+        severity: "error",
+      })
+
+      return
+    }
+
+    if (schema.operation === "set") {
+      for (const assignment of splitOutsideQuotes(clause.rest, ",")) {
+        this.#validateAssignment(element, assignment)
+      }
+
+      return
+    }
+
+    for (const name of names(clause.rest)) {
+      const resolved = this.#declaration(element, name)
+      if (!resolved) continue
+
+      const kind = resolved[1].kind
+
+      if (schema.needs && kind !== schema.needs && kind !== "seeded") {
+        this.#reportKind(resolved[0].region.file, attribute, name, kind, schema.needs)
+      }
+    }
+  }
+
+  #validateAssignment(element: Element, assignment: string): void {
+    const separator = assignment.indexOf("=")
+
+    if (separator < 1) {
+      report({
+        template: this.#templateOf(element),
+        message: `\`${assignment.trim()}\` in \`${HERB_ATTRIBUTES.set}\` is not a \`state=value\` pair`,
+        code: "herb-invalid-action",
+        severity: "error",
+      })
+
+      return
+    }
+
+    const name = assignment.slice(0, separator).trim()
+    const raw = unquote(assignment.slice(separator + 1).trim())
+    const resolved = this.#declaration(element, name)
+
+    if (!resolved || raw === "$value") return
+
+    const kind = resolved[1].kind
+
+    if ((kind === "boolean" && raw !== "true" && raw !== "false") || (kind === "integer" && !/^-?\d+$/.test(raw))) {
+      report({
+        template: resolved[0].region.file,
+        message: `\`${name}=${raw}\` does not parse as a ${kind}; \`${name}\` is declared as one`,
+        code: "herb-state-type",
+        severity: "error",
+        value: name,
+      })
+    }
+  }
+
+  #reportKind(template: string, attribute: string, name: string, kind: string, wanted: string): void {
+    report({
+      template,
+      message: `\`${attribute}\` on \`${name}\` can never work, because \`${name}\` is a ${kind} and it needs a ${wanted}`,
+      code: "herb-state-type",
+      severity: "error",
+      value: name,
+    })
+  }
+
+  #templateOf(element: Element): string {
+    return this.#state.scopeFor(element)?.region.file ?? ""
+  }
+
+  #delegate(event: string): void {
+    if (this.#events.has(event)) return
+
+    this.#events.add(event)
+
+    const listener = (fired: Event): void => this.#dispatch(fired)
+
+    document.addEventListener(event, listener, true)
+    this.#listeners.push([event, listener])
+  }
+
+  #attach(element: Element, _event: string): void {
+    if (this.#direct.has(element)) return
+
+    const listener = (fired: Event): void => {
+      this.#run(element, fired)
+    }
+
+    for (const direct of DIRECT_EVENTS) element.addEventListener(direct, listener)
+
+    this.#direct.set(element, () => {
+      for (const direct of DIRECT_EVENTS) element.removeEventListener(direct, listener)
+    })
+  }
+
+  #dispatch(event: Event): void {
+    const start = event.target
+
+    if (!(start instanceof Element)) return
+
+    let element: Element | null = start.closest(ACTION_SELECTOR)
+
+    while (element) {
+      if (this.#run(element, event)) return
+
+      element = element.parentElement?.closest(ACTION_SELECTOR) ?? null
+    }
+  }
+
+  #run(element: Element, event: Event): boolean {
+    let handled = false
+
+    for (const name of ACTION_NAMES) {
+      const attribute = HERB_ATTRIBUTES[name]
+      const value = element.getAttribute(attribute)
+
+      if (value === null) continue
+
+      for (const clause of clauses(value)) {
+        if ((clause.event ?? defaultEventFor(element)) !== event.type) continue
+
+        this.#execute(element, name, clause.rest, event)
+        handled = true
+      }
+    }
+
+    return handled
+  }
+
+  #execute(element: Element, action: ActionName, rest: string, event: Event): void {
+    const schema: ActionSchema = ACTION_SCHEMA[action]
+
+    try {
+      if (schema.operation === "set") {
+        this.#set(element, rest, event)
+      } else if (schema.operation === "toggle") {
+        this.#toggle(element, rest)
+      } else if (schema.operation === "reset") {
+        this.#reset(element, rest)
+      } else {
+        this.#count(element, rest, schema.step ?? 1)
+      }
+    } catch (error) {
+      if (!(error instanceof TypeError)) throw error
+    }
+  }
+
+  #declaration(element: Element, name: string): [StateScope, DeclaredState] | null {
+    const scope = this.#state.scopeFor(element, name)
+
+    if (!scope) {
+      report({
+        template: "",
+        message: `nothing around this element declares the state \`${name}\``,
+        code: "herb-unknown-state",
+        severity: "error",
+        value: name,
+      })
+
+      return null
+    }
+
+    const declaration = this.#state
+      .declaredStates(scope)
+      .find((candidate) => candidate.name === name)
+
+    return declaration ? [scope, declaration] : null
+  }
+
+  #apply(groups: Map<StateScope, Record<string, StateValue>>): void {
+    for (const [scope, values] of groups) {
+      this.#state.setState(values, { scope })
+    }
+  }
+
+  #group(groups: Map<StateScope, Record<string, StateValue>>, scope: StateScope, name: string, value: StateValue): void {
+    for (const [existing, values] of groups) {
+      if (existing.region === scope.region && existing.item === scope.item) {
+        values[name] = value
+
+        return
+      }
+    }
+
+    groups.set(scope, { [name]: value })
+  }
+
+  #set(element: Element, rest: string, event: Event): void {
+    const groups = new Map<StateScope, Record<string, StateValue>>()
+
+    for (const assignment of splitOutsideQuotes(rest, ",")) {
+      const separator = assignment.indexOf("=")
+
+      if (separator < 1) {
+        report({
+          template: "",
+          message: `\`${assignment}\` in \`${HERB_ATTRIBUTES.set}\` is not a \`state=value\` pair`,
+          code: "herb-invalid-action",
+          severity: "error",
+        })
+
+        return
+      }
+
+      const name = assignment.slice(0, separator).trim()
+      const raw = unquote(assignment.slice(separator + 1).trim())
+
+      const resolved = this.#declaration(element, name)
+      if (!resolved) return
+
+      const [scope, declaration] = resolved
+      const kind = declaration.kind
+
+      if (raw === "$value") {
+        const target = event.target
+
+        this.#group(groups, scope, name, target instanceof Element ? boundValue(target, kind) : null)
+
+        continue
+      }
+
+      if ((kind === "boolean" && raw !== "true" && raw !== "false") || (kind === "integer" && !/^-?\d+$/.test(raw))) {
+        report({
+          template: scope.region.file,
+          message: `\`${name}=${raw}\` does not parse as a ${kind}; \`${name}\` is declared as one`,
+          code: "herb-state-type",
+          severity: "error",
+          value: name,
+        })
+
+        return
+      }
+
+      this.#group(groups, scope, name, coerceState(raw, kind))
+    }
+
+    this.#apply(groups)
+  }
+
+  #toggle(element: Element, rest: string): void {
+    const groups = new Map<StateScope, Record<string, StateValue>>()
+
+    for (const name of names(rest)) {
+      const resolved = this.#declaration(element, name)
+      if (!resolved) return
+
+      const [scope, declaration] = resolved
+
+      if (declaration.kind !== "boolean" && declaration.kind !== "seeded") {
+        report({
+          template: scope.region.file,
+          message: `\`${HERB_ATTRIBUTES.toggle}\` on \`${name}\` did nothing, because \`${name}\` is a ${declaration.kind} and toggling needs a boolean`,
+          code: "herb-state-type",
+          severity: "error",
+          value: name,
+        })
+
+        return
+      }
+
+      this.#group(groups, scope, name, this.#state.getState(name, { scope }) !== true)
+    }
+
+    this.#apply(groups)
+  }
+
+  #count(element: Element, rest: string, direction: number): void {
+    const by = Number(element.getAttribute(HERB_ATTRIBUTES.by) ?? "1")
+    const step = direction * (Number.isFinite(by) ? by : 1)
+
+    for (const name of names(rest)) {
+      const resolved = this.#declaration(element, name)
+      if (!resolved) return
+
+      this.#state.increment(name, { scope: resolved[0], by: step })
+    }
+  }
+
+  #reset(element: Element, rest: string): void {
+    if (rest.trim() === "") {
+      const scope = this.#state.scopeFor(element)
+      if (!scope) return
+
+      for (const declaration of this.#state.declaredStates(scope)) {
+        this.#state.reset(declaration.name, { scope: this.#state.scopeFor(element, declaration.name) ?? scope })
+      }
+
+      return
+    }
+
+    for (const name of names(rest)) {
+      const resolved = this.#declaration(element, name)
+      if (!resolved) return
+
+      this.#state.reset(name, { scope: resolved[0] })
+    }
+  }
+}
+
+function clauses(value: string): Clause[] {
+  return splitOutsideQuotes(value.trim(), " ")
+    .filter((part) => part.length > 0)
+    .map((part) => {
+      const arrow = part.indexOf("->")
+
+      if (arrow === -1) {
+        return { event: null, rest: part }
+      }
+
+      return { event: part.slice(0, arrow), rest: part.slice(arrow + 2) }
+    })
+}
+
+function names(rest: string): string[] {
+  return splitOutsideQuotes(rest, ",").map((name) => name.trim()).filter((name) => name.length > 0)
+}
+
+function balancedQuotes(source: string): boolean {
+  let quoted = false
+
+  for (let position = 0; position < source.length; position += 1) {
+    if (source[position] === "'" && source[position - 1] !== "\\") {
+      quoted = !quoted
+    }
+  }
+
+  return !quoted
+}
+
+function splitOutsideQuotes(source: string, separator: string): string[] {
+  const parts: string[] = []
+  let current = ""
+  let quoted = false
+
+  for (let position = 0; position < source.length; position += 1) {
+    const character = source[position]
+
+    if (character === "'" && source[position - 1] !== "\\") {
+      quoted = !quoted
+      current += character
+
+      continue
+    }
+
+    if (character === separator && !quoted) {
+      parts.push(current)
+      current = ""
+
+      continue
+    }
+
+    current += character
+  }
+
+  parts.push(current)
+
+  return parts
+}
+
+function unquote(raw: string): string {
+  if (raw.length >= 2 && raw.startsWith("'") && raw.endsWith("'")) {
+    return raw.slice(1, -1).replace(/\\'/g, "'")
+  }
+
+  return raw
+}

--- a/javascript/packages/client/src/attributes.ts
+++ b/javascript/packages/client/src/attributes.ts
@@ -1,0 +1,34 @@
+export type ActionName = keyof typeof ACTION_SCHEMA
+export type HerbAttribute = keyof typeof HERB_ATTRIBUTES
+
+export interface ActionSchema {
+  operation: "set" | "toggle" | "count" | "reset"
+  needs?: "boolean" | "integer"
+  step?: number
+  bare?: boolean
+}
+
+export const HERB_ATTRIBUTES = {
+  slot: "data-herb-slot",
+  name: "data-herb-name",
+  region: "data-herb-region",
+  statics: "data-herb-statics",
+  dependencies: "data-herb-dependencies",
+  set: "data-herb-set",
+  toggle: "data-herb-toggle",
+  increment: "data-herb-increment",
+  decrement: "data-herb-decrement",
+  reset: "data-herb-reset",
+  by: "data-herb-by",
+} as const
+
+export const ACTION_SCHEMA = {
+  set: { operation: "set" },
+  toggle: { operation: "toggle", needs: "boolean" },
+  increment: { operation: "count", needs: "integer", step: 1 },
+  decrement: { operation: "count", needs: "integer", step: -1 },
+  reset: { operation: "reset", bare: true },
+} as const satisfies Record<string, ActionSchema>
+
+export const ACTION_NAMES = Object.keys(ACTION_SCHEMA) as ActionName[]
+export const ACTION_SELECTOR = ACTION_NAMES.map((name) => `[${HERB_ATTRIBUTES[name]}]`).join(", ")

--- a/javascript/packages/client/src/index.ts
+++ b/javascript/packages/client/src/index.ts
@@ -1,9 +1,19 @@
-export { HerbRuntime, stateFor } from "./runtime"
-export { SlotIndex, SLOT_EVENT } from "./slot-index"
-export { SlotState, DEPENDENCIES_ATTRIBUTE, DEPENDENCIES_SELECTOR, STATE_EVENT } from "./state"
+export { HerbRuntime } from "./runtime"
+export { SlotIndex } from "./slot-index"
+export { SlotState } from "./state"
 export { SlotMutations } from "./mutations"
-export { report, clearOnNavigation, RUNTIME_ORIGIN } from "./report"
+export { SlotActions } from "./actions"
+
+export { stateFor } from "./runtime"
+export { report, clearOnNavigation } from "./report"
+
+export { SLOT_EVENT } from "./slot-index"
+export { RUNTIME_ORIGIN } from "./report"
+export { DEPENDENCIES_ATTRIBUTE, DEPENDENCIES_SELECTOR, STATE_EVENT } from "./state"
+export { HERB_ATTRIBUTES, ACTION_NAMES, ACTION_SCHEMA, ACTION_SELECTOR } from "./attributes"
+
 export type { RuntimeDiagnostic } from "./report"
+export type { HerbAttribute, ActionName, ActionSchema } from "./attributes"
 export type { MutationTarget, SubmitOptions, MutationStatus, MutationResult, MutationRequest, MutationTransport, MutationsOptions } from "./mutations"
 
 export type { RuntimeOptions, ScopedState } from "./runtime"

--- a/javascript/packages/client/src/report.ts
+++ b/javascript/packages/client/src/report.ts
@@ -34,6 +34,8 @@ export function report(diagnostic: RuntimeDiagnostic): void {
 
   if (!debugging()) return
 
+  console.warn(`[herb] ${entry.message}${entry.suggestion ? `. ${entry.suggestion}` : ""}`, entry)
+
   queued.push(entry)
 
   if (queued.length > MAX_QUEUED) queued.shift()

--- a/javascript/packages/client/src/runtime.ts
+++ b/javascript/packages/client/src/runtime.ts
@@ -1,4 +1,5 @@
 import { clearOnNavigation } from "./report"
+import { SlotActions } from "./actions"
 import { SlotIndex } from "./slot-index"
 import { SlotMutations } from "./mutations"
 import { SlotState } from "./state"
@@ -19,6 +20,7 @@ export class HerbRuntime {
   public readonly slots: SlotIndex
   public readonly state: SlotState
   public readonly mutations: SlotMutations
+  public readonly actions: SlotActions
 
   private stopClearing: (() => void) | null = null
 
@@ -30,6 +32,7 @@ export class HerbRuntime {
     this.slots = new SlotIndex()
     this.state = new SlotState(this.slots, options.state)
     this.mutations = new SlotMutations(this.slots, this.state, options.mutations)
+    this.actions = new SlotActions(this.state)
   }
 
   static start(options: RuntimeOptions = {}): HerbRuntime {
@@ -41,6 +44,7 @@ export class HerbRuntime {
     runtime.slots.observe()
     runtime.state.adopt()
     runtime.state.observe()
+    runtime.actions.start()
     runtime.stopClearing = clearOnNavigation()
 
     instance = runtime
@@ -56,6 +60,7 @@ export class HerbRuntime {
     this.slots.disconnect()
     this.state.disconnect()
     this.mutations.abort()
+    this.actions.stop()
     this.stopClearing?.()
     this.stopClearing = null
 

--- a/javascript/packages/client/src/slot-index.ts
+++ b/javascript/packages/client/src/slot-index.ts
@@ -17,6 +17,8 @@
  * attaching slots to an already-indexed region when the new markup landed inside one.
  */
 
+import { HERB_ATTRIBUTES } from "./attributes"
+
 const REGION_OPEN = /^herb-region:(.*):([0-9a-f]+):(\d+)$/
 const REGION_CLOSE = /^\/herb-region:(.*)$/
 const SLOT_OPEN = /^herb-slot:(\d+)(?::([a-z_]+))?$/
@@ -27,12 +29,12 @@ const BRANCH = /^herb-branch:(\d+):(\w+)$/
 const MARKER = /^\/?herb-(region|slot|item|branch):/
 const STATICS_REGION = /^(.*):([0-9a-f]+)$/
 const ITEM_STATICS = "item"
-const STATICS_SELECTOR = "template[data-herb-region], template[data-herb-statics]"
+const STATICS_SELECTOR = `template[${HERB_ATTRIBUTES.region}], template[${HERB_ATTRIBUTES.statics}]`
 const MAX_JOURNAL = 50
 
-const ANCHOR_ATTRIBUTE = "data-herb-slot"
+const ANCHOR_ATTRIBUTE = HERB_ATTRIBUTES.slot
 const ANCHOR_SELECTOR = `[${ANCHOR_ATTRIBUTE}]`
-const NAME_ATTRIBUTE = "data-herb-name"
+const NAME_ATTRIBUTE = HERB_ATTRIBUTES.name
 const NAME_ENTRY = /^(\d+):(.+)$/
 
 const DEFAULT_SLOT_TYPE: SlotType = "child"
@@ -109,10 +111,10 @@ export interface Slot {
 export type SlotOperation =
   | "value"
   | "attribute"
-  | "item-rekeyed"
   | "markup"
   | "branch"
   | "item-added"
+  | "item-rekeyed"
   | "item-removed"
   | "item-updated"
 
@@ -1416,7 +1418,7 @@ export class SlotIndex {
   }
 
   #staticsIdentity(element: HTMLTemplateElement): StaticsIdentity | null {
-    const named = element.getAttribute("data-herb-region")
+    const named = element.getAttribute(HERB_ATTRIBUTES.region)
 
     if (named !== null) {
       const match = STATICS_REGION.exec(named)
@@ -1641,7 +1643,7 @@ function skeletonElements(root: Node): HTMLTemplateElement[] {
 }
 
 function parkedBranches(element: HTMLTemplateElement): FragmentMap {
-  const named = element.getAttribute("data-herb-statics")
+  const named = element.getAttribute(HERB_ATTRIBUTES.statics)
 
   if (named !== null) return new Map([[named, element.content]])
 

--- a/javascript/packages/client/src/state.ts
+++ b/javascript/packages/client/src/state.ts
@@ -1,18 +1,22 @@
 import { report } from "./report"
+
+import { HERB_ATTRIBUTES } from "./attributes"
 import { SLOT_EVENT } from "./slot-index"
 
 import type { ApplyReport, Item, Payload, Region, Slot, SlotEventDetail, SlotIndex } from "./slot-index"
 
 const VALUE_ELEMENTS = ["INPUT", "TEXTAREA", "SELECT"]
-
-export const DEPENDENCIES_ATTRIBUTE = "data-herb-dependencies"
-export const DEPENDENCIES_SELECTOR = `template[${DEPENDENCIES_ATTRIBUTE}]`
+const IDLE: StateReport = { applied: 0, deferred: [], written: 0, restored: 0, stale: false, failed: false }
 
 export const STATE_EVENT = "herb:state-change"
+export const DEPENDENCIES_ATTRIBUTE = HERB_ATTRIBUTES.dependencies
+export const DEPENDENCIES_SELECTOR = `template[${DEPENDENCIES_ATTRIBUTE}]`
 
 export type StateMode = "identity" | "structural" | "derived"
 export type StateKind = "boolean" | "integer" | "string" | "symbol" | "nil" | "seeded"
 export type StateValue = string | number | boolean | null
+export type StatePersistence = "url" | "known" | "none"
+export type StateTransport = (request: StateRequest, signal: AbortSignal) => Promise<Payload | null>
 
 export interface DeclaredState {
   name: string
@@ -48,7 +52,6 @@ export interface StateChangeDetail {
 export interface ScopedSetOptions {
   scope?: StateScope | Element
 }
-export type StatePersistence = "url" | "known" | "none"
 
 export interface StateSlot {
   file: string
@@ -68,8 +71,6 @@ export interface StateRequest {
   changed: string[]
 }
 
-export type StateTransport = (request: StateRequest, signal: AbortSignal) => Promise<Payload | null>
-
 export interface StateOptions {
   transport?: StateTransport
   debounce?: number
@@ -88,8 +89,6 @@ interface Restore {
   slot: Slot
   value: string
 }
-
-const IDLE: StateReport = { applied: 0, deferred: [], written: 0, restored: 0, stale: false, failed: false }
 
 export class SlotState {
   readonly #slots: SlotIndex
@@ -112,6 +111,7 @@ export class SlotState {
 
   constructor(slots: SlotIndex, options: StateOptions = {}) {
     this.#slots = slots
+
     this.#options = {
       transport: options.transport ?? this.#fetch.bind(this),
       debounce: options.debounce ?? 0,
@@ -119,7 +119,9 @@ export class SlotState {
       format: options.format ?? "slots",
     }
 
-    if (this.#persisted()) this.#readLocation()
+    if (this.#persisted()) {
+      this.#readLocation()
+    }
   }
 
   #persisted(): boolean {
@@ -224,7 +226,9 @@ export class SlotState {
       this.#pending.set(name, next)
       this.#sequence.set(name, (this.#sequence.get(name) ?? 0) + 1)
 
-      if (!this.#previous.has(name)) this.#previous.set(name, this.#values.get(name))
+      if (!this.#previous.has(name)) {
+        this.#previous.set(name, this.#values.get(name))
+      }
 
       this.#values.set(name, next)
     }
@@ -253,7 +257,9 @@ export class SlotState {
     this.#restores = []
     this.#previous = new Map()
 
-    if (changes.size === 0) return this.#settle(IDLE)
+    if (changes.size === 0) {
+      return this.#settle(IDLE)
+    }
 
     const changed = [...changes.keys()]
     const taken = new Map(changed.map((name) => [name, this.#sequence.get(name) ?? 0]))
@@ -286,11 +292,15 @@ export class SlotState {
 
     this.#forget(transient)
 
-    if (this.#superseded(taken)) return this.#settle({ ...IDLE, written: restores.length, stale: true })
+    if (this.#superseded(taken)) {
+      return this.#settle({ ...IDLE, written: restores.length, stale: true })
+    }
 
     const report = payload ? this.#slots.apply(payload) : { applied: 0, deferred: [] }
 
-    if (this.#persisted()) this.#writeLocation()
+    if (this.#persisted()) {
+      this.#writeLocation()
+    }
 
     return this.#settle({ ...report, written: restores.length, restored: 0, stale: false, failed: false })
   }
@@ -300,7 +310,9 @@ export class SlotState {
 
     this.#waiting = []
 
-    for (const resolve of waiting) resolve(report)
+    for (const resolve of waiting) {
+      resolve(report)
+    }
 
     return report
   }
@@ -334,7 +346,9 @@ export class SlotState {
   }
 
   #restore(restores: Restore[]): void {
-    for (const restore of [...restores].reverse()) this.#write(restore.slot, restore.value)
+    for (const restore of [...restores].reverse()) {
+      this.#write(restore.slot, restore.value)
+    }
   }
 
   #write(slot: Slot, value: string): boolean {
@@ -398,7 +412,6 @@ export class SlotState {
       if (!containsNode(region, target)) continue
 
       const manifest = this.manifestFor(region)
-
       if (!manifest) continue
 
       const item = enclosingItem(region, target)
@@ -415,7 +428,6 @@ export class SlotState {
 
   declaredStates(scope: StateScope): DeclaredState[] {
     const manifest = this.manifestFor(scope.region)
-
     if (!manifest) return []
 
     const collection = scope.item ? collectionOf(scope.region, scope.item) : null
@@ -427,7 +439,6 @@ export class SlotState {
 
   getState(name: string, options: ScopedSetOptions = {}): StateValue {
     const resolved = this.#scope(options.scope, name)
-
     if (!resolved) return null
 
     return this.#valueOf(name, resolved)
@@ -435,7 +446,6 @@ export class SlotState {
 
   setState(values: Record<string, StateValue>, options: ScopedSetOptions = {}): boolean {
     const names = Object.keys(values)
-
     if (names.length === 0) return false
 
     const resolved = this.#scope(options.scope, names[0])
@@ -511,7 +521,6 @@ export class SlotState {
 
   reset(name: string, options: ScopedSetOptions = {}): boolean {
     const resolved = this.#scope(options.scope, name)
-
     if (!resolved) return false
 
     const seeded = this.#seeds.get(resolved.region)?.get(resolved.item?.key ?? "")?.get(name)
@@ -524,7 +533,6 @@ export class SlotState {
 
     const handler = (event: Event): void => {
       const detail = (event as CustomEvent<StateChangeDetail>).detail
-
       if (detail.name !== name) return
 
       if (scope) {
@@ -625,10 +633,11 @@ export class SlotState {
   #seed(name: string, scope: StateScope): StateValue | undefined {
     const bucket = scoped(this.#seeds, scope)
 
-    if (bucket.has(name)) return bucket.get(name)
+    if (bucket.has(name)) {
+      return bucket.get(name)
+    }
 
     const manifest = this.manifestFor(scope.region)
-
     if (!manifest) return undefined
 
     let value = this.#seedFromValueSlot(manifest, scope, name)
@@ -655,7 +664,7 @@ export class SlotState {
           ? (slot.anchor.element.getAttribute(slot.attribute) ?? "")
           : this.#slots.currentText(slot)
 
-        return coerce(text, declaration?.kind ?? "string")
+        return coerceState(text, declaration?.kind ?? "string")
       }
     }
 
@@ -685,6 +694,7 @@ export class SlotState {
 
   #store(scope: StateScope, name: string, value: StateValue): void {
     this.#seed(name, scope)
+
     scoped(this.#scoped, scope).set(name, value)
   }
 
@@ -692,14 +702,15 @@ export class SlotState {
     const text = printValue(value)
 
     for (const index of manifest.reads[name] ?? []) {
-      for (const slot of this.#scopedSlots(scope, index)) this.#write(slot, text)
+      for (const slot of this.#scopedSlots(scope, index)) {
+        this.#write(slot, text)
+      }
     }
   }
 
   #writeConditionals(manifest: StateManifest, scope: StateScope, changed: string[]): void {
     for (const [indexKey, conditional] of Object.entries(manifest.conditionals)) {
       const mentions = conditional.arms.some(([name]) => changed.includes(name))
-
       if (!mentions) continue
 
       const target = this.#targetBranch(conditional, scope)
@@ -736,7 +747,6 @@ export class SlotState {
     }
 
     const region = scope.region.slots.get(index)
-
     if (region) return [region]
 
     const found: Slot[] = []
@@ -803,11 +813,9 @@ export class SlotState {
     if (!(element instanceof Element) || !VALUE_ELEMENTS.includes(element.tagName)) return
 
     const scope = this.scopeFor(element)
-
     if (!scope) return
 
     const manifest = this.manifestFor(scope.region)
-
     if (!manifest) return
 
     for (const [name, indices] of Object.entries(manifest.bound ?? {})) {
@@ -888,10 +896,7 @@ export class SlotState {
 }
 
 
-function scoped(
-  store: Map<Region, Map<string, Map<string, StateValue>>>,
-  scope: StateScope,
-): Map<string, StateValue> {
+function scoped(store: Map<Region, Map<string, Map<string, StateValue>>>, scope: StateScope): Map<string, StateValue> {
   let regionStore = store.get(scope.region)
 
   if (!regionStore) {
@@ -981,7 +986,7 @@ function printValue(value: StateValue): string {
   return String(value)
 }
 
-function coerce(text: string, kind: StateKind): StateValue {
+export function coerceState(text: string, kind: StateKind): StateValue {
   if (kind === "boolean") return text === "true"
   if (kind === "integer") return /^-?\d+$/.test(text.trim()) ? Number(text.trim()) : 0
   if (kind === "nil") return text === "" ? null : text
@@ -989,12 +994,12 @@ function coerce(text: string, kind: StateKind): StateValue {
   return text
 }
 
-function boundValue(element: Element, kind: StateKind): StateValue {
+export function boundValue(element: Element, kind: StateKind): StateValue {
   if (element instanceof HTMLInputElement && element.type === "checkbox") return element.checked
 
   const raw = (element as HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement).value
 
-  return coerce(raw, kind)
+  return coerceState(raw, kind)
 }
 
 function rubyTruthy(value: StateValue): boolean {

--- a/javascript/packages/client/test/actions.test.ts
+++ b/javascript/packages/client/test/actions.test.ts
@@ -1,0 +1,296 @@
+import { describe, test, expect, beforeEach, afterEach } from "vitest"
+import { SlotActions } from "../src/actions"
+import { SlotIndex } from "../src/slot-index"
+import { SlotState, STATE_EVENT } from "../src/state"
+
+const FILE = "app/views/page/panel.html.erb"
+
+const PAGE =
+  `<!--herb-region:${FILE}:aaaaaaaa:0-->` +
+  `<section>` +
+  `<button id="toggle" data-herb-toggle="open">Details</button>` +
+  `<button id="both" data-herb-set="pending=false,failed=true">Fail</button>` +
+  `<button id="bump" data-herb-increment="attempts" data-herb-by="2">More</button>` +
+  `<button id="tab-a" data-herb-set="sort=name">A</button>` +
+  `<button id="quoted" data-herb-set="sort='hello, world'">Q</button>` +
+  `<form id="form" data-herb-set="pending=true"><input id="draft-input" data-herb-reset="blur->sort"></form>` +
+  `<input id="typer" data-herb-set="sort=$value">` +
+  `<select id="chooser" data-herb-set="sort=$value"><option value="date">date</option></select>` +
+  `<div id="menu" data-herb-set="mouseenter->open=true mouseleave->open=false">hover</div>` +
+  `<div><!--herb-slot:0:conditional--><!--herb-branch:0:1-->closed<!--/herb-slot:0--></div>` +
+  `<p><!--herb-slot:1-->0<!--/herb-slot:1--></p>` +
+  `<ul><!--herb-slot:2:collection-->` +
+  `<!--herb-item:2:a--><li id="a" data-herb-slot="3:attribute:id"><button class="star" data-herb-toggle="starred">s</button>` +
+  `<em><!--herb-slot:4:conditional--><!--herb-branch:4:1-->plain<!--/herb-slot:4--></em></li><!--/herb-item:2-->` +
+  `<!--herb-item:2:b--><li id="b" data-herb-slot="3:attribute:id"><button class="star" data-herb-toggle="starred">s</button>` +
+  `<em><!--herb-slot:4:conditional--><!--herb-branch:4:1-->plain<!--/herb-slot:4--></em></li><!--/herb-item:2-->` +
+  `<!--/herb-slot:2--></ul>` +
+  `</section>` +
+  `<template data-herb-region="${FILE}:aaaaaaaa">` +
+  `<!--herb-branch:0:0-->opened<!--herb-branch:0:1-->closed` +
+  `<!--herb-branch:4:0-->starred<!--herb-branch:4:1-->plain` +
+  `</template>` +
+  `<!--/herb-region:${FILE}-->` +
+  `<template data-herb-dependencies>${JSON.stringify({
+    state: {},
+    states: {
+      [FILE]: {
+        version: "aaaaaaaa",
+        declarations: [
+          { name: "open", kind: "boolean", default: "false", scope: "region" },
+          { name: "pending", kind: "boolean", default: "false", scope: "region" },
+          { name: "failed", kind: "boolean", default: "false", scope: "region" },
+          { name: "attempts", kind: "integer", default: "0", scope: "region" },
+          { name: "sort", kind: "string", default: '"name"', scope: "region" },
+          { name: "starred", kind: "boolean", default: "false", scope: 2 },
+        ],
+        reads: { attempts: [1] },
+        conditionals: {
+          0: { arms: [["open", null, 0]], else: 1 },
+          4: { arms: [["starred", null, 0]], else: 1 },
+        },
+      },
+    },
+  })}</template>`
+
+let slots: SlotIndex
+let state: SlotState
+let actions: SlotActions
+
+function click(selector: string): void {
+  document.querySelector<HTMLElement>(selector)!.dispatchEvent(new MouseEvent("click", { bubbles: true }))
+}
+
+beforeEach(() => {
+  document.body.innerHTML = PAGE
+
+  slots = new SlotIndex()
+  slots.scan(document.body)
+
+  state = new SlotState(slots, { persist: "none" })
+  state.adopt()
+
+  actions = new SlotActions(state)
+  actions.start(document.body)
+})
+
+afterEach(() => actions.stop())
+
+describe("declarative actions", () => {
+  test("a click toggles a boolean and flips its branch", () => {
+    click("#toggle")
+
+    expect(state.getState("open")).toBe(true)
+    expect(document.querySelector("div:not([id])")?.textContent).toContain("opened")
+
+    click("#toggle")
+
+    expect(state.getState("open")).toBe(false)
+  })
+
+  test("a comma pair lands as one transition", () => {
+    const order: string[] = []
+    const handler = (event: Event): void => {
+      order.push((event as CustomEvent<{ name: string }>).detail.name)
+    }
+
+    document.addEventListener(STATE_EVENT, handler)
+    click("#both")
+    document.removeEventListener(STATE_EVENT, handler)
+
+    expect(state.getState("pending")).toBe(false)
+    expect(state.getState("failed")).toBe(true)
+    expect(order).toEqual(["pending", "failed"])
+  })
+
+  test("increment honours data-herb-by", () => {
+    click("#bump")
+    click("#bump")
+
+    expect(state.getState("attempts")).toBe(4)
+    expect(document.querySelector("p")?.textContent).toContain("4")
+  })
+
+  test("a step that does not parse falls back to one", () => {
+    const bump = document.querySelector("#bump")!
+
+    bump.setAttribute("data-herb-by", "two")
+    click("#bump")
+
+    expect(state.getState("attempts")).toBe(1)
+  })
+
+  test("a stopped runtime detaches its hover listeners", () => {
+    const menu = document.querySelector("#menu")!
+
+    menu.dispatchEvent(new Event("mouseenter"))
+    expect(state.getState("open")).toBe(true)
+
+    actions.stop()
+
+    menu.dispatchEvent(new Event("mouseleave"))
+    expect(state.getState("open")).toBe(true)
+
+    actions = new SlotActions(state)
+    actions.start(document.body)
+  })
+
+  test("a string set is typed by the declaration", () => {
+    click("#tab-a")
+
+    expect(state.getState("sort")).toBe("name")
+  })
+
+  test("single quotes protect separators", () => {
+    click("#quoted")
+
+    expect(state.getState("sort")).toBe("hello, world")
+  })
+
+  test("a form defaults to submit, not click", () => {
+    expect(state.getState("pending")).toBe(false)
+
+    const form = document.querySelector("#form")!
+
+    form.dispatchEvent(new MouseEvent("click", { bubbles: true }))
+    expect(state.getState("pending")).toBe(false)
+
+    form.dispatchEvent(new Event("submit", { bubbles: true }))
+    expect(state.getState("pending")).toBe(true)
+  })
+
+  test("a select defaults to change and $value reads the target", () => {
+    const select = document.querySelector<HTMLSelectElement>("#chooser")!
+
+    select.value = "date"
+    select.dispatchEvent(new Event("change", { bubbles: true }))
+
+    expect(state.getState("sort")).toBe("date")
+  })
+
+  test("an input defaults to input", () => {
+    const input = document.querySelector<HTMLInputElement>("#typer")!
+
+    input.value = "typed"
+    input.dispatchEvent(new MouseEvent("click", { bubbles: true }))
+    expect(state.getState("sort")).toBe("name")
+
+    input.dispatchEvent(new Event("input", { bubbles: true }))
+    expect(state.getState("sort")).toBe("typed")
+  })
+
+  test("an explicit event overrides the element default", () => {
+    const input = document.querySelector<HTMLInputElement>("#draft-input")!
+
+    state.setState({ sort: "changed" })
+    input.dispatchEvent(new Event("input", { bubbles: true }))
+    expect(state.getState("sort")).toBe("changed")
+
+    input.dispatchEvent(new FocusEvent("blur"))
+    expect(state.getState("sort")).toBe("name")
+  })
+
+  test("mouseenter and mouseleave drive a dropdown without bubbling", () => {
+    const menu = document.querySelector("#menu")!
+
+    menu.dispatchEvent(new MouseEvent("mouseenter"))
+    expect(state.getState("open")).toBe(true)
+
+    menu.dispatchEvent(new MouseEvent("mouseleave"))
+    expect(state.getState("open")).toBe(false)
+  })
+
+  test("a button inside a row toggles that row's state and no other", () => {
+    document.querySelector("#a .star")!.dispatchEvent(new MouseEvent("click", { bubbles: true }))
+
+    expect(document.querySelector("#a em")?.textContent).toContain("starred")
+    expect(document.querySelector("#b em")?.textContent).toContain("plain")
+  })
+
+  test("a dynamically added element works through delegation", () => {
+    const late = document.createElement("button")
+
+    late.id = "late"
+    late.setAttribute("data-herb-toggle", "open")
+    document.querySelector("section")!.append(late)
+
+    click("#late")
+
+    expect(state.getState("open")).toBe(true)
+  })
+
+  test("invalid syntax is reported at scan, before any event", async () => {
+    const entries: { code: string }[] = []
+
+    ;(window as unknown as { HerbDevTools?: unknown }).HerbDevTools = {
+      report: (input: unknown) => entries.push(input as { code: string }),
+    }
+
+    const section = document.querySelector("section")!
+    const bad = document.createElement("button")
+
+    bad.setAttribute("data-herb-set", "pending")
+    section.append(bad)
+
+    const unquoted = document.createElement("button")
+
+    unquoted.setAttribute("data-herb-set", "sort='oops")
+    section.append(unquoted)
+
+    const unknown = document.createElement("button")
+
+    unknown.setAttribute("data-herb-toggle", "missing")
+    section.append(unknown)
+
+    const mistyped = document.createElement("button")
+
+    mistyped.setAttribute("data-herb-increment", "sort")
+    section.append(mistyped)
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(entries.map((entry) => entry.code)).toEqual([
+      "herb-invalid-action",
+      "herb-invalid-action",
+      "herb-unknown-state",
+      "herb-state-type",
+    ])
+
+    delete (window as unknown as { HerbDevTools?: unknown }).HerbDevTools
+  })
+
+  test("a valid page reports nothing at scan", () => {
+    const entries: unknown[] = []
+
+    ;(window as unknown as { HerbDevTools?: unknown }).HerbDevTools = {
+      report: (input: unknown) => entries.push(input),
+    }
+
+    actions.stop()
+    actions = new SlotActions(state)
+    actions.start(document.body)
+
+    expect(entries).toEqual([])
+
+    delete (window as unknown as { HerbDevTools?: unknown }).HerbDevTools
+  })
+
+  test("toggle on a non-boolean reports and does nothing", () => {
+    const entries: unknown[] = []
+
+    ;(window as unknown as { HerbDevTools?: unknown }).HerbDevTools = {
+      report: (input: unknown) => entries.push(input),
+    }
+
+    const rogue = document.createElement("button")
+
+    rogue.setAttribute("data-herb-toggle", "sort,open")
+    document.querySelector("section")!.append(rogue)
+    rogue.dispatchEvent(new MouseEvent("click", { bubbles: true }))
+
+    expect(state.getState("open")).toBe(false)
+    expect((entries[0] as { code: string }).code).toBe("herb-state-type")
+
+    delete (window as unknown as { HerbDevTools?: unknown }).HerbDevTools
+  })
+})

--- a/javascript/packages/client/test/report.test.ts
+++ b/javascript/packages/client/test/report.test.ts
@@ -138,6 +138,37 @@ describe("runtime diagnostics", () => {
     stop()
   })
 
+  test("falls back to the console while the panel is absent in debug mode", async () => {
+    const { vi } = await import("vitest")
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
+
+    document.head.innerHTML = `<meta name="herb-debug-mode" content="true">`
+    state.setState({ missing: true })
+
+    expect(warn).toHaveBeenCalledTimes(1)
+    expect(String(warn.mock.calls[0][0])).toContain("[herb]")
+
+    const devTools = installDevTools()
+
+    state.setState({ also_missing: true })
+
+    expect(warn).toHaveBeenCalledTimes(1)
+    expect(devTools.entries).toHaveLength(2)
+
+    warn.mockRestore()
+  })
+
+  test("production logs nothing to the console", async () => {
+    const { vi } = await import("vitest")
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
+
+    state.setState({ missing: true })
+
+    expect(warn).not.toHaveBeenCalled()
+
+    warn.mockRestore()
+  })
+
   test("without the debug signal nothing is retained", () => {
     state.setState({ missing: true })
 


### PR DESCRIPTION
This pull request adds the declarative action layer, five `data-herb-*` attributes that write declared state from DOM events without a controller.

```erb
<button data-herb-toggle="open">Details</button>
<button data-herb-set="pending=false,failed=true">Fail</button>
<button data-herb-increment="attempts" data-herb-by="2">Retry</button>
<form data-herb-set="pending=true">…</form>
<select data-herb-set="sort=$value">…</select>
<input data-herb-reset="blur->draft">
<div data-herb-set="mouseenter->menu=true mouseleave->menu=false">…</div>
```

The event defaults per element the way Stimulus defaults `data-action`, a form submits, an input inputs, a select changes, everything else clicks, and `event->` names one explicitly. Space separates independent clauses, comma separates states inside one clause so a multi-state transition stays one journal entry, single quotes protect separators inside a value, and `$value` is the only interpolation, standing for the event target's value. Values are typed by the declaration, so `pending=true` against a boolean is the boolean and `draft=true` against a string is the four-letter word.

`SlotActions` wires everything through delegation from the document, so late-inserted rows work with no rescan, with direct listeners only for `mouseenter` and `mouseleave`, which do not bubble. Scope resolves by name per state, walking up from the element to the nearest scope that declares it, so a button inside a row can flip that row's flag and set a region state in the same clause. Every attribute maps to exactly one call on the typed state API, the declarative layer has no privileged access.

Attributes are validated at scan time, before any event fires. Unbalanced quotes, malformed clauses, unknown states and kind mismatches report through the runtime diagnostics from #2338 with `herb-invalid-action`, `herb-unknown-state` and `herb-state-type` codes. The whole `data-herb-*` vocabulary now lives in one `HERB_ATTRIBUTES` map in `attributes.ts`, alongside the exported `ACTION_SCHEMA`, so the attribute names have a single home and a linter rule can consume the same definitions.
