### PR TITLE
Dev Tools: Deliver runtime diagnostics and locate their elements

### DIFF
--- a/javascript/packages/client/src/actions.ts
+++ b/javascript/packages/client/src/actions.ts
@@ -110,6 +110,7 @@ export class SlotActions {
       if (!balancedQuotes(value)) {
         report({
           template: this.#templateOf(element),
+          element,
           message: `\`${attribute}="${value}"\` has an unbalanced quote`,
           code: "herb-invalid-action",
           severity: "error",
@@ -131,6 +132,7 @@ export class SlotActions {
     if (clause.event === "" || (clause.rest.trim() === "" && !schema.bare)) {
       report({
         template: this.#templateOf(element),
+        element,
         message: `\`${attribute}\` has a clause with ${clause.event === "" ? "no event before the arrow" : "nothing after the event"}`,
         code: "herb-invalid-action",
         severity: "error",
@@ -154,7 +156,7 @@ export class SlotActions {
       const kind = resolved[1].kind
 
       if (schema.needs && kind !== schema.needs && kind !== "seeded") {
-        this.#reportKind(resolved[0].region.file, attribute, name, kind, schema.needs)
+        this.#reportKind(resolved[0].region.file, attribute, name, kind, schema.needs, element)
       }
     }
   }
@@ -165,6 +167,7 @@ export class SlotActions {
     if (separator < 1) {
       report({
         template: this.#templateOf(element),
+        element,
         message: `\`${assignment.trim()}\` in \`${HERB_ATTRIBUTES.set}\` is not a \`state=value\` pair`,
         code: "herb-invalid-action",
         severity: "error",
@@ -184,6 +187,7 @@ export class SlotActions {
     if ((kind === "boolean" && raw !== "true" && raw !== "false") || (kind === "integer" && !/^-?\d+$/.test(raw))) {
       report({
         template: resolved[0].region.file,
+        element,
         message: `\`${name}=${raw}\` does not parse as a ${kind}; \`${name}\` is declared as one`,
         code: "herb-state-type",
         severity: "error",
@@ -192,9 +196,10 @@ export class SlotActions {
     }
   }
 
-  #reportKind(template: string, attribute: string, name: string, kind: string, wanted: string): void {
+  #reportKind(template: string, attribute: string, name: string, kind: string, wanted: string, element: Element | null = null): void {
     report({
       template,
+      element,
       message: `\`${attribute}\` on \`${name}\` can never work, because \`${name}\` is a ${kind} and it needs a ${wanted}`,
       code: "herb-state-type",
       severity: "error",
@@ -288,7 +293,8 @@ export class SlotActions {
 
     if (!scope) {
       report({
-        template: "",
+        template: this.#templateOf(element),
+        element,
         message: `nothing around this element declares the state \`${name}\``,
         code: "herb-unknown-state",
         severity: "error",
@@ -331,7 +337,8 @@ export class SlotActions {
 
       if (separator < 1) {
         report({
-          template: "",
+          template: this.#templateOf(element),
+          element,
           message: `\`${assignment}\` in \`${HERB_ATTRIBUTES.set}\` is not a \`state=value\` pair`,
           code: "herb-invalid-action",
           severity: "error",
@@ -360,6 +367,7 @@ export class SlotActions {
       if ((kind === "boolean" && raw !== "true" && raw !== "false") || (kind === "integer" && !/^-?\d+$/.test(raw))) {
         report({
           template: scope.region.file,
+          element,
           message: `\`${name}=${raw}\` does not parse as a ${kind}; \`${name}\` is declared as one`,
           code: "herb-state-type",
           severity: "error",
@@ -387,6 +395,7 @@ export class SlotActions {
       if (declaration.kind !== "boolean" && declaration.kind !== "seeded") {
         report({
           template: scope.region.file,
+          element,
           message: `\`${HERB_ATTRIBUTES.toggle}\` on \`${name}\` did nothing, because \`${name}\` is a ${declaration.kind} and toggling needs a boolean`,
           code: "herb-state-type",
           severity: "error",

--- a/javascript/packages/client/src/report.ts
+++ b/javascript/packages/client/src/report.ts
@@ -19,6 +19,7 @@ export const RUNTIME_ORIGIN = "Herb Client Runtime"
 export const DEV_TOOLS_START_EVENT = "herb:dev-tools-start"
 
 const MAX_QUEUED = 50
+const NAVIGATION_EVENT = "turbo:before-render"
 
 const queued: RuntimeDiagnostic[] = []
 
@@ -135,15 +136,7 @@ function unhookGlobal(): void {
 export function clearOnNavigation(): () => void {
   if (typeof document === "undefined") return () => {}
 
-  let landed = false
-
   const clear = (): void => {
-    if (!landed) {
-      landed = true
-
-      return
-    }
-
     queued.length = 0
 
     const devTools = globalThis.window && (window as { HerbDevTools?: DevToolsGlobal }).HerbDevTools
@@ -151,9 +144,9 @@ export function clearOnNavigation(): () => void {
     devTools?.clear?.(RUNTIME_ORIGIN)
   }
 
-  document.addEventListener("turbo:load", clear)
+  document.addEventListener(NAVIGATION_EVENT, clear)
 
-  return () => document.removeEventListener("turbo:load", clear)
+  return () => document.removeEventListener(NAVIGATION_EVENT, clear)
 }
 
 function debugging(): boolean {

--- a/javascript/packages/client/src/report.ts
+++ b/javascript/packages/client/src/report.ts
@@ -7,6 +7,7 @@ export interface RuntimeDiagnostic {
   location?: { start: { line: number; column: number } }
   suggestion?: string
   value?: string
+  element?: Element | null
 }
 
 interface DevToolsGlobal {
@@ -15,14 +16,18 @@ interface DevToolsGlobal {
 }
 
 export const RUNTIME_ORIGIN = "Herb Client Runtime"
+export const DEV_TOOLS_START_EVENT = "herb:dev-tools-start"
 
 const MAX_QUEUED = 50
 
 const queued: RuntimeDiagnostic[] = []
 
+let armed = false
+let hooked = false
+
 export function report(diagnostic: RuntimeDiagnostic): void {
   const entry = { origin: RUNTIME_ORIGIN, ...diagnostic }
-  const devTools = globalThis.window && (window as { HerbDevTools?: DevToolsGlobal }).HerbDevTools
+  const devTools = currentDevTools()
 
   if (devTools?.report) {
     if (queued.length > 0) devTools.report(queued.splice(0))
@@ -33,16 +38,98 @@ export function report(diagnostic: RuntimeDiagnostic): void {
   }
 
   if (debugging()) {
-    console.warn(`[herb] ${entry.message}${entry.suggestion ? `. ${entry.suggestion}` : ""}`, entry)
+    const log = entry.severity === "error" ? console.error : console.warn
+
+    log(`[herb] ${entry.message}${entry.suggestion ? `. ${entry.suggestion}` : ""}`, entry)
   }
 
   queued.push(entry)
 
   if (queued.length > MAX_QUEUED) queued.shift()
+
+  arm()
+}
+
+export function flushReports(): number {
+  const devTools = currentDevTools()
+
+  if (!devTools?.report || queued.length === 0) return 0
+
+  const flushed = queued.splice(0)
+
+  devTools.report(flushed)
+
+  return flushed.length
 }
 
 export function resetReport(): void {
   queued.length = 0
+  disarm()
+}
+
+function currentDevTools(): DevToolsGlobal | undefined {
+  return globalThis.window ? (window as { HerbDevTools?: DevToolsGlobal }).HerbDevTools : undefined
+}
+
+function arm(): void {
+  if (typeof document === "undefined") return
+
+  hookGlobal()
+
+  if (armed) return
+
+  armed = true
+  document.addEventListener(DEV_TOOLS_START_EVENT, onDevToolsReady)
+  window.addEventListener("load", onDevToolsReady)
+}
+
+function disarm(): void {
+  unhookGlobal()
+
+  if (!armed) return
+
+  armed = false
+  document.removeEventListener(DEV_TOOLS_START_EVENT, onDevToolsReady)
+  window.removeEventListener("load", onDevToolsReady)
+}
+
+function onDevToolsReady(): void {
+  flushReports()
+}
+
+function hookGlobal(): void {
+  if (typeof window === "undefined") return
+
+  const descriptor = Object.getOwnPropertyDescriptor(window, "HerbDevTools")
+
+  if (descriptor?.get) return
+  if (descriptor && (descriptor.value !== undefined && descriptor.value !== null)) return
+  if (descriptor && descriptor.configurable === false) return
+
+  let current: DevToolsGlobal | undefined
+
+  Object.defineProperty(window, "HerbDevTools", {
+    configurable: true,
+    enumerable: true,
+    get: () => current,
+    set: (value: DevToolsGlobal | undefined) => {
+      current = value
+
+      if (value) queueMicrotask(flushReports)
+    },
+  })
+
+  hooked = true
+}
+
+function unhookGlobal(): void {
+  if (!hooked || typeof window === "undefined") return
+
+  hooked = false
+
+  const descriptor = Object.getOwnPropertyDescriptor(window, "HerbDevTools")
+
+  if (descriptor?.get && descriptor.get() === undefined) delete (window as { HerbDevTools?: unknown }).HerbDevTools
 }
 
 export function clearOnNavigation(): () => void {

--- a/javascript/packages/client/src/state.ts
+++ b/javascript/packages/client/src/state.ts
@@ -694,7 +694,7 @@ export class SlotState {
     const listed = known.length > 0 ? `the states in scope are ${known.join(", ")}` : "no scope on this page declares it"
 
     report({
-      template: scope?.region.file ?? "",
+      template: scope?.region.file ?? this.#slots.regions()[0]?.file ?? "",
       message: `nothing here declares the state \`${name}\`; ${listed}`,
       code: "herb-unknown-state",
       severity: "error",
@@ -1018,6 +1018,7 @@ export class SlotState {
         if (!this.#slots.switchBranch(slot, target) && slot.branch !== target) {
           report({
             template: scope.region.file,
+            element: slot.anchor.kind === "range" ? slot.anchor.start.parentElement : slot.anchor.element,
             message: `branch ${target ?? "else"} of slot ${slot.index} was never parked, so it cannot be shown`,
             code: "herb-no-parked-branch",
             severity: "warning",

--- a/javascript/packages/client/test/report.test.ts
+++ b/javascript/packages/client/test/report.test.ts
@@ -1,8 +1,9 @@
 import { describe, test, expect, beforeEach, afterEach } from "vitest"
 import { SlotIndex } from "../src/slot-index"
+import { SlotActions } from "../src/actions"
 import { SlotState } from "../src/state"
 
-import { clearOnNavigation, resetReport } from "../src/report"
+import { clearOnNavigation, report, resetReport, DEV_TOOLS_START_EVENT } from "../src/report"
 
 import type { RuntimeDiagnostic } from "../src/report"
 
@@ -82,12 +83,31 @@ describe("runtime diagnostics", () => {
     expect(state.getState("sort")).toBe("name")
   })
 
+  test("a diagnostic raised by an action carries the element it is about", () => {
+    const devTools = installDevTools()
+    const button = document.createElement("button")
+
+    button.setAttribute("data-herb-toggle", "nope")
+    document.body.appendChild(button)
+
+    const actions = new SlotActions(state)
+
+    actions.start(document.body)
+
+    const entry = devTools.entries.find((candidate) => candidate.code === "herb-unknown-state")
+
+    expect(entry?.element).toBe(button)
+
+    actions.stop()
+  })
+
   test("an unknown state lists what is in scope", () => {
     const devTools = installDevTools()
 
     expect(state.setState({ missing: true })).toBe(false)
 
     expect(devTools.entries[0].code).toBe("herb-unknown-state")
+    expect(devTools.entries[0].template).toBe(FILE)
   })
 
   test("a version mismatch reports and declines", () => {
@@ -145,21 +165,118 @@ describe("runtime diagnostics", () => {
   test("falls back to the console while the panel is absent in debug mode", async () => {
     const { vi } = await import("vitest")
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
+    const error = vi.spyOn(console, "error").mockImplementation(() => {})
 
     document.head.innerHTML = `<meta name="herb-debug-mode" content="true">`
     state.setState({ missing: true })
 
-    expect(warn).toHaveBeenCalledTimes(1)
-    expect(String(warn.mock.calls[0][0])).toContain("[herb]")
+    expect(error).toHaveBeenCalledTimes(1)
+    expect(String(error.mock.calls[0][0])).toContain("[herb]")
+    expect(warn).not.toHaveBeenCalled()
 
     const devTools = installDevTools()
 
     state.setState({ also_missing: true })
 
-    expect(warn).toHaveBeenCalledTimes(1)
+    expect(error).toHaveBeenCalledTimes(1)
     expect(devTools.entries).toHaveLength(2)
 
     warn.mockRestore()
+    error.mockRestore()
+  })
+
+  test("the console fallback follows the severity", async () => {
+    const { vi } = await import("vitest")
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
+    const error = vi.spyOn(console, "error").mockImplementation(() => {})
+
+    document.head.innerHTML = `<meta name="herb-debug-mode" content="true">`
+
+    report({ template: "t.html.erb", message: "soft", severity: "warning" })
+    report({ template: "t.html.erb", message: "hard", severity: "error" })
+    report({ template: "t.html.erb", message: "quiet" })
+
+    expect(warn.mock.calls.map((call) => String(call[0]))).toEqual(["[herb] soft", "[herb] quiet"])
+    expect(error.mock.calls.map((call) => String(call[0]))).toEqual(["[herb] hard"])
+
+    warn.mockRestore()
+    error.mockRestore()
+  })
+
+  test("the dev tools' start event flushes the queue without another report", () => {
+    state.setState({ missing: true })
+    state.setState({ also_missing: true })
+
+    const devTools = installDevTools()
+
+    expect(devTools.entries).toHaveLength(0)
+
+    document.dispatchEvent(new CustomEvent(DEV_TOOLS_START_EVENT))
+
+    expect(devTools.entries.map((entry) => entry.value)).toEqual(["missing", "also_missing"])
+
+    document.dispatchEvent(new CustomEvent(DEV_TOOLS_START_EVENT))
+
+    expect(devTools.entries).toHaveLength(2)
+  })
+
+  test("a bundle that assigns the global without announcing itself still gets the queue", async () => {
+    state.setState({ missing: true })
+
+    const devTools = installDevTools()
+
+    expect(devTools.entries).toHaveLength(0)
+
+    await new Promise((resolve) => queueMicrotask(() => resolve(null)))
+
+    expect(devTools.entries.map((entry) => entry.value)).toEqual(["missing"])
+    expect((window as unknown as { HerbDevTools?: unknown }).HerbDevTools).toBe(devTools)
+
+    delete (window as unknown as { HerbDevTools?: unknown }).HerbDevTools
+
+    expect((window as unknown as { HerbDevTools?: unknown }).HerbDevTools).toBeUndefined()
+  })
+
+  test("the hook re-installs after the dev tools stop and the global is deleted", async () => {
+    state.setState({ missing: true })
+
+    const first = installDevTools()
+
+    await new Promise((resolve) => queueMicrotask(() => resolve(null)))
+
+    expect(first.entries).toHaveLength(1)
+
+    delete (window as unknown as { HerbDevTools?: unknown }).HerbDevTools
+
+    state.setState({ also_missing: true })
+
+    const second = installDevTools()
+
+    await new Promise((resolve) => queueMicrotask(() => resolve(null)))
+
+    expect(second.entries.map((entry) => entry.value)).toEqual(["also_missing"])
+  })
+
+  test("a dangling undefined global is replaced by the hook", async () => {
+    ;(window as unknown as { HerbDevTools?: unknown }).HerbDevTools = undefined
+
+    state.setState({ missing: true })
+
+    const devTools = installDevTools()
+
+    await new Promise((resolve) => queueMicrotask(() => resolve(null)))
+
+    expect(devTools.entries.map((entry) => entry.value)).toEqual(["missing"])
+  })
+
+  test("the window load event flushes a queue the dev tools were late for", () => {
+    state.setState({ missing: true })
+
+    const devTools = installDevTools()
+
+    window.dispatchEvent(new Event("load"))
+
+    expect(devTools.entries.map((entry) => entry.value)).toEqual(["missing"])
   })
 
   test("production logs nothing to the console", async () => {

--- a/javascript/packages/client/test/report.test.ts
+++ b/javascript/packages/client/test/report.test.ts
@@ -31,6 +31,7 @@ const PAGE =
 
 interface FakeDevTools {
   report(input: RuntimeDiagnostic | RuntimeDiagnostic[]): void
+  clear(origin?: string): void
   entries: RuntimeDiagnostic[]
 }
 
@@ -39,6 +40,9 @@ function installDevTools(): FakeDevTools {
     entries: [],
     report(input) {
       devTools.entries.push(...(Array.isArray(input) ? input : [input]))
+    },
+    clear(origin) {
+      devTools.entries = devTools.entries.filter((entry) => origin !== undefined && entry.origin !== origin)
     },
   }
 
@@ -143,10 +147,8 @@ describe("runtime diagnostics", () => {
 
     const stop = clearOnNavigation()
 
-    document.dispatchEvent(new Event("turbo:load"))
-
     state.setState({ missing: true })
-    document.dispatchEvent(new Event("turbo:load"))
+    document.dispatchEvent(new Event("turbo:before-render"))
 
     const devTools = installDevTools()
     const cleared: (string | undefined)[] = []
@@ -156,7 +158,7 @@ describe("runtime diagnostics", () => {
     state.setState({ also_missing: true })
     expect(devTools.entries.map((entry) => entry.value)).toEqual(["also_missing"])
 
-    document.dispatchEvent(new Event("turbo:load"))
+    document.dispatchEvent(new Event("turbo:before-render"))
     expect(cleared).toEqual(["Herb Client Runtime"])
 
     stop()
@@ -300,7 +302,7 @@ describe("runtime diagnostics", () => {
     expect(devTools.entries.map((entry) => entry.value)).toEqual(["missing", "also_missing"])
   })
 
-  test("the landing page's own turbo:load keeps its diagnostics", () => {
+  test("a full page load keeps its diagnostics", () => {
     const stop = clearOnNavigation()
 
     state.setState({ missing: true })
@@ -311,6 +313,23 @@ describe("runtime diagnostics", () => {
     state.setState({ also_missing: true })
 
     expect(devTools.entries.map((entry) => entry.value)).toEqual(["missing", "also_missing"])
+
+    stop()
+  })
+
+  test("a navigated page keeps what its own scan reports", () => {
+    const devTools = installDevTools()
+    const stop = clearOnNavigation()
+
+    state.setState({ missing: true })
+
+    document.dispatchEvent(new Event("turbo:before-render"))
+    expect(devTools.entries).toEqual([])
+
+    state.setState({ also_missing: true })
+    document.dispatchEvent(new Event("turbo:load"))
+
+    expect(devTools.entries.map((entry) => entry.value)).toEqual(["also_missing"])
 
     stop()
   })

--- a/javascript/packages/dev-tools/src/herb-dev-tools.ts
+++ b/javascript/packages/dev-tools/src/herb-dev-tools.ts
@@ -12,6 +12,8 @@ import type { RuntimeDiagnostic } from './runtime/report.js'
 
 const NOOP_HANDLE: RuntimeReportHandle = { dismiss() {} }
 
+export const DEV_TOOLS_START_EVENT = 'herb:dev-tools-start'
+
 export interface HerbDevToolsOptions {
   projectPath?: string
   devServer?: boolean | HerbClientOptions
@@ -41,6 +43,10 @@ export class HerbDevTools {
     window.HerbDevTools = devTools
 
     devTools.setup()
+
+    if (typeof document !== 'undefined') {
+      document.dispatchEvent(new CustomEvent(DEV_TOOLS_START_EVENT, { detail: devTools }))
+    }
 
     return devTools
   }

--- a/javascript/packages/dev-tools/src/index.ts
+++ b/javascript/packages/dev-tools/src/index.ts
@@ -1,4 +1,4 @@
-export { HerbDevTools } from './herb-dev-tools.js'
+export { HerbDevTools, DEV_TOOLS_START_EVENT } from './herb-dev-tools.js'
 export { RuntimePanel } from './runtime/panel.js'
 
 export type { HerbDevToolsOptions } from './herb-dev-tools.js'

--- a/javascript/packages/dev-tools/src/runtime/panel.css
+++ b/javascript/packages/dev-tools/src/runtime/panel.css
@@ -548,3 +548,27 @@
 .herb-dev-tools-panel.herb-dev-tools-expanded .herb-dev-tools-group-title {
   grid-column: 1 / -1;
 }
+
+.herb-dev-tools-element {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  margin: 0.25rem 0 0.4rem;
+  padding: 0.15rem 0.5rem;
+  border: 1px solid rgba(245, 158, 11, 0.5);
+  border-radius: 999px;
+  background: rgba(245, 158, 11, 0.08);
+  color: inherit;
+  font: inherit;
+  font-size: 0.75rem;
+  cursor: pointer;
+}
+
+.herb-dev-tools-element:hover {
+  background: rgba(245, 158, 11, 0.2);
+}
+
+.herb-dev-tools-element code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.72rem;
+}

--- a/javascript/packages/dev-tools/src/runtime/panel.ts
+++ b/javascript/packages/dev-tools/src/runtime/panel.ts
@@ -2,7 +2,8 @@ import panelStyles from './panel.css'
 
 import { injectStyle } from '../styles.js'
 import { loadRuntimeHighlighting } from './highlighting.js'
-import { buildRenderStack, diagnosticKey, normalizeDiagnostic, trimOrigin, readRuntimeReport } from './report.js'
+import { buildRenderStack, diagnosticKey, normalizeDiagnostic, trimOrigin, readRuntimeReport, UNKNOWN_TEMPLATE } from './report.js'
+import { flashElement } from '../slots/flash.js'
 
 import { MAX_RUNTIME_DIAGNOSTICS, RUNTIME_SEVERITIES } from './report.js'
 
@@ -31,6 +32,7 @@ interface PanelEntry {
   key: string
   diagnostic: NormalizedDiagnostic
   count: number
+  payload: boolean
 }
 
 interface PanelState {
@@ -125,6 +127,7 @@ function mergeDiagnostics(existing: NormalizedDiagnostic, incoming: NormalizedDi
     docsUrl: existing.docsUrl ?? incoming.docsUrl,
     value: existing.value ?? incoming.value,
     fix: existing.fix ?? incoming.fix,
+    element: incoming.element?.isConnected ? incoming.element : existing.element,
   }
 }
 
@@ -179,7 +182,11 @@ export class RuntimePanel {
 
     this.cleared = false
 
-    for (const candidate of candidates) {
+    for (const raw of candidates) {
+      const candidate = raw !== null && typeof raw === 'object' && (typeof raw.template !== 'string' || raw.template.length === 0)
+        ? { ...raw, template: UNKNOWN_TEMPLATE }
+        : raw
+
       if (typeof candidate?.template === 'string' && typeof candidate?.source === 'string') {
         this.sources[candidate.template] = candidate.source
       }
@@ -337,7 +344,7 @@ export class RuntimePanel {
       return
     }
 
-    this.entries = []
+    this.entries = this.entries.filter(entry => !entry.payload)
     this.cleared = false
 
     this.applyPayload(report)
@@ -366,11 +373,11 @@ export class RuntimePanel {
     this.sources = report.sources
 
     for (const diagnostic of report.diagnostics) {
-      this.add(diagnostic)
+      this.add(diagnostic, true)
     }
   }
 
-  private add(diagnostic: NormalizedDiagnostic): string {
+  private add(diagnostic: NormalizedDiagnostic, payload = false): string {
     const key = diagnosticKey(diagnostic)
     const existing = this.entries.find(entry => entry.key === key)
 
@@ -381,7 +388,7 @@ export class RuntimePanel {
       return key
     }
 
-    this.entries.push({ key, diagnostic, count: 1 })
+    this.entries.push({ key, diagnostic, count: 1, payload })
 
     while (this.entries.length > MAX_RUNTIME_DIAGNOSTICS) {
       this.entries.shift()
@@ -735,11 +742,15 @@ export class RuntimePanel {
 
     const repeat = entry.count > 1 ? `<span class="herb-dev-tools-repeat" title="Reported ${entry.count} times">×${entry.count}</span>` : ''
     const suggestion = diagnostic.suggestion === null ? '' : `<p class="herb-dev-tools-suggestion">${inlineCodeHTML(diagnostic.suggestion)}</p>`
+    const element = diagnostic.element !== null && diagnostic.element.isConnected
+      ? `<button type="button" class="herb-dev-tools-element" data-herb-dev-tools-action="locate" data-herb-dev-tools-entry="${this.entries.indexOf(entry)}" title="Scroll to this element and flash it"><span class="herb-dev-tools-element-glyph" aria-hidden="true">◎</span><code>${escapeHTML(describeElement(diagnostic.element))}</code></button>`
+      : ''
 
     return [
       `<article class="herb-dev-tools-card" data-herb-dev-tools-origin="${escapeHTML(diagnostic.origin)}" data-herb-dev-tools-kind="${escapeHTML(diagnostic.kind)}">`,
       `<div class="herb-dev-tools-card-head">${marker}${code}${docs}<span class="herb-dev-tools-origin">${escapeHTML(diagnostic.origin)}</span>${repeat}</div>`,
       `<p class="herb-dev-tools-message">${inlineCodeHTML(diagnostic.message)}</p>`,
+      element,
       suggestion,
       this.excerptHTML(diagnostic),
       this.stackHTML(diagnostic),
@@ -759,7 +770,7 @@ export class RuntimePanel {
       return `<div class="herb-dev-tools-excerpt" data-herb-dev-tools-excerpt-pending></div>`
     }
 
-    const target = this.onOpenFile === null
+    const target = this.onOpenFile === null || diagnostic.template === UNKNOWN_TEMPLATE
       ? null
       : { file: diagnostic.template, line: diagnostic.location.start.line, column: diagnostic.location.start.column }
 
@@ -889,8 +900,15 @@ export class RuntimePanel {
           this.render()
         } else if (action === 'open') {
           this.openFrom(element)
+        } else if (action === 'locate') {
+          this.locateFrom(element)
         }
       })
+
+      if (element.getAttribute('data-herb-dev-tools-action') === 'locate') {
+        element.addEventListener('mouseenter', () => this.outlineFrom(element, true))
+        element.addEventListener('mouseleave', () => this.outlineFrom(element, false))
+      }
     })
 
     root.querySelectorAll<HTMLElement>('herb-ansi[data-herb-dev-tools-file]').forEach((element) => {
@@ -907,6 +925,43 @@ export class RuntimePanel {
     })
   }
 
+  private entryFor(trigger: HTMLElement): PanelEntry | undefined {
+    const index = Number(trigger.getAttribute('data-herb-dev-tools-entry'))
+
+    return Number.isInteger(index) ? this.entries[index] : undefined
+  }
+
+  private locateFrom(trigger: HTMLElement) {
+    const target = this.entryFor(trigger)?.diagnostic.element
+
+    if (!target || !target.isConnected) return
+
+    target.scrollIntoView({ block: 'center', behavior: 'smooth' })
+    flashElement(target)
+  }
+
+  private outline: HTMLElement | null = null
+
+  private outlineFrom(trigger: HTMLElement, on: boolean) {
+    this.outline?.remove()
+    this.outline = null
+
+    if (!on) return
+
+    const target = this.entryFor(trigger)?.diagnostic.element
+
+    if (!target || !target.isConnected) return
+
+    const rect = target.getBoundingClientRect()
+    const box = document.createElement('div')
+
+    box.className = 'herb-slot-flash herb-element-outline'
+    box.style.cssText = `position:absolute;z-index:2147483000;pointer-events:none;top:${rect.top + window.scrollY}px;left:${rect.left + window.scrollX}px;width:${rect.width}px;height:${rect.height}px;outline:2px solid #f59e0b;outline-offset:2px;background:rgba(245,158,11,0.12)`
+
+    document.body.appendChild(box)
+    this.outline = box
+  }
+
   private openFrom(element: HTMLElement) {
     const file = element.getAttribute('data-herb-dev-tools-file')
 
@@ -919,4 +974,13 @@ export class RuntimePanel {
 
     this.onOpenFile(file, Number.isFinite(line) ? line : 1, Number.isFinite(column) ? column : 1)
   }
+}
+
+function describeElement(element: Element): string {
+  const tag = element.tagName.toLowerCase()
+  const id = element.id ? `#${element.id}` : ''
+  const herb = [...element.attributes].find(attribute => attribute.name.startsWith('data-herb-'))
+  const detail = herb ? ` ${herb.name}="${herb.value.length > 40 ? `${herb.value.slice(0, 40)}…` : herb.value}"` : ''
+
+  return `<${tag}${id}${detail}>`
 }

--- a/javascript/packages/dev-tools/src/runtime/report.ts
+++ b/javascript/packages/dev-tools/src/runtime/report.ts
@@ -2,6 +2,7 @@ export const RUNTIME_REPORT_VERSION = 1;
 export const RUNTIME_REPORT_SELECTOR = 'script[type="application/json"][data-herb-runtime-report]';
 export const MAX_RUNTIME_DIAGNOSTICS = 200;
 export const DEFAULT_ORIGIN = 'unknown';
+export const UNKNOWN_TEMPLATE = '(unknown template)';
 export const DEFAULT_SEVERITY: RuntimeSeverity = 'error';
 export const RENDER_VIA_VALUES = ['layout', 'template', 'partial', 'component'] as const;
 export const RUNTIME_SEVERITIES = ['error', 'warning', 'info', 'hint'] as const;
@@ -66,6 +67,7 @@ export interface RuntimeDiagnostic {
   value?: string;
   fix?: RuntimeFix;
   source?: string;
+  element?: Element | null;
 }
 
 export interface RuntimeReport {
@@ -88,6 +90,7 @@ export interface NormalizedDiagnostic {
   docsUrl: string | null;
   value: string | null;
   fix: NormalizedFix | null;
+  element: Element | null;
 }
 
 export interface NormalizedRuntimeReport {
@@ -261,7 +264,12 @@ export function normalizeDiagnostic(value: unknown, sources: Record<string, stri
     docsUrl: asString(value.docsUrl),
     value: asString(value.value),
     fix: normalizeFix(value.fix, template, sources),
+    element: asElement(value.element),
   };
+}
+
+function asElement(value: unknown): Element | null {
+  return typeof Element !== 'undefined' && value instanceof Element ? value : null;
 }
 
 function normalizeSources(value: unknown): Record<string, string> {

--- a/javascript/packages/dev-tools/src/slots/flash.ts
+++ b/javascript/packages/dev-tools/src/slots/flash.ts
@@ -12,6 +12,29 @@ const COLORS: Record<SlotOperation, string> = {
   'item-rekeyed': '#14b8a6'
 }
 
+export const ELEMENT_FLASH_COLOUR = '#f59e0b'
+const ELEMENT_FLASH_DURATION = 1600
+
+export function flashElement(element: Element, colour = ELEMENT_FLASH_COLOUR): HTMLElement | null {
+  if (!element.isConnected) return null
+
+  const rect = element.getBoundingClientRect()
+
+  if (rect.width === 0 && rect.height === 0) return null
+
+  const overlay = document.createElement('div')
+
+  overlay.className = 'herb-slot-flash herb-element-flash'
+  overlay.style.cssText = `position:absolute;z-index:2147483000;pointer-events:none;top:${rect.top + window.scrollY}px;left:${rect.left + window.scrollX}px;width:${rect.width}px;height:${rect.height}px;background:${colour};opacity:0.22;outline:2px solid ${colour};outline-offset:2px;transition:opacity ${ELEMENT_FLASH_DURATION}ms ease-out`
+
+  document.body.appendChild(overlay)
+
+  requestAnimationFrame(() => { overlay.style.opacity = '0' })
+  setTimeout(() => overlay.remove(), ELEMENT_FLASH_DURATION)
+
+  return overlay
+}
+
 export class SlotFlash {
   private static readonly DURATION = 1600
 

--- a/javascript/packages/dev-tools/test/runtime-panel.test.ts
+++ b/javascript/packages/dev-tools/test/runtime-panel.test.ts
@@ -1391,10 +1391,10 @@ describe("report", () => {
     expect(fix.querySelector(".herb-dev-tools-fix-diff")).not.toBeNull()
   })
 
-  test("ignores an entry without a template or message", () => {
+  test("ignores an entry without a message", () => {
     const panel = createPanel()
 
-    panel.report([{ message: "no template" } as RuntimeDiagnostic])
+    panel.report([{ template: "app/views/a.html.erb" } as RuntimeDiagnostic])
 
     expect(root()).toBeNull()
   })
@@ -1647,13 +1647,63 @@ describe("destroy", () => {
   })
 })
 
+describe("diagnostics that name an element", () => {
+  test("render a locate control that scrolls to the element and flashes it", () => {
+    const target = document.createElement("button")
+    target.setAttribute("data-herb-toggle", "open")
+    target.textContent = "Details"
+    document.body.appendChild(target)
+
+    const scrolled: unknown[] = []
+    target.scrollIntoView = ((options: unknown) => { scrolled.push(options) }) as typeof target.scrollIntoView
+
+    const panel = createPanel()
+
+    panel.report({ template: "app/views/a.html.erb", message: "nothing around this element declares the state `open`", code: "herb-unknown-state", element: target })
+
+    const control = document.querySelector<HTMLElement>(".herb-dev-tools-element")!
+
+    expect(control).not.toBeNull()
+    expect(control.textContent).toContain('<button data-herb-toggle="open">')
+
+    control.click()
+
+    expect(scrolled).toHaveLength(1)
+    expect(document.querySelector(".herb-element-flash")).not.toBeNull()
+  })
+
+  test("skip the control once the element has left the page", () => {
+    const target = document.createElement("span")
+    document.body.appendChild(target)
+
+    const panel = createPanel()
+
+    panel.report({ template: "app/views/a.html.erb", message: "gone", element: target })
+    target.remove()
+    panel.refresh()
+
+    expect(document.querySelector(".herb-dev-tools-element")).toBeNull()
+  })
+})
+
+describe("diagnostics without a template", () => {
+  test("are kept under a placeholder instead of being dropped", () => {
+    const panel = createPanel()
+
+    panel.report({ template: "", message: "nothing around this element declares the state `pending`", code: "herb-unknown-state", severity: "error" })
+
+    expect(cards()).toHaveLength(1)
+    expect(document.body.textContent).toContain("(unknown template)")
+  })
+})
+
 describe("refresh", () => {
-  test("replaces the entries from a fresh payload", () => {
+  test("replaces the payload's entries and keeps the reported ones", () => {
     embed(PAYLOAD)
 
     const panel = createPanel()
 
-    panel.report(diagnostic({ origin: "Acme Scanner", code: "hook-rule" }))
+    panel.report(diagnostic({ origin: "Acme Scanner", code: "hook-rule", message: "reported at runtime" }))
 
     expect(cards()).toHaveLength(4)
 
@@ -1663,8 +1713,26 @@ describe("refresh", () => {
 
     panel.refresh()
 
-    expect(cards()).toHaveLength(1)
-    expect(document.querySelector(".herb-dev-tools-message")!.textContent).toBe("fresh")
+    expect(cards()).toHaveLength(2)
+
+    const messages = [...document.querySelectorAll(".herb-dev-tools-message")].map(element => element.textContent)
+
+    expect(messages).toContain("fresh")
+    expect(messages).toContain("reported at runtime")
+  })
+
+  test("a navigation's refresh keeps what the client runtime reported before it", () => {
+    embed(PAYLOAD)
+
+    const panel = createPanel()
+
+    panel.report(diagnostic({ code: "herb-state-type", message: "raised during the first scan" }))
+
+    expect(cards()).toHaveLength(4)
+
+    panel.refresh()
+
+    expect(cards()).toHaveLength(4)
   })
 
   test("keeps the current entries when the page ships no payload", () => {

--- a/javascript/packages/dev-tools/test/runtime-report-integration.test.ts
+++ b/javascript/packages/dev-tools/test/runtime-report-integration.test.ts
@@ -38,14 +38,13 @@ describe("the client runtime reporting into the panel", () => {
     const instance = HerbDevTools.start({ devServer: false })!
     devTools = instance
     stopClearing = clearOnNavigation()
-    document.dispatchEvent(new Event("turbo:load"))
 
     report({ template: "app/views/a.html.erb", message: "from the runtime" })
     instance.report({ template: "app/views/a.html.erb", message: "from the linter", origin: "Herb Linter" })
 
     expect(instance.runtimePanel?.count).toBe(2)
 
-    document.dispatchEvent(new Event("turbo:load"))
+    document.dispatchEvent(new Event("turbo:before-render"))
 
     expect(instance.runtimePanel?.count).toBe(1)
   })

--- a/javascript/packages/dev-tools/test/runtime-report-integration.test.ts
+++ b/javascript/packages/dev-tools/test/runtime-report-integration.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect, beforeEach, afterEach } from "vitest"
 import { report, clearOnNavigation, RUNTIME_ORIGIN } from "@herb-tools/client"
 
-import { HerbDevTools } from "../src/index"
+import { HerbDevTools, DEV_TOOLS_START_EVENT } from "../src/index"
 
 let devTools: HerbDevTools | null = null
 let stopClearing: (() => void) | null = null
@@ -21,13 +21,13 @@ afterEach(() => {
 })
 
 describe("the client runtime reporting into the panel", () => {
-  test("a diagnostic raised before start is delivered with the next one after it", () => {
+  test("a diagnostic raised before start is delivered as soon as the panel starts", () => {
     report({ template: "app/views/a.html.erb", message: "raised before the panel existed" })
 
     const instance = HerbDevTools.start({ devServer: false })!
     devTools = instance
 
-    expect(instance.runtimePanel?.count).toBe(0)
+    expect(instance.runtimePanel?.count).toBe(1)
 
     report({ template: "app/views/a.html.erb", message: "raised after", code: "herb-unknown-state" })
 
@@ -61,5 +61,20 @@ describe("the client runtime reporting into the panel", () => {
     handle.dismiss()
 
     expect(instance.runtimePanel?.count).toBe(0)
+  })
+
+  test("start() announces itself so a runtime can flush what it queued", () => {
+    const seen: unknown[] = []
+    const listener = (event: Event) => seen.push((event as CustomEvent).detail)
+
+    document.addEventListener(DEV_TOOLS_START_EVENT, listener)
+
+    const instance = HerbDevTools.start({ devServer: false })!
+
+    document.removeEventListener(DEV_TOOLS_START_EVENT, listener)
+
+    expect(seen).toEqual([instance])
+
+    instance.stop()
   })
 })


### PR DESCRIPTION
This pull request makes the runtime diagnostics the slots runtime already produces actually reach the dev tools panel, and gives each one the element it is about.

Three things stopped a diagnostic from arriving. The client reports through `window.HerbDevTools`, which does not exist until `HerbDevTools.start()` runs, so anything raised during the first scan was dropped. The panel rejected a diagnostic whose `template` was empty, which is exactly what the client sends when it cannot name a template, so those cards never appeared. And `RuntimePanel#refresh` cleared every entry whenever a server report arrived, wiping what the runtime had reported moments earlier.

The client now arms three flush triggers, a `herb:dev-tools-start` event the dev tools dispatch once they are set up, the window `load` event, and a configurable accessor installed on `window.HerbDevTools` so a bundle that assigns the global without announcing itself still gets the queue. The panel substitutes `(unknown template)` for an empty template, and `refresh` keeps entries the runtime reported, dropping only the ones that came with a payload.

A diagnostic can now carry the element it is about:

```js
report({
  template: "app/views/chat/show.html.erb",
  message: "nothing around this element declares the state `failed`",
  code: "herb-unknown-state",
  element: button,
})
```

The card renders a control for it, and clicking scrolls the element into view and flashes it, so a diagnostic about markup is one click from the markup. A disconnected element is skipped, so no card offers a control that goes nowhere.

While the panel is absent the client falls back to the console, routed by severity, so an `error` reaches `console.error` instead of being lost among warnings.

Related marcoroth/reactionview#78
