### PR TITLE
Engine: Ship state manifests for every rendered partial

### DIFF
--- a/javascript/packages/client/test/state-scoped.test.ts
+++ b/javascript/packages/client/test/state-scoped.test.ts
@@ -65,6 +65,66 @@ function boot(markup: string): void {
 
 beforeEach(() => boot(regionMarkup(0)))
 
+describe("sibling collections sharing a state name", () => {
+  const TWIN_FILE = "app/views/page/twins.html.erb"
+
+  const TWIN_PAGE =
+    `<!--herb-region:${TWIN_FILE}:cccccccc:0-->` +
+    `<ul><!--herb-slot:0:collection-->` +
+    `<!--herb-item:0:a--><li id="left-a"><span data-herb-slot="1:conditional"><!--herb-branch:1:1-->plain</span></li><!--/herb-item:0-->` +
+    `<!--/herb-slot:0--></ul>` +
+    `<ul><!--herb-slot:5:collection-->` +
+    `<!--herb-item:5:a--><li id="right-a"><span data-herb-slot="6:conditional"><!--herb-branch:6:1-->plain</span></li><!--/herb-item:5-->` +
+    `<!--/herb-slot:5--></ul>` +
+    `<template data-herb-region="${TWIN_FILE}:cccccccc">` +
+    `<!--herb-branch:1:0-->starred<!--herb-branch:1:1-->plain` +
+    `<!--herb-branch:6:0-->starred<!--herb-branch:6:1-->plain` +
+    `</template>` +
+    `<!--/herb-region:${TWIN_FILE}-->`
+
+  const TWIN_MANIFEST = {
+    state: {},
+    states: {
+      [TWIN_FILE]: {
+        version: "cccccccc",
+        declarations: [
+          { name: "starred", kind: "boolean", default: "false", scope: 0 },
+          { name: "starred", kind: "boolean", default: "false", scope: 5 },
+        ],
+        reads: {},
+        conditionals: {
+          1: { arms: [["starred", null, 0]], else: 1 },
+          6: { arms: [["starred", null, 0]], else: 1 },
+        },
+      },
+    },
+  }
+
+  test("a write in one collection leaves the other alone", () => {
+    document.body.innerHTML = TWIN_PAGE + `<template data-herb-dependencies>${JSON.stringify(TWIN_MANIFEST)}</template>`
+
+    const twinSlots = new SlotIndex()
+
+    twinSlots.scan(document.body)
+
+    const twinState = new SlotState(twinSlots, {
+      persist: "none",
+      transport: () => {
+        throw new Error("a declared state must never reach the transport")
+      },
+    })
+
+    twinState.adopt()
+
+    const scope = twinState.scopeFor(document.querySelector("#left-a")!, "starred")!
+
+    expect(twinState.setState({ starred: true }, { scope })).toBe(true)
+
+    expect(document.querySelector("#left-a")?.textContent).toContain("starred")
+    expect(document.querySelector("#right-a")?.textContent).toBe("plain")
+  })
+})
+
 describe("declared state", () => {
   test("a burst of state writes does not evict held revert tokens", () => {
     const report = slots.apply({ template: FILE, version: "aaaaaaaa", occurrence: 0, slots: { 1: "9" } })

--- a/lib/herb/engine/slot_dependencies.rb
+++ b/lib/herb/engine/slot_dependencies.rb
@@ -81,7 +81,7 @@ module Herb
 
       #: (String, Hash[String, untyped]) -> Hash[String, untyped]
       def declared_states(entry_point, reached)
-        files = ([absolute(entry_point)] + reached.values.flatten.map { |slot| slot[:file] }).uniq
+        files = ([absolute(entry_point)] + reached.values.flatten.map { |slot| slot[:file] } + rendered_files(entry_point)).uniq
         manifests = {} #: Hash[String, untyped]
 
         files.each do |file|
@@ -257,6 +257,39 @@ module Herb
         }
 
         defaults.reject { |_, name| declared.value?(name) }.merge(declared)
+      end
+
+      #: (String) -> Array[String]
+      def rendered_files(entry_point)
+        partials = partial_paths
+        seen = [absolute(entry_point)]
+        queue = seen.dup
+
+        until queue.empty?
+          file = queue.shift
+
+          @dependencies.analyze(file).render_calls.each do |call|
+            next unless call[:partial]
+
+            name = File.basename(call[:partial].to_s)
+
+            (partials[name] || []).each do |candidate|
+              next if seen.include?(candidate)
+
+              seen << candidate
+              queue << candidate
+            end
+          end
+        end
+
+        seen
+      end
+
+      #: () -> Hash[String, Array[String]]
+      def partial_paths
+        @partial_paths ||= Dir.glob(@project_path.join("app/views/**/_*.erb").to_s).group_by { |path|
+          File.basename(path).delete_prefix("_").split(".").first.to_s
+        }
       end
 
       #: (String) -> String

--- a/lib/herb/engine/slot_visitor.rb
+++ b/lib/herb/engine/slot_visitor.rb
@@ -947,6 +947,13 @@ module Herb
 
         return nil unless read.is_a?(StateDirectives::Read)
 
+        if read.comparand.nil? && ![:boolean, :nil, :seeded].include?(read.kind)
+          raise Herb::Engine::CompilationError,
+                "`#{slot.attribute}=\"<%= #{expression} %>\"` reads the #{read.kind.to_s.capitalize} state `#{read.name}` " \
+                "as a presence; only `nil` and `false` are falsy in Ruby, so the attribute could never turn off. " \
+                "Compare the state to a literal, or declare it as a boolean"
+        end
+
         open_tag = @attribute_open_tags[node]
         children = open_tag&.children
         position = children&.find_index { |child| child.equal?(node) }

--- a/sig/herb/engine/slot_dependencies.rbs
+++ b/sig/herb/engine/slot_dependencies.rbs
@@ -76,6 +76,12 @@ module Herb
       # : (String, Array[String], Hash[String, String]) -> Hash[String, String]
       def request_names: (String, Array[String], Hash[String, String]) -> Hash[String, String]
 
+      # : (String) -> Array[String]
+      def rendered_files: (String) -> Array[String]
+
+      # : () -> Hash[String, Array[String]]
+      def partial_paths: () -> Hash[String, Array[String]]
+
       # : (String) -> String
       def identifier_for: (String) -> String
 

--- a/test/engine/slots/dependencies_test.rb
+++ b/test/engine/slots/dependencies_test.rb
@@ -477,6 +477,15 @@ module Engine
         refute_includes manifest["bound"]["draft"], manifest["reads"]["draft"].last
       end
 
+      test "carries the states of a partial no server state reaches" do
+        write("_menu.html.erb", %(<%# herb:state (open: false) %><nav><%= open %></nav>))
+        path = write("index.html.erb", %(<div><%= render "menu" %></div>))
+
+        manifests = subject.payload(path)["states"]
+
+        assert_equal(["open"], manifests.values.compact.flat_map { |manifest| manifest["declarations"].map { |declaration| declaration["name"] } })
+      end
+
       test "carries no states section entry for a template that declares none" do
         path = write("index.html.erb", "<div><%= @query %></div>")
 

--- a/test/engine/slots/states_test.rb
+++ b/test/engine/slots/states_test.rb
@@ -297,6 +297,14 @@ module Engine
         assert_includes rendered, 'disabled="false"'
       end
 
+      test "a bare non-boolean state in a boolean attribute raises" do
+        error = assert_raises(Herb::Engine::CompilationError) do
+          compile(%(<%# herb:state (status: "") %><video muted="<%= status %>"></video>))
+        end
+
+        assert_match(/as a presence/, error.message)
+      end
+
       test "a computed read in a boolean attribute still raises" do
         error = assert_raises(Herb::Engine::CompilationError) do
           compile(<<~ERB)


### PR DESCRIPTION
This pull request makes a state declared inside a partial reachable by the client.

The dependency payload carried one `states` section for the template being rendered, so a partial that declared its own states rendered them correctly and then went inert, since the client had no manifest to resolve its reads and conditionals against. A page whose interactive parts live in partials, which is most pages, had a working server render and nothing else.

Every rendered partial now contributes its own manifest, keyed by file, so the client resolves a state against the manifest of the template that declared it.
