### PR TITLE
Linter: Fix SVG false positives in `html-no-block-inside-inline`

### DIFF
--- a/javascript/packages/linter/docs/rules/html-no-block-inside-inline.md
+++ b/javascript/packages/linter/docs/rules/html-no-block-inside-inline.md
@@ -34,6 +34,12 @@ This practice can cause:
   <img src="icon.png" alt="Icon">
   <span>Link text</span>
 </a>
+
+<button type="button">
+  <svg aria-hidden="true" viewBox="0 0 16 16">
+    <path d="M0 0h16v16H0z"></path>
+  </svg>
+</button>
 ```
 
 ### 🚫 Bad
@@ -62,5 +68,6 @@ This practice can cause:
 ## References
 
 * [HTML Living Standard - Content models](https://html.spec.whatwg.org/multipage/dom.html#content-models)
+* [HTML Living Standard - The SVG element](https://html.spec.whatwg.org/multipage/embedded-content-other.html#the-svg-element)
 * [MDN - Block-level elements](https://developer.mozilla.org/en-US/docs/Web/HTML/Block-level_elements)
 * [MDN - Inline elements](https://developer.mozilla.org/en-US/docs/Web/HTML/Inline_elements)

--- a/javascript/packages/linter/src/rules/html-no-block-inside-inline.ts
+++ b/javascript/packages/linter/src/rules/html-no-block-inside-inline.ts
@@ -7,6 +7,7 @@ import type { HTMLOpenTagNode, HTMLElementNode, ParseResult } from "@herb-tools/
 
 const SVG_HTML_INTEGRATION_POINTS = new Set(["foreignobject", "desc", "title"])
 
+// TODO: refactor using ElementStackVisitor
 class BlockInsideInlineVisitor extends BaseRuleVisitor {
   private inlineStack: string[] = []
   private insideSVG = false

--- a/javascript/packages/linter/src/rules/html-no-block-inside-inline.ts
+++ b/javascript/packages/linter/src/rules/html-no-block-inside-inline.ts
@@ -5,8 +5,11 @@ import { isHTMLOpenTagNode } from "@herb-tools/core"
 import type { UnboundLintOffense, LintContext, FullRuleConfig } from "../types.js"
 import type { HTMLOpenTagNode, HTMLElementNode, ParseResult } from "@herb-tools/core"
 
+const SVG_HTML_INTEGRATION_POINTS = new Set(["foreignobject", "desc", "title"])
+
 class BlockInsideInlineVisitor extends BaseRuleVisitor {
   private inlineStack: string[] = []
+  private insideSVG = false
 
   private getElementType(tagName: string): { isInline: boolean; isBlock: boolean; isUnknown: boolean } {
     const isInline = isInlineElement(tagName)
@@ -39,6 +42,17 @@ class BlockInsideInlineVisitor extends BaseRuleVisitor {
     this.inlineStack = savedStack
   }
 
+  private visitSVGElement(node: HTMLElementNode): void {
+    const savedStack = this.inlineStack
+    const wasInsideSVG = this.insideSVG
+
+    this.inlineStack = []
+    this.insideSVG = true
+    super.visitHTMLElementNode(node)
+    this.insideSVG = wasInsideSVG
+    this.inlineStack = savedStack
+  }
+
   visitHTMLElementNode(node: HTMLElementNode): void {
     if (!isHTMLOpenTagNode(node.open_tag)) {
       super.visitHTMLElementNode(node)
@@ -49,6 +63,25 @@ class BlockInsideInlineVisitor extends BaseRuleVisitor {
 
     if (!tagName) {
       super.visitHTMLElementNode(node)
+      return
+    }
+
+    if (this.insideSVG) {
+      if (SVG_HTML_INTEGRATION_POINTS.has(tagName)) {
+        this.insideSVG = false
+        super.visitHTMLElementNode(node)
+        this.insideSVG = true
+        return
+      }
+
+      super.visitHTMLElementNode(node)
+      return
+    }
+
+    // SVG is valid embedded phrasing content. Traverse its descendants without
+    // classifying SVG-native elements using HTML block/inline element sets.
+    if (tagName === "svg") {
+      this.visitSVGElement(node)
       return
     }
 

--- a/javascript/packages/linter/src/rules/html-no-block-inside-inline.ts
+++ b/javascript/packages/linter/src/rules/html-no-block-inside-inline.ts
@@ -78,8 +78,6 @@ class BlockInsideInlineVisitor extends BaseRuleVisitor {
       return
     }
 
-    // SVG is valid embedded phrasing content. Traverse its descendants without
-    // classifying SVG-native elements using HTML block/inline element sets.
     if (tagName === "svg") {
       this.visitSVGElement(node)
       return

--- a/javascript/packages/linter/test/rules/html-no-block-inside-inline.test.ts
+++ b/javascript/packages/linter/test/rules/html-no-block-inside-inline.test.ts
@@ -57,6 +57,28 @@ describe("html-no-block-inside-inline", () => {
     expectNoOffenses(`<span>Text before <code>code</code> text after</span>`)
   })
 
+  test("passes for SVG inside inline elements", () => {
+    expectNoOffenses(`
+      <button><svg><a><g><path d="M0 0h1v1z"></path></g></a></svg></button>
+      <span><svg><circle cx="1" cy="1" r="1"></circle></svg></span>
+      <label><svg><title>Icon</title></svg> Label</label>
+    `)
+  })
+
+  test("still fails for block elements after SVG inside inline elements", () => {
+    expectError('Block-level element `<div>` cannot be placed inside inline element `<span>`.')
+    assertOffenses(`<span><svg><path></path></svg><div>Invalid block</div></span>`)
+  })
+
+  test.each(["foreignObject", "desc", "title"])("resumes HTML checks inside SVG %s integration points", integrationPoint => {
+    expectError('Block-level element `<div>` cannot be placed inside inline element `<span>`.')
+    assertOffenses(`<svg><${integrationPoint}><span><div>Invalid block</div></span></${integrationPoint}></svg>`)
+  })
+
+  test("does not carry an outer inline constraint into SVG integration points", () => {
+    expectNoOffenses(`<span><svg><foreignObject><div>Valid HTML inside SVG</div></foreignObject></svg></span>`)
+  })
+
   test("fails for list inside inline element", () => {
     expectError('Block-level element `<ul>` cannot be placed inside inline element `<span>`.')
     assertOffenses(`<span><ul><li>Item</li></ul></span>`)


### PR DESCRIPTION
- allow SVG embedded content inside elements classified as inline
- skip SVG descendants rather than classifying them using HTML block/inline sets
- add regression coverage and document SVG as a valid example

`svg` is valid embedded phrasing content, but the rule currently classifies it as unknown. SVG descendants also belong to the SVG namespace and should not be checked against HTML element categories.

This preserves the rule's existing handling of block, unknown, custom, and anchor elements.

Addresses #267.
Related #291
