### PR TITLE
Client: Write a state in the scope that declares it

### DIFF
--- a/javascript/packages/client/src/state.ts
+++ b/javascript/packages/client/src/state.ts
@@ -413,7 +413,21 @@ export class SlotState {
   }
 
   scopeFor(target: Element | StateScope, name?: string): StateScope | null {
-    if (!(target instanceof Element)) return target
+    if (!(target instanceof Element)) {
+      if (!name || !target.item) return target
+
+      const manifest = this.manifestFor(target.region)
+
+      if (!manifest) return target
+
+      const collection = collectionOf(target.region, target.item)
+      const declaration = collection === null ? null : declared(manifest, name, collection)
+
+      if (declaration !== null && declaration.scope === collection) return target
+      if (declared(manifest, name, null) !== null) return { region: target.region, item: null }
+
+      return target
+    }
 
     for (const region of this.#slots.regions()) {
       if (!containsNode(region, target)) continue
@@ -478,29 +492,41 @@ export class SlotState {
     }
 
     const previous = new Map<string, StateValue>()
+    const scopes = new Map<string, StateScope>()
+    const groups = new Map<StateScope, string[]>()
 
     for (const name of names) {
-      if (this.#declaration(manifest, resolved, name) === null) {
+      const target = this.scopeFor(resolved, name) ?? resolved
+
+      if (this.#declaration(manifest, target, name) === null) {
         this.#reportUnknown(name, resolved)
 
         return false
       }
 
-      previous.set(name, this.#valueOf(name, resolved))
+      const shared = [...groups.keys()].find(candidate => candidate.region === target.region && candidate.item === target.item) ?? target
+
+      groups.set(shared, [...(groups.get(shared) ?? []), name])
+      scopes.set(name, shared)
+      previous.set(name, this.#valueOf(name, shared))
     }
 
     this.#slots.transaction(() => {
       for (const [name, value] of Object.entries(values)) {
-        this.#store(resolved, name, value)
-        this.#writeValueSlots(manifest, resolved, name, value)
+        const target = scopes.get(name) ?? resolved
+
+        this.#store(target, name, value)
+        this.#writeValueSlots(manifest, target, name, value)
       }
 
-      this.#writeConditionals(manifest, resolved, names)
-      this.#writePresence(manifest, resolved, names)
+      for (const [scope, grouped] of groups) {
+        this.#writeConditionals(manifest, scope, grouped)
+        this.#writePresence(manifest, scope, grouped)
+      }
     }, { retain: false })
 
     for (const [name, value] of Object.entries(values)) {
-      this.#announceState(resolved, name, value, previous.get(name) ?? null)
+      this.#announceState(scopes.get(name) ?? resolved, name, value, previous.get(name) ?? null)
     }
 
     return true

--- a/javascript/packages/client/test/actions.test.ts
+++ b/javascript/packages/client/test/actions.test.ts
@@ -11,10 +11,13 @@ const PAGE =
   `<button id="toggle" data-herb-toggle="open">Details</button>` +
   `<button id="both" data-herb-set="pending=false,failed=true">Fail</button>` +
   `<button id="bump" data-herb-increment="attempts" data-herb-by="2">More</button>` +
+  `<button id="combo" data-herb-increment="attempts" data-herb-set="open=true">Both</button>` +
   `<button id="tab-a" data-herb-set="sort=name">A</button>` +
   `<button id="quoted" data-herb-set="sort='hello, world'">Q</button>` +
   `<form id="form" data-herb-set="pending=true"><input id="draft-input" data-herb-reset="blur->sort"></form>` +
   `<input id="typer" data-herb-set="sort=$value">` +
+  `<input id="bound" value="name" data-herb-slot="5:attribute:value">` +
+  `<button id="setter" data-herb-set="sort=date">Date</button>` +
   `<select id="chooser" data-herb-set="sort=$value"><option value="date">date</option></select>` +
   `<div id="menu" data-herb-set="mouseenter->open=true mouseleave->open=false">hover</div>` +
   `<div><!--herb-slot:0:conditional--><!--herb-branch:0:1-->closed<!--/herb-slot:0--></div>` +
@@ -44,7 +47,8 @@ const PAGE =
           { name: "sort", kind: "string", default: '"name"', scope: "region" },
           { name: "starred", kind: "boolean", default: "false", scope: 2 },
         ],
-        reads: { attempts: [1] },
+        reads: { attempts: [1], sort: [5] },
+        bound: { sort: [5] },
         conditionals: {
           0: { arms: [["open", null, 0]], else: 1 },
           4: { arms: [["starred", null, 0]], else: 1 },
@@ -101,6 +105,24 @@ describe("declarative actions", () => {
     expect(state.getState("pending")).toBe(false)
     expect(state.getState("failed")).toBe(true)
     expect(order).toEqual(["pending", "failed"])
+  })
+
+  test("a set writes through to the bound input", () => {
+    click("#setter")
+
+    expect(state.getState("sort")).toBe("date")
+
+    const bound = document.querySelector<HTMLInputElement>("#bound")!
+
+    expect(bound.getAttribute("value")).toBe("date")
+    expect(bound.value).toBe("date")
+  })
+
+  test("two action attributes on one element both run", () => {
+    click("#combo")
+
+    expect(state.getState("attempts")).toBe(1)
+    expect(state.getState("open")).toBe(true)
   })
 
   test("increment honours data-herb-by", () => {

--- a/javascript/packages/client/test/state-scoped.test.ts
+++ b/javascript/packages/client/test/state-scoped.test.ts
@@ -181,6 +181,15 @@ describe("declared state", () => {
     expect(slots.revert(report.token!)).toBe(true)
   })
 
+  test("a scoped write to a region state reaches the region", () => {
+    const scope = state.scopeFor(document.querySelector("#a")!)!
+
+    expect(state.setState({ pending: true }, { scope })).toBe(true)
+
+    expect(state.getState("pending")).toBe(true)
+    expect(document.querySelector("div")?.textContent).toContain("Sending…")
+  })
+
   test("a rekeyed item keeps its scoped state", () => {
     const first = document.querySelector("#a")!
     const scope = state.scopeFor(first, "starred")!


### PR DESCRIPTION
This pull request makes a scoped write resolve the way a read does.

`SlotState` stored values in one page-level map, so two renders of a partial shared a single `open`, and an item state written on one row moved every row. The store is keyed by scope now, with server state living in a page-level scope beside it.

A write resolves from an element to the nearest scope that declares the name, which is what makes an action need no scope syntax:

```erb
<%# herb:state (editing_id: nil) %>

<% @messages.each do |message| %>
  <%# herb:state (pending: false) %>

  <button data-herb-toggle="pending">Retry</button>
  <button data-herb-set="editing_id=<%= message.id %>">Edit</button>
<% end %>
```

Both buttons carry the same kind of attribute and land in different scopes, because a name belongs to exactly one scope and the walk finds it.
