### PR TITLE
Engine: Ship an item's seeded states with the values response

### DIFF
--- a/javascript/packages/client/src/slot-index.ts
+++ b/javascript/packages/client/src/slot-index.ts
@@ -33,6 +33,7 @@ const ITEM_STATICS = "item"
 const STATICS_SELECTOR = `template[${HERB_ATTRIBUTES.region}], template[${HERB_ATTRIBUTES.statics}]`
 const MAX_JOURNAL = 50
 const PART_MARKER = "herb-part"
+const SEEDS_KEY = "seeds"
 
 const ANCHOR_ATTRIBUTE = HERB_ATTRIBUTES.slot
 const ANCHOR_SELECTOR = `[${ANCHOR_ATTRIBUTE}]`
@@ -642,9 +643,15 @@ export class SlotIndex {
     for (const key of wanted) {
       const item = slot.items.get(key)
 
-      if (item) {
-        this.#applySlots(payload, item.slots, value.items[key], report, mode)
-      }
+      if (!item) continue
+
+      const { [SEEDS_KEY]: seeds, ...slots } = value.items[key] as PayloadSlots & { [SEEDS_KEY]?: Record<string, unknown> }
+
+      // A row the client built has no `herb-seeds` comment of its own, so the response is where
+      // its seeded states come from.
+      if (seeds) item.seeds = { ...(item.seeds ?? {}), ...seeds }
+
+      this.#applySlots(payload, item.slots, slots, report, mode)
     }
   }
 

--- a/javascript/packages/client/test/item-state-hydration.test.ts
+++ b/javascript/packages/client/test/item-state-hydration.test.ts
@@ -1,5 +1,7 @@
 import { describe, test, expect, beforeEach } from "vitest"
 import { SlotIndex } from "../src/slot-index"
+
+import type { PayloadSlots } from "../src/slot-index"
 import { SlotState } from "../src/state"
 
 const FILE = "app/views/chat/show.html.erb"
@@ -133,5 +135,58 @@ describe("a state read inside a branch that was never on the page", () => {
     branchState.setState({ editing: true })
 
     expect(document.querySelector("textarea")?.textContent).toBe("seeded body")
+  })
+})
+
+const SEEDED_FILE = "app/views/chat/seeded.html.erb"
+
+const SEEDED_PAGE =
+  `<!--herb-region:${SEEDED_FILE}:11111111:0-->` +
+  `<ul><!--herb-slot:0:collection--><!--/herb-slot:0--></ul>` +
+  `<template data-herb-region="${SEEDED_FILE}:11111111">` +
+  `<!--herb-branch:0:item--><!--herb-item:0:--><li><span data-herb-slot="2:child"></span></li><!--/herb-item:0-->` +
+  `</template>` +
+  `<!--/herb-region:${SEEDED_FILE}-->` +
+  `<template data-herb-dependencies>${JSON.stringify({
+    state: {},
+    states: {
+      [SEEDED_FILE]: {
+        version: "11111111",
+        declarations: [{ name: "body_draft", kind: "seeded", default: "message.body", scope: 0 }],
+        reads: { body_draft: [2] },
+        conditionals: {},
+      },
+    },
+  })}</template>`
+
+describe("a seeded item state on a row the client built", () => {
+  test("takes its value from the response, since the row carries no seeds comment", () => {
+    document.body.innerHTML = SEEDED_PAGE
+
+    const seededSlots = new SlotIndex()
+
+    seededSlots.scan(document.body)
+
+    const seededState = new SlotState(seededSlots, {
+      persist: "none",
+      transport: () => {
+        throw new Error("a declared state must never reach the transport")
+      },
+    })
+
+    seededState.adopt()
+
+    seededSlots.apply({
+      template: SEEDED_FILE,
+      version: "11111111",
+      occurrence: 0,
+      slots: { 0: { items: { 7: { 2: "hello", seeds: { body_draft: "hello" } } } } } as unknown as PayloadSlots,
+    })
+
+    const region = seededSlots.regionsFor(SEEDED_FILE)[0]
+    const item = region.slots.get(0)!.items.get("7")!
+
+    expect(item.seeds).toEqual({ body_draft: "hello" })
+    expect(seededState.getState("body_draft", { scope: { region, item } })).toBe("hello")
   })
 })

--- a/lib/herb/engine/dynamics_compiler.rb
+++ b/lib/herb/engine/dynamics_compiler.rb
@@ -580,7 +580,23 @@ module Herb
       def scope_item_end(index)
         leave_scope(index)
 
+        @src << item_seeds(index)
         @src << "; #{ITEMS_BUFFER}#{index}[#{KEY_BUFFER}#{index}.to_s] = #{SCOPE_BUFFER}#{index};"
+      end
+
+      # A row the client builds from the parked skeleton carries no `herb-seeds` comment, so the
+      # values response is the only place it can learn what the server seeded its states with.
+      #: (Integer) -> String
+      def item_seeds(index)
+        names = @slot_visitor.seeded_item_states[index]
+
+        return "" if names.nil? || names.empty?
+
+        pairs = names.map { |name| "#{name.inspect} => #{name}" }.join(", ")
+
+        "; #{SCOPE_BUFFER}#{index}[:seeds] = { #{pairs} }" \
+          ".select { |_, v| #{SlotVisitor::SEED_VALUE_TYPES}.any? { |t| t === v } }" \
+          ".transform_values { |v| v.is_a?(::Symbol) ? v.to_s : v };"
       end
 
       #: (Integer) -> void

--- a/lib/herb/engine/slot_visitor.rb
+++ b/lib/herb/engine/slot_visitor.rb
@@ -200,6 +200,26 @@ module Herb
         { region: @region_states.values.map(&:to_h), items: items }
       end
 
+      # The names of the seeded states declared inside a collection's item body, keyed by the
+      # collection's slot index. A seeded value is a Ruby expression only the server can evaluate,
+      # so a row the client builds for itself has no way to learn it from the markup.
+      #: () -> Hash[Integer, Array[String]]
+      def seeded_item_states
+        seeded = {} #: Hash[Integer, Array[String]]
+
+        @item_states.each do |scope, declarations|
+          index = @indices[scope]
+
+          next unless index
+
+          names = declarations.values.select { |declaration| StateDirectives.seeded?(declaration) }.map(&:name)
+
+          seeded[index] = names unless names.empty?
+        end
+
+        seeded
+      end
+
       #: () -> Array[Hash[Symbol, untyped]]
       def state_entries
         declared = state_declarations

--- a/sig/herb/engine/dynamics_compiler.rbs
+++ b/sig/herb/engine/dynamics_compiler.rbs
@@ -266,6 +266,11 @@ module Herb
       # : (Integer) -> void
       def scope_item_end: (Integer) -> void
 
+      # A row the client builds from the parked skeleton carries no `herb-seeds` comment, so the
+      # values response is the only place it can learn what the server seeded its states with.
+      # : (Integer) -> String
+      def item_seeds: (Integer) -> String
+
       # : (Integer) -> void
       def scope_close_collection: (Integer) -> void
 

--- a/sig/herb/engine/slot_visitor.rbs
+++ b/sig/herb/engine/slot_visitor.rbs
@@ -122,6 +122,12 @@ module Herb
       # : () -> Hash[Symbol, untyped]
       def state_declarations: () -> Hash[Symbol, untyped]
 
+      # The names of the seeded states declared inside a collection's item body, keyed by the
+      # collection's slot index. A seeded value is a Ruby expression only the server can evaluate,
+      # so a row the client builds for itself has no way to learn it from the markup.
+      # : () -> Hash[Integer, Array[String]]
+      def seeded_item_states: () -> Hash[Integer, Array[String]]
+
       # : () -> Array[Hash[Symbol, untyped]]
       def state_entries: () -> Array[Hash[Symbol, untyped]]
 

--- a/test/engine/dynamics_compiler_test.rb
+++ b/test/engine/dynamics_compiler_test.rb
@@ -42,6 +42,64 @@ module Engine
       payload(source, **assigns)[:slots]
     end
 
+    describe "seeded item states" do
+      def seeded_rows
+        <<~ERB
+          <%# herb:slots client %>
+          <ul>
+            <% @rows.each do |row| %>
+              <%# herb:key row %>
+              <%# herb:state (draft: row.to_s, flag: false) %>
+              <li id="r<%= row %>"><%= row %></li>
+            <% end %>
+          </ul>
+        ERB
+      end
+
+      test "each item carries the values the server seeded it with" do
+        items = dynamics(seeded_rows, rows: [1, 2]).fetch(0).fetch(:items)
+
+        assert_equal({ "draft" => "1" }, items.fetch("1").fetch(:seeds))
+        assert_equal({ "draft" => "2" }, items.fetch("2").fetch(:seeds))
+      end
+
+      test "a literal default is not shipped, since the client already knows it" do
+        seeds = dynamics(seeded_rows, rows: [1]).fetch(0).fetch(:items).fetch("1").fetch(:seeds)
+
+        refute_includes seeds.keys, "flag"
+      end
+
+      test "an item with only literal defaults carries no seeds" do
+        source = <<~ERB
+          <%# herb:slots client %>
+          <ul>
+            <% @rows.each do |row| %>
+              <%# herb:key row %>
+              <%# herb:state (flag: false) %>
+              <li id="r<%= row %>"><%= row %></li>
+            <% end %>
+          </ul>
+        ERB
+
+        refute_includes dynamics(source, rows: [1]).fetch(0).fetch(:items).fetch("1").keys, :seeds
+      end
+
+      test "a value the client cannot hold is dropped" do
+        source = <<~ERB
+          <%# herb:slots client %>
+          <ul>
+            <% @rows.each do |row| %>
+              <%# herb:key row %>
+              <%# herb:state (shape: @list, name: row.to_s) %>
+              <li id="r<%= row %>"><%= row %></li>
+            <% end %>
+          </ul>
+        ERB
+
+        assert_equal({ "name" => "1" }, dynamics(source, rows: [1], list: [1, 2]).fetch(0).fetch(:items).fetch("1").fetch(:seeds))
+      end
+    end
+
     describe "what it collects" do
       test "one value per expression" do
         assert_equal({ 0 => "Hello" }, dynamics("<h1><%= @title %></h1>", title: "Hello"))


### PR DESCRIPTION
Follow up on #2379 and #2382, which give a seeded state one way to reach the client, the `herb-seeds` comment in a full render.

A row the client builds for itself never sees that comment. It comes from the parked item skeleton, and the values response that confirms it had no field for a seed, so a seeded item state on such a row simply had no value:

```erb
<% @messages.each do |message| %>
  <%# herb:key message.id %>
  <%# herb:state (body_draft: message.body) %>
<% end %>
```

Send a message and open its editor and the textarea was empty, because `body_draft` is a Ruby expression only the server can evaluate and nothing had told the client the answer. The values are computed during the confirming render already, they were just discarded.

`SlotVisitor#seeded_item_states` reports the seeded names per collection, and `DynamicsCompiler` emits them beside the item's slots:

```ruby
{ 0 => { items: { "7" => { 1 => ["7"], 2 => "hello", seeds: { "draft" => "hello" } } } } }
```

It reuses the comment channel's rules, so a literal default is never shipped, since the client already knows it, and a value the client cannot hold is dropped, since the client would only have to guess at it. `#applyItems` splits `seeds` off and merges it into the item, where every existing seed path reads from unchanged.

This is scoped to items deliberately. A region is never built by the client, so region seeds have no equivalent gap.
