### PR TITLE
Client: Write a state into the textarea that renders it

### DIFF
--- a/javascript/packages/client/src/slot-index.ts
+++ b/javascript/packages/client/src/slot-index.ts
@@ -41,6 +41,11 @@ const NAME_ENTRY = /^(\d+):(.+)$/
 
 const DEFAULT_SLOT_TYPE: SlotType = "child"
 
+// A slot anchored on an element writes that element's content when the slot IS the content, which
+// covers a plain child and the RCDATA of a `<textarea>` or `<title>`. Every other anchored slot
+// addresses an attribute instead, so its content must be left alone.
+const CONTENT_SLOT_TYPES: SlotType[] = ["child", "raw_text"]
+
 export type SlotType =
   | "child"
   | "conditional"
@@ -1585,7 +1590,9 @@ export class SlotIndex {
 
     for (const entry of anchorEntries(element)) {
       const [index, type, ...name] = entry.split(":")
-      const kind = (type ?? DEFAULT_SLOT_TYPE) === DEFAULT_SLOT_TYPE ? ("content" as const) : ("element" as const)
+      const kind = CONTENT_SLOT_TYPES.includes((type as SlotType) ?? DEFAULT_SLOT_TYPE)
+        ? ("content" as const)
+        : ("element" as const)
 
       this.#attach(
         region,

--- a/javascript/packages/client/test/binding.test.ts
+++ b/javascript/packages/client/test/binding.test.ts
@@ -190,3 +190,44 @@ describe("property sync after user interaction", () => {
     expect(input.value).toBe("from code")
   })
 })
+
+const AREA_FILE = "app/views/page/note.html.erb"
+
+const AREA_PAGE =
+  `<!--herb-region:${AREA_FILE}:bbbbbbbb:0-->` +
+  `<textarea data-herb-slot="0:raw_text">hi</textarea>` +
+  `<!--/herb-region:${AREA_FILE}-->` +
+  `<template data-herb-dependencies>${JSON.stringify({
+    state: {},
+    states: {
+      [AREA_FILE]: {
+        version: "bbbbbbbb",
+        declarations: [{ name: "note", kind: "string", default: '"hi"', scope: "region" }],
+        reads: { note: [0] },
+        bound: { note: [0] },
+        conditionals: {},
+      },
+    },
+  })}</template>`
+
+describe("a state rendered as a textarea's content", () => {
+  test("a write reaches the textarea", () => {
+    document.body.innerHTML = AREA_PAGE
+
+    const areaSlots = new SlotIndex()
+
+    areaSlots.scan(document.body)
+
+    const areaState = new SlotState(areaSlots, {
+      persist: "none",
+      transport: () => {
+        throw new Error("a declared state must never reach the transport")
+      },
+    })
+
+    areaState.adopt()
+
+    expect(areaState.setState({ note: "rewritten" })).toBe(true)
+    expect(document.querySelector("textarea")?.value).toBe("rewritten")
+  })
+})


### PR DESCRIPTION
This pull request fixes a documented binding that only ever worked in one direction.

A `<textarea>` is listed as a two-way binding, and reading works, typing into one updates the state. Writing never did. The engine anchors the slot on the element and types it `raw_text`:

```erb
<%# herb:state (draft: "") %>
<textarea><%= draft %></textarea>
```

```html
<textarea data-herb-slot="0:raw_text">hi</textarea>
```

The scan gave a `content` anchor to `child` slots alone and an `element` anchor to everything else, and `setText` returns `false` for an `element` anchor, since that anchor addresses an attribute. So `state.set({ draft: "…" })` resolved the slot, called `setText`, and silently declined.

An anchored slot writes the element's content when the slot **is** the content, which covers a plain child and the RCDATA of a `<textarea>` or `<title>`. Both types now take a `content` anchor, and the write lands.

This is what an edit form needs, where the draft is seeded from the record and the textarea has to show it:

```erb
<%# herb:state (body_draft: message.body) %>
<textarea><%= body_draft %></textarea>
```
