### PR TITLE
Rewriter: Import the package's own source in its loader test

### DIFF
--- a/javascript/packages/rewriter/test/custom-rewriter-loader.test.ts
+++ b/javascript/packages/rewriter/test/custom-rewriter-loader.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect, beforeEach, afterEach } from "vitest"
 
-import { CustomRewriterLoader } from "@herb-tools/rewriter/loader"
-import { ASTRewriter } from "@herb-tools/rewriter"
+import { CustomRewriterLoader } from "../src/loader.js"
+import { ASTRewriter } from "../src/index.js"
 
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "fs"
 import { tmpdir } from "os"


### PR DESCRIPTION
This pull request stops `@herb-tools/rewriter:typecheck` failing on a clean checkout.

`test/custom-rewriter-loader.test.ts` imported the package it belongs to by name:

```ts
import { CustomRewriterLoader } from "@herb-tools/rewriter/loader"
import { ASTRewriter } from "@herb-tools/rewriter"
```

Under `moduleResolution: "bundler"` those resolve through the package's own `exports` map to `./dist/types/loader.d.ts` and `./dist/types/index.d.ts`, which are build artifacts. The `typecheck` target depends on `^build`, which builds a project's dependencies and not the project itself, so nothing guarantees those files exist when the check runs:

```
error TS2307: Cannot find module '@herb-tools/rewriter/loader' or its corresponding type declarations.
```