### PR TITLE
Client: Track the branch a collection item's conditional rendered

### DIFF
--- a/javascript/packages/client/src/slot-index.ts
+++ b/javascript/packages/client/src/slot-index.ts
@@ -596,6 +596,8 @@ export class SlotIndex {
 
     this.#writeFragment(slot, built)
 
+    slot.branch = value.branch
+
     report.applied += 1
 
     if (value.slots) {
@@ -1277,6 +1279,8 @@ export class SlotIndex {
 
     this.#writeFragment(slot, built)
 
+    slot.branch = branch
+
     return true
   }
 
@@ -1482,8 +1486,11 @@ export class SlotIndex {
       const branch = BRANCH.exec(data)
 
       if (branch) {
+        const index = Number(branch[1])
         const region = openRegions[openRegions.length - 1]?.region ?? this.#enclosingRegion(comment)
-        const slot = region?.slots.get(Number(branch[1]))
+        const item = openItems[openItems.length - 1]?.item ?? (region ? this.#enclosingItem(region, comment) : null)
+        const holder = item ?? region
+        const slot = openSlots.find((candidate) => candidate.index === index)?.slot ?? holder?.slots.get(index)
 
         if (slot && /^\d+$/.test(branch[2])) slot.branch = Number(branch[2])
 

--- a/javascript/packages/client/src/slot-index.ts
+++ b/javascript/packages/client/src/slot-index.ts
@@ -240,7 +240,16 @@ export class SlotIndex {
   #slotRegions = new WeakMap<Slot, Region>()
   #slotOwners = new WeakMap<Slot, SlotMap>()
   #skeletons = new Map<string, Statics>()
+  #clientOwned = new WeakSet<Slot>()
   #observer: MutationObserver | null = null
+
+  claim(slot: Slot): void {
+    this.#clientOwned.add(slot)
+  }
+
+  claimed(slot: Slot): boolean {
+    return this.#clientOwned.has(slot)
+  }
 
   observe(root: Node = document.documentElement): ScanResult {
     this.#observer?.disconnect()
@@ -524,6 +533,9 @@ export class SlotIndex {
         this.#defer(report, payload, index, "no-slot")
         continue
       }
+
+      if (this.#clientOwned.has(slot)) continue
+
 
       if (typeof value === "boolean") {
         if (this.setBooleanAttribute(slot, value)) report.applied += 1

--- a/javascript/packages/client/src/state.ts
+++ b/javascript/packages/client/src/state.ts
@@ -192,6 +192,7 @@ export class SlotState {
     if (typeof document !== "undefined") {
       document.addEventListener(SLOT_EVENT, this.#migrateItemState)
       document.addEventListener(SLOT_EVENT, this.#recountItems)
+      document.addEventListener(SLOT_EVENT, this.#hydrateItemState)
     }
 
     const templates = [...root.querySelectorAll<HTMLTemplateElement>(DEPENDENCIES_SELECTOR)]
@@ -210,6 +211,7 @@ export class SlotState {
     document.addEventListener(SLOT_EVENT, this.#syncProperty)
     document.addEventListener(SLOT_EVENT, this.#migrateItemState)
     document.addEventListener(SLOT_EVENT, this.#recountItems)
+    document.addEventListener(SLOT_EVENT, this.#hydrateItemState)
     document.addEventListener("input", this.#onBoundInput)
     document.addEventListener("change", this.#onBoundInput)
     document.addEventListener("reset", this.#onFormReset)
@@ -244,6 +246,7 @@ export class SlotState {
     document.removeEventListener(SLOT_EVENT, this.#syncProperty)
     document.removeEventListener(SLOT_EVENT, this.#migrateItemState)
     document.removeEventListener(SLOT_EVENT, this.#recountItems)
+    document.removeEventListener(SLOT_EVENT, this.#hydrateItemState)
     document.removeEventListener("input", this.#onBoundInput)
     document.removeEventListener("change", this.#onBoundInput)
     document.removeEventListener("reset", this.#onFormReset)
@@ -991,6 +994,7 @@ export class SlotState {
         if (slot.type === "boolean_attribute") continue
 
         this.#write(slot, text)
+        this.#slots.claim(slot)
       }
     }
   }
@@ -1271,6 +1275,42 @@ export class SlotState {
 
       buckets.delete(detail.previousKey)
       buckets.set(detail.key, bucket)
+    }
+  }
+
+  #hydrateItemState = (event: Event): void => {
+    const detail = (event as CustomEvent<SlotEventDetail>).detail
+
+    if (detail.operation !== "item-added" || !detail.slot || !detail.item) return
+
+    const region = this.#slots.regionOf(detail.slot)
+
+    if (!region) return
+
+    const manifest = this.manifestFor(region)
+
+    if (!manifest) return
+
+    const scope: StateScope = { region, item: null }
+    const item = detail.item
+
+    for (const [name, indices] of Object.entries(manifest.reads)) {
+      if (this.#declaration(manifest, scope, name)?.scope !== "region") continue
+
+      const value = this.getState(name, { scope })
+
+      if (value === undefined) continue
+
+      const text = printValue(value)
+
+      for (const index of indices) {
+        const slot = item.slots.get(index)
+
+        if (!slot || slot.type === "boolean_attribute") continue
+
+        this.#write(slot, text)
+        this.#slots.claim(slot)
+      }
     }
   }
 

--- a/javascript/packages/client/test/branch.test.ts
+++ b/javascript/packages/client/test/branch.test.ts
@@ -588,3 +588,79 @@ describe("switching a branch from the client", () => {
     expect(index.rangeFor(index.slot(FILE, 0)!).toString()).toBe("under")
   })
 })
+
+describe("a conditional inside a collection item", () => {
+  const ITEMS_FILE = "app/views/chat/show.html.erb"
+
+  const rendered =
+    `<!--herb-region:${ITEMS_FILE}:bbbbbbbb:0--><ul><!--herb-slot:0:collection-->` +
+    `<!--herb-item:0:1--><li><!--herb-slot:6:conditional--><!--herb-branch:6:2-->Sent <span data-herb-slot="7:child">08:15</span><!--/herb-slot:6--></li><!--/herb-item:0-->` +
+    `<!--herb-item:0:2--><li><!--herb-slot:6:conditional--><!--herb-branch:6:0-->Sending…<!--/herb-slot:6--></li><!--/herb-item:0-->` +
+    `<!--/herb-slot:0--></ul>` +
+    `<template data-herb-region="${ITEMS_FILE}:bbbbbbbb">` +
+    `<!--herb-branch:6:0-->Sending…` +
+    `<!--herb-branch:6:2-->Sent <span data-herb-slot="7:child"></span>` +
+    `</template>` +
+    `<!--/herb-region:${ITEMS_FILE}-->`
+
+  beforeEach(() => { document.body.innerHTML = "" })
+
+  test("remembers the branch the server rendered for each item", () => {
+    const index = new SlotIndex()
+    document.body.innerHTML = rendered
+    index.scan(document.body)
+
+    expect(index.slotInItem(ITEMS_FILE, 0, "1", 6)?.branch).toBe(2)
+    expect(index.slotInItem(ITEMS_FILE, 0, "2", 6)?.branch).toBe(0)
+  })
+
+  test("switching to the branch an item already shows keeps its server values", () => {
+    const index = new SlotIndex()
+    document.body.innerHTML = rendered
+    index.scan(document.body)
+
+    const slot = index.slotInItem(ITEMS_FILE, 0, "1", 6)!
+
+    expect(index.switchBranch(slot, 2)).toBe(false)
+    expect(index.rangeFor(slot).toString()).toContain("08:15")
+  })
+})
+
+describe("a branch written into an item keeps its values", () => {
+  const CONFIRM_FILE = "app/views/chat/show.html.erb"
+
+  const pendingRow =
+    `<!--herb-region:${CONFIRM_FILE}:cccccccc:0--><ul><!--herb-slot:0:collection-->` +
+    `<!--herb-item:0:7--><li><!--herb-slot:6:conditional--><!--herb-branch:6:0-->Sending…<!--/herb-slot:6--></li><!--/herb-item:0-->` +
+    `<!--/herb-slot:0--></ul>` +
+    `<template data-herb-region="${CONFIRM_FILE}:cccccccc">` +
+    `<!--herb-branch:6:0-->Sending…` +
+    `<!--herb-branch:6:2-->Sent <span data-herb-slot="7:child"></span>` +
+    `</template>` +
+    `<!--/herb-region:${CONFIRM_FILE}-->`
+
+  beforeEach(() => { document.body.innerHTML = "" })
+
+  test("applying the server's branch records it, so a later switch is a no-op", () => {
+    const index = new SlotIndex()
+    document.body.innerHTML = pendingRow
+    index.scan(document.body)
+
+    const slot = index.slotInItem(CONFIRM_FILE, 0, "7", 6)!
+
+    expect(slot.branch).toBe(0)
+
+    index.apply({
+      template: CONFIRM_FILE,
+      version: "cccccccc",
+      occurrence: 0,
+      slots: { 0: { items: { 7: { 6: { branch: 2, slots: { 7: "08:15" } } } } } },
+    })
+
+    expect(slot.branch).toBe(2)
+    expect(index.rangeFor(slot).toString()).toContain("08:15")
+
+    expect(index.switchBranch(slot, 2)).toBe(false)
+    expect(index.rangeFor(slot).toString()).toContain("08:15")
+  })
+})

--- a/javascript/packages/client/test/item-state-hydration.test.ts
+++ b/javascript/packages/client/test/item-state-hydration.test.ts
@@ -1,0 +1,86 @@
+import { describe, test, expect, beforeEach } from "vitest"
+import { SlotIndex } from "../src/slot-index"
+import { SlotState } from "../src/state"
+
+const FILE = "app/views/chat/show.html.erb"
+
+const PAGE =
+  `<!--herb-region:${FILE}:eeeeeeee:0-->` +
+  `<ul><!--herb-slot:0:collection-->` +
+  `<!--herb-item:0:1--><li><span data-herb-slot="2:child">0</span></li><!--/herb-item:0-->` +
+  `<!--/herb-slot:0--></ul>` +
+  `<template data-herb-region="${FILE}:eeeeeeee">` +
+  `<!--herb-branch:0:item--><!--herb-item:0:--><li><span data-herb-slot="2:child"></span></li><!--/herb-item:0-->` +
+  `</template>` +
+  `<!--/herb-region:${FILE}-->`
+
+const MANIFEST = {
+  state: {},
+  states: {
+    [FILE]: {
+      version: "eeeeeeee",
+      declarations: [{ name: "count", kind: "integer", default: "0", scope: "region" }],
+      reads: { count: [2] },
+      conditionals: {},
+    },
+  },
+}
+
+let slots: SlotIndex
+let state: SlotState
+
+function textOf(key: string): string {
+  const item = slots.regionsFor(FILE)[0].slots.get(0)!.items.get(key)!
+
+  return slots.rangeFor(item.slots.get(2)!).toString()
+}
+
+beforeEach(() => {
+  document.body.innerHTML = PAGE + `<template data-herb-dependencies>${JSON.stringify(MANIFEST)}</template>`
+
+  slots = new SlotIndex()
+  slots.scan(document.body)
+
+  state = new SlotState(slots, {
+    persist: "none",
+    transport: () => {
+      throw new Error("a declared state must never reach the transport")
+    },
+  })
+
+  state.adopt()
+})
+
+describe("a region state read inside a collection item", () => {
+  test("a row added after the write renders the current value, not the default", () => {
+    const region = slots.regionsFor(FILE)[0]
+    const collection = region.slots.get(0)!
+
+    state.setState({ count: 3 }, { scope: { region, item: null } })
+
+    expect(textOf("1")).toBe("3")
+
+    slots.addItem(collection, "2")
+
+    expect(textOf("2")).toBe("3")
+  })
+
+  test("the server cannot write its default over the value the client owns", () => {
+    const region = slots.regionsFor(FILE)[0]
+    const collection = region.slots.get(0)!
+
+    state.setState({ count: 3 }, { scope: { region, item: null } })
+
+    slots.addItem(collection, "2")
+
+    slots.apply({
+      template: FILE,
+      version: "eeeeeeee",
+      occurrence: 0,
+      slots: { 0: { items: { 1: { 2: "0" }, 2: { 2: "0" } } } },
+    })
+
+    expect(textOf("1")).toBe("3")
+    expect(textOf("2")).toBe("3")
+  })
+})


### PR DESCRIPTION
This pull request fixes two ways a row inside a keyed collection lost what the server had already rendered into it.

The engine emits `<!--herb-branch:N:M-->` inside each rendered arm, and `#attach` puts a slot declared inside a collection body on the **item**. The scan looked that slot up on the **region** only, so an item's conditional never recorded which arm it rendered and every one of them stayed at `branch: null`.

The consequence is worse than a missing field. A write that resolved to the arm the row was already showing looked like a change, so instead of the intended no-op the client rebuilt the arm from the parked statics, where every dynamic slot is blank:

```erb
<% if pending? %>
  Sending…
<% else %>
  Sent <span><%= message.sent_at %></span>
<% end %>
```

Hovering an element that set `pending` to the value it already held erased the timestamp. `capture` could not save it either, since it returns early when `branch` is `null`, so the live markup was never parked before being replaced.

The branch marker now resolves against the open slot, then the innermost item, then the region. The fallback matters because `#writeFragment` rescans only the nodes it inserted, where the enclosing `herb-item` and `herb-slot` markers are out of range, so `switchBranch` and `#applyBranch` also record the branch they wrote instead of depending on the marker surviving a partial rescan.

The second half is a region state read inside a collection. A row added after that state changed rendered the declaration's default, because nothing wrote the current value into a row that missed the write. `#hydrateItemState` now fills a new row's read slots from the state in scope, and marks them client-owned so a later payload cannot put the server's default back over them.
