### PR TITLE
Client: Settle the markup a client builds for itself

### DIFF
--- a/javascript/packages/client/src/slot-index.ts
+++ b/javascript/packages/client/src/slot-index.ts
@@ -247,6 +247,7 @@ export class SlotIndex {
   #slotOwners = new WeakMap<Slot, SlotMap>()
   #skeletons = new Map<string, Statics>()
   #clientOwned = new WeakSet<Slot>()
+  #applying = 0
   #observer: MutationObserver | null = null
 
   claim(slot: Slot): void {
@@ -425,13 +426,23 @@ export class SlotIndex {
   apply(payload: Payload, options: ApplyOptions = {}): ApplyReport {
     const report: ApplyReport = { applied: 0, deferred: [] }
 
-    const { token } = this.transaction(() => {
-      this.#applyPayload(payload, report, options.items ?? "replace")
-    })
+    this.#applying += 1
 
-    if (token !== null) report.token = token
+    try {
+      const { token } = this.transaction(() => {
+        this.#applyPayload(payload, report, options.items ?? "replace")
+      })
+
+      if (token !== null) report.token = token
+    } finally {
+      this.#applying -= 1
+    }
 
     return report
+  }
+
+  applying(): boolean {
+    return this.#applying > 0
   }
 
   transaction<T>(work: () => T, options: { retain?: boolean } = {}): { token: RevertToken | null; result: T } {

--- a/javascript/packages/client/src/state.ts
+++ b/javascript/packages/client/src/state.ts
@@ -133,6 +133,7 @@ export class SlotState {
   #timer: ReturnType<typeof setTimeout> | null = null
   #controller: AbortController | null = null
   #observer: MutationObserver | null = null
+  #hydrating = false
 
   constructor(slots: SlotIndex, options: StateOptions = {}) {
     this.#slots = slots
@@ -1296,6 +1297,7 @@ export class SlotState {
     const detail = (event as CustomEvent<SlotEventDetail>).detail
 
     if (detail.operation !== "branch" || !detail.slot) return
+    if (this.#hydrating) return
 
     const slot = detail.slot
     const region = this.#slots.regionOf(slot)
@@ -1324,6 +1326,22 @@ export class SlotState {
       this.#writeValueSlots(manifest, scope, name, value)
     }
 
+    // Markup arriving from a skeleton brings its own nested conditionals and boolean attributes,
+    // and the parked copy says nothing about either. Settle them against the states in scope.
+    const at = this.scopeFor(element)
+
+    if (!at) return
+
+    const declared = manifest.declarations.map((declaration) => declaration.name)
+
+    this.#hydrating = true
+
+    try {
+      this.#writePresence(manifest, at, declared)
+      this.#writeConditionals(manifest, at, declared)
+    } finally {
+      this.#hydrating = false
+    }
   }
 
   #hydrateItemState = (event: Event): void => {

--- a/javascript/packages/client/src/state.ts
+++ b/javascript/packages/client/src/state.ts
@@ -816,13 +816,7 @@ export class SlotState {
       }
     }
 
-    const value = start + matches * (count.by ?? 1)
-    const cache = this.#lastCounts.get(scope.region) ?? new Map<string, StateValue>()
-
-    cache.set(declaration.name, value)
-    this.#lastCounts.set(scope.region, cache)
-
-    return value
+    return start + matches * (count.by ?? 1)
   }
 
   #derivedDependents(manifest: StateManifest, scope: StateScope, written: string[]): string[] {
@@ -1253,7 +1247,7 @@ export class SlotState {
 
     const cache = this.#lastCounts.get(region) ?? new Map<string, StateValue>()
 
-    for (const entry of cascade) cache.set(entry.name, entry.value)
+    for (const entry of [...changed, ...cascade]) cache.set(entry.name, entry.value)
 
     this.#lastCounts.set(region, cache)
 

--- a/javascript/packages/client/src/state.ts
+++ b/javascript/packages/client/src/state.ts
@@ -1019,13 +1019,15 @@ export class SlotState {
     }
   }
 
-  #writeConditionals(manifest: StateManifest, scope: StateScope, changed: string[]): void {
+  #writeConditionals(manifest: StateManifest, scope: StateScope, changed: string[], skip: Slot | null = null): void {
     for (const [indexKey, conditional] of Object.entries(manifest.conditionals)) {
       const mentions = conditional.arms.some((arm) => armMentions(arm, changed))
       if (!mentions) continue
 
       for (const placed of this.#placedSlots(scope, Number(indexKey))) {
         const slot = placed.slot
+
+        if (slot === skip) continue
         const target = this.#targetBranch(conditional, placed.scope)
 
         if (!this.#slots.switchBranch(slot, target) && slot.branch !== target) {
@@ -1297,7 +1299,7 @@ export class SlotState {
     const detail = (event as CustomEvent<SlotEventDetail>).detail
 
     if (detail.operation !== "branch" || !detail.slot) return
-    if (this.#hydrating) return
+    if (this.#hydrating || this.#slots.applying()) return
 
     const slot = detail.slot
     const region = this.#slots.regionOf(slot)
@@ -1338,7 +1340,8 @@ export class SlotState {
 
     try {
       this.#writePresence(manifest, at, declared)
-      this.#writeConditionals(manifest, at, declared)
+
+      this.#writeConditionals(manifest, at, declared, slot)
     } finally {
       this.#hydrating = false
     }
@@ -1348,6 +1351,8 @@ export class SlotState {
     const detail = (event as CustomEvent<SlotEventDetail>).detail
 
     if (detail.operation !== "item-added" || !detail.slot || !detail.item) return
+
+    if (this.#slots.applying()) return
 
     const region = this.#slots.regionOf(detail.slot)
 

--- a/javascript/packages/client/src/state.ts
+++ b/javascript/packages/client/src/state.ts
@@ -1362,12 +1362,11 @@ export class SlotState {
 
     if (!manifest) return
 
-    const scope: StateScope = { region, item: null }
     const item = detail.item
+    const at: StateScope = { region, item }
 
     for (const [name, indices] of Object.entries(manifest.reads)) {
-      if (this.#declaration(manifest, scope, name)?.scope !== "region") continue
-
+      const scope = this.scopeFor(at, name) ?? at
       const value = this.getState(name, { scope })
 
       if (value === undefined) continue
@@ -1386,8 +1385,6 @@ export class SlotState {
 
     // A row built from the parked skeleton carries whatever presence the skeleton was blanked
     // with, so every boolean attribute has to be decided from this item's own scope once.
-    const at: StateScope = { region, item }
-
     for (const [indexKey, entry] of Object.entries(manifest.presence ?? {})) {
       const slot = item.slots.get(Number(indexKey))
 

--- a/javascript/packages/client/src/state.ts
+++ b/javascript/packages/client/src/state.ts
@@ -1013,6 +1013,7 @@ export class SlotState {
         const present = conditionMatches(entry, (name) => this.#valueOf(name, placed.scope))
 
         this.#slots.setBooleanAttribute(placed.slot, present)
+        this.#slots.claim(placed.slot)
       }
     }
   }
@@ -1322,6 +1323,7 @@ export class SlotState {
 
       this.#writeValueSlots(manifest, scope, name, value)
     }
+
   }
 
   #hydrateItemState = (event: Event): void => {
@@ -1357,6 +1359,19 @@ export class SlotState {
         this.#write(slot, text)
         this.#slots.claim(slot)
       }
+    }
+
+    // A row built from the parked skeleton carries whatever presence the skeleton was blanked
+    // with, so every boolean attribute has to be decided from this item's own scope once.
+    const at: StateScope = { region, item }
+
+    for (const [indexKey, entry] of Object.entries(manifest.presence ?? {})) {
+      const slot = item.slots.get(Number(indexKey))
+
+      if (!slot) continue
+
+      this.#slots.setBooleanAttribute(slot, conditionMatches(entry, (name) => this.#valueOf(name, at)))
+      this.#slots.claim(slot)
     }
   }
 

--- a/javascript/packages/client/test/item-state-hydration.test.ts
+++ b/javascript/packages/client/test/item-state-hydration.test.ts
@@ -190,3 +190,63 @@ describe("a seeded item state on a row the client built", () => {
     expect(seededState.getState("body_draft", { scope: { region, item } })).toBe("hello")
   })
 })
+
+const NESTED_FILE = "app/views/chat/toolbar.html.erb"
+
+const NESTED_PAGE =
+  `<!--herb-region:${NESTED_FILE}:22222222:0-->` +
+  `<div><!--herb-slot:0:conditional--><!--/herb-slot:0--></div>` +
+  `<template data-herb-region="${NESTED_FILE}:22222222">` +
+  `<!--herb-branch:0:0-->` +
+  `<span><!--herb-slot:1:conditional--><!--/herb-slot:1--></span>` +
+  `<button data-herb-slot="2:boolean_attribute:disabled">Delete</button>` +
+  `<!--herb-branch:1:0-->Delete message` +
+  `<!--herb-branch:1:1-->Delete selected` +
+  `</template>` +
+  `<!--/herb-region:${NESTED_FILE}-->` +
+  `<template data-herb-dependencies>${JSON.stringify({
+    state: {},
+    states: {
+      [NESTED_FILE]: {
+        version: "22222222",
+        declarations: [
+          { name: "open", kind: "boolean", default: "false", scope: "region" },
+          { name: "count", kind: "integer", default: "0", scope: "region" },
+        ],
+        reads: {},
+        conditionals: {
+          0: { arms: [["open", null, 0]], else: null },
+          1: { arms: [["count", "1", 0]], else: 1 },
+        },
+        presence: { 2: ["count", "0"] },
+      },
+    },
+  })}</template>`
+
+describe("markup that materializes with a conditional and a boolean attribute inside it", () => {
+  test("settles both from the states in scope", () => {
+    document.body.innerHTML = NESTED_PAGE
+
+    const nestedSlots = new SlotIndex()
+
+    nestedSlots.scan(document.body)
+
+    const nestedState = new SlotState(nestedSlots, {
+      persist: "none",
+      transport: () => {
+        throw new Error("a declared state must never reach the transport")
+      },
+    })
+
+    nestedState.adopt()
+    nestedState.setState({ open: true })
+
+    expect(document.querySelector("span")?.textContent).toBe("Delete selected")
+    expect(document.querySelector("button")?.hasAttribute("disabled")).toBe(true)
+
+    nestedState.setState({ count: 1 })
+
+    expect(document.querySelector("span")?.textContent).toBe("Delete message")
+    expect(document.querySelector("button")?.hasAttribute("disabled")).toBe(false)
+  })
+})

--- a/javascript/packages/client/test/state-scoped.test.ts
+++ b/javascript/packages/client/test/state-scoped.test.ts
@@ -1011,4 +1011,48 @@ describe("a condition reading both a region state and an item state", () => {
 
     expect(rows()).toEqual([false, false])
   })
+
+  test("a row added while the condition holds is hidden as soon as it appears", () => {
+    document.body.innerHTML = MIXED_PAGE.replace(
+      `<!--/herb-slot:0--></ul>`,
+      `<!--/herb-slot:0--></ul>` +
+        `<template data-herb-region="${MIXED_FILE}:eeeeeeee">` +
+        `<!--herb-branch:0:item--><!--herb-item:0:--><li data-herb-slot="1:boolean_attribute:hidden"></li><!--/herb-item:0-->` +
+        `</template>`,
+    )
+
+    const addedSlots = new SlotIndex()
+
+    addedSlots.scan(document.body)
+
+    const addedState = new SlotState(addedSlots, {
+      persist: "none",
+      transport: () => {
+        throw new Error("a declared state must never reach the transport")
+      },
+    })
+
+    addedState.adopt()
+
+    const region = addedSlots.regionsFor(MIXED_FILE)[0]
+    const collection = region.slots.get(0)!
+
+    addedState.setState({ filter: "starred" }, { scope: { region, item: null } })
+
+    addedSlots.addItem(collection, "c")
+
+    expect(collection.items.get("c")!.slots.get(1)!.anchor.kind).toBe("element")
+    expect([...document.querySelectorAll("li")].map((li) => li.hasAttribute("hidden"))).toEqual([true, true, true])
+
+    // The server renders every state as its default, so its answer for a state-driven boolean
+    // attribute is always stale. It must not win over what the client already decided.
+    addedSlots.apply({
+      template: MIXED_FILE,
+      version: "eeeeeeee",
+      occurrence: 0,
+      slots: { 0: { items: { a: { 1: false }, b: { 1: false }, c: { 1: false } } } },
+    })
+
+    expect([...document.querySelectorAll("li")].map((li) => li.hasAttribute("hidden"))).toEqual([true, true, true])
+  })
 })


### PR DESCRIPTION
This pull request closes the remaining ways markup the client builds is missing something a server-rendered page gets for free.

A row comes from the parked item skeleton and a branch comes from parked statics. Both are blanked, so nothing in them is decided until something decides it. Four gaps followed from that.

A new row's **boolean attributes** were never computed, so it kept whatever presence the skeleton was blanked with. Sending a message while a filter was active inserted a row that ignored the filter. A newly materialized branch had the same problem one level up, its nested **conditionals and boolean attributes** were never resolved, so a toolbar arrived with an empty label and an enabled button that should have been disabled. And a new row's **item states** were not written into the slots that read them, only region states were.

Presence and nested conditionals are now settled from the states in scope when a row is added or a branch materializes, and both are marked client-owned so a later payload cannot overwrite them with the server's defaults.

The fourth is the opposite failure, hydration running when it should not. While a payload is being applied the payload is authoritative, and a listener re-deriving a branch from state mid-apply would rebuild it without the values that payload carried, discarding them:

```json
{ "23": { "branch": 2, "slots": { "24": "2026-08-23 00:48:03 UTC" } } }
```

An edit confirmed with that response lost its timestamp. Hydration now stands down for the duration of an apply.

The last commit fixes a counted state that stopped updating. `#countValue` wrote to `#lastCounts` as a side effect of being read, and `#recountRegion` uses that same map as the baseline it compares against, so any read of a counted state erased the evidence of change and the recount skipped the write. An empty state driven by a fold stayed on screen after the collection stopped being empty. The cache belongs to the recount now, which also records the counts it wrote.
