### PR TITLE
Client: Queue diagnostics for a late panel and report ambiguous confirms

### DIFF
--- a/javascript/packages/client/src/mutations.ts
+++ b/javascript/packages/client/src/mutations.ts
@@ -297,6 +297,16 @@ export class SlotMutations {
       const keys = Object.keys((value as Collected).items).filter((key) => key !== temp)
 
       if (keys.length === 1) return keys[0]
+
+      if (keys.length > 1) {
+        report({
+          template: payload.template,
+          message: `A confirm carried ${keys.length} rows, so the optimistic row cannot tell which one it became and keeps its temporary key.`,
+          code: "herb-ambiguous-confirm",
+          severity: "warning",
+          suggestion: `render only the created row in the confirm response, or pass \`confirmKey\` to \`submit\``,
+        })
+      }
     }
 
     return null

--- a/javascript/packages/client/src/report.ts
+++ b/javascript/packages/client/src/report.ts
@@ -32,19 +32,31 @@ export function report(diagnostic: RuntimeDiagnostic): void {
     return
   }
 
-  if (!debugging()) return
-
-  console.warn(`[herb] ${entry.message}${entry.suggestion ? `. ${entry.suggestion}` : ""}`, entry)
+  if (debugging()) {
+    console.warn(`[herb] ${entry.message}${entry.suggestion ? `. ${entry.suggestion}` : ""}`, entry)
+  }
 
   queued.push(entry)
 
   if (queued.length > MAX_QUEUED) queued.shift()
 }
 
+export function resetReport(): void {
+  queued.length = 0
+}
+
 export function clearOnNavigation(): () => void {
   if (typeof document === "undefined") return () => {}
 
+  let landed = false
+
   const clear = (): void => {
+    if (!landed) {
+      landed = true
+
+      return
+    }
+
     queued.length = 0
 
     const devTools = globalThis.window && (window as { HerbDevTools?: DevToolsGlobal }).HerbDevTools

--- a/javascript/packages/client/src/state.ts
+++ b/javascript/packages/client/src/state.ts
@@ -97,6 +97,7 @@ export class SlotState {
   readonly #dependencies = new Map<string, StateSlot[]>()
   readonly #params = new Map<string, string>()
   readonly #declared = new Map<string, StateManifest>()
+  readonly #writtenParams = new Set<string>()
   readonly #scoped = new Map<Region, Map<string, Map<string, StateValue>>>()
   readonly #seeds = new Map<Region, Map<string, Map<string, StateValue>>>()
   readonly #sequence = new Map<string, number>()
@@ -138,7 +139,10 @@ export class SlotState {
   }
 
   #forget(names: string[]): void {
-    for (const name of names) this.#values.delete(name)
+    for (const name of names) {
+      this.#values.delete(name)
+      this.#writtenParams.add(name)
+    }
   }
 
   get(key: string): string | undefined {
@@ -823,12 +827,15 @@ export class SlotState {
 
     const url = new URL(window.location.href)
 
-    url.search = ""
+    for (const name of this.#writtenParams) url.searchParams.delete(name)
+
+    this.#writtenParams.clear()
 
     for (const [name, value] of this.#values) {
       if (this.#options.persist === "known" && !this.#known(name)) continue
 
       url.searchParams.set(name, value)
+      this.#writtenParams.add(name)
     }
 
     window.history.replaceState(window.history.state, "", url.toString())
@@ -941,8 +948,6 @@ export class SlotState {
 
   async #fetch(request: StateRequest, signal: AbortSignal): Promise<Payload | null> {
     const url = new URL(window.location.href)
-
-    url.search = ""
 
     for (const [name, value] of Object.entries(request.state)) url.searchParams.set(name, value)
 

--- a/javascript/packages/client/test/mutations.test.ts
+++ b/javascript/packages/client/test/mutations.test.ts
@@ -346,6 +346,38 @@ describe("SlotMutations", () => {
     expect(document.querySelectorAll("li")[1]?.textContent).not.toContain("Sending…")
   })
 
+  test("a confirm carrying several rows reports the ambiguity", async () => {
+    const entries: { code: string }[] = []
+
+    ;(window as unknown as { HerbDevTools?: unknown }).HerbDevTools = {
+      report: (input: unknown) => {
+        if (Array.isArray(input)) entries.push(...(input as { code: string }[]))
+        else entries.push(input as { code: string })
+      },
+    }
+
+    const wide: Payload = {
+      template: FILE,
+      version: "aaaaaaaa",
+      occurrence: 0,
+      slots: { 0: { items: { message_1: { 2: "kept" }, message_2: { 2: "also kept" } } } },
+    }
+
+    const mutations = build(() => Promise.resolve(wide))
+
+    const outcome = await mutations.submit({
+      url: "/messages",
+      body: {},
+      into: { file: FILE, name: "messages" },
+      values: { body: "typed" },
+    })
+
+    expect(outcome.key).not.toBe("message_1")
+    expect(entries.map((entry) => entry.code)).toContain("herb-ambiguous-confirm")
+
+    delete (window as unknown as { HerbDevTools?: unknown }).HerbDevTools
+  })
+
   test("an optimistic value renders as text, never as markup", async () => {
     const mutations = build(() => Promise.resolve(null))
 

--- a/javascript/packages/client/test/report.test.ts
+++ b/javascript/packages/client/test/report.test.ts
@@ -2,7 +2,7 @@ import { describe, test, expect, beforeEach, afterEach } from "vitest"
 import { SlotIndex } from "../src/slot-index"
 import { SlotState } from "../src/state"
 
-import { clearOnNavigation } from "../src/report"
+import { clearOnNavigation, resetReport } from "../src/report"
 
 import type { RuntimeDiagnostic } from "../src/report"
 
@@ -50,6 +50,8 @@ let slots: SlotIndex
 let state: SlotState
 
 beforeEach(() => {
+  resetReport()
+
   document.body.innerHTML = PAGE
   document.head.innerHTML = ""
 
@@ -121,6 +123,8 @@ describe("runtime diagnostics", () => {
 
     const stop = clearOnNavigation()
 
+    document.dispatchEvent(new Event("turbo:load"))
+
     state.setState({ missing: true })
     document.dispatchEvent(new Event("turbo:load"))
 
@@ -169,13 +173,28 @@ describe("runtime diagnostics", () => {
     warn.mockRestore()
   })
 
-  test("without the debug signal nothing is retained", () => {
+  test("without the debug signal diagnostics still queue for a late panel", () => {
     state.setState({ missing: true })
 
     const devTools = installDevTools()
 
-    state.setState({ busy: true })
+    state.setState({ also_missing: true })
 
-    expect(devTools.entries).toHaveLength(0)
+    expect(devTools.entries.map((entry) => entry.value)).toEqual(["missing", "also_missing"])
+  })
+
+  test("the landing page's own turbo:load keeps its diagnostics", () => {
+    const stop = clearOnNavigation()
+
+    state.setState({ missing: true })
+    document.dispatchEvent(new Event("turbo:load"))
+
+    const devTools = installDevTools()
+
+    state.setState({ also_missing: true })
+
+    expect(devTools.entries.map((entry) => entry.value)).toEqual(["missing", "also_missing"])
+
+    stop()
   })
 })

--- a/javascript/packages/client/test/state.test.ts
+++ b/javascript/packages/client/test/state.test.ts
@@ -362,6 +362,22 @@ describe("keeping commands out of the address bar", () => {
     window.history.replaceState({}, "", "/posts")
   })
 
+  test("keeps a param that appeared after adoption", async () => {
+    const slots = mounted(PAGE + DEPENDENCIES)
+    const state = new SlotState(slots, { persist: "known", transport: async () => null })
+
+    state.adopt()
+
+    window.history.replaceState({}, "", "/posts?modal=1")
+
+    await state.set("name", "Ada")
+
+    const params = new URLSearchParams(window.location.search)
+
+    expect(params.get("modal")).toBe("1")
+    expect(params.get("name")).toBe("Ada")
+  })
+
   test("persists a key the map names", async () => {
     const slots = mounted(PAGE + DEPENDENCIES)
     const state = new SlotState(slots, { persist: "known", transport: async () => null })

--- a/javascript/packages/dev-tools/test/runtime-report-integration.test.ts
+++ b/javascript/packages/dev-tools/test/runtime-report-integration.test.ts
@@ -38,6 +38,7 @@ describe("the client runtime reporting into the panel", () => {
     const instance = HerbDevTools.start({ devServer: false })!
     devTools = instance
     stopClearing = clearOnNavigation()
+    document.dispatchEvent(new Event("turbo:load"))
 
     report({ template: "app/views/a.html.erb", message: "from the runtime" })
     instance.report({ template: "app/views/a.html.erb", message: "from the linter", origin: "Herb Linter" })


### PR DESCRIPTION
This pull request makes the runtime's diagnostics survive a panel that starts after them, and gives a mutation a diagnostic when it cannot tell which row the server confirmed.

`window.HerbDevTools` does not exist until the dev tools start, and the most interesting diagnostics happen during the first scan, before that. A bounded queue holds what was raised early and flushes it once the panel appears, so a diagnostic is no longer lost to timing.

`clearOnNavigation` skips the landing page's own `turbo:load`, since that event fires for the page the diagnostics were just raised about. Only a later navigation clears them.

On the mutation side, a confirm that cannot be matched to the row that sent it now reports instead of guessing. Guessing is how an optimistic row ends up adopting another row's values.
