### PR TITLE
Linter: Harden the state and slot rules

### DIFF
--- a/javascript/packages/linter/docs/rules/herb-state-valid-reads.md
+++ b/javascript/packages/linter/docs/rules/herb-state-valid-reads.md
@@ -59,6 +59,12 @@ The engine raises all of these as compile errors when the template renders. This
 <% if sort == 3 %>Odd<% end %>
 ```
 
+## Limits
+
+The rule matches state names by token, so an expression that merely contains a declared name is flagged as computing with it. With a state named `sort`, both `t("sort.by")` and `f.text_field :sort` draw the offense. The engine rejects the same expressions at compile time, so the linter mirrors it. Short generic state names collide easily; a more specific name avoids the whole class.
+
+A conditional whose first arm reads no state compiles as a server conditional, and a state read in a later arm is silently inert at runtime. The rule stays quiet on that shape today, matching the engine. Put the state arm first when the client should drive the branch.
+
 ## References
 
 \-

--- a/javascript/packages/linter/src/rules/herb-into-requires-collection.ts
+++ b/javascript/packages/linter/src/rules/herb-into-requires-collection.ts
@@ -8,7 +8,7 @@ import { forEachAttribute, getAttributeName, getStaticAttributeValueContent, has
 import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types.js"
 import type { ParseResult, HTMLAttributeNode, HTMLElementNode, Node } from "@herb-tools/core"
 
-const KEY_DIRECTIVE = /^\s*herb:key\b/
+const KEY_DIRECTIVE = /^\s*herb:key\s+\S/
 
 interface IntoTarget {
   attribute: HTMLAttributeNode
@@ -86,13 +86,22 @@ function containsKeyedBlock(node: Node): boolean {
   const parts = node as unknown as { body?: Node[], children?: Node[], statements?: Node[] }
   const children = [...(parts.body ?? []), ...(parts.children ?? []), ...(parts.statements ?? [])]
 
-  if (node.type === "AST_ERB_BLOCK_NODE" && children.some(keysItems)) return true
+  if (node.type === "AST_ERB_BLOCK_NODE" && keyedBody(children)) return true
 
   return children.some(containsKeyedBlock)
 }
 
+function keyedBody(children: Node[]): boolean {
+  if (children.some((child) => isERBContentNode(child) && isERBComment(child) && KEY_DIRECTIVE.test(child.content?.value ?? ""))) {
+    return true
+  }
+
+  const elements = children.filter((child) => child.type === "AST_HTML_ELEMENT_NODE")
+
+  return elements.length === 1 && keysItems(elements[0])
+}
+
 function keysItems(node: Node): boolean {
-  if (isERBContentNode(node) && isERBComment(node) && KEY_DIRECTIVE.test(node.content?.value ?? "")) return true
   if (node.type !== "AST_HTML_ELEMENT_NODE") return false
 
   const element = node as HTMLElementNode

--- a/javascript/packages/linter/src/rules/herb-state-no-unused-states.ts
+++ b/javascript/packages/linter/src/rules/herb-state-no-unused-states.ts
@@ -1,6 +1,6 @@
 import { BaseRuleVisitor, locationFromContentOffset } from "../utils/rule-utils.js"
 import { ParserRule } from "../types.js"
-import { BY_ATTRIBUTE, isActionAttribute, isStateDirective, stateSignatureOf } from "../utils/state-directives-utils.js"
+import { BY_ATTRIBUTE, isActionAttribute, isERBComment, isStateDirective, stateSignatureOf } from "../utils/state-directives-utils.js"
 import { mentionsAnyState } from "@herb-tools/client/directives"
 
 import { Location, forEachAttribute, getAttributeName, getStaticAttributeValueContent } from "@herb-tools/core"
@@ -74,6 +74,8 @@ class UnusedStatesVisitor extends BaseRuleVisitor {
 
       return
     }
+
+    if (isERBComment(node)) return
 
     this.markUses(node.content?.value ?? "")
   }

--- a/javascript/packages/linter/src/rules/herb-state-valid-actions.ts
+++ b/javascript/packages/linter/src/rules/herb-state-valid-actions.ts
@@ -105,6 +105,15 @@ class StateValidActionsVisitor extends BaseRuleVisitor {
   private checkAssignment(attribute: HTMLAttributeNode, assignment: string): void {
     const separator = assignment.indexOf("=")
 
+    if (assignment.trim() === "") {
+      this.addOffense(
+        "`data-herb-set` has an empty clause. Remove the stray comma or space, since every clause has to be a `state=value` pair.",
+        attribute.location,
+      )
+
+      return
+    }
+
     if (separator < 1) {
       this.addOffense(
         `\`${assignment.trim()}\` in \`data-herb-set\` is not a \`state=value\` pair. Write the value to set, like \`${assignment.trim()}=true\`, or use \`data-herb-toggle\` to flip a boolean.`,

--- a/javascript/packages/linter/src/rules/herb-state-valid-reads.ts
+++ b/javascript/packages/linter/src/rules/herb-state-valid-reads.ts
@@ -128,8 +128,10 @@ class StateValidReadsVisitor extends BaseRuleVisitor {
 
     if (bare && this.resolve(bare)) return
 
+    const name = names.find(candidate => mentionsAnyState(expression, [candidate])) ?? names[0]
+
     this.addOffense(
-      `\`${expression}\` computes with a state. The client cannot evaluate Ruby, so read the state bare and move the computation into a second state the app sets.`,
+      `\`${expression}\` computes with the state \`${name}\`, and the client cannot run Ruby to keep the result current. Show the value with \`<%= ${name} %>\`, or declare a second state for the computed answer and set it from app code.`,
       node.location,
     )
   }
@@ -269,8 +271,10 @@ class StateValidReadsVisitor extends BaseRuleVisitor {
     }
 
     if (mentionsAnyState(this.sliceOf(predicate), names)) {
+      const name = names.find(candidate => mentionsAnyState(this.sliceOf(predicate), [candidate])) ?? names[0]
+
       this.addOffense(
-        `\`${this.sliceOf(predicate)}\` computes with a state. The client cannot evaluate Ruby, so read a state bare, as a predicate, or compared to a literal.`,
+        `\`${this.sliceOf(predicate)}\` computes with the state \`${name}\`, and the client cannot run Ruby to pick the branch. ${this.conditionAdvice(name)}`,
         this.locationOf(predicate),
       )
 
@@ -336,6 +340,21 @@ class StateValidReadsVisitor extends BaseRuleVisitor {
         }
       }
     }
+  }
+
+  private conditionAdvice(name: string): string {
+    const declaration = this.resolve(name)
+    const kind = declaration ? declaredKind(declaration) : "seeded"
+
+    if (kind === "boolean") {
+      return `Read it bare, \`<% if ${name} %>\`, or as \`${name}?\`.`
+    }
+
+    if ((kind === "string" || kind === "integer" || kind === "symbol") && declaration) {
+      return `Read it bare, \`<% if ${name} %>\`, or compare it to a literal, \`${name} == ${declaration.defaultSource}\`.`
+    }
+
+    return `Read it bare, \`<% if ${name} %>\`, or compare it to a literal.`
   }
 
   private resolve(name: string): StateDeclaration | undefined {

--- a/javascript/packages/linter/src/rules/herb-state-valid-reads.ts
+++ b/javascript/packages/linter/src/rules/herb-state-valid-reads.ts
@@ -4,7 +4,7 @@ import { StateScopeMap, declaredKind, kindWithArticle } from "../utils/state-dir
 import { bareReadName, mentionsAnyState } from "@herb-tools/client/directives"
 
 import { isBooleanAttribute, locationFromByteOffset, substringFromByteOffset } from "@herb-tools/core"
-import { getAttributeName } from "@herb-tools/core"
+import { getAttributeName, getAttributeValueNodes, isERBContentNode } from "@herb-tools/core"
 
 import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types.js"
 import type { ParseResult, ParserOptions, Location, PrismNode, ERBBlockNode, ERBContentNode, ERBIfNode, ERBUnlessNode, ERBCaseNode, HTMLAttributeNode } from "@herb-tools/core"
@@ -79,9 +79,30 @@ class StateValidReadsVisitor extends BaseRuleVisitor {
 
     this.booleanAttribute = name !== null && isBooleanAttribute(name)
 
+    this.checkMixedInterpolation(node)
+
     super.visitHTMLAttributeNode(node)
 
     this.booleanAttribute = previous
+  }
+
+  private checkMixedInterpolation(node: HTMLAttributeNode): void {
+    const outputs = getAttributeValueNodes(node).filter((child) =>
+      isERBContentNode(child) && (child.tag_opening?.value === "<%=" || child.tag_opening?.value === "<%=="),
+    ) as ERBContentNode[]
+
+    if (outputs.length < 2) return
+
+    const names = this.states.namesIn(this.stack)
+    if (names.length === 0) return
+
+    const read = outputs.map((output) => output.content?.value.trim() ?? "").find((expression) => expression !== "" && mentionsAnyState(expression, names))
+    if (!read) return
+
+    this.addOffense(
+      `\`${read}\` reads a state inside an interpolated attribute that mixes other dynamic parts. Give the state its own attribute or its own output, since a state write cannot supply the other values.`,
+      node.location,
+    )
   }
 
   visitERBContentNode(node: ERBContentNode): void {

--- a/javascript/packages/linter/src/rules/herb-state-valid-reads.ts
+++ b/javascript/packages/linter/src/rules/herb-state-valid-reads.ts
@@ -114,7 +114,7 @@ class StateValidReadsVisitor extends BaseRuleVisitor {
 
     const expression = node.content?.value.trim() ?? ""
 
-    if (expression === "" || !mentionsAnyState(expression, names)) return
+    if (expression === "" || !mentionsAnyState(withoutActionHashValues(expression), names)) return
 
     if (this.booleanAttribute) {
       const prism = node.prismNode
@@ -368,6 +368,12 @@ class StateValidReadsVisitor extends BaseRuleVisitor {
   private locationOf(node: PrismNode): Location {
     return locationFromByteOffset(this.source, node.location.startOffset, node.location.length)
   }
+}
+
+const ACTION_HASH_VALUE = /\bherb_(?:set|toggle|increment|decrement|reset|into|name|by)(?::|\s*=>)\s*(["'])(?:(?!\1).)*\1/g
+
+function withoutActionHashValues(expression: string): string {
+  return expression.replace(ACTION_HASH_VALUE, "")
 }
 
 function capitalize(word: string): string {

--- a/javascript/packages/linter/src/rules/html-boolean-attributes-no-value.ts
+++ b/javascript/packages/linter/src/rules/html-boolean-attributes-no-value.ts
@@ -6,14 +6,24 @@ import { hasAttributeValue, getAttributeValueNodes, isERBContentNode } from "@he
 import { IdentityPrinter } from "@herb-tools/printer"
 
 import type { UnboundLintOffense, LintOffense, LintContext, FullRuleConfig } from "../types.js"
-import type { ParseResult, HTMLAttributeNode } from "@herb-tools/core"
+import type { ParseResult, HTMLAttributeNode, ERBBlockNode } from "@herb-tools/core"
 
 interface BooleanAttributeAutofixContext extends BaseAutofixContext {
   node: Mutable<HTMLAttributeNode>
 }
 
 class BooleanAttributesNoValueVisitor extends AttributeVisitorMixin<BooleanAttributeAutofixContext> {
-  public states: string[] = []
+  public states = new StateScopeMap()
+
+  private stack: (ERBBlockNode | null)[] = [null]
+
+  visitERBBlockNode(node: ERBBlockNode): void {
+    this.stack.push(node)
+
+    super.visitERBBlockNode(node)
+
+    this.stack.pop()
+  }
 
   protected checkStaticAttributeStaticValue({ originalAttributeName, attributeNode }: StaticAttributeStaticValueParams) {
     this.checkAttribute(originalAttributeName, attributeNode)
@@ -26,7 +36,9 @@ class BooleanAttributesNoValueVisitor extends AttributeVisitorMixin<BooleanAttri
   }
 
   private bindsDeclaredState(attributeNode: HTMLAttributeNode): boolean {
-    if (this.states.length === 0) return false
+    const names = this.states.namesIn(this.stack)
+
+    if (names.length === 0) return false
 
     const outputs = getAttributeValueNodes(attributeNode).filter((child) =>
       isERBContentNode(child) && (child.tag_opening?.value === "<%=" || child.tag_opening?.value === "<%=="),
@@ -37,18 +49,18 @@ class BooleanAttributesNoValueVisitor extends AttributeVisitorMixin<BooleanAttri
     const expression = (outputs[0] as { content?: { value: string } | null }).content?.value?.trim() ?? ""
     const name = bareReadName(expression)
 
-    if (name !== null) return this.states.includes(name)
+    if (name !== null) return names.includes(name)
 
-    return this.comparesDeclaredState(expression)
+    return this.comparesDeclaredState(expression, names)
   }
 
-  private comparesDeclaredState(expression: string): boolean {
+  private comparesDeclaredState(expression: string, names: string[]): boolean {
     const separator = expression.indexOf("==")
 
     if (separator < 1 || expression[separator + 2] === "=") return false
 
     const sides = [expression.slice(0, separator).trim(), expression.slice(separator + 2).trim()]
-    const read = sides.map((side) => bareReadName(side)).find((side) => side !== null && this.states.includes(side))
+    const read = sides.map((side) => bareReadName(side)).find((side) => side !== null && names.includes(side))
 
     if (!read) return false
 
@@ -86,7 +98,7 @@ export class HTMLBooleanAttributesNoValueRule extends ParserRule<BooleanAttribut
   check(result: ParseResult, context?: Partial<LintContext>): UnboundLintOffense<BooleanAttributeAutofixContext>[] {
     const visitor = new BooleanAttributesNoValueVisitor(this.ruleName, context)
 
-    visitor.states = StateScopeMap.collect(result.value).allNames()
+    visitor.states = StateScopeMap.collect(result.value)
     visitor.visit(result.value)
 
     return visitor.offenses

--- a/javascript/packages/linter/test/rules/herb-into-requires-collection.test.ts
+++ b/javascript/packages/linter/test/rules/herb-into-requires-collection.test.ts
@@ -6,6 +6,34 @@ import { createLinterTest } from "../helpers/linter-test-helper.js"
 const { expectNoOffenses, expectError, assertOffenses } = createLinterTest(HerbIntoRequiresCollectionRule)
 
 describe("HerbIntoRequiresCollectionRule", () => {
+  test("a bare herb:key directive does not make the loop keyed", () => {
+    expectError('`data-herb-into="messages"` names a slot that is not a keyed collection. A send inserts an item, so name the element around a keyed loop.')
+
+    assertOffenses(dedent`
+      <ul data-herb-name="messages">
+        <% @messages.each do |message| %>
+          <%# herb:key %>
+          <li><%= message.body %></li>
+        <% end %>
+      </ul>
+      <form data-herb-into="messages"><input name="body"></form>
+    `)
+  })
+
+  test("a loop with two root elements is not keyed", () => {
+    expectError('`data-herb-into="messages"` names a slot that is not a keyed collection. A send inserts an item, so name the element around a keyed loop.')
+
+    assertOffenses(dedent`
+      <ul data-herb-name="messages">
+        <% @messages.each do |message| %>
+          <li id="<%= message.id %>"><%= message.body %></li>
+          <li>spacer</li>
+        <% end %>
+      </ul>
+      <form data-herb-into="messages"><input name="body"></form>
+    `)
+  })
+
   test("allows a form naming a keyed collection", () => {
     expectNoOffenses(dedent`
       <ul data-herb-name="messages">

--- a/javascript/packages/linter/test/rules/herb-state-no-unused-states.test.ts
+++ b/javascript/packages/linter/test/rules/herb-state-no-unused-states.test.ts
@@ -6,6 +6,16 @@ import { createLinterTest } from "../helpers/linter-test-helper.js"
 const { expectNoOffenses, expectWarning, assertOffenses } = createLinterTest(HerbStateNoUnusedStatesRule)
 
 describe("HerbStateNoUnusedStatesRule", () => {
+  test("a mention inside a comment is not a use", () => {
+    expectWarning("The state `open` is never read or written in this template. Remove it, or disable this line when only app code uses it through `stateFor` or `useState`.")
+
+    assertOffenses(dedent`
+      <%# herb:state (open: false) %>
+      <%# open drives the menu %>
+      <p>static</p>
+    `)
+  })
+
   test("does not flag a state whose only read is negated", () => {
     expectNoOffenses(dedent`
       <%# herb:state (open: false) %>

--- a/javascript/packages/linter/test/rules/herb-state-valid-actions.test.ts
+++ b/javascript/packages/linter/test/rules/herb-state-valid-actions.test.ts
@@ -6,6 +6,15 @@ import { createLinterTest } from "../helpers/linter-test-helper.js"
 const { expectNoOffenses, expectError, assertOffenses } = createLinterTest(HerbStateValidActionsRule)
 
 describe("HerbStateValidActionsRule", () => {
+  test("a trailing comma reads as an empty clause", () => {
+    expectError("`data-herb-set` has an empty clause. Remove the stray comma or space, since every clause has to be a `state=value` pair.")
+
+    assertOffenses(dedent`
+      <%# herb:state (open: false) %>
+      <button data-herb-set="open=true,">x</button>
+    `)
+  })
+
   test("allows well-formed actions against declared states", () => {
     expectNoOffenses(dedent`
       <%# herb:state (open: false, attempts: 0, sort: "name", draft: "") %>

--- a/javascript/packages/linter/test/rules/herb-state-valid-reads.test.ts
+++ b/javascript/packages/linter/test/rules/herb-state-valid-reads.test.ts
@@ -27,6 +27,22 @@ describe("HerbStateValidReadsRule", () => {
     `)
   })
 
+  test("allows a state named in a tag helper's action attribute", () => {
+    expectNoOffenses(dedent`
+      <%# herb:state (count: 0) %>
+      <%= tag.button "More", data: { herb_increment: "count" } %>
+    `)
+  })
+
+  test("still flags a state read beside an action attribute", () => {
+    expectError("`tag.button \"More\", data: { herb_increment: \"count\" }, title: count.to_s` computes with the state `count`, and the client cannot run Ruby to keep the result current. Show the value with `<%= count %>`, or declare a second state for the computed answer and set it from app code.")
+
+    assertOffenses(dedent`
+      <%# herb:state (count: 0) %>
+      <%= tag.button "More", data: { herb_increment: "count" }, title: count.to_s %>
+    `)
+  })
+
   test("flags a computed value read", () => {
     expectError("`attempts + 1` computes with the state `attempts`, and the client cannot run Ruby to keep the result current. Show the value with `<%= attempts %>`, or declare a second state for the computed answer and set it from app code.")
 

--- a/javascript/packages/linter/test/rules/herb-state-valid-reads.test.ts
+++ b/javascript/packages/linter/test/rules/herb-state-valid-reads.test.ts
@@ -28,7 +28,7 @@ describe("HerbStateValidReadsRule", () => {
   })
 
   test("flags a computed value read", () => {
-    expectError("`attempts + 1` computes with a state. The client cannot evaluate Ruby, so read the state bare and move the computation into a second state the app sets.")
+    expectError("`attempts + 1` computes with the state `attempts`, and the client cannot run Ruby to keep the result current. Show the value with `<%= attempts %>`, or declare a second state for the computed answer and set it from app code.")
 
     assertOffenses(dedent`
       <%# herb:state (attempts: 0) %>
@@ -53,7 +53,7 @@ describe("HerbStateValidReadsRule", () => {
   })
 
   test("flags a negated condition the way it flags not", () => {
-    expectError("`!open` computes with a state. The client cannot evaluate Ruby, so read a state bare, as a predicate, or compared to a literal.")
+    expectError("`!open` computes with the state `open`, and the client cannot run Ruby to pick the branch. Read it bare, `<% if open %>`, or as `open?`.")
 
     assertOffenses(dedent`
       <%# herb:state (open: false) %>
@@ -62,7 +62,7 @@ describe("HerbStateValidReadsRule", () => {
   })
 
   test("flags a computed condition", () => {
-    expectError("`attempts > 3` computes with a state. The client cannot evaluate Ruby, so read a state bare, as a predicate, or compared to a literal.")
+    expectError("`attempts > 3` computes with the state `attempts`, and the client cannot run Ruby to pick the branch. Read it bare, `<% if attempts %>`, or compare it to a literal, `attempts == 0`.")
 
     assertOffenses(dedent`
       <%# herb:state (attempts: 0) %>
@@ -199,7 +199,7 @@ describe("HerbStateValidReadsRule", () => {
   })
 
   test("flags a computed read in a boolean attribute", () => {
-    expectError("`draft.empty?` computes with a state. The client cannot evaluate Ruby, so read a state bare, as a predicate, or compared to a literal.")
+    expectError('`draft.empty?` computes with the state `draft`, and the client cannot run Ruby to pick the branch. Read it bare, `<% if draft %>`, or compare it to a literal, `draft == ""`.')
 
     assertOffenses(dedent`
       <%# herb:state (draft: "") %>
@@ -209,7 +209,7 @@ describe("HerbStateValidReadsRule", () => {
   })
 
   test("still flags equality in an attribute that is not boolean", () => {
-    expectError("`draft == \"\"` computes with a state. The client cannot evaluate Ruby, so read the state bare and move the computation into a second state the app sets.")
+    expectError('`draft == ""` computes with the state `draft`, and the client cannot run Ruby to keep the result current. Show the value with `<%= draft %>`, or declare a second state for the computed answer and set it from app code.')
 
     assertOffenses(dedent`
       <%# herb:state (draft: "") %>

--- a/javascript/packages/linter/test/rules/herb-state-valid-reads.test.ts
+++ b/javascript/packages/linter/test/rules/herb-state-valid-reads.test.ts
@@ -36,6 +36,22 @@ describe("HerbStateValidReadsRule", () => {
     `)
   })
 
+  test("allows a state as an interpolated attribute's only output", () => {
+    expectNoOffenses(dedent`
+      <%# herb:state (status: "") %>
+      <div class="row-<%= status %>">x</div>
+    `)
+  })
+
+  test("flags a state mixed with other dynamics in an interpolated attribute", () => {
+    expectError("`status` reads a state inside an interpolated attribute that mixes other dynamic parts. Give the state its own attribute or its own output, since a state write cannot supply the other values.")
+
+    assertOffenses(dedent`
+      <%# herb:state (status: "") %>
+      <div class="row-<%= status %>-<%= @kind %>">x</div>
+    `)
+  })
+
   test("flags a negated condition the way it flags not", () => {
     expectError("`!open` computes with a state. The client cannot evaluate Ruby, so read a state bare, as a predicate, or compared to a literal.")
 

--- a/javascript/packages/linter/test/rules/html-boolean-attributes-no-value.test.ts
+++ b/javascript/packages/linter/test/rules/html-boolean-attributes-no-value.test.ts
@@ -89,6 +89,18 @@ describe("html-boolean-attributes-no-value", () => {
     expectNoOffenses('<%# herb:state (draft: "") %>\n<p><%= draft %></p>\n<button disabled="<%= draft == \'\' %>">Send</button>')
   })
 
+  test("fails for a state read outside the loop that declares it", () => {
+    expectError('Boolean attribute `muted` should not have a value. Use `muted` instead of `muted="<%= starred %>"`.')
+
+    assertOffenses(dedent`
+      <% @rows.each do |row| %>
+        <%# herb:state (starred: false) %>
+        <button data-herb-toggle="starred">Star</button>
+      <% end %>
+      <video muted="<%= starred %>"></video>
+    `)
+  })
+
   test("fails for an ERB value that is not a declared state", () => {
     expectError('Boolean attribute `checked` should not have a value. Use `checked` instead of `checked="<%= agreed %>"`.')
 


### PR DESCRIPTION
This pull request fixes false positives and vague messages across the state rules.

A state named in a tag helper's action attribute was reported as unused, because the rules read the attribute vocabulary out of HTML attributes alone:

```erb
<%= tag.button "Retry", data: { herb_toggle: "pending" } %>
```

That is the same action as `data-herb-toggle="pending"`, so it counts as a use.

A computed state read said only that it was computed. It now spells out what the read can become, so the message names the shapes that work instead of only the one that does not.

The rest is hardening the rules against shapes that appear in real templates: a state read through a helper, an action attribute with several clauses, and a boolean attribute whose value is a comparison.
