### PR TITLE
Only configure VS Code extension when `.vscode` exists

### DIFF
--- a/javascript/packages/linter/src/cli.ts
+++ b/javascript/packages/linter/src/cli.ts
@@ -211,7 +211,7 @@ export class CLI {
       }
 
       const config = await Config.loadForCLI(configPath, version, true)
-      const extensionAdded = addHerbExtensionRecommendation(this.projectPath)
+      const extensionAdded = existsSync(resolve(this.projectPath, ".vscode")) && addHerbExtensionRecommendation(this.projectPath)
 
       console.log(`\n✓ Configuration initialized at ${config.path}`)
 


### PR DESCRIPTION
## Summary

For developers not using VS Code, `herb --init` pollutes the repository with an unwanted file.

This change makes is so `.vscode/extensions.json` is only touched when the project already has a `.vscode/` directory.