### PR TITLE
Engine: Derive a state from the states it reads

### DIFF
--- a/javascript/packages/client/src/directives.ts
+++ b/javascript/packages/client/src/directives.ts
@@ -40,6 +40,7 @@ export interface StateDeclaration {
   defaultSource: string
   defaultOffset: number
   kind: StateDefaultKind
+  derived?: DerivedDefault | "mixed" | "forward" | null
 }
 
 export interface StateSignature {
@@ -106,6 +107,27 @@ function parseStateSignature(signature: string, signatureOffset: number): StateS
     })
   }
 
+  const names = declarations.map((declaration) => declaration.name)
+  const resolved = new Map<string, string>()
+
+  for (const [index, declaration] of declarations.entries()) {
+    if (declaration.kind === "bare" || declaration.kind === "seeded") {
+      const outcome = classifyDerivedDefault(declaration.defaultSource, resolved)
+
+      if (outcome === null) {
+        declaration.derived = mentionsAnyState(declaration.defaultSource, names.slice(index + 1)) ? "forward" : null
+      } else {
+        declaration.derived = outcome
+      }
+    } else {
+      declaration.derived = null
+    }
+
+    const kind = declaration.derived !== null && typeof declaration.derived === "object" ? declaration.derived.kind : declaration.kind
+
+    resolved.set(declaration.name, kind)
+  }
+
   return { signature, signatureOffset, declarations, malformed: null }
 }
 
@@ -126,6 +148,177 @@ export function classifyDefault(source: string): StateDefaultKind {
   if (BARE_IDENTIFIER.test(source)) return "bare"
 
   return "seeded"
+}
+
+export type DerivedComparand = string | null | { state: string }
+
+export type DerivedCondition =
+  | [string, DerivedComparand]
+  | [string, DerivedComparand, string]
+  | { all?: DerivedCondition[]; any?: DerivedCondition[] }
+
+export interface DerivedDefault {
+  kind: "boolean" | "integer" | "string" | "symbol" | "nil" | "seeded"
+  condition: DerivedCondition
+  sources: string[]
+}
+
+const MIRRORED_COMPARISONS: Record<string, string> = { ">": "<", ">=": "<=", "<": ">", "<=": ">=" }
+const LITERAL_DEFAULT_KINDS = new Set(["boolean", "integer", "string", "symbol", "nil"])
+
+export function classifyDerivedDefault(source: string, declared: ReadonlyMap<string, string>): DerivedDefault | "mixed" | null {
+  const parsed = parseDerivedCondition(source.trim(), declared)
+
+  if (parsed === null && mentionsAnyState(source, [...declared.keys()])) return "mixed"
+
+  return parsed
+}
+
+function parseDerivedCondition(source: string, declared: ReadonlyMap<string, string>): DerivedDefault | "mixed" | null {
+  const trimmed = unwrapParentheses(source.trim())
+
+  for (const [operator, key] of [["||", "any"], ["&&", "all"]] as const) {
+    const parts = splitTopLevelOperator(trimmed, operator)
+
+    if (parts.length > 1) {
+      const conditions: DerivedCondition[] = []
+      const sources: string[] = []
+
+      for (const part of parts) {
+        const parsed = parseDerivedCondition(part, declared)
+
+        if (parsed === null || parsed === "mixed") return parsed === "mixed" ? "mixed" : null
+
+        conditions.push(parsed.condition)
+        sources.push(...parsed.sources)
+      }
+
+      return { kind: "boolean", condition: { [key]: conditions }, sources: [...new Set(sources)] }
+    }
+  }
+
+  const comparison = splitTopLevelComparison(trimmed)
+
+  if (comparison) {
+    const [left, operator, right] = comparison
+    const leftState = derivedStateSide(left, declared)
+    const rightState = derivedStateSide(right, declared)
+
+    if (leftState && rightState) {
+      const spelled = operator === "==" ? undefined : operator
+      const condition: DerivedCondition = spelled ? [leftState, { state: rightState }, spelled] : [leftState, { state: rightState }]
+
+      return { kind: "boolean", condition, sources: [...new Set([leftState, rightState])] }
+    }
+
+    const state = leftState ?? rightState
+
+    if (!state) return null
+
+    const literal = (leftState ? right : left).trim()
+
+    if (!LITERAL_DEFAULT_KINDS.has(classifyDefault(literal))) return null
+
+    let spelled = operator === "==" ? undefined : operator
+
+    if (spelled && rightState && spelled !== "!=") spelled = MIRRORED_COMPARISONS[spelled]
+
+    const condition: DerivedCondition = spelled ? [state, literal, spelled] : [state, literal]
+
+    return { kind: "boolean", condition, sources: [state] }
+  }
+
+  const bare = bareReadName(trimmed)
+
+  if (bare === null) return null
+
+  const kind = declared.get(bare)
+
+  if (kind === undefined) return null
+
+  if (trimmed.endsWith("?")) {
+    return kind === "boolean" || kind === "seeded" || kind === "bare"
+      ? { kind: "boolean", condition: [bare, null], sources: [bare] }
+      : "mixed"
+  }
+
+  const resolved = LITERAL_DEFAULT_KINDS.has(kind) ? kind as DerivedDefault["kind"] : "seeded"
+
+  return { kind: resolved, condition: [bare, null], sources: [bare] }
+}
+
+function derivedStateSide(side: string, declared: ReadonlyMap<string, string>): string | null {
+  const bare = bareReadName(side.trim())
+
+  if (bare === null || !declared.has(bare)) return null
+
+  return bare
+}
+
+function unwrapParentheses(source: string): string {
+  let current = source
+
+  while (current.startsWith("(") && current.endsWith(")") && balanced(current.slice(1, -1))) {
+    current = current.slice(1, -1).trim()
+  }
+
+  return current
+}
+
+function splitTopLevelOperator(source: string, operator: "||" | "&&"): string[] {
+  const parts: string[] = []
+  let depth = 0
+  let start = 0
+
+  for (let index = 0; index < source.length; index += 1) {
+    const character = source[index]
+
+    if (character === '"' || character === "'") {
+      index = skipString(source, index) - 1
+
+      continue
+    }
+
+    if (character === "(" || character === "[" || character === "{") depth += 1
+    else if (character === ")" || character === "]" || character === "}") depth -= 1
+    else if (depth === 0 && character === operator[0] && source[index + 1] === operator[1]) {
+      parts.push(source.slice(start, index).trim())
+      index += 1
+      start = index + 1
+    }
+  }
+
+  parts.push(source.slice(start).trim())
+
+  return parts
+}
+
+function splitTopLevelComparison(source: string): [string, string, string] | null {
+  let depth = 0
+
+  for (let index = 0; index < source.length; index += 1) {
+    const character = source[index]
+
+    if (character === '"' || character === "'") {
+      index = skipString(source, index) - 1
+
+      continue
+    }
+
+    if (character === "(" || character === "[" || character === "{") depth += 1
+    else if (character === ")" || character === "]" || character === "}") depth -= 1
+    else if (depth === 0) {
+      for (const operator of ["==", "!=", ">=", "<=", ">", "<"]) {
+        if (!source.startsWith(operator, index)) continue
+        if (operator === "<" && source[index + 1] === "<") break
+        if (operator === ">" && source[index + 1] === ">") break
+
+        return [source.slice(0, index), operator, source.slice(index + operator.length)]
+      }
+    }
+  }
+
+  return null
 }
 
 export function mentionsAnyState(source: string, stateNames: readonly string[]): boolean {

--- a/javascript/packages/client/src/state.ts
+++ b/javascript/packages/client/src/state.ts
@@ -22,6 +22,7 @@ export interface DeclaredState {
   name: string
   kind: StateKind
   default: string
+  derived?: StateCondition | null
   scope: "region" | number
   line?: number | null
   column?: number | null
@@ -512,9 +513,22 @@ export class SlotState {
 
     for (const name of names) {
       const target = this.scopeFor(resolved, name) ?? resolved
+      const declaration = this.#declaration(manifest, target, name)
 
-      if (this.#declaration(manifest, target, name) === null) {
+      if (declaration === null) {
         this.#reportUnknown(name, resolved)
+
+        return false
+      }
+
+      if (declaration.derived) {
+        report({
+          template: resolved.region.file,
+          message: `\`${name}\` is derived from \`${declaration.default}\`, so it cannot be written. Write the states it reads.`,
+          code: "herb-state-derived",
+          severity: "error",
+          value: name,
+        })
 
         return false
       }
@@ -526,6 +540,12 @@ export class SlotState {
       previous.set(name, this.#valueOf(name, shared))
     }
 
+    const dependents = new Map<StateScope, { name: string; previous: StateValue }[]>()
+
+    for (const [scope, grouped] of groups) {
+      dependents.set(scope, this.#derivedDependents(manifest, scope, grouped).map((name) => ({ name, previous: this.#valueOf(name, scope) })))
+    }
+
     this.#slots.transaction(() => {
       for (const [name, value] of Object.entries(values)) {
         const target = scopes.get(name) ?? resolved
@@ -535,13 +555,34 @@ export class SlotState {
       }
 
       for (const [scope, grouped] of groups) {
-        this.#writeConditionals(manifest, scope, grouped)
-        this.#writePresence(manifest, scope, grouped)
+        const recomputed: string[] = []
+
+        for (const dependent of dependents.get(scope) ?? []) {
+          const value = this.#valueOf(dependent.name, scope)
+
+          if (value === dependent.previous) continue
+
+          recomputed.push(dependent.name)
+          this.#writeValueSlots(manifest, scope, dependent.name, value)
+        }
+
+        const changed = [...grouped, ...recomputed]
+
+        this.#writeConditionals(manifest, scope, changed)
+        this.#writePresence(manifest, scope, changed)
       }
     }, { retain: false })
 
     for (const [name, value] of Object.entries(values)) {
       this.#announceState(scopes.get(name) ?? resolved, name, value, previous.get(name) ?? null)
+    }
+
+    for (const [scope, list] of dependents) {
+      for (const dependent of list) {
+        const value = this.#valueOf(dependent.name, scope)
+
+        if (value !== dependent.previous) this.#announceState(scope, dependent.name, value, dependent.previous)
+      }
     }
 
     return true
@@ -659,6 +700,11 @@ export class SlotState {
   }
 
   #valueOf(name: string, scope: StateScope): StateValue {
+    const manifest = this.manifestFor(scope.region)
+    const declaration = manifest ? this.#declaration(manifest, scope, name) : null
+
+    if (declaration?.derived) return this.#deriveValue(declaration, scope)
+
     const stored = this.#scoped.get(scope.region)?.get(scope.item?.key ?? "")?.get(name)
 
     if (stored !== undefined) return stored
@@ -666,6 +712,38 @@ export class SlotState {
     const seeded = this.#seed(name, scope)
 
     return seeded !== undefined ? seeded : this.#defaultOf(name, scope)
+  }
+
+  #deriveValue(declaration: DeclaredState, scope: StateScope): StateValue {
+    const entry = declaration.derived
+
+    if (entry === undefined || entry === null) return null
+
+    if (declaration.kind !== "boolean" && Array.isArray(entry) && entry.length === 2 && entry[1] === null) {
+      return this.#valueOf(entry[0], scope)
+    }
+
+    return conditionMatches(entry, (name) => this.#valueOf(name, scope))
+  }
+
+  #derivedDependents(manifest: StateManifest, scope: StateScope, written: string[]): string[] {
+    const collection = scope.item ? collectionOf(scope.region, scope.item) : null
+    const changed = new Set(written)
+    const dependents: string[] = []
+
+    for (const declaration of manifest.declarations) {
+      if (!declaration.derived) continue
+
+      const matches = collection !== null ? declaration.scope === collection : declaration.scope === "region"
+
+      if (!matches) continue
+      if (!conditionMentions(declaration.derived, [...changed])) continue
+
+      dependents.push(declaration.name)
+      changed.add(declaration.name)
+    }
+
+    return dependents
   }
 
   #defaultOf(name: string, scope: StateScope): StateValue {

--- a/javascript/packages/client/test/state-scoped.test.ts
+++ b/javascript/packages/client/test/state-scoped.test.ts
@@ -518,3 +518,121 @@ describe("combo conditions", () => {
     expect(document.querySelector("b")?.textContent).toContain("Calm")
   })
 })
+
+describe("derived states", () => {
+  const DERIVED_FILE = "app/views/page/derived.html.erb"
+
+  const DERIVED_PAGE =
+    `<!--herb-region:${DERIVED_FILE}:ffffffff:0-->` +
+    `<div><!--herb-slot:0:conditional--><!--herb-branch:0:1-->Idle<!--/herb-slot:0--></div>` +
+    `<p><!--herb-slot:1-->0<!--/herb-slot:1--></p>` +
+    `<input data-herb-slot="2:boolean_attribute:disabled">` +
+    `<b><!--herb-slot:3:conditional--><!--herb-branch:3:1-->Calm<!--/herb-slot:3--></b>` +
+    `<template data-herb-region="${DERIVED_FILE}:ffffffff">` +
+    `<!--herb-branch:0:0-->Busy<!--herb-branch:0:1-->Idle` +
+    `<!--herb-branch:3:0-->Deep<!--herb-branch:3:1-->Calm` +
+    `</template>` +
+    `<!--/herb-region:${DERIVED_FILE}-->`
+
+  const DERIVED_MANIFEST = {
+    state: {},
+    states: {
+      [DERIVED_FILE]: {
+        version: "ffffffff",
+        declarations: [
+          { name: "pending", kind: "boolean", default: "false", scope: "region" },
+          { name: "failed", kind: "boolean", default: "false", scope: "region" },
+          { name: "attempts", kind: "integer", default: "0", scope: "region" },
+          { name: "busy", kind: "boolean", default: "pending || failed", derived: { any: [["pending", null], ["failed", null]] }, scope: "region" },
+          { name: "total", kind: "integer", default: "attempts", derived: ["attempts", null], scope: "region" },
+          { name: "deep", kind: "boolean", default: "busy && attempts > 2", derived: { all: [["busy", null], ["attempts", "2", ">"]] }, scope: "region" },
+        ],
+        reads: { total: [1] },
+        conditionals: {
+          0: { arms: [["busy", null, 0]], else: 1 },
+          3: { arms: [["deep", null, 0]], else: 1 },
+        },
+        presence: { 2: ["busy", null] },
+      },
+    },
+  }
+
+  let derivedState: SlotState
+
+  beforeEach(() => {
+    document.body.innerHTML = DERIVED_PAGE + `<template data-herb-dependencies>${JSON.stringify(DERIVED_MANIFEST)}</template>`
+
+    const derivedSlots = new SlotIndex()
+
+    derivedSlots.scan(document.body)
+
+    derivedState = new SlotState(derivedSlots, {
+      persist: "none",
+      transport: () => {
+        throw new Error("a declared state must never reach the transport")
+      },
+    })
+
+    derivedState.adopt()
+  })
+
+  test("a derived state computes from its sources", () => {
+    expect(derivedState.getState("busy")).toBe(false)
+    expect(derivedState.getState("total")).toBe(0)
+
+    derivedState.setState({ pending: true })
+
+    expect(derivedState.getState("busy")).toBe(true)
+  })
+
+  test("a source write fans out through the derivation", () => {
+    derivedState.setState({ failed: true })
+
+    expect(document.querySelector("div")?.textContent).toContain("Busy")
+    expect(document.querySelector("input")?.hasAttribute("disabled")).toBe(true)
+
+    derivedState.setState({ failed: false })
+
+    expect(document.querySelector("div")?.textContent).toContain("Idle")
+    expect(document.querySelector("input")?.hasAttribute("disabled")).toBe(false)
+  })
+
+  test("a derived value slot rewrites when its source changes", () => {
+    derivedState.setState({ attempts: 5 })
+
+    expect(document.querySelector("p")?.textContent).toContain("5")
+  })
+
+  test("a derivation cascades through another derivation", () => {
+    derivedState.setState({ pending: true })
+
+    expect(document.querySelector("b")?.textContent).toContain("Calm")
+
+    derivedState.setState({ attempts: 3 })
+
+    expect(document.querySelector("b")?.textContent).toContain("Deep")
+
+    derivedState.setState({ pending: false })
+
+    expect(document.querySelector("b")?.textContent).toContain("Calm")
+  })
+
+  test("a derived state cannot be written", () => {
+    expect(derivedState.setState({ busy: true })).toBe(false)
+    expect(document.querySelector("div")?.textContent).toContain("Idle")
+
+    expect(derivedState.toggle("busy")).toBe(false)
+  })
+
+  test("a derived change announces like any other", () => {
+    const names: string[] = []
+    const handler = (event: Event) => names.push((event as CustomEvent).detail.name)
+
+    document.addEventListener(STATE_EVENT, handler)
+    derivedState.setState({ failed: true })
+    document.removeEventListener(STATE_EVENT, handler)
+
+    expect(names).toContain("failed")
+    expect(names).toContain("busy")
+  })
+})

--- a/javascript/packages/language-service/src/hover_provider.ts
+++ b/javascript/packages/language-service/src/hover_provider.ts
@@ -139,8 +139,18 @@ function declaredStateKind(kind: string): string {
   return ["boolean", "integer", "string", "symbol", "nil"].includes(kind) ? kind : "seeded"
 }
 
-function stateUsageLines(name: string, kind: string, defaultSource: string): string[] {
+function stateUsageLines(name: string, kind: string, defaultSource: string, derived = false): string[] {
   const fence = (language: string, ...lines: string[]) => ["```" + language, ...lines, "```"]
+
+  if (derived) {
+    const read = kind === "boolean" ? `<% if ${name} %>` : `<% if ${name} == ${defaultSource || "..."} %>`
+
+    return [
+      ...fence("erb", `<%= ${name} %>`, read),
+      "",
+      ...fence("javascript", `stateFor(element).get("${name}")`),
+    ]
+  }
 
   if (kind === "boolean") {
     return [
@@ -296,20 +306,25 @@ export class HoverProvider {
 
     if (!declaration) return null
 
-    const kind = declaredStateKind(declaration.kind)
+    const derived = declaration.derived !== undefined && declaration.derived !== null && typeof declaration.derived === "object" ? declaration.derived : null
+    const kind = derived ? derived.kind : declaredStateKind(declaration.kind)
     const parameter = entry.scope === null ? null : blockParameter(entry.scope)
     const scope = entry.scope === null
       ? "one value per rendering"
       : `one value for each \`${parameter ?? "item"}\``
 
+    const source = derived
+      ? `derived from \`${declaration.defaultSource}\``
+      : `default \`${declaration.defaultSource || "(none)"}\``
+
     const lines = [
       `**${declaration.name}** · Herb Client State`,
       "",
-      `\`${kind}\` · default \`${declaration.defaultSource || "(none)"}\` · ${scope}`,
+      `\`${kind}\` · ${source} · ${scope}`,
       "",
       "Example usage:",
       "",
-      ...stateUsageLines(declaration.name, kind, declaration.defaultSource),
+      ...stateUsageLines(declaration.name, kind, derived ? "" : declaration.defaultSource, derived !== null),
     ]
 
     const range = [local.declaration, ...(local.defaultValue ? [local.defaultValue] : []), ...local.usages]

--- a/javascript/packages/linter/docs/rules/herb-state-valid-actions.md
+++ b/javascript/packages/linter/docs/rules/herb-state-valid-actions.md
@@ -4,7 +4,7 @@
 
 ## Description
 
-Validates the declarative action attributes `data-herb-set`, `data-herb-toggle`, `data-herb-increment`, `data-herb-decrement`, `data-herb-reset` and `data-herb-by`. Clause syntax must parse, quotes must balance, a named state must be declared in a scope enclosing the element, the operation must match the state's declared kind, and a `set` value must parse to that kind.
+Validates the declarative action attributes `data-herb-set`, `data-herb-toggle`, `data-herb-increment`, `data-herb-decrement`, `data-herb-reset` and `data-herb-by`. Clause syntax must parse, quotes must balance, a named state must be declared in a scope enclosing the element, the operation must match the state's declared kind, and a `set` value must parse to that kind. A derived state cannot be the target of any action, since its value follows from the states it reads.
 
 ## Rationale
 

--- a/javascript/packages/linter/docs/rules/herb-state-valid-bindings.md
+++ b/javascript/packages/linter/docs/rules/herb-state-valid-bindings.md
@@ -4,7 +4,7 @@
 
 ## Description
 
-Validates two-way bindings between form controls and declared states. A `checked` or `selected` attribute reading a state binds a boolean, so the state must be declared as one. A `value` attribute or a `<textarea>`'s content holds text, so the state must be a String, or an Integer for numeric inputs.
+Validates two-way bindings between form controls and declared states. A `checked` or `selected` attribute reading a state binds a boolean, so the state must be declared as one. A `value` attribute or a `<textarea>`'s content holds text, so the state must be a String, or an Integer for numeric inputs. A derived state cannot be bound at all, since a binding writes back what the user changes and a derived value follows from its sources.
 
 ## Rationale
 

--- a/javascript/packages/linter/docs/rules/herb-state-valid-declaration.md
+++ b/javascript/packages/linter/docs/rules/herb-state-valid-declaration.md
@@ -6,9 +6,13 @@
 
 Validates `<%# herb:state (name: default, ...) %>` directives. The signature must declare keyword parameters with defaults, each default must be a primitive the client can hold (`true`/`false`, an Integer, a String, a Symbol, or `nil`), a bare-identifier default must name a declared strict local, and a state name must be unique. It may not collide with a strict local, repeat within its scope, or appear in both an item and its region.
 
+A default may also read other states declared before it in the same signature (`busy: pending || failed`), which makes the state derived. The client re-evaluates it whenever a source changes. A derived default may not mix state reads with other Ruby, read a state declared after it, or read a state from an enclosing scope.
+
 ## Rationale
 
 A state is client-owned, so both sides have to agree on its value. The default carries the type the client validates operations against, which is why it is required and why it has to be a primitive with one text form both Ruby and JavaScript agree on. Floats print differently in the two languages, an Array on the page is a collection of items, and a Hash is a grouping each leaf can express as its own state.
+
+A derived state works because its default is the same condition grammar the client already resolves for branches, so declaring `busy: pending || failed` names the condition once and every read of `busy` stays current. An expression that mixes a state with server Ruby has no client answer, and one that reads forward has no server value yet, since declarations compile in signature order.
 
 The naming restrictions keep every read unambiguous. A local comes from the caller and a state is client-owned, so one name cannot mean both, and a name declared in an item and its region would make a later read depend on where it sits.
 
@@ -44,6 +48,14 @@ The engine raises these as compile errors when the template renders. This rule r
     <li><%= message.body %> <% if pending? %>Sending<% end %></li>
   <% end %>
 </ul>
+```
+
+```erb
+<%# herb:slots client %>
+<%# herb:state (pending: false, failed: false, busy: pending || failed) %>
+
+<div><% if busy %>Working<% else %>Ready<% end %></div>
+<input disabled="<%= busy %>">
 ```
 
 ### 🚫 Bad
@@ -89,6 +101,13 @@ The engine raises these as compile errors when the template renders. This rule r
 <%# herb:state (open: false) %>
 
 <% if open %>Open<% end %>
+```
+
+```erb
+<%# herb:slots client %>
+<%# herb:state (pending: false, busy: pending || current_user.admin?) %>
+
+<div><% if busy %>Working<% end %></div>
 ```
 
 ## References

--- a/javascript/packages/linter/src/rules/herb-state-no-unused-states.ts
+++ b/javascript/packages/linter/src/rules/herb-state-no-unused-states.ts
@@ -69,6 +69,10 @@ class UnusedStatesVisitor extends BaseRuleVisitor {
 
         for (const declaration of parsed.declarations) {
           this.declarations.push({ node, declaration, scope, used: false })
+
+          if (declaration.derived !== undefined && declaration.derived !== null && typeof declaration.derived === "object") {
+            this.uses.push({ source: declaration.defaultSource, stack: [...this.stack] })
+          }
         }
       }
 

--- a/javascript/packages/linter/src/rules/herb-state-valid-actions.ts
+++ b/javascript/packages/linter/src/rules/herb-state-valid-actions.ts
@@ -1,6 +1,6 @@
 import { BaseRuleVisitor } from "../utils/rule-utils.js"
 import { ParserRule } from "../types.js"
-import { ACTION_ATTRIBUTE_SCHEMA, BY_ATTRIBUTE, StateScopeMap, declaredKind, isActionAttribute, kindWithArticle } from "../utils/state-directives-utils.js"
+import { ACTION_ATTRIBUTE_SCHEMA, BY_ATTRIBUTE, StateScopeMap, declaredKind, isActionAttribute, isDerived, kindWithArticle } from "../utils/state-directives-utils.js"
 import { balancedQuotes, clauses, names, splitOutsideQuotes, unquote } from "@herb-tools/client/directives"
 
 import { forEachAttribute, getAttributeName, getStaticAttributeValueContent, hasDynamicOutput, getAttributeValueNodes } from "@herb-tools/core"
@@ -85,7 +85,18 @@ class StateValidActionsVisitor extends BaseRuleVisitor {
     for (const stateName of names(clause.rest)) {
       const declaration = this.declarationOf(attribute, stateName)
 
-      if (!declaration || !schema.needs) continue
+      if (!declaration) continue
+
+      if (isDerived(declaration)) {
+        this.addOffense(
+          `\`${name}\` on \`${stateName}\` can never work, because \`${stateName}\` is derived from \`${declaration.defaultSource}\`. Write the states it reads instead.`,
+          attribute.location,
+        )
+
+        continue
+      }
+
+      if (!schema.needs) continue
 
       const kind = declaredKind(declaration)
 
@@ -127,7 +138,18 @@ class StateValidActionsVisitor extends BaseRuleVisitor {
     const raw = unquote(assignment.slice(separator + 1).trim())
     const declaration = this.declarationOf(attribute, name)
 
-    if (!declaration || raw === "$value") return
+    if (!declaration) return
+
+    if (isDerived(declaration)) {
+      this.addOffense(
+        `\`${name}=${raw}\` can never work, because \`${name}\` is derived from \`${declaration.defaultSource}\`. Write the states it reads instead.`,
+        attribute.location,
+      )
+
+      return
+    }
+
+    if (raw === "$value") return
 
     const kind = declaredKind(declaration)
 

--- a/javascript/packages/linter/src/rules/herb-state-valid-bindings.ts
+++ b/javascript/packages/linter/src/rules/herb-state-valid-bindings.ts
@@ -1,6 +1,6 @@
 import { BaseRuleVisitor } from "../utils/rule-utils.js"
 import { ParserRule } from "../types.js"
-import { StateScopeMap, declaredKind } from "../utils/state-directives-utils.js"
+import { StateScopeMap, declaredKind, isDerived } from "../utils/state-directives-utils.js"
 import { bareReadName } from "@herb-tools/client/directives"
 
 import { forEachAttribute, getAttributeName, getAttributeValueNodes, getTagLocalName, isERBContentNode, isHTMLElementNode } from "@herb-tools/core"
@@ -56,6 +56,16 @@ class StateValidBindingsVisitor extends BaseRuleVisitor {
       if (!read) return
 
       const [name, declaration] = read
+
+      if (isDerived(declaration)) {
+        this.addOffense(
+          `\`${attributeName}\` binds the derived state \`${name}\`, and a binding writes back what the user changes. A derived state cannot be written, so bind one of its sources, or show the value outside a form control.`,
+          attribute.location,
+        )
+
+        return
+      }
+
       const kind = declaredKind(declaration)
 
       if (BOOLEAN_ATTRIBUTES.includes(attributeName!)) {
@@ -84,6 +94,16 @@ class StateValidBindingsVisitor extends BaseRuleVisitor {
     if (!read) return
 
     const [name, declaration] = read
+
+    if (isDerived(declaration)) {
+      this.addOffense(
+        `\`<textarea>\` binds the derived state \`${name}\`, and a binding writes back what the user changes. A derived state cannot be written, so bind one of its sources, or show the value outside a form control.`,
+        node.location,
+      )
+
+      return
+    }
+
     const kind = declaredKind(declaration)
 
     if (!TEXT_KINDS.includes(kind)) {

--- a/javascript/packages/linter/src/rules/herb-state-valid-declaration.ts
+++ b/javascript/packages/linter/src/rules/herb-state-valid-declaration.ts
@@ -1,6 +1,6 @@
 import { BaseRuleVisitor, locationFromContentOffset } from "../utils/rule-utils.js"
 import { ParserRule } from "../types.js"
-import { stateSignatureOf } from "../utils/state-directives-utils.js"
+import { isDerived, stateSignatureOf } from "../utils/state-directives-utils.js"
 
 import { isRubyParameterNode, Location } from "@herb-tools/core"
 
@@ -77,6 +77,24 @@ class StateValidDeclarationVisitor extends BaseRuleVisitor {
     const nameLocation = this.contentLocation(node, declaration.nameOffset, declaration.name.length)
     const defaultLocation = this.contentLocation(node, declaration.defaultOffset, Math.max(declaration.defaultSource.length, 1))
 
+    if (declaration.derived === "mixed") {
+      this.addOffense(
+        `The state \`${declaration.name}\` defaults to \`${declaration.defaultSource}\`, which mixes state reads with other Ruby. A derived state reads only other states, and a seed reads none, so split the two apart.`,
+        defaultLocation,
+      )
+
+      return
+    }
+
+    if (declaration.derived === "forward") {
+      this.addOffense(
+        `The state \`${declaration.name}\` reads a state that is declared after it. Reorder the signature, since a derived state reads only states declared before it.`,
+        defaultLocation,
+      )
+
+      return
+    }
+
     switch (declaration.kind) {
       case "missing":
         this.addOffense(
@@ -107,6 +125,17 @@ class StateValidDeclarationVisitor extends BaseRuleVisitor {
 
         return
       case "bare":
+        if (isDerived(declaration)) break
+
+        if (this.scopes.some((outer) => outer !== this.scopes[this.scopes.length - 1] && outer.has(declaration.defaultSource))) {
+          this.addOffense(
+            `The state \`${declaration.name}\` reads \`${declaration.defaultSource}\` from an enclosing scope. Declare it beside its sources, since a derived state reads states declared in its own signature.`,
+            defaultLocation,
+          )
+
+          return
+        }
+
         if (!this.locals.has(declaration.defaultSource)) {
           this.addOffense(
             `The state \`${declaration.name}\` defaults to \`${declaration.defaultSource}\`, which is not a declared strict local. Declare it, like \`<%# locals: (${declaration.defaultSource}: false) %>\`, or use a literal default. A bare name a caller never passed raises a \`NameError\` at render.`,

--- a/javascript/packages/linter/src/utils/state-directives-utils.ts
+++ b/javascript/packages/linter/src/utils/state-directives-utils.ts
@@ -44,7 +44,15 @@ export function slotsDirectiveMode(node: ERBContentNode): "server" | "client" | 
   return slotsDirectiveModeOf(node.content?.value ?? "")
 }
 
+export function isDerived(declaration: StateDeclaration): boolean {
+  return declaration.derived !== undefined && declaration.derived !== null && typeof declaration.derived === "object"
+}
+
 export function declaredKind(declaration: StateDeclaration): "boolean" | "integer" | "string" | "symbol" | "nil" | "seeded" {
+  if (declaration.derived !== undefined && declaration.derived !== null && typeof declaration.derived === "object") {
+    return declaration.derived.kind
+  }
+
   switch (declaration.kind) {
     case "boolean":
     case "integer":

--- a/javascript/packages/linter/test/rules/herb-state-no-unused-states.test.ts
+++ b/javascript/packages/linter/test/rules/herb-state-no-unused-states.test.ts
@@ -94,4 +94,12 @@ describe("HerbStateNoUnusedStatesRule", () => {
       <% end %>
     `)
   })
+  test("counts a derivation's sources as used", () => {
+    expectWarning("The state `stray` is never read or written in this template. Remove it, or disable this line when only app code uses it through `stateFor` or `useState`.")
+
+    assertOffenses(dedent`
+      <%# herb:state (pending: false, failed: false, stray: false, busy: pending || failed) %>
+      <div><% if busy %>B<% end %></div>
+    `)
+  })
 })

--- a/javascript/packages/linter/test/rules/herb-state-valid-actions.test.ts
+++ b/javascript/packages/linter/test/rules/herb-state-valid-actions.test.ts
@@ -167,4 +167,24 @@ describe("HerbStateValidActionsRule", () => {
       <button data-herb-set="draft=">Empty</button>
     `)
   })
+  test("flags every action on a derived state", () => {
+    expectError("`data-herb-toggle` on `busy` can never work, because `busy` is derived from `pending || failed`. Write the states it reads instead.")
+    expectError("`busy=false` can never work, because `busy` is derived from `pending || failed`. Write the states it reads instead.")
+
+    assertOffenses(dedent`
+      <%# herb:state (pending: false, failed: false, busy: pending || failed) %>
+      <button data-herb-toggle="busy">Toggle</button>
+      <button data-herb-set="busy=false">Clear</button>
+      <div><% if busy %>B<% end %></div>
+    `)
+  })
+
+  test("allows actions on a derived state's sources", () => {
+    expectNoOffenses(dedent`
+      <%# herb:state (pending: false, failed: false, busy: pending || failed) %>
+      <button data-herb-toggle="pending">Toggle</button>
+      <button data-herb-set="failed=true">Fail</button>
+      <div><% if busy %>B<% end %></div>
+    `)
+  })
 })

--- a/javascript/packages/linter/test/rules/herb-state-valid-bindings.test.ts
+++ b/javascript/packages/linter/test/rules/herb-state-valid-bindings.test.ts
@@ -86,4 +86,21 @@ describe("HerbStateValidBindingsRule", () => {
       <% end %>
     `)
   })
+  test("flags a control bound to a derived state", () => {
+    expectError("`checked` binds the derived state `busy`, and a binding writes back what the user changes. A derived state cannot be written, so bind one of its sources, or show the value outside a form control.")
+
+    assertOffenses(dedent`
+      <%# herb:state (pending: false, failed: false, busy: pending || failed) %>
+      <input type="checkbox" checked="<%= busy %>">
+    `)
+  })
+
+  test("flags a textarea bound to a derived state", () => {
+    expectError("`<textarea>` binds the derived state `copy`, and a binding writes back what the user changes. A derived state cannot be written, so bind one of its sources, or show the value outside a form control.")
+
+    assertOffenses(dedent`
+      <%# herb:state (draft: "", copy: draft) %>
+      <textarea><%= copy %></textarea>
+    `)
+  })
 })

--- a/javascript/packages/linter/test/rules/herb-state-valid-declaration.test.ts
+++ b/javascript/packages/linter/test/rules/herb-state-valid-declaration.test.ts
@@ -183,4 +183,45 @@ describe("HerbStateValidDeclarationRule", () => {
       <div></div>
     `)
   })
+  test("allows derived states over earlier declarations", () => {
+    expectNoOffenses(dedent`
+      <%# herb:state (pending: false, failed: false, attempts: 0, sort: "name", busy: pending || failed, many: attempts > 2, named: sort == "name", total: attempts, pred: pending?) %>
+      <div><% if busy %>B<% end %></div>
+      <p><%= total %></p>
+      <span><% if many %>M<% end %></span>
+      <b><% if named %>N<% end %></b>
+      <i><% if pred %>P<% end %></i>
+    `)
+  })
+
+  test("flags a derived default mixing states with other Ruby", () => {
+    expectError("The state `busy` defaults to `pending || current_user.admin?`, which mixes state reads with other Ruby. A derived state reads only other states, and a seed reads none, so split the two apart.")
+
+    assertOffenses(dedent`
+      <%# herb:state (pending: false, busy: pending || current_user.admin?) %>
+      <div><% if busy %>B<% end %></div>
+    `)
+  })
+
+  test("flags a derived state reading forward", () => {
+    expectError("The state `busy` reads a state that is declared after it. Reorder the signature, since a derived state reads only states declared before it.")
+
+    assertOffenses(dedent`
+      <%# herb:state (busy: pending || failed, pending: false, failed: false) %>
+      <div><% if busy %>B<% end %></div>
+    `)
+  })
+
+  test("flags an item state deriving from the region", () => {
+    expectError("The state `mirror` reads `open` from an enclosing scope. Declare it beside its sources, since a derived state reads states declared in its own signature.")
+
+    assertOffenses(dedent`
+      <%# herb:state (open: false) %>
+      <% @rows.each do |row| %>
+        <%# herb:state (mirror: open) %>
+        <span><% if mirror %>M<% end %></span>
+      <% end %>
+      <% if open? %>O<% end %>
+    `)
+  })
 })

--- a/javascript/packages/linter/test/rules/herb-state-valid-reads.test.ts
+++ b/javascript/packages/linter/test/rules/herb-state-valid-reads.test.ts
@@ -265,6 +265,23 @@ describe("HerbStateValidReadsRule", () => {
     `)
   })
 
+  test("infers a derived state's kind for its reads", () => {
+    expectNoOffenses(dedent`
+      <%# herb:state (pending: false, failed: false, attempts: 0, busy: pending || failed, total: attempts) %>
+      <% if busy? %>Busy<% end %>
+      <% if total > 3 %>Many<% end %>
+    `)
+  })
+
+  test("flags a comparison against a derived state's inferred kind", () => {
+    expectError("`busy == 3` compares the Boolean state `busy` against an Integer literal, so it can never match. Compare against a Boolean, or redeclare the state.")
+
+    assertOffenses(dedent`
+      <%# herb:state (pending: false, failed: false, busy: pending || failed) %>
+      <% if busy == 3 %>x<% end %>
+    `)
+  })
+
   test("flags a case that does not switch on a bare state read", () => {
     expectError("`case sort.downcase` does not switch on a bare state read. Write the state alone, or compute the value into its own state.")
 

--- a/lib/herb/engine/slot_visitor.rb
+++ b/lib/herb/engine/slot_visitor.rb
@@ -644,7 +644,7 @@ module Herb
         return unless signature
 
         scope = @collection_nodes.last
-        declared = StateDirectives.parse(signature, @strict_locals)
+        declared = StateDirectives.parse(signature, @strict_locals, enclosing: scope ? @region_states : {})
         empty = {} #: Hash[String, StateDirectives::Declaration]
         bucket = scope ? (@item_states[scope] ||= empty) : @region_states
 
@@ -722,9 +722,17 @@ module Herb
 
       #: (StateDirectives::Declaration) -> String
       def state_assignment(declaration)
-        return "#{declaration.name} = !!(#{declaration.default})" if declaration.kind == :boolean
+        source = declaration.default
 
-        "#{declaration.name} = #{declaration.default}"
+        if declaration.derived
+          StateDirectives.condition_names(declaration.derived).each do |name|
+            source = source.gsub(/(?<![\w?!])#{Regexp.escape(name)}\?(?![\w?!])/) { name }
+          end
+        end
+
+        return "#{declaration.name} = !!(#{source})" if declaration.kind == :boolean
+
+        "#{declaration.name} = #{source}"
       end
 
       #: () -> void

--- a/lib/herb/engine/state_directives.rb
+++ b/lib/herb/engine/state_directives.rb
@@ -24,6 +24,7 @@ module Herb
         :name,    #: String
         :kind,    #: Symbol
         :default, #: String
+        :derived, #: untyped
         :line,    #: Integer?
         :column   #: Integer?
       )
@@ -53,8 +54,8 @@ module Herb
           PATTERN.match(node.content&.value.to_s.strip)&.[](:signature)
         end
 
-        #: (String, Hash[String, Symbol]) -> Array[Declaration]
-        def parse(signature, locals)
+        #: (String, Hash[String, Symbol], ?enclosing: Hash[String, Declaration]) -> Array[Declaration]
+        def parse(signature, locals, enclosing: {})
           result = Prism.parse("def __herb_states#{signature}; end")
 
           raise Herb::Engine::CompilationError, "`herb:state #{signature}` does not parse as a keyword signature" if result.failure?
@@ -69,7 +70,15 @@ module Herb
                   "`herb:state #{signature}` must declare keyword parameters with defaults, like `(pending: false)`"
           end
 
-          parameters.keywords.map { |keyword| declaration_for(keyword, locals) }
+          names = parameters.keywords.map { |keyword| keyword.name.to_s }
+          declared = {} #: Hash[String, Declaration]
+
+          parameters.keywords.map { |keyword|
+            declaration = declaration_for(keyword, locals, declared, names, enclosing)
+            declared[declaration.name] = declaration
+
+            declaration
+          }
         end
 
         #: (String, Hash[String, Declaration]) -> (Read | Combo | Symbol)?
@@ -139,6 +148,17 @@ module Herb
           read.parts.flat_map { |part| read_names(part) }
         end
 
+        #: (untyped) -> Array[String]
+        def condition_names(entry)
+          return entry.values.flat_map { |parts| parts.flat_map { |part| condition_names(part) } } if entry.is_a?(Hash) && !entry.key?("state")
+          return [entry["state"]] if entry.is_a?(Hash)
+
+          names = [entry[0]] #: Array[String]
+          names += condition_names(entry[1]) if entry[1].is_a?(Hash)
+
+          names.uniq
+        end
+
         #: (Read | Combo) -> untyped
         def condition_entry(read)
           return { read.op => read.parts.map { |part| condition_entry(part) } } if read.is_a?(Combo)
@@ -188,8 +208,8 @@ module Herb
 
         private
 
-        #: (untyped, Hash[String, Symbol]) -> Declaration
-        def declaration_for(keyword, locals)
+        #: (untyped, Hash[String, Symbol], Hash[String, Declaration], Array[String], Hash[String, Declaration]) -> Declaration
+        def declaration_for(keyword, locals, declared, names, enclosing)
           name = keyword.name.to_s
 
           unless keyword.is_a?(Prism::OptionalKeywordParameterNode)
@@ -200,7 +220,7 @@ module Herb
           value = keyword.value
           kind = KINDS[value.class.name]
 
-          return Declaration.new(name: name, kind: kind, default: value.slice, line: nil, column: nil) if kind
+          return Declaration.new(name: name, kind: kind, default: value.slice, derived: nil, line: nil, column: nil) if kind
 
           case value
           when Prism::FloatNode
@@ -213,18 +233,64 @@ module Herb
             raise Herb::Engine::CompilationError,
                   "the state `#{name}` has a Hash default; declare each leaf as its own state, like `#{name}_title`"
           when Prism::CallNode
-            bare_default(name, value, locals)
+            derived_default(name, value, declared, names) || bare_default(name, value, locals, enclosing)
           else
-            Declaration.new(name: name, kind: :seeded, default: value.slice, line: nil, column: nil)
+            derived_default(name, value, declared, names) ||
+              Declaration.new(name: name, kind: :seeded, default: value.slice, derived: nil, line: nil, column: nil)
           end
         end
 
-        #: (String, untyped, Hash[String, Symbol]) -> Declaration
-        def bare_default(name, value, locals)
+        #: (String, untyped, Hash[String, Declaration], Array[String]) -> Declaration?
+        def derived_default(name, value, declared, names)
+          read = tree_read(value, declared) #: untyped
+
+          if read == :computed
+            raise Herb::Engine::CompilationError,
+                  "the state `#{name}` defaults to `#{value.slice}`, which mixes state reads with other Ruby; " \
+                  "a derived state reads only other states, and a seed reads none, so split the two apart"
+          end
+
+          if read.nil?
+            later = {} #: Hash[String, untyped]
+            (names - declared.keys - [name]).each { |candidate| later[candidate] = true }
+
+            if mentions_any?(value.slice, later)
+              raise Herb::Engine::CompilationError,
+                    "the state `#{name}` reads a state that is declared after it; a derived state reads only " \
+                    "states declared before it, so reorder the signature"
+            end
+
+            if mentions_any?(value.slice, declared)
+              raise Herb::Engine::CompilationError,
+                    "the state `#{name}` defaults to `#{value.slice}`, which mixes state reads with other Ruby; " \
+                    "a derived state reads only other states, and a seed reads none, so split the two apart"
+            end
+
+            return nil
+          end
+
+          Declaration.new(name: name, kind: derived_kind(read), default: value.slice, derived: condition_entry(read), line: nil, column: nil)
+        end
+
+        #: (Read | Combo) -> Symbol
+        def derived_kind(read)
+          return read.kind || :seeded if read.is_a?(Read) && read.comparand.nil? && read.against.nil?
+
+          :boolean
+        end
+
+        #: (String, untyped, Hash[String, Symbol], Hash[String, Declaration]) -> Declaration
+        def bare_default(name, value, locals, enclosing)
           identifier = value.name.to_s
 
           unless value.receiver.nil? && value.arguments.nil? && value.block.nil? && BARE.match?(identifier)
-            return Declaration.new(name: name, kind: :seeded, default: value.slice, line: nil, column: nil)
+            return Declaration.new(name: name, kind: :seeded, default: value.slice, derived: nil, line: nil, column: nil)
+          end
+
+          if enclosing.key?(identifier)
+            raise Herb::Engine::CompilationError,
+                  "the state `#{name}` reads `#{identifier}` from an enclosing scope; a derived state reads " \
+                  "states declared in its own signature, so declare it beside its sources"
           end
 
           kind = locals[identifier]
@@ -235,7 +301,7 @@ module Herb
                   "a bare name that was never passed raises at render, so it has to be declared"
           end
 
-          Declaration.new(name: name, kind: kind, default: identifier, line: nil, column: nil)
+          Declaration.new(name: name, kind: kind, default: identifier, derived: nil, line: nil, column: nil)
         end
 
         #: (String) -> untyped
@@ -251,6 +317,14 @@ module Herb
 
         #: (untyped, Hash[String, Declaration]) -> Read?
         def bare_read(node, states)
+          if node.is_a?(Prism::LocalVariableReadNode)
+            declaration = states[node.name.to_s]
+
+            return nil unless declaration
+
+            return Read.new(name: node.name.to_s, comparand: nil, kind: declaration.kind, operator: nil, against: nil)
+          end
+
           return nil unless node.is_a?(Prism::CallNode) && node.receiver.nil? && node.arguments.nil? && node.block.nil?
 
           spelled = node.name.to_s

--- a/sig/herb/engine/state_directives.rbs
+++ b/sig/herb/engine/state_directives.rbs
@@ -18,16 +18,18 @@ module Herb
 
         attr_reader default(): String
 
+        attr_reader derived(): untyped
+
         attr_reader line(): Integer?
 
         attr_reader column(): Integer?
 
-        def self.new: (String name, Symbol kind, String default, Integer? line, Integer? column) -> instance
-                    | (name: String, kind: Symbol, default: String, line: Integer?, column: Integer?) -> instance
+        def self.new: (String name, Symbol kind, String default, untyped derived, Integer? line, Integer? column) -> instance
+                    | (name: String, kind: Symbol, default: String, derived: untyped, line: Integer?, column: Integer?) -> instance
 
-        def self.members: () -> [ :name, :kind, :default, :line, :column ]
+        def self.members: () -> [ :name, :kind, :default, :derived, :line, :column ]
 
-        def members: () -> [ :name, :kind, :default, :line, :column ]
+        def members: () -> [ :name, :kind, :default, :derived, :line, :column ]
       end
 
       class Read < Data
@@ -69,8 +71,8 @@ module Herb
       # : (untyped) -> String?
       def self.signature_of: (untyped) -> String?
 
-      # : (String, Hash[String, Symbol]) -> Array[Declaration]
-      def self.parse: (String, Hash[String, Symbol]) -> Array[Declaration]
+      # : (String, Hash[String, Symbol], ?enclosing: Hash[String, Declaration]) -> Array[Declaration]
+      def self.parse: (String, Hash[String, Symbol], ?enclosing: Hash[String, Declaration]) -> Array[Declaration]
 
       # : (String, Hash[String, Declaration]) -> (Read | Combo | Symbol)?
       def self.condition_read: (String, Hash[String, Declaration]) -> (Read | Combo | Symbol)?
@@ -90,6 +92,9 @@ module Herb
       # : (Read | Combo) -> Array[String]
       def self.read_names: (Read | Combo) -> Array[String]
 
+      # : (untyped) -> Array[String]
+      def self.condition_names: (untyped) -> Array[String]
+
       # : (Read | Combo) -> untyped
       def self.condition_entry: (Read | Combo) -> untyped
 
@@ -102,11 +107,17 @@ module Herb
       # : (String, Hash[String, Declaration]) -> bool
       def self.mentions_any?: (String, Hash[String, Declaration]) -> bool
 
-      # : (untyped, Hash[String, Symbol]) -> Declaration
-      private def self.declaration_for: (untyped, Hash[String, Symbol]) -> Declaration
+      # : (untyped, Hash[String, Symbol], Hash[String, Declaration], Array[String], Hash[String, Declaration]) -> Declaration
+      private def self.declaration_for: (untyped, Hash[String, Symbol], Hash[String, Declaration], Array[String], Hash[String, Declaration]) -> Declaration
 
-      # : (String, untyped, Hash[String, Symbol]) -> Declaration
-      private def self.bare_default: (String, untyped, Hash[String, Symbol]) -> Declaration
+      # : (String, untyped, Hash[String, Declaration], Array[String]) -> Declaration?
+      private def self.derived_default: (String, untyped, Hash[String, Declaration], Array[String]) -> Declaration?
+
+      # : (Read | Combo) -> Symbol
+      private def self.derived_kind: (Read | Combo) -> Symbol
+
+      # : (String, untyped, Hash[String, Symbol], Hash[String, Declaration]) -> Declaration
+      private def self.bare_default: (String, untyped, Hash[String, Symbol], Hash[String, Declaration]) -> Declaration
 
       # : (String) -> untyped
       private def self.expression_node: (String) -> untyped

--- a/test/engine/slots/dependencies_test.rb
+++ b/test/engine/slots/dependencies_test.rb
@@ -458,6 +458,19 @@ module Engine
         assert_equal [{ "branch" => 0, "all" => [["pending", nil], ["failed", nil]] }], conditional["arms"]
       end
 
+      test "carries a derived state with its condition" do
+        path = write("index.html.erb", <<~ERB)
+          <%# herb:state (pending: false, failed: false, busy: pending || failed) %>
+          <div><% if busy %>Busy<% else %>Idle<% end %></div>
+        ERB
+
+        manifest = subject.payload(path)["states"].values.first
+        declaration = manifest["declarations"].find { |declared| declared["name"] == "busy" }
+
+        assert_equal "boolean", declaration["kind"].to_s
+        assert_equal({ "any" => [["pending", nil], ["failed", nil]] }, declaration["derived"])
+      end
+
       test "carries the states a template declares" do
         path = write("index.html.erb", <<~ERB)
           <%# herb:state (pending: false, attempts: 0) %>

--- a/test/engine/slots/states_test.rb
+++ b/test/engine/slots/states_test.rb
@@ -379,6 +379,75 @@ module Engine
         assert_includes on, "<input disabled"
       end
 
+      test "a pure-state default declares a derived state" do
+        visitor, = compile(<<~ERB)
+          <%# herb:state (pending: false, failed: false, attempts: 0, sort: "name", busy: pending || failed, many: attempts > 2, named: sort == "name", total: attempts) %>
+          <div><% if busy %>B<% end %></div>
+        ERB
+
+        entries = visitor.state_entries.to_h { |entry| [entry[:name], entry] }
+
+        assert_equal :boolean, entries.fetch("busy")[:kind]
+        assert_equal({ "any" => [["pending", nil], ["failed", nil]] }, entries.fetch("busy")[:derived])
+        assert_equal ["attempts", "2", ">"], entries.fetch("many")[:derived]
+        assert_equal ["sort", %("name")], entries.fetch("named")[:derived]
+        assert_equal :integer, entries.fetch("total")[:kind]
+        assert_equal ["attempts", nil], entries.fetch("total")[:derived]
+        assert_nil entries.fetch("pending")[:derived]
+      end
+
+      test "the server renders a derived state from its sources" do
+        rendered = render(<<~ERB)
+          <%# herb:state (pending: true, failed: false, busy: pending? || failed?) %>
+          <div><% if busy %>Busy<% else %>Idle<% end %></div>
+        ERB
+
+        assert_includes rendered, "Busy"
+      end
+
+      test "a derived default mixing states with other Ruby raises" do
+        refuse(
+          %(<%# herb:state (pending: false, busy: pending || current_user.admin?) %><p><%= pending %></p>),
+          /mixes state reads with other Ruby/
+        )
+
+        refuse(
+          %(<%# herb:state (attempts: 0, doubled: attempts + 1) %><p><%= attempts %></p>),
+          /mixes state reads with other Ruby/
+        )
+      end
+
+      test "a derived state cannot read forward" do
+        refuse(
+          %(<%# herb:state (busy: pending || failed, pending: false, failed: false) %><p><%= pending %></p>),
+          /declared after it/
+        )
+      end
+
+      test "an item state cannot derive from the region" do
+        template = <<~ERB
+          <%# herb:state (open: false) %>
+          <ul>
+            <% @rows.each do |row| %>
+              <%# herb:key row.id %>
+              <%# herb:state (mirror: open) %>
+              <li id="<%= row.id %>"><%= row.name %></li>
+            <% end %>
+          </ul>
+          <% if open? %>O<% end %>
+        ERB
+
+        refuse(template, /from an enclosing scope/)
+      end
+
+      test "a seed reading no state still compiles" do
+        visitor, = compile(%(<%# herb:state (pending: false, hue: current_user.hue) %><p><%= pending %></p>))
+        entries = visitor.state_entries.to_h { |entry| [entry[:name], entry] }
+
+        assert_equal :seeded, entries.fetch("hue")[:kind]
+        assert_nil entries.fetch("hue")[:derived]
+      end
+
       test "an unless reads a state with its arms inverted" do
         template = %(<%# herb:state (pending: false) %><div><% unless pending %>Idle<% else %>Busy<% end %></div>)
         visitor, = compile(template)


### PR DESCRIPTION
This pull request lets a state's default read the states declared before it, which makes the state derived.

Naming a condition once is better than repeating it at every read:

```erb
<%# herb:state (pending: false, failed: false, busy: pending || failed) %>

<div><% if busy %>Working<% else %>Ready<% end %></div>
<input disabled="<%= busy %>">
```

A derived default is the same condition grammar the client already resolves for branches, so `busy` needs no new runtime concept. The client re-evaluates it whenever a source changes, and every read of it stays current.

A derived default may not mix a state with other Ruby, read a state declared after it, or read a state from an enclosing scope. The first has no client answer, and the other two have no server value at the point they are compiled.
