### PR TITLE
Engine: Combine state conditions with `&&` and `||`

### DIFF
--- a/javascript/packages/client/src/state.ts
+++ b/javascript/packages/client/src/state.ts
@@ -33,12 +33,23 @@ export interface StateManifest {
   reads: Record<string, number[]>
   bound?: Record<string, number[]>
   conditionals: Record<string, { arms: ConditionalArm[]; else: number | null }>
-  presence?: Record<string, [string, StateComparand] | [string, StateComparand, string]>
+  presence?: Record<string, StateCondition>
 }
 
 export type StateComparand = string | null | { state: string }
 
-export type ConditionalArm = [string, StateComparand, number | null] | [string, StateComparand, number | null, string]
+export type StateCondition = [string, StateComparand] | [string, StateComparand, string] | ComboCondition
+
+export interface ComboCondition {
+  all?: StateCondition[]
+  any?: StateCondition[]
+}
+
+export interface ComboArm extends ComboCondition {
+  branch: number | null
+}
+
+export type ConditionalArm = [string, StateComparand, number | null] | [string, StateComparand, number | null, string] | ComboArm
 
 export interface StateScope {
   region: Region
@@ -701,7 +712,7 @@ export class SlotState {
         if (slot.type === "boolean_attribute") {
           const entry = manifest.presence?.[String(index)]
 
-          if (!entry || entry[1] !== null || slot.anchor.kind === "range" || !slot.attribute) continue
+          if (!entry || !Array.isArray(entry) || entry[1] !== null || slot.anchor.kind === "range" || !slot.attribute) continue
 
           return slot.anchor.element.hasAttribute(slot.attribute)
         }
@@ -719,12 +730,14 @@ export class SlotState {
 
   #seedFromConditional(manifest: StateManifest, scope: StateScope, name: string): StateValue | undefined {
     for (const [indexKey, conditional] of Object.entries(manifest.conditionals)) {
-      const mentions = conditional.arms.some(([armName]) => armName === name)
+      const mentions = conditional.arms.some((arm) => Array.isArray(arm) && arm[0] === name)
 
       if (!mentions) continue
 
       for (const slot of this.#scopedSlots(scope, Number(indexKey))) {
-        const arm = conditional.arms.find(([, , branch]) => branch === slot.branch)
+        const arm = conditional.arms.find(
+          (candidate): candidate is Exclude<ConditionalArm, ComboArm> => Array.isArray(candidate) && candidate[2] === slot.branch,
+        )
 
         if (arm && arm[0] === name && arm[3] === undefined && typeof arm[1] !== "object") return arm[1] === null ? true : parseLiteral(arm[1])
         if (arm && arm[0] === name) return undefined
@@ -758,13 +771,10 @@ export class SlotState {
   }
 
   #writePresence(manifest: StateManifest, scope: StateScope, changed: string[]): void {
-    for (const [indexKey, [name, comparand, operator]] of Object.entries(manifest.presence ?? {})) {
-      const against = typeof comparand === "object" && comparand !== null ? comparand.state : null
+    for (const [indexKey, entry] of Object.entries(manifest.presence ?? {})) {
+      if (!conditionMentions(entry, changed)) continue
 
-      if (!changed.includes(name) && (against === null || !changed.includes(against))) continue
-
-      const value = this.#valueOf(name, scope)
-      const present = armMatches(value, comparand, operator, (against) => this.#valueOf(against, scope))
+      const present = conditionMatches(entry, (name) => this.#valueOf(name, scope))
 
       for (const slot of this.#scopedSlots(scope, Number(indexKey))) {
         this.#slots.setBooleanAttribute(slot, present)
@@ -794,10 +804,18 @@ export class SlotState {
   }
 
   #targetBranch(conditional: StateManifest["conditionals"][string], scope: StateScope): number | null {
-    for (const [name, comparand, branch, operator] of conditional.arms) {
-      const value = this.#valueOf(name, scope)
+    const valueOf = (name: string) => this.#valueOf(name, scope)
 
-      if (armMatches(value, comparand, operator, (against) => this.#valueOf(against, scope))) return branch
+    for (const arm of conditional.arms) {
+      if (!Array.isArray(arm)) {
+        if (conditionMatches(arm, valueOf)) return arm.branch
+
+        continue
+      }
+
+      const [name, comparand, branch, operator] = arm
+
+      if (armMatches(valueOf(name), comparand, operator, valueOf)) return branch
     }
 
     return conditional.else
@@ -1104,11 +1122,39 @@ export function boundValue(element: Element, kind: StateKind): StateValue {
 }
 
 function armMentions(arm: ConditionalArm, changed: string[]): boolean {
+  if (!Array.isArray(arm)) return conditionMentions(arm, changed)
+
   const [name, comparand] = arm
 
   if (changed.includes(name)) return true
 
   return typeof comparand === "object" && comparand !== null && changed.includes(comparand.state)
+}
+
+function conditionMentions(condition: StateCondition, changed: string[]): boolean {
+  if (!Array.isArray(condition)) return comboParts(condition).some((part) => conditionMentions(part, changed))
+
+  const [name, comparand] = condition
+
+  if (changed.includes(name)) return true
+
+  return typeof comparand === "object" && comparand !== null && changed.includes(comparand.state)
+}
+
+function conditionMatches(condition: StateCondition, valueOf: (name: string) => StateValue): boolean {
+  if (Array.isArray(condition)) {
+    const [name, comparand, operator] = condition
+
+    return armMatches(valueOf(name), comparand, operator, valueOf)
+  }
+
+  if (condition.all) return condition.all.every((part) => conditionMatches(part, valueOf))
+
+  return comboParts(condition).some((part) => conditionMatches(part, valueOf))
+}
+
+function comboParts(combo: ComboCondition): StateCondition[] {
+  return combo.all ?? combo.any ?? []
 }
 
 function armMatches(value: StateValue, comparand: StateComparand, operator: string | undefined, other: (name: string) => StateValue): boolean {

--- a/javascript/packages/client/test/state-scoped.test.ts
+++ b/javascript/packages/client/test/state-scoped.test.ts
@@ -411,3 +411,110 @@ describe("declared state", () => {
     expect(details).toMatchObject([{ name: "pending", value: true, previous: false, file: FILE, occurrence: 0, key: null }])
   })
 })
+
+describe("combo conditions", () => {
+  const COMBO_FILE = "app/views/page/combos.html.erb"
+
+  const COMBO_PAGE =
+    `<!--herb-region:${COMBO_FILE}:eeeeeeee:0-->` +
+    `<div><!--herb-slot:0:conditional--><!--herb-branch:0:1-->Out<!--/herb-slot:0--></div>` +
+    `<span><!--herb-slot:1:conditional--><!--herb-branch:1:1-->Idle<!--/herb-slot:1--></span>` +
+    `<input data-herb-slot="2:boolean_attribute:disabled">` +
+    `<b><!--herb-slot:3:conditional--><!--herb-branch:3:1-->Calm<!--/herb-slot:3--></b>` +
+    `<template data-herb-region="${COMBO_FILE}:eeeeeeee">` +
+    `<!--herb-branch:0:0-->In<!--herb-branch:0:1-->Out` +
+    `<!--herb-branch:1:0-->Busy<!--herb-branch:1:1-->Idle` +
+    `<!--herb-branch:3:0-->Stuck<!--herb-branch:3:1-->Calm` +
+    `</template>` +
+    `<!--/herb-region:${COMBO_FILE}-->`
+
+  const COMBO_MANIFEST = {
+    state: {},
+    states: {
+      [COMBO_FILE]: {
+        version: "eeeeeeee",
+        declarations: [
+          { name: "counter1", kind: "integer", default: "0", scope: "region" },
+          { name: "counter2", kind: "integer", default: "5", scope: "region" },
+          { name: "pending", kind: "boolean", default: "false", scope: "region" },
+          { name: "failed", kind: "boolean", default: "false", scope: "region" },
+          { name: "attempts", kind: "integer", default: "0", scope: "region" },
+        ],
+        reads: {},
+        conditionals: {
+          0: { arms: [{ branch: 0, all: [["counter1", "0", ">"], ["counter2", "10", "<"]] }], else: 1 },
+          1: { arms: [{ branch: 0, any: [["pending", null], ["failed", null]] }], else: 1 },
+          3: { arms: [{ branch: 0, all: [["pending", null], { any: [["failed", null], ["attempts", "2", ">"]] }] }], else: 1 },
+        },
+        presence: { 2: { any: [["pending", null], ["failed", null]] } },
+      },
+    },
+  }
+
+  let comboState: SlotState
+
+  beforeEach(() => {
+    document.body.innerHTML = COMBO_PAGE + `<template data-herb-dependencies>${JSON.stringify(COMBO_MANIFEST)}</template>`
+
+    const comboSlots = new SlotIndex()
+
+    comboSlots.scan(document.body)
+
+    comboState = new SlotState(comboSlots, {
+      persist: "none",
+      transport: () => {
+        throw new Error("a declared state must never reach the transport")
+      },
+    })
+
+    comboState.adopt()
+  })
+
+  test("an all combo needs every condition and reacts to each state", () => {
+    expect(comboState.setState({ counter1: 3 })).toBe(true)
+    expect(document.querySelector("div")?.textContent).toContain("In")
+
+    expect(comboState.setState({ counter2: 12 })).toBe(true)
+    expect(document.querySelector("div")?.textContent).toContain("Out")
+
+    expect(comboState.setState({ counter2: 5 })).toBe(true)
+    expect(document.querySelector("div")?.textContent).toContain("In")
+  })
+
+  test("an any combo flips on either state", () => {
+    expect(comboState.setState({ failed: true })).toBe(true)
+    expect(document.querySelector("span")?.textContent).toContain("Busy")
+
+    expect(comboState.setState({ failed: false })).toBe(true)
+    expect(document.querySelector("span")?.textContent).toContain("Idle")
+
+    expect(comboState.setState({ pending: true })).toBe(true)
+    expect(document.querySelector("span")?.textContent).toContain("Busy")
+  })
+
+  test("a combo presence toggles the attribute from either state", () => {
+    const input = document.querySelector("input")!
+
+    expect(input.hasAttribute("disabled")).toBe(false)
+
+    comboState.setState({ failed: true })
+    expect(input.hasAttribute("disabled")).toBe(true)
+
+    comboState.setState({ failed: false })
+    expect(input.hasAttribute("disabled")).toBe(false)
+
+    comboState.setState({ pending: true })
+    expect(input.hasAttribute("disabled")).toBe(true)
+  })
+
+  test("a nested combo resolves its grouping", () => {
+    comboState.setState({ pending: true })
+    expect(document.querySelector("b")?.textContent).toContain("Calm")
+
+    comboState.setState({ attempts: 3 })
+    expect(document.querySelector("b")?.textContent).toContain("Stuck")
+
+    comboState.setState({ pending: false })
+    expect(document.querySelector("b")?.textContent).toContain("Calm")
+  })
+})

--- a/javascript/packages/linter/docs/rules/herb-state-valid-reads.md
+++ b/javascript/packages/linter/docs/rules/herb-state-valid-reads.md
@@ -4,11 +4,11 @@
 
 ## Description
 
-Validates every read of a declared state. A state is read bare (`<%= attempts %>`, `<% if pending %>`, `<% unless pending %>`), as a predicate on a boolean (`pending?`), compared to a literal of its own type (`sort == "name"`, `sort != "date"`), ordered against an Integer literal when it is an Integer (`attempts > 3`), or compared with another state of the same kind (`counter1 > counter2`), or switched over with literal `when` arms. A boolean attribute accepts the same read shapes, since its presence is a two-arm conditional (`disabled="<%= draft == "" %>"`). Anything else, a computed expression, a predicate on a non-boolean, or a comparison against a non-literal or a mismatched literal, is flagged.
+Validates every read of a declared state. A state is read bare (`<%= attempts %>`, `<% if pending %>`, `<% unless pending %>`), as a predicate on a boolean (`pending?`), compared to a literal of its own type (`sort == "name"`, `sort != "date"`), ordered against an Integer literal when it is an Integer (`attempts > 3`), or compared with another state of the same kind (`counter1 > counter2`), or switched over with literal `when` arms. Those conditions also combine with `&&` and `||` (`pending? || failed?`), as long as every side reads a state. A boolean attribute accepts the same read shapes, since its presence is a two-arm conditional (`disabled="<%= draft == "" %>"`). Anything else, a computed expression, a predicate on a non-boolean, a comparison against a non-literal or a mismatched literal, or a combination that mixes a state with server Ruby, is flagged.
 
 ## Rationale
 
-The client resolves state reads itself, without the server. That works because every allowed shape is a lookup or a comparison both languages compute identically. A computed read (`attempts + 1`, `attempts * 2 > 3`) would need a Ruby evaluator in JavaScript, so the engine rejects it at compile time. An `unless` reads like an `if` with its arms inverted, so every `if` shape works there too.
+The client resolves state reads itself, without the server. That works because every allowed shape is a lookup or a comparison both languages compute identically, and a `&&`/`||` combination of those shapes is resolved one condition at a time. A computed read (`attempts + 1`, `attempts * 2 > 3`) would need a Ruby evaluator in JavaScript, so the engine rejects it at compile time. A combination like `pending? && current_user.admin?` has the same problem on its server side, since the client holds no value for it. An `unless` reads like an `if` with its arms inverted, so every `if` shape works there too.
 
 The engine raises all of these as compile errors when the template renders. This rule reports the same findings in the editor first.
 
@@ -25,6 +25,8 @@ The engine raises all of these as compile errors when the template renders. This
 <% if pending? %>Sending<% else %>Sent<% end %>
 
 <% if sort == "name" %>By name<% elsif sort == "date" %>By date<% end %>
+
+<% if pending? || attempts > 3 %>Hold on<% else %>Ready<% end %>
 
 <% case sort %>
 <% when "name" %>By name
@@ -48,8 +50,7 @@ The engine raises all of these as compile errors when the template renders. This
 
 <p><%= attempts + 1 %></p>
 
-<% if attempts > 3 %>Too many<% end %>
-
+<% if pending? && current_user.admin? %>Retry as admin<% end %>
 
 <% if attempts? %>Tried<% end %>
 

--- a/javascript/packages/linter/src/rules/herb-state-valid-reads.ts
+++ b/javascript/packages/linter/src/rules/herb-state-valid-reads.ts
@@ -206,6 +206,38 @@ class StateValidReadsVisitor extends BaseRuleVisitor {
   }
 
   private classifyPredicate(predicate: PrismNode, names: readonly string[]): "state" | "other" | "reported" {
+    const type = prismType(predicate)
+
+    if (type === "ParenthesesNode") {
+      const statements = predicate.body?.body
+
+      if (Array.isArray(statements) && statements.length === 1) {
+        return this.classifyPredicate(statements[0], names)
+      }
+    }
+
+    if ((type === "AndNode" || type === "OrNode") && predicate.left && predicate.right) {
+      const left = this.classifyPredicate(predicate.left, names)
+      if (left === "reported") return "reported"
+
+      const right = this.classifyPredicate(predicate.right, names)
+      if (right === "reported") return "reported"
+      if (left === "state" && right === "state") return "state"
+
+      if (left === "state" || right === "state") {
+        const server = left === "state" ? predicate.right : predicate.left
+
+        this.addOffense(
+          `\`${this.sliceOf(predicate)}\` combines a state with \`${this.sliceOf(server)}\`, which the client cannot evaluate. Split the server condition into its own conditional, or compute it into a second state set from app code.`,
+          this.locationOf(predicate),
+        )
+
+        return "reported"
+      }
+
+      return "other"
+    }
+
     const bare = prismBareRead(predicate)
 
     if (bare) {

--- a/javascript/packages/linter/test/rules/herb-state-valid-reads.test.ts
+++ b/javascript/packages/linter/test/rules/herb-state-valid-reads.test.ts
@@ -229,6 +229,42 @@ describe("HerbStateValidReadsRule", () => {
     `)
   })
 
+  test("allows combos of state conditions", () => {
+    expectNoOffenses(dedent`
+      <%# herb:state (pending: false, failed: false, counter1: 0, counter2: 5) %>
+      <% if counter1 > 0 && counter2 < 10 %>In range<% else %>Out<% end %>
+      <% if pending? || failed? %>Busy<% else %>Idle<% end %>
+      <% unless pending? || failed? %>Free<% end %>
+      <% if pending? && (failed? || counter1 > 2) %>Stuck<% end %>
+      <input disabled="<%= pending? || failed? %>">
+    `)
+  })
+
+  test("flags a combo mixing a state with server code", () => {
+    expectError("`pending? && current_user.admin?` combines a state with `current_user.admin?`, which the client cannot evaluate. Split the server condition into its own conditional, or compute it into a second state set from app code.")
+
+    assertOffenses(dedent`
+      <%# herb:state (pending: false) %>
+      <% if pending? && current_user.admin? %>Ready<% else %>Not yet<% end %>
+    `)
+  })
+
+  test("flags the invalid condition inside a combo once", () => {
+    expectError("`attempts?` reads the Integer state `attempts` as a predicate. Write `attempts` bare, or declare a boolean flag. Only a boolean state reads with a `?`.")
+
+    assertOffenses(dedent`
+      <%# herb:state (pending: false, attempts: 0) %>
+      <% if pending? && attempts? %>x<% end %>
+    `)
+  })
+
+  test("allows a combo of server conditions", () => {
+    expectNoOffenses(dedent`
+      <%# herb:state (pending: false) %>
+      <% if signed_in? && current_user.admin? %>Admin<% end %>
+    `)
+  })
+
   test("flags a case that does not switch on a bare state read", () => {
     expectError("`case sort.downcase` does not switch on a bare state read. Write the state alone, or compute the value into its own state.")
 

--- a/lib/herb/engine/slot_dependencies.rb
+++ b/lib/herb/engine/slot_dependencies.rb
@@ -173,10 +173,12 @@ module Herb
         presence = {} #: Hash[String, untyped]
 
         visitor.state_presence.each do |index, read|
-          comparand = read.against ? { "state" => read.against } : read.comparand
-          presence[index.to_s] = read.operator ? [read.name, comparand, read.operator] : [read.name, comparand]
-          (reads[read.name] ||= []) << index
-          (bound[read.name] ||= []) << index if read.comparand.nil? && bound_slot?(visitor.slots[index])
+          presence[index.to_s] = StateDirectives.condition_entry(read)
+          StateDirectives.read_names(read).each { |name| (reads[name] ||= []) << index }
+
+          next unless read.is_a?(StateDirectives::Read)
+
+          (bound[read.name] ||= []) << index if read.comparand.nil? && read.against.nil? && bound_slot?(visitor.slots[index])
         end
 
         conditionals = visitor.state_conditional_entries.to_h { |index, info|

--- a/lib/herb/engine/slot_visitor.rb
+++ b/lib/herb/engine/slot_visitor.rb
@@ -34,7 +34,7 @@ module Herb
       required_parser_option action_view_helpers: true, track_locations: true
 
       attr_reader :slots #: Array[Slot]
-      attr_reader :state_presence #: Hash[Integer, StateDirectives::Read]
+      attr_reader :state_presence #: Hash[Integer, untyped]
       attr_reader :document #: untyped
       attr_reader :warnings #: Array[Herb::Warnings::Warning]
 
@@ -132,7 +132,7 @@ module Herb
         @named_elements = [] #: Array[Hash[Symbol, untyped]]
         attribute_open_tags = {} #: Hash[untyped, untyped]
         @attribute_open_tags = attribute_open_tags.compare_by_identity
-        @state_presence = {} #: Hash[Integer, StateDirectives::Read]
+        @state_presence = {} #: Hash[Integer, untyped]
         @interpolated_attributes = [] #: Array[untyped]
         @strict_locals = {} #: Hash[String, Symbol]
         @region_states = {} #: Hash[String, StateDirectives::Declaration]
@@ -768,7 +768,7 @@ module Herb
                   "as a predicate, or compared to a literal"
           end
 
-          unless read.is_a?(StateDirectives::Read)
+          unless read.is_a?(StateDirectives::Read) || read.is_a?(StateDirectives::Combo)
             return nil if arms.empty?
 
             raise Herb::Engine::CompilationError,
@@ -776,8 +776,7 @@ module Herb
                   "arm, so each one has to read a state"
           end
 
-          rewrite_predicate(arm, read.name)
-          rewrite_predicate(arm, read.against) if read.against
+          StateDirectives.read_names(read).each { |name| rewrite_predicate(arm, name) }
 
           arms << arm_entry(read, branch)
         end
@@ -787,11 +786,11 @@ module Herb
         { arms: arms, else: else_position }
       end
 
-      #: (StateDirectives::Read, Integer?) -> Array[untyped]
+      #: (untyped, Integer?) -> untyped
       def arm_entry(read, branch)
-        comparand = read.against ? { "state" => read.against } : read.comparand
+        return { "branch" => branch, read.op => read.parts.map { |part| StateDirectives.condition_entry(part) } } if read.is_a?(StateDirectives::Combo)
 
-        read.operator ? [read.name, comparand, branch, read.operator] : [read.name, comparand, branch]
+        StateDirectives.condition_entry(read).insert(2, branch)
       end
 
       #: (untyped, Hash[String, StateDirectives::Declaration]) -> Hash[Symbol, untyped]?
@@ -807,14 +806,12 @@ module Herb
                 "bare, as a predicate, or compared to a literal"
         end
 
-        return nil unless read.is_a?(StateDirectives::Read)
-
-        rewrite_predicate(node, read.name)
+        return nil unless read.is_a?(StateDirectives::Read) || read.is_a?(StateDirectives::Combo)
 
         chain = conditional_chain(node)
         else_position = chain.index { |arm| arm.is_a?(Herb::AST::ERBElseNode) }
 
-        rewrite_predicate(node, read.against) if read.against
+        StateDirectives.read_names(read).each { |name| rewrite_predicate(node, name) }
 
         { arms: [arm_entry(read, else_position)], else: 0 }
       end
@@ -961,16 +958,16 @@ module Herb
         end
       end
 
-      #: (untyped, Integer, untyped, String, Hash[String, StateDirectives::Declaration]) -> StateDirectives::Read?
+      #: (untyped, Integer, untyped, String, Hash[String, StateDirectives::Declaration]) -> untyped
       def convert_boolean_attribute(node, index, slot, expression, states)
         return nil unless slot.type == :attribute
         return nil unless slot.attribute && Herb::HTML::Util.boolean_attribute?(slot.attribute)
 
         read = StateDirectives.condition_read(expression, states)
 
-        return nil unless read.is_a?(StateDirectives::Read)
+        return nil unless read.is_a?(StateDirectives::Read) || read.is_a?(StateDirectives::Combo)
 
-        if read.comparand.nil? && read.against.nil? && ![:boolean, :nil, :seeded].include?(read.kind)
+        if read.is_a?(StateDirectives::Read) && read.comparand.nil? && read.against.nil? && ![:boolean, :nil, :seeded].include?(read.kind)
           raise Herb::Engine::CompilationError,
                 "`#{slot.attribute}=\"<%= #{expression} %>\"` reads the #{read.kind.to_s.capitalize} state `#{read.name}` " \
                 "as a presence; only `nil` and `false` are falsy in Ruby, so the attribute could never turn off. " \
@@ -983,13 +980,7 @@ module Herb
 
         return nil unless position
 
-        condition = if read.against
-                      "#{read.name} #{read.operator || "=="} #{read.against}"
-                    elsif read.comparand
-                      "#{read.name} #{read.operator || "=="} #{read.comparand}"
-                    else
-                      read.name
-                    end
+        condition = StateDirectives.condition_source(read)
         replacement = erb_output_node(%[("#{slot.attribute}" if #{condition})])
 
         children[position] = replacement

--- a/lib/herb/engine/state_directives.rb
+++ b/lib/herb/engine/state_directives.rb
@@ -36,6 +36,11 @@ module Herb
         :against    #: String?
       )
 
+      Combo = Data.define(
+        :op,    #: String
+        :parts  #: Array[untyped]
+      )
+
       ORDERED_OPERATORS = [:>, :>=, :<, :<=].freeze #: Array[Symbol]
       MIRRORED_OPERATORS = { ">" => "<", ">=" => "<=", "<" => ">", "<=" => ">=" }.freeze #: Hash[String, String]
 
@@ -67,20 +72,93 @@ module Herb
           parameters.keywords.map { |keyword| declaration_for(keyword, locals) }
         end
 
-        #: (String, Hash[String, Declaration]) -> (Read | Symbol)?
+        #: (String, Hash[String, Declaration]) -> (Read | Combo | Symbol)?
         def condition_read(expression, states)
           source = expression.strip
           parsed = expression_node(source)
 
           return mentions_any?(source, states) ? :computed : nil if parsed.nil?
 
-          read = bare_read(parsed, states)
+          read = tree_read(parsed, states)
           return read if read
 
-          equality = equality_read(parsed, states)
+          mentions_any?(source, states) ? :computed : nil
+        end
+
+        #: (untyped, Hash[String, Declaration]) -> (Read | Combo | Symbol)?
+        def tree_read(node, states)
+          node = unwrap_parentheses(node)
+
+          read = bare_read(node, states)
+          return read if read
+
+          equality = equality_read(node, states)
           return equality if equality
 
-          mentions_any?(source, states) ? :computed : nil
+          combo_read(node, states)
+        end
+
+        #: (untyped) -> untyped
+        def unwrap_parentheses(node)
+          return node unless node.is_a?(Prism::ParenthesesNode)
+
+          body = node.body
+
+          return node unless body.is_a?(Prism::StatementsNode) && body.body.one?
+
+          unwrap_parentheses(body.body.first)
+        end
+
+        #: (untyped, Hash[String, Declaration]) -> (Combo | Symbol)?
+        def combo_read(node, states)
+          op = case node
+               when Prism::AndNode then "all"
+               when Prism::OrNode then "any"
+               else return nil
+               end
+
+          parts = flatten_combo(node, node.class).map { |part| tree_read(part, states) }
+
+          return nil if parts.none? { |part| part.is_a?(Read) || part.is_a?(Combo) }
+          return :computed if parts.any? { |part| part.nil? || part == :computed }
+
+          Combo.new(op: op, parts: parts)
+        end
+
+        #: (untyped, untyped) -> Array[untyped]
+        def flatten_combo(node, klass)
+          return [node] unless node.is_a?(klass)
+
+          flatten_combo(node.left, klass) + flatten_combo(node.right, klass)
+        end
+
+        #: (Read | Combo) -> Array[String]
+        def read_names(read)
+          return [read.name, read.against].compact if read.is_a?(Read)
+
+          read.parts.flat_map { |part| read_names(part) }
+        end
+
+        #: (Read | Combo) -> untyped
+        def condition_entry(read)
+          return { read.op => read.parts.map { |part| condition_entry(part) } } if read.is_a?(Combo)
+
+          comparand = read.against ? { "state" => read.against } : read.comparand
+
+          read.operator ? [read.name, comparand, read.operator] : [read.name, comparand]
+        end
+
+        #: (Read | Combo) -> String
+        def condition_source(read)
+          if read.is_a?(Read)
+            return read.name if read.comparand.nil? && read.against.nil?
+
+            "#{read.name} #{read.operator || "=="} #{read.against || read.comparand}"
+          else
+            joiner = read.op == "all" ? " && " : " || "
+
+            "(#{read.parts.map { |part| condition_source(part) }.join(joiner)})"
+          end
         end
 
         #: (String, Declaration) -> (Array[String] | Symbol)

--- a/sig/herb/engine/slot_visitor.rbs
+++ b/sig/herb/engine/slot_visitor.rbs
@@ -22,7 +22,7 @@ module Herb
 
       attr_reader slots: Array[Slot]
 
-      attr_reader state_presence: Hash[Integer, StateDirectives::Read]
+      attr_reader state_presence: Hash[Integer, untyped]
 
       attr_reader document: untyped
 
@@ -231,8 +231,8 @@ module Herb
       # : (untyped, Hash[String, StateDirectives::Declaration]) -> Hash[Symbol, untyped]?
       def state_conditional_for: (untyped, Hash[String, StateDirectives::Declaration]) -> Hash[Symbol, untyped]?
 
-      # : (StateDirectives::Read, Integer?) -> Array[untyped]
-      def arm_entry: (StateDirectives::Read, Integer?) -> Array[untyped]
+      # : (untyped, Integer?) -> untyped
+      def arm_entry: (untyped, Integer?) -> untyped
 
       # : (untyped, Hash[String, StateDirectives::Declaration]) -> Hash[Symbol, untyped]?
       def state_unless_for: (untyped, Hash[String, StateDirectives::Declaration]) -> Hash[Symbol, untyped]?
@@ -258,8 +258,8 @@ module Herb
       # : () -> void
       def check_state_value_reads: () -> void
 
-      # : (untyped, Integer, untyped, String, Hash[String, StateDirectives::Declaration]) -> StateDirectives::Read?
-      def convert_boolean_attribute: (untyped, Integer, untyped, String, Hash[String, StateDirectives::Declaration]) -> StateDirectives::Read?
+      # : (untyped, Integer, untyped, String, Hash[String, StateDirectives::Declaration]) -> untyped
+      def convert_boolean_attribute: (untyped, Integer, untyped, String, Hash[String, StateDirectives::Declaration]) -> untyped
 
       # : (untyped, untyped, Integer, untyped, Integer) -> void
       def record_named_element: (untyped, untyped, Integer, untyped, Integer) -> void

--- a/sig/herb/engine/state_directives.rbs
+++ b/sig/herb/engine/state_directives.rbs
@@ -49,6 +49,19 @@ module Herb
         def members: () -> [ :name, :comparand, :kind, :operator, :against ]
       end
 
+      class Combo < Data
+        attr_reader op(): String
+
+        attr_reader parts(): Array[untyped]
+
+        def self.new: (String op, Array[untyped] parts) -> instance
+                    | (op: String, parts: Array[untyped]) -> instance
+
+        def self.members: () -> [ :op, :parts ]
+
+        def members: () -> [ :op, :parts ]
+      end
+
       ORDERED_OPERATORS: Array[Symbol]
 
       MIRRORED_OPERATORS: Hash[String, String]
@@ -59,8 +72,29 @@ module Herb
       # : (String, Hash[String, Symbol]) -> Array[Declaration]
       def self.parse: (String, Hash[String, Symbol]) -> Array[Declaration]
 
-      # : (String, Hash[String, Declaration]) -> (Read | Symbol)?
-      def self.condition_read: (String, Hash[String, Declaration]) -> (Read | Symbol)?
+      # : (String, Hash[String, Declaration]) -> (Read | Combo | Symbol)?
+      def self.condition_read: (String, Hash[String, Declaration]) -> (Read | Combo | Symbol)?
+
+      # : (untyped, Hash[String, Declaration]) -> (Read | Combo | Symbol)?
+      def self.tree_read: (untyped, Hash[String, Declaration]) -> (Read | Combo | Symbol)?
+
+      # : (untyped) -> untyped
+      def self.unwrap_parentheses: (untyped) -> untyped
+
+      # : (untyped, Hash[String, Declaration]) -> (Combo | Symbol)?
+      def self.combo_read: (untyped, Hash[String, Declaration]) -> (Combo | Symbol)?
+
+      # : (untyped, untyped) -> Array[untyped]
+      def self.flatten_combo: (untyped, untyped) -> Array[untyped]
+
+      # : (Read | Combo) -> Array[String]
+      def self.read_names: (Read | Combo) -> Array[String]
+
+      # : (Read | Combo) -> untyped
+      def self.condition_entry: (Read | Combo) -> untyped
+
+      # : (Read | Combo) -> String
+      def self.condition_source: (Read | Combo) -> String
 
       # : (String, Declaration) -> (Array[String] | Symbol)
       def self.when_comparands: (String, Declaration) -> (Array[String] | Symbol)

--- a/test/engine/slots/dependencies_test.rb
+++ b/test/engine/slots/dependencies_test.rb
@@ -437,6 +437,27 @@ module Engine
         assert_equal manifest["presence"].keys.map(&:to_i).sort, (manifest["reads"]["draft"] + manifest["reads"]["sending"]).sort - manifest["reads"]["draft"].take(1)
       end
 
+      test "carries a combo presence and registers every state it reads" do
+        path = write("index.html.erb", <<~ERB)
+          <%# herb:state (pending: false, failed: false) %>
+          <input disabled="<%= pending? || failed? %>">
+          <div><% if pending? && failed? %>Stuck<% else %>Fine<% end %></div>
+        ERB
+
+        manifest = subject.payload(path)["states"].values.first
+
+        assert_equal [{ "any" => [["pending", nil], ["failed", nil]] }], manifest["presence"].values
+
+        index = manifest["presence"].keys.first.to_i
+
+        assert_includes manifest["reads"]["pending"], index
+        assert_includes manifest["reads"]["failed"], index
+
+        conditional = manifest["conditionals"].values.first
+
+        assert_equal [{ "branch" => 0, "all" => [["pending", nil], ["failed", nil]] }], conditional["arms"]
+      end
+
       test "carries the states a template declares" do
         path = write("index.html.erb", <<~ERB)
           <%# herb:state (pending: false, attempts: 0) %>

--- a/test/engine/slots/states_test.rb
+++ b/test/engine/slots/states_test.rb
@@ -297,6 +297,88 @@ module Engine
         refuse("<%# herb:state (attempts: 0) %><div><% if attempts > \"a\" %>x<% end %></div>", /against a String literal/)
       end
 
+      test "a conjunction compiles as an all combo" do
+        template = %(<%# herb:state (counter1: 0, counter2: 5) %><div><% if counter1 > 0 && counter2 < 10 %>In<% else %>Out<% end %></div>)
+        visitor, = compile(template)
+
+        assert_equal(
+          { arms: [{ "branch" => 0, "all" => [["counter1", "0", ">"], ["counter2", "10", "<"]] }], else: 1 },
+          visitor.state_conditional_entries.fetch(0)
+        )
+
+        rendered = render(template)
+
+        assert_includes rendered, "Out"
+
+        markup = parked(template)
+
+        assert_includes markup, "In"
+      end
+
+      test "a disjunction compiles as an any combo" do
+        visitor, = compile(%(<%# herb:state (pending: false, failed: false) %><div><% if pending? || failed? %>Busy<% else %>Idle<% end %></div>))
+
+        assert_equal(
+          { arms: [{ "branch" => 0, "any" => [["pending", nil], ["failed", nil]] }], else: 1 },
+          visitor.state_conditional_entries.fetch(0)
+        )
+      end
+
+      test "a parenthesized combo nests" do
+        visitor, = compile(%(<%# herb:state (pending: false, failed: false, attempts: 0) %><div><% if pending? && (failed? || attempts > 2) %>x<% end %></div>))
+
+        assert_equal(
+          { arms: [{ "branch" => 0, "all" => [["pending", nil], { "any" => [["failed", nil], ["attempts", "2", ">"]] }] }], else: nil },
+          visitor.state_conditional_entries.fetch(0)
+        )
+      end
+
+      test "a combo takes a state pair as one of its conditions" do
+        visitor, = compile(%(<%# herb:state (counter1: 0, counter2: 5, pending: false) %><div><% if counter1 == counter2 && pending? %>x<% end %></div>))
+
+        assert_equal(
+          { arms: [{ "branch" => 0, "all" => [["counter1", { "state" => "counter2" }], ["pending", nil]] }], else: nil },
+          visitor.state_conditional_entries.fetch(0)
+        )
+      end
+
+      test "a combo mixing a state with server code raises" do
+        refuse(
+          "<%# herb:state (pending: false) %><div><% if pending? && current_user.admin? %>x<% else %>y<% end %></div>",
+          /computes with a state/
+        )
+      end
+
+      test "a combo of server reads stays a server conditional" do
+        visitor, = compile(%(<%# herb:state (pending: false) %><div><% if signed_in? && admin? %>x<% else %>y<% end %></div>))
+
+        assert_empty visitor.state_conditional_entries
+      end
+
+      test "an unless reads a combo with its arms inverted" do
+        visitor, = compile(%(<%# herb:state (pending: false, failed: false) %><div><% unless pending? || failed? %>Free<% end %></div>))
+
+        assert_equal(
+          { arms: [{ "branch" => nil, "any" => [["pending", nil], ["failed", nil]] }], else: 0 },
+          visitor.state_conditional_entries.fetch(0)
+        )
+      end
+
+      test "a boolean attribute reads a combo" do
+        template = %(<%# herb:state (pending: false, failed: false) %><input disabled="<%= pending? || failed? %>">)
+        visitor, = compile(template)
+
+        assert_instance_of Herb::Engine::StateDirectives::Combo, visitor.state_presence.fetch(0)
+
+        off = render(template)
+
+        refute_includes off, "<input disabled"
+
+        on = render(%(<%# herb:state (pending: true, failed: false) %><input disabled="<%= pending? || failed? %>">))
+
+        assert_includes on, "<input disabled"
+      end
+
       test "an unless reads a state with its arms inverted" do
         template = %(<%# herb:state (pending: false) %><div><% unless pending %>Idle<% else %>Busy<% end %></div>)
         visitor, = compile(template)


### PR DESCRIPTION
Follow up on #2372.

A condition frequently needs more than one state, and splitting it into nested conditionals changes the markup structure to work around a grammar limit:

```erb
<%# herb:state (pending: false, failed: false, attempts: 0) %>

<% if pending? || failed? %>Busy<% else %>Idle<% end %>
<% if attempts > 0 && pending? %>Retrying<% end %>
```

A combined condition is recorded as an `all`/`any` group of the reads it contains, which nests, so parentheses work and a group can hold another group. The client resolves a group by resolving its parts, so this needs no new evaluation model.

A combo that mixes a state with server Ruby is still refused, since the client has no way to evaluate the Ruby half.
