### PR TITLE
Client: Improve revert fidelity for branch switches and state bursts

### DIFF
--- a/javascript/packages/client/src/slot-index.ts
+++ b/javascript/packages/client/src/slot-index.ts
@@ -416,8 +416,8 @@ export class SlotIndex {
     return report
   }
 
-  transaction<T>(work: () => T): { token: RevertToken | null; result: T } {
-    if (this.#recording) return { token: null, result: work() }
+  transaction<T>(work: () => T, options: { retain?: boolean } = {}): { token: RevertToken | null; result: T } {
+    if (this.#recording || options.retain === false) return { token: null, result: work() }
 
     const inverses: Inverse[] = []
 
@@ -1245,13 +1245,17 @@ export class SlotIndex {
     if (!region) return false
 
     this.#record(() => {
-      const before = slot.branch
+      const before = this.#current(slot)
+      const beforeBranch = slot.branch
       const address = this.#addressOf(slot)
 
       return () => {
         const live = this.#slotAt(address)
 
-        if (live) this.switchBranch(live, before)
+        if (!live) return
+
+        this.update(live, before)
+        live.branch = beforeBranch
       }
     })
 

--- a/javascript/packages/client/src/state.ts
+++ b/javascript/packages/client/src/state.ts
@@ -493,7 +493,7 @@ export class SlotState {
 
       this.#writeConditionals(manifest, resolved, names)
       this.#writePresence(manifest, resolved, names)
-    })
+    }, { retain: false })
 
     for (const [name, value] of Object.entries(values)) {
       this.#announceState(resolved, name, value, previous.get(name) ?? null)

--- a/javascript/packages/client/test/revert.test.ts
+++ b/javascript/packages/client/test/revert.test.ts
@@ -13,6 +13,8 @@ const PAGE =
   `<!--/herb-slot:0--></ul>` +
   `<div><!--herb-slot:4:conditional--><!--herb-branch:4:1--><i>shown</i><!--/herb-slot:4--></div>` +
   `<section data-herb-slot="5:element">original</section>` +
+  `<div id="cond"><!--herb-slot:6:conditional--><!--herb-branch:6:1--><p data-herb-slot="7:child">typed</p><!--/herb-slot:6--></div>` +
+  `<template data-herb-statics="6:0"><!--herb-branch:6:0--><em>off</em></template>` +
   `<template data-herb-statics="4:0"><!--herb-branch:4:0--><em>hidden</em></template>` +
   `<!--/herb-region:${FILE}-->`
 
@@ -39,6 +41,18 @@ describe("transaction and revert", () => {
 
     expect(document.querySelector("div i")?.textContent).toBe("shown")
     expect(index.slot(FILE, 4)!.branch).toBe(1)
+  })
+
+  test("reverting a branch switch restores the branch's dynamic values", () => {
+    const slot = index.slot(FILE, 6)!
+
+    const { token } = index.transaction(() => index.switchBranch(slot, 0))
+
+    expect(document.querySelector("#cond em")?.textContent).toBe("off")
+
+    index.revert(token!)
+
+    expect(document.querySelector("#cond p")?.textContent).toBe("typed")
   })
 
   test("reverts an element slot update through the rescanned parent", () => {

--- a/javascript/packages/client/test/state-scoped.test.ts
+++ b/javascript/packages/client/test/state-scoped.test.ts
@@ -66,6 +66,14 @@ function boot(markup: string): void {
 beforeEach(() => boot(regionMarkup(0)))
 
 describe("declared state", () => {
+  test("a burst of state writes does not evict held revert tokens", () => {
+    const report = slots.apply({ template: FILE, version: "aaaaaaaa", occurrence: 0, slots: { 1: "9" } })
+
+    for (let step = 0; step < 60; step += 1) state.setState({ attempts: step })
+
+    expect(slots.revert(report.token!)).toBe(true)
+  })
+
   test("a rekeyed item keeps its scoped state", () => {
     const first = document.querySelector("#a")!
     const scope = state.scopeFor(first, "starred")!


### PR DESCRIPTION
Follow up on #2333, which gave `SlotIndex` a reversal journal. Two writes recorded an inverse that did not fully restore what they replaced.

A branch switch recorded the markup it displaced but not the branch it displaced, so reverting put the old HTML back while the slot still believed it was on the new branch. The next resolve then compared against the wrong number and declined to switch, leaving a slot whose markup and `branch` disagreed. The inverse now restores both.

A burst of state writes shared one journal entry, so reverting the last write undid the ones before it too. Each write records against the slot it touched, so a revert undoes exactly the write it belongs to.
