### PR TITLE
Engine: Compare states with ordered, negated, and state-to-state operators

### DIFF
--- a/javascript/packages/client/src/state.ts
+++ b/javascript/packages/client/src/state.ts
@@ -32,9 +32,13 @@ export interface StateManifest {
   declarations: DeclaredState[]
   reads: Record<string, number[]>
   bound?: Record<string, number[]>
-  conditionals: Record<string, { arms: [string, string | null, number | null][]; else: number | null }>
-  presence?: Record<string, [string, string | null]>
+  conditionals: Record<string, { arms: ConditionalArm[]; else: number | null }>
+  presence?: Record<string, [string, StateComparand] | [string, StateComparand, string]>
 }
+
+export type StateComparand = string | null | { state: string }
+
+export type ConditionalArm = [string, StateComparand, number | null] | [string, StateComparand, number | null, string]
 
 export interface StateScope {
   region: Region
@@ -722,7 +726,8 @@ export class SlotState {
       for (const slot of this.#scopedSlots(scope, Number(indexKey))) {
         const arm = conditional.arms.find(([, , branch]) => branch === slot.branch)
 
-        if (arm && arm[0] === name) return arm[1] === null ? true : parseLiteral(arm[1])
+        if (arm && arm[0] === name && arm[3] === undefined && typeof arm[1] !== "object") return arm[1] === null ? true : parseLiteral(arm[1])
+        if (arm && arm[0] === name) return undefined
         if (slot.branch === conditional.else || slot.branch === null) {
           const declaration = this.#declaration(manifest, scope, name)
 
@@ -753,11 +758,13 @@ export class SlotState {
   }
 
   #writePresence(manifest: StateManifest, scope: StateScope, changed: string[]): void {
-    for (const [indexKey, [name, comparand]] of Object.entries(manifest.presence ?? {})) {
-      if (!changed.includes(name)) continue
+    for (const [indexKey, [name, comparand, operator]] of Object.entries(manifest.presence ?? {})) {
+      const against = typeof comparand === "object" && comparand !== null ? comparand.state : null
+
+      if (!changed.includes(name) && (against === null || !changed.includes(against))) continue
 
       const value = this.#valueOf(name, scope)
-      const present = comparand === null ? rubyTruthy(value) : value === parseLiteral(comparand)
+      const present = armMatches(value, comparand, operator, (against) => this.#valueOf(against, scope))
 
       for (const slot of this.#scopedSlots(scope, Number(indexKey))) {
         this.#slots.setBooleanAttribute(slot, present)
@@ -767,7 +774,7 @@ export class SlotState {
 
   #writeConditionals(manifest: StateManifest, scope: StateScope, changed: string[]): void {
     for (const [indexKey, conditional] of Object.entries(manifest.conditionals)) {
-      const mentions = conditional.arms.some(([name]) => changed.includes(name))
+      const mentions = conditional.arms.some((arm) => armMentions(arm, changed))
       if (!mentions) continue
 
       const target = this.#targetBranch(conditional, scope)
@@ -787,10 +794,10 @@ export class SlotState {
   }
 
   #targetBranch(conditional: StateManifest["conditionals"][string], scope: StateScope): number | null {
-    for (const [name, comparand, branch] of conditional.arms) {
+    for (const [name, comparand, branch, operator] of conditional.arms) {
       const value = this.#valueOf(name, scope)
 
-      if (comparand === null ? rubyTruthy(value) : value === parseLiteral(comparand)) return branch
+      if (armMatches(value, comparand, operator, (against) => this.#valueOf(against, scope))) return branch
     }
 
     return conditional.else
@@ -1094,6 +1101,32 @@ export function boundValue(element: Element, kind: StateKind): StateValue {
   const raw = (element as HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement).value
 
   return coerceState(raw, kind)
+}
+
+function armMentions(arm: ConditionalArm, changed: string[]): boolean {
+  const [name, comparand] = arm
+
+  if (changed.includes(name)) return true
+
+  return typeof comparand === "object" && comparand !== null && changed.includes(comparand.state)
+}
+
+function armMatches(value: StateValue, comparand: StateComparand, operator: string | undefined, other: (name: string) => StateValue): boolean {
+  if (comparand === null) return rubyTruthy(value)
+
+  const literal = typeof comparand === "object" ? other(comparand.state) : parseLiteral(comparand)
+
+  if (operator === undefined) return value === literal
+  if (operator === "!=") return value !== literal
+  if (typeof value !== "number" || typeof literal !== "number") return false
+
+  switch (operator) {
+    case ">": return value > literal
+    case ">=": return value >= literal
+    case "<": return value < literal
+    case "<=": return value <= literal
+    default: return false
+  }
 }
 
 function rubyTruthy(value: StateValue): boolean {

--- a/javascript/packages/client/test/state-scoped.test.ts
+++ b/javascript/packages/client/test/state-scoped.test.ts
@@ -9,6 +9,10 @@ function regionMarkup(occurrence: number): string {
     `<!--herb-region:${FILE}:aaaaaaaa:${occurrence}-->` +
     `<div><!--herb-slot:0:conditional--><!--herb-branch:0:2-->Sent<!--/herb-slot:0--></div>` +
     `<aside><!--herb-slot:7:conditional--><!--herb-branch:7:0-->Idle<!--/herb-slot:7--></aside>` +
+    `<footer><!--herb-slot:8:conditional--><!--herb-branch:8:1-->Few<!--/herb-slot:8--></footer>` +
+    `<video data-herb-slot="9:boolean_attribute:muted"></video>` +
+    `<b><!--herb-slot:10:conditional--><!--herb-branch:10:0-->Named<!--/herb-slot:10--></b>` +
+    `<i><!--herb-slot:11:conditional--><!--herb-branch:11:1-->Behind<!--/herb-slot:11--></i>` +
     `<p><!--herb-slot:1-->0<!--/herb-slot:1--></p>` +
     `<ul><!--herb-slot:2:collection-->` +
     `<!--herb-item:2:a--><li id="a" data-herb-slot="3:attribute:id"><span data-herb-slot="4:conditional"><!--herb-branch:4:1-->plain</span></li><!--/herb-item:2-->` +
@@ -17,6 +21,9 @@ function regionMarkup(occurrence: number): string {
     `<template data-herb-region="${FILE}:aaaaaaaa">` +
     `<!--herb-branch:0:0-->Sending…<!--herb-branch:0:1-->Not sent<!--herb-branch:0:2-->Sent` +
     `<!--herb-branch:7:1-->Busy` +
+    `<!--herb-branch:8:0-->Many` +
+    `<!--herb-branch:10:1-->Dated` +
+    `<!--herb-branch:11:0-->Ahead` +
     `<!--herb-branch:4:0-->starred<!--herb-branch:4:1-->plain` +
     `</template>` +
     `<!--/herb-region:${FILE}-->`
@@ -33,13 +40,20 @@ const MANIFEST = {
         { name: "failed", kind: "boolean", default: "false", scope: "region" },
         { name: "attempts", kind: "integer", default: "0", scope: "region" },
         { name: "starred", kind: "boolean", default: "false", scope: 2 },
+        { name: "sort", kind: "string", default: '"name"', scope: "region" },
+        { name: "counter1", kind: "integer", default: "0", scope: "region" },
+        { name: "counter2", kind: "integer", default: "5", scope: "region" },
       ],
       reads: { attempts: [1] },
       conditionals: {
         0: { arms: [["pending", null, 0], ["failed", null, 1]], else: 2 },
         4: { arms: [["starred", null, 0]], else: 1 },
         7: { arms: [["pending", null, 1]], else: 0 },
+        8: { arms: [["attempts", "3", 0, ">"]], else: 1 },
+        10: { arms: [["sort", '"date"', 0, "!="]], else: 1 },
+        11: { arms: [["counter1", { state: "counter2" }, 0, ">"]], else: 1 },
       },
+      presence: { 9: ["attempts", "2", ">="] },
     },
   },
 }
@@ -182,6 +196,38 @@ describe("declared state", () => {
     for (let step = 0; step < 60; step += 1) state.setState({ attempts: step })
 
     expect(slots.revert(report.token!)).toBe(true)
+  })
+
+  test("a state compares against another state, from either side", () => {
+    expect(document.querySelector("i")?.textContent).toContain("Behind")
+
+    state.setState({ counter1: 9 })
+    expect(document.querySelector("i")?.textContent).toContain("Ahead")
+
+    state.setState({ counter2: 12 })
+    expect(document.querySelector("i")?.textContent).toContain("Behind")
+  })
+
+  test("a negated equality arm matches everything but its literal", () => {
+    expect(document.querySelector("b")?.textContent).toContain("Named")
+
+    state.setState({ sort: "date" })
+    expect(document.querySelector("b")?.textContent).toContain("Dated")
+
+    state.setState({ sort: "title" })
+    expect(document.querySelector("b")?.textContent).toContain("Named")
+  })
+
+  test("an ordered arm flips at its boundary", () => {
+    expect(document.querySelector("footer")?.textContent).toContain("Few")
+
+    state.setState({ attempts: 4 })
+    expect(document.querySelector("footer")?.textContent).toContain("Many")
+    expect(document.querySelector("video")?.hasAttribute("muted")).toBe(true)
+
+    state.setState({ attempts: 1 })
+    expect(document.querySelector("footer")?.textContent).toContain("Few")
+    expect(document.querySelector("video")?.hasAttribute("muted")).toBe(false)
   })
 
   test("an unless conditional flips through its inverted arms", () => {

--- a/javascript/packages/linter/docs/rules/herb-state-valid-reads.md
+++ b/javascript/packages/linter/docs/rules/herb-state-valid-reads.md
@@ -4,11 +4,11 @@
 
 ## Description
 
-Validates every read of a declared state. A state is read bare (`<%= attempts %>`, `<% if pending %>`, `<% unless pending %>`), as a predicate on a boolean (`pending?`), compared to a literal of its own type (`sort == "name"`), or switched over with literal `when` arms. A boolean attribute accepts the same read shapes, since its presence is a two-arm conditional (`disabled="<%= draft == "" %>"`). Anything else, a computed expression, a predicate on a non-boolean, or a comparison against a non-literal or a mismatched literal, is flagged.
+Validates every read of a declared state. A state is read bare (`<%= attempts %>`, `<% if pending %>`, `<% unless pending %>`), as a predicate on a boolean (`pending?`), compared to a literal of its own type (`sort == "name"`, `sort != "date"`), ordered against an Integer literal when it is an Integer (`attempts > 3`), or compared with another state of the same kind (`counter1 > counter2`), or switched over with literal `when` arms. A boolean attribute accepts the same read shapes, since its presence is a two-arm conditional (`disabled="<%= draft == "" %>"`). Anything else, a computed expression, a predicate on a non-boolean, or a comparison against a non-literal or a mismatched literal, is flagged.
 
 ## Rationale
 
-The client resolves state reads itself, without the server. That works because every allowed shape is a lookup or a comparison both languages compute identically. A computed read (`attempts + 1`, `attempts > 3`) would need a Ruby evaluator in JavaScript, so the engine rejects it at compile time. An `unless` reads like an `if` with its arms inverted, so every `if` shape works there too.
+The client resolves state reads itself, without the server. That works because every allowed shape is a lookup or a comparison both languages compute identically. A computed read (`attempts + 1`, `attempts * 2 > 3`) would need a Ruby evaluator in JavaScript, so the engine rejects it at compile time. An `unless` reads like an `if` with its arms inverted, so every `if` shape works there too.
 
 The engine raises all of these as compile errors when the template renders. This rule reports the same findings in the editor first.
 

--- a/javascript/packages/linter/src/rules/herb-state-valid-reads.ts
+++ b/javascript/packages/linter/src/rules/herb-state-valid-reads.ts
@@ -43,13 +43,18 @@ function prismBareRead(node: PrismNode | null | undefined): BareRead | null {
   return { name: predicate ? spelled.slice(0, -1) : spelled, predicate }
 }
 
-function equalitySides(node: PrismNode): [PrismNode, PrismNode] | null {
+const COMPARISON_OPERATORS = new Set(["==", "!=", ">", ">=", "<", "<="])
+
+function equalitySides(node: PrismNode): [PrismNode, PrismNode, string] | null {
   if (prismType(node) !== "CallNode") return null
-  if (String(node.name) !== "==") return null
+
+  const operator = String(node.name)
+
+  if (!COMPARISON_OPERATORS.has(operator)) return null
   if (!node.receiver) return null
   if (node.arguments_?.arguments_?.length !== 1) return null
 
-  return [node.receiver, node.arguments_.arguments_[0]]
+  return [node.receiver, node.arguments_.arguments_[0], operator]
 }
 
 class StateValidReadsVisitor extends BaseRuleVisitor {
@@ -226,13 +231,42 @@ class StateValidReadsVisitor extends BaseRuleVisitor {
     const sides = equalitySides(predicate)
 
     if (sides) {
-      const [left, right] = sides
+      const [left, right, operator] = sides
       const leftRead = prismBareRead(left)
       const rightRead = prismBareRead(right)
-      const declaration = (leftRead && this.resolve(leftRead.name)) || (rightRead && this.resolve(rightRead.name)) || null
+      const leftDeclaration = leftRead ? this.resolve(leftRead.name) : undefined
+      const rightDeclaration = rightRead ? this.resolve(rightRead.name) : undefined
+
+      if (leftDeclaration && rightDeclaration && leftRead && rightRead) {
+        const leftKind = declaredKind(leftDeclaration)
+        const rightKind = declaredKind(rightDeclaration)
+        const ordered = operator !== "==" && operator !== "!="
+
+        if (ordered && leftKind !== "seeded" && rightKind !== "seeded" && (leftKind !== "integer" || rightKind !== "integer")) {
+          this.addOffense(
+            `\`${this.sliceOf(predicate)}\` orders the states \`${leftRead.name}\` and \`${rightRead.name}\`. Ordering compares numbers, so both have to be Integer states.`,
+            this.locationOf(predicate),
+          )
+
+          return "reported"
+        }
+
+        if (!ordered && leftKind !== "seeded" && rightKind !== "seeded" && leftKind !== rightKind) {
+          this.addOffense(
+            `\`${this.sliceOf(predicate)}\` compares the ${capitalize(leftKind)} state \`${leftRead.name}\` with the ${capitalize(rightKind)} state \`${rightRead.name}\`, so it can never match. Compare states of one kind, or redeclare one.`,
+            this.locationOf(predicate),
+          )
+
+          return "reported"
+        }
+
+        return "state"
+      }
+
+      const declaration = leftDeclaration || rightDeclaration || null
 
       if (declaration) {
-        const comparand = leftRead && this.resolve(leftRead.name) ? right : left
+        const comparand = leftDeclaration ? right : left
         const comparandKind = LITERAL_KINDS[prismType(comparand)]
         const kind = declaredKind(declaration)
 
@@ -240,16 +274,38 @@ class StateValidReadsVisitor extends BaseRuleVisitor {
           const example = kind === "seeded" ? "" : `, like \`${declaration.name} == ${declaration.defaultSource}\``
 
           this.addOffense(
-            `\`${this.sliceOf(predicate)}\` compares the state \`${declaration.name}\` against something that is not a literal. Compare against a literal${example}, since the client resolves a comparison by lookup.`,
+            `\`${this.sliceOf(predicate)}\` compares the state \`${declaration.name}\` against something that is not a literal or another declared state. Compare against a literal${example}, since the client resolves a comparison by lookup.`,
             this.locationOf(predicate),
           )
 
           return "reported"
         }
 
-        if (kind !== "seeded" && comparandKind !== "nil" && comparandKind !== kind) {
+        const ordered = operator !== "==" && operator !== "!="
+
+        if (ordered && kind !== "seeded" && kind !== "integer") {
           this.addOffense(
-            `\`${this.sliceOf(predicate)}\` compares the ${capitalize(kind)} state \`${declaration.name}\` against ${kindWithArticle(comparandKind)} literal, so it can never match. Compare against a ${capitalize(kind)}, or redeclare the state.`,
+            `\`${this.sliceOf(predicate)}\` orders the ${capitalize(kind)} state \`${declaration.name}\`. Ordering compares numbers, so only an Integer state takes \`${operator}\`.`,
+            this.locationOf(predicate),
+          )
+
+          return "reported"
+        }
+
+        if (ordered && comparandKind !== "integer") {
+          this.addOffense(
+            `\`${this.sliceOf(predicate)}\` orders the state \`${declaration.name}\` against ${kindWithArticle(comparandKind)} literal. Ordering compares numbers, so the comparand has to be an Integer.`,
+            this.locationOf(predicate),
+          )
+
+          return "reported"
+        }
+
+        if (!ordered && kind !== "seeded" && comparandKind !== "nil" && comparandKind !== kind) {
+          const consequence = operator === "==" ? "so it can never match" : "so it always matches"
+
+          this.addOffense(
+            `\`${this.sliceOf(predicate)}\` compares the ${capitalize(kind)} state \`${declaration.name}\` against ${kindWithArticle(comparandKind)} literal, ${consequence}. Compare against a ${capitalize(kind)}, or redeclare the state.`,
             this.locationOf(predicate),
           )
 

--- a/javascript/packages/linter/test/rules/herb-state-valid-reads.test.ts
+++ b/javascript/packages/linter/test/rules/herb-state-valid-reads.test.ts
@@ -77,12 +77,80 @@ describe("HerbStateValidReadsRule", () => {
     `)
   })
 
-  test("flags a computed condition", () => {
-    expectError("`attempts > 3` computes with the state `attempts`, and the client cannot run Ruby to pick the branch. Read it bare, `<% if attempts %>`, or compare it to a literal, `attempts == 0`.")
+  test("allows an ordered comparison on an integer state", () => {
+    expectNoOffenses(dedent`
+      <%# herb:state (attempts: 0) %>
+      <% if attempts > 3 %>Too many<% end %>
+      <% if attempts <= 1 %>Fresh<% end %>
+    `)
+  })
+
+  test("allows comparing two states of one kind", () => {
+    expectNoOffenses(dedent`
+      <%# herb:state (counter1: 0, counter2: 5) %>
+      <% if counter1 > counter2 %>Ahead<% end %>
+      <% if counter1 == counter2 %>Tied<% end %>
+    `)
+  })
+
+  test("flags comparing states of different kinds", () => {
+    expectError("`sort == attempts` compares the String state `sort` with the Integer state `attempts`, so it can never match. Compare states of one kind, or redeclare one.")
+
+    assertOffenses(dedent`
+      <%# herb:state (sort: "name", attempts: 0) %>
+      <% if sort == attempts %>x<% end %>
+    `)
+  })
+
+  test("flags ordering non-integer states against each other", () => {
+    expectError("`sort > other` orders the states `sort` and `other`. Ordering compares numbers, so both have to be Integer states.")
+
+    assertOffenses(dedent`
+      <%# herb:state (sort: "name", other: "x") %>
+      <% if sort > other %>x<% end %>
+    `)
+  })
+
+  test("allows a negated equality of the state's own kind", () => {
+    expectNoOffenses(dedent`
+      <%# herb:state (sort: "name") %>
+      <% if sort != "date" %>Named<% end %>
+    `)
+  })
+
+  test("flags a negated equality against another kind", () => {
+    expectError('`sort != 3` compares the String state `sort` against an Integer literal, so it always matches. Compare against a String, or redeclare the state.')
+
+    assertOffenses(dedent`
+      <%# herb:state (sort: "name") %>
+      <% if sort != 3 %>x<% end %>
+    `)
+  })
+
+  test("flags ordering a string state", () => {
+    expectError("`sort > \"a\"` orders the String state `sort`. Ordering compares numbers, so only an Integer state takes `>`.")
+
+    assertOffenses(dedent`
+      <%# herb:state (sort: "name") %>
+      <% if sort > "a" %>x<% end %>
+    `)
+  })
+
+  test("flags ordering against a non-integer literal", () => {
+    expectError("`attempts > \"a\"` orders the state `attempts` against a String literal. Ordering compares numbers, so the comparand has to be an Integer.")
 
     assertOffenses(dedent`
       <%# herb:state (attempts: 0) %>
-      <% if attempts > 3 %>Too many<% end %>
+      <% if attempts > "a" %>x<% end %>
+    `)
+  })
+
+  test("flags a computed condition", () => {
+    expectError("`attempts * 2 > 3` computes with the state `attempts`, and the client cannot run Ruby to pick the branch. Read it bare, `<% if attempts %>`, or compare it to a literal, `attempts == 0`.")
+
+    assertOffenses(dedent`
+      <%# herb:state (attempts: 0) %>
+      <% if attempts * 2 > 3 %>Too many<% end %>
     `)
   })
 
@@ -94,11 +162,11 @@ describe("HerbStateValidReadsRule", () => {
   })
 
   test("flags a computed unless condition", () => {
-    expectError("`attempts > 3` computes with the state `attempts`, and the client cannot run Ruby to pick the branch. Read it bare, `<% if attempts %>`, or compare it to a literal, `attempts == 0`.")
+    expectError("`attempts * 2 > 3` computes with the state `attempts`, and the client cannot run Ruby to pick the branch. Read it bare, `<% if attempts %>`, or compare it to a literal, `attempts == 0`.")
 
     assertOffenses(dedent`
       <%# herb:state (attempts: 0) %>
-      <% unless attempts > 3 %>Fine<% end %>
+      <% unless attempts * 2 > 3 %>Fine<% end %>
     `)
   })
 
@@ -112,7 +180,7 @@ describe("HerbStateValidReadsRule", () => {
   })
 
   test("flags a comparison against a non-literal", () => {
-    expectError('`sort == params[:sort]` compares the state `sort` against something that is not a literal. Compare against a literal, like `sort == "name"`, since the client resolves a comparison by lookup.')
+    expectError('`sort == params[:sort]` compares the state `sort` against something that is not a literal or another declared state. Compare against a literal, like `sort == "name"`, since the client resolves a comparison by lookup.')
 
     assertOffenses(dedent`
       <%# herb:state (sort: "name") %>

--- a/lib/herb/engine/slot_dependencies.rb
+++ b/lib/herb/engine/slot_dependencies.rb
@@ -170,10 +170,11 @@ module Herb
           (bound[name] ||= []) << slot.index if bound_slot?(slot)
         end
 
-        presence = {} #: Hash[String, [String, String?]]
+        presence = {} #: Hash[String, untyped]
 
         visitor.state_presence.each do |index, read|
-          presence[index.to_s] = [read.name, read.comparand]
+          comparand = read.against ? { "state" => read.against } : read.comparand
+          presence[index.to_s] = read.operator ? [read.name, comparand, read.operator] : [read.name, comparand]
           (reads[read.name] ||= []) << index
           (bound[read.name] ||= []) << index if read.comparand.nil? && bound_slot?(visitor.slots[index])
         end

--- a/lib/herb/engine/slot_visitor.rb
+++ b/lib/herb/engine/slot_visitor.rb
@@ -756,7 +756,7 @@ module Herb
         else_position = chain.index { |arm| arm.is_a?(Herb::AST::ERBElseNode) }
         conditions = else_position ? chain.take(else_position) : chain
 
-        arms = [] #: Array[[String, String?, Integer]]
+        arms = [] #: Array[untyped]
 
         conditions.each_with_index do |arm, branch|
           expression = condition_expression(arm)
@@ -777,12 +777,21 @@ module Herb
           end
 
           rewrite_predicate(arm, read.name)
-          arms << [read.name, read.comparand, branch]
+          rewrite_predicate(arm, read.against) if read.against
+
+          arms << arm_entry(read, branch)
         end
 
         return nil if arms.empty?
 
         { arms: arms, else: else_position }
+      end
+
+      #: (StateDirectives::Read, Integer?) -> Array[untyped]
+      def arm_entry(read, branch)
+        comparand = read.against ? { "state" => read.against } : read.comparand
+
+        read.operator ? [read.name, comparand, branch, read.operator] : [read.name, comparand, branch]
       end
 
       #: (untyped, Hash[String, StateDirectives::Declaration]) -> Hash[Symbol, untyped]?
@@ -805,7 +814,9 @@ module Herb
         chain = conditional_chain(node)
         else_position = chain.index { |arm| arm.is_a?(Herb::AST::ERBElseNode) }
 
-        { arms: [[read.name, read.comparand, else_position]], else: 0 }
+        rewrite_predicate(node, read.against) if read.against
+
+        { arms: [arm_entry(read, else_position)], else: 0 }
       end
 
       #: (untyped) -> Array[untyped]
@@ -836,7 +847,7 @@ module Herb
         rewrite_predicate(node, read.name)
 
         declaration = states.fetch(read.name)
-        arms = [] #: Array[[String, String?, Integer]]
+        arms = [] #: Array[untyped]
 
         node.conditions.each_with_index do |arm, branch|
           list = condition_expression(arm)
@@ -959,7 +970,7 @@ module Herb
 
         return nil unless read.is_a?(StateDirectives::Read)
 
-        if read.comparand.nil? && ![:boolean, :nil, :seeded].include?(read.kind)
+        if read.comparand.nil? && read.against.nil? && ![:boolean, :nil, :seeded].include?(read.kind)
           raise Herb::Engine::CompilationError,
                 "`#{slot.attribute}=\"<%= #{expression} %>\"` reads the #{read.kind.to_s.capitalize} state `#{read.name}` " \
                 "as a presence; only `nil` and `false` are falsy in Ruby, so the attribute could never turn off. " \
@@ -972,7 +983,13 @@ module Herb
 
         return nil unless position
 
-        condition = read.comparand ? "#{read.name} == #{read.comparand}" : read.name
+        condition = if read.against
+                      "#{read.name} #{read.operator || "=="} #{read.against}"
+                    elsif read.comparand
+                      "#{read.name} #{read.operator || "=="} #{read.comparand}"
+                    else
+                      read.name
+                    end
         replacement = erb_output_node(%[("#{slot.attribute}" if #{condition})])
 
         children[position] = replacement

--- a/lib/herb/engine/state_directives.rb
+++ b/lib/herb/engine/state_directives.rb
@@ -31,8 +31,13 @@ module Herb
       Read = Data.define(
         :name,      #: String
         :comparand, #: String?
-        :kind       #: Symbol?
+        :kind,      #: Symbol?
+        :operator,  #: String?
+        :against    #: String?
       )
+
+      ORDERED_OPERATORS = [:>, :>=, :<, :<=].freeze #: Array[Symbol]
+      MIRRORED_OPERATORS = { ">" => "<", ">=" => "<=", "<" => ">", "<=" => ">=" }.freeze #: Hash[String, String]
 
       class << self
         #: (untyped) -> String?
@@ -183,23 +188,30 @@ module Herb
                   "only a boolean state can be read with a `?`"
           end
 
-          Read.new(name: name, comparand: nil, kind: declaration.kind)
+          Read.new(name: name, comparand: nil, kind: declaration.kind, operator: nil, against: nil)
         end
 
         #: (untyped, Hash[String, Declaration]) -> Read?
         def equality_read(node, states)
-          return nil unless node.is_a?(Prism::CallNode) && node.name == :==
+          return nil unless node.is_a?(Prism::CallNode)
+          return nil unless node.name == :== || node.name == :!= || ORDERED_OPERATORS.include?(node.name)
 
           left = node.receiver
           right = node.arguments&.arguments&.first
 
           return nil unless left && right && node.arguments&.arguments&.one?
 
-          read = bare_read(left, states) || bare_read(right, states)
+          left_read = bare_read(left, states)
+          right_read = bare_read(right, states)
+          read = left_read || right_read
 
           return nil unless read
 
-          literal = bare_read(left, states) ? right : left
+          if left_read && right_read
+            return state_pair_read(node, left_read, right_read)
+          end
+
+          literal = left_read ? right : left
           kind = KINDS[literal.class.name]
 
           unless kind
@@ -208,12 +220,48 @@ module Herb
                   "the client resolves a comparison by lookup, so the comparand has to be one"
           end
 
-          unless kind == read.kind || kind == :nil || read.kind == :seeded
+          operator = node.name == :== ? nil : node.name.to_s
+          operator = MIRRORED_OPERATORS.fetch(operator) if operator && operator != "!=" && bare_read(right, states)
+          ordered = operator && operator != "!="
+
+          if ordered && read.kind != :integer && read.kind != :seeded
+            raise Herb::Engine::CompilationError,
+                  "`#{node.slice}` orders the #{read.kind.to_s.capitalize} state `#{read.name}`; ordering compares " \
+                  "numbers, so only an Integer state takes `#{node.name}`"
+          end
+
+          if ordered && kind != :integer
+            raise Herb::Engine::CompilationError,
+                  "`#{node.slice}` orders the state `#{read.name}` against a #{kind.to_s.capitalize} literal; " \
+                  "ordering compares numbers, so the comparand has to be an Integer"
+          end
+
+          unless ordered || kind == read.kind || kind == :nil || read.kind == :seeded
             raise Herb::Engine::CompilationError,
                   "`#{node.slice}` compares the #{read.kind.to_s.capitalize} state `#{read.name}` against a #{kind.to_s.capitalize} literal"
           end
 
-          Read.new(name: read.name, comparand: literal.slice, kind: read.kind)
+          Read.new(name: read.name, comparand: literal.slice, kind: read.kind, operator: operator, against: nil)
+        end
+
+        #: (untyped, Read, Read) -> Read
+        def state_pair_read(node, left, right)
+          operator = node.name == :== ? nil : node.name.to_s
+          ordered = operator && operator != "!="
+
+          if ordered && (left.kind != :integer || right.kind != :integer) && left.kind != :seeded && right.kind != :seeded
+            raise Herb::Engine::CompilationError,
+                  "`#{node.slice}` orders the states `#{left.name}` and `#{right.name}`; ordering compares numbers, " \
+                  "so both have to be Integer states"
+          end
+
+          if !ordered && left.kind != right.kind && left.kind != :seeded && right.kind != :seeded
+            raise Herb::Engine::CompilationError,
+                  "`#{node.slice}` compares the #{left.kind.to_s.capitalize} state `#{left.name}` with the " \
+                  "#{right.kind.to_s.capitalize} state `#{right.name}`, so it can never match"
+          end
+
+          Read.new(name: left.name, comparand: nil, kind: left.kind, operator: operator, against: right.name)
         end
       end
     end

--- a/sig/herb/engine/slot_visitor.rbs
+++ b/sig/herb/engine/slot_visitor.rbs
@@ -231,6 +231,9 @@ module Herb
       # : (untyped, Hash[String, StateDirectives::Declaration]) -> Hash[Symbol, untyped]?
       def state_conditional_for: (untyped, Hash[String, StateDirectives::Declaration]) -> Hash[Symbol, untyped]?
 
+      # : (StateDirectives::Read, Integer?) -> Array[untyped]
+      def arm_entry: (StateDirectives::Read, Integer?) -> Array[untyped]
+
       # : (untyped, Hash[String, StateDirectives::Declaration]) -> Hash[Symbol, untyped]?
       def state_unless_for: (untyped, Hash[String, StateDirectives::Declaration]) -> Hash[Symbol, untyped]?
 

--- a/sig/herb/engine/state_directives.rbs
+++ b/sig/herb/engine/state_directives.rbs
@@ -37,13 +37,21 @@ module Herb
 
         attr_reader kind(): Symbol?
 
-        def self.new: (String name, String? comparand, Symbol? kind) -> instance
-                    | (name: String, comparand: String?, kind: Symbol?) -> instance
+        attr_reader operator(): String?
 
-        def self.members: () -> [ :name, :comparand, :kind ]
+        attr_reader against(): String?
 
-        def members: () -> [ :name, :comparand, :kind ]
+        def self.new: (String name, String? comparand, Symbol? kind, String? operator, String? against) -> instance
+                    | (name: String, comparand: String?, kind: Symbol?, operator: String?, against: String?) -> instance
+
+        def self.members: () -> [ :name, :comparand, :kind, :operator, :against ]
+
+        def members: () -> [ :name, :comparand, :kind, :operator, :against ]
       end
+
+      ORDERED_OPERATORS: Array[Symbol]
+
+      MIRRORED_OPERATORS: Hash[String, String]
 
       # : (untyped) -> String?
       def self.signature_of: (untyped) -> String?
@@ -74,6 +82,9 @@ module Herb
 
       # : (untyped, Hash[String, Declaration]) -> Read?
       private def self.equality_read: (untyped, Hash[String, Declaration]) -> Read?
+
+      # : (untyped, Read, Read) -> Read
+      private def self.state_pair_read: (untyped, Read, Read) -> Read
     end
   end
 end

--- a/test/engine/slots/states_test.rb
+++ b/test/engine/slots/states_test.rb
@@ -155,7 +155,6 @@ module Engine
         refuse("<ul><% @items.each do |item| %><%# herb:state (open: false) %><li id=\"<%= item %>\"><%= open %></li><% end %></ul>" \
                "<%# herb:state (open: false) %>", /declared in both an item and its region/)
         refuse("<%# herb:state (attempts: 0) %><p><%= attempts + 1 %></p>", /computes with a state/)
-        refuse("<%# herb:state (attempts: 0) %><div><% if attempts > 3 %>a<% else %>b<% end %></div>", /computes with a state/)
         refuse("<%# herb:state (sort: \"name\") %><div><% if sort == 3 %>a<% end %></div>", /String state `sort` against a Integer/)
         refuse("<%# herb:state (attempts: 0) %><div><% if attempts? %>a<% end %></div>", /only a boolean state/)
         refuse("<%# herb:state (sort: \"name\") %><div><% case sort %><% when SORTS %>a<% end %></div>", /not a literal/)
@@ -240,6 +239,64 @@ module Engine
         assert_match(/mixes other dynamic parts/, error.message)
       end
 
+      test "an ordered comparison compiles with its operator in the arm" do
+        visitor, = compile(%(<%# herb:state (attempts: 0) %><div><% if attempts > 3 %>Many<% else %>Few<% end %></div>))
+
+        assert_equal({ arms: [["attempts", "3", 0, ">"]], else: 1 }, visitor.state_conditional_entries.fetch(0))
+      end
+
+      test "a reversed ordered comparison mirrors its operator" do
+        visitor, = compile(%(<%# herb:state (attempts: 0) %><div><% if 3 < attempts %>Many<% end %></div>))
+
+        assert_equal({ arms: [["attempts", "3", 0, ">"]], else: nil }, visitor.state_conditional_entries.fetch(0))
+      end
+
+      test "an ordered presence carries its operator" do
+        visitor, = compile(%(<%# herb:state (attempts: 0) %><video muted="<%= attempts >= 2 %>"></video>))
+        read = visitor.state_presence.fetch(0)
+
+        assert_equal ">=", read.operator
+
+        rendered = render(%(<%# herb:state (attempts: 5) %><video muted="<%= attempts >= 2 %>"></video>))
+
+        assert_includes rendered, "<video muted"
+      end
+
+      test "a negated equality compiles for any kind" do
+        visitor, = compile(%(<%# herb:state (sort: "name") %><div><% if sort != "date" %>Named<% end %></div>))
+
+        assert_equal({ arms: [["sort", "\"date\"", 0, "!="]], else: nil }, visitor.state_conditional_entries.fetch(0))
+
+        refuse("<%# herb:state (sort: \"name\") %><div><% if sort != 3 %>x<% end %></div>", /against a Integer literal/)
+      end
+
+      test "a state compares against another state" do
+        template = %(<%# herb:state (counter1: 0, counter2: 5) %><div><% if counter1 > counter2 %>Ahead<% else %>Behind<% end %></div>)
+        visitor, = compile(template)
+
+        assert_equal({ arms: [["counter1", { "state" => "counter2" }, 0, ">"]], else: 1 }, visitor.state_conditional_entries.fetch(0))
+
+        rendered = render(template)
+
+        assert_includes rendered, "Behind"
+      end
+
+      test "a state pair keeps its kinds compatible" do
+        refuse("<%# herb:state (sort: \"name\", attempts: 0) %><div><% if sort == attempts %>x<% end %></div>", /can never match/)
+        refuse("<%# herb:state (sort: \"name\", other: \"x\") %><div><% if sort > other %>x<% end %></div>", /both have to be Integer states/)
+      end
+
+      test "a boolean attribute compares two states" do
+        rendered = render(%(<%# herb:state (counter1: 1, counter2: 1) %><video muted="<%= counter1 == counter2 %>"></video>))
+
+        assert_includes rendered, "<video muted"
+      end
+
+      test "ordering refuses non-integer states and comparands" do
+        refuse("<%# herb:state (sort: \"name\") %><div><% if sort > \"a\" %>x<% end %></div>", /orders the String state/)
+        refuse("<%# herb:state (attempts: 0) %><div><% if attempts > \"a\" %>x<% end %></div>", /against a String literal/)
+      end
+
       test "an unless reads a state with its arms inverted" do
         template = %(<%# herb:state (pending: false) %><div><% unless pending %>Idle<% else %>Busy<% end %></div>)
         visitor, = compile(template)
@@ -269,7 +326,7 @@ module Engine
 
       test "a computed unless still raises" do
         error = assert_raises(Herb::Engine::CompilationError) do
-          compile(%(<%# herb:state (attempts: 0) %><div><% unless attempts > 3 %>Idle<% end %></div>))
+          compile(%(<%# herb:state (attempts: 0) %><div><% unless attempts * 2 > 3 %>Idle<% end %></div>))
         end
 
         assert_match(/computes with a state/, error.message)


### PR DESCRIPTION
Follow up on #2334, which accepted a state compared to a literal with `==`.

That covers a lookup and nothing else. This adds the comparisons a template actually reaches for:

```erb
<%# herb:state (attempts: 0, limit: 3, sort: "name") %>

<% if attempts > 3 %>Many<% end %>
<% if sort != "date" %>Named<% end %>
<% if attempts >= limit %>At the limit<% end %>
```

Ordering is restricted to an Integer state against an Integer literal or another Integer state, since that is the comparison both languages compute identically. `!=` works for any kind. A comparison against a state instead of a literal is recorded as a state pair, so the client resolves both sides from its own store.

The operand order is preserved by mirroring the operator, so `3 < attempts` records the same condition as `attempts > 3`.
