### PR TITLE
Engine: Refuse two named elements claiming one slot

### DIFF
--- a/javascript/packages/linter/docs/rules/herb-valid-slot-names.md
+++ b/javascript/packages/linter/docs/rules/herb-valid-slot-names.md
@@ -35,6 +35,8 @@ The engine raises each of these as a compile error when the template renders. Th
 <p data-herb-name="body"><%= @outro %></p>
 
 <p data-herb-name="body">just static text</p>
+
+<div data-herb-name="row"><span data-herb-name="body"><%= message.body %></span></div>
 ```
 
 ## References

--- a/javascript/packages/linter/src/rules/herb-valid-slot-names.ts
+++ b/javascript/packages/linter/src/rules/herb-valid-slot-names.ts
@@ -119,10 +119,56 @@ class ValidSlotNamesVisitor extends BaseRuleVisitor {
         continue
       }
 
+      const outer = this.named.find((candidate) =>
+        candidate !== named && containsElement(candidate.element, named.element) && !containsERBOutside(candidate.element, named.element),
+      )
+
+      if (outer) {
+        this.addOffense(
+          `\`${NAME_ATTRIBUTE}="${named.name}"\` claims the slot already named \`${outer.name}\`. Keep one name or wrap what each should address, since both elements hold the same slot.`,
+          named.attribute.location,
+        )
+
+        continue
+      }
+
       names.add(named.name)
       taken.set(named.scope, names)
     }
   }
+}
+
+function containsElement(outer: HTMLElementNode, inner: HTMLElementNode): boolean {
+  if (outer === inner) return false
+
+  return outer.body.some((child) => containsElementNode(child, inner))
+}
+
+function containsElementNode(node: Node, inner: HTMLElementNode): boolean {
+  if (node === (inner as unknown as Node)) return true
+  if (typeof node.type !== "string") return false
+
+  return childrenOf(node).some((child) => containsElementNode(child, inner))
+}
+
+function containsERBOutside(node: Node, excluded: HTMLElementNode): boolean {
+  if (node === (excluded as unknown as Node)) return false
+  if (typeof node.type !== "string") return false
+  if (node.type.startsWith("AST_ERB_")) return true
+
+  return childrenOf(node).some((child) => containsERBOutside(child, excluded))
+}
+
+function childrenOf(node: Node): Node[] {
+  const parts = node as unknown as { body?: Node[], children?: Node[], open_tag?: Node | null, value?: Node | null, statements?: Node[] }
+
+  return [
+    ...(parts.body ?? []),
+    ...(parts.children ?? []),
+    ...(parts.statements ?? []),
+    ...(parts.open_tag ? [parts.open_tag] : []),
+    ...(parts.value ? [parts.value] : []),
+  ] as Node[]
 }
 
 function containsDynamicContent(element: HTMLElementNode): boolean {

--- a/javascript/packages/linter/test/rules/herb-valid-slot-names.test.ts
+++ b/javascript/packages/linter/test/rules/herb-valid-slot-names.test.ts
@@ -6,6 +6,20 @@ import { createLinterTest } from "../helpers/linter-test-helper.js"
 const { expectNoOffenses, expectError, assertOffenses } = createLinterTest(HerbValidSlotNamesRule)
 
 describe("HerbValidSlotNamesRule", () => {
+  test("flags a named element claiming the slot another one names", () => {
+    expectError('`data-herb-name="inner"` claims the slot already named `outer`. Keep one name or wrap what each should address, since both elements hold the same slot.')
+
+    assertOffenses(dedent`
+      <div data-herb-name="outer"><span data-herb-name="inner"><%= body %></span></div>
+    `)
+  })
+
+  test("allows a named element beside more dynamic content", () => {
+    expectNoOffenses(dedent`
+      <div data-herb-name="outer"><span data-herb-name="inner"><%= body %></span><%= caption %></div>
+    `)
+  })
+
   test("allows a named content slot", () => {
     expectNoOffenses(dedent`
       <p data-herb-name="body"><%= message.body %></p>

--- a/lib/herb/engine/slot_visitor.rb
+++ b/lib/herb/engine/slot_visitor.rb
@@ -1015,6 +1015,12 @@ module Herb
                 "two slots in the same scope are both named `#{name}`; a slot name is an address, so it has to be unique"
         end
 
+        if (existing = @slots[index].name)
+          raise Herb::Engine::CompilationError,
+                "`#{NAME_ATTRIBUTE}=\"#{name}\"` claims the slot already named `#{existing}`; " \
+                "both elements hold the same slot, so keep one name or wrap what each should address"
+        end
+
         if attribute_conflict?(name, index, named[:scope])
           raise Herb::Engine::CompilationError,
                 "the name `#{name}` collides with the `#{name}` attribute slot in the same scope; " \

--- a/test/engine/slots/names_test.rb
+++ b/test/engine/slots/names_test.rb
@@ -119,6 +119,14 @@ module Engine
         assert_equal :child, named.type
       end
 
+      test "two named elements cannot claim one slot" do
+        error = assert_raises(Herb::Engine::CompilationError) do
+          compile(%(<div data-herb-name="outer"><span data-herb-name="inner"><%= @x %></span></div>))
+        end
+
+        assert_match(/claims the slot already named/, error.message)
+      end
+
       test "a nested container's slots do not confuse the count" do
         template = %(<div data-herb-name="status"><% if @ok %><b><%= @yes %></b><% else %><%= @no %><% end %></div>)
         named = slots(template).find { |slot| slot.name == "status" }


### PR DESCRIPTION
Follow up on #2330, which let a template name a slot with `data-herb-name`.

A name binds to the single slot its element holds, so two named elements resolving to the same slot is ambiguous. The engine accepted it and silently kept one:

```erb
<div data-herb-name="wrapper">
  <p data-herb-name="body"><%= message.body %></p>
</div>
```

Both names claim the one child slot, and which one the client could address depended on visit order. That is now a compile error naming both elements, alongside a linter rule that reports it in the editor before a render runs.
