### PR TITLE
Dev Tools: Show compile diagnostic with the source

### DIFF
--- a/javascript/packages/dev-tools/src/dev-server/diagnostics.ts
+++ b/javascript/packages/dev-tools/src/dev-server/diagnostics.ts
@@ -13,5 +13,6 @@ export function diagnosticsFromError(message: ErrorMessage): RuntimeDiagnostic[]
     phase: "compile" as const,
     overlay: "dismissible" as const,
     location: { start: { line: error.line, column: error.column + 1 } },
+    ...(message.source === undefined ? {} : { source: message.source }),
   }))
 }

--- a/javascript/packages/dev-tools/src/dev-server/types.ts
+++ b/javascript/packages/dev-tools/src/dev-server/types.ts
@@ -46,6 +46,7 @@ export interface ErrorMessage {
   type: "error"
   file: string
   errors: ParseError[]
+  source?: string
 }
 
 export interface FixedMessage {

--- a/javascript/packages/dev-tools/test/dev-server-diagnostics.test.ts
+++ b/javascript/packages/dev-tools/test/dev-server-diagnostics.test.ts
@@ -1,9 +1,51 @@
-import { describe, expect, test } from "vitest"
+import { DEV_SERVER_ORIGIN } from "../src/dev-server/diagnostics"
 
-import { DEV_SERVER_ORIGIN, diagnosticsFromError } from "../src/dev-server/diagnostics"
+import { afterEach, beforeEach, describe, expect, test } from "vitest"
+import { stripAnsiColors } from "@herb-tools/highlighter"
+import { diagnosticsFromError } from "../src/dev-server/diagnostics"
+
 import { RuntimePanel } from "../src/runtime/panel"
 
 import type { ErrorMessage } from "../src/dev-server/types"
+
+let panels: RuntimePanel[] = []
+
+beforeEach(() => {
+  document.body.innerHTML = ""
+  sessionStorage.clear()
+  panels = []
+})
+
+afterEach(() => {
+  panels.forEach(panel => panel.destroy())
+
+  document.body.innerHTML = ""
+  sessionStorage.clear()
+})
+
+function createPanel() {
+  const panel = new RuntimePanel()
+
+  panels.push(panel)
+
+  return panel
+}
+
+async function waitFor<T>(read: () => T | null, what: string): Promise<T> {
+  const deadline = Date.now() + 30000
+
+  while (Date.now() < deadline) {
+    const found = read()
+
+    if (found !== null) {
+      return found
+    }
+
+    await new Promise(resolve => setTimeout(resolve, 25))
+  }
+
+  throw new Error(`Timed out waiting for ${what}`)
+}
 
 function errorMessage(overrides: Partial<ErrorMessage["errors"][number]> = {}): ErrorMessage {
   return {
@@ -55,6 +97,22 @@ describe("diagnostics from a dev server error", () => {
     expect(diagnostic.origin).toBe(DEV_SERVER_ORIGIN)
   })
 
+  test("carries the source the server sent, so the panel can draw a frame", () => {
+    const message = errorMessage()
+
+    message.source = "<div>\n  <form>\n</div>\n"
+
+    const [diagnostic] = diagnosticsFromError(message)
+
+    expect(diagnostic.source).toBe("<div>\n  <form>\n</div>\n")
+  })
+
+  test("leaves the source off when the server sent none", () => {
+    const [diagnostic] = diagnosticsFromError(errorMessage())
+
+    expect("source" in diagnostic).toBe(false)
+  })
+
   test("carries every error the message holds", () => {
     const message = errorMessage()
 
@@ -66,7 +124,7 @@ describe("diagnostics from a dev server error", () => {
 
 describe("a dev server error in the panel", () => {
   test("opens a dismissible screen and clears again by origin", () => {
-    const panel = new RuntimePanel()
+    const panel = createPanel()
 
     panel.report(diagnosticsFromError(errorMessage()))
 
@@ -76,7 +134,29 @@ describe("a dev server error in the panel", () => {
     panel.clear(DEV_SERVER_ORIGIN)
 
     expect(document.querySelector(".herb-dev-tools-card")).toBeNull()
+  })
 
-    panel.destroy()
+  test("renders a highlighted excerpt from the source the server sent", async () => {
+    const panel = createPanel()
+    const message = errorMessage()
+
+    message.source = "<div>\n  <form>\n</div>\n"
+
+    panel.report(diagnosticsFromError(message))
+
+    const excerpt = await waitFor(
+      () => document.querySelector(".herb-dev-tools-excerpt herb-ansi") as HTMLElement | null,
+      "the excerpt to hydrate",
+    )
+
+    expect(stripAnsiColors(excerpt.textContent ?? "")).toContain("<form>")
+  })
+
+  test("renders no excerpt when the server sent no source", () => {
+    const panel = createPanel()
+
+    panel.report(diagnosticsFromError(errorMessage()))
+
+    expect(document.querySelector(".herb-dev-tools-excerpt")).toBeNull()
   })
 })

--- a/javascript/packages/dev-tools/test/runtime-panel.test.ts
+++ b/javascript/packages/dev-tools/test/runtime-panel.test.ts
@@ -1,5 +1,7 @@
 import { describe, test, expect, beforeEach, afterEach, vi } from "vitest"
 
+import { stripAnsiColors } from "@herb-tools/highlighter"
+
 import { RuntimePanel, inlineCodeHTML, safeUrl } from "../src/runtime/panel"
 import { dropLeadingBlocks, resetRuntimeHighlighting } from "../src/runtime/highlighting"
 import { MAX_RUNTIME_DIAGNOSTICS, resetRuntimeReportWarnings } from "../src/runtime/report"
@@ -89,10 +91,8 @@ function waitForFix() {
   return waitFor(() => document.querySelector(".herb-dev-tools-fix") as HTMLDetailsElement | null, "the fix diff to hydrate")
 }
 
-const ANSI_ESCAPES = /\u001b\[[0-9;]*m/g
-
 function plain(element: HTMLElement) {
-  return (element.textContent ?? "").replace(ANSI_ESCAPES, "")
+  return stripAnsiColors(element.textContent ?? "")
 }
 
 function waitForExcerpt() {

--- a/javascript/packages/highlighter/src/ansi.ts
+++ b/javascript/packages/highlighter/src/ansi.ts
@@ -9,4 +9,6 @@ export const ANSI_REGEX_START = /^\x1b\[[0-9;]*m/
 // eslint-disable-next-line no-control-regex
 export const ANSI_REGEX_CAPTURE = /(\x1b\[[0-9;]*m)/g
 
-export const visibleWidth = (text: string): number => text.replace(ANSI_REGEX, "").length
+export const stripAnsiColors = (text: string): string => text.replace(ANSI_REGEX, "")
+
+export const visibleWidth = (text: string): number => stripAnsiColors(text).length

--- a/javascript/packages/highlighter/test/ansi-utils.test.ts
+++ b/javascript/packages/highlighter/test/ansi-utils.test.ts
@@ -5,7 +5,7 @@ import { ANSI_ESCAPE, ANSI_REGEX, ANSI_REGEX_START, ANSI_REGEX_CAPTURE } from ".
 import { dimStyledText } from "../src/util.js"
 import { TextFormatter } from "../src/text-formatter.js"
 import { LineWrapper } from "../src/line-wrapper.js"
-import { stripAnsiColors } from "./util.js"
+import { stripAnsiColors } from "../src/ansi.js"
 
 describe("ANSI constants", () => {
   it("ANSI_ESCAPE matches the ESC control character", () => {

--- a/javascript/packages/highlighter/test/diagnostic-renderer.test.ts
+++ b/javascript/packages/highlighter/test/diagnostic-renderer.test.ts
@@ -3,7 +3,7 @@ import dedent from "dedent"
 
 import { themes } from "../src/themes.js"
 import { ANSI_REGEX } from "../src/ansi.js"
-import { stripAnsiColors } from "./util.js"
+import { stripAnsiColors } from "../src/ansi.js"
 
 import { DiagnosticRenderer } from "../src/diagnostic-renderer.js"
 import { Herb } from "@herb-tools/node-wasm"

--- a/javascript/packages/highlighter/test/diff-examples.test.ts
+++ b/javascript/packages/highlighter/test/diff-examples.test.ts
@@ -4,7 +4,7 @@ import { Herb } from "@herb-tools/node-wasm"
 
 import { Highlighter } from "../src/highlighter.js"
 import { renderDiffExamples } from "../examples/diff-view.js"
-import { stripAnsiColors } from "./util.js"
+import { stripAnsiColors } from "../src/ansi.js"
 
 describe("examples/diff-view.ts", () => {
   let highlighter: Highlighter

--- a/javascript/packages/highlighter/test/diff-renderer.test.ts
+++ b/javascript/packages/highlighter/test/diff-renderer.test.ts
@@ -4,7 +4,7 @@ import dedent from "dedent"
 import { Herb } from "@herb-tools/node-wasm"
 import { themes } from "../src/themes.js"
 import { ANSI_REGEX } from "../src/ansi.js"
-import { stripAnsiColors } from "./util.js"
+import { stripAnsiColors } from "../src/ansi.js"
 
 import { DiffRenderer } from "../src/diff-renderer.js"
 import { computeDiffHunks } from "../src/diff-computer.js"

--- a/javascript/packages/highlighter/test/file-renderer.test.ts
+++ b/javascript/packages/highlighter/test/file-renderer.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach } from "vitest"
 import dedent from "dedent"
 
 import { themes } from "../src/themes.js"
-import { stripAnsiColors } from "./util.js"
+import { stripAnsiColors } from "../src/ansi.js"
 
 import { FileRenderer } from "../src/file-renderer.js"
 import { Herb } from "@herb-tools/node-wasm"

--- a/javascript/packages/highlighter/test/inline-diagnostic-renderer.test.ts
+++ b/javascript/packages/highlighter/test/inline-diagnostic-renderer.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach } from "vitest"
 import dedent from "dedent"
 
 import { themes } from "../src/themes.js"
-import { stripAnsiColors } from "./util.js"
+import { stripAnsiColors } from "../src/ansi.js"
 
 import { InlineDiagnosticRenderer } from "../src/inline-diagnostic-renderer.js"
 import { Herb } from "@herb-tools/node-wasm"

--- a/javascript/packages/highlighter/test/util.ts
+++ b/javascript/packages/highlighter/test/util.ts
@@ -1,5 +1,1 @@
-import { ANSI_REGEX } from "../src/ansi.js"
-
-export const stripAnsiColors = (text: string): string => {
-  return text.replace(ANSI_REGEX, "")
-}
+export { stripAnsiColors } from "../src/ansi.js"

--- a/javascript/packages/highlighter/test/util.ts
+++ b/javascript/packages/highlighter/test/util.ts
@@ -1,1 +1,0 @@
-export { stripAnsiColors } from "../src/ansi.js"

--- a/lib/herb/dev/runner.rb
+++ b/lib/herb/dev/runner.rb
@@ -252,7 +252,7 @@ module Herb
         current_parse = Herb.parse(current_content, strict: true, analyze: true)
 
         if current_parse.errors.any?
-          broadcast_errors(file_path, relative_path, current_parse, previous_content, errored_files, websocket, timestamp, display_path)
+          broadcast_errors(file_path, relative_path, current_parse, current_content, previous_content, errored_files, websocket, timestamp, display_path)
           return
         end
 
@@ -264,7 +264,7 @@ module Herb
         handle_diff(file_path, relative_path, current_content, previous_content, file_states, websocket, timestamp, display_path)
       end
 
-      def broadcast_errors(file_path, relative_path, current_parse, previous_content, errored_files, websocket, timestamp, display_path)
+      def broadcast_errors(file_path, relative_path, current_parse, current_content, previous_content, errored_files, websocket, timestamp, display_path)
         current_errors = current_parse.errors
 
         previous_parse = Herb.parse(previous_content, strict: true, analyze: true)
@@ -291,6 +291,7 @@ module Herb
           websocket.broadcast({
             type: "error",
             file: relative_path,
+            source: current_content,
             errors: current_errors.map { |error|
               {
                 name: error.error_name,

--- a/lib/herb/engine/error_formatter.rb
+++ b/lib/herb/engine/error_formatter.rb
@@ -4,6 +4,9 @@
 module Herb
   class Engine
     class ErrorFormatter
+      attr_reader :source #: String
+      attr_reader :filename #: (String | Pathname)
+
       def initialize(source, errors, options = {})
         @source = source
         @errors = errors

--- a/lib/herb/engine/report/error_page.rb
+++ b/lib/herb/engine/report/error_page.rb
@@ -204,8 +204,7 @@ module Herb
             "<title>#{escape(title(diagnostics))}</title>",
             "<style>#{STYLES}</style>",
             "</head><body>",
-            fallback(diagnostics, report.sources),
-            provenance(report.meta),
+            fallback(diagnostics, report.sources, provenance(report.meta)),
             report.to_html,
             script_tag,
             "</body></html>"
@@ -265,11 +264,11 @@ module Herb
           %(<footer class="herb-error-provenance">#{rows.join}</footer>)
         end
 
-        #: (Array[Herb::Diagnostic], Hash[String, String]) -> String
-        def fallback(diagnostics, sources)
+        #: (Array[Herb::Diagnostic], Hash[String, String], String) -> String
+        def fallback(diagnostics, sources, provenance)
           sections = diagnostics.map { |diagnostic| section(diagnostic, sources[diagnostic.template]) }
 
-          %(<main class="herb-error"><h1>This template could not be compiled</h1>#{sections.join}</main>)
+          %(<main class="herb-error"><h1>This template could not be compiled</h1>#{sections.join}#{provenance}</main>)
         end
 
         #: (Herb::Diagnostic, String?) -> String
@@ -302,7 +301,7 @@ module Herb
             %(<span class="#{"herb-marked" if number == line}">#{marker} #{number.to_s.rjust(4)}  #{text}</span>)
           }
 
-          "<pre>#{rows.join("\n")}</pre>"
+          "<pre>#{rows.join}</pre>"
         end
 
         #: (String) -> String

--- a/lib/herb/engine/report/error_page.rb
+++ b/lib/herb/engine/report/error_page.rb
@@ -114,15 +114,22 @@ module Herb
 
           diagnostics_for(error).each { |diagnostic| report.add(diagnostic) }
 
-          if error.is_a?(Herb::Engine::ParseError)
-            template = error.filename
-
-            report.source(template, error.source) if template
-          end
-
+          note_source(report, error)
           note_provenance(report, error)
 
           report
+        end
+
+        #: (Herb::Engine::Report, Herb::Engine::CompilationError) -> void
+        def note_source(report, error)
+          template = template_for(error)
+
+          return unless template
+          return report.source(template, error.source) if error.is_a?(Herb::Engine::ParseError)
+
+          details = error.details
+
+          report.source(template, details.source) if details.is_a?(Herb::Engine::ErrorFormatter)
         end
 
         #: (Herb::Engine::Report, Herb::Engine::CompilationError) -> void
@@ -138,9 +145,7 @@ module Herb
 
         #: (Herb::Engine::CompilationError) -> Array[Herb::Diagnostic]
         def diagnostics_for(error)
-          if error.is_a?(Herb::Engine::ParseError) && !error.diagnostics.empty?
-            return error.diagnostics.map { |diagnostic| blocking(diagnostic) }
-          end
+          return error.diagnostics.map { |diagnostic| blocking(diagnostic) } unless error.diagnostics.empty?
 
           [
             Herb::Diagnostic.new(
@@ -175,7 +180,15 @@ module Herb
 
         #: (Herb::Engine::CompilationError) -> String?
         def template_for(error)
-          error.is_a?(Herb::Engine::ParseError) ? error.filename : nil
+          return error.filename if error.is_a?(Herb::Engine::ParseError)
+
+          template = error.diagnostics.first&.template
+
+          return template if template
+
+          details = error.details
+
+          details.filename.to_s if details.is_a?(Herb::Engine::ErrorFormatter)
         end
 
         #: (Herb::Engine::CompilationError) -> String

--- a/lib/herb/engine/report/session.rb
+++ b/lib/herb/engine/report/session.rb
@@ -89,6 +89,21 @@ module Herb
         def self.record_compile_diagnostics(template, entries)
           entries.each { |entry| record(Herb::Diagnostic.from_compiled(template, entry)) }
 
+          read_source(template)
+
+          nil
+        end
+
+        #: (String) -> void
+        def self.read_source(template)
+          return unless scoped?
+
+          session = current
+
+          return if session.report.sources.key?(template)
+
+          session.source(template, File.read(template))
+        rescue SystemCallError, IOError
           nil
         end
 

--- a/sig/herb/dev/runner.rbs
+++ b/sig/herb/dev/runner.rbs
@@ -43,7 +43,7 @@ module Herb
 
       def handle_file_change: (untyped file_path, untyped relative_path, untyped file_states, untyped errored_files, untyped websocket, untyped timestamp, untyped display_path) -> untyped
 
-      def broadcast_errors: (untyped file_path, untyped relative_path, untyped current_parse, untyped previous_content, untyped errored_files, untyped websocket, untyped timestamp, untyped display_path) -> untyped
+      def broadcast_errors: (untyped file_path, untyped relative_path, untyped current_parse, untyped current_content, untyped previous_content, untyped errored_files, untyped websocket, untyped timestamp, untyped display_path) -> untyped
 
       def broadcast_fixed: (untyped file_path, untyped relative_path, untyped current_content, untyped file_states, untyped websocket, untyped timestamp, untyped display_path) -> untyped
 

--- a/sig/herb/engine/error_formatter.rbs
+++ b/sig/herb/engine/error_formatter.rbs
@@ -3,6 +3,10 @@
 module Herb
   class Engine
     class ErrorFormatter
+      attr_reader source: String
+
+      attr_reader filename: String | Pathname
+
       def initialize: (untyped source, untyped errors, ?untyped options) -> untyped
 
       # : () -> String

--- a/sig/herb/engine/report/error_page.rbs
+++ b/sig/herb/engine/report/error_page.rbs
@@ -52,6 +52,9 @@ module Herb
         def report_for: (Herb::Engine::CompilationError) -> Herb::Engine::Report
 
         # : (Herb::Engine::Report, Herb::Engine::CompilationError) -> void
+        def note_source: (Herb::Engine::Report, Herb::Engine::CompilationError) -> void
+
+        # : (Herb::Engine::Report, Herb::Engine::CompilationError) -> void
         def note_provenance: (Herb::Engine::Report, Herb::Engine::CompilationError) -> void
 
         # : (Herb::Engine::CompilationError) -> Array[Herb::Diagnostic]

--- a/sig/herb/engine/report/error_page.rbs
+++ b/sig/herb/engine/report/error_page.rbs
@@ -78,8 +78,8 @@ module Herb
         # : (Hash[Symbol, untyped]) -> String
         def provenance: (Hash[Symbol, untyped]) -> String
 
-        # : (Array[Herb::Diagnostic], Hash[String, String]) -> String
-        def fallback: (Array[Herb::Diagnostic], Hash[String, String]) -> String
+        # : (Array[Herb::Diagnostic], Hash[String, String], String) -> String
+        def fallback: (Array[Herb::Diagnostic], Hash[String, String], String) -> String
 
         # : (Herb::Diagnostic, String?) -> String
         def section: (Herb::Diagnostic, String?) -> String

--- a/sig/herb/engine/report/session.rbs
+++ b/sig/herb/engine/report/session.rbs
@@ -48,6 +48,9 @@ module Herb
 
         def self.record_compile_diagnostics: (untyped template, untyped entries) -> untyped
 
+        # : (String) -> void
+        def self.read_source: (String) -> void
+
         # : [T] (String?, Integer, Integer, ?Symbol?) { () -> T } -> T
         def self.at: [T] (String?, Integer, Integer, ?Symbol?) { () -> T } -> T
 

--- a/test/dev/runner_test.rb
+++ b/test/dev/runner_test.rb
@@ -5,6 +5,54 @@ require_relative "../../lib/herb/dev/runner"
 
 module Dev
   class RunnerTest < Minitest::Spec
+    class FakeWebSocket
+      attr_reader :messages #: Array[Hash[Symbol, untyped]]
+
+      def initialize
+        @messages = []
+      end
+
+      def client_count
+        1
+      end
+
+      def broadcast(message)
+        @messages << message
+      end
+    end
+
+    BROKEN = "<div>\n  <form>\n</div>\n" #: String
+
+    def broadcast_for(current_content, previous_content)
+      websocket = FakeWebSocket.new
+      parse = Herb.parse(current_content, strict: true, analyze: true)
+
+      capture_io do
+        Herb::Dev::Runner.new.send(
+          :broadcast_errors,
+          "/app/views/posts/index.html.erb",
+          "app/views/posts/index.html.erb",
+          parse,
+          current_content,
+          previous_content,
+          Set.new,
+          websocket,
+          "12:00:00",
+          "index.html.erb"
+        )
+      end
+
+      websocket.messages.first
+    end
+
+    test "sends the whole file with the errors, so the panel can highlight it" do
+      assert_equal BROKEN, broadcast_for(BROKEN, "")[:source]
+    end
+
+    test "sends the content it just read, not the content it replaced" do
+      assert_equal BROKEN, broadcast_for(BROKEN, "<div>\n</div>\n")[:source]
+    end
+
     test "text_changed is patchable" do
       diff_result = Herb.diff("<div>Hello</div>", "<div>World</div>")
 

--- a/test/engine/report/error_page_test.rb
+++ b/test/engine/report/error_page_test.rb
@@ -30,6 +30,24 @@ module Engine
       )
     end
 
+    def second_diagnostic
+      Herb::Diagnostic.new(
+        template: "app/views/posts/_post.html.erb",
+        message: "The state `rate` has a Float default.",
+        code: "slots-declaration",
+        origin: "Herb Compiler",
+        location: Herb::Location.from(3, 4, 3, 9),
+        suggestion: "Declare it as an Integer or a String instead."
+      )
+    end
+
+    def compile_error(filename: "app/views/posts/_post.html.erb")
+      errors = [diagnostic, second_diagnostic]
+      formatter = Herb::Engine::ErrorFormatter.new(SOURCE, errors, filename: filename)
+
+      Herb::Engine::CompilationError.new(formatter.summary, details: formatter, diagnostics: errors)
+    end
+
     def ok_app
       ->(_env) { [200, { "content-type" => "text/html" }, [PAGE]] }
     end
@@ -120,6 +138,45 @@ module Engine
         )
       end
 
+      test "carries every diagnostic a compile error collected, not just its summary" do
+        _status, _headers, body = middleware(raising_app(compile_error)).call(HTML_ENV)
+
+        entries = payload(body.first)["diagnostics"]
+
+        assert_equal(["missing-closing-tag", "slots-declaration"], entries.map { |entry| entry["code"] })
+        assert_equal(["blocking", "blocking"], entries.map { |entry| entry["overlay"] })
+      end
+
+      test "keeps the template and location a compile error's diagnostics carry" do
+        _status, _headers, body = middleware(raising_app(compile_error)).call(HTML_ENV)
+
+        entry = payload(body.first)["diagnostics"].last
+
+        assert_equal "app/views/posts/_post.html.erb", entry["template"]
+        assert_equal 3, entry["location"]["start"]["line"]
+        assert_equal "Declare it as an Integer or a String instead.", entry["suggestion"]
+      end
+
+      test "carries the source of a compile error that is not a parse error" do
+        _status, _headers, body = middleware(raising_app(compile_error)).call(HTML_ENV)
+
+        assert_equal(
+          { "app/views/posts/_post.html.erb" => SOURCE },
+          payload(body.first)["sources"]
+        )
+      end
+
+      test "keys that source by the template its diagnostics name, not the path it compiled" do
+        error = compile_error(filename: "/Users/me/app/app/views/posts/_post.html.erb")
+
+        _status, _headers, body = middleware(raising_app(error)).call(HTML_ENV)
+
+        assert_equal(
+          { "app/views/posts/_post.html.erb" => SOURCE },
+          payload(body.first)["sources"]
+        )
+      end
+
       test "makes one up for an error carrying no diagnostics" do
         error = Herb::Engine::CompilationError.new("Something went wrong.")
 
@@ -182,6 +239,14 @@ module Engine
         assert_equal 2, body.first.scan("<section>").size
         assert_equal 2, payload(body.first)["diagnostics"].size
         assert_includes body.first, "without a matching opening tag"
+      end
+
+      test "shows a section with an excerpt for every diagnostic a compile error collected" do
+        _status, _headers, body = middleware(raising_app(compile_error)).call(HTML_ENV)
+
+        assert_equal 2, body.first.scan("<section>").size
+        assert_equal 2, body.first.scan("<pre>").size
+        assert_includes body.first, "app/views/posts/_post.html.erb:3:5"
       end
 
       test "starts the dev tools when it is told where they are" do

--- a/test/engine/report/error_page_test.rb
+++ b/test/engine/report/error_page_test.rb
@@ -199,11 +199,29 @@ module Engine
         assert_includes body.first, "Close the `&lt;form&gt;` before"
       end
 
+      test "prints one row per source line, with no blank line between them" do
+        _status, _headers, body = middleware(raising_app(parse_error)).call(HTML_ENV)
+
+        pre = body.first[%r{<pre>(.+?)</pre>}m, 1]
+
+        assert_equal 4, pre.scan("<span").size
+        assert_equal 0, pre.scan("\n").size
+      end
+
       test "escapes the source it prints" do
         _status, _headers, body = middleware(raising_app(parse_error)).call(HTML_ENV)
 
         assert_includes body.first, "&lt;form&gt;"
         refute_includes body.first[%r{<pre>.+?</pre>}m], "<form>"
+      end
+
+      test "keeps the provenance footer inside the container its rules are scoped to" do
+        _status, _headers, body = middleware(raising_app(parse_error)).call(HTML_ENV)
+
+        main = body.first[%r{<main class="herb-error">.+?</main>}m]
+
+        assert_includes main, %(<footer class="herb-error-provenance">)
+        assert_equal 1, body.first.scan("herb-error-provenance\"").size
       end
 
       test "scopes every style rule to itself" do

--- a/test/engine/report/session_test.rb
+++ b/test/engine/report/session_test.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require "fileutils"
+require "tmpdir"
+
 require_relative "../../test_helper"
 
 module Engine
@@ -85,6 +88,62 @@ module Engine
       end
 
       assert_equal({ "app/views/a.html.erb" => "<div></div>\n" }, session.report.to_h[:sources])
+    end
+
+    def compiled_entry
+      { message: "m", code: "slots-declaration", severity: :error, origin: "Herb Compiler", phase: :compile }
+    end
+
+    def in_project(contents = "<div>\n  <span>\n</div>\n")
+      Dir.mktmpdir do |directory|
+        Dir.chdir(directory) do
+          FileUtils.mkdir_p("app/views")
+          File.write("app/views/a.html.erb", contents)
+
+          yield
+        end
+      end
+    end
+
+    test "reads the template off disk, so a finding can be shown in context" do
+      in_project do
+        session = Herb::Engine::Report::Session.capture do
+          Herb::Engine::Report::Session.record_compile_diagnostics("app/views/a.html.erb", [compiled_entry])
+        end
+
+        assert_equal({ "app/views/a.html.erb" => "<div>\n  <span>\n</div>\n" }, session.report.sources)
+      end
+    end
+
+    test "reads it once, however many times the template renders" do
+      in_project do
+        session = Herb::Engine::Report::Session.capture do
+          Herb::Engine::Report::Session.record_compile_diagnostics("app/views/a.html.erb", [compiled_entry])
+
+          File.write("app/views/a.html.erb", "<p>rewritten after the first read</p>\n")
+
+          Herb::Engine::Report::Session.record_compile_diagnostics("app/views/a.html.erb", [compiled_entry])
+        end
+
+        assert_equal({ "app/views/a.html.erb" => "<div>\n  <span>\n</div>\n" }, session.report.sources)
+      end
+    end
+
+    test "reads nothing when nobody opened a session to read it" do
+      in_project do
+        Herb::Engine::Report::Session.record_compile_diagnostics("app/views/a.html.erb", [compiled_entry])
+
+        assert_empty Herb::Engine::Report::Session.current.report.sources
+      end
+    end
+
+    test "records the findings even when the template leads nowhere on disk" do
+      session = Herb::Engine::Report::Session.capture do
+        Herb::Engine::Report::Session.record_compile_diagnostics("app/views/gone.html.erb", [compiled_entry])
+      end
+
+      assert_equal ["slots-declaration"], session.report.diagnostics.map(&:code)
+      assert_empty session.report.sources
     end
 
     test "is empty until something is recorded" do


### PR DESCRIPTION
This pull request updates `Report::ErrorPage`, `Report::Session` and the dev server so a compile diagnostic reaches the browser together with the template source it points at, which is what the diagnostics panel needs to draw a code frame.

<img width="1244" height="938" alt="CleanShot 2026-08-28 at 07 28 10@2x" src="https://github.com/user-attachments/assets/d9cb92df-0317-4e87-b6aa-e8d440f3d483" />


<img width="2576" height="1584" alt="CleanShot 2026-08-28 at 07 28 27@2x" src="https://github.com/user-attachments/assets/a85d67b2-138c-4615-a4e4-7a0ca014d1ea" />

