### PR TITLE
Ruby: Strip leftover RBS type alias fragment from errors template

### DIFF
--- a/templates/lib/herb/errors.rb.erb
+++ b/templates/lib/herb/errors.rb.erb
@@ -68,11 +68,6 @@ module Herb
       <%- if error.fields.any? -%>
 
       <%- error.fields.each do |field| -%>
-      #|  <%= "#{field.name}: #{field.ruby_type}?," %>
-      <%- end -%>
-      #| }
-
-      <%- error.fields.each do |field| -%>
       attr_reader :<%= field.name %> #: <%= field.ruby_type %>?
       <%- end -%>
 


### PR DESCRIPTION
This pull request removes a half-finished RBS type alias declaration that `templates/lib/herb/errors.rb.erb` emitted into the body of every generated error class.

#465 added the `serialized_error` type alias block at the module level and, in the same change, added the tail of a per-error `serialized_<error>` alias to the error class template. The opening `#:` line that would have started that alias never made it in, so what the template renders is a run of `#|` continuation lines with nothing to continue:

```ruby
class UnexpectedError < Error
  include Colors

  #|  description: String?,
  #|  expected: String?,
  #|  found: String?,
  #| }

  attr_reader :description #: String?
  attr_reader :expected #: String?
  attr_reader :found #: String?
```

After this change the class body starts at the attributes:

```ruby
class UnexpectedError < Error
  include Colors

  attr_reader :description #: String?
  attr_reader :expected #: String?
  attr_reader :found #: String?
```