### PR TITLE
Engine: Give the report channels for what a page collects

### DIFF
--- a/docs/docs/projects/engine.md
+++ b/docs/docs/projects/engine.md
@@ -824,6 +824,39 @@ Wrapping a request works too. A session that is already open is one somebody mea
 session = Herb::Engine::Report::Session.capture { get "/posts" }
 ```
 
+### Delivering something other than diagnostics
+
+Diagnostics are not the only thing a page collects. A `Herb::Engine::Report` also keeps **channels**, which is where a producer other than the compiler puts what it found, and it knows nothing about what any of them hold.
+
+A channel is anything answering three methods:
+
+| Method     | Returns  | Description                                                        |
+|------------|----------|--------------------------------------------------------------------|
+| `empty?`   | `bool`   | Whether it collected anything. An empty channel is never written.  |
+| `to_html`  | `String` | The markup to put on the page.                                     |
+| `anchor`   | `Symbol` | `:head` or `:body`, the tag it wants to be written before.         |
+
+The block builds one the first time its name is asked for, so a producer registers itself as it records and nothing has to be wired up in advance:
+
+```ruby
+Herb::Engine::Report::Session.current.channel(:query_log) { QueryLog.new }.add(sql)
+```
+
+A channel that collects queries and writes them at the end of the body looks like this:
+
+```ruby
+class QueryLog
+  def initialize = @queries = []
+  def add(sql) = @queries << sql
+
+  def anchor = :body
+  def empty? = @queries.empty?
+  def to_html = %(<script type="application/json" data-query-log>#{JSON.generate(@queries)}</script>)
+end
+```
+
+The middleware writes every non-empty channel before the tag it asked for, and a channel asking for a tag the response does not have is left alone. Adding a producer needs nothing in `Report`, `Session`, or `Middleware`.
+
 ## Instrumentation <Badge type="warning" text="experimental" />
 
 `InstrumentationVisitor` frames every ERB tag with a call saying which tag is rendering, so whatever happens while it renders can be attributed to it rather than to the template as a whole.

--- a/lib/herb/engine/report.rb
+++ b/lib/herb/engine/report.rb
@@ -32,6 +32,17 @@ module Herb
         @sources = {} #: Hash[String, String]
         @nodes = {} #: Hash[String, Hash[String, Hash[Symbol, untyped]]]
         @render_tree = [] #: Array[Hash[Symbol, untyped]]
+        @channels = {} #: Hash[Symbol, untyped]
+      end
+
+      #: (Symbol) { () -> untyped } -> untyped
+      def channel(name, &build)
+        @channels[name] ||= build.call
+      end
+
+      #: () -> Array[untyped]
+      def channels
+        @channels.each_value.reject(&:empty?)
       end
 
       #: (Herb::Diagnostic) -> Herb::Diagnostic
@@ -91,7 +102,12 @@ module Herb
 
       #: () -> bool
       def empty?
-        @diagnostics.empty? && @nodes.empty?
+        !reportable? && channels.empty?
+      end
+
+      #: () -> bool
+      def reportable?
+        !(@diagnostics.empty? && @nodes.empty?)
       end
 
       #: () -> Hash[Symbol, untyped]

--- a/lib/herb/engine/report/middleware.rb
+++ b/lib/herb/engine/report/middleware.rb
@@ -19,6 +19,8 @@ module Herb
       class Middleware
         HTML_CONTENT_TYPE = %r{\Atext/html}i #: Regexp
         BODY_END_TAG = %r{</body>}i #: Regexp
+        HEAD_END_TAG = %r{</head>}i #: Regexp
+        ANCHORS = { head: HEAD_END_TAG, body: BODY_END_TAG }.freeze #: Hash[Symbol, Regexp]
 
         # Where the session for this request is left, so that anything holding the env can read what
         # the page collected.
@@ -63,15 +65,38 @@ module Herb
           html = read(body)
 
           return response unless html
-          return response unless html.match?(BODY_END_TAG)
 
-          html = html.sub(BODY_END_TAG) { |tag| "#{report.to_html}#{tag}" }
+          injected = inject_channels(html, report)
+          injected = inject_report(injected, report)
 
-          set_content_length(headers, html)
+          return response if injected.equal?(html)
 
-          [status, headers, [html]]
+          set_content_length(headers, injected)
+
+          [status, headers, [injected]]
         rescue StandardError
           response
+        end
+
+        #: (String, Herb::Engine::Report) -> String
+        def inject_channels(html, report)
+          report.channels.reduce(html) do |carried, channel|
+            tag = ANCHORS[channel.anchor]
+            markup = channel.to_html
+
+            next carried if tag.nil? || markup.empty?
+            next carried unless carried.match?(tag)
+
+            carried.sub(tag) { |matched| "#{markup}#{matched}" }
+          end
+        end
+
+        #: (String, Herb::Engine::Report) -> String
+        def inject_report(html, report)
+          return html unless report.reportable?
+          return html unless html.match?(BODY_END_TAG)
+
+          html.sub(BODY_END_TAG) { |tag| "#{report.to_html}#{tag}" }
         end
 
         #: (untyped) -> bool

--- a/lib/herb/engine/report/session.rb
+++ b/lib/herb/engine/report/session.rb
@@ -193,6 +193,11 @@ module Herb
           report.source(template, source)
         end
 
+        #: (Symbol) { () -> untyped } -> untyped
+        def channel(name, &)
+          report.channel(name, &)
+        end
+
         #: () -> Array[Herb::Diagnostic]
         def diagnostics
           report.diagnostics

--- a/sig/herb/engine/report.rbs
+++ b/sig/herb/engine/report.rbs
@@ -27,6 +27,12 @@ module Herb
       # : (?max_diagnostics: Integer) -> void
       def initialize: (?max_diagnostics: Integer) -> void
 
+      # : (Symbol) { () -> untyped } -> untyped
+      def channel: (Symbol) { () -> untyped } -> untyped
+
+      # : () -> Array[untyped]
+      def channels: () -> Array[untyped]
+
       # : (Herb::Diagnostic) -> Herb::Diagnostic
       def add: (Herb::Diagnostic) -> Herb::Diagnostic
 
@@ -47,6 +53,9 @@ module Herb
 
       # : () -> bool
       def empty?: () -> bool
+
+      # : () -> bool
+      def reportable?: () -> bool
 
       # : () -> Hash[Symbol, untyped]
       def to_h: () -> Hash[Symbol, untyped]

--- a/sig/herb/engine/report/middleware.rbs
+++ b/sig/herb/engine/report/middleware.rbs
@@ -18,6 +18,10 @@ module Herb
 
         BODY_END_TAG: Regexp
 
+        HEAD_END_TAG: Regexp
+
+        ANCHORS: Hash[Symbol, Regexp]
+
         # Where the session for this request is left, so that anything holding the env can read what
         # the page collected.
         #
@@ -36,6 +40,12 @@ module Herb
 
         # : (untyped, Herb::Engine::Report) -> untyped
         def inject: (untyped, Herb::Engine::Report) -> untyped
+
+        # : (String, Herb::Engine::Report) -> String
+        def inject_channels: (String, Herb::Engine::Report) -> String
+
+        # : (String, Herb::Engine::Report) -> String
+        def inject_report: (String, Herb::Engine::Report) -> String
 
         # : (untyped) -> bool
         def html?: (untyped) -> bool

--- a/sig/herb/engine/report/session.rbs
+++ b/sig/herb/engine/report/session.rbs
@@ -99,6 +99,9 @@ module Herb
         # : (String, String?) -> void
         def source: (String, String?) -> void
 
+        # : (Symbol) { () -> untyped } -> untyped
+        def channel: (Symbol) { () -> untyped } -> untyped
+
         # : () -> Array[Herb::Diagnostic]
         def diagnostics: () -> Array[Herb::Diagnostic]
 

--- a/test/engine/report/middleware_test.rb
+++ b/test/engine/report/middleware_test.rb
@@ -14,6 +14,18 @@ module Engine
       Herb::Engine::Report::Session.reset!
     end
 
+    class Marker
+      def initialize(anchor, entry)
+        @anchor = anchor
+        @entry = entry
+      end
+
+      attr_reader :anchor #: Symbol
+
+      def empty? = false
+      def to_html = "<!--#{@entry}-->"
+    end
+
     def diagnostic(message: "Something is wrong.")
       Herb::Diagnostic.new(
         template: "app/views/a.html.erb",
@@ -195,6 +207,65 @@ module Engine
 
       assert_includes body_of(first), "first"
       refute_includes body_of(second), "first"
+    end
+
+    DOCUMENT = "<html><head><title>t</title></head><body><h1>Hello</h1></body></html>"
+
+    describe "channels" do
+      def respond_with(document = DOCUMENT, &collect)
+        app = lambda { |_env|
+          collect&.call
+
+          [200, { "content-type" => "text/html" }, [document]]
+        }
+
+        Herb::Engine::Report::Middleware.new(app).call({}).last.first
+      end
+
+      test "writes a channel before the tag it asked for" do
+        html = respond_with do
+          Herb::Engine::Report::Session.current.channel(:head) { Marker.new(:head, "h") }
+        end
+
+        assert_equal "<html><head><title>t</title><!--h--></head><body><h1>Hello</h1></body></html>", html
+      end
+
+      test "writes a body channel before the closing body tag" do
+        html = respond_with do
+          Herb::Engine::Report::Session.current.channel(:body) { Marker.new(:body, "b") }
+        end
+
+        assert_equal "<html><head><title>t</title></head><body><h1>Hello</h1><!--b--></body></html>", html
+      end
+
+      test "writes every channel it was given" do
+        html = respond_with do
+          Herb::Engine::Report::Session.current.channel(:head) { Marker.new(:head, "h") }
+          Herb::Engine::Report::Session.current.channel(:body) { Marker.new(:body, "b") }
+        end
+
+        assert_equal "<html><head><title>t</title><!--h--></head><body><h1>Hello</h1><!--b--></body></html>", html
+      end
+
+      test "leaves a channel alone when the response has no tag for it" do
+        html = respond_with("<div>no document here</div>") do
+          Herb::Engine::Report::Session.current.channel(:head) { Marker.new(:head, "h") }
+        end
+
+        assert_equal "<div>no document here</div>", html
+      end
+
+      test "leaves a channel alone when it asked for a tag nobody writes before" do
+        html = respond_with do
+          Herb::Engine::Report::Session.current.channel(:nowhere) { Marker.new(:nowhere, "n") }
+        end
+
+        assert_equal DOCUMENT, html
+      end
+
+      test "returns the response untouched when nothing collected" do
+        assert_equal DOCUMENT, respond_with
+      end
     end
   end
 end

--- a/test/engine/report/session_test.rb
+++ b/test/engine/report/session_test.rb
@@ -565,5 +565,13 @@ module Engine
         refute_predicate session, :empty?
       end
     end
+
+    test "hands a channel through to the report it is collecting into" do
+      session = Herb::Engine::Report::Session.open
+      channel = Object.new
+
+      assert_same channel, session.channel(:thing) { channel }
+      assert_same channel, session.report.channel(:thing) { Object.new }
+    end
   end
 end

--- a/test/engine/report_test.rb
+++ b/test/engine/report_test.rb
@@ -4,6 +4,19 @@ require_relative "../test_helper"
 
 module Engine
   class ReportTest < Minitest::Spec
+    class Marker
+      attr_reader :entries, :anchor #: Array[String]
+
+      def initialize(anchor = :body)
+        @anchor = anchor
+        @entries = []
+      end #: Symbol
+
+      def add(entry) = @entries << entry
+      def empty? = @entries.empty?
+      def to_html = "<!--#{@entries.join(",")}-->"
+    end
+
     def report
       @report ||= Herb::Engine::Report.new
     end
@@ -154,6 +167,60 @@ module Engine
 
         assert_equal "https://herb-tools.dev/diagnostics/x", entry["docs_url"]
         refute entry.key?("docsUrl")
+      end
+    end
+
+    describe "channels" do
+      test "builds a channel the first time its name is asked for" do
+        built = 0
+
+        2.times do
+          report.channel(:marker) do
+            built += 1
+
+            Marker.new
+          end
+        end
+
+        assert_equal 1, built
+      end
+
+      test "answers the same channel every time" do
+        assert_same report.channel(:marker) { Marker.new }, report.channel(:marker) { Marker.new }
+      end
+
+      test "keeps a channel for each name" do
+        report.channel(:one) { Marker.new }.add("a")
+        report.channel(:two) { Marker.new }.add("b")
+
+        assert_equal 2, report.channels.length
+      end
+
+      test "leaves out a channel that collected nothing" do
+        report.channel(:empty) { Marker.new }
+        report.channel(:filled) { Marker.new }.add("a")
+
+        assert_equal ["<!--a-->"], report.channels.map(&:to_html)
+      end
+
+      test "is empty while every channel is" do
+        report.channel(:marker) { Marker.new }
+
+        assert_predicate report, :empty?
+
+        report.channel(:marker) { Marker.new }.add("a")
+
+        refute_predicate report, :empty?
+      end
+
+      test "a channel does not make it reportable, which is about diagnostics" do
+        report.channel(:marker) { Marker.new }.add("a")
+
+        refute_predicate report, :reportable?
+      end
+
+      test "knows nothing about what a channel holds" do
+        assert_empty Herb::Engine::Report.instance_methods(false).grep(/marker/)
       end
     end
   end


### PR DESCRIPTION
This pull request adds channels to `Herb::Engine::Report`, so a producer other than the compiler can put markup on a page without `Report`, `Session`, or `Middleware` knowing what it holds.

Diagnostics are the only thing the report delivers to the browser today, through one `data-herb-diagnostics` script tag. Scoped styles, and anything after them, need to put their own markup on the page too. A one-off path for each would mean teaching `Report` about every producer. A channel is the general version of that.

The block builds one the first time its name is asked for, so a producer registers itself as it records and nothing has to be wired up in advance:

```ruby
report.channel(:query_log) { QueryLog.new }.add(sql)
```

`Middleware` writes every non-empty channel before the tag it asked for, and a channel asking for a tag the response does not have is left alone.

```ruby
class QueryLog
  def initialize = @queries = []
  def add(sql) = @queries << sql

  def anchor = :body
  def empty? = @queries.empty?
  def to_html = %(<script type="application/json" data-query-log>#{JSON.generate(@queries)}</script>)
end
```

```html
<html><head></head><body>page<script type="application/json" data-query-log>["SELECT 1","SELECT 2"]</script></body></html>
```

In a follow-up pull request, we should probably also refactor the current diagnostics to also collect and deliver of a channel.