### PR TITLE
Ruby: Fix malformed type declaration

### DIFF
--- a/lib/herb/engine/runtime/session.rb
+++ b/lib/herb/engine/runtime/session.rb
@@ -209,7 +209,7 @@ module Herb
           report.source(template, source)
         end
 
-        #: (Symbol) { () -> untyped } -> untyped
+        # @rbs params(Symbol, "&": T.proc.untyped).untyped
         def channel(name, &)
           report.channel(name, &)
         end

--- a/sig/herb/engine/runtime/session.rbs
+++ b/sig/herb/engine/runtime/session.rbs
@@ -102,8 +102,8 @@ module Herb
         # : (String, String?) -> void
         def source: (String, String?) -> void
 
-        # : (Symbol) { () -> untyped } -> untyped
-        def channel: (Symbol) { () -> untyped } -> untyped
+        # @rbs params(Symbol, "&": T.proc.untyped).untyped
+        def channel: (untyped name) ?{ (?) -> untyped } -> untyped
 
         # : () -> Array[Herb::Diagnostic]
         def diagnostics: () -> Array[Herb::Diagnostic]


### PR DESCRIPTION
The error we got in our project that uses `herb`:

```
sorbet/rbi/gems/herb@0.10.3-781842db2b700728c8fc9728c321d42958b2082d.rbi:5621: Malformed type declaration. Unknown type syntax. Expected a ClassName or T.<func> https://srb.help/5004
    5621 |  sig { params(name: ::Symbol, _arg1: ).returns(T.untyped) }
                                         ^^^^^^
```


I think that this is a bug in rbs-inline, as anonymous block parameter types seem to have gained support in sorbet:
https://github.com/sorbet/sorbet/pull/9768

Although, perhaps it is not full support?:
https://github.com/sorbet/sorbet/issues/6832
