### PR TITLE
Engine: Slot a state read inside a tag helper attribute

### DIFF
--- a/javascript/packages/client/test/actions.test.ts
+++ b/javascript/packages/client/test/actions.test.ts
@@ -12,6 +12,9 @@ const PAGE =
   `<button id="both" data-herb-set="pending=false,failed=true">Fail</button>` +
   `<button id="bump" data-herb-increment="attempts" data-herb-by="2">More</button>` +
   `<button id="combo" data-herb-increment="attempts" data-herb-set="open=true">Both</button>` +
+  `<button id="same" data-herb-increment="attempts" data-herb-set="attempts=10">Same</button>` +
+  `<button id="arrowed" data-herb-set="click->open=true" data-herb-increment="attempts">Arrowed</button>` +
+  `<button id="trio" data-herb-toggle="open" data-herb-increment="attempts" data-herb-reset="sort">Trio</button>` +
   `<button id="tab-a" data-herb-set="sort=name">A</button>` +
   `<button id="quoted" data-herb-set="sort='hello, world'">Q</button>` +
   `<form id="form" data-herb-set="pending=true"><input id="draft-input" data-herb-reset="blur->sort"></form>` +
@@ -123,6 +126,29 @@ describe("declarative actions", () => {
 
     expect(state.getState("attempts")).toBe(1)
     expect(state.getState("open")).toBe(true)
+  })
+
+  test("increment and set on the same state apply set first, then the step", () => {
+    click("#same")
+
+    expect(state.getState("attempts")).toBe(11)
+  })
+
+  test("an arrowed set and a bare increment both fire on one click", () => {
+    click("#arrowed")
+
+    expect(state.getState("open")).toBe(true)
+    expect(state.getState("attempts")).toBe(1)
+  })
+
+  test("three action attributes on one element all fire", () => {
+    state.setState({ sort: "date" })
+
+    click("#trio")
+
+    expect(state.getState("open")).toBe(true)
+    expect(state.getState("attempts")).toBe(1)
+    expect(state.getState("sort")).toBe("name")
   })
 
   test("increment honours data-herb-by", () => {
@@ -314,5 +340,56 @@ describe("declarative actions", () => {
     expect((entries[0] as { code: string }).code).toBe("herb-state-type")
 
     delete (window as unknown as { HerbDevTools?: unknown }).HerbDevTools
+  })
+})
+
+describe("a tag helper input bound to a state", () => {
+  const HELPER_FILE = "app/views/page/show.html.erb"
+
+  const HELPER_PAGE =
+    `<!--herb-region:${HELPER_FILE}:57899424:0-->` +
+    `<input value="" data-herb-slot="0:attribute:value">` +
+    `<button id="quoted" data-herb-set="draft='abc'">Set</button>` +
+    `<p data-herb-slot="1:child"></p>` +
+    `<!--/herb-region:${HELPER_FILE}-->` +
+    `<template data-herb-dependencies>${JSON.stringify({
+      state: {},
+      params: {},
+      states: {
+        [HELPER_FILE]: {
+          version: "57899424",
+          declarations: [{ name: "draft", kind: "string", default: '""', derived: null, line: 2, column: 0, scope: "region" }],
+          reads: { draft: [0, 1] },
+          bound: { draft: [0] },
+          conditionals: {},
+          presence: {},
+        },
+      },
+    })}</template>`
+
+  test("a quoted set writes the value into the input", () => {
+    document.body.innerHTML = HELPER_PAGE
+
+    const helperSlots = new SlotIndex()
+    helperSlots.scan(document.body)
+
+    const helperState = new SlotState(helperSlots, { persist: "none" })
+    helperState.adopt()
+    helperState.observe()
+
+    const helperActions = new SlotActions(helperState)
+    helperActions.start(document.body)
+
+    document.querySelector<HTMLElement>("#quoted")!.dispatchEvent(new MouseEvent("click", { bubbles: true }))
+
+    const input = document.querySelector<HTMLInputElement>("input")!
+
+    expect(helperState.getState("draft")).toBe("abc")
+    expect(input.getAttribute("value")).toBe("abc")
+    expect(input.value).toBe("abc")
+    expect(document.querySelector("p")?.textContent).toBe("abc")
+
+    helperActions.stop()
+    helperState.disconnect()
   })
 })

--- a/javascript/packages/client/test/binding.test.ts
+++ b/javascript/packages/client/test/binding.test.ts
@@ -88,3 +88,105 @@ describe("bound slots", () => {
     expect(state.getState("draft")).toBe("")
   })
 })
+
+describe("property sync after user interaction", () => {
+  const SYNC_FILE = "app/views/page/sync.html.erb"
+
+  const SYNC_PAGE =
+    `<!--herb-region:${SYNC_FILE}:beefcafe:0-->` +
+    `<input id="agree" type="checkbox" data-herb-slot="0:boolean_attribute:checked">` +
+    `<select id="pick"><option value="name">name</option><option value="date" data-herb-slot="1:boolean_attribute:selected">date</option></select>` +
+    `<button id="submit" data-herb-slot="2:boolean_attribute:disabled">Send</button>` +
+    `<input id="draft" value="" data-herb-slot="3:attribute:value">` +
+    `<!--/herb-region:${SYNC_FILE}-->` +
+    `<template data-herb-dependencies>${JSON.stringify({
+      state: {},
+      states: {
+        [SYNC_FILE]: {
+          version: "beefcafe",
+          declarations: [
+            { name: "agreed", kind: "boolean", default: "false", scope: "region" },
+            { name: "dated", kind: "boolean", default: "false", scope: "region" },
+            { name: "pending", kind: "boolean", default: "false", scope: "region" },
+            { name: "draft", kind: "string", default: '""', scope: "region" },
+          ],
+          reads: { agreed: [0], dated: [1], pending: [2], draft: [3] },
+          bound: { agreed: [0], draft: [3] },
+          conditionals: {},
+          presence: { 0: ["agreed", null], 1: ["dated", null], 2: ["pending", null] },
+        },
+      },
+    })}</template>`
+
+  let syncSlots: SlotIndex
+  let syncState: SlotState
+
+  beforeEach(() => {
+    document.body.innerHTML = SYNC_PAGE
+
+    syncSlots = new SlotIndex()
+    syncSlots.scan(document.body)
+
+    syncState = new SlotState(syncSlots, { persist: "none" })
+    syncState.adopt()
+    syncState.observe()
+  })
+
+  afterEach(() => syncState.disconnect())
+
+  test("a checkbox follows the state after the user has clicked it", () => {
+    const checkbox = document.querySelector<HTMLInputElement>("#agree")!
+
+    checkbox.click()
+
+    expect(syncState.getState("agreed")).toBe(true)
+    expect(checkbox.checked).toBe(true)
+
+    syncState.setState({ agreed: false })
+
+    expect(checkbox.hasAttribute("checked")).toBe(false)
+    expect(checkbox.checked).toBe(false)
+
+    syncState.setState({ agreed: true })
+
+    expect(checkbox.checked).toBe(true)
+  })
+
+  test("an option follows the state after the user has picked another", () => {
+    const select = document.querySelector<HTMLSelectElement>("#pick")!
+
+    select.value = "name"
+    select.dispatchEvent(new Event("change", { bubbles: true }))
+
+    syncState.setState({ dated: true })
+
+    expect(select.querySelector<HTMLOptionElement>("option[value=date]")!.selected).toBe(true)
+    expect(select.value).toBe("date")
+  })
+
+  test("a disabled button follows the state", () => {
+    const button = document.querySelector<HTMLButtonElement>("#submit")!
+
+    expect(button.disabled).toBe(false)
+
+    syncState.setState({ pending: true })
+
+    expect(button.disabled).toBe(true)
+
+    syncState.setState({ pending: false })
+
+    expect(button.disabled).toBe(false)
+  })
+
+  test("a bound input's value property follows a programmatic set", () => {
+    const input = document.querySelector<HTMLInputElement>("#draft")!
+
+    input.value = "typed by hand"
+    input.dispatchEvent(new Event("input", { bubbles: true }))
+
+    syncState.setState({ draft: "from code" })
+
+    expect(input.getAttribute("value")).toBe("from code")
+    expect(input.value).toBe("from code")
+  })
+})

--- a/javascript/packages/linter/src/rules/herb-state-valid-actions.ts
+++ b/javascript/packages/linter/src/rules/herb-state-valid-actions.ts
@@ -6,7 +6,7 @@ import { balancedQuotes, clauses, names, splitOutsideQuotes, unquote } from "@he
 import { forEachAttribute, getAttributeName, getStaticAttributeValueContent, hasDynamicOutput, getAttributeValueNodes } from "@herb-tools/core"
 
 import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types.js"
-import type { ParseResult, ParserOptions, ERBBlockNode, HTMLOpenTagNode, HTMLAttributeNode } from "@herb-tools/core"
+import type { ParseResult, ParserOptions, ERBBlockNode, HTMLOpenTagNode, HTMLAttributeNode, ERBOpenTagNode } from "@herb-tools/core"
 import type { ActionClause, ActionAttribute } from "../utils/state-directives-utils.js"
 import type { StateDeclaration } from "@herb-tools/client/directives"
 
@@ -39,6 +39,17 @@ class StateValidActionsVisitor extends BaseRuleVisitor {
     })
 
     super.visitHTMLOpenTagNode(node)
+  }
+
+  visitERBOpenTagNode(node: ERBOpenTagNode): void {
+    forEachAttribute(node, (attribute) => {
+      const name = getAttributeName(attribute)
+
+      if (name && isActionAttribute(name)) this.checkAction(attribute, name)
+      if (name === BY_ATTRIBUTE) this.checkBy(attribute)
+    })
+
+    super.visitERBOpenTagNode(node)
   }
 
   private checkAction(attribute: HTMLAttributeNode, name: ActionAttribute): void {
@@ -224,6 +235,7 @@ export class HerbStateValidActionsRule extends ParserRule {
   get parserOptions(): Partial<ParserOptions> {
     return {
       strict_locals: true,
+      action_view_helpers: true,
     }
   }
 

--- a/javascript/packages/linter/src/rules/herb-state-valid-bindings.ts
+++ b/javascript/packages/linter/src/rules/herb-state-valid-bindings.ts
@@ -6,7 +6,7 @@ import { bareReadName } from "@herb-tools/client/directives"
 import { forEachAttribute, getAttributeName, getAttributeValueNodes, getTagLocalName, isERBContentNode, isHTMLElementNode } from "@herb-tools/core"
 
 import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types.js"
-import type { ParseResult, ParserOptions, ERBBlockNode, ERBContentNode, HTMLElementNode, Node } from "@herb-tools/core"
+import type { ParseResult, ParserOptions, ERBBlockNode, ERBContentNode, HTMLElementNode, Node, RubyLiteralNode } from "@herb-tools/core"
 import type { StateDeclaration } from "@herb-tools/client/directives"
 
 const BOUND_ELEMENTS = ["input", "textarea", "select", "option"]
@@ -141,7 +141,9 @@ class StateValidBindingsVisitor extends BaseRuleVisitor {
       return child.tag_opening?.value === "<%=" || child.tag_opening?.value === "<%=="
     })
 
-    if (outputs.length !== 1) return null
+    const literal = nodes.length === 1 && nodes[0].type === "AST_RUBY_LITERAL_NODE" ? (nodes[0] as RubyLiteralNode) : null
+
+    if (outputs.length !== 1 && !literal) return null
 
     const meaningful = nodes.filter((child) => {
       if (isHTMLElementNode(child)) return true
@@ -151,7 +153,7 @@ class StateValidBindingsVisitor extends BaseRuleVisitor {
 
     if (meaningful.length > 0) return null
 
-    const name = bareReadName(outputs[0].content?.value ?? "")
+    const name = bareReadName(literal ? literal.content ?? "" : outputs[0].content?.value ?? "")
 
     if (!name) return null
 
@@ -172,6 +174,7 @@ export class HerbStateValidBindingsRule extends ParserRule {
   get parserOptions(): Partial<ParserOptions> {
     return {
       strict_locals: true,
+      action_view_helpers: true,
     }
   }
 

--- a/javascript/packages/linter/src/rules/herb-state-valid-reads.ts
+++ b/javascript/packages/linter/src/rules/herb-state-valid-reads.ts
@@ -1,13 +1,13 @@
 import { BaseRuleVisitor } from "../utils/rule-utils.js"
 import { ParserRule } from "../types.js"
 import { StateScopeMap, declaredKind, kindWithArticle } from "../utils/state-directives-utils.js"
-import { bareReadName, mentionsAnyState } from "@herb-tools/client/directives"
+import { bareReadName, classifyDerivedDefault, mentionsAnyState } from "@herb-tools/client/directives"
 
 import { isBooleanAttribute, locationFromByteOffset, substringFromByteOffset } from "@herb-tools/core"
 import { getAttributeName, getAttributeValueNodes, isERBContentNode } from "@herb-tools/core"
 
 import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types.js"
-import type { ParseResult, ParserOptions, Location, PrismNode, ERBBlockNode, ERBContentNode, ERBIfNode, ERBUnlessNode, ERBCaseNode, HTMLAttributeNode } from "@herb-tools/core"
+import type { ParseResult, ParserOptions, Location, PrismNode, ERBBlockNode, ERBContentNode, ERBIfNode, ERBUnlessNode, ERBCaseNode, HTMLAttributeNode, RubyLiteralNode } from "@herb-tools/core"
 import type { StateDeclaration } from "@herb-tools/client/directives"
 
 const LITERAL_KINDS: Record<string, string> = {
@@ -130,6 +130,31 @@ class StateValidReadsVisitor extends BaseRuleVisitor {
     const bare = bareReadName(expression)
 
     if (bare && this.resolve(bare)) return
+
+    const name = names.find(candidate => mentionsAnyState(expression, [candidate])) ?? names[0]
+
+    this.addOffense(
+      `\`${expression}\` computes with the state \`${name}\`, and the client cannot run Ruby to keep the result current. Show the value with \`<%= ${name} %>\`, or declare a second state for the computed answer and set it from app code.`,
+      node.location,
+    )
+  }
+
+  visitRubyLiteralNode(node: RubyLiteralNode): void {
+    const names = this.states.namesIn(this.stack)
+    if (names.length === 0) return
+
+    const expression = (node.content ?? "").trim()
+    if (expression === "" || !mentionsAnyState(expression, names)) return
+
+    if (this.booleanAttribute) {
+      const declared = new Map(names.map((name) => [name, declaredKind(this.resolve(name)!)]))
+
+      if (classifyDerivedDefault(expression, declared) !== "mixed") return
+    } else {
+      const bare = bareReadName(expression)
+
+      if (bare && this.resolve(bare)) return
+    }
 
     const name = names.find(candidate => mentionsAnyState(expression, [candidate])) ?? names[0]
 
@@ -464,6 +489,7 @@ export class HerbStateValidReadsRule extends ParserRule {
     return {
       strict_locals: true,
       prism_nodes: true,
+      action_view_helpers: true,
     }
   }
 

--- a/javascript/packages/linter/test/rules/herb-state-valid-actions.test.ts
+++ b/javascript/packages/linter/test/rules/herb-state-valid-actions.test.ts
@@ -199,4 +199,13 @@ describe("HerbStateValidActionsRule", () => {
       <p><%= total %></p>
     `)
   })
+  test("validates actions built by a tag helper", () => {
+    expectError("`data-herb-toggle` on `attempts` can never work, because `attempts` is an Integer and it needs a Boolean. Set a value instead, like `data-herb-set=\"attempts=...\"`, or declare a boolean flag.")
+
+    assertOffenses(dedent`
+      <%# herb:state (attempts: 0) %>
+      <%= tag.button "More", data: { herb_toggle: "attempts" } %>
+      <p><%= attempts %></p>
+    `)
+  })
 })

--- a/javascript/packages/linter/test/rules/herb-state-valid-bindings.test.ts
+++ b/javascript/packages/linter/test/rules/herb-state-valid-bindings.test.ts
@@ -112,4 +112,13 @@ describe("HerbStateValidBindingsRule", () => {
       <input type="number" value="<%= total %>">
     `)
   })
+  test("checks a binding built by a tag helper", () => {
+    expectError("`value` on `<input>` binds the Boolean state `pending`, and a `value` holds text. Declare it as a String, like `(pending: \"\")`.")
+
+    assertOffenses(dedent`
+      <%# herb:state (pending: false, draft: "") %>
+      <%= tag.input value: draft %>
+      <%= tag.input value: pending %>
+    `)
+  })
 })

--- a/javascript/packages/linter/test/rules/herb-state-valid-reads.test.ts
+++ b/javascript/packages/linter/test/rules/herb-state-valid-reads.test.ts
@@ -35,7 +35,7 @@ describe("HerbStateValidReadsRule", () => {
   })
 
   test("still flags a state read beside an action attribute", () => {
-    expectError("`tag.button \"More\", data: { herb_increment: \"count\" }, title: count.to_s` computes with the state `count`, and the client cannot run Ruby to keep the result current. Show the value with `<%= count %>`, or declare a second state for the computed answer and set it from app code.")
+    expectError("`count.to_s` computes with the state `count`, and the client cannot run Ruby to keep the result current. Show the value with `<%= count %>`, or declare a second state for the computed answer and set it from app code.")
 
     assertOffenses(dedent`
       <%# herb:state (count: 0) %>
@@ -279,6 +279,25 @@ describe("HerbStateValidReadsRule", () => {
     assertOffenses(dedent`
       <%# herb:state (pending: false, failed: false, busy: pending || failed) %>
       <% if busy == 3 %>x<% end %>
+    `)
+  })
+
+  test("allows tag helper attributes that read a state", () => {
+    expectNoOffenses(dedent`
+      <%# herb:state (draft: "", agreed: false, pending: false, sort: "name") %>
+      <%= tag.input value: draft %>
+      <%= tag.input type: "checkbox", checked: agreed %>
+      <%= tag.button "Send", disabled: pending? %>
+      <%= tag.option "Name", value: "name", selected: sort == "name" %>
+    `)
+  })
+
+  test("flags a computed tag helper attribute", () => {
+    expectError("`draft.upcase` computes with the state `draft`, and the client cannot run Ruby to keep the result current. Show the value with `<%= draft %>`, or declare a second state for the computed answer and set it from app code.")
+
+    assertOffenses(dedent`
+      <%# herb:state (draft: "") %>
+      <%= tag.input value: draft.upcase %>
     `)
   })
 

--- a/lib/herb/engine/slot_visitor.rb
+++ b/lib/herb/engine/slot_visitor.rb
@@ -342,6 +342,12 @@ module Herb
         @in_open_tag = false
       end
 
+      def visit_erb_open_tag_node(node)
+        @in_open_tag = true
+        super
+        @in_open_tag = false
+      end
+
       def visit_html_attribute_node(node)
         if dynamic?(node)
           record_slot(node, attribute_type_for(node))
@@ -388,6 +394,7 @@ module Herb
 
       def visit_erb_if_node(node)
         return if register_count_fold(node)
+        return if convert_helper_boolean_attribute(node)
 
         record_slot(node, :conditional) unless continuation?(node)
 
@@ -907,6 +914,47 @@ module Herb
       end
 
       #: (untyped) -> untyped
+      def convert_helper_boolean_attribute(node)
+        open_tag = @current_open_tag
+
+        return nil unless @in_open_tag && open_tag.is_a?(Herb::AST::ERBOpenTagNode)
+        return nil if continuation?(node)
+        return nil unless node.respond_to?(:subsequent) && node.subsequent.nil?
+
+        children = open_tag.children
+        position = children.index { |child| child.equal?(node) }
+
+        return nil unless position
+
+        statements = node.statements
+
+        return nil unless statements.is_a?(Array) && statements.one?
+
+        attribute = statements.fetch(0)
+
+        return nil unless attribute.is_a?(Herb::AST::HTMLAttributeNode) && !dynamic?(attribute)
+
+        name = attribute_name_for(attribute)
+
+        return nil unless name && Herb::HTML::Util.boolean_attribute?(name)
+
+        condition = condition_expression(node)
+        replacement = erb_output_node(%[(" #{name}" if #{condition})])
+
+        children[position] = replacement
+        record_slot(replacement, :attribute)
+
+        index = @indices[replacement]
+
+        return nil unless index
+
+        @slots[index] = @slots[index].with(type: :boolean_attribute, attribute: name, expression: condition)
+        @attribute_open_tags[replacement] = open_tag
+
+        replacement
+      end
+
+      #: (untyped) -> untyped
       def register_count_fold(node)
         return nil if continuation?(node)
         return nil unless node.respond_to?(:subsequent) && node.subsequent.nil?
@@ -1060,6 +1108,8 @@ module Herb
 
       #: (untyped, String) -> void
       def rewrite_predicate(node, name)
+        return if rewrite_literal_predicate(node, name)
+
         token = predicate_token_for(node)
 
         return unless token
@@ -1067,6 +1117,27 @@ module Herb
         token.value.gsub!(/(?<![\w?!])#{Regexp.escape(name)}\?(?![\w?!])/) { name }
       rescue FrozenError
         nil
+      end
+
+      #: (untyped, String) -> untyped
+      def rewrite_literal_predicate(node, name)
+        return nil unless node.is_a?(Herb::AST::HTMLAttributeNode)
+
+        children = node.value&.children
+
+        return nil unless children.is_a?(Array)
+
+        position = children.index { |child| child.is_a?(Herb::AST::RubyLiteralNode) }
+
+        return nil unless position
+
+        literal = children.fetch(position) #: untyped
+        rewritten = literal.content.to_s.gsub(/(?<![\w?!])#{Regexp.escape(name)}\?(?![\w?!])/) { name }
+        replacement = Herb::AST::RubyLiteralNode.build(content: rewritten, location: literal.location)
+
+        children[position] = replacement
+
+        replacement
       end
 
       #: (untyped) -> untyped
@@ -1138,7 +1209,7 @@ module Herb
 
       #: (untyped, Integer, untyped, String, Hash[String, StateDirectives::Declaration]) -> untyped
       def convert_boolean_attribute(node, index, slot, expression, states)
-        return nil unless slot.type == :attribute
+        return nil unless slot.type == :attribute || (slot.type == :boolean_attribute && !@state_presence.key?(index))
         return nil unless slot.attribute && Herb::HTML::Util.boolean_attribute?(slot.attribute)
 
         read = StateDirectives.condition_read(expression, states)
@@ -1159,7 +1230,8 @@ module Herb
         return nil unless position
 
         condition = StateDirectives.condition_source(read)
-        replacement = erb_output_node(%[("#{slot.attribute}" if #{condition})])
+        spacing = open_tag.is_a?(Herb::AST::ERBOpenTagNode) ? " " : ""
+        replacement = erb_output_node(%[("#{spacing}#{slot.attribute}" if #{condition})])
 
         children[position] = replacement
 
@@ -1395,6 +1467,7 @@ module Herb
       #: (untyped) -> bool
       def dynamic?(node)
         return true if node.type.to_s.start_with?("AST_ERB_")
+        return true if node.is_a?(Herb::AST::RubyLiteralNode)
 
         node.compact_child_nodes.any? { |child| dynamic?(child) }
       end
@@ -1412,6 +1485,10 @@ module Herb
       #: (untyped) -> String?
       def attribute_expression_for(node)
         children = node.value&.children || []
+
+        literal = children.grep(Herb::AST::RubyLiteralNode)
+
+        return literal.fetch(0).content.to_s.strip if literal.one? && children.one?
 
         return nil unless children.all? { |child| child.is_a?(Herb::AST::LiteralNode) || child.is_a?(Herb::AST::ERBContentNode) }
 
@@ -1637,7 +1714,7 @@ module Herb
         return unless node.is_a?(Herb::AST::HTMLElementNode)
 
         open_tag = node.open_tag
-        return unless open_tag.is_a?(Herb::AST::HTMLOpenTagNode)
+        return unless open_tag.is_a?(Herb::AST::HTMLOpenTagNode) || open_tag.is_a?(Herb::AST::ERBOpenTagNode)
 
         anchors = (@element_anchored[open_tag] || []).map { |index|
           slot = @slots[index]

--- a/sig/herb/engine/slot_visitor.rbs
+++ b/sig/herb/engine/slot_visitor.rbs
@@ -148,6 +148,8 @@ module Herb
 
       def visit_html_open_tag_node: (untyped node) -> untyped
 
+      def visit_erb_open_tag_node: (untyped node) -> untyped
+
       def visit_html_attribute_node: (untyped node) -> untyped
 
       def visit_html_comment_node: (untyped node) -> untyped
@@ -252,6 +254,9 @@ module Herb
       def condition_expression: (untyped) -> String
 
       # : (untyped) -> untyped
+      def convert_helper_boolean_attribute: (untyped) -> untyped
+
+      # : (untyped) -> untyped
       def register_count_fold: (untyped) -> untyped
 
       # : (untyped) -> void
@@ -268,6 +273,9 @@ module Herb
 
       # : (untyped, String) -> void
       def rewrite_predicate: (untyped, String) -> void
+
+      # : (untyped, String) -> untyped
+      def rewrite_literal_predicate: (untyped, String) -> untyped
 
       # : (untyped) -> untyped
       def predicate_token_for: (untyped) -> untyped

--- a/test/engine/slots/dependencies_test.rb
+++ b/test/engine/slots/dependencies_test.rb
@@ -492,6 +492,21 @@ module Engine
         assert_includes manifest["reads"]["pending_count"], 3
       end
 
+      test "binds a tag helper input that reads a state" do
+        path = write("index.html.erb", <<~ERB)
+          <%# herb:state (draft: "", agreed: false) %>
+          <%= tag.input value: draft %>
+          <%= tag.input type: "checkbox", checked: agreed %>
+        ERB
+
+        manifest = subject.payload(path)["states"].values.first
+
+        assert_equal [0], manifest["reads"]["draft"]
+        assert_equal [0], manifest["bound"]["draft"]
+        assert_equal [["agreed", nil]], manifest["presence"].values
+        assert_equal [1], manifest["bound"]["agreed"]
+      end
+
       test "carries the states a template declares" do
         path = write("index.html.erb", <<~ERB)
           <%# herb:state (pending: false, attempts: 0) %>

--- a/test/engine/slots/states_test.rb
+++ b/test/engine/slots/states_test.rb
@@ -545,6 +545,53 @@ module Engine
         ERB
       end
 
+      test "a tag helper attribute reading a state is a bound slot" do
+        template = %(<%# herb:slots client %><%# herb:state (draft: "") %><%= tag.input value: draft %>)
+        visitor, = compile(template)
+        slot = visitor.slots.fetch(0)
+
+        assert_equal [:attribute, "value", "draft", "input"], [slot.type, slot.attribute, slot.expression, slot.tag]
+        assert_includes render(template), %(<input value="" data-herb-slot="0:attribute:value">)
+      end
+
+      test "a tag helper boolean attribute reading a state renders presence" do
+        template = %(<%# herb:slots client %><%# herb:state (agreed: true) %><%= tag.input type: "checkbox", checked: agreed %>)
+        visitor, = compile(template)
+
+        assert_equal :boolean_attribute, visitor.slots.fetch(0).type
+        assert_equal "checked", visitor.slots.fetch(0).attribute
+        assert visitor.state_presence.key?(0)
+        assert_includes render(template), %(<input type="checkbox" checked data-herb-slot="0:boolean_attribute:checked">)
+
+        off = render(%(<%# herb:slots client %><%# herb:state (agreed: false) %><%= tag.input type: "checkbox", checked: agreed %>))
+
+        assert_includes off, %(<input type="checkbox" data-herb-slot="0:boolean_attribute:checked">)
+      end
+
+      test "a tag helper boolean attribute takes a predicate and a comparison" do
+        rendered = render(%(<%# herb:slots client %><%# herb:state (pending: true) %><%= tag.button "Send", disabled: pending? %>))
+
+        assert_includes rendered, %(<button disabled data-herb-slot="0:boolean_attribute:disabled">)
+
+        rendered = render(%(<%# herb:slots client %><%# herb:state (sort: "name") %><%= tag.option "Name", value: "name", selected: sort == "name" %>))
+
+        assert_includes rendered, %(<option value="name" selected data-herb-slot="0:boolean_attribute:selected">)
+      end
+
+      test "a tag helper boolean attribute on a server value stays a presence slot" do
+        template = %(<%# herb:slots client %><%# herb:state (draft: "") %><%= tag.input disabled: done %>)
+        visitor, = compile(template)
+
+        assert_equal :boolean_attribute, visitor.slots.fetch(0).type
+        refute visitor.state_presence.key?(0)
+        assert_includes render(template, { "done" => true }), %(<input disabled data-herb-slot="0:boolean_attribute:disabled">)
+        assert_includes render(template, { "done" => false }), %(<input data-herb-slot="0:boolean_attribute:disabled">)
+      end
+
+      test "a computed tag helper attribute raises" do
+        refuse(%(<%# herb:slots client %><%# herb:state (draft: "") %><%= tag.input value: draft.upcase %>), /computes with a state/)
+      end
+
       test "an unless reads a state with its arms inverted" do
         template = %(<%# herb:state (pending: false) %><div><% unless pending %>Idle<% else %>Busy<% end %></div>)
         visitor, = compile(template)


### PR DESCRIPTION
This pull request makes a state read work in an Action View tag helper's attributes, as it does in written HTML.

The two spellings should behave the same, and did not:

```erb
<%# herb:state (draft: "", agreed: false) %>

<input value="<%= draft %>">
<%= tag.input value: draft %>
```

The first compiled to a bound attribute slot; the second compiled to opaque helper output, so the state was rendered once and never updated. A boolean attribute in a helper had the same gap, and a state-driven `checked:` or `disabled:` never became a presence attribute.

A helper attribute whose value reads a state is now recorded as the same slot kind the written form produces, including the presence rewrite for boolean attributes, so binding and fan-out work either way.
