### PR TITLE
Engine: Reach the report session from the fiber a render happens in

### DIFF
--- a/lib/herb/engine/report/session.rb
+++ b/lib/herb/engine/report/session.rb
@@ -20,13 +20,36 @@ module Herb
       # never has to guard its own calls.
       class Session
         STATE_KEY = :herb_engine_report_session #: Symbol
+        RACTOR_KEY = :herb_engine_report_session_ractor #: Symbol
+        THREAD_KEY = :herb_engine_report_session_thread #: Symbol
 
         attr_reader :report #: Herb::Engine::Report
         attr_reader :previous #: Session?
 
+        #: () -> Session?
+        def self.stored
+          return nil unless Fiber[RACTOR_KEY].equal?(Ractor.current)
+          return nil unless Fiber[THREAD_KEY] == Thread.current.object_id
+
+          Fiber[STATE_KEY]
+        end
+
+        #: (Session?) -> void
+        def self.store(session)
+          Fiber[STATE_KEY] = session
+          Fiber[RACTOR_KEY] = session && Ractor.current
+          Fiber[THREAD_KEY] = session && Thread.current.object_id
+
+          nil
+        end
+
         #: () -> Session
         def self.current
-          Thread.current[STATE_KEY] ||= new
+          session = stored || new
+
+          store(session)
+
+          session
         end
 
         #: [T] () { () -> T } -> Session
@@ -42,18 +65,18 @@ module Herb
 
         #: () -> Session
         def self.open
-          session = new(scoped: true, previous: Thread.current[STATE_KEY])
+          session = new(scoped: true, previous: stored)
 
-          Thread.current[STATE_KEY] = session
+          store(session)
 
           session
         end
 
         #: () -> Session?
         def self.close
-          session = Thread.current[STATE_KEY]
+          session = stored
 
-          Thread.current[STATE_KEY] = session.is_a?(Session) ? session.previous : nil
+          store(session&.previous)
 
           session
         end
@@ -139,7 +162,9 @@ module Herb
 
         #: () -> void
         def self.reset!
-          Thread.current[STATE_KEY] = nil
+          store(nil)
+
+          nil
         end
 
         #: (?scoped: bool, ?report: Herb::Engine::Report?, ?previous: Session?) -> void

--- a/sig/herb/engine/report/session.rbs
+++ b/sig/herb/engine/report/session.rbs
@@ -17,9 +17,19 @@ module Herb
       class Session
         STATE_KEY: Symbol
 
+        RACTOR_KEY: Symbol
+
+        THREAD_KEY: Symbol
+
         attr_reader report: Herb::Engine::Report
 
         attr_reader previous: Session?
+
+        # : () -> Session?
+        def self.stored: () -> Session?
+
+        # : (Session?) -> void
+        def self.store: (Session?) -> void
 
         # : () -> Session
         def self.current: () -> Session

--- a/test/engine/report/session_test.rb
+++ b/test/engine/report/session_test.rb
@@ -132,6 +132,54 @@ module Engine
       assert_equal 1, Herb::Engine::Report::Session.current.diagnostics.length
     end
 
+    test "a thread spawned while a session is open records into its own" do
+      session = Herb::Engine::Report::Session.open
+
+      Thread.new { Herb::Engine::Report::Session.record(diagnostic(code: "background")) }.join
+
+      assert_empty session.diagnostics
+    end
+
+    test "reaches a render happening in a fiber, the way a streaming response renders" do
+      session = Herb::Engine::Report::Session.open
+
+      Fiber.new { Herb::Engine::Report::Session.record(diagnostic(code: "streamed")) }.resume
+
+      assert_equal ["streamed"], session.diagnostics.map(&:code)
+      refute_predicate session, :empty?
+    end
+
+    test "a session opened inside a fiber does not escape it" do
+      session = Herb::Engine::Report::Session.open
+
+      Fiber.new { Herb::Engine::Report::Session.open }.resume
+
+      assert_same session, Herb::Engine::Report::Session.current
+    end
+
+    test "a ractor collects into its own, even reaching the one in fiber storage" do
+      session = Herb::Engine::Report::Session.open
+      Herb::Engine::Report::Session.record(diagnostic(code: "main"))
+
+      ractor = Ractor.new do
+        klass = Herb::Engine::Report::Session
+
+        reached = !Fiber[klass::STATE_KEY].nil?
+        refused = klass.stored.nil?
+
+        klass.record(Herb::Diagnostic.new(template: "app/views/a.html.erb", message: "m", code: "ractor"))
+
+        [reached, refused, klass.current.diagnostics.map(&:code)]
+      end
+
+      reached, refused, collected = ractor.value
+
+      assert reached, "expected fiber storage to still be inherited into the ractor"
+      assert refused, "expected the inherited session to be refused"
+      assert_equal ["ractor"], collected
+      assert_equal ["main"], session.diagnostics.map(&:code)
+    end
+
     describe "attributing what happens to the tag that caused it" do
       def session_with_frames
         Herb::Engine::Report::Session.capture do


### PR DESCRIPTION
This pull request fixes `Herb::Engine::Report::Session` never being found by a render that happens inside a fiber. `Session` keeps the open session in `Thread.current[]`, which is fiber-local storage and not thread-local:

```ruby
Thread.current[:key] = "outer"

Fiber.new { Thread.current[:key] }.resume #=> nil
```

`ActionView::StreamingTemplateRenderer#delayed_render` wraps the whole layout-and-template render in a `Fiber`, so a render there never sees the session `Report::Middleware` opened. It builds a throwaway one that nobody reads, and because the middleware's session stays `empty?` the middleware returns early and injects nothing at all.

The session now lives in `Fiber.storage`, which a child fiber inherits, so a render reaches the session whatever fiber it runs in.