### PR TITLE
Client: Reconstruct interpolated attributes from parked parts

### DIFF
--- a/javascript/packages/client/src/slot-index.ts
+++ b/javascript/packages/client/src/slot-index.ts
@@ -31,6 +31,7 @@ const STATICS_REGION = /^(.*):([0-9a-f]+)$/
 const ITEM_STATICS = "item"
 const STATICS_SELECTOR = `template[${HERB_ATTRIBUTES.region}], template[${HERB_ATTRIBUTES.statics}]`
 const MAX_JOURNAL = 50
+const PART_MARKER = "herb-part"
 
 const ANCHOR_ATTRIBUTE = HERB_ATTRIBUTES.slot
 const ANCHOR_SELECTOR = `[${ANCHOR_ATTRIBUTE}]`
@@ -61,8 +62,8 @@ export type SlotAnchor =
 export type SlotMap = Map<number, Slot>
 export type ItemMap = Map<string, Item>
 export type FragmentMap = Map<string, DocumentFragment>
-export type SlotValues = Record<number, string>
-export type ItemValues = Record<number | string, string>
+export type SlotValues = Record<number, string | string[]>
+export type ItemValues = Record<number | string, string | string[]>
 
 export interface AddItemOptions {
   values?: ItemValues
@@ -172,7 +173,7 @@ export interface Collected {
   items: { [key: string]: PayloadSlots }
 }
 
-export type PayloadValue = string | boolean | Payload | Branched | Collected
+export type PayloadValue = string | string[] | boolean | Payload | Branched | Collected
 
 export type DeferredReason = "no-region" | "stale-version" | "no-slot" | "branch" | "items" | "partial-attribute"
 
@@ -528,7 +529,7 @@ export class SlotIndex {
         continue
       }
 
-      if (typeof value === "string") {
+      if (typeof value === "string" || Array.isArray(value)) {
         if (this.#same(slot, value)) continue
 
         if (slot.attribute && !this.setAttribute(slot, value)) {
@@ -536,7 +537,14 @@ export class SlotIndex {
           continue
         }
 
-        if (!slot.attribute) this.update(slot, value)
+        if (!slot.attribute) {
+          if (Array.isArray(value)) {
+            this.#defer(report, payload, index, "partial-attribute")
+            continue
+          }
+
+          this.update(slot, value)
+        }
 
         report.applied += 1
         continue
@@ -714,7 +722,9 @@ export class SlotIndex {
       if (branch && branch[2] === ITEM_STATICS) node.remove()
     }
 
-    fillSlots(copy, values, text)
+    const region = this.#slotRegions.get(slot)
+
+    fillSlots(copy, values, text, region ? (index) => this.#partsFor(region.file, index) : undefined)
 
     const added = [...copy.childNodes]
     const target =
@@ -898,8 +908,16 @@ export class SlotIndex {
     return holder.innerHTML
   }
 
-  #same(slot: Slot, value: string): boolean {
-    if (slot.type === "attribute_interpolation") return false
+  #same(slot: Slot, value: string | string[]): boolean {
+    if (slot.type === "attribute_interpolation") {
+      const whole = this.#interpolate(slot, value)
+
+      if (whole === null || slot.anchor.kind === "range" || !slot.attribute) return false
+
+      return slot.anchor.element.getAttribute(slot.attribute) === whole
+    }
+
+    if (Array.isArray(value)) return false
 
     if (slot.attribute && slot.anchor.kind !== "range") {
       return slot.anchor.element.getAttribute(slot.attribute) === value
@@ -1084,9 +1102,24 @@ export class SlotIndex {
     return resolved
   }
 
-  setAttribute(slot: Slot, value: string | null, name = slot.attribute): boolean {
+  setAttribute(slot: Slot, value: string | string[] | null, name = slot.attribute): boolean {
     if (slot.anchor.kind === "range" || name === null) return false
-    if (slot.type === "attribute_interpolation") return false
+
+    if (slot.type === "attribute_interpolation") {
+      const whole = this.#interpolate(slot, value)
+
+      if (whole === null) return false
+
+      value = whole
+    }
+
+    if (Array.isArray(value)) return false
+
+    return this.#writeAttribute(slot, value, name)
+  }
+
+  #writeAttribute(slot: Slot, value: string | null, name: string): boolean {
+    if (slot.anchor.kind === "range") return false
     if (slot.anchor.element.getAttribute(name) === value) return true
 
     this.#record(() => {
@@ -1096,7 +1129,7 @@ export class SlotIndex {
       return () => {
         const live = this.#slotAt(address)
 
-        if (live) this.setAttribute(live, before, name)
+        if (live) this.#writeAttribute(live, before, name)
       }
     })
 
@@ -1139,6 +1172,19 @@ export class SlotIndex {
     this.#announce(slot, "attribute", slot.index)
 
     return true
+  }
+
+  #interpolate(slot: Slot, value: string | string[] | null): string | null {
+    if (value === null) return null
+
+    const region = this.#slotRegions.get(slot)
+    if (!region) return null
+
+    return interpolateParts(this.#partsFor(region.file, slot.index), value)
+  }
+
+  #partsFor(file: string, index: number): string[] | null {
+    return attributeParts(this.skeletonFor(file, `${index}:parts`))
   }
 
   capture(slot: Slot): boolean {
@@ -1186,7 +1232,7 @@ export class SlotIndex {
 
     const copy = skeleton.cloneNode(true) as DocumentFragment
 
-    fillSlots(copy, dynamics)
+    fillSlots(copy, dynamics, false, (index) => this.#partsFor(file, index))
 
     return copy
   }
@@ -1679,6 +1725,24 @@ function skeletonElements(root: Node): HTMLTemplateElement[] {
   return found
 }
 
+function attributeParts(fragment: DocumentFragment | null): string[] | null {
+  if (!fragment) return null
+
+  const segments: string[] = [""]
+
+  for (const node of fragment.childNodes) {
+    if (node.nodeType === Node.COMMENT_NODE) {
+      if ((node as Comment).data.trim() === PART_MARKER) segments.push("")
+
+      continue
+    }
+
+    segments[segments.length - 1] += node.textContent ?? ""
+  }
+
+  return segments.length > 1 ? segments : null
+}
+
 function parkedBranches(element: HTMLTemplateElement): FragmentMap {
   const named = element.getAttribute(HERB_ATTRIBUTES.statics)
 
@@ -1724,12 +1788,14 @@ function templateNames(template: DocumentFragment): Map<string, number> {
   return names
 }
 
-function fillSlots(fragment: DocumentFragment, dynamics: SlotValues, text = false): void {
+function fillSlots(fragment: DocumentFragment, dynamics: SlotValues, text = false, parts?: (index: number) => string[] | null): void {
   for (const open of slotOpeners(fragment)) {
     const index = Number(SLOT_OPEN.exec(open.data.trim())?.[1])
     const value = dynamics[index]
 
     if (value === undefined) continue
+
+    if (Array.isArray(value)) continue
 
     const close = closingFor(open, index)
     if (!close) continue
@@ -1749,14 +1815,31 @@ function fillSlots(fragment: DocumentFragment, dynamics: SlotValues, text = fals
 
       if (value === undefined) continue
 
-      if (name.length > 0) element.setAttribute(name.join(":"), value)
-      else if ((type ?? DEFAULT_SLOT_TYPE) === DEFAULT_SLOT_TYPE) element.innerHTML = text ? escapeText(value) : value
+      if (name.length > 0) {
+        const whole = type === "attribute_interpolation"
+          ? interpolateParts(parts?.(Number(index)) ?? null, value)
+          : Array.isArray(value) ? null : value
+
+        if (whole !== null) element.setAttribute(name.join(":"), whole)
+      } else if ((type ?? DEFAULT_SLOT_TYPE) === DEFAULT_SLOT_TYPE && !Array.isArray(value)) {
+        element.innerHTML = text ? escapeText(value) : value
+      }
     }
   }
 }
 
 function escapeText(value: string): string {
   return value.replace(/[&<>]/g, (match) => (match === "&" ? "&amp;" : match === "<" ? "&lt;" : "&gt;"))
+}
+
+function interpolateParts(parts: string[] | null, value: string | string[]): string | null {
+  if (!parts) return null
+
+  const dynamics = Array.isArray(value) ? value : [value]
+
+  if (dynamics.length !== parts.length - 1) return null
+
+  return parts.reduce((whole, segment, position) => (position === 0 ? segment : `${whole}${dynamics[position - 1]}${segment}`), "")
 }
 
 function blankSlots(fragment: DocumentFragment): void {

--- a/javascript/packages/client/test/attribute-parts.test.ts
+++ b/javascript/packages/client/test/attribute-parts.test.ts
@@ -1,0 +1,104 @@
+import { describe, test, expect, beforeEach } from "vitest"
+import { SlotIndex } from "../src/slot-index"
+
+const FILE = "app/views/chat/show.html.erb"
+
+const PAGE =
+  `<!--herb-region:${FILE}:aaaaaaaa:0-->` +
+  `<ul><!--herb-slot:0:collection-->` +
+  `<!--herb-item:0:1--><li id="message_1" data-herb-slot="1:attribute_interpolation:id 2:attribute_interpolation:class">` +
+  `<span data-herb-slot="3:child">hello</span></li><!--/herb-item:0-->` +
+  `<!--/herb-slot:0--></ul>` +
+  `<template data-herb-region="${FILE}:aaaaaaaa">` +
+  `<!--herb-branch:0:item--><!--herb-item:0:--><li id="" class="" data-herb-slot="1:attribute_interpolation:id 2:attribute_interpolation:class">` +
+  `<span data-herb-slot="3:child"></span></li><!--/herb-item:0-->` +
+  `<!--herb-branch:1:parts-->message_<!--herb-part-->` +
+  `<!--herb-branch:2:parts-->row-<!--herb-part-->-of-<!--herb-part-->` +
+  `</template>` +
+  `<!--/herb-region:${FILE}-->`
+
+let slots: SlotIndex
+
+function row(selector: string): HTMLElement | null {
+  return document.querySelector(selector)
+}
+
+beforeEach(() => {
+  document.body.innerHTML = PAGE
+
+  slots = new SlotIndex()
+  slots.scan(document.body)
+})
+
+describe("interpolated attribute slots", () => {
+  test("a payload's dynamic parts reconstruct the whole attribute", () => {
+    const report = slots.apply({
+      template: FILE,
+      version: "aaaaaaaa",
+      occurrence: 0,
+      slots: { 0: { items: { 1: { 1: ["9"], 2: ["a", "b"], 3: "updated" } } } },
+    })
+
+    expect(report.deferred).toEqual([])
+    expect(row("li")?.id).toBe("message_9")
+    expect(row("li")?.className).toBe("row-a-of-b")
+  })
+
+  test("the revert restores the previous whole value", () => {
+    const report = slots.apply({
+      template: FILE,
+      version: "aaaaaaaa",
+      occurrence: 0,
+      slots: { 0: { items: { 1: { 1: ["9"] } } } },
+    })
+
+    expect(row("li")?.id).toBe("message_9")
+
+    if (report.token) slots.revert(report.token)
+
+    expect(row("li")?.id).toBe("message_1")
+  })
+
+  test("a skeleton-built row interpolates the values it is given", () => {
+    const collection = slots.slot(FILE, 0)!
+    const item = slots.addItem(collection, "7", { values: { id: "7", class: ["x", "y"] } })
+
+    expect(item).not.toBeNull()
+
+    const fresh = document.querySelectorAll("li")[1]
+
+    expect(fresh.id).toBe("message_7")
+    expect(fresh.className).toBe("row-x-of-y")
+  })
+
+  test("an unchanged value applies without touching the attribute", () => {
+    const before = row("li")!.id
+
+    const report = slots.apply({
+      template: FILE,
+      version: "aaaaaaaa",
+      occurrence: 0,
+      slots: { 0: { items: { 1: { 1: ["1"] } } } },
+    })
+
+    expect(report.deferred).toEqual([])
+    expect(row("li")?.id).toBe(before)
+  })
+
+  test("a slot whose parts were never parked still defers", () => {
+    document.body.innerHTML = PAGE.replace("<!--herb-branch:1:parts-->message_<!--herb-part-->", "")
+
+    const bare = new SlotIndex()
+    bare.scan(document.body)
+
+    const report = bare.apply({
+      template: FILE,
+      version: "aaaaaaaa",
+      occurrence: 0,
+      slots: { 0: { items: { 1: { 1: ["9"] } } } },
+    })
+
+    expect(report.deferred.map((deferred) => deferred.reason)).toContain("partial-attribute")
+    expect(row("li")?.id).toBe("message_1")
+  })
+})

--- a/lib/herb/engine/dynamics_compiler.rb
+++ b/lib/herb/engine/dynamics_compiler.rb
@@ -473,6 +473,10 @@ module Herb
             return add_block_dynamic("(#{assignment(index, value)}) ? #{attribute} : \"\"")
           end
 
+          if index && interpolated?(index)
+            return add_block_dynamic("(#{assignment(index, value)}).fetch(-1)")
+          end
+
           return add_block_dynamic(index ? assignment(index, value) : value)
         end
         return if index.nil?
@@ -601,7 +605,16 @@ module Herb
 
       #: (Integer, String) -> String
       def assignment(index, value)
-        "#{current_scope}[#{index}] = #{value}"
+        if interpolated?(index)
+          "(#{current_scope}[#{index}] ||= []) << #{value}"
+        else
+          "#{current_scope}[#{index}] = #{value}"
+        end
+      end
+
+      #: (Integer) -> bool
+      def interpolated?(index)
+        @slot_visitor.slots[index]&.type == :attribute_interpolation
       end
 
       #: (String) -> void

--- a/lib/herb/engine/slot_visitor.rb
+++ b/lib/herb/engine/slot_visitor.rb
@@ -39,6 +39,7 @@ module Herb
       attr_reader :warnings #: Array[Herb::Warnings::Warning]
 
       SLOTS_DIRECTIVE = /<%#-?\s*herb:slots\b(?<mode>[^%]*?)-?%>/ #: Regexp
+      PART_MARKER = "<!--herb-part-->" #: String
       MODE_OPTION = /\b(server|client)\b/ #: Regexp
       MODES = [:server, :client].freeze #: Array[Symbol]
       COVERED = "_herb_covered_branches" #: String
@@ -132,6 +133,7 @@ module Herb
         attribute_open_tags = {} #: Hash[untyped, untyped]
         @attribute_open_tags = attribute_open_tags.compare_by_identity
         @state_presence = {} #: Hash[Integer, StateDirectives::Read]
+        @interpolated_attributes = [] #: Array[untyped]
         @strict_locals = {} #: Hash[String, Symbol]
         @region_states = {} #: Hash[String, StateDirectives::Declaration]
         item_states = {} #: Hash[untyped, Hash[String, StateDirectives::Declaration]]
@@ -266,6 +268,7 @@ module Herb
 
         return unless @mark
 
+        park_attribute_parts
         insert_markers(node)
         wrap_displaced
         wrap_region(node)
@@ -323,6 +326,7 @@ module Herb
         if dynamic?(node)
           record_slot(node, attribute_type_for(node))
           @attribute_open_tags[node] = @current_open_tag
+          @interpolated_attributes << node if attribute_type_for(node) == :attribute_interpolation
         end
 
         @in_attribute = true
@@ -1361,6 +1365,42 @@ module Herb
 
           body.push(text_node(@markers.item_close(slot_index)))
         end
+      end
+
+      #: () -> void
+      def park_attribute_parts
+        statics = @statics
+        return unless statics
+
+        @interpolated_attributes.each do |node|
+          index = @indices[node]
+          next unless index
+
+          segments = attribute_segments(node)
+          next unless segments
+
+          statics["#{index}:parts"] = @markers.branch(index, "parts") + segments.join(PART_MARKER)
+        end
+      end
+
+      #: (untyped) -> Array[String]?
+      def attribute_segments(node)
+        segments = [+""]
+
+        (node.value&.children || []).each do |child|
+          case child
+          when Herb::AST::LiteralNode
+            segments.last << child.content.to_s
+          when Herb::AST::ERBContentNode
+            return nil unless erb_output?(child.tag_opening&.value.to_s)
+
+            segments << +""
+          else
+            return nil
+          end
+        end
+
+        segments.size > 1 ? segments : nil
       end
 
       def park_item(slot_index, body)

--- a/sig/herb/engine/dynamics_compiler.rbs
+++ b/sig/herb/engine/dynamics_compiler.rbs
@@ -278,6 +278,9 @@ module Herb
       # : (Integer, String) -> String
       def assignment: (Integer, String) -> String
 
+      # : (Integer) -> bool
+      def interpolated?: (Integer) -> bool
+
       # : (String) -> void
       def add_block_dynamic: (String) -> void
 

--- a/sig/herb/engine/slot_visitor.rbs
+++ b/sig/herb/engine/slot_visitor.rbs
@@ -30,6 +30,8 @@ module Herb
 
       SLOTS_DIRECTIVE: Regexp
 
+      PART_MARKER: String
+
       MODE_OPTION: Regexp
 
       MODES: Array[Symbol]
@@ -340,6 +342,12 @@ module Herb
 
       # : (untyped, Integer?) -> void
       def wrap_items: (untyped, Integer?) -> void
+
+      # : () -> void
+      def park_attribute_parts: () -> void
+
+      # : (untyped) -> Array[String]?
+      def attribute_segments: (untyped) -> Array[String]?
 
       def park_item: (untyped slot_index, untyped body) -> untyped
 

--- a/test/engine/slots/parity_test.rb
+++ b/test/engine/slots/parity_test.rb
@@ -38,6 +38,7 @@ module Engine
         "an iteration whose value is output" => [%(<%= @items.each do |r| %><%= r %><% end %>), { items: [1, 2] }],
         "a conditional inside a block" => [%(<%= form_with(model: 1) do |f| %><% if @on %><%= @x %><% end %><% end %>), { on: true, x: "x" }],
         "a boolean attribute inside a block" => [%(<%# herb:state (sending: false) %><%= form_with(model: 1) do |f| %><video muted="<%= sending %>"></video><% end %>), {}],
+        "an interpolated attribute inside a block" => [%(<%= form_with(model: 1) do |f| %><li id="row_<%= @r %>">x</li><% end %>), { r: 7 }],
         "nothing dynamic at all" => [%(<p>static</p>), {}],
       }.freeze
 
@@ -104,6 +105,17 @@ module Engine
             assert_equal known[index], shape, "slot #{index} was recorded as #{known[index]} and its value arrived as #{shape}"
           end
         end
+      end
+
+      test "an interpolated attribute inside a block records its parts and renders text" do
+        source = %(<%= form_with(model: 1) do |f| %><li id="row_<%= @r %>">x</li><% end %>)
+        compiler = compile(source)
+        values = evaluate(compiler, { r: 7 })
+
+        interpolated = compiler.slot_visitor.slots.find { |slot| slot.type == :attribute_interpolation }
+
+        assert_equal ["7"], values.fetch(interpolated.index)
+        assert_includes values.values.grep(String).join, 'id="row_7"'
       end
 
       test "a boolean attribute inside a block records presence and renders text" do

--- a/test/engine/slots/statics_test.rb
+++ b/test/engine/slots/statics_test.rb
@@ -4,6 +4,7 @@ require_relative "../../test_helper"
 require_relative "../../snapshot_utils"
 require_relative "../../../lib/herb/engine"
 require_relative "../../../lib/herb/engine/slot_visitor"
+require_relative "../../../lib/herb/engine/dynamics_compiler"
 
 module Engine
   module Slots
@@ -152,6 +153,28 @@ module Engine
         refute_includes compiled, "_herb_covered_branches"
         refute_includes compiled, "<template"
         assert_includes evaluate_herb_source(compiled, { "@a" => false }), "herb-slot:0:conditional"
+      end
+
+      test "parks an interpolated attribute's static segments" do
+        template = %(<div id="message_<%= @id %>" class="row-<%= @kind %>-of-<%= @size %>">x</div>)
+        markup = parked(template, { "@id" => 7, "@kind" => "a", "@size" => "b" })
+
+        assert_includes markup, "<!--herb-branch:0:parts-->message_<!--herb-part-->"
+        assert_includes markup, "<!--herb-branch:1:parts-->row-<!--herb-part-->-of-<!--herb-part-->"
+      end
+
+      test "the values payload carries an interpolated attribute as its dynamic parts" do
+        template = %(<div class="row-<%= @kind %>-of-<%= @size %>">x</div>)
+        source = Herb::Engine::DynamicsCompiler.new(template, filename: "app/views/test.html.erb").src
+        payload = evaluate_herb_source(source, { "@kind" => "a", "@size" => "b" })
+
+        assert_equal ["a", "b"], payload[:slots][0]
+      end
+
+      test "parks no segments for an attribute holding more than outputs" do
+        rendered = render(%(<div class="x<% if @a %>y<% end %>z">c</div>), { "@a" => true })
+
+        refute_includes rendered, ":parts-->"
       end
 
       test "parks nothing at all unless the mode asks for it" do


### PR DESCRIPTION
This pull request makes `attribute_interpolation` slots writable, so a values payload or an optimistic insert can set an attribute that mixes static text with dynamic output.

An interpolated attribute like `id="message_<%= message.id %>"` was the one slot shape the runtime could not write. The values payload carries only the dynamic parts, the client only has the rendered whole, and it cannot know where the static text ends and the value begins. Every write to such a slot deferred as `partial-attribute`, which is why an optimistic chat row could never receive its real `id` on confirm and templates had to fall back to computing the whole attribute in one output tag.

#### How it works

The engine already parks static markup the client needs later, so the attribute's literal segments go through the same channel. `SlotVisitor` records each interpolated attribute during the walk and parks its segments in the region template under a `parts` branch, joined by a marker comment.

```erb
<li id="message_<%= message.id %>">
```

```html
<template data-herb-region="app/views/chat/show.html.erb:383854c4">
  <!--herb-branch:1:parts-->message_<!--herb-part-->
</template>
```

Only attributes composed purely of literals and output tags park their segments. A value with control flow inside it has no static shape to park, so those writes keep deferring as before.

`DynamicsCompiler` then delivers an interpolated slot's values as an array of its dynamic parts instead of one merged string, appending each output to the slot's entry.

```ruby
(scope[1] ||= []) << value
```

On the client, `setAttribute` and `fillSlots` accept `string[]` for interpolation slots and rebuild the whole value by interleaving the parked segments with the dynamics, so a payload carrying `{ 1 => ["42"] }` writes `id="message_42"`. The same resolution runs for `addItem`, where values are keyed by attribute name.

```js
slots.addItem(collection, key, { values: { id: "7" } })
// the skeleton row materializes with id="message_7"
```

A slot whose parts were never parked still defers as `partial-attribute`, and applying a value that reconstructs to what the page already shows is skipped as unchanged.

The reversal journal needed one structural fix. The inverse used to replay the previous whole value back through `setAttribute`, which re-interpolated it into `message_message_1`. The raw attribute write now lives in a private `#writeAttribute` that both the public path and the inverse use, so a revert restores the exact previous value.

Engine tests cover the parked segments, the array payload, and the refusal to park an attribute holding control flow. Client tests cover apply, revert, skeleton-built rows, the unchanged skip, and the missing-parts deferral.