### PR TITLE
Client: Resolve a condition's states in the scopes that declare them

### DIFF
--- a/javascript/packages/client/src/actions.ts
+++ b/javascript/packages/client/src/actions.ts
@@ -32,6 +32,7 @@ export class SlotActions {
   #direct = new Map<Element, () => void>()
   #validated = new WeakSet<Element>()
   #observer: MutationObserver | null = null
+  #pinned: Map<string, StateScope> | null = null
   #listeners: [string, (event: Event) => void][] = []
 
   constructor(state: SlotState) {
@@ -251,7 +252,7 @@ export class SlotActions {
   }
 
   #run(element: Element, event: Event): boolean {
-    let handled = false
+    const pending: { action: ActionName; rest: string }[] = []
 
     for (const name of ACTION_NAMES) {
       const attribute = HERB_ATTRIBUTES[name]
@@ -262,9 +263,21 @@ export class SlotActions {
       for (const clause of clauses(value)) {
         if ((clause.event ?? defaultEventFor(element)) !== event.type) continue
 
-        this.#execute(element, name, clause.rest, event)
-        handled = true
+        pending.push({ action: name, rest: clause.rest })
       }
+    }
+
+    const handled = pending.length > 0
+
+    // One action can rewrite a branch that contains this very element, and a detached element has
+    // no scope to walk up from. Resolve every scope while the element is still on the page, so a
+    // later action in the same dispatch still knows where it lives.
+    this.#pinned = handled ? this.#pinScopes(element, pending) : null
+
+    try {
+      for (const entry of pending) this.#execute(element, entry.action, entry.rest, event)
+    } finally {
+      this.#pinned = null
     }
 
     return handled
@@ -288,8 +301,35 @@ export class SlotActions {
     }
   }
 
+  #pinScopes(element: Element, pending: { action: ActionName; rest: string }[]): Map<string, StateScope> {
+    const pinned = new Map<string, StateScope>()
+    const bare = this.#state.scopeFor(element)
+
+    if (bare) {
+      for (const declaration of this.#state.declaredStates(bare)) {
+        const scope = this.#state.scopeFor(element, declaration.name)
+
+        if (scope) pinned.set(declaration.name, scope)
+      }
+    }
+
+    for (const entry of pending) {
+      for (const raw of names(entry.rest)) {
+        const name = raw.split("=")[0].trim()
+
+        if (name === "" || pinned.has(name)) continue
+
+        const scope = this.#state.scopeFor(element, name)
+
+        if (scope) pinned.set(name, scope)
+      }
+    }
+
+    return pinned
+  }
+
   #declaration(element: Element, name: string): [StateScope, DeclaredState] | null {
-    const scope = this.#state.scopeFor(element, name)
+    const scope = this.#pinned?.get(name) ?? this.#state.scopeFor(element, name)
 
     if (!scope) {
       report({

--- a/javascript/packages/client/src/state.ts
+++ b/javascript/packages/client/src/state.ts
@@ -193,6 +193,7 @@ export class SlotState {
       document.addEventListener(SLOT_EVENT, this.#migrateItemState)
       document.addEventListener(SLOT_EVENT, this.#recountItems)
       document.addEventListener(SLOT_EVENT, this.#hydrateItemState)
+      document.addEventListener(SLOT_EVENT, this.#hydrateBranch)
     }
 
     const templates = [...root.querySelectorAll<HTMLTemplateElement>(DEPENDENCIES_SELECTOR)]
@@ -212,6 +213,7 @@ export class SlotState {
     document.addEventListener(SLOT_EVENT, this.#migrateItemState)
     document.addEventListener(SLOT_EVENT, this.#recountItems)
     document.addEventListener(SLOT_EVENT, this.#hydrateItemState)
+    document.addEventListener(SLOT_EVENT, this.#hydrateBranch)
     document.addEventListener("input", this.#onBoundInput)
     document.addEventListener("change", this.#onBoundInput)
     document.addEventListener("reset", this.#onFormReset)
@@ -247,6 +249,7 @@ export class SlotState {
     document.removeEventListener(SLOT_EVENT, this.#migrateItemState)
     document.removeEventListener(SLOT_EVENT, this.#recountItems)
     document.removeEventListener(SLOT_EVENT, this.#hydrateItemState)
+    document.removeEventListener(SLOT_EVENT, this.#hydrateBranch)
     document.removeEventListener("input", this.#onBoundInput)
     document.removeEventListener("change", this.#onBoundInput)
     document.removeEventListener("reset", this.#onFormReset)
@@ -753,7 +756,10 @@ export class SlotState {
     }
   }
 
-  #valueOf(name: string, scope: StateScope): StateValue {
+  #valueOf(name: string, at: StateScope): StateValue {
+    // A condition may name states from more than one scope, so each name resolves against the
+    // nearest scope that declares it rather than against the scope the write started from.
+    const scope = this.scopeFor(at, name) ?? at
     const manifest = this.manifestFor(scope.region)
     const declaration = manifest ? this.#declaration(manifest, scope, name) : null
 
@@ -1003,10 +1009,10 @@ export class SlotState {
     for (const [indexKey, entry] of Object.entries(manifest.presence ?? {})) {
       if (!conditionMentions(entry, changed)) continue
 
-      const present = conditionMatches(entry, (name) => this.#valueOf(name, scope))
+      for (const placed of this.#placedSlots(scope, Number(indexKey))) {
+        const present = conditionMatches(entry, (name) => this.#valueOf(name, placed.scope))
 
-      for (const slot of this.#scopedSlots(scope, Number(indexKey))) {
-        this.#slots.setBooleanAttribute(slot, present)
+        this.#slots.setBooleanAttribute(placed.slot, present)
       }
     }
   }
@@ -1016,9 +1022,10 @@ export class SlotState {
       const mentions = conditional.arms.some((arm) => armMentions(arm, changed))
       if (!mentions) continue
 
-      const target = this.#targetBranch(conditional, scope)
+      for (const placed of this.#placedSlots(scope, Number(indexKey))) {
+        const slot = placed.slot
+        const target = this.#targetBranch(conditional, placed.scope)
 
-      for (const slot of this.#scopedSlots(scope, Number(indexKey))) {
         if (!this.#slots.switchBranch(slot, target) && slot.branch !== target) {
           report({
             template: scope.region.file,
@@ -1052,16 +1059,22 @@ export class SlotState {
   }
 
   #scopedSlots(scope: StateScope, index: number): Slot[] {
+    return this.#placedSlots(scope, index).map((placed) => placed.slot)
+  }
+
+  // The same as `#scopedSlots`, but each slot keeps the scope it actually sits in. A condition
+  // that reads an item state has to be evaluated once per row, not once for the collection.
+  #placedSlots(scope: StateScope, index: number): { slot: Slot; scope: StateScope }[] {
     if (scope.item) {
       const slot = scope.item.slots.get(index)
 
-      return slot ? [slot] : []
+      return slot ? [{ slot, scope }] : []
     }
 
     const region = scope.region.slots.get(index)
-    if (region) return [region]
+    if (region) return [{ slot: region, scope }]
 
-    const found: Slot[] = []
+    const found: { slot: Slot; scope: StateScope }[] = []
 
     for (const candidate of scope.region.slots.values()) {
       if (candidate.type !== "collection") continue
@@ -1069,7 +1082,7 @@ export class SlotState {
       for (const item of candidate.items.values()) {
         const slot = item.slots.get(index)
 
-        if (slot) found.push(slot)
+        if (slot) found.push({ slot, scope: { region: scope.region, item } })
       }
     }
 
@@ -1275,6 +1288,39 @@ export class SlotState {
 
       buckets.delete(detail.previousKey)
       buckets.set(detail.key, bucket)
+    }
+  }
+
+  #hydrateBranch = (event: Event): void => {
+    const detail = (event as CustomEvent<SlotEventDetail>).detail
+
+    if (detail.operation !== "branch" || !detail.slot) return
+
+    const slot = detail.slot
+    const region = this.#slots.regionOf(slot)
+
+    if (!region) return
+
+    const manifest = this.manifestFor(region)
+
+    if (!manifest) return
+
+    const element = slot.anchor.kind === "range" ? slot.anchor.start.parentElement : slot.anchor.element
+
+    if (!element) return
+
+    for (const [name, reads] of Object.entries(manifest.reads)) {
+      if (reads.length === 0) continue
+
+      const scope = this.scopeFor(element, name)
+
+      if (!scope) continue
+
+      const value = this.getState(name, { scope })
+
+      if (value === undefined) continue
+
+      this.#writeValueSlots(manifest, scope, name, value)
     }
   }
 

--- a/javascript/packages/client/test/actions.test.ts
+++ b/javascript/packages/client/test/actions.test.ts
@@ -393,3 +393,62 @@ describe("a tag helper input bound to a state", () => {
     helperState.disconnect()
   })
 })
+
+const SWAP_FILE = "app/views/page/swap.html.erb"
+
+const SWAP_PAGE =
+  `<!--herb-region:${SWAP_FILE}:cccccccc:0-->` +
+  `<div><!--herb-slot:0:conditional--><!--herb-branch:0:0-->` +
+  `<button id="cancel" data-herb-set="editing=false" data-herb-reset="draft">Cancel</button>` +
+  `<!--/herb-slot:0--></div>` +
+  `<template data-herb-region="${SWAP_FILE}:cccccccc">` +
+  `<!--herb-branch:0:0--><button id="cancel" data-herb-set="editing=false" data-herb-reset="draft">Cancel</button>` +
+  `</template>` +
+  `<!--/herb-region:${SWAP_FILE}-->` +
+  `<template data-herb-dependencies>${JSON.stringify({
+    state: {},
+    states: {
+      [SWAP_FILE]: {
+        version: "cccccccc",
+        declarations: [
+          { name: "editing", kind: "boolean", default: "true", scope: "region" },
+          { name: "draft", kind: "string", default: '"original"', scope: "region" },
+        ],
+        reads: {},
+        conditionals: { 0: { arms: [["editing", null, 0]], else: null } },
+      },
+    },
+  })}</template>`
+
+describe("an action on an element its own sibling action removes", () => {
+  test("the later action still resolves the scope the element had", () => {
+    document.body.innerHTML = SWAP_PAGE
+
+    const swapSlots = new SlotIndex()
+
+    swapSlots.scan(document.body)
+
+    const swapState = new SlotState(swapSlots, {
+      persist: "none",
+      transport: () => {
+        throw new Error("a declared state must never reach the transport")
+      },
+    })
+
+    swapState.adopt()
+
+    const actions = new SlotActions(swapState)
+
+    actions.start(document.body)
+    swapState.setState({ draft: "typed" })
+
+    document.getElementById("cancel")!.click()
+
+    const scope = swapState.scopeFor(document.querySelector("div")!)!
+
+    expect(swapState.getState("editing", { scope })).toBe(false)
+    expect(swapState.getState("draft", { scope })).toBe("original")
+
+    actions.stop()
+  })
+})

--- a/javascript/packages/client/test/item-state-hydration.test.ts
+++ b/javascript/packages/client/test/item-state-hydration.test.ts
@@ -84,3 +84,54 @@ describe("a region state read inside a collection item", () => {
     expect(textOf("2")).toBe("3")
   })
 })
+
+const BRANCH_FILE = "app/views/chat/edit.html.erb"
+
+const BRANCH_PAGE =
+  `<!--herb-region:${BRANCH_FILE}:ffffffff:0-->` +
+  `<div><!--herb-slot:0:conditional--><!--/herb-slot:0--></div>` +
+  `<template data-herb-region="${BRANCH_FILE}:ffffffff">` +
+  `<!--herb-branch:0:0--><textarea data-herb-slot="1:raw_text"></textarea>` +
+  `</template>` +
+  `<!--/herb-region:${BRANCH_FILE}-->`
+
+const BRANCH_MANIFEST = {
+  state: {},
+  states: {
+    [BRANCH_FILE]: {
+      version: "ffffffff",
+      declarations: [
+        { name: "editing", kind: "boolean", default: "false", scope: "region" },
+        { name: "body_draft", kind: "string", default: '""', scope: "region" },
+      ],
+      reads: { body_draft: [1] },
+      conditionals: { 0: { arms: [["editing", null, 0]], else: null } },
+    },
+  },
+}
+
+describe("a state read inside a branch that was never on the page", () => {
+  test("materializing the branch fills it with the value the client holds", () => {
+    document.body.innerHTML = BRANCH_PAGE + `<template data-herb-dependencies>${JSON.stringify(BRANCH_MANIFEST)}</template>`
+
+    const branchSlots = new SlotIndex()
+
+    branchSlots.scan(document.body)
+
+    const branchState = new SlotState(branchSlots, {
+      persist: "none",
+      transport: () => {
+        throw new Error("a declared state must never reach the transport")
+      },
+    })
+
+    branchState.adopt()
+    branchState.setState({ body_draft: "seeded body" })
+
+    expect(document.querySelector("textarea")).toBeNull()
+
+    branchState.setState({ editing: true })
+
+    expect(document.querySelector("textarea")?.textContent).toBe("seeded body")
+  })
+})

--- a/javascript/packages/client/test/state-scoped.test.ts
+++ b/javascript/packages/client/test/state-scoped.test.ts
@@ -954,3 +954,61 @@ describe("shipped seeds that disagree with the declaration", () => {
     expect(devTools.entries[0].message).toContain("shipped no value")
   })
 })
+
+const MIXED_FILE = "app/views/page/filtered.html.erb"
+
+const MIXED_PAGE =
+  `<!--herb-region:${MIXED_FILE}:eeeeeeee:0-->` +
+  `<ul><!--herb-slot:0:collection-->` +
+  `<!--herb-item:0:a--><li data-herb-slot="1:boolean_attribute:hidden">first</li><!--/herb-item:0-->` +
+  `<!--herb-item:0:b--><li data-herb-slot="1:boolean_attribute:hidden">second</li><!--/herb-item:0-->` +
+  `<!--/herb-slot:0--></ul>` +
+  `<!--/herb-region:${MIXED_FILE}-->` +
+  `<template data-herb-dependencies>${JSON.stringify({
+    state: {},
+    states: {
+      [MIXED_FILE]: {
+        version: "eeeeeeee",
+        declarations: [
+          { name: "filter", kind: "string", default: '"all"', scope: "region" },
+          { name: "starred", kind: "boolean", default: "false", scope: 0 },
+        ],
+        reads: {},
+        conditionals: {},
+        presence: { 1: { all: [["filter", '"starred"'], ["starred", "false"]] } },
+      },
+    },
+  })}</template>`
+
+describe("a condition reading both a region state and an item state", () => {
+  test("resolves each name in its own scope, once per row", () => {
+    document.body.innerHTML = MIXED_PAGE
+
+    const mixedSlots = new SlotIndex()
+
+    mixedSlots.scan(document.body)
+
+    const mixedState = new SlotState(mixedSlots, {
+      persist: "none",
+      transport: () => {
+        throw new Error("a declared state must never reach the transport")
+      },
+    })
+
+    mixedState.adopt()
+
+    const region = mixedSlots.regionsFor(MIXED_FILE)[0]
+    const rows = () => [...document.querySelectorAll("li")].map((li) => li.hasAttribute("hidden"))
+
+    expect(rows()).toEqual([false, false])
+
+    mixedState.setState({ starred: true }, { scope: { region, item: region.slots.get(0)!.items.get("b")! } })
+    mixedState.setState({ filter: "starred" }, { scope: { region, item: null } })
+
+    expect(rows()).toEqual([true, false])
+
+    mixedState.setState({ filter: "all" }, { scope: { region, item: null } })
+
+    expect(rows()).toEqual([false, false])
+  })
+})


### PR DESCRIPTION
This pull request makes a condition that names states from more than one scope actually evaluate, and stops an action from losing its scope when a sibling action removes the element it is on.

A condition may read a region state and an item state together. The engine compiles it correctly, into a combo the manifest carries:

```erb
<%# herb:state (filter: "all") %>

<% @messages.each do |message| %>
  <%# herb:key message.id %>
  <%# herb:state (starred: false) %>

  <li id="message_<%= message.id %>" hidden="<%= filter == "starred" && starred == false %>">…</li>
<% end %>
```

The client could not evaluate it. `#valueOf` looked every name up in the bucket of the scope it was handed, so an item scope could not see a region state at all, and `#writePresence` and `#writeConditionals` evaluated the condition once per scope and applied one answer to every row, which makes per-row variation impossible by construction. The attribute never flipped, so a filter like this was silently inert.

Each name now resolves against the nearest scope that declares it, and a new `#placedSlots` keeps every slot paired with the scope it actually sits in, so presence and conditionals are decided once per row.

The second half is a dispatch ordering bug. `#run` walks `ACTION_NAMES` in a fixed order, so `set` always precedes `reset`:

```erb
<button data-herb-set="editing=false" data-herb-reset="body_draft">Cancel</button>
```

Leaving edit mode swaps the branch this button lives in, so by the time `reset` ran the element was detached and had nothing to resolve a scope against. The reset was dropped. Every scope an element's actions need is now resolved before any of them execute.
