### PR TITLE
Client: Drive a boolean attribute's presence from state

### DIFF
--- a/javascript/packages/client/src/slot-index.ts
+++ b/javascript/packages/client/src/slot-index.ts
@@ -172,7 +172,7 @@ export interface Collected {
   items: { [key: string]: PayloadSlots }
 }
 
-export type PayloadValue = string | Payload | Branched | Collected
+export type PayloadValue = string | boolean | Payload | Branched | Collected
 
 export type DeferredReason = "no-region" | "stale-version" | "no-slot" | "branch" | "items" | "partial-attribute"
 
@@ -518,6 +518,13 @@ export class SlotIndex {
 
       if (!slot) {
         this.#defer(report, payload, index, "no-slot")
+        continue
+      }
+
+      if (typeof value === "boolean") {
+        if (this.setBooleanAttribute(slot, value)) report.applied += 1
+        else this.#defer(report, payload, index, "partial-attribute")
+
         continue
       }
 
@@ -1097,6 +1104,36 @@ export class SlotIndex {
       slot.anchor.element.removeAttribute(name)
     } else {
       slot.anchor.element.setAttribute(name, value)
+    }
+
+    this.#announce(slot, "attribute", slot.index)
+
+    return true
+  }
+
+  setBooleanAttribute(slot: Slot, present: boolean, name = slot.attribute): boolean {
+    if (slot.anchor.kind === "range" || name === null) return false
+    if (slot.type !== "boolean_attribute") return false
+
+    const element = slot.anchor.element
+
+    if (element.hasAttribute(name) === present) return true
+
+    this.#record(() => {
+      const before = element.hasAttribute(name)
+      const address = this.#addressOf(slot)
+
+      return () => {
+        const live = this.#slotAt(address)
+
+        if (live) this.setBooleanAttribute(live, before, name)
+      }
+    })
+
+    element.toggleAttribute(name, present)
+
+    if (name in element) {
+      ;(element as unknown as Record<string, unknown>)[name] = present
     }
 
     this.#announce(slot, "attribute", slot.index)
@@ -1740,8 +1777,12 @@ function blankSlots(fragment: DocumentFragment): void {
     for (const entry of anchorEntries(element)) {
       const [, type, ...name] = entry.split(":")
 
-      if (name.length > 0) element.setAttribute(name.join(":"), "")
-      else if ((type ?? DEFAULT_SLOT_TYPE) === DEFAULT_SLOT_TYPE) element.replaceChildren()
+      if (name.length > 0) {
+        if (type === "boolean_attribute") element.removeAttribute(name.join(":"))
+        else element.setAttribute(name.join(":"), "")
+      } else if ((type ?? DEFAULT_SLOT_TYPE) === DEFAULT_SLOT_TYPE) {
+        element.replaceChildren()
+      }
     }
   }
 }

--- a/javascript/packages/client/src/state.ts
+++ b/javascript/packages/client/src/state.ts
@@ -33,6 +33,7 @@ export interface StateManifest {
   reads: Record<string, number[]>
   bound?: Record<string, number[]>
   conditionals: Record<string, { arms: [string, string | null, number][]; else: number | null }>
+  presence?: Record<string, [string, string | null]>
 }
 
 export interface StateScope {
@@ -489,6 +490,7 @@ export class SlotState {
       }
 
       this.#writeConditionals(manifest, resolved, names)
+      this.#writePresence(manifest, resolved, names)
     })
 
     for (const [name, value] of Object.entries(values)) {
@@ -660,6 +662,14 @@ export class SlotState {
 
     for (const index of manifest.reads[name] ?? []) {
       for (const slot of this.#scopedSlots(scope, index)) {
+        if (slot.type === "boolean_attribute") {
+          const entry = manifest.presence?.[String(index)]
+
+          if (!entry || entry[1] !== null || slot.anchor.kind === "range" || !slot.attribute) continue
+
+          return slot.anchor.element.hasAttribute(slot.attribute)
+        }
+
         const text = slot.attribute && slot.anchor.kind !== "range"
           ? (slot.anchor.element.getAttribute(slot.attribute) ?? "")
           : this.#slots.currentText(slot)
@@ -703,7 +713,22 @@ export class SlotState {
 
     for (const index of manifest.reads[name] ?? []) {
       for (const slot of this.#scopedSlots(scope, index)) {
+        if (slot.type === "boolean_attribute") continue
+
         this.#write(slot, text)
+      }
+    }
+  }
+
+  #writePresence(manifest: StateManifest, scope: StateScope, changed: string[]): void {
+    for (const [indexKey, [name, comparand]] of Object.entries(manifest.presence ?? {})) {
+      if (!changed.includes(name)) continue
+
+      const value = this.#valueOf(name, scope)
+      const present = comparand === null ? rubyTruthy(value) : value === parseLiteral(comparand)
+
+      for (const slot of this.#scopedSlots(scope, Number(indexKey))) {
+        this.#slots.setBooleanAttribute(slot, present)
       }
     }
   }

--- a/javascript/packages/client/test/boolean-attributes.test.ts
+++ b/javascript/packages/client/test/boolean-attributes.test.ts
@@ -1,0 +1,149 @@
+import { describe, test, expect, beforeEach, afterEach } from "vitest"
+import { SlotIndex } from "../src/slot-index"
+import { SlotState } from "../src/state"
+
+const FILE = "app/views/chat/show.html.erb"
+
+const PAGE =
+  `<!--herb-region:${FILE}:aaaaaaaa:0-->` +
+  `<input value="" data-herb-slot="0:attribute:value">` +
+  `<button disabled data-herb-slot="1:boolean_attribute:disabled">Send</button>` +
+  `<video data-herb-slot="2:boolean_attribute:muted"></video>` +
+  `<!--/herb-region:${FILE}-->` +
+  `<template data-herb-dependencies>${JSON.stringify({
+    state: {},
+    states: {
+      [FILE]: {
+        version: "aaaaaaaa",
+        declarations: [
+          { name: "draft", kind: "string", default: '""', scope: "region" },
+          { name: "sending", kind: "boolean", default: "false", scope: "region" },
+        ],
+        reads: { draft: [0, 1], sending: [2] },
+        bound: { draft: [0] },
+        conditionals: {},
+        presence: { 1: ["draft", '""'], 2: ["sending", null] },
+      },
+    },
+  })}</template>`
+
+let slots: SlotIndex
+let state: SlotState
+
+function button(): HTMLButtonElement {
+  return document.querySelector("button")!
+}
+
+function video(): HTMLVideoElement {
+  return document.querySelector("video")!
+}
+
+beforeEach(() => {
+  document.body.innerHTML = PAGE
+
+  slots = new SlotIndex()
+  slots.scan(document.body)
+
+  state = new SlotState(slots, { persist: "none" })
+  state.adopt()
+  state.observe()
+})
+
+afterEach(() => state.disconnect())
+
+describe("a skeleton derived from a live row", () => {
+  test("is born without the row's boolean attributes", () => {
+    document.body.innerHTML =
+      `<!--herb-region:${FILE}:aaaaaaaa:0-->` +
+      `<ul><!--herb-slot:9:collection-->` +
+      `<!--herb-item:9:a--><li id="a" data-herb-slot="10:attribute:id"><input type="checkbox" checked data-herb-slot="11:boolean_attribute:checked"></li><!--/herb-item:9-->` +
+      `<!--/herb-slot:9--></ul>` +
+      `<!--/herb-region:${FILE}-->`
+
+    const index = new SlotIndex()
+
+    index.scan(document.body)
+
+    const collection = index.slot(FILE, 9)!
+    const item = index.addItem(collection, "b", { values: { 10: "b" } })
+
+    expect(item).not.toBeNull()
+
+    const fresh = document.querySelectorAll("li")[1].querySelector("input")!
+
+    expect(fresh.hasAttribute("checked")).toBe(false)
+  })
+})
+
+describe("state-driven boolean attributes", () => {
+  test("an equality presence follows the state it compares", () => {
+    expect(button().disabled).toBe(true)
+
+    state.setState({ draft: "hello" })
+
+    expect(button().hasAttribute("disabled")).toBe(false)
+    expect(button().disabled).toBe(false)
+
+    state.setState({ draft: "" })
+
+    expect(button().hasAttribute("disabled")).toBe(true)
+    expect(button().disabled).toBe(true)
+  })
+
+  test("a bare presence follows the boolean it reads", () => {
+    expect(video().hasAttribute("muted")).toBe(false)
+
+    state.setState({ sending: true })
+
+    expect(video().hasAttribute("muted")).toBe(true)
+    expect(video().muted).toBe(true)
+
+    state.setState({ sending: false })
+
+    expect(video().hasAttribute("muted")).toBe(false)
+  })
+
+  test("typing into the bound input drives the presence", () => {
+    const input = document.querySelector<HTMLInputElement>("input")!
+
+    input.value = "typed"
+    input.dispatchEvent(new Event("input", { bubbles: true }))
+
+    expect(button().disabled).toBe(false)
+  })
+
+  test("the presence is toggled, never written as text", () => {
+    state.setState({ draft: "hello" })
+    state.setState({ draft: "" })
+
+    expect(button().getAttribute("disabled")).toBe("")
+  })
+
+  test("a bare presence seeds from what the page rendered", () => {
+    document.body.innerHTML = PAGE.replace("<video ", "<video muted ")
+
+    const freshSlots = new SlotIndex()
+    freshSlots.scan(document.body)
+
+    const fresh = new SlotState(freshSlots, { persist: "none" })
+    fresh.adopt()
+
+    expect(fresh.getState("sending")).toBe(true)
+  })
+
+  test("a payload boolean applies as presence and reverts as one", () => {
+    const report = slots.apply({
+      template: FILE,
+      version: "aaaaaaaa",
+      occurrence: 0,
+      slots: { 2: true },
+    })
+
+    expect(report.applied).toBe(1)
+    expect(video().hasAttribute("muted")).toBe(true)
+
+    if (report.token) slots.revert(report.token)
+
+    expect(video().hasAttribute("muted")).toBe(false)
+  })
+})

--- a/javascript/packages/linter/docs/rules/herb-state-valid-reads.md
+++ b/javascript/packages/linter/docs/rules/herb-state-valid-reads.md
@@ -4,7 +4,7 @@
 
 ## Description
 
-Validates every read of a declared state. A state is read bare (`<%= attempts %>`, `<% if pending %>`), as a predicate on a boolean (`pending?`), compared to a literal of its own type (`sort == "name"`), or switched over with literal `when` arms. Anything else, a computed expression, an `unless`, a predicate on a non-boolean, or a comparison against a non-literal or a mismatched literal, is flagged.
+Validates every read of a declared state. A state is read bare (`<%= attempts %>`, `<% if pending %>`), as a predicate on a boolean (`pending?`), compared to a literal of its own type (`sort == "name"`), or switched over with literal `when` arms. A boolean attribute accepts the same read shapes, since its presence is a two-arm conditional (`disabled="<%= draft == "" %>"`). Anything else, a computed expression, an `unless`, a predicate on a non-boolean, or a comparison against a non-literal or a mismatched literal, is flagged.
 
 ## Rationale
 
@@ -30,6 +30,14 @@ The engine raises all of these as compile errors when the template renders. This
 <% when "name" %>By name
 <% when "date" %>By date
 <% end %>
+```
+
+```erb
+<%# herb:slots client %>
+<%# herb:state (draft: "") %>
+
+<input value="<%= draft %>" autocomplete="off">
+<button disabled="<%= draft == "" %>">Send</button>
 ```
 
 ### 🚫 Bad

--- a/javascript/packages/linter/docs/rules/html-boolean-attributes-no-value.md
+++ b/javascript/packages/linter/docs/rules/html-boolean-attributes-no-value.md
@@ -12,6 +12,8 @@ Using the canonical form for boolean attributes improves readability, keeps HTML
 
 For example, instead of writing `disabled="disabled"` or `disabled="true"`, simply write `disabled`.
 
+One exemption: a value that reads a declared `herb:state`, bare or compared to a literal, like `checked="<%= agreed %>"` or `disabled="<%= draft == "" %>"`. The Herb engine compiles that to presence, rendering the attribute only when the read is truthy, so the value never reaches the page.
+
 ## Examples
 
 ### ✅ Good

--- a/javascript/packages/linter/src/rules/herb-state-valid-reads.ts
+++ b/javascript/packages/linter/src/rules/herb-state-valid-reads.ts
@@ -3,10 +3,11 @@ import { ParserRule } from "../types.js"
 import { StateScopeMap, declaredKind, kindWithArticle } from "../utils/state-directives-utils.js"
 import { bareReadName, mentionsAnyState } from "@herb-tools/client/directives"
 
-import { locationFromByteOffset, substringFromByteOffset } from "@herb-tools/core"
+import { isBooleanAttribute, locationFromByteOffset, substringFromByteOffset } from "@herb-tools/core"
+import { getAttributeName } from "@herb-tools/core"
 
 import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types.js"
-import type { ParseResult, ParserOptions, Location, PrismNode, ERBBlockNode, ERBContentNode, ERBIfNode, ERBUnlessNode, ERBCaseNode } from "@herb-tools/core"
+import type { ParseResult, ParserOptions, Location, PrismNode, ERBBlockNode, ERBContentNode, ERBIfNode, ERBUnlessNode, ERBCaseNode, HTMLAttributeNode } from "@herb-tools/core"
 import type { StateDeclaration } from "@herb-tools/client/directives"
 
 const LITERAL_KINDS: Record<string, string> = {
@@ -55,6 +56,7 @@ class StateValidReadsVisitor extends BaseRuleVisitor {
   private states: StateScopeMap
   private source: string
   private stack: (ERBBlockNode | null)[] = [null]
+  private booleanAttribute = false
 
   constructor(ruleName: string, states: StateScopeMap, source: string, context?: Partial<LintContext>) {
     super(ruleName, context)
@@ -71,6 +73,17 @@ class StateValidReadsVisitor extends BaseRuleVisitor {
     this.stack.pop()
   }
 
+  visitHTMLAttributeNode(node: HTMLAttributeNode): void {
+    const name = getAttributeName(node)
+    const previous = this.booleanAttribute
+
+    this.booleanAttribute = name !== null && isBooleanAttribute(name)
+
+    super.visitHTMLAttributeNode(node)
+
+    this.booleanAttribute = previous
+  }
+
   visitERBContentNode(node: ERBContentNode): void {
     if (node.tag_opening?.value !== "<%=" && node.tag_opening?.value !== "<%==") return
 
@@ -81,6 +94,14 @@ class StateValidReadsVisitor extends BaseRuleVisitor {
     const expression = node.content?.value.trim() ?? ""
 
     if (expression === "" || !mentionsAnyState(expression, names)) return
+
+    if (this.booleanAttribute) {
+      const prism = node.prismNode
+
+      if (prism) this.classifyPredicate(prism, names)
+
+      return
+    }
 
     const bare = bareReadName(expression)
 

--- a/javascript/packages/linter/src/rules/html-boolean-attributes-no-value.ts
+++ b/javascript/packages/linter/src/rules/html-boolean-attributes-no-value.ts
@@ -1,7 +1,7 @@
 import { ParserRule, BaseAutofixContext, Mutable } from "../types.js"
 import { AttributeVisitorMixin, StaticAttributeStaticValueParams, StaticAttributeDynamicValueParams, isBooleanAttribute } from "../utils/rule-utils.js"
 import { StateScopeMap } from "../utils/state-directives-utils.js"
-import { bareReadName } from "@herb-tools/client/directives"
+import { bareReadName, classifyDefault } from "@herb-tools/client/directives"
 import { hasAttributeValue, getAttributeValueNodes, isERBContentNode } from "@herb-tools/core"
 import { IdentityPrinter } from "@herb-tools/printer"
 
@@ -34,9 +34,27 @@ class BooleanAttributesNoValueVisitor extends AttributeVisitorMixin<BooleanAttri
 
     if (outputs.length !== 1 || getAttributeValueNodes(attributeNode).length !== 1) return false
 
-    const name = bareReadName((outputs[0] as { content?: { value: string } | null }).content?.value ?? "")
+    const expression = (outputs[0] as { content?: { value: string } | null }).content?.value?.trim() ?? ""
+    const name = bareReadName(expression)
 
-    return name !== null && this.states.includes(name)
+    if (name !== null) return this.states.includes(name)
+
+    return this.comparesDeclaredState(expression)
+  }
+
+  private comparesDeclaredState(expression: string): boolean {
+    const separator = expression.indexOf("==")
+
+    if (separator < 1 || expression[separator + 2] === "=") return false
+
+    const sides = [expression.slice(0, separator).trim(), expression.slice(separator + 2).trim()]
+    const read = sides.map((side) => bareReadName(side)).find((side) => side !== null && this.states.includes(side))
+
+    if (!read) return false
+
+    const comparand = sides.find((side) => bareReadName(side) !== read)
+
+    return comparand !== undefined && ["boolean", "integer", "string", "symbol", "nil"].includes(classifyDefault(comparand))
   }
 
   private checkAttribute(attributeName: string, attributeNode: HTMLAttributeNode) {

--- a/javascript/packages/linter/test/rules/herb-state-valid-reads.test.ts
+++ b/javascript/packages/linter/test/rules/herb-state-valid-reads.test.ts
@@ -162,6 +162,46 @@ describe("HerbStateValidReadsRule", () => {
     `)
   })
 
+  test("allows state reads in a boolean attribute", () => {
+    expectNoOffenses(dedent`
+      <%# herb:state (draft: "", sending: false) %>
+      <p><%= draft %></p>
+      <button disabled="<%= draft == "" %>">Send</button>
+      <video muted="<%= sending %>"></video>
+      <audio loop="<%= sending? %>"></audio>
+    `)
+  })
+
+  test("flags a mismatched comparand in a boolean attribute", () => {
+    expectError("`draft == 3` compares the String state `draft` against an Integer literal, so it can never match. Compare against a String, or redeclare the state.")
+
+    assertOffenses(dedent`
+      <%# herb:state (draft: "") %>
+      <p><%= draft %></p>
+      <button disabled="<%= draft == 3 %>">Send</button>
+    `)
+  })
+
+  test("flags a computed read in a boolean attribute", () => {
+    expectError("`draft.empty?` computes with a state. The client cannot evaluate Ruby, so read a state bare, as a predicate, or compared to a literal.")
+
+    assertOffenses(dedent`
+      <%# herb:state (draft: "") %>
+      <p><%= draft %></p>
+      <button disabled="<%= draft.empty? %>">Send</button>
+    `)
+  })
+
+  test("still flags equality in an attribute that is not boolean", () => {
+    expectError("`draft == \"\"` computes with a state. The client cannot evaluate Ruby, so read the state bare and move the computation into a second state the app sets.")
+
+    assertOffenses(dedent`
+      <%# herb:state (draft: "") %>
+      <p><%= draft %></p>
+      <button title="<%= draft == "" %>">Send</button>
+    `)
+  })
+
   test("scopes item states to their loop", () => {
     expectNoOffenses(dedent`
       <% @rows.each do |row| %>

--- a/javascript/packages/linter/test/rules/html-boolean-attributes-no-value.test.ts
+++ b/javascript/packages/linter/test/rules/html-boolean-attributes-no-value.test.ts
@@ -85,6 +85,10 @@ describe("html-boolean-attributes-no-value", () => {
     `)
   })
 
+  test("allows a boolean attribute comparing a declared state to a literal", () => {
+    expectNoOffenses('<%# herb:state (draft: "") %>\n<p><%= draft %></p>\n<button disabled="<%= draft == \'\' %>">Send</button>')
+  })
+
   test("fails for an ERB value that is not a declared state", () => {
     expectError('Boolean attribute `checked` should not have a value. Use `checked` instead of `checked="<%= agreed %>"`.')
 

--- a/lib/herb/engine/dynamics_compiler.rb
+++ b/lib/herb/engine/dynamics_compiler.rb
@@ -458,12 +458,31 @@ module Herb
 
       #: (String, Symbol?, Integer?, bool, ?nested: bool) -> void
       def add_dynamic(code, context, index, escaped, nested: false)
-        value = nested ? "(#{code})" : dynamic_value(code, context, escaped)
+        value = if index && boolean_presence?(index)
+                  "!!(#{code})"
+                elsif nested
+                  "(#{code})"
+                else
+                  dynamic_value(code, context, escaped)
+                end
 
-        return add_block_dynamic(index ? assignment(index, value) : value) unless @block_depth.zero?
+        unless @block_depth.zero?
+          if index && boolean_presence?(index)
+            attribute = @slot_visitor.slots[index].attribute.to_s.inspect
+
+            return add_block_dynamic("(#{assignment(index, value)}) ? #{attribute} : \"\"")
+          end
+
+          return add_block_dynamic(index ? assignment(index, value) : value)
+        end
         return if index.nil?
 
         @src << "; " << assignment(index, value) << ";"
+      end
+
+      #: (Integer) -> bool
+      def boolean_presence?(index)
+        @slot_visitor.slots[index]&.type == :boolean_attribute
       end
 
       #: (String, Integer?, bool) -> void

--- a/lib/herb/engine/slot_dependencies.rb
+++ b/lib/herb/engine/slot_dependencies.rb
@@ -170,6 +170,14 @@ module Herb
           (bound[name] ||= []) << slot.index if bound_slot?(slot)
         end
 
+        presence = {} #: Hash[String, [String, String?]]
+
+        visitor.state_presence.each do |index, read|
+          presence[index.to_s] = [read.name, read.comparand]
+          (reads[read.name] ||= []) << index
+          (bound[read.name] ||= []) << index if read.comparand.nil? && bound_slot?(visitor.slots[index])
+        end
+
         conditionals = visitor.state_conditional_entries.to_h { |index, info|
           [index.to_s, { "arms" => info[:arms], "else" => info[:else] }]
         }
@@ -180,6 +188,7 @@ module Herb
           "reads" => reads,
           "bound" => bound,
           "conditionals" => conditionals,
+          "presence" => presence,
         }
       end
 

--- a/lib/herb/engine/slot_visitor.rb
+++ b/lib/herb/engine/slot_visitor.rb
@@ -34,6 +34,7 @@ module Herb
       required_parser_option action_view_helpers: true, track_locations: true
 
       attr_reader :slots #: Array[Slot]
+      attr_reader :state_presence #: Hash[Integer, StateDirectives::Read]
       attr_reader :document #: untyped
       attr_reader :warnings #: Array[Herb::Warnings::Warning]
 
@@ -128,6 +129,9 @@ module Herb
         slot_scopes = {} #: Hash[untyped, untyped]
         @slot_scopes = slot_scopes.compare_by_identity
         @named_elements = [] #: Array[Hash[Symbol, untyped]]
+        attribute_open_tags = {} #: Hash[untyped, untyped]
+        @attribute_open_tags = attribute_open_tags.compare_by_identity
+        @state_presence = {} #: Hash[Integer, StateDirectives::Read]
         @strict_locals = {} #: Hash[String, Symbol]
         @region_states = {} #: Hash[String, StateDirectives::Declaration]
         item_states = {} #: Hash[untyped, Hash[String, StateDirectives::Declaration]]
@@ -316,7 +320,10 @@ module Herb
       end
 
       def visit_html_attribute_node(node)
-        record_slot(node, attribute_type_for(node)) if dynamic?(node)
+        if dynamic?(node)
+          record_slot(node, attribute_type_for(node))
+          @attribute_open_tags[node] = @current_open_tag
+        end
 
         @in_attribute = true
         super
@@ -913,16 +920,43 @@ module Herb
           next if expression.empty?
           next unless StateDirectives.mentions_any?(expression, states)
 
+          next if convert_boolean_attribute(node, index, slot, expression, states)
+
           bare = states.key?(expression) || states.key?(expression.delete_suffix("?"))
 
           unless bare
             raise Herb::Engine::CompilationError,
-                  "`#{expression}` computes with a state; the client cannot evaluate Ruby, so a state is read bare " \
-                  "or compared to a literal inside a conditional"
+                  "`#{expression}` computes with a state; the client cannot evaluate Ruby, so a state is read bare, " \
+                  "compared to a literal inside a conditional, or compared to a literal in a boolean attribute"
           end
 
           rewrite_predicate(node, expression.delete_suffix("?")) if expression.end_with?("?")
         end
+      end
+
+      #: (untyped, Integer, untyped, String, Hash[String, StateDirectives::Declaration]) -> StateDirectives::Read?
+      def convert_boolean_attribute(node, index, slot, expression, states)
+        return nil unless slot.type == :attribute
+        return nil unless slot.attribute && Herb::HTML::Util.boolean_attribute?(slot.attribute)
+
+        read = StateDirectives.condition_read(expression, states)
+
+        return nil unless read.is_a?(StateDirectives::Read)
+
+        open_tag = @attribute_open_tags[node]
+        children = open_tag&.children
+        position = children&.find_index { |child| child.equal?(node) }
+
+        return nil unless position
+
+        condition = read.comparand ? "#{read.name} == #{read.comparand}" : read.name
+        replacement = erb_output_node(%[("#{slot.attribute}" if #{condition})])
+
+        children[position] = replacement
+
+        @slots[index] = slot.with(type: :boolean_attribute)
+        @indices[replacement] = index
+        @state_presence[index] = read
       end
 
       #: (untyped, untyped, Integer, untyped, Integer) -> void

--- a/lib/herb/html/util.rb
+++ b/lib/herb/html/util.rb
@@ -9,6 +9,16 @@ module Herb
       RCDATA_ELEMENTS = ["textarea", "title"].freeze #: Array[String]
       RAW_TEXT_ELEMENTS = ["script", "style", "xmp", "iframe", "noembed", "noframes", "plaintext"].freeze #: Array[String]
 
+      # https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#boolean-attributes
+      BOOLEAN_ATTRIBUTES = [
+        "allowfullscreen", "async", "autofocus", "autoplay", "checked", "compact",
+        "controls", "declare", "default", "defer", "disabled", "formnovalidate",
+        "hidden", "inert", "ismap", "itemscope", "loop", "multiple", "muted",
+        "nomodule", "nohref", "noresize", "noshade", "novalidate", "nowrap",
+        "open", "playsinline", "readonly", "required", "reversed", "scoped",
+        "seamless", "selected", "sortable", "truespeed", "typemustmatch"
+      ].freeze #: Array[String]
+
       #: (String) -> bool
       def self.void_element?(tag_name)
         VOID_ELEMENTS.include?(tag_name.downcase)
@@ -22,6 +32,11 @@ module Herb
       #: (String) -> bool
       def self.raw_text_element?(tag_name)
         RAW_TEXT_ELEMENTS.include?(tag_name.downcase)
+      end
+
+      #: (String) -> bool
+      def self.boolean_attribute?(attribute_name)
+        BOOLEAN_ATTRIBUTES.include?(attribute_name.downcase)
       end
     end
   end

--- a/sig/herb/engine/dynamics_compiler.rbs
+++ b/sig/herb/engine/dynamics_compiler.rbs
@@ -223,6 +223,9 @@ module Herb
       # : (String, Symbol?, Integer?, bool, ?nested: bool) -> void
       def add_dynamic: (String, Symbol?, Integer?, bool, ?nested: bool) -> void
 
+      # : (Integer) -> bool
+      def boolean_presence?: (Integer) -> bool
+
       # : (String, Integer?, bool) -> void
       def add_dynamic_block: (String, Integer?, bool) -> void
 

--- a/sig/herb/engine/slot_visitor.rbs
+++ b/sig/herb/engine/slot_visitor.rbs
@@ -22,6 +22,8 @@ module Herb
 
       attr_reader slots: Array[Slot]
 
+      attr_reader state_presence: Hash[Integer, StateDirectives::Read]
+
       attr_reader document: untyped
 
       attr_reader warnings: Array[Herb::Warnings::Warning]
@@ -250,6 +252,9 @@ module Herb
 
       # : () -> void
       def check_state_value_reads: () -> void
+
+      # : (untyped, Integer, untyped, String, Hash[String, StateDirectives::Declaration]) -> StateDirectives::Read?
+      def convert_boolean_attribute: (untyped, Integer, untyped, String, Hash[String, StateDirectives::Declaration]) -> StateDirectives::Read?
 
       # : (untyped, untyped, Integer, untyped, Integer) -> void
       def record_named_element: (untyped, untyped, Integer, untyped, Integer) -> void

--- a/sig/herb/html/util.rbs
+++ b/sig/herb/html/util.rbs
@@ -10,6 +10,9 @@ module Herb
 
       RAW_TEXT_ELEMENTS: Array[String]
 
+      # https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#boolean-attributes
+      BOOLEAN_ATTRIBUTES: Array[String]
+
       # : (String) -> bool
       def self.void_element?: (String) -> bool
 
@@ -18,6 +21,9 @@ module Herb
 
       # : (String) -> bool
       def self.raw_text_element?: (String) -> bool
+
+      # : (String) -> bool
+      def self.boolean_attribute?: (String) -> bool
     end
   end
 end

--- a/test/engine/slots/dependencies_test.rb
+++ b/test/engine/slots/dependencies_test.rb
@@ -423,6 +423,20 @@ module Engine
 
         assert_empty subject.across(entry)
       end
+      test "carries the presence a boolean attribute compares" do
+        path = write("index.html.erb", <<~ERB)
+          <%# herb:state (draft: "", sending: false) %>
+          <p><%= draft %></p>
+          <button disabled="<%= draft == "" %>">Send</button>
+          <video muted="<%= sending %>"></video>
+        ERB
+
+        manifest = subject.payload(path)["states"].values.first
+
+        assert_equal [["draft", %("")], ["sending", nil]], manifest["presence"].values
+        assert_equal manifest["presence"].keys.map(&:to_i).sort, (manifest["reads"]["draft"] + manifest["reads"]["sending"]).sort - manifest["reads"]["draft"].take(1)
+      end
+
       test "carries the states a template declares" do
         path = write("index.html.erb", <<~ERB)
           <%# herb:state (pending: false, attempts: 0) %>

--- a/test/engine/slots/parity_test.rb
+++ b/test/engine/slots/parity_test.rb
@@ -37,6 +37,7 @@ module Engine
         "a helper block building an element" => [%(<%= tag.li(id: 1) do %><%= @n %><% end %><%= @after %>), { n: "n", after: "A" }],
         "an iteration whose value is output" => [%(<%= @items.each do |r| %><%= r %><% end %>), { items: [1, 2] }],
         "a conditional inside a block" => [%(<%= form_with(model: 1) do |f| %><% if @on %><%= @x %><% end %><% end %>), { on: true, x: "x" }],
+        "a boolean attribute inside a block" => [%(<%# herb:state (sending: false) %><%= form_with(model: 1) do |f| %><video muted="<%= sending %>"></video><% end %>), {}],
         "nothing dynamic at all" => [%(<p>static</p>), {}],
       }.freeze
 
@@ -103,6 +104,17 @@ module Engine
             assert_equal known[index], shape, "slot #{index} was recorded as #{known[index]} and its value arrived as #{shape}"
           end
         end
+      end
+
+      test "a boolean attribute inside a block records presence and renders text" do
+        source = %(<%# herb:state (sending: true) %><%= form_with(model: 1) do |f| %><video muted="<%= sending %>"></video><% end %>)
+        compiler = compile(source)
+        values = evaluate(compiler, {})
+
+        presence = compiler.slot_visitor.slots.find { |slot| slot.type == :boolean_attribute }
+
+        assert_equal true, values.fetch(presence.index)
+        assert_includes values.values.grep(String).join, "muted"
       end
 
       test "a block's interior is covered alongside the block itself" do

--- a/test/engine/slots/states_test.rb
+++ b/test/engine/slots/states_test.rb
@@ -4,6 +4,7 @@ require_relative "../../test_helper"
 require_relative "../../snapshot_utils"
 require_relative "../../../lib/herb/engine"
 require_relative "../../../lib/herb/engine/slot_visitor"
+require_relative "../../../lib/herb/engine/dynamics_compiler"
 
 module Engine
   module Slots
@@ -243,6 +244,79 @@ module Engine
 
         assert_includes parked(template, { "@items" => ["a"] }), "herb-branch:0:item"
         assert_includes parked(template, { "@items" => [] }), "herb-branch:0:item"
+      end
+
+      BOOLEAN_ATTRIBUTES = <<~ERB
+        <%# herb:state (draft: "", sending: false) %>
+        <button disabled="<%= draft == "" %>">Send</button>
+        <video muted="<%= sending %>"></video>
+        <audio loop="<%= sending? %>"></audio>
+      ERB
+
+      test "a boolean attribute reading a state renders presence" do
+        rendered = render(BOOLEAN_ATTRIBUTES)
+
+        assert_includes rendered, "<button disabled "
+        refute_includes rendered, 'disabled="'
+        refute_includes rendered, "<video muted"
+        refute_includes rendered, "<audio loop"
+      end
+
+      test "a boolean attribute reading a state is retyped for the client" do
+        rendered = render(BOOLEAN_ATTRIBUTES)
+
+        assert_includes rendered, "0:boolean_attribute:disabled"
+        assert_includes rendered, "1:boolean_attribute:muted"
+        assert_includes rendered, "2:boolean_attribute:loop"
+      end
+
+      test "the visitor records what each presence compares" do
+        visitor, = compile(BOOLEAN_ATTRIBUTES)
+
+        assert_equal ["draft", %("")], [visitor.state_presence[0].name, visitor.state_presence[0].comparand]
+        assert_equal ["sending", nil], [visitor.state_presence[1].name, visitor.state_presence[1].comparand]
+        assert_equal ["sending", nil], [visitor.state_presence[2].name, visitor.state_presence[2].comparand]
+      end
+
+      test "the values payload carries presence as a boolean" do
+        source = Herb::Engine::DynamicsCompiler.new(BOOLEAN_ATTRIBUTES, filename: "app/views/test.html.erb").src
+        payload = evaluate_herb_source(source, {})
+
+        assert_equal true, payload[:slots][0]
+        assert_equal false, payload[:slots][1]
+        assert_equal false, payload[:slots][2]
+      end
+
+      test "a boolean attribute reading no state keeps its value" do
+        rendered = render(<<~ERB, "@locked": false)
+          <%# herb:state (draft: "") %>
+          <p><%= draft %></p>
+          <button disabled="<%= @locked %>">Send</button>
+        ERB
+
+        assert_includes rendered, 'disabled="false"'
+      end
+
+      test "a computed read in a boolean attribute still raises" do
+        error = assert_raises(Herb::Engine::CompilationError) do
+          compile(<<~ERB)
+            <%# herb:state (draft: "") %>
+            <button disabled="<%= draft.empty? %>">Send</button>
+          ERB
+        end
+
+        assert_includes error.message, "computes with a state"
+      end
+
+      test "a mismatched comparand in a boolean attribute still raises" do
+        error = assert_raises(Herb::Engine::CompilationError) do
+          compile(<<~ERB)
+            <%# herb:state (draft: "") %>
+            <button disabled="<%= draft == 3 %>">Send</button>
+          ERB
+        end
+
+        assert_includes error.message, "Integer literal"
       end
     end
   end


### PR DESCRIPTION
This pull request lets a boolean attribute read a declared state, rendering and toggling its presence instead of its value.

```erb
<%# herb:state (draft: "", sending: false) %>

<input value="<%= draft %>">
<button disabled="<%= draft == "" %>" class="disabled:opacity-40">Send</button>
<form inert="<%= sending %>">…</form>
```

A boolean attribute is a two-arm conditional wearing attribute syntax: present or absent. So the same read shapes a state-driven conditional accepts, a bare boolean, a predicate, or an equality against a literal, are now legal in a boolean attribute, and they compile to the same arm machinery. Before this, the only spelling was duplicating the element into `<% if %>` arms that differ by one attribute, and a plain `disabled="<%= draft == "" %>"` was rejected as a computed read. It would also have been wrong as a plain attribute: `disabled="false"` still disables the button, which is the bug `html-boolean-attributes-no-value` exists for.

The engine detects the pattern in `check_state_value_reads`: an `:attribute` slot on a boolean attribute, from the new `Herb::HTML::Util::BOOLEAN_ATTRIBUTES` list mirroring core's, whose expression is a client-resolvable read through the existing `StateDirectives.condition_read`, which keeps raising on computed reads and mismatched comparands. The slot retypes to the previously reserved `:boolean_attribute`, the attribute node is replaced with a synthesized `<%= ("disabled" if draft == "") %>` so the server renders presence, and the read lands in a new `state_presence` table. The values payload carries these slots as real booleans, `DynamicsCompiler` wraps their expression in `!!()`, and the dependency map gains a `presence` section, `index` to `[name, comparand]`, with the names joining `reads`. A comparand-free presence on a form control stays `bound`, so `checked="<%= agreed %>"` keeps its change listener while gaining correct presence rendering.

On the client, `SlotIndex#setBooleanAttribute` toggles the attribute, mirrors the DOM property, `disabled`, `checked`, `open` and friends all need the property in sync, records its inverse in the reversal journal, and announces like any attribute write. `SlotState` writes presence through the same fan-out that writes text and branches, computing truthiness or the literal comparison per the manifest entry, skips these slots in text writes, and seeds a bare presence from whether the page rendered the attribute. Payload booleans apply and revert as presence.

Two linter rules follow along. `herb-state-valid-reads` allows the three read shapes inside boolean attributes, tracking the attribute context and classifying through Prism, while still flagging computed reads and type mismatches there. `html-boolean-attributes-no-value` widens its declared-state exemption to equality reads, which matters because its autofix would otherwise delete the binding it flags.

Paired with Tailwind's `disabled:` and `inert:` variants, this collapses the two-arm button into one element whose styling and interactivity both follow the state.
