### PR TITLE
Engine: Support Erubi's `trim` option

### DIFF
--- a/docs/docs/projects/engine.md
+++ b/docs/docs/projects/engine.md
@@ -35,21 +35,24 @@ If a framework renders `.erb` files through the standard-library `ERB` by defaul
 
 `Herb::Engine` accepts all the same options as `Erubi::Engine`:
 
-- `bufvar` / `outvar` — Buffer variable name
-- `bufval` — Initial buffer value
-- `escape` / `escape_html` — Whether `<%= %>` escapes by default
-- `escapefunc` — Escape function name
-- `filename` — Template filename
-- `freeze` — Add frozen string literal comment
-- `freeze_template_literals` — Freeze template string literals
-- `preamble` / `postamble` — Custom preamble/postamble
-- `chain_appends` — Chain `<<` calls for performance
-- `ensure` — Wrap in begin/ensure block
-- `src` — Initial source string
+| Option | Purpose |
+| --- | --- |
+| `bufvar` / `outvar` | Buffer variable name |
+| `bufval` | Initial buffer value |
+| `escape` / `escape_html` | Whether `<%= %>` escapes by default |
+| `escapefunc` | Escape function name |
+| `filename` | Template filename |
+| `freeze` | Add frozen string literal comment |
+| `freeze_template_literals` | Freeze template string literals |
+| `preamble` / `postamble` | Custom preamble/postamble |
+| `chain_appends` | Chain `<<` calls for performance |
+| `ensure` | Wrap in begin/ensure block |
+| `src` | Initial source string |
+| `trim` | Fold the whitespace around standalone `<% %>` and `<%# %>` tags into the code (default `true`) |
 
 ### Whitespace trimming
 
-Erubi's `trim` behavior is always on and is not configurable. A `<% %>` tag that stands alone on its line drops the newline that follows it, and `-%>` drops it wherever the tag sits. `<%-` is accepted and leaves the whitespace in front of the tag alone, which is what Erubi does with it too. Trimming is what makes a `case` written across several tags compile:
+`trim` is on by default, the same as in Erubi. A `<% %>` or `<%# %>` tag that stands alone on its line folds the indentation in front of it and the newline after it into the code line, so neither reaches the output. `-%>` on a `<%= %>` tag drops the newline after it wherever the tag sits. `<%-` is accepted and leaves the whitespace in front of the tag alone, which is what Erubi does with it too. Trimming is what makes a `case` written across several tags compile under Erubi:
 
 ```erb
 <% case status %>
@@ -62,17 +65,17 @@ Erubi's `trim` behavior is always on and is not configurable. A `<% %>` tag that
 <% end %>
 ```
 
-The newline after `<% case status %>` is trimmed, so nothing lands between `case` and its first `when`, and the compiled Ruby is valid. Herb and Erubi emit byte-identical output here. Passing `trim: false` has no effect, whereas Erubi would honor it and emit a buffer append between the two tags.
+The newline after `<% case status %>` is trimmed, so nothing lands between `case` and its first `when`, and the compiled Ruby is valid. Herb and Erubi emit byte-identical output here.
+
+Pass `trim: false` to keep every byte of whitespace around code and comment tags, which is what a plain-text template usually wants. Herb renders the same output as Erubi with the option off, including the newline that `-%>` still drops after an expression. The `case` template above is the one place the two part ways under `trim: false`. Erubi appends the newline between `case` and `when` to the buffer and produces invalid Ruby. Herb does not emit the whitespace between a `case` tag and its first `when`, so the template keeps compiling.
 
 ### Known differences from Erubi
 
-Three things that `Erubi::Engine` accepts are handled differently by `Herb::Engine` on its default settings. Each one is deliberate.
+Two things that `Erubi::Engine` accepts are handled differently by `Herb::Engine` on its default settings. Each one is deliberate.
 
 A `case` with its first `when`/`in` in the same ERB tag raises `ERB_CASE_WITH_CONDITIONS_ERROR` under [strict parsing](/parser-options). The AST that pattern produces cannot be formatted or compiled reliably. The [`erb-no-inline-case-conditions`](/linter/rules/erb-no-inline-case-conditions.md) rule reports the same thing.
 
 Escaped tags such as `<%% %>` and `<%%= %>` raise `Herb::Engine::GeneratorTemplateError`. A template that emits literal ERB is a generator template, not a template to render.
-
-`trim: false` is ignored and trimming stays on. Herb's whitespace handling is tied to the parsed AST, not to a scanner mode.
 
 One difference changes what a template renders. Erubi calls `to_s` on every `<%= %>` wherever it sits, because it never looks at the markup around the tag. Herb parses the HTML, so it knows the tag's context and escapes for it:
 

--- a/lib/herb/cli.rb
+++ b/lib/herb/cli.rb
@@ -13,7 +13,7 @@ require_relative "engine/slots/visitor"
 class Herb::CLI
   include Herb::Colors
 
-  attr_accessor :json, :silent, :log_file, :no_timing, :local, :escape, :no_escape, :freeze, :debug, :tool, :strict, :analyze, :track_whitespace, :track_locations, :verbose, :isolate, :arena_stats, :leak_check, :action_view_helpers, :trim, :optimize, :slots, :scoped_styles, :inline_css, :file_timeout
+  attr_accessor :json, :silent, :log_file, :no_timing, :local, :escape, :no_escape, :freeze, :debug, :tool, :strict, :analyze, :track_whitespace, :track_locations, :verbose, :isolate, :arena_stats, :leak_check, :action_view_helpers, :no_trim, :optimize, :slots, :scoped_styles, :inline_css, :file_timeout
 
   def initialize(args)
     @args = args
@@ -335,8 +335,8 @@ class Herb::CLI
         self.action_view_helpers = true
       end
 
-      parser.on("--trim", "Enable trimming of leading/trailing whitespace (for compile/render commands)") do
-        self.trim = true
+      parser.on("--no-trim", "Disable whitespace trimming around standalone ERB tags (for compile/render commands)") do
+        self.no_trim = true
       end
 
       parser.on("--optimize", "Enable compile-time optimizations for Action View helpers (for compile/render commands) (default: false)") do
@@ -1165,7 +1165,7 @@ class Herb::CLI
       end
 
       options[:optimize] = true if optimize
-      options[:trim] = true if trim
+      options[:trim] = false if no_trim
       options[:validate_ruby] = true
       options[:visitors] = visitors unless visitors.empty?
 
@@ -1278,7 +1278,7 @@ class Herb::CLI
       end
 
       options[:optimize] = true if optimize
-      options[:trim] = true if trim
+      options[:trim] = false if no_trim
 
       visitors = []
       visitors << slot_visitor if slot_visitor

--- a/lib/herb/engine/compiler.rb
+++ b/lib/herb/engine/compiler.rb
@@ -24,6 +24,7 @@ module Herb
 
         @engine = engine
         @escape = options.fetch(:escape) { options.fetch(:escape_html, false) }
+        @trim = options[:trim] != false
         @tokens = [] #: Array[untyped]
         @padding_before = nil #: Hash[Integer, Integer]?
         @element_stack = [] #: Array[String]
@@ -79,9 +80,9 @@ module Herb
 
           if node.open_tag.is_a?(Herb::AST::ERBOpenTagNode) && tag_name && node.close_tag
             if node.close_tag.is_a?(Herb::AST::ERBEndNode)
-              remove_trailing_whitespace_from_last_token! if left_trim?(node.close_tag)
+              remove_trailing_whitespace_from_last_token! if @trim && left_trim?(node.close_tag)
               add_text("</#{tag_name}>")
-              @trim_next_whitespace = true
+              @trim_next_whitespace = true if @trim
             else
               add_text("</#{tag_name}>")
             end
@@ -348,11 +349,11 @@ module Herb
       end
 
       def visit_erb_block_end_node(node, escaped: false)
-        remove_trailing_whitespace_from_last_token! if left_trim?(node)
+        remove_trailing_whitespace_from_last_token! if @trim && left_trim?(node)
 
         code = node.content.value.strip
 
-        if at_line_start?
+        if @trim && at_line_start?
           leading_space = extract_and_remove_leading_space!
           right_space = " \n"
 
@@ -430,6 +431,12 @@ module Herb
         check_for_escaped_erb_tag!(opening)
 
         if !skip_comment_check && erb_comment?(opening)
+          unless @trim
+            keep_line_count(node)
+
+            return
+          end
+
           follows_newline = leading_space_follows_newline?
           remove_trailing_whitespace_from_last_token! if left_trim?(node)
           swallows_newline = at_line_start?
@@ -726,6 +733,8 @@ module Herb
       end
 
       def apply_trim(node, code)
+        return add_code(code) unless @trim
+
         follows_newline = leading_space_follows_newline?
         removed_whitespace = left_trim?(node) ? remove_trailing_whitespace_from_last_token! : ""
 

--- a/test/engine/engine_erubi_compat_test.rb
+++ b/test/engine/engine_erubi_compat_test.rb
@@ -259,5 +259,63 @@ module Engine
 
       assert_equal ["ERBCaseWithConditionsError"], error.diagnostics.map(&:code)
     end
+
+    test "keeps the whitespace around a standalone code tag with trim: false" do
+      template = <<~ERB
+        <% a = 1 %>
+        text
+      ERB
+
+      assert_compiled_snapshot(template, trim: false)
+      assert_evaluated_snapshot(template, trim: false, enforce_erubi_equality: true)
+    end
+
+    test "keeps the indentation in front of a code tag with trim: false" do
+      template = "before\n  <% a = 1 %>\nafter\n"
+
+      assert_compiled_snapshot(template, trim: false)
+      assert_evaluated_snapshot(template, trim: false, enforce_erubi_equality: true)
+    end
+
+    test "keeps the whitespace around a comment with trim: false" do
+      template = "before\n  <%# comment %>\nafter\n"
+
+      assert_compiled_snapshot(template, trim: false)
+      assert_evaluated_snapshot(template, trim: false, enforce_erubi_equality: true)
+    end
+
+    test "leaves whitespace before a <%- tag alone with trim: false" do
+      template = "before\n  <%- a = 1 %>\nafter\n"
+
+      assert_compiled_snapshot(template, trim: false)
+      assert_evaluated_snapshot(template, trim: false, enforce_erubi_equality: true)
+    end
+
+    test "keeps the newline after a code tag ending in -%> with trim: false" do
+      template = "<% a = 1 -%>\ntext\n"
+
+      assert_compiled_snapshot(template, trim: false)
+      assert_evaluated_snapshot(template, trim: false, enforce_erubi_equality: true)
+    end
+
+    test "drops the newline after an expression ending in -%> with trim: false" do
+      template = "<%= a -%>\ntext\n"
+
+      assert_compiled_snapshot(template, trim: false)
+      assert_evaluated_snapshot(template, { a: 1 }, trim: false, enforce_erubi_equality: true)
+    end
+
+    test "keeps the whitespace around control flow with trim: false" do
+      template = <<~ERB
+        <% if a == 1 %>
+          yes
+        <% else %>
+          no
+        <% end %>
+      ERB
+
+      assert_compiled_snapshot(template, trim: false)
+      assert_evaluated_snapshot(template, { a: 1 }, trim: false, enforce_erubi_equality: true)
+    end
   end
 end

--- a/test/engine/engine_erubi_divergence_test.rb
+++ b/test/engine/engine_erubi_divergence_test.rb
@@ -217,14 +217,13 @@ module Engine
       assert_raises(SyntaxError) { RubyVM::InstructionSequence.compile(erubi) }
     end
 
-    test "ignores trim: false and keeps trimming" do
-      template = "<% a = 1 %>\ntext\n"
+    test "compiles a case split across tags with trim: false where Erubi produces invalid Ruby" do
+      template = "<% case a %>\n<% when 1 %>\nA\n<% end %>\n"
       herb, erubi = assert_diverges_from_erubi(template, { trim: false })
 
-      assert_equal Herb::Engine.new(template).src, herb
-      assert_includes erubi, "_buf << '\n'.freeze;"
+      assert_equal "\nA\n\n", evaluate(herb, { a: 1 })
 
-      refute_equal evaluate(erubi, {}), evaluate(herb, {})
+      assert_raises(SyntaxError) { RubyVM::InstructionSequence.compile(erubi) }
     end
 
     test "refuses an escaped ERB tag that Erubi passes through" do

--- a/test/engine/whitespace_trimming_test.rb
+++ b/test/engine/whitespace_trimming_test.rb
@@ -442,5 +442,29 @@ module Engine
       assert_compiled_snapshot(template)
       assert_evaluated_snapshot(template, enforce_erubi_equality: true)
     end
+
+    test "trim: false keeps the whitespace around <%- and -%> code tags" do
+      template = <<~ERB
+        <%- if true -%>
+          <h1>Content</h1>
+        <%- end -%>
+      ERB
+
+      assert_compiled_snapshot(template, trim: false)
+      assert_evaluated_snapshot(template, trim: false, enforce_erubi_equality: true)
+    end
+
+    test "trim: false keeps the newline after the end of a block expression" do
+      template = <<~ERB
+        <%= wrapper do %>
+          <p>hi</p>
+        <% end %>
+        after
+      ERB
+
+      engine = assert_compiled_snapshot(template, trim: false)
+
+      assert_includes engine.src, "'\nafter\n'"
+    end
   end
 end

--- a/test/integration/cli_test.rb
+++ b/test/integration/cli_test.rb
@@ -102,6 +102,19 @@ module Engine
       end
     end
 
+    test "compile with --no-trim" do
+      template = "<% a = 1 %>\ntext\n"
+
+      with_temp_file(template) do |file_path|
+        assert_raises(SystemExit) do
+          Herb::CLI.new(["compile", file_path, "--no-trim"]).call
+        end
+
+        output = captured_output
+        assert_includes output, "a = 1; _buf << '\ntext\n'"
+      end
+    end
+
     test "compile with json output" do
       template = "<div>Hello World</div>"
 

--- a/test/snapshot_utils.rb
+++ b/test/snapshot_utils.rb
@@ -367,12 +367,12 @@ module SnapshotUtils
     end
   end
 
-  def compare_with_actionview_erubi_evaluated(source, herb_result, locals, _options, enforce_equality: false)
+  def compare_with_actionview_erubi_evaluated(source, herb_result, locals, options, enforce_equality: false)
     require "action_view"
     require_erubi_silently
 
     begin
-      erubi_engine = ActionView::Template::Handlers::ERB::Erubi.new(source, bufvar: "@output_buffer")
+      erubi_engine = ActionView::Template::Handlers::ERB::Erubi.new(source, bufvar: "@output_buffer", **options.slice(:trim))
 
       view = ActionView::Base.new(ActionView::LookupContext.new([]), {}, nil)
       view.instance_variable_set(:@output_buffer, ActionView::OutputBuffer.new)

--- a/test/snapshots/engine/engine_erubi_compat_test/test_0028_keeps_the_whitespace_around_a_standalone_code_tag_with_trim_false_2f44fe42d70f88dd5df31209c6933545.txt
+++ b/test/snapshots/engine/engine_erubi_compat_test/test_0028_keeps_the_whitespace_around_a_standalone_code_tag_with_trim_false_2f44fe42d70f88dd5df31209c6933545.txt
@@ -1,0 +1,8 @@
+---
+source: "Engine::EngineErubiCompatTest#test_0028_keeps the whitespace around a standalone code tag with trim: false"
+input: "{source: \"<% a = 1 %>\\ntext\\n\", options: {trim: false}}"
+---
+_buf = ::String.new; a = 1; _buf << '
+text
+'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/engine_erubi_compat_test/test_0028_keeps_the_whitespace_around_a_standalone_code_tag_with_trim_false_3a6d5cb2b25f08d5da06c24ec11d59df.txt
+++ b/test/snapshots/engine/engine_erubi_compat_test/test_0028_keeps_the_whitespace_around_a_standalone_code_tag_with_trim_false_3a6d5cb2b25f08d5da06c24ec11d59df.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::EngineErubiCompatTest#test_0028_keeps the whitespace around a standalone code tag with trim: false"
+input: "{source: \"<% a = 1 %>\\ntext\\n\", locals: {}, options: {trim: false}}"
+---
+
+text

--- a/test/snapshots/engine/engine_erubi_compat_test/test_0029_keeps_the_indentation_in_front_of_a_code_tag_with_trim_false_287142874585203f18c04fec5fc46dbc.txt
+++ b/test/snapshots/engine/engine_erubi_compat_test/test_0029_keeps_the_indentation_in_front_of_a_code_tag_with_trim_false_287142874585203f18c04fec5fc46dbc.txt
@@ -1,0 +1,9 @@
+---
+source: "Engine::EngineErubiCompatTest#test_0029_keeps the indentation in front of a code tag with trim: false"
+input: "{source: \"before\\n  <% a = 1 %>\\nafter\\n\", options: {trim: false}}"
+---
+_buf = ::String.new; _buf << 'before
+  '.freeze; a = 1; _buf << '
+after
+'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/engine_erubi_compat_test/test_0029_keeps_the_indentation_in_front_of_a_code_tag_with_trim_false_d3abe67ec8cda679163153242180a303.txt
+++ b/test/snapshots/engine/engine_erubi_compat_test/test_0029_keeps_the_indentation_in_front_of_a_code_tag_with_trim_false_d3abe67ec8cda679163153242180a303.txt
@@ -1,0 +1,7 @@
+---
+source: "Engine::EngineErubiCompatTest#test_0029_keeps the indentation in front of a code tag with trim: false"
+input: "{source: \"before\\n  <% a = 1 %>\\nafter\\n\", locals: {}, options: {trim: false}}"
+---
+before
+  
+after

--- a/test/snapshots/engine/engine_erubi_compat_test/test_0030_keeps_the_whitespace_around_a_comment_with_trim_false_538053bdcf74ccc667ff88225ea7f109.txt
+++ b/test/snapshots/engine/engine_erubi_compat_test/test_0030_keeps_the_whitespace_around_a_comment_with_trim_false_538053bdcf74ccc667ff88225ea7f109.txt
@@ -1,0 +1,7 @@
+---
+source: "Engine::EngineErubiCompatTest#test_0030_keeps the whitespace around a comment with trim: false"
+input: "{source: \"before\\n  <%# comment %>\\nafter\\n\", locals: {}, options: {trim: false}}"
+---
+before
+  
+after

--- a/test/snapshots/engine/engine_erubi_compat_test/test_0030_keeps_the_whitespace_around_a_comment_with_trim_false_a5103ecb3f8a650501a63743370ba96d.txt
+++ b/test/snapshots/engine/engine_erubi_compat_test/test_0030_keeps_the_whitespace_around_a_comment_with_trim_false_a5103ecb3f8a650501a63743370ba96d.txt
@@ -1,0 +1,9 @@
+---
+source: "Engine::EngineErubiCompatTest#test_0030_keeps the whitespace around a comment with trim: false"
+input: "{source: \"before\\n  <%# comment %>\\nafter\\n\", options: {trim: false}}"
+---
+_buf = ::String.new; _buf << 'before
+  
+after
+'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/engine_erubi_compat_test/test_0031_leaves_whitespace_before_a_lt%-_tag_alone_with_trim_false_340544427250c07654c836376ed2131d.txt
+++ b/test/snapshots/engine/engine_erubi_compat_test/test_0031_leaves_whitespace_before_a_lt%-_tag_alone_with_trim_false_340544427250c07654c836376ed2131d.txt
@@ -1,0 +1,9 @@
+---
+source: "Engine::EngineErubiCompatTest#test_0031_leaves whitespace before a <%- tag alone with trim: false"
+input: "{source: \"before\\n  <%- a = 1 %>\\nafter\\n\", options: {trim: false}}"
+---
+_buf = ::String.new; _buf << 'before
+  '.freeze; a = 1; _buf << '
+after
+'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/engine_erubi_compat_test/test_0031_leaves_whitespace_before_a_lt%-_tag_alone_with_trim_false_8c33a8238cdb66e4a3e02414f85505a5.txt
+++ b/test/snapshots/engine/engine_erubi_compat_test/test_0031_leaves_whitespace_before_a_lt%-_tag_alone_with_trim_false_8c33a8238cdb66e4a3e02414f85505a5.txt
@@ -1,0 +1,7 @@
+---
+source: "Engine::EngineErubiCompatTest#test_0031_leaves whitespace before a <%- tag alone with trim: false"
+input: "{source: \"before\\n  <%- a = 1 %>\\nafter\\n\", locals: {}, options: {trim: false}}"
+---
+before
+  
+after

--- a/test/snapshots/engine/engine_erubi_compat_test/test_0032_keeps_the_newline_after_a_code_tag_ending_in_-%gt_with_trim_false_0443418624db75ce33c76116685d91a1.txt
+++ b/test/snapshots/engine/engine_erubi_compat_test/test_0032_keeps_the_newline_after_a_code_tag_ending_in_-%gt_with_trim_false_0443418624db75ce33c76116685d91a1.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::EngineErubiCompatTest#test_0032_keeps the newline after a code tag ending in -%> with trim: false"
+input: "{source: \"<% a = 1 -%>\\ntext\\n\", locals: {}, options: {trim: false}}"
+---
+
+text

--- a/test/snapshots/engine/engine_erubi_compat_test/test_0032_keeps_the_newline_after_a_code_tag_ending_in_-%gt_with_trim_false_716a60be9997e7f30880cc31d5dddc44.txt
+++ b/test/snapshots/engine/engine_erubi_compat_test/test_0032_keeps_the_newline_after_a_code_tag_ending_in_-%gt_with_trim_false_716a60be9997e7f30880cc31d5dddc44.txt
@@ -1,0 +1,8 @@
+---
+source: "Engine::EngineErubiCompatTest#test_0032_keeps the newline after a code tag ending in -%> with trim: false"
+input: "{source: \"<% a = 1 -%>\\ntext\\n\", options: {trim: false}}"
+---
+_buf = ::String.new; a = 1; _buf << '
+text
+'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/engine_erubi_compat_test/test_0033_drops_the_newline_after_an_expression_ending_in_-%gt_with_trim_false_257cf5c52bf591c07759f000c1edd4ce.txt
+++ b/test/snapshots/engine/engine_erubi_compat_test/test_0033_drops_the_newline_after_an_expression_ending_in_-%gt_with_trim_false_257cf5c52bf591c07759f000c1edd4ce.txt
@@ -1,0 +1,5 @@
+---
+source: "Engine::EngineErubiCompatTest#test_0033_drops the newline after an expression ending in -%> with trim: false"
+input: "{source: \"<%= a -%>\\ntext\\n\", locals: {a: 1}, options: {trim: false}}"
+---
+1text

--- a/test/snapshots/engine/engine_erubi_compat_test/test_0033_drops_the_newline_after_an_expression_ending_in_-%gt_with_trim_false_6a353de3e0975e29dae0e77b4134d89e.txt
+++ b/test/snapshots/engine/engine_erubi_compat_test/test_0033_drops_the_newline_after_an_expression_ending_in_-%gt_with_trim_false_6a353de3e0975e29dae0e77b4134d89e.txt
@@ -1,0 +1,7 @@
+---
+source: "Engine::EngineErubiCompatTest#test_0033_drops the newline after an expression ending in -%> with trim: false"
+input: "{source: \"<%= a -%>\\ntext\\n\", options: {trim: false}}"
+---
+_buf = ::String.new; _buf << (a).to_s; _buf << 'text
+'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/engine_erubi_compat_test/test_0034_keeps_the_whitespace_around_control_flow_with_trim_false_3bf4ae5e75e30dcf71e4ef281019b167.txt
+++ b/test/snapshots/engine/engine_erubi_compat_test/test_0034_keeps_the_whitespace_around_control_flow_with_trim_false_3bf4ae5e75e30dcf71e4ef281019b167.txt
@@ -1,0 +1,11 @@
+---
+source: "Engine::EngineErubiCompatTest#test_0034_keeps the whitespace around control flow with trim: false"
+input: "{source: \"<% if a == 1 %>\\n  yes\\n<% else %>\\n  no\\n<% end %>\\n\", options: {trim: false}}"
+---
+_buf = ::String.new; if a == 1; _buf << '
+  yes
+'.freeze; else; _buf << '
+  no
+'.freeze; end; _buf << '
+'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/engine_erubi_compat_test/test_0034_keeps_the_whitespace_around_control_flow_with_trim_false_84cf9bfe8a7f010010edd08214f51a2d.txt
+++ b/test/snapshots/engine/engine_erubi_compat_test/test_0034_keeps_the_whitespace_around_control_flow_with_trim_false_84cf9bfe8a7f010010edd08214f51a2d.txt
@@ -1,0 +1,7 @@
+---
+source: "Engine::EngineErubiCompatTest#test_0034_keeps the whitespace around control flow with trim: false"
+input: "{source: \"<% if a == 1 %>\\n  yes\\n<% else %>\\n  no\\n<% end %>\\n\", locals: {a: 1}, options: {trim: false}}"
+---
+
+  yes
+

--- a/test/snapshots/engine/whitespace_trimming_test/test_0056_trim_false_keeps_the_whitespace_around_lt%-_and_-%gt_code_tags_d1910bd276d87403b7e20025d4f551ae.txt
+++ b/test/snapshots/engine/whitespace_trimming_test/test_0056_trim_false_keeps_the_whitespace_around_lt%-_and_-%gt_code_tags_d1910bd276d87403b7e20025d4f551ae.txt
@@ -1,0 +1,9 @@
+---
+source: "Engine::WhitespaceTrimmingTest#test_0056_trim: false keeps the whitespace around <%- and -%> code tags"
+input: "{source: \"<%- if true -%>\\n  <h1>Content</h1>\\n<%- end -%>\\n\", options: {trim: false}}"
+---
+_buf = ::String.new; if true; _buf << '
+  <h1>Content</h1>
+'.freeze; end; _buf << '
+'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/whitespace_trimming_test/test_0056_trim_false_keeps_the_whitespace_around_lt%-_and_-%gt_code_tags_e8cbb36c05f2dcb8ccc97adc53e34092.txt
+++ b/test/snapshots/engine/whitespace_trimming_test/test_0056_trim_false_keeps_the_whitespace_around_lt%-_and_-%gt_code_tags_e8cbb36c05f2dcb8ccc97adc53e34092.txt
@@ -1,0 +1,7 @@
+---
+source: "Engine::WhitespaceTrimmingTest#test_0056_trim: false keeps the whitespace around <%- and -%> code tags"
+input: "{source: \"<%- if true -%>\\n  <h1>Content</h1>\\n<%- end -%>\\n\", locals: {}, options: {trim: false}}"
+---
+
+  <h1>Content</h1>
+

--- a/test/snapshots/engine/whitespace_trimming_test/test_0057_trim_false_keeps_the_newline_after_the_end_of_a_block_expression_a68f7abccd40026367f75e02d73741ad.txt
+++ b/test/snapshots/engine/whitespace_trimming_test/test_0057_trim_false_keeps_the_newline_after_the_end_of_a_block_expression_a68f7abccd40026367f75e02d73741ad.txt
@@ -1,0 +1,10 @@
+---
+source: "Engine::WhitespaceTrimmingTest#test_0057_trim: false keeps the newline after the end of a block expression"
+input: "{source: \"<%= wrapper do %>\\n  <p>hi</p>\\n<% end %>\\nafter\\n\", options: {trim: false}}"
+---
+_buf = ::String.new; _buf << (wrapper do; _buf << '
+  <p>hi</p>
+'.freeze; end); _buf << '
+after
+'.freeze;
+_buf.to_s


### PR DESCRIPTION
This pull request makes `Herb::Engine` honor Erubi's `trim` option. It stays on by default, as in Erubi, and `trim: false` now keeps the whitespace around `<% %>` and `<%# %>` tags in the output.

Before this, the compiler always trimmed and `trim: false` was silently accepted and ignored, which the engine docs listed as a known difference from `Erubi::Engine`. That is invisible in HTML, but it was the one option where the same template with the same options rendered differently under Herb than under Erubi, and it shows in plain-text templates such as mail text, where the preserved newlines are part of the output.

What `trim` controls in Erubi is narrow. A code or comment tag standing alone on its line folds the indentation in front of it and the newline after it into the code line. `-%>` on an expression drops the following newline regardless of the option, and `<%-` does nothing under Erubi's default regexp. 

The compiler now mirrors exactly that. With the option off it skips the folding in `apply_trim`, the comment handling, the block-end handling, and the `<%-` left trim, while `-%>` on expressions keeps trimming.

```ruby
template = "Hi <%= name %>,\n<% if urgent %>\nURGENT\n<% end %>\nBye\n"

Herb::Engine.new(template)               # renders "Hi X,\nURGENT\nBye\n", unchanged
Herb::Engine.new(template, trim: false)  # renders "Hi X,\n\nURGENT\n\nBye\n", same as Erubi
```

The CLI's `--trim` flag set `trim: true`, which was already the default, so it did nothing. It becomes `--no-trim`. The engine docs describe the option, and the options list becomes a table with `trim` in it.