### PR TITLE
Dev Tools: Report why a diagnostic's element cannot be located

### DIFF
--- a/javascript/packages/dev-tools/README.md
+++ b/javascript/packages/dev-tools/README.md
@@ -134,6 +134,17 @@ leave a reader unable to tell a diagnostic about markup from one that never name
 those it is turns out to be the more useful thing to know. A Turbo navigation, a re-render, or a
 removal all land here.
 
+An element that is still on the page but has nothing rendered for it reads
+`<div#cover-three> not visible (display: none)`, with the control inert for the same reason. There is
+no box to scroll to and none to outline, so a live control would appear to do nothing. The chip names
+the property that hides it, and its tooltip names the ancestor carrying that property when it is not
+the element itself, since that ancestor is the part the card cannot show. `display: none`,
+`content-visibility: hidden`, `opacity: 0` and `visibility: hidden` all land here, as does
+`display: contents`, which renders its children and keeps no box of its own.
+
+An element that is merely scrolled out of view is not this. It has a box, locating it works, and it
+keeps its control.
+
 An element the producer looked for and did not find is a different thing, and the panel cannot see
 it. `document.querySelector` returns `null`, `element` arrives as `null`, and that is
 indistinguishable from a diagnostic that meant to name nothing. A producer that wants to say it went

--- a/javascript/packages/dev-tools/README.md
+++ b/javascript/packages/dev-tools/README.md
@@ -126,9 +126,18 @@ excerpt, which is a supported state rather than a degraded one.
 [`source`](#source) it is a convenience of the JavaScript API and has no place in the payload.
 
 A card whose entry carries a connected element grows a locate control. Pressing it scrolls the page
-to that element and flashes it, and hovering the control outlines the element where it sits. An
-element that has since left the document is ignored, so a stale reference degrades to a card without
-the control instead of to a broken one.
+to that element and flashes it, and hovering the control outlines the element where it sits.
+
+An element that has since left the document keeps its chip and says so, reading
+`<div#cover-three> no longer on the page` with the control inert. Dropping the chip instead would
+leave a reader unable to tell a diagnostic about markup from one that never named any, and which of
+those it is turns out to be the more useful thing to know. A Turbo navigation, a re-render, or a
+removal all land here.
+
+An element the producer looked for and did not find is a different thing, and the panel cannot see
+it. `document.querySelector` returns `null`, `element` arrives as `null`, and that is
+indistinguishable from a diagnostic that meant to name nothing. A producer that wants to say it went
+looking has to say so in its `message`.
 
 Locating gets the panel out of its own way first. A panel filling the window collapses back to the
 corner, and a dismissible overlay closes, because both of them are covering the thing you just asked

--- a/javascript/packages/dev-tools/src/runtime/panel.css
+++ b/javascript/packages/dev-tools/src/runtime/panel.css
@@ -822,6 +822,20 @@
   background: rgba(245, 158, 11, 0.2);
 }
 
+.herb-dev-tools-element-gone,
+.herb-dev-tools-element-gone:hover {
+  border-color: #d1d5db;
+  border-style: dashed;
+  background: transparent;
+  color: #6b7280;
+  cursor: default;
+}
+
+.herb-dev-tools-element-note {
+  font-size: 0.72rem;
+  font-style: italic;
+}
+
 .herb-dev-tools-element code {
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: 0.72rem;

--- a/javascript/packages/dev-tools/src/runtime/panel.css
+++ b/javascript/packages/dev-tools/src/runtime/panel.css
@@ -823,7 +823,9 @@
 }
 
 .herb-dev-tools-element-gone,
-.herb-dev-tools-element-gone:hover {
+.herb-dev-tools-element-gone:hover,
+.herb-dev-tools-element-hidden,
+.herb-dev-tools-element-hidden:hover {
   border-color: #d1d5db;
   border-style: dashed;
   background: transparent;

--- a/javascript/packages/dev-tools/src/runtime/panel.ts
+++ b/javascript/packages/dev-tools/src/runtime/panel.ts
@@ -1365,9 +1365,6 @@ export class RuntimePanel {
     ].join('')
   }
 
-  // A diagnostic that named an element says so whether or not the element is still there. Dropping
-  // the chip when the node goes leaves the reader unable to tell a diagnostic about markup from one
-  // that never named any, which is the more useful thing to know.
   private elementHTML(entry: PanelEntry): string {
     const element = entry.diagnostic.element
 
@@ -1385,6 +1382,22 @@ export class RuntimePanel {
         `<span class="herb-dev-tools-element-glyph" aria-hidden="true">◌</span>`,
         `<code>${described}</code>`,
         `<span class="herb-dev-tools-element-note">no longer on the page</span>`,
+        `</span>`,
+      ].join('')
+    }
+
+    const hidden = hiddenBy(element)
+
+    if (hidden !== null) {
+      const label = hidden.culprit === null
+        ? 'This element is on the page but nothing is rendered for it, so there is nothing to scroll to'
+        : `This element is on the page but nothing is rendered for it, because ${describeElement(hidden.culprit)} has ${hidden.reason}`
+
+      return [
+        `<span class="herb-dev-tools-element herb-dev-tools-element-hidden" title="${escapeHTML(label)}">`,
+        `<span class="herb-dev-tools-element-glyph" aria-hidden="true">○</span>`,
+        `<code>${described}</code>`,
+        `<span class="herb-dev-tools-element-note">not visible (${escapeHTML(hidden.reason)})</span>`,
         `</span>`,
       ].join('')
     }
@@ -1595,7 +1608,7 @@ export class RuntimePanel {
   private locateFrom(trigger: HTMLElement) {
     const target = this.entryFor(trigger)?.diagnostic.element
 
-    if (!target || !target.isConnected) return
+    if (!target || !target.isConnected || hiddenBy(target) !== null) return
 
     this.stepOutOfTheWay()
 
@@ -1625,7 +1638,7 @@ export class RuntimePanel {
 
     const target = this.entryFor(trigger)?.diagnostic.element
 
-    if (!target || !target.isConnected) return
+    if (!target || !target.isConnected || hiddenBy(target) !== null) return
 
     const rect = target.getBoundingClientRect()
     const box = document.createElement('div')
@@ -1660,6 +1673,40 @@ function severityOf(entries: PanelEntry[]): RuntimeSeverity | null {
     if (present) {
       return severity
     }
+  }
+
+  return null
+}
+
+function hiddenBy(element: Element): { reason: string, culprit: Element | null } | null {
+  let current: Element | null = element
+
+  while (current !== null) {
+    const style = getComputedStyle(current)
+
+    if (style.display === 'none') {
+      return { reason: 'display: none', culprit: current === element ? null : current }
+    }
+
+    if (style.getPropertyValue('content-visibility') === 'hidden') {
+      return { reason: 'content-visibility: hidden', culprit: current === element ? null : current }
+    }
+
+    if (style.opacity === '0') {
+      return { reason: 'opacity: 0', culprit: current === element ? null : current }
+    }
+
+    current = current.parentElement
+  }
+
+  const style = getComputedStyle(element)
+
+  if (style.visibility === 'hidden' || style.visibility === 'collapse') {
+    return { reason: `visibility: ${style.visibility}`, culprit: null }
+  }
+
+  if (style.display === 'contents') {
+    return { reason: 'display: contents', culprit: null }
   }
 
   return null

--- a/javascript/packages/dev-tools/src/runtime/panel.ts
+++ b/javascript/packages/dev-tools/src/runtime/panel.ts
@@ -1350,9 +1350,7 @@ export class RuntimePanel {
     const repeat = entry.count > 1 ? `<span class="herb-dev-tools-repeat" title="Reported ${entry.count} times">×${entry.count}</span>` : ''
     const feature = this.featureButtonHTML(entry)
     const suggestion = diagnostic.suggestion === null ? '' : `<p class="herb-dev-tools-suggestion">${inlineCodeHTML(diagnostic.suggestion)}</p>`
-    const element = diagnostic.element !== null && diagnostic.element.isConnected
-      ? `<button type="button" class="herb-dev-tools-element" data-herb-dev-tools-action="locate" data-herb-dev-tools-entry="${this.entries.indexOf(entry)}" title="Scroll to this element and flash it"><span class="herb-dev-tools-element-glyph" aria-hidden="true">◎</span><code>${escapeHTML(describeElement(diagnostic.element))}</code></button>`
-      : ''
+    const element = this.elementHTML(entry)
 
     return [
       `<article class="herb-dev-tools-card" data-herb-dev-tools-entry="${this.entries.indexOf(entry)}" data-herb-dev-tools-origin="${escapeHTML(diagnostic.origin)}" data-herb-dev-tools-kind="${escapeHTML(diagnostic.kind)}">`,
@@ -1364,6 +1362,39 @@ export class RuntimePanel {
       this.stackHTML(diagnostic),
       this.fixHTML(diagnostic),
       `</article>`,
+    ].join('')
+  }
+
+  // A diagnostic that named an element says so whether or not the element is still there. Dropping
+  // the chip when the node goes leaves the reader unable to tell a diagnostic about markup from one
+  // that never named any, which is the more useful thing to know.
+  private elementHTML(entry: PanelEntry): string {
+    const element = entry.diagnostic.element
+
+    if (element === null) {
+      return ''
+    }
+
+    const described = escapeHTML(describeElement(element))
+
+    if (!element.isConnected) {
+      const label = 'This element was on the page when it was reported and is not any more'
+
+      return [
+        `<span class="herb-dev-tools-element herb-dev-tools-element-gone" title="${label}">`,
+        `<span class="herb-dev-tools-element-glyph" aria-hidden="true">◌</span>`,
+        `<code>${described}</code>`,
+        `<span class="herb-dev-tools-element-note">no longer on the page</span>`,
+        `</span>`,
+      ].join('')
+    }
+
+    return [
+      `<button type="button" class="herb-dev-tools-element" data-herb-dev-tools-action="locate"`,
+      ` data-herb-dev-tools-entry="${this.entries.indexOf(entry)}" title="Scroll to this element and flash it">`,
+      `<span class="herb-dev-tools-element-glyph" aria-hidden="true">◎</span>`,
+      `<code>${described}</code>`,
+      `</button>`,
     ].join('')
   }
 

--- a/javascript/packages/dev-tools/test/runtime-panel.test.ts
+++ b/javascript/packages/dev-tools/test/runtime-panel.test.ts
@@ -1775,8 +1775,34 @@ describe("diagnostics that name an element", () => {
     expect(document.querySelector(".herb-element-flash")).not.toBeNull()
   })
 
-  test("skip the control once the element has left the page", () => {
+  test("says the element has left the page instead of dropping the chip", () => {
     const target = document.createElement("span")
+
+    target.id = "gone-away"
+    document.body.appendChild(target)
+
+    const panel = createPanel()
+
+    panel.report({ template: "app/views/a.html.erb", message: "gone", element: target })
+
+    expect(document.querySelector('[data-herb-dev-tools-action="locate"]')).not.toBeNull()
+
+    target.remove()
+    panel.refresh()
+
+    const chip = document.querySelector(".herb-dev-tools-element") as HTMLElement
+
+    expect(chip).not.toBeNull()
+    expect(chip.tagName).toBe("SPAN")
+    expect(chip.classList.contains("herb-dev-tools-element-gone")).toBe(true)
+    expect(chip.textContent).toContain("<span#gone-away>")
+    expect(chip.textContent).toContain("no longer on the page")
+    expect(chip.title).toBe("This element was on the page when it was reported and is not any more")
+  })
+
+  test("offers no locate control for an element that has left the page", () => {
+    const target = document.createElement("span")
+
     document.body.appendChild(target)
 
     const panel = createPanel()
@@ -1784,6 +1810,15 @@ describe("diagnostics that name an element", () => {
     panel.report({ template: "app/views/a.html.erb", message: "gone", element: target })
     target.remove()
     panel.refresh()
+
+    expect(document.querySelector('[data-herb-dev-tools-action="locate"]')).toBeNull()
+    expect(getComputedStyle(document.querySelector(".herb-dev-tools-element")!).cursor).toBe("default")
+  })
+
+  test("says nothing at all when no element was named", () => {
+    const panel = createPanel()
+
+    panel.report({ template: "app/views/a.html.erb", message: "no element here" })
 
     expect(document.querySelector(".herb-dev-tools-element")).toBeNull()
   })

--- a/javascript/packages/dev-tools/test/runtime-panel.test.ts
+++ b/javascript/packages/dev-tools/test/runtime-panel.test.ts
@@ -1800,6 +1800,90 @@ describe("diagnostics that name an element", () => {
     expect(chip.title).toBe("This element was on the page when it was reported and is not any more")
   })
 
+  test("says an element is not visible when it is on the page with no box", () => {
+    const target = document.createElement("span")
+
+    target.id = "cover-three"
+    target.style.display = "none"
+    document.body.appendChild(target)
+
+    const panel = createPanel()
+
+    panel.report({ template: "app/views/a.html.erb", message: "hidden", element: target })
+
+    const chip = document.querySelector(".herb-dev-tools-element") as HTMLElement
+
+    expect(chip.tagName).toBe("SPAN")
+    expect(chip.classList.contains("herb-dev-tools-element-hidden")).toBe(true)
+    expect(chip.textContent).toContain("<span#cover-three>")
+    expect(chip.textContent).toContain("not visible (display: none)")
+    expect(document.querySelector('[data-herb-dev-tools-action="locate"]')).toBeNull()
+  })
+
+  test("names the ancestor that hides an element the diagnostic named", () => {
+    const parent = document.createElement("div")
+    const target = document.createElement("span")
+
+    parent.id = "modal"
+    parent.style.display = "none"
+    parent.appendChild(target)
+    document.body.appendChild(parent)
+
+    const panel = createPanel()
+
+    panel.report({ template: "app/views/a.html.erb", message: "hidden", element: target })
+
+    const chip = document.querySelector(".herb-dev-tools-element") as HTMLElement
+
+    expect(chip.title).toBe("This element is on the page but nothing is rendered for it, because <div#modal> has display: none")
+  })
+
+  test("does not name an ancestor when the element hides itself", () => {
+    const target = document.createElement("span")
+
+    target.style.visibility = "hidden"
+    document.body.appendChild(target)
+
+    const panel = createPanel()
+
+    panel.report({ template: "app/views/a.html.erb", message: "hidden", element: target })
+
+    const chip = document.querySelector(".herb-dev-tools-element") as HTMLElement
+
+    expect(chip.textContent).toContain("not visible (visibility: hidden)")
+    expect(chip.title).toBe("This element is on the page but nothing is rendered for it, so there is nothing to scroll to")
+  })
+
+  test("says an element that has no box of its own is not visible", () => {
+    const target = document.createElement("div")
+
+    target.style.display = "contents"
+    target.textContent = "rendered by its children"
+    document.body.appendChild(target)
+
+    const panel = createPanel()
+
+    panel.report({ template: "app/views/a.html.erb", message: "contents", element: target })
+
+    const chip = document.querySelector(".herb-dev-tools-element") as HTMLElement
+
+    expect(chip.textContent).toContain("not visible (display: contents)")
+  })
+
+  test("keeps the locate control for an element that is merely scrolled out of view", () => {
+    const target = document.createElement("div")
+
+    target.textContent = "below the fold"
+    target.style.marginTop = "300vh"
+    document.body.appendChild(target)
+
+    const panel = createPanel()
+
+    panel.report({ template: "app/views/a.html.erb", message: "offscreen", element: target })
+
+    expect(document.querySelector('[data-herb-dev-tools-action="locate"]')).not.toBeNull()
+  })
+
   test("offers no locate control for an element that has left the page", () => {
     const target = document.createElement("span")
 

--- a/javascript/packages/linter/test/cli.test.ts
+++ b/javascript/packages/linter/test/cli.test.ts
@@ -1632,7 +1632,7 @@ describe("CLI Output Formatting", () => {
 
       expect(result.summary.ruleCount).toBeGreaterThan(withoutAllRules.summary.ruleCount)
       expect(exitCode).toBe(0)
-    })
+    }, 10_000)
 
     test("can't be combined with --only", () => {
       const { output, exitCode } = runLinter("test-file-with-errors.html.erb", "--simple", "--all-rules", "--only", "html-tag-name-lowercase")


### PR DESCRIPTION
This pull request updates the runtime diagnostics panel to report why it cannot locate the element a diagnostic named.

A card whose entry carries an element grows a locate control, added in #2409. Pressing it scrolls to that element and flashes it. There are two ways for that to stop working, and the card said nothing about either.

An element inside a closed modal is still in the document, so the control stayed live. Pressing it scrolled nowhere and flashed an outline around a box with no size, which reads as the panel being broken instead of the element being hidden. The chip now says what hides it, with the control inert.

```
○ <div#cover-three>  not visible (display: none)
```

Its tooltip names the ancestor carrying that property when it is not the element itself, since an ancestor is the part a card cannot show.

```
This element is on the page but nothing is rendered for it,
because <div#modal> has display: none
```

The walk covers `display`, `content-visibility`, `opacity` and `visibility`, and treats `display: contents` as hidden too, because such an element renders its children and keeps no box of its own. An element that is merely scrolled out of view keeps its control, and so does one whose box has no size, since both are on the page and can be scrolled to.

An element that has since left the document was ignored, and the control simply went away with it. That leaves a reader unable to tell two different cards apart. A diagnostic about markup whose element has been replaced looked exactly like a diagnostic that never named an element at all, and which of those you are looking at is the more useful thing to know. A Turbo navigation, a re-render, and a plain removal all land there.

```
◌ <div#cover-three>  no longer on the page
```


<img width="1556" height="1448" alt="CleanShot 2026-08-27 at 02 01 50@2x" src="https://github.com/user-attachments/assets/7814b37f-d0cd-4965-a8ac-05aa2573ae9f" />

