### PR TITLE
Engine: Report what a `<style scoped>` transform could not do

### DIFF
--- a/docs/docs/projects/engine.md
+++ b/docs/docs/projects/engine.md
@@ -800,7 +800,7 @@ Herb::Engine.new(source, filename: path, visitors: [
 
 The `herb compile --scoped-styles` and `herb render --scoped-styles` commands wire the same thing up from the command line, installing `lightningcss` the first time if it is not already there.
 
-Given no `transform`, the block is left as it was written and a diagnostic reports it, because scoping the markup while leaving the CSS untouched would turn a scoped block into a global one. The same holds for a block built with ERB, which has no CSS to read at compile time, and for a template compiled without a `filename`, which has no stable scope to derive.
+Given no `transform`, the block is left as it was written and a diagnostic reports it, because scoping the markup while leaving the CSS untouched would turn a scoped block into a global one. The same holds for a block built with ERB, which has no CSS to read at compile time, and for a template compiled without a `filename`, which has no stable scope to derive. A `transform` that raises is treated the same way, so CSS nobody can read costs the block it was written in and not the whole template.
 
 `deliver` says where the narrowed CSS goes.
 

--- a/docs/docs/projects/engine.md
+++ b/docs/docs/projects/engine.md
@@ -831,6 +831,8 @@ transform.call(".title { color: red }", scope: "[data-herb-scope-1a2b3c4d]")
 #=> ".title[data-herb-scope-1a2b3c4d] { color: red }"
 ```
 
+A return value answering `warnings` has each of them reported as a diagnostic, which is how a `LightningCSS::Result` surfaces what Lightning CSS kept without acting on. CSS a transform could not act on is CSS that does nothing once the page renders, so it is worth saying so at compile time. A transform answering with a plain string reports nothing.
+
 #### Gathering the CSS ahead of time
 
 A scope and its CSS are decided when a file is compiled, so everything a stylesheet needs is knowable before anything renders. `ScopedStyle::Collector` compiles a set of files for that and nothing else:

--- a/lib/herb/engine/scoped_style/visitor.rb
+++ b/lib/herb/engine/scoped_style/visitor.rb
@@ -45,6 +45,9 @@ module Herb
       #     transform.call(".title { color: red }", scope: "[data-herb-scope-1a2b3c4d]")
       #     #=> ".title[data-herb-scope-1a2b3c4d] { color: red }"
       #
+      # Anything the return value answers to `warnings` is reported, because CSS a transform kept
+      # without acting on it is CSS that does nothing once the page is rendered.
+      #
       # `LightningCSS::Transformer` answers that, so it can be handed over as it is:
       #
       #     Herb::Engine::ScopedStyle::Visitor.new(transform: LightningCSS::Transformer.new(minify: true))
@@ -297,7 +300,11 @@ module Herb
 
         #: (Pending, String) -> String?
         def narrowed_css(pending, scope)
-          @transform.call(pending.css, scope: scope_selector(pending.file, scope)).to_s
+          result = @transform.call(pending.css, scope: scope_selector(pending.file, scope))
+
+          warned_style(pending.node, result)
+
+          result.to_s
         rescue StandardError => e
           untransformable_style(pending.node, e)
         end
@@ -429,6 +436,21 @@ module Herb
             node.location,
             code: "scoped-style-that-could-not-be-narrowed"
           )
+
+          nil
+        end
+
+        #: (Herb::AST::HTMLElementNode, untyped) -> void
+        def warned_style(node, result)
+          return unless result.respond_to?(:warnings)
+
+          result.warnings.each do |message|
+            warning(
+              "The `transform` could not act on something in this `<style scoped>` block, so that part of the CSS was kept as it was written and does nothing. It reported `#{message}`.",
+              node.location,
+              code: "scoped-style-with-a-warning"
+            )
+          end
 
           nil
         end

--- a/lib/herb/engine/scoped_style/visitor.rb
+++ b/lib/herb/engine/scoped_style/visitor.rb
@@ -56,7 +56,9 @@ module Herb
       #     scope: ":where([data-herb-scope-1a2b3c4d], [data-herb-scope-1a2b3c4d] *)"
       #
       # Without one, a block is left exactly as it was written and reported. Scoping the markup while
-      # leaving the CSS alone would turn a scoped block into a global one.
+      # leaving the CSS alone would turn a scoped block into a global one. A `transform` that raises
+      # is treated the same way, so CSS nobody can read costs the block it was written in and not the
+      # whole template.
       #
       # `deliver` says where the narrowed CSS goes. `:inline` leaves the block where it was written,
       # which needs nothing else installed and writes the block again on every render of the file it
@@ -279,13 +281,25 @@ module Herb
         def narrow
           @pending.each do |pending|
             scope = @scopes[pending.file] #: as String
-            narrowed = @transform.call(pending.css, scope: scope_selector(pending.file, scope)).to_s
+            narrowed = narrowed_css(pending, scope)
+
+            next unless narrowed
+
             place(pending, scope, narrowed)
 
             @styles[scope] = narrowed
           end
 
+          @scopes.delete_if { |_file, scope| !@styles.key?(scope) }
+
           nil
+        end
+
+        #: (Pending, String) -> String?
+        def narrowed_css(pending, scope)
+          @transform.call(pending.css, scope: scope_selector(pending.file, scope)).to_s
+        rescue StandardError => e
+          untransformable_style(pending.node, e)
         end
 
         #: (Pending, String, String) -> void
@@ -403,6 +417,17 @@ module Herb
             "A `<style scoped>` block was found, and #{self.class.name} was given no `transform` to narrow its selectors with, so it was left as it was written and still applies to the whole page.",
             node.location,
             code: "scoped-style-without-a-transform"
+          )
+
+          nil
+        end
+
+        #: (Herb::AST::HTMLElementNode, StandardError) -> nil
+        def untransformable_style(node, error)
+          warning(
+            "A `<style scoped>` block could not be narrowed by the `transform` #{self.class.name} was given, so it was left as it was written and still applies to the whole page. It failed with `#{error.message}`.",
+            node.location,
+            code: "scoped-style-that-could-not-be-narrowed"
           )
 
           nil

--- a/sig/herb/engine/scoped_style/visitor.rbs
+++ b/sig/herb/engine/scoped_style/visitor.rbs
@@ -47,7 +47,9 @@ module Herb
       #     scope: ":where([data-herb-scope-1a2b3c4d], [data-herb-scope-1a2b3c4d] *)"
       #
       # Without one, a block is left exactly as it was written and reported. Scoping the markup while
-      # leaving the CSS alone would turn a scoped block into a global one.
+      # leaving the CSS alone would turn a scoped block into a global one. A `transform` that raises
+      # is treated the same way, so CSS nobody can read costs the block it was written in and not the
+      # whole template.
       #
       # `deliver` says where the narrowed CSS goes. `:inline` leaves the block where it was written,
       # which needs nothing else installed and writes the block again on every render of the file it
@@ -146,6 +148,9 @@ module Herb
         # : () -> void
         def narrow: () -> void
 
+        # : (Pending, String) -> String?
+        def narrowed_css: (Pending, String) -> String?
+
         # : (Pending, String, String) -> void
         def place: (Pending, String, String) -> void
 
@@ -175,6 +180,9 @@ module Herb
 
         # : (Herb::AST::HTMLElementNode) -> void
         def untransformed_style: (Herb::AST::HTMLElementNode) -> void
+
+        # : (Herb::AST::HTMLElementNode, StandardError) -> nil
+        def untransformable_style: (Herb::AST::HTMLElementNode, StandardError) -> nil
 
         # : (String, String) -> String
         def scope_selector: (String, String) -> String

--- a/sig/herb/engine/scoped_style/visitor.rbs
+++ b/sig/herb/engine/scoped_style/visitor.rbs
@@ -36,6 +36,9 @@ module Herb
       #     transform.call(".title { color: red }", scope: "[data-herb-scope-1a2b3c4d]")
       #     #=> ".title[data-herb-scope-1a2b3c4d] { color: red }"
       #
+      # Anything the return value answers to `warnings` is reported, because CSS a transform kept
+      # without acting on it is CSS that does nothing once the page is rendered.
+      #
       # `LightningCSS::Transformer` answers that, so it can be handed over as it is:
       #
       #     Herb::Engine::ScopedStyle::Visitor.new(transform: LightningCSS::Transformer.new(minify: true))
@@ -183,6 +186,9 @@ module Herb
 
         # : (Herb::AST::HTMLElementNode, StandardError) -> nil
         def untransformable_style: (Herb::AST::HTMLElementNode, StandardError) -> nil
+
+        # : (Herb::AST::HTMLElementNode, untyped) -> void
+        def warned_style: (Herb::AST::HTMLElementNode, untyped) -> void
 
         # : (String, String) -> String
         def scope_selector: (String, String) -> String

--- a/test/engine/scoped_style/lightningcss_test.rb
+++ b/test/engine/scoped_style/lightningcss_test.rb
@@ -67,5 +67,9 @@ module Engine
 
       assert_compiled_snapshot(source, options(deliver: :hoist))
     end
+
+    test "leaves a block it could not parse as it was written, instead of raising" do
+      assert_compiled_snapshot(%(<style scoped>!!! { color: red }</style><h1>Hi</h1>), options)
+    end
   end
 end

--- a/test/engine/scoped_style/lightningcss_test.rb
+++ b/test/engine/scoped_style/lightningcss_test.rb
@@ -71,5 +71,9 @@ module Engine
     test "leaves a block it could not parse as it was written, instead of raising" do
       assert_compiled_snapshot(%(<style scoped>!!! { color: red }</style><h1>Hi</h1>), options)
     end
+
+    test "reports what Lightning CSS kept without acting on" do
+      assert_compiled_snapshot(%(<style scoped>.a:deep(.b) { color: red }</style><h1>Hi</h1>), options)
+    end
   end
 end

--- a/test/engine/scoped_style/visitor_test.rb
+++ b/test/engine/scoped_style/visitor_test.rb
@@ -31,6 +31,14 @@ module Engine
       end
     end
 
+    class RaisingTransform
+      def call(css, **)
+        raise ArgumentError, "no idea what to do with that" if css.include?("!!!")
+
+        "#{css}/* narrowed */"
+      end
+    end
+
     def options(transform: Transform.new, filename: TEMPLATE, visitors: [], deliver: :inline, **overrides)
       visitor = Herb::Engine::ScopedStyle::Visitor.new(transform: transform, deliver: deliver)
 
@@ -267,6 +275,29 @@ module Engine
 
         assert_equal 0, response.first.scan("<style").length
       end
+    end
+
+    test "leaves a block alone, and the file unattributed, when the transform could not narrow it" do
+      settings = options(transform: RaisingTransform.new)
+
+      assert_compiled_snapshot(%(<style scoped>!!! { color: red; }</style><h1>Hi</h1>), settings)
+
+      visitor = settings[:visitors].last
+
+      assert_equal ["scoped-style-that-could-not-be-narrowed"], visitor.diagnostics.map(&:code)
+      assert_empty visitor.styles
+    end
+
+    test "scopes the file all the same when one block narrowed and another could not" do
+      source = %(<style scoped>.a { color: red; }</style><style scoped>!!! {}</style><h1 class="a">Hi</h1>)
+      settings = options(transform: RaisingTransform.new)
+
+      assert_compiled_snapshot(source, settings)
+
+      visitor = settings[:visitors].last
+
+      assert_equal ["scoped-style-that-could-not-be-narrowed"], visitor.diagnostics.map(&:code)
+      assert_equal 1, visitor.styles.size
     end
 
     test "visitor is not loaded when only requiring herb" do

--- a/test/engine/scoped_style/visitor_test.rb
+++ b/test/engine/scoped_style/visitor_test.rb
@@ -39,6 +39,18 @@ module Engine
       end
     end
 
+    class WarningTransform
+      Narrowed = Data.define(:css, :warnings) do
+        def to_s
+          css
+        end
+      end
+
+      def call(css, **)
+        Narrowed.new(css: "#{css}/* narrowed */", warnings: ["it kept `:deep()` without acting on it"])
+      end
+    end
+
     def options(transform: Transform.new, filename: TEMPLATE, visitors: [], deliver: :inline, **overrides)
       visitor = Herb::Engine::ScopedStyle::Visitor.new(transform: transform, deliver: deliver)
 
@@ -297,6 +309,17 @@ module Engine
       visitor = settings[:visitors].last
 
       assert_equal ["scoped-style-that-could-not-be-narrowed"], visitor.diagnostics.map(&:code)
+      assert_equal 1, visitor.styles.size
+    end
+
+    test "reports what the transform kept but could not act on" do
+      settings = options(transform: WarningTransform.new)
+
+      assert_compiled_snapshot(%(<style scoped>.a:deep(.b) { color: red; }</style><h1>Hi</h1>), settings)
+
+      visitor = settings[:visitors].last
+
+      assert_equal ["scoped-style-with-a-warning"], visitor.diagnostics.map(&:code)
       assert_equal 1, visitor.styles.size
     end
 

--- a/test/snapshots/engine/scoped_style_lightning_css_test/test_0009_leaves_a_block_it_could_not_parse_as_it_was_written,_instead_of_raising_c667415b043aa22a29267c6a5530c7ed.txt
+++ b/test/snapshots/engine/scoped_style_lightning_css_test/test_0009_leaves_a_block_it_could_not_parse_as_it_was_written,_instead_of_raising_c667415b043aa22a29267c6a5530c7ed.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::ScopedStyleLightningCSSTest#test_0009_leaves a block it could not parse as it was written, instead of raising"
+input: "{source: \"<style scoped>!!! { color: red }</style><h1>Hi</h1>\", options: {filename: \"app/views/posts/index.html.erb\", project_path: \"test/fixtures/scoped_styles\", escape: false, visitors: [#<Herb::Engine::ScopedStyle::Visitor transform=LightningCSS::Transformer>]}}"
+---
+_buf = ::String.new; ::Herb::Engine::Report::Session.record_compile_diagnostics("app/views/posts/index.html.erb", [{ message: "A `<style scoped>` block could not be narrowed by the `transform` Herb::Engine::ScopedStyle::Visitor was given, so it was left as it was written and still applies to the whole page. It failed with `Invalid empty selector at :0:1`.", severity: :warning, code: "scoped-style-that-could-not-be-narrowed", origin: "Herb Compiler", line: 1, column: 0, end_line: 1, end_column: 40 }].freeze); _buf << '<style scoped>!!! { color: red }</style><h1>Hi</h1>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/scoped_style_lightning_css_test/test_0010_reports_what_Lightning_CSS_kept_without_acting_on_ce1b0d2fabda2464ac8868ad968a76a0.txt
+++ b/test/snapshots/engine/scoped_style_lightning_css_test/test_0010_reports_what_Lightning_CSS_kept_without_acting_on_ce1b0d2fabda2464ac8868ad968a76a0.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::ScopedStyleLightningCSSTest#test_0010_reports what Lightning CSS kept without acting on"
+input: "{source: \"<style scoped>.a:deep(.b) { color: red }</style><h1>Hi</h1>\", options: {filename: \"app/views/posts/index.html.erb\", project_path: \"test/fixtures/scoped_styles\", escape: false, visitors: [#<Herb::Engine::ScopedStyle::Visitor transform=LightningCSS::Transformer>]}}"
+---
+_buf = ::String.new; ::Herb::Engine::Report::Session.record_compile_diagnostics("app/views/posts/index.html.erb", [{ message: "The `transform` could not act on something in this `<style scoped>` block, so that part of the CSS was kept as it was written and does nothing. It reported `'deep' is not recognized as a valid pseudo-class. Did you mean '::deep' (pseudo-element) or is this a typo? at :0:9`.", severity: :warning, code: "scoped-style-with-a-warning", origin: "Herb Compiler", line: 1, column: 0, end_line: 1, end_column: 48 }].freeze); _buf << '<style>.a:deep(.b):where([data-herb-scope-2940ba8a],[data-herb-scope-2940ba8a] *){color:red}</style><h1 data-herb-scope-2940ba8a>Hi</h1>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/scoped_style_visitor_test/test_0024_leaves_a_block_alone,_and_the_file_unattributed,_when_the_transform_could_not_narrow_it_1ef3317d18e708a41971231743997387.txt
+++ b/test/snapshots/engine/scoped_style_visitor_test/test_0024_leaves_a_block_alone,_and_the_file_unattributed,_when_the_transform_could_not_narrow_it_1ef3317d18e708a41971231743997387.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::ScopedStyleVisitorTest#test_0024_leaves a block alone, and the file unattributed, when the transform could not narrow it"
+input: "{source: \"<style scoped>!!! { color: red; }</style><h1>Hi</h1>\", options: {filename: \"app/views/posts/index.html.erb\", escape: false, visitors: [#<Herb::Engine::ScopedStyle::Visitor transform=Engine::ScopedStyleVisitorTest::RaisingTransform>]}}"
+---
+_buf = ::String.new; ::Herb::Engine::Report::Session.record_compile_diagnostics("app/views/posts/index.html.erb", [{ message: "A `<style scoped>` block could not be narrowed by the `transform` Herb::Engine::ScopedStyle::Visitor was given, so it was left as it was written and still applies to the whole page. It failed with `no idea what to do with that`.", severity: :warning, code: "scoped-style-that-could-not-be-narrowed", origin: "Herb Compiler", line: 1, column: 0, end_line: 1, end_column: 41 }].freeze); _buf << '<style scoped>!!! { color: red; }</style><h1>Hi</h1>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/scoped_style_visitor_test/test_0025_scopes_the_file_all_the_same_when_one_block_narrowed_and_another_could_not_d0d7463aaadd1ebc53d4e2889526f6a0.txt
+++ b/test/snapshots/engine/scoped_style_visitor_test/test_0025_scopes_the_file_all_the_same_when_one_block_narrowed_and_another_could_not_d0d7463aaadd1ebc53d4e2889526f6a0.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::ScopedStyleVisitorTest#test_0025_scopes the file all the same when one block narrowed and another could not"
+input: "{source: \"<style scoped>.a { color: red; }</style><style scoped>!!! {}</style><h1 class=\\\"a\\\">Hi</h1>\", options: {filename: \"app/views/posts/index.html.erb\", escape: false, visitors: [#<Herb::Engine::ScopedStyle::Visitor transform=Engine::ScopedStyleVisitorTest::RaisingTransform>]}}"
+---
+_buf = ::String.new; ::Herb::Engine::Report::Session.record_compile_diagnostics("app/views/posts/index.html.erb", [{ message: "A `<style scoped>` block could not be narrowed by the `transform` Herb::Engine::ScopedStyle::Visitor was given, so it was left as it was written and still applies to the whole page. It failed with `no idea what to do with that`.", severity: :warning, code: "scoped-style-that-could-not-be-narrowed", origin: "Herb Compiler", line: 1, column: 40, end_line: 1, end_column: 68 }].freeze); _buf << '<style>.a { color: red; }/* narrowed */</style><style scoped>!!! {}</style><h1 class="a" data-herb-scope-2940ba8a>Hi</h1>'.freeze;
+_buf.to_s

--- a/test/snapshots/engine/scoped_style_visitor_test/test_0026_reports_what_the_transform_kept_but_could_not_act_on_7b82bc2ca532b7863def65dba3e3df11.txt
+++ b/test/snapshots/engine/scoped_style_visitor_test/test_0026_reports_what_the_transform_kept_but_could_not_act_on_7b82bc2ca532b7863def65dba3e3df11.txt
@@ -1,0 +1,6 @@
+---
+source: "Engine::ScopedStyleVisitorTest#test_0026_reports what the transform kept but could not act on"
+input: "{source: \"<style scoped>.a:deep(.b) { color: red; }</style><h1>Hi</h1>\", options: {filename: \"app/views/posts/index.html.erb\", escape: false, visitors: [#<Herb::Engine::ScopedStyle::Visitor transform=Engine::ScopedStyleVisitorTest::WarningTransform>]}}"
+---
+_buf = ::String.new; ::Herb::Engine::Report::Session.record_compile_diagnostics("app/views/posts/index.html.erb", [{ message: "The `transform` could not act on something in this `<style scoped>` block, so that part of the CSS was kept as it was written and does nothing. It reported `it kept `:deep()` without acting on it`.", severity: :warning, code: "scoped-style-with-a-warning", origin: "Herb Compiler", line: 1, column: 0, end_line: 1, end_column: 49 }].freeze); _buf << '<style>.a:deep(.b) { color: red; }/* narrowed */</style><h1 data-herb-scope-2940ba8a>Hi</h1>'.freeze;
+_buf.to_s


### PR DESCRIPTION
This pull request turns both halves of a `transform` that did not fully work into diagnostics. One half took the whole template down. The other went missing entirely.

#### A transform that raises

`ScopedStyle::Visitor` handed the block's CSS to its `transform` and let whatever came back out come back out, so a block Lightning CSS could not parse raised straight through `Herb::Engine.new`.

```ruby
Herb::Engine.new(%(<style scoped>!!! { color: red }</style><h1>Hi</h1>), filename: path, visitors: [visitor])
#=> LightningCSS::ParseError: Invalid empty selector at :0:1
```

The parser was perfectly happy with that template. Only the CSS inside the block was unreadable, and the visitor already knows how to report a block it cannot narrow. It reports this one the same way now, under `scoped-style-that-could-not-be-narrowed`, and the compile carries on.

```
A `<style scoped>` block could not be narrowed by the `transform` Herb::Engine::ScopedStyle::Visitor was given, so it was left as it was written and still applies to the whole page. It failed with `Invalid empty selector at :0:1`.
```

The rescue is on `StandardError`, because `transform` is anything answering `call` and the visitor cannot know which exception any particular one raises. The error's own message carries the detail, which is why it travels into the diagnostic.

#### A transform that warns

The narrowed CSS was read back with `to_s`, so everything else the transform had to say was dropped. Lightning CSS reports what it kept without acting on, and what it kept without acting on is CSS that does nothing once the page renders.

```html+erb
<style scoped>.a:deep(.b) { color: red }</style>
```

That block compiled clean and shipped a rule matching nothing at all. It is reported now, under `scoped-style-with-a-warning`, one diagnostic per warning.

```
The `transform` could not act on something in this `<style scoped>` block, so that part of the CSS was kept as it was written and does nothing. It reported `'deep' is not recognized as a valid pseudo-class. Did you mean '::deep' (pseudo-element) or is this a typo? at :0:9`.
```

Reading them is duck typed on `warnings`, so a `LightningCSS::Result` is picked up as it is and a transform answering with a plain string reports nothing. The documented contract still asks only for something whose `to_s` is the narrowed CSS, and every transform written against it keeps working untouched.