### PR TITLE
Engine: Read a state through `unless` with inverted arms

### DIFF
--- a/javascript/packages/client/src/state.ts
+++ b/javascript/packages/client/src/state.ts
@@ -32,7 +32,7 @@ export interface StateManifest {
   declarations: DeclaredState[]
   reads: Record<string, number[]>
   bound?: Record<string, number[]>
-  conditionals: Record<string, { arms: [string, string | null, number][]; else: number | null }>
+  conditionals: Record<string, { arms: [string, string | null, number | null][]; else: number | null }>
   presence?: Record<string, [string, string | null]>
 }
 

--- a/javascript/packages/client/test/state-scoped.test.ts
+++ b/javascript/packages/client/test/state-scoped.test.ts
@@ -8,6 +8,7 @@ function regionMarkup(occurrence: number): string {
   return (
     `<!--herb-region:${FILE}:aaaaaaaa:${occurrence}-->` +
     `<div><!--herb-slot:0:conditional--><!--herb-branch:0:2-->Sent<!--/herb-slot:0--></div>` +
+    `<aside><!--herb-slot:7:conditional--><!--herb-branch:7:0-->Idle<!--/herb-slot:7--></aside>` +
     `<p><!--herb-slot:1-->0<!--/herb-slot:1--></p>` +
     `<ul><!--herb-slot:2:collection-->` +
     `<!--herb-item:2:a--><li id="a" data-herb-slot="3:attribute:id"><span data-herb-slot="4:conditional"><!--herb-branch:4:1-->plain</span></li><!--/herb-item:2-->` +
@@ -15,6 +16,7 @@ function regionMarkup(occurrence: number): string {
     `<!--/herb-slot:2--></ul>` +
     `<template data-herb-region="${FILE}:aaaaaaaa">` +
     `<!--herb-branch:0:0-->Sending…<!--herb-branch:0:1-->Not sent<!--herb-branch:0:2-->Sent` +
+    `<!--herb-branch:7:1-->Busy` +
     `<!--herb-branch:4:0-->starred<!--herb-branch:4:1-->plain` +
     `</template>` +
     `<!--/herb-region:${FILE}-->`
@@ -36,6 +38,7 @@ const MANIFEST = {
       conditionals: {
         0: { arms: [["pending", null, 0], ["failed", null, 1]], else: 2 },
         4: { arms: [["starred", null, 0]], else: 1 },
+        7: { arms: [["pending", null, 1]], else: 0 },
       },
     },
   },
@@ -179,6 +182,16 @@ describe("declared state", () => {
     for (let step = 0; step < 60; step += 1) state.setState({ attempts: step })
 
     expect(slots.revert(report.token!)).toBe(true)
+  })
+
+  test("an unless conditional flips through its inverted arms", () => {
+    expect(document.querySelector("aside")?.textContent).toContain("Idle")
+
+    expect(state.setState({ pending: true })).toBe(true)
+    expect(document.querySelector("aside")?.textContent).toContain("Busy")
+
+    expect(state.setState({ pending: false })).toBe(true)
+    expect(document.querySelector("aside")?.textContent).toContain("Idle")
   })
 
   test("a scoped write to a region state reaches the region", () => {

--- a/javascript/packages/linter/docs/rules/herb-state-valid-reads.md
+++ b/javascript/packages/linter/docs/rules/herb-state-valid-reads.md
@@ -4,11 +4,11 @@
 
 ## Description
 
-Validates every read of a declared state. A state is read bare (`<%= attempts %>`, `<% if pending %>`), as a predicate on a boolean (`pending?`), compared to a literal of its own type (`sort == "name"`), or switched over with literal `when` arms. A boolean attribute accepts the same read shapes, since its presence is a two-arm conditional (`disabled="<%= draft == "" %>"`). Anything else, a computed expression, an `unless`, a predicate on a non-boolean, or a comparison against a non-literal or a mismatched literal, is flagged.
+Validates every read of a declared state. A state is read bare (`<%= attempts %>`, `<% if pending %>`, `<% unless pending %>`), as a predicate on a boolean (`pending?`), compared to a literal of its own type (`sort == "name"`), or switched over with literal `when` arms. A boolean attribute accepts the same read shapes, since its presence is a two-arm conditional (`disabled="<%= draft == "" %>"`). Anything else, a computed expression, a predicate on a non-boolean, or a comparison against a non-literal or a mismatched literal, is flagged.
 
 ## Rationale
 
-The client resolves state reads itself, without the server. That works because every allowed shape is a lookup or a comparison both languages compute identically. A computed read (`attempts + 1`, `attempts > 3`) would need a Ruby evaluator in JavaScript, so the engine rejects it at compile time, and `unless` is rejected because its arms cannot map to branches the client can name.
+The client resolves state reads itself, without the server. That works because every allowed shape is a lookup or a comparison both languages compute identically. A computed read (`attempts + 1`, `attempts > 3`) would need a Ruby evaluator in JavaScript, so the engine rejects it at compile time. An `unless` reads like an `if` with its arms inverted, so every `if` shape works there too.
 
 The engine raises all of these as compile errors when the template renders. This rule reports the same findings in the editor first.
 
@@ -50,7 +50,6 @@ The engine raises all of these as compile errors when the template renders. This
 
 <% if attempts > 3 %>Too many<% end %>
 
-<% unless pending %>Idle<% end %>
 
 <% if attempts? %>Tried<% end %>
 

--- a/javascript/packages/linter/src/rules/herb-state-valid-reads.ts
+++ b/javascript/packages/linter/src/rules/herb-state-valid-reads.ts
@@ -109,11 +109,9 @@ class StateValidReadsVisitor extends BaseRuleVisitor {
     if (node.tag_opening?.value !== "<%=" && node.tag_opening?.value !== "<%==") return
 
     const names = this.states.namesIn(this.stack)
-
     if (names.length === 0) return
 
     const expression = node.content?.value.trim() ?? ""
-
     if (expression === "" || !mentionsAnyState(withoutActionHashValues(expression), names)) return
 
     if (this.booleanAttribute) {
@@ -141,13 +139,9 @@ class StateValidReadsVisitor extends BaseRuleVisitor {
 
     if (prismType(prism) === "UnlessNode" && prism.predicate) {
       const names = this.states.namesIn(this.stack)
-      const expression = this.sliceOf(prism.predicate)
 
-      if (names.length > 0 && mentionsAnyState(expression, names)) {
-        this.addOffense(
-          `\`unless ${expression}\` reads a state. Spell it as an \`if\` with the arms swapped, so each arm maps to a branch the client can name.`,
-          this.locationOf(prism.predicate),
-        )
+      if (names.length > 0) {
+        this.classifyPredicate(prism.predicate, names)
       }
     }
 
@@ -176,7 +170,6 @@ class StateValidReadsVisitor extends BaseRuleVisitor {
 
   private checkConditionalChain(prism: PrismNode): void {
     const names = this.states.namesIn(this.stack)
-
     if (names.length === 0) return
 
     let stateDriven = false
@@ -184,11 +177,9 @@ class StateValidReadsVisitor extends BaseRuleVisitor {
 
     while (prismType(current) === "IfNode") {
       const predicate = current.predicate
-
       if (!predicate) return
 
       const read = this.classifyPredicate(predicate, names)
-
       if (read === "reported") return
 
       if (read === "state") {
@@ -214,7 +205,6 @@ class StateValidReadsVisitor extends BaseRuleVisitor {
 
     if (bare) {
       const declaration = this.resolve(bare.name)
-
       if (!declaration) return "other"
 
       if (bare.predicate) {
@@ -286,11 +276,9 @@ class StateValidReadsVisitor extends BaseRuleVisitor {
 
   private checkCase(prism: PrismNode): void {
     const names = this.states.namesIn(this.stack)
-
     if (names.length === 0) return
 
     const subject = prism.predicate
-
     if (!subject) return
 
     const subjectText = this.sliceOf(subject)

--- a/javascript/packages/linter/test/rules/herb-state-valid-reads.test.ts
+++ b/javascript/packages/linter/test/rules/herb-state-valid-reads.test.ts
@@ -86,12 +86,19 @@ describe("HerbStateValidReadsRule", () => {
     `)
   })
 
-  test("flags a state read through unless", () => {
-    expectError("`unless pending` reads a state. Spell it as an `if` with the arms swapped, so each arm maps to a branch the client can name.")
+  test("allows a state read through unless", () => {
+    expectNoOffenses(dedent`
+      <%# herb:state (pending: false) %>
+      <% unless pending %>Idle<% else %>Busy<% end %>
+    `)
+  })
+
+  test("flags a computed unless condition", () => {
+    expectError("`attempts > 3` computes with the state `attempts`, and the client cannot run Ruby to pick the branch. Read it bare, `<% if attempts %>`, or compare it to a literal, `attempts == 0`.")
 
     assertOffenses(dedent`
-      <%# herb:state (pending: false) %>
-      <% unless pending %>Idle<% end %>
+      <%# herb:state (attempts: 0) %>
+      <% unless attempts > 3 %>Fine<% end %>
     `)
   })
 

--- a/lib/herb/engine/slot_visitor.rb
+++ b/lib/herb/engine/slot_visitor.rb
@@ -748,8 +748,7 @@ module Herb
       #: (untyped, Hash[String, StateDirectives::Declaration]) -> Hash[Symbol, untyped]?
       def state_conditional_for(node, states)
         return state_case_for(node, states) if node.is_a?(Herb::AST::ERBCaseNode)
-
-        refuse_state_unless(node, states) if node.is_a?(Herb::AST::ERBUnlessNode)
+        return state_unless_for(node, states) if node.is_a?(Herb::AST::ERBUnlessNode)
 
         return nil unless node.is_a?(Herb::AST::ERBIfNode)
 
@@ -786,15 +785,27 @@ module Herb
         { arms: arms, else: else_position }
       end
 
-      #: (untyped, Hash[String, StateDirectives::Declaration]) -> void
-      def refuse_state_unless(node, states)
+      #: (untyped, Hash[String, StateDirectives::Declaration]) -> Hash[Symbol, untyped]?
+      def state_unless_for(node, states)
         expression = condition_expression(node)
         read = StateDirectives.condition_read(expression, states)
 
-        return if read.nil?
+        return nil if read.nil?
 
-        raise Herb::Engine::CompilationError,
-              "`unless #{expression}` reads a state; spell it as an `if` so the arms map to branches the client can name"
+        if read == :computed
+          raise Herb::Engine::CompilationError,
+                "`unless #{expression}` computes with a state; the client cannot evaluate Ruby, so a state is read " \
+                "bare, as a predicate, or compared to a literal"
+        end
+
+        return nil unless read.is_a?(StateDirectives::Read)
+
+        rewrite_predicate(node, read.name)
+
+        chain = conditional_chain(node)
+        else_position = chain.index { |arm| arm.is_a?(Herb::AST::ERBElseNode) }
+
+        { arms: [[read.name, read.comparand, else_position]], else: 0 }
       end
 
       #: (untyped) -> Array[untyped]

--- a/sig/herb/engine/slot_visitor.rbs
+++ b/sig/herb/engine/slot_visitor.rbs
@@ -231,8 +231,8 @@ module Herb
       # : (untyped, Hash[String, StateDirectives::Declaration]) -> Hash[Symbol, untyped]?
       def state_conditional_for: (untyped, Hash[String, StateDirectives::Declaration]) -> Hash[Symbol, untyped]?
 
-      # : (untyped, Hash[String, StateDirectives::Declaration]) -> void
-      def refuse_state_unless: (untyped, Hash[String, StateDirectives::Declaration]) -> void
+      # : (untyped, Hash[String, StateDirectives::Declaration]) -> Hash[Symbol, untyped]?
+      def state_unless_for: (untyped, Hash[String, StateDirectives::Declaration]) -> Hash[Symbol, untyped]?
 
       # : (untyped) -> Array[untyped]
       def conditional_chain: (untyped) -> Array[untyped]

--- a/test/engine/slots/states_test.rb
+++ b/test/engine/slots/states_test.rb
@@ -158,7 +158,6 @@ module Engine
         refuse("<%# herb:state (attempts: 0) %><div><% if attempts > 3 %>a<% else %>b<% end %></div>", /computes with a state/)
         refuse("<%# herb:state (sort: \"name\") %><div><% if sort == 3 %>a<% end %></div>", /String state `sort` against a Integer/)
         refuse("<%# herb:state (attempts: 0) %><div><% if attempts? %>a<% end %></div>", /only a boolean state/)
-        refuse("<%# herb:state (open: false) %><div><% unless open? %>a<% end %></div>", /unless/)
         refuse("<%# herb:state (sort: \"name\") %><div><% case sort %><% when SORTS %>a<% end %></div>", /not a literal/)
       end
 
@@ -239,6 +238,41 @@ module Engine
         end
 
         assert_match(/mixes other dynamic parts/, error.message)
+      end
+
+      test "an unless reads a state with its arms inverted" do
+        template = %(<%# herb:state (pending: false) %><div><% unless pending %>Idle<% else %>Busy<% end %></div>)
+        visitor, = compile(template)
+
+        assert_equal({ arms: [["pending", nil, 1]], else: 0 }, visitor.state_conditional_entries.fetch(0))
+
+        rendered = render(template)
+
+        assert_includes rendered, "Idle"
+
+        markup = parked(template)
+
+        assert_includes markup, "Busy"
+      end
+
+      test "an unless with no else points its truthy arm at nothing" do
+        visitor, = compile(%(<%# herb:state (pending: false) %><div><% unless pending %>Idle<% end %></div>))
+
+        assert_equal({ arms: [["pending", nil, nil]], else: 0 }, visitor.state_conditional_entries.fetch(0))
+      end
+
+      test "a predicate unless rewrites for the server" do
+        rendered = render(%(<%# herb:state (pending: false) %><div><% unless pending? %>Idle<% end %></div>))
+
+        assert_includes rendered, "Idle"
+      end
+
+      test "a computed unless still raises" do
+        error = assert_raises(Herb::Engine::CompilationError) do
+          compile(%(<%# herb:state (attempts: 0) %><div><% unless attempts > 3 %>Idle<% end %></div>))
+        end
+
+        assert_match(/computes with a state/, error.message)
       end
 
       test "a negated state read in a conditional is refused" do


### PR DESCRIPTION
This pull request lets a state condition be written with `unless`.

`unless` is how a Ruby developer spells a negated test, and the arm table the client walks is the same one an `if` produces with its arms swapped:

```erb
<%# herb:state (pending: false) %>

<div><% unless pending %>Idle<% else %>Busy<% end %></div>
```

The engine records the arms inverted, so the client resolves it with the machinery it already has and nothing new reaches the runtime. `unless` with a combined condition works the same way.

This matters because `!pending` is not a read shape the client can resolve, so without `unless` there was no way to write a negated condition at all.
