### PR TITLE
Engine: Ship seeded state values with the render

### DIFF
--- a/javascript/packages/client/src/slot-index.ts
+++ b/javascript/packages/client/src/slot-index.ts
@@ -26,7 +26,8 @@ const SLOT_CLOSE = /^\/herb-slot:(\d+)$/
 const ITEM_OPEN = /^herb-item:(\d+):([\s\S]*)$/
 const ITEM_CLOSE = /^\/herb-item:(\d+)$/
 const BRANCH = /^herb-branch:(\d+):(\w+)$/
-const MARKER = /^\/?herb-(region|slot|item|branch):/
+const MARKER = /^\/?herb-(region|slot|item|branch|seeds):/
+const SEEDS = /^herb-seeds:([\s\S]*)$/
 const STATICS_REGION = /^(.*):([0-9a-f]+)$/
 const ITEM_STATICS = "item"
 const STATICS_SELECTOR = `template[${HERB_ATTRIBUTES.region}], template[${HERB_ATTRIBUTES.statics}]`
@@ -96,6 +97,7 @@ export interface Item {
   start: Comment
   end: Comment
   slots: SlotMap
+  seeds?: Record<string, unknown>
 }
 
 export interface Slot {
@@ -146,6 +148,7 @@ export interface Region {
   end: Comment | null
   slots: SlotMap
   names: Map<string, number>
+  seeds?: Record<string, unknown>
 }
 
 export interface ScanResult {
@@ -1464,6 +1467,18 @@ export class SlotIndex {
         continue
       }
 
+      const seeds = SEEDS.exec(data)
+
+      if (seeds) {
+        const holder = openItems[openItems.length - 1]?.item ?? openRegions[openRegions.length - 1]?.region ?? this.#enclosingRegion(comment)
+
+        if (holder) holder.seeds = { ...(holder.seeds ?? {}), ...parseSeeds(seeds[1]) }
+
+        this.#seen.add(comment)
+
+        continue
+      }
+
       const branch = BRANCH.exec(data)
 
       if (branch) {
@@ -1711,6 +1726,16 @@ export class SlotIndex {
       yield node as Comment | Element
       node = walker.nextNode()
     }
+  }
+}
+
+function parseSeeds(json: string): Record<string, unknown> {
+  try {
+    const parsed = JSON.parse(json) as unknown
+
+    return parsed !== null && typeof parsed === "object" && !Array.isArray(parsed) ? (parsed as Record<string, unknown>) : {}
+  } catch {
+    return {}
   }
 }
 

--- a/javascript/packages/client/src/state.ts
+++ b/javascript/packages/client/src/state.ts
@@ -856,8 +856,9 @@ export class SlotState {
     const manifest = this.manifestFor(scope.region)
     if (!manifest) return undefined
 
-    let value = this.#seedFromValueSlot(manifest, scope, name)
+    let value = this.#shippedSeed(manifest, scope, name)
 
+    if (value === undefined) value = this.#seedFromValueSlot(manifest, scope, name)
     if (value === undefined) value = this.#seedFromConditional(manifest, scope, name)
     if (value === undefined) {
       const declaration = this.#declaration(manifest, scope, name)
@@ -869,6 +870,63 @@ export class SlotState {
     if (value !== undefined) bucket.set(name, value)
 
     return value
+  }
+
+  #shippedSeed(manifest: StateManifest, scope: StateScope, name: string): StateValue | undefined {
+    const declaration = this.#declaration(manifest, scope, name)
+
+    if (!declaration || declaration.derived || declaration.count) return undefined
+
+    const channel = scope.item?.seeds ?? scope.region.seeds
+    const shipped = scope.item?.seeds?.[name] ?? scope.region.seeds?.[name]
+
+    if (shipped === undefined) {
+      if (channel && parseLiteral(declaration.default) === undefined) {
+        this.#reportSeed(scope, declaration, `the server shipped no value for \`${name}\`; its rendered value was not a boolean, number, string, or nil, so the client falls back to what the page shows`, "seed the state with a primitive, since that is all a state can hold")
+      }
+
+      return undefined
+    }
+
+    const coerced = coerceSeed(shipped, declaration.kind)
+
+    if (coerced === undefined) {
+      this.#reportSeed(scope, declaration, `the server shipped ${JSON.stringify(shipped)} for \`${name}\`, which is declared as ${kindArticle(declaration.kind)}, and the client cannot read it as one`, `seed the state with ${kindArticle(declaration.kind)}`)
+
+      return undefined
+    }
+
+    if (coerced !== shipped) {
+      this.#reportSeed(scope, declaration, `the server shipped ${JSON.stringify(shipped)} for \`${name}\`, which is declared as ${kindArticle(declaration.kind)}, so the client coerced it to ${JSON.stringify(coerced)}`, `seed the state with ${kindArticle(declaration.kind)}`)
+    }
+
+    return coerced
+  }
+
+  #reportedSeeds = new WeakMap<Region, Set<string>>()
+
+  #reportSeed(scope: StateScope, declaration: DeclaredState, message: string, suggestion: string): void {
+    const reported = this.#reportedSeeds.get(scope.region) ?? new Set<string>()
+    const key = `${scope.item?.key ?? ""}:${declaration.name}`
+
+    if (reported.has(key)) return
+
+    reported.add(key)
+    this.#reportedSeeds.set(scope.region, reported)
+
+    const spot = declaration.line !== undefined && declaration.line !== null
+      ? { location: { start: { line: declaration.line, column: declaration.column ?? 0 } } }
+      : {}
+
+    report({
+      template: scope.region.file,
+      message,
+      code: "herb-state-type",
+      severity: "warning",
+      value: declaration.name,
+      suggestion,
+      ...spot,
+    })
   }
 
   #seedFromValueSlot(manifest: StateManifest, scope: StateScope, name: string): StateValue | undefined {
@@ -1357,6 +1415,32 @@ export function boundValue(element: Element, kind: StateKind): StateValue {
   const raw = (element as HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement).value
 
   return coerceState(raw, kind)
+}
+
+function coerceSeed(shipped: unknown, kind: StateKind): StateValue | undefined {
+  if (shipped !== null && typeof shipped !== "boolean" && typeof shipped !== "number" && typeof shipped !== "string") return undefined
+
+  switch (kind) {
+    case "boolean":
+      return typeof shipped === "boolean" ? shipped : shipped !== null
+    case "integer":
+      if (typeof shipped === "number") return Number.isInteger(shipped) ? shipped : Math.trunc(shipped)
+      if (typeof shipped === "string" && /^-?\d+$/.test(shipped.trim())) return Number(shipped.trim())
+
+      return undefined
+    case "string":
+    case "symbol":
+      if (typeof shipped === "string") return shipped
+      if (typeof shipped === "number" || typeof shipped === "boolean") return String(shipped)
+
+      return undefined
+    default:
+      return shipped
+  }
+}
+
+function kindArticle(kind: StateKind): string {
+  return kind === "integer" ? "an Integer" : `a ${kind.charAt(0).toUpperCase() + kind.slice(1)}`
 }
 
 function armMentions(arm: ConditionalArm, changed: string[]): boolean {

--- a/javascript/packages/client/test/state-scoped.test.ts
+++ b/javascript/packages/client/test/state-scoped.test.ts
@@ -1,6 +1,8 @@
-import { describe, test, expect, beforeEach, vi } from "vitest"
+import { describe, test, expect, beforeEach, afterEach, vi } from "vitest"
 import { SlotIndex } from "../src/slot-index"
 import { SlotState, STATE_EVENT } from "../src/state"
+import { resetReport } from "../src/report"
+import type { RuntimeDiagnostic } from "../src/report"
 
 const FILE = "app/views/page/chat.html.erb"
 
@@ -751,5 +753,204 @@ describe("counted states", () => {
   test("a counted state cannot be written", () => {
     expect(countState.setState({ pending_count: 5 })).toBe(false)
     expect(document.querySelector("p")?.textContent).toContain("0")
+  })
+})
+
+describe("shipped seeds", () => {
+  const SEED_FILE = "app/views/page/seeds.html.erb"
+
+  const SEED_PAGE =
+    `<!--herb-region:${SEED_FILE}:0a1b2c3d:0-->` +
+    `<!--herb-seeds:{"open":true,"label":"a-\\u002db"}-->` +
+    `<div><!--herb-slot:0:conditional--><!--herb-branch:0:0-->Busy<!--/herb-slot:0--></div>` +
+    `<ul><!--herb-slot:1:collection-->` +
+    `<!--herb-item:1:a--><!--herb-seeds:{"pending":true}--><li id="a"><i><!--herb-slot:2:conditional--><!--herb-branch:2:0-->sending<!--/herb-slot:2--></i></li><!--/herb-item:1-->` +
+    `<!--herb-item:1:b--><!--herb-seeds:{"pending":false}--><li id="b"><i><!--herb-slot:2:conditional--><!--herb-branch:2:1-->sent<!--/herb-slot:2--></i></li><!--/herb-item:1-->` +
+    `<!--/herb-slot:1--></ul>` +
+    `<template data-herb-region="${SEED_FILE}:0a1b2c3d">` +
+    `<!--herb-branch:0:0-->Busy<!--herb-branch:0:1-->Idle` +
+    `<!--herb-branch:2:0-->sending<!--herb-branch:2:1-->sent` +
+    `</template>` +
+    `<!--/herb-region:${SEED_FILE}-->`
+
+  const SEED_MANIFEST = {
+    state: {},
+    states: {
+      [SEED_FILE]: {
+        version: "0a1b2c3d",
+        declarations: [
+          { name: "open", kind: "boolean", default: "open_initially", scope: "region" },
+          { name: "label", kind: "seeded", default: "@label", scope: "region" },
+          { name: "failed", kind: "boolean", default: "false", scope: "region" },
+          { name: "pending", kind: "boolean", default: "message.odd?", scope: 1 },
+        ],
+        reads: {},
+        conditionals: {
+          0: { arms: [{ branch: 0, any: [["open", null], ["failed", null]] }], else: 1 },
+          2: { arms: [["pending", null, 0]], else: 1 },
+        },
+      },
+    },
+  }
+
+  let seedSlots: SlotIndex
+  let seedState: SlotState
+
+  beforeEach(() => {
+    document.body.innerHTML = SEED_PAGE + `<template data-herb-dependencies>${JSON.stringify(SEED_MANIFEST)}</template>`
+
+    seedSlots = new SlotIndex()
+    seedSlots.scan(document.body)
+
+    seedState = new SlotState(seedSlots, {
+      persist: "none",
+      transport: () => {
+        throw new Error("a declared state must never reach the transport")
+      },
+    })
+
+    seedState.adopt()
+  })
+
+  test("the scanner attaches seeds to the region and to each item", () => {
+    const region = seedSlots.regions()[0]!
+    const collection = region.slots.get(1)!
+
+    expect(region.seeds).toEqual({ open: true, label: "a--b" })
+    expect(collection.items.get("a")?.seeds).toEqual({ pending: true })
+    expect(collection.items.get("b")?.seeds).toEqual({ pending: false })
+  })
+
+  test("a seed the DOM cannot reveal still seeds from the channel", () => {
+    expect(seedState.getState("open")).toBe(true)
+    expect(seedState.getState("label")).toBe("a--b")
+
+    seedState.setState({ failed: true })
+    seedState.setState({ failed: false })
+
+    expect(document.querySelector("div")?.textContent).toContain("Busy")
+  })
+
+  test("item seeds resolve per item", () => {
+    const a = seedState.scopeFor(document.querySelector("#a")!, "pending")!
+    const b = seedState.scopeFor(document.querySelector("#b")!, "pending")!
+
+    expect(seedState.getState("pending", { scope: a })).toBe(true)
+    expect(seedState.getState("pending", { scope: b })).toBe(false)
+  })
+
+  test("reset returns to the shipped value", () => {
+    seedState.setState({ open: false })
+
+    expect(seedState.getState("open")).toBe(false)
+
+    seedState.reset("open")
+
+    expect(seedState.getState("open")).toBe(true)
+  })
+})
+
+describe("shipped seeds that disagree with the declaration", () => {
+  const ODD_FILE = "app/views/page/odd-seeds.html.erb"
+
+  interface FakeDevTools {
+    report(input: RuntimeDiagnostic | RuntimeDiagnostic[]): void
+    entries: RuntimeDiagnostic[]
+  }
+
+  let devTools: FakeDevTools
+
+  function boot(seeds: string, declarations: Record<string, unknown>[]): SlotState {
+    document.body.innerHTML =
+      `<!--herb-region:${ODD_FILE}:0ddc0ffe:0-->` +
+      `<!--herb-seeds:${seeds}-->` +
+      `<p><!--herb-slot:0-->0<!--/herb-slot:0--></p>` +
+      `<!--/herb-region:${ODD_FILE}-->` +
+      `<template data-herb-dependencies>${JSON.stringify({
+        state: {},
+        states: { [ODD_FILE]: { version: "0ddc0ffe", declarations, reads: {}, conditionals: {} } },
+      })}</template>`
+
+    const oddSlots = new SlotIndex()
+    oddSlots.scan(document.body)
+
+    const oddState = new SlotState(oddSlots, { persist: "none" })
+    oddState.adopt()
+
+    return oddState
+  }
+
+  beforeEach(() => {
+    resetReport()
+    devTools = { entries: [], report(input) { devTools.entries.push(...(Array.isArray(input) ? input : [input])) } }
+    ;(window as unknown as { HerbDevTools?: FakeDevTools }).HerbDevTools = devTools
+  })
+
+  afterEach(() => {
+    delete (window as unknown as { HerbDevTools?: unknown }).HerbDevTools
+  })
+
+  test("a seed of the declared kind reports nothing", () => {
+    const oddState = boot('{"count":5,"name":"x"}', [
+      { name: "count", kind: "integer", default: "@count", scope: "region", line: 2, column: 0 },
+      { name: "name", kind: "string", default: "@name", scope: "region", line: 2, column: 0 },
+    ])
+
+    expect(oddState.getState("count")).toBe(5)
+    expect(oddState.getState("name")).toBe("x")
+    expect(devTools.entries).toEqual([])
+  })
+
+  test("a seed of another kind is coerced and reported at the declaration", () => {
+    const oddState = boot('{"count":"5","name":7,"open":"yes"}', [
+      { name: "count", kind: "integer", default: "@count", scope: "region", line: 2, column: 0 },
+      { name: "name", kind: "string", default: "@name", scope: "region", line: 2, column: 0 },
+      { name: "open", kind: "boolean", default: "@open", scope: "region", line: 2, column: 0 },
+    ])
+
+    expect(oddState.getState("count")).toBe(5)
+    expect(oddState.getState("name")).toBe("7")
+    expect(oddState.getState("open")).toBe(true)
+
+    expect(devTools.entries.map((entry) => [entry.code, entry.severity, entry.value])).toEqual([
+      ["herb-state-type", "warning", "count"],
+      ["herb-state-type", "warning", "name"],
+      ["herb-state-type", "warning", "open"],
+    ])
+    expect(devTools.entries[0].message).toContain("coerced it to 5")
+    expect(devTools.entries[0].location).toEqual({ start: { line: 2, column: 0 } })
+  })
+
+  test("a seed the client cannot read falls back and reports", () => {
+    const oddState = boot('{"count":"five"}', [
+      { name: "count", kind: "integer", default: "@count", scope: "region", line: 2, column: 0 },
+    ])
+
+    expect(oddState.getState("count")).toBeNull()
+    expect(oddState.getState("count")).toBeNull()
+    expect(devTools.entries).toHaveLength(1)
+    expect(devTools.entries[0].message).toContain("cannot read it as one")
+  })
+
+  test("an empty channel still reports every dropped seed", () => {
+    const oddState = boot("{}", [
+      { name: "shape", kind: "seeded", default: "@shape", scope: "region", line: 2, column: 0 },
+    ])
+
+    expect(oddState.getState("shape")).toBeNull()
+    expect(devTools.entries.map((entry) => entry.value)).toEqual(["shape"])
+  })
+
+  test("a seeded state missing from a present channel reports the dropped value", () => {
+    const oddState = boot('{"name":"x"}', [
+      { name: "name", kind: "string", default: "@name", scope: "region", line: 2, column: 0 },
+      { name: "shape", kind: "seeded", default: "@shape", scope: "region", line: 2, column: 0 },
+      { name: "count", kind: "integer", default: "0", scope: "region", line: 2, column: 0 },
+    ])
+
+    expect(oddState.getState("shape")).toBeNull()
+    expect(oddState.getState("count")).toBe(0)
+    expect(devTools.entries.map((entry) => entry.value)).toEqual(["shape"])
+    expect(devTools.entries[0].message).toContain("shipped no value")
   })
 })

--- a/lib/herb/engine/slot_visitor.rb
+++ b/lib/herb/engine/slot_visitor.rb
@@ -63,6 +63,10 @@ module Herb
       NAME_ATTRIBUTE = "data-herb-name" #: String
       NAMEABLE_TYPES = [:child, :collection, :conditional, :block].freeze #: Array[Symbol]
 
+      SEEDS_MARKER = "herb-seeds:" #: String
+      SEEDS_LOCAL = "_herb_seeds" #: String
+      SEED_VALUE_TYPES = "[true, false, ::Integer, ::String, ::Symbol, nil]" #: String
+
       Slot = Data.define(
         :index,      #: Integer
         :type,       #: Symbol
@@ -700,7 +704,7 @@ module Herb
           bucket[declaration.name] = declaration
         end
 
-        @state_directives << { node: node, parent: parent, scope: scope }
+        @state_directives << { node: node, parent: parent, scope: scope, inline: @in_open_tag || @in_attribute }
       end
 
       #: (String?) -> Symbol
@@ -734,8 +738,9 @@ module Herb
           scope = directive[:scope]
           bucket = scope ? (@item_states[scope] || {}) : @region_states
           assignments = bucket.values.map { |declaration| state_assignment(declaration) }.join("; ")
+          seeds = directive[:inline] ? nil : seeds_marker(bucket.values)
 
-          parent[position] = erb_code_node(assignments)
+          parent[position] = erb_code_node(seeds ? "#{assignments}; #{seeds}" : assignments)
         end
 
         return if @region_states.empty? && @item_states.empty?
@@ -743,6 +748,21 @@ module Herb
         classify_state_conditionals
         check_state_value_reads
         check_state_count_reads
+      end
+
+      #: (Array[StateDirectives::Declaration]) -> String?
+      def seeds_marker(declarations)
+        return nil unless @mark
+
+        seeded = declarations.select { |declaration| StateDirectives.seeded?(declaration) }
+
+        return nil if seeded.empty?
+
+        pairs = seeded.map { |declaration| "#{declaration.name.inspect} => #{declaration.name}" }.join(", ")
+
+        "#{SEEDS_LOCAL} = { #{pairs} }.select { |_, v| #{SEED_VALUE_TYPES}.any? { |t| t === v } }" \
+          ".transform_values { |v| v.is_a?(::Symbol) ? v.to_s : v }; " \
+          "_buf << \"<!--#{SEEDS_MARKER}\" << ::JSON.generate(#{SEEDS_LOCAL}).gsub(\"--\", \"-\\\\u002d\") << \"-->\""
       end
 
       #: (StateDirectives::Declaration) -> String

--- a/lib/herb/engine/state_directives.rb
+++ b/lib/herb/engine/state_directives.rb
@@ -274,6 +274,15 @@ module Herb
           }
         end
 
+        #: (Declaration) -> bool
+        def seeded?(declaration)
+          return false if declaration.derived
+
+          node = expression_node(declaration.default)
+
+          node.nil? || !KINDS.key?(node.class.name)
+        end
+
         #: (String, Hash[String, Declaration]) -> bool
         def mentions_any?(source, states)
           states.each_key.any? { |name| /(?<![\w?])#{Regexp.escape(name)}\??(?![\w?!])/.match?(source) }

--- a/sig/herb/engine/slot_visitor.rbs
+++ b/sig/herb/engine/slot_visitor.rbs
@@ -64,6 +64,12 @@ module Herb
 
       NAMEABLE_TYPES: Array[Symbol]
 
+      SEEDS_MARKER: String
+
+      SEEDS_LOCAL: String
+
+      SEED_VALUE_TYPES: String
+
       class Slot < Data
         attr_reader index(): Integer
 
@@ -228,6 +234,9 @@ module Herb
 
       # : () -> void
       def apply_states: () -> void
+
+      # : (Array[StateDirectives::Declaration]) -> String?
+      def seeds_marker: (Array[StateDirectives::Declaration]) -> String?
 
       # : (StateDirectives::Declaration) -> String
       def state_assignment: (StateDirectives::Declaration) -> String

--- a/sig/herb/engine/state_directives.rbs
+++ b/sig/herb/engine/state_directives.rbs
@@ -123,6 +123,9 @@ module Herb
       # : (String, Declaration) -> (Array[String] | Symbol)
       def self.when_comparands: (String, Declaration) -> (Array[String] | Symbol)
 
+      # : (Declaration) -> bool
+      def self.seeded?: (Declaration) -> bool
+
       # : (String, Hash[String, Declaration]) -> bool
       def self.mentions_any?: (String, Hash[String, Declaration]) -> bool
 

--- a/test/engine/slots/states_test.rb
+++ b/test/engine/slots/states_test.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "json"
 require_relative "../../test_helper"
 require_relative "../../snapshot_utils"
 require_relative "../../../lib/herb/engine"
@@ -590,6 +591,53 @@ module Engine
 
       test "a computed tag helper attribute raises" do
         refuse(%(<%# herb:slots client %><%# herb:state (draft: "") %><%= tag.input value: draft.upcase %>), /computes with a state/)
+      end
+
+      SEEDED = <<~ERB
+        <%# locals: (open_initially: false) %>
+        <%# herb:slots client %>
+        <%# herb:state (open: open_initially, label: @label, count: 0, busy: open) %>
+        <div><% if busy %>Open<% else %>Closed<% end %></div>
+        <ul>
+          <% @messages.each do |message| %>
+            <%# herb:key message %>
+            <%# herb:state (pending: message.odd?, note: "x") %>
+            <li id="m<%= message %>"><%= message %></li>
+          <% end %>
+        </ul>
+      ERB
+
+      def seeds_in(rendered)
+        rendered.scan(/<!--herb-seeds:(.*?)-->/).flatten.map { |json| JSON.parse(json) }
+      end
+
+      test "the render ships the values of seeded states" do
+        rendered = render(SEEDED, { "open_initially" => true, "@label" => "shipped", "@messages" => [1, 2] })
+
+        assert_equal [{ "open" => true, "label" => "shipped" }, { "pending" => true }, { "pending" => false }], seeds_in(rendered)
+      end
+
+      test "the seeds marker survives a value containing a comment terminator" do
+        rendered = render(SEEDED, { "open_initially" => false, "@label" => "a-->b", "@messages" => [] })
+
+        assert_equal "a-->b", seeds_in(rendered).fetch(0).fetch("label")
+        assert_includes rendered, "<!--herb-seeds:"
+        refute_match(/<!--herb-seeds:[^>]*-->b/, rendered)
+      end
+
+      test "the seeds marker skips values the client cannot hold" do
+        template = %(<%# herb:slots client %><%# herb:state (shape: @shape, name: @name) %><p><%= name %></p>)
+        rendered = render(template, { "@shape" => [1, 2], "@name" => "n" })
+
+        assert_equal [{ "name" => "n" }], seeds_in(rendered)
+
+        only_shape = render(%(<%# herb:slots client %><%# herb:state (shape: @shape) %><p><%= shape %></p>), { "@shape" => [1, 2] })
+
+        assert_includes only_shape, "<!--herb-seeds:{}-->"
+      end
+
+      test "a template with only literal defaults ships no seeds" do
+        refute_includes render(STATUS), "herb-seeds"
       end
 
       test "an unless reads a state with its arms inverted" do


### PR DESCRIPTION
This pull request delivers the value a seeded state was rendered with, so the client starts from what is on the page.

A state's default may be any expression, which is how a partial receives an initial value per instance:

```erb
<%# locals: (open_initially: false) %>
<%# herb:state (open: open_initially) %>
```

The client cannot evaluate that, and inferring the value from rendered markup only works when the state is visible in the markup. So the render ships them:

```html
<!--herb-seeds:{"open":true}-->
```

One marker per scope, carrying the seeded states of that scope, so an item's seeds sit with the item. Values are restricted to what a state can hold, and anything else is dropped instead of being sent as something the client would have to guess at. A `--` inside a value is escaped so it cannot terminate the comment early.

When a shipped value does not match what the state was declared to hold, the client coerces it and reports a `herb-state-type` diagnostic naming the declaration, since that mismatch means a caller passed the wrong thing and the page is showing it.
