### PR TITLE
Ruby: Add `html` to `Herb::ParserOptions`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -81,6 +81,7 @@ Metrics/CyclomaticComplexity:
     - lib/herb/dev/runner.rb
     - lib/herb/engine.rb
     - lib/herb/engine/**/*.rb
+    - lib/herb/parser_options.rb
     - lib/herb/prism_inspect.rb
     - lib/herb/project.rb
     - templates/template.rb
@@ -99,6 +100,7 @@ Metrics/MethodLength:
     - lib/herb/diagnostic.rb
     - lib/herb/engine.rb
     - lib/herb/engine/**/*.rb
+    - lib/herb/parser_options.rb
     - lib/herb/prism_inspect.rb
     - lib/herb/project.rb
     - templates/template.rb
@@ -125,6 +127,7 @@ Metrics/AbcSize:
     - lib/herb/engine.rb
     - lib/herb/engine/**/*.rb
     - lib/herb/errors.rb
+    - lib/herb/parser_options.rb
     - lib/herb/prism_inspect.rb
     - lib/herb/project.rb
     - lib/herb/token.rb
@@ -193,6 +196,7 @@ Metrics/ParameterLists:
     - lib/herb/errors.rb
     - lib/herb/parse_result.rb
     - lib/herb/parser_options.rb
+    - lib/herb/parser_options.rb
     - lib/herb/prism_inspect.rb
     - lib/herb/visitor/diagnostics.rb
     - lib/herb/engine/visitors/optimize_visitor.rb
@@ -213,6 +217,7 @@ Metrics/PerceivedComplexity:
     - lib/herb/dev/server.rb
     - lib/herb/engine.rb
     - lib/herb/engine/**/*.rb
+    - lib/herb/parser_options.rb
     - lib/herb/prism_inspect.rb
     - lib/herb/project.rb
     - templates/template.rb

--- a/ext/herb/extension_helpers.c
+++ b/ext/herb/extension_helpers.c
@@ -152,6 +152,7 @@ VALUE create_parse_result(AST_DOCUMENT_NODE_T* root, VALUE source, const parser_
   rb_hash_aset(kwargs, ID2SYM(rb_intern("prism_nodes")), options->prism_nodes ? Qtrue : Qfalse);
   rb_hash_aset(kwargs, ID2SYM(rb_intern("prism_nodes_deep")), options->prism_nodes_deep ? Qtrue : Qfalse);
   rb_hash_aset(kwargs, ID2SYM(rb_intern("prism_program")), options->prism_program ? Qtrue : Qfalse);
+  rb_hash_aset(kwargs, ID2SYM(rb_intern("html")), options->html ? Qtrue : Qfalse);
 
   VALUE erb_openers = rb_ary_new_capa((long) options->erb_opener_count);
 

--- a/lib/herb/parser_options.rb
+++ b/lib/herb/parser_options.rb
@@ -15,6 +15,7 @@ module Herb
     attr_reader :prism_program #: bool
     attr_reader :prism_nodes #: bool
     attr_reader :prism_nodes_deep #: bool
+    attr_reader :html #: bool
     attr_reader :erb_openers #: Array[String]
     attr_reader :timeout #: Numeric
     attr_reader :max_errors #: Integer?
@@ -33,12 +34,13 @@ module Herb
     DEFAULT_PRISM_PROGRAM = false #: bool
     DEFAULT_PRISM_NODES = false #: bool
     DEFAULT_PRISM_NODES_DEEP = false #: bool
+    DEFAULT_HTML = true #: bool
     DEFAULT_TIMEOUT = 1 #: Numeric
     DEFAULT_MAX_ERRORS = 25 #: Integer
     DEFAULT_CAPTURE_ARENA_STATS = false #: bool
 
-    #: (?strict: bool, ?track_whitespace: bool, ?track_locations: bool, ?analyze: bool, ?action_view_helpers: bool, ?transform_conditionals: bool, ?render_nodes: bool, ?strict_locals: bool, ?herb_directives: bool, ?iteration_nodes: bool, ?prism_nodes: bool, ?prism_nodes_deep: bool, ?prism_program: bool, ?erb_openers: Array[String], ?timeout: Numeric) -> void
-    def initialize(strict: DEFAULT_STRICT, track_whitespace: DEFAULT_TRACK_WHITESPACE, track_locations: DEFAULT_TRACK_LOCATIONS, analyze: DEFAULT_ANALYZE, action_view_helpers: DEFAULT_ACTION_VIEW_HELPERS, transform_conditionals: DEFAULT_TRANSFORM_CONDITIONALS, render_nodes: DEFAULT_RENDER_NODES, strict_locals: DEFAULT_STRICT_LOCALS, herb_directives: DEFAULT_HERB_DIRECTIVES, iteration_nodes: DEFAULT_ITERATION_NODES, prism_nodes: DEFAULT_PRISM_NODES, prism_nodes_deep: DEFAULT_PRISM_NODES_DEEP, prism_program: DEFAULT_PRISM_PROGRAM, erb_openers: [], timeout: DEFAULT_TIMEOUT, max_errors: DEFAULT_MAX_ERRORS, arena_stats: DEFAULT_CAPTURE_ARENA_STATS)
+    #: (?strict: bool, ?track_whitespace: bool, ?track_locations: bool, ?analyze: bool, ?action_view_helpers: bool, ?transform_conditionals: bool, ?render_nodes: bool, ?strict_locals: bool, ?herb_directives: bool, ?iteration_nodes: bool, ?prism_nodes: bool, ?prism_nodes_deep: bool, ?prism_program: bool, ?html: bool, ?erb_openers: Array[String], ?timeout: Numeric) -> void
+    def initialize(strict: DEFAULT_STRICT, track_whitespace: DEFAULT_TRACK_WHITESPACE, track_locations: DEFAULT_TRACK_LOCATIONS, analyze: DEFAULT_ANALYZE, action_view_helpers: DEFAULT_ACTION_VIEW_HELPERS, transform_conditionals: DEFAULT_TRANSFORM_CONDITIONALS, render_nodes: DEFAULT_RENDER_NODES, strict_locals: DEFAULT_STRICT_LOCALS, herb_directives: DEFAULT_HERB_DIRECTIVES, iteration_nodes: DEFAULT_ITERATION_NODES, prism_nodes: DEFAULT_PRISM_NODES, prism_nodes_deep: DEFAULT_PRISM_NODES_DEEP, prism_program: DEFAULT_PRISM_PROGRAM, html: DEFAULT_HTML, erb_openers: [], timeout: DEFAULT_TIMEOUT, max_errors: DEFAULT_MAX_ERRORS, arena_stats: DEFAULT_CAPTURE_ARENA_STATS)
       @strict = strict
       @track_whitespace = track_whitespace
       @track_locations = track_locations
@@ -52,6 +54,7 @@ module Herb
       @prism_nodes = prism_nodes
       @prism_nodes_deep = prism_nodes_deep
       @prism_program = prism_program
+      @html = html
       @erb_openers = erb_openers
       @timeout = timeout
       @max_errors = max_errors
@@ -74,6 +77,7 @@ module Herb
         prism_nodes: @prism_nodes,
         prism_nodes_deep: @prism_nodes_deep,
         prism_program: @prism_program,
+        html: @html,
         erb_openers: @erb_openers,
         timeout: @timeout,
         max_errors: @max_errors,
@@ -97,6 +101,7 @@ module Herb
         "prism_nodes=#{@prism_nodes}\n  " \
         "prism_nodes_deep=#{@prism_nodes_deep}\n  " \
         "prism_program=#{@prism_program}\n  " \
+        "html=#{@html}\n  " \
         "erb_openers=#{@erb_openers.inspect}\n  " \
         "timeout=#{@timeout}\n  " \
         "max_errors=#{@max_errors}\n  " \

--- a/sig/herb/parser_options.rbs
+++ b/sig/herb/parser_options.rbs
@@ -28,6 +28,8 @@ module Herb
 
     attr_reader prism_nodes_deep: bool
 
+    attr_reader html: bool
+
     attr_reader erb_openers: Array[String]
 
     attr_reader timeout: Numeric
@@ -62,14 +64,16 @@ module Herb
 
     DEFAULT_PRISM_NODES_DEEP: bool
 
+    DEFAULT_HTML: bool
+
     DEFAULT_TIMEOUT: Numeric
 
     DEFAULT_MAX_ERRORS: Integer
 
     DEFAULT_CAPTURE_ARENA_STATS: bool
 
-    # : (?strict: bool, ?track_whitespace: bool, ?track_locations: bool, ?analyze: bool, ?action_view_helpers: bool, ?transform_conditionals: bool, ?render_nodes: bool, ?strict_locals: bool, ?herb_directives: bool, ?iteration_nodes: bool, ?prism_nodes: bool, ?prism_nodes_deep: bool, ?prism_program: bool, ?erb_openers: Array[String], ?timeout: Numeric) -> void
-    def initialize: (?strict: bool, ?track_whitespace: bool, ?track_locations: bool, ?analyze: bool, ?action_view_helpers: bool, ?transform_conditionals: bool, ?render_nodes: bool, ?strict_locals: bool, ?herb_directives: bool, ?iteration_nodes: bool, ?prism_nodes: bool, ?prism_nodes_deep: bool, ?prism_program: bool, ?erb_openers: Array[String], ?timeout: Numeric) -> void
+    # : (?strict: bool, ?track_whitespace: bool, ?track_locations: bool, ?analyze: bool, ?action_view_helpers: bool, ?transform_conditionals: bool, ?render_nodes: bool, ?strict_locals: bool, ?herb_directives: bool, ?iteration_nodes: bool, ?prism_nodes: bool, ?prism_nodes_deep: bool, ?prism_program: bool, ?html: bool, ?erb_openers: Array[String], ?timeout: Numeric) -> void
+    def initialize: (?strict: bool, ?track_whitespace: bool, ?track_locations: bool, ?analyze: bool, ?action_view_helpers: bool, ?transform_conditionals: bool, ?render_nodes: bool, ?strict_locals: bool, ?herb_directives: bool, ?iteration_nodes: bool, ?prism_nodes: bool, ?prism_nodes_deep: bool, ?prism_program: bool, ?html: bool, ?erb_openers: Array[String], ?timeout: Numeric) -> void
 
     # : () -> Hash[Symbol, (bool | Numeric | Array[String] | nil)]
     def to_h: () -> Hash[Symbol, bool | Numeric | Array[String] | nil]

--- a/test/parser/parser_options_test.rb
+++ b/test/parser/parser_options_test.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+module Parser
+  class ParserOptionsTest < Minitest::Spec
+    include SnapshotUtils
+
+    test "html is on by default" do
+      options = Herb::ParserOptions.new
+
+      assert_equal true, options.html
+      assert_equal true, options.to_h[:html]
+      assert_equal true, Herb.parse("<b>bold</b>").options.html
+    end
+
+    test "html false reaches the parse result" do
+      options = Herb::ParserOptions.new(html: false)
+
+      assert_equal false, options.html
+      assert_equal false, options.to_h[:html]
+      assert_snapshot_matches(options.inspect, "Herb::ParserOptions.new(html: false)")
+
+      result = Herb.parse("a <b", html: false)
+
+      assert_equal false, result.options.html
+      assert_instance_of Herb::AST::LiteralNode, result.value.children.first
+    end
+
+    test "to_h round-trips through Herb.parse" do
+      options = Herb::ParserOptions.new(html: false, strict: false)
+      result = Herb.parse("a <b", **options.to_h)
+
+      assert_equal false, result.options.html
+      assert_equal false, result.options.strict
+    end
+  end
+end

--- a/test/snapshots/parser/parser_options_test/test_0002_html_false_reaches_the_parse_result_6f518a29c55ff9baa847ab21e3c784ad.txt
+++ b/test/snapshots/parser/parser_options_test/test_0002_html_false_reaches_the_parse_result_6f518a29c55ff9baa847ab21e3c784ad.txt
@@ -1,0 +1,23 @@
+---
+source: "Parser::ParserOptionsTest#test_0002_html false reaches the parse result"
+input: "Herb::ParserOptions.new(html: false)"
+---
+#<Herb::ParserOptions
+  strict=true
+  track_whitespace=false
+  track_locations=true
+  analyze=true
+  action_view_helpers=false
+  transform_conditionals=false
+  render_nodes=false
+  strict_locals=false
+  herb_directives=false
+  iteration_nodes=false
+  prism_nodes=false
+  prism_nodes_deep=false
+  prism_program=false
+  html=false
+  erb_openers=[]
+  timeout=1
+  max_errors=25
+  arena_stats=false>


### PR DESCRIPTION
This pull request adds the parser's `html` option to the Ruby `Herb::ParserOptions` class.

The option has been in the C parser since #1434 and is declared in the JavaScript `ParserOptions`, the Ruby extension reads it, and `Herb.parse(source, html: false)` honors it, but the Ruby class never declared it. 