### PR TITLE
Engine: Count items into a state with a template fold

### DIFF
--- a/javascript/packages/client/src/state.ts
+++ b/javascript/packages/client/src/state.ts
@@ -23,9 +23,16 @@ export interface DeclaredState {
   kind: StateKind
   default: string
   derived?: StateCondition | null
+  count?: StateCount | null
   scope: "region" | number
   line?: number | null
   column?: number | null
+}
+
+export interface StateCount {
+  collection: number
+  when: StateCondition | null
+  by?: number
 }
 
 export interface StateManifest {
@@ -182,7 +189,10 @@ export class SlotState {
   }
 
   adopt(root: ParentNode = document): number {
-    if (typeof document !== "undefined") document.addEventListener(SLOT_EVENT, this.#migrateItemState)
+    if (typeof document !== "undefined") {
+      document.addEventListener(SLOT_EVENT, this.#migrateItemState)
+      document.addEventListener(SLOT_EVENT, this.#recountItems)
+    }
 
     const templates = [...root.querySelectorAll<HTMLTemplateElement>(DEPENDENCIES_SELECTOR)]
 
@@ -199,6 +209,7 @@ export class SlotState {
 
     document.addEventListener(SLOT_EVENT, this.#syncProperty)
     document.addEventListener(SLOT_EVENT, this.#migrateItemState)
+    document.addEventListener(SLOT_EVENT, this.#recountItems)
     document.addEventListener("input", this.#onBoundInput)
     document.addEventListener("change", this.#onBoundInput)
     document.addEventListener("reset", this.#onFormReset)
@@ -232,6 +243,7 @@ export class SlotState {
 
     document.removeEventListener(SLOT_EVENT, this.#syncProperty)
     document.removeEventListener(SLOT_EVENT, this.#migrateItemState)
+    document.removeEventListener(SLOT_EVENT, this.#recountItems)
     document.removeEventListener("input", this.#onBoundInput)
     document.removeEventListener("change", this.#onBoundInput)
     document.removeEventListener("reset", this.#onFormReset)
@@ -533,6 +545,18 @@ export class SlotState {
         return false
       }
 
+      if (declaration.count) {
+        report({
+          template: resolved.region.file,
+          message: `\`${name}\` is counted from the template's loop, so it cannot be written. Write the item states its condition reads.`,
+          code: "herb-state-counted",
+          severity: "error",
+          value: name,
+        })
+
+        return false
+      }
+
       const shared = [...groups.keys()].find(candidate => candidate.region === target.region && candidate.item === target.item) ?? target
 
       groups.set(shared, [...(groups.get(shared) ?? []), name])
@@ -545,6 +569,11 @@ export class SlotState {
     for (const [scope, grouped] of groups) {
       dependents.set(scope, this.#derivedDependents(manifest, scope, grouped).map((name) => ({ name, previous: this.#valueOf(name, scope) })))
     }
+
+    const regionScope: StateScope = { region: resolved.region, item: null }
+    const counted = this.#countDeclarations(manifest).map((declaration) => ({ name: declaration.name, previous: this.#valueOf(declaration.name, regionScope) }))
+    const countDependents = this.#derivedDependents(manifest, regionScope, counted.map((entry) => entry.name))
+      .map((name) => ({ name, previous: this.#valueOf(name, regionScope) }))
 
     this.#slots.transaction(() => {
       for (const [name, value] of Object.entries(values)) {
@@ -571,6 +600,22 @@ export class SlotState {
         this.#writeConditionals(manifest, scope, changed)
         this.#writePresence(manifest, scope, changed)
       }
+
+      const recounted: string[] = []
+
+      for (const entry of [...counted, ...countDependents]) {
+        const value = this.#valueOf(entry.name, regionScope)
+
+        if (value === entry.previous) continue
+
+        recounted.push(entry.name)
+        this.#writeValueSlots(manifest, regionScope, entry.name, value)
+      }
+
+      if (recounted.length > 0) {
+        this.#writeConditionals(manifest, regionScope, recounted)
+        this.#writePresence(manifest, regionScope, recounted)
+      }
     }, { retain: false })
 
     for (const [name, value] of Object.entries(values)) {
@@ -583,6 +628,12 @@ export class SlotState {
 
         if (value !== dependent.previous) this.#announceState(scope, dependent.name, value, dependent.previous)
       }
+    }
+
+    for (const entry of [...counted, ...countDependents]) {
+      const value = this.#valueOf(entry.name, regionScope)
+
+      if (value !== entry.previous) this.#announceState(regionScope, entry.name, value, entry.previous)
     }
 
     return true
@@ -703,6 +754,7 @@ export class SlotState {
     const manifest = this.manifestFor(scope.region)
     const declaration = manifest ? this.#declaration(manifest, scope, name) : null
 
+    if (declaration?.count) return this.#countValue(declaration, scope)
     if (declaration?.derived) return this.#deriveValue(declaration, scope)
 
     const stored = this.#scoped.get(scope.region)?.get(scope.item?.key ?? "")?.get(name)
@@ -724,6 +776,43 @@ export class SlotState {
     }
 
     return conditionMatches(entry, (name) => this.#valueOf(name, scope))
+  }
+
+  #countDeclarations(manifest: StateManifest): DeclaredState[] {
+    return manifest.declarations.filter((declaration) => declaration.count)
+  }
+
+  #lastCounts = new WeakMap<Region, Map<string, StateValue>>()
+
+  #countValue(declaration: DeclaredState, scope: StateScope): StateValue {
+    const count = declaration.count
+
+    if (count === undefined || count === null) return null
+
+    const base = parseLiteral(declaration.default)
+    const start = typeof base === "number" ? base : 0
+    const slot = scope.region.slots.get(count.collection)
+    const items = slot && "items" in slot ? slot.items : null
+
+    if (!items) return start
+
+    let matches = 0
+
+    for (const item of items.values()) {
+      const itemScope: StateScope = { region: scope.region, item }
+
+      if (count.when === null || count.when === undefined || conditionMatches(count.when, (name) => this.#valueOf(name, itemScope))) {
+        matches += 1
+      }
+    }
+
+    const value = start + matches * (count.by ?? 1)
+    const cache = this.#lastCounts.get(scope.region) ?? new Map<string, StateValue>()
+
+    cache.set(declaration.name, value)
+    this.#lastCounts.set(scope.region, cache)
+
+    return value
   }
 
   #derivedDependents(manifest: StateManifest, scope: StateScope, written: string[]): string[] {
@@ -1034,6 +1123,77 @@ export class SlotState {
   #onPopState = (): void => {
     this.#readLocation()
   }
+
+  #recountItems = (event: Event): void => {
+    const detail = (event as CustomEvent<SlotEventDetail>).detail
+
+    if (detail.operation !== "item-added" && detail.operation !== "item-removed") return
+    if (!detail.slot) return
+
+    const region = this.#slots.regionOf(detail.slot)
+
+    if (!region) return
+
+    const manifest = this.manifestFor(region)
+
+    if (!manifest) return
+    if (!this.#countDeclarations(manifest).some((declaration) => declaration.count?.collection === detail.index)) return
+    if (this.#recountQueued.has(region)) return
+
+    this.#recountQueued.add(region)
+
+    queueMicrotask(() => {
+      this.#recountQueued.delete(region)
+      this.#recountRegion(region)
+    })
+  }
+
+  #recountRegion(region: Region): void {
+    const manifest = this.manifestFor(region)
+
+    if (!manifest) return
+
+    const regionScope: StateScope = { region, item: null }
+    const changed: { name: string; value: StateValue; previous: StateValue }[] = []
+
+    for (const declaration of this.#countDeclarations(manifest)) {
+      const previous = this.#lastCounts.get(region)?.get(declaration.name) ?? null
+      const value = this.#valueOf(declaration.name, regionScope)
+
+      if (value === previous) continue
+
+      changed.push({ name: declaration.name, value, previous })
+    }
+
+    if (changed.length === 0) return
+
+    const cascade = this.#derivedDependents(manifest, regionScope, changed.map((entry) => entry.name))
+      .map((name) => ({ name, previous: this.#lastCounts.get(region)?.get(name) ?? null, value: this.#valueOf(name, regionScope) }))
+      .filter((entry) => entry.value !== entry.previous)
+
+    const cache = this.#lastCounts.get(region) ?? new Map<string, StateValue>()
+
+    for (const entry of cascade) cache.set(entry.name, entry.value)
+
+    this.#lastCounts.set(region, cache)
+
+    this.#slots.transaction(() => {
+      for (const entry of [...changed, ...cascade]) {
+        this.#writeValueSlots(manifest, regionScope, entry.name, entry.value)
+      }
+
+      const names = [...changed, ...cascade].map((entry) => entry.name)
+
+      this.#writeConditionals(manifest, regionScope, names)
+      this.#writePresence(manifest, regionScope, names)
+    }, { retain: false })
+
+    for (const entry of [...changed, ...cascade]) {
+      this.#announceState(regionScope, entry.name, entry.value, entry.previous)
+    }
+  }
+
+  #recountQueued = new Set<Region>()
 
   #migrateItemState = (event: Event): void => {
     const detail = (event as CustomEvent<SlotEventDetail>).detail

--- a/javascript/packages/client/test/state-scoped.test.ts
+++ b/javascript/packages/client/test/state-scoped.test.ts
@@ -636,3 +636,120 @@ describe("derived states", () => {
     expect(names).toContain("busy")
   })
 })
+
+describe("counted states", () => {
+  const COUNT_FILE = "app/views/page/counts.html.erb"
+
+  const COUNT_PAGE =
+    `<!--herb-region:${COUNT_FILE}:cafe1234:0-->` +
+    `<ul><!--herb-slot:0:collection-->` +
+    `<!--herb-item:0:a--><li id="a"><i><!--herb-slot:1:conditional--><!--herb-branch:1:1-->plain<!--/herb-slot:1--></i></li><!--/herb-item:0-->` +
+    `<!--herb-item:0:b--><li id="b"><i><!--herb-slot:1:conditional--><!--herb-branch:1:1-->plain<!--/herb-slot:1--></i></li><!--/herb-item:0-->` +
+    `<!--/herb-slot:0--></ul>` +
+    `<p><!--herb-slot:2-->0<!--/herb-slot:2--></p>` +
+    `<b><!--herb-slot:4:conditional--><!--herb-branch:4:1-->None<!--/herb-slot:4--></b>` +
+    `<template data-herb-region="${COUNT_FILE}:cafe1234">` +
+    `<!--herb-branch:0:item--><!--herb-item:0:--><li id=""><i><!--herb-slot:1:conditional--><!--/herb-slot:1--></i></li><!--/herb-item:0-->` +
+    `<!--herb-branch:1:0-->starred<!--herb-branch:1:1-->plain` +
+    `<!--herb-branch:4:0-->Some<!--herb-branch:4:1-->None` +
+    `</template>` +
+    `<!--/herb-region:${COUNT_FILE}-->`
+
+  const COUNT_MANIFEST = {
+    state: {},
+    states: {
+      [COUNT_FILE]: {
+        version: "cafe1234",
+        declarations: [
+          { name: "pending", kind: "boolean", default: "false", scope: 0 },
+          { name: "pending_count", kind: "integer", default: "0", count: { collection: 0, when: ["pending", null], by: 1 }, scope: "region" },
+          { name: "loud", kind: "boolean", default: "pending_count > 0", derived: ["pending_count", "0", ">"], scope: "region" },
+        ],
+        reads: { pending_count: [2] },
+        conditionals: {
+          1: { arms: [["pending", null, 0]], else: 1 },
+          4: { arms: [["loud", null, 0]], else: 1 },
+        },
+      },
+    },
+  }
+
+  let countSlots: SlotIndex
+  let countState: SlotState
+
+  beforeEach(() => {
+    document.body.innerHTML = COUNT_PAGE + `<template data-herb-dependencies>${JSON.stringify(COUNT_MANIFEST)}</template>`
+
+    countSlots = new SlotIndex()
+    countSlots.scan(document.body)
+
+    countState = new SlotState(countSlots, {
+      persist: "none",
+      transport: () => {
+        throw new Error("a declared state must never reach the transport")
+      },
+    })
+
+    countState.adopt()
+  })
+
+  function scopeOf(selector: string): NonNullable<ReturnType<SlotState["scopeFor"]>> {
+    return countState.scopeFor(document.querySelector(selector)!, "pending")!
+  }
+
+  test("a count computes over the collection's items", () => {
+    expect(countState.getState("pending_count")).toBe(0)
+
+    countState.setState({ pending: true }, { scope: scopeOf("#a") })
+
+    expect(countState.getState("pending_count")).toBe(1)
+  })
+
+  test("an item write fans out through the count and its derivations", () => {
+    countState.setState({ pending: true }, { scope: scopeOf("#a") })
+
+    expect(document.querySelector("p")?.textContent).toContain("1")
+    expect(document.querySelector("b")?.textContent).toContain("Some")
+
+    countState.setState({ pending: true }, { scope: scopeOf("#b") })
+
+    expect(document.querySelector("p")?.textContent).toContain("2")
+
+    countState.setState({ pending: false }, { scope: scopeOf("#a") })
+    countState.setState({ pending: false }, { scope: scopeOf("#b") })
+
+    expect(document.querySelector("p")?.textContent).toContain("0")
+    expect(document.querySelector("b")?.textContent).toContain("None")
+  })
+
+  test("removing a counted item recounts", async () => {
+    countState.setState({ pending: true }, { scope: scopeOf("#a") })
+
+    expect(document.querySelector("p")?.textContent).toContain("1")
+
+    const collection = countSlots.slot(COUNT_FILE, 0)!
+
+    expect(countSlots.removeItem(collection, "a")).toBe(true)
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(document.querySelector("p")?.textContent).toContain("0")
+    expect(document.querySelector("b")?.textContent).toContain("None")
+  })
+
+  test("an added item joins the count once its state turns on", () => {
+    const collection = countSlots.slot(COUNT_FILE, 0)!
+
+    expect(countSlots.addItem(collection, "c")).not.toBeNull()
+    expect(countState.getState("pending_count")).toBe(0)
+
+    countState.setState({ pending: true }, { scope: countState.scopeFor(document.querySelectorAll("li")[2]!, "pending")! })
+
+    expect(document.querySelector("p")?.textContent).toContain("1")
+  })
+
+  test("a counted state cannot be written", () => {
+    expect(countState.setState({ pending_count: 5 })).toBe(false)
+    expect(document.querySelector("p")?.textContent).toContain("0")
+  })
+})

--- a/lib/herb/engine/slot_dependencies.rb
+++ b/lib/herb/engine/slot_dependencies.rb
@@ -185,6 +185,16 @@ module Herb
           [index.to_s, { "arms" => info[:arms], "else" => info[:else] }]
         }
 
+        if visitor.respond_to?(:state_count_entries)
+          visitor.state_count_entries.each do |count|
+            declaration = declarations.find { |declared| declared["name"] == count[:name] && declared["scope"] == "region" }
+
+            next unless declaration
+
+            declaration["count"] = { "collection" => count[:collection], "when" => count[:when], "by" => count[:by] }
+          end
+        end
+
         {
           "version" => visitor.schema[:version],
           "declarations" => declarations,

--- a/lib/herb/engine/slot_visitor.rb
+++ b/lib/herb/engine/slot_visitor.rb
@@ -142,6 +142,8 @@ module Herb
         state_conditionals = {} #: Hash[untyped, Hash[Symbol, untyped]]
         @state_conditionals = state_conditionals.compare_by_identity
         @collection_nodes = [] #: Array[untyped]
+        @collection_body_depths = [] #: Array[Integer]
+        @state_counts = [] #: Array[Hash[Symbol, untyped]]
         @container_depth = 0
 
         @in_attribute = false
@@ -157,8 +159,26 @@ module Herb
       #: () -> String
       def version
         @version ||= Digest::SHA256.hexdigest(
-          (slot_entries.map(&:inspect) + state_entries.map(&:inspect)).join(",")
+          (slot_entries.map(&:inspect) + state_entries.map(&:inspect) + state_count_entries.map(&:inspect)).join(",")
         ).slice(0, 8).to_s
+      end
+
+      #: () -> Array[Hash[Symbol, untyped]]
+      def state_count_entries
+        @state_counts.filter_map { |count|
+          index = @indices[count[:collection]]
+
+          next unless index
+
+          read = count[:when]
+
+          {
+            name: count[:name],
+            collection: index,
+            by: count[:by],
+            when: read ? StateDirectives.condition_entry(read) : nil,
+          }
+        }
       end
 
       #: () -> Hash[Symbol, untyped]
@@ -367,6 +387,8 @@ module Herb
       end
 
       def visit_erb_if_node(node)
+        return if register_count_fold(node)
+
         record_slot(node, :conditional) unless continuation?(node)
 
         visit_branching_node(node)
@@ -415,34 +437,28 @@ module Herb
       end
 
       def visit_erb_iteration_block_node(node)
-        record_slot(node, :collection)
-
-        @collection_nodes.push(node)
-        visit_branching_node(node)
-        @collection_nodes.pop
+        visit_collection_node(node)
       end
 
       def visit_erb_while_node(node)
-        record_slot(node, :collection)
-
-        @collection_nodes.push(node)
-        visit_branching_node(node)
-        @collection_nodes.pop
+        visit_collection_node(node)
       end
 
       def visit_erb_until_node(node)
-        record_slot(node, :collection)
-
-        @collection_nodes.push(node)
-        visit_branching_node(node)
-        @collection_nodes.pop
+        visit_collection_node(node)
       end
 
       def visit_erb_for_node(node)
+        visit_collection_node(node)
+      end
+
+      def visit_collection_node(node)
         record_slot(node, :collection)
 
         @collection_nodes.push(node)
+        @collection_body_depths.push(@container_depth + 1)
         visit_branching_node(node)
+        @collection_body_depths.pop
         @collection_nodes.pop
       end
 
@@ -453,6 +469,7 @@ module Herb
 
         children.each_with_index do |child, index|
           register_state_directive(child, children)
+          check_state_assignment(child)
 
           @path.push(index)
           visit(child)
@@ -718,6 +735,7 @@ module Herb
 
         classify_state_conditionals
         check_state_value_reads
+        check_state_count_reads
       end
 
       #: (StateDirectives::Declaration) -> String
@@ -886,6 +904,158 @@ module Herb
         keyword = source[/\A[a-z]+/]
 
         STATE_KEYWORDS.key?(keyword.to_s) ? source.delete_prefix(keyword.to_s).strip : source
+      end
+
+      #: (untyped) -> untyped
+      def register_count_fold(node)
+        return nil if continuation?(node)
+        return nil unless node.respond_to?(:subsequent) && node.subsequent.nil?
+        return nil unless @container_depth == @collection_body_depths.last
+
+        scope = @collection_nodes.last
+
+        return nil unless scope
+
+        states = states_for(scope)
+
+        return nil if states.empty?
+
+        body = node.respond_to?(:statements) ? node.statements : nil #: untyped
+
+        return nil unless body.is_a?(Array)
+
+        significant = body.reject { |child| blank_child?(child) }
+
+        return nil unless significant.one?
+
+        assignment = significant.first
+
+        return nil unless assignment.is_a?(Herb::AST::ERBContentNode) && assignment.tag_opening&.value == "<%"
+
+        increment = StateDirectives.fold_increment(assignment.content&.value.to_s)
+
+        return nil unless increment && states.key?(increment.name)
+
+        read = StateDirectives.condition_read(condition_expression(node), states)
+
+        return nil unless read.is_a?(StateDirectives::Read) || read.is_a?(StateDirectives::Combo)
+
+        register_count(increment, when_read: read)
+        StateDirectives.read_names(read).each { |name| rewrite_predicate(node, name) }
+
+        node
+      end
+
+      #: (untyped) -> void
+      def check_state_assignment(node)
+        return unless node.is_a?(Herb::AST::ERBContentNode)
+
+        tag = node.tag_opening&.value
+
+        return unless ["<%", "<%=", "<%=="].include?(tag)
+
+        scope = @collection_nodes.last
+        states = states_for(scope)
+
+        return if states.empty?
+
+        content = node.content&.value.to_s
+        assigned = StateDirectives.assigned_state_names(content, states)
+
+        return if assigned.empty?
+
+        if tag == "<%" && scope && @container_depth == @collection_body_depths.last
+          increment = StateDirectives.fold_increment(content)
+
+          if increment && assigned == [increment.name]
+            register_count(increment, when_read: nil)
+
+            return
+          end
+        end
+
+        raise Herb::Engine::CompilationError,
+              "`#{content.strip}` assigns the state `#{assigned.first}`; the client never sees a server-side " \
+              "write, so seed the initial value in the declaration, derive it from other states, count items " \
+              "with `#{assigned.first} += 1` behind a state condition in a keyed loop, or write it at runtime " \
+              "with `data-herb-set` or `state.set`"
+      end
+
+      #: (StateDirectives::FoldIncrement, when_read: untyped) -> void
+      def register_count(increment, when_read:)
+        name = increment.name
+        declaration = @region_states[name]
+
+        unless declaration
+          raise Herb::Engine::CompilationError,
+                "`#{name} += #{increment.by}` counts into `#{name}`, which is an item state; a count lives once " \
+                "per region, so declare `#{name}` at the top of the template"
+        end
+
+        if declaration.derived
+          raise Herb::Engine::CompilationError,
+                "`#{name} += #{increment.by}` counts into `#{name}`, which is derived from " \
+                "`#{declaration.default}`; a state is either derived or counted, so drop one of the two"
+        end
+
+        unless declaration.kind == :integer
+          raise Herb::Engine::CompilationError,
+                "`#{name} += #{increment.by}` counts into the #{declaration.kind.to_s.capitalize} state " \
+                "`#{name}`; a count is a number, so declare it as an Integer, like `(#{name}: 0)`"
+        end
+
+        if @state_counts.any? { |count| count[:name] == name }
+          raise Herb::Engine::CompilationError,
+                "`#{name}` is counted twice; one state holds one count, so declare a second state for the " \
+                "second count"
+        end
+
+        if @slots.any? { |slot| StateDirectives.mentions_any?(slot.expression.to_s, { name => declaration }) }
+          raise Herb::Engine::CompilationError,
+                "`#{name}` is read before its count is complete; the server renders that read mid-count and " \
+                "the client cannot keep it current there, so move the read after the loop"
+        end
+
+        @state_counts << { name: name, by: increment.by, collection: @collection_nodes.last, when: when_read }
+      end
+
+      #: () -> void
+      def check_state_count_reads
+        @state_counts.each do |count|
+          @slot_nodes.each do |node|
+            index = @indices[node]
+
+            next unless index
+
+            scope, = @slot_scopes[node]
+
+            next unless scope.equal?(count[:collection])
+
+            expression = @slots[index].expression.to_s
+
+            next if expression.strip.empty?
+
+            mentioned = {} #: Hash[String, untyped]
+            mentioned[count[:name]] = true
+
+            next unless StateDirectives.mentions_any?(expression, mentioned)
+
+            raise Herb::Engine::CompilationError,
+                  "`#{count[:name]}` is read inside the loop that counts it; the count is complete only after " \
+                  "the loop, so move the read below it"
+          end
+        end
+      end
+
+      #: (untyped) -> bool
+      def blank_child?(node)
+        return true if node.is_a?(Herb::AST::WhitespaceNode)
+
+        if node.is_a?(Herb::AST::HTMLTextNode) || node.is_a?(Herb::AST::LiteralNode)
+          return node.content.to_s.strip.empty?
+        end
+
+        false
       end
 
       #: (untyped, String) -> void

--- a/lib/herb/engine/state_directives.rb
+++ b/lib/herb/engine/state_directives.rb
@@ -42,6 +42,11 @@ module Herb
         :parts  #: Array[untyped]
       )
 
+      FoldIncrement = Data.define(
+        :name, #: String
+        :by    #: Integer
+      )
+
       ORDERED_OPERATORS = [:>, :>=, :<, :<=].freeze #: Array[Symbol]
       MIRRORED_OPERATORS = { ">" => "<", ">=" => "<=", "<" => ">", "<=" => ">=" }.freeze #: Hash[String, String]
 
@@ -179,6 +184,74 @@ module Herb
 
             "(#{read.parts.map { |part| condition_source(part) }.join(joiner)})"
           end
+        end
+
+        #: (String) -> FoldIncrement?
+        def fold_increment(source)
+          result = Prism.parse(source.to_s.strip)
+
+          return nil if result.failure?
+
+          body = result.value.statements.body
+
+          return nil unless body.one?
+
+          node = body.first
+
+          case node
+          when Prism::LocalVariableOperatorWriteNode
+            return nil unless node.binary_operator == :+
+
+            step = node.value
+
+            return nil unless step.is_a?(Prism::IntegerNode)
+
+            FoldIncrement.new(name: node.name.to_s, by: step.value)
+          when Prism::LocalVariableWriteNode
+            value = node.value
+
+            return nil unless value.is_a?(Prism::CallNode) && value.name == :+
+
+            receiver = value.receiver
+
+            return nil unless receiver.is_a?(Prism::LocalVariableReadNode) && receiver.name == node.name
+
+            arguments = value.arguments&.arguments
+
+            return nil unless arguments&.one?
+
+            step = arguments.first
+
+            return nil unless step.is_a?(Prism::IntegerNode)
+
+            FoldIncrement.new(name: node.name.to_s, by: step.value)
+          end
+        end
+
+        #: (String, Hash[String, Declaration]) -> Array[String]
+        def assigned_state_names(source, states)
+          return [] unless mentions_any?(source, states)
+
+          result = Prism.parse(source)
+
+          return [] if result.failure?
+
+          names = [] #: Array[String]
+          queue = [] #: Array[untyped]
+          queue << result.value
+
+          while (node = queue.shift)
+            case node
+            when Prism::LocalVariableWriteNode, Prism::LocalVariableOperatorWriteNode,
+                 Prism::LocalVariableOrWriteNode, Prism::LocalVariableAndWriteNode,
+                 Prism::LocalVariableTargetNode
+              names << node.name.to_s if states.key?(node.name.to_s)
+            end
+
+            queue.concat(node.child_nodes.compact) if node.respond_to?(:child_nodes)
+          end
+
+          names.uniq
         end
 
         #: (String, Declaration) -> (Array[String] | Symbol)

--- a/sig/herb/engine/slot_visitor.rbs
+++ b/sig/herb/engine/slot_visitor.rbs
@@ -108,6 +108,9 @@ module Herb
       # : () -> String
       def version: () -> String
 
+      # : () -> Array[Hash[Symbol, untyped]]
+      def state_count_entries: () -> Array[Hash[Symbol, untyped]]
+
       # : () -> Hash[Symbol, untyped]
       def state_declarations: () -> Hash[Symbol, untyped]
 
@@ -180,6 +183,8 @@ module Herb
 
       def visit_erb_for_node: (untyped node) -> untyped
 
+      def visit_collection_node: (untyped node) -> untyped
+
       private
 
       def visit_children_with_paths: (untyped children) -> untyped
@@ -245,6 +250,21 @@ module Herb
 
       # : (untyped) -> String
       def condition_expression: (untyped) -> String
+
+      # : (untyped) -> untyped
+      def register_count_fold: (untyped) -> untyped
+
+      # : (untyped) -> void
+      def check_state_assignment: (untyped) -> void
+
+      # : (StateDirectives::FoldIncrement, when_read: untyped) -> void
+      def register_count: (StateDirectives::FoldIncrement, when_read: untyped) -> void
+
+      # : () -> void
+      def check_state_count_reads: () -> void
+
+      # : (untyped) -> bool
+      def blank_child?: (untyped) -> bool
 
       # : (untyped, String) -> void
       def rewrite_predicate: (untyped, String) -> void

--- a/sig/herb/engine/state_directives.rbs
+++ b/sig/herb/engine/state_directives.rbs
@@ -64,6 +64,19 @@ module Herb
         def members: () -> [ :op, :parts ]
       end
 
+      class FoldIncrement < Data
+        attr_reader name(): String
+
+        attr_reader by(): Integer
+
+        def self.new: (String name, Integer by) -> instance
+                    | (name: String, by: Integer) -> instance
+
+        def self.members: () -> [ :name, :by ]
+
+        def members: () -> [ :name, :by ]
+      end
+
       ORDERED_OPERATORS: Array[Symbol]
 
       MIRRORED_OPERATORS: Hash[String, String]
@@ -100,6 +113,12 @@ module Herb
 
       # : (Read | Combo) -> String
       def self.condition_source: (Read | Combo) -> String
+
+      # : (String) -> FoldIncrement?
+      def self.fold_increment: (String) -> FoldIncrement?
+
+      # : (String, Hash[String, Declaration]) -> Array[String]
+      def self.assigned_state_names: (String, Hash[String, Declaration]) -> Array[String]
 
       # : (String, Declaration) -> (Array[String] | Symbol)
       def self.when_comparands: (String, Declaration) -> (Array[String] | Symbol)

--- a/test/engine/slots/dependencies_test.rb
+++ b/test/engine/slots/dependencies_test.rb
@@ -471,6 +471,27 @@ module Engine
         assert_equal({ "any" => [["pending", nil], ["failed", nil]] }, declaration["derived"])
       end
 
+      test "carries a counted state with its fold" do
+        path = write("index.html.erb", <<~ERB)
+          <%# herb:state (pending_count: 0) %>
+          <ul>
+            <% @messages.each do |message| %>
+              <%# herb:key message.id %>
+              <%# herb:state (pending: false) %>
+              <% if pending? %><% pending_count += 1 %><% end %>
+              <li id="<%= message.id %>"><%= message.body %></li>
+            <% end %>
+          </ul>
+          <p><%= pending_count %></p>
+        ERB
+
+        manifest = subject.payload(path)["states"].values.first
+        declaration = manifest["declarations"].find { |declared| declared["name"] == "pending_count" }
+
+        assert_equal({ "collection" => 0, "when" => ["pending", nil], "by" => 1 }, declaration["count"])
+        assert_includes manifest["reads"]["pending_count"], 3
+      end
+
       test "carries the states a template declares" do
         path = write("index.html.erb", <<~ERB)
           <%# herb:state (pending: false, attempts: 0) %>

--- a/test/engine/slots/states_test.rb
+++ b/test/engine/slots/states_test.rb
@@ -448,6 +448,103 @@ module Engine
         assert_nil entries.fetch("hue")[:derived]
       end
 
+      COUNTED = <<~ERB
+        <%# herb:slots client %>
+        <%# herb:state (pending_count: 0) %>
+        <ul>
+          <% @messages.each do |message| %>
+            <%# herb:key message %>
+            <%# herb:state (pending: message.odd?) %>
+            <% if pending? %><% pending_count = pending_count + 1 %><% end %>
+            <li id="m<%= message %>"><%= message %></li>
+          <% end %>
+        </ul>
+        <p><%= pending_count %></p>
+      ERB
+
+      test "a conditional increment compiles as a count" do
+        visitor, = compile(COUNTED)
+
+        assert_equal(
+          [{ name: "pending_count", collection: 0, by: 1, when: ["pending", nil] }],
+          visitor.state_count_entries
+        )
+
+        refute(visitor.slots.any? { |slot| slot.type == :conditional }, "the fold must not record a conditional slot")
+      end
+
+      test "the server renders the count the fold produces" do
+        rendered = render(COUNTED, { "@messages" => [1, 2, 3] })
+
+        assert_includes rendered, %(>2<)
+      end
+
+      test "a bare increment counts every item" do
+        template = <<~ERB
+          <%# herb:state (total: 0) %>
+          <ul><% @items.each do |item| %><%# herb:key item %><% total += 2 %><li id="i<%= item %>"><%= item %></li><% end %></ul>
+          <p><%= total %></p>
+        ERB
+
+        visitor, = compile(template)
+
+        assert_equal [{ name: "total", collection: 0, by: 2, when: nil }], visitor.state_count_entries
+        assert_includes render(template, { "@items" => [1, 2] }), %(>4<)
+      end
+
+      test "assigning a state outside a fold raises" do
+        refuse(
+          %(<%# herb:state (pending: false) %><div><% pending = true %><% if pending? %>A<% end %></div>),
+          /assigns the state `pending`/
+        )
+      end
+
+      test "a fold gated by a server condition raises" do
+        refuse(<<~ERB, /assigns the state `total`/)
+          <%# herb:state (total: 0) %>
+          <ul><% @items.each do |item| %><%# herb:key item %><% if item.big? %><% total += 1 %><% end %><li id="i<%= item %>"><%= item %></li><% end %></ul>
+          <p><%= total %></p>
+        ERB
+      end
+
+      test "a count read before or inside its loop raises" do
+        refuse(<<~ERB, /before its count is complete/)
+          <%# herb:state (total: 0) %>
+          <p><%= total %></p>
+          <ul><% @items.each do |item| %><%# herb:key item %><% total += 1 %><li id="i<%= item %>"><%= item %></li><% end %></ul>
+        ERB
+
+        refuse(<<~ERB, /inside the loop that counts it/)
+          <%# herb:state (total: 0) %>
+          <ul><% @items.each do |item| %><%# herb:key item %><% total += 1 %><li id="i<%= item %>"><%= total %></li><% end %></ul>
+        ERB
+      end
+
+      test "a count needs an integer region state counted once" do
+        refuse(<<~ERB, /counts into the String state/)
+          <%# herb:state (label: "x") %>
+          <ul><% @items.each do |item| %><%# herb:key item %><% label += 1 %><li id="i<%= item %>"><%= item %></li><% end %></ul>
+        ERB
+
+        refuse(<<~ERB, /which is an item state/)
+          <%# herb:slots client %>
+          <ul><% @items.each do |item| %><%# herb:key item %><%# herb:state (mine: 0) %><% mine += 1 %><li id="i<%= item %>"><%= item %></li><% end %></ul>
+        ERB
+
+        refuse(<<~ERB, /counted twice/)
+          <%# herb:state (total: 0) %>
+          <ul><% @items.each do |item| %><%# herb:key item %><% total += 1 %><% total += 1 %><li id="i<%= item %>"><%= item %></li><% end %></ul>
+          <p><%= total %></p>
+        ERB
+      end
+
+      test "a count cannot target a derived state" do
+        refuse(<<~ERB, /is derived from/)
+          <%# herb:state (pending: false, busy: pending) %>
+          <ul><% @items.each do |item| %><%# herb:key item %><% busy += 1 %><li id="i<%= item %>"><%= item %></li><% end %></ul>
+        ERB
+      end
+
       test "an unless reads a state with its arms inverted" do
         template = %(<%# herb:state (pending: false) %><div><% unless pending %>Idle<% else %>Busy<% end %></div>)
         visitor, = compile(template)


### PR DESCRIPTION
This pull request lets a template count its own rows into a state, and keeps that count current on the client.

Assigning a declared state in template Ruby is refused, because the client never sees a server-side write. A fold is the one exception worth making, since the client can re-run it:

```erb
<%# herb:slots client %>
<%# herb:state (pending_count: 0) %>

<ul>
  <% @messages.each do |message| %>
    <%# herb:key message.id %>
    <%# herb:state (pending: false) %>

    <% if pending? %><% pending_count = pending_count + 1 %><% end %>

    <li id="message_<%= message.id %>"><%= message.body %></li>
  <% end %>
</ul>

<p><%= pending_count %> sending</p>
```

Counting items whose condition holds needs no Ruby evaluator, so the count stays right when a row's state flips or a row is added or removed.

The fold is deliberately narrow. It must sit directly in a keyed collection body, count into an Integer region state, be the only statement in a single-armed `if` whose condition reads only state, and the count may be read only after the loop. Each of those is a compile error with a message naming the fix, because a fold that broke any of them would be a count the client cannot reproduce.
