### PR TITLE
Engine: Fan out a state read in an interpolated attribute

### DIFF
--- a/javascript/packages/client/test/state-scoped.test.ts
+++ b/javascript/packages/client/test/state-scoped.test.ts
@@ -65,6 +65,53 @@ function boot(markup: string): void {
 
 beforeEach(() => boot(regionMarkup(0)))
 
+describe("a state read in an interpolated attribute", () => {
+  const ROW_FILE = "app/views/page/rows.html.erb"
+
+  const ROW_PAGE =
+    `<!--herb-region:${ROW_FILE}:dddddddd:0-->` +
+    `<div class="row-" data-herb-slot="0:attribute_interpolation:class">x</div>` +
+    `<template data-herb-region="${ROW_FILE}:dddddddd">` +
+    `<!--herb-branch:0:parts-->row-<!--herb-part-->` +
+    `</template>` +
+    `<!--/herb-region:${ROW_FILE}-->`
+
+  const ROW_MANIFEST = {
+    state: {},
+    states: {
+      [ROW_FILE]: {
+        version: "dddddddd",
+        declarations: [{ name: "status", kind: "string", default: '""', scope: "region" }],
+        reads: { status: [0] },
+        conditionals: {},
+      },
+    },
+  }
+
+  test("a state write rebuilds the whole attribute from its parts", () => {
+    document.body.innerHTML = ROW_PAGE + `<template data-herb-dependencies>${JSON.stringify(ROW_MANIFEST)}</template>`
+
+    const rowSlots = new SlotIndex()
+
+    rowSlots.scan(document.body)
+
+    const rowState = new SlotState(rowSlots, {
+      persist: "none",
+      transport: () => {
+        throw new Error("a declared state must never reach the transport")
+      },
+    })
+
+    rowState.adopt()
+
+    expect(rowState.setState({ status: "busy" })).toBe(true)
+    expect(document.querySelector("div")?.className).toBe("row-busy")
+
+    expect(rowState.setState({ status: "" })).toBe(true)
+    expect(document.querySelector("div")?.className).toBe("row-")
+  })
+})
+
 describe("sibling collections sharing a state name", () => {
   const TWIN_FILE = "app/views/page/twins.html.erb"
 

--- a/lib/herb/engine/slot_dependencies.rb
+++ b/lib/herb/engine/slot_dependencies.rb
@@ -159,7 +159,7 @@ module Herb
         bound = {} #: Hash[String, Array[Integer]]
 
         visitor.slots.each do |slot|
-          next unless [:child, :attribute, :element, :raw_text].include?(slot.type)
+          next unless [:child, :attribute, :attribute_interpolation, :element, :raw_text].include?(slot.type)
 
           expression = slot.expression.to_s.strip
           name = expression.delete_suffix("?")
@@ -195,6 +195,7 @@ module Herb
       #: (untyped) -> bool
       def bound_slot?(slot)
         return false unless slot.respond_to?(:tag)
+        return false if slot.type == :attribute_interpolation
 
         tag = slot.tag.to_s
 

--- a/lib/herb/engine/slot_visitor.rb
+++ b/lib/herb/engine/slot_visitor.rb
@@ -894,7 +894,8 @@ module Herb
         return unless read
 
         raise Herb::Engine::CompilationError,
-              "`#{read}` reads a state inside an interpolated attribute; a state write cannot rebuild the mixed value, so give the state its own attribute or compute the whole value in one output tag"
+              "`#{read}` reads a state inside an interpolated attribute that mixes other dynamic parts; a state " \
+              "write cannot supply the other values, so give the state its own attribute or its own output"
       end
 
       #: () -> void
@@ -913,7 +914,7 @@ module Herb
 
           next if states.empty?
 
-          if slot.type == :attribute_interpolation
+          if slot.type == :attribute_interpolation && slot.expression.to_s.strip.empty?
             check_interpolated_state_read(node, states)
             next
           end
@@ -1215,13 +1216,14 @@ module Herb
       def attribute_expression_for(node)
         children = node.value&.children || []
 
-        return nil unless children.one?
+        return nil unless children.all? { |child| child.is_a?(Herb::AST::LiteralNode) || child.is_a?(Herb::AST::ERBContentNode) }
 
-        child = children.first
+        outputs = children.grep(Herb::AST::ERBContentNode)
 
-        return nil unless child.is_a?(Herb::AST::ERBContentNode)
+        return nil unless outputs.one?
+        return nil unless erb_output?(outputs.fetch(0).tag_opening&.value.to_s)
 
-        child.content&.value&.strip
+        outputs.fetch(0).content&.value&.strip
       end
 
       def location_for(node)

--- a/test/engine/slots/dependencies_test.rb
+++ b/test/engine/slots/dependencies_test.rb
@@ -477,6 +477,15 @@ module Engine
         refute_includes manifest["bound"]["draft"], manifest["reads"]["draft"].last
       end
 
+      test "counts a state read in an interpolated attribute" do
+        path = write("index.html.erb", %(<%# herb:state (status: "") %><div class="row-<%= status %>">x</div>))
+
+        manifest = subject.payload(path)["states"].values.first
+
+        assert_equal [0], manifest["reads"]["status"]
+        assert_empty manifest["bound"]
+      end
+
       test "carries the states of a partial no server state reaches" do
         write("_menu.html.erb", %(<%# herb:state (open: false) %><nav><%= open %></nav>))
         path = write("index.html.erb", %(<div><%= render "menu" %></div>))

--- a/test/engine/slots/states_test.rb
+++ b/test/engine/slots/states_test.rb
@@ -221,12 +221,24 @@ module Engine
         assert_includes rendered, "<span"
       end
 
-      test "a state read inside an interpolated attribute is refused" do
+      test "a state read compiles as an interpolated attribute's only output" do
+        rendered = render(%(<%# herb:state (status: "") %><div class="row-<%= status %>">x</div>))
+
+        assert_includes rendered, 'class="row-"'
+      end
+
+      test "a predicate read in an interpolated attribute rewrites for the server" do
+        rendered = render(%(<%# herb:state (pending: false) %><div class="row-<%= pending? %>">x</div>))
+
+        assert_includes rendered, 'class="row-false"'
+      end
+
+      test "a state mixed with other dynamics in an interpolated attribute is refused" do
         error = assert_raises(Herb::Engine::CompilationError) do
-          compile(%(<%# herb:state (status: "") %><div class="row-<%= status %>">x</div>))
+          compile(%(<%# herb:state (status: "") %><div class="row-<%= status %>-<%= @kind %>">x</div>))
         end
 
-        assert_match(/interpolated attribute/, error.message)
+        assert_match(/mixes other dynamic parts/, error.message)
       end
 
       test "a negated state read in a conditional is refused" do

--- a/test/snapshots/engine/slots/visitor_test/test_0028_distinguishes_an_interpolated_attribute_value_from_a_whole_one_837fe9b56534d0c379f6504e5444e1a2-4c591885d0bd22e1b3fcfc215038ec41.txt
+++ b/test/snapshots/engine/slots/visitor_test/test_0028_distinguishes_an_interpolated_attribute_value_from_a_whole_one_837fe9b56534d0c379f6504e5444e1a2-4c591885d0bd22e1b3fcfc215038ec41.txt
@@ -7,4 +7,4 @@ file: app/views/test.html.erb
 version: 0861a400
 
 slots:
-  index=0  type=attribute_interpolation  node_path=[0]  location=1:5  attribute="class"
+  index=0  type=attribute_interpolation  node_path=[0]  expression="@c"  location=1:5  attribute="class"

--- a/test/snapshots/engine/slots/visitor_test/test_0040_reads_a_key_from_an_attribute_that_surrounds_its_expression_with_text_9503ca3f147db59b3ebcc6705b8e4db0-4c591885d0bd22e1b3fcfc215038ec41.txt
+++ b/test/snapshots/engine/slots/visitor_test/test_0040_reads_a_key_from_an_attribute_that_surrounds_its_expression_with_text_9503ca3f147db59b3ebcc6705b8e4db0-4c591885d0bd22e1b3fcfc215038ec41.txt
@@ -8,4 +8,4 @@ version: e7649cfc
 
 slots:
   index=0  type=collection  node_path=[0]  expression="@u.each do |u|"  location=1:0  key_source=id  key_expression="\"user-\#{u.id}\""
-  index=1  type=attribute_interpolation  node_path=[0, 0]  location=1:24  attribute="id"
+  index=1  type=attribute_interpolation  node_path=[0, 0]  expression="u.id"  location=1:24  attribute="id"

--- a/test/snapshots/engine/slots/visitor_test/test_0042_reads_an_interpolated_herb-key_c4258dd4f5c12055efecb62ca9facb1d-4c591885d0bd22e1b3fcfc215038ec41.txt
+++ b/test/snapshots/engine/slots/visitor_test/test_0042_reads_an_interpolated_herb-key_c4258dd4f5c12055efecb62ca9facb1d-4c591885d0bd22e1b3fcfc215038ec41.txt
@@ -8,4 +8,4 @@ version: 3e1464a0
 
 slots:
   index=0  type=collection  node_path=[0]  expression="@u.each do |u|"  location=1:0  key_source=herb_key  key_expression="\"item-\#{u.id}\""
-  index=1  type=attribute_interpolation  node_path=[0, 0]  location=1:24  attribute="herb-key"
+  index=1  type=attribute_interpolation  node_path=[0, 0]  expression="u.id"  location=1:24  attribute="herb-key"

--- a/test/snapshots/engine/slots/visitor_test/test_0043_keeps_a_literal_key_part_from_being_read_as_Ruby_b0564df02030152ba5346bbd87545397-4c591885d0bd22e1b3fcfc215038ec41.txt
+++ b/test/snapshots/engine/slots/visitor_test/test_0043_keeps_a_literal_key_part_from_being_read_as_Ruby_b0564df02030152ba5346bbd87545397-4c591885d0bd22e1b3fcfc215038ec41.txt
@@ -8,4 +8,4 @@ version: e7649cfc
 
 slots:
   index=0  type=collection  node_path=[0]  expression="@u.each do |u|"  location=1:0  key_source=id  key_expression="\"a\\\\b\\\#{c}-\#{u.id}\""
-  index=1  type=attribute_interpolation  node_path=[0, 0]  location=1:24  attribute="id"
+  index=1  type=attribute_interpolation  node_path=[0, 0]  expression="u.id"  location=1:24  attribute="id"


### PR DESCRIPTION
Follow up on #2348, which reconstructs an interpolated attribute from its parked parts.

An attribute that interpolates a state compiled to a slot, but the state's reads manifest never recorded it, so writing the state did not reach it:

```erb
<%# herb:state (status: "idle") %>

<div class="row row-<%= status %>">…</div>
```

The read is registered now, so `state.set({ status: "busy" })` rebuilds the attribute from its parts and the class follows. This is the shape most per-row styling takes, so it was a large gap between what compiles and what changes on screen.
