### PR TITLE
Ruby: Build AST nodes with their canonical type strings

### DIFF
--- a/lib/herb/engine/slot_visitor.rb
+++ b/lib/herb/engine/slot_visitor.rb
@@ -874,54 +874,49 @@ module Herb
       end
 
       def text_node(content)
-        Herb::AST::HTMLTextNode.new("HTMLTextNode", Herb::Location.zero, [], content.dup)
+        Herb::AST::HTMLTextNode.build(content: content.dup)
       end
 
       def erb_code_node(code)
-        Herb::AST::ERBContentNode.new(
-          "ERBContentNode", Herb::Location.zero, [],
-          token(:erb_start, "<%"), token(:erb_content, " #{code} "), token(:erb_end, "%>"),
-          nil, false, true,
-          nil
+        Herb::AST::ERBContentNode.build(
+          tag_opening: token(:erb_start, "<%"),
+          content: token(:erb_content, " #{code} "),
+          tag_closing: token(:erb_end, "%>"),
+          valid: true
         )
       end
 
       def erb_output_node(code)
-        Herb::AST::ERBContentNode.new(
-          "ERBContentNode", Herb::Location.zero, [],
-          token(:erb_start, "<%="), token(:erb_content, " #{code} "), token(:erb_end, "%>"),
-          nil, false, true,
-          nil
+        Herb::AST::ERBContentNode.build(
+          tag_opening: token(:erb_start, "<%="),
+          content: token(:erb_content, " #{code} "),
+          tag_closing: token(:erb_end, "%>"),
+          valid: true
         )
       end
 
       def comment_node(text)
-        Herb::AST::HTMLCommentNode.new(
-          "HTMLCommentNode",
-          Herb::Location.zero,
-          [],
-          token(:html_comment_start, text),
-          [],
-          token(:html_comment_end, "")
+        Herb::AST::HTMLCommentNode.build(
+          comment_start: token(:html_comment_start, text),
+          comment_end: token(:html_comment_end, "")
         )
       end
 
       def attribute_node(name, value)
-        name_node = Herb::AST::HTMLAttributeNameNode.new(
-          "HTMLAttributeNameNode", Herb::Location.zero, [], [literal(name)]
+        name_node = Herb::AST::HTMLAttributeNameNode.build(children: [literal(name)])
+
+        value_node = Herb::AST::HTMLAttributeValueNode.build(
+          open_quote: token(:quote, '"'),
+          children: [literal(value)],
+          close_quote: token(:quote, '"'),
+          quoted: true
         )
 
-        value_node = Herb::AST::HTMLAttributeValueNode.new(
-          "HTMLAttributeValueNode", Herb::Location.zero, [], token(:quote, '"'), [literal(value)], token(:quote, '"'), true
-        )
-
-        Herb::AST::HTMLAttributeNode.new(
-          "HTMLAttributeNode", Herb::Location.zero, [], name_node, token(:equals, "="), value_node
-        )
+        Herb::AST::HTMLAttributeNode.build(name: name_node, equals: token(:equals, "="), value: value_node)
       end
 
       def literal(content)
-        Herb::AST::LiteralNode.new("LiteralNode", Herb::Location.zero, [], content.dup)
+        Herb::AST::LiteralNode.build(content: content.dup)
       end
 
       def token(type, value)

--- a/rust/tests/tree_inspect_test.rs
+++ b/rust/tests/tree_inspect_test.rs
@@ -10,14 +10,14 @@ fn test_document_with_text_node() {
   let loc = Location::new(Position::new(1, 0), Position::new(1, 5));
 
   let text_node = HTMLTextNode {
-    node_type: "HTMLTextNode".to_string(),
+    node_type: "AST_HTML_TEXT_NODE".to_string(),
     location: loc,
     errors: vec![],
     content: "Hello".to_string(),
   };
 
   let doc_node = DocumentNode {
-    node_type: "DocumentNode".to_string(),
+    node_type: "AST_DOCUMENT_NODE".to_string(),
     location: Location::new(Position::new(1, 0), Position::new(2, 0)),
     errors: vec![],
     children: vec![AnyNode::HTMLTextNode(Box::new(text_node))],

--- a/sig/herb/ast/nodes.rbs
+++ b/sig/herb/ast/nodes.rbs
@@ -19,6 +19,9 @@ module Herb
       # : (String, Location, Array[Herb::Errors::Error], Array[Herb::AST::Node], nil, String?) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], Array[Herb::AST::Node], nil, String?) -> void
 
+      # : () -> String
+      def self.type: () -> String
+
       # : (?children: Array[Herb::AST::Node], ?prism_context: nil, ?prism_node: String?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> DocumentNode
       def self.build: (?children: Array[Herb::AST::Node], ?prism_context: nil, ?prism_node: String?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> DocumentNode
 
@@ -54,6 +57,9 @@ module Herb
 
       # : (String, Location, Array[Herb::Errors::Error], String?) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], String?) -> void
+
+      # : () -> String
+      def self.type: () -> String
 
       # : (?content: String?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> LiteralNode
       def self.build: (?content: String?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> LiteralNode
@@ -100,6 +106,9 @@ module Herb
       # : (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, Array[Herb::AST::Node], bool) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, Array[Herb::AST::Node], bool) -> void
 
+      # : () -> String
+      def self.type: () -> String
+
       # : (?tag_opening: Herb::Token?, ?tag_name: Herb::Token?, ?tag_closing: Herb::Token?, ?children: Array[Herb::AST::Node], ?is_void: bool, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> HTMLOpenTagNode
       def self.build: (?tag_opening: Herb::Token?, ?tag_name: Herb::Token?, ?tag_closing: Herb::Token?, ?children: Array[Herb::AST::Node], ?is_void: bool, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> HTMLOpenTagNode
 
@@ -138,6 +147,9 @@ module Herb
 
       # : (String, Location, Array[Herb::Errors::Error], (Herb::AST::ERBIfNode | Herb::AST::ERBUnlessNode)?, Herb::Token?, bool) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], (Herb::AST::ERBIfNode | Herb::AST::ERBUnlessNode)?, Herb::Token?, bool) -> void
+
+      # : () -> String
+      def self.type: () -> String
 
       # : (?conditional: (Herb::AST::ERBIfNode | Herb::AST::ERBUnlessNode)?, ?tag_name: Herb::Token?, ?is_void: bool, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> HTMLConditionalOpenTagNode
       def self.build: (?conditional: (Herb::AST::ERBIfNode | Herb::AST::ERBUnlessNode)?, ?tag_name: Herb::Token?, ?is_void: bool, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> HTMLConditionalOpenTagNode
@@ -181,6 +193,9 @@ module Herb
       # : (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Array[Herb::AST::WhitespaceNode]?, Herb::Token?) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Array[Herb::AST::WhitespaceNode]?, Herb::Token?) -> void
 
+      # : () -> String
+      def self.type: () -> String
+
       # : (?tag_opening: Herb::Token?, ?tag_name: Herb::Token?, ?children: Array[Herb::AST::WhitespaceNode]?, ?tag_closing: Herb::Token?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> HTMLCloseTagNode
       def self.build: (?tag_opening: Herb::Token?, ?tag_name: Herb::Token?, ?children: Array[Herb::AST::WhitespaceNode]?, ?tag_closing: Herb::Token?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> HTMLCloseTagNode
 
@@ -214,6 +229,9 @@ module Herb
       # : (String, Location, Array[Herb::Errors::Error], Herb::Token?) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], Herb::Token?) -> void
 
+      # : () -> String
+      def self.type: () -> String
+
       # : (?tag_name: Herb::Token?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> HTMLOmittedCloseTagNode
       def self.build: (?tag_name: Herb::Token?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> HTMLOmittedCloseTagNode
 
@@ -246,6 +264,9 @@ module Herb
 
       # : (String, Location, Array[Herb::Errors::Error], Herb::Token?) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], Herb::Token?) -> void
+
+      # : () -> String
+      def self.type: () -> String
 
       # : (?tag_name: Herb::Token?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> HTMLVirtualCloseTagNode
       def self.build: (?tag_name: Herb::Token?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> HTMLVirtualCloseTagNode
@@ -294,6 +315,9 @@ module Herb
 
       # : (String, Location, Array[Herb::Errors::Error], (Herb::AST::HTMLOpenTagNode | Herb::AST::HTMLConditionalOpenTagNode | Herb::AST::ERBOpenTagNode)?, Herb::Token?, Array[Herb::AST::Node], (Herb::AST::HTMLCloseTagNode | Herb::AST::HTMLOmittedCloseTagNode | Herb::AST::HTMLVirtualCloseTagNode | Herb::AST::ERBEndNode)?, bool, String?) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], (Herb::AST::HTMLOpenTagNode | Herb::AST::HTMLConditionalOpenTagNode | Herb::AST::ERBOpenTagNode)?, Herb::Token?, Array[Herb::AST::Node], (Herb::AST::HTMLCloseTagNode | Herb::AST::HTMLOmittedCloseTagNode | Herb::AST::HTMLVirtualCloseTagNode | Herb::AST::ERBEndNode)?, bool, String?) -> void
+
+      # : () -> String
+      def self.type: () -> String
 
       # : (?open_tag: (Herb::AST::HTMLOpenTagNode | Herb::AST::HTMLConditionalOpenTagNode | Herb::AST::ERBOpenTagNode)?, ?tag_name: Herb::Token?, ?body: Array[Herb::AST::Node], ?close_tag: (Herb::AST::HTMLCloseTagNode | Herb::AST::HTMLOmittedCloseTagNode | Herb::AST::HTMLVirtualCloseTagNode | Herb::AST::ERBEndNode)?, ?is_void: bool, ?element_source: String?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> HTMLElementNode
       def self.build: (?open_tag: (Herb::AST::HTMLOpenTagNode | Herb::AST::HTMLConditionalOpenTagNode | Herb::AST::ERBOpenTagNode)?, ?tag_name: Herb::Token?, ?body: Array[Herb::AST::Node], ?close_tag: (Herb::AST::HTMLCloseTagNode | Herb::AST::HTMLOmittedCloseTagNode | Herb::AST::HTMLVirtualCloseTagNode | Herb::AST::ERBEndNode)?, ?is_void: bool, ?element_source: String?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> HTMLElementNode
@@ -349,6 +373,9 @@ module Herb
       # : (String, Location, Array[Herb::Errors::Error], String?, (Herb::AST::ERBIfNode | Herb::AST::ERBUnlessNode)?, Herb::AST::HTMLOpenTagNode?, Array[Herb::AST::Node], (Herb::AST::HTMLCloseTagNode | Herb::AST::HTMLOmittedCloseTagNode)?, (Herb::AST::ERBIfNode | Herb::AST::ERBUnlessNode)?, Herb::Token?, String?) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], String?, (Herb::AST::ERBIfNode | Herb::AST::ERBUnlessNode)?, Herb::AST::HTMLOpenTagNode?, Array[Herb::AST::Node], (Herb::AST::HTMLCloseTagNode | Herb::AST::HTMLOmittedCloseTagNode)?, (Herb::AST::ERBIfNode | Herb::AST::ERBUnlessNode)?, Herb::Token?, String?) -> void
 
+      # : () -> String
+      def self.type: () -> String
+
       # : (?condition: String?, ?open_conditional: (Herb::AST::ERBIfNode | Herb::AST::ERBUnlessNode)?, ?open_tag: Herb::AST::HTMLOpenTagNode?, ?body: Array[Herb::AST::Node], ?close_tag: (Herb::AST::HTMLCloseTagNode | Herb::AST::HTMLOmittedCloseTagNode)?, ?close_conditional: (Herb::AST::ERBIfNode | Herb::AST::ERBUnlessNode)?, ?tag_name: Herb::Token?, ?element_source: String?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> HTMLConditionalElementNode
       def self.build: (?condition: String?, ?open_conditional: (Herb::AST::ERBIfNode | Herb::AST::ERBUnlessNode)?, ?open_tag: Herb::AST::HTMLOpenTagNode?, ?body: Array[Herb::AST::Node], ?close_tag: (Herb::AST::HTMLCloseTagNode | Herb::AST::HTMLOmittedCloseTagNode)?, ?close_conditional: (Herb::AST::ERBIfNode | Herb::AST::ERBUnlessNode)?, ?tag_name: Herb::Token?, ?element_source: String?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> HTMLConditionalElementNode
 
@@ -391,6 +418,9 @@ module Herb
       # : (String, Location, Array[Herb::Errors::Error], Herb::Token?, Array[Herb::AST::Node], Herb::Token?, bool) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], Herb::Token?, Array[Herb::AST::Node], Herb::Token?, bool) -> void
 
+      # : () -> String
+      def self.type: () -> String
+
       # : (?open_quote: Herb::Token?, ?children: Array[Herb::AST::Node], ?close_quote: Herb::Token?, ?quoted: bool, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> HTMLAttributeValueNode
       def self.build: (?open_quote: Herb::Token?, ?children: Array[Herb::AST::Node], ?close_quote: Herb::Token?, ?quoted: bool, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> HTMLAttributeValueNode
 
@@ -423,6 +453,9 @@ module Herb
 
       # : (String, Location, Array[Herb::Errors::Error], Array[(Herb::AST::LiteralNode | Herb::AST::ERBContentNode)]?) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], Array[Herb::AST::LiteralNode | Herb::AST::ERBContentNode]?) -> void
+
+      # : () -> String
+      def self.type: () -> String
 
       # : (?children: Array[(Herb::AST::LiteralNode | Herb::AST::ERBContentNode)]?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> HTMLAttributeNameNode
       def self.build: (?children: Array[Herb::AST::LiteralNode | Herb::AST::ERBContentNode]?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> HTMLAttributeNameNode
@@ -463,6 +496,9 @@ module Herb
       # : (String, Location, Array[Herb::Errors::Error], Herb::AST::HTMLAttributeNameNode?, Herb::Token?, Herb::AST::HTMLAttributeValueNode?) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], Herb::AST::HTMLAttributeNameNode?, Herb::Token?, Herb::AST::HTMLAttributeValueNode?) -> void
 
+      # : () -> String
+      def self.type: () -> String
+
       # : (?name: Herb::AST::HTMLAttributeNameNode?, ?equals: Herb::Token?, ?value: Herb::AST::HTMLAttributeValueNode?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> HTMLAttributeNode
       def self.build: (?name: Herb::AST::HTMLAttributeNameNode?, ?equals: Herb::Token?, ?value: Herb::AST::HTMLAttributeValueNode?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> HTMLAttributeNode
 
@@ -495,6 +531,9 @@ module Herb
 
       # : (String, Location, Array[Herb::Errors::Error], String?) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], String?) -> void
+
+      # : () -> String
+      def self.type: () -> String
 
       # : (?content: String?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> RubyLiteralNode
       def self.build: (?content: String?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> RubyLiteralNode
@@ -531,6 +570,9 @@ module Herb
 
       # : (String, Location, Array[Herb::Errors::Error], String?, String?) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], String?, String?) -> void
+
+      # : () -> String
+      def self.type: () -> String
 
       # : (?content: String?, ?prefix: String?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> RubyHTMLAttributesSplatNode
       def self.build: (?content: String?, ?prefix: String?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> RubyHTMLAttributesSplatNode
@@ -577,6 +619,9 @@ module Herb
       # : (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, Herb::Token?, Array[Herb::AST::Node]) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, Herb::Token?, Array[Herb::AST::Node]) -> void
 
+      # : () -> String
+      def self.type: () -> String
+
       # : (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?tag_name: Herb::Token?, ?children: Array[Herb::AST::Node], ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBOpenTagNode
       def self.build: (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?tag_name: Herb::Token?, ?children: Array[Herb::AST::Node], ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBOpenTagNode
 
@@ -609,6 +654,9 @@ module Herb
 
       # : (String, Location, Array[Herb::Errors::Error], String?) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], String?) -> void
+
+      # : () -> String
+      def self.type: () -> String
 
       # : (?content: String?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> HTMLTextNode
       def self.build: (?content: String?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> HTMLTextNode
@@ -649,6 +697,9 @@ module Herb
       # : (String, Location, Array[Herb::Errors::Error], Herb::Token?, Array[Herb::AST::Node], Herb::Token?) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], Herb::Token?, Array[Herb::AST::Node], Herb::Token?) -> void
 
+      # : () -> String
+      def self.type: () -> String
+
       # : (?comment_start: Herb::Token?, ?children: Array[Herb::AST::Node], ?comment_end: Herb::Token?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> HTMLCommentNode
       def self.build: (?comment_start: Herb::Token?, ?children: Array[Herb::AST::Node], ?comment_end: Herb::Token?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> HTMLCommentNode
 
@@ -688,6 +739,9 @@ module Herb
       # : (String, Location, Array[Herb::Errors::Error], Herb::Token?, Array[Herb::AST::Node], Herb::Token?) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], Herb::Token?, Array[Herb::AST::Node], Herb::Token?) -> void
 
+      # : () -> String
+      def self.type: () -> String
+
       # : (?tag_opening: Herb::Token?, ?children: Array[Herb::AST::Node], ?tag_closing: Herb::Token?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> HTMLDoctypeNode
       def self.build: (?tag_opening: Herb::Token?, ?children: Array[Herb::AST::Node], ?tag_closing: Herb::Token?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> HTMLDoctypeNode
 
@@ -726,6 +780,9 @@ module Herb
 
       # : (String, Location, Array[Herb::Errors::Error], Herb::Token?, Array[Herb::AST::Node], Herb::Token?) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], Herb::Token?, Array[Herb::AST::Node], Herb::Token?) -> void
+
+      # : () -> String
+      def self.type: () -> String
 
       # : (?tag_opening: Herb::Token?, ?children: Array[Herb::AST::Node], ?tag_closing: Herb::Token?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> XMLDeclarationNode
       def self.build: (?tag_opening: Herb::Token?, ?children: Array[Herb::AST::Node], ?tag_closing: Herb::Token?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> XMLDeclarationNode
@@ -769,6 +826,9 @@ module Herb
       # : (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Array[Herb::AST::Node], Herb::Token?) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Array[Herb::AST::Node], Herb::Token?) -> void
 
+      # : () -> String
+      def self.type: () -> String
+
       # : (?tag_opening: Herb::Token?, ?target: Herb::Token?, ?children: Array[Herb::AST::Node], ?tag_closing: Herb::Token?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> XMLProcessingInstructionNode
       def self.build: (?tag_opening: Herb::Token?, ?target: Herb::Token?, ?children: Array[Herb::AST::Node], ?tag_closing: Herb::Token?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> XMLProcessingInstructionNode
 
@@ -808,6 +868,9 @@ module Herb
       # : (String, Location, Array[Herb::Errors::Error], Herb::Token?, Array[Herb::AST::Node], Herb::Token?) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], Herb::Token?, Array[Herb::AST::Node], Herb::Token?) -> void
 
+      # : () -> String
+      def self.type: () -> String
+
       # : (?tag_opening: Herb::Token?, ?children: Array[Herb::AST::Node], ?tag_closing: Herb::Token?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> CDATANode
       def self.build: (?tag_opening: Herb::Token?, ?children: Array[Herb::AST::Node], ?tag_closing: Herb::Token?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> CDATANode
 
@@ -840,6 +903,9 @@ module Herb
 
       # : (String, Location, Array[Herb::Errors::Error], Herb::Token?) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], Herb::Token?) -> void
+
+      # : () -> String
+      def self.type: () -> String
 
       # : (?value: Herb::Token?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> WhitespaceNode
       def self.build: (?value: Herb::Token?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> WhitespaceNode
@@ -892,6 +958,9 @@ module Herb
       # : (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, nil, bool, bool, String?) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, nil, bool, bool, String?) -> void
 
+      # : () -> String
+      def self.type: () -> String
+
       # : (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?analyzed_ruby: nil, ?parsed: bool, ?valid: bool, ?prism_node: String?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBContentNode
       def self.build: (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?analyzed_ruby: nil, ?parsed: bool, ?valid: bool, ?prism_node: String?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBContentNode
 
@@ -934,6 +1003,9 @@ module Herb
       # : (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?) -> void
 
+      # : () -> String
+      def self.type: () -> String
+
       # : (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBEndNode
       def self.build: (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBEndNode
 
@@ -975,6 +1047,9 @@ module Herb
 
       # : (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, Array[Herb::AST::Node]) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, Array[Herb::AST::Node]) -> void
+
+      # : () -> String
+      def self.type: () -> String
 
       # : (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?statements: Array[Herb::AST::Node], ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBElseNode
       def self.build: (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?statements: Array[Herb::AST::Node], ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBElseNode
@@ -1029,6 +1104,9 @@ module Herb
 
       # : (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, Herb::Location?, String?, Array[Herb::AST::Node], (Herb::AST::ERBIfNode | Herb::AST::ERBElseNode)?, Herb::AST::ERBEndNode?) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, Herb::Location?, String?, Array[Herb::AST::Node], (Herb::AST::ERBIfNode | Herb::AST::ERBElseNode)?, Herb::AST::ERBEndNode?) -> void
+
+      # : () -> String
+      def self.type: () -> String
 
       # : (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?then_keyword: Herb::Location?, ?prism_node: String?, ?statements: Array[Herb::AST::Node], ?subsequent: (Herb::AST::ERBIfNode | Herb::AST::ERBElseNode)?, ?end_node: Herb::AST::ERBEndNode?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBIfNode
       def self.build: (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?then_keyword: Herb::Location?, ?prism_node: String?, ?statements: Array[Herb::AST::Node], ?subsequent: (Herb::AST::ERBIfNode | Herb::AST::ERBElseNode)?, ?end_node: Herb::AST::ERBEndNode?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBIfNode
@@ -1092,6 +1170,9 @@ module Herb
 
       # : (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, String?, Array[Herb::AST::Node], Array[Herb::AST::RubyParameterNode]?, Herb::AST::ERBRescueNode?, Herb::AST::ERBElseNode?, Herb::AST::ERBEnsureNode?, Herb::AST::ERBEndNode?) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, String?, Array[Herb::AST::Node], Array[Herb::AST::RubyParameterNode]?, Herb::AST::ERBRescueNode?, Herb::AST::ERBElseNode?, Herb::AST::ERBEnsureNode?, Herb::AST::ERBEndNode?) -> void
+
+      # : () -> String
+      def self.type: () -> String
 
       # : (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?prism_node: String?, ?body: Array[Herb::AST::Node], ?block_arguments: Array[Herb::AST::RubyParameterNode]?, ?rescue_clause: Herb::AST::ERBRescueNode?, ?else_clause: Herb::AST::ERBElseNode?, ?ensure_clause: Herb::AST::ERBEnsureNode?, ?end_node: Herb::AST::ERBEndNode?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBBlockNode
       def self.build: (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?prism_node: String?, ?body: Array[Herb::AST::Node], ?block_arguments: Array[Herb::AST::RubyParameterNode]?, ?rescue_clause: Herb::AST::ERBRescueNode?, ?else_clause: Herb::AST::ERBElseNode?, ?ensure_clause: Herb::AST::ERBEnsureNode?, ?end_node: Herb::AST::ERBEndNode?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBBlockNode
@@ -1171,6 +1252,9 @@ module Herb
       # : (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, String?, Herb::Token?, Herb::Token?, Herb::Token?, Array[Herb::AST::RubyLiteralNode]?, Herb::Token?, Array[Herb::AST::Node], Array[Herb::AST::RubyParameterNode]?, Herb::AST::ERBRescueNode?, Herb::AST::ERBElseNode?, Herb::AST::ERBEnsureNode?, Herb::AST::ERBEndNode?) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, String?, Herb::Token?, Herb::Token?, Herb::Token?, Array[Herb::AST::RubyLiteralNode]?, Herb::Token?, Array[Herb::AST::Node], Array[Herb::AST::RubyParameterNode]?, Herb::AST::ERBRescueNode?, Herb::AST::ERBElseNode?, Herb::AST::ERBEnsureNode?, Herb::AST::ERBEndNode?) -> void
 
+      # : () -> String
+      def self.type: () -> String
+
       # : (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?prism_node: String?, ?receiver: Herb::Token?, ?call_operator: Herb::Token?, ?message: Herb::Token?, ?arguments: Array[Herb::AST::RubyLiteralNode]?, ?block_opening: Herb::Token?, ?body: Array[Herb::AST::Node], ?block_arguments: Array[Herb::AST::RubyParameterNode]?, ?rescue_clause: Herb::AST::ERBRescueNode?, ?else_clause: Herb::AST::ERBElseNode?, ?ensure_clause: Herb::AST::ERBEnsureNode?, ?end_node: Herb::AST::ERBEndNode?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBIterationBlockNode
       def self.build: (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?prism_node: String?, ?receiver: Herb::Token?, ?call_operator: Herb::Token?, ?message: Herb::Token?, ?arguments: Array[Herb::AST::RubyLiteralNode]?, ?block_opening: Herb::Token?, ?body: Array[Herb::AST::Node], ?block_arguments: Array[Herb::AST::RubyParameterNode]?, ?rescue_clause: Herb::AST::ERBRescueNode?, ?else_clause: Herb::AST::ERBElseNode?, ?ensure_clause: Herb::AST::ERBEnsureNode?, ?end_node: Herb::AST::ERBEndNode?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBIterationBlockNode
 
@@ -1218,6 +1302,9 @@ module Herb
 
       # : (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, Herb::Location?, Array[Herb::AST::Node]) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, Herb::Location?, Array[Herb::AST::Node]) -> void
+
+      # : () -> String
+      def self.type: () -> String
 
       # : (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?then_keyword: Herb::Location?, ?statements: Array[Herb::AST::Node], ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBWhenNode
       def self.build: (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?then_keyword: Herb::Location?, ?statements: Array[Herb::AST::Node], ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBWhenNode
@@ -1272,6 +1359,9 @@ module Herb
 
       # : (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, Array[Herb::AST::Node], String?, Array[Herb::AST::ERBWhenNode], Herb::AST::ERBElseNode?, Herb::AST::ERBEndNode?) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, Array[Herb::AST::Node], String?, Array[Herb::AST::ERBWhenNode], Herb::AST::ERBElseNode?, Herb::AST::ERBEndNode?) -> void
+
+      # : () -> String
+      def self.type: () -> String
 
       # : (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?children: Array[Herb::AST::Node], ?prism_node: String?, ?conditions: Array[Herb::AST::ERBWhenNode], ?else_clause: Herb::AST::ERBElseNode?, ?end_node: Herb::AST::ERBEndNode?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBCaseNode
       def self.build: (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?children: Array[Herb::AST::Node], ?prism_node: String?, ?conditions: Array[Herb::AST::ERBWhenNode], ?else_clause: Herb::AST::ERBElseNode?, ?end_node: Herb::AST::ERBEndNode?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBCaseNode
@@ -1330,6 +1420,9 @@ module Herb
       # : (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, Array[Herb::AST::Node], String?, Array[Herb::AST::ERBInNode], Herb::AST::ERBElseNode?, Herb::AST::ERBEndNode?) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, Array[Herb::AST::Node], String?, Array[Herb::AST::ERBInNode], Herb::AST::ERBElseNode?, Herb::AST::ERBEndNode?) -> void
 
+      # : () -> String
+      def self.type: () -> String
+
       # : (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?children: Array[Herb::AST::Node], ?prism_node: String?, ?conditions: Array[Herb::AST::ERBInNode], ?else_clause: Herb::AST::ERBElseNode?, ?end_node: Herb::AST::ERBEndNode?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBCaseMatchNode
       def self.build: (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?children: Array[Herb::AST::Node], ?prism_node: String?, ?conditions: Array[Herb::AST::ERBInNode], ?else_clause: Herb::AST::ERBElseNode?, ?end_node: Herb::AST::ERBEndNode?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBCaseMatchNode
 
@@ -1380,6 +1473,9 @@ module Herb
 
       # : (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, String?, Array[Herb::AST::Node], Herb::AST::ERBEndNode?) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, String?, Array[Herb::AST::Node], Herb::AST::ERBEndNode?) -> void
+
+      # : () -> String
+      def self.type: () -> String
 
       # : (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?prism_node: String?, ?statements: Array[Herb::AST::Node], ?end_node: Herb::AST::ERBEndNode?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBWhileNode
       def self.build: (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?prism_node: String?, ?statements: Array[Herb::AST::Node], ?end_node: Herb::AST::ERBEndNode?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBWhileNode
@@ -1432,6 +1528,9 @@ module Herb
       # : (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, String?, Array[Herb::AST::Node], Herb::AST::ERBEndNode?) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, String?, Array[Herb::AST::Node], Herb::AST::ERBEndNode?) -> void
 
+      # : () -> String
+      def self.type: () -> String
+
       # : (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?prism_node: String?, ?statements: Array[Herb::AST::Node], ?end_node: Herb::AST::ERBEndNode?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBUntilNode
       def self.build: (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?prism_node: String?, ?statements: Array[Herb::AST::Node], ?end_node: Herb::AST::ERBEndNode?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBUntilNode
 
@@ -1483,6 +1582,9 @@ module Herb
       # : (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, String?, Array[Herb::AST::Node], Herb::AST::ERBEndNode?) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, String?, Array[Herb::AST::Node], Herb::AST::ERBEndNode?) -> void
 
+      # : () -> String
+      def self.type: () -> String
+
       # : (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?prism_node: String?, ?statements: Array[Herb::AST::Node], ?end_node: Herb::AST::ERBEndNode?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBForNode
       def self.build: (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?prism_node: String?, ?statements: Array[Herb::AST::Node], ?end_node: Herb::AST::ERBEndNode?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBForNode
 
@@ -1531,6 +1633,9 @@ module Herb
       # : (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, Array[Herb::AST::Node], Herb::AST::ERBRescueNode?) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, Array[Herb::AST::Node], Herb::AST::ERBRescueNode?) -> void
 
+      # : () -> String
+      def self.type: () -> String
+
       # : (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?statements: Array[Herb::AST::Node], ?subsequent: Herb::AST::ERBRescueNode?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBRescueNode
       def self.build: (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?statements: Array[Herb::AST::Node], ?subsequent: Herb::AST::ERBRescueNode?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBRescueNode
 
@@ -1572,6 +1677,9 @@ module Herb
 
       # : (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, Array[Herb::AST::Node]) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, Array[Herb::AST::Node]) -> void
+
+      # : () -> String
+      def self.type: () -> String
 
       # : (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?statements: Array[Herb::AST::Node], ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBEnsureNode
       def self.build: (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?statements: Array[Herb::AST::Node], ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBEnsureNode
@@ -1630,6 +1738,9 @@ module Herb
       # : (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, String?, Array[Herb::AST::Node], Herb::AST::ERBRescueNode?, Herb::AST::ERBElseNode?, Herb::AST::ERBEnsureNode?, Herb::AST::ERBEndNode?) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, String?, Array[Herb::AST::Node], Herb::AST::ERBRescueNode?, Herb::AST::ERBElseNode?, Herb::AST::ERBEnsureNode?, Herb::AST::ERBEndNode?) -> void
 
+      # : () -> String
+      def self.type: () -> String
+
       # : (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?prism_node: String?, ?statements: Array[Herb::AST::Node], ?rescue_clause: Herb::AST::ERBRescueNode?, ?else_clause: Herb::AST::ERBElseNode?, ?ensure_clause: Herb::AST::ERBEnsureNode?, ?end_node: Herb::AST::ERBEndNode?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBBeginNode
       def self.build: (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?prism_node: String?, ?statements: Array[Herb::AST::Node], ?rescue_clause: Herb::AST::ERBRescueNode?, ?else_clause: Herb::AST::ERBElseNode?, ?ensure_clause: Herb::AST::ERBEnsureNode?, ?end_node: Herb::AST::ERBEndNode?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBBeginNode
 
@@ -1687,6 +1798,9 @@ module Herb
       # : (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, Herb::Location?, String?, Array[Herb::AST::Node], Herb::AST::ERBElseNode?, Herb::AST::ERBEndNode?) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, Herb::Location?, String?, Array[Herb::AST::Node], Herb::AST::ERBElseNode?, Herb::AST::ERBEndNode?) -> void
 
+      # : () -> String
+      def self.type: () -> String
+
       # : (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?then_keyword: Herb::Location?, ?prism_node: String?, ?statements: Array[Herb::AST::Node], ?else_clause: Herb::AST::ERBElseNode?, ?end_node: Herb::AST::ERBEndNode?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBUnlessNode
       def self.build: (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?then_keyword: Herb::Location?, ?prism_node: String?, ?statements: Array[Herb::AST::Node], ?else_clause: Herb::AST::ERBElseNode?, ?end_node: Herb::AST::ERBEndNode?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBUnlessNode
 
@@ -1725,6 +1839,9 @@ module Herb
 
       # : (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::AST::RubyLiteralNode?) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::AST::RubyLiteralNode?) -> void
+
+      # : () -> String
+      def self.type: () -> String
 
       # : (?name: Herb::Token?, ?value: Herb::AST::RubyLiteralNode?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> RubyRenderLocalNode
       def self.build: (?name: Herb::Token?, ?value: Herb::AST::RubyLiteralNode?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> RubyRenderLocalNode
@@ -1810,6 +1927,9 @@ module Herb
       # : (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, Herb::Token?, Herb::Token?, Herb::Token?, Herb::Token?, Herb::Token?, Herb::Token?, Herb::Token?, Herb::Token?, Herb::Token?, Herb::Token?, Herb::Token?, Herb::Token?, Herb::Token?, Herb::Token?, Array[Herb::AST::RubyRenderLocalNode]?) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, Herb::Token?, Herb::Token?, Herb::Token?, Herb::Token?, Herb::Token?, Herb::Token?, Herb::Token?, Herb::Token?, Herb::Token?, Herb::Token?, Herb::Token?, Herb::Token?, Herb::Token?, Herb::Token?, Array[Herb::AST::RubyRenderLocalNode]?) -> void
 
+      # : () -> String
+      def self.type: () -> String
+
       # : (?partial: Herb::Token?, ?template_path: Herb::Token?, ?layout: Herb::Token?, ?file: Herb::Token?, ?inline_template: Herb::Token?, ?body: Herb::Token?, ?plain: Herb::Token?, ?html: Herb::Token?, ?renderable: Herb::Token?, ?collection: Herb::Token?, ?object: Herb::Token?, ?as_name: Herb::Token?, ?spacer_template: Herb::Token?, ?formats: Herb::Token?, ?variants: Herb::Token?, ?handlers: Herb::Token?, ?content_type: Herb::Token?, ?locals: Array[Herb::AST::RubyRenderLocalNode]?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> RubyRenderKeywordsNode
       def self.build: (?partial: Herb::Token?, ?template_path: Herb::Token?, ?layout: Herb::Token?, ?file: Herb::Token?, ?inline_template: Herb::Token?, ?body: Herb::Token?, ?plain: Herb::Token?, ?html: Herb::Token?, ?renderable: Herb::Token?, ?collection: Herb::Token?, ?object: Herb::Token?, ?as_name: Herb::Token?, ?spacer_template: Herb::Token?, ?formats: Herb::Token?, ?variants: Herb::Token?, ?handlers: Herb::Token?, ?content_type: Herb::Token?, ?locals: Array[Herb::AST::RubyRenderLocalNode]?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> RubyRenderKeywordsNode
 
@@ -1876,6 +1996,9 @@ module Herb
       # : (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, nil, String?, Herb::AST::RubyRenderKeywordsNode?, Array[Herb::AST::Node], Array[Herb::AST::RubyParameterNode]?, Herb::AST::ERBRescueNode?, Herb::AST::ERBElseNode?, Herb::AST::ERBEnsureNode?, Herb::AST::ERBEndNode?) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, nil, String?, Herb::AST::RubyRenderKeywordsNode?, Array[Herb::AST::Node], Array[Herb::AST::RubyParameterNode]?, Herb::AST::ERBRescueNode?, Herb::AST::ERBElseNode?, Herb::AST::ERBEnsureNode?, Herb::AST::ERBEndNode?) -> void
 
+      # : () -> String
+      def self.type: () -> String
+
       # : (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?analyzed_ruby: nil, ?prism_node: String?, ?keywords: Herb::AST::RubyRenderKeywordsNode?, ?body: Array[Herb::AST::Node], ?block_arguments: Array[Herb::AST::RubyParameterNode]?, ?rescue_clause: Herb::AST::ERBRescueNode?, ?else_clause: Herb::AST::ERBElseNode?, ?ensure_clause: Herb::AST::ERBEnsureNode?, ?end_node: Herb::AST::ERBEndNode?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBRenderNode
       def self.build: (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?analyzed_ruby: nil, ?prism_node: String?, ?keywords: Herb::AST::RubyRenderKeywordsNode?, ?body: Array[Herb::AST::Node], ?block_arguments: Array[Herb::AST::RubyParameterNode]?, ?rescue_clause: Herb::AST::ERBRescueNode?, ?else_clause: Herb::AST::ERBElseNode?, ?ensure_clause: Herb::AST::ERBEnsureNode?, ?end_node: Herb::AST::ERBEndNode?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBRenderNode
 
@@ -1920,6 +2043,9 @@ module Herb
 
       # : (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::AST::RubyLiteralNode?, String?, bool) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::AST::RubyLiteralNode?, String?, bool) -> void
+
+      # : () -> String
+      def self.type: () -> String
 
       # : (?name: Herb::Token?, ?default_value: Herb::AST::RubyLiteralNode?, ?kind: String?, ?required: bool, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> RubyParameterNode
       def self.build: (?name: Herb::Token?, ?default_value: Herb::AST::RubyLiteralNode?, ?kind: String?, ?required: bool, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> RubyParameterNode
@@ -1969,6 +2095,9 @@ module Herb
       # : (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, nil, String?, Array[Herb::AST::RubyParameterNode]?) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, nil, String?, Array[Herb::AST::RubyParameterNode]?) -> void
 
+      # : () -> String
+      def self.type: () -> String
+
       # : (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?analyzed_ruby: nil, ?prism_node: String?, ?locals: Array[Herb::AST::RubyParameterNode]?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBStrictLocalsNode
       def self.build: (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?analyzed_ruby: nil, ?prism_node: String?, ?locals: Array[Herb::AST::RubyParameterNode]?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBStrictLocalsNode
 
@@ -2010,6 +2139,9 @@ module Herb
 
       # : (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?) -> void
+
+      # : () -> String
+      def self.type: () -> String
 
       # : (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBYieldNode
       def self.build: (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBYieldNode
@@ -2055,6 +2187,9 @@ module Herb
 
       # : (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, Herb::Location?, Array[Herb::AST::Node]) -> void
       def initialize: (String, Location, Array[Herb::Errors::Error], Herb::Token?, Herb::Token?, Herb::Token?, Herb::Location?, Array[Herb::AST::Node]) -> void
+
+      # : () -> String
+      def self.type: () -> String
 
       # : (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?then_keyword: Herb::Location?, ?statements: Array[Herb::AST::Node], ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBInNode
       def self.build: (?tag_opening: Herb::Token?, ?content: Herb::Token?, ?tag_closing: Herb::Token?, ?then_keyword: Herb::Location?, ?statements: Array[Herb::AST::Node], ?location: Location, ?errors: Array[Herb::Errors::Error]) -> ERBInNode

--- a/templates/lib/herb/ast/nodes.rb.erb
+++ b/templates/lib/herb/ast/nodes.rb.erb
@@ -27,9 +27,14 @@ module Herb
         <%- end -%>
       end
 
+      #: () -> String
+      def self.type
+        "<%= node.type %>"
+      end
+
       #: (<%= [*node.fields.map { |field| "?#{field.name}: #{field.nilable_ruby_type}" }, "?location: Location", "?errors: Array[Herb::Errors::Error]"].join(", ") %>) -> <%= node.name %>
       def self.build(<%= [*node.fields.map { |field| "#{field.name}: #{field.default_ruby_value}" }, "location: Location.zero", "errors: []"].join(", ") %>)
-        new(<%= ["\"#{node.name}\"", "location", "errors", *node.fields.map(&:name)].join(", ") %>)
+        new(<%= ["type", "location", "errors", *node.fields.map(&:name)].join(", ") %>)
       end
 
       <%- if node.fields.any? { |f| f.is_a?(Herb::Template::PrismSerializedField) || f.is_a?(Herb::Template::PrismNodeField) } -%>

--- a/templates/rust/src/ast/nodes.rs.erb
+++ b/templates/rust/src/ast/nodes.rs.erb
@@ -199,7 +199,7 @@ pub(crate) unsafe fn convert_node(node_pointer: *const c_void, source: &std::syn
     let node_base_ref = &(*c_node_pointer).base;
 
     Some(<%= node.name %> {
-      node_type: "<%= node.name %>".to_string(),
+      node_type: "<%= node.type %>".to_string(),
       location: convert_location(node_base_ref.location),
       errors: convert_errors(node_base_ref.errors),
       <%- node.fields.each do |field| -%>


### PR DESCRIPTION
This pull request makes every generated Ruby AST class supply its own canonical type string, so nodes built in Ruby carry the same `type` as nodes the parser produces.

The parser interns the canonical `AST_*` form, so a parsed text node answers `"AST_HTML_TEXT_NODE"`. The `build` factories from #2055 passed the class name instead, so a hand-built node answered `"HTMLTextNode"`. Any code branching on the canonical form silently missed synthesized nodes. `SlotStatics` hit this for real. It skips ERB nodes by the `AST_ERB_` prefix, a synthesized `ERBContentNode` slipped past the skip into the else branch, raised `Unprintable`, and item-skeleton parking silently aborted whenever a loop body contained a replaced directive.

Each generated class now knows its canonical type as a class method, mirroring `static get type()` on the JavaScript side, and `build` constructs with it.