### PR TITLE
Linter: Allow a combined state condition in a boolean attribute

### DIFF
--- a/javascript/packages/linter/src/rules/html-boolean-attributes-no-value.ts
+++ b/javascript/packages/linter/src/rules/html-boolean-attributes-no-value.ts
@@ -1,7 +1,7 @@
 import { ParserRule, BaseAutofixContext, Mutable } from "../types.js"
 import { AttributeVisitorMixin, StaticAttributeStaticValueParams, StaticAttributeDynamicValueParams, isBooleanAttribute } from "../utils/rule-utils.js"
-import { StateScopeMap } from "../utils/state-directives-utils.js"
-import { bareReadName, classifyDefault } from "@herb-tools/client/directives"
+import { StateScopeMap, declaredKind } from "../utils/state-directives-utils.js"
+import { bareReadName, classifyDerivedDefault } from "@herb-tools/client/directives"
 import { hasAttributeValue, getAttributeValueNodes, isERBContentNode } from "@herb-tools/core"
 import { IdentityPrinter } from "@herb-tools/printer"
 
@@ -51,22 +51,19 @@ class BooleanAttributesNoValueVisitor extends AttributeVisitorMixin<BooleanAttri
 
     if (name !== null) return names.includes(name)
 
-    return this.comparesDeclaredState(expression, names)
-  }
+    // The engine accepts the whole condition grammar in a boolean attribute, combos included, so
+    // this defers to the same classifier the state rules use instead of matching one `==` by hand.
+    const declared = new Map<string, string>()
 
-  private comparesDeclaredState(expression: string, names: string[]): boolean {
-    const separator = expression.indexOf("==")
+    for (const candidate of names) {
+      const declaration = this.states.resolve(this.stack, candidate)
 
-    if (separator < 1 || expression[separator + 2] === "=") return false
+      if (declaration) declared.set(candidate, declaredKind(declaration))
+    }
 
-    const sides = [expression.slice(0, separator).trim(), expression.slice(separator + 2).trim()]
-    const read = sides.map((side) => bareReadName(side)).find((side) => side !== null && names.includes(side))
+    const classified = classifyDerivedDefault(expression, declared)
 
-    if (!read) return false
-
-    const comparand = sides.find((side) => bareReadName(side) !== read)
-
-    return comparand !== undefined && ["boolean", "integer", "string", "symbol", "nil"].includes(classifyDefault(comparand))
+    return classified !== null && classified !== "mixed"
   }
 
   private checkAttribute(attributeName: string, attributeNode: HTMLAttributeNode) {

--- a/javascript/packages/linter/test/rules/html-boolean-attributes-no-value.test.ts
+++ b/javascript/packages/linter/test/rules/html-boolean-attributes-no-value.test.ts
@@ -111,3 +111,37 @@ describe("html-boolean-attributes-no-value", () => {
     `)
   })
 })
+
+describe("a boolean attribute driven by a combined state condition", () => {
+  test("allows a condition reading a region state and an item state", () => {
+    expectNoOffenses(dedent`
+      <%# herb:slots client %>
+      <%# herb:state (filter: "all") %>
+      <ul>
+        <% @messages.each do |message| %>
+          <%# herb:key message.id %>
+          <%# herb:state (starred: false) %>
+          <li id="m<%= message.id %>" hidden="<%= filter == "starred" && starred == false %>"><%= message.body %></li>
+        <% end %>
+      </ul>
+    `)
+  })
+
+  test("allows an either-or condition", () => {
+    expectNoOffenses(dedent`
+      <%# herb:slots client %>
+      <%# herb:state (pending: false, failed: false) %>
+      <input disabled="<%= pending? || failed? %>">
+    `)
+  })
+
+  test("still flags a value that reads no state", () => {
+    expectError('Boolean attribute `disabled` should not have a value. Use `disabled` instead of `disabled="<%= @locked && @admin %>"`.')
+
+    assertOffenses(dedent`
+      <%# herb:slots client %>
+      <%# herb:state (pending: false) %>
+      <input disabled="<%= @locked && @admin %>">
+    `)
+  })
+})


### PR DESCRIPTION
This pull request stops `html-boolean-attributes-no-value` flagging a boolean attribute the engine fully supports.

The rule exempts a boolean attribute whose value reads a declared state, but its exemption only understood two shapes, a bare read and a single `==`. It matched the `==` by hand, so anything longer fell through and was reported:

```erb
<%# herb:state (pending: false, failed: false) %>

<input disabled="<%= pending? || failed? %>">
```

The engine accepts the whole condition grammar here, combos included, so that attribute is correct and the offense was wrong. Worse, the suggested fix is to drop the value, which would leave the input permanently disabled.

The exemption now defers to `classifyDerivedDefault`, the same classifier the state rules use, so the rule and the engine agree on what a condition is by construction instead of by two hand-written parsers staying in sync. A value that reads no declared state is still flagged:

```erb
<%# herb:state (pending: false) %>

<input disabled="<%= @locked && @admin %>">
```

Found while writing a filter that hides rows on a condition spanning a region state and an item state.
