### PR TITLE
Engine: Ship the seeds marker through the template's own buffer

### DIFF
--- a/lib/herb/engine.rb
+++ b/lib/herb/engine.rb
@@ -89,6 +89,7 @@ module Herb
       else
         @visitors.each do |visitor|
           visitor.inherit_context(@context) if visitor.is_a?(ContextAware)
+          visitor.bufvar = @bufvar if visitor.respond_to?(:bufvar=)
 
           parse_result.value.accept(visitor)
         end
@@ -127,6 +128,16 @@ module Herb
 
     def self.h(value)
       value.to_s.gsub(/[&<>"']/, ESCAPE_TABLE)
+    end
+
+    # Appending to a plain String buffer never escapes, but `ActionView::OutputBuffer#<<` does
+    # unless the value is already marked safe. A marker the engine generated is markup, so it has
+    # to survive both buffers unchanged.
+    #: (untyped) -> String
+    def self.raw(value)
+      string = value.to_s
+
+      string.respond_to?(:html_safe) ? string.html_safe : string
     end
 
     def self.attr(value)

--- a/lib/herb/engine/slot_visitor.rb
+++ b/lib/herb/engine/slot_visitor.rb
@@ -33,6 +33,7 @@ module Herb
       recommended_parser_option iteration_nodes: true, render_nodes: true, strict_locals: true
       required_parser_option action_view_helpers: true, track_locations: true
 
+      attr_accessor :bufvar #: String
       attr_reader :slots #: Array[Slot]
       attr_reader :state_presence #: Hash[Integer, untyped]
       attr_reader :document #: untyped
@@ -110,6 +111,7 @@ module Herb
 
         @markers = markers
         @mark = mark
+        @bufvar = "_buf"
         @mode = mode
         @statics = mode == :client ? {} : nil #: Hash[String, String]?
         @identify = identifier
@@ -762,7 +764,7 @@ module Herb
 
         "#{SEEDS_LOCAL} = { #{pairs} }.select { |_, v| #{SEED_VALUE_TYPES}.any? { |t| t === v } }" \
           ".transform_values { |v| v.is_a?(::Symbol) ? v.to_s : v }; " \
-          "_buf << \"<!--#{SEEDS_MARKER}\" << ::JSON.generate(#{SEEDS_LOCAL}).gsub(\"--\", \"-\\\\u002d\") << \"-->\""
+          "#{@bufvar} << ::Herb::Engine.raw(\"<!--#{SEEDS_MARKER}\" + ::JSON.generate(#{SEEDS_LOCAL}).gsub(\"--\", \"-\\\\u002d\") + \"-->\")"
       end
 
       #: (StateDirectives::Declaration) -> String

--- a/sig/herb/engine.rbs
+++ b/sig/herb/engine.rbs
@@ -28,6 +28,12 @@ module Herb
 
     def self.h: (untyped value) -> untyped
 
+    # Appending to a plain String buffer never escapes, but `ActionView::OutputBuffer#<<` does
+    # unless the value is already marked safe. A marker the engine generated is markup, so it has
+    # to survive both buffers unchanged.
+    # : (untyped) -> String
+    def self.raw: (untyped) -> String
+
     def self.attr: (untyped value) -> untyped
 
     def self.js: (untyped value) -> untyped

--- a/sig/herb/engine/slot_visitor.rbs
+++ b/sig/herb/engine/slot_visitor.rbs
@@ -20,6 +20,8 @@ module Herb
     class SlotVisitor < Herb::Visitor
       include ContextAware
 
+      attr_accessor bufvar: String
+
       attr_reader slots: Array[Slot]
 
       attr_reader state_presence: Hash[Integer, untyped]

--- a/test/engine/slots/states_test.rb
+++ b/test/engine/slots/states_test.rb
@@ -640,6 +640,29 @@ module Engine
         refute_includes render(STATUS), "herb-seeds"
       end
 
+      test "the seeds marker writes to the buffer the engine was configured with" do
+        template = %(<%# herb:slots client %><%# herb:state (label: @label) %><p><%= label %></p>)
+        engine = Herb::Engine.new(
+          template,
+          visitors: [Herb::Engine::SlotVisitor.new(mode: :client)],
+          filename: "app/views/test.html.erb",
+          bufvar: "@output_buffer"
+        )
+
+        assert_includes engine.src, '@output_buffer << ::Herb::Engine.raw("<!--herb-seeds:'
+        refute_includes engine.src, "_buf <<"
+      end
+
+      test "the seeds marker survives a buffer that escapes what it appends" do
+        buffer = Class.new(String) do
+          def <<(value)
+            super(value.respond_to?(:html_safe?) && value.html_safe? ? value : value.to_s.gsub("<", "&lt;"))
+          end
+        end
+
+        assert_equal "<!--x-->", buffer.new.tap { |written| written << Herb::Engine.raw("<!--x-->") }.to_s
+      end
+
       test "an unless reads a state with its arms inverted" do
         template = %(<%# herb:state (pending: false) %><div><% unless pending %>Idle<% else %>Busy<% end %></div>)
         visitor, = compile(template)


### PR DESCRIPTION
Follow up on #2379, which added the seeds comment but wrote it to a buffer that only exists in one of the two ways Herb compiles a template.

`seeds_marker` emitted `_buf << "<!--herb-seeds:…"` with the buffer name hardcoded. `Herb::Engine` takes the name as a property, and ReActionView sets it to `@output_buffer`, so every template with a seeded state raised `NameError` at render under Action View. The visitor now takes the engine's `bufvar` and emits against it.

That exposed a second layer. `ActionView::OutputBuffer#<<` escapes what it appends unless the value is already marked safe, so the marker rendered as visible text on the page:

```html
herb-seeds:{&quot;body_draft&quot;:&quot;Hey!&quot;}--&gt;
```

A marker the engine generated is markup, so it has to survive both buffers unchanged. `Herb::Engine.raw` marks the string safe when the buffer cares and returns it untouched when it does not, which keeps a plain `String` buffer working exactly as before:

```ruby
def self.raw(value)
  string = value.to_s

  string.respond_to?(:html_safe) ? string.html_safe : string
end
```

The regression tests cover both halves, that the marker is written to the buffer the engine was configured with, and that it survives a buffer which escapes what it appends.
