### PR TITLE
Rust: Index `herb:state` declarations like locals

### DIFF
--- a/rust/herb-analysis/src/ruby_locals_index/mod.rs
+++ b/rust/herb-analysis/src/ruby_locals_index/mod.rs
@@ -47,6 +47,7 @@ impl RubyLocalsIndex {
 
     let mut locals = strict_locals(document, &references, &offsets);
     locals.extend(block_locals(document, &references, &offsets));
+    locals.extend(state_locals(document, &references, &offsets));
 
     Self {
       locals,
@@ -203,6 +204,114 @@ fn any_children(node: &AnyNode) -> Vec<&AnyNode> {
     AnyNode::ERBRenderNode(inner) => inner.body.iter().collect(),
     _ => Vec::new(),
   }
+}
+
+fn state_locals(document: &herb::nodes::DocumentNode, references: &ReferenceCollector, offsets: &OffsetTable) -> Vec<Local> {
+  let mut found = Vec::new();
+
+  for child in &document.children {
+    collect_state_locals(child, references, offsets, &mut found);
+  }
+
+  found
+}
+
+fn collect_state_locals(node: &AnyNode, references: &ReferenceCollector, offsets: &OffsetTable, found: &mut Vec<Local>) {
+  if let AnyNode::ERBContentNode(inner) = node {
+    if let Some(signature) = state_signature(inner) {
+      for name in signature_names(&signature) {
+        let predicate = format!("{name}?");
+        let usages = references
+          .bare_calls
+          .iter()
+          .filter(|call| call.name == name || call.name == predicate)
+          .map(|call| offsets.location_for(call))
+          .collect();
+
+        found.push(Local::new(name, inner.location, usages));
+      }
+    }
+  }
+
+  for child in any_children(node) {
+    collect_state_locals(child, references, offsets, found);
+  }
+}
+
+fn state_signature(node: &herb::nodes::ERBContentNode) -> Option<String> {
+  if node.tag_opening.as_ref()?.value != "<%#" {
+    return None;
+  }
+
+  let content = node.content.as_ref()?.value.trim();
+  let content = content.strip_prefix('-').map_or(content, str::trim);
+  let content = content.strip_suffix('-').map_or(content, str::trim);
+  let rest = content.strip_prefix("herb:state")?.trim();
+
+  if rest.starts_with('(') && rest.ends_with(')') {
+    Some(rest.to_string())
+  } else {
+    None
+  }
+}
+
+fn signature_names(signature: &str) -> Vec<String> {
+  let inner = signature.get(1..signature.len().saturating_sub(1)).unwrap_or("");
+  let mut parts: Vec<String> = Vec::new();
+  let mut current = String::new();
+  let mut depth = 0i32;
+  let mut quote: Option<char> = None;
+
+  for character in inner.chars() {
+    match quote {
+      Some(open) => {
+        if character == open {
+          quote = None;
+        }
+
+        current.push(character);
+      }
+      None => match character {
+        '"' | '\'' => {
+          quote = Some(character);
+          current.push(character);
+        }
+        '(' | '[' | '{' => {
+          depth += 1;
+          current.push(character);
+        }
+        ')' | ']' | '}' => {
+          depth -= 1;
+          current.push(character);
+        }
+        ',' if depth == 0 => parts.push(std::mem::take(&mut current)),
+        _ => current.push(character),
+      },
+    }
+  }
+
+  if !current.trim().is_empty() {
+    parts.push(current);
+  }
+
+  parts.iter().filter_map(|part| keyword_name(part)).collect()
+}
+
+fn keyword_name(part: &str) -> Option<String> {
+  let trimmed = part.trim();
+  let name = trimmed[..trimmed.find(':')?].trim();
+  let mut characters = name.chars();
+  let first = characters.next()?;
+
+  if !(first.is_ascii_lowercase() || first == '_') {
+    return None;
+  }
+
+  if !characters.all(|character| character.is_ascii_alphanumeric() || character == '_') {
+    return None;
+  }
+
+  Some(name.to_string())
 }
 
 fn innermost_enclosing<'a>(locations: &'a [Location], inner: &Location) -> Option<&'a Location> {

--- a/rust/herb-analysis/tests/ruby_locals_index_test.rs
+++ b/rust/herb-analysis/tests/ruby_locals_index_test.rs
@@ -133,3 +133,37 @@ fn counts_columns_in_bytes_so_multibyte_content_does_not_shift_a_location() {
   assert_eq!(3, local.usages[0].start.line);
   assert_eq!("title", text_at(source, &local.declaration));
 }
+
+#[test]
+fn indexes_a_state_declaration_like_a_local() {
+  let source = "<%# herb:state (pending: false, attempts: 0) %>\n<p><%= pending? %></p>\n<p><%= attempts %></p>\n";
+  let index = index_for(source);
+
+  assert_eq!(vec![1, 2], lines_of(index.find("pending").expect("pending")));
+  assert_eq!(vec![1, 3], lines_of(index.find("attempts").expect("attempts")));
+}
+
+#[test]
+fn indexes_a_state_declared_inside_a_loop() {
+  let source = "<% @items.each do |item| %>\n  <%# herb:state (locked: true) %>\n  <p><%= locked %></p>\n<% end %>\n";
+  let index = index_for(source);
+
+  assert_eq!(vec![2, 3], lines_of(index.find("locked").expect("locked")));
+}
+
+#[test]
+fn ignores_a_plain_comment_that_is_not_a_state_directive() {
+  let index = index_for("<%# locked drives the row %>\n<p>static</p>\n");
+
+  assert!(index.find("locked").is_none());
+}
+
+#[test]
+fn keeps_a_quoted_comma_inside_one_state_default() {
+  let source = "<%# herb:state (draft: \"a,b\", open: false) %>\n<p><%= draft %></p>\n";
+  let index = index_for(source);
+
+  assert!(index.find("draft").is_some());
+  assert!(index.find("open").is_some());
+  assert!(index.find("b\"").is_none());
+}


### PR DESCRIPTION
This pull request teaches the Rust locals index about `herb:state`, matching what the Ruby and TypeScript indexes already do.

A state compiles to a reader in its scope, so a read of it is a defined name. The index did not know that, and reported every state read as an undefined local. Anything built on the index inherited the false positive.

Declarations are now indexed with their scope, so a state read resolves the same way a strict local does, and an item-scoped state resolves only inside the collection body that declares it.
