### PR TITLE
Language Service: Support herb:state and the data-herb attributes

### DIFF
--- a/javascript/packages/language-server/src/project.ts
+++ b/javascript/packages/language-server/src/project.ts
@@ -74,6 +74,7 @@ export class Project {
       this.index,
       shared.documents,
       shared.readFile,
+      shared.parserService,
     )
   }
 

--- a/javascript/packages/language-server/src/server.ts
+++ b/javascript/packages/language-server/src/server.ts
@@ -87,7 +87,7 @@ export class Server {
           inlayHintProvider: true,
           hoverProvider: true,
           completionProvider: {
-            triggerCharacters: [".", ":", "<", "&", "\"", "'", "/", ",", " ", "@"],
+            triggerCharacters: [".", ":", "<", "&", "\"", "'", "/", ",", " ", "@", "=", ">", "-"],
           },
           definitionProvider: true,
           referencesProvider: true,

--- a/javascript/packages/language-service/package.json
+++ b/javascript/packages/language-service/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "@herb-tools/analysis": "0.10.3",
+    "@herb-tools/client": "0.10.3",
     "@herb-tools/config": "0.10.3",
     "@herb-tools/core": "0.10.3",
     "@herb-tools/printer": "0.10.3",

--- a/javascript/packages/language-service/src/completion_provider.ts
+++ b/javascript/packages/language-service/src/completion_provider.ts
@@ -257,6 +257,22 @@ export class CompletionProvider {
       return this.getHerbValueCompletions(valueMatch[1], valueMatch[2], position, root)
     }
 
+    const rubyValueMatch = lineText.match(/\bherb_([a-z]+):\s*["']([^"']*)$/)
+
+    if (rubyValueMatch) {
+      const attribute = (HERB_ATTRIBUTES as Record<string, string>)[rubyValueMatch[1]]
+
+      if (attribute && HERB_VALUE_ATTRIBUTES.has(attribute)) {
+        return this.getHerbValueCompletions(attribute, rubyValueMatch[2], position, root)
+      }
+    }
+
+    const rubyKeyMatch = lineText.match(/\bdata:\s*\{[^{}]*?([a-z_]*)$/)
+
+    if (rubyKeyMatch) {
+      return this.getHerbHashKeyCompletions(rubyKeyMatch[1], position)
+    }
+
     const nameMatch = lineText.match(/<[a-zA-Z][^<>]*\s(data-[\w-]*)$/)
 
     if (nameMatch) {
@@ -264,6 +280,26 @@ export class CompletionProvider {
     }
 
     return null
+  }
+
+  private getHerbHashKeyCompletions(prefix: string, position: Position): CompletionList | null {
+    const keys = AUTHORED_HERB_ATTRIBUTES.map(attribute => attribute.replace("data-", "").replace(/-/g, "_"))
+    const matching = keys.filter(key => key.startsWith(prefix))
+
+    if (matching.length === 0) return null
+
+    const replaced = Range.create(Position.create(position.line, position.character - prefix.length), position)
+
+    const items = matching.map(key => ({
+      label: `${key}:`,
+      kind: CompletionItemKind.Property,
+      insertTextFormat: InsertTextFormat.Snippet,
+      textEdit: TextEdit.replace(replaced, `${key}: "$1"`),
+      detail: "Herb",
+      command: HERB_VALUE_ATTRIBUTES.has(`data-${key.replace(/_/g, "-")}`) ? TRIGGER_SUGGEST : undefined,
+    }))
+
+    return { isIncomplete: false, items }
   }
 
   private getHerbNameCompletions(prefix: string, position: Position): CompletionList | null {

--- a/javascript/packages/language-service/src/completion_provider.ts
+++ b/javascript/packages/language-service/src/completion_provider.ts
@@ -5,6 +5,10 @@ import { Command, CompletionItem, CompletionItemKind, CompletionList, InsertText
 
 import { getBlockArgumentCompletions } from "./language-service"
 import { nodeToRange, isPositionInRange, rangeSize, lspPosition } from "./range_utils"
+import { collectHerbAttributes, collectStateDirectives } from "./herb_attribute_links"
+import { HERB_ATTRIBUTES } from "@herb-tools/client/directives"
+
+import type { DocumentNode } from "@herb-tools/core"
 import { partialNameForFile, strictLocalsDeclaration, templateNameForFile } from "@herb-tools/analysis"
 import { isERBContentNode, isERBOutputNode, isHTMLOpenTagNode, isHTMLTextNode, isValidLocalName, getHelperEntries } from "@herb-tools/core"
 
@@ -15,6 +19,53 @@ import type { PartialIndex, PartialDeclaration } from "@herb-tools/analysis"
 import { HELPER_REGISTRY, HTML_NAMED_CHARACTER_REFERENCES, HTML_ELEMENTS } from "@herb-tools/core"
 
 const HTML_OPEN_TAG_PATTERN = /<(\w*)$/
+const AUTHORED_HERB_ATTRIBUTES = [
+  HERB_ATTRIBUTES.name,
+  HERB_ATTRIBUTES.into,
+  HERB_ATTRIBUTES.set,
+  HERB_ATTRIBUTES.toggle,
+  HERB_ATTRIBUTES.increment,
+  HERB_ATTRIBUTES.decrement,
+  HERB_ATTRIBUTES.reset,
+  HERB_ATTRIBUTES.by,
+]
+
+const HERB_VALUE_ATTRIBUTES = new Set<string>([
+  HERB_ATTRIBUTES.into,
+  HERB_ATTRIBUTES.set,
+  HERB_ATTRIBUTES.toggle,
+  HERB_ATTRIBUTES.increment,
+  HERB_ATTRIBUTES.decrement,
+  HERB_ATTRIBUTES.reset,
+])
+
+const COMMON_ACTION_EVENTS = ["click", "change", "input", "submit", "focus", "blur", "focusin", "focusout", "mouseenter", "mouseleave", "keydown", "keyup"]
+
+const ACTION_EVENTS = [
+  ...COMMON_ACTION_EVENTS,
+  "animationend", "animationiteration", "animationstart",
+  "beforeinput", "cancel", "close", "contextmenu", "copy", "cut",
+  "dblclick", "drag", "dragend", "dragenter", "dragleave", "dragover", "dragstart", "drop",
+  "ended", "invalid", "mousedown", "mousemove", "mouseout", "mouseover", "mouseup",
+  "paste", "pause", "play", "pointercancel", "pointerdown", "pointerenter", "pointerleave", "pointermove", "pointerup",
+  "reset", "scroll", "scrollend", "select", "toggle",
+  "touchcancel", "touchend", "touchmove", "touchstart",
+  "transitioncancel", "transitionend", "transitionrun", "transitionstart",
+  "wheel",
+]
+
+function currentToken(valueText: string, separators: string[]): string {
+  let token = valueText
+
+  for (const separator of separators) {
+    const index = token.lastIndexOf(separator)
+
+    if (index !== -1) token = token.slice(index + 1)
+  }
+
+  return token
+}
+
 const CHARACTER_REFERENCE_PATTERN = /&([a-zA-Z]*)$/
 
 const TAG_DOT_PATTERN = /tag\.(\w*)$/
@@ -165,6 +216,10 @@ export class CompletionProvider {
       track_whitespace: true,
     })
 
+    const herb = this.getHerbAttributeCompletions(document, position, parseResult.value as DocumentNode)
+
+    if (herb) return herb
+
     const collector = new NodeAtPositionCollector(position)
     collector.visit(parseResult.value)
 
@@ -188,6 +243,132 @@ export class CompletionProvider {
     }
 
     return this.getDocumentLevelCompletions(document, position)
+  }
+
+  private getHerbAttributeCompletions(document: TextDocument, position: Position, root: DocumentNode): CompletionList | null {
+    const lineText = document.getText({
+      start: Position.create(position.line, 0),
+      end: position,
+    })
+
+    const valueMatch = lineText.match(/([\w-]+)="([^"]*)$/)
+
+    if (valueMatch && HERB_VALUE_ATTRIBUTES.has(valueMatch[1])) {
+      return this.getHerbValueCompletions(valueMatch[1], valueMatch[2], position, root)
+    }
+
+    const nameMatch = lineText.match(/<[a-zA-Z][^<>]*\s(data-[\w-]*)$/)
+
+    if (nameMatch) {
+      return this.getHerbNameCompletions(nameMatch[1], position)
+    }
+
+    return null
+  }
+
+  private getHerbNameCompletions(prefix: string, position: Position): CompletionList | null {
+    const matching = AUTHORED_HERB_ATTRIBUTES.filter(attribute => attribute.startsWith(prefix))
+
+    if (matching.length === 0) return null
+
+    const replaced = Range.create(Position.create(position.line, position.character - prefix.length), position)
+
+    const items = matching.map(attribute => ({
+      label: attribute,
+      kind: CompletionItemKind.Property,
+      textEdit: TextEdit.replace(replaced, `${attribute}="$1"`),
+      insertTextFormat: InsertTextFormat.Snippet,
+      detail: "Herb",
+      command: HERB_VALUE_ATTRIBUTES.has(attribute) ? TRIGGER_SUGGEST : undefined,
+    }))
+
+    return { isIncomplete: false, items }
+  }
+
+  private getHerbValueCompletions(attribute: string, valueText: string, position: Position, root: DocumentNode): CompletionList | null {
+    if (attribute === HERB_ATTRIBUTES.into) {
+      const names = collectHerbAttributes(root).slotNames.filter(group => group.declarations.length > 0)
+
+      return this.herbItems(names.map(group => group.name), valueText, position, CompletionItemKind.Reference, "collection")
+    }
+
+    const states = collectStateDirectives(root)
+      .filter(entry => entry.scope === null || isPositionInRange(position, nodeToRange(entry.scope)))
+      .flatMap(entry => entry.signature.declarations)
+    const kinds = new Map(states.map(declaration => [declaration.name, declaration.kind]))
+
+    if (attribute === HERB_ATTRIBUTES.toggle || attribute === HERB_ATTRIBUTES.increment || attribute === HERB_ATTRIBUTES.decrement || attribute === HERB_ATTRIBUTES.reset) {
+      const wanted = attribute === HERB_ATTRIBUTES.toggle ? "boolean" : attribute === HERB_ATTRIBUTES.reset ? null : "integer"
+      const token = currentToken(valueText, [",", " ", ">"])
+      const names = [...kinds.entries()].filter(([, kind]) => wanted === null || kind === wanted || kind === "bare").map(([name]) => name)
+
+      return this.herbItems(names, token, position, CompletionItemKind.Variable, "state", name => kinds.get(name) ?? "")
+    }
+
+    if (attribute === HERB_ATTRIBUTES.set) {
+      const clause = valueText.split(" ").pop() ?? ""
+      const piece = clause.slice(clause.lastIndexOf(">") + 1).split(",").pop() ?? ""
+      const separator = piece.indexOf("=")
+
+      if (separator !== -1) {
+        const name = piece.slice(0, separator).trim()
+        const kind = kinds.get(name)
+
+        if (kind === "boolean") {
+          return this.herbItems(["true", "false"], piece.slice(separator + 1), position, CompletionItemKind.Value, "value")
+        }
+
+        if (kind === "string") {
+          return this.herbItems(["''"], piece.slice(separator + 1), position, CompletionItemKind.Value, "empty string")
+        }
+
+        return null
+      }
+
+      const items = this.herbItems([...kinds.keys()], piece, position, CompletionItemKind.Variable, "state", name => kinds.get(name) ?? "", "=", TRIGGER_SUGGEST)
+        ?? { isIncomplete: false, items: [] as CompletionItem[] }
+
+      if (!clause.includes("->")) {
+        const replaced = Range.create(Position.create(position.line, position.character - piece.length), position)
+
+        for (const event of ACTION_EVENTS.filter(event => event.startsWith(piece))) {
+          items.items.push({
+            label: `${event}->`,
+            kind: CompletionItemKind.Event,
+            insertTextFormat: InsertTextFormat.Snippet,
+            textEdit: TextEdit.replace(replaced, `${event}->$0`),
+            detail: "event",
+            command: TRIGGER_SUGGEST,
+            sortText: COMMON_ACTION_EVENTS.includes(event) ? `1_${String(COMMON_ACTION_EVENTS.indexOf(event)).padStart(2, "0")}` : `2_${event}`,
+          })
+        }
+      }
+
+      return items.items.length > 0 ? items : null
+    }
+
+    return null
+  }
+
+  private herbItems(names: string[], prefix: string, position: Position, kind: CompletionItemKind, detail: string, kindOf?: (name: string) => string, suffix = "", command?: Command): CompletionList | null {
+    const matching = names.filter(name => name.startsWith(prefix.trim()))
+
+    if (matching.length === 0) return null
+
+    const replaced = Range.create(Position.create(position.line, position.character - prefix.length), position)
+
+    const items = matching.map((name, index) => ({
+      label: name,
+      kind,
+      insertTextFormat: InsertTextFormat.Snippet,
+      textEdit: TextEdit.replace(replaced, `${name}${suffix}$0`),
+      detail: kindOf ? `${detail} (${kindOf(name)})` : detail,
+      sortText: `0_${String(index).padStart(2, "0")}`,
+      preselect: index === 0,
+      command,
+    }))
+
+    return { isIncomplete: false, items }
   }
 
   private getDocumentLevelCompletions(document: TextDocument, position: Position): CompletionList | null {

--- a/javascript/packages/language-service/src/definition_provider.ts
+++ b/javascript/packages/language-service/src/definition_provider.ts
@@ -2,6 +2,8 @@ import { Hover, Location, LocationLink, MarkupKind, Position, Range } from "vsco
 import { IdentityPrinter } from "@herb-tools/printer"
 import { ParserService } from "./parser_service"
 import { isPositionInRange, lspRangeFromLocation } from "./range_utils"
+import { RubyLocalsIndex } from "./ruby_locals_index"
+import { slotNameGroupAt } from "./herb_attribute_links"
 import { pathFromUri, uriFromPath } from "./uri"
 import { RenderCollector } from "./render_collector"
 
@@ -52,6 +54,10 @@ export class DefinitionProvider {
   }
 
   getDefinition(document: TextDocument, position: Position, options?: FrameworkOptions): LocationLink[] {
+    const herb = this.getHerbDefinition(document, position)
+
+    if (herb.length > 0) return herb
+
     if (options?.framework !== "actionview") return []
 
     const reference = this.referenceAt(document, position)
@@ -65,6 +71,37 @@ export class DefinitionProvider {
       targetUri: uriFromPath(filePath),
       targetRange,
       targetSelectionRange: targetRange,
+    }))
+  }
+
+  private getHerbDefinition(document: TextDocument, position: Position): LocationLink[] {
+    const index = RubyLocalsIndex.build(this.parserService, document)
+    const local = index.at(position)
+
+    if (local) {
+      const onDefault = local.defaultValue !== undefined && isPositionInRange(position, local.defaultValue)
+      const origin = local.usages.find(usage => isPositionInRange(position, usage))
+        ?? (onDefault ? local.defaultValue : local.declaration)
+
+      return [{
+        originSelectionRange: origin,
+        targetUri: document.uri,
+        targetRange: local.declaration,
+        targetSelectionRange: local.declaration,
+      }]
+    }
+
+    const group = slotNameGroupAt(index.herbAttributes, position, isPositionInRange)
+
+    if (!group || group.declarations.length === 0) return []
+
+    const origin = group.usages.find(usage => isPositionInRange(position, usage)) ?? group.declarations[0]
+
+    return group.declarations.map(declaration => ({
+      originSelectionRange: origin,
+      targetUri: document.uri,
+      targetRange: declaration,
+      targetSelectionRange: declaration,
     }))
   }
 

--- a/javascript/packages/language-service/src/document_highlight_provider.ts
+++ b/javascript/packages/language-service/src/document_highlight_provider.ts
@@ -243,7 +243,8 @@ export class DocumentHighlightProvider {
     if (local) {
       return [
         DocumentHighlight.create(local.declaration, DocumentHighlightKind.Write),
-        ...local.usages.map(usage => DocumentHighlight.create(usage, DocumentHighlightKind.Read))
+        ...local.usages.map(usage => DocumentHighlight.create(usage, DocumentHighlightKind.Read)),
+        ...(local.defaultValue ? [DocumentHighlight.create(local.defaultValue, DocumentHighlightKind.Text)] : [])
       ]
     }
 

--- a/javascript/packages/language-service/src/document_highlight_provider.ts
+++ b/javascript/packages/language-service/src/document_highlight_provider.ts
@@ -7,6 +7,7 @@ import { RubyLocalsIndex } from "./ruby_locals_index"
 
 import { isERBIfNode, isERBElseNode, isHTMLOpenTagNode } from "@herb-tools/core"
 import { erbTagToRange, tokenToRange, nodeToRange, openTagRanges, isPositionInRange, rangeSize } from "./range_utils"
+import { slotNameGroupAt } from "./herb_attribute_links"
 
 import type {
   Node,
@@ -238,13 +239,23 @@ export class DocumentHighlightProvider {
   }
 
   getDocumentHighlights(textDocument: TextDocument, position: Position): DocumentHighlight[] {
-    const local = RubyLocalsIndex.build(this.parserService, textDocument).at(position)
+    const index = RubyLocalsIndex.build(this.parserService, textDocument)
+    const local = index.at(position)
 
     if (local) {
       return [
         DocumentHighlight.create(local.declaration, DocumentHighlightKind.Write),
         ...local.usages.map(usage => DocumentHighlight.create(usage, DocumentHighlightKind.Read)),
         ...(local.defaultValue ? [DocumentHighlight.create(local.defaultValue, DocumentHighlightKind.Text)] : [])
+      ]
+    }
+
+    const slotGroup = slotNameGroupAt(index.herbAttributes, position, isPositionInRange)
+
+    if (slotGroup) {
+      return [
+        ...slotGroup.declarations.map(declaration => DocumentHighlight.create(declaration, DocumentHighlightKind.Write)),
+        ...slotGroup.usages.map(usage => DocumentHighlight.create(usage, DocumentHighlightKind.Read))
       ]
     }
 

--- a/javascript/packages/language-service/src/herb_attribute_links.ts
+++ b/javascript/packages/language-service/src/herb_attribute_links.ts
@@ -1,0 +1,217 @@
+import { Range, Position } from "vscode-languageserver-types"
+
+import { Visitor } from "@herb-tools/core"
+import { HERB_ATTRIBUTES, ACTION_NAMES, splitOutsideQuotes, parseStateDirective } from "@herb-tools/client/directives"
+
+import { lspPosition } from "./range_utils"
+
+import type { ActionName, StateSignature } from "@herb-tools/client/directives"
+import type { DocumentNode, Node, HTMLAttributeNode, LiteralNode, ERBContentNode } from "@herb-tools/core"
+
+export interface AttributeStateUsage {
+  name: string
+  range: Range
+}
+
+export interface SlotNameGroup {
+  name: string
+  declarations: Range[]
+  usages: Range[]
+}
+
+export interface HerbAttributeLinks {
+  stateUsages: AttributeStateUsage[]
+  slotNames: SlotNameGroup[]
+}
+
+const ACTION_ATTRIBUTES = new Map<string, ActionName>(ACTION_NAMES.map(action => [HERB_ATTRIBUTES[action], action]))
+
+export function collectHerbAttributes(document: DocumentNode): HerbAttributeLinks {
+  const collector = new HerbAttributeCollector()
+
+  collector.visit(document)
+
+  const groups = new Map<string, SlotNameGroup>()
+
+  const groupFor = (name: string): SlotNameGroup => {
+    const existing = groups.get(name)
+
+    if (existing) return existing
+
+    const group = { name, declarations: [], usages: [] }
+
+    groups.set(name, group)
+
+    return group
+  }
+
+  for (const { name, range } of collector.slotDeclarations) groupFor(name).declarations.push(range)
+  for (const { name, range } of collector.slotUsages) groupFor(name).usages.push(range)
+
+  return { stateUsages: collector.stateUsages, slotNames: [...groups.values()].filter(group => group.declarations.length > 0 || group.usages.length > 0) }
+}
+
+class HerbAttributeCollector extends Visitor {
+  readonly stateUsages: AttributeStateUsage[] = []
+  readonly slotDeclarations: AttributeStateUsage[] = []
+  readonly slotUsages: AttributeStateUsage[] = []
+
+  visitChildNodes(node: Node): void {
+    if (node.type === "AST_HTML_ATTRIBUTE_NODE") this.collect(node as HTMLAttributeNode)
+
+    super.visitChildNodes(node)
+  }
+
+  private collect(attribute: HTMLAttributeNode): void {
+    const attributeName = staticText(attribute.name?.children)
+    const literal = singleLiteral(attribute.value?.children)
+
+    if (attributeName === null || literal === null) return
+
+    const action = ACTION_ATTRIBUTES.get(attributeName)
+
+    if (action) {
+      for (const { name, offset } of stateNamesIn(literal.content ?? "", action)) {
+        this.stateUsages.push({ name, range: literalRange(literal, offset, name.length) })
+      }
+
+      return
+    }
+
+    if (attributeName === HERB_ATTRIBUTES.name || attributeName === HERB_ATTRIBUTES.into) {
+      const value = (literal.content ?? "").trim()
+
+      if (value === "") return
+
+      if (attributeName === HERB_ATTRIBUTES.name) {
+        const offset = (literal.content ?? "").indexOf(value)
+
+        this.slotDeclarations.push({ name: value, range: literalRange(literal, offset, value.length) })
+      } else {
+        this.slotUsages.push({ name: value, range: attributeRange(attribute) })
+      }
+    }
+  }
+}
+
+function stateNamesIn(content: string, action: ActionName): { name: string, offset: number }[] {
+  const found: { name: string, offset: number }[] = []
+  let cursor = 0
+
+  for (const part of splitOutsideQuotes(content, " ")) {
+    if (part.trim() === "") {
+      cursor += part.length + 1
+
+      continue
+    }
+
+    const partOffset = content.indexOf(part, cursor)
+
+    if (partOffset === -1) continue
+
+    const arrow = part.indexOf("->")
+    const restOffset = arrow === -1 ? partOffset : partOffset + arrow + 2
+    const rest = arrow === -1 ? part : part.slice(arrow + 2)
+
+    let nameCursor = restOffset
+
+    for (const piece of splitOutsideQuotes(rest, ",")) {
+      const separator = piece.indexOf("=")
+      const raw = action === "set" ? (separator === -1 ? piece : piece.slice(0, separator)) : piece
+      const name = raw.trim()
+
+      if (name !== "" && /^[a-z_][a-zA-Z0-9_]*$/.test(name)) {
+        const offset = content.indexOf(name, nameCursor)
+
+        if (offset !== -1) {
+          found.push({ name, offset })
+          nameCursor = offset + name.length
+        }
+      } else {
+        nameCursor += piece.length + 1
+      }
+    }
+
+    cursor = partOffset + part.length
+  }
+
+  return found
+}
+
+function singleLiteral(children: Node[] | undefined): LiteralNode | null {
+  if (!children || children.length !== 1) return null
+
+  const child = children[0]
+
+  return child.type === "AST_LITERAL_NODE" ? (child as LiteralNode) : null
+}
+
+function staticText(children: Node[] | undefined): string | null {
+  const literal = singleLiteral(children)
+
+  return literal ? (literal.content ?? "") : null
+}
+
+function attributeRange(attribute: HTMLAttributeNode): Range {
+  return Range.create(lspPosition(attribute.location.start), lspPosition(attribute.location.end))
+}
+
+function literalRange(literal: LiteralNode, offset: number, length: number): Range {
+  const before = (literal.content ?? "").slice(0, offset)
+  const lines = before.split("\n")
+  const line = literal.location.start.line + lines.length - 1
+  const column = lines.length === 1 ? literal.location.start.column + before.length : lines[lines.length - 1].length
+  const from = lspPosition({ line, column })
+
+  return Range.create(from, Position.create(from.line, from.character + length))
+}
+
+export interface StateDirectiveEntry {
+  node: ERBContentNode
+  signature: StateSignature
+  scope: Node | null
+}
+
+export function collectStateDirectives(document: DocumentNode): StateDirectiveEntry[] {
+  const collector = new StateDirectiveCollector()
+
+  collector.visit(document)
+
+  return collector.entries
+}
+
+class StateDirectiveCollector extends Visitor {
+  readonly entries: StateDirectiveEntry[] = []
+
+  private stack: Node[] = []
+
+  visitChildNodes(node: Node): void {
+    if (node.type === "AST_ERB_CONTENT_NODE") {
+      const content = node as ERBContentNode
+
+      if (content.tag_opening?.value === "<%#") {
+        const signature = parseStateDirective(content.content?.value ?? "")
+
+        if (signature && !signature.malformed) {
+          this.entries.push({ node: content, signature, scope: this.stack[this.stack.length - 1] ?? null })
+        }
+      }
+    }
+
+    const scoping = node.type === "AST_ERB_BLOCK_NODE" || node.type === "AST_ERB_ITERATION_BLOCK_NODE"
+
+    if (scoping) this.stack.push(node)
+
+    super.visitChildNodes(node)
+
+    if (scoping) this.stack.pop()
+  }
+}
+
+export function slotNameGroupAt(links: HerbAttributeLinks, position: Position, covers: (position: Position, range: Range) => boolean): SlotNameGroup | null {
+  for (const group of links.slotNames) {
+    if ([...group.declarations, ...group.usages].some(range => covers(position, range))) return group
+  }
+
+  return null
+}

--- a/javascript/packages/language-service/src/herb_html_data_provider.ts
+++ b/javascript/packages/language-service/src/herb_html_data_provider.ts
@@ -1,0 +1,26 @@
+import { HERB_ATTRIBUTES } from "@herb-tools/client/directives"
+
+import type { IHTMLDataProvider } from "vscode-html-languageservice"
+
+const DESCRIPTIONS: Record<string, string> = {
+  [HERB_ATTRIBUTES.name]: "Names the slot this element holds, so client code can address it without counting indices.",
+  [HERB_ATTRIBUTES.into]: "Makes the form an optimistic send into the keyed collection this names.",
+  [HERB_ATTRIBUTES.set]: 'Sets declared states on an event, like `click->open=true,failed=false`.',
+  [HERB_ATTRIBUTES.toggle]: "Flips a boolean state on click, or on the event named in the value.",
+  [HERB_ATTRIBUTES.increment]: "Increments an integer state, stepping by `data-herb-by`.",
+  [HERB_ATTRIBUTES.decrement]: "Decrements an integer state, stepping by `data-herb-by`.",
+  [HERB_ATTRIBUTES.reset]: "Returns states to what the server rendered; with no value, every state in scope.",
+  [HERB_ATTRIBUTES.by]: "The step for `data-herb-increment` and `data-herb-decrement`.",
+}
+
+export const herbHTMLDataProvider: IHTMLDataProvider = {
+  getId: () => "herb",
+  isApplicable: () => true,
+  provideTags: () => [],
+  provideAttributes: () =>
+    Object.entries(DESCRIPTIONS).map(([name, description]) => ({
+      name,
+      description: { kind: "markdown", value: description },
+    })),
+  provideValues: () => [],
+}

--- a/javascript/packages/language-service/src/hover_provider.ts
+++ b/javascript/packages/language-service/src/hover_provider.ts
@@ -6,7 +6,11 @@ import { IdentityPrinter } from "@herb-tools/printer"
 import { ActionViewTagHelperToHTMLRewriter, cloneNode } from "@herb-tools/rewriter"
 import { isERBOpenTagNode, isHTMLElementNode, isERBContentNode, getNamedCharacterReference, HELPER_BY_SOURCE, HELPER_REGISTRY, CHARACTER_REFERENCE_PATTERN } from "@herb-tools/core"
 import { ParserService } from "./parser_service"
-import { lspPosition, isPositionInRange, rangeSize, hasSourceLocation } from "./range_utils"
+import { lspPosition, isPositionInRange, rangeSize, hasSourceLocation, nodeToRange } from "./range_utils"
+import { RubyLocalsIndex } from "./ruby_locals_index"
+import { collectStateDirectives } from "./herb_attribute_links"
+
+import type { DocumentNode } from "@herb-tools/core"
 
 import type { Node, HTMLElementNode, ERBOpenTagNode, ERBContentNode, HTMLCharacterReference, HelperEntry } from "@herb-tools/core"
 import type { FrameworkOptions } from "./types.js"
@@ -124,6 +128,124 @@ function dedent(text: string): string {
   return lines.map(line => line.slice(minIndent)).join("\n")
 }
 
+function blockParameter(scope: Node): string | null {
+  const content = (scope as { content?: { value?: string } }).content?.value ?? ""
+  const match = content.match(/\|\s*([A-Za-z_][A-Za-z0-9_]*)/)
+
+  return match ? match[1] : null
+}
+
+function declaredStateKind(kind: string): string {
+  return ["boolean", "integer", "string", "symbol", "nil"].includes(kind) ? kind : "seeded"
+}
+
+function stateUsageLines(name: string, kind: string, defaultSource: string): string[] {
+  const fence = (language: string, ...lines: string[]) => ["```" + language, ...lines, "```"]
+
+  if (kind === "boolean") {
+    return [
+      ...fence("erb", `<%= ${name} %>`, `<% if ${name}? %>`, `<button data-herb-toggle="${name}">`),
+      "",
+      ...fence("javascript", `stateFor(element).set({ ${name}: true })`),
+    ]
+  }
+
+  if (kind === "integer") {
+    return [
+      ...fence("erb", `<%= ${name} %>`, `<% if ${name} == ${defaultSource || "0"} %>`, `<button data-herb-increment="${name}">`),
+      "",
+      ...fence("javascript", `stateFor(element).set({ ${name}: ${defaultSource || "0"} })`),
+    ]
+  }
+
+  if (kind === "string" || kind === "symbol") {
+    return [
+      ...fence("erb", `<%= ${name} %>`, `<% if ${name} == ${defaultSource || '""'} %>`, `<button data-herb-set="${name}=...">`, `<button data-herb-reset="${name}">`),
+      "",
+      ...fence("javascript", `stateFor(element).set({ ${name}: ${defaultSource || '"..."'} })`),
+    ]
+  }
+
+  return [
+    ...fence("erb", `<%= ${name} %>`, `<% if ${name} %>`),
+    "",
+    ...fence("javascript", `stateFor(element).set({ ${name}: value })`),
+  ]
+}
+
+const DIRECTIVE_DOCS: Record<string, string> = {
+  "herb:slots": [
+    "**herb:slots** · Herb directive",
+    "",
+    "Chooses who renders this template's dynamic parts. `server` keeps every update a round trip. `client` also ships the markup that did not render, untaken branches and an empty collection row, parked in a `<template>`, so a branch can switch or a row can be inserted without asking the server.",
+    "",
+    "Example usage:",
+    "",
+    "```erb",
+    "<%# herb:slots client %>",
+    "```",
+  ].join("\n"),
+  "herb:state": [
+    "**herb:state** · Herb directive",
+    "",
+    "Declares client-owned state with the strict-locals signature. The server renders each default, and every read updates in place when the client writes. Placement scopes it, at the top of the template it is one value per rendering, inside a keyed loop one value per item.",
+    "",
+    "Example usage:",
+    "",
+    "```erb",
+    '<%# herb:state (pending: false, draft: "") %>',
+    "```",
+  ].join("\n"),
+  "herb:key": [
+    "**herb:key** · Herb directive",
+    "",
+    "Keys each item of the enclosing collection by an expression, so the client can add, remove, re-key, and reorder rows without rebuilding them. A dynamic \`id\` or \`herb-key\` attribute on the item's root element keys it the same way, so the directive is only needed when the row has neither.",
+    "",
+    "Example usage:",
+    "",
+    "```erb",
+    "<%# herb:key message.id %>",
+    "```",
+    "",
+    "Keyed by its \`id\` instead, with no directive:",
+    "",
+    "```erb",
+    '<li id="<%= dom_id(message) %>">',
+    "```",
+  ].join("\n"),
+}
+
+const DIRECTIVE_KEYWORD = /herb:(?:state|slots|key)\b/
+
+class DirectiveKeywordCollector extends Visitor {
+  readonly found: { node: ERBContentNode, keyword: string, offset: number }[] = []
+
+  visitChildNodes(node: Node): void {
+    if (isERBContentNode(node) && node.tag_opening?.value === "<%#") {
+      const content = node.content?.value ?? ""
+      const match = DIRECTIVE_KEYWORD.exec(content)
+
+      if (match) this.found.push({ node, keyword: match[0], offset: match.index })
+    }
+
+    super.visitChildNodes(node)
+  }
+}
+
+function contentTokenRange(node: ERBContentNode, offset: number, length: number): Range {
+  const content = node.content
+
+  if (!content) return Range.create(lspPosition(node.location.start), lspPosition(node.location.end))
+
+  const before = content.value.slice(0, offset)
+  const lines = before.split("\n")
+  const line = content.location.start.line + lines.length - 1
+  const column = lines.length === 1 ? content.location.start.column + before.length : lines[lines.length - 1].length
+  const from = lspPosition({ line, column })
+
+  return Range.create(from, Position.create(from.line, from.character + length))
+}
+
 export class HoverProvider {
   private parserService: ParserService
 
@@ -134,7 +256,80 @@ export class HoverProvider {
     this.baseDir = baseDir
   }
 
+  private getDirectiveHover(textDocument: TextDocument, position: Position): Hover | null {
+    const parsed = this.parserService.parseContent(textDocument.getText(), { track_whitespace: true })
+    const collector = new DirectiveKeywordCollector()
+
+    collector.visit(parsed.value)
+
+    for (const { node, keyword, offset } of collector.found) {
+      const range = contentTokenRange(node, offset, keyword.length)
+
+      if (!isPositionInRange(position, range)) continue
+
+      const documentation = DIRECTIVE_DOCS[keyword]
+
+      if (!documentation) continue
+
+      return { contents: { kind: MarkupKind.Markdown, value: documentation }, range }
+    }
+
+    return null
+  }
+
+  private getStateHover(textDocument: TextDocument, position: Position): Hover | null {
+    const index = RubyLocalsIndex.build(this.parserService, textDocument)
+    const local = index.at(position)
+
+    if (!local) return null
+
+    const parsed = this.parserService.parseContent(textDocument.getText(), { prism_program: true, strict_locals: true })
+    const entries = collectStateDirectives(parsed.value as DocumentNode).filter(entry =>
+      entry.signature.declarations.some(declaration => declaration.name === local.name),
+    )
+
+    if (entries.length === 0) return null
+
+    const scoped = entries.find(entry => entry.scope !== null && isPositionInRange(position, nodeToRange(entry.scope)))
+    const entry = scoped ?? entries.find(candidate => candidate.scope === null) ?? entries[0]
+    const declaration = entry.signature.declarations.find(candidate => candidate.name === local.name)
+
+    if (!declaration) return null
+
+    const kind = declaredStateKind(declaration.kind)
+    const parameter = entry.scope === null ? null : blockParameter(entry.scope)
+    const scope = entry.scope === null
+      ? "one value per rendering"
+      : `one value for each \`${parameter ?? "item"}\``
+
+    const lines = [
+      `**${declaration.name}** · Herb Client State`,
+      "",
+      `\`${kind}\` · default \`${declaration.defaultSource || "(none)"}\` · ${scope}`,
+      "",
+      "Example usage:",
+      "",
+      ...stateUsageLines(declaration.name, kind, declaration.defaultSource),
+    ]
+
+    const range = [local.declaration, ...(local.defaultValue ? [local.defaultValue] : []), ...local.usages]
+      .find(candidate => isPositionInRange(position, candidate))
+
+    return {
+      contents: { kind: MarkupKind.Markdown, value: lines.join("\n") },
+      range,
+    }
+  }
+
   getHover(textDocument: TextDocument, position: Position, options?: FrameworkOptions): Hover | null {
+    const state = this.getStateHover(textDocument, position)
+
+    if (state) return state
+
+    const directive = this.getDirectiveHover(textDocument, position)
+
+    if (directive) return directive
+
     if (options?.framework !== "actionview") {
       return this.getEntityHover(textDocument, position)
     }

--- a/javascript/packages/language-service/src/index.ts
+++ b/javascript/packages/language-service/src/index.ts
@@ -1,4 +1,5 @@
 export { getLanguageService, getBlockArgumentCompletions } from "./language-service.js"
+export { herbHTMLDataProvider } from "./herb_html_data_provider.js"
 export { findTokenIndex, HerbHTMLNode } from "./herb-html-node.js"
 export { buildHTMLDocument } from "./herb-html-document.js"
 export { buildLineOffsetTable, positionToOffset, locationToOffsets } from "./offset-utils.js"

--- a/javascript/packages/language-service/src/language-service.ts
+++ b/javascript/packages/language-service/src/language-service.ts
@@ -3,6 +3,7 @@ import { CompletionItemKind, InsertTextFormat } from "vscode-html-languageservic
 
 import { buildHTMLDocument } from "./herb-html-document.js"
 import { getLanguageService as getUpstreamLanguageService } from "vscode-html-languageservice"
+import { herbHTMLDataProvider } from "./herb_html_data_provider"
 
 import { TOKEN_LIST_ATTRIBUTES, getHelper } from "@herb-tools/core"
 
@@ -21,9 +22,9 @@ const DEFAULT_HERB_PARSE_OPTIONS: ParseOptions = {
 }
 
 export function getLanguageService(options?: LanguageServiceOptions): LanguageService {
-  const upstream = getUpstreamLanguageService(options)
+  const dataProviders = [herbHTMLDataProvider, ...(options?.customDataProviders ?? [])]
+  const upstream = getUpstreamLanguageService({ ...options, customDataProviders: dataProviders })
   const herb = options?.herb
-  const dataProviders = options?.customDataProviders ?? []
 
   const framework = options?.framework
 

--- a/javascript/packages/language-service/src/references_provider.ts
+++ b/javascript/packages/language-service/src/references_provider.ts
@@ -6,6 +6,10 @@ import { uriFromPath } from "./uri"
 import { Location, Position, Range } from "vscode-languageserver-types"
 import { TextDocument } from "vscode-languageserver-textdocument"
 import { DefinitionProvider } from "./definition_provider"
+import { RubyLocalsIndex } from "./ruby_locals_index"
+import { slotNameGroupAt } from "./herb_attribute_links"
+import { isPositionInRange } from "./range_utils"
+import type { ParserService } from "./parser_service"
 
 import type { ProjectConfig } from "./types.js"
 import type { PartialReference } from "@herb-tools/language-service"
@@ -25,16 +29,20 @@ export class ReferencesProvider {
   private read: (filePath: string) => string | null
   private config?: ProjectConfig
 
+  private parserService?: ParserService
+
   constructor(
     definitionProvider: DefinitionProvider,
     index: ProjectIndex,
     documents: OpenDocuments,
-    read: (filePath: string) => string | null
+    read: (filePath: string) => string | null,
+    parserService?: ParserService
   ) {
     this.definitionProvider = definitionProvider
     this.index = index
     this.documents = documents
     this.read = read
+    this.parserService = parserService
   }
 
   setConfig(config?: ProjectConfig) {
@@ -42,6 +50,10 @@ export class ReferencesProvider {
   }
 
   getReferences(document: TextDocument, position: Position, includeDeclaration: boolean): Location[] {
+    const herb = this.getHerbReferences(document, position, includeDeclaration)
+
+    if (herb.length > 0) return herb
+
     if (this.config?.framework !== "actionview") return []
 
     const callers = this.index.callers
@@ -63,6 +75,27 @@ export class ReferencesProvider {
     }
 
     return locations
+  }
+
+  private getHerbReferences(document: TextDocument, position: Position, includeDeclaration: boolean): Location[] {
+    if (!this.parserService) return []
+
+    const index = RubyLocalsIndex.build(this.parserService, document)
+    const local = index.at(position)
+
+    if (local) {
+      const locations = includeDeclaration ? [Location.create(document.uri, local.declaration)] : []
+
+      return [...locations, ...local.usages.map(usage => Location.create(document.uri, usage))]
+    }
+
+    const group = slotNameGroupAt(index.herbAttributes, position, isPositionInRange)
+
+    if (!group) return []
+
+    const declarations = includeDeclaration ? group.declarations : []
+
+    return [...declarations, ...group.usages].map(range => Location.create(document.uri, range))
   }
 
   private partialAt(document: TextDocument, position: Position): string | null {

--- a/javascript/packages/language-service/src/ruby_locals_index.ts
+++ b/javascript/packages/language-service/src/ruby_locals_index.ts
@@ -6,8 +6,7 @@ import { StrictLocalsCollector } from "./strict_locals_collector"
 
 import { lspPosition, isPositionInRange, nodeToRange } from "./range_utils"
 import { stringIndexFromByteOffset, isERBBlockNode, isERBIterationBlockNode, isERBContentNode } from "@herb-tools/core"
-import { parseStateDirective } from "@herb-tools/client/directives"
-import { collectHerbAttributes } from "./herb_attribute_links"
+import { collectHerbAttributes, collectStateDirectives } from "./herb_attribute_links"
 
 import type { HerbAttributeLinks, AttributeStateUsage } from "./herb_attribute_links"
 
@@ -97,11 +96,7 @@ function blockLocals(document: DocumentNode, references: RubyReferenceCollector,
 }
 
 function stateLocals(document: DocumentNode, references: RubyReferenceCollector, toRange: (reference: RubyReference) => Range, attributeUsages: AttributeStateUsage[]): RubyLocal[] {
-  const collector = new StateDirectiveCollector()
-
-  collector.visit(document)
-
-  return collector.entries.flatMap(({ node, signature }) =>
+  return collectStateDirectives(document).flatMap(({ node, signature }) =>
     signature.declarations.map(declaration => ({
       name: declaration.name,
       declaration: contentRange(node, declaration.nameOffset, declaration.name.length),
@@ -128,20 +123,6 @@ function contentRange(node: ERBContentNode, offset: number, length: number): Ran
   const from = lspPosition({ line, column })
 
   return Range.create(from, Position.create(from.line, from.character + length))
-}
-
-class StateDirectiveCollector extends Visitor {
-  readonly entries: { node: ERBContentNode, signature: StateSignature }[] = []
-
-  visitChildNodes(node: Node): void {
-    if (isERBContentNode(node) && node.tag_opening?.value === "<%#") {
-      const signature = parseStateDirective(node.content?.value ?? "")
-
-      if (signature && !signature.malformed) this.entries.push({ node, signature })
-    }
-
-    super.visitChildNodes(node)
-  }
 }
 
 function blockRanges(document: DocumentNode): Range[] {

--- a/javascript/packages/language-service/src/ruby_locals_index.ts
+++ b/javascript/packages/language-service/src/ruby_locals_index.ts
@@ -5,10 +5,12 @@ import { Visitor, RubyReferenceCollector } from "@herb-tools/core"
 import { StrictLocalsCollector } from "./strict_locals_collector"
 
 import { lspPosition, isPositionInRange, nodeToRange } from "./range_utils"
-import { stringIndexFromByteOffset, isERBBlockNode, isERBIterationBlockNode } from "@herb-tools/core"
+import { stringIndexFromByteOffset, isERBBlockNode, isERBIterationBlockNode, isERBContentNode } from "@herb-tools/core"
+import { parseStateDirective } from "@herb-tools/client/directives"
 
 import type { ParserService } from "./parser_service"
-import type { DocumentNode, Node, RubyReference } from "@herb-tools/core"
+import type { DocumentNode, Node, RubyReference, ERBContentNode } from "@herb-tools/core"
+import type { StateSignature } from "@herb-tools/client/directives"
 
 const PARSER_OPTIONS = { prism_program: true, strict_locals: true } as const
 
@@ -16,6 +18,7 @@ export interface RubyLocal {
   name: string
   declaration: Range
   usages: Range[]
+  defaultValue?: Range
 }
 
 export class RubyLocalsIndex {
@@ -42,7 +45,8 @@ export class RubyLocalsIndex {
 
     return new RubyLocalsIndex([
       ...strictLocals(document, references, toRange),
-      ...blockLocals(document, references, toRange)
+      ...blockLocals(document, references, toRange),
+      ...stateLocals(document, references, toRange)
     ])
   }
 
@@ -50,7 +54,9 @@ export class RubyLocalsIndex {
     let best: RubyLocal | null = null
 
     for (const local of this.locals) {
-      if (!isPositionInRange(position, local.declaration) && !local.usages.some(usage => isPositionInRange(position, usage))) continue
+      const onDefault = local.defaultValue !== undefined && isPositionInRange(position, local.defaultValue)
+
+      if (!isPositionInRange(position, local.declaration) && !onDefault && !local.usages.some(usage => isPositionInRange(position, usage))) continue
       if (!best || encloses(best.declaration, local.declaration)) best = local
     }
 
@@ -80,6 +86,51 @@ function blockLocals(document: DocumentNode, references: RubyReferenceCollector,
 
     return { name: binding.name, declaration: range, usages }
   })
+}
+
+function stateLocals(document: DocumentNode, references: RubyReferenceCollector, toRange: (reference: RubyReference) => Range): RubyLocal[] {
+  const collector = new StateDirectiveCollector()
+
+  collector.visit(document)
+
+  return collector.entries.flatMap(({ node, signature }) =>
+    signature.declarations.map(declaration => ({
+      name: declaration.name,
+      declaration: contentRange(node, declaration.nameOffset, declaration.name.length),
+      usages: references.bareCalls
+        .filter(call => call.name === declaration.name || call.name === `${declaration.name}?`)
+        .map(toRange),
+      defaultValue: declaration.defaultSource === "" ? undefined : contentRange(node, declaration.defaultOffset, declaration.defaultSource.length)
+    }))
+  )
+}
+
+function contentRange(node: ERBContentNode, offset: number, length: number): Range {
+  const content = node.content
+
+  if (!content) return nodeToRange(node)
+
+  const before = content.value.slice(0, offset)
+  const lines = before.split("\n")
+  const line = content.location.start.line + lines.length - 1
+  const column = lines.length === 1 ? content.location.start.column + before.length : lines[lines.length - 1].length
+  const from = lspPosition({ line, column })
+
+  return Range.create(from, Position.create(from.line, from.character + length))
+}
+
+class StateDirectiveCollector extends Visitor {
+  readonly entries: { node: ERBContentNode, signature: StateSignature }[] = []
+
+  visitChildNodes(node: Node): void {
+    if (isERBContentNode(node) && node.tag_opening?.value === "<%#") {
+      const signature = parseStateDirective(node.content?.value ?? "")
+
+      if (signature && !signature.malformed) this.entries.push({ node, signature })
+    }
+
+    super.visitChildNodes(node)
+  }
 }
 
 function blockRanges(document: DocumentNode): Range[] {

--- a/javascript/packages/language-service/src/ruby_locals_index.ts
+++ b/javascript/packages/language-service/src/ruby_locals_index.ts
@@ -7,6 +7,9 @@ import { StrictLocalsCollector } from "./strict_locals_collector"
 import { lspPosition, isPositionInRange, nodeToRange } from "./range_utils"
 import { stringIndexFromByteOffset, isERBBlockNode, isERBIterationBlockNode, isERBContentNode } from "@herb-tools/core"
 import { parseStateDirective } from "@herb-tools/client/directives"
+import { collectHerbAttributes } from "./herb_attribute_links"
+
+import type { HerbAttributeLinks, AttributeStateUsage } from "./herb_attribute_links"
 
 import type { ParserService } from "./parser_service"
 import type { DocumentNode, Node, RubyReference, ERBContentNode } from "@herb-tools/core"
@@ -23,31 +26,36 @@ export interface RubyLocal {
 
 export class RubyLocalsIndex {
   readonly locals: RubyLocal[]
+  readonly herbAttributes: HerbAttributeLinks
 
-  private constructor(locals: RubyLocal[]) {
+  private constructor(locals: RubyLocal[], herbAttributes: HerbAttributeLinks) {
     this.locals = locals
+    this.herbAttributes = herbAttributes
   }
 
   static build(parserService: ParserService, textDocument: TextDocument): RubyLocalsIndex {
     const text = textDocument.getText()
 
+    const empty = { stateUsages: [], slotNames: [] }
+
     const result = parserService.parseContent(text, PARSER_OPTIONS)
-    if (result.failed) return new RubyLocalsIndex([])
+    if (result.failed) return new RubyLocalsIndex([], empty)
 
     const document = result.value as DocumentNode
-    if (!document.prismNode) return new RubyLocalsIndex([])
+    if (!document.prismNode) return new RubyLocalsIndex([], empty)
 
     const references = new RubyReferenceCollector()
 
     references.visit(document.prismNode)
 
     const toRange = (reference: RubyReference) => referenceRange(reference, textDocument, text)
+    const herbAttributes = collectHerbAttributes(document)
 
     return new RubyLocalsIndex([
       ...strictLocals(document, references, toRange),
       ...blockLocals(document, references, toRange),
-      ...stateLocals(document, references, toRange)
-    ])
+      ...stateLocals(document, references, toRange, herbAttributes.stateUsages)
+    ], herbAttributes)
   }
 
   at(position: Position): RubyLocal | null {
@@ -88,7 +96,7 @@ function blockLocals(document: DocumentNode, references: RubyReferenceCollector,
   })
 }
 
-function stateLocals(document: DocumentNode, references: RubyReferenceCollector, toRange: (reference: RubyReference) => Range): RubyLocal[] {
+function stateLocals(document: DocumentNode, references: RubyReferenceCollector, toRange: (reference: RubyReference) => Range, attributeUsages: AttributeStateUsage[]): RubyLocal[] {
   const collector = new StateDirectiveCollector()
 
   collector.visit(document)
@@ -97,9 +105,12 @@ function stateLocals(document: DocumentNode, references: RubyReferenceCollector,
     signature.declarations.map(declaration => ({
       name: declaration.name,
       declaration: contentRange(node, declaration.nameOffset, declaration.name.length),
-      usages: references.bareCalls
-        .filter(call => call.name === declaration.name || call.name === `${declaration.name}?`)
-        .map(toRange),
+      usages: [
+        ...references.bareCalls
+          .filter(call => call.name === declaration.name || call.name === `${declaration.name}?`)
+          .map(toRange),
+        ...attributeUsages.filter(usage => usage.name === declaration.name).map(usage => usage.range)
+      ],
       defaultValue: declaration.defaultSource === "" ? undefined : contentRange(node, declaration.defaultOffset, declaration.defaultSource.length)
     }))
   )

--- a/javascript/packages/language-service/src/ruby_locals_index.ts
+++ b/javascript/packages/language-service/src/ruby_locals_index.ts
@@ -14,7 +14,7 @@ import type { ParserService } from "./parser_service"
 import type { DocumentNode, Node, RubyReference, ERBContentNode } from "@herb-tools/core"
 import type { StateSignature } from "@herb-tools/client/directives"
 
-const PARSER_OPTIONS = { prism_program: true, strict_locals: true } as const
+const PARSER_OPTIONS = { prism_program: true, strict_locals: true, action_view_helpers: true } as const
 
 export interface RubyLocal {
   name: string

--- a/javascript/packages/language-service/test/completion_provider.test.ts
+++ b/javascript/packages/language-service/test/completion_provider.test.ts
@@ -1395,3 +1395,142 @@ describe("CompletionProvider", () => {
     })
   })
 })
+
+describe("herb attribute completions", () => {
+  let service: CompletionProvider
+
+  beforeAll(async () => {
+    await Herb.load()
+    service = new CompletionProvider(new ParserService(Herb))
+  })
+
+  const STATES = '<%# herb:state (open: false, attempts: 0, draft: "") %>\n'
+
+  function labels(content: string, line: number, character: number): string[] {
+    const document = TextDocument.create("file:///test.html.erb", "erb", 1, content)
+    const completions = service.getCompletions(document, Position.create(line, character))
+
+    return (completions?.items ?? []).map(item => item.label)
+  }
+
+  function insideValue(content: string, marker: string): [number, number] {
+    const lines = content.split("\n")
+    const line = lines.findIndex(text => text.includes(marker))
+
+    return [line, lines[line].indexOf(marker) + marker.length]
+  }
+
+  it("completes the authored attribute names", () => {
+    const content = "<button data-herb->x</button>"
+
+    expect(labels(content, 0, 18)).toEqual([
+      "data-herb-name",
+      "data-herb-into",
+      "data-herb-set",
+      "data-herb-toggle",
+      "data-herb-increment",
+      "data-herb-decrement",
+      "data-herb-reset",
+      "data-herb-by",
+    ])
+  })
+
+  it("toggle offers only boolean states", () => {
+    const content = STATES + '<button data-herb-toggle="">x</button>'
+
+    expect(labels(content, ...insideValue(content, 'data-herb-toggle="'))).toEqual(["open"])
+  })
+
+  it("increment offers only integer states", () => {
+    const content = STATES + '<button data-herb-increment="">x</button>'
+
+    expect(labels(content, ...insideValue(content, 'data-herb-increment="'))).toEqual(["attempts"])
+  })
+
+  it("decrement offers only integer states", () => {
+    const content = STATES + '<button data-herb-decrement="">x</button>'
+
+    expect(labels(content, ...insideValue(content, 'data-herb-decrement="'))).toEqual(["attempts"])
+  })
+
+  it("reset offers every state", () => {
+    const content = STATES + '<button data-herb-reset="">x</button>'
+
+    expect(labels(content, ...insideValue(content, 'data-herb-reset="'))).toEqual(["open", "attempts", "draft"])
+  })
+
+  it("set offers states and event prefixes", () => {
+    const content = STATES + '<button data-herb-set="">x</button>'
+    const offered = labels(content, ...insideValue(content, 'data-herb-set="'))
+
+    expect(offered).toContain("open")
+    expect(offered).toContain("draft")
+    expect(offered).toContain("click->")
+    expect(offered).toContain("pointerdown->")
+    expect(offered).toContain("transitionend->")
+  })
+
+  it("narrows the events to the typed prefix", () => {
+    const content = STATES + '<button data-herb-set="pointer">x</button>'
+    const offered = labels(content, ...insideValue(content, 'data-herb-set="pointer'))
+
+    expect(offered).toContain("pointerup->")
+    expect(offered).not.toContain("click->")
+  })
+
+  it("set completes a boolean assignment's value", () => {
+    const content = STATES + '<button data-herb-set="open=">x</button>'
+
+    expect(labels(content, ...insideValue(content, 'data-herb-set="open='))).toEqual(["true", "false"])
+  })
+
+  it("set offers the empty string for a string assignment", () => {
+    const content = STATES + '<button data-herb-set="draft=">x</button>'
+
+    expect(labels(content, ...insideValue(content, 'data-herb-set="draft='))).toEqual(["''"])
+  })
+
+  it("chains the suggestion popup through an event and a state", () => {
+    const content = STATES + '<button data-herb-set="">x</button>'
+    const document = TextDocument.create("file:///test.html.erb", "erb", 1, content)
+    const [line, character] = insideValue(content, 'data-herb-set="')
+    const completions = service.getCompletions(document, Position.create(line, character))
+    const items = completions?.items ?? []
+
+    const event = items.find(item => item.label === "click->")
+    const state = items.find(item => item.label === "open")
+    const other = items.find(item => item.label === "draft")
+
+    expect(event?.command?.command).toBe("editor.action.triggerSuggest")
+    expect(state?.command?.command).toBe("editor.action.triggerSuggest")
+    expect(other?.textEdit && "newText" in other.textEdit && other.textEdit.newText).toBe("draft=$0")
+  })
+
+  it("set offers no events after an event prefix", () => {
+    const content = STATES + '<button data-herb-set="change->">x</button>'
+    const offered = labels(content, ...insideValue(content, 'data-herb-set="change->'))
+
+    expect(offered).toContain("open")
+    expect(offered).not.toContain("click->")
+  })
+
+  it("offers an item state only inside its loop", () => {
+    const content =
+      '<%# herb:state (open: false) %>\n' +
+      "<% @items.each do |item| %>\n" +
+      '  <%# herb:state (locked: true) %>\n' +
+      '  <button data-herb-toggle="">in</button>\n' +
+      "<% end %>\n" +
+      '<button data-herb-toggle="">out</button>'
+
+    expect(labels(content, 3, 28)).toEqual(["open", "locked"])
+    expect(labels(content, 5, 26)).toEqual(["open"])
+  })
+
+  it("into offers the collections the template names", () => {
+    const content = '<ul data-herb-name="messages"><% @m.each do |m| %><li id="<%= m %>">x</li><% end %></ul>\n<form data-herb-into=""></form>'
+
+    expect(labels(content, ...insideValue(content, 'data-herb-into="'))).toEqual(["messages"])
+  })
+})
+

--- a/javascript/packages/language-service/test/completion_provider.test.ts
+++ b/javascript/packages/language-service/test/completion_provider.test.ts
@@ -1514,6 +1514,33 @@ describe("herb attribute completions", () => {
     expect(offered).not.toContain("click->")
   })
 
+  it("completes herb keys inside a tag helper's data hash", () => {
+    const content = '<%= tag.button "x", data: { herb_t } %>'
+    const offered = labels(content, 0, content.indexOf("herb_t") + 6)
+
+    expect(offered).toEqual(["herb_toggle:"])
+  })
+
+  it("offers every herb key at an empty data hash", () => {
+    const content = '<%= tag.button "x", data: {  } %>'
+    const offered = labels(content, 0, content.indexOf("{ ") + 2)
+
+    expect(offered).toContain("herb_set:")
+    expect(offered).toContain("herb_into:")
+  })
+
+  it("completes a state inside a data hash value", () => {
+    const content = STATES + '<%= tag.button "x", data: { herb_toggle: "" } %>'
+
+    expect(labels(content, ...insideValue(content, 'herb_toggle: "'))).toEqual(["open"])
+  })
+
+  it("runs the set grammar inside a data hash value", () => {
+    const content = STATES + '<%= tag.button "x", data: { herb_set: "open=" } %>'
+
+    expect(labels(content, ...insideValue(content, 'herb_set: "open='))).toEqual(["true", "false"])
+  })
+
   it("offers an item state only inside its loop", () => {
     const content =
       '<%# herb:state (open: false) %>\n' +

--- a/javascript/packages/language-service/test/completions.test.ts
+++ b/javascript/packages/language-service/test/completions.test.ts
@@ -37,6 +37,31 @@ describe("doComplete", () => {
     })
   })
 
+  describe("herb attributes", () => {
+    test("offers the herb attribute names on a plain element", () => {
+      const service = createService()
+      const document = createDocument("<div ></div>")
+      const html = service.parseHTMLDocument(document)
+      const completions = service.doComplete(document, Position.create(0, 5), html)
+      const labels = completions.items.map(item => item.label)
+
+      expect(labels).toContain("data-herb-toggle")
+      expect(labels).toContain("data-herb-into")
+    })
+
+    test("offers the herb attribute names inside a tag helper's data hash", () => {
+      const service = createService()
+      const source = '<%= tag.button data: { controller: "x",  } %>'
+      const document = createDocument(source)
+      const html = service.parseHTMLDocument(document)
+      const completions = service.doComplete(document, Position.create(0, source.indexOf('"x",') + 5), html)
+      const labels = completions.items.map(item => String(item.label))
+
+      expect(labels).toContain("herb_toggle")
+      expect(labels).toContain("herb_into")
+    })
+  })
+
   describe("ActionView tag helpers", () => {
     test("provides attribute value completions for data-controller", () => {
       const service = createService()

--- a/javascript/packages/language-service/test/definition_provider.test.ts
+++ b/javascript/packages/language-service/test/definition_provider.test.ts
@@ -49,6 +49,44 @@ describe("DefinitionProvider", () => {
     return document.getText(link.originSelectionRange)
   }
 
+  describe("herb declarations", () => {
+    function targeted(service: DefinitionProvider, content: string, target: string, offset = 1) {
+      const document = TextDocument.create(VIEW_URI, "erb", 1, content)
+      const position = document.positionAt(content.indexOf(target) + offset)
+      const links = service.getDefinition(document, position, { framework: "actionview" })
+
+      return links.map(link => document.getText(link.targetSelectionRange))
+    }
+
+    it("jumps from a state read to its declaration", () => {
+      const service = createService()
+      const content = '<%# herb:state (pending: false) %>\n<p><%= pending? %></p>'
+
+      expect(targeted(service, content, "pending?")).toEqual(["pending"])
+    })
+
+    it("jumps from an action attribute to the declaration", () => {
+      const service = createService()
+      const content = '<%# herb:state (open: false) %>\n<button data-herb-toggle="open">x</button>'
+
+      expect(targeted(service, content, 'toggle="open', 8)).toEqual(["open"])
+    })
+
+    it("jumps from the default value to the declaration", () => {
+      const service = createService()
+      const content = '<%# herb:state (open: false) %>\n<p><%= open %></p>'
+
+      expect(targeted(service, content, "false")).toEqual(["open"])
+    })
+
+    it("jumps from data-herb-into to the collection it names", () => {
+      const service = createService()
+      const content = '<ul data-herb-name="messages"><% @m.each do |m| %><li id="<%= m %>">x</li><% end %></ul>\n<form data-herb-into="messages"></form>'
+
+      expect(targeted(service, content, "data-herb-into")).toEqual(["messages"])
+    })
+  })
+
   describe("qualified partial names", () => {
     it("resolves a partial relative to app/views", () => {
       const service = createService("/project/app/views/events/_featured_home.html.erb")

--- a/javascript/packages/language-service/test/document_highlight_provider.test.ts
+++ b/javascript/packages/language-service/test/document_highlight_provider.test.ts
@@ -64,6 +64,66 @@ describe("DocumentHighlightProvider", () => {
     })
   })
 
+  describe("herb action attributes", () => {
+    const template = dedent`
+      <%# herb:state (open: false, attempts: 0) %>
+
+      <button data-herb-toggle="open">Details</button>
+      <button data-herb-set="click->open=false,attempts=0">Reset</button>
+      <button data-herb-increment="attempts" data-herb-by="2">More</button>
+      <% if open %><nav>menu</nav><% end %>
+    `
+
+    function texts(highlights: ReturnType<typeof getHighlights>) {
+      const lines = template.split("\n")
+
+      return highlights.map(highlight => lines[highlight.range.start.line].slice(highlight.range.start.character, highlight.range.end.character))
+    }
+
+    it("counts an action attribute as a read of the state", () => {
+      expect(texts(getHighlights(template, 5, 7))).toEqual(["open", "open", "open", "open", "false"])
+    })
+
+    it("resolves the state from inside the attribute value", () => {
+      expect(texts(getHighlights(template, 2, 28))).toEqual(["open", "open", "open", "open", "false"])
+    })
+
+    it("collects a name from every attribute that writes it", () => {
+      const highlights = getHighlights(template, 4, 29)
+
+      expect(texts(highlights)).toEqual(["attempts", "attempts", "attempts", "0"])
+    })
+  })
+
+  describe("slot names", () => {
+    const template = dedent`
+      <ul data-herb-name="messages">
+        <% @messages.each do |message| %>
+          <li id="<%= dom_id(message) %>"><%= message.body %></li>
+        <% end %>
+      </ul>
+      <form data-herb-into="messages"><input name="body"></form>
+    `
+
+    function texts(highlights: ReturnType<typeof getHighlights>) {
+      const lines = template.split("\n")
+
+      return highlights.map(highlight => lines[highlight.range.start.line].slice(highlight.range.start.character, highlight.range.end.character))
+    }
+
+    it("links a send target to the collection it names", () => {
+      expect(texts(getHighlights(template, 5, 25))).toEqual(["messages", 'data-herb-into="messages"'])
+    })
+
+    it("resolves from the attribute name as well as its value", () => {
+      expect(texts(getHighlights(template, 5, 10))).toEqual(["messages", 'data-herb-into="messages"'])
+    })
+
+    it("links the collection name to the sends naming it", () => {
+      expect(texts(getHighlights(template, 0, 22))).toEqual(["messages", 'data-herb-into="messages"'])
+    })
+  })
+
   describe("strict locals", () => {
     const partial = dedent`
       <%# locals: (title:, count: 0) %>

--- a/javascript/packages/language-service/test/document_highlight_provider.test.ts
+++ b/javascript/packages/language-service/test/document_highlight_provider.test.ts
@@ -27,6 +27,43 @@ describe("DocumentHighlightProvider", () => {
     return service.getDocumentHighlights(document, Position.create(line, character))
   }
 
+  describe("declared states", () => {
+    const template = dedent`
+      <%# herb:state (pending: false, failed: false) %>
+
+      <p><%= pending? %></p>
+      <% if failed %>
+        <span>not sent</span>
+      <% end %>
+    `
+
+    function texts(highlights: ReturnType<typeof getHighlights>) {
+      const lines = template.split("\n")
+
+      return highlights.map(highlight => lines[highlight.range.start.line].slice(highlight.range.start.character, highlight.range.end.character))
+    }
+
+    it("highlights every read of a state from one of them", () => {
+      expect(texts(getHighlights(template, 2, 9))).toEqual(["pending", "pending?", "false"])
+    })
+
+    it("anchors the declaration to the name inside the directive", () => {
+      expect(texts(getHighlights(template, 0, 17))).toEqual(["pending", "pending?", "false"])
+    })
+
+    it("resolves the group from the default value too", () => {
+      expect(texts(getHighlights(template, 0, 26))).toEqual(["pending", "pending?", "false"])
+      expect(texts(getHighlights(template, 0, 42))).toEqual(["failed", "failed", "false"])
+    })
+
+    it("resolves each declaration in a shared directive on its own", () => {
+      const highlights = getHighlights(template, 0, 33)
+
+      expect(texts(highlights)).toEqual(["failed", "failed", "false"])
+      expect(highlights[2].range.start.character).toBe(40)
+    })
+  })
+
   describe("strict locals", () => {
     const partial = dedent`
       <%# locals: (title:, count: 0) %>

--- a/javascript/packages/language-service/test/hover_provider.test.ts
+++ b/javascript/packages/language-service/test/hover_provider.test.ts
@@ -12,6 +12,99 @@ import { Herb } from "@herb-tools/node-wasm"
 
 import type { ParseOptions, ParseResult } from "@herb-tools/core"
 
+describe("herb state hover", () => {
+  let service: HoverProvider
+
+  beforeAll(async () => {
+    await Herb.load()
+    service = new HoverProvider(new ParserService(Herb))
+  })
+
+  function hover(content: string, line: number, character: number): string {
+    const document = TextDocument.create("file:///test.html.erb", "erb", 1, content)
+    const result = service.getHover(document, Position.create(line, character))
+    const contents = result?.contents
+
+    return contents && typeof contents === "object" && "value" in contents ? contents.value : ""
+  }
+
+  const TEMPLATE =
+    '<%# herb:state (pending: false, attempts: 0) %>\n' +
+    "<% @items.each do |item| %>\n" +
+    '  <%# herb:state (locked: true) %>\n' +
+    '  <p><%= locked %></p>\n' +
+    "<% end %>\n" +
+    "<p><%= pending? %></p>\n" +
+    '<button data-herb-increment="attempts">More</button>'
+
+  it("documents a boolean state from a read", () => {
+    const value = hover(TEMPLATE, 5, 9)
+
+    expect(value).toContain("**pending** · Herb Client State")
+    expect(value).toContain("`boolean` · default `false` · one value per rendering")
+    expect(value).toContain("```erb")
+    expect(value).toContain("<%= pending %>")
+    expect(value).toContain('data-herb-toggle="pending"')
+    expect(value).toContain('stateFor(element).set({ pending: true })')
+    expect(value).toContain('<% if pending? %>')
+  })
+
+  it("documents an item state with its loop scope", () => {
+    const value = hover(TEMPLATE, 3, 10)
+
+    expect(value).toContain("**locked** · Herb Client State")
+    expect(value).toContain("one value for each `item`")
+  })
+
+  it("documents an integer state from an action attribute", () => {
+    const value = hover(TEMPLATE, 6, 30)
+
+    expect(value).toContain("**attempts** · Herb Client State")
+    expect(value).toContain("`integer` · default `0` · one value per rendering")
+    expect(value).toContain('data-herb-increment="attempts"')
+    expect(value).toContain('<% if attempts == 0 %>')
+  })
+
+  it("scopes the hover range to the state token inside an attribute", () => {
+    const document = TextDocument.create("file:///test.html.erb", "erb", 1, TEMPLATE)
+    const result = service.getHover(document, Position.create(6, 30))
+
+    expect(document.getText(result?.range)).toBe("attempts")
+  })
+
+  it("documents a state inside a tag helper's data hash", () => {
+    const content =
+      '<%# herb:state (draft: "") %>\n' +
+      '<%= tag.button data: { herb_set: "click->draft=abc" } do %>\n' +
+      "  a\n" +
+      "<% end %>"
+
+    const value = hover(content, 1, content.split("\n")[1].indexOf("draft"))
+
+    expect(value).toContain("**draft** · Herb Client State")
+  })
+
+  it("documents the herb:state directive keyword", () => {
+    const value = hover(TEMPLATE, 0, 6)
+
+    expect(value).toContain("**herb:state** · Herb directive")
+    expect(value).toContain("strict-locals signature")
+  })
+
+  it("documents herb:slots and herb:key", () => {
+    const content = "<%# herb:slots client %>\n<% @items.each do |item| %><%# herb:key item %><li id=\"x\"><%= item %></li><% end %>"
+
+    expect(hover(content, 0, 8)).toContain("**herb:slots** · Herb directive")
+    expect(hover(content, 1, 35)).toContain("**herb:key** · Herb directive")
+  })
+
+  it("says nothing for a plain local", () => {
+    const content = "<%# locals: (title:) %>\n<h1><%= title %></h1>"
+
+    expect(hover(content, 1, 9)).toBe("")
+  })
+})
+
 describe("HoverProvider", () => {
   let parserService: ParserService
   let service: HoverProvider

--- a/javascript/packages/language-service/test/references_provider.test.ts
+++ b/javascript/packages/language-service/test/references_provider.test.ts
@@ -278,3 +278,54 @@ describe("ReferencesProvider", () => {
     expect(referencesAt(services, "app/views/posts/_card.html.erb")).toEqual([])
   })
 })
+
+describe("herb state references", () => {
+  let parserService: ParserService
+
+  beforeAll(async () => {
+    await Herb.load()
+    parserService = new ParserService(Herb)
+  })
+
+  function build(): ReferencesProvider {
+    const definitionProvider = new DefinitionProvider(parserService, () => false, () => null)
+
+    return new ReferencesProvider(definitionProvider, { relativePathFor: () => null, callers: null } as never, { get: () => undefined }, () => null, parserService)
+  }
+
+  function referenceTexts(content: string, target: string, offset = 1, includeDeclaration = true): string[] {
+    const document = TextDocument.create("file:///test.html.erb", "erb", 1, content)
+    const position = document.positionAt(content.indexOf(target) + offset)
+    const locations = build().getReferences(document, position, includeDeclaration)
+
+    return locations.map(location => document.getText(location.range))
+  }
+
+  const TEMPLATE =
+    '<%# herb:state (open: false) %>\n' +
+    '<button data-herb-toggle="open">Details</button>\n' +
+    "<% if open %><nav>menu</nav><% end %>"
+
+  test("finds every reference of a state from a read", () => {
+    expect(referenceTexts(TEMPLATE, "if open", 4).length).toBeGreaterThanOrEqual(3)
+    expect(referenceTexts(TEMPLATE, "if open", 4)).toContain("open")
+  })
+
+  test("leaves the declaration out when asked", () => {
+    const withDeclaration = referenceTexts(TEMPLATE, "if open", 4, true)
+    const without = referenceTexts(TEMPLATE, "if open", 4, false)
+
+    expect(without.length).toBe(withDeclaration.length - 1)
+  })
+
+  test("finds the sends naming a collection", () => {
+    const content =
+      '<ul data-herb-name="messages"><% @m.each do |m| %><li id="<%= m %>">x</li><% end %></ul>\n' +
+      '<form data-herb-into="messages"></form>'
+
+    const texts = referenceTexts(content, 'data-herb-name="messages', 20)
+
+    expect(texts.some(text => text.includes("data-herb-into"))).toBe(true)
+  })
+})
+


### PR DESCRIPTION
This pull request teaches the language service about client state, so the editor understands the vocabulary the runtime already implements.

Hover documents a state's kind, default and scope, and explains the `herb:` directives. Go-to-definition jumps from a read to the `herb:state` that declares it, or from `data-herb-into` to the collection it names. Find-references lists every read, write and action naming a state, and document highlight marks them in place.

Completion offers the `data-herb-*` attributes and the grammar inside `data-herb-set`, including the `event->` prefix, and ranks them above the generic HTML attributes in a template that declares state. The attributes are also exposed through an HTML data provider, so an editor that reads that format gets them without a Herb-specific integration, and in tag helpers as their `data:` hash spelling.

Underneath, the locals index learns about `herb:state` the same way the Rust index does in #2367, so a state read resolves as a defined name.
