### PR TITLE
Dev Tools: Implement full-screen overlays for the Diagnostics Panel

### DIFF
--- a/javascript/packages/client/src/report.ts
+++ b/javascript/packages/client/src/report.ts
@@ -7,6 +7,7 @@ export interface RuntimeDiagnostic {
   location?: { start: { line: number; column: number } }
   suggestion?: string
   value?: string
+  overlay?: "blocking" | "dismissible" | false
   element?: Element | null
 }
 

--- a/javascript/packages/dev-tools/README.md
+++ b/javascript/packages/dev-tools/README.md
@@ -60,7 +60,9 @@ HerbDevTools.start({
 
 The package ships a demo page under `demo/`, a stand-in Rails posts page carrying a realistic report. A layout renders an index which renders one partial twice as a collection, and the report describes a linter error with an autofix, a linter warning, and a runtime metric against it. Every content card names the partial that rendered it, so the render stack in the panel reads against something visible on the page.
 
-A card at the top wires up buttons for `report()`, batching, deduplication, `dismiss()`, both forms of `clear()`, `show()`, and the expand toggle, so every part of the API is exercisable without the console.
+A card at the top wires up buttons for `report()`, batching, deduplication, `dismiss()`, both forms of `clear()`, `show()`, `open()`, `close()`, the expand toggle, and both [`overlay`](#overlay) modes, so every part of the API is exercisable without the console.
+
+One of them reports entries carrying an `element`, which is the field the payload cannot express and only the JavaScript API has. Each of those cards gets a locate control that scrolls the page to its element and flashes it, and hovering the control outlines the element in place. The two point at different things on purpose, so the card labels show both shapes the panel can render: an id, as `<div#cover-three>`, and the first `data-herb-` attribute it finds, as `<article data-herb-debug-outline-type="partial">`.
 
 `yarn dev` inside `javascript/packages/dev-tools` serves it on `http://localhost:5212` straight from `src/`, so edits hot reload with no build step.
 
@@ -118,6 +120,149 @@ Passing `source` registers it for that template, so later calls naming the same 
 out. A card whose template has no source renders its message, suggestion and render stack without an
 excerpt, which is a supported state rather than a degraded one.
 
+#### `element`
+
+`element` points a diagnostic at the DOM node it is about. It is a live `Element`, so like
+[`source`](#source) it is a convenience of the JavaScript API and has no place in the payload.
+
+A card whose entry carries a connected element grows a locate control. Pressing it scrolls the page
+to that element and flashes it, and hovering the control outlines the element where it sits. An
+element that has since left the document is ignored, so a stale reference degrades to a card without
+the control instead of to a broken one.
+
+Locating gets the panel out of its own way first. A panel filling the window collapses back to the
+corner, and a dismissible overlay closes, because both of them are covering the thing you just asked
+to be shown. A blocking overlay is the exception and stays exactly where it is, since nothing may
+dismiss it and the page behind it did not render anyway.
+
+#### `overlay`
+
+By default an entry lands in the docked panel and waits to be clicked. `overlay` asks the panel to
+present itself full screen instead, for a finding that the page cannot sensibly be read around.
+
+```js
+window.HerbDevTools.report({
+  template: "app/views/posts/show.html.erb",
+  message: "The template could not be compiled.",
+  origin: "Herb Parser",
+  overlay: "blocking"
+})
+```
+
+It takes one of two values, and omitting it (or passing `false`) keeps the entry docked.
+
+| Value | Presentation |
+| --- | --- |
+| `"blocking"` | Fills the viewport, scroll locked, with no control that closes it. |
+| `"dismissible"` | The same screen inside a box over the page, closed by the × button, the backdrop, or `Escape`. |
+
+`"blocking"` is for a page that does not exist. A template that failed to compile rendered nothing,
+so there is nothing behind the overlay to go back to, and the panel therefore draws no close button,
+no "Hide for this session", and no **Clear**. `Escape` does nothing. It also shows over a panel that
+was hidden for the session, because a hidden panel is a preference about noise and this is not noise.
+
+`"dismissible"` is for a page that works with something broken in it. Server-rendered markup that
+failed to hydrate is the case it exists for. Closing it puts the panel back in its docked corner,
+open, with the filter chip belonging to the finding that was just featured selected and that finding
+scrolled into view, so what filled the screen a moment ago is the first thing you see. When the
+featured findings come from more than one origin the All chip is selected instead.
+
+Closing always lands in the same place, whether the overlay was raised over a docked panel or over an
+expanded one, since **close** means leaving full screen behind and there is only one place to leave
+it to. Any severity filter is released on the way out, so nothing can hide the finding you were just
+looking at.
+
+Dismissal is tracked per entry, using the same key as [deduplication](#deduplication). It survives
+re-renders, which is its job, and it does not survive a new report. Calling `report()` again for a
+diagnostic whose overlay was closed raises the overlay again, because a producer calling `report()`
+is asking for the screen. Clearing a diagnostic forgets its dismissal along with it.
+
+Both modes are properties of a diagnostic, not of the panel, so the overlay is up exactly as long as
+something is asking for it. Removing the last entry that asked takes the overlay down.
+
+##### The overlay shows only what asked for it
+
+An overlay is not the panel drawn larger. It lists the entries that requested it and nothing else,
+because a finding that takes the whole screen is claiming to be the thing worth reading. A page whose
+template failed to compile has linter warnings and query counts still sitting in the panel, and none
+of them describe a page that exists.
+
+So the origin filters and the **Clear** control are both absent while an overlay is focused. With the
+chips gone, the header is the only place left to say how much is on screen, so a focused overlay
+showing more than one entry puts the count there. Everything the panel holds is still there, and
+`count` still reports all of it.
+
+A **Show other diagnostics** button in the header widens the overlay to every entry the panel holds,
+with the origin filters back. It appears only when something is actually being held back. **Back to
+the error** returns to the focused view, and widening the scope of a blocking overlay does not
+unblock it.
+
+The button carries no count, because none of the available counts is the right one. The badge counts
+diagnostics and drops metrics, the panel's own total counts both, and neither answers "how many will
+I see if I press this". Its tooltip names the exact number being held back, where there is room to be
+precise about which number it is.
+
+##### Blocking gets its own screen
+
+A focused overlay is not styled like the panel. Its header becomes a band carrying a severity dot,
+the shared `origin` of the entries as a title, and the `template:line:column` of the single entry
+when there is only one. That location opens the file in the editor, the same as the paths on a card
+do, and falls back to plain text when no editor handler is configured. Excerpts get more surrounding
+context and a larger type size, since there is room for both.
+
+The band is tinted by severity, never filled with it. A pale wash of the severity colour, a border of
+the same hue, a severity dot, and darkened text carry the signal without a saturated block of colour
+on screen, so an error reads red and a warning reads amber at the same weight. The severity comes
+from the entries on show, so featuring a warning stays amber even while an unrelated error sits in
+the panel behind it.
+
+The bar's size and layout belong to the panel at full size, not to overlays, so expanding the docked
+panel with its own control gets the same bar. The three full-size views (a focused overlay, a widened
+one, and the expanded panel) are the same object at different scopes, and only the compact docked
+panel keeps the small header.
+
+The **colour** is narrower than that. It appears only while an overlay is focused on something, which
+is the only state where one diagnostic is the subject. Widening the overlay and expanding the
+panel both show the ordinary list, so both get the neutral bar. A tinted bar always means "this
+entry", never "this panel".
+
+The two modes differ in how much they take. A blocking overlay fills the viewport edge to edge with
+no border, no corner radius, and nothing showing through, in the shape a framework error screen
+takes. A dismissible one puts that same screen in a box over the page, with the page still visible
+around it, which is the honest picture when the page underneath still works.
+
+Widening either puts the ordinary panel title and the origin filters back, and
+nothing else about the bar moves. Its layout, size, tint and controls stay where they were, so
+widening does not make the page jump. How much screen the overlay takes does not change either, so a
+widened blocking overlay is still edge to edge and a widened dismissible one is still a box.
+
+#### Featuring an entry from the panel
+
+Every card in the docked panel carries an expand control that puts that one entry on a dismissible
+screen of its own, whatever it was reported with. It is a way of looking at an entry, so it does not change the
+diagnostic. Closing the screen behaves exactly as closing a reported dismissible overlay does, and
+the entry can be featured again afterwards.
+
+The control is absent while a screen is already featured, and while a blocking overlay is up, since
+blocking outranks it.
+
+When entries disagree, `"blocking"` wins. A page holding one blocking finding and five dismissible
+ones is blocked, and the overlay shows the blocking one alone.
+
+##### Blocking is not uncloseable
+
+The absent controls are the ones a **person** can reach. The reporter keeps every programmatic
+route, so the producer that raised a blocking overlay can always take it down.
+
+```js
+const handle = window.HerbDevTools.report({ /* … */ overlay: "blocking" })
+
+handle.dismiss()
+```
+
+`clear()` and `clear(origin)` do the same. This is what lets a dev server drop the overlay when the
+file it complained about is saved and compiles.
+
 #### The handle
 
 `report` returns a handle whose `dismiss()` removes exactly what that call added.
@@ -142,8 +287,8 @@ window.HerbDevTools.clear()
 The argument is matched exactly against the `origin` a diagnostic carries, after the same whitespace
 trim the reader applies on the way in.
 
-The panel header carries the same operation as a control, scoped to the active filter. With the All
-filter selected it reads **Clear all** and empties the panel. With an origin chip selected it reads
+The panel header carries the same operation as a control, scoped to the active origin chip. With the
+All chip selected it reads **Clear all** and empties the panel. With an origin chip selected it reads
 **Clear Herb Linter**, or whatever the chip says, and removes only that origin. Nothing about it is
 confirmed first, because the cost of clearing is a page reload.
 
@@ -152,10 +297,14 @@ Diagnostics that came from the embedded payload return on the next page load, be
 re-reads the tag. Anything pushed through `report()` is gone until something calls `report()` again.
 The stored "hidden for this session" state is untouched, so clearing and hiding stay independent.
 
-Clearing everything would normally take the badge and the panel with it, since the panel only renders
-while it holds entries. To keep that from reading as a crash, a clear that empties an open panel
-leaves it open on an empty state saying so. Closing the panel, or reporting something new, returns it
-to normal behaviour.
+The control closes the panel when it empties it, since an empty panel has nothing to say and the
+badge has nothing to count. Clearing one origin out of several leaves the panel open on what remains.
+Nothing about this touches the stored "hidden for this session" state, so the panel comes back on the
+next `report()` or the next page.
+
+`clear()` called from JavaScript leaves an emptied panel open on an empty state saying what happened,
+because a panel that vanishes under a caller reads as a crash. The control can afford to close
+because the person pressing it knows what they just did.
 
 #### `show({ open })`
 
@@ -167,6 +316,22 @@ window.HerbDevTools.show()
 window.HerbDevTools.show({ open: true })
 ```
 
+#### `open({ expanded })` and `close()`
+
+`open()` opens the runtime diagnostics panel, undismissing it first if it was hidden for the session.
+Pass `{ expanded: true }` to open it filling the window, or `{ expanded: false }` to force it back
+into the corner. Omitting `expanded` leaves whichever of the two the panel was last in.
+
+```js
+window.HerbDevTools.open()
+window.HerbDevTools.open({ expanded: true })
+window.HerbDevTools.close()
+```
+
+`close()` closes the panel and leaves the badge in place, which is what the panel's own × does.
+Neither one touches the stored "hidden for this session" state, and neither can close an overlay. Use
+[`overlay`](#overlay) for that.
+
 The Herb menu carries a **Runtime Diagnostics** toggle that does the same thing without the console.
 Switching it off is the panel header's "Hide for this session", and switching it back on is `show()`.
 Both write the same stored state, so the two can never disagree. Neither one brings back entries that
@@ -174,8 +339,8 @@ were cleared, because those are gone rather than hidden.
 
 #### When the panel is off
 
-`report`, `clear` and `show` are no-ops that log nothing when the panel is switched off with
-`runtimePanel: false`. Guarding the global is the only check a caller needs.
+`report`, `clear`, `show`, `open` and `close` are no-ops that log nothing when the panel is switched
+off with `runtimePanel: false`. Guarding the global is the only check a caller needs.
 
 #### Deduplication
 
@@ -188,6 +353,24 @@ used in its place, so untyped findings and metrics on the same line stay distinc
 The panel holds at most **200** entries. Reporting past that cap drops the oldest entry rather than
 growing without bound, since a report loop must not be able to exhaust the page's memory.
 Deduplication happens first, so a repeated finding costs one slot no matter how often it fires.
+
+### Filters
+
+The panel filters on two independent axes, each a row of chips above the list. The first is
+[`origin`](#origins), the second is severity.
+
+The severity row folds the four `severity` values into three words, matching the vocabulary the badge
+tooltip uses, so the panel speaks one language about severity. **Errors** and **Warnings** are what they say, **Notices**
+covers `info` and `hint` together, and **Metrics** covers everything with `kind: "metric"`, which has
+no severity at all. **Any severity** clears the row.
+
+The two rows are faceted, so each one counts against the other's selection. Picking **Warnings**
+leaves the origin row listing only the origins that have a warning, with counts to match, and picking
+an origin does the same to the severity row. A chip is never shown leading to an empty list.
+
+The severity row appears only when the panel holds more than one of these groups, since a row that
+can only ever say "all of them" is noise. A selection that stops matching anything is released rather
+than left stranded, and both selections persist for the session the same way.
 
 ### Origins
 
@@ -223,7 +406,14 @@ The badge takes its glyph and colour from the worst severity it is holding, and 
 
 Code excerpts and autofix diffs are rendered as ANSI by [`@herb-tools/highlighter`](/projects/highlighter) and displayed in a `<herb-ansi>` element.
 
-The header ends with a control that expands the panel to fill the window, which gives long excerpts and wide autofix diffs room to breathe. Expanding is always user-initiated. Collapse it with the same control, by clicking the backdrop, or by pressing Escape, and the panel returns to its anchored position. Both the open and the expanded state persist for the session. The host page keeps its own scrolling throughout.
+The header carries no counts of its own. The filter chips directly beneath it already count every
+origin and every severity, and the badge's tooltip carries the whole summary, so repeating it in the
+title row only cost space the controls could use. The controls sit next to the title, and the window
+controls stay at the right edge.
+
+The header ends with a control that expands the panel to fill the window, which gives long excerpts and wide autofix diffs room to breathe. Its icon is a pair of corner brackets, pointing outwards to expand and inwards to collapse. Expanding is always user-initiated. Collapse it with the same control or by clicking the backdrop, and the panel returns to its anchored position. Both the open and the expanded state persist for the session. The host page keeps its own scrolling throughout.
+
+`Escape` does what the close button does, so it closes the panel and leaves the badge. It does not collapse an expanded panel back into the corner, because closing is what a reader reaches for Escape to do. It is only listened for while the panel fills the window, so a docked panel never takes the key away from the page.
 
 The panel header's "Hide for this session" and the Herb menu's **Runtime Diagnostics** toggle are the same switch. Either one hides the badge for the session, and the toggle or `show()` brings it back.
 
@@ -352,6 +542,7 @@ The same shape the JavaScript API accepts.
 | `docsUrl` | no | string | Absolute `http` or `https` URL. |
 | `value` | no | string | Badge text for a `metric`. |
 | `fix` | no | object | `{ kind, source }`, the template as this one fix would rewrite it. |
+| `overlay` | no | string | `blocking` or `dismissible`. Absent leaves the entry docked. |
 | `source` | no | string | JavaScript API only. The payload uses top level `sources` instead. |
 
 An entry missing `template` or `message` is dropped. Everything else falls back to a default, so a
@@ -478,6 +669,8 @@ never throws. Concretely:
   signal, since it distinguishes "checked and clean" from "not checked".
 - A `fix` that is unusable is dropped on its own. The card keeps its message, excerpt, and render
   stack.
+- An `overlay` value the reader does not know becomes no overlay, so a payload from a newer producer
+  degrades to a docked entry instead of a screen nothing can dismiss.
 
 ### Not built
 

--- a/javascript/packages/dev-tools/demo/demo.ts
+++ b/javascript/packages/dev-tools/demo/demo.ts
@@ -69,11 +69,68 @@ on("report-spaced", () => {
   })
 })
 
+on("report-blocking", () => {
+  lastHandle = devTools.report({
+    template: "app/views/posts/_post.html.erb",
+    message: "Unclosed `<form>` element. The template could not be compiled.",
+    code: "html-missing-closing-tag",
+    severity: "error",
+    origin: "Herb Parser",
+    location: { start: { line: 2, column: 3 }, end: { line: 2, column: 47 } },
+    suggestion: "Close the `<form>` before the `</article>` on line 11.",
+    overlay: "blocking",
+  })
+})
+
+on("report-dismissible", () => {
+  lastHandle = devTools.report({
+    template: "app/components/post_actions_component.html.erb",
+    message: "This slot could not be hydrated. The page is showing server-rendered markup.",
+    code: "slot-hydration-failed",
+    severity: "error",
+    origin: "Herb Client Runtime",
+    location: { start: { line: 2, column: 3 } },
+    suggestion: "Check that the slot markers survived the server response.",
+    overlay: "dismissible",
+  })
+})
+
+on("report-located", () => {
+  const posts = document.querySelectorAll<HTMLElement>("article.post")
+
+  lastHandle = devTools.report([
+    {
+      template: "app/views/posts/_post.html.erb",
+      node: "3",
+      message: "Cover image has no intrinsic size, so the page reflows once it loads.",
+      code: "html-img-require-dimensions",
+      severity: "warning",
+      origin: "Acme Scanner",
+      location: { start: { line: 1, column: 1 } },
+      suggestion: "Give the cover an explicit `width` and `height`.",
+      element: document.getElementById("cover-three"),
+    },
+    {
+      template: "app/views/posts/_post.html.erb",
+      node: "3",
+      message: "This partial rendered without a byline.",
+      code: "demo-missing-byline",
+      severity: "info",
+      origin: "Acme Scanner",
+      location: { start: { line: 1, column: 1 } },
+      element: posts[1] ?? null,
+    },
+  ])
+})
+
 on("dismiss-last", () => {
   lastHandle?.dismiss()
   lastHandle = null
 })
 
+on("open-panel", () => devTools.open())
+on("open-expanded", () => devTools.open({ expanded: true }))
+on("close-panel", () => devTools.close())
 on("clear-origin", () => devTools.clear("Acme Scanner"))
 on("clear-all", () => devTools.clear())
 on("unhide", () => devTools.show({ open: true }))

--- a/javascript/packages/dev-tools/demo/index.html
+++ b/javascript/packages/dev-tools/demo/index.html
@@ -186,15 +186,22 @@
       <div class="controls">
         <h2>Client-side hook</h2>
         <p>Exercises <code>report()</code>, <code>clear()</code> and <code>show()</code> on the running instance.</p>
+        <p>A blocking overlay covers these controls on purpose. Reload the page to leave it, since entries pushed through <code>report()</code> do not survive a reload. Every card in the panel also carries an expand control that puts that entry on a screen of its own.</p>
 
         <div class="row">
           <button id="report-one">report() one</button>
           <button id="report-batch">report() a batch</button>
           <button id="report-repeat">report() the same finding again</button>
           <button id="report-spaced">report() with a trailing space in origin</button>
+          <button id="report-blocking" title="Covers the page with no way out. Reload to leave it.">report() a blocking overlay</button>
+          <button id="report-dismissible">report() a dismissible overlay</button>
+          <button id="report-located" title="Both entries carry an element, so each card gets a locate control.">report() pointing at DOM elements</button>
           <button id="dismiss-last">dismiss() the last handle</button>
           <button id="clear-origin">clear("Acme Scanner")</button>
           <button id="clear-all">clear()</button>
+          <button id="open-panel">open()</button>
+          <button id="open-expanded">open({ expanded: true })</button>
+          <button id="close-panel">close()</button>
           <button id="unhide">show() after "Hide for this session"</button>
           <button id="toggle-expand">expand() and collapse()</button>
         </div>
@@ -308,7 +315,7 @@
 
       <article class="post">
         <h2>Reading a render stack</h2>
-        <div class="cover three"></div>
+        <div class="cover three" id="cover-three"></div>
         <p>Rendered inline by app/views/posts/index.html.erb.</p>
       </article>
     </main>

--- a/javascript/packages/dev-tools/src/herb-dev-tools.ts
+++ b/javascript/packages/dev-tools/src/herb-dev-tools.ts
@@ -112,6 +112,20 @@ export class HerbDevTools {
     this.panel?.show(options)
   }
 
+  open(options: { expanded?: boolean } = {}): void {
+    this.panel?.show({ open: true })
+
+    if (options.expanded === true) {
+      this.panel?.expand()
+    } else if (options.expanded === false) {
+      this.panel?.collapse()
+    }
+  }
+
+  close(): void {
+    this.panel?.close()
+  }
+
   private setup(): void {
     this.injectStyles()
 

--- a/javascript/packages/dev-tools/src/index.ts
+++ b/javascript/packages/dev-tools/src/index.ts
@@ -3,4 +3,4 @@ export { RuntimePanel } from './runtime/panel.js'
 
 export type { HerbDevToolsOptions } from './herb-dev-tools.js'
 export type { RuntimePanelOptions, RuntimeReportHandle } from './runtime/panel.js'
-export type { RenderTreeNode, RuntimeDiagnostic, RuntimeReport } from './runtime/report.js'
+export type { OverlayMode, RenderTreeNode, RuntimeDiagnostic, RuntimeReport } from './runtime/report.js'

--- a/javascript/packages/dev-tools/src/runtime/highlighting.ts
+++ b/javascript/packages/dev-tools/src/runtime/highlighting.ts
@@ -8,13 +8,19 @@ import type { NormalizedDiagnostic, NormalizedFix } from './report.js'
 
 export const HIGHLIGHTER_THEME = 'onedark'
 export const CONTEXT_LINES = 2
+export const FOCUSED_CONTEXT_LINES = 6
 export const DIFF_CONTEXT_LINES = 1
 export const MAX_WIDTH = 120
 
 const BLOCK_SEPARATOR = '\n\n'
 
+export interface ExcerptOptions {
+  fileUrl?: string
+  contextLines?: number
+}
+
 export interface RuntimeHighlighting {
-  excerpt(source: string, diagnostic: NormalizedDiagnostic, fileUrl?: string): string | null
+  excerpt(source: string, diagnostic: NormalizedDiagnostic, options?: ExcerptOptions): string | null
   diff(path: string, source: string, fix: NormalizedFix): string | null
 }
 
@@ -50,24 +56,27 @@ async function build(): Promise<RuntimeHighlighting> {
   const diffRenderer = new DiffRenderer(syntaxRenderer, colors)
 
   return {
-    excerpt(source, diagnostic, fileUrl) {
+    excerpt(source, diagnostic, options = {}) {
       if (diagnostic.location === null) {
         return null
       }
+
+      const { fileUrl } = options
+      const contextLines = options.contextLines ?? CONTEXT_LINES
 
       try {
         if (diagnostic.severity === null) {
           const focusLine = clampLine(diagnostic.location.start.line, source)
 
           return dropLeadingBlocks(
-            fileRenderer.renderWithFocusLine(diagnostic.template, source, focusLine, CONTEXT_LINES, true, MAX_WIDTH, false, false, fileUrl),
+            fileRenderer.renderWithFocusLine(diagnostic.template, source, focusLine, contextLines, true, MAX_WIDTH, false, false, fileUrl),
             1,
           )
         }
 
         return dropLeadingBlocks(
           diagnosticRenderer.renderSingle(diagnostic.template, toDiagnostic(diagnostic, source), source, {
-            contextLines: CONTEXT_LINES,
+            contextLines,
             showLineNumbers: true,
             wrapLines: false,
             truncateLines: false,

--- a/javascript/packages/dev-tools/src/runtime/panel.css
+++ b/javascript/packages/dev-tools/src/runtime/panel.css
@@ -79,6 +79,8 @@
 
 .herb-dev-tools-panel {
   order: 1;
+  position: relative;
+  box-sizing: border-box;
   display: none;
   flex-direction: column;
   width: min(560px, calc(100vw - 24px));
@@ -96,6 +98,64 @@
   display: flex;
 }
 
+.herb-dev-tools-resize {
+  position: absolute;
+  z-index: 1;
+  touch-action: none;
+}
+
+.herb-dev-tools-resize::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: 999px;
+  background: transparent;
+  transition: background 0.12s ease;
+}
+
+.herb-dev-tools-resize:hover::after,
+.herb-dev-tools-resize:active::after {
+  background: rgba(59, 130, 246, 0.55);
+}
+
+.herb-dev-tools-resize-left {
+  top: 12px;
+  bottom: 12px;
+  left: 0;
+  width: 6px;
+  cursor: ew-resize;
+}
+
+.herb-dev-tools-resize-left::after {
+  left: 2px;
+  right: 2px;
+}
+
+.herb-dev-tools-resize-bottom {
+  left: 12px;
+  right: 12px;
+  bottom: 0;
+  height: 6px;
+  cursor: ns-resize;
+}
+
+.herb-dev-tools-resize-bottom::after {
+  top: 2px;
+  bottom: 2px;
+}
+
+.herb-dev-tools-resize-corner {
+  bottom: 0;
+  left: 0;
+  width: 16px;
+  height: 16px;
+  cursor: nesw-resize;
+}
+
+.herb-dev-tools-resize-corner::after {
+  inset: 3px;
+}
+
 .herb-dev-tools-header {
   display: flex;
   align-items: center;
@@ -106,6 +166,8 @@
 }
 
 .herb-dev-tools-title {
+  flex: 1;
+  min-width: 0;
   font-weight: 600;
   color: #111827;
 }
@@ -143,15 +205,18 @@
 
 .herb-dev-tools-clear,
 .herb-dev-tools-hide {
-  flex-shrink: 0;
+  flex: 0 1 auto;
+  min-width: 0;
+  overflow: hidden;
   white-space: nowrap;
+  text-overflow: ellipsis;
 }
 
 .herb-dev-tools-window-controls {
   display: flex;
   align-items: center;
   gap: 2px;
-  flex-shrink: 0;
+  flex: none;
 }
 
 .herb-dev-tools-expand,
@@ -173,6 +238,11 @@
   padding: 8px 12px;
   border-bottom: 1px solid #e5e7eb;
   background: #f9fafb;
+}
+
+.herb-dev-tools-filters-severity {
+  border-bottom: 1px solid #e5e7eb;
+  background: #ffffff;
 }
 
 .herb-dev-tools-filter {
@@ -292,6 +362,30 @@
   margin-left: auto;
   color: #9ca3af;
   font-size: 10px;
+}
+
+.herb-dev-tools-icon {
+  display: block;
+  flex: none;
+}
+
+.herb-dev-tools-feature {
+  flex: none;
+  padding: 1px 6px;
+  border: 1px solid #e5e7eb;
+  border-radius: 6px;
+  background: transparent;
+  color: #6b7280;
+  font: inherit;
+  font-size: 12px;
+  line-height: 1.2;
+  cursor: pointer;
+}
+
+.herb-dev-tools-feature:hover {
+  border-color: #d1d5db;
+  background: #f3f4f6;
+  color: #111827;
 }
 
 .herb-dev-tools-repeat {
@@ -524,6 +618,166 @@
   inset: 0;
   z-index: 2147483640;
   background: rgba(17, 24, 39, 0.45);
+}
+
+.herb-dev-tools-scope {
+  flex: none;
+  padding: 4px 10px;
+  border: 1px solid currentColor;
+  border-radius: 999px;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  font-size: 11px;
+  font-weight: 600;
+  cursor: pointer;
+  opacity: 0.85;
+}
+
+.herb-dev-tools-scope:hover {
+  opacity: 1;
+}
+
+.herb-dev-tools-runtime-root .herb-dev-tools-panel.herb-dev-tools-overlay.herb-dev-tools-overlay-fullscreen,
+.herb-dev-tools-runtime-root.herb-dev-tools-attached .herb-dev-tools-panel.herb-dev-tools-overlay.herb-dev-tools-overlay-fullscreen {
+  position: fixed;
+  inset: 0;
+  width: 100%;
+  max-width: none;
+  max-height: none;
+  border: 0;
+  border-radius: 0;
+  box-shadow: none;
+  background: #f3f4f6;
+  z-index: 2147483642;
+}
+
+.herb-dev-tools-panel {
+  --herb-dev-tools-accent: var(--herb-dev-tools-severity-error);
+}
+
+.herb-dev-tools-tone-error {
+  --herb-dev-tools-accent: var(--herb-dev-tools-severity-error);
+}
+
+.herb-dev-tools-tone-warning {
+  --herb-dev-tools-accent: var(--herb-dev-tools-severity-warning);
+}
+
+.herb-dev-tools-tone-info {
+  --herb-dev-tools-accent: var(--herb-dev-tools-severity-info);
+}
+
+.herb-dev-tools-tone-hint {
+  --herb-dev-tools-accent: var(--herb-dev-tools-severity-hint);
+}
+
+.herb-dev-tools-tone-metric {
+  --herb-dev-tools-accent: #374151;
+}
+
+.herb-dev-tools-expanded .herb-dev-tools-header {
+  gap: 12px;
+  padding: 18px 28px;
+}
+
+.herb-dev-tools-expanded .herb-dev-tools-title {
+  font-size: 16px;
+}
+
+.herb-dev-tools-expanded .herb-dev-tools-summary {
+  font-size: 12.5px;
+}
+
+.herb-dev-tools-expanded .herb-dev-tools-filters {
+  gap: 8px;
+  padding: 12px 28px;
+}
+
+.herb-dev-tools-overlay-focused .herb-dev-tools-header {
+  background: color-mix(in srgb, var(--herb-dev-tools-accent) 9%, #ffffff);
+  border-bottom: 1px solid color-mix(in srgb, var(--herb-dev-tools-accent) 28%, #ffffff);
+  color: color-mix(in srgb, var(--herb-dev-tools-accent) 45%, #111827);
+}
+
+.herb-dev-tools-overlay-focused .herb-dev-tools-header .herb-dev-tools-dot {
+  width: 9px;
+  height: 9px;
+}
+
+.herb-dev-tools-overlay-focused .herb-dev-tools-title {
+  color: inherit;
+}
+
+.herb-dev-tools-overlay-focused .herb-dev-tools-title {
+  flex: none;
+}
+
+.herb-dev-tools-overlay-focused .herb-dev-tools-summary {
+  color: color-mix(in srgb, var(--herb-dev-tools-accent) 30%, #4b5563);
+}
+
+.herb-dev-tools-overlay-focused .herb-dev-tools-summary {
+  flex: 0 1 auto;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.herb-dev-tools-expanded .herb-dev-tools-window-controls {
+  gap: 8px;
+}
+
+.herb-dev-tools-overlay-focused .herb-dev-tools-window-controls {
+  margin-left: auto;
+}
+
+.herb-dev-tools-overlay-focused .herb-dev-tools-summary.herb-dev-tools-path:hover {
+  color: color-mix(in srgb, var(--herb-dev-tools-accent) 55%, #111827);
+}
+
+.herb-dev-tools-overlay-focused .herb-dev-tools-ansi {
+  padding: 12px 14px;
+  font-size: 13px;
+}
+
+.herb-dev-tools-overlay-focused .herb-dev-tools-body {
+  box-sizing: border-box;
+  width: 100%;
+  max-width: 1040px;
+  margin: 0 auto;
+  padding: 28px 28px 72px;
+}
+
+.herb-dev-tools-overlay-focused .herb-dev-tools-group {
+  margin-top: 0;
+}
+
+.herb-dev-tools-overlay-focused .herb-dev-tools-card {
+  background: #ffffff;
+  border-radius: 10px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12);
+}
+
+.herb-dev-tools-expanded .herb-dev-tools-close {
+  flex: none;
+  font-size: 15px;
+  line-height: 1;
+  padding: 3px 8px;
+}
+
+.herb-dev-tools-expanded .herb-dev-tools-scope {
+  opacity: 1;
+}
+
+.herb-dev-tools-overlay-focused .herb-dev-tools-close,
+.herb-dev-tools-overlay-focused .herb-dev-tools-scope {
+  border-color: color-mix(in srgb, var(--herb-dev-tools-accent) 32%, #ffffff);
+  color: inherit;
+}
+
+.herb-dev-tools-overlay-focused .herb-dev-tools-close:hover,
+.herb-dev-tools-overlay-focused .herb-dev-tools-scope:hover {
+  background: color-mix(in srgb, var(--herb-dev-tools-accent) 16%, #ffffff);
+  color: inherit;
 }
 
 .herb-dev-tools-runtime-root .herb-dev-tools-panel.herb-dev-tools-expanded,

--- a/javascript/packages/dev-tools/src/runtime/panel.ts
+++ b/javascript/packages/dev-tools/src/runtime/panel.ts
@@ -1,14 +1,14 @@
 import panelStyles from './panel.css'
 
 import { injectStyle } from '../styles.js'
-import { loadRuntimeHighlighting } from './highlighting.js'
+import { loadRuntimeHighlighting, CONTEXT_LINES, FOCUSED_CONTEXT_LINES } from './highlighting.js'
 import { buildRenderStack, diagnosticKey, normalizeDiagnostic, trimOrigin, readRuntimeReport, UNKNOWN_TEMPLATE } from './report.js'
 import { flashElement } from '../slots/flash.js'
 
 import { MAX_RUNTIME_DIAGNOSTICS, RUNTIME_SEVERITIES } from './report.js'
 
 import type { RuntimeHighlighting } from './highlighting.js'
-import type { NormalizedDiagnostic, NormalizedRuntimeReport, RenderStackFrame, RenderTreeNode, RuntimeDiagnostic, RuntimeSeverity } from './report.js'
+import type { NormalizedDiagnostic, NormalizedRuntimeReport, OverlayMode, RenderStackFrame, RenderTreeNode, RuntimeDiagnostic, RuntimeSeverity } from './report.js'
 
 export type BadgeTone = RuntimeSeverity | 'metric'
 
@@ -40,9 +40,44 @@ interface PanelState {
   open: boolean
   expanded: boolean
   origin: string
+  severity: string
+  width: number | null
+  height: number | null
 }
 
 const ALL_ORIGINS = '*'
+const ALL_SEVERITIES = '*'
+
+const MIN_PANEL_WIDTH = 440
+const MIN_PANEL_HEIGHT = 180
+const VIEWPORT_MARGIN = 24
+
+const RESIZE_EDGES = ['left', 'bottom', 'corner'] as const
+
+type ResizeEdge = typeof RESIZE_EDGES[number]
+
+function clamp(value: number, low: number, high: number): number {
+  return Math.min(Math.max(value, low), Math.max(low, high))
+}
+
+function asSize(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? Math.round(value) : null
+}
+
+const SEVERITY_FILTERS: Array<{ value: string, label: string, matches: (diagnostic: NormalizedDiagnostic) => boolean }> = [
+  { value: 'error', label: 'Errors', matches: diagnostic => diagnostic.kind === 'diagnostic' && diagnostic.severity === 'error' },
+  { value: 'warning', label: 'Warnings', matches: diagnostic => diagnostic.kind === 'diagnostic' && diagnostic.severity === 'warning' },
+  { value: 'notice', label: 'Notices', matches: diagnostic => diagnostic.kind === 'diagnostic' && (diagnostic.severity === 'info' || diagnostic.severity === 'hint') },
+  { value: 'metric', label: 'Metrics', matches: diagnostic => diagnostic.kind === 'metric' },
+]
+
+function matchesSeverity(diagnostic: NormalizedDiagnostic, severity: string): boolean {
+  if (severity === ALL_SEVERITIES) {
+    return true
+  }
+
+  return SEVERITY_FILTERS.find(filter => filter.value === severity)?.matches(diagnostic) ?? true
+}
 const STATE_KEY = 'herb-dev-tools-runtime-panel'
 const ROOT_CLASS = 'herb-dev-tools-runtime-root'
 const LINKABLE_SCHEMES = ['http:', 'https:', 'file:']
@@ -53,6 +88,18 @@ const VIA_LABELS: Record<string, string> = {
   partial: 'partial',
   component: 'component',
 }
+
+function cornerIcon(paths: string[]): string {
+  return [
+    `<svg class="herb-dev-tools-icon" viewBox="0 0 16 16" width="13" height="13" aria-hidden="true"`,
+    ` fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round">`,
+    paths.map(path => `<path d="${path}"/>`).join(''),
+    `</svg>`,
+  ].join('')
+}
+
+const EXPAND_ICON = cornerIcon(['M6 2H2v4', 'M10 2h4v4', 'M6 14H2v-4', 'M10 14h4v-4'])
+const COLLAPSE_ICON = cornerIcon(['M2 6h4V2', 'M14 6h-4V2', 'M2 10h4v4', 'M14 10h-4v4'])
 
 const BADGE_GLYPHS: Record<BadgeTone, string> = {
   error: '⛔',
@@ -116,6 +163,14 @@ function ansiHTML(ansi: string, className: string, target: OpenTarget | null = n
   return `<herb-ansi class="${className}"${openTargetAttributes(target)}>${escapeHTML(ansi)}</herb-ansi>`
 }
 
+function strongerOverlay(existing: OverlayMode | null, incoming: OverlayMode | null): OverlayMode | null {
+  if (existing === 'blocking' || incoming === 'blocking') {
+    return 'blocking'
+  }
+
+  return existing ?? incoming
+}
+
 function mergeDiagnostics(existing: NormalizedDiagnostic, incoming: NormalizedDiagnostic): NormalizedDiagnostic {
   return {
     ...existing,
@@ -127,6 +182,7 @@ function mergeDiagnostics(existing: NormalizedDiagnostic, incoming: NormalizedDi
     docsUrl: existing.docsUrl ?? incoming.docsUrl,
     value: existing.value ?? incoming.value,
     fix: existing.fix ?? incoming.fix,
+    overlay: strongerOverlay(existing.overlay, incoming.overlay),
     element: incoming.element?.isConnected ? incoming.element : existing.element,
   }
 }
@@ -140,7 +196,7 @@ export class RuntimePanel {
   private primed = false
   private onOpenFile: ((file: string, line: number, column: number) => void) | null = null
   private onOpen: (() => void) | null = null
-  private state: PanelState = { dismissed: false, open: false, expanded: false, origin: ALL_ORIGINS }
+  private state: PanelState = { dismissed: false, open: false, expanded: false, origin: ALL_ORIGINS, severity: ALL_SEVERITIES, width: null, height: null }
   private root: HTMLElement | null = null
   private highlighting: RuntimeHighlighting | null = null
   private hydrating = false
@@ -148,6 +204,10 @@ export class RuntimePanel {
   private escapeHandler: ((event: KeyboardEvent) => void) | null = null
   private styleElement: HTMLStyleElement | null = null
   private cleared = false
+  private overlayDismissed = new Set<string>()
+  private overlayShowAll = false
+  private featuredKey: string | null = null
+  private scrollLock: string | null = null
 
   constructor(options: RuntimePanelOptions = {}) {
     this.onOpenFile = options.onOpenFile ?? null
@@ -167,6 +227,9 @@ export class RuntimePanel {
     this.destroyed = true
 
     this.unbindEscape()
+    this.lockScroll(false)
+
+    document.body.style.userSelect = ''
 
     this.root?.remove()
     this.root = null
@@ -243,18 +306,18 @@ export class RuntimePanel {
       .reduce((total, entry) => total + entry.count, 0)
   }
 
+  public get badgeCount(): number {
+    return this.badgeSeverity === null ? this.metricCount : this.diagnosticCount
+  }
+
   public get badgeSeverity(): RuntimeSeverity | null {
-    for (const severity of RUNTIME_SEVERITIES) {
-      const present = this.entries.some(
-        entry => entry.diagnostic.kind === 'diagnostic' && entry.diagnostic.severity === severity
-      )
+    return severityOf(this.entries)
+  }
 
-      if (present) {
-        return severity
-      }
-    }
+  private get headerTone(): BadgeTone {
+    const scope = this.overlayFocused ? this.visibleEntries() : this.entries
 
-    return null
+    return severityOf(scope) ?? 'metric'
   }
 
   public get element(): HTMLElement | null {
@@ -307,6 +370,115 @@ export class RuntimePanel {
 
   public get dismissed(): boolean {
     return this.state.dismissed
+  }
+
+  public get overlay(): OverlayMode | null {
+    let mode: OverlayMode | null = null
+
+    for (const entry of this.entries) {
+      if (entry.diagnostic.overlay === 'blocking') {
+        return 'blocking'
+      }
+
+      if (entry.diagnostic.overlay === 'dismissible' && !this.overlayDismissed.has(entry.key)) {
+        mode = 'dismissible'
+      }
+    }
+
+    return mode ?? (this.featuredEntry === null ? null : 'dismissible')
+  }
+
+  private get featuredEntry(): PanelEntry | null {
+    if (this.featuredKey === null) {
+      return null
+    }
+
+    return this.entries.find(entry => entry.key === this.featuredKey) ?? null
+  }
+
+  public get featured(): string | null {
+    return this.featuredEntry === null ? null : this.featuredKey
+  }
+
+  public feature(key: string) {
+    if (!this.entries.some(entry => entry.key === key)) {
+      return
+    }
+
+    this.featuredKey = key
+    this.overlayShowAll = false
+    this.state.open = true
+
+    this.onOpen?.()
+
+    this.saveState()
+    this.render()
+  }
+
+  public get overlayShowingAll(): boolean {
+    return this.overlay !== null && this.overlayShowAll
+  }
+
+  public toggleOverlayScope() {
+    if (this.overlay === null) {
+      return
+    }
+
+    this.overlayShowAll = !this.overlayShowAll
+
+    this.render()
+  }
+
+  public dismissOverlay() {
+    if (this.overlay !== 'dismissible') {
+      return
+    }
+
+    const featured = this.visibleEntries()
+    const origins = new Set(featured.map(entry => entry.diagnostic.origin))
+
+    this.featuredKey = null
+
+    for (const entry of this.entries) {
+      if (entry.diagnostic.overlay === 'dismissible') {
+        this.overlayDismissed.add(entry.key)
+      }
+    }
+
+    this.state.open = true
+    this.state.expanded = false
+    this.state.origin = origins.size === 1 ? [...origins][0] : ALL_ORIGINS
+    this.state.severity = ALL_SEVERITIES
+
+    this.onOpen?.()
+
+    this.saveState()
+    this.render()
+    this.revealCard(featured[0]?.key)
+  }
+
+  private revealCard(key: string | undefined) {
+    if (key === undefined || this.root === null) {
+      return
+    }
+
+    const index = this.entries.findIndex(entry => entry.key === key)
+
+    if (index === -1) {
+      return
+    }
+
+    const card = this.root.querySelector(`.herb-dev-tools-card[data-herb-dev-tools-entry="${index}"]`)
+
+    card?.scrollIntoView({ block: 'nearest' })
+  }
+
+  private featureFrom(trigger: HTMLElement) {
+    const entry = this.entryFor(trigger)
+
+    if (entry !== undefined) {
+      this.feature(entry.key)
+    }
   }
 
   public dismiss() {
@@ -381,6 +553,10 @@ export class RuntimePanel {
     const key = diagnosticKey(diagnostic)
     const existing = this.entries.find(entry => entry.key === key)
 
+    if (diagnostic.overlay !== null) {
+      this.overlayDismissed.delete(key)
+    }
+
     if (existing !== undefined) {
       existing.count += 1
       existing.diagnostic = mergeDiagnostics(existing.diagnostic, diagnostic)
@@ -428,9 +604,12 @@ export class RuntimePanel {
         open: parsed?.open === true,
         expanded: parsed?.expanded === true,
         origin: typeof parsed?.origin === 'string' ? parsed.origin : ALL_ORIGINS,
+        severity: typeof parsed?.severity === 'string' ? parsed.severity : ALL_SEVERITIES,
+        width: asSize(parsed?.width),
+        height: asSize(parsed?.height),
       }
     } catch (_error) {
-      this.state = { dismissed: false, open: false, expanded: false, origin: ALL_ORIGINS }
+      this.state = { dismissed: false, open: false, expanded: false, origin: ALL_ORIGINS, severity: ALL_SEVERITIES, width: null, height: null }
     }
   }
 
@@ -448,9 +627,17 @@ export class RuntimePanel {
     }
 
     this.escapeHandler = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        this.collapse()
+      if (event.key !== 'Escape') {
+        return
       }
+
+      if (this.overlay === 'dismissible') {
+        this.dismissOverlay()
+
+        return
+      }
+
+      this.close()
     }
 
     document.addEventListener('keydown', this.escapeHandler)
@@ -467,15 +654,87 @@ export class RuntimePanel {
   }
 
   private get showingExpanded(): boolean {
-    return this.state.open && this.state.expanded
+    return this.overlay !== null || (this.state.open && this.state.expanded)
+  }
+
+  private lockScroll(locked: boolean) {
+    if (typeof document === 'undefined') {
+      return
+    }
+
+    if (locked) {
+      if (this.scrollLock !== null) {
+        return
+      }
+
+      this.scrollLock = document.documentElement.style.overflow
+      document.documentElement.style.overflow = 'hidden'
+
+      return
+    }
+
+    if (this.scrollLock === null) {
+      return
+    }
+
+    document.documentElement.style.overflow = this.scrollLock
+    this.scrollLock = null
+  }
+
+  private pruneOverlayDismissals() {
+    for (const key of this.overlayDismissed) {
+      if (!this.entries.some(entry => entry.key === key)) {
+        this.overlayDismissed.delete(key)
+      }
+    }
+
+    if (this.featuredEntry === null) {
+      this.featuredKey = null
+    }
+  }
+
+  private overlayEntries(mode: OverlayMode): PanelEntry[] {
+    if (mode === 'blocking') {
+      return this.entries.filter(entry => entry.diagnostic.overlay === 'blocking')
+    }
+
+    const declared = this.entries.filter(
+      entry => entry.diagnostic.overlay === 'dismissible' && !this.overlayDismissed.has(entry.key)
+    )
+
+    if (declared.length > 0) {
+      return declared
+    }
+
+    const featured = this.featuredEntry
+
+    return featured === null ? [] : [featured]
+  }
+
+  private get overlayFocused(): boolean {
+    return this.overlay !== null && !this.overlayShowAll
+  }
+
+  private get overlayEdgeToEdge(): boolean {
+    return this.overlay === 'blocking'
+  }
+
+  private matching(origin: string, severity: string): PanelEntry[] {
+    return this.entries.filter(entry => {
+      const sameOrigin = origin === ALL_ORIGINS || entry.diagnostic.origin === origin
+
+      return sameOrigin && matchesSeverity(entry.diagnostic, severity)
+    })
   }
 
   private visibleEntries(): PanelEntry[] {
-    if (this.state.origin === ALL_ORIGINS) {
-      return this.entries
+    const overlay = this.overlay
+
+    if (overlay !== null && !this.overlayShowAll) {
+      return this.overlayEntries(overlay)
     }
 
-    return this.entries.filter(entry => entry.diagnostic.origin === this.state.origin)
+    return this.matching(this.state.origin, this.state.severity)
   }
 
   private render() {
@@ -489,16 +748,31 @@ export class RuntimePanel {
       this.saveState()
     }
 
+    if (this.state.severity !== ALL_SEVERITIES && this.matching(ALL_ORIGINS, this.state.severity).length === 0) {
+      this.state.severity = ALL_SEVERITIES
+
+      this.saveState()
+    }
+
+    this.pruneOverlayDismissals()
+
     const currentCount = this.diagnosticCount
 
     this.bumped = this.primed && currentCount > this.lastCount
     this.lastCount = currentCount
     this.primed = true
 
+    const overlay = this.overlay
+
+    if (overlay === null) {
+      this.overlayShowAll = false
+    }
+
     const shouldShow = this.entries.length > 0 || (this.cleared && this.state.open)
 
-    if (!shouldShow || this.state.dismissed) {
+    if (overlay === null && (!shouldShow || this.state.dismissed)) {
       this.unbindEscape()
+      this.lockScroll(false)
 
       this.root?.remove()
       this.root = null
@@ -506,7 +780,9 @@ export class RuntimePanel {
       return
     }
 
-    if (this.showingExpanded) {
+    this.lockScroll(overlay === 'blocking')
+
+    if (this.showingExpanded && overlay !== 'blocking') {
       this.bindEscape()
     } else {
       this.unbindEscape()
@@ -529,6 +805,7 @@ export class RuntimePanel {
     this.root.innerHTML = this.rootHTML()
 
     this.bindHandlers()
+    this.bindResizeHandles()
 
     void this.hydrateHighlighting()
   }
@@ -560,25 +837,46 @@ export class RuntimePanel {
   }
 
   private rootHTML(): string {
+    const overlay = this.overlay
     const severity = this.badgeSeverity
     const tone = severity ?? 'metric'
-    const badgeCount = severity === null ? this.metricCount : this.diagnosticCount
-    const openClass = this.state.open ? ' herb-dev-tools-open' : ''
+    const badgeCount = this.badgeCount
+    const openClass = this.state.open || overlay !== null ? ' herb-dev-tools-open' : ''
     const expandedClass = this.showingExpanded ? ' herb-dev-tools-expanded' : ''
+    const overlayClass = overlay === null
+      ? ''
+      : [
+        ` herb-dev-tools-overlay herb-dev-tools-overlay-${overlay}`,
+        this.overlayShowAll ? '' : ` herb-dev-tools-overlay-focused herb-dev-tools-tone-${this.headerTone}`,
+        this.overlayEdgeToEdge ? ' herb-dev-tools-overlay-fullscreen' : '',
+      ].join('')
     const bumpClass = this.bumped ? ' herb-dev-tools-bump' : ''
     const summary = escapeHTML(this.summary())
 
-    const backdrop = this.showingExpanded
-      ? `<div class="herb-dev-tools-backdrop" data-herb-dev-tools-action="collapse" aria-hidden="true"></div>`
+    const backdrop = this.showingExpanded && !this.overlayEdgeToEdge
+      ? [
+        `<div class="herb-dev-tools-backdrop"`,
+        overlay === 'blocking' ? '' : ` data-herb-dev-tools-action="${overlay === null ? 'collapse' : 'dismiss-overlay'}"`,
+        ` aria-hidden="true"></div>`,
+      ].join('')
       : ''
+
+    const badge = overlay === null
+      ? [
+        `<button type="button" class="herb-dev-tools-badge herb-dev-tools-badge-${tone}${openClass}" data-herb-dev-tools-action="toggle" data-herb-dev-tools-tone="${tone}" title="${summary}" aria-label="${summary}" aria-expanded="${this.state.open}">`,
+        `<span class="herb-dev-tools-badge-glyph" aria-hidden="true">${BADGE_GLYPHS[tone]}</span>`,
+        `<span class="herb-dev-tools-badge-count${bumpClass}">${badgeCount}</span>`,
+        `</button>`,
+      ].join('')
+      : ''
+
+    const modal = overlay === null ? '' : ' role="dialog" aria-modal="true"'
 
     return [
       backdrop,
-      `<button type="button" class="herb-dev-tools-badge herb-dev-tools-badge-${tone}${openClass}" data-herb-dev-tools-action="toggle" data-herb-dev-tools-tone="${tone}" title="${summary}" aria-label="${summary}" aria-expanded="${this.state.open}">`,
-      `<span class="herb-dev-tools-badge-glyph" aria-hidden="true">${BADGE_GLYPHS[tone]}</span>`,
-      `<span class="herb-dev-tools-badge-count${bumpClass}">${badgeCount}</span>`,
-      `</button>`,
-      `<section class="herb-dev-tools-panel${openClass}${expandedClass}" aria-label="Herb Runtime Diagnostics">`,
+      badge,
+      `<section class="herb-dev-tools-panel${openClass}${expandedClass}${overlayClass}" aria-label="Herb Runtime Diagnostics"${modal}${this.sizeStyle()}>`,
+      this.resizeHandlesHTML(),
       this.headerHTML(),
       this.filtersHTML(),
       `<div class="herb-dev-tools-body">${this.bodyHTML()}</div>`,
@@ -586,11 +884,123 @@ export class RuntimePanel {
     ].join('')
   }
 
+  private get resizable(): boolean {
+    return this.overlay === null && !this.state.expanded
+  }
+
+  private sizeStyle(): string {
+    if (!this.resizable) {
+      return ''
+    }
+
+    const parts: string[] = []
+
+    if (this.state.width !== null) {
+      parts.push(`width:${this.state.width}px`)
+    }
+
+    if (this.state.height !== null) {
+      parts.push(`height:${this.state.height}px`, 'max-height:none')
+    }
+
+    return parts.length === 0 ? '' : ` style="${parts.join(';')}"`
+  }
+
+  private resizeHandlesHTML(): string {
+    if (!this.resizable) {
+      return ''
+    }
+
+    return RESIZE_EDGES.map(edge => [
+      `<div class="herb-dev-tools-resize herb-dev-tools-resize-${edge}" data-herb-dev-tools-resize="${edge}"`,
+      ` role="separator" aria-label="Resize the panel" title="Drag to resize"></div>`,
+    ].join('')).join('')
+  }
+
+  private bindResizeHandles() {
+    const root = this.root
+
+    if (root === null) {
+      return
+    }
+
+    const element = root.querySelector<HTMLElement>('.herb-dev-tools-panel')
+
+    if (element === null) {
+      return
+    }
+
+    root.querySelectorAll<HTMLElement>('[data-herb-dev-tools-resize]').forEach((handle) => {
+      handle.addEventListener('pointerdown', (event) => {
+        event.preventDefault()
+        event.stopPropagation()
+
+        const edge = handle.getAttribute('data-herb-dev-tools-resize') as ResizeEdge
+        const box = element.getBoundingClientRect()
+        const selection = document.body.style.userSelect
+
+        handle.setPointerCapture(event.pointerId)
+
+        document.body.style.userSelect = 'none'
+
+        const move = (moved: PointerEvent) => {
+          if (edge === 'left' || edge === 'corner') {
+            const room = window.innerWidth - VIEWPORT_MARGIN
+            const width = clamp(box.right - moved.clientX, Math.min(MIN_PANEL_WIDTH, room), room)
+
+            element.style.width = `${Math.round(width)}px`
+          }
+
+          if (edge === 'bottom' || edge === 'corner') {
+            const room = window.innerHeight - VIEWPORT_MARGIN
+            const height = clamp(moved.clientY - box.top, Math.min(MIN_PANEL_HEIGHT, room), room)
+
+            element.style.height = `${Math.round(height)}px`
+            element.style.maxHeight = 'none'
+          }
+        }
+
+        const release = () => {
+          handle.removeEventListener('pointermove', move)
+          handle.removeEventListener('pointerup', release)
+          handle.removeEventListener('pointercancel', release)
+
+          document.body.style.userSelect = selection
+
+          const settled = element.getBoundingClientRect()
+
+          if (edge === 'left' || edge === 'corner') {
+            this.state.width = Math.round(settled.width)
+          }
+
+          if (edge === 'bottom' || edge === 'corner') {
+            this.state.height = Math.round(settled.height)
+          }
+
+          this.saveState()
+        }
+
+        handle.addEventListener('pointermove', move)
+        handle.addEventListener('pointerup', release)
+        handle.addEventListener('pointercancel', release)
+      })
+    })
+  }
+
+  public resetSize() {
+    this.state.width = null
+    this.state.height = null
+
+    this.saveState()
+    this.render()
+  }
+
   private summary(): string {
-    const errors = this.countBy(entry => entry.diagnostic.severity === 'error')
-    const warnings = this.countBy(entry => entry.diagnostic.severity === 'warning')
-    const notices = this.countBy(entry => entry.diagnostic.severity === 'info' || entry.diagnostic.severity === 'hint')
-    const metrics = this.countBy(entry => entry.diagnostic.kind === 'metric')
+    const scope = this.overlayFocused ? this.visibleEntries() : this.entries
+    const errors = this.countBy(scope, entry => entry.diagnostic.severity === 'error')
+    const warnings = this.countBy(scope, entry => entry.diagnostic.severity === 'warning')
+    const notices = this.countBy(scope, entry => entry.diagnostic.severity === 'info' || entry.diagnostic.severity === 'hint')
+    const metrics = this.countBy(scope, entry => entry.diagnostic.kind === 'metric')
     const parts: string[] = []
 
     if (errors > 0) parts.push(`${errors} error${errors === 1 ? '' : 's'}`)
@@ -601,23 +1011,168 @@ export class RuntimePanel {
     return parts.length === 0 ? 'No runtime diagnostics' : parts.join(', ')
   }
 
-  private countBy(predicate: (entry: PanelEntry) => boolean): number {
-    return this.entries.filter(predicate).reduce((total, entry) => total + entry.count, 0)
+  private countBy(entries: PanelEntry[], predicate: (entry: PanelEntry) => boolean): number {
+    return entries.filter(predicate).reduce((total, entry) => total + entry.count, 0)
   }
 
   private headerHTML(): string {
+    const overlay = this.overlay
+
+    if (this.overlayFocused) {
+      return this.focusedHeaderHTML(overlay!)
+    }
+
     return [
       `<header class="herb-dev-tools-header">`,
       `<span class="herb-dev-tools-title">Herb Runtime Diagnostics</span>`,
-      `<span class="herb-dev-tools-summary">${escapeHTML(this.summary())}</span>`,
+      ...this.headerControlsHTML(overlay),
+      `</header>`,
+    ].join('')
+  }
+
+  private toneMarkerHTML(): string {
+    const tone = this.headerTone
+
+    if (tone === 'metric') {
+      return ''
+    }
+
+    return `<span class="herb-dev-tools-dot herb-dev-tools-dot-${tone}" aria-hidden="true"></span>`
+  }
+
+  private focusedHeaderHTML(overlay: OverlayMode): string {
+    const entries = this.visibleEntries()
+    const marker = this.toneMarkerHTML()
+    const label = 'Dismiss this overlay and keep the panel docked'
+
+    const close = overlay === 'blocking'
+      ? ''
+      : `<button type="button" class="herb-dev-tools-close" data-herb-dev-tools-action="dismiss-overlay" aria-label="${label}" title="${label}">×</button>`
+
+    return [
+      `<header class="herb-dev-tools-header">`,
+      marker,
+      `<span class="herb-dev-tools-title">${escapeHTML(this.overlayHeadline(entries))}</span>`,
+      this.overlayLocationHTML(entries),
+      `<div class="herb-dev-tools-window-controls">`,
+      this.overlayScopeButtonHTML(),
+      close,
+      `</div>`,
+      `</header>`,
+    ].join('')
+  }
+
+  private overlayLocationHTML(entries: PanelEntry[]): string {
+    const location = this.overlayLocation(entries)
+
+    if (location === null) {
+      return `<span class="herb-dev-tools-summary">${escapeHTML(this.summary())}</span>`
+    }
+
+    const diagnostic = entries[0].diagnostic
+    const start = diagnostic.location?.start
+
+    if (diagnostic.template === UNKNOWN_TEMPLATE) {
+      return `<span class="herb-dev-tools-summary">${escapeHTML(location)}</span>`
+    }
+
+    return this.pathHTML(
+      location,
+      diagnostic.template,
+      start?.line ?? 1,
+      start?.column ?? 1,
+      'herb-dev-tools-summary',
+    )
+  }
+
+  private overlayHeadline(entries: PanelEntry[]): string {
+    const origins = new Set(entries.map(entry => entry.diagnostic.origin))
+
+    return origins.size === 1 ? [...origins][0] : 'Herb Runtime Diagnostics'
+  }
+
+  private overlayLocation(entries: PanelEntry[]): string | null {
+    if (entries.length !== 1) {
+      return null
+    }
+
+    const diagnostic = entries[0].diagnostic
+    const start = diagnostic.location?.start
+
+    if (start === undefined) {
+      return diagnostic.template
+    }
+
+    return `${diagnostic.template}:${start.line}:${start.column}`
+  }
+
+  private featureButtonHTML(entry: PanelEntry): string {
+    if (this.overlayFocused || this.overlay === 'blocking') {
+      return ''
+    }
+
+    const label = 'Show this on its own screen'
+
+    return [
+      `<button type="button" class="herb-dev-tools-feature" data-herb-dev-tools-action="feature"`,
+      ` data-herb-dev-tools-entry="${this.entries.indexOf(entry)}"`,
+      ` title="${label}" aria-label="${label}">${EXPAND_ICON}</button>`,
+    ].join('')
+  }
+
+  private overlayScopeButtonHTML(): string {
+    if (this.overlay === null) {
+      return ''
+    }
+
+    if (this.overlayShowAll) {
+      const shown = this.overlayEntries(this.overlay).length
+      const label = shown === 1 ? 'Back to the error' : 'Back to the errors'
+
+      return `<button type="button" class="herb-dev-tools-scope" data-herb-dev-tools-action="overlay-scope">${label}</button>`
+    }
+
+    const hidden = this.count - this.visibleCount
+
+    if (hidden <= 0) {
+      return ''
+    }
+
+    const label = 'Show other diagnostics'
+    const description = hidden === 1
+      ? 'Show the one other diagnostic this page reported'
+      : `Show the other ${hidden} diagnostics this page reported`
+
+    return [
+      `<button type="button" class="herb-dev-tools-scope" data-herb-dev-tools-action="overlay-scope"`,
+      ` title="${escapeHTML(description)}" aria-label="${escapeHTML(description)}">${label}</button>`,
+    ].join('')
+  }
+
+  private headerControlsHTML(overlay: OverlayMode | null): string[] {
+    if (overlay === 'blocking') {
+      return [`<div class="herb-dev-tools-window-controls">`, this.overlayScopeButtonHTML(), `</div>`]
+    }
+
+    if (overlay === 'dismissible') {
+      const label = 'Dismiss this overlay and keep the panel docked'
+
+      return [
+        `<div class="herb-dev-tools-window-controls">`,
+        this.overlayScopeButtonHTML(),
+        `<button type="button" class="herb-dev-tools-close" data-herb-dev-tools-action="dismiss-overlay" aria-label="${label}" title="${label}">×</button>`,
+        `</div>`,
+      ]
+    }
+
+    return [
       this.clearButtonHTML(),
       `<button type="button" class="herb-dev-tools-hide" data-herb-dev-tools-action="dismiss">Hide for this session</button>`,
       `<div class="herb-dev-tools-window-controls">`,
       this.expandButtonHTML(),
       `<button type="button" class="herb-dev-tools-close" data-herb-dev-tools-action="close" aria-label="Close panel">×</button>`,
       `</div>`,
-      `</header>`,
-    ].join('')
+    ]
   }
 
   private get visibleCount(): number {
@@ -649,20 +1204,44 @@ export class RuntimePanel {
 
   private expandButtonHTML(): string {
     const label = this.state.expanded ? 'Collapse panel back to the corner' : 'Expand panel to fill the window'
-    const glyph = this.state.expanded ? '⤡' : '⤢'
+    const icon = this.state.expanded ? COLLAPSE_ICON : EXPAND_ICON
 
     return [
       `<button type="button" class="herb-dev-tools-expand" data-herb-dev-tools-action="expand"`,
       ` aria-expanded="${this.state.expanded}" aria-label="${label}" title="${label}">`,
-      `<span aria-hidden="true">${glyph}</span>`,
+      icon,
       `</button>`,
     ].join('')
   }
 
   private filtersHTML(): string {
+    if (this.overlayFocused) {
+      return ''
+    }
+
+    if (this.entries.length === 0) {
+      return ''
+    }
+
+    return `${this.originFiltersHTML()}${this.severityFiltersHTML()}`
+  }
+
+  private countOf(entries: PanelEntry[]): number {
+    return entries.reduce((total, entry) => total + entry.count, 0)
+  }
+
+  private filterButtonHTML(attribute: string, value: string, label: string, count: number, active: boolean): string {
+    return [
+      `<button type="button" class="herb-dev-tools-filter${active ? ' herb-dev-tools-filter-active' : ''}"`,
+      ` data-herb-dev-tools-action="filter" data-herb-dev-tools-${attribute}="${escapeHTML(value)}"`,
+      ` aria-pressed="${active}">${escapeHTML(label)} (${count})</button>`,
+    ].join('')
+  }
+
+  private originFiltersHTML(): string {
     const origins = new Map<string, number>()
 
-    for (const entry of this.entries) {
+    for (const entry of this.matching(ALL_ORIGINS, this.state.severity)) {
       origins.set(entry.diagnostic.origin, (origins.get(entry.diagnostic.origin) ?? 0) + entry.count)
     }
 
@@ -670,15 +1249,43 @@ export class RuntimePanel {
       return ''
     }
 
-    const buttons = [`<button type="button" class="herb-dev-tools-filter${this.state.origin === ALL_ORIGINS ? ' herb-dev-tools-filter-active' : ''}" data-herb-dev-tools-action="filter" data-herb-dev-tools-origin="${ALL_ORIGINS}">All (${this.count})</button>`]
+    const buttons = [this.filterButtonHTML(
+      'origin',
+      ALL_ORIGINS,
+      'All',
+      this.countOf(this.matching(ALL_ORIGINS, this.state.severity)),
+      this.state.origin === ALL_ORIGINS,
+    )]
 
     for (const [origin, count] of origins) {
-      const active = this.state.origin === origin ? ' herb-dev-tools-filter-active' : ''
-
-      buttons.push(`<button type="button" class="herb-dev-tools-filter${active}" data-herb-dev-tools-action="filter" data-herb-dev-tools-origin="${escapeHTML(origin)}">${escapeHTML(origin)} (${count})</button>`)
+      buttons.push(this.filterButtonHTML('origin', origin, origin, count, this.state.origin === origin))
     }
 
     return `<div class="herb-dev-tools-filters">${buttons.join('')}</div>`
+  }
+
+  private severityFiltersHTML(): string {
+    const available = SEVERITY_FILTERS
+      .map(filter => ({ filter, count: this.countOf(this.matching(this.state.origin, filter.value)) }))
+      .filter(candidate => candidate.count > 0)
+
+    if (available.length < 2) {
+      return ''
+    }
+
+    const buttons = [this.filterButtonHTML(
+      'severity',
+      ALL_SEVERITIES,
+      'Any severity',
+      this.countOf(this.matching(this.state.origin, ALL_SEVERITIES)),
+      this.state.severity === ALL_SEVERITIES,
+    )]
+
+    for (const { filter, count } of available) {
+      buttons.push(this.filterButtonHTML('severity', filter.value, filter.label, count, this.state.severity === filter.value))
+    }
+
+    return `<div class="herb-dev-tools-filters herb-dev-tools-filters-severity">${buttons.join('')}</div>`
   }
 
   private bodyHTML(): string {
@@ -741,14 +1348,15 @@ export class RuntimePanel {
       ].join('')
 
     const repeat = entry.count > 1 ? `<span class="herb-dev-tools-repeat" title="Reported ${entry.count} times">×${entry.count}</span>` : ''
+    const feature = this.featureButtonHTML(entry)
     const suggestion = diagnostic.suggestion === null ? '' : `<p class="herb-dev-tools-suggestion">${inlineCodeHTML(diagnostic.suggestion)}</p>`
     const element = diagnostic.element !== null && diagnostic.element.isConnected
       ? `<button type="button" class="herb-dev-tools-element" data-herb-dev-tools-action="locate" data-herb-dev-tools-entry="${this.entries.indexOf(entry)}" title="Scroll to this element and flash it"><span class="herb-dev-tools-element-glyph" aria-hidden="true">◎</span><code>${escapeHTML(describeElement(diagnostic.element))}</code></button>`
       : ''
 
     return [
-      `<article class="herb-dev-tools-card" data-herb-dev-tools-origin="${escapeHTML(diagnostic.origin)}" data-herb-dev-tools-kind="${escapeHTML(diagnostic.kind)}">`,
-      `<div class="herb-dev-tools-card-head">${marker}${code}${docs}<span class="herb-dev-tools-origin">${escapeHTML(diagnostic.origin)}</span>${repeat}</div>`,
+      `<article class="herb-dev-tools-card" data-herb-dev-tools-entry="${this.entries.indexOf(entry)}" data-herb-dev-tools-origin="${escapeHTML(diagnostic.origin)}" data-herb-dev-tools-kind="${escapeHTML(diagnostic.kind)}">`,
+      `<div class="herb-dev-tools-card-head">${marker}${code}${docs}<span class="herb-dev-tools-origin">${escapeHTML(diagnostic.origin)}</span>${repeat}${feature}</div>`,
       `<p class="herb-dev-tools-message">${inlineCodeHTML(diagnostic.message)}</p>`,
       element,
       suggestion,
@@ -774,7 +1382,10 @@ export class RuntimePanel {
       ? null
       : { file: diagnostic.template, line: diagnostic.location.start.line, column: diagnostic.location.start.column }
 
-    const rendered = this.highlighting.excerpt(source, diagnostic, target === null ? undefined : templateUrl(target.file))
+    const rendered = this.highlighting.excerpt(source, diagnostic, {
+      ...(target === null ? {} : { fileUrl: templateUrl(target.file) }),
+      contextLines: this.overlayFocused ? FOCUSED_CONTEXT_LINES : CONTEXT_LINES,
+    })
 
     if (rendered === null) {
       return ''
@@ -889,12 +1500,31 @@ export class RuntimePanel {
           this.toggleExpanded()
         } else if (action === 'collapse') {
           this.collapse()
+        } else if (action === 'dismiss-overlay') {
+          this.dismissOverlay()
+        } else if (action === 'overlay-scope') {
+          this.toggleOverlayScope()
+        } else if (action === 'feature') {
+          this.featureFrom(element)
         } else if (action === 'dismiss') {
           this.dismiss()
         } else if (action === 'clear') {
           this.clear(this.state.origin === ALL_ORIGINS ? undefined : this.state.origin)
+
+          if (this.entries.length === 0) {
+            this.close()
+          }
         } else if (action === 'filter') {
-          this.state.origin = element.getAttribute('data-herb-dev-tools-origin') ?? ALL_ORIGINS
+          const origin = element.getAttribute('data-herb-dev-tools-origin')
+          const severity = element.getAttribute('data-herb-dev-tools-severity')
+
+          if (origin !== null) {
+            this.state.origin = origin
+          }
+
+          if (severity !== null) {
+            this.state.severity = severity
+          }
 
           this.saveState()
           this.render()
@@ -936,8 +1566,22 @@ export class RuntimePanel {
 
     if (!target || !target.isConnected) return
 
+    this.stepOutOfTheWay()
+
     target.scrollIntoView({ block: 'center', behavior: 'smooth' })
     flashElement(target)
+  }
+
+  private stepOutOfTheWay() {
+    if (this.overlay === 'dismissible') {
+      this.dismissOverlay()
+
+      return
+    }
+
+    if (this.overlay === null && this.state.expanded) {
+      this.collapse()
+    }
   }
 
   private outline: HTMLElement | null = null
@@ -974,6 +1618,20 @@ export class RuntimePanel {
 
     this.onOpenFile(file, Number.isFinite(line) ? line : 1, Number.isFinite(column) ? column : 1)
   }
+}
+
+function severityOf(entries: PanelEntry[]): RuntimeSeverity | null {
+  for (const severity of RUNTIME_SEVERITIES) {
+    const present = entries.some(
+      entry => entry.diagnostic.kind === 'diagnostic' && entry.diagnostic.severity === severity
+    )
+
+    if (present) {
+      return severity
+    }
+  }
+
+  return null
 }
 
 function describeElement(element: Element): string {

--- a/javascript/packages/dev-tools/src/runtime/report.ts
+++ b/javascript/packages/dev-tools/src/runtime/report.ts
@@ -7,12 +7,14 @@ export const DEFAULT_SEVERITY: RuntimeSeverity = 'error';
 export const RENDER_VIA_VALUES = ['layout', 'template', 'partial', 'component'] as const;
 export const RUNTIME_SEVERITIES = ['error', 'warning', 'info', 'hint'] as const;
 export const RUNTIME_KINDS = ['diagnostic', 'metric'] as const;
+export const OVERLAY_MODES = ['blocking', 'dismissible'] as const;
 export const FIX_KINDS = ['safe', 'unsafe'] as const;
 export const DEFAULT_FIX_KIND: FixKind = 'safe';
 
 export type RenderVia = typeof RENDER_VIA_VALUES[number];
 export type RuntimeSeverity = typeof RUNTIME_SEVERITIES[number];
 export type RuntimeKind = typeof RUNTIME_KINDS[number];
+export type OverlayMode = typeof OVERLAY_MODES[number];
 export type FixKind = typeof FIX_KINDS[number];
 
 export function trimOrigin(value: unknown): string {
@@ -66,6 +68,7 @@ export interface RuntimeDiagnostic {
   docsUrl?: string;
   value?: string;
   fix?: RuntimeFix;
+  overlay?: OverlayMode | false;
   source?: string;
   element?: Element | null;
 }
@@ -90,6 +93,7 @@ export interface NormalizedDiagnostic {
   docsUrl: string | null;
   value: string | null;
   fix: NormalizedFix | null;
+  overlay: OverlayMode | null;
   element: Element | null;
 }
 
@@ -171,6 +175,10 @@ function normalizeSeverity(value: unknown): RuntimeSeverity | null {
 
 function normalizeKind(value: unknown): RuntimeKind {
   return RUNTIME_KINDS.includes(value as RuntimeKind) ? (value as RuntimeKind) : 'diagnostic';
+}
+
+function normalizeOverlay(value: unknown): OverlayMode | null {
+  return OVERLAY_MODES.includes(value as OverlayMode) ? (value as OverlayMode) : null;
 }
 
 function normalizeFixKind(value: unknown): FixKind {
@@ -264,6 +272,7 @@ export function normalizeDiagnostic(value: unknown, sources: Record<string, stri
     docsUrl: asString(value.docsUrl),
     value: asString(value.value),
     fix: normalizeFix(value.fix, template, sources),
+    overlay: normalizeOverlay(value.overlay),
     element: asElement(value.element),
   };
 }

--- a/javascript/packages/dev-tools/test/listener-lifecycle.test.ts
+++ b/javascript/packages/dev-tools/test/listener-lifecycle.test.ts
@@ -398,3 +398,72 @@ describe("runtime diagnostics menu toggle", () => {
     expect(toggle()!.checked).toBe(true)
   })
 })
+
+describe("opening the runtime diagnostics", () => {
+  function panel() {
+    return document.querySelector(".herb-dev-tools-panel") as HTMLElement | null
+  }
+
+  function report(instance: HerbDevTools) {
+    instance.report({
+      template: "app/views/posts/_actions.html.erb",
+      message: "Nested `<form>` elements are not allowed.",
+    })
+  }
+
+  test("opens the panel and closes it again", () => {
+    const instance = startDevTools()
+
+    report(instance)
+
+    expect(panel()!.classList.contains("herb-dev-tools-open")).toBe(false)
+
+    instance.open()
+
+    expect(panel()!.classList.contains("herb-dev-tools-open")).toBe(true)
+
+    instance.close()
+
+    expect(panel()!.classList.contains("herb-dev-tools-open")).toBe(false)
+  })
+
+  test("opens filling the window and back into the corner", () => {
+    const instance = startDevTools()
+
+    report(instance)
+
+    instance.open({ expanded: true })
+
+    expect(panel()!.classList.contains("herb-dev-tools-expanded")).toBe(true)
+
+    instance.open({ expanded: false })
+
+    expect(panel()!.classList.contains("herb-dev-tools-expanded")).toBe(false)
+  })
+
+  test("opens a panel that was hidden for the session", () => {
+    const instance = startDevTools()
+
+    report(instance)
+    instance.runtimePanel!.dismiss()
+
+    expect(panel()).toBeNull()
+
+    instance.open()
+
+    expect(instance.runtimePanel!.dismissed).toBe(false)
+    expect(panel()!.classList.contains("herb-dev-tools-open")).toBe(true)
+  })
+
+  test("is a no-op when the panel is switched off", () => {
+    const instance = startDevTools({ runtimePanel: false })
+
+    expect(() => {
+      instance.open()
+      instance.open({ expanded: true })
+      instance.close()
+    }).not.toThrow()
+
+    expect(panel()).toBeNull()
+  })
+})

--- a/javascript/packages/dev-tools/test/runtime-panel.test.ts
+++ b/javascript/packages/dev-tools/test/runtime-panel.test.ts
@@ -255,13 +255,39 @@ describe("clear control", () => {
     expect(JSON.parse(sessionStorage.getItem("herb-dev-tools-runtime-panel")!).dismissed).toBe(false)
   })
 
-  test("explains itself instead of vanishing when everything goes", () => {
+  test("closes the panel when the control empties it", () => {
     embed(PAYLOAD)
 
     const panel = createPanel()
 
     panel.open()
     clearButton()!.click()
+
+    expect(panel.count).toBe(0)
+    expect(root()).toBeNull()
+    expect(panel.dismissed).toBe(false)
+  })
+
+  test("stays open when the control only clears one origin", () => {
+    embed(PAYLOAD)
+
+    const panel = createPanel()
+
+    panel.open()
+    ;(document.querySelector('[data-herb-dev-tools-origin="Herb Linter"]') as HTMLButtonElement).click()
+    clearButton()!.click()
+
+    expect(root()).not.toBeNull()
+    expect(panel.count).toBe(2)
+  })
+
+  test("still explains itself when the API empties it", () => {
+    embed(PAYLOAD)
+
+    const panel = createPanel()
+
+    panel.open()
+    panel.clear()
 
     expect(root()).not.toBeNull()
     expect(document.querySelector(".herb-dev-tools-empty")!.textContent)
@@ -960,19 +986,16 @@ describe("expanded presentation", () => {
 
     const header = document.querySelector(".herb-dev-tools-header") as HTMLElement
     const title = document.querySelector(".herb-dev-tools-title") as HTMLElement
-    const summary = document.querySelector(".herb-dev-tools-summary") as HTMLElement
 
     const neutral = {
       band: getComputedStyle(header).backgroundColor,
       border: getComputedStyle(header).borderBottomColor,
       title: getComputedStyle(title).color,
-      summary: getComputedStyle(summary).color,
     }
 
     expect(neutral.band).toBe("rgb(249, 250, 251)")
     expect(neutral.border).toBe("rgb(229, 231, 235)")
     expect(neutral.title).toBe("rgb(17, 24, 39)")
-    expect(neutral.summary).toBe("rgb(107, 114, 128)")
 
     instance.clear()
     instance.report(diagnostic({ kind: "metric", value: "3 SQL queries", code: "two" }))
@@ -1016,7 +1039,7 @@ describe("expanded presentation", () => {
     expect(parseFloat(getComputedStyle(expandButton()).fontSize)).toBeGreaterThan(15)
   })
 
-  test("keeps the summary readable in the anchored header", () => {
+  test("keeps every control reachable in the anchored header", () => {
     embed(PAYLOAD)
 
     const instance = createPanel()
@@ -1027,15 +1050,64 @@ describe("expanded presentation", () => {
     const headerElement = document.querySelector(".herb-dev-tools-header") as HTMLElement
     const header = headerElement.getBoundingClientRect()
     const close = document.querySelector(".herb-dev-tools-close")!.getBoundingClientRect()
-    const summary = document.querySelector(".herb-dev-tools-summary")!.getBoundingClientRect()
 
     expect(headerElement.scrollWidth).toBeLessThanOrEqual(headerElement.clientWidth)
     expect(close.right).toBeLessThanOrEqual(header.right + 1)
-    expect(summary.right).toBeLessThanOrEqual(header.right)
-    expect(summary.width).toBeGreaterThan(60)
+
+    for (const control of Array.from(headerElement.querySelectorAll("button"))) {
+      const box = control.getBoundingClientRect()
+
+      expect(box.left).toBeGreaterThanOrEqual(header.left)
+      expect(box.right).toBeLessThanOrEqual(header.right + 1)
+    }
   })
 
-  test("gives the summary away before the controls when the panel is narrow", () => {
+  test("spends the header's width on controls, not on counts", () => {
+    embed(PAYLOAD)
+
+    const instance = createPanel()
+
+    instance.open()
+
+    expect(document.querySelector(".herb-dev-tools-summary")).toBeNull()
+    expect(document.querySelector(".herb-dev-tools-clear")).not.toBeNull()
+    expect(document.querySelector(".herb-dev-tools-hide")).not.toBeNull()
+
+    instance.expand()
+
+    expect(document.querySelector(".herb-dev-tools-summary")).toBeNull()
+  })
+
+  test("leaves the counts to the filter chips and the badge", () => {
+    embed(PAYLOAD)
+
+    const instance = createPanel()
+
+    instance.open()
+
+    const badge = document.querySelector(".herb-dev-tools-badge") as HTMLElement
+
+    expect(badge.title).toBe("1 error, 1 warning, 1 metric")
+
+    const chips = Array.from(document.querySelectorAll(".herb-dev-tools-filter")).map(node => node.textContent)
+
+    expect(chips).toContain("All (3)")
+    expect(chips.every(label => /\(\d+\)$/.test(label!))).toBe(true)
+  })
+
+  test("still counts what a focused overlay shows, where there are no chips", () => {
+    const instance = createPanel()
+
+    instance.report([
+      diagnostic({ code: "one", origin: "Herb Parser", overlay: "blocking" }),
+      diagnostic({ code: "two", origin: "Herb Validator", overlay: "blocking" }),
+    ])
+
+    expect(document.querySelector(".herb-dev-tools-filters")).toBeNull()
+    expect(document.querySelector(".herb-dev-tools-summary")!.textContent).toBe("2 errors")
+  })
+
+  test("gives the action labels away before the controls when the panel is narrow", () => {
     embed(PAYLOAD)
 
     const instance = createPanel()
@@ -1048,10 +1120,14 @@ describe("expanded presentation", () => {
     expect(headerElement.scrollWidth).toBeLessThanOrEqual(headerElement.clientWidth)
 
     const close = document.querySelector(".herb-dev-tools-close")!.getBoundingClientRect()
+    const expand = document.querySelector(".herb-dev-tools-expand")!.getBoundingClientRect()
     const clear = document.querySelector(".herb-dev-tools-clear")!.getBoundingClientRect()
+    const title = document.querySelector(".herb-dev-tools-title")!.getBoundingClientRect()
 
     expect(close.width).toBe(26)
+    expect(expand.width).toBe(26)
     expect(clear.width).toBeGreaterThan(0)
+    expect(title.width).toBeGreaterThan(0)
   })
 
   test("toggles the expanded surface on and off", () => {
@@ -1157,7 +1233,7 @@ describe("expanded presentation", () => {
     expect(instance.expanded).toBe(false)
   })
 
-  test("collapses on Escape and stops listening once collapsed", () => {
+  test("closes on Escape, the way the close button does, and stops listening", () => {
     embed(PAYLOAD)
 
     const instance = createPanel()
@@ -1167,14 +1243,40 @@ describe("expanded presentation", () => {
 
     document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }))
 
-    expect(instance.expanded).toBe(false)
+    expect(document.querySelector(".herb-dev-tools-panel.herb-dev-tools-open")).toBeNull()
+    expect(badge()).not.toBeNull()
+    expect(instance.dismissed).toBe(false)
 
     const remove = vi.spyOn(document, "removeEventListener")
 
     document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }))
 
-    expect(instance.expanded).toBe(false)
     expect(remove).not.toHaveBeenCalledWith("keydown", expect.anything())
+  })
+
+  test("leaves Escape and the close button in the same place", () => {
+    embed(PAYLOAD)
+
+    const escaped = createPanel()
+
+    escaped.open()
+    escaped.expand()
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }))
+
+    const afterEscape = { open: escaped.element?.querySelector(".herb-dev-tools-open") ?? null, expanded: escaped.expanded, dismissed: escaped.dismissed }
+
+    escaped.destroy()
+    document.body.innerHTML = ""
+    embed(PAYLOAD)
+
+    const clicked = createPanel()
+
+    clicked.open()
+    clicked.expand()
+    ;(document.querySelector('[data-herb-dev-tools-action="close"]') as HTMLButtonElement).click()
+
+    expect({ open: clicked.element?.querySelector(".herb-dev-tools-open") ?? null, expanded: clicked.expanded, dismissed: clicked.dismissed })
+      .toEqual(afterEscape)
   })
 
   test("releases the Escape listener on destroy", () => {
@@ -1231,7 +1333,8 @@ describe("filters", () => {
     embed(PAYLOAD)
     createPanel()
 
-    const labels = Array.from(document.querySelectorAll(".herb-dev-tools-filter")).map(node => node.textContent)
+    const labels = Array.from(document.querySelectorAll("[data-herb-dev-tools-origin].herb-dev-tools-filter"))
+      .map(node => node.textContent)
 
     expect(labels).toEqual(["All (3)", "Herb Linter (1)", "Acme Scanner (1)", "Herb Engine Runtime (1)"])
   })
@@ -1761,5 +1864,1859 @@ describe("highlighting cache", () => {
 
     expect(cards()).toHaveLength(1)
     expect(warn).not.toHaveBeenCalled()
+  })
+})
+
+describe("overlay", () => {
+  function panel() {
+    return document.querySelector(".herb-dev-tools-panel") as HTMLElement | null
+  }
+
+  function backdrop() {
+    return document.querySelector(".herb-dev-tools-backdrop") as HTMLElement | null
+  }
+
+  function escape() {
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }))
+  }
+
+  test("stays docked when nothing asks for an overlay", () => {
+    const instance = createPanel()
+
+    instance.report(diagnostic())
+
+    expect(instance.overlay).toBeNull()
+    expect(backdrop()).toBeNull()
+    expect(badge()).not.toBeNull()
+  })
+
+  test("takes over the screen when a diagnostic asks to block", () => {
+    const instance = createPanel()
+
+    instance.report(diagnostic({ overlay: "blocking" }))
+
+    expect(instance.overlay).toBe("blocking")
+    expect(panel()!.classList.contains("herb-dev-tools-overlay-blocking")).toBe(true)
+    expect(panel()!.classList.contains("herb-dev-tools-overlay-focused")).toBe(true)
+    expect(panel()!.getAttribute("aria-modal")).toBe("true")
+    expect(backdrop()).toBeNull()
+  })
+
+  test("offers no way out of a blocking overlay", () => {
+    const instance = createPanel()
+
+    instance.report(diagnostic({ overlay: "blocking" }))
+
+    expect(badge()).toBeNull()
+    expect(document.querySelector(".herb-dev-tools-close")).toBeNull()
+    expect(document.querySelector(".herb-dev-tools-hide")).toBeNull()
+    expect(document.querySelector(".herb-dev-tools-expand")).toBeNull()
+    expect(document.querySelector(".herb-dev-tools-clear")).toBeNull()
+
+    escape()
+
+    expect(instance.overlay).toBe("blocking")
+    expect(panel()).not.toBeNull()
+  })
+
+  test("ignores dismissOverlay while blocking", () => {
+    const instance = createPanel()
+
+    instance.report(diagnostic({ overlay: "blocking" }))
+    instance.dismissOverlay()
+
+    expect(instance.overlay).toBe("blocking")
+  })
+
+  test("shows a blocking overlay over a panel hidden for the session", () => {
+    const instance = createPanel()
+
+    instance.report(diagnostic({ code: "one" }))
+    instance.dismiss()
+
+    expect(panel()).toBeNull()
+
+    instance.report(diagnostic({ code: "two", overlay: "blocking" }))
+
+    expect(instance.dismissed).toBe(true)
+    expect(panel()).not.toBeNull()
+    expect(instance.overlay).toBe("blocking")
+  })
+
+  test("locks page scroll while blocking and gives it back afterwards", () => {
+    const instance = createPanel()
+    const before = document.documentElement.style.overflow
+
+    const handle = instance.report(diagnostic({ overlay: "blocking" }))
+
+    expect(document.documentElement.style.overflow).toBe("hidden")
+
+    handle.dismiss()
+
+    expect(instance.overlay).toBeNull()
+    expect(document.documentElement.style.overflow).toBe(before)
+  })
+
+  test("gives page scroll back on destroy", () => {
+    const instance = createPanel()
+    const before = document.documentElement.style.overflow
+
+    instance.report(diagnostic({ overlay: "blocking" }))
+    instance.destroy()
+
+    expect(document.documentElement.style.overflow).toBe(before)
+  })
+
+  test("lets the reporter take a blocking overlay down through its handle", () => {
+    const instance = createPanel()
+
+    const handle = instance.report(diagnostic({ overlay: "blocking" }))
+
+    handle.dismiss()
+
+    expect(instance.overlay).toBeNull()
+    expect(panel()).toBeNull()
+  })
+
+  test("leaves only the full-screen mode behind, keeping the panel open", () => {
+    const instance = createPanel()
+
+    instance.report([
+      diagnostic({ code: "linted", severity: "warning" }),
+      diagnostic({ code: "unhydrated", overlay: "dismissible" }),
+    ])
+
+    const close = document.querySelector('[data-herb-dev-tools-action="dismiss-overlay"]') as HTMLButtonElement
+
+    expect(close).not.toBeNull()
+
+    close.click()
+
+    expect(instance.overlay).toBeNull()
+    expect(backdrop()).toBeNull()
+    expect(panel()!.classList.contains("herb-dev-tools-open")).toBe(true)
+    expect(panel()!.classList.contains("herb-dev-tools-overlay-focused")).toBe(false)
+    expect(cards()).toHaveLength(2)
+  })
+
+  test("keeps the error it just featured visible in the panel", () => {
+    const instance = createPanel()
+
+    instance.report([
+      diagnostic({ code: "linted", severity: "warning", origin: "Herb Linter" }),
+      diagnostic({ code: "unhydrated", origin: "Herb Client Runtime", overlay: "dismissible" }),
+    ])
+
+    instance.dismissOverlay()
+
+    const featured = Array.from(document.querySelectorAll(".herb-dev-tools-card"))
+      .find(card => card.querySelector(".herb-dev-tools-code")?.textContent === "unhydrated") as HTMLElement
+
+    expect(featured).toBeDefined()
+    expect(featured.offsetParent).not.toBeNull()
+    expect(featured.getBoundingClientRect().height).toBeGreaterThan(0)
+  })
+
+  test("selects the featured error's own filter chip on the way out", () => {
+    const instance = createPanel()
+
+    instance.report([
+      diagnostic({ code: "linted", severity: "warning", origin: "Herb Linter" }),
+      diagnostic({ code: "unhydrated", origin: "Herb Client Runtime", overlay: "dismissible" }),
+    ])
+
+    instance.dismissOverlay()
+
+    const active = document.querySelector(".herb-dev-tools-filter-active") as HTMLButtonElement
+
+    expect(active.getAttribute("data-herb-dev-tools-origin")).toBe("Herb Client Runtime")
+    expect(Array.from(document.querySelectorAll(".herb-dev-tools-code")).map(node => node.textContent))
+      .toEqual(["unhydrated"])
+  })
+
+  test("overrides a filter that would have hidden the featured error", () => {
+    const instance = createPanel()
+
+    instance.report(diagnostic({ code: "linted", severity: "warning", origin: "Herb Linter" }))
+
+    ;(document.querySelector('[data-herb-dev-tools-origin="Herb Linter"]') as HTMLButtonElement).click()
+
+    instance.report(diagnostic({ code: "unhydrated", origin: "Herb Client Runtime", overlay: "dismissible" }))
+    instance.dismissOverlay()
+
+    expect(Array.from(document.querySelectorAll(".herb-dev-tools-code")).map(node => node.textContent))
+      .toContain("unhydrated")
+  })
+
+  test("falls back to All when the featured errors span origins", () => {
+    const instance = createPanel()
+
+    instance.report([
+      diagnostic({ code: "one", origin: "Herb Client Runtime", overlay: "dismissible" }),
+      diagnostic({ code: "two", origin: "Herb Parser", overlay: "dismissible" }),
+    ])
+
+    instance.dismissOverlay()
+
+    const active = document.querySelector(".herb-dev-tools-filter-active") as HTMLButtonElement
+
+    expect(active.getAttribute("data-herb-dev-tools-origin")).toBe("*")
+    expect(cards()).toHaveLength(2)
+  })
+
+  test("drops to the open panel when the overlay is escaped away", () => {
+    const instance = createPanel()
+
+    instance.report(diagnostic({ overlay: "dismissible" }))
+
+    escape()
+
+    expect(instance.overlay).toBeNull()
+    expect(panel()!.classList.contains("herb-dev-tools-open")).toBe(true)
+    expect(instance.count).toBe(1)
+  })
+
+  test("closes a widened dismissible overlay by its backdrop", () => {
+    const instance = createPanel()
+
+    instance.report([
+      diagnostic({ code: "linted", severity: "warning" }),
+      diagnostic({ code: "unhydrated", overlay: "dismissible" }),
+    ])
+
+    expect(backdrop()!.getAttribute("data-herb-dev-tools-action")).toBe("dismiss-overlay")
+
+    instance.toggleOverlayScope()
+
+    expect(backdrop()!.getAttribute("data-herb-dev-tools-action")).toBe("dismiss-overlay")
+
+    backdrop()!.click()
+
+    expect(instance.overlay).toBeNull()
+  })
+
+  test("gives a dismissible overlay the same chrome inside a box, plus a way out", () => {
+    const instance = createPanel()
+
+    instance.report(diagnostic({ origin: "Herb Client Runtime", overlay: "dismissible" }))
+
+    const element = panel()!
+    const box = element.getBoundingClientRect()
+
+    expect(element.classList.contains("herb-dev-tools-overlay-focused")).toBe(true)
+    expect(element.classList.contains("herb-dev-tools-overlay-fullscreen")).toBe(false)
+    expect(parseFloat(getComputedStyle(element).borderRadius)).toBeGreaterThan(0)
+    expect(box.width).toBeLessThan(window.innerWidth)
+    expect(box.height).toBeLessThan(window.innerHeight)
+    expect(backdrop()).not.toBeNull()
+
+    expect(document.querySelector(".herb-dev-tools-title")!.textContent).toBe("Herb Client Runtime")
+
+    const close = document.querySelector('[data-herb-dev-tools-action="dismiss-overlay"]') as HTMLButtonElement
+
+    close.click()
+
+    expect(instance.overlay).toBeNull()
+    expect(panel()!.classList.contains("herb-dev-tools-overlay-focused")).toBe(false)
+    expect(panel()!.classList.contains("herb-dev-tools-open")).toBe(true)
+  })
+
+  test("keeps the blocking screen edge to edge and the dismissible one inside a box", () => {
+    const instance = createPanel()
+
+    instance.report(diagnostic({ code: "unhydrated", overlay: "dismissible" }))
+
+    const boxed = panel()!.getBoundingClientRect()
+
+    instance.report(diagnostic({ code: "broke", overlay: "blocking" }))
+
+    const full = panel()!.getBoundingClientRect()
+
+    expect(boxed.width).toBeLessThan(full.width)
+    expect(full.width).toBe(window.innerWidth)
+    expect(backdrop()).toBeNull()
+  })
+
+  test("sizes the header path to its content and keeps the controls flush right", () => {
+    const instance = createPanel()
+
+    instance.report(diagnostic({
+      template: "app/components/post_actions_component.html.erb",
+      origin: "Herb Client Runtime",
+      location: { start: { line: 2, column: 3 } },
+      overlay: "dismissible",
+    }))
+
+    const header = document.querySelector(".herb-dev-tools-header") as HTMLElement
+    const path = header.querySelector(".herb-dev-tools-summary") as HTMLElement
+    const close = header.querySelector(".herb-dev-tools-close") as HTMLElement
+
+    expect(getComputedStyle(path).flexGrow).toBe("0")
+
+    const padding = parseFloat(getComputedStyle(header).paddingRight)
+
+    expect(close.getBoundingClientRect().right).toBeCloseTo(header.getBoundingClientRect().right - padding, 0)
+  })
+
+  test("accents the screen with the severity it is showing", () => {
+    const instance = createPanel()
+
+    instance.report(diagnostic({ code: "one", severity: "warning", overlay: "dismissible" }))
+
+    const header = () => getComputedStyle(document.querySelector(".herb-dev-tools-header") as HTMLElement).backgroundColor
+    const warning = header()
+
+    instance.report(diagnostic({ code: "two", severity: "error", overlay: "dismissible" }))
+
+    expect(header()).not.toBe(warning)
+  })
+
+  test("takes down every overlay it was showing, and no future one", () => {
+    const instance = createPanel()
+
+    instance.report([
+      diagnostic({ code: "one", overlay: "dismissible" }),
+      diagnostic({ code: "two", overlay: "dismissible" }),
+    ])
+
+    instance.dismissOverlay()
+
+    expect(instance.overlay).toBeNull()
+
+    instance.report(diagnostic({ code: "three", overlay: "dismissible" }))
+
+    expect(instance.overlay).toBe("dismissible")
+    expect(cards()).toHaveLength(1)
+  })
+
+  test("lets a blocking diagnostic override a dismissed overlay", () => {
+    const instance = createPanel()
+
+    instance.report(diagnostic({ code: "one", overlay: "dismissible" }))
+    instance.dismissOverlay()
+    instance.report(diagnostic({ code: "two", overlay: "blocking" }))
+
+    expect(instance.overlay).toBe("blocking")
+  })
+
+  test("escalates to blocking when a repeat of the same diagnostic blocks", () => {
+    const instance = createPanel()
+
+    instance.report(diagnostic({ code: "one", overlay: "dismissible" }))
+    instance.report(diagnostic({ code: "one", overlay: "blocking" }))
+
+    expect(instance.overlay).toBe("blocking")
+  })
+
+  test("reads an overlay out of the embedded report payload", () => {
+    embed({
+      version: 1,
+      diagnostics: [{
+        template: "app/views/posts/_actions.html.erb",
+        message: "Nested `<form>` elements are not allowed.",
+        overlay: "blocking",
+      }],
+    })
+
+    const instance = createPanel()
+
+    expect(instance.overlay).toBe("blocking")
+    expect(panel()!.classList.contains("herb-dev-tools-overlay-blocking")).toBe(true)
+  })
+
+  test("shows only the blocking entry, not the rest of the panel", () => {
+    const instance = createPanel()
+
+    instance.report([
+      diagnostic({ code: "linted", severity: "warning", origin: "Herb Linter" }),
+      diagnostic({ code: "measured", kind: "metric", value: "3 SQL queries", origin: "Herb Engine Runtime" }),
+    ])
+
+    expect(cards()).toHaveLength(2)
+
+    instance.report(diagnostic({ code: "broke", origin: "Herb Parser", overlay: "blocking" }))
+
+    expect(cards()).toHaveLength(1)
+    expect(cards()[0].querySelector(".herb-dev-tools-code")!.textContent).toBe("broke")
+    expect(instance.count).toBe(3)
+  })
+
+  test("shows only the dismissible entry while its overlay is up", () => {
+    const instance = createPanel()
+
+    instance.report([
+      diagnostic({ code: "linted", severity: "warning" }),
+      diagnostic({ code: "unhydrated", overlay: "dismissible" }),
+    ])
+
+    expect(cards()).toHaveLength(1)
+    expect(cards()[0].querySelector(".herb-dev-tools-code")!.textContent).toBe("unhydrated")
+
+    instance.dismissOverlay()
+
+    expect(cards()).toHaveLength(2)
+  })
+
+  test("leaves the dismissible entries out of a blocking overlay", () => {
+    const instance = createPanel()
+
+    instance.report([
+      diagnostic({ code: "unhydrated", overlay: "dismissible" }),
+      diagnostic({ code: "broke", overlay: "blocking" }),
+    ])
+
+    expect(instance.overlay).toBe("blocking")
+    expect(cards()).toHaveLength(1)
+    expect(cards()[0].querySelector(".herb-dev-tools-code")!.textContent).toBe("broke")
+  })
+
+  test("hides the origin filters while an overlay is up", () => {
+    const instance = createPanel()
+
+    instance.report([
+      diagnostic({ code: "linted", origin: "Herb Linter" }),
+      diagnostic({ code: "broke", origin: "Herb Parser", overlay: "blocking" }),
+    ])
+
+    expect(document.querySelector(".herb-dev-tools-filters")).toBeNull()
+
+    instance.clear("Herb Parser")
+
+    expect(document.querySelector(".herb-dev-tools-filters")).not.toBeNull()
+  })
+
+  test("heads a single blocking error with its origin and location", () => {
+    const instance = createPanel()
+
+    instance.report([
+      diagnostic({ code: "one", severity: "warning" }),
+      diagnostic({ code: "two", severity: "warning" }),
+    ])
+
+    instance.report(diagnostic({
+      code: "broke",
+      severity: "error",
+      origin: "Herb Parser",
+      location: { start: { line: 11, column: 3 } },
+      overlay: "blocking",
+    }))
+
+    expect(document.querySelector(".herb-dev-tools-title")!.textContent).toBe("Herb Parser")
+    expect(document.querySelector(".herb-dev-tools-summary")!.textContent)
+      .toBe("app/views/posts/_actions.html.erb:11:3")
+  })
+
+  test("carries no glyph in the blocking header", () => {
+    const instance = createPanel()
+
+    instance.report(diagnostic({ overlay: "blocking" }))
+
+    const header = document.querySelector(".herb-dev-tools-header")!
+
+    expect(header.querySelector(".herb-dev-tools-blocking-glyph")).toBeNull()
+    expect(header.querySelector(".herb-dev-tools-badge-glyph")).toBeNull()
+    expect(header.textContent).not.toMatch(/\p{Extended_Pictographic}/u)
+  })
+
+  test("opens the file from the blocking header path", () => {
+    const opened: unknown[] = []
+    const instance = createPanel({ onOpenFile: (file, line, column) => opened.push([file, line, column]) })
+
+    instance.report(diagnostic({
+      origin: "Herb Parser",
+      location: { start: { line: 11, column: 3 } },
+      overlay: "blocking",
+    }))
+
+    const path = document.querySelector(".herb-dev-tools-summary") as HTMLButtonElement
+
+    expect(path.tagName).toBe("BUTTON")
+
+    path.click()
+
+    expect(opened).toEqual([["app/views/posts/_actions.html.erb", 11, 3]])
+  })
+
+  test("leaves the header path as text with no editor handler", () => {
+    const instance = createPanel()
+
+    instance.report(diagnostic({ location: { start: { line: 11, column: 3 } }, overlay: "blocking" }))
+
+    expect((document.querySelector(".herb-dev-tools-summary") as HTMLElement).tagName).toBe("SPAN")
+  })
+
+  test("widens the excerpt and enlarges the code in a focused overlay", async () => {
+    const longSource = Array.from({ length: 40 }, (_, index) => `  <p>line ${index + 1}</p>`).join("\n")
+
+    embed({
+      version: 1,
+      sources: { "app/views/posts/_actions.html.erb": longSource },
+      diagnostics: [{
+        template: "app/views/posts/_actions.html.erb",
+        message: "Nested `<form>` elements are not allowed.",
+        code: "html-no-nested-forms",
+        severity: "error",
+        origin: "Herb Parser",
+        location: { start: { line: 20, column: 3 }, end: { line: 20, column: 10 } },
+        overlay: "blocking",
+      }],
+    })
+
+    const instance = createPanel()
+
+    const element = await waitForExcerpt()
+
+    expect(parseFloat(getComputedStyle(element).fontSize)).toBeGreaterThan(12)
+
+    const focused = element.textContent!.split("\n").length
+
+    instance.toggleOverlayScope()
+
+    const widened = await waitFor(
+      () => document.querySelector(".herb-dev-tools-ansi") as HTMLElement | null,
+      "the excerpt to re-render",
+    )
+
+    expect(focused).toBeGreaterThan(widened.textContent!.split("\n").length)
+    expect(parseFloat(getComputedStyle(widened).fontSize)).toBeLessThan(12)
+  })
+
+  test("falls back to a count when blocking entries disagree on origin", () => {
+    const instance = createPanel()
+
+    instance.report([
+      diagnostic({ code: "one", origin: "Herb Parser", overlay: "blocking" }),
+      diagnostic({ code: "two", origin: "Herb Validator", overlay: "blocking" }),
+    ])
+
+    expect(document.querySelector(".herb-dev-tools-title")!.textContent).toBe("Herb Runtime Diagnostics")
+    expect(document.querySelector(".herb-dev-tools-summary")!.textContent).toBe("2 errors")
+  })
+
+  test("gives a blocking screen its own full-screen chrome", () => {
+    const instance = createPanel()
+
+    instance.report(diagnostic({ overlay: "blocking" }))
+
+    const element = document.querySelector(".herb-dev-tools-panel") as HTMLElement
+    const styles = getComputedStyle(element)
+    const box = element.getBoundingClientRect()
+
+    expect(element.classList.contains("herb-dev-tools-overlay-focused")).toBe(true)
+    expect(styles.borderRadius).toBe("0px")
+    expect(box.width).toBe(window.innerWidth)
+    expect(box.height).toBe(window.innerHeight)
+  })
+
+  test("keeps the blocking screen from scrolling sideways", () => {
+    const instance = createPanel()
+
+    instance.report(diagnostic({ overlay: "blocking" }))
+
+    const body = document.querySelector(".herb-dev-tools-body") as HTMLElement
+    const card = document.querySelector(".herb-dev-tools-card") as HTMLElement
+
+    expect(body.getBoundingClientRect().width).toBeLessThanOrEqual(window.innerWidth)
+    expect(card.getBoundingClientRect().right).toBeLessThanOrEqual(window.innerWidth)
+  })
+
+  test("relaxes the chrome but stays edge to edge when a blocking overlay widens", () => {
+    const instance = createPanel()
+
+    instance.report([
+      diagnostic({ code: "linted", severity: "warning" }),
+      diagnostic({ code: "broke", overlay: "blocking" }),
+    ])
+
+    instance.toggleOverlayScope()
+
+    const element = document.querySelector(".herb-dev-tools-panel") as HTMLElement
+    const box = element.getBoundingClientRect()
+
+    expect(element.classList.contains("herb-dev-tools-overlay-focused")).toBe(false)
+    expect(element.classList.contains("herb-dev-tools-overlay-fullscreen")).toBe(true)
+    expect(box.width).toBe(window.innerWidth)
+    expect(box.height).toBe(window.innerHeight)
+    expect(backdrop()).toBeNull()
+  })
+
+  test("puts a widened dismissible overlay back in its box", () => {
+    const instance = createPanel()
+
+    instance.report([
+      diagnostic({ code: "linted", severity: "warning" }),
+      diagnostic({ code: "unhydrated", overlay: "dismissible" }),
+    ])
+
+    instance.toggleOverlayScope()
+
+    const element = document.querySelector(".herb-dev-tools-panel") as HTMLElement
+
+    expect(element.classList.contains("herb-dev-tools-overlay-fullscreen")).toBe(false)
+    expect(element.getBoundingClientRect().width).toBeLessThan(window.innerWidth)
+  })
+
+  test("offers no Clear control inside a dismissible overlay", () => {
+    const instance = createPanel()
+
+    instance.report(diagnostic({ overlay: "dismissible" }))
+
+    expect(document.querySelector(".herb-dev-tools-clear")).toBeNull()
+
+    instance.dismissOverlay()
+
+    expect(document.querySelector(".herb-dev-tools-clear")).not.toBeNull()
+  })
+
+  test("offers the widen control only when the overlay is hiding something", () => {
+    const instance = createPanel()
+
+    instance.report(diagnostic({ code: "broke", overlay: "blocking" }))
+
+    expect(document.querySelector('[data-herb-dev-tools-action="overlay-scope"]')).toBeNull()
+
+    instance.report(diagnostic({ code: "linted", severity: "warning" }))
+
+    const scope = document.querySelector('[data-herb-dev-tools-action="overlay-scope"]') as HTMLButtonElement
+
+    expect(scope).not.toBeNull()
+    expect(scope.textContent).toBe("Show other diagnostics")
+  })
+
+  test("shows everything behind a blocking overlay and comes back", () => {
+    const instance = createPanel()
+
+    instance.report([
+      diagnostic({ code: "linted", severity: "warning", origin: "Herb Linter" }),
+      diagnostic({ code: "broke", origin: "Herb Parser", overlay: "blocking" }),
+    ])
+
+    expect(cards()).toHaveLength(1)
+
+    const scope = () => document.querySelector('[data-herb-dev-tools-action="overlay-scope"]') as HTMLButtonElement
+
+    scope().click()
+
+    expect(instance.overlayShowingAll).toBe(true)
+    expect(cards()).toHaveLength(2)
+    expect(document.querySelector(".herb-dev-tools-filters")).not.toBeNull()
+    expect(scope().textContent).toBe("Back to the error")
+
+    scope().click()
+
+    expect(instance.overlayShowingAll).toBe(false)
+    expect(cards()).toHaveLength(1)
+  })
+
+  test("keeps a blocking overlay blocking while it shows everything", () => {
+    const instance = createPanel()
+
+    instance.report([
+      diagnostic({ code: "linted", severity: "warning" }),
+      diagnostic({ code: "broke", overlay: "blocking" }),
+    ])
+
+    instance.toggleOverlayScope()
+
+    expect(document.querySelector(".herb-dev-tools-close")).toBeNull()
+    expect(document.querySelector(".herb-dev-tools-hide")).toBeNull()
+    expect(document.documentElement.style.overflow).toBe("hidden")
+
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }))
+
+    expect(instance.overlay).toBe("blocking")
+  })
+
+  test("forgets the widened scope once the overlay goes", () => {
+    const instance = createPanel()
+
+    instance.report([
+      diagnostic({ code: "linted", severity: "warning" }),
+      diagnostic({ code: "broke", origin: "Herb Parser", overlay: "blocking" }),
+    ])
+
+    instance.toggleOverlayScope()
+    instance.clear("Herb Parser")
+
+    expect(instance.overlayShowingAll).toBe(false)
+  })
+
+  test("forgets a dismissal once the diagnostic is cleared", () => {
+    const instance = createPanel()
+
+    instance.report(diagnostic({ code: "one", overlay: "dismissible" }))
+    instance.dismissOverlay()
+    instance.clear()
+    instance.report(diagnostic({ code: "one", overlay: "dismissible" }))
+
+    expect(instance.overlay).toBe("dismissible")
+  })
+})
+
+describe("re-raising a dismissed overlay", () => {
+  test("raises again when the same diagnostic is reported again", () => {
+    const instance = createPanel()
+
+    instance.report(diagnostic({ code: "unhydrated", overlay: "dismissible" }))
+    instance.dismissOverlay()
+
+    expect(instance.overlay).toBeNull()
+
+    instance.report(diagnostic({ code: "unhydrated", overlay: "dismissible" }))
+
+    expect(instance.overlay).toBe("dismissible")
+    expect(instance.count).toBe(2)
+  })
+
+  test("stays down across renders that report nothing", () => {
+    const instance = createPanel()
+
+    instance.report(diagnostic({ code: "unhydrated", overlay: "dismissible" }))
+    instance.dismissOverlay()
+
+    instance.report(diagnostic({ code: "linted", severity: "warning" }))
+    instance.open()
+    instance.expand()
+    instance.collapse()
+
+    expect(instance.overlay).toBeNull()
+  })
+
+  test("raises again when a fresh payload carries the overlay", () => {
+    const instance = createPanel()
+
+    instance.report(diagnostic({ code: "unhydrated", overlay: "dismissible" }))
+    instance.dismissOverlay()
+
+    embed({
+      version: 1,
+      diagnostics: [{
+        template: "app/views/posts/_actions.html.erb",
+        message: "Nested `<form>` elements are not allowed.",
+        code: "unhydrated",
+        overlay: "dismissible",
+      }],
+    })
+
+    instance.refresh()
+
+    expect(instance.overlay).toBe("dismissible")
+  })
+})
+
+describe("featuring an entry from the panel", () => {
+  function panel() {
+    return document.querySelector(".herb-dev-tools-panel") as HTMLElement | null
+  }
+
+  function featureButtons() {
+    return Array.from(document.querySelectorAll('[data-herb-dev-tools-action="feature"]')) as HTMLButtonElement[]
+  }
+
+  function seed(instance: RuntimePanel) {
+    instance.report([
+      diagnostic({ code: "linted", severity: "warning", origin: "Herb Linter" }),
+      diagnostic({ code: "measured", kind: "metric", value: "3 SQL queries", origin: "Herb Engine Runtime" }),
+    ])
+  }
+
+  test("offers a control on every card in the docked panel", () => {
+    const instance = createPanel()
+
+    seed(instance)
+    instance.open()
+
+    expect(featureButtons()).toHaveLength(2)
+  })
+
+  test("puts a plain entry on its own dismissible screen", () => {
+    const instance = createPanel()
+
+    seed(instance)
+    instance.open()
+
+    featureButtons()[0].click()
+
+    expect(instance.overlay).toBe("dismissible")
+    expect(instance.featured).not.toBeNull()
+    expect(panel()!.classList.contains("herb-dev-tools-overlay-focused")).toBe(true)
+    expect(cards()).toHaveLength(1)
+    expect(document.querySelector(".herb-dev-tools-code")!.textContent).toBe("linted")
+    expect(document.querySelector(".herb-dev-tools-title")!.textContent).toBe("Herb Linter")
+  })
+
+  test("leaves the diagnostic itself untouched", () => {
+    const instance = createPanel()
+
+    seed(instance)
+    instance.open()
+    featureButtons()[0].click()
+    instance.dismissOverlay()
+
+    expect(instance.overlay).toBeNull()
+    expect(instance.featured).toBeNull()
+
+    instance.open()
+    featureButtons()[0].click()
+
+    expect(instance.overlay).toBe("dismissible")
+  })
+
+  test("hides its own control while a screen is featured", () => {
+    const instance = createPanel()
+
+    seed(instance)
+    instance.open()
+    featureButtons()[0].click()
+
+    expect(featureButtons()).toHaveLength(0)
+  })
+
+  test("offers no control while a blocking overlay outranks it", () => {
+    const instance = createPanel()
+
+    seed(instance)
+    instance.report(diagnostic({ code: "broke", overlay: "blocking" }))
+    instance.toggleOverlayScope()
+
+    expect(featureButtons()).toHaveLength(0)
+  })
+
+  test("gives way to a declared overlay", () => {
+    const instance = createPanel()
+
+    seed(instance)
+    instance.open()
+    featureButtons()[0].click()
+
+    instance.report(diagnostic({ code: "unhydrated", origin: "Herb Client Runtime", overlay: "dismissible" }))
+
+    expect(document.querySelector(".herb-dev-tools-code")!.textContent).toBe("unhydrated")
+  })
+
+  test("forgets a featured entry once it is cleared", () => {
+    const instance = createPanel()
+
+    seed(instance)
+    instance.open()
+    featureButtons()[0].click()
+
+    instance.clear("Herb Linter")
+
+    expect(instance.featured).toBeNull()
+    expect(instance.overlay).toBeNull()
+  })
+
+  test("ignores a key that names nothing", () => {
+    const instance = createPanel()
+
+    seed(instance)
+    instance.feature("not a key")
+
+    expect(instance.overlay).toBeNull()
+  })
+})
+
+describe("overlay heading bar", () => {
+  function header() {
+    return document.querySelector(".herb-dev-tools-header") as HTMLElement
+  }
+
+  function metrics(element: HTMLElement) {
+    const styles = getComputedStyle(element)
+
+    return { padding: styles.padding, gap: styles.gap }
+  }
+
+  test("puts no count on the widen control, since none of them is the right one", () => {
+    const instance = createPanel()
+
+    instance.report([
+      diagnostic({ code: "linted", severity: "warning" }),
+      diagnostic({ code: "measured", kind: "metric", value: "3 SQL queries" }),
+      diagnostic({ code: "broke", overlay: "blocking" }),
+    ])
+
+    const scope = document.querySelector('[data-herb-dev-tools-action="overlay-scope"]') as HTMLButtonElement
+
+    expect(scope.textContent).toBe("Show other diagnostics")
+    expect(scope.textContent).not.toMatch(/\d/)
+  })
+
+  test("names the hidden count where there is room to be exact", () => {
+    const instance = createPanel()
+
+    instance.report([
+      diagnostic({ code: "linted", severity: "warning" }),
+      diagnostic({ code: "measured", kind: "metric", value: "3 SQL queries" }),
+      diagnostic({ code: "broke", overlay: "blocking" }),
+    ])
+
+    const scope = () => document.querySelector('[data-herb-dev-tools-action="overlay-scope"]') as HTMLButtonElement
+
+    expect(scope().title).toBe("Show the other 2 diagnostics this page reported")
+
+    instance.clear("unknown")
+    instance.report([
+      diagnostic({ code: "linted", severity: "warning" }),
+      diagnostic({ code: "broke", overlay: "blocking" }),
+    ])
+
+    expect(scope().title).toBe("Show the one other diagnostic this page reported")
+  })
+
+  test("keeps one bar layout across the focused and widened views", () => {
+    const instance = createPanel()
+
+    instance.report([
+      diagnostic({ code: "linted", severity: "warning" }),
+      diagnostic({ code: "broke", overlay: "blocking" }),
+    ])
+
+    const focused = metrics(header())
+    const focusedTitle = getComputedStyle(document.querySelector(".herb-dev-tools-title") as HTMLElement).fontSize
+
+    instance.toggleOverlayScope()
+
+    const widened = metrics(header())
+    const widenedTitle = getComputedStyle(document.querySelector(".herb-dev-tools-title") as HTMLElement).fontSize
+
+    expect(widened).toEqual(focused)
+    expect(widenedTitle).toBe(focusedTitle)
+  })
+
+  test("groups the controls to the right in both views", () => {
+    const instance = createPanel()
+
+    instance.report([
+      diagnostic({ code: "linted", severity: "warning" }),
+      diagnostic({ code: "unhydrated", overlay: "dismissible" }),
+    ])
+
+    const controls = () => header().querySelector(".herb-dev-tools-window-controls") as HTMLElement
+
+    expect(controls()).toBe(header().lastElementChild)
+    expect(Array.from(controls().children).map(node => node.getAttribute("data-herb-dev-tools-action")))
+      .toEqual(["overlay-scope", "dismiss-overlay"])
+
+    instance.toggleOverlayScope()
+
+    expect(controls()).toBe(header().lastElementChild)
+    expect(Array.from(controls().children).map(node => node.getAttribute("data-herb-dev-tools-action")))
+      .toEqual(["overlay-scope", "dismiss-overlay"])
+  })
+
+  test("lines the filter chips up with the heading bar", () => {
+    const instance = createPanel()
+
+    instance.report([
+      diagnostic({ code: "linted", severity: "warning" }),
+      diagnostic({ code: "broke", overlay: "blocking" }),
+    ])
+
+    instance.toggleOverlayScope()
+
+    const filters = document.querySelector(".herb-dev-tools-filters") as HTMLElement
+
+    expect(getComputedStyle(filters).paddingLeft).toBe(getComputedStyle(header()).paddingLeft)
+  })
+})
+
+describe("overlay severity accent", () => {
+  function band() {
+    const header = document.querySelector(".herb-dev-tools-header") as HTMLElement
+
+    return getComputedStyle(header)
+  }
+
+  test("tints instead of filling, keeping the text dark", () => {
+    const instance = createPanel()
+
+    instance.report(diagnostic({ severity: "error", overlay: "dismissible" }))
+
+    const styles = band()
+
+    expect(styles.backgroundColor).not.toBe("rgb(220, 38, 38)")
+    expect(styles.color).not.toBe("rgb(255, 255, 255)")
+    expect(styles.backgroundColor).not.toBe("rgb(249, 250, 251)")
+    expect(styles.borderBottomColor).not.toBe("rgb(229, 231, 235)")
+    expect(styles.boxShadow).toBe("none")
+  })
+
+  test("takes the accent from the severity it is showing", () => {
+    const instance = createPanel()
+
+    instance.report(diagnostic({ code: "warned", severity: "warning", overlay: "dismissible" }))
+
+    const warning = band().backgroundColor
+
+    instance.dismissOverlay()
+    instance.report(diagnostic({ code: "errored", severity: "error", overlay: "dismissible" }))
+
+    expect(band().backgroundColor).not.toBe(warning)
+  })
+
+  test("follows the featured entry, not the loudest entry in the panel", () => {
+    const instance = createPanel()
+
+    instance.report(diagnostic({ code: "errored", severity: "error" }))
+    instance.report(diagnostic({ code: "warned", severity: "warning", overlay: "dismissible" }))
+
+    const featured = band().backgroundColor
+
+    instance.dismissOverlay()
+    instance.clear()
+    instance.report(diagnostic({ code: "warned", severity: "warning", overlay: "dismissible" }))
+
+    expect(band().backgroundColor).toBe(featured)
+  })
+
+  test("carries a severity dot, not an emoji", () => {
+    const instance = createPanel()
+
+    instance.report(diagnostic({ severity: "warning", overlay: "dismissible" }))
+
+    const header = document.querySelector(".herb-dev-tools-header")!
+
+    expect(header.querySelector(".herb-dev-tools-dot-warning")).not.toBeNull()
+    expect(header.textContent).not.toMatch(/\p{Extended_Pictographic}/u)
+  })
+})
+
+describe("heading bar across the overlay toggle", () => {
+  function header() {
+    return document.querySelector(".herb-dev-tools-header") as HTMLElement
+  }
+
+  function chrome() {
+    const styles = getComputedStyle(header())
+
+    return {
+      background: styles.backgroundColor,
+      border: styles.borderBottomColor,
+      shadow: styles.boxShadow,
+      color: styles.color,
+      padding: styles.padding,
+    }
+  }
+
+  test("keeps the bar's size but drops the colour when the view widens", () => {
+    const instance = createPanel()
+
+    instance.report([
+      diagnostic({ code: "linted", severity: "error", origin: "Herb Linter" }),
+      diagnostic({ code: "broke", severity: "error", origin: "Herb Parser", overlay: "blocking" }),
+    ])
+
+    const featured = chrome()
+
+    expect(header().querySelector(".herb-dev-tools-dot-error")).not.toBeNull()
+
+    instance.toggleOverlayScope()
+
+    const widened = chrome()
+
+    expect(widened.padding).toBe(featured.padding)
+    expect(widened.background).not.toBe(featured.background)
+    expect(widened.background).toBe("rgb(249, 250, 251)")
+    expect(header().querySelector(".herb-dev-tools-dot")).toBeNull()
+  })
+
+  test("does the same for a dismissible overlay", () => {
+    const instance = createPanel()
+
+    instance.report([
+      diagnostic({ code: "linted", severity: "warning", origin: "Herb Linter" }),
+      diagnostic({ code: "unhydrated", severity: "warning", origin: "Herb Client Runtime", overlay: "dismissible" }),
+    ])
+
+    const featured = chrome()
+
+    instance.toggleOverlayScope()
+
+    expect(chrome().padding).toBe(featured.padding)
+    expect(chrome().background).toBe("rgb(249, 250, 251)")
+  })
+
+  test("leaves the docked panel header untinted", () => {
+    const instance = createPanel()
+
+    instance.report(diagnostic({ severity: "error" }))
+    instance.open()
+
+    const docked = chrome()
+
+    expect(docked.background).toBe("rgb(249, 250, 251)")
+    expect(docked.shadow).toBe("none")
+    expect(header().querySelector(".herb-dev-tools-dot")).toBeNull()
+  })
+})
+
+describe("expanding the docked panel", () => {
+  function header() {
+    return document.querySelector(".herb-dev-tools-header") as HTMLElement
+  }
+
+  function chrome() {
+    const styles = getComputedStyle(header())
+
+    return {
+      background: styles.backgroundColor,
+      border: styles.borderBottomColor,
+      color: styles.color,
+      padding: styles.padding,
+      title: getComputedStyle(document.querySelector(".herb-dev-tools-title") as HTMLElement).fontSize,
+    }
+  }
+
+  test("uses the widened overlay's heading bar, not the docked one", () => {
+    const instance = createPanel()
+
+    instance.report([
+      diagnostic({ code: "linted", severity: "error", origin: "Herb Linter" }),
+      diagnostic({ code: "broke", severity: "error", origin: "Herb Parser", overlay: "blocking" }),
+    ])
+
+    instance.toggleOverlayScope()
+
+    const widened = chrome()
+
+    instance.clear("Herb Parser")
+    instance.open()
+
+    const docked = chrome()
+
+    instance.expand()
+
+    expect(chrome()).toEqual(widened)
+    expect(docked).not.toEqual(widened)
+  })
+
+  test("stays neutral, since nothing is featured", () => {
+    const instance = createPanel()
+
+    instance.report(diagnostic({ code: "warned", severity: "warning" }))
+    instance.open()
+    instance.expand()
+
+    const warning = chrome().background
+
+    instance.report(diagnostic({ code: "errored", severity: "error" }))
+
+    expect(chrome().background).toBe(warning)
+    expect(chrome().background).toBe("rgb(249, 250, 251)")
+    expect(header().querySelector(".herb-dev-tools-dot")).toBeNull()
+  })
+
+  test("goes back to the compact bar when collapsed", () => {
+    const instance = createPanel()
+
+    instance.report(diagnostic({ severity: "error" }))
+    instance.open()
+
+    const docked = chrome()
+
+    instance.expand()
+    instance.collapse()
+
+    expect(chrome()).toEqual(docked)
+    expect(header().querySelector(".herb-dev-tools-dot")).toBeNull()
+  })
+})
+
+describe("severity filter", () => {
+  function severityChips() {
+    return Array.from(document.querySelectorAll("[data-herb-dev-tools-severity]")) as HTMLButtonElement[]
+  }
+
+  function chip(value: string) {
+    return document.querySelector(`[data-herb-dev-tools-severity="${value}"]`) as HTMLButtonElement
+  }
+
+  function originChip(value: string) {
+    return document.querySelector(`[data-herb-dev-tools-origin="${value}"]`) as HTMLButtonElement
+  }
+
+  function codes() {
+    return Array.from(document.querySelectorAll(".herb-dev-tools-code")).map(node => node.textContent)
+  }
+
+  function seed(instance: RuntimePanel) {
+    instance.report([
+      diagnostic({ code: "broke", severity: "error", origin: "Herb Parser" }),
+      diagnostic({ code: "linted", severity: "warning", origin: "Herb Linter" }),
+      diagnostic({ code: "styled", severity: "warning", origin: "Acme Scanner" }),
+      diagnostic({ code: "noted", severity: "info", origin: "Herb Linter" }),
+      diagnostic({ code: "hinted", severity: "hint", origin: "Herb Linter" }),
+      diagnostic({ code: "measured", kind: "metric", value: "3 SQL queries", origin: "Herb Engine Runtime" }),
+    ])
+
+    instance.open()
+  }
+
+  test("offers a chip per severity present, counting each", () => {
+    const instance = createPanel()
+
+    seed(instance)
+
+    expect(severityChips().map(node => node.textContent))
+      .toEqual(["Any severity (6)", "Errors (1)", "Warnings (2)", "Notices (2)", "Metrics (1)"])
+  })
+
+  test("folds info and hint together the way the summary does", () => {
+    const instance = createPanel()
+
+    seed(instance)
+    chip("notice").click()
+
+    expect(codes()).toEqual(["noted", "hinted"])
+  })
+
+  test("narrows the list and marks the chip active", () => {
+    const instance = createPanel()
+
+    seed(instance)
+
+    expect(cards()).toHaveLength(6)
+
+    chip("warning").click()
+
+    expect(codes()).toEqual(["linted", "styled"])
+    expect(chip("warning").getAttribute("aria-pressed")).toBe("true")
+    expect(chip("*").getAttribute("aria-pressed")).toBe("false")
+
+    chip("*").click()
+
+    expect(cards()).toHaveLength(6)
+  })
+
+  test("separates metrics from diagnostics", () => {
+    const instance = createPanel()
+
+    seed(instance)
+    chip("metric").click()
+
+    expect(codes()).toEqual(["measured"])
+
+    chip("error").click()
+
+    expect(codes()).toEqual(["broke"])
+  })
+
+  test("combines with the origin filter", () => {
+    const instance = createPanel()
+
+    seed(instance)
+
+    originChip("Herb Linter").click()
+    chip("warning").click()
+
+    expect(codes()).toEqual(["linted"])
+  })
+
+  test("recounts each group against the other filter", () => {
+    const instance = createPanel()
+
+    seed(instance)
+    originChip("Herb Linter").click()
+
+    expect(severityChips().map(node => node.textContent))
+      .toEqual(["Any severity (3)", "Warnings (1)", "Notices (2)"])
+
+    chip("notice").click()
+
+    expect(Array.from(document.querySelectorAll(".herb-dev-tools-filter[data-herb-dev-tools-origin]"))
+      .map(node => node.textContent)).toEqual(["All (2)", "Herb Linter (2)"])
+  })
+
+  test("stays out of the way when everything shares one severity", () => {
+    const instance = createPanel()
+
+    instance.report([
+      diagnostic({ code: "one", severity: "error" }),
+      diagnostic({ code: "two", severity: "error" }),
+    ])
+
+    instance.open()
+
+    expect(severityChips()).toHaveLength(0)
+  })
+
+  test("releases a filter whose entries are all gone", () => {
+    const instance = createPanel()
+
+    seed(instance)
+    chip("metric").click()
+
+    expect(cards()).toHaveLength(1)
+
+    instance.clear("Herb Engine Runtime")
+
+    expect(chip("metric")).toBeNull()
+    expect(chip("*").getAttribute("aria-pressed")).toBe("true")
+    expect(cards()).toHaveLength(5)
+  })
+
+  test("drops the whole row when one severity is left", () => {
+    const instance = createPanel()
+
+    seed(instance)
+
+    instance.clear("Herb Engine Runtime")
+    instance.clear("Herb Linter")
+    instance.clear("Acme Scanner")
+
+    expect(severityChips()).toHaveLength(0)
+    expect(cards()).toHaveLength(1)
+  })
+
+  test("is cleared when an overlay hands back to the panel", () => {
+    const instance = createPanel()
+
+    seed(instance)
+    chip("metric").click()
+
+    instance.report(diagnostic({ code: "unhydrated", severity: "error", origin: "Herb Client Runtime", overlay: "dismissible" }))
+    instance.dismissOverlay()
+
+    expect(codes()).toEqual(["unhydrated"])
+  })
+
+  test("survives a reload the way the origin filter does", () => {
+    embed(PAYLOAD)
+
+    const first = createPanel()
+
+    first.open()
+    chip("warning").click()
+
+    const before = Array.from(document.querySelectorAll(".herb-dev-tools-code")).map(node => node.textContent)
+
+    first.destroy()
+    document.body.innerHTML = ""
+    embed(PAYLOAD)
+
+    const second = createPanel()
+
+    second.open()
+
+    expect(chip("warning").getAttribute("aria-pressed")).toBe("true")
+    expect(Array.from(document.querySelectorAll(".herb-dev-tools-code")).map(node => node.textContent)).toEqual(before)
+  })
+})
+
+describe("leaving a featured overlay", () => {
+  function panel() {
+    return document.querySelector(".herb-dev-tools-panel") as HTMLElement | null
+  }
+
+  function state(instance: RuntimePanel) {
+    return {
+      overlay: instance.overlay,
+      featured: instance.featured,
+      expanded: instance.expanded,
+      open: panel()!.classList.contains("herb-dev-tools-open"),
+      focused: panel()!.classList.contains("herb-dev-tools-overlay-focused"),
+      backdrop: document.querySelector(".herb-dev-tools-backdrop") !== null,
+    }
+  }
+
+  function seed(instance: RuntimePanel) {
+    instance.report([
+      diagnostic({ code: "linted", severity: "warning", origin: "Herb Linter" }),
+      diagnostic({ code: "measured", kind: "metric", value: "3 SQL queries", origin: "Herb Engine Runtime" }),
+    ])
+  }
+
+  function click(action: string) {
+    ;(document.querySelector(`[data-herb-dev-tools-action="${action}"]`) as HTMLButtonElement).click()
+  }
+
+  test("lands in the docked panel, whatever it was expanded to before", () => {
+    const instance = createPanel()
+
+    seed(instance)
+    instance.open()
+    instance.expand()
+
+    expect(instance.expanded).toBe(true)
+
+    click("feature")
+
+    expect(state(instance)).toMatchObject({ overlay: "dismissible", focused: true, expanded: true })
+
+    click("dismiss-overlay")
+
+    expect(state(instance)).toEqual({
+      overlay: null,
+      featured: null,
+      expanded: false,
+      open: true,
+      focused: false,
+      backdrop: false,
+    })
+  })
+
+  test("lands in the same place whether or not it was expanded first", () => {
+    const collapsed = createPanel()
+
+    seed(collapsed)
+    collapsed.open()
+    click("feature")
+    click("dismiss-overlay")
+
+    const withoutExpanding = state(collapsed)
+
+    collapsed.destroy()
+    document.body.innerHTML = ""
+    sessionStorage.clear()
+
+    const expanded = createPanel()
+
+    seed(expanded)
+    expanded.open()
+    expanded.expand()
+    click("feature")
+    click("dismiss-overlay")
+
+    expect(state(expanded)).toEqual(withoutExpanding)
+  })
+
+  test("collapses a reported dismissible overlay out of full screen too", () => {
+    const instance = createPanel()
+
+    seed(instance)
+    instance.open()
+    instance.expand()
+
+    instance.report(diagnostic({ code: "unhydrated", origin: "Herb Client Runtime", overlay: "dismissible" }))
+    instance.dismissOverlay()
+
+    expect(instance.expanded).toBe(false)
+    expect(document.querySelector(".herb-dev-tools-backdrop")).toBeNull()
+  })
+})
+
+describe("header control alignment", () => {
+  function header() {
+    return document.querySelector(".herb-dev-tools-header") as HTMLElement
+  }
+
+  function measure() {
+    const element = header()
+    const box = element.getBoundingClientRect()
+    const gap = parseFloat(getComputedStyle(element).gap)
+    const padding = parseFloat(getComputedStyle(element).paddingRight)
+
+    return {
+      element,
+      box,
+      gap,
+      padding,
+      title: element.querySelector(".herb-dev-tools-title")!.getBoundingClientRect(),
+      clear: element.querySelector(".herb-dev-tools-clear")!.getBoundingClientRect(),
+      hide: element.querySelector(".herb-dev-tools-hide")!.getBoundingClientRect(),
+      controls: element.querySelector(".herb-dev-tools-window-controls")!.getBoundingClientRect(),
+    }
+  }
+
+  test("groups every action on the right, with the title alone on the left", () => {
+    embed(PAYLOAD)
+
+    createPanel().open()
+    ;(document.querySelector(".herb-dev-tools-panel") as HTMLElement).style.width = "640px"
+
+    const { box, gap, padding, title, clear, hide, controls } = measure()
+
+    expect(title.left).toBeCloseTo(box.left + padding, 0)
+    expect(clear.left).toBeGreaterThan(box.left + box.width / 2)
+    expect(title.right).toBeGreaterThan(box.left + box.width / 2)
+
+    expect(hide.left - clear.right).toBeCloseTo(gap, 0)
+    expect(controls.left - hide.right).toBeCloseTo(gap, 0)
+    expect(controls.right).toBeCloseTo(box.right - padding, 0)
+  })
+
+  test("does the same once the panel fills the window", () => {
+    embed(PAYLOAD)
+
+    const instance = createPanel()
+
+    instance.open()
+    instance.expand()
+    ;(document.querySelector(".herb-dev-tools-panel") as HTMLElement).style.width = "640px"
+
+    const { element, box, gap, padding, title, clear, hide, controls } = measure()
+
+    expect(clear.left).toBeGreaterThan(box.left + box.width / 2)
+    expect(title.right).toBeGreaterThan(box.left + box.width / 2)
+    expect(hide.left - clear.right).toBeCloseTo(gap, 0)
+    expect(controls.left - hide.right).toBeCloseTo(gap, 0)
+    expect(controls.right).toBeCloseTo(box.right - padding, 0)
+    expect(element.scrollWidth).toBeLessThanOrEqual(element.clientWidth)
+  })
+})
+
+describe("locating an element from a full-size view", () => {
+  function target() {
+    const element = document.createElement("section")
+
+    element.id = "locate-target"
+    element.style.cssText = "height:200px;margin-top:3000px;background:#eee"
+
+    document.body.appendChild(element)
+
+    return element
+  }
+
+  function locateButton() {
+    return document.querySelector('[data-herb-dev-tools-action="locate"]') as HTMLButtonElement
+  }
+
+  function panel() {
+    return document.querySelector(".herb-dev-tools-panel") as HTMLElement | null
+  }
+
+  test("collapses the expanded panel so the element is visible", () => {
+    const element = target()
+    const instance = createPanel()
+
+    instance.report(diagnostic({ code: "sized", severity: "warning", element }))
+    instance.open()
+    instance.expand()
+
+    expect(instance.expanded).toBe(true)
+
+    locateButton().click()
+
+    expect(instance.expanded).toBe(false)
+    expect(panel()!.classList.contains("herb-dev-tools-open")).toBe(true)
+    expect(document.querySelector(".herb-slot-flash")).not.toBeNull()
+  })
+
+  test("leaves a dismissible overlay so the element is visible", () => {
+    const element = target()
+    const instance = createPanel()
+
+    instance.report(diagnostic({ code: "sized", severity: "warning", element, overlay: "dismissible" }))
+
+    expect(instance.overlay).toBe("dismissible")
+
+    locateButton().click()
+
+    expect(instance.overlay).toBeNull()
+    expect(instance.expanded).toBe(false)
+    expect(document.querySelector(".herb-dev-tools-backdrop")).toBeNull()
+  })
+
+  test("never lets a blocking overlay be escaped this way", () => {
+    const element = target()
+    const instance = createPanel()
+
+    instance.report(diagnostic({ code: "broke", element, overlay: "blocking" }))
+
+    locateButton().click()
+
+    expect(instance.overlay).toBe("blocking")
+    expect(document.documentElement.style.overflow).toBe("hidden")
+  })
+
+  test("leaves a docked panel exactly where it was", () => {
+    const element = target()
+    const instance = createPanel()
+
+    instance.report(diagnostic({ code: "sized", severity: "warning", element }))
+    instance.open()
+
+    locateButton().click()
+
+    expect(instance.expanded).toBe(false)
+    expect(panel()!.classList.contains("herb-dev-tools-open")).toBe(true)
+    expect(document.querySelector(".herb-slot-flash")).not.toBeNull()
+  })
+})
+
+describe("resizing the docked panel", () => {
+  function attach() {
+    const slot = document.createElement("div")
+
+    slot.setAttribute("data-herb-dev-tools-badge-slot", "")
+    document.body.appendChild(slot)
+  }
+
+  function panel() {
+    return document.querySelector(".herb-dev-tools-panel") as HTMLElement
+  }
+
+  function handle(edge: string) {
+    return document.querySelector(`[data-herb-dev-tools-resize="${edge}"]`) as HTMLElement | null
+  }
+
+  function drag(edge: string, to: { x?: number, y?: number }) {
+    const element = handle(edge)!
+    const box = panel().getBoundingClientRect()
+
+    element.setPointerCapture = () => {}
+    element.releasePointerCapture = () => {}
+
+    element.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, pointerId: 1, clientX: box.left, clientY: box.top }))
+    element.dispatchEvent(new PointerEvent("pointermove", { bubbles: true, pointerId: 1, clientX: to.x ?? box.left, clientY: to.y ?? box.top }))
+    element.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, pointerId: 1, clientX: to.x ?? box.left, clientY: to.y ?? box.top }))
+  }
+
+  test("offers a handle on each grabbable edge while docked", () => {
+    attach()
+    const instance = createPanel()
+
+    instance.report(diagnostic())
+    instance.open()
+
+    expect(handle("left")).not.toBeNull()
+    expect(handle("bottom")).not.toBeNull()
+    expect(handle("corner")).not.toBeNull()
+    expect(handle("top")).toBeNull()
+
+    const corner = getComputedStyle(handle("corner")!)
+
+    expect(corner.bottom).toBe("0px")
+    expect(corner.left).toBe("0px")
+    expect(corner.cursor).toBe("nesw-resize")
+  })
+
+  test("holds the right anchor while the left edge moves", () => {
+    attach()
+    const instance = createPanel()
+
+    instance.report(diagnostic())
+    instance.open()
+
+    const before = panel().getBoundingClientRect()
+
+    drag("left", { x: before.left + 60 })
+
+    const after = panel().getBoundingClientRect()
+
+    expect(Math.round(after.right)).toBe(Math.round(before.right))
+  })
+
+  test("never asks for more width than the viewport has", () => {
+    attach()
+    const instance = createPanel()
+
+    instance.report(diagnostic())
+    instance.open()
+
+    drag("left", { x: -400 })
+
+    expect(panel().getBoundingClientRect().width).toBeLessThanOrEqual(window.innerWidth)
+  })
+
+  test("grows the panel downward when the bottom edge is dragged down", () => {
+    attach()
+    const instance = createPanel()
+
+    instance.report(diagnostic())
+    instance.open()
+
+    const before = panel().getBoundingClientRect()
+
+    drag("bottom", { y: before.top + 260 })
+
+    const after = panel().getBoundingClientRect()
+
+    expect(Math.round(after.height)).toBe(260)
+    expect(Math.round(after.top)).toBe(Math.round(before.top))
+    expect(Math.round(after.width)).toBe(Math.round(before.width))
+  })
+
+  test("resizes both axes from the corner", () => {
+    attach()
+    const instance = createPanel()
+
+    instance.report(diagnostic())
+    instance.open()
+
+    const before = panel().getBoundingClientRect()
+
+    drag("corner", { x: before.left + 40, y: before.top + 240 })
+
+    const after = panel().getBoundingClientRect()
+
+    expect(Math.round(after.height)).toBe(240)
+    expect(Math.round(after.right)).toBe(Math.round(before.right))
+  })
+
+  test("keeps the size across a re-render and a reload", () => {
+    attach()
+    const first = createPanel()
+
+    first.report(diagnostic())
+    first.open()
+
+    const start = panel().getBoundingClientRect()
+
+    drag("bottom", { y: start.top + 240 })
+
+    const height = Math.round(panel().getBoundingClientRect().height)
+
+    expect(height).toBe(240)
+
+    first.report(diagnostic({ code: "another" }))
+
+    expect(Math.round(panel().getBoundingClientRect().height)).toBe(height)
+
+    first.destroy()
+    document.body.innerHTML = ""
+
+    attach()
+    const second = createPanel()
+
+    second.report(diagnostic())
+    second.open()
+
+    expect(Math.round(panel().getBoundingClientRect().height)).toBe(height)
+
+    second.resetSize()
+
+    expect(Math.round(panel().getBoundingClientRect().height)).not.toBe(height)
+  })
+
+  test("refuses to shrink below a usable size, or below what the viewport allows", () => {
+    attach()
+    const instance = createPanel()
+
+    instance.report(diagnostic())
+    instance.open()
+
+    drag("left", { x: window.innerWidth })
+
+    const floor = Math.min(435, window.innerWidth - 24)
+
+    expect(Math.round(panel().getBoundingClientRect().width)).toBe(floor)
+
+    drag("bottom", { y: 0 })
+
+    expect(Math.round(panel().getBoundingClientRect().height)).toBe(180)
+  })
+
+  test("offers no handles once the panel fills the window or an overlay is up", () => {
+    attach()
+    const instance = createPanel()
+
+    instance.report(diagnostic())
+    instance.open()
+    instance.expand()
+
+    expect(handle("left")).toBeNull()
+
+    instance.collapse()
+
+    expect(handle("left")).not.toBeNull()
+
+    instance.report(diagnostic({ code: "unhydrated", overlay: "dismissible" }))
+
+    expect(handle("left")).toBeNull()
+  })
+})
+
+describe("resize round trips", () => {
+  function attach() {
+    const slot = document.createElement("div")
+
+    slot.setAttribute("data-herb-dev-tools-badge-slot", "")
+    document.body.appendChild(slot)
+  }
+
+  function panel() {
+    return document.querySelector(".herb-dev-tools-panel") as HTMLElement
+  }
+
+  test("does not drift when the same size is stored and reapplied", () => {
+    attach()
+    const instance = createPanel()
+
+    instance.report(diagnostic())
+    instance.open()
+
+    const widths: number[] = []
+
+    for (let round = 0; round < 4; round += 1) {
+      const element = document.querySelector('[data-herb-dev-tools-resize="left"]') as HTMLElement
+
+      element.setPointerCapture = () => {}
+
+      const box = panel().getBoundingClientRect()
+      const target = box.left + 10
+
+      element.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, pointerId: 1, clientX: box.left, clientY: box.top }))
+      element.dispatchEvent(new PointerEvent("pointermove", { bubbles: true, pointerId: 1, clientX: target, clientY: box.top }))
+      element.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, pointerId: 1, clientX: target, clientY: box.top }))
+
+      instance.report(diagnostic({ code: `round-${round}` }))
+
+      widths.push(Math.round(panel().getBoundingClientRect().width))
+    }
+
+    for (let index = 1; index < widths.length; index += 1) {
+      expect(widths[index]).toBeLessThanOrEqual(widths[index - 1])
+    }
+
+    expect(new Set(widths).size).toBeGreaterThan(0)
+    expect(Math.max(...widths)).toBeLessThanOrEqual(window.innerWidth)
+  })
+})
+
+describe("resize drag hygiene", () => {
+  test("suppresses text selection for the length of the drag", () => {
+    const instance = createPanel()
+
+    instance.report(diagnostic())
+    instance.open()
+
+    const handle = document.querySelector('[data-herb-dev-tools-resize="left"]') as HTMLElement
+
+    handle.setPointerCapture = () => {}
+
+    expect(document.body.style.userSelect).toBe("")
+
+    handle.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, pointerId: 1, clientX: 100, clientY: 100 }))
+
+    expect(document.body.style.userSelect).toBe("none")
+
+    handle.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, pointerId: 1, clientX: 200, clientY: 100 }))
+
+    expect(document.body.style.userSelect).toBe("")
+  })
+
+  test("gives selection back when a drag is cancelled", () => {
+    const instance = createPanel()
+
+    instance.report(diagnostic())
+    instance.open()
+
+    const handle = document.querySelector('[data-herb-dev-tools-resize="left"]') as HTMLElement
+
+    handle.setPointerCapture = () => {}
+
+    handle.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, pointerId: 1, clientX: 100, clientY: 100 }))
+    handle.dispatchEvent(new PointerEvent("pointercancel", { bubbles: true, pointerId: 1, clientX: 100, clientY: 100 }))
+
+    expect(document.body.style.userSelect).toBe("")
+  })
+
+  test("gives selection back when the panel is destroyed mid-drag", () => {
+    const instance = createPanel()
+
+    instance.report(diagnostic())
+    instance.open()
+
+    const handle = document.querySelector('[data-herb-dev-tools-resize="left"]') as HTMLElement
+
+    handle.setPointerCapture = () => {}
+    handle.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, pointerId: 1, clientX: 100, clientY: 100 }))
+
+    instance.destroy()
+
+    expect(document.body.style.userSelect).toBe("")
   })
 })

--- a/javascript/packages/dev-tools/test/runtime-report.test.ts
+++ b/javascript/packages/dev-tools/test/runtime-report.test.ts
@@ -112,6 +112,20 @@ describe("parseRuntimeReport", () => {
   })
 })
 
+describe("overlay mode", () => {
+  test("keeps the two modes it understands", () => {
+    expect(diagnostic({ overlay: "blocking" } as never).overlay).toBe("blocking")
+    expect(diagnostic({ overlay: "dismissible" } as never).overlay).toBe("dismissible")
+  })
+
+  test("reads no overlay from an absent, false, or unknown value", () => {
+    expect(diagnostic().overlay).toBeNull()
+    expect(diagnostic({ overlay: false } as never).overlay).toBeNull()
+    expect(diagnostic({ overlay: "modal" } as never).overlay).toBeNull()
+    expect(diagnostic({ overlay: true } as never).overlay).toBeNull()
+  })
+})
+
 describe("normalizeDiagnostic", () => {
   test("requires template and message", () => {
     expect(normalizeDiagnostic({ message: "no template" })).toBeNull()


### PR DESCRIPTION
This pull request gives the runtime diagnostics panel a way to take the whole screen, for findings the page cannot be read around.

The panel from #2327 could only dock in the corner and wait to be clicked. That is the right shape for a linter warning and the wrong one for a template that failed to compile, which rendered nothing, so there is no page behind the badge to go back to. It is also the wrong shape for markup that failed to hydrate, which leaves a page that works with something visibly broken in it. Neither of those reads as a number in the corner.

A reported diagnostic can now ask for the screen:

```js
window.HerbDevTools.report({
  template: "app/views/posts/show.html.erb",
  message: "The template could not be compiled.",
  origin: "Herb Parser",
  overlay: "blocking",
})
```

`"blocking"` fills the viewport, scroll locked, with no control that closes it and `"dismissible"` the same screen inside a box over the page, closed by its button, the backdrop, or `Escape`.

https://github.com/user-attachments/assets/a1ad762e-6349-4b2b-b4a5-6776c0f31312

